### PR TITLE
refactor: add `non_ascii_literal` clippy correctness lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ large_stack_frames = "warn"
 mem_forget = "warn"
 mixed_read_write_in_expression = "warn"
 needless_raw_strings = "warn"
+non_ascii_literal = "warn"
 
 # == Style, readability == #
 semicolon_outside_block = "warn" # With semicolon-outside-block-ignore-multiline = true

--- a/crates/ironrdp-client/src/main.rs
+++ b/crates/ironrdp-client/src/main.rs
@@ -94,7 +94,7 @@ fn setup_logging(log_file: Option<&str>) -> anyhow::Result<()> {
             .create(true)
             .append(true)
             .open(log_file)
-            .with_context(|| format!("couldn’t open {log_file}"))?;
+            .with_context(|| format!("couldn't open {log_file}"))?;
         let fmt_layer = tracing_subscriber::fmt::layer()
             .with_ansi(false)
             .with_writer(file)

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -394,7 +394,7 @@ where
         framed
             .write_all(&rdcleanpath_req)
             .await
-            .map_err(|e| connector::custom_err!("couldn’t write RDCleanPath request", e))?;
+            .map_err(|e| connector::custom_err!("couldn't write RDCleanPath request", e))?;
     }
 
     {

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -354,7 +354,7 @@ impl Sequence for ClientConnector {
                 if client_gcc_blocks.security == gcc::ClientSecurityData::no_security()
                     && server_gcc_blocks.security != gcc::ServerSecurityData::no_security()
                 {
-                    return Err(general_err!("can’t satisfy server security settings"));
+                    return Err(general_err!("can't satisfy server security settings"));
                 }
 
                 if server_gcc_blocks.message_channel.is_some() {

--- a/crates/ironrdp-connector/src/lib.rs
+++ b/crates/ironrdp-connector/src/lib.rs
@@ -280,7 +280,7 @@ impl Written {
     pub fn from_size(value: usize) -> ConnectorResult<Self> {
         core::num::NonZeroUsize::new(value)
             .map(Self::Size)
-            .ok_or_else(|| ConnectorError::general("invalid written length (can’t be zero)"))
+            .ok_or_else(|| ConnectorError::general("invalid written length (can't be zero)"))
     }
 
     #[inline]

--- a/crates/ironrdp-pdu/src/rdp/server_error_info.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_error_info.rs
@@ -149,7 +149,7 @@ impl ProtocolIndependentCode {
             Self::ServerDeniedConnection => "The server denied the connection",
             Self::ServerInsufficientPrivileges => "The user cannot connect to the server due to insufficient access privileges",
             Self::ServerFreshCredentialsRequired => "The server does not accept saved user credentials and requires that the user enter their credentials for each connection",
-            Self::RpcInitiatedDisconnectByuser => "The disconnection was initiated by an administrative tool on the server running in the user’s session",
+            Self::RpcInitiatedDisconnectByuser => "The disconnection was initiated by an administrative tool on the server running in the user's session",
             Self::LogoffByUser => "The disconnection was initiated by the user logging off his or her session on the server",
             Self::CloseStackOnDriverNotReady => "The display driver in the remote session did not report any status within the time allotted for startup",
             Self::ServerDwmCrash => "The DWM process running in the remote session terminated unexpectedly",

--- a/xtask/src/clean.rs
+++ b/xtask/src/clean.rs
@@ -3,11 +3,11 @@ use crate::prelude::*;
 pub fn workspace(sh: &Shell) -> anyhow::Result<()> {
     let _s = Section::new("CLEAN");
 
-    println!("Remove wasm package folder…");
+    println!("Remove wasm package folder...");
     sh.remove_path("./crates/ironrdp-web/pkg")?;
     println!("Done.");
 
-    println!("Remove npm folders…");
+    println!("Remove npm folders...");
     sh.remove_path("./web-client/iron-remote-desktop/node_modules")?;
     sh.remove_path("./web-client/iron-remote-desktop/dist")?;
     sh.remove_path("./web-client/iron-remote-desktop-rdp/node_modules")?;
@@ -15,7 +15,7 @@ pub fn workspace(sh: &Shell) -> anyhow::Result<()> {
     sh.remove_path("./web-client/iron-svelte-client/node_modules")?;
     println!("Done.");
 
-    println!("Remove local cargo root folder…");
+    println!("Remove local cargo root folder...");
     sh.remove_path("./.cargo/local_root")?;
     println!("Done.");
 

--- a/xtask/src/cov.rs
+++ b/xtask/src/cov.rs
@@ -92,7 +92,7 @@ pub fn report_github(sh: &Shell, repo: &str, pr_id: u32) -> anyhow::Result<()> {
     match std::env::var_os("GH_TOKEN") {
         Some(value) if value.is_empty() => trace!("WARNING: `GH_TOKEN` environment variable is empty"),
         Some(value) if value.is_ascii() => trace!("`GH_TOKEN` environment variable appears to be set properly"),
-        Some(_) => trace!("WARNING: `GH_TOKEN` environment variable’s value is not an ASCII string"),
+        Some(_) => trace!("WARNING: `GH_TOKEN` environment variable's value is not an ASCII string"),
         None => trace!("WARNING: `GH_TOKEN` environment variable is not set"),
     }
 
@@ -151,7 +151,7 @@ pub fn report_github(sh: &Shell, repo: &str, pr_id: u32) -> anyhow::Result<()> {
             .ignore_stdout()
             .run()?;
     } else {
-        println!("Coverage didn’t change, skip GitHub comment");
+        println!("Coverage didn't change, skip GitHub comment");
     }
 
     Ok(())


### PR DESCRIPTION
This lint checks for non-ASCII characters in string and char literals.