### PR TITLE
chore(release): remove leading zero from nuget version

### DIFF
--- a/ffi/dotnet/Devolutions.IronRdp/Devolutions.IronRdp.csproj
+++ b/ffi/dotnet/Devolutions.IronRdp/Devolutions.IronRdp.csproj
@@ -4,7 +4,7 @@
     <Company>Devolutions</Company>
     <Description>Bindings to Rust IronRDP native library</Description>
     <LangVersion>latest</LangVersion>
-    <Version>2025.09.24.0</Version>
+    <Version>2025.9.24.0</Version>
     <ImplicitUsings>enable</ImplicitUsings> <!-- FIXME: set to disable -->
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
leading zero in Nuget version caused CI to fail on ffi crate build:

```
 error: invalid leading zero in minor version number
 --> ffi/Cargo.toml:3:11
  |
3 | version = "2025.09.24"
  |           ^^^^^^^^^^^^
  |
error: failed to load manifest for workspace member `/Users/runner/work/IronRDP/IronRDP/ffi`
referenced by workspace at `/Users/runner/work/IronRDP/IronRDP/Cargo.toml`
```