### PR TITLE
docs(dvc-com-plugin): add missing README.md to unblock crates.io publish

### DIFF
--- a/crates/ironrdp-dvc-com-plugin/README.md
+++ b/crates/ironrdp-dvc-com-plugin/README.md
@@ -1,0 +1,25 @@
+# IronRDP DVC COM Plugin
+
+Loader for native Windows [DVC (Dynamic Virtual Channel)][dvc-overview] client plugin DLLs
+(e.g. `webauthn.dll`) that bridges them into IronRDP's DVC infrastructure.
+
+The plugin DLL is loaded via `LoadLibraryW`, its `VirtualChannelGetInstance` export is called
+to obtain `IWTSPlugin` COM objects, and a Rust implementation of `IWTSVirtualChannelManager`
+bridges data bidirectionally between the plugin's COM callbacks and IronRDP's DVC system.
+
+This crate is **Windows-only** (`#![cfg(windows)]`).
+
+## Architecture
+
+A dedicated COM worker thread owns all COM objects (which are `!Send`). The `DvcComChannel`
+structs (which implement `DvcProcessor + Send`) are registered as DVC channels in IronRDP's
+`DrdynvcClient` and communicate with the COM thread via `std::sync::mpsc` channels.
+
+Outbound data from the plugin (`IWTSVirtualChannel::Write`) is injected into the active
+session loop via the `on_write_dvc` callback, following the same pattern as
+`ironrdp-dvc-pipe-proxy`.
+
+This crate is part of the [IronRDP] project.
+
+[IronRDP]: https://github.com/Devolutions/IronRDP
+[dvc-overview]: https://learn.microsoft.com/en-us/windows/win32/termserv/writing-a-client-dvc-component


### PR DESCRIPTION
## Summary

- Adds a `README.md` to `ironrdp-dvc-com-plugin`, which declares `readme = "README.md"` in its `Cargo.toml` but was missing the file.

## Problem

The `Release crates` workflow fails when `release-plz` attempts to `cargo publish` the `ironrdp-dvc-com-plugin` crate:

```
error: readme `README.md` does not appear to exist
  (relative to crates/ironrdp-dvc-com-plugin)
```

This blocks publishing of any crate that follows `ironrdp-dvc-com-plugin` in the dependency graph.

## Fix

Added a README consistent with other crates in the workspace, describing the crate's purpose, architecture, and linking to relevant Microsoft documentation.

## Note on the release-plz PR CI failure

The CI failure on PR #1212 (`release-plz/2026-04-09T06-06-06Z`) is a separate issue: the lock file check fails because the release-plz branch's lock files have drifted from master after subsequent commits (e.g. #1203). This will (hopefully) self-resolve when release-plz regenerates its PR on the next cycle after this fix merges.