### PR TITLE
Fix Windows 10 2004 update connectivity (RDP client or server)

### DIFF
--- a/ironrdp/src/gcc/core_data.rs
+++ b/ironrdp/src/gcc/core_data.rs
@@ -22,6 +22,14 @@ pub enum RdpVersion {
     V10_5 = 0x0008_000A,
     V10_6 = 0x0008_000B,
     V10_7 = 0x0008_000C,
+    V10_8 = 0x0008_000D,
+
+    // future proofing
+    V10_9 = 0x0008_000E,
+    V10_10 = 0x0008_000F,
+    V10_11 = 0x0008_0010,
+    V10_12 = 0x0008_0011,
+    VUnknown = 0x0000_0000,
 }
 
 #[derive(Debug, Fail)]

--- a/ironrdp/src/gcc/core_data/client.rs
+++ b/ironrdp/src/gcc/core_data/client.rs
@@ -83,7 +83,7 @@ impl PduParsing for ClientCoreData {
 
     fn from_buffer(mut buffer: impl io::Read) -> Result<Self, Self::Error> {
         let version = RdpVersion::from_u32(buffer.read_u32::<LittleEndian>()?)
-            .ok_or(CoreDataError::InvalidVersion)?;
+            .unwrap_or(RdpVersion::VUnknown);
         let desktop_width = buffer.read_u16::<LittleEndian>()?;
         let desktop_height = buffer.read_u16::<LittleEndian>()?;
         let color_depth = ColorDepth::from_u16(buffer.read_u16::<LittleEndian>()?)

--- a/ironrdp/src/gcc/core_data/server.rs
+++ b/ironrdp/src/gcc/core_data/server.rs
@@ -24,7 +24,7 @@ impl PduParsing for ServerCoreData {
 
     fn from_buffer(mut buffer: impl io::Read) -> Result<Self, Self::Error> {
         let version = RdpVersion::from_u32(buffer.read_u32::<LittleEndian>()?)
-            .ok_or(CoreDataError::InvalidVersion)?;
+            .unwrap_or(RdpVersion::VUnknown);
         let optional_data = ServerCoreOptionalData::from_buffer(&mut buffer)?;
 
         Ok(Self {


### PR DESCRIPTION
Newer RDP clients or server with the Windows 10 2004 update advertised RDP protocol 10.8, which caused issues with conversion to the RdpVersion enum that lacked this new value. I added a few of the expected future protocol version values, and also added a "VUnknown" element as a safety net for any unknown protocol versions. If we see a value we don't know, we can just ignore it, it is just an indicator, not something that should cause a hard protocol failure.