### PR TITLE
Improve server responsiveness & usability

### DIFF
--- a/crates/ironrdp-async/src/framed.rs
+++ b/crates/ironrdp-async/src/framed.rs
@@ -209,10 +209,14 @@ where
     }
 }
 
-impl<S> Framed<S>
+impl<S> FramedWrite for Framed<S>
 where
     S: FramedWrite,
 {
+    type WriteAllFut<'write> = S::WriteAllFut<'write>
+    where
+        Self: 'write;
+
     /// Attempts to write an entire buffer into this `Framed`’s stream.
     ///
     /// # Cancel safety
@@ -222,8 +226,8 @@ where
     /// branch completes first, then the provided buffer may have been
     /// partially written, but future calls to `write_all` will start over
     /// from the beginning of the buffer.
-    pub async fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
-        self.stream.write_all(buf).await
+    fn write_all<'a>(&'a mut self, buf: &'a [u8]) -> Self::WriteAllFut<'a> {
+        self.stream.write_all(buf)
     }
 }
 

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -10,7 +10,7 @@ use ironrdp::session::{fast_path, ActiveStage, ActiveStageOutput, GracefulDiscon
 use ironrdp::{cliprdr, connector, rdpdr, rdpsnd, session};
 use ironrdp_core::WriteBuf;
 use ironrdp_rdpsnd_native::cpal;
-use ironrdp_tokio::{single_sequence_step_read, split_tokio_framed};
+use ironrdp_tokio::{single_sequence_step_read, split_tokio_framed, FramedWrite};
 use rdpdr::NoopRdpdrBackend;
 use smallvec::SmallVec;
 use tokio::net::TcpStream;

--- a/crates/ironrdp-server/src/encoder/mod.rs
+++ b/crates/ironrdp-server/src/encoder/mod.rs
@@ -131,6 +131,14 @@ impl UpdateEncoder {
         update(self, bitmap)
     }
 
+    pub(crate) fn fragmenter_from_owned(&self, res: UpdateFragmenterOwned) -> UpdateFragmenter<'_> {
+        UpdateFragmenter {
+            code: res.code,
+            index: res.index,
+            data: &self.buffer[0..res.len],
+        }
+    }
+
     fn bitmap_update(&mut self, bitmap: BitmapUpdate) -> Result<UpdateFragmenter<'_>> {
         let len = loop {
             match self.bitmap.encode(&bitmap, self.buffer.as_mut_slice()) {
@@ -208,6 +216,12 @@ impl UpdateEncoder {
     }
 }
 
+pub(crate) struct UpdateFragmenterOwned {
+    code: UpdateCode,
+    index: usize,
+    len: usize,
+}
+
 pub(crate) struct UpdateFragmenter<'a> {
     code: UpdateCode,
     index: usize,
@@ -217,6 +231,14 @@ pub(crate) struct UpdateFragmenter<'a> {
 impl<'a> UpdateFragmenter<'a> {
     pub(crate) fn new(code: UpdateCode, data: &'a [u8]) -> Self {
         Self { code, index: 0, data }
+    }
+
+    pub(crate) fn into_owned(self) -> UpdateFragmenterOwned {
+        UpdateFragmenterOwned {
+            code: self.code,
+            index: self.index,
+            len: self.data.len(),
+        }
     }
 
     pub(crate) fn size_hint(&self) -> usize {

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -24,7 +24,7 @@ use ironrdp::pdu::rdp::client_info::PerformanceFlags;
 use ironrdp::session::image::DecodedImage;
 use ironrdp::session::{fast_path, ActiveStage, ActiveStageOutput, GracefulDisconnectReason};
 use ironrdp_core::WriteBuf;
-use ironrdp_futures::single_sequence_step_read;
+use ironrdp_futures::{single_sequence_step_read, FramedWrite};
 use rgb::AsPixels as _;
 use tap::prelude::*;
 use wasm_bindgen::prelude::*;
@@ -883,7 +883,7 @@ async fn connect_rdcleanpath<S>(
     pcb: Option<String>,
 ) -> Result<(ironrdp_futures::Upgraded, Vec<u8>), IronRdpError>
 where
-    S: ironrdp_futures::FramedRead + ironrdp_futures::FramedWrite,
+    S: ironrdp_futures::FramedRead + FramedWrite,
 {
     use ironrdp::connector::Sequence as _;
     use x509_cert::der::Decode as _;


### PR DESCRIPTION
The current server implementation processes events one at a time.

This creates issues when doing large IO or CPU intensive task, such as rfx encoding of large surfaces.

This series split read & write halfes, so they can be processed in parallel. It moves bitmap encoding to a blocking task thread, and finally processes the various server tasks concurrently, rather than via one tokio:select!() branch at a time. 

This makes qemu-rdp a lot more usable under some stressing conditions (playing video, large screen etc)