### PR TITLE
CLIPRDR(clipboard) processing - initialization sequence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1699,6 +1699,7 @@ name = "ironrdp"
 version = "0.5.0"
 dependencies = [
  "ironrdp-acceptor",
+ "ironrdp-cliprdr",
  "ironrdp-connector",
  "ironrdp-dvc",
  "ironrdp-graphics",
@@ -1762,6 +1763,9 @@ version = "0.1.0"
 dependencies = [
  "bitflags 2.4.0",
  "ironrdp-pdu",
+ "ironrdp-svc",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ proptest = "1.1.0"
 rstest = "0.17.0"
 sspi = "0.10.1"
 tracing = "0.1.37"
+thiserror = "1.0.40"
 
 [profile.dev]
 opt-level = 1

--- a/crates/ironrdp-client/Cargo.toml
+++ b/crates/ironrdp-client/Cargo.toml
@@ -28,7 +28,7 @@ native-tls = ["ironrdp-tls/native-tls"]
 [dependencies]
 
 # Protocols
-ironrdp = { workspace = true, features = ["input", "graphics", "dvc", "rdpdr", "rdpsnd"] }
+ironrdp = { workspace = true, features = ["input", "graphics", "dvc", "rdpdr", "rdpsnd", "cliprdr"] }
 ironrdp-tls.workspace = true
 ironrdp-tokio.workspace = true
 sspi = { workspace = true, features = ["network_client", "dns_resolver"] } # enable additional features

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -102,7 +102,8 @@ async fn connect(config: &Config) -> ConnectorResult<(ConnectionResult, Upgraded
         .with_credssp_network_client(RequestClientFactory)
         // .with_static_channel(ironrdp::dvc::Drdynvc::new()) // FIXME: drdynvc is not working
         .with_static_channel(ironrdp::rdpsnd::Rdpsnd::new())
-        .with_static_channel(ironrdp::rdpdr::Rdpdr::default());
+        .with_static_channel(ironrdp::rdpdr::Rdpdr::default())
+        .with_static_channel(ironrdp::cliprdr::Cliprdr::default());
 
     let should_upgrade = ironrdp_tokio::connect_begin(&mut framed, &mut connector).await?;
 

--- a/crates/ironrdp-cliprdr/Cargo.toml
+++ b/crates/ironrdp-cliprdr/Cargo.toml
@@ -18,5 +18,7 @@ test = false
 
 [dependencies]
 ironrdp-pdu.workspace = true
-
+ironrdp-svc.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
 bitflags = "2"

--- a/crates/ironrdp-cliprdr/src/lib.rs
+++ b/crates/ironrdp-cliprdr/src/lib.rs
@@ -4,3 +4,147 @@
 //! - Clipboard SVC processing (TODO)
 
 pub mod pdu;
+
+use ironrdp_pdu::{decode, gcc::ChannelName, PduResult};
+use ironrdp_svc::{impl_as_any, ChannelFlags, CompressionCondition, StaticVirtualChannel, SvcMessage};
+use pdu::{
+    Capabilities, ClientTemporaryDirectory, ClipboardFormat, ClipboardFormatId, ClipboardGeneralCapabilityFlags,
+    ClipboardPdu, ClipboardProtocolVersion, FormatListResponse,
+};
+
+use crate::pdu::FormatList;
+use thiserror::Error;
+use tracing::{error, info};
+
+#[derive(Debug, Error)]
+enum ClipboardError {
+    #[error("Received clipboard PDU is not implemented")]
+    UnimplementedPdu { pdu: &'static str },
+
+    #[error("Sent format list was rejected")]
+    FormatListRejected,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CliprdrState {
+    Initialization,
+    Ready,
+    Failed,
+}
+
+/// CLIPRDR static virtual channel client endpoint implementation
+#[derive(Debug)]
+pub struct Cliprdr {
+    capabilities: Capabilities,
+    temporary_directory: String,
+    state: CliprdrState,
+}
+
+impl_as_any!(Cliprdr);
+
+impl Cliprdr {
+    const CHANNEL_NAME: ChannelName = ChannelName::from_static(b"cliprdr\0");
+
+    fn build_local_format_list(&self) -> PduResult<FormatList<'static>> {
+        let formats = vec![
+            ClipboardFormat::new(ClipboardFormatId::CF_TEXT),
+            ClipboardFormat::new(ClipboardFormatId::CF_UNICODETEXT),
+        ];
+
+        FormatList::new_unicode(
+            &formats,
+            self.capabilities
+                .flags()
+                .contains(ClipboardGeneralCapabilityFlags::USE_LONG_FORMAT_NAMES),
+        )
+    }
+
+    fn handle_error_transition(&mut self, err: ClipboardError) -> PduResult<Vec<SvcMessage>> {
+        // Failure of clipboard is not an critical error, but we should properly report it
+        // and transition channel to failed state.
+        self.state = CliprdrState::Failed;
+        error!("CLIPRDR(clipboard) failed: {err}");
+
+        Ok(vec![])
+    }
+
+    fn handle_server_capabilities(&mut self, server_capabilities: Capabilities) -> PduResult<Vec<SvcMessage>> {
+        self.capabilities.downgrade(&server_capabilities);
+
+        // Do not send anything, wait for monitor ready pdu
+        Ok(vec![])
+    }
+
+    fn handle_monitor_ready(&mut self) -> PduResult<Vec<SvcMessage>> {
+        let response = [
+            ClipboardPdu::Capabilities(self.capabilities.clone()),
+            ClipboardPdu::TemporaryDirectory(ClientTemporaryDirectory::new(self.temporary_directory.clone())?),
+            ClipboardPdu::FormatList(self.build_local_format_list()?),
+        ]
+        .into_iter()
+        .map(into_cliprdr_message)
+        .collect();
+
+        Ok(response)
+    }
+
+    fn handle_format_list_response(&mut self, response: FormatListResponse) -> PduResult<Vec<SvcMessage>> {
+        match response {
+            FormatListResponse::Ok => {
+                info!("CLIPRDR(clipboard) virtual channel has been initialized");
+                self.state = CliprdrState::Ready;
+            }
+            FormatListResponse::Fail => {
+                return self.handle_error_transition(ClipboardError::FormatListRejected);
+            }
+        }
+
+        Ok(vec![])
+    }
+}
+
+impl Default for Cliprdr {
+    fn default() -> Self {
+        Self {
+            state: CliprdrState::Initialization,
+            capabilities: Capabilities::new(
+                ClipboardProtocolVersion::V2,
+                ClipboardGeneralCapabilityFlags::USE_LONG_FORMAT_NAMES,
+            ),
+            temporary_directory: ".cliprdr".to_string(),
+        }
+    }
+}
+
+impl StaticVirtualChannel for Cliprdr {
+    fn channel_name(&self) -> ChannelName {
+        Self::CHANNEL_NAME
+    }
+
+    fn process(&mut self, payload: &[u8]) -> PduResult<Vec<SvcMessage>> {
+        let pdu = decode::<ClipboardPdu>(payload)?;
+
+        if self.state == CliprdrState::Failed {
+            error!("Attempted to process clipboard static virtual channel in failed state");
+            return Ok(vec![]);
+        }
+
+        match pdu {
+            ClipboardPdu::Capabilities(caps) => self.handle_server_capabilities(caps),
+            ClipboardPdu::FormatListResponse(response) => self.handle_format_list_response(response),
+            ClipboardPdu::MonitorReady => self.handle_monitor_ready(),
+            _ => self.handle_error_transition(ClipboardError::UnimplementedPdu {
+                pdu: pdu.message_name(),
+            }),
+        }
+    }
+
+    fn compression_condition(&self) -> ironrdp_svc::CompressionCondition {
+        CompressionCondition::WhenRdpDataIsCompressed
+    }
+}
+
+fn into_cliprdr_message(pdu: ClipboardPdu<'static>) -> SvcMessage {
+    // Adding [`CHANNEL_FLAG_SHOW_PROTOCOL`] is a must for clipboard svc messages
+    SvcMessage::from(pdu).with_flags(ChannelFlags::SHOW_PROTOCOL)
+}

--- a/crates/ironrdp-cliprdr/src/pdu/format_data/file_list.rs
+++ b/crates/ironrdp-cliprdr/src/pdu/format_data/file_list.rs
@@ -17,7 +17,7 @@ bitflags! {
 }
 
 bitflags! {
-    /// Represents `fileAttributes` of `CLIPRDR_FILEDESCRIPTOR` strucutre.
+    /// Represents `fileAttributes` of `CLIPRDR_FILEDESCRIPTOR` structure.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct ClipboardFileAttributes: u32 {
         /// A file that is read-only. Applications can read the file, but cannot write to
@@ -43,7 +43,7 @@ bitflags! {
 /// Represents `CLIPRDR_FILEDESCRIPTOR`
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FileDescriptor {
-    pub attibutes: Option<ClipboardFileAttributes>,
+    pub attributes: Option<ClipboardFileAttributes>,
     pub last_write_time: Option<u64>,
     pub file_size: Option<u64>,
     pub name: String,
@@ -67,7 +67,7 @@ impl PduEncode for FileDescriptor {
         ensure_fixed_part_size!(in: dst);
 
         let mut flags = ClipboardFileFlags::empty();
-        if self.attibutes.is_some() {
+        if self.attributes.is_some() {
             flags |= ClipboardFileFlags::ATTRIBUTES;
         }
         if self.last_write_time.is_some() {
@@ -79,7 +79,7 @@ impl PduEncode for FileDescriptor {
 
         dst.write_u32(flags.bits());
         dst.write_array([0u8; 32]);
-        dst.write_u32(self.attibutes.unwrap_or(ClipboardFileAttributes::empty()).bits());
+        dst.write_u32(self.attributes.unwrap_or(ClipboardFileAttributes::empty()).bits());
         dst.write_array([0u8; 16]);
         dst.write_u64(self.last_write_time.unwrap_or_default());
 
@@ -112,7 +112,7 @@ impl<'de> PduDecode<'de> for FileDescriptor {
 
         let flags = ClipboardFileFlags::from_bits_truncate(src.read_u32());
         src.read_array::<32>();
-        let attibutes = if flags.contains(ClipboardFileFlags::ATTRIBUTES) {
+        let attributes = if flags.contains(ClipboardFileFlags::ATTRIBUTES) {
             Some(ClipboardFileAttributes::from_bits_truncate(src.read_u32()))
         } else {
             let _ = src.read_u32();
@@ -142,7 +142,7 @@ impl<'de> PduDecode<'de> for FileDescriptor {
         src.advance(520);
 
         Ok(Self {
-            attibutes,
+            attributes,
             last_write_time,
             file_size,
             name,

--- a/crates/ironrdp-cliprdr/src/pdu/format_data/metafile.rs
+++ b/crates/ironrdp-cliprdr/src/pdu/format_data/metafile.rs
@@ -5,7 +5,7 @@ use ironrdp_pdu::cursor::{ReadCursor, WriteCursor};
 use ironrdp_pdu::{ensure_fixed_part_size, ensure_size, PduDecode, PduEncode, PduResult};
 
 bitflags! {
-    /// Represents `mappingMode` fields of `CLIPRDR_MFPICT` strucutre.
+    /// Represents `mappingMode` fields of `CLIPRDR_MFPICT` structure.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct PackedMetafileMappingMode: u32 {
         /// Each logical unit is mapped to one device pixel. Positive x is to the right; positive

--- a/crates/ironrdp-cliprdr/src/pdu/mod.rs
+++ b/crates/ironrdp-cliprdr/src/pdu/mod.rs
@@ -105,7 +105,7 @@ pub enum ClipboardPdu<'a> {
     FormatDataRequest(FormatDataRequest),
     FormatDataResponse(FormatDataResponse<'a>),
     TemporaryDirectory(ClientTemporaryDirectory<'a>),
-    Capabilites(Capabilities),
+    Capabilities(Capabilities),
     FileContentsRequest(FileContentsRequest),
     FileContentsResponse(FileContentsResponse<'a>),
     LockData(LockDataId),
@@ -115,6 +115,22 @@ pub enum ClipboardPdu<'a> {
 impl ClipboardPdu<'_> {
     const NAME: &str = "CliboardPdu";
     const FIXED_PART_SIZE: usize = std::mem::size_of::<u16>();
+
+    pub fn message_name(&self) -> &'static str {
+        match self {
+            ClipboardPdu::MonitorReady => "CLIPRDR_MONITOR_READY",
+            ClipboardPdu::FormatList(_) => "CLIPRDR_FORMAT_LIST",
+            ClipboardPdu::FormatListResponse(_) => "CLIPRDR_FORMAT_LIST_RESPONSE",
+            ClipboardPdu::FormatDataRequest(_) => "CLIPRDR_FORMAT_DATA_REQUEST",
+            ClipboardPdu::FormatDataResponse(_) => "CLIPRDR_FORMAT_DATA_RESPONSE",
+            ClipboardPdu::TemporaryDirectory(_) => "CLIPRDR_TEMP_DIRECTORY",
+            ClipboardPdu::Capabilities(_) => "CLIPRDR_CAPABILITIES",
+            ClipboardPdu::FileContentsRequest(_) => "CLIPRDR_FILECONTENTS_REQUEST",
+            ClipboardPdu::FileContentsResponse(_) => "CLIPRDR_FILECONTENTS_RESPONSE",
+            ClipboardPdu::LockData(_) => "CLIPRDR_LOCK_CLIPDATA",
+            ClipboardPdu::UnlockData(_) => "CLIPRDR_UNLOCK_CLIPDATA",
+        }
+    }
 }
 
 impl PduEncode for ClipboardPdu<'_> {
@@ -151,7 +167,7 @@ impl PduEncode for ClipboardPdu<'_> {
                 dst.write_u16(MSG_TYPE_TEMPORARY_DIRECTORY);
                 pdu.encode(dst)
             }
-            ClipboardPdu::Capabilites(pdu) => {
+            ClipboardPdu::Capabilities(pdu) => {
                 dst.write_u16(MSG_TYPE_CAPABILITIES);
                 pdu.encode(dst)
             }
@@ -188,7 +204,7 @@ impl PduEncode for ClipboardPdu<'_> {
             ClipboardPdu::FormatDataRequest(pdu) => pdu.size(),
             ClipboardPdu::FormatDataResponse(pdu) => pdu.size(),
             ClipboardPdu::TemporaryDirectory(pdu) => pdu.size(),
-            ClipboardPdu::Capabilites(pdu) => pdu.size(),
+            ClipboardPdu::Capabilities(pdu) => pdu.size(),
             ClipboardPdu::FileContentsRequest(pdu) => pdu.size(),
             ClipboardPdu::FileContentsResponse(pdu) => pdu.size(),
             ClipboardPdu::LockData(pdu) => pdu.size(),
@@ -218,7 +234,7 @@ impl<'de> PduDecode<'de> for ClipboardPdu<'de> {
             MSG_TYPE_FORMAT_DATA_REQUEST => ClipboardPdu::FormatDataRequest(FormatDataRequest::decode(src)?),
             MSG_TYPE_FORMAT_DATA_RESPONSE => ClipboardPdu::FormatDataResponse(FormatDataResponse::decode(src)?),
             MSG_TYPE_TEMPORARY_DIRECTORY => ClipboardPdu::TemporaryDirectory(ClientTemporaryDirectory::decode(src)?),
-            MSG_TYPE_CAPABILITIES => ClipboardPdu::Capabilites(Capabilities::decode(src)?),
+            MSG_TYPE_CAPABILITIES => ClipboardPdu::Capabilities(Capabilities::decode(src)?),
             MSG_TYPE_FILE_CONTENTS_REQUEST => ClipboardPdu::FileContentsRequest(FileContentsRequest::decode(src)?),
             MSG_TYPE_FILE_CONTENTS_RESPONSE => ClipboardPdu::FileContentsResponse(FileContentsResponse::decode(src)?),
             MSG_TYPE_LOCK_CLIPDATA => ClipboardPdu::LockData(LockDataId::decode(src)?),
@@ -241,7 +257,7 @@ bitflags! {
         const RESPONSE_OK = 0x0001;
         /// Used by the Format List Response PDU, Format Data Response PDU, and File
         /// Contents Response PDU to indicate that the associated Format List PDU, Format
-        /// Data Request PDU, and File Contents Request PDU were not processed successfull
+        /// Data Request PDU, and File Contents Request PDU were not processed successful
         const RESPONSE_FAIL = 0x0002;
         /// Used by the Short Format Name variant of the Format List Response PDU to indicate
         /// that the format names are in ASCII 8

--- a/crates/ironrdp-dvc/src/lib.rs
+++ b/crates/ironrdp-dvc/src/lib.rs
@@ -24,7 +24,7 @@ use ironrdp_pdu::gcc::ChannelName;
 use ironrdp_pdu::rdp::vc;
 use ironrdp_pdu::write_buf::WriteBuf;
 use ironrdp_pdu::{assert_obj_safe, dvc, PduResult};
-use ironrdp_svc::{AsAny, CompressionCondition, StaticVirtualChannel};
+use ironrdp_svc::{impl_as_any, CompressionCondition, StaticVirtualChannel, SvcMessage};
 use pdu::cursor::WriteCursor;
 use pdu::PduEncode;
 
@@ -90,15 +90,7 @@ impl Drdynvc {
     }
 }
 
-impl AsAny for Drdynvc {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-}
+impl_as_any!(Drdynvc);
 
 impl Default for Drdynvc {
     fn default() -> Self {
@@ -115,7 +107,7 @@ impl StaticVirtualChannel for Drdynvc {
         CompressionCondition::WhenRdpDataIsCompressed
     }
 
-    fn process(&mut self, payload: &[u8]) -> PduResult<Vec<Box<dyn PduEncode>>> {
+    fn process(&mut self, payload: &[u8]) -> PduResult<Vec<SvcMessage>> {
         let dvc_ctx = decode_dvc_message(payload)?;
 
         match dvc_ctx.dvc_pdu {
@@ -248,7 +240,7 @@ impl StaticVirtualChannel for Drdynvc {
 
         Err(ironrdp_pdu::other_err!(
             "DRDYNVC",
-            "ironrdp-dvc::Drdynvc implemention is not yet ready"
+            "ironrdp-dvc::Drdynvc implementation is not yet ready"
         ))
     }
 

--- a/crates/ironrdp-glutin-renderer/Cargo.toml
+++ b/crates/ironrdp-glutin-renderer/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 [dependencies]
 ironrdp.workspace = true
 tracing.workspace = true
-thiserror = "1.0.40"
+thiserror.workspace = true
 glow = "0.12"
 glutin = { version = "0.29" }
 openh264  = { version = "0.4" }

--- a/crates/ironrdp-graphics/Cargo.toml
+++ b/crates/ironrdp-graphics/Cargo.toml
@@ -25,7 +25,7 @@ ironrdp-pdu = { workspace = true, features = ["std"] }
 lazy_static = "1.4.0"
 num-derive = "0.3.3"
 num-traits = "0.2.15"
-thiserror = "1.0.40"
+thiserror.workspace = true
 
 [dev-dependencies]
 bmp = "0.5"

--- a/crates/ironrdp-pdu/Cargo.toml
+++ b/crates/ironrdp-pdu/Cargo.toml
@@ -29,7 +29,7 @@ tap = "1.0.1"
 bit_field = "0.10.2"
 byteorder = "1.4.3"
 der-parser = "8.2.0"
-thiserror = "1.0.40"
+thiserror.workspace = true
 md5 = { package = "md-5", version = "0.10.5" }
 num-bigint = "0.4.3"
 num-derive = "0.3.3"

--- a/crates/ironrdp-pdu/README.md
+++ b/crates/ironrdp-pdu/README.md
@@ -100,7 +100,7 @@ fn process(&mut self, payload: &[u8], output: &mut WriteBuf) -> PduResult<()> {
 Methods such as `write_u8` are overlapping with the `WriteCursor` API, but it’s mostly for
 convenience if one needs to manually write something in an ad-hoc fashion.
 
-Otherwise, using `WriteCursor` is prefered in order to write `no-std` and `no-alloc` friendly code.
+Otherwise, using `WriteCursor` is preferred in order to write `no-std` and `no-alloc` friendly code.
 
 ## Most PDUs are "plain old data" structures with public fields
 
@@ -130,4 +130,3 @@ When hiding some fields is really required, one of the following approach is sug
 [2]: https://doc.rust-lang.org/reference/expressions/struct-expr.html#functional-update-syntax
 [3]: https://matklad.github.io/2022/05/29/builder-lite.html
 [4]: https://xaeroxe.github.io/init-struct-pattern/
-

--- a/crates/ironrdp-pdu/src/lib.rs
+++ b/crates/ironrdp-pdu/src/lib.rs
@@ -175,7 +175,7 @@ where
 
 /// Same as `encode` but allocates and returns a new buffer each time.
 ///
-/// This is a convenience function, but it’s not very ressource efficient.
+/// This is a convenience function, but it’s not very resource efficient.
 #[cfg(feature = "alloc")]
 pub fn encode_vec<T>(pdu: &T) -> PduResult<Vec<u8>>
 where

--- a/crates/ironrdp-pdu/src/macros.rs
+++ b/crates/ironrdp-pdu/src/macros.rs
@@ -242,7 +242,7 @@ macro_rules! write_padding {
 
 /// Moves read cursor, ignoring padding bytes.
 ///
-/// This is similar to `ironrdp_pdu::padding::read`, only exists for consistancy with `write_padding!`.
+/// This is similar to `ironrdp_pdu::padding::read`, only exists for consistency with `write_padding!`.
 #[macro_export]
 macro_rules! read_padding {
     ($src:expr, $n:expr) => {

--- a/crates/ironrdp-pdu/src/write_buf.rs
+++ b/crates/ironrdp-pdu/src/write_buf.rs
@@ -116,7 +116,7 @@ impl WriteBuf {
 
     /// Set the filled cursor to the very beginning of the buffer.
     ///
-    /// If the buffer grew big, it is shrinked in order to reclaim memory.
+    /// If the buffer grew big, it is shrunk in order to reclaim memory.
     pub fn clear(&mut self) {
         self.filled = 0;
         self.inner.shrink_to(MAX_CAPACITY_WHEN_CLEARED);

--- a/crates/ironrdp-rdpsnd/src/lib.rs
+++ b/crates/ironrdp-rdpsnd/src/lib.rs
@@ -1,8 +1,6 @@
-use std::any::Any;
-
 use ironrdp_pdu::gcc::ChannelName;
-use ironrdp_pdu::{PduEncode, PduResult};
-use ironrdp_svc::{AsAny, CompressionCondition, StaticVirtualChannel};
+use ironrdp_pdu::PduResult;
+use ironrdp_svc::{impl_as_any, CompressionCondition, StaticVirtualChannel, SvcMessage};
 
 /// We currently don't implement any of rdpsnd, however it's required
 /// for rdpdr to work: [\[MS-RDPEFS\] Appendix A<1>]
@@ -25,15 +23,7 @@ impl Default for Rdpsnd {
     }
 }
 
-impl AsAny for Rdpsnd {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-}
+impl_as_any!(Rdpsnd);
 
 impl StaticVirtualChannel for Rdpsnd {
     fn channel_name(&self) -> ChannelName {
@@ -44,7 +34,7 @@ impl StaticVirtualChannel for Rdpsnd {
         CompressionCondition::Never
     }
 
-    fn process(&mut self, _payload: &[u8]) -> PduResult<Vec<Box<dyn PduEncode>>> {
+    fn process(&mut self, _payload: &[u8]) -> PduResult<Vec<SvcMessage>> {
         Err(ironrdp_pdu::other_err!(
             "RDPSND",
             "ironrdp-rdpsnd::Rdpsnd is not implemented"

--- a/crates/ironrdp-server/src/display.rs
+++ b/crates/ironrdp-server/src/display.rs
@@ -33,9 +33,9 @@ pub struct BitmapUpdate {
     pub data: Vec<u8>,
 }
 
-/// Display Update reciever for an RDP server
+/// Display Update receiver for an RDP server
 ///
-/// The RDP server will repeatadly call the `get_update` method to receive display updates
+/// The RDP server will repeatedly call the `get_update` method to receive display updates
 /// which will then be encoded and sent to the client
 ///
 /// # Example

--- a/crates/ironrdp-server/src/handler.rs
+++ b/crates/ironrdp-server/src/handler.rs
@@ -33,7 +33,7 @@ pub enum MouseEvent {
 
 /// Input Event Handler for an RDP server
 ///
-/// Whenever the RDP server will receive an input event from a client, the relevent callback from
+/// Whenever the RDP server will receive an input event from a client, the relevant callback from
 /// this handler will be called
 ///
 /// # Example

--- a/crates/ironrdp-session/src/x224/mod.rs
+++ b/crates/ironrdp-session/src/x224/mod.rs
@@ -12,7 +12,8 @@ use ironrdp_pdu::rdp::headers::ShareDataPdu;
 use ironrdp_pdu::rdp::server_error_info::{ErrorInfo, ProtocolIndependentCode, ServerSetErrorInfoPdu};
 use ironrdp_pdu::rdp::vc::dvc;
 use ironrdp_pdu::write_buf::WriteBuf;
-use ironrdp_pdu::{encode_buf, mcs, PduParsing};
+use ironrdp_pdu::PduParsing;
+use ironrdp_pdu::{encode_buf, mcs};
 use ironrdp_svc::{chunkify, StaticChannelSet, CHANNEL_CHUNK_LENGTH};
 
 pub use self::gfx::GfxHandler;
@@ -61,7 +62,7 @@ impl Processor {
     }
 
     pub fn process(&mut self, frame: &[u8]) -> SessionResult<Vec<u8>> {
-        let data_ctx =
+        let data_ctx: SendDataIndicationCtx<'_> =
             ironrdp_connector::legacy::decode_send_data_indication(frame).map_err(crate::legacy::map_error)?;
         let channel_id = data_ctx.channel_id;
 

--- a/crates/ironrdp-svc/src/lib.rs
+++ b/crates/ironrdp-svc/src/lib.rs
@@ -20,6 +20,30 @@ use pdu::{encode_buf, PduEncode};
 /// The integer type representing a static virtual channel ID.
 pub type StaticChannelId = u16;
 
+/// Encodable PDU that can used as a message to be sent over a static virtual channel.
+/// Additional SVC header flags could be added via [`SvcMessage::with_flags`] method.
+pub struct SvcMessage {
+    pdu: Box<dyn PduEncode>,
+    flags: ChannelFlags,
+}
+
+impl SvcMessage {
+    /// Adds additional SVC header flags to the message.
+    pub fn with_flags(mut self, flags: ChannelFlags) -> Self {
+        self.flags |= flags;
+        self
+    }
+}
+
+impl<T: PduEncode + 'static> From<T> for SvcMessage {
+    fn from(pdu: T) -> Self {
+        Self {
+            pdu: Box::new(pdu),
+            flags: ChannelFlags::empty(),
+        }
+    }
+}
+
 /// Defines which compression flag should be sent along the [`ChannelDef`] structure (CHANNEL_DEF)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CompressionCondition {
@@ -48,7 +72,7 @@ pub trait StaticVirtualChannel: AsAny + fmt::Debug + Send + Sync {
 
     /// Processes a payload received on the virtual channel.
     /// Returns a list of PDUs to be sent back to the client.
-    fn process(&mut self, payload: &[u8]) -> PduResult<Vec<Box<dyn PduEncode>>>;
+    fn process(&mut self, payload: &[u8]) -> PduResult<Vec<SvcMessage>>;
 
     #[doc(hidden)]
     fn is_drdynvc(&self) -> bool {
@@ -62,10 +86,10 @@ assert_obj_safe!(StaticVirtualChannel);
 /// Takes a vector of PDUs and breaks them into chunks prefixed with a [`ChannelPduHeader`].
 ///
 /// Each chunk is at most `max_chunk_len` bytes long (not including the Channel PDU Header).
-pub fn chunkify(pdus: Vec<Box<dyn PduEncode>>, max_chunk_len: usize) -> PduResult<Vec<WriteBuf>> {
+pub fn chunkify(messages: Vec<SvcMessage>, max_chunk_len: usize) -> PduResult<Vec<WriteBuf>> {
     let mut results = vec![];
-    for pdu in pdus {
-        results.extend(chunkify_one(pdu, max_chunk_len)?);
+    for message in messages {
+        results.extend(chunkify_one(message, max_chunk_len)?);
     }
     Ok(results)
 }
@@ -78,9 +102,9 @@ pub fn chunkify(pdus: Vec<Box<dyn PduEncode>>, max_chunk_len: usize) -> PduResul
 /// return 3 chunks, each 1600 bytes long, and the last chunk will be 800 bytes long.
 ///
 /// [[ Channel PDU Header | 1600 bytes of PDU data ] [ Channel PDU Header | 1600 bytes of PDU data ] [ Channel PDU Header | 800 bytes of PDU data ]]
-fn chunkify_one(pdu: Box<dyn PduEncode>, max_chunk_len: usize) -> PduResult<Vec<WriteBuf>> {
+fn chunkify_one(message: SvcMessage, max_chunk_len: usize) -> PduResult<Vec<WriteBuf>> {
     let mut encoded_pdu = WriteBuf::new(); // TODO(perf): reuse this buffer using `clear` and `filled` as appropriate
-    encode_buf(pdu.as_ref(), &mut encoded_pdu)?;
+    encode_buf(message.pdu.as_ref(), &mut encoded_pdu)?;
 
     let mut chunks = Vec::new();
 
@@ -107,6 +131,8 @@ fn chunkify_one(pdu: Box<dyn PduEncode>, max_chunk_len: usize) -> PduResult<Vec<
             if last {
                 flags |= ChannelFlags::LAST;
             }
+
+            flags |= message.flags;
 
             ChannelPduHeader {
                 length: ironrdp_pdu::cast_int!(ChannelPduHeader::NAME, "length", total_len)?,
@@ -155,6 +181,23 @@ pub trait AsAny {
     fn as_any(&self) -> &dyn Any;
 
     fn as_any_mut(&mut self) -> &mut dyn Any;
+}
+
+#[macro_export]
+macro_rules! impl_as_any {
+    ($t:ty) => {
+        impl $crate::AsAny for $t {
+            #[inline]
+            fn as_any(&self) -> &dyn core::any::Any {
+                self
+            }
+
+            #[inline]
+            fn as_any_mut(&mut self) -> &mut dyn core::any::Any {
+                self
+            }
+        }
+    };
 }
 
 /// A set holding at most one trait object for any given static channel.
@@ -300,7 +343,7 @@ bitflags! {
     ///
     /// [section 2.2.6.1.1 of MS-RDPBCGR]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/f125c65e-6901-43c3-8071-d7d5aaee7ae4
     #[derive(Debug, PartialEq, Copy, Clone)]
-    struct ChannelFlags: u32 {
+    pub struct ChannelFlags: u32 {
         /// CHANNEL_FLAG_FIRST
         const FIRST = 0x00000001;
         /// CHANNEL_FLAG_LAST

--- a/crates/ironrdp-testsuite-core/tests/clipboard.rs
+++ b/crates/ironrdp-testsuite-core/tests/clipboard.rs
@@ -1,15 +1,16 @@
 use expect_test::expect;
 use ironrdp_cliprdr::pdu::{
-    Capabilities, CapabilitySet, ClipboardFormat, ClipboardGeneralCapabilityFlags, ClipboardPdu,
-    ClipboardProtocolVersion, FileContentsFlags, FileContentsRequest, FileContentsResponse, FormatDataRequest,
-    FormatDataResponse, FormatList, FormatListResponse, GeneralCapabilitySet, LockDataId, PackedMetafileMappingMode,
+    Capabilities, CapabilitySet, ClipboardFormat, ClipboardFormatId, ClipboardFormatName,
+    ClipboardGeneralCapabilityFlags, ClipboardPdu, ClipboardProtocolVersion, FileContentsFlags, FileContentsRequest,
+    FileContentsResponse, FormatDataRequest, FormatDataResponse, FormatList, FormatListResponse, GeneralCapabilitySet,
+    LockDataId, PackedMetafileMappingMode,
 };
 use ironrdp_testsuite_core::encode_decode_test;
 
 // Test blobs from [MS-RDPECLIP]
 encode_decode_test! {
     capabilities:
-        ClipboardPdu::Capabilites(
+        ClipboardPdu::Capabilities(
             Capabilities {
                 capabilities: vec![
                     CapabilitySet::General(
@@ -163,20 +164,32 @@ fn format_list_ms_1() {
         expect![[r#"
             [
                 ClipboardFormat {
-                    id: 49156,
-                    name: "Native",
+                    id: ClipboardFormatId(
+                        49156,
+                    ),
+                    name: Some(
+                        ClipboardFormatName(
+                            "Native",
+                        ),
+                    ),
                 },
                 ClipboardFormat {
-                    id: 3,
-                    name: "",
+                    id: ClipboardFormatId(
+                        3,
+                    ),
+                    name: None,
                 },
                 ClipboardFormat {
-                    id: 8,
-                    name: "",
+                    id: ClipboardFormatId(
+                        8,
+                    ),
+                    name: None,
                 },
                 ClipboardFormat {
-                    id: 17,
-                    name: "",
+                    id: ClipboardFormatId(
+                        17,
+                    ),
+                    name: None,
                 },
             ]
         "#]]
@@ -205,44 +218,84 @@ fn format_list_ms_2() {
         expect![[r#"
             [
                 ClipboardFormat {
-                    id: 49290,
-                    name: "Rich Text Format",
+                    id: ClipboardFormatId(
+                        49290,
+                    ),
+                    name: Some(
+                        ClipboardFormatName(
+                            "Rich Text Format",
+                        ),
+                    ),
                 },
                 ClipboardFormat {
-                    id: 49477,
-                    name: "Rich Text Format Without Objects",
+                    id: ClipboardFormatId(
+                        49477,
+                    ),
+                    name: Some(
+                        ClipboardFormatName(
+                            "Rich Text Format Without Objects",
+                        ),
+                    ),
                 },
                 ClipboardFormat {
-                    id: 49475,
-                    name: "RTF As Text",
+                    id: ClipboardFormatId(
+                        49475,
+                    ),
+                    name: Some(
+                        ClipboardFormatName(
+                            "RTF As Text",
+                        ),
+                    ),
                 },
                 ClipboardFormat {
-                    id: 1,
-                    name: "",
+                    id: ClipboardFormatId(
+                        1,
+                    ),
+                    name: None,
                 },
                 ClipboardFormat {
-                    id: 13,
-                    name: "",
+                    id: ClipboardFormatId(
+                        13,
+                    ),
+                    name: None,
                 },
                 ClipboardFormat {
-                    id: 49156,
-                    name: "Native",
+                    id: ClipboardFormatId(
+                        49156,
+                    ),
+                    name: Some(
+                        ClipboardFormatName(
+                            "Native",
+                        ),
+                    ),
                 },
                 ClipboardFormat {
-                    id: 49166,
-                    name: "Object Descriptor",
+                    id: ClipboardFormatId(
+                        49166,
+                    ),
+                    name: Some(
+                        ClipboardFormatName(
+                            "Object Descriptor",
+                        ),
+                    ),
                 },
                 ClipboardFormat {
-                    id: 3,
-                    name: "",
+                    id: ClipboardFormatId(
+                        3,
+                    ),
+                    name: None,
                 },
                 ClipboardFormat {
-                    id: 16,
-                    name: "",
+                    id: ClipboardFormatId(
+                        16,
+                    ),
+                    name: None,
                 },
                 ClipboardFormat {
-                    id: 7,
-                    name: "",
+                    id: ClipboardFormatId(
+                        7,
+                    ),
+                    name: None,
                 },
             ]
         "#]]
@@ -260,18 +313,9 @@ fn format_list_ms_2() {
 
 fn fake_format_list(use_ascii: bool, use_long_format: bool) -> Box<FormatList<'static>> {
     let formats = vec![
-        ClipboardFormat {
-            id: 42,
-            name: "Hello".to_string(),
-        },
-        ClipboardFormat {
-            id: 24,
-            name: "".to_string(),
-        },
-        ClipboardFormat {
-            id: 11,
-            name: "World".to_string(),
-        },
+        ClipboardFormat::new(ClipboardFormatId::new(42)).with_name(ClipboardFormatName::new("Hello")),
+        ClipboardFormat::new(ClipboardFormatId::new(24)),
+        ClipboardFormat::new(ClipboardFormatId::new(11)).with_name(ClipboardFormatName::new("World")),
     ];
 
     let list = if use_ascii {
@@ -359,7 +403,7 @@ fn file_list_pdu_ms() {
         expect![[r#"
             [
                 FileDescriptor {
-                    attibutes: Some(
+                    attributes: Some(
                         ClipboardFileAttributes(
                             ARCHIVE,
                         ),
@@ -373,7 +417,7 @@ fn file_list_pdu_ms() {
                     name: "File1.txt",
                 },
                 FileDescriptor {
-                    attibutes: Some(
+                    attributes: Some(
                         ClipboardFileAttributes(
                             ARCHIVE,
                         ),

--- a/crates/ironrdp/Cargo.toml
+++ b/crates/ironrdp/Cargo.toml
@@ -18,6 +18,7 @@ test = false
 [features]
 default = ["pdu", "connector", "session"]
 pdu = ["dep:ironrdp-pdu"]
+cliprdr = ["dep:ironrdp-cliprdr"]
 connector = ["dep:ironrdp-connector"]
 acceptor = ["dep:ironrdp-acceptor"]
 session = ["dep:ironrdp-session"]
@@ -31,6 +32,7 @@ rdpsnd = ["dep:ironrdp-rdpsnd"]
 
 [dependencies]
 ironrdp-pdu = { workspace = true, optional = true }
+ironrdp-cliprdr = { workspace = true, optional = true }
 ironrdp-connector = { workspace = true, optional = true }
 ironrdp-acceptor = { workspace = true, optional = true }
 ironrdp-session = { workspace = true, optional = true }

--- a/crates/ironrdp/src/lib.rs
+++ b/crates/ironrdp/src/lib.rs
@@ -4,6 +4,8 @@
 
 #[cfg(feature = "acceptor")]
 pub use ironrdp_acceptor as acceptor;
+#[cfg(feature = "cliprdr")]
+pub use ironrdp_cliprdr as cliprdr;
 #[cfg(feature = "connector")]
 pub use ironrdp_connector as connector;
 #[cfg(feature = "dvc")]


### PR DESCRIPTION
Adds initialization sequence of CLIPRDR static virtual channel

+ Changes `ironrdp-svc` API to accommodate the need for adding SVC PDU flags on a per-message basis
+ Reduces boilerplate code for `AsAny`

Part of #107