### PR TITLE
feat: add support for skip channel join flag

### DIFF
--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -376,11 +376,21 @@ impl Sequence for ClientConnector {
                     self.static_channels.attach_channel_id(channel, channel_id);
                 });
 
+                let skip_channel_join = server_gcc_blocks
+                    .core
+                    .optional_data
+                    .early_capability_flags
+                    .is_some_and(|c| c.contains(gcc::ServerEarlyCapabilityFlags::SKIP_CHANNELJOIN_SUPPORTED));
+
                 (
                     Written::Nothing,
                     ClientConnectorState::ChannelConnection {
                         io_channel_id,
-                        channel_connection: ChannelConnectionSequence::new(io_channel_id, static_channel_ids),
+                        channel_connection: if skip_channel_join {
+                            ChannelConnectionSequence::skip_channel_join()
+                        } else {
+                            ChannelConnectionSequence::new(io_channel_id, static_channel_ids)
+                        },
                     },
                 )
             }
@@ -676,7 +686,8 @@ fn create_gcc_blocks<'a>(
                 early_capability_flags: {
                     let mut early_capability_flags = ClientEarlyCapabilityFlags::VALID_CONNECTION_TYPE
                         | ClientEarlyCapabilityFlags::SUPPORT_ERR_INFO_PDU
-                        | ClientEarlyCapabilityFlags::STRONG_ASYMMETRIC_KEYS;
+                        | ClientEarlyCapabilityFlags::STRONG_ASYMMETRIC_KEYS
+                        | ClientEarlyCapabilityFlags::SUPPORT_SKIP_CHANNELJOIN;
 
                     // TODO(#136): support for ClientEarlyCapabilityFlags::SUPPORT_STATUS_INFO_PDU
 


### PR DESCRIPTION
Closes #165

Added support for `RNS_UD_CS_SUPPORT_SKIP_CHANNELJOIN` on both client and server.

I implemented it according to (my best understanding of) the spec, however I couldn't get the windows rdp server to actually send the flag to verify it.
I guess I could try to validate the server implementation using a freerdp client instead.

Let me know if you guys have any suggestions for making sure this is working properly :)