### PR TITLE
chore: add lossy_float_literal clippy correctness lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ cast_possible_truncation = "warn"
 cast_possible_wrap = "warn"
 cast_sign_loss = "warn"
 float_cmp = "warn"
+lossy_float_literal = "warn"
 as_underscore = "warn"
 # TODO: unwrap_used = "warn" # Let’s either handle `None`, `Err` or use `expect` to give a reason.
 large_stack_frames = "warn"


### PR DESCRIPTION
This lint checks the float literals that cannot be represented as the underlying type without loss.