### PR TITLE
docs(ffi): fix compilation of examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,35 @@ jobs:
       - name: Lock files
         run: cargo xtask check locks -v
 
+  ffi:
+    name: FFI
+    runs-on: ubuntu-latest
+    needs: formatting
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2.7.3
+
+      - name: Binary cache
+        uses: actions/cache@v4
+        with:
+          path: ./.cargo/local_root/bin
+          key: ${{ runner.os }}-bin-${{ github.job }}-${{ hashFiles('xtask/src/bin_version.rs') }}
+
+      - name: Prepare runner
+        run: cargo xtask ffi install -v
+
+      - name: Build native library
+        run: cargo xtask ffi build -v
+
+      - name: Generate bindings
+        run: cargo xtask ffi bindings -v
+
+      - name: Build .NET projects
+        run: cd ./ffi/dotnet && dotnet build
+
   success:
     name: Success
     runs-on: ubuntu-latest
@@ -181,6 +210,7 @@ jobs:
       - checks
       - fuzz
       - web
+      - ffi
 
     steps:
       - name: Check success

--- a/ffi/dotnet/Devolutions.IronRdp.AvaloniaExample/Devolutions.IronRdp.AvaloniaExample.csproj
+++ b/ffi/dotnet/Devolutions.IronRdp.AvaloniaExample/Devolutions.IronRdp.AvaloniaExample.csproj
@@ -9,7 +9,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="11.0.10" />
     <PackageReference Include="Avalonia.Desktop" Version="11.0.10" />
@@ -25,6 +24,4 @@
   <ItemGroup Condition="'$([System.OperatingSystem]::IsWindows())'">
     <PackageReference Include="Avalonia.Win32" Version="11.0.10" />
   </ItemGroup>
-
-
 </Project>

--- a/ffi/dotnet/Devolutions.IronRdp.AvaloniaExample/MainWindow.axaml.cs
+++ b/ffi/dotnet/Devolutions.IronRdp.AvaloniaExample/MainWindow.axaml.cs
@@ -48,8 +48,6 @@ public partial class MainWindow : Window
         AvaloniaXamlLoader.Load(this);
     }
 
-    bool _resizeTaskStarted = false;
-
     protected override void OnSizeChanged(SizeChangedEventArgs e)
     {
         base.OnSizeChanged(e);
@@ -94,10 +92,11 @@ public partial class MainWindow : Window
         var config = BuildConfig(username, password, domain, _renderModel.Width, _renderModel.Height);
 
         CliprdrBackendFactory? factory = null;
-        var handle = GetWindowHandle();
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && handle != null)
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            _cliprdr = WinCliprdr.New(handle.Value);
+            _cliprdr = WinCliprdr.New();
+
             if (_cliprdr != null)
             {
                 factory = _cliprdr.BackendFactory();

--- a/ffi/dotnet/Devolutions.IronRdp.ConnectExample/Program.cs
+++ b/ffi/dotnet/Devolutions.IronRdp.ConnectExample/Program.cs
@@ -20,9 +20,10 @@ namespace Devolutions.IronRdp.ConnectExample
             var username = arguments["--username"];
             var password = arguments["--password"];
             var domain = arguments["--domain"];
+
             try
             {
-                var (res, framed) = await Connection.Connect(buildConfig(serverName, username, password, domain, 1980, 1080), serverName);
+                var (res, framed) = await Connection.Connect(buildConfig(serverName, username, password, domain, 1980, 1080), serverName, null);
                 var decodedImage = DecodedImage.New(PixelFormat.RgbA32, res.GetDesktopSize().GetWidth(), res.GetDesktopSize().GetHeight());
                 var activeState = ActiveStage.New(res);
                 var keepLooping = true;


### PR DESCRIPTION
Fixes compilation of .NET examples in the first commit, and adds CI checks in the second commit.