### PR TITLE
docs: uniformize links to specification

### DIFF
--- a/crates/ironrdp-pdu/src/rdp/client_info.rs
+++ b/crates/ironrdp-pdu/src/rdp/client_info.rs
@@ -31,9 +31,9 @@ const RECONNECT_COOKIE_LENGTH_SIZE: usize = 2;
 const BIAS_SIZE: usize = 4;
 const SYSTEM_TIME_SIZE: usize = 16;
 
-/// [2.2.1.11.1.1 Info Packet (TS_INFO_PACKET)]
+/// [2.2.1.11.1.1] Info Packet (TS_INFO_PACKET)
 ///
-/// [2.2.1.11.1.1 Info Packet (TS_INFO_PACKET)]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/732394f5-e2b5-4ac5-8a0a-35345386b0d1
+/// [2.2.1.11.1.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/732394f5-e2b5-4ac5-8a0a-35345386b0d1
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ClientInfo {
     pub credentials: Credentials,

--- a/crates/ironrdp-rdpdr/src/pdu/efs.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/efs.rs
@@ -16,11 +16,17 @@ use super::{PacketId, SharedHeader};
 
 #[derive(Debug, PartialEq)]
 pub enum VersionAndIdPduKind {
-    /// [2.2.2.2 Server Announce Request (DR_CORE_SERVER_ANNOUNCE_REQ)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/046047aa-62d8-49f9-bf16-7fe41880aaf4)
+    /// [2.2.2.2] Server Announce Request (DR_CORE_SERVER_ANNOUNCE_REQ)
+    ///
+    /// [2.2.2.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/046047aa-62d8-49f9-bf16-7fe41880aaf4
     ServerAnnounceRequest,
-    /// [2.2.2.3 Client Announce Reply (DR_CORE_CLIENT_ANNOUNCE_RSP)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/d6fe6d1b-c145-4a6f-99aa-4fe3cdcea398)
+    /// [2.2.2.3] Client Announce Reply (DR_CORE_CLIENT_ANNOUNCE_RSP)
+    ///
+    /// [2.2.2.3]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/d6fe6d1b-c145-4a6f-99aa-4fe3cdcea398
     ClientAnnounceReply,
-    /// [2.2.2.6 Server Client ID Confirm (DR_CORE_SERVER_CLIENTID_CONFIRM)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/bbbb9666-6994-4cf6-8e65-0d46eb319c6e)
+    /// [2.2.2.6] Server Client ID Confirm (DR_CORE_SERVER_CLIENTID_CONFIRM)
+    ///
+    /// [2.2.2.6]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/bbbb9666-6994-4cf6-8e65-0d46eb319c6e
     ServerClientIdConfirm,
 }
 
@@ -109,7 +115,9 @@ impl VersionAndIdPdu {
     }
 }
 
-/// [2.2.2.4 Client Name Request (DR_CORE_CLIENT_NAME_REQ)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/902497f1-3b1c-4aee-95f8-1668f9b7b7d2)
+/// [2.2.2.4] Client Name Request (DR_CORE_CLIENT_NAME_REQ)
+///
+/// [2.2.2.4]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/902497f1-3b1c-4aee-95f8-1668f9b7b7d2
 #[derive(Debug)]
 pub enum ClientNameRequest {
     Ascii(String),
@@ -180,8 +188,11 @@ impl From<ClientNameRequestUnicodeFlag> for u32 {
     }
 }
 
-/// [2.2.2.7 Server Core Capability Request (DR_CORE_CAPABILITY_REQ)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/702789c3-b924-4bc2-9280-3221bc7d6797)
-/// [2.2.2.8 Client Core Capability Response (DR_CORE_CAPABILITY_RSP)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/f513bf87-cca0-488a-ac5c-18cf18f4a7e1)
+/// [2.2.2.7] Server Core Capability Request (DR_CORE_CAPABILITY_REQ)
+/// and [2.2.2.8] Client Core Capability Response (DR_CORE_CAPABILITY_RSP)
+///
+/// [2.2.2.7]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/702789c3-b924-4bc2-9280-3221bc7d6797
+/// [2.2.2.8]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/f513bf87-cca0-488a-ac5c-18cf18f4a7e1
 #[derive(Debug)]
 pub struct CoreCapability {
     pub capabilities: Vec<CapabilityMessage>,
@@ -251,9 +262,13 @@ impl CoreCapability {
 
 #[derive(Debug, PartialEq)]
 pub enum CoreCapabilityKind {
-    /// [2.2.2.7 Server Core Capability Request (DR_CORE_CAPABILITY_REQ)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/702789c3-b924-4bc2-9280-3221bc7d6797)
+    /// [2.2.2.7] Server Core Capability Request (DR_CORE_CAPABILITY_REQ)
+    ///
+    /// [2.2.2.7]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/702789c3-b924-4bc2-9280-3221bc7d6797
     ServerCoreCapabilityRequest,
-    /// [2.2.2.8 Client Core Capability Response (DR_CORE_CAPABILITY_RSP)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/f513bf87-cca0-488a-ac5c-18cf18f4a7e1)
+    /// [2.2.2.8] Client Core Capability Response (DR_CORE_CAPABILITY_RSP)
+    ///
+    /// [2.2.2.8]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/f513bf87-cca0-488a-ac5c-18cf18f4a7e1
     ClientCoreCapabilityResponse,
 }
 
@@ -317,7 +332,9 @@ impl Default for Capabilities {
     }
 }
 
-/// [2.2.1.2.1 Capability Message (CAPABILITY_SET)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/f1b9dd1d-2c37-4aac-9836-4b0df02369ba)
+/// [2.2.1.2.1] Capability Message (CAPABILITY_SET)
+///
+/// [2.2.1.2.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/f1b9dd1d-2c37-4aac-9836-4b0df02369ba
 #[derive(Debug, Clone, Copy)]
 pub struct CapabilityMessage {
     header: CapabilityHeader,
@@ -394,7 +411,9 @@ impl CapabilityMessage {
     }
 }
 
-/// [2.2.1.2 Capability Header (CAPABILITY_HEADER)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/b3c3304a-2e1b-4667-97e9-3bce49544907)
+/// [2.2.1.2] Capability Header (CAPABILITY_HEADER)
+///
+/// [2.2.1.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/b3c3304a-2e1b-4667-97e9-3bce49544907
 #[derive(Debug, Clone, Copy)]
 struct CapabilityHeader {
     cap_type: CapabilityType,
@@ -536,7 +555,9 @@ impl CapabilityData {
     }
 }
 
-/// [2.2.2.7.1 General Capability Set (GENERAL_CAPS_SET)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/06c7cb30-303d-4fa2-b396-806df8ac1501)
+/// [2.2.2.7.1] General Capability Set (GENERAL_CAPS_SET)
+///
+/// [2.2.2.7.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/06c7cb30-303d-4fa2-b396-806df8ac1501
 #[derive(Debug, Clone, Copy)]
 struct GeneralCapabilitySet {
     /// MUST be ignored.
@@ -712,14 +733,15 @@ bitflags! {
 /// the difference is.
 ///
 /// [Server Client ID Confirm (section 2.2.2.6)]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/bbbb9666-6994-4cf6-8e65-0d46eb319c6e
-/// [2.2.2.3 Client Announce Reply (DR_CORE_CLIENT_ANNOUNCE_RSP)]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/d6fe6d1b-c145-4a6f-99aa-4fe3cdcea398
+/// [2.2.2.3]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/d6fe6d1b-c145-4a6f-99aa-4fe3cdcea398
 const VERSION_MINOR_12: u16 = 0x000C;
 const VERSION_MAJOR: u16 = 0x0001;
 
-/// [2.2.2.9 Client Device List Announce Request (DR_CORE_DEVICELIST_ANNOUNCE_REQ)], [2.2.3.1 Client Device List Announce (DR_DEVICELIST_ANNOUNCE)]
+/// [2.2.2.9] Client Device List Announce Request (DR_CORE_DEVICELIST_ANNOUNCE_REQ)
+/// and [2.2.3.1] Client Device List Announce (DR_DEVICELIST_ANNOUNCE)
 ///
-/// [2.2.2.9 Client Device List Announce Request (DR_CORE_DEVICELIST_ANNOUNCE_REQ)]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/10ef9ada-cba2-4384-ab60-7b6290ed4a9a
-/// [2.2.3.1 Client Device List Announce (DR_DEVICELIST_ANNOUNCE)]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/d8b2bc1c-0207-4c15-abe3-62eaa2afcaf1
+/// [2.2.2.9]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/10ef9ada-cba2-4384-ab60-7b6290ed4a9a
+/// [2.2.3.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/d8b2bc1c-0207-4c15-abe3-62eaa2afcaf1
 #[derive(Debug)]
 pub struct ClientDeviceListAnnounce {
     pub device_list: Vec<DeviceAnnounceHeader>,
@@ -802,9 +824,9 @@ impl Default for Devices {
     }
 }
 
-/// [2.2.1.3 Device Announce Header (DEVICE_ANNOUNCE)]
+/// [2.2.1.3] Device Announce Header (DEVICE_ANNOUNCE)
 ///
-/// [2.2.1.3 Device Announce Header (DEVICE_ANNOUNCE)]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/32e34332-774b-4ead-8c9d-5d64720d6bf9
+/// [2.2.1.3]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/32e34332-774b-4ead-8c9d-5d64720d6bf9
 #[derive(Debug, Clone)]
 pub struct DeviceAnnounceHeader {
     device_type: DeviceType,
@@ -928,9 +950,9 @@ impl TryFrom<u32> for DeviceType {
     }
 }
 
-/// [2.2.2.1 Server Device Announce Response (DR_CORE_DEVICE_ANNOUNCE_RSP)]
+/// [2.2.2.1] Server Device Announce Response (DR_CORE_DEVICE_ANNOUNCE_RSP)
 ///
-/// [2.2.2.1 Server Device Announce Response (DR_CORE_DEVICE_ANNOUNCE_RSP)]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/a4c0b619-6e87-4721-bdc4-5d2db7f485f3
+/// [2.2.2.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/a4c0b619-6e87-4721-bdc4-5d2db7f485f3
 #[derive(Debug)]
 pub struct ServerDeviceAnnounceResponse {
     pub device_id: u32,
@@ -965,12 +987,12 @@ impl ServerDeviceAnnounceResponse {
     }
 }
 
-/// [2.3.1 NTSTATUS Values]
+/// [2.3.1] NTSTATUS Values
 ///
 /// Windows defines an absolutely massive list of potential NTSTATUS values.
 /// This enum includes some basic ones for communicating with the RDP server.
 ///
-/// [2.3.1 NTSTATUS Values]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/596a1078-e883-4972-9bbc-49e60bebca55
+/// [2.3.1]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/596a1078-e883-4972-9bbc-49e60bebca55
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct NtStatus(u32);
 
@@ -1027,9 +1049,9 @@ impl From<NtStatus> for u32 {
     }
 }
 
-/// [2.2.1.4 Device I/O Request (DR_DEVICE_IOREQUEST)]
+/// [2.2.1.4] Device I/O Request (DR_DEVICE_IOREQUEST)
 ///
-/// [2.2.1.4 Device I/O Request (DR_DEVICE_IOREQUEST)]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/a087ffa8-d0d5-4874-ac7b-0494f63e2d5d
+/// [2.2.1.4]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/a087ffa8-d0d5-4874-ac7b-0494f63e2d5d
 #[derive(Debug, Clone)]
 pub struct DeviceIoRequest {
     pub device_id: u32,
@@ -1177,9 +1199,9 @@ impl From<MinorFunction> for u32 {
     }
 }
 
-/// [2.2.1.4.5 Device Control Request (DR_CONTROL_REQ)]
+/// [2.2.1.4.5] Device Control Request (DR_CONTROL_REQ)
 ///
-/// [2.2.1.4.5 Device Control Request (DR_CONTROL_REQ)]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/30662c80-ec6e-4ed1-9004-2e6e367bb59f
+/// [2.2.1.4.5]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/30662c80-ec6e-4ed1-9004-2e6e367bb59f
 #[derive(Debug)]
 pub struct DeviceControlRequest<T: IoCtlCode> {
     pub header: DeviceIoRequest,
@@ -1220,9 +1242,9 @@ where
 /// A 32-bit unsigned integer. This field is specific to the redirected device.
 pub trait IoCtlCode: TryFrom<u32> {}
 
-/// [2.2.1.5.5 Device Control Response (DR_CONTROL_RSP)]
+/// [2.2.1.5.5] Device Control Response (DR_CONTROL_RSP)
 ///
-/// [2.2.1.5.5 Device Control Response (DR_CONTROL_RSP)]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/a00fbce4-95bb-4e15-8182-be2b5ef9076a
+/// [2.2.1.5.5]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/a00fbce4-95bb-4e15-8182-be2b5ef9076a
 #[derive(Debug)]
 pub struct DeviceControlResponse {
     pub device_io_reply: DeviceIoResponse,
@@ -1269,9 +1291,9 @@ impl DeviceControlResponse {
     }
 }
 
-/// [2.2.1.5 Device I/O Response (DR_DEVICE_IOCOMPLETION)]
+/// [2.2.1.5] Device I/O Response (DR_DEVICE_IOCOMPLETION)
 ///
-/// [2.2.1.5 Device I/O Response (DR_DEVICE_IOCOMPLETION)]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/1c412a84-0776-4984-b35c-3f0445fcae65
+/// [2.2.1.5]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/1c412a84-0776-4984-b35c-3f0445fcae65
 #[derive(Debug)]
 pub struct DeviceIoResponse {
     pub device_id: u32,
@@ -1317,9 +1339,9 @@ impl DeviceIoResponse {
     }
 }
 
-/// [2.2.3.3 Server Drive I/O Request (DR_DRIVE_CORE_DEVICE_IOREQUEST)]
+/// [2.2.3.3] Server Drive I/O Request (DR_DRIVE_CORE_DEVICE_IOREQUEST)
 ///
-/// [2.2.3.3 Server Drive I/O Request (DR_DRIVE_CORE_DEVICE_IOREQUEST)]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/89bb51af-c54d-40fb-81c1-d1bb353c4536
+/// [2.2.3.3]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/89bb51af-c54d-40fb-81c1-d1bb353c4536
 #[derive(Debug)]
 pub enum ServerDriveIoRequest {
     ServerCreateDriveRequest(DeviceCreateRequest),
@@ -1348,10 +1370,11 @@ impl ServerDriveIoRequest {
     }
 }
 
-/// [2.2.3.3.1 Server Create Drive Request (DR_DRIVE_CREATE_REQ)] and [2.2.1.4.1 Device Create Request (DR_CREATE_REQ)]
+/// [2.2.3.3.1] Server Create Drive Request (DR_DRIVE_CREATE_REQ)
+/// and [2.2.1.4.1] Device Create Request (DR_CREATE_REQ)
 ///
-/// [2.2.3.3.1 Server Create Drive Request (DR_DRIVE_CREATE_REQ)]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/95b16fd0-d530-407c-a310-adedc85e9897
-/// [2.2.1.4.1 Device Create Request (DR_CREATE_REQ)]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/5f71f6d2-d9ff-40c2-bdb5-a739447d3c3e
+/// [2.2.3.3.1]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/95b16fd0-d530-407c-a310-adedc85e9897
+/// [2.2.1.4.1]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/5f71f6d2-d9ff-40c2-bdb5-a739447d3c3e
 #[derive(Debug)]
 pub struct DeviceCreateRequest {
     /// The MajorFunction field in this header MUST be set to IRP_MJ_CREATE.
@@ -1402,14 +1425,14 @@ impl DeviceCreateRequest {
 
 bitflags! {
     /// DesiredAccess can be interpreted as either
-    /// [2.2.13.1.1 File_Pipe_Printer_Access_Mask \[MS-SMB2\]] or [2.2.13.1.2 Directory_Access_Mask \[MS-SMB2\]]
+    /// [2.2.13.1.1] File_Pipe_Printer_Access_Mask \[MS-SMB2\] or [2.2.13.1.2] Directory_Access_Mask \[MS-SMB2\]
     ///
     /// This implements the combination of the two. For flags where the names and/or functions are distinct between the two,
     /// the names are appended with an "_OR_", and the File_Pipe_Printer_Access_Mask functionality is described on the top line comment,
     /// and the Directory_Access_Mask functionality is described on the bottom (2nd) line comment.
     ///
-    /// [2.2.13.1.1 File_Pipe_Printer_Access_Mask \[MS-SMB2\]]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/77b36d0f-6016-458a-a7a0-0f4a72ae1534
-    /// [2.2.13.1.2 Directory_Access_Mask \[MS-SMB2\]]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/0a5934b1-80f1-4da0-b1bf-5e021c309b71
+    /// [2.2.13.1.1]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/77b36d0f-6016-458a-a7a0-0f4a72ae1534
+    /// [2.2.13.1.2]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/0a5934b1-80f1-4da0-b1bf-5e021c309b71
     #[derive(Debug, Clone)]
     pub struct DesiredAccess: u32 {
         /// This value indicates the right to read data from the file or named pipe.
@@ -1464,9 +1487,9 @@ bitflags! {
 }
 
 bitflags! {
-    /// [2.6 File Attributes \[MS-FSCC\]]
+    /// [2.6] File Attributes \[MS-FSCC\]
     ///
-    /// [2.6 File Attributes \[MS-FSCC\]]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/ca28ec38-f155-4768-81d6-4bfeb8586fc9
+    /// [2.6]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/ca28ec38-f155-4768-81d6-4bfeb8586fc9
     #[derive(Debug, Clone)]
     pub struct FileAttributes: u32 {
         const FILE_ATTRIBUTE_READONLY = 0x00000001;
@@ -1492,9 +1515,9 @@ bitflags! {
 }
 
 bitflags! {
-    /// Specified in [2.2.13 SMB2 CREATE Request]
+    /// Specified in [2.2.13] SMB2 CREATE Request
     ///
-    /// [2.2.13 SMB2 CREATE Request]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/e8fb45c1-a03d-44ca-b7ae-47385cfd7997
+    /// [2.2.13]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/e8fb45c1-a03d-44ca-b7ae-47385cfd7997
     #[derive(Debug, Clone)]
     pub struct SharedAccess: u32 {
         const FILE_SHARE_READ = 0x00000001;
@@ -1504,11 +1527,11 @@ bitflags! {
 }
 
 bitflags! {
-    /// Defined in [2.2.13 SMB2 CREATE Request]
+    /// Defined in [2.2.13] SMB2 CREATE Request
     ///
     /// See FreeRDP's [drive_file.c] for context about how these should be interpreted.
     ///
-    /// [2.2.13 SMB2 CREATE Request]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/e8fb45c1-a03d-44ca-b7ae-47385cfd7997
+    /// [2.2.13]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/e8fb45c1-a03d-44ca-b7ae-47385cfd7997
     /// [drive_file.c]: https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L207
     #[derive(PartialEq, Eq, Debug, Clone)]
     pub struct CreateDisposition: u32 {
@@ -1522,9 +1545,9 @@ bitflags! {
 }
 
 bitflags! {
-    /// Defined in [2.2.13 SMB2 CREATE Request]
+    /// Defined in [2.2.13] SMB2 CREATE Request
     ///
-    /// [2.2.13 SMB2 CREATE Request]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/e8fb45c1-a03d-44ca-b7ae-47385cfd7997
+    /// [2.2.13]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/e8fb45c1-a03d-44ca-b7ae-47385cfd7997
     #[derive(Debug, Clone)]
     pub struct CreateOptions: u32 {
         const FILE_DIRECTORY_FILE = 0x00000001;
@@ -1551,9 +1574,9 @@ bitflags! {
     }
 }
 
-/// [2.2.1.5.1 Device Create Response (DR_CREATE_RSP)]
+/// [2.2.1.5.1] Device Create Response (DR_CREATE_RSP)
 ///
-/// [2.2.1.5.1 Device Create Response (DR_CREATE_RSP)]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/99e5fca5-b37a-41e4-bc69-8d7da7860f76
+/// [2.2.1.5.1]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/99e5fca5-b37a-41e4-bc69-8d7da7860f76
 #[derive(Debug)]
 pub struct DeviceCreateResponse {
     pub device_io_reply: DeviceIoResponse,
@@ -1584,9 +1607,9 @@ impl DeviceCreateResponse {
 }
 
 bitflags! {
-    /// Defined in [2.2.1.5.1 Device Create Response (DR_CREATE_RSP)]
+    /// Defined in [2.2.1.5.1] Device Create Response (DR_CREATE_RSP)
     ///
-    /// [2.2.1.5.1 Device Create Response (DR_CREATE_RSP)]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/99e5fca5-b37a-41e4-bc69-8d7da7860f76
+    /// [2.2.1.5.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/99e5fca5-b37a-41e4-bc69-8d7da7860f76
     #[derive(Debug)]
     pub struct Information: u8 {
         /// A new file was created.
@@ -1598,11 +1621,11 @@ bitflags! {
     }
 }
 
-/// [2.2.3.3.8 Server Drive Query Information Request (DR_DRIVE_QUERY_INFORMATION_REQ)]
+/// [2.2.3.3.8] Server Drive Query Information Request (DR_DRIVE_QUERY_INFORMATION_REQ)
 ///
 /// Note that Length, Padding, and QueryBuffer fields are all ignored in keeping with the [analogous code in FreeRDP].
 ///
-/// [2.2.3.3.8 Server Drive Query Information Request (DR_DRIVE_QUERY_INFORMATION_REQ)]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/e43dcd68-2980-40a9-9238-344b6cf94946
+/// [2.2.3.3.8]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/e43dcd68-2980-40a9-9238-344b6cf94946
 /// [analogous code in FreeRDP]: https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_main.c#L384
 #[derive(Debug)]
 pub struct ServerDriveQueryInformationRequest {
@@ -1622,9 +1645,9 @@ impl ServerDriveQueryInformationRequest {
     }
 }
 
-/// [2.4 File Information Classes \[MS-FSCC\]]
+/// [2.4] File Information Classes \[MS-FSCC\]
 ///
-/// [2.4 File Information Classes \[MS-FSCC\]]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/4718fc40-e539-4014-8e33-b675af74e3e1
+/// [2.4]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/4718fc40-e539-4014-8e33-b675af74e3e1
 #[derive(PartialEq, Eq, Clone)]
 pub struct FileInformationClassLevel(u32);
 
@@ -1660,9 +1683,9 @@ impl From<FileInformationClassLevel> for u32 {
     }
 }
 
-/// [2.2.3.4.8 Client Drive Query Information Response (DR_DRIVE_QUERY_INFORMATION_RSP)]
+/// [2.2.3.4.8] Client Drive Query Information Response (DR_DRIVE_QUERY_INFORMATION_RSP)
 ///
-/// [2.2.3.4.8 Client Drive Query Information Response (DR_DRIVE_QUERY_INFORMATION_RSP)]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/37ef4fb1-6a95-4200-9fbf-515464f034a4
+/// [2.2.3.4.8]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/37ef4fb1-6a95-4200-9fbf-515464f034a4
 #[derive(Debug)]
 pub struct ClientDriveQueryInformationResponse {
     pub device_io_response: DeviceIoResponse,
@@ -1705,9 +1728,9 @@ impl ClientDriveQueryInformationResponse {
     }
 }
 
-/// [2.4 File Information Classes \[MS-FSCC\]]
+/// [2.4] File Information Classes \[MS-FSCC\]
 ///
-/// [2.4 File Information Classes \[MS-FSCC\]]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/4718fc40-e539-4014-8e33-b675af74e3e1
+/// [2.4]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/4718fc40-e539-4014-8e33-b675af74e3e1
 #[derive(Debug, Clone)]
 pub enum FileInformationClass {
     Basic(FileBasicInformation),
@@ -1733,9 +1756,9 @@ impl FileInformationClass {
     }
 }
 
-/// [2.4.7 FileBasicInformation \[MS-FSCC\]]
+/// [2.4.7] FileBasicInformation \[MS-FSCC\]
 ///
-/// [2.4.7 FileBasicInformation \[MS-FSCC\]]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/16023025-8a78-492f-8b96-c873b042ac50
+/// [2.4.7]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/16023025-8a78-492f-8b96-c873b042ac50
 #[derive(Debug, Clone)]
 pub struct FileBasicInformation {
     pub creation_time: i64,
@@ -1769,9 +1792,9 @@ impl FileBasicInformation {
     }
 }
 
-/// [2.4.41 FileStandardInformation \[MS-FSCC\]]
+/// [2.4.41] FileStandardInformation \[MS-FSCC\]
 ///
-/// [2.4.41 FileStandardInformation \[MS-FSCC\]]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/5afa7f66-619c-48f3-955f-68c4ece704ae
+/// [2.4.41]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/5afa7f66-619c-48f3-955f-68c4ece704ae
 #[derive(Debug, Clone)]
 pub struct FileStandardInformation {
     pub allocation_size: i64,
@@ -1804,9 +1827,9 @@ impl FileStandardInformation {
     }
 }
 
-/// [2.1.8 Boolean]
+/// [2.1.8] Boolean
 ///
-/// [2.1.8 Boolean]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/8ce7b38c-d3cc-415d-ab39-944000ea77ff
+/// [2.1.8]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/8ce7b38c-d3cc-415d-ab39-944000ea77ff
 #[derive(Debug, PartialEq, Clone, Copy)]
 #[repr(u8)]
 pub enum Boolean {
@@ -1823,9 +1846,9 @@ impl From<Boolean> for u8 {
     }
 }
 
-/// [2.4.6 FileAttributeTagInformation \[MS-FSCC\]]
+/// [2.4.6] FileAttributeTagInformation \[MS-FSCC\]
 ///
-/// [2.4.6 FileAttributeTagInformation \[MS-FSCC\]]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/d295752f-ce89-4b98-8553-266d37c84f0e?redirectedfrom=MSDN
+/// [2.4.6]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/d295752f-ce89-4b98-8553-266d37c84f0e?redirectedfrom=MSDN
 #[derive(Debug, Clone)]
 pub struct FileAttributeTagInformation {
     pub file_attributes: FileAttributes,

--- a/crates/ironrdp-rdpdr/src/pdu/esc.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/esc.rs
@@ -17,9 +17,9 @@ use ironrdp_pdu::{cast_length, ensure_size, invalid_message_err, PduDecode, PduE
 use super::efs::IoCtlCode;
 use crate::pdu::esc::ndr::{Decode as _, Encode as _};
 
-/// [2.2.2 TS Server-Generated Structures]
+/// [2.2.2] TS Server-Generated Structures
 ///
-/// [2.2.2 TS Server-Generated Structures]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/f4ca3b61-b49c-463c-8932-2cf82fb7ec7a
+/// [2.2.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/f4ca3b61-b49c-463c-8932-2cf82fb7ec7a
 #[derive(Debug)]
 pub enum ScardCall {
     AccessStartedEventCall(ScardAccessStartedEventCall),
@@ -75,9 +75,9 @@ impl ScardCall {
     }
 }
 
-/// [2.2.1.1 REDIR_SCARDCONTEXT]
+/// [2.2.1.1] REDIR_SCARDCONTEXT
 ///
-/// [2.2.1.1 REDIR_SCARDCONTEXT]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/060abee1-e520-4149-9ef7-ce79eb500a59
+/// [2.2.1.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/060abee1-e520-4149-9ef7-ce79eb500a59
 #[derive(Debug, Copy, Clone)]
 pub struct ScardContext {
     /// Shortcut: we always create 4-byte context values.
@@ -150,9 +150,9 @@ impl ndr::Decode for ScardContext {
     }
 }
 
-/// [2.2.1.7 ReaderStateW]
+/// [2.2.1.7] ReaderStateW
 ///
-/// [2.2.1.7 ReaderStateW]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/0ba03cd2-bed0-495b-adbe-3d2cde61980c
+/// [2.2.1.7]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/0ba03cd2-bed0-495b-adbe-3d2cde61980c
 #[derive(Debug)]
 pub struct ReaderState {
     pub reader: String,
@@ -175,9 +175,9 @@ impl ndr::Decode for ReaderState {
     }
 }
 
-/// From [3.1.4 Message Processing Events and Sequencing Rules]
+/// From [3.1.4] Message Processing Events and Sequencing Rules
 ///
-/// [3.1.4 Message Processing Events and Sequencing Rules]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/60d5977d-0017-4c90-ab0c-f34bf44a74a5
+/// [3.1.4]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/60d5977d-0017-4c90-ab0c-f34bf44a74a5
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(u32)]
 pub enum ScardIoCtlCode {
@@ -343,9 +343,9 @@ impl TryFrom<u32> for ScardIoCtlCode {
 /// Allow [`ScardIoCtlCode`] to be used as an [`IoCtlCode`].
 impl IoCtlCode for ScardIoCtlCode {}
 
-/// [2.2.2.30 ScardAccessStartedEvent_Call]
+/// [2.2.2.30] ScardAccessStartedEvent_Call
 ///
-/// [2.2.2.30 ScardAccessStartedEvent_Call]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/c5ab8dd0-4914-4355-960c-0a527971ea69
+/// [2.2.2.30]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/c5ab8dd0-4914-4355-960c-0a527971ea69
 #[derive(Debug)]
 pub struct ScardAccessStartedEventCall;
 
@@ -356,9 +356,9 @@ impl ScardAccessStartedEventCall {
     }
 }
 
-/// [2.2.3.3 Long_Return]
+/// [2.2.3.3] Long_Return
 ///
-/// [2.2.3.3 Long_Return]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/e77a1365-2379-4037-99c4-d30d14ba10fc
+/// [2.2.3.3]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/e77a1365-2379-4037-99c4-d30d14ba10fc
 #[derive(Debug)]
 pub struct LongReturn {
     return_code: ReturnCode,
@@ -388,9 +388,9 @@ impl rpce::HeaderlessEncode for LongReturn {
     }
 }
 
-/// [2.2.8 Return Code]
+/// [2.2.8] Return Code
 ///
-/// [2.2.8 Return Code]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/9861f8da-76fe-41e6-847e-40c9aa35df8d
+/// [2.2.8]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/9861f8da-76fe-41e6-847e-40c9aa35df8d
 #[derive(Debug, Clone, Copy)]
 #[repr(u32)]
 pub enum ReturnCode {
@@ -542,9 +542,9 @@ impl From<ReturnCode> for u32 {
     }
 }
 
-/// [2.2.2.1 EstablishContext_Call]
+/// [2.2.2.1] EstablishContext_Call
 ///
-/// [2.2.2.1 EstablishContext_Call]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/b990635a-7637-464a-8923-361ed3e3d67a
+/// [2.2.2.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/b990635a-7637-464a-8923-361ed3e3d67a
 #[derive(Debug)]
 pub struct EstablishContextCall {
     pub scope: Scope,
@@ -600,9 +600,9 @@ impl TryFrom<u32> for Scope {
     }
 }
 
-/// [2.2.3.2 EstablishContext_Return]
+/// [2.2.3.2] EstablishContext_Return
 ///
-/// [2.2.3.2 EstablishContext_Return]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/9135d95f-3740-411b-bdca-34ac7571fddc
+/// [2.2.3.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/9135d95f-3740-411b-bdca-34ac7571fddc
 #[derive(Debug)]
 pub struct EstablishContextReturn {
     return_code: ReturnCode,
@@ -636,9 +636,9 @@ impl rpce::HeaderlessEncode for EstablishContextReturn {
     }
 }
 
-/// [2.2.2.4 ListReaders_Call]
+/// [2.2.2.4] ListReaders_Call
 ///
-/// [2.2.2.4 ListReaders_Call]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/be2f46a5-77fb-40bf-839c-aed45f0a26d7
+/// [2.2.2.4]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/be2f46a5-77fb-40bf-839c-aed45f0a26d7
 #[derive(Debug)]
 pub struct ListReadersCall {
     pub context: ScardContext,
@@ -709,9 +709,9 @@ impl rpce::HeaderlessDecode for ListReadersCall {
     }
 }
 
-/// [2.2.3.4 ListReaderGroups_Return and ListReaders_Return]
+/// [2.2.3.4] ListReaderGroups_Return and ListReaders_Return
 ///
-/// [2.2.3.4 ListReaderGroups_Return and ListReaders_Return]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/6630bb5b-fc0e-4141-8b53-263225c7628d
+/// [2.2.3.4]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/6630bb5b-fc0e-4141-8b53-263225c7628d
 #[derive(Debug)]
 pub struct ListReadersReturn {
     pub return_code: ReturnCode,
@@ -754,9 +754,9 @@ impl rpce::HeaderlessEncode for ListReadersReturn {
     }
 }
 
-/// [2.2.2.12 GetStatusChangeW_Call]
+/// [2.2.2.12] GetStatusChangeW_Call
 ///
-/// [2.2.2.12 GetStatusChangeW_Call]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/af357ce8-63ee-4577-b6bf-c6f5ca68d754
+/// [2.2.2.12]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/af357ce8-63ee-4577-b6bf-c6f5ca68d754
 #[derive(Debug)]
 pub struct GetStatusChangeCall {
     pub context: ScardContext,
@@ -811,9 +811,9 @@ impl rpce::HeaderlessDecode for GetStatusChangeCall {
     }
 }
 
-/// [2.2.1.5 ReaderState_Common_Call]
+/// [2.2.1.5] ReaderState_Common_Call
 ///
-/// [2.2.1.5 ReaderState_Common_Call]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/a71e63ba-e58f-487c-a5d2-5a3e48856594
+/// [2.2.1.5]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/a71e63ba-e58f-487c-a5d2-5a3e48856594
 #[derive(Debug)]
 pub struct ReaderStateCommonCall {
     pub current_state: CardStateFlags,
@@ -872,9 +872,9 @@ bitflags! {
     }
 }
 
-/// [2.2.3.5 LocateCards_Return and GetStatusChange_Return]
+/// [2.2.3.5] LocateCards_Return and GetStatusChange_Return
 ///
-/// [2.2.3.5 LocateCards_Return and GetStatusChange_Return]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/7b73e0c2-e0fc-46b1-9b03-50684ad2beba
+/// [2.2.3.5]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/7b73e0c2-e0fc-46b1-9b03-50684ad2beba
 #[derive(Debug)]
 pub struct GetStatusChangeReturn {
     pub return_code: ReturnCode,
@@ -918,9 +918,9 @@ impl rpce::HeaderlessEncode for GetStatusChangeReturn {
     }
 }
 
-/// [2.2.2.14 ConnectW_Call]
+/// [2.2.2.14] ConnectW_Call
 ///
-/// [2.2.2.14 ConnectW_Call]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/fd06f6a0-a9ea-478c-9b5e-470fd9cde5a6
+/// [2.2.2.14]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/fd06f6a0-a9ea-478c-9b5e-470fd9cde5a6
 #[derive(Debug)]
 pub struct ConnectCall {
     pub reader: String,
@@ -944,9 +944,9 @@ impl rpce::HeaderlessDecode for ConnectCall {
     }
 }
 
-/// [2.2.1.3 Connect_Common]
+/// [2.2.1.3] Connect_Common
 ///
-/// [2.2.1.3 Connect_Common]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/32752f32-4410-4682-b9fc-9096674b52de
+/// [2.2.1.3]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/32752f32-4410-4682-b9fc-9096674b52de
 #[derive(Debug)]
 pub struct ConnectCommon {
     pub context: ScardContext,
@@ -980,9 +980,9 @@ impl ndr::Decode for ConnectCommon {
 }
 
 bitflags! {
-    /// [2.2.5 Protocol Identifier]
+    /// [2.2.5] Protocol Identifier
     ///
-    /// [2.2.5 Protocol Identifier]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/41673567-2710-4e86-be87-7b6f46fe10af
+    /// [2.2.5]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/41673567-2710-4e86-be87-7b6f46fe10af
     #[derive(Debug, Clone)]
     pub struct CardProtocol: u32 {
         const SCARD_PROTOCOL_UNDEFINED = 0x0000_0000;
@@ -995,9 +995,9 @@ bitflags! {
     }
 }
 
-/// [2.2.1.2 REDIR_SCARDHANDLE]
+/// [2.2.1.2] REDIR_SCARDHANDLE
 ///
-/// [2.2.1.2 REDIR_SCARDHANDLE]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/b6276356-7c5f-4d3e-be92-a6c85e58d008
+/// [2.2.1.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/b6276356-7c5f-4d3e-be92-a6c85e58d008
 #[derive(Debug)]
 pub struct ScardHandle {
     pub context: ScardContext,
@@ -1076,9 +1076,9 @@ impl ndr::Encode for ScardHandle {
     }
 }
 
-/// [2.2.3.8 Connect_Return]
+/// [2.2.3.8] Connect_Return
 ///
-/// [2.2.3.8 Connect_Return]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/ad9fbc8e-0963-44ac-8d71-38021685790c
+/// [2.2.3.8]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/ad9fbc8e-0963-44ac-8d71-38021685790c
 #[derive(Debug)]
 pub struct ConnectReturn {
     pub return_code: ReturnCode,
@@ -1118,9 +1118,9 @@ impl rpce::HeaderlessEncode for ConnectReturn {
     }
 }
 
-/// [2.2.2.16 HCardAndDisposition_Call]
+/// [2.2.2.16] HCardAndDisposition_Call
 ///
-/// [2.2.2.16 HCardAndDisposition_Call]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/f15ae865-9e99-4c5b-bb43-15a6b4885bd0
+/// [2.2.2.16]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/f15ae865-9e99-4c5b-bb43-15a6b4885bd0
 #[derive(Debug)]
 pub struct HCardAndDispositionCall {
     pub handle: ScardHandle,
@@ -1146,9 +1146,9 @@ impl rpce::HeaderlessDecode for HCardAndDispositionCall {
     }
 }
 
-/// [2.2.2.19 Transmit_Call]
+/// [2.2.2.19] Transmit_Call
 ///
-/// [2.2.2.19 Transmit_Call]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/e3861cfa-e61b-4d64-b19d-f6b31e076beb
+/// [2.2.2.19]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/e3861cfa-e61b-4d64-b19d-f6b31e076beb
 #[derive(Debug)]
 pub struct TransmitCall {
     pub handle: ScardHandle,
@@ -1210,9 +1210,9 @@ impl rpce::HeaderlessDecode for TransmitCall {
     }
 }
 
-/// [2.2.1.8 SCardIO_Request]
+/// [2.2.1.8] SCardIO_Request
 ///
-/// [2.2.1.8 SCardIO_Request]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/f6e15da8-5bc0-4ef6-b28a-ce88e8415621
+/// [2.2.1.8]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/f6e15da8-5bc0-4ef6-b28a-ce88e8415621
 #[derive(Debug, Clone)]
 pub struct SCardIORequest {
     pub protocol: CardProtocol,
@@ -1271,9 +1271,9 @@ impl ndr::Encode for SCardIORequest {
     }
 }
 
-/// [2.2.3.11 Transmit_Return]
+/// [2.2.3.11] Transmit_Return
 ///
-/// [2.2.3.11 Transmit_Return]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/252cffd0-58b8-434d-9e1b-0d547544fb0f
+/// [2.2.3.11]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/252cffd0-58b8-434d-9e1b-0d547544fb0f
 #[derive(Debug)]
 pub struct TransmitReturn {
     pub return_code: ReturnCode,
@@ -1331,9 +1331,9 @@ impl rpce::HeaderlessEncode for TransmitReturn {
     }
 }
 
-/// [2.2.2.18 Status_Call]
+/// [2.2.2.18] Status_Call
 ///
-/// [2.2.2.18 Status_Call]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/f1139aed-e578-47f3-a800-f36b56c80500
+/// [2.2.2.18]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/f1139aed-e578-47f3-a800-f36b56c80500
 #[derive(Debug)]
 pub struct StatusCall {
     pub handle: ScardHandle,
@@ -1368,9 +1368,9 @@ impl rpce::HeaderlessDecode for StatusCall {
     }
 }
 
-/// [2.2.3.10 Status_Return]
+/// [2.2.3.10] Status_Return
 ///
-/// [2.2.3.10 Status_Return]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/987c1358-ad6b-4c8e-88e1-06210c28a66f
+/// [2.2.3.10]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/987c1358-ad6b-4c8e-88e1-06210c28a66f
 #[derive(Debug)]
 pub struct StatusReturn {
     pub return_code: ReturnCode,
@@ -1439,9 +1439,9 @@ impl rpce::HeaderlessEncode for StatusReturn {
     }
 }
 
-/// [2.2.4 Card/Reader State]
+/// [2.2.4] Card/Reader State
 ///
-/// [2.2.4 Card/Reader State]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/264bc504-1195-43ff-a057-3d86a02c5d9c
+/// [2.2.4]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/264bc504-1195-43ff-a057-3d86a02c5d9c
 #[derive(Debug, Clone, Copy)]
 pub enum CardState {
     /// SCARD_UNKNOWN
@@ -1466,9 +1466,9 @@ impl From<CardState> for u32 {
     }
 }
 
-/// [2.2.2.2 Context_Call]
+/// [2.2.2.2] Context_Call
 ///
-/// [2.2.2.2 Context_Call]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/b11d26d9-c3d5-4e96-8d9f-aba35cded852
+/// [2.2.2.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/b11d26d9-c3d5-4e96-8d9f-aba35cded852
 #[derive(Debug)]
 pub struct ContextCall {
     pub context: ScardContext,
@@ -1489,9 +1489,9 @@ impl rpce::HeaderlessDecode for ContextCall {
     }
 }
 
-/// [2.2.2.32 GetDeviceTypeId_Call]
+/// [2.2.2.32] GetDeviceTypeId_Call
 ///
-/// [2.2.2.32 GetDeviceTypeId_Call]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/b5e18874-c42d-42ea-b1b1-3fd86a8a95f1
+/// [2.2.2.32]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/b5e18874-c42d-42ea-b1b1-3fd86a8a95f1
 #[derive(Debug)]
 pub struct GetDeviceTypeIdCall {
     pub context: ScardContext,
@@ -1520,9 +1520,9 @@ impl rpce::HeaderlessDecode for GetDeviceTypeIdCall {
     }
 }
 
-/// [2.2.3.15 GetDeviceTypeId_Return]
+/// [2.2.3.15] GetDeviceTypeId_Return
 ///
-/// [2.2.3.15 GetDeviceTypeId_Return]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/fed90d29-c41f-490a-86e9-7e88e42656b2
+/// [2.2.3.15]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/fed90d29-c41f-490a-86e9-7e88e42656b2
 #[derive(Debug)]
 pub struct GetDeviceTypeIdReturn {
     pub return_code: ReturnCode,
@@ -1558,9 +1558,9 @@ impl rpce::HeaderlessEncode for GetDeviceTypeIdReturn {
     }
 }
 
-/// [2.2.2.26 ReadCacheW_Call]
+/// [2.2.2.26] ReadCacheW_Call
 ///
-/// [2.2.2.26 ReadCacheW_Call]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/f45705cf-9299-4802-b408-685f02025e6a
+/// [2.2.2.26]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/f45705cf-9299-4802-b408-685f02025e6a
 #[derive(Debug)]
 pub struct ReadCacheCall {
     pub lookup_name: String,
@@ -1584,9 +1584,9 @@ impl rpce::HeaderlessDecode for ReadCacheCall {
     }
 }
 
-/// [2.2.1.9 ReadCache_Common]
+/// [2.2.1.9] ReadCache_Common
 ///
-/// [2.2.1.9 ReadCache_Common]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/3f9e07fa-66e2-498b-920c-39531709116b
+/// [2.2.1.9]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/3f9e07fa-66e2-498b-920c-39531709116b
 #[derive(Debug)]
 pub struct ReadCacheCommon {
     pub context: ScardContext,
@@ -1629,9 +1629,9 @@ impl ndr::Decode for ReadCacheCommon {
     }
 }
 
-/// [2.2.3.1 ReadCache_Return]
+/// [2.2.3.1] ReadCache_Return
 ///
-/// [2.2.3.1 ReadCache_Return]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/da342355-e37f-485e-a490-3222a97fa356
+/// [2.2.3.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/da342355-e37f-485e-a490-3222a97fa356
 #[derive(Debug)]
 pub struct ReadCacheReturn {
     pub return_code: ReturnCode,
@@ -1670,9 +1670,9 @@ impl rpce::HeaderlessEncode for ReadCacheReturn {
     }
 }
 
-/// [2.2.2.28 WriteCacheW_Call]
+/// [2.2.2.28] WriteCacheW_Call
 ///
-/// [2.2.2.28 WriteCacheW_Call]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/3969bdcd-ecf3-42db-8bc6-2d6f970f9c67
+/// [2.2.2.28]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/3969bdcd-ecf3-42db-8bc6-2d6f970f9c67
 #[derive(Debug)]
 pub struct WriteCacheCall {
     pub lookup_name: String,
@@ -1696,9 +1696,9 @@ impl rpce::HeaderlessDecode for WriteCacheCall {
     }
 }
 
-/// [2.2.1.10 WriteCache_Common]
+/// [2.2.1.10] WriteCache_Common
 ///
-/// [2.2.1.10 WriteCache_Common]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/5604251b-9173-457c-9476-57863df9010e
+/// [2.2.1.10]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/5604251b-9173-457c-9476-57863df9010e
 #[derive(Debug)]
 pub struct WriteCacheCommon {
     pub context: ScardContext,
@@ -1743,9 +1743,9 @@ impl ndr::Decode for WriteCacheCommon {
     }
 }
 
-/// [2.2.2.31 GetReaderIcon_Call]
+/// [2.2.2.31] GetReaderIcon_Call
 ///
-/// [2.2.2.31 GetReaderIcon_Call]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/e6a68d90-697f-4b98-8ad6-f74853d27ccb
+/// [2.2.2.31]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/e6a68d90-697f-4b98-8ad6-f74853d27ccb
 #[derive(Debug)]
 pub struct GetReaderIconCall {
     pub context: ScardContext,
@@ -1771,9 +1771,9 @@ impl rpce::HeaderlessDecode for GetReaderIconCall {
     }
 }
 
-/// [2.2.3.14 GetReaderIcon_Return]
+/// [2.2.3.14] GetReaderIcon_Return
 ///
-/// [2.2.3.14 GetReaderIcon_Return]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/f011f3d9-e2a4-4c43-a336-4c89ecaa8360
+/// [2.2.3.14]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/f011f3d9-e2a4-4c43-a336-4c89ecaa8360
 #[derive(Debug)]
 pub struct GetReaderIconReturn {
     pub return_code: ReturnCode,

--- a/crates/ironrdp-rdpdr/src/pdu/esc/rpce.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/esc/rpce.rs
@@ -162,9 +162,9 @@ pub trait HeaderlessDecode: Sized {
     fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self>;
 }
 
-/// [2.2.6.1 Common Type Header for the Serialization Stream]
+/// [2.2.6.1] Common Type Header for the Serialization Stream
 ///
-/// [2.2.6.1 Common Type Header for the Serialization Stream]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/6d75d40e-e2d2-4420-b9e9-8508a726a9ae
+/// [2.2.6.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/6d75d40e-e2d2-4420-b9e9-8508a726a9ae
 struct StreamHeader {
     version: u8,
     endianness: Endianness,
@@ -247,9 +247,9 @@ impl From<Endianness> for u8 {
     }
 }
 
-/// [2.2.6.2 Private Header for Constructed Type]
+/// [2.2.6.2] Private Header for Constructed Type
 ///
-/// [2.2.6.2 Private Header for Constructed Type]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/63949ba8-bc88-4c0c-9377-23f14b197827
+/// [2.2.6.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/63949ba8-bc88-4c0c-9377-23f14b197827
 #[derive(Debug)]
 struct TypeHeader {
     object_buffer_length: u32,

--- a/crates/ironrdp-rdpdr/src/pdu/mod.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/mod.rs
@@ -201,8 +201,9 @@ impl From<DeviceCreateResponse> for RdpdrPdu {
     }
 }
 
-/// [2.2.1.1 Shared Header (RDPDR_HEADER)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/29d4108f-8163-4a67-8271-e48c4b9c2a7c)
-/// A header that is shared by all RDPDR PDUs.
+/// [2.2.1.1] Shared Header (RDPDR_HEADER), a header that is shared by all RDPDR PDUs.
+///
+/// [2.2.1.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/29d4108f-8163-4a67-8271-e48c4b9c2a7c
 #[derive(Debug)]
 pub struct SharedHeader {
     pub component: Component,


### PR DESCRIPTION
@ibeckermayer you’re right, there were quite a bunch of these!

I ran `sd` commands to change most places, and modified using multi-cursors the last few places it didn’t covered (mainly the places which were not consistent in the first place).

```shell
$ fd --extension=rs --exec sd "/// \[([\d\.]+)( .+)\]:" "/// [\$1]:"
$ fd --extension=rs --exec sd "/// \[([\d\.]+)( .+)\]" "/// [\$1]\$2"
```