### PR TITLE
chore: add `pub_without_shorthand` clippy style and readability lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ unused_result_ok = "warn"
 semicolon_outside_block = "warn" # With semicolon-outside-block-ignore-multiline = true
 clone_on_ref_ptr = "warn"
 cloned_instead_of_copied = "warn"
+pub_without_shorthand = "warn"
 trait_duplication_in_bounds = "warn"
 type_repetition_in_bounds = "warn"
 checked_conversions = "warn"


### PR DESCRIPTION
[pub_without_shorthand](https://rust-lang.github.io/rust-clippy/master/index.html#/pub_without_shorthand):

> Checks for usage of pub(<loc>) without in.
> Note: As you cannot write a module’s path in pub(<loc>), this will only trigger on pub(super) and the like.