### PR TITLE
feat(connector): advertise multitransport channel in GCC blocks

### DIFF
--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -497,6 +497,7 @@ impl Config {
             enable_audio_playback: true,
             request_data: None,
             pointer_software_rendering: false,
+            multitransport_flags: None,
             compression_type,
             performance_flags: PerformanceFlags::default(),
             timezone_info: TimezoneInfo::default(),

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -728,8 +728,9 @@ fn create_gcc_blocks<'a>(
         monitor: None,
         // TODO(#140): support for Client Message Channel Data (https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/f50e791c-de03-4b25-b17e-e914c9020bc3)
         message_channel: None,
-        // TODO(#140): support for Some(MultiTransportChannelData { flags: MultiTransportFlags::empty(), })
-        multi_transport_channel: None,
+        multi_transport_channel: config
+            .multitransport_flags
+            .map(|flags| gcc::MultiTransportChannelData { flags }),
         monitor_extended: None,
     })
 }

--- a/crates/ironrdp-connector/src/lib.rs
+++ b/crates/ironrdp-connector/src/lib.rs
@@ -249,6 +249,12 @@ pub struct Config {
     // FIXME(@CBenoit): these are client-only options, not part of the connector.
     pub enable_server_pointer: bool,
     pub pointer_software_rendering: bool,
+
+    /// Flags to advertise in the [`MultiTransportChannelData`] GCC block.
+    ///
+    /// [\[MS-RDPBCGR\] 2.2.1.3.7]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/861f2bbb-6ca2-4c5a-8c44-0714fa901e70
+    /// [`MultiTransportChannelData`]: ironrdp_pdu::gcc::MultiTransportChannelData
+    pub multitransport_flags: Option<gcc::MultiTransportFlags>,
 }
 
 ironrdp_core::assert_impl!(Config: Send, Sync);

--- a/crates/ironrdp-testsuite-extra/tests/mod.rs
+++ b/crates/ironrdp-testsuite-extra/tests/mod.rs
@@ -306,6 +306,7 @@ fn default_client_config() -> connector::Config {
         compression_type: None,
         enable_server_pointer: true,
         pointer_software_rendering: true,
+        multitransport_flags: None,
         performance_flags: Default::default(),
         timezone_info: Default::default(),
     }

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -906,6 +906,7 @@ fn build_config(
         enable_audio_playback: false,
         request_data: None,
         pointer_software_rendering: false,
+        multitransport_flags: None,
         performance_flags: PerformanceFlags::default(),
         desktop_scale_factor: 0,
         hardware_id: None,

--- a/crates/ironrdp/examples/screenshot.rs
+++ b/crates/ironrdp/examples/screenshot.rs
@@ -264,6 +264,7 @@ fn build_config(
         enable_audio_playback: false,
         compression_type,
         pointer_software_rendering: true,
+        multitransport_flags: None,
         performance_flags: PerformanceFlags::default(),
         desktop_scale_factor: 0,
         hardware_id: None,

--- a/ffi/src/connector/config.rs
+++ b/ffi/src/connector/config.rs
@@ -215,6 +215,7 @@ pub mod ffi {
                 request_data: None,
                 compression_type: None,
                 pointer_software_rendering: self.pointer_software_rendering.unwrap_or(false),
+                multitransport_flags: None,
                 performance_flags: self.performance_flags.ok_or("performance flag is missing")?,
                 desktop_scale_factor: 0,
                 hardware_id: None,


### PR DESCRIPTION
Add multitransport_flags config option to populate the MultiTransportChannelData
GCC block during connection negotiation. When None (the default), behavior is
unchanged. Resolves the TODO at connection.rs line 731.

Spec: [MS-RDPBCGR] 2.2.1.3.7
See #140 for context.