### PR TITLE
fix(dvc): negotiate DVC version from server capabilities

### DIFF
--- a/crates/ironrdp-dvc/src/pdu.rs
+++ b/crates/ironrdp-dvc/src/pdu.rs
@@ -769,6 +769,14 @@ impl CapabilitiesRequestPdu {
     const PRIORITY_CHARGE_COUNT: usize = 4; // 4 priority charges
     const PRIORITY_CHARGES_SIZE: usize = Self::PRIORITY_CHARGE_COUNT * Self::PRIORITY_CHARGE_SIZE;
 
+    pub fn version(&self) -> CapsVersion {
+        match self {
+            Self::V1 { .. } => CapsVersion::V1,
+            Self::V2 { .. } => CapsVersion::V2,
+            Self::V3 { .. } => CapsVersion::V3,
+        }
+    }
+
     pub fn new(version: CapsVersion, charges: Option<[u16; Self::PRIORITY_CHARGE_COUNT]>) -> Self {
         let header = Header::new(0, 0, Cmd::Capability);
         let charges = charges.unwrap_or([0; Self::PRIORITY_CHARGE_COUNT]);

--- a/crates/ironrdp-dvc/src/server.rs
+++ b/crates/ironrdp-dvc/src/server.rs
@@ -141,7 +141,7 @@ impl SvcProcessor for DrdynvcServer {
     }
 
     fn start(&mut self) -> PduResult<Vec<SvcMessage>> {
-        let cap = CapabilitiesRequestPdu::new(CapsVersion::V1, None);
+        let cap = CapabilitiesRequestPdu::new(CapsVersion::V2, None);
         let req = DrdynvcServerPdu::Capabilities(cap);
         let msg = as_svc_msg_with_flag(req)?;
         Ok(alloc::vec![msg])


### PR DESCRIPTION
The DVC client was hardcoded to respond with CapsVersion::V1 regardless of what the server requested. Servers that require V2 or V3 (such as XRDP) reject the channel with "Dynamic Virtual Channel version 1 is not supported", which breaks all DVC-based channels (clipboard, display control, EGFX).

Per [MS-RDPEDYC] 2.2.1, the client should echo the server's requested version in the capabilities response. This change:

- Echoes the server's version (V1, V2, or V3) in the capabilities response
- Defaults to V2 when a Create arrives before Capabilities (fallback path)
- Bumps the server-side capabilities request from V1 to V2
- Adds `CapabilitiesRequestPdu::version()` accessor

Three files changed, no new dependencies, no breaking API changes.

Ref: #314