### PR TITLE
chore: add `precedence_bits` clippy correctness lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ mixed_read_write_in_expression = "warn"
 needless_raw_strings = "warn"
 non_ascii_literal = "warn"
 panic = "warn"
+precedence_bits = "warn"
 
 # == Style, readability == #
 semicolon_outside_block = "warn" # With semicolon-outside-block-ignore-multiline = true


### PR DESCRIPTION
This lint checks bit shifting operations combined with bit masking/combining operators and suggest using parentheses.