### PR TITLE
server: add ServerEvent for clipboard

### DIFF
--- a/crates/ironrdp-cliprdr-native/src/lib.rs
+++ b/crates/ironrdp-cliprdr-native/src/lib.rs
@@ -16,4 +16,4 @@ mod windows;
 pub use crate::windows::{WinClipboard, WinCliprdrError, WinCliprdrResult};
 
 mod stub;
-pub use crate::stub::StubClipboard;
+pub use crate::stub::{StubClipboard, StubCliprdrBackend};

--- a/crates/ironrdp-cliprdr-native/src/stub.rs
+++ b/crates/ironrdp-cliprdr-native/src/stub.rs
@@ -33,13 +33,19 @@ impl CliprdrBackendFactory for StubCliprdrBackendFactory {
 }
 
 #[derive(Debug)]
-pub(crate) struct StubCliprdrBackend;
+pub struct StubCliprdrBackend;
 
 impl_as_any!(StubCliprdrBackend);
 
 impl StubCliprdrBackend {
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self
+    }
+}
+
+impl Default for StubCliprdrBackend {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/ironrdp-cliprdr/src/lib.rs
+++ b/crates/ironrdp-cliprdr/src/lib.rs
@@ -168,6 +168,11 @@ impl<R: Role> Cliprdr<R> {
     }
 
     fn handle_format_list(&mut self, format_list: FormatList<'_>) -> PduResult<Vec<SvcMessage>> {
+        if R::is_server() && self.state == CliprdrState::Initialization {
+            info!("CLIPRDR(clipboard) virtual channel has been initialized");
+            self.state = CliprdrState::Ready;
+        }
+
         let formats = format_list.get_formats(self.are_long_format_names_enabled())?;
         self.backend.on_remote_copy(&formats);
 

--- a/crates/ironrdp-cliprdr/src/pdu/format_data/mod.rs
+++ b/crates/ironrdp-cliprdr/src/pdu/format_data/mod.rs
@@ -166,6 +166,10 @@ impl<'a> FormatDataResponse<'a> {
     pub fn into_owned(self) -> OwnedFormatDataResponse {
         self.into_owned_pdu()
     }
+
+    pub fn into_data(self) -> Cow<'a, [u8]> {
+        self.data
+    }
 }
 
 impl PduEncode for FormatDataResponse<'_> {

--- a/crates/ironrdp-server/Cargo.toml
+++ b/crates/ironrdp-server/Cargo.toml
@@ -17,7 +17,7 @@ test = false
 
 [dependencies]
 anyhow = "1.0"
-tokio = { version = "1", features = ["net", "macros"] }
+tokio = { version = "1", features = ["net", "macros", "sync"] }
 tokio-rustls = "0.24"
 async-trait = "0.1"
 ironrdp-ainput.workspace = true

--- a/crates/ironrdp-server/src/builder.rs
+++ b/crates/ironrdp-server/src/builder.rs
@@ -1,11 +1,11 @@
 use std::net::SocketAddr;
 
 use anyhow::Result;
-use ironrdp_cliprdr::backend::CliprdrBackendFactory;
 use tokio_rustls::TlsAcceptor;
 
 use crate::{DisplayUpdate, RdpServerDisplayUpdates};
 
+use super::clipboard::CliprdrServerFactory;
 use super::display::{DesktopSize, RdpServerDisplay};
 use super::handler::{KeyboardEvent, MouseEvent, RdpServerInputHandler};
 use super::server::*;
@@ -28,7 +28,7 @@ pub struct BuilderDone {
     security: RdpServerSecurity,
     handler: Box<dyn RdpServerInputHandler>,
     display: Box<dyn RdpServerDisplay>,
-    cliprdr_factory: Option<Box<dyn CliprdrBackendFactory>>,
+    cliprdr_factory: Option<Box<dyn CliprdrServerFactory>>,
 }
 
 pub struct RdpServerBuilder<State> {
@@ -131,7 +131,7 @@ impl RdpServerBuilder<WantsDisplay> {
 }
 
 impl RdpServerBuilder<BuilderDone> {
-    pub fn with_cliprdr_factory(mut self, cliprdr_factory: Option<Box<dyn CliprdrBackendFactory>>) -> Self {
+    pub fn with_cliprdr_factory(mut self, cliprdr_factory: Option<Box<dyn CliprdrServerFactory>>) -> Self {
         self.state.cliprdr_factory = cliprdr_factory;
         self
     }

--- a/crates/ironrdp-server/src/builder.rs
+++ b/crates/ironrdp-server/src/builder.rs
@@ -28,7 +28,7 @@ pub struct BuilderDone {
     security: RdpServerSecurity,
     handler: Box<dyn RdpServerInputHandler>,
     display: Box<dyn RdpServerDisplay>,
-    cliprdr_factory: Option<Box<dyn CliprdrBackendFactory + Send>>,
+    cliprdr_factory: Option<Box<dyn CliprdrBackendFactory>>,
 }
 
 pub struct RdpServerBuilder<State> {
@@ -131,7 +131,7 @@ impl RdpServerBuilder<WantsDisplay> {
 }
 
 impl RdpServerBuilder<BuilderDone> {
-    pub fn with_cliprdr_factory(mut self, cliprdr_factory: Option<Box<dyn CliprdrBackendFactory + Send>>) -> Self {
+    pub fn with_cliprdr_factory(mut self, cliprdr_factory: Option<Box<dyn CliprdrBackendFactory>>) -> Self {
         self.state.cliprdr_factory = cliprdr_factory;
         self
     }

--- a/crates/ironrdp-server/src/clipboard.rs
+++ b/crates/ironrdp-server/src/clipboard.rs
@@ -1,0 +1,5 @@
+use ironrdp_cliprdr::backend::CliprdrBackendFactory;
+
+use crate::ServerEventSender;
+
+pub trait CliprdrServerFactory: CliprdrBackendFactory + ServerEventSender {}

--- a/crates/ironrdp-server/src/lib.rs
+++ b/crates/ironrdp-server/src/lib.rs
@@ -5,11 +5,13 @@ extern crate tracing;
 
 mod builder;
 mod capabilities;
+mod clipboard;
 mod display;
 mod encoder;
 mod handler;
 mod server;
 
+pub use clipboard::*;
 pub use display::*;
 pub use handler::*;
 pub use server::*;

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -147,7 +147,7 @@ pub struct RdpServer {
     handler: Arc<Mutex<Box<dyn RdpServerInputHandler>>>,
     display: Box<dyn RdpServerDisplay>,
     static_channels: StaticChannelSet,
-    cliprdr_factory: Option<Box<dyn CliprdrBackendFactory + Send>>,
+    cliprdr_factory: Option<Box<dyn CliprdrBackendFactory>>,
     ev_sender: mpsc::UnboundedSender<ServerEvent>,
     ev_receiver: mpsc::UnboundedReceiver<ServerEvent>,
 }
@@ -166,7 +166,7 @@ impl RdpServer {
         opts: RdpServerOptions,
         handler: Box<dyn RdpServerInputHandler>,
         display: Box<dyn RdpServerDisplay>,
-        cliprdr_factory: Option<Box<dyn CliprdrBackendFactory + Send>>,
+        cliprdr_factory: Option<Box<dyn CliprdrBackendFactory>>,
     ) -> Self {
         let (ev_sender, ev_receiver) = ServerEvent::create_channel();
         Self {


### PR DESCRIPTION
The clipboard factory/backend alone isn't enough to send back or notify of messages, adopt a similar approach as the client, using a channel to dispatch and send messages from the server loop.

(ideally, I wish the channel implementation details wouldn't be handled by the main loop, but this has pros and cons, so let's just follow the client approach for now)