### PR TITLE
fix(credssp): catch KDC proxy HTTP status error

### DIFF
--- a/crates/ironrdp-web/src/network_client.rs
+++ b/crates/ironrdp-web/src/network_client.rs
@@ -27,12 +27,23 @@ impl AsyncNetworkClient for WasmNetworkClient {
                         .map_err(|e| custom_err!("failed to send KDC request", e))?
                         .send()
                         .await
-                        .map_err(|e| custom_err!("failed to send KDC request", e))?
+                        .map_err(|e| custom_err!("failed to send KDC request", e))?;
+
+                    if !response.ok() {
+                        return Err(reason_err!(
+                            "KdcProxy",
+                            "HTTP status error ({} {})",
+                            response.status(),
+                            response.status_text(),
+                        ));
+                    }
+
+                    let body = response
                         .binary()
                         .await
                         .map_err(|e| custom_err!("failed to retrieve HTTP response", e))?;
 
-                    Ok(response)
+                    Ok(body)
                 }
                 unsupported => Err(reason_err!("CredSSP", "unsupported protocol: {unsupported:?}")),
             }


### PR DESCRIPTION
The HTTP client was ignoring the status code of the HTTP response received from the KDC proxy (Devolutions Gateway), and provided sspi-rs with an empty payload, resulting in the "TruncatedData" error.

Previous error:

```
[CredSSP] CredSSP Caused by: InvalidToken: ASN1 DER error: TruncatedData
```

New error:

```
[KdcProxy] reason: HTTP status error (500 Internal Server Error)
```

![tmpscrot](https://github.com/Devolutions/IronRDP/assets/3809077/076183aa-7bb5-4238-a16d-e2bc88d60e77)

Issue: https://devolutions.atlassian.net/browse/DPS-9810