### PR TITLE
fix(pdu): TS_RFX_CHANNELT width/height SHOULD be within range

### DIFF
--- a/crates/ironrdp-pdu/src/codecs/rfx.rs
+++ b/crates/ironrdp-pdu/src/codecs/rfx.rs
@@ -15,9 +15,7 @@ pub use self::data_messages::{
     ContextPdu, EntropyAlgorithm, FrameBeginPdu, FrameEndPdu, OperatingMode, Quant, RegionPdu, RfxRectangle, Tile,
     TileSetPdu,
 };
-pub use self::header_messages::{
-    ChannelsPdu, CodecVersionsPdu, RfxChannel, RfxChannelHeight, RfxChannelWidth, SyncPdu,
-};
+pub use self::header_messages::{ChannelsPdu, CodecVersionsPdu, RfxChannel, SyncPdu};
 
 const CODEC_ID: u8 = 1;
 const CHANNEL_ID_FOR_CONTEXT: u8 = 0xFF;

--- a/crates/ironrdp-pdu/src/codecs/rfx/header_messages.rs
+++ b/crates/ironrdp-pdu/src/codecs/rfx/header_messages.rs
@@ -155,46 +155,8 @@ impl<'de> Decode<'de> for ChannelsPdu {
 /// [2.2.2.1.3]: https://learn.microsoft.com/pt-br/openspecs/windows_protocols/ms-rdprfx/4060f07e-9d73-454d-841e-131a93aca675
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct RfxChannel {
-    pub width: RfxChannelWidth,
-    pub height: RfxChannelHeight,
-}
-
-/// A 16-bit, signed integer within the range of 1 to 4096
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[repr(transparent)]
-pub struct RfxChannelWidth(i16);
-
-impl RfxChannelWidth {
-    pub fn new(value: i16) -> Self {
-        Self(value)
-    }
-
-    pub fn as_u16(self) -> u16 {
-        u16::try_from(self.0).expect("integer within the range of 1 to 4096")
-    }
-
-    pub fn get(self) -> i16 {
-        self.0
-    }
-}
-
-/// A 16-bit, signed integer within the range of 1 to 2048
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[repr(transparent)]
-pub struct RfxChannelHeight(i16);
-
-impl RfxChannelHeight {
-    pub fn new(value: i16) -> Self {
-        Self(value)
-    }
-
-    pub fn as_u16(self) -> u16 {
-        u16::try_from(self.0).expect("integer within the range of 1 to 2048")
-    }
-
-    pub fn get(self) -> i16 {
-        self.0
-    }
+    pub width: i16,
+    pub height: i16,
 }
 
 impl RfxChannel {
@@ -208,8 +170,8 @@ impl Encode for RfxChannel {
         ensure_fixed_part_size!(in: dst);
 
         dst.write_u8(CHANNEL_ID);
-        dst.write_i16(self.width.get());
-        dst.write_i16(self.height.get());
+        dst.write_i16(self.width);
+        dst.write_i16(self.height);
 
         Ok(())
     }
@@ -232,8 +194,8 @@ impl<'de> Decode<'de> for RfxChannel {
             return Err(invalid_field_err!("channelId", "Invalid channel ID"));
         }
 
-        let width = RfxChannelWidth::new(src.read_i16());
-        let height = RfxChannelHeight::new(src.read_i16());
+        let width = src.read_i16();
+        let height = src.read_i16();
 
         Ok(Self { width, height })
     }

--- a/crates/ironrdp-pdu/src/codecs/rfx/header_messages.rs
+++ b/crates/ironrdp-pdu/src/codecs/rfx/header_messages.rs
@@ -232,17 +232,8 @@ impl<'de> Decode<'de> for RfxChannel {
             return Err(invalid_field_err!("channelId", "Invalid channel ID"));
         }
 
-        let width = src.read_i16();
-        if !(1..=4096).contains(&width) {
-            return Err(invalid_field_err!("width", "Invalid channel width"));
-        }
-        let width = RfxChannelWidth::new(width);
-
-        let height = src.read_i16();
-        if !(1..=2048).contains(&height) {
-            return Err(invalid_field_err!("height", "Invalid channel height"));
-        }
-        let height = RfxChannelHeight::new(height);
+        let width = RfxChannelWidth::new(src.read_i16());
+        let height = RfxChannelHeight::new(src.read_i16());
 
         Ok(Self { width, height })
     }

--- a/crates/ironrdp-server/src/encoder/rfx.rs
+++ b/crates/ironrdp-server/src/encoder/rfx.rs
@@ -4,7 +4,7 @@ use ironrdp_graphics::rfx_encode_component;
 use ironrdp_graphics::rlgr::RlgrError;
 use ironrdp_pdu::codecs::rfx::{
     self, Block, ChannelsPdu, CodecChannel, CodecVersionsPdu, FrameBeginPdu, FrameEndPdu, OperatingMode, Quant,
-    RegionPdu, RfxChannel, RfxChannelHeight, RfxChannelWidth, SyncPdu, TileSetPdu,
+    RegionPdu, RfxChannel, SyncPdu, TileSetPdu,
 };
 use ironrdp_pdu::rdp::capability_sets::EntropyBits;
 use ironrdp_pdu::WriteCursor;
@@ -42,8 +42,8 @@ impl RfxEncoder {
         Block::CodecChannel(CodecChannel::Context(context)).encode(&mut cursor)?;
 
         let channels = ChannelsPdu(vec![RfxChannel {
-            width: RfxChannelWidth::new(cast_length!("width", width)?),
-            height: RfxChannelHeight::new(cast_length!("height", height)?),
+            width: cast_length!("width", width)?,
+            height: cast_length!("height", height)?,
         }]);
         Block::Channels(channels).encode(&mut cursor)?;
 

--- a/crates/ironrdp-session/src/rfx.rs
+++ b/crates/ironrdp-session/src/rfx.rs
@@ -108,8 +108,8 @@ impl DecodingContext {
         destination: &InclusiveRectangle,
     ) -> SessionResult<(FrameId, InclusiveRectangle)> {
         let channel = self.channels.0.first().unwrap();
-        let width = channel.width.as_u16();
-        let height = channel.height.as_u16();
+        let width = channel.width.try_into().map_err(|_| general_err!("invalid width"))?;
+        let height = channel.height.try_into().map_err(|_| general_err!("invalid height"))?;
         let entropy_algorithm = self.context.entropy_algorithm;
 
         let region: rfx::Block<'_> = decode_cursor(input).map_err(|e| custom_err!("decode region", e))?;

--- a/crates/ironrdp-testsuite-core/tests/pdu/rfx.rs
+++ b/crates/ironrdp-testsuite-core/tests/pdu/rfx.rs
@@ -253,8 +253,8 @@ const FRAME_END_PDU: Block<'_> = Block::CodecChannel(CodecChannel::FrameEnd(Fram
 
 lazy_static::lazy_static! {
     static ref CHANNELS_PDU: Block<'static> = Block::Channels(ChannelsPdu(vec![
-        RfxChannel { width: RfxChannelWidth::new(64), height: RfxChannelHeight::new(64) },
-        RfxChannel { width: RfxChannelWidth::new(32), height: RfxChannelHeight::new(32) }
+        RfxChannel { width: 64, height: 64 },
+        RfxChannel { width: 32, height: 32 }
     ]));
     static ref REGION_PDU: Block<'static> = Block::CodecChannel(CodecChannel::Region(RegionPdu {
         rectangles: vec![


### PR DESCRIPTION
According to the specification, the value does not need to be in the range: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdprfx/4060f07e-9d73-454d-841e-131a93aca675

(the ironrdp-server can send larger values)