### PR TITLE
fix(ironrdp-async)!: use static dispatch for NetworkClient trait

### DIFF
--- a/crates/ironrdp-acceptor/src/credssp.rs
+++ b/crates/ironrdp-acceptor/src/credssp.rs
@@ -1,4 +1,4 @@
-use ironrdp_async::AsyncNetworkClient;
+use ironrdp_async::NetworkClient;
 use ironrdp_connector::sspi::credssp::{
     CredSspServer, CredentialsProxy, ServerError, ServerMode, ServerState, TsRequest,
 };
@@ -71,7 +71,7 @@ impl CredentialsProxy for CredentialsProxyImpl<'_> {
 
 pub(crate) async fn resolve_generator(
     generator: &mut CredsspProcessGenerator<'_>,
-    network_client: &mut dyn AsyncNetworkClient,
+    network_client: &mut impl NetworkClient,
 ) -> Result<ServerState, ServerError> {
     let mut state = generator.start();
 

--- a/crates/ironrdp-async/src/lib.rs
+++ b/crates/ironrdp-async/src/lib.rs
@@ -1,14 +1,13 @@
 #![cfg_attr(doc, doc = include_str!("../README.md"))]
 #![doc(html_logo_url = "https://cdnweb.devolutions.net/images/projects/devolutions/logos/devolutions-icon-shadow.svg")]
 
+use core::future::Future;
+
 pub use bytes;
 
 mod connector;
 mod framed;
 mod session;
-
-use core::future::Future;
-use core::pin::Pin;
 
 use ironrdp_connector::sspi::generator::NetworkRequest;
 use ironrdp_connector::ConnectorResult;
@@ -17,9 +16,6 @@ pub use self::connector::*;
 pub use self::framed::*;
 // pub use self::session::*;
 
-pub trait AsyncNetworkClient {
-    fn send<'a>(
-        &'a mut self,
-        network_request: &'a NetworkRequest,
-    ) -> Pin<Box<dyn Future<Output = ConnectorResult<Vec<u8>>> + 'a>>;
+pub trait NetworkClient {
+    fn send(&mut self, network_request: &NetworkRequest) -> impl Future<Output = ConnectorResult<Vec<u8>>>;
 }

--- a/crates/ironrdp-blocking/src/connector.rs
+++ b/crates/ironrdp-blocking/src/connector.rs
@@ -53,11 +53,11 @@ pub fn mark_as_upgraded(_: ShouldUpgrade, connector: &mut ClientConnector) -> Up
 #[instrument(skip_all)]
 pub fn connect_finalize<S>(
     _: Upgraded,
-    framed: &mut Framed<S>,
     mut connector: ClientConnector,
+    framed: &mut Framed<S>,
+    network_client: &mut impl NetworkClient,
     server_name: ServerName,
     server_public_key: Vec<u8>,
-    network_client: &mut impl NetworkClient,
     kerberos_config: Option<KerberosConfig>,
 ) -> ConnectorResult<ConnectionResult>
 where
@@ -69,12 +69,12 @@ where
 
     if connector.should_perform_credssp() {
         perform_credssp_step(
-            framed,
             &mut connector,
+            framed,
+            network_client,
             &mut buf,
             server_name,
             server_public_key,
-            network_client,
             kerberos_config,
         )?;
     }
@@ -118,12 +118,12 @@ fn resolve_generator(
 
 #[instrument(level = "trace", skip_all)]
 fn perform_credssp_step<S>(
-    framed: &mut Framed<S>,
     connector: &mut ClientConnector,
+    framed: &mut Framed<S>,
+    network_client: &mut impl NetworkClient,
     buf: &mut WriteBuf,
     server_name: ServerName,
     server_public_key: Vec<u8>,
-    network_client: &mut impl NetworkClient,
     kerberos_config: Option<KerberosConfig>,
 ) -> ConnectorResult<()>
 where

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -240,11 +240,11 @@ async fn connect(
 
     let connection_result = ironrdp_tokio::connect_finalize(
         upgraded,
-        &mut upgraded_framed,
         connector,
+        &mut upgraded_framed,
+        &mut ReqwestNetworkClient::new(),
         (&config.destination).into(),
         server_public_key,
-        Some(&mut ReqwestNetworkClient::new()),
         None,
     )
     .await?;
@@ -326,11 +326,11 @@ async fn connect_ws(
 
     let connection_result = ironrdp_tokio::connect_finalize(
         upgraded,
-        &mut framed,
         connector,
+        &mut framed,
+        &mut ReqwestNetworkClient::new(),
         (&config.destination).into(),
         server_public_key,
-        Some(&mut ReqwestNetworkClient::new()),
         None,
     )
     .await?;

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -349,9 +349,9 @@ impl RdpServer {
                     ironrdp_acceptor::accept_credssp(
                         &mut framed,
                         &mut acceptor,
+                        &mut ironrdp_tokio::reqwest::ReqwestNetworkClient::new(),
                         client_name.into(),
                         pub_key.clone(),
-                        None,
                         None,
                     )
                     .await?;

--- a/crates/ironrdp-testsuite-extra/tests/mod.rs
+++ b/crates/ironrdp-testsuite-extra/tests/mod.rs
@@ -212,11 +212,11 @@ where
                 let mut upgraded_framed = ironrdp_tokio::TokioFramed::new(upgraded_stream);
                 let connection_result = ironrdp_async::connect_finalize(
                     upgraded,
-                    &mut upgraded_framed,
                     connector,
+                    &mut upgraded_framed,
+                    &mut ironrdp_tokio::reqwest::ReqwestNetworkClient::new(),
                     "localhost".into(),
                     server_public_key,
-                    None,
                     None,
                 )
                 .await

--- a/crates/ironrdp-tokio/src/reqwest.rs
+++ b/crates/ironrdp-tokio/src/reqwest.rs
@@ -1,6 +1,4 @@
-use core::future::Future;
 use core::net::{IpAddr, Ipv4Addr};
-use core::pin::Pin;
 
 use ironrdp_connector::{custom_err, general_err, ConnectorResult};
 use reqwest::Client;
@@ -9,18 +7,15 @@ use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio::net::{TcpStream, UdpSocket};
 use url::Url;
 
-use crate::AsyncNetworkClient;
+use crate::NetworkClient;
 
 pub struct ReqwestNetworkClient {
     client: Option<Client>,
 }
 
-impl AsyncNetworkClient for ReqwestNetworkClient {
-    fn send<'a>(
-        &'a mut self,
-        network_request: &'a sspi::generator::NetworkRequest,
-    ) -> Pin<Box<dyn Future<Output = ConnectorResult<Vec<u8>>> + 'a>> {
-        Box::pin(ReqwestNetworkClient::send_request(self, network_request))
+impl NetworkClient for ReqwestNetworkClient {
+    async fn send(&mut self, network_request: &sspi::generator::NetworkRequest) -> ConnectorResult<Vec<u8>> {
+        ReqwestNetworkClient::send_request(self, network_request).await
     }
 }
 

--- a/crates/ironrdp-web/src/network_client.rs
+++ b/crates/ironrdp-web/src/network_client.rs
@@ -1,53 +1,45 @@
-use core::pin::Pin;
-
-use futures_util::Future;
 use ironrdp::connector::sspi::generator::NetworkRequest;
 use ironrdp::connector::sspi::network_client::NetworkProtocol;
 use ironrdp::connector::{custom_err, reason_err, ConnectorResult};
-use ironrdp_futures::AsyncNetworkClient;
+use ironrdp_futures::NetworkClient;
 use tracing::debug;
 
 #[derive(Debug)]
 pub(crate) struct WasmNetworkClient;
 
-impl AsyncNetworkClient for WasmNetworkClient {
-    fn send<'a>(
-        &'a mut self,
-        network_request: &'a NetworkRequest,
-    ) -> Pin<Box<dyn Future<Output = ConnectorResult<Vec<u8>>> + 'a>> {
-        Box::pin(async move {
-            debug!(?network_request.protocol, ?network_request.url);
+impl NetworkClient for WasmNetworkClient {
+    async fn send(&mut self, network_request: &NetworkRequest) -> ConnectorResult<Vec<u8>> {
+        debug!(?network_request.protocol, ?network_request.url);
 
-            match &network_request.protocol {
-                NetworkProtocol::Http | NetworkProtocol::Https => {
-                    let body = js_sys::Uint8Array::from(network_request.data.as_slice());
+        match &network_request.protocol {
+            NetworkProtocol::Http | NetworkProtocol::Https => {
+                let body = js_sys::Uint8Array::from(network_request.data.as_slice());
 
-                    let response = gloo_net::http::Request::post(network_request.url.as_str())
-                        .header("keep-alive", "true")
-                        .body(body)
-                        .map_err(|e| custom_err!("failed to send KDC request", e))?
-                        .send()
-                        .await
-                        .map_err(|e| custom_err!("failed to send KDC request", e))?;
+                let response = gloo_net::http::Request::post(network_request.url.as_str())
+                    .header("keep-alive", "true")
+                    .body(body)
+                    .map_err(|e| custom_err!("failed to send KDC request", e))?
+                    .send()
+                    .await
+                    .map_err(|e| custom_err!("failed to send KDC request", e))?;
 
-                    if !response.ok() {
-                        return Err(reason_err!(
-                            "KdcProxy",
-                            "HTTP status error ({} {})",
-                            response.status(),
-                            response.status_text(),
-                        ));
-                    }
-
-                    let body = response
-                        .binary()
-                        .await
-                        .map_err(|e| custom_err!("failed to retrieve HTTP response", e))?;
-
-                    Ok(body)
+                if !response.ok() {
+                    return Err(reason_err!(
+                        "KdcProxy",
+                        "HTTP status error ({} {})",
+                        response.status(),
+                        response.status_text(),
+                    ));
                 }
-                unsupported => Err(reason_err!("CredSSP", "unsupported protocol: {unsupported:?}")),
+
+                let body = response
+                    .binary()
+                    .await
+                    .map_err(|e| custom_err!("failed to retrieve HTTP response", e))?;
+
+                Ok(body)
             }
-        })
+            unsupported => Err(reason_err!("CredSSP", "unsupported protocol: {unsupported:?}")),
+        }
     }
 }

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -979,11 +979,11 @@ async fn connect(
 
     let connection_result = ironrdp_futures::connect_finalize(
         upgraded,
-        &mut framed,
         connector,
+        &mut framed,
+        &mut WasmNetworkClient,
         (&destination).into(),
         server_public_key,
-        Some(&mut WasmNetworkClient),
         url::Url::parse(kdc_proxy_url.unwrap_or_default().as_str()) // if kdc_proxy_url does not exit, give url parser a empty string, it will fail anyway and map to a None
             .ok()
             .map(|url| KerberosConfig {

--- a/crates/ironrdp/examples/screenshot.rs
+++ b/crates/ironrdp/examples/screenshot.rs
@@ -258,11 +258,11 @@ fn connect(
     let mut network_client = ReqwestNetworkClient;
     let connection_result = ironrdp_blocking::connect_finalize(
         upgraded,
-        &mut upgraded_framed,
         connector,
+        &mut upgraded_framed,
+        &mut network_client,
         server_name.into(),
         server_public_key,
-        &mut network_client,
         None,
     )
     .context("finalize connection")?;


### PR DESCRIPTION
- Rename `AsyncNetworkClient` to `NetworkClient`
- Replace dynamic dispatch (`Option<&mut dyn ...>`) with static dispatch using generics (`&mut N where N: NetworkClient`)
- Reorder `connect_finalize` parameters for consistency across crates