### PR TITLE
ci: check for dirty lock files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
       - name: WASM (check)
         run: cargo xtask wasm check -v
 
+      - name: Lock files
+        run: cargo xtask check locks -v
+
   fuzz:
     name: Fuzzing
     runs-on: ubuntu-20.04
@@ -104,6 +107,9 @@ jobs:
       - name: Fuzz
         run: cargo xtask fuzz run -v
 
+      - name: Lock files
+        run: cargo xtask check locks -v
+
   web:
     name: Web Client
     runs-on: ubuntu-20.04
@@ -126,3 +132,6 @@ jobs:
 
       - name: Check
         run: cargo xtask web check -v
+
+      - name: Lock files
+        run: cargo xtask check locks -v

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "arbitrary"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +75,12 @@ checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
@@ -128,6 +140,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -210,10 +231,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "fdeflate"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64d6dafc854908ff5da46ff3f8f473c6984119a2876a383a860246dd7841a868"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "flagset"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda653ca797810c02f7ca4b804b40b8b95ae046eb989d356bce17919a8c25499"
+
+[[package]]
+name = "flate2"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "funty"
@@ -235,11 +275,20 @@ dependencies = [
 name = "ironrdp-cliprdr"
 version = "0.1.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.3.3",
  "ironrdp-pdu",
  "ironrdp-svc",
  "thiserror",
  "tracing",
+]
+
+[[package]]
+name = "ironrdp-cliprdr-format"
+version = "0.1.0"
+dependencies = [
+ "ironrdp-pdu",
+ "png",
+ "thiserror",
 ]
 
 [[package]]
@@ -260,6 +309,7 @@ version = "0.0.0"
 dependencies = [
  "arbitrary",
  "ironrdp-cliprdr",
+ "ironrdp-cliprdr-format",
  "ironrdp-graphics",
  "ironrdp-pdu",
  "ironrdp-rdpdr",
@@ -270,7 +320,7 @@ name = "ironrdp-graphics"
 version = "0.1.0"
 dependencies = [
  "bit_field",
- "bitflags",
+ "bitflags 2.3.3",
  "bitvec",
  "byteorder",
  "ironrdp-error",
@@ -286,7 +336,7 @@ name = "ironrdp-pdu"
 version = "0.1.0"
 dependencies = [
  "bit_field",
- "bitflags",
+ "bitflags 2.3.3",
  "byteorder",
  "der-parser",
  "ironrdp-error",
@@ -306,7 +356,7 @@ dependencies = [
 name = "ironrdp-rdpdr"
 version = "0.1.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.3.3",
  "ironrdp-error",
  "ironrdp-pdu",
  "ironrdp-svc",
@@ -317,7 +367,7 @@ dependencies = [
 name = "ironrdp-svc"
 version = "0.1.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.3.3",
  "ironrdp-pdu",
 ]
 
@@ -379,6 +429,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+ "simd-adler32",
+]
 
 [[package]]
 name = "nom"
@@ -454,6 +514,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.17.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd75bf2d8dd3702b9707cdbc56a5b9ef42cec752eb8b3bafc01234558442aa64"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,6 +593,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "spki"

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -12,6 +12,7 @@ TASKS:
   bootstrap               Install all requirements for development
   check fmt               Check formatting
   check lints             Check lints
+  check locks             Check for dirty or staged lock files not yet committed
   check tests [--no-run]  Compile tests and, unless specified otherwise, run them
   ci                      Run all checks required on CI
   clean                   Clean workspace
@@ -49,6 +50,7 @@ pub enum Action {
     Bootstrap,
     CheckFmt,
     CheckLints,
+    CheckLocks,
     CheckTests {
         no_run: bool,
     },
@@ -92,6 +94,7 @@ pub fn parse_args() -> anyhow::Result<Args> {
             Some("check") => match args.subcommand()?.as_deref() {
                 Some("fmt") => Action::CheckFmt,
                 Some("lints") => Action::CheckLints,
+                Some("locks") => Action::CheckLocks,
                 Some("tests") => Action::CheckTests {
                     no_run: args.contains("--no-run"),
                 },

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -51,6 +51,7 @@ fn main() -> anyhow::Result<()> {
         }
         Action::CheckFmt => check::fmt(&sh)?,
         Action::CheckLints => check::lints(&sh)?,
+        Action::CheckLocks => check::lock_files(&sh)?,
         Action::CheckTests { no_run } => {
             if no_run {
                 check::tests_compile(&sh)?;
@@ -67,6 +68,7 @@ fn main() -> anyhow::Result<()> {
             fuzz::run(&sh, None, None)?;
             web::install(&sh)?;
             web::check(&sh)?;
+            check::lock_files(&sh)?;
         }
         Action::Clean => clean::workspace(&sh)?,
         Action::CovGrcov => cov::grcov(&sh)?,


### PR DESCRIPTION
Note that we can’t really use the `--locked` option of cargo, because to run xtask, we need to compile it using cargo, and thus the lock files are already "refreshed" as far as cargo is concerned. Instead, this new task will check for modifications to the lock files using `git-status` porcelain. The side benefit is that we can check for npm lock files too.