### PR TITLE
feat(ironrdp-tokio): add async `ReqwestNetworkClient::send` method

### DIFF
--- a/crates/ironrdp-tokio/src/reqwest.rs
+++ b/crates/ironrdp-tokio/src/reqwest.rs
@@ -20,15 +20,7 @@ impl AsyncNetworkClient for ReqwestNetworkClient {
         &'a mut self,
         request: &'a sspi::generator::NetworkRequest,
     ) -> Pin<Box<dyn Future<Output = ConnectorResult<Vec<u8>>> + 'a>> {
-        Box::pin(async move {
-            match &request.protocol {
-                sspi::network_client::NetworkProtocol::Tcp => self.send_tcp(&request.url, &request.data).await,
-                sspi::network_client::NetworkProtocol::Udp => self.send_udp(&request.url, &request.data).await,
-                sspi::network_client::NetworkProtocol::Http | sspi::network_client::NetworkProtocol::Https => {
-                    self.send_http(&request.url, &request.data).await
-                }
-            }
-        })
+        Box::pin(ReqwestNetworkClient::send(self, request))
     }
 }
 
@@ -45,6 +37,16 @@ impl Default for ReqwestNetworkClient {
 }
 
 impl ReqwestNetworkClient {
+    pub async fn send<'a>(&'a mut self, request: &'a sspi::generator::NetworkRequest) -> ConnectorResult<Vec<u8>> {
+        match &request.protocol {
+            sspi::network_client::NetworkProtocol::Tcp => self.send_tcp(&request.url, &request.data).await,
+            sspi::network_client::NetworkProtocol::Udp => self.send_udp(&request.url, &request.data).await,
+            sspi::network_client::NetworkProtocol::Http | sspi::network_client::NetworkProtocol::Https => {
+                self.send_http(&request.url, &request.data).await
+            }
+        }
+    }
+
     async fn send_tcp(&self, url: &Url, data: &[u8]) -> ConnectorResult<Vec<u8>> {
         let addr = format!("{}:{}", url.host_str().unwrap_or_default(), url.port().unwrap_or(88));
 


### PR DESCRIPTION
Hi,
I add a public `ReqwestNetworkClient::send` method. It is needed for the Devolutions-Gateway. More context: https://github.com/Devolutions/IronRDP/pull/839#pullrequestreview-2974986096