### PR TITLE
refactor(async): use the "Local" terminology

### DIFF
--- a/crates/ironrdp-futures/src/lib.rs
+++ b/crates/ironrdp-futures/src/lib.rs
@@ -75,13 +75,13 @@ where
     }
 }
 
-pub type SingleThreadedFuturesFramed<S> = Framed<SingleThreadedFuturesStream<S>>;
+pub type LocalFuturesFramed<S> = Framed<LocalFuturesStream<S>>;
 
-pub struct SingleThreadedFuturesStream<S> {
+pub struct LocalFuturesStream<S> {
     inner: S,
 }
 
-impl<S> StreamWrapper for SingleThreadedFuturesStream<S> {
+impl<S> StreamWrapper for LocalFuturesStream<S> {
     type InnerStream = S;
 
     fn from_inner(stream: Self::InnerStream) -> Self {
@@ -101,7 +101,7 @@ impl<S> StreamWrapper for SingleThreadedFuturesStream<S> {
     }
 }
 
-impl<S> FramedRead for SingleThreadedFuturesStream<S>
+impl<S> FramedRead for LocalFuturesStream<S>
 where
     S: Unpin + AsyncRead,
 {
@@ -123,7 +123,7 @@ where
     }
 }
 
-impl<S> FramedWrite for SingleThreadedFuturesStream<S>
+impl<S> FramedWrite for LocalFuturesStream<S>
 where
     S: Unpin + AsyncWrite,
 {

--- a/crates/ironrdp-tokio/src/lib.rs
+++ b/crates/ironrdp-tokio/src/lib.rs
@@ -68,13 +68,13 @@ where
     }
 }
 
-pub type SingleThreadedTokioFramed<S> = Framed<SingleThreadedTokioStream<S>>;
+pub type LocalTokioFramed<S> = Framed<LocalTokioStream<S>>;
 
-pub struct SingleThreadedTokioStream<S> {
+pub struct LocalTokioStream<S> {
     inner: S,
 }
 
-impl<S> StreamWrapper for SingleThreadedTokioStream<S> {
+impl<S> StreamWrapper for LocalTokioStream<S> {
     type InnerStream = S;
 
     fn from_inner(stream: Self::InnerStream) -> Self {
@@ -94,7 +94,7 @@ impl<S> StreamWrapper for SingleThreadedTokioStream<S> {
     }
 }
 
-impl<S> FramedRead for SingleThreadedTokioStream<S>
+impl<S> FramedRead for LocalTokioStream<S>
 where
     S: Unpin + AsyncRead,
 {
@@ -109,7 +109,7 @@ where
     }
 }
 
-impl<S> FramedWrite for SingleThreadedTokioStream<S>
+impl<S> FramedWrite for LocalTokioStream<S>
 where
     S: Unpin + AsyncWrite,
 {

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -405,7 +405,7 @@ impl Session {
 
         let mut clipboard = self.clipboard.borrow_mut().take().expect("run called only once");
 
-        let mut framed = ironrdp_futures::SingleThreadedFuturesFramed::new(rdp_reader);
+        let mut framed = ironrdp_futures::LocalFuturesFramed::new(rdp_reader);
 
         debug!("Initialize canvas");
 
@@ -786,7 +786,7 @@ async fn connect(
     kdc_proxy_url: Option<String>,
     clipboard_backend: Option<WasmClipboardBackend>,
 ) -> Result<(connector::ConnectionResult, WebSocket), IronRdpError> {
-    let mut framed = ironrdp_futures::SingleThreadedFuturesFramed::new(ws);
+    let mut framed = ironrdp_futures::LocalFuturesFramed::new(ws);
 
     let mut connector = connector::ClientConnector::new(config);
 


### PR DESCRIPTION
For non-Send types, the common terminology is "Local", or "Thread Local" instead of "Single Threaded".

This patch is renaming such types since this is shorter and standard.