### PR TITLE
feat(server): add ConnectionHandler trait for connection lifecycle hooks

### DIFF
--- a/crates/ironrdp-server/src/builder.rs
+++ b/crates/ironrdp-server/src/builder.rs
@@ -9,7 +9,7 @@ use super::display::{DesktopSize, RdpServerDisplay};
 #[cfg(feature = "egfx")]
 use super::gfx::GfxServerFactory;
 use super::handler::{KeyboardEvent, MouseEvent, RdpServerInputHandler};
-use super::server::{RdpServer, RdpServerOptions, RdpServerSecurity};
+use super::server::{ConnectionHandler, RdpServer, RdpServerOptions, RdpServerSecurity};
 use crate::{DisplayUpdate, RdpServerDisplayUpdates, SoundServerFactory};
 
 pub struct WantsAddr {}
@@ -34,6 +34,7 @@ pub struct BuilderDone {
     display: Box<dyn RdpServerDisplay>,
     cliprdr_factory: Option<Box<dyn CliprdrServerFactory>>,
     sound_factory: Option<Box<dyn SoundServerFactory>>,
+    connection_handler: Option<Box<dyn ConnectionHandler>>,
     #[cfg(feature = "egfx")]
     gfx_factory: Option<Box<dyn GfxServerFactory>>,
 }
@@ -128,6 +129,7 @@ impl RdpServerBuilder<WantsDisplay> {
                 display: Box::new(display),
                 sound_factory: None,
                 cliprdr_factory: None,
+                connection_handler: None,
                 codecs: server_codecs_capabilities(&[]).expect("can't panic for &[]"),
                 max_request_size: RdpServerOptions::DEFAULT_MAX_REQUEST_SIZE,
                 #[cfg(feature = "egfx")]
@@ -145,6 +147,7 @@ impl RdpServerBuilder<WantsDisplay> {
                 display: Box::new(NoopDisplay),
                 sound_factory: None,
                 cliprdr_factory: None,
+                connection_handler: None,
                 codecs: server_codecs_capabilities(&[]).expect("can't panic for &[]"),
                 max_request_size: RdpServerOptions::DEFAULT_MAX_REQUEST_SIZE,
                 #[cfg(feature = "egfx")]
@@ -188,6 +191,13 @@ impl RdpServerBuilder<BuilderDone> {
         self
     }
 
+    /// Set a handler for connection lifecycle events (accept filtering,
+    /// post-disconnect cleanup).
+    pub fn with_connection_handler(mut self, handler: Option<Box<dyn ConnectionHandler>>) -> Self {
+        self.state.connection_handler = handler;
+        self
+    }
+
     pub fn build(self) -> RdpServer {
         RdpServer::new(
             RdpServerOptions {
@@ -200,6 +210,7 @@ impl RdpServerBuilder<BuilderDone> {
             self.state.display,
             self.state.sound_factory,
             self.state.cliprdr_factory,
+            self.state.connection_handler,
             #[cfg(feature = "egfx")]
             self.state.gfx_factory,
         )

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -1,4 +1,5 @@
 use core::net::SocketAddr;
+use core::time::Duration;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -41,6 +42,50 @@ use crate::{SoundServerFactory, builder, capabilities};
 
 /// TCP listen backlog size for the RDP server socket.
 const LISTENER_BACKLOG: u32 = 1024;
+
+/// Action to take after a client disconnects.
+///
+/// Returned by [`ConnectionHandler::on_disconnected`] to control whether
+/// the server continues accepting new connections or shuts down.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PostConnectionAction {
+    /// Continue accepting new connections.
+    Continue,
+    /// Stop the accept loop and return from [`RdpServer::run`].
+    Stop,
+}
+
+/// Hooks for connection lifecycle events in [`RdpServer::run`].
+///
+/// Implement this trait to add pre-accept filtering (rate limiting,
+/// IP allowlists) and post-disconnect logic (cleanup, session validity
+/// checks, metrics).
+///
+/// All methods have default implementations that accept all connections
+/// and continue unconditionally.
+pub trait ConnectionHandler: Send {
+    /// Called after `accept()` returns but before `run_connection()`.
+    ///
+    /// Return `false` to reject the connection (the TCP stream is dropped).
+    fn on_accept(&mut self, peer: SocketAddr) -> bool {
+        let _ = peer;
+        true
+    }
+
+    /// Called after `run_connection()` completes (successfully or with error).
+    ///
+    /// `duration` is the wall-clock time the connection was active.
+    /// `error` is `Some` if the connection ended with an error.
+    fn on_disconnected(
+        &mut self,
+        peer: SocketAddr,
+        duration: Duration,
+        error: Option<&anyhow::Error>,
+    ) -> PostConnectionAction {
+        let _ = (peer, duration, error);
+        PostConnectionAction::Continue
+    }
+}
 
 #[derive(Clone)]
 pub struct RdpServerOptions {
@@ -245,6 +290,7 @@ pub struct RdpServer {
     creds: Option<Credentials>,
     local_addr: Option<SocketAddr>,
     autodetect: Option<AutoDetectManager>,
+    connection_handler: Option<Box<dyn ConnectionHandler>>,
 }
 
 #[derive(Debug)]
@@ -285,6 +331,7 @@ impl RdpServer {
         display: Box<dyn RdpServerDisplay>,
         mut sound_factory: Option<Box<dyn SoundServerFactory>>,
         mut cliprdr_factory: Option<Box<dyn CliprdrServerFactory>>,
+        connection_handler: Option<Box<dyn ConnectionHandler>>,
         #[cfg(feature = "egfx")] mut gfx_factory: Option<Box<dyn GfxServerFactory>>,
     ) -> Self {
         let (ev_sender, ev_receiver) = ServerEvent::create_channel();
@@ -315,6 +362,7 @@ impl RdpServer {
             creds: None,
             local_addr: None,
             autodetect: None,
+            connection_handler,
         }
     }
 
@@ -531,9 +579,36 @@ impl RdpServer {
                 Ok((stream, peer)) = listener.accept() => {
                     debug!(?peer, "Received connection");
                     drop(ev_receiver);
-                    if let Err(error) = self.run_connection(stream).await {
-                        error!(?error, "Connection error");
+
+                    let accepted = self.connection_handler
+                        .as_mut()
+                        .is_none_or(|h| h.on_accept(peer));
+
+                    if !accepted {
+                        debug!(?peer, "Connection rejected by handler");
+                        drop(stream);
+                    } else {
+                        let started = tokio::time::Instant::now();
+                        let result = self.run_connection(stream).await;
+                        let duration = started.elapsed();
+
+                        if let Err(ref error) = result {
+                            error!(?error, "Connection error");
+                        }
+
+                        if let Some(ref mut handler) = self.connection_handler {
+                            let action = handler.on_disconnected(
+                                peer,
+                                duration,
+                                result.as_ref().err(),
+                            );
+                            if action == PostConnectionAction::Stop {
+                                debug!(?peer, "Handler requested stop after disconnect");
+                                break;
+                            }
+                        }
                     }
+
                     self.static_channels = StaticChannelSet::new();
                 }
                 else => break,

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -596,6 +596,8 @@ impl RdpServer {
                             error!(?error, "Connection error");
                         }
 
+                        self.static_channels = StaticChannelSet::new();
+
                         if let Some(ref mut handler) = self.connection_handler {
                             let action = handler.on_disconnected(
                                 peer,
@@ -608,8 +610,6 @@ impl RdpServer {
                             }
                         }
                     }
-
-                    self.static_channels = StaticChannelSet::new();
                 }
                 else => break,
             }


### PR DESCRIPTION
## Summary

Add optional `ConnectionHandler` to `RdpServer::run()` with two lifecycle callbacks:

- `on_accept(peer) -> bool`: called after `accept()`, return `false` to reject the connection before `run_connection()`
- `on_disconnected(peer, duration, error) -> PostConnectionAction`: called after `run_connection()` completes, return `Stop` to exit the accept loop

This enables server implementations to add:
- Pre-accept filtering (rate limiting, IP allowlists)
- Post-disconnect cleanup (session validity checks, metrics collection)
- Controlled shutdown when external state becomes invalid (e.g. compositor session terminated)

Both methods have default implementations that accept all connections and continue unconditionally, so existing callers are unaffected.

## Motivation

`lamco-rdp-server` currently duplicates the entire `run()` accept loop (~100 lines) to add connection lifecycle hooks for D-Bus event emission, PAM peer IP tracking, and Portal session validity checks. With `ConnectionHandler`, it can adopt the upstream `run()` directly.

The key gap was `PostConnectionAction::Stop`: after each client disconnects, lamco checks whether the Wayland compositor session is still valid and stops accepting if not. The existing `ServerEvent::Quit` mechanism requires the handler to know about IronRDP internals; `PostConnectionAction` keeps the contract explicit.

## Changes

- `server.rs`: `ConnectionHandler` trait, `PostConnectionAction` enum, `connection_handler` field on `RdpServer`, hooks wired into `run()` accept loop
- `builder.rs`: `with_connection_handler()` on `BuilderDone`, `ConnectionHandler` import, `BuilderDone` field

## Test plan

- [ ] Existing tests pass (all 5 xtask gates green)
- [ ] Server without handler: behavior unchanged (default impls)
- [ ] Server with handler returning `Stop`: accept loop exits after disconnect
- [ ] Server with handler rejecting `on_accept`: connection dropped, loop continues