### PR TITLE
feat(connector,session): dispatch multitransport PDUs on IO channel

### DIFF
--- a/crates/ironrdp-session/src/active_stage.rs
+++ b/crates/ironrdp-session/src/active_stage.rs
@@ -297,12 +297,12 @@ pub enum ActiveStageOutput {
     PointerBitmap(Arc<DecodedPointer>),
     Terminate(GracefulDisconnectReason),
     DeactivateAll(Box<ConnectionActivationSequence>),
-    /// Server Initiate Multitransport Request. The application should establish a
-    /// sideband UDP transport using the provided request parameters.
+    /// [2.2.15.1] Server Initiate Multitransport Request PDU
     ///
-    /// See [\[MS-RDPBCGR\] 2.2.15.1].
+    /// The application should establish a sideband UDP transport using the
+    /// provided request parameters.
     ///
-    /// [\[MS-RDPBCGR\] 2.2.15.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/de783158-8b01-4818-8fb0-62523a5b3490
+    /// [2.2.15.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/de783158-8b01-4818-8fb0-62523a5b3490
     MultitransportRequest(MultitransportRequestPdu),
 }
 

--- a/crates/ironrdp-session/src/x224/mod.rs
+++ b/crates/ironrdp-session/src/x224/mod.rs
@@ -24,13 +24,13 @@ pub enum ProcessorOutput {
     ///
     /// [Deactivation-Reactivation Sequence]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/dfc234ce-481a-4674-9a5d-2a7bafb14432
     DeactivateAll(Box<ConnectionActivationSequence>),
-    /// Server Initiate Multitransport Request. The application should establish a
-    /// sideband UDP transport using the request ID and security cookie, then send
-    /// a [`MultitransportResponsePdu`] back on the IO channel.
+    /// [2.2.15.1] Server Initiate Multitransport Request PDU
     ///
-    /// See [\[MS-RDPBCGR\] 2.2.15.1].
+    /// The application should establish a sideband UDP transport using the
+    /// request ID and security cookie, then send a [`MultitransportResponsePdu`]
+    /// back on the IO channel.
     ///
-    /// [\[MS-RDPBCGR\] 2.2.15.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/de783158-8b01-4818-8fb0-62523a5b3490
+    /// [2.2.15.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/de783158-8b01-4818-8fb0-62523a5b3490
     /// [`MultitransportResponsePdu`]: ironrdp_pdu::rdp::multitransport::MultitransportResponsePdu
     MultitransportRequest(MultitransportRequestPdu),
 }
@@ -183,8 +183,9 @@ impl Processor {
             }
             ironrdp_connector::legacy::IoChannelPdu::MultitransportRequest(pdu) => {
                 debug!(
-                    "Received Initiate Multitransport Request: request_id={}",
-                    pdu.request_id
+                    request_id = pdu.request_id,
+                    protocol = ?pdu.requested_protocol,
+                    "Received Initiate Multitransport Request"
                 );
                 Ok(vec![ProcessorOutput::MultitransportRequest(pdu)])
             }

--- a/ffi/src/session/mod.rs
+++ b/ffi/src/session/mod.rs
@@ -278,8 +278,9 @@ pub mod ffi {
 
         /// Returns the multitransport request ID and requested protocol.
         ///
-        /// The security cookie is intentionally not exposed — it is sensitive
-        /// and only needed internally for transport binding.
+        /// The security cookie is not yet exposed because UDP transport is not
+        /// currently implemented. It will be added when full multitransport
+        /// support is available.
         #[expect(
             clippy::as_conversions,
             reason = "RequestedProtocol is #[repr(u16)], cast is lossless"


### PR DESCRIPTION
Companion to #1098 — surfaces multitransport request PDUs through the session layer so applications can respond.

## What this does

After licensing, the server may send Initiate Multitransport Request PDUs on the IO channel. These use a `BasicSecurityHeader` rather than the usual `ShareControlHeader`, so they need special discrimination in `decode_io_channel`.

This PR:

- **ironrdp-connector**: Adds a `MultitransportRequest` variant to `IoChannelPdu` and discriminates it from `ShareControlHeader` by checking bytes `[2..4]` — `ShareControl` always has `pduType | PROTOCOL_VERSION` (≥ `0x11`) at that offset, while `BasicSecurityHeader` has `flagsHi == 0`.
- **ironrdp-session**: Propagates `MultitransportRequest` through `ProcessorOutput` → `ActiveStageOutput` so applications receive the event.
- **ffi**: Exposes the multitransport request fields via diplomat bindings (request ID + requested protocol; security cookie deferred until UDP transport is implemented).

## Discrimination approach

The key insight is that `ShareControlHeader` encodes `pduType | PROTOCOL_VERSION` at bytes `[2..4]`, which is always `>= 0x11`. A `BasicSecurityHeader` with `TRANSPORT_REQ` flag has `flagsHi == 0` at that same offset. This lets us cheaply distinguish the two header types without backtracking.

The discriminant logic uses an inner function (`try_decode_multitransport`) per the project's style guide preference for inner functions over single-use closures.

## Relationship to #1098

- **#1098** handles the connector-level handshake (collecting 0–2 multitransport requests during `MultitransportBootstrapping`).
- **This PR** handles the session-level dispatch (surfacing multitransport requests that arrive on the IO channel during the active stage).

Both are needed for full multitransport support, but they're independent — each modifies different files and can be reviewed/merged in either order.

Builds on: #1091
Related: #1098, #140