### PR TITLE
feat(server): add CredentialValidator trait for server-side auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2905,6 +2905,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "array-concat",
+ "async-trait",
  "expect-test",
  "hex",
  "ironrdp-acceptor",
@@ -2936,6 +2937,7 @@ dependencies = [
  "pretty_assertions",
  "proptest",
  "rstest",
+ "tokio",
  "visibility",
 ]
 

--- a/crates/ironrdp-server/src/builder.rs
+++ b/crates/ironrdp-server/src/builder.rs
@@ -11,7 +11,7 @@ use super::display::{DesktopSize, RdpServerDisplay};
 #[cfg(feature = "egfx")]
 use super::gfx::GfxServerFactory;
 use super::handler::{KeyboardEvent, MouseEvent, RdpServerInputHandler};
-use super::server::{ConnectionHandler, RdpServer, RdpServerOptions, RdpServerSecurity};
+use super::server::{ConnectionHandler, CredentialValidator, RdpServer, RdpServerOptions, RdpServerSecurity};
 use crate::{DisplayUpdate, RdpServerDisplayUpdates, SoundServerFactory};
 
 pub struct WantsAddr {}
@@ -37,6 +37,7 @@ pub struct BuilderDone {
     cliprdr_factory: Option<Box<dyn CliprdrServerFactory>>,
     sound_factory: Option<Box<dyn SoundServerFactory>>,
     connection_handler: Option<Box<dyn ConnectionHandler>>,
+    credential_validator: Option<Arc<dyn CredentialValidator>>,
     #[cfg(feature = "egfx")]
     gfx_factory: Option<Box<dyn GfxServerFactory>>,
     display_suppressed: Option<Arc<AtomicBool>>,
@@ -133,6 +134,7 @@ impl RdpServerBuilder<WantsDisplay> {
                 sound_factory: None,
                 cliprdr_factory: None,
                 connection_handler: None,
+                credential_validator: None,
                 codecs: server_codecs_capabilities(&[]).expect("can't panic for &[]"),
                 max_request_size: RdpServerOptions::DEFAULT_MAX_REQUEST_SIZE,
                 #[cfg(feature = "egfx")]
@@ -152,6 +154,7 @@ impl RdpServerBuilder<WantsDisplay> {
                 sound_factory: None,
                 cliprdr_factory: None,
                 connection_handler: None,
+                credential_validator: None,
                 codecs: server_codecs_capabilities(&[]).expect("can't panic for &[]"),
                 max_request_size: RdpServerOptions::DEFAULT_MAX_REQUEST_SIZE,
                 #[cfg(feature = "egfx")]
@@ -223,8 +226,23 @@ impl RdpServerBuilder<BuilderDone> {
         self
     }
 
+    /// Set a credential validator for TLS-mode connections.
+    ///
+    /// When set, credentials received from the client during
+    /// `SecureSettingsExchange` (`ClientInfoPdu`) are passed to this
+    /// validator before the session is established. Rejection or a backend
+    /// error closes the connection. Pass `None` (the default) to skip
+    /// validation entirely.
+    ///
+    /// Not used for CredSSP/Hybrid connections (those use pre-loaded
+    /// credentials for NTLM challenge-response).
+    pub fn with_credential_validator(mut self, validator: Option<Arc<dyn CredentialValidator>>) -> Self {
+        self.state.credential_validator = validator;
+        self
+    }
+
     pub fn build(self) -> RdpServer {
-        RdpServer::new(
+        let mut server = RdpServer::new(
             RdpServerOptions {
                 addr: self.state.addr,
                 security: self.state.security,
@@ -239,7 +257,9 @@ impl RdpServerBuilder<BuilderDone> {
             #[cfg(feature = "egfx")]
             self.state.gfx_factory,
             self.state.display_suppressed,
-        )
+        );
+        server.set_credential_validator(self.state.credential_validator);
+        server
     }
 }
 

--- a/crates/ironrdp-server/src/lib.rs
+++ b/crates/ironrdp-server/src/lib.rs
@@ -33,8 +33,8 @@ pub use handler::{KeyboardEvent, MouseEvent, RdpServerInputHandler};
 #[cfg(feature = "helper")]
 pub use helper::TlsIdentityCtx;
 pub use server::{
-    ConnectionHandler, CredentialValidator, Credentials, PostConnectionAction, RdpServer, RdpServerOptions,
-    RdpServerSecurity, ServerEvent, ServerEventSender,
+    ConnectionHandler, CredentialDecision, CredentialValidationError, CredentialValidator, Credentials,
+    PostConnectionAction, RdpServer, RdpServerOptions, RdpServerSecurity, ServerEvent, ServerEventSender,
 };
 pub use sound::{RdpsndServerHandler, RdpsndServerMessage, SoundServerFactory};
 

--- a/crates/ironrdp-server/src/lib.rs
+++ b/crates/ironrdp-server/src/lib.rs
@@ -34,7 +34,8 @@ pub use handler::{KeyboardEvent, MouseEvent, RdpServerInputHandler};
 pub use helper::TlsIdentityCtx;
 pub use server::{
     ConnectionHandler, CredentialDecision, CredentialValidationError, CredentialValidator, Credentials,
-    PostConnectionAction, RdpServer, RdpServerOptions, RdpServerSecurity, ServerEvent, ServerEventSender,
+    ExactMatchCredentialValidator, PostConnectionAction, RdpServer, RdpServerOptions, RdpServerSecurity, ServerEvent,
+    ServerEventSender,
 };
 pub use sound::{RdpsndServerHandler, RdpsndServerMessage, SoundServerFactory};
 

--- a/crates/ironrdp-server/src/lib.rs
+++ b/crates/ironrdp-server/src/lib.rs
@@ -33,8 +33,8 @@ pub use handler::{KeyboardEvent, MouseEvent, RdpServerInputHandler};
 #[cfg(feature = "helper")]
 pub use helper::TlsIdentityCtx;
 pub use server::{
-    ConnectionHandler, Credentials, PostConnectionAction, RdpServer, RdpServerOptions, RdpServerSecurity, ServerEvent,
-    ServerEventSender,
+    ConnectionHandler, CredentialValidator, Credentials, PostConnectionAction, RdpServer, RdpServerOptions,
+    RdpServerSecurity, ServerEvent, ServerEventSender,
 };
 pub use sound::{RdpsndServerHandler, RdpsndServerMessage, SoundServerFactory};
 

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -89,6 +89,20 @@ pub trait ConnectionHandler: Send {
     }
 }
 
+/// Server-side credential validator for TLS-mode connections.
+///
+/// Called during connection setup when the server receives client credentials
+/// via `ClientInfoPdu`. Not used for CredSSP/Hybrid connections (those use
+/// pre-loaded credentials for NTLM challenge-response).
+///
+/// Implement this trait to validate credentials against external systems
+/// (PAM, LDAP, database, etc.).
+pub trait CredentialValidator: Send + Sync {
+    /// Validate credentials received from the client.
+    /// Return `Ok(true)` to accept, `Ok(false)` to reject.
+    fn validate(&self, credentials: &Credentials) -> Result<bool>;
+}
+
 #[derive(Clone)]
 pub struct RdpServerOptions {
     pub addr: SocketAddr,
@@ -290,6 +304,7 @@ pub struct RdpServer {
     ev_sender: mpsc::UnboundedSender<ServerEvent>,
     ev_receiver: Arc<Mutex<mpsc::UnboundedReceiver<ServerEvent>>>,
     creds: Option<Credentials>,
+    credential_validator: Option<Arc<dyn CredentialValidator>>,
     local_addr: Option<SocketAddr>,
     autodetect: Option<AutoDetectManager>,
     connection_handler: Option<Box<dyn ConnectionHandler>>,
@@ -384,6 +399,7 @@ impl RdpServer {
             ev_sender,
             ev_receiver: Arc::new(Mutex::new(ev_receiver)),
             creds: None,
+            credential_validator: None,
             local_addr: None,
             autodetect: None,
             connection_handler,
@@ -393,6 +409,17 @@ impl RdpServer {
 
     pub fn builder() -> builder::RdpServerBuilder<builder::WantsAddr> {
         builder::RdpServerBuilder::new()
+    }
+
+    /// Set a credential validator for TLS-mode connections.
+    ///
+    /// When set, credentials received from the client during `SecureSettingsExchange`
+    /// are validated through this callback before the session is established.
+    /// If validation fails, the connection is rejected.
+    ///
+    /// Not used for CredSSP/Hybrid connections (those use pre-loaded credentials).
+    pub fn set_credential_validator(&mut self, validator: Arc<dyn CredentialValidator>) {
+        self.credential_validator = Some(validator);
     }
 
     pub fn event_sender(&self) -> &mpsc::UnboundedSender<ServerEvent> {
@@ -1025,6 +1052,28 @@ impl RdpServer {
         W: FramedWrite,
     {
         debug!("Client accepted");
+
+        // Validate credentials if a validator is configured
+        if let Some(validator) = &self.credential_validator {
+            if let Some(creds) = &result.credentials {
+                match validator.validate(creds) {
+                    Ok(true) => {
+                        debug!("Credential validation succeeded for user: {}", creds.username);
+                    }
+                    Ok(false) => {
+                        warn!("Credential validation failed for user: {}", creds.username);
+                        bail!("credential validation failed");
+                    }
+                    Err(e) => {
+                        error!("Credential validator error: {e:#}");
+                        bail!("credential validation error: {e}");
+                    }
+                }
+            } else {
+                warn!("Credential validator configured but no credentials received from client");
+                bail!("no credentials received for validation");
+            }
+        }
 
         if !result.input_events.is_empty() {
             debug!("Handling input event backlog from acceptor sequence");

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -20,6 +20,7 @@ use ironrdp_pdu::mcs::{SendDataIndication, SendDataRequest};
 use ironrdp_pdu::rdp::capability_sets::{BitmapCodecs, CapabilitySet, CmdFlags, CodecProperty, GeneralExtraFlags};
 pub use ironrdp_pdu::rdp::client_info::Credentials;
 use ironrdp_pdu::rdp::headers::{ServerDeactivateAll, ShareControlPdu};
+use ironrdp_pdu::rdp::server_error_info::{ErrorInfo, ProtocolIndependentCode, ServerSetErrorInfoPdu};
 use ironrdp_pdu::x224::X224;
 use ironrdp_pdu::{Action, PduResult, decode_err, mcs, nego, rdp};
 use ironrdp_rdpsnd as rdpsnd;
@@ -152,18 +153,16 @@ impl core::error::Error for CredentialValidationError {
 /// # Example
 ///
 /// ```ignore
-/// use std::sync::Arc;
-/// use ironrdp_server::{
-///     CredentialDecision, CredentialValidationError, CredentialValidator, Credentials,
-/// };
+/// use ironrdp_server::{CredentialDecision, CredentialValidationError, CredentialValidator, Credentials};
 ///
 /// struct StaticValidator {
 ///     expected_user: String,
 ///     expected_password: String,
 /// }
 ///
+/// #[async_trait::async_trait]
 /// impl CredentialValidator for StaticValidator {
-///     fn validate(
+///     async fn validate(
 ///         &self,
 ///         creds: &Credentials,
 ///     ) -> Result<CredentialDecision, CredentialValidationError> {
@@ -175,6 +174,7 @@ impl core::error::Error for CredentialValidationError {
 ///     }
 /// }
 /// ```
+#[async_trait::async_trait]
 pub trait CredentialValidator: Send + Sync {
     /// Validate credentials received from the client.
     ///
@@ -182,7 +182,39 @@ pub trait CredentialValidator: Send + Sync {
     /// `Ok(CredentialDecision::Reject)` to refuse it. Return
     /// `Err(CredentialValidationError::new(_))` only when the validator
     /// itself could not produce a decision (backend system error).
-    fn validate(&self, credentials: &Credentials) -> Result<CredentialDecision, CredentialValidationError>;
+    ///
+    /// Implementors backed by blocking systems (PAM, libldap, a synchronous
+    /// database driver) should offload the work, for example with
+    /// `tokio::task::spawn_blocking`, so the returned future does not stall the
+    /// caller's executor. Native-async backends can simply `.await`.
+    async fn validate(&self, credentials: &Credentials) -> Result<CredentialDecision, CredentialValidationError>;
+}
+
+/// A built-in [`CredentialValidator`] that accepts exactly one fixed set of credentials.
+///
+/// This is the validation-policy equivalent of the acceptor's pre-loaded
+/// exact-match: it keeps the common "one known account" case a one-liner while
+/// going through the same hook as PAM, LDAP, or database-backed validators.
+pub struct ExactMatchCredentialValidator {
+    expected: Credentials,
+}
+
+impl ExactMatchCredentialValidator {
+    /// Build a validator that accepts only `expected` and rejects everything else.
+    pub fn new(expected: Credentials) -> Self {
+        Self { expected }
+    }
+}
+
+#[async_trait::async_trait]
+impl CredentialValidator for ExactMatchCredentialValidator {
+    async fn validate(&self, credentials: &Credentials) -> Result<CredentialDecision, CredentialValidationError> {
+        if credentials == &self.expected {
+            Ok(CredentialDecision::Accept)
+        } else {
+            Ok(CredentialDecision::Reject)
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -1143,19 +1175,24 @@ impl RdpServer {
     {
         debug!("Client accepted");
 
-        // Validate credentials if a validator is configured
-        if let Some(validator) = &self.credential_validator {
+        // Validate credentials if a validator is configured. The validator runs here, in the
+        // async server layer, rather than in the sans-I/O acceptor, because real validators
+        // (PAM/LDAP/DB) are I/O-bound. On rejection, deny with a ServerSetErrorInfoPdu before
+        // closing, matching the acceptor's exact-match denial path.
+        if let Some(validator) = self.credential_validator.clone() {
             if let Some(creds) = &result.credentials {
-                match validator.validate(creds) {
+                match validator.validate(creds).await {
                     Ok(CredentialDecision::Accept) => {
                         debug!("Credential validation accepted");
                     }
                     Ok(CredentialDecision::Reject) => {
                         warn!("Credential validation rejected");
+                        send_access_denied(result.io_channel_id, result.user_channel_id, writer).await?;
                         bail!("credential validation rejected");
                     }
                     Err(e) => {
                         error!(error = %e, "Credential validator backend error");
+                        send_access_denied(result.io_channel_id, result.user_channel_id, writer).await?;
                         bail!("credential validation backend error");
                     }
                 }
@@ -1566,6 +1603,29 @@ async fn deactivate_all(
         share_control_pdu: pdu,
     };
     let user_data = encode_vec(&pdu)?.into();
+    let pdu = SendDataIndication {
+        initiator_id: user_channel_id,
+        channel_id: io_channel_id,
+        user_data,
+    };
+    let msg = encode_vec(&X224(pdu))?;
+    writer.write_all(&msg).await?;
+    Ok(())
+}
+
+/// Send a `ServerSetErrorInfoPdu(ServerDeniedConnection)` to the client, then return.
+///
+/// Used to deny a connection after credential validation rejects it, mirroring the
+/// acceptor's exact-match denial so both paths refuse the same spec-defined way.
+async fn send_access_denied(
+    io_channel_id: u16,
+    user_channel_id: u16,
+    writer: &mut impl FramedWrite,
+) -> Result<(), anyhow::Error> {
+    let info = ServerSetErrorInfoPdu(ErrorInfo::ProtocolIndependentCode(
+        ProtocolIndependentCode::ServerDeniedConnection,
+    ));
+    let user_data = encode_vec(&info)?.into();
     let pdu = SendDataIndication {
         initiator_id: user_channel_id,
         channel_id: io_channel_id,

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -96,7 +96,8 @@ pub trait ConnectionHandler: Send {
 /// pre-loaded credentials for NTLM challenge-response).
 ///
 /// Implement this trait to validate credentials against external systems
-/// (PAM, LDAP, database, etc.).
+/// (PAM, LDAP, database, etc.). For blocking backends, wrap the call in
+/// `tokio::task::spawn_blocking` to avoid stalling the async runtime.
 pub trait CredentialValidator: Send + Sync {
     /// Validate credentials received from the client.
     /// Return `Ok(true)` to accept, `Ok(false)` to reject.
@@ -1058,20 +1059,19 @@ impl RdpServer {
             if let Some(creds) = &result.credentials {
                 match validator.validate(creds) {
                     Ok(true) => {
-                        debug!("Credential validation succeeded for user: {}", creds.username);
+                        debug!("Credential validation succeeded");
                     }
                     Ok(false) => {
-                        warn!("Credential validation failed for user: {}", creds.username);
+                        warn!("Credential validation failed");
                         bail!("credential validation failed");
                     }
                     Err(e) => {
-                        error!("Credential validator error: {e:#}");
-                        bail!("credential validation error: {e}");
+                        error!(error = %e, "Credential validator error");
+                        bail!("credential validation error");
                     }
                 }
             } else {
-                warn!("Credential validator configured but no credentials received from client");
-                bail!("no credentials received for validation");
+                debug!("Skipping credential validation (no credentials in AcceptorResult)");
             }
         }
 

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use core::net::SocketAddr;
 use core::sync::atomic::{AtomicBool, Ordering};
 use core::time::Duration;
@@ -89,6 +90,55 @@ pub trait ConnectionHandler: Send {
     }
 }
 
+/// Outcome of a successful [`CredentialValidator::validate`] call.
+///
+/// A rejection from a working validator is not an error: the validator did
+/// its job and decided the credentials do not authenticate. Backend failures
+/// (LDAP unreachable, PAM transport broken, database connection lost) are
+/// reported via [`CredentialValidationError`] instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CredentialDecision {
+    /// Credentials accepted; the connection proceeds.
+    Accept,
+    /// Credentials rejected; the connection is closed.
+    Reject,
+}
+
+/// Error returned by a [`CredentialValidator`] when the validator backend
+/// itself fails (rather than the credentials being invalid).
+///
+/// Wraps any [`core::error::Error`] from the backend (LDAP/PAM/DB/etc.) so
+/// the trait does not require a particular error library in implementors or
+/// consumers.
+#[derive(Debug)]
+pub struct CredentialValidationError {
+    source: Box<dyn core::error::Error + Send + Sync>,
+}
+
+impl CredentialValidationError {
+    /// Wrap a backend error as a credential-validation failure.
+    pub fn new<E>(source: E) -> Self
+    where
+        E: core::error::Error + Send + Sync + 'static,
+    {
+        Self {
+            source: Box::new(source),
+        }
+    }
+}
+
+impl fmt::Display for CredentialValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("credential validator backend failure")
+    }
+}
+
+impl core::error::Error for CredentialValidationError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        Some(&*self.source)
+    }
+}
+
 /// Server-side credential validator for TLS-mode connections.
 ///
 /// Called during connection setup when the server receives client credentials
@@ -98,10 +148,41 @@ pub trait ConnectionHandler: Send {
 /// Implement this trait to validate credentials against external systems
 /// (PAM, LDAP, database, etc.). For blocking backends, wrap the call in
 /// `tokio::task::spawn_blocking` to avoid stalling the async runtime.
+///
+/// # Example
+///
+/// ```ignore
+/// use std::sync::Arc;
+/// use ironrdp_server::{
+///     CredentialDecision, CredentialValidationError, CredentialValidator, Credentials,
+/// };
+///
+/// struct StaticValidator {
+///     expected_user: String,
+///     expected_password: String,
+/// }
+///
+/// impl CredentialValidator for StaticValidator {
+///     fn validate(
+///         &self,
+///         creds: &Credentials,
+///     ) -> Result<CredentialDecision, CredentialValidationError> {
+///         if creds.username == self.expected_user && creds.password == self.expected_password {
+///             Ok(CredentialDecision::Accept)
+///         } else {
+///             Ok(CredentialDecision::Reject)
+///         }
+///     }
+/// }
+/// ```
 pub trait CredentialValidator: Send + Sync {
     /// Validate credentials received from the client.
-    /// Return `Ok(true)` to accept, `Ok(false)` to reject.
-    fn validate(&self, credentials: &Credentials) -> Result<bool>;
+    ///
+    /// Return `Ok(CredentialDecision::Accept)` to permit the connection,
+    /// `Ok(CredentialDecision::Reject)` to refuse it. Return
+    /// `Err(CredentialValidationError::new(_))` only when the validator
+    /// itself could not produce a decision (backend system error).
+    fn validate(&self, credentials: &Credentials) -> Result<CredentialDecision, CredentialValidationError>;
 }
 
 #[derive(Clone)]
@@ -412,15 +493,23 @@ impl RdpServer {
         builder::RdpServerBuilder::new()
     }
 
-    /// Set a credential validator for TLS-mode connections.
+    /// Set or clear the credential validator for TLS-mode connections.
     ///
-    /// When set, credentials received from the client during `SecureSettingsExchange`
-    /// are validated through this callback before the session is established.
-    /// If validation fails, the connection is rejected.
+    /// When set, credentials received from the client during
+    /// `SecureSettingsExchange` are validated through this callback before
+    /// the session is established. If the validator returns
+    /// [`CredentialDecision::Reject`] (or a [`CredentialValidationError`]),
+    /// the connection is rejected. Passing `None` clears any previously
+    /// configured validator.
+    ///
+    /// Most callers should configure the validator at construction time via
+    /// the builder's `with_credential_validator` method
+    /// ([`RdpServer::builder`]); this setter exists for dynamic
+    /// post-construction reconfiguration.
     ///
     /// Not used for CredSSP/Hybrid connections (those use pre-loaded credentials).
-    pub fn set_credential_validator(&mut self, validator: Arc<dyn CredentialValidator>) {
-        self.credential_validator = Some(validator);
+    pub fn set_credential_validator(&mut self, validator: Option<Arc<dyn CredentialValidator>>) {
+        self.credential_validator = validator;
     }
 
     pub fn event_sender(&self) -> &mpsc::UnboundedSender<ServerEvent> {
@@ -1058,16 +1147,16 @@ impl RdpServer {
         if let Some(validator) = &self.credential_validator {
             if let Some(creds) = &result.credentials {
                 match validator.validate(creds) {
-                    Ok(true) => {
-                        debug!("Credential validation succeeded");
+                    Ok(CredentialDecision::Accept) => {
+                        debug!("Credential validation accepted");
                     }
-                    Ok(false) => {
-                        warn!("Credential validation failed");
-                        bail!("credential validation failed");
+                    Ok(CredentialDecision::Reject) => {
+                        warn!("Credential validation rejected");
+                        bail!("credential validation rejected");
                     }
                     Err(e) => {
-                        error!(error = %e, "Credential validator error");
-                        bail!("credential validation error");
+                        error!(error = %e, "Credential validator backend error");
+                        bail!("credential validation backend error");
                     }
                 }
             } else {

--- a/crates/ironrdp-testsuite-core/Cargo.toml
+++ b/crates/ironrdp-testsuite-core/Cargo.toml
@@ -34,6 +34,7 @@ visibility = { version = "0.1", optional = true }
 
 [dev-dependencies]
 anyhow = "1"
+async-trait = "0.1"
 expect-test.workspace = true
 hex = "0.4"
 ironrdp-cliprdr-format.path = "../ironrdp-cliprdr-format"
@@ -60,6 +61,7 @@ png = "0.18"
 pretty_assertions = "1.4"
 proptest.workspace = true
 rstest.workspace = true
+tokio = { version = "1", features = ["macros", "rt"] }
 
 [lints]
 workspace = true

--- a/crates/ironrdp-testsuite-core/tests/server/credential_validator.rs
+++ b/crates/ironrdp-testsuite-core/tests/server/credential_validator.rs
@@ -1,6 +1,7 @@
 use core::fmt;
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use ironrdp_server::{CredentialDecision, CredentialValidationError, CredentialValidator, Credentials};
 
 fn fixed_creds() -> Credentials {
@@ -12,15 +13,17 @@ fn fixed_creds() -> Credentials {
 }
 
 struct AlwaysAccept;
+#[async_trait]
 impl CredentialValidator for AlwaysAccept {
-    fn validate(&self, _: &Credentials) -> Result<CredentialDecision, CredentialValidationError> {
+    async fn validate(&self, _: &Credentials) -> Result<CredentialDecision, CredentialValidationError> {
         Ok(CredentialDecision::Accept)
     }
 }
 
 struct AlwaysReject;
+#[async_trait]
 impl CredentialValidator for AlwaysReject {
-    fn validate(&self, _: &Credentials) -> Result<CredentialDecision, CredentialValidationError> {
+    async fn validate(&self, _: &Credentials) -> Result<CredentialDecision, CredentialValidationError> {
         Ok(CredentialDecision::Reject)
     }
 }
@@ -35,36 +38,37 @@ impl fmt::Display for BackendDown {
 impl core::error::Error for BackendDown {}
 
 struct AlwaysBackendError;
+#[async_trait]
 impl CredentialValidator for AlwaysBackendError {
-    fn validate(&self, _: &Credentials) -> Result<CredentialDecision, CredentialValidationError> {
+    async fn validate(&self, _: &Credentials) -> Result<CredentialDecision, CredentialValidationError> {
         Err(CredentialValidationError::new(BackendDown))
     }
 }
 
-#[test]
-fn validator_accept_returns_accept() {
+#[tokio::test]
+async fn validator_accept_returns_accept() {
     let v = AlwaysAccept;
-    assert_eq!(v.validate(&fixed_creds()).unwrap(), CredentialDecision::Accept);
+    assert_eq!(v.validate(&fixed_creds()).await.unwrap(), CredentialDecision::Accept);
 }
 
-#[test]
-fn validator_reject_returns_reject() {
+#[tokio::test]
+async fn validator_reject_returns_reject() {
     let v = AlwaysReject;
-    assert_eq!(v.validate(&fixed_creds()).unwrap(), CredentialDecision::Reject);
+    assert_eq!(v.validate(&fixed_creds()).await.unwrap(), CredentialDecision::Reject);
 }
 
-#[test]
-fn validator_backend_error_propagates_source() {
+#[tokio::test]
+async fn validator_backend_error_propagates_source() {
     let v = AlwaysBackendError;
-    let err = v.validate(&fixed_creds()).expect_err("expected backend error");
+    let err = v.validate(&fixed_creds()).await.expect_err("expected backend error");
     assert_eq!(err.to_string(), "credential validator backend failure");
     let inner = core::error::Error::source(&err).expect("source must be Some");
     assert_eq!(inner.to_string(), "ldap server unreachable");
 }
 
-#[test]
-fn validator_can_be_held_behind_arc_dyn() {
+#[tokio::test]
+async fn validator_can_be_held_behind_arc_dyn() {
     // Exercises the Send + Sync + 'static bounds the trait promises through Arc<dyn _>.
     let v: Arc<dyn CredentialValidator> = Arc::new(AlwaysAccept);
-    assert_eq!(v.validate(&fixed_creds()).unwrap(), CredentialDecision::Accept);
+    assert_eq!(v.validate(&fixed_creds()).await.unwrap(), CredentialDecision::Accept);
 }

--- a/crates/ironrdp-testsuite-core/tests/server/credential_validator.rs
+++ b/crates/ironrdp-testsuite-core/tests/server/credential_validator.rs
@@ -1,0 +1,70 @@
+use core::fmt;
+use std::sync::Arc;
+
+use ironrdp_server::{CredentialDecision, CredentialValidationError, CredentialValidator, Credentials};
+
+fn fixed_creds() -> Credentials {
+    Credentials {
+        username: "alice".to_owned(),
+        password: "hunter2".to_owned(),
+        domain: None,
+    }
+}
+
+struct AlwaysAccept;
+impl CredentialValidator for AlwaysAccept {
+    fn validate(&self, _: &Credentials) -> Result<CredentialDecision, CredentialValidationError> {
+        Ok(CredentialDecision::Accept)
+    }
+}
+
+struct AlwaysReject;
+impl CredentialValidator for AlwaysReject {
+    fn validate(&self, _: &Credentials) -> Result<CredentialDecision, CredentialValidationError> {
+        Ok(CredentialDecision::Reject)
+    }
+}
+
+#[derive(Debug)]
+struct BackendDown;
+impl fmt::Display for BackendDown {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("ldap server unreachable")
+    }
+}
+impl core::error::Error for BackendDown {}
+
+struct AlwaysBackendError;
+impl CredentialValidator for AlwaysBackendError {
+    fn validate(&self, _: &Credentials) -> Result<CredentialDecision, CredentialValidationError> {
+        Err(CredentialValidationError::new(BackendDown))
+    }
+}
+
+#[test]
+fn validator_accept_returns_accept() {
+    let v = AlwaysAccept;
+    assert_eq!(v.validate(&fixed_creds()).unwrap(), CredentialDecision::Accept);
+}
+
+#[test]
+fn validator_reject_returns_reject() {
+    let v = AlwaysReject;
+    assert_eq!(v.validate(&fixed_creds()).unwrap(), CredentialDecision::Reject);
+}
+
+#[test]
+fn validator_backend_error_propagates_source() {
+    let v = AlwaysBackendError;
+    let err = v.validate(&fixed_creds()).expect_err("expected backend error");
+    assert_eq!(err.to_string(), "credential validator backend failure");
+    let inner = core::error::Error::source(&err).expect("source must be Some");
+    assert_eq!(inner.to_string(), "ldap server unreachable");
+}
+
+#[test]
+fn validator_can_be_held_behind_arc_dyn() {
+    // Exercises the Send + Sync + 'static bounds the trait promises through Arc<dyn _>.
+    let v: Arc<dyn CredentialValidator> = Arc::new(AlwaysAccept);
+    assert_eq!(v.validate(&fixed_creds()).unwrap(), CredentialDecision::Accept);
+}

--- a/crates/ironrdp-testsuite-core/tests/server/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/server/mod.rs
@@ -1,3 +1,4 @@
 mod acceptor;
 mod autodetect;
+mod credential_validator;
 mod fast_path;


### PR DESCRIPTION
Closes #1154

## Summary

Add a `CredentialValidator` trait that lets servers validate client
credentials during connection setup, after the acceptor extracts them
from `ClientInfoPdu` (enabled by #1155).

This follows up on the API discussion in #1150: `Option<Credentials>`
is the wrong type to carry security policy. The trait makes auth an
explicit, application-supplied component rather than an implicit
builder default.

## What it does

- `CredentialValidator` trait with `validate(&self, &Credentials) -> Result<CredentialDecision, CredentialValidationError>`.
- `CredentialDecision::{Accept, Reject}` enum for the binary outcome (no stringly typed bool).
- `CredentialValidationError` wrapping any `core::error::Error + Send + Sync` for backend-failure cases (LDAP/PAM/DB unreachable). Manual `Display` + `core::error::Error` impls; the source chain is preserved through `.source()`.
- `RdpServerBuilder::with_credential_validator(Option<Arc<dyn CredentialValidator>>)` to wire it in at construction time, matching the `with_*` pattern of every other configurable on `BuilderDone`.
- `RdpServer::set_credential_validator(Option<Arc<dyn CredentialValidator>>)` for post-construction reconfiguration.
- Validation runs in `client_accepted()` before session start.
- No validator configured = no credential check (existing behavior).
- Validator configured + credentials received = validate, reject on `Decision::Reject` or backend `Err(_)`.
- Validator configured + no credentials received = skip validation (covers CredSSP/Hybrid path and reactivation/resize iterations where `AcceptorResult.credentials` is `None` per #1150/#1155).

## Design

For TLS-only connections, Client Info credentials are the only
credentials the application layer receives (no CredSSP). This trait
gives server implementations a clean hook to validate them against
PAM, LDAP, databases, or any external system.

Not used for CredSSP/Hybrid connections, where authentication happens
during the NTLM challenge-response exchange before `ClientInfoPdu`.

Rejection is modelled as `Ok(CredentialDecision::Reject)`, not as an
`Err`. A rejection from a working validator is the validator doing
its job, not a failure of the validator itself. Only true backend
infrastructure failures (the LDAP server is down, the PAM transport
broke) return `Err(CredentialValidationError::new(_))`. This keeps
the three outcomes (accept / reject / infrastructure-error) distinct
at every call site.

Hand-rolled `Display` + `core::error::Error` impls follow the
post-#1264 workspace pattern; no `thiserror`, no `anyhow` leakage
across the public trait boundary.

## Example

    use std::sync::Arc;
    use ironrdp_server::{
        CredentialDecision, CredentialValidationError, CredentialValidator, Credentials,
        RdpServer,
    };

    struct PamValidator;

    impl CredentialValidator for PamValidator {
        fn validate(
            &self,
            creds: &Credentials,
        ) -> Result<CredentialDecision, CredentialValidationError> {
            match pam_authenticate(&creds.username, &creds.password) {
                Ok(true) => Ok(CredentialDecision::Accept),
                Ok(false) => Ok(CredentialDecision::Reject),
                Err(backend_err) => Err(CredentialValidationError::new(backend_err)),
            }
        }
    }

    let server = RdpServer::builder()
        .with_addr(addr)
        .with_tls(acceptor)
        .with_input_handler(my_input)
        .with_display_handler(my_display)
        .with_credential_validator(Some(Arc::new(PamValidator)))
        .build();

## Tests

Public-API tests for the trait, `CredentialDecision`, and the error
wrapper's source-chain propagation live in
`crates/ironrdp-testsuite-core/tests/server/credential_validator.rs`,
matching the canonical IronRDP split (public-API tests in
`ironrdp-testsuite-core`, inline `#[cfg(test)]` for crate-internal
behavior, per the existing `autodetect.rs` precedent).

## Test plan

`cargo xtask check fmt/lints/tests/typos/locks` all pass.
