### PR TITLE
refactor(server): make UpdateEncoder::update() an iterator 

### DIFF
--- a/crates/ironrdp-server/Cargo.toml
+++ b/crates/ironrdp-server/Cargo.toml
@@ -13,7 +13,6 @@ categories.workspace = true
 
 [lib]
 doctest = true
-test = false
 
 [features]
 default = ["rayon"]

--- a/crates/ironrdp-server/Cargo.toml
+++ b/crates/ironrdp-server/Cargo.toml
@@ -13,6 +13,7 @@ categories.workspace = true
 
 [lib]
 doctest = true
+test = false
 
 [features]
 default = ["rayon"]

--- a/crates/ironrdp-server/src/encoder/bitmap.rs
+++ b/crates/ironrdp-server/src/encoder/bitmap.rs
@@ -7,6 +7,7 @@ use ironrdp_pdu::geometry::InclusiveRectangle;
 use crate::BitmapUpdate;
 
 // PERF: we could also remove the need for this buffer
+#[derive(Clone)]
 pub(crate) struct BitmapEncoder {
     buffer: Vec<u8>,
 }

--- a/crates/ironrdp-server/src/encoder/fast_path.rs
+++ b/crates/ironrdp-server/src/encoder/fast_path.rs
@@ -1,0 +1,111 @@
+use core::{cmp, fmt};
+
+use ironrdp_pdu::{
+    fast_path::{EncryptionFlags, FastPathHeader, FastPathUpdatePdu, Fragmentation, UpdateCode},
+    Encode, WriteCursor,
+};
+
+// this is the maximum amount of data (not including headers) we can send in a single TS_FP_UPDATE_PDU
+const MAX_FASTPATH_UPDATE_SIZE: usize = 16_374;
+
+const FASTPATH_HEADER_SIZE: usize = 6;
+
+pub(crate) struct UpdateFragmenterOwned {
+    code: UpdateCode,
+    index: usize,
+    len: usize,
+}
+
+pub(crate) struct UpdateFragmenter<'a> {
+    code: UpdateCode,
+    index: usize,
+    data: &'a [u8],
+}
+
+impl fmt::Debug for UpdateFragmenter<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UpdateFragmenter")
+            .field("len", &self.data.len())
+            .finish()
+    }
+}
+
+impl<'a> UpdateFragmenter<'a> {
+    pub(crate) fn new(code: UpdateCode, data: &'a [u8]) -> Self {
+        Self { code, index: 0, data }
+    }
+
+    pub(crate) fn into_owned(self) -> UpdateFragmenterOwned {
+        UpdateFragmenterOwned {
+            code: self.code,
+            index: self.index,
+            len: self.data.len(),
+        }
+    }
+
+    pub(crate) fn from_owned(res: UpdateFragmenterOwned, buffer: &'a [u8]) -> UpdateFragmenter<'a> {
+        Self {
+            code: res.code,
+            index: res.index,
+            data: &buffer[0..res.len],
+        }
+    }
+
+    pub(crate) fn size_hint(&self) -> usize {
+        FASTPATH_HEADER_SIZE + cmp::min(self.data.len(), MAX_FASTPATH_UPDATE_SIZE)
+    }
+
+    pub(crate) fn next(&mut self, dst: &mut [u8]) -> Option<usize> {
+        let (consumed, written) = self.encode_next(dst)?;
+        self.data = &self.data[consumed..];
+        self.index = self.index.checked_add(1)?;
+        Some(written)
+    }
+
+    fn encode_next(&mut self, dst: &mut [u8]) -> Option<(usize, usize)> {
+        match self.data.len() {
+            0 => None,
+
+            1..=MAX_FASTPATH_UPDATE_SIZE => {
+                let frag = if self.index > 0 {
+                    Fragmentation::Last
+                } else {
+                    Fragmentation::Single
+                };
+
+                self.encode_fastpath(frag, self.data, dst)
+                    .map(|written| (self.data.len(), written))
+            }
+
+            _ => {
+                let frag = if self.index > 0 {
+                    Fragmentation::Next
+                } else {
+                    Fragmentation::First
+                };
+
+                self.encode_fastpath(frag, &self.data[..MAX_FASTPATH_UPDATE_SIZE], dst)
+                    .map(|written| (MAX_FASTPATH_UPDATE_SIZE, written))
+            }
+        }
+    }
+
+    fn encode_fastpath(&self, frag: Fragmentation, data: &[u8], dst: &mut [u8]) -> Option<usize> {
+        let mut cursor = WriteCursor::new(dst);
+
+        let update = FastPathUpdatePdu {
+            fragmentation: frag,
+            update_code: self.code,
+            compression_flags: None,
+            compression_type: None,
+            data,
+        };
+
+        let header = FastPathHeader::new(EncryptionFlags::empty(), update.size());
+
+        header.encode(&mut cursor).ok()?;
+        update.encode(&mut cursor).ok()?;
+
+        Some(cursor.pos())
+    }
+}

--- a/crates/ironrdp-server/src/encoder/rfx.rs
+++ b/crates/ironrdp-server/src/encoder/rfx.rs
@@ -11,7 +11,7 @@ use ironrdp_pdu::WriteCursor;
 
 use crate::BitmapUpdate;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct RfxEncoder {
     entropy_algorithm: rfx::EntropyAlgorithm,
 }

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -426,12 +426,12 @@ impl RdpServer {
         let mut fragmenter = match update {
             DisplayUpdate::Bitmap(bitmap) => {
                 let (enc, res) = task::spawn_blocking(move || {
-                    let res = time_warn!("Encoding bitmap", 10, encoder.bitmap(bitmap).map(|r| r.into_owned()));
+                    let res = time_warn!("Encoding bitmap", 10, encoder.bitmap(bitmap));
                     (encoder, res)
                 })
                 .await?;
                 encoder = enc;
-                res.map(|r| encoder.fragmenter_from_owned(r))
+                res
             }
             DisplayUpdate::PointerPosition(pos) => encoder.pointer_position(pos),
             DisplayUpdate::Resize(desktop_size) => {

--- a/crates/ironrdp-testsuite-core/tests/main.rs
+++ b/crates/ironrdp-testsuite-core/tests/main.rs
@@ -21,5 +21,6 @@ mod pcb;
 mod pdu;
 mod rdcleanpath;
 mod rdpsnd;
+mod server;
 mod server_name;
 mod session;

--- a/crates/ironrdp-testsuite-core/tests/server/fast_path.rs
+++ b/crates/ironrdp-testsuite-core/tests/server/fast_path.rs
@@ -1,0 +1,1 @@
+../../../ironrdp-server/src/encoder/fast_path.rs

--- a/crates/ironrdp-testsuite-core/tests/server/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/server/mod.rs
@@ -1,0 +1,1 @@
+mod fast_path;


### PR DESCRIPTION
A single display update can now result in multiple commands / update
code (FastPathUpdate).

The update dispatching and bitmap encoding is now done by the
UpdateEncoder itself.

(preliminary patches from #670)