### PR TITLE
fix(dotnet): disable dotnet TLS cache/resume

### DIFF
--- a/ffi/dotnet/Devolutions.IronRdp/src/Connection.cs
+++ b/ffi/dotnet/Devolutions.IronRdp/src/Connection.cs
@@ -47,7 +47,10 @@ public static class Connection
             promise.SetResult(certificate!.GetPublicKey());
             return true;
         });
-        await sslStream.AuthenticateAsClientAsync(servername);
+        await sslStream.AuthenticateAsClientAsync(new SslClientAuthenticationOptions()
+        {
+            AllowTlsResume = false
+        });
         serverPublicKey = await promise.Task;
         framedSsl = new Framed<SslStream>(sslStream);
         connector.MarkSecurityUpgradeAsDone();


### PR DESCRIPTION
Dotnet TLS cache/resume will lead to failure of RDP connections at the second time to the same server. Specific reason see this thread (I don't understand completely, but it fixes the problem)

https://github.com/dotnet/runtime/issues/78305#issuecomment-1315342177