### PR TITLE
feat(client): log to stdout/err by default

### DIFF
--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 
 use anyhow::Context as _;
 use clap::clap_derive::ValueEnum;
-use clap::{crate_name, Parser};
+use clap::Parser;
 use ironrdp::connector::Credentials;
 use ironrdp::pdu::rdp::capability_sets::MajorPlatformType;
 use ironrdp::{connector, pdu};
@@ -15,7 +15,7 @@ const DEFAULT_HEIGHT: u16 = 1080;
 
 #[derive(Clone, Debug)]
 pub struct Config {
-    pub log_file: String,
+    pub log_file: Option<String>,
     pub destination: Destination,
     pub connector: connector::Config,
 }
@@ -150,8 +150,8 @@ impl From<&Destination> for connector::ServerName {
 #[clap(version, long_about = None)]
 struct Args {
     /// A file with IronRDP client logs
-    #[clap(short, long, value_parser, default_value_t = format!("{}.log", crate_name!()))]
-    log_file: String,
+    #[clap(short, long, value_parser)]
+    log_file: Option<String>,
 
     /// An address on which the client will connect.
     destination: Option<Destination>,

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -71,17 +71,17 @@ impl RdpServerSecurity {
 ///# async fn stub() {
 /// fn make_tls_acceptor() -> TlsAcceptor {
 ///    /* snip */
-///#    todo!()  
+///#    todo!()
 /// }
 ///
 /// fn make_input_handler() -> impl RdpServerInputHandler {
 ///    /* snip */
-///#    NoopInputHandler    
+///#    NoopInputHandler
 /// }
 ///
 /// fn make_display_handler() -> impl RdpServerDisplay {
 ///    /* snip */
-///#    NoopDisplay    
+///#    NoopDisplay
 /// }
 ///
 /// let tls_acceptor = make_tls_acceptor();


### PR DESCRIPTION
Logging to a file by default isn't common.
    
Use a more verbose, colorful and developer-friendly format in this case.

It would be nice to move setup_logging() in some common place, for other binaries.