### PR TITLE
refactor: function! macro for error context

### DIFF
--- a/crates/ironrdp-cliprdr/src/pdu/capabilities.rs
+++ b/crates/ironrdp-cliprdr/src/pdu/capabilities.rs
@@ -233,8 +233,6 @@ impl ClipboardProtocolVersion {
     const VERSION_VALUE_V1: u32 = 0x0000_0001;
     const VERSION_VALUE_V2: u32 = 0x0000_0002;
 
-    const NAME: &str = "CLIPRDR_CAPS_VERSION";
-
     #[must_use]
     pub fn downgrade(self, other: Self) -> Self {
         if self != other {

--- a/crates/ironrdp-pdu/src/basic_output/bitmap/rdp6.rs
+++ b/crates/ironrdp-pdu/src/basic_output/bitmap/rdp6.rs
@@ -282,7 +282,7 @@ mod tests {
             &[],
             expect![[r#"
                 Error {
-                    context: "Rdp6BitmapStream",
+                    context: "<ironrdp_pdu::basic_output::bitmap::rdp6::BitmapStream as ironrdp_pdu::PduDecode>::decode",
                     kind: NotEnoughBytes {
                         received: 0,
                         expected: 1,
@@ -297,7 +297,7 @@ mod tests {
             &[0x20],
             expect![[r#"
                 Error {
-                    context: "Rdp6BitmapStream",
+                    context: "<ironrdp_pdu::basic_output::bitmap::rdp6::BitmapStream as ironrdp_pdu::PduDecode>::decode",
                     kind: InvalidMessage {
                         field: "padding",
                         reason: "missing padding byte from zero-sized non-RLE bitmap data",

--- a/crates/ironrdp-pdu/src/macros.rs
+++ b/crates/ironrdp-pdu/src/macros.rs
@@ -2,6 +2,20 @@
 //!
 //! Some are exported and available to external crates
 
+/// Automatically returns the full pathname to a
+/// function. Taken from https://stackoverflow.com/a/40234666.
+#[macro_export]
+macro_rules! function {
+    () => {{
+        fn f() {}
+        fn type_name_of<T>(_: T) -> &'static str {
+            std::any::type_name::<T>()
+        }
+        let name = type_name_of(f);
+        name.strip_suffix("::f").unwrap()
+    }};
+}
+
 /// Creates a `PduError` with `NotEnoughBytes` kind
 ///
 /// Shorthand for
@@ -10,7 +24,7 @@
 /// ```
 /// and
 /// ```rust
-/// <ironrdp_pdu::PduError as ironrdp_pdu::PduErrorExt>::not_enough_bytes(Self::NAME, received, expected)
+/// <ironrdp_pdu::PduError as ironrdp_pdu::PduErrorExt>::not_enough_bytes($crate::function!(), received, expected)
 /// ```
 #[macro_export]
 macro_rules! not_enough_bytes_err {
@@ -18,7 +32,7 @@ macro_rules! not_enough_bytes_err {
         <$crate::PduError as $crate::PduErrorExt>::not_enough_bytes($context, $received, $expected)
     }};
     ( $received:expr , $expected:expr $(,)? ) => {{
-        not_enough_bytes_err!(Self::NAME, $received, $expected)
+        not_enough_bytes_err!($crate::function!(), $received, $expected)
     }};
 }
 
@@ -30,7 +44,7 @@ macro_rules! not_enough_bytes_err {
 /// ```
 /// and
 /// ```rust
-/// <ironrdp_pdu::PduError as ironrdp_pdu::PduErrorExt>::invalid_message(Self::NAME, field, reason)
+/// <ironrdp_pdu::PduError as ironrdp_pdu::PduErrorExt>::invalid_message($crate::function!(), field, reason)
 /// ```
 #[macro_export]
 macro_rules! invalid_message_err {
@@ -38,7 +52,7 @@ macro_rules! invalid_message_err {
         <$crate::PduError as $crate::PduErrorExt>::invalid_message($context, $field, $reason)
     }};
     ( $field:expr , $reason:expr $(,)? ) => {{
-        invalid_message_err!(Self::NAME, $field, $reason)
+        invalid_message_err!($crate::function!(), $field, $reason)
     }};
 }
 
@@ -50,7 +64,7 @@ macro_rules! invalid_message_err {
 /// ```
 /// and
 /// ```rust
-/// <ironrdp_pdu::PduError as ironrdp_pdu::PduErrorExt>::unexpected_message_type(Self::NAME, got)
+/// <ironrdp_pdu::PduError as ironrdp_pdu::PduErrorExt>::unexpected_message_type($crate::function!(), got)
 /// ```
 #[macro_export]
 macro_rules! unexpected_message_type_err {
@@ -58,7 +72,7 @@ macro_rules! unexpected_message_type_err {
         <$crate::PduError as $crate::PduErrorExt>::unexpected_message_type($context, $got)
     }};
     ( $got:expr $(,)? ) => {{
-        unexpected_message_type_err!(Self::NAME, $got)
+        unexpected_message_type_err!($crate::function!(), $got)
     }};
 }
 
@@ -70,7 +84,7 @@ macro_rules! unexpected_message_type_err {
 /// ```
 /// and
 /// ```rust
-/// <ironrdp_pdu::PduError as ironrdp_pdu::PduErrorExt>::unsupported_version(Self::NAME, got)
+/// <ironrdp_pdu::PduError as ironrdp_pdu::PduErrorExt>::unsupported_version($crate::function!(), got)
 /// ```
 #[macro_export]
 macro_rules! unsupported_version_err {
@@ -78,7 +92,7 @@ macro_rules! unsupported_version_err {
         <$crate::PduError as $crate::PduErrorExt>::unsupported_version($context, $got)
     }};
     ( $got:expr $(,)? ) => {{
-        unsupported_version_err!(Self::NAME, $got)
+        unsupported_version_err!($crate::function!(), $got)
     }};
 }
 
@@ -89,7 +103,7 @@ macro_rules! unsupported_version_err {
 /// ```
 /// and
 /// ```rust
-/// <ironrdp_pdu::PduError as ironrdp_pdu::PduErrorExt>::unsupported_pdu(Self::NAME, name, value)
+/// <ironrdp_pdu::PduError as ironrdp_pdu::PduErrorExt>::unsupported_pdu($crate::function!(), name, value)
 /// ```
 #[macro_export]
 macro_rules! unsupported_pdu_err {
@@ -97,7 +111,7 @@ macro_rules! unsupported_pdu_err {
         <$crate::PduError as $crate::PduErrorExt>::unsupported_pdu($context, $name, $value)
     }};
     ( $name:expr, $value:expr $(,)? ) => {{
-        unsupported_pdu_err!(Self::NAME, $name, $value)
+        unsupported_pdu_err!($crate::function!(), $name, $value)
     }};
 }
 
@@ -109,7 +123,7 @@ macro_rules! unsupported_pdu_err {
 /// ```
 /// and
 /// ```rust
-/// <ironrdp_pdu::PduError as ironrdp_pdu::PduErrorExt>::other(Self::NAME, description)
+/// <ironrdp_pdu::PduError as ironrdp_pdu::PduErrorExt>::other($crate::function!(), description)
 /// ```
 #[macro_export]
 macro_rules! other_err {
@@ -117,7 +131,7 @@ macro_rules! other_err {
         <$crate::PduError as $crate::PduErrorExt>::other($context, $description)
     }};
     ( $description:expr $(,)? ) => {{
-        other_err!(Self::NAME, $description)
+        other_err!($crate::function!(), $description)
     }};
 }
 
@@ -129,7 +143,7 @@ macro_rules! other_err {
 /// ```
 /// and
 /// ```rust
-/// <ironrdp_pdu::PduError as ironrdp_pdu::PduErrorExt>::custom(Self::NAME, source)
+/// <ironrdp_pdu::PduError as ironrdp_pdu::PduErrorExt>::custom($crate::function!(), source)
 /// ```
 #[macro_export]
 macro_rules! custom_err {
@@ -137,7 +151,7 @@ macro_rules! custom_err {
         <$crate::PduError as $crate::PduErrorExt>::custom($context, $source)
     }};
     ( $source:expr $(,)? ) => {{
-        custom_err!(Self::NAME, $source)
+        custom_err!($crate::function!(), $source)
     }};
 }
 
@@ -151,14 +165,14 @@ macro_rules! ensure_size {
         }
     }};
     (in: $buf:ident, size: $expected:expr) => {{
-        $crate::ensure_size!(ctx: Self::NAME, in: $buf, size: $expected)
+        $crate::ensure_size!(ctx: $crate::function!(), in: $buf, size: $expected)
     }};
 }
 
 #[macro_export]
 macro_rules! ensure_fixed_part_size {
     (in: $buf:ident) => {{
-        $crate::ensure_size!(ctx: Self::NAME, in: $buf, size: Self::FIXED_PART_SIZE)
+        $crate::ensure_size!(ctx: $crate::function!(), in: $buf, size: Self::FIXED_PART_SIZE)
     }};
 }
 
@@ -170,7 +184,7 @@ macro_rules! cast_length {
         })
     }};
     ($field:expr, $len:expr) => {{
-        $crate::cast_length!(<Self as $crate::Pdu>::NAME, $field, $len)
+        $crate::cast_length!($crate::function!(), $field, $len)
     }};
 }
 
@@ -187,7 +201,7 @@ macro_rules! cast_int {
         })
     }};
     ($field:expr, $len:expr) => {{
-        $crate::cast_int!(Self::NAME, $field, $len)
+        $crate::cast_int!($crate::function!(), $field, $len)
     }};
 }
 

--- a/crates/ironrdp-rdpdr/src/pdu/efs.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/efs.rs
@@ -345,7 +345,6 @@ pub struct CapabilityMessage {
 }
 
 impl CapabilityMessage {
-    const NAME: &str = "CAPABILITY_SET";
     /// Creates a new [`GENERAL_CAPS_SET`].
     ///
     /// `special_type_device_cap`: A 32-bit unsigned integer that
@@ -425,7 +424,6 @@ struct CapabilityHeader {
 }
 
 impl CapabilityHeader {
-    const NAME: &str = "CAPABILITY_HEADER";
     const SIZE: usize = size_of::<u16>() * 2 + size_of::<u32>();
 
     fn new_general() -> Self {
@@ -593,7 +591,6 @@ struct GeneralCapabilitySet {
 }
 
 impl GeneralCapabilitySet {
-    const NAME: &str = "GENERAL_CAPS_SET";
     #[allow(clippy::manual_bits)]
     const SIZE: usize = size_of::<u32>() * 8 + size_of::<u16>() * 2;
 
@@ -1338,7 +1335,6 @@ pub struct DeviceIoResponse {
 }
 
 impl DeviceIoResponse {
-    const NAME: &str = "DR_DEVICE_IOCOMPLETION";
     const FIXED_PART_SIZE: usize = size_of::<u32>() * 3; // DeviceId, CompletionId, IoStatus
 
     pub fn new(device_io_request: DeviceIoRequest, io_status: NtStatus) -> Self {
@@ -1916,8 +1912,6 @@ pub enum FileInformationClass {
 }
 
 impl FileInformationClass {
-    const NAME: &str = "FileInformationClass";
-
     pub fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
         ensure_size!(in: dst, size: self.size());
         match self {
@@ -2077,8 +2071,6 @@ pub struct FileBasicInformation {
 }
 
 impl FileBasicInformation {
-    const NAME: &str = "FileBasicInformation";
-
     fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
         ensure_size!(ctx: "FileBasicInformation", in: src, size: Self::size());
         let creation_time = src.read_i64();
@@ -2131,8 +2123,6 @@ pub struct FileStandardInformation {
 }
 
 impl FileStandardInformation {
-    const NAME: &str = "FileStandardInformation";
-
     fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
         ensure_size!(in: dst, size: Self::size());
         dst.write_i64(self.allocation_size);
@@ -2190,8 +2180,6 @@ pub struct FileAttributeTagInformation {
 }
 
 impl FileAttributeTagInformation {
-    const NAME: &str = "FileAttributeTagInformation";
-
     fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
         ensure_size!(in: dst, size: Self::size());
         dst.write_u32(self.file_attributes.bits());
@@ -2228,8 +2216,6 @@ pub struct FileBothDirectoryInformation {
 }
 
 impl FileBothDirectoryInformation {
-    const NAME: &str = "FileBothDirectoryInformation";
-
     pub fn new(
         creation_time: i64,
         last_access_time: i64,
@@ -2320,8 +2306,6 @@ pub struct FileFullDirectoryInformation {
 }
 
 impl FileFullDirectoryInformation {
-    const NAME: &str = "FileFullDirectoryInformation";
-
     pub fn new(
         creation_time: i64,
         last_access_time: i64,
@@ -2396,8 +2380,6 @@ pub struct FileNamesInformation {
 }
 
 impl FileNamesInformation {
-    const NAME: &str = "FileNamesInformation";
-
     pub fn new(file_name: String) -> Self {
         // Default field values taken from
         // https://github.com/FreeRDP/FreeRDP/blob/dfa231c0a55b005af775b833f92f6bcd30363d77/channels/drive/client/drive_file.c#L912
@@ -2447,8 +2429,6 @@ pub struct FileDirectoryInformation {
 }
 
 impl FileDirectoryInformation {
-    const NAME: &str = "FileDirectoryInformation";
-
     pub fn new(
         creation_time: i64,
         last_access_time: i64,
@@ -2568,7 +2548,6 @@ pub struct ServerDriveQueryDirectoryRequest {
 }
 
 impl ServerDriveQueryDirectoryRequest {
-    const NAME: &str = "DR_DRIVE_QUERY_DIRECTORY_REQ";
     const FIXED_PART_SIZE: usize = 4 /* FsInformationClass */ + 1 /* InitialQuery */ + 4 /* PathLength */ + 23 /* Padding */;
 
     fn decode(device_io_request: DeviceIoRequest, src: &mut ReadCursor<'_>) -> PduResult<Self> {
@@ -2618,7 +2597,6 @@ pub struct ServerDriveNotifyChangeDirectoryRequest {
 }
 
 impl ServerDriveNotifyChangeDirectoryRequest {
-    const NAME: &str = "DR_DRIVE_NOTIFY_CHANGE_DIRECTORY_REQ";
     const FIXED_PART_SIZE: usize = 1 /* WatchTree */ + 4 /* CompletionFilter */ + 27 /* Padding */;
 
     fn decode(device_io_request: DeviceIoRequest, src: &mut ReadCursor<'_>) -> PduResult<Self> {
@@ -2697,7 +2675,6 @@ pub struct ServerDriveQueryVolumeInformationRequest {
 }
 
 impl ServerDriveQueryVolumeInformationRequest {
-    const NAME: &str = "DR_DRIVE_QUERY_VOLUME_INFORMATION_REQ";
     const FIXED_PART_SIZE: usize = 4 /* FsInformationClass */ + 4 /* Length */ + 24 /* Padding */;
 
     pub fn decode(dev_io_req: DeviceIoRequest, src: &mut ReadCursor<'_>) -> PduResult<Self> {
@@ -2785,8 +2762,6 @@ pub enum FileSystemInformationClass {
 }
 
 impl FileSystemInformationClass {
-    const NAME: &str = "FileSystemInformationClass";
-
     fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
         ensure_size!(in: dst, size: self.size());
         match self {
@@ -2853,8 +2828,6 @@ pub struct FileFsVolumeInformation {
 }
 
 impl FileFsVolumeInformation {
-    const NAME: &str = "FileFsVolumeInformation";
-
     pub fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
         ensure_size!(in: dst, size: self.size());
         dst.write_i64(self.volume_creation_time);
@@ -2890,8 +2863,6 @@ pub struct FileFsSizeInformation {
 }
 
 impl FileFsSizeInformation {
-    const NAME: &str = "FileFsSizeInformation";
-
     pub fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
         ensure_size!(in: dst, size: self.size());
         dst.write_i64(self.total_alloc_units);
@@ -2920,8 +2891,6 @@ pub struct FileFsAttributeInformation {
 }
 
 impl FileFsAttributeInformation {
-    const NAME: &str = "FileFsAttributeInformation";
-
     pub fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
         ensure_size!(in: dst, size: self.size());
         dst.write_u32(self.file_system_attributes.bits());
@@ -2956,8 +2925,6 @@ pub struct FileFsFullSizeInformation {
 }
 
 impl FileFsFullSizeInformation {
-    const NAME: &str = "FileFsFullSizeInformation";
-
     pub fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
         ensure_size!(in: dst, size: Self::size());
         dst.write_i64(self.total_alloc_units);
@@ -2987,8 +2954,6 @@ pub struct FileFsDeviceInformation {
 }
 
 impl FileFsDeviceInformation {
-    const NAME: &str = "FileFsDeviceInformation";
-
     pub fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
         ensure_size!(in: dst, size: Self::size());
         dst.write_u32(self.device_type);
@@ -3123,7 +3088,6 @@ pub struct DeviceReadRequest {
 }
 
 impl DeviceReadRequest {
-    const NAME: &str = "DR_READ_REQ";
     const FIXED_PART_SIZE: usize = 4 /* Length */ + 8 /* Offset */ + 20 /* Padding */;
 
     pub fn decode(dev_io_req: DeviceIoRequest, src: &mut ReadCursor<'_>) -> PduResult<Self> {
@@ -3190,7 +3154,6 @@ pub struct DeviceWriteRequest {
 }
 
 impl DeviceWriteRequest {
-    const NAME: &str = "DR_WRITE_REQ";
     const FIXED_PART_SIZE: usize = 4 /* Length */ + 8 /* Offset */ + 20 /* Padding */;
 
     pub fn decode(dev_io_req: DeviceIoRequest, src: &mut ReadCursor<'_>) -> PduResult<Self> {
@@ -3262,7 +3225,6 @@ pub struct ServerDriveSetInformationRequest {
 }
 
 impl ServerDriveSetInformationRequest {
-    const NAME: &str = "DR_DRIVE_SET_INFORMATION_REQ";
     const FIXED_PART_SIZE: usize = 4 /* FileInformationClass */ + 4 /* Length */ + 24 /* Padding */;
 
     fn decode(dev_io_req: DeviceIoRequest, src: &mut ReadCursor<'_>) -> PduResult<Self> {
@@ -3307,7 +3269,6 @@ pub struct FileEndOfFileInformation {
 }
 
 impl FileEndOfFileInformation {
-    const NAME: &str = "FileEndOfFileInformation";
     const FIXED_PART_SIZE: usize = 8; // EndOfFile
 
     fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
@@ -3330,7 +3291,6 @@ pub struct FileDispositionInformation {
 }
 
 impl FileDispositionInformation {
-    const NAME: &str = "FileDispositionInformation";
     const FIXED_PART_SIZE: usize = 1; // DeletePending
 
     fn decode(src: &mut ReadCursor<'_>, length: usize) -> PduResult<Self> {
@@ -3360,7 +3320,6 @@ pub struct FileRenameInformation {
 }
 
 impl FileRenameInformation {
-    const NAME: &str = "FileRenameInformation";
     const FIXED_PART_SIZE: usize = 1 /* ReplaceIfExists */ + 1 /* RootDirectory */ + 4 /* FileNameLength */;
 
     fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
@@ -3392,7 +3351,6 @@ pub struct FileAllocationInformation {
 }
 
 impl FileAllocationInformation {
-    const NAME: &str = "FileAllocationInformation";
     const FIXED_PART_SIZE: usize = 8; // AllocationSize
 
     fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
@@ -3452,8 +3410,6 @@ pub struct ServerDriveLockControlRequest {
 }
 
 impl ServerDriveLockControlRequest {
-    const NAME: &str = "DR_DRIVE_LOCK_REQ";
-
     fn decode(dev_io_req: DeviceIoRequest, src: &mut ReadCursor<'_>) -> PduResult<Self> {
         // It's not quite clear why this is done this way, but it's what FreeRDP does:
         // https://github.com/FreeRDP/FreeRDP/blob/dfa231c0a55b005af775b833f92f6bcd30363d77/channels/drive/client/drive_main.c#L600

--- a/crates/ironrdp-rdpdr/src/pdu/esc.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/esc.rs
@@ -86,7 +86,6 @@ pub struct ScardContext {
 }
 
 impl ScardContext {
-    const NAME: &'static str = "REDIR_SCARDCONTEXT";
     /// See [`ScardContext::value`]
     const VALUE_LENGTH: u32 = 4;
 
@@ -551,8 +550,6 @@ pub struct EstablishContextCall {
 }
 
 impl EstablishContextCall {
-    const NAME: &'static str = "EstablishContext_Call";
-
     pub fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
         Ok(rpce::Pdu::<Self>::decode(src)?.into_inner())
     }
@@ -651,8 +648,6 @@ pub struct ListReadersCall {
 }
 
 impl ListReadersCall {
-    const NAME: &'static str = "ListReaders_Call";
-
     pub fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
         Ok(rpce::Pdu::<Self>::decode(src)?.into_inner())
     }
@@ -768,8 +763,6 @@ pub struct GetStatusChangeCall {
 }
 
 impl GetStatusChangeCall {
-    const NAME: &'static str = "GetStatusChangeW_Call";
-
     pub fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
         Ok(rpce::Pdu::<Self>::decode(src)?.into_inner())
     }
@@ -823,7 +816,6 @@ pub struct ReaderStateCommonCall {
 }
 
 impl ReaderStateCommonCall {
-    const NAME: &'static str = "ReaderState_Common_Call";
     const FIXED_PART_SIZE: usize = size_of::<u32>() * 3 /* dwCurrentState, dwEventState, cbAtr */ + 36 /* rgbAtr */;
 
     fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
@@ -954,10 +946,6 @@ pub struct ConnectCommon {
     pub preferred_protocols: CardProtocol,
 }
 
-impl ConnectCommon {
-    const NAME: &'static str = "Connect_Common";
-}
-
 impl ndr::Decode for ConnectCommon {
     fn decode_ptr(src: &mut ReadCursor<'_>, index: &mut u32) -> PduResult<Self>
     where
@@ -1007,7 +995,6 @@ pub struct ScardHandle {
 }
 
 impl ScardHandle {
-    const NAME: &'static str = "REDIR_SCARDHANDLE";
     /// See [`ScardHandle::value`]
     const VALUE_LENGTH: u32 = 4;
 
@@ -1128,8 +1115,6 @@ pub struct HCardAndDispositionCall {
 }
 
 impl HCardAndDispositionCall {
-    const NAME: &'static str = "HCardAndDisposition_Call";
-
     pub fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
         Ok(rpce::Pdu::<Self>::decode(src)?.into_inner())
     }
@@ -1161,8 +1146,6 @@ pub struct TransmitCall {
 }
 
 impl TransmitCall {
-    const NAME: &'static str = "Transmit_Call";
-
     pub fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
         Ok(rpce::Pdu::<Self>::decode(src)?.into_inner())
     }
@@ -1218,10 +1201,6 @@ pub struct SCardIORequest {
     pub protocol: CardProtocol,
     pub extra_bytes_length: u32,
     pub extra_bytes: Vec<u8>,
-}
-
-impl SCardIORequest {
-    const NAME: &'static str = "SCardIO_Request";
 }
 
 impl ndr::Decode for SCardIORequest {
@@ -1343,8 +1322,6 @@ pub struct StatusCall {
 }
 
 impl StatusCall {
-    const NAME: &'static str = "Status_Call";
-
     pub fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
         Ok(rpce::Pdu::<Self>::decode(src)?.into_inner())
     }
@@ -1596,10 +1573,6 @@ pub struct ReadCacheCommon {
     pub data_len: u32,
 }
 
-impl ReadCacheCommon {
-    const NAME: &'static str = "ReadCache_Common";
-}
-
 impl ndr::Decode for ReadCacheCommon {
     fn decode_ptr(src: &mut ReadCursor<'_>, index: &mut u32) -> PduResult<Self>
     where
@@ -1705,10 +1678,6 @@ pub struct WriteCacheCommon {
     pub card_uuid: Vec<u8>,
     pub freshness_counter: u32,
     pub data: Vec<u8>,
-}
-
-impl WriteCacheCommon {
-    const NAME: &'static str = "WriteCache_Common";
 }
 
 impl ndr::Decode for WriteCacheCommon {

--- a/crates/ironrdp-rdpdr/src/pdu/esc/rpce.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/esc/rpce.rs
@@ -184,8 +184,6 @@ impl Default for StreamHeader {
 }
 
 impl StreamHeader {
-    const NAME: &'static str = "RpceStreamHeader";
-
     fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
         ensure_size!(in: dst, size: Self::size());
         dst.write_u8(self.version);
@@ -257,8 +255,6 @@ struct TypeHeader {
 }
 
 impl TypeHeader {
-    const NAME: &'static str = "RpceTypeHeader";
-
     fn new(object_buffer_length: u32) -> Self {
         Self {
             object_buffer_length,

--- a/crates/ironrdp-rdpdr/src/pdu/mod.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/mod.rs
@@ -306,7 +306,6 @@ pub struct SharedHeader {
 }
 
 impl SharedHeader {
-    const NAME: &str = "RDPDR_HEADER";
     const SIZE: usize = size_of::<u16>() * 2;
 
     fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {

--- a/crates/ironrdp-testsuite-core/tests/pcb.rs
+++ b/crates/ironrdp-testsuite-core/tests/pcb.rs
@@ -99,7 +99,8 @@ fn null_size() {
         .err()
         .unwrap();
 
-    expect![[r#"
+    expect![
+        [r#"
             Error {
                 context: "PreconnectionBlob",
                 kind: InvalidMessage {
@@ -108,7 +109,8 @@ fn null_size() {
                 },
                 source: None,
             }
-        "#]]
+        "#]
+    ]
     .assert_debug_eq(&e);
 }
 

--- a/crates/ironrdp-testsuite-core/tests/pcb.rs
+++ b/crates/ironrdp-testsuite-core/tests/pcb.rs
@@ -99,8 +99,7 @@ fn null_size() {
         .err()
         .unwrap();
 
-    expect![
-        [r#"
+    expect![[r#"
             Error {
                 context: "PreconnectionBlob",
                 kind: InvalidMessage {
@@ -109,8 +108,7 @@ fn null_size() {
                 },
                 source: None,
             }
-        "#]
-    ]
+        "#]]
     .assert_debug_eq(&e);
 }
 
@@ -129,7 +127,7 @@ fn truncated() {
 
     expect![[r#"
             Error {
-                context: "PreconnectionBlob",
+                context: "<ironrdp_pdu::pcb::PreconnectionBlob as ironrdp_pdu::PduDecode>::decode",
                 kind: NotEnoughBytes {
                     received: 0,
                     expected: 239,


### PR DESCRIPTION
@zmb3 suggested we add this for Teleport to avoid copy-paste errors wherever we're using these macros, however it occurred to me that this might best fit as a more general solution throughout IronRDP.

I tested this by applying the following patch
<details>

```patch
diff --git a/crates/ironrdp-cliprdr/src/pdu/capabilities.rs b/crates/ironrdp-cliprdr/src/pdu/capabilities.rs
index 508b4e5..34381af 100644
--- a/crates/ironrdp-cliprdr/src/pdu/capabilities.rs
+++ b/crates/ironrdp-cliprdr/src/pdu/capabilities.rs
@@ -166,10 +166,10 @@ impl<'de> PduDecode<'de> for CapabilitySet {
         let _length = src.read_u16();
 
         match caps_type {
-            Self::CAPSTYPE_GENERAL => {
-                let general = GeneralCapabilitySet::decode(src)?;
-                Ok(Self::General(general))
-            }
+            // Self::CAPSTYPE_GENERAL => {
+            //     let general = GeneralCapabilitySet::decode(src)?;
+            //     Ok(Self::General(general))
+            // }
             _ => Err(invalid_message_err!(
                 "capabilitySetType",
                 "invalid clipboard capability set type"
```
</details>

and running a session (via teleport), which results in a log message like

```log
SessionError(Error { context: "invalid payload", kind: Pdu(Error { context: "<ironrdp_cliprdr::pdu::capabilities::CapabilitySet as ironrdp_pdu::PduDecode>::decode", kind: InvalidMessage { field: "capabilitySetType", reason: "invalid clipboard capability set type" }, source: None }), source: None })
```

the key piece being `context: "<ironrdp_cliprdr::pdu::capabilities::CapabilitySet as ironrdp_pdu::PduDecode>::decode"`