### PR TITLE
fix: do not returns an error when compression is used

### DIFF
--- a/ironrdp-core/src/basic_output/fast_path/test.rs
+++ b/ironrdp-core/src/basic_output/fast_path/test.rs
@@ -32,6 +32,7 @@ lazy_static! {
     static ref FAST_PATH_UPDATE_PDU: FastPathUpdatePdu<'static> = FastPathUpdatePdu {
         fragmentation: Fragmentation::Single,
         update_code: UpdateCode::SurfaceCommands,
+        compression: Compression::empty(),
         data: &FAST_PATH_UPDATE_PDU_BUFFER[3..],
     };
 }


### PR DESCRIPTION
Sometimes the FastPathUpdatePdu header has the
COMPRESSION_USED bit flipped and it returns an error. It should not.