### PR TITLE
fix(web): make check for `isUnicodeCharacter` in `sendKeyboard` more strict

### DIFF
--- a/web-client/iron-remote-desktop/src/services/remote-desktop.service.ts
+++ b/web-client/iron-remote-desktop/src/services/remote-desktop.service.ts
@@ -343,7 +343,7 @@ export class RemoteDesktopService {
                 }
 
                 const keyCode = scanCode(evt.key);
-                const isUnicodeCharacter = Number.isNaN(keyCode) && evt.key.length === 1;
+                const isUnicodeCharacter = Number.isNaN(keyCode) && evt.key.length === 1 && !isModifierKey;
 
                 if (isUnicodeCharacter && sendAsUnicode) {
                     this.doTransactionFromDeviceEvents([unicodeEvent(evt.key)]);


### PR DESCRIPTION
This resolves an issue with Unicode input that happens under _Chrome_, where entering `Alt` codes results in broken modifier state and broken input in general.

This happens because of how _Chrome_ handles `KeyboardEvent` key and code in this particular case. For example, holding `Alt`, pressing 1, 2, 3 on a numpad, then releasing `Alt` will result in events with the following key/code values being passed to `sendKeyboard`:
`{ "key": "Alt", "code": "AltLeft" ,"type": "keydown" }`
`{ "key": "1", "code": "Numpad1" ,"type": "keydown" }`
`{ "key": "1", "code": "Numpad1" ,"type": "keyup" }`
`{ "key": "2", "code": "Numpad2" ,"type": "keydown" }`
`{ "key": "2", "code": "Numpad2" ,"type": "keyup" }`
`{ "key": "3", "code": "Numpad3" ,"type": "keydown" }`
`{ "key": "3", "code": "Numpad3" ,"type": "keyup" }`
`{ "key": "{", "code": "AltLeft" ,"type": "keyup" }`

Without this fix, this will send Unicode `{` instead of plain `Alt` to the RDP server, messing up the `Alt` code sequence and leaving `Al` in pressed state.

For comparison, in _Firefox_ last event looks like this: `{ "key": "Alt", "code": "AltLeft","type": "keyup" }`

Fixes https://github.com/Devolutions/IronVNC/issues/862.