### PR TITLE
test(graphics): add progressive RFX round-trip tests and documentation

### DIFF
--- a/crates/ironrdp-graphics/src/progressive.rs
+++ b/crates/ironrdp-graphics/src/progressive.rs
@@ -2338,9 +2338,11 @@ mod tests {
     }
 
     #[test]
+    #[expect(clippy::similar_names, reason = "y/cb/cr are standard YCbCr component names")]
     fn rgba_ycbcr_reconstruct_round_trip() {
-        // Test the color conversion path: RGB -> YCbCr -> DWT -> IDWT -> RGB
-        // should produce approximately the same pixel values
+        // RGB -> YCbCr -> RGB. ITU-R BT.601 fixed-point round-trip carries a
+        // few units of integer-rounding error per channel. We assert a bounded
+        // per-channel max and verify Y/Cb/Cr stay in [-128, 127] in between.
         let mut pixels = vec![0u8; 64 * 64 * 4];
         for i in 0..64 * 64 {
             // Smooth gradient
@@ -2364,6 +2366,127 @@ mod tests {
             assert!(cb[i] >= -128 && cb[i] <= 127, "Cb[{i}] = {} out of range", cb[i]);
             assert!(cr[i] >= -128 && cr[i] <= 127, "Cr[{i}] = {} out of range", cr[i]);
         }
+
+        // Inverse YCbCr -> RGB using the same BT.601 matrix as
+        // TileState::reconstruct_to_rgba (the decode-side counterpart).
+        let mut max_err = 0i32;
+        for i in 0..64 * 64 {
+            let y_val = i32::from(y[i]) + 128;
+            let cb_val = i32::from(cb[i]);
+            let cr_val = i32::from(cr[i]);
+
+            let r_rec = (y_val + ((cr_val * 91881 + 32768) >> 16)).clamp(0, 255);
+            let g_rec = (y_val - ((cb_val * 22554 + cr_val * 46802 + 32768) >> 16)).clamp(0, 255);
+            let b_rec = (y_val + ((cb_val * 116130 + 32768) >> 16)).clamp(0, 255);
+
+            let off = i * 4;
+            let r_orig = i32::from(pixels[off]);
+            let g_orig = i32::from(pixels[off + 1]);
+            let b_orig = i32::from(pixels[off + 2]);
+
+            max_err = max_err.max((r_rec - r_orig).abs());
+            max_err = max_err.max((g_rec - g_orig).abs());
+            max_err = max_err.max((b_rec - b_orig).abs());
+        }
+        assert!(
+            max_err <= 2,
+            "RGB -> YCbCr -> RGB max per-channel error {max_err} exceeds 2"
+        );
+    }
+
+    #[test]
+    fn upgrade_pass_encode_decode_round_trip() {
+        // Two-pass refinement round-trip on the upgrade-pass wire format. Uses
+        // synthetic post-DWT post-quant coefficients to isolate the upgrade-pass
+        // mechanism from forward/inverse DWT and RLGR1 framing.
+        //
+        // The contract under test: encode_upgrade_pass(refined, prev, ...)
+        // followed by decode_upgrade_pass applied to prev must not increase the
+        // L1 distance to refined. The wire format is monotonic (encoder writes
+        // additive magnitude deltas with DAS-determined sign per MS-RDPRFX
+        // 3.1.8.1.7.2), so the post-decode distance cannot exceed pre-decode.
+        let prev_prog_quant = ComponentCodecQuant {
+            ll3: 0,
+            hl3: 0,
+            lh3: 0,
+            hh3: 0,
+            hl2: 0,
+            lh2: 0,
+            hh2: 0,
+            hl1: 4,
+            lh1: 0,
+            hh1: 0,
+        };
+        let curr_prog_quant = ComponentCodecQuant {
+            ll3: 0,
+            hl3: 0,
+            lh3: 0,
+            hh3: 0,
+            hl2: 0,
+            lh2: 0,
+            hh2: 0,
+            hl1: 2,
+            lh1: 0,
+            hh1: 0,
+        };
+
+        // Populate HL1 band (band index 0, offset 0, count 1024) with paired
+        // values: prev is coarser (low 4 bits zeroed), refined adds those bits.
+        let mut prev_coeffs = vec![0i16; COEFFICIENTS_PER_COMPONENT];
+        let mut refined_coeffs = vec![0i16; COEFFICIENTS_PER_COMPONENT];
+        let mut sign = vec![SIGN_ZERO; COEFFICIENTS_PER_COMPONENT];
+
+        for i in 0..1024 {
+            let base = ((i as i32) * 5) % 256 - 128;
+            let coarse = base & !0x0F;
+            let refined = base;
+            prev_coeffs[i] = coarse as i16;
+            refined_coeffs[i] = refined as i16;
+            sign[i] = match prev_coeffs[i].cmp(&0) {
+                core::cmp::Ordering::Greater => SIGN_POSITIVE,
+                core::cmp::Ordering::Less => SIGN_NEGATIVE,
+                core::cmp::Ordering::Equal => SIGN_ZERO,
+            };
+        }
+
+        let prev_dist: u32 = prev_coeffs
+            .iter()
+            .zip(refined_coeffs.iter())
+            .map(|(p, r)| (i32::from(*p) - i32::from(*r)).unsigned_abs())
+            .sum();
+
+        let (srl_data, raw_data) = encode_upgrade_pass(
+            &refined_coeffs,
+            &prev_coeffs,
+            &prev_prog_quant,
+            &curr_prog_quant,
+            &sign,
+            false,
+        );
+
+        let mut decoded = prev_coeffs.clone();
+        let mut decoded_sign = sign.clone();
+        decode_upgrade_pass(
+            &srl_data,
+            &raw_data,
+            &prev_prog_quant,
+            &curr_prog_quant,
+            false,
+            &mut decoded,
+            &mut decoded_sign,
+        );
+
+        let post_dist: u32 = decoded
+            .iter()
+            .zip(refined_coeffs.iter())
+            .map(|(d, r)| (i32::from(*d) - i32::from(*r)).unsigned_abs())
+            .sum();
+
+        // Upgrade pass must not move further from the refined target.
+        assert!(
+            post_dist <= prev_dist,
+            "upgrade pass must not increase distance to refined: prev_dist={prev_dist} post_dist={post_dist}"
+        );
     }
 
     #[test]

--- a/crates/ironrdp-graphics/src/progressive.rs
+++ b/crates/ironrdp-graphics/src/progressive.rs
@@ -1,11 +1,36 @@
-//! Progressive RFX decode and encode algorithms ([MS-RDPEGFX] 2.2.4.2).
+//! RemoteFX Progressive codec implementation ([MS-RDPEGFX] 2.2.4.2).
 //!
-//! Provides first-pass decode (RLGR1 + progressive dequantization + sign capture)
-//! and upgrade-pass decode (SRL/raw routing by DAS sign state, coefficient
-//! accumulation) for the RemoteFX Progressive codec.
+//! This module implements the full progressive RemoteFX codec for both
+//! client-side decode and server-side encode. The progressive codec delivers
+//! screen updates in multiple passes: a coarse first pass followed by
+//! refinement upgrade passes that progressively improve quality.
 //!
-//! These are pure algorithmic functions operating on coefficient buffers.
-//! Tile state management and EGFX integration belong in a higher layer.
+//! # Architecture
+//!
+//! ## Decode pipeline (client)
+//! - [`decode_first_pass`]: RLGR1 → LL3 delta decode → base dequantization →
+//!   progressive dequantization → DAS sign capture
+//! - [`decode_upgrade_pass`]: SRL/raw routing by DAS sign state → coefficient
+//!   accumulation
+//!
+//! ## Encode pipeline (server)
+//! - [`encode_first_pass`]: forward DWT → base quantization → progressive
+//!   quantization → LL3 delta encode → RLGR1
+//! - [`encode_upgrade_pass`]: per-band SRL + raw bit encoding for refinement
+//! - [`rgba_to_ycbcr`]: ITU-R BT.601 color space conversion
+//!
+//! ## State management
+//! - [`TileState`]: per-tile coefficient and DAS sign storage (~37 KB per tile)
+//! - [`SurfaceTiles`]: lazily-allocated tile grid for a surface
+//! - [`ProgressiveDecoder`]: high-level decoder maintaining per-context state,
+//!   wired into the EGFX `WireToSurface2Pdu` path
+//!
+//! # Progressive quantization
+//!
+//! Progressive regions use [`ComponentCodecQuant`] (different nibble ordering
+//! from classic RFX `Quant`). Each quality level specifies a BitPos per band
+//! that controls how many bits are transmitted. Higher BitPos means fewer bits
+//! (coarser quality). Upgrade passes decrease BitPos, revealing more bits.
 
 extern crate alloc;
 
@@ -2170,5 +2195,220 @@ mod tests {
 
         assert!(srl_data.is_empty(), "no refinement bits, SRL should be empty");
         assert!(raw_data.is_empty(), "no refinement bits, raw should be empty");
+    }
+
+    // --- B12: Integration / round-trip tests ---
+
+    #[test]
+    fn first_pass_encode_decode_round_trip_lossless() {
+        // With LOSSLESS quants (all 1s), quantization is a no-op (shift by 0).
+        // The only error source is DWT integer truncation (LeGall 5/3).
+        //
+        // decode_first_pass returns frequency-domain coefficients (post-dequant),
+        // so we apply inverse DWT to get back to spatial domain for comparison.
+        let original = [42i16; COEFFICIENTS_PER_COMPONENT];
+        let mut encode_buf = original;
+        let mut output = vec![0u8; 16384];
+
+        let base_quant = ComponentCodecQuant::LOSSLESS;
+        let prog_quant = ComponentCodecQuant::LOSSLESS;
+
+        let bytes = encode_first_pass(&mut encode_buf, &mut output, &base_quant, &prog_quant, false).unwrap();
+
+        let mut decoded = [0i16; COEFFICIENTS_PER_COMPONENT];
+        let mut sign = [0i8; COEFFICIENTS_PER_COMPONENT];
+        decode_first_pass(
+            &output[..bytes],
+            &base_quant,
+            &prog_quant,
+            false,
+            &mut decoded,
+            &mut sign,
+        )
+        .unwrap();
+
+        // Inverse DWT to get back to spatial domain
+        let mut temp = [0i16; COEFFICIENTS_PER_COMPONENT];
+        crate::dwt::decode(&mut decoded, &mut temp);
+
+        let max_err = original
+            .iter()
+            .zip(decoded.iter())
+            .map(|(a, b)| (i32::from(*a) - i32::from(*b)).unsigned_abs())
+            .max()
+            .unwrap();
+
+        assert!(max_err <= 4, "flat data round-trip max error {max_err} exceeds 4");
+    }
+
+    #[test]
+    fn first_pass_encode_decode_round_trip_reduce_extrapolate() {
+        let original = [42i16; COEFFICIENTS_PER_COMPONENT];
+        let mut encode_buf = original;
+        let mut output = vec![0u8; 16384];
+
+        let base_quant = ComponentCodecQuant::LOSSLESS;
+        let prog_quant = ComponentCodecQuant::LOSSLESS;
+
+        let bytes = encode_first_pass(&mut encode_buf, &mut output, &base_quant, &prog_quant, true).unwrap();
+
+        let mut decoded = [0i16; COEFFICIENTS_PER_COMPONENT];
+        let mut sign = [0i8; COEFFICIENTS_PER_COMPONENT];
+        decode_first_pass(
+            &output[..bytes],
+            &base_quant,
+            &prog_quant,
+            true,
+            &mut decoded,
+            &mut sign,
+        )
+        .unwrap();
+
+        // Inverse DWT (reduce-extrapolate variant)
+        let mut temp = [0i16; COEFFICIENTS_PER_COMPONENT];
+        crate::dwt_extrapolate::decode(&mut decoded, &mut temp);
+
+        let max_err = original
+            .iter()
+            .zip(decoded.iter())
+            .map(|(a, b)| (i32::from(*a) - i32::from(*b)).unsigned_abs())
+            .max()
+            .unwrap();
+
+        assert!(
+            max_err <= 6,
+            "reduce-extrapolate round-trip max error {max_err} exceeds 6"
+        );
+    }
+
+    #[test]
+    fn first_pass_encode_decode_with_quantization() {
+        // Test encode/decode with realistic quantization (non-lossless).
+        // Quantization introduces controlled error, so we just verify
+        // the pipeline completes and the decoded output is in a sensible range.
+        let mut coefficients = [42i16; COEFFICIENTS_PER_COMPONENT];
+        let mut output = vec![0u8; 16384];
+
+        let base_quant = ComponentCodecQuant {
+            ll3: 6,
+            hl3: 6,
+            lh3: 6,
+            hh3: 6,
+            hl2: 7,
+            lh2: 7,
+            hh2: 7,
+            hl1: 8,
+            lh1: 8,
+            hh1: 8,
+        };
+        let prog_quant = ComponentCodecQuant::LOSSLESS;
+
+        let bytes = encode_first_pass(&mut coefficients, &mut output, &base_quant, &prog_quant, false).unwrap();
+        assert!(bytes > 0, "should produce encoded output");
+
+        // Quantized data should compress better than lossless
+        let mut decoded = [0i16; COEFFICIENTS_PER_COMPONENT];
+        let mut sign = [0i8; COEFFICIENTS_PER_COMPONENT];
+        decode_first_pass(
+            &output[..bytes],
+            &base_quant,
+            &prog_quant,
+            false,
+            &mut decoded,
+            &mut sign,
+        )
+        .unwrap();
+
+        // Inverse DWT
+        let mut temp = [0i16; COEFFICIENTS_PER_COMPONENT];
+        crate::dwt::decode(&mut decoded, &mut temp);
+
+        // With quantization, values should be approximately the original (42)
+        // but with significant quantization noise. Just check within +-200.
+        let mean_err: f64 = decoded
+            .iter()
+            .map(|v| f64::from((i32::from(*v) - 42).unsigned_abs()))
+            .sum::<f64>()
+            / 4096.0;
+
+        assert!(
+            mean_err < 200.0,
+            "mean error {mean_err} too large for quantized flat tile"
+        );
+    }
+
+    #[test]
+    fn rgba_ycbcr_reconstruct_round_trip() {
+        // Test the color conversion path: RGB -> YCbCr -> DWT -> IDWT -> RGB
+        // should produce approximately the same pixel values
+        let mut pixels = vec![0u8; 64 * 64 * 4];
+        for i in 0..64 * 64 {
+            // Smooth gradient
+            let row = i / 64;
+            let col = i % 64;
+            pixels[i * 4] = (row * 4) as u8; // R
+            pixels[i * 4 + 1] = (col * 4) as u8; // G
+            pixels[i * 4 + 2] = 128; // B
+            pixels[i * 4 + 3] = 255; // A
+        }
+
+        let mut y = vec![0i16; 4096];
+        let mut cb = vec![0i16; 4096];
+        let mut cr = vec![0i16; 4096];
+
+        rgba_to_ycbcr(&pixels, &mut y, &mut cb, &mut cr);
+
+        // Verify Y is in expected range [-128..127] and Cb/Cr in [-128..127]
+        for i in 0..4096 {
+            assert!(y[i] >= -128 && y[i] <= 127, "Y[{i}] = {} out of range", y[i]);
+            assert!(cb[i] >= -128 && cb[i] <= 127, "Cb[{i}] = {} out of range", cb[i]);
+            assert!(cr[i] >= -128 && cr[i] <= 127, "Cr[{i}] = {} out of range", cr[i]);
+        }
+    }
+
+    #[test]
+    fn quantize_dequantize_ccq_round_trip() {
+        let quant = ComponentCodecQuant {
+            ll3: 4,
+            hl3: 4,
+            lh3: 4,
+            hh3: 5,
+            hl2: 5,
+            lh2: 5,
+            hh2: 6,
+            hl1: 6,
+            lh1: 6,
+            hh1: 7,
+        };
+
+        // Start with some known coefficient values
+        let original = {
+            let mut c = [0i16; COEFFICIENTS_PER_COMPONENT];
+            for (i, v) in c.iter_mut().enumerate() {
+                *v = ((i * 7 % 256) as i16) - 128;
+            }
+            c
+        };
+
+        let mut coefficients = original;
+
+        // Quantize then dequantize
+        quantize_component_ccq(&mut coefficients, &quant, false);
+        dequantize_component_ccq(&mut coefficients, &quant, false);
+
+        // Quantization is lossy, but the round-trip should be in the right ballpark.
+        // Error bound per coefficient: at most 2^(quant_val-1) per quantization step
+        // With quant values 4-7, max error per step is 2^6 = 64
+        let max_err = original
+            .iter()
+            .zip(coefficients.iter())
+            .map(|(a, b)| (i32::from(*a) - i32::from(*b)).unsigned_abs())
+            .max()
+            .unwrap();
+
+        assert!(
+            max_err <= 64,
+            "quantize/dequantize round-trip max error {max_err} exceeds 64"
+        );
     }
 }


### PR DESCRIPTION
Final PR in the multi-codec EGFX implementation described in #1158 (Section 4). Its two prerequisites have since merged, so this now applies directly to master.

## Summary

Add encode/decode round-trip tests verifying bounded-tolerance reconstruction through the Progressive RFX pipeline. Coverage:

- **First-pass round-trip** (`first_pass_encode_decode_round_trip_lossless` + `_reduce_extrapolate`): forward DWT → progressive quantization → RLGR1 entropy code → RLGR1 decode → progressive dequant → inverse DWT. With LOSSLESS quants the only residual error is LeGall 5/3 DWT integer truncation; assertions `max_err ≤ 4` (standard) / `≤ 6` (reduce-extrapolate).
- **First-pass with quantization** (`first_pass_encode_decode_with_quantization`): the same pipeline at realistic non-lossless quants; assertion `mean_err < 200` for the flat-tile input.
- **Upgrade-pass round-trip** (`upgrade_pass_encode_decode_round_trip`): `encode_upgrade_pass` + `decode_upgrade_pass` on the SRL + raw-bit wire format, with synthetic post-DWT post-quant coefficients. Asserts the monotonic-refinement contract (MS-RDPRFX 3.1.8.1.7.2): post-decode L1 distance to the refined target cannot exceed pre-decode distance.
- **Color conversion round-trip** (`rgba_ycbcr_reconstruct_round_trip`): RGB → YCbCr (forward BT.601) → RGB (inverse BT.601 matching `TileState::reconstruct_to_rgba`) on a gradient input; assertion `max_err ≤ 2` per channel.
- **Quantization round-trip** (`quantize_dequantize_ccq_round_trip`): `quantize_component_ccq` + `dequantize_component_ccq` on varied input.

Module-level documentation expanded with the decode/encode pipeline layout, state-management types, and progressive-quantization notes.

A libFuzzer-driven round-trip oracle and full EGFX-PDU integration round-trip remain follow-ups; the unit-level coverage above is the algorithmic foundation those build on.

## Stack ordering

No longer stacked. This was step 3 of 3 behind #1197 (merged 2026-05-21) and #1198 (merged 2026-05-25); with both upstream it has been rebased onto master and carries only its own two commits.

## Test plan

`cargo xtask check fmt/lints/tests/typos/locks` all pass. 43 tests in the `progressive` module on the head, of which 6 are this PR's round-trip additions; the rest cover lower-level algorithm pieces from #1197 and #1198.

Rebased onto current master, which absorbed 66 commits of drift with no conflict and replayed both commits byte-identically. That includes #1499 (progressive base quantization scale), which touches the same file this PR is confined to: the round-trip assertions still hold against the corrected scale.

