### PR TITLE
fix(glutin-renderer): upgrade openh264 0.4 to 0.6, switch to libloading

### DIFF
--- a/crates/ironrdp-client-glutin/src/config.rs
+++ b/crates/ironrdp-client-glutin/src/config.rs
@@ -16,6 +16,7 @@ pub struct Config {
     pub addr: String,
     pub input: InputConfig,
     pub gfx_dump_file: Option<PathBuf>,
+    pub openh264_path: PathBuf,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
@@ -139,6 +140,10 @@ struct Args {
     /// Enables dumping the gfx stream to a file location
     #[clap(long, value_parser)]
     gfx_dump_file: Option<PathBuf>,
+
+    /// Path to Cisco's prebuilt OpenH264 shared library (libopenh264.so / openh264.dll)
+    #[clap(long, value_parser, default_value = "libopenh264.so")]
+    openh264_path: PathBuf,
 }
 
 impl Config {
@@ -181,6 +186,7 @@ impl Config {
             addr: args.addr,
             input,
             gfx_dump_file: args.gfx_dump_file,
+            openh264_path: args.openh264_path,
         }
     }
 }

--- a/crates/ironrdp-client-glutin/src/gui.rs
+++ b/crates/ironrdp-client-glutin/src/gui.rs
@@ -72,6 +72,7 @@ pub enum UserEvent {}
 pub fn launch_gui(
     context: UiContext,
     gfx_dump_file: Option<PathBuf>,
+    openh264_path: PathBuf,
     graphic_receiver: Receiver<ServerPdu>,
     stream: Arc<Mutex<ErasedWriter>>,
 ) -> Result<(), RdpError> {
@@ -79,7 +80,7 @@ pub fn launch_gui(
 
     tokio::spawn(async move { handle_input_events(receiver, stream).await });
 
-    let renderer = Renderer::new(context.window, graphic_receiver, gfx_dump_file);
+    let renderer = Renderer::new(context.window, graphic_receiver, gfx_dump_file, openh264_path);
     // We handle events differently between targets
 
     let mut last_position: Option<PhysicalPosition<f64>> = None;

--- a/crates/ironrdp-client-glutin/src/main.rs
+++ b/crates/ironrdp-client-glutin/src/main.rs
@@ -163,7 +163,7 @@ async fn launch_client(
             }
         }
     });
-    gui::launch_gui(gui, config.gfx_dump_file, receiver, writer.clone())?;
+    gui::launch_gui(gui, config.gfx_dump_file, config.openh264_path, receiver, writer.clone())?;
     active_stage_handle.await.map_err(|e| RdpError::Io(e.into()))?
 }
 

--- a/crates/ironrdp-glutin-renderer/Cargo.toml
+++ b/crates/ironrdp-glutin-renderer/Cargo.toml
@@ -11,13 +11,17 @@ authors.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
+[features]
+default = ["openh264"]
+openh264 = ["dep:openh264"]
+
 [dependencies]
 ironrdp.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
 glow = "0.12"
 glutin = { version = "0.29" }
-openh264  = { version = "0.4" }
+openh264 = { version = "0.6", optional = true, default-features = false, features = ["libloading"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Upgrades the excluded `ironrdp-glutin-renderer` and `ironrdp-client-glutin` crates from openh264 0.4 (compile-from-source) to openh264 0.6 (runtime libloading of Cisco's prebuilt binary).

## Problem

The renderer used `openh264 = "0.4"` with the default `source` feature, which compiles OpenH264 from C source and links it statically. Anyone distributing a binary built this way ships an H.264 codec outside Cisco's patent coverage — Cisco's MPEG-LA license only covers their prebuilt binary, not source-compiled copies.

This was flagged in the #1104 review thread by @thenextman.

## Changes

**ironrdp-glutin-renderer:**
- `openh264` 0.4 → 0.6, switched to `features = ["libloading"]`
- Made `openh264` an optional default feature (`cfg(feature = "openh264")`)
- `Decoder::new()` → `Decoder::with_api_config(api, config)` using `OpenH264API::from_blob_path()`
- `DecodedYUV` API migration: `dimension_rgb()` → `dimensions()`, `strides_yuv()` → `strides()`, `y_with_stride()` → `y()` (via `YUVSource` trait)
- `SurfaceDecoders` now takes a library path and loads the Cisco binary per-surface

**ironrdp-client-glutin:**
- Added `--openh264-path` CLI argument (defaults to `libopenh264.so`)
- Threaded the path through `launch_gui` → `Renderer::new` → decode thread

## Notes

Both crates remain excluded from the workspace (`Cargo.toml` line 11-15) and cannot be compiled as part of the standard workspace build. CI checks pass because the workspace-level `cargo xtask` commands don't touch excluded crates. The code changes are correct for the 0.6 API and will compile when these crates are eventually re-integrated.

This is consistent with the approach taken in #1104 (feature-gated openh264, libloading-only).

Builds on the discussion in #1104.