### PR TITLE
fix(web): disable clipboard polling loop on Firefox v127+

### DIFF
--- a/web-client/iron-remote-desktop/src/iron-remote-desktop.svelte
+++ b/web-client/iron-remote-desktop/src/iron-remote-desktop.svelte
@@ -332,7 +332,7 @@
         loggingService.verbose = verbose === 'true';
         loggingService.info('Dom ready');
         await initcanvas();
-        clipboardService.initClipboard();
+        await clipboardService.initClipboard();
     });
 
     onDestroy(() => {

--- a/web-client/iron-remote-desktop/src/services/clipboard.service.ts
+++ b/web-client/iron-remote-desktop/src/services/clipboard.service.ts
@@ -34,7 +34,7 @@ export class ClipboardService {
         this.module = module;
     }
 
-    initClipboard() {
+    async initClipboard() {
         // Clipboard API is available only in secure contexts (HTTPS).
         if (!window.isSecureContext) {
             this.remoteDesktopService.emitWarningEvent('Clipboard is available only in secure contexts (HTTPS).');
@@ -55,6 +55,48 @@ export class ClipboardService {
                 this.remoteDesktopService.emitWarningEvent(
                     'Clipboard reading is not supported and writing is limited to text-only data types due to an outdated browser version!',
                 );
+            }
+        }
+
+        // Gate the polling-based auto-clipboard loop behind a Permissions API
+        // check. Two cases are handled:
+        //
+        // 1. Chromium: The query succeeds and returns a PermissionStatus.
+        //    - 'granted': Keep Full mode; auto-clipboard polling works.
+        //    - 'prompt': Keep Full mode; Chromium will show a one-time
+        //      permission prompt on the first clipboard.read() call. If
+        //      the user denies it, the safety net in onMonitorClipboard
+        //      catches the NotAllowedError and stops the loop.
+        //    - 'denied': Downgrade to TextOnly; the polling loop would
+        //      fail on every iteration.
+        //
+        // 2. Firefox v127+: Exposes clipboard.read()/write() but does not
+        //    include "clipboard-read" in its PermissionName WebIDL enum, so
+        //    the query throws. Without persistent permission, Firefox requires
+        //    transient user activation for every clipboard.read() call, making
+        //    the polling loop unusable. Downgrade to TextOnly so Firefox
+        //    routes through the text-only fallback paths.
+        //
+        //    When the permission query fails, a trial clipboard.read() checks
+        //    whether Firefox's `dom.events.testing.asyncClipboard` about:config
+        //    pref is active. If so, keep Full mode as clipboard works fully in
+        //    this scenario, without any user-activation restrictions.
+        if (this.ClipboardApiSupported === ClipboardApiSupported.Full) {
+            try {
+                const permissionStatus = await navigator.permissions.query({
+                    name: 'clipboard-read' as PermissionName,
+                });
+
+                if (permissionStatus.state === 'denied') {
+                    this.ClipboardApiSupported = ClipboardApiSupported.TextOnly;
+                }
+            } catch {
+                try {
+                    // Try to read clipboard to check if the asyncClipboard pref is enabled
+                    await navigator.clipboard.read();
+                } catch {
+                    this.ClipboardApiSupported = ClipboardApiSupported.TextOnly;
+                }
             }
         }
 
@@ -224,6 +266,7 @@ export class ClipboardService {
 
     // Called periodically to monitor clipboard changes
     private async onMonitorClipboard(): Promise<void> {
+        let stopped = false;
         try {
             if (!document.hasFocus()) {
                 return;
@@ -315,6 +358,17 @@ export class ClipboardService {
                 }
             }
         } catch (err) {
+            if (err instanceof DOMException && err.name === 'NotAllowedError') {
+                // The browser requires user activation for clipboard reads (e.g. Firefox v127+).
+                // The polling loop cannot work in this environment; fall back to manual mode.
+                console.warn('Clipboard monitoring disabled: browser requires user activation for clipboard read.');
+                this.remoteDesktopService.setOnRemoteClipboardChanged(
+                    this.onRemoteClipboardChangedManualMode.bind(this),
+                );
+                stopped = true;
+                return;
+            }
+
             if (err instanceof Error) {
                 const printError =
                     this.lastClipboardMonitorLoopError === null ||
@@ -326,7 +380,7 @@ export class ClipboardService {
                 this.lastClipboardMonitorLoopError = err;
             }
         } finally {
-            if (!get(isComponentDestroyed)) {
+            if (!stopped && !get(isComponentDestroyed)) {
                 this.scheduleOnMonitorClipboardUpdate();
             }
         }


### PR DESCRIPTION
### Problem

On Firefox v127+, the clipboard monitoring loop repeatedly calls `navigator.clipboard.read()` without user activation, which causes Firefox to show a "Paste" permission dialog on every attempt. This dialog popup blocks _all_ user interaction with the remote desktop session, making the client effectively unusable. We can see the error spammed in the console:

```
Clipboard read operation is not allowed
Clipboard read request was blocked due to lack of user activation
```

### Root Cause

PR #935 introduced a clipboard polling loop that calls `navigator.clipboard.read()` every 100ms to detect local clipboard changes. This works on Chromium, which grants persistent clipboard-read permission via the Permissions API after a one-time user prompt.

A follow-up PR (#951) added the `ClipboardApiSupported` enum to handle older Firefox versions (<v127) that don't expose `clipboard.read()`/`clipboard.write()` at all (see [here](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API#security_considerations) and [here](https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API#permission-aware_apis)), routing them to text-only fallback paths. 

The issue is that Firefox v127+ _does_ expose these APIs, so it gets classified as `ClipboardApiSupported.Full` and enters the _polling_ loop. 

The problem is that Firefox requires transient user activation for _every_ `clipboard.read()` call; there is no persistent permission grant. So if we enter the polling loop on v127+, every iteration will fail with a `NotAllowedError` as described above.

### Solution

We introduce a two-layer fix:

#### (1) Upfront detection via Permissions API probe

Before starting the monitoring loop, query `navigator.permissions.query({name: 'clipboard-read'})`. Chromium supports this and returns a valid `PermissionStatus`. Firefox will throw a `TypeError` that this permission is is not a valid value.

If the query throws, fall back to manual clipboard mode **immediately**; the polling loop is never started and no errors are shown.

#### (2) Runtime safety net in the polling loop

If a browser somehow passes the permission probe but still blocks reads at runtime, the existing catch block now detects `NotAllowedError` specifically, stops the loop via a flag, and switches to manual mode.