### PR TITLE
Increase the maximum certificate length

### DIFF
--- a/ironrdp/src/rdp/server_license/server_license_request/cert.rs
+++ b/ironrdp/src/rdp/server_license/server_license_request/cert.rs
@@ -16,7 +16,7 @@ pub const RSA_KEY_SIZE_WITHOUT_MODULUS: usize = 20;
 
 const MIN_CERTIFICATE_AMOUNT: u32 = 2;
 const MAX_CERTIFICATE_AMOUNT: u32 = 200;
-const MAX_CERTIFICATE_LEN: u32 = 1024;
+const MAX_CERTIFICATE_LEN: u32 = 4096;
 
 #[derive(Debug, PartialEq)]
 pub enum CertificateType {


### PR DESCRIPTION
Actually the certificate length can be more than 1024 bytes - 1277 for example. So I increated the maximum certificate length.