### PR TITLE
fix(ffi): correct FfiClipbarodMessageProxy typo

### DIFF
--- a/ffi/src/clipboard/mod.rs
+++ b/ffi/src/clipboard/mod.rs
@@ -28,11 +28,11 @@ pub mod ffi {
 }
 
 #[derive(Debug)]
-pub struct FfiClipbarodMessageProxy {
+pub struct FfiClipboardMessageProxy {
     pub sender: std::sync::mpsc::Sender<ironrdp::cliprdr::backend::ClipboardMessage>,
 }
 
-impl ironrdp::cliprdr::backend::ClipboardMessageProxy for FfiClipbarodMessageProxy {
+impl ironrdp::cliprdr::backend::ClipboardMessageProxy for FfiClipboardMessageProxy {
     fn send_clipboard_message(&self, message: ironrdp::cliprdr::backend::ClipboardMessage) {
         if let Err(error) = self.sender.send(message) {
             error!(?error, "Failed to send clipboard message");

--- a/ffi/src/clipboard/windows.rs
+++ b/ffi/src/clipboard/windows.rs
@@ -94,7 +94,7 @@ impl WinCliprdrInner {
     fn new() -> Result<WinCliprdrInner, Box<IronRdpError>> {
         let (sender, receiver) = std::sync::mpsc::channel();
 
-        let proxy = crate::clipboard::FfiClipbarodMessageProxy { sender };
+        let proxy = crate::clipboard::FfiClipboardMessageProxy { sender };
 
         let clipboard = ironrdp_cliprdr_native::WinClipboard::new(proxy)?;
 


### PR DESCRIPTION
Rename FfiClipbarodMessageProxy to FfiClipboardMessageProxy in
ffi/src/clipboard/mod.rs and ffi/src/clipboard/windows.rs.

Found by typos-cli while testing ClearCodec PR submission.