### PR TITLE
feat(cliprdr): BI_BITFIELDS compression is supported

### DIFF
--- a/crates/ironrdp-cliprdr-format/src/bitmap.rs
+++ b/crates/ironrdp-cliprdr-format/src/bitmap.rs
@@ -417,13 +417,6 @@ fn validate_v1_header(header: &BitmapInfoHeader) -> Result<(), BitmapError> {
         return Err(BitmapError::Unsupported("unsupported bit count"));
     }
 
-    // We support only uncompressed DIB bitmaps as it is the most common case for clipboard-copied
-    // bitmaps.
-    const SUPPORTED_COMPRESSION: &[BitmapCompression] = &[BitmapCompression::RGB, BitmapCompression::BITFIELDS];
-    if !SUPPORTED_COMPRESSION.contains(&header.compression) {
-        return Err(BitmapError::Unsupported("unsupported compression"));
-    }
-
     // This is only relevant for bitmaps with bpp < 24, which are not supported.
     if header.clr_used != 0 {
         return Err(BitmapError::Unsupported("color table is not supported"));
@@ -434,6 +427,29 @@ fn validate_v1_header(header: &BitmapInfoHeader) -> Result<(), BitmapError> {
 
 fn validate_v5_header(header: &BitmapV5Header) -> Result<(), BitmapError> {
     validate_v1_header(&header.header_v1)?;
+
+    // We support only uncompressed DIB bitmaps as it is the most common case for clipboard-copied bitmaps.
+    const DIBV5_SUPPORTED_COMPRESSION: &[BitmapCompression] = &[BitmapCompression::RGB, BitmapCompression::BITFIELDS];
+
+    if !DIBV5_SUPPORTED_COMPRESSION.contains(&header.header_v1.compression) {
+        return Err(BitmapError::Unsupported("unsupported compression"));
+    }
+
+    if header.header_v1.compression == BitmapCompression::BITFIELDS {
+        // Currently, we only support the standard order, BGRA, for the bitfields compression.
+        // Note: we are making sure to interpret the masks as big-endian using `u32::to_be`.
+        // (`to_be` is a no-op on big endian architectures.)
+        let is_bgra = header.red_mask.to_be() == 0x00FF0000
+            || header.green_mask.to_be() == 0x0000FF00
+            || header.blue_mask.to_be() == 0x000000FF
+            || header.alpha_mask.to_be() == 0xFF000000;
+
+        if !is_bgra {
+            return Err(BitmapError::Unsupported(
+                "non-standard color masks for `BITFIELDS` compression are not supported",
+            ));
+        }
+    }
 
     const SUPPORTED_COLOR_SPACE: &[ColorSpace] = &[
         ColorSpace::SRGB,
@@ -588,6 +604,15 @@ pub fn dib_to_png(input: &[u8]) -> Result<Vec<u8>, BitmapError> {
     let header = BitmapInfoHeader::decode(&mut src).map_err(BitmapError::InvalidHeader)?;
 
     validate_v1_header(&header)?;
+
+    // We support only uncompressed DIB bitmaps as it is the most common case for clipboard-copied bitmaps.
+    // However, for DIBv1 specifically, BitmapCompression::BITFIELDS is not supported even when the order is BGRA,
+    // because there is an additional variable-sized header holding the color masks that we don’t support yet.
+    const DIBV1_SUPPORTED_COMPRESSION: &[BitmapCompression] = &[BitmapCompression::RGB];
+
+    if !DIBV1_SUPPORTED_COMPRESSION.contains(&header.compression) {
+        return Err(BitmapError::Unsupported("unsupported compression"));
+    }
 
     let png_inputs = transform_bitmap(&header, src.remaining(), false)?;
     encode_png(png_inputs)

--- a/crates/ironrdp-cliprdr-format/src/bitmap.rs
+++ b/crates/ironrdp-cliprdr-format/src/bitmap.rs
@@ -437,15 +437,10 @@ fn validate_v5_header(header: &BitmapV5Header) -> Result<(), BitmapError> {
 
     if header.header_v1.compression == BitmapCompression::BITFIELDS {
         // Currently, we only support the standard order, BGRA, for the bitfields compression.
-        // Note: we are making sure to interpret the masks as little-endian using `u32::to_le`.
-        // (`to_le` is a no-op on little endian architectures, which are the most common.)
-
-        let is_bgr = header.red_mask.to_le() == 0x00FF0000
-            && header.green_mask.to_le() == 0x0000FF00
-            && header.blue_mask.to_le() == 0x000000FF;
+        let is_bgr = header.red_mask == 0x00FF0000 && header.green_mask == 0x0000FF00 && header.blue_mask == 0x000000FF;
 
         // Note: when there is no alpha channel, the mask is 0x00000000 and we support this too.
-        let is_supported_alpha = header.alpha_mask == 0 || header.alpha_mask.to_le() == 0xFF000000;
+        let is_supported_alpha = header.alpha_mask == 0 || header.alpha_mask == 0xFF000000;
 
         if !is_bgr || !is_supported_alpha {
             return Err(BitmapError::Unsupported(

--- a/crates/ironrdp-cliprdr-format/src/bitmap.rs
+++ b/crates/ironrdp-cliprdr-format/src/bitmap.rs
@@ -419,7 +419,7 @@ fn validate_v1_header(header: &BitmapInfoHeader) -> Result<(), BitmapError> {
 
     // We support only uncompressed DIB bitmaps as it is the most common case for clipboard-copied
     // bitmaps.
-    const SUPPORTED_COMPRESSION: &[BitmapCompression] = &[BitmapCompression::RGB];
+    const SUPPORTED_COMPRESSION: &[BitmapCompression] = &[BitmapCompression::RGB, BitmapCompression::BITFIELDS];
     if !SUPPORTED_COMPRESSION.contains(&header.compression) {
         return Err(BitmapError::Unsupported("unsupported compression"));
     }

--- a/crates/ironrdp-cliprdr-format/src/bitmap.rs
+++ b/crates/ironrdp-cliprdr-format/src/bitmap.rs
@@ -445,7 +445,7 @@ fn validate_v5_header(header: &BitmapV5Header) -> Result<(), BitmapError> {
             && header.blue_mask.to_le() == 0x000000FF;
 
         // Note: when there is no alpha channel, the mask is 0x00000000 and we support this too.
-        let is_supported_alpha = header.alpha_mask.to_le() == 0x00000000 || header.alpha_mask.to_le() == 0xFF000000;
+        let is_supported_alpha = header.alpha_mask == 0 || header.alpha_mask.to_le() == 0xFF000000;
 
         if !is_bgr || !is_supported_alpha {
             return Err(BitmapError::Unsupported(


### PR DESCRIPTION
As it turns out we actually support the BI_BITFIELDS compression (which is not actually for compressed bitmaps).

Quote from [MS-WMF] section 2.1.1.7:

> The bitmap is not compressed, and the color table consists of three
> DWORD (defined in [MS-DTYP] section 2.2.9) color masks that specify the
> red, green, and blue components, respectively, of each pixel. This is
> valid when used with 16 and 32-bits per pixel bitmaps.

[dibv5-bitfields-compression.webm](https://github.com/Devolutions/IronRDP/assets/3809077/440695e7-88ce-4d64-96e1-670ec8b5409f)

All I did was to add `BitmapCompression::BITFIELDS` to the `SUPPORTED_COMPRESSION` array, and things just worked out of the box.
@pacmancoder maybe you understand why it works better than me?
