### PR TITLE
Handle the set keyboard indicators PDU

### DIFF
--- a/crates/ironrdp-session/src/x224/mod.rs
+++ b/crates/ironrdp-session/src/x224/mod.rs
@@ -106,6 +106,7 @@ impl Processor {
                         debug!("Got Session Save Info PDU: {session_info:?}");
                         Ok(Vec::new())
                     }
+                    // FIXME: workaround fix to not terminate the session on "unhandled PDU: Set Keyboard Indicators PDU"
                     ShareDataPdu::SetKeyboardIndicators(data) => {
                         debug!("Got Keyboard Indicators PDU: {data:?}");
                         Ok(Vec::new())

--- a/crates/ironrdp-session/src/x224/mod.rs
+++ b/crates/ironrdp-session/src/x224/mod.rs
@@ -106,6 +106,10 @@ impl Processor {
                         debug!("Got Session Save Info PDU: {session_info:?}");
                         Ok(Vec::new())
                     }
+                    ShareDataPdu::SetKeyboardIndicators(data) => {
+                        debug!("Got Keyboard Indicators PDU: {data:?}");
+                        Ok(Vec::new())
+                    }
                     ShareDataPdu::ServerSetErrorInfo(ServerSetErrorInfoPdu(ErrorInfo::ProtocolIndependentCode(
                         ProtocolIndependentCode::None,
                     ))) => {


### PR DESCRIPTION
This message doesn't require a response of any kind, but handling it here will prevent an unknown PDU error which kills the session.