### PR TITLE
`LockControl`

### DIFF
--- a/crates/ironrdp-pdu/src/cursor.rs
+++ b/crates/ironrdp-pdu/src/cursor.rs
@@ -46,12 +46,6 @@ impl<'a> ReadCursor<'a> {
     }
 
     #[inline]
-    pub fn discard(&mut self) {
-        let remaining_len = self.len();
-        self.advance(remaining_len);
-    }
-
-    #[inline]
     #[track_caller]
     pub fn read_array<const N: usize>(&mut self) -> [u8; N] {
         let bytes = &self.inner[self.pos..self.pos + N];

--- a/crates/ironrdp-pdu/src/cursor.rs
+++ b/crates/ironrdp-pdu/src/cursor.rs
@@ -168,6 +168,28 @@ impl<'a> ReadCursor<'a> {
     }
 
     #[inline]
+    pub fn read_i64(&mut self) -> i64 {
+        i64::from_le_bytes(self.read_array::<8>())
+    }
+
+    #[inline]
+    pub fn read_i64_be(&mut self) -> i64 {
+        i64::from_be_bytes(self.read_array::<8>())
+    }
+
+    #[inline]
+    pub fn try_read_i64(&mut self, ctx: &'static str) -> PduResult<i64> {
+        ensure_size!(ctx: ctx, in: self, size: 8);
+        Ok(i64::from_le_bytes(self.read_array::<8>()))
+    }
+
+    #[inline]
+    pub fn try_read_i64_be(&mut self, ctx: &'static str) -> PduResult<i64> {
+        ensure_size!(ctx: ctx, in: self, size: 8);
+        Ok(i64::from_be_bytes(self.read_array::<8>()))
+    }
+
+    #[inline]
     #[track_caller]
     pub fn peek<const N: usize>(&mut self) -> [u8; N] {
         self.inner[self.pos..self.pos + N].try_into().expect("N-elements array")

--- a/crates/ironrdp-pdu/src/cursor.rs
+++ b/crates/ironrdp-pdu/src/cursor.rs
@@ -46,6 +46,12 @@ impl<'a> ReadCursor<'a> {
     }
 
     #[inline]
+    pub fn discard(&mut self) {
+        let remaining_len = self.len();
+        self.advance(remaining_len);
+    }
+
+    #[inline]
     #[track_caller]
     pub fn read_array<const N: usize>(&mut self) -> [u8; N] {
         let bytes = &self.inner[self.pos..self.pos + N];

--- a/crates/ironrdp-pdu/src/lib.rs
+++ b/crates/ironrdp-pdu/src/lib.rs
@@ -52,6 +52,7 @@ pub enum PduErrorKind {
     InvalidMessage { field: &'static str, reason: &'static str },
     UnexpectedMessageType { got: u8 },
     UnsupportedVersion { got: u8 },
+    UnsupportedPdu { name: &'static str, value: String },
     Other { description: &'static str },
     Custom,
 }
@@ -74,6 +75,9 @@ impl fmt::Display for PduErrorKind {
             Self::UnsupportedVersion { got } => {
                 write!(f, "unsupported version ({got})")
             }
+            Self::UnsupportedPdu { name, value } => {
+                write!(f, "unsupported {name} ({value})")
+            }
             Self::Other { description } => {
                 write!(f, "{description}")
             }
@@ -89,6 +93,7 @@ pub trait PduErrorExt {
     fn invalid_message(context: &'static str, field: &'static str, reason: &'static str) -> Self;
     fn unexpected_message_type(context: &'static str, got: u8) -> Self;
     fn unsupported_version(context: &'static str, got: u8) -> Self;
+    fn unsupported_pdu(context: &'static str, name: &'static str, value: String) -> Self;
     fn other(context: &'static str, description: &'static str) -> Self;
     fn custom<E>(context: &'static str, e: E) -> Self
     where
@@ -110,6 +115,10 @@ impl PduErrorExt for PduError {
 
     fn unsupported_version(context: &'static str, got: u8) -> Self {
         Self::new(context, PduErrorKind::UnsupportedVersion { got })
+    }
+
+    fn unsupported_pdu(context: &'static str, name: &'static str, value: String) -> Self {
+        Self::new(context, PduErrorKind::UnsupportedPdu { name, value })
     }
 
     fn other(context: &'static str, description: &'static str) -> Self {

--- a/crates/ironrdp-pdu/src/macros.rs
+++ b/crates/ironrdp-pdu/src/macros.rs
@@ -82,6 +82,25 @@ macro_rules! unsupported_version_err {
     }};
 }
 
+/// Creates a `PduError` with `UnsupportedPdu` kind
+/// Shorthand for
+/// ```rust
+/// <ironrdp_pdu::PduError as ironrdp_pdu::PduErrorExt>::unsupported_pdu(context, name, value)
+/// ```
+/// and
+/// ```rust
+/// <ironrdp_pdu::PduError as ironrdp_pdu::PduErrorExt>::unsupported_pdu(Self::NAME, name, value)
+/// ```
+#[macro_export]
+macro_rules! unsupported_pdu_err {
+    ( $context:expr, $name:expr, $value:expr $(,)? ) => {{
+        <$crate::PduError as $crate::PduErrorExt>::unsupported_pdu($context, $name, $value)
+    }};
+    ( $name:expr, $value:expr $(,)? ) => {{
+        unsupported_pdu_err!(Self::NAME, $name, $value)
+    }};
+}
+
 /// Creates a `PduError` with `Other` kind
 ///
 /// Shorthand for

--- a/crates/ironrdp-rdpdr/src/lib.rs
+++ b/crates/ironrdp-rdpdr/src/lib.rs
@@ -221,7 +221,8 @@ impl StaticVirtualChannelProcessor for Rdpdr {
             | RdpdrPdu::ClientDriveQueryDirectoryResponse(_)
             | RdpdrPdu::ClientDriveQueryVolumeInformationResponse(_)
             | RdpdrPdu::DeviceReadResponse(_)
-            | RdpdrPdu::DeviceWriteResponse(_) => Err(other_err!("Rdpdr", "received unexpected packet")),
+            | RdpdrPdu::DeviceWriteResponse(_)
+            | RdpdrPdu::ClientDriveSetInformationResponse(_) => Err(other_err!("Rdpdr", "received unexpected packet")),
         }
     }
 }

--- a/crates/ironrdp-rdpdr/src/pdu/efs.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/efs.rs
@@ -3334,9 +3334,13 @@ impl FileDispositionInformation {
     const FIXED_PART_SIZE: usize = 1; // DeletePending
 
     fn decode(src: &mut ReadCursor<'_>, length: usize) -> PduResult<Self> {
-        ensure_fixed_part_size!(in: src);
         // https://github.com/FreeRDP/FreeRDP/blob/dfa231c0a55b005af775b833f92f6bcd30363d77/channels/drive/client/drive_file.c#L684-L692
-        let delete_pending = if length != 0 { src.read_u8() } else { 1 };
+        let delete_pending = if length != 0 {
+            ensure_fixed_part_size!(in: src);
+            src.read_u8()
+        } else {
+            1
+        };
         Ok(Self { delete_pending })
     }
 

--- a/crates/ironrdp-rdpdr/src/pdu/mod.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/mod.rs
@@ -6,9 +6,9 @@ use ironrdp_pdu::{ensure_size, invalid_message_err, PduDecode, PduEncode, PduErr
 
 use self::efs::{
     ClientDeviceListAnnounce, ClientDriveQueryDirectoryResponse, ClientDriveQueryInformationResponse,
-    ClientDriveQueryVolumeInformationResponse, ClientNameRequest, CoreCapability, CoreCapabilityKind,
-    DeviceCloseResponse, DeviceControlResponse, DeviceCreateResponse, DeviceIoRequest, DeviceReadResponse,
-    DeviceWriteResponse, ServerDeviceAnnounceResponse, VersionAndIdPdu, VersionAndIdPduKind,
+    ClientDriveQueryVolumeInformationResponse, ClientDriveSetInformationResponse, ClientNameRequest, CoreCapability,
+    CoreCapabilityKind, DeviceCloseResponse, DeviceControlResponse, DeviceCreateResponse, DeviceIoRequest,
+    DeviceReadResponse, DeviceWriteResponse, ServerDeviceAnnounceResponse, VersionAndIdPdu, VersionAndIdPduKind,
 };
 
 pub mod efs;
@@ -30,6 +30,7 @@ pub enum RdpdrPdu {
     ClientDriveQueryVolumeInformationResponse(ClientDriveQueryVolumeInformationResponse),
     DeviceReadResponse(DeviceReadResponse),
     DeviceWriteResponse(DeviceWriteResponse),
+    ClientDriveSetInformationResponse(ClientDriveSetInformationResponse),
     /// TODO: temporary value for development, this should be removed
     Unimplemented,
 }
@@ -85,7 +86,8 @@ impl RdpdrPdu {
             | RdpdrPdu::ClientDriveQueryDirectoryResponse(_)
             | RdpdrPdu::ClientDriveQueryVolumeInformationResponse(_)
             | RdpdrPdu::DeviceReadResponse(_)
-            | RdpdrPdu::DeviceWriteResponse(_) => SharedHeader {
+            | RdpdrPdu::DeviceWriteResponse(_)
+            | RdpdrPdu::ClientDriveSetInformationResponse(_) => SharedHeader {
                 component: Component::RdpdrCtypCore,
                 packet_id: PacketId::CoreDeviceIoCompletion,
             },
@@ -132,6 +134,7 @@ impl PduEncode for RdpdrPdu {
             RdpdrPdu::ClientDriveQueryVolumeInformationResponse(pdu) => pdu.encode(dst),
             RdpdrPdu::DeviceReadResponse(pdu) => pdu.encode(dst),
             RdpdrPdu::DeviceWriteResponse(pdu) => pdu.encode(dst),
+            RdpdrPdu::ClientDriveSetInformationResponse(pdu) => pdu.encode(dst),
             RdpdrPdu::Unimplemented => Ok(()),
         }
     }
@@ -152,6 +155,7 @@ impl PduEncode for RdpdrPdu {
             RdpdrPdu::ClientDriveQueryVolumeInformationResponse(pdu) => pdu.name(),
             RdpdrPdu::DeviceReadResponse(pdu) => pdu.name(),
             RdpdrPdu::DeviceWriteResponse(pdu) => pdu.name(),
+            RdpdrPdu::ClientDriveSetInformationResponse(pdu) => pdu.name(),
             RdpdrPdu::Unimplemented => "Unimplemented",
         }
     }
@@ -173,6 +177,7 @@ impl PduEncode for RdpdrPdu {
                 RdpdrPdu::ClientDriveQueryVolumeInformationResponse(pdu) => pdu.size(),
                 RdpdrPdu::DeviceReadResponse(pdu) => pdu.size(),
                 RdpdrPdu::DeviceWriteResponse(pdu) => pdu.size(),
+                RdpdrPdu::ClientDriveSetInformationResponse(pdu) => pdu.size(),
                 RdpdrPdu::Unimplemented => 0,
             }
     }
@@ -221,6 +226,9 @@ impl fmt::Debug for RdpdrPdu {
                 write!(f, "RdpdrPdu({:?})", it)
             }
             Self::DeviceWriteResponse(it) => {
+                write!(f, "RdpdrPdu({:?})", it)
+            }
+            Self::ClientDriveSetInformationResponse(it) => {
                 write!(f, "RdpdrPdu({:?})", it)
             }
             Self::Unimplemented => {
@@ -275,6 +283,12 @@ impl From<DeviceReadResponse> for RdpdrPdu {
 impl From<DeviceWriteResponse> for RdpdrPdu {
     fn from(value: DeviceWriteResponse) -> Self {
         Self::DeviceWriteResponse(value)
+    }
+}
+
+impl From<ClientDriveSetInformationResponse> for RdpdrPdu {
+    fn from(value: ClientDriveSetInformationResponse) -> Self {
+        Self::ClientDriveSetInformationResponse(value)
     }
 }
 


### PR DESCRIPTION
- Add a new `UnsupportedPdu` kind to `PduError`, enhancing error handling capabilities in ironrdp-pdu. This new error kind allows for more specific error messages when encountering unsupported PDUs.
- Implement a macro `unsupported_pdu_err` for conveniently creating `PduError` instances with the `UnsupportedPdu` kind.
- Implement handling for `ServerDriveLockControlRequest` in ironrdp-rdpdr, including the definition of the struct and its decoding method. This adds support for processing lock control requests in the RDPDR protocol.
- Update `Rdpdr`'s `process` method to utilize the new `unsupported_pdu_err` when encountering unknown packet IDs, replacing the previous handling of unimplemented PDUs.
- Remove the `Unimplemented` variant from `RdpdrPdu` and `Component` enums, replacing it with `EmptyResponse` in `RdpdrPdu`. This change streamlines the handling of unimplemented or unexpected PDUs.
- Enhance `FileInformationClass` and `FileInformationClassLevel` with `Display` implementations, providing better logging and error message capabilities.