### PR TITLE
fix(connector): client should also join user channel id

### DIFF
--- a/crates/ironrdp-connector/src/channel_connection.rs
+++ b/crates/ironrdp-connector/src/channel_connection.rs
@@ -124,6 +124,9 @@ impl Sequence for ChannelConnectionSequence {
 
                 let user_channel_id = attach_user_confirm.initiator_id;
 
+                // user channel ID must also be joined
+                self.channel_ids.push(user_channel_id);
+
                 debug!(message = ?attach_user_confirm, user_channel_id, "Received");
 
                 debug_assert!(!self.channel_ids.is_empty());


### PR DESCRIPTION
According to [this](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/c2bb6f47-779c-42d4-98f3-d7afa2a4906b), during the channel connection phase, the client is supposed to also join the user channel id.
FreeRDP already does this.

This isn't the cleanest fix, but it's simple.