### PR TITLE
Ignore *.css in Eslint

### DIFF
--- a/web-client/iron-svelte-client/.eslintrc.yaml
+++ b/web-client/iron-svelte-client/.eslintrc.yaml
@@ -31,6 +31,7 @@ parserOptions:
 
 ignorePatterns:
   - '*.cjs'
+  - '*.css'
 
 overrides:
   - files: '*.svelte'


### PR DESCRIPTION
Ignore css files in Eslint process for now. We don't have a lot of css file at this moment and it blocks other PR from merging. 

Eslint will give this error is ./web/iron-svelte-client
```
C:\Users\jou\code\IronRDP\web-client\iron-svelte-client\src\lib\login\login.css
  0:0  error  Parsing error: ESLint was configured to run on `<tsconfigRootDir>/src\lib\login\login.css` using `parserOptions.project`: <tsconfigRootDir>/tsconfig.json
The extension for the file (`.css`) is non-standard. It should be added to your existing `parserOptions.extraFileExtensions`

✖ 1 problem (1 error, 0 warnings)
```