### PR TITLE
chore: add `float_cmp_const` clippy correctness lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ cast_sign_loss = "warn"
 filetype_is_file = "warn"
 float_cmp = "warn"
 lossy_float_literal = "warn"
+float_cmp_const = "warn"
 as_underscore = "warn"
 # TODO: unwrap_used = "warn" # Let’s either handle `None`, `Err` or use `expect` to give a reason.
 large_stack_frames = "warn"


### PR DESCRIPTION
This lint [docs](https://rust-lang.github.io/rust-clippy/master/index.html#/float_cmp_const):
> Checks for (in-)equality comparisons on constant floating-point values (apart from zero), except in functions called *eq* (which probably implement equality for a type involving floats).