### PR TITLE
feat(cliprdr)!: add on_ready() callback

### DIFF
--- a/crates/ironrdp-cliprdr-native/src/stub.rs
+++ b/crates/ironrdp-cliprdr-native/src/stub.rs
@@ -54,6 +54,8 @@ impl CliprdrBackend for StubCliprdrBackend {
         ".cliprdr"
     }
 
+    fn on_ready(&mut self) {}
+
     fn client_capabilities(&self) -> ClipboardGeneralCapabilityFlags {
         // No additional capabilities yet
         ClipboardGeneralCapabilityFlags::empty()

--- a/crates/ironrdp-cliprdr-native/src/windows/cliprdr_backend.rs
+++ b/crates/ironrdp-cliprdr-native/src/windows/cliprdr_backend.rs
@@ -54,6 +54,8 @@ impl CliprdrBackend for WinCliprdrBackend {
         ClipboardGeneralCapabilityFlags::empty()
     }
 
+    fn on_ready(&mut self) {}
+
     fn on_process_negotiated_capabilities(&mut self, capabilities: ClipboardGeneralCapabilityFlags) {
         self.send_event(BackendEvent::DowngradedCapabilities(capabilities))
     }

--- a/crates/ironrdp-cliprdr/src/backend.rs
+++ b/crates/ironrdp-cliprdr/src/backend.rs
@@ -60,6 +60,9 @@ pub trait CliprdrBackend: AsAny + core::fmt::Debug + Send {
     /// [crate::Cliprdr] capabilities.
     fn client_capabilities(&self) -> ClipboardGeneralCapabilityFlags;
 
+    /// Called by [crate::Cliprdr] when it is ready to process clipboard data (channel initialized)
+    fn on_ready(&mut self);
+
     /// Processes signal to start clipboard copy sequence.
     ///
     /// Trait implementer is responsible for gathering its list of available [`ClipboardFormat`]

--- a/crates/ironrdp-cliprdr/src/lib.rs
+++ b/crates/ironrdp-cliprdr/src/lib.rs
@@ -154,6 +154,7 @@ impl<R: Role> Cliprdr<R> {
                     if self.state == CliprdrState::Initialization {
                         info!("CLIPRDR(clipboard) virtual channel has been initialized");
                         self.state = CliprdrState::Ready;
+                        self.backend.on_ready();
                     } else {
                         info!("CLIPRDR(clipboard) Remote has received format list successfully");
                     }
@@ -173,6 +174,7 @@ impl<R: Role> Cliprdr<R> {
         if R::is_server() && self.state == CliprdrState::Initialization {
             info!("CLIPRDR(clipboard) virtual channel has been initialized");
             self.state = CliprdrState::Ready;
+            self.backend.on_ready();
         }
 
         let formats = format_list.get_formats(self.are_long_format_names_enabled())?;

--- a/crates/ironrdp-web/src/clipboard/mod.rs
+++ b/crates/ironrdp-web/src/clipboard/mod.rs
@@ -540,6 +540,8 @@ impl CliprdrBackend for WasmClipboardBackend {
         ClipboardGeneralCapabilityFlags::empty()
     }
 
+    fn on_ready(&mut self) {}
+
     fn on_request_format_list(&mut self) {
         // Initial clipboard is assumed to be empty on WASM (TODO: This is only relevant for Firefox?)
         self.send_event(WasmClipboardBackendMessage::ForceClipboardUpdate);


### PR DESCRIPTION
Give a hint to the backend when the channel is actually connected & ready to process messages.