### PR TITLE
fix(rdpsnd): handle AudioFormat renegotiation in Ready state

### DIFF
--- a/crates/ironrdp-rdpsnd/src/client.rs
+++ b/crates/ironrdp-rdpsnd/src/client.rs
@@ -218,7 +218,7 @@ impl SvcProcessor for Rdpsnd {
                             msgs.append(&mut m);
                         }
                         return Ok(msgs);
-                    },
+                    }
                     _ => {
                         error!("Invalid PDU");
                         self.state = RdpsndState::Stop;


### PR DESCRIPTION
Fixes #1163

Sometimes Windows Server re-sends `SNDC_FORMATS` during Ready state (e.g., after mute/unmute in remote browser). Previously this hit the wildcard branch, entering Stop and permanently killing audio.
  
Add an `AudioFormat` arm in Ready state to close the current stream and restart negotiation.