### PR TITLE
fix(web): send first clipboard only after the connection is established

### DIFF
--- a/web-client/iron-remote-desktop/src/services/remote-desktop.service.ts
+++ b/web-client/iron-remote-desktop/src/services/remote-desktop.service.ts
@@ -41,6 +41,8 @@ export class RemoteDesktopService {
     private enableClipboard: boolean = true;
     private _autoClipboard: boolean = true;
 
+    sessionStartedObservable: Observable<null> = new Observable();
+
     resizeObservable: Observable<ResizeEvent> = new Observable();
 
     session?: Session;
@@ -179,6 +181,8 @@ export class RemoteDesktopService {
             desktopSize: session.desktopSize(),
             sessionId: 0,
         });
+
+        this.sessionStartedObservable.publish(null);
 
         const run = async (): Promise<SessionTerminationInfo> => {
             try {


### PR DESCRIPTION
When the clipboard is in automatic mode, `iron-remote-desktop` can send the first clipboard PDU to the server before the connection is established. Thus, this packet is ignored, and the clipboard on the server will not be synced with the current host's clipboard. 

This PR fixes it. 