### PR TITLE
feat(cliprdr): add request_file_contents method

### DIFF
--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -573,6 +573,10 @@ async fn active_session(
                                     Some(cliprdr.unlock_clipboard(clip_data_id)
                                         .map_err(|e| session::custom_err!("CLIPRDR", e))?)
                                 }
+                                ClipboardMessage::SendFileContentsRequest(request) => {
+                                    Some(cliprdr.request_file_contents(request)
+                                        .map_err(|e| session::custom_err!("CLIPRDR", e))?)
+                                }
                                 ClipboardMessage::Error(e) => {
                                     error!("Clipboard backend error: {}", e);
                                     None

--- a/crates/ironrdp-cliprdr/src/backend.rs
+++ b/crates/ironrdp-cliprdr/src/backend.rs
@@ -43,6 +43,11 @@ pub enum ClipboardMessage {
     /// Implementation should send unlock clipboard data PDU on `CLIPRDR` SVC when received.
     SendUnlockClipboard { clip_data_id: u32 },
 
+    /// Sent by clipboard backend when file contents are needed from the remote.
+    ///
+    /// Implementation should send file contents request on `CLIPRDR` SVC when received.
+    SendFileContentsRequest(FileContentsRequest),
+
     /// Failure received from the OS clipboard event loop.
     ///
     /// Client implementation should log/display this error.

--- a/crates/ironrdp-cliprdr/src/lib.rs
+++ b/crates/ironrdp-cliprdr/src/lib.rs
@@ -15,8 +15,8 @@ use ironrdp_svc::{
 };
 use pdu::{
     Capabilities, ClientTemporaryDirectory, ClipboardFormat, ClipboardFormatId, ClipboardGeneralCapabilityFlags,
-    ClipboardPdu, ClipboardProtocolVersion, FileContentsResponse, FormatDataRequest, FormatListResponse, LockDataId,
-    OwnedFormatDataResponse,
+    ClipboardPdu, ClipboardProtocolVersion, FileContentsRequest, FileContentsResponse, FormatDataRequest,
+    FormatListResponse, LockDataId, OwnedFormatDataResponse,
 };
 use tracing::{error, info};
 
@@ -300,6 +300,20 @@ impl<R: Role> Cliprdr<R> {
         ready_guard!(self, unlock_clipboard);
 
         let pdu = ClipboardPdu::UnlockData(LockDataId(clip_data_id));
+        Ok(vec![into_cliprdr_message(pdu)].into())
+    }
+
+    /// [2.2.5.3] File Contents Request PDU (CLIPRDR_FILECONTENTS_REQUEST)
+    ///
+    /// Requests file contents from the Shared Clipboard Owner. Should be called when
+    /// the Local Clipboard Owner needs file data after receiving a file list format.
+    /// The remote will respond via [`CliprdrBackend::on_file_contents_response`].
+    ///
+    /// [2.2.5.3]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeclip/cbc851d3-4e68-45f4-9292-26872a9209f2
+    pub fn request_file_contents(&self, request: FileContentsRequest) -> PduResult<CliprdrSvcMessages<R>> {
+        ready_guard!(self, request_file_contents);
+
+        let pdu = ClipboardPdu::FileContentsRequest(request);
         Ok(vec![into_cliprdr_message(pdu)].into())
     }
 }

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -556,6 +556,7 @@ impl RdpServer {
                         ClipboardMessage::SendUnlockClipboard { clip_data_id } => {
                             cliprdr.unlock_clipboard(clip_data_id)
                         }
+                        ClipboardMessage::SendFileContentsRequest(request) => cliprdr.request_file_contents(request),
                         ClipboardMessage::Error(error) => {
                             error!(?error, "Handling clipboard event");
                             continue;

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -534,6 +534,10 @@ impl iron_remote_desktop::Session for Session {
                                         cliprdr.unlock_clipboard(clip_data_id)
                                             .context("CLIPRDR unlock clipboard")?
                                     ),
+                                    ClipboardMessage::SendFileContentsRequest(request) => Some(
+                                        cliprdr.request_file_contents(request)
+                                            .context("CLIPRDR request file contents")?
+                                    ),
                                     ClipboardMessage::Error(e) => {
                                         error!("Clipboard backend error: {}", e);
                                         None

--- a/ffi/src/clipboard/message.rs
+++ b/ffi/src/clipboard/message.rs
@@ -20,6 +20,9 @@ pub mod ffi {
                 ironrdp::cliprdr::backend::ClipboardMessage::SendUnlockClipboard { .. } => {
                     ClipboardMessageType::SendUnlockClipboard
                 }
+                ironrdp::cliprdr::backend::ClipboardMessage::SendFileContentsRequest(_) => {
+                    ClipboardMessageType::SendFileContentsRequest
+                }
                 ironrdp::cliprdr::backend::ClipboardMessage::Error(_) => ClipboardMessageType::Error,
             }
         }
@@ -59,6 +62,7 @@ pub mod ffi {
         SendInitiatePaste,
         SendLockClipboard,
         SendUnlockClipboard,
+        SendFileContentsRequest,
         Error,
     }
 


### PR DESCRIPTION
Per [MS-RDPECLIP section 2.2.5.3][file-contents-spec], the Local Clipboard Owner
sends File Contents Request PDU to retrieve file data from the Shared Clipboard
Owner during paste operations.

This enables server implementations to request file contents from clients,
completing the bidirectional file transfer capability.

## Changes

- `SendFileContentsRequest` message variant in `ClipboardMessage`
- `request_file_contents()` method on `Cliprdr<R>`
- Server handler wiring

## Dependencies

Depends on #1064 (lock/unlock methods).

[file-contents-spec]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeclip/cbc851d3-4e68-45f4-9292-26872a9209f2