### PR TITLE
fix: add a few temporary, hidden re-exports for Teleport

### DIFF
--- a/crates/ironrdp-core/src/macros.rs
+++ b/crates/ironrdp-core/src/macros.rs
@@ -64,7 +64,7 @@ macro_rules! not_enough_bytes_err {
         $crate::not_enough_bytes_err($context, $received, $expected)
     }};
     ( $received:expr , $expected:expr $(,)? ) => {{
-        not_enough_bytes_err!($crate::function!(), $received, $expected)
+        $crate::not_enough_bytes_err!($crate::function!(), $received, $expected)
     }};
 }
 
@@ -96,7 +96,7 @@ macro_rules! invalid_field_err {
         $crate::invalid_field_err($context, $field, $reason)
     }};
     ( $field:expr , $reason:expr $(,)? ) => {{
-        invalid_field_err!($crate::function!(), $field, $reason)
+        $crate::invalid_field_err!($crate::function!(), $field, $reason)
     }};
 }
 
@@ -127,7 +127,7 @@ macro_rules! unexpected_message_type_err {
         $crate::unexpected_message_type_err($context, $got)
     }};
     ( $got:expr $(,)? ) => {{
-        unexpected_message_type_err!($crate::function!(), $got)
+        $crate::unexpected_message_type_err!($crate::function!(), $got)
     }};
 }
 
@@ -158,7 +158,7 @@ macro_rules! unsupported_version_err {
         $crate::unsupported_version_err($context, $got)
     }};
     ( $got:expr $(,)? ) => {{
-        unsupported_version_err!($crate::function!(), $got)
+        $crate::unsupported_version_err!($crate::function!(), $got)
     }};
 }
 
@@ -190,7 +190,7 @@ macro_rules! unsupported_value_err {
         $crate::unsupported_value_err($context, $name, $value)
     }};
     ( $name:expr, $value:expr $(,)? ) => {{
-        unsupported_value_err!($crate::function!(), $name, $value)
+        $crate::unsupported_value_err!($crate::function!(), $name, $value)
     }};
 }
 
@@ -237,10 +237,10 @@ macro_rules! other_err {
         $crate::other_err($context, $description)
     }};
     ( source: $source:expr $(,)? ) => {{
-        other_err!($crate::function!(), source: $source)
+        $crate::other_err!($crate::function!(), source: $source)
     }};
     ( $description:expr $(,)? ) => {{
-        other_err!($crate::function!(), $description)
+        $crate::other_err!($crate::function!(), $description)
     }};
 }
 

--- a/crates/ironrdp-pdu/src/lib.rs
+++ b/crates/ironrdp-pdu/src/lib.rs
@@ -235,3 +235,7 @@ mod legacy {
         fn buffer_length(&self) -> usize;
     }
 }
+
+// Private! Used by the macros.
+#[doc(hidden)]
+pub use ironrdp_core;

--- a/crates/ironrdp-pdu/src/lib.rs
+++ b/crates/ironrdp-pdu/src/lib.rs
@@ -10,7 +10,8 @@
 
 use core::fmt;
 
-use ironrdp_core::{unexpected_message_type_err, DecodeResult, EncodeResult, ReadCursor};
+// TODO(#583): uncomment once re-exports are removed.
+// use ironrdp_core::{unexpected_message_type_err, DecodeResult, EncodeResult, ReadCursor};
 use ironrdp_error::Source;
 
 #[macro_use]
@@ -239,3 +240,45 @@ mod legacy {
 // Private! Used by the macros.
 #[doc(hidden)]
 pub use ironrdp_core;
+
+// -- Temporary re-exports to ease teleport’s migration to the newer versions -- //
+// TODO(#583): remove once Teleport migrated to the newer item paths.
+// NOTE: #[deprecated] has no effect on re-exports, so this is mostly for documenting the code at this point.
+#[doc(hidden)]
+#[deprecated(since = "0.1.0", note = "use ironrdp_core::{ReadCursor, WriteCursor}")]
+pub mod cursor {
+    pub use ironrdp_core::ReadCursor;
+    pub use ironrdp_core::WriteCursor;
+}
+
+#[doc(hidden)]
+#[deprecated(since = "0.1.0", note = "use ironrdp_core::WriteBuf")]
+pub mod write_buf {
+    pub use ironrdp_core::WriteBuf;
+}
+
+#[doc(hidden)]
+#[deprecated(since = "0.1.0", note = "use ironrdp_core")]
+pub use ironrdp_core::*;
+
+#[doc(hidden)]
+#[deprecated(since = "0.1.0")]
+#[macro_export]
+macro_rules! custom_err {
+    ( $description:expr, $source:expr $(,)? ) => {{
+        $crate::PduError::new(
+            $description,
+            $crate::PduErrorKind::Other {
+                description: $description,
+            },
+        )
+        .with_source($source)
+    }};
+    ( $source:expr $(,)? ) => {{
+        $crate::custom_err!($crate::function!(), $source)
+    }};
+}
+
+#[doc(hidden)]
+#[deprecated(since = "0.1.0", note = "use ironrdp_core::other_err")]
+pub use crate::pdu_other_err as other_err;

--- a/crates/ironrdp-pdu/src/macros.rs
+++ b/crates/ironrdp-pdu/src/macros.rs
@@ -5,14 +5,14 @@
 #[macro_export]
 macro_rules! decode_err {
     ($source:expr $(,)? ) => {
-        <$crate::PduError as $crate::PduErrorExt>::decode(ironrdp_core::function!(), $source)
+        <$crate::PduError as $crate::PduErrorExt>::decode($crate::ironrdp_core::function!(), $source)
     };
 }
 
 #[macro_export]
 macro_rules! encode_err {
     ($source:expr $(,)? ) => {
-        <$crate::PduError as $crate::PduErrorExt>::encode(ironrdp_core::function!(), $source)
+        <$crate::PduError as $crate::PduErrorExt>::encode($crate::ironrdp_core::function!(), $source)
     };
 }
 
@@ -25,12 +25,14 @@ macro_rules! pdu_other_err {
         $crate::PduError::new($context, $crate::PduErrorKind::Other { description: $description })
     }};
     ( source: $source:expr $(,)? ) => {{
-        pdu_other_err!(ironrdp_core::function!(), "", source: $source)
+        $crate::pdu_other_err!($crate::ironrdp_core::function!(), "", source: $source)
     }};
     ( $description:expr $(,)? ) => {{
-        pdu_other_err!(ironrdp_core::function!(), $description)
+        $crate::pdu_other_err!($crate::ironrdp_core::function!(), $description)
     }};
 }
+
+// FIXME: some of these macros should be in ironrdp_core, and some should be private to ironrdp_pdu.
 
 /// Asserts that constant expressions evaluate to `true`.
 ///
@@ -50,7 +52,7 @@ macro_rules! const_assert {
 #[macro_export]
 macro_rules! impl_pdu_pod {
     ($pdu_ty:ty) => {
-        impl ::ironrdp_core::IntoOwned for $pdu_ty {
+        impl $crate::ironrdp_core::IntoOwned for $pdu_ty {
             type Owned = Self;
 
             fn into_owned(self) -> Self::Owned {
@@ -58,9 +60,9 @@ macro_rules! impl_pdu_pod {
             }
         }
 
-        impl ironrdp_core::DecodeOwned for $pdu_ty {
+        impl $crate::ironrdp_core::DecodeOwned for $pdu_ty {
             fn decode_owned(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
-                <Self as ironrdp_core::Decode>::decode(src)
+                <Self as $crate::ironrdp_core::Decode>::decode(src)
             }
         }
     };
@@ -70,7 +72,7 @@ macro_rules! impl_pdu_pod {
 #[macro_export]
 macro_rules! impl_x224_pdu_pod {
     ($pdu_ty:ty) => {
-        impl ::ironrdp_core::IntoOwned for $pdu_ty {
+        impl $crate::ironrdp_core::IntoOwned for $pdu_ty {
             type Owned = Self;
 
             fn into_owned(self) -> Self::Owned {
@@ -78,9 +80,9 @@ macro_rules! impl_x224_pdu_pod {
             }
         }
 
-        impl ::ironrdp_core::DecodeOwned for $pdu_ty {
+        impl $crate::ironrdp_core::DecodeOwned for $pdu_ty {
             fn decode_owned(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
-                <$crate::x224::X224<Self> as ::ironrdp_core::Decode>::decode(src).map(|p| p.0)
+                <$crate::x224::X224<Self> as $crate::ironrdp_core::Decode>::decode(src).map(|p| p.0)
             }
         }
     };
@@ -92,10 +94,10 @@ macro_rules! impl_pdu_borrowing {
     ($pdu_ty:ident $(<$($lt:lifetime),+>)?, $owned_ty:ident) => {
         pub type $owned_ty = $pdu_ty<'static>;
 
-        impl ironrdp_core::DecodeOwned for $owned_ty {
+        impl $crate::ironrdp_core::DecodeOwned for $owned_ty {
             fn decode_owned(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
-                let pdu = <$pdu_ty $(<$($lt),+>)? as ::ironrdp_core::Decode>::decode(src)?;
-                Ok(::ironrdp_core::IntoOwned::into_owned(pdu))
+                let pdu = <$pdu_ty $(<$($lt),+>)? as $crate::ironrdp_core::Decode>::decode(src)?;
+                Ok($crate::ironrdp_core::IntoOwned::into_owned(pdu))
             }
         }
     };
@@ -107,10 +109,10 @@ macro_rules! impl_x224_pdu_borrowing {
     ($pdu_ty:ident $(<$($lt:lifetime),+>)?, $owned_ty:ident) => {
         pub type $owned_ty = $pdu_ty<'static>;
 
-        impl ::ironrdp_core::DecodeOwned for $owned_ty {
+        impl $crate::ironrdp_core::DecodeOwned for $owned_ty {
             fn decode_owned(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
-                let pdu = <$crate::x224::X224<$pdu_ty $(<$($lt),+>)?> as ::ironrdp_core::Decode>::decode(src).map(|r| r.0)?;
-                Ok(::ironrdp_core::IntoOwned::into_owned(pdu))
+                let pdu = <$crate::x224::X224<$pdu_ty $(<$($lt),+>)?> as $crate::ironrdp_core::Decode>::decode(src).map(|r| r.0)?;
+                Ok($crate::ironrdp_core::IntoOwned::into_owned(pdu))
             }
         }
     };

--- a/crates/ironrdp-svc/src/lib.rs
+++ b/crates/ironrdp-svc/src/lib.rs
@@ -7,11 +7,6 @@
 
 extern crate alloc;
 
-use ironrdp_pdu::x224::X224;
-// Re-export ironrdp_pdu crate for convenience
-#[rustfmt::skip] // do not re-order this pub use
-pub use ironrdp_pdu as pdu;
-
 use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
 use core::any::TypeId;
@@ -24,10 +19,24 @@ use ironrdp_core::{
     assert_obj_safe, decode_cursor, encode_buf, AsAny, DecodeResult, Encode, EncodeResult, ReadCursor, WriteBuf,
     WriteCursor,
 };
+use ironrdp_pdu::gcc::ChannelDef;
 use ironrdp_pdu::gcc::{ChannelName, ChannelOptions};
+use ironrdp_pdu::rdp::vc::ChannelControlFlags;
+use ironrdp_pdu::x224::X224;
 use ironrdp_pdu::{decode_err, mcs, PduResult};
-use pdu::gcc::ChannelDef;
-use pdu::rdp::vc::ChannelControlFlags;
+
+// Re-export ironrdp_pdu crate for convenience
+#[rustfmt::skip] // Do not re-order this pub use.
+pub use ironrdp_pdu as pdu;
+
+// TODO(#583): Remove once Teleport migrated to the newer item paths.
+#[doc(hidden)]
+#[deprecated(since = "0.1.0", note = "use ironrdp-core")]
+#[rustfmt::skip] // Do not re-order this pub use.
+pub use ironrdp_core::impl_as_any;
+
+// NOTE: We may re-consider moving some types dedicated to SVC out of ironrdp_pdu in some future major version bump.
+// The idea is to reduce the amount of code required when building a static/dynamic channel to a minimum.
 
 /// The integer type representing a static virtual channel ID.
 pub type StaticChannelId = u16;


### PR DESCRIPTION
Teleport is generating many errors when using the latest IronRDP crates.
This patch is re-exporting a few items from ironrdp_core so it’s easier for them to incrementally migrate to the newer versions.