### PR TITLE
refactor(ironrdp-web): implement to `JsValue` from `ClipboardTransaction` and `ClipboardContent`

### DIFF
--- a/crates/iron-remote-desktop/src/clipboard.rs
+++ b/crates/iron-remote-desktop/src/clipboard.rs
@@ -1,13 +1,15 @@
+use crate::IronError;
 use wasm_bindgen::JsValue;
 use web_sys::js_sys;
 
 pub trait ClipboardTransaction {
     type ClipboardContent: ClipboardContent;
+    type Error: IronError;
 
     fn init() -> Self;
     fn add_content(&mut self, content: Self::ClipboardContent);
     fn is_empty(&self) -> bool;
-    fn contents(&self) -> js_sys::Array;
+    fn contents(&self) -> Result<js_sys::Array, Self::Error>;
 }
 
 pub trait ClipboardContent {

--- a/crates/iron-remote-desktop/src/error.rs
+++ b/crates/iron-remote-desktop/src/error.rs
@@ -5,7 +5,7 @@ pub trait IronError {
     fn kind(&self) -> IronErrorKind;
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 #[wasm_bindgen]
 pub enum IronErrorKind {
     /// Catch-all error kind

--- a/crates/iron-remote-desktop/src/lib.rs
+++ b/crates/iron-remote-desktop/src/lib.rs
@@ -331,8 +331,8 @@ macro_rules! export {
                     self.0.is_empty()
                 }
 
-                pub fn content(&self) -> js_sys::Array {
-                    iron_remote_desktop::ClipboardTransaction::contents(&self.0)
+                pub fn content(&self) -> Result<js_sys::Array, IronError> {
+                    iron_remote_desktop::ClipboardTransaction::contents(&self.0).map_err(IronError)
                 }
             }
 

--- a/crates/ironrdp-web/src/error.rs
+++ b/crates/ironrdp-web/src/error.rs
@@ -1,6 +1,7 @@
 use iron_remote_desktop::IronErrorKind;
 use ironrdp::connector::{self, sspi, ConnectorErrorKind};
 
+#[derive(Debug)]
 pub(crate) struct IronError {
     kind: IronErrorKind,
     source: anyhow::Error,

--- a/crates/ironrdp-web/src/lib.rs
+++ b/crates/ironrdp-web/src/lib.rs
@@ -30,8 +30,8 @@ impl RemoteDesktopApi for Api {
     type SessionTerminationInfo = session::SessionTerminationInfo;
     type DeviceEvent = input::DeviceEvent;
     type InputTransaction = input::InputTransaction;
-    type ClipboardTransaction = clipboard::RdpClipboardTransaction;
-    type ClipboardContent = clipboard::RdpClipboardContent;
+    type ClipboardTransaction = clipboard::ClipboardTransaction;
+    type ClipboardContent = clipboard::ClipboardContent;
     type Error = error::IronError;
 }
 

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -38,7 +38,7 @@ use web_sys::HtmlCanvasElement;
 
 use crate::canvas::Canvas;
 use crate::clipboard;
-use crate::clipboard::{RdpClipboardTransaction, WasmClipboard, WasmClipboardBackend, WasmClipboardBackendMessage};
+use crate::clipboard::{ClipboardTransaction, WasmClipboard, WasmClipboardBackend, WasmClipboardBackendMessage};
 use crate::error::IronError;
 use crate::image::extract_partial_image;
 use crate::input::InputTransaction;
@@ -447,7 +447,7 @@ impl Session {
 impl iron_remote_desktop::Session for Session {
     type SessionTerminationInfo = SessionTerminationInfo;
     type InputTransaction = InputTransaction;
-    type ClipboardTransaction = RdpClipboardTransaction;
+    type ClipboardTransaction = ClipboardTransaction;
     type Error = IronError;
 
     async fn run(&self) -> Result<Self::SessionTerminationInfo, Self::Error> {


### PR DESCRIPTION
Follow-up for https://github.com/Devolutions/IronRDP/pull/755#discussion_r2048757239, and https://github.com/Devolutions/IronRDP/pull/755#discussion_r2048387450. 