### PR TITLE
chore: add `rc_mutex` clippy correctness lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ needless_raw_strings = "warn"
 non_ascii_literal = "warn"
 panic = "warn"
 precedence_bits = "warn"
+rc_mutex = "warn"
 
 # == Style, readability == #
 semicolon_outside_block = "warn" # With semicolon-outside-block-ignore-multiline = true


### PR DESCRIPTION
This lint checks for `Rc<Mutex<T>>`.