### PR TITLE
Makes `CliprdrBackend` `AsAny`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,6 +1765,7 @@ name = "ironrdp-cliprdr-native"
 version = "0.1.0"
 dependencies = [
  "ironrdp-cliprdr",
+ "ironrdp-svc",
  "thiserror",
  "tracing",
  "windows 0.48.0",

--- a/crates/ironrdp-cliprdr-native/Cargo.toml
+++ b/crates/ironrdp-cliprdr-native/Cargo.toml
@@ -18,6 +18,7 @@ test = false
 
 [target.'cfg(windows)'.dependencies]
 ironrdp-cliprdr.workspace = true
+ironrdp-svc.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 windows = { version = "0.48", features = [

--- a/crates/ironrdp-cliprdr-native/src/windows/cliprdr_backend.rs
+++ b/crates/ironrdp-cliprdr-native/src/windows/cliprdr_backend.rs
@@ -5,6 +5,7 @@ use ironrdp_cliprdr::pdu::{
     ClipboardFormat, ClipboardGeneralCapabilityFlags, FileContentsRequest, FileContentsResponse, FormatDataRequest,
     FormatDataResponse, LockDataId,
 };
+use ironrdp_svc::impl_as_any;
 use windows::Win32::Foundation::{HWND, LPARAM, WPARAM};
 use windows::Win32::UI::WindowsAndMessaging::PostMessageW;
 
@@ -15,6 +16,8 @@ pub(crate) struct WinCliprdrBackend {
     backend_event_tx: mpsc_sync::SyncSender<BackendEvent>,
     window: HWND,
 }
+
+impl_as_any!(WinCliprdrBackend);
 
 impl WinCliprdrBackend {
     pub(crate) fn new(window: HWND, backend_event_tx: mpsc_sync::SyncSender<BackendEvent>) -> Self {

--- a/crates/ironrdp-cliprdr/src/backend.rs
+++ b/crates/ironrdp-cliprdr/src/backend.rs
@@ -1,11 +1,10 @@
 //! This module provides infrastructure for implementing OS-specific clipboard backend.
 
-use ironrdp_svc::AsAny;
-
 use crate::pdu::{
     ClipboardFormat, ClipboardFormatId, ClipboardGeneralCapabilityFlags, FileContentsRequest, FileContentsResponse,
     FormatDataRequest, FormatDataResponse, LockDataId, OwnedFormatDataResponse,
 };
+use ironrdp_svc::AsAny;
 
 pub trait ClipboardError: std::error::Error + Send + Sync + 'static {}
 impl<T> ClipboardError for T where T: std::error::Error + Send + Sync + 'static {}

--- a/crates/ironrdp-cliprdr/src/backend.rs
+++ b/crates/ironrdp-cliprdr/src/backend.rs
@@ -1,5 +1,7 @@
 //! This module provides infrastructure for implementing OS-specific clipboard backend.
 
+use ironrdp_svc::AsAny;
+
 use crate::pdu::{
     ClipboardFormat, ClipboardFormatId, ClipboardGeneralCapabilityFlags, FileContentsRequest, FileContentsResponse,
     FormatDataRequest, FormatDataResponse, LockDataId, OwnedFormatDataResponse,
@@ -43,7 +45,7 @@ pub trait ClipboardMessageProxy: std::fmt::Debug + Send + Sync {
 }
 
 /// OS-specific clipboard backend interface.
-pub trait CliprdrBackend: std::fmt::Debug + Send + Sync + 'static {
+pub trait CliprdrBackend: AsAny + std::fmt::Debug + Send + Sync + 'static {
     /// Returns path to local temporary directory where clipboard-transferred files should be
     /// stored.
     fn temporary_directory(&self) -> &str;

--- a/crates/ironrdp-cliprdr/src/lib.rs
+++ b/crates/ironrdp-cliprdr/src/lib.rs
@@ -47,7 +47,7 @@ enum CliprdrState {
 /// CLIPRDR static virtual channel client endpoint implementation
 #[derive(Debug)]
 pub struct Cliprdr {
-    pub backend: Box<dyn CliprdrBackend>,
+    backend: Box<dyn CliprdrBackend>,
     capabilities: Capabilities,
     state: CliprdrState,
 }
@@ -77,6 +77,14 @@ impl Cliprdr {
             state: CliprdrState::Initialization,
             capabilities: Capabilities::new(ClipboardProtocolVersion::V2, flags),
         }
+    }
+
+    pub fn downcast_backend<T: CliprdrBackend>(&self) -> Option<&T> {
+        self.backend.as_any().downcast_ref::<T>()
+    }
+
+    pub fn downcast_backend_mut<T: CliprdrBackend>(&mut self) -> Option<&mut T> {
+        self.backend.as_any_mut().downcast_mut::<T>()
     }
 
     fn are_long_format_names_enabled(&self) -> bool {

--- a/crates/ironrdp-cliprdr/src/lib.rs
+++ b/crates/ironrdp-cliprdr/src/lib.rs
@@ -47,7 +47,7 @@ enum CliprdrState {
 /// CLIPRDR static virtual channel client endpoint implementation
 #[derive(Debug)]
 pub struct Cliprdr {
-    backend: Box<dyn CliprdrBackend>,
+    pub backend: Box<dyn CliprdrBackend>,
     capabilities: Capabilities,
     state: CliprdrState,
 }


### PR DESCRIPTION
Teleport could use this feature, afaik it's harmless and simple to add (we're using `impl_as_any!`).

Corresponds with https://github.com/gravitational/teleport/pull/33506