### PR TITLE
feat(connector): support for strong asymmetric keys

### DIFF
--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -825,10 +825,10 @@ fn create_gcc_blocks(config: &Config, selected_protocol: nego::SecurityProtocol)
                 supported_color_depths: Some(supported_color_depths),
                 early_capability_flags: {
                     let mut early_capability_flags = ClientEarlyCapabilityFlags::VALID_CONNECTION_TYPE
-                        | ClientEarlyCapabilityFlags::SUPPORT_ERR_INFO_PDU;
+                        | ClientEarlyCapabilityFlags::SUPPORT_ERR_INFO_PDU
+                        | ClientEarlyCapabilityFlags::STRONG_ASYMMETRIC_KEYS;
 
                     // TODO: support for ClientEarlyCapabilityFlags::SUPPORT_STATUS_INFO_PDU
-                    // TODO: support for ClientEarlyCapabilityFlags::STRONG_ASYMMETRIC_KEYS
 
                     if config.graphics.is_some() {
                         early_capability_flags |= ClientEarlyCapabilityFlags::SUPPORT_DYN_VC_GFX_PROTOCOL;


### PR DESCRIPTION
This flag is used to indicate that the client supports asymmetric keys larger than 512 bits for use with the Server Certificate (section 2.2.1.4.3.1) sent in the Server Security Data block (section 2.2.1.4.3).

This is supported by IronRDP.