### PR TITLE
refactor(web): raise `TERMINATED` event on connection error

### DIFF
--- a/web-client/iron-remote-desktop/src/services/remote-desktop.service.ts
+++ b/web-client/iron-remote-desktop/src/services/remote-desktop.service.ts
@@ -153,13 +153,14 @@ export class RemoteDesktopService {
 
         const session = await sessionBuilder.connect().catch((err: IronError) => {
             this.raiseSessionEvent({
-                type: SessionEventType.ERROR,
+                type: SessionEventType.TERMINATED,
                 data: {
                     backtrace: () => err.backtrace(),
                     kind: () => err.kind() as number as IronErrorKind,
                 },
             });
-            throw new Error('could not connect to the session');
+            // The client must ignore this error and use session events for error handling.
+            throw new Error();
         });
 
         this.run(session);


### PR DESCRIPTION
This PR changes the session to not return an error on the connection stage. The `iron-remote-desktop` raises `TERMINATED` instead of `ERROR`, because `ERROR` is now handled as non-critical and does not close the session.