### PR TITLE
fix(connector): make LicenseCache RefUnwindSafe

### DIFF
--- a/crates/ironrdp-connector/src/license_exchange.rs
+++ b/crates/ironrdp-connector/src/license_exchange.rs
@@ -1,6 +1,7 @@
 use super::{legacy, ConnectorError, ConnectorErrorExt};
 use crate::{encode_send_data_request, ConnectorResult, ConnectorResultExt as _, Sequence, State, Written};
 use core::fmt::Debug;
+use core::panic::RefUnwindSafe;
 use core::{fmt, mem};
 use ironrdp_core::WriteBuf;
 use ironrdp_pdu::rdp::server_license::{self, LicenseInformation, LicensePdu, ServerLicenseError};
@@ -62,7 +63,8 @@ pub struct LicenseExchangeSequence {
     pub license_cache: Arc<dyn LicenseCache>,
 }
 
-pub trait LicenseCache: Sync + Send + Debug {
+// Use RefUnwindSafe so that types that embed LicenseCache remain UnwindSafe
+pub trait LicenseCache: Sync + Send + Debug + RefUnwindSafe {
     fn get_license(&self, license_info: LicenseInformation) -> ConnectorResult<Option<Vec<u8>>>;
     fn store_license(&self, license_info: LicenseInformation) -> ConnectorResult<()>;
 }


### PR DESCRIPTION
This fixes commit dd221bf ("feat: support license caching (#634)") and semver-checks is now happy:

    type ProcessorOutput is no longer UnwindSafe, in /tmp/.tmppi9kAf/IronRDP/crates/ironrdp-session/src/x224/mod.rs:15