### PR TITLE
fix(server): enable reqwest feature for ironrdp-tokio dependency

### DIFF
--- a/crates/ironrdp-server/Cargo.toml
+++ b/crates/ironrdp-server/Cargo.toml
@@ -39,7 +39,7 @@ ironrdp-svc = { path = "../ironrdp-svc", version = "0.6" } # public
 ironrdp-cliprdr = { path = "../ironrdp-cliprdr", version = "0.5" } # public
 ironrdp-displaycontrol = { path = "../ironrdp-displaycontrol", version = "0.5" } # public
 ironrdp-dvc = { path = "../ironrdp-dvc", version = "0.5" } # public
-ironrdp-tokio = { path = "../ironrdp-tokio", version = "0.8" }
+ironrdp-tokio = { path = "../ironrdp-tokio", version = "0.8", features = ["reqwest"] }
 ironrdp-acceptor = { path = "../ironrdp-acceptor", version = "0.8" } # public
 ironrdp-graphics = { path = "../ironrdp-graphics", version = "0.7" } # public
 ironrdp-rdpsnd = { path = "../ironrdp-rdpsnd", version = "0.7" } # public


### PR DESCRIPTION
The server uses `ironrdp_tokio::reqwest::ReqwestNetworkClient` in `accept_credssp` but the `reqwest` feature was not enabled on the `ironrdp-tokio` dependency, causing compilation to fail.

## Reproduction

```bash
cargo check -p ironrdp-server
```

Fails with:
```
error[E0433]: failed to resolve: could not find `reqwest` in `ironrdp_tokio`
```

## Fix

Enable the `reqwest` feature on `ironrdp-tokio` in `ironrdp-server/Cargo.toml`.

Fixes #1062