### PR TITLE
fix: avoids infinite loop in HandleClipboardEvents when not on Windows

### DIFF
--- a/ffi/dotnet/Devolutions.IronRdp.AvaloniaExample/MainWindow.axaml.cs
+++ b/ffi/dotnet/Devolutions.IronRdp.AvaloniaExample/MainWindow.axaml.cs
@@ -112,7 +112,10 @@ public partial class MainWindow : Window
             this._activeStage = ActiveStage.New(res);
             this._framed = framed;
             ReadPduAndProcessActiveStage();
-            HandleClipboardEvents();
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                HandleClipboardEvents();
+            }
         });
     }
 


### PR DESCRIPTION
When running on non-Windows, HandleClipboardEvents will create an infinite loop consuming 100% CPU.
This PR calls HandleClipboardEvents only when on Windows.