### PR TITLE
ci(coverage): install ALSA dev package on linux

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,6 +25,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install devel packages
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get -y install libasound2-dev
+
       - name: Rust cache
         uses: Swatinem/rust-cache@v2.7.3
 


### PR DESCRIPTION
## Summary
- install libasound2-dev in the Coverage workflow before running cargo xtask cov ...
- align coverage runner system dependencies with Linux CI checks

## Why
Recent Coverage failures in PRs were caused by lsa-sys failing to find lsa.pc during cargo llvm-cov (pkg-config error), while regular Linux CI already installs this package.

## Validation
- workflow file updated in .github/workflows/coverage.yml
- branch pushed; rerun of Coverage check should now compile crates depending on ALSA