### PR TITLE
Add ECHO virtual channel support across IronRDP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2428,6 +2428,7 @@ dependencies = [
  "ironrdp-core",
  "ironrdp-displaycontrol",
  "ironrdp-dvc",
+ "ironrdp-echo",
  "ironrdp-graphics",
  "ironrdp-input",
  "ironrdp-pdu",
@@ -2659,6 +2660,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ironrdp-echo"
+version = "0.1.0"
+dependencies = [
+ "ironrdp-core",
+ "ironrdp-dvc",
+ "ironrdp-pdu",
+ "tracing",
+]
+
+[[package]]
 name = "ironrdp-egfx"
 version = "0.1.0"
 dependencies = [
@@ -2857,6 +2868,7 @@ dependencies = [
  "ironrdp-core",
  "ironrdp-displaycontrol",
  "ironrdp-dvc",
+ "ironrdp-echo",
  "ironrdp-egfx",
  "ironrdp-graphics",
  "ironrdp-pdu",

--- a/crates/ironrdp-client/Cargo.toml
+++ b/crates/ironrdp-client/Cargo.toml
@@ -29,6 +29,7 @@ rustls = ["ironrdp-tls/rustls", "tokio-tungstenite/rustls-tls-native-roots", "ir
 native-tls = ["ironrdp-tls/native-tls", "tokio-tungstenite/native-tls", "ironrdp-mstsgu/native-tls"]
 qoi = ["ironrdp/qoi"]
 qoiz = ["ironrdp/qoiz"]
+echo = ["ironrdp/echo"]
 
 [dependencies]
 # Protocols

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -8,6 +8,8 @@ use ironrdp::displaycontrol::client::DisplayControlClient;
 use ironrdp::displaycontrol::pdu::MonitorLayoutEntry;
 #[cfg(windows)]
 use ironrdp::dvc::DvcProcessor as _;
+#[cfg(feature = "echo")]
+use ironrdp::echo::client::EchoClient;
 use ironrdp::graphics::image_processing::PixelFormat;
 use ironrdp::graphics::pointer::DecodedPointer;
 use ironrdp::pdu::input::fast_path::FastPathInputEvent;
@@ -208,6 +210,11 @@ async fn connect(
     let mut drdynvc =
         ironrdp::dvc::DrdynvcClient::new().with_dynamic_channel(DisplayControlClient::new(|_| Ok(Vec::new())));
 
+    #[cfg(feature = "echo")]
+    {
+        drdynvc = drdynvc.with_dynamic_channel(EchoClient::new());
+    }
+
     // Instantiate all DVC proxies
     for proxy in config.dvc_pipe_proxies.iter() {
         let channel_name = proxy.channel_name.clone();
@@ -330,6 +337,11 @@ async fn connect_ws(
 
     let mut drdynvc =
         ironrdp::dvc::DrdynvcClient::new().with_dynamic_channel(DisplayControlClient::new(|_| Ok(Vec::new())));
+
+    #[cfg(feature = "echo")]
+    {
+        drdynvc = drdynvc.with_dynamic_channel(EchoClient::new());
+    }
 
     // Instantiate all DVC proxies
     for proxy in config.dvc_pipe_proxies.iter() {

--- a/crates/ironrdp-dvc/src/server.rs
+++ b/crates/ironrdp-dvc/src/server.rs
@@ -74,6 +74,19 @@ impl DrdynvcServer {
         }
     }
 
+    pub fn get_dvc_channel_id_by_type<T>(&self) -> Option<u32>
+    where
+        T: DvcServerProcessor + 'static,
+    {
+        self.dynamic_channels.iter().find_map(|(id, channel)| {
+            if channel.state != ChannelState::Opened || !channel.processor.as_any().is::<T>() {
+                return None;
+            }
+
+            id.try_into().ok()
+        })
+    }
+
     // FIXME(#61): it’s likely we want to enable adding dynamic channels at any point during the session (message passing? other approach?)
 
     #[must_use]

--- a/crates/ironrdp-echo/CHANGELOG.md
+++ b/crates/ironrdp-echo/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/ironrdp-echo/Cargo.toml
+++ b/crates/ironrdp-echo/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "ironrdp-echo"
+version = "0.1.0"
+readme = "README.md"
+description = "Virtual channel echo extension implementation"
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lib]
+doctest = false
+test = false
+
+[dependencies]
+ironrdp-core = { path = "../ironrdp-core", version = "0.1" } # public
+ironrdp-dvc = { path = "../ironrdp-dvc", version = "0.5" } # public
+ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.7" } # public
+tracing = { version = "0.1", features = ["log"] }
+
+[lints]
+workspace = true

--- a/crates/ironrdp-echo/README.md
+++ b/crates/ironrdp-echo/README.md
@@ -1,0 +1,11 @@
+# IronRDP Virtual Channel Echo Extension [MS-RDPEECO][1] implementation.
+
+Virtual Channel Echo Extension [MS-RDPEECO][1] implementation over Dynamic Virtual Channels [MS-RDPEDYC][2].
+
+This library includes:
+- ECHO request/response PDUs parsing and serialization
+- ECHO dynamic virtual channel client processor
+- ECHO dynamic virtual channel server processor
+
+[1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeeco/5f4f5b76-14f2-4807-bf8c-10fcb7f7f41c
+[2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpedyc/3bd53020-9b64-4c9a-97fc-90a79e7e1e06

--- a/crates/ironrdp-echo/src/client.rs
+++ b/crates/ironrdp-echo/src/client.rs
@@ -1,0 +1,40 @@
+use ironrdp_core::{decode, impl_as_any};
+use ironrdp_dvc::{DvcClientProcessor, DvcMessage, DvcProcessor};
+use ironrdp_pdu::{decode_err, PduResult};
+use tracing::debug;
+
+use crate::pdu::{EchoRequestPdu, EchoResponsePdu};
+use crate::CHANNEL_NAME;
+
+/// A client for the ECHO virtual channel.
+#[derive(Debug, Default)]
+pub struct EchoClient;
+
+impl EchoClient {
+    /// Creates a new [`EchoClient`].
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl_as_any!(EchoClient);
+
+impl DvcProcessor for EchoClient {
+    fn channel_name(&self) -> &str {
+        CHANNEL_NAME
+    }
+
+    fn start(&mut self, _channel_id: u32) -> PduResult<Vec<DvcMessage>> {
+        Ok(Vec::new())
+    }
+
+    fn process(&mut self, _channel_id: u32, payload: &[u8]) -> PduResult<Vec<DvcMessage>> {
+        let request: EchoRequestPdu = decode(payload).map_err(|e| decode_err!(e))?;
+        debug!(size = request.payload().len(), "Received ECHO request");
+
+        let response = EchoResponsePdu::new(request.into_payload());
+        Ok(vec![Box::new(response)])
+    }
+}
+
+impl DvcClientProcessor for EchoClient {}

--- a/crates/ironrdp-echo/src/lib.rs
+++ b/crates/ironrdp-echo/src/lib.rs
@@ -1,0 +1,9 @@
+#![cfg_attr(doc, doc = include_str!("../README.md"))]
+#![doc(html_logo_url = "https://cdnweb.devolutions.net/images/projects/devolutions/logos/devolutions-icon-shadow.svg")]
+
+/// ECHO dynamic virtual channel name per MS-RDPEECO.
+pub const CHANNEL_NAME: &str = "ECHO";
+
+pub mod client;
+pub mod pdu;
+pub mod server;

--- a/crates/ironrdp-echo/src/pdu.rs
+++ b/crates/ironrdp-echo/src/pdu.rs
@@ -1,0 +1,104 @@
+//! ECHO virtual channel extension PDUs [MS-RDPEECO][1] implementation.
+//!
+//! [1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeeco/5f4f5b76-14f2-4807-bf8c-10fcb7f7f41c
+
+use ironrdp_core::{ensure_size, Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor};
+use ironrdp_dvc::DvcEncode;
+
+/// 2.2.1 ECHO_REQUEST_PDU
+///
+/// [2.2.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeeco/bf2c9ef3-2f8b-40c2-b27d-ce9df72976f2
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EchoRequestPdu {
+    payload: Vec<u8>,
+}
+
+impl EchoRequestPdu {
+    const NAME: &'static str = "ECHO_REQUEST_PDU";
+
+    pub fn new(payload: Vec<u8>) -> Self {
+        Self { payload }
+    }
+
+    pub fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+
+    pub fn into_payload(self) -> Vec<u8> {
+        self.payload
+    }
+}
+
+impl Encode for EchoRequestPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.payload.len());
+        dst.write_slice(&self.payload);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        self.payload.len()
+    }
+}
+
+impl<'de> Decode<'de> for EchoRequestPdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        let payload = src.read_remaining().to_vec();
+        Ok(Self { payload })
+    }
+}
+
+impl DvcEncode for EchoRequestPdu {}
+
+/// 2.2.2 ECHO_RESPONSE_PDU
+///
+/// [2.2.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeeco/f95db8eb-fffd-4b76-9f8f-60322ea2dd2d
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EchoResponsePdu {
+    payload: Vec<u8>,
+}
+
+impl EchoResponsePdu {
+    const NAME: &'static str = "ECHO_RESPONSE_PDU";
+
+    pub fn new(payload: Vec<u8>) -> Self {
+        Self { payload }
+    }
+
+    pub fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+
+    pub fn into_payload(self) -> Vec<u8> {
+        self.payload
+    }
+}
+
+impl Encode for EchoResponsePdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.payload.len());
+        dst.write_slice(&self.payload);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        self.payload.len()
+    }
+}
+
+impl<'de> Decode<'de> for EchoResponsePdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        let payload = src.read_remaining().to_vec();
+        Ok(Self { payload })
+    }
+}
+
+impl DvcEncode for EchoResponsePdu {}

--- a/crates/ironrdp-echo/src/server.rs
+++ b/crates/ironrdp-echo/src/server.rs
@@ -1,0 +1,63 @@
+use ironrdp_core::{decode, impl_as_any};
+use ironrdp_dvc::{DvcMessage, DvcProcessor, DvcServerProcessor};
+use ironrdp_pdu::{decode_err, pdu_other_err, PduResult};
+use tracing::debug;
+
+use crate::pdu::{EchoRequestPdu, EchoResponsePdu};
+use crate::CHANNEL_NAME;
+
+/// A server for the ECHO virtual channel.
+#[derive(Debug, Default)]
+pub struct EchoServer {
+    initial_request: Option<Vec<u8>>,
+}
+
+impl EchoServer {
+    /// Creates a new [`EchoServer`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Configures an initial request that will be sent once the ECHO channel is opened.
+    #[must_use]
+    pub fn with_initial_request(mut self, payload: Vec<u8>) -> Self {
+        self.initial_request = Some(payload);
+        self
+    }
+
+    /// Builds a request message.
+    pub fn request_message(payload: Vec<u8>) -> PduResult<DvcMessage> {
+        if payload.is_empty() {
+            return Err(pdu_other_err!(
+                "EchoServer::request_message",
+                "echoRequest payload must be at least one byte"
+            ));
+        }
+
+        Ok(Box::new(EchoRequestPdu::new(payload)))
+    }
+}
+
+impl_as_any!(EchoServer);
+
+impl DvcProcessor for EchoServer {
+    fn channel_name(&self) -> &str {
+        CHANNEL_NAME
+    }
+
+    fn start(&mut self, _channel_id: u32) -> PduResult<Vec<DvcMessage>> {
+        if let Some(payload) = self.initial_request.take() {
+            return Ok(vec![Self::request_message(payload)?]);
+        }
+
+        Ok(Vec::new())
+    }
+
+    fn process(&mut self, _channel_id: u32, payload: &[u8]) -> PduResult<Vec<DvcMessage>> {
+        let response: EchoResponsePdu = decode(payload).map_err(|e| decode_err!(e))?;
+        debug!(size = response.payload().len(), "Received ECHO response");
+        Ok(Vec::new())
+    }
+}
+
+impl DvcServerProcessor for EchoServer {}

--- a/crates/ironrdp-echo/tests/echo.rs
+++ b/crates/ironrdp-echo/tests/echo.rs
@@ -1,0 +1,60 @@
+use ironrdp_core::{decode, encode_vec};
+use ironrdp_dvc::DvcProcessor as _;
+use ironrdp_echo::client::EchoClient;
+use ironrdp_echo::pdu::{EchoRequestPdu, EchoResponsePdu};
+use ironrdp_echo::server::EchoServer;
+use {ironrdp_pdu as _, tracing as _};
+
+#[test]
+fn request_pdu_roundtrip() {
+    let request = EchoRequestPdu::new(b"Hello world!".to_vec());
+    let encoded = encode_vec(&request).expect("request should encode");
+    let decoded: EchoRequestPdu = decode(&encoded).expect("request should decode");
+
+    assert_eq!(decoded.payload(), b"Hello world!");
+}
+
+#[test]
+fn response_pdu_roundtrip() {
+    let response = EchoResponsePdu::new(b"Hello world!".to_vec());
+    let encoded = encode_vec(&response).expect("response should encode");
+    let decoded: EchoResponsePdu = decode(&encoded).expect("response should decode");
+
+    assert_eq!(decoded.payload(), b"Hello world!");
+}
+
+#[test]
+fn client_echoes_request_payload() {
+    let mut client = EchoClient::new();
+    let request = EchoRequestPdu::new(b"ping".to_vec());
+    let encoded_request = encode_vec(&request).expect("request should encode");
+
+    let responses = client
+        .process(1, &encoded_request)
+        .expect("client should process request");
+
+    assert_eq!(responses.len(), 1);
+
+    let encoded_response = encode_vec(responses[0].as_ref()).expect("response should encode");
+    let response: EchoResponsePdu = decode(&encoded_response).expect("response should decode");
+    assert_eq!(response.payload(), b"ping");
+}
+
+#[test]
+fn server_with_initial_request_sends_one_message() {
+    let mut server = EchoServer::new().with_initial_request(b"probe".to_vec());
+
+    let messages = server.start(42).expect("server should start channel");
+
+    assert_eq!(messages.len(), 1);
+
+    let encoded_request = encode_vec(messages[0].as_ref()).expect("request should encode");
+    let request: EchoRequestPdu = decode(&encoded_request).expect("request should decode");
+    assert_eq!(request.payload(), b"probe");
+}
+
+#[test]
+fn server_rejects_empty_requests() {
+    let result = EchoServer::request_message(Vec::new());
+    assert!(result.is_err());
+}

--- a/crates/ironrdp-server/Cargo.toml
+++ b/crates/ironrdp-server/Cargo.toml
@@ -22,6 +22,7 @@ rayon = ["dep:rayon"]
 qoi = ["dep:qoicoubeh", "ironrdp-pdu/qoi"]
 qoiz = ["dep:zstd-safe", "qoi", "ironrdp-pdu/qoiz"]
 egfx = ["dep:ironrdp-egfx"]
+echo = ["dep:ironrdp-echo"]
 
 # Internal (PRIVATE!) features used to aid testing.
 # Don't rely on these whatsoever. They may disappear at any time.
@@ -39,6 +40,7 @@ ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.7" } # public
 ironrdp-svc = { path = "../ironrdp-svc", version = "0.6" } # public
 ironrdp-cliprdr = { path = "../ironrdp-cliprdr", version = "0.5" } # public
 ironrdp-displaycontrol = { path = "../ironrdp-displaycontrol", version = "0.5" } # public
+ironrdp-echo = { path = "../ironrdp-echo", version = "0.1", optional = true } # public
 ironrdp-dvc = { path = "../ironrdp-dvc", version = "0.5" } # public
 ironrdp-tokio = { path = "../ironrdp-tokio", version = "0.8", features = ["reqwest"] }
 ironrdp-acceptor = { path = "../ironrdp-acceptor", version = "0.8" } # public

--- a/crates/ironrdp-server/src/echo.rs
+++ b/crates/ironrdp-server/src/echo.rs
@@ -1,0 +1,156 @@
+use core::time::Duration;
+use std::collections::{BTreeMap, VecDeque};
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::Instant;
+
+use anyhow::{bail, Context as _, Result};
+use ironrdp_core::impl_as_any;
+use ironrdp_dvc::{DvcMessage, DvcProcessor, DvcServerProcessor};
+use ironrdp_echo::server::EchoServer;
+use ironrdp_pdu::PduResult;
+use tokio::sync::mpsc;
+
+use crate::server::ServerEvent;
+
+#[derive(Debug, Clone)]
+pub struct EchoRoundTripMeasurement {
+    pub payload: Vec<u8>,
+    pub round_trip_time: Duration,
+}
+
+#[derive(Debug)]
+pub enum EchoServerMessage {
+    SendRequest { payload: Vec<u8> },
+}
+
+impl core::fmt::Display for EchoServerMessage {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::SendRequest { payload } => write!(f, "SendRequest(size={})", payload.len()),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct EchoHandleState {
+    pending: BTreeMap<Vec<u8>, VecDeque<Instant>>,
+    measurements: VecDeque<EchoRoundTripMeasurement>,
+}
+
+/// Shared handle for runtime ECHO requests and RTT measurements.
+#[derive(Debug, Clone)]
+pub struct EchoServerHandle {
+    sender: mpsc::UnboundedSender<ServerEvent>,
+    state: Arc<Mutex<EchoHandleState>>,
+}
+
+impl EchoServerHandle {
+    pub(crate) fn new(sender: mpsc::UnboundedSender<ServerEvent>) -> Self {
+        Self {
+            sender,
+            state: Arc::new(Mutex::new(EchoHandleState::default())),
+        }
+    }
+
+    /// Sends a runtime ECHO request.
+    ///
+    /// The payload must be at least one byte, as required by MS-RDPEECO section 3.1.5.1.
+    pub fn send_request(&self, payload: Vec<u8>) -> Result<()> {
+        if payload.is_empty() {
+            bail!("echoRequest payload must be at least one byte");
+        }
+
+        self.sender
+            .send(ServerEvent::Echo(EchoServerMessage::SendRequest { payload }))
+            .map_err(|_error| anyhow::anyhow!("send ECHO request event"))
+    }
+
+    /// Drains collected RTT measurements.
+    pub fn take_measurements(&self) -> Vec<EchoRoundTripMeasurement> {
+        let mut state = self.lock_state();
+        state.measurements.drain(..).collect()
+    }
+
+    pub(crate) fn on_request_sent(&self, payload: &[u8]) {
+        let mut state = self.lock_state();
+        state
+            .pending
+            .entry(payload.to_vec())
+            .or_default()
+            .push_back(Instant::now());
+    }
+
+    fn on_response(&self, payload: &[u8]) {
+        let mut state = self.lock_state();
+        let Some(sent_at_queue) = state.pending.get_mut(payload) else {
+            return;
+        };
+
+        let Some(sent_at) = sent_at_queue.pop_front() else {
+            return;
+        };
+
+        if sent_at_queue.is_empty() {
+            state.pending.remove(payload);
+        }
+
+        state.measurements.push_back(EchoRoundTripMeasurement {
+            payload: payload.to_vec(),
+            round_trip_time: sent_at.elapsed(),
+        });
+    }
+
+    fn lock_state(&self) -> MutexGuard<'_, EchoHandleState> {
+        match self.state.lock() {
+            Ok(state) => state,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+}
+
+/// DVC bridge for ECHO that tracks RTT on responses.
+pub struct EchoDvcBridge {
+    inner: EchoServer,
+    handle: EchoServerHandle,
+}
+
+impl EchoDvcBridge {
+    pub fn new(handle: EchoServerHandle) -> Self {
+        Self {
+            inner: EchoServer::new(),
+            handle,
+        }
+    }
+
+    pub fn handle(&self) -> &EchoServerHandle {
+        &self.handle
+    }
+}
+
+impl_as_any!(EchoDvcBridge);
+
+impl DvcProcessor for EchoDvcBridge {
+    fn channel_name(&self) -> &str {
+        self.inner.channel_name()
+    }
+
+    fn start(&mut self, channel_id: u32) -> PduResult<Vec<DvcMessage>> {
+        self.inner.start(channel_id)
+    }
+
+    fn process(&mut self, channel_id: u32, payload: &[u8]) -> PduResult<Vec<DvcMessage>> {
+        let messages = self.inner.process(channel_id, payload)?;
+        self.handle.on_response(payload);
+        Ok(messages)
+    }
+
+    fn close(&mut self, channel_id: u32) {
+        self.inner.close(channel_id)
+    }
+}
+
+impl DvcServerProcessor for EchoDvcBridge {}
+
+pub(crate) fn build_echo_request(payload: Vec<u8>) -> Result<DvcMessage> {
+    EchoServer::request_message(payload).context("build ECHO request message")
+}

--- a/crates/ironrdp-server/src/lib.rs
+++ b/crates/ironrdp-server/src/lib.rs
@@ -10,6 +10,8 @@ mod builder;
 mod capabilities;
 mod clipboard;
 mod display;
+#[cfg(feature = "echo")]
+mod echo;
 mod encoder;
 #[cfg(feature = "egfx")]
 mod gfx;
@@ -21,6 +23,8 @@ mod sound;
 
 pub use clipboard::*;
 pub use display::*;
+#[cfg(feature = "echo")]
+pub use echo::*;
 #[cfg(feature = "egfx")]
 pub use gfx::*;
 pub use handler::*;

--- a/crates/ironrdp-testsuite-extra/Cargo.toml
+++ b/crates/ironrdp-testsuite-extra/Cargo.toml
@@ -14,7 +14,7 @@ categories.workspace = true
 [dev-dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-ironrdp = { path = "../ironrdp", features = ["server", "pdu", "connector", "session", "connector"] }
+ironrdp = { path = "../ironrdp", features = ["server", "pdu", "connector", "session", "dvc", "echo"] }
 ironrdp-async.path = "../ironrdp-async"
 ironrdp-tokio.path = "../ironrdp-tokio"
 ironrdp-tls = { path = "../ironrdp-tls", features = ["rustls"] }

--- a/crates/ironrdp/Cargo.toml
+++ b/crates/ironrdp/Cargo.toml
@@ -31,6 +31,7 @@ dvc = ["dep:ironrdp-dvc"]
 rdpdr = ["dep:ironrdp-rdpdr"]
 rdpsnd = ["dep:ironrdp-rdpsnd"]
 displaycontrol = ["dep:ironrdp-displaycontrol"]
+echo = ["dep:ironrdp-echo", "ironrdp-server?/echo"]
 qoi = ["ironrdp-server?/qoi", "ironrdp-pdu?/qoi", "ironrdp-connector?/qoi", "ironrdp-session?/qoi"]
 qoiz = ["ironrdp-server?/qoiz", "ironrdp-pdu?/qoiz", "ironrdp-connector?/qoiz", "ironrdp-session?/qoiz"]
 # Internal (PRIVATE!) features used to aid testing.
@@ -52,6 +53,7 @@ ironrdp-dvc = { path = "../ironrdp-dvc", version = "0.5", optional = true } # pu
 ironrdp-rdpdr = { path = "../ironrdp-rdpdr", version = "0.5", optional = true } # public
 ironrdp-rdpsnd = { path = "../ironrdp-rdpsnd", version = "0.7", optional = true } # public
 ironrdp-displaycontrol = { path = "../ironrdp-displaycontrol", version = "0.5", optional = true } # public
+ironrdp-echo = { path = "../ironrdp-echo", version = "0.1", optional = true } # public
 
 [dev-dependencies]
 ironrdp-blocking = { path = "../ironrdp-blocking", version = "0.8.0" }

--- a/crates/ironrdp/src/lib.rs
+++ b/crates/ironrdp/src/lib.rs
@@ -28,6 +28,10 @@ pub use ironrdp_core as core;
 #[doc(inline)]
 pub use ironrdp_displaycontrol as displaycontrol;
 
+#[cfg(feature = "echo")]
+#[doc(inline)]
+pub use ironrdp_echo as echo;
+
 #[cfg(feature = "dvc")]
 #[doc(inline)]
 pub use ironrdp_dvc as dvc;


### PR DESCRIPTION
## Summary
- add new ironrdp-echo crate with MS-RDPEECO PDUs and DVC client/server processors
- wire feature-gated cho support through ironrdp, ironrdp-client, and ironrdp-server
- add server-side runtime ECHO handle/bridge for request dispatch and RTT measurement tracking
- add end-to-end Echo virtual channel test in ironrdp-testsuite-extra
- update server docs and fix fmt/clippy/doctest issues for CI parity

## Validation
- cargo xtask check fmt -v
- cargo xtask check lints -v
- cargo xtask check tests -v
- cargo test -p ironrdp-server --doc --locked
