### PR TITLE
feat(ironrdp-tls)!: return x509_cert::Certificate from upgrade()

### DIFF
--- a/crates/ironrdp-tls/Cargo.toml
+++ b/crates/ironrdp-tls/Cargo.toml
@@ -23,7 +23,7 @@ stub = []
 
 [dependencies]
 tokio = { version = "1.47" }
-x509-cert = { version = "0.2", default-features = false, features = ["std"], optional = true }
+x509-cert = { version = "0.2", default-features = false, features = ["std"], optional = true } # public
 tokio-native-tls = { version = "0.3", optional = true } # public
 tokio-rustls =  { version = "0.26", optional = true } # public
 

--- a/crates/ironrdp-tls/src/lib.rs
+++ b/crates/ironrdp-tls/src/lib.rs
@@ -25,21 +25,9 @@ compile_error!("a TLS backend must be selected by enabling a single feature out 
 #[cfg(any(feature = "stub", feature = "native-tls", feature = "rustls"))]
 pub use impl_::{upgrade, TlsStream};
 
-#[cfg(any(feature = "native-tls", feature = "rustls"))]
-pub(crate) fn extract_tls_server_public_key(cert: &[u8]) -> std::io::Result<Vec<u8>> {
-    use std::io;
-
-    use x509_cert::der::Decode as _;
-
-    let cert = x509_cert::Certificate::from_der(cert).map_err(io::Error::other)?;
-
-    let server_public_key = cert
-        .tbs_certificate
+pub fn extract_tls_server_public_key(cert: &x509_cert::Certificate) -> Option<&[u8]> {
+    cert.tbs_certificate
         .subject_public_key_info
         .subject_public_key
         .as_bytes()
-        .ok_or_else(|| io::Error::other("subject public key BIT STRING is not aligned"))?
-        .to_owned();
-
-    Ok(server_public_key)
 }

--- a/crates/ironrdp-tls/src/rustls.rs
+++ b/crates/ironrdp-tls/src/rustls.rs
@@ -6,7 +6,7 @@ use tokio_rustls::rustls::pki_types::ServerName;
 
 pub type TlsStream<S> = tokio_rustls::client::TlsStream<S>;
 
-pub async fn upgrade<S>(stream: S, server_name: &str) -> io::Result<(TlsStream<S>, Vec<u8>)>
+pub async fn upgrade<S>(stream: S, server_name: &str) -> io::Result<(TlsStream<S>, x509_cert::Certificate)>
 where
     S: Unpin + AsyncRead + AsyncWrite,
 {
@@ -35,17 +35,20 @@ where
 
     tls_stream.flush().await?;
 
-    let server_public_key = {
+    let tls_cert = {
+        use x509_cert::der::Decode as _;
+
         let cert = tls_stream
             .get_ref()
             .1
             .peer_certificates()
             .and_then(|certificates| certificates.first())
             .ok_or_else(|| io::Error::other("peer certificate is missing"))?;
-        crate::extract_tls_server_public_key(cert)?
+
+        x509_cert::Certificate::from_der(cert).map_err(io::Error::other)?
     };
 
-    Ok((tls_stream, server_public_key))
+    Ok((tls_stream, tls_cert))
 }
 
 mod danger {


### PR DESCRIPTION
This allows client applications to verify details of the certificate, possibly with the user, when connecting to a server using TLS.

Note that this does not use Rustls's certificate verification, and still gives it danger::NoCertificateVerification.