### PR TITLE
chore: enable `rest_pat_in_fully_bound_structs` clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,7 @@ range_plus_one = "warn"
 # TODO: self_named_module_files = "warn"
 # TODO: partial_pub_fields = "warn" (should we enable only in pdu crates?)
 redundant_type_annotations = "warn"
+rest_pat_in_fully_bound_structs = "warn"
 
 # == Compile-time / optimization == #
 doc_include_without_cfg = "warn"


### PR DESCRIPTION
[`rest_pat_in_fully_bound_structs`](https://rust-lang.github.io/rust-clippy/stable/index.html#/rest_pat_in_fully_bound_structs):
> Checks for unnecessary ‘..’ pattern binding on struct when all fields are explicitly matched.