### PR TITLE
fix(now-proto): expose NowProto::decode_from_body

### DIFF
--- a/crates/now-proto-pdu/src/core/mod.rs
+++ b/crates/now-proto-pdu/src/core/mod.rs
@@ -6,7 +6,7 @@ mod number;
 mod status;
 mod string;
 
-pub(crate) use header::{NowHeader, NowMessageClass};
+pub use header::{NowHeader, NowMessageClass};
 
 pub use buffer::{NowLrgBuf, NowVarBuf};
 pub use number::{VarI16, VarI32, VarI64, VarU16, VarU32, VarU64};

--- a/crates/now-proto-pdu/src/message.rs
+++ b/crates/now-proto-pdu/src/message.rs
@@ -42,7 +42,12 @@ impl Encode for NowMessage {
 impl Decode<'_> for NowMessage {
     fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
         let header = NowHeader::decode(src)?;
+        Self::decode_from_body(header, src)
+    }
+}
 
+impl NowMessage {
+    pub fn decode_from_body(header: NowHeader, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
         match NowMessageClass(header.class.0) {
             NowMessageClass::SYSTEM => Ok(Self::System(NowSystemMessage::decode_from_body(header, src)?)),
             NowMessageClass::SESSION => Ok(Self::Session(NowSessionMessage::decode_from_body(header, src)?)),


### PR DESCRIPTION
Minor fix in `NowProto` to allow separate decoding of header and message body