### PR TITLE
fix(pdu): fix FastPathHeader minimal size

### DIFF
--- a/crates/ironrdp-pdu/src/basic_output/fast_path.rs
+++ b/crates/ironrdp-pdu/src/basic_output/fast_path.rs
@@ -39,7 +39,10 @@ impl FastPathHeader {
     }
 
     fn minimal_size(&self) -> usize {
-        Self::FIXED_PART_SIZE + per::sizeof_length(self.data_length as u16)
+        // it may then be +2 if > 0x7f
+        let len = self.data_length + Self::FIXED_PART_SIZE + 1;
+
+        Self::FIXED_PART_SIZE + per::sizeof_length(len as u16)
     }
 }
 

--- a/crates/ironrdp-pdu/src/basic_output/fast_path/tests.rs
+++ b/crates/ironrdp-pdu/src/basic_output/fast_path/tests.rs
@@ -140,3 +140,19 @@ fn to_buffer_correctly_serializes_fast_path_update() {
 fn buffer_length_is_correct_for_fast_path_update() {
     assert_eq!(FAST_PATH_UPDATE_PDU_BUFFER.len(), FAST_PATH_UPDATE_PDU.size());
 }
+
+#[test]
+fn buffer_size_boundary_fast_path_update() {
+    let fph = FastPathHeader {
+        flags: EncryptionFlags::ENCRYPTED,
+        data_length: 125,
+        forced_long_length: false,
+    };
+    assert_eq!(fph.size(), 2);
+    let fph = FastPathHeader {
+        flags: EncryptionFlags::ENCRYPTED,
+        data_length: 126,
+        forced_long_length: false,
+    };
+    assert_eq!(fph.size(), 3);
+}


### PR DESCRIPTION
The minimal_size() logic didn't properly take into account the overall PDU size.

This fixes random error/disconnect in client.