### PR TITLE
feat(cliprdr): add SendFileContentsResponse message variant

### DIFF
--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -577,6 +577,10 @@ async fn active_session(
                                     Some(cliprdr.request_file_contents(request)
                                         .map_err(|e| session::custom_err!("CLIPRDR", e))?)
                                 }
+                                ClipboardMessage::SendFileContentsResponse(response) => {
+                                    Some(cliprdr.submit_file_contents(response)
+                                        .map_err(|e| session::custom_err!("CLIPRDR", e))?)
+                                }
                                 ClipboardMessage::Error(e) => {
                                     error!("Clipboard backend error: {}", e);
                                     None

--- a/crates/ironrdp-cliprdr/src/backend.rs
+++ b/crates/ironrdp-cliprdr/src/backend.rs
@@ -48,6 +48,11 @@ pub enum ClipboardMessage {
     /// Implementation should send file contents request on `CLIPRDR` SVC when received.
     SendFileContentsRequest(FileContentsRequest),
 
+    /// Sent by clipboard backend when file contents data is ready to be sent to the remote.
+    ///
+    /// Implementation should send file contents response on `CLIPRDR` SVC when received.
+    SendFileContentsResponse(FileContentsResponse<'static>),
+
     /// Failure received from the OS clipboard event loop.
     ///
     /// Client implementation should log/display this error.

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -557,6 +557,7 @@ impl RdpServer {
                             cliprdr.unlock_clipboard(clip_data_id)
                         }
                         ClipboardMessage::SendFileContentsRequest(request) => cliprdr.request_file_contents(request),
+                        ClipboardMessage::SendFileContentsResponse(response) => cliprdr.submit_file_contents(response),
                         ClipboardMessage::Error(error) => {
                             error!(?error, "Handling clipboard event");
                             continue;

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -538,6 +538,10 @@ impl iron_remote_desktop::Session for Session {
                                         cliprdr.request_file_contents(request)
                                             .context("CLIPRDR request file contents")?
                                     ),
+                                    ClipboardMessage::SendFileContentsResponse(response) => Some(
+                                        cliprdr.submit_file_contents(response)
+                                            .context("CLIPRDR submit file contents")?
+                                    ),
                                     ClipboardMessage::Error(e) => {
                                         error!("Clipboard backend error: {}", e);
                                         None

--- a/ffi/src/clipboard/message.rs
+++ b/ffi/src/clipboard/message.rs
@@ -23,6 +23,9 @@ pub mod ffi {
                 ironrdp::cliprdr::backend::ClipboardMessage::SendFileContentsRequest(_) => {
                     ClipboardMessageType::SendFileContentsRequest
                 }
+                ironrdp::cliprdr::backend::ClipboardMessage::SendFileContentsResponse(_) => {
+                    ClipboardMessageType::SendFileContentsResponse
+                }
                 ironrdp::cliprdr::backend::ClipboardMessage::Error(_) => ClipboardMessageType::Error,
             }
         }
@@ -63,6 +66,7 @@ pub mod ffi {
         SendLockClipboard,
         SendUnlockClipboard,
         SendFileContentsRequest,
+        SendFileContentsResponse,
         Error,
     }
 


### PR DESCRIPTION
Adds `SendFileContentsResponse` to `ClipboardMessage` enum, enabling clipboard
backends to signal when file data is ready to send via `submit_file_contents()`.

This provides the message-based interface pattern used consistently by server
implementations for clipboard operations.

## Changes

- `SendFileContentsResponse` message variant in `ClipboardMessage`
- Server handler wiring

## Dependencies

Depends on #1065 (request_file_contents method).