### PR TITLE
fix(client): let address resolve to either ipv4 or ipv6

### DIFF
--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -103,14 +103,15 @@ async fn connect(
     config: &Config,
     cliprdr_factory: Option<&(dyn CliprdrBackendFactory + Send)>,
 ) -> ConnectorResult<(ConnectionResult, UpgradedFramed)> {
-    let server_addr = config
-        .destination
-        .lookup_addr()
-        .map_err(|e| connector::custom_err!("lookup addr", e))?;
+    let dest = format!("{}:{}", config.destination.name(), config.destination.port());
 
-    let stream = TcpStream::connect(&server_addr)
+    let stream = TcpStream::connect(dest)
         .await
         .map_err(|e| connector::custom_err!("TCP connect", e))?;
+
+    let server_addr = stream
+        .peer_addr()
+        .map_err(|e| connector::custom_err!("Peer address", e))?;
 
     let mut framed = ironrdp_tokio::TokioFramed::new(stream);
 


### PR DESCRIPTION
Let TcpStream::connect() handle address resolution, so that multiple addresses (typically localhost -> ipv4 127.0.0.1 or ipv6 ::1) are attempted.