### PR TITLE
chore: update release-plz.toml configuration file

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -59,6 +59,7 @@ conventional_commits = true
 filter_unconventional = false
 filter_commits = false
 date_order = false
+protect_breaking_commits = true
 sort_commits = "oldest"
 
 commit_preprocessors = [
@@ -77,8 +78,6 @@ commit_parsers = [
   { message = "^test", skip = true },
   { message = "^ci", skip = true },
   { message = "^chore\\(release\\): prepare for", skip = true },
-  { message = "^chore\\(deps\\)", skip = true },
-  { message = "^build\\(deps\\)", skip = true },
   { footer = "^[Cc]hangelog: ?ignore", skip = true },
 
   { message = "(?i)security", group = "<!-- 0 -->Security" },

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -5,3 +5,17 @@ semver_check = true
 pr_branch_prefix = "release-plz/"
 pr_name = "chore(release): prepare for publishing"
 changelog_config = "cliff.toml"
+git_release_enable = false
+release_commits = "^(feat|docs|fix|build|perf)"
+
+[[package]]
+name = "ironrdp"
+git_release_enable = true
+
+[[package]]
+name = "ironrdp-client"
+git_release_enable = true
+
+[[package]]
+name = "ironrdp-tls"
+publish_features = ["rustls"]


### PR DESCRIPTION
- Only create release PR for features, bug fixes, documentation updates, build and dependencies changes, and performance improvements.
- Only create GitHub releases for ironrdp and ironrdp-client crates.
- Enable the rustls feature flag when publishing ironrdp-tls, otherwise the compilation will errors out.