### PR TITLE
fix(cliprdr): add missing std feature to ironrdp-code dependency

### DIFF
--- a/crates/ironrdp-cliprdr-format/Cargo.toml
+++ b/crates/ironrdp-cliprdr-format/Cargo.toml
@@ -16,9 +16,8 @@ doctest = false
 test = false
 
 [dependencies]
-ironrdp-core = { path = "../ironrdp-core", version = "0.1" } # public
+ironrdp-core = { path = "../ironrdp-core", version = "0.1", features = ["std"] } # public
 png = "0.18"
 
 [lints]
 workspace = true
-


### PR DESCRIPTION
Fixes currently failing `Release crates` CI step