### PR TITLE
fix(pdu): don't be strict about platform type

### DIFF
--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -301,12 +301,12 @@ impl Config {
             // https://github.com/FreeRDP/FreeRDP/blob/4e24b966c86fdf494a782f0dfcfc43a057a2ea60/libfreerdp/core/settings.c#LL49C34-L49C70
             client_dir: "C:\\Windows\\System32\\mstscax.dll".to_owned(),
             platform: match whoami::platform() {
-                whoami::Platform::Windows => MajorPlatformType::Windows,
-                whoami::Platform::Linux => MajorPlatformType::Unix,
-                whoami::Platform::MacOS => MajorPlatformType::Macintosh,
-                whoami::Platform::Ios => MajorPlatformType::IOs,
-                whoami::Platform::Android => MajorPlatformType::Android,
-                _ => MajorPlatformType::Unspecified,
+                whoami::Platform::Windows => MajorPlatformType::WINDOWS,
+                whoami::Platform::Linux => MajorPlatformType::UNIX,
+                whoami::Platform::MacOS => MajorPlatformType::MACINTOSH,
+                whoami::Platform::Ios => MajorPlatformType::IOS,
+                whoami::Platform::Android => MajorPlatformType::ANDROID,
+                _ => MajorPlatformType::UNSPECIFIED,
             },
             no_server_pointer: args.no_server_pointer,
         };

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -947,7 +947,7 @@ fn create_client_confirm_active(
     server_capability_sets.extend_from_slice(&[
         CapabilitySet::General(General {
             major_platform_type: config.platform,
-            minor_platform_type: MinorPlatformType::Unspecified,
+            minor_platform_type: MinorPlatformType::UNSPECIFIED,
             extra_flags: GeneralExtraFlags::FASTPATH_OUTPUT_SUPPORTED | GeneralExtraFlags::NO_BITMAP_COMPRESSION_HDR,
             refresh_rect_support: false,
             suppress_output_support: false,

--- a/crates/ironrdp-pdu/src/rdp/capability_sets.rs
+++ b/crates/ironrdp-pdu/src/rdp/capability_sets.rs
@@ -544,10 +544,6 @@ pub enum CapabilitySetsError {
     InvalidCompressionFlag,
     #[error("Invalid multiple rectangle support field")]
     InvalidMultipleRectSupport,
-    #[error("Invalid major platform type field")]
-    InvalidMajorPlatformType,
-    #[error("Invalid minor platform type field")]
-    InvalidMinorPlatformType,
     #[error("Invalid protocol version field")]
     InvalidProtocolVersion,
     #[error("Invalid compression types field")]

--- a/crates/ironrdp-pdu/src/rdp/capability_sets/general/tests.rs
+++ b/crates/ironrdp-pdu/src/rdp/capability_sets/general/tests.rs
@@ -18,8 +18,8 @@ const GENERAL_CAPSET_BUFFER: [u8; 20] = [
 
 lazy_static! {
     pub static ref CAPSET_GENERAL: General = General {
-        major_platform_type: MajorPlatformType::Windows,
-        minor_platform_type: MinorPlatformType::WindowsNT,
+        major_platform_type: MajorPlatformType::WINDOWS,
+        minor_platform_type: MinorPlatformType::WINDOWS_NT,
         extra_flags: GeneralExtraFlags::FASTPATH_OUTPUT_SUPPORTED
             | GeneralExtraFlags::LONG_CREDENTIALS_SUPPORTED
             | GeneralExtraFlags::AUTORECONNECT_SUPPORTED

--- a/crates/ironrdp-server/src/capabilities.rs
+++ b/crates/ironrdp-server/src/capabilities.rs
@@ -16,8 +16,8 @@ pub fn capabilities(_opts: &RdpServerOptions, size: DesktopSize) -> Vec<capabili
 
 fn general_capabilities() -> capability_sets::General {
     capability_sets::General {
-        major_platform_type: capability_sets::MajorPlatformType::Unspecified,
-        minor_platform_type: capability_sets::MinorPlatformType::Unspecified,
+        major_platform_type: capability_sets::MajorPlatformType::UNSPECIFIED,
+        minor_platform_type: capability_sets::MinorPlatformType::UNSPECIFIED,
         extra_flags: capability_sets::GeneralExtraFlags::empty(),
         refresh_rect_support: false,
         suppress_output_support: false,

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -494,7 +494,7 @@ fn build_config(
         // NOTE: hardcode this value like in freerdp
         // https://github.com/FreeRDP/FreeRDP/blob/4e24b966c86fdf494a782f0dfcfc43a057a2ea60/libfreerdp/core/settings.c#LL49C34-L49C70
         client_dir: "C:\\Windows\\System32\\mstscax.dll".to_owned(),
-        platform: ironrdp::pdu::rdp::capability_sets::MajorPlatformType::Unspecified,
+        platform: ironrdp::pdu::rdp::capability_sets::MajorPlatformType::UNSPECIFIED,
         no_server_pointer: false,
     }
 }


### PR DESCRIPTION
Allow values outside the range of known values. FreeRDP has been using 0xFFFF - N for custom values.