### PR TITLE
refactor: enable `unnecessary_self_imports` clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,7 @@ range_plus_one = "warn"
 # TODO: self_named_module_files = "warn"
 # TODO: partial_pub_fields = "warn" (should we enable only in pdu crates?)
 redundant_type_annotations = "warn"
+unnecessary_self_imports = "warn"
 
 # == Compile-time / optimization == #
 doc_include_without_cfg = "warn"

--- a/crates/ironrdp-acceptor/src/channel_connection.rs
+++ b/crates/ironrdp-acceptor/src/channel_connection.rs
@@ -4,8 +4,7 @@ use ironrdp_connector::{
     reason_err, ConnectorError, ConnectorErrorExt as _, ConnectorResult, Sequence, State, Written,
 };
 use ironrdp_core::WriteBuf;
-use ironrdp_pdu::x224::X224;
-use ironrdp_pdu::{self as pdu};
+use ironrdp_pdu::{self as pdu, x224::X224};
 use pdu::mcs;
 use tracing::debug;
 

--- a/crates/ironrdp-acceptor/src/finalization.rs
+++ b/crates/ironrdp-acceptor/src/finalization.rs
@@ -1,7 +1,6 @@
 use ironrdp_connector::{ConnectorError, ConnectorErrorExt as _, ConnectorResult, Sequence, State, Written};
 use ironrdp_core::WriteBuf;
-use ironrdp_pdu::x224::X224;
-use ironrdp_pdu::{self as pdu};
+use ironrdp_pdu::{self as pdu, x224::X224};
 use pdu::rdp;
 use tracing::debug;
 

--- a/crates/ironrdp-connector/src/connection_activation.rs
+++ b/crates/ironrdp-connector/src/connection_activation.rs
@@ -1,7 +1,6 @@
 use core::mem;
 
-use ironrdp_pdu::rdp::capability_sets::CapabilitySet;
-use ironrdp_pdu::rdp::{self};
+use ironrdp_pdu::rdp::{self, capability_sets::CapabilitySet};
 use tracing::{debug, warn};
 
 use crate::{

--- a/crates/ironrdp-server/src/helper.rs
+++ b/crates/ironrdp-server/src/helper.rs
@@ -5,9 +5,9 @@ use std::sync::Arc;
 
 use anyhow::Context as _;
 use rustls_pemfile::{certs, pkcs8_private_keys};
+use tokio_rustls::rustls;
 use tokio_rustls::rustls::pki_types::pem::PemObject as _;
 use tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer};
-use tokio_rustls::rustls::{self};
 use tokio_rustls::TlsAcceptor;
 
 pub struct TlsIdentityCtx {

--- a/crates/ironrdp-tls/src/rustls.rs
+++ b/crates/ironrdp-tls/src/rustls.rs
@@ -2,7 +2,7 @@ use std::io;
 
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt as _};
 use tokio_rustls::rustls::pki_types::ServerName;
-use tokio_rustls::rustls::{self};
+use tokio_rustls::rustls;
 
 pub type TlsStream<S> = tokio_rustls::client::TlsStream<S>;
 


### PR DESCRIPTION
[`unnecessary_self_imports`](https://rust-lang.github.io/rust-clippy/stable/index.html#unnecessary_self_imports):
> Checks for imports ending in ::{self}.