### PR TITLE
feat(zgfx): add LZ77 compression support

### DIFF
--- a/crates/ironrdp-graphics/src/zgfx/mod.rs
+++ b/crates/ironrdp-graphics/src/zgfx/mod.rs
@@ -23,7 +23,8 @@ use self::circular_buffer::FixedCircularBuffer;
 use self::control_messages::{BulkEncodedData, CompressionFlags, SegmentedDataPdu};
 use crate::utils::Bits;
 
-const HISTORY_SIZE: usize = 2_500_000;
+/// Sliding window size shared by compressor and decompressor.
+pub(crate) const HISTORY_SIZE: usize = 2_500_000;
 
 pub struct Decompressor {
     history: FixedCircularBuffer,

--- a/crates/ironrdp-graphics/src/zgfx/wrapper.rs
+++ b/crates/ironrdp-graphics/src/zgfx/wrapper.rs
@@ -44,7 +44,7 @@ const ZGFX_PACKET_COMPR_TYPE_RDP8: u8 = 0x04;
 const ZGFX_PACKET_COMPRESSED: u8 = 0x02;
 
 /// Maximum size for a single ZGFX segment (65535 bytes)
-const ZGFX_SEGMENTED_MAXSIZE: usize = 65535;
+pub(crate) const ZGFX_SEGMENTED_MAXSIZE: usize = 65535;
 
 /// Wrap data in ZGFX segment structure (uncompressed)
 ///


### PR DESCRIPTION
Adds ZGFX (RDP8) LZ77 compression to complement the existing decompressor, plus a high-level API for EGFX PDU preparation with auto/always/never mode selection.

The compressor uses a hash table mapping 3-byte prefixes to history positions for O(1) match candidate lookup against the 2.5 MB sliding window.

Depends on #1076 (segment wrapping utilities).