### PR TITLE
feat: scard ascii variants

### DIFF
--- a/crates/ironrdp-rdpdr/src/pdu/esc.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/esc.rs
@@ -12,7 +12,7 @@ use ironrdp_pdu::cursor::{ReadCursor, WriteCursor};
 use ironrdp_pdu::utils::{
     encoded_multistring_len, read_multistring_from_cursor, write_multistring_to_cursor, CharacterSet,
 };
-use ironrdp_pdu::{cast_length, ensure_size, invalid_message_err, PduDecode, PduError, PduResult};
+use ironrdp_pdu::{cast_length, ensure_size, invalid_message_err, PduError, PduResult};
 
 use super::efs::IoCtlCode;
 use crate::pdu::esc::ndr::{Decode as _, Encode as _};

--- a/crates/ironrdp-rdpdr/src/pdu/esc/ndr.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/esc/ndr.rs
@@ -31,7 +31,7 @@ pub trait Decode {
     fn decode_ptr(src: &mut ReadCursor<'_>, index: &mut u32) -> PduResult<Self>
     where
         Self: Sized;
-    fn decode_value(&mut self, src: &mut ReadCursor<'_>) -> PduResult<()>;
+    fn decode_value(&mut self, src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> PduResult<()>;
 }
 
 pub trait Encode {
@@ -82,13 +82,13 @@ pub fn ptr_size(with_length: bool) -> usize {
 /// A special read_string_from_cursor which reads and ignores the additional length and
 /// offset fields prefixing the string, as well as any extra padding for a 4-byte aligned
 /// NULL-terminated string.
-pub fn read_string_from_cursor(cursor: &mut ReadCursor<'_>) -> PduResult<String> {
+pub fn read_string_from_cursor(cursor: &mut ReadCursor<'_>, charset: CharacterSet) -> PduResult<String> {
     ensure_size!(ctx: "ndr::read_string_from_cursor", in: cursor, size: size_of::<u32>() * 3);
     let length = cursor.read_u32();
     let _offset = cursor.read_u32();
     let _length2 = cursor.read_u32();
 
-    let string = utils::read_string_from_cursor(cursor, CharacterSet::Unicode, true)?;
+    let string = utils::read_string_from_cursor(cursor, charset, true)?;
 
     // Skip padding for 4-byte aligned NULL-terminated string.
     if length % 2 != 0 {

--- a/crates/ironrdp-rdpdr/src/pdu/esc/rpce.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/esc/rpce.rs
@@ -5,7 +5,7 @@
 use std::mem::size_of;
 
 use ironrdp_pdu::cursor::{ReadCursor, WriteCursor};
-use ironrdp_pdu::{cast_length, ensure_size, invalid_message_err, PduDecode, PduEncode, PduError, PduResult};
+use ironrdp_pdu::{cast_length, ensure_size, invalid_message_err, PduEncode, PduError, PduResult};
 
 /// Wrapper struct for [MS-RPCE] PDUs that allows for common [`PduEncode`], [`Encode`], and [`Self::decode`] implementations.
 ///
@@ -91,9 +91,9 @@ impl<T> Pdu<T> {
     }
 }
 
-impl<T: HeaderlessDecode> PduDecode<'_> for Pdu<T> {
+impl<T: HeaderlessDecode> Pdu<T> {
     /// Decodes the instance from a buffer stripping it of its [`StreamHeader`] and [`TypeHeader`].
-    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Pdu<T>> {
+    pub fn decode(src: &mut ReadCursor<'_>) -> PduResult<Pdu<T>> {
         // We expect `StreamHeader::decode`, `TypeHeader::decode`, and `T::decode` to each
         // call `ensure_size!` to ensure that the buffer is large enough, so we can safely
         // omit that check here.


### PR DESCRIPTION
Adds handling for the ascii variants of the currently support smartcard calls.

A couple of Teleport users have encountered these in the wild, and one of them tested this implementation. 