### PR TITLE
chore: add `mem_forget` clippy correctness lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ lossy_float_literal = "warn"
 as_underscore = "warn"
 # TODO: unwrap_used = "warn" # Let’s either handle `None`, `Err` or use `expect` to give a reason.
 large_stack_frames = "warn"
+mem_forget = "warn"
 
 # == Style, readability == #
 semicolon_outside_block = "warn" # With semicolon-outside-block-ignore-multiline = true

--- a/crates/ironrdp-cliprdr-native/src/windows/utils.rs
+++ b/crates/ironrdp-cliprdr-native/src/windows/utils.rs
@@ -69,6 +69,7 @@ pub(crate) unsafe fn render_format(format: ClipboardFormatId, data: &[u8]) -> Wi
 
     // We successfully transferred ownership of the data to the clipboard, we don't need to
     // call drop on handle
+    #[expect(clippy::mem_forget)]
     core::mem::forget(global_data);
 
     Ok(())


### PR DESCRIPTION
This lint warns on usage of `std::mem::forget`. If it's needed, we should silence the lint and justify that it's used mindfully. 