### PR TITLE
Fix broken Package 0.11.0, bundle Rxjs back into umd.js 

### DIFF
--- a/web-client/iron-remote-gui/vite.config.ts
+++ b/web-client/iron-remote-gui/vite.config.ts
@@ -12,9 +12,6 @@ export default defineConfig({
             name: 'IronRemoteGui',
             formats: ['umd', 'es'],
         },
-        rollupOptions: {
-            external: ['rxjs'],
-        },
     },
     server: {
         fs: {


### PR DESCRIPTION
Fixes the broken package 0.11.0, as rxjs is excluded as umd js, but our project all includes rxjs as module. Wrap rxjs back into the umd js defination, so it operates. This is temporary solution, as umd js causes larger bundles size and optimization slow down. in fact, we cannot use the exported enum value, as our TS is in module js format, but our actual js is not module, hence, we can only export types not any values.

but anyway, it works for now. 