### PR TITLE
refactor(iron-remote-desktop): use `PartialObserver` instead of single callback for `onSessionEvent`

### DIFF
--- a/web-client/iron-remote-desktop/src/interfaces/UserInteraction.ts
+++ b/web-client/iron-remote-desktop/src/interfaces/UserInteraction.ts
@@ -3,6 +3,7 @@ import type { NewSessionInfo } from './NewSessionInfo';
 import type { SessionEvent } from './session-event';
 import { ConfigBuilder } from '../services/ConfigBuilder';
 import type { Config } from '../services/Config';
+import type { PartialObserver } from 'rxjs';
 
 export interface UserInteraction {
     setVisibility(state: boolean): void;
@@ -23,7 +24,7 @@ export interface UserInteraction {
 
     setCursorStyleOverride(style: string | null): void;
 
-    onSessionEvent(callback: (event: SessionEvent) => void): void;
+    onSessionEvent(partialObserver: PartialObserver<SessionEvent>): void;
 
     resize(width: number, height: number, scale?: number): void;
 

--- a/web-client/iron-remote-desktop/src/services/PublicAPI.ts
+++ b/web-client/iron-remote-desktop/src/services/PublicAPI.ts
@@ -68,8 +68,8 @@ export class PublicAPI {
             configBuilder: this.configBuilder.bind(this),
             connect: this.connect.bind(this),
             setScale: this.setScale.bind(this),
-            onSessionEvent: (callback) => {
-                this.remoteDesktopService.sessionObserver.subscribe(callback);
+            onSessionEvent: (partialObserver) => {
+                this.remoteDesktopService.sessionObserver.subscribe(partialObserver);
             },
             ctrlAltDel: this.ctrlAltDel.bind(this),
             metaKey: this.metaKey.bind(this),

--- a/web-client/iron-svelte-client/src/lib/login/login.svelte
+++ b/web-client/iron-svelte-client/src/lib/login/login.svelte
@@ -30,20 +30,22 @@
     });
 
     const initListeners = () => {
-        userInteraction.onSessionEvent((event) => {
-            if (event.type === 2) {
-                console.log('Error event', event.data);
+        userInteraction.onSessionEvent({
+            next: (event) => {
+                if (event.type === 2) {
+                    console.log('Error event', event.data);
 
-                toast.set({
-                    type: 'error',
-                    message: typeof event.data !== 'string' ? event.data.backtrace() : event.data,
-                });
-            } else {
-                toast.set({
-                    type: 'info',
-                    message: typeof event.data === 'string' ? event.data : event.data?.backtrace() ?? 'No info',
-                });
-            }
+                    toast.set({
+                        type: 'error',
+                        message: typeof event.data !== 'string' ? event.data.backtrace() : event.data,
+                    });
+                } else {
+                    toast.set({
+                        type: 'info',
+                        message: typeof event.data === 'string' ? event.data : event.data?.backtrace() ?? 'No info',
+                    });
+                }
+            },
         });
     };
 

--- a/web-client/iron-svelte-client/src/lib/popup-screen/popup-screen.svelte
+++ b/web-client/iron-svelte-client/src/lib/popup-screen/popup-screen.svelte
@@ -12,12 +12,14 @@
     userInteractionService.subscribe((val) => {
         if (val != null) {
             userInteraction = val;
-            userInteraction.onSessionEvent((event) => {
-                if (event.type === 0) {
-                    userInteraction.setVisibility(true);
-                } else if (event.type === 1) {
-                    setCurrentSessionActive(false);
-                }
+            userInteraction.onSessionEvent({
+                next: (event) => {
+                    if (event.type === 0) {
+                        userInteraction.setVisibility(true);
+                    } else if (event.type === 1) {
+                        setCurrentSessionActive(false);
+                    }
+                },
             });
         }
     });

--- a/web-client/iron-svelte-client/src/lib/remote-screen/remote-screen.svelte
+++ b/web-client/iron-svelte-client/src/lib/remote-screen/remote-screen.svelte
@@ -12,13 +12,15 @@
     userInteractionService.subscribe((uis) => {
         if (uis != null) {
             uiService = uis;
-            uiService.onSessionEvent((event) => {
-                if (event.type === 0) {
-                    uiService.setVisibility(true);
-                } else if (event.type === 1) {
-                    setCurrentSessionActive(false);
-                    showLogin.set(true);
-                }
+            uiService.onSessionEvent({
+                next: (event) => {
+                    if (event.type === 0) {
+                        uiService.setVisibility(true);
+                    } else if (event.type === 1) {
+                        setCurrentSessionActive(false);
+                        showLogin.set(true);
+                    }
+                },
             });
         }
     });


### PR DESCRIPTION
 I've refactored the `onSessionEvent` method to use` PartialObserver` instead of a single callback.
This change gives the ability to pass `next` and `error` callbacks instead of only `next` in places like [this](https://github.com/Devolutions/devolutions-gateway/blob/e90f06f7bab3267eedb0586eb167e43d409f7f82/webapp/src/client/app/modules/web-client/ard/web-client-ard.component.ts#L336-L350) in Devolutions Gateway Standalone