### PR TITLE
feat(web): add human-readable descriptions to RDCleanPath error messages

### DIFF
--- a/crates/ironrdp-rdcleanpath/src/lib.rs
+++ b/crates/ironrdp-rdcleanpath/src/lib.rs
@@ -30,18 +30,128 @@ pub struct RDCleanPathErr {
 
 impl fmt::Display for RDCleanPathErr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "RDCleanPath error (code {})", self.error_code)?;
+        let error_description = match self.error_code {
+            GENERAL_ERROR_CODE => "general error",
+            NEGOTIATION_ERROR_CODE => "negotiation error",
+            _ => "unknown error",
+        };
+        write!(f, "RDCleanPath {error_description} (code {})", self.error_code)?;
 
         if let Some(http_status_code) = self.http_status_code {
-            write!(f, " [HTTP status = {http_status_code}]")?;
+            let description = match http_status_code {
+                200 => "OK",
+                400 => "Bad Request",
+                401 => "Unauthorized",
+                403 => "Forbidden",
+                404 => "Not Found",
+                405 => "Method Not Allowed",
+                408 => "Request Timeout",
+                409 => "Conflict",
+                410 => "Gone",
+                413 => "Payload Too Large",
+                414 => "URI Too Long",
+                422 => "Unprocessable Entity",
+                429 => "Too Many Requests",
+                500 => "Internal Server Error",
+                501 => "Not Implemented",
+                502 => "Bad Gateway",
+                503 => "Service Unavailable",
+                504 => "Gateway Timeout",
+                505 => "HTTP Version Not Supported",
+                _ => "Unknown HTTP Status",
+            };
+            write!(f, " [HTTP {http_status_code}: {description}]")?;
         }
 
         if let Some(wsa_last_error) = self.wsa_last_error {
-            write!(f, " [WSA last error = {wsa_last_error}]")?;
+            let description = match wsa_last_error {
+                10004 => "Interrupted system call",
+                10009 => "Bad file descriptor",
+                10013 => "Permission denied",
+                10014 => "Bad address",
+                10022 => "Invalid argument",
+                10024 => "Too many open files",
+                10035 => "Resource temporarily unavailable",
+                10036 => "Operation now in progress",
+                10037 => "Operation already in progress",
+                10038 => "Socket operation on nonsocket",
+                10039 => "Destination address required",
+                10040 => "Message too long",
+                10041 => "Protocol wrong type for socket",
+                10042 => "Bad protocol option",
+                10043 => "Protocol not supported",
+                10044 => "Socket type not supported",
+                10045 => "Operation not supported",
+                10046 => "Protocol family not supported",
+                10047 => "Address family not supported by protocol family",
+                10048 => "Address already in use",
+                10049 => "Cannot assign requested address",
+                10050 => "Network is down",
+                10051 => "Network is unreachable",
+                10052 => "Network dropped connection on reset",
+                10053 => "Software caused connection abort",
+                10054 => "Connection reset by peer",
+                10055 => "No buffer space available",
+                10056 => "Socket is already connected",
+                10057 => "Socket is not connected",
+                10058 => "Cannot send after socket shutdown",
+                10060 => "Connection timed out",
+                10061 => "Connection refused",
+                10064 => "Host is down",
+                10065 => "No route to host",
+                10067 => "Too many processes",
+                10091 => "Network subsystem is unavailable",
+                10092 => "Winsock version not supported",
+                10093 => "Successful WSAStartup not yet performed",
+                10101 => "Graceful shutdown in progress",
+                10109 => "Class type not found",
+                11001 => "Host not found",
+                11002 => "Nonauthoritative host not found",
+                11003 => "This is a nonrecoverable error",
+                11004 => "Valid name, no data record of requested type",
+                _ => "Unknown WSA error",
+            };
+            write!(f, " [WSA {wsa_last_error}: {description}]")?;
         }
 
         if let Some(tls_alert_code) = self.tls_alert_code {
-            write!(f, " [TLS alert = {tls_alert_code}]")?;
+            let description = match tls_alert_code {
+                0 => "Close notify",
+                10 => "Unexpected message",
+                20 => "Bad record MAC",
+                21 => "Decryption failed",
+                22 => "Record overflow",
+                30 => "Decompression failure",
+                40 => "Handshake failure",
+                41 => "No certificate",
+                42 => "Bad certificate",
+                43 => "Unsupported certificate",
+                44 => "Certificate revoked",
+                45 => "Certificate expired",
+                46 => "Certificate unknown",
+                47 => "Illegal parameter",
+                48 => "Unknown CA",
+                49 => "Access denied",
+                50 => "Decode error",
+                51 => "Decrypt error",
+                60 => "Export restriction",
+                70 => "Protocol version",
+                71 => "Insufficient security",
+                80 => "Internal error",
+                90 => "User canceled",
+                100 => "No renegotiation",
+                109 => "Missing extension",
+                110 => "Unsupported extension",
+                111 => "Certificate unobtainable",
+                112 => "Unrecognized name",
+                113 => "Bad certificate status response",
+                114 => "Bad certificate hash value",
+                115 => "Unknown PSK identity",
+                116 => "Certificate required",
+                120 => "No application protocol",
+                _ => "Unknown TLS alert",
+            };
+            write!(f, " [TLS alert {tls_alert_code}: {description}]")?;
         }
 
         Ok(())

--- a/crates/ironrdp-testsuite-core/tests/rdcleanpath.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdcleanpath.rs
@@ -1,4 +1,6 @@
-use ironrdp_rdcleanpath::{DetectionResult, RDCleanPathPdu, VERSION_1};
+use ironrdp_rdcleanpath::{
+    DetectionResult, RDCleanPathErr, RDCleanPathPdu, GENERAL_ERROR_CODE, NEGOTIATION_ERROR_CODE, VERSION_1,
+};
 use rstest::rstest;
 
 fn request() -> RDCleanPathPdu {
@@ -122,4 +124,88 @@ fn detect(#[case] der: &[u8]) {
 fn detect_not_enough(#[case] payload: &[u8]) {
     let result = RDCleanPathPdu::detect(payload);
     assert_eq!(result, DetectionResult::NotEnoughBytes);
+}
+
+#[test]
+fn error_display_http() {
+    let error = RDCleanPathErr {
+        error_code: GENERAL_ERROR_CODE,
+        http_status_code: Some(404),
+        wsa_last_error: None,
+        tls_alert_code: None,
+    };
+
+    let display_str = format!("{error}");
+    assert_eq!(display_str, "RDCleanPath general error (code 1) [HTTP 404: Not Found]");
+}
+
+#[test]
+fn error_display_wsa() {
+    let error = RDCleanPathErr {
+        error_code: GENERAL_ERROR_CODE,
+        http_status_code: None,
+        wsa_last_error: Some(10061),
+        tls_alert_code: None,
+    };
+
+    let display_str = format!("{error}");
+    assert_eq!(
+        display_str,
+        "RDCleanPath general error (code 1) [WSA 10061: Connection refused]"
+    );
+}
+
+#[test]
+fn error_display_tls() {
+    let error = RDCleanPathErr {
+        error_code: GENERAL_ERROR_CODE,
+        http_status_code: None,
+        wsa_last_error: None,
+        tls_alert_code: Some(40),
+    };
+
+    let display_str = format!("{error}");
+    assert_eq!(
+        display_str,
+        "RDCleanPath general error (code 1) [TLS alert 40: Handshake failure]"
+    );
+}
+
+#[test]
+fn error_display_negotiation_error() {
+    let error = RDCleanPathErr {
+        error_code: NEGOTIATION_ERROR_CODE,
+        http_status_code: None,
+        wsa_last_error: None,
+        tls_alert_code: None,
+    };
+
+    let display_str = format!("{error}");
+    assert_eq!(display_str, "RDCleanPath negotiation error (code 2)");
+}
+
+#[test]
+fn error_display_combined() {
+    let error = RDCleanPathErr {
+        error_code: GENERAL_ERROR_CODE,
+        http_status_code: Some(502),
+        wsa_last_error: Some(10060),
+        tls_alert_code: Some(45),
+    };
+
+    let display_str = format!("{error}");
+    assert_eq!(display_str, "RDCleanPath general error (code 1) [HTTP 502: Bad Gateway] [WSA 10060: Connection timed out] [TLS alert 45: Certificate expired]");
+}
+
+#[test]
+fn error_display_unknown_codes() {
+    let error = RDCleanPathErr {
+        error_code: 99,
+        http_status_code: Some(999),
+        wsa_last_error: Some(65000),
+        tls_alert_code: Some(255),
+    };
+
+    let display_str = format!("{error}");
+    assert_eq!(display_str, "RDCleanPath unknown error (code 99) [HTTP 999: Unknown HTTP Status] [WSA 65000: Unknown WSA error] [TLS alert 255: Unknown TLS alert]");
 }

--- a/crates/ironrdp-web/src/error.rs
+++ b/crates/ironrdp-web/src/error.rs
@@ -15,7 +15,7 @@ impl IronError {
 
 impl iron_remote_desktop::IronError for IronError {
     fn backtrace(&self) -> String {
-        format!("{:?}", self.source)
+        format!("{:#}", self.source)
     }
 
     fn kind(&self) -> IronErrorKind {


### PR DESCRIPTION
More munging to give human-readable client-side errors for RDCleanPath general/negotiation errors, including strings for WSA and TLS and HTTP error conditions.