### PR TITLE
feat(server): expose client display size to RdpServerDisplay

### DIFF
--- a/crates/ironrdp-server/src/display.rs
+++ b/crates/ironrdp-server/src/display.rs
@@ -284,9 +284,15 @@ pub trait RdpServerDisplayUpdates {
 #[async_trait::async_trait]
 pub trait RdpServerDisplay: Send {
     /// This method should return the current size of the display.
-    /// Currently, there is no way for the client to negotiate resolution,
-    /// so the size returned by this method will be enforced.
     async fn size(&mut self) -> DesktopSize;
+
+    /// Request an initial size for the display.
+    ///
+    /// This method should return the negotiated display size.
+    async fn request_initial_size(&mut self, client_size: DesktopSize) -> DesktopSize {
+        debug!(?client_size, "Requesting initial size");
+        self.size().await
+    }
 
     /// Return a display updates receiver
     async fn updates(&mut self) -> Result<Box<dyn RdpServerDisplayUpdates>>;

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -736,7 +736,7 @@ impl RdpServer {
                         width: b.desktop_width,
                         height: b.desktop_height,
                     };
-                    let display_size = self.display.lock().await.size().await;
+                    let display_size = self.display.lock().await.request_initial_size(client_size).await;
 
                     // It's problematic when the client didn't resize, as we send bitmap updates that don't fit.
                     // The client will likely drop the connection.


### PR DESCRIPTION
This allows the server implementation to handle the requested initial client display size. The default implementation simply returns `self.size()` so there's no change to existing behavior.

Note that this method is also called during reactivations.