### PR TITLE
fix(acceptor): skip credential check when server credentials are None

### DIFF
--- a/crates/ironrdp-acceptor/src/connection.rs
+++ b/crates/ironrdp-acceptor/src/connection.rs
@@ -567,18 +567,20 @@ impl Sequence for Acceptor {
                 if !protocol.intersects(SecurityProtocol::HYBRID | SecurityProtocol::HYBRID_EX) {
                     let creds = client_info.client_info.credentials;
 
-                    if self.creds.is_some() && self.creds.as_ref() != Some(&creds) {
-                        // FIXME: How authorization should be denied with standard RDP security?
-                        // Since standard RDP security is not a priority, we just send a ServerDeniedConnection ServerSetErrorInfo PDU.
-                        let info = ServerSetErrorInfoPdu(ErrorInfo::ProtocolIndependentCode(
-                            ProtocolIndependentCode::ServerDeniedConnection,
-                        ));
+                    if let Some(expected) = &self.creds {
+                        if expected != &creds {
+                            // FIXME: How authorization should be denied with standard RDP security?
+                            // Since standard RDP security is not a priority, we just send a ServerDeniedConnection ServerSetErrorInfo PDU.
+                            let info = ServerSetErrorInfoPdu(ErrorInfo::ProtocolIndependentCode(
+                                ProtocolIndependentCode::ServerDeniedConnection,
+                            ));
 
-                        debug!(message = ?info, "Send");
+                            debug!(message = ?info, "Send");
 
-                        util::encode_send_data_indication(self.user_channel_id, self.io_channel_id, &info, output)?;
+                            util::encode_send_data_indication(self.user_channel_id, self.io_channel_id, &info, output)?;
 
-                        return Err(ConnectorError::general("invalid credentials"));
+                            return Err(ConnectorError::general("invalid credentials"));
+                        }
                     }
 
                     // Store credentials for later retrieval via AcceptorResult.


### PR DESCRIPTION
Fixes #1149

### Problem

In TLS-only (non-NLA) connections, the credential check at [`connection.rs:533`](https://github.com/Devolutions/IronRDP/blob/master/crates/ironrdp-acceptor/src/connection.rs#L533) unconditionally rejects clients when `self.creds` is `None`:

```rust
if self.creds.as_ref() != Some(&creds) {
    // ServerDeniedConnection
}
```

`None != Some(anything)` is always `true`, so every client is rejected when the server has no credential requirement. This makes it impossible to run a TLS-mode server that accepts connections without authentication.

### Fix

Guard the check so `None` means "no credential requirement — accept any client":

```rust
if self.creds.is_some() && self.creds.as_ref() != Some(&creds) {
    // ServerDeniedConnection
}
```

One-line change. Preserves existing behavior when credentials are set (exact match required). No API surface change. No impact on NLA/CredSSP connections.

### Spec justification

MS-RDPBCGR does not require the server to validate Client Info PDU credentials at the protocol level in non-NLA mode. These fields carry auto-logon data, not authentication tokens. Both Windows RDP Server and FreeRDP's server pass credentials through to the application layer without protocol-level rejection. See #1149 for full analysis.