### PR TITLE
feat(connector): add alternate_shell and work_dir configuration support

### DIFF
--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -514,6 +514,8 @@ impl Config {
             compression_type,
             performance_flags: PerformanceFlags::default(),
             timezone_info: TimezoneInfo::default(),
+            alternate_shell: String::new(),
+            work_dir: String::new(),
         };
 
         let rdcleanpath = args

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -787,8 +787,8 @@ fn create_client_info_pdu(config: &Config, client_addr: &SocketAddr) -> rdp::Cli
         code_page: 0, // ignored if the keyboardLayout field of the Client Core Data is set to zero
         flags,
         compression_type,
-        alternate_shell: String::new(),
-        work_dir: String::new(),
+        alternate_shell: config.alternate_shell.clone(),
+        work_dir: config.work_dir.clone(),
         extra_info: ExtendedClientInfo {
             address_family: match client_addr {
                 SocketAddr::V4(_) => AddressFamily::INET,

--- a/crates/ironrdp-connector/src/lib.rs
+++ b/crates/ironrdp-connector/src/lib.rs
@@ -209,6 +209,12 @@ pub struct Config {
     pub bitmap: Option<BitmapConfig>,
     pub dig_product_id: String,
     pub client_dir: String,
+    /// Alternate shell to execute on the remote server (e.g., specific application instead of desktop)
+    ///
+    /// Used by CyberArk PSM for privileged session tokens and remote application scenarios.
+    pub alternate_shell: String,
+    /// Working directory for the alternate shell
+    pub work_dir: String,
     pub platform: capability_sets::MajorPlatformType,
     /// Unique identifier for the computer
     ///

--- a/crates/ironrdp-testsuite-extra/tests/mod.rs
+++ b/crates/ironrdp-testsuite-extra/tests/mod.rs
@@ -308,5 +308,7 @@ fn default_client_config() -> connector::Config {
         pointer_software_rendering: true,
         performance_flags: Default::default(),
         timezone_info: Default::default(),
+        alternate_shell: String::new(),
+        work_dir: String::new(),
     }
 }

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -911,6 +911,8 @@ fn build_config(
         hardware_id: None,
         license_cache: None,
         timezone_info: TimezoneInfo::default(),
+        alternate_shell: String::new(),
+        work_dir: String::new(),
     }
 }
 

--- a/crates/ironrdp/examples/screenshot.rs
+++ b/crates/ironrdp/examples/screenshot.rs
@@ -269,6 +269,8 @@ fn build_config(
         hardware_id: None,
         license_cache: None,
         timezone_info: TimezoneInfo::default(),
+        alternate_shell: String::new(),
+        work_dir: String::new(),
     })
 }
 

--- a/ffi/src/connector/config.rs
+++ b/ffi/src/connector/config.rs
@@ -220,6 +220,8 @@ pub mod ffi {
                 hardware_id: None,
                 license_cache: None,
                 timezone_info: self.timezone_info.clone().unwrap_or_default(),
+                alternate_shell: String::new(),
+                work_dir: String::new(),
             };
             let dvc_pipe_proxy = self.dvc_pipe_proxy.clone();
 


### PR DESCRIPTION
Add support for configuring `alternate_shell` and `work_dir` fields in ClientInfoPdu, which are used by:
  - CyberArk PSM (Privileged Session Manager) for session tokens
  - Remote application scenarios (RemoteApp)
  - Custom shell configurations

Changes:
  - Add `alternate_shell` and `work_dir` fields to `Config` struct
  - Use these fields in `create_client_info_pdu()` instead of hardcoded empty strings

This enables compatibility with enterprise security solutions like CyberArk that require alternate_shell for privileged access management.