### PR TITLE
style: normalize casing of error messages

### DIFF
--- a/crates/ironrdp-cliprdr-format/Cargo.toml
+++ b/crates/ironrdp-cliprdr-format/Cargo.toml
@@ -19,5 +19,4 @@ test = false
 [dependencies]
 ironrdp-pdu.workspace = true
 thiserror.workspace = true
-
 png = "0.17"

--- a/crates/ironrdp-cliprdr-format/src/bitmap.rs
+++ b/crates/ironrdp-cliprdr-format/src/bitmap.rs
@@ -7,17 +7,17 @@ const MAX_BUFFER_SIZE: usize = 64 * 1024 * 1024; // 64 MB
 
 #[derive(Debug, Error)]
 pub enum BitmapError {
-    #[error("Invalid bitmap header")]
+    #[error("invalid bitmap header")]
     InvalidHeader(ironrdp_pdu::PduError),
-    #[error("Unsupported bitmap: {0}")]
+    #[error("unsupported bitmap: {0}")]
     Unsupported(&'static str),
-    #[error("One of bitmap's dimensions is invalid")]
+    #[error("one of bitmap's dimensions is invalid")]
     InvalidSize,
-    #[error("Buffer size required for allocation is too big")]
+    #[error("buffer size required for allocation is too big")]
     BufferTooBig,
-    #[error("Image width is too big")]
+    #[error("image width is too big")]
     WidthTooBig,
-    #[error("Image height is too big")]
+    #[error("image height is too big")]
     HeightTooBig,
     #[error("PNG encoding error")]
     PngEncode(#[from] png::EncodingError),

--- a/crates/ironrdp-cliprdr-format/src/html.rs
+++ b/crates/ironrdp-cliprdr-format/src/html.rs
@@ -2,13 +2,13 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum HtmlError {
-    #[error("Invalid CF_HTML format")]
+    #[error("invalid CF_HTML format")]
     InvalidFormat,
-    #[error("Invalid UTF-8")]
+    #[error("invalid UTF-8")]
     InvalidUtf8(#[from] std::string::FromUtf8Error),
-    #[error("Failed to parse integer")]
+    #[error("failed to parse integer")]
     InvalidInteger(#[from] std::num::ParseIntError),
-    #[error("Invalid integer conversion")]
+    #[error("invalid integer conversion")]
     InvalidConversion,
 }
 

--- a/crates/ironrdp-cliprdr-native/src/windows.rs
+++ b/crates/ironrdp-cliprdr-native/src/windows.rs
@@ -28,40 +28,40 @@ pub type WinCliprdrResult<T> = Result<T, WinCliprdrError>;
 
 #[derive(Debug, Error)]
 pub enum WinCliprdrError {
-    #[error("Failed to register clipboard format listener")]
+    #[error("failed to register clipboard format listener")]
     AddClipboardFormatListener,
 
-    #[error("Failed to enumerate formats available in the current clipboard")]
+    #[error("failed to enumerate formats available in the current clipboard")]
     FormatsEnumeration,
 
-    #[error("Clipboard is busy")]
+    #[error("clipboard is busy")]
     ClipboardAccessDenied,
 
-    #[error("Failed to open the clipboard")]
+    #[error("failed to open the clipboard")]
     ClipboardOpen,
 
-    #[error("Failed to empty the clipboard")]
+    #[error("failed to empty the clipboard")]
     ClipboardEmpty,
 
-    #[error("Failed to convert UTF-16 string to UTF-8")]
+    #[error("failed to convert UTF-16 string to UTF-8")]
     Uft16Conversion,
 
-    #[error("Failed to get current clipboard data")]
+    #[error("failed to get current clipboard data")]
     ClipboardData,
 
-    #[error("Failed to set clipboard data")]
+    #[error("failed to set clipboard data")]
     SetClipboardData,
 
-    #[error("Failed to subclass window")]
+    #[error("failed to subclass window")]
     WindowSubclass,
 
-    #[error("Failed to allocate global memory")]
+    #[error("failed to allocate global memory")]
     Alloc,
 
-    #[error("Failed to receive data from remote clipboard")]
+    #[error("failed to receive data from remote clipboard")]
     DataReceiveTimeout,
 
-    #[error("Failed to render clipboard format")]
+    #[error("failed to render clipboard format")]
     RenderFormat,
 
     #[error("WinAPI error")]

--- a/crates/ironrdp-cliprdr/src/lib.rs
+++ b/crates/ironrdp-cliprdr/src/lib.rs
@@ -30,10 +30,10 @@ pub type CliprdrSvcMessages = SvcProcessorMessages<Cliprdr>;
 
 #[derive(Debug, Error)]
 enum ClipboardError {
-    #[error("Received clipboard PDU is not implemented")]
+    #[error("received clipboard PDU is not implemented")]
     UnimplementedPdu { pdu: &'static str },
 
-    #[error("Sent format list was rejected")]
+    #[error("sent format list was rejected")]
     FormatListRejected,
 }
 

--- a/crates/ironrdp-glutin-renderer/src/renderer.rs
+++ b/crates/ironrdp-glutin-renderer/src/renderer.rs
@@ -168,21 +168,21 @@ impl Renderer {
 
 #[derive(Debug, Error)]
 pub enum RendererError {
-    #[error("Unable to send message on channel {0}")]
+    #[error("unable to send message on channel {0}")]
     SendError(String),
-    #[error("Unable to receive message on channel {0}")]
+    #[error("unable to receive message on channel {0}")]
     ReceiveError(String),
-    #[error("errored to decode openh264 stream {0}")]
+    #[error("failed to decode OpenH264 stream {0}")]
     OpenH264Error(#[from] openh264::Error),
-    #[error("Graphics pipeline protocol error: {0}")]
+    #[error("graphics pipeline protocol error: {0}")]
     GraphicsPipelineError(#[from] gfx::GraphicsPipelineError),
-    #[error("Invalid surface id: {0}")]
+    #[error("invalid surface id: {0}")]
     InvalidSurfaceId(u16),
-    #[error("Codec not supported: {0:?}")]
+    #[error("codec not supported: {0:?}")]
     UnsupportedCodec(Codec1Type),
-    #[error("errored to decode rdp data")]
+    #[error("failed to decode rdp data")]
     DecodeError,
-    #[error("Lock poisoned")]
+    #[error("lock poisoned")]
     LockPoisonedError,
 }
 

--- a/crates/ironrdp-graphics/src/pointer.rs
+++ b/crates/ironrdp-graphics/src/pointer.rs
@@ -27,11 +27,11 @@ use crate::color_conversion::rdp_16bit_to_rgb;
 
 #[derive(Debug, Error)]
 pub enum PointerError {
-    #[error("Invalid pointer xorMask size. Expected: {expected}, actual: {actual}")]
+    #[error("invalid pointer xorMask size. Expected: {expected}, actual: {actual}")]
     InvalidXorMaskSize { expected: usize, actual: usize },
-    #[error("Invalid pointer andMask size. Expected: {expected}, actual: {actual}")]
+    #[error("invalid pointer andMask size. Expected: {expected}, actual: {actual}")]
     InvalidAndMaskSize { expected: usize, actual: usize },
-    #[error("Not supported pointer bpp: {bpp}")]
+    #[error("not supported pointer bpp: {bpp}")]
     NotSupportedBpp { bpp: usize },
     #[error(transparent)]
     Pdu(#[from] ironrdp_pdu::PduError),

--- a/crates/ironrdp-graphics/src/rdp6/bitmap_stream/decoder.rs
+++ b/crates/ironrdp-graphics/src/rdp6/bitmap_stream/decoder.rs
@@ -7,11 +7,11 @@ use crate::rdp6::rle::{decompress_8bpp_plane, RleDecodeError};
 
 #[derive(Debug, Error)]
 pub enum BitmapDecodeError {
-    #[error("Failed to decode RDP6 bitmap stream PDU: {0}")]
+    #[error("failed to decode RDP6 bitmap stream PDU: {0}")]
     Pdu(#[from] PduError),
-    #[error("Failed to perform RLE decompression of RDP6 bitmap stream: {0}")]
+    #[error("failed to perform RLE decompression of RDP6 bitmap stream: {0}")]
     Rle(#[from] RleDecodeError),
-    #[error("Color plane data size provided in PDU is not sufficient to reconstruct the bitmap")]
+    #[error("color plane data size provided in PDU is not sufficient to reconstruct the bitmap")]
     InvalidUncompressedDataSize,
 }
 

--- a/crates/ironrdp-graphics/src/rdp6/bitmap_stream/encoder.rs
+++ b/crates/ironrdp-graphics/src/rdp6/bitmap_stream/encoder.rs
@@ -7,9 +7,9 @@ use crate::rdp6::rle::{compress_8bpp_plane, RleEncodeError};
 
 #[derive(Debug, Error)]
 pub enum BitmapEncodeError {
-    #[error("Failed to rle compress")]
+    #[error("failed to rle compress")]
     Rle(RleEncodeError),
-    #[error("Failed to encode pdu")]
+    #[error("failed to encode pdu")]
     Pdu(PduError),
 }
 

--- a/crates/ironrdp-graphics/src/rdp6/rle.rs
+++ b/crates/ironrdp-graphics/src/rdp6/rle.rs
@@ -10,25 +10,25 @@ const MAX_DECODED_SEGMENT_SIZE: usize = 47;
 
 #[derive(Debug, Error)]
 pub enum RleDecodeError {
-    #[error("Failed to read RLE-compressed data: {0}")]
+    #[error("failed to read RLE-compressed data: {0}")]
     ReadCompressedData(#[source] std::io::Error),
 
-    #[error("Failed to write decompressed data: {0}")]
+    #[error("failed to write decompressed data: {0}")]
     WriteDecompressedData(#[source] std::io::Error),
 
-    #[error("Invalid RLE segment header")]
+    #[error("invalid RLE segment header")]
     InvalidSegmentHeader,
 
-    #[error("Decoded scanline segments length exceeds scanline length")]
+    #[error("decoded scanline segments length exceeds scanline length")]
     SegmentDoNotFitScanline,
 }
 
 #[derive(Debug, Error)]
 pub enum RleEncodeError {
-    #[error("Not enough data to compress")]
+    #[error("not enough data to compress")]
     NotEnoughBytes,
 
-    #[error("Destination buffer is too small")]
+    #[error("destination buffer is too small")]
     BufferTooSmall,
 }
 

--- a/crates/ironrdp-graphics/src/rlgr.rs
+++ b/crates/ironrdp-graphics/src/rlgr.rs
@@ -229,6 +229,6 @@ impl From<u32> for CompressionMode {
 pub enum RlgrError {
     #[error("IO error: {0}")]
     IoError(#[from] io::Error),
-    #[error("The input tile is empty")]
+    #[error("the input tile is empty")]
     EmptyTile,
 }

--- a/crates/ironrdp-graphics/src/zgfx/mod.rs
+++ b/crates/ironrdp-graphics/src/zgfx/mod.rs
@@ -430,12 +430,12 @@ lazy_static::lazy_static! {
 pub enum ZgfxError {
     #[error("IO error")]
     IOError(#[from] io::Error),
-    #[error("Invalid compression type")]
+    #[error("invalid compression type")]
     InvalidCompressionType,
-    #[error("Invalid segmented descriptor")]
+    #[error("invalid segmented descriptor")]
     InvalidSegmentedDescriptor,
     #[error(
-        "Decompressed size of segments ({}) does not equal to uncompressed size ({})",
+        "decompressed size of segments ({}) does not equal to uncompressed size ({})",
         decompressed_size,
         uncompressed_size
     )]
@@ -443,7 +443,7 @@ pub enum ZgfxError {
         decompressed_size: usize,
         uncompressed_size: usize,
     },
-    #[error("Token bits not found")]
+    #[error("token bits not found")]
     TokenBitsNotFound,
 }
 

--- a/crates/ironrdp-pdu/src/codecs/rfx.rs
+++ b/crates/ironrdp-pdu/src/codecs/rfx.rs
@@ -208,55 +208,55 @@ pub enum BlockType {
 pub enum RfxError {
     #[error("IO error")]
     IoError(#[from] io::Error),
-    #[error("Got invalid block type: {0}")]
+    #[error("got invalid block type: {0}")]
     InvalidBlockType(u16),
-    #[error("Got unexpected Block type: expected ({expected:?}) != actual({actual:?})")]
+    #[error("got unexpected Block type: expected ({expected:?}) != actual({actual:?})")]
     UnexpectedBlockType { expected: BlockType, actual: BlockType },
-    #[error("Got unexpected Block type ({0:?}) while was expected header message")]
+    #[error("got unexpected Block type ({0:?}) while was expected header message")]
     InvalidHeaderBlockType(BlockType),
-    #[error("Got invalid block length: {0}")]
+    #[error("got invalid block length: {0}")]
     InvalidBlockLength(usize),
-    #[error("Got invalid Sync magic number: {0}")]
+    #[error("got invalid Sync magic number: {0}")]
     InvalidMagicNumber(u32),
-    #[error("Got invalid Sync version: {0}")]
+    #[error("got invalid Sync version: {0}")]
     InvalidSyncVersion(u16),
-    #[error("Got invalid codecs number: {0}")]
+    #[error("got invalid codecs number: {0}")]
     InvalidCodecsNumber(u8),
-    #[error("Got invalid codec ID: {0}")]
+    #[error("got invalid codec ID: {0}")]
     InvalidCodecId(u8),
-    #[error("Got invalid codec version: {0}")]
+    #[error("got invalid codec version: {0}")]
     InvalidCodecVersion(u16),
-    #[error("Got invalid channel ID: {0}")]
+    #[error("got invalid channel ID: {0}")]
     InvalidChannelId(u8),
-    #[error("Got invalid context ID: {0}")]
+    #[error("got invalid context ID: {0}")]
     InvalidContextId(u8),
-    #[error("Got invalid context tile size: {0}")]
+    #[error("got invalid context tile size: {0}")]
     InvalidTileSize(u16),
-    #[error("Got invalid conversion transform: {0}")]
+    #[error("got invalid conversion transform: {0}")]
     InvalidColorConversionTransform(u16),
-    #[error("Got invalid DWT: {0}")]
+    #[error("got invalid DWT: {0}")]
     InvalidDwt(u16),
-    #[error("Got invalid entropy algorithm: {0}")]
+    #[error("got invalid entropy algorithm: {0}")]
     InvalidEntropyAlgorithm(u16),
-    #[error("Got invalid quantization type: {0}")]
+    #[error("got invalid quantization type: {0}")]
     InvalidQuantizationType(u16),
-    #[error("Input buffer is shorter than the data length: {actual} < {expected}")]
+    #[error("input buffer is shorter than the data length: {actual} < {expected}")]
     InvalidDataLength { expected: usize, actual: usize },
-    #[error("Got invalid Region LRF: {0}")]
+    #[error("got invalid Region LRF: {0}")]
     InvalidLrf(bool),
-    #[error("Got invalid Region type: {0}")]
+    #[error("got invalid Region type: {0}")]
     InvalidRegionType(u16),
-    #[error("Got invalid number of tilesets: {0}")]
+    #[error("got invalid number of tilesets: {0}")]
     InvalidNumberOfTilesets(u16),
-    #[error("Got invalid ID of context: {0}")]
+    #[error("got invalid ID of context: {0}")]
     InvalidIdOfContext(u16),
-    #[error("Got invalid TileSet subtype: {0}")]
+    #[error("got invalid TileSet subtype: {0}")]
     InvalidSubtype(u16),
-    #[error("Got invalid IT flag of TileSet: {0}")]
+    #[error("got invalid IT flag of TileSet: {0}")]
     InvalidItFlag(bool),
-    #[error("Got invalid channel width: {0}")]
+    #[error("got invalid channel width: {0}")]
     InvalidChannelWidth(i16),
-    #[error("Got invalid channel height: {0}")]
+    #[error("got invalid channel height: {0}")]
     InvalidChannelHeight(i16),
 }
 

--- a/crates/ironrdp-pdu/src/gcc.rs
+++ b/crates/ironrdp-pdu/src/gcc.rs
@@ -371,28 +371,28 @@ impl<T: FromPrimitive + ToPrimitive> PduParsing for UserDataHeader<T> {
 pub enum GccError {
     #[error("IO error")]
     IOError(#[from] io::Error),
-    #[error("Core data block error")]
+    #[error("core data block error")]
     CoreError(#[from] CoreDataError),
-    #[error("Security data block error")]
+    #[error("security data block error")]
     SecurityError(#[from] SecurityDataError),
-    #[error("Network data block error")]
+    #[error("network data block error")]
     NetworkError(#[from] NetworkDataError),
-    #[error("Cluster data block error")]
+    #[error("cluster data block error")]
     ClusterError(#[from] ClusterDataError),
-    #[error("Monitor data block error")]
+    #[error("monitor data block error")]
     MonitorError(#[from] MonitorDataError),
-    #[error("Multi-transport channel data block error")]
+    #[error("multi-transport channel data block error")]
     MultiTransportChannelError(#[from] MultiTransportChannelDataError),
-    #[error("Monitor extended data block error")]
+    #[error("monitor extended data block error")]
     MonitorExtendedError(#[from] MonitorExtendedDataError),
-    #[error("Invalid GCC block type")]
+    #[error("invalid GCC block type")]
     InvalidGccType,
-    #[error("Invalid conference create request: {0}")]
+    #[error("invalid conference create request: {0}")]
     InvalidConferenceCreateRequest(String),
-    #[error("Invalid Conference create response: {0}")]
+    #[error("invalid Conference create response: {0}")]
     InvalidConferenceCreateResponse(String),
-    #[error("A server did not send the required GCC data block: {0:?}")]
+    #[error("a server did not send the required GCC data block: {0:?}")]
     RequiredClientDataBlockIsAbsent(ClientGccType),
-    #[error("A client did not send the required GCC data block: {0:?}")]
+    #[error("a client did not send the required GCC data block: {0:?}")]
     RequiredServerDataBlockIsAbsent(ServerGccType),
 }

--- a/crates/ironrdp-pdu/src/gcc/cluster_data.rs
+++ b/crates/ironrdp-pdu/src/gcc/cluster_data.rs
@@ -77,6 +77,6 @@ pub enum RedirectionVersion {
 pub enum ClusterDataError {
     #[error("IO error")]
     IOError(#[from] io::Error),
-    #[error("Invalid redirection flags field")]
+    #[error("invalid redirection flags field")]
     InvalidRedirectionFlags,
 }

--- a/crates/ironrdp-pdu/src/gcc/core_data.rs
+++ b/crates/ironrdp-pdu/src/gcc/core_data.rs
@@ -45,24 +45,24 @@ impl RdpVersion {
 pub enum CoreDataError {
     #[error("IO error")]
     IOError(#[from] io::Error),
-    #[error("Invalid version field")]
+    #[error("invalid version field")]
     InvalidVersion,
-    #[error("Invalid color depth field")]
+    #[error("invalid color depth field")]
     InvalidColorDepth,
-    #[error("Invalid post beta color depth field")]
+    #[error("invalid post beta color depth field")]
     InvalidPostBetaColorDepth,
-    #[error("Invalid high color depth field")]
+    #[error("invalid high color depth field")]
     InvalidHighColorDepth,
-    #[error("Invalid supported color depths field")]
+    #[error("invalid supported color depths field")]
     InvalidSupportedColorDepths,
-    #[error("Invalid secure access sequence field")]
+    #[error("invalid secure access sequence field")]
     InvalidSecureAccessSequence,
-    #[error("Invalid keyboard type field")]
+    #[error("invalid keyboard type field")]
     InvalidKeyboardType,
-    #[error("Invalid early capability flags field")]
+    #[error("invalid early capability flags field")]
     InvalidEarlyCapabilityFlags,
-    #[error("Invalid connection type field")]
+    #[error("invalid connection type field")]
     InvalidConnectionType,
-    #[error("Invalid server security protocol field")]
+    #[error("invalid server security protocol field")]
     InvalidServerSecurityProtocol,
 }

--- a/crates/ironrdp-pdu/src/gcc/monitor_data.rs
+++ b/crates/ironrdp-pdu/src/gcc/monitor_data.rs
@@ -104,8 +104,8 @@ bitflags! {
 pub enum MonitorDataError {
     #[error("IO error")]
     IOError(#[from] io::Error),
-    #[error("Invalid monitor count field")]
+    #[error("invalid monitor count field")]
     InvalidMonitorCount,
-    #[error("Invalid monitor flags field")]
+    #[error("invalid monitor flags field")]
     InvalidMonitorFlags,
 }

--- a/crates/ironrdp-pdu/src/gcc/monitor_extended_data.rs
+++ b/crates/ironrdp-pdu/src/gcc/monitor_extended_data.rs
@@ -118,10 +118,10 @@ pub enum MonitorOrientation {
 pub enum MonitorExtendedDataError {
     #[error("IO error")]
     IOError(#[from] io::Error),
-    #[error("Invalid monitor attribute size field")]
+    #[error("invalid monitor attribute size field")]
     InvalidMonitorAttributeSize,
-    #[error("Invalid monitor orientation field")]
+    #[error("invalid monitor orientation field")]
     InvalidMonitorOrientation,
-    #[error("Invalid monitor count field")]
+    #[error("invalid monitor count field")]
     InvalidMonitorCount,
 }

--- a/crates/ironrdp-pdu/src/gcc/multi_transport_channel_data.rs
+++ b/crates/ironrdp-pdu/src/gcc/multi_transport_channel_data.rs
@@ -47,6 +47,6 @@ bitflags! {
 pub enum MultiTransportChannelDataError {
     #[error("IO error")]
     IOError(#[from] io::Error),
-    #[error("Invalid flags field")]
+    #[error("invalid flags field")]
     InvalidMultiTransportFlags,
 }

--- a/crates/ironrdp-pdu/src/gcc/network_data.rs
+++ b/crates/ironrdp-pdu/src/gcc/network_data.rs
@@ -250,8 +250,8 @@ pub enum NetworkDataError {
     IOError(#[from] io::Error),
     #[error("UTF-8 error")]
     Utf8Error(#[from] str::Utf8Error),
-    #[error("Invalid channel options field")]
+    #[error("invalid channel options field")]
     InvalidChannelOptions,
-    #[error("Invalid channel count field")]
+    #[error("invalid channel count field")]
     InvalidChannelCount,
 }

--- a/crates/ironrdp-pdu/src/gcc/security_data.rs
+++ b/crates/ironrdp-pdu/src/gcc/security_data.rs
@@ -185,14 +185,14 @@ pub enum EncryptionLevel {
 pub enum SecurityDataError {
     #[error("IO error")]
     IOError(#[from] io::Error),
-    #[error("Invalid encryption methods field")]
+    #[error("invalid encryption methods field")]
     InvalidEncryptionMethod,
-    #[error("Invalid encryption level field")]
+    #[error("invalid encryption level field")]
     InvalidEncryptionLevel,
-    #[error("Invalid server random length field: {0}")]
+    #[error("invalid server random length field: {0}")]
     InvalidServerRandomLen(u32),
-    #[error("Invalid input: {0}")]
+    #[error("invalid input: {0}")]
     InvalidInput(String),
-    #[error("Invalid server certificate length: {0}")]
+    #[error("invalid server certificate length: {0}")]
     InvalidServerCertificateLen(u32),
 }

--- a/crates/ironrdp-pdu/src/input/mod.rs
+++ b/crates/ironrdp-pdu/src/input/mod.rs
@@ -138,16 +138,16 @@ impl From<&InputEvent> for InputEventType {
 pub enum InputEventError {
     #[error("IO error")]
     IOError(#[from] io::Error),
-    #[error("Invalid Input Event type: {0}")]
+    #[error("invalid Input Event type: {0}")]
     InvalidInputEventType(u16),
-    #[error("Encryption not supported")]
+    #[error("encryption not supported")]
     EncryptionNotSupported,
-    #[error("Event code not supported {0}")]
+    #[error("event code not supported {0}")]
     EventCodeUnsupported(u8),
-    #[error("Keyboard flags not supported {0}")]
+    #[error("keyboard flags not supported {0}")]
     KeyboardFlagsUnsupported(u8),
-    #[error("Synchronize flags not supported {0}")]
+    #[error("synchronize flags not supported {0}")]
     SynchronizeFlagsUnsupported(u8),
-    #[error("FastPathInput PDU is empty")]
+    #[error("Fast-Path Input Event PDU is empty")]
     EmptyFastPathInput,
 }

--- a/crates/ironrdp-pdu/src/lib.rs
+++ b/crates/ironrdp-pdu/src/lib.rs
@@ -414,7 +414,7 @@ mod legacy {
     pub enum RdpError {
         #[error("IO error")]
         IOError(#[from] std::io::Error),
-        #[error("Received invalid action code: {0}")]
+        #[error("received invalid action code: {0}")]
         InvalidActionCode(u8),
     }
 }

--- a/crates/ironrdp-pdu/src/mcs.rs
+++ b/crates/ironrdp-pdu/src/mcs.rs
@@ -1119,13 +1119,13 @@ mod legacy {
         RdpError(#[from] crate::RdpError),
         #[error("GCC block error")]
         GccError(#[from] GccError),
-        #[error("Invalid disconnect provider ultimatum")]
+        #[error("invalid disconnect provider ultimatum")]
         InvalidDisconnectProviderUltimatum,
-        #[error("Invalid domain MCS PDU")]
+        #[error("invalid domain MCS PDU")]
         InvalidDomainMcsPdu,
-        #[error("Invalid MCS Connection Sequence PDU")]
+        #[error("invalid MCS Connection Sequence PDU")]
         InvalidPdu(String),
-        #[error("Invalid invalid MCS channel id")]
+        #[error("invalid invalid MCS channel id")]
         UnexpectedChannelId(String),
     }
 

--- a/crates/ironrdp-pdu/src/rdp.rs
+++ b/crates/ironrdp-pdu/src/rdp.rs
@@ -61,33 +61,33 @@ impl PduParsing for ClientInfoPdu {
 pub enum RdpError {
     #[error("IO error")]
     IOError(#[from] io::Error),
-    #[error("Client Info PDU error")]
+    #[error("client Info PDU error")]
     ClientInfoError(#[from] ClientInfoError),
-    #[error("Server License PDU error")]
+    #[error("server License PDU error")]
     ServerLicenseError(#[from] ServerLicenseError),
-    #[error("Capability sets error")]
+    #[error("capability sets error")]
     CapabilitySetsError(#[from] CapabilitySetsError),
-    #[error("Finalization PDUs error")]
+    #[error("finalization PDUs error")]
     FinalizationMessagesError(#[from] FinalizationMessagesError),
-    #[error("Invalid RDP security header")]
+    #[error("invalid RDP security header")]
     InvalidSecurityHeader,
-    #[error("Invalid RDP Share Control Header: {0}")]
+    #[error("invalid RDP Share Control Header: {0}")]
     InvalidShareControlHeader(String),
-    #[error("Invalid RDP Share Data Header: {0}")]
+    #[error("invalid RDP Share Data Header: {0}")]
     InvalidShareDataHeader(String),
-    #[error("Invalid RDP Connection Sequence PDU")]
+    #[error("invalid RDP Connection Sequence PDU")]
     InvalidPdu(String),
-    #[error("Unexpected RDP Share Control Header PDU type: {0:?}")]
+    #[error("unexpected RDP Share Control Header PDU type: {0:?}")]
     UnexpectedShareControlPdu(ShareControlPduType),
-    #[error("Unexpected RDP Share Data Header PDU type: {0:?}")]
+    #[error("unexpected RDP Share Data Header PDU type: {0:?}")]
     UnexpectedShareDataPdu(ShareDataPduType),
-    #[error("Save session info PDU error")]
+    #[error("save session info PDU error")]
     SaveSessionInfoError(#[from] session_info::SessionError),
-    #[error("Server set error info PDU error")]
+    #[error("server set error info PDU error")]
     ServerSetErrorInfoError(#[from] ServerSetErrorInfoError),
-    #[error("Input event PDU error")]
+    #[error("input event PDU error")]
     InputEventError(#[from] InputEventError),
-    #[error("Not enough bytes")]
+    #[error("not enough bytes")]
     NotEnoughBytes,
 }
 

--- a/crates/ironrdp-pdu/src/rdp/capability_sets.rs
+++ b/crates/ironrdp-pdu/src/rdp/capability_sets.rs
@@ -536,56 +536,56 @@ enum CapabilitySetType {
 pub enum CapabilitySetsError {
     #[error("IO error")]
     IOError(#[from] io::Error),
-    #[error("Utf8 error")]
+    #[error("UTF-8 error")]
     Utf8Error(#[from] std::string::FromUtf8Error),
-    #[error("Invalid type field")]
+    #[error("invalid type field")]
     InvalidType,
-    #[error("Invalid bitmap compression field")]
+    #[error("invalid bitmap compression field")]
     InvalidCompressionFlag,
-    #[error("Invalid multiple rectangle support field")]
+    #[error("invalid multiple rectangle support field")]
     InvalidMultipleRectSupport,
-    #[error("Invalid protocol version field")]
+    #[error("invalid protocol version field")]
     InvalidProtocolVersion,
-    #[error("Invalid compression types field")]
+    #[error("invalid compression types field")]
     InvalidCompressionTypes,
-    #[error("Invalid update capability flags field")]
+    #[error("invalid update capability flags field")]
     InvalidUpdateCapFlag,
-    #[error("Invalid remote unshare flag field")]
+    #[error("invalid remote unshare flag field")]
     InvalidRemoteUnshareFlag,
-    #[error("Invalid compression level field")]
+    #[error("invalid compression level field")]
     InvalidCompressionLevel,
-    #[error("Invalid brush support level field")]
+    #[error("invalid brush support level field")]
     InvalidBrushSupportLevel,
-    #[error("Invalid glyph support level field")]
+    #[error("invalid glyph support level field")]
     InvalidGlyphSupportLevel,
-    #[error("Invalid RemoteFX capability version")]
+    #[error("invalid RemoteFX capability version")]
     InvalidRfxICapVersion,
-    #[error("Invalid RemoteFX capability tile size")]
+    #[error("invalid RemoteFX capability tile size")]
     InvalidRfxICapTileSize,
-    #[error("Invalid RemoteFXICap color conversion bits")]
+    #[error("invalid RemoteFXICap color conversion bits")]
     InvalidRfxICapColorConvBits,
-    #[error("Invalid RemoteFXICap transform bits")]
+    #[error("invalid RemoteFXICap transform bits")]
     InvalidRfxICapTransformBits,
-    #[error("Invalid RemoteFXICap entropy bits field")]
+    #[error("invalid RemoteFXICap entropy bits field")]
     InvalidRfxICapEntropyBits,
-    #[error("Invalid RemoteFX capability set block type")]
+    #[error("invalid RemoteFX capability set block type")]
     InvalidRfxCapsetBlockType,
-    #[error("Invalid RemoteFX capability set type")]
+    #[error("invalid RemoteFX capability set type")]
     InvalidRfxCapsetType,
-    #[error("Invalid RemoteFX capabilities block type")]
+    #[error("invalid RemoteFX capabilities block type")]
     InvalidRfxCapsBlockType,
-    #[error("Invalid RemoteFX capabilities block length")]
+    #[error("invalid RemoteFX capabilities block length")]
     InvalidRfxCapsBockLength,
-    #[error("Invalid number of capability sets in RemoteFX capabilities")]
+    #[error("invalid number of capability sets in RemoteFX capabilities")]
     InvalidRfxCapsNumCapsets,
-    #[error("Invalid codec property field")]
+    #[error("invalid codec property field")]
     InvalidCodecProperty,
-    #[error("Invalid codec ID")]
+    #[error("invalid codec ID")]
     InvalidCodecID,
-    #[error("Invalid channel chunk size field")]
+    #[error("invalid channel chunk size field")]
     InvalidChunkSize,
-    #[error("Invalid codec property length for the current property ID")]
+    #[error("invalid codec property length for the current property ID")]
     InvalidPropertyLength,
-    #[error("Invalid data length")]
+    #[error("invalid data length")]
     InvalidLength,
 }

--- a/crates/ironrdp-pdu/src/rdp/client_info.rs
+++ b/crates/ironrdp-pdu/src/rdp/client_info.rs
@@ -585,13 +585,13 @@ pub enum ClientInfoError {
     IOError(#[from] io::Error),
     #[error("UTF-8 error")]
     Utf8Error(#[from] std::string::FromUtf8Error),
-    #[error("Invalid address family field")]
+    #[error("invalid address family field")]
     InvalidAddressFamily,
-    #[error("Invalid flags field")]
+    #[error("invalid flags field")]
     InvalidClientInfoFlags,
-    #[error("Invalid performance flags field")]
+    #[error("invalid performance flags field")]
     InvalidPerformanceFlags,
-    #[error("Invalid reconnect cookie field")]
+    #[error("invalid reconnect cookie field")]
     InvalidReconnectCookie,
 }
 

--- a/crates/ironrdp-pdu/src/rdp/finalization_messages.rs
+++ b/crates/ironrdp-pdu/src/rdp/finalization_messages.rs
@@ -179,18 +179,18 @@ bitflags! {
 pub enum FinalizationMessagesError {
     #[error("IO error")]
     IOError(#[from] io::Error),
-    #[error("Monitor Data error")]
+    #[error("monitor Data error")]
     MonitorDataError(#[from] gcc::MonitorDataError),
-    #[error("Invalid message type field in Synchronize PDU")]
+    #[error("invalid message type field in Synchronize PDU")]
     InvalidMessageType,
-    #[error("Invalid control action field in Control PDU")]
+    #[error("invalid control action field in Control PDU")]
     InvalidControlAction,
-    #[error("Invalid grant id field in Control PDU")]
+    #[error("invalid grant id field in Control PDU")]
     InvalidGrantId,
-    #[error("Invalid control id field in Control PDU")]
+    #[error("invalid control id field in Control PDU")]
     InvalidControlId,
-    #[error("Invalid list flags field in Font List PDU")]
+    #[error("invalid list flags field in Font List PDU")]
     InvalidListFlags,
-    #[error("Invalid monitor count field: {0}")]
+    #[error("invalid monitor count field: {0}")]
     InvalidMonitorCount(u32),
 }

--- a/crates/ironrdp-pdu/src/rdp/server_error_info.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_error_info.rs
@@ -389,7 +389,7 @@ impl RdpSpecificCode {
 pub enum ServerSetErrorInfoError {
     #[error("IO error")]
     IoError(#[from] io::Error),
-    #[error("Unexpected info code: {0}")]
+    #[error("unexpected info code: {0}")]
     UnexpectedInfoCode(u32),
 }
 

--- a/crates/ironrdp-pdu/src/rdp/server_license.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_license.rs
@@ -216,7 +216,7 @@ pub enum ServerLicenseError {
     InvalidRsaPublicKeyDataLength,
     #[error("invalid License Header security flags")]
     InvalidSecurityFlags,
-    #[error("ihe server returned unexpected error")]
+    #[error("the server returned unexpected error: {0:?}")]
     UnexpectedError(LicensingErrorMessage),
     #[error("got unexpected license message")]
     UnexpectedLicenseMessage,

--- a/crates/ironrdp-pdu/src/rdp/session_info.rs
+++ b/crates/ironrdp-pdu/src/rdp/session_info.rs
@@ -104,22 +104,22 @@ pub enum InfoData {
 pub enum SessionError {
     #[error("IO error")]
     IOError(#[from] io::Error),
-    #[error("Invalid save session info type value")]
+    #[error("invalid save session info type value")]
     InvalidSaveSessionInfoType,
-    #[error("Invalid domain name size value")]
+    #[error("invalid domain name size value")]
     InvalidDomainNameSize,
-    #[error("Invalid user name size value")]
+    #[error("invalid user name size value")]
     InvalidUserNameSize,
-    #[error("Invalid logon version value")]
+    #[error("invalid logon version value")]
     InvalidLogonVersion2,
-    #[error("Invalid logon info version2 size value")]
+    #[error("invalid logon info version2 size value")]
     InvalidLogonVersion2Size,
-    #[error("Invalid server auto-reconnect packet size value")]
+    #[error("invalid server auto-reconnect packet size value")]
     InvalidAutoReconnectPacketSize,
-    #[error("Invalid server auto-reconnect version")]
+    #[error("invalid server auto-reconnect version")]
     InvalidAutoReconnectVersion,
-    #[error("Invalid logon error type value")]
+    #[error("invalid logon error type value")]
     InvalidLogonErrorType,
-    #[error("Invalid logon error data value")]
+    #[error("invalid logon error data value")]
     InvalidLogonErrorData,
 }

--- a/crates/ironrdp-pdu/src/rdp/vc.rs
+++ b/crates/ironrdp-pdu/src/rdp/vc.rs
@@ -69,23 +69,23 @@ bitflags! {
 pub enum ChannelError {
     #[error("IO error")]
     IOError(#[from] io::Error),
-    #[error("From UTF8 error: {}", _0)]
+    #[error("from UTF-8 error")]
     FromUtf8Error(#[from] std::string::FromUtf8Error),
-    #[error("Invalid channel PDU header")]
+    #[error("invalid channel PDU header")]
     InvalidChannelPduHeader,
-    #[error("Invalid channel total data length")]
+    #[error("invalid channel total data length")]
     InvalidChannelTotalDataLength,
-    #[error("Invalid DVC PDU type")]
+    #[error("invalid DVC PDU type")]
     InvalidDvcPduType,
-    #[error("Invalid DVC id length value")]
+    #[error("invalid DVC id length value")]
     InvalidDVChannelIdLength,
-    #[error("Invalid DVC data length value")]
+    #[error("invalid DVC data length value")]
     InvalidDvcDataLength,
-    #[error("Invalid DVC capabilities version")]
+    #[error("invalid DVC capabilities version")]
     InvalidDvcCapabilitiesVersion,
-    #[error("Invalid DVC message size")]
+    #[error("invalid DVC message size")]
     InvalidDvcMessageSize,
-    #[error("Invalid DVC total message size: actual ({actual}) > expected ({expected})")]
+    #[error("invalid DVC total message size: actual ({actual}) > expected ({expected})")]
     InvalidDvcTotalMessageSize { actual: usize, expected: usize },
 }
 

--- a/crates/ironrdp-pdu/src/rdp/vc/dvc/display.rs
+++ b/crates/ironrdp-pdu/src/rdp/vc/dvc/display.rs
@@ -292,9 +292,9 @@ impl<'a> From<&'a ClientPdu> for ClientPduType {
 pub enum DisplayPipelineError {
     #[error("IO error")]
     IOError(#[from] io::Error),
-    #[error("Invalid Header cmd ID")]
+    #[error("invalid Header cmd ID")]
     InvalidCmdId,
-    #[error("Invalid PDU length: expected ({expected}) != actual ({actual})")]
+    #[error("invalid PDU length: expected ({expected}) != actual ({actual})")]
     InvalidPduLength { expected: usize, actual: usize },
 }
 

--- a/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx.rs
+++ b/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx.rs
@@ -300,17 +300,17 @@ impl<'a> From<&'a ServerPdu> for ServerPduType {
 pub enum GraphicsPipelineError {
     #[error("IO error")]
     IOError(#[from] io::Error),
-    #[error("Graphics messages error")]
+    #[error("graphics messages error")]
     GraphicsMessagesError(#[from] graphics_messages::GraphicsMessagesError),
-    #[error("Invalid Header cmd ID")]
+    #[error("invalid Header cmd ID")]
     InvalidCmdId,
-    #[error("Unexpected client's PDU type: {0:?}")]
+    #[error("unexpected client's PDU type: {0:?}")]
     UnexpectedClientPduType(ClientPduType),
-    #[error("Unexpected server's PDU type: {0:?}")]
+    #[error("unexpected server's PDU type: {0:?}")]
     UnexpectedServerPduType(ServerPduType),
-    #[error("Invalid ResetGraphics PDU size: expected ({expected}) != actual ({actual})")]
+    #[error("invalid ResetGraphics PDU size: expected ({expected}) != actual ({actual})")]
     InvalidResetGraphicsPduSize { expected: usize, actual: usize },
-    #[error("Invalid PDU length: expected ({expected}) != actual ({actual})")]
+    #[error("invalid PDU length: expected ({expected}) != actual ({actual})")]
     InvalidPduLength { expected: usize, actual: usize },
 }
 

--- a/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx/graphics_messages.rs
+++ b/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx/graphics_messages.rs
@@ -289,22 +289,22 @@ bitflags! {
 pub enum GraphicsMessagesError {
     #[error("IO error")]
     IOError(#[from] io::Error),
-    #[error("Invalid codec ID version 1")]
+    #[error("invalid codec ID version 1")]
     InvalidCodec1Id,
-    #[error("Invalid codec ID version 2")]
+    #[error("invalid codec ID version 2")]
     InvalidCodec2Id,
-    #[error("Invalid pixel format")]
+    #[error("invalid pixel format")]
     InvalidFixelFormat,
-    #[error("Monitor error")]
+    #[error("monitor error")]
     MonitorError(#[from] MonitorDataError),
-    #[error("Invalid ResetGraphics PDU width: {} > MAX ({})", actual, max)]
+    #[error("invalid ResetGraphics PDU width: {} > MAX ({})", actual, max)]
     InvalidResetGraphicsPduWidth { actual: u32, max: u32 },
-    #[error("Invalid ResetGraphics PDU height: {} > MAX ({})", actual, max)]
+    #[error("invalid ResetGraphics PDU height: {} > MAX ({})", actual, max)]
     InvalidResetGraphicsPduHeight { actual: u32, max: u32 },
-    #[error("Invalid ResetGraphics PDU monitors count: {} > MAX ({})", actual, max)]
+    #[error("invalid ResetGraphics PDU monitors count: {} > MAX ({})", actual, max)]
     InvalidResetGraphicsPduMonitorsCount { actual: u32, max: u32 },
-    #[error("Invalid capabilities version")]
+    #[error("invalid capabilities version")]
     InvalidCapabilitiesVersion,
-    #[error("Both luma and chroma packets specified but length is missing")]
+    #[error("both luma and chroma packets specified but length is missing")]
     InvalidAvcEncoding,
 }


### PR DESCRIPTION
Error messages should start by a lowercase so it’s easier to compose with other error messages and the final casing is left up to the "error reporter" down the line. This is the convention adopted by the Rust project:

- https://rust-lang.github.io/api-guidelines/interoperability.html
- https://doc.rust-lang.org/stable/std/error/trait.Error.html