### PR TITLE
fix(session): avoid panics when First fragmentation is missing

### DIFF
--- a/crates/ironrdp-session/src/fast_path.rs
+++ b/crates/ironrdp-session/src/fast_path.rs
@@ -431,9 +431,7 @@ impl CompleteData {
             Fragmentation::Last => {
                 self.append_data(data);
 
-                let complete_data = self.fragmented_data.take().unwrap();
-
-                Some(complete_data)
+                self.fragmented_data.take()
             }
         }
     }


### PR DESCRIPTION
When we hit `Last` fragmentation PDU and there was no `First` before `unwrap` will cause panic.
With this change we will simply skip invalid/incomplete frames the same way we do when we encounter `Single` after `First` or `Next` without `Last`.