### PR TITLE
refactor(ironrdp-web): fix `indexing_slicing` clippy lint warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ ptr_cast_constness = "warn"
 
 # == Correctness == #
 as_conversions = "warn"
+#indexing_slicing = "warn" TODO: enable this lint project wide.
 cast_lossless = "warn"
 cast_possible_truncation = "warn"
 cast_possible_wrap = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ ptr_cast_constness = "warn"
 
 # == Correctness == #
 as_conversions = "warn"
-#indexing_slicing = "warn" TODO: enable this lint project wide.
+# indexing_slicing = "warn" TODO: enable this lint project wide.
 cast_lossless = "warn"
 cast_possible_truncation = "warn"
 cast_possible_wrap = "warn"

--- a/crates/ironrdp-web/src/canvas.rs
+++ b/crates/ironrdp-web/src/canvas.rs
@@ -45,10 +45,8 @@ impl Canvas {
         let region_height = region.height();
 
         let mut src = buffer.chunks_exact(4).map(|pixel| {
-            let r = *pixel.first().expect("index cannot be out of bounds");
-            let g = *pixel.get(1).expect("index cannot be out of bounds");
-            let b = *pixel.get(2).expect("index cannot be out of bounds");
-            u32::from_be_bytes([0, r, g, b])
+            let [r, g, b] = pixel.first_chunk::<3>().expect("cannot be out of bounds");
+            u32::from_be_bytes([0, *r, *g, *b])
         });
 
         let mut dst = self.surface.buffer_mut().expect("surface buffer");

--- a/crates/ironrdp-web/src/canvas.rs
+++ b/crates/ironrdp-web/src/canvas.rs
@@ -45,9 +45,9 @@ impl Canvas {
         let region_height = region.height();
 
         let mut src = buffer.chunks_exact(4).map(|pixel| {
-            let r = pixel[0];
-            let g = pixel[1];
-            let b = pixel[2];
+            let r = *pixel.first().expect("index cannot be out of bounds");
+            let g = *pixel.get(1).expect("index cannot be out of bounds");
+            let b = *pixel.get(2).expect("index cannot be out of bounds");
             u32::from_be_bytes([0, r, g, b])
         });
 

--- a/crates/ironrdp-web/src/image.rs
+++ b/crates/ironrdp-web/src/image.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::arithmetic_side_effects)]
 
-use anyhow::Context;
+use anyhow::Context as _;
 use ironrdp::pdu::geometry::{InclusiveRectangle, Rectangle as _};
 use ironrdp::session::image::DecodedImage;
 

--- a/crates/ironrdp-web/src/image.rs
+++ b/crates/ironrdp-web/src/image.rs
@@ -50,10 +50,10 @@ fn extract_smallest_rectangle(
 
         let target_begin = region_stride * row;
         let target_end = target_begin + region_stride;
-        let target_slice = dst
-            .get_mut(target_begin..target_end)
-            .expect("destination buffer sized correctly based on region dimensions; \
-                     target slice indices must be in-bounds");
+        let target_slice = dst.get_mut(target_begin..target_end).expect(
+            "destination buffer sized correctly based on region dimensions; \
+                     target slice indices must be in-bounds",
+        );
 
         target_slice.copy_from_slice(src_slice);
     }

--- a/crates/ironrdp-web/src/image.rs
+++ b/crates/ironrdp-web/src/image.rs
@@ -52,7 +52,8 @@ fn extract_smallest_rectangle(
         let target_end = target_begin + region_stride;
         let target_slice = dst
             .get_mut(target_begin..target_end)
-            .expect("slice index cannot be out of bounds");
+            .expect("destination buffer sized correctly based on region dimensions; \
+                     target slice indices must be in-bounds");
 
         target_slice.copy_from_slice(src_slice);
     }

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -603,7 +603,7 @@ impl iron_remote_desktop::Session for Session {
                     }
                     ActiveStageOutput::GraphicsUpdate(region) => {
                         // PERF: some copies and conversion could be optimized
-                        let (region, buffer) = extract_partial_image(&image, region);
+                        let (region, buffer) = extract_partial_image(&image, region)?;
                         gui.draw(&buffer, region).context("draw updated region")?;
                     }
                     ActiveStageOutput::PointerDefault => {


### PR DESCRIPTION
[This lint](https://rust-lang.github.io/rust-clippy/master/index.html#/indexing_slicing)
> Checks for usage of indexing or slicing that may panic at runtime.

This one is quite pedantic and changes the way we write the code, but on the other hand, it makes the code more panic-resistant. Fixed the lint warnings only for _ironrdp-web_ to see early feedback on it. 
If we agree on adding it, I will add this lint for each crate separately, because there are too many warnings to do in 1 PR:
<img width="631" height="651" alt="image" src="https://github.com/user-attachments/assets/0e44c9c4-85c0-42c5-8bfb-65a3158d31d7" />
