### PR TITLE
fix(web): allow clipboard callback to be set to null explicitly to disable clipboard

### DIFF
--- a/web-client/iron-remote-gui/src/services/wasm-bridge.service.ts
+++ b/web-client/iron-remote-gui/src/services/wasm-bridge.service.ts
@@ -43,7 +43,7 @@ export class WasmBridgeService {
     private keyboardActive: boolean = false;
     private keyboardUnicodeMode: boolean = false;
     private backendSupportsUnicodeKeyboardShortcuts: boolean | undefined = undefined;
-    private onRemoteClipboardChanged?: OnRemoteClipboardChanged;
+    private onRemoteClipboardChanged?: OnRemoteClipboardChanged | null;
     private onRemoteReceivedFormatList?: OnRemoteReceivedFormatsList;
     private onForceClipboardUpdate?: OnForceClipboardUpdate;
     private cursorHasOverride: boolean = false;
@@ -75,7 +75,7 @@ export class WasmBridgeService {
     }
 
     /// Callback to set the local clipboard content to data received from the remote.
-    setOnRemoteClipboardChanged(callback: OnRemoteClipboardChanged) {
+    setOnRemoteClipboardChanged(callback: OnRemoteClipboardChanged | null) {
         this.onRemoteClipboardChanged = callback;
     }
 


### PR DESCRIPTION
Sometimes in DVLS we want to be able to disable clipboard.

https://devolutions.slack.com/archives/C1FL0GS03/p1734031803626829