### PR TITLE
ci: make sure the coverage workflow is disabled for forks

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,6 +25,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Test
+        run: echo "${{ github.repository }}"
+
       - name: Rust cache
         uses: Swatinem/rust-cache@v2.3.0
 


### PR DESCRIPTION
The check to disable the coverage job is not working properly.