### PR TITLE
Integrate new sspi-rs Kerberos module in ironrdp client and add support for `native-tls` as TLS backend

### DIFF
--- a/ironrdp_client/Cargo.toml
+++ b/ironrdp_client/Cargo.toml
@@ -25,7 +25,7 @@ native-tls = ["dep:native-tls"]
 
 [dependencies]
 ironrdp = { path = "../ironrdp" }
-sspi = { git = "https://github.com/Devolutions/sspi-rs.git", branch = "portable-kerberos", features = ["with_reqwest_network_client"] }
+sspi = { git = "https://github.com/Devolutions/sspi-rs.git", branch = "portable-kerberos", features = ["network_client"] }
 clap = "2.33"
 bytes = "0.5"
 failure = "0.1"

--- a/ironrdp_client/Cargo.toml
+++ b/ironrdp_client/Cargo.toml
@@ -18,6 +18,11 @@ path = "src/lib.rs"
 name = "ironrdp_client_app"
 path = "src/main.rs"
 
+[features]
+default = ["native-tls"]
+rustls = ["dep:rustls"]
+native-tls = ["dep:native-tls"]
+
 [dependencies]
 ironrdp = { path = "../ironrdp" }
 sspi = { git = "https://github.com/Devolutions/sspi-rs.git", branch = "portable-kerberos", features = ["with_reqwest_network_client"] }
@@ -34,9 +39,9 @@ num-derive = "0.3"
 semver = "0.9"
 lazy_static = "1.4"
 exitcode = "1.1"
-webpki = "0.22.0"
 bufstream = "0.1"
 ring = "0.16.0"
 # native-tls is preferred over rustls
 # rustls set 1.0 in the client hello request header for TLS 1.2 and windows RDP server rejects such requests
-native-tls = "0.2.10"
+native-tls = { version = "0.2", optional = true }
+rustls = { version = "0.20", features = ["dangerous_configuration"], optional = true }

--- a/ironrdp_client/Cargo.toml
+++ b/ironrdp_client/Cargo.toml
@@ -19,7 +19,7 @@ name = "ironrdp_client_app"
 path = "src/main.rs"
 
 [features]
-default = ["native-tls"]
+default = ["rustls"]
 rustls = ["dep:rustls"]
 native-tls = ["dep:native-tls"]
 

--- a/ironrdp_client/Cargo.toml
+++ b/ironrdp_client/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 
 [dependencies]
 ironrdp = { path = "../ironrdp" }
-sspi = { path = "../../sspi-rs" }
+sspi = { git = "https://github.com/Devolutions/sspi-rs.git", branch = "portable-kerberos", features = ["with_reqwest_network_client"] }
 clap = "2.33"
 bytes = "0.5"
 failure = "0.1"

--- a/ironrdp_client/Cargo.toml
+++ b/ironrdp_client/Cargo.toml
@@ -20,14 +20,13 @@ path = "src/main.rs"
 
 [dependencies]
 ironrdp = { path = "../ironrdp" }
-sspi = "0.3.0"
+sspi = { path = "../../sspi-rs" }
 clap = "2.33"
 bytes = "0.5"
 failure = "0.1"
 chrono = "0.4"
 fern = "0.6"
 log = "0.4"
-rustls = { version = "0.16.0", features = ["dangerous_configuration"] }
 x509-parser = "0.6.0"
 whoami = "0.8"
 num-traits = "0.2"
@@ -35,6 +34,7 @@ num-derive = "0.3"
 semver = "0.9"
 lazy_static = "1.4"
 exitcode = "1.1"
-webpki = "0.21.0"
+webpki = "0.22.0"
 bufstream = "0.1"
 ring = "0.16.0"
+native-tls = "0.2.10"

--- a/ironrdp_client/Cargo.toml
+++ b/ironrdp_client/Cargo.toml
@@ -41,7 +41,5 @@ lazy_static = "1.4"
 exitcode = "1.1"
 bufstream = "0.1"
 ring = "0.16.0"
-# native-tls is preferred over rustls
-# rustls set 1.0 in the client hello request header for TLS 1.2 and windows RDP server rejects such requests
 native-tls = { version = "0.2", optional = true }
 rustls = { version = "0.20", features = ["dangerous_configuration"], optional = true }

--- a/ironrdp_client/Cargo.toml
+++ b/ironrdp_client/Cargo.toml
@@ -25,7 +25,7 @@ native-tls = ["dep:native-tls"]
 
 [dependencies]
 ironrdp = { path = "../ironrdp" }
-sspi = { git = "https://github.com/Devolutions/sspi-rs.git", branch = "portable-kerberos", features = ["network_client"] }
+sspi = { version = "0.3.3" features = ["network_client"] }
 clap = "2.33"
 bytes = "0.5"
 failure = "0.1"

--- a/ironrdp_client/Cargo.toml
+++ b/ironrdp_client/Cargo.toml
@@ -37,4 +37,6 @@ exitcode = "1.1"
 webpki = "0.22.0"
 bufstream = "0.1"
 ring = "0.16.0"
+# native-tls is preferred over rustls
+# rustls set 1.0 in the client hello request header for TLS 1.2 and windows RDP server rejects such requests
 native-tls = "0.2.10"

--- a/ironrdp_client/Cargo.toml
+++ b/ironrdp_client/Cargo.toml
@@ -25,7 +25,7 @@ native-tls = ["dep:native-tls"]
 
 [dependencies]
 ironrdp = { path = "../ironrdp" }
-sspi = { version = "0.3.3" features = ["network_client"] }
+sspi = { version = "0.3.3", features = ["network_client"] }
 clap = "2.33"
 bytes = "0.5"
 failure = "0.1"

--- a/ironrdp_client/src/connection_sequence.rs
+++ b/ironrdp_client/src/connection_sequence.rs
@@ -144,12 +144,12 @@ pub fn process_cred_ssp(
 
         match result {
             credssp::ClientState::ReplyNeeded(ts_request) => {
-                debug!("Send CredSSP TSRequest: {:x?}", ts_request);
+                debug!("Send CredSSP TSRequest (reply needed): {:x?}", ts_request);
                 transport.encode(ts_request, &mut tls_stream)?;
                 next_ts_request = transport.decode(&mut tls_stream)?;
             }
             credssp::ClientState::FinalMessage(ts_request) => {
-                debug!("Send CredSSP TSRequest: {:x?}", ts_request);
+                debug!("Send CredSSP TSRequest (final): {:x?}", ts_request);
                 transport.encode(ts_request, &mut tls_stream)?;
                 break;
             }

--- a/ironrdp_client/src/connection_sequence.rs
+++ b/ironrdp_client/src/connection_sequence.rs
@@ -17,6 +17,7 @@ use ironrdp::{nego, rdp, PduParsing};
 use log::{debug, info, trace, warn};
 use ring::rand::SecureRandom;
 use sspi::internal::credssp;
+use sspi::KerberosConfig;
 
 use crate::transport::*;
 use crate::{InputConfig, RdpError, BUF_STREAM_SIZE};
@@ -131,9 +132,13 @@ pub fn process_cred_ssp(
 ) -> Result<(), RdpError> {
     let mut transport = TsRequestTransport::default();
 
-    let mut cred_ssp_client =
-        credssp::CredSspClient::new(server_public_key, credentials, credssp::CredSspMode::WithCredentials)
-            .map_err(RdpError::CredSspError)?;
+    let mut cred_ssp_client = credssp::CredSspClient::new(
+        server_public_key,
+        credentials,
+        credssp::CredSspMode::WithCredentials,
+        credssp::ClientMode::Kerberos(KerberosConfig::from_env()),
+    )
+    .map_err(RdpError::CredSspError)?;
     let mut next_ts_request = credssp::TsRequest::default();
 
     loop {

--- a/ironrdp_client/src/errors.rs
+++ b/ironrdp_client/src/errors.rs
@@ -22,9 +22,9 @@ pub enum RdpError {
     #[fail(display = "invalid response: {}", _0)]
     InvalidResponse(String),
     #[fail(display = "TLS connector error: {}", _0)]
-    TlsConnectorError(rustls::TLSError),
+    TlsConnectorError(native_tls::Error),
     #[fail(display = "TLS handshake error: {}", _0)]
-    TlsHandshakeError(rustls::TLSError),
+    TlsHandshakeError(native_tls::Error),
     #[fail(display = "CredSSP error: {}", _0)]
     CredSspError(#[fail(cause)] sspi::Error),
     #[fail(display = "CredSSP TSRequest error: {}", _0)]
@@ -80,22 +80,13 @@ pub enum RdpError {
     UnexpectedFastPathUpdate(ironrdp::fast_path::UpdateCode),
     #[fail(display = "server error: {}", _0)]
     ServerError(String),
+    #[fail(display = "Missing peer certificate")]
+    MissingPeerCertificate,
 }
 
 impl From<io::Error> for RdpError {
     fn from(e: io::Error) -> Self {
         RdpError::IOError(e)
-    }
-}
-
-impl From<rustls::TLSError> for RdpError {
-    fn from(e: rustls::TLSError) -> Self {
-        match e {
-            rustls::TLSError::InappropriateHandshakeMessage { .. } | rustls::TLSError::HandshakeNotComplete => {
-                RdpError::TlsHandshakeError(e)
-            }
-            _ => RdpError::TlsConnectorError(e),
-        }
     }
 }
 

--- a/ironrdp_client/src/errors.rs
+++ b/ironrdp_client/src/errors.rs
@@ -82,6 +82,8 @@ pub enum RdpError {
     ServerError(String),
     #[fail(display = "Missing peer certificate")]
     MissingPeerCertificate,
+    #[fail(display = "Invalid DER structure: {}", _0)]
+    DerEncode(#[fail(cause)] native_tls::Error),
 }
 
 impl From<io::Error> for RdpError {

--- a/ironrdp_client/src/errors.rs
+++ b/ironrdp_client/src/errors.rs
@@ -21,16 +21,16 @@ pub enum RdpError {
     UnexpectedDisconnection(String),
     #[fail(display = "invalid response: {}", _0)]
     InvalidResponse(String),
-    #[cfg(feature = "native-tls")]
+    #[cfg(all(feature = "native-tls", not(feature = "rustls")))]
     #[fail(display = "TLS connector error: {}", _0)]
     TlsConnectorError(native_tls::Error),
-    #[cfg(feature = "native-tls")]
+    #[cfg(all(feature = "native-tls", not(feature = "rustls")))]
     #[fail(display = "TLS handshake error: {}", _0)]
     TlsHandshakeError(native_tls::Error),
-    #[cfg(all(feature = "rustls", not(feature = "native-tls")))]
+    #[cfg(feature = "rustls")]
     #[fail(display = "TLS connector error: {}", _0)]
     TlsConnectorError(rustls::Error),
-    #[cfg(all(feature = "rustls", not(feature = "native-tls")))]
+    #[cfg(feature = "rustls")]
     #[fail(display = "TLS handshake error: {}", _0)]
     TlsHandshakeError(rustls::Error),
     #[fail(display = "CredSSP error: {}", _0)]
@@ -90,7 +90,7 @@ pub enum RdpError {
     ServerError(String),
     #[fail(display = "Missing peer certificate")]
     MissingPeerCertificate,
-    #[cfg(feature = "native-tls")]
+    #[cfg(all(feature = "native-tls", not(feature = "rustls")))]
     #[fail(display = "Invalid DER structure: {}", _0)]
     DerEncode(#[fail(cause)] native_tls::Error),
 }
@@ -101,7 +101,7 @@ impl From<io::Error> for RdpError {
     }
 }
 
-#[cfg(all(feature = "rustls", not(feature = "native-tls")))]
+#[cfg(feature = "rustls")]
 impl From<rustls::Error> for RdpError {
     fn from(e: rustls::Error) -> Self {
         match e {


### PR DESCRIPTION
* Changed the `CredSspClient` creation according to changes in the `sspi-rs`
* ~~Replace `rustls` with `native-tls`: when using TLS 1.2 `rustls` sets *record version = 1.0* and *client version = 1.2*  in client hello request and Windows RDP server rejects such messages. `native-tls` sets 1.2 in both places. Also, I've added a comment about it in the code (see `Cargo.toml`).~~
* Add optional support for `native-tls`