### PR TITLE
feat: allow users to specify a timezone

### DIFF
--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -9,7 +9,7 @@ use clap::clap_derive::ValueEnum;
 use clap::Parser;
 use ironrdp::connector::{self, Credentials};
 use ironrdp::pdu::rdp::capability_sets::{client_codecs_capabilities, MajorPlatformType};
-use ironrdp::pdu::rdp::client_info::PerformanceFlags;
+use ironrdp::pdu::rdp::client_info::{PerformanceFlags, TimezoneInfo};
 use ironrdp_mstsgu::GwConnectTarget;
 use tap::prelude::*;
 use url::Url;
@@ -463,6 +463,7 @@ impl Config {
             request_data: None,
             pointer_software_rendering: false,
             performance_flags: PerformanceFlags::default(),
+            timezone_info: TimezoneInfo::default(),
         };
 
         let rdcleanpath = args

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -4,7 +4,6 @@ use std::borrow::Cow;
 use std::sync::Arc;
 
 use ironrdp_core::{decode, encode_vec, Encode, WriteBuf};
-use ironrdp_pdu::rdp::client_info::{OptionalSystemTime, TimezoneInfo};
 use ironrdp_pdu::x224::X224;
 use ironrdp_pdu::{gcc, mcs, nego, rdp, PduHint};
 use ironrdp_svc::{StaticChannelSet, StaticVirtualChannel, SvcClientProcessor};
@@ -756,15 +755,7 @@ fn create_client_info_pdu(config: &Config, client_addr: &SocketAddr) -> rdp::Cli
             address: client_addr.ip().to_string(),
             dir: config.client_dir.clone(),
             optional_data: ExtendedClientOptionalInfo::builder()
-                .timezone(TimezoneInfo {
-                    bias: 0,
-                    standard_name: String::new(),
-                    standard_date: OptionalSystemTime(None),
-                    standard_bias: 0,
-                    daylight_name: String::new(),
-                    daylight_date: OptionalSystemTime(None),
-                    daylight_bias: 0,
-                })
+                .timezone(config.timezone_info.clone())
                 .session_id(0)
                 .performance_flags(config.performance_flags)
                 .build(),

--- a/crates/ironrdp-connector/src/lib.rs
+++ b/crates/ironrdp-connector/src/lib.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use ironrdp_core::{encode_buf, encode_vec, Encode, WriteBuf};
 use ironrdp_pdu::nego::NegoRequestData;
 use ironrdp_pdu::rdp::capability_sets::{self, BitmapCodecs};
-use ironrdp_pdu::rdp::client_info::PerformanceFlags;
+use ironrdp_pdu::rdp::client_info::{PerformanceFlags, TimezoneInfo};
 use ironrdp_pdu::x224::X224;
 use ironrdp_pdu::{gcc, x224, PduHint};
 pub use sspi;
@@ -228,6 +228,9 @@ pub struct Config {
     pub performance_flags: PerformanceFlags,
 
     pub license_cache: Option<Arc<dyn LicenseCache>>,
+
+    // For Timezone Redirection to sync the server's timezone with the client's.
+    pub timezone_info: TimezoneInfo,
 
     // FIXME(@CBenoit): these are client-only options, not part of the connector.
     pub enable_server_pointer: bool,

--- a/crates/ironrdp-testsuite-extra/tests/tests.rs
+++ b/crates/ironrdp-testsuite-extra/tests/tests.rs
@@ -302,5 +302,6 @@ fn default_client_config() -> connector::Config {
         enable_server_pointer: true,
         pointer_software_rendering: true,
         performance_flags: Default::default(),
+        timezone_info: Default::default(),
     }
 }

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -23,7 +23,7 @@ use ironrdp::dvc::DrdynvcClient;
 use ironrdp::graphics::image_processing::PixelFormat;
 use ironrdp::pdu::input::fast_path::FastPathInputEvent;
 use ironrdp::pdu::rdp::capability_sets::client_codecs_capabilities;
-use ironrdp::pdu::rdp::client_info::PerformanceFlags;
+use ironrdp::pdu::rdp::client_info::{PerformanceFlags, TimezoneInfo};
 use ironrdp::session::image::DecodedImage;
 use ironrdp::session::{fast_path, ActiveStage, ActiveStageOutput, GracefulDisconnectReason};
 use ironrdp_core::WriteBuf;
@@ -897,6 +897,7 @@ fn build_config(
         desktop_scale_factor: 0,
         hardware_id: None,
         license_cache: None,
+        timezone_info: TimezoneInfo::default(),
     }
 }
 

--- a/crates/ironrdp/examples/screenshot.rs
+++ b/crates/ironrdp/examples/screenshot.rs
@@ -30,7 +30,7 @@ use ironrdp::pdu::gcc::KeyboardType;
 use ironrdp::pdu::rdp::capability_sets::MajorPlatformType;
 use ironrdp::session::image::DecodedImage;
 use ironrdp::session::{ActiveStage, ActiveStageOutput};
-use ironrdp_pdu::rdp::client_info::PerformanceFlags;
+use ironrdp_pdu::rdp::client_info::{PerformanceFlags, TimezoneInfo};
 use sspi::network_client::reqwest_network_client::ReqwestNetworkClient;
 use tokio_rustls::rustls;
 use tracing::{debug, info, trace};
@@ -212,6 +212,7 @@ fn build_config(username: String, password: String, domain: Option<String>) -> c
         desktop_scale_factor: 0,
         hardware_id: None,
         license_cache: None,
+        timezone_info: TimezoneInfo::default(),
     }
 }
 

--- a/ffi/src/connector/config.rs
+++ b/ffi/src/connector/config.rs
@@ -42,6 +42,7 @@ pub mod ffi {
         pub no_audio_playback: Option<bool>,
         pub pointer_software_rendering: Option<bool>,
         pub performance_flags: Option<ironrdp::pdu::rdp::client_info::PerformanceFlags>,
+        pub timezone_info: Option<ironrdp::pdu::rdp::client_info::TimezoneInfo>,
     }
 
     #[diplomat::enum_convert(ironrdp::pdu::gcc::KeyboardType)]
@@ -124,6 +125,10 @@ pub mod ffi {
             self.performance_flags = Some(performance_flags.0);
         }
 
+        pub fn set_timezone_info(&mut self, timezone_info: Option<ironrdp::pdu::rdp::client_info::TimezoneInfo>) {
+            self.timezone_info = timezone_info;
+        }
+
         pub fn set_bitmap_config(&mut self, bitmap: &BitmapConfig) {
             self.bitmap = Some(bitmap.0.clone());
         }
@@ -200,6 +205,7 @@ pub mod ffi {
                 desktop_scale_factor: 0,
                 hardware_id: None,
                 license_cache: None,
+                timezone_info: self.timezone_info.clone().unwrap_or_default(),
             };
             tracing::debug!(config=?inner_config, "Built config");
             Ok(Box::new(Config(inner_config)))

--- a/ffi/src/connector/config.rs
+++ b/ffi/src/connector/config.rs
@@ -125,9 +125,9 @@ pub mod ffi {
             self.performance_flags = Some(performance_flags.0);
         }
 
-        pub fn set_timezone_info(&mut self, timezone_info: Option<ironrdp::pdu::rdp::client_info::TimezoneInfo>) {
-            self.timezone_info = timezone_info;
-        }
+        // pub fn set_timezone_info(&mut self, timezone_info: Option<ironrdp::pdu::rdp::client_info::TimezoneInfo>) {
+        //     self.timezone_info = timezone_info;
+        // }
 
         pub fn set_bitmap_config(&mut self, bitmap: &BitmapConfig) {
             self.bitmap = Some(bitmap.0.clone());


### PR DESCRIPTION
This PR allows you to pass a timezone to the remote desktop.

At some point, the Microsoft spec for the timezone bias types should be unsigned based on implementations of this spec in other clients. Now the docs have been updated to have the timezone bias type as a signed integer, so I've updated the `TimezoneInfo` struct to reflect that.