### PR TITLE
chore(tools): update release-plz.toml

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -7,14 +7,30 @@ pr_name = "chore(release): prepare for publishing"
 changelog_config = "cliff.toml"
 release_commits = "^(feat|docs|fix|build|perf)"
 
+# Flagship crates for which we push a GitHub release.
 [[package]]
 name = "ironrdp"
 git_release_enable = true
-
 [[package]]
 name = "ironrdp-client"
 git_release_enable = true
 
+# ironrdp-tls does not compile if no backend is specified.
+# rustls is the most common backend, so we let cargo publish check with it.
 [[package]]
 name = "ironrdp-tls"
 publish_features = ["rustls"]
+
+# *-native crates may have all kinds of system requirements depending on the platform.
+# We can only check for the current platform when cargo publish is invoked, all the others are effectively unverified.
+# For this reason, it's not worth complexifying the release-crates.yml workflow.
+# We already verify all targets properly in the CI.
+[[package]]
+name = "ironrdp-rdpdr-native"
+publish_no_verify = true
+[[package]]
+name = "ironrdp-rdpsnd-native"
+publish_no_verify = true
+[[package]]
+name = "ironrdp-cliprdr-native"
+publish_no_verify = true


### PR DESCRIPTION
Pass `--no-verify` to `cargo publish` when publishing `*-native` crates.

`*-native` crates may have all kinds of system requirements depending on the platform. We can only check for the current platform when cargo publish is invoked, all the others are effectively unverified. For this reason, it's not worth complexifying the release-crates.yml workflow. We already verify all targets properly in the CI.

![image](https://github.com/user-attachments/assets/946f5588-7ed1-4ed4-b9ce-15ca1fb9dbff)