### PR TITLE
fix(dvc-pipe-proxy): change dvc proxy pipe mode from Message to Byte on Windows

### DIFF
--- a/crates/ironrdp-dvc-pipe-proxy/src/platform/windows.rs
+++ b/crates/ironrdp-dvc-pipe-proxy/src/platform/windows.rs
@@ -24,7 +24,7 @@ impl OsPipe for WindowsPipe {
             .max_instances(2)
             .in_buffer_size(PIPE_BUFFER_SIZE)
             .out_buffer_size(PIPE_BUFFER_SIZE)
-            .pipe_mode(named_pipe::PipeMode::Message)
+            .pipe_mode(named_pipe::PipeMode::Byte)
             .create(pipe_name)
             .map_err(DvcPipeProxyError::Io)?;
 


### PR DESCRIPTION
We don't need Message mode anymore, message defragmentation logic is implemented in https://github.com/Devolutions/now-proto/pull/41