### PR TITLE
fix(pdu): fix preamble_size in LicensingErrorMessage regression

### DIFF
--- a/crates/ironrdp-pdu/src/rdp/server_license/licensing_error_message.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_license/licensing_error_message.rs
@@ -8,7 +8,7 @@ use super::{BlobHeader, BlobType, LicenseHeader, PreambleFlags, PreambleVersion,
 use crate::{
     cursor::{ReadCursor, WriteCursor},
     rdp::{
-        headers::{BasicSecurityHeader, BasicSecurityHeaderFlags},
+        headers::{BasicSecurityHeader, BasicSecurityHeaderFlags, BASIC_SECURITY_HEADER_SIZE},
         server_license::PreambleType,
     },
     PduDecode, PduEncode, PduResult,
@@ -48,8 +48,11 @@ impl LicensingErrorMessage {
             state_transition: LicensingStateTransition::NoTransition,
             error_info: Vec::new(),
         };
-        this.license_header.preamble_message_size =
-            cast_length!("LicensingErrorMessage", "preamble_message_size", this.size())?;
+        this.license_header.preamble_message_size = cast_length!(
+            "LicensingErrorMessage",
+            "preamble_message_size",
+            this.size() - BASIC_SECURITY_HEADER_SIZE
+        )?;
         Ok(this)
     }
 }


### PR DESCRIPTION
According to
https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/73170ca2-5f82-4a2d-9d1b-b439f3d8dadc

wMsgSize is "the size in bytes of the licensing packet (including the size of the preamble)". It must thus exclude BASIC_SECURITY_HEADER_SIZE.

Fixes mstsc connection to IronRDP server/acceptor.

Fixes 5c42ade597fa442 ("fix: make license parsing and protocol more resilient (#436)")
