### PR TITLE
fix(web)!: replace current clipboard logic with auto and manual clipboard modes

### DIFF
--- a/crates/iron-remote-desktop/src/lib.rs
+++ b/crates/iron-remote-desktop/src/lib.rs
@@ -267,16 +267,6 @@ macro_rules! make_bridge {
                 ))
             }
 
-            #[wasm_bindgen(js_name = remoteReceivedFormatListCallback)]
-            pub fn remote_received_format_list_callback(
-                &self,
-                callback: $crate::internal::web_sys::js_sys::Function,
-            ) -> Self {
-                Self($crate::SessionBuilder::remote_received_format_list_callback(
-                    &self.0, callback,
-                ))
-            }
-
             #[wasm_bindgen(js_name = forceClipboardUpdateCallback)]
             pub fn force_clipboard_update_callback(
                 &self,

--- a/crates/iron-remote-desktop/src/session.rs
+++ b/crates/iron-remote-desktop/src/session.rs
@@ -46,9 +46,6 @@ pub trait SessionBuilder {
     fn remote_clipboard_changed_callback(&self, callback: js_sys::Function) -> Self;
 
     #[must_use]
-    fn remote_received_format_list_callback(&self, callback: js_sys::Function) -> Self;
-
-    #[must_use]
     fn force_clipboard_update_callback(&self, callback: js_sys::Function) -> Self;
 
     #[must_use]

--- a/crates/ironrdp-cliprdr/src/backend.rs
+++ b/crates/ironrdp-cliprdr/src/backend.rs
@@ -73,18 +73,6 @@ pub trait CliprdrBackend: AsAny + core::fmt::Debug + Send {
     /// client's clipboard prior to `CLIPRDR` SVC initialization.
     fn on_request_format_list(&mut self);
 
-    /// Called by [crate::Cliprdr] when copy sequence is finished.
-    /// This method is called after remote returns format list response.
-    ///
-    /// Useful for the backend implementations which need to know when remote is ready to paste
-    /// previously advertised formats from the client. E.g. Web client uses this for
-    /// Firefox-specific logic to delay sending keyboard key events to prevent pasting the old
-    /// data from the clipboard.
-    ///
-    /// This method has default implementation which does nothing because it is not required for
-    /// most of the backends.
-    fn on_format_list_received(&mut self) {}
-
     /// Adjusts [crate::Cliprdr] backend capabilities based on capabilities negotiated with a server.
     ///
     /// Called by [crate::Cliprdr] when capability negotiation is finished and server capabilities are

--- a/crates/ironrdp-cliprdr/src/lib.rs
+++ b/crates/ironrdp-cliprdr/src/lib.rs
@@ -166,8 +166,6 @@ impl<R: Role> Cliprdr<R> {
                         info!("CLIPRDR(clipboard) Remote has received format list successfully");
                     }
                 }
-
-                self.backend.on_format_list_received();
             }
             FormatListResponse::Fail => {
                 return self.handle_error_transition(ClipboardError::FormatListRejected);

--- a/crates/ironrdp-web/src/clipboard.rs
+++ b/crates/ironrdp-web/src/clipboard.rs
@@ -104,7 +104,6 @@ pub(crate) enum WasmClipboardBackendMessage {
     RemoteClipboardChanged(Vec<ClipboardFormat>),
     RemoteDataResponse(FormatDataResponse<'static>),
 
-    FormatListReceived,
     ForceClipboardUpdate,
 }
 
@@ -124,7 +123,6 @@ pub(crate) struct WasmClipboard {
 /// Callbacks, required to interact with JS code from within the backend.
 pub(crate) struct JsClipboardCallbacks {
     pub(crate) on_remote_clipboard_changed: js_sys::Function,
-    pub(crate) on_remote_received_format_list: Option<js_sys::Function>,
     pub(crate) on_force_clipboard_update: Option<js_sys::Function>,
 }
 
@@ -495,11 +493,6 @@ impl WasmClipboard {
                     }
                 }
             }
-            WasmClipboardBackendMessage::FormatListReceived => {
-                if let Some(callback) = self.js_callbacks.on_remote_received_format_list.as_mut() {
-                    callback.call0(&JsValue::NULL).expect("failed to call JS callback");
-                }
-            }
             WasmClipboardBackendMessage::ForceClipboardUpdate => {
                 if let Some(callback) = self.js_callbacks.on_force_clipboard_update.as_mut() {
                     callback.call0(&JsValue::NULL).expect("failed to call JS callback");
@@ -545,10 +538,6 @@ impl CliprdrBackend for WasmClipboardBackend {
     fn on_request_format_list(&mut self) {
         // Initial clipboard is assumed to be empty on WASM (TODO: This is only relevant for Firefox?)
         self.send_event(WasmClipboardBackendMessage::ForceClipboardUpdate);
-    }
-
-    fn on_format_list_received(&mut self) {
-        self.send_event(WasmClipboardBackendMessage::FormatListReceived);
     }
 
     fn on_process_negotiated_capabilities(&mut self, _: ClipboardGeneralCapabilityFlags) {

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -65,7 +65,6 @@ struct SessionBuilderInner {
     set_cursor_style_callback: Option<js_sys::Function>,
     set_cursor_style_callback_context: Option<JsValue>,
     remote_clipboard_changed_callback: Option<js_sys::Function>,
-    remote_received_format_list_callback: Option<js_sys::Function>,
     force_clipboard_update_callback: Option<js_sys::Function>,
 
     use_display_control: bool,
@@ -94,7 +93,6 @@ impl Default for SessionBuilderInner {
             set_cursor_style_callback: None,
             set_cursor_style_callback_context: None,
             remote_clipboard_changed_callback: None,
-            remote_received_format_list_callback: None,
             force_clipboard_update_callback: None,
 
             use_display_control: false,
@@ -199,12 +197,6 @@ impl iron_remote_desktop::SessionBuilder for SessionBuilder {
     }
 
     /// Optional
-    fn remote_received_format_list_callback(&self, callback: js_sys::Function) -> Self {
-        self.0.borrow_mut().remote_received_format_list_callback = Some(callback);
-        self.clone()
-    }
-
-    /// Optional
     fn force_clipboard_update_callback(&self, callback: js_sys::Function) -> Self {
         self.0.borrow_mut().force_clipboard_update_callback = Some(callback);
         self.clone()
@@ -253,7 +245,6 @@ impl iron_remote_desktop::SessionBuilder for SessionBuilder {
             set_cursor_style_callback,
             set_cursor_style_callback_context,
             remote_clipboard_changed_callback,
-            remote_received_format_list_callback,
             force_clipboard_update_callback,
             outbound_message_size_limit,
         );
@@ -283,7 +274,6 @@ impl iron_remote_desktop::SessionBuilder for SessionBuilder {
                 .clone()
                 .context("set_cursor_style_callback_context missing")?;
             remote_clipboard_changed_callback = inner.remote_clipboard_changed_callback.clone();
-            remote_received_format_list_callback = inner.remote_received_format_list_callback.clone();
             force_clipboard_update_callback = inner.force_clipboard_update_callback.clone();
             outbound_message_size_limit = inner.outbound_message_size_limit;
         }
@@ -302,7 +292,6 @@ impl iron_remote_desktop::SessionBuilder for SessionBuilder {
                 clipboard::WasmClipboardMessageProxy::new(input_events_tx.clone()),
                 clipboard::JsClipboardCallbacks {
                     on_remote_clipboard_changed: callback,
-                    on_remote_received_format_list: remote_received_format_list_callback,
                     on_force_clipboard_update: force_clipboard_update_callback,
                 },
             )

--- a/web-client/iron-remote-desktop/src/enums/SessionEventType.ts
+++ b/web-client/iron-remote-desktop/src/enums/SessionEventType.ts
@@ -2,4 +2,7 @@
     STARTED,
     TERMINATED,
     ERROR,
+
+    // Clipboard events
+    CLIPBOARD_REMOTE_UPDATE,
 }

--- a/web-client/iron-remote-desktop/src/interfaces/UserInteraction.ts
+++ b/web-client/iron-remote-desktop/src/interfaces/UserInteraction.ts
@@ -31,5 +31,11 @@ export interface UserInteraction {
 
     setEnableClipboard(enable: boolean): void;
 
+    setEnableAutoClipboard(enable: boolean): void;
+
+    saveRemoteClipboardData(): Promise<boolean>;
+
+    sendClipboardData(): Promise<boolean>;
+
     invokeExtension(ext: Extension): void;
 }

--- a/web-client/iron-remote-desktop/src/iron-remote-desktop.svelte
+++ b/web-client/iron-remote-desktop/src/iron-remote-desktop.svelte
@@ -20,8 +20,10 @@
     import type { ResizeEvent } from './interfaces/ResizeEvent';
     import { PublicAPI } from './services/PublicAPI';
     import { ScreenScale } from './enums/ScreenScale';
-    import type { ClipboardData } from './interfaces/ClipboardData';
     import type { RemoteDesktopModule } from './interfaces/RemoteDesktopModule';
+    import { isComponentDestroyed } from './lib/stores/componentLifecycleStore';
+    import { runWhenFocusedQueue } from './lib/stores/runWhenFocusedStore';
+    import { ClipboardService } from './services/clipboard.service';
 
     let {
         scale,
@@ -46,381 +48,15 @@
 
     let inner: HTMLDivElement;
     let wrapper: HTMLDivElement;
-    let screenViewer: HTMLDivElement;
     let canvas: HTMLCanvasElement;
 
     let viewerStyle = $state('');
     let wrapperStyle = $state('');
     let remoteDesktopService = new RemoteDesktopService(module);
-    let publicAPI = new PublicAPI(remoteDesktopService);
+    let clipboardService = new ClipboardService(remoteDesktopService, module);
+    let publicAPI = new PublicAPI(remoteDesktopService, clipboardService);
 
     let currentScreenScale = ScreenScale.Fit;
-
-    // Firefox's clipboard API is very limited, and doesn't support reading from the clipboard
-    // without changing browser settings via `about:config`.
-    //
-    // For firefox, we will use a different approach by marking `screen-wrapper` component
-    // as `contenteditable=true`, and then using the `onpaste`/`oncopy`/`oncut` events.
-    let isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
-
-    const CLIPBOARD_MONITORING_INTERVAL = 100; // ms
-
-    let isClipboardApiSupported = false;
-    let lastClientClipboardItems: Record<string, string | Uint8Array> = {};
-    let lastReceivedClipboardData: Record<string, string | Uint8Array> = {};
-    let lastSentClipboardData: ClipboardData | null = null;
-    let lastClipboardMonitorLoopError: Error | null = null;
-
-    let componentDestroyed = false;
-    let runWhenFocusedQueue: (() => void)[] = [];
-
-    /* Firefox-specific BEGIN */
-
-    // See `ffRemoteClipboardData` variable docs below
-    const FF_REMOTE_CLIPBOARD_DATA_SET_RETRY_INTERVAL = 100; // ms
-    const FF_REMOTE_CLIPBOARD_DATA_SET_MAX_RETRIES = 30; // 3 seconds (100ms * 30)
-    // On Firefox, this interval is used to stop delaying the keyboard events if the paste event has
-    // failed and we haven't received any clipboard data from the remote side.
-    const FF_LOCAL_CLIPBOARD_COPY_TIMEOUT = 1000; // 1s (For text-only data this should be enough)
-
-    // In Firefox, we need this variable due to fact that `clipboard.writeText()` should only be
-    // called in scope of user-initiated event processing (e.g. keyboard event), but we receive
-    // clipboard data from the remote side asynchronously in wasm service callback. therefore we
-    // set this variable in callback and use its value on the user-initiated copy event.
-    let ffRemoteClipboardData: ClipboardData | null = null;
-    // For Firefox we need this variable to perform wait loop for the remote side to finish sending
-    // clipboard content to the client.
-    let ffRemoteClipboardDataRetriesLeft = 0;
-    let ffPostponeKeyboardEvents = false;
-    let ffDelayedKeyboardEvents: KeyboardEvent[] = [];
-    let ffCnavasFocused = false;
-
-    /* Firefox-specific END */
-
-    /* Clipboard initialization BEGIN */
-    function initClipboard() {
-        // Detect if browser supports async Clipboard API
-        if (!isFirefox && navigator.clipboard != undefined) {
-            if (navigator.clipboard.read != undefined && navigator.clipboard.write != undefined) {
-                isClipboardApiSupported = true;
-            }
-        }
-
-        if (isFirefox) {
-            remoteDesktopService.setOnRemoteClipboardChanged(ffOnRemoteClipboardChanged);
-            remoteDesktopService.setOnRemoteReceivedFormatList(ffOnRemoteReceivedFormatList);
-            remoteDesktopService.setOnForceClipboardUpdate(onForceClipboardUpdate);
-        } else if (isClipboardApiSupported) {
-            remoteDesktopService.setOnRemoteClipboardChanged(onRemoteClipboardChanged);
-            remoteDesktopService.setOnForceClipboardUpdate(onForceClipboardUpdate);
-
-            // Start the clipboard monitoring loop
-            setTimeout(onMonitorClipboard, CLIPBOARD_MONITORING_INTERVAL);
-        }
-    }
-
-    /* Clipboard initialization END */
-
-    function isCopyKeyboardEvent(evt: KeyboardEvent) {
-        return (
-            (evt.ctrlKey && evt.code === 'KeyC') ||
-            (evt.ctrlKey && evt.code === 'KeyX') ||
-            evt.code == 'Copy' ||
-            evt.code == 'Cut'
-        );
-    }
-
-    function isPasteKeyboardEvent(evt: KeyboardEvent) {
-        return (evt.ctrlKey && evt.code === 'KeyV') || evt.code == 'Paste';
-    }
-
-    // This function is required to convert `ClipboardData` to an object that can be used
-    // with `ClipboardItem` API.
-    function clipboardDataToRecord(data: ClipboardData): Record<string, Blob> {
-        let result = {} as Record<string, Blob>;
-
-        for (const item of data.items()) {
-            let mime = item.mimeType();
-            let value = new Blob([item.value()], { type: mime });
-
-            result[mime] = value;
-        }
-
-        return result;
-    }
-
-    function clipboardDataToClipboardItemsRecord(data: ClipboardData): Record<string, string | Uint8Array> {
-        let result = {} as Record<string, string | Uint8Array>;
-
-        for (const item of data.items()) {
-            let mime = item.mimeType();
-            result[mime] = item.value();
-        }
-
-        return result;
-    }
-
-    // This callback is required to send initial clipboard state if available.
-    function onForceClipboardUpdate() {
-        // TODO(Fix): lastSentClipboardData is nullptr.
-        try {
-            if (lastSentClipboardData) {
-                remoteDesktopService.onClipboardChanged(lastSentClipboardData);
-            } else {
-                remoteDesktopService.onClipboardChangedEmpty();
-            }
-        } catch (err) {
-            console.error('Failed to send initial clipboard state: ' + err);
-        }
-    }
-
-    function runWhenWindowFocused(fn: () => void) {
-        if (document.hasFocus()) {
-            fn();
-        } else {
-            runWhenFocusedQueue.push(fn);
-        }
-    }
-
-    // This callback is required to update client clipboard state when remote side has changed.
-    function onRemoteClipboardChanged(data: ClipboardData) {
-        try {
-            const mime_formats = clipboardDataToRecord(data);
-            const clipboard_item = new ClipboardItem(mime_formats);
-            runWhenWindowFocused(() => {
-                lastReceivedClipboardData = clipboardDataToClipboardItemsRecord(data);
-                navigator.clipboard.write([clipboard_item]);
-            });
-        } catch (err) {
-            console.error('Failed to set client clipboard: ' + err);
-        }
-    }
-
-    // Called periodically to monitor clipboard changes
-    async function onMonitorClipboard() {
-        try {
-            if (!document.hasFocus()) {
-                return;
-            }
-
-            var value = await navigator.clipboard.read();
-
-            // Clipboard is empty
-            if (value.length == 0) {
-                return;
-            }
-
-            // We only support one item at a time
-            var item = value[0];
-
-            if (!item.types.some((type) => type.startsWith('text/') || type.startsWith('image/png'))) {
-                // Unsupported types
-                return;
-            }
-
-            var values: Record<string, string | Uint8Array> = {};
-            var sameValue = true;
-
-            // Sadly, browsers build new `ClipboardItem` object for each `read` call,
-            // so we can't do reference comparison here :(
-            //
-            // For monitoring loop approach we also can't drop this logic, as it will result in
-            // very frequent network activity.
-            for (const kind of item.types) {
-                // Get blob
-                const blobIsString = kind.startsWith('text/');
-
-                const blob = await item.getType(kind);
-                const value = blobIsString ? await blob.text() : new Uint8Array(await blob.arrayBuffer());
-
-                const is_equal = blobIsString
-                    ? function (a: string | Uint8Array | undefined, b: string | Uint8Array | undefined) {
-                          return a === b;
-                      }
-                    : function (a: string | Uint8Array | undefined, b: string | Uint8Array | undefined) {
-                          if (!(a instanceof Uint8Array) || !(b instanceof Uint8Array)) {
-                              return false;
-                          }
-
-                          return (
-                              a != undefined && b != undefined && a.length === b.length && a.every((v, i) => v === b[i])
-                          );
-                      };
-
-                const previousValue = lastClientClipboardItems[kind];
-
-                if (!is_equal(previousValue, value)) {
-                    // When the local clipboard updates, we need to compare it with the last data received from the server.
-                    // If it's identical, the clipboard was updated with the server's data, so we shouldn't send this data
-                    // to the server.
-                    if (is_equal(lastReceivedClipboardData[kind], value)) {
-                        lastClientClipboardItems[kind] = lastReceivedClipboardData[kind];
-                    }
-                    // One of mime types has changed, we need to update the clipboard cache
-                    else {
-                        sameValue = false;
-                    }
-                }
-
-                values[kind] = value;
-            }
-
-            // Clipboard has changed, we need to acknowledge remote side about it.
-            if (!sameValue) {
-                lastClientClipboardItems = values;
-
-                let clipboardData = new module.ClipboardData();
-
-                // Iterate over `Record` type
-                Object.entries(values).forEach(([key, value]: [string, string | Uint8Array]) => {
-                    // skip null/undefined values
-                    if (value == null || value == undefined) {
-                        return;
-                    }
-
-                    if (key.startsWith('text/') && typeof value === 'string') {
-                        clipboardData.addText(key, value);
-                    } else if (key.startsWith('image/') && value instanceof Uint8Array) {
-                        clipboardData.addBinary(key, value);
-                    }
-                });
-
-                if (!clipboardData.isEmpty()) {
-                    lastSentClipboardData = clipboardData;
-                    // TODO(Fix): onClipboardChanged takes an ownership over clipboardData, so lastSentClipboardData will be nullptr.
-                    await remoteDesktopService.onClipboardChanged(clipboardData);
-                }
-            }
-        } catch (err) {
-            if (err instanceof Error) {
-                const printError =
-                    lastClipboardMonitorLoopError === null ||
-                    lastClipboardMonitorLoopError.toString() !== err.toString();
-                // Prevent spamming the console with the same error
-                if (printError) {
-                    console.error('Clipboard monitoring error: ' + err);
-                }
-                lastClipboardMonitorLoopError = err;
-            }
-        } finally {
-            if (!componentDestroyed) {
-                setTimeout(onMonitorClipboard, CLIPBOARD_MONITORING_INTERVAL);
-            }
-        }
-    }
-
-    /* Firefox-specific BEGIN */
-
-    function ffOnRemoteReceivedFormatList() {
-        try {
-            // We are ready to send delayed Ctrl+V events
-            ffSimulateDelayedKeyEvents();
-        } catch (err) {
-            console.error('Failed to send delayed keyboard events: ' + err);
-        }
-    }
-
-    // Only set variable on callback, the real clipboard update will be performed in keyboard
-    // callback. (User-initiated event is required for Firefox to allow clipboard write)
-    function ffOnRemoteClipboardChanged(data: ClipboardData) {
-        ffRemoteClipboardData = data;
-    }
-
-    function ffWaitForRemoteClipboardDataSet() {
-        if (ffRemoteClipboardData) {
-            try {
-                let clipboard_data = ffRemoteClipboardData;
-                ffRemoteClipboardData = null;
-                for (const item of clipboard_data.items()) {
-                    // Firefox only supports text/plain mime type for clipboard writes :(
-                    if (item.mimeType() === 'text/plain') {
-                        const value = item.value();
-
-                        if (typeof value === 'string') {
-                            navigator.clipboard.writeText(value);
-                        } else {
-                            loggingService.error('Unexpected value for text/plain clipboard item');
-                        }
-
-                        break;
-                    }
-                }
-            } catch (err) {
-                console.error('Failed to set client clipboard: ' + err);
-            }
-        } else if (ffRemoteClipboardDataRetriesLeft > 0) {
-            ffRemoteClipboardDataRetriesLeft--;
-            setTimeout(ffWaitForRemoteClipboardDataSet, FF_REMOTE_CLIPBOARD_DATA_SET_RETRY_INTERVAL);
-        }
-    }
-
-    function ffSimulateDelayedKeyEvents() {
-        if (ffDelayedKeyboardEvents.length > 0) {
-            for (const evt of ffDelayedKeyboardEvents) {
-                // simulate consecutive key events
-                keyboardEvent(evt);
-            }
-            ffDelayedKeyboardEvents = [];
-        }
-        ffPostponeKeyboardEvents = false;
-    }
-
-    function ffOnPasteHandler(evt: ClipboardEvent) {
-        // We don't actually want to paste the clipboard data into the `contenteditable` div.
-        evt.preventDefault();
-
-        // `onpaste` events are handled only for Firefox, other browsers we use the clipboard API
-        // for reading the clipboard.
-        if (!isFirefox) {
-            // Prevent processing of the paste event by the browser.
-            return;
-        }
-
-        try {
-            let clipboardData = new module.ClipboardData();
-
-            if (evt.clipboardData == null) {
-                return;
-            }
-
-            for (var clipItem of evt.clipboardData.items) {
-                let mime = clipItem.type;
-
-                if (mime.startsWith('text/')) {
-                    clipItem.getAsString((str: string) => {
-                        clipboardData.addText(mime, str);
-
-                        if (!clipboardData.isEmpty()) {
-                            remoteDesktopService.onClipboardChanged(clipboardData);
-                        }
-                    });
-                    break;
-                }
-
-                if (mime.startsWith('image/')) {
-                    let file = clipItem.getAsFile();
-                    if (file == null) {
-                        continue;
-                    }
-
-                    file.arrayBuffer().then((buffer: ArrayBuffer) => {
-                        const strict_buffer = new Uint8Array(buffer);
-
-                        clipboardData.addBinary(mime, strict_buffer);
-
-                        if (!clipboardData.isEmpty()) {
-                            remoteDesktopService.onClipboardChanged(clipboardData);
-                        }
-                    });
-                    break;
-                }
-            }
-        } catch (err) {
-            console.error('Failed to update remote clipboard: ' + err);
-        }
-    }
-
-    /* Firefox-specific END */
 
     function initListeners() {
         serverBridgeListeners();
@@ -428,28 +64,6 @@
 
         function captureKeys(evt: KeyboardEvent) {
             if (capturingInputs()) {
-                if (ffPostponeKeyboardEvents) {
-                    evt.preventDefault();
-                    ffDelayedKeyboardEvents.push(evt);
-                    return;
-                }
-
-                // For Firefox we need to make `onpaste` event still fire even if
-                // keyboard is being captured. Not capturing `Ctrl + V` should not create any
-                // side effects, therefore is safe to skip capture for it.
-                let isFirefoxPaste = isFirefox && isPasteKeyboardEvent(evt);
-
-                if (isFirefoxPaste) {
-                    ffPostponeKeyboardEvents = true;
-                    ffDelayedKeyboardEvents = [];
-                    ffDelayedKeyboardEvents.push(evt);
-
-                    // If during the given timeout we weren't able to finish the copy sequence, we need to
-                    // simulate all queued keyboard events.
-                    setTimeout(ffSimulateDelayedKeyEvents, FF_LOCAL_CLIPBOARD_COPY_TIMEOUT);
-                    return;
-                }
-
                 keyboardEvent(evt);
             }
         }
@@ -645,22 +259,6 @@
     }
 
     function setMouseButtonState(state: MouseEvent, isDown: boolean) {
-        if (isFirefox) {
-            if (isDown && state.button == 0 && !ffCnavasFocused) {
-                // Do not capture first mouse down event on Firefox, as we need to transfer focus to the
-                // canvas first in order to receive paste events.
-                // wasmService.mouseButtonState(state, isDown, false);
-                // Focus `contenteditable` element to receive `on_paste` events
-                canvas.focus();
-                // Finish the focus sequence on Firefox
-                ffCnavasFocused = true;
-            } else {
-                // This is needed to prevent visible "double click" selection on
-                // `texteditable` element
-                screenViewer.blur();
-            }
-        }
-
         remoteDesktopService.mouseButtonState(state, isDown, true);
     }
 
@@ -678,18 +276,6 @@
     }
 
     function keyboardEvent(evt: KeyboardEvent) {
-        const browserHasClipboardAccess =
-            navigator.clipboard != undefined && navigator.clipboard.writeText != undefined;
-
-        if (isFirefox && browserHasClipboardAccess && isCopyKeyboardEvent(evt)) {
-            // Special processing for firefox, as the only way Firefox supports clipboard write is
-            // only after some user-initiated event (e.g. keyboard event).
-            // therefore we need to wait here for the clipboard data to be ready.
-
-            ffRemoteClipboardDataRetriesLeft = FF_REMOTE_CLIPBOARD_DATA_SET_MAX_RETRIES;
-            ffWaitForRemoteClipboardDataSet();
-        }
-
         remoteDesktopService.sendKeyboardEvent(evt);
 
         // Propagate further
@@ -731,23 +317,28 @@
     }
 
     function focusEventHandler() {
-        while (runWhenFocusedQueue.length > 0) {
-            const fn = runWhenFocusedQueue.shift();
-            fn?.();
+        try {
+            while (runWhenFocusedQueue.length() > 0) {
+                const fn = runWhenFocusedQueue.shift();
+                fn?.();
+            }
+        } catch (err) {
+            console.error('Failed to run the function queued for execution when the window received focus: ' + err);
         }
     }
 
     onMount(async () => {
+        isComponentDestroyed.set(false);
         loggingService.verbose = verbose === 'true';
         loggingService.info('Dom ready');
         await initcanvas();
-        initClipboard();
+        clipboardService.initClipboard();
     });
 
     onDestroy(() => {
         window.removeEventListener('resize', resizeHandler);
         window.removeEventListener('focus', focusEventHandler);
-        componentDestroyed = true;
+        isComponentDestroyed.set(true);
     });
 </script>
 
@@ -759,13 +350,7 @@
         class:capturing-inputs={capturingInputs}
         style={wrapperStyle}
     >
-        <div
-            bind:this={screenViewer}
-            class="screen-viewer"
-            style={viewerStyle}
-            contenteditable={isFirefox}
-            onpaste={ffOnPasteHandler}
-        >
+        <div class="screen-viewer" style={viewerStyle}>
             <canvas
                 bind:this={canvas}
                 onmousemove={getMousePos}

--- a/web-client/iron-remote-desktop/src/lib/stores/componentLifecycleStore.ts
+++ b/web-client/iron-remote-desktop/src/lib/stores/componentLifecycleStore.ts
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store';
+
+export const isComponentDestroyed = writable(false);

--- a/web-client/iron-remote-desktop/src/lib/stores/runWhenFocusedStore.ts
+++ b/web-client/iron-remote-desktop/src/lib/stores/runWhenFocusedStore.ts
@@ -1,0 +1,29 @@
+import { get, writable } from 'svelte/store';
+
+function createQueueStore<T>() {
+    const store = writable<T[]>([]);
+
+    return {
+        subscribe: store.subscribe,
+
+        enqueue(item: T) {
+            store.update((queue) => [...queue, item]);
+        },
+
+        shift(): T | undefined {
+            let first: T | undefined;
+            store.update((queue) => {
+                if (queue.length == 0) return queue;
+                first = queue[0];
+                return queue.slice(1);
+            });
+            return first;
+        },
+
+        length(): number {
+            return get(store).length;
+        },
+    };
+}
+
+export const runWhenFocusedQueue = createQueueStore<() => void>();

--- a/web-client/iron-remote-desktop/src/services/PublicAPI.ts
+++ b/web-client/iron-remote-desktop/src/services/PublicAPI.ts
@@ -7,12 +7,15 @@ import type { ScreenScale } from '../enums/ScreenScale';
 import { ConfigBuilder } from './ConfigBuilder';
 import { Config } from './Config';
 import type { Extension } from '../interfaces/Extension';
+import type { ClipboardService } from './clipboard.service';
 
 export class PublicAPI {
     private remoteDesktopService: RemoteDesktopService;
+    private clipboardService: ClipboardService;
 
-    constructor(remoteDesktopService: RemoteDesktopService) {
+    constructor(remoteDesktopService: RemoteDesktopService, clipboardService: ClipboardService) {
         this.remoteDesktopService = remoteDesktopService;
+        this.clipboardService = clipboardService;
     }
 
     private configBuilder(): ConfigBuilder {
@@ -61,6 +64,18 @@ export class PublicAPI {
         this.remoteDesktopService.setEnableClipboard(enable);
     }
 
+    private setEnableAutoClipboard(enable: boolean) {
+        this.remoteDesktopService.setEnableAutoClipboard(enable);
+    }
+
+    private async saveRemoteClipboardData(): Promise<boolean> {
+        return await this.clipboardService.saveRemoteClipboardData();
+    }
+
+    private async sendClipboardData(): Promise<boolean> {
+        return await this.clipboardService.sendClipboardData();
+    }
+
     private invokeExtension(ext: Extension) {
         this.remoteDesktopService.invokeExtension(ext);
     }
@@ -81,6 +96,9 @@ export class PublicAPI {
             setCursorStyleOverride: this.setCursorStyleOverride.bind(this),
             resize: this.resize.bind(this),
             setEnableClipboard: this.setEnableClipboard.bind(this),
+            setEnableAutoClipboard: this.setEnableAutoClipboard.bind(this),
+            saveRemoteClipboardData: this.saveRemoteClipboardData.bind(this),
+            sendClipboardData: this.sendClipboardData.bind(this),
             invokeExtension: this.invokeExtension.bind(this),
         };
     }

--- a/web-client/iron-remote-desktop/src/services/clipboard.service.ts
+++ b/web-client/iron-remote-desktop/src/services/clipboard.service.ts
@@ -1,0 +1,312 @@
+import type { RemoteDesktopService } from './remote-desktop.service';
+import { isComponentDestroyed } from '../lib/stores/componentLifecycleStore';
+import { get } from 'svelte/store';
+import type { ClipboardData } from '../interfaces/ClipboardData';
+import type { RemoteDesktopModule } from '../interfaces/RemoteDesktopModule';
+import { runWhenFocusedQueue } from '../lib/stores/runWhenFocusedStore';
+import { SessionEventType } from '../enums/SessionEventType';
+
+const CLIPBOARD_MONITORING_INTERVAL = 100; // ms
+
+export class ClipboardService {
+    private remoteDesktopService: RemoteDesktopService;
+    private module: RemoteDesktopModule;
+
+    private isClipboardApiSupported: boolean = false;
+
+    private lastClientClipboardItems: Record<string, string | Uint8Array> = {};
+    private lastReceivedClipboardData: Record<string, string | Uint8Array> = {};
+    private lastSentClipboardData: ClipboardData | null = null;
+    private clipboardDataToSave: ClipboardData | null = null;
+    private lastClipboardMonitorLoopError: Error | null = null;
+
+    constructor(remoteDesktopService: RemoteDesktopService, module: RemoteDesktopModule) {
+        this.remoteDesktopService = remoteDesktopService;
+        this.module = module;
+    }
+
+    initClipboard() {
+        // Detect if browser supports async Clipboard API
+        if (navigator.clipboard != undefined) {
+            if (navigator.clipboard.read != undefined && navigator.clipboard.write != undefined) {
+                this.isClipboardApiSupported = true;
+            }
+        }
+
+        if (!this.isClipboardApiSupported) return;
+
+        this.remoteDesktopService.setOnForceClipboardUpdate(this.onForceClipboardUpdate.bind(this));
+
+        if (this.remoteDesktopService.autoClipboard) {
+            this.remoteDesktopService.setOnRemoteClipboardChanged(this.onRemoteClipboardChangedAutoMode.bind(this));
+            // Start the clipboard monitoring loop
+            setTimeout(this.onMonitorClipboard.bind(this), CLIPBOARD_MONITORING_INTERVAL);
+        } else {
+            this.remoteDesktopService.setOnRemoteClipboardChanged(this.onRemoteClipboardChangedManualMode.bind(this));
+        }
+    }
+
+    // Copies clipboard content received from the server to the local clipboard.
+    // Returns the result of the operation. On failure, it additionally raises an error session event.
+    async saveRemoteClipboardData(): Promise<boolean> {
+        if (this.clipboardDataToSave == null) {
+            this.remoteDesktopService.raiseSessionEvent({
+                type: SessionEventType.ERROR,
+                data: 'The server did not send the clipboard data.',
+            });
+            return false;
+        }
+
+        try {
+            const mime_formats = this.clipboardDataToRecord(this.clipboardDataToSave);
+            const clipboard_item = new ClipboardItem(mime_formats);
+            await navigator.clipboard.write([clipboard_item]);
+
+            this.clipboardDataToSave = null;
+            return true;
+        } catch (err) {
+            this.remoteDesktopService.raiseSessionEvent({
+                type: SessionEventType.ERROR,
+                data: 'Failed to write to the clipboard: ' + err,
+            });
+            return false;
+        }
+    }
+
+    // Sends local clipboard's content to the server.
+    // Returns the result of the operation. On failure, it additionally raises an error session event.
+    async sendClipboardData(): Promise<boolean> {
+        try {
+            const value = await navigator.clipboard.read();
+
+            // Clipboard is empty
+            if (value.length == 0) {
+                this.remoteDesktopService.raiseSessionEvent({
+                    type: SessionEventType.ERROR,
+                    data: 'The clipboard has no data.',
+                });
+                return false;
+            }
+
+            // We only support one item at a time
+            const item = value[0];
+
+            if (!item.types.some((type) => type.startsWith('text/') || type.startsWith('image/png'))) {
+                // Unsupported types
+                this.remoteDesktopService.raiseSessionEvent({
+                    type: SessionEventType.ERROR,
+                    data: 'The clipboard has no data of supported type (text or image).',
+                });
+                return false;
+            }
+
+            const clipboardData = new this.module.ClipboardData();
+
+            for (const kind of item.types) {
+                // Get blob
+                const blobIsString = kind.startsWith('text/');
+                const blob = await item.getType(kind);
+
+                if (blobIsString) {
+                    clipboardData.addText(kind, await blob.text());
+                } else {
+                    clipboardData.addBinary(kind, new Uint8Array(await blob.arrayBuffer()));
+                }
+            }
+
+            if (!clipboardData.isEmpty()) {
+                this.lastSentClipboardData = clipboardData;
+                // TODO(Fix): onClipboardChanged takes an ownership over clipboardData, so lastSentClipboardData will be nullptr.
+                await this.remoteDesktopService.onClipboardChanged(clipboardData);
+            }
+
+            return true;
+        } catch (err) {
+            this.remoteDesktopService.raiseSessionEvent({
+                type: SessionEventType.ERROR,
+                data: 'Failed to read from the clipboard: ' + err,
+            });
+            return false;
+        }
+    }
+
+    private runWhenWindowFocused(fn: () => void) {
+        if (document.hasFocus()) {
+            fn();
+        } else {
+            runWhenFocusedQueue.enqueue(fn);
+        }
+    }
+
+    // This function is required to convert `ClipboardData` to an object that can be used
+    // with `ClipboardItem` API.
+    private clipboardDataToRecord(data: ClipboardData): Record<string, Blob> {
+        const result = {} as Record<string, Blob>;
+
+        for (const item of data.items()) {
+            const mime = item.mimeType();
+            result[mime] = new Blob([item.value()], { type: mime });
+        }
+
+        return result;
+    }
+
+    private clipboardDataToClipboardItemsRecord(data: ClipboardData): Record<string, string | Uint8Array> {
+        const result = {} as Record<string, string | Uint8Array>;
+
+        for (const item of data.items()) {
+            const mime = item.mimeType();
+            result[mime] = item.value();
+        }
+
+        return result;
+    }
+
+    // This callback is required to send initial clipboard state if available.
+    private onForceClipboardUpdate() {
+        // TODO(Fix): lastSentClipboardData is nullptr.
+        try {
+            if (this.lastSentClipboardData) {
+                this.remoteDesktopService.onClipboardChanged(this.lastSentClipboardData);
+            } else {
+                this.remoteDesktopService.onClipboardChangedEmpty();
+            }
+        } catch (err) {
+            console.error('Failed to send initial clipboard state: ' + err);
+        }
+    }
+
+    // This callback is required to update client clipboard state when remote side has changed.
+    private onRemoteClipboardChangedManualMode(data: ClipboardData) {
+        this.clipboardDataToSave = data;
+        this.remoteDesktopService.raiseSessionEvent({
+            type: SessionEventType.CLIPBOARD_REMOTE_UPDATE,
+            data: '',
+        });
+    }
+
+    // This callback is required to update client clipboard state when remote side has changed.
+    private onRemoteClipboardChangedAutoMode(data: ClipboardData) {
+        try {
+            const mime_formats = this.clipboardDataToRecord(data);
+            const clipboard_item = new ClipboardItem(mime_formats);
+            this.runWhenWindowFocused(() => {
+                this.lastReceivedClipboardData = this.clipboardDataToClipboardItemsRecord(data);
+                navigator.clipboard.write([clipboard_item]);
+            });
+        } catch (err) {
+            console.error('Failed to set client clipboard: ' + err);
+        }
+    }
+
+    // Called periodically to monitor clipboard changes
+    private async onMonitorClipboard() {
+        try {
+            if (!document.hasFocus()) {
+                return;
+            }
+
+            const value = await navigator.clipboard.read();
+
+            // Clipboard is empty
+            if (value.length == 0) {
+                return;
+            }
+
+            // We only support one item at a time
+            const item = value[0];
+
+            if (!item.types.some((type) => type.startsWith('text/') || type.startsWith('image/png'))) {
+                // Unsupported types
+                return;
+            }
+
+            const values: Record<string, string | Uint8Array> = {};
+            let sameValue = true;
+
+            // Sadly, browsers build new `ClipboardItem` object for each `read` call,
+            // so we can't do reference comparison here :(
+            //
+            // For monitoring loop approach we also can't drop this logic, as it will result in
+            // very frequent network activity.
+            for (const kind of item.types) {
+                // Get blob
+                const blobIsString = kind.startsWith('text/');
+
+                const blob = await item.getType(kind);
+                const value = blobIsString ? await blob.text() : new Uint8Array(await blob.arrayBuffer());
+
+                const is_equal = blobIsString
+                    ? function (a: string | Uint8Array | undefined, b: string | Uint8Array | undefined) {
+                          return a === b;
+                      }
+                    : function (a: string | Uint8Array | undefined, b: string | Uint8Array | undefined) {
+                          if (!(a instanceof Uint8Array) || !(b instanceof Uint8Array)) {
+                              return false;
+                          }
+
+                          return a.length === b.length && a.every((v, i) => v === b[i]);
+                      };
+
+                const previousValue = this.lastClientClipboardItems[kind];
+
+                if (!is_equal(previousValue, value)) {
+                    // When the local clipboard updates, we need to compare it with the last data received from the server.
+                    // If it's identical, the clipboard was updated with the server's data, so we shouldn't send this data
+                    // to the server.
+                    if (is_equal(this.lastReceivedClipboardData[kind], value)) {
+                        this.lastClientClipboardItems[kind] = this.lastReceivedClipboardData[kind];
+                    }
+                    // One of mime types has changed, we need to update the clipboard cache
+                    else {
+                        sameValue = false;
+                    }
+                }
+
+                values[kind] = value;
+            }
+
+            // Clipboard has changed, we need to acknowledge remote side about it.
+            if (!sameValue) {
+                this.lastClientClipboardItems = values;
+
+                const clipboardData = new this.module.ClipboardData();
+
+                // Iterate over `Record` type
+                Object.entries(values).forEach(([key, value]: [string, string | Uint8Array]) => {
+                    // skip null/undefined values
+                    if (value == null) {
+                        return;
+                    }
+
+                    if (key.startsWith('text/') && typeof value === 'string') {
+                        clipboardData.addText(key, value);
+                    } else if (key.startsWith('image/') && value instanceof Uint8Array) {
+                        clipboardData.addBinary(key, value);
+                    }
+                });
+
+                if (!clipboardData.isEmpty()) {
+                    this.lastSentClipboardData = clipboardData;
+                    // TODO(Fix): onClipboardChanged takes an ownership over clipboardData, so lastSentClipboardData will be nullptr.
+                    await this.remoteDesktopService.onClipboardChanged(clipboardData);
+                }
+            }
+        } catch (err) {
+            if (err instanceof Error) {
+                const printError =
+                    this.lastClipboardMonitorLoopError === null ||
+                    this.lastClipboardMonitorLoopError.toString() !== err.toString();
+                // Prevent spamming the console with the same error
+                if (printError) {
+                    console.error('Clipboard monitoring error: ' + err);
+                }
+                this.lastClipboardMonitorLoopError = err;
+            }
+        } finally {
+            if (!get(isComponentDestroyed)) {
+                setTimeout(this.onMonitorClipboard.bind(this), CLIPBOARD_MONITORING_INTERVAL);
+            }
+        }
+    }
+}

--- a/web-client/iron-remote-desktop/src/services/remote-desktop.service.ts
+++ b/web-client/iron-remote-desktop/src/services/remote-desktop.service.ts
@@ -36,6 +36,7 @@ export class RemoteDesktopService {
     private cursorHasOverride: boolean = false;
     private lastCursorStyle: string = 'default';
     private enableClipboard: boolean = true;
+    private _autoClipboard: boolean = true;
 
     resizeObservable: Observable<ResizeEvent> = new Observable();
 
@@ -54,19 +55,26 @@ export class RemoteDesktopService {
         loggingService.info('Web bridge initialized.');
     }
 
+    get autoClipboard(): boolean {
+        return this._autoClipboard;
+    }
+
     // If set to false, the clipboard will not be enabled and the callbacks will not be registered to the Rust side
     setEnableClipboard(enable: boolean) {
         this.enableClipboard = enable;
     }
 
+    // If set to true, automatic clipboard synchronization with the server is enabled.
+    //
+    // If set to false, then the client must invoke `PublicAPI.saveRemoteClipboardData` and
+    // `PublicAPI.sendClipboardData` to write to clipboard and to send clipboard data to the server.
+    setEnableAutoClipboard(enable: boolean) {
+        this._autoClipboard = enable;
+    }
+
     /// Callback to set the local clipboard content to data received from the remote.
     setOnRemoteClipboardChanged(callback: OnRemoteClipboardChanged) {
         this.onRemoteClipboardChanged = callback;
-    }
-
-    /// Callback which is called when the remote sends a list of supported clipboard formats.
-    setOnRemoteReceivedFormatList(callback: OnRemoteReceivedFormatsList) {
-        this.onRemoteReceivedFormatList = callback;
     }
 
     /// Callback which is called when the remote requests a forced clipboard update (e.g. on
@@ -272,6 +280,10 @@ export class RemoteDesktopService {
         this.session?.invokeExtension(ext);
     }
 
+    raiseSessionEvent(event: SessionEvent) {
+        this.sessionEventObservable.publish(event);
+    }
+
     private releaseAllInputs() {
         this.session?.releaseAllInputs();
     }
@@ -416,10 +428,6 @@ export class RemoteDesktopService {
             syncCapsLockActive,
             syncKanaModeActive,
         );
-    }
-
-    private raiseSessionEvent(event: SessionEvent) {
-        this.sessionEventObservable.publish(event);
     }
 
     private updateModifierKeyState(evt: KeyboardEvent) {


### PR DESCRIPTION
This PR adds:
* auto clipboard mode. 
When it's enabled, the clipboard will be automatically monitored for changes, and updates from the server will be automatically saved to the local clipboard (this is the old logic; nothing has changed). 
* manual clipboard mode. 
One calls dedicated functions to interact with the clipboard.