### PR TITLE
refactor(web): add IronErrorKind variants for connector FailureCode types

### DIFF
--- a/crates/iron-remote-desktop/src/error.rs
+++ b/crates/iron-remote-desktop/src/error.rs
@@ -21,4 +21,16 @@ pub enum IronErrorKind {
     RDCleanPath,
     /// Couldn’t connect to proxy
     ProxyConnect,
+    /// Server requires Enhanced RDP Security with TLS or CredSSP
+    SslRequiredByServer,
+    /// Server only supports Standard RDP Security
+    SslNotAllowedByServer,
+    /// Server lacks valid authentication certificate
+    SslCertNotOnServer,
+    /// Inconsistent security protocol flags
+    InconsistentFlags,
+    /// Server requires Enhanced RDP Security with CredSSP
+    HybridRequiredByServer,
+    /// Server requires Enhanced RDP Security with TLS and client certificate
+    SslWithUserAuthRequiredByServer,
 }

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -13,8 +13,8 @@ use crate::channel_connection::{ChannelConnectionSequence, ChannelConnectionStat
 use crate::connection_activation::{ConnectionActivationSequence, ConnectionActivationState};
 use crate::license_exchange::{LicenseExchangeSequence, NoopLicenseCache};
 use crate::{
-    encode_x224_packet, Config, ConnectorError, ConnectorErrorExt as _, ConnectorResult, DesktopSize, Sequence, State,
-    Written,
+    encode_x224_packet, Config, ConnectorError, ConnectorErrorExt as _, ConnectorErrorKind, ConnectorResult,
+    DesktopSize, Sequence, State, Written,
 };
 
 #[derive(Debug)]
@@ -274,7 +274,10 @@ impl Sequence for ClientConnector {
                     nego::ConnectionConfirm::Response { flags, protocol } => (flags, protocol),
                     nego::ConnectionConfirm::Failure { code } => {
                         error!(?code, "Received connection failure code");
-                        return Err(reason_err!("Initiation", "{code}"));
+                        return Err(ConnectorError::new(
+                            "negotiation failure",
+                            ConnectorErrorKind::NegotiationFailure(code),
+                        ));
                     }
                 };
 

--- a/crates/ironrdp-connector/src/lib.rs
+++ b/crates/ironrdp-connector/src/lib.rs
@@ -276,6 +276,7 @@ pub enum ConnectorErrorKind {
     AccessDenied,
     General,
     Custom,
+    NegotiationFailure(ironrdp_pdu::nego::FailureCode),
 }
 
 impl fmt::Display for ConnectorErrorKind {
@@ -288,6 +289,7 @@ impl fmt::Display for ConnectorErrorKind {
             ConnectorErrorKind::AccessDenied => write!(f, "access denied"),
             ConnectorErrorKind::General => write!(f, "general error"),
             ConnectorErrorKind::Custom => write!(f, "custom error"),
+            ConnectorErrorKind::NegotiationFailure(code) => write!(f, "negotiation failure: {code}"),
         }
     }
 }
@@ -302,6 +304,7 @@ impl core::error::Error for ConnectorErrorKind {
             ConnectorErrorKind::AccessDenied => None,
             ConnectorErrorKind::Custom => None,
             ConnectorErrorKind::General => None,
+            ConnectorErrorKind::NegotiationFailure(_) => None,
         }
     }
 }

--- a/crates/ironrdp-web/Cargo.toml
+++ b/crates/ironrdp-web/Cargo.toml
@@ -34,6 +34,7 @@ ironrdp = { path = "../ironrdp", features = [
     "cliprdr",
     "svc",
     "displaycontrol",
+    "pdu",
 ] }
 ironrdp-core.path = "../ironrdp-core"
 ironrdp-cliprdr-format.path = "../ironrdp-cliprdr-format"

--- a/crates/ironrdp-web/src/error.rs
+++ b/crates/ironrdp-web/src/error.rs
@@ -1,5 +1,6 @@
 use iron_remote_desktop::IronErrorKind;
 use ironrdp::connector::{self, sspi, ConnectorErrorKind};
+use tracing::info;
 
 pub(crate) struct IronError {
     kind: IronErrorKind,
@@ -37,6 +38,21 @@ impl From<connector::ConnectorError> for IronError {
                 ..
             }) => IronErrorKind::LogonFailure,
             ConnectorErrorKind::AccessDenied => IronErrorKind::AccessDenied,
+            ConnectorErrorKind::NegotiationFailure(code) => {
+                use ironrdp::pdu::nego::FailureCode;
+                info!("RDP negotiation failure: {} (code: 0x{:08x})", code, u32::from(code));
+                match code {
+                    FailureCode::SSL_REQUIRED_BY_SERVER => IronErrorKind::SslRequiredByServer,
+                    FailureCode::SSL_NOT_ALLOWED_BY_SERVER => IronErrorKind::SslNotAllowedByServer,
+                    FailureCode::SSL_CERT_NOT_ON_SERVER => IronErrorKind::SslCertNotOnServer,
+                    FailureCode::INCONSISTENT_FLAGS => IronErrorKind::InconsistentFlags,
+                    FailureCode::HYBRID_REQUIRED_BY_SERVER => IronErrorKind::HybridRequiredByServer,
+                    FailureCode::SSL_WITH_USER_AUTH_REQUIRED_BY_SERVER => {
+                        IronErrorKind::SslWithUserAuthRequiredByServer
+                    }
+                    _ => IronErrorKind::General,
+                }
+            }
             _ => IronErrorKind::General,
         };
 


### PR DESCRIPTION
Allows Javascript embedders to handle negotiation errors that occur before the RDP session begins.

Changes:
- Add specific IronErrorKind variants for negotiation failures:
  - SslRequiredByServer: Server requires TLS/CredSSP
  - SslNotAllowedByServer: Server only supports Standard RDP Security
  - SslCertNotOnServer: Server lacks valid authentication certificate
  - InconsistentFlags: Inconsistent security protocol flags
  - HybridRequiredByServer: Server requires CredSSP
  - SslWithUserAuthRequiredByServer: Server requires TLS + client cert
- Update ironrdp-web to map FailureCode constants to specific error kinds

In JavaScript:
  if (error.kind() === IronErrorKind.SslRequiredByServer) { ... }