### PR TITLE
fix(web): run navigator.clipboard.write only when window has focus

### DIFF
--- a/web-client/iron-remote-desktop/src/iron-remote-desktop.svelte
+++ b/web-client/iron-remote-desktop/src/iron-remote-desktop.svelte
@@ -747,7 +747,7 @@
     onDestroy(() => {
         window.removeEventListener('resize', resizeHandler);
         window.removeEventListener('focus', focusEventHandler);
-	componentDestroyed = true;
+        componentDestroyed = true;
     });
 </script>
 


### PR DESCRIPTION
When we receive clipboard update from the server and the browser window is not in focus (for example, when the user copies some text directly on the machine, not via the browser's VNC viewer), we got an error that `navigator.clipboard.write` is not allowed when window is not in focus.
This PR adds a window check that the window has focus, and now `clipboard.write` runs only when the window is in focus.

https://github.com/Devolutions/IronRDP/pull/857 has to be merged first. 