### PR TITLE
fix(cliprdr)!: receiving a TemporaryDirectory PDU should not fail the svc

### DIFF
--- a/crates/ironrdp-cliprdr/src/lib.rs
+++ b/crates/ironrdp-cliprdr/src/lib.rs
@@ -28,16 +28,12 @@ pub type CliprdrSvcMessages<R> = SvcProcessorMessages<Cliprdr<R>>;
 
 #[derive(Debug)]
 enum ClipboardError {
-    UnimplementedPdu { pdu: &'static str },
     FormatListRejected,
 }
 
 impl core::fmt::Display for ClipboardError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            ClipboardError::UnimplementedPdu { pdu } => {
-                write!(f, "received clipboard PDU `{pdu}` is not implemented")
-            }
             ClipboardError::FormatListRejected => write!(f, "sent format list was rejected"),
         }
     }
@@ -333,9 +329,10 @@ impl<R: Role> SvcProcessor for Cliprdr<R> {
                 self.backend.on_file_contents_response(response);
                 Ok(Vec::new())
             }
-            _ => self.handle_error_transition(ClipboardError::UnimplementedPdu {
-                pdu: pdu.message_name(),
-            }),
+            ClipboardPdu::TemporaryDirectory(_) => {
+                // do nothing
+                Ok(Vec::new())
+            }
         }
     }
 


### PR DESCRIPTION
- Fixes the Cliprdr `SvcProcessor` impl. to support handling a `TemporaryDirectory` Clipboard PDU. 
- Removes `ClipboardError::UnimplementedPdu` since it is no longer used

Without this fix, I was unable to get the `ironrdp-server` crate to work with my custom`CliprdrBackend` impl. This change makes sense since this PDU is a valid clipboard PDU that we should process and is (optionally) sent by an RDP client. I've chosen not to add a callback in the `CliprdrBackend` trait since this PDU seems useless as there is nothing todo with it from the `ironrdp-server`'s perspective.