### PR TITLE
chore: bump iOS nuget package to net9.0

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -337,7 +337,7 @@ jobs:
         run: |
           # net8.0 target packaged as Devolutions.IronRdp
           dotnet build .\ffi\dotnet\Devolutions.IronRdp\Devolutions.IronRdp.csproj -c Release
-          # net8.0-ios target packaged as Devolutions.IronRdp.iOS
+          # net9.0-ios target packaged as Devolutions.IronRdp.iOS
           dotnet build .\ffi\dotnet\Devolutions.IronRdp\Devolutions.IronRdp.csproj -c Release /p:PackageId=Devolutions.IronRdp.iOS
         shell: pwsh
 

--- a/ffi/dotnet/Devolutions.IronRdp/Devolutions.IronRdp.Build.iOS.props
+++ b/ffi/dotnet/Devolutions.IronRdp/Devolutions.IronRdp.Build.iOS.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Condition="$(PackageId.EndsWith('iOS'))">
-    <TargetFrameworks>net8.0-ios</TargetFrameworks>
+    <TargetFrameworks>net9.0-ios</TargetFrameworks>
     <SupportedOSPlatformVersion>12.1</SupportedOSPlatformVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
The `net8.0-ios` workload is out of support and won't build out-of-the-box anymore. Bump the target framework to `net9.0-ios`.