### PR TITLE
acceptor: fix input events during connection finalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1918,7 +1918,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bytes",
  "ironrdp-acceptor",
  "ironrdp-graphics",
  "ironrdp-pdu",

--- a/crates/ironrdp-acceptor/src/connection.rs
+++ b/crates/ironrdp-acceptor/src/connection.rs
@@ -29,6 +29,7 @@ pub struct Acceptor {
 pub struct AcceptorResult {
     pub channels: Vec<(u16, gcc::ChannelDef)>,
     pub capabilities: Vec<CapabilitySet>,
+    pub input_events: Vec<Vec<u8>>,
 }
 
 impl Acceptor {
@@ -51,13 +52,15 @@ impl Acceptor {
     }
 
     pub fn get_result(&mut self) -> Option<AcceptorResult> {
-        match &self.state {
+        match &mut self.state {
             AcceptorState::Accepted {
                 channels,
                 client_capabilities,
+                input_events,
             } => Some(AcceptorResult {
-                channels: channels.clone(),
-                capabilities: client_capabilities.clone(),
+                channels: std::mem::take(channels),
+                capabilities: std::mem::take(client_capabilities),
+                input_events: std::mem::take(input_events),
             }),
 
             _ => None,
@@ -120,6 +123,7 @@ pub enum AcceptorState {
     Accepted {
         channels: Vec<(u16, gcc::ChannelDef)>,
         client_capabilities: Vec<CapabilitySet>,
+        input_events: Vec<Vec<u8>>,
     },
 }
 
@@ -451,6 +455,7 @@ impl Sequence for Acceptor {
                     AcceptorState::Accepted {
                         channels,
                         client_capabilities,
+                        input_events: finalization.input_events,
                     }
                 } else {
                     AcceptorState::ConnectionFinalization {

--- a/crates/ironrdp-pdu/src/lib.rs
+++ b/crates/ironrdp-pdu/src/lib.rs
@@ -327,6 +327,18 @@ pub trait PduHint: Send + Sync + core::fmt::Debug + 'static {
     fn find_size(&self, bytes: &[u8]) -> PduResult<Option<usize>>;
 }
 
+// Matches both X224 and FastPath pdus
+#[derive(Clone, Copy, Debug)]
+pub struct RdpHint;
+
+pub const RDP_HINT: RdpHint = RdpHint;
+
+impl PduHint for RdpHint {
+    fn find_size(&self, bytes: &[u8]) -> PduResult<Option<usize>> {
+        find_size(bytes).map(|opt| opt.map(|info| info.length))
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct X224Hint;
 

--- a/crates/ironrdp-server/Cargo.toml
+++ b/crates/ironrdp-server/Cargo.toml
@@ -17,7 +17,6 @@ test = false
 
 [dependencies]
 anyhow = "1.0"
-bytes = "1"
 tokio = { version = "1", features = ["net", "macros"] }
 tokio-rustls = "0.24"
 async-trait = "0.1"


### PR DESCRIPTION
Fixes #220 

This makes the acceptor accumulate any input events received during connection finalization, so they can be processed before starting the client loop.

Because the FontList is an x224 pdu and input events could be FastPath, I added a new PduHint that matches any pdu.

Also made the acceptor a little more robust and improved logging.