### PR TITLE
chore: add `mixed_read_write_in_expression` clippy correctness lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ as_underscore = "warn"
 # TODO: unwrap_used = "warn" # Let’s either handle `None`, `Err` or use `expect` to give a reason.
 large_stack_frames = "warn"
 mem_forget = "warn"
+mixed_read_write_in_expression = "warn"
 
 # == Style, readability == #
 semicolon_outside_block = "warn" # With semicolon-outside-block-ignore-multiline = true


### PR DESCRIPTION
`mixed_read_write_in_expression`  checks for a read and a write to the same variable, where whether the read occurs before or after the write depends on the evaluation order of sub-expressions.