### PR TITLE
fix(web): remove `contenteditable=true` from top level element

### DIFF
--- a/web-client/iron-remote-desktop/src/iron-remote-desktop.svelte
+++ b/web-client/iron-remote-desktop/src/iron-remote-desktop.svelte
@@ -759,12 +759,7 @@
         class:capturing-inputs={capturingInputs}
         style={wrapperStyle}
     >
-        <div
-            bind:this={screenViewer}
-            class="screen-viewer"
-            style={viewerStyle}
-            onpaste={ffOnPasteHandler}
-        >
+        <div bind:this={screenViewer} class="screen-viewer" style={viewerStyle} onpaste={ffOnPasteHandler}>
             <canvas
                 bind:this={canvas}
                 onmousemove={getMousePos}


### PR DESCRIPTION
Setting `contenteditable=true` causes spurious edits of that element (when pressing dead keys using the BEPO or AZERTY keyboard).

`contenteditable=true`  was added to workaround the clipboard on Firefox: https://github.com/Devolutions/IronRDP/blob/35c19ce444bcbb1b4250d00977d60b30fab42eca/web-client/iron-remote-desktop/src/iron-remote-desktop.svelte#L59-L63

Its removal in this PR will likely break clibpoard on Firefox, but it shouldn't be an issue since we're going to rework clibpoard logic. I might good idea to merge this PR with the clipboard rework PRs to have the least possible impact. 