### PR TITLE
fix(server)!: remove time_warn! from the public API

### DIFF
--- a/crates/ironrdp-server/src/encoder/mod.rs
+++ b/crates/ironrdp-server/src/encoder/mod.rs
@@ -12,7 +12,8 @@ use ironrdp_pdu::surface_commands::{ExtendedBitmapDataPdu, SurfaceBitsPdu, Surfa
 use self::bitmap::BitmapEncoder;
 use self::rfx::RfxEncoder;
 use super::BitmapUpdate;
-use crate::{time_warn, ColorPointer, DisplayUpdate, Framebuffer, RGBAPointer};
+use crate::macros::time_warn;
+use crate::{ColorPointer, DisplayUpdate, Framebuffer, RGBAPointer};
 
 mod bitmap;
 mod fast_path;

--- a/crates/ironrdp-server/src/lib.rs
+++ b/crates/ironrdp-server/src/lib.rs
@@ -7,6 +7,9 @@ pub use {tokio, tokio_rustls};
 #[macro_use]
 extern crate tracing;
 
+#[macro_use]
+mod macros;
+
 mod builder;
 mod capabilities;
 mod clipboard;
@@ -33,28 +36,4 @@ pub mod bench {
             pub use crate::encoder::rfx::bench::{rfx_enc, rfx_enc_tile};
         }
     }
-}
-
-#[macro_export]
-macro_rules! time_warn {
-    ($context:expr, $threshold_ms:expr, $op:expr) => {{
-        #[cold]
-        fn warn_log(context: &str, duration: u128) {
-            use ::core::sync::atomic::AtomicUsize;
-
-            static COUNT: AtomicUsize = AtomicUsize::new(0);
-            let current_count = COUNT.fetch_add(1, ::core::sync::atomic::Ordering::Relaxed);
-            if current_count < 50 || current_count % 100 == 0 {
-                ::tracing::warn!("{context} took {duration} ms! (count: {current_count})");
-            }
-        }
-
-        let start = std::time::Instant::now();
-        let result = $op;
-        let duration = start.elapsed().as_millis();
-        if duration > $threshold_ms {
-            warn_log($context, duration);
-        }
-        result
-    }};
 }

--- a/crates/ironrdp-server/src/macros.rs
+++ b/crates/ironrdp-server/src/macros.rs
@@ -1,0 +1,24 @@
+macro_rules! time_warn {
+    ($context:expr, $threshold_ms:expr, $op:expr) => {{
+        #[cold]
+        fn warn_log(context: &str, duration: u128) {
+            use ::core::sync::atomic::AtomicUsize;
+
+            static COUNT: AtomicUsize = AtomicUsize::new(0);
+            let current_count = COUNT.fetch_add(1, ::core::sync::atomic::Ordering::Relaxed);
+            if current_count < 50 || current_count % 100 == 0 {
+                ::tracing::warn!("{context} took {duration} ms! (count: {current_count})");
+            }
+        }
+
+        let start = std::time::Instant::now();
+        let result = $op;
+        let duration = start.elapsed().as_millis();
+        if duration > $threshold_ms {
+            warn_log($context, duration);
+        }
+        result
+    }};
+}
+
+pub(crate) use time_warn;


### PR DESCRIPTION
This is intended to be an internal macro.