### PR TITLE
feat: configurable performance flags

### DIFF
--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -7,6 +7,7 @@ use clap::clap_derive::ValueEnum;
 use clap::Parser;
 use ironrdp::connector::{self, Credentials};
 use ironrdp::pdu::rdp::capability_sets::MajorPlatformType;
+use ironrdp::pdu::rdp::client_info::PerformanceFlags;
 use tap::prelude::*;
 
 const DEFAULT_WIDTH: u16 = 1920;
@@ -337,6 +338,7 @@ impl Config {
             no_server_pointer: args.no_server_pointer,
             autologon: args.autologon,
             pointer_software_rendering: true,
+            performance_flags: PerformanceFlags::default(),
         };
 
         Ok(Self {

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::mem;
 use std::net::SocketAddr;
 
-use ironrdp_pdu::rdp::client_info::{PerformanceFlags, TimezoneInfo};
+use ironrdp_pdu::rdp::client_info::TimezoneInfo;
 use ironrdp_pdu::write_buf::WriteBuf;
 use ironrdp_pdu::{decode, encode_vec, gcc, mcs, nego, rdp, PduEncode, PduHint};
 use ironrdp_svc::{StaticChannelSet, StaticVirtualChannel, SvcClientProcessor};
@@ -749,11 +749,7 @@ fn create_client_info_pdu(config: &Config, routing_addr: &SocketAddr) -> rdp::Cl
                     daylight_bias: 0,
                 })
                 .session_id(0)
-                .performance_flags(
-                    PerformanceFlags::DISABLE_FULLWINDOWDRAG
-                        | PerformanceFlags::DISABLE_MENUANIMATIONS
-                        | PerformanceFlags::ENABLE_FONT_SMOOTHING,
-                )
+                .performance_flags(config.performance_flags)
                 .build(),
         },
     };

--- a/crates/ironrdp-connector/src/lib.rs
+++ b/crates/ironrdp-connector/src/lib.rs
@@ -24,6 +24,7 @@ pub use channel_connection::{ChannelConnectionSequence, ChannelConnectionState};
 pub use connection::{encode_send_data_request, ClientConnector, ClientConnectorState, ConnectionResult};
 pub use connection_finalization::{ConnectionFinalizationSequence, ConnectionFinalizationState};
 use ironrdp_pdu::rdp::capability_sets;
+use ironrdp_pdu::rdp::client_info::PerformanceFlags;
 use ironrdp_pdu::write_buf::WriteBuf;
 use ironrdp_pdu::{encode_buf, encode_vec, gcc, x224, PduEncode, PduHint};
 pub use license_exchange::{LicenseExchangeSequence, LicenseExchangeState};
@@ -150,6 +151,7 @@ pub struct Config {
     // FIXME(@CBenoit): these are client-only options, not part of the connector.
     pub no_server_pointer: bool,
     pub pointer_software_rendering: bool,
+    pub performance_flags: PerformanceFlags,
 }
 
 ironrdp_pdu::assert_impl!(Config: Send, Sync);

--- a/crates/ironrdp-pdu/src/rdp/client_info.rs
+++ b/crates/ironrdp-pdu/src/rdp/client_info.rs
@@ -599,9 +599,7 @@ bitflags! {
 
 impl Default for PerformanceFlags {
     fn default() -> Self {
-        Self::DISABLE_FULLWINDOWDRAG
-            | Self::DISABLE_MENUANIMATIONS
-            | Self::ENABLE_FONT_SMOOTHING
+        Self::DISABLE_FULLWINDOWDRAG | Self::DISABLE_MENUANIMATIONS | Self::ENABLE_FONT_SMOOTHING
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/client_info.rs
+++ b/crates/ironrdp-pdu/src/rdp/client_info.rs
@@ -597,6 +597,14 @@ bitflags! {
     }
 }
 
+impl Default for PerformanceFlags {
+    fn default() -> Self {
+        Self::DISABLE_FULLWINDOWDRAG
+            | Self::DISABLE_MENUANIMATIONS
+            | Self::ENABLE_FONT_SMOOTHING
+    }
+}
+
 #[repr(u16)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
 pub enum AddressFamily {

--- a/crates/ironrdp-testsuite-core/tests/pcb.rs
+++ b/crates/ironrdp-testsuite-core/tests/pcb.rs
@@ -99,8 +99,7 @@ fn null_size() {
         .err()
         .unwrap();
 
-    expect![
-        [r#"
+    expect![[r#"
             Error {
                 context: "PreconnectionBlob",
                 kind: InvalidMessage {
@@ -109,8 +108,7 @@ fn null_size() {
                 },
                 source: None,
             }
-        "#]
-    ]
+        "#]]
     .assert_debug_eq(&e);
 }
 

--- a/crates/ironrdp-testsuite-core/tests/pcb.rs
+++ b/crates/ironrdp-testsuite-core/tests/pcb.rs
@@ -99,7 +99,8 @@ fn null_size() {
         .err()
         .unwrap();
 
-    expect![[r#"
+    expect![
+        [r#"
             Error {
                 context: "PreconnectionBlob",
                 kind: InvalidMessage {
@@ -108,7 +109,8 @@ fn null_size() {
                 },
                 source: None,
             }
-        "#]]
+        "#]
+    ]
     .assert_debug_eq(&e);
 }
 

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -16,6 +16,7 @@ use ironrdp::connector::credssp::KerberosConfig;
 use ironrdp::connector::{self, ClientConnector, Credentials};
 use ironrdp::graphics::image_processing::PixelFormat;
 use ironrdp::pdu::input::fast_path::FastPathInputEvent;
+use ironrdp::pdu::rdp::client_info::PerformanceFlags;
 use ironrdp::pdu::write_buf::WriteBuf;
 use ironrdp::session::image::DecodedImage;
 use ironrdp::session::{ActiveStage, ActiveStageOutput, GracefulDisconnectReason};
@@ -759,6 +760,7 @@ fn build_config(
         no_server_pointer: false,
         autologon: false,
         pointer_software_rendering: false,
+        performance_flags: PerformanceFlags::default(),
     }
 }
 

--- a/crates/ironrdp/examples/screenshot.rs
+++ b/crates/ironrdp/examples/screenshot.rs
@@ -31,6 +31,7 @@ use ironrdp::pdu::gcc::KeyboardType;
 use ironrdp::pdu::rdp::capability_sets::MajorPlatformType;
 use ironrdp::session::image::DecodedImage;
 use ironrdp::session::{ActiveStage, ActiveStageOutput};
+use ironrdp_pdu::rdp::client_info::PerformanceFlags;
 
 const HELP: &str = "\
 USAGE:
@@ -216,6 +217,7 @@ fn build_config(username: String, password: String, domain: Option<String>) -> c
         no_server_pointer: true,
         autologon: false,
         pointer_software_rendering: true,
+        performance_flags: PerformanceFlags::default(),
     }
 }
 


### PR DESCRIPTION
Adds performance flags to the `connector::Config`.

Also adds a Default impl for PerformanceFlags. Teleport requires this in order to optionally use a non-default performance flag based on our user config.