### PR TITLE
Preconnection PDU parsing improvements

### DIFF
--- a/ironrdp/Cargo.toml
+++ b/ironrdp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironrdp"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2018"
 readme = "../README.md"
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
This PR introduces a few improvements to the Preconnection PDU parsing, which were made in the scope of Devolutions Jet JWT routing feature implementation.

Changes:
- Changed InvalidDataLength errors to io::Error(ErrorKind::Eof,...) where more data is required to parse the packet. Thiss will make Preconnection PDU parsing error handling consistent with other PDU parsers. Without this change, it is hard to tell if PDU parsing is actually failed or buffer just had not enough data
- Moved around preconnection PDU header check code to eliminate case, when we could read first 4 bytes of the packet and immediately use it as required PDU data buffer size to allocate, which can cause some nasty out-of-memory errors