### PR TITLE
refactor(clipbrdr-native): provide information about source WinAPI error when `Display` formatting

### DIFF
--- a/crates/ironrdp-cliprdr-native/src/windows.rs
+++ b/crates/ironrdp-cliprdr-native/src/windows.rs
@@ -64,7 +64,7 @@ impl core::fmt::Display for WinCliprdrError {
             WinCliprdrError::Alloc => write!(f, "failed to allocate global memory"),
             WinCliprdrError::DataReceiveTimeout => write!(f, "failed to receive data from remote clipboard"),
             WinCliprdrError::RenderFormat => write!(f, "failed to render clipboard format"),
-            WinCliprdrError::WinAPI(_error) => write!(f, "WinAPI error"),
+            WinCliprdrError::WinAPI(error) => write!(f, "WinAPI error: {error}"),
         }
     }
 }


### PR DESCRIPTION
This way it's easier to troubleshoot. 