### PR TITLE
chore(web-client): fix prettier checks

### DIFF
--- a/web-client/iron-remote-gui/package.json
+++ b/web-client/iron-remote-gui/package.json
@@ -6,7 +6,7 @@
     "Benoit Cortier",
     "Zacharia Ellaham"
   ],
-  "description": "Web Component providing agnostic implementation for Iron Wasm base client.",
+  "description": "Web Component providing agnostic implementation for Iron Wasm base client",
   "version": "0.8.1",
   "type": "module",
   "private": true,
@@ -19,10 +19,11 @@
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "npm run lint:prettier && npm run lint:eslint",
-    "lint:prettier": "prettier . --check",
+    "lint:prettier": "prettier --check . --plugin prettier-plugin-svelte",
     "lint:eslint": "eslint src/**",
-    "format": "prettier . --write ."
+    "format": "prettier --write . --plugin prettier-plugin-svelte"
   },
+  "//": "FIXME: There's currently an issue with Prettier 3.0 which requires the seemingly redundant --plugin setting. This bug will be fixed in the 3.1, and the extra argument may then be removed",
   "devDependencies": {
     "eslint": "^8.52.0",
     "eslint-config-prettier": "^9.0.0",

--- a/web-client/iron-remote-gui/src/enums/MouseButton.ts
+++ b/web-client/iron-remote-gui/src/enums/MouseButton.ts
@@ -1,7 +1,0 @@
-﻿export enum MouseButton {
-    LEFT = 0,
-    MIDDLE = 1,
-    RIGHT = 2,
-    BROWSER_BACK = 3,
-    BROWSER_FORWARD = 4,
-}

--- a/web-client/iron-remote-gui/src/enums/MouseButtonState.ts
+++ b/web-client/iron-remote-gui/src/enums/MouseButtonState.ts
@@ -1,4 +1,0 @@
-﻿export enum MouseButtonState {
-    MOUSE_DOWN,
-    MOUSE_UP,
-}

--- a/web-client/iron-svelte-client/package.json
+++ b/web-client/iron-svelte-client/package.json
@@ -14,10 +14,11 @@
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "npm run lint:prettier && npm run lint:eslint",
-    "lint:prettier": "prettier . --check",
+    "lint:prettier": "prettier --check . --plugin prettier-plugin-svelte",
     "lint:eslint": "eslint src/**",
-    "format": "prettier . --write ."
+    "format": "prettier --write . --plugin prettier-plugin-svelte"
   },
+  "//": "FIXME: There's currently an issue with Prettier 3.0 which requires the seemingly redundant --plugin setting. This bug will be fixed in the 3.1, and the extra argument may then be removed",
   "devDependencies": {
     "beercss": "^2.3.0",
     "cross-env": "7.0.3",


### PR DESCRIPTION
There's currently an issue with Prettier 3.0 which requires the seemingly redundant --plugin setting. This bug will be fixed in the 3.1, and the extra argument may then be removed.