### PR TITLE
chore: update `iron-remote-desktop` version to 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2319,7 +2319,7 @@ dependencies = [
 
 [[package]]
 name = "iron-remote-desktop"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "console_error_panic_hook",
  "tracing",

--- a/crates/iron-remote-desktop/Cargo.toml
+++ b/crates/iron-remote-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iron-remote-desktop"
-version = "0.3.0"
+version = "0.3.1"
 readme = "README.md"
 description = "Helper crate for building WASM modules compatible with iron-remote-desktop WebComponent"
 edition.workspace = true

--- a/web-client/iron-remote-desktop/public/package.json
+++ b/web-client/iron-remote-desktop/public/package.json
@@ -10,7 +10,7 @@
     "Alexandr Yusuk"
   ],
   "description": "Web Component providing agnostic implementation for Iron Wasm base client",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "iron-remote-desktop.js",
   "types": "index.d.ts",
   "files": [


### PR DESCRIPTION
It seems that in https://github.com/Devolutions/IronRDP/pull/800, we released a version that included https://github.com/Devolutions/IronRDP/pull/799, but not https://github.com/Devolutions/IronRDP/pull/803, and it's the reason why we have https://github.com/Devolutions/devolutions-gateway/pull/1369#issuecomment-2943811482 issue. 