### PR TITLE
chore(release): prepare web client for 0.10.0

### DIFF
--- a/web-client/iron-remote-gui/package-lock.json
+++ b/web-client/iron-remote-gui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@devolutions/iron-remote-gui",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@devolutions/iron-remote-gui",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
         "@types/ua-parser-js": "^0.7.36",
         "ua-parser-js": "^1.0.33"

--- a/web-client/iron-remote-gui/package.json
+++ b/web-client/iron-remote-gui/package.json
@@ -7,7 +7,7 @@
     "Zacharia Ellaham"
   ],
   "description": "Web Component providing agnostic implementation for Iron Wasm base client",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "type": "module",
   "private": true,
   "scripts": {

--- a/web-client/iron-remote-gui/public/package.json
+++ b/web-client/iron-remote-gui/public/package.json
@@ -7,7 +7,7 @@
     "Zacharia Ellaham"
   ],
   "description": "Web Component providing agnostic implementation for Iron Wasm base client.",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "main": "iron-remote-gui.umd.cjs",
   "types": "main.d.ts",
   "files": [


### PR DESCRIPTION
The new version of IronRDP web client supports hardware cursors. This can significantly improve perceived performance over slow links.

Demonstration:
[demo-hardware-cursor.webm](https://github.com/Devolutions/IronRDP/assets/3809077/1f895688-edb0-4923-9b10-de5fe32d5a2e)

One difference with the previous implementation is that the cursor style remains unchanged and can go out of the canvas as long as the hotspot remains inside (the point which actually interacts with elements on the screen). Also, the I-beam icon (the cursor icon shown when selecting text) is following a checkered pattern, alternating black and white pixels. This is a compromise so that the cursor is visible even if the background is dark.

cc @pacmancoder 