### PR TITLE
Adding helper method for async

### DIFF
--- a/ironrdp/src/lib.rs
+++ b/ironrdp/src/lib.rs
@@ -102,8 +102,8 @@ impl_from_error!(std::io::Error, RdpError, RdpError::IOError);
 impl_from_error!(nego::NegotiationError, RdpError, RdpError::X224Error);
 impl_from_error!(fast_path::FastPathError, RdpError, RdpError::FastPathError);
 
-#[derive(Debug, Copy, Clone, PartialEq, num_derive::FromPrimitive, num_derive::ToPrimitive)]
-enum Action {
+#[derive(Debug, Copy, Clone, PartialEq, Eq, num_derive::FromPrimitive, num_derive::ToPrimitive)]
+pub enum Action {
     FastPath = 0x0,
     X224 = 0x3,
 }

--- a/ironrdp/src/mcs.rs
+++ b/ironrdp/src/mcs.rs
@@ -344,6 +344,8 @@ impl DisconnectUltimatumReason {
 pub enum McsError {
     #[fail(display = "IO error: {}", _0)]
     IOError(#[fail(cause)] io::Error),
+    #[fail(display = "RDP error: {}", _0)]
+    RdpError(#[fail(cause)] crate::RdpError),
     #[fail(display = "GCC block error: {}", _0)]
     GccError(#[fail(cause)] GccError),
     #[fail(display = "Invalid disconnect provider ultimatum")]
@@ -357,6 +359,7 @@ pub enum McsError {
 }
 
 impl_from_error!(io::Error, McsError, McsError::IOError);
+impl_from_error!(crate::RdpError, McsError, McsError::RdpError);
 impl_from_error!(GccError, McsError, McsError::GccError);
 
 impl From<McsError> for io::Error {

--- a/ironrdp/src/x224.rs
+++ b/ironrdp/src/x224.rs
@@ -17,7 +17,7 @@ pub const TPDU_REQUEST_LENGTH: usize = TPKT_HEADER_LENGTH + TPDU_REQUEST_HEADER_
 pub const TPDU_REQUEST_HEADER_LENGTH: usize = 7;
 pub const TPDU_ERROR_HEADER_LENGTH: usize = 5;
 
-const TPKT_VERSION: u8 = 3;
+pub const TPKT_VERSION: u8 = 3;
 
 const EOF: u8 = 0x80;
 

--- a/ironrdp_client/Cargo.toml
+++ b/ironrdp_client/Cargo.toml
@@ -20,8 +20,8 @@ path = "src/main.rs"
 
 [features]
 default = ["rustls"]
-rustls = ["dep:rustls"]
-native-tls = ["dep:native-tls"]
+rustls = ["dep:rustls", "dep:tokio-rustls"]
+native-tls = ["dep:native-tls", "dep:async-native-tls"]
 
 [dependencies]
 ironrdp = { path = "../ironrdp" }
@@ -42,6 +42,13 @@ exitcode = "1.1"
 bufstream = "0.1"
 ring = "0.16.0"
 native-tls = { version = "0.2", optional = true }
+async-native-tls = { version = "0.4", default-features = false, features = [ "runtime-tokio" ], optional = true }
 rustls = { version = "0.20", features = ["dangerous_configuration"], optional = true }
 dns-lookup = "1.0.8"
 bitflags = "1"
+tokio = { version = "1", features = ["full"]}
+tokio-rustls =  { version = "0.23", optional = true }
+bit_field = "0.10.1"
+tokio-util = { version = "0.7", features = ["full"] }
+byteorder = "1.4.3"
+futures = "0.3"

--- a/ironrdp_client/src/active_session/fast_path.rs
+++ b/ironrdp_client/src/active_session/fast_path.rs
@@ -28,22 +28,18 @@ impl Processor {
     pub fn process(
         &mut self,
         header: &FastPathHeader,
-        mut stream: impl io::BufRead + io::Write,
+        stream: &[u8],
+        mut output: impl io::Write,
     ) -> Result<(), RdpError> {
         debug!("Got Fast-Path Header: {:?}", header);
 
-        let input_buffer = &stream.fill_buf()?[..header.data_length];
-
-        let update_pdu = FastPathUpdatePdu::from_buffer(input_buffer)?;
-        let update_pdu_length = update_pdu.buffer_length();
-
+        let update_pdu = FastPathUpdatePdu::from_buffer(stream)?;
         debug!("Fast-Path Update fragmentation: {:?}", update_pdu.fragmentation);
 
         let processed_complete_data = self
             .complete_data
             .process_data(update_pdu.data, update_pdu.fragmentation);
         let update_code = update_pdu.update_code;
-        stream.consume(update_pdu_length);
 
         if let Some(data) = processed_complete_data {
             let update = FastPathUpdate::from_buffer_with_code(data.as_slice(), update_code);
@@ -52,7 +48,7 @@ impl Processor {
                 Ok(FastPathUpdate::SurfaceCommands(surface_commands)) => {
                     info!("Received Surface Commands: {} pieces", surface_commands.len());
 
-                    self.process_surface_commands(&mut stream, surface_commands)?;
+                    self.process_surface_commands(&mut output, surface_commands)?;
                 }
                 Ok(FastPathUpdate::Bitmap(bitmap)) => {
                     info!("Received Bitmap: {:?}", bitmap);

--- a/ironrdp_client/src/codecs.rs
+++ b/ironrdp_client/src/codecs.rs
@@ -1,0 +1,115 @@
+use bit_field::BitField;
+use bytes::{BufMut, BytesMut};
+use ironrdp::{Action, RdpError};
+use tokio_util::codec::{Decoder, Encoder};
+
+use byteorder::{BigEndian, ReadBytesExt};
+
+use num_traits::FromPrimitive;
+
+use crate::transport::{Decoder as TransportDecoder, Encoder as TransportEncoder};
+#[derive(Default)]
+pub struct RdpFrameCodec {}
+
+impl<T> Encoder<T> for RdpFrameCodec
+where
+    T: AsRef<[u8]>,
+{
+    type Error = RdpError;
+
+    fn encode(&mut self, item: T, buf: &mut bytes::BytesMut) -> Result<(), Self::Error> {
+        buf.extend_from_slice(item.as_ref());
+        Ok(())
+    }
+}
+
+impl Decoder for RdpFrameCodec {
+    type Item = BytesMut;
+    type Error = ironrdp::RdpError;
+
+    fn decode(&mut self, src: &mut bytes::BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        let mut stream = src.as_ref();
+        if stream.is_empty() {
+            return Ok(None);
+        }
+        let header = stream.read_u8()?;
+        let action = header.get_bits(0..2);
+        let action = Action::from_u8(action).ok_or(ironrdp::RdpError::InvalidActionCode(action))?;
+
+        let length = match action {
+            Action::X224 if stream.len() >= 3 => {
+                let _reserved = stream.read_u8()?;
+
+                stream.read_u16::<BigEndian>()?
+            }
+            Action::FastPath if !stream.is_empty() => {
+                let a = stream.read_u8()?;
+                if a & 0x80 != 0 {
+                    if stream.is_empty() {
+                        return Ok(None);
+                    }
+                    let b = stream.read_u8()?;
+                    ((u16::from(a) & !0x80) << 8) + u16::from(b)
+                } else {
+                    u16::from(a)
+                }
+            }
+            _ => {
+                return Ok(None);
+            }
+        };
+
+        if src.len() >= length as usize {
+            Ok(Some(src.split_to(length as usize)))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+pub struct TrasnportCodec<T> {
+    inner: RdpFrameCodec,
+    transport: T,
+}
+
+impl<T> TrasnportCodec<T> {
+    pub fn new(transport: T) -> Self {
+        TrasnportCodec {
+            inner: RdpFrameCodec::default(),
+            transport,
+        }
+    }
+}
+
+impl<E, T> Encoder<E> for TrasnportCodec<T>
+where
+    T: TransportEncoder<Item = E>,
+    <T as TransportEncoder>::Error: From<std::io::Error>,
+    <T as TransportEncoder>::Error: From<RdpError>,
+{
+    type Error = <T as TransportEncoder>::Error;
+
+    fn encode(&mut self, item: E, buf: &mut bytes::BytesMut) -> Result<(), Self::Error> {
+        self.transport.encode(item, buf.writer())?;
+        Ok(())
+    }
+}
+
+impl<T> Decoder for TrasnportCodec<T>
+where
+    T: TransportDecoder,
+    <T as TransportDecoder>::Error: From<std::io::Error>,
+    <T as TransportDecoder>::Error: From<ironrdp::RdpError>,
+{
+    type Item = <T as TransportDecoder>::Item;
+    type Error = <T as TransportDecoder>::Error;
+
+    fn decode(&mut self, src: &mut bytes::BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        let buf = self.inner.decode(src)?;
+        if let Some(data) = buf {
+            Ok(Some(self.transport.decode(data.as_ref())?))
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/ironrdp_client/src/errors.rs
+++ b/ironrdp_client/src/errors.rs
@@ -5,7 +5,9 @@ use ironrdp::{
     codecs,
     dvc::{display, gfx},
     fast_path::FastPathError,
-    nego, rdp, McsError,
+    nego,
+    rdp::{self, server_license::ServerLicenseError},
+    McsError,
 };
 
 #[derive(Debug, Fail)]
@@ -103,6 +105,8 @@ pub enum RdpError {
     StaticChannelNotConnected,
     #[fail(display = "Invalid Capabilities mask provided. Mask: {:X}", _0)]
     InvalidCapabilitiesMask(u32),
+    #[fail(display = "Stream terminated while waiting for some data")]
+    UnexpectedStreamTermination,
     #[cfg(all(feature = "native-tls", not(feature = "rustls")))]
     #[fail(display = "Invalid DER structure: {}", _0)]
     DerEncode(#[fail(cause)] native_tls::Error),
@@ -183,5 +187,11 @@ impl From<codecs::rfx::RfxError> for RdpError {
 impl From<codecs::rfx::rlgr::RlgrError> for RdpError {
     fn from(e: codecs::rfx::rlgr::RlgrError) -> Self {
         RdpError::RlgrError(e)
+    }
+}
+
+impl From<ServerLicenseError> for RdpError {
+    fn from(e: ServerLicenseError) -> Self {
+        RdpError::ServerLicenseError(rdp::RdpError::ServerLicenseError(e))
     }
 }

--- a/ironrdp_client/src/lib.rs
+++ b/ironrdp_client/src/lib.rs
@@ -2,6 +2,7 @@ mod errors;
 mod utils;
 
 use ironrdp::{gcc, nego};
+use tokio::net::TcpStream;
 
 pub mod active_session;
 pub mod connection_sequence;
@@ -11,7 +12,7 @@ pub use self::active_session::process_active_stage;
 pub use self::connection_sequence::{process_connection_sequence, ConnectionSequenceResult, UpgradedStream};
 pub use self::errors::RdpError;
 
-const BUF_STREAM_SIZE: usize = 32 * 1024;
+mod codecs;
 
 pub struct GraphicsConfig {
     pub avc444: bool,
@@ -30,8 +31,17 @@ pub struct InputConfig {
     pub ime_file_name: String,
     pub dig_product_id: String,
     pub width: u16,
+
     pub height: u16,
     pub global_channel_name: String,
     pub user_channel_name: String,
     pub graphics_config: Option<GraphicsConfig>,
 }
+
+#[cfg(all(feature = "native-tls", not(feature = "rustls")))]
+use async_native_tls::TlsStream;
+
+#[cfg(feature = "rustls")]
+use tokio_rustls::client::TlsStream;
+
+pub type TlsStreamType = TlsStream<TcpStream>;

--- a/ironrdp_client/src/transport/connection.rs
+++ b/ironrdp_client/src/transport/connection.rs
@@ -1,23 +1,24 @@
-use std::io;
-
 use bytes::BytesMut;
+use futures::StreamExt;
 use ironrdp::{nego, PduParsing};
 use log::debug;
 use sspi::internal::credssp;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio_util::codec::Framed;
 
-use super::{DataTransport, Decoder, Encoder};
-use crate::RdpError;
+use crate::{codecs::RdpFrameCodec, RdpError};
 
 const MAX_TS_REQUEST_LENGTH_BUFFER_SIZE: usize = 4;
 
 #[derive(Default)]
 pub struct TsRequestTransport;
 
-impl Encoder for TsRequestTransport {
-    type Item = credssp::TsRequest;
-    type Error = RdpError;
-
-    fn encode(&mut self, ts_request: Self::Item, mut stream: impl io::Write) -> Result<(), RdpError> {
+impl TsRequestTransport {
+    pub async fn encode(
+        &mut self,
+        ts_request: credssp::TsRequest,
+        mut stream: impl AsyncWrite + Unpin,
+    ) -> Result<(), RdpError> {
         let mut buf = BytesMut::with_capacity(ts_request.buffer_len() as usize);
         buf.resize(ts_request.buffer_len() as usize, 0x00);
 
@@ -25,25 +26,20 @@ impl Encoder for TsRequestTransport {
             .encode_ts_request(buf.as_mut())
             .map_err(RdpError::TsRequestError)?;
 
-        stream.write_all(buf.as_ref())?;
-        stream.flush()?;
+        stream.write_all(buf.as_ref()).await?;
+        stream.flush().await?;
 
         Ok(())
     }
-}
 
-impl Decoder for TsRequestTransport {
-    type Item = credssp::TsRequest;
-    type Error = RdpError;
-
-    fn decode(&mut self, mut stream: impl io::Read) -> Result<Self::Item, RdpError> {
+    pub async fn decode(&mut self, mut stream: impl AsyncRead + Unpin) -> Result<credssp::TsRequest, RdpError> {
         let mut buf = BytesMut::with_capacity(MAX_TS_REQUEST_LENGTH_BUFFER_SIZE);
         buf.resize(MAX_TS_REQUEST_LENGTH_BUFFER_SIZE, 0x00);
-        stream.read_exact(&mut buf)?;
+        stream.read_exact(&mut buf).await?;
 
         let ts_request_buffer_length = credssp::TsRequest::read_length(buf.as_ref())?;
         buf.resize(ts_request_buffer_length, 0x00);
-        stream.read_exact(&mut buf[MAX_TS_REQUEST_LENGTH_BUFFER_SIZE..])?;
+        stream.read_exact(&mut buf[MAX_TS_REQUEST_LENGTH_BUFFER_SIZE..]).await?;
 
         let ts_request = credssp::TsRequest::from_buffer(buf.as_ref()).map_err(RdpError::TsRequestError)?;
 
@@ -54,10 +50,10 @@ impl Decoder for TsRequestTransport {
 pub struct EarlyUserAuthResult;
 
 impl EarlyUserAuthResult {
-    pub fn read(mut stream: impl io::Read) -> Result<credssp::EarlyUserAuthResult, RdpError> {
+    pub async fn read(mut stream: impl AsyncRead + Unpin) -> Result<credssp::EarlyUserAuthResult, RdpError> {
         let mut buf = BytesMut::with_capacity(credssp::EARLY_USER_AUTH_RESULT_PDU_SIZE);
         buf.resize(credssp::EARLY_USER_AUTH_RESULT_PDU_SIZE, 0x00);
-        stream.read_exact(&mut buf)?;
+        stream.read_exact(&mut buf).await?;
         let early_user_auth_result =
             credssp::EarlyUserAuthResult::from_buffer(buf.as_ref()).map_err(RdpError::EarlyUserAuthResultError)?;
 
@@ -65,24 +61,25 @@ impl EarlyUserAuthResult {
     }
 }
 
-pub fn connect(
-    mut stream: impl io::Read + io::Write,
+pub async fn connect(
+    mut stream: impl AsyncRead + AsyncWrite + Unpin,
     security_protocol: nego::SecurityProtocol,
     username: String,
-) -> Result<(DataTransport, nego::SecurityProtocol), RdpError> {
+) -> Result<nego::SecurityProtocol, RdpError> {
     let selected_protocol = process_negotiation(
         &mut stream,
         Some(nego::NegoData::Cookie(username)),
         security_protocol,
         nego::RequestFlags::empty(),
         0,
-    )?;
+    )
+    .await?;
 
-    Ok((DataTransport::default(), selected_protocol))
+    Ok(selected_protocol)
 }
 
-fn process_negotiation(
-    mut stream: impl io::Read + io::Write,
+async fn process_negotiation(
+    mut stream: impl AsyncRead + AsyncWrite + Unpin,
     nego_data: Option<nego::NegoData>,
     protocol: nego::SecurityProtocol,
     flags: nego::RequestFlags,
@@ -95,10 +92,15 @@ fn process_negotiation(
         src_ref,
     };
     debug!("Send X.224 Connection Request PDU: {:?}", connection_request);
-    connection_request.to_buffer(&mut stream)?;
-    stream.flush()?;
+    let mut buffer = Vec::new();
+    connection_request.to_buffer(&mut buffer)?;
+    stream.write_all(buffer.as_slice()).await?;
+    stream.flush().await?;
 
-    let connection_response = nego::Response::from_buffer(&mut stream)?;
+    let mut framed = Framed::new(&mut stream, RdpFrameCodec::default());
+
+    let data = framed.next().await.ok_or(RdpError::AccessDenied)??;
+    let connection_response = nego::Response::from_buffer(data.as_ref())?;
     if let Some(nego::ResponseData::Response {
         flags,
         protocol: selected_protocol,


### PR DESCRIPTION
This is part 2 of a 3 part PR with the intent to add a minimal GUI on top of IronRDP. 

Soliciting feedback if this is the right approach for moving ahead. The problem with IronRDP in the current state is that the connection stream is synchronous. This makes it hard to send events from client side while waiting for a message from the RDP server. In the prototype i created for the interactive client i had a hack [here](https://github.com/msabansal/IronRDP/blob/gui/ironrdp_client/src/utils/cloneable_stream.rs) which would allow for the data to be send while waiting for messages. The proper way to do this in my opinion is to make the client asynchronous. 

This PR contains the minimal set of changes to enable that. The basic premise being we asynchronously wait for a full X224 frame to arrive before processing the frame synchronously. 