### PR TITLE
fixes BitmapInfoHeader::decode_with_size issue with abs()

### DIFF
--- a/crates/ironrdp-cliprdr-format/src/bitmap.rs
+++ b/crates/ironrdp-cliprdr-format/src/bitmap.rs
@@ -200,10 +200,12 @@ impl BitmapInfoHeader {
         let size = src.read_u32();
 
         let width = src.read_i32();
-        check_invariant(width.abs() <= 10_000).ok_or_else(|| invalid_message_err!("biWidth", "width is too big"))?;
+        check_invariant(width != i32::MIN && width.abs() <= 10_000)
+            .ok_or_else(|| invalid_message_err!("biWidth", "width is too big"))?;
 
         let height = src.read_i32();
-        check_invariant(height.abs() <= 10_000).ok_or_else(|| invalid_message_err!("biHeight", "height is too big"))?;
+        check_invariant(height != i32::MIN && height.abs() <= 10_000)
+            .ok_or_else(|| invalid_message_err!("biHeight", "height is too big"))?;
 
         let planes = src.read_u16();
         if planes != 1 {


### PR DESCRIPTION
Fixes the issue when the value `-2147483648` is read and passed to the `abs()` function, causing panic with `attempt to negate with overflow`. See [here](https://doc.rust-lang.org/std/primitive.i32.html#method.abs). 

Reproduction steps:
```
$ echo "CAAAAAAAAIABAAqJurq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urq6urpQTn5HTg==" | base64 -D > /tmp/testcase
$ cargo fuzz run cliprdr_format /tmp/testcase
```