### PR TITLE
feat(session)!: handle Auto-Detect Request PDUs from server

### DIFF
--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -781,6 +781,9 @@ async fn active_session(
                         "Multitransport request received (UDP transport not implemented)"
                     );
                 }
+                ActiveStageOutput::AutoDetect(request) => {
+                    debug!(?request, "Auto-detect");
+                }
                 ActiveStageOutput::Terminate(reason) => break 'outer reason,
             }
         }

--- a/crates/ironrdp-session/src/active_stage.rs
+++ b/crates/ironrdp-session/src/active_stage.rs
@@ -9,6 +9,7 @@ use ironrdp_dvc::{DrdynvcClient, DvcProcessor, DynamicVirtualChannel};
 use ironrdp_graphics::pointer::DecodedPointer;
 use ironrdp_pdu::geometry::InclusiveRectangle;
 use ironrdp_pdu::input::fast_path::{FastPathInput, FastPathInputEvent};
+use ironrdp_pdu::rdp::autodetect::AutoDetectRequest;
 use ironrdp_pdu::rdp::client_info::CompressionType as PduCompressionType;
 use ironrdp_pdu::rdp::headers::ShareDataPdu;
 use ironrdp_pdu::rdp::multitransport::MultitransportRequestPdu;
@@ -312,6 +313,15 @@ pub enum ActiveStageOutput {
     ///
     /// [\[MS-RDPBCGR\] 2.2.15.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/de783158-8b01-4818-8fb0-62523a5b3490
     MultitransportRequest(MultitransportRequestPdu),
+    /// Server-reported network characteristics ([\[MS-RDPBCGR\] 2.2.14.1.5]).
+    ///
+    /// Contains an [`AutoDetectRequest::NetworkCharacteristicsResult`] with
+    /// RTT and/or bandwidth measurements computed by the server.
+    ///
+    /// See [\[MS-RDPBCGR\] 2.2.14.1.5].
+    ///
+    /// [\[MS-RDPBCGR\] 2.2.14.1.5]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/228ffc5c-b60c-4d3e-9781-ac613f822fdf
+    AutoDetect(AutoDetectRequest),
 }
 
 impl TryFrom<x224::ProcessorOutput> for ActiveStageOutput {
@@ -334,6 +344,7 @@ impl TryFrom<x224::ProcessorOutput> for ActiveStageOutput {
             }
             x224::ProcessorOutput::DeactivateAll(cas) => Ok(Self::DeactivateAll(cas)),
             x224::ProcessorOutput::MultitransportRequest(pdu) => Ok(Self::MultitransportRequest(pdu)),
+            x224::ProcessorOutput::AutoDetect(request) => Ok(Self::AutoDetect(request)),
         }
     }
 }

--- a/crates/ironrdp-session/src/x224/mod.rs
+++ b/crates/ironrdp-session/src/x224/mod.rs
@@ -3,6 +3,7 @@ use ironrdp_connector::legacy::SendDataIndicationCtx;
 use ironrdp_core::WriteBuf;
 use ironrdp_dvc::{DrdynvcClient, DvcProcessor, DynamicVirtualChannel};
 use ironrdp_pdu::mcs::{DisconnectProviderUltimatum, DisconnectReason, McsMessage};
+use ironrdp_pdu::rdp::autodetect::{AutoDetectRequest, AutoDetectResponse};
 use ironrdp_pdu::rdp::headers::ShareDataPdu;
 use ironrdp_pdu::rdp::multitransport::MultitransportRequestPdu;
 use ironrdp_pdu::rdp::server_error_info::{ErrorInfo, ProtocolIndependentCode, ServerSetErrorInfoPdu};
@@ -33,6 +34,13 @@ pub enum ProcessorOutput {
     /// [\[MS-RDPBCGR\] 2.2.15.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/de783158-8b01-4818-8fb0-62523a5b3490
     /// [`MultitransportResponsePdu`]: ironrdp_pdu::rdp::multitransport::MultitransportResponsePdu
     MultitransportRequest(MultitransportRequestPdu),
+    /// Auto-detect network characteristics from server ([\[MS-RDPBCGR\] 2.2.14]).
+    ///
+    /// Currently only surfaces [`AutoDetectRequest::NetworkCharacteristicsResult`].
+    /// RTT requests are handled internally with automatic responses.
+    ///
+    /// [\[MS-RDPBCGR\] 2.2.14]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/dc672839-4f4e-40b1-a71c-cd6a959baa38
+    AutoDetect(AutoDetectRequest),
 }
 
 #[derive(Debug, Clone)]
@@ -180,6 +188,28 @@ impl Processor {
                                 DisconnectReason::UserRequested,
                             )),
                         ])
+                    }
+                    ShareDataPdu::AutoDetectReq(AutoDetectRequest::RttRequest { sequence_number, .. }) => {
+                        let response = AutoDetectResponse::RttResponse { sequence_number };
+                        let mut frame = WriteBuf::new();
+                        ironrdp_connector::legacy::encode_share_data(
+                            data_ctx.initiator_id,
+                            self.io_channel_id,
+                            self.share_id,
+                            ShareDataPdu::AutoDetectRsp(response),
+                            &mut frame,
+                        )
+                        .map_err(crate::legacy::map_error)?;
+                        debug!(sequence_number, "Responded to auto-detect RTT request");
+                        Ok(vec![ProcessorOutput::ResponseFrame(frame.into_inner())])
+                    }
+                    ShareDataPdu::AutoDetectReq(ref req @ AutoDetectRequest::NetworkCharacteristicsResult { .. }) => {
+                        debug!(?req, "Received network characteristics from server");
+                        Ok(vec![ProcessorOutput::AutoDetect(req.clone())])
+                    }
+                    ShareDataPdu::AutoDetectReq(_) => {
+                        debug!(pdu = %ctx.pdu.as_short_name(), "Auto-detect request not yet implemented");
+                        Ok(Vec::new())
                     }
                     _ => Err(reason_err!(
                         "IO channel",

--- a/crates/ironrdp-session/src/x224/mod.rs
+++ b/crates/ironrdp-session/src/x224/mod.rs
@@ -193,7 +193,7 @@ impl Processor {
                         let response = AutoDetectResponse::RttResponse { sequence_number };
                         let mut frame = WriteBuf::new();
                         ironrdp_connector::legacy::encode_share_data(
-                            data_ctx.initiator_id,
+                            self.user_channel_id,
                             self.io_channel_id,
                             self.share_id,
                             ShareDataPdu::AutoDetectRsp(response),
@@ -203,9 +203,9 @@ impl Processor {
                         debug!(sequence_number, "Responded to auto-detect RTT request");
                         Ok(vec![ProcessorOutput::ResponseFrame(frame.into_inner())])
                     }
-                    ShareDataPdu::AutoDetectReq(ref req @ AutoDetectRequest::NetworkCharacteristicsResult { .. }) => {
+                    ShareDataPdu::AutoDetectReq(req @ AutoDetectRequest::NetworkCharacteristicsResult { .. }) => {
                         debug!(?req, "Received network characteristics from server");
-                        Ok(vec![ProcessorOutput::AutoDetect(req.clone())])
+                        Ok(vec![ProcessorOutput::AutoDetect(req)])
                     }
                     ShareDataPdu::AutoDetectReq(_) => {
                         debug!(pdu = %ctx.pdu.as_short_name(), "Auto-detect request not yet implemented");

--- a/crates/ironrdp-testsuite-core/tests/session/autodetect.rs
+++ b/crates/ironrdp-testsuite-core/tests/session/autodetect.rs
@@ -1,0 +1,192 @@
+use std::borrow::Cow;
+
+use ironrdp_connector::connection_activation::ConnectionActivationSequence;
+use ironrdp_connector::{Credentials, DesktopSize};
+use ironrdp_core::encode_vec;
+use ironrdp_pdu::gcc;
+use ironrdp_pdu::mcs::{McsMessage, SendDataIndication};
+use ironrdp_pdu::rdp::autodetect::{AutoDetectRequest, AutoDetectResponse};
+use ironrdp_pdu::rdp::capability_sets::MajorPlatformType;
+use ironrdp_pdu::rdp::client_info::CompressionType;
+use ironrdp_pdu::rdp::headers::{
+    CompressionFlags, ShareControlHeader, ShareControlPdu, ShareDataHeader, ShareDataPdu, StreamPriority,
+};
+use ironrdp_pdu::x224::X224;
+use ironrdp_session::x224::Processor;
+use ironrdp_svc::StaticChannelSet;
+
+const USER_CHANNEL_ID: u16 = 1003;
+const IO_CHANNEL_ID: u16 = 1003;
+const SHARE_ID: u32 = 0x0001_0000;
+
+fn test_config() -> ironrdp_connector::Config {
+    ironrdp_connector::Config {
+        desktop_size: DesktopSize {
+            width: 1024,
+            height: 768,
+        },
+        desktop_scale_factor: 0,
+        enable_tls: true,
+        enable_credssp: false,
+        credentials: Credentials::UsernamePassword {
+            username: "test".into(),
+            password: "test".into(),
+        },
+        domain: None,
+        client_build: 0,
+        client_name: "test".into(),
+        keyboard_type: gcc::KeyboardType::IbmEnhanced,
+        keyboard_subtype: 0,
+        keyboard_layout: 0,
+        keyboard_functional_keys_count: 12,
+        ime_file_name: String::new(),
+        bitmap: None,
+        dig_product_id: String::new(),
+        client_dir: String::new(),
+        platform: MajorPlatformType::UNIX,
+        hardware_id: None,
+        request_data: None,
+        autologon: false,
+        enable_audio_playback: false,
+        license_cache: None,
+        compression_type: None,
+        enable_server_pointer: false,
+        pointer_software_rendering: false,
+        multitransport_flags: None,
+        performance_flags: Default::default(),
+        timezone_info: Default::default(),
+        alternate_shell: String::new(),
+        work_dir: String::new(),
+    }
+}
+
+fn make_processor() -> Processor {
+    let config = test_config();
+    let cas = ConnectionActivationSequence::new(config, IO_CHANNEL_ID, USER_CHANNEL_ID);
+    Processor::new(StaticChannelSet::new(), USER_CHANNEL_ID, IO_CHANNEL_ID, SHARE_ID, cas)
+}
+
+/// Encode a ShareDataPdu as a server-to-client SendDataIndication frame.
+fn encode_server_share_data(pdu: ShareDataPdu) -> Vec<u8> {
+    let share_data_header = ShareDataHeader {
+        share_data_pdu: pdu,
+        stream_priority: StreamPriority::Medium,
+        compression_flags: CompressionFlags::empty(),
+        compression_type: CompressionType::K8,
+    };
+
+    let share_control_header = ShareControlHeader {
+        share_control_pdu: ShareControlPdu::Data(share_data_header),
+        pdu_source: USER_CHANNEL_ID,
+        share_id: SHARE_ID,
+    };
+
+    let user_data = encode_vec(&share_control_header).unwrap();
+
+    let indication = McsMessage::SendDataIndication(SendDataIndication {
+        initiator_id: USER_CHANNEL_ID,
+        channel_id: IO_CHANNEL_ID,
+        user_data: Cow::Owned(user_data),
+    });
+
+    encode_vec(&X224(indication)).unwrap()
+}
+
+#[test]
+fn rtt_request_produces_response_frame() {
+    let mut processor = make_processor();
+    let request = AutoDetectRequest::rtt_continuous(42);
+    let frame = encode_server_share_data(ShareDataPdu::AutoDetectReq(request));
+
+    let outputs = processor.process(&frame).unwrap();
+
+    assert_eq!(outputs.len(), 1);
+    match &outputs[0] {
+        ironrdp_session::x224::ProcessorOutput::ResponseFrame(data) => {
+            assert!(!data.is_empty(), "response frame must not be empty");
+        }
+        other => panic!("expected ResponseFrame, got {other:?}"),
+    }
+}
+
+#[test]
+fn rtt_response_preserves_sequence_number() {
+    let mut processor = make_processor();
+    let sequence_number = 0x1234;
+    let request = AutoDetectRequest::rtt_connect_time(sequence_number);
+    let frame = encode_server_share_data(ShareDataPdu::AutoDetectReq(request));
+
+    let outputs = processor.process(&frame).unwrap();
+
+    assert_eq!(outputs.len(), 1);
+    let ironrdp_session::x224::ProcessorOutput::ResponseFrame(response_data) = &outputs[0] else {
+        panic!("expected ResponseFrame");
+    };
+
+    // The response frame wraps X224 > MCS SendDataRequest > ShareControl > ShareData > AutoDetectRsp.
+    // Decode the MCS layer to extract user data, then decode the share headers.
+    let mcs_msg = ironrdp_core::decode::<X224<McsMessage<'_>>>(response_data).unwrap();
+    let McsMessage::SendDataRequest(send_data) = mcs_msg.0 else {
+        panic!("expected SendDataRequest in response frame");
+    };
+    let share_control = ironrdp_core::decode::<ShareControlHeader>(&send_data.user_data).unwrap();
+    let ShareControlPdu::Data(share_data) = share_control.share_control_pdu else {
+        panic!("expected Data PDU in ShareControl");
+    };
+
+    match share_data.share_data_pdu {
+        ShareDataPdu::AutoDetectRsp(AutoDetectResponse::RttResponse {
+            sequence_number: rsp_seq,
+        }) => {
+            assert_eq!(rsp_seq, sequence_number, "sequence number must be echoed");
+        }
+        other => panic!("expected AutoDetectRsp(RttResponse), got {other:?}"),
+    }
+}
+
+#[test]
+fn network_characteristics_result_surfaces_as_autodetect() {
+    let mut processor = make_processor();
+    let request = AutoDetectRequest::netchar_result(7, 10, 50000, 20);
+    let frame = encode_server_share_data(ShareDataPdu::AutoDetectReq(request.clone()));
+
+    let outputs = processor.process(&frame).unwrap();
+
+    assert_eq!(outputs.len(), 1);
+    match &outputs[0] {
+        ironrdp_session::x224::ProcessorOutput::AutoDetect(req) => {
+            assert_eq!(req, &request, "surfaced request must match the original");
+        }
+        other => panic!("expected AutoDetect output, got {other:?}"),
+    }
+}
+
+#[test]
+fn bandwidth_measure_start_does_not_crash() {
+    let mut processor = make_processor();
+    let request = AutoDetectRequest::bw_start_connect_time(100);
+    let frame = encode_server_share_data(ShareDataPdu::AutoDetectReq(request));
+
+    let outputs = processor.process(&frame).unwrap();
+    assert!(outputs.is_empty(), "BW start should produce no output");
+}
+
+#[test]
+fn bandwidth_measure_stop_does_not_crash() {
+    let mut processor = make_processor();
+    let request = AutoDetectRequest::bw_stop_continuous(200);
+    let frame = encode_server_share_data(ShareDataPdu::AutoDetectReq(request));
+
+    let outputs = processor.process(&frame).unwrap();
+    assert!(outputs.is_empty(), "BW stop should produce no output");
+}
+
+#[test]
+fn bandwidth_measure_payload_does_not_crash() {
+    let mut processor = make_processor();
+    let request = AutoDetectRequest::bw_payload(300, vec![0xAA; 64]);
+    let frame = encode_server_share_data(ShareDataPdu::AutoDetectReq(request));
+
+    let outputs = processor.process(&frame).unwrap();
+    assert!(outputs.is_empty(), "BW payload should produce no output");
+}

--- a/crates/ironrdp-testsuite-core/tests/session/autodetect.rs
+++ b/crates/ironrdp-testsuite-core/tests/session/autodetect.rs
@@ -15,7 +15,7 @@ use ironrdp_pdu::x224::X224;
 use ironrdp_session::x224::Processor;
 use ironrdp_svc::StaticChannelSet;
 
-const USER_CHANNEL_ID: u16 = 1003;
+const USER_CHANNEL_ID: u16 = 1002;
 const IO_CHANNEL_ID: u16 = 1003;
 const SHARE_ID: u32 = 0x0001_0000;
 

--- a/crates/ironrdp-testsuite-core/tests/session/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/session/mod.rs
@@ -1,3 +1,4 @@
+mod autodetect;
 mod rfx;
 
 #[cfg(test)]

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -769,6 +769,9 @@ impl iron_remote_desktop::Session for Session {
                             "Multitransport request received (UDP transport not implemented)"
                         );
                     }
+                    ActiveStageOutput::AutoDetect(request) => {
+                        debug!(?request, "Auto-detect");
+                    }
                     ActiveStageOutput::Terminate(reason) => break 'outer reason,
                 }
             }

--- a/ffi/src/session/mod.rs
+++ b/ffi/src/session/mod.rs
@@ -197,6 +197,7 @@ pub mod ffi {
         Terminate,
         DeactivateAll,
         MultitransportRequest,
+        AutoDetect,
     }
 
     impl ActiveStageOutput {
@@ -213,6 +214,7 @@ pub mod ffi {
                 ironrdp::session::ActiveStageOutput::MultitransportRequest { .. } => {
                     ActiveStageOutputType::MultitransportRequest
                 }
+                ironrdp::session::ActiveStageOutput::AutoDetect { .. } => ActiveStageOutputType::AutoDetect,
             }
         }
 

--- a/ffi/src/session/mod.rs
+++ b/ffi/src/session/mod.rs
@@ -197,6 +197,9 @@ pub mod ffi {
         Terminate,
         DeactivateAll,
         MultitransportRequest,
+        /// Auto-detect network characteristics from server.
+        /// Use `get_autodetect_network_characteristics()` to retrieve
+        /// RTT and bandwidth values for connection quality monitoring.
         AutoDetect,
     }
 
@@ -300,6 +303,46 @@ pub mod ffi {
                     .into()),
             }
         }
+
+        /// Connection quality signals from the server's auto-detect mechanism.
+        /// Returns RTT and bandwidth measurements for health monitoring.
+        /// These values will feed into FramePacingFeedback when the
+        /// library-level health observer traits from #1158 land.
+        pub fn get_autodetect_network_characteristics(&self) -> Result<NetworkCharacteristics, Box<IronRdpError>> {
+            match &self.0 {
+                ironrdp::session::ActiveStageOutput::AutoDetect(
+                    ironrdp::pdu::rdp::autodetect::AutoDetectRequest::NetworkCharacteristicsResult {
+                        base_rtt_ms,
+                        bandwidth_kbps,
+                        average_rtt_ms,
+                        ..
+                    },
+                ) => Ok(NetworkCharacteristics {
+                    base_rtt_ms: base_rtt_ms.unwrap_or(0),
+                    has_base_rtt: base_rtt_ms.is_some(),
+                    average_rtt_ms: *average_rtt_ms,
+                    bandwidth_kbps: bandwidth_kbps.unwrap_or(0),
+                    has_bandwidth: bandwidth_kbps.is_some(),
+                }),
+                _ => Err(IncorrectEnumTypeError::on_variant("AutoDetect")
+                    .of_enum("ActiveStageOutput")
+                    .into()),
+            }
+        }
+    }
+
+    /// Connection quality measurements from server auto-detect (MS-RDPBCGR 2.2.14).
+    pub struct NetworkCharacteristics {
+        /// Lowest detected round-trip time in milliseconds.
+        /// Only valid when `has_base_rtt` is true.
+        pub base_rtt_ms: u32,
+        pub has_base_rtt: bool,
+        /// Current average round-trip time in milliseconds.
+        pub average_rtt_ms: u32,
+        /// Estimated bandwidth in kilobits per second.
+        /// Only valid when `has_bandwidth` is true.
+        pub bandwidth_kbps: u32,
+        pub has_bandwidth: bool,
     }
 
     pub struct MultitransportRequest {


### PR DESCRIPTION
Fixes a crash when the server sends Auto-Detect Request PDUs during an
active session. After #1176 added ShareDataPdu::AutoDetectReq routing,
these PDUs decode correctly but hit the catch-all error path in the x224
processor: "unhandled PDU: Auto-Detect Request PDU".

Per [MS-RDPBCGR 2.2.14], the client must respond to RTT Measure
Requests by echoing the sequence number. Without this, servers that
probe RTT (Windows Server, or IronRDP servers using #1177) get no
response, and the session terminates.

Changes:

- Handle RttRequest by auto-responding with RttResponse (echoes the
  sequence number per spec). Follows the ShutdownDenied pattern already
  used in the processor for protocol-mandated auto-responses.

- Surface NetworkCharacteristicsResult as a new
  ActiveStageOutput::AutoDetect(AutoDetectRequest) variant. This
  carries server-computed RTT and bandwidth metrics for applications
  that want adaptive behavior.

- Log and return empty for BW_START/BW_PAYLOAD/BW_STOP until the
  bandwidth measurement state machine is implemented. This prevents
  crashes without incorrect protocol behavior.

- Update all in-tree exhaustive matches: ironrdp-client, ironrdp-web,
  FFI.

- 6 tests in ironrdp-testsuite-core: RTT response generation, sequence
  number preservation, NetworkCharacteristicsResult surfacing, and
  crash-prevention for each BW variant.

Depends on: #1168 (merged), #1176 (merged)
Related: #1177 (server-side RTT), #1158 (multi-codec pipeline)

BREAKING CHANGE: ActiveStageOutput and ProcessorOutput have new
AutoDetect variants. Consumers with exhaustive matches must add an arm.