### PR TITLE
refactor(web): improve error handling

### DIFF
--- a/web-client/iron-remote-desktop/src/enums/SessionEventType.ts
+++ b/web-client/iron-remote-desktop/src/enums/SessionEventType.ts
@@ -1,9 +1,0 @@
-﻿export enum SessionEventType {
-    STARTED,
-    TERMINATED,
-    ERROR,
-    WARNING,
-
-    // Clipboard events
-    CLIPBOARD_REMOTE_UPDATE,
-}

--- a/web-client/iron-remote-desktop/src/interfaces/Error.ts
+++ b/web-client/iron-remote-desktop/src/interfaces/Error.ts
@@ -1,6 +1,4 @@
-﻿import type { SessionEventType } from '../enums/SessionEventType';
-
-export enum IronErrorKind {
+﻿export enum IronErrorKind {
     General = 0,
     WrongPassword = 1,
     LogonFailure = 2,
@@ -13,9 +11,4 @@ export enum IronErrorKind {
 export interface IronError {
     backtrace: () => string;
     kind: () => IronErrorKind;
-}
-
-export interface SessionEvent {
-    type: SessionEventType;
-    data: IronError | string;
 }

--- a/web-client/iron-remote-desktop/src/interfaces/NewSessionInfo.ts
+++ b/web-client/iron-remote-desktop/src/interfaces/NewSessionInfo.ts
@@ -1,7 +1,9 @@
 ﻿import type { DesktopSize } from './DesktopSize';
+import type { SessionTerminationInfo } from './SessionTerminationInfo';
 
 export interface NewSessionInfo {
     sessionId: number;
     websocketPort: number;
     initialDesktopSize: DesktopSize;
+    run: () => Promise<SessionTerminationInfo>;
 }

--- a/web-client/iron-remote-desktop/src/interfaces/UserInteraction.ts
+++ b/web-client/iron-remote-desktop/src/interfaces/UserInteraction.ts
@@ -1,6 +1,5 @@
 ﻿import type { ScreenScale } from '../enums/ScreenScale';
 import type { NewSessionInfo } from './NewSessionInfo';
-import type { SessionEvent } from './session-event';
 import { ConfigBuilder } from '../services/ConfigBuilder';
 import type { Config } from '../services/Config';
 import type { Extension } from './Extension';
@@ -25,7 +24,9 @@ export interface UserInteraction {
 
     setCursorStyleOverride(style: string | null): void;
 
-    onSessionEvent(callback: Callback<SessionEvent>): void;
+    onWarningCallback(callback: Callback<string>): void;
+
+    onClipboardRemoteUpdateCallback(callback: Callback<void>): void;
 
     resize(width: number, height: number, scale?: number): void;
 
@@ -33,9 +34,9 @@ export interface UserInteraction {
 
     setEnableAutoClipboard(enable: boolean): void;
 
-    saveRemoteClipboardData(): Promise<boolean>;
+    saveRemoteClipboardData(): Promise<void>;
 
-    sendClipboardData(): Promise<boolean>;
+    sendClipboardData(): Promise<void>;
 
     invokeExtension(ext: Extension): void;
 }

--- a/web-client/iron-remote-desktop/src/main.ts
+++ b/web-client/iron-remote-desktop/src/main.ts
@@ -1,8 +1,7 @@
 export * as default from './iron-remote-desktop.svelte';
 export type { ResizeEvent } from './interfaces/ResizeEvent';
 export type { NewSessionInfo } from './interfaces/NewSessionInfo';
-export type { SessionEvent, IronError, IronErrorKind } from './interfaces/session-event';
-export type { SessionEventType } from './enums/SessionEventType';
+export type { IronError, IronErrorKind } from './interfaces/Error';
 export type { SessionTerminationInfo } from './interfaces/SessionTerminationInfo';
 export type { ClipboardData } from './interfaces/ClipboardData';
 export type { ClipboardItem } from './interfaces/ClipboardItem';

--- a/web-client/iron-remote-desktop/src/services/PublicAPI.ts
+++ b/web-client/iron-remote-desktop/src/services/PublicAPI.ts
@@ -68,11 +68,19 @@ export class PublicAPI {
         this.remoteDesktopService.setEnableAutoClipboard(enable);
     }
 
-    private async saveRemoteClipboardData(): Promise<boolean> {
+    private setOnWarningCallback(callback: (data: string) => void) {
+        this.remoteDesktopService.setOnWarningCallback(callback);
+    }
+
+    private setOnClipboardRemoteUpdateCallback(callback: () => void) {
+        this.remoteDesktopService.setOnClipboardRemoteUpdate(callback);
+    }
+
+    private async saveRemoteClipboardData(): Promise<void> {
         return await this.clipboardService.saveRemoteClipboardData();
     }
 
-    private async sendClipboardData(): Promise<boolean> {
+    private async sendClipboardData(): Promise<void> {
         return await this.clipboardService.sendClipboardData();
     }
 
@@ -85,10 +93,9 @@ export class PublicAPI {
             setVisibility: this.setVisibility.bind(this),
             configBuilder: this.configBuilder.bind(this),
             connect: this.connect.bind(this),
+            onWarningCallback: this.setOnWarningCallback.bind(this),
+            onClipboardRemoteUpdateCallback: this.setOnClipboardRemoteUpdateCallback.bind(this),
             setScale: this.setScale.bind(this),
-            onSessionEvent: (callback) => {
-                this.remoteDesktopService.sessionEventObservable.subscribe(callback);
-            },
             ctrlAltDel: this.ctrlAltDel.bind(this),
             metaKey: this.metaKey.bind(this),
             shutdown: this.shutdown.bind(this),


### PR DESCRIPTION
This PR improves the error handling in _iron-remote-desktop_ by replacing the session events with throwing errors for terminated and error events and callbacks for warnings and the clipboard remote update event.