### PR TITLE
`DirectoryControl`.`QueryDirectory`

### DIFF
--- a/crates/ironrdp-pdu/src/cursor.rs
+++ b/crates/ironrdp-pdu/src/cursor.rs
@@ -386,6 +386,12 @@ impl<'a> WriteCursor<'a> {
 
     #[inline]
     #[track_caller]
+    pub fn write_i8(&mut self, value: i8) {
+        self.write_array(value.to_le_bytes())
+    }
+
+    #[inline]
+    #[track_caller]
     pub fn write_u16(&mut self, value: u16) {
         self.write_array(value.to_le_bytes())
     }

--- a/crates/ironrdp-rdpdr/src/lib.rs
+++ b/crates/ironrdp-rdpdr/src/lib.rs
@@ -217,7 +217,8 @@ impl StaticVirtualChannelProcessor for Rdpdr {
             | RdpdrPdu::DeviceControlResponse(_)
             | RdpdrPdu::DeviceCreateResponse(_)
             | RdpdrPdu::ClientDriveQueryInformationResponse(_)
-            | RdpdrPdu::DeviceCloseResponse(_) => Err(other_err!("Rdpdr", "received unexpected packet")),
+            | RdpdrPdu::DeviceCloseResponse(_)
+            | RdpdrPdu::ClientDriveQueryDirectoryResponse(_) => Err(other_err!("Rdpdr", "received unexpected packet")),
         }
     }
 }

--- a/crates/ironrdp-rdpdr/src/pdu/efs.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/efs.rs
@@ -1715,7 +1715,11 @@ impl Debug for FileInformationClassLevel {
             FileInformationClassLevel::FILE_BASIC_INFORMATION => write!(f, "FileBasicInformation"),
             FileInformationClassLevel::FILE_STANDARD_INFORMATION => write!(f, "FileStandardInformation"),
             FileInformationClassLevel::FILE_ATTRIBUTE_TAG_INFORMATION => write!(f, "FileAttributeTagInformation"),
-            _ => write!(f, "FileInformationClassLevel({:#010X})", self.0),
+            FileInformationClassLevel::FILE_DIRECTORY_INFORMATION => write!(f, "FileDirectoryInformation"),
+            FileInformationClassLevel::FILE_FULL_DIRECTORY_INFORMATION => write!(f, "FileFullDirectoryInformation"),
+            FileInformationClassLevel::FILE_BOTH_DIRECTORY_INFORMATION => write!(f, "FileBothDirectoryInformation"),
+            FileInformationClassLevel::FILE_NAMES_INFORMATION => write!(f, "FileNamesInformation"),
+            _ => write!(f, "FileInformationClassLevel({})", self.0),
         }
     }
 }

--- a/crates/ironrdp-rdpdr/src/pdu/mod.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/mod.rs
@@ -5,9 +5,9 @@ use ironrdp_pdu::cursor::{ReadCursor, WriteCursor};
 use ironrdp_pdu::{ensure_size, invalid_message_err, PduDecode, PduEncode, PduError, PduResult};
 
 use self::efs::{
-    ClientDeviceListAnnounce, ClientDriveQueryInformationResponse, ClientNameRequest, CoreCapability,
-    CoreCapabilityKind, DeviceCloseResponse, DeviceControlResponse, DeviceCreateResponse, DeviceIoRequest,
-    ServerDeviceAnnounceResponse, VersionAndIdPdu, VersionAndIdPduKind,
+    ClientDeviceListAnnounce, ClientDriveQueryDirectoryResponse, ClientDriveQueryInformationResponse,
+    ClientNameRequest, CoreCapability, CoreCapabilityKind, DeviceCloseResponse, DeviceControlResponse,
+    DeviceCreateResponse, DeviceIoRequest, ServerDeviceAnnounceResponse, VersionAndIdPdu, VersionAndIdPduKind,
 };
 
 pub mod efs;
@@ -25,6 +25,7 @@ pub enum RdpdrPdu {
     DeviceCreateResponse(DeviceCreateResponse),
     ClientDriveQueryInformationResponse(ClientDriveQueryInformationResponse),
     DeviceCloseResponse(DeviceCloseResponse),
+    ClientDriveQueryDirectoryResponse(ClientDriveQueryDirectoryResponse),
     /// TODO: temporary value for development, this should be removed
     Unimplemented,
 }
@@ -76,7 +77,8 @@ impl RdpdrPdu {
             RdpdrPdu::DeviceControlResponse(_)
             | RdpdrPdu::DeviceCreateResponse(_)
             | RdpdrPdu::ClientDriveQueryInformationResponse(_)
-            | RdpdrPdu::DeviceCloseResponse(_) => SharedHeader {
+            | RdpdrPdu::DeviceCloseResponse(_)
+            | RdpdrPdu::ClientDriveQueryDirectoryResponse(_) => SharedHeader {
                 component: Component::RdpdrCtypCore,
                 packet_id: PacketId::CoreDeviceIoCompletion,
             },
@@ -119,6 +121,7 @@ impl PduEncode for RdpdrPdu {
             RdpdrPdu::DeviceCreateResponse(pdu) => pdu.encode(dst),
             RdpdrPdu::ClientDriveQueryInformationResponse(pdu) => pdu.encode(dst),
             RdpdrPdu::DeviceCloseResponse(pdu) => pdu.encode(dst),
+            RdpdrPdu::ClientDriveQueryDirectoryResponse(pdu) => pdu.encode(dst),
             RdpdrPdu::Unimplemented => Ok(()),
         }
     }
@@ -135,6 +138,7 @@ impl PduEncode for RdpdrPdu {
             RdpdrPdu::DeviceCreateResponse(pdu) => pdu.name(),
             RdpdrPdu::ClientDriveQueryInformationResponse(pdu) => pdu.name(),
             RdpdrPdu::DeviceCloseResponse(pdu) => pdu.name(),
+            RdpdrPdu::ClientDriveQueryDirectoryResponse(pdu) => pdu.name(),
             RdpdrPdu::Unimplemented => "Unimplemented",
         }
     }
@@ -152,6 +156,7 @@ impl PduEncode for RdpdrPdu {
                 RdpdrPdu::DeviceCreateResponse(pdu) => pdu.size(),
                 RdpdrPdu::ClientDriveQueryInformationResponse(pdu) => pdu.size(),
                 RdpdrPdu::DeviceCloseResponse(pdu) => pdu.size(),
+                RdpdrPdu::ClientDriveQueryDirectoryResponse(pdu) => pdu.size(),
                 RdpdrPdu::Unimplemented => 0,
             }
     }
@@ -190,6 +195,9 @@ impl fmt::Debug for RdpdrPdu {
             Self::DeviceCloseResponse(it) => {
                 write!(f, "RdpdrPdu({:?})", it)
             }
+            Self::ClientDriveQueryDirectoryResponse(it) => {
+                write!(f, "RdpdrPdu({:?})", it)
+            }
             Self::Unimplemented => {
                 write!(f, "RdpdrPdu::Unimplemented")
             }
@@ -218,6 +226,12 @@ impl From<ClientDriveQueryInformationResponse> for RdpdrPdu {
 impl From<DeviceCloseResponse> for RdpdrPdu {
     fn from(value: DeviceCloseResponse) -> Self {
         Self::DeviceCloseResponse(value)
+    }
+}
+
+impl From<ClientDriveQueryDirectoryResponse> for RdpdrPdu {
+    fn from(value: ClientDriveQueryDirectoryResponse) -> Self {
+        Self::ClientDriveQueryDirectoryResponse(value)
     }
 }
 


### PR DESCRIPTION
- Added a new method write_i8 to WriteCursor in ironrdp-pdu/src/cursor.rs, allowing for writing an 8-bit integer value to the cursor.

- Updated Rdpdr in ironrdp-rdpdr/src/lib.rs to handle an additional case for ClientDriveQueryDirectoryResponse in the error handling logic.

- Introduced several new structures in ironrdp-rdpdr/src/pdu/efs.rs related to directory information, including FileBothDirectoryInformation, FileFullDirectoryInformation, FileNamesInformation, and FileDirectoryInformation.

- Added support for the ClientDriveQueryDirectoryResponse PDU in various parts of ironrdp-rdpdr, including the RdpdrPdu enum and its implementation.

- Added a ServerDriveQueryDirectoryRequest structure to handle server requests for querying directory information, along with the necessary encoding logic.

- Added a ClientDriveQueryDirectoryResponse structure to handle client responses for directory queries, along with the necessary encoding logic.

- Updated the RDPDR PDU encoding and size calculation methods to support the new ClientDriveQueryDirectoryResponse structure.