### PR TITLE
refactor(web): extend `DeviceEvent.wheelRotations` event to support passing rotation units other than pixels

### DIFF
--- a/crates/iron-remote-desktop/src/input.rs
+++ b/crates/iron-remote-desktop/src/input.rs
@@ -1,3 +1,12 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub enum RotationUnit {
+    Pixel,
+    Line,
+    Page,
+}
+
 pub trait DeviceEvent {
     fn mouse_button_pressed(button: u8) -> Self;
 
@@ -5,7 +14,7 @@ pub trait DeviceEvent {
 
     fn mouse_move(x: u16, y: u16) -> Self;
 
-    fn wheel_rotations(vertical: bool, rotation_units: i16) -> Self;
+    fn wheel_rotations(vertical: bool, rotation_amount: i16, rotation_unit: RotationUnit) -> Self;
 
     fn key_pressed(scancode: u16) -> Self;
 

--- a/crates/iron-remote-desktop/src/lib.rs
+++ b/crates/iron-remote-desktop/src/lib.rs
@@ -14,7 +14,7 @@ pub use cursor::CursorStyle;
 pub use desktop_size::DesktopSize;
 pub use error::{IronError, IronErrorKind};
 pub use extension::Extension;
-pub use input::{DeviceEvent, InputTransaction};
+pub use input::{DeviceEvent, InputTransaction, RotationUnit};
 pub use session::{Session, SessionBuilder, SessionTerminationInfo};
 
 pub trait RemoteDesktopApi {
@@ -329,11 +329,12 @@ macro_rules! make_bridge {
             }
 
             #[wasm_bindgen(js_name = wheelRotations)]
-            pub fn wheel_rotations(vertical: bool, rotation_units: i16) -> Self {
+            pub fn wheel_rotations(vertical: bool, rotation_amount: i16, rotation_unit: $crate::RotationUnit) -> Self {
                 Self(
                     <<$api as $crate::RemoteDesktopApi>::DeviceEvent as $crate::DeviceEvent>::wheel_rotations(
                         vertical,
-                        rotation_units,
+                        rotation_amount,
+                        rotation_unit,
                     ),
                 )
             }

--- a/web-client/iron-remote-desktop/src/interfaces/DeviceEvent.ts
+++ b/web-client/iron-remote-desktop/src/interfaces/DeviceEvent.ts
@@ -1,1 +1,7 @@
+export enum RotationUnit {
+    Pixel = 0,
+    Line = 1,
+    Page = 2,
+}
+
 export type DeviceEvent = unknown;

--- a/web-client/iron-remote-desktop/src/interfaces/RemoteDesktopModule.ts
+++ b/web-client/iron-remote-desktop/src/interfaces/RemoteDesktopModule.ts
@@ -3,6 +3,7 @@ import type { DeviceEvent } from './DeviceEvent';
 import type { InputTransaction } from './InputTransaction';
 import type { SessionBuilder } from './SessionBuilder';
 import type { ClipboardData } from './ClipboardData';
+import type { RotationUnit } from './DeviceEvent.ts';
 
 export interface RemoteDesktopModule {
     DesktopSize: { new (width: number, height: number): DesktopSize };
@@ -13,7 +14,7 @@ export interface RemoteDesktopModule {
         mouseButtonPressed(button: number): DeviceEvent;
         mouseButtonReleased(button: number): DeviceEvent;
         mouseMove(x: number, y: number): DeviceEvent;
-        wheelRotations(vertical: boolean, rotationUnits: number): DeviceEvent;
+        wheelRotations(vertical: boolean, rotation_amount: number, rotation_unit: RotationUnit): DeviceEvent;
         keyPressed(scancode: number): DeviceEvent;
         keyReleased(scancode: number): DeviceEvent;
         unicodePressed(unicode: string): DeviceEvent;

--- a/web-client/iron-remote-desktop/src/services/remote-desktop.service.ts
+++ b/web-client/iron-remote-desktop/src/services/remote-desktop.service.ts
@@ -11,6 +11,7 @@ import type { MousePosition } from '../interfaces/MousePosition';
 import type { IronError, IronErrorKind, SessionEvent } from '../interfaces/session-event';
 import type { ClipboardData } from '../interfaces/ClipboardData';
 import type { Session } from '../interfaces/Session';
+import { RotationUnit } from '../interfaces/DeviceEvent';
 import type { DeviceEvent } from '../interfaces/DeviceEvent';
 import type { RemoteDesktopModule } from '../interfaces/RemoteDesktopModule';
 import { ConfigBuilder } from './ConfigBuilder';
@@ -224,10 +225,27 @@ export class RemoteDesktopService {
         }
     }
 
+    rotation_unit_from_wheel_event(event: WheelEvent): RotationUnits {
+        switch (event.deltaMode) {
+            case event.DOM_DELTA_PIXEL:
+                return RotationUnit.Pixel;
+            case event.DOM_DELTA_LINE:
+                return RotationUnit.Line;
+            case event.DOM_DELTA_PAGE:
+                return RotationUnit.Page;
+            default:
+                return RotationUnit.Pixel;
+        }
+    }
+
     mouseWheel(event: WheelEvent) {
         const vertical = event.deltaY !== 0;
         const rotation = vertical ? event.deltaY : event.deltaX;
-        this.doTransactionFromDeviceEvents([this.module.DeviceEvent.wheelRotations(vertical, -rotation)]);
+        const rotation_unit = this.rotation_unit_from_wheel_event(event);
+
+        this.doTransactionFromDeviceEvents([
+            this.module.DeviceEvent.wheelRotations(vertical, -rotation, rotation_unit),
+        ]);
     }
 
     setVisibility(state: boolean) {


### PR DESCRIPTION
Closes https://github.com/Devolutions/IronVNC/issues/905.