### PR TITLE
feat(svc): add SvcMessage::encode_unframed_pdu for headerless encoding

### DIFF
--- a/crates/ironrdp-svc/src/lib.rs
+++ b/crates/ironrdp-svc/src/lib.rs
@@ -99,11 +99,11 @@ impl SvcMessage {
         self
     }
 
-    /// Encodes the inner PDU without SVC channel headers.
+    /// Encodes the inner PDU without SVC channel framing headers.
     ///
     /// Returns the raw PDU bytes for transports that handle their own framing
     /// (e.g. RDPEMT tunnel data for UDP transport).
-    pub fn encode_raw(&self) -> EncodeResult<Vec<u8>> {
+    pub fn encode_unframed_pdu(&self) -> EncodeResult<Vec<u8>> {
         ironrdp_core::encode_vec(self.pdu.as_ref())
     }
 }


### PR DESCRIPTION
Add encode_raw() method that encodes the inner PDU without SVC channel headers.
Over UDP, DVC messages are sent as RDPEMT tunnel data without SVC framing, but
the pdu field on SvcMessage is private so there's no way to get the raw bytes.

See #140 for context.