### PR TITLE
fix(web): detect errors when opening WebSocket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1257,6 +1257,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "gloo-utils"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1776,6 +1788,7 @@ dependencies = [
  "futures-util",
  "getrandom 0.2.8",
  "gloo-net",
+ "gloo-timers",
  "ironrdp",
  "ironrdp-futures",
  "ironrdp-rdcleanpath",

--- a/crates/ironrdp-web/Cargo.toml
+++ b/crates/ironrdp-web/Cargo.toml
@@ -33,6 +33,7 @@ wasm-bindgen = "0.2.84"
 wasm-bindgen-futures = "0.4.34"
 js-sys = "0.3.61"
 gloo-net = { version = "0.2.6", default-features = false, features = ["websocket", "http"] }
+gloo-timers = { version = "0.2.6", default-features = false, features = ["futures"] }
 tracing-web = "0.1.2"
 
 # Enable WebAssembly support for a few crates

--- a/web-client/iron-remote-gui/package-lock.json
+++ b/web-client/iron-remote-gui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@devolutions/iron-remote-gui",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@devolutions/iron-remote-gui",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "dependencies": {
         "@types/ua-parser-js": "^0.7.36",
         "ua-parser-js": "^1.0.33"


### PR DESCRIPTION
Ideally, when the WebSocket can’t be opened, the call to `WebSocket::open` should fail with details on why is that (e.g., the proxy hostname could not be resolved, proxy service is not running), but errors are neved bubbled up in practice, so instead we poll the WebSocket state until we know its connected (i.e., the WebSocket handshake is a success and user data can be exchanged).

For instance, here is the new error shown to the user when the proxy service is not running:
![tmpscrot](https://github.com/Devolutions/IronRDP/assets/3809077/cee2a1ba-f3ef-43cb-b709-e1a3352fd1a3)

Compare with:
![image](https://github.com/Devolutions/IronRDP/assets/3809077/30cfd8a8-0884-4758-877f-385702d258f0)

The RDCleanPath packet is not supposed to be relevant when the service is not even running.