### PR TITLE
chore: enable `large_futures` clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,7 @@ or_fun_call = "warn"
 rc_buffer = "warn"
 string_lit_chars_any = "warn"
 unnecessary_box_returns = "warn"
+large_futures = "warn"
 
 # == Extra-pedantic clippy == #
 allow_attributes = "warn"


### PR DESCRIPTION
> It checks for the size of a Future created by async fn or async {}.

The maximum byte size a `Future` can have, before it triggers the clippy::large_futures lint is by default 16384, but we can adjust it.