### PR TITLE
feat(server): make run_connection generic over stream type

### DIFF
--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -22,7 +22,7 @@ use ironrdp_svc::{ChannelFlags, StaticChannelId, StaticChannelSet, SvcProcessor,
 use ironrdp_tokio::{FramedRead, FramedWrite, TokioFramed, split_tokio_framed, unsplit_tokio_framed};
 use rdpsnd::server::{RdpsndServer, RdpsndServerMessage};
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt as _};
-use tokio::net::{TcpListener, TcpStream};
+use tokio::net::TcpListener;
 use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio::task;
 use tokio_rustls::TlsAcceptor;
@@ -380,7 +380,10 @@ impl RdpServer {
         acceptor.attach_static_channel(dvc);
     }
 
-    pub async fn run_connection(&mut self, stream: TcpStream) -> Result<()> {
+    pub async fn run_connection<S>(&mut self, stream: S) -> Result<()>
+    where
+        S: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static,
+    {
         let framed = TokioFramed::new(stream);
 
         let size = self.display.lock().await.size().await;
@@ -412,9 +415,9 @@ impl RdpServer {
                 acceptor.mark_security_upgrade_as_done();
 
                 if let RdpServerSecurity::Hybrid((_, pub_key)) = &self.opts.security {
-                    // how to get the client name?
-                    // doesn't seem to matter yet
-                    let client_name = framed.get_inner().0.get_ref().0.peer_addr()?.to_string();
+                    let client_name = self
+                        .local_addr
+                        .map_or_else(|| "rdp-client".to_owned(), |a| a.to_string());
 
                     ironrdp_acceptor::accept_credssp(
                         &mut framed,


### PR DESCRIPTION
## Summary

Make `run_connection` accept any `AsyncRead + AsyncWrite` stream instead of requiring `TcpStream` concretely.

- `run_connection<S>(&mut self, stream: S)` where `S: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static`
- Replace `peer_addr()` call in Hybrid/CredSSP path with `local_addr` fallback
- Remove unused `TcpStream` import

## Motivation

RDP servers may accept connections from transports other than TCP: Unix domain sockets (for local WebSocket relay), VSOCK (VM-to-host), or in-process streams (integration tests). The current `TcpStream` parameter prevents this, even though everything downstream of `run_connection` already operates generically (`TokioFramed<S>`, TLS accept, `accept_finalize<S>`, `client_loop<R, W>`).

Concrete use case: a QEMU display server that listens on both TCP (native RDP clients) and a Unix domain socket (browser clients via WebSocket relay) using the same `RdpServer` instance.

## Changes

**1 file, +8/-5 lines:**

- Generalize `run_connection` signature with `AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static` bounds (matching `accept_finalize`)
- Replace `peer_addr()` in the Hybrid/CredSSP path: the existing comment noted "doesn't seem to matter yet" for NTLM auth. Use `local_addr` as fallback since generic streams don't expose peer address
- Remove now-unused `TcpStream` import (`TcpListener` remains for `run()`)

## Backward Compatibility

Fully backward compatible. Callers passing `TcpStream` continue to work unchanged via type inference. `run()` is unaffected.

## Test Plan

- [x] `cargo xtask check fmt -v` passes
- [x] `cargo xtask check lints -v` passes
- [x] `cargo xtask check tests -v` passes
- [x] `cargo xtask check typos -v` passes
- [x] Verified `run()` compiles with inferred `TcpStream`
- [x] Verified `UnixStream` accepted via `run_connection` in downstream project