### PR TITLE
refactor(pdu)!: fix unwrap_used clippy lint warnings

### DIFF
--- a/crates/ironrdp-acceptor/src/connection.rs
+++ b/crates/ironrdp-acceptor/src/connection.rs
@@ -381,26 +381,19 @@ impl Sequence for Acceptor {
 
                 debug!(message = ?settings_initial, "Received");
 
-                let early_capability = settings_initial
-                    .conference_create_request
-                    .gcc_blocks()
-                    .core
-                    .optional_data
-                    .early_capability_flags;
+                let gcc_blocks = settings_initial.conference_create_request.into_gcc_blocks();
+                let early_capability = gcc_blocks.core.optional_data.early_capability_flags;
 
-                let joined: Vec<_> = settings_initial
-                    .conference_create_request
-                    .gcc_blocks()
+                let joined: Vec<_> = gcc_blocks
                     .network
-                    .as_ref()
                     .map(|network| {
                         network
                             .channels
-                            .iter()
+                            .into_iter()
                             .map(|c| {
                                 self.static_channels
                                     .get_by_channel_name(&c.name)
-                                    .map(|(type_id, _)| (type_id, c.clone()))
+                                    .map(|(type_id, _)| (type_id, c))
                             })
                             .collect()
                     })

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -350,7 +350,7 @@ impl Sequence for ClientConnector {
 
                 let client_gcc_blocks = connect_initial.conference_create_request.gcc_blocks();
 
-                let server_gcc_blocks = connect_response.conference_create_response.gcc_blocks();
+                let server_gcc_blocks = connect_response.conference_create_response.into_gcc_blocks();
 
                 if client_gcc_blocks.security == gcc::ClientSecurityData::no_security()
                     && server_gcc_blocks.security != gcc::ServerSecurityData::no_security()

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -348,7 +348,7 @@ impl Sequence for ClientConnector {
 
                 debug!(message = ?connect_response, "Received");
 
-                let client_gcc_blocks = &connect_initial.conference_create_request.gcc_blocks();
+                let client_gcc_blocks = connect_initial.conference_create_request.gcc_blocks();
 
                 let server_gcc_blocks = connect_response.conference_create_response.gcc_blocks();
 

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -366,7 +366,7 @@ impl Sequence for ClientConnector {
                     warn!("Unexpected MultiTransportChannelData GCC block (not supported)");
                 }
 
-                let static_channel_ids = server_gcc_blocks.network.channel_ids.clone();
+                let static_channel_ids = server_gcc_blocks.network.channel_ids;
                 let io_channel_id = server_gcc_blocks.network.io_channel;
 
                 debug!(?static_channel_ids, io_channel_id);

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -327,7 +327,8 @@ impl Sequence for ClientConnector {
                 let client_gcc_blocks =
                     create_gcc_blocks(&self.config, selected_protocol, self.static_channels.values())?;
 
-                let connect_initial = mcs::ConnectInitial::with_gcc_blocks(client_gcc_blocks);
+                let connect_initial =
+                    mcs::ConnectInitial::with_gcc_blocks(client_gcc_blocks).map_err(ConnectorError::decode)?;
 
                 debug!(message = ?connect_initial, "Send");
 
@@ -347,9 +348,9 @@ impl Sequence for ClientConnector {
 
                 debug!(message = ?connect_response, "Received");
 
-                let client_gcc_blocks = &connect_initial.conference_create_request.gcc_blocks;
+                let client_gcc_blocks = &connect_initial.conference_create_request.gcc_blocks();
 
-                let server_gcc_blocks = connect_response.conference_create_response.gcc_blocks;
+                let server_gcc_blocks = connect_response.conference_create_response.gcc_blocks();
 
                 if client_gcc_blocks.security == gcc::ClientSecurityData::no_security()
                     && server_gcc_blocks.security != gcc::ServerSecurityData::no_security()
@@ -365,7 +366,7 @@ impl Sequence for ClientConnector {
                     warn!("Unexpected MultiTransportChannelData GCC block (not supported)");
                 }
 
-                let static_channel_ids = server_gcc_blocks.network.channel_ids;
+                let static_channel_ids = server_gcc_blocks.network.channel_ids.clone();
                 let io_channel_id = server_gcc_blocks.network.io_channel;
 
                 debug!(?static_channel_ids, io_channel_id);

--- a/crates/ironrdp-pdu/src/basic_output/fast_path.rs
+++ b/crates/ironrdp-pdu/src/basic_output/fast_path.rs
@@ -312,6 +312,7 @@ impl Encode for FastPathUpdate<'_> {
     }
 }
 
+#[repr(u8)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum UpdateCode {
     Orders = 0x0,
@@ -329,21 +330,12 @@ pub enum UpdateCode {
 }
 
 impl UpdateCode {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     pub fn as_u8(&self) -> u8 {
-        match self {
-            Self::Orders => 0x0,
-            Self::Bitmap => 0x1,
-            Self::Palette => 0x2,
-            Self::Synchronize => 0x3,
-            Self::SurfaceCommands => 0x4,
-            Self::HiddenPointer => 0x5,
-            Self::DefaultPointer => 0x6,
-            Self::PositionPointer => 0x8,
-            Self::ColorPointer => 0x9,
-            Self::CachedPointer => 0xa,
-            Self::NewPointer => 0xb,
-            Self::LargePointer => 0xc,
-        }
+        *self as u8
     }
 }
 
@@ -365,6 +357,7 @@ impl From<&FastPathUpdate<'_>> for UpdateCode {
     }
 }
 
+#[repr(u8)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum Fragmentation {
     Single = 0x0,
@@ -374,13 +367,12 @@ pub enum Fragmentation {
 }
 
 impl Fragmentation {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     pub fn as_u8(&self) -> u8 {
-        match self {
-            Self::Single => 0x0,
-            Self::Last => 0x1,
-            Self::First => 0x2,
-            Self::Next => 0x3,
-        }
+        *self as u8
     }
 }
 

--- a/crates/ironrdp-pdu/src/basic_output/fast_path.rs
+++ b/crates/ironrdp-pdu/src/basic_output/fast_path.rs
@@ -334,8 +334,8 @@ impl UpdateCode {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    pub fn as_u8(&self) -> u8 {
-        *self as u8
+    pub fn as_u8(self) -> u8 {
+        self as u8
     }
 }
 
@@ -371,8 +371,8 @@ impl Fragmentation {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    pub fn as_u8(&self) -> u8 {
-        *self as u8
+    pub fn as_u8(self) -> u8 {
+        self as u8
     }
 }
 

--- a/crates/ironrdp-pdu/src/basic_output/fast_path.rs
+++ b/crates/ironrdp-pdu/src/basic_output/fast_path.rs
@@ -7,8 +7,8 @@ use ironrdp_core::{
     decode_cursor, ensure_fixed_part_size, ensure_size, invalid_field_err, Decode, DecodeError, DecodeResult, Encode,
     EncodeResult, InvalidFieldErr as _, ReadCursor, WriteCursor,
 };
-use num_derive::{FromPrimitive, ToPrimitive};
-use num_traits::{FromPrimitive as _, ToPrimitive as _};
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive as _;
 
 use super::bitmap::BitmapUpdateData;
 use super::pointer::PointerUpdateData;
@@ -136,15 +136,15 @@ impl Encode for FastPathUpdatePdu<'_> {
         }
 
         let mut header = 0u8;
-        header.set_bits(0..4, self.update_code.to_u8().unwrap());
-        header.set_bits(4..6, self.fragmentation.to_u8().unwrap());
+        header.set_bits(0..4, self.update_code.as_u8());
+        header.set_bits(4..6, self.fragmentation.as_u8());
 
         dst.write_u8(header);
 
         if self.compression_flags.is_some() {
             header.set_bits(6..8, Compression::COMPRESSION_USED.bits());
-            let compression_flags_with_type = self.compression_flags.map(|f| f.bits()).unwrap_or(0)
-                | self.compression_type.and_then(|f| f.to_u8()).unwrap_or(0);
+            let compression_flags_with_type =
+                self.compression_flags.map(|f| f.bits()).unwrap_or(0) | self.compression_type.map_or(0, |f| f.as_u8());
             dst.write_u8(compression_flags_with_type);
         }
 
@@ -312,7 +312,7 @@ impl Encode for FastPathUpdate<'_> {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum UpdateCode {
     Orders = 0x0,
     Bitmap = 0x1,
@@ -326,6 +326,25 @@ pub enum UpdateCode {
     CachedPointer = 0xa,
     NewPointer = 0xb,
     LargePointer = 0xc,
+}
+
+impl UpdateCode {
+    pub fn as_u8(&self) -> u8 {
+        match self {
+            Self::Orders => 0x0,
+            Self::Bitmap => 0x1,
+            Self::Palette => 0x2,
+            Self::Synchronize => 0x3,
+            Self::SurfaceCommands => 0x4,
+            Self::HiddenPointer => 0x5,
+            Self::DefaultPointer => 0x6,
+            Self::PositionPointer => 0x8,
+            Self::ColorPointer => 0x9,
+            Self::CachedPointer => 0xa,
+            Self::NewPointer => 0xb,
+            Self::LargePointer => 0xc,
+        }
+    }
 }
 
 impl From<&FastPathUpdate<'_>> for UpdateCode {
@@ -346,12 +365,23 @@ impl From<&FastPathUpdate<'_>> for UpdateCode {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum Fragmentation {
     Single = 0x0,
     Last = 0x1,
     First = 0x2,
     Next = 0x3,
+}
+
+impl Fragmentation {
+    pub fn as_u8(&self) -> u8 {
+        match self {
+            Self::Single => 0x0,
+            Self::Last => 0x1,
+            Self::First => 0x2,
+            Self::Next => 0x3,
+        }
+    }
 }
 
 bitflags! {

--- a/crates/ironrdp-pdu/src/basic_output/surface_commands.rs
+++ b/crates/ironrdp-pdu/src/basic_output/surface_commands.rs
@@ -333,12 +333,12 @@ enum SurfaceCommandType {
 }
 
 impl SurfaceCommandType {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u16(&self) -> u16 {
-        match self {
-            Self::SetSurfaceBits => 0x01,
-            Self::FrameMarker => 0x04,
-            Self::StreamSurfaceBits => 0x06,
-        }
+        *self as u16
     }
 }
 

--- a/crates/ironrdp-pdu/src/basic_output/surface_commands.rs
+++ b/crates/ironrdp-pdu/src/basic_output/surface_commands.rs
@@ -7,7 +7,7 @@ use ironrdp_core::{
     WriteCursor,
 };
 use num_derive::{FromPrimitive, ToPrimitive};
-use num_traits::{FromPrimitive as _, ToPrimitive as _};
+use num_traits::FromPrimitive as _;
 
 use crate::geometry::ExclusiveRectangle;
 
@@ -31,7 +31,7 @@ impl Encode for SurfaceCommand<'_> {
         ensure_size!(in: dst, size: self.size());
 
         let cmd_type = SurfaceCommandType::from(self);
-        dst.write_u16(cmd_type.to_u16().unwrap());
+        dst.write_u16(cmd_type.as_u16());
 
         match self {
             Self::SetSurfaceBits(pdu) | Self::StreamSurfaceBits(pdu) => pdu.encode(dst),
@@ -324,12 +324,22 @@ impl Decode<'_> for BitmapDataHeader {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, FromPrimitive)]
 #[repr(u16)]
 enum SurfaceCommandType {
     SetSurfaceBits = 0x01,
     FrameMarker = 0x04,
     StreamSurfaceBits = 0x06,
+}
+
+impl SurfaceCommandType {
+    fn as_u16(&self) -> u16 {
+        match self {
+            Self::SetSurfaceBits => 0x01,
+            Self::FrameMarker => 0x04,
+            Self::StreamSurfaceBits => 0x06,
+        }
+    }
 }
 
 impl From<&SurfaceCommand<'_>> for SurfaceCommandType {

--- a/crates/ironrdp-pdu/src/basic_output/surface_commands.rs
+++ b/crates/ironrdp-pdu/src/basic_output/surface_commands.rs
@@ -337,8 +337,8 @@ impl SurfaceCommandType {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u16(&self) -> u16 {
-        *self as u16
+    fn as_u16(self) -> u16 {
+        self as u16
     }
 }
 

--- a/crates/ironrdp-pdu/src/codecs/rfx.rs
+++ b/crates/ironrdp-pdu/src/codecs/rfx.rs
@@ -5,8 +5,8 @@ use ironrdp_core::{
     cast_length, ensure_fixed_part_size, ensure_size, invalid_field_err, Decode, DecodeResult, Encode, EncodeResult,
     ReadCursor, WriteCursor,
 };
-use num_derive::{FromPrimitive, ToPrimitive};
-use num_traits::{FromPrimitive as _, ToPrimitive as _};
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive as _;
 
 use crate::rdp::capability_sets::{RfxCaps, RfxCapset};
 
@@ -187,7 +187,7 @@ impl Encode for BlockHeader {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         ensure_fixed_part_size!(in: dst);
 
-        dst.write_u16(self.ty.to_u16().unwrap());
+        dst.write_u16(self.ty.as_u16());
         dst.write_u32(cast_length!("data len", self.data_length)?);
 
         Ok(())
@@ -307,7 +307,7 @@ impl<'de> Decode<'de> for FrameAcknowledgePdu {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 #[repr(u16)]
 pub enum BlockType {
     Tile = 0xCAC3,
@@ -329,5 +329,21 @@ impl BlockType {
             self,
             BlockType::Context | BlockType::FrameBegin | BlockType::FrameEnd | BlockType::Region | BlockType::Extension
         )
+    }
+
+    fn as_u16(&self) -> u16 {
+        match self {
+            Self::Tile => 0xCAC3,
+            Self::Capabilities => 0xCBC0,
+            Self::CapabilitySet => 0xCBC1,
+            Self::Sync => 0xCCC0,
+            Self::CodecVersions => 0xCCC1,
+            Self::Channels => 0xCCC2,
+            Self::Context => 0xCCC3,
+            Self::FrameBegin => 0xCCC4,
+            Self::FrameEnd => 0xCCC5,
+            Self::Region => 0xCCC6,
+            Self::Extension => 0xCCC7,
+        }
     }
 }

--- a/crates/ironrdp-pdu/src/codecs/rfx.rs
+++ b/crates/ironrdp-pdu/src/codecs/rfx.rs
@@ -331,19 +331,11 @@ impl BlockType {
         )
     }
 
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u16(&self) -> u16 {
-        match self {
-            Self::Tile => 0xCAC3,
-            Self::Capabilities => 0xCBC0,
-            Self::CapabilitySet => 0xCBC1,
-            Self::Sync => 0xCCC0,
-            Self::CodecVersions => 0xCCC1,
-            Self::Channels => 0xCCC2,
-            Self::Context => 0xCCC3,
-            Self::FrameBegin => 0xCCC4,
-            Self::FrameEnd => 0xCCC5,
-            Self::Region => 0xCCC6,
-            Self::Extension => 0xCCC7,
-        }
+        *self as u16
     }
 }

--- a/crates/ironrdp-pdu/src/codecs/rfx.rs
+++ b/crates/ironrdp-pdu/src/codecs/rfx.rs
@@ -335,7 +335,7 @@ impl BlockType {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u16(&self) -> u16 {
-        *self as u16
+    fn as_u16(self) -> u16 {
+        self as u16
     }
 }

--- a/crates/ironrdp-pdu/src/codecs/rfx/data_messages.rs
+++ b/crates/ironrdp-pdu/src/codecs/rfx/data_messages.rs
@@ -674,11 +674,12 @@ pub enum EntropyAlgorithm {
 }
 
 impl EntropyAlgorithm {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u16(&self) -> u16 {
-        match self {
-            Self::Rlgr1 => 0x01,
-            Self::Rlgr3 => 0x04,
-        }
+        *self as u16
     }
 }
 

--- a/crates/ironrdp-pdu/src/codecs/rfx/data_messages.rs
+++ b/crates/ironrdp-pdu/src/codecs/rfx/data_messages.rs
@@ -4,8 +4,8 @@ use ironrdp_core::{
     cast_length, ensure_fixed_part_size, ensure_size, invalid_field_err, Decode, DecodeResult, Encode, EncodeResult,
     ReadCursor, WriteCursor,
 };
-use num_derive::{FromPrimitive, ToPrimitive};
-use num_traits::{FromPrimitive as _, ToPrimitive as _};
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive as _;
 
 use crate::codecs::rfx::Block;
 
@@ -48,7 +48,7 @@ impl Encode for ContextPdu {
         properties.set_bits(0..3, self.flags.bits());
         properties.set_bits(3..5, COLOR_CONVERSION_ICT);
         properties.set_bits(5..9, CLW_XFORM_DWT_53_A);
-        properties.set_bits(9..13, self.entropy_algorithm.to_u16().unwrap());
+        properties.set_bits(9..13, self.entropy_algorithm.as_u16());
         properties.set_bits(13..15, SCALAR_QUANTIZATION);
         properties.set_bit(15, false); // reserved
         dst.write_u16(properties);
@@ -297,7 +297,7 @@ impl Encode for TileSetPdu<'_> {
         properties.set_bits(1..4, OperatingMode::empty().bits()); // The decoder MUST ignore this flag
         properties.set_bits(4..6, COLOR_CONVERSION_ICT);
         properties.set_bits(6..10, CLW_XFORM_DWT_53_A);
-        properties.set_bits(10..14, self.entropy_algorithm.to_u16().unwrap());
+        properties.set_bits(10..14, self.entropy_algorithm.as_u16());
         properties.set_bits(14..16, SCALAR_QUANTIZATION);
         dst.write_u16(properties);
 
@@ -666,11 +666,20 @@ impl<'de> Decode<'de> for Tile<'de> {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 #[repr(u16)]
 pub enum EntropyAlgorithm {
     Rlgr1 = 0x01,
     Rlgr3 = 0x04,
+}
+
+impl EntropyAlgorithm {
+    fn as_u16(&self) -> u16 {
+        match self {
+            Self::Rlgr1 => 0x01,
+            Self::Rlgr3 => 0x04,
+        }
+    }
 }
 
 bitflags! {

--- a/crates/ironrdp-pdu/src/codecs/rfx/data_messages.rs
+++ b/crates/ironrdp-pdu/src/codecs/rfx/data_messages.rs
@@ -678,8 +678,8 @@ impl EntropyAlgorithm {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u16(&self) -> u16 {
-        *self as u16
+    fn as_u16(self) -> u16 {
+        self as u16
     }
 }
 

--- a/crates/ironrdp-pdu/src/gcc.rs
+++ b/crates/ironrdp-pdu/src/gcc.rs
@@ -4,8 +4,8 @@ use ironrdp_core::{
     cast_length, decode, ensure_fixed_part_size, ensure_size, invalid_field_err, Decode, DecodeErrorKind, DecodeResult,
     Encode, EncodeResult, ReadCursor, WriteCursor,
 };
-use num_derive::{FromPrimitive, ToPrimitive};
-use num_traits::{FromPrimitive, ToPrimitive};
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
 use thiserror::Error;
 
 use crate::PduError;
@@ -265,7 +265,7 @@ impl<'de> Decode<'de> for ServerGccBlocks {
 }
 
 #[repr(u16)]
-#[derive(Debug, Copy, Clone, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, FromPrimitive)]
 pub enum ClientGccType {
     CoreData = 0xC001,
     SecurityData = 0xC002,
@@ -277,14 +277,41 @@ pub enum ClientGccType {
     MultiTransportChannelData = 0xC00A,
 }
 
+impl From<ClientGccType> for u16 {
+    fn from(value: ClientGccType) -> Self {
+        match value {
+            ClientGccType::CoreData => 0xC001,
+            ClientGccType::SecurityData => 0xC002,
+            ClientGccType::NetworkData => 0xC003,
+            ClientGccType::ClusterData => 0xC004,
+            ClientGccType::MonitorData => 0xC005,
+            ClientGccType::MessageChannelData => 0xC006,
+            ClientGccType::MonitorExtendedData => 0xC008,
+            ClientGccType::MultiTransportChannelData => 0xC00A,
+        }
+    }
+}
+
 #[repr(u16)]
-#[derive(Debug, Copy, Clone, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, FromPrimitive)]
 pub enum ServerGccType {
     CoreData = 0x0C01,
     SecurityData = 0x0C02,
     NetworkData = 0x0C03,
     MessageChannelData = 0x0C04,
     MultiTransportChannelData = 0x0C08,
+}
+
+impl From<ServerGccType> for u16 {
+    fn from(value: ServerGccType) -> Self {
+        match value {
+            ServerGccType::CoreData => 0x0C01,
+            ServerGccType::SecurityData => 0x0C02,
+            ServerGccType::NetworkData => 0x0C03,
+            ServerGccType::MessageChannelData => 0x0C04,
+            ServerGccType::MultiTransportChannelData => 0x0C08,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -295,12 +322,12 @@ impl UserDataHeader {
 
     pub fn encode<T, B>(dst: &mut WriteCursor<'_>, block_type: T, block: &B) -> EncodeResult<()>
     where
-        T: ToPrimitive,
+        T: Into<u16>,
         B: Encode,
     {
         ensure_fixed_part_size!(in: dst);
 
-        dst.write_u16(block_type.to_u16().unwrap());
+        dst.write_u16(block_type.into());
         dst.write_u16(cast_length!("blockLen", block.size() + USER_DATA_HEADER_SIZE)?);
         block.encode(dst)?;
 

--- a/crates/ironrdp-pdu/src/gcc.rs
+++ b/crates/ironrdp-pdu/src/gcc.rs
@@ -86,26 +86,30 @@ impl Encode for ClientGccBlocks {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         ensure_size!(in: dst, size: self.size());
 
-        UserDataHeader::encode(dst, ClientGccType::CoreData, &self.core)?;
-        UserDataHeader::encode(dst, ClientGccType::SecurityData, &self.security)?;
+        UserDataHeader::encode(dst, ClientGccType::CoreData.as_u16(), &self.core)?;
+        UserDataHeader::encode(dst, ClientGccType::SecurityData.as_u16(), &self.security)?;
 
         if let Some(ref network) = self.network {
-            UserDataHeader::encode(dst, ClientGccType::NetworkData, network)?;
+            UserDataHeader::encode(dst, ClientGccType::NetworkData.as_u16(), network)?;
         }
         if let Some(ref cluster) = self.cluster {
-            UserDataHeader::encode(dst, ClientGccType::ClusterData, cluster)?;
+            UserDataHeader::encode(dst, ClientGccType::ClusterData.as_u16(), cluster)?;
         }
         if let Some(ref monitor) = self.monitor {
-            UserDataHeader::encode(dst, ClientGccType::MonitorData, monitor)?;
+            UserDataHeader::encode(dst, ClientGccType::MonitorData.as_u16(), monitor)?;
         }
         if let Some(ref message_channel) = self.message_channel {
-            UserDataHeader::encode(dst, ClientGccType::MessageChannelData, message_channel)?;
+            UserDataHeader::encode(dst, ClientGccType::MessageChannelData.as_u16(), message_channel)?;
         }
         if let Some(ref multi_transport_channel) = self.multi_transport_channel {
-            UserDataHeader::encode(dst, ClientGccType::MultiTransportChannelData, multi_transport_channel)?;
+            UserDataHeader::encode(
+                dst,
+                ClientGccType::MultiTransportChannelData.as_u16(),
+                multi_transport_channel,
+            )?;
         }
         if let Some(ref monitor_extended) = self.monitor_extended {
-            UserDataHeader::encode(dst, ClientGccType::MonitorExtendedData, monitor_extended)?;
+            UserDataHeader::encode(dst, ClientGccType::MonitorExtendedData.as_u16(), monitor_extended)?;
         }
 
         Ok(())
@@ -202,15 +206,19 @@ impl ServerGccBlocks {
 
 impl Encode for ServerGccBlocks {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        UserDataHeader::encode(dst, ServerGccType::CoreData, &self.core)?;
-        UserDataHeader::encode(dst, ServerGccType::NetworkData, &self.network)?;
-        UserDataHeader::encode(dst, ServerGccType::SecurityData, &self.security)?;
+        UserDataHeader::encode(dst, ServerGccType::CoreData.as_u16(), &self.core)?;
+        UserDataHeader::encode(dst, ServerGccType::NetworkData.as_u16(), &self.network)?;
+        UserDataHeader::encode(dst, ServerGccType::SecurityData.as_u16(), &self.security)?;
 
         if let Some(ref message_channel) = self.message_channel {
-            UserDataHeader::encode(dst, ServerGccType::MessageChannelData, message_channel)?;
+            UserDataHeader::encode(dst, ServerGccType::MessageChannelData.as_u16(), message_channel)?;
         }
         if let Some(ref multi_transport_channel) = self.multi_transport_channel {
-            UserDataHeader::encode(dst, ServerGccType::MultiTransportChannelData, multi_transport_channel)?;
+            UserDataHeader::encode(
+                dst,
+                ServerGccType::MultiTransportChannelData.as_u16(),
+                multi_transport_channel,
+            )?;
         }
 
         Ok(())
@@ -277,18 +285,13 @@ pub enum ClientGccType {
     MultiTransportChannelData = 0xC00A,
 }
 
-impl From<ClientGccType> for u16 {
-    fn from(value: ClientGccType) -> Self {
-        match value {
-            ClientGccType::CoreData => 0xC001,
-            ClientGccType::SecurityData => 0xC002,
-            ClientGccType::NetworkData => 0xC003,
-            ClientGccType::ClusterData => 0xC004,
-            ClientGccType::MonitorData => 0xC005,
-            ClientGccType::MessageChannelData => 0xC006,
-            ClientGccType::MonitorExtendedData => 0xC008,
-            ClientGccType::MultiTransportChannelData => 0xC00A,
-        }
+impl ClientGccType {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
+    pub fn as_u16(&self) -> u16 {
+        *self as u16
     }
 }
 
@@ -302,15 +305,13 @@ pub enum ServerGccType {
     MultiTransportChannelData = 0x0C08,
 }
 
-impl From<ServerGccType> for u16 {
-    fn from(value: ServerGccType) -> Self {
-        match value {
-            ServerGccType::CoreData => 0x0C01,
-            ServerGccType::SecurityData => 0x0C02,
-            ServerGccType::NetworkData => 0x0C03,
-            ServerGccType::MessageChannelData => 0x0C04,
-            ServerGccType::MultiTransportChannelData => 0x0C08,
-        }
+impl ServerGccType {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
+    pub fn as_u16(&self) -> u16 {
+        *self as u16
     }
 }
 

--- a/crates/ironrdp-pdu/src/gcc.rs
+++ b/crates/ironrdp-pdu/src/gcc.rs
@@ -290,8 +290,8 @@ impl ClientGccType {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    pub fn as_u16(&self) -> u16 {
-        *self as u16
+    pub fn as_u16(self) -> u16 {
+        self as u16
     }
 }
 
@@ -310,8 +310,8 @@ impl ServerGccType {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    pub fn as_u16(&self) -> u16 {
-        *self as u16
+    pub fn as_u16(self) -> u16 {
+        self as u16
     }
 }
 

--- a/crates/ironrdp-pdu/src/gcc/cluster_data.rs
+++ b/crates/ironrdp-pdu/src/gcc/cluster_data.rs
@@ -4,8 +4,8 @@ use bitflags::bitflags;
 use ironrdp_core::{
     ensure_fixed_part_size, invalid_field_err, Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor,
 };
-use num_derive::{FromPrimitive, ToPrimitive};
-use num_traits::{FromPrimitive as _, ToPrimitive as _};
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive as _;
 use thiserror::Error;
 
 const REDIRECTION_VERSION_MASK: u32 = 0x0000_003C;
@@ -30,7 +30,7 @@ impl Encode for ClientClusterData {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         ensure_fixed_part_size!(in: dst);
 
-        let flags_with_version = self.flags.bits() | (self.redirection_version.to_u32().unwrap() << 2);
+        let flags_with_version = self.flags.bits() | (self.redirection_version.as_u32() << 2);
 
         dst.write_u32(flags_with_version);
         dst.write_u32(self.redirected_session_id);
@@ -77,7 +77,7 @@ bitflags! {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum RedirectionVersion {
     V1 = 0,
     V2 = 1,
@@ -85,6 +85,19 @@ pub enum RedirectionVersion {
     V4 = 3,
     V5 = 4,
     V6 = 5,
+}
+
+impl RedirectionVersion {
+    fn as_u32(&self) -> u32 {
+        match self {
+            Self::V1 => 0,
+            Self::V2 => 1,
+            Self::V3 => 2,
+            Self::V4 => 3,
+            Self::V5 => 4,
+            Self::V6 => 5,
+        }
+    }
 }
 
 #[derive(Debug, Error)]

--- a/crates/ironrdp-pdu/src/gcc/cluster_data.rs
+++ b/crates/ironrdp-pdu/src/gcc/cluster_data.rs
@@ -93,8 +93,8 @@ impl RedirectionVersion {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u32(&self) -> u32 {
-        *self as u32
+    fn as_u32(self) -> u32 {
+        self as u32
     }
 }
 

--- a/crates/ironrdp-pdu/src/gcc/cluster_data.rs
+++ b/crates/ironrdp-pdu/src/gcc/cluster_data.rs
@@ -77,6 +77,7 @@ bitflags! {
     }
 }
 
+#[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum RedirectionVersion {
     V1 = 0,
@@ -88,15 +89,12 @@ pub enum RedirectionVersion {
 }
 
 impl RedirectionVersion {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u32(&self) -> u32 {
-        match self {
-            Self::V1 => 0,
-            Self::V2 => 1,
-            Self::V3 => 2,
-            Self::V4 => 3,
-            Self::V5 => 4,
-            Self::V6 => 5,
-        }
+        *self as u32
     }
 }
 

--- a/crates/ironrdp-pdu/src/gcc/conference_create.rs
+++ b/crates/ironrdp-pdu/src/gcc/conference_create.rs
@@ -34,8 +34,8 @@ impl ConferenceCreateRequest {
     const NAME: &'static str = "ConferenceCreateRequest";
 
     pub fn new(gcc_blocks: ClientGccBlocks) -> DecodeResult<Self> {
-        // Ensure the invariant on gcc_blocks.size() is respected
-        if gcc_blocks.size() + CONFERENCE_REQUEST_CONNECT_PDU_SIZE > usize::from(u16::MAX) {
+        // Ensure the invariant on gcc_blocks.size() is respected.
+        if !(gcc_blocks.size() + CONFERENCE_REQUEST_CONNECT_PDU_SIZE <= usize::from(u16::MAX)) {
             return Err(invalid_field_err!(
                 "gcc_blocks",
                 "gcc_blocks.size() + CONFERENCE_REQUEST_CONNECT_PDU_SIZE > u16::MAX"

--- a/crates/ironrdp-pdu/src/gcc/conference_create.rs
+++ b/crates/ironrdp-pdu/src/gcc/conference_create.rs
@@ -205,11 +205,13 @@ impl ConferenceCreateResponse {
     const NAME: &'static str = "ConferenceCreateResponse";
 
     pub fn new(user_id: u16, gcc_blocks: ServerGccBlocks) -> DecodeResult<Self> {
-        // INVARIANT: gcc_blocks.size() + CONFERENCE_RESPONSE_CONNECT_PDU_SIZE <= u16::MAX
-        let _: usize = cast_length!(
-            "gcc blocks length",
-            gcc_blocks.size() + CONFERENCE_RESPONSE_CONNECT_PDU_SIZE
-        )?;
+        // Ensure the invariant on gcc_blocks.size() is respected.
+        if !(gcc_blocks.size() + CONFERENCE_RESPONSE_CONNECT_PDU_SIZE <= usize::from(u16::MAX)) {
+            return Err(invalid_field_err!(
+                "gcc_blocks",
+                "gcc_blocks.size() + CONFERENCE_REQUEST_CONNECT_PDU_SIZE > u16::MAX"
+            ));
+        }
 
         Ok(Self { user_id, gcc_blocks })
     }

--- a/crates/ironrdp-pdu/src/gcc/conference_create.rs
+++ b/crates/ironrdp-pdu/src/gcc/conference_create.rs
@@ -35,12 +35,14 @@ impl ConferenceCreateRequest {
 
     pub fn new(gcc_blocks: ClientGccBlocks) -> DecodeResult<Self> {
         // Ensure the invariant on gcc_blocks.size() is respected.
-        if !(gcc_blocks.size() + CONFERENCE_REQUEST_CONNECT_PDU_SIZE <= usize::from(u16::MAX)) {
-            return Err(invalid_field_err!(
-                "gcc_blocks",
-                "gcc_blocks.size() + CONFERENCE_REQUEST_CONNECT_PDU_SIZE > u16::MAX"
-            ));
-        }
+        check_invariant(gcc_blocks.size() + CONFERENCE_REQUEST_CONNECT_PDU_SIZE <= usize::from(u16::MAX)).ok_or_else(
+            || {
+                invalid_field_err!(
+                    "gcc_blocks",
+                    "gcc_blocks.size() + CONFERENCE_REQUEST_CONNECT_PDU_SIZE > u16::MAX"
+                )
+            },
+        )?;
 
         Ok(Self { gcc_blocks })
     }
@@ -206,12 +208,14 @@ impl ConferenceCreateResponse {
 
     pub fn new(user_id: u16, gcc_blocks: ServerGccBlocks) -> DecodeResult<Self> {
         // Ensure the invariant on gcc_blocks.size() is respected.
-        if !(gcc_blocks.size() + CONFERENCE_RESPONSE_CONNECT_PDU_SIZE <= usize::from(u16::MAX)) {
-            return Err(invalid_field_err!(
-                "gcc_blocks",
-                "gcc_blocks.size() + CONFERENCE_REQUEST_CONNECT_PDU_SIZE > u16::MAX"
-            ));
-        }
+        check_invariant(gcc_blocks.size() + CONFERENCE_RESPONSE_CONNECT_PDU_SIZE <= usize::from(u16::MAX)).ok_or_else(
+            || {
+                invalid_field_err!(
+                    "gcc_blocks",
+                    "gcc_blocks.size() + CONFERENCE_REQUEST_CONNECT_PDU_SIZE > u16::MAX"
+                )
+            },
+        )?;
 
         Ok(Self { user_id, gcc_blocks })
     }
@@ -219,7 +223,7 @@ impl ConferenceCreateResponse {
     pub fn gcc_blocks(&self) -> &ServerGccBlocks {
         &self.gcc_blocks
     }
-    
+
     pub fn into_gcc_blocks(self) -> ServerGccBlocks {
         self.gcc_blocks
     }
@@ -361,4 +365,11 @@ impl<'de> Decode<'de> for ConferenceCreateResponse {
 
         Self::new(user_id, gcc_blocks)
     }
+}
+
+/// Use this when establishing invariants.
+#[inline]
+#[must_use]
+fn check_invariant(condition: bool) -> Option<()> {
+    condition.then_some(())
 }

--- a/crates/ironrdp-pdu/src/gcc/conference_create.rs
+++ b/crates/ironrdp-pdu/src/gcc/conference_create.rs
@@ -217,6 +217,10 @@ impl ConferenceCreateResponse {
     pub fn gcc_blocks(&self) -> &ServerGccBlocks {
         &self.gcc_blocks
     }
+    
+    pub fn into_gcc_blocks(self) -> ServerGccBlocks {
+        self.gcc_blocks
+    }
 }
 
 impl Encode for ConferenceCreateResponse {

--- a/crates/ironrdp-pdu/src/gcc/conference_create.rs
+++ b/crates/ironrdp-pdu/src/gcc/conference_create.rs
@@ -26,7 +26,7 @@ const CONFERENCE_NAME: &[u8] = b"1";
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ConferenceCreateRequest {
-    /// INVARIANT: `gcc_blocks.size() + CONFERENCE_REQUEST_CONNECT_PDU_SIZE <= u16::MAX`
+    /// INVARIANT: `gcc_blocks.size() <= u16::MAX - CONFERENCE_REQUEST_CONNECT_PDU_SIZE`
     gcc_blocks: ClientGccBlocks,
 }
 
@@ -35,7 +35,7 @@ impl ConferenceCreateRequest {
 
     pub fn new(gcc_blocks: ClientGccBlocks) -> DecodeResult<Self> {
         // Ensure the invariant on gcc_blocks.size() is respected.
-        check_invariant(gcc_blocks.size() + CONFERENCE_REQUEST_CONNECT_PDU_SIZE <= usize::from(u16::MAX)).ok_or_else(
+        check_invariant(gcc_blocks.size() <= usize::from(u16::MAX) - CONFERENCE_REQUEST_CONNECT_PDU_SIZE).ok_or_else(
             || {
                 invalid_field_err!(
                     "gcc_blocks",
@@ -199,7 +199,7 @@ impl<'de> Decode<'de> for ConferenceCreateRequest {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ConferenceCreateResponse {
     user_id: u16,
-    /// INVARIANT: `gcc_blocks.size() + CONFERENCE_RESPONSE_CONNECT_PDU_SIZE <= u16::MAX`
+    /// INVARIANT: `gcc_blocks.size() <= u16::MAX - CONFERENCE_RESPONSE_CONNECT_PDU_SIZE`
     gcc_blocks: ServerGccBlocks,
 }
 
@@ -208,7 +208,7 @@ impl ConferenceCreateResponse {
 
     pub fn new(user_id: u16, gcc_blocks: ServerGccBlocks) -> DecodeResult<Self> {
         // Ensure the invariant on gcc_blocks.size() is respected.
-        check_invariant(gcc_blocks.size() + CONFERENCE_RESPONSE_CONNECT_PDU_SIZE <= usize::from(u16::MAX)).ok_or_else(
+        check_invariant(gcc_blocks.size() <= usize::from(u16::MAX) - CONFERENCE_RESPONSE_CONNECT_PDU_SIZE).ok_or_else(
             || {
                 invalid_field_err!(
                     "gcc_blocks",

--- a/crates/ironrdp-pdu/src/gcc/core_data/client.rs
+++ b/crates/ironrdp-pdu/src/gcc/core_data/client.rs
@@ -516,14 +516,12 @@ pub enum ColorDepth {
 }
 
 impl ColorDepth {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u16(&self) -> u16 {
-        match self {
-            Self::Bpp4 => 0xCA00,
-            Self::Bpp8 => 0xCA01,
-            Self::Rgb555Bpp16 => 0xCA02,
-            Self::Rgb565Bpp16 => 0xCA03,
-            Self::Bpp24 => 0xCA04,
-        }
+        *self as u16
     }
 }
 
@@ -538,14 +536,12 @@ pub enum HighColorDepth {
 }
 
 impl HighColorDepth {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u16(&self) -> u16 {
-        match self {
-            Self::Bpp4 => 0x0004,
-            Self::Bpp8 => 0x0008,
-            Self::Rgb555Bpp16 => 0x000F,
-            Self::Rgb565Bpp16 => 0x0010,
-            Self::Bpp24 => 0x0018,
-        }
+        *self as u16
     }
 }
 
@@ -556,13 +552,16 @@ pub enum SecureAccessSequence {
 }
 
 impl SecureAccessSequence {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u16(&self) -> u16 {
-        match self {
-            Self::Del => 0xAA03,
-        }
+        *self as u16
     }
 }
 
+#[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum KeyboardType {
     IbmPcXt = 1,
@@ -575,16 +574,12 @@ pub enum KeyboardType {
 }
 
 impl KeyboardType {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     pub fn as_u32(&self) -> u32 {
-        match self {
-            Self::IbmPcXt => 1,
-            Self::OlivettiIco => 2,
-            Self::IbmPcAt => 3,
-            Self::IbmEnhanced => 4,
-            Self::Nokia1050 => 5,
-            Self::Nokia9140 => 6,
-            Self::Japanese => 7,
-        }
+        *self as u32
     }
 }
 
@@ -602,17 +597,12 @@ pub enum ConnectionType {
 }
 
 impl ConnectionType {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u8(&self) -> u8 {
-        match self {
-            Self::NotUsed => 0,
-            Self::Modem => 1,
-            Self::BroadbandLow => 2,
-            Self::Satellite => 3,
-            Self::BroadbandHigh => 4,
-            Self::Wan => 5,
-            Self::Lan => 6,
-            Self::Autodetect => 7,
-        }
+        *self as u8
     }
 }
 

--- a/crates/ironrdp-pdu/src/gcc/core_data/client.rs
+++ b/crates/ironrdp-pdu/src/gcc/core_data/client.rs
@@ -520,8 +520,8 @@ impl ColorDepth {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u16(&self) -> u16 {
-        *self as u16
+    fn as_u16(self) -> u16 {
+        self as u16
     }
 }
 
@@ -540,8 +540,8 @@ impl HighColorDepth {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u16(&self) -> u16 {
-        *self as u16
+    fn as_u16(self) -> u16 {
+        self as u16
     }
 }
 
@@ -556,8 +556,8 @@ impl SecureAccessSequence {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u16(&self) -> u16 {
-        *self as u16
+    fn as_u16(self) -> u16 {
+        self as u16
     }
 }
 
@@ -578,8 +578,8 @@ impl KeyboardType {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    pub fn as_u32(&self) -> u32 {
-        *self as u32
+    pub fn as_u32(self) -> u32 {
+        self as u32
     }
 }
 
@@ -601,8 +601,8 @@ impl ConnectionType {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u8(&self) -> u8 {
-        *self as u8
+    fn as_u8(self) -> u8 {
+        self as u8
     }
 }
 

--- a/crates/ironrdp-pdu/src/gcc/core_data/client.rs
+++ b/crates/ironrdp-pdu/src/gcc/core_data/client.rs
@@ -3,8 +3,8 @@ use ironrdp_core::{
     ensure_fixed_part_size, ensure_size, invalid_field_err, write_padding, Decode, DecodeResult, Encode, EncodeResult,
     ReadCursor, WriteCursor,
 };
-use num_derive::{FromPrimitive, ToPrimitive};
-use num_traits::{FromPrimitive as _, ToPrimitive as _};
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive as _;
 use tap::Pipe as _;
 
 use super::{RdpVersion, VERSION_SIZE};
@@ -108,13 +108,13 @@ impl Encode for ClientCoreData {
         dst.write_u32(self.version.0);
         dst.write_u16(self.desktop_width);
         dst.write_u16(self.desktop_height);
-        dst.write_u16(self.color_depth.to_u16().unwrap());
-        dst.write_u16(self.sec_access_sequence.to_u16().unwrap());
+        dst.write_u16(self.color_depth.as_u16());
+        dst.write_u16(self.sec_access_sequence.as_u16());
         dst.write_u32(self.keyboard_layout);
         dst.write_u32(self.client_build);
         dst.write_slice(client_name_dst.as_ref());
         dst.write_u16(0); // client name UTF-16 null terminator
-        dst.write_u32(self.keyboard_type.to_u32().unwrap());
+        dst.write_u32(self.keyboard_type.as_u32());
         dst.write_u32(self.keyboard_subtype);
         dst.write_u32(self.keyboard_functional_keys_count);
         dst.write_slice(ime_file_name_dst.as_ref());
@@ -223,7 +223,7 @@ impl Encode for ClientCoreOptionalData {
         ensure_size!(in: dst, size: self.size());
 
         if let Some(value) = self.post_beta2_color_depth {
-            dst.write_u16(value.to_u16().unwrap());
+            dst.write_u16(value.as_u16());
         }
 
         if let Some(value) = self.client_product_id {
@@ -247,7 +247,7 @@ impl Encode for ClientCoreOptionalData {
             if self.serial_number.is_none() {
                 return Err(invalid_field_err!("serialNumber", "serialNumber must be present"));
             }
-            dst.write_u16(value.to_u16().unwrap());
+            dst.write_u16(value.as_u16());
         }
 
         if let Some(value) = self.supported_color_depths {
@@ -285,7 +285,7 @@ impl Encode for ClientCoreOptionalData {
             if self.dig_product_id.is_none() {
                 return Err(invalid_field_err!("digProductId", "digProductId must be present"));
             }
-            dst.write_u8(value.to_u8().unwrap());
+            dst.write_u8(value.as_u8());
             write_padding!(dst, 1);
         }
 
@@ -506,7 +506,7 @@ impl From<HighColorDepth> for ClientColorDepth {
 }
 
 #[repr(u16)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum ColorDepth {
     Bpp4 = 0xCA00,
     Bpp8 = 0xCA01,
@@ -515,8 +515,20 @@ pub enum ColorDepth {
     Bpp24 = 0xCA04,
 }
 
+impl ColorDepth {
+    fn as_u16(&self) -> u16 {
+        match self {
+            Self::Bpp4 => 0xCA00,
+            Self::Bpp8 => 0xCA01,
+            Self::Rgb555Bpp16 => 0xCA02,
+            Self::Rgb565Bpp16 => 0xCA03,
+            Self::Bpp24 => 0xCA04,
+        }
+    }
+}
+
 #[repr(u16)]
-#[derive(Debug, Copy, Clone, FromPrimitive, ToPrimitive, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Debug, Copy, Clone, FromPrimitive, Eq, Ord, PartialEq, PartialOrd)]
 pub enum HighColorDepth {
     Bpp4 = 0x0004,
     Bpp8 = 0x0008,
@@ -525,13 +537,33 @@ pub enum HighColorDepth {
     Bpp24 = 0x0018,
 }
 
+impl HighColorDepth {
+    fn as_u16(&self) -> u16 {
+        match self {
+            Self::Bpp4 => 0x0004,
+            Self::Bpp8 => 0x0008,
+            Self::Rgb555Bpp16 => 0x000F,
+            Self::Rgb565Bpp16 => 0x0010,
+            Self::Bpp24 => 0x0018,
+        }
+    }
+}
+
 #[repr(u16)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum SecureAccessSequence {
     Del = 0xAA03,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+impl SecureAccessSequence {
+    fn as_u16(&self) -> u16 {
+        match self {
+            Self::Del => 0xAA03,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum KeyboardType {
     IbmPcXt = 1,
     OlivettiIco = 2,
@@ -542,8 +574,22 @@ pub enum KeyboardType {
     Japanese = 7,
 }
 
+impl KeyboardType {
+    pub fn as_u32(&self) -> u32 {
+        match self {
+            Self::IbmPcXt => 1,
+            Self::OlivettiIco => 2,
+            Self::IbmPcAt => 3,
+            Self::IbmEnhanced => 4,
+            Self::Nokia1050 => 5,
+            Self::Nokia9140 => 6,
+            Self::Japanese => 7,
+        }
+    }
+}
+
 #[repr(u8)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum ConnectionType {
     NotUsed = 0, // not used as ClientEarlyCapabilityFlags::VALID_CONNECTION_TYPE not set
     Modem = 1,
@@ -553,6 +599,21 @@ pub enum ConnectionType {
     Wan = 5,
     Lan = 6,
     Autodetect = 7,
+}
+
+impl ConnectionType {
+    fn as_u8(&self) -> u8 {
+        match self {
+            Self::NotUsed => 0,
+            Self::Modem => 1,
+            Self::BroadbandLow => 2,
+            Self::Satellite => 3,
+            Self::BroadbandHigh => 4,
+            Self::Wan => 5,
+            Self::Lan => 6,
+            Self::Autodetect => 7,
+        }
+    }
 }
 
 bitflags! {

--- a/crates/ironrdp-pdu/src/gcc/monitor_extended_data.rs
+++ b/crates/ironrdp-pdu/src/gcc/monitor_extended_data.rs
@@ -132,6 +132,7 @@ impl<'de> Decode<'de> for ExtendedMonitorInfo {
     }
 }
 
+#[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum MonitorOrientation {
     Landscape = 0,
@@ -141,12 +142,11 @@ pub enum MonitorOrientation {
 }
 
 impl MonitorOrientation {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u32(&self) -> u32 {
-        match self {
-            Self::Landscape => 0,
-            Self::Portrait => 90,
-            Self::LandscapeFlipped => 180,
-            Self::PortraitFlipped => 270,
-        }
+        *self as u32
     }
 }

--- a/crates/ironrdp-pdu/src/gcc/monitor_extended_data.rs
+++ b/crates/ironrdp-pdu/src/gcc/monitor_extended_data.rs
@@ -2,8 +2,8 @@ use ironrdp_core::{
     cast_length, ensure_fixed_part_size, ensure_size, invalid_field_err, Decode, DecodeResult, Encode, EncodeResult,
     ReadCursor, WriteCursor,
 };
-use num_derive::{FromPrimitive, ToPrimitive};
-use num_traits::{FromPrimitive as _, ToPrimitive as _};
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive as _;
 
 const MONITOR_COUNT_MAX: usize = 16;
 const MONITOR_ATTRIBUTE_SIZE: u32 = 20;
@@ -95,7 +95,7 @@ impl Encode for ExtendedMonitorInfo {
 
         dst.write_u32(self.physical_width);
         dst.write_u32(self.physical_height);
-        dst.write_u32(self.orientation.to_u32().unwrap());
+        dst.write_u32(self.orientation.as_u32());
         dst.write_u32(self.desktop_scale_factor);
         dst.write_u32(self.device_scale_factor);
 
@@ -132,10 +132,21 @@ impl<'de> Decode<'de> for ExtendedMonitorInfo {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum MonitorOrientation {
     Landscape = 0,
     Portrait = 90,
     LandscapeFlipped = 180,
     PortraitFlipped = 270,
+}
+
+impl MonitorOrientation {
+    fn as_u32(&self) -> u32 {
+        match self {
+            Self::Landscape => 0,
+            Self::Portrait => 90,
+            Self::LandscapeFlipped => 180,
+            Self::PortraitFlipped => 270,
+        }
+    }
 }

--- a/crates/ironrdp-pdu/src/gcc/monitor_extended_data.rs
+++ b/crates/ironrdp-pdu/src/gcc/monitor_extended_data.rs
@@ -146,7 +146,7 @@ impl MonitorOrientation {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u32(&self) -> u32 {
-        *self as u32
+    fn as_u32(self) -> u32 {
+        self as u32
     }
 }

--- a/crates/ironrdp-pdu/src/gcc/security_data.rs
+++ b/crates/ironrdp-pdu/src/gcc/security_data.rs
@@ -207,14 +207,12 @@ pub enum EncryptionLevel {
 }
 
 impl EncryptionLevel {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u32(&self) -> u32 {
-        match self {
-            Self::None => 0,
-            Self::Low => 1,
-            Self::ClientCompatible => 2,
-            Self::High => 3,
-            Self::Fips => 4,
-        }
+        *self as u32
     }
 }
 

--- a/crates/ironrdp-pdu/src/gcc/security_data.rs
+++ b/crates/ironrdp-pdu/src/gcc/security_data.rs
@@ -211,8 +211,8 @@ impl EncryptionLevel {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u32(&self) -> u32 {
-        *self as u32
+    fn as_u32(self) -> u32 {
+        self as u32
     }
 }
 

--- a/crates/ironrdp-pdu/src/gcc/security_data.rs
+++ b/crates/ironrdp-pdu/src/gcc/security_data.rs
@@ -5,8 +5,8 @@ use ironrdp_core::{
     cast_length, ensure_fixed_part_size, ensure_size, invalid_field_err, Decode, DecodeResult, Encode, EncodeResult,
     ReadCursor, WriteCursor,
 };
-use num_derive::{FromPrimitive, ToPrimitive};
-use num_traits::{FromPrimitive as _, ToPrimitive as _};
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive as _;
 use thiserror::Error;
 
 const CLIENT_ENCRYPTION_METHODS_SIZE: usize = 4;
@@ -100,7 +100,7 @@ impl Encode for ServerSecurityData {
         ensure_size!(in: dst, size: self.size());
 
         dst.write_u32(self.encryption_method.bits());
-        dst.write_u32(self.encryption_level.to_u32().unwrap());
+        dst.write_u32(self.encryption_level.as_u32());
 
         if self.encryption_method.is_empty() && self.encryption_level == EncryptionLevel::None {
             if self.server_random.is_some() || !self.server_cert.is_empty() {
@@ -197,13 +197,25 @@ bitflags! {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum EncryptionLevel {
     None = 0,
     Low = 1,
     ClientCompatible = 2,
     High = 3,
     Fips = 4,
+}
+
+impl EncryptionLevel {
+    fn as_u32(&self) -> u32 {
+        match self {
+            Self::None => 0,
+            Self::Low => 1,
+            Self::ClientCompatible => 2,
+            Self::High => 3,
+            Self::Fips => 4,
+        }
+    }
 }
 
 #[derive(Debug, Error)]

--- a/crates/ironrdp-pdu/src/geometry.rs
+++ b/crates/ironrdp-pdu/src/geometry.rs
@@ -149,10 +149,12 @@ impl_rectangle!(InclusiveRectangle);
 impl_rectangle!(ExclusiveRectangle);
 
 impl Rectangle for InclusiveRectangle {
+    /// INVARIANT: `0 < output (width)`
     fn width(&self) -> u16 {
         self.right - self.left + 1
     }
 
+    /// INVARIANT: `0 < output (height)`
     fn height(&self) -> u16 {
         self.bottom - self.top + 1
     }

--- a/crates/ironrdp-pdu/src/input/fast_path.rs
+++ b/crates/ironrdp-pdu/src/input/fast_path.rs
@@ -105,8 +105,8 @@ impl FastpathInputEventType {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u8(&self) -> u8 {
-        *self as u8
+    fn as_u8(self) -> u8 {
+        self as u8
     }
 }
 

--- a/crates/ironrdp-pdu/src/input/fast_path.rs
+++ b/crates/ironrdp-pdu/src/input/fast_path.rs
@@ -4,8 +4,8 @@ use ironrdp_core::{
     cast_length, ensure_fixed_part_size, ensure_size, invalid_field_err, other_err, Decode, DecodeResult, Encode,
     EncodeResult, ReadCursor, WriteCursor,
 };
-use num_derive::{FromPrimitive, ToPrimitive};
-use num_traits::{FromPrimitive as _, ToPrimitive as _};
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive as _;
 
 use crate::fast_path::EncryptionFlags;
 use crate::input::{MousePdu, MouseRelPdu, MouseXPdu};
@@ -88,7 +88,7 @@ impl<'de> Decode<'de> for FastPathInputHeader {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 #[repr(u8)]
 pub enum FastpathInputEventType {
     ScanCode = 0x0000,
@@ -98,6 +98,20 @@ pub enum FastpathInputEventType {
     Unicode = 0x0004,
     MouseRel = 0x0005,
     QoeTimestamp = 0x0006,
+}
+
+impl FastpathInputEventType {
+    fn as_u8(&self) -> u8 {
+        match self {
+            Self::ScanCode => 0x0000,
+            Self::Mouse => 0x0001,
+            Self::MouseX => 0x0002,
+            Self::Sync => 0x0003,
+            Self::Unicode => 0x0004,
+            Self::MouseRel => 0x0005,
+            Self::QoeTimestamp => 0x0006,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -132,7 +146,7 @@ impl Encode for FastPathInputEvent {
             FastPathInputEvent::SyncEvent(flags) => (flags.bits(), FastpathInputEventType::Sync),
         };
         header.set_bits(0..5, flags);
-        header.set_bits(5..8, code.to_u8().unwrap());
+        header.set_bits(5..8, code.as_u8());
         dst.write_u8(header);
         match self {
             FastPathInputEvent::KeyboardEvent(_, code) => {

--- a/crates/ironrdp-pdu/src/input/fast_path.rs
+++ b/crates/ironrdp-pdu/src/input/fast_path.rs
@@ -101,16 +101,12 @@ pub enum FastpathInputEventType {
 }
 
 impl FastpathInputEventType {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u8(&self) -> u8 {
-        match self {
-            Self::ScanCode => 0x0000,
-            Self::Mouse => 0x0001,
-            Self::MouseX => 0x0002,
-            Self::Sync => 0x0003,
-            Self::Unicode => 0x0004,
-            Self::MouseRel => 0x0005,
-            Self::QoeTimestamp => 0x0006,
-        }
+        *self as u8
     }
 }
 

--- a/crates/ironrdp-pdu/src/input/mod.rs
+++ b/crates/ironrdp-pdu/src/input/mod.rs
@@ -163,8 +163,8 @@ impl InputEventType {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u16(&self) -> u16 {
-        *self as u16
+    fn as_u16(self) -> u16 {
+        self as u16
     }
 }
 

--- a/crates/ironrdp-pdu/src/input/mod.rs
+++ b/crates/ironrdp-pdu/src/input/mod.rs
@@ -159,16 +159,12 @@ enum InputEventType {
 }
 
 impl InputEventType {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u16(&self) -> u16 {
-        match self {
-            Self::Sync => 0x0000,
-            Self::Unused => 0x0002,
-            Self::ScanCode => 0x0004,
-            Self::Unicode => 0x0005,
-            Self::Mouse => 0x8001,
-            Self::MouseX => 0x8002,
-            Self::MouseRel => 0x8004,
-        }
+        *self as u16
     }
 }
 

--- a/crates/ironrdp-pdu/src/input/mod.rs
+++ b/crates/ironrdp-pdu/src/input/mod.rs
@@ -4,8 +4,8 @@ use ironrdp_core::{
     ensure_fixed_part_size, ensure_size, invalid_field_err, read_padding, write_padding, Decode, DecodeResult, Encode,
     EncodeResult, ReadCursor, WriteCursor,
 };
-use num_derive::{FromPrimitive, ToPrimitive};
-use num_traits::{FromPrimitive as _, ToPrimitive as _};
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive as _;
 use thiserror::Error;
 
 pub mod fast_path;
@@ -94,7 +94,7 @@ impl Encode for InputEvent {
         ensure_fixed_part_size!(in: dst);
 
         dst.write_u32(0); // event time is ignored by a server
-        dst.write_u16(InputEventType::from(self).to_u16().unwrap());
+        dst.write_u16(InputEventType::from(self).as_u16());
 
         match self {
             Self::Sync(pdu) => pdu.encode(dst),
@@ -146,7 +146,7 @@ impl<'de> Decode<'de> for InputEvent {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, FromPrimitive)]
 #[repr(u16)]
 enum InputEventType {
     Sync = 0x0000,
@@ -156,6 +156,20 @@ enum InputEventType {
     Mouse = 0x8001,
     MouseX = 0x8002,
     MouseRel = 0x8004,
+}
+
+impl InputEventType {
+    fn as_u16(&self) -> u16 {
+        match self {
+            Self::Sync => 0x0000,
+            Self::Unused => 0x0002,
+            Self::ScanCode => 0x0004,
+            Self::Unicode => 0x0005,
+            Self::Mouse => 0x8001,
+            Self::MouseX => 0x8002,
+            Self::MouseRel => 0x8004,
+        }
+    }
 }
 
 impl From<&InputEvent> for InputEventType {

--- a/crates/ironrdp-pdu/src/mcs.rs
+++ b/crates/ironrdp-pdu/src/mcs.rs
@@ -847,20 +847,20 @@ pub struct ConnectInitial {
 }
 
 impl ConnectInitial {
-    pub fn with_gcc_blocks(gcc_blocks: ClientGccBlocks) -> Self {
-        Self {
-            conference_create_request: ConferenceCreateRequest { gcc_blocks },
+    pub fn with_gcc_blocks(gcc_blocks: ClientGccBlocks) -> DecodeResult<Self> {
+        Ok(Self {
+            conference_create_request: ConferenceCreateRequest::new(gcc_blocks)?,
             calling_domain_selector: vec![0x01],
             called_domain_selector: vec![0x01],
             upward_flag: true,
             target_parameters: DomainParameters::target(),
             min_parameters: DomainParameters::min(),
             max_parameters: DomainParameters::max(),
-        }
+        })
     }
 
     pub fn channel_names(&self) -> Option<Vec<ChannelDef>> {
-        self.conference_create_request.gcc_blocks.channel_names()
+        self.conference_create_request.gcc_blocks().channel_names()
     }
 }
 
@@ -873,11 +873,11 @@ pub struct ConnectResponse {
 
 impl ConnectResponse {
     pub fn channel_ids(&self) -> Vec<u16> {
-        self.conference_create_response.gcc_blocks.channel_ids()
+        self.conference_create_response.gcc_blocks().channel_ids()
     }
 
     pub fn global_channel_id(&self) -> u16 {
-        self.conference_create_response.gcc_blocks.global_channel_id()
+        self.conference_create_response.gcc_blocks().global_channel_id()
     }
 }
 

--- a/crates/ironrdp-pdu/src/per.rs
+++ b/crates/ironrdp-pdu/src/per.rs
@@ -105,7 +105,7 @@ pub(crate) fn write_length(dst: &mut WriteCursor<'_>, length: u16) {
     if length > 0x7f {
         write_long_length(dst, length);
     } else {
-        dst.write_u8(u8::try_from(length).unwrap());
+        dst.write_u8(u8::try_from(length).expect("length is guaranteed to fit into u8 due to the prior check"));
     }
 }
 
@@ -187,10 +187,10 @@ pub(crate) fn read_u32(src: &mut ReadCursor<'_>) -> Result<u32, PerError> {
 pub(crate) fn write_u32(dst: &mut WriteCursor<'_>, value: u32) {
     if value <= 0xff {
         write_length(dst, 1);
-        dst.write_u8(u8::try_from(value).unwrap());
+        dst.write_u8(u8::try_from(value).expect("value is guaranteed to fit into u8 due to the prior check"));
     } else if value <= 0xffff {
         write_length(dst, 2);
-        dst.write_u16_be(u16::try_from(value).unwrap());
+        dst.write_u16_be(u16::try_from(value).expect("value is guaranteed to fit into u16 due to the prior check"));
     } else {
         write_length(dst, 4);
         dst.write_u32_be(value);

--- a/crates/ironrdp-pdu/src/rdp/capability_sets.rs
+++ b/crates/ironrdp-pdu/src/rdp/capability_sets.rs
@@ -601,8 +601,8 @@ impl CapabilitySetType {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u16(&self) -> u16 {
-        *self as u16
+    fn as_u16(self) -> u16 {
+        self as u16
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/capability_sets.rs
+++ b/crates/ironrdp-pdu/src/rdp/capability_sets.rs
@@ -4,8 +4,8 @@ use ironrdp_core::{
     cast_length, decode, ensure_fixed_part_size, ensure_size, invalid_field_err, unsupported_value_err, write_padding,
     Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor,
 };
-use num_derive::{FromPrimitive, ToPrimitive};
-use num_traits::{FromPrimitive as _, ToPrimitive as _};
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive as _;
 use thiserror::Error;
 
 use crate::{utils, PduError};
@@ -293,7 +293,7 @@ impl Encode for CapabilitySet {
 
         match self {
             CapabilitySet::General(capset) => {
-                dst.write_u16(CapabilitySetType::General.to_u16().unwrap());
+                dst.write_u16(CapabilitySetType::General.as_u16());
                 dst.write_u16(cast_length!(
                     "len",
                     capset.size() + CAPABILITY_SET_TYPE_FIELD_SIZE + CAPABILITY_SET_LENGTH_FIELD_SIZE
@@ -301,7 +301,7 @@ impl Encode for CapabilitySet {
                 capset.encode(dst)?;
             }
             CapabilitySet::Bitmap(capset) => {
-                dst.write_u16(CapabilitySetType::Bitmap.to_u16().unwrap());
+                dst.write_u16(CapabilitySetType::Bitmap.as_u16());
                 dst.write_u16(cast_length!(
                     "len",
                     capset.size() + CAPABILITY_SET_TYPE_FIELD_SIZE + CAPABILITY_SET_LENGTH_FIELD_SIZE
@@ -309,7 +309,7 @@ impl Encode for CapabilitySet {
                 capset.encode(dst)?;
             }
             CapabilitySet::Order(capset) => {
-                dst.write_u16(CapabilitySetType::Order.to_u16().unwrap());
+                dst.write_u16(CapabilitySetType::Order.as_u16());
                 dst.write_u16(cast_length!(
                     "len",
                     capset.size() + CAPABILITY_SET_TYPE_FIELD_SIZE + CAPABILITY_SET_LENGTH_FIELD_SIZE
@@ -317,7 +317,7 @@ impl Encode for CapabilitySet {
                 capset.encode(dst)?;
             }
             CapabilitySet::BitmapCache(capset) => {
-                dst.write_u16(CapabilitySetType::BitmapCache.to_u16().unwrap());
+                dst.write_u16(CapabilitySetType::BitmapCache.as_u16());
                 dst.write_u16(cast_length!(
                     "len",
                     capset.size() + CAPABILITY_SET_TYPE_FIELD_SIZE + CAPABILITY_SET_LENGTH_FIELD_SIZE
@@ -325,7 +325,7 @@ impl Encode for CapabilitySet {
                 capset.encode(dst)?;
             }
             CapabilitySet::BitmapCacheRev2(capset) => {
-                dst.write_u16(CapabilitySetType::BitmapCacheRev2.to_u16().unwrap());
+                dst.write_u16(CapabilitySetType::BitmapCacheRev2.as_u16());
                 dst.write_u16(cast_length!(
                     "len",
                     capset.size() + CAPABILITY_SET_TYPE_FIELD_SIZE + CAPABILITY_SET_LENGTH_FIELD_SIZE
@@ -333,7 +333,7 @@ impl Encode for CapabilitySet {
                 capset.encode(dst)?;
             }
             CapabilitySet::Pointer(capset) => {
-                dst.write_u16(CapabilitySetType::Pointer.to_u16().unwrap());
+                dst.write_u16(CapabilitySetType::Pointer.as_u16());
                 dst.write_u16(cast_length!(
                     "len",
                     capset.size() + CAPABILITY_SET_TYPE_FIELD_SIZE + CAPABILITY_SET_LENGTH_FIELD_SIZE
@@ -341,7 +341,7 @@ impl Encode for CapabilitySet {
                 capset.encode(dst)?;
             }
             CapabilitySet::Sound(capset) => {
-                dst.write_u16(CapabilitySetType::Sound.to_u16().unwrap());
+                dst.write_u16(CapabilitySetType::Sound.as_u16());
                 dst.write_u16(cast_length!(
                     "len",
                     capset.size() + CAPABILITY_SET_TYPE_FIELD_SIZE + CAPABILITY_SET_LENGTH_FIELD_SIZE
@@ -349,7 +349,7 @@ impl Encode for CapabilitySet {
                 capset.encode(dst)?;
             }
             CapabilitySet::Input(capset) => {
-                dst.write_u16(CapabilitySetType::Input.to_u16().unwrap());
+                dst.write_u16(CapabilitySetType::Input.as_u16());
                 dst.write_u16(cast_length!(
                     "len",
                     capset.size() + CAPABILITY_SET_TYPE_FIELD_SIZE + CAPABILITY_SET_LENGTH_FIELD_SIZE
@@ -357,7 +357,7 @@ impl Encode for CapabilitySet {
                 capset.encode(dst)?;
             }
             CapabilitySet::Brush(capset) => {
-                dst.write_u16(CapabilitySetType::Brush.to_u16().unwrap());
+                dst.write_u16(CapabilitySetType::Brush.as_u16());
                 dst.write_u16(cast_length!(
                     "len",
                     capset.size() + CAPABILITY_SET_TYPE_FIELD_SIZE + CAPABILITY_SET_LENGTH_FIELD_SIZE
@@ -365,7 +365,7 @@ impl Encode for CapabilitySet {
                 capset.encode(dst)?;
             }
             CapabilitySet::GlyphCache(capset) => {
-                dst.write_u16(CapabilitySetType::GlyphCache.to_u16().unwrap());
+                dst.write_u16(CapabilitySetType::GlyphCache.as_u16());
                 dst.write_u16(cast_length!(
                     "len",
                     capset.size() + CAPABILITY_SET_TYPE_FIELD_SIZE + CAPABILITY_SET_LENGTH_FIELD_SIZE
@@ -373,7 +373,7 @@ impl Encode for CapabilitySet {
                 capset.encode(dst)?;
             }
             CapabilitySet::OffscreenBitmapCache(capset) => {
-                dst.write_u16(CapabilitySetType::OffscreenBitmapCache.to_u16().unwrap());
+                dst.write_u16(CapabilitySetType::OffscreenBitmapCache.as_u16());
                 dst.write_u16(cast_length!(
                     "len",
                     capset.size() + CAPABILITY_SET_TYPE_FIELD_SIZE + CAPABILITY_SET_LENGTH_FIELD_SIZE
@@ -381,7 +381,7 @@ impl Encode for CapabilitySet {
                 capset.encode(dst)?;
             }
             CapabilitySet::VirtualChannel(capset) => {
-                dst.write_u16(CapabilitySetType::VirtualChannel.to_u16().unwrap());
+                dst.write_u16(CapabilitySetType::VirtualChannel.as_u16());
                 dst.write_u16(cast_length!(
                     "len",
                     capset.size() + CAPABILITY_SET_TYPE_FIELD_SIZE + CAPABILITY_SET_LENGTH_FIELD_SIZE
@@ -389,7 +389,7 @@ impl Encode for CapabilitySet {
                 capset.encode(dst)?;
             }
             CapabilitySet::SurfaceCommands(capset) => {
-                dst.write_u16(CapabilitySetType::SurfaceCommands.to_u16().unwrap());
+                dst.write_u16(CapabilitySetType::SurfaceCommands.as_u16());
                 dst.write_u16(cast_length!(
                     "len",
                     capset.size() + CAPABILITY_SET_TYPE_FIELD_SIZE + CAPABILITY_SET_LENGTH_FIELD_SIZE
@@ -397,7 +397,7 @@ impl Encode for CapabilitySet {
                 capset.encode(dst)?;
             }
             CapabilitySet::BitmapCodecs(capset) => {
-                dst.write_u16(CapabilitySetType::BitmapCodecs.to_u16().unwrap());
+                dst.write_u16(CapabilitySetType::BitmapCodecs.as_u16());
                 dst.write_u16(cast_length!(
                     "len",
                     capset.size() + CAPABILITY_SET_TYPE_FIELD_SIZE + CAPABILITY_SET_LENGTH_FIELD_SIZE
@@ -405,7 +405,7 @@ impl Encode for CapabilitySet {
                 capset.encode(dst)?;
             }
             CapabilitySet::MultiFragmentUpdate(capset) => {
-                dst.write_u16(CapabilitySetType::MultiFragmentUpdate.to_u16().unwrap());
+                dst.write_u16(CapabilitySetType::MultiFragmentUpdate.as_u16());
                 dst.write_u16(cast_length!(
                     "len",
                     capset.size() + CAPABILITY_SET_TYPE_FIELD_SIZE + CAPABILITY_SET_LENGTH_FIELD_SIZE
@@ -413,7 +413,7 @@ impl Encode for CapabilitySet {
                 capset.encode(dst)?;
             }
             CapabilitySet::LargePointer(capset) => {
-                dst.write_u16(CapabilitySetType::LargePointer.to_u16().unwrap());
+                dst.write_u16(CapabilitySetType::LargePointer.as_u16());
                 dst.write_u16(cast_length!(
                     "len",
                     capset.size() + CAPABILITY_SET_TYPE_FIELD_SIZE + CAPABILITY_SET_LENGTH_FIELD_SIZE
@@ -421,7 +421,7 @@ impl Encode for CapabilitySet {
                 capset.encode(dst)?;
             }
             CapabilitySet::FrameAcknowledge(capset) => {
-                dst.write_u16(CapabilitySetType::FrameAcknowledge.to_u16().unwrap());
+                dst.write_u16(CapabilitySetType::FrameAcknowledge.as_u16());
                 dst.write_u16(cast_length!(
                     "len",
                     capset.size() + CAPABILITY_SET_TYPE_FIELD_SIZE + CAPABILITY_SET_LENGTH_FIELD_SIZE
@@ -446,7 +446,7 @@ impl Encode for CapabilitySet {
                     _ => unreachable!(),
                 };
 
-                dst.write_u16(capability_set_type.to_u16().unwrap());
+                dst.write_u16(capability_set_type.as_u16());
                 dst.write_u16(cast_length!(
                     "len",
                     capability_set_buffer.len() + CAPABILITY_SET_TYPE_FIELD_SIZE + CAPABILITY_SET_LENGTH_FIELD_SIZE
@@ -562,7 +562,7 @@ impl<'de> Decode<'de> for CapabilitySet {
     }
 }
 
-#[derive(Copy, Clone, Debug, FromPrimitive, ToPrimitive)]
+#[derive(Copy, Clone, Debug, FromPrimitive)]
 enum CapabilitySetType {
     General = 0x01,
     Bitmap = 0x02,
@@ -593,6 +593,42 @@ enum CapabilitySetType {
     SurfaceCommands = 0x1c,
     BitmapCodecs = 0x1d,
     FrameAcknowledge = 0x1e,
+}
+
+impl CapabilitySetType {
+    fn as_u16(&self) -> u16 {
+        match self {
+            Self::General => 0x01,
+            Self::Bitmap => 0x02,
+            Self::Order => 0x03,
+            Self::BitmapCache => 0x04,
+            Self::Control => 0x05,
+            Self::BitmapCacheV3CodecID => 0x06,
+            Self::WindowActivation => 0x07,
+            Self::Pointer => 0x08,
+            Self::Share => 0x09,
+            Self::ColorCache => 0x0a,
+            Self::Sound => 0x0c,
+            Self::Input => 0x0d,
+            Self::Font => 0x0e,
+            Self::Brush => 0x0f,
+            Self::GlyphCache => 0x10,
+            Self::OffscreenBitmapCache => 0x11,
+            Self::BitmapCacheHostSupport => 0x12,
+            Self::BitmapCacheRev2 => 0x13,
+            Self::VirtualChannel => 0x14,
+            Self::DrawNineGridCache => 0x15,
+            Self::DrawGdiPlus => 0x16,
+            Self::Rail => 0x17,
+            Self::WindowList => 0x18,
+            Self::DesktopComposition => 0x19,
+            Self::MultiFragmentUpdate => 0x1a,
+            Self::LargePointer => 0x1b,
+            Self::SurfaceCommands => 0x1c,
+            Self::BitmapCodecs => 0x1d,
+            Self::FrameAcknowledge => 0x1e,
+        }
+    }
 }
 
 #[derive(Debug, Error)]

--- a/crates/ironrdp-pdu/src/rdp/capability_sets.rs
+++ b/crates/ironrdp-pdu/src/rdp/capability_sets.rs
@@ -562,6 +562,7 @@ impl<'de> Decode<'de> for CapabilitySet {
     }
 }
 
+#[repr(u16)]
 #[derive(Copy, Clone, Debug, FromPrimitive)]
 enum CapabilitySetType {
     General = 0x01,
@@ -596,38 +597,12 @@ enum CapabilitySetType {
 }
 
 impl CapabilitySetType {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u16(&self) -> u16 {
-        match self {
-            Self::General => 0x01,
-            Self::Bitmap => 0x02,
-            Self::Order => 0x03,
-            Self::BitmapCache => 0x04,
-            Self::Control => 0x05,
-            Self::BitmapCacheV3CodecID => 0x06,
-            Self::WindowActivation => 0x07,
-            Self::Pointer => 0x08,
-            Self::Share => 0x09,
-            Self::ColorCache => 0x0a,
-            Self::Sound => 0x0c,
-            Self::Input => 0x0d,
-            Self::Font => 0x0e,
-            Self::Brush => 0x0f,
-            Self::GlyphCache => 0x10,
-            Self::OffscreenBitmapCache => 0x11,
-            Self::BitmapCacheHostSupport => 0x12,
-            Self::BitmapCacheRev2 => 0x13,
-            Self::VirtualChannel => 0x14,
-            Self::DrawNineGridCache => 0x15,
-            Self::DrawGdiPlus => 0x16,
-            Self::Rail => 0x17,
-            Self::WindowList => 0x18,
-            Self::DesktopComposition => 0x19,
-            Self::MultiFragmentUpdate => 0x1a,
-            Self::LargePointer => 0x1b,
-            Self::SurfaceCommands => 0x1c,
-            Self::BitmapCodecs => 0x1d,
-            Self::FrameAcknowledge => 0x1e,
-        }
+        *self as u16
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/capability_sets/bitmap_codecs.rs
+++ b/crates/ironrdp-pdu/src/rdp/capability_sets/bitmap_codecs.rs
@@ -629,6 +629,7 @@ impl<'de> Decode<'de> for RfxICap {
     }
 }
 
+#[repr(u8)]
 #[derive(PartialEq, Eq, Debug, FromPrimitive, Copy, Clone)]
 pub enum EntropyBits {
     Rlgr1 = 1,
@@ -637,10 +638,7 @@ pub enum EntropyBits {
 
 impl EntropyBits {
     fn as_u8(&self) -> u8 {
-        match self {
-            Self::Rlgr1 => 1,
-            Self::Rlgr3 => 4,
-        }
+        *self as u8
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/capability_sets/bitmap_codecs.rs
+++ b/crates/ironrdp-pdu/src/rdp/capability_sets/bitmap_codecs.rs
@@ -637,8 +637,8 @@ pub enum EntropyBits {
 }
 
 impl EntropyBits {
-    fn as_u8(&self) -> u8 {
-        *self as u8
+    fn as_u8(self) -> u8 {
+        self as u8
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/capability_sets/bitmap_codecs.rs
+++ b/crates/ironrdp-pdu/src/rdp/capability_sets/bitmap_codecs.rs
@@ -9,8 +9,8 @@ use ironrdp_core::{
     cast_length, decode, ensure_fixed_part_size, ensure_size, invalid_field_err, other_err, Decode, DecodeResult,
     Encode, EncodeResult, ReadCursor, WriteCursor,
 };
-use num_derive::{FromPrimitive, ToPrimitive};
-use num_traits::{FromPrimitive as _, ToPrimitive as _};
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive as _;
 
 const RFX_ICAP_VERSION: u16 = 0x0100;
 const RFX_ICAP_TILE_SIZE: u16 = 0x40;
@@ -582,7 +582,7 @@ impl Encode for RfxICap {
         dst.write_u8(self.flags.bits());
         dst.write_u8(RFX_ICAP_COLOR_CONVERSION);
         dst.write_u8(RFX_ICAP_TRANSFORM_BITS);
-        dst.write_u8(self.entropy_bits.to_u8().unwrap());
+        dst.write_u8(self.entropy_bits.as_u8());
 
         Ok(())
     }
@@ -629,10 +629,19 @@ impl<'de> Decode<'de> for RfxICap {
     }
 }
 
-#[derive(PartialEq, Eq, Debug, FromPrimitive, ToPrimitive, Copy, Clone)]
+#[derive(PartialEq, Eq, Debug, FromPrimitive, Copy, Clone)]
 pub enum EntropyBits {
     Rlgr1 = 1,
     Rlgr3 = 4,
+}
+
+impl EntropyBits {
+    fn as_u8(&self) -> u8 {
+        match self {
+            Self::Rlgr1 => 1,
+            Self::Rlgr3 => 4,
+        }
+    }
 }
 
 bitflags! {

--- a/crates/ironrdp-pdu/src/rdp/capability_sets/brush.rs
+++ b/crates/ironrdp-pdu/src/rdp/capability_sets/brush.rs
@@ -22,8 +22,8 @@ impl SupportLevel {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u32(&self) -> u32 {
-        *self as u32
+    fn as_u32(self) -> u32 {
+        self as u32
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/capability_sets/brush.rs
+++ b/crates/ironrdp-pdu/src/rdp/capability_sets/brush.rs
@@ -9,6 +9,7 @@ use num_traits::FromPrimitive as _;
 
 const BRUSH_LENGTH: usize = 4;
 
+#[repr(u32)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, FromPrimitive)]
 pub enum SupportLevel {
     Default = 0,
@@ -17,12 +18,12 @@ pub enum SupportLevel {
 }
 
 impl SupportLevel {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u32(&self) -> u32 {
-        match self {
-            Self::Default => 0,
-            Self::Color8x8 => 1,
-            Self::ColorFull => 2,
-        }
+        *self as u32
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/capability_sets/brush.rs
+++ b/crates/ironrdp-pdu/src/rdp/capability_sets/brush.rs
@@ -4,16 +4,26 @@ mod tests;
 use ironrdp_core::{
     ensure_fixed_part_size, invalid_field_err, Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor,
 };
-use num_derive::{FromPrimitive, ToPrimitive};
-use num_traits::{FromPrimitive as _, ToPrimitive as _};
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive as _;
 
 const BRUSH_LENGTH: usize = 4;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, FromPrimitive)]
 pub enum SupportLevel {
     Default = 0,
     Color8x8 = 1,
     ColorFull = 2,
+}
+
+impl SupportLevel {
+    fn as_u32(&self) -> u32 {
+        match self {
+            Self::Default => 0,
+            Self::Color8x8 => 1,
+            Self::ColorFull => 2,
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -31,7 +41,7 @@ impl Encode for Brush {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         ensure_fixed_part_size!(in: dst);
 
-        dst.write_u32(self.support_level.to_u32().unwrap());
+        dst.write_u32(self.support_level.as_u32());
 
         Ok(())
     }

--- a/crates/ironrdp-pdu/src/rdp/capability_sets/glyph_cache.rs
+++ b/crates/ironrdp-pdu/src/rdp/capability_sets/glyph_cache.rs
@@ -5,20 +5,31 @@ use ironrdp_core::{
     ensure_fixed_part_size, invalid_field_err, write_padding, Decode, DecodeResult, Encode, EncodeResult, ReadCursor,
     WriteCursor,
 };
-use num_derive::{FromPrimitive, ToPrimitive};
-use num_traits::{FromPrimitive as _, ToPrimitive as _};
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive as _;
 
 pub const GLYPH_CACHE_NUM: usize = 10;
 
 const GLYPH_CACHE_LENGTH: usize = 48;
 const CACHE_DEFINITION_LENGTH: usize = 4;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, FromPrimitive)]
 pub enum GlyphSupportLevel {
     None = 0,
     Partial = 1,
     Full = 2,
     Encode = 3,
+}
+
+impl GlyphSupportLevel {
+    fn as_u16(&self) -> u16 {
+        match self {
+            Self::None => 0,
+            Self::Partial => 1,
+            Self::Full => 2,
+            Self::Encode => 3,
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Default)]
@@ -86,7 +97,7 @@ impl Encode for GlyphCache {
 
         self.frag_cache.encode(dst)?;
 
-        dst.write_u16(self.glyph_support_level.to_u16().unwrap());
+        dst.write_u16(self.glyph_support_level.as_u16());
         write_padding!(dst, 2);
 
         Ok(())

--- a/crates/ironrdp-pdu/src/rdp/capability_sets/glyph_cache.rs
+++ b/crates/ironrdp-pdu/src/rdp/capability_sets/glyph_cache.rs
@@ -13,6 +13,7 @@ pub const GLYPH_CACHE_NUM: usize = 10;
 const GLYPH_CACHE_LENGTH: usize = 48;
 const CACHE_DEFINITION_LENGTH: usize = 4;
 
+#[repr(u16)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, FromPrimitive)]
 pub enum GlyphSupportLevel {
     None = 0,
@@ -22,13 +23,12 @@ pub enum GlyphSupportLevel {
 }
 
 impl GlyphSupportLevel {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u16(&self) -> u16 {
-        match self {
-            Self::None => 0,
-            Self::Partial => 1,
-            Self::Full => 2,
-            Self::Encode => 3,
-        }
+        *self as u16
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/capability_sets/glyph_cache.rs
+++ b/crates/ironrdp-pdu/src/rdp/capability_sets/glyph_cache.rs
@@ -27,8 +27,8 @@ impl GlyphSupportLevel {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u16(&self) -> u16 {
-        *self as u16
+    fn as_u16(self) -> u16 {
+        self as u16
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/capability_sets/input.rs
+++ b/crates/ironrdp-pdu/src/rdp/capability_sets/input.rs
@@ -6,7 +6,7 @@ use ironrdp_core::{
     ensure_fixed_part_size, read_padding, write_padding, Decode, DecodeResult, Encode, EncodeResult, ReadCursor,
     WriteCursor,
 };
-use num_traits::{FromPrimitive as _, ToPrimitive as _};
+use num_traits::FromPrimitive as _;
 
 use crate::gcc::{KeyboardType, IME_FILE_NAME_SIZE};
 use crate::utils;
@@ -53,7 +53,7 @@ impl Encode for Input {
         dst.write_u32(self.keyboard_layout);
 
         let type_buffer = match self.keyboard_type.as_ref() {
-            Some(value) => value.to_u32().unwrap_or(0),
+            Some(value) => value.as_u32(),
             None => 0,
         };
         dst.write_u32(type_buffer);

--- a/crates/ironrdp-pdu/src/rdp/client_info.rs
+++ b/crates/ironrdp-pdu/src/rdp/client_info.rs
@@ -603,8 +603,8 @@ impl Month {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u16(&self) -> u16 {
-        *self as u16
+    fn as_u16(self) -> u16 {
+        self as u16
     }
 }
 
@@ -625,8 +625,8 @@ impl DayOfWeek {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u16(&self) -> u16 {
-        *self as u16
+    fn as_u16(self) -> u16 {
+        self as u16
     }
 }
 
@@ -645,8 +645,8 @@ impl DayOfWeekOccurrence {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u16(&self) -> u16 {
-        *self as u16
+    fn as_u16(self) -> u16 {
+        self as u16
     }
 }
 
@@ -753,8 +753,8 @@ impl CompressionType {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    pub fn as_u8(&self) -> u8 {
-        *self as u8
+    pub fn as_u8(self) -> u8 {
+        self as u8
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/client_info.rs
+++ b/crates/ironrdp-pdu/src/rdp/client_info.rs
@@ -3,11 +3,11 @@ use std::io;
 
 use bitflags::bitflags;
 use ironrdp_core::{
-    ensure_fixed_part_size, ensure_size, invalid_field_err, write_padding, Decode, DecodeResult, Encode, EncodeResult,
-    ReadCursor, WriteCursor,
+    cast_length, ensure_fixed_part_size, ensure_size, invalid_field_err, write_padding, Decode, DecodeResult, Encode,
+    EncodeResult, ReadCursor, WriteCursor,
 };
-use num_derive::{FromPrimitive, ToPrimitive};
-use num_traits::{FromPrimitive as _, ToPrimitive as _};
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive as _;
 use thiserror::Error;
 
 use crate::utils::CharacterSet;
@@ -71,15 +71,30 @@ impl Encode for ClientInfo {
 
         dst.write_u32(self.code_page);
 
-        let flags_with_compression_type = self.flags.bits() | (self.compression_type.to_u32().unwrap() << 9);
+        let flags_with_compression_type = self.flags.bits() | (u32::from(self.compression_type.as_u8()) << 9);
         dst.write_u32(flags_with_compression_type);
 
         let domain = self.credentials.domain.clone().unwrap_or_default();
-        dst.write_u16(string_len(domain.as_str(), character_set));
-        dst.write_u16(string_len(self.credentials.username.as_str(), character_set));
-        dst.write_u16(string_len(self.credentials.password.as_str(), character_set));
-        dst.write_u16(string_len(self.alternate_shell.as_str(), character_set));
-        dst.write_u16(string_len(self.work_dir.as_str(), character_set));
+        dst.write_u16(cast_length!(
+            "domain length",
+            string_len(domain.as_str(), character_set)
+        )?);
+        dst.write_u16(cast_length!(
+            "username length",
+            string_len(self.credentials.username.as_str(), character_set)
+        )?);
+        dst.write_u16(cast_length!(
+            "password length",
+            string_len(self.credentials.password.as_str(), character_set)
+        )?);
+        dst.write_u16(cast_length!(
+            "alternate shell length",
+            string_len(self.alternate_shell.as_str(), character_set)
+        )?);
+        dst.write_u16(cast_length!(
+            "work dir length",
+            string_len(self.work_dir.as_str(), character_set)
+        )?);
 
         utils::write_string_to_cursor(dst, domain.as_str(), character_set, true)?;
         utils::write_string_to_cursor(dst, self.credentials.username.as_str(), character_set, true)?;
@@ -111,12 +126,12 @@ impl Encode for ClientInfo {
             + PASSWORD_LENGTH_SIZE
             + ALTERNATE_SHELL_LENGTH_SIZE
             + WORK_DIR_LENGTH_SIZE
-            + (string_len(domain.as_str(), character_set)
+            + string_len(domain.as_str(), character_set)
                 + string_len(self.credentials.username.as_str(), character_set)
                 + string_len(self.credentials.password.as_str(), character_set)
                 + string_len(self.alternate_shell.as_str(), character_set)
-                + string_len(self.work_dir.as_str(), character_set)) as usize
-            + character_set.to_usize().unwrap() * 5 // null terminator
+                + string_len(self.work_dir.as_str(), character_set)
+            + usize::from(character_set.as_u16()) * 5 // null terminator
             + self.extra_info.size(character_set)
     }
 }
@@ -141,7 +156,7 @@ impl<'de> Decode<'de> for ClientInfo {
         };
 
         // Sizes exclude the length of the mandatory null terminator
-        let nt = character_set.to_usize().unwrap();
+        let nt = usize::from(character_set.as_u16());
         let domain_size = src.read_u16() as usize + nt;
         let user_name_size = src.read_u16() as usize + nt;
         let password_size = src.read_u16() as usize + nt;
@@ -234,11 +249,14 @@ impl ExtendedClientInfo {
     fn encode(&self, dst: &mut WriteCursor<'_>, character_set: CharacterSet) -> EncodeResult<()> {
         ensure_size!(in: dst, size: self.size(character_set));
 
+        let address_string_len: u16 = cast_length!("address length", string_len(self.address.as_str(), character_set))?;
+        let dir_string_len: u16 = cast_length!("dir length", string_len(self.dir.as_str(), character_set))?;
+
         dst.write_u16(self.address_family.as_u16());
         // // + size of null terminator, which will write in the write_string function
-        dst.write_u16(string_len(self.address.as_str(), character_set) + character_set.to_u16().unwrap());
+        dst.write_u16(address_string_len + character_set.as_u16());
         utils::write_string_to_cursor(dst, self.address.as_str(), character_set, true)?;
-        dst.write_u16(string_len(self.dir.as_str(), character_set) + character_set.to_u16().unwrap());
+        dst.write_u16(dir_string_len + character_set.as_u16());
         utils::write_string_to_cursor(dst, self.dir.as_str(), character_set, true)?;
         self.optional_data.encode(dst)?;
 
@@ -248,11 +266,11 @@ impl ExtendedClientInfo {
     fn size(&self, character_set: CharacterSet) -> usize {
         CLIENT_ADDRESS_FAMILY_SIZE
             + CLIENT_ADDRESS_LENGTH_SIZE
-            + string_len(self.address.as_str(), character_set) as usize
-            + character_set.to_usize().unwrap() // null terminator
+            + string_len(self.address.as_str(), character_set)
+            + usize::from(character_set.as_u16()) // null terminator
         + CLIENT_DIR_LENGTH_SIZE
-        + string_len(self.dir.as_str(), character_set) as usize
-            + character_set.to_usize().unwrap() // null terminator
+        + string_len(self.dir.as_str(), character_set)
+            + usize::from(character_set.as_u16()) // null terminator
         + self.optional_data.size()
     }
 }
@@ -508,9 +526,9 @@ impl Encode for OptionalSystemTime {
 
         dst.write_u16(0); // year
         if let Some(st) = &self.0 {
-            dst.write_u16(st.month.to_u16().unwrap());
-            dst.write_u16(st.day_of_week.to_u16().unwrap());
-            dst.write_u16(st.day.to_u16().unwrap());
+            dst.write_u16(st.month.as_u16());
+            dst.write_u16(st.day_of_week.as_u16());
+            dst.write_u16(st.day.as_u16());
             dst.write_u16(st.hour);
             dst.write_u16(st.minute);
             dst.write_u16(st.second);
@@ -564,7 +582,7 @@ impl<'de> Decode<'de> for OptionalSystemTime {
 }
 
 #[repr(u16)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum Month {
     January = 1,
     February = 2,
@@ -580,8 +598,27 @@ pub enum Month {
     December = 12,
 }
 
+impl Month {
+    fn as_u16(&self) -> u16 {
+        match self {
+            Self::January => 1,
+            Self::February => 2,
+            Self::March => 3,
+            Self::April => 4,
+            Self::May => 5,
+            Self::June => 6,
+            Self::July => 7,
+            Self::August => 8,
+            Self::September => 9,
+            Self::October => 10,
+            Self::November => 11,
+            Self::December => 12,
+        }
+    }
+}
+
 #[repr(u16)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum DayOfWeek {
     Sunday = 0,
     Monday = 1,
@@ -592,14 +629,40 @@ pub enum DayOfWeek {
     Saturday = 6,
 }
 
+impl DayOfWeek {
+    fn as_u16(&self) -> u16 {
+        match self {
+            Self::Sunday => 0,
+            Self::Monday => 1,
+            Self::Tuesday => 2,
+            Self::Wednesday => 3,
+            Self::Thursday => 4,
+            Self::Friday => 5,
+            Self::Saturday => 6,
+        }
+    }
+}
+
 #[repr(u16)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum DayOfWeekOccurrence {
     First = 1,
     Second = 2,
     Third = 3,
     Fourth = 4,
     Last = 5,
+}
+
+impl DayOfWeekOccurrence {
+    fn as_u16(&self) -> u16 {
+        match self {
+            Self::First => 1,
+            Self::Second => 2,
+            Self::Third => 3,
+            Self::Fourth => 4,
+            Self::Last => 5,
+        }
+    }
 }
 
 bitflags! {
@@ -691,12 +754,23 @@ bitflags! {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum CompressionType {
     K8 = 0,
     K64 = 1,
     Rdp6 = 2,
     Rdp61 = 3,
+}
+
+impl CompressionType {
+    pub fn as_u8(&self) -> u8 {
+        match self {
+            Self::K8 => 0,
+            Self::K64 => 1,
+            Self::Rdp6 => 2,
+            Self::Rdp61 => 3,
+        }
+    }
 }
 
 #[derive(Debug, Error)]
@@ -723,10 +797,10 @@ impl From<PduError> for ClientInfoError {
     }
 }
 
-fn string_len(value: &str, character_set: CharacterSet) -> u16 {
+fn string_len(value: &str, character_set: CharacterSet) -> usize {
     match character_set {
-        CharacterSet::Ansi => u16::try_from(value.len()).unwrap(),
-        CharacterSet::Unicode => u16::try_from(value.encode_utf16().count() * 2).unwrap(),
+        CharacterSet::Ansi => value.len(),
+        CharacterSet::Unicode => value.encode_utf16().count() * 2,
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/client_info.rs
+++ b/crates/ironrdp-pdu/src/rdp/client_info.rs
@@ -599,21 +599,12 @@ pub enum Month {
 }
 
 impl Month {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u16(&self) -> u16 {
-        match self {
-            Self::January => 1,
-            Self::February => 2,
-            Self::March => 3,
-            Self::April => 4,
-            Self::May => 5,
-            Self::June => 6,
-            Self::July => 7,
-            Self::August => 8,
-            Self::September => 9,
-            Self::October => 10,
-            Self::November => 11,
-            Self::December => 12,
-        }
+        *self as u16
     }
 }
 
@@ -630,16 +621,12 @@ pub enum DayOfWeek {
 }
 
 impl DayOfWeek {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u16(&self) -> u16 {
-        match self {
-            Self::Sunday => 0,
-            Self::Monday => 1,
-            Self::Tuesday => 2,
-            Self::Wednesday => 3,
-            Self::Thursday => 4,
-            Self::Friday => 5,
-            Self::Saturday => 6,
-        }
+        *self as u16
     }
 }
 
@@ -654,14 +641,12 @@ pub enum DayOfWeekOccurrence {
 }
 
 impl DayOfWeekOccurrence {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u16(&self) -> u16 {
-        match self {
-            Self::First => 1,
-            Self::Second => 2,
-            Self::Third => 3,
-            Self::Fourth => 4,
-            Self::Last => 5,
-        }
+        *self as u16
     }
 }
 
@@ -754,6 +739,7 @@ bitflags! {
     }
 }
 
+#[repr(u8)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum CompressionType {
     K8 = 0,
@@ -763,13 +749,12 @@ pub enum CompressionType {
 }
 
 impl CompressionType {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     pub fn as_u8(&self) -> u8 {
-        match self {
-            Self::K8 => 0,
-            Self::K64 => 1,
-            Self::Rdp6 => 2,
-            Self::Rdp61 => 3,
-        }
+        *self as u8
     }
 }
 
@@ -800,6 +785,7 @@ impl From<PduError> for ClientInfoError {
 fn string_len(value: &str, character_set: CharacterSet) -> usize {
     match character_set {
         CharacterSet::Ansi => value.len(),
+        // TODO: Use UTF-16 helper.
         CharacterSet::Unicode => value.encode_utf16().count() * 2,
     }
 }

--- a/crates/ironrdp-pdu/src/rdp/finalization_messages.rs
+++ b/crates/ironrdp-pdu/src/rdp/finalization_messages.rs
@@ -230,7 +230,7 @@ impl<'de> Decode<'de> for MonitorLayoutPdu {
 }
 
 #[repr(u16)]
-#[derive(Debug, Clone, PartialEq, Eq, FromPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum ControlAction {
     RequestControl = 1,
     GrantedControl = 2,
@@ -239,13 +239,12 @@ pub enum ControlAction {
 }
 
 impl ControlAction {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u16(&self) -> u16 {
-        match self {
-            Self::RequestControl => 1,
-            Self::GrantedControl => 2,
-            Self::Detach => 3,
-            Self::Cooperate => 4,
-        }
+        *self as u16
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/finalization_messages.rs
+++ b/crates/ironrdp-pdu/src/rdp/finalization_messages.rs
@@ -3,8 +3,8 @@ use ironrdp_core::{
     cast_length, ensure_fixed_part_size, invalid_field_err, Decode, DecodeResult, Encode, EncodeResult, ReadCursor,
     WriteCursor,
 };
-use num_derive::{FromPrimitive, ToPrimitive};
-use num_traits::{FromPrimitive as _, ToPrimitive as _};
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive as _;
 
 use crate::gcc;
 
@@ -76,7 +76,7 @@ impl Encode for ControlPdu {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         ensure_fixed_part_size!(in: dst);
 
-        dst.write_u16(self.action.to_u16().unwrap());
+        dst.write_u16(self.action.as_u16());
         dst.write_u16(self.grant_id);
         dst.write_u32(self.control_id);
 
@@ -230,12 +230,23 @@ impl<'de> Decode<'de> for MonitorLayoutPdu {
 }
 
 #[repr(u16)]
-#[derive(Debug, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum ControlAction {
     RequestControl = 1,
     GrantedControl = 2,
     Detach = 3,
     Cooperate = 4,
+}
+
+impl ControlAction {
+    fn as_u16(&self) -> u16 {
+        match self {
+            Self::RequestControl => 1,
+            Self::GrantedControl => 2,
+            Self::Detach => 3,
+            Self::Cooperate => 4,
+        }
+    }
 }
 
 bitflags! {

--- a/crates/ironrdp-pdu/src/rdp/finalization_messages.rs
+++ b/crates/ironrdp-pdu/src/rdp/finalization_messages.rs
@@ -243,8 +243,8 @@ impl ControlAction {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u16(&self) -> u16 {
-        *self as u16
+    fn as_u16(self) -> u16 {
+        self as u16
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/headers.rs
+++ b/crates/ironrdp-pdu/src/rdp/headers.rs
@@ -515,6 +515,7 @@ bitflags! {
     }
 }
 
+#[repr(u8)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum StreamPriority {
     Undefined = 0,
@@ -524,16 +525,16 @@ pub enum StreamPriority {
 }
 
 impl StreamPriority {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u8(&self) -> u8 {
-        match self {
-            Self::Undefined => 0,
-            Self::Low => 1,
-            Self::Medium => 2,
-            Self::High => 4,
-        }
+        *self as u8
     }
 }
 
+#[repr(u16)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum ShareControlPduType {
     DemandActivePdu = 0x1,
@@ -544,14 +545,12 @@ pub enum ShareControlPduType {
 }
 
 impl ShareControlPduType {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u16(&self) -> u16 {
-        match self {
-            Self::DemandActivePdu => 0x1,
-            Self::ConfirmActivePdu => 0x3,
-            Self::DeactivateAllPdu => 0x6,
-            Self::DataPdu => 0x7,
-            Self::ServerRedirect => 0xa,
-        }
+        *self as u16
     }
 }
 
@@ -586,34 +585,12 @@ pub enum ShareDataPduType {
 }
 
 impl ShareDataPduType {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u8(&self) -> u8 {
-        match self {
-            Self::Update => 0x02,
-            Self::Control => 0x14,
-            Self::Pointer => 0x1b,
-            Self::Input => 0x1c,
-            Self::Synchronize => 0x1f,
-            Self::RefreshRectangle => 0x21,
-            Self::PlaySound => 0x22,
-            Self::SuppressOutput => 0x23,
-            Self::ShutdownRequest => 0x24,
-            Self::ShutdownDenied => 0x25,
-            Self::SaveSessionInfo => 0x26,
-            Self::FontList => 0x27,
-            Self::FontMap => 0x28,
-            Self::SetKeyboardIndicators => 0x29,
-            Self::BitmapCachePersistentList => 0x2b,
-            Self::BitmapCacheErrorPdu => 0x2c,
-            Self::SetKeyboardImeStatus => 0x2d,
-            Self::OffscreenCacheErrorPdu => 0x2e,
-            Self::SetErrorInfoPdu => 0x2f,
-            Self::DrawNineGridErrorPdu => 0x30,
-            Self::DrawGdiPusErrorPdu => 0x31,
-            Self::ArcStatusPdu => 0x32,
-            Self::StatusInfoPdu => 0x36,
-            Self::MonitorLayoutPdu => 0x37,
-            Self::FrameAcknowledgePdu => 0x38,
-        }
+        *self as u8
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/headers.rs
+++ b/crates/ironrdp-pdu/src/rdp/headers.rs
@@ -529,8 +529,8 @@ impl StreamPriority {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u8(&self) -> u8 {
-        *self as u8
+    fn as_u8(self) -> u8 {
+        self as u8
     }
 }
 
@@ -549,8 +549,8 @@ impl ShareControlPduType {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u16(&self) -> u16 {
-        *self as u16
+    fn as_u16(self) -> u16 {
+        self as u16
     }
 }
 
@@ -589,8 +589,8 @@ impl ShareDataPduType {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u8(&self) -> u8 {
-        *self as u8
+    fn as_u8(self) -> u8 {
+        self as u8
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/server_error_info.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_error_info.rs
@@ -1,8 +1,8 @@
 use ironrdp_core::{
     ensure_fixed_part_size, invalid_field_err, Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor,
 };
-use num_derive::{FromPrimitive, ToPrimitive};
-use num_traits::{FromPrimitive, ToPrimitive};
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ServerSetErrorInfoPdu(pub ErrorInfo);
@@ -17,7 +17,7 @@ impl Encode for ServerSetErrorInfoPdu {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         ensure_fixed_part_size!(in: dst);
 
-        dst.write_u32(self.0.to_u32().unwrap());
+        dst.write_u32(self.0.as_u32());
 
         Ok(())
     }
@@ -66,6 +66,15 @@ impl ErrorInfo {
             Self::RdpSpecificCode(c) => format!("[RDP specific code]: {}", c.description()),
         }
     }
+
+    fn as_u32(&self) -> u32 {
+        match self {
+            Self::ProtocolIndependentCode(c) => c.as_u32(),
+            Self::ProtocolIndependentLicensingCode(c) => c.as_u32(),
+            Self::ProtocolIndependentConnectionBrokerCode(c) => c.as_u32(),
+            Self::RdpSpecificCode(c) => c.as_u32(),
+        }
+    }
 }
 
 impl FromPrimitive for ErrorInfo {
@@ -94,27 +103,7 @@ impl FromPrimitive for ErrorInfo {
     }
 }
 
-impl ToPrimitive for ErrorInfo {
-    fn to_i64(&self) -> Option<i64> {
-        match self {
-            Self::ProtocolIndependentCode(c) => c.to_i64(),
-            Self::ProtocolIndependentLicensingCode(c) => c.to_i64(),
-            Self::ProtocolIndependentConnectionBrokerCode(c) => c.to_i64(),
-            Self::RdpSpecificCode(c) => c.to_i64(),
-        }
-    }
-
-    fn to_u64(&self) -> Option<u64> {
-        match self {
-            Self::ProtocolIndependentCode(c) => c.to_u64(),
-            Self::ProtocolIndependentLicensingCode(c) => c.to_u64(),
-            Self::ProtocolIndependentConnectionBrokerCode(c) => c.to_u64(),
-            Self::RdpSpecificCode(c) => c.to_u64(),
-        }
-    }
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum ProtocolIndependentCode {
     None = 0x0000_0000,
     RpcInitiatedDisconnect = 0x0000_0001,
@@ -159,9 +148,32 @@ impl ProtocolIndependentCode {
             Self::ServerCsrssCrash => "The CSRSS process running in the remote session terminated unexpectedly",
         }
     }
+
+    pub fn as_u32(&self) -> u32 {
+        match self {
+            Self::None => 0x0000_0000,
+            Self::RpcInitiatedDisconnect => 0x0000_0001,
+            Self::RpcInitiatedLogoff => 0x0000_0002,
+            Self::IdleTimeout => 0x0000_0003,
+            Self::LogonTimeout => 0x0000_0004,
+            Self::DisconnectedByOtherconnection => 0x0000_0005,
+            Self::OutOfMemory => 0x0000_0006,
+            Self::ServerDeniedConnection => 0x0000_0007,
+            Self::ServerInsufficientPrivileges => 0x0000_0009,
+            Self::ServerFreshCredentialsRequired => 0x0000_000A,
+            Self::RpcInitiatedDisconnectByuser => 0x0000_000B,
+            Self::LogoffByUser => 0x0000_000C,
+            Self::CloseStackOnDriverNotReady => 0x0000_000F,
+            Self::ServerDwmCrash => 0x0000_0010,
+            Self::CloseStackOnDriverFailure => 0x0000_0011,
+            Self::CloseStackOnDriverIfaceFailure => 0x0000_0012,
+            Self::ServerWinlogonCrash => 0x0000_0017,
+            Self::ServerCsrssCrash => 0x0000_0018,
+        }
+    }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum ProtocolIndependentLicensingCode {
     Internal = 0x0000_0100,
     NoLicenseServer = 0x0000_0101,
@@ -194,9 +206,25 @@ impl ProtocolIndependentLicensingCode {
             Self::NoRemoteConnections => "The remote computer is not licensed to accept remote connections",
         }
     }
+
+    fn as_u32(&self) -> u32 {
+        match self {
+            Self::Internal => 0x0000_0100,
+            Self::NoLicenseServer => 0x0000_0101,
+            Self::NoLicense => 0x0000_0102,
+            Self::BadClientMsg => 0x0000_0103,
+            Self::HwidDoesntMatchLicense => 0x0000_0104,
+            Self::BadClientLicense => 0x0000_0105,
+            Self::CantFinishProtocol => 0x0000_0106,
+            Self::ClientEndedProtocol => 0x0000_0107,
+            Self::BadClientEncryption => 0x0000_0108,
+            Self::CantUpgradeLicense => 0x0000_0109,
+            Self::NoRemoteConnections => 0x0000_010A,
+        }
+    }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum ProtocolIndependentConnectionBrokerCode {
     DestinationNotFound = 0x0000_0400,
     LoadingDestination = 0x0000_0402,
@@ -227,9 +255,25 @@ impl ProtocolIndependentConnectionBrokerCode {
             Self::SessionOnlineVmSessmonFailed => "A session monitoring error occurred while the target endpoint (a virtual machine) was being started",
         }
     }
+
+    fn as_u32(&self) -> u32 {
+        match self {
+            Self::DestinationNotFound => 0x0000_0400,
+            Self::LoadingDestination => 0x0000_0402,
+            Self::RedirectingToDestination => 0x0000_0404,
+            Self::SessionOnlineVmWake => 0x0000_0405,
+            Self::SessionOnlineVmBoot => 0x0000_0406,
+            Self::SessionOnlineVmNoDns => 0x0000_0407,
+            Self::DestinationPoolNotFree => 0x0000_0408,
+            Self::ConnectionCancelled => 0x0000_0409,
+            Self::ConnectionErrorInvalidSettings => 0x0000_0410,
+            Self::SessionOnlineVmBootTimeout => 0x0000_0411,
+            Self::SessionOnlineVmSessmonFailed => 0x0000_0412,
+        }
+    }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum RdpSpecificCode {
     UnknownPduType2 = 0x0000_10C9,
     UnknownPduType = 0x0000_10CA,
@@ -392,6 +436,89 @@ impl RdpSpecificCode {
             Self::EncryptFailed => "Encryption using Standard RDP Security mechanisms failed",
             Self::EncPkgMismatch => "Failed to find a usable Encryption Method in the encryptionMethods field of the Client Security Data",
             Self::DecryptFailed2 => "Unencrypted data was encountered in a protocol stream which is meant to be encrypted with Standard RDP Security mechanisms",
+        }
+    }
+
+    fn as_u32(&self) -> u32 {
+        match self {
+            Self::UnknownPduType2 => 0x0000_10C9,
+            Self::UnknownPduType => 0x0000_10CA,
+            Self::DataPdusEquence => 0x0000_10CB,
+            Self::ControlPduSequence => 0x0000_10CD,
+            Self::InvalidControlPduAction => 0x0000_10CE,
+            Self::InvalidInputPduType => 0x0000_10CF,
+            Self::InvalidInputPduMouse => 0x0000_10D0,
+            Self::InvalidRefreshRectPdu => 0x0000_10D1,
+            Self::CreateUserDataFailed => 0x0000_10D2,
+            Self::ConnectFailed => 0x0000_10D3,
+            Self::ConfirmActiveWrongShareId => 0x0000_10D4,
+            Self::ConfirmActiveWrongOriginator => 0x0000_10D5,
+            Self::PersistentKeyPduBadLength => 0x0000_10DA,
+            Self::PersistentKeyPduIllegalFirst => 0x0000_10DB,
+            Self::PersistentKeyPduTooManyTotalKeys => 0x0000_10DC,
+            Self::PersistentKeyPduTooManyCacheKeys => 0x0000_10DD,
+            Self::InputPduBadLength => 0x0000_10DE,
+            Self::BitmapCacheErrorPduBadLength => 0x0000_10DF,
+            Self::SecurityDataTooShort => 0x0000_10E0,
+            Self::VcHannelDataTooShort => 0x0000_10E1,
+            Self::ShareDataTooShort => 0x0000_10E2,
+            Self::BadSuppressOutputPdu => 0x0000_10E3,
+            Self::ConfirmActivePduTooShort => 0x0000_10E5,
+            Self::CapabilitySetTooSmall => 0x0000_10E7,
+            Self::CapabilitySetTooLarge => 0x0000_10E8,
+            Self::NoCursorCache => 0x0000_10E9,
+            Self::BadCapabilities => 0x0000_10EA,
+            Self::VirtualChannelDecompressionError => 0x0000_10EC,
+            Self::InvalidVcCompressionType => 0x0000_10ED,
+            Self::InvalidChannelId => 0x0000_10EF,
+            Self::VirtualChannelsTooMany => 0x0000_10F0,
+            Self::RemoteAppsNotEnabled => 0x0000_10F3,
+            Self::CacheCapabilityNotSet => 0x0000_10F4,
+            Self::BitmapCacheErrorPduBadLength2 => 0x0000_10F5,
+            Self::OffscrCacheErrorPduBadLength => 0x0000_10F6,
+            Self::DngCacheErrorPduBadLength => 0x0000_10F7,
+            Self::GdiPlusPduBadLength => 0x0000_10F8,
+            Self::SecurityDataTooShort2 => 0x0000_1111,
+            Self::SecurityDataTooShort3 => 0x0000_1112,
+            Self::SecurityDataTooShort4 => 0x0000_1113,
+            Self::SecurityDataTooShort5 => 0x0000_1114,
+            Self::SecurityDataTooShort6 => 0x0000_1115,
+            Self::SecurityDataTooShort7 => 0x0000_1116,
+            Self::SecurityDataTooShort8 => 0x0000_1117,
+            Self::SecurityDataTooShort9 => 0x0000_1118,
+            Self::SecurityDataTooShort10 => 0x0000_1119,
+            Self::SecurityDataTooShort11 => 0x0000_111A,
+            Self::SecurityDataTooShort12 => 0x0000_111B,
+            Self::SecurityDataTooShort13 => 0x0000_111C,
+            Self::SecurityDataTooShort14 => 0x0000_111D,
+            Self::SecurityDataTooShort15 => 0x0000_111E,
+            Self::SecurityDataTooShort16 => 0x0000_111F,
+            Self::SecurityDataTooShort17 => 0x0000_1120,
+            Self::SecurityDataTooShort18 => 0x0000_1121,
+            Self::SecurityDataTooShort19 => 0x0000_1122,
+            Self::SecurityDataTooShort20 => 0x0000_1123,
+            Self::SecurityDataTooShort21 => 0x0000_1124,
+            Self::SecurityDataTooShort22 => 0x0000_1125,
+            Self::SecurityDataTooShort23 => 0x0000_1126,
+            Self::BadMonitorData => 0x0000_1129,
+            Self::VcDecompressedReassembleFailed => 0x0000_112A,
+            Self::VcDataTooLong => 0x0000_112B,
+            Self::BadFrameAckData => 0x0000_112C,
+            Self::GraphicsModeNotSupported => 0x0000_112D,
+            Self::GraphicsSubsystemResetFailed => 0x0000_112E,
+            Self::GraphicsSubsystemFailed => 0x0000_112F,
+            Self::TimezoneKeyNameLengthTooShort => 0x0000_1130,
+            Self::TimezoneKeyNameLengthTooLong => 0x0000_1131,
+            Self::DynamicDstDisabledFieldMissing => 0x0000_1132,
+            Self::VcDecodingError => 0x0000_1133,
+            Self::VirtualDesktopTooLarge => 0x0000_1134,
+            Self::MonitorGeometryValidationFailed => 0x0000_1135,
+            Self::InvalidMonitorCount => 0x0000_1136,
+            Self::UpdateSessionKeyFailed => 0x0000_1191,
+            Self::DecryptFailed => 0x0000_1192,
+            Self::EncryptFailed => 0x0000_1193,
+            Self::EncPkgMismatch => 0x0000_1194,
+            Self::DecryptFailed2 => 0x0000_1195,
         }
     }
 }

--- a/crates/ironrdp-pdu/src/rdp/server_error_info.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_error_info.rs
@@ -103,6 +103,7 @@ impl FromPrimitive for ErrorInfo {
     }
 }
 
+#[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum ProtocolIndependentCode {
     None = 0x0000_0000,
@@ -149,30 +150,16 @@ impl ProtocolIndependentCode {
         }
     }
 
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     pub fn as_u32(&self) -> u32 {
-        match self {
-            Self::None => 0x0000_0000,
-            Self::RpcInitiatedDisconnect => 0x0000_0001,
-            Self::RpcInitiatedLogoff => 0x0000_0002,
-            Self::IdleTimeout => 0x0000_0003,
-            Self::LogonTimeout => 0x0000_0004,
-            Self::DisconnectedByOtherconnection => 0x0000_0005,
-            Self::OutOfMemory => 0x0000_0006,
-            Self::ServerDeniedConnection => 0x0000_0007,
-            Self::ServerInsufficientPrivileges => 0x0000_0009,
-            Self::ServerFreshCredentialsRequired => 0x0000_000A,
-            Self::RpcInitiatedDisconnectByuser => 0x0000_000B,
-            Self::LogoffByUser => 0x0000_000C,
-            Self::CloseStackOnDriverNotReady => 0x0000_000F,
-            Self::ServerDwmCrash => 0x0000_0010,
-            Self::CloseStackOnDriverFailure => 0x0000_0011,
-            Self::CloseStackOnDriverIfaceFailure => 0x0000_0012,
-            Self::ServerWinlogonCrash => 0x0000_0017,
-            Self::ServerCsrssCrash => 0x0000_0018,
-        }
+        *self as u32
     }
 }
 
+#[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum ProtocolIndependentLicensingCode {
     Internal = 0x0000_0100,
@@ -207,23 +194,16 @@ impl ProtocolIndependentLicensingCode {
         }
     }
 
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u32(&self) -> u32 {
-        match self {
-            Self::Internal => 0x0000_0100,
-            Self::NoLicenseServer => 0x0000_0101,
-            Self::NoLicense => 0x0000_0102,
-            Self::BadClientMsg => 0x0000_0103,
-            Self::HwidDoesntMatchLicense => 0x0000_0104,
-            Self::BadClientLicense => 0x0000_0105,
-            Self::CantFinishProtocol => 0x0000_0106,
-            Self::ClientEndedProtocol => 0x0000_0107,
-            Self::BadClientEncryption => 0x0000_0108,
-            Self::CantUpgradeLicense => 0x0000_0109,
-            Self::NoRemoteConnections => 0x0000_010A,
-        }
+        *self as u32
     }
 }
 
+#[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum ProtocolIndependentConnectionBrokerCode {
     DestinationNotFound = 0x0000_0400,
@@ -256,23 +236,16 @@ impl ProtocolIndependentConnectionBrokerCode {
         }
     }
 
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u32(&self) -> u32 {
-        match self {
-            Self::DestinationNotFound => 0x0000_0400,
-            Self::LoadingDestination => 0x0000_0402,
-            Self::RedirectingToDestination => 0x0000_0404,
-            Self::SessionOnlineVmWake => 0x0000_0405,
-            Self::SessionOnlineVmBoot => 0x0000_0406,
-            Self::SessionOnlineVmNoDns => 0x0000_0407,
-            Self::DestinationPoolNotFree => 0x0000_0408,
-            Self::ConnectionCancelled => 0x0000_0409,
-            Self::ConnectionErrorInvalidSettings => 0x0000_0410,
-            Self::SessionOnlineVmBootTimeout => 0x0000_0411,
-            Self::SessionOnlineVmSessmonFailed => 0x0000_0412,
-        }
+        *self as u32
     }
 }
 
+#[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum RdpSpecificCode {
     UnknownPduType2 = 0x0000_10C9,
@@ -440,86 +413,7 @@ impl RdpSpecificCode {
     }
 
     fn as_u32(&self) -> u32 {
-        match self {
-            Self::UnknownPduType2 => 0x0000_10C9,
-            Self::UnknownPduType => 0x0000_10CA,
-            Self::DataPdusEquence => 0x0000_10CB,
-            Self::ControlPduSequence => 0x0000_10CD,
-            Self::InvalidControlPduAction => 0x0000_10CE,
-            Self::InvalidInputPduType => 0x0000_10CF,
-            Self::InvalidInputPduMouse => 0x0000_10D0,
-            Self::InvalidRefreshRectPdu => 0x0000_10D1,
-            Self::CreateUserDataFailed => 0x0000_10D2,
-            Self::ConnectFailed => 0x0000_10D3,
-            Self::ConfirmActiveWrongShareId => 0x0000_10D4,
-            Self::ConfirmActiveWrongOriginator => 0x0000_10D5,
-            Self::PersistentKeyPduBadLength => 0x0000_10DA,
-            Self::PersistentKeyPduIllegalFirst => 0x0000_10DB,
-            Self::PersistentKeyPduTooManyTotalKeys => 0x0000_10DC,
-            Self::PersistentKeyPduTooManyCacheKeys => 0x0000_10DD,
-            Self::InputPduBadLength => 0x0000_10DE,
-            Self::BitmapCacheErrorPduBadLength => 0x0000_10DF,
-            Self::SecurityDataTooShort => 0x0000_10E0,
-            Self::VcHannelDataTooShort => 0x0000_10E1,
-            Self::ShareDataTooShort => 0x0000_10E2,
-            Self::BadSuppressOutputPdu => 0x0000_10E3,
-            Self::ConfirmActivePduTooShort => 0x0000_10E5,
-            Self::CapabilitySetTooSmall => 0x0000_10E7,
-            Self::CapabilitySetTooLarge => 0x0000_10E8,
-            Self::NoCursorCache => 0x0000_10E9,
-            Self::BadCapabilities => 0x0000_10EA,
-            Self::VirtualChannelDecompressionError => 0x0000_10EC,
-            Self::InvalidVcCompressionType => 0x0000_10ED,
-            Self::InvalidChannelId => 0x0000_10EF,
-            Self::VirtualChannelsTooMany => 0x0000_10F0,
-            Self::RemoteAppsNotEnabled => 0x0000_10F3,
-            Self::CacheCapabilityNotSet => 0x0000_10F4,
-            Self::BitmapCacheErrorPduBadLength2 => 0x0000_10F5,
-            Self::OffscrCacheErrorPduBadLength => 0x0000_10F6,
-            Self::DngCacheErrorPduBadLength => 0x0000_10F7,
-            Self::GdiPlusPduBadLength => 0x0000_10F8,
-            Self::SecurityDataTooShort2 => 0x0000_1111,
-            Self::SecurityDataTooShort3 => 0x0000_1112,
-            Self::SecurityDataTooShort4 => 0x0000_1113,
-            Self::SecurityDataTooShort5 => 0x0000_1114,
-            Self::SecurityDataTooShort6 => 0x0000_1115,
-            Self::SecurityDataTooShort7 => 0x0000_1116,
-            Self::SecurityDataTooShort8 => 0x0000_1117,
-            Self::SecurityDataTooShort9 => 0x0000_1118,
-            Self::SecurityDataTooShort10 => 0x0000_1119,
-            Self::SecurityDataTooShort11 => 0x0000_111A,
-            Self::SecurityDataTooShort12 => 0x0000_111B,
-            Self::SecurityDataTooShort13 => 0x0000_111C,
-            Self::SecurityDataTooShort14 => 0x0000_111D,
-            Self::SecurityDataTooShort15 => 0x0000_111E,
-            Self::SecurityDataTooShort16 => 0x0000_111F,
-            Self::SecurityDataTooShort17 => 0x0000_1120,
-            Self::SecurityDataTooShort18 => 0x0000_1121,
-            Self::SecurityDataTooShort19 => 0x0000_1122,
-            Self::SecurityDataTooShort20 => 0x0000_1123,
-            Self::SecurityDataTooShort21 => 0x0000_1124,
-            Self::SecurityDataTooShort22 => 0x0000_1125,
-            Self::SecurityDataTooShort23 => 0x0000_1126,
-            Self::BadMonitorData => 0x0000_1129,
-            Self::VcDecompressedReassembleFailed => 0x0000_112A,
-            Self::VcDataTooLong => 0x0000_112B,
-            Self::BadFrameAckData => 0x0000_112C,
-            Self::GraphicsModeNotSupported => 0x0000_112D,
-            Self::GraphicsSubsystemResetFailed => 0x0000_112E,
-            Self::GraphicsSubsystemFailed => 0x0000_112F,
-            Self::TimezoneKeyNameLengthTooShort => 0x0000_1130,
-            Self::TimezoneKeyNameLengthTooLong => 0x0000_1131,
-            Self::DynamicDstDisabledFieldMissing => 0x0000_1132,
-            Self::VcDecodingError => 0x0000_1133,
-            Self::VirtualDesktopTooLarge => 0x0000_1134,
-            Self::MonitorGeometryValidationFailed => 0x0000_1135,
-            Self::InvalidMonitorCount => 0x0000_1136,
-            Self::UpdateSessionKeyFailed => 0x0000_1191,
-            Self::DecryptFailed => 0x0000_1192,
-            Self::EncryptFailed => 0x0000_1193,
-            Self::EncPkgMismatch => 0x0000_1194,
-            Self::DecryptFailed2 => 0x0000_1195,
-        }
+        *self as u32
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/server_error_info.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_error_info.rs
@@ -67,7 +67,7 @@ impl ErrorInfo {
         }
     }
 
-    fn as_u32(&self) -> u32 {
+    fn as_u32(self) -> u32 {
         match self {
             Self::ProtocolIndependentCode(c) => c.as_u32(),
             Self::ProtocolIndependentLicensingCode(c) => c.as_u32(),
@@ -154,8 +154,8 @@ impl ProtocolIndependentCode {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    pub fn as_u32(&self) -> u32 {
-        *self as u32
+    pub fn as_u32(self) -> u32 {
+        self as u32
     }
 }
 
@@ -198,8 +198,8 @@ impl ProtocolIndependentLicensingCode {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u32(&self) -> u32 {
-        *self as u32
+    fn as_u32(self) -> u32 {
+        self as u32
     }
 }
 
@@ -240,8 +240,8 @@ impl ProtocolIndependentConnectionBrokerCode {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u32(&self) -> u32 {
-        *self as u32
+    fn as_u32(self) -> u32 {
+        self as u32
     }
 }
 
@@ -412,8 +412,8 @@ impl RdpSpecificCode {
         }
     }
 
-    fn as_u32(&self) -> u32 {
-        *self as u32
+    fn as_u32(self) -> u32 {
+        self as u32
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/server_license.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_license.rs
@@ -135,7 +135,7 @@ impl<'de> Decode<'de> for LicenseHeader {
 ///
 /// [2.2.1.12.1.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/73170ca2-5f82-4a2d-9d1b-b439f3d8dadc
 #[repr(u8)]
-#[derive(Debug, PartialEq, Eq, FromPrimitive)]
+#[derive(Debug, PartialEq, Eq, FromPrimitive, Copy, Clone)]
 pub enum PreambleType {
     LicenseRequest = 0x01,
     PlatformChallenge = 0x02,
@@ -148,17 +148,12 @@ pub enum PreambleType {
 }
 
 impl PreambleType {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u8(&self) -> u8 {
-        match self {
-            Self::LicenseRequest => 0x01,
-            Self::PlatformChallenge => 0x02,
-            Self::NewLicense => 0x03,
-            Self::UpgradeLicense => 0x04,
-            Self::LicenseInfo => 0x12,
-            Self::NewLicenseRequest => 0x13,
-            Self::PlatformChallengeResponse => 0x15,
-            Self::ErrorAlert => 0xff,
-        }
+        *self as u8
     }
 }
 
@@ -169,18 +164,20 @@ bitflags! {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, FromPrimitive)]
+#[repr(u8)]
+#[derive(Debug, PartialEq, Eq, FromPrimitive, Copy, Clone)]
 pub enum PreambleVersion {
     V2 = 2, // RDP 4.0
     V3 = 3, // RDP 5.0, 5.1, 5.2, 6.0, 6.1, 7.0, 7.1, 8.0, 8.1, 10.0, 10.1, 10.2, 10.3, 10.4, and 10.5
 }
 
 impl PreambleVersion {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u8(&self) -> u8 {
-        match self {
-            Self::V2 => 2,
-            Self::V3 => 3,
-        }
+        *self as u8
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/server_license.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_license.rs
@@ -152,8 +152,8 @@ impl PreambleType {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u8(&self) -> u8 {
-        *self as u8
+    fn as_u8(self) -> u8 {
+        self as u8
     }
 }
 
@@ -176,8 +176,8 @@ impl PreambleVersion {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u8(&self) -> u8 {
-        *self as u8
+    fn as_u8(self) -> u8 {
+        self as u8
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/server_license/client_platform_challenge_response.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_license/client_platform_challenge_response.rs
@@ -176,8 +176,8 @@ impl ClientType {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u16(&self) -> u16 {
-        *self as u16
+    fn as_u16(self) -> u16 {
+        self as u16
     }
 }
 
@@ -194,8 +194,8 @@ impl LicenseDetailLevel {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u16(&self) -> u16 {
-        *self as u16
+    fn as_u16(self) -> u16 {
+        self as u16
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/server_license/client_platform_challenge_response.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_license/client_platform_challenge_response.rs
@@ -162,7 +162,8 @@ impl ClientPlatformChallengeResponse {
     }
 }
 
-#[derive(Debug, PartialEq, FromPrimitive)]
+#[repr(u16)]
+#[derive(Debug, Copy, Clone, PartialEq, FromPrimitive)]
 pub enum ClientType {
     Win32 = 0x0100,
     Win16 = 0x0200,
@@ -171,17 +172,17 @@ pub enum ClientType {
 }
 
 impl ClientType {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u16(&self) -> u16 {
-        match self {
-            Self::Win32 => 0x0100,
-            Self::Win16 => 0x0200,
-            Self::WinCe => 0x0300,
-            Self::Other => 0xff00,
-        }
+        *self as u16
     }
 }
 
-#[derive(Debug, PartialEq, FromPrimitive)]
+#[repr(u16)]
+#[derive(Debug, Copy, Clone, PartialEq, FromPrimitive)]
 pub enum LicenseDetailLevel {
     Simple = 1,
     Moderate = 2,
@@ -189,12 +190,12 @@ pub enum LicenseDetailLevel {
 }
 
 impl LicenseDetailLevel {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u16(&self) -> u16 {
-        match self {
-            Self::Simple => 1,
-            Self::Moderate => 2,
-            Self::Detail => 3,
-        }
+        *self as u16
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/server_license/client_platform_challenge_response.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_license/client_platform_challenge_response.rs
@@ -8,8 +8,8 @@ use ironrdp_core::{
     cast_length, ensure_fixed_part_size, ensure_size, invalid_field_err, Decode, DecodeResult, Encode, EncodeResult,
     ReadCursor, WriteCursor,
 };
-use num_derive::{FromPrimitive, ToPrimitive};
-use num_traits::{FromPrimitive as _, ToPrimitive as _};
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive as _;
 
 use super::{
     BasicSecurityHeader, BasicSecurityHeaderFlags, BlobHeader, BlobType, LicenseEncryptionData, LicenseHeader,
@@ -54,8 +54,8 @@ impl ClientPlatformChallengeResponse {
 
         let mut challenge_response_data = vec![0u8; RESPONSE_DATA_STATIC_FIELDS_SIZE];
         challenge_response_data.write_u16::<LittleEndian>(RESPONSE_DATA_VERSION)?;
-        challenge_response_data.write_u16::<LittleEndian>(ClientType::Other.to_u16().unwrap())?;
-        challenge_response_data.write_u16::<LittleEndian>(LicenseDetailLevel::Detail.to_u16().unwrap())?;
+        challenge_response_data.write_u16::<LittleEndian>(ClientType::Other.as_u16())?;
+        challenge_response_data.write_u16::<LittleEndian>(LicenseDetailLevel::Detail.as_u16())?;
         challenge_response_data.write_u16::<LittleEndian>(decrypted_challenge.len() as u16)?;
         challenge_response_data.write_all(&decrypted_challenge)?;
 
@@ -162,7 +162,7 @@ impl ClientPlatformChallengeResponse {
     }
 }
 
-#[derive(Debug, PartialEq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, PartialEq, FromPrimitive)]
 pub enum ClientType {
     Win32 = 0x0100,
     Win16 = 0x0200,
@@ -170,11 +170,32 @@ pub enum ClientType {
     Other = 0xff00,
 }
 
-#[derive(Debug, PartialEq, FromPrimitive, ToPrimitive)]
+impl ClientType {
+    fn as_u16(&self) -> u16 {
+        match self {
+            Self::Win32 => 0x0100,
+            Self::Win16 => 0x0200,
+            Self::WinCe => 0x0300,
+            Self::Other => 0xff00,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, FromPrimitive)]
 pub enum LicenseDetailLevel {
     Simple = 1,
     Moderate = 2,
     Detail = 3,
+}
+
+impl LicenseDetailLevel {
+    fn as_u16(&self) -> u16 {
+        match self {
+            Self::Simple => 1,
+            Self::Moderate => 2,
+            Self::Detail => 3,
+        }
+    }
 }
 
 #[derive(Debug, PartialEq)]
@@ -195,8 +216,8 @@ impl Encode for PlatformChallengeResponseData {
         ensure_size!(in: dst, size: self.size());
 
         dst.write_u16(RESPONSE_DATA_VERSION);
-        dst.write_u16(self.client_type.to_u16().unwrap());
-        dst.write_u16(self.license_detail_level.to_u16().unwrap());
+        dst.write_u16(self.client_type.as_u16());
+        dst.write_u16(self.license_detail_level.as_u16());
         dst.write_u16(cast_length!("len", self.challenge.len())?);
         dst.write_slice(&self.challenge);
 

--- a/crates/ironrdp-pdu/src/rdp/server_license/licensing_error_message.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_license/licensing_error_message.rs
@@ -107,7 +107,8 @@ impl LicensingErrorMessage {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, FromPrimitive)]
+#[repr(u32)]
+#[derive(Debug, PartialEq, Eq, FromPrimitive, Copy, Clone)]
 pub enum LicenseErrorCode {
     InvalidServerCertificate = 0x01,
     NoLicense = 0x02,
@@ -121,22 +122,17 @@ pub enum LicenseErrorCode {
 }
 
 impl LicenseErrorCode {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u32(&self) -> u32 {
-        match self {
-            Self::InvalidServerCertificate => 0x01,
-            Self::NoLicense => 0x02,
-            Self::InvalidMac => 0x03,
-            Self::InvalidScope => 0x04,
-            Self::NoLicenseServer => 0x06,
-            Self::StatusValidClient => 0x07,
-            Self::InvalidClient => 0x08,
-            Self::InvalidProductId => 0x0b,
-            Self::InvalidFieldLen => 0x0c,
-        }
+        *self as u32
     }
 }
 
-#[derive(Debug, PartialEq, Eq, FromPrimitive)]
+#[repr(u32)]
+#[derive(Debug, PartialEq, Eq, FromPrimitive, Copy, Clone)]
 pub enum LicensingStateTransition {
     TotalAbort = 1,
     NoTransition = 2,
@@ -145,12 +141,11 @@ pub enum LicensingStateTransition {
 }
 
 impl LicensingStateTransition {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u32(&self) -> u32 {
-        match self {
-            Self::TotalAbort => 1,
-            Self::NoTransition => 2,
-            Self::ResetPhaseToStart => 3,
-            Self::ResendLastMessage => 4,
-        }
+        *self as u32
     }
 }

--- a/crates/ironrdp-pdu/src/rdp/server_license/licensing_error_message.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_license/licensing_error_message.rs
@@ -126,8 +126,8 @@ impl LicenseErrorCode {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u32(&self) -> u32 {
-        *self as u32
+    fn as_u32(self) -> u32 {
+        self as u32
     }
 }
 
@@ -145,7 +145,7 @@ impl LicensingStateTransition {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u32(&self) -> u32 {
-        *self as u32
+    fn as_u32(self) -> u32 {
+        self as u32
     }
 }

--- a/crates/ironrdp-pdu/src/rdp/server_license/licensing_error_message.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_license/licensing_error_message.rs
@@ -5,8 +5,8 @@ use ironrdp_core::{
     cast_length, ensure_fixed_part_size, ensure_size, invalid_field_err, Decode as _, DecodeResult, Encode as _,
     EncodeResult, ReadCursor, WriteCursor,
 };
-use num_derive::{FromPrimitive, ToPrimitive};
-use num_traits::{FromPrimitive as _, ToPrimitive as _};
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive as _;
 
 use super::{BlobHeader, BlobType, LicenseHeader, PreambleFlags, PreambleVersion, BLOB_LENGTH_SIZE, BLOB_TYPE_SIZE};
 use crate::rdp::headers::{BasicSecurityHeader, BasicSecurityHeaderFlags, BASIC_SECURITY_HEADER_SIZE};
@@ -61,8 +61,8 @@ impl LicensingErrorMessage {
 
         self.license_header.encode(dst)?;
 
-        dst.write_u32(self.error_code.to_u32().unwrap());
-        dst.write_u32(self.state_transition.to_u32().unwrap());
+        dst.write_u32(self.error_code.as_u32());
+        dst.write_u32(self.state_transition.as_u32());
 
         BlobHeader::new(BlobType::ERROR, self.error_info.len()).encode(dst)?;
         dst.write_slice(&self.error_info);
@@ -107,7 +107,7 @@ impl LicensingErrorMessage {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, PartialEq, Eq, FromPrimitive)]
 pub enum LicenseErrorCode {
     InvalidServerCertificate = 0x01,
     NoLicense = 0x02,
@@ -120,10 +120,37 @@ pub enum LicenseErrorCode {
     InvalidFieldLen = 0x0c,
 }
 
-#[derive(Debug, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+impl LicenseErrorCode {
+    fn as_u32(&self) -> u32 {
+        match self {
+            Self::InvalidServerCertificate => 0x01,
+            Self::NoLicense => 0x02,
+            Self::InvalidMac => 0x03,
+            Self::InvalidScope => 0x04,
+            Self::NoLicenseServer => 0x06,
+            Self::StatusValidClient => 0x07,
+            Self::InvalidClient => 0x08,
+            Self::InvalidProductId => 0x0b,
+            Self::InvalidFieldLen => 0x0c,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, FromPrimitive)]
 pub enum LicensingStateTransition {
     TotalAbort = 1,
     NoTransition = 2,
     ResetPhaseToStart = 3,
     ResendLastMessage = 4,
+}
+
+impl LicensingStateTransition {
+    fn as_u32(&self) -> u32 {
+        match self {
+            Self::TotalAbort => 1,
+            Self::NoTransition => 2,
+            Self::ResetPhaseToStart => 3,
+            Self::ResendLastMessage => 4,
+        }
+    }
 }

--- a/crates/ironrdp-pdu/src/rdp/server_license/server_license_request.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_license/server_license_request.rs
@@ -221,11 +221,11 @@ impl ServerCertificate {
                 let public_exponent = certificate.public_key.public_exponent.to_le_bytes();
 
                 let rsa_public_key = pkcs1::RsaPublicKey {
-                    modulus: pkcs1::UintRef::new(&certificate.public_key.modulus).unwrap(),
-                    public_exponent: pkcs1::UintRef::new(&public_exponent).unwrap(),
+                    modulus: pkcs1::UintRef::new(&certificate.public_key.modulus)?,
+                    public_exponent: pkcs1::UintRef::new(&public_exponent)?,
                 };
 
-                let public_key = pkcs1::der::Encode::to_der(&rsa_public_key).unwrap();
+                let public_key = pkcs1::der::Encode::to_der(&rsa_public_key)?;
 
                 Ok(public_key)
             }

--- a/crates/ironrdp-pdu/src/rdp/session_info.rs
+++ b/crates/ironrdp-pdu/src/rdp/session_info.rs
@@ -114,8 +114,8 @@ impl InfoType {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u32(&self) -> u32 {
-        *self as u32
+    fn as_u32(self) -> u32 {
+        self as u32
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/session_info.rs
+++ b/crates/ironrdp-pdu/src/rdp/session_info.rs
@@ -4,8 +4,8 @@ use ironrdp_core::{
     ensure_fixed_part_size, ensure_size, invalid_field_err, read_padding, write_padding, Decode, DecodeResult, Encode,
     EncodeResult, ReadCursor, WriteCursor,
 };
-use num_derive::{FromPrimitive, ToPrimitive};
-use num_traits::{FromPrimitive as _, ToPrimitive as _};
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive as _;
 use thiserror::Error;
 
 use crate::PduError;
@@ -41,7 +41,7 @@ impl Encode for SaveSessionInfoPdu {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         ensure_fixed_part_size!(in: dst);
 
-        dst.write_u32(self.info_type.to_u32().unwrap());
+        dst.write_u32(self.info_type.as_u32());
         match self.info_data {
             InfoData::LogonInfoV1(ref info_v1) => {
                 info_v1.encode(dst)?;
@@ -101,12 +101,23 @@ impl<'de> Decode<'de> for SaveSessionInfoPdu {
 }
 
 #[repr(u32)]
-#[derive(Debug, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum InfoType {
     Logon = 0x0000_0000,
     LogonLong = 0x0000_0001,
     PlainNotify = 0x0000_0002,
     LogonExtended = 0x0000_0003,
+}
+
+impl InfoType {
+    fn as_u32(&self) -> u32 {
+        match self {
+            Self::Logon => 0x0000_0000,
+            Self::LogonLong => 0x0000_0001,
+            Self::PlainNotify => 0x0000_0002,
+            Self::LogonExtended => 0x0000_0003,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/ironrdp-pdu/src/rdp/session_info.rs
+++ b/crates/ironrdp-pdu/src/rdp/session_info.rs
@@ -101,7 +101,7 @@ impl<'de> Decode<'de> for SaveSessionInfoPdu {
 }
 
 #[repr(u32)]
-#[derive(Debug, Clone, PartialEq, Eq, FromPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum InfoType {
     Logon = 0x0000_0000,
     LogonLong = 0x0000_0001,
@@ -110,13 +110,12 @@ pub enum InfoType {
 }
 
 impl InfoType {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u32(&self) -> u32 {
-        match self {
-            Self::Logon => 0x0000_0000,
-            Self::LogonLong => 0x0000_0001,
-            Self::PlainNotify => 0x0000_0002,
-            Self::LogonExtended => 0x0000_0003,
-        }
+        *self as u32
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/session_info/logon_extended.rs
+++ b/crates/ironrdp-pdu/src/rdp/session_info/logon_extended.rs
@@ -3,8 +3,8 @@ use ironrdp_core::{
     cast_length, ensure_fixed_part_size, ensure_size, invalid_field_err, read_padding, Decode, DecodeResult, Encode,
     EncodeResult, ReadCursor, WriteCursor,
 };
-use num_derive::{FromPrimitive, ToPrimitive};
-use num_traits::{FromPrimitive as _, ToPrimitive as _};
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive as _;
 
 const LOGON_EX_LENGTH_FIELD_SIZE: usize = 2;
 const LOGON_EX_FLAGS_FIELD_SIZE: usize = 4;
@@ -172,7 +172,7 @@ impl Encode for LogonErrorsInfo {
         ensure_fixed_part_size!(in: dst);
 
         dst.write_u32(LOGON_ERRORS_INFO_SIZE as u32);
-        dst.write_u32(self.error_type.to_u32().unwrap());
+        dst.write_u32(self.error_type.as_u32());
         dst.write_u32(self.error_data.to_u32());
 
         Ok(())
@@ -213,7 +213,7 @@ bitflags! {
 }
 
 #[repr(u32)]
-#[derive(Debug, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum LogonErrorNotificationType {
     SessionBusyOptions = 0xFFFF_FFF8,
     DisconnectRefused = 0xFFFF_FFF9,
@@ -225,13 +225,39 @@ pub enum LogonErrorNotificationType {
     AccessDenied = 0xFFFF_FFFF,
 }
 
+impl LogonErrorNotificationType {
+    fn as_u32(&self) -> u32 {
+        match self {
+            Self::SessionBusyOptions => 0xFFFF_FFF8,
+            Self::DisconnectRefused => 0xFFFF_FFF9,
+            Self::NoPermission => 0xFFFF_FFFA,
+            Self::BumpOptions => 0xFFFF_FFFB,
+            Self::ReconnectOptions => 0xFFFF_FFFC,
+            Self::SessionTerminate => 0xFFFF_FFFD,
+            Self::SessionContinue => 0xFFFF_FFFE,
+            Self::AccessDenied => 0xFFFF_FFFF,
+        }
+    }
+}
+
 #[repr(u32)]
-#[derive(Debug, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum LogonErrorNotificationDataErrorCode {
     FailedBadPassword = 0x0000_0000,
     FailedUpdatePassword = 0x0000_0001,
     FailedOther = 0x0000_0002,
     Warning = 0x0000_0003,
+}
+
+impl LogonErrorNotificationDataErrorCode {
+    fn as_u32(&self) -> u32 {
+        match self {
+            Self::FailedBadPassword => 0x0000_0000,
+            Self::FailedUpdatePassword => 0x0000_0001,
+            Self::FailedOther => 0x0000_0002,
+            Self::Warning => 0x0000_0003,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -243,7 +269,7 @@ pub enum LogonErrorNotificationData {
 impl LogonErrorNotificationData {
     pub fn to_u32(&self) -> u32 {
         match self {
-            LogonErrorNotificationData::ErrorCode(code) => code.to_u32().unwrap(),
+            LogonErrorNotificationData::ErrorCode(code) => code.as_u32(),
             LogonErrorNotificationData::SessionId(id) => *id,
         }
     }

--- a/crates/ironrdp-pdu/src/rdp/session_info/logon_extended.rs
+++ b/crates/ironrdp-pdu/src/rdp/session_info/logon_extended.rs
@@ -213,7 +213,7 @@ bitflags! {
 }
 
 #[repr(u32)]
-#[derive(Debug, Clone, PartialEq, Eq, FromPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum LogonErrorNotificationType {
     SessionBusyOptions = 0xFFFF_FFF8,
     DisconnectRefused = 0xFFFF_FFF9,
@@ -226,22 +226,17 @@ pub enum LogonErrorNotificationType {
 }
 
 impl LogonErrorNotificationType {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u32(&self) -> u32 {
-        match self {
-            Self::SessionBusyOptions => 0xFFFF_FFF8,
-            Self::DisconnectRefused => 0xFFFF_FFF9,
-            Self::NoPermission => 0xFFFF_FFFA,
-            Self::BumpOptions => 0xFFFF_FFFB,
-            Self::ReconnectOptions => 0xFFFF_FFFC,
-            Self::SessionTerminate => 0xFFFF_FFFD,
-            Self::SessionContinue => 0xFFFF_FFFE,
-            Self::AccessDenied => 0xFFFF_FFFF,
-        }
+        *self as u32
     }
 }
 
 #[repr(u32)]
-#[derive(Debug, Clone, PartialEq, Eq, FromPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum LogonErrorNotificationDataErrorCode {
     FailedBadPassword = 0x0000_0000,
     FailedUpdatePassword = 0x0000_0001,
@@ -250,13 +245,12 @@ pub enum LogonErrorNotificationDataErrorCode {
 }
 
 impl LogonErrorNotificationDataErrorCode {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u32(&self) -> u32 {
-        match self {
-            Self::FailedBadPassword => 0x0000_0000,
-            Self::FailedUpdatePassword => 0x0000_0001,
-            Self::FailedOther => 0x0000_0002,
-            Self::Warning => 0x0000_0003,
-        }
+        *self as u32
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/session_info/logon_extended.rs
+++ b/crates/ironrdp-pdu/src/rdp/session_info/logon_extended.rs
@@ -230,8 +230,8 @@ impl LogonErrorNotificationType {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u32(&self) -> u32 {
-        *self as u32
+    fn as_u32(self) -> u32 {
+        self as u32
     }
 }
 
@@ -249,8 +249,8 @@ impl LogonErrorNotificationDataErrorCode {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u32(&self) -> u32 {
-        *self as u32
+    fn as_u32(self) -> u32 {
+        self as u32
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/suppress_output.rs
+++ b/crates/ironrdp-pdu/src/rdp/suppress_output.rs
@@ -6,7 +6,7 @@ use ironrdp_core::{
 use crate::geometry::InclusiveRectangle;
 
 #[repr(u8)]
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum AllowDisplayUpdatesType {
     SuppressDisplayUpdates = 0x00,
     AllowDisplayUpdates = 0x01,
@@ -20,9 +20,12 @@ impl AllowDisplayUpdatesType {
             _ => None,
         }
     }
-
-    pub fn as_u8(self) -> u8 {
-        self as u8
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
+    pub fn as_u8(&self) -> u8 {
+        *self as u8
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/suppress_output.rs
+++ b/crates/ironrdp-pdu/src/rdp/suppress_output.rs
@@ -24,8 +24,8 @@ impl AllowDisplayUpdatesType {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    pub fn as_u8(&self) -> u8 {
-        *self as u8
+    pub fn as_u8(self) -> u8 {
+        self as u8
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/suppress_output.rs
+++ b/crates/ironrdp-pdu/src/rdp/suppress_output.rs
@@ -20,6 +20,7 @@ impl AllowDisplayUpdatesType {
             _ => None,
         }
     }
+
     #[expect(
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"

--- a/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx.rs
+++ b/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx.rs
@@ -13,7 +13,7 @@ use ironrdp_core::{
     cast_length, ensure_fixed_part_size, ensure_size, invalid_field_err, Decode, DecodeResult, Encode, EncodeResult,
     ReadCursor, WriteCursor,
 };
-use num_derive::{FromPrimitive, ToPrimitive};
+use num_derive::FromPrimitive;
 use num_traits::FromPrimitive as _;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -221,7 +221,8 @@ impl<'a> Decode<'a> for ClientPdu {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[repr(u16)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum ClientPduType {
     FrameAcknowledge = 0x0d,
     CacheImportOffer = 0x10,
@@ -230,13 +231,12 @@ pub enum ClientPduType {
 }
 
 impl ClientPduType {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u16(&self) -> u16 {
-        match self {
-            Self::FrameAcknowledge => 0x0d,
-            Self::CacheImportOffer => 0x10,
-            Self::CapabilitiesAdvertise => 0x12,
-            Self::QoeFrameAcknowledge => 0x16,
-        }
+        *self as u16
     }
 }
 
@@ -249,6 +249,7 @@ impl<'a> From<&'a ClientPdu> for ClientPduType {
     }
 }
 
+#[repr(u16)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum ServerPduType {
     WireToSurface1 = 0x01,
@@ -273,28 +274,12 @@ pub enum ServerPduType {
 }
 
 impl ServerPduType {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u16(&self) -> u16 {
-        match self {
-            Self::WireToSurface1 => 0x01,
-            Self::WireToSurface2 => 0x02,
-            Self::DeleteEncodingContext => 0x03,
-            Self::SolidFill => 0x04,
-            Self::SurfaceToSurface => 0x05,
-            Self::SurfaceToCache => 0x06,
-            Self::CacheToSurface => 0x07,
-            Self::EvictCacheEntry => 0x08,
-            Self::CreateSurface => 0x09,
-            Self::DeleteSurface => 0x0a,
-            Self::StartFrame => 0x0b,
-            Self::EndFrame => 0x0c,
-            Self::ResetGraphics => 0x0e,
-            Self::MapSurfaceToOutput => 0x0f,
-            Self::CacheImportReply => 0x11,
-            Self::CapabilitiesConfirm => 0x13,
-            Self::MapSurfaceToWindow => 0x15,
-            Self::MapSurfaceToScaledOutput => 0x17,
-            Self::MapSurfaceToScaledWindow => 0x18,
-        }
+        *self as u16
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx.rs
+++ b/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx.rs
@@ -235,8 +235,8 @@ impl ClientPduType {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u16(&self) -> u16 {
-        *self as u16
+    fn as_u16(self) -> u16 {
+        self as u16
     }
 }
 
@@ -278,8 +278,8 @@ impl ServerPduType {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u16(&self) -> u16 {
-        *self as u16
+    fn as_u16(self) -> u16 {
+        self as u16
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx.rs
+++ b/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx.rs
@@ -14,7 +14,7 @@ use ironrdp_core::{
     ReadCursor, WriteCursor,
 };
 use num_derive::{FromPrimitive, ToPrimitive};
-use num_traits::{FromPrimitive as _, ToPrimitive as _};
+use num_traits::FromPrimitive as _;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ServerPdu {
@@ -52,7 +52,7 @@ impl Encode for ServerPdu {
 
         let buffer_length = self.size();
 
-        dst.write_u16(ServerPduType::from(self).to_u16().unwrap());
+        dst.write_u16(ServerPduType::from(self).as_u16());
         dst.write_u16(0); // flags
         dst.write_u32(cast_length!("bufferLen", buffer_length)?);
 
@@ -175,7 +175,7 @@ impl Encode for ClientPdu {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         ensure_size!(in: dst, size: self.size());
 
-        dst.write_u16(ClientPduType::from(self).to_u16().unwrap());
+        dst.write_u16(ClientPduType::from(self).as_u16());
         dst.write_u16(0); // flags
         dst.write_u32(cast_length!("bufferLen", self.size())?);
 
@@ -229,6 +229,17 @@ pub enum ClientPduType {
     QoeFrameAcknowledge = 0x16,
 }
 
+impl ClientPduType {
+    fn as_u16(&self) -> u16 {
+        match self {
+            Self::FrameAcknowledge => 0x0d,
+            Self::CacheImportOffer => 0x10,
+            Self::CapabilitiesAdvertise => 0x12,
+            Self::QoeFrameAcknowledge => 0x16,
+        }
+    }
+}
+
 impl<'a> From<&'a ClientPdu> for ClientPduType {
     fn from(c: &'a ClientPdu) -> Self {
         match c {
@@ -238,7 +249,7 @@ impl<'a> From<&'a ClientPdu> for ClientPduType {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum ServerPduType {
     WireToSurface1 = 0x01,
     WireToSurface2 = 0x02,
@@ -259,6 +270,32 @@ pub enum ServerPduType {
     MapSurfaceToWindow = 0x15,
     MapSurfaceToScaledOutput = 0x17,
     MapSurfaceToScaledWindow = 0x18,
+}
+
+impl ServerPduType {
+    fn as_u16(&self) -> u16 {
+        match self {
+            Self::WireToSurface1 => 0x01,
+            Self::WireToSurface2 => 0x02,
+            Self::DeleteEncodingContext => 0x03,
+            Self::SolidFill => 0x04,
+            Self::SurfaceToSurface => 0x05,
+            Self::SurfaceToCache => 0x06,
+            Self::CacheToSurface => 0x07,
+            Self::EvictCacheEntry => 0x08,
+            Self::CreateSurface => 0x09,
+            Self::DeleteSurface => 0x0a,
+            Self::StartFrame => 0x0b,
+            Self::EndFrame => 0x0c,
+            Self::ResetGraphics => 0x0e,
+            Self::MapSurfaceToOutput => 0x0f,
+            Self::CacheImportReply => 0x11,
+            Self::CapabilitiesConfirm => 0x13,
+            Self::MapSurfaceToWindow => 0x15,
+            Self::MapSurfaceToScaledOutput => 0x17,
+            Self::MapSurfaceToScaledWindow => 0x18,
+        }
+    }
 }
 
 impl<'a> From<&'a ServerPdu> for ServerPduType {

--- a/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx/graphics_messages.rs
+++ b/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx/graphics_messages.rs
@@ -292,21 +292,12 @@ pub(crate) enum CapabilityVersion {
 }
 
 impl CapabilityVersion {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u32(&self) -> u32 {
-        match self {
-            Self::V8 => 0x8_0004,
-            Self::V8_1 => 0x8_0105,
-            Self::V10 => 0xa_0002,
-            Self::V10_1 => 0xa_0100,
-            Self::V10_2 => 0xa_0200,
-            Self::V10_3 => 0xa_0301,
-            Self::V10_4 => 0xa_0400,
-            Self::V10_5 => 0xa_0502,
-            Self::V10_6 => 0xa_0600,
-            Self::V10_6Err => 0xa_0601,
-            Self::V10_7 => 0xa_0701,
-            Self::Unknown => 0xa_0702,
-        }
+        *self as u32
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx/graphics_messages.rs
+++ b/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx/graphics_messages.rs
@@ -3,8 +3,8 @@ mod server;
 
 mod avc_messages;
 use bitflags::bitflags;
-use num_derive::{FromPrimitive, ToPrimitive};
-use num_traits::{FromPrimitive as _, ToPrimitive as _};
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive as _;
 
 #[rustfmt::skip] // do not re-order this
 pub use avc_messages::{Avc420BitmapStream, Avc444BitmapStream, Encoding, QuantQuality};
@@ -71,7 +71,7 @@ impl Encode for CapabilitySet {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         ensure_size!(in: dst, size: self.size());
 
-        dst.write_u32(self.version().to_u32().unwrap());
+        dst.write_u32(self.version().as_u32());
         dst.write_u32(cast_length!("dataLength", self.size() - CAPABILITY_SET_HEADER_SIZE)?);
 
         match self {
@@ -275,7 +275,7 @@ impl<'de> Decode<'de> for Point {
 }
 
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub(crate) enum CapabilityVersion {
     V8 = 0x8_0004,
     V8_1 = 0x8_0105,
@@ -289,6 +289,25 @@ pub(crate) enum CapabilityVersion {
     V10_6Err = 0xa_0601, // defined similar to FreeRDP to maintain best compatibility
     V10_7 = 0xa_0701,
     Unknown = 0xa_0702,
+}
+
+impl CapabilityVersion {
+    fn as_u32(&self) -> u32 {
+        match self {
+            Self::V8 => 0x8_0004,
+            Self::V8_1 => 0x8_0105,
+            Self::V10 => 0xa_0002,
+            Self::V10_1 => 0xa_0100,
+            Self::V10_2 => 0xa_0200,
+            Self::V10_3 => 0xa_0301,
+            Self::V10_4 => 0xa_0400,
+            Self::V10_5 => 0xa_0502,
+            Self::V10_6 => 0xa_0600,
+            Self::V10_6Err => 0xa_0601,
+            Self::V10_7 => 0xa_0701,
+            Self::Unknown => 0xa_0702,
+        }
+    }
 }
 
 bitflags! {

--- a/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx/graphics_messages.rs
+++ b/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx/graphics_messages.rs
@@ -296,8 +296,8 @@ impl CapabilityVersion {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u32(&self) -> u32 {
-        *self as u32
+    fn as_u32(self) -> u32 {
+        self as u32
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx/graphics_messages/server.rs
+++ b/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx/graphics_messages/server.rs
@@ -5,8 +5,8 @@ use ironrdp_core::{
     cast_length, decode_cursor, ensure_fixed_part_size, ensure_size, invalid_field_err, read_padding, write_padding,
     Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor,
 };
-use num_derive::{FromPrimitive, ToPrimitive};
-use num_traits::{FromPrimitive as _, ToPrimitive as _};
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive as _;
 
 use super::{CapabilitySet, Color, Point, RDP_GFX_HEADER_SIZE};
 use crate::gcc::Monitor;
@@ -49,8 +49,8 @@ impl Encode for WireToSurface1Pdu {
         ensure_size!(in: dst, size: self.size());
 
         dst.write_u16(self.surface_id);
-        dst.write_u16(self.codec_id.to_u16().unwrap());
-        dst.write_u8(self.pixel_format.to_u8().unwrap());
+        dst.write_u16(self.codec_id.as_u16());
+        dst.write_u8(self.pixel_format.as_u8());
         self.destination_rectangle.encode(dst)?;
         dst.write_u32(cast_length!("BitmapDataLen", self.bitmap_data.len())?);
         dst.write_slice(&self.bitmap_data);
@@ -123,9 +123,9 @@ impl Encode for WireToSurface2Pdu {
         ensure_size!(in: dst, size: self.size());
 
         dst.write_u16(self.surface_id);
-        dst.write_u16(self.codec_id.to_u16().unwrap());
+        dst.write_u16(self.codec_id.as_u16());
         dst.write_u32(self.codec_context_id);
-        dst.write_u8(self.pixel_format.to_u8().unwrap());
+        dst.write_u8(self.pixel_format.as_u8());
         dst.write_u32(cast_length!("BitmapDataLen", self.bitmap_data.len())?);
         dst.write_slice(&self.bitmap_data);
 
@@ -460,7 +460,7 @@ impl Encode for CreateSurfacePdu {
         dst.write_u16(self.surface_id);
         dst.write_u16(self.width);
         dst.write_u16(self.height);
-        dst.write_u8(self.pixel_format.to_u8().unwrap());
+        dst.write_u8(self.pixel_format.as_u8());
 
         Ok(())
     }
@@ -931,7 +931,7 @@ impl<'a> Decode<'a> for CapabilitiesConfirmPdu {
 }
 
 #[repr(u16)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum Codec1Type {
     Uncompressed = 0x0,
     RemoteFx = 0x3,
@@ -943,17 +943,49 @@ pub enum Codec1Type {
     Avc444v2 = 0xf,
 }
 
+impl Codec1Type {
+    fn as_u16(&self) -> u16 {
+        match self {
+            Self::Uncompressed => 0x0,
+            Self::RemoteFx => 0x3,
+            Self::ClearCodec => 0x8,
+            Self::Planar => 0xa,
+            Self::Avc420 => 0xb,
+            Self::Alpha => 0xc,
+            Self::Avc444 => 0xe,
+            Self::Avc444v2 => 0xf,
+        }
+    }
+}
+
 #[repr(u16)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum Codec2Type {
     RemoteFxProgressive = 0x9,
 }
 
+impl Codec2Type {
+    fn as_u16(&self) -> u16 {
+        match self {
+            Self::RemoteFxProgressive => 0x9,
+        }
+    }
+}
+
 #[repr(u8)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum PixelFormat {
     XRgb = 0x20,
     ARgb = 0x21,
+}
+
+impl PixelFormat {
+    fn as_u8(&self) -> u8 {
+        match self {
+            Self::XRgb => 0x20,
+            Self::ARgb => 0x21,
+        }
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx/graphics_messages/server.rs
+++ b/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx/graphics_messages/server.rs
@@ -944,17 +944,12 @@ pub enum Codec1Type {
 }
 
 impl Codec1Type {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u16(&self) -> u16 {
-        match self {
-            Self::Uncompressed => 0x0,
-            Self::RemoteFx => 0x3,
-            Self::ClearCodec => 0x8,
-            Self::Planar => 0xa,
-            Self::Avc420 => 0xb,
-            Self::Alpha => 0xc,
-            Self::Avc444 => 0xe,
-            Self::Avc444v2 => 0xf,
-        }
+        *self as u16
     }
 }
 
@@ -965,10 +960,12 @@ pub enum Codec2Type {
 }
 
 impl Codec2Type {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     fn as_u16(&self) -> u16 {
-        match self {
-            Self::RemoteFxProgressive => 0x9,
-        }
+        *self as u16
     }
 }
 
@@ -981,10 +978,7 @@ pub enum PixelFormat {
 
 impl PixelFormat {
     fn as_u8(&self) -> u8 {
-        match self {
-            Self::XRgb => 0x20,
-            Self::ARgb => 0x21,
-        }
+        *self as u8
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx/graphics_messages/server.rs
+++ b/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx/graphics_messages/server.rs
@@ -948,8 +948,8 @@ impl Codec1Type {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u16(&self) -> u16 {
-        *self as u16
+    fn as_u16(self) -> u16 {
+        self as u16
     }
 }
 
@@ -964,8 +964,8 @@ impl Codec2Type {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    fn as_u16(&self) -> u16 {
-        *self as u16
+    fn as_u16(self) -> u16 {
+        self as u16
     }
 }
 
@@ -977,8 +977,8 @@ pub enum PixelFormat {
 }
 
 impl PixelFormat {
-    fn as_u8(&self) -> u8 {
-        *self as u8
+    fn as_u8(self) -> u8 {
+        self as u8
     }
 }
 

--- a/crates/ironrdp-pdu/src/utils.rs
+++ b/crates/ironrdp-pdu/src/utils.rs
@@ -50,8 +50,8 @@ impl CharacterSet {
         clippy::as_conversions,
         reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
     )]
-    pub fn as_u16(&self) -> u16 {
-        *self as u16
+    pub fn as_u16(self) -> u16 {
+        self as u16
     }
 }
 

--- a/crates/ironrdp-pdu/src/utils.rs
+++ b/crates/ironrdp-pdu/src/utils.rs
@@ -3,17 +3,16 @@ use core::ops::Add;
 
 use byteorder::{LittleEndian, ReadBytesExt as _};
 use ironrdp_core::{ensure_size, invalid_field_err, other_err, ReadCursor, WriteCursor};
-use num_derive::{FromPrimitive, ToPrimitive};
+use num_derive::FromPrimitive;
 
 use crate::{DecodeResult, EncodeResult};
 
 pub fn split_u64(value: u64) -> (u32, u32) {
-    let bytes = value.to_le_bytes();
-    let (low, high) = bytes.split_at(size_of::<u32>());
-    (
-        u32::from_le_bytes(low.try_into().unwrap()),
-        u32::from_le_bytes(high.try_into().unwrap()),
-    )
+    let low =
+        u32::try_from(value & 0xFFFF_FFFF).expect("masking with 0xFFFF_FFFF ensures that the value fits into u32");
+    let high = u32::try_from(value >> 32).expect("(u64 >> 32) fits into u32");
+
+    (low, high)
 }
 
 pub fn combine_u64(lo: u32, hi: u32) -> u64 {
@@ -39,10 +38,19 @@ pub fn from_utf16_bytes(mut value: &[u8]) -> String {
     String::from_utf16_lossy(value_u16.as_ref())
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum CharacterSet {
     Ansi = 1,
     Unicode = 2,
+}
+
+impl CharacterSet {
+    pub fn as_u16(&self) -> u16 {
+        match self {
+            Self::Ansi => 1,
+            Self::Unicode => 2,
+        }
+    }
 }
 
 // Read a string from the cursor, using the specified character set.

--- a/crates/ironrdp-pdu/src/utils.rs
+++ b/crates/ironrdp-pdu/src/utils.rs
@@ -38,6 +38,7 @@ pub fn from_utf16_bytes(mut value: &[u8]) -> String {
     String::from_utf16_lossy(value_u16.as_ref())
 }
 
+#[repr(u16)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum CharacterSet {
     Ansi = 1,
@@ -45,11 +46,12 @@ pub enum CharacterSet {
 }
 
 impl CharacterSet {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
     pub fn as_u16(&self) -> u16 {
-        match self {
-            Self::Ansi => 1,
-            Self::Unicode => 2,
-        }
+        *self as u16
     }
 }
 

--- a/crates/ironrdp-testsuite-core/src/conference_create.rs
+++ b/crates/ironrdp-testsuite-core/src/conference_create.rs
@@ -15,13 +15,11 @@ pub const CONFERENCE_CREATE_RESPONSE_PREFIX_BUFFER: [u8; 24] = [
 ];
 
 lazy_static! {
-    pub static ref CONFERENCE_CREATE_REQUEST: ConferenceCreateRequest = ConferenceCreateRequest {
-        gcc_blocks: gcc::CLIENT_GCC_WITH_CLUSTER_OPTIONAL_FIELD.clone(),
-    };
-    pub static ref CONFERENCE_CREATE_RESPONSE: ConferenceCreateResponse = ConferenceCreateResponse {
-        user_id: 0x79f3,
-        gcc_blocks: gcc::SERVER_GCC_WITHOUT_OPTIONAL_FIELDS.clone(),
-    };
+    pub static ref CONFERENCE_CREATE_REQUEST: ConferenceCreateRequest =
+        ConferenceCreateRequest::new(gcc::CLIENT_GCC_WITH_CLUSTER_OPTIONAL_FIELD.clone()).expect("should not fail");
+    pub static ref CONFERENCE_CREATE_RESPONSE: ConferenceCreateResponse =
+        ConferenceCreateResponse::new(0x79f3, gcc::SERVER_GCC_WITHOUT_OPTIONAL_FIELDS.clone(),)
+            .expect("should not fail");
 }
 
 pub const CONFERENCE_CREATE_REQUEST_BUFFER: [u8; concat_arrays_size!(


### PR DESCRIPTION
Extract code changes in `ironrdp-pdu` from the previous PR - https://github.com/Devolutions/IronRDP/pull/963. 
Github shows that we have 1K of changes, but it should be easy to review since the changes are really simple: replace `unwrap` with `expect`,  propagate the error instead of unwrapping, add `cast_length!` usage, etc. 