### PR TITLE
ci: run apt-get update before installing devel packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
       - name: Install devel packages
         if: ${{ runner.os == 'Linux' }}
         run: |
+          sudo apt-get update -qq
           sudo apt-get -y install libasound2-dev
 
       - name: Install NASM


### PR DESCRIPTION
## Summary
- Add `apt-get update` before `apt-get install` in the Linux CI job to prevent stale apt cache 404 errors

The `ubuntu-latest` runner's package index can reference superseded package versions (currently `libasound2-dev 1.2.11-1ubuntu0.1`), causing the install step to fail with a 404. This is currently breaking the Linux check on all open PRs (e.g. #1104).

## Test plan
- [ ] Verify `Checks [linux]` passes after merge