### PR TITLE
refactor: temporarily restore public Error fields for crate publishing

### DIFF
--- a/crates/ironrdp-connector/src/lib.rs
+++ b/crates/ironrdp-connector/src/lib.rs
@@ -406,7 +406,8 @@ pub trait ConnectorResultExt {
 impl<T> ConnectorResultExt for ConnectorResult<T> {
     fn with_context(self, context: &'static str) -> Self {
         self.map_err(|mut e| {
-            e.set_context(context);
+            e.context = context;
+            // e.set_context(context);
             e
         })
     }

--- a/crates/ironrdp-error/src/lib.rs
+++ b/crates/ironrdp-error/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(doc, doc = include_str!("../README.md"))]
 #![doc(html_logo_url = "https://cdnweb.devolutions.net/images/projects/devolutions/logos/devolutions-icon-shadow.svg")]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![expect(clippy::partial_pub_fields)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
@@ -23,8 +24,8 @@ impl<T> Source for T where T: fmt::Display + fmt::Debug + Send + Sync + 'static 
 
 #[derive(Debug)]
 pub struct Error<Kind> {
-    context: &'static str,
-    kind: Kind,
+    pub context: &'static str,
+    pub kind: Kind,
     #[cfg(feature = "std")]
     source: Option<Box<dyn core::error::Error + Sync + Send>>,
     #[cfg(all(not(feature = "std"), feature = "alloc"))]
@@ -78,10 +79,6 @@ impl<Kind> Error<Kind> {
 
     pub fn kind(&self) -> &Kind {
         &self.kind
-    }
-
-    pub fn set_context(&mut self, context: &'static str) {
-        self.context = context;
     }
 
     pub fn report(&self) -> ErrorReport<'_, Kind> {

--- a/crates/ironrdp-session/src/lib.rs
+++ b/crates/ironrdp-session/src/lib.rs
@@ -110,7 +110,7 @@ pub trait SessionResultExt {
 impl<T> SessionResultExt for SessionResult<T> {
     fn with_context(self, context: &'static str) -> Self {
         self.map_err(|mut e| {
-            e.set_context(context);
+            e.context = context;
             e
         })
     }


### PR DESCRIPTION
Makes Error::context and Error::kind public again to fix a breaking change that wasn't properly reported. This is a temporary workaround to allow crate publishing to proceed.