### PR TITLE
build: optimize binary size for FFI builds

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -198,7 +198,7 @@ jobs:
           $CargoParams = @(
               "build",
               "-p", "ffi",
-              "--release",
+              "--profile", "production-ffi",
               "--target", "$RustTarget"
           )
 
@@ -206,7 +206,7 @@ jobs:
 
           $OutputLibraryName = "${LibPrefix}ironrdp$LibSuffix"
           $RenamedLibraryName = "${LibPrefix}DevolutionsIronRdp$LibSuffix"
-          $OutputLibrary = Join-Path "target" $RustTarget 'release' $OutputLibraryName
+          $OutputLibrary = Join-Path "target" $RustTarget 'production-ffi' $OutputLibraryName
           $OutputPath = Join-Path "dependencies" "runtimes" $DotNetRid "native"
           New-Item -ItemType Directory -Path $OutputPath | Out-Null
           Copy-Item $OutputLibrary $(Join-Path $OutputPath $RenamedLibraryName)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,6 +175,12 @@ opt-level = 1
 inherits = "release"
 lto = true
 
+[profile.production-ffi]
+inherits = "release"
+strip = "symbols"
+codegen-units = 1
+lto = true
+
 [profile.production-wasm]
 inherits = "release"
 opt-level = "s"

--- a/ffi/dotnet/Devolutions.IronRdp/Devolutions.IronRdp.csproj
+++ b/ffi/dotnet/Devolutions.IronRdp/Devolutions.IronRdp.csproj
@@ -4,7 +4,7 @@
     <Company>Devolutions</Company>
     <Description>Bindings to Rust IronRDP native library</Description>
     <LangVersion>latest</LangVersion>
-    <Version>2024.5.22.0</Version>
+    <Version>2024.10.9.0</Version>
     <ImplicitUsings>enable</ImplicitUsings> <!-- FIXME: set to disable -->
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
Still optimizing for performance, but enabled the following options:

> strip = "symbols"
> codegen-units = 1
> lto = true

- Baseline: 8.9M
- New: 5.6M