### PR TITLE
fix(web): fix `this.lastSentClipboardData` being null

### DIFF
--- a/crates/iron-remote-desktop/src/clipboard.rs
+++ b/crates/iron-remote-desktop/src/clipboard.rs
@@ -1,6 +1,6 @@
 use wasm_bindgen::JsValue;
 
-pub trait ClipboardData: Clone {
+pub trait ClipboardData {
     type Item: ClipboardItem;
 
     fn create() -> Self;

--- a/crates/iron-remote-desktop/src/lib.rs
+++ b/crates/iron-remote-desktop/src/lib.rs
@@ -160,7 +160,7 @@ macro_rules! make_bridge {
 
             #[wasm_bindgen(js_name = onClipboardPaste)]
             pub async fn on_clipboard_paste(&self, content: &ClipboardData) -> Result<(), IronError> {
-                $crate::Session::on_clipboard_paste(&self.0, content.0.clone())
+                $crate::Session::on_clipboard_paste(&self.0, &content.0)
                     .await
                     .map_err(IronError)
             }

--- a/crates/iron-remote-desktop/src/session.rs
+++ b/crates/iron-remote-desktop/src/session.rs
@@ -84,7 +84,7 @@ pub trait Session {
 
     fn on_clipboard_paste(
         &self,
-        content: Self::ClipboardData,
+        content: &Self::ClipboardData,
     ) -> impl core::future::Future<Output = Result<(), Self::Error>>;
 
     fn resize(

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -800,10 +800,10 @@ impl iron_remote_desktop::Session for Session {
         Ok(())
     }
 
-    async fn on_clipboard_paste(&self, content: Self::ClipboardData) -> Result<(), Self::Error> {
+    async fn on_clipboard_paste(&self, content: &Self::ClipboardData) -> Result<(), Self::Error> {
         self.input_events_tx
             .unbounded_send(RdpInputEvent::ClipboardBackend(
-                WasmClipboardBackendMessage::LocalClipboardChanged(content),
+                WasmClipboardBackendMessage::LocalClipboardChanged(content.clone()),
             ))
             .context("Send clipboard backend event")?;
 

--- a/web-client/iron-remote-desktop/src/services/clipboard.service.ts
+++ b/web-client/iron-remote-desktop/src/services/clipboard.service.ts
@@ -146,7 +146,6 @@ export class ClipboardService {
 
         if (!clipboardData.isEmpty()) {
             this.lastSentClipboardData = clipboardData;
-            // Explicitly clone the `clipboardData` object as `onClipboardChanged` consumes the value.
             await this.remoteDesktopService.onClipboardChanged(clipboardData);
         }
     }
@@ -397,7 +396,6 @@ export class ClipboardService {
 
         if (!clipboardData.isEmpty()) {
             this.lastSentClipboardData = clipboardData;
-            // Explicitly clone the `clipboardData` object as `onClipboardChanged` consumes the value.
             await this.remoteDesktopService.onClipboardChanged(clipboardData);
         }
     }


### PR DESCRIPTION
```js
await this.remoteDesktopService.onClipboardChanged(...)
```
Consumes the clipboard data we pass, so we need to clone the data to prevent `this.lastSentClipboardData` from being null.