### PR TITLE
Updated bitvec crate the latest version

### DIFF
--- a/ironrdp/Cargo.toml
+++ b/ironrdp/Cargo.toml
@@ -26,5 +26,5 @@ md-5 = "0.8.0"
 num-bigint = "0.2.0"
 der-parser = "3.0.0"
 bit_field = "0.10"
-bitvec = { git = "https://github.com/myrrlyn/bitvec.git", rev = "3e79e6d53b2f7d01f5b139c67310e7918332905c" }
+bitvec = "0.17.1"
 hex-literal = "0.2"

--- a/ironrdp/src/rdp/vc/dvc/gfx/zgfx.rs
+++ b/ironrdp/src/rdp/vc/dvc/gfx/zgfx.rs
@@ -8,8 +8,8 @@ use std::{
     ops,
 };
 
-use bitvec::prelude::{BitSlice, BitVec, Msb0 as BigEndian};
-use byteorder::{ReadBytesExt, WriteBytesExt};
+use bitvec::prelude::{bits, BitField, BitSlice, Msb0};
+use byteorder::WriteBytesExt;
 use failure::Fail;
 use lazy_static::lazy_static;
 
@@ -106,12 +106,7 @@ impl Decompressor {
                 TokenType::NullLiteral => {
                     // The prefix value is encoded with a "0" prefix,
                     // then read 8 bits containing the byte to output.
-                    let value = bits.split_to(8);
-                    let value = *value
-                        .to_vec()
-                        .into_vec()
-                        .first()
-                        .expect("8 bits must equal to vec of 1 byte");
+                    let value = bits.split_to(8).load_be::<u8>();
 
                     self.history.write_u8(value)?;
                     output.push(value);
@@ -151,18 +146,18 @@ impl Default for Decompressor {
 }
 
 struct Bits<'a> {
-    bits_slice: &'a BitSlice<BigEndian, u8>,
+    bits_slice: &'a BitSlice<Msb0, u8>,
     remaining_bits_of_last_byte: usize,
 }
 
 impl<'a> Bits<'a> {
-    pub fn new(bits_slice: &'a BitSlice<BigEndian, u8>) -> Self {
+    pub fn new(bits_slice: &'a BitSlice<Msb0, u8>) -> Self {
         Self {
             bits_slice,
             remaining_bits_of_last_byte: 0,
         }
     }
-    pub fn split_to(&mut self, at: usize) -> &'a BitSlice<BigEndian, u8> {
+    pub fn split_to(&mut self, at: usize) -> &'a BitSlice<Msb0, u8> {
         let (value, new_bits) = self.bits_slice.split_at(at);
         self.bits_slice = new_bits;
         self.remaining_bits_of_last_byte = (self.remaining_bits_of_last_byte + at) % 8;
@@ -175,7 +170,7 @@ impl<'a> Bits<'a> {
 }
 
 impl<'a> ops::Deref for Bits<'a> {
-    type Target = BitSlice<BigEndian, u8>;
+    type Target = BitSlice<Msb0, u8>;
 
     fn deref(&self) -> &Self::Target {
         self.bits_slice
@@ -192,9 +187,7 @@ fn handle_match(
     // Each token has been assigned a different base distance
     // and number of additional value bits to be added to compute the full distance.
 
-    let distance_value = bits.split_to(distance_value_size);
-    let distance =
-        (distance_base + bytes_to_u32_be(complete_to_u32(distance_value).into_vec())) as usize;
+    let distance = (distance_base + bits.split_to(distance_value_size).load_be::<u32>()) as usize;
 
     if distance == 0 {
         read_unencoded_bytes(bits, history, &mut output)
@@ -211,8 +204,7 @@ fn read_unencoded_bytes(
     // A match distance of zero is a special case,
     // which indicates that an unencoded run of bytes follows.
     // The count of bytes is encoded as a 15-bit value
-    let length_value = bits.split_to(15);
-    let length = bytes_to_u32_be(complete_to_u32(length_value).into_vec()) as usize;
+    let length = bits.split_to(15).load_be::<u32>() as usize;
 
     if bits.remaining_bits_of_last_byte() > 0 {
         let pad_to_byte_boundary = 8 - bits.remaining_bits_of_last_byte();
@@ -246,8 +238,7 @@ fn read_encoded_bytes(
 
         3
     } else {
-        let length_value = bits.split_to(length_token_size + 1);
-        let length = bytes_to_u32_be(complete_to_u32(length_value).into_vec()) as usize;
+        let length = bits.split_to(length_token_size + 1).load_be::<u32>() as usize;
 
         let base = 2u32.pow(length_token_size as u32 + 1) as usize;
 
@@ -263,25 +254,8 @@ fn read_encoded_bytes(
     Ok(length)
 }
 
-fn complete_to_u32(bits: &BitSlice<BigEndian, u8>) -> BitVec<BigEndian, u8> {
-    let mut result = BitVec::<BigEndian, u8>::from_vec(vec![0; 4]);
-    let result_slice = &mut result[4 * 8 - bits.len()..];
-    result_slice.clone_from_slice(bits);
-
-    result
-}
-
-fn bytes_to_u32_be(mut bytes: Vec<u8>) -> u32 {
-    bytes.resize(4, 0);
-
-    bytes
-        .as_slice()
-        .read_u32::<byteorder::BigEndian>()
-        .expect("previously resized to 4 bytes must not fail")
-}
-
 struct Token {
-    pub prefix: BitVec<BigEndian, u8>,
+    pub prefix: &'static BitSlice<Msb0, u8>,
     pub ty: TokenType,
 }
 
@@ -299,252 +273,252 @@ enum TokenType {
 lazy_static! {
     static ref TOKEN_TABLE: [Token; 40] = [
         Token {
-            prefix: slice_to_bitvec(&[0]),
+            prefix: bits![Msb0, u8; 0],
             ty: TokenType::NullLiteral,
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 1, 0, 0, 0]),
+            prefix: bits![Msb0, u8; 1, 1, 0, 0, 0],
             ty: TokenType::Literal {
                 literal_value: 0x00
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 1, 0, 0, 1]),
+            prefix: bits![Msb0, u8; 1, 1, 0, 0, 1],
             ty: TokenType::Literal {
                 literal_value: 0x01
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 1, 0, 1, 0, 0]),
+            prefix: bits![Msb0, u8; 1, 1, 0, 1, 0, 0],
             ty: TokenType::Literal {
                 literal_value: 0x02
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 1, 0, 1, 0, 1]),
+            prefix: bits![Msb0, u8; 1, 1, 0, 1, 0, 1],
             ty: TokenType::Literal {
                 literal_value: 0x03
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 1, 0, 1, 1, 0]),
+            prefix: bits![Msb0, u8; 1, 1, 0, 1, 1, 0],
             ty: TokenType::Literal {
                 literal_value: 0x0ff
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 1, 0, 1, 1, 1, 0]),
+            prefix: bits![Msb0, u8; 1, 1, 0, 1, 1, 1, 0],
             ty: TokenType::Literal {
                 literal_value: 0x04
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 1, 0, 1, 1, 1, 1]),
+            prefix: bits![Msb0, u8; 1, 1, 0, 1, 1, 1, 1],
             ty: TokenType::Literal {
                 literal_value: 0x05
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 1, 1, 0, 0, 0, 0]),
+            prefix: bits![Msb0, u8; 1, 1, 1, 0, 0, 0, 0],
             ty: TokenType::Literal {
                 literal_value: 0x06
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 1, 1, 0, 0, 0, 1]),
+            prefix: bits![Msb0, u8; 1, 1, 1, 0, 0, 0, 1],
             ty: TokenType::Literal {
                 literal_value: 0x07
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 1, 1, 0, 0, 1, 0]),
+            prefix: bits![Msb0, u8; 1, 1, 1, 0, 0, 1, 0],
             ty: TokenType::Literal {
                 literal_value: 0x08
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 1, 1, 0, 0, 1, 1]),
+            prefix: bits![Msb0, u8; 1, 1, 1, 0, 0, 1, 1],
             ty: TokenType::Literal {
                 literal_value: 0x09
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 1, 1, 0, 1, 0, 0]),
+            prefix: bits![Msb0, u8; 1, 1, 1, 0, 1, 0, 0],
             ty: TokenType::Literal {
                 literal_value: 0x0a
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 1, 1, 0, 1, 0, 1]),
+            prefix: bits![Msb0, u8; 1, 1, 1, 0, 1, 0, 1],
             ty: TokenType::Literal {
                 literal_value: 0x0b
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 1, 1, 0, 1, 1, 0]),
+            prefix: bits![Msb0, u8; 1, 1, 1, 0, 1, 1, 0],
             ty: TokenType::Literal {
                 literal_value: 0x3a
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 1, 1, 0, 1, 1, 1]),
+            prefix: bits![Msb0, u8; 1, 1, 1, 0, 1, 1, 1],
             ty: TokenType::Literal {
                 literal_value: 0x3b
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 1, 1, 1, 0, 0, 0]),
+            prefix: bits![Msb0, u8; 1, 1, 1, 1, 0, 0, 0],
             ty: TokenType::Literal {
                 literal_value: 0x3c
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 1, 1, 1, 0, 0, 1]),
+            prefix: bits![Msb0, u8; 1, 1, 1, 1, 0, 0, 1],
             ty: TokenType::Literal {
                 literal_value: 0x3d
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 1, 1, 1, 0, 1, 0]),
+            prefix: bits![Msb0, u8; 1, 1, 1, 1, 0, 1, 0],
             ty: TokenType::Literal {
                 literal_value: 0x3e
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 1, 1, 1, 0, 1, 1]),
+            prefix: bits![Msb0, u8; 1, 1, 1, 1, 0, 1, 1],
             ty: TokenType::Literal {
                 literal_value: 0x3f
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 1, 1, 1, 1, 0, 0]),
+            prefix: bits![Msb0, u8; 1, 1, 1, 1, 1, 0, 0],
             ty: TokenType::Literal {
                 literal_value: 0x40
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 1, 1, 1, 1, 0, 1]),
+            prefix: bits![Msb0, u8; 1, 1, 1, 1, 1, 0, 1],
             ty: TokenType::Literal {
                 literal_value: 0x80
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 1, 1, 1, 1, 1, 0, 0]),
+            prefix: bits![Msb0, u8; 1, 1, 1, 1, 1, 1, 0, 0],
             ty: TokenType::Literal {
                 literal_value: 0x0c
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 1, 1, 1, 1, 1, 0, 1]),
+            prefix: bits![Msb0, u8; 1, 1, 1, 1, 1, 1, 0, 1],
             ty: TokenType::Literal {
                 literal_value: 0x38
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 1, 1, 1, 1, 1, 1, 0]),
+            prefix: bits![Msb0, u8; 1, 1, 1, 1, 1, 1, 1, 0],
             ty: TokenType::Literal {
                 literal_value: 0x39
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 1, 1, 1, 1, 1, 1, 1]),
+            prefix: bits![Msb0, u8; 1, 1, 1, 1, 1, 1, 1, 1],
             ty: TokenType::Literal {
                 literal_value: 0x66
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 0, 0, 0, 1]),
+            prefix: bits![Msb0, u8; 1, 0, 0, 0, 1],
             ty: TokenType::Match {
                 distance_value_size: 5,
                 distance_base: 0
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 0, 0, 1, 0]),
+            prefix: bits![Msb0, u8; 1, 0, 0, 1, 0],
             ty: TokenType::Match {
                 distance_value_size: 7,
                 distance_base: 32
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 0, 0, 1, 1]),
+            prefix: bits![Msb0, u8; 1, 0, 0, 1, 1],
             ty: TokenType::Match {
                 distance_value_size: 9,
                 distance_base: 160
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 0, 1, 0, 0]),
+            prefix: bits![Msb0, u8; 1, 0, 1, 0, 0],
             ty: TokenType::Match {
                 distance_value_size: 10,
                 distance_base: 672,
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 0, 1, 0, 1]),
+            prefix: bits![Msb0, u8; 1, 0, 1, 0, 1],
             ty: TokenType::Match {
                 distance_value_size: 12,
                 distance_base: 1_696,
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 0, 1, 1, 0, 0]),
+            prefix: bits![Msb0, u8; 1, 0, 1, 1, 0, 0],
             ty: TokenType::Match {
                 distance_value_size: 14,
                 distance_base: 5_792,
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 0, 1, 1, 0, 1]),
+            prefix: bits![Msb0, u8; 1, 0, 1, 1, 0, 1],
             ty: TokenType::Match {
                 distance_value_size: 15,
                 distance_base: 22_176,
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 0, 1, 1, 1, 0, 0]),
+            prefix: bits![Msb0, u8; 1, 0, 1, 1, 1, 0, 0],
             ty: TokenType::Match {
                 distance_value_size: 18,
                 distance_base: 54_944,
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 0, 1, 1, 1, 0, 1]),
+            prefix: bits![Msb0, u8; 1, 0, 1, 1, 1, 0, 1],
             ty: TokenType::Match {
                 distance_value_size: 20,
                 distance_base: 317_088,
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 0, 1, 1, 1, 1, 0, 0]),
+            prefix: bits![Msb0, u8; 1, 0, 1, 1, 1, 1, 0, 0],
             ty: TokenType::Match {
                 distance_value_size: 20,
                 distance_base: 1_365_664,
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 0, 1, 1, 1, 1, 0, 1]),
+            prefix: bits![Msb0, u8; 1, 0, 1, 1, 1, 1, 0, 1],
             ty: TokenType::Match {
                 distance_value_size: 21,
                 distance_base: 2_414_240,
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 0, 1, 1, 1, 1, 1, 0, 0]),
+            prefix: bits![Msb0, u8; 1, 0, 1, 1, 1, 1, 1, 0, 0],
             ty: TokenType::Match {
                 distance_value_size: 22,
                 distance_base: 4_511_392,
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 0, 1, 1, 1, 1, 1, 0, 1]),
+            prefix: bits![Msb0, u8; 1, 0, 1, 1, 1, 1, 1, 0, 1],
             ty: TokenType::Match {
                 distance_value_size: 23,
                 distance_base: 8_705_696,
             },
         },
         Token {
-            prefix: slice_to_bitvec(&[1, 0, 1, 1, 1, 1, 1, 1, 0]),
+            prefix: bits![Msb0, u8; 1, 0, 1, 1, 1, 1, 1, 1, 0],
             ty: TokenType::Match {
                 distance_value_size: 24,
                 distance_base: 17_094_304,
@@ -574,9 +548,3 @@ pub enum ZgfxError {
 }
 
 impl_from_error!(io::Error, ZgfxError, ZgfxError::IOError);
-
-fn slice_to_bitvec(s: &[u8]) -> BitVec<BigEndian, u8> {
-    use std::iter::FromIterator;
-
-    BitVec::from_iter(s.iter().map(|v| v == &1))
-}

--- a/ironrdp/src/rdp/vc/dvc/gfx/zgfx/tests.rs
+++ b/ironrdp/src/rdp/vc/dvc/gfx/zgfx/tests.rs
@@ -228,15 +228,3 @@ fn zgfx_decopresses_unencoded_block_without_padding() {
         .unwrap();
     assert_eq!(decompressed, expected);
 }
-
-#[test]
-fn complete_to_u32_fills_zeros_for_less_then_one_byte_bits_buffer() {
-    let bits: BitVec<BigEndian, u8> = slice_to_bitvec(&[0, 0, 1, 0, 1, 1, 0]);
-    let expected: BitVec<BigEndian, u8> = slice_to_bitvec(&[
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1,
-        1, 0,
-    ]);
-    let bits = complete_to_u32(bits.as_bitslice());
-
-    assert_eq!(bits, expected);
-}


### PR DESCRIPTION
- Update bitvec to the latest version (0.17.1);
- Fixed broken tests;
- Optimized according to the new version's opportunities.