### PR TITLE
chore: add `suspicious_xor_user_as_pow` clippy correctness lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ precedence_bits = "warn"
 rc_mutex = "warn"
 same_name_method = "warn"
 string_slice = "warn"
+suspicious_xor_used_as_pow = "warn"
 
 # == Style, readability == #
 semicolon_outside_block = "warn" # With semicolon-outside-block-ignore-multiline = true


### PR DESCRIPTION
From the lint [docs](https://rust-lang.github.io/rust-clippy/stable/index.html#suspicious_xor_used_as_pow):
> Warns for a Bitwise XOR (^) operator being probably confused as a powering. It will not trigger if any of the numbers are not in decimal. It’s most probably a typo and may lead to unexpected behaviours.