### PR TITLE
feat: support for `Server Deactivate All PDU`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ tracing = { version = "0.1", features = ["log"] }
 thiserror = "1.0"
 png = "0.17"
 bitflags = "2.4"
+byteorder = "1.5"
 
 [profile.dev]
 opt-level = 1

--- a/crates/ironrdp-acceptor/src/lib.rs
+++ b/crates/ironrdp-acceptor/src/lib.rs
@@ -1,8 +1,8 @@
 #[macro_use]
 extern crate tracing;
 
-use ironrdp_async::{Framed, FramedRead, FramedWrite, StreamWrapper};
-use ironrdp_connector::{custom_err, ConnectorResult, Sequence, Written};
+use ironrdp_async::{single_sequence_step, Framed, FramedRead, FramedWrite, StreamWrapper};
+use ironrdp_connector::ConnectorResult;
 use ironrdp_pdu::write_buf::WriteBuf;
 
 mod channel_connection;
@@ -41,7 +41,7 @@ where
             return Ok(result);
         }
 
-        single_accept_state(&mut framed, acceptor, &mut buf).await?;
+        single_sequence_step(&mut framed, acceptor, &mut buf).await?;
     }
 }
 
@@ -59,48 +59,6 @@ where
             return Ok((framed, result));
         }
 
-        single_accept_state(&mut framed, acceptor, &mut buf).await?;
+        single_sequence_step(&mut framed, acceptor, &mut buf).await?;
     }
-}
-
-async fn single_accept_state<S>(
-    framed: &mut Framed<S>,
-    acceptor: &mut Acceptor,
-    buf: &mut WriteBuf,
-) -> ConnectorResult<Written>
-where
-    S: FramedRead + FramedWrite,
-{
-    buf.clear();
-
-    let written = if let Some(next_pdu_hint) = acceptor.next_pdu_hint() {
-        debug!(
-            acceptor.state = acceptor.state().name(),
-            hint = ?next_pdu_hint,
-            "Wait for PDU"
-        );
-
-        let pdu = framed
-            .read_by_hint(next_pdu_hint)
-            .await
-            .map_err(|e| custom_err!("read frame by hint", e))?;
-
-        trace!(length = pdu.len(), "PDU received");
-
-        acceptor.step(&pdu, buf)?
-    } else {
-        acceptor.step_no_input(buf)?
-    };
-
-    if let Some(response_len) = written.size() {
-        debug_assert_eq!(buf.filled_len(), response_len);
-        let response = buf.filled();
-        trace!(response_len, "Send response");
-        framed
-            .write_all(response)
-            .await
-            .map_err(|e| custom_err!("write all", e))?;
-    }
-
-    Ok(written)
 }

--- a/crates/ironrdp-async/src/connector.rs
+++ b/crates/ironrdp-async/src/connector.rs
@@ -2,13 +2,13 @@ use ironrdp_connector::credssp::{CredsspProcessGenerator, CredsspSequence, Kerbe
 use ironrdp_connector::sspi::credssp::ClientState;
 use ironrdp_connector::sspi::generator::GeneratorState;
 use ironrdp_connector::{
-    custom_err, ClientConnector, ClientConnectorState, ConnectionResult, ConnectorError, ConnectorResult, Sequence,
-    ServerName, State as _, Written,
+    custom_err, ClientConnector, ClientConnectorState, ConnectionResult, ConnectorError, ConnectorResult, ServerName,
+    State as _,
 };
 use ironrdp_pdu::write_buf::WriteBuf;
 
 use crate::framed::{Framed, FramedRead, FramedWrite};
-use crate::AsyncNetworkClient;
+use crate::{single_sequence_step, AsyncNetworkClient};
 
 #[non_exhaustive]
 pub struct ShouldUpgrade;
@@ -23,7 +23,7 @@ where
     info!("Begin connection procedure");
 
     while !connector.should_perform_security_upgrade() {
-        single_connect_step(framed, connector, &mut buf).await?;
+        single_sequence_step(framed, connector, &mut buf).await?;
     }
 
     Ok(ShouldUpgrade)
@@ -73,7 +73,7 @@ where
     }
 
     let result = loop {
-        single_connect_step(framed, &mut connector, &mut buf).await?;
+        single_sequence_step(framed, &mut connector, &mut buf).await?;
 
         if let ClientConnectorState::Connected { result } = connector.state {
             break result;
@@ -174,70 +174,6 @@ where
     }
 
     connector.mark_credssp_as_done();
-
-    Ok(())
-}
-
-pub async fn single_connect_step<S>(
-    framed: &mut Framed<S>,
-    connector: &mut ClientConnector,
-    buf: &mut WriteBuf,
-) -> ConnectorResult<()>
-where
-    S: FramedWrite + FramedRead,
-{
-    buf.clear();
-    let written = single_connect_step_read(framed, connector, buf).await?;
-    single_connect_step_write(framed, buf, written).await
-}
-
-pub async fn single_connect_step_read<S>(
-    framed: &mut Framed<S>,
-    connector: &mut dyn Sequence,
-    buf: &mut WriteBuf,
-) -> ConnectorResult<Written>
-where
-    S: FramedRead,
-{
-    buf.clear();
-
-    if let Some(next_pdu_hint) = connector.next_pdu_hint() {
-        debug!(
-            connector.state = connector.state().name(),
-            hint = ?next_pdu_hint,
-            "Wait for PDU"
-        );
-
-        let pdu = framed
-            .read_by_hint(next_pdu_hint)
-            .await
-            .map_err(|e| ironrdp_connector::custom_err!("read frame by hint", e))?;
-
-        trace!(length = pdu.len(), "PDU received");
-
-        connector.step(&pdu, buf)
-    } else {
-        connector.step_no_input(buf)
-    }
-}
-
-async fn single_connect_step_write<S>(
-    framed: &mut Framed<S>,
-    buf: &mut WriteBuf,
-    written: Written,
-) -> ConnectorResult<()>
-where
-    S: FramedWrite,
-{
-    if let Some(response_len) = written.size() {
-        debug_assert_eq!(buf.filled_len(), response_len);
-        let response = buf.filled();
-        trace!(response_len, "Send response");
-        framed
-            .write_all(response)
-            .await
-            .map_err(|e| ironrdp_connector::custom_err!("write all", e))?;
-    }
 
     Ok(())
 }

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -280,6 +280,7 @@ async fn active_session(
                 ActiveStageOutput::PointerBitmap(_) => {
                     // Not applicable, because we use the software cursor rendering.
                 }
+                ActiveStageOutput::DeactivateAll(_) => todo!("DeactivateAll"),
                 ActiveStageOutput::Terminate(reason) => break 'outer reason,
             }
         }

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -25,6 +25,7 @@ pub struct ConnectionResult {
     pub graphics_config: Option<crate::GraphicsConfig>,
     pub no_server_pointer: bool,
     pub pointer_software_rendering: bool,
+    pub connection_activation: ConnectionActivationSequence,
 }
 
 #[derive(Default, Debug)]
@@ -560,6 +561,7 @@ impl Sequence for ClientConnector {
                                 graphics_config: self.config.graphics.clone(),
                                 no_server_pointer: self.config.no_server_pointer,
                                 pointer_software_rendering: self.config.pointer_software_rendering,
+                                connection_activation,
                             },
                         },
                         _ => return Err(general_err!("invalid state (this is a bug)")),

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -2,21 +2,18 @@ use std::borrow::Cow;
 use std::mem;
 use std::net::SocketAddr;
 
-use ironrdp_pdu::rdp::capability_sets::CapabilitySet;
 use ironrdp_pdu::rdp::client_info::{PerformanceFlags, TimezoneInfo};
 use ironrdp_pdu::write_buf::WriteBuf;
 use ironrdp_pdu::{decode, encode_vec, gcc, mcs, nego, rdp, PduEncode, PduHint};
 use ironrdp_svc::{StaticChannelSet, StaticVirtualChannel, SvcClientProcessor};
 
 use crate::channel_connection::{ChannelConnectionSequence, ChannelConnectionState};
-use crate::connection_finalization::ConnectionFinalizationSequence;
+use crate::connection_activation::{ConnectionActivationSequence, ConnectionActivationState};
 use crate::license_exchange::LicenseExchangeSequence;
 use crate::{
-    encode_x224_packet, legacy, Config, ConnectorError, ConnectorErrorExt as _, ConnectorResult, DesktopSize, Sequence,
-    State, Written,
+    encode_x224_packet, Config, ConnectorError, ConnectorErrorExt as _, ConnectorResult, DesktopSize, Sequence, State,
+    Written,
 };
-
-const DEFAULT_POINTER_CACHE_SIZE: u16 = 32;
 
 #[derive(Debug)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
@@ -75,14 +72,10 @@ pub enum ClientConnectorState {
         user_channel_id: u16,
     },
     CapabilitiesExchange {
-        io_channel_id: u16,
-        user_channel_id: u16,
+        connection_activation: ConnectionActivationSequence,
     },
     ConnectionFinalization {
-        io_channel_id: u16,
-        user_channel_id: u16,
-        desktop_size: DesktopSize,
-        connection_finalization: ConnectionFinalizationSequence,
+        connection_activation: ConnectionActivationSequence,
     },
     Connected {
         result: ConnectionResult,
@@ -104,8 +97,12 @@ impl State for ClientConnectorState {
             Self::ConnectTimeAutoDetection { .. } => "ConnectTimeAutoDetection",
             Self::LicensingExchange { .. } => "LicensingExchange",
             Self::MultitransportBootstrapping { .. } => "MultitransportBootstrapping",
-            Self::CapabilitiesExchange { .. } => "CapabilitiesExchange",
-            Self::ConnectionFinalization { .. } => "ConnectionFinalization",
+            Self::CapabilitiesExchange {
+                connection_activation, ..
+            } => connection_activation.state().name(),
+            Self::ConnectionFinalization {
+                connection_activation, ..
+            } => connection_activation.state().name(),
             Self::Connected { .. } => "Connected",
         }
     }
@@ -203,11 +200,12 @@ impl Sequence for ClientConnector {
             ClientConnectorState::ConnectTimeAutoDetection { .. } => None,
             ClientConnectorState::LicensingExchange { license_exchange, .. } => license_exchange.next_pdu_hint(),
             ClientConnectorState::MultitransportBootstrapping { .. } => None,
-            ClientConnectorState::CapabilitiesExchange { .. } => Some(&ironrdp_pdu::X224_HINT),
+            ClientConnectorState::CapabilitiesExchange {
+                connection_activation, ..
+            } => connection_activation.next_pdu_hint(),
             ClientConnectorState::ConnectionFinalization {
-                connection_finalization,
-                ..
-            } => connection_finalization.next_pdu_hint(),
+                connection_activation, ..
+            } => connection_activation.next_pdu_hint(),
             ClientConnectorState::Connected { .. } => None,
         }
     }
@@ -514,120 +512,57 @@ impl Sequence for ClientConnector {
             } => (
                 Written::Nothing,
                 ClientConnectorState::CapabilitiesExchange {
-                    io_channel_id,
-                    user_channel_id,
+                    connection_activation: ConnectionActivationSequence::new(
+                        self.config.clone(),
+                        io_channel_id,
+                        user_channel_id,
+                    ),
                 },
             ),
 
             //== Capabilities Exchange ==/
             // The server sends the set of capabilities it supports to the client.
             ClientConnectorState::CapabilitiesExchange {
-                io_channel_id,
-                user_channel_id,
+                mut connection_activation,
             } => {
-                debug!("Capabilities Exchange");
-
-                let send_data_indication_ctx = legacy::decode_send_data_indication(input)?;
-                let share_control_ctx = legacy::decode_share_control(send_data_indication_ctx)?;
-
-                debug!(message = ?share_control_ctx.pdu, "Received");
-
-                if share_control_ctx.channel_id != io_channel_id {
-                    warn!(
-                        io_channel_id,
-                        share_control_ctx.channel_id, "Unexpected channel ID for received Share Control Pdu"
-                    );
+                let written = connection_activation.step(input, output)?;
+                match connection_activation.state {
+                    ConnectionActivationState::ConnectionFinalization { .. } => (
+                        written,
+                        ClientConnectorState::ConnectionFinalization { connection_activation },
+                    ),
+                    _ => return Err(general_err!("invalid state (this is a bug)")),
                 }
-
-                let capability_sets = if let rdp::headers::ShareControlPdu::ServerDemandActive(server_demand_active) =
-                    share_control_ctx.pdu
-                {
-                    server_demand_active.pdu.capability_sets
-                } else {
-                    return Err(general_err!(
-                        "unexpected Share Control Pdu (expected ServerDemandActive)",
-                    ));
-                };
-
-                for c in &capability_sets {
-                    if let rdp::capability_sets::CapabilitySet::General(g) = c {
-                        if g.protocol_version != rdp::capability_sets::PROTOCOL_VER {
-                            warn!(version = g.protocol_version, "Unexpected protocol version");
-                        }
-                        break;
-                    }
-                }
-
-                let desktop_size = capability_sets
-                    .iter()
-                    .find_map(|c| match c {
-                        rdp::capability_sets::CapabilitySet::Bitmap(b) => Some(DesktopSize {
-                            width: b.desktop_width,
-                            height: b.desktop_height,
-                        }),
-                        _ => None,
-                    })
-                    .unwrap_or(DesktopSize {
-                        width: self.config.desktop_size.width,
-                        height: self.config.desktop_size.height,
-                    });
-
-                let client_confirm_active = rdp::headers::ShareControlPdu::ClientConfirmActive(
-                    create_client_confirm_active(&self.config, capability_sets),
-                );
-
-                debug!(message = ?client_confirm_active, "Send");
-
-                let written = legacy::encode_share_control(
-                    user_channel_id,
-                    io_channel_id,
-                    share_control_ctx.share_id,
-                    client_confirm_active,
-                    output,
-                )?;
-
-                (
-                    Written::from_size(written)?,
-                    ClientConnectorState::ConnectionFinalization {
-                        io_channel_id,
-                        user_channel_id,
-                        desktop_size,
-                        connection_finalization: ConnectionFinalizationSequence::new(io_channel_id, user_channel_id),
-                    },
-                )
             }
 
             //== Connection Finalization ==//
             // Client and server exchange a few PDUs in order to finalize the connection.
             // Client may send PDUs one after the other without waiting for a response in order to speed up the process.
             ClientConnectorState::ConnectionFinalization {
-                io_channel_id,
-                user_channel_id,
-                desktop_size,
-                mut connection_finalization,
+                mut connection_activation,
             } => {
-                debug!("Connection Finalization");
+                let written = connection_activation.step(input, output)?;
 
-                let written = connection_finalization.step(input, output)?;
-
-                let next_state = if connection_finalization.state.is_terminal() {
-                    ClientConnectorState::Connected {
-                        result: ConnectionResult {
+                let next_state = if !connection_activation.state.is_terminal() {
+                    ClientConnectorState::ConnectionFinalization { connection_activation }
+                } else {
+                    match connection_activation.state {
+                        ConnectionActivationState::Finalized {
                             io_channel_id,
                             user_channel_id,
-                            static_channels: mem::take(&mut self.static_channels),
                             desktop_size,
-                            graphics_config: self.config.graphics.clone(),
-                            no_server_pointer: self.config.no_server_pointer,
-                            pointer_software_rendering: self.config.pointer_software_rendering,
+                        } => ClientConnectorState::Connected {
+                            result: ConnectionResult {
+                                io_channel_id,
+                                user_channel_id,
+                                static_channels: mem::take(&mut self.static_channels),
+                                desktop_size,
+                                graphics_config: self.config.graphics.clone(),
+                                no_server_pointer: self.config.no_server_pointer,
+                                pointer_software_rendering: self.config.pointer_software_rendering,
+                            },
                         },
-                    }
-                } else {
-                    ClientConnectorState::ConnectionFinalization {
-                        io_channel_id,
-                        user_channel_id,
-                        desktop_size,
-                        connection_finalization,
+                        _ => return Err(general_err!("invalid state (this is a bug)")),
                     }
                 };
 
@@ -824,133 +759,5 @@ fn create_client_info_pdu(config: &Config, routing_addr: &SocketAddr) -> rdp::Cl
     ClientInfoPdu {
         security_header,
         client_info,
-    }
-}
-
-fn create_client_confirm_active(
-    config: &Config,
-    mut server_capability_sets: Vec<CapabilitySet>,
-) -> rdp::capability_sets::ClientConfirmActive {
-    use ironrdp_pdu::rdp::capability_sets::*;
-
-    server_capability_sets.retain(|capability_set| matches!(capability_set, CapabilitySet::MultiFragmentUpdate(_)));
-
-    let lossy_bitmap_compression = config
-        .bitmap
-        .as_ref()
-        .map(|bitmap| bitmap.lossy_compression)
-        .unwrap_or(false);
-
-    let drawing_flags = if lossy_bitmap_compression {
-        BitmapDrawingFlags::ALLOW_SKIP_ALPHA
-            | BitmapDrawingFlags::ALLOW_DYNAMIC_COLOR_FIDELITY
-            | BitmapDrawingFlags::ALLOW_COLOR_SUBSAMPLING
-    } else {
-        BitmapDrawingFlags::ALLOW_SKIP_ALPHA
-    };
-
-    server_capability_sets.extend_from_slice(&[
-        CapabilitySet::General(General {
-            major_platform_type: config.platform,
-            extra_flags: GeneralExtraFlags::FASTPATH_OUTPUT_SUPPORTED | GeneralExtraFlags::NO_BITMAP_COMPRESSION_HDR,
-            ..Default::default()
-        }),
-        CapabilitySet::Bitmap(Bitmap {
-            pref_bits_per_pix: 32,
-            desktop_width: config.desktop_size.width,
-            desktop_height: config.desktop_size.height,
-            desktop_resize_flag: false,
-            drawing_flags,
-        }),
-        CapabilitySet::Order(Order::new(
-            OrderFlags::NEGOTIATE_ORDER_SUPPORT | OrderFlags::ZERO_BOUNDS_DELTAS_SUPPORT,
-            OrderSupportExFlags::empty(),
-            0,
-            0,
-        )),
-        CapabilitySet::BitmapCache(BitmapCache {
-            caches: [CacheEntry {
-                entries: 0,
-                max_cell_size: 0,
-            }; BITMAP_CACHE_ENTRIES_NUM],
-        }),
-        CapabilitySet::Input(Input {
-            input_flags: InputFlags::all(),
-            keyboard_layout: 0,
-            keyboard_type: Some(config.keyboard_type),
-            keyboard_subtype: config.keyboard_subtype,
-            keyboard_function_key: config.keyboard_functional_keys_count,
-            keyboard_ime_filename: config.ime_file_name.clone(),
-        }),
-        CapabilitySet::Pointer(Pointer {
-            // Pointer cache should be set to non-zero value to enable client-side pointer rendering.
-            color_pointer_cache_size: DEFAULT_POINTER_CACHE_SIZE,
-            pointer_cache_size: DEFAULT_POINTER_CACHE_SIZE,
-        }),
-        CapabilitySet::Brush(Brush {
-            support_level: SupportLevel::Default,
-        }),
-        CapabilitySet::GlyphCache(GlyphCache {
-            glyph_cache: [CacheDefinition {
-                entries: 0,
-                max_cell_size: 0,
-            }; GLYPH_CACHE_NUM],
-            frag_cache: CacheDefinition {
-                entries: 0,
-                max_cell_size: 0,
-            },
-            glyph_support_level: GlyphSupportLevel::None,
-        }),
-        CapabilitySet::OffscreenBitmapCache(OffscreenBitmapCache {
-            is_supported: false,
-            cache_size: 0,
-            cache_entries: 0,
-        }),
-        CapabilitySet::VirtualChannel(VirtualChannel {
-            flags: VirtualChannelFlags::NO_COMPRESSION,
-            chunk_size: Some(0), // ignored
-        }),
-        CapabilitySet::Sound(Sound {
-            flags: SoundFlags::empty(),
-        }),
-        CapabilitySet::LargePointer(LargePointer {
-            // Setting `LargePointerSupportFlags::UP_TO_384X384_PIXELS` allows server to send
-            // `TS_FP_LARGEPOINTERATTRIBUTE` update messages, which are required for client-side
-            // rendering of pointers bigger than 96x96 pixels.
-            flags: LargePointerSupportFlags::UP_TO_384X384_PIXELS,
-        }),
-        CapabilitySet::SurfaceCommands(SurfaceCommands {
-            flags: CmdFlags::SET_SURFACE_BITS | CmdFlags::STREAM_SURFACE_BITS | CmdFlags::FRAME_MARKER,
-        }),
-        CapabilitySet::BitmapCodecs(BitmapCodecs(vec![Codec {
-            id: 0x03, // RemoteFX
-            property: CodecProperty::RemoteFx(RemoteFxContainer::ClientContainer(RfxClientCapsContainer {
-                capture_flags: CaptureFlags::empty(),
-                caps_data: RfxCaps(RfxCapset(vec![RfxICap {
-                    flags: RfxICapFlags::empty(),
-                    entropy_bits: EntropyBits::Rlgr3,
-                }])),
-            })),
-        }])),
-        CapabilitySet::FrameAcknowledge(FrameAcknowledge {
-            max_unacknowledged_frame_count: 2,
-        }),
-    ]);
-
-    if !server_capability_sets
-        .iter()
-        .any(|c| matches!(&c, CapabilitySet::MultiFragmentUpdate(_)))
-    {
-        server_capability_sets.push(CapabilitySet::MultiFragmentUpdate(MultifragmentUpdate {
-            max_request_size: 1024,
-        }));
-    }
-
-    ClientConfirmActive {
-        originator_id: SERVER_CHANNEL_ID,
-        pdu: DemandActive {
-            source_descriptor: "IRONRDP".to_owned(),
-            capability_sets: server_capability_sets,
-        },
     }
 }

--- a/crates/ironrdp-connector/src/connection_activation.rs
+++ b/crates/ironrdp-connector/src/connection_activation.rs
@@ -1,0 +1,341 @@
+use std::mem;
+
+use ironrdp_pdu::rdp::{self, capability_sets::CapabilitySet};
+
+use crate::{legacy, Config, ConnectionFinalizationSequence, ConnectorResult, DesktopSize, Sequence, State, Written};
+
+/// Represents the Capability Exchange and Connection Finalization phases
+/// of the connection sequence (section [1.3.1.1]).
+///
+/// This is abstracted into its own struct to allow it to be used for the ordinary
+/// RDP connection sequence [`ClientConnector`] that occurs for every RDP connection,
+/// as well as the Deactivation-Reactivation Sequence ([1.3.1.3]) that occurs when
+/// a [Server Deactivate All PDU] is received.
+///
+/// [1.3.1.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/023f1e69-cfe8-4ee6-9ee0-7e759fb4e4ee
+/// [1.3.1.3]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/dfc234ce-481a-4674-9a5d-2a7bafb14432
+/// [`ClientConnector`]: crate::ClientConnector
+/// [Server Deactivate All PDU]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/8a29971a-df3c-48da-add2-8ed9a05edc89
+#[derive(Debug, Clone)]
+pub struct ConnectionActivationSequence {
+    pub state: ConnectionActivationState,
+    pub config: Config,
+}
+
+impl ConnectionActivationSequence {
+    pub fn new(config: Config, io_channel_id: u16, user_channel_id: u16) -> Self {
+        Self {
+            state: ConnectionActivationState::CapabilitiesExchange {
+                io_channel_id,
+                user_channel_id,
+            },
+            config,
+        }
+    }
+}
+
+impl Sequence for ConnectionActivationSequence {
+    fn next_pdu_hint(&self) -> Option<&dyn ironrdp_pdu::PduHint> {
+        match &self.state {
+            ConnectionActivationState::Consumed => None,
+            ConnectionActivationState::Finalized { .. } => None,
+            ConnectionActivationState::CapabilitiesExchange { .. } => Some(&ironrdp_pdu::X224_HINT),
+            ConnectionActivationState::ConnectionFinalization {
+                connection_finalization,
+                ..
+            } => connection_finalization.next_pdu_hint(),
+        }
+    }
+
+    fn state(&self) -> &dyn State {
+        &self.state
+    }
+
+    fn step(&mut self, input: &[u8], output: &mut ironrdp_pdu::write_buf::WriteBuf) -> ConnectorResult<Written> {
+        let (written, next_state) = match mem::take(&mut self.state) {
+            // Invalid state
+            ConnectionActivationState::Consumed => {
+                return Err(general_err!("connector sequence state is consumed (this is a bug)"))
+            }
+            ConnectionActivationState::Finalized { .. } => {
+                return Err(general_err!("connector sequence state is finalized (this is a bug)"))
+            }
+            ConnectionActivationState::CapabilitiesExchange {
+                io_channel_id,
+                user_channel_id,
+            } => {
+                debug!("Capabilities Exchange");
+
+                let send_data_indication_ctx = legacy::decode_send_data_indication(input)?;
+                let share_control_ctx = legacy::decode_share_control(send_data_indication_ctx)?;
+
+                debug!(message = ?share_control_ctx.pdu, "Received");
+
+                if share_control_ctx.channel_id != io_channel_id {
+                    warn!(
+                        io_channel_id,
+                        share_control_ctx.channel_id, "Unexpected channel ID for received Share Control Pdu"
+                    );
+                }
+
+                let capability_sets = if let rdp::headers::ShareControlPdu::ServerDemandActive(server_demand_active) =
+                    share_control_ctx.pdu
+                {
+                    server_demand_active.pdu.capability_sets
+                } else {
+                    return Err(general_err!(
+                        "unexpected Share Control Pdu (expected ServerDemandActive)",
+                    ));
+                };
+
+                for c in &capability_sets {
+                    if let rdp::capability_sets::CapabilitySet::General(g) = c {
+                        if g.protocol_version != rdp::capability_sets::PROTOCOL_VER {
+                            warn!(version = g.protocol_version, "Unexpected protocol version");
+                        }
+                        break;
+                    }
+                }
+
+                let desktop_size = capability_sets
+                    .iter()
+                    .find_map(|c| match c {
+                        rdp::capability_sets::CapabilitySet::Bitmap(b) => Some(DesktopSize {
+                            width: b.desktop_width,
+                            height: b.desktop_height,
+                        }),
+                        _ => None,
+                    })
+                    .unwrap_or(DesktopSize {
+                        width: self.config.desktop_size.width,
+                        height: self.config.desktop_size.height,
+                    });
+
+                let client_confirm_active = rdp::headers::ShareControlPdu::ClientConfirmActive(
+                    create_client_confirm_active(&self.config, capability_sets),
+                );
+
+                debug!(message = ?client_confirm_active, "Send");
+
+                let written = legacy::encode_share_control(
+                    user_channel_id,
+                    io_channel_id,
+                    share_control_ctx.share_id,
+                    client_confirm_active,
+                    output,
+                )?;
+
+                (
+                    Written::from_size(written)?,
+                    ConnectionActivationState::ConnectionFinalization {
+                        io_channel_id,
+                        user_channel_id,
+                        desktop_size,
+                        connection_finalization: ConnectionFinalizationSequence::new(io_channel_id, user_channel_id),
+                    },
+                )
+            }
+            ConnectionActivationState::ConnectionFinalization {
+                io_channel_id,
+                user_channel_id,
+                desktop_size,
+                mut connection_finalization,
+            } => {
+                debug!("Connection Finalization");
+
+                let written = connection_finalization.step(input, output)?;
+
+                let next_state = if !connection_finalization.state.is_terminal() {
+                    ConnectionActivationState::ConnectionFinalization {
+                        io_channel_id,
+                        user_channel_id,
+                        desktop_size,
+                        connection_finalization,
+                    }
+                } else {
+                    ConnectionActivationState::Finalized {
+                        io_channel_id,
+                        user_channel_id,
+                        desktop_size,
+                    }
+                };
+
+                (written, next_state)
+            }
+        };
+
+        self.state = next_state;
+
+        Ok(written)
+    }
+}
+
+#[derive(Default, Debug, Clone)]
+pub enum ConnectionActivationState {
+    #[default]
+    Consumed,
+    CapabilitiesExchange {
+        io_channel_id: u16,
+        user_channel_id: u16,
+    },
+    ConnectionFinalization {
+        io_channel_id: u16,
+        user_channel_id: u16,
+        desktop_size: DesktopSize,
+        connection_finalization: ConnectionFinalizationSequence,
+    },
+    Finalized {
+        io_channel_id: u16,
+        user_channel_id: u16,
+        desktop_size: DesktopSize,
+    },
+}
+
+impl State for ConnectionActivationState {
+    fn name(&self) -> &'static str {
+        match self {
+            ConnectionActivationState::Consumed => "Consumed",
+            ConnectionActivationState::CapabilitiesExchange { .. } => "CapabilitiesExchange",
+            ConnectionActivationState::ConnectionFinalization { .. } => "ConnectionFinalization",
+            ConnectionActivationState::Finalized { .. } => "Finalized",
+        }
+    }
+
+    fn is_terminal(&self) -> bool {
+        matches!(self, ConnectionActivationState::Finalized { .. })
+    }
+
+    fn as_any(&self) -> &dyn core::any::Any {
+        self
+    }
+}
+
+const DEFAULT_POINTER_CACHE_SIZE: u16 = 32;
+
+fn create_client_confirm_active(
+    config: &Config,
+    mut server_capability_sets: Vec<CapabilitySet>,
+) -> rdp::capability_sets::ClientConfirmActive {
+    use ironrdp_pdu::rdp::capability_sets::*;
+
+    server_capability_sets.retain(|capability_set| matches!(capability_set, CapabilitySet::MultiFragmentUpdate(_)));
+
+    let lossy_bitmap_compression = config
+        .bitmap
+        .as_ref()
+        .map(|bitmap| bitmap.lossy_compression)
+        .unwrap_or(false);
+
+    let drawing_flags = if lossy_bitmap_compression {
+        BitmapDrawingFlags::ALLOW_SKIP_ALPHA
+            | BitmapDrawingFlags::ALLOW_DYNAMIC_COLOR_FIDELITY
+            | BitmapDrawingFlags::ALLOW_COLOR_SUBSAMPLING
+    } else {
+        BitmapDrawingFlags::ALLOW_SKIP_ALPHA
+    };
+
+    server_capability_sets.extend_from_slice(&[
+        CapabilitySet::General(General {
+            major_platform_type: config.platform,
+            extra_flags: GeneralExtraFlags::FASTPATH_OUTPUT_SUPPORTED | GeneralExtraFlags::NO_BITMAP_COMPRESSION_HDR,
+            ..Default::default()
+        }),
+        CapabilitySet::Bitmap(Bitmap {
+            pref_bits_per_pix: 32,
+            desktop_width: config.desktop_size.width,
+            desktop_height: config.desktop_size.height,
+            desktop_resize_flag: false,
+            drawing_flags,
+        }),
+        CapabilitySet::Order(Order::new(
+            OrderFlags::NEGOTIATE_ORDER_SUPPORT | OrderFlags::ZERO_BOUNDS_DELTAS_SUPPORT,
+            OrderSupportExFlags::empty(),
+            0,
+            0,
+        )),
+        CapabilitySet::BitmapCache(BitmapCache {
+            caches: [CacheEntry {
+                entries: 0,
+                max_cell_size: 0,
+            }; BITMAP_CACHE_ENTRIES_NUM],
+        }),
+        CapabilitySet::Input(Input {
+            input_flags: InputFlags::all(),
+            keyboard_layout: 0,
+            keyboard_type: Some(config.keyboard_type),
+            keyboard_subtype: config.keyboard_subtype,
+            keyboard_function_key: config.keyboard_functional_keys_count,
+            keyboard_ime_filename: config.ime_file_name.clone(),
+        }),
+        CapabilitySet::Pointer(Pointer {
+            // Pointer cache should be set to non-zero value to enable client-side pointer rendering.
+            color_pointer_cache_size: DEFAULT_POINTER_CACHE_SIZE,
+            pointer_cache_size: DEFAULT_POINTER_CACHE_SIZE,
+        }),
+        CapabilitySet::Brush(Brush {
+            support_level: SupportLevel::Default,
+        }),
+        CapabilitySet::GlyphCache(GlyphCache {
+            glyph_cache: [CacheDefinition {
+                entries: 0,
+                max_cell_size: 0,
+            }; GLYPH_CACHE_NUM],
+            frag_cache: CacheDefinition {
+                entries: 0,
+                max_cell_size: 0,
+            },
+            glyph_support_level: GlyphSupportLevel::None,
+        }),
+        CapabilitySet::OffscreenBitmapCache(OffscreenBitmapCache {
+            is_supported: false,
+            cache_size: 0,
+            cache_entries: 0,
+        }),
+        CapabilitySet::VirtualChannel(VirtualChannel {
+            flags: VirtualChannelFlags::NO_COMPRESSION,
+            chunk_size: Some(0), // ignored
+        }),
+        CapabilitySet::Sound(Sound {
+            flags: SoundFlags::empty(),
+        }),
+        CapabilitySet::LargePointer(LargePointer {
+            // Setting `LargePointerSupportFlags::UP_TO_384X384_PIXELS` allows server to send
+            // `TS_FP_LARGEPOINTERATTRIBUTE` update messages, which are required for client-side
+            // rendering of pointers bigger than 96x96 pixels.
+            flags: LargePointerSupportFlags::UP_TO_384X384_PIXELS,
+        }),
+        CapabilitySet::SurfaceCommands(SurfaceCommands {
+            flags: CmdFlags::SET_SURFACE_BITS | CmdFlags::STREAM_SURFACE_BITS | CmdFlags::FRAME_MARKER,
+        }),
+        CapabilitySet::BitmapCodecs(BitmapCodecs(vec![Codec {
+            id: 0x03, // RemoteFX
+            property: CodecProperty::RemoteFx(RemoteFxContainer::ClientContainer(RfxClientCapsContainer {
+                capture_flags: CaptureFlags::empty(),
+                caps_data: RfxCaps(RfxCapset(vec![RfxICap {
+                    flags: RfxICapFlags::empty(),
+                    entropy_bits: EntropyBits::Rlgr3,
+                }])),
+            })),
+        }])),
+        CapabilitySet::FrameAcknowledge(FrameAcknowledge {
+            max_unacknowledged_frame_count: 2,
+        }),
+    ]);
+
+    if !server_capability_sets
+        .iter()
+        .any(|c| matches!(&c, CapabilitySet::MultiFragmentUpdate(_)))
+    {
+        server_capability_sets.push(CapabilitySet::MultiFragmentUpdate(MultifragmentUpdate {
+            max_request_size: 1024,
+        }));
+    }
+
+    ClientConfirmActive {
+        originator_id: SERVER_CHANNEL_ID,
+        pdu: DemandActive {
+            source_descriptor: "IRONRDP".to_owned(),
+            capability_sets: server_capability_sets,
+        },
+    }
+}

--- a/crates/ironrdp-connector/src/connection_activation.rs
+++ b/crates/ironrdp-connector/src/connection_activation.rs
@@ -274,7 +274,8 @@ fn create_client_confirm_active(
             pref_bits_per_pix: 32,
             desktop_width: config.desktop_size.width,
             desktop_height: config.desktop_size.height,
-            desktop_resize_flag: false,
+            // This is required to be true in order for the Microsoft::Windows::RDS::DisplayControl DVC to work.
+            desktop_resize_flag: true,
             drawing_flags,
         }),
         CapabilitySet::Order(Order::new(

--- a/crates/ironrdp-connector/src/connection_finalization.rs
+++ b/crates/ironrdp-connector/src/connection_finalization.rs
@@ -8,7 +8,7 @@ use ironrdp_pdu::PduHint;
 
 use crate::{legacy, ConnectorResult, Sequence, State, Written};
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 #[non_exhaustive]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum ConnectionFinalizationState {
@@ -47,7 +47,7 @@ impl State for ConnectionFinalizationState {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ConnectionFinalizationSequence {
     pub state: ConnectionFinalizationState,

--- a/crates/ironrdp-connector/src/legacy.rs
+++ b/crates/ironrdp-connector/src/legacy.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use ironrdp_pdu::rdp::headers::ServerDeactivateAll;
 use ironrdp_pdu::write_buf::WriteBuf;
 use ironrdp_pdu::{decode, encode_vec, rdp, PduDecode, PduEncode};
 
@@ -147,7 +148,7 @@ pub fn decode_share_data(ctx: SendDataIndicationCtx<'_>) -> ConnectorResult<Shar
 
     let rdp::headers::ShareControlPdu::Data(share_data_header) = ctx.pdu else {
         return Err(general_err!(
-            "received unexpected Share Control Pdu (expected SHare Data Header)"
+            "received unexpected Share Control Pdu (expected Share Data Header)"
         ));
     };
 
@@ -158,6 +159,35 @@ pub fn decode_share_data(ctx: SendDataIndicationCtx<'_>) -> ConnectorResult<Shar
         pdu_source: ctx.pdu_source,
         pdu: share_data_header.share_data_pdu,
     })
+}
+
+pub enum IoChannelPdu {
+    Data(ShareDataCtx),
+    DeactivateAll(ServerDeactivateAll),
+}
+
+pub fn decode_io_channel(ctx: SendDataIndicationCtx<'_>) -> ConnectorResult<IoChannelPdu> {
+    let ctx = decode_share_control(ctx)?;
+
+    match ctx.pdu {
+        rdp::headers::ShareControlPdu::ServerDeactivateAll(deactivate_all) => {
+            Ok(IoChannelPdu::DeactivateAll(deactivate_all))
+        }
+        rdp::headers::ShareControlPdu::Data(share_data_header) => {
+            let share_data_ctx = ShareDataCtx {
+                initiator_id: ctx.initiator_id,
+                channel_id: ctx.channel_id,
+                share_id: ctx.share_id,
+                pdu_source: ctx.pdu_source,
+                pdu: share_data_header.share_data_pdu,
+            };
+
+            Ok(IoChannelPdu::Data(share_data_ctx))
+        }
+        _ => Err(general_err!(
+            "received unexpected Share Control Pdu (expected Share Data Header or Server Deactivate All)"
+        )),
+    }
 }
 
 impl ironrdp_error::legacy::CatchAllKind for crate::ConnectorErrorKind {

--- a/crates/ironrdp-connector/src/lib.rs
+++ b/crates/ironrdp-connector/src/lib.rs
@@ -11,6 +11,7 @@ pub mod legacy;
 
 mod channel_connection;
 mod connection;
+pub mod connection_activation;
 mod connection_finalization;
 pub mod credssp;
 mod license_exchange;

--- a/crates/ironrdp-graphics/Cargo.toml
+++ b/crates/ironrdp-graphics/Cargo.toml
@@ -19,7 +19,7 @@ doctest = false
 bit_field = "0.10"
 bitflags.workspace = true
 bitvec = "1.0"
-byteorder = "1.5"
+byteorder.workspace = true
 ironrdp-error.workspace = true
 ironrdp-pdu = { workspace = true, features = ["std"] }
 lazy_static = "1.4"

--- a/crates/ironrdp-pdu/Cargo.toml
+++ b/crates/ironrdp-pdu/Cargo.toml
@@ -27,7 +27,7 @@ tap = "1"
 
 # TODO: get rid of these dependencies (related code should probably go into another crate)
 bit_field = "0.10"
-byteorder = "1.5"
+byteorder.workspace = true
 der-parser = "8.2"
 thiserror.workspace = true
 md5 = { package = "md-5", version = "0.10" }

--- a/crates/ironrdp-pdu/src/codecs/rfx/data_messages.rs
+++ b/crates/ironrdp-pdu/src/codecs/rfx/data_messages.rs
@@ -120,11 +120,8 @@ pub struct FrameBeginPdu {
     pub number_of_regions: i16,
 }
 
-impl PduBufferParsing<'_> for FrameBeginPdu {
-    type Error = RfxError;
-
-    fn from_buffer_consume(buffer: &mut &[u8]) -> Result<Self, Self::Error> {
-        let header = BlockHeader::from_buffer_consume_with_expected_type(buffer, BlockType::FrameBegin)?;
+impl FrameBeginPdu {
+    pub fn from_buffer_consume_with_header(buffer: &mut &[u8], header: BlockHeader) -> Result<Self, RfxError> {
         CodecChannelHeader::from_buffer_consume_with_type(buffer, BlockType::FrameBegin)?;
         let mut buffer = buffer.split_to(header.data_length);
 
@@ -135,6 +132,15 @@ impl PduBufferParsing<'_> for FrameBeginPdu {
             index,
             number_of_regions,
         })
+    }
+}
+
+impl PduBufferParsing<'_> for FrameBeginPdu {
+    type Error = RfxError;
+
+    fn from_buffer_consume(buffer: &mut &[u8]) -> Result<Self, Self::Error> {
+        let header = BlockHeader::from_buffer_consume_with_expected_type(buffer, BlockType::FrameBegin)?;
+        Self::from_buffer_consume_with_header(buffer, header)
     }
 
     fn to_buffer_consume(&self, buffer: &mut &mut [u8]) -> Result<(), Self::Error> {

--- a/crates/ironrdp-pdu/src/codecs/rfx/header_messages.rs
+++ b/crates/ironrdp-pdu/src/codecs/rfx/header_messages.rs
@@ -16,11 +16,8 @@ const CHANNEL_SIZE: usize = 5;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SyncPdu;
 
-impl PduBufferParsing<'_> for SyncPdu {
-    type Error = RfxError;
-
-    fn from_buffer_consume(buffer: &mut &[u8]) -> Result<Self, Self::Error> {
-        let header = BlockHeader::from_buffer_consume_with_expected_type(buffer, BlockType::Sync)?;
+impl SyncPdu {
+    pub fn from_buffer_consume_with_header(buffer: &mut &[u8], header: BlockHeader) -> Result<Self, RfxError> {
         let mut buffer = buffer.split_to(header.data_length);
 
         let magic = buffer.read_u32::<LittleEndian>()?;
@@ -33,6 +30,15 @@ impl PduBufferParsing<'_> for SyncPdu {
         } else {
             Ok(Self)
         }
+    }
+}
+
+impl PduBufferParsing<'_> for SyncPdu {
+    type Error = RfxError;
+
+    fn from_buffer_consume(buffer: &mut &[u8]) -> Result<Self, Self::Error> {
+        let header = BlockHeader::from_buffer_consume_with_expected_type(buffer, BlockType::Sync)?;
+        Self::from_buffer_consume_with_header(buffer, header)
     }
 
     fn to_buffer_consume(&self, buffer: &mut &mut [u8]) -> Result<(), Self::Error> {

--- a/crates/ironrdp-pdu/src/rdp/capability_sets.rs
+++ b/crates/ironrdp-pdu/src/rdp/capability_sets.rs
@@ -59,6 +59,9 @@ const ORIGINATOR_ID_FIELD_SIZE: usize = 2;
 
 const NULL_TERMINATOR: &str = "\0";
 
+/// [2.2.1.13.1] Server Demand Active PDU
+///
+/// [2.2.1.13.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/a07abad1-38bb-4a1a-96c9-253e3d5440df
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ServerDemandActive {
     pub pdu: DemandActive,
@@ -100,6 +103,9 @@ impl<'de> PduDecode<'de> for ServerDemandActive {
     }
 }
 
+/// [2.2.1.13.2] Client Confirm Active PDU
+///
+/// [2.2.1.13.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/4c3c2710-0bf0-4c54-8e69-aff40ffcde66
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ClientConfirmActive {
     /// According to [MSDN](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/4e9722c3-ad83-43f5-af5a-529f73d88b48),
@@ -147,6 +153,9 @@ impl<'de> PduDecode<'de> for ClientConfirmActive {
     }
 }
 
+/// 2.2.1.13.1.1 Demand Active PDU Data (TS_DEMAND_ACTIVE_PDU)
+///
+/// [2.2.1.13.1.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/bd612af5-cb54-43a2-9646-438bc3ecf5db
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DemandActive {
     pub source_descriptor: String,

--- a/crates/ironrdp-pdu/src/rdp/headers.rs
+++ b/crates/ironrdp-pdu/src/rdp/headers.rs
@@ -518,18 +518,24 @@ bitflags! {
 ///
 /// [2.2.3.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/8a29971a-df3c-48da-add2-8ed9a05edc89
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ServerDeactivateAll;
+pub struct ServerDeactivateAll {}
+
+impl ServerDeactivateAll {
+    const FIXED_PART_SIZE: usize = 2 /* length_source_descriptor */ + 1 /* source_descriptor */;
+}
 
 impl PduDecode<'_> for ServerDeactivateAll {
     fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        ensure_fixed_part_size!(in: src);
         let length_source_descriptor = src.read_u16();
         let _ = src.read_slice(length_source_descriptor.into());
-        Ok(Self)
+        Ok(Self {})
     }
 }
 
 impl PduEncode for ServerDeactivateAll {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        ensure_fixed_part_size!(in: dst);
         // A 16-bit, unsigned integer. The size in bytes of the sourceDescriptor field.
         dst.write_u16(1);
         // Variable number of bytes. The source descriptor. This field SHOULD be set to 0x00.
@@ -542,6 +548,6 @@ impl PduEncode for ServerDeactivateAll {
     }
 
     fn size(&self) -> usize {
-        2 /* length_source_descriptor */ + 1 /* source_descriptor */
+        Self::FIXED_PART_SIZE
     }
 }

--- a/crates/ironrdp-pdu/src/rdp/headers.rs
+++ b/crates/ironrdp-pdu/src/rdp/headers.rs
@@ -518,7 +518,7 @@ bitflags! {
 ///
 /// [2.2.3.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/8a29971a-df3c-48da-add2-8ed9a05edc89
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ServerDeactivateAll {}
+pub struct ServerDeactivateAll;
 
 impl ServerDeactivateAll {
     const FIXED_PART_SIZE: usize = 2 /* length_source_descriptor */ + 1 /* source_descriptor */;

--- a/crates/ironrdp-pdu/src/rdp/headers.rs
+++ b/crates/ironrdp-pdu/src/rdp/headers.rs
@@ -158,6 +158,7 @@ pub enum ShareControlPdu {
     ServerDemandActive(ServerDemandActive),
     ClientConfirmActive(ClientConfirmActive),
     Data(ShareDataHeader),
+    ServerDeactivateAll(ServerDeactivateAll),
 }
 
 impl ShareControlPdu {
@@ -168,6 +169,7 @@ impl ShareControlPdu {
             ShareControlPdu::ServerDemandActive(_) => "Server Demand Active PDU",
             ShareControlPdu::ClientConfirmActive(_) => "Client Confirm Active PDU",
             ShareControlPdu::Data(_) => "Data PDU",
+            ShareControlPdu::ServerDeactivateAll(_) => "Server Deactivate All PDU",
         }
     }
 
@@ -176,6 +178,7 @@ impl ShareControlPdu {
             ShareControlPdu::ServerDemandActive(_) => ShareControlPduType::DemandActivePdu,
             ShareControlPdu::ClientConfirmActive(_) => ShareControlPduType::ConfirmActivePdu,
             ShareControlPdu::Data(_) => ShareControlPduType::DataPdu,
+            ShareControlPdu::ServerDeactivateAll(_) => ShareControlPduType::DeactivateAllPdu,
         }
     }
 
@@ -188,6 +191,9 @@ impl ShareControlPdu {
                 Ok(ShareControlPdu::ClientConfirmActive(ClientConfirmActive::decode(src)?))
             }
             ShareControlPduType::DataPdu => Ok(ShareControlPdu::Data(ShareDataHeader::decode(src)?)),
+            ShareControlPduType::DeactivateAllPdu => {
+                Ok(ShareControlPdu::ServerDeactivateAll(ServerDeactivateAll::decode(src)?))
+            }
             _ => Err(invalid_message_err!("share_type", "unexpected share control PDU type")),
         }
     }
@@ -199,6 +205,7 @@ impl PduEncode for ShareControlPdu {
             ShareControlPdu::ServerDemandActive(pdu) => pdu.encode(dst),
             ShareControlPdu::ClientConfirmActive(pdu) => pdu.encode(dst),
             ShareControlPdu::Data(share_data_header) => share_data_header.encode(dst),
+            ShareControlPdu::ServerDeactivateAll(deactivate_all) => deactivate_all.encode(dst),
         }
     }
 
@@ -211,6 +218,7 @@ impl PduEncode for ShareControlPdu {
             ShareControlPdu::ServerDemandActive(pdu) => pdu.size(),
             ShareControlPdu::ClientConfirmActive(pdu) => pdu.size(),
             ShareControlPdu::Data(share_data_header) => share_data_header.size(),
+            ShareControlPdu::ServerDeactivateAll(deactivate_all) => deactivate_all.size(),
         }
     }
 }
@@ -503,5 +511,37 @@ bitflags! {
         const COMPRESSED = 0x20;
         const AT_FRONT = 0x40;
         const FLUSHED = 0x80;
+    }
+}
+
+/// 2.2.3.1 Server Deactivate All PDU
+///
+/// [2.2.3.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/8a29971a-df3c-48da-add2-8ed9a05edc89
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServerDeactivateAll;
+
+impl PduDecode<'_> for ServerDeactivateAll {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        let length_source_descriptor = src.read_u16();
+        let _ = src.read_slice(length_source_descriptor.into());
+        Ok(Self)
+    }
+}
+
+impl PduEncode for ServerDeactivateAll {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        // A 16-bit, unsigned integer. The size in bytes of the sourceDescriptor field.
+        dst.write_u16(1);
+        // Variable number of bytes. The source descriptor. This field SHOULD be set to 0x00.
+        dst.write_u8(0);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "Server Deactivate All"
+    }
+
+    fn size(&self) -> usize {
+        2 /* length_source_descriptor */ + 1 /* source_descriptor */
     }
 }

--- a/crates/ironrdp-pdu/src/rdp/headers.rs
+++ b/crates/ironrdp-pdu/src/rdp/headers.rs
@@ -528,6 +528,7 @@ impl PduDecode<'_> for ServerDeactivateAll {
     fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
         ensure_fixed_part_size!(in: src);
         let length_source_descriptor = src.read_u16();
+        ensure_size!(in: src, size: length_source_descriptor.into());
         let _ = src.read_slice(length_source_descriptor.into());
         Ok(Self {})
     }

--- a/crates/ironrdp-pdu/src/rdp/vc/dvc/display.rs
+++ b/crates/ironrdp-pdu/src/rdp/vc/dvc/display.rs
@@ -73,6 +73,9 @@ pub enum Orientation {
     PortraitFlipped = 270,
 }
 
+/// [2.2.2.2.1] DISPLAYCONTROL_MONITOR_LAYOUT_PDU
+///
+/// [2.2.2.2.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpedisp/ea2de591-9203-42cd-9908-be7a55237d1c
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Monitor {
     pub flags: MonitorFlags,
@@ -154,6 +157,9 @@ impl<'de> PduDecode<'de> for Monitor {
     }
 }
 
+/// [2.2.2.2] DISPLAYCONTROL_MONITOR_LAYOUT_PDU
+///
+/// [2.2.2.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpedisp/22741217-12a0-4fb8-b5a0-df43905aaf06
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MonitorLayoutPdu {
     pub monitors: Vec<Monitor>,

--- a/crates/ironrdp-session/src/active_stage.rs
+++ b/crates/ironrdp-session/src/active_stage.rs
@@ -1,5 +1,6 @@
 use std::rc::Rc;
 
+use ironrdp_connector::connection_activation::ConnectionActivationSequence;
 use ironrdp_connector::ConnectionResult;
 use ironrdp_graphics::pointer::DecodedPointer;
 use ironrdp_pdu::geometry::InclusiveRectangle;
@@ -198,6 +199,7 @@ pub enum ActiveStageOutput {
     PointerPosition { x: u16, y: u16 },
     PointerBitmap(Rc<DecodedPointer>),
     Terminate(GracefulDisconnectReason),
+    DeactivateAll(ConnectionActivationSequence),
 }
 
 impl TryFrom<x224::ProcessorOutput> for ActiveStageOutput {
@@ -215,6 +217,7 @@ impl TryFrom<x224::ProcessorOutput> for ActiveStageOutput {
 
                 Ok(Self::Terminate(reason))
             }
+            x224::ProcessorOutput::DeactivateAll(cas) => Ok(Self::DeactivateAll(cas)),
         }
     }
 }

--- a/crates/ironrdp-session/src/active_stage.rs
+++ b/crates/ironrdp-session/src/active_stage.rs
@@ -29,6 +29,7 @@ impl ActiveStage {
             connection_result.io_channel_id,
             connection_result.graphics_config,
             graphics_handler,
+            connection_result.connection_activation,
         );
 
         let fast_path_processor = fast_path::ProcessorBuilder {

--- a/crates/ironrdp-session/src/x224/mod.rs
+++ b/crates/ironrdp-session/src/x224/mod.rs
@@ -30,7 +30,10 @@ pub enum ProcessorOutput {
     ResponseFrame(Vec<u8>),
     /// A graceful disconnect notification. Client should close the connection upon receiving this.
     Disconnect(DisconnectReason),
-    /// Received a [`ironrdp_pdu::rdp::headers::ServerDeactivateAll`] PDU.
+    /// Received a [`ironrdp_pdu::rdp::headers::ServerDeactivateAll`] PDU. Client should execute the
+    /// [Deactivation-Reactivation Sequence].
+    ///
+    /// [Deactivation-Reactivation Sequence]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/dfc234ce-481a-4674-9a5d-2a7bafb14432
     DeactivateAll(ConnectionActivationSequence),
 }
 

--- a/crates/ironrdp-session/src/x224/mod.rs
+++ b/crates/ironrdp-session/src/x224/mod.rs
@@ -45,6 +45,7 @@ pub struct Processor {
     drdynvc_initialized: bool,
     graphics_config: Option<GraphicsConfig>,
     graphics_handler: Option<Box<dyn GfxHandler + Send>>,
+    connection_activation: ConnectionActivationSequence,
 }
 
 impl Processor {
@@ -54,6 +55,7 @@ impl Processor {
         io_channel_id: u16,
         graphics_config: Option<GraphicsConfig>,
         graphics_handler: Option<Box<dyn GfxHandler + Send>>,
+        connection_activation: ConnectionActivationSequence,
     ) -> Self {
         let drdynvc_channel_id = static_channels.iter().find_map(|(type_id, channel)| {
             if channel.is_drdynvc() {
@@ -73,6 +75,7 @@ impl Processor {
             drdynvc_initialized: false,
             graphics_config,
             graphics_handler,
+            connection_activation,
         }
     }
 
@@ -182,7 +185,9 @@ impl Processor {
                     )),
                 }
             }
-            ironrdp_connector::legacy::IoChannelPdu::DeactivateAll(_) => todo!(),
+            ironrdp_connector::legacy::IoChannelPdu::DeactivateAll(_) => Ok(vec![ProcessorOutput::DeactivateAll(
+                self.connection_activation.reset_clone(),
+            )]),
         }
     }
 

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -603,6 +603,7 @@ impl Session {
                             hotspot_y,
                         })?;
                     }
+                    ActiveStageOutput::DeactivateAll(_) => todo!("DeactivateAll"),
                     ActiveStageOutput::Terminate(reason) => break 'outer reason,
                 }
             }


### PR DESCRIPTION
The [Deactivate All PDU](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/8a29971a-df3c-48da-add2-8ed9a05edc89)  is sent from server to client to indicate that the connection will be dropped or that a capability re-exchange using a [Deactivation-Reactivation Sequence](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/dfc234ce-481a-4674-9a5d-2a7bafb14432) will occur.

In practice, this happens when a screen resize is requested. When this PDU is received by the client, it is meant to begin executing the Deactivation-Reactivation Sequence, which is the Capability Exchange and Connection Finalization phases of the connection sequence.

What this PR does is

1. Break out the Capability Exchange and Connection Finalization phases of the connection sequence into their own logical abstraction `ConnectionActivationSequence`. This allows this execution `Sequence` to be used both during the initial connection phase, as well as be passed out as an [`x224::ProcessorOutput`](https://github.com/Devolutions/IronRDP/blob/717d02068b2cbcae804c3a5043d4f440a8ae62d8/crates/ironrdp-session/src/x224/mod.rs#L33-L37) in the event of a Deactivate All PDU.
2. Refactors the [`rfx::DecodingContext`](https://github.com/Devolutions/IronRDP/blob/717d02068b2cbcae804c3a5043d4f440a8ae62d8/crates/ironrdp-session/src/rfx.rs#L17-L21) to remove its explicit state management. This is included because, upon a successful Deactivation-Reactivation Sequence executing, the remote fx system is also reset, with a Sync being re-sent and so on. With this refactor, rather than needing to communicate this "reset" from the x224 processor over to the fast path processor and ultimately the `rfx::DecodingContext` to update its explicit [`state`](https://github.com/Devolutions/IronRDP/blob/master/crates/ironrdp-session/src/rfx.rs#L18) to the right value, we just let the server keep track of all state and simply decode based on whatever header it sends us.

In terms of existing IronRDP clients (like web and native), these changes should have no effect, since they are not hooked up to send screen resizes yet. This was tested via wiring things up in Teleport which can be seen in part starting [here](https://github.com/gravitational/teleport/blob/92929e381f95526cf7e0a2ef39462413f5fedfef/lib/srv/desktop/rdp/rdpclient/src/client.rs#L329).
