### PR TITLE
chore(ffi):allow Devolutions.IronRdp to be build and packed with Nuget with the dll on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Build artifacts
 /target
-
+/dependencies
 # Local cargo root
 /.cargo/local_root
 

--- a/ffi/dotnet/Devolutions.IronRdp.ConnectExample/Devolutions.IronRdp.ConnectExample.csproj
+++ b/ffi/dotnet/Devolutions.IronRdp.ConnectExample/Devolutions.IronRdp.ConnectExample.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../Devolutions.IronRdp/Devolutions.IronRdp.csproj" />
 
     <!--
     System.Drawing.Common NuGet package is only supported on Windows operating systems.
@@ -15,7 +16,6 @@
 
     https://learn.microsoft.com/en-us/dotnet/api/system.drawing?view=net-8.0
     -->
-    <PackageReference Include="Devolutions.IronRdp" Version="1.0.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.3" />
   </ItemGroup>
 

--- a/ffi/dotnet/Devolutions.IronRdp.ConnectExample/Devolutions.IronRdp.ConnectExample.csproj
+++ b/ffi/dotnet/Devolutions.IronRdp.ConnectExample/Devolutions.IronRdp.ConnectExample.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../Devolutions.IronRdp/Devolutions.IronRdp.csproj" />
 
     <!--
     System.Drawing.Common NuGet package is only supported on Windows operating systems.
@@ -16,6 +15,7 @@
 
     https://learn.microsoft.com/en-us/dotnet/api/system.drawing?view=net-8.0
     -->
+    <PackageReference Include="Devolutions.IronRdp" Version="1.0.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.3" />
   </ItemGroup>
 

--- a/ffi/dotnet/Devolutions.IronRdp.ConnectExample/Program.cs
+++ b/ffi/dotnet/Devolutions.IronRdp.ConnectExample/Program.cs
@@ -7,9 +7,9 @@ namespace Devolutions.IronRdp.ConnectExample
     {
         static async Task Main(string[] args)
         {
-            var arguments = ParseArguments(args);
-
             Log.InitWithEnv();
+
+            var arguments = ParseArguments(args);
 
             if (arguments == null)
             {

--- a/ffi/dotnet/Devolutions.IronRdp/Devolutions.IronRdp.csproj
+++ b/ffi/dotnet/Devolutions.IronRdp/Devolutions.IronRdp.csproj
@@ -5,6 +5,24 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <SuppressDependenciesWhenPacking>false</SuppressDependenciesWhenPacking>
+
+    <PackageId>Devolutions.IronRdp</PackageId>
+    <Version>1.0.1</Version>
+    <Description>Dotnet bindings for the IronRDP project</Description>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <RuntimesPath>../../../dependencies/runtimes</RuntimesPath>
+    <NativeLibPath_win_x64>$(RuntimesPath)/win-x64/native/DevolutionsIronRdp.dll</NativeLibPath_win_x64>
+  </PropertyGroup>
+
+  <ItemGroup Condition="Exists('$(NativeLibPath_win_x64)')">
+    <None Include="$(NativeLibPath_win_x64)" Link="runtimes/win-x64/native/%(Filename)%(Extension)"
+      CopyToOutputDirectory="PreserveNewest"
+      Pack="true" PackagePath="runtimes/win-x64/native/%(Filename)%(Extension)"
+    />
+  </ItemGroup>
 
 </Project>

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -112,7 +112,7 @@ fn main() -> anyhow::Result<()> {
         Action::WebCheck => web::check(&sh)?,
         Action::WebInstall => web::install(&sh)?,
         Action::WebRun => web::run(&sh)?,
-        Action::FfiBuildDll { release: debug } => ffi::build_dll(&sh, debug)?,
+        Action::FfiBuildDll { release: debug } => ffi::build_dynamic_lib(&sh, debug)?,
         Action::FfiBuildBindings { skip_dotnet_build } => ffi::build_bindings(&sh, skip_dotnet_build)?,
     }
 


### PR DESCRIPTION
First step in building FFI, allow it to be used simply by `dotnet add package` command by our consumers without worrying about loading the .dll

Only support windows x64 for now, and used solely in local development, not suppose to be pushed to any Nuget registry.
Other platform support will be added later.

---

step to build and publish
1. run `cargo xtask ffi bindings` and `cargo xtask ffi build --release` in IronRdp project root
2. (optional) remove the /bin/ directory under `Devolutions.IronRdp` 
3. run `dotnet build -r  win-x64` to build the dotnet project as well as packages it
4. run `dotnet nuget push ".\bin\Release\Devolutions.IronRdp.{version}.nupkg" --source "{your_local_nuget_server_source}"`

the other end can download with 
`dotnet add package "Devolutions.IronRdp" --source "{your_local_nuget_server_source}"`

reference: https://learn.microsoft.com/en-us/nuget/create-packages/native-files-in-net-packages