### PR TITLE
Make it easier to use IronRDP with Tokio

### DIFF
--- a/crates/ironrdp-async/src/framed.rs
+++ b/crates/ironrdp-async/src/framed.rs
@@ -11,14 +11,17 @@ pub trait FramedRead {
     fn read<'a>(
         &'a mut self,
         buf: &'a mut BytesMut,
-    ) -> Pin<Box<dyn std::future::Future<Output = io::Result<usize>> + 'a>>
+    ) -> Pin<Box<dyn std::future::Future<Output = io::Result<usize>> + 'a + Send>>
     where
         Self: 'a;
 }
 
 pub trait FramedWrite {
     /// Writes an entire buffer into this stream.
-    fn write_all<'a>(&'a mut self, buf: &'a [u8]) -> Pin<Box<dyn std::future::Future<Output = io::Result<()>> + 'a>>
+    fn write_all<'a>(
+        &'a mut self,
+        buf: &'a [u8],
+    ) -> Pin<Box<dyn std::future::Future<Output = io::Result<()>> + 'a + Send>>
     where
         Self: 'a;
 }

--- a/crates/ironrdp-futures/src/lib.rs
+++ b/crates/ironrdp-futures/src/lib.rs
@@ -61,7 +61,10 @@ impl<S> FramedWrite for FuturesStream<S>
 where
     S: Unpin + AsyncWrite,
 {
-    fn write_all<'a>(&'a mut self, buf: &'a [u8]) -> Pin<Box<dyn std::future::Future<Output = io::Result<()>> + 'a>>
+    fn write_all<'a>(
+        &'a mut self,
+        buf: &'a [u8],
+    ) -> Pin<Box<dyn std::future::Future<Output = io::Result<()>> + 'a + Send>>
     where
         Self: 'a,
     {

--- a/crates/ironrdp-pdu/src/lib.rs
+++ b/crates/ironrdp-pdu/src/lib.rs
@@ -282,7 +282,7 @@ pub fn find_size(bytes: &[u8]) -> PduResult<Option<PduInfo>> {
     }
 }
 
-pub trait PduHint: core::fmt::Debug {
+pub trait PduHint: core::fmt::Debug + Sync {
     /// Finds next PDU size by reading the next few bytes.
     fn find_size(&self, bytes: &[u8]) -> PduResult<Option<usize>>;
 }

--- a/crates/ironrdp-tokio/src/lib.rs
+++ b/crates/ironrdp-tokio/src/lib.rs
@@ -33,14 +33,14 @@ impl<S> StreamWrapper for TokioStream<S> {
 
 impl<S> FramedRead for TokioStream<S>
 where
-    S: Unpin + AsyncRead,
+    S: Unpin + AsyncRead + Send,
 {
     fn read<'a>(
         &'a mut self,
         buf: &'a mut BytesMut,
-    ) -> Pin<Box<dyn std::future::Future<Output = io::Result<usize>> + 'a>>
+    ) -> Pin<Box<dyn std::future::Future<Output = io::Result<usize>> + 'a + Send>>
     where
-        Self: 'a,
+        Self: 'a + Send,
     {
         use tokio::io::AsyncReadExt as _;
 
@@ -50,9 +50,12 @@ where
 
 impl<S> FramedWrite for TokioStream<S>
 where
-    S: Unpin + AsyncWrite,
+    S: Unpin + AsyncWrite + Send,
 {
-    fn write_all<'a>(&'a mut self, buf: &'a [u8]) -> Pin<Box<dyn std::future::Future<Output = io::Result<()>> + 'a>>
+    fn write_all<'a>(
+        &'a mut self,
+        buf: &'a [u8],
+    ) -> Pin<Box<dyn std::future::Future<Output = io::Result<()>> + 'a + Send>>
     where
         Self: 'a,
     {


### PR DESCRIPTION
Various types used in connection sequence were not picked up as `Send` or `Sync` which made it impossible to use inside `tokio::spawn` blocks