### PR TITLE
CLIPRDR housekeeping

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -180,6 +180,33 @@ Re-using originally single-purpose function often leads to bad coupling.
 
 Exception: if you want to make use of `return` or `?`.
 
+## Local helper functions
+
+Put nested helper functions at the end of the enclosing functions (this requires using return statement).
+Don't nest more than one level deep.
+
+```rust
+// GOOD
+fn func() -> u32 {
+    return helper();
+
+    fn helper() -> u32 {
+        /* ... */
+    }
+}
+
+// BAD
+fn func() -> u32 {
+    fn helper() -> u32 {
+        /* ... */
+    }
+
+    helper()
+}
+```
+
+**Rationale:** consistency, improved top-down readability.
+
 ## Documentation
 
 ### Doc comments should link to reference documents

--- a/crates/ironrdp-cliprdr-format/README.md
+++ b/crates/ironrdp-cliprdr-format/README.md
@@ -3,5 +3,10 @@
 This Library provides the conversion logic between RDP-specific clipboard formats and
 widely used formats like PNG for images, plain string for HTML etc.
 
-### INVARIANTS
-- This crate expects the target machine's pointer size (usize) to be equal or greater than 32bits
+### Overflows
+
+This crate has been audited by us and is guaranteed overflow-free on 32 and 64 bits architectures.
+It would be easy to cause an overflow on a 16-bit architecture.
+However, it’s hard to imagine an RDP client running on such machines.
+Size of pointers on such architectures greatly limits the maximum size of the bitmap buffers.
+It’s likely the RDP client will choke on a big payload before overflowing because of this crate.

--- a/crates/ironrdp-cliprdr-format/src/html.rs
+++ b/crates/ironrdp-cliprdr-format/src/html.rs
@@ -5,32 +5,41 @@ pub enum HtmlError {
     #[error("invalid CF_HTML format")]
     InvalidFormat,
     #[error("invalid UTF-8")]
-    InvalidUtf8(#[from] std::string::FromUtf8Error),
+    InvalidUtf8(#[from] core::str::Utf8Error),
     #[error("failed to parse integer")]
-    InvalidInteger(#[from] std::num::ParseIntError),
+    InvalidInteger(#[from] core::num::ParseIntError),
     #[error("invalid integer conversion")]
     InvalidConversion,
 }
 
 /// Converts `CF_HTML` format to plain HTML text.
-pub fn cf_html_to_plain_html(input: &[u8]) -> Result<String, HtmlError> {
+///
+/// Note that the `CF_HTML` format is using UTF-8, and the input is expected to be valid UTF-8.
+/// However, there is no easy way to know the size of the `CF_HTML` payload:
+/// 1) it’s typically not null-terminated, and
+/// 2) reading the headers is already half of the work.
+/// Because of that, this function takes the input as a byte slice and finds the end of the payload itself.
+/// This is expected to be more convenient at the callsite.
+pub fn cf_html_to_plain_html(input: &[u8]) -> Result<&str, HtmlError> {
+    const EOL_CONTROL_CHARS: &[u8] = &[b'\r', b'\n'];
+
     let mut start_fragment = None;
     let mut end_fragment = None;
 
-    let mut headers_cursor = input;
+    // We’ll move the lower bound of this slice until all headers are read.
+    let mut cursor = input;
 
-    let fragment = loop {
-        // Line split logic is manual instead of using BufReader::read_line because
-        // the line ending could be represented as `\r\n`, `\n` or even `\r`.
-        const EOL_CONTROL_CHARS: &[u8] = &[b'\r', b'\n'];
-
-        let end_pos = match headers_cursor.iter().position(|ch| EOL_CONTROL_CHARS.contains(ch)) {
-            Some(pos) => pos,
-            // Failed to find the end of the line
-            None => return Err(HtmlError::InvalidFormat),
+    loop {
+        let line = {
+            // We use a custom logic for splitting lines, instead of something like `str::lines`.
+            // That’s because `str::lines` does not split at carriage return (`\r`) not followed by line feed (`\n`).
+            // In `CF_HTML` format, the line ending could be represented using `\r` alone.
+            let eol_pos = cursor
+                .iter()
+                .position(|byte| EOL_CONTROL_CHARS.contains(byte))
+                .ok_or(HtmlError::InvalidFormat)?;
+            core::str::from_utf8(&cursor[..eol_pos])?
         };
-
-        let line = String::from_utf8(headers_cursor[..end_pos].to_vec())?;
 
         match line.split_once(':') {
             Some((key, value)) => match key {
@@ -45,44 +54,33 @@ pub fn cf_html_to_plain_html(input: &[u8]) -> Result<String, HtmlError> {
                 }
             },
             None => {
-                if start_fragment.is_none() || end_fragment.is_none() {
-                    // We reached the end of the headers, but we didn't find the required ones,
-                    // so the format is invalid.
+                // At this point, we reached the end of the headers.
+                if let (Some(start), Some(end)) = (start_fragment, end_fragment) {
+                    let start = usize::try_from(start).map_err(|_| HtmlError::InvalidConversion)?;
+                    let end = usize::try_from(end).map_err(|_| HtmlError::InvalidConversion)?;
+
+                    // Ensure start and end values are properly bounded.
+                    if start > end || end > input.len() {
+                        return Err(HtmlError::InvalidFormat);
+                    }
+
+                    // Extract the fragment from the original buffer.
+                    let fragment = core::str::from_utf8(&input[start..end])?;
+
+                    return Ok(fragment);
+                } else {
+                    // If required headers were not found, the input is considered invalid.
                     return Err(HtmlError::InvalidFormat);
                 }
             }
         };
 
-        if let (Some(start), Some(end)) = (start_fragment, end_fragment) {
-            let start = usize::try_from(start).map_err(|_| HtmlError::InvalidConversion)?;
-            let end = usize::try_from(end).map_err(|_| HtmlError::InvalidConversion)?;
-
-            // Extract fragment from the original buffer.
-            if start > end || end > input.len() {
-                return Err(HtmlError::InvalidFormat);
-            }
-
-            break String::from_utf8(input[start..end].to_vec())?;
+        // Skip EOL control characters and prepare for next line.
+        cursor = &cursor[line.len()..];
+        while let Some(b'\n' | b'\r') = cursor.first() {
+            cursor = &cursor[1..];
         }
-
-        // INVARIANT: end_pos < headers_cursor.len() - 1
-        // This is safe because we already checked above that the line ends with `\r` or `\n`.
-        #[allow(clippy::arithmetic_side_effects)]
-        {
-            // Go to the next line, skipping any leftover `LF` if CRLF was used.
-            let has_leftover_lf = end_pos + 1 != headers_cursor.len()
-                && headers_cursor[end_pos] == b'\r'
-                && headers_cursor[end_pos + 1] == b'\n';
-
-            if has_leftover_lf {
-                headers_cursor = &headers_cursor[end_pos + 2..];
-            } else {
-                headers_cursor = &headers_cursor[end_pos + 1..];
-            }
-        }
-    };
-
-    return Ok(fragment);
+    }
 
     fn header_value_to_u32(value: &str) -> Result<u32, std::num::ParseIntError> {
         value.trim_start_matches('0').parse::<u32>()
@@ -90,8 +88,10 @@ pub fn cf_html_to_plain_html(input: &[u8]) -> Result<String, HtmlError> {
 }
 
 /// Converts plain HTML text to `CF_HTML` format.
-pub fn plain_html_to_cf_html(fragment: &str) -> Vec<u8> {
-    let mut buffer = Vec::new();
+pub fn plain_html_to_cf_html(fragment: &str) -> String {
+    const POS_PLACEHOLDER: &str = "0000000000";
+
+    let mut buffer = String::new();
 
     // INVARIANT: key.len() + value.len() + ":\r\n".len() < usize::MAX
     // This is always true because we know `key` and `value` used in code below are
@@ -101,31 +101,30 @@ pub fn plain_html_to_cf_html(fragment: &str) -> Vec<u8> {
         let size = key.len() + value.len() + ":\r\n".len();
         buffer.reserve(size);
 
-        buffer.extend_from_slice(key.as_bytes());
-        buffer.extend_from_slice(b":");
+        buffer.push_str(key);
+        buffer.push(':');
         let value_pos = buffer.len();
-        buffer.extend_from_slice(value.as_bytes());
-        buffer.extend_from_slice(b"\r\n");
+        buffer.push_str(value);
+        buffer.push_str("\r\n");
 
         value_pos
     };
 
-    const POS_PLACEHOLDER: &str = "0000000000";
-
     write_header("Version", "0.9");
-    let start_html_placeholder_pos = write_header("StartHTML", POS_PLACEHOLDER);
-    let end_html_placeholder_pos = write_header("EndHTML", POS_PLACEHOLDER);
-    let start_fragment_placeholder_pos = write_header("StartFragment", POS_PLACEHOLDER);
-    let end_fragment_placeholder_pos = write_header("EndFragment", POS_PLACEHOLDER);
+
+    let start_html_header_pos = write_header("StartHTML", POS_PLACEHOLDER);
+    let end_html_header_pos = write_header("EndHTML", POS_PLACEHOLDER);
+    let start_fragment_header_pos = write_header("StartFragment", POS_PLACEHOLDER);
+    let end_fragment_header_pos = write_header("EndFragment", POS_PLACEHOLDER);
 
     let start_html_pos = buffer.len();
-    buffer.extend_from_slice(b"<html>\r\n<body>\r\n<!--StartFragment-->");
+    buffer.push_str("<html>\r\n<body>\r\n<!--StartFragment-->");
 
     let start_fragment_pos = buffer.len();
-    buffer.extend_from_slice(fragment.as_bytes());
+    buffer.push_str(fragment);
 
     let end_fragment_pos = buffer.len();
-    buffer.extend_from_slice(b"<!--EndFragment-->\r\n</body>\r\n</html>");
+    buffer.push_str("<!--EndFragment-->\r\n</body>\r\n</html>");
 
     let end_html_pos = buffer.len();
 
@@ -138,14 +137,14 @@ pub fn plain_html_to_cf_html(fragment: &str) -> Vec<u8> {
     // This is always valid because we know that placeholder is always present in the buffer
     // after the header is written and placeholder is within the bounds of the buffer.
     #[allow(clippy::arithmetic_side_effects)]
-    let mut replace_placeholder = |placeholder_pos: usize, placeholder_value: &str| {
-        buffer[placeholder_pos..placeholder_pos + POS_PLACEHOLDER.len()].copy_from_slice(placeholder_value.as_bytes());
+    let mut replace_placeholder = |header_pos: usize, header_value: &str| {
+        buffer.replace_range(header_pos..header_pos + POS_PLACEHOLDER.len(), header_value);
     };
 
-    replace_placeholder(start_html_placeholder_pos, &start_html_pos_value);
-    replace_placeholder(end_html_placeholder_pos, &end_html_pos_value);
-    replace_placeholder(start_fragment_placeholder_pos, &start_fragment_pos_value);
-    replace_placeholder(end_fragment_placeholder_pos, &end_fragment_pos_value);
+    replace_placeholder(start_html_header_pos, &start_html_pos_value);
+    replace_placeholder(end_html_header_pos, &end_html_pos_value);
+    replace_placeholder(start_fragment_header_pos, &start_fragment_pos_value);
+    replace_placeholder(end_fragment_header_pos, &end_fragment_pos_value);
 
     buffer
 }

--- a/crates/ironrdp-cliprdr-format/src/html.rs
+++ b/crates/ironrdp-cliprdr-format/src/html.rs
@@ -60,7 +60,7 @@ pub fn cf_html_to_plain_html(input: &[u8]) -> Result<&str, HtmlError> {
                     let end = usize::try_from(end).map_err(|_| HtmlError::InvalidConversion)?;
 
                     // Ensure start and end values are properly bounded.
-                    if start > end || end > input.len() {
+                    if !(start < end && end < input.len()) {
                         return Err(HtmlError::InvalidFormat);
                     }
 

--- a/crates/ironrdp-cliprdr-format/src/html.rs
+++ b/crates/ironrdp-cliprdr-format/src/html.rs
@@ -32,8 +32,6 @@ pub fn cf_html_to_text(input: &[u8]) -> Result<String, HtmlError> {
 
         let line = String::from_utf8(headers_cursor[..end_pos].to_vec())?;
 
-        let header_value_to_u32 = |value: &str| value.trim_start_matches('0').parse::<u32>();
-
         match line.split_once(':') {
             Some((key, value)) => match key {
                 "StartFragment" => {
@@ -84,7 +82,11 @@ pub fn cf_html_to_text(input: &[u8]) -> Result<String, HtmlError> {
         }
     };
 
-    Ok(fragment)
+    return Ok(fragment);
+
+    fn header_value_to_u32(value: &str) -> Result<u32, std::num::ParseIntError> {
+        value.trim_start_matches('0').parse::<u32>()
+    }
 }
 
 /// Convert plain text HTML to `CF_HTML` format.

--- a/crates/ironrdp-cliprdr-format/src/html.rs
+++ b/crates/ironrdp-cliprdr-format/src/html.rs
@@ -134,7 +134,7 @@ pub fn text_to_cf_html(fragment: &str) -> Vec<u8> {
 
     // INVARIANT: placeholder_pos + POS_PLACEHOLDER.len() < buffer.len()
     // This is always valid because we know that placeholder is always present in the buffer
-    // fter the header is written and placeholder is within the bounds of the buffer.
+    // after the header is written and placeholder is within the bounds of the buffer.
     #[allow(clippy::arithmetic_side_effects)]
     let mut replace_placeholder = |placeholder_pos: usize, placeholder_value: &str| {
         buffer[placeholder_pos..placeholder_pos + POS_PLACEHOLDER.len()].copy_from_slice(placeholder_value.as_bytes());

--- a/crates/ironrdp-cliprdr-format/src/html.rs
+++ b/crates/ironrdp-cliprdr-format/src/html.rs
@@ -12,8 +12,8 @@ pub enum HtmlError {
     InvalidConversion,
 }
 
-/// Convert `CF_HTML` format to plain text.
-pub fn cf_html_to_text(input: &[u8]) -> Result<String, HtmlError> {
+/// Converts `CF_HTML` format to plain HTML text.
+pub fn cf_html_to_plain_html(input: &[u8]) -> Result<String, HtmlError> {
     let mut start_fragment = None;
     let mut end_fragment = None;
 
@@ -22,11 +22,11 @@ pub fn cf_html_to_text(input: &[u8]) -> Result<String, HtmlError> {
     let fragment = loop {
         // Line split logic is manual instead of using BufReader::read_line because
         // the line ending could be represented as `\r\n`, `\n` or even `\r`.
-        const ENDLINE_CONTROLS: &[u8] = &[b'\r', b'\n'];
+        const EOL_CONTROL_CHARS: &[u8] = &[b'\r', b'\n'];
 
-        // Failed to find the end of the line
-        let end_pos = match headers_cursor.iter().position(|ch| ENDLINE_CONTROLS.contains(ch)) {
+        let end_pos = match headers_cursor.iter().position(|ch| EOL_CONTROL_CHARS.contains(ch)) {
             Some(pos) => pos,
+            // Failed to find the end of the line
             None => return Err(HtmlError::InvalidFormat),
         };
 
@@ -89,8 +89,8 @@ pub fn cf_html_to_text(input: &[u8]) -> Result<String, HtmlError> {
     }
 }
 
-/// Convert plain text HTML to `CF_HTML` format.
-pub fn text_to_cf_html(fragment: &str) -> Vec<u8> {
+/// Converts plain HTML text to `CF_HTML` format.
+pub fn plain_html_to_cf_html(fragment: &str) -> Vec<u8> {
     let mut buffer = Vec::new();
 
     // INVARIANT: key.len() + value.len() + ":\r\n".len() < usize::MAX

--- a/crates/ironrdp-cliprdr-native/src/windows/clipboard_impl.rs
+++ b/crates/ironrdp-cliprdr-native/src/windows/clipboard_impl.rs
@@ -148,7 +148,7 @@ impl WinClipboardImpl {
         // We need to be clipboard owner to be able to set all clipboard formats
         let _clipboard = match OwnedOsClipboard::new(self.window) {
             Ok(clipboard) => {
-                // SAFETY: `GetClipboardOwner` is alwys safe to call
+                // SAFETY: `GetClipboardOwner` is always safe to call
                 if self.window != unsafe { GetClipboardOwner() } {
                     // As per MSDN, we need to validate clipboard owner after opening clipboard
                     return Ok(None);

--- a/crates/ironrdp-cliprdr-native/src/windows/remote_format_registry.rs
+++ b/crates/ironrdp-cliprdr-native/src/windows/remote_format_registry.rs
@@ -45,7 +45,7 @@ impl RemoteClipboardFormatRegistry {
             return None;
         }
 
-        if !remote_format.id().is_registrered() {
+        if !remote_format.id().is_registered() {
             // Unknown format range, we could skip it
             return None;
         }

--- a/crates/ironrdp-cliprdr/README.md
+++ b/crates/ironrdp-cliprdr/README.md
@@ -1,9 +1,9 @@
 # IronRDP CLIPRDR
 
-Implementation of cliboard static virtual channel(`CLIPRDR`) described in `MS-RDPECLIP`
+Implementation of clipboard static virtual channel(`CLIPRDR`) described in `MS-RDPECLIP`
 
 This library includes:
-- Cliboard SVC PDUs parsing
+- Clipboard SVC PDUs parsing
 - Clipboard SVC processing
 - Clipboard backend API types for implementing OS-specific clipboard logic
 

--- a/crates/ironrdp-cliprdr/src/backend.rs
+++ b/crates/ironrdp-cliprdr/src/backend.rs
@@ -73,7 +73,7 @@ pub trait CliprdrBackend: AsAny + std::fmt::Debug + Send {
     /// Called by [crate::Cliprdr] when copy sequence is finished.
     /// This method is called after remote returns format list response.
     ///
-    /// Usefull for the backend implementations which need to know when remote is ready to paste
+    /// Useful for the backend implementations which need to know when remote is ready to paste
     /// previously advertised formats from the client. E.g. Web client uses this for
     /// Firefox-specific logic to delay sending keyboard key events to prevent pasting the old
     /// data from the clipboard.

--- a/crates/ironrdp-cliprdr/src/pdu/format_list.rs
+++ b/crates/ironrdp-cliprdr/src/pdu/format_list.rs
@@ -135,7 +135,7 @@ impl ClipboardFormatId {
         )
     }
 
-    pub fn is_registrered(self) -> bool {
+    pub fn is_registered(self) -> bool {
         (self.0 >= 0xC000) && (self.0 <= 0xFFFF)
     }
 }

--- a/crates/ironrdp-cliprdr/src/pdu/format_list.rs
+++ b/crates/ironrdp-cliprdr/src/pdu/format_list.rs
@@ -199,10 +199,12 @@ impl ClipboardFormat {
         }
     }
 
+    #[inline]
     pub fn id(&self) -> ClipboardFormatId {
         self.id
     }
 
+    #[inline]
     pub fn name(&self) -> Option<&ClipboardFormatName> {
         self.name.as_ref()
     }

--- a/crates/ironrdp-cliprdr/src/pdu/mod.rs
+++ b/crates/ironrdp-cliprdr/src/pdu/mod.rs
@@ -113,7 +113,7 @@ pub enum ClipboardPdu<'a> {
 }
 
 impl ClipboardPdu<'_> {
-    const NAME: &str = "CliboardPdu";
+    const NAME: &str = "ClipboardPdu";
     const FIXED_PART_SIZE: usize = std::mem::size_of::<u16>();
 
     pub fn message_name(&self) -> &'static str {

--- a/crates/ironrdp-fuzzing/src/oracles/mod.rs
+++ b/crates/ironrdp-fuzzing/src/oracles/mod.rs
@@ -120,7 +120,7 @@ pub fn rdp6_decode_bitmap_stream_to_rgb24(input: &BitmapInput<'_>) {
 
 pub fn cliprdr_format(input: &[u8]) {
     use ironrdp_cliprdr_format::bitmap::{dib_to_png, dibv5_to_png, png_to_cf_dib, png_to_cf_dibv5};
-    use ironrdp_cliprdr_format::html::{cf_html_to_text, text_to_cf_html};
+    use ironrdp_cliprdr_format::html::{cf_html_to_plain_html, plain_html_to_cf_html};
 
     let _ = png_to_cf_dib(input);
     let _ = png_to_cf_dibv5(input);
@@ -128,6 +128,6 @@ pub fn cliprdr_format(input: &[u8]) {
     let _ = dib_to_png(input);
     let _ = dibv5_to_png(input);
 
-    let _ = cf_html_to_text(input);
-    let _ = text_to_cf_html(String::from_utf8_lossy(input).as_ref());
+    let _ = cf_html_to_plain_html(input);
+    let _ = plain_html_to_cf_html(String::from_utf8_lossy(input).as_ref());
 }

--- a/crates/ironrdp-fuzzing/src/oracles/mod.rs
+++ b/crates/ironrdp-fuzzing/src/oracles/mod.rs
@@ -129,5 +129,8 @@ pub fn cliprdr_format(input: &[u8]) {
     let _ = dibv5_to_png(input);
 
     let _ = cf_html_to_plain_html(input);
-    let _ = plain_html_to_cf_html(String::from_utf8_lossy(input).as_ref());
+
+    if let Ok(input) = core::str::from_utf8(input) {
+        let _ = plain_html_to_cf_html(input);
+    }
 }

--- a/crates/ironrdp-graphics/src/pointer.rs
+++ b/crates/ironrdp-graphics/src/pointer.rs
@@ -10,7 +10,7 @@
 //! RDP's pointer representation is a bit weird. It uses two masks to represent a pointer -
 //! andMask and xorMask. Xor mask is used as a base color for a pointer pixel, and andMask
 //! mask is used co control pixel's full transparency (`src_color.a = 0`), full opacity
-//! (`src_color.a = 255`) or pixel invertion (`dst_color.rgb = vec3(255) - dst_color.rgb`).
+//! (`src_color.a = 255`) or pixel inversion (`dst_color.rgb = vec3(255) - dst_color.rgb`).
 //!
 //! Xor basks could be 1, 8, 16, 24 or 32 bits per pixel, and andMask is always 1 bit per pixel.
 //!

--- a/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx/graphics_messages.rs
+++ b/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx/graphics_messages.rs
@@ -294,7 +294,7 @@ pub enum GraphicsMessagesError {
     #[error("invalid codec ID version 2")]
     InvalidCodec2Id,
     #[error("invalid pixel format")]
-    InvalidFixelFormat,
+    InvalidPixelFormat,
     #[error("monitor error")]
     MonitorError(#[from] MonitorDataError),
     #[error("invalid ResetGraphics PDU width: {} > MAX ({})", actual, max)]

--- a/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx/graphics_messages/server.rs
+++ b/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx/graphics_messages/server.rs
@@ -43,7 +43,7 @@ impl PduParsing for WireToSurface1Pdu {
         let surface_id = stream.read_u16::<LittleEndian>()?;
         let codec_id =
             Codec1Type::from_u16(stream.read_u16::<LittleEndian>()?).ok_or(GraphicsMessagesError::InvalidCodec1Id)?;
-        let pixel_format = PixelFormat::from_u8(stream.read_u8()?).ok_or(GraphicsMessagesError::InvalidFixelFormat)?;
+        let pixel_format = PixelFormat::from_u8(stream.read_u8()?).ok_or(GraphicsMessagesError::InvalidPixelFormat)?;
         let destination_rectangle = InclusiveRectangle::from_buffer(&mut stream)?;
         let bitmap_data_length = stream.read_u32::<LittleEndian>()? as usize;
         let mut bitmap_data = vec![0; bitmap_data_length];
@@ -101,7 +101,7 @@ impl PduParsing for WireToSurface2Pdu {
         let codec_id =
             Codec2Type::from_u16(stream.read_u16::<LittleEndian>()?).ok_or(GraphicsMessagesError::InvalidCodec2Id)?;
         let codec_context_id = stream.read_u32::<LittleEndian>()?;
-        let pixel_format = PixelFormat::from_u8(stream.read_u8()?).ok_or(GraphicsMessagesError::InvalidFixelFormat)?;
+        let pixel_format = PixelFormat::from_u8(stream.read_u8()?).ok_or(GraphicsMessagesError::InvalidPixelFormat)?;
         let bitmap_data_length = stream.read_u32::<LittleEndian>()? as usize;
         let mut bitmap_data = vec![0; bitmap_data_length];
         stream.read_exact(&mut bitmap_data)?;
@@ -348,7 +348,7 @@ impl PduParsing for CreateSurfacePdu {
         let surface_id = stream.read_u16::<LittleEndian>()?;
         let width = stream.read_u16::<LittleEndian>()?;
         let height = stream.read_u16::<LittleEndian>()?;
-        let pixel_format = PixelFormat::from_u8(stream.read_u8()?).ok_or(GraphicsMessagesError::InvalidFixelFormat)?;
+        let pixel_format = PixelFormat::from_u8(stream.read_u8()?).ok_or(GraphicsMessagesError::InvalidPixelFormat)?;
 
         Ok(Self {
             surface_id,

--- a/crates/ironrdp-testsuite-core/tests/clipboard/format.rs
+++ b/crates/ironrdp-testsuite-core/tests/clipboard/format.rs
@@ -1,5 +1,5 @@
 use ironrdp_cliprdr_format::bitmap::{dib_to_png, dibv5_to_png, png_to_cf_dib, png_to_cf_dibv5};
-use ironrdp_cliprdr_format::html::{cf_html_to_text, text_to_cf_html};
+use ironrdp_cliprdr_format::html::{cf_html_to_plain_html, plain_html_to_cf_html};
 
 #[test]
 fn dib_to_png_conversion_1() {
@@ -20,36 +20,34 @@ fn dibv5_to_png_conversion_1() {
 #[test]
 fn html_failure() {
     // Empty
-    assert!(cf_html_to_text(&[]).is_err());
+    assert!(cf_html_to_plain_html(&[]).is_err());
     // Garbage
-    assert!(cf_html_to_text(&[0x00, 0x00, 0x00, 0x00]).is_err());
+    assert!(cf_html_to_plain_html(&[0x00, 0x00, 0x00, 0x00]).is_err());
     // No headers
-    assert!(cf_html_to_text(b"hello world").is_err());
+    assert!(cf_html_to_plain_html(b"hello world").is_err());
     // Headers with fragment size not found
-    assert!(cf_html_to_text(b"Version:0.9\r\n<html>nopers</html>").is_err());
+    assert!(cf_html_to_plain_html(b"Version:0.9\r\n<html>nopers</html>").is_err());
     // Out of bounds headers
-    assert!(cf_html_to_text(b"StartFragment:999\r\nEndFragment:9999\r\n<html>nopers</html>").is_err());
+    assert!(cf_html_to_plain_html(b"StartFragment:999\r\nEndFragment:9999\r\n<html>nopers</html>").is_err());
 }
 
 #[test]
 fn test_cf_html_to_text() {
     let input = include_bytes!("../../test_data/pdu/clipboard/cf_html.pdu");
-    let actual = cf_html_to_text(input).unwrap();
+    let actual = cf_html_to_plain_html(input).unwrap();
 
     // Validate that the output is valid HTML
     assert!(actual.starts_with("<b>Remote Desktop Protocol</b>"));
     assert!(actual.ends_with("</sup>"));
 
     // Validate roundtrip
-    let mut cf_html = text_to_cf_html(&actual);
-    let roundtrip_text_html = cf_html_to_text(&cf_html).unwrap();
-    assert_eq!(actual, roundtrip_text_html);
+    let mut cf_html = plain_html_to_cf_html(&actual);
+    let roundtrip_html_text = cf_html_to_plain_html(&cf_html).unwrap();
+    assert_eq!(actual, roundtrip_html_text);
 
     // Add some padding (CF_HTML is not null-terminated, we need to work with data which is
     // potentially padded with arbitrary fill bytes).
     cf_html.extend_from_slice(&[0xFFu8; 10]);
-
-    let roundtrip_text_html = cf_html_to_text(&cf_html).unwrap();
-
-    assert_eq!(actual, roundtrip_text_html);
+    let roundtrip_html_text = cf_html_to_plain_html(&cf_html).unwrap();
+    assert_eq!(actual, roundtrip_html_text);
 }

--- a/crates/ironrdp-testsuite-core/tests/clipboard/format.rs
+++ b/crates/ironrdp-testsuite-core/tests/clipboard/format.rs
@@ -22,7 +22,7 @@ fn html_failure() {
     // Empty
     assert!(cf_html_to_plain_html(&[]).is_err());
     // Garbage
-    assert!(cf_html_to_plain_html(&[0x00, 0x00, 0x00, 0x00]).is_err());
+    assert!(cf_html_to_plain_html(&[0x00, 0x01, 0x02, 0x03]).is_err());
     // No headers
     assert!(cf_html_to_plain_html(b"hello world").is_err());
     // Headers with fragment size not found
@@ -41,13 +41,14 @@ fn test_cf_html_to_text() {
     assert!(actual.ends_with("</sup>"));
 
     // Validate roundtrip
-    let mut cf_html = plain_html_to_cf_html(&actual);
-    let roundtrip_html_text = cf_html_to_plain_html(&cf_html).unwrap();
+    let cf_html = plain_html_to_cf_html(&actual);
+    let roundtrip_html_text = cf_html_to_plain_html(cf_html.as_bytes()).unwrap();
     assert_eq!(actual, roundtrip_html_text);
 
     // Add some padding (CF_HTML is not null-terminated, we need to work with data which is
     // potentially padded with arbitrary fill bytes).
-    cf_html.extend_from_slice(&[0xFFu8; 10]);
+    let mut cf_html = cf_html.into_bytes();
+    cf_html.extend_from_slice(&[0xFF; 10]);
     let roundtrip_html_text = cf_html_to_plain_html(&cf_html).unwrap();
     assert_eq!(actual, roundtrip_html_text);
 }

--- a/crates/ironrdp-web/src/clipboard/mod.rs
+++ b/crates/ironrdp-web/src/clipboard/mod.rs
@@ -104,7 +104,7 @@ pub(crate) enum WasmClipboardBackendMessage {
 /// kept alive until session is terminated.
 pub(crate) struct WasmClipboard {
     local_clipboard: Option<ClipboardTransaction>,
-    remote_clipborad: ClipboardTransaction,
+    remote_clipboard: ClipboardTransaction,
 
     remote_mapping: HashMap<ClipboardFormatId, String>,
     remote_formats_to_read: Vec<ClipboardFormatId>,
@@ -124,7 +124,7 @@ impl WasmClipboard {
     pub(crate) fn new(message_proxy: WasmClipboardMessageProxy, js_callbacks: JsClipboardCallbacks) -> Self {
         Self {
             local_clipboard: None,
-            remote_clipborad: ClipboardTransaction::new(),
+            remote_clipboard: ClipboardTransaction::new(),
             proxy: message_proxy,
             js_callbacks,
 
@@ -255,7 +255,7 @@ impl WasmClipboard {
         formats: Vec<ClipboardFormat>,
     ) -> anyhow::Result<Option<ClipboardFormatId>> {
         self.remote_formats_to_read.clear();
-        self.remote_clipborad.clear();
+        self.remote_clipboard.clear();
 
         let is_format_name_equal = |format: &ClipboardFormat, name: &str| {
             format
@@ -265,7 +265,7 @@ impl WasmClipboard {
         };
 
         for format in &formats {
-            if format.id().is_registrered() {
+            if format.id().is_registered() {
                 if let Some(name) = format.name() {
                     const SUPPORTED_FORMATS: &[&str] = &[
                         FORMAT_WIN_HTML.name,
@@ -401,7 +401,7 @@ impl WasmClipboard {
         };
 
         if let Some(content) = content {
-            self.remote_clipborad.add_content(content);
+            self.remote_clipboard.add_content(content);
         }
 
         // Request next format
@@ -411,7 +411,7 @@ impl WasmClipboard {
                 .send_cliprdr_message(ClipboardMessage::SendInitiatePaste(*format));
         } else {
             // All formats were read, send clipboard to JS
-            let transaction = std::mem::take(&mut self.remote_clipborad);
+            let transaction = std::mem::take(&mut self.remote_clipboard);
             if transaction.is_empty() {
                 return Ok(());
             }

--- a/crates/ironrdp-web/src/clipboard/mod.rs
+++ b/crates/ironrdp-web/src/clipboard/mod.rs
@@ -23,7 +23,7 @@ use ironrdp::cliprdr::pdu::{
 };
 use ironrdp::svc::impl_as_any;
 use ironrdp_cliprdr_format::bitmap::{dib_to_png, dibv5_to_png, png_to_cf_dibv5};
-use ironrdp_cliprdr_format::html::{cf_html_to_text, text_to_cf_html};
+use ironrdp_cliprdr_format::html::{cf_html_to_plain_html, plain_html_to_cf_html};
 use transaction::{ClipboardContent, ClipboardContentValue};
 use wasm_bindgen::prelude::*;
 
@@ -239,7 +239,7 @@ impl WasmClipboard {
             }
             FORMAT_WIN_HTML_ID => {
                 let text = find_text_content_by_mime(MIME_HTML)?;
-                let buffer = text_to_cf_html(text);
+                let buffer = plain_html_to_cf_html(text);
                 FormatDataResponse::new_data(buffer)
             }
             FORMAT_MIME_HTML_ID => {
@@ -394,7 +394,7 @@ impl WasmClipboard {
             registered => {
                 let format_name = self.remote_mapping.get(&registered).map(|s| s.as_str());
                 match format_name {
-                    Some(FORMAT_WIN_HTML_NAME) => match cf_html_to_text(response.data()) {
+                    Some(FORMAT_WIN_HTML_NAME) => match cf_html_to_plain_html(response.data()) {
                         Ok(text) => Some(ClipboardContent::new_text(MIME_HTML, &text)),
                         Err(err) => {
                             warn!("CF_HTML decode error: {}", err);

--- a/crates/ironrdp-web/src/clipboard/mod.rs
+++ b/crates/ironrdp-web/src/clipboard/mod.rs
@@ -238,13 +238,13 @@ impl WasmClipboard {
                 FormatDataResponse::new_unicode_string(text)
             }
             FORMAT_WIN_HTML_ID => {
-                let text = find_text_content_by_mime(MIME_HTML)?;
-                let buffer = plain_html_to_cf_html(text);
-                FormatDataResponse::new_data(buffer)
+                let html_text = find_text_content_by_mime(MIME_HTML)?;
+                let cf_html = plain_html_to_cf_html(html_text);
+                FormatDataResponse::new_data(cf_html.into_bytes())
             }
             FORMAT_MIME_HTML_ID => {
-                let text = find_text_content_by_mime(MIME_HTML)?;
-                FormatDataResponse::new_string(text)
+                let html_text = find_text_content_by_mime(MIME_HTML)?;
+                FormatDataResponse::new_string(html_text)
             }
             ClipboardFormatId::CF_DIBV5 => {
                 let png_data = find_binary_content_by_mime(MIME_PNG)?;
@@ -395,7 +395,7 @@ impl WasmClipboard {
                 let format_name = self.remote_mapping.get(&registered).map(|s| s.as_str());
                 match format_name {
                     Some(FORMAT_WIN_HTML_NAME) => match cf_html_to_plain_html(response.data()) {
-                        Ok(text) => Some(ClipboardContent::new_text(MIME_HTML, &text)),
+                        Ok(text) => Some(ClipboardContent::new_text(MIME_HTML, text)),
                         Err(err) => {
                             warn!("CF_HTML decode error: {}", err);
                             None

--- a/web-client/iron-remote-gui/src/iron-remote-gui.svelte
+++ b/web-client/iron-remote-gui/src/iron-remote-gui.svelte
@@ -170,7 +170,7 @@
             var values = new Map<string, string | Uint8Array>();
             var sameValue = true;
 
-            // Saddly, browsers build new `ClipboardItem` object for each `read` call,
+            // Sadly, browsers build new `ClipboardItem` object for each `read` call,
             // so we can't do reference comparison here :(
             //
             // For monitoring loop approach we also can't drop this logic, as it will result in


### PR DESCRIPTION
I studied and experimented with cliprdr code over the weekend. Here is some related housekeeping.

Commits are independents and the intention is to rebase-merge them:

- [refactor(cliprdr): fix typos](https://github.com/Devolutions/IronRDP/pull/289/commits/48b8856f4b0033388e7ea10d6365f261fc3a3c99)
- [refactor(web): explain cliprdr web backend quirks](https://github.com/Devolutions/IronRDP/pull/289/commits/575a85fc6bf91de2a5a27d99ab4d5c35556b909a)
- [perf: enable inlining for a few functions](https://github.com/Devolutions/IronRDP/pull/289/commits/773901e379a9b9d657165b82f50ded2b56d38732)
  These are very small functions which are used multiple times in the same loop inside cliprdr web backend.
- [style: local helper functions](https://github.com/Devolutions/IronRDP/pull/289/commits/290bf37efae5b45b28f74967165903968619ccdc)
- [refactor(cliprdr): clarify naming](https://github.com/Devolutions/IronRDP/pull/289/commits/efdd30b38f9ae4bfd4043017fe5bdf679397db74)
- [refactor(cliprdr): consolidate HTML conversions](https://github.com/Devolutions/IronRDP/pull/289/commits/b9ebe67a4986660f9ad38b39f1a7bf53cf0cf5b0)
  - `cf_html_to_plain_html` does not allocate anymore
  - `plain_html_to_cf_html` returns a `String` (`CF_HTML` payload is UTF-8)
- [style(cliprdr): clarify invariants](https://github.com/Devolutions/IronRDP/pull/289/commits/3d621a808447d3d85cd785b1350d1455dcba8cd5)

@pacmancoder can you verify everything is looking good to you?