### PR TITLE
chore(release): prepare for Devolutions.IronRdp v2025.12.4.0

### DIFF
--- a/ffi/dotnet/Devolutions.IronRdp/Devolutions.IronRdp.csproj
+++ b/ffi/dotnet/Devolutions.IronRdp/Devolutions.IronRdp.csproj
@@ -4,7 +4,7 @@
     <Company>Devolutions</Company>
     <Description>Bindings to Rust IronRDP native library</Description>
     <LangVersion>latest</LangVersion>
-    <Version>2025.9.24.0</Version>
+    <Version>2025.12.4.0</Version>
     <ImplicitUsings>enable</ImplicitUsings> <!-- FIXME: set to disable -->
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
We still don't have a means to set the nuget version directly in the workflow. I thought of adding it, but on closer inspection we have logic to handle package and product version differently (and the same is true of sspi-rs etc) and probably needs a closer look. It can be troublesome to deploy a newer nuget package that doesn't increment the assembly versions (for example - and it shouldn't be an issue for Devolutions, but maybe for other consumers - Windows Installers generally might not overwrite a DLL if the version number is not newer than what is already installed.

For now, I just bump the package version manually.