### PR TITLE
fix(connector): better security protocol selection

### DIFF
--- a/crates/ironrdp-async/src/connector.rs
+++ b/crates/ironrdp-async/src/connector.rs
@@ -120,12 +120,36 @@ where
 {
     assert!(connector.should_perform_credssp());
 
-    let mut credssp_sequence = CredsspSequence::new(connector, server_name, server_public_key, kerberos_config)?;
+    let (mut sequence, mut ts_request) =
+        CredsspSequence::init(connector, server_name, server_public_key, kerberos_config)?;
 
-    while !credssp_sequence.is_done() {
+    loop {
+        let client_state = {
+            let mut generator = sequence.process_ts_request(ts_request);
+
+            if let Some(network_client_ref) = network_client.as_deref_mut() {
+                trace!("resolving network");
+                resolve_generator(&mut generator, network_client_ref).await?
+            } else {
+                generator
+                    .resolve_to_result()
+                    .map_err(|e| custom_err!("resolve without network client", e))?
+            }
+        }; // drop generator
+
         buf.clear();
+        let written = sequence.handle_process_result(client_state, buf)?;
 
-        if let Some(next_pdu_hint) = credssp_sequence.next_pdu_hint() {
+        if let Some(response_len) = written.size() {
+            let response = &buf[..response_len];
+            trace!(response_len, "Send response");
+            framed
+                .write_all(response)
+                .await
+                .map_err(|e| ironrdp_connector::custom_err!("write all", e))?;
+        }
+
+        if let Some(next_pdu_hint) = sequence.next_pdu_hint() {
             debug!(
                 connector.state = connector.state.name(),
                 hint = ?next_pdu_hint,
@@ -139,31 +163,12 @@ where
 
             trace!(length = pdu.len(), "PDU received");
 
-            credssp_sequence.read_request_from_server(&pdu)?;
-        }
-
-        let client_state = {
-            let mut generator = credssp_sequence.process();
-
-            if let Some(network_client_ref) = network_client.as_deref_mut() {
-                trace!("resolving network");
-                resolve_generator(&mut generator, network_client_ref).await?
-            } else {
-                generator
-                    .resolve_to_result()
-                    .map_err(|e| custom_err!("resolve without network client", e))?
+            match sequence.decode_server_message(&pdu)? {
+                Some(next_request) => ts_request = next_request,
+                None => break,
             }
-        }; // drop generator
-
-        let written = credssp_sequence.handle_process_result(client_state, buf)?;
-
-        if let Some(response_len) = written.size() {
-            let response = &buf[..response_len];
-            trace!(response_len, "Send response");
-            framed
-                .write_all(response)
-                .await
-                .map_err(|e| ironrdp_connector::custom_err!("write all", e))?;
+        } else {
+            break;
         }
     }
 

--- a/crates/ironrdp-blocking/src/connector.rs
+++ b/crates/ironrdp-blocking/src/connector.rs
@@ -145,23 +145,24 @@ where
                 .map_err(|e| ironrdp_connector::custom_err!("write all", e))?;
         }
 
-        if let Some(next_pdu_hint) = sequence.next_pdu_hint() {
-            debug!(
-                connector.state = connector.state.name(),
-                hint = ?next_pdu_hint,
-                "Wait for PDU"
-            );
+        let Some(next_pdu_hint) = sequence.next_pdu_hint() else {
+            break;
+        };
 
-            let pdu = framed
-                .read_by_hint(next_pdu_hint)
-                .map_err(|e| ironrdp_connector::custom_err!("read frame by hint", e))?;
+        debug!(
+            connector.state = connector.state.name(),
+            hint = ?next_pdu_hint,
+            "Wait for PDU"
+        );
 
-            trace!(length = pdu.len(), "PDU received");
+        let pdu = framed
+            .read_by_hint(next_pdu_hint)
+            .map_err(|e| ironrdp_connector::custom_err!("read frame by hint", e))?;
 
-            match sequence.decode_server_message(&pdu)? {
-                Some(next_request) => ts_request = next_request,
-                None => break,
-            }
+        trace!(length = pdu.len(), "PDU received");
+
+        if let Some(next_request) = sequence.decode_server_message(&pdu)? {
+            ts_request = next_request;
         } else {
             break;
         }

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -5,9 +5,8 @@ use std::str::FromStr;
 use anyhow::Context as _;
 use clap::clap_derive::ValueEnum;
 use clap::{crate_name, Parser};
-use ironrdp::connector::Credentials;
+use ironrdp::connector::{self, Credentials};
 use ironrdp::pdu::rdp::capability_sets::MajorPlatformType;
-use ironrdp::{connector, pdu};
 use tap::prelude::*;
 
 const DEFAULT_WIDTH: u16 = 1920;
@@ -18,23 +17,6 @@ pub struct Config {
     pub log_file: String,
     pub destination: Destination,
     pub connector: connector::Config,
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
-enum SecurityProtocol {
-    Ssl,
-    Hybrid,
-    HybridEx,
-}
-
-impl SecurityProtocol {
-    fn parse(security_protocol: SecurityProtocol) -> pdu::nego::SecurityProtocol {
-        match security_protocol {
-            SecurityProtocol::Ssl => pdu::nego::SecurityProtocol::SSL,
-            SecurityProtocol::Hybrid => pdu::nego::SecurityProtocol::HYBRID,
-            SecurityProtocol::HybridEx => pdu::nego::SecurityProtocol::HYBRID_EX,
-        }
-    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
@@ -168,10 +150,6 @@ struct Args {
     #[clap(short, long, value_parser)]
     password: Option<String>,
 
-    /// Specify the security protocols to use
-    #[clap(long, value_enum, value_parser, default_value_t = SecurityProtocol::Hybrid)]
-    security_protocol: SecurityProtocol,
-
     /// The keyboard type
     #[clap(long, value_enum, value_parser, default_value_t = KeyboardType::IbmEnhanced)]
     keyboard_type: KeyboardType,
@@ -222,10 +200,25 @@ struct Args {
     #[clap(long, value_parser = parse_hex, default_value_t = 0)]
     capabilities: u32,
 
-    /// Automatically logon to the server by passing the INFO_AUTOLOGON flag. This flag is
-    /// ignored if CredSSP is used (SecurityProtocol::Hybrid | SecurityProtocol::HybridEx).
+    /// Automatically logon to the server by passing the INFO_AUTOLOGON flag
+    ///
+    /// This flag is ignored if CredSSP authentication is used.
+    /// You can use `--no-credssp` to ensure it’s not.
     #[clap(long)]
     autologon: bool,
+
+    /// Disable TLS + Graphical login (legacy authentication method)
+    ///
+    /// Disabling this in order to enforce usage of CredSSP (NLA) is recommended.
+    #[clap(long)]
+    no_winlogon: bool,
+
+    /// Disable TLS + Network Level Authentication (NLA) using CredSSP
+    ///
+    /// NLA is used to authenticates RDP clients and servers before sending credentials over the network.
+    /// It’s not recommended to disable this.
+    #[clap(long)]
+    no_credssp: bool,
 }
 
 impl Config {
@@ -284,7 +277,8 @@ impl Config {
         let connector = connector::Config {
             credentials: Credentials::UsernamePassword { username, password },
             domain: args.domain,
-            security_protocol: SecurityProtocol::parse(args.security_protocol),
+            enable_winlogon: !args.no_winlogon,
+            enable_credssp: !args.no_credssp,
             keyboard_type: KeyboardType::parse(args.keyboard_type),
             keyboard_subtype: args.keyboard_subtype,
             keyboard_functional_keys_count: args.keyboard_functional_keys_count,

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -211,13 +211,13 @@ struct Args {
     ///
     /// Disabling this in order to enforce usage of CredSSP (NLA) is recommended.
     #[clap(long)]
-    no_winlogon: bool,
+    no_tls: bool,
 
     /// Disable TLS + Network Level Authentication (NLA) using CredSSP
     ///
     /// NLA is used to authenticates RDP clients and servers before sending credentials over the network.
     /// It’s not recommended to disable this.
-    #[clap(long)]
+    #[clap(long, alias = "no-nla")]
     no_credssp: bool,
 }
 
@@ -277,7 +277,7 @@ impl Config {
         let connector = connector::Config {
             credentials: Credentials::UsernamePassword { username, password },
             domain: args.domain,
-            enable_winlogon: !args.no_winlogon,
+            enable_tls: !args.no_tls,
             enable_credssp: !args.no_credssp,
             keyboard_type: KeyboardType::parse(args.keyboard_type),
             keyboard_subtype: args.keyboard_subtype,

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -227,7 +227,7 @@ impl Sequence for ClientConnector {
 
                 let mut security_protocol = nego::SecurityProtocol::empty();
 
-                if self.config.enable_winlogon {
+                if self.config.enable_tls {
                     security_protocol.insert(nego::SecurityProtocol::SSL);
                 }
 

--- a/crates/ironrdp-connector/src/lib.rs
+++ b/crates/ironrdp-connector/src/lib.rs
@@ -83,23 +83,48 @@ pub struct Config {
     /// TLS + Graphical login (legacy)
     ///
     /// Also called SSL or TLS security protocol.
+    /// The PROTOCOL_SSL flag will be set.
     ///
     /// When this security protocol is negotiated, the RDP server will show a graphical login screen.
     /// For Windows, it means that the login subsystem (winlogon.exe) and the GDI graphics subsystem
-    /// will be initiated and the user will authenticate himself using the GUI, as if using the
-    /// physical machine directly.
+    /// will be initiated and the user will authenticate himself using LogonUI.exe, as if
+    /// using the physical machine directly.
     ///
-    /// The PROTOCOL_SSL flag will be set.
-    /// By disabling this flag, it’s possible to effectively enforce usage of NLA on client side.
-    pub enable_winlogon: bool,
+    /// This security protocol is being phased out because it’s not great security-wise.
+    /// Indeed, the whole RDP connection sequence will be performed, allowing anyone to effectively
+    /// open a RDP session session with all static channels joined and active (e.g.: I/O, clipboard,
+    /// sound, drive redirection, etc). This exposes a wide attack surface with many impacts on both
+    /// the client and the server.
+    ///
+    /// - Man-in-the-middle (MITM)
+    /// - Server-side takeover
+    /// - Client-side file stealing
+    /// - Client-side takeover
+    ///
+    /// Recommended reads on this topic:
+    ///
+    /// - <https://www.gosecure.net/blog/2018/12/19/rdp-man-in-the-middle-smile-youre-on-camera/>
+    /// - <https://www.gosecure.net/divi_overlay/mitigating-the-risks-of-remote-desktop-protocols/>
+    /// - <https://gosecure.github.io/presentations/2021-08-05_blackhat-usa/BlackHat-USA-21-Arsenal-PyRDP-OlivierBilodeau.pdf>
+    /// - <https://gosecure.github.io/presentations/2022-10-06_sector/OlivierBilodeau-Purple_RDP.pdf>
+    ///
+    /// By setting this option to `false`, it’s possible to effectively enforce usage of NLA on client side.
+    pub enable_tls: bool,
     /// TLS + Network Level Authentication (NLA) using CredSSP
+    ///
+    /// The PROTOCOL_HYBRID and PROTOCOL_HYBRID_EX flags will be set.
+    ///
+    /// NLA is allowing authentication to be performed before session establishement.
     ///
     /// This option includes the extended CredSSP early user authorization result PDU.
     /// This PDU is used by the server to deny access before any credentials (except for the username)
     /// have been submitted, e.g.: typically if the user does not have the necessary remote access
     /// privileges.
     ///
-    /// The PROTOCOL_HYBRID and PROTOCOL_HYBRID_EX flags will be set.
+    /// The attack surface is considerably reduced in comparison to the legacy "TLS" security protocol.
+    /// For this reason, it is recommended to set `enable_tls` to `false` when connecting to NLA-capable
+    /// computers.
+    #[doc(alias("enable_nla", "nla"))]
     pub enable_credssp: bool,
     pub credentials: Credentials,
     pub domain: Option<String>,

--- a/crates/ironrdp-connector/src/lib.rs
+++ b/crates/ironrdp-connector/src/lib.rs
@@ -78,6 +78,7 @@ impl Credentials {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Config {
+    /// The initial desktop size to request
     pub desktop_size: DesktopSize,
     /// TLS + Graphical login (legacy)
     ///
@@ -94,7 +95,7 @@ pub struct Config {
     /// TLS + Network Level Authentication (NLA) using CredSSP
     ///
     /// This option includes the extended CredSSP early user authorization result PDU.
-    /// This PDU used by the server to deny access before any credentials (except for the username)
+    /// This PDU is used by the server to deny access before any credentials (except for the username)
     /// have been submitted, e.g.: typically if the user does not have the necessary remote access
     /// privileges.
     ///
@@ -117,7 +118,7 @@ pub struct Config {
     pub dig_product_id: String,
     pub client_dir: String,
     pub platform: capability_sets::MajorPlatformType,
-    /// If true, the INFO_AUTOLOGON flag is set in the [`ironrdp_pdu::rdp::ClientInfoPdu`]
+    /// If true, the INFO_AUTOLOGON flag is set in the [`ClientInfoPdu`](ironrdp_pdu::rdp::ClientInfoPdu)
     pub autologon: bool,
 
     // FIXME(@CBenoit): these are client-only options, not part of the connector.

--- a/crates/ironrdp-pdu/src/macros.rs
+++ b/crates/ironrdp-pdu/src/macros.rs
@@ -2,10 +2,10 @@
 //!
 //! Some are exported and available to external crates
 
-/// Automatically returns the full pathname to a
-/// function. Taken from https://stackoverflow.com/a/40234666.
+/// Finds the name of the function in which this macro is expanded
 #[macro_export]
 macro_rules! function {
+    // Taken from https://stackoverflow.com/a/40234666
     () => {{
         fn f() {}
         fn type_name_of<T>(_: T) -> &'static str {

--- a/crates/ironrdp-pdu/src/nego.rs
+++ b/crates/ironrdp-pdu/src/nego.rs
@@ -1,5 +1,7 @@
 //! PDUs used during the Connection Initiation stage
 
+use core::fmt;
+
 use bitflags::bitflags;
 use tap::prelude::*;
 
@@ -10,21 +12,38 @@ use crate::x224::X224Pdu;
 use crate::{Pdu as _, PduError, PduErrorExt as _, PduResult};
 
 bitflags! {
-    /// A 32-bit, unsigned integer that contains flags indicating the supported
-    /// security protocols.
-    /// The client and server agree on it during the Connection Initiation phase.
+    /// [2.2.1.1.1] RDP Negotiation Request (RDP_NEG_REQ)
     ///
-    /// # MSDN
+    /// The RDP Negotiation Request structure is used by a client to advertise the security protocols which it supports.
+    /// The client and server agree on the protocol to use during the Connection Initiation phase.
     ///
-    /// * [RDP Negotiation Request (RDP_NEG_REQ)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/902b090b-9cb3-4efc-92bf-ee13373371e3)
+    /// [2.2.1.1.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/902b090b-9cb3-4efc-92bf-ee13373371e3
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct SecurityProtocol: u32 {
+        /// PROTOCOL_RDP, standard RDP security.
+        ///
+        /// Because this is equivalent to `SecurityProtocol::empty()`, this "flag" is always implied and can’t be unset.
         const RDP = 0x0000_0000;
+        /// PROTOCOL_SSL, TLS + login subsystem (winlogon.exe)
         const SSL = 0x0000_0001;
+        /// PROTOCOL_HYBRID, TLS + Credential Security Support Provider protocol (CredSSP)
         const HYBRID = 0x0000_0002;
+        /// PROTOCOL_RDSTLS, RDSTLS protocol
         const RDSTLS = 0x0000_0004;
+        /// PROTOCOL_HYBRID_EX, TLS + Credential Security Support Provider protocol (CredSSP) coupled with the Early User Authorization Result PDU
         const HYBRID_EX = 0x0000_0008;
+        /// PROTOCOL_RDSAAD, RDS-AAD-Auth Security
         const RDSAAD = 0x0000_0010;
+    }
+}
+
+impl fmt::Display for SecurityProtocol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if *self == Self::RDP {
+            write!(f, "STANDARD_RDP_SECURITY")
+        } else {
+            bitflags::parser::to_writer(self, f)
+        }
     }
 }
 
@@ -58,17 +77,32 @@ bitflags! {
     }
 }
 
-/// The type of the negotiation error. May be contained in ResponseData.
+/// A 32-bit, unsigned integer that specifies the negotiation failure code
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct FailureCode(u32);
 
 impl FailureCode {
+    /// The server requires that the client support Enhanced RDP Security (section 5.4)
+    /// with either TLS 1.0, 1.1 or 1.2 (section 5.4.5.1) or CredSSP (section 5.4.5.2).
+    /// If only CredSSP was requested then the server only supports TLS.
     pub const SSL_REQUIRED_BY_SERVER: Self = Self(1);
+    /// The server is configured to only use Standard RDP Security mechanisms (section
+    /// 5.3) and does not support any External Security Protocols (section 5.4.5).
     pub const SSL_NOT_ALLOWED_BY_SERVER: Self = Self(2);
+    /// The server does not possess a valid authentication certificate and cannot
+    /// initialize the External Security Protocol Provider (section 5.4.5).
     pub const SSL_CERT_NOT_ON_SERVER: Self = Self(3);
+    /// The list of requested security protocols is not consistent with the current
+    /// security protocol in effect. This error is only possible when the Direct
+    /// Approach (sections 5.4.2.2 and 1.3.1.2) is used and an External Security
+    /// Protocol (section 5.4.5) is already being used.
     pub const INCONSISTENT_FLAGS: Self = Self(4);
+    /// The server requires that the client support Enhanced RDP Security (section 5.4)
+    /// with CredSSP (section 5.4.5.2).
     pub const HYBRID_REQUIRED_BY_SERVER: Self = Self(5);
-    /// Used when the failure caused by ResponseFailure.
+    /// The server requires that the client support Enhanced RDP Security (section
+    /// 5.4) with TLS 1.0, 1.1 or 1.2 (section 5.4.5.1) and certificate-based client
+    /// authentication.
     pub const SSL_WITH_USER_AUTH_REQUIRED_BY_SERVER: Self = Self(6);
 }
 
@@ -81,6 +115,32 @@ impl From<u32> for FailureCode {
 impl From<FailureCode> for u32 {
     fn from(value: FailureCode) -> Self {
         value.0
+    }
+}
+
+impl fmt::Display for FailureCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::SSL_REQUIRED_BY_SERVER => {
+                write!(f, "enhanced RDP security required by server")
+            }
+            Self::SSL_NOT_ALLOWED_BY_SERVER => {
+                write!(f, "enhanced RDP security not allowed by server")
+            }
+            Self::SSL_CERT_NOT_ON_SERVER => {
+                write!(f, "no valid TLS authentication certificate on server")
+            }
+            Self::INCONSISTENT_FLAGS => {
+                write!(f, "inconsistent flags for security protocols")
+            }
+            Self::HYBRID_REQUIRED_BY_SERVER => {
+                write!(f, "CredSSP enhanced RDP security required by server")
+            }
+            Self::SSL_WITH_USER_AUTH_REQUIRED_BY_SERVER => {
+                write!(f, "TLS certificate-based client authentication required by server")
+            }
+            _ => write!(f, "unknown failure code: {}", self.0),
+        }
     }
 }
 
@@ -208,11 +268,20 @@ impl<'de> X224Pdu<'de> for ConnectionRequest {
             nego_data.write(dst)?;
         }
 
-        if self.protocol != SecurityProtocol::RDP {
-            dst.write_u8(u8::from(NegoMsgType::REQUEST));
-            dst.write_u8(self.flags.bits());
-            dst.write_u16(Self::RDP_NEG_REQ_SIZE);
-            dst.write_u32(self.protocol.bits());
+        // [MS-RDPBCGR] mentions the following payload as optional, but it appears that on recent
+        // versions of Windows, the server always expect to find this payload.
+        dst.write_u8(u8::from(NegoMsgType::REQUEST));
+        dst.write_u8(self.flags.bits());
+        dst.write_u16(Self::RDP_NEG_REQ_SIZE);
+        dst.write_u32(self.protocol.bits());
+
+        if self.flags.contains(RequestFlags::CORRELATION_INFO_PRESENT) {
+            // TODO(#111): support for RDP_NEG_CORRELATION_INFO
+            return Err(PduError::invalid_message(
+                Self::NAME,
+                "flags",
+                "CORRECTION_INFO_PRESENT flag is set, but not supported by IronRDP",
+            ));
         }
 
         Ok(())
@@ -273,14 +342,7 @@ impl<'de> X224Pdu<'de> for ConnectionRequest {
 
     fn tpdu_header_variable_part_size(&self) -> usize {
         let optional_nego_data_size = self.nego_data.as_ref().map(|data| data.size()).unwrap_or(0);
-
-        let rdp_neg_req_size = if self.protocol == SecurityProtocol::RDP {
-            0
-        } else {
-            usize::from(Self::RDP_NEG_REQ_SIZE)
-        };
-
-        optional_nego_data_size + rdp_neg_req_size
+        optional_nego_data_size + usize::from(Self::RDP_NEG_REQ_SIZE)
     }
 
     fn tpdu_user_data_size(&self) -> usize {

--- a/crates/ironrdp-pdu/src/rdp/suppress_output.rs
+++ b/crates/ironrdp-pdu/src/rdp/suppress_output.rs
@@ -34,7 +34,7 @@ impl AllowDisplayUpdatesType {
 /// restored. Server support for this PDU is indicated in the General Capability
 /// Set [2.2.7.1.1].
 ///
-/// [2.2.11.3.1] https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/0be71491-0b01-402c-947d-080706ccf91b
+/// [2.2.11.3.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/0be71491-0b01-402c-947d-080706ccf91b
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SuppressOutputPdu {
     pub desktop_rect: Option<InclusiveRectangle>,

--- a/crates/ironrdp-testsuite-core/src/core_data.rs
+++ b/crates/ironrdp-testsuite-core/src/core_data.rs
@@ -82,7 +82,7 @@ lazy_static! {
         data.optional_data.early_capability_flags = Some(ClientEarlyCapabilityFlags::SUPPORT_ERR_INFO_PDU);
         data.optional_data.dig_product_id = Some(String::from("69712-783-0357974-42714"));
         data.optional_data.connection_type = Some(ConnectionType::NotUsed);
-        data.optional_data.server_selected_protocol = Some(SecurityProtocol::RDP);
+        data.optional_data.server_selected_protocol = Some(SecurityProtocol::empty());
         data
     };
     pub static ref CLIENT_CORE_DATA_WITH_ALL_OPTIONAL_FIELDS: ClientCoreData = {
@@ -163,14 +163,14 @@ lazy_static! {
     pub static ref SERVER_CORE_DATA_TO_FLAGS: ServerCoreData = ServerCoreData {
         version: RdpVersion::V5_PLUS,
         optional_data: ServerCoreOptionalData {
-            client_requested_protocols: Some(SecurityProtocol::RDP),
+            client_requested_protocols: Some(SecurityProtocol::empty()),
             early_capability_flags: None,
         },
     };
     pub static ref SERVER_CORE_DATA_WITH_ALL_OPTIONAL_FIELDS: ServerCoreData = ServerCoreData {
         version: RdpVersion::V5_PLUS,
         optional_data: ServerCoreOptionalData {
-            client_requested_protocols: Some(SecurityProtocol::RDP),
+            client_requested_protocols: Some(SecurityProtocol::empty()),
             early_capability_flags: Some(ServerEarlyCapabilityFlags::EDGE_ACTIONS_SUPPORTED_V1),
         },
     };

--- a/crates/ironrdp-testsuite-core/tests/pdu/x224.rs
+++ b/crates/ironrdp-testsuite-core/tests/pdu/x224.rs
@@ -84,14 +84,15 @@ encode_decode_test! {
             // tpkt header
             0x03, // version
             0x00, // reserved
-            0x00, 0x0B, // length in BE
+            0x00, 0x13, // length in BE
             // tpdu header
-            0x06, // length
+            0x0E, // length
             0xE0, // code
             0x00, 0x00, // dst_ref
             0x00, 0x00, // src_ref
             0x00, // class
             // variable part
+            0x01, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, // RDP_NEG_REQ
         ];
 
     nego_connection_request_rdp_security_with_cookie:
@@ -104,9 +105,9 @@ encode_decode_test! {
             // tpkt header
             0x03, // version
             0x00, // reserved
-            0x00, 0x22, // length in BE
+            0x00, 0x2A, // length in BE
             // tpdu header
-            0x1D, // length
+            0x25, // length
             0xE0, // code
             0x00, 0x00, // dst_ref
             0x00, 0x00, // src_ref
@@ -114,6 +115,7 @@ encode_decode_test! {
             // variable part
             0x43, 0x6F, 0x6F, 0x6B, 0x69, 0x65, 0x3A, 0x20, 0x6D, 0x73, 0x74, 0x73, 0x68, 0x61, 0x73, 0x68, 0x3D, 0x55,
             0x73, 0x65, 0x72, 0x0D, 0x0A, // cookie
+            0x01, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, // RDP_NEG_REQ
         ];
 
     nego_connection_request_ssl_security_with_cookie:

--- a/crates/ironrdp-testsuite-core/tests/pdu/x224.rs
+++ b/crates/ironrdp-testsuite-core/tests/pdu/x224.rs
@@ -78,7 +78,7 @@ encode_decode_test! {
         ConnectionRequest {
             nego_data: None,
             flags: RequestFlags::empty(),
-            protocol: SecurityProtocol::RDP,
+            protocol: SecurityProtocol::empty(),
         },
         [
             // tpkt header
@@ -99,7 +99,7 @@ encode_decode_test! {
         ConnectionRequest {
             nego_data: Some(NegoRequestData::Cookie(Cookie("User".to_owned()))),
             flags: RequestFlags::empty(),
-            protocol: SecurityProtocol::RDP,
+            protocol: SecurityProtocol::empty(),
         },
         [
             // tpkt header

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -704,7 +704,9 @@ fn build_config(
     connector::Config {
         credentials: Credentials::UsernamePassword { username, password },
         domain,
-        security_protocol: ironrdp::pdu::nego::SecurityProtocol::HYBRID,
+        // TODO(#327): expose these options from the WASM module.
+        enable_winlogon: true,
+        enable_credssp: true,
         keyboard_type: ironrdp::pdu::gcc::KeyboardType::IbmEnhanced,
         keyboard_subtype: 0,
         keyboard_functional_keys_count: 12,
@@ -898,7 +900,7 @@ where
 
         connector.attach_server_addr(server_addr);
 
-        let ironrdp::connector::ClientConnectorState::ConnectionInitiationWaitConfirm = connector.state else {
+        let ironrdp::connector::ClientConnectorState::ConnectionInitiationWaitConfirm { .. } = connector.state else {
             return Err(anyhow::Error::msg("invalid connector state (wait confirm)").into());
         };
 

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -705,7 +705,7 @@ fn build_config(
         credentials: Credentials::UsernamePassword { username, password },
         domain,
         // TODO(#327): expose these options from the WASM module.
-        enable_winlogon: true,
+        enable_tls: true,
         enable_credssp: true,
         keyboard_type: ironrdp::pdu::gcc::KeyboardType::IbmEnhanced,
         keyboard_subtype: 0,

--- a/crates/ironrdp/examples/screenshot.rs
+++ b/crates/ironrdp/examples/screenshot.rs
@@ -176,7 +176,7 @@ fn build_config(username: String, password: String, domain: Option<String>) -> c
     connector::Config {
         credentials: Credentials::UsernamePassword { username, password },
         domain,
-        enable_winlogon: false, // This example does not expose any frontend.
+        enable_tls: false, // This example does not expose any frontend.
         enable_credssp: true,
         keyboard_type: KeyboardType::IbmEnhanced,
         keyboard_subtype: 0,

--- a/crates/ironrdp/examples/screenshot.rs
+++ b/crates/ironrdp/examples/screenshot.rs
@@ -28,7 +28,6 @@ use ironrdp::connector;
 use ironrdp::connector::sspi::network_client::reqwest_network_client::ReqwestNetworkClient;
 use ironrdp::connector::ConnectionResult;
 use ironrdp::pdu::gcc::KeyboardType;
-use ironrdp::pdu::nego::SecurityProtocol;
 use ironrdp::pdu::rdp::capability_sets::MajorPlatformType;
 use ironrdp::session::image::DecodedImage;
 use ironrdp::session::{ActiveStage, ActiveStageOutput};
@@ -177,7 +176,8 @@ fn build_config(username: String, password: String, domain: Option<String>) -> c
     connector::Config {
         credentials: Credentials::UsernamePassword { username, password },
         domain,
-        security_protocol: SecurityProtocol::HYBRID,
+        enable_winlogon: false, // This example does not expose any frontend.
+        enable_credssp: true,
         keyboard_type: KeyboardType::IbmEnhanced,
         keyboard_subtype: 0,
         keyboard_functional_keys_count: 12,


### PR DESCRIPTION
Replace the bitflag-based connector config API with a boolean-based one:

- `enable_tls`: set the PROTOCOL_SSL flag
- `enable_credssp`: set the PROTOCOL_HYBRID and PROTOCOL_HYBRID_EX flags

NLA can be enforced on client-side with `enable_tls = false`  + `enable_credssp = true`.

The `--security_protocol` argument was removed from the native client CLI, and instead it’s possible to disable specific protocols with `--no-tls` and `--no-credssp`. By default, both protocols are enabled for maximum compatibility with most RDP servers. We may change the defaults in the future.

For additional background on this change, see [this comment](https://github.com/Devolutions/IronRDP/issues/314#issuecomment-1843925374).

cc @awakecoding @thenextman 

FYI @ibeckermayer 
In your case, you’ll have to set `enable_tls` to `true` and `enable_credssp` to `false` (if you want to use the autologon flag).