### PR TITLE
refactor(ffi): ISequence interface for sequences

### DIFF
--- a/ffi/dotnet/Devolutions.IronRdp.AvaloniaExample/MainWindow.axaml.cs
+++ b/ffi/dotnet/Devolutions.IronRdp.AvaloniaExample/MainWindow.axaml.cs
@@ -416,11 +416,7 @@ public partial class MainWindow : Window
                     var writeBuf = WriteBuf.New();
                     while (true)
                     {
-                        var written = await Connection.SingleSequenceStepRead(_framed!, activationSequence, writeBuf);
-                        if (written.GetSize().IsSome())
-                        {
-                            await _framed!.Write(writeBuf);
-                        }
+                        await Connection.SingleSequenceStep(activationSequence, writeBuf,_framed!);
 
                         if (activationSequence.GetState().GetType() != ConnectionActivationStateType.Finalized)
                             continue;

--- a/ffi/dotnet/Devolutions.IronRdp.AvaloniaExample/Program.cs
+++ b/ffi/dotnet/Devolutions.IronRdp.AvaloniaExample/Program.cs
@@ -13,10 +13,13 @@ class Program
     public static void Main(string[] args)
     {
         InitializeLogging();
-        try{
+        try
+        {
             BuildAvaloniaApp()
             .StartWithClassicDesktopLifetime(args);
-        }catch(Exception e){
+        }
+        catch (Exception e)
+        {
             Trace.TraceError(e.Message);
             Trace.TraceError(e.StackTrace);
         }

--- a/ffi/dotnet/Devolutions.IronRdp/Generated/DiplomatRuntime.cs
+++ b/ffi/dotnet/Devolutions.IronRdp/Generated/DiplomatRuntime.cs
@@ -46,11 +46,11 @@ public struct DiplomatWriteable : IDisposable
 
         IntPtr flushFuncPtr = Marshal.GetFunctionPointerForDelegate(flushFunc);
         IntPtr growFuncPtr = Marshal.GetFunctionPointerForDelegate(growFunc);
-        
+
         // flushFunc and growFunc are managed objects and might be disposed of by the garbage collector.
         // To prevent this, we make the context hold the references and protect the context itself
         // for automatic disposal by moving it behind a GCHandle.
-        DiplomatWriteableContext ctx = new DiplomatWriteableContext();        
+        DiplomatWriteableContext ctx = new DiplomatWriteableContext();
         ctx.flushFunc = flushFunc;
         ctx.growFunc = growFunc;
         GCHandle ctxHandle = GCHandle.Alloc(ctx);
@@ -81,7 +81,7 @@ public struct DiplomatWriteable : IDisposable
         {
             throw new IndexOutOfRangeException("DiplomatWriteable buffer is too big");
         }
-        return Marshal.PtrToStringUTF8(buf, (int) len);
+        return Marshal.PtrToStringUTF8(buf, (int)len);
 #else
         byte[] utf8 = ToUtf8Bytes();
         return DiplomatUtils.Utf8ToString(utf8);

--- a/ffi/dotnet/Devolutions.IronRdp/src/ClientConnector.Addons.cs
+++ b/ffi/dotnet/Devolutions.IronRdp/src/ClientConnector.Addons.cs
@@ -1,0 +1,5 @@
+namespace Devolutions.IronRdp;
+
+public partial class ClientConnector : ISequence
+{
+}

--- a/ffi/dotnet/Devolutions.IronRdp/src/Connection.cs
+++ b/ffi/dotnet/Devolutions.IronRdp/src/Connection.cs
@@ -176,7 +176,7 @@ public static class Connection
         }
     }
 
-    static async Task SingleSequenceStep<S, T>(S sequence, WriteBuf buf, Framed<T> framed)
+    public static async Task SingleSequenceStep<S, T>(S sequence, WriteBuf buf, Framed<T> framed)
         where T : Stream
         where S : ISequence
     {

--- a/ffi/dotnet/Devolutions.IronRdp/src/ConnectionActivationSequence.Addons.cs
+++ b/ffi/dotnet/Devolutions.IronRdp/src/ConnectionActivationSequence.Addons.cs
@@ -1,0 +1,5 @@
+namespace Devolutions.IronRdp;
+
+public partial class ConnectionActivationSequence : ISequence
+{
+}

--- a/ffi/dotnet/Devolutions.IronRdp/src/ISequence.cs
+++ b/ffi/dotnet/Devolutions.IronRdp/src/ISequence.cs
@@ -1,0 +1,9 @@
+namespace Devolutions.IronRdp;
+
+public interface ISequence
+{
+    PduHint? NextPduHint();
+    Written Step(byte[] pduHint, WriteBuf buf);
+    Written StepNoInput(WriteBuf buf);
+}
+


### PR DESCRIPTION
It’s possible to implement interfaces even on FFI types, because they are declared as partials.

```csharp
public partial class MySequence : ISequence {}
```
So long as the type exposes the required functions, this one-liner is enough.

cc @irvingoujAtDevolution 