### PR TITLE
fix(client): set back control flow to wait

### DIFF
--- a/crates/ironrdp-client/src/app.rs
+++ b/crates/ironrdp-client/src/app.rs
@@ -98,6 +98,7 @@ impl ApplicationHandler<RdpOutputEvent> for App {
             } else {
                 self.send_resize_event();
                 self.resize_timeout = None;
+                event_loop.set_control_flow(ControlFlow::Wait);
             }
         }
     }


### PR DESCRIPTION
After resize event is sent, we should switch back to a normal mode, instead of wait-duration(0)/polling.