### PR TITLE
chore(release): prepare iron-remote-gui for 0.11.1

### DIFF
--- a/web-client/iron-remote-gui/package-lock.json
+++ b/web-client/iron-remote-gui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@devolutions/iron-remote-gui",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@devolutions/iron-remote-gui",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "dependencies": {
         "rxjs": "^6.6.7",
         "ua-parser-js": "^1.0.33"

--- a/web-client/iron-remote-gui/package.json
+++ b/web-client/iron-remote-gui/package.json
@@ -9,7 +9,7 @@
     "Zacharia Ellaham"
   ],
   "description": "Web Component providing agnostic implementation for Iron Wasm base client",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "type": "module",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Fixed broken 0.11.0 package for rxjs dependency issue