### PR TITLE
chore: add `unused_result_ok` clippy correctness lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ precedence_bits = "warn"
 rc_mutex = "warn"
 same_name_method = "warn"
 string_slice = "warn"
+unused_result_ok = "warn"
 
 # == Style, readability == #
 semicolon_outside_block = "warn" # With semicolon-outside-block-ignore-multiline = true


### PR DESCRIPTION
This lint checks for calls to `Result::ok()` without using the returned `Option`.