### PR TITLE
fix(web): move `onDestroy` function out of the `scaleSession` function

### DIFF
--- a/web-client/iron-remote-desktop/src/iron-remote-desktop.svelte
+++ b/web-client/iron-remote-desktop/src/iron-remote-desktop.svelte
@@ -515,10 +515,6 @@
                     break;
             }
         }
-
-        onDestroy(() => {
-            window.removeEventListener('resize', resizeHandler);
-        });
     }
 
     function fullResize() {
@@ -691,6 +687,10 @@
         loggingService.info('Dom ready');
         await initcanvas();
         initClipboard();
+    });
+
+    onDestroy(() => {
+        window.removeEventListener('resize', resizeHandler);
     });
 </script>
 


### PR DESCRIPTION
I put it in a wrong place in https://github.com/Devolutions/IronRDP/pull/823