### PR TITLE
fix(ironrdp-session, ironrdp. ironrp-cli, ironrdp-gui-client): fix bulding with native-tls

### DIFF
--- a/ironrdp-cli/Cargo.toml
+++ b/ironrdp-cli/Cargo.toml
@@ -11,8 +11,8 @@ keywords = ["rdp", "client", "remote", "desktop", "protocol", "gfx", "rfx"]
 
 [features]
 default = ["rustls"]
-rustls = ["dep:tokio-rustls"]
-native-tls = ["dep:async-native-tls"]
+rustls = ["dep:tokio-rustls", "ironrdp/rustls"]
+native-tls = ["dep:async-native-tls", "ironrdp/native-tls"]
 
 [dependencies]
 

--- a/ironrdp-cli/src/main.rs
+++ b/ironrdp-cli/src/main.rs
@@ -160,7 +160,7 @@ async fn establish_tls(stream: tokio_util::compat::Compat<TcpStream>) -> Result<
         // domain is an empty string because client accepts IP address in the cli
         match connector.connect("", stream).await {
             Ok(tls) => tls,
-            Err(err) => return Err(RdpError::TlsHandshakeError(err)),
+            Err(err) => return Err(RdpError::TlsHandshake(err)),
         }
     };
 
@@ -184,7 +184,7 @@ async fn establish_tls(stream: tokio_util::compat::Compat<TcpStream>) -> Result<
     let server_public_key = {
         let cert = tls_stream
             .peer_certificate()
-            .map_err(RdpError::TlsConnectorError)?
+            .map_err(RdpError::TlsConnector)?
             .ok_or(RdpError::MissingPeerCertificate)?;
         get_tls_peer_pubkey(cert.to_der().map_err(RdpError::DerEncode)?)?
     };

--- a/ironrdp-devolutions-gateway/src/lib.rs
+++ b/ironrdp-devolutions-gateway/src/lib.rs
@@ -1,6 +1,5 @@
 // Re-export der crate for convenience
 pub use der;
-
 use der::asn1::OctetString;
 
 pub const BASE_VERSION: u64 = 3389;

--- a/ironrdp-gui-client/Cargo.toml
+++ b/ironrdp-gui-client/Cargo.toml
@@ -11,8 +11,8 @@ keywords = ["rdp", "client", "remote", "desktop", "protocol", "gfx", "rfx"]
 
 [features]
 default = ["rustls"]
-rustls = ["dep:tokio-rustls"]
-native-tls = ["dep:async-native-tls"]
+rustls = ["dep:tokio-rustls", "ironrdp/rustls"]
+native-tls = ["dep:async-native-tls", "ironrdp/native-tls"]
 
 [dependencies]
 

--- a/ironrdp-gui-client/src/main.rs
+++ b/ironrdp-gui-client/src/main.rs
@@ -196,7 +196,7 @@ async fn establish_tls(stream: tokio_util::compat::Compat<TcpStream>) -> Result<
         // domain is an empty string because client accepts IP address in the cli
         match connector.connect("", stream).await {
             Ok(tls) => tls,
-            Err(err) => return Err(RdpError::TlsHandshakeError(err)),
+            Err(err) => return Err(RdpError::TlsHandshake(err)),
         }
     };
 
@@ -220,7 +220,7 @@ async fn establish_tls(stream: tokio_util::compat::Compat<TcpStream>) -> Result<
     let server_public_key = {
         let cert = tls_stream
             .peer_certificate()
-            .map_err(RdpError::TlsConnectorError)?
+            .map_err(RdpError::TlsConnector)?
             .ok_or(RdpError::MissingPeerCertificate)?;
         get_tls_peer_pubkey(cert.to_der().map_err(RdpError::DerEncode)?)?
     };

--- a/ironrdp-session/Cargo.toml
+++ b/ironrdp-session/Cargo.toml
@@ -10,6 +10,8 @@ authors = ["Devolutions Inc. <infos@devolutions.net>"]
 
 [features]
 default = []
+rustls = ["dep:tokio-rustls"]
+native-tls = ["dep:async-native-tls"]
 dgw_ext = []
 
 [dependencies]
@@ -31,3 +33,5 @@ futures-util = "0.3"
 thiserror = "1.0.37"
 rand_core = "0.6.4"
 x509-cert = "0.1.0" # TODO: consider removing dependency on this one in `ironrdp-session`
+async-native-tls = { version = "0.4", default-features = false, optional = true }
+tokio-rustls =  { version = "0.23", default-features = false, optional = true }

--- a/ironrdp-session/src/errors.rs
+++ b/ironrdp-session/src/errors.rs
@@ -27,16 +27,16 @@ pub enum RdpError {
     InvalidResponse(String),
     #[cfg(all(feature = "native-tls", not(feature = "rustls")))]
     #[error("TLS connector error")]
-    TlsConnector(#[source] native_tls::Error),
+    TlsConnector(#[source] async_native_tls::Error),
     #[cfg(all(feature = "native-tls", not(feature = "rustls")))]
     #[error("TLS handshake error")]
-    TlsHandshake(#[source] native_tls::Error),
+    TlsHandshake(#[source] async_native_tls::Error),
     #[cfg(feature = "rustls")]
     #[error("TLS connector error")]
-    TlsConnector(#[source] rustls::Error),
+    TlsConnector(#[source] tokio_rustls::rustls::Error),
     #[cfg(feature = "rustls")]
     #[error("TLS handshake error")]
-    TlsHandshake(#[source] rustls::Error),
+    TlsHandshake(#[source] tokio_rustls::rustls::Error),
     #[error("CredSSP error")]
     CredSsp(#[from] sspi::Error),
     #[error("CredSSP TSRequest error")]
@@ -109,17 +109,17 @@ pub enum RdpError {
     LockPoisoned,
     #[cfg(all(feature = "native-tls", not(feature = "rustls")))]
     #[error("Invalid DER structure")]
-    DerEncode(#[source] native_tls::Error),
+    DerEncode(#[source] async_native_tls::Error),
 }
 
 #[cfg(feature = "rustls")]
-impl From<rustls::Error> for RdpError {
-    fn from(e: rustls::Error) -> Self {
+impl From<tokio_rustls::rustls::Error> for RdpError {
+    fn from(e: tokio_rustls::rustls::Error) -> Self {
         match e {
-            rustls::Error::InappropriateHandshakeMessage { .. } | rustls::Error::HandshakeNotComplete => {
-                RdpError::TlsHandshakeError(e)
+            tokio_rustls::rustls::Error::InappropriateHandshakeMessage { .. } | tokio_rustls::rustls::Error::HandshakeNotComplete => {
+                RdpError::TlsHandshake(e)
             }
-            _ => RdpError::TlsConnectorError(e),
+            _ => RdpError::TlsConnector(e),
         }
     }
 }

--- a/ironrdp-session/src/errors.rs
+++ b/ironrdp-session/src/errors.rs
@@ -116,9 +116,8 @@ pub enum RdpError {
 impl From<tokio_rustls::rustls::Error> for RdpError {
     fn from(e: tokio_rustls::rustls::Error) -> Self {
         match e {
-            tokio_rustls::rustls::Error::InappropriateHandshakeMessage { .. } | tokio_rustls::rustls::Error::HandshakeNotComplete => {
-                RdpError::TlsHandshake(e)
-            }
+            tokio_rustls::rustls::Error::InappropriateHandshakeMessage { .. }
+            | tokio_rustls::rustls::Error::HandshakeNotComplete => RdpError::TlsHandshake(e),
             _ => RdpError::TlsConnector(e),
         }
     }

--- a/ironrdp/Cargo.toml
+++ b/ironrdp/Cargo.toml
@@ -10,6 +10,11 @@ authors = ["Devolutions Inc. <infos@devolutions.net>"]
 description = "A Rust implementation of the Microsoft Remote Desktop Protocol"
 keywords = ["rdp", "remote", "desktop", "protocol"]
 
+[features]
+default = []
+rustls = ["ironrdp-session/rustls"]
+native-tls = ["ironrdp-session/native-tls"]
+
 [dependencies]
 ironrdp-core = { path = "../ironrdp-core" }
 ironrdp-session = { path = "../ironrdp-session" }


### PR DESCRIPTION
Building with `native-tls` is essential cause rustls doesn't allow to connect to Windows 7,8.1 without adding enhanced SSL cipher suites  