### PR TITLE
refactor: add `map_with_unused_argument_over_ranges` clippy style and readability lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ semicolon_outside_block = "warn" # With semicolon-outside-block-ignore-multiline
 clone_on_ref_ptr = "warn"
 cloned_instead_of_copied = "warn"
 pub_without_shorthand = "warn"
+map_with_unused_argument_over_ranges = "warn"
 trait_duplication_in_bounds = "warn"
 type_repetition_in_bounds = "warn"
 checked_conversions = "warn"

--- a/crates/ironrdp-graphics/src/rlgr.rs
+++ b/crates/ironrdp-graphics/src/rlgr.rs
@@ -275,15 +275,15 @@ fn truncate_leading_value(bits: &mut Bits<'_>, value: bool) -> usize {
 }
 
 fn count_run(number_of_zeros: usize, k: &mut u32, kp: &mut u32) -> u32 {
-    (0..number_of_zeros)
-        .map(|_| {
-            let run = 1 << *k;
-            *kp = min(*kp + UP_GR, KP_MAX);
-            *k = *kp >> LS_GR;
+    core::iter::repeat_with(|| {
+        let run = 1 << *k;
+        *kp = min(*kp + UP_GR, KP_MAX);
+        *k = *kp >> LS_GR;
 
-            run
-        })
-        .sum()
+        run
+    })
+    .take(number_of_zeros)
+    .sum()
 }
 
 fn compute_rl_magnitude(sign_bit: u8, code_remainder: u32) -> i16 {

--- a/crates/ironrdp-pdu/src/codecs/rfx/data_messages.rs
+++ b/crates/ironrdp-pdu/src/codecs/rfx/data_messages.rs
@@ -1,3 +1,5 @@
+use core::iter;
+
 use bit_field::BitField as _;
 use bitflags::bitflags;
 use ironrdp_core::{
@@ -249,8 +251,8 @@ impl<'de> Decode<'de> for RegionPdu {
 
         ensure_size!(in: src, size: number_of_rectangles * RECTANGLE_SIZE);
 
-        let rectangles = (0..number_of_rectangles)
-            .map(|_| RfxRectangle::decode(src))
+        let rectangles = iter::repeat_with(|| RfxRectangle::decode(src))
+            .take(number_of_rectangles)
             .collect::<Result<Vec<_>, _>>()?;
 
         ensure_size!(in: src, size: 4);
@@ -381,15 +383,15 @@ impl<'de> Decode<'de> for TileSetPdu<'de> {
             return Err(invalid_field_err!("tile_size", "Invalid tile size"));
         }
 
-        let number_of_tiles = src.read_u16();
+        let number_of_tiles = usize::from(src.read_u16());
         let _tiles_data_size = src.read_u32() as usize;
 
-        let quants = (0..number_of_quants)
-            .map(|_| Quant::decode(src))
+        let quants = iter::repeat_with(|| Quant::decode(src))
+            .take(number_of_quants)
             .collect::<Result<Vec<_>, _>>()?;
 
-        let tiles = (0..number_of_tiles)
-            .map(|_| Block::decode(src))
+        let tiles = iter::repeat_with(|| Block::decode(src))
+            .take(number_of_tiles)
             .collect::<Result<Vec<_>, _>>()?;
 
         let tiles = tiles

--- a/crates/ironrdp-pdu/src/codecs/rfx/header_messages.rs
+++ b/crates/ironrdp-pdu/src/codecs/rfx/header_messages.rs
@@ -141,9 +141,9 @@ impl<'de> Decode<'de> for ChannelsPdu {
     fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
         ensure_fixed_part_size!(in: src);
 
-        let num_channels = src.read_u8();
-        let channels = (0..num_channels)
-            .map(|_| RfxChannel::decode(src))
+        let num_channels = usize::from(src.read_u8());
+        let channels = core::iter::repeat_with(|| RfxChannel::decode(src))
+            .take(num_channels)
             .collect::<DecodeResult<Vec<_>>>()?;
 
         Ok(Self(channels))

--- a/crates/ironrdp-pdu/src/input/fast_path.rs
+++ b/crates/ironrdp-pdu/src/input/fast_path.rs
@@ -302,8 +302,8 @@ impl Encode for FastPathInput {
 impl<'de> Decode<'de> for FastPathInput {
     fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
         let header = FastPathInputHeader::decode(src)?;
-        let events = (0..header.num_events)
-            .map(|_| FastPathInputEvent::decode(src))
+        let events = core::iter::repeat_with(|| FastPathInputEvent::decode(src))
+            .take(usize::from(header.num_events))
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Self(events))

--- a/crates/ironrdp-pdu/src/input/mod.rs
+++ b/crates/ironrdp-pdu/src/input/mod.rs
@@ -61,11 +61,11 @@ impl<'de> Decode<'de> for InputEventPdu {
     fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
         ensure_fixed_part_size!(in: src);
 
-        let number_of_events = src.read_u16();
+        let number_of_events = usize::from(src.read_u16());
         read_padding!(src, 2);
 
-        let events = (0..number_of_events)
-            .map(|_| InputEvent::decode(src))
+        let events = core::iter::repeat_with(|| InputEvent::decode(src))
+            .take(number_of_events)
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Self(events))

--- a/crates/ironrdp-pdu/src/rdp/refresh_rectangle.rs
+++ b/crates/ironrdp-pdu/src/rdp/refresh_rectangle.rs
@@ -54,10 +54,10 @@ impl<'de> Decode<'de> for RefreshRectanglePdu {
     fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
         ensure_fixed_part_size!(in: src);
 
-        let number_of_areas = src.read_u8();
+        let number_of_areas = usize::from(src.read_u8());
         read_padding!(src, 3);
-        let areas_to_refresh = (0..number_of_areas)
-            .map(|_| InclusiveRectangle::decode(src))
+        let areas_to_refresh = core::iter::repeat_with(|| InclusiveRectangle::decode(src))
+            .take(number_of_areas)
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Self { areas_to_refresh })

--- a/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx/graphics_messages/client.rs
+++ b/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx/graphics_messages/client.rs
@@ -1,3 +1,5 @@
+use core::iter;
+
 use ironrdp_core::{
     cast_length, ensure_fixed_part_size, ensure_size, Decode, DecodeResult, Encode, EncodeResult, ReadCursor,
     WriteCursor,
@@ -44,8 +46,8 @@ impl<'a> Decode<'a> for CapabilitiesAdvertisePdu {
 
         ensure_size!(in: src, size: capabilities_count * CapabilitySet::FIXED_PART_SIZE);
 
-        let capabilities = (0..capabilities_count)
-            .map(|_| CapabilitySet::decode(src))
+        let capabilities = iter::repeat_with(|| CapabilitySet::decode(src))
+            .take(capabilities_count)
             .collect::<Result<_, _>>()?;
 
         Ok(Self(capabilities))
@@ -138,9 +140,9 @@ impl<'a> Decode<'a> for CacheImportReplyPdu {
     fn decode(src: &mut ReadCursor<'a>) -> DecodeResult<Self> {
         ensure_fixed_part_size!(in: src);
 
-        let entries_count = src.read_u16();
+        let entries_count = usize::from(src.read_u16());
 
-        let cache_slots = (0..entries_count).map(|_| src.read_u16()).collect();
+        let cache_slots = iter::repeat_with(|| src.read_u16()).take(entries_count).collect();
 
         Ok(Self { cache_slots })
     }

--- a/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx/graphics_messages/server.rs
+++ b/crates/ironrdp-pdu/src/rdp/vc/dvc/gfx/graphics_messages/server.rs
@@ -1,3 +1,4 @@
+use core::iter;
 use std::fmt;
 
 use bit_field::BitField as _;
@@ -15,7 +16,7 @@ use crate::geometry::InclusiveRectangle;
 pub(crate) const RESET_GRAPHICS_PDU_SIZE: usize = 340;
 
 const MAX_RESET_GRAPHICS_WIDTH_HEIGHT: u32 = 32_766;
-const MONITOR_COUNT_MAX: u32 = 16;
+const MONITOR_COUNT_MAX: usize = 16;
 
 #[derive(Clone, PartialEq, Eq)]
 pub struct WireToSurface1Pdu {
@@ -254,11 +255,11 @@ impl<'a> Decode<'a> for SolidFillPdu {
 
         let surface_id = src.read_u16();
         let fill_pixel = Color::decode(src)?;
-        let rectangles_count = src.read_u16();
+        let rectangles_count = usize::from(src.read_u16());
 
-        ensure_size!(in: src, size: usize::from(rectangles_count) * InclusiveRectangle::FIXED_PART_SIZE);
-        let rectangles = (0..rectangles_count)
-            .map(|_| InclusiveRectangle::decode(src))
+        ensure_size!(in: src, size: rectangles_count * InclusiveRectangle::FIXED_PART_SIZE);
+        let rectangles = iter::repeat_with(|| InclusiveRectangle::decode(src))
+            .take(rectangles_count)
             .collect::<Result<_, _>>()?;
 
         Ok(Self {
@@ -315,10 +316,10 @@ impl<'a> Decode<'a> for SurfaceToSurfacePdu {
         let source_surface_id = src.read_u16();
         let destination_surface_id = src.read_u16();
         let source_rectangle = InclusiveRectangle::decode(src)?;
-        let destination_points_count = src.read_u16();
+        let destination_points_count = usize::from(src.read_u16());
 
-        let destination_points = (0..destination_points_count)
-            .map(|_| Point::decode(src))
+        let destination_points = iter::repeat_with(|| Point::decode(src))
+            .take(destination_points_count)
             .collect::<Result<_, _>>()?;
 
         Ok(Self {
@@ -425,10 +426,10 @@ impl<'de> Decode<'de> for CacheToSurfacePdu {
 
         let cache_slot = src.read_u16();
         let surface_id = src.read_u16();
-        let destination_points_count = src.read_u16();
+        let destination_points_count = usize::from(src.read_u16());
 
-        let destination_points = (0..destination_points_count)
-            .map(|_| decode_cursor(src))
+        let destination_points = iter::repeat_with(|| decode_cursor(src))
+            .take(destination_points_count)
             .collect::<Result<_, _>>()?;
 
         Ok(Self {
@@ -585,13 +586,13 @@ impl<'a> Decode<'a> for ResetGraphicsPdu {
             return Err(invalid_field_err!("height", "invalid reset graphics height"));
         }
 
-        let monitor_count = src.read_u32();
+        let monitor_count = cast_length!("monitor count", src.read_u32())?;
         if monitor_count > MONITOR_COUNT_MAX {
             return Err(invalid_field_err!("height", "invalid reset graphics monitor count"));
         }
 
-        let monitors = (0..monitor_count)
-            .map(|_| Monitor::decode(src))
+        let monitors = iter::repeat_with(|| Monitor::decode(src))
+            .take(monitor_count)
             .collect::<Result<Vec<_>, _>>()?;
 
         let pdu = Self {

--- a/crates/ironrdp-rdpsnd/src/pdu/mod.rs
+++ b/crates/ironrdp-rdpsnd/src/pdu/mod.rs
@@ -351,12 +351,12 @@ impl<'de> Decode<'de> for ServerAudioFormatPdu {
         read_padding!(src, 4); /* volume */
         read_padding!(src, 4); /* pitch */
         read_padding!(src, 2); /* DGramPort */
-        let n_formats = src.read_u16();
+        let n_formats = usize::from(src.read_u16());
         read_padding!(src, 1); /* blockNo */
         let version = Version::try_from(src.read_u16())?;
         read_padding!(src, 1);
-        let formats = (0..n_formats)
-            .map(|_| AudioFormat::decode(src))
+        let formats = core::iter::repeat_with(|| AudioFormat::decode(src))
+            .take(n_formats)
             .collect::<DecodeResult<_>>()?;
 
         Ok(Self { version, formats })
@@ -447,12 +447,12 @@ impl<'de> Decode<'de> for ClientAudioFormatPdu {
         let volume_right = (volume >> 16) as u16;
         let pitch = src.read_u32();
         let dgram_port = src.read_u16_be();
-        let n_formats = src.read_u16();
+        let n_formats = usize::from(src.read_u16());
         let _block_no = src.read_u8();
         let version = Version::try_from(src.read_u16())?;
         read_padding!(src, 1);
-        let formats = (0..n_formats)
-            .map(|_| AudioFormat::decode(src))
+        let formats = core::iter::repeat_with(|| AudioFormat::decode(src))
+            .take(n_formats)
             .collect::<DecodeResult<_>>()?;
 
         Ok(Self {


### PR DESCRIPTION
> Checks for Iterator::map over ranges without using the parameter which could be more clearly expressed using std::iter::repeat(...).take(...) or std::iter::repeat_n.