### PR TITLE
ci(release-crates): also update fuzz/Cargo.lock

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -28,12 +28,36 @@ jobs:
           fetch-depth: 512
 
       - name: Run release-plz
+        id: release-plz
         uses: Devolutions/actions-public/release-plz@v1
         with:
           command: release-pr
           git-name: Devolutions Bot
           git-email: bot@devolutions.net
           github-token: ${{ secrets.DEVOLUTIONSBOT_WRITE_TOKEN }}
+
+      - name: Update fuzz/Cargo.lock
+        shell: pwsh
+        if: ${{ steps.release-plz.outputs.did-open-pr == 'true' }}
+        run: |
+          $prRaw = '${{ steps.release-plz.outputs.pr }}'
+          Write-Host "prRaw: $prRaw"
+
+          $pr = $prRaw | ConvertFrom-Json
+          Write-Host "pr: $pr"
+
+          Write-Host "Switch to branch $($pr.head_branch)"
+          git checkout "$($pr.head_branch)"
+
+          Write-Host "Update ./fuzz/Cargo.lock"
+          cargo update --manifest-path ./fuzz/Cargo.toml
+
+          Write-Host "Update last commit"
+          git add ./fuzz/Cargo.lock
+          git commit --amend --no-edit
+
+          Write-Host "Update the release pull request"
+          git push --force
 
   # Release unpublished packages.
   release:


### PR DESCRIPTION
We also need to update the Cargo.lock found in the fuzz folder:

![image](https://github.com/user-attachments/assets/15e403b8-2957-4cfd-9d95-7bd5d17a52bd)

Waiting for https://github.com/Devolutions/actions-public/pull/3