### PR TITLE
docs(ironrdp): README.md dedicated to the meta crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ exclude = [
 ]
 
 [workspace.package]
-readme = "README.md"
 edition = "2021"
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/Devolutions/IronRDP"

--- a/crates/ironrdp/Cargo.toml
+++ b/crates/ironrdp/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "ironrdp"
 version = "0.5.0"
-description = "A Rust implementation of the Microsoft Remote Desktop Protocol (RDP)"
-readme.workspace = true
+readme = "README.md"
+description = "A meta crate re-exporting IronRDP crates for convenience"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/ironrdp/README.md
+++ b/crates/ironrdp/README.md
@@ -1,0 +1,7 @@
+# IronRDP meta crate
+
+A meta crate re-exporting IronRDP crates for convenience.
+
+This crate is part of the [IronRDP] project.
+
+[IronRDP]: https://github.com/Devolutions/IronRDP

--- a/crates/ironrdp/src/lib.rs
+++ b/crates/ironrdp/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc = include_str!("../../../README.md")]
+#![doc = include_str!("../README.md")]
 #![doc(
     html_logo_url = "https://webdevolutions.blob.core.windows.net/images/projects/devolutions/logos/devolutions-icon-shadow.svg"
 )]


### PR DESCRIPTION
Using the top-level README.md of the repository is not ideal.

1/ It contains many information unrelated to the meta crate itself.

2/ The following attribute:

```
 #![doc = include_str!("../../../README.md")]
```

will fail at finding the README.md when built via `cargo package`.