### PR TITLE
fix!: update timezone info to use i32 bias

### DIFF
--- a/crates/ironrdp-testsuite-core/src/client_info.rs
+++ b/crates/ironrdp-testsuite-core/src/client_info.rs
@@ -105,7 +105,7 @@ lazy_static::lazy_static! {
             dir: String::from("C:\\depots\\w2k3_1\\termsrv\\newclient\\lib\\win32\\obj\\i386\\mstscax.dll"),
             optional_data: ExtendedClientOptionalInfo::builder()
                 .timezone(TimezoneInfo {
-                    bias: 0x01e0,
+                    bias: 480,
                     standard_name: String::from("Pacific Standard Time"),
                     standard_date: OptionalSystemTime(Some(SystemTime {
                         month: Month::October,
@@ -127,7 +127,7 @@ lazy_static::lazy_static! {
                         second: 0,
                         milliseconds: 0,
                     })),
-                    daylight_bias: 0xffff_ffc4,
+                    daylight_bias: -60,
                 })
                 .session_id(0)
                 .performance_flags(PerformanceFlags::DISABLE_WALLPAPER)


### PR DESCRIPTION
To match the Microsoft [documentation](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/526ed635-d7a9-4d3c-bbe1-4e3fb17585f4) on Time Zone Information, this breaking change is required.

It switches `bias` from an unsigned to a signed integer and adds a Default implementation.