### PR TITLE
chore(release): prepare web client for 0.9.0

### DIFF
--- a/web-client/iron-remote-gui/package-lock.json
+++ b/web-client/iron-remote-gui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@devolutions/iron-remote-gui",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@devolutions/iron-remote-gui",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "@types/ua-parser-js": "^0.7.36",
         "ua-parser-js": "^1.0.33"

--- a/web-client/iron-remote-gui/package.json
+++ b/web-client/iron-remote-gui/package.json
@@ -7,7 +7,7 @@
     "Zacharia Ellaham"
   ],
   "description": "Web Component providing agnostic implementation for Iron Wasm base client",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "type": "module",
   "private": true,
   "scripts": {

--- a/web-client/iron-remote-gui/public/package.json
+++ b/web-client/iron-remote-gui/public/package.json
@@ -7,7 +7,7 @@
     "Zacharia Ellaham"
   ],
   "description": "Web Component providing agnostic implementation for Iron Wasm base client.",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "main": "iron-remote-gui.umd.cjs",
   "types": "main.d.ts",
   "files": [


### PR DESCRIPTION
Version 0.9.0 of the Web Client includes:
- Fix for https://github.com/Devolutions/IronRDP/issues/268
- Clipboard support :tada: (by @pacmancoder)