### PR TITLE
docs(ffi): document how to build the .NET bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1508,7 +1508,7 @@ dependencies = [
 
 [[package]]
 name = "ffi"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "diplomat",
  "diplomat-runtime",

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffi"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
 publish = false
 

--- a/ffi/README.md
+++ b/ffi/README.md
@@ -1,0 +1,21 @@
+# IronRDP FFI
+
+[Diplomat]-based FFI for IronRDP.
+
+Currently, only the .NET target is officially supported.
+
+## How to build
+
+- Install required tools: `cargo xtask ffi install`
+  - For .NET, note that `dotnet` is also a requirement that you will need to install on your own.
+
+- Build the shared library: `cargo xtask ffi build` (alternatively, in release mode: `cargo xtask ffi build --release`)
+
+- Build the bindings: `cargo xtask ffi bindings`
+
+At this point, you may build and run the examples for .NET:
+
+- `dotnet run --project Devolutions.IronRdp.ConnectExample`
+- `dotnet run --project Devolutions.IronRdp.AvaloniaExample`
+
+[Diplomat]: https://github.com/rust-diplomat/diplomat

--- a/xtask/src/bin_version.rs
+++ b/xtask/src/bin_version.rs
@@ -8,5 +8,6 @@ pub const CARGO_LLVM_COV: CargoPackage = CargoPackage::new("cargo-llvm-cov", "0.
 pub const GRCOV: CargoPackage = CargoPackage::new("grcov", "0.8.20");
 pub const WASM_PACK: CargoPackage = CargoPackage::new("wasm-pack", "0.13.1");
 pub const TYPOS_CLI: CargoPackage = CargoPackage::new("typos-cli", "1.29.5").with_binary_name("typos");
+pub const DIPLOMAT_TOOL: CargoPackage = CargoPackage::new("diplomat-tool", "0.7.1");
 
 pub const WABT_VERSION: &str = "1.0.36";

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -36,6 +36,7 @@ TASKS:
   web check               Ensure Web Client is building without error
   web install             Install dependencies required to build and run Web Client
   web run                 Run SvelteKit-based standalone Web Client
+  ffi install             Install all requirements for ffi tasks
   ffi build [--release]   Build DLL for FFI (default is debug)
   ffi bindings [--skip-dotnet-build]            
                           Generate C# bindings for FFI, optionally skipping the .NET build
@@ -88,6 +89,7 @@ pub enum Action {
     WebCheck,
     WebInstall,
     WebRun,
+    FfiInstall,
     FfiBuildDll {
         release: bool,
     },
@@ -162,6 +164,7 @@ pub fn parse_args() -> anyhow::Result<Args> {
                 None => Action::ShowHelp,
             },
             Some("ffi") => match args.subcommand()?.as_deref() {
+                Some("install") => Action::FfiInstall,
                 Some("build") => Action::FfiBuildDll {
                     release: args.contains("--release"),
                 },

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -112,7 +112,8 @@ fn main() -> anyhow::Result<()> {
         Action::WebCheck => web::check(&sh)?,
         Action::WebInstall => web::install(&sh)?,
         Action::WebRun => web::run(&sh)?,
-        Action::FfiBuildDll { release: debug } => ffi::build_dynamic_lib(&sh, debug)?,
+        Action::FfiInstall => ffi::install(&sh)?,
+        Action::FfiBuildDll { release } => ffi::build_dynamic_lib(&sh, release)?,
         Action::FfiBuildBindings { skip_dotnet_build } => ffi::build_bindings(&sh, skip_dotnet_build)?,
     }
 


### PR DESCRIPTION
Two commits:
- Adds `cargo xtask ffi install` task for installing the correct version of `diplomat-tool`, in the local root.
- Documents how to build the .NET bindings and the examples.

I noticed the examples were broken. Future work includes: fixing the examples and extending the CI to check the compilation of the .NET examples.