### PR TITLE
fix(pdu): correct ShareDataHeader uncompressedLength calculation

### DIFF
--- a/crates/ironrdp-pdu/src/rdp/headers.rs
+++ b/crates/ironrdp-pdu/src/rdp/headers.rs
@@ -253,13 +253,7 @@ impl Encode for ShareDataHeader {
 
             write_padding!(dst, 1);
             dst.write_u8(self.stream_priority.as_u8());
-            dst.write_u16(cast_length!(
-                "uncompressedLength",
-                self.share_data_pdu.size()
-                    + PDU_TYPE_FIELD_SIZE
-                    + COMPRESSION_TYPE_FIELD_SIZE
-                    + COMPRESSED_LENGTH_FIELD_SIZE
-            )?);
+            dst.write_u16(cast_length!("uncompressedLength", self.share_data_pdu.size())?);
             dst.write_u8(self.share_data_pdu.share_header_type().as_u8());
             dst.write_u8(compression_flags_with_type);
             dst.write_u16(0); // compressed length

--- a/crates/ironrdp-testsuite-core/src/rdp.rs
+++ b/crates/ironrdp-testsuite-core/src/rdp.rs
@@ -47,7 +47,7 @@ pub const MONITOR_LAYOUT_HEADERS_BUFFER: [u8; 18] = [
     0xea, 0x03, 0x01, 0x00, // share id
     0x00, // padding
     0x01, // stream id
-    0x30, 0x00, // uncompressed length
+    0x2c, 0x00, // uncompressed length
     0x37, // pdu type
     0x00, // compression type
     0x00, 0x00, // compressed length
@@ -60,7 +60,7 @@ pub const CLIENT_SYNCHRONIZE_BUFFER: [u8; 22] = [
     0xea, 0x03, 0x01, 0x00, // share id
     0x00, // padding
     0x01, // stream id
-    0x08, 0x00, // uncompressed length
+    0x04, 0x00, // uncompressed length
     0x1f, // pdu type
     0x00, // compression type
     0x00, 0x00, // compressed length
@@ -75,7 +75,7 @@ pub const CONTROL_COOPERATE_BUFFER: [u8; 26] = [
     0xea, 0x03, 0x01, 0x00, // share id
     0x00, // padding
     0x01, // stream id
-    0x0c, 0x00, // uncompressed length
+    0x08, 0x00, // uncompressed length
     0x14, // pdu type
     0x00, // compression type
     0x00, 0x00, // compressed length
@@ -91,7 +91,7 @@ pub const CONTROL_REQUEST_CONTROL_BUFFER: [u8; 26] = [
     0xea, 0x03, 0x01, 0x00, // share id
     0x00, // padding
     0x01, // stream id
-    0x0c, 0x00, // uncompressed length
+    0x08, 0x00, // uncompressed length
     0x14, // pdu type
     0x00, // compression type
     0x00, 0x00, // compressed length
@@ -107,7 +107,7 @@ pub const SERVER_GRANTED_CONTROL_BUFFER: [u8; 26] = [
     0xea, 0x03, 0x01, 0x00, // share id
     0x00, // padding
     0x02, // stream id
-    0x0c, 0x00, // uncompressed length
+    0x08, 0x00, // uncompressed length
     0x14, // pdu type
     0x00, // compression type
     0x00, 0x00, // compressed length
@@ -123,7 +123,7 @@ pub const CLIENT_FONT_LIST_BUFFER: [u8; 26] = [
     0xea, 0x03, 0x01, 0x00, // share id
     0x00, // padding
     0x01, // stream id
-    0x0c, 0x00, // uncompressed length
+    0x08, 0x00, // uncompressed length
     0x27, // pdu type
     0x00, // compression type
     0x00, 0x00, // compressed length
@@ -140,7 +140,7 @@ pub const SERVER_FONT_MAP_BUFFER: [u8; 26] = [
     0xea, 0x03, 0x01, 0x00, // share id
     0x00, // padding
     0x02, // stream id
-    0x0c, 0x00, // uncompressed length
+    0x08, 0x00, // uncompressed length
     0x28, // pdu type
     0x00, // compression type
     0x00, 0x00, // compressed length


### PR DESCRIPTION
## Summary

`ShareDataHeader::encode()` was calculating `uncompressedLength` as
`payload_size + 4` (adding pduType2, compressedType, and compressedLength
field sizes). Per [MS-RDPBCGR] 2.2.8.1.1.1.2, this field should contain
only the uncompressed payload size.

@pacmancoder confirmed this as a bug in May 2024
(https://github.com/Devolutions/IronRDP/issues/447#issuecomment-2093879507):
"pretty sure this is a bug on our side"

FreeRDP encodes only the payload size. Servers tolerate both values since
the decode path does not validate `uncompressedLength` against actual
payload size, but the current encoding does not match the spec.

## Changes

| File | Change |
|------|--------|
| `ironrdp-pdu/src/rdp/headers.rs` | Remove extra field sizes from uncompressedLength |
| `ironrdp-testsuite-core/src/rdp.rs` | Update 7 byte buffer fixtures to match corrected encoding |

## Verification

`cargo xtask check fmt`, `cargo xtask check lints`, and `cargo xtask check tests` all pass.

[MS-RDPBCGR]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/

Fixes part of #447