### PR TITLE
fix(cliprdr-native): handle `WM_ACTIVATEAPP` in `clipboard_subproc`

### DIFF
--- a/crates/ironrdp-cliprdr-native/src/windows/clipboard_impl.rs
+++ b/crates/ironrdp-cliprdr-native/src/windows/clipboard_impl.rs
@@ -9,7 +9,7 @@ use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
 use windows::Win32::System::DataExchange::GetClipboardOwner;
 use windows::Win32::UI::Shell::DefSubclassProc;
 use windows::Win32::UI::WindowsAndMessaging::{
-    KillTimer, SetTimer, WA_INACTIVE, WM_ACTIVATE, WM_CLIPBOARDUPDATE, WM_DESTROY, WM_RENDERALLFORMATS,
+    KillTimer, SetTimer, WA_INACTIVE, WM_ACTIVATE, WM_ACTIVATEAPP, WM_CLIPBOARDUPDATE, WM_DESTROY, WM_RENDERALLFORMATS,
     WM_RENDERFORMAT, WM_TIMER,
 };
 
@@ -328,7 +328,7 @@ pub(crate) unsafe extern "system" fn clipboard_subproc(
 
     match msg {
         // We need to keep track of window state to distinguish between local and remote copy
-        WM_ACTIVATE => ctx.window_is_active = wparam.0 != WA_INACTIVE as usize, // `as` conversion is fine for constants
+        WM_ACTIVATE | WM_ACTIVATEAPP => ctx.window_is_active = wparam.0 != WA_INACTIVE as usize, // `as` conversion is fine for constants
         // Sent by the OS when OS clipboard content is changed
         WM_CLIPBOARDUPDATE => {
             // SAFETY: `GetClipboardOwner` is always safe to call.


### PR DESCRIPTION
This PR adds handling of `WM_ACTIVATEAPP` in `clipboard_subproc`. Previously, the function handled only `WM_ACTIVATE`. MSDN references:
* WM_ACTIVATE: https://learn.microsoft.com/ru-ru/windows/win32/inputdev/wm-activate ( WM_ACTIVATEAPP: https://learn.microsoft.com/en-us/windows/win32/winmsg/wm-activateapp As you can see from the general description they are quite similar.

During the tests, I was only receiving `WM_ACTIVATEAPP.` To investigate the issue I went to see how Windows handles them. I found that Windows just straight-up handles those messages as they are the same:
* https://github.com/tongzx/nt5src/blob/daad8a087a4e75422ec96b7911f1df4669989611/Source/XPSP1/NT/shell/comctl32/v6/prsht.c#L3873-L3887
* https://github.com/tongzx/nt5src/blob/daad8a087a4e75422ec96b7911f1df4669989611/Source/XPSP1/NT/shell/comctl32/v5/prsht.c#L3954-L3968
* https://github.com/tongzx/nt5src/blob/daad8a087a4e75422ec96b7911f1df4669989611/Source/XPSP1/NT/multimedia/dshow/filters/image/video/window.cpp#L176-L203
* https://github.com/tongzx/nt5src/blob/daad8a087a4e75422ec96b7911f1df4669989611/Source/XPSP1/NT/base/mvdm/tools/c932/inc/scrnsave.h#L96-L106. 

The bug is in IronVNC repo - https://github.com/Devolutions/IronVNC/issues/687