### PR TITLE
feat(pdu,graphics): add RemoteFX Progressive codec primitives

### DIFF
--- a/crates/ironrdp-graphics/src/dwt_extrapolate.rs
+++ b/crates/ironrdp-graphics/src/dwt_extrapolate.rs
@@ -1,0 +1,590 @@
+//! Reduce-extrapolate variant of the LeGall 5/3 DWT for progressive RFX.
+//!
+//! When `RFX_DWT_REDUCE_EXTRAPOLATE` (0x01) is set in the progressive context,
+//! the DWT uses boundary extrapolation instead of symmetric extension. This
+//! produces asymmetric subbands that avoid wraparound artifacts at tile edges.
+//!
+//! For a 64x64 tile with 3-level decomposition:
+//!
+//!   Level 1: HL1(31x33), LH1(33x31), HH1(31x31) — LL1(33x33) feeds level 2
+//!   Level 2: HL2(16x17), LH2(17x16), HH2(16x16) — LL2(17x17) feeds level 3
+//!   Level 3: HL3(8x9), LH3(9x8), HH3(8x8), LL3(9x9)
+//!
+//! Buffer layout (4096 coefficients total):
+//!   [HL1:1023][LH1:1023][HH1:961][HL2:272][LH2:272][HH2:256][HL3:72][LH3:72][HH3:64][LL3:81]
+
+/// Subband position and dimensions within the coefficient buffer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BandInfo {
+    /// Width (columns) of the subband.
+    pub width: usize,
+    /// Height (rows) of the subband.
+    pub height: usize,
+    /// Starting index in the linearized coefficient array.
+    pub offset: usize,
+}
+
+impl BandInfo {
+    /// Total number of coefficients in this subband.
+    pub const fn count(&self) -> usize {
+        self.width * self.height
+    }
+}
+
+/// Low-pass output count for the reduce-extrapolate split.
+///
+/// For even N: `N/2 + 1` (extrapolated sample).
+/// For odd N: `(N + 1) / 2` (standard ceiling division).
+fn low_count(n: usize) -> usize {
+    // Even: (64+2)/2=33. Odd: (33+2)/2=17, (17+2)/2=9.
+    (n + 2) / 2
+}
+
+/// High-pass output count: remainder after low-pass.
+fn high_count(n: usize) -> usize {
+    n - low_count(n)
+}
+
+/// Band layout for the reduce-extrapolate 3-level DWT on a 64x64 tile.
+///
+/// Returns 10 subbands in buffer order:
+/// `[HL1, LH1, HH1, HL2, LH2, HH2, HL3, LH3, HH3, LL3]`
+///
+/// Band indices for progressive quantization (`ComponentCodecQuant::for_band()`):
+///   0=LL3, 1=HL3, 2=LH3, 3=HH3, 4=HL2, 5=LH2, 6=HH2, 7=HL1, 8=LH1, 9=HH1
+#[expect(clippy::similar_names, reason = "lw/hw/lh/hh are standard DWT band dimensions")]
+pub fn band_layout() -> [BandInfo; 10] {
+    let (lw1, hw1) = (low_count(64), high_count(64)); // (33, 31)
+    let (lw2, hw2) = (low_count(lw1), high_count(lw1)); // (17, 16)
+    let (lw3, hw3) = (low_count(lw2), high_count(lw2)); // (9, 8)
+
+    // Vertical dimensions are the same (square tile)
+    let (lh1, hh1) = (lw1, hw1);
+    let (lh2, hh2) = (lw2, hw2);
+    let (lh3, hh3) = (lw3, hw3);
+
+    let mut off = 0;
+    let mut b = |w: usize, h: usize| {
+        let info = BandInfo {
+            width: w,
+            height: h,
+            offset: off,
+        };
+        off += w * h;
+        info
+    };
+
+    [
+        b(hw1, lh1), // HL1: 31x33 = 1023
+        b(lw1, hh1), // LH1: 33x31 = 1023
+        b(hw1, hh1), // HH1: 31x31 = 961
+        b(hw2, lh2), // HL2: 16x17 = 272
+        b(lw2, hh2), // LH2: 17x16 = 272
+        b(hw2, hh2), // HH2: 16x16 = 256
+        b(hw3, lh3), // HL3: 8x9  = 72
+        b(lw3, hh3), // LH3: 9x8  = 72
+        b(hw3, hh3), // HH3: 8x8  = 64
+        b(lw3, lh3), // LL3: 9x9  = 81
+    ]
+}
+
+/// Inverse 3-level reduce-extrapolate DWT (coefficients to 64x64 tile).
+///
+/// Reconstructs the tile in-place in `buffer`. Both slices must have at least
+/// 4096 elements.
+///
+/// # Panics
+///
+/// Panics if either slice has fewer than 4096 elements.
+pub fn decode(buffer: &mut [i16], temp: &mut [i16]) {
+    assert!(buffer.len() >= 4096, "buffer must hold 4096 coefficients");
+    assert!(temp.len() >= 4096, "temp must hold 4096 elements");
+
+    // Inner-to-outer: level 3 first (smallest subbands), then 2, then 1
+    decode_block(&mut buffer[3807..], temp, 9, 8);
+    decode_block(&mut buffer[3007..], temp, 17, 16);
+    decode_block(buffer, temp, 33, 31);
+}
+
+/// Forward 3-level reduce-extrapolate DWT (64x64 tile to coefficients).
+///
+/// Transforms the tile in-place in `buffer`. Both slices must have at least
+/// 4096 elements.
+///
+/// # Panics
+///
+/// Panics if either slice has fewer than 4096 elements.
+pub fn encode(buffer: &mut [i16], temp: &mut [i16]) {
+    assert!(buffer.len() >= 4096, "buffer must hold 4096 coefficients");
+    assert!(temp.len() >= 4096, "temp must hold 4096 elements");
+
+    // Outer-to-inner: level 1 first (full tile), then 2, then 3
+    encode_block(buffer, temp, 33, 31);
+    encode_block(&mut buffer[3007..], temp, 17, 16);
+    encode_block(&mut buffer[3807..], temp, 9, 8);
+}
+
+// ---------------------------------------------------------------------------
+// Inverse (decode) implementation
+// ---------------------------------------------------------------------------
+
+/// Inverse DWT for one decomposition level.
+///
+/// `n_l` and `n_h` are the low-pass and high-pass band counts.
+/// Buffer contains `[HL, LH, HH, LL]` contiguously.
+#[expect(clippy::similar_names, reason = "hl/lh/hh/ll are standard DWT subband names")]
+fn decode_block(buffer: &mut [i16], temp: &mut [i16], n_l: usize, n_h: usize) {
+    let dst_w = n_l + n_h;
+
+    // Subband offsets within this block's buffer region
+    let hl_off = 0;
+    let lh_off = n_h * n_l;
+    let hh_off = lh_off + n_l * n_h;
+    let ll_off = hh_off + n_h * n_h;
+
+    // Temp: L half (n_l rows x dst_w cols) then H half (n_h rows x dst_w cols)
+    let l_off = 0;
+    let h_off = n_l * dst_w;
+
+    // Horizontal inverse: (LL + HL) -> L rows
+    for row in 0..n_l {
+        let ll_start = ll_off + row * n_l;
+        let hl_start = hl_off + row * n_h;
+        let l_start = l_off + row * dst_w;
+        idwt_row(
+            &buffer[ll_start..ll_start + n_l],
+            &buffer[hl_start..hl_start + n_h],
+            &mut temp[l_start..l_start + dst_w],
+        );
+    }
+
+    // Horizontal inverse: (LH + HH) -> H rows
+    for row in 0..n_h {
+        let lh_start = lh_off + row * n_l;
+        let hh_start = hh_off + row * n_h;
+        let h_start = h_off + row * dst_w;
+        idwt_row(
+            &buffer[lh_start..lh_start + n_l],
+            &buffer[hh_start..hh_start + n_h],
+            &mut temp[h_start..h_start + dst_w],
+        );
+    }
+
+    // Vertical inverse: (L + H) -> reconstructed columns in buffer
+    for col in 0..dst_w {
+        idwt_col(temp, l_off + col, h_off + col, dst_w, buffer, col, dst_w, n_l, n_h);
+    }
+}
+
+/// 1D inverse DWT on a contiguous row.
+///
+/// Reconstructs `n_l + n_h` output samples from `n_l` low-pass and `n_h`
+/// high-pass coefficients.
+fn idwt_row(low: &[i16], high: &[i16], dst: &mut [i16]) {
+    let n_l = low.len();
+    let n_h = high.len();
+
+    let mut h0 = i32::from(high[0]);
+    let mut x0 = t(i32::from(low[0]) - h0);
+    let mut x2 = x0;
+
+    let mut di = 0;
+
+    for j in 0..n_h - 1 {
+        let h1 = i32::from(high[j + 1]);
+        let l_val = i32::from(low[j + 1]);
+        x2 = t(l_val - (h0 + h1) / 2);
+        let x1 = t((i32::from(x0) + i32::from(x2)) / 2 + 2 * h0);
+        dst[di] = x0;
+        dst[di + 1] = x1;
+        di += 2;
+        x0 = x2;
+        h0 = h1;
+    }
+
+    if n_l <= n_h + 1 {
+        if n_l <= n_h {
+            dst[di] = x2;
+            dst[di + 1] = t(i32::from(x2) + 2 * h0);
+        } else {
+            let x_new = t(i32::from(low[n_h]) - h0);
+            dst[di] = x2;
+            dst[di + 1] = t((i32::from(x_new) + i32::from(x2)) / 2 + 2 * h0);
+            dst[di + 2] = x_new;
+        }
+    } else {
+        let x_new = t(i32::from(low[n_h]) - h0 / 2);
+        dst[di] = x2;
+        dst[di + 1] = t((i32::from(x_new) + i32::from(x2)) / 2 + 2 * h0);
+        dst[di + 2] = x_new;
+        dst[di + 3] = t((i32::from(x_new) + i32::from(low[n_h + 1])) / 2);
+    }
+}
+
+/// 1D inverse DWT on a strided column.
+///
+/// Reads from `src` with stride, writes to `dst` with stride.
+#[expect(clippy::too_many_arguments)]
+fn idwt_col(
+    src: &[i16],
+    l_start: usize,
+    h_start: usize,
+    src_stride: usize,
+    dst: &mut [i16],
+    d_start: usize,
+    dst_stride: usize,
+    n_l: usize,
+    n_h: usize,
+) {
+    let l = |i: usize| i32::from(src[l_start + i * src_stride]);
+    let h = |i: usize| i32::from(src[h_start + i * src_stride]);
+
+    let mut h0 = h(0);
+    let mut x0 = t(l(0) - h0);
+    let mut x2 = x0;
+
+    let mut d = d_start;
+
+    for j in 0..n_h - 1 {
+        let h1 = h(j + 1);
+        x2 = t(l(j + 1) - (h0 + h1) / 2);
+        let x1 = t((i32::from(x0) + i32::from(x2)) / 2 + 2 * h0);
+        dst[d] = x0;
+        d += dst_stride;
+        dst[d] = x1;
+        d += dst_stride;
+        x0 = x2;
+        h0 = h1;
+    }
+
+    if n_l <= n_h + 1 {
+        if n_l <= n_h {
+            dst[d] = x2;
+            d += dst_stride;
+            dst[d] = t(i32::from(x2) + 2 * h0);
+        } else {
+            let x_new = t(l(n_h) - h0);
+            dst[d] = x2;
+            d += dst_stride;
+            dst[d] = t((i32::from(x_new) + i32::from(x2)) / 2 + 2 * h0);
+            d += dst_stride;
+            dst[d] = x_new;
+        }
+    } else {
+        let x_new = t(l(n_h) - h0 / 2);
+        dst[d] = x2;
+        d += dst_stride;
+        dst[d] = t((i32::from(x_new) + i32::from(x2)) / 2 + 2 * h0);
+        d += dst_stride;
+        dst[d] = x_new;
+        d += dst_stride;
+        dst[d] = t((i32::from(x_new) + l(n_h + 1)) / 2);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Forward (encode) implementation
+// ---------------------------------------------------------------------------
+
+/// Forward DWT for one decomposition level.
+#[expect(clippy::similar_names, reason = "hl/lh/hh/ll are standard DWT subband names")]
+fn encode_block(buffer: &mut [i16], temp: &mut [i16], n_l: usize, n_h: usize) {
+    let src_w = n_l + n_h;
+
+    let hl_off = 0;
+    let lh_off = n_h * n_l;
+    let hh_off = lh_off + n_l * n_h;
+    let ll_off = hh_off + n_h * n_h;
+
+    let l_off = 0;
+    let h_off = n_l * src_w;
+
+    // Forward vertical: split columns into L (n_l rows) and H (n_h rows) in temp
+    for col in 0..src_w {
+        dwt_col(buffer, col, src_w, temp, l_off + col, h_off + col, src_w, n_l, n_h);
+    }
+
+    // Forward horizontal on L rows: produce LL and HL subbands.
+    // Read from temp (vertical output), write directly to scattered buffer locations.
+    for row in 0..n_l {
+        let l_start = l_off + row * src_w;
+        dwt_row_scattered(
+            &temp[l_start..l_start + src_w],
+            buffer,
+            ll_off + row * n_l,
+            hl_off + row * n_h,
+            n_l,
+            n_h,
+        );
+    }
+
+    // Forward horizontal on H rows: produce LH and HH subbands
+    for row in 0..n_h {
+        let h_start = h_off + row * src_w;
+        dwt_row_scattered(
+            &temp[h_start..h_start + src_w],
+            buffer,
+            lh_off + row * n_l,
+            hh_off + row * n_h,
+            n_l,
+            n_h,
+        );
+    }
+}
+
+/// 1D forward DWT: reads from `input`, writes low-pass to `out[low_off..]` and
+/// high-pass to `out[high_off..]`. This avoids needing two separate mutable
+/// slice borrows.
+fn dwt_row_scattered(input: &[i16], out: &mut [i16], low_off: usize, high_off: usize, n_l: usize, n_h: usize) {
+    // Predict step: compute high-pass from odd samples
+    for i in 0..n_h {
+        let x0 = i32::from(input[2 * i]);
+        let x1 = i32::from(input[2 * i + 1]);
+        let x2 = i32::from(input[2 * i + 2]);
+        out[high_off + i] = t((x1 - (x0 + x2) / 2) / 2);
+    }
+
+    // Update step: compute low-pass from even samples + high-pass
+    out[low_off] = t(i32::from(input[0]) + i32::from(out[high_off]));
+    for i in 1..n_h {
+        let h_prev = i32::from(out[high_off + i - 1]);
+        let h_curr = i32::from(out[high_off + i]);
+        out[low_off + i] = t(i32::from(input[2 * i]) + (h_prev + h_curr) / 2);
+    }
+
+    if n_l <= n_h + 1 {
+        let h_last = i32::from(out[high_off + n_h - 1]);
+        out[low_off + n_h] = t(i32::from(input[2 * n_h]) + h_last);
+    } else {
+        let h_last = i32::from(out[high_off + n_h - 1]);
+        out[low_off + n_h] = t(i32::from(input[2 * n_h]) + h_last / 2);
+        out[low_off + n_h + 1] = t(2 * i32::from(input[n_l + n_h - 1]) - i32::from(input[n_l + n_h - 2]));
+    }
+}
+
+/// 1D forward DWT on a strided column.
+///
+/// Reads from `src` at stride `s_stride`, writes low-pass to `dst[l_start..]`
+/// and high-pass to `dst[h_start..]` at stride `d_stride`.
+#[expect(clippy::too_many_arguments)]
+fn dwt_col(
+    src: &[i16],
+    s_start: usize,
+    s_stride: usize,
+    dst: &mut [i16],
+    l_start: usize,
+    h_start: usize,
+    d_stride: usize,
+    n_l: usize,
+    n_h: usize,
+) {
+    let x = |i: usize| i32::from(src[s_start + i * s_stride]);
+
+    // Predict: compute high-pass
+    for i in 0..n_h {
+        dst[h_start + i * d_stride] = t((x(2 * i + 1) - (x(2 * i) + x(2 * i + 2)) / 2) / 2);
+    }
+
+    // Update: compute low-pass (reads high-pass values we just wrote)
+    dst[l_start] = t(x(0) + i32::from(dst[h_start]));
+
+    for i in 1..n_h {
+        let h_prev = i32::from(dst[h_start + (i - 1) * d_stride]);
+        let h_curr = i32::from(dst[h_start + i * d_stride]);
+        dst[l_start + i * d_stride] = t(x(2 * i) + (h_prev + h_curr) / 2);
+    }
+
+    if n_l <= n_h + 1 {
+        let h_last = i32::from(dst[h_start + (n_h - 1) * d_stride]);
+        dst[l_start + n_h * d_stride] = t(x(2 * n_h) + h_last);
+    } else {
+        let n = n_l + n_h;
+        let h_last = i32::from(dst[h_start + (n_h - 1) * d_stride]);
+        dst[l_start + n_h * d_stride] = t(x(2 * n_h) + h_last / 2);
+        dst[l_start + (n_h + 1) * d_stride] = t(2 * x(n - 1) - x(n - 2));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+/// Truncate i32 to i16 (matches the `i32_to_i16_possible_truncation` pattern
+/// in the existing `dwt.rs`). DWT coefficients stay within i16 range for
+/// typical image data; truncation handles rare overflow gracefully.
+#[expect(
+    clippy::as_conversions,
+    clippy::cast_possible_truncation,
+    reason = "intentional truncation matching existing DWT convention"
+)]
+fn t(value: i32) -> i16 {
+    value as i16
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::as_conversions, clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn band_dimensions_match_spec() {
+        let bands = band_layout();
+
+        // Verify dimensions from MS-RDPEGFX spec
+        assert_eq!((bands[0].width, bands[0].height), (31, 33), "HL1");
+        assert_eq!((bands[1].width, bands[1].height), (33, 31), "LH1");
+        assert_eq!((bands[2].width, bands[2].height), (31, 31), "HH1");
+        assert_eq!((bands[3].width, bands[3].height), (16, 17), "HL2");
+        assert_eq!((bands[4].width, bands[4].height), (17, 16), "LH2");
+        assert_eq!((bands[5].width, bands[5].height), (16, 16), "HH2");
+        assert_eq!((bands[6].width, bands[6].height), (8, 9), "HL3");
+        assert_eq!((bands[7].width, bands[7].height), (9, 8), "LH3");
+        assert_eq!((bands[8].width, bands[8].height), (8, 8), "HH3");
+        assert_eq!((bands[9].width, bands[9].height), (9, 9), "LL3");
+    }
+
+    #[test]
+    fn band_offsets_match_freerdp() {
+        let bands = band_layout();
+
+        assert_eq!(bands[0].offset, 0, "HL1");
+        assert_eq!(bands[1].offset, 1023, "LH1");
+        assert_eq!(bands[2].offset, 2046, "HH1");
+        assert_eq!(bands[3].offset, 3007, "HL2");
+        assert_eq!(bands[4].offset, 3279, "LH2");
+        assert_eq!(bands[5].offset, 3551, "HH2");
+        assert_eq!(bands[6].offset, 3807, "HL3");
+        assert_eq!(bands[7].offset, 3879, "LH3");
+        assert_eq!(bands[8].offset, 3951, "HH3");
+        assert_eq!(bands[9].offset, 4015, "LL3");
+    }
+
+    #[test]
+    fn band_total_is_4096() {
+        let bands = band_layout();
+        let total: usize = bands.iter().map(|b| b.count()).sum();
+        assert_eq!(total, 4096);
+    }
+
+    #[test]
+    fn low_high_counts() {
+        assert_eq!(low_count(64), 33);
+        assert_eq!(high_count(64), 31);
+        assert_eq!(low_count(33), 17);
+        assert_eq!(high_count(33), 16);
+        assert_eq!(low_count(17), 9);
+        assert_eq!(high_count(17), 8);
+    }
+
+    #[test]
+    fn decode_all_zeros() {
+        let mut buffer = vec![0i16; 4096];
+        let mut temp = vec![0i16; 4096];
+        decode(&mut buffer, &mut temp);
+        // All-zero coefficients should produce all-zero output
+        assert!(buffer.iter().all(|&v| v == 0));
+    }
+
+    #[test]
+    fn encode_all_zeros() {
+        let mut buffer = vec![0i16; 4096];
+        let mut temp = vec![0i16; 4096];
+        encode(&mut buffer, &mut temp);
+        assert!(buffer.iter().all(|&v| v == 0));
+    }
+
+    #[test]
+    fn round_trip_identity() {
+        // A simple signal: DC component only (flat tile)
+        let mut buffer = vec![100i16; 4096];
+        let original = buffer.clone();
+        let mut temp = vec![0i16; 4096];
+
+        encode(&mut buffer, &mut temp);
+        decode(&mut buffer, &mut temp);
+
+        // Due to integer truncation, allow small per-sample error
+        let max_err: i16 = buffer
+            .iter()
+            .zip(original.iter())
+            .map(|(&a, &b)| (a - b).abs())
+            .max()
+            .unwrap_or(0);
+        assert!(max_err <= 2, "max round-trip error {max_err} exceeds tolerance");
+    }
+
+    #[test]
+    fn round_trip_gradient() {
+        // Horizontal gradient: tests non-trivial frequency content
+        let mut buffer = vec![0i16; 4096];
+        for row in 0..64 {
+            for col in 0..64 {
+                buffer[row * 64 + col] = col as i16 * 4;
+            }
+        }
+        let original = buffer.clone();
+        let mut temp = vec![0i16; 4096];
+
+        encode(&mut buffer, &mut temp);
+        decode(&mut buffer, &mut temp);
+
+        let max_err: i16 = buffer
+            .iter()
+            .zip(original.iter())
+            .map(|(&a, &b)| (a - b).abs())
+            .max()
+            .unwrap_or(0);
+        assert!(max_err <= 4, "max round-trip error {max_err} exceeds tolerance");
+    }
+
+    #[test]
+    fn round_trip_random_like() {
+        // Pseudo-random signal using a simple LCG to test general case
+        let mut buffer = vec![0i16; 4096];
+        let mut seed: u32 = 12345;
+        for val in buffer.iter_mut() {
+            seed = seed.wrapping_mul(1103515245).wrapping_add(12345);
+            *val = ((seed >> 16) as i16) >> 4; // range roughly -2048..2047
+        }
+        let original = buffer.clone();
+        let mut temp = vec![0i16; 4096];
+
+        encode(&mut buffer, &mut temp);
+        decode(&mut buffer, &mut temp);
+
+        let max_err: i16 = buffer
+            .iter()
+            .zip(original.iter())
+            .map(|(&a, &b)| (a - b).abs())
+            .max()
+            .unwrap_or(0);
+        // Reduce-extrapolate DWT has slightly more rounding error at
+        // boundaries than standard DWT due to asymmetric sample counts
+        assert!(max_err <= 6, "max round-trip error {max_err} exceeds tolerance");
+    }
+
+    #[test]
+    fn idwt_row_even_input() {
+        // Test the 1D inverse on a small even-length case (n_l=3, n_h=1)
+        let low = [10i16, 20, 30];
+        let high = [5i16];
+        let mut dst = [0i16; 4];
+        idwt_row(&low, &high, &mut dst);
+        // Just verify it doesn't panic and produces 4 values
+        assert_eq!(dst.len(), 4);
+    }
+
+    #[test]
+    fn idwt_row_odd_input() {
+        // Test the 1D inverse on a small odd-length case (n_l=2, n_h=1)
+        let low = [10i16, 20];
+        let high = [5i16];
+        let mut dst = [0i16; 3];
+        idwt_row(&low, &high, &mut dst);
+        assert_eq!(dst.len(), 3);
+    }
+}

--- a/crates/ironrdp-graphics/src/dwt_extrapolate.rs
+++ b/crates/ironrdp-graphics/src/dwt_extrapolate.rs
@@ -50,8 +50,8 @@ fn high_count(n: usize) -> usize {
 /// Returns 10 subbands in buffer order:
 /// `[HL1, LH1, HH1, HL2, LH2, HH2, HL3, LH3, HH3, LL3]`
 ///
-/// Band indices for progressive quantization (`ComponentCodecQuant::for_band()`):
-///   0=LL3, 1=HL3, 2=LH3, 3=HH3, 4=HL2, 5=LH2, 6=HH2, 7=HL1, 8=LH1, 9=HH1
+/// Band indices match `ComponentCodecQuant::for_band()`:
+///   0=HL1, 1=LH1, 2=HH1, 3=HL2, 4=LH2, 5=HH2, 6=HL3, 7=LH3, 8=HH3, 9=LL3
 #[expect(clippy::similar_names, reason = "lw/hw/lh/hh are standard DWT band dimensions")]
 pub fn band_layout() -> [BandInfo; 10] {
     let (lw1, hw1) = (low_count(64), high_count(64)); // (33, 31)

--- a/crates/ironrdp-graphics/src/lib.rs
+++ b/crates/ironrdp-graphics/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod color_conversion;
 pub mod diff;
 pub mod dwt;
+pub mod dwt_extrapolate;
 pub mod image_processing;
 pub mod pointer;
 pub mod quantization;
@@ -12,6 +13,7 @@ pub mod rdp6;
 pub mod rectangle_processing;
 pub mod rle;
 pub mod rlgr;
+pub mod srl;
 pub mod subband_reconstruction;
 pub mod zgfx;
 

--- a/crates/ironrdp-graphics/src/srl.rs
+++ b/crates/ironrdp-graphics/src/srl.rs
@@ -1,0 +1,383 @@
+//! SRL (Simplified Run-Length) entropy codec for progressive upgrade passes.
+//!
+//! Used during progressive TILE_UPGRADE decoding where the tri-state sign
+//! array (DAS) indicates zero-valued coefficients. SRL encodes/decodes
+//! magnitudes for coefficients that were previously zero.
+//!
+//! The algorithm is similar to RLGR's zero-run mode with a simpler structure:
+//! adaptive K parameter controlling zero-run lengths, followed by unary-coded
+//! magnitudes with sign bits.
+
+/// Decode SRL data for a set of zero-valued (DAS=0) coefficient positions.
+///
+/// `data` is the SRL byte stream (terminated by a 0x00 sentinel).
+/// `num_values` is the number of coefficients to decode.
+/// `num_bits` is the bit width for each magnitude value.
+///
+/// Returns a vector of decoded signed coefficient values. Zero entries
+/// mean the coefficient remains zero after this upgrade pass.
+pub fn decode_srl(data: &[u8], num_values: usize, num_bits: u8) -> Vec<i16> {
+    if num_values == 0 || data.is_empty() {
+        return vec![0; num_values];
+    }
+
+    let mut output = vec![0i16; num_values];
+    let mut reader = BitReader::new(data);
+    let mut kp: u32 = 0;
+    let mut out_idx = 0;
+    let mut nz: u32 = 0; // remaining zeros in current run
+
+    while out_idx < num_values {
+        let k = kp >> 3;
+
+        if nz > 0 {
+            // Still emitting zeros from a previous run
+            nz -= 1;
+            output[out_idx] = 0;
+            out_idx += 1;
+            continue;
+        }
+
+        if k > 0 {
+            // Zero-run mode: read one bit to decide
+            let bit = reader.read_bit();
+            if !bit {
+                // Emit 1 << k zeros
+                nz = 1u32.checked_shl(k).unwrap_or(0);
+                kp = kp.saturating_add(4).min(80);
+                // First zero of the run
+                nz -= 1;
+                output[out_idx] = 0;
+                out_idx += 1;
+                continue;
+            }
+            // Read k bits for exact remaining zero count
+            let zeros = reader.read_bits(k);
+            if zeros > 0 {
+                nz = zeros;
+                nz -= 1;
+                output[out_idx] = 0;
+                out_idx += 1;
+                continue;
+            }
+            // Fall through to unary mode (no more zeros)
+        }
+
+        // Unary mode: decode a non-zero magnitude
+        kp = kp.saturating_sub(6);
+
+        if num_bits == 0 {
+            // No bits to decode, just emit +/-1 from sign bit
+            let sign = reader.read_bit();
+            output[out_idx] = if sign { -1 } else { 1 };
+            out_idx += 1;
+            continue;
+        }
+
+        // Read sign bit
+        let sign = reader.read_bit();
+
+        if num_bits == 1 {
+            output[out_idx] = if sign { -1 } else { 1 };
+            out_idx += 1;
+            continue;
+        }
+
+        // Decode unary magnitude: count leading zeros until a 1-bit.
+        // Cap at 16 bits to prevent overflow if the stream ends prematurely
+        // (BitReader returns 0 for out-of-bounds reads).
+        let mut magnitude: u32 = 1;
+        loop {
+            let bit = reader.read_bit();
+            if bit || magnitude >= 0x8000 {
+                break;
+            }
+            magnitude += 1;
+        }
+
+        // Read remaining magnitude bits (num_bits - 1 bits)
+        let extra_bits = u32::from(num_bits).saturating_sub(1);
+        if extra_bits > 0 && extra_bits < 16 {
+            let extra = reader.read_bits(extra_bits);
+            magnitude = (magnitude << extra_bits) | extra;
+        }
+
+        let value = i16::try_from(magnitude.min(0x7FFF)).unwrap_or(i16::MAX);
+        output[out_idx] = if sign { -value } else { value };
+        out_idx += 1;
+    }
+
+    output
+}
+
+/// Encode coefficient magnitudes using the SRL algorithm.
+///
+/// `values` contains signed coefficient values (non-zero = needs encoding,
+/// zero = contributes to zero runs).
+/// `num_bits` is the bit width for magnitude encoding.
+///
+/// Returns the encoded SRL byte stream (with trailing 0x00 sentinel).
+pub fn encode_srl(values: &[i16], num_bits: u8) -> Vec<u8> {
+    if values.is_empty() {
+        return vec![0x00];
+    }
+
+    let mut writer = BitWriter::new();
+    let mut kp: u32 = 0;
+    let mut idx = 0;
+
+    while idx < values.len() {
+        let k = kp >> 3;
+
+        if values[idx] == 0 {
+            // Count consecutive zeros
+            let mut zero_count: u32 = 0;
+            while idx + usize::try_from(zero_count).unwrap_or(usize::MAX) < values.len()
+                && values[idx + usize::try_from(zero_count).unwrap_or(usize::MAX)] == 0
+            {
+                zero_count += 1;
+            }
+
+            // Encode zero run
+            if k > 0 {
+                let chunk_size = 1u32.checked_shl(k).unwrap_or(u32::MAX);
+                while zero_count >= chunk_size {
+                    writer.write_bit(false); // full chunk
+                    kp = kp.saturating_add(4).min(80);
+                    zero_count -= chunk_size;
+                    idx += usize::try_from(chunk_size).unwrap_or(usize::MAX);
+                }
+                // Emit remaining zeros with escape + count
+                writer.write_bit(true);
+                writer.write_bits(zero_count, k);
+                idx += usize::try_from(zero_count).unwrap_or(usize::MAX);
+
+                if zero_count > 0 {
+                    continue;
+                }
+            } else {
+                // k == 0, each zero is individually handled
+                // (zero coefficient in unary mode is skipped, we move to next)
+                idx += usize::try_from(zero_count).unwrap_or(usize::MAX);
+                continue;
+            }
+
+            // Fall through to encode the non-zero value that stopped the run
+            if idx >= values.len() {
+                break;
+            }
+        }
+
+        // Encode non-zero value
+        kp = kp.saturating_sub(6);
+        let value = values[idx];
+        let sign = value < 0;
+        let magnitude = u32::from(value.unsigned_abs());
+
+        writer.write_bit(sign);
+
+        if num_bits <= 1 {
+            idx += 1;
+            continue;
+        }
+
+        // Unary encode the magnitude
+        let extra_bits = u32::from(num_bits).saturating_sub(1);
+        if extra_bits > 0 && extra_bits < 16 {
+            let base = magnitude >> extra_bits;
+            let remainder = magnitude & ((1u32 << extra_bits) - 1);
+
+            // Write base in unary: (base - 1) zeros + 1
+            for _ in 1..base {
+                writer.write_bit(false);
+            }
+            writer.write_bit(true);
+
+            // Write remainder
+            writer.write_bits(remainder, extra_bits);
+        }
+
+        idx += 1;
+    }
+
+    // Trailing sentinel
+    let mut result = writer.finish();
+    result.push(0x00);
+    result
+}
+
+// ---------------------------------------------------------------------------
+// Bit-level I/O helpers
+// ---------------------------------------------------------------------------
+
+struct BitReader<'a> {
+    data: &'a [u8],
+    byte_idx: usize,
+    bit_idx: u8, // 0..7, MSB first
+}
+
+impl<'a> BitReader<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        Self {
+            data,
+            byte_idx: 0,
+            bit_idx: 0,
+        }
+    }
+
+    fn read_bit(&mut self) -> bool {
+        if self.byte_idx >= self.data.len() {
+            return false;
+        }
+        let bit = (self.data[self.byte_idx] >> (7 - self.bit_idx)) & 1 != 0;
+        self.bit_idx += 1;
+        if self.bit_idx >= 8 {
+            self.bit_idx = 0;
+            self.byte_idx += 1;
+        }
+        bit
+    }
+
+    fn read_bits(&mut self, count: u32) -> u32 {
+        let mut value = 0u32;
+        for _ in 0..count {
+            value = (value << 1) | u32::from(self.read_bit());
+        }
+        value
+    }
+}
+
+struct BitWriter {
+    bytes: Vec<u8>,
+    current: u8,
+    bit_count: u8, // bits written in current byte (0..7)
+}
+
+impl BitWriter {
+    fn new() -> Self {
+        Self {
+            bytes: Vec::new(),
+            current: 0,
+            bit_count: 0,
+        }
+    }
+
+    fn write_bit(&mut self, bit: bool) {
+        self.current = (self.current << 1) | u8::from(bit);
+        self.bit_count += 1;
+        if self.bit_count >= 8 {
+            self.bytes.push(self.current);
+            self.current = 0;
+            self.bit_count = 0;
+        }
+    }
+
+    fn write_bits(&mut self, value: u32, count: u32) {
+        for i in (0..count).rev() {
+            self.write_bit((value >> i) & 1 != 0);
+        }
+    }
+
+    fn finish(mut self) -> Vec<u8> {
+        if self.bit_count > 0 {
+            // Pad remaining bits with zeros (MSB aligned)
+            self.current <<= 8 - self.bit_count;
+            self.bytes.push(self.current);
+        }
+        self.bytes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_empty() {
+        let result = decode_srl(&[], 0, 1);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn decode_empty_data() {
+        // With no data (empty slice), all positions default to zero
+        let result = decode_srl(&[], 5, 1);
+        assert_eq!(result, vec![0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn encode_empty() {
+        let encoded = encode_srl(&[], 1);
+        assert_eq!(encoded, vec![0x00]); // just sentinel
+    }
+
+    #[test]
+    fn encode_all_zeros() {
+        let encoded = encode_srl(&[0, 0, 0], 1);
+        // Should contain only the sentinel since k starts at 0
+        // and zeros with k=0 are just skipped
+        assert_eq!(*encoded.last().unwrap(), 0x00);
+    }
+
+    #[test]
+    fn round_trip_single_positive() {
+        let original = vec![1];
+        let encoded = encode_srl(&original, 1);
+        let decoded = decode_srl(&encoded, 1, 1);
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn round_trip_single_negative() {
+        let original = vec![-1];
+        let encoded = encode_srl(&original, 1);
+        let decoded = decode_srl(&encoded, 1, 1);
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn round_trip_nonzero_only() {
+        // SRL is designed for coefficients already identified as non-zero
+        // by the DAS (delta-analysis state). Test with only non-zero values.
+        let original = vec![1, -1, 2, -3, 1];
+        let encoded = encode_srl(&original, 4);
+        let decoded = decode_srl(&encoded, original.len(), 4);
+        for (i, (&orig, &dec)) in original.iter().zip(decoded.iter()).enumerate() {
+            assert_eq!(orig.signum(), dec.signum(), "index {i}: sign mismatch");
+        }
+    }
+
+    #[test]
+    fn bit_reader_basic() {
+        let data = [0b10110000];
+        let mut reader = BitReader::new(&data);
+        assert!(reader.read_bit()); // 1
+        assert!(!reader.read_bit()); // 0
+        assert!(reader.read_bit()); // 1
+        assert!(reader.read_bit()); // 1
+    }
+
+    #[test]
+    fn bit_writer_basic() {
+        let mut writer = BitWriter::new();
+        writer.write_bit(true);
+        writer.write_bit(false);
+        writer.write_bit(true);
+        writer.write_bit(true);
+        writer.write_bit(false);
+        writer.write_bit(false);
+        writer.write_bit(false);
+        writer.write_bit(false);
+        let result = writer.finish();
+        assert_eq!(result, vec![0b10110000]);
+    }
+
+    #[test]
+    fn bit_writer_multi_byte() {
+        let mut writer = BitWriter::new();
+        writer.write_bits(0xFF, 8);
+        writer.write_bits(0x00, 8);
+        let result = writer.finish();
+        assert_eq!(result, vec![0xFF, 0x00]);
+    }
+}

--- a/crates/ironrdp-graphics/src/srl.rs
+++ b/crates/ironrdp-graphics/src/srl.rs
@@ -38,20 +38,18 @@ pub fn decode_srl(data: &[u8], num_values: usize, num_bits: u8) -> Vec<i16> {
             continue;
         }
 
-        if k > 0 {
-            // Zero-run mode: read one bit to decide
+        // Zero-run mode: chunk_size = 1 << k (1 when k=0).
+        // read_bits(0) returns 0, so k=0 degenerates to single-zero runs.
+        {
             let bit = reader.read_bit();
             if !bit {
-                // Emit 1 << k zeros
                 nz = 1u32.checked_shl(k).unwrap_or(0);
                 kp = kp.saturating_add(4).min(80);
-                // First zero of the run
                 nz -= 1;
                 output[out_idx] = 0;
                 out_idx += 1;
                 continue;
             }
-            // Read k bits for exact remaining zero count
             let zeros = reader.read_bits(k);
             if zeros > 0 {
                 nz = zeros;
@@ -83,24 +81,24 @@ pub fn decode_srl(data: &[u8], num_values: usize, num_bits: u8) -> Vec<i16> {
             continue;
         }
 
-        // Decode unary magnitude: count leading zeros until a 1-bit.
-        // Cap at 16 bits to prevent overflow if the stream ends prematurely
-        // (BitReader returns 0 for out-of-bounds reads).
-        let mut magnitude: u32 = 1;
+        // Decode unary quotient: count 0-bits before the terminating 1-bit.
+        // magnitude = (quotient << extra_bits) | remainder.
+        let mut quotient: u32 = 0;
         loop {
             let bit = reader.read_bit();
-            if bit || magnitude >= 0x8000 {
+            if bit || quotient >= 0x8000 {
                 break;
             }
-            magnitude += 1;
+            quotient += 1;
         }
 
-        // Read remaining magnitude bits (num_bits - 1 bits)
         let extra_bits = u32::from(num_bits).saturating_sub(1);
-        if extra_bits > 0 && extra_bits < 16 {
-            let extra = reader.read_bits(extra_bits);
-            magnitude = (magnitude << extra_bits) | extra;
-        }
+        let magnitude = if extra_bits > 0 && extra_bits < 16 {
+            let remainder = reader.read_bits(extra_bits);
+            (quotient << extra_bits) | remainder
+        } else {
+            quotient
+        };
 
         let value = i16::try_from(magnitude.min(0x7FFF)).unwrap_or(i16::MAX);
         output[out_idx] = if sign { -value } else { value };
@@ -127,45 +125,40 @@ pub fn encode_srl(values: &[i16], num_bits: u8) -> Vec<u8> {
     let mut idx = 0;
 
     while idx < values.len() {
-        let k = kp >> 3;
+        // Count leading zeros (may be 0)
+        let mut zero_count: u32 = 0;
+        while idx + usize::try_from(zero_count).unwrap_or(usize::MAX) < values.len()
+            && values[idx + usize::try_from(zero_count).unwrap_or(usize::MAX)] == 0
+        {
+            zero_count += 1;
+        }
 
-        if values[idx] == 0 {
-            // Count consecutive zeros
-            let mut zero_count: u32 = 0;
-            while idx + usize::try_from(zero_count).unwrap_or(usize::MAX) < values.len()
-                && values[idx + usize::try_from(zero_count).unwrap_or(usize::MAX)] == 0
-            {
-                zero_count += 1;
-            }
-
-            // Encode zero run
-            if k > 0 {
-                let chunk_size = 1u32.checked_shl(k).unwrap_or(u32::MAX);
-                while zero_count >= chunk_size {
-                    writer.write_bit(false); // full chunk
-                    kp = kp.saturating_add(4).min(80);
-                    zero_count -= chunk_size;
-                    idx += usize::try_from(chunk_size).unwrap_or(usize::MAX);
-                }
-                // Emit remaining zeros with escape + count
-                writer.write_bit(true);
-                writer.write_bits(zero_count, k);
-                idx += usize::try_from(zero_count).unwrap_or(usize::MAX);
-
-                if zero_count > 0 {
-                    continue;
-                }
+        // Encode zero run one chunk at a time, recomputing k after
+        // each kp update to stay in sync with the decoder.
+        while zero_count > 0 {
+            let cur_k = kp >> 3;
+            let chunk_size = 1u32.checked_shl(cur_k).unwrap_or(u32::MAX);
+            if zero_count >= chunk_size {
+                writer.write_bit(false);
+                kp = kp.saturating_add(4).min(80);
+                zero_count -= chunk_size;
+                idx += usize::try_from(chunk_size).unwrap_or(usize::MAX);
             } else {
-                // k == 0, each zero is individually handled
-                // (zero coefficient in unary mode is skipped, we move to next)
+                // Remaining zeros < chunk: escape bit + count
+                writer.write_bit(true);
+                writer.write_bits(zero_count, cur_k);
                 idx += usize::try_from(zero_count).unwrap_or(usize::MAX);
+                zero_count = 0;
                 continue;
             }
+        }
+        // No remaining zeros: write escape with zero count
+        let cur_k = kp >> 3;
+        writer.write_bit(true);
+        writer.write_bits(0, cur_k);
 
-            // Fall through to encode the non-zero value that stopped the run
-            if idx >= values.len() {
-                break;
-            }
+        if idx >= values.len() {
+            break;
         }
 
         // Encode non-zero value
@@ -181,19 +174,17 @@ pub fn encode_srl(values: &[i16], num_bits: u8) -> Vec<u8> {
             continue;
         }
 
-        // Unary encode the magnitude
+        // Unary encode: quotient zeros + terminator + remainder bits.
+        // magnitude = (quotient << extra_bits) | remainder.
         let extra_bits = u32::from(num_bits).saturating_sub(1);
         if extra_bits > 0 && extra_bits < 16 {
-            let base = magnitude >> extra_bits;
+            let quotient = magnitude >> extra_bits;
             let remainder = magnitude & ((1u32 << extra_bits) - 1);
 
-            // Write base in unary: (base - 1) zeros + 1
-            for _ in 1..base {
+            for _ in 0..quotient {
                 writer.write_bit(false);
             }
             writer.write_bit(true);
-
-            // Write remainder
             writer.write_bits(remainder, extra_bits);
         }
 
@@ -314,9 +305,11 @@ mod tests {
     #[test]
     fn encode_all_zeros() {
         let encoded = encode_srl(&[0, 0, 0], 1);
-        // Should contain only the sentinel since k starts at 0
-        // and zeros with k=0 are just skipped
+        // Sentinel must be present
         assert_eq!(*encoded.last().unwrap(), 0x00);
+        // Round-trip: all zeros must survive
+        let decoded = decode_srl(&encoded, 3, 1);
+        assert_eq!(decoded, vec![0, 0, 0]);
     }
 
     #[test]
@@ -336,15 +329,20 @@ mod tests {
     }
 
     #[test]
+    fn round_trip_mixed_zeros() {
+        // Zeros at the start (where k=0) must survive the round-trip
+        let original = vec![0, 0, 1, -1, 0, 3];
+        let encoded = encode_srl(&original, 4);
+        let decoded = decode_srl(&encoded, original.len(), 4);
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
     fn round_trip_nonzero_only() {
-        // SRL is designed for coefficients already identified as non-zero
-        // by the DAS (delta-analysis state). Test with only non-zero values.
         let original = vec![1, -1, 2, -3, 1];
         let encoded = encode_srl(&original, 4);
         let decoded = decode_srl(&encoded, original.len(), 4);
-        for (i, (&orig, &dec)) in original.iter().zip(decoded.iter()).enumerate() {
-            assert_eq!(orig.signum(), dec.signum(), "index {i}: sign mismatch");
-        }
+        assert_eq!(decoded, original);
     }
 
     #[test]

--- a/crates/ironrdp-pdu/src/codecs/rfx/mod.rs
+++ b/crates/ironrdp-pdu/src/codecs/rfx/mod.rs
@@ -1,5 +1,6 @@
 mod data_messages;
 mod header_messages;
+pub mod progressive;
 
 use ironrdp_core::{
     Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, cast_length, ensure_fixed_part_size,

--- a/crates/ironrdp-pdu/src/codecs/rfx/progressive.rs
+++ b/crates/ironrdp-pdu/src/codecs/rfx/progressive.rs
@@ -1,0 +1,1350 @@
+//! RemoteFX Progressive Codec wire types ([MS-RDPEGFX] 2.2.4.2).
+//!
+//! The progressive codec delivers multi-pass bitmap updates via
+//! `WireToSurface2Pdu` (codecId 0x0009). Tiles start at coarse quality
+//! and refine over successive upgrade passes.
+//!
+//! Block types share a 6-byte header: `blockType(u16) + blockLen(u32)`.
+//! The payload of a `WireToSurface2Pdu.bitmapData` is a sequence of these
+//! blocks forming a progressive bitmap stream.
+
+use core::iter;
+
+use ironrdp_core::{
+    Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, cast_length, ensure_fixed_part_size,
+    ensure_size, invalid_field_err,
+};
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive as _;
+
+use super::RfxRectangle;
+
+// Wire constants
+const SYNC_MAGIC: u32 = 0xCACCACCA;
+const SYNC_VERSION: u16 = 0x0100;
+const TILE_SIZE: u16 = 0x0040;
+/// Block header size as u32 for checked_sub arithmetic (avoids `as` cast).
+const BLOCK_HEADER_SIZE_U32: u32 = 6;
+
+/// Progressive block type discriminator.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
+#[repr(u16)]
+pub enum ProgressiveBlockType {
+    Sync = 0xCCC0,
+    FrameBegin = 0xCCC1,
+    FrameEnd = 0xCCC2,
+    Context = 0xCCC3,
+    Region = 0xCCC4,
+    TileSimple = 0xCCC5,
+    TileFirst = 0xCCC6,
+    TileUpgrade = 0xCCC7,
+}
+
+impl ProgressiveBlockType {
+    #[expect(
+        clippy::as_conversions,
+        reason = "repr(u16) discriminant cast is the canonical pattern"
+    )]
+    fn as_u16(self) -> u16 {
+        self as u16
+    }
+}
+
+/// 6-byte block header shared by all progressive blocks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProgressiveBlockHeader {
+    pub block_type: ProgressiveBlockType,
+    pub block_len: u32,
+}
+
+impl ProgressiveBlockHeader {
+    const NAME: &'static str = "ProgressiveBlockHeader";
+    pub const SIZE: usize = 6;
+    const FIXED_PART_SIZE: usize = Self::SIZE;
+}
+
+impl Encode for ProgressiveBlockHeader {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_fixed_part_size!(in: dst);
+        dst.write_u16(self.block_type.as_u16());
+        dst.write_u32(self.block_len);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::SIZE
+    }
+}
+
+impl Decode<'_> for ProgressiveBlockHeader {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+        let raw = src.read_u16();
+        let block_type = ProgressiveBlockType::from_u16(raw)
+            .ok_or_else(|| invalid_field_err!("blockType", "unknown progressive block type"))?;
+        let block_len = src.read_u32();
+        Ok(Self { block_type, block_len })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Quantization types (progressive nibble order)
+// ---------------------------------------------------------------------------
+
+/// Per-component quantization values with the progressive nibble packing.
+///
+/// The progressive codec swaps HL/LH at each level compared to classic RFX:
+/// Classic:      LL3, LH3, HL3, HH3, LH2, HL2, HH2, LH1, HL1, HH1
+/// Progressive:  LL3, HL3, LH3, HH3, HL2, LH2, HH2, HL1, LH1, HH1
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ComponentCodecQuant {
+    pub ll3: u8,
+    pub hl3: u8,
+    pub lh3: u8,
+    pub hh3: u8,
+    pub hl2: u8,
+    pub lh2: u8,
+    pub hh2: u8,
+    pub hl1: u8,
+    pub lh1: u8,
+    pub hh1: u8,
+}
+
+impl ComponentCodecQuant {
+    const NAME: &'static str = "ComponentCodecQuant";
+    /// 10 nibbles packed into 5 bytes.
+    pub const SIZE: usize = 5;
+    const FIXED_PART_SIZE: usize = Self::SIZE;
+
+    /// All-zero quant (no extra quantization, full quality).
+    pub const LOSSLESS: Self = Self {
+        ll3: 0,
+        hl3: 0,
+        lh3: 0,
+        hh3: 0,
+        hl2: 0,
+        lh2: 0,
+        hh2: 0,
+        hl1: 0,
+        lh1: 0,
+        hh1: 0,
+    };
+
+    /// Return the quantization value for a given subband index (0..9).
+    /// Band order: HL1, LH1, HH1, HL2, LH2, HH2, HL3, LH3, HH3, LL3
+    pub fn for_band(&self, band_idx: usize) -> u8 {
+        match band_idx {
+            0 => self.hl1,
+            1 => self.lh1,
+            2 => self.hh1,
+            3 => self.hl2,
+            4 => self.lh2,
+            5 => self.hh2,
+            6 => self.hl3,
+            7 => self.lh3,
+            8 => self.hh3,
+            9 => self.ll3,
+            _ => 0,
+        }
+    }
+}
+
+impl Encode for ComponentCodecQuant {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_fixed_part_size!(in: dst);
+        // Progressive nibble order: LL3|HL3, LH3|HH3, HL2|LH2, HH2|HL1, LH1|HH1
+        dst.write_u8(self.ll3 | (self.hl3 << 4));
+        dst.write_u8(self.lh3 | (self.hh3 << 4));
+        dst.write_u8(self.hl2 | (self.lh2 << 4));
+        dst.write_u8(self.hh2 | (self.hl1 << 4));
+        dst.write_u8(self.lh1 | (self.hh1 << 4));
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::SIZE
+    }
+}
+
+impl Decode<'_> for ComponentCodecQuant {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+        let b0 = src.read_u8();
+        let b1 = src.read_u8();
+        let b2 = src.read_u8();
+        let b3 = src.read_u8();
+        let b4 = src.read_u8();
+        Ok(Self {
+            ll3: b0 & 0x0F,
+            hl3: b0 >> 4,
+            lh3: b1 & 0x0F,
+            hh3: b1 >> 4,
+            hl2: b2 & 0x0F,
+            lh2: b2 >> 4,
+            hh2: b3 & 0x0F,
+            hl1: b3 >> 4,
+            lh1: b4 & 0x0F,
+            hh1: b4 >> 4,
+        })
+    }
+}
+
+/// Per-quality-level progressive quantization: quality byte + 3 component quants.
+///
+/// `quality` ranges from 0 (minimum) to 0xFF (full quality / no extra quantization).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProgressiveCodecQuant {
+    pub quality: u8,
+    pub y_quant: ComponentCodecQuant,
+    pub cb_quant: ComponentCodecQuant,
+    pub cr_quant: ComponentCodecQuant,
+}
+
+impl ProgressiveCodecQuant {
+    const NAME: &'static str = "ProgressiveCodecQuant";
+    /// 1 byte quality + 3 x 5 bytes = 16 bytes.
+    pub const SIZE: usize = 16;
+    const FIXED_PART_SIZE: usize = Self::SIZE;
+}
+
+impl Encode for ProgressiveCodecQuant {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_fixed_part_size!(in: dst);
+        dst.write_u8(self.quality);
+        self.y_quant.encode(dst)?;
+        self.cb_quant.encode(dst)?;
+        self.cr_quant.encode(dst)?;
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::SIZE
+    }
+}
+
+impl Decode<'_> for ProgressiveCodecQuant {
+    #[expect(clippy::similar_names, reason = "y/cb/cr quant names follow spec terminology")]
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+        let quality = src.read_u8();
+        let y_quant = ComponentCodecQuant::decode(src)?;
+        let cb_quant = ComponentCodecQuant::decode(src)?;
+        let cr_quant = ComponentCodecQuant::decode(src)?;
+        Ok(Self {
+            quality,
+            y_quant,
+            cb_quant,
+            cr_quant,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Individual block types
+// ---------------------------------------------------------------------------
+
+/// RFX_PROGRESSIVE_SYNC: magic 0xCACCACCA + version 0x0100.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProgressiveSyncPdu;
+
+impl ProgressiveSyncPdu {
+    const NAME: &'static str = "ProgressiveSync";
+    const FIXED_PART_SIZE: usize = 4 /* magic */ + 2 /* version */;
+}
+
+impl Encode for ProgressiveSyncPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_fixed_part_size!(in: dst);
+        dst.write_u32(SYNC_MAGIC);
+        dst.write_u16(SYNC_VERSION);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl Decode<'_> for ProgressiveSyncPdu {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+        let magic = src.read_u32();
+        if magic != SYNC_MAGIC {
+            return Err(invalid_field_err!("magic", "invalid progressive sync magic"));
+        }
+        let version = src.read_u16();
+        if version != SYNC_VERSION {
+            return Err(invalid_field_err!("version", "unsupported progressive version"));
+        }
+        Ok(Self)
+    }
+}
+
+/// RFX_PROGRESSIVE_FRAME_BEGIN.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProgressiveFrameBeginPdu {
+    pub frame_index: u32,
+    pub region_count: u16,
+}
+
+impl ProgressiveFrameBeginPdu {
+    const NAME: &'static str = "ProgressiveFrameBegin";
+    const FIXED_PART_SIZE: usize = 4 /* frameIndex */ + 2 /* regionCount */;
+}
+
+impl Encode for ProgressiveFrameBeginPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_fixed_part_size!(in: dst);
+        dst.write_u32(self.frame_index);
+        dst.write_u16(self.region_count);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl Decode<'_> for ProgressiveFrameBeginPdu {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+        let frame_index = src.read_u32();
+        let region_count = src.read_u16();
+        Ok(Self {
+            frame_index,
+            region_count,
+        })
+    }
+}
+
+/// RFX_PROGRESSIVE_FRAME_END (empty body).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProgressiveFrameEndPdu;
+
+impl ProgressiveFrameEndPdu {
+    const NAME: &'static str = "ProgressiveFrameEnd";
+    const FIXED_PART_SIZE: usize = 0;
+}
+
+impl Encode for ProgressiveFrameEndPdu {
+    fn encode(&self, _dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl Decode<'_> for ProgressiveFrameEndPdu {
+    fn decode(_src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        Ok(Self)
+    }
+}
+
+/// RFX_PROGRESSIVE_CONTEXT.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProgressiveContextPdu {
+    pub context_id: u8,
+    pub tile_size: u16,
+    pub flags: u8,
+}
+
+/// Bit 0 of context flags: use reduce-extrapolate DWT.
+pub const FLAG_DWT_REDUCE_EXTRAPOLATE: u8 = 0x01;
+
+impl ProgressiveContextPdu {
+    const NAME: &'static str = "ProgressiveContext";
+    const FIXED_PART_SIZE: usize = 1 /* ctxId */ + 2 /* tileSize */ + 1 /* flags */;
+
+    /// Whether the reduce-extrapolate DWT variant is selected.
+    pub fn uses_reduce_extrapolate(&self) -> bool {
+        self.flags & FLAG_DWT_REDUCE_EXTRAPOLATE != 0
+    }
+}
+
+impl Encode for ProgressiveContextPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_fixed_part_size!(in: dst);
+        dst.write_u8(self.context_id);
+        dst.write_u16(self.tile_size);
+        dst.write_u8(self.flags);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl Decode<'_> for ProgressiveContextPdu {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+        let context_id = src.read_u8();
+        let tile_size = src.read_u16();
+        if tile_size != TILE_SIZE {
+            return Err(invalid_field_err!("tileSize", "only 64x64 tiles supported"));
+        }
+        let flags = src.read_u8();
+        Ok(Self {
+            context_id,
+            tile_size,
+            flags,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tile blocks
+// ---------------------------------------------------------------------------
+
+/// TILE_SIMPLE: non-progressive full-quality tile (single pass).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TileSimple<'a> {
+    pub quant_idx_y: u8,
+    pub quant_idx_cb: u8,
+    pub quant_idx_cr: u8,
+    pub x_idx: u16,
+    pub y_idx: u16,
+    pub flags: u8,
+    pub y_data: &'a [u8],
+    pub cb_data: &'a [u8],
+    pub cr_data: &'a [u8],
+    pub tail_data: &'a [u8],
+}
+
+impl TileSimple<'_> {
+    const NAME: &'static str = "TileSimple";
+    /// Fixed header: 3 quant idx + 2 x_idx + 2 y_idx + 1 flags + 4x2 lengths = 16 bytes.
+    const HEADER_SIZE: usize = 3 + 2 + 2 + 1 + 8;
+}
+
+impl Encode for TileSimple<'_> {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u8(self.quant_idx_y);
+        dst.write_u8(self.quant_idx_cb);
+        dst.write_u8(self.quant_idx_cr);
+        dst.write_u16(self.x_idx);
+        dst.write_u16(self.y_idx);
+        dst.write_u8(self.flags);
+        dst.write_u16(cast_length!("yLen", self.y_data.len())?);
+        dst.write_u16(cast_length!("cbLen", self.cb_data.len())?);
+        dst.write_u16(cast_length!("crLen", self.cr_data.len())?);
+        dst.write_u16(cast_length!("tailLen", self.tail_data.len())?);
+        dst.write_slice(self.y_data);
+        dst.write_slice(self.cb_data);
+        dst.write_slice(self.cr_data);
+        dst.write_slice(self.tail_data);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::HEADER_SIZE + self.y_data.len() + self.cb_data.len() + self.cr_data.len() + self.tail_data.len()
+    }
+}
+
+impl<'de> Decode<'de> for TileSimple<'de> {
+    #[expect(clippy::similar_names, reason = "y/cb/cr quant and length names follow spec")]
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_size!(ctx: Self::NAME, in: src, size: Self::HEADER_SIZE);
+        let quant_idx_y = src.read_u8();
+        let quant_idx_cb = src.read_u8();
+        let quant_idx_cr = src.read_u8();
+        let x_idx = src.read_u16();
+        let y_idx = src.read_u16();
+        let flags = src.read_u8();
+        let y_len = usize::from(src.read_u16());
+        let cb_len = usize::from(src.read_u16());
+        let cr_len = usize::from(src.read_u16());
+        let tail_len = usize::from(src.read_u16());
+
+        let total = y_len + cb_len + cr_len + tail_len;
+        ensure_size!(ctx: Self::NAME, in: src, size: total);
+        let y_data = src.read_slice(y_len);
+        let cb_data = src.read_slice(cb_len);
+        let cr_data = src.read_slice(cr_len);
+        let tail_data = src.read_slice(tail_len);
+
+        Ok(Self {
+            quant_idx_y,
+            quant_idx_cb,
+            quant_idx_cr,
+            x_idx,
+            y_idx,
+            flags,
+            y_data,
+            cb_data,
+            cr_data,
+            tail_data,
+        })
+    }
+}
+
+/// TILE_FIRST: first progressive pass (coarse quality).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TileFirst<'a> {
+    pub quant_idx_y: u8,
+    pub quant_idx_cb: u8,
+    pub quant_idx_cr: u8,
+    pub x_idx: u16,
+    pub y_idx: u16,
+    pub flags: u8,
+    pub quality: u8,
+    pub y_data: &'a [u8],
+    pub cb_data: &'a [u8],
+    pub cr_data: &'a [u8],
+    pub tail_data: &'a [u8],
+}
+
+impl TileFirst<'_> {
+    const NAME: &'static str = "TileFirst";
+    /// Same as TileSimple + 1 byte for quality = 17 bytes.
+    const HEADER_SIZE: usize = 3 + 2 + 2 + 1 + 1 + 8;
+}
+
+impl Encode for TileFirst<'_> {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u8(self.quant_idx_y);
+        dst.write_u8(self.quant_idx_cb);
+        dst.write_u8(self.quant_idx_cr);
+        dst.write_u16(self.x_idx);
+        dst.write_u16(self.y_idx);
+        dst.write_u8(self.flags);
+        dst.write_u8(self.quality);
+        dst.write_u16(cast_length!("yLen", self.y_data.len())?);
+        dst.write_u16(cast_length!("cbLen", self.cb_data.len())?);
+        dst.write_u16(cast_length!("crLen", self.cr_data.len())?);
+        dst.write_u16(cast_length!("tailLen", self.tail_data.len())?);
+        dst.write_slice(self.y_data);
+        dst.write_slice(self.cb_data);
+        dst.write_slice(self.cr_data);
+        dst.write_slice(self.tail_data);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::HEADER_SIZE + self.y_data.len() + self.cb_data.len() + self.cr_data.len() + self.tail_data.len()
+    }
+}
+
+impl<'de> Decode<'de> for TileFirst<'de> {
+    #[expect(clippy::similar_names, reason = "y/cb/cr quant and length names follow spec")]
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_size!(ctx: Self::NAME, in: src, size: Self::HEADER_SIZE);
+        let quant_idx_y = src.read_u8();
+        let quant_idx_cb = src.read_u8();
+        let quant_idx_cr = src.read_u8();
+        let x_idx = src.read_u16();
+        let y_idx = src.read_u16();
+        let flags = src.read_u8();
+        let quality = src.read_u8();
+        let y_len = usize::from(src.read_u16());
+        let cb_len = usize::from(src.read_u16());
+        let cr_len = usize::from(src.read_u16());
+        let tail_len = usize::from(src.read_u16());
+
+        let total = y_len + cb_len + cr_len + tail_len;
+        ensure_size!(ctx: Self::NAME, in: src, size: total);
+        let y_data = src.read_slice(y_len);
+        let cb_data = src.read_slice(cb_len);
+        let cr_data = src.read_slice(cr_len);
+        let tail_data = src.read_slice(tail_len);
+
+        Ok(Self {
+            quant_idx_y,
+            quant_idx_cb,
+            quant_idx_cr,
+            x_idx,
+            y_idx,
+            flags,
+            quality,
+            y_data,
+            cb_data,
+            cr_data,
+            tail_data,
+        })
+    }
+}
+
+/// TILE_UPGRADE: progressive refinement pass.
+///
+/// Each component has separate SRL and raw data streams.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TileUpgrade<'a> {
+    pub quant_idx_y: u8,
+    pub quant_idx_cb: u8,
+    pub quant_idx_cr: u8,
+    pub x_idx: u16,
+    pub y_idx: u16,
+    pub quality: u8,
+    pub y_srl_data: &'a [u8],
+    pub y_raw_data: &'a [u8],
+    pub cb_srl_data: &'a [u8],
+    pub cb_raw_data: &'a [u8],
+    pub cr_srl_data: &'a [u8],
+    pub cr_raw_data: &'a [u8],
+}
+
+impl TileUpgrade<'_> {
+    const NAME: &'static str = "TileUpgrade";
+    /// 3 quant + 2 x + 2 y + 1 quality + 6x2 lengths = 20 bytes.
+    const HEADER_SIZE: usize = 3 + 2 + 2 + 1 + 12;
+}
+
+impl Encode for TileUpgrade<'_> {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u8(self.quant_idx_y);
+        dst.write_u8(self.quant_idx_cb);
+        dst.write_u8(self.quant_idx_cr);
+        dst.write_u16(self.x_idx);
+        dst.write_u16(self.y_idx);
+        dst.write_u8(self.quality);
+        dst.write_u16(cast_length!("ySrlLen", self.y_srl_data.len())?);
+        dst.write_u16(cast_length!("yRawLen", self.y_raw_data.len())?);
+        dst.write_u16(cast_length!("cbSrlLen", self.cb_srl_data.len())?);
+        dst.write_u16(cast_length!("cbRawLen", self.cb_raw_data.len())?);
+        dst.write_u16(cast_length!("crSrlLen", self.cr_srl_data.len())?);
+        dst.write_u16(cast_length!("crRawLen", self.cr_raw_data.len())?);
+        dst.write_slice(self.y_srl_data);
+        dst.write_slice(self.y_raw_data);
+        dst.write_slice(self.cb_srl_data);
+        dst.write_slice(self.cb_raw_data);
+        dst.write_slice(self.cr_srl_data);
+        dst.write_slice(self.cr_raw_data);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::HEADER_SIZE
+            + self.y_srl_data.len()
+            + self.y_raw_data.len()
+            + self.cb_srl_data.len()
+            + self.cb_raw_data.len()
+            + self.cr_srl_data.len()
+            + self.cr_raw_data.len()
+    }
+}
+
+impl<'de> Decode<'de> for TileUpgrade<'de> {
+    #[expect(clippy::similar_names, reason = "SRL/raw per component is inherently similar")]
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_size!(ctx: Self::NAME, in: src, size: Self::HEADER_SIZE);
+        let quant_idx_y = src.read_u8();
+        let quant_idx_cb = src.read_u8();
+        let quant_idx_cr = src.read_u8();
+        let x_idx = src.read_u16();
+        let y_idx = src.read_u16();
+        let quality = src.read_u8();
+        let y_srl_len = usize::from(src.read_u16());
+        let y_raw_len = usize::from(src.read_u16());
+        let cb_srl_len = usize::from(src.read_u16());
+        let cb_raw_len = usize::from(src.read_u16());
+        let cr_srl_len = usize::from(src.read_u16());
+        let cr_raw_len = usize::from(src.read_u16());
+
+        let total = y_srl_len + y_raw_len + cb_srl_len + cb_raw_len + cr_srl_len + cr_raw_len;
+        ensure_size!(ctx: Self::NAME, in: src, size: total);
+        let y_srl_data = src.read_slice(y_srl_len);
+        let y_raw_data = src.read_slice(y_raw_len);
+        let cb_srl_data = src.read_slice(cb_srl_len);
+        let cb_raw_data = src.read_slice(cb_raw_len);
+        let cr_srl_data = src.read_slice(cr_srl_len);
+        let cr_raw_data = src.read_slice(cr_raw_len);
+
+        Ok(Self {
+            quant_idx_y,
+            quant_idx_cb,
+            quant_idx_cr,
+            x_idx,
+            y_idx,
+            quality,
+            y_srl_data,
+            y_raw_data,
+            cb_srl_data,
+            cb_raw_data,
+            cr_srl_data,
+            cr_raw_data,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Region container
+// ---------------------------------------------------------------------------
+
+/// A progressive tile: one of the three tile block types.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProgressiveTile<'a> {
+    Simple(TileSimple<'a>),
+    First(TileFirst<'a>),
+    Upgrade(TileUpgrade<'a>),
+}
+
+impl ProgressiveTile<'_> {
+    pub fn x_idx(&self) -> u16 {
+        match self {
+            Self::Simple(t) => t.x_idx,
+            Self::First(t) => t.x_idx,
+            Self::Upgrade(t) => t.x_idx,
+        }
+    }
+
+    pub fn y_idx(&self) -> u16 {
+        match self {
+            Self::Simple(t) => t.y_idx,
+            Self::First(t) => t.y_idx,
+            Self::Upgrade(t) => t.y_idx,
+        }
+    }
+}
+
+/// RFX_PROGRESSIVE_REGION: the main container holding rects, quant tables, and tiles.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProgressiveRegion<'a> {
+    pub tile_size: u8,
+    pub rects: Vec<RfxRectangle>,
+    pub quant_vals: Vec<ComponentCodecQuant>,
+    pub quant_prog_vals: Vec<ProgressiveCodecQuant>,
+    pub flags: u8,
+    pub tiles: Vec<ProgressiveTile<'a>>,
+}
+
+impl ProgressiveRegion<'_> {
+    const NAME: &'static str = "ProgressiveRegion";
+    /// tileSize(1) + numRects(2) + numQuant(1) + numProgQuant(1)
+    /// + flags(1) + numTiles(2) + tileDataSize(4) = 12 bytes.
+    const HEADER_SIZE: usize = 12;
+
+    /// Whether this region uses the reduce-extrapolate DWT variant.
+    pub fn uses_reduce_extrapolate(&self) -> bool {
+        self.flags & FLAG_DWT_REDUCE_EXTRAPOLATE != 0
+    }
+}
+
+impl Encode for ProgressiveRegion<'_> {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+
+        dst.write_u8(self.tile_size);
+        dst.write_u16(cast_length!("numRects", self.rects.len())?);
+        dst.write_u8(cast_length!("numQuant", self.quant_vals.len())?);
+        dst.write_u8(cast_length!("numProgQuant", self.quant_prog_vals.len())?);
+        dst.write_u8(self.flags);
+        dst.write_u16(cast_length!("numTiles", self.tiles.len())?);
+
+        // Compute tile data size (sum of block header + tile body for each tile)
+        let tile_data_size: usize = self
+            .tiles
+            .iter()
+            .map(|t| {
+                ProgressiveBlockHeader::SIZE
+                    + match t {
+                        ProgressiveTile::Simple(s) => s.size(),
+                        ProgressiveTile::First(f) => f.size(),
+                        ProgressiveTile::Upgrade(u) => u.size(),
+                    }
+            })
+            .sum();
+        dst.write_u32(cast_length!("tileDataSize", tile_data_size)?);
+
+        for rect in &self.rects {
+            rect.encode(dst)?;
+        }
+        for qv in &self.quant_vals {
+            qv.encode(dst)?;
+        }
+        for qpv in &self.quant_prog_vals {
+            qpv.encode(dst)?;
+        }
+
+        // Each tile is wrapped in a block header
+        for tile in &self.tiles {
+            let (block_type, body_size) = match tile {
+                ProgressiveTile::Simple(s) => (ProgressiveBlockType::TileSimple, s.size()),
+                ProgressiveTile::First(f) => (ProgressiveBlockType::TileFirst, f.size()),
+                ProgressiveTile::Upgrade(u) => (ProgressiveBlockType::TileUpgrade, u.size()),
+            };
+            let block_len = u32::try_from(ProgressiveBlockHeader::SIZE + body_size).expect("tile size fits u32");
+            let header = ProgressiveBlockHeader { block_type, block_len };
+            header.encode(dst)?;
+            match tile {
+                ProgressiveTile::Simple(s) => s.encode(dst)?,
+                ProgressiveTile::First(f) => f.encode(dst)?,
+                ProgressiveTile::Upgrade(u) => u.encode(dst)?,
+            }
+        }
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        let rect_size: usize = self.rects.iter().map(Encode::size).sum();
+        let quant_size = self.quant_vals.len() * ComponentCodecQuant::SIZE;
+        let prog_quant_size = self.quant_prog_vals.len() * ProgressiveCodecQuant::SIZE;
+        let tile_data_size: usize = self
+            .tiles
+            .iter()
+            .map(|t| {
+                ProgressiveBlockHeader::SIZE
+                    + match t {
+                        ProgressiveTile::Simple(s) => s.size(),
+                        ProgressiveTile::First(f) => f.size(),
+                        ProgressiveTile::Upgrade(u) => u.size(),
+                    }
+            })
+            .sum();
+        Self::HEADER_SIZE + rect_size + quant_size + prog_quant_size + tile_data_size
+    }
+}
+
+impl<'de> Decode<'de> for ProgressiveRegion<'de> {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_size!(ctx: Self::NAME, in: src, size: Self::HEADER_SIZE);
+
+        let tile_size = src.read_u8();
+        if tile_size != 0x40 {
+            return Err(invalid_field_err!("tileSize", "only 64x64 tiles supported"));
+        }
+
+        let num_rects = usize::from(src.read_u16());
+        let num_quant = usize::from(src.read_u8());
+        let num_prog_quant = usize::from(src.read_u8());
+        let flags = src.read_u8();
+        let num_tiles = usize::from(src.read_u16());
+        let _tile_data_size = src.read_u32();
+
+        // Rectangles (4 x u16 = 8 bytes each)
+        const RFX_RECT_SIZE: usize = 8;
+        ensure_size!(ctx: Self::NAME, in: src, size: num_rects * RFX_RECT_SIZE);
+        let rects = iter::repeat_with(|| RfxRectangle::decode(src))
+            .take(num_rects)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // Base quantization values
+        ensure_size!(ctx: Self::NAME, in: src, size: num_quant * ComponentCodecQuant::SIZE);
+        let quant_vals = iter::repeat_with(|| ComponentCodecQuant::decode(src))
+            .take(num_quant)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // Progressive quantization values
+        ensure_size!(ctx: Self::NAME, in: src, size: num_prog_quant * ProgressiveCodecQuant::SIZE);
+        let quant_prog_vals = iter::repeat_with(|| ProgressiveCodecQuant::decode(src))
+            .take(num_prog_quant)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // Tile blocks (each preceded by a block header)
+        let mut tiles = Vec::with_capacity(num_tiles);
+        for _ in 0..num_tiles {
+            let header = ProgressiveBlockHeader::decode(src)?;
+            let body_len = header
+                .block_len
+                .checked_sub(BLOCK_HEADER_SIZE_U32)
+                .ok_or_else(|| invalid_field_err!("blockLen", "tile block length too small"))?;
+            let body_len: usize = cast_length!("tileBodyLen", body_len)?;
+            ensure_size!(ctx: Self::NAME, in: src, size: body_len);
+            let tile_src = &mut ReadCursor::new(src.read_slice(body_len));
+
+            let tile = match header.block_type {
+                ProgressiveBlockType::TileSimple => ProgressiveTile::Simple(TileSimple::decode(tile_src)?),
+                ProgressiveBlockType::TileFirst => ProgressiveTile::First(TileFirst::decode(tile_src)?),
+                ProgressiveBlockType::TileUpgrade => ProgressiveTile::Upgrade(TileUpgrade::decode(tile_src)?),
+                _ => {
+                    return Err(invalid_field_err!("blockType", "expected tile block inside region"));
+                }
+            };
+            tiles.push(tile);
+        }
+
+        Ok(Self {
+            tile_size,
+            rects,
+            quant_vals,
+            quant_prog_vals,
+            flags,
+            tiles,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Top-level block enum + stream parser
+// ---------------------------------------------------------------------------
+
+/// A progressive block in the bitmap stream.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProgressiveBlock<'a> {
+    Sync(ProgressiveSyncPdu),
+    FrameBegin(ProgressiveFrameBeginPdu),
+    FrameEnd(ProgressiveFrameEndPdu),
+    Context(ProgressiveContextPdu),
+    Region(ProgressiveRegion<'a>),
+}
+
+/// Parse a progressive bitmap stream (the `bitmapData` from `WireToSurface2Pdu`).
+///
+/// Returns the sequence of progressive blocks. The stream always starts with
+/// SYNC + CONTEXT, followed by FRAME_BEGIN, one or more REGION blocks
+/// (containing tiles), and FRAME_END.
+pub fn decode_progressive_stream<'a>(data: &'a [u8]) -> DecodeResult<Vec<ProgressiveBlock<'a>>> {
+    let mut blocks = Vec::new();
+    let mut src = ReadCursor::new(data);
+
+    while src.len() >= ProgressiveBlockHeader::SIZE {
+        let header = ProgressiveBlockHeader::decode(&mut src)?;
+        let body_len = header
+            .block_len
+            .checked_sub(BLOCK_HEADER_SIZE_U32)
+            .ok_or_else(|| invalid_field_err!("blockLen", "block length too small"))?;
+        let body_len: usize = cast_length!("bodyLen", body_len)?;
+        ensure_size!(ctx: "ProgressiveStream", in: src, size: body_len);
+        let body_src = &mut ReadCursor::new(src.read_slice(body_len));
+
+        let block = match header.block_type {
+            ProgressiveBlockType::Sync => ProgressiveBlock::Sync(ProgressiveSyncPdu::decode(body_src)?),
+            ProgressiveBlockType::FrameBegin => {
+                ProgressiveBlock::FrameBegin(ProgressiveFrameBeginPdu::decode(body_src)?)
+            }
+            ProgressiveBlockType::FrameEnd => ProgressiveBlock::FrameEnd(ProgressiveFrameEndPdu::decode(body_src)?),
+            ProgressiveBlockType::Context => ProgressiveBlock::Context(ProgressiveContextPdu::decode(body_src)?),
+            ProgressiveBlockType::Region => ProgressiveBlock::Region(ProgressiveRegion::decode(body_src)?),
+            // Tile blocks should only appear inside regions; skip at top level
+            ProgressiveBlockType::TileSimple | ProgressiveBlockType::TileFirst | ProgressiveBlockType::TileUpgrade => {
+                return Err(invalid_field_err!("blockType", "tile block outside of region"));
+            }
+        };
+        blocks.push(block);
+    }
+
+    Ok(blocks)
+}
+
+/// Encode a progressive bitmap stream into bytes.
+///
+/// # Panics
+///
+/// Cannot panic in practice. Internal `expect()` calls guard `u32::try_from`
+/// on block sizes that are bounded by available memory.
+pub fn encode_progressive_stream(blocks: &[ProgressiveBlock<'_>]) -> EncodeResult<Vec<u8>> {
+    let total_size: usize = blocks
+        .iter()
+        .map(|b| {
+            ProgressiveBlockHeader::SIZE
+                + match b {
+                    ProgressiveBlock::Sync(s) => s.size(),
+                    ProgressiveBlock::FrameBegin(f) => f.size(),
+                    ProgressiveBlock::FrameEnd(f) => f.size(),
+                    ProgressiveBlock::Context(c) => c.size(),
+                    ProgressiveBlock::Region(r) => r.size(),
+                }
+        })
+        .sum();
+
+    let mut buf = vec![0u8; total_size];
+    let mut dst = WriteCursor::new(&mut buf);
+
+    for block in blocks {
+        let (block_type, body_size) = match block {
+            ProgressiveBlock::Sync(s) => (ProgressiveBlockType::Sync, s.size()),
+            ProgressiveBlock::FrameBegin(f) => (ProgressiveBlockType::FrameBegin, f.size()),
+            ProgressiveBlock::FrameEnd(f) => (ProgressiveBlockType::FrameEnd, f.size()),
+            ProgressiveBlock::Context(c) => (ProgressiveBlockType::Context, c.size()),
+            ProgressiveBlock::Region(r) => (ProgressiveBlockType::Region, r.size()),
+        };
+        let block_len = u32::try_from(ProgressiveBlockHeader::SIZE + body_size).expect("block size fits u32");
+        ProgressiveBlockHeader { block_type, block_len }.encode(&mut dst)?;
+
+        match block {
+            ProgressiveBlock::Sync(s) => s.encode(&mut dst)?,
+            ProgressiveBlock::FrameBegin(f) => f.encode(&mut dst)?,
+            ProgressiveBlock::FrameEnd(f) => f.encode(&mut dst)?,
+            ProgressiveBlock::Context(c) => c.encode(&mut dst)?,
+            ProgressiveBlock::Region(r) => r.encode(&mut dst)?,
+        }
+    }
+
+    Ok(buf)
+}
+
+#[cfg(test)]
+#[expect(clippy::similar_names, reason = "y/cb/cr test variables follow spec terminology")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn component_codec_quant_round_trip() {
+        let original = ComponentCodecQuant {
+            ll3: 6,
+            hl3: 7,
+            lh3: 8,
+            hh3: 9,
+            hl2: 10,
+            lh2: 11,
+            hh2: 12,
+            hl1: 13,
+            lh1: 14,
+            hh1: 15,
+        };
+        let mut buf = [0u8; ComponentCodecQuant::SIZE];
+        original.encode(&mut WriteCursor::new(&mut buf)).unwrap();
+        let decoded = ComponentCodecQuant::decode(&mut ReadCursor::new(&buf)).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn progressive_codec_quant_round_trip() {
+        let original = ProgressiveCodecQuant {
+            quality: 0x80,
+            y_quant: ComponentCodecQuant {
+                ll3: 1,
+                hl3: 2,
+                lh3: 3,
+                hh3: 4,
+                hl2: 5,
+                lh2: 6,
+                hh2: 7,
+                hl1: 8,
+                lh1: 9,
+                hh1: 10,
+            },
+            cb_quant: ComponentCodecQuant::LOSSLESS,
+            cr_quant: ComponentCodecQuant::LOSSLESS,
+        };
+        let mut buf = [0u8; ProgressiveCodecQuant::SIZE];
+        original.encode(&mut WriteCursor::new(&mut buf)).unwrap();
+        let decoded = ProgressiveCodecQuant::decode(&mut ReadCursor::new(&buf)).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn sync_round_trip() {
+        let original = ProgressiveSyncPdu;
+        let mut buf = [0u8; 64];
+        let header_size = ProgressiveBlockHeader::SIZE;
+        let body_size = original.size();
+        let block_len = u32::try_from(header_size + body_size).unwrap();
+        let mut dst = WriteCursor::new(&mut buf);
+        ProgressiveBlockHeader {
+            block_type: ProgressiveBlockType::Sync,
+            block_len,
+        }
+        .encode(&mut dst)
+        .unwrap();
+        original.encode(&mut dst).unwrap();
+        let written = header_size + body_size;
+        let blocks = decode_progressive_stream(&buf[..written]).unwrap();
+        assert_eq!(blocks.len(), 1);
+        assert!(matches!(blocks[0], ProgressiveBlock::Sync(_)));
+    }
+
+    #[test]
+    fn context_pdu_round_trip() {
+        let original = ProgressiveContextPdu {
+            context_id: 0,
+            tile_size: 0x0040,
+            flags: FLAG_DWT_REDUCE_EXTRAPOLATE,
+        };
+        assert!(original.uses_reduce_extrapolate());
+
+        let mut buf = [0u8; ProgressiveContextPdu::FIXED_PART_SIZE];
+        original.encode(&mut WriteCursor::new(&mut buf)).unwrap();
+        let decoded = ProgressiveContextPdu::decode(&mut ReadCursor::new(&buf)).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn tile_simple_round_trip() {
+        let y_data = &[1, 2, 3, 4, 5];
+        let cb_data = &[6, 7];
+        let cr_data = &[8, 9, 10];
+        let tail_data = &[];
+
+        let original = TileSimple {
+            quant_idx_y: 0,
+            quant_idx_cb: 0,
+            quant_idx_cr: 0,
+            x_idx: 3,
+            y_idx: 7,
+            flags: 0,
+            y_data,
+            cb_data,
+            cr_data,
+            tail_data,
+        };
+        let mut buf = vec![0u8; original.size()];
+        original.encode(&mut WriteCursor::new(&mut buf)).unwrap();
+        let decoded = TileSimple::decode(&mut ReadCursor::new(&buf)).unwrap();
+        assert_eq!(decoded.x_idx, 3);
+        assert_eq!(decoded.y_idx, 7);
+        assert_eq!(decoded.y_data, y_data);
+        assert_eq!(decoded.cb_data, cb_data);
+        assert_eq!(decoded.cr_data, cr_data);
+    }
+
+    #[test]
+    fn tile_first_round_trip() {
+        let original = TileFirst {
+            quant_idx_y: 0,
+            quant_idx_cb: 1,
+            quant_idx_cr: 0,
+            x_idx: 0,
+            y_idx: 0,
+            flags: 0,
+            quality: 0x40,
+            y_data: &[10, 20],
+            cb_data: &[30],
+            cr_data: &[40],
+            tail_data: &[],
+        };
+        let mut buf = vec![0u8; original.size()];
+        original.encode(&mut WriteCursor::new(&mut buf)).unwrap();
+        let decoded = TileFirst::decode(&mut ReadCursor::new(&buf)).unwrap();
+        assert_eq!(decoded.quality, 0x40);
+        assert_eq!(decoded.quant_idx_cb, 1);
+    }
+
+    #[test]
+    fn tile_upgrade_round_trip() {
+        let original = TileUpgrade {
+            quant_idx_y: 0,
+            quant_idx_cb: 0,
+            quant_idx_cr: 0,
+            x_idx: 1,
+            y_idx: 2,
+            quality: 0x80,
+            y_srl_data: &[1, 2, 3],
+            y_raw_data: &[4, 5],
+            cb_srl_data: &[6],
+            cb_raw_data: &[],
+            cr_srl_data: &[7, 8],
+            cr_raw_data: &[9],
+        };
+        let mut buf = vec![0u8; original.size()];
+        original.encode(&mut WriteCursor::new(&mut buf)).unwrap();
+        let decoded = TileUpgrade::decode(&mut ReadCursor::new(&buf)).unwrap();
+        assert_eq!(decoded.quality, 0x80);
+        assert_eq!(decoded.y_srl_data, &[1, 2, 3]);
+        assert_eq!(decoded.cr_raw_data, &[9]);
+    }
+
+    #[test]
+    fn full_stream_round_trip() {
+        let quant = ComponentCodecQuant {
+            ll3: 6,
+            hl3: 6,
+            lh3: 6,
+            hh3: 6,
+            hl2: 7,
+            lh2: 7,
+            hh2: 8,
+            hl1: 8,
+            lh1: 8,
+            hh1: 9,
+        };
+        let prog_quant = ProgressiveCodecQuant {
+            quality: 0x40,
+            y_quant: quant,
+            cb_quant: quant,
+            cr_quant: quant,
+        };
+
+        let region = ProgressiveRegion {
+            tile_size: 0x40,
+            rects: vec![RfxRectangle {
+                x: 0,
+                y: 0,
+                width: 64,
+                height: 64,
+            }],
+            quant_vals: vec![quant],
+            quant_prog_vals: vec![prog_quant],
+            flags: FLAG_DWT_REDUCE_EXTRAPOLATE,
+            tiles: vec![ProgressiveTile::First(TileFirst {
+                quant_idx_y: 0,
+                quant_idx_cb: 0,
+                quant_idx_cr: 0,
+                x_idx: 0,
+                y_idx: 0,
+                flags: 0,
+                quality: 0x40,
+                y_data: &[0xAA; 50],
+                cb_data: &[0xBB; 30],
+                cr_data: &[0xCC; 20],
+                tail_data: &[],
+            })],
+        };
+
+        let blocks = vec![
+            ProgressiveBlock::Sync(ProgressiveSyncPdu),
+            ProgressiveBlock::Context(ProgressiveContextPdu {
+                context_id: 0,
+                tile_size: 0x0040,
+                flags: FLAG_DWT_REDUCE_EXTRAPOLATE,
+            }),
+            ProgressiveBlock::FrameBegin(ProgressiveFrameBeginPdu {
+                frame_index: 0,
+                region_count: 1,
+            }),
+            ProgressiveBlock::Region(region),
+            ProgressiveBlock::FrameEnd(ProgressiveFrameEndPdu),
+        ];
+
+        let encoded = encode_progressive_stream(&blocks).unwrap();
+        let decoded = decode_progressive_stream(&encoded).unwrap();
+
+        assert_eq!(decoded.len(), 5);
+        assert!(matches!(decoded[0], ProgressiveBlock::Sync(_)));
+        assert!(matches!(decoded[1], ProgressiveBlock::Context(_)));
+        assert!(matches!(decoded[2], ProgressiveBlock::FrameBegin(_)));
+        assert!(matches!(decoded[4], ProgressiveBlock::FrameEnd(_)));
+
+        if let ProgressiveBlock::Region(r) = &decoded[3] {
+            assert_eq!(r.rects.len(), 1);
+            assert_eq!(r.quant_vals.len(), 1);
+            assert_eq!(r.quant_prog_vals.len(), 1);
+            assert_eq!(r.tiles.len(), 1);
+            assert!(r.uses_reduce_extrapolate());
+            if let ProgressiveTile::First(t) = &r.tiles[0] {
+                assert_eq!(t.quality, 0x40);
+                assert_eq!(t.y_data.len(), 50);
+            } else {
+                panic!("expected TileFirst");
+            }
+        } else {
+            panic!("expected Region");
+        }
+    }
+
+    #[test]
+    fn nibble_order_differs_from_classic() {
+        // Verify that progressive ComponentCodecQuant has HL/LH swapped vs classic
+        let prog = ComponentCodecQuant {
+            ll3: 1,
+            hl3: 2,
+            lh3: 3,
+            hh3: 4,
+            hl2: 5,
+            lh2: 6,
+            hh2: 7,
+            hl1: 8,
+            lh1: 9,
+            hh1: 10,
+        };
+        let mut buf = [0u8; 5];
+        prog.encode(&mut WriteCursor::new(&mut buf)).unwrap();
+
+        // First byte: low nibble = LL3(1), high nibble = HL3(2) → 0x21
+        assert_eq!(buf[0], 0x21);
+        // Second byte: low nibble = LH3(3), high nibble = HH3(4) → 0x43
+        assert_eq!(buf[1], 0x43);
+        // Third byte: low nibble = HL2(5), high nibble = LH2(6) → 0x65
+        assert_eq!(buf[2], 0x65);
+
+        // Compare: classic Quant would have LL3|LH3, HL3|HH3 order
+        // So our first byte would be 0x31 (not 0x21) in classic order
+    }
+
+    #[test]
+    fn reject_tile_block_at_top_level() {
+        // A tile block at the top level should be rejected
+        let mut buf = [0u8; 64];
+        let mut dst = WriteCursor::new(&mut buf);
+        ProgressiveBlockHeader {
+            block_type: ProgressiveBlockType::TileSimple,
+            block_len: 6 + 16, // header + minimal body
+        }
+        .encode(&mut dst)
+        .unwrap();
+        // Fill minimal tile body
+        let tile = TileSimple {
+            quant_idx_y: 0,
+            quant_idx_cb: 0,
+            quant_idx_cr: 0,
+            x_idx: 0,
+            y_idx: 0,
+            flags: 0,
+            y_data: &[],
+            cb_data: &[],
+            cr_data: &[],
+            tail_data: &[],
+        };
+        tile.encode(&mut dst).unwrap();
+        let written = 6 + tile.size();
+        let result = decode_progressive_stream(&buf[..written]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn empty_stream() {
+        let blocks = decode_progressive_stream(&[]).unwrap();
+        assert!(blocks.is_empty());
+    }
+
+    #[test]
+    fn component_codec_quant_for_band() {
+        let q = ComponentCodecQuant {
+            ll3: 10,
+            hl3: 1,
+            lh3: 2,
+            hh3: 3,
+            hl2: 4,
+            lh2: 5,
+            hh2: 6,
+            hl1: 7,
+            lh1: 8,
+            hh1: 9,
+        };
+        // Band order: HL1, LH1, HH1, HL2, LH2, HH2, HL3, LH3, HH3, LL3
+        assert_eq!(q.for_band(0), 7); // HL1
+        assert_eq!(q.for_band(1), 8); // LH1
+        assert_eq!(q.for_band(2), 9); // HH1
+        assert_eq!(q.for_band(3), 4); // HL2
+        assert_eq!(q.for_band(9), 10); // LL3
+    }
+}

--- a/crates/ironrdp-pdu/src/codecs/rfx/progressive.rs
+++ b/crates/ironrdp-pdu/src/codecs/rfx/progressive.rs
@@ -10,14 +10,11 @@
 
 use core::iter;
 
+use super::RfxRectangle;
 use ironrdp_core::{
     Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, cast_length, ensure_fixed_part_size,
     ensure_size, invalid_field_err,
 };
-use num_derive::FromPrimitive;
-use num_traits::FromPrimitive as _;
-
-use super::RfxRectangle;
 
 // Wire constants
 const SYNC_MAGIC: u32 = 0xCACCACCA;
@@ -27,7 +24,7 @@ const TILE_SIZE: u16 = 0x0040;
 const BLOCK_HEADER_SIZE_U32: u32 = 6;
 
 /// Progressive block type discriminator.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromPrimitive)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(u16)]
 pub enum ProgressiveBlockType {
     Sync = 0xCCC0,
@@ -41,6 +38,20 @@ pub enum ProgressiveBlockType {
 }
 
 impl ProgressiveBlockType {
+    fn from_u16(val: u16) -> Option<Self> {
+        match val {
+            0xCCC0 => Some(Self::Sync),
+            0xCCC1 => Some(Self::FrameBegin),
+            0xCCC2 => Some(Self::FrameEnd),
+            0xCCC3 => Some(Self::Context),
+            0xCCC4 => Some(Self::Region),
+            0xCCC5 => Some(Self::TileSimple),
+            0xCCC6 => Some(Self::TileFirst),
+            0xCCC7 => Some(Self::TileUpgrade),
+            _ => None,
+        }
+    }
+
     #[expect(
         clippy::as_conversions,
         reason = "repr(u16) discriminant cast is the canonical pattern"
@@ -807,7 +818,7 @@ impl Encode for ProgressiveRegion<'_> {
                 ProgressiveTile::First(f) => (ProgressiveBlockType::TileFirst, f.size()),
                 ProgressiveTile::Upgrade(u) => (ProgressiveBlockType::TileUpgrade, u.size()),
             };
-            let block_len = u32::try_from(ProgressiveBlockHeader::SIZE + body_size).expect("tile size fits u32");
+            let block_len: u32 = cast_length!("tileBlockLen", ProgressiveBlockHeader::SIZE + body_size)?;
             let header = ProgressiveBlockHeader { block_type, block_len };
             header.encode(dst)?;
             match tile {
@@ -857,6 +868,16 @@ impl<'de> Decode<'de> for ProgressiveRegion<'de> {
         let num_quant = usize::from(src.read_u8());
         let num_prog_quant = usize::from(src.read_u8());
         let flags = src.read_u8();
+
+        if num_rects == 0 {
+            return Err(invalid_field_err!(
+                "numRects",
+                "region must contain at least one rectangle"
+            ));
+        }
+        if num_quant > 7 {
+            return Err(invalid_field_err!("numQuant", "quant count exceeds maximum of 7"));
+        }
         let num_tiles = usize::from(src.read_u16());
         let _tile_data_size = src.read_u32();
 
@@ -902,6 +923,18 @@ impl<'de> Decode<'de> for ProgressiveRegion<'de> {
             tiles.push(tile);
         }
 
+        let quant_count = quant_vals.len();
+        for tile in &tiles {
+            let indices = match tile {
+                ProgressiveTile::Simple(t) => [t.quant_idx_y, t.quant_idx_cb, t.quant_idx_cr],
+                ProgressiveTile::First(t) => [t.quant_idx_y, t.quant_idx_cb, t.quant_idx_cr],
+                ProgressiveTile::Upgrade(t) => [t.quant_idx_y, t.quant_idx_cb, t.quant_idx_cr],
+            };
+            if indices.iter().any(|&i| usize::from(i) >= quant_count) {
+                return Err(invalid_field_err!("quantIdx", "tile quant index out of range"));
+            }
+        }
+
         Ok(Self {
             tile_size,
             rects,
@@ -944,6 +977,21 @@ pub fn decode_progressive_stream<'a>(data: &'a [u8]) -> DecodeResult<Vec<Progres
             .ok_or_else(|| invalid_field_err!("blockLen", "block length too small"))?;
         let body_len: usize = cast_length!("bodyLen", body_len)?;
         ensure_size!(ctx: "ProgressiveStream", in: src, size: body_len);
+
+        // Fixed-size blocks have normative blockLen values (MS-RDPEGFX 2.2.4.2.1)
+        let expected_body: Option<usize> = match header.block_type {
+            ProgressiveBlockType::Sync => Some(ProgressiveSyncPdu::FIXED_PART_SIZE),
+            ProgressiveBlockType::FrameBegin => Some(ProgressiveFrameBeginPdu::FIXED_PART_SIZE),
+            ProgressiveBlockType::FrameEnd => Some(ProgressiveFrameEndPdu::FIXED_PART_SIZE),
+            ProgressiveBlockType::Context => Some(ProgressiveContextPdu::FIXED_PART_SIZE),
+            _ => None,
+        };
+        if let Some(expected) = expected_body {
+            if body_len != expected {
+                return Err(invalid_field_err!("blockLen", "unexpected size for fixed-size block"));
+            }
+        }
+
         let body_src = &mut ReadCursor::new(src.read_slice(body_len));
 
         let block = match header.block_type {
@@ -967,10 +1015,6 @@ pub fn decode_progressive_stream<'a>(data: &'a [u8]) -> DecodeResult<Vec<Progres
 
 /// Encode a progressive bitmap stream into bytes.
 ///
-/// # Panics
-///
-/// Cannot panic in practice. Internal `expect()` calls guard `u32::try_from`
-/// on block sizes that are bounded by available memory.
 pub fn encode_progressive_stream(blocks: &[ProgressiveBlock<'_>]) -> EncodeResult<Vec<u8>> {
     let total_size: usize = blocks
         .iter()
@@ -997,7 +1041,7 @@ pub fn encode_progressive_stream(blocks: &[ProgressiveBlock<'_>]) -> EncodeResul
             ProgressiveBlock::Context(c) => (ProgressiveBlockType::Context, c.size()),
             ProgressiveBlock::Region(r) => (ProgressiveBlockType::Region, r.size()),
         };
-        let block_len = u32::try_from(ProgressiveBlockHeader::SIZE + body_size).expect("block size fits u32");
+        let block_len: u32 = cast_length!("blockLen", ProgressiveBlockHeader::SIZE + body_size)?;
         ProgressiveBlockHeader { block_type, block_len }.encode(&mut dst)?;
 
         match block {


### PR DESCRIPTION
Part of the multi-codec EGFX implementation described in #1158 (Section 4).

## Summary

Add wire-format types for RemoteFX Progressive Codec (MS-RDPRFX Progressive Extension) and the computational primitives required for progressive refinement.

**ironrdp-pdu**: Progressive codec block types (SYNC, CONTEXT, REGION, TILE_SIMPLE, TILE_FIRST, TILE_UPGRADE, FRAME_BEGIN, FRAME_END), quantization values with band-level accessors, tile header parsing.

**ironrdp-graphics**: Reduce-extrapolate discrete wavelet transform (DWT) for 64x64 tile decomposition into 10 subbands. SRL (Subband Reconstruction Layer) entropy codec for progressive coefficient transmission with zero-run encoding and sign-magnitude packing.

## Changes

5 files, 2,326 lines. No changes to existing code.

## Test plan

- [ ] All 5 xtask gates pass
- [ ] DWT and SRL have inline unit tests