### PR TITLE
refactor: add `string_slice` clippy correctness lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ panic = "warn"
 precedence_bits = "warn"
 rc_mutex = "warn"
 same_name_method = "warn"
+string_slice = "warn"
 
 # == Style, readability == #
 semicolon_outside_block = "warn" # With semicolon-outside-block-ignore-multiline = true

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -88,7 +88,7 @@ impl Destination {
 
         let addr = addr.into();
 
-        if let Some(idx) = addr.rfind(':') {
+        if let Some(addr_split) = addr.rsplit_once(':') {
             if let Ok(sock_addr) = addr.parse::<core::net::SocketAddr>() {
                 Ok(Self {
                     name: sock_addr.ip().to_string(),
@@ -101,8 +101,8 @@ impl Destination {
                 })
             } else {
                 Ok(Self {
-                    name: addr[..idx].to_owned(),
-                    port: addr[idx + 1..].parse().context("invalid port")?,
+                    name: addr_split.0.to_owned(),
+                    port: addr_split.1.parse().context("invalid port")?,
                 })
             }
         } else {

--- a/crates/ironrdp-connector/src/server_name.rs
+++ b/crates/ironrdp-connector/src/server_name.rs
@@ -34,7 +34,7 @@ impl From<&str> for ServerName {
 }
 
 fn sanitize_server_name(name: String) -> String {
-    if let Some(idx) = name.rfind(':') {
+    if let Some(addr_split) = name.rsplit_once(':') {
         if let Ok(sock_addr) = name.parse::<core::net::SocketAddr>() {
             // A socket address, including a port
             sock_addr.ip().to_string()
@@ -43,7 +43,7 @@ fn sanitize_server_name(name: String) -> String {
             name
         } else {
             // An IPv4 address or server hostname including a port after the `:` token
-            name[..idx].to_owned()
+            addr_split.0.to_owned()
         }
     } else {
         // An IPv4 address or server hostname which does not include a port, already sane

--- a/crates/ironrdp-pdu/src/rdp/capability_sets/bitmap_codecs.rs
+++ b/crates/ironrdp-pdu/src/rdp/capability_sets/bitmap_codecs.rs
@@ -695,10 +695,7 @@ fn parse_codecs_config<'a>(codecs: &'a [&'a str]) -> Result<HashMap<&'a str, boo
     let mut result = HashMap::new();
 
     for &codec_str in codecs {
-        if let Some(colon_index) = codec_str.find(':') {
-            let codec_name = &codec_str[0..colon_index];
-            let state_str = &codec_str[colon_index + 1..];
-
+        if let Some((codec_name, state_str)) = codec_str.split_once(':') {
             let state = match state_str {
                 "on" => true,
                 "off" => false,

--- a/crates/ironrdp-rdpdr/src/pdu/efs.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/efs.rs
@@ -966,7 +966,9 @@ impl PreferredDosName {
     fn format(&self) -> String {
         let mut name: &str = &self.0;
         if name.len() > 7 {
-            name = &name[..7];
+            name = name
+                .get(..7)
+                .expect("index is guaranteed to be on a UTF-8 boundary for a string of ASCII characters");
         }
         format!("{name:\x00<8}")
     }


### PR DESCRIPTION
This lint checks for slice operations on strings.

From `string_slice`  [docs](https://rust-lang.github.io/rust-clippy/master/index.html#/string_slice):

> UTF-8 characters span multiple bytes, and it is easy to inadvertently confuse character counts and string indices. This may lead to panics, and should warrant some test cases containing wide UTF-8 characters. This lint is most useful in code that should avoid panics at all costs.