### PR TITLE
build(ffi): enable required feature from ironrdp

### DIFF
--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -19,7 +19,7 @@ doctest = false
 [dependencies]
 diplomat = "0.7"
 diplomat-runtime = "0.7"
-ironrdp = { workspace = true, features = ["connector", "dvc", "svc", "rdpdr", "rdpsnd", "graphics", "input", "cliprdr", "displaycontrol"] }
+ironrdp = { workspace = true, features = ["session", "connector", "dvc", "svc", "rdpdr", "rdpsnd", "graphics", "input", "cliprdr", "displaycontrol"] }
 ironrdp-cliprdr-native = { workspace = true }
 ironrdp-core = { workspace = true, features = ["alloc"] }
 sspi = { workspace = true, features = ["network_client"] }


### PR DESCRIPTION
This feature used to be enabled by default, but it's not anymore.