### PR TITLE
ironrdp-connector: wrap AuthIdentity into a Credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,12 +283,6 @@ checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
@@ -2724,17 +2718,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle 2.4.1",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2742,15 +2725,13 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pbkdf2"
-version = "0.11.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
  "hmac 0.12.1",
- "password-hash",
- "sha-1",
- "sha2 0.10.7",
+ "sha1",
 ]
 
 [[package]]
@@ -2780,8 +2761,7 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 [[package]]
 name = "picky"
 version = "7.0.0-rc.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfbf0740cad569c1d113042305d0a8337e2e8ecaee643a924eb782417e08f6f1"
+source = "git+https://github.com/Devolutions/picky-rs.git?rev=19838e703b3e3bddfcac14682eaf88e15cbd55d8#19838e703b3e3bddfcac14682eaf88e15cbd55d8"
 dependencies = [
  "base64 0.21.2",
  "digest 0.10.7",
@@ -2792,7 +2772,7 @@ dependencies = [
  "p384",
  "picky-asn1",
  "picky-asn1-der",
- "picky-asn1-x509 0.11.0",
+ "picky-asn1-x509",
  "rand 0.7.3",
  "rand 0.8.5",
  "rsa",
@@ -2809,8 +2789,7 @@ dependencies = [
 [[package]]
 name = "picky-asn1"
 version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f338f1fd4f3e13e75e986ca29f2a3c62528d88d3cbadf4afdcefb6b087f2d32"
+source = "git+https://github.com/Devolutions/picky-rs.git?rev=19838e703b3e3bddfcac14682eaf88e15cbd55d8#19838e703b3e3bddfcac14682eaf88e15cbd55d8"
 dependencies = [
  "chrono",
  "oid",
@@ -2822,8 +2801,7 @@ dependencies = [
 [[package]]
 name = "picky-asn1-der"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47267a46f4ea246b772381970b8ed3f15963dd3e15ffc2c3f4ac3bc2d77384b"
+source = "git+https://github.com/Devolutions/picky-rs.git?rev=19838e703b3e3bddfcac14682eaf88e15cbd55d8#19838e703b3e3bddfcac14682eaf88e15cbd55d8"
 dependencies = [
  "picky-asn1",
  "serde",
@@ -2832,23 +2810,8 @@ dependencies = [
 
 [[package]]
 name = "picky-asn1-x509"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb51541f90aa99f2fa7191c8daebc224d500cd5963c6ca3e6cede9645a1b2e1"
-dependencies = [
- "base64 0.13.1",
- "oid",
- "picky-asn1",
- "picky-asn1-der",
- "serde",
- "widestring 0.5.1",
-]
-
-[[package]]
-name = "picky-asn1-x509"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25c2718a5fe2b6c4b651bad5514699182f01db1b2f256fd6ab237f5879a01a4a"
+source = "git+https://github.com/Devolutions/picky-rs.git?rev=19838e703b3e3bddfcac14682eaf88e15cbd55d8#19838e703b3e3bddfcac14682eaf88e15cbd55d8"
 dependencies = [
  "base64 0.21.2",
  "num-bigint-dig",
@@ -2856,14 +2819,14 @@ dependencies = [
  "picky-asn1",
  "picky-asn1-der",
  "serde",
+ "widestring 0.5.1",
  "zeroize",
 ]
 
 [[package]]
 name = "picky-krb"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ce6e874e53f3a7375000c959adebeee4f419f1340280cfd59fb8962bfe6edf"
+version = "0.7.1"
+source = "git+https://github.com/Devolutions/picky-rs.git?rev=19838e703b3e3bddfcac14682eaf88e15cbd55d8#19838e703b3e3bddfcac14682eaf88e15cbd55d8"
 dependencies = [
  "aes",
  "byteorder",
@@ -2876,7 +2839,7 @@ dependencies = [
  "pbkdf2",
  "picky-asn1",
  "picky-asn1-der",
- "picky-asn1-x509 0.9.0",
+ "picky-asn1-x509",
  "rand 0.8.5",
  "serde",
  "sha1",
@@ -3875,8 +3838,7 @@ dependencies = [
 [[package]]
 name = "sspi"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c7d9adbb5308206ea1c4c98b7d941ed9b1cfda2af2c2a1d6456d2a1701e4cf1"
+source = "git+https://github.com/Devolutions/sspi-rs.git?rev=b89ff480e7475cb2ee9a51cd2a755d78f6e9bed4#b89ff480e7475cb2ee9a51cd2a755d78f6e9bed4"
 dependencies = [
  "async-dnssd",
  "bitflags 1.3.2",
@@ -3896,7 +3858,7 @@ dependencies = [
  "picky",
  "picky-asn1",
  "picky-asn1-der",
- "picky-asn1-x509 0.9.0",
+ "picky-asn1-x509",
  "picky-krb",
  "portpicker",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ ironrdp-tokio = { version = "0.1", path = "crates/ironrdp-tokio" }
 ironrdp = { version = "0.5", path = "crates/ironrdp" }
 proptest = "1.1.0"
 rstest = "0.17.0"
-sspi = "0.10.1"
+sspi = { git  = "https://github.com/Devolutions/sspi-rs.git", rev = "b89ff480e7475cb2ee9a51cd2a755d78f6e9bed4" }
 tracing = "0.1.37"
 
 [profile.dev]

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -349,11 +349,11 @@ impl Sequence for ClientConnector {
 
             //== CredSSP ==//
             ClientConnectorState::CredsspInitial { selected_protocol } => {
-                let credentials = sspi::AuthIdentity {
+                let credentials = sspi::Credentials::AuthIdentity(sspi::AuthIdentity {
                     username: self.config.username.clone(),
                     password: self.config.password.clone().into(),
                     domain: self.config.domain.clone(),
-                };
+                });
 
                 let server_public_key = self
                     .server_public_key


### PR DESCRIPTION
Hello,
After the Kerberos smart card logon improvements, the `CredSspiClient/Server` accepts the `Credentials`  instead of just `AuthIdentity`. This PR fixes credentials creation in the `ironrdp-connector` crate.

See the related pull request in the `sspi-rs` for more info: https://github.com/Devolutions/sspi-rs/pull/143