### PR TITLE
Add pointer caching support to ironrdp-server

### DIFF
--- a/crates/ironrdp-server/src/display.rs
+++ b/crates/ironrdp-server/src/display.rs
@@ -25,10 +25,12 @@ pub enum DisplayUpdate {
     RGBAPointer(RGBAPointer),
     HidePointer,
     DefaultPointer,
+    CachedPointer(u16),
 }
 
 #[derive(Clone)]
 pub struct RGBAPointer {
+    pub cache_index: u16,
     pub width: u16,
     pub height: u16,
     pub hot_x: u16,
@@ -50,6 +52,7 @@ impl core::fmt::Debug for RGBAPointer {
 
 #[derive(Debug, Clone)]
 pub struct ColorPointer {
+    pub cache_index: u16,
     pub width: u16,
     pub height: u16,
     pub hot_x: u16,


### PR DESCRIPTION
Currently, pointer updates are always sent as fresh `ColorPointer`/`NewPointer` PDUs with `cache_index` hardcoded to `0`, meaning that clients always receive a full pointer bitmap when the cursor changes, even for pointers they've already seen.

This adds `CachedPointer(u16)` to the `DisplayUpdate` enum and a `cache_index` field to `ColorPointer`/`RGBAPointer`, so that server implementations can assign cache slots to pointers and later re-select them cheaply via `CachedPointer` updates. The underlying PDU type `CachedPointerAttribute` and update code `UpdateCode::CachedPointer` already existed in ironrdp-pdu; this PR just wire them up in the server encoder.

PS: I've added this because the back-to-back pointer updates seemed to be the reason for a crash of `sdl-freerdp` I've been experiencing. Running my server with this patch (and caching the pointers) fixed the issue.
