### PR TITLE
fix(web): set correct `src` for cursor proxy `Image` object

### DIFF
--- a/web-client/iron-remote-gui/src/services/wasm-bridge.service.ts
+++ b/web-client/iron-remote-gui/src/services/wasm-bridge.service.ts
@@ -315,7 +315,7 @@ export class WasmBridgeService {
                 // IMPORTANT: We need to make proxy `Image` object to actually load the image and
                 // make it usable for CSS property. Without this proxy object, URL will be rejected.
                 const image = new Image();
-                image.src = style;
+                image.src = data;
 
                 const rounded_hotspot_x = Math.round(hotspot_x);
                 const rounded_hotspot_y = Math.round(hotspot_y);


### PR DESCRIPTION
Fix for the following error message spam in `ironrdp-web`

![image](https://github.com/Devolutions/IronRDP/assets/3994505/a6562682-ad28-48d5-8f45-64feaa3753f3)
