### PR TITLE
ci: update macos runner version

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -59,11 +59,11 @@ jobs:
           - os: win
             runner: windows-2022
           - os: osx
-            runner: macos-11
+            runner: macos-12
           - os: linux
             runner: ubuntu-20.04
           - os: ios
-            runner: macos-11
+            runner: macos-12
           - os: android
             runner: ubuntu-20.04
         exclude:


### PR DESCRIPTION
Avoiding macos-13 and macos-14 for now, as it requires selecting an Intel or Apple Silicon runner.