### PR TITLE
refactor(server): replace wildcard re-exports with explicit item list

### DIFF
--- a/crates/ironrdp-server/src/lib.rs
+++ b/crates/ironrdp-server/src/lib.rs
@@ -23,8 +23,8 @@ mod sound;
 
 pub use clipboard::CliprdrServerFactory;
 pub use display::{
-    BitmapUpdate, ColorPointer, DesktopSize, DisplayUpdate, Framebuffer, PixelFormat, RGBAPointer,
-    RdpServerDisplay, RdpServerDisplayUpdates,
+    BitmapUpdate, ColorPointer, DesktopSize, DisplayUpdate, Framebuffer, PixelFormat, RGBAPointer, RdpServerDisplay,
+    RdpServerDisplayUpdates,
 };
 pub use echo::{EchoDvcBridge, EchoRoundTripMeasurement, EchoServerHandle, EchoServerMessage};
 #[cfg(feature = "egfx")]
@@ -33,8 +33,8 @@ pub use handler::{KeyboardEvent, MouseEvent, RdpServerInputHandler};
 #[cfg(feature = "helper")]
 pub use helper::TlsIdentityCtx;
 pub use server::{
-    ConnectionHandler, Credentials, PostConnectionAction, RdpServer, RdpServerOptions, RdpServerSecurity,
-    ServerEvent, ServerEventSender,
+    ConnectionHandler, Credentials, PostConnectionAction, RdpServer, RdpServerOptions, RdpServerSecurity, ServerEvent,
+    ServerEventSender,
 };
 pub use sound::{RdpsndServerHandler, RdpsndServerMessage, SoundServerFactory};
 

--- a/crates/ironrdp-server/src/lib.rs
+++ b/crates/ironrdp-server/src/lib.rs
@@ -21,17 +21,22 @@ mod helper;
 mod server;
 mod sound;
 
-// FIXME: too much wildcards here.
-pub use clipboard::*;
-pub use display::*;
-pub use echo::*;
+pub use clipboard::CliprdrServerFactory;
+pub use display::{
+    BitmapUpdate, ColorPointer, DesktopSize, DisplayUpdate, Framebuffer, PixelFormat, RGBAPointer,
+    RdpServerDisplay, RdpServerDisplayUpdates,
+};
+pub use echo::{EchoDvcBridge, EchoRoundTripMeasurement, EchoServerHandle, EchoServerMessage};
 #[cfg(feature = "egfx")]
-pub use gfx::*;
-pub use handler::*;
+pub use gfx::{EgfxServerMessage, GfxDvcBridge, GfxServerFactory, GfxServerHandle};
+pub use handler::{KeyboardEvent, MouseEvent, RdpServerInputHandler};
 #[cfg(feature = "helper")]
-pub use helper::*;
-pub use server::*;
-pub use sound::*;
+pub use helper::TlsIdentityCtx;
+pub use server::{
+    ConnectionHandler, Credentials, PostConnectionAction, RdpServer, RdpServerOptions, RdpServerSecurity,
+    ServerEvent, ServerEventSender,
+};
+pub use sound::{RdpsndServerHandler, RdpsndServerMessage, SoundServerFactory};
 
 #[cfg(feature = "__bench")]
 pub mod bench {


### PR DESCRIPTION
Replace all `pub use module::*` in ironrdp-server with explicit item lists, addressing the existing `FIXME: too much wildcards here` comment.

This makes the public API surface auditable and prevents accidental exposure of internal types when new items are added to modules.

No functional change. All previously exported items remain exported at the same paths.