### PR TITLE
fix: use 'OR' for SPDX license expression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 
 [workspace.package]
 edition = "2021"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 homepage = "https://github.com/Devolutions/IronRDP"
 repository = "https://github.com/Devolutions/IronRDP"
 authors = ["Devolutions Inc. <infos@devolutions.net>", "Teleport <goteleport.com>"]


### PR DESCRIPTION
Replacing deprecated '/' operator in SPDX license expression with 'OR' https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/#d42-disjunctive-or-operator