### PR TITLE
fix(connector): always expect STATUS_VALID_CLIENT

### DIFF
--- a/crates/ironrdp-connector/src/license_exchange.rs
+++ b/crates/ironrdp-connector/src/license_exchange.rs
@@ -7,7 +7,7 @@ use ironrdp_pdu::PduHint;
 use rand_core::{OsRng, RngCore as _};
 
 use super::legacy;
-use crate::{ConnectorResult, Sequence, State, Written};
+use crate::{ConnectorError, ConnectorResult, ConnectorResultExt as _, Sequence, State, Written};
 
 #[derive(Default, Debug)]
 #[non_exhaustive]
@@ -91,8 +91,9 @@ impl Sequence for LicenseExchangeSequence {
 
             LicenseExchangeState::NewLicenseRequest => {
                 let send_data_indication_ctx = legacy::decode_send_data_indication(input)?;
-                let initial_server_license =
-                    send_data_indication_ctx.decode_user_data::<server_license::InitialServerLicenseMessage>()?;
+                let initial_server_license = send_data_indication_ctx
+                    .decode_user_data::<server_license::InitialServerLicenseMessage>()
+                    .with_context("decode initial server license PDU")?;
 
                 debug!(message = ?initial_server_license, "Received");
 
@@ -164,7 +165,10 @@ impl Sequence for LicenseExchangeSequence {
             LicenseExchangeState::PlatformChallenge { encryption_data } => {
                 let send_data_indication_ctx = legacy::decode_send_data_indication(input)?;
 
-                match send_data_indication_ctx.decode_user_data::<server_license::ServerPlatformChallenge>() {
+                match send_data_indication_ctx
+                    .decode_user_data::<server_license::ServerPlatformChallenge>()
+                    .with_context("decode SERVER_PLATFORM_CHALLENGE")
+                {
                     Ok(challenge) => {
                         debug!(message = ?challenge, "Received");
 
@@ -191,38 +195,49 @@ impl Sequence for LicenseExchangeSequence {
                         )
                     }
                     Err(error) => {
-                        // In some cases, server does not send a platform challenge and a ServerLicenseError PDU
-                        // with the VALID_CLIENT_STATUS flag is received.
-                        if let Some(source) = std::error::Error::source(&error) {
-                            match source.downcast_ref::<server_license::ServerLicenseError>() {
-                                Some(server_license::ServerLicenseError::ValidClientStatus(
-                                    licensing_error_message,
-                                )) => {
-                                    debug!(message = ?licensing_error_message, "Received");
-
-                                    (Written::Nothing, LicenseExchangeState::LicenseExchanged)
-                                }
-                                _ => return Err(error),
-                            }
-                        } else {
-                            return Err(error);
-                        }
+                        // It appears that in some cases (?), the server does not send a SERVER_PLATFORM_CHALLENGE.
+                        // Instead a SERVER_LICENSE_ERROR with the STATUS_VALID_CLIENT error code is received.
+                        // Note that the specification says this SHOULD happen at the beginning of the Licensing Phase:
+                        // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/7d941d0d-d482-41c5-b728-538faa3efb31
+                        downcast_if_status_valid_client(error, |licensing_error_message| {
+                            debug!(message = ?licensing_error_message, "Received");
+                            warn!("STATUS_VALID_CLIENT error code at License Platform Challenge step");
+                            (Written::Nothing, LicenseExchangeState::LicenseExchanged)
+                        })?
                     }
                 }
             }
 
             LicenseExchangeState::UpgradeLicense { encryption_data } => {
                 let send_data_indication_ctx = legacy::decode_send_data_indication(input)?;
-                let upgrade_license =
-                    send_data_indication_ctx.decode_user_data::<server_license::ServerUpgradeLicense>()?;
 
-                debug!(message = ?upgrade_license, "Received");
+                // FIXME: The ServerUpgradeLicense type is handling both SERVER_UPGRADE_LICENSE and SERVER_NEW_LICENSE PDUs.
+                // It’s expected that fixing #263 will also lead to a better alternative here.
 
-                upgrade_license
-                    .verify_server_license(&encryption_data)
-                    .map_err(|e| custom_err!("license verification", e))?;
+                match send_data_indication_ctx
+                    .decode_user_data::<server_license::ServerUpgradeLicense>()
+                    .with_context("decode SERVER_NEW_LICENSE/SERVER_UPGRADE_LICENSE")
+                {
+                    Ok(upgrade_license) => {
+                        debug!(message = ?upgrade_license, "Received");
 
-                debug!("License verified with success");
+                        upgrade_license
+                            .verify_server_license(&encryption_data)
+                            .map_err(|e| custom_err!("license verification", e))?;
+
+                        debug!("License verified with success");
+                    }
+                    Err(error) => {
+                        // It appears that in some cases (?), the server does not send a SERVER_NEW_LICENSE/SERVER_UPGRADE_LICENSE.
+                        // Instead a SERVER_LICENSE_ERROR with the STATUS_VALID_CLIENT error code is received.
+                        // Note that the specification says this SHOULD happen at the beginning of the Licensing Phase:
+                        // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/7d941d0d-d482-41c5-b728-538faa3efb31
+                        downcast_if_status_valid_client(error, |licensing_error_message| {
+                            debug!(message = ?licensing_error_message, "Received");
+                            warn!("STATUS_VALID_CLIENT error code at Licensing final step");
+                        })?;
+                    }
+                }
 
                 (Written::Nothing, LicenseExchangeState::LicenseExchanged)
             }
@@ -233,5 +248,22 @@ impl Sequence for LicenseExchangeSequence {
         self.state = next_state;
 
         Ok(written)
+    }
+}
+
+// FIXME(#269): server_license::ServerLicenseError should not be retrieved from an error type.
+fn downcast_if_status_valid_client<T, Fn>(error: ConnectorError, op: Fn) -> ConnectorResult<T>
+where
+    Fn: FnOnce(&server_license::LicensingErrorMessage) -> T,
+{
+    match std::error::Error::source(&error)
+        .and_then(|source| source.downcast_ref::<server_license::ServerLicenseError>())
+    {
+        Some(server_license::ServerLicenseError::ValidClientStatus(licensing_error_message))
+            if licensing_error_message.error_code == server_license::LicenseErrorCode::StatusValidClient =>
+        {
+            Ok(op(licensing_error_message))
+        }
+        _ => Err(error),
     }
 }

--- a/crates/ironrdp-connector/src/server_name.rs
+++ b/crates/ironrdp-connector/src/server_name.rs
@@ -3,7 +3,7 @@ pub struct ServerName(String);
 
 impl ServerName {
     pub fn new(name: impl Into<String>) -> Self {
-        Self(sanitize_server_name(name))
+        Self(sanitize_server_name(name.into()))
     }
 
     pub fn as_str(&self) -> &str {
@@ -33,9 +33,7 @@ impl From<&str> for ServerName {
     }
 }
 
-fn sanitize_server_name(name: impl Into<String>) -> String {
-    let name = name.into();
-
+fn sanitize_server_name(name: String) -> String {
     if let Some(idx) = name.rfind(':') {
         if let Ok(sock_addr) = name.parse::<std::net::SocketAddr>() {
             // A socket address, including a port

--- a/crates/ironrdp-fuzzing/src/oracles/mod.rs
+++ b/crates/ironrdp-fuzzing/src/oracles/mod.rs
@@ -39,7 +39,6 @@ pub fn pdu_decode(data: &[u8]) {
     let _ = server_license::ClientPlatformChallengeResponse::from_buffer(data);
     let _ = server_license::InitialServerLicenseMessage::from_buffer(data);
     let _ = server_license::ServerLicenseRequest::from_buffer(data);
-    let _ = server_license::InitialServerLicenseMessage::from_buffer(data);
     let _ = server_license::ServerPlatformChallenge::from_buffer(data);
 
     let _ = vc::ChannelPduHeader::from_buffer(data);

--- a/crates/ironrdp-pdu/src/rdp/server_license.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_license.rs
@@ -121,6 +121,9 @@ impl PduParsing for LicenseHeader {
     }
 }
 
+/// [2.2.1.12.1.1] Licensing Preamble (LICENSE_PREAMBLE)
+///
+/// [2.2.1.12.1.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/73170ca2-5f82-4a2d-9d1b-b439f3d8dadc
 #[repr(u8)]
 #[derive(Debug, PartialEq, Eq, FromPrimitive, ToPrimitive)]
 pub enum PreambleType {

--- a/crates/ironrdp-pdu/src/rdp/server_license/client_new_license_request.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_license/client_new_license_request.rs
@@ -38,6 +38,9 @@ bitflags! {
     }
 }
 
+/// [2.2.2.2] Client New License Request (CLIENT_NEW_LICENSE_REQUEST)
+///
+/// [2.2.2.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpele/c57e4890-9049-421e-9fe8-9a6f9519675a
 #[derive(Debug, PartialEq, Eq)]
 pub struct ClientNewLicenseRequest {
     pub license_header: LicenseHeader,

--- a/crates/ironrdp-pdu/src/rdp/server_license/client_platform_challenge_response.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_license/client_platform_challenge_response.rs
@@ -22,6 +22,9 @@ const RESPONSE_DATA_STATIC_FIELDS_SIZE: usize = 8;
 
 const CLIENT_HARDWARE_IDENTIFICATION_SIZE: usize = 20;
 
+/// [2.2.2.5] Client Platform Challenge Response (CLIENT_PLATFORM_CHALLENGE_RESPONSE)
+///
+/// [2.2.2.5]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpele/f53ab87c-d07d-4bf9-a2ac-79542f7b456c
 #[derive(Debug, PartialEq, Eq)]
 pub struct ClientPlatformChallengeResponse {
     pub license_header: LicenseHeader,

--- a/crates/ironrdp-pdu/src/rdp/server_license/licensing_error_message.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_license/licensing_error_message.rs
@@ -13,6 +13,9 @@ use crate::PduParsing;
 const ERROR_CODE_SIZE: usize = 4;
 const STATE_TRANSITION_SIZE: usize = 4;
 
+/// [2.2.1.12.1.3] Licensing Error Message (LICENSE_ERROR_MESSAGE)
+///
+/// [2.2.1.12.1.3]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/f18b6c9f-f3d8-4a0e-8398-f9b153233dca
 #[derive(Debug, PartialEq, Eq)]
 pub struct LicensingErrorMessage {
     pub error_code: LicenseErrorCode,

--- a/crates/ironrdp-pdu/src/rdp/server_license/server_license_request.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_license/server_license_request.rs
@@ -34,6 +34,15 @@ pub enum InitialMessageType {
     StatusValidClient(LicensingErrorMessage),
 }
 
+// FIXME(#269): this is a helper structure which tries to detect if a
+// SERVER_LICENSE_REQUEST PDU is received from the server, or if a
+// STATUS_VALID_CLIENT error code is received instead (no need to negotiate
+// a license). I think this could be refactored into a more generic struct / enum,
+// without trying to be too smart by, e.g., returning errors when a LICENSE_ERROR_MESSAGE
+// is received depending on the error code. Parsing code should lend the data received
+// from the network without making too much decisions.
+
+/// Either a SERVER_LICENSE_REQUEST or a LICENSE_ERROR_MESSAGE with the STATUS_VALID_CLIENT code
 #[derive(Debug, PartialEq, Eq)]
 pub struct InitialServerLicenseMessage {
     pub license_header: LicenseHeader,
@@ -130,6 +139,9 @@ impl PduParsing for InitialServerLicenseMessage {
     }
 }
 
+/// [2.2.2.1] Server License Request (SERVER_LICENSE_REQUEST)
+///
+/// [2.2.2.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpele/e17772e9-9642-4bb6-a2bc-82875dd6da7c
 #[derive(Debug, PartialEq, Eq)]
 pub struct ServerLicenseRequest {
     pub server_random: Vec<u8>,
@@ -262,6 +274,9 @@ impl PduParsing for Scope {
     }
 }
 
+/// [2.2.1.4.3.1] Server Certificate (SERVER_CERTIFICATE)
+///
+/// [2.2.1.4.3.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/54e72cc6-3422-404c-a6b4-2486db125342
 #[derive(Debug, PartialEq, Eq)]
 pub struct ServerCertificate {
     pub issued_permanently: bool,

--- a/crates/ironrdp-pdu/src/rdp/server_license/server_license_request/cert.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_license/server_license_request/cert.rs
@@ -24,6 +24,9 @@ pub enum CertificateType {
     X509(X509CertificateChain),
 }
 
+/// [2.2.1.4.2] X.509 Certificate Chain (X509 _CERTIFICATE_CHAIN)
+///
+/// [2.2.1.4.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpele/bf2cc9cc-2b01-442e-a288-6ddfa3b80d59
 #[derive(Debug, PartialEq, Eq)]
 pub struct X509CertificateChain {
     pub certificate_array: Vec<Vec<u8>>,
@@ -84,6 +87,9 @@ impl PduParsing for X509CertificateChain {
     }
 }
 
+/// [2.2.1.4.3.1.1] Server Proprietary Certificate (PROPRIETARYSERVERCERTIFICATE)
+///
+/// [2.2.1.4.3.1.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/a37d449a-73ac-4f00-9b9d-56cefc954634
 #[derive(Debug, PartialEq, Eq)]
 pub struct ProprietaryCertificate {
     pub public_key: RsaPublicKey,

--- a/crates/ironrdp-pdu/src/rdp/server_license/server_platform_challenge.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_license/server_platform_challenge.rs
@@ -13,6 +13,9 @@ use crate::PduParsing;
 
 const CONNECT_FLAGS_FIELD_SIZE: usize = 4;
 
+/// [2.2.2.4] Server Platform Challenge (SERVER_PLATFORM_CHALLENGE)
+///
+/// [2.2.2.4]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpele/41e129ad-0f35-43ad-a399-1b10e7d007a9
 #[derive(Debug, PartialEq, Eq)]
 pub struct ServerPlatformChallenge {
     pub license_header: LicenseHeader,

--- a/crates/ironrdp-pdu/src/rdp/server_license/server_upgrade_license.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_license/server_upgrade_license.rs
@@ -15,6 +15,9 @@ use crate::{utils, PduParsing};
 
 const NEW_LICENSE_INFO_STATIC_FIELDS_SIZE: usize = 20;
 
+/// [2.2.2.6] Server Upgrade License (SERVER_UPGRADE_LICENSE)
+///
+/// [2.2.2.6]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpele/e8339fbd-1fe3-42c2-a599-27c04407166d
 #[derive(Debug, PartialEq, Eq)]
 pub struct ServerUpgradeLicense {
     pub license_header: LicenseHeader,


### PR DESCRIPTION
I was not able to reproduce the problem even when using the RDS Lab.
Because of that, I attempted to gut-solve the problem by:

- Expecting a SERVER_LICENSE_ERROR message in the final step of the licensing sequence, handling the STATUS_VALID_CLIENT error code as a success
- Attach additional context to the returned errors
- Log a warning when we receive the STATUS_VALID_CLIENT code at an unexpected place

The rationale is that either the problem is fixed, or we will have more information to troubleshoot otherwise.

Closes #268

Issue: ARC-180