### PR TITLE
ci: aggregate success results into a single job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,3 +154,18 @@ jobs:
 
       - name: Lock files
         run: cargo xtask check locks -v
+
+  success:
+    name: Success
+    runs-on: ubuntu-latest
+    if: ${{ success() }}
+    needs:
+      - formatting
+      - typos
+      - checks
+      - fuzz
+      - web
+
+    steps:
+      - name: CI succeeded
+        run: exit 0


### PR DESCRIPTION
This greatly simplifies the terraform configuration, because we only have to require the "Success" status check. It’s simpler than listing all the checks in terraform which can be sometimes problematic:

- We need to list all the job names generated using `matrix`
- We need to open a PR in infrastructure-as-code AND to deploy the change when we change / add / remove a job

Here, we just list the required jobs directly as dependencies of the `success` job, without having to modify multiple repositories. Job dependencies also does not use the job names, but the job "key", so there is much less things to enumerate. Less error prone overall.