### PR TITLE
fix(clipbrdr-native): map `E_ACCESSDENIED` WinAPI error code to `ClipboarAccessDenied` error

### DIFF
--- a/crates/ironrdp-cliprdr-native/src/windows.rs
+++ b/crates/ironrdp-cliprdr-native/src/windows.rs
@@ -91,7 +91,11 @@ impl core::error::Error for WinCliprdrError {
 
 impl From<Error> for WinCliprdrError {
     fn from(err: Error) -> Self {
-        WinCliprdrError::WinAPI(err)
+        if err.code() == E_ACCESSDENIED {
+            WinCliprdrError::ClipboardAccessDenied
+        } else {
+            WinCliprdrError::WinAPI(err)
+        }
     }
 }
 

--- a/crates/ironrdp-cliprdr-native/src/windows.rs
+++ b/crates/ironrdp-cliprdr-native/src/windows.rs
@@ -13,7 +13,7 @@ use ironrdp_cliprdr::pdu::{
 };
 use tracing::error;
 use windows::core::{s, Error};
-pub use windows::Win32::Foundation::HWND;
+pub use windows::Win32::Foundation::{E_ACCESSDENIED, HWND};
 use windows::Win32::Foundation::{FALSE, LPARAM, LRESULT, WPARAM};
 use windows::Win32::System::DataExchange::{AddClipboardFormatListener, RemoveClipboardFormatListener};
 use windows::Win32::System::LibraryLoader::GetModuleHandleA;

--- a/crates/ironrdp-cliprdr-native/src/windows.rs
+++ b/crates/ironrdp-cliprdr-native/src/windows.rs
@@ -13,8 +13,8 @@ use ironrdp_cliprdr::pdu::{
 };
 use tracing::error;
 use windows::core::{s, Error};
-pub use windows::Win32::Foundation::{E_ACCESSDENIED, HWND};
-use windows::Win32::Foundation::{FALSE, LPARAM, LRESULT, WPARAM};
+pub use windows::Win32::Foundation::HWND;
+use windows::Win32::Foundation::{E_ACCESSDENIED, FALSE, LPARAM, LRESULT, WPARAM};
 use windows::Win32::System::DataExchange::{AddClipboardFormatListener, RemoveClipboardFormatListener};
 use windows::Win32::System::LibraryLoader::GetModuleHandleA;
 use windows::Win32::UI::Shell::{RemoveWindowSubclass, SetWindowSubclass};


### PR DESCRIPTION
When the system clipboard updates, we receive an `Updated` event. Then we try to open it, but we can get `AccessDenied` error because the clipboard may still be locked for another window (like _Notepad_). To handle this, we have special logic that attempts to open the clipboard in the event of such errors. 
The problem is that nothing in the code actually sets the `ClipboardAccessDenied` error to be able to run the retrieval logic. This PR fixes it.