### PR TITLE
feat(session): handle surface with codec ID 0 (raw bitmap)

### DIFF
--- a/crates/ironrdp-session/src/utils.rs
+++ b/crates/ironrdp-session/src/utils.rs
@@ -1,15 +1,16 @@
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(u8)]
 pub enum CodecId {
+    None = 0x0,
     RemoteFx = 0x3,
 }
 
 impl CodecId {
     pub const fn from_u8(value: u8) -> Option<Self> {
-        if value == 0x3 {
-            Some(Self::RemoteFx)
-        } else {
-            None
+        match value {
+            0 => Some(Self::None),
+            3 => Some(Self::RemoteFx),
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
This fixes the compability with the server example.