### PR TITLE
chore(release): prepare ironrdp-server 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2673,7 +2673,7 @@ dependencies = [
 
 [[package]]
 name = "ironrdp-server"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/ironrdp-server/Cargo.toml
+++ b/crates/ironrdp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironrdp-server"
-version = "0.6.0"
+version = "0.6.1"
 readme = "README.md"
 description = "Extendable skeleton for implementing custom RDP servers"
 edition.workspace = true


### PR DESCRIPTION
Patch bump including the ironrdp-tokio dependency.

Closes #814