### PR TITLE
refactor: add redundant_imports rustc style/readability lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ unused_qualifications = "warn"
 keyword_idents = "warn"
 noop_method_call = "warn"
 macro_use_extern_crate = "warn"
+redundant_imports = "warn"
 # missing_docs = "warn" # TODO: NOTE(@CBenoit): we probably want to ensure this in core tier crates only
 
 # == Compile-time / optimization == #

--- a/crates/ironrdp-connector/src/connection_activation.rs
+++ b/crates/ironrdp-connector/src/connection_activation.rs
@@ -266,8 +266,8 @@ fn create_client_confirm_active(
 ) -> rdp::capability_sets::ClientConfirmActive {
     use ironrdp_pdu::rdp::capability_sets::{
         client_codecs_capabilities, Bitmap, BitmapCache, BitmapDrawingFlags, Brush, CacheDefinition, CacheEntry,
-        CapabilitySet, ClientConfirmActive, CmdFlags, DemandActive, FrameAcknowledge, General, GeneralExtraFlags,
-        GlyphCache, GlyphSupportLevel, Input, InputFlags, LargePointer, LargePointerSupportFlags, MultifragmentUpdate,
+        ClientConfirmActive, CmdFlags, DemandActive, FrameAcknowledge, General, GeneralExtraFlags, GlyphCache,
+        GlyphSupportLevel, Input, InputFlags, LargePointer, LargePointerSupportFlags, MultifragmentUpdate,
         OffscreenBitmapCache, Order, OrderFlags, OrderSupportExFlags, Pointer, Sound, SoundFlags, SupportLevel,
         SurfaceCommands, VirtualChannel, VirtualChannelFlags, BITMAP_CACHE_ENTRIES_NUM, GLYPH_CACHE_NUM,
         SERVER_CHANNEL_ID,

--- a/crates/ironrdp-dvc/src/lib.rs
+++ b/crates/ironrdp-dvc/src/lib.rs
@@ -18,7 +18,7 @@ use crate::alloc::borrow::ToOwned as _;
 pub use ironrdp_pdu;
 use ironrdp_core::{assert_obj_safe, cast_length, encode_vec, other_err, AsAny, Encode, EncodeResult};
 use ironrdp_pdu::{decode_err, pdu_other_err, PduResult};
-use ironrdp_svc::{self, SvcMessage};
+use ironrdp_svc::SvcMessage;
 
 mod complete_data;
 use complete_data::CompleteData;

--- a/crates/ironrdp-error/src/lib.rs
+++ b/crates/ironrdp-error/src/lib.rs
@@ -5,7 +5,7 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", not(feature = "std")))]
 use alloc::boxed::Box;
 use core::fmt;
 

--- a/crates/ironrdp-fuzzing/src/oracles/mod.rs
+++ b/crates/ironrdp-fuzzing/src/oracles/mod.rs
@@ -18,7 +18,7 @@ pub fn pdu_decode(data: &[u8]) {
     use ironrdp_pdu::nego::{ConnectionConfirm, ConnectionRequest};
     use ironrdp_pdu::rdp::{capability_sets, headers, server_error_info, server_license, vc, ClientInfoPdu};
     use ironrdp_pdu::x224::X224;
-    use ironrdp_pdu::{bitmap, codecs, fast_path, gcc, input, ironrdp_core, pcb, surface_commands};
+    use ironrdp_pdu::{bitmap, codecs, fast_path, gcc, input, pcb, surface_commands};
 
     let _ = decode::<X224<ConnectionRequest>>(data);
     let _ = decode::<X224<ConnectionConfirm>>(data);

--- a/crates/ironrdp-graphics/src/rlgr.rs
+++ b/crates/ironrdp-graphics/src/rlgr.rs
@@ -2,9 +2,7 @@ use core::cmp::min;
 use std::io;
 
 use bitvec::field::BitField as _;
-use bitvec::order::Msb0;
 use bitvec::prelude::*;
-use bitvec::slice::BitSlice;
 use ironrdp_pdu::codecs::rfx::EntropyAlgorithm;
 
 use crate::utils::Bits;

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -25,9 +25,8 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::TcpStream;
 use tokio::sync::oneshot;
 use tokio_tungstenite::tungstenite::handshake::client::generate_key;
-use tokio_tungstenite::tungstenite::http;
 use tokio_tungstenite::tungstenite::protocol::Role;
-use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::{http, Message};
 use tokio_tungstenite::WebSocketStream;
 use tokio_util::sync::PollSender;
 

--- a/crates/ironrdp-pdu/src/basic_output/surface_commands/tests.rs
+++ b/crates/ironrdp-pdu/src/basic_output/surface_commands/tests.rs
@@ -2,7 +2,6 @@ use ironrdp_core::{decode, encode};
 use lazy_static::lazy_static;
 
 use super::*;
-use crate::geometry::ExclusiveRectangle;
 
 const FRAME_MARKER_BUFFER: [u8; 8] = [0x4, 0x0, 0x0, 0x0, 0x5, 0x0, 0x0, 0x0];
 

--- a/crates/ironrdp-pdu/src/mcs.rs
+++ b/crates/ironrdp-pdu/src/mcs.rs
@@ -939,16 +939,15 @@ pub use legacy::McsError;
 mod legacy {
     use std::io;
 
-    use ironrdp_core::{Decode, DecodeResult, Encode, EncodeResult};
+    use ironrdp_core::{Decode, DecodeResult, Encode};
     use thiserror::Error;
 
     use super::{
         cast_length, ensure_size, ConnectInitial, ConnectResponse, DomainParameters, PduError, ReadCursor, WriteCursor,
         RESULT_ENUM_LENGTH,
     };
-    use crate::ber;
-    use crate::gcc::conference_create::{ConferenceCreateRequest, ConferenceCreateResponse};
-    use crate::gcc::GccError;
+    use crate::gcc::{ConferenceCreateRequest, ConferenceCreateResponse, GccError};
+    use crate::{ber, EncodeResult};
 
     // impl<'de> McsPdu<'de> for ConnectInitial {
     //     const MCS_NAME: &'static str = "DisconnectProviderUltimatum";

--- a/crates/ironrdp-pdu/src/rdp/capability_sets/bitmap_codecs/tests.rs
+++ b/crates/ironrdp-pdu/src/rdp/capability_sets/bitmap_codecs/tests.rs
@@ -1,4 +1,4 @@
-use ironrdp_core::{decode, decode_cursor, encode_vec, DecodeErrorKind};
+use ironrdp_core::{decode_cursor, encode_vec, DecodeErrorKind};
 use lazy_static::lazy_static;
 
 use super::*;

--- a/crates/ironrdp-pdu/src/rdp/server_license/client_new_license_request/tests.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_license/client_new_license_request/tests.rs
@@ -5,7 +5,7 @@ use lazy_static::lazy_static;
 use super::*;
 use crate::rdp::server_license::server_license_request::cert::{CertificateType, X509CertificateChain};
 use crate::rdp::server_license::server_license_request::{ProductInfo, Scope, ServerCertificate};
-use crate::rdp::server_license::{LicensePdu, PREAMBLE_SIZE};
+use crate::rdp::server_license::LicensePdu;
 
 const LICENSE_HEADER_BUFFER_NO_SIZE: [u8; 6] = [
     0x80, 0x00, // flags

--- a/crates/ironrdp-pdu/src/rdp/server_license/client_platform_challenge_response/test.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_license/client_platform_challenge_response/test.rs
@@ -2,10 +2,7 @@ use ironrdp_core::{decode, encode_vec};
 use lazy_static::lazy_static;
 
 use super::*;
-use crate::rdp::server_license::{
-    BasicSecurityHeader, BasicSecurityHeaderFlags, LicenseHeader, LicensePdu, PreambleFlags, PreambleType,
-    PreambleVersion, BASIC_SECURITY_HEADER_SIZE, PREAMBLE_SIZE,
-};
+use crate::rdp::server_license::{LicensePdu, BASIC_SECURITY_HEADER_SIZE};
 
 const PLATFORM_CHALLENGE_RESPONSE_DATA_BUFFER: [u8; 18] = [
     0x00, 0x01, // version

--- a/crates/ironrdp-pdu/src/rdp/server_license/licensing_error_message/test.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_license/licensing_error_message/test.rs
@@ -2,8 +2,7 @@ use ironrdp_core::{decode, encode_vec};
 use lazy_static::lazy_static;
 
 use super::*;
-use crate::rdp::headers::{BasicSecurityHeader, BasicSecurityHeaderFlags};
-use crate::rdp::server_license::{LicensePdu, PreambleFlags, PreambleVersion};
+use crate::rdp::server_license::LicensePdu;
 
 const HEADER_MESSAGE_BUFFER: [u8; 8] = [0x80, 0x00, 0x00, 0x00, 0xFF, 0x03, 0x14, 0x00];
 

--- a/crates/ironrdp-pdu/src/rdp/server_license/server_license_request/tests.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_license/server_license_request/tests.rs
@@ -1,4 +1,4 @@
-use ironrdp_core::{decode, encode_vec, Encode as _};
+use ironrdp_core::{decode, encode_vec};
 use lazy_static::lazy_static;
 
 use super::cert::{RsaPublicKey, PROP_CERT_BLOBS_HEADERS_SIZE, PROP_CERT_NO_BLOBS_SIZE, RSA_KEY_SIZE_WITHOUT_MODULUS};

--- a/crates/ironrdp-pdu/src/rdp/session_info/tests.rs
+++ b/crates/ironrdp-pdu/src/rdp/session_info/tests.rs
@@ -1,4 +1,4 @@
-use ironrdp_core::{decode, encode_vec, DecodeErrorKind, Encode as _};
+use ironrdp_core::{decode, encode_vec, DecodeErrorKind};
 use lazy_static::lazy_static;
 
 use super::*;

--- a/crates/ironrdp-pdu/src/utils.rs
+++ b/crates/ironrdp-pdu/src/utils.rs
@@ -1,5 +1,4 @@
 use core::fmt::Debug;
-use core::mem::size_of;
 use core::ops::Add;
 
 use byteorder::{LittleEndian, ReadBytesExt as _};

--- a/crates/ironrdp-rdpdr/src/pdu/efs.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/efs.rs
@@ -4,7 +4,6 @@
 
 use core::fmt;
 use core::fmt::{Debug, Display};
-use core::mem::size_of;
 
 use bitflags::bitflags;
 use ironrdp_core::{

--- a/crates/ironrdp-rdpdr/src/pdu/esc.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/esc.rs
@@ -5,8 +5,6 @@
 pub mod ndr;
 pub mod rpce;
 
-use core::mem::size_of;
-
 use bitflags::bitflags;
 use ironrdp_core::{
     cast_length, ensure_size, invalid_field_err, other_err, DecodeError, DecodeResult, EncodeResult, ReadCursor,

--- a/crates/ironrdp-rdpdr/src/pdu/esc/ndr.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/esc/ndr.rs
@@ -21,8 +21,6 @@
 //!
 //! [smartcard_pack.c]: https://github.com/FreeRDP/FreeRDP/blob/ff303a9bda911c54ffc1b9f2471acd79c897b075/libfreerdp/utils/smartcard_pack.c
 
-use core::mem::size_of;
-
 use ironrdp_core::{ensure_size, invalid_field_err, DecodeResult, EncodeResult, ReadCursor, WriteCursor};
 use ironrdp_pdu::utils::{self, CharacterSet};
 

--- a/crates/ironrdp-rdpdr/src/pdu/esc/rpce.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/esc/rpce.rs
@@ -2,8 +2,6 @@
 //!
 //! [\[MS-RPCE\]: Remote Procedure Call Protocol Extensions]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rpce/290c38b1-92fe-4229-91e6-4fc376610c15
 
-use core::mem::size_of;
-
 use ironrdp_core::{
     cast_length, ensure_size, invalid_field_err, DecodeError, DecodeResult, EncodeResult, ReadCursor, WriteCursor,
 };

--- a/crates/ironrdp-rdpdr/src/pdu/mod.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/mod.rs
@@ -1,5 +1,4 @@
 use core::fmt::{self, Display};
-use core::mem::size_of;
 
 use ironrdp_core::{
     ensure_size, invalid_field_err, unsupported_value_err, Decode, DecodeError, DecodeResult, Encode, EncodeResult,

--- a/crates/ironrdp-rdpsnd-native/src/cpal.rs
+++ b/crates/ironrdp-rdpsnd-native/src/cpal.rs
@@ -1,4 +1,3 @@
-use core::mem::size_of;
 use core::sync::atomic::{AtomicBool, Ordering};
 use core::time::Duration;
 use std::borrow::Cow;

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -3,8 +3,8 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use anyhow::{anyhow, bail, Context as _, Result};
-use ironrdp_acceptor::{self, Acceptor, AcceptorResult, BeginResult, DesktopSize};
-use ironrdp_async::{bytes, Framed};
+use ironrdp_acceptor::{Acceptor, AcceptorResult, BeginResult, DesktopSize};
+use ironrdp_async::Framed;
 use ironrdp_cliprdr::backend::ClipboardMessage;
 use ironrdp_cliprdr::CliprdrServer;
 use ironrdp_core::{decode, encode_vec, impl_as_any};
@@ -17,7 +17,7 @@ use ironrdp_pdu::rdp::capability_sets::{BitmapCodecs, CapabilitySet, CmdFlags, C
 pub use ironrdp_pdu::rdp::client_info::Credentials;
 use ironrdp_pdu::rdp::headers::{ServerDeactivateAll, ShareControlPdu};
 use ironrdp_pdu::x224::X224;
-use ironrdp_pdu::{self, decode_err, mcs, nego, rdp, Action, PduResult};
+use ironrdp_pdu::{decode_err, mcs, nego, rdp, Action, PduResult};
 use ironrdp_svc::{server_encode_svc_messages, StaticChannelId, StaticChannelSet, SvcProcessor};
 use ironrdp_tokio::{split_tokio_framed, unsplit_tokio_framed, FramedRead, FramedWrite, TokioFramed};
 use rdpsnd::server::{RdpsndServer, RdpsndServerMessage};

--- a/crates/ironrdp-svc/src/lib.rs
+++ b/crates/ironrdp-svc/src/lib.rs
@@ -5,7 +5,6 @@
 
 extern crate alloc;
 
-use alloc::boxed::Box;
 use alloc::collections::BTreeMap;
 use core::any::TypeId;
 use core::fmt;


### PR DESCRIPTION
The name of the lint is self-explanatory 😁