### PR TITLE
refactor: enable elided_lifetimes_in_paths lint

### DIFF
--- a/crates/ironrdp-acceptor/src/connection.rs
+++ b/crates/ironrdp-acceptor/src/connection.rs
@@ -324,7 +324,7 @@ impl Sequence for Acceptor {
                 early_capability,
                 channels,
             } => {
-                let data = pdu::decode::<pdu::mcs::SendDataRequest>(input).map_err(ConnectorError::pdu)?;
+                let data = pdu::decode::<pdu::mcs::SendDataRequest<'_>>(input).map_err(ConnectorError::pdu)?;
 
                 let client_info = rdp::ClientInfoPdu::from_buffer(Cursor::new(data.user_data))?;
 
@@ -421,7 +421,7 @@ impl Sequence for Acceptor {
             }
 
             AcceptorState::CapabilitiesWaitConfirm { channels } => {
-                let data = pdu::decode::<pdu::mcs::SendDataRequest>(input).map_err(ConnectorError::pdu)?;
+                let data = pdu::decode::<pdu::mcs::SendDataRequest<'_>>(input).map_err(ConnectorError::pdu)?;
 
                 let capabilities_confirm = rdp::headers::ShareControlHeader::from_buffer(Cursor::new(data.user_data))?;
 

--- a/crates/ironrdp-acceptor/src/finalization.rs
+++ b/crates/ironrdp-acceptor/src/finalization.rs
@@ -80,7 +80,7 @@ impl Sequence for FinalizationSequence {
     fn step(&mut self, input: &[u8], output: &mut WriteBuf) -> ConnectorResult<Written> {
         let (written, next_state) = match std::mem::take(&mut self.state) {
             FinalizationState::WaitSynchronize => {
-                let data = pdu::decode::<pdu::mcs::SendDataRequest>(input).map_err(ConnectorError::pdu)?;
+                let data = pdu::decode::<pdu::mcs::SendDataRequest<'_>>(input).map_err(ConnectorError::pdu)?;
 
                 let synchronize = rdp::headers::ShareControlHeader::from_buffer(Cursor::new(data.user_data))?;
 
@@ -90,7 +90,7 @@ impl Sequence for FinalizationSequence {
             }
 
             FinalizationState::WaitControlCooperate => {
-                let data = pdu::decode::<pdu::mcs::SendDataRequest>(input).map_err(ConnectorError::pdu)?;
+                let data = pdu::decode::<pdu::mcs::SendDataRequest<'_>>(input).map_err(ConnectorError::pdu)?;
 
                 let cooperate = rdp::headers::ShareControlHeader::from_buffer(Cursor::new(data.user_data))?;
 
@@ -100,7 +100,7 @@ impl Sequence for FinalizationSequence {
             }
 
             FinalizationState::WaitRequestControl => {
-                let data = pdu::decode::<pdu::mcs::SendDataRequest>(input).map_err(ConnectorError::pdu)?;
+                let data = pdu::decode::<pdu::mcs::SendDataRequest<'_>>(input).map_err(ConnectorError::pdu)?;
 
                 let control = rdp::headers::ShareControlHeader::from_buffer(Cursor::new(data.user_data))?;
 
@@ -110,7 +110,7 @@ impl Sequence for FinalizationSequence {
             }
 
             FinalizationState::WaitFontList => {
-                let data = pdu::decode::<pdu::mcs::SendDataRequest>(input).map_err(ConnectorError::pdu)?;
+                let data = pdu::decode::<pdu::mcs::SendDataRequest<'_>>(input).map_err(ConnectorError::pdu)?;
 
                 let font_list = rdp::headers::ShareControlHeader::from_buffer(Cursor::new(data.user_data))?;
 

--- a/crates/ironrdp-cliprdr-native/src/windows/clipboard_impl.rs
+++ b/crates/ironrdp-cliprdr-native/src/windows/clipboard_impl.rs
@@ -74,7 +74,7 @@ impl WinClipboardImpl {
 
     fn on_format_data_response(
         requested_local_format: ClipboardFormatId,
-        response: &FormatDataResponse,
+        response: &FormatDataResponse<'_>,
     ) -> WinCliprdrResult<()> {
         if response.is_error() {
             // No data available for this format anymore

--- a/crates/ironrdp-cliprdr-native/src/windows/cliprdr_backend.rs
+++ b/crates/ironrdp-cliprdr-native/src/windows/cliprdr_backend.rs
@@ -58,7 +58,7 @@ impl CliprdrBackend for WinCliprdrBackend {
         self.send_event(BackendEvent::FormatDataRequest(request));
     }
 
-    fn on_format_data_response(&mut self, response: FormatDataResponse) {
+    fn on_format_data_response(&mut self, response: FormatDataResponse<'_>) {
         self.send_event(BackendEvent::FormatDataResponse(response.into_owned()));
     }
 
@@ -66,7 +66,7 @@ impl CliprdrBackend for WinCliprdrBackend {
         // File transfer not implemented yet
     }
 
-    fn on_file_contents_response(&mut self, _response: FileContentsResponse) {
+    fn on_file_contents_response(&mut self, _response: FileContentsResponse<'_>) {
         // File transfer not implemented yet
     }
 

--- a/crates/ironrdp-cliprdr/src/backend.rs
+++ b/crates/ironrdp-cliprdr/src/backend.rs
@@ -2,7 +2,7 @@
 
 use crate::pdu::{
     ClipboardFormat, ClipboardFormatId, ClipboardGeneralCapabilityFlags, FileContentsRequest, FileContentsResponse,
-    FormatDataRequest, FormatDataResponse, LockDataId,
+    FormatDataRequest, FormatDataResponse, LockDataId, OwnedFormatDataResponse,
 };
 
 pub trait ClipboardError: std::error::Error + Send + Sync + 'static {}
@@ -21,7 +21,7 @@ pub enum ClipboardMessage {
     ///
     /// Client implementation should send format data to `CLIPRDR` SVC when this message is
     /// received.
-    SendFormatData(FormatDataResponse<'static>),
+    SendFormatData(OwnedFormatDataResponse),
 
     /// Sent by clipboard backend when format data in given format is need to be received from
     /// the remote.
@@ -100,7 +100,7 @@ pub trait CliprdrBackend: std::fmt::Debug + Send + Sync + 'static {
     ///
     /// If data is not available anymore, [`FormatDataResponse`] will have its `is_error` field
     /// set to `true`.
-    fn on_format_data_response(&mut self, response: FormatDataResponse);
+    fn on_format_data_response(&mut self, response: FormatDataResponse<'_>);
 
     /// Processes remote's request to send file contents.
     ///
@@ -117,7 +117,7 @@ pub trait CliprdrBackend: std::fmt::Debug + Send + Sync + 'static {
     /// previously sent file contents request.
     ///
     /// If data is not available anymore, then server will send error response instead.
-    fn on_file_contents_response(&mut self, response: FileContentsResponse);
+    fn on_file_contents_response(&mut self, response: FileContentsResponse<'_>);
 
     /// Locks specific data stream in the client clipboard.
     ///

--- a/crates/ironrdp-cliprdr/src/pdu/capabilities.rs
+++ b/crates/ironrdp-cliprdr/src/pdu/capabilities.rs
@@ -1,8 +1,8 @@
 use bitflags::bitflags;
 use ironrdp_pdu::cursor::{ReadCursor, WriteCursor};
 use ironrdp_pdu::{
-    cast_int, cast_length, ensure_fixed_part_size, ensure_size, invalid_message_err, read_padding, write_padding,
-    PduDecode, PduEncode, PduResult,
+    cast_int, cast_length, ensure_fixed_part_size, ensure_size, impl_pdu_pod, invalid_message_err, read_padding,
+    write_padding, PduDecode, PduEncode, PduResult,
 };
 
 use crate::pdu::PartialHeader;
@@ -12,6 +12,8 @@ use crate::pdu::PartialHeader;
 pub struct Capabilities {
     pub capabilities: Vec<CapabilitySet>,
 }
+
+impl_pdu_pod!(Capabilities);
 
 impl Capabilities {
     const NAME: &str = "CLIPRDR_CAPS";
@@ -106,6 +108,8 @@ impl<'de> PduDecode<'de> for Capabilities {
 pub enum CapabilitySet {
     General(GeneralCapabilitySet),
 }
+
+impl_pdu_pod!(CapabilitySet);
 
 impl CapabilitySet {
     const NAME: &str = "CLIPRDR_CAPS_SET";

--- a/crates/ironrdp-cliprdr/src/pdu/client_temporary_directory.rs
+++ b/crates/ironrdp-cliprdr/src/pdu/client_temporary_directory.rs
@@ -2,7 +2,9 @@ use std::borrow::Cow;
 
 use ironrdp_pdu::cursor::{ReadCursor, WriteCursor};
 use ironrdp_pdu::utils::{read_string_from_cursor, write_string_to_cursor, CharacterSet};
-use ironrdp_pdu::{cast_int, ensure_size, invalid_message_err, PduDecode, PduEncode, PduResult};
+use ironrdp_pdu::{
+    cast_int, ensure_size, impl_pdu_borrowing, invalid_message_err, IntoOwnedPdu, PduDecode, PduEncode, PduResult,
+};
 
 use crate::pdu::PartialHeader;
 
@@ -10,6 +12,18 @@ use crate::pdu::PartialHeader;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ClientTemporaryDirectory<'a> {
     path_buffer: Cow<'a, [u8]>,
+}
+
+impl_pdu_borrowing!(ClientTemporaryDirectory<'_>, OwnedClientTemporaryDirectory);
+
+impl IntoOwnedPdu for ClientTemporaryDirectory<'_> {
+    type Owned = OwnedClientTemporaryDirectory;
+
+    fn into_owned_pdu(self) -> Self::Owned {
+        OwnedClientTemporaryDirectory {
+            path_buffer: Cow::Owned(self.path_buffer.into_owned()),
+        }
+    }
 }
 
 impl ClientTemporaryDirectory<'_> {

--- a/crates/ironrdp-cliprdr/src/pdu/file_contents.rs
+++ b/crates/ironrdp-cliprdr/src/pdu/file_contents.rs
@@ -3,7 +3,9 @@ use std::borrow::Cow;
 use bitflags::bitflags;
 use ironrdp_pdu::cursor::{ReadCursor, WriteCursor};
 use ironrdp_pdu::utils::{combine_u64, split_u64};
-use ironrdp_pdu::{cast_int, ensure_size, invalid_message_err, PduDecode, PduEncode, PduResult};
+use ironrdp_pdu::{
+    cast_int, ensure_size, impl_pdu_borrowing, invalid_message_err, IntoOwnedPdu, PduDecode, PduEncode, PduResult,
+};
 
 use crate::pdu::{ClipboardPduFlags, PartialHeader};
 
@@ -30,6 +32,20 @@ pub struct FileContentsResponse<'a> {
     is_error: bool,
     stream_id: u32,
     data: Cow<'a, [u8]>,
+}
+
+impl_pdu_borrowing!(FileContentsResponse<'_>, OwnedFileContentsResponse);
+
+impl IntoOwnedPdu for FileContentsResponse<'_> {
+    type Owned = OwnedFileContentsResponse;
+
+    fn into_owned_pdu(self) -> Self::Owned {
+        OwnedFileContentsResponse {
+            is_error: self.is_error,
+            stream_id: self.stream_id,
+            data: Cow::Owned(self.data.into_owned()),
+        }
+    }
 }
 
 impl<'a> FileContentsResponse<'a> {

--- a/crates/ironrdp-cliprdr/src/pdu/format_data/file_list.rs
+++ b/crates/ironrdp-cliprdr/src/pdu/format_data/file_list.rs
@@ -1,7 +1,7 @@
 use bitflags::bitflags;
 use ironrdp_pdu::cursor::{ReadCursor, WriteCursor};
 use ironrdp_pdu::utils::{combine_u64, read_string_from_cursor, split_u64, write_string_to_cursor, CharacterSet};
-use ironrdp_pdu::{cast_length, ensure_fixed_part_size, PduDecode, PduEncode, PduResult};
+use ironrdp_pdu::{cast_length, ensure_fixed_part_size, impl_pdu_pod, PduDecode, PduEncode, PduResult};
 
 bitflags! {
     /// Represents `flags` field of `CLIPRDR_FILEDESCRIPTOR` structure.
@@ -48,6 +48,8 @@ pub struct FileDescriptor {
     pub file_size: Option<u64>,
     pub name: String,
 }
+
+impl_pdu_pod!(FileDescriptor);
 
 impl FileDescriptor {
     const NAME: &str = "CLIPRDR_FILEDESCRIPTOR";
@@ -157,6 +159,8 @@ impl<'de> PduDecode<'de> for FileDescriptor {
 pub struct PackedFileList {
     pub files: Vec<FileDescriptor>,
 }
+
+impl_pdu_pod!(PackedFileList);
 
 impl PackedFileList {
     const NAME: &str = "CLIPRDR_FILELIST";

--- a/crates/ironrdp-cliprdr/src/pdu/format_data/palette.rs
+++ b/crates/ironrdp-cliprdr/src/pdu/format_data/palette.rs
@@ -1,5 +1,5 @@
 use ironrdp_pdu::cursor::{ReadCursor, WriteCursor};
-use ironrdp_pdu::{PduDecode, PduEncode, PduResult};
+use ironrdp_pdu::{impl_pdu_pod, PduDecode, PduEncode, PduResult};
 
 /// Represents `PALETTEENTRY`
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -21,6 +21,8 @@ impl PaletteEntry {
 pub struct ClipboardPalette {
     pub entries: Vec<PaletteEntry>,
 }
+
+impl_pdu_pod!(ClipboardPalette);
 
 impl ClipboardPalette {
     const NAME: &str = "CLIPRDR_PALETTE";

--- a/crates/ironrdp-cliprdr/src/pdu/lock.rs
+++ b/crates/ironrdp-cliprdr/src/pdu/lock.rs
@@ -1,11 +1,13 @@
 use ironrdp_pdu::cursor::{ReadCursor, WriteCursor};
-use ironrdp_pdu::{cast_int, ensure_fixed_part_size, PduDecode, PduEncode, PduResult};
+use ironrdp_pdu::{cast_int, ensure_fixed_part_size, impl_pdu_pod, PduDecode, PduEncode, PduResult};
 
 use crate::pdu::PartialHeader;
 
 /// Represents `CLIPRDR_LOCK_CLIPDATA`/`CLIPRDR_UNLOCK_CLIPDATA`
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LockDataId(pub u32);
+
+impl_pdu_pod!(LockDataId);
 
 impl LockDataId {
     const NAME: &str = "CLIPRDR_(UN)LOCK_CLIPDATA";

--- a/crates/ironrdp-connector/src/legacy.rs
+++ b/crates/ironrdp-connector/src/legacy.rs
@@ -31,7 +31,7 @@ where
     T: PduParsing,
     ConnectorError: From<T::Error>,
 {
-    let x224_payload = ironrdp_pdu::decode::<x224::X224Data>(src).map_err(ConnectorError::pdu)?;
+    let x224_payload = ironrdp_pdu::decode::<x224::X224Data<'_>>(src).map_err(ConnectorError::pdu)?;
     let x224_msg = T::from_buffer(x224_payload.data.as_ref())?;
     Ok(x224_msg)
 }
@@ -83,7 +83,7 @@ impl SendDataIndicationCtx<'_> {
 pub fn decode_send_data_indication(src: &[u8]) -> ConnectorResult<SendDataIndicationCtx<'_>> {
     use ironrdp_pdu::mcs::McsMessage;
 
-    let mcs_msg = ironrdp_pdu::decode::<McsMessage>(src).map_err(ConnectorError::pdu)?;
+    let mcs_msg = ironrdp_pdu::decode::<McsMessage<'_>>(src).map_err(ConnectorError::pdu)?;
 
     match mcs_msg {
         McsMessage::SendDataIndication(msg) => {

--- a/crates/ironrdp-fuzzing/src/oracles/mod.rs
+++ b/crates/ironrdp-fuzzing/src/oracles/mod.rs
@@ -20,7 +20,7 @@ pub fn pdu_decode(data: &[u8]) {
 
     let _ = decode::<ConnectionRequest>(data);
     let _ = decode::<ConnectionConfirm>(data);
-    let _ = decode::<McsMessage>(data);
+    let _ = decode::<McsMessage<'_>>(data);
     let _ = ConnectInitial::from_buffer(data);
     let _ = ConnectResponse::from_buffer(data);
     let _ = ClientInfoPdu::from_buffer(data);
@@ -45,13 +45,13 @@ pub fn pdu_decode(data: &[u8]) {
     let _ = vc::ChannelPduHeader::from_buffer(data);
 
     let _ = decode::<fast_path::FastPathHeader>(data);
-    let _ = decode::<fast_path::FastPathUpdatePdu>(data);
+    let _ = decode::<fast_path::FastPathUpdatePdu<'_>>(data);
     let _ = fast_path::FastPathUpdate::decode_with_code(data, fast_path::UpdateCode::SurfaceCommands);
 
-    let _ = decode::<surface_commands::SurfaceCommand>(data);
-    let _ = decode::<surface_commands::SurfaceBitsPdu>(data);
+    let _ = decode::<surface_commands::SurfaceCommand<'_>>(data);
+    let _ = decode::<surface_commands::SurfaceBitsPdu<'_>>(data);
     let _ = decode::<surface_commands::FrameMarkerPdu>(data);
-    let _ = decode::<surface_commands::ExtendedBitmapDataPdu>(data);
+    let _ = decode::<surface_commands::ExtendedBitmapDataPdu<'_>>(data);
     let _ = decode::<surface_commands::BitmapDataHeader>(data);
 
     let _ = codecs::rfx::Headers::from_buffer(data);
@@ -72,14 +72,14 @@ pub fn pdu_decode(data: &[u8]) {
     let _ = input::InputEventPdu::from_buffer(data);
     let _ = input::InputEvent::from_buffer(data);
 
-    let _ = decode::<bitmap::rdp6::BitmapStream>(data);
+    let _ = decode::<bitmap::rdp6::BitmapStream<'_>>(data);
 
-    let _ = decode::<ironrdp_cliprdr::pdu::ClipboardPdu>(data);
+    let _ = decode::<ironrdp_cliprdr::pdu::ClipboardPdu<'_>>(data);
 
     let _ = decode::<ironrdp_rdpdr::pdu::RdpdrPdu>(data);
 }
 
-pub fn rle_decompress_bitmap(input: BitmapInput) {
+pub fn rle_decompress_bitmap(input: BitmapInput<'_>) {
     let mut out = Vec::new();
 
     let _ = ironrdp_graphics::rle::decompress_24_bpp(input.src, &mut out, input.width, input.height);
@@ -88,7 +88,7 @@ pub fn rle_decompress_bitmap(input: BitmapInput) {
     let _ = ironrdp_graphics::rle::decompress_8_bpp(input.src, &mut out, input.width, input.height);
 }
 
-pub fn rdp6_encode_bitmap_stream(input: &BitmapInput) {
+pub fn rdp6_encode_bitmap_stream(input: &BitmapInput<'_>) {
     use ironrdp_graphics::rdp6::{BitmapStreamEncoder, RgbAChannels, RgbChannels};
 
     let mut out = vec![0; input.src.len() * 2];
@@ -106,7 +106,7 @@ pub fn rdp6_encode_bitmap_stream(input: &BitmapInput) {
     );
 }
 
-pub fn rdp6_decode_bitmap_stream_to_rgb24(input: &BitmapInput) {
+pub fn rdp6_decode_bitmap_stream_to_rgb24(input: &BitmapInput<'_>) {
     use ironrdp_graphics::rdp6::BitmapStreamDecoder;
 
     let mut out = Vec::new();

--- a/crates/ironrdp-graphics/src/pointer.rs
+++ b/crates/ironrdp-graphics/src/pointer.rs
@@ -58,7 +58,7 @@ impl DecodedPointer {
         }
     }
 
-    pub fn decode_pointer_attribute(src: &PointerAttribute) -> Result<Self, PointerError> {
+    pub fn decode_pointer_attribute(src: &PointerAttribute<'_>) -> Result<Self, PointerError> {
         Self::decode_pointer(PointerData {
             width: src.color_pointer.width as usize,
             height: src.color_pointer.height as usize,
@@ -70,7 +70,7 @@ impl DecodedPointer {
         })
     }
 
-    pub fn decode_color_pointer_attribute(src: &ColorPointerAttribute) -> Result<Self, PointerError> {
+    pub fn decode_color_pointer_attribute(src: &ColorPointerAttribute<'_>) -> Result<Self, PointerError> {
         Self::decode_pointer(PointerData {
             width: src.width as usize,
             height: src.height as usize,
@@ -82,7 +82,7 @@ impl DecodedPointer {
         })
     }
 
-    pub fn decode_large_pointer_attribute(src: &LargePointerAttribute) -> Result<Self, PointerError> {
+    pub fn decode_large_pointer_attribute(src: &LargePointerAttribute<'_>) -> Result<Self, PointerError> {
         Self::decode_pointer(PointerData {
             width: src.width as usize,
             height: src.height as usize,

--- a/crates/ironrdp-graphics/src/rdp6/bitmap_stream/decoder.rs
+++ b/crates/ironrdp-graphics/src/rdp6/bitmap_stream/decoder.rs
@@ -258,7 +258,7 @@ impl BitmapStreamDecoder {
         image_width: usize,
         image_height: usize,
     ) -> Result<(), BitmapDecodeError> {
-        let bitmap = decode::<BitmapStreamPdu>(bitmap_data)?;
+        let bitmap = decode::<BitmapStreamPdu<'_>>(bitmap_data)?;
 
         let decoder = BitmapStreamDecoderImpl::init(bitmap, image_width, image_height);
 

--- a/crates/ironrdp-pdu/src/basic_output/bitmap.rs
+++ b/crates/ironrdp-pdu/src/basic_output/bitmap.rs
@@ -176,7 +176,7 @@ impl<'de> PduDecode<'de> for BitmapData<'de> {
 }
 
 impl Debug for BitmapData<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("BitmapData")
             .field("rectangle", &self.rectangle)
             .field("width", &self.width)

--- a/crates/ironrdp-pdu/src/basic_output/fast_path.rs
+++ b/crates/ironrdp-pdu/src/basic_output/fast_path.rs
@@ -232,7 +232,7 @@ impl<'a> FastPathUpdate<'a> {
             UpdateCode::SurfaceCommands => {
                 let mut commands = Vec::with_capacity(1);
                 while src.len() >= SURFACE_COMMAND_HEADER_SIZE {
-                    commands.push(decode_cursor::<SurfaceCommand>(src)?);
+                    commands.push(decode_cursor::<SurfaceCommand<'_>>(src)?);
                 }
 
                 Ok(Self::SurfaceCommands(commands))

--- a/crates/ironrdp-pdu/src/cursor.rs
+++ b/crates/ironrdp-pdu/src/cursor.rs
@@ -1,190 +1,253 @@
 use crate::PduResult;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ReadCursor<'a> {
     inner: &'a [u8],
     pos: usize,
 }
 
 impl<'a> ReadCursor<'a> {
+    #[inline]
     pub const fn new(bytes: &'a [u8]) -> Self {
         Self { inner: bytes, pos: 0 }
     }
 
+    #[inline]
+    #[track_caller]
     pub const fn len(&self) -> usize {
         self.inner.len() - self.pos
     }
 
+    #[inline]
     pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
+    #[inline]
     pub const fn eof(&self) -> bool {
         self.is_empty()
     }
 
+    #[inline]
+    #[track_caller]
     pub fn remaining(&self) -> &[u8] {
         &self.inner[self.pos..]
     }
 
+    #[inline]
     pub const fn inner(&self) -> &[u8] {
         self.inner
     }
 
+    #[inline]
     pub const fn pos(&self) -> usize {
         self.pos
     }
 
+    #[inline]
+    #[track_caller]
     pub fn read_array<const N: usize>(&mut self) -> [u8; N] {
         let bytes = &self.inner[self.pos..self.pos + N];
         self.pos += N;
         bytes.try_into().expect("N-elements array")
     }
 
+    #[inline]
+    #[track_caller]
     pub fn read_slice(&mut self, n: usize) -> &'a [u8] {
         let bytes = &self.inner[self.pos..self.pos + n];
         self.pos += n;
         bytes
     }
 
+    #[inline]
+    #[track_caller]
     pub fn read_u8(&mut self) -> u8 {
         self.read_array::<1>()[0]
     }
 
+    #[inline]
     pub fn try_read_u8(&mut self, ctx: &'static str) -> PduResult<u8> {
         ensure_size!(ctx: ctx, in: self, size: 1);
         Ok(self.read_array::<1>()[0])
     }
 
+    #[inline]
+    #[track_caller]
     pub fn read_u16(&mut self) -> u16 {
         u16::from_le_bytes(self.read_array::<2>())
     }
 
+    #[inline]
+    #[track_caller]
     pub fn read_u16_be(&mut self) -> u16 {
         u16::from_be_bytes(self.read_array::<2>())
     }
 
+    #[inline]
     pub fn try_read_u16(&mut self, ctx: &'static str) -> PduResult<u16> {
         ensure_size!(ctx: ctx, in: self, size: 2);
         Ok(u16::from_le_bytes(self.read_array::<2>()))
     }
 
+    #[inline]
     pub fn try_read_u16_be(&mut self, ctx: &'static str) -> PduResult<u16> {
         ensure_size!(ctx: ctx, in: self, size: 2);
         Ok(u16::from_be_bytes(self.read_array::<2>()))
     }
 
+    #[inline]
+    #[track_caller]
     pub fn read_u32(&mut self) -> u32 {
         u32::from_le_bytes(self.read_array::<4>())
     }
 
+    #[inline]
+    #[track_caller]
     pub fn read_u32_be(&mut self) -> u32 {
         u32::from_be_bytes(self.read_array::<4>())
     }
 
+    #[inline]
     pub fn try_read_u32(&mut self, ctx: &'static str) -> PduResult<u32> {
         ensure_size!(ctx: ctx, in: self, size: 4);
         Ok(u32::from_le_bytes(self.read_array::<4>()))
     }
 
+    #[inline]
     pub fn try_read_u32_be(&mut self, ctx: &'static str) -> PduResult<u32> {
         ensure_size!(ctx: ctx, in: self, size: 4);
         Ok(u32::from_be_bytes(self.read_array::<4>()))
     }
 
+    #[inline]
+    #[track_caller]
     pub fn read_u64(&mut self) -> u64 {
         u64::from_le_bytes(self.read_array::<8>())
     }
 
+    #[inline]
+    #[track_caller]
     pub fn read_u64_be(&mut self) -> u64 {
         u64::from_be_bytes(self.read_array::<8>())
     }
 
+    #[inline]
     pub fn try_read_u64(&mut self, ctx: &'static str) -> PduResult<u64> {
         ensure_size!(ctx: ctx, in: self, size: 8);
         Ok(u64::from_le_bytes(self.read_array::<8>()))
     }
 
+    #[inline]
     pub fn try_read_u64_be(&mut self, ctx: &'static str) -> PduResult<u64> {
         ensure_size!(ctx: ctx, in: self, size: 8);
         Ok(u64::from_be_bytes(self.read_array::<8>()))
     }
 
+    #[inline]
+    #[track_caller]
     pub fn peek<const N: usize>(&mut self) -> [u8; N] {
         self.inner[self.pos..self.pos + N].try_into().expect("N-elements array")
     }
 
+    #[inline]
+    #[track_caller]
     pub fn peek_slice(&mut self, n: usize) -> &'a [u8] {
         &self.inner[self.pos..self.pos + n]
     }
 
+    #[inline]
+    #[track_caller]
     pub fn peek_u8(&mut self) -> u8 {
         self.peek::<1>()[0]
     }
 
+    #[inline]
     pub fn try_peek_u8(&mut self, ctx: &'static str) -> PduResult<u8> {
         ensure_size!(ctx: ctx, in: self, size: 1);
         Ok(self.peek::<1>()[0])
     }
 
+    #[inline]
+    #[track_caller]
     pub fn peek_u16(&mut self) -> u16 {
         u16::from_le_bytes(self.peek::<2>())
     }
 
+    #[inline]
+    #[track_caller]
     pub fn peek_u16_be(&mut self) -> u16 {
         u16::from_be_bytes(self.peek::<2>())
     }
 
+    #[inline]
     pub fn try_peek_u16(&mut self, ctx: &'static str) -> PduResult<u16> {
         ensure_size!(ctx: ctx, in: self, size: 2);
         Ok(u16::from_le_bytes(self.peek::<2>()))
     }
 
+    #[inline]
     pub fn try_peek_u16_be(&mut self, ctx: &'static str) -> PduResult<u16> {
         ensure_size!(ctx: ctx, in: self, size: 2);
         Ok(u16::from_be_bytes(self.peek::<2>()))
     }
 
+    #[inline]
+    #[track_caller]
     pub fn peek_u32(&mut self) -> u32 {
         u32::from_le_bytes(self.peek::<4>())
     }
 
+    #[inline]
+    #[track_caller]
     pub fn peek_u32_be(&mut self) -> u32 {
         u32::from_be_bytes(self.peek::<4>())
     }
 
+    #[inline]
     pub fn try_peek_u32(&mut self, ctx: &'static str) -> PduResult<u32> {
         ensure_size!(ctx: ctx, in: self, size: 4);
         Ok(u32::from_le_bytes(self.peek::<4>()))
     }
 
+    #[inline]
     pub fn try_peek_u32_be(&mut self, ctx: &'static str) -> PduResult<u32> {
         ensure_size!(ctx: ctx, in: self, size: 4);
         Ok(u32::from_be_bytes(self.peek::<4>()))
     }
 
+    #[inline]
+    #[track_caller]
     pub fn peek_u64(&mut self) -> u64 {
         u64::from_le_bytes(self.peek::<8>())
     }
 
+    #[inline]
+    #[track_caller]
     pub fn peek_u64_be(&mut self) -> u64 {
         u64::from_be_bytes(self.peek::<8>())
     }
 
+    #[inline]
     pub fn try_peek_u64(&mut self, ctx: &'static str) -> PduResult<u64> {
         ensure_size!(ctx: ctx, in: self, size: 8);
         Ok(u64::from_le_bytes(self.peek::<8>()))
     }
 
+    #[inline]
     pub fn try_peek_u64_be(&mut self, ctx: &'static str) -> PduResult<u64> {
         ensure_size!(ctx: ctx, in: self, size: 8);
         Ok(u64::from_be_bytes(self.peek::<8>()))
     }
 
+    #[inline]
+    #[track_caller]
     pub fn advance(&mut self, len: usize) {
         self.pos += len;
     }
 
+    #[inline]
+    #[track_caller]
     #[must_use]
     pub const fn advanced(&'a self, len: usize) -> ReadCursor<'a> {
         ReadCursor {
@@ -193,10 +256,14 @@ impl<'a> ReadCursor<'a> {
         }
     }
 
+    #[inline]
+    #[track_caller]
     pub fn rewind(&mut self, len: usize) {
         self.pos -= len;
     }
 
+    #[inline]
+    #[track_caller]
     #[must_use]
     pub const fn rewinded(&'a self, len: usize) -> ReadCursor<'a> {
         ReadCursor {
@@ -223,85 +290,119 @@ pub struct WriteCursor<'a> {
 }
 
 impl<'a> WriteCursor<'a> {
+    #[inline]
     pub fn new(bytes: &'a mut [u8]) -> Self {
         Self { inner: bytes, pos: 0 }
     }
 
+    #[inline]
+    #[track_caller]
     pub const fn len(&self) -> usize {
         self.inner.len() - self.pos
     }
 
+    #[inline]
     pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
+    #[inline]
     pub const fn eof(&self) -> bool {
         self.is_empty()
     }
 
+    #[inline]
+    #[track_caller]
     pub fn remaining(&self) -> &[u8] {
         &self.inner[self.pos..]
     }
 
+    #[inline]
+    #[track_caller]
     pub fn remaining_mut(&mut self) -> &mut [u8] {
         &mut self.inner[self.pos..]
     }
 
+    #[inline]
     pub const fn inner(&self) -> &[u8] {
         self.inner
     }
 
+    #[inline]
     pub fn inner_mut(&mut self) -> &mut [u8] {
         self.inner
     }
 
+    #[inline]
     pub const fn pos(&self) -> usize {
         self.pos
     }
 
+    #[inline]
+    #[track_caller]
     pub fn write_array<const N: usize>(&mut self, array: [u8; N]) {
         self.inner[self.pos..self.pos + N].copy_from_slice(&array);
         self.pos += N;
     }
 
+    #[inline]
+    #[track_caller]
     pub fn write_slice(&mut self, slice: &[u8]) {
         let n = slice.len();
         self.inner[self.pos..self.pos + n].copy_from_slice(slice);
         self.pos += n;
     }
 
+    #[inline]
+    #[track_caller]
     pub fn write_u8(&mut self, value: u8) {
         self.write_array(value.to_le_bytes())
     }
 
+    #[inline]
+    #[track_caller]
     pub fn write_u16(&mut self, value: u16) {
         self.write_array(value.to_le_bytes())
     }
 
+    #[inline]
+    #[track_caller]
     pub fn write_u16_be(&mut self, value: u16) {
         self.write_array(value.to_be_bytes())
     }
 
+    #[inline]
+    #[track_caller]
     pub fn write_u32(&mut self, value: u32) {
         self.write_array(value.to_le_bytes())
     }
 
+    #[inline]
+    #[track_caller]
     pub fn write_u32_be(&mut self, value: u32) {
         self.write_array(value.to_be_bytes())
     }
 
+    #[inline]
+    #[track_caller]
     pub fn write_u64(&mut self, value: u64) {
         self.write_array(value.to_le_bytes())
     }
 
+    #[inline]
+    #[track_caller]
     pub fn write_u64_be(&mut self, value: u64) {
         self.write_array(value.to_be_bytes())
     }
 
+    #[inline]
+    #[track_caller]
     pub fn advance(&mut self, len: usize) {
         self.pos += len;
     }
 
+    #[inline]
+    #[track_caller]
     #[must_use]
     pub fn advanced(&'a mut self, len: usize) -> WriteCursor<'a> {
         WriteCursor {
@@ -310,10 +411,14 @@ impl<'a> WriteCursor<'a> {
         }
     }
 
+    #[inline]
+    #[track_caller]
     pub fn rewind(&mut self, len: usize) {
         self.pos -= len;
     }
 
+    #[inline]
+    #[track_caller]
     #[must_use]
     pub fn rewinded(&'a mut self, len: usize) -> WriteCursor<'a> {
         WriteCursor {
@@ -325,11 +430,13 @@ impl<'a> WriteCursor<'a> {
 
 #[cfg(feature = "std")]
 impl std::io::Write for WriteCursor<'_> {
+    #[inline]
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         self.write_slice(buf);
         Ok(buf.len())
     }
 
+    #[inline]
     fn flush(&mut self) -> std::io::Result<()> {
         Ok(())
     }

--- a/crates/ironrdp-pdu/src/macros.rs
+++ b/crates/ironrdp-pdu/src/macros.rs
@@ -219,12 +219,12 @@ macro_rules! impl_pdu_pod {
 /// Implements additional traits for a borrowing PDU and defines a static-bounded owned version.
 #[macro_export]
 macro_rules! impl_pdu_borrowing {
-    ($pdu_ty:ident, $owned_ty:ident) => {
+    ($pdu_ty:ident $(<$($lt:lifetime),+>)?, $owned_ty:ident) => {
         pub type $owned_ty = $pdu_ty<'static>;
 
         impl $crate::PduDecodeOwned for $owned_ty {
             fn decode_owned(src: &mut $crate::cursor::ReadCursor<'_>) -> $crate::PduResult<Self> {
-                let pdu = <$pdu_ty as $crate::PduDecode>::decode(src)?;
+                let pdu = <$pdu_ty $(<$($lt),+>)? as $crate::PduDecode>::decode(src)?;
                 Ok($crate::IntoOwnedPdu::into_owned_pdu(pdu))
             }
         }

--- a/crates/ironrdp-pdu/src/mcs.rs
+++ b/crates/ironrdp-pdu/src/mcs.rs
@@ -272,7 +272,7 @@ pub enum McsMessage<'a> {
     DisconnectProviderUltimatum(DisconnectProviderUltimatum),
 }
 
-impl_pdu_borrowing!(McsMessage, OwnedMcsMessage);
+impl_pdu_borrowing!(McsMessage<'_>, OwnedMcsMessage);
 
 impl IntoOwnedPdu for McsMessage<'_> {
     type Owned = OwnedMcsMessage;
@@ -555,7 +555,7 @@ pub struct SendDataRequest<'a> {
     pub user_data: Cow<'a, [u8]>,
 }
 
-impl_pdu_borrowing!(SendDataRequest, OwnedSendDataRequest);
+impl_pdu_borrowing!(SendDataRequest<'_>, OwnedSendDataRequest);
 
 impl IntoOwnedPdu for SendDataRequest<'_> {
     type Owned = OwnedSendDataRequest;
@@ -636,7 +636,7 @@ pub struct SendDataIndication<'a> {
     pub user_data: Cow<'a, [u8]>,
 }
 
-impl_pdu_borrowing!(SendDataIndication, OwnedSendDataIndication);
+impl_pdu_borrowing!(SendDataIndication<'_>, OwnedSendDataIndication);
 
 impl IntoOwnedPdu for SendDataIndication<'_> {
     type Owned = OwnedSendDataIndication;

--- a/crates/ironrdp-pdu/src/padding.rs
+++ b/crates/ironrdp-pdu/src/padding.rs
@@ -32,6 +32,7 @@ pub fn write(dst: &mut WriteCursor<'_>, mut n: usize) {
 }
 
 /// Moves read cursor, ignoring padding bytes.
+#[inline]
 pub fn read(src: &mut ReadCursor<'_>, n: usize) {
     src.advance(n);
 }

--- a/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx/graphics_messages/server.rs
+++ b/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx/graphics_messages/server.rs
@@ -25,7 +25,7 @@ pub struct WireToSurface1Pdu {
 }
 
 impl fmt::Debug for WireToSurface1Pdu {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("WireToSurface1Pdu")
             .field("surface_id", &self.surface_id)
             .field("codec_id", &self.codec_id)
@@ -82,7 +82,7 @@ pub struct WireToSurface2Pdu {
 }
 
 impl fmt::Debug for WireToSurface2Pdu {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("WireToSurface2Pdu")
             .field("surface_id", &self.surface_id)
             .field("codec_id", &self.codec_id)

--- a/crates/ironrdp-pdu/src/write_buf.rs
+++ b/crates/ironrdp-pdu/src/write_buf.rs
@@ -24,6 +24,7 @@ impl WriteBuf {
     /// Constructs a new, empty `WriteBuf`.
     ///
     /// The underlying buffer will not allocate until bytes are written to it.
+    #[inline]
     pub const fn new() -> Self {
         Self {
             inner: Vec::new(),
@@ -31,6 +32,7 @@ impl WriteBuf {
         }
     }
 
+    #[inline]
     pub const fn from_vec(buffer: Vec<u8>) -> Self {
         Self {
             inner: buffer,
@@ -38,6 +40,7 @@ impl WriteBuf {
         }
     }
 
+    #[inline]
     pub fn into_inner(self) -> Vec<u8> {
         self.inner
     }
@@ -45,16 +48,19 @@ impl WriteBuf {
     /// Returns length of the filled region.
     ///
     /// This is always equal to the starting index for the unfilled initialized portion of the buffer.
+    #[inline]
     pub const fn filled_len(&self) -> usize {
         self.filled
     }
 
     /// Returns a shared reference to the filled portion of the buffer.
+    #[inline]
     pub fn filled(&self) -> &[u8] {
         &self.inner[..self.filled]
     }
 
     /// Ensures initialized and unfilled portion of the buffer is big enough for `additional` more bytes.
+    #[inline]
     pub fn initialize(&mut self, additional: usize) {
         if self.inner.len() < self.filled + additional {
             self.inner.resize(self.filled + additional, 0);
@@ -63,22 +69,26 @@ impl WriteBuf {
 
     /// Returns a mutable reference to the first n bytes of the unfilled part of the buffer,
     /// allocating additional memory as necessary.
+    #[inline]
     pub fn unfilled_to(&mut self, n: usize) -> &mut [u8] {
         self.initialize(n);
         &mut self.inner[self.filled..self.filled + n]
     }
 
     /// Returns a mutable reference to the unfilled part of the buffer.
+    #[inline]
     pub fn unfilled_mut(&mut self) -> &mut [u8] {
         &mut self.inner[self.filled..]
     }
 
+    #[inline]
     pub fn write_array<const N: usize>(&mut self, array: [u8; N]) {
         self.initialize(N);
         self.inner[self.filled..self.filled + N].copy_from_slice(&array);
         self.filled += N;
     }
 
+    #[inline]
     pub fn write_slice(&mut self, slice: &[u8]) {
         let n = slice.len();
         self.initialize(n);
@@ -86,30 +96,37 @@ impl WriteBuf {
         self.filled += n;
     }
 
+    #[inline]
     pub fn write_u8(&mut self, value: u8) {
         self.write_array(value.to_le_bytes())
     }
 
+    #[inline]
     pub fn write_u16(&mut self, value: u16) {
         self.write_array(value.to_le_bytes())
     }
 
+    #[inline]
     pub fn write_u16_be(&mut self, value: u16) {
         self.write_array(value.to_be_bytes())
     }
 
+    #[inline]
     pub fn write_u32(&mut self, value: u32) {
         self.write_array(value.to_le_bytes())
     }
 
+    #[inline]
     pub fn write_u32_be(&mut self, value: u32) {
         self.write_array(value.to_be_bytes())
     }
 
+    #[inline]
     pub fn write_u64(&mut self, value: u64) {
         self.write_array(value.to_le_bytes())
     }
 
+    #[inline]
     pub fn write_u64_be(&mut self, value: u64) {
         self.write_array(value.to_be_bytes())
     }
@@ -117,12 +134,14 @@ impl WriteBuf {
     /// Set the filled cursor to the very beginning of the buffer.
     ///
     /// If the buffer grew big, it is shrunk in order to reclaim memory.
+    #[inline]
     pub fn clear(&mut self) {
         self.filled = 0;
         self.inner.shrink_to(MAX_CAPACITY_WHEN_CLEARED);
     }
 
     /// Advances the buffer’s cursor of `len` bytes.
+    #[inline]
     pub fn advance(&mut self, len: usize) {
         self.filled += len;
         debug_assert!(self.filled <= self.inner.len());
@@ -131,11 +150,13 @@ impl WriteBuf {
 
 #[cfg(feature = "std")]
 impl std::io::Write for WriteBuf {
+    #[inline]
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         self.write_slice(buf);
         Ok(buf.len())
     }
 
+    #[inline]
     fn flush(&mut self) -> std::io::Result<()> {
         Ok(())
     }
@@ -146,6 +167,7 @@ impl std::io::Write for WriteBuf {
 impl Index<Range<usize>> for WriteBuf {
     type Output = [u8];
 
+    #[inline]
     fn index(&self, range: Range<usize>) -> &Self::Output {
         &self.filled()[range]
     }
@@ -154,6 +176,7 @@ impl Index<Range<usize>> for WriteBuf {
 impl Index<RangeFrom<usize>> for WriteBuf {
     type Output = [u8];
 
+    #[inline]
     fn index(&self, range: RangeFrom<usize>) -> &Self::Output {
         &self.filled()[range]
     }
@@ -162,6 +185,7 @@ impl Index<RangeFrom<usize>> for WriteBuf {
 impl Index<RangeFull> for WriteBuf {
     type Output = [u8];
 
+    #[inline]
     fn index(&self, _: RangeFull) -> &Self::Output {
         self.filled()
     }
@@ -170,6 +194,7 @@ impl Index<RangeFull> for WriteBuf {
 impl Index<RangeInclusive<usize>> for WriteBuf {
     type Output = [u8];
 
+    #[inline]
     fn index(&self, range: RangeInclusive<usize>) -> &Self::Output {
         &self.filled()[range]
     }
@@ -178,6 +203,7 @@ impl Index<RangeInclusive<usize>> for WriteBuf {
 impl Index<RangeTo<usize>> for WriteBuf {
     type Output = [u8];
 
+    #[inline]
     fn index(&self, range: RangeTo<usize>) -> &Self::Output {
         &self.filled()[range]
     }
@@ -186,6 +212,7 @@ impl Index<RangeTo<usize>> for WriteBuf {
 impl Index<RangeToInclusive<usize>> for WriteBuf {
     type Output = [u8];
 
+    #[inline]
     fn index(&self, range: RangeToInclusive<usize>) -> &Self::Output {
         &self.filled()[range]
     }

--- a/crates/ironrdp-pdu/src/x224.rs
+++ b/crates/ironrdp-pdu/src/x224.rs
@@ -90,7 +90,7 @@ pub struct X224Data<'a> {
     pub data: Cow<'a, [u8]>,
 }
 
-impl_pdu_borrowing!(X224Data, OwnedX224Data);
+impl_pdu_borrowing!(X224Data<'_>, OwnedX224Data);
 
 impl IntoOwnedPdu for X224Data<'_> {
     type Owned = OwnedX224Data;

--- a/crates/ironrdp-rdpdr/src/pdu/esc.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/esc.rs
@@ -183,8 +183,8 @@ impl IoCtlCode for ScardIoCtlCode {}
 pub struct ScardAccessStartedEventCall;
 
 impl ScardAccessStartedEventCall {
-    pub fn decode(payload: &mut ReadCursor<'_>) -> PduResult<Self> {
-        ironrdp_pdu::read_padding!(payload, 4); // Unused (4 bytes)
+    pub fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        ironrdp_pdu::read_padding!(src, 4); // Unused (4 bytes)
         Ok(Self)
     }
 }

--- a/crates/ironrdp-rdpdr/src/pdu/mod.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/mod.rs
@@ -184,14 +184,14 @@ impl SharedHeader {
     const NAME: &str = "RDPDR_HEADER";
     const SIZE: usize = size_of::<u16>() * 2;
 
-    fn encode(&self, dst: &mut WriteCursor) -> PduResult<()> {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
         ensure_size!(in: dst, size: Self::SIZE);
         dst.write_u16(self.component.into());
         dst.write_u16(self.packet_id.into());
         Ok(())
     }
 
-    pub fn decode(src: &mut ReadCursor) -> PduResult<Self> {
+    pub fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
         ensure_size!(in: src, size: Self::SIZE);
         Ok(Self {
             component: src.read_u16().try_into()?,

--- a/crates/ironrdp-server/src/encoder/mod.rs
+++ b/crates/ironrdp-server/src/encoder/mod.rs
@@ -27,7 +27,7 @@ impl UpdateEncoder {
         }
     }
 
-    pub(crate) fn bitmap(&mut self, bitmap: BitmapUpdate) -> Option<UpdateFragmenter> {
+    pub(crate) fn bitmap(&mut self, bitmap: BitmapUpdate) -> Option<UpdateFragmenter<'_>> {
         let len = loop {
             match self.bitmap.encode(&bitmap, self.buffer.as_mut_slice()) {
                 Err(e) => match e.kind() {

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -211,7 +211,7 @@ impl RdpServer {
     }
 
     async fn handle_x224(&mut self, frame: BytesMut) -> Result<bool> {
-        let message = ironrdp_pdu::decode::<mcs::McsMessage>(&frame)?;
+        let message = ironrdp_pdu::decode::<mcs::McsMessage<'_>>(&frame)?;
         match message {
             mcs::McsMessage::SendDataRequest(data) => {
                 let control = rdp::headers::ShareControlHeader::from_buffer(Cursor::new(data.user_data))?;

--- a/crates/ironrdp-session/src/fast_path.rs
+++ b/crates/ironrdp-session/src/fast_path.rs
@@ -63,7 +63,7 @@ impl Processor {
         let header = decode_cursor::<FastPathHeader>(&mut input).map_err(SessionError::pdu)?;
         debug!(fast_path_header = ?header, "Received Fast-Path packet");
 
-        let update_pdu = decode_cursor::<FastPathUpdatePdu>(&mut input).map_err(SessionError::pdu)?;
+        let update_pdu = decode_cursor::<FastPathUpdatePdu<'_>>(&mut input).map_err(SessionError::pdu)?;
         trace!(fast_path_update_fragmentation = ?update_pdu.fragmentation);
 
         let processed_complete_data = self

--- a/crates/ironrdp-session/src/rfx.rs
+++ b/crates/ironrdp-session/src/rfx.rs
@@ -240,7 +240,7 @@ fn tiles_to_rectangles<'a>(
     })
 }
 
-fn map_tiles_data<'a>(tiles: &'_ [Tile<'a>], quants: &'_ [Quant]) -> Vec<TileData<'a>> {
+fn map_tiles_data<'a>(tiles: &[Tile<'a>], quants: &[Quant]) -> Vec<TileData<'a>> {
     tiles
         .iter()
         .map(|t| TileData {

--- a/crates/ironrdp-session/src/x224/mod.rs
+++ b/crates/ironrdp-session/src/x224/mod.rs
@@ -345,7 +345,7 @@ fn process_svc_messages(messages: Vec<SvcMessage>, channel_id: u16, initiator_id
             channel_id,
             user_data: Cow::Borrowed(buf.filled()),
         })
-        .collect::<Vec<mcs::SendDataRequest>>();
+        .collect::<Vec<mcs::SendDataRequest<'_>>>();
 
     // SendDataRequest is [`McsPdu`], which is [`x224Pdu`], which is [`PduEncode`]. [`PduEncode`] for [`x224Pdu`]
     // also takes care of adding the Tpkt header, so therefore we can just call `encode_buf` on each of these and

--- a/xtask/src/check.rs
+++ b/xtask/src/check.rs
@@ -1,5 +1,6 @@
 use crate::prelude::*;
 
+// TODO: when 1.74 is released use `[lints]`: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#lints
 const EXTRA_LINTS: &[&str] = &[
     // == Safer unsafe == //
     "unsafe_op_in_unsafe_fn",
@@ -24,6 +25,7 @@ const EXTRA_LINTS: &[&str] = &[
     // TODO: "clippy::unwrap_used", // let’s either handle `None`, `Err` or use `expect` to give a reason
     "clippy::large_stack_frames",
     // == Style, readability == //
+    "elided_lifetimes_in_paths", // https://quinedot.github.io/rust-learning/dont-hide.html
     "absolute_paths_not_starting_with_crate",
     "single_use_lifetimes",
     "unreachable_pub",
@@ -92,6 +94,7 @@ pub fn fmt(sh: &Shell) -> anyhow::Result<()> {
 pub fn lints(sh: &Shell) -> anyhow::Result<()> {
     let _s = Section::new("LINTS");
 
+    // TODO: when 1.74 is released use `--keep-going`: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#keep-going
     let cmd = cmd!(sh, "{CARGO} clippy --workspace --locked -- -D warnings");
 
     EXTRA_LINTS.iter().fold(cmd, |cmd, lint| cmd.args(["-W", lint])).run()?;


### PR DESCRIPTION
Hiding the lifetimes in "paths" is making the code less obvious.

That’s not a problem for types that I know about intimately such as `ReadCursor` or `WriteCursor`, but I actually found myself surprised more than once when reading code I didn’t authored, discovering  later there was in fact a hidden lifetime parameter.
I expect this problem to be worse for someone not familiar with our codebase.

I understand this lint is "allow" by default because in some cases it leads to writing unergonomic ugly code when a type has many generic lifetimes parameters:

```rust
TyCtxt<'_, '_, '_>
```

However we _never_ work with more than one generic lifetime parameter in IronRDP codebase, so it seems to me that the tradeoff towards clarity is worth it, in our case.