### PR TITLE
refactor(client): fix name of client address field

### DIFF
--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -132,7 +132,7 @@ async fn connect(
     let mut framed = ironrdp_tokio::TokioFramed::new(stream);
 
     let mut connector = connector::ClientConnector::new(config.connector.clone())
-        .with_server_addr(server_addr)
+        .with_client_addr(server_addr)
         .with_static_channel(
             ironrdp::dvc::DrdynvcClient::new().with_dynamic_channel(DisplayControlClient::new(|_| Ok(Vec::new()))),
         )
@@ -335,7 +335,7 @@ where
             .parse()
             .map_err(|e| connector::custom_err!("failed to parse server address sent by proxy", e))?;
 
-        connector.attach_server_addr(server_addr);
+        connector.attach_client_addr(server_addr);
 
         let connector::ClientConnectorState::ConnectionInitiationWaitConfirm { .. } = connector.state else {
             return Err(connector::general_err!("invalid connector state (wait confirm)"));

--- a/crates/ironrdp-testsuite-extra/tests/tests.rs
+++ b/crates/ironrdp-testsuite-extra/tests/tests.rs
@@ -198,7 +198,7 @@ where
                 let addr = rx.await.unwrap().unwrap();
                 let tcp_stream = TcpStream::connect(addr).await.expect("TCP connect");
                 let mut framed = ironrdp_tokio::TokioFramed::new(tcp_stream);
-                let mut connector = connector::ClientConnector::new(client_config).with_server_addr(addr);
+                let mut connector = connector::ClientConnector::new(client_config).with_client_addr(addr);
                 let should_upgrade = ironrdp_async::connect_begin(&mut framed, &mut connector)
                     .await
                     .expect("begin connection");

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -1059,7 +1059,7 @@ where
             .parse()
             .context("failed to parse server address sent by proxy")?;
 
-        connector.attach_server_addr(server_addr);
+        connector.attach_client_addr(server_addr);
 
         let connector::ClientConnectorState::ConnectionInitiationWaitConfirm { .. } = connector.state else {
             return Err(anyhow::Error::msg("invalid connector state (wait confirm)").into());

--- a/crates/ironrdp/examples/screenshot.rs
+++ b/crates/ironrdp/examples/screenshot.rs
@@ -239,7 +239,7 @@ fn connect(
 
     let mut framed = ironrdp_blocking::Framed::new(tcp_stream);
 
-    let mut connector = connector::ClientConnector::new(config).with_server_addr(server_addr);
+    let mut connector = connector::ClientConnector::new(config).with_client_addr(server_addr);
 
     let should_upgrade = ironrdp_blocking::connect_begin(&mut framed, &mut connector).context("begin connection")?;
 

--- a/ffi/dotnet/Devolutions.IronRdp/Generated/ClientConnector.cs
+++ b/ffi/dotnet/Devolutions.IronRdp/Generated/ClientConnector.cs
@@ -59,7 +59,7 @@ public partial class ClientConnector: IDisposable
     /// Must use
     /// </summary>
     /// <exception cref="IronRdpException"></exception>
-    public void WithServerAddr(string serverAddr)
+    public void WithClientAddr(string clientAddr)
     {
         unsafe
         {
@@ -67,11 +67,11 @@ public partial class ClientConnector: IDisposable
             {
                 throw new ObjectDisposedException("ClientConnector");
             }
-            byte[] serverAddrBuf = DiplomatUtils.StringToUtf8(serverAddr);
-            nuint serverAddrBufLength = (nuint)serverAddrBuf.Length;
-            fixed (byte* serverAddrBufPtr = serverAddrBuf)
+            byte[] clientAddrBuf = DiplomatUtils.StringToUtf8(clientAddr);
+            nuint clientAddrBufLength = (nuint)clientAddrBuf.Length;
+            fixed (byte* clientAddrBufPtr = clientAddrBuf)
             {
-                Raw.ConnectorFfiResultVoidBoxIronRdpError result = Raw.ClientConnector.WithServerAddr(_inner, serverAddrBufPtr, serverAddrBufLength);
+                Raw.ConnectorFfiResultVoidBoxIronRdpError result = Raw.ClientConnector.WithClientAddr(_inner, clientAddrBufPtr, clientAddrBufLength);
                 if (!result.isOk)
                 {
                     throw new IronRdpException(new IronRdpError(result.Err));

--- a/ffi/dotnet/Devolutions.IronRdp/Generated/RawClientConnector.cs
+++ b/ffi/dotnet/Devolutions.IronRdp/Generated/RawClientConnector.cs
@@ -22,8 +22,8 @@ public partial struct ClientConnector
     /// <summary>
     /// Must use
     /// </summary>
-    [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ClientConnector_with_server_addr", ExactSpelling = true)]
-    public static unsafe extern ConnectorFfiResultVoidBoxIronRdpError WithServerAddr(ClientConnector* self, byte* serverAddr, nuint serverAddrSz);
+    [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ClientConnector_with_client_addr", ExactSpelling = true)]
+    public static unsafe extern ConnectorFfiResultVoidBoxIronRdpError WithClientAddr(ClientConnector* self, byte* clientAddr, nuint clientAddrSz);
 
     /// <summary>
     /// Must use

--- a/ffi/dotnet/Devolutions.IronRdp/src/Connection.cs
+++ b/ffi/dotnet/Devolutions.IronRdp/src/Connection.cs
@@ -21,8 +21,8 @@ public static class Connection
                 "Cannot resolve DNS to " + serverName);
         }
 
-        var serverAddr = ip[0] + ":" + port;
-        connector.WithServerAddr(serverAddr);
+        var clientAddr = ip[0] + ":" + port;
+        connector.WithClientAddr(clientAddr);
         connector.WithDynamicChannelDisplayControl();
         if (factory != null)
         {

--- a/ffi/src/connector/mod.rs
+++ b/ffi/src/connector/mod.rs
@@ -32,12 +32,12 @@ pub mod ffi {
         }
 
         /// Must use
-        pub fn with_server_addr(&mut self, server_addr: &str) -> Result<(), Box<IronRdpError>> {
+        pub fn with_client_addr(&mut self, client_addr: &str) -> Result<(), Box<IronRdpError>> {
             let Some(connector) = self.0.take() else {
                 return Err(IronRdpErrorKind::Consumed.into());
             };
-            let server_addr = server_addr.parse().map_err(|_| IronRdpErrorKind::Generic)?;
-            self.0 = Some(connector.with_server_addr(server_addr));
+            let client_addr = client_addr.parse().map_err(|_| IronRdpErrorKind::Generic)?;
+            self.0 = Some(connector.with_client_addr(client_addr));
 
             Ok(())
         }


### PR DESCRIPTION
This is a cosmetic rename to better reflect the purpose of the client address field used in the initial connection sequence. No functional changes.

Closes #735