### PR TITLE
feat(client): support for hardware cursor

### DIFF
--- a/crates/ironrdp-client/src/app.rs
+++ b/crates/ironrdp-client/src/app.rs
@@ -363,7 +363,7 @@ impl ApplicationHandler<RdpOutputEvent> for App {
             RdpOutputEvent::PointerBitmap(pointer) => {
                 debug!(width = ?pointer.width, height = ?pointer.height, "Received pointer bitmap");
                 match CustomCursor::from_rgba(
-                    pointer.bitmap_data,
+                    pointer.bitmap_data.clone(),
                     pointer.width,
                     pointer.height,
                     pointer.hotspot_x,

--- a/crates/ironrdp-client/src/app.rs
+++ b/crates/ironrdp-client/src/app.rs
@@ -13,7 +13,7 @@ use winit::event::{self, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
 use winit::keyboard::ModifiersKeyState;
 use winit::platform::scancode::PhysicalKeyExtScancode;
-use winit::window::{Window, WindowAttributes};
+use winit::window::{CursorIcon, CustomCursor, Window, WindowAttributes};
 
 use crate::rdp::{RdpInputEvent, RdpOutputEvent};
 
@@ -352,12 +352,27 @@ impl ApplicationHandler<RdpOutputEvent> for App {
                 window.set_cursor_visible(false);
             }
             RdpOutputEvent::PointerDefault => {
+                window.set_cursor(CursorIcon::default());
                 window.set_cursor_visible(true);
             }
             RdpOutputEvent::PointerPosition { x, y } => {
                 if let Err(error) = window.set_cursor_position(LogicalPosition::new(x, y)) {
                     error!(?error, "Failed to set cursor position");
                 }
+            }
+            RdpOutputEvent::PointerBitmap(pointer) => {
+                debug!(width = ?pointer.width, height = ?pointer.height, "Received pointer bitmap");
+                match CustomCursor::from_rgba(
+                    pointer.bitmap_data,
+                    pointer.width,
+                    pointer.height,
+                    pointer.hotspot_x,
+                    pointer.hotspot_y,
+                ) {
+                    Ok(cursor) => window.set_cursor(event_loop.create_custom_cursor(cursor)),
+                    Err(error) => error!(?error, "Failed to set cursor bitmap"),
+                }
+                window.set_cursor_visible(true);
             }
         }
     }

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -342,7 +342,7 @@ impl Config {
             autologon: args.autologon,
             no_audio_playback: false,
             request_data: None,
-            pointer_software_rendering: true,
+            pointer_software_rendering: false,
             performance_flags: PerformanceFlags::default(),
         };
 

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use ironrdp::cliprdr::backend::{ClipboardMessage, CliprdrBackendFactory};
 use ironrdp::connector::connection_activation::ConnectionActivationState;
 use ironrdp::connector::{ConnectionResult, ConnectorResult};
@@ -29,7 +31,7 @@ pub enum RdpOutputEvent {
     PointerDefault,
     PointerHidden,
     PointerPosition { x: u16, y: u16 },
-    PointerBitmap(DecodedPointer),
+    PointerBitmap(Arc<DecodedPointer>),
     Terminated(SessionResult<GracefulDisconnectReason>),
 }
 
@@ -513,7 +515,7 @@ async fn active_session(
                 }
                 ActiveStageOutput::PointerBitmap(pointer) => {
                     event_loop_proxy
-                        .send_event(RdpOutputEvent::PointerBitmap(pointer.as_ref().clone()))
+                        .send_event(RdpOutputEvent::PointerBitmap(pointer))
                         .map_err(|e| session::custom_err!("event_loop_proxy", e))?;
                 }
                 ActiveStageOutput::DeactivateAll(mut connection_activation) => {

--- a/crates/ironrdp-graphics/src/pointer.rs
+++ b/crates/ironrdp-graphics/src/pointer.rs
@@ -38,7 +38,7 @@ pub enum PointerError {
 }
 
 /// Represents RDP pointer in decoded form (color channels stored as RGBA pre-multiplied values)
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct DecodedPointer {
     pub width: u16,
     pub height: u16,

--- a/crates/ironrdp-graphics/src/pointer.rs
+++ b/crates/ironrdp-graphics/src/pointer.rs
@@ -38,7 +38,7 @@ pub enum PointerError {
 }
 
 /// Represents RDP pointer in decoded form (color channels stored as RGBA pre-multiplied values)
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct DecodedPointer {
     pub width: u16,
     pub height: u16,


### PR DESCRIPTION
Render cursor icon at client side with `winit` custom cursor API. This should close #255.
Tested on Wayland.

Closes #251 
Closes #252 
Closes #253 
Closes #254 
Closes #255 