### PR TITLE
refactor: add `same_name_method` clippy correctness lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ non_ascii_literal = "warn"
 panic = "warn"
 precedence_bits = "warn"
 rc_mutex = "warn"
+same_name_method = "warn"
 
 # == Style, readability == #
 semicolon_outside_block = "warn" # With semicolon-outside-block-ignore-multiline = true

--- a/crates/ironrdp-rdpdr/src/pdu/esc.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/esc.rs
@@ -598,7 +598,7 @@ impl EstablishContextCall {
 }
 
 impl rpce::HeaderlessDecode for EstablishContextCall {
-    fn decode(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
+    fn decode_without_headers(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
         expect_no_charset(charset)?;
         ensure_size!(in: src, size: Self::size());
         let scope = Scope::try_from(src.read_u32())?;
@@ -693,7 +693,7 @@ impl ListReadersCall {
 }
 
 impl rpce::HeaderlessDecode for ListReadersCall {
-    fn decode(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
+    fn decode_without_headers(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
         let charset = expect_charset(charset)?;
         let mut index = 0;
         let mut context = ScardContext::decode_ptr(src, &mut index)?;
@@ -809,7 +809,7 @@ impl GetStatusChangeCall {
 }
 
 impl rpce::HeaderlessDecode for GetStatusChangeCall {
-    fn decode(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
+    fn decode_without_headers(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
         let mut index = 0;
         let mut context = ScardContext::decode_ptr(src, &mut index)?;
 
@@ -966,7 +966,7 @@ impl ConnectCall {
 }
 
 impl rpce::HeaderlessDecode for ConnectCall {
-    fn decode(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
+    fn decode_without_headers(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
         let charset = expect_charset(charset)?;
         let mut index = 0;
         let _reader_ptr = ndr::decode_ptr(src, &mut index)?;
@@ -1164,7 +1164,7 @@ impl HCardAndDispositionCall {
 }
 
 impl rpce::HeaderlessDecode for HCardAndDispositionCall {
-    fn decode(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
+    fn decode_without_headers(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
         expect_no_charset(charset)?;
         let mut index = 0;
         let mut handle = ScardHandle::decode_ptr(src, &mut index)?;
@@ -1196,7 +1196,7 @@ impl TransmitCall {
 }
 
 impl rpce::HeaderlessDecode for TransmitCall {
-    fn decode(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
+    fn decode_without_headers(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
         expect_no_charset(charset)?;
         let mut index = 0;
         let mut handle = ScardHandle::decode_ptr(src, &mut index)?;
@@ -1374,7 +1374,7 @@ impl StatusCall {
 }
 
 impl rpce::HeaderlessDecode for StatusCall {
-    fn decode(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
+    fn decode_without_headers(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
         expect_no_charset(charset)?;
         let mut index = 0;
         let mut handle = ScardHandle::decode_ptr(src, &mut index)?;
@@ -1505,7 +1505,7 @@ impl ContextCall {
 }
 
 impl rpce::HeaderlessDecode for ContextCall {
-    fn decode(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
+    fn decode_without_headers(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
         expect_no_charset(charset)?;
         let mut index = 0;
         let mut context = ScardContext::decode_ptr(src, &mut index)?;
@@ -1531,7 +1531,7 @@ impl GetDeviceTypeIdCall {
 }
 
 impl rpce::HeaderlessDecode for GetDeviceTypeIdCall {
-    fn decode(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
+    fn decode_without_headers(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
         expect_no_charset(charset)?;
         let mut index = 0;
         let mut context = ScardContext::decode_ptr(src, &mut index)?;
@@ -1600,7 +1600,7 @@ impl ReadCacheCall {
 }
 
 impl rpce::HeaderlessDecode for ReadCacheCall {
-    fn decode(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
+    fn decode_without_headers(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
         let charset = expect_charset(charset)?;
         let mut index = 0;
         let _lookup_name_ptr = ndr::decode_ptr(src, &mut index)?;
@@ -1710,7 +1710,7 @@ impl WriteCacheCall {
 }
 
 impl rpce::HeaderlessDecode for WriteCacheCall {
-    fn decode(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
+    fn decode_without_headers(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
         let charset = expect_charset(charset)?;
         let mut index = 0;
         let _lookup_name_ptr = ndr::decode_ptr(src, &mut index)?;
@@ -1781,7 +1781,7 @@ impl GetReaderIconCall {
 }
 
 impl rpce::HeaderlessDecode for GetReaderIconCall {
-    fn decode(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
+    fn decode_without_headers(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
         expect_no_charset(charset)?;
         let mut index = 0;
         let mut context = ScardContext::decode_ptr(src, &mut index)?;

--- a/crates/ironrdp-rdpdr/src/pdu/esc/rpce.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/esc/rpce.rs
@@ -99,7 +99,7 @@ impl<T: HeaderlessDecode> Pdu<T> {
         // omit that check here.
         let _stream_header = StreamHeader::decode(src)?;
         let _type_header = TypeHeader::decode(src)?;
-        let pdu = T::decode(src, charset)?;
+        let pdu = T::decode_without_headers(src, charset)?;
         Ok(Self(pdu))
     }
 }
@@ -163,7 +163,7 @@ pub trait HeaderlessDecode: Sized {
     /// `charset` is an optional parameter that can be used to specify the character set
     /// when relevant. This is useful for accounting for the "A" vs "W" variants of certain
     /// opcodes e.g. [`ListReadersA`][`super::ScardIoCtlCode::ListReadersA`] vs [`ListReadersW`][`super::ScardIoCtlCode::ListReadersW`].
-    fn decode(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self>;
+    fn decode_without_headers(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self>;
 }
 
 /// [2.2.6.1] Common Type Header for the Serialization Stream

--- a/crates/ironrdp-tokio/src/reqwest.rs
+++ b/crates/ironrdp-tokio/src/reqwest.rs
@@ -20,7 +20,7 @@ impl AsyncNetworkClient for ReqwestNetworkClient {
         &'a mut self,
         network_request: &'a sspi::generator::NetworkRequest,
     ) -> Pin<Box<dyn Future<Output = ConnectorResult<Vec<u8>>> + 'a>> {
-        Box::pin(ReqwestNetworkClient::send(self, network_request))
+        Box::pin(ReqwestNetworkClient::send_impl(self, network_request))
     }
 }
 
@@ -37,7 +37,7 @@ impl Default for ReqwestNetworkClient {
 }
 
 impl ReqwestNetworkClient {
-    pub async fn send<'a>(&'a mut self, request: &'a sspi::generator::NetworkRequest) -> ConnectorResult<Vec<u8>> {
+    async fn send_impl<'a>(&'a mut self, request: &'a sspi::generator::NetworkRequest) -> ConnectorResult<Vec<u8>> {
         match &request.protocol {
             sspi::network_client::NetworkProtocol::Tcp => self.send_tcp(&request.url, &request.data).await,
             sspi::network_client::NetworkProtocol::Udp => self.send_udp(&request.url, &request.data).await,

--- a/crates/ironrdp-web/src/clipboard.rs
+++ b/crates/ironrdp-web/src/clipboard.rs
@@ -14,6 +14,7 @@
 use std::collections::HashMap;
 
 use futures_channel::mpsc;
+use iron_remote_desktop::ClipboardData as _;
 use ironrdp::cliprdr::backend::{ClipboardMessage, CliprdrBackend};
 use ironrdp::cliprdr::pdu::{
     ClipboardFormat, ClipboardFormatId, ClipboardFormatName, ClipboardGeneralCapabilityFlags, FileContentsRequest,
@@ -599,14 +600,6 @@ impl ClipboardData {
 
     pub(crate) fn add(&mut self, item: ClipboardItem) {
         self.items.push(item);
-    }
-
-    pub(crate) fn items(&self) -> &[ClipboardItem] {
-        &self.items
-    }
-
-    pub(crate) fn is_empty(&self) -> bool {
-        self.items.is_empty()
     }
 
     pub(crate) fn clear(&mut self) {


### PR DESCRIPTION
From the lint [docs](https://rust-lang.github.io/rust-clippy/master/index.html#/same_name_method):
> It lints if a struct has two methods with the same name: one from a trait, another not from a trait.

Because it can be confusing.