### PR TITLE
ci: migrate iron crates to trusted publishing

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -66,6 +66,8 @@ jobs:
     name: Release crates
     environment: cratesio-publish
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -73,8 +75,12 @@ jobs:
         with:
           fetch-depth: 512
 
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+
       - name: Run release-plz
         uses: Devolutions/actions-public/release-plz@v1
         with:
           command: release
-          registry-token: ${{ secrets.CRATES_IO_TOKEN }}
+          registry-token: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
All crates migrated:

- ironrdp
- ironrdp-acceptor
- ironrdp-ainput
- ironrdp-async
- ironrdp-blocking
- ironrdp-cliprdr
- ironrdp-cliprdr-format
- ironrdp-cliprdr-native
- ironrdp-connector
- ironrdp-core
- ironrdp-displaycontrol
- ironrdp-dvc
- ironrdp-dvc-pipe-proxy
- ironrdp-error
- ironrdp-futures
- ironrdp-graphics
- ironrdp-input
- ironrdp-pdu
- ironrdp-rdcleanpath
- ironrdp-rdpdr
- ironrdp-rdpdr-native
- ironrdp-rdpsnd
- ironrdp-rdpsnd-native
- ironrdp-server
- ironrdp-session
- ironrdp-svc
- ironrdp-tls
- ironrdp-tokio
- iron-remote-desktop