### PR TITLE
feat: Add DVC COM plugin loader for native Windows DVC client plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2529,6 +2529,7 @@ dependencies = [
  "ironrdp-cfg",
  "ironrdp-cliprdr-native",
  "ironrdp-core",
+ "ironrdp-dvc-com-plugin",
  "ironrdp-dvc-pipe-proxy",
  "ironrdp-mstsgu",
  "ironrdp-propertyset",
@@ -2631,6 +2632,19 @@ dependencies = [
  "ironrdp-svc",
  "slab",
  "tracing",
+]
+
+[[package]]
+name = "ironrdp-dvc-com-plugin"
+version = "0.1.0"
+dependencies = [
+ "ironrdp-core",
+ "ironrdp-dvc",
+ "ironrdp-pdu",
+ "ironrdp-svc",
+ "tracing",
+ "windows",
+ "windows-core",
 ]
 
 [[package]]

--- a/crates/ironrdp-client/Cargo.toml
+++ b/crates/ironrdp-client/Cargo.toml
@@ -89,6 +89,7 @@ url = "2"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.62", features = ["Win32_Foundation"] }
+ironrdp-dvc-com-plugin = { path = "../ironrdp-dvc-com-plugin" }
 
 [lints]
 workspace = true

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -32,6 +32,13 @@ pub struct Config {
     /// server, which will be used for proxying DVC messages to/from user-defined DVC logic
     /// implemented as named pipe clients (either in the same process or in a different process).
     pub dvc_pipe_proxies: Vec<DvcProxyInfo>,
+
+    /// Paths to DVC client plugin DLLs to load (Windows only).
+    ///
+    /// Each DLL is loaded via `LoadLibraryW` and its `VirtualChannelGetInstance` export is called
+    /// to obtain DVC plugin COM objects. Example: `C:\Windows\System32\webauthn.dll`.
+    #[cfg(windows)]
+    pub dvc_plugins: Vec<PathBuf>,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
@@ -325,6 +332,13 @@ struct Args {
     /// `<pipe>` will automatically be prefixed with `\\.\pipe\` on Windows.
     #[clap(long)]
     dvc_proxy: Vec<DvcProxyInfo>,
+    /// Load a DVC client plugin DLL (Windows only).
+    ///
+    /// Path to a DVC plugin DLL that exports VirtualChannelGetInstance.
+    /// Example: C:\Windows\System32\webauthn.dll
+    #[cfg(windows)]
+    #[clap(long)]
+    dvc_plugin: Vec<PathBuf>,
 }
 
 impl Config {
@@ -515,6 +529,8 @@ impl Config {
             clipboard_type,
             rdcleanpath,
             dvc_pipe_proxies: args.dvc_proxy,
+            #[cfg(windows)]
+            dvc_plugins: args.dvc_plugin,
         })
     }
 }

--- a/crates/ironrdp-dvc-com-plugin/Cargo.toml
+++ b/crates/ironrdp-dvc-com-plugin/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "ironrdp-dvc-com-plugin"
+version = "0.1.0"
+readme = "README.md"
+description = "DVC COM client plugin loader for IronRDP (Windows)"
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lib]
+doctest = false
+test = false
+
+[dependencies]
+
+[target.'cfg(windows)'.dependencies]
+ironrdp-core = { path = "../ironrdp-core", version = "0.1" }
+ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.7" }
+ironrdp-dvc = { path = "../ironrdp-dvc", version = "0.5" }
+ironrdp-svc = { path = "../ironrdp-svc", version = "0.6" }
+tracing = { version = "0.1", features = ["log"] }
+windows = { version = "0.62", features = [
+    "Win32_Foundation",
+    "Win32_System_RemoteDesktop",
+    "Win32_System_Com",
+    "Win32_System_Com_StructuredStorage",
+    "Win32_System_LibraryLoader",
+] }
+windows-core = "0.62"
+
+[lints]
+workspace = true

--- a/crates/ironrdp-dvc-com-plugin/src/channel.rs
+++ b/crates/ironrdp-dvc-com-plugin/src/channel.rs
@@ -1,0 +1,331 @@
+//! [`DvcComChannel`] — the `DvcProcessor` implementation that bridges IronRDP ↔ COM plugin.
+//!
+//! Also contains the public [`load_dvc_plugin`] function which loads a plugin DLL,
+//! initializes its COM objects, and returns a set of `DvcComChannel`s to register
+//! with IronRDP's `DrdynvcClient`.
+
+use core::cell::Cell;
+use core::ffi::c_void;
+use std::collections::HashMap;
+use std::os::windows::ffi::OsStrExt as _;
+use std::path::Path;
+use std::sync::{mpsc as std_mpsc, Arc};
+use std::thread;
+
+use ironrdp_core::impl_as_any;
+use ironrdp_dvc::{DvcClientProcessor, DvcMessage, DvcProcessor};
+use ironrdp_pdu::{pdu_other_err, PduResult};
+use ironrdp_svc::SvcMessage;
+use tracing::{debug, error, info, warn};
+use windows::core::{HRESULT, PCSTR, PCWSTR};
+use windows::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryW};
+use windows::Win32::System::RemoteDesktop::{IWTSListenerCallback, IWTSPlugin, IWTSVirtualChannelManager};
+use windows_core::{Interface as _, GUID};
+
+use crate::com::{ChannelManager, OnWriteDvc};
+use crate::worker::{run_com_worker, ComCommand};
+
+/// Type signature for the `VirtualChannelGetInstance` export in a DVC plugin DLL.
+///
+/// ```c
+/// HRESULT VCAPITYPE VirtualChannelGetInstance(
+///     REFIID  refiid,
+///     ULONG  *pNumObjs,
+///     VOID  **ppObjArray
+/// );
+/// ```
+type VirtualChannelGetInstanceFn =
+    unsafe extern "system" fn(refiid: *const GUID, pnumobjs: *mut u32, ppobjarray: *mut *mut c_void) -> HRESULT;
+
+/// A DVC channel backed by a native COM plugin DLL.
+///
+/// Each instance represents one listener (channel name) registered by the plugin
+/// during `IWTSPlugin::Initialize`. It implements [`DvcProcessor`] + [`DvcClientProcessor`]
+/// so it can be registered with IronRDP's `DrdynvcClient`.
+///
+/// Communication with the COM worker thread happens via `std::sync::mpsc` channels.
+pub struct DvcComChannel {
+    channel_name: String,
+    command_tx: std_mpsc::Sender<ComCommand>,
+    on_write_dvc_tx: std_mpsc::Sender<OnWriteDvc>,
+    on_write_dvc_factory: Arc<dyn Fn() -> OnWriteDvcMessage + Send + Sync>,
+    /// Set to false after the first `start()` call sends `Connected`
+    needs_connected: bool,
+    _worker_handle: Option<thread::JoinHandle<()>>,
+}
+
+impl_as_any!(DvcComChannel);
+
+impl DvcProcessor for DvcComChannel {
+    fn channel_name(&self) -> &str {
+        &self.channel_name
+    }
+
+    fn start(&mut self, channel_id: u32) -> PduResult<Vec<DvcMessage>> {
+        info!(
+            channel_name = %self.channel_name,
+            channel_id,
+            "DVC COM channel start"
+        );
+
+        // Notify the plugin that the RDP connection is established (only once per plugin)
+        if self.needs_connected {
+            self.needs_connected = false;
+            let _ = self.command_tx.send(ComCommand::Connected);
+        }
+
+        // Create a fresh write callback for this channel opening
+        let write_cb = (self.on_write_dvc_factory)();
+        let _ = self.on_write_dvc_tx.send(write_cb);
+
+        let (accept_tx, accept_rx) = std_mpsc::sync_channel(1);
+
+        self.command_tx
+            .send(ComCommand::ChannelOpened {
+                channel_name: self.channel_name.clone(),
+                channel_id,
+                accept_tx,
+            })
+            .map_err(|_| pdu_other_err!("COM worker thread is gone"))?;
+
+        // Block until the COM thread processes the channel open
+        let accepted = accept_rx.recv().unwrap_or(false);
+
+        if accepted {
+            info!(
+                channel_name = %self.channel_name,
+                channel_id,
+                "COM plugin accepted DVC channel"
+            );
+        } else {
+            warn!(
+                channel_name = %self.channel_name,
+                channel_id,
+                "COM plugin rejected DVC channel"
+            );
+        }
+
+        Ok(vec![])
+    }
+
+    fn process(&mut self, channel_id: u32, payload: &[u8]) -> PduResult<Vec<DvcMessage>> {
+        self.command_tx
+            .send(ComCommand::DataReceived {
+                channel_id,
+                data: payload.to_vec(),
+            })
+            .map_err(|_| pdu_other_err!("COM worker thread is gone"))?;
+
+        Ok(vec![])
+    }
+
+    fn close(&mut self, channel_id: u32) {
+        debug!(
+            channel_name = %self.channel_name,
+            channel_id,
+            "DVC COM channel close"
+        );
+
+        let _ = self.command_tx.send(ComCommand::ChannelClosed { channel_id });
+    }
+}
+
+impl DvcClientProcessor for DvcComChannel {}
+
+impl Drop for DvcComChannel {
+    fn drop(&mut self) {
+        // Send shutdown to the COM worker thread
+        let _ = self.command_tx.send(ComCommand::Shutdown);
+        // Don't join — the worker will clean up asynchronously
+    }
+}
+
+/// Callback type matching the pipe proxy pattern: called when the plugin writes outbound DVC data.
+pub(crate) type OnWriteDvcMessage = Box<dyn Fn(u32, Vec<SvcMessage>) -> PduResult<()> + Send + 'static>;
+
+/// Load a DVC client plugin DLL and return channels for each listener the plugin registers.
+///
+/// # Arguments
+///
+/// * `dll_path` — Path to the DVC plugin DLL (e.g. `C:\Windows\System32\webauthn.dll`)
+/// * `on_write_dvc` — Factory function that creates a write callback for each channel.
+///   The callback is invoked when the plugin calls `IWTSVirtualChannel::Write()`,
+///   sending the encoded DVC messages back into IronRDP's session event loop.
+///
+/// # Returns
+///
+/// A `Vec<DvcComChannel>`, one per listener the plugin registered during `Initialize`.
+/// These should be added to a `DrdynvcClient` via `with_dynamic_channel()`.
+///
+/// # Panics
+///
+/// Panics if the COM worker thread cannot be spawned.
+pub fn load_dvc_plugin<F>(dll_path: &Path, on_write_dvc_factory: F) -> PduResult<Vec<DvcComChannel>>
+where
+    F: Fn() -> OnWriteDvcMessage + Send + Sync + 'static,
+{
+    info!(dll = %dll_path.display(), "Loading DVC COM plugin");
+
+    // Channel for sending commands to the COM worker thread
+    let (command_tx, command_rx) = std_mpsc::channel();
+
+    // Channel for sending write callbacks to the COM worker thread
+    let (on_write_dvc_tx, on_write_dvc_rx) = std_mpsc::channel();
+
+    // Channel for receiving the list of registered listeners back from the COM thread
+    let (init_tx, init_rx) = std_mpsc::sync_channel::<Result<Vec<String>, String>>(1);
+
+    let dll_path_owned = dll_path.to_path_buf();
+    let _on_write_dvc_tx_clone = on_write_dvc_tx.clone();
+
+    let _worker_handle = thread::Builder::new()
+        .name("dvc-com-worker".into())
+        .spawn(move || {
+            // Load and initialize on the COM thread
+            match initialize_plugin_on_thread(&dll_path_owned) {
+                Ok((plugin, manager, listeners)) => {
+                    let channel_names: Vec<String> = listeners.keys().cloned().collect();
+                    info!(
+                        channels = ?channel_names,
+                        "Plugin initialized, registered {} listener(s)",
+                        channel_names.len()
+                    );
+                    let _ = init_tx.send(Ok(channel_names));
+
+                    // Enter the command loop
+                    run_com_worker(plugin, manager, listeners, command_rx, on_write_dvc_rx);
+                }
+                Err(e) => {
+                    error!(error = %e, "Failed to initialize DVC COM plugin");
+                    let _ = init_tx.send(Err(e));
+                }
+            }
+        })
+        .expect("spawn COM worker thread");
+
+    // Wait for initialization to complete
+    let channel_names = init_rx
+        .recv()
+        .map_err(|_| pdu_other_err!("COM worker thread died during initialization"))?
+        .map_err(|e| pdu_other_err!("plugin initialization failed").with_source(std::io::Error::other(e)))?;
+
+    if channel_names.is_empty() {
+        warn!(dll = %dll_path.display(), "Plugin registered no listeners");
+    }
+
+    // Create a DvcComChannel for each registered listener
+    let mut channels = Vec::with_capacity(channel_names.len());
+    let is_first = Cell::new(true);
+    let factory: Arc<dyn Fn() -> OnWriteDvcMessage + Send + Sync> = Arc::new(on_write_dvc_factory);
+
+    for name in channel_names {
+        debug!(channel_name = %name, "Creating DvcComChannel");
+
+        channels.push(DvcComChannel {
+            channel_name: name,
+            command_tx: command_tx.clone(),
+            on_write_dvc_tx: on_write_dvc_tx.clone(),
+            on_write_dvc_factory: Arc::clone(&factory),
+            needs_connected: is_first.get(),
+            _worker_handle: None,
+        });
+        is_first.set(false);
+    }
+
+    Ok(channels)
+}
+
+/// Load the plugin DLL and call VirtualChannelGetInstance + Initialize on the COM thread.
+///
+/// Returns the plugin COM object, the channel manager interface, and
+/// the map of listener names → callbacks.
+fn initialize_plugin_on_thread(
+    dll_path: &Path,
+) -> Result<
+    (
+        IWTSPlugin,
+        IWTSVirtualChannelManager,
+        HashMap<String, IWTSListenerCallback>,
+    ),
+    String,
+> {
+    // Load the DLL
+    let dll_path_wide: Vec<u16> = dll_path.as_os_str().encode_wide().chain(core::iter::once(0)).collect();
+    let dll_path_pcwstr = PCWSTR(dll_path_wide.as_ptr());
+
+    // SAFETY: loading the DLL into this process
+    let hmodule = unsafe { LoadLibraryW(dll_path_pcwstr) }.map_err(|e| format!("LoadLibraryW failed: {e}"))?;
+
+    info!(dll = %dll_path.display(), "DLL loaded successfully");
+
+    // Get the VirtualChannelGetInstance export
+    let proc_name = PCSTR::from_raw(c"VirtualChannelGetInstance".as_ptr().cast::<u8>());
+
+    // SAFETY: hmodule is valid, proc_name is a null-terminated ASCII string
+    let proc_addr = unsafe { GetProcAddress(hmodule, proc_name) }
+        .ok_or_else(|| "VirtualChannelGetInstance export not found in DLL".to_owned())?;
+
+    // SAFETY: transmuting the function pointer; we trust the DLL follows the documented API
+    let get_instance: VirtualChannelGetInstanceFn = unsafe { core::mem::transmute(proc_addr) };
+
+    info!("VirtualChannelGetInstance export found");
+
+    // Phase 1: query the number of plugin objects
+    let iid = IWTSPlugin::IID;
+    let mut num_objs: u32 = 0;
+
+    // SAFETY: first call with null array to get count
+    let hr = unsafe { get_instance(&iid, &mut num_objs, core::ptr::null_mut()) };
+    if hr.is_err() {
+        return Err(format!(
+            "VirtualChannelGetInstance phase 1 failed: HRESULT 0x{:08X}",
+            hr.0
+        ));
+    }
+
+    info!(count = num_objs, "Plugin reports {} object(s)", num_objs);
+
+    if num_objs == 0 {
+        return Err("plugin returned 0 objects".to_owned());
+    }
+
+    // Phase 2: get the actual plugin objects
+    let mut obj_array: Vec<*mut c_void> =
+        vec![core::ptr::null_mut(); usize::try_from(num_objs).expect("u32 fits in usize")];
+
+    // SAFETY: second call with allocated array
+    let hr = unsafe { get_instance(&iid, &mut num_objs, obj_array.as_mut_ptr()) };
+    if hr.is_err() {
+        return Err(format!(
+            "VirtualChannelGetInstance phase 2 failed: HRESULT 0x{:08X}",
+            hr.0
+        ));
+    }
+
+    // Use the first plugin object
+    let plugin_ptr = obj_array[0];
+    if plugin_ptr.is_null() {
+        return Err("VirtualChannelGetInstance returned null plugin pointer".to_owned());
+    }
+
+    // SAFETY: the plugin pointer is a valid IWTSPlugin COM interface pointer
+    let plugin: IWTSPlugin = unsafe { IWTSPlugin::from_raw(plugin_ptr) };
+
+    info!("Got IWTSPlugin COM object");
+
+    // Create shared state for listeners: we keep an Rc clone so we can read the
+    // map after Initialize() without needing an unsafe cast from the COM pointer.
+    let listeners_rc = std::rc::Rc::new(core::cell::RefCell::new(HashMap::new()));
+    let channel_manager_impl = ChannelManager::new(std::rc::Rc::clone(&listeners_rc));
+    let manager: IWTSVirtualChannelManager = channel_manager_impl.into();
+
+    // SAFETY: calling IWTSPlugin::Initialize with our channel manager
+    unsafe { plugin.Initialize(&manager) }.map_err(|e| format!("IWTSPlugin::Initialize failed: {e}"))?;
+
+    info!("IWTSPlugin::Initialize succeeded");
+
+    // Read the listener map that the plugin populated during Initialize.
+    let listeners: HashMap<String, IWTSListenerCallback> = listeners_rc.borrow().clone();
+
+    Ok((plugin, manager, listeners))
+}

--- a/crates/ironrdp-dvc-com-plugin/src/com.rs
+++ b/crates/ironrdp-dvc-com-plugin/src/com.rs
@@ -1,0 +1,185 @@
+//! COM interface implementations for the DVC plugin bridge.
+//!
+//! We implement the "RDC client framework" side of the DVC plugin API:
+//! - [`ChannelManager`] implements `IWTSVirtualChannelManager` (provides `CreateListener`)
+//! - [`VirtualChannel`] implements `IWTSVirtualChannel` (provides `Write` / `Close`)
+//! - [`Listener`] implements `IWTSListener` (stub `GetConfiguration`)
+//!
+//! The plugin DLL implements the other side:
+//! - `IWTSPlugin` (lifecycle)
+//! - `IWTSListenerCallback` (accept incoming channels)
+//! - `IWTSVirtualChannelCallback` (receive data, close notifications)
+
+use core::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use ironrdp_dvc::encode_dvc_messages;
+use ironrdp_svc::{ChannelFlags, SvcMessage};
+use tracing::{debug, trace};
+use windows::core::{Error, IUnknown, Ref, Result, PCSTR};
+use windows::Win32::Foundation::{E_FAIL, E_INVALIDARG, E_NOTIMPL};
+use windows::Win32::System::Com::StructuredStorage::IPropertyBag;
+use windows::Win32::System::RemoteDesktop::{
+    IWTSListener, IWTSListenerCallback, IWTSListener_Impl, IWTSVirtualChannel, IWTSVirtualChannelCallback,
+    IWTSVirtualChannelManager, IWTSVirtualChannelManager_Impl, IWTSVirtualChannel_Impl,
+};
+use windows_core::implement;
+
+/// Callback type for sending DVC messages from the COM plugin back into IronRDP's session loop.
+pub(crate) type OnWriteDvc = Box<dyn Fn(u32, Vec<SvcMessage>) -> ironrdp_pdu::PduResult<()> + Send>;
+
+// ─── IWTSVirtualChannelManager ──────────────────────────────────────────────
+
+/// Rust implementation of `IWTSVirtualChannelManager`.
+///
+/// The plugin calls `CreateListener` during `IWTSPlugin::Initialize` to register
+/// interest in named DVC channels. We store the channel name → listener callback
+/// mapping so the worker can later dispatch `OnNewChannelConnection` when the
+/// server opens a matching DVC.
+#[implement(IWTSVirtualChannelManager)]
+pub(crate) struct ChannelManager {
+    /// channel_name → IWTSListenerCallback provided by the plugin.
+    /// Shared via `Rc` so the caller can read the map after `Initialize` completes
+    /// without needing an unsafe cast from the COM interface pointer.
+    pub(crate) listeners: Rc<RefCell<HashMap<String, IWTSListenerCallback>>>,
+}
+
+impl ChannelManager {
+    pub(crate) fn new(listeners: Rc<RefCell<HashMap<String, IWTSListenerCallback>>>) -> Self {
+        Self { listeners }
+    }
+}
+
+impl IWTSVirtualChannelManager_Impl for ChannelManager_Impl {
+    fn CreateListener(
+        &self,
+        pszchannelname: &PCSTR,
+        uflags: u32,
+        plistenercallback: Ref<'_, IWTSListenerCallback>,
+    ) -> Result<IWTSListener> {
+        // SAFETY: pszchannelname is a null-terminated C string from the plugin
+        let name = unsafe { pszchannelname.to_string() }
+            .map_err(|e| Error::new(E_INVALIDARG, format!("invalid channel name: {e}")))?;
+
+        debug!(channel_name = %name, flags = uflags, "Plugin registered DVC listener");
+
+        let callback: IWTSListenerCallback = plistenercallback
+            .ok()
+            .map_err(|_| Error::new(E_INVALIDARG, "null listener callback"))?
+            .clone();
+        self.listeners.borrow_mut().insert(name.clone(), callback);
+
+        let listener: IWTSListener = Listener { channel_name: name }.into();
+
+        Ok(listener)
+    }
+}
+
+// ─── IWTSListener ───────────────────────────────────────────────────────────
+
+/// Stub `IWTSListener` implementation. Most plugins don't use `GetConfiguration`.
+#[implement(IWTSListener)]
+struct Listener {
+    channel_name: String,
+}
+
+impl IWTSListener_Impl for Listener_Impl {
+    fn GetConfiguration(&self) -> Result<IPropertyBag> {
+        trace!(channel = %self.channel_name, "IWTSListener::GetConfiguration called (not implemented)");
+        Err(Error::new(E_NOTIMPL, "GetConfiguration not implemented"))
+    }
+}
+
+// ─── IWTSVirtualChannel ─────────────────────────────────────────────────────
+
+/// Rust implementation of `IWTSVirtualChannel`.
+///
+/// When the plugin calls `Write()`, we encode the raw bytes as DVC data PDUs
+/// and send them into IronRDP's session loop via the `on_write_dvc` callback.
+#[implement(IWTSVirtualChannel)]
+pub(crate) struct VirtualChannel {
+    channel_id: u32,
+    on_write_dvc: OnWriteDvc,
+    closed: RefCell<bool>,
+}
+
+impl VirtualChannel {
+    pub(crate) fn new(channel_id: u32, on_write_dvc: OnWriteDvc) -> Self {
+        Self {
+            channel_id,
+            on_write_dvc,
+            closed: RefCell::new(false),
+        }
+    }
+}
+
+/// A trivial DvcEncode wrapper for raw bytes going from the plugin to the server.
+struct RawDvcData(Vec<u8>);
+
+impl ironrdp_core::Encode for RawDvcData {
+    fn encode(&self, dst: &mut ironrdp_core::WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
+        dst.write_slice(&self.0);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "RawDvcData"
+    }
+
+    fn size(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl ironrdp_dvc::DvcEncode for RawDvcData {}
+
+impl IWTSVirtualChannel_Impl for VirtualChannel_Impl {
+    fn Write(&self, cbsize: u32, pbuffer: *const u8, _preserved: Ref<'_, IUnknown>) -> Result<()> {
+        if *self.closed.borrow() {
+            return Err(Error::new(E_FAIL, "channel is closed"));
+        }
+
+        let size = usize::try_from(cbsize).expect("u32 fits in usize");
+        if pbuffer.is_null() && size > 0 {
+            return Err(Error::new(E_INVALIDARG, "null buffer"));
+        }
+
+        // SAFETY: the plugin guarantees the buffer is valid for the duration of Write()
+        let data = if size > 0 {
+            unsafe { core::slice::from_raw_parts(pbuffer, size) }.to_vec()
+        } else {
+            Vec::new()
+        };
+
+        trace!(
+            channel_id = self.channel_id,
+            size = data.len(),
+            "IWTSVirtualChannel::Write"
+        );
+
+        let msg: ironrdp_dvc::DvcMessage = Box::new(RawDvcData(data));
+        let svc_messages = encode_dvc_messages(self.channel_id, vec![msg], ChannelFlags::empty())
+            .map_err(|e| Error::new(E_FAIL, format!("encode error: {e}")))?;
+
+        (self.on_write_dvc)(self.channel_id, svc_messages)
+            .map_err(|e| Error::new(E_FAIL, format!("send error: {e}")))?;
+
+        Ok(())
+    }
+
+    fn Close(&self) -> Result<()> {
+        debug!(channel_id = self.channel_id, "IWTSVirtualChannel::Close");
+        *self.closed.borrow_mut() = true;
+        Ok(())
+    }
+}
+
+// ─── Active channel state ───────────────────────────────────────────────────
+
+/// Per-channel state held on the COM thread. Tracks the COM objects for a single
+/// open DVC channel so we can forward data from IronRDP → plugin.
+pub(crate) struct ActiveChannel {
+    pub(crate) callback: IWTSVirtualChannelCallback,
+    pub(crate) _channel: IWTSVirtualChannel,
+}

--- a/crates/ironrdp-dvc-com-plugin/src/lib.rs
+++ b/crates/ironrdp-dvc-com-plugin/src/lib.rs
@@ -1,0 +1,38 @@
+//! DVC COM client plugin loader for IronRDP (Windows-only).
+//!
+//! This crate enables loading native Windows DVC (Dynamic Virtual Channel) client plugin DLLs
+//! such as `webauthn.dll` into IronRDP's DVC channel infrastructure.
+//!
+//! The plugin DLL is loaded via `LoadLibraryW`, its `VirtualChannelGetInstance` export is called
+//! to obtain `IWTSPlugin` COM objects, and a Rust implementation of `IWTSVirtualChannelManager`
+//! bridges data bidirectionally between the plugin's COM callbacks and IronRDP's DVC system.
+//!
+//! # Architecture
+//!
+//! A dedicated COM worker thread owns all COM objects (which are `!Send`). The [`DvcComChannel`]
+//! structs (which implement `DvcProcessor + Send`) are registered as DVC channels in IronRDP's
+//! `DrdynvcClient` and communicate with the COM thread via `std::sync::mpsc` channels.
+//!
+//! Outbound data from the plugin (`IWTSVirtualChannel::Write`) is injected into the active
+//! session loop via the `on_write_dvc` callback, following the same pattern as
+//! `ironrdp-dvc-pipe-proxy`.
+//!
+//! # References
+//!
+//! - [Writing a Client DVC Component](https://learn.microsoft.com/en-us/windows/win32/termserv/writing-a-client-dvc-component)
+//! - [tsvirtualchannels.h](https://learn.microsoft.com/en-us/windows/win32/api/tsvirtualchannels/)
+
+#![cfg(windows)]
+// The `windows` crate's `#[implement]` macro generates code that triggers these lints.
+// We must allow them crate-wide since the generated code is not under our control.
+#![allow(clippy::inline_always)]
+#![allow(clippy::as_pointer_underscore)]
+#![allow(clippy::multiple_unsafe_ops_per_block)]
+#![allow(clippy::undocumented_unsafe_blocks)]
+#![allow(clippy::unnecessary_safety_comment)]
+
+mod channel;
+mod com;
+mod worker;
+
+pub use channel::{load_dvc_plugin, DvcComChannel};

--- a/crates/ironrdp-dvc-com-plugin/src/worker.rs
+++ b/crates/ironrdp-dvc-com-plugin/src/worker.rs
@@ -1,0 +1,220 @@
+//! COM worker thread that drives the plugin lifecycle.
+//!
+//! All COM objects live on this single thread. Communication with the
+//! [`DvcComChannel`](crate::channel::DvcComChannel) instances (which live on
+//! IronRDP's async runtime threads) happens via `std::sync::mpsc` channels.
+
+use std::collections::HashMap;
+use std::sync::mpsc as std_mpsc;
+
+use tracing::{debug, error, info, trace, warn};
+use windows::Win32::System::RemoteDesktop::{
+    IWTSListenerCallback, IWTSPlugin, IWTSVirtualChannel, IWTSVirtualChannelCallback, IWTSVirtualChannelManager,
+};
+use windows_core::{BOOL, BSTR};
+
+use crate::com::{ActiveChannel, OnWriteDvc, VirtualChannel};
+
+/// Commands sent from [`DvcComChannel`] to the COM worker thread.
+pub(crate) enum ComCommand {
+    /// The server created a DVC matching one of our listeners.
+    /// The COM worker should call `OnNewChannelConnection` on the plugin's listener callback.
+    ChannelOpened {
+        channel_name: String,
+        channel_id: u32,
+        /// Reply channel: send `true` if the plugin accepted the channel.
+        accept_tx: std_mpsc::SyncSender<bool>,
+    },
+
+    /// Data arrived from the RDP server for this channel.
+    DataReceived { channel_id: u32, data: Vec<u8> },
+
+    /// The server (or IronRDP) closed this channel.
+    ChannelClosed { channel_id: u32 },
+
+    /// The RDP connection is established; notify the plugin.
+    Connected,
+
+    /// The session is ending; tell the plugin to clean up.
+    Shutdown,
+}
+
+/// Run the COM worker loop on the current thread.
+///
+/// This function blocks until a `Shutdown` command is received. It must be called
+/// on a dedicated thread since COM objects are `!Send`.
+pub(crate) fn run_com_worker(
+    plugin: IWTSPlugin,
+    _manager: IWTSVirtualChannelManager,
+    listeners: HashMap<String, IWTSListenerCallback>,
+    command_rx: std_mpsc::Receiver<ComCommand>,
+    on_write_dvc_rx: std_mpsc::Receiver<OnWriteDvc>,
+) {
+    info!("COM worker thread started");
+
+    let mut active_channels: HashMap<u32, ActiveChannel> = HashMap::new();
+
+    loop {
+        let cmd = match command_rx.recv() {
+            Ok(cmd) => cmd,
+            Err(_) => {
+                debug!("Command channel closed, shutting down COM worker");
+                break;
+            }
+        };
+
+        match cmd {
+            ComCommand::Connected => {
+                debug!("Notifying plugin: Connected");
+                // SAFETY: calling COM method on the thread that owns the objects
+                let result = unsafe { plugin.Connected() };
+                if let Err(e) = result {
+                    // Per the spec, Connected() failure is non-fatal
+                    warn!("IWTSPlugin::Connected returned error (non-fatal): {e}");
+                }
+            }
+
+            ComCommand::ChannelOpened {
+                channel_name,
+                channel_id,
+                accept_tx,
+            } => {
+                debug!(channel_name = %channel_name, channel_id, "Opening DVC channel via COM plugin");
+
+                let listener_callback = match listeners.get(&channel_name) {
+                    Some(cb) => cb,
+                    None => {
+                        warn!(channel_name = %channel_name, "No listener registered for channel");
+                        let _ = accept_tx.send(false);
+                        continue;
+                    }
+                };
+
+                // Create the IWTSVirtualChannel that the plugin will use to Write() data
+                //
+                // We need to clone the on_write_dvc callback. Since it's boxed, we need
+                // to receive a new one for each channel. But for simplicity, we'll wrap
+                // the callback in an Arc-based approach.
+                //
+                // Actually, the write callback just sends to an mpsc channel, so we
+                // receive a fresh one for each channel that needs it.
+                let on_write: OnWriteDvc = match on_write_dvc_rx.try_recv() {
+                    Ok(cb) => cb,
+                    Err(_) => {
+                        // Reuse the primary one by having the caller send a fresh one
+                        // For the first channel, we already got it above. For subsequent channels
+                        // we need a fresh callback. The caller sends one per ChannelOpened.
+                        // If we can't get one, something went wrong.
+                        error!("No write callback for channel {channel_name}");
+                        let _ = accept_tx.send(false);
+                        continue;
+                    }
+                };
+
+                let virtual_channel: IWTSVirtualChannel = VirtualChannel::new(channel_id, on_write).into();
+
+                let mut accept = BOOL::default();
+                let mut channel_callback: Option<IWTSVirtualChannelCallback> = None;
+
+                // SAFETY: calling COM method on the owner thread; pointers are valid for the call duration
+                let result = unsafe {
+                    listener_callback.OnNewChannelConnection(
+                        &virtual_channel,
+                        &BSTR::default(),
+                        &mut accept,
+                        &mut channel_callback,
+                    )
+                };
+
+                match result {
+                    Ok(()) if accept.as_bool() => {
+                        if let Some(callback) = channel_callback {
+                            info!(channel_name = %channel_name, channel_id, "Plugin accepted DVC channel");
+                            active_channels.insert(
+                                channel_id,
+                                ActiveChannel {
+                                    callback,
+                                    _channel: virtual_channel,
+                                },
+                            );
+                            let _ = accept_tx.send(true);
+                        } else {
+                            warn!(
+                                channel_name = %channel_name, channel_id,
+                                "Plugin accepted channel but returned no callback"
+                            );
+                            let _ = accept_tx.send(false);
+                        }
+                    }
+                    Ok(()) => {
+                        debug!(channel_name = %channel_name, channel_id, "Plugin rejected DVC channel");
+                        let _ = accept_tx.send(false);
+                    }
+                    Err(e) => {
+                        warn!(
+                            channel_name = %channel_name, channel_id,
+                            "OnNewChannelConnection failed: {e}"
+                        );
+                        let _ = accept_tx.send(false);
+                    }
+                }
+            }
+
+            ComCommand::DataReceived { channel_id, data } => {
+                trace!(channel_id, size = data.len(), "Forwarding data to COM plugin");
+
+                if let Some(active) = active_channels.get(&channel_id) {
+                    // SAFETY: calling COM method on the owner thread; buffer is valid for the call
+                    let result = unsafe { active.callback.OnDataReceived(&data) };
+                    if let Err(e) = result {
+                        warn!(channel_id, "OnDataReceived failed: {e}");
+                    }
+                } else {
+                    warn!(channel_id, "Data received for unknown channel");
+                }
+            }
+
+            ComCommand::ChannelClosed { channel_id } => {
+                debug!(channel_id, "Closing DVC channel in COM plugin");
+
+                if let Some(active) = active_channels.remove(&channel_id) {
+                    // SAFETY: calling COM method on the owner thread
+                    let result = unsafe { active.callback.OnClose() };
+                    if let Err(e) = result {
+                        warn!(channel_id, "OnClose failed: {e}");
+                    }
+                }
+            }
+
+            ComCommand::Shutdown => {
+                info!("Shutting down COM plugin");
+
+                // Close all active channels
+                for (channel_id, active) in active_channels.drain() {
+                    // SAFETY: calling COM method on the owner thread
+                    let result = unsafe { active.callback.OnClose() };
+                    if let Err(e) = result {
+                        warn!(channel_id, "OnClose during shutdown failed: {e}");
+                    }
+                }
+
+                // SAFETY: calling COM methods on the owner thread
+                unsafe {
+                    let result = plugin.Disconnected(0);
+                    if let Err(e) = result {
+                        warn!("IWTSPlugin::Disconnected failed: {e}");
+                    }
+
+                    let result = plugin.Terminated();
+                    if let Err(e) = result {
+                        warn!("IWTSPlugin::Terminated failed: {e}");
+                    }
+                }
+
+                break;
+            }
+        }
+    }
+
+    info!("COM worker thread exiting");
+}


### PR DESCRIPTION
Implements support for loading and using native Windows Dynamic Virtual
Channel (DVC) client plugin DLLs through the COM-based IWTSPlugin API.
This enables IronRDP to leverage existing Windows DVC plugins such as
webauthn.dll for hardware security key support via RDP.

New crate: ironrdp-dvc-com-plugin
- Implements IWTSVirtualChannelManager and IWTSVirtualChannel COM interfaces
- Manages plugin lifecycle on dedicated COM worker thread
- Handles channel open/close/reopen cycles with per-instance write callbacks
- Properly bridges between COM synchronous calls and IronRDP's async runtime

Client integration:
- Add --dvc-plugin CLI argument to ironrdp-client
- Load plugins in both TCP and WebSocket connection paths
- Windows-only conditional compilation for cross-platform builds

Additional fixes:
- Fix pre-existing crash in ironrdp-tokio KDC handler on 64-bit Windows
  (usize to u32 conversion in reqwest.rs)
- Add proper error handling using try_from instead of unsafe as casts
- All changes pass cargo fmt and cargo clippy with strict pedantic lints

Tested with: C:\Windows\System32\webauthn.dll



https://github.com/user-attachments/assets/b92fe825-b6e5-4825-aac8-40e36b9b0def

