### PR TITLE
refactor(web): iron_init/setup logic

### DIFF
--- a/crates/ironrdp-web/src/lib.rs
+++ b/crates/ironrdp-web/src/lib.rs
@@ -33,14 +33,8 @@ impl RemoteDesktopApi for Api {
     type ClipboardTransaction = clipboard::RdpClipboardTransaction;
     type ClipboardContent = clipboard::RdpClipboardContent;
     type Error = error::IronError;
-}
 
-#[doc(hidden)]
-pub mod internal {
-    #[allow(dead_code)]
-    fn iron_init(log_level: &str) {
-        iron_remote_desktop::iron_init(log_level);
-
+    fn post_setup() {
         debug!("IronRDP is ready");
     }
 }

--- a/web-client/iron-remote-desktop-rdp/src/main.ts
+++ b/web-client/iron-remote-desktop-rdp/src/main.ts
@@ -1,5 +1,5 @@
 import init, {
-    iron_init,
+    setup,
     DesktopSize,
     DeviceEvent,
     InputTransaction,
@@ -14,7 +14,7 @@ import { Extension } from './interfaces/Extension';
 
 export default {
     init,
-    iron_init,
+    setup,
     DesktopSize,
     DeviceEvent,
     InputTransaction,

--- a/web-client/iron-remote-desktop/src/interfaces/RemoteDesktopModule.ts
+++ b/web-client/iron-remote-desktop/src/interfaces/RemoteDesktopModule.ts
@@ -11,7 +11,7 @@ import type { Extension } from './Extension';
 
 export interface RemoteDesktopModule {
     init: () => Promise<unknown>;
-    iron_init: (logLevel: string) => void;
+    setup: (logLevel: string) => void;
     DesktopSize: DesktopSize;
     DeviceEvent: DeviceEvent;
     InputTransaction: InputTransaction;

--- a/web-client/iron-remote-desktop/src/iron-remote-desktop.svelte
+++ b/web-client/iron-remote-desktop/src/iron-remote-desktop.svelte
@@ -655,7 +655,7 @@
     }
 
     async function initcanvas() {
-        loggingService.info('Start canvas initialization.');
+        loggingService.info('Start canvas initialization...');
 
         // Set a default canvas size. Need more test to know if i can remove it.
         canvas.width = 800;
@@ -671,6 +671,7 @@
 
         loggingService.info('Component ready');
         loggingService.info('Dispatching ready event');
+
         // bubbles:true is significant here, all our consumer code expect this specific event
         // but they only listen to the event on the custom element itself, not on the inner div
         // in Svelte 3, we had direct access to the customelement, but now in Svelte5, we have to

--- a/web-client/iron-remote-desktop/src/services/remote-desktop.service.ts
+++ b/web-client/iron-remote-desktop/src/services/remote-desktop.service.ts
@@ -78,10 +78,10 @@ export class RemoteDesktopService {
     }
 
     async init(debug: LogType) {
-        loggingService.info('Loading wasm file.');
+        loggingService.info('Load wasm file...');
         await this.module.init();
-        loggingService.info('Initializing IronRDP.');
-        this.module.iron_init(LogType[debug]);
+        loggingService.info('Initialize the remote desktop module...');
+        this.module.setup(LogType[debug]);
     }
 
     // If set to false, the clipboard will not be enabled and the callbacks will not be registered to the Rust side


### PR DESCRIPTION
- `iron_init` is renamed to `setup`, so that
  - `init` is the function for initializing the WASM module.
  - `setup` is the function taking parameters for logger and performing other setting up operations.
  - Since `setup` may be called after `init` is called, it’s possible to use some functions of the WASM module before calling `setup` if necessity arises.

- Common initializion code is moved to an hidden "internal" module of iron-remote-desktop crate, that is thus not part of the public API.

- Restored the "IronRDP is ready" debug log when `setup` is called.