### PR TITLE
refactor: add `let_underscore_must_use` clippy correctness lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ filetype_is_file = "warn"
 float_cmp = "warn"
 lossy_float_literal = "warn"
 float_cmp_const = "warn"
+let_underscore_must_use = "warn"
 as_underscore = "warn"
 # TODO: unwrap_used = "warn" # Let’s either handle `None`, `Err` or use `expect` to give a reason.
 large_stack_frames = "warn"

--- a/crates/ironrdp-client/src/main.rs
+++ b/crates/ironrdp-client/src/main.rs
@@ -5,7 +5,7 @@ use ironrdp_client::app::App;
 use ironrdp_client::config::{ClipboardType, Config};
 use ironrdp_client::rdp::{DvcPipeProxyFactory, RdpClient, RdpInputEvent, RdpOutputEvent};
 use tokio::runtime;
-use tracing::debug;
+use tracing::{debug, error};
 use winit::event_loop::EventLoop;
 
 fn main() -> anyhow::Result<()> {
@@ -69,7 +69,9 @@ fn main() -> anyhow::Result<()> {
 
     debug!("Start RDP thread");
     std::thread::spawn(move || {
-        rt.block_on(client.run());
+        if let Err(err) = rt.block_on(client.run()) {
+            error!(?err, "An error occurred in RDP thread");
+        }
     });
 
     debug!("Run App");

--- a/crates/ironrdp-cliprdr-native/src/windows/utils.rs
+++ b/crates/ironrdp-cliprdr-native/src/windows/utils.rs
@@ -65,7 +65,7 @@ pub(crate) unsafe fn render_format(format: ClipboardFormatId, data: &[u8]) -> Wi
 
     // SAFETY: If described above safety requirements of `render_format` call are met, then
     // `SetClipboardData` is safe to call.
-    let _ = unsafe { SetClipboardData(format.value(), Some(handle)) };
+    let _handle = unsafe { SetClipboardData(format.value(), Some(handle)) };
 
     // We successfully transferred ownership of the data to the clipboard, we don't need to
     // call drop on handle

--- a/crates/ironrdp-fuzzing/src/oracles/mod.rs
+++ b/crates/ironrdp-fuzzing/src/oracles/mod.rs
@@ -10,6 +10,11 @@
 //! When an oracle finds a bug, it should report it to the fuzzing engine by
 //! panicking.
 
+#![allow(
+    clippy::let_underscore_must_use,
+    reason = "The result can be ignored, because we are only checking for panics in the fuzzing."
+)]
+
 use crate::generators::BitmapInput;
 
 pub fn pdu_decode(data: &[u8]) {

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -168,7 +168,7 @@ impl GwClient {
             return Err(Error::new("WS Upgrade", GwErrorKind::Connect));
         }
 
-        let _ = tx.send(()); // TODO: Not needed since it doesnt keep alive conn?
+        let _unused = tx.send(()); // TODO: Not needed since it doesnt keep alive conn?
         let stream = jh.await.map_err(|e| custom_err!("WS join", e))?.io.into_inner();
 
         Self::connect_ws(target.clone(), client_name, stream)
@@ -407,7 +407,7 @@ impl AsyncRead for GwClient {
             let max = core::cmp::min(rem, rx_buf.len());
             buf.put_slice(&rx_buf[..max]);
             n += max;
-            let _ = rx_buf.split_to(max);
+            let _unused = rx_buf.split_to(max);
 
             !rx_buf.is_empty()
         });

--- a/crates/ironrdp-rdpsnd-native/examples/cpal.rs
+++ b/crates/ironrdp-rdpsnd-native/examples/cpal.rs
@@ -56,7 +56,7 @@ fn main() -> anyhow::Result<()> {
 
     stream.stream.play()?;
     thread::sleep(Duration::from_secs(3));
-    let _ = producer.join();
+    producer.join().expect("thread failed");
 
     Ok(())
 }

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -385,7 +385,9 @@ impl RdpServer {
                             break;
                         }
                         ServerEvent::GetLocalAddr(tx) => {
-                            let _ = tx.send(self.local_addr);
+                            if tx.send(self.local_addr).is_err() {
+                                bail!("failed to send the local address");
+                            }
                         }
                         ServerEvent::SetCredentials(creds) => {
                             self.set_credentials(Some(creds));
@@ -504,7 +506,9 @@ impl RdpServer {
                     return Ok(RunState::Disconnect);
                 }
                 ServerEvent::GetLocalAddr(tx) => {
-                    let _ = tx.send(self.local_addr);
+                    if tx.send(self.local_addr).is_err() {
+                        bail!("failed to send the local address");
+                    }
                 }
                 ServerEvent::SetCredentials(creds) => {
                     self.set_credentials(Some(creds));
@@ -801,7 +805,7 @@ impl RdpServer {
                 }
 
                 Ok(Action::X224) => {
-                    let _ = self.handle_x224(writer, io_channel_id, user_channel_id, &frame).await;
+                    self.handle_x224(writer, io_channel_id, user_channel_id, &frame).await?;
                 }
 
                 // the frame here is always valid, because otherwise it would

--- a/crates/ironrdp-testsuite-extra/tests/tests.rs
+++ b/crates/ironrdp-testsuite-extra/tests/tests.rs
@@ -160,7 +160,7 @@ where
     F: FnOnce(ActiveStage, Framed<TokioStream<TlsStream<TcpStream>>>, UnboundedSender<DisplayUpdate>) -> Fut + 'static,
     Fut: Future<Output = (ActiveStage, Framed<TokioStream<TlsStream<TcpStream>>>)>,
 {
-    let _ = tracing_subscriber::fmt()
+    let _unused = tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .try_init();
 

--- a/crates/ironrdp/examples/server.rs
+++ b/crates/ironrdp/examples/server.rs
@@ -22,7 +22,7 @@ use ironrdp::server::{
 };
 use ironrdp_cliprdr_native::StubCliprdrBackend;
 use rand::prelude::*;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 const HELP: &str = "\
 USAGE:
@@ -339,7 +339,9 @@ impl RdpsndServerHandler for SndHandler {
 
                 let inner = inner.lock().unwrap();
                 if let Some(sender) = inner.ev_sender.as_ref() {
-                    let _ = sender.send(ServerEvent::Rdpsnd(RdpsndServerMessage::Wave(data, ts)));
+                    if let Err(err) = sender.send(ServerEvent::Rdpsnd(RdpsndServerMessage::Wave(data, ts))) {
+                        error!(?err);
+                    }
                 }
                 ts = ts.wrapping_add(100);
             }

--- a/ffi/src/error.rs
+++ b/ffi/src/error.rs
@@ -114,6 +114,7 @@ pub mod ffi {
     use core::fmt::Write as _;
 
     use diplomat_runtime::DiplomatWriteable;
+    use tracing::error;
 
     #[derive(Debug, Clone, Copy, thiserror::Error)]
     pub enum IronRdpErrorKind {
@@ -148,7 +149,9 @@ pub mod ffi {
     impl IronRdpError {
         /// Returns the error as a string.
         pub fn to_display(&self, writeable: &mut DiplomatWriteable) {
-            let _ = write!(writeable, "{}", self.0.repr);
+            if let Err(err) = write!(writeable, "{}", self.0.repr) {
+                error!("Failed to write error into a writable: {err}");
+            }
             writeable.flush();
         }
 

--- a/xtask/src/cov.rs
+++ b/xtask/src/cov.rs
@@ -22,7 +22,7 @@ pub fn update(sh: &Shell) -> anyhow::Result<()> {
     let initial_branch = cmd!(sh, "git rev-parse --abbrev-ref HEAD").read()?;
 
     println!("Switch branch");
-    let _ = cmd!(sh, "git branch -D cov-data").run();
+    cmd!(sh, "git branch -D cov-data").run()?;
     cmd!(sh, "git checkout --orphan cov-data").run()?;
 
     let result = || -> anyhow::Result<()> {

--- a/xtask/src/section.rs
+++ b/xtask/src/section.rs
@@ -25,6 +25,10 @@ impl Drop for Section {
 fn flush_all() {
     use std::io::{self, Write as _};
 
-    let _ = io::stdout().flush();
-    let _ = io::stderr().flush();
+    if let Err(err) = io::stdout().flush() {
+        eprintln!("stdout flush error: {err}");
+    }
+    if let Err(err) = io::stderr().flush() {
+        eprintln!("stderr flush error: {err}");
+    }
 }


### PR DESCRIPTION
This lint checks for `let _ = <expr>` where expr is `#[must_use]`.