### PR TITLE
chore(deps): bump sspi to 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3864,9 +3864,9 @@ dependencies = [
 
 [[package]]
 name = "sspi"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8907f51dea05e678ea3259a1e2d28eedb6bdc3bae7bbf969013a3eb334a8b37a"
+checksum = "6c7d9adbb5308206ea1c4c98b7d941ed9b1cfda2af2c2a1d6456d2a1701e4cf1"
 dependencies = [
  "async-dnssd",
  "bitflags 1.3.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ ironrdp-tokio = { version = "0.1", path = "crates/ironrdp-tokio" }
 ironrdp = { version = "0.5", path = "crates/ironrdp" }
 proptest = "1.1.0"
 rstest = "0.17.0"
-sspi = "0.10.0"
+sspi = "0.10.1"
 tracing = "0.1.37"
 
 [profile.dev]


### PR DESCRIPTION
To include this patch: https://github.com/Devolutions/sspi-rs/pull/142