### PR TITLE
refactor: use u16 for pointer position

### DIFF
--- a/crates/ironrdp-client/src/gui.rs
+++ b/crates/ironrdp-client/src/gui.rs
@@ -242,7 +242,7 @@ impl GuiContext {
                     window.set_cursor_visible(true);
                 }
                 Event::UserEvent(RdpOutputEvent::PointerPosition { x, y }) => {
-                    if let Err(error) = window.set_cursor_position(LogicalPosition::new(x as f64, y as f64)) {
+                    if let Err(error) = window.set_cursor_position(LogicalPosition::new(x, y)) {
                         error!(?error, "Failed to set cursor position");
                     }
                 }

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -20,7 +20,7 @@ pub enum RdpOutputEvent {
     ConnectionFailure(connector::ConnectorError),
     PointerDefault,
     PointerHidden,
-    PointerPosition { x: usize, y: usize },
+    PointerPosition { x: u16, y: u16 },
     Terminated(SessionResult<()>),
 }
 

--- a/crates/ironrdp-session/src/active_stage.rs
+++ b/crates/ironrdp-session/src/active_stage.rs
@@ -175,6 +175,6 @@ pub enum ActiveStageOutput {
     GraphicsUpdate(InclusiveRectangle),
     PointerDefault,
     PointerHidden,
-    PointerPosition { x: usize, y: usize },
+    PointerPosition { x: u16, y: u16 },
     Terminate,
 }

--- a/crates/ironrdp-session/src/fast_path.rs
+++ b/crates/ironrdp-session/src/fast_path.rs
@@ -24,7 +24,7 @@ pub enum UpdateKind {
     Region(InclusiveRectangle),
     PointerDefault,
     PointerHidden,
-    PointerPosition { x: usize, y: usize },
+    PointerPosition { x: u16, y: u16 },
 }
 
 pub struct Processor {
@@ -199,8 +199,8 @@ impl Processor {
                     PointerUpdateData::SetPosition(position) => {
                         if self.use_system_pointer {
                             processor_updates.push(UpdateKind::PointerPosition {
-                                x: position.x as usize,
-                                y: position.y as usize,
+                                x: position.x,
+                                y: position.y,
                             });
                         } else if let Some(rect) = image.move_pointer(position.x, position.y)? {
                             processor_updates.push(UpdateKind::Region(rect));


### PR DESCRIPTION
This removes some `as` casts that were never required.