### PR TITLE
fix(acceptor): upgrade sspi, use NTLM when no Kerberos

### DIFF
--- a/crates/ironrdp-acceptor/src/credssp.rs
+++ b/crates/ironrdp-acceptor/src/credssp.rs
@@ -3,7 +3,7 @@ use ironrdp_connector::sspi::credssp::{
     CredSspServer, CredentialsProxy, ServerError, ServerMode, ServerState, TsRequest,
 };
 use ironrdp_connector::sspi::generator::{Generator, GeneratorState};
-use ironrdp_connector::sspi::negotiate::ProtocolConfig;
+use ironrdp_connector::sspi::ntlm::NtlmConfig;
 use ironrdp_connector::sspi::{self, AuthIdentity, KerberosServerConfig, NegotiateConfig, NetworkRequest, Username};
 use ironrdp_connector::{
     custom_err, general_err, ConnectorError, ConnectorErrorKind, ConnectorResult, ServerName, Written,
@@ -107,22 +107,18 @@ impl<'a> CredsspSequence<'a> {
         let client_computer_name = client_computer_name.into_inner();
         let credentials = CredentialsProxyImpl::new(creds);
 
-        let credssp_config: Box<dyn ProtocolConfig> = if let Some(krb_config) = krb_config {
-            Box::new(krb_config)
-        } else {
-            Box::<sspi::ntlm::NtlmConfig>::default()
-        };
-
-        let server = CredSspServer::new(
-            public_key,
-            credentials,
+        let server_mode = if let Some(krb_config) = krb_config {
             ServerMode::Negotiate(NegotiateConfig {
-                protocol_config: credssp_config,
+                protocol_config: Box::new(krb_config),
                 package_list: None,
                 client_computer_name,
-            }),
-        )
-        .map_err(|e| ConnectorError::new("CredSSP", ConnectorErrorKind::Credssp(e)))?;
+            })
+        } else {
+            ServerMode::Ntlm(NtlmConfig::new(client_computer_name))
+        };
+
+        let server = CredSspServer::new(public_key, credentials, server_mode)
+            .map_err(|e| ConnectorError::new("CredSSP", ConnectorErrorKind::Credssp(e)))?;
 
         let sequence = Self {
             server,

--- a/crates/ironrdp-connector/Cargo.toml
+++ b/crates/ironrdp-connector/Cargo.toml
@@ -27,13 +27,13 @@ ironrdp-core = { path = "../ironrdp-core", version = "0.1" } # public
 ironrdp-error = { path = "../ironrdp-error", version = "0.1" } # public
 ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.7", features = ["std"] } # public
 arbitrary = { version = "1", features = ["derive"], optional = true } # public
-sspi = { version = "0.18", features = ["scard"] }
+sspi = { git = "https://github.com/Devolutions/sspi-rs", rev = "2ded76b76734110d45de2270d3c782c561fe54d1", version = "0.18", features = ["scard"] } # FIXME: Replace with next sspi release
 url = "2.5" # public
 rand = { version = "0.9", features = ["std"] } # TODO: dependency injection?
 tracing = { version = "0.1", features = ["log"] }
 picky-asn1-der = "0.5"
 picky-asn1-x509 = "0.15"
-picky = "=7.0.0-rc.20" # FIXME: We are pinning with = because the candidate version number counts as the minor number by Cargo, and will be automatically bumped in the Cargo.lock.
+picky = "=7.0.0-rc.22" # FIXME: We are pinning with = because the candidate version number counts as the minor number by Cargo, and will be automatically bumped in the Cargo.lock.
 
 [lints]
 workspace = true

--- a/crates/ironrdp-connector/src/credssp.rs
+++ b/crates/ironrdp-connector/src/credssp.rs
@@ -35,7 +35,7 @@ impl From<KerberosConfig> for sspi::KerberosConfig {
     fn from(val: KerberosConfig) -> Self {
         sspi::KerberosConfig {
             kdc_url: val.kdc_proxy_url,
-            client_computer_name: val.hostname,
+            client_computer_name: val.hostname.unwrap_or_default(),
         }
     }
 }

--- a/crates/ironrdp-tokio/Cargo.toml
+++ b/crates/ironrdp-tokio/Cargo.toml
@@ -27,7 +27,7 @@ ironrdp-async = { path = "../ironrdp-async", version = "0.8" } # public
 ironrdp-connector = { path = "../ironrdp-connector", version = "0.8", optional = true }
 tokio = { version = "1", features = ["io-util"] }
 reqwest = { version = "0.12", default-features = false, features = ["http2", "system-proxy"], optional = true }
-sspi = { version = "0.18", features = ["network_client", "dns_resolver"], optional = true }
+sspi = { git = "https://github.com/Devolutions/sspi-rs", rev = "2ded76b76734110d45de2270d3c782c561fe54d1", version = "0.18", features = ["network_client", "dns_resolver"], optional = true } # FIXME: Replace with next sspi release
 url = { version = "2.5", optional = true }
 
 [lints]

--- a/crates/ironrdp/Cargo.toml
+++ b/crates/ironrdp/Cargo.toml
@@ -63,7 +63,7 @@ async-trait = "0.1"
 image = { version = "0.25.6", default-features = false, features = ["png"] }
 pico-args = "0.5"
 x509-cert = { version = "0.2", default-features = false, features = ["std"] }
-sspi = { version = "0.18", features = ["network_client"] }
+sspi = { git = "https://github.com/Devolutions/sspi-rs", rev = "2ded76b76734110d45de2270d3c782c561fe54d1", version = "0.18", features = ["network_client"] } # FIXME: Replace with next sspi release
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio-rustls = "0.26"


### PR DESCRIPTION
Upgrade sspi to incorporate latest changes. The new version introduces a real SPNEGO implementation in `ServerMode::Negotiate`, but some RDP clients seem to send raw NTLM tokens in CredSSP rather than SPNEGO-wrapped ones, which doesn't seem supported by sspi yet? In the meantime, we can use `ServerMode::Ntlm` directly when Kerberos is disabled, so that we maintain compatibility with previous sspi behavior.

Note: I can't get the dependencies right, looks like there's a picky rc.22 / getrandom conflict; any help appreciated here!