### PR TITLE
Remove redundant debug comment

### DIFF
--- a/crates/ironrdp-session/src/image.rs
+++ b/crates/ironrdp-session/src/image.rs
@@ -155,7 +155,6 @@ impl DecodedImage {
 
     fn apply_pointer_layer(&mut self, layer: PointerLayer) -> SessionResult<Option<InclusiveRectangle>> {
         if self.data.is_empty() {
-            eprintln!("FUCK, EMPTY DST!");
             return Ok(None);
         }
 


### PR DESCRIPTION
@CBenoit I accidentally discovered I made an oopsie and forgot to remove inappropriate `eprintln!` which was left after pointer rendering implementation, sorry 😨 It somehow slipped through the cracks during self-review & PR