### PR TITLE
fix(web): raise only `TERMINATED` message on session termination with the error backtrace

### DIFF
--- a/web-client/iron-remote-desktop/src/services/remote-desktop.service.ts
+++ b/web-client/iron-remote-desktop/src/services/remote-desktop.service.ts
@@ -189,12 +189,8 @@ export class RemoteDesktopService {
                 this.setVisibility(false);
 
                 this.raiseSessionEvent({
-                    type: SessionEventType.ERROR,
-                    data: err.backtrace(),
-                });
-                this.raiseSessionEvent({
                     type: SessionEventType.TERMINATED,
-                    data: 'Session was terminated.',
+                    data: 'Session was terminated with an error: ' + err.backtrace() + '.',
                 });
             });
     }


### PR DESCRIPTION
When the session ends with an error, `iron-remote-desktop` raises `ERROR` in pair with `TERMINATED`. The handling function in Devolutions Gateway Standalone handles these types of events similarly. As a result, we see only the message from the `TERMINATED` event in the `error notify bar`, because the message from the `ERROR` is overwritten.

This PR fixes the issue by only raising the `TERMINATED` with the error backtrace.