### PR TITLE
build(xtask): bump wabt to 1.0.36

### DIFF
--- a/xtask/src/bin_version.rs
+++ b/xtask/src/bin_version.rs
@@ -9,4 +9,4 @@ pub const GRCOV: CargoPackage = CargoPackage::new("grcov", "0.8.19");
 pub const WASM_PACK: CargoPackage = CargoPackage::new("wasm-pack", "0.12.1");
 pub const TYPOS_CLI: CargoPackage = CargoPackage::new("typos-cli", "1.16.23").with_binary_name("typos");
 
-pub const WABT_VERSION: &str = "1.0.33";
+pub const WABT_VERSION: &str = "1.0.36";

--- a/xtask/src/wasm.rs
+++ b/xtask/src/wasm.rs
@@ -61,7 +61,7 @@ fn install_wasm2wat(sh: &Shell) -> anyhow::Result<()> {
     } else if cfg!(target_os = "macos") {
         "macos-14"
     } else {
-        "ubuntu"
+        "ubuntu-20.04"
     };
 
     let url = format!(


### PR DESCRIPTION
https://github.com/WebAssembly/wabt/releases/download/1.0.33/wabt-1.0.33-macos-14.tar.gz is now 404.