### PR TITLE
fix(rdpsnd): send client formats that match server

### DIFF
--- a/crates/ironrdp-rdpsnd/src/client.rs
+++ b/crates/ironrdp-rdpsnd/src/client.rs
@@ -94,6 +94,8 @@ impl Rdpsnd {
     }
 
     pub fn client_formats(&mut self) -> PduResult<RdpsndSvcMessages> {
+        // Windows seems to be confused if the client replies with more formats, or unknown formats (e.g.: opus).
+        // We ensure to only send supported formats in common with the server.
         let server_format: HashSet<_> = self
             .server_format
             .as_ref()

--- a/crates/ironrdp-rdpsnd/src/pdu/mod.rs
+++ b/crates/ironrdp-rdpsnd/src/pdu/mod.rs
@@ -208,7 +208,7 @@ impl fmt::Display for WaveFormat {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct AudioFormat {
     pub format: WaveFormat,
     pub n_channels: u16,


### PR DESCRIPTION
Windows seems to be confused if the client replies with more formats, or unknown formats (opus).