### PR TITLE
feat: add a "ready" channel to the `DisplayControlClient`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1773,6 +1773,7 @@ dependencies = [
  "ironrdp-dvc",
  "ironrdp-pdu",
  "ironrdp-svc",
+ "tokio",
  "tracing",
 ]
 

--- a/crates/ironrdp-displaycontrol/Cargo.toml
+++ b/crates/ironrdp-displaycontrol/Cargo.toml
@@ -15,4 +15,5 @@ categories.workspace = true
 ironrdp-dvc.workspace = true
 ironrdp-pdu.workspace = true
 ironrdp-svc.workspace = true
+tokio = "1"
 tracing.workspace = true

--- a/crates/ironrdp-displaycontrol/src/client.rs
+++ b/crates/ironrdp-displaycontrol/src/client.rs
@@ -1,16 +1,50 @@
 use crate::{
-    pdu::{DisplayControlMonitorLayout, DisplayControlPdu, MonitorLayoutEntry},
+    pdu::{DisplayControlCapabilities, DisplayControlMonitorLayout, DisplayControlPdu, MonitorLayoutEntry},
     CHANNEL_NAME,
 };
 use ironrdp_dvc::{encode_dvc_messages, DvcClientProcessor, DvcMessage, DvcProcessor};
-use ironrdp_pdu::PduResult;
+use ironrdp_pdu::{cursor::ReadCursor, PduDecode, PduResult};
 use ironrdp_svc::{impl_as_any, ChannelFlags, SvcMessage};
-use tracing::debug;
+use tokio::sync::mpsc::{self as tokio_mpsc};
+use tracing::{debug, warn};
 
 /// A client for the Display Control Virtual Channel.
-pub struct DisplayControlClient {}
+pub struct DisplayControlClient {
+    ready_notifier: tokio_mpsc::UnboundedSender<()>,
+    ready_listener: Option<tokio_mpsc::UnboundedReceiver<()>>,
+}
 
 impl_as_any!(DisplayControlClient);
+
+impl DisplayControlClient {
+    pub fn new() -> Self {
+        let (ready_notifier, ready_listener) = tokio_mpsc::unbounded_channel();
+        Self {
+            ready_notifier,
+            ready_listener: Some(ready_listener),
+        }
+    }
+
+    /// Returns a channel that receives a message when the ['DisplayControlClient`] channel is ready
+    /// to send messages. (In practice this means that the server has sent the capabilities PDU).
+    ///
+    /// The channel channel can only be taken once. If the channel is already taken, None is returned.
+    pub fn take_ready_listener(&mut self) -> Option<tokio_mpsc::UnboundedReceiver<()>> {
+        self.ready_listener.take()
+    }
+
+    fn notify_ready(&self) {
+        if self.ready_notifier.send(()).is_err() {
+            warn!("Failed to notify async open listener: channel is closed");
+        }
+    }
+
+    /// Fully encodes a [`MonitorLayoutPdu`] with the given monitors.
+    pub fn encode_monitors(&self, channel_id: u32, monitors: Vec<MonitorLayoutEntry>) -> PduResult<Vec<SvcMessage>> {
+        let pdu: DisplayControlPdu = DisplayControlMonitorLayout::new(&monitors)?.into();
+        encode_dvc_messages(channel_id, vec![Box::new(pdu)], ChannelFlags::empty())
+    }
+}
 
 impl DvcProcessor for DisplayControlClient {
     fn channel_name(&self) -> &str {
@@ -22,26 +56,14 @@ impl DvcProcessor for DisplayControlClient {
     }
 
     fn process(&mut self, _channel_id: u32, payload: &[u8]) -> PduResult<Vec<DvcMessage>> {
-        // TODO: We can parse the payload here for completeness sake,
-        // in practice we don't need to do anything with the payload.
-        debug!("Got Display PDU of length: {}", payload.len());
+        let caps = DisplayControlCapabilities::decode(&mut ReadCursor::new(payload))?;
+        debug!("received {:?}", caps);
+        self.notify_ready();
         Ok(Vec::new())
     }
 }
 
 impl DvcClientProcessor for DisplayControlClient {}
-
-impl DisplayControlClient {
-    pub fn new() -> Self {
-        Self {}
-    }
-
-    /// Fully encodes a [`MonitorLayoutPdu`] with the given monitors.
-    pub fn encode_monitors(&self, channel_id: u32, monitors: Vec<MonitorLayoutEntry>) -> PduResult<Vec<SvcMessage>> {
-        let pdu: DisplayControlPdu = DisplayControlMonitorLayout::new(&monitors)?.into();
-        encode_dvc_messages(channel_id, vec![Box::new(pdu)], ChannelFlags::empty())
-    }
-}
 
 impl Default for DisplayControlClient {
     fn default() -> Self {

--- a/crates/ironrdp-testsuite-core/tests/displaycontrol/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/displaycontrol/mod.rs
@@ -76,11 +76,18 @@ fn invalid_caps() {
 }
 
 #[test]
+fn monitor_layout_entry_odd_dimensions_adjustment() {
+    let odd_value = 1023;
+    let entry = pdu::MonitorLayoutEntry::new_primary(odd_value, odd_value).expect("valid entry should be created");
+    let (width, height) = entry.dimensions();
+    assert_eq!(width, odd_value - 1);
+    assert_eq!(height, odd_value);
+}
+
+#[test]
 fn invalid_monitor_layout_entry() {
     pdu::MonitorLayoutEntry::new_primary(32 * 1024, 32 * 1024)
         .expect_err("resolution more than 8k should not be allowed");
-
-    pdu::MonitorLayoutEntry::new_primary(1023, 1024).expect_err("only width which is power of two is allowed");
 
     pdu::MonitorLayoutEntry::new_primary(1024, 1024)
         .unwrap()


### PR DESCRIPTION
This can be used to notify callers to when the client is ready to send messages.

This is necessary, for example, in Teleport, where the user might adjust the size of their screen before the Display Control DVC is opened or before the server has sent its `DisplayControlCapabilities` pdu. Sending a resize before then would result in an error or an ignored event, respectively. Instead, Teleport wants to withhold the latest resize request, and send it when a read from this new "ready" channel indicates that the `DisplayControlClient` is ready to send messages.

This PR also adds code to automatically adjust `MonitorLayoutEntry`'s width when an odd value is passed.