### PR TITLE
feat(acceptor): expose received client credentials in AcceptorResult

### DIFF
--- a/crates/ironrdp-acceptor/src/connection.rs
+++ b/crates/ironrdp-acceptor/src/connection.rs
@@ -34,6 +34,7 @@ pub struct Acceptor {
     static_channels: StaticChannelSet,
     saved_for_reactivation: AcceptorState,
     pub(crate) creds: Option<Credentials>,
+    received_credentials: Option<Credentials>,
     reactivation: bool,
 }
 
@@ -45,6 +46,15 @@ pub struct AcceptorResult {
     pub user_channel_id: u16,
     pub io_channel_id: u16,
     pub reactivation: bool,
+    /// Credentials received from the client during SecureSettingsExchange.
+    ///
+    /// Present for TLS-mode connections where the client sends credentials
+    /// in the ClientInfoPdu. `None` for CredSSP/Hybrid connections (where
+    /// authentication happens during the CredSSP exchange instead).
+    ///
+    /// Servers that need to validate credentials (e.g., via PAM or LDAP)
+    /// can use this field for post-handshake validation.
+    pub credentials: Option<Credentials>,
 }
 
 impl Acceptor {
@@ -64,6 +74,7 @@ impl Acceptor {
             static_channels: StaticChannelSet::new(),
             saved_for_reactivation: Default::default(),
             creds,
+            received_credentials: None,
             reactivation: false,
         }
     }
@@ -105,6 +116,7 @@ impl Acceptor {
             static_channels,
             saved_for_reactivation,
             creds: consumed.creds,
+            received_credentials: consumed.received_credentials,
             reactivation: true,
         })
     }
@@ -159,6 +171,7 @@ impl Acceptor {
                 user_channel_id: self.user_channel_id,
                 io_channel_id: self.io_channel_id,
                 reactivation: self.reactivation,
+                credentials: self.received_credentials.take(),
             }),
             previous_state => {
                 self.state = previous_state;
@@ -567,6 +580,9 @@ impl Sequence for Acceptor {
 
                         return Err(ConnectorError::general("invalid credentials"));
                     }
+
+                    // Store credentials for later retrieval via AcceptorResult.
+                    self.received_credentials = Some(creds);
                 }
 
                 (


### PR DESCRIPTION
## Summary

Adds `credentials: Option<Credentials>` to `AcceptorResult` so servers can access the credentials received from the client during `SecureSettingsExchange`.

This is a companion to #1150 and an interim solution for #1154. Together, they enable servers to implement post-handshake credential validation (PAM, LDAP, etc.) for TLS-mode connections.

## Changes

- Add `received_credentials: Option<Credentials>` field to `Acceptor` (private)
- Store client credentials during `SecureSettingsExchange` (connection.rs, TLS-mode only)
- Add `credentials: Option<Credentials>` field to `AcceptorResult` (public)
- Pass stored credentials through `get_result()` into `AcceptorResult`
- Propagate field through `new_deactivation_reactivation`

## Behavior

- **TLS-mode connections**: `credentials` is `Some(...)` containing the credentials from `ClientInfoPdu`
- **CredSSP/Hybrid connections**: `credentials` is `None` (authentication happens via CredSSP, not `ClientInfoPdu`)
- **BREAKING CHANGE**: `AcceptorResult` is not `#[non_exhaustive]`, so adding a new public field is semver-breaking. Existing code that destructures `AcceptorResult` will need to add the field.

## Context

This is explicitly a **stopgap** for #1154, which proposes a `CredentialValidator` trait as the proper long-term solution. This PR enables the use case immediately with minimal changes while the trait design is discussed.

### Use case

I'm building a standalone Linux RDP server using IronRDP. For Linux authentication, I need to validate client-supplied credentials against PAM (`pam_authenticate`). The current acceptor compares credentials and drops them; after the handshake there's no way to retrieve what the client sent. This PR retains them in `AcceptorResult` so the server can extract and validate them post-handshake.

## Checks

- `cargo xtask check fmt -v`: pass
- `cargo xtask check lints -v`: pass
- `cargo xtask check tests -v`: pass

Ref: #1154, #1149, #1150