### PR TITLE
feat(client): add --prevent-session-lock CLI option

### DIFF
--- a/crates/ironrdp-client/src/app.rs
+++ b/crates/ironrdp-client/src/app.rs
@@ -6,7 +6,10 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::Context as _;
+use ironrdp::pdu::input::fast_path::FastPathInputEvent;
+use ironrdp::pdu::input::{MousePdu, mouse::PointerFlags};
 use raw_window_handle::{DisplayHandle, HasDisplayHandle as _};
+use smallvec::SmallVec;
 use tokio::sync::mpsc;
 use tracing::{debug, error, trace, warn};
 use winit::application::ApplicationHandler;
@@ -30,12 +33,15 @@ pub struct App {
     input_database: ironrdp::input::Database,
     last_size: Option<PhysicalSize<u32>>,
     resize_timeout: Option<Instant>,
+    last_event: Option<Instant>,
+    fake_events_interval: Option<Duration>,
 }
 
 impl App {
     pub fn new(
         event_loop: &EventLoop<RdpOutputEvent>,
         input_event_sender: &mpsc::UnboundedSender<RdpInputEvent>,
+        fake_events_interval: Option<Duration>,
         initial_window_size: PhysicalSize<u32>,
     ) -> anyhow::Result<Self> {
         // SAFETY: We drop the softbuffer context right before the event loop is stopped, thus making this safe.
@@ -59,6 +65,8 @@ impl App {
             input_database,
             last_size: None,
             resize_timeout: None,
+            last_event: None,
+            fake_events_interval,
         })
     }
 
@@ -98,10 +106,30 @@ impl App {
         sb_buffer.copy_from_slice(self.buffer.as_slice());
         sb_buffer.present().expect("buffer present");
     }
+
+    pub fn fake_mouse_move(&mut self) {
+        let (Some(last_event), Some(fake_events_interval)) = (self.last_event, self.fake_events_interval) else {
+            return;
+        };
+
+        if last_event.elapsed() > fake_events_interval {
+            let mut events = SmallVec::new();
+            let curr_pos = self.input_database.mouse_position();
+            events.push(FastPathInputEvent::MouseEvent(MousePdu {
+                flags: PointerFlags::MOVE,
+                number_of_wheel_rotation_units: 0,
+                x_position: curr_pos.x,
+                y_position: curr_pos.y,
+            }));
+            let _ = self.input_event_sender.send(RdpInputEvent::FastPath(events));
+        }
+    }
 }
 
 impl ApplicationHandler<RdpOutputEvent> for App {
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        self.fake_mouse_move();
+
         if let Some(timeout) = self.resize_timeout {
             if let Some(timeout) = timeout.checked_duration_since(Instant::now()) {
                 event_loop.set_control_flow(ControlFlow::wait_duration(timeout));
@@ -188,7 +216,7 @@ impl ApplicationHandler<RdpOutputEvent> for App {
 
                     let input_events = self.input_database.apply(core::iter::once(operation));
 
-                    send_fast_path_events(&self.input_event_sender, input_events);
+                    send_fast_path_events(&self.input_event_sender, input_events, &mut self.last_event);
                 }
             }
             WindowEvent::ModifiersChanged(modifiers) => {
@@ -197,7 +225,7 @@ impl ApplicationHandler<RdpOutputEvent> for App {
                 const ALT_LEFT: ironrdp::input::Scancode = ironrdp::input::Scancode::from_u8(false, 0x38);
                 const LOGO_LEFT: ironrdp::input::Scancode = ironrdp::input::Scancode::from_u8(true, 0x5B);
 
-                let mut operations = smallvec::SmallVec::<[ironrdp::input::Operation; 4]>::new();
+                let mut operations = SmallVec::<[ironrdp::input::Operation; 4]>::new();
 
                 let mut add_operation = |pressed: bool, scancode: ironrdp::input::Scancode| {
                     let operation = if pressed {
@@ -224,7 +252,7 @@ impl ApplicationHandler<RdpOutputEvent> for App {
 
                 let input_events = self.input_database.apply(operations);
 
-                send_fast_path_events(&self.input_event_sender, input_events);
+                send_fast_path_events(&self.input_event_sender, input_events, &mut self.last_event);
             }
             WindowEvent::CursorMoved { position, .. } => {
                 let win_size = window.inner_size();
@@ -236,10 +264,10 @@ impl ApplicationHandler<RdpOutputEvent> for App {
 
                 let input_events = self.input_database.apply(core::iter::once(operation));
 
-                send_fast_path_events(&self.input_event_sender, input_events);
+                send_fast_path_events(&self.input_event_sender, input_events, &mut self.last_event);
             }
             WindowEvent::MouseWheel { delta, .. } => {
-                let mut operations = smallvec::SmallVec::<[ironrdp::input::Operation; 2]>::new();
+                let mut operations = SmallVec::<[ironrdp::input::Operation; 2]>::new();
 
                 match delta {
                     event::MouseScrollDelta::LineDelta(delta_x, delta_y) => {
@@ -288,7 +316,7 @@ impl ApplicationHandler<RdpOutputEvent> for App {
 
                 let input_events = self.input_database.apply(operations);
 
-                send_fast_path_events(&self.input_event_sender, input_events);
+                send_fast_path_events(&self.input_event_sender, input_events, &mut self.last_event);
             }
             WindowEvent::MouseInput { state, button, .. } => {
                 let mouse_button = match button {
@@ -313,7 +341,7 @@ impl ApplicationHandler<RdpOutputEvent> for App {
 
                 let input_events = self.input_database.apply(core::iter::once(operation));
 
-                send_fast_path_events(&self.input_event_sender, input_events);
+                send_fast_path_events(&self.input_event_sender, input_events, &mut self.last_event);
             }
             WindowEvent::RedrawRequested => {
                 self.draw();
@@ -411,9 +439,11 @@ impl ApplicationHandler<RdpOutputEvent> for App {
 
 fn send_fast_path_events(
     input_event_sender: &mpsc::UnboundedSender<RdpInputEvent>,
-    input_events: smallvec::SmallVec<[ironrdp::pdu::input::fast_path::FastPathInputEvent; 2]>,
+    input_events: SmallVec<[FastPathInputEvent; 2]>,
+    last_event: &mut Option<Instant>,
 ) {
     if !input_events.is_empty() {
         let _ = input_event_sender.send(RdpInputEvent::FastPath(input_events));
     }
+    *last_event = Some(Instant::now());
 }

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -3,6 +3,7 @@
 use core::fmt;
 use core::num::ParseIntError;
 use core::str::FromStr;
+use core::time::Duration;
 use std::path::PathBuf;
 
 use anyhow::Context as _;
@@ -27,6 +28,7 @@ pub struct Config {
     pub connector: connector::Config,
     pub clipboard_type: ClipboardType,
     pub rdcleanpath: Option<RDCleanPathConfig>,
+    pub fake_events_interval: Option<Duration>,
 
     /// DVC channel <-> named pipe proxy configuration.
     ///
@@ -396,6 +398,11 @@ struct Args {
     #[clap(long, value_parser = clap::value_parser!(u32).range(0..=3), default_value_t = 3)]
     compression_level: u32,
 
+    /// Prevents session locking by injecting fake mouse movement events when
+    /// the connection is idle (interval in minutes)
+    #[clap(long)]
+    prevent_session_lock: Option<u32>,
+
     /// Add DVC channel named pipe proxy
     ///
     /// The format is `<name>=<pipe>`, e.g., `ChannelName=PipeName` where `ChannelName` is the name of the channel,
@@ -448,6 +455,7 @@ pub struct PartialConfig {
     pub clipboard_type: ClipboardType,
     pub codecs: Vec<String>,
     pub compression_level: u32,
+    pub prevent_session_lock: Option<u32>,
     pub dvc_pipe_proxies: Vec<DvcProxyInfo>,
     #[cfg(windows)]
     pub dvc_plugins: Vec<PathBuf>,
@@ -506,6 +514,7 @@ impl PartialConfig {
             clipboard_type: args.clipboard_type,
             codecs: args.codecs,
             compression_level: args.compression_level,
+            prevent_session_lock: args.prevent_session_lock,
             dvc_pipe_proxies: args.dvc_proxy,
             #[cfg(windows)]
             dvc_plugins: args.dvc_plugin,
@@ -629,6 +638,11 @@ impl PartialConfig {
             }
             bitmap.color_depth = color_depth;
         };
+
+        // make a duration from cmdline argument (minutes)
+        let fake_events_interval = self
+            .prevent_session_lock
+            .map(|v| Duration::from_secs(u64::from(v) * 60));
 
         let enable_credssp = properties.enable_credssp_support().unwrap_or(true);
 
@@ -764,6 +778,7 @@ impl PartialConfig {
             connector,
             clipboard_type,
             rdcleanpath: self.rdcleanpath,
+            fake_events_interval,
             dvc_pipe_proxies: self.dvc_pipe_proxies,
             #[cfg(windows)]
             dvc_plugins: self.dvc_plugins,

--- a/crates/ironrdp-client/src/main.rs
+++ b/crates/ironrdp-client/src/main.rs
@@ -30,8 +30,13 @@ fn main() -> anyhow::Result<()> {
         u32::from(config.connector.desktop_size.width),
         u32::from(config.connector.desktop_size.height),
     );
-    let mut app =
-        App::new(&event_loop, &input_event_sender, initial_window_size).context("unable to initialize App")?;
+    let mut app = App::new(
+        &event_loop,
+        &input_event_sender,
+        config.fake_events_interval,
+        initial_window_size,
+    )
+    .context("unable to initialize App")?;
 
     let rt = runtime::Builder::new_multi_thread()
         .enable_all()


### PR DESCRIPTION
Adds a new CLI flag to prevent remote session locking by injecting fake mouse movement events when the connection is idle, similarly to FreeRDP's equivalent option.

--
Hi,
another important piece of the puzzle when moving away from FreeRDP: the --prevent-session-lock option I was missing.
FreeRDP PR:
https://github.com/FreeRDP/FreeRDP/pull/9482