### PR TITLE
fix(server): tile bitmaps that exceed `MultifragmentUpdate` limit

### DIFF
--- a/benches/src/perfenc.rs
+++ b/benches/src/perfenc.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<(), anyhow::Error> {
         OptCodec::QoiZ => update_codecs.set_qoiz(Some(0)),
     };
 
-    let mut encoder = UpdateEncoder::new(DesktopSize { width, height }, flags, update_codecs)
+    let mut encoder = UpdateEncoder::new(DesktopSize { width, height }, flags, update_codecs, 8 * 1024 * 1024)
         .context("failed to initialize update encoder")?;
 
     let mut total_raw = 0u64;

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -906,7 +906,7 @@ impl RdpServer {
         }
 
         let desktop_size = self.display.lock().await.size().await;
-        let encoder = UpdateEncoder::new(desktop_size, surface_flags, update_codecs)
+        let encoder = UpdateEncoder::new(desktop_size, surface_flags, update_codecs, self.opts.max_request_size)
             .context("failed to initialize update encoder")?;
 
         let state = self


### PR DESCRIPTION
The `NoneHandler` sends uncompressed surface commands whose size is proportional to the bitmap area. On large desktops (e.g. 3008x1692 at 32bpp ~ 20 MB), a single surface command easily exceeds the negotiated `MultifragmentUpdate` reassembly buffer (8 MB by default), causing clients to disconnect.

The approach here is to split oversized dirty rects into horizontal strips that fit within `max_request_size` before handing them to the bitmap encoder.