### PR TITLE
revert: set protect_breaking_commits = true in release-plz.toml

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -32,6 +32,3 @@ publish_no_verify = true
 [[package]]
 name = "ironrdp-cliprdr-native"
 publish_no_verify = true
-
-[changelog]
-protect_breaking_commits = true # Always include commits with breaking changes in the changelog.


### PR DESCRIPTION
Already enabled in cliff.toml.

Refs: d202d0516f7891486b3d2de697b11c810364dd23.