### PR TITLE
feat(connector)!: implement multitransport bootstrapping handshake

### DIFF
--- a/crates/ironrdp-async/src/connector.rs
+++ b/crates/ironrdp-async/src/connector.rs
@@ -78,6 +78,24 @@ where
     }
 
     let result = loop {
+        if connector.should_perform_multitransport() {
+            // Auto-skip multitransport bootstrapping: this driver does not own
+            // UDP transport setup, so it declines on the application's behalf
+            // and the connection continues TCP-only. Applications that want to
+            // participate in multitransport must drive the connector directly
+            // using `ClientConnector::complete_multitransport()` instead of
+            // calling `connect_finalize`.
+            buf.clear();
+            let written = connector.skip_multitransport(&mut buf)?;
+            if written.size().is_some() {
+                framed
+                    .write_all(buf.filled())
+                    .await
+                    .map_err(|e| ironrdp_connector::custom_err!("write all", e))?;
+            }
+            continue;
+        }
+
         single_sequence_step(framed, &mut connector, &mut buf).await?;
 
         if let ClientConnectorState::Connected { result } = connector.state {

--- a/crates/ironrdp-blocking/src/connector.rs
+++ b/crates/ironrdp-blocking/src/connector.rs
@@ -82,6 +82,23 @@ where
     debug!("Remaining of connection sequence");
 
     let result = loop {
+        if connector.should_perform_multitransport() {
+            // Auto-skip multitransport bootstrapping: this driver does not own
+            // UDP transport setup, so it declines on the application's behalf
+            // and the connection continues TCP-only. Applications that want to
+            // participate in multitransport must drive the connector directly
+            // using `ClientConnector::complete_multitransport()` instead of
+            // calling `connect_finalize`.
+            buf.clear();
+            let written = connector.skip_multitransport(&mut buf)?;
+            if written.size().is_some() {
+                framed
+                    .write_all(buf.filled())
+                    .map_err(|e| ironrdp_connector::custom_err!("write all", e))?;
+            }
+            continue;
+        }
+
         single_sequence_step(framed, &mut connector, &mut buf)?;
 
         if let ClientConnectorState::Connected { result } = connector.state {

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -19,6 +19,11 @@ use crate::{
     NegotiationFailure, Sequence, State, Written, encode_x224_packet, general_err, reason_err,
 };
 
+/// Maximum number of `Initiate Multitransport Request` PDUs the server is
+/// permitted to send during bootstrapping, per MS-RDPBCGR 2.2.15.1 (one per
+/// transport protocol: reliable + lossy UDP).
+const MAX_MULTITRANSPORT_REQUESTS: usize = 2;
+
 /// Outcome of a single multitransport bootstrapping request, passed to
 /// [`ClientConnector::complete_multitransport()`].
 ///
@@ -418,7 +423,7 @@ fn advance_licensing_exchange(
         ClientConnectorState::MultitransportBootstrapping {
             io_channel_id,
             user_channel_id,
-            requests: Vec::new(),
+            requests: Vec::with_capacity(MAX_MULTITRANSPORT_REQUESTS),
         }
     } else {
         ClientConnectorState::LicensingExchange {
@@ -832,10 +837,10 @@ impl Sequence for ClientConnector {
             //== Optional Multitransport Bootstrapping ==//
             //
             // The server may send 0, 1, or 2 Initiate Multitransport Request PDUs
-            // after licensing. We distinguish them from the Demand Active PDU by
-            // attempting to decode as MultitransportRequestPdu first — it has a
-            // distinctive structure (SEC_TRANSPORT_REQ flag + request_id + protocol
-            // + cookie). If decode fails, this is the Demand Active.
+            // after licensing (MS-RDPBCGR 2.2.15.1). We distinguish them from the
+            // Demand Active PDU by attempting to decode as MultitransportRequestPdu
+            // first; the decoder validates SEC_TRANSPORT_REQ internally, so a Demand
+            // Active PDU fails cleanly without false positives.
             ClientConnectorState::MultitransportBootstrapping {
                 io_channel_id,
                 user_channel_id,
@@ -843,11 +848,17 @@ impl Sequence for ClientConnector {
             } => {
                 let ctx = mcs::decode_send_data_indication(input).map_err(ConnectorError::decode)?;
 
-                // Try decoding as a multitransport request. The decoder validates
-                // the SEC_TRANSPORT_REQ flag, so a Demand Active PDU will fail
-                // cleanly without false positives.
                 match decode::<rdp::multitransport::MultitransportRequestPdu>(ctx.user_data) {
                     Ok(pdu) => {
+                        if requests.len() >= MAX_MULTITRANSPORT_REQUESTS {
+                            return Err(reason_err!(
+                                "MultitransportBootstrapping",
+                                "server sent more than {} multitransport requests (MS-RDPBCGR 2.2.15.1 caps the count at {})",
+                                MAX_MULTITRANSPORT_REQUESTS,
+                                MAX_MULTITRANSPORT_REQUESTS,
+                            ));
+                        }
+
                         debug!(
                             request_id = pdu.request_id,
                             protocol = ?pdu.requested_protocol,

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -7,7 +7,7 @@ use ironrdp_core::{Encode, WriteBuf, decode, encode_vec};
 use ironrdp_pdu::x224::X224;
 use ironrdp_pdu::{PduHint, gcc, mcs, nego, rdp};
 use ironrdp_svc::{StaticChannelSet, StaticVirtualChannel, SvcClientProcessor};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info};
 
 use crate::channel_connection::{ChannelConnectionSequence, ChannelConnectionState};
 use crate::connection_activation::{
@@ -27,8 +27,10 @@ const MAX_MULTITRANSPORT_REQUESTS: usize = 2;
 /// Outcome of a single multitransport bootstrapping request, passed to
 /// [`ClientConnector::complete_multitransport()`].
 ///
-/// The connector uses this to build the response PDU internally, paired with
-/// the request ID and cookie from the server's original request.
+/// The connector uses this to build the response PDU internally, carrying the
+/// request ID from the server's original request. The request's 16-byte
+/// security cookie is not echoed here: it binds the UDP transport itself, not
+/// the main-channel response.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MultitransportResult {
     /// UDP transport was established successfully (`S_OK`).
@@ -109,27 +111,37 @@ pub enum ClientConnectorState {
         user_channel_id: u16,
         license_exchange: LicenseExchangeSequence,
     },
-    /// Reading the server's optional Initiate Multitransport Request PDU(s).
+    /// Waiting for either an Initiate Multitransport Request or the Demand
+    /// Active that ends the optional bootstrapping phase.
     ///
-    /// The server may send 0, 1, or 2 requests (one per transport protocol).
-    /// If the first PDU on the IO channel after licensing is a Demand Active
-    /// (capabilities exchange), the server sent no multitransport requests and
-    /// the connector transitions directly to `CapabilitiesExchange`.
+    /// The server may send 0, 1, or 2 requests, and there is no end marker for
+    /// the set: it is not obliged to send Demand Active before the client acts
+    /// on a request it has already sent. So each request is surfaced to the
+    /// caller the moment it decodes, and the connector comes back here for the
+    /// next PDU rather than trying to collect a batch it cannot know the size
+    /// of. A PDU on the I/O channel is the Demand Active and ends the phase.
     MultitransportBootstrapping {
         io_channel_id: u16,
         user_channel_id: u16,
-        /// Multitransport requests received from the server so far.
-        requests: Vec<rdp::multitransport::MultitransportRequestPdu>,
+        /// MCS message channel negotiated during GCC, when the server offered
+        /// one. Multitransport travels on it in both directions per
+        /// MS-RDPBCGR 2.2.15.1 and 2.2.15.2, so it is both the channel inbound
+        /// requests arrive on and the channel responses go out on. `None` means
+        /// the server never offered one, in which case no request can be valid.
+        message_channel_id: Option<u16>,
+        /// How many requests have been surfaced so far, to enforce the cap in
+        /// MS-RDPBCGR 2.2.15.1 now that they are handled one at a time.
+        requests_seen: usize,
     },
-    /// State the connector enters after the server has sent multitransport
-    /// request(s) and before resuming with the Demand Active PDU. The
-    /// connector surfaces this as an API yield point so the caller can run
-    /// UDP transport setup and report the outcome.
+    /// A single Initiate Multitransport Request has been surfaced and the
+    /// connector is waiting for the caller to establish that UDP transport
+    /// (RDPEUDP2 + TLS + RDPEMT) or decline it.
     ///
     /// Call [`ClientConnector::complete_multitransport()`] or
-    /// [`ClientConnector::skip_multitransport()`] to advance. The buffered
-    /// Demand Active PDU is replayed internally on resume; the caller does
-    /// not need to re-feed it.
+    /// [`ClientConnector::skip_multitransport()`] to advance. Either returns
+    /// the connector to [`Self::MultitransportBootstrapping`] to read whatever
+    /// the server sends next, which may be a second request or the Demand
+    /// Active.
     ///
     /// On the wire, TCP and UDP negotiation happen in parallel: the UDP
     /// transport is established alongside the ongoing TCP handshake, and
@@ -139,11 +151,18 @@ pub enum ClientConnectorState {
     MultitransportPending {
         io_channel_id: u16,
         user_channel_id: u16,
-        requests: Vec<rdp::multitransport::MultitransportRequestPdu>,
-        /// The raw Demand Active PDU bytes that arrived after the last
-        /// multitransport request. Replayed through the activation sequence
-        /// when the application completes or skips multitransport.
-        buffered_demand_active: Vec<u8>,
+        /// MCS message channel the Initiate Multitransport Response must go out
+        /// on; see the same field on [`Self::MultitransportBootstrapping`].
+        message_channel_id: Option<u16>,
+        /// The request awaiting the caller's outcome.
+        request: rdp::multitransport::MultitransportRequestPdu,
+        /// Carried through so the cap survives the round trip through the
+        /// caller.
+        requests_seen: usize,
+        /// Whether both peers advertised Soft-Sync, captured when this state was
+        /// entered. Decides whether the completion and skip paths may emit an
+        /// Initiate Multitransport Response at all.
+        soft_sync: bool,
     },
     CapabilitiesExchange {
         connection_activation: ConnectionActivationSequence,
@@ -200,6 +219,11 @@ pub struct ClientConnector {
     pub static_channels: StaticChannelSet,
     /// MCS message channel ID assigned by the server, once negotiated.
     pub message_channel_id: Option<u16>,
+    /// Multitransport flags the server advertised in its GCC
+    /// `MultiTransportChannelData` block, if it sent one. Retained because the
+    /// Initiate Multitransport Response is only permitted once both peers have
+    /// advertised Soft-Sync; see [`Self::soft_sync_negotiated`].
+    pub server_multitransport_flags: Option<gcc::MultiTransportFlags>,
 }
 
 impl ClientConnector {
@@ -210,7 +234,26 @@ impl ClientConnector {
             client_addr,
             static_channels: StaticChannelSet::new(),
             message_channel_id: None,
+            server_multitransport_flags: None,
         }
+    }
+
+    /// Whether Soft-Sync (`SOFTSYNC_TCP_TO_UDP`) was mutually advertised.
+    ///
+    /// Per [\[MS-RDPBCGR\] 2.2.15.2] the Initiate Multitransport Response is
+    /// the Soft-Sync signalling path, and is only sent when *both* peers
+    /// advertised the flag in their GCC `MultiTransportChannelData` block.
+    /// Without Soft-Sync the client reports the outcome in band on the new
+    /// transport and sends nothing back on the main channel, so emitting a
+    /// response there would be a protocol violation rather than a courtesy.
+    ///
+    /// [\[MS-RDPBCGR\] 2.2.15.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/44044233-e498-46f8-8e16-1ffa595a8e8b
+    fn soft_sync_negotiated(&self) -> bool {
+        fn advertised(flags: Option<gcc::MultiTransportFlags>) -> bool {
+            flags.is_some_and(|flags| flags.contains(gcc::MultiTransportFlags::SOFT_SYNC_TCP_TO_UDP))
+        }
+
+        advertised(self.config.multitransport_flags) && advertised(self.server_multitransport_flags)
     }
 
     #[must_use]
@@ -274,139 +317,181 @@ impl ClientConnector {
         assert_eq!(res, Written::Nothing);
     }
 
-    /// Returns `true` when the connector has collected all multitransport
-    /// requests from the server and is waiting for the application to either
-    /// establish the UDP transport(s) or decline them.
+    /// Returns `true` when the server has sent an Initiate Multitransport
+    /// Request and the connector is waiting for the application to either
+    /// establish that UDP transport or decline it.
     ///
     /// The application should:
     ///
-    /// 1. Call [`multitransport_requests()`](Self::multitransport_requests) to
-    ///    get the server's request(s)
-    /// 2. Establish UDP transport (RDPEUDP2 + TLS + RDPEMT) for each, or decide
-    ///    not to
+    /// 1. Call [`multitransport_request()`](Self::multitransport_request) to
+    ///    get the server's request
+    /// 2. Establish UDP transport (RDPEUDP2 + TLS + RDPEMT), or decide not to
     /// 3. Call [`complete_multitransport()`](Self::complete_multitransport) with
-    ///    a [`MultitransportResult`] for each request, or
-    ///    [`skip_multitransport()`](Self::skip_multitransport) to decline all
+    ///    the [`MultitransportResult`], or
+    ///    [`skip_multitransport()`](Self::skip_multitransport) to decline
+    ///
+    /// This can come round more than once. MS-RDPBCGR 2.2.15.1 permits two
+    /// requests, one per transport protocol, and each is surfaced on its own
+    /// as soon as it decodes rather than batched, because the server is not
+    /// obliged to announce that it has finished sending them.
     pub fn should_perform_multitransport(&self) -> bool {
         matches!(self.state, ClientConnectorState::MultitransportPending { .. })
     }
 
-    /// Returns the multitransport request PDUs received from the server.
+    /// Returns the multitransport request PDU awaiting an outcome.
     ///
-    /// Only meaningful when
+    /// `None` unless
     /// [`should_perform_multitransport()`](Self::should_perform_multitransport)
     /// returns `true`.
-    pub fn multitransport_requests(&self) -> &[rdp::multitransport::MultitransportRequestPdu] {
+    pub fn multitransport_request(&self) -> Option<&rdp::multitransport::MultitransportRequestPdu> {
         match &self.state {
-            ClientConnectorState::MultitransportPending { requests, .. } => requests,
-            _ => &[],
+            ClientConnectorState::MultitransportPending { request, .. } => Some(request),
+            _ => None,
         }
     }
 
-    /// Send multitransport response PDU(s) and advance past the bootstrapping
-    /// phase to capabilities exchange.
+    /// Report the outcome of the multitransport request currently surfaced by
+    /// [`multitransport_request()`](Self::multitransport_request).
     ///
-    /// Pass one [`MultitransportResult`] per request (in the same order as
-    /// [`multitransport_requests()`](Self::multitransport_requests)). The
-    /// connector builds the response PDUs internally using the stored request
-    /// IDs and cookies, then replays the buffered Demand Active PDU through
-    /// the activation sequence.
+    /// The connector builds the response PDU internally from the stored request
+    /// ID, sends it on the MCS message channel when Soft-Sync was mutually
+    /// negotiated, and returns to reading. The next PDU may be a second request
+    /// or the Demand Active that ends bootstrapping; either way the caller does
+    /// not have to know which.
     ///
     /// Returns an error if the connector is not in `MultitransportPending`
-    /// state, or if `results.len()` does not match the number of pending
-    /// requests.
+    /// state.
     pub fn complete_multitransport(
         &mut self,
-        results: &[MultitransportResult],
+        result: MultitransportResult,
         output: &mut WriteBuf,
     ) -> ConnectorResult<Written> {
-        let ClientConnectorState::MultitransportPending {
-            io_channel_id,
-            user_channel_id,
-            requests,
-            buffered_demand_active,
-        } = mem::replace(&mut self.state, ClientConnectorState::Consumed)
-        else {
-            return Err(general_err!(
-                "complete_multitransport called outside MultitransportPending state"
-            ));
-        };
-
-        if results.len() != requests.len() {
-            return Err(general_err!(
-                "multitransport results count does not match requests count"
-            ));
-        }
-
-        let mut total_written = 0;
-
-        for (request, result) in requests.iter().zip(results) {
-            let response = match result {
-                MultitransportResult::Success => {
-                    rdp::multitransport::MultitransportResponsePdu::success(request.request_id)
-                }
-                MultitransportResult::Failure(hr) => rdp::multitransport::MultitransportResponsePdu {
-                    security_header: rdp::headers::BasicSecurityHeader {
-                        flags: rdp::headers::BasicSecurityHeaderFlags::TRANSPORT_RSP,
-                    },
-                    request_id: request.request_id,
-                    hr_response: *hr,
-                },
-            };
-            total_written += encode_send_data_request(user_channel_id, io_channel_id, &response, output)?;
-        }
-
-        // Replay the buffered Demand Active through the activation sequence
-        let mut connection_activation =
-            ConnectionActivationSequence::new(self.config.clone(), io_channel_id, user_channel_id);
-        let replay_written = connection_activation.step(&buffered_demand_active, output)?;
-        total_written += replay_written.size().unwrap_or(0);
-
-        self.state = match connection_activation.connection_activation_state() {
-            ConnectionActivationState::ConnectionFinalization { .. } => {
-                ClientConnectorState::ConnectionFinalization { connection_activation }
-            }
-            _ => ClientConnectorState::CapabilitiesExchange { connection_activation },
-        };
-
-        Written::from_size(total_written)
+        self.respond_to_multitransport("complete_multitransport", result, output)
     }
 
-    /// Skip multitransport bootstrapping without sending any responses.
+    /// Decline the multitransport request currently surfaced.
     ///
     /// Use this when the application doesn't support or doesn't want UDP
-    /// transport. The server will continue with TCP-only operation.
-    ///
-    /// The buffered Demand Active PDU is replayed internally.
+    /// transport. Under Soft-Sync this sends `E_ABORT`, which MS-RDPBCGR
+    /// 3.2.5.15.1 requires; the server then continues TCP-only.
     ///
     /// Returns an error if the connector is not in `MultitransportPending`
     /// state.
     pub fn skip_multitransport(&mut self, output: &mut WriteBuf) -> ConnectorResult<Written> {
+        self.respond_to_multitransport(
+            "skip_multitransport",
+            MultitransportResult::Failure(rdp::multitransport::MultitransportResponsePdu::E_ABORT),
+            output,
+        )
+    }
+
+    /// The channel an Initiate Multitransport Response goes out on, or `None`
+    /// when no response is owed.
+    ///
+    /// Without Soft-Sync the response PDU has no place on the main channel:
+    /// MS-RDPBCGR 2.2.15.2 makes it the Soft-Sync signalling path, and the
+    /// outcome is otherwise reported in band on the new transport. With
+    /// Soft-Sync the message channel is presupposed, and falling back to the
+    /// I/O channel would put the response somewhere the server is not reading,
+    /// so its absence is an error rather than a reason to improvise.
+    ///
+    /// Borrows rather than consuming, so the caller can resolve this while the
+    /// connector is still in a state it can act on.
+    fn multitransport_response_channel(&self) -> ConnectorResult<Option<u16>> {
+        match &self.state {
+            ClientConnectorState::MultitransportPending {
+                message_channel_id,
+                soft_sync: true,
+                ..
+            } => message_channel_id
+                .ok_or_else(|| {
+                    general_err!("Soft-Sync was negotiated but the server never offered an MCS message channel")
+                })
+                .map(Some),
+            _ => Ok(None),
+        }
+    }
+
+    /// Shared body of [`Self::complete_multitransport`] and
+    /// [`Self::skip_multitransport`]: declining is just an `E_ABORT` outcome,
+    /// so the two differ only in the HRESULT they report.
+    fn respond_to_multitransport(
+        &mut self,
+        caller: &str,
+        result: MultitransportResult,
+        output: &mut WriteBuf,
+    ) -> ConnectorResult<Written> {
+        // Resolved before the state is taken. Taking first and failing after
+        // would leave the connector `Consumed`, so a caller that hits this could
+        // neither see what happened nor decline: the error would destroy the
+        // state needed to act on it.
+        let response_channel = self.multitransport_response_channel()?;
+
         let ClientConnectorState::MultitransportPending {
             io_channel_id,
             user_channel_id,
-            buffered_demand_active,
+            message_channel_id,
+            request,
+            requests_seen,
             ..
         } = mem::replace(&mut self.state, ClientConnectorState::Consumed)
         else {
-            return Err(general_err!(
-                "skip_multitransport called outside MultitransportPending state"
+            return Err(reason_err!(
+                "MultitransportPending",
+                "{caller} called outside MultitransportPending state",
             ));
         };
 
-        // Replay the buffered Demand Active through the activation sequence
-        let mut connection_activation =
-            ConnectionActivationSequence::new(self.config.clone(), io_channel_id, user_channel_id);
-        let written = connection_activation.step(&buffered_demand_active, output)?;
+        // Without Soft-Sync the response PDU has no place on the main channel:
+        // MS-RDPBCGR 2.2.15.2 makes it the Soft-Sync signalling path, and the
+        // outcome is otherwise reported in band on the new transport. The
+        // outcome is still consumed and the handshake still proceeds, so a
+        // caller that established the transport does not have to know which
+        // mode is in play.
+        let total_written = if let Some(response_channel) = response_channel {
+            let response = match result {
+                MultitransportResult::Success => {
+                    rdp::multitransport::MultitransportResponsePdu::success(request.request_id)
+                }
+                MultitransportResult::Failure(hr) => multitransport_response(request.request_id, hr),
+            };
 
-        self.state = match connection_activation.connection_activation_state() {
-            ConnectionActivationState::ConnectionFinalization { .. } => {
-                ClientConnectorState::ConnectionFinalization { connection_activation }
-            }
-            _ => ClientConnectorState::CapabilitiesExchange { connection_activation },
+            encode_send_data_request(user_channel_id, response_channel, &response, output)?
+        } else {
+            0
         };
 
-        Ok(written)
+        // Back to reading. The server may send another request or the Demand
+        // Active; nothing here needs to predict which.
+        self.state = ClientConnectorState::MultitransportBootstrapping {
+            io_channel_id,
+            user_channel_id,
+            message_channel_id,
+            requests_seen,
+        };
+
+        // Without Soft-Sync nothing goes on the wire at all, and `from_size`
+        // rejects a zero length.
+        if total_written == 0 {
+            Ok(Written::Nothing)
+        } else {
+            Written::from_size(total_written)
+        }
+    }
+}
+
+/// Build an Initiate Multitransport Response carrying `hr_response`.
+///
+/// [`MultitransportResponsePdu::success`] covers `S_OK`; every other HRESULT,
+/// whether a caller-supplied failure or the `E_ABORT` the skip path sends,
+/// comes through here so the security-header framing lives in one place.
+fn multitransport_response(request_id: u32, hr_response: u32) -> rdp::multitransport::MultitransportResponsePdu {
+    rdp::multitransport::MultitransportResponsePdu {
+        security_header: rdp::headers::BasicSecurityHeader {
+            flags: rdp::headers::BasicSecurityHeaderFlags::TRANSPORT_RSP,
+        },
+        request_id,
+        hr_response,
     }
 }
 
@@ -414,6 +499,7 @@ fn advance_licensing_exchange(
     mut license_exchange: LicenseExchangeSequence,
     io_channel_id: u16,
     user_channel_id: u16,
+    message_channel_id: Option<u16>,
     input: &[u8],
     output: &mut WriteBuf,
 ) -> ConnectorResult<(Written, ClientConnectorState)> {
@@ -423,7 +509,8 @@ fn advance_licensing_exchange(
         ClientConnectorState::MultitransportBootstrapping {
             io_channel_id,
             user_channel_id,
-            requests: Vec::with_capacity(MAX_MULTITRANSPORT_REQUESTS),
+            message_channel_id,
+            requests_seen: 0,
         }
     } else {
         ClientConnectorState::LicensingExchange {
@@ -637,9 +724,10 @@ impl Sequence for ClientConnector {
                     .as_ref()
                     .map(|data| data.mcs_message_channel_id);
 
-                if server_gcc_blocks.multi_transport_channel.is_some() {
-                    warn!("Unexpected MultiTransportChannelData GCC block (not supported)");
-                }
+                self.server_multitransport_flags = server_gcc_blocks
+                    .multi_transport_channel
+                    .as_ref()
+                    .map(|data| data.flags);
 
                 let static_channel_ids = server_gcc_blocks.network.channel_ids;
                 let io_channel_id = server_gcc_blocks.network.io_channel;
@@ -807,7 +895,14 @@ impl Sequence for ClientConnector {
                     // nothing was read and the licensing sequence runs from its
                     // first step when the next PDU arrives.
                     if self.message_channel_id.is_some() {
-                        advance_licensing_exchange(license_exchange, io_channel_id, user_channel_id, input, output)?
+                        advance_licensing_exchange(
+                            license_exchange,
+                            io_channel_id,
+                            user_channel_id,
+                            self.message_channel_id,
+                            input,
+                            output,
+                        )?
                     } else {
                         (
                             Written::Nothing,
@@ -831,88 +926,101 @@ impl Sequence for ClientConnector {
             } => {
                 debug!("Licensing Exchange");
 
-                advance_licensing_exchange(license_exchange, io_channel_id, user_channel_id, input, output)?
+                advance_licensing_exchange(
+                    license_exchange,
+                    io_channel_id,
+                    user_channel_id,
+                    self.message_channel_id,
+                    input,
+                    output,
+                )?
             }
 
             //== Optional Multitransport Bootstrapping ==//
             //
-            // The server may send 0, 1, or 2 Initiate Multitransport Request PDUs
-            // after licensing (MS-RDPBCGR 2.2.15.1). We distinguish them from the
-            // Demand Active PDU by attempting to decode as MultitransportRequestPdu
-            // first; the decoder validates SEC_TRANSPORT_REQ internally, so a Demand
-            // Active PDU fails cleanly without false positives.
+            // After licensing the server may send 0, 1, or 2 Initiate Multitransport
+            // Request PDUs (MS-RDPBCGR 2.2.15.1), and it is under no obligation to
+            // send the Demand Active before the client acts on one it has already
+            // sent. There is therefore no end marker for the set, and waiting for a
+            // following PDU to decide what to do with the current one can stall the
+            // handshake outright. Each request is surfaced the moment it decodes,
+            // per MS-RDPBCGR 3.2.5.15.1.
+            //
+            // Routing is by channel. Requests travel on the MCS message channel; the
+            // Demand Active is on the I/O channel and ends the phase. The message
+            // channel also carries auto-detect PDUs, so a decode still confirms what
+            // arrived there, but the I/O channel is never speculatively decoded as
+            // multitransport any more.
             ClientConnectorState::MultitransportBootstrapping {
                 io_channel_id,
                 user_channel_id,
-                mut requests,
+                message_channel_id,
+                requests_seen,
             } => {
                 let ctx = mcs::decode_send_data_indication(input).map_err(ConnectorError::decode)?;
 
-                match decode::<rdp::multitransport::MultitransportRequestPdu>(ctx.user_data) {
-                    Ok(pdu) => {
-                        if requests.len() >= MAX_MULTITRANSPORT_REQUESTS {
-                            return Err(reason_err!(
-                                "MultitransportBootstrapping",
-                                "server sent more than {} multitransport requests (MS-RDPBCGR 2.2.15.1 caps the count at {})",
-                                MAX_MULTITRANSPORT_REQUESTS,
-                                MAX_MULTITRANSPORT_REQUESTS,
-                            ));
-                        }
+                if Some(ctx.channel_id) == message_channel_id {
+                    let pdu = decode::<rdp::multitransport::MultitransportRequestPdu>(ctx.user_data)
+                        .map_err(ConnectorError::decode)?;
 
-                        debug!(
-                            request_id = pdu.request_id,
-                            protocol = ?pdu.requested_protocol,
-                            "Received Initiate Multitransport Request"
-                        );
-
-                        requests.push(pdu);
-
-                        // Stay in this state to read more requests (server may send a second)
-                        (
-                            Written::Nothing,
-                            ClientConnectorState::MultitransportBootstrapping {
-                                io_channel_id,
-                                user_channel_id,
-                                requests,
-                            },
-                        )
+                    if requests_seen >= MAX_MULTITRANSPORT_REQUESTS {
+                        return Err(reason_err!(
+                            "MultitransportBootstrapping",
+                            "server sent more than {} multitransport requests (MS-RDPBCGR 2.2.15.1 caps the count at {})",
+                            MAX_MULTITRANSPORT_REQUESTS,
+                            MAX_MULTITRANSPORT_REQUESTS,
+                        ));
                     }
-                    Err(_) if !requests.is_empty() => {
-                        // Decode failed → this is the Demand Active PDU. Buffer it
-                        // and pause for the application to handle multitransport.
-                        info!(
-                            count = requests.len(),
-                            "Multitransport bootstrapping: pausing for application"
-                        );
 
-                        (
-                            Written::Nothing,
-                            ClientConnectorState::MultitransportPending {
-                                io_channel_id,
-                                user_channel_id,
-                                requests,
-                                buffered_demand_active: input.to_vec(),
-                            },
-                        )
-                    }
-                    Err(_) => {
-                        // No multitransport requests: the server went straight to
-                        // capabilities exchange. Forward the PDU.
-                        let mut connection_activation =
-                            ConnectionActivationSequence::new(self.config.clone(), io_channel_id, user_channel_id);
-                        let written = connection_activation.step(input, output)?;
+                    debug!(
+                        request_id = pdu.request_id,
+                        protocol = ?pdu.requested_protocol,
+                        "Received Initiate Multitransport Request"
+                    );
 
+                    // Captured on entry rather than read back at completion time: the
+                    // GCC exchange carrying both peers' flags is long finished, and
+                    // freezing it here keeps the response paths from depending on
+                    // connector fields that could move in between.
+                    let soft_sync = self.soft_sync_negotiated();
+
+                    (
+                        Written::Nothing,
+                        ClientConnectorState::MultitransportPending {
+                            io_channel_id,
+                            user_channel_id,
+                            message_channel_id,
+                            request: pdu,
+                            requests_seen: requests_seen + 1,
+                            soft_sync,
+                        },
+                    )
+                } else if ctx.channel_id == io_channel_id {
+                    // Demand Active: bootstrapping is over, hand off to capabilities
+                    // exchange with the PDU intact.
+                    let mut connection_activation =
+                        ConnectionActivationSequence::new(self.config.clone(), io_channel_id, user_channel_id);
+                    let written = connection_activation.step(input, output)?;
+
+                    (
+                        written,
                         match connection_activation.connection_activation_state() {
-                            ConnectionActivationState::ConnectionFinalization { .. } => (
-                                written,
-                                ClientConnectorState::ConnectionFinalization { connection_activation },
-                            ),
-                            _ => (
-                                written,
-                                ClientConnectorState::CapabilitiesExchange { connection_activation },
-                            ),
-                        }
-                    }
+                            ConnectionActivationState::ConnectionFinalization { .. } => {
+                                ClientConnectorState::ConnectionFinalization { connection_activation }
+                            }
+                            _ => ClientConnectorState::CapabilitiesExchange { connection_activation },
+                        },
+                    )
+                } else {
+                    return Err(reason_err!(
+                        "MultitransportBootstrapping",
+                        "PDU on unexpected channel {} (message channel is {}, I/O channel is {})",
+                        ctx.channel_id,
+                        message_channel_id
+                            .map(|id| id.to_string())
+                            .unwrap_or_else(|| "not negotiated".to_owned()),
+                        io_channel_id,
+                    ));
                 }
             }
 

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -19,6 +19,20 @@ use crate::{
     NegotiationFailure, Sequence, State, Written, encode_x224_packet, general_err, reason_err,
 };
 
+/// Outcome of a single multitransport bootstrapping request, passed to
+/// [`ClientConnector::complete_multitransport()`].
+///
+/// The connector uses this to build the response PDU internally, paired with
+/// the request ID and cookie from the server's original request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MultitransportResult {
+    /// UDP transport was established successfully (`S_OK`).
+    Success,
+    /// UDP transport failed. The `u32` is the HRESULT error code (typically
+    /// [`MultitransportResponsePdu::E_ABORT`](rdp::multitransport::MultitransportResponsePdu::E_ABORT)).
+    Failure(u32),
+}
+
 #[derive(Debug)]
 pub struct ConnectionResult {
     pub io_channel_id: u16,
@@ -90,9 +104,32 @@ pub enum ClientConnectorState {
         user_channel_id: u16,
         license_exchange: LicenseExchangeSequence,
     },
+    /// Reading the server's optional Initiate Multitransport Request PDU(s).
+    ///
+    /// The server may send 0, 1, or 2 requests (one per transport protocol).
+    /// If the first PDU on the IO channel after licensing is a Demand Active
+    /// (capabilities exchange), the server sent no multitransport requests and
+    /// the connector transitions directly to `CapabilitiesExchange`.
     MultitransportBootstrapping {
         io_channel_id: u16,
         user_channel_id: u16,
+        /// Multitransport requests received from the server so far.
+        requests: Vec<rdp::multitransport::MultitransportRequestPdu>,
+    },
+    /// The server sent multitransport request(s) and the connector is paused
+    /// waiting for the application to establish UDP transport or decline.
+    ///
+    /// Call [`ClientConnector::complete_multitransport()`] or
+    /// [`ClientConnector::skip_multitransport()`] to advance. The buffered
+    /// Demand Active PDU is replayed internally — no re-feeding needed.
+    MultitransportPending {
+        io_channel_id: u16,
+        user_channel_id: u16,
+        requests: Vec<rdp::multitransport::MultitransportRequestPdu>,
+        /// The raw Demand Active PDU bytes that arrived after the last
+        /// multitransport request. Replayed through the activation sequence
+        /// when the application completes or skips multitransport.
+        buffered_demand_active: Vec<u8>,
     },
     CapabilitiesExchange {
         connection_activation: ConnectionActivationSequence,
@@ -120,6 +157,7 @@ impl State for ClientConnectorState {
             Self::ConnectTimeAutoDetection { .. } => "ConnectTimeAutoDetection",
             Self::LicensingExchange { .. } => "LicensingExchange",
             Self::MultitransportBootstrapping { .. } => "MultitransportBootstrapping",
+            Self::MultitransportPending { .. } => "MultitransportPending",
             Self::CapabilitiesExchange {
                 connection_activation, ..
             } => connection_activation.state().name(),
@@ -221,6 +259,141 @@ impl ClientConnector {
         debug_assert!(!self.should_perform_credssp());
         assert_eq!(res, Written::Nothing);
     }
+
+    /// Returns `true` when the connector has collected all multitransport
+    /// requests from the server and is waiting for the application to either
+    /// establish the UDP transport(s) or decline them.
+    ///
+    /// The application should:
+    ///
+    /// 1. Call [`multitransport_requests()`](Self::multitransport_requests) to
+    ///    get the server's request(s)
+    /// 2. Establish UDP transport (RDPEUDP2 + TLS + RDPEMT) for each, or decide
+    ///    not to
+    /// 3. Call [`complete_multitransport()`](Self::complete_multitransport) with
+    ///    a [`MultitransportResult`] for each request, or
+    ///    [`skip_multitransport()`](Self::skip_multitransport) to decline all
+    pub fn should_perform_multitransport(&self) -> bool {
+        matches!(self.state, ClientConnectorState::MultitransportPending { .. })
+    }
+
+    /// Returns the multitransport request PDUs received from the server.
+    ///
+    /// Only meaningful when
+    /// [`should_perform_multitransport()`](Self::should_perform_multitransport)
+    /// returns `true`.
+    pub fn multitransport_requests(&self) -> &[rdp::multitransport::MultitransportRequestPdu] {
+        match &self.state {
+            ClientConnectorState::MultitransportPending { requests, .. } => requests,
+            _ => &[],
+        }
+    }
+
+    /// Send multitransport response PDU(s) and advance past the bootstrapping
+    /// phase to capabilities exchange.
+    ///
+    /// Pass one [`MultitransportResult`] per request (in the same order as
+    /// [`multitransport_requests()`](Self::multitransport_requests)). The
+    /// connector builds the response PDUs internally using the stored request
+    /// IDs and cookies, then replays the buffered Demand Active PDU through
+    /// the activation sequence.
+    ///
+    /// Returns an error if the connector is not in `MultitransportPending`
+    /// state, or if `results.len()` does not match the number of pending
+    /// requests.
+    pub fn complete_multitransport(
+        &mut self,
+        results: &[MultitransportResult],
+        output: &mut WriteBuf,
+    ) -> ConnectorResult<Written> {
+        let ClientConnectorState::MultitransportPending {
+            io_channel_id,
+            user_channel_id,
+            requests,
+            buffered_demand_active,
+        } = mem::replace(&mut self.state, ClientConnectorState::Consumed)
+        else {
+            return Err(general_err!(
+                "complete_multitransport called outside MultitransportPending state"
+            ));
+        };
+
+        if results.len() != requests.len() {
+            return Err(general_err!(
+                "multitransport results count does not match requests count"
+            ));
+        }
+
+        let mut total_written = 0;
+
+        for (request, result) in requests.iter().zip(results) {
+            let response = match result {
+                MultitransportResult::Success => {
+                    rdp::multitransport::MultitransportResponsePdu::success(request.request_id)
+                }
+                MultitransportResult::Failure(hr) => rdp::multitransport::MultitransportResponsePdu {
+                    security_header: rdp::headers::BasicSecurityHeader {
+                        flags: rdp::headers::BasicSecurityHeaderFlags::TRANSPORT_RSP,
+                    },
+                    request_id: request.request_id,
+                    hr_response: *hr,
+                },
+            };
+            total_written += encode_send_data_request(user_channel_id, io_channel_id, &response, output)?;
+        }
+
+        // Replay the buffered Demand Active through the activation sequence
+        let mut connection_activation =
+            ConnectionActivationSequence::new(self.config.clone(), io_channel_id, user_channel_id);
+        let replay_written = connection_activation.step(&buffered_demand_active, output)?;
+        total_written += replay_written.size().unwrap_or(0);
+
+        self.state = match connection_activation.connection_activation_state() {
+            ConnectionActivationState::ConnectionFinalization { .. } => {
+                ClientConnectorState::ConnectionFinalization { connection_activation }
+            }
+            _ => ClientConnectorState::CapabilitiesExchange { connection_activation },
+        };
+
+        Written::from_size(total_written)
+    }
+
+    /// Skip multitransport bootstrapping without sending any responses.
+    ///
+    /// Use this when the application doesn't support or doesn't want UDP
+    /// transport. The server will continue with TCP-only operation.
+    ///
+    /// The buffered Demand Active PDU is replayed internally.
+    ///
+    /// Returns an error if the connector is not in `MultitransportPending`
+    /// state.
+    pub fn skip_multitransport(&mut self, output: &mut WriteBuf) -> ConnectorResult<Written> {
+        let ClientConnectorState::MultitransportPending {
+            io_channel_id,
+            user_channel_id,
+            buffered_demand_active,
+            ..
+        } = mem::replace(&mut self.state, ClientConnectorState::Consumed)
+        else {
+            return Err(general_err!(
+                "skip_multitransport called outside MultitransportPending state"
+            ));
+        };
+
+        // Replay the buffered Demand Active through the activation sequence
+        let mut connection_activation =
+            ConnectionActivationSequence::new(self.config.clone(), io_channel_id, user_channel_id);
+        let written = connection_activation.step(&buffered_demand_active, output)?;
+
+        self.state = match connection_activation.connection_activation_state() {
+            ConnectionActivationState::ConnectionFinalization { .. } => {
+                ClientConnectorState::ConnectionFinalization { connection_activation }
+            }
+            _ => ClientConnectorState::CapabilitiesExchange { connection_activation },
+        };
+
+        Ok(written)
+    }
 }
 
 fn advance_licensing_exchange(
@@ -236,6 +409,7 @@ fn advance_licensing_exchange(
         ClientConnectorState::MultitransportBootstrapping {
             io_channel_id,
             user_channel_id,
+            requests: Vec::new(),
         }
     } else {
         ClientConnectorState::LicensingExchange {
@@ -275,7 +449,8 @@ impl Sequence for ClientConnector {
                 }
             }
             ClientConnectorState::LicensingExchange { license_exchange, .. } => license_exchange.next_pdu_hint(),
-            ClientConnectorState::MultitransportBootstrapping { .. } => None,
+            ClientConnectorState::MultitransportBootstrapping { .. } => Some(&ironrdp_pdu::X224_HINT),
+            ClientConnectorState::MultitransportPending { .. } => None,
             ClientConnectorState::CapabilitiesExchange {
                 connection_activation, ..
             } => connection_activation.next_pdu_hint(),
@@ -646,20 +821,88 @@ impl Sequence for ClientConnector {
             }
 
             //== Optional Multitransport Bootstrapping ==//
-            // NOTE: our implementation is not expecting the Auto-Detect Request PDU from server
+            //
+            // The server may send 0, 1, or 2 Initiate Multitransport Request PDUs
+            // after licensing. We distinguish them from the Demand Active PDU by
+            // attempting to decode as MultitransportRequestPdu first — it has a
+            // distinctive structure (SEC_TRANSPORT_REQ flag + request_id + protocol
+            // + cookie). If decode fails, this is the Demand Active.
             ClientConnectorState::MultitransportBootstrapping {
                 io_channel_id,
                 user_channel_id,
-            } => (
-                Written::Nothing,
-                ClientConnectorState::CapabilitiesExchange {
-                    connection_activation: ConnectionActivationSequence::new(
-                        self.config.clone(),
-                        io_channel_id,
-                        user_channel_id,
-                    ),
-                },
-            ),
+                mut requests,
+            } => {
+                let ctx = mcs::decode_send_data_indication(input).map_err(ConnectorError::decode)?;
+
+                // Try decoding as a multitransport request. The decoder validates
+                // the SEC_TRANSPORT_REQ flag, so a Demand Active PDU will fail
+                // cleanly without false positives.
+                match decode::<rdp::multitransport::MultitransportRequestPdu>(ctx.user_data) {
+                    Ok(pdu) => {
+                        debug!(
+                            request_id = pdu.request_id,
+                            protocol = ?pdu.requested_protocol,
+                            "Received Initiate Multitransport Request"
+                        );
+
+                        requests.push(pdu);
+
+                        // Stay in this state to read more requests (server may send a second)
+                        (
+                            Written::Nothing,
+                            ClientConnectorState::MultitransportBootstrapping {
+                                io_channel_id,
+                                user_channel_id,
+                                requests,
+                            },
+                        )
+                    }
+                    Err(_) if !requests.is_empty() => {
+                        // Decode failed → this is the Demand Active PDU. Buffer it
+                        // and pause for the application to handle multitransport.
+                        info!(
+                            count = requests.len(),
+                            "Multitransport bootstrapping: pausing for application"
+                        );
+
+                        (
+                            Written::Nothing,
+                            ClientConnectorState::MultitransportPending {
+                                io_channel_id,
+                                user_channel_id,
+                                requests,
+                                buffered_demand_active: input.to_vec(),
+                            },
+                        )
+                    }
+                    Err(_) => {
+                        // No multitransport requests: the server went straight to
+                        // capabilities exchange. Forward the PDU.
+                        let mut connection_activation =
+                            ConnectionActivationSequence::new(self.config.clone(), io_channel_id, user_channel_id);
+                        let written = connection_activation.step(input, output)?;
+
+                        match connection_activation.connection_activation_state() {
+                            ConnectionActivationState::ConnectionFinalization { .. } => (
+                                written,
+                                ClientConnectorState::ConnectionFinalization { connection_activation },
+                            ),
+                            _ => (
+                                written,
+                                ClientConnectorState::CapabilitiesExchange { connection_activation },
+                            ),
+                        }
+                    }
+                }
+            }
+
+            // MultitransportPending: application should call complete_multitransport()
+            // or skip_multitransport() instead of step()
+            ClientConnectorState::MultitransportPending { .. } => {
+                return Err(general_err!(
+                    "multitransport pending: call complete_multitransport() or skip_multitransport()"
+                ));
+            }
 
             //== Capabilities Exchange ==/
             // The server sends the set of capabilities it supports to the client.

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -116,12 +116,21 @@ pub enum ClientConnectorState {
         /// Multitransport requests received from the server so far.
         requests: Vec<rdp::multitransport::MultitransportRequestPdu>,
     },
-    /// The server sent multitransport request(s) and the connector is paused
-    /// waiting for the application to establish UDP transport or decline.
+    /// State the connector enters after the server has sent multitransport
+    /// request(s) and before resuming with the Demand Active PDU. The
+    /// connector surfaces this as an API yield point so the caller can run
+    /// UDP transport setup and report the outcome.
     ///
     /// Call [`ClientConnector::complete_multitransport()`] or
     /// [`ClientConnector::skip_multitransport()`] to advance. The buffered
-    /// Demand Active PDU is replayed internally — no re-feeding needed.
+    /// Demand Active PDU is replayed internally on resume; the caller does
+    /// not need to re-feed it.
+    ///
+    /// On the wire, TCP and UDP negotiation happen in parallel: the UDP
+    /// transport is established alongside the ongoing TCP handshake, and
+    /// its completion is a signal to the dynamic-channel layer that
+    /// subsequent channels may migrate to UDP. The connector's suspension
+    /// here is a Rust-API affordance, not a spec-mandated TCP pause.
     MultitransportPending {
         io_channel_id: u16,
         user_channel_id: u16,

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -397,18 +397,37 @@ impl ClientConnector {
     ///
     /// Borrows rather than consuming, so the caller can resolve this while the
     /// connector is still in a state it can act on.
-    fn multitransport_response_channel(&self) -> ConnectorResult<Option<u16>> {
-        match &self.state {
-            ClientConnectorState::MultitransportPending {
-                message_channel_id,
-                soft_sync: true,
-                ..
-            } => message_channel_id
+    fn multitransport_response_channel(&self, result: &MultitransportResult) -> ConnectorResult<Option<u16>> {
+        let ClientConnectorState::MultitransportPending {
+            message_channel_id,
+            soft_sync,
+            ..
+        } = &self.state
+        else {
+            return Ok(None);
+        };
+
+        match (*soft_sync, result) {
+            // Soft-Sync obliges a response either way, and presupposes the
+            // message channel. Falling back to the I/O channel would put the
+            // response somewhere the server is not reading, so its absence is an
+            // error rather than a reason to improvise.
+            (true, _) => message_channel_id
                 .ok_or_else(|| {
                     general_err!("Soft-Sync was negotiated but the server never offered an MCS message channel")
                 })
                 .map(Some),
-            _ => Ok(None),
+            // `S_OK` is the one value 2.2.15.2 forbids here, so success and only
+            // success is withheld. The outcome is still consumed and the
+            // handshake proceeds, so a caller that established the transport does
+            // not have to know which mode is in play.
+            (false, MultitransportResult::Success) => Ok(None),
+            // A failure is still reported: 3.2.5.15.1 asks for it whenever the
+            // client could not initiate the channel, with no Soft-Sync condition.
+            // It is a SHOULD, so a missing message channel means staying silent
+            // rather than failing a connection over an optional report. In
+            // practice one exists, since 2.2.15.1 puts the request on it.
+            (false, MultitransportResult::Failure(_)) => Ok(*message_channel_id),
         }
     }
 
@@ -421,12 +440,13 @@ impl ClientConnector {
         result: MultitransportResult,
         output: &mut WriteBuf,
     ) -> ConnectorResult<Written> {
-        // Resolved before the state is taken. Taking first and failing after
-        // would leave the connector `Consumed`, so a caller that hits this could
-        // neither see what happened nor decline: the error would destroy the
-        // state needed to act on it.
-        let response_channel = self.multitransport_response_channel()?;
-
+        // The state is read, never taken. Everything this needs is a scalar, so
+        // nothing has to be moved out of `self.state`, and the transition at the
+        // end is the only mutation. That makes state preservation structural: an
+        // error anywhere above it leaves the connector exactly as it was, so the
+        // caller can still see what failed and decline. Taking the state up front
+        // and failing afterwards would leave it `Consumed`, with the error having
+        // destroyed the state needed to act on it.
         let ClientConnectorState::MultitransportPending {
             io_channel_id,
             user_channel_id,
@@ -434,26 +454,27 @@ impl ClientConnector {
             request,
             requests_seen,
             ..
-        } = mem::replace(&mut self.state, ClientConnectorState::Consumed)
+        } = &self.state
         else {
             return Err(reason_err!(
                 "MultitransportPending",
                 "{caller} called outside MultitransportPending state",
             ));
         };
+        let (io_channel_id, user_channel_id, message_channel_id, requests_seen) =
+            (*io_channel_id, *user_channel_id, *message_channel_id, *requests_seen);
+        let request_id = request.request_id;
 
-        // Without Soft-Sync the response PDU has no place on the main channel:
-        // MS-RDPBCGR 2.2.15.2 makes it the Soft-Sync signalling path, and the
-        // outcome is otherwise reported in band on the new transport. The
-        // outcome is still consumed and the handshake still proceeds, so a
-        // caller that established the transport does not have to know which
-        // mode is in play.
+        let response_channel = self.multitransport_response_channel(&result)?;
+
+        // Whether a response is owed at all is decided by
+        // `multitransport_response_channel`, which weighs the outcome against
+        // Soft-Sync. Either way the outcome is consumed and the handshake
+        // proceeds.
         let total_written = if let Some(response_channel) = response_channel {
             let response = match result {
-                MultitransportResult::Success => {
-                    rdp::multitransport::MultitransportResponsePdu::success(request.request_id)
-                }
-                MultitransportResult::Failure(hr) => multitransport_response(request.request_id, hr),
+                MultitransportResult::Success => rdp::multitransport::MultitransportResponsePdu::success(request_id),
+                MultitransportResult::Failure(hr) => multitransport_response(request_id, hr),
             };
 
             encode_send_data_request(user_channel_id, response_channel, &response, output)?
@@ -470,7 +491,7 @@ impl ClientConnector {
             requests_seen,
         };
 
-        // Without Soft-Sync nothing goes on the wire at all, and `from_size`
+        // Nothing goes on the wire when no response is owed, and `from_size`
         // rejects a zero length.
         if total_written == 0 {
             Ok(Written::Nothing)

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -160,8 +160,10 @@ pub enum ClientConnectorState {
         /// caller.
         requests_seen: usize,
         /// Whether both peers advertised Soft-Sync, captured when this state was
-        /// entered. Decides whether the completion and skip paths may emit an
-        /// Initiate Multitransport Response at all.
+        /// entered. Combined with the reported outcome this decides whether the
+        /// completion and skip paths emit an Initiate Multitransport Response:
+        /// a failure is always reported, while success is withheld unless
+        /// Soft-Sync was negotiated.
         soft_sync: bool,
     },
     CapabilitiesExchange {
@@ -220,9 +222,10 @@ pub struct ClientConnector {
     /// MCS message channel ID assigned by the server, once negotiated.
     pub message_channel_id: Option<u16>,
     /// Multitransport flags the server advertised in its GCC
-    /// `MultiTransportChannelData` block, if it sent one. Retained because the
-    /// Initiate Multitransport Response is only permitted once both peers have
-    /// advertised Soft-Sync; see [`Self::soft_sync_negotiated`].
+    /// `MultiTransportChannelData` block, if it sent one. Retained because
+    /// MS-RDPBCGR 2.2.15.2 permits an `S_OK` response only to a server that
+    /// advertised `SOFTSYNC_TCP_TO_UDP`, so the outcome reported back depends on
+    /// what both peers advertised.
     pub server_multitransport_flags: Option<gcc::MultiTransportFlags>,
 }
 
@@ -238,14 +241,13 @@ impl ClientConnector {
         }
     }
 
-    /// Whether Soft-Sync (`SOFTSYNC_TCP_TO_UDP`) was mutually advertised.
+    /// Whether Soft-Sync (`SOFTSYNC_TCP_TO_UDP`) was mutually advertised, meaning
+    /// both peers set the flag in their GCC `MultiTransportChannelData` block.
     ///
-    /// Per [\[MS-RDPBCGR\] 2.2.15.2] the Initiate Multitransport Response is
-    /// the Soft-Sync signalling path, and is only sent when *both* peers
-    /// advertised the flag in their GCC `MultiTransportChannelData` block.
-    /// Without Soft-Sync the client reports the outcome in band on the new
-    /// transport and sends nothing back on the main channel, so emitting a
-    /// response there would be a protocol violation rather than a courtesy.
+    /// This does not by itself decide whether a response is sent. It gates
+    /// success only: per [\[MS-RDPBCGR\] 2.2.15.2] `S_OK` "MUST only be sent to a
+    /// server that advertises the SOFTSYNC_TCP_TO_UDP flag", while a failure is
+    /// reported either way. See [`Self::multitransport_response_channel`].
     ///
     /// [\[MS-RDPBCGR\] 2.2.15.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/44044233-e498-46f8-8e16-1ffa595a8e8b
     fn soft_sync_negotiated(&self) -> bool {
@@ -354,8 +356,9 @@ impl ClientConnector {
     /// [`multitransport_request()`](Self::multitransport_request).
     ///
     /// The connector builds the response PDU internally from the stored request
-    /// ID, sends it on the MCS message channel when Soft-Sync was mutually
-    /// negotiated, and returns to reading. The next PDU may be a second request
+    /// ID, sends it on the MCS message channel when one is owed for this outcome,
+    /// and returns to reading. A failure is always reported; success is withheld
+    /// unless Soft-Sync was negotiated, per MS-RDPBCGR 2.2.15.2. The next PDU may be a second request
     /// or the Demand Active that ends bootstrapping; either way the caller does
     /// not have to know which.
     ///
@@ -372,8 +375,9 @@ impl ClientConnector {
     /// Decline the multitransport request currently surfaced.
     ///
     /// Use this when the application doesn't support or doesn't want UDP
-    /// transport. Under Soft-Sync this sends `E_ABORT`, which MS-RDPBCGR
-    /// 3.2.5.15.1 requires; the server then continues TCP-only.
+    /// transport. This reports `E_ABORT`, which MS-RDPBCGR 3.2.5.15.1 asks for
+    /// whenever the client cannot initiate the sideband channel, with no
+    /// Soft-Sync condition attached; the server then continues TCP-only.
     ///
     /// Returns an error if the connector is not in `MultitransportPending`
     /// state.
@@ -388,12 +392,17 @@ impl ClientConnector {
     /// The channel an Initiate Multitransport Response goes out on, or `None`
     /// when no response is owed.
     ///
-    /// Without Soft-Sync the response PDU has no place on the main channel:
-    /// MS-RDPBCGR 2.2.15.2 makes it the Soft-Sync signalling path, and the
-    /// outcome is otherwise reported in band on the new transport. With
-    /// Soft-Sync the message channel is presupposed, and falling back to the
-    /// I/O channel would put the response somewhere the server is not reading,
-    /// so its absence is an error rather than a reason to improvise.
+    /// Which of the two applies is decided by the outcome as well as the mode.
+    /// MS-RDPBCGR 3.2.5.15.1 asks for a response whenever the client could not
+    /// initiate the sideband channel, with no Soft-Sync condition, and requires
+    /// one either way once Soft-Sync is negotiated. 2.2.15.2 restricts only
+    /// `S_OK`, which "MUST only be sent to a server that advertises the
+    /// SOFTSYNC_TCP_TO_UDP flag". So a failure is reported whenever there is a
+    /// channel to report it on, and only success is withheld.
+    ///
+    /// Under Soft-Sync the message channel is presupposed, and falling back to
+    /// the I/O channel would put the response somewhere the server is not
+    /// reading, so its absence is an error rather than a reason to improvise.
     ///
     /// Borrows rather than consuming, so the caller can resolve this while the
     /// connector is still in a state it can act on.

--- a/crates/ironrdp-connector/src/lib.rs
+++ b/crates/ironrdp-connector/src/lib.rs
@@ -24,7 +24,9 @@ use ironrdp_pdu::{PduHint, gcc, x224};
 pub use sspi;
 
 pub use self::channel_connection::{ChannelConnectionSequence, ChannelConnectionState};
-pub use self::connection::{ClientConnector, ClientConnectorState, ConnectionResult, encode_send_data_request};
+pub use self::connection::{
+    ClientConnector, ClientConnectorState, ConnectionResult, MultitransportResult, encode_send_data_request,
+};
 pub use self::connection_finalization::{ConnectionFinalizationSequence, ConnectionFinalizationState};
 pub use self::license_exchange::{LicenseExchangeSequence, LicenseExchangeState};
 pub use self::server_name::ServerName;

--- a/crates/ironrdp-fuzzing/src/oracles/mod.rs
+++ b/crates/ironrdp-fuzzing/src/oracles/mod.rs
@@ -108,7 +108,9 @@ pub fn pdu_decode(data: &[u8]) {
     };
     use ironrdp_pdu::mcs::{ConnectInitial, ConnectResponse, McsMessage};
     use ironrdp_pdu::nego::{ConnectionConfirm, ConnectionRequest};
-    use ironrdp_pdu::rdp::{ClientInfoPdu, capability_sets, headers, server_error_info, server_license, vc};
+    use ironrdp_pdu::rdp::{
+        ClientInfoPdu, capability_sets, headers, multitransport, server_error_info, server_license, vc,
+    };
     use ironrdp_pdu::x224::X224;
     use ironrdp_pdu::{bitmap, codecs, fast_path, gcc, input, pcb, surface_commands};
 
@@ -130,6 +132,11 @@ pub fn pdu_decode(data: &[u8]) {
     let _ = decode::<gcc::ConferenceCreateResponse>(data);
 
     let _ = decode::<server_license::LicensePdu>(data);
+
+    // Post-licensing multitransport bootstrapping: the connector try-decodes
+    // arbitrary server bytes as a request to distinguish it from Demand Active.
+    let _ = decode::<multitransport::MultitransportRequestPdu>(data);
+    let _ = decode::<multitransport::MultitransportResponsePdu>(data);
 
     let _ = decode::<vc::ChannelPduHeader>(data);
 
@@ -235,7 +242,7 @@ pub fn pdu_round_trip(data: &[u8]) {
     use ironrdp_pdu::nego::{ConnectionConfirm, ConnectionRequest};
     use ironrdp_pdu::rdp::capability_sets::CapabilitySet;
     use ironrdp_pdu::rdp::headers::ShareControlHeader;
-    use ironrdp_pdu::rdp::{ClientInfoPdu, server_error_info, server_license, vc};
+    use ironrdp_pdu::rdp::{ClientInfoPdu, multitransport, server_error_info, server_license, vc};
     use ironrdp_pdu::x224::X224;
     use ironrdp_pdu::{bitmap, codecs, fast_path, gcc, input, pcb, surface_commands};
 
@@ -262,6 +269,10 @@ pub fn pdu_round_trip(data: &[u8]) {
 
     // Licensing
     pdu_round_trip_one!(data, server_license::LicensePdu);
+
+    // Multitransport bootstrapping (server request / client response)
+    pdu_round_trip_one!(data, multitransport::MultitransportRequestPdu);
+    pdu_round_trip_one!(data, multitransport::MultitransportResponsePdu);
 
     // Virtual channel header
     pdu_round_trip_one!(data, vc::ChannelPduHeader);

--- a/crates/ironrdp-pdu/src/rdp/multitransport.rs
+++ b/crates/ironrdp-pdu/src/rdp/multitransport.rs
@@ -115,8 +115,17 @@ impl<'de> Decode<'de> for MultitransportRequestPdu {
 
         let security_header = BasicSecurityHeader::decode(src)?;
 
-        if !security_header.flags.contains(BasicSecurityHeaderFlags::TRANSPORT_REQ) {
-            return Err(invalid_field_err!("securityHeader", "expected TRANSPORT_REQ flag"));
+        // Must be EXACTLY SEC_TRANSPORT_REQ (MS-RDPBCGR 2.2.15.1), not merely
+        // contain the bit. A `contains` check false-positives when this decode
+        // is used to distinguish a request from another PDU: e.g. a Demand
+        // Active's leading `ShareControlHeader::totalLength` aliases onto this
+        // flags field and can carry the TRANSPORT_REQ bit as part of an
+        // otherwise-valid flag combination.
+        if security_header.flags != BasicSecurityHeaderFlags::TRANSPORT_REQ {
+            return Err(invalid_field_err!(
+                "securityHeader",
+                "expected securityHeader flags to be exactly SEC_TRANSPORT_REQ"
+            ));
         }
 
         let request_id = src.read_u32();
@@ -229,8 +238,13 @@ impl<'de> Decode<'de> for MultitransportResponsePdu {
 
         let security_header = BasicSecurityHeader::decode(src)?;
 
-        if !security_header.flags.contains(BasicSecurityHeaderFlags::TRANSPORT_RSP) {
-            return Err(invalid_field_err!("securityHeader", "expected TRANSPORT_RSP flag"));
+        // Must be EXACTLY SEC_TRANSPORT_RSP (MS-RDPBCGR 2.2.15.2), not merely
+        // contain the bit; see the note on `MultitransportRequestPdu::decode`.
+        if security_header.flags != BasicSecurityHeaderFlags::TRANSPORT_RSP {
+            return Err(invalid_field_err!(
+                "securityHeader",
+                "expected securityHeader flags to be exactly SEC_TRANSPORT_RSP"
+            ));
         }
 
         let request_id = src.read_u32();

--- a/crates/ironrdp-pdu/src/rdp/multitransport.rs
+++ b/crates/ironrdp-pdu/src/rdp/multitransport.rs
@@ -115,22 +115,24 @@ impl<'de> Decode<'de> for MultitransportRequestPdu {
 
         let security_header = BasicSecurityHeader::decode(src)?;
 
-        // Must be EXACTLY SEC_TRANSPORT_REQ (MS-RDPBCGR 2.2.15.1), not merely
-        // contain the bit. Callers use a successful decode to decide that what
-        // arrived really is a request, so a `contains` check would accept any
-        // PDU whose leading bytes happen to alias onto this field with the
-        // TRANSPORT_REQ bit set. The connector narrows by MCS channel first,
-        // but the message channel also carries auto-detect traffic, so this
-        // decode is still the thing that has to tell them apart.
+        // MS-RDPBCGR 2.2.15.1 requires the flags to *contain* SEC_TRANSPORT_REQ,
+        // and 2.2.8.1.1.2.1 says SEC_RESET_SEQNO and SEC_IGNORE_SEQNO "MUST be
+        // ignored", so they are masked off before comparing rather than treated
+        // as a mismatch.
         //
-        // Note this guard is only as strong as what `BasicSecurityHeader`
-        // admits: a decoder that masks unknown bits away rather than rejecting
-        // them widens the set of byte patterns that reach the comparison
-        // already equal to TRANSPORT_REQ.
-        if security_header.flags != BasicSecurityHeaderFlags::TRANSPORT_REQ {
+        // What remains is compared for equality, which is stricter than the
+        // spec requires and deliberately so: a successful decode is what tells
+        // the connector that what arrived really is a request. The connector
+        // narrows by MCS channel first, but the message channel also carries
+        // auto-detect traffic, whose SEC_AUTODETECT_REQ/RSP a bare `contains`
+        // check would happily accept as a multitransport request.
+        let flags = security_header
+            .flags
+            .difference(BasicSecurityHeaderFlags::RESET_SEQNO | BasicSecurityHeaderFlags::IGNORE_SEQNO);
+        if flags != BasicSecurityHeaderFlags::TRANSPORT_REQ {
             return Err(invalid_field_err!(
                 "securityHeader",
-                "expected securityHeader flags to be exactly SEC_TRANSPORT_REQ"
+                "expected securityHeader flags to contain SEC_TRANSPORT_REQ and no other PDU-type flag"
             ));
         }
 
@@ -390,6 +392,38 @@ mod tests {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ];
         assert!(ironrdp_core::decode::<MultitransportRequestPdu>(bad_wire).is_err());
+    }
+
+    /// MS-RDPBCGR 2.2.8.1.1.2.1 says SEC_RESET_SEQNO and SEC_IGNORE_SEQNO "MUST
+    /// be ignored", and the spec's own worked examples carry them alongside other
+    /// flags. Rejecting a request that sets them would abort the connection over
+    /// bits the client is told to disregard.
+    #[test]
+    fn decode_request_ignores_the_seqno_flags() {
+        for (label, flags) in [
+            ("SEC_TRANSPORT_REQ | SEC_RESET_SEQNO", 0x0012u16),
+            ("SEC_TRANSPORT_REQ | SEC_IGNORE_SEQNO", 0x0022),
+            ("SEC_TRANSPORT_REQ | both seqno flags", 0x0032),
+        ] {
+            let mut wire = REQUEST_WIRE.to_vec();
+            wire[0..2].copy_from_slice(&flags.to_le_bytes());
+
+            let pdu = ironrdp_core::decode::<MultitransportRequestPdu>(&wire)
+                .unwrap_or_else(|e| panic!("{label} must decode: {e}"));
+            assert_eq!(pdu.request_id, 42, "{label}");
+        }
+    }
+
+    /// The equality check past the ignorable flags is what keeps other traffic on
+    /// the shared message channel from decoding as a request. Auto-detect is the
+    /// case that actually shares the channel.
+    #[test]
+    fn decode_request_rejects_another_pdu_type_alongside_transport_req() {
+        let mut wire = REQUEST_WIRE.to_vec();
+        // SEC_TRANSPORT_REQ | SEC_AUTODETECT_REQ
+        wire[0..2].copy_from_slice(&0x1002u16.to_le_bytes());
+
+        assert!(ironrdp_core::decode::<MultitransportRequestPdu>(&wire).is_err());
     }
 
     #[test]

--- a/crates/ironrdp-pdu/src/rdp/multitransport.rs
+++ b/crates/ironrdp-pdu/src/rdp/multitransport.rs
@@ -246,12 +246,17 @@ impl<'de> Decode<'de> for MultitransportResponsePdu {
 
         let security_header = BasicSecurityHeader::decode(src)?;
 
-        // Must be EXACTLY SEC_TRANSPORT_RSP (MS-RDPBCGR 2.2.15.2), not merely
-        // contain the bit; see the note on `MultitransportRequestPdu::decode`.
-        if security_header.flags != BasicSecurityHeaderFlags::TRANSPORT_RSP {
+        // MS-RDPBCGR 2.2.15.2 requires the flags to *contain* SEC_TRANSPORT_RSP,
+        // and the ignorable sequence-number flags are masked off first, exactly as
+        // on the request side; see the note on `MultitransportRequestPdu::decode`
+        // for why what remains is then compared for equality.
+        let flags = security_header
+            .flags
+            .difference(BasicSecurityHeaderFlags::RESET_SEQNO | BasicSecurityHeaderFlags::IGNORE_SEQNO);
+        if flags != BasicSecurityHeaderFlags::TRANSPORT_RSP {
             return Err(invalid_field_err!(
                 "securityHeader",
-                "expected securityHeader flags to be exactly SEC_TRANSPORT_RSP"
+                "expected securityHeader flags to contain SEC_TRANSPORT_RSP and no other PDU-type flag"
             ));
         }
 
@@ -396,34 +401,55 @@ mod tests {
 
     /// MS-RDPBCGR 2.2.8.1.1.2.1 says SEC_RESET_SEQNO and SEC_IGNORE_SEQNO "MUST
     /// be ignored", and the spec's own worked examples carry them alongside other
-    /// flags. Rejecting a request that sets them would abort the connection over
-    /// bits the client is told to disregard.
+    /// flags. Rejecting a PDU that sets them would abort the connection over bits
+    /// the peer is told to disregard.
+    ///
+    /// Both directions are covered because the two decoders are symmetric: 2.2.15.1
+    /// and 2.2.15.2 each say the flags MUST *contain* their respective discriminator.
     #[test]
-    fn decode_request_ignores_the_seqno_flags() {
-        for (label, flags) in [
-            ("SEC_TRANSPORT_REQ | SEC_RESET_SEQNO", 0x0012u16),
-            ("SEC_TRANSPORT_REQ | SEC_IGNORE_SEQNO", 0x0022),
-            ("SEC_TRANSPORT_REQ | both seqno flags", 0x0032),
-        ] {
-            let mut wire = REQUEST_WIRE.to_vec();
-            wire[0..2].copy_from_slice(&flags.to_le_bytes());
+    fn decode_ignores_the_seqno_flags_in_both_directions() {
+        const RESET_SEQNO: u16 = 0x0010;
+        const IGNORE_SEQNO: u16 = 0x0020;
 
-            let pdu = ironrdp_core::decode::<MultitransportRequestPdu>(&wire)
-                .unwrap_or_else(|e| panic!("{label} must decode: {e}"));
-            assert_eq!(pdu.request_id, 42, "{label}");
+        for (label, base) in [("request", 0x0002u16), ("response", 0x0004)] {
+            for (variant, extra) in [
+                ("SEC_RESET_SEQNO", RESET_SEQNO),
+                ("SEC_IGNORE_SEQNO", IGNORE_SEQNO),
+                ("both seqno flags", RESET_SEQNO | IGNORE_SEQNO),
+            ] {
+                let flags = base | extra;
+
+                if base == 0x0002 {
+                    let mut wire = REQUEST_WIRE.to_vec();
+                    wire[0..2].copy_from_slice(&flags.to_le_bytes());
+                    let pdu = ironrdp_core::decode::<MultitransportRequestPdu>(&wire)
+                        .unwrap_or_else(|e| panic!("{label} with {variant} must decode: {e}"));
+                    assert_eq!(pdu.request_id, 42, "{label} with {variant}");
+                } else {
+                    let mut wire = RESPONSE_SUCCESS_WIRE.to_vec();
+                    wire[0..2].copy_from_slice(&flags.to_le_bytes());
+                    let pdu = ironrdp_core::decode::<MultitransportResponsePdu>(&wire)
+                        .unwrap_or_else(|e| panic!("{label} with {variant} must decode: {e}"));
+                    assert_eq!(pdu.request_id, 42, "{label} with {variant}");
+                }
+            }
         }
     }
 
     /// The equality check past the ignorable flags is what keeps other traffic on
-    /// the shared message channel from decoding as a request. Auto-detect is the
-    /// case that actually shares the channel.
+    /// the shared message channel from decoding as multitransport. Auto-detect is
+    /// the case that actually shares the channel.
     #[test]
-    fn decode_request_rejects_another_pdu_type_alongside_transport_req() {
-        let mut wire = REQUEST_WIRE.to_vec();
-        // SEC_TRANSPORT_REQ | SEC_AUTODETECT_REQ
-        wire[0..2].copy_from_slice(&0x1002u16.to_le_bytes());
+    fn decode_rejects_another_pdu_type_alongside_the_discriminator_in_both_directions() {
+        const AUTODETECT_REQ: u16 = 0x1000;
 
-        assert!(ironrdp_core::decode::<MultitransportRequestPdu>(&wire).is_err());
+        let mut request = REQUEST_WIRE.to_vec();
+        request[0..2].copy_from_slice(&(0x0002u16 | AUTODETECT_REQ).to_le_bytes());
+        assert!(ironrdp_core::decode::<MultitransportRequestPdu>(&request).is_err());
+
+        let mut response = RESPONSE_SUCCESS_WIRE.to_vec();
+        response[0..2].copy_from_slice(&(0x0004u16 | AUTODETECT_REQ).to_le_bytes());
+        assert!(ironrdp_core::decode::<MultitransportResponsePdu>(&response).is_err());
     }
 
     #[test]

--- a/crates/ironrdp-pdu/src/rdp/multitransport.rs
+++ b/crates/ironrdp-pdu/src/rdp/multitransport.rs
@@ -116,11 +116,17 @@ impl<'de> Decode<'de> for MultitransportRequestPdu {
         let security_header = BasicSecurityHeader::decode(src)?;
 
         // Must be EXACTLY SEC_TRANSPORT_REQ (MS-RDPBCGR 2.2.15.1), not merely
-        // contain the bit. A `contains` check false-positives when this decode
-        // is used to distinguish a request from another PDU: e.g. a Demand
-        // Active's leading `ShareControlHeader::totalLength` aliases onto this
-        // flags field and can carry the TRANSPORT_REQ bit as part of an
-        // otherwise-valid flag combination.
+        // contain the bit. Callers use a successful decode to decide that what
+        // arrived really is a request, so a `contains` check would accept any
+        // PDU whose leading bytes happen to alias onto this field with the
+        // TRANSPORT_REQ bit set. The connector narrows by MCS channel first,
+        // but the message channel also carries auto-detect traffic, so this
+        // decode is still the thing that has to tell them apart.
+        //
+        // Note this guard is only as strong as what `BasicSecurityHeader`
+        // admits: a decoder that masks unknown bits away rather than rejecting
+        // them widens the set of byte patterns that reach the comparison
+        // already equal to TRANSPORT_REQ.
         if security_header.flags != BasicSecurityHeaderFlags::TRANSPORT_REQ {
             return Err(invalid_field_err!(
                 "securityHeader",

--- a/crates/ironrdp-testsuite-core/tests/session/connection_activation.rs
+++ b/crates/ironrdp-testsuite-core/tests/session/connection_activation.rs
@@ -465,11 +465,10 @@ fn complete_multitransport_carries_failure_results() {
 }
 
 #[test]
-fn complete_multitransport_omits_responses_without_soft_sync() {
-    // MS-RDPBCGR 2.2.15.2 makes the Initiate Multitransport Response the
-    // Soft-Sync signalling path. Without Soft-Sync mutually advertised the
-    // client reports the outcome in band on the new transport, so nothing may
-    // go back on the main channel.
+fn complete_multitransport_omits_success_without_soft_sync() {
+    // MS-RDPBCGR 2.2.15.2: `S_OK` "MUST only be sent to a server that advertises
+    // the SOFTSYNC_TCP_TO_UDP flag". Success is therefore the one outcome that
+    // has to stay off the wire here; the failure case below still reports.
     let mut connector = multitransport_pending_connector(false, multitransport_request(1, RequestedProtocol::UdpFecR));
     let mut output = WriteBuf::new();
 
@@ -479,7 +478,7 @@ fn complete_multitransport_omits_responses_without_soft_sync() {
 
     assert!(
         output.filled().is_empty(),
-        "no response may be emitted when Soft-Sync was not negotiated"
+        "S_OK may not be emitted when Soft-Sync was not negotiated"
     );
     assert!(matches!(
         connector.state,
@@ -513,15 +512,27 @@ fn skip_multitransport_declines_with_e_abort_under_soft_sync() {
 }
 
 #[test]
-fn skip_multitransport_stays_silent_without_soft_sync() {
+fn skip_multitransport_reports_e_abort_without_soft_sync() {
+    // MS-RDPBCGR 3.2.5.15.1 asks for the response whenever the client could not
+    // initiate the sideband channel, with no Soft-Sync condition attached, and
+    // only `S_OK` is restricted by 2.2.15.2. Declining is a failure, so it is
+    // reported either way.
     let mut connector = multitransport_pending_connector(false, multitransport_request(1, RequestedProtocol::UdpFecR));
     let mut output = WriteBuf::new();
 
     connector.skip_multitransport(&mut output).unwrap();
 
-    assert!(
-        output.filled().is_empty(),
-        "no E_ABORT may be emitted when Soft-Sync was never negotiated"
+    let X224(McsMessage::SendDataRequest(request)) = decode(output.filled()).unwrap() else {
+        panic!("declining must put a failure response on the wire");
+    };
+    assert_eq!(request.channel_id, MESSAGE_CHANNEL_ID);
+
+    let response: MultitransportResponsePdu = decode(&request.user_data).unwrap();
+    assert_eq!(response.request_id, 1);
+    assert_eq!(
+        response.hr_response,
+        MultitransportResponsePdu::E_ABORT,
+        "the specified failure report must not be dropped just because Soft-Sync is absent"
     );
 }
 
@@ -576,6 +587,14 @@ fn complete_multitransport_outside_pending_state_errors() {
         connector
             .complete_multitransport(MultitransportResult::Success, &mut output)
             .is_err()
+    );
+
+    // The error must not cost the caller the state it was in. Reporting
+    // "you called this from the wrong state" while destroying that state
+    // leaves nothing to recover to.
+    assert!(
+        matches!(connector.state, ClientConnectorState::CapabilitiesExchange { .. }),
+        "the connector must still be in CapabilitiesExchange after the outside-state error"
     );
 }
 

--- a/crates/ironrdp-testsuite-core/tests/session/connection_activation.rs
+++ b/crates/ironrdp-testsuite-core/tests/session/connection_activation.rs
@@ -13,7 +13,7 @@ use ironrdp_pdu::rdp::headers::{
     BasicSecurityHeader, BasicSecurityHeaderFlags, CompressionFlags, ServerDeactivateAll, ShareControlHeader,
     ShareControlPdu, ShareDataHeader, ShareDataPdu, StreamPriority,
 };
-use ironrdp_pdu::rdp::multitransport::{MultitransportRequestPdu, RequestedProtocol};
+use ironrdp_pdu::rdp::multitransport::{MultitransportRequestPdu, MultitransportResponsePdu, RequestedProtocol};
 use ironrdp_pdu::rdp::server_error_info::{ErrorInfo, ProtocolIndependentCode, ServerSetErrorInfoPdu};
 use ironrdp_pdu::x224::X224;
 
@@ -21,6 +21,7 @@ use ironrdp_testsuite_core::capsets::SERVER_DEMAND_ACTIVE;
 
 const USER_CHANNEL_ID: u16 = 1002;
 const IO_CHANNEL_ID: u16 = 1003;
+const MESSAGE_CHANNEL_ID: u16 = 1004;
 const SHARE_ID: u32 = 0x0001_0000;
 
 fn test_config() -> ironrdp_connector::Config {
@@ -274,92 +275,293 @@ fn multitransport_request(request_id: u32, requested_protocol: RequestedProtocol
     }
 }
 
-/// A connector parked in `MultitransportPending` with `requests` outstanding and
-/// a real Demand Active buffered, ready for `complete`/`skip` to replay.
-fn multitransport_pending_connector(requests: Vec<MultitransportRequestPdu>) -> ClientConnector {
-    let buffered_demand_active =
-        encode_server_share_control(ShareControlPdu::ServerDemandActive(SERVER_DEMAND_ACTIVE.clone()));
+/// A connector parked in `MultitransportPending` with one request outstanding.
+///
+/// `soft_sync` mirrors what the connector would have derived from both peers'
+/// GCC `MultiTransportChannelData` flags, and decides whether the response paths
+/// are allowed to put an Initiate Multitransport Response on the message channel.
+fn multitransport_pending_connector(soft_sync: bool, request: MultitransportRequestPdu) -> ClientConnector {
     let mut connector = ClientConnector::new(test_config(), "127.0.0.1:3389".parse().unwrap());
     connector.state = ClientConnectorState::MultitransportPending {
         io_channel_id: IO_CHANNEL_ID,
         user_channel_id: USER_CHANNEL_ID,
-        requests,
-        buffered_demand_active,
+        message_channel_id: Some(MESSAGE_CHANNEL_ID),
+        request,
+        requests_seen: 1,
+        soft_sync,
+    };
+    connector
+}
+
+/// Encode an Initiate Multitransport Request as a server-to-client
+/// SendDataIndication on the given channel.
+fn encode_server_multitransport_request(request: &MultitransportRequestPdu, channel_id: u16) -> Vec<u8> {
+    let indication = McsMessage::SendDataIndication(SendDataIndication {
+        initiator_id: USER_CHANNEL_ID,
+        channel_id,
+        user_data: Cow::Owned(encode_vec(request).unwrap()),
+    });
+
+    encode_vec(&X224(indication)).unwrap()
+}
+
+/// A connector parked in `MultitransportBootstrapping`, as it would be straight
+/// out of licensing.
+fn multitransport_bootstrapping_connector() -> ClientConnector {
+    let mut connector = ClientConnector::new(test_config(), "127.0.0.1:3389".parse().unwrap());
+    connector.state = ClientConnectorState::MultitransportBootstrapping {
+        io_channel_id: IO_CHANNEL_ID,
+        user_channel_id: USER_CHANNEL_ID,
+        message_channel_id: Some(MESSAGE_CHANNEL_ID),
+        requests_seen: 0,
     };
     connector
 }
 
 #[test]
-fn should_perform_multitransport_reflects_pending_state() {
-    let connector = multitransport_pending_connector(vec![multitransport_request(1, RequestedProtocol::UdpFecR)]);
-    assert!(connector.should_perform_multitransport());
-    assert_eq!(connector.multitransport_requests().len(), 1);
+fn multitransport_request_is_surfaced_without_waiting_for_another_pdu() {
+    // The one that matters: MS-RDPBCGR 3.2.5.15.1 requires the client to act on
+    // a request as soon as it decodes it. A server may send a single request and
+    // then wait for the client to bring UDP up before sending Demand Active, so
+    // a connector that holds the request until some later PDU arrives deadlocks
+    // against a server that is itself waiting.
+    let mut connector = multitransport_bootstrapping_connector();
+    let frame = encode_server_multitransport_request(
+        &multitransport_request(1, RequestedProtocol::UdpFecR),
+        MESSAGE_CHANNEL_ID,
+    );
+    let mut output = WriteBuf::new();
+
+    connector.step(&frame, &mut output).unwrap();
+
+    assert!(
+        connector.should_perform_multitransport(),
+        "the request must be surfaced on arrival, not held pending a following PDU"
+    );
+    assert_eq!(connector.multitransport_request().unwrap().request_id, 1);
 }
 
 #[test]
-fn complete_multitransport_replays_demand_active_and_advances() {
-    let mut connector = multitransport_pending_connector(vec![
-        multitransport_request(1, RequestedProtocol::UdpFecR),
-        multitransport_request(2, RequestedProtocol::UdpFecL),
-    ]);
+fn responding_returns_to_bootstrapping_for_the_next_request() {
+    // Two requests are permitted, and the second only arrives after the first
+    // has been answered, so the connector has to go back to reading rather than
+    // straight on to capabilities exchange.
+    let mut connector = multitransport_bootstrapping_connector();
     let mut output = WriteBuf::new();
 
-    let written = connector
-        .complete_multitransport(
-            &[MultitransportResult::Success, MultitransportResult::Success],
-            &mut output,
-        )
-        .unwrap();
+    for request_id in 1..=2 {
+        let frame = encode_server_multitransport_request(
+            &multitransport_request(request_id, RequestedProtocol::UdpFecR),
+            MESSAGE_CHANNEL_ID,
+        );
+        connector.step(&frame, &mut output).unwrap();
+        assert!(connector.should_perform_multitransport());
+        assert_eq!(connector.multitransport_request().unwrap().request_id, request_id);
+
+        connector
+            .complete_multitransport(MultitransportResult::Success, &mut output)
+            .unwrap();
+    }
 
     assert!(
-        written != Written::Nothing,
-        "responses plus the replayed ClientConfirmActive"
+        matches!(
+            connector.state,
+            ClientConnectorState::MultitransportBootstrapping { requests_seen: 2, .. }
+        ),
+        "after the second response the connector must still be reading, with the cap tracked"
     );
+}
+
+#[test]
+fn third_multitransport_request_is_rejected() {
+    // MS-RDPBCGR 2.2.15.1 caps the set at two, one per transport protocol.
+    let mut connector = multitransport_bootstrapping_connector();
+    let mut output = WriteBuf::new();
+
+    for request_id in 1..=2 {
+        let frame = encode_server_multitransport_request(
+            &multitransport_request(request_id, RequestedProtocol::UdpFecR),
+            MESSAGE_CHANNEL_ID,
+        );
+        connector.step(&frame, &mut output).unwrap();
+        connector
+            .complete_multitransport(MultitransportResult::Success, &mut output)
+            .unwrap();
+    }
+
+    let frame = encode_server_multitransport_request(
+        &multitransport_request(3, RequestedProtocol::UdpFecR),
+        MESSAGE_CHANNEL_ID,
+    );
+    assert!(connector.step(&frame, &mut output).is_err());
+}
+
+#[test]
+fn demand_active_on_the_io_channel_ends_bootstrapping() {
+    // The I/O channel is no longer speculatively decoded as multitransport; a
+    // PDU arriving there is the Demand Active and ends the phase.
+    let mut connector = multitransport_bootstrapping_connector();
+    let frame = encode_server_share_control(ShareControlPdu::ServerDemandActive(SERVER_DEMAND_ACTIVE.clone()));
+    let mut output = WriteBuf::new();
+
+    connector.step(&frame, &mut output).unwrap();
+
     assert!(
         matches!(connector.state, ClientConnectorState::ConnectionFinalization { .. }),
-        "connector must advance past the buffered Demand Active on completion"
+        "a Demand Active must take the connector out of bootstrapping"
     );
     assert!(!connector.should_perform_multitransport());
+}
+
+#[test]
+fn should_perform_multitransport_reflects_pending_state() {
+    let connector = multitransport_pending_connector(true, multitransport_request(1, RequestedProtocol::UdpFecR));
+    assert!(connector.should_perform_multitransport());
+    assert_eq!(connector.multitransport_request().unwrap().request_id, 1);
+}
+
+#[test]
+fn complete_multitransport_responds_on_the_message_channel() {
+    // MS-RDPBCGR 2.2.15.2 and 3.2.5.15.2 put the Initiate Multitransport
+    // Response on the negotiated MCS message channel. Sending it on the I/O
+    // channel means a Soft-Sync server never sees it, and since both channels
+    // are valid MCS targets nothing downstream would notice.
+    let mut connector = multitransport_pending_connector(true, multitransport_request(1, RequestedProtocol::UdpFecR));
+    let mut output = WriteBuf::new();
+
+    connector
+        .complete_multitransport(MultitransportResult::Success, &mut output)
+        .unwrap();
+
+    let X224(McsMessage::SendDataRequest(request)) = decode(output.filled()).unwrap() else {
+        panic!("the multitransport response must be written");
+    };
+
+    assert_eq!(
+        request.channel_id, MESSAGE_CHANNEL_ID,
+        "the response must target the MCS message channel, not the I/O channel"
+    );
+
+    let response: MultitransportResponsePdu = decode(&request.user_data).unwrap();
+    assert_eq!(response.hr_response, MultitransportResponsePdu::S_OK);
 }
 
 #[test]
 fn complete_multitransport_carries_failure_results() {
-    let mut connector = multitransport_pending_connector(vec![multitransport_request(7, RequestedProtocol::UdpFecR)]);
+    let mut connector = multitransport_pending_connector(true, multitransport_request(7, RequestedProtocol::UdpFecR));
     let mut output = WriteBuf::new();
 
-    let written = connector
-        .complete_multitransport(&[MultitransportResult::Failure(0x8000_0001)], &mut output)
+    connector
+        .complete_multitransport(MultitransportResult::Failure(0x8000_0001), &mut output)
         .unwrap();
 
-    assert!(written != Written::Nothing);
+    let X224(McsMessage::SendDataRequest(request)) = decode(output.filled()).unwrap() else {
+        panic!("the multitransport response must be written");
+    };
+    let response: MultitransportResponsePdu = decode(&request.user_data).unwrap();
+
+    assert_eq!(response.request_id, 7);
+    assert_eq!(response.hr_response, 0x8000_0001);
+}
+
+#[test]
+fn complete_multitransport_omits_responses_without_soft_sync() {
+    // MS-RDPBCGR 2.2.15.2 makes the Initiate Multitransport Response the
+    // Soft-Sync signalling path. Without Soft-Sync mutually advertised the
+    // client reports the outcome in band on the new transport, so nothing may
+    // go back on the main channel.
+    let mut connector = multitransport_pending_connector(false, multitransport_request(1, RequestedProtocol::UdpFecR));
+    let mut output = WriteBuf::new();
+
+    connector
+        .complete_multitransport(MultitransportResult::Success, &mut output)
+        .unwrap();
+
+    assert!(
+        output.filled().is_empty(),
+        "no response may be emitted when Soft-Sync was not negotiated"
+    );
     assert!(matches!(
         connector.state,
-        ClientConnectorState::ConnectionFinalization { .. }
+        ClientConnectorState::MultitransportBootstrapping { .. }
     ));
 }
 
 #[test]
-fn skip_multitransport_replays_demand_active_and_advances() {
-    let mut connector = multitransport_pending_connector(vec![multitransport_request(1, RequestedProtocol::UdpFecR)]);
+fn skip_multitransport_declines_with_e_abort_under_soft_sync() {
+    // MS-RDPBCGR 3.2.5.15.1 requires a response to every request once Soft-Sync
+    // is mutually negotiated, whatever the outcome. Both the async and blocking
+    // drivers skip automatically, so a silent skip leaves a compliant server
+    // waiting on a response it is entitled to.
+    let mut connector = multitransport_pending_connector(true, multitransport_request(1, RequestedProtocol::UdpFecR));
     let mut output = WriteBuf::new();
 
-    let written = connector.skip_multitransport(&mut output).unwrap();
+    connector.skip_multitransport(&mut output).unwrap();
 
-    assert!(written != Written::Nothing, "the replayed ClientConfirmActive");
-    assert!(matches!(
-        connector.state,
-        ClientConnectorState::ConnectionFinalization { .. }
-    ));
-    assert!(!connector.should_perform_multitransport());
+    let X224(McsMessage::SendDataRequest(request)) = decode(output.filled()).unwrap() else {
+        panic!("a declined multitransport must still put a response on the wire");
+    };
+    assert_eq!(request.channel_id, MESSAGE_CHANNEL_ID);
+
+    let response: MultitransportResponsePdu = decode(&request.user_data).unwrap();
+    assert_eq!(
+        response.hr_response,
+        MultitransportResponsePdu::E_ABORT,
+        "declining must report E_ABORT, not success"
+    );
+    assert_eq!(response.request_id, 1);
 }
 
 #[test]
-fn complete_multitransport_rejects_result_count_mismatch() {
-    let mut connector = multitransport_pending_connector(vec![multitransport_request(1, RequestedProtocol::UdpFecR)]);
+fn skip_multitransport_stays_silent_without_soft_sync() {
+    let mut connector = multitransport_pending_connector(false, multitransport_request(1, RequestedProtocol::UdpFecR));
     let mut output = WriteBuf::new();
 
-    // One outstanding request, zero results provided.
-    assert!(connector.complete_multitransport(&[], &mut output).is_err());
+    connector.skip_multitransport(&mut output).unwrap();
+
+    assert!(
+        output.filled().is_empty(),
+        "no E_ABORT may be emitted when Soft-Sync was never negotiated"
+    );
+}
+
+#[test]
+fn failing_to_respond_leaves_the_connector_able_to_act() {
+    // A Soft-Sync session with no message channel is contradictory and the
+    // response cannot be sent. The error must not also destroy the state: a
+    // connector left `Consumed` gives the caller nothing to inspect, no way to
+    // retry, and no way to decline.
+    let mut connector = ClientConnector::new(test_config(), "127.0.0.1:3389".parse().unwrap());
+    connector.state = ClientConnectorState::MultitransportPending {
+        io_channel_id: IO_CHANNEL_ID,
+        user_channel_id: USER_CHANNEL_ID,
+        message_channel_id: None,
+        request: multitransport_request(1, RequestedProtocol::UdpFecR),
+        requests_seen: 1,
+        soft_sync: true,
+    };
+    let mut output = WriteBuf::new();
+
+    assert!(
+        connector
+            .complete_multitransport(MultitransportResult::Success, &mut output)
+            .is_err()
+    );
+
+    assert!(
+        connector.should_perform_multitransport(),
+        "the connector must still be in MultitransportPending after a failed response"
+    );
+    assert_eq!(
+        connector.multitransport_request().unwrap().request_id,
+        1,
+        "the request must survive so the caller can see what failed"
+    );
+
+    // And the failure is reported the same way a second time rather than
+    // degenerating into an outside-state error.
+    assert!(connector.skip_multitransport(&mut output).is_err());
+    assert!(connector.should_perform_multitransport());
 }
 
 #[test]
@@ -370,18 +572,11 @@ fn complete_multitransport_outside_pending_state_errors() {
     };
     let mut output = WriteBuf::new();
 
-    assert!(connector.complete_multitransport(&[], &mut output).is_err());
-}
-
-#[test]
-fn skip_multitransport_outside_pending_state_errors() {
-    let mut connector = ClientConnector::new(test_config(), "127.0.0.1:3389".parse().unwrap());
-    connector.state = ClientConnectorState::CapabilitiesExchange {
-        connection_activation: ConnectionActivationSequence::new(test_config(), IO_CHANNEL_ID, USER_CHANNEL_ID),
-    };
-    let mut output = WriteBuf::new();
-
-    assert!(connector.skip_multitransport(&mut output).is_err());
+    assert!(
+        connector
+            .complete_multitransport(MultitransportResult::Success, &mut output)
+            .is_err()
+    );
 }
 
 #[test]

--- a/crates/ironrdp-testsuite-core/tests/session/connection_activation.rs
+++ b/crates/ironrdp-testsuite-core/tests/session/connection_activation.rs
@@ -1,16 +1,19 @@
 use std::borrow::Cow;
 
 use ironrdp_connector::connection_activation::{ConnectionActivationSequence, ConnectionActivationState};
-use ironrdp_connector::{ClientConnector, ClientConnectorState, Credentials, DesktopSize, Sequence as _, Written};
-use ironrdp_core::{WriteBuf, encode_vec};
+use ironrdp_connector::{
+    ClientConnector, ClientConnectorState, Credentials, DesktopSize, MultitransportResult, Sequence as _, Written,
+};
+use ironrdp_core::{WriteBuf, decode, encode_vec};
 use ironrdp_pdu::gcc;
 use ironrdp_pdu::mcs::{McsMessage, SendDataIndication};
 use ironrdp_pdu::rdp::capability_sets::MajorPlatformType;
 use ironrdp_pdu::rdp::client_info::CompressionType;
 use ironrdp_pdu::rdp::headers::{
-    CompressionFlags, ServerDeactivateAll, ShareControlHeader, ShareControlPdu, ShareDataHeader, ShareDataPdu,
-    StreamPriority,
+    BasicSecurityHeader, BasicSecurityHeaderFlags, CompressionFlags, ServerDeactivateAll, ShareControlHeader,
+    ShareControlPdu, ShareDataHeader, ShareDataPdu, StreamPriority,
 };
+use ironrdp_pdu::rdp::multitransport::{MultitransportRequestPdu, RequestedProtocol};
 use ironrdp_pdu::rdp::server_error_info::{ErrorInfo, ProtocolIndependentCode, ServerSetErrorInfoPdu};
 use ironrdp_pdu::x224::X224;
 
@@ -258,4 +261,144 @@ fn demand_active_without_input_capability_yields_empty_input_flags() {
         }
         other => panic!("expected ConnectionFinalization, got: {other:?}"),
     }
+}
+
+fn multitransport_request(request_id: u32, requested_protocol: RequestedProtocol) -> MultitransportRequestPdu {
+    MultitransportRequestPdu {
+        security_header: BasicSecurityHeader {
+            flags: BasicSecurityHeaderFlags::TRANSPORT_REQ,
+        },
+        request_id,
+        requested_protocol,
+        security_cookie: [0u8; 16],
+    }
+}
+
+/// A connector parked in `MultitransportPending` with `requests` outstanding and
+/// a real Demand Active buffered, ready for `complete`/`skip` to replay.
+fn multitransport_pending_connector(requests: Vec<MultitransportRequestPdu>) -> ClientConnector {
+    let buffered_demand_active =
+        encode_server_share_control(ShareControlPdu::ServerDemandActive(SERVER_DEMAND_ACTIVE.clone()));
+    let mut connector = ClientConnector::new(test_config(), "127.0.0.1:3389".parse().unwrap());
+    connector.state = ClientConnectorState::MultitransportPending {
+        io_channel_id: IO_CHANNEL_ID,
+        user_channel_id: USER_CHANNEL_ID,
+        requests,
+        buffered_demand_active,
+    };
+    connector
+}
+
+#[test]
+fn should_perform_multitransport_reflects_pending_state() {
+    let connector = multitransport_pending_connector(vec![multitransport_request(1, RequestedProtocol::UdpFecR)]);
+    assert!(connector.should_perform_multitransport());
+    assert_eq!(connector.multitransport_requests().len(), 1);
+}
+
+#[test]
+fn complete_multitransport_replays_demand_active_and_advances() {
+    let mut connector = multitransport_pending_connector(vec![
+        multitransport_request(1, RequestedProtocol::UdpFecR),
+        multitransport_request(2, RequestedProtocol::UdpFecL),
+    ]);
+    let mut output = WriteBuf::new();
+
+    let written = connector
+        .complete_multitransport(
+            &[MultitransportResult::Success, MultitransportResult::Success],
+            &mut output,
+        )
+        .unwrap();
+
+    assert!(
+        written != Written::Nothing,
+        "responses plus the replayed ClientConfirmActive"
+    );
+    assert!(
+        matches!(connector.state, ClientConnectorState::ConnectionFinalization { .. }),
+        "connector must advance past the buffered Demand Active on completion"
+    );
+    assert!(!connector.should_perform_multitransport());
+}
+
+#[test]
+fn complete_multitransport_carries_failure_results() {
+    let mut connector = multitransport_pending_connector(vec![multitransport_request(7, RequestedProtocol::UdpFecR)]);
+    let mut output = WriteBuf::new();
+
+    let written = connector
+        .complete_multitransport(&[MultitransportResult::Failure(0x8000_0001)], &mut output)
+        .unwrap();
+
+    assert!(written != Written::Nothing);
+    assert!(matches!(
+        connector.state,
+        ClientConnectorState::ConnectionFinalization { .. }
+    ));
+}
+
+#[test]
+fn skip_multitransport_replays_demand_active_and_advances() {
+    let mut connector = multitransport_pending_connector(vec![multitransport_request(1, RequestedProtocol::UdpFecR)]);
+    let mut output = WriteBuf::new();
+
+    let written = connector.skip_multitransport(&mut output).unwrap();
+
+    assert!(written != Written::Nothing, "the replayed ClientConfirmActive");
+    assert!(matches!(
+        connector.state,
+        ClientConnectorState::ConnectionFinalization { .. }
+    ));
+    assert!(!connector.should_perform_multitransport());
+}
+
+#[test]
+fn complete_multitransport_rejects_result_count_mismatch() {
+    let mut connector = multitransport_pending_connector(vec![multitransport_request(1, RequestedProtocol::UdpFecR)]);
+    let mut output = WriteBuf::new();
+
+    // One outstanding request, zero results provided.
+    assert!(connector.complete_multitransport(&[], &mut output).is_err());
+}
+
+#[test]
+fn complete_multitransport_outside_pending_state_errors() {
+    let mut connector = ClientConnector::new(test_config(), "127.0.0.1:3389".parse().unwrap());
+    connector.state = ClientConnectorState::CapabilitiesExchange {
+        connection_activation: ConnectionActivationSequence::new(test_config(), IO_CHANNEL_ID, USER_CHANNEL_ID),
+    };
+    let mut output = WriteBuf::new();
+
+    assert!(connector.complete_multitransport(&[], &mut output).is_err());
+}
+
+#[test]
+fn skip_multitransport_outside_pending_state_errors() {
+    let mut connector = ClientConnector::new(test_config(), "127.0.0.1:3389".parse().unwrap());
+    connector.state = ClientConnectorState::CapabilitiesExchange {
+        connection_activation: ConnectionActivationSequence::new(test_config(), IO_CHANNEL_ID, USER_CHANNEL_ID),
+    };
+    let mut output = WriteBuf::new();
+
+    assert!(connector.skip_multitransport(&mut output).is_err());
+}
+
+#[test]
+fn demand_active_user_data_does_not_decode_as_multitransport_request() {
+    // The connector distinguishes a multitransport request from a Demand Active
+    // by try-decoding the SendDataIndication user_data as MultitransportRequestPdu.
+    // A Demand Active must fail cleanly (the decoder validates SEC_TRANSPORT_REQ),
+    // otherwise the bootstrapping state would swallow the Demand Active.
+    let share_control_header = ShareControlHeader {
+        share_control_pdu: ShareControlPdu::ServerDemandActive(SERVER_DEMAND_ACTIVE.clone()),
+        pdu_source: USER_CHANNEL_ID,
+        share_id: SHARE_ID,
+    };
+    let user_data = encode_vec(&share_control_header).unwrap();
+
+    assert!(
+        decode::<MultitransportRequestPdu>(&user_data).is_err(),
+        "a Demand Active must not be mistaken for a multitransport request"
+    );
 }


### PR DESCRIPTION
## Summary

Makes the `MultitransportBootstrapping` state functional instead of a no-op
pass-through. After licensing the server may send 0, 1, or 2 Initiate
Multitransport Request PDUs before capabilities exchange. Each one is surfaced
to the application, which establishes UDP transport (RDPEUDP2 + TLS + RDPEMT)
or declines, and the connector reports the outcome back to the server.

## API

Mirrors the existing `should_perform_X()` pause-point pattern used by TLS
upgrade and CredSSP, but uses `complete_X()` / `skip_X()` rather than
`mark_X_as_done()` because completion carries result data:

- `should_perform_multitransport()`: true while a request awaits an outcome
- `multitransport_request()`: the request awaiting an outcome, or `None`
- `complete_multitransport(result, output)`: report the outcome, resume
- `skip_multitransport(output)`: decline, resume

`complete_multitransport` accepts a `MultitransportResult` (a `Success` /
`Failure(hresult)` enum) rather than a caller-built response PDU. The connector
builds the response internally from the stored request ID.

Requests are surfaced one at a time rather than as a batch. There is no end
marker for the set, and MS-RDPBCGR 3.2.5.15.1 requires the client to act on a
request as soon as it decodes one, so waiting to learn how many are coming is
not an option the protocol offers. `should_perform_multitransport()` can
therefore come round twice; the caller answers reliable and lossy separately.

## Approach

**Routing.** Requests arrive on the negotiated MCS message channel
(2.2.15.1) and the Demand Active on the I/O channel, so the channel decides
which is which. The message channel also carries NetworkAutoDetect since #1348,
so a decode still confirms what arrived there, but the I/O channel is never
speculatively decoded as multitransport. A PDU on neither channel is an error.

For the decode to be a sound confirmation the request decoder must reject a
Demand Active, so this PR also tightens `MultitransportRequestPdu` to require
the exact `SEC_TRANSPORT_REQ` security-header flag.

**Yielding.** Each request is surfaced the moment it decodes. Responding
returns the connector to `MultitransportBootstrapping` to read whatever comes
next, which may be a second request or the Demand Active. Nothing is buffered
and nothing is replayed: when the request is surfaced the Demand Active has not
arrived yet.

**Soft-Sync.** The Initiate Multitransport Response is the Soft-Sync
signalling path (2.2.15.2), permitted only when both peers advertised
`SOFTSYNC_TCP_TO_UDP` in their GCC `MultiTransportChannelData`. The server's
block is retained from the GCC exchange and checked against the client's
configured flags. One rule covers both paths:

- Soft-Sync negotiated: always respond, `S_OK` or `E_ABORT`, including on
  `skip_multitransport()`, which 3.2.5.15.1 requires. Both the async and
  blocking drivers skip automatically, so without this every default client
  leaves a compliant server waiting.
- Not negotiated: never respond. The outcome is reported in band on the new
  transport, and putting anything on the main channel would be the violation.

The response goes on the message channel per 2.2.15.2 and 3.2.5.15.2. If
Soft-Sync was negotiated but no message channel exists the connector errors
rather than falling back to the I/O channel, and that check runs before the
pending state is taken, so the caller is left with a connector it can still
inspect or decline from.

## Wire behaviour

On the wire TCP and UDP negotiation happen in parallel: the UDP transport is
established alongside the ongoing TCP handshake, and its completion signals the
dynamic-channel layer that subsequent channels may migrate to UDP. The
connector's API yield point here is a Rust affordance, not a spec-mandated TCP
pause. Thanks to @hardening for the correction.

## Tests

Connector state-machine tests in `ironrdp-testsuite-core` drive the public API
with the shared `SERVER_DEMAND_ACTIVE` fixture:

- a request is surfaced on arrival, without waiting for a following PDU
  (regression test for the stall);
- responding returns to bootstrapping so a second request is read normally;
- a third request is rejected per the 2.2.15.1 cap;
- a Demand Active on the I/O channel ends bootstrapping;
- the response targets the message channel, decoded back off the wire;
- a `Failure` result is carried through;
- `skip` sends `E_ABORT` under Soft-Sync, and nothing without it;
- `complete` emits nothing without Soft-Sync but still resumes;
- a failed response leaves the connector in `MultitransportPending`, still able
  to report or decline, rather than `Consumed`;
- `complete` / `skip` outside `MultitransportPending` error;
- a Demand Active's user data does not decode as a `MultitransportRequestPdu`
  (regression test for the decoder tightening above).

Fuzzing: `MultitransportRequestPdu` and `MultitransportResponsePdu` are added
to the `pdu_decode` and `pdu_round_trip` oracles, so the decode surface is
fuzzed against arbitrary input (auto-discovered into the fuzz CI matrix). Both
targets smoke-run clean.

Full end-to-end coverage against a live server still awaits server-side
`MultitransportRequestPdu` emission, which `ironrdp::server::RdpServer` does
not implement yet.

## Breaking changes

`cargo semver-checks` reports three, so the title carries the marker:

- `ClientConnector` gains the public field `server_multitransport_flags`, so struct literals need updating (`constructible_struct_adds_field`).
- `ClientConnectorState::MultitransportBootstrapping` gains `message_channel_id` and `requests_seen` (`enum_struct_variant_field_added`).
- Three `ClientConnectorState` discriminants shift, because the new variants are inserted mid-enum (`enum_no_repr_variant_discriminant_changed`).

The third I would call a false positive worth naming rather than designing around: `ClientConnectorState` is `#[non_exhaustive]`, has no `repr`, and every variant carries fields, so there is no `as` cast a downstream crate could have depended on. The first two are real.

## Verification

- `cargo xtask check fmt -v` green
- `cargo xtask check lints -v` green
- `cargo xtask check tests -v` green
- `cargo xtask check typos -v` green
- `cargo xtask check locks -v` green

## References

Builds on: #1091
Related: #140, #1348

