### PR TITLE
ci: separate workflow for fuzzing using corpus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,9 @@ jobs:
           key: ${{ runner.os }}-wasm-${{ hashFiles('ffi/wasm/Cargo.lock') }}
 
       - name: Prepare runner
-        run: sudo apt install wabt
+        run: |
+          sudo apt install wabt
+          cargo xtask wasm install
 
       - name: Check
         run: cargo xtask check wasm
@@ -114,30 +116,9 @@ jobs:
             ./fuzz/target/
           key: ${{ runner.os }}-fuzz-${{ hashFiles('fuzz/Cargo.lock') }}
 
-      - name: Fuzz subcommand installation cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.cargo/bin/cargo-fuzz
-          key: ${{ runner.os }}-binary-cargo-fuzz
-
       - name: Prepare runner
-        shell: pwsh
-        run: |
-          if (-Not (Test-Path -Path ~/.cargo/bin/cargo-fuzz -PathType Leaf)) {
-            # Install in debug because it's faster to compile and we don't need execution speed anyway
-            cargo install --debug --locked cargo-fuzz
-          }
+        run: cargo xtask fuzz install
 
-          rustup install nightly --profile=minimal
-
-      - name: Download fuzzing corpus
-        run: cargo xtask fuzz corpus-fetch
-
+      # Simply run all fuzz targets for a few seconds, just making there is nothing obviously wrong at a quick glance
       - name: Fuzz
         run: cargo xtask fuzz run
-
-      - name: Minify fuzzing corpus
-        run: cargo xtask fuzz corpus-min
-
-      - name: Upload fuzzing corpus
-        run: cargo xtask fuzz corpus-push

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,45 @@
+name: Fuzz
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '12 3 * * 0,1,6' # At 03:12 AM UTC on Sunday, Monday, and Saturday.
+
+env:
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+
+jobs:
+  fuzz:
+    name: Fuzzing
+    runs-on: ubuntu-20.04
+    needs: formatting
+    env:
+      AZURE_STORAGE_KEY: ${{ secrets.CORPUS_AZURE_STORAGE_KEY }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Fuzz build cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry/
+            ~/.cargo/git/
+            ./target/
+            ./fuzz/target/
+          key: ${{ runner.os }}-fuzz-${{ hashFiles('fuzz/Cargo.lock') }}
+
+      - name: Prepare runner
+        run: cargo xtask fuzz install
+
+      - name: Download fuzzing corpus
+        run: cargo xtask fuzz corpus-fetch
+
+      - name: Fuzz
+        run: cargo xtask fuzz run
+
+      - name: Minify fuzzing corpus
+        run: cargo xtask fuzz corpus-min
+
+      - name: Upload fuzzing corpus
+        run: cargo xtask fuzz corpus-push

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -8,19 +8,21 @@ FLAGS:
   -h, --help      Prints help information
 
 TASKS:
-  ci                Runs all checks required on CI
   check [all]       Runs all checks
   check fmt         Checks formatting
-  check tests       Runs tests
   check lints       Checks lints
+  check tests       Runs tests
   check wasm        Ensures wasm module is compatible for the web
-  fuzz run          Fuzz all targets for a few seconds
-  fuzz corpus-min   Minify fuzzing corpus
-  fuzz corpus-fetch Minify fuzzing corpus
-  fuzz corpus-push  Minify fuzzing corpus
-  svelte-run        Runs SvelteKit-based standalone Web Client
-  coverage          Generate code-coverage data using tests and fuzz targets
+  ci                Runs all checks required on CI
   clean             Clean workspace
+  coverage          Generate code-coverage data using tests and fuzz targets
+  fuzz corpus-fetch Minify fuzzing corpus
+  fuzz corpus-min   Minify fuzzing corpus
+  fuzz corpus-push  Minify fuzzing corpus
+  fuzz install      Install dependencies required for fuzzing
+  fuzz run          Fuzz all targets for a few seconds
+  svelte-run        Runs SvelteKit-based standalone Web Client
+  wasm install      Install dependencies required to build the wasm target
 ";
 
 pub fn print_help() {
@@ -28,19 +30,21 @@ pub fn print_help() {
 }
 
 pub enum Action {
-    ShowHelp,
     CheckAll,
     CheckFmt,
-    CheckTests,
     CheckLints,
+    CheckTests,
     CheckWasm,
-    FuzzRun,
-    FuzzCorpusMin,
-    FuzzCorpusFetch,
-    FuzzCorpusPush,
-    SvelteRun,
-    Coverage,
     Clean,
+    Coverage,
+    FuzzCorpusFetch,
+    FuzzCorpusMin,
+    FuzzCorpusPush,
+    FuzzInstall,
+    FuzzRun, // TODO: add option to choose the target and run duration so we can optimize CI further
+    ShowHelp,
+    SvelteRun,
+    WasmInstall,
 }
 
 pub fn parse_args() -> anyhow::Result<Action> {
@@ -52,23 +56,29 @@ pub fn parse_args() -> anyhow::Result<Action> {
         match args.subcommand()?.as_deref() {
             Some("ci") => Action::CheckAll,
             Some("check") => match args.subcommand()?.as_deref() {
-                Some("fmt") => Action::CheckFmt,
-                Some("tests") => Action::CheckTests,
-                Some("lints") => Action::CheckLints,
-                Some("wasm") => Action::CheckWasm,
                 Some("all") | None => Action::CheckAll,
+                Some("fmt") => Action::CheckFmt,
+                Some("lints") => Action::CheckLints,
+                Some("tests") => Action::CheckTests,
+                Some("wasm") => Action::CheckWasm,
                 Some(_) => anyhow::bail!("Unknown check action"),
             },
+            Some("clean") => Action::Clean,
+            Some("coverage") => Action::Coverage,
             Some("fuzz") => match args.subcommand()?.as_deref() {
-                Some("run") | None => Action::FuzzRun,
-                Some("corpus-min") => Action::FuzzCorpusMin,
                 Some("corpus-fetch") => Action::FuzzCorpusFetch,
+                Some("corpus-min") => Action::FuzzCorpusMin,
                 Some("corpus-push") => Action::FuzzCorpusPush,
+                Some("run") | None => Action::FuzzRun,
+                Some("install") => Action::FuzzInstall,
                 Some(_) => anyhow::bail!("Unknown fuzz action"),
             },
-            Some("clean") => Action::Clean,
             Some("svelte-run") => Action::SvelteRun,
-            Some("coverage") => Action::Coverage,
+            Some("wasm") => match args.subcommand()?.as_deref() {
+                Some("install") => Action::WasmInstall,
+                Some(_) => anyhow::bail!("Unknown wasm action"),
+                None => Action::ShowHelp,
+            },
             None | Some(_) => Action::ShowHelp,
         }
     };

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -31,16 +31,18 @@ fn main() -> anyhow::Result<()> {
             tasks::fuzz_run(&sh)?;
         }
         Action::CheckFmt => tasks::check_formatting(&sh)?,
-        Action::CheckTests => tasks::run_tests(&sh)?,
         Action::CheckLints => tasks::check_lints(&sh)?,
+        Action::CheckTests => tasks::run_tests(&sh)?,
         Action::CheckWasm => tasks::check_wasm(&sh)?,
-        Action::FuzzRun => tasks::fuzz_run(&sh)?,
-        Action::FuzzCorpusMin => tasks::fuzz_corpus_minify(&sh)?,
-        Action::FuzzCorpusFetch => tasks::fuzz_corpus_fetch(&sh)?,
-        Action::FuzzCorpusPush => tasks::fuzz_corpus_push(&sh)?,
-        Action::SvelteRun => tasks::svelte_run(&sh)?,
-        Action::Coverage => tasks::report_code_coverage(&sh)?,
         Action::Clean => tasks::clean_workspace(&sh)?,
+        Action::Coverage => tasks::report_code_coverage(&sh)?,
+        Action::FuzzCorpusFetch => tasks::fuzz_corpus_fetch(&sh)?,
+        Action::FuzzCorpusMin => tasks::fuzz_corpus_minify(&sh)?,
+        Action::FuzzCorpusPush => tasks::fuzz_corpus_push(&sh)?,
+        Action::FuzzInstall => tasks::fuzz_install(&sh)?,
+        Action::FuzzRun => tasks::fuzz_run(&sh)?,
+        Action::SvelteRun => tasks::svelte_run(&sh)?,
+        Action::WasmInstall => tasks::wasm_install(&sh)?,
     }
 
     Ok(())


### PR DESCRIPTION
Fetching the corpus in the main CI worflow is a problem because it will fail when the azure storage is modified during the download:

> ERROR: The specified blob does not exist.
> RequestId:76c40723-901e-0098-38b9-8215c9000000
> Time:2023-05-09T21:03:10.8992962Z
> ErrorCode:BlobNotFound

This occurs when there are multiple runs at the same time. This happens for example when two pull requests are opened. This will cause CI to go red for no good reason.

With this patch, main CI will simply run the fuzz targets without using the corpus, as a sanity check. Then, another workflow will run at 03:12 AM UTC on Sunday, Monday, and Saturday using the corpus from azure storage.

Future work: make the scheduled run fuzz longer and in parallel.

cc @pacmancoder 