### PR TITLE
ci: update macos-12 runners to macos-14

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -59,11 +59,11 @@ jobs:
           - os: win
             runner: windows-2022
           - os: osx
-            runner: macos-12
+            runner: macos-14
           - os: linux
             runner: ubuntu-20.04
           - os: ios
-            runner: macos-12
+            runner: macos-14
           - os: android
             runner: ubuntu-20.04
         exclude:

--- a/xtask/src/wasm.rs
+++ b/xtask/src/wasm.rs
@@ -59,7 +59,7 @@ fn install_wasm2wat(sh: &Shell) -> anyhow::Result<()> {
     let platform_suffix = if cfg!(target_os = "windows") {
         "windows"
     } else if cfg!(target_os = "macos") {
-        "macos-12"
+        "macos-14"
     } else {
         "ubuntu"
     };


### PR DESCRIPTION
The macOS 12 runner image will be removed by December 3rd, 2024