### PR TITLE
Fuzz capability sets

### DIFF
--- a/ironrdp/fuzz/Cargo.toml
+++ b/ironrdp/fuzz/Cargo.toml
@@ -35,3 +35,7 @@ path = "fuzz_targets/fuzz_tpdu.rs"
 [[bin]]
 name = "fuzz_gcc"
 path = "fuzz_targets/fuzz_gcc.rs"
+
+[[bin]]
+name = "fuzz_capability_sets"
+path = "fuzz_targets/fuzz_capability_sets.rs"

--- a/ironrdp/fuzz/fuzz_targets/fuzz_capability_sets.rs
+++ b/ironrdp/fuzz/fuzz_targets/fuzz_capability_sets.rs
@@ -1,0 +1,9 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate ironrdp;
+
+use ironrdp::{CapabilitySet, PduParsing};
+
+fuzz_target!(|data: &[u8]| {
+    let _ = CapabilitySet::from_buffer(data);
+});

--- a/ironrdp/src/rdp/capability_sets.rs
+++ b/ironrdp/src/rdp/capability_sets.rs
@@ -244,7 +244,14 @@ impl PduParsing for CapabilitySet {
     fn from_buffer(mut stream: impl io::Read) -> Result<Self, Self::Error> {
         let capability_set_type = CapabilitySetType::from_u16(stream.read_u16::<LittleEndian>()?)
             .ok_or(CapabilitySetsError::InvalidType)?;
-        let buffer_length = stream.read_u16::<LittleEndian>()? as usize
+        
+        let length = stream.read_u16::<LittleEndian>()? as usize;
+        
+        if length < CAPABILITY_SET_TYPE_FIELD_SIZE + CAPABILITY_SET_LENGTH_FIELD_SIZE {
+            return Err(CapabilitySetsError::InvalidLength);
+        }
+        
+        let buffer_length = length
             - CAPABILITY_SET_TYPE_FIELD_SIZE
             - CAPABILITY_SET_LENGTH_FIELD_SIZE;
         let mut capability_set_buffer = vec![0; buffer_length];
@@ -635,6 +642,8 @@ pub enum CapabilitySetsError {
     InvalidChunkSize,
     #[fail(display = "Invalid codec property length for the current property ID")]
     InvalidPropertyLength,
+    #[fail(display = "Invalid data length")]
+    InvalidLength,
 }
 
 impl_from_error!(io::Error, CapabilitySetsError, CapabilitySetsError::IOError);


### PR DESCRIPTION
This PR fixes a panic where we would attempt to initialize a vector with a negative size when the provided length was too small.

It also adds a fuzzer for capability sets. 