### PR TITLE
Fix DVC message length

### DIFF
--- a/crates/ironrdp-session/src/legacy.rs
+++ b/crates/ironrdp-session/src/legacy.rs
@@ -1,9 +1,9 @@
-use std::io::{Read, Write};
 use ironrdp_connector::legacy::{encode_send_data_request, SendDataIndicationCtx};
 use ironrdp_pdu::rdp::vc;
+use ironrdp_pdu::rdp::vc::ChannelError;
 use ironrdp_pdu::write_buf::WriteBuf;
 use ironrdp_pdu::PduParsing;
-use ironrdp_pdu::rdp::vc::ChannelError;
+use std::io::{Read, Write};
 
 use crate::{SessionError, SessionResult};
 
@@ -21,12 +21,16 @@ pub fn encode_dvc_message(
         flags: vc::ChannelControlFlags::FLAG_FIRST | vc::ChannelControlFlags::FLAG_LAST,
     };
 
-    let dvc_message = DvcMessage { channel_header, dvc_pdu, dvc_data };
+    let dvc_message = DvcMessage {
+        channel_header,
+        dvc_pdu,
+        dvc_data,
+    };
 
     let previous_length = buf.filled_len();
     // [ TPKT | TPDU | SendDataRequest | vc::ChannelPduHeader | vc::dvc::ClientPdu | DvcData ]
     let written = encode_send_data_request(initiator_id, drdynvc_id, &dvc_message, buf).map_err(map_error)?;
-    debug_assert_eq!(written, buf.filled_len()-previous_length);
+    debug_assert_eq!(written, buf.filled_len() - previous_length);
 
     Ok(())
 }
@@ -34,13 +38,16 @@ pub fn encode_dvc_message(
 struct DvcMessage<'a> {
     channel_header: vc::ChannelPduHeader,
     dvc_pdu: vc::dvc::ClientPdu,
-    dvc_data: &'a[u8],
+    dvc_data: &'a [u8],
 }
 
 impl PduParsing for DvcMessage<'_> {
     type Error = ChannelError;
 
-    fn from_buffer(_: impl Read) -> Result<Self, Self::Error> where Self: Sized {
+    fn from_buffer(_: impl Read) -> Result<Self, Self::Error>
+    where
+        Self: Sized,
+    {
         todo!()
     }
 

--- a/crates/ironrdp-session/src/legacy.rs
+++ b/crates/ironrdp-session/src/legacy.rs
@@ -54,7 +54,7 @@ impl PduParsing for DvcMessage<'_> {
     fn to_buffer(&self, mut stream: impl Write) -> Result<(), Self::Error> {
         self.channel_header.to_buffer(&mut stream)?;
         self.dvc_pdu.to_buffer(&mut stream)?;
-        stream.write(self.dvc_data)?;
+        stream.write_all(self.dvc_data)?;
         Ok(())
     }
 

--- a/crates/ironrdp-session/src/legacy.rs
+++ b/crates/ironrdp-session/src/legacy.rs
@@ -48,7 +48,7 @@ impl PduParsing for DvcMessage<'_> {
     where
         Self: Sized,
     {
-        todo!()
+        Err(std::io::Error::other("legacy::DvcMessage::from_buffer called – this is a bug").into())
     }
 
     fn to_buffer(&self, mut stream: impl Write) -> Result<(), Self::Error> {


### PR DESCRIPTION
Previously, when encoding DVC messages we didn't set length correctly - `dvc::ClientPdu` and `DvcData` was not included. That led to broken stream and errors.
This PR fixes that by creating additional wrapper (`DvcMessage`) that is encoded with all constituents included.