### PR TITLE
feat(rdpdr): `DR_CORE_SERVER_CLIENTID_CONFIRM` and `DR_CORE_DEVICELIST_ANNOUNCE`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1820,6 +1820,7 @@ dependencies = [
  "ironrdp-cliprdr",
  "ironrdp-graphics",
  "ironrdp-pdu",
+ "ironrdp-rdpdr",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1749,6 +1749,8 @@ dependencies = [
  "exitcode",
  "inquire",
  "ironrdp",
+ "ironrdp-rdpdr",
+ "ironrdp-rdpsnd",
  "ironrdp-tls",
  "ironrdp-tokio",
  "semver",
@@ -4266,6 +4268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if 1.0.0",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ expect-test = "1"
 proptest = "1.1.0"
 rstest = "0.17.0"
 sspi = "0.10.1"
-tracing = "0.1.37"
+tracing = { version = "0.1.37", features = ["log"] }
 thiserror = "1.0.40"
 
 [profile.dev]

--- a/crates/ironrdp-client/Cargo.toml
+++ b/crates/ironrdp-client/Cargo.toml
@@ -31,6 +31,8 @@ native-tls = ["ironrdp-tls/native-tls"]
 ironrdp = { workspace = true, features = ["input", "graphics", "dvc", "rdpdr", "rdpsnd", "cliprdr"] }
 ironrdp-tls.workspace = true
 ironrdp-tokio.workspace = true
+ironrdp-rdpsnd.workspace = true
+ironrdp-rdpdr.workspace = true
 sspi = { workspace = true, features = ["network_client", "dns_resolver"] } # enable additional features
 
 # GUI

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -12,7 +12,7 @@ use tap::prelude::*;
 const DEFAULT_WIDTH: u16 = 1920;
 const DEFAULT_HEIGHT: u16 = 1080;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Config {
     pub log_file: String,
     pub destination: Destination,

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -102,8 +102,8 @@ async fn connect(config: &Config) -> ConnectorResult<(ConnectionResult, Upgraded
         .with_credssp_network_client(RequestClientFactory)
         // .with_static_channel(ironrdp::dvc::Drdynvc::new()) // FIXME: drdynvc is not working
         .with_static_channel(ironrdp::rdpsnd::Rdpsnd::new())
-        .with_static_channel(ironrdp::rdpdr::Rdpdr::default())
-        .with_static_channel(ironrdp::cliprdr::Cliprdr::default());
+        .with_static_channel(ironrdp_rdpdr::Rdpdr::new("IronRDP".to_string()));
+    // .with_static_channel(ironrdp::cliprdr::Cliprdr::default());
 
     let should_upgrade = ironrdp_tokio::connect_begin(&mut framed, &mut connector).await?;
 
@@ -121,6 +121,8 @@ async fn connect(config: &Config) -> ConnectorResult<(ConnectionResult, Upgraded
     let mut upgraded_framed = ironrdp_tokio::TokioFramed::new(upgraded_stream);
 
     let connection_result = ironrdp_tokio::connect_finalize(upgraded, &mut upgraded_framed, connector).await?;
+
+    debug!(?connection_result);
 
     Ok((connection_result, upgraded_framed))
 }

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -102,8 +102,8 @@ async fn connect(config: &Config) -> ConnectorResult<(ConnectionResult, Upgraded
         .with_credssp_network_client(RequestClientFactory)
         // .with_static_channel(ironrdp::dvc::Drdynvc::new()) // FIXME: drdynvc is not working
         .with_static_channel(ironrdp::rdpsnd::Rdpsnd::new())
-        .with_static_channel(ironrdp_rdpdr::Rdpdr::new("IronRDP".to_string()));
-    // .with_static_channel(ironrdp::cliprdr::Cliprdr::default());
+        .with_static_channel(ironrdp_rdpdr::Rdpdr::new("IronRDP".to_string()).with_smartcard(0))
+        .with_static_channel(ironrdp::cliprdr::Cliprdr::default());
 
     let should_upgrade = ironrdp_tokio::connect_begin(&mut framed, &mut connector).await?;
 

--- a/crates/ironrdp-cliprdr/src/lib.rs
+++ b/crates/ironrdp-cliprdr/src/lib.rs
@@ -65,14 +65,14 @@ impl Cliprdr {
         self.state = CliprdrState::Failed;
         error!("CLIPRDR(clipboard) failed: {err}");
 
-        Ok(vec![])
+        Ok(Vec::new())
     }
 
     fn handle_server_capabilities(&mut self, server_capabilities: Capabilities) -> PduResult<Vec<SvcMessage>> {
         self.capabilities.downgrade(&server_capabilities);
 
         // Do not send anything, wait for monitor ready pdu
-        Ok(vec![])
+        Ok(Vec::new())
     }
 
     fn handle_monitor_ready(&mut self) -> PduResult<Vec<SvcMessage>> {
@@ -99,7 +99,7 @@ impl Cliprdr {
             }
         }
 
-        Ok(vec![])
+        Ok(Vec::new())
     }
 }
 
@@ -126,7 +126,7 @@ impl StaticVirtualChannel for Cliprdr {
 
         if self.state == CliprdrState::Failed {
             error!("Attempted to process clipboard static virtual channel in failed state");
-            return Ok(vec![]);
+            return Ok(Vec::new());
         }
 
         match pdu {

--- a/crates/ironrdp-fuzzing/Cargo.toml
+++ b/crates/ironrdp-fuzzing/Cargo.toml
@@ -14,3 +14,4 @@ arbitrary = { version = "1", features = ["derive"] }
 ironrdp-graphics.workspace = true
 ironrdp-pdu.workspace = true
 ironrdp-cliprdr.workspace = true
+ironrdp-rdpdr.workspace = true

--- a/crates/ironrdp-fuzzing/src/oracles/mod.rs
+++ b/crates/ironrdp-fuzzing/src/oracles/mod.rs
@@ -75,6 +75,8 @@ pub fn pdu_decode(data: &[u8]) {
     let _ = decode::<bitmap::rdp6::BitmapStream>(data);
 
     let _ = decode::<ironrdp_cliprdr::pdu::ClipboardPdu>(data);
+
+    let _ = decode::<ironrdp_rdpdr::pdu::RdpdrPdu>(data);
 }
 
 pub fn rle_decompress_bitmap(input: BitmapInput) {

--- a/crates/ironrdp-graphics/src/pointer.rs
+++ b/crates/ironrdp-graphics/src/pointer.rs
@@ -126,7 +126,7 @@ impl DecodedPointer {
             });
         }
 
-        let mut bitmap_data = vec![];
+        let mut bitmap_data = Vec::new();
 
         for row_idx in 0..data.height {
             // For non-monochrome cursors we read strides from bottom to top

--- a/crates/ironrdp-graphics/src/rectangle_processing.rs
+++ b/crates/ironrdp-graphics/src/rectangle_processing.rs
@@ -1477,7 +1477,7 @@ mod tests {
                 right: 0,
                 bottom: 0,
             },
-            rectangles: vec![],
+            rectangles: Vec::new(),
         };
         let input_rectangle = InclusiveRectangle {
             left: 5,
@@ -1499,7 +1499,7 @@ mod tests {
                 right: 0,
                 bottom: 0,
             },
-            rectangles: vec![],
+            rectangles: Vec::new(),
         };
         let input_rectangle = InclusiveRectangle {
             left: 5,

--- a/crates/ironrdp-rdpdr/src/lib.rs
+++ b/crates/ironrdp-rdpdr/src/lib.rs
@@ -35,12 +35,6 @@ pub struct Rdpdr {
     device_list: Devices,
 }
 
-impl Default for Rdpdr {
-    fn default() -> Self {
-        Self::new("IronRDP".to_string())
-    }
-}
-
 impl Rdpdr {
     pub const NAME: ChannelName = ChannelName::from_static(b"rdpdr\0\0\0");
 

--- a/crates/ironrdp-rdpdr/src/lib.rs
+++ b/crates/ironrdp-rdpdr/src/lib.rs
@@ -111,7 +111,7 @@ impl StaticVirtualChannel for Rdpdr {
             }
             RdpdrPdu::Unimplemented => {
                 warn!("received unimplemented packet: {:?}", pdu);
-                Ok(vec![])
+                Ok(Vec::new())
             }
             _ => Err(other_err!("rdpdr", "internal error")),
         }

--- a/crates/ironrdp-rdpdr/src/lib.rs
+++ b/crates/ironrdp-rdpdr/src/lib.rs
@@ -76,14 +76,14 @@ impl Rdpdr {
     }
 
     fn handle_server_capability(&mut self, _req: CoreCapability) -> PduResult<Vec<SvcMessage>> {
-        let res = RdpdrPdu::CoreCapability(CoreCapability::new_response(self.capabilities.take_clone()));
+        let res = RdpdrPdu::CoreCapability(CoreCapability::new_response(self.capabilities.clone_inner()));
         trace!("sending {:?}", res);
         Ok(vec![SvcMessage::from(res)])
     }
 
     fn handle_client_id_confirm(&mut self) -> PduResult<Vec<SvcMessage>> {
         let res = RdpdrPdu::ClientDeviceListAnnounce(ClientDeviceListAnnounce {
-            device_list: self.device_list.take_clone(),
+            device_list: self.device_list.clone_inner(),
         });
         trace!("sending {:?}", res);
         Ok(vec![SvcMessage::from(res)])

--- a/crates/ironrdp-rdpdr/src/lib.rs
+++ b/crates/ironrdp-rdpdr/src/lib.rs
@@ -76,14 +76,14 @@ impl Rdpdr {
     }
 
     fn handle_server_capability(&mut self, _req: CoreCapability) -> PduResult<Vec<SvcMessage>> {
-        let res = RdpdrPdu::CoreCapability(CoreCapability::new_response(self.capabilities.take()));
+        let res = RdpdrPdu::CoreCapability(CoreCapability::new_response(self.capabilities.take_clone()));
         trace!("sending {:?}", res);
         Ok(vec![SvcMessage::from(res)])
     }
 
     fn handle_client_id_confirm(&mut self) -> PduResult<Vec<SvcMessage>> {
         let res = RdpdrPdu::ClientDeviceListAnnounce(ClientDeviceListAnnounce {
-            device_list: self.device_list.take(),
+            device_list: self.device_list.take_clone(),
         });
         trace!("sending {:?}", res);
         Ok(vec![SvcMessage::from(res)])

--- a/crates/ironrdp-rdpdr/src/lib.rs
+++ b/crates/ironrdp-rdpdr/src/lib.rs
@@ -3,17 +3,17 @@
 //!
 //! [\[MS-RDPEFS\]: Remote Desktop Protocol: File System Virtual Channel Extension]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/34d9de58-b2b5-40b6-b970-f82d4603bdb5
 
-mod pdu;
+pub mod pdu;
 use crate::pdu::{
     efs::{
-        CapabilityMessage, ClientNameRequest, ClientNameRequestUnicodeFlag, CoreCapability, CoreCapabilityKind,
-        VersionAndIdPdu, VersionAndIdPduKind,
+        ClientNameRequest, ClientNameRequestUnicodeFlag, CoreCapability, CoreCapabilityKind, VersionAndIdPdu,
+        VersionAndIdPduKind,
     },
     RdpdrPdu,
 };
 use ironrdp_pdu::{decode, gcc::ChannelName, other_err, PduResult};
 use ironrdp_svc::{impl_as_any, CompressionCondition, StaticVirtualChannel, SvcMessage};
-use pdu::efs::{ClientDeviceListAnnounce, DeviceAnnounceHeader};
+use pdu::efs::{Capabilities, ClientDeviceListAnnounce, Devices};
 use tracing::{trace, warn};
 
 /// The RDPDR channel as specified in [\[MS-RDPEFS\]].
@@ -28,32 +28,35 @@ use tracing::{trace, warn};
 pub struct Rdpdr {
     /// TODO: explain what this is
     computer_name: String,
-    capabilities: Vec<CapabilityMessage>,
+    capabilities: Capabilities,
     /// Pre-configured list of devices to announce to the server.
     ///
     /// All devices not of the type [`DeviceType::Filesystem`] must be declared here.
-    device_list: Option<Vec<DeviceAnnounceHeader>>,
+    device_list: Devices,
 }
 
 impl Default for Rdpdr {
     fn default() -> Self {
-        Self::new("IronRDP".to_string(), vec![CapabilityMessage::new_general(0)], None)
+        Self::new("IronRDP".to_string())
     }
 }
 
 impl Rdpdr {
     pub const NAME: ChannelName = ChannelName::from_static(b"rdpdr\0\0\0");
 
-    pub fn new(
-        computer_name: String,
-        capabilities: Vec<CapabilityMessage>,
-        device_list: Option<Vec<DeviceAnnounceHeader>>,
-    ) -> Self {
+    /// Creates a new [`Rdpdr`].
+    pub fn new(computer_name: String) -> Self {
         Self {
             computer_name,
-            capabilities,
-            device_list,
+            capabilities: Capabilities::new(),
+            device_list: Devices::new(),
         }
+    }
+
+    pub fn with_smartcard(mut self, device_id: u32) -> Self {
+        self.device_list.add_smartcard(device_id);
+        self.capabilities.add_smartcard();
+        self
     }
 
     fn handle_server_announce(&mut self, req: VersionAndIdPdu) -> PduResult<Vec<SvcMessage>> {
@@ -73,19 +76,16 @@ impl Rdpdr {
     }
 
     fn handle_server_capability(&mut self, _req: CoreCapability) -> PduResult<Vec<SvcMessage>> {
-        let res = RdpdrPdu::CoreCapability(CoreCapability::new_response(self.capabilities.clone()));
+        let res = RdpdrPdu::CoreCapability(CoreCapability::new_response(self.capabilities.take()));
         trace!("sending {:?}", res);
-
-        // TODO: Make CoreCapability PduEncode
         Ok(vec![SvcMessage::from(res)])
     }
 
     fn handle_client_id_confirm(&mut self) -> PduResult<Vec<SvcMessage>> {
         let res = RdpdrPdu::ClientDeviceListAnnounce(ClientDeviceListAnnounce {
-            device_list: self.device_list.take().unwrap_or_default(),
+            device_list: self.device_list.take(),
         });
         trace!("sending {:?}", res);
-
         Ok(vec![SvcMessage::from(res)])
     }
 }

--- a/crates/ironrdp-rdpdr/src/pdu/efs.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/efs.rs
@@ -282,7 +282,7 @@ impl Capabilities {
         self.increment_special_devices();
     }
 
-    pub fn take_clone(&mut self) -> Vec<CapabilityMessage> {
+    pub fn clone_inner(&mut self) -> Vec<CapabilityMessage> {
         self.0.clone()
     }
 
@@ -769,7 +769,7 @@ impl Devices {
         self.0.push(device);
     }
 
-    pub fn take_clone(&mut self) -> Vec<DeviceAnnounceHeader> {
+    pub fn clone_inner(&mut self) -> Vec<DeviceAnnounceHeader> {
         self.0.clone()
     }
 }

--- a/crates/ironrdp-rdpdr/src/pdu/efs.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/efs.rs
@@ -4,7 +4,6 @@
 use bitflags::bitflags;
 use std::fmt::Debug;
 use std::mem::size_of;
-use std::vec;
 
 use ironrdp_pdu::utils::{encoded_str_len, write_string_to_cursor, CharacterSet};
 use ironrdp_pdu::{cast_length, ensure_size, invalid_message_err, PduError};
@@ -229,7 +228,7 @@ impl CoreCapability {
 
         let num_capabilities = payload.read_u16();
         let padding = payload.read_u16();
-        let mut capabilities = vec![];
+        let mut capabilities = Vec::new();
         for _ in 0..num_capabilities {
             capabilities.push(CapabilityMessage::decode(payload)?);
         }
@@ -272,7 +271,7 @@ pub struct Capabilities(Vec<CapabilityMessage>);
 
 impl Capabilities {
     pub fn new() -> Self {
-        let mut this = Self(vec![]);
+        let mut this = Self(Vec::new());
         this.add_general(0);
         this
     }
@@ -758,7 +757,7 @@ pub struct Devices(Vec<DeviceAnnounceHeader>);
 
 impl Devices {
     pub fn new() -> Self {
-        Self(vec![])
+        Self(Vec::new())
     }
 
     pub fn add_smartcard(&mut self, device_id: u32) {
@@ -800,7 +799,7 @@ impl DeviceAnnounceHeader {
             device_id,
             // This name is a constant defined by the spec.
             preferred_dos_name: PreferredDosName("SCARD".to_string()),
-            device_data: vec![],
+            device_data: Vec::new(),
         }
     }
 

--- a/crates/ironrdp-rdpdr/src/pdu/efs.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/efs.rs
@@ -20,6 +20,8 @@ pub enum VersionAndIdPduKind {
     ServerAnnounceRequest,
     /// [2.2.2.3 Client Announce Reply (DR_CORE_CLIENT_ANNOUNCE_RSP)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/d6fe6d1b-c145-4a6f-99aa-4fe3cdcea398)
     ClientAnnounceReply,
+    /// [2.2.2.6 Server Client ID Confirm (DR_CORE_SERVER_CLIENTID_CONFIRM)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/bbbb9666-6994-4cf6-8e65-0d46eb319c6e)
+    ServerClientIdConfirm,
 }
 
 impl VersionAndIdPduKind {
@@ -27,6 +29,7 @@ impl VersionAndIdPduKind {
         match self {
             VersionAndIdPduKind::ServerAnnounceRequest => "DR_CORE_SERVER_ANNOUNCE_REQ",
             VersionAndIdPduKind::ClientAnnounceReply => "DR_CORE_CLIENT_ANNOUNCE_RSP",
+            VersionAndIdPduKind::ServerClientIdConfirm => "DR_CORE_SERVER_CLIENTID_CONFIRM",
         }
     }
 }
@@ -63,7 +66,7 @@ impl VersionAndIdPdu {
         })
     }
 
-    pub fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+    pub fn encode(&self, dst: &mut WriteCursor) -> PduResult<()> {
         ensure_size!(ctx: self.name(), in: dst, size: Self::FIXED_PART_SIZE);
         dst.write_u16(self.version_major);
         dst.write_u16(self.version_minor);
@@ -74,7 +77,7 @@ impl VersionAndIdPdu {
     pub fn decode(header: SharedHeader, src: &mut ReadCursor) -> PduResult<Self> {
         let kind = match header.packet_id {
             PacketId::CoreServerAnnounce => VersionAndIdPduKind::ServerAnnounceRequest,
-            PacketId::CoreClientidConfirm => VersionAndIdPduKind::ClientAnnounceReply,
+            PacketId::CoreClientidConfirm => VersionAndIdPduKind::ServerClientIdConfirm,
             _ => {
                 return Err(invalid_message_err!(
                     "VersionAndIdPdu::decode",
@@ -138,7 +141,7 @@ impl ClientNameRequest {
         }
     }
 
-    pub fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+    pub fn encode(&self, dst: &mut WriteCursor) -> PduResult<()> {
         ensure_size!(in: dst, size: self.size());
         dst.write_u32(self.unicode_flag() as u32);
         dst.write_u32(0); // // CodePage (4 bytes): it MUST be set to 0
@@ -194,7 +197,7 @@ impl CoreCapability {
         }
     }
 
-    pub fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+    pub fn encode(&self, dst: &mut WriteCursor) -> PduResult<()> {
         ensure_size!(ctx: self.name(), in: dst, size: self.size());
         dst.write_u16(cast_length!(
             "CoreCapability",
@@ -319,7 +322,7 @@ impl CapabilityMessage {
         }
     }
 
-    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+    fn encode(&self, dst: &mut WriteCursor) -> PduResult<()> {
         ensure_size!(in: dst, size: self.size());
         self.header.encode(dst)?;
         self.capability_data.encode(dst)
@@ -389,7 +392,7 @@ impl CapabilityHeader {
         })
     }
 
-    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+    fn encode(&self, dst: &mut WriteCursor) -> PduResult<()> {
         ensure_size!(in: dst, size: self.size());
         dst.write_u16(self.cap_type as u16);
         dst.write_u16(self.length);
@@ -449,7 +452,7 @@ enum CapabilityData {
 }
 
 impl CapabilityData {
-    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+    fn encode(&self, dst: &mut WriteCursor) -> PduResult<()> {
         match self {
             CapabilityData::General(general) => general.encode(dst),
             _ => Ok(()),
@@ -517,7 +520,7 @@ impl GeneralCapabilitySet {
     #[allow(clippy::manual_bits)]
     const SIZE: usize = size_of::<u32>() * 8 + size_of::<u16>() * 2;
 
-    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+    fn encode(&self, dst: &mut WriteCursor) -> PduResult<()> {
         ensure_size!(in: dst, size: self.size());
         dst.write_u32(self.os_type);
         dst.write_u32(self.os_version);
@@ -666,3 +669,135 @@ bitflags! {
 /// [2.2.2.3 Client Announce Reply (DR_CORE_CLIENT_ANNOUNCE_RSP)]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/d6fe6d1b-c145-4a6f-99aa-4fe3cdcea398
 const VERSION_MINOR_12: u16 = 0x000C;
 const VERSION_MAJOR: u16 = 0x0001;
+
+/// [2.2.2.9 Client Device List Announce Request (DR_CORE_DEVICELIST_ANNOUNCE_REQ)], [2.2.3.1 Client Device List Announce (DR_DEVICELIST_ANNOUNCE)]
+///
+/// [2.2.2.9 Client Device List Announce Request (DR_CORE_DEVICELIST_ANNOUNCE_REQ)]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/10ef9ada-cba2-4384-ab60-7b6290ed4a9a
+/// [2.2.3.1 Client Device List Announce (DR_DEVICELIST_ANNOUNCE)]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/d8b2bc1c-0207-4c15-abe3-62eaa2afcaf1
+#[derive(Debug)]
+pub struct ClientDeviceListAnnounce {
+    pub device_list: Vec<DeviceAnnounceHeader>,
+}
+
+impl ClientDeviceListAnnounce {
+    const FIXED_PART_SIZE: usize = size_of::<u32>(); // DeviceCount
+
+    pub fn encode(&self, dst: &mut WriteCursor) -> PduResult<()> {
+        dst.write_u32(cast_length!(
+            "ClientDeviceListAnnounce",
+            "DeviceCount",
+            self.device_list.len()
+        )?);
+
+        for dev in self.device_list.iter() {
+            dev.encode(dst)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn name(&self) -> &'static str {
+        "DR_CORE_DEVICELIST_ANNOUNCE_REQ"
+    }
+
+    pub fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.device_list.iter().map(|d| d.size()).sum::<usize>()
+    }
+}
+
+/// [2.2.1.3 Device Announce Header (DEVICE_ANNOUNCE)]
+///
+/// [2.2.1.3 Device Announce Header (DEVICE_ANNOUNCE)]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/32e34332-774b-4ead-8c9d-5d64720d6bf9
+#[derive(Debug)]
+pub struct DeviceAnnounceHeader {
+    device_type: DeviceType,
+    device_id: u32,
+    preferred_dos_name: PreferredDosName,
+    device_data: Vec<u8>,
+}
+
+impl DeviceAnnounceHeader {
+    const FIXED_PART_SIZE: usize = size_of::<u32>() * 3 + 8; // DeviceType, DeviceId, DeviceDataLength, PreferredDosName
+
+    fn encode(&self, dst: &mut WriteCursor) -> PduResult<()> {
+        dst.write_u32(self.device_type as u32);
+        dst.write_u32(self.device_id);
+        self.preferred_dos_name.encode(dst)?;
+        dst.write_u32(cast_length!(
+            "DeviceAnnounceHeader",
+            "DeviceDataLength",
+            self.device_data.len()
+        )?);
+        dst.write_slice(&self.device_data);
+        Ok(())
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.device_data.len()
+    }
+}
+
+/// From ["PreferredDosName"](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/32e34332-774b-4ead-8c9d-5d64720d6bf9):
+///
+/// PreferredDosName (8 bytes): A string of ASCII characters (with a maximum length of eight characters) that represents the name of the device as it appears on the client. This field MUST be null-terminated, so the maximum device name is 7 characters long. The following characters are considered invalid for the PreferredDosName field:
+///
+/// <, >, ", /, \, |
+///
+/// If any of these characters are present, the DR_CORE_DEVICE_ANNOUNC_RSP packet for this device (section 2.2.2.1) will be sent with STATUS_ACCESS_DENIED set in the ResultCode field.
+///
+/// If DeviceType is set to RDPDR_DTYP_SMARTCARD, the PreferredDosName MUST be set to "SCARD".
+///
+/// Note A column character, ":", is valid only when present at the end of the PreferredDosName field, otherwise it is also considered invalid.
+#[derive(Debug)]
+struct PreferredDosName(String);
+
+impl PreferredDosName {
+    fn encode(&self, dst: &mut WriteCursor) -> PduResult<()> {
+        write_string_to_cursor(dst, &self.format(), CharacterSet::Ansi, false)
+    }
+
+    /// Returns the underlying String with a maximum length of 7 characters plus a null terminator.
+    fn format(&self) -> String {
+        let mut name: &str = &self.0;
+        if name.len() > 7 {
+            name = &name[..7];
+        }
+        format!("{name:\x00<8}")
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(u32)]
+pub enum DeviceType {
+    /// RDPDR_DTYP_SERIAL
+    Serial = 0x00000001,
+    /// RDPDR_DTYP_PARALLEL
+    Parallel = 0x00000002,
+    /// RDPDR_DTYP_PRINT
+    Print = 0x00000004,
+    /// RDPDR_DTYP_FILESYSTEM
+    Filesystem = 0x00000008,
+    /// RDPDR_DTYP_SMARTCARD
+    Smartcard = 0x00000020,
+}
+
+impl From<DeviceType> for u32 {
+    fn from(device_type: DeviceType) -> Self {
+        device_type as u32
+    }
+}
+
+impl std::convert::TryFrom<u32> for DeviceType {
+    type Error = PduError;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            0x00000001 => Ok(DeviceType::Serial),
+            0x00000002 => Ok(DeviceType::Parallel),
+            0x00000004 => Ok(DeviceType::Print),
+            0x00000008 => Ok(DeviceType::Filesystem),
+            0x00000020 => Ok(DeviceType::Smartcard),
+            _ => Err(invalid_message_err!("try_from", "DeviceType", "invalid value")),
+        }
+    }
+}

--- a/crates/ironrdp-session/src/active_stage.rs
+++ b/crates/ironrdp-session/src/active_stage.rs
@@ -51,7 +51,7 @@ impl ActiveStage {
         events: &[FastPathInputEvent],
     ) -> SessionResult<Vec<ActiveStageOutput>> {
         if events.is_empty() {
-            return Ok(vec![]);
+            return Ok(Vec::new());
         }
 
         // Mouse move events are prevalent, so we can preallocate space for
@@ -106,7 +106,7 @@ impl ActiveStage {
                 let processor_updates = self.fast_path_processor.process(image, frame, &mut output)?;
                 (output.into_inner(), processor_updates)
             }
-            Action::X224 => (self.x224_processor.process(frame)?, vec![]),
+            Action::X224 => (self.x224_processor.process(frame)?, Vec::new()),
         };
 
         let mut stage_outputs = Vec::new();

--- a/crates/ironrdp-session/src/active_stage.rs
+++ b/crates/ironrdp-session/src/active_stage.rs
@@ -151,6 +151,7 @@ impl ActiveStage {
     }
 }
 
+#[derive(Debug)]
 pub enum ActiveStageOutput {
     ResponseFrame(Vec<u8>),
     GraphicsUpdate(InclusiveRectangle),

--- a/crates/ironrdp-session/src/fast_path.rs
+++ b/crates/ironrdp-session/src/fast_path.rs
@@ -18,6 +18,7 @@ use crate::pointer::PointerCache;
 use crate::utils::CodecId;
 use crate::{rfx, SessionError, SessionErrorExt, SessionResult};
 
+#[derive(Debug)]
 pub enum UpdateKind {
     None,
     Region(InclusiveRectangle),

--- a/crates/ironrdp-session/src/fast_path.rs
+++ b/crates/ironrdp-session/src/fast_path.rs
@@ -73,7 +73,7 @@ impl Processor {
         let update_code = update_pdu.update_code;
 
         let Some(data) = processed_complete_data else {
-            return Ok(vec![]);
+            return Ok(Vec::new());
         };
 
         let update = FastPathUpdate::decode_with_code(data.as_slice(), update_code);

--- a/crates/ironrdp-session/src/rfx.rs
+++ b/crates/ironrdp-session/src/rfx.rs
@@ -29,7 +29,7 @@ impl Default for DecodingContext {
                 flags: rfx::OperatingMode::empty(),
                 entropy_algorithm: rfx::EntropyAlgorithm::Rlgr1,
             },
-            channels: rfx::ChannelsPdu(vec![]),
+            channels: rfx::ChannelsPdu(Vec::new()),
             decoding_tiles: DecodingTileContext::new(),
         }
     }

--- a/crates/ironrdp-session/src/x224/gfx.rs
+++ b/crates/ironrdp-session/src/x224/gfx.rs
@@ -35,7 +35,7 @@ impl Handler {
 
 impl DynamicChannelDataHandler for Handler {
     fn process_complete_data(&mut self, complete_data: Vec<u8>) -> SessionResult<Option<Vec<u8>>> {
-        let mut client_pdu_buffer: Vec<u8> = vec![];
+        let mut client_pdu_buffer: Vec<u8> = Vec::new();
         self.decompressed_buffer.clear();
         self.decompressor
             .decompress(complete_data.as_slice(), &mut self.decompressed_buffer)?;
@@ -97,7 +97,7 @@ bitflags! {
 }
 
 pub fn create_capabilities_advertise(graphics_config: &Option<GraphicsConfig>) -> SessionResult<Vec<u8>> {
-    let mut capabilities = vec![];
+    let mut capabilities = Vec::new();
 
     if let Some(config) = graphics_config {
         let capability_version = CapabilityVersion::from_bits(config.capabilities)

--- a/crates/ironrdp-svc/src/lib.rs
+++ b/crates/ironrdp-svc/src/lib.rs
@@ -87,7 +87,7 @@ assert_obj_safe!(StaticVirtualChannel);
 ///
 /// Each chunk is at most `max_chunk_len` bytes long (not including the Channel PDU Header).
 pub fn chunkify(messages: Vec<SvcMessage>, max_chunk_len: usize) -> PduResult<Vec<WriteBuf>> {
-    let mut results = vec![];
+    let mut results = Vec::new();
     for message in messages {
         results.extend(chunkify_one(message, max_chunk_len)?);
     }

--- a/crates/ironrdp-testsuite-core/tests/pdu/pointer.rs
+++ b/crates/ironrdp-testsuite-core/tests/pdu/pointer.rs
@@ -9,7 +9,7 @@ fn expect_pointer_png(pointer: &DecodedPointer, expected_file_path: &str) {
     let path = format!("{}/test_data/{}", env!("CARGO_MANIFEST_DIR"), expected_file_path);
 
     if std::env::var("UPDATE_EXPECT").unwrap_or_default() == "1" {
-        let mut encoded_png = vec![];
+        let mut encoded_png = Vec::new();
 
         let mut png = png::Encoder::new(&mut encoded_png, pointer.width as u32, pointer.height as u32);
         png.set_color(png::ColorType::Rgba);


### PR DESCRIPTION
Adds handling for `DR_CORE_SERVER_CLIENTID_CONFIRM` and `DR_CORE_DEVICELIST_ANNOUNCE`/`DR_CORE_DEVICELIST_ANNOUNCE_REQ`, the next steps in the rdpdr initialization sequence.