### PR TITLE
Update IronRDP client to be able to be reused in web-based client

### DIFF
--- a/ironrdp_client/Cargo.toml
+++ b/ironrdp_client/Cargo.toml
@@ -8,7 +8,15 @@ homepage = "https://github.com/Devolutions/IronRDP"
 repository = "https://github.com/Devolutions/IronRDP"
 authors = ["Marc-André Moreau <mamoreau@devolutions.net>",
            "Vladyslav Hordiienko <hord.vlad@gmail.com"]
-keywords = ["rdp", "client", "remote", "desktop", "protocol"]
+keywords = ["rdp", "client", "remote", "desktop", "protocol", "gfx", "rfx"]
+
+[lib]
+name = "ironrdp_client"
+path = "src/lib.rs"
+
+[[bin]]
+name = "ironrdp_client_app"
+path = "src/main.rs"
 
 [dependencies]
 ironrdp = { path = "../ironrdp" }

--- a/ironrdp_client/src/active_session.rs
+++ b/ironrdp_client/src/active_session.rs
@@ -15,9 +15,9 @@ use ironrdp::{
 use log::warn;
 
 use crate::{
-    connection_sequence::DesktopSizes,
+    connection_sequence::{DesktopSizes, StaticChannels},
     transport::{Decoder, RdpTransport},
-    utils, RdpError, RdpResult, StaticChannels,
+    utils, InputConfig, RdpError,
 };
 
 const DESTINATION_PIXEL_FORMAT: PixelFormat = PixelFormat::RgbA32;
@@ -28,13 +28,17 @@ pub fn process_active_stage(
     global_channel_id: u16,
     initiator_id: u16,
     desktop_sizes: DesktopSizes,
-) -> RdpResult<()> {
+    config: InputConfig,
+) -> Result<(), RdpError> {
     let decoded_image = Arc::new(Mutex::new(DecodedImage::new(
         u32::from(desktop_sizes.width),
         u32::from(desktop_sizes.height),
         DESTINATION_PIXEL_FORMAT,
     )));
-    let mut x224_processor = x224::Processor::new(utils::swap_hashmap_kv(static_channels));
+    let mut x224_processor = x224::Processor::new(
+        utils::swap_hashmap_kv(static_channels),
+        config.global_channel_name.as_str(),
+    );
     let mut fast_path_processor = fast_path::ProcessorBuilder {
         decoded_image,
         global_channel_id,

--- a/ironrdp_client/src/active_session/fast_path.rs
+++ b/ironrdp_client/src/active_session/fast_path.rs
@@ -21,7 +21,7 @@ use crate::{
         ShareControlHeaderTransport, ShareDataHeaderTransport,
     },
     utils::CodecId,
-    RdpError, RdpResult,
+    RdpError,
 };
 use ironrdp::surface_commands::FrameMarkerPdu;
 
@@ -37,7 +37,7 @@ impl Processor {
         &mut self,
         header: &FastPathHeader,
         mut stream: impl io::BufRead + io::Write,
-    ) -> RdpResult<()> {
+    ) -> Result<(), RdpError> {
         debug!("Got Fast-Path Header: {:?}", header);
 
         let input_buffer = &stream.fill_buf()?[..header.data_length];
@@ -91,7 +91,7 @@ impl Processor {
         &mut self,
         mut output: impl io::Write,
         surface_commands: Vec<SurfaceCommand<'_>>,
-    ) -> RdpResult<()> {
+    ) -> Result<(), RdpError> {
         for command in surface_commands {
             match command {
                 SurfaceCommand::SetSurfaceBits(bits) | SurfaceCommand::StreamSurfaceBits(bits) => {
@@ -230,7 +230,7 @@ impl Frame {
         &mut self,
         marker: &FrameMarkerPdu,
         mut output: impl io::Write,
-    ) -> RdpResult<()> {
+    ) -> Result<(), RdpError> {
         match marker.frame_action {
             FrameAction::Begin => Ok(()),
             FrameAction::End => self.transport.encode(

--- a/ironrdp_client/src/config.rs
+++ b/ironrdp_client/src/config.rs
@@ -4,15 +4,17 @@ use clap::{crate_name, crate_version, App, Arg};
 use ironrdp::nego::SecurityProtocol;
 use sspi::AuthIdentity;
 
+use ironrdp_client::InputConfig;
+
 const DEFAULT_WIDTH: u16 = 1920;
 const DEFAULT_HEIGHT: u16 = 1080;
+const GLOBAL_CHANNEL_NAME: &str = "GLOBAL";
+const USER_CHANNEL_NAME: &str = "USER";
 
 pub struct Config {
     pub log_file: String,
     pub routing_addr: SocketAddr,
-    pub width: u16,
-    pub height: u16,
-    pub input: Input,
+    pub input: InputConfig,
 }
 
 impl Config {
@@ -47,7 +49,7 @@ impl Config {
                         )),
                     }),
             )
-            .args(&Input::args());
+            .args(&input_args());
         let matches = cli_app.get_matches();
 
         let log_file = matches
@@ -60,177 +62,166 @@ impl Config {
             .map(|u| u.parse().unwrap())
             .expect("addr must be at least the default");
 
-        let input = Input::from_matches(&matches);
+        let input = from_input_matches(&matches);
 
         Self {
             log_file,
             routing_addr,
-            width: DEFAULT_WIDTH,
-            height: DEFAULT_HEIGHT,
             input,
         }
     }
 }
 
-pub struct Input {
-    pub credentials: AuthIdentity,
-    pub security_protocol: SecurityProtocol,
-    pub keyboard_type: ironrdp::gcc::KeyboardType,
-    pub keyboard_subtype: u32,
-    pub keyboard_functional_keys_count: u32,
-    pub ime_file_name: String,
-    pub dig_product_id: String,
+fn input_args<'a, 'b>() -> [Arg<'a, 'b>; 9] {
+    [
+        Arg::with_name("username")
+            .short("u")
+            .long("username")
+            .value_name("USERNAME")
+            .help("A target RDP server user name")
+            .takes_value(true)
+            .empty_values(false)
+            .required(true),
+        Arg::with_name("domain")
+            .short("d")
+            .long("domain")
+            .value_name("DOMAIN")
+            .help("An optional target RDP server domain name")
+            .takes_value(true)
+            .required(false),
+        Arg::with_name("password")
+            .short("p")
+            .long("password")
+            .value_name("PASSWORD")
+            .help("A target RDP server user password")
+            .takes_value(true)
+            .required(true),
+        Arg::with_name("security-protocol")
+            .long("security-protocol")
+            .value_name("SECURITY_PROTOCOL")
+            .help("Specify the security protocols to use")
+            .takes_value(true)
+            .multiple(true)
+            .possible_values(&["ssl", "hybrid", "hybrid_ex"])
+            .default_value(&"hybrid_ex")
+            .required(true),
+        Arg::with_name("keyboard-type")
+            .long("keyboard-type")
+            .value_name("KEYBOARD_TYPE")
+            .help("The keyboard type")
+            .takes_value(true)
+            .possible_values(&[
+                "ibm_pc_xt",
+                "olivetti_ico",
+                "ibm_pc_at",
+                "ibm_enhanced",
+                "nokia1050",
+                "nokia9140",
+                "japanese",
+            ])
+            .default_value(&"ibm_enhanced"),
+        Arg::with_name("keyboard-subtype")
+            .long("keyboard-subtype")
+            .value_name("KEYBOARD_SUBTYPE")
+            .help("The keyboard subtype (an original equipment manufacturer-dependent value)")
+            .takes_value(true)
+            .default_value(&"0")
+            .validator(is_uint),
+        Arg::with_name("keyboard-functional-keys-count")
+            .long("keyboard-functional-keys-count")
+            .value_name("KEYBOARD_FUNCTIONAL_KEYS_COUNT")
+            .help("The number of function keys on the keyboard")
+            .takes_value(true)
+            .default_value(&"12")
+            .validator(is_uint),
+        Arg::with_name("ime-file-name")
+            .long("ime-file-name")
+            .value_name("IME_FILENAME")
+            .help("The input method editor (IME) file name associated with the active input locale")
+            .takes_value(true)
+            .default_value(&""),
+        Arg::with_name("dig-product-id")
+            .long("dig-product-id")
+            .value_name("DIG_PRODUCT_ID")
+            .help("Contains a value that uniquely identifies the client")
+            .takes_value(true)
+            .default_value(&""),
+    ]
 }
 
-impl Input {
-    fn args<'a, 'b>() -> [Arg<'a, 'b>; 9] {
-        [
-            Arg::with_name("username")
-                .short("u")
-                .long("username")
-                .value_name("USERNAME")
-                .help("A target RDP server user name")
-                .takes_value(true)
-                .empty_values(false)
-                .required(true),
-            Arg::with_name("domain")
-                .short("d")
-                .long("domain")
-                .value_name("DOMAIN")
-                .help("An optional target RDP server domain name")
-                .takes_value(true)
-                .required(false),
-            Arg::with_name("password")
-                .short("p")
-                .long("password")
-                .value_name("PASSWORD")
-                .help("A target RDP server user password")
-                .takes_value(true)
-                .required(true),
-            Arg::with_name("security-protocol")
-                .long("security-protocol")
-                .value_name("SECURITY_PROTOCOL")
-                .help("Specify the security protocols to use")
-                .takes_value(true)
-                .multiple(true)
-                .possible_values(&["ssl", "hybrid", "hybrid_ex"])
-                .default_value(&"hybrid_ex")
-                .required(true),
-            Arg::with_name("keyboard-type")
-                .long("keyboard-type")
-                .value_name("KEYBOARD_TYPE")
-                .help("The keyboard type")
-                .takes_value(true)
-                .possible_values(&[
-                    "ibm_pc_xt",
-                    "olivetti_ico",
-                    "ibm_pc_at",
-                    "ibm_enhanced",
-                    "nokia1050",
-                    "nokia9140",
-                    "japanese",
-                ])
-                .default_value(&"ibm_enhanced"),
-            Arg::with_name("keyboard-subtype")
-                .long("keyboard-subtype")
-                .value_name("KEYBOARD_SUBTYPE")
-                .help(
-                    "The keyboard subtype (an original equipment manufacturer-dependent value)",
-                )
-                .takes_value(true)
-                .default_value(&"0")
-                .validator(is_uint),
-            Arg::with_name("keyboard-functional-keys-count")
-                .long("keyboard-functional-keys-count")
-                .value_name("KEYBOARD_FUNCTIONAL_KEYS_COUNT")
-                .help("The number of function keys on the keyboard")
-                .takes_value(true)
-                .default_value(&"12")
-                .validator(is_uint),
-            Arg::with_name("ime-file-name")
-                .long("ime-file-name")
-                .value_name("IME_FILENAME")
-                .help("The input method editor (IME) file name associated with the active input locale")
-                .takes_value(true)
-                .default_value(&""),
-            Arg::with_name("dig-product-id")
-                .long("dig-product-id")
-                .value_name("DIG_PRODUCT_ID")
-                .help("Contains a value that uniquely identifies the client")
-                .takes_value(true)
-                .default_value(&""),
-]
-    }
-    fn from_matches(matches: &clap::ArgMatches<'_>) -> Self {
-        let username = matches
-            .value_of("username")
-            .map(String::from)
-            .expect("username must be specified");
-        let domain = matches.value_of("domain").map(String::from);
-        let password = matches
-            .value_of("password")
-            .map(String::from)
-            .expect("password must be specified");
-        let credentials = AuthIdentity {
-            username,
-            password,
-            domain,
-        };
+fn from_input_matches(matches: &clap::ArgMatches<'_>) -> InputConfig {
+    let username = matches
+        .value_of("username")
+        .map(String::from)
+        .expect("username must be specified");
+    let domain = matches.value_of("domain").map(String::from);
+    let password = matches
+        .value_of("password")
+        .map(String::from)
+        .expect("password must be specified");
+    let credentials = AuthIdentity {
+        username,
+        password,
+        domain,
+    };
 
-        let security_protocol = matches
-            .values_of("security-protocol")
-            .expect("security-protocol must be specified")
-            .map(|value| match value {
-                "ssl" => SecurityProtocol::SSL,
-                "hybrid" => SecurityProtocol::HYBRID,
-                "hybrid_ex" => SecurityProtocol::HYBRID_EX,
-                _ => unreachable!("clap must not allow other security protocols"),
-            })
-            .collect();
+    let security_protocol = matches
+        .values_of("security-protocol")
+        .expect("security-protocol must be specified")
+        .map(|value| match value {
+            "ssl" => SecurityProtocol::SSL,
+            "hybrid" => SecurityProtocol::HYBRID,
+            "hybrid_ex" => SecurityProtocol::HYBRID_EX,
+            _ => unreachable!("clap must not allow other security protocols"),
+        })
+        .collect();
 
-        let keyboard_type = matches
-            .value_of("keyboard-type")
-            .map(|value| match value {
-                "ibm_pc_xt" => ironrdp::gcc::KeyboardType::IbmPcXt,
-                "olivetti_ico" => ironrdp::gcc::KeyboardType::OlivettiIco,
-                "ibm_pc_at" => ironrdp::gcc::KeyboardType::IbmPcAt,
-                "ibm_enhanced" => ironrdp::gcc::KeyboardType::IbmEnhanced,
-                "nokia1050" => ironrdp::gcc::KeyboardType::Nokia1050,
-                "nokia9140" => ironrdp::gcc::KeyboardType::Nokia9140,
-                "japanese" => ironrdp::gcc::KeyboardType::Japanese,
-                _ => unreachable!("clap must not allow other keyboard types"),
-            })
-            .expect("keyboard type must be at least the default");
+    let keyboard_type = matches
+        .value_of("keyboard-type")
+        .map(|value| match value {
+            "ibm_pc_xt" => ironrdp::gcc::KeyboardType::IbmPcXt,
+            "olivetti_ico" => ironrdp::gcc::KeyboardType::OlivettiIco,
+            "ibm_pc_at" => ironrdp::gcc::KeyboardType::IbmPcAt,
+            "ibm_enhanced" => ironrdp::gcc::KeyboardType::IbmEnhanced,
+            "nokia1050" => ironrdp::gcc::KeyboardType::Nokia1050,
+            "nokia9140" => ironrdp::gcc::KeyboardType::Nokia9140,
+            "japanese" => ironrdp::gcc::KeyboardType::Japanese,
+            _ => unreachable!("clap must not allow other keyboard types"),
+        })
+        .expect("keyboard type must be at least the default");
 
-        let keyboard_subtype = matches
-            .value_of("keyboard-subtype")
-            .map(|value| value.parse::<u32>().unwrap())
-            .expect("keyboard subtype must be at least the default");
+    let keyboard_subtype = matches
+        .value_of("keyboard-subtype")
+        .map(|value| value.parse::<u32>().unwrap())
+        .expect("keyboard subtype must be at least the default");
 
-        let keyboard_functional_keys_count = matches
-            .value_of("keyboard-functional-keys-count")
-            .map(|value| value.parse::<u32>().unwrap())
-            .expect("keyboard functional keys count must be at least the default");
+    let keyboard_functional_keys_count = matches
+        .value_of("keyboard-functional-keys-count")
+        .map(|value| value.parse::<u32>().unwrap())
+        .expect("keyboard functional keys count must be at least the default");
 
-        let ime_file_name = matches
-            .value_of("ime-file-name")
-            .map(String::from)
-            .expect("IME file name must be at least the default");
+    let ime_file_name = matches
+        .value_of("ime-file-name")
+        .map(String::from)
+        .expect("IME file name must be at least the default");
 
-        let dig_product_id = matches
-            .value_of("dig-product-id")
-            .map(String::from)
-            .expect("DIG product ID must be at least the default");
+    let dig_product_id = matches
+        .value_of("dig-product-id")
+        .map(String::from)
+        .expect("DIG product ID must be at least the default");
 
-        Self {
-            credentials,
-            security_protocol,
-            keyboard_type,
-            keyboard_subtype,
-            keyboard_functional_keys_count,
-            ime_file_name,
-            dig_product_id,
-        }
+    InputConfig {
+        credentials,
+        security_protocol,
+        keyboard_type,
+        keyboard_subtype,
+        keyboard_functional_keys_count,
+        ime_file_name,
+        dig_product_id,
+        width: DEFAULT_WIDTH,
+        height: DEFAULT_HEIGHT,
+        global_channel_name: GLOBAL_CHANNEL_NAME.to_string(),
+        user_channel_name: USER_CHANNEL_NAME.to_string(),
     }
 }
 

--- a/ironrdp_client/src/errors.rs
+++ b/ironrdp_client/src/errors.rs
@@ -1,0 +1,149 @@
+use std::io;
+
+use failure::Fail;
+use ironrdp::{codecs, dvc::gfx, fast_path::FastPathError, nego, rdp, McsError};
+
+#[derive(Debug, Fail)]
+pub enum RdpError {
+    #[fail(display = "IO error: {}", _0)]
+    IOError(#[fail(cause)] io::Error),
+    #[fail(display = "connection error: {}", _0)]
+    ConnectionError(#[fail(cause)] io::Error),
+    #[fail(display = "X.224 error: {}", _0)]
+    X224Error(#[fail(cause)] io::Error),
+    #[fail(display = "negotiation error: {}", _0)]
+    NegotiationError(#[fail(cause)] nego::NegotiationError),
+    #[fail(display = "unexpected PDU: {}", _0)]
+    UnexpectedPdu(String),
+    #[fail(display = "Unexpected disconnection: {}", _0)]
+    UnexpectedDisconnection(String),
+    #[fail(display = "invalid response: {}", _0)]
+    InvalidResponse(String),
+    #[fail(display = "TLS connector error: {}", _0)]
+    TlsConnectorError(rustls::TLSError),
+    #[fail(display = "TLS handshake error: {}", _0)]
+    TlsHandshakeError(rustls::TLSError),
+    #[fail(display = "CredSSP error: {}", _0)]
+    CredSspError(#[fail(cause)] sspi::Error),
+    #[fail(display = "CredSSP TSRequest error: {}", _0)]
+    TsRequestError(#[fail(cause)] io::Error),
+    #[fail(display = "early User Authentication Result error: {}", _0)]
+    EarlyUserAuthResultError(#[fail(cause)] io::Error),
+    #[fail(display = "the server denied access via Early User Authentication Result")]
+    AccessDenied,
+    #[fail(display = "MCS Connect error: {}", _0)]
+    McsConnectError(#[fail(cause)] McsError),
+    #[fail(display = "failed to get info about the user: {}", _0)]
+    UserInfoError(String),
+    #[fail(display = "MCS error: {}", _0)]
+    McsError(McsError),
+    #[fail(display = "Client Info PDU error: {}", _0)]
+    ClientInfoError(rdp::RdpError),
+    #[fail(display = "Server License PDU error: {}", _0)]
+    ServerLicenseError(rdp::RdpError),
+    #[fail(display = "Share Control Header error: {}", _0)]
+    ShareControlHeaderError(rdp::RdpError),
+    #[fail(display = "capability sets error: {}", _0)]
+    CapabilitySetsError(rdp::RdpError),
+    #[fail(display = "Virtual channel error: {}", _0)]
+    VirtualChannelError(rdp::vc::ChannelError),
+    #[fail(display = "Invalid channel id error: {}", _0)]
+    InvalidChannelIdError(String),
+    #[fail(display = "Graphics pipeline protocol error: {}", _0)]
+    GraphicsPipelineError(gfx::GraphicsPipelineError),
+    #[fail(display = "ZGFX error: {}", _0)]
+    ZgfxError(#[fail(cause)] gfx::zgfx::ZgfxError),
+    #[fail(display = "Fast-Path error: {}", _0)]
+    FastPathError(#[fail(cause)] FastPathError),
+    #[fail(display = "RDP error: {}", _0)]
+    RdpError(#[fail(cause)] ironrdp::RdpError),
+    #[fail(display = "access to the non-existing channel: {}", _0)]
+    AccessToNonExistingChannel(u32),
+    #[fail(display = "data in unexpected channel: {}", _0)]
+    UnexpectedChannel(u16),
+    #[fail(display = "unexpected Surface Command codec ID: {}", _0)]
+    UnexpectedCodecId(u8),
+    #[fail(display = "RDP error: {}", _0)]
+    RfxError(#[fail(cause)] codecs::rfx::RfxError),
+    #[fail(display = "absence of mandatory Fast-Path header")]
+    MandatoryHeaderIsAbsent,
+    #[fail(display = "RLGR error: {}", _0)]
+    RlgrError(#[fail(cause)] codecs::rfx::rlgr::RlgrError),
+    #[fail(display = "absence of RFX channels")]
+    NoRfxChannelsAnnounced,
+    #[fail(
+        display = "the server that started working using the inconsistent protocol: {:?}",
+        _0
+    )]
+    UnexpectedFastPathUpdate(ironrdp::fast_path::UpdateCode),
+}
+
+impl From<io::Error> for RdpError {
+    fn from(e: io::Error) -> Self {
+        RdpError::IOError(e)
+    }
+}
+
+impl From<rustls::TLSError> for RdpError {
+    fn from(e: rustls::TLSError) -> Self {
+        match e {
+            rustls::TLSError::InappropriateHandshakeMessage { .. }
+            | rustls::TLSError::HandshakeNotComplete => RdpError::TlsHandshakeError(e),
+            _ => RdpError::TlsConnectorError(e),
+        }
+    }
+}
+
+impl From<nego::NegotiationError> for RdpError {
+    fn from(e: nego::NegotiationError) -> Self {
+        RdpError::NegotiationError(e)
+    }
+}
+
+impl From<McsError> for RdpError {
+    fn from(e: McsError) -> Self {
+        RdpError::McsError(e)
+    }
+}
+
+impl From<rdp::vc::ChannelError> for RdpError {
+    fn from(e: rdp::vc::ChannelError) -> Self {
+        RdpError::VirtualChannelError(e)
+    }
+}
+
+impl From<gfx::GraphicsPipelineError> for RdpError {
+    fn from(e: gfx::GraphicsPipelineError) -> Self {
+        RdpError::GraphicsPipelineError(e)
+    }
+}
+
+impl From<gfx::zgfx::ZgfxError> for RdpError {
+    fn from(e: gfx::zgfx::ZgfxError) -> Self {
+        RdpError::ZgfxError(e)
+    }
+}
+
+impl From<FastPathError> for RdpError {
+    fn from(e: FastPathError) -> Self {
+        RdpError::FastPathError(e)
+    }
+}
+
+impl From<ironrdp::RdpError> for RdpError {
+    fn from(e: ironrdp::RdpError) -> Self {
+        RdpError::RdpError(e)
+    }
+}
+
+impl From<codecs::rfx::RfxError> for RdpError {
+    fn from(e: codecs::rfx::RfxError) -> Self {
+        RdpError::RfxError(e)
+    }
+}
+
+impl From<codecs::rfx::rlgr::RlgrError> for RdpError {
+    fn from(e: codecs::rfx::rlgr::RlgrError) -> Self {
+        RdpError::RlgrError(e)
+    }
+}

--- a/ironrdp_client/src/lib.rs
+++ b/ironrdp_client/src/lib.rs
@@ -5,9 +5,15 @@ pub mod transport;
 mod errors;
 mod utils;
 
-pub use errors::RdpError;
+pub use self::{
+    active_session::process_active_stage,
+    connection_sequence::{process_connection_sequence, ConnectionSequenceResult, UpgradedStream},
+    errors::RdpError,
+};
 
 use ironrdp::{gcc, nego};
+
+const BUF_STREAM_SIZE: usize = 32 * 1024;
 
 pub struct InputConfig {
     pub credentials: sspi::AuthIdentity,

--- a/ironrdp_client/src/lib.rs
+++ b/ironrdp_client/src/lib.rs
@@ -1,0 +1,24 @@
+pub mod active_session;
+pub mod connection_sequence;
+pub mod transport;
+
+mod errors;
+mod utils;
+
+pub use errors::RdpError;
+
+use ironrdp::{gcc, nego};
+
+pub struct InputConfig {
+    pub credentials: sspi::AuthIdentity,
+    pub security_protocol: nego::SecurityProtocol,
+    pub keyboard_type: gcc::KeyboardType,
+    pub keyboard_subtype: u32,
+    pub keyboard_functional_keys_count: u32,
+    pub ime_file_name: String,
+    pub dig_product_id: String,
+    pub width: u16,
+    pub height: u16,
+    pub global_channel_name: String,
+    pub user_channel_name: String,
+}

--- a/ironrdp_client/src/transport/channels.rs
+++ b/ironrdp_client/src/transport/channels.rs
@@ -3,7 +3,7 @@ use std::io;
 use ironrdp::{rdp::vc, PduParsing};
 
 use super::{Decoder, Encoder, SendDataContextTransport};
-use crate::{RdpError, RdpResult};
+use crate::RdpError;
 
 #[derive(Copy, Clone, Debug)]
 pub struct ChannelIdentificators {
@@ -37,7 +37,7 @@ impl Encoder for StaticVirtualChannelTransport {
         &mut self,
         mut channel_data_buffer: Self::Item,
         mut stream: impl io::Write,
-    ) -> RdpResult<()> {
+    ) -> Result<(), RdpError> {
         let channel_header = vc::ChannelPduHeader {
             total_length: channel_data_buffer.len() as u32,
             flags: vc::ChannelControlFlags::FLAG_FIRST | vc::ChannelControlFlags::FLAG_LAST,
@@ -57,7 +57,7 @@ impl Decoder for StaticVirtualChannelTransport {
     type Item = (u16, usize);
     type Error = RdpError;
 
-    fn decode(&mut self, mut stream: impl io::Read) -> RdpResult<Self::Item> {
+    fn decode(&mut self, mut stream: impl io::Read) -> Result<Self::Item, RdpError> {
         let channel_ids = self.transport.decode(&mut stream)?;
         self.channel_ids = channel_ids;
         let channel_header = vc::ChannelPduHeader::from_buffer(&mut stream)?;
@@ -82,7 +82,7 @@ impl DynamicVirtualChannelTransport {
     pub fn prepare_data_to_encode(
         dvc_pdu: vc::dvc::ClientPdu,
         extra_data: Option<Vec<u8>>,
-    ) -> RdpResult<Vec<u8>> {
+    ) -> Result<Vec<u8>, RdpError> {
         let mut full_data_buff = Vec::with_capacity(dvc_pdu.buffer_length());
         dvc_pdu.to_buffer(&mut full_data_buff)?;
 
@@ -98,7 +98,11 @@ impl Encoder for DynamicVirtualChannelTransport {
     type Item = Vec<u8>;
     type Error = RdpError;
 
-    fn encode(&mut self, client_pdu_buff: Self::Item, mut stream: impl io::Write) -> RdpResult<()> {
+    fn encode(
+        &mut self,
+        client_pdu_buff: Self::Item,
+        mut stream: impl io::Write,
+    ) -> Result<(), RdpError> {
         self.transport.encode(client_pdu_buff, &mut stream)
     }
 }
@@ -107,7 +111,7 @@ impl Decoder for DynamicVirtualChannelTransport {
     type Item = vc::dvc::ServerPdu;
     type Error = RdpError;
 
-    fn decode(&mut self, mut stream: impl io::Read) -> RdpResult<Self::Item> {
+    fn decode(&mut self, mut stream: impl io::Read) -> Result<Self::Item, RdpError> {
         let (channel_id, dvc_data_size) = self.transport.decode(&mut stream)?;
         if self.drdynvc_id != channel_id {
             return Err(RdpError::InvalidChannelIdError(format!(

--- a/ironrdp_client/src/transport/connection.rs
+++ b/ironrdp_client/src/transport/connection.rs
@@ -71,7 +71,7 @@ impl EarlyUserAuthResult {
 }
 
 pub fn connect(
-    mut stream: impl io::BufRead + io::Write,
+    mut stream: impl io::Read + io::Write,
     security_protocol: nego::SecurityProtocol,
     username: String,
 ) -> Result<(DataTransport, nego::SecurityProtocol), RdpError> {
@@ -87,7 +87,7 @@ pub fn connect(
 }
 
 fn process_negotiation(
-    mut stream: impl io::BufRead + io::Write,
+    mut stream: impl io::Read + io::Write,
     nego_data: Option<nego::NegoData>,
     protocol: nego::SecurityProtocol,
     flags: nego::RequestFlags,

--- a/ironrdp_client/src/transport/connection.rs
+++ b/ironrdp_client/src/transport/connection.rs
@@ -6,7 +6,7 @@ use log::debug;
 use sspi::internal::credssp;
 
 use super::{DataTransport, Decoder, Encoder};
-use crate::{RdpError, RdpResult};
+use crate::RdpError;
 
 const MAX_TS_REQUEST_LENGTH_BUFFER_SIZE: usize = 4;
 
@@ -17,7 +17,11 @@ impl Encoder for TsRequestTransport {
     type Item = credssp::TsRequest;
     type Error = RdpError;
 
-    fn encode(&mut self, ts_request: Self::Item, mut stream: impl io::Write) -> RdpResult<()> {
+    fn encode(
+        &mut self,
+        ts_request: Self::Item,
+        mut stream: impl io::Write,
+    ) -> Result<(), RdpError> {
         let mut buf = BytesMut::with_capacity(ts_request.buffer_len() as usize);
         buf.resize(ts_request.buffer_len() as usize, 0x00);
 
@@ -36,7 +40,7 @@ impl Decoder for TsRequestTransport {
     type Item = credssp::TsRequest;
     type Error = RdpError;
 
-    fn decode(&mut self, mut stream: impl io::Read) -> RdpResult<Self::Item> {
+    fn decode(&mut self, mut stream: impl io::Read) -> Result<Self::Item, RdpError> {
         let mut buf = BytesMut::with_capacity(MAX_TS_REQUEST_LENGTH_BUFFER_SIZE);
         buf.resize(MAX_TS_REQUEST_LENGTH_BUFFER_SIZE, 0x00);
         stream.read_exact(&mut buf)?;
@@ -55,7 +59,7 @@ impl Decoder for TsRequestTransport {
 pub struct EarlyUserAuthResult;
 
 impl EarlyUserAuthResult {
-    pub fn read(mut stream: impl io::Read) -> RdpResult<credssp::EarlyUserAuthResult> {
+    pub fn read(mut stream: impl io::Read) -> Result<credssp::EarlyUserAuthResult, RdpError> {
         let mut buf = BytesMut::with_capacity(credssp::EARLY_USER_AUTH_RESULT_PDU_SIZE);
         buf.resize(credssp::EARLY_USER_AUTH_RESULT_PDU_SIZE, 0x00);
         stream.read_exact(&mut buf)?;
@@ -70,7 +74,7 @@ pub fn connect(
     mut stream: impl io::BufRead + io::Write,
     security_protocol: nego::SecurityProtocol,
     username: String,
-) -> RdpResult<(DataTransport, nego::SecurityProtocol)> {
+) -> Result<(DataTransport, nego::SecurityProtocol), RdpError> {
     let selected_protocol = process_negotiation(
         &mut stream,
         Some(nego::NegoData::Cookie(username)),
@@ -88,7 +92,7 @@ fn process_negotiation(
     protocol: nego::SecurityProtocol,
     flags: nego::RequestFlags,
     src_ref: u16,
-) -> RdpResult<nego::SecurityProtocol> {
+) -> Result<nego::SecurityProtocol, RdpError> {
     let connection_request = nego::Request {
         nego_data,
         flags,

--- a/ironrdp_client/src/utils.rs
+++ b/ironrdp_client/src/utils.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, hash::Hash, io};
+use std::{collections::HashMap, hash::Hash};
 
 use num_derive::{FromPrimitive, ToPrimitive};
 
@@ -40,12 +40,4 @@ where
 #[derive(Debug, Copy, Clone, PartialEq, FromPrimitive, ToPrimitive)]
 pub enum CodecId {
     RemoteFx = 0x3,
-}
-
-pub fn get_tls_peer_pubkey(cert: Vec<u8>) -> io::Result<Vec<u8>> {
-    let res = x509_parser::parse_x509_der(&cert[..])
-        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "Invalid der certificate."))?;
-    let public_key = res.1.tbs_certificate.subject_pki.subject_public_key;
-
-    Ok(public_key.data.to_vec())
 }

--- a/ironrdp_client/src/utils.rs
+++ b/ironrdp_client/src/utils.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashMap, hash::Hash, io};
 
 use num_derive::{FromPrimitive, ToPrimitive};
-use x509_parser::parse_x509_der;
 
 #[macro_export]
 macro_rules! eof_try {
@@ -26,18 +25,6 @@ macro_rules! try_ready {
     };
 }
 
-pub fn socket_addr_to_string(socket_addr: std::net::SocketAddr) -> String {
-    format!("{}:{}", socket_addr.ip(), socket_addr.port())
-}
-
-pub fn get_tls_peer_pubkey(cert: Vec<u8>) -> io::Result<Vec<u8>> {
-    let res = parse_x509_der(&cert[..])
-        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "Invalid der certificate."))?;
-    let public_key = res.1.tbs_certificate.subject_pki.subject_public_key;
-
-    Ok(public_key.data.to_vec())
-}
-
 pub fn swap_hashmap_kv<K, V>(hm: HashMap<K, V>) -> HashMap<V, K>
 where
     V: Hash + Eq,
@@ -53,4 +40,12 @@ where
 #[derive(Debug, Copy, Clone, PartialEq, FromPrimitive, ToPrimitive)]
 pub enum CodecId {
     RemoteFx = 0x3,
+}
+
+pub fn get_tls_peer_pubkey(cert: Vec<u8>) -> io::Result<Vec<u8>> {
+    let res = x509_parser::parse_x509_der(&cert[..])
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "Invalid der certificate."))?;
+    let public_key = res.1.tbs_certificate.subject_pki.subject_public_key;
+
+    Ok(public_key.data.to_vec())
 }


### PR DESCRIPTION
1. Moved out all independent parts to the lib.rs file;
2. Updated connection sequence and active stage parts to be independent of the underlying streams (via traits);
3. Moved connection sequence to the separate function to make the ability to reuse the function.