### PR TITLE
ci: fix success job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
   success:
     name: Success
     runs-on: ubuntu-latest
-    if: ${{ success() }}
+    if: ${{ always() }}
     needs:
       - formatting
       - typos
@@ -182,4 +182,10 @@ jobs:
 
     steps:
       - name: CI succeeded
+        id: succeeded
+        if: ${{ !contains(needs.*.result, 'failure') }}
         run: exit 0
+
+      - name: CI failed
+        if: ${{ steps.succeeded.outcome == 'skipped' }}
+        run: exit 1

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -201,7 +201,7 @@ async fn active_session(
                             }
                         }
 
-                        info!(width, height, "resize event");
+                        trace!(width, height, "Resize event");
                         let (width, height) = MonitorLayoutEntry::adjust_display_size(width.into(), height.into());
                         debug!(width, height, "Adjusted display size");
 


### PR DESCRIPTION
GitHub considers skipped jobs as fulfilling requirements when merging pull requests. We need to ensure that the success job fails if any previous job has failed.