### PR TITLE
fix(client): fix special key modifiers on linux

### DIFF
--- a/crates/ironrdp-client/src/app.rs
+++ b/crates/ironrdp-client/src/app.rs
@@ -11,7 +11,6 @@ use winit::application::ApplicationHandler;
 use winit::dpi::{LogicalPosition, PhysicalSize};
 use winit::event::{self, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
-use winit::keyboard::ModifiersKeyState;
 use winit::platform::scancode::PhysicalKeyExtScancode as _;
 use winit::window::{CursorIcon, CustomCursor, Window, WindowAttributes};
 


### PR DESCRIPTION
As documented in winit keyboard ModifiersKeys doesnt work for X11/Wayland: https://docs.rs/winit/latest/src/winit/keyboard.rs.html#1688-1703 "[..] on some platforms like Wayland/X11 which key resulted 1740// in modifiers change is hidden [..]"

This makes CTRL+C, CTRL+V, etc. work.