### PR TITLE
chore(web-client): bump prettier to 3.1.0

### DIFF
--- a/web-client/iron-remote-gui/package-lock.json
+++ b/web-client/iron-remote-gui/package-lock.json
@@ -19,8 +19,8 @@
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.1",
         "eslint-plugin-svelte": "^2.34.1",
-        "prettier": "^3.0.3",
-        "prettier-plugin-svelte": "^3.0.3",
+        "prettier": "^3.1.0",
+        "prettier-plugin-svelte": "^3.1.0",
         "rxjs": "^6.6.7",
         "svelte": "^3.54.0",
         "svelte-check": "^2.10.0",
@@ -3129,9 +3129,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
-      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
+      "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -3156,13 +3156,13 @@
       }
     },
     "node_modules/prettier-plugin-svelte": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.0.3.tgz",
-      "integrity": "sha512-dLhieh4obJEK1hnZ6koxF+tMUrZbV5YGvRpf2+OADyanjya5j0z1Llo8iGwiHmFWZVG/hLEw/AJD5chXd9r3XA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.1.0.tgz",
+      "integrity": "sha512-96+AZxs2ESqIFA9j+o+DHqY+BsUglezfl553LQd6VOtTyJq5GPuBEb3ElxF2cerFzKlYKttlH/VcVmRNj5oc3A==",
       "dev": true,
       "peerDependencies": {
         "prettier": "^3.0.0",
-        "svelte": "^3.2.0 || ^4.0.0-next.0"
+        "svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
       }
     },
     "node_modules/punycode": {

--- a/web-client/iron-remote-gui/package.json
+++ b/web-client/iron-remote-gui/package.json
@@ -19,18 +19,17 @@
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "npm run lint:prettier && npm run lint:eslint",
-    "lint:prettier": "prettier --check . --plugin prettier-plugin-svelte",
+    "lint:prettier": "prettier --check .",
     "lint:eslint": "eslint src/**",
-    "format": "prettier --write . --plugin prettier-plugin-svelte"
+    "format": "prettier --write ."
   },
-  "//": "FIXME: There's currently an issue with Prettier 3.0 which requires the seemingly redundant --plugin setting. This bug will be fixed in the 3.1, and the extra argument may then be removed",
   "devDependencies": {
     "eslint": "^8.52.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-svelte": "^2.34.1",
-    "prettier": "^3.0.3",
-    "prettier-plugin-svelte": "^3.0.3",
+    "prettier": "^3.1.0",
+    "prettier-plugin-svelte": "^3.1.0",
     "rxjs": "^6.6.7",
     "svelte": "^3.54.0",
     "svelte-check": "^2.10.0",

--- a/web-client/iron-svelte-client/package-lock.json
+++ b/web-client/iron-svelte-client/package-lock.json
@@ -24,8 +24,8 @@
         "eslint-plugin-svelte": "^2.34.1",
         "fs-extra": "^11.1.0",
         "guid-typescript": "^1.0.9",
-        "prettier": "^3.0.3",
-        "prettier-plugin-svelte": "^3.0.3",
+        "prettier": "^3.1.0",
+        "prettier-plugin-svelte": "^3.1.0",
         "rxjs": "^6.6.7",
         "svelte": "^3.44.0",
         "svelte-check": "^2.7.1",
@@ -3262,9 +3262,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
-      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
+      "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -3289,13 +3289,13 @@
       }
     },
     "node_modules/prettier-plugin-svelte": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.0.3.tgz",
-      "integrity": "sha512-dLhieh4obJEK1hnZ6koxF+tMUrZbV5YGvRpf2+OADyanjya5j0z1Llo8iGwiHmFWZVG/hLEw/AJD5chXd9r3XA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.1.0.tgz",
+      "integrity": "sha512-96+AZxs2ESqIFA9j+o+DHqY+BsUglezfl553LQd6VOtTyJq5GPuBEb3ElxF2cerFzKlYKttlH/VcVmRNj5oc3A==",
       "dev": true,
       "peerDependencies": {
         "prettier": "^3.0.0",
-        "svelte": "^3.2.0 || ^4.0.0-next.0"
+        "svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
       }
     },
     "node_modules/punycode": {

--- a/web-client/iron-svelte-client/package.json
+++ b/web-client/iron-svelte-client/package.json
@@ -14,11 +14,10 @@
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "npm run lint:prettier && npm run lint:eslint",
-    "lint:prettier": "prettier --check . --plugin prettier-plugin-svelte",
+    "lint:prettier": "prettier --check .",
     "lint:eslint": "eslint src/**",
-    "format": "prettier --write . --plugin prettier-plugin-svelte"
+    "format": "prettier --write ."
   },
-  "//": "FIXME: There's currently an issue with Prettier 3.0 which requires the seemingly redundant --plugin setting. This bug will be fixed in the 3.1, and the extra argument may then be removed",
   "devDependencies": {
     "beercss": "^2.3.0",
     "cross-env": "7.0.3",
@@ -30,8 +29,8 @@
     "fs-extra": "^11.1.0",
     "guid-typescript": "^1.0.9",
     "@material-design-icons/font": "^0.14.2",
-    "prettier": "^3.0.3",
-    "prettier-plugin-svelte": "^3.0.3",
+    "prettier": "^3.1.0",
+    "prettier-plugin-svelte": "^3.1.0",
     "@rollup/plugin-replace": "^5.0.1",
     "rxjs": "^6.6.7",
     "svelte": "^3.44.0",


### PR DESCRIPTION
A bug in 3.0.x versions was causing the --plugin setting to be required in order to let prettier know about svelte. This is now fixed.