### PR TITLE
fix(client): swap transposed width/height parameters for dynamic resizes

### DIFF
--- a/web-client/iron-remote-desktop/src/iron-remote-desktop.svelte
+++ b/web-client/iron-remote-desktop/src/iron-remote-desktop.svelte
@@ -473,7 +473,7 @@
 
         remoteDesktopService.dynamicResize.subscribe((evt) => {
             loggingService.info(`Dynamic resize!, width: ${evt.width}, height: ${evt.height}`);
-            setViewerStyle(evt.width.toString(), evt.height.toString(), true);
+            setViewerStyle(evt.height.toString(), evt.width.toString(), true);
         });
 
         remoteDesktopService.changeVisibilityObservable.subscribe((val) => {


### PR DESCRIPTION
Dynamic resizes were setting height to width and width to height, which ended up distorting things rather badly. Here's the fix.