### PR TITLE
Speed up RemoteFX encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2484,6 +2484,7 @@ dependencies = [
  "ironrdp-rdpsnd",
  "ironrdp-svc",
  "ironrdp-tokio",
+ "rayon",
  "rustls-pemfile",
  "tokio",
  "tokio-rustls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2201,6 +2201,7 @@ name = "ironrdp-bench"
 version = "0.0.0"
 dependencies = [
  "criterion",
+ "ironrdp-graphics",
  "ironrdp-pdu",
  "ironrdp-server",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,6 +595,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,6 +659,33 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -896,6 +935,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,6 +1019,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto"
@@ -1743,6 +1843,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2084,6 +2194,15 @@ dependencies = [
  "ironrdp-core",
  "ironrdp-pdu",
  "tracing",
+]
+
+[[package]]
+name = "ironrdp-bench"
+version = "0.0.0"
+dependencies = [
+ "criterion",
+ "ironrdp-pdu",
+ "ironrdp-server",
 ]
 
 [[package]]
@@ -2486,10 +2605,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+dependencies = [
+ "hermit-abi 0.4.0",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -3233,6 +3372,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
+name = "oorandom"
+version = "11.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3570,6 +3715,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "png"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3780,6 +3953,26 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "rc2"
@@ -4730,6 +4923,16 @@ name = "tinyjson"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ab95735ea2c8fd51154d01e39cf13912a78071c2d89abc49a7ef102a7dd725a"
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "tinyvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ categories = ["network-programming"]
 ironrdp-acceptor = { version = "0.1", path = "crates/ironrdp-acceptor" }
 ironrdp-ainput = { version = "0.1", path = "crates/ironrdp-ainput" }
 ironrdp-async = { version = "0.1", path = "crates/ironrdp-async" }
+ironrdp-bench = { version = "0.1", path = "crates/ironrdp-bench" }
 ironrdp-blocking = { version = "0.1", path = "crates/ironrdp-blocking" }
 ironrdp-cliprdr = { version = "0.1", path = "crates/ironrdp-cliprdr" }
 ironrdp-cliprdr-native = { version = "0.1", path = "crates/ironrdp-cliprdr-native" }

--- a/crates/ironrdp-bench/Cargo.toml
+++ b/crates/ironrdp-bench/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 
 [dev-dependencies]
 criterion = "0.5"
+ironrdp-graphics.workspace = true
 ironrdp-pdu.workspace = true
 ironrdp-server = { workspace = true, features = ["__bench"] }
 

--- a/crates/ironrdp-bench/Cargo.toml
+++ b/crates/ironrdp-bench/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "ironrdp-bench"
+version = "0.0.0"
+description = "IronRDP benchmarks"
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+publish = false
+
+[dev-dependencies]
+criterion = "0.5"
+ironrdp-pdu.workspace = true
+ironrdp-server = { workspace = true, features = ["__bench"] }
+
+[[bench]]
+name = "bench"
+path = "benches/bench.rs"
+harness = false
+
+[lints]
+workspace = true

--- a/crates/ironrdp-bench/benches/bench.rs
+++ b/crates/ironrdp-bench/benches/bench.rs
@@ -1,0 +1,43 @@
+use std::num::NonZero;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use ironrdp_pdu::codecs::rfx;
+use ironrdp_server::{
+    bench::encoder::rfx::{rfx_enc, rfx_enc_tile},
+    BitmapUpdate,
+};
+
+pub fn rfx_enc_tile_bench(c: &mut Criterion) {
+    let quant = rfx::Quant::default();
+    let algo = rfx::EntropyAlgorithm::Rlgr3;
+    let bitmap = BitmapUpdate {
+        top: 0,
+        left: 0,
+        width: NonZero::new(64).unwrap(),
+        height: NonZero::new(64).unwrap(),
+        format: ironrdp_server::PixelFormat::ARgb32,
+        data: vec![0; 64 * 64 * 4],
+        order: ironrdp_server::PixelOrder::BottomToTop,
+        stride: 64 * 4,
+    };
+    c.bench_function("rfx_enc_tile", |b| b.iter(|| rfx_enc_tile(&bitmap, &quant, algo, 0, 0)));
+}
+
+pub fn rfx_enc_bench(c: &mut Criterion) {
+    let quant = rfx::Quant::default();
+    let algo = rfx::EntropyAlgorithm::Rlgr3;
+    let bitmap = BitmapUpdate {
+        top: 0,
+        left: 0,
+        width: NonZero::new(2048).unwrap(),
+        height: NonZero::new(2048).unwrap(),
+        format: ironrdp_server::PixelFormat::ARgb32,
+        data: vec![0; 2048 * 2048 * 4],
+        order: ironrdp_server::PixelOrder::BottomToTop,
+        stride: 64 * 4,
+    };
+    c.bench_function("rfx_enc", |b| b.iter(|| rfx_enc(&bitmap, &quant, algo)));
+}
+
+criterion_group!(benches, rfx_enc_tile_bench, rfx_enc_bench);
+criterion_main!(benches);

--- a/crates/ironrdp-bench/benches/bench.rs
+++ b/crates/ironrdp-bench/benches/bench.rs
@@ -1,6 +1,7 @@
 use std::num::NonZero;
 
 use criterion::{criterion_group, criterion_main, Criterion};
+use ironrdp_graphics::color_conversion::to_64x64_ycbcr_tile;
 use ironrdp_pdu::codecs::rfx;
 use ironrdp_server::{
     bench::encoder::rfx::{rfx_enc, rfx_enc_tile},
@@ -39,5 +40,19 @@ pub fn rfx_enc_bench(c: &mut Criterion) {
     c.bench_function("rfx_enc", |b| b.iter(|| rfx_enc(&bitmap, &quant, algo)));
 }
 
-criterion_group!(benches, rfx_enc_tile_bench, rfx_enc_bench);
+pub fn to_ycbcr_bench(c: &mut Criterion) {
+    const WIDTH: usize = 64;
+    const HEIGHT: usize = 64;
+    let input = vec![0; WIDTH * HEIGHT * 4];
+    let stride = WIDTH * 4;
+    let mut y = [0i16; WIDTH * HEIGHT];
+    let mut cb = [0i16; WIDTH * HEIGHT];
+    let mut cr = [0i16; WIDTH * HEIGHT];
+    let format = ironrdp_graphics::image_processing::PixelFormat::ARgb32;
+    c.bench_function("to_ycbcr", |b| {
+        b.iter(|| to_64x64_ycbcr_tile(&input, WIDTH, HEIGHT, stride, format, &mut y, &mut cb, &mut cr))
+    });
+}
+
+criterion_group!(benches, rfx_enc_tile_bench, rfx_enc_bench, to_ycbcr_bench);
 criterion_main!(benches);

--- a/crates/ironrdp-graphics/src/color_conversion.rs
+++ b/crates/ironrdp-graphics/src/color_conversion.rs
@@ -29,28 +29,44 @@ where
     }
 }
 
-fn pixel_format_to_rgb_fn(format: PixelFormat) -> fn(&[u8]) -> Rgb {
+fn xrgb_to_rgb(pixel: &[u8]) -> Rgb {
+    Rgb {
+        r: pixel[1],
+        g: pixel[2],
+        b: pixel[3],
+    }
+}
+
+fn xbgr_to_rgb(pixel: &[u8]) -> Rgb {
+    Rgb {
+        b: pixel[1],
+        g: pixel[2],
+        r: pixel[3],
+    }
+}
+
+fn bgrx_to_rgb(pixel: &[u8]) -> Rgb {
+    Rgb {
+        b: pixel[0],
+        g: pixel[1],
+        r: pixel[2],
+    }
+}
+
+fn rgbx_to_rgb(pixel: &[u8]) -> Rgb {
+    Rgb {
+        r: pixel[0],
+        g: pixel[1],
+        b: pixel[2],
+    }
+}
+
+const fn pixel_format_to_rgb_fn(format: PixelFormat) -> fn(&[u8]) -> Rgb {
     match format {
-        PixelFormat::ARgb32 | PixelFormat::XRgb32 => |pixel: &[u8]| Rgb {
-            r: pixel[1],
-            g: pixel[2],
-            b: pixel[3],
-        },
-        PixelFormat::ABgr32 | PixelFormat::XBgr32 => |pixel: &[u8]| Rgb {
-            b: pixel[1],
-            g: pixel[2],
-            r: pixel[3],
-        },
-        PixelFormat::BgrA32 | PixelFormat::BgrX32 => |pixel: &[u8]| Rgb {
-            b: pixel[0],
-            g: pixel[1],
-            r: pixel[2],
-        },
-        PixelFormat::RgbA32 | PixelFormat::RgbX32 => |pixel: &[u8]| Rgb {
-            r: pixel[0],
-            g: pixel[1],
-            b: pixel[2],
-        },
+        PixelFormat::ARgb32 | PixelFormat::XRgb32 => xrgb_to_rgb,
+        PixelFormat::ABgr32 | PixelFormat::XBgr32 => xbgr_to_rgb,
+        PixelFormat::BgrA32 | PixelFormat::BgrX32 => bgrx_to_rgb,
+        PixelFormat::RgbA32 | PixelFormat::RgbX32 => rgbx_to_rgb,
     }
 }
 

--- a/crates/ironrdp-graphics/src/color_conversion.rs
+++ b/crates/ironrdp-graphics/src/color_conversion.rs
@@ -135,15 +135,12 @@ pub fn to_64x64_ycbcr_tile(
     height: usize,
     stride: usize,
     format: PixelFormat,
-    y: &mut [i16],
-    cb: &mut [i16],
-    cr: &mut [i16],
+    y: &mut [i16; 64 * 64],
+    cb: &mut [i16; 64 * 64],
+    cr: &mut [i16; 64 * 64],
 ) {
     assert!(width <= 64);
     assert!(height <= 64);
-    assert_eq!(y.len(), 64 * 64);
-    assert_eq!(cb.len(), 64 * 64);
-    assert_eq!(cr.len(), 64 * 64);
 
     let to_rgb = pixel_format_to_rgb_fn(format);
     let bpp = format.bytes_per_pixel() as usize;

--- a/crates/ironrdp-graphics/src/color_conversion.rs
+++ b/crates/ironrdp-graphics/src/color_conversion.rs
@@ -17,7 +17,7 @@ pub fn ycbcr_to_bgra(input: YCbCrBuffer<'_>, mut output: &mut [u8]) -> io::Resul
 
 fn iter_to_ycbcr<'a, I, C>(input: I, y: &mut [i16], cb: &mut [i16], cr: &mut [i16], conv: C)
 where
-    I: IntoIterator<Item = &'a [u8]>,
+    I: ExactSizeIterator<Item = &'a [u8]>,
     C: Fn(&[u8]) -> Rgb,
 {
     for (i, pixel) in input.into_iter().enumerate() {
@@ -141,6 +141,12 @@ impl<'a> Iterator for TileIterator<'a> {
         }
 
         Some(&self.slice[pos..pos + self.bpp])
+    }
+}
+
+impl ExactSizeIterator for TileIterator<'_> {
+    fn len(&self) -> usize {
+        64 * 64
     }
 }
 

--- a/crates/ironrdp-graphics/src/color_conversion.rs
+++ b/crates/ironrdp-graphics/src/color_conversion.rs
@@ -254,24 +254,33 @@ impl From<Rgb> for YCbCr {
         // terms need to be scaled by << 5 we simply scale the final
         // sum by >> 10
         const DIVISOR: f32 = (1 << 15) as f32;
+        const Y_R: i32 = (0.299 * DIVISOR) as i32;
+        const Y_G: i32 = (0.587 * DIVISOR) as i32;
+        const Y_B: i32 = (0.114 * DIVISOR) as i32;
+        const CB_R: i32 = (0.168_935 * DIVISOR) as i32;
+        const CB_G: i32 = (0.331_665 * DIVISOR) as i32;
+        const CB_B: i32 = (0.500_59 * DIVISOR) as i32;
+        const CR_R: i32 = (0.499_813 * DIVISOR) as i32;
+        const CR_G: i32 = (0.418_531 * DIVISOR) as i32;
+        const CR_B: i32 = (0.081_282 * DIVISOR) as i32;
 
         let r = i32::from(r);
         let g = i32::from(g);
         let b = i32::from(b);
 
-        let y_r = r.overflowing_mul((0.299 * DIVISOR) as i32).0;
-        let y_g = g.overflowing_mul((0.587 * DIVISOR) as i32).0;
-        let y_b = b.overflowing_mul((0.114 * DIVISOR) as i32).0;
+        let y_r = r.overflowing_mul(Y_R).0;
+        let y_g = g.overflowing_mul(Y_G).0;
+        let y_b = b.overflowing_mul(Y_B).0;
         let y = y_r.overflowing_add(y_g).0.overflowing_add(y_b).0 >> 10;
 
-        let cb_r = r.overflowing_mul((0.168_935 * DIVISOR) as i32).0;
-        let cb_g = g.overflowing_mul((0.331_665 * DIVISOR) as i32).0;
-        let cb_b = b.overflowing_mul((0.500_59 * DIVISOR) as i32).0;
+        let cb_r = r.overflowing_mul(CB_R).0;
+        let cb_g = g.overflowing_mul(CB_G).0;
+        let cb_b = b.overflowing_mul(CB_B).0;
         let cb = cb_b.overflowing_sub(cb_g).0.overflowing_sub(cb_r).0 >> 10;
 
-        let cr_r = r.overflowing_mul((0.499_813 * DIVISOR) as i32).0;
-        let cr_g = g.overflowing_mul((0.418_531 * DIVISOR) as i32).0;
-        let cr_b = b.overflowing_mul((0.081_282 * DIVISOR) as i32).0;
+        let cr_r = r.overflowing_mul(CR_R).0;
+        let cr_g = g.overflowing_mul(CR_G).0;
+        let cr_b = b.overflowing_mul(CR_B).0;
         let cr = cr_r.overflowing_sub(cr_g).0.overflowing_sub(cr_b).0 >> 10;
 
         Self {

--- a/crates/ironrdp-graphics/src/color_conversion.rs
+++ b/crates/ironrdp-graphics/src/color_conversion.rs
@@ -164,11 +164,15 @@ pub fn to_64x64_ycbcr_tile(
     assert!(width <= 64);
     assert!(height <= 64);
 
-    let to_rgb = pixel_format_to_rgb_fn(format);
     let bpp = format.bytes_per_pixel() as usize;
 
     let input = TileIterator::new(input, width, height, stride, bpp);
-    iter_to_ycbcr(input, y, cb, cr, to_rgb);
+    match format {
+        PixelFormat::ARgb32 | PixelFormat::XRgb32 => iter_to_ycbcr(input, y, cb, cr, xrgb_to_rgb),
+        PixelFormat::ABgr32 | PixelFormat::XBgr32 => iter_to_ycbcr(input, y, cb, cr, xbgr_to_rgb),
+        PixelFormat::BgrA32 | PixelFormat::BgrX32 => iter_to_ycbcr(input, y, cb, cr, bgrx_to_rgb),
+        PixelFormat::RgbA32 | PixelFormat::RgbX32 => iter_to_ycbcr(input, y, cb, cr, rgbx_to_rgb),
+    };
 }
 
 /// Convert a 16-bit RDP color to RGB representation. Input value should be represented in

--- a/crates/ironrdp-server/Cargo.toml
+++ b/crates/ironrdp-server/Cargo.toml
@@ -18,6 +18,10 @@ test = false
 [features]
 helper = ["dep:x509-cert", "dep:rustls-pemfile"]
 
+# Internal (PRIVATE!) features used to aid testing.
+# Don't rely on these whatsoever. They may disappear at any time.
+__bench = []
+
 [dependencies]
 anyhow = "1.0"
 tokio = { version = "1", features = ["net", "macros", "sync", "rt"] }

--- a/crates/ironrdp-server/Cargo.toml
+++ b/crates/ironrdp-server/Cargo.toml
@@ -16,7 +16,9 @@ doctest = true
 test = false
 
 [features]
+default = ["rayon"]
 helper = ["dep:x509-cert", "dep:rustls-pemfile"]
+rayon = ["dep:rayon"]
 
 # Internal (PRIVATE!) features used to aid testing.
 # Don't rely on these whatsoever. They may disappear at any time.
@@ -42,6 +44,7 @@ ironrdp-rdpsnd.workspace = true
 tracing.workspace = true
 x509-cert = { version = "0.2.5", optional = true }
 rustls-pemfile = { version = "2.2.0", optional = true }
+rayon = { version = "1.10.0", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["sync"] }

--- a/crates/ironrdp-server/src/encoder/mod.rs
+++ b/crates/ironrdp-server/src/encoder/mod.rs
@@ -1,4 +1,4 @@
-pub(crate) mod bitmap;
+mod bitmap;
 pub(crate) mod rfx;
 
 use std::{cmp, mem};

--- a/crates/ironrdp-server/src/encoder/rfx.rs
+++ b/crates/ironrdp-server/src/encoder/rfx.rs
@@ -100,7 +100,7 @@ impl RfxEncoder {
     }
 }
 
-struct UpdateEncoder<'a> {
+pub(crate) struct UpdateEncoder<'a> {
     bitmap: &'a BitmapUpdate,
     quant: rfx::Quant,
     entropy_algorithm: rfx::EntropyAlgorithm,
@@ -217,5 +217,28 @@ impl<'a> UpdateEncoder<'a> {
             cb_data,
             cr_data,
         })
+    }
+}
+
+#[cfg(feature = "__bench")]
+pub(crate) mod bench {
+    use super::*;
+
+    pub fn rfx_enc_tile(
+        bitmap: &BitmapUpdate,
+        quant: &rfx::Quant,
+        algo: rfx::EntropyAlgorithm,
+        tile_x: usize,
+        tile_y: usize,
+    ) {
+        let (enc, mut data) = UpdateEncoder::new(bitmap, quant.clone(), algo);
+
+        enc.encode_tile(tile_x, tile_y, &mut data.0).unwrap();
+    }
+
+    pub fn rfx_enc(bitmap: &BitmapUpdate, quant: &rfx::Quant, algo: rfx::EntropyAlgorithm) {
+        let (enc, mut data) = UpdateEncoder::new(bitmap, quant.clone(), algo);
+
+        enc.encode(&mut data).unwrap();
     }
 }

--- a/crates/ironrdp-server/src/encoder/rfx.rs
+++ b/crates/ironrdp-server/src/encoder/rfx.rs
@@ -144,9 +144,16 @@ impl<'a> UpdateEncoder<'a> {
     }
 
     fn encode(&self, data: &'a mut UpdateEncoderData) -> EncodeResult<Vec<rfx::Tile<'a>>> {
+        #[cfg(feature = "rayon")]
+        use rayon::prelude::*;
+
         let (tiles_x, tiles_y) = self.tiles_xy();
 
+        #[cfg(not(feature = "rayon"))]
         let chunks = data.0.chunks_mut(64 * 64 * 3);
+        #[cfg(feature = "rayon")]
+        let chunks = data.0.par_chunks_mut(64 * 64 * 3);
+
         let tiles: Vec<_> = (0..tiles_y).flat_map(|y| (0..tiles_x).map(move |x| (x, y))).collect();
 
         chunks

--- a/crates/ironrdp-server/src/lib.rs
+++ b/crates/ironrdp-server/src/lib.rs
@@ -29,6 +29,15 @@ pub use helper::*;
 pub use server::*;
 pub use sound::*;
 
+#[cfg(feature = "__bench")]
+pub mod bench {
+    pub mod encoder {
+        pub mod rfx {
+            pub use crate::encoder::rfx::bench::{rfx_enc, rfx_enc_tile};
+        }
+    }
+}
+
 #[macro_export]
 macro_rules! time_warn {
     ($context:expr, $threshold_ms:expr, $op:expr) => {{

--- a/crates/ironrdp-server/src/lib.rs
+++ b/crates/ironrdp-server/src/lib.rs
@@ -28,3 +28,27 @@ pub use handler::*;
 pub use helper::*;
 pub use server::*;
 pub use sound::*;
+
+#[macro_export]
+macro_rules! time_warn {
+    ($context:expr, $threshold_ms:expr, $op:expr) => {{
+        #[cold]
+        fn warn_log(context: &str, duration: u128) {
+            use std::sync::atomic::AtomicUsize;
+
+            static COUNT: AtomicUsize = AtomicUsize::new(0);
+            let current_count = COUNT.fetch_add(1, ::std::sync::atomic::Ordering::Relaxed);
+            if current_count < 50 || current_count % 100 == 0 {
+                ::tracing::warn!("{context} took {duration} ms! (count: {current_count})");
+            }
+        }
+
+        let start = std::time::Instant::now();
+        let result = $op;
+        let duration = start.elapsed().as_millis();
+        if duration > $threshold_ms {
+            warn_log($context, duration);
+        }
+        result
+    }};
+}

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -32,7 +32,7 @@ use crate::clipboard::CliprdrServerFactory;
 use crate::display::{DisplayUpdate, RdpServerDisplay};
 use crate::encoder::UpdateEncoder;
 use crate::handler::RdpServerInputHandler;
-use crate::{builder, capabilities, SoundServerFactory};
+use crate::{builder, capabilities, time_warn, SoundServerFactory};
 
 #[derive(Clone)]
 pub struct RdpServerOptions {
@@ -417,7 +417,7 @@ impl RdpServer {
         let mut fragmenter = match update {
             DisplayUpdate::Bitmap(bitmap) => {
                 let (enc, res) = task::spawn_blocking(move || {
-                    let res = encoder.bitmap(bitmap).map(|r| r.into_owned());
+                    let res = time_warn!("Encoding bitmap", 10, encoder.bitmap(bitmap).map(|r| r.into_owned()));
                     (encoder, res)
                 })
                 .await?;

--- a/crates/ironrdp-testsuite-core/tests/graphics/color_conversion.rs
+++ b/crates/ironrdp-testsuite-core/tests/graphics/color_conversion.rs
@@ -4,9 +4,9 @@ use ironrdp_graphics::{color_conversion::*, image_processing::PixelFormat};
 fn to_64x64_ycbcr() {
     let input = [0u8; 4];
 
-    let mut y = vec![0; 4096];
-    let mut cb = vec![0; 4096];
-    let mut cr = vec![0; 4096];
+    let mut y = [0; 64 * 64];
+    let mut cb = [0; 64 * 64];
+    let mut cr = [0; 64 * 64];
     to_64x64_ycbcr_tile(&input, 1, 1, 4, PixelFormat::ABgr32, &mut y, &mut cb, &mut cr);
 }
 


### PR DESCRIPTION
- introduce rfx encoding benchmark with criterion
- speed up a bit DWT with const generics
- use rayon to parallel encode each tile
- speed up a bit rgb->yuv conversion

Unfortunately, it's not simple to use hand-written assembly from a project like yuvutils, because RDP uses odd bias and precision. Something left for the another day.