### PR TITLE
feat(web): add pluggable storage backends for RDP file downloads

### DIFF
--- a/web-client/iron-remote-desktop-rdp/src/RdpFileTransferProvider.test.ts
+++ b/web-client/iron-remote-desktop-rdp/src/RdpFileTransferProvider.test.ts
@@ -1095,3 +1095,657 @@ describe('RdpFileTransferProvider', () => {
         });
     });
 });
+
+// ---------------------------------------------------------------------------
+// Constructor validation for storageBackend option
+// ---------------------------------------------------------------------------
+
+describe('RdpFileTransferProvider storageBackend validation', () => {
+    it('rejects an object missing createWriteHandle', () => {
+        expect(
+            () =>
+                new RdpFileTransferProvider({
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    storageBackend: { dispose: async () => {} } as any,
+                }),
+        ).toThrow(/createWriteHandle\(\) and dispose\(\)/);
+    });
+
+    it('rejects an object missing dispose', () => {
+        expect(
+            () =>
+                new RdpFileTransferProvider({
+                    storageBackend: {
+                        createWriteHandle: async () => ({}),
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    } as any,
+                }),
+        ).toThrow(/createWriteHandle\(\) and dispose\(\)/);
+    });
+
+    it('rejects an invalid preference string', () => {
+        expect(
+            () =>
+                new RdpFileTransferProvider({
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    storageBackend: 'opfs' as any,
+                }),
+        ).toThrow(/invalid preference 'opfs'/);
+    });
+
+    it('accepts a valid FileStorageBackend object', () => {
+        expect(
+            () =>
+                new RdpFileTransferProvider({
+                    storageBackend: {
+                        name: 'test',
+                        createWriteHandle: async () => ({}) as never,
+                        dispose: async () => {},
+                    },
+                }),
+        ).not.toThrow();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Download flow with injected storage backend
+// ---------------------------------------------------------------------------
+
+import type { FileStorageBackend, FileWriteHandle } from './storage';
+
+/**
+ * Helper to build an 8-byte little-endian SIZE response for a given file size.
+ */
+function makeSizeResponse(streamId: number, size: number): { streamId: number; isError: boolean; data: Uint8Array } {
+    const buf = new ArrayBuffer(8);
+    new DataView(buf).setBigUint64(0, BigInt(size), true);
+    return { streamId, isError: false, data: new Uint8Array(buf) };
+}
+
+function makeDataResponse(streamId: number, bytes: number[]): { streamId: number; isError: boolean; data: Uint8Array } {
+    return { streamId, isError: false, data: new Uint8Array(bytes) };
+}
+
+function makeErrorResponse(streamId: number): { streamId: number; isError: boolean; data: Uint8Array } {
+    return { streamId, isError: true, data: new Uint8Array(0) };
+}
+
+/**
+ * Create a mock FileStorageBackend that records all operations.
+ */
+function createMockStorageBackend(options?: {
+    createWriteHandleError?: Error;
+    writeError?: Error;
+    finalizeError?: Error;
+}) {
+    const writes: Uint8Array[] = [];
+    let finalized = false;
+    let aborted = false;
+    let bytesWritten = 0;
+
+    const writeHandle: FileWriteHandle = {
+        get bytesWritten() {
+            return bytesWritten;
+        },
+        async write(chunk: Uint8Array) {
+            if (options?.writeError) throw options.writeError;
+            writes.push(new Uint8Array(chunk));
+            bytesWritten += chunk.length;
+        },
+        async finalize() {
+            if (options?.finalizeError) throw options.finalizeError;
+            finalized = true;
+            return new Blob(writes);
+        },
+        async abort() {
+            aborted = true;
+        },
+    };
+
+    const backend: FileStorageBackend = {
+        name: 'mock',
+        async createWriteHandle(_fileName: string, _expectedSize: number) {
+            if (options?.createWriteHandleError) throw options.createWriteHandleError;
+            return writeHandle;
+        },
+        async dispose() {},
+    };
+
+    return {
+        backend,
+        writeHandle,
+        get writes() {
+            return writes;
+        },
+        get finalized() {
+            return finalized;
+        },
+        get aborted() {
+            return aborted;
+        },
+    };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type CallbackMap = Record<string, (...args: any[]) => void>;
+
+/**
+ * Set up a provider with an injected storage backend and extract the
+ * protocol callbacks from getBuilderExtensions().
+ */
+function setupDownloadTest(backendOrOptions?: FileStorageBackend | Parameters<typeof createMockStorageBackend>[0]) {
+    let mockStorage: ReturnType<typeof createMockStorageBackend>;
+    let backend: FileStorageBackend;
+
+    if (backendOrOptions !== undefined && 'name' in backendOrOptions) {
+        backend = backendOrOptions;
+        mockStorage = undefined as unknown as ReturnType<typeof createMockStorageBackend>;
+    } else {
+        mockStorage = createMockStorageBackend(backendOrOptions);
+        backend = mockStorage.backend;
+    }
+
+    const provider = new RdpFileTransferProvider({
+        chunkSize: 4, // small chunks for testing
+        storageBackend: backend,
+    });
+
+    const session = new MockSession();
+    provider.setSession(session);
+
+    // Extract callback functions from the mocked extensions
+    const extensions = provider.getBuilderExtensions();
+    const callbacks: CallbackMap = {};
+    for (const ext of extensions) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const e = ext as any;
+        if (typeof e.value === 'function') {
+            callbacks[e.ident] = e.value;
+        }
+    }
+
+    return { provider, session, callbacks, mockStorage };
+}
+
+describe('download flow with storage backend', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('happy path: SIZE + DATA -> write -> finalize -> resolve', async () => {
+        const { provider, session, callbacks, mockStorage } = setupDownloadTest();
+        const fileInfo: FileInfo = { name: 'test.bin', size: 6, lastModified: 0 };
+
+        // Announce files available
+        callbacks['files_available_callback']([fileInfo]);
+
+        // Start download
+        const { transferId, completion } = provider.downloadFile(fileInfo, 0);
+        expect(transferId).toBeGreaterThan(0);
+
+        // Session should have received the SIZE request
+        expect(session.invokeExtension).toHaveBeenCalledTimes(1);
+
+        // Feed SIZE response (6 bytes)
+        callbacks['file_contents_response_callback'](makeSizeResponse(transferId, 6));
+
+        // Wait a tick for the async write handle init to complete
+        await new Promise((r) => setTimeout(r, 10));
+
+        // Session should now have received a RANGE request
+        expect(session.invokeExtension.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+        // Feed DATA responses (chunkSize=4, so two chunks: 4+2)
+        callbacks['file_contents_response_callback'](makeDataResponse(transferId, [1, 2, 3, 4]));
+        await new Promise((r) => setTimeout(r, 10));
+
+        callbacks['file_contents_response_callback'](makeDataResponse(transferId, [5, 6]));
+        await new Promise((r) => setTimeout(r, 10));
+
+        // Download should complete
+        const blob = await completion;
+        expect(blob.size).toBe(6);
+        expect(mockStorage.finalized).toBe(true);
+        expect(mockStorage.writes).toHaveLength(2);
+
+        provider.dispose();
+    });
+
+    it('empty file (size=0) resolves without creating a write handle', async () => {
+        const { provider, callbacks, mockStorage } = setupDownloadTest();
+        const fileInfo: FileInfo = { name: 'empty.bin', size: 0, lastModified: 0 };
+
+        callbacks['files_available_callback']([fileInfo]);
+        const { transferId, completion } = provider.downloadFile(fileInfo, 0);
+
+        // Feed SIZE response: 0 bytes
+        callbacks['file_contents_response_callback'](makeSizeResponse(transferId, 0));
+
+        const blob = await completion;
+        expect(blob.size).toBe(0);
+        // Write handle should NOT have been created for empty files
+        expect(mockStorage.finalized).toBe(false);
+        expect(mockStorage.writes).toHaveLength(0);
+
+        provider.dispose();
+    });
+
+    it('remote error response rejects the download', async () => {
+        const { provider, callbacks } = setupDownloadTest();
+        const fileInfo: FileInfo = { name: 'fail.bin', size: 100, lastModified: 0 };
+
+        const errorHandler = vi.fn();
+        provider.on('error', errorHandler);
+
+        callbacks['files_available_callback']([fileInfo]);
+        const { transferId, completion } = provider.downloadFile(fileInfo, 0);
+
+        // Feed error response
+        callbacks['file_contents_response_callback'](makeErrorResponse(transferId));
+
+        await expect(completion).rejects.toThrow('Remote failed to provide file contents');
+        expect(errorHandler).toHaveBeenCalledTimes(1);
+        expect(errorHandler.mock.calls[0][0].direction).toBe('download');
+
+        provider.dispose();
+    });
+
+    it('storage backend init failure emits error', async () => {
+        const { provider, callbacks } = setupDownloadTest({
+            createWriteHandleError: new Error('disk full'),
+        });
+        const fileInfo: FileInfo = { name: 'fail.bin', size: 100, lastModified: 0 };
+
+        const errorHandler = vi.fn();
+        provider.on('error', errorHandler);
+
+        callbacks['files_available_callback']([fileInfo]);
+        const { transferId, completion } = provider.downloadFile(fileInfo, 0);
+
+        // Feed SIZE response to trigger write handle creation
+        callbacks['file_contents_response_callback'](makeSizeResponse(transferId, 100));
+
+        // Wait for the async init to fail
+        await expect(completion).rejects.toThrow('Failed to initialize storage for download');
+        expect(errorHandler).toHaveBeenCalledTimes(1);
+
+        provider.dispose();
+    });
+
+    it('write failure emits error and aborts', async () => {
+        const { provider, callbacks, mockStorage } = setupDownloadTest({
+            writeError: new Error('I/O error'),
+        });
+        const fileInfo: FileInfo = { name: 'fail.bin', size: 4, lastModified: 0 };
+
+        const errorHandler = vi.fn();
+        provider.on('error', errorHandler);
+
+        callbacks['files_available_callback']([fileInfo]);
+        const { transferId, completion } = provider.downloadFile(fileInfo, 0);
+
+        // Attach a rejection handler immediately to prevent unhandled rejection
+        const completionResult = completion.catch((e: unknown) => e);
+
+        // Feed SIZE response
+        callbacks['file_contents_response_callback'](makeSizeResponse(transferId, 4));
+        await new Promise((r) => setTimeout(r, 10));
+
+        // Feed DATA response -- the write will fail
+        callbacks['file_contents_response_callback'](makeDataResponse(transferId, [1, 2, 3, 4]));
+        await new Promise((r) => setTimeout(r, 10));
+
+        const error = await completionResult;
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toBe('Failed to write download chunk to storage');
+        expect(mockStorage.aborted).toBe(true);
+
+        provider.dispose();
+    });
+
+    it('QuotaExceededError produces a specific error message', async () => {
+        const quotaError = new DOMException('quota exceeded', 'QuotaExceededError');
+        const { provider, callbacks } = setupDownloadTest({
+            writeError: quotaError,
+        });
+        const fileInfo: FileInfo = { name: 'big.bin', size: 4, lastModified: 0 };
+
+        const errorHandler = vi.fn();
+        provider.on('error', errorHandler);
+
+        callbacks['files_available_callback']([fileInfo]);
+        const { transferId, completion } = provider.downloadFile(fileInfo, 0);
+
+        // Attach a rejection handler immediately to prevent unhandled rejection
+        const completionResult = completion.catch((e: unknown) => e);
+
+        callbacks['file_contents_response_callback'](makeSizeResponse(transferId, 4));
+        await new Promise((r) => setTimeout(r, 10));
+
+        callbacks['file_contents_response_callback'](makeDataResponse(transferId, [1, 2, 3, 4]));
+        await new Promise((r) => setTimeout(r, 10));
+
+        const error = await completionResult;
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toMatch(/[Ss]torage quota exceeded/);
+        expect(errorHandler).toHaveBeenCalledTimes(1);
+        expect(errorHandler.mock.calls[0][0].message).toMatch(/[Ss]torage quota exceeded/);
+
+        provider.dispose();
+    });
+
+    it('dispose during download aborts write handle', async () => {
+        const { provider, callbacks, mockStorage } = setupDownloadTest();
+        const fileInfo: FileInfo = { name: 'partial.bin', size: 100, lastModified: 0 };
+
+        callbacks['files_available_callback']([fileInfo]);
+        const { transferId, completion } = provider.downloadFile(fileInfo, 0);
+
+        // Feed SIZE response and wait for write handle init
+        callbacks['file_contents_response_callback'](makeSizeResponse(transferId, 100));
+        await new Promise((r) => setTimeout(r, 10));
+
+        // Feed one chunk
+        callbacks['file_contents_response_callback'](makeDataResponse(transferId, [1, 2, 3, 4]));
+        await new Promise((r) => setTimeout(r, 10));
+
+        // Dispose mid-download
+        provider.dispose();
+
+        await expect(completion).rejects.toThrow('disposed');
+        expect(mockStorage.aborted).toBe(true);
+    });
+
+    it('emits download-progress during transfer', async () => {
+        const { provider, callbacks } = setupDownloadTest();
+        const fileInfo: FileInfo = { name: 'progress.bin', size: 8, lastModified: 0 };
+        const progressEvents: Array<{ bytesTransferred: number; percentage: number }> = [];
+
+        provider.on('download-progress', (p) => progressEvents.push(p));
+
+        callbacks['files_available_callback']([fileInfo]);
+        const { transferId, completion } = provider.downloadFile(fileInfo, 0);
+
+        callbacks['file_contents_response_callback'](makeSizeResponse(transferId, 8));
+        await new Promise((r) => setTimeout(r, 10));
+
+        callbacks['file_contents_response_callback'](makeDataResponse(transferId, [1, 2, 3, 4]));
+        await new Promise((r) => setTimeout(r, 10));
+
+        callbacks['file_contents_response_callback'](makeDataResponse(transferId, [5, 6, 7, 8]));
+        await new Promise((r) => setTimeout(r, 10));
+
+        await completion;
+
+        expect(progressEvents.length).toBeGreaterThanOrEqual(2);
+        expect(progressEvents[0].bytesTransferred).toBe(4);
+        expect(progressEvents[0].percentage).toBe(50);
+        expect(progressEvents[progressEvents.length - 1].percentage).toBe(100);
+
+        provider.dispose();
+    });
+
+    it('emits download-complete on success', async () => {
+        const { provider, callbacks } = setupDownloadTest();
+        const fileInfo: FileInfo = { name: 'done.bin', size: 2, lastModified: 0 };
+        const completeEvents: Array<{ fileInfo: FileInfo; blob: Blob }> = [];
+
+        provider.on('download-complete', (fi, blob) => completeEvents.push({ fileInfo: fi, blob }));
+
+        callbacks['files_available_callback']([fileInfo]);
+        const { transferId, completion } = provider.downloadFile(fileInfo, 0);
+
+        callbacks['file_contents_response_callback'](makeSizeResponse(transferId, 2));
+        await new Promise((r) => setTimeout(r, 10));
+
+        callbacks['file_contents_response_callback'](makeDataResponse(transferId, [0xca, 0xfe]));
+        await new Promise((r) => setTimeout(r, 10));
+
+        await completion;
+
+        expect(completeEvents).toHaveLength(1);
+        expect(completeEvents[0].fileInfo.name).toBe('done.bin');
+        expect(completeEvents[0].blob.size).toBe(2);
+
+        provider.dispose();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Write-handle-ready race path tests
+// ---------------------------------------------------------------------------
+
+describe('download flow with delayed write handle init', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    /**
+     * Create a mock backend whose createWriteHandle resolves after an
+     * explicit trigger, simulating slow OPFS init.
+     */
+    function createDelayedBackend() {
+        const writes: Uint8Array[] = [];
+        let finalized = false;
+        let aborted = false;
+        let bytesWritten = 0;
+        let resolveInit!: () => void;
+        let rejectInit!: (err: Error) => void;
+
+        const initPromise = new Promise<void>((resolve, reject) => {
+            resolveInit = resolve;
+            rejectInit = reject;
+        });
+
+        const writeHandle: FileWriteHandle = {
+            get bytesWritten() {
+                return bytesWritten;
+            },
+            async write(chunk: Uint8Array) {
+                writes.push(new Uint8Array(chunk));
+                bytesWritten += chunk.length;
+            },
+            async finalize() {
+                finalized = true;
+                return new Blob(writes);
+            },
+            async abort() {
+                aborted = true;
+            },
+        };
+
+        const backend: FileStorageBackend = {
+            name: 'delayed-mock',
+            async createWriteHandle(_fileName: string, _expectedSize: number) {
+                await initPromise;
+                return writeHandle;
+            },
+            async dispose() {},
+        };
+
+        return {
+            backend,
+            /** Call to let createWriteHandle resolve. */
+            resolveInit,
+            /** Call to make createWriteHandle fail. */
+            rejectInit,
+            get writes() {
+                return writes;
+            },
+            get finalized() {
+                return finalized;
+            },
+            get aborted() {
+                return aborted;
+            },
+        };
+    }
+
+    it('DATA arriving before write handle is ready awaits init then writes', async () => {
+        const delayed = createDelayedBackend();
+        const { provider, callbacks } = setupDownloadTest(delayed.backend);
+        const fileInfo: FileInfo = { name: 'race.bin', size: 4, lastModified: 0 };
+
+        callbacks['files_available_callback']([fileInfo]);
+        const { transferId, completion } = provider.downloadFile(fileInfo, 0);
+
+        // SIZE response triggers write handle init (which blocks on initPromise)
+        callbacks['file_contents_response_callback'](makeSizeResponse(transferId, 4));
+
+        // DATA arrives while write handle init is still pending
+        callbacks['file_contents_response_callback'](makeDataResponse(transferId, [1, 2, 3, 4]));
+
+        // Let microtasks settle -- handleDataChunk should be awaiting writeHandleReady
+        await new Promise((r) => setTimeout(r, 10));
+
+        // Writes should NOT have happened yet
+        expect(delayed.writes).toHaveLength(0);
+
+        // Now release the init
+        delayed.resolveInit();
+        await new Promise((r) => setTimeout(r, 10));
+
+        // Download should complete
+        const blob = await completion;
+        expect(blob.size).toBe(4);
+        expect(delayed.writes).toHaveLength(1);
+        expect(delayed.finalized).toBe(true);
+
+        provider.dispose();
+    });
+
+    it('init failure while DATA is waiting does not hang', async () => {
+        const delayed = createDelayedBackend();
+        const { provider, callbacks } = setupDownloadTest(delayed.backend);
+        const fileInfo: FileInfo = { name: 'fail-race.bin', size: 4, lastModified: 0 };
+
+        const errorHandler = vi.fn();
+        provider.on('error', errorHandler);
+
+        callbacks['files_available_callback']([fileInfo]);
+        const { transferId, completion } = provider.downloadFile(fileInfo, 0);
+
+        // Attach rejection handler early to prevent unhandled rejection warning.
+        const completionResult = completion.catch((e: unknown) => e);
+
+        // SIZE response triggers write handle init
+        callbacks['file_contents_response_callback'](makeSizeResponse(transferId, 4));
+
+        // DATA arrives while init is pending
+        callbacks['file_contents_response_callback'](makeDataResponse(transferId, [1, 2, 3, 4]));
+
+        // Fail the init
+        delayed.rejectInit(new Error('OPFS broken'));
+        await new Promise((r) => setTimeout(r, 10));
+
+        // Download should reject (not hang)
+        const error = await completionResult;
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toBe('Failed to initialize storage for download');
+        expect(delayed.writes).toHaveLength(0);
+        expect(errorHandler).toHaveBeenCalledTimes(1);
+
+        provider.dispose();
+    });
+
+    it('dispose during pending write-handle init does not leak', async () => {
+        const delayed = createDelayedBackend();
+        const { provider, callbacks } = setupDownloadTest(delayed.backend);
+        const fileInfo: FileInfo = { name: 'dispose-race.bin', size: 100, lastModified: 0 };
+
+        callbacks['files_available_callback']([fileInfo]);
+        const { transferId, completion } = provider.downloadFile(fileInfo, 0);
+
+        // SIZE response triggers write handle init (blocked)
+        callbacks['file_contents_response_callback'](makeSizeResponse(transferId, 100));
+        await new Promise((r) => setTimeout(r, 5));
+
+        // Dispose before init completes
+        provider.dispose();
+
+        await expect(completion).rejects.toThrow('disposed');
+
+        // Resolve init after dispose -- should not cause errors
+        delayed.resolveInit();
+        await new Promise((r) => setTimeout(r, 10));
+
+        // No writes should have occurred
+        expect(delayed.writes).toHaveLength(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Edge case error path tests
+// ---------------------------------------------------------------------------
+
+describe('download flow edge cases', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('finalize() failure emits error and rejects', async () => {
+        const { provider, callbacks, mockStorage } = setupDownloadTest({
+            finalizeError: new Error('disk corruption'),
+        });
+        const fileInfo: FileInfo = { name: 'corrupt.bin', size: 4, lastModified: 0 };
+
+        const errorHandler = vi.fn();
+        provider.on('error', errorHandler);
+
+        callbacks['files_available_callback']([fileInfo]);
+        const { transferId, completion } = provider.downloadFile(fileInfo, 0);
+
+        // Attach rejection handler early.
+        const completionResult = completion.catch((e: unknown) => e);
+
+        callbacks['file_contents_response_callback'](makeSizeResponse(transferId, 4));
+        await new Promise((r) => setTimeout(r, 10));
+
+        callbacks['file_contents_response_callback'](makeDataResponse(transferId, [1, 2, 3, 4]));
+        await new Promise((r) => setTimeout(r, 10));
+
+        const error = await completionResult;
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toBe('Failed to finalize downloaded file');
+        expect(errorHandler).toHaveBeenCalledTimes(1);
+        expect(errorHandler.mock.calls[0][0].message).toBe('Failed to finalize downloaded file');
+        expect(mockStorage.aborted).toBe(true);
+
+        provider.dispose();
+    });
+
+    it('lock expiration aborts affected downloads', async () => {
+        const { provider, callbacks, mockStorage } = setupDownloadTest();
+        const fileInfo: FileInfo = { name: 'locked.bin', size: 100, lastModified: 0 };
+
+        const errorHandler = vi.fn();
+        provider.on('error', errorHandler);
+
+        // Announce files with a clipDataId (lock ID).
+        callbacks['files_available_callback']([fileInfo], 42);
+
+        const { transferId, completion } = provider.downloadFile(fileInfo, 0);
+
+        // Attach rejection handler early.
+        const completionResult = completion.catch((e: unknown) => e);
+
+        // Feed SIZE and first chunk.
+        callbacks['file_contents_response_callback'](makeSizeResponse(transferId, 100));
+        await new Promise((r) => setTimeout(r, 10));
+
+        callbacks['file_contents_response_callback'](makeDataResponse(transferId, [1, 2, 3, 4]));
+        await new Promise((r) => setTimeout(r, 10));
+
+        // Expire the lock.
+        callbacks['locks_expired_callback'](new Uint32Array([42]));
+
+        const error = await completionResult;
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toMatch(/timed out/i);
+        expect(errorHandler).toHaveBeenCalledTimes(1);
+        expect(errorHandler.mock.calls[0][0].message).toMatch(/timed out/i);
+        expect(mockStorage.aborted).toBe(true);
+
+        provider.dispose();
+    });
+});

--- a/web-client/iron-remote-desktop-rdp/src/RdpFileTransferProvider.ts
+++ b/web-client/iron-remote-desktop-rdp/src/RdpFileTransferProvider.ts
@@ -13,6 +13,9 @@ import {
     submitFileContents,
     initiateFileCopy,
 } from './extensions';
+import type { FileStorageBackend, FileWriteHandle } from './storage';
+import { detectStorageBackend } from './storage';
+import type { StorageBackendPreference } from './storage';
 
 /**
  * Minimal session interface for extension-based file transfer.
@@ -44,6 +47,21 @@ export interface RdpFileTransferProviderOptions {
      * Use this to resume clipboard monitoring after {@link onUploadStarted}.
      */
     onUploadFinished?: () => void;
+
+    /**
+     * Storage backend for downloads.
+     *
+     * Accepts either a preference string or a pre-constructed backend
+     * instance (useful for testing or custom backends):
+     *
+     * - `'auto'` (default): use OPFS when available, fall back to
+     *   in-memory Blob.  OPFS reduces peak RAM from ~2x file size to
+     *   ~chunk size.
+     * - `'blob'`: force in-memory Blob storage.
+     * - `FileStorageBackend`: use the provided backend instance directly,
+     *   bypassing auto-detection.
+     */
+    storageBackend?: StorageBackendPreference | FileStorageBackend;
 }
 
 /**
@@ -143,7 +161,12 @@ interface TransferState {
     streamId: number;
     clipDataId?: number;
     expectedSize?: number;
-    chunks: Uint8Array[];
+    writeHandle?: FileWriteHandle;
+    /** Resolves when `writeHandle` has been assigned.  Always resolves (never
+     *  rejects) so that concurrent `handleDataChunk` callers awaiting this
+     *  promise do not need individual error handling -- failures are detected
+     *  via the `!state.writeHandle` guard after the await. */
+    writeHandleReady?: Promise<void>;
     bytesReceived: number;
     resolve: (blob: Blob) => void;
     reject: (error: Error) => void;
@@ -286,6 +309,8 @@ export class RdpFileTransferProvider {
      * slow-but-progressing transfer keeps resetting it, so it is never killed.
      */
     private static readonly UPLOAD_INACTIVITY_TIMEOUT_MS = 60 * 1000;
+    /** Timeout for storage backend write handle initialization (30 seconds). */
+    private static readonly WRITE_HANDLE_INIT_TIMEOUT_MS = 30 * 1000;
     /** Maximum recursion depth when traversing dropped directories. */
     private static readonly MAX_DIRECTORY_DEPTH = 32;
     /** Maximum total entries (files + directories) collected from a single drop. */
@@ -295,9 +320,12 @@ export class RdpFileTransferProvider {
     private readonly chunkSize: number;
     private readonly onUploadStarted?: () => void;
     private readonly onUploadFinished?: () => void;
+    private readonly storagePreference: StorageBackendPreference;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private readonly eventHandlers: Map<keyof EventMap, Set<EventHandler<any>>> = new Map();
 
+    private storageBackend?: FileStorageBackend;
+    private storageBackendReady?: Promise<FileStorageBackend>;
     private activeDownloads: Map<number, TransferState> = new Map();
     private uploadState?: UploadState;
     // Upload paste-window watchdog. Armed when we advertise an upload, disarmed on the
@@ -333,6 +361,29 @@ export class RdpFileTransferProvider {
         this.chunkSize = options?.chunkSize ?? 65536; // Default: 64KB
         this.onUploadStarted = options?.onUploadStarted;
         this.onUploadFinished = options?.onUploadFinished;
+
+        const sb = options?.storageBackend;
+        if (typeof sb === 'object' && sb !== null) {
+            if (
+                typeof (sb as FileStorageBackend).createWriteHandle !== 'function' ||
+                typeof (sb as FileStorageBackend).dispose !== 'function'
+            ) {
+                throw new Error(
+                    "storageBackend: expected 'auto', 'blob', or a FileStorageBackend " +
+                        'with createWriteHandle() and dispose() methods',
+                );
+            }
+            this.storageBackend = sb;
+            this.storagePreference = 'auto'; // unused when backend is pre-set
+        } else {
+            const pref = sb ?? 'auto';
+            if (pref !== 'auto' && pref !== 'blob') {
+                throw new Error(
+                    `storageBackend: invalid preference '${pref}', expected 'auto', 'blob', or a FileStorageBackend instance`,
+                );
+            }
+            this.storagePreference = pref;
+        }
     }
 
     /**
@@ -348,6 +399,37 @@ export class RdpFileTransferProvider {
             throw new Error('RdpFileTransferProvider: Session not available. Ensure connect() has been called.');
         }
         return this.session;
+    }
+
+    /**
+     * Lazily initialize and return the storage backend.
+     *
+     * Detection is performed once and cached.  Concurrent callers share
+     * the same initialization promise so the probe only runs once.
+     * If detection fails the cached promise is cleared so subsequent
+     * downloads can retry.
+     */
+    private async ensureStorageBackend(): Promise<FileStorageBackend> {
+        if (this.storageBackend) {
+            return this.storageBackend;
+        }
+
+        if (!this.storageBackendReady) {
+            this.storageBackendReady = detectStorageBackend(this.storagePreference)
+                .then((backend) => {
+                    this.storageBackend = backend;
+                    console.debug(`File transfer storage: ${backend.name}`);
+                    return backend;
+                })
+                .catch((error: unknown) => {
+                    // Clear the cached promise so the next download retries
+                    // detection instead of hitting the same failure.
+                    this.storageBackendReady = undefined;
+                    throw error;
+                });
+        }
+
+        return this.storageBackendReady;
     }
 
     // --- Extension-based session method wrappers ---
@@ -495,7 +577,6 @@ export class RdpFileTransferProvider {
                 fileIndex,
                 streamId,
                 clipDataId,
-                chunks: [],
                 bytesReceived: 0,
                 resolve,
                 reject,
@@ -587,7 +668,7 @@ export class RdpFileTransferProvider {
 
         // Execute with concurrency limit.
         // Each task promise catches its own errors so that Promise.race/Promise.all
-        // never reject — errors are collected in the `errors` array above.
+        // never reject - errors are collected in the `errors` array above.
         const executing: Array<Promise<void>> = [];
         for (const task of downloadTasks) {
             const promise = task().finally(() => {
@@ -1198,7 +1279,7 @@ export class RdpFileTransferProvider {
 
         // Cancel active downloads (lock cleanup is handled by the Rust layer)
         for (const state of this.activeDownloads.values()) {
-            state.chunks = [];
+            void this.abortWriteHandle(state);
             state.reject(new Error('RdpFileTransferProvider disposed'));
         }
         this.activeDownloads.clear();
@@ -1214,6 +1295,16 @@ export class RdpFileTransferProvider {
         // Clear available files and lock reference
         this.availableFiles = [];
         this.clipDataId = undefined;
+
+        // Dispose the storage backend (deletes OPFS session directory, etc.).
+        // Fire-and-forget -- dispose() is synchronous per the FileTransferProvider
+        // interface, but backend cleanup is async.  This is acceptable because
+        // the session is terminating and the OPFS data is expendable.
+        if (this.storageBackend) {
+            void this.storageBackend.dispose();
+            this.storageBackend = undefined;
+            this.storageBackendReady = undefined;
+        }
 
         // Clear event handlers
         this.eventHandlers.clear();
@@ -1333,7 +1424,9 @@ export class RdpFileTransferProvider {
         const fileHandle = files[request.index];
         const dropped = droppedFiles[request.index];
         if (dropped === undefined) {
-            console.error(`File index ${request.index} out of range`);
+            console.error(
+                `File index ${request.index} out of range (stream ${request.streamId}, valid: 0..${droppedFiles.length - 1})`,
+            );
             this.sendSubmitFileContents(request.streamId, true, new Uint8Array());
             return;
         }
@@ -1548,7 +1641,7 @@ export class RdpFileTransferProvider {
 
         if (response.isError) {
             this.activeDownloads.delete(response.streamId);
-            state.chunks = [];
+            void this.abortWriteHandle(state);
             const err: FileTransferError = {
                 message: 'Remote failed to provide file contents',
                 transferId: state.streamId,
@@ -1566,7 +1659,7 @@ export class RdpFileTransferProvider {
             // Validate response data is valid before creating DataView
             if (response.data.length < 8) {
                 this.activeDownloads.delete(response.streamId);
-                state.chunks = [];
+                void this.abortWriteHandle(state);
                 const err: FileTransferError = {
                     message: 'Invalid SIZE response: expected 8 bytes for file size',
                     transferId: state.streamId,
@@ -1585,7 +1678,7 @@ export class RdpFileTransferProvider {
             // Validate file size doesn't exceed browser memory limits
             if (size > RdpFileTransferProvider.MAX_FILE_SIZE) {
                 this.activeDownloads.delete(response.streamId);
-                state.chunks = [];
+                void this.abortWriteHandle(state);
                 const err: FileTransferError = {
                     message: `File size ${(size / (1024 * 1024 * 1024)).toFixed(2)}GB exceeds maximum download limit of 2GB`,
                     transferId: state.streamId,
@@ -1603,40 +1696,160 @@ export class RdpFileTransferProvider {
             // Handle empty files
             if (size === 0) {
                 this.activeDownloads.delete(response.streamId);
+                void this.abortWriteHandle(state);
                 const blob = new Blob([]);
                 this.emit('download-complete', state.fileInfo, blob, state.fileIndex, state.streamId);
                 state.resolve(blob);
                 return;
             }
 
-            // Request data in chunks
-            this.requestNextChunk(state);
+            // Initialize the storage write handle now that we know the file
+            // size, then request the first data chunk.
+            this.initWriteHandleAndRequestFirstChunk(state);
         } else {
-            // This is a DATA response.
-            // TODO: chunks accumulate in memory until the download completes and a
-            // Blob is created. For a 2 GB file this means ~4 GB peak RAM (chunks +
-            // final Blob). Consider incremental Blob construction or the File System
-            // Access API (WritableStream) to reduce peak memory in a future milestone.
-            state.chunks.push(response.data);
-            state.bytesReceived += response.data.length;
+            // This is a DATA response -- write the chunk to the storage backend.
+            void this.handleDataChunk(state, response.data);
+        }
+    }
 
-            // Validate that received data doesn't grossly exceed expected size
-            if (state.bytesReceived > state.expectedSize * 2) {
-                this.activeDownloads.delete(response.streamId);
-                state.chunks = [];
+    /**
+     * Create a write handle for the given transfer and request the first
+     * data chunk.  Runs asynchronously because backend initialization
+     * (especially OPFS) is async.
+     *
+     * The init promise is stored on `state.writeHandleReady` so that
+     * DATA responses arriving before the handle is ready can await it.
+     */
+    private initWriteHandleAndRequestFirstChunk(state: TransferState): void {
+        // The init promise always resolves (never rejects) so that awaiting
+        // callers in handleDataChunk do not need individual error handling.
+        // Failures are signaled by leaving writeHandle undefined; the
+        // !state.writeHandle guard after the await detects this.
+        state.writeHandleReady = (async () => {
+            try {
+                const initPromise = (async () => {
+                    const backend = await this.ensureStorageBackend();
+                    return backend.createWriteHandle(state.fileInfo.name, state.expectedSize ?? 0);
+                })();
+
+                const timeout = RdpFileTransferProvider.WRITE_HANDLE_INIT_TIMEOUT_MS;
+                const handle = await Promise.race([
+                    initPromise,
+                    new Promise<never>((_resolve, reject) =>
+                        setTimeout(() => reject(new Error(`Storage init timed out after ${timeout / 1000}s`)), timeout),
+                    ),
+                ]);
+
+                // Provider may have been disposed while we were awaiting.
+                // Abort the newly created handle to avoid orphaned OPFS files.
+                if (this.disposed || !this.activeDownloads.has(state.streamId)) {
+                    try {
+                        await handle.abort();
+                    } catch {
+                        // Best-effort cleanup.
+                    }
+                    return;
+                }
+
+                state.writeHandle = handle;
+            } catch (error) {
+                this.activeDownloads.delete(state.streamId);
                 const err: FileTransferError = {
-                    message: `Received ${state.bytesReceived} bytes but expected ${state.expectedSize} — aborting`,
+                    message: 'Failed to initialize storage for download',
                     transferId: state.streamId,
                     fileIndex: state.fileIndex,
                     fileName: state.fileInfo.name,
                     direction: 'download',
+                    cause: error,
                 };
                 this.emit('error', err);
-                state.reject(new Error(err.message));
+                state.reject(new Error(err.message, { cause: error }));
+                // Do not rethrow: the promise must resolve (not reject) so
+                // that awaiting callers in handleDataChunk can detect the
+                // failure via the !state.writeHandle guard without needing
+                // per-caller error handling.
                 return;
             }
 
-            // Emit progress (clamp percentage to 100% in case server sends slightly more than expected)
+            this.requestNextChunk(state);
+        })();
+    }
+
+    /**
+     * Write a data chunk to the storage backend and advance the download.
+     *
+     * If the write handle is not yet ready (DATA response arrived before
+     * backend init completed), this method awaits `state.writeHandleReady`
+     * to preserve chunk ordering -- each concurrent caller awaits the same
+     * promise in sequence.
+     */
+    private async handleDataChunk(state: TransferState, data: Uint8Array): Promise<void> {
+        if (!state.writeHandle) {
+            if (!state.writeHandleReady || this.disposed || !this.activeDownloads.has(state.streamId)) {
+                // No init in progress or download already cancelled.
+                return;
+            }
+            // writeHandleReady always resolves (never rejects); init
+            // failures leave writeHandle undefined, caught by the
+            // guard below.
+            await state.writeHandleReady;
+
+            // Re-check: the download may have been cancelled or disposed
+            // while we were waiting for the write handle.
+            if (this.disposed || !this.activeDownloads.has(state.streamId)) {
+                return;
+            }
+        }
+
+        // Guard defensively: writeHandle may still be undefined if init
+        // failed or dispose() cleared it during the await above.
+        const writeHandle = state.writeHandle;
+        if (!writeHandle) {
+            return;
+        }
+
+        try {
+            await writeHandle.write(data);
+        } catch (error) {
+            this.activeDownloads.delete(state.streamId);
+            void this.abortWriteHandle(state);
+            const isQuota = error instanceof DOMException && error.name === 'QuotaExceededError';
+            const message = isQuota
+                ? `Storage quota exceeded while downloading "${state.fileInfo.name}"`
+                : 'Failed to write download chunk to storage';
+            const err: FileTransferError = {
+                message,
+                transferId: state.streamId,
+                fileIndex: state.fileIndex,
+                fileName: state.fileInfo.name,
+                direction: 'download',
+                cause: error,
+            };
+            this.emit('error', err);
+            state.reject(new Error(err.message, { cause: error }));
+            return;
+        }
+
+        state.bytesReceived += data.length;
+
+        // Validate that received data doesn't grossly exceed expected size
+        if (state.expectedSize !== undefined && state.bytesReceived > state.expectedSize * 2) {
+            this.activeDownloads.delete(state.streamId);
+            void this.abortWriteHandle(state);
+            const err: FileTransferError = {
+                message: `Received ${state.bytesReceived} bytes but expected ${state.expectedSize} - aborting`,
+                transferId: state.streamId,
+                fileIndex: state.fileIndex,
+                fileName: state.fileInfo.name,
+                direction: 'download',
+            };
+            this.emit('error', err);
+            state.reject(new Error(err.message));
+            return;
+        }
+
+        // Emit progress (clamp percentage to 100% in case server sends slightly more than expected)
+        if (state.expectedSize !== undefined) {
             const progress: TransferProgress = {
                 transferId: state.streamId,
                 fileIndex: state.fileIndex,
@@ -1646,17 +1859,43 @@ export class RdpFileTransferProvider {
                 percentage: Math.min((state.bytesReceived / state.expectedSize) * 100, 100),
             };
             this.emit('download-progress', progress);
+        }
 
-            // Check if download complete
-            if (state.bytesReceived >= state.expectedSize) {
-                this.activeDownloads.delete(response.streamId);
-                const blob = new Blob(state.chunks as BlobPart[]);
+        // Check if download complete
+        if (state.expectedSize !== undefined && state.bytesReceived >= state.expectedSize) {
+            this.activeDownloads.delete(state.streamId);
+            try {
+                const blob = await writeHandle.finalize();
                 this.emit('download-complete', state.fileInfo, blob, state.fileIndex, state.streamId);
                 state.resolve(blob);
-            } else {
-                // Request next chunk
-                this.requestNextChunk(state);
+            } catch (error) {
+                void this.abortWriteHandle(state);
+                const err: FileTransferError = {
+                    message: 'Failed to finalize downloaded file',
+                    transferId: state.streamId,
+                    fileIndex: state.fileIndex,
+                    fileName: state.fileInfo.name,
+                    direction: 'download',
+                    cause: error,
+                };
+                this.emit('error', err);
+                state.reject(new Error(err.message, { cause: error }));
             }
+        } else {
+            // Request next chunk
+            this.requestNextChunk(state);
+        }
+    }
+
+    /** Abort and clean up a write handle, ignoring errors. */
+    private async abortWriteHandle(state: TransferState): Promise<void> {
+        if (state.writeHandle) {
+            try {
+                await state.writeHandle.abort();
+            } catch {
+                // Best-effort cleanup.
+            }
+            state.writeHandle = undefined;
         }
     }
 
@@ -1699,7 +1938,7 @@ export class RdpFileTransferProvider {
         for (const [streamId, state] of this.activeDownloads) {
             if (state.clipDataId !== undefined && expiredLockSet.has(state.clipDataId)) {
                 this.activeDownloads.delete(streamId);
-                state.chunks = [];
+                void this.abortWriteHandle(state);
 
                 // Build user-friendly error message with timeout info and remediation
                 const errorMessage =
@@ -1743,7 +1982,7 @@ export class RdpFileTransferProvider {
             );
         } catch (error) {
             this.activeDownloads.delete(state.streamId);
-            state.chunks = [];
+            void this.abortWriteHandle(state);
             const err: FileTransferError = {
                 message: 'Failed to request file chunk',
                 transferId: state.streamId,
@@ -1773,6 +2012,6 @@ export class RdpFileTransferProvider {
             }
         }
         // Should never happen: more active downloads than the counter can skip
-        throw new Error('unable to generate unique stream ID');
+        throw new Error('Unable to generate unique stream ID');
     }
 }

--- a/web-client/iron-remote-desktop-rdp/src/main.ts
+++ b/web-client/iron-remote-desktop-rdp/src/main.ts
@@ -60,6 +60,15 @@ export type {
 export type { FileInfo, FileContentsRequest, FileContentsResponse } from './FileTransfer';
 export { FileContentsFlags } from './FileContentsFlags';
 
+// --- Storage backends ---
+// Re-export for consumers who want to configure the storageBackend
+// option on RdpFileTransferProviderOptions, implement a custom backend,
+// or construct a specific backend instance directly.
+export type { FileStorageBackend, FileWriteHandle, StorageBackendPreference } from './storage';
+export { BlobStorageBackend } from './storage';
+export { OpfsStorageBackend } from './storage';
+export { detectStorageBackend } from './storage';
+
 // Re-export extension factories for advanced consumers who want to
 // register callbacks or invoke file transfer operations directly.
 export {

--- a/web-client/iron-remote-desktop-rdp/src/storage/BlobStorageBackend.ts
+++ b/web-client/iron-remote-desktop-rdp/src/storage/BlobStorageBackend.ts
@@ -1,0 +1,69 @@
+import type { FileStorageBackend, FileWriteHandle } from './FileStorageBackend';
+
+/**
+ * Write handle that accumulates chunks in an in-memory array and assembles
+ * a {@link Blob} on {@link finalize}.
+ *
+ * Simple and universally supported, but peak RAM is approximately 2x the
+ * file size (the chunk array plus the final Blob).  See
+ * {@link OpfsStorageBackend} for a streaming alternative.
+ */
+class BlobWriteHandle implements FileWriteHandle {
+    private chunks: Uint8Array[] = [];
+    private _bytesWritten = 0;
+    private finalized = false;
+
+    get bytesWritten(): number {
+        return this._bytesWritten;
+    }
+
+    async write(chunk: Uint8Array): Promise<void> {
+        if (this.finalized) {
+            throw new Error('BlobWriteHandle: write after finalize/abort');
+        }
+        this.chunks.push(chunk);
+        this._bytesWritten += chunk.length;
+    }
+
+    async finalize(): Promise<Blob> {
+        if (this.finalized) {
+            throw new Error('BlobWriteHandle: already finalized or aborted');
+        }
+        this.finalized = true;
+        const blob = new Blob(this.chunks);
+        this.chunks = [];
+        return blob;
+    }
+
+    async abort(): Promise<void> {
+        if (this.finalized) {
+            return;
+        }
+        this.finalized = true;
+        this.chunks = [];
+    }
+}
+
+/**
+ * In-memory Blob storage backend.
+ *
+ * Downloads are buffered as {@link Uint8Array} chunks in a plain array and
+ * assembled into a single {@link Blob} when the transfer completes.  This
+ * is the universal fallback that works in every browser context.
+ *
+ * **Trade-offs:**
+ * - Peak RAM ~2x file size (chunk array + final Blob).
+ * - No persistent storage; data is lost on page unload.
+ * - No setup cost; works even in non-secure contexts and private browsing.
+ */
+export class BlobStorageBackend implements FileStorageBackend {
+    readonly name = 'blob';
+
+    async createWriteHandle(_fileName: string, _expectedSize: number): Promise<FileWriteHandle> {
+        return new BlobWriteHandle();
+    }
+
+    async dispose(): Promise<void> {
+        // Nothing persistent to clean up.
+    }
+}

--- a/web-client/iron-remote-desktop-rdp/src/storage/FileStorageBackend.ts
+++ b/web-client/iron-remote-desktop-rdp/src/storage/FileStorageBackend.ts
@@ -1,0 +1,85 @@
+/**
+ * A write handle for streaming file data to a storage backend.
+ *
+ * Created once per download via {@link FileStorageBackend.createWriteHandle}.
+ * Chunks are appended via {@link write}, and on success {@link finalize}
+ * returns the assembled data as a {@link Blob} (or {@link File}, which
+ * extends Blob).  On failure or cancellation, {@link abort} releases all
+ * resources held by the handle.
+ *
+ * Implementations may buffer in memory (Blob backend), stream to the
+ * Origin Private File System (OPFS backend), or stream to a user-chosen
+ * location (future FSAPI backend).
+ */
+export interface FileWriteHandle {
+    /** Append a chunk of data.
+     *
+     *  Backends may buffer the chunk in memory or flush it to persistent
+     *  storage immediately.  The returned promise resolves once the chunk
+     *  has been accepted (not necessarily persisted). */
+    write(chunk: Uint8Array): Promise<void>;
+
+    /**
+     * Finalize the file and return the result as a Blob.
+     *
+     * For in-memory backends this assembles a Blob from buffered chunks.
+     * For persistent backends (e.g. OPFS) this closes the writable stream
+     * and returns a {@link File} (which extends Blob) backed by the on-disk
+     * data, keeping peak RAM close to zero.
+     *
+     * After calling finalize the handle must not be reused.
+     */
+    finalize(): Promise<Blob>;
+
+    /**
+     * Discard all written data and release resources.
+     *
+     * Safe to call multiple times.  After abort the handle must not be
+     * reused.
+     */
+    abort(): Promise<void>;
+
+    /** Number of bytes successfully written so far. */
+    readonly bytesWritten: number;
+}
+
+/**
+ * Pluggable storage backend for file transfer downloads.
+ *
+ * The backend determines *where* incoming file chunks are buffered during
+ * a download.  Protocol-specific file transfer providers delegate all
+ * storage concerns to the active backend, keeping download orchestration
+ * logic storage-agnostic.
+ *
+ * Three backends are planned:
+ *
+ * | Backend | Buffering          | Peak RAM      | Browser support           |
+ * |---------|--------------------|---------------|---------------------------|
+ * | Blob    | In-memory array    | ~2x file size | Universal                 |
+ * | OPFS    | Origin Private FS  | ~chunk size   | Baseline (September 2025) |
+ * | FSAPI   | User-chosen file   | ~chunk size   | Chromium-only (future)    |
+ */
+export interface FileStorageBackend {
+    /** Human-readable backend name, used in log messages. */
+    readonly name: string;
+
+    /**
+     * Create a write handle for a new download.
+     *
+     * @param fileName   - Sanitized file basename (used for the temp file
+     *                     name in persistent backends).
+     * @param expectedSize - Expected total size in bytes.  Backends may use
+     *                     this for pre-allocation or quota checks.  A value
+     *                     of 0 means the size is unknown or the file is
+     *                     empty.
+     */
+    createWriteHandle(fileName: string, expectedSize: number): Promise<FileWriteHandle>;
+
+    /**
+     * Release all backend resources.
+     *
+     * For persistent backends this deletes the session directory and any
+     * temp files.  Safe to call multiple times.
+     */
+    dispose(): Promise<void>;
+}

--- a/web-client/iron-remote-desktop-rdp/src/storage/OpfsStorageBackend.ts
+++ b/web-client/iron-remote-desktop-rdp/src/storage/OpfsStorageBackend.ts
@@ -1,0 +1,301 @@
+import type { FileStorageBackend, FileWriteHandle } from './FileStorageBackend';
+
+/**
+ * Write handle that streams chunks to a file in the Origin Private File
+ * System via {@link FileSystemWritableFileStream}.
+ *
+ * Each chunk is flushed to disk immediately, so peak RAM stays close to
+ * the chunk size regardless of total file size.  On {@link finalize} the
+ * stream is closed and a lazy {@link File} reference (which extends
+ * {@link Blob}) is returned -- the browser memory-maps reads from OPFS
+ * rather than loading the entire file into RAM.
+ */
+class OpfsWriteHandle implements FileWriteHandle {
+    private writable: FileSystemWritableFileStream | undefined;
+    private _bytesWritten = 0;
+    private finalized = false;
+
+    constructor(
+        private readonly fileHandle: FileSystemFileHandle,
+        private readonly sessionDir: FileSystemDirectoryHandle,
+        private readonly entryName: string,
+        writable: FileSystemWritableFileStream,
+    ) {
+        this.writable = writable;
+    }
+
+    get bytesWritten(): number {
+        return this._bytesWritten;
+    }
+
+    async write(chunk: Uint8Array): Promise<void> {
+        if (this.finalized || !this.writable) {
+            throw new Error('OpfsWriteHandle: write after finalize/abort');
+        }
+        await this.writable.write(chunk);
+        this._bytesWritten += chunk.length;
+    }
+
+    async finalize(): Promise<Blob> {
+        if (this.finalized) {
+            throw new Error('OpfsWriteHandle: already finalized or aborted');
+        }
+        this.finalized = true;
+
+        if (this.writable) {
+            await this.writable.close();
+            this.writable = undefined;
+        }
+
+        // getFile() returns a File (extends Blob) backed by OPFS storage.
+        // The browser lazily reads from disk -- the file data is NOT copied
+        // into RAM here.
+        return this.fileHandle.getFile();
+    }
+
+    async abort(): Promise<void> {
+        if (this.finalized) {
+            return;
+        }
+        this.finalized = true;
+
+        if (this.writable) {
+            try {
+                await this.writable.abort();
+            } catch {
+                // Writable may already be closed or errored; ignore.
+            }
+            this.writable = undefined;
+        }
+
+        // Remove the temp file so it does not consume quota.
+        try {
+            await this.sessionDir.removeEntry(this.entryName);
+        } catch {
+            // Entry may already be gone (e.g., session dir was deleted).
+        }
+    }
+}
+
+/**
+ * Storage backend that streams download chunks to the Origin Private File
+ * System (OPFS).
+ *
+ * OPFS is a browser-provided, origin-scoped file system that requires no
+ * user permission prompts and is available on the main thread (async
+ * only).  This backend requires the {@link FileSystemWritableFileStream}
+ * API, which reached Baseline across all major browsers in September 2025
+ * (Chrome 86+, Firefox 111+, Safari 17.2+, Edge 86+).  Older browsers
+ * are detected automatically via {@link OpfsStorageBackend.probe} and
+ * fall back to the Blob backend.
+ *
+ * **How it works:**
+ * 1. On construction, a per-session subdirectory is created under
+ *    `ironrdp-transfers/` in the OPFS root.
+ * 2. Each download opens a {@link FileSystemWritableFileStream} inside
+ *    that directory and flushes chunks to disk as they arrive.
+ * 3. On completion, the stream is closed and a lazy {@link File} handle is
+ *    returned.  The File extends Blob, so existing consumers that expect
+ *    a Blob work without changes.
+ * 4. On dispose, the entire session directory is deleted.
+ *
+ * **Trade-offs vs Blob backend:**
+ * - Peak RAM drops from ~2x file size to ~chunk size (typically 64 KB).
+ * - Moderate write latency per chunk (async disk I/O), but the download
+ *   is already async and network-bound.
+ * - Storage is subject to the origin's quota (typically 60% of disk).
+ * - May be unavailable in some private browsing modes.
+ *
+ * **Construction:** Use the static {@link OpfsStorageBackend.create}
+ * factory method.  The constructor is private because initialization
+ * requires async OPFS directory setup.
+ */
+export class OpfsStorageBackend implements FileStorageBackend {
+    readonly name = 'opfs';
+
+    /** Sequence counter for generating unique temp file names. */
+    private sequence = 0;
+
+    private constructor(
+        private readonly opfsRoot: FileSystemDirectoryHandle,
+        private sessionDir: FileSystemDirectoryHandle | undefined,
+        private readonly sessionId: string,
+    ) {}
+
+    /**
+     * Create an OPFS backend, including the per-session directory.
+     *
+     * Call {@link probe} first to verify OPFS is available before
+     * constructing -- this factory assumes OPFS works.
+     */
+    static async create(opfsRoot: FileSystemDirectoryHandle, sessionId?: string): Promise<OpfsStorageBackend> {
+        const id = sessionId ?? `s-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        const transfersDir = await opfsRoot.getDirectoryHandle('ironrdp-transfers', { create: true });
+        const sessionDir = await transfersDir.getDirectoryHandle(id, { create: true });
+
+        // Best-effort cleanup of orphaned session directories from previous
+        // sessions that did not call dispose() (e.g., tab crash, browser
+        // force-quit).  Runs asynchronously and never blocks creation.
+        void OpfsStorageBackend.cleanupStale(transfersDir, id);
+
+        return new OpfsStorageBackend(opfsRoot, sessionDir, id);
+    }
+
+    /** Maximum age (in milliseconds) before a session directory is considered stale. */
+    private static readonly STALE_SESSION_THRESHOLD_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+    /**
+     * Remove session directories older than {@link STALE_SESSION_THRESHOLD_MS}.
+     *
+     * Session IDs generated by {@link create} embed a timestamp in the
+     * format `s-{Date.now()}-{random}`.  This method parses that timestamp
+     * to determine age.  Directories with unparsable names or those
+     * belonging to the current session are skipped.
+     */
+    private static async cleanupStale(
+        transfersDir: FileSystemDirectoryHandle,
+        currentSessionId: string,
+    ): Promise<void> {
+        const now = Date.now();
+        try {
+            for await (const name of transfersDir.keys()) {
+                if (name === currentSessionId) {
+                    continue;
+                }
+                // Parse timestamp from the session ID format: s-{timestamp}-{random}.
+                const match = /^s-(\d+)-/.exec(name);
+                if (!match) {
+                    continue;
+                }
+                const timestamp = Number(match[1]);
+                if (now - timestamp > OpfsStorageBackend.STALE_SESSION_THRESHOLD_MS) {
+                    try {
+                        await transfersDir.removeEntry(name, { recursive: true });
+                    } catch {
+                        // Ignore per-entry errors (may be in use by another tab).
+                    }
+                }
+            }
+        } catch {
+            // The transfers directory may have been removed or is inaccessible.
+        }
+    }
+
+    /**
+     * Probe whether OPFS is usable in the current context.
+     *
+     * Performs a full round-trip: creates a temp file, opens a writable,
+     * closes it, and deletes it.  This catches environments where the API
+     * exists but throws at runtime (e.g., some private browsing modes).
+     */
+    static async probe(opfsRoot: FileSystemDirectoryHandle): Promise<boolean> {
+        try {
+            const handle = await opfsRoot.getFileHandle('.ironrdp-opfs-probe', { create: true });
+            const writable = await handle.createWritable();
+            await writable.close();
+            await opfsRoot.removeEntry('.ironrdp-opfs-probe');
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    async createWriteHandle(fileName: string, _expectedSize: number): Promise<FileWriteHandle> {
+        if (!this.sessionDir) {
+            throw new Error('OpfsStorageBackend: backend has been disposed');
+        }
+
+        // Use a sequence number + sanitized name to avoid collisions when
+        // the same file name is downloaded multiple times in one session.
+        const seq = this.sequence++;
+        const entryName = `${seq}-${sanitizeOpfsName(fileName)}`;
+
+        const fileHandle = await this.sessionDir.getFileHandle(entryName, { create: true });
+        const writable = await fileHandle.createWritable();
+
+        return new OpfsWriteHandle(fileHandle, this.sessionDir, entryName, writable);
+    }
+
+    async dispose(): Promise<void> {
+        if (!this.sessionDir) {
+            return;
+        }
+
+        const sessionDir = this.sessionDir;
+        this.sessionDir = undefined;
+
+        try {
+            const transfersDir = await this.opfsRoot.getDirectoryHandle('ironrdp-transfers');
+            await transfersDir.removeEntry(this.sessionId, { recursive: true });
+
+            // Clean up the parent directory if it is now empty.
+            let hasEntries = false;
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            for await (const _ of transfersDir.values()) {
+                hasEntries = true;
+                break;
+            }
+            if (!hasEntries) {
+                await this.opfsRoot.removeEntry('ironrdp-transfers');
+            }
+        } catch (error) {
+            console.debug('OPFS session directory removal failed, falling back to per-file cleanup:', error);
+            // The directory may already be gone if another tab cleaned up,
+            // or the OPFS was cleared externally.  Fall back to deleting
+            // individual files from the session directory handle.
+            try {
+                for await (const name of sessionDir.keys()) {
+                    try {
+                        await sessionDir.removeEntry(name);
+                    } catch {
+                        // Ignore per-file errors.
+                    }
+                }
+            } catch {
+                // Session dir handle may be stale; nothing more to do.
+            }
+        }
+    }
+}
+
+/**
+ * Sanitize a file name for use as an OPFS entry name.
+ *
+ * OPFS entry names must not contain `/` or `\`, and must not be `.` or
+ * `..`.  We strip control characters, replace separators with
+ * underscores, and strip leading dots.
+ */
+function sanitizeOpfsName(name: string): string {
+    // Strip ASCII control characters (U+0000-U+001F) that could cause
+    // inconsistent behavior across OPFS implementations or confuse logs.
+    // eslint-disable-next-line no-control-regex
+    let safe = name.replace(/[\u0000-\u001f]/g, '');
+
+    safe = safe.replace(/[/\\]/g, '_');
+
+    // Strip leading dots to avoid `.` / `..` collisions.
+    safe = safe.replace(/^\.+/, '');
+
+    // Ensure we always have a non-empty name.
+    if (safe.length === 0) {
+        safe = 'unnamed';
+    }
+
+    // OPFS entry names are typically limited to 255 bytes.  Truncate by
+    // UTF-8 byte length (not JS char count) to leave room for the
+    // sequence prefix added by createWriteHandle.  Non-ASCII characters
+    // can be 2-4 bytes each, so a char-based limit could still exceed
+    // the byte budget.
+    const encoder = new TextEncoder();
+    if (encoder.encode(safe).byteLength > 200) {
+        while (encoder.encode(safe).byteLength > 200) {
+            safe = safe.slice(0, -1);
+        }
+        // Ensure truncation did not leave us empty.
+        if (safe.length === 0) {
+            safe = 'unnamed';
+        }
+    }
+
+    return safe;
+}

--- a/web-client/iron-remote-desktop-rdp/src/storage/detect.ts
+++ b/web-client/iron-remote-desktop-rdp/src/storage/detect.ts
@@ -1,0 +1,62 @@
+import type { FileStorageBackend } from './FileStorageBackend';
+import { BlobStorageBackend } from './BlobStorageBackend';
+import { OpfsStorageBackend } from './OpfsStorageBackend';
+
+/**
+ * Storage backend preference for downloads.
+ *
+ * - `'auto'` - detect the best available backend (OPFS with Blob
+ *   fallback).  OPFS reduces peak download RAM from ~2x file size to
+ *   ~chunk size.
+ * - `'blob'` - force in-memory Blob storage regardless of OPFS
+ *   availability.
+ */
+export type StorageBackendPreference = 'auto' | 'blob';
+
+/**
+ * Detect the best available storage backend for the current browser
+ * context.
+ *
+ * When `preference` is `'auto'` (default), the function probes for OPFS
+ * support with a full round-trip smoke test.  If OPFS is available, an
+ * {@link OpfsStorageBackend} is returned; otherwise a
+ * {@link BlobStorageBackend} is used as the universal fallback.
+ *
+ * When `preference` is `'blob'`, OPFS detection is skipped entirely and
+ * the Blob backend is returned immediately.
+ *
+ * @param preference - `'auto'` to detect, `'blob'` to force in-memory.
+ * @param sessionId  - Optional session identifier used as the OPFS
+ *                    subdirectory name.  When omitted a unique ID is
+ *                    generated from the current timestamp.
+ * @returns The selected backend, ready to use.
+ */
+export async function detectStorageBackend(
+    preference: StorageBackendPreference = 'auto',
+    sessionId?: string,
+): Promise<FileStorageBackend> {
+    if (preference === 'blob') {
+        return new BlobStorageBackend();
+    }
+
+    // Attempt OPFS detection.
+    if (typeof globalThis.navigator?.storage?.getDirectory === 'function') {
+        try {
+            const opfsRoot = await navigator.storage.getDirectory();
+
+            if (await OpfsStorageBackend.probe(opfsRoot)) {
+                return OpfsStorageBackend.create(opfsRoot, sessionId);
+            }
+
+            // Probe failed: the OPFS API exists but is not functional
+            // (e.g., createWritable() throws in some browser modes).
+            console.debug('OPFS probe failed (createWritable not functional), falling back to blob storage');
+        } catch (error) {
+            // getDirectory() itself threw (e.g., SecurityError in some
+            // private browsing modes).  Fall through to Blob.
+            console.debug('OPFS unavailable, falling back to blob storage:', error);
+        }
+    }
+
+    return new BlobStorageBackend();
+}

--- a/web-client/iron-remote-desktop-rdp/src/storage/index.ts
+++ b/web-client/iron-remote-desktop-rdp/src/storage/index.ts
@@ -1,0 +1,5 @@
+export type { FileStorageBackend, FileWriteHandle } from './FileStorageBackend';
+export { BlobStorageBackend } from './BlobStorageBackend';
+export { OpfsStorageBackend } from './OpfsStorageBackend';
+export { detectStorageBackend } from './detect';
+export type { StorageBackendPreference } from './detect';

--- a/web-client/iron-remote-desktop-rdp/src/storage/storage.test.ts
+++ b/web-client/iron-remote-desktop-rdp/src/storage/storage.test.ts
@@ -1,0 +1,620 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { BlobStorageBackend } from './BlobStorageBackend';
+import { OpfsStorageBackend } from './OpfsStorageBackend';
+import { detectStorageBackend } from './detect';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function chunk(bytes: number[]): Uint8Array {
+    return new Uint8Array(bytes);
+}
+
+async function blobToBytes(blob: Blob): Promise<Uint8Array> {
+    // jsdom Blob.arrayBuffer() may not be available or may behave
+    // inconsistently.  Use FileReader which jsdom supports reliably.
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(new Uint8Array(reader.result as ArrayBuffer));
+        reader.onerror = () => reject(reader.error);
+        reader.readAsArrayBuffer(blob);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Minimal in-memory mock of the OPFS directory/file handle API.
+// Shared across OpfsStorageBackend and detectStorageBackend test suites.
+// ---------------------------------------------------------------------------
+
+interface MockEntry {
+    kind: 'file' | 'directory';
+    name: string;
+    children?: Map<string, MockEntry>;
+    content?: Uint8Array[];
+    writable?: MockWritable;
+}
+
+class MockWritable {
+    closed = false;
+    aborted = false;
+    private target: MockEntry;
+
+    constructor(target: MockEntry) {
+        this.target = target;
+        // Reset content on each new writable (mirrors real createWritable)
+        this.target.content = [];
+    }
+
+    async write(data: Uint8Array): Promise<void> {
+        if (this.closed || this.aborted) throw new Error('stream closed');
+        this.target.content!.push(new Uint8Array(data));
+    }
+
+    async close(): Promise<void> {
+        this.closed = true;
+    }
+
+    async abort(): Promise<void> {
+        this.aborted = true;
+    }
+}
+
+function createMockFileHandle(entry: MockEntry): FileSystemFileHandle {
+    return {
+        kind: 'file' as const,
+        name: entry.name,
+        isSameEntry: vi.fn(),
+        async getFile() {
+            const parts = entry.content ?? [];
+            return new Blob(parts);
+        },
+        async createWritable() {
+            const w = new MockWritable(entry);
+            entry.writable = w;
+            return w as unknown as FileSystemWritableFileStream;
+        },
+        async createSyncAccessHandle() {
+            throw new Error('not implemented');
+        },
+    } as unknown as FileSystemFileHandle;
+}
+
+function createMockDirectoryHandle(name: string, children?: Map<string, MockEntry>): FileSystemDirectoryHandle {
+    const entries: Map<string, MockEntry> = children ?? new Map();
+
+    function makeValuesIterator(): AsyncIterableIterator<FileSystemHandle> {
+        const values = [...entries.values()];
+        let index = 0;
+        return {
+            [Symbol.asyncIterator]() {
+                return this;
+            },
+            async next() {
+                if (index < values.length) {
+                    return { value: values[index++] as unknown as FileSystemHandle, done: false as const };
+                }
+                return { value: undefined, done: true as const };
+            },
+        };
+    }
+
+    function makeKeysIterator(): AsyncIterableIterator<string> {
+        const keys = [...entries.keys()];
+        let index = 0;
+        return {
+            [Symbol.asyncIterator]() {
+                return this;
+            },
+            async next() {
+                if (index < keys.length) {
+                    return { value: keys[index++], done: false as const };
+                }
+                return { value: undefined, done: true as const };
+            },
+        };
+    }
+
+    return {
+        kind: 'directory' as const,
+        name,
+        isSameEntry: vi.fn(),
+        async getFileHandle(fileName: string, options?: FileSystemGetFileOptions) {
+            let entry = entries.get(fileName);
+            if (entry === undefined && options?.create === true) {
+                entry = { kind: 'file', name: fileName, content: [] };
+                entries.set(fileName, entry);
+            }
+            if (entry === undefined) throw new DOMException('NotFoundError');
+            return createMockFileHandle(entry);
+        },
+        async getDirectoryHandle(dirName: string, options?: FileSystemGetDirectoryOptions) {
+            let entry = entries.get(dirName);
+            if (entry === undefined && options?.create === true) {
+                entry = { kind: 'directory', name: dirName, children: new Map() };
+                entries.set(dirName, entry);
+            }
+            if (entry === undefined) throw new DOMException('NotFoundError');
+            return createMockDirectoryHandle(dirName, entry.children);
+        },
+        async removeEntry(entryName: string, _options?: FileSystemRemoveOptions) {
+            if (!entries.has(entryName)) throw new DOMException('NotFoundError');
+            entries.delete(entryName);
+        },
+        async resolve(_child: FileSystemHandle) {
+            return null;
+        },
+        values: makeValuesIterator,
+        keys: makeKeysIterator,
+        entries() {
+            return makeValuesIterator() as unknown as AsyncIterableIterator<[string, FileSystemHandle]>;
+        },
+        [Symbol.asyncIterator]() {
+            return makeValuesIterator() as unknown as AsyncIterableIterator<[string, FileSystemHandle]>;
+        },
+    } as unknown as FileSystemDirectoryHandle;
+}
+
+// ---------------------------------------------------------------------------
+// BlobStorageBackend
+// ---------------------------------------------------------------------------
+
+describe('BlobStorageBackend', () => {
+    let backend: BlobStorageBackend;
+
+    beforeEach(() => {
+        backend = new BlobStorageBackend();
+    });
+
+    it('has name "blob"', () => {
+        expect(backend.name).toBe('blob');
+    });
+
+    it('write then finalize produces correct Blob', async () => {
+        const handle = await backend.createWriteHandle('test.bin', 6);
+
+        await handle.write(chunk([1, 2, 3]));
+        expect(handle.bytesWritten).toBe(3);
+
+        await handle.write(chunk([4, 5, 6]));
+        expect(handle.bytesWritten).toBe(6);
+
+        const blob = await handle.finalize();
+        expect(blob).toBeInstanceOf(Blob);
+        expect(blob.size).toBe(6);
+
+        const data = await blobToBytes(blob);
+        expect(data).toEqual(new Uint8Array([1, 2, 3, 4, 5, 6]));
+    });
+
+    it('finalize on empty handle returns empty Blob', async () => {
+        const handle = await backend.createWriteHandle('empty.bin', 0);
+        const blob = await handle.finalize();
+        expect(blob.size).toBe(0);
+        expect(handle.bytesWritten).toBe(0);
+    });
+
+    it('abort clears state and prevents reuse', async () => {
+        const handle = await backend.createWriteHandle('test.bin', 3);
+        await handle.write(chunk([1, 2, 3]));
+        await handle.abort();
+
+        // Write after abort throws
+        await expect(handle.write(chunk([4]))).rejects.toThrow(/finalize|abort/);
+        // Finalize after abort throws
+        await expect(handle.finalize()).rejects.toThrow(/finalize|abort/);
+    });
+
+    it('double abort is safe', async () => {
+        const handle = await backend.createWriteHandle('test.bin', 0);
+        await handle.abort();
+        await expect(handle.abort()).resolves.toBeUndefined();
+    });
+
+    it('write after finalize throws', async () => {
+        const handle = await backend.createWriteHandle('test.bin', 0);
+        await handle.finalize();
+        await expect(handle.write(chunk([1]))).rejects.toThrow(/finalize|abort/);
+    });
+
+    it('double finalize throws', async () => {
+        const handle = await backend.createWriteHandle('test.bin', 0);
+        await handle.finalize();
+        await expect(handle.finalize()).rejects.toThrow(/finalize|abort/);
+    });
+
+    it('dispose is a no-op', async () => {
+        await expect(backend.dispose()).resolves.toBeUndefined();
+    });
+
+    it('multiple concurrent handles are independent', async () => {
+        const h1 = await backend.createWriteHandle('a.bin', 2);
+        const h2 = await backend.createWriteHandle('b.bin', 2);
+
+        await h1.write(chunk([10, 20]));
+        await h2.write(chunk([30, 40]));
+
+        const b1 = await h1.finalize();
+        const b2 = await h2.finalize();
+
+        expect(await blobToBytes(b1)).toEqual(new Uint8Array([10, 20]));
+        expect(await blobToBytes(b2)).toEqual(new Uint8Array([30, 40]));
+    });
+});
+
+// ---------------------------------------------------------------------------
+// OpfsStorageBackend - mocked OPFS
+// ---------------------------------------------------------------------------
+
+describe('OpfsStorageBackend', () => {
+    let mockOpfsRoot: FileSystemDirectoryHandle;
+
+    beforeEach(() => {
+        mockOpfsRoot = createMockDirectoryHandle('');
+    });
+
+    describe('probe', () => {
+        it('returns true when OPFS works', async () => {
+            expect(await OpfsStorageBackend.probe(mockOpfsRoot)).toBe(true);
+        });
+
+        it('returns false when createWritable throws', async () => {
+            const broken = {
+                ...mockOpfsRoot,
+                async getFileHandle() {
+                    return {
+                        async createWritable() {
+                            throw new Error('SecurityError');
+                        },
+                    } as unknown as FileSystemFileHandle;
+                },
+            } as unknown as FileSystemDirectoryHandle;
+
+            expect(await OpfsStorageBackend.probe(broken)).toBe(false);
+        });
+    });
+
+    describe('lifecycle', () => {
+        it('creates session directory on construction', async () => {
+            const backend = await OpfsStorageBackend.create(mockOpfsRoot, 'test-session');
+            expect(backend.name).toBe('opfs');
+
+            // Verify the session directory was created
+            const transfersDir = await mockOpfsRoot.getDirectoryHandle('ironrdp-transfers');
+            const sessionDir = await transfersDir.getDirectoryHandle('test-session');
+            expect(sessionDir.name).toBe('test-session');
+
+            await backend.dispose();
+        });
+
+        it('write/finalize produces a Blob', async () => {
+            const backend = await OpfsStorageBackend.create(mockOpfsRoot, 'sess-1');
+            const handle = await backend.createWriteHandle('hello.bin', 4);
+
+            await handle.write(chunk([10, 20]));
+            expect(handle.bytesWritten).toBe(2);
+
+            await handle.write(chunk([30, 40]));
+            expect(handle.bytesWritten).toBe(4);
+
+            const blob = await handle.finalize();
+            expect(blob.size).toBe(4);
+
+            const data = await blobToBytes(blob);
+            expect(data).toEqual(new Uint8Array([10, 20, 30, 40]));
+
+            await backend.dispose();
+        });
+
+        it('abort removes the temp file', async () => {
+            const backend = await OpfsStorageBackend.create(mockOpfsRoot, 'sess-2');
+            const handle = await backend.createWriteHandle('abort-me.bin', 4);
+            await handle.write(chunk([1, 2, 3, 4]));
+            await handle.abort();
+
+            // Write after abort should throw
+            await expect(handle.write(chunk([5]))).rejects.toThrow();
+
+            await backend.dispose();
+        });
+
+        it('double abort is safe', async () => {
+            const backend = await OpfsStorageBackend.create(mockOpfsRoot, 'sess-3');
+            const handle = await backend.createWriteHandle('test.bin', 0);
+            await handle.abort();
+            await expect(handle.abort()).resolves.toBeUndefined();
+            await backend.dispose();
+        });
+
+        it('write after finalize throws', async () => {
+            const backend = await OpfsStorageBackend.create(mockOpfsRoot, 'sess-waf');
+            const handle = await backend.createWriteHandle('test.bin', 0);
+            await handle.finalize();
+            await expect(handle.write(chunk([1]))).rejects.toThrow(/finalize|abort/);
+            await backend.dispose();
+        });
+
+        it('double finalize throws', async () => {
+            const backend = await OpfsStorageBackend.create(mockOpfsRoot, 'sess-df');
+            const handle = await backend.createWriteHandle('test.bin', 0);
+            await handle.finalize();
+            await expect(handle.finalize()).rejects.toThrow(/finalize|abort/);
+            await backend.dispose();
+        });
+
+        it('dispose cleans up session directory', async () => {
+            const backend = await OpfsStorageBackend.create(mockOpfsRoot, 'sess-cleanup');
+            await backend.createWriteHandle('file1.bin', 0);
+            await backend.dispose();
+
+            // When the session was the only child, dispose also removes the
+            // parent `ironrdp-transfers` directory.  Either the parent or
+            // the session subdir being gone confirms cleanup succeeded.
+            let sessionDirExists = true;
+            try {
+                const transfersDir = await mockOpfsRoot.getDirectoryHandle('ironrdp-transfers');
+                await transfersDir.getDirectoryHandle('sess-cleanup');
+            } catch {
+                sessionDirExists = false;
+            }
+            expect(sessionDirExists).toBe(false);
+        });
+
+        it('double dispose is safe', async () => {
+            const backend = await OpfsStorageBackend.create(mockOpfsRoot, 'sess-double');
+            await backend.dispose();
+            await expect(backend.dispose()).resolves.toBeUndefined();
+        });
+
+        it('createWriteHandle after dispose throws', async () => {
+            const backend = await OpfsStorageBackend.create(mockOpfsRoot, 'sess-after');
+            await backend.dispose();
+            await expect(backend.createWriteHandle('nope.bin', 0)).rejects.toThrow(/disposed/);
+        });
+
+        it('sanitizes file names for OPFS entries', async () => {
+            const backend = await OpfsStorageBackend.create(mockOpfsRoot, 'sess-sanitize');
+
+            // Collect entry names created in the session directory.
+            const transfersDir = await mockOpfsRoot.getDirectoryHandle('ironrdp-transfers');
+            const sessionDir = await transfersDir.getDirectoryHandle('sess-sanitize');
+            async function entryNames(): Promise<string[]> {
+                const names: string[] = [];
+                for await (const name of sessionDir.keys()) names.push(name);
+                return names;
+            }
+
+            // Path traversal: slashes become underscores, dots are interior
+            // (leading-dot stripping only applies after separator replacement).
+            const h1 = await backend.createWriteHandle('../../etc/passwd', 3);
+            await h1.write(chunk([1, 2, 3]));
+            await h1.finalize();
+            expect(await entryNames()).toEqual(['0-_.._etc_passwd']);
+
+            // Bare ".." becomes empty after stripping, falls back to "unnamed".
+            const h2 = await backend.createWriteHandle('..', 1);
+            await h2.write(chunk([1]));
+            await h2.finalize();
+            expect(await entryNames()).toContain('1-unnamed');
+
+            // Leading dots stripped, rest preserved.
+            const h3 = await backend.createWriteHandle('.hidden', 1);
+            await h3.write(chunk([1]));
+            await h3.finalize();
+            expect(await entryNames()).toContain('2-hidden');
+
+            // Control characters (null bytes, tabs, newlines) are stripped.
+            const h4 = await backend.createWriteHandle('foo\x00bar\tbaz\n.txt', 1);
+            await h4.write(chunk([1]));
+            await h4.finalize();
+            expect(await entryNames()).toContain('3-foobarbaz.txt');
+
+            // Multi-byte UTF-8 names are truncated by byte length, not char count.
+            // Each emoji is 4 UTF-8 bytes; 51 emojis = 204 bytes > 200 byte limit.
+            const longEmoji = '\u{1F600}'.repeat(51); // 51 x 4 = 204 bytes
+            const h5 = await backend.createWriteHandle(longEmoji, 1);
+            await h5.write(chunk([1]));
+            await h5.finalize();
+            const names = await entryNames();
+            const emojiEntry = names.find((n) => n.startsWith('4-'));
+            expect(emojiEntry).toBeDefined();
+            // Should be truncated to at most 200 UTF-8 bytes (50 emojis = 200 bytes).
+            const encoder = new TextEncoder();
+            const sanitized = emojiEntry!.slice(2); // strip "4-" prefix
+            expect(encoder.encode(sanitized).byteLength).toBeLessThanOrEqual(200);
+            expect(encoder.encode(sanitized).byteLength).toBeGreaterThan(0);
+
+            await backend.dispose();
+        });
+
+        it('handles concurrent writes to different files', async () => {
+            const backend = await OpfsStorageBackend.create(mockOpfsRoot, 'sess-concurrent');
+
+            const h1 = await backend.createWriteHandle('a.bin', 2);
+            const h2 = await backend.createWriteHandle('b.bin', 2);
+
+            await h1.write(chunk([1, 2]));
+            await h2.write(chunk([3, 4]));
+
+            const b1 = await h1.finalize();
+            const b2 = await h2.finalize();
+
+            expect(await blobToBytes(b1)).toEqual(new Uint8Array([1, 2]));
+            expect(await blobToBytes(b2)).toEqual(new Uint8Array([3, 4]));
+
+            await backend.dispose();
+        });
+
+        it('generates unique entry names for duplicate file names', async () => {
+            const backend = await OpfsStorageBackend.create(mockOpfsRoot, 'sess-dup');
+
+            // Two downloads of the same file name should not collide
+            const h1 = await backend.createWriteHandle('same.bin', 1);
+            const h2 = await backend.createWriteHandle('same.bin', 1);
+
+            await h1.write(chunk([10]));
+            await h2.write(chunk([20]));
+
+            const b1 = await h1.finalize();
+            const b2 = await h2.finalize();
+
+            // They should be independent
+            expect(await blobToBytes(b1)).toEqual(new Uint8Array([10]));
+            expect(await blobToBytes(b2)).toEqual(new Uint8Array([20]));
+
+            await backend.dispose();
+        });
+    });
+
+    describe('stale session cleanup', () => {
+        it('removes session directories older than 24 hours on create', async () => {
+            // Pre-populate ironrdp-transfers/ with stale and fresh entries.
+            const transfersDir = await mockOpfsRoot.getDirectoryHandle('ironrdp-transfers', { create: true });
+
+            const staleTimestamp = Date.now() - 25 * 60 * 60 * 1000; // 25 hours ago
+            const freshTimestamp = Date.now() - 1 * 60 * 60 * 1000; // 1 hour ago
+            const staleId = `s-${staleTimestamp}-abc123`;
+            const freshId = `s-${freshTimestamp}-def456`;
+
+            await transfersDir.getDirectoryHandle(staleId, { create: true });
+            await transfersDir.getDirectoryHandle(freshId, { create: true });
+
+            // Creating a new backend triggers cleanupStale (fire-and-forget).
+            const backend = await OpfsStorageBackend.create(mockOpfsRoot, `s-${Date.now()}-new000`);
+            await new Promise((r) => setTimeout(r, 10));
+
+            // The stale directory should have been removed.
+            let staleExists = true;
+            try {
+                await transfersDir.getDirectoryHandle(staleId);
+            } catch {
+                staleExists = false;
+            }
+            expect(staleExists).toBe(false);
+
+            // The fresh directory should still exist.
+            const freshDir = await transfersDir.getDirectoryHandle(freshId);
+            expect(freshDir.name).toBe(freshId);
+
+            await backend.dispose();
+        });
+
+        it('skips directories with unparsable names', async () => {
+            const transfersDir = await mockOpfsRoot.getDirectoryHandle('ironrdp-transfers', { create: true });
+
+            // Non-matching names should be left alone.
+            await transfersDir.getDirectoryHandle('custom-dir', { create: true });
+
+            const backend = await OpfsStorageBackend.create(mockOpfsRoot, `s-${Date.now()}-test00`);
+            await new Promise((r) => setTimeout(r, 10));
+
+            const customDir = await transfersDir.getDirectoryHandle('custom-dir');
+            expect(customDir.name).toBe('custom-dir');
+
+            await backend.dispose();
+        });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// detectStorageBackend
+// ---------------------------------------------------------------------------
+
+describe('detectStorageBackend', () => {
+    const originalNavigator = globalThis.navigator;
+
+    afterEach(() => {
+        // Restore navigator after each test
+        Object.defineProperty(globalThis, 'navigator', {
+            value: originalNavigator,
+            writable: true,
+            configurable: true,
+        });
+    });
+
+    it('returns BlobStorageBackend when preference is "blob"', async () => {
+        const backend = await detectStorageBackend('blob');
+        expect(backend.name).toBe('blob');
+    });
+
+    it('returns BlobStorageBackend when navigator.storage is unavailable', async () => {
+        Object.defineProperty(globalThis, 'navigator', {
+            value: {},
+            writable: true,
+            configurable: true,
+        });
+
+        const backend = await detectStorageBackend('auto');
+        expect(backend.name).toBe('blob');
+    });
+
+    it('returns BlobStorageBackend when getDirectory throws', async () => {
+        Object.defineProperty(globalThis, 'navigator', {
+            value: {
+                storage: {
+                    getDirectory: () => Promise.reject(new Error('SecurityError')),
+                },
+            },
+            writable: true,
+            configurable: true,
+        });
+
+        const backend = await detectStorageBackend('auto');
+        expect(backend.name).toBe('blob');
+    });
+
+    it('defaults to auto when no preference given', async () => {
+        Object.defineProperty(globalThis, 'navigator', {
+            value: {},
+            writable: true,
+            configurable: true,
+        });
+
+        const backend = await detectStorageBackend();
+        expect(backend.name).toBe('blob');
+    });
+
+    it('returns BlobStorageBackend when OPFS probe fails', async () => {
+        // getDirectory() succeeds, but createWritable() throws inside probe().
+        const brokenRoot = {
+            ...createMockDirectoryHandle(''),
+            async getFileHandle() {
+                return {
+                    async createWritable() {
+                        throw new Error('SecurityError');
+                    },
+                } as unknown as FileSystemFileHandle;
+            },
+        } as unknown as FileSystemDirectoryHandle;
+
+        Object.defineProperty(globalThis, 'navigator', {
+            value: {
+                storage: {
+                    getDirectory: () => Promise.resolve(brokenRoot),
+                },
+            },
+            writable: true,
+            configurable: true,
+        });
+
+        const backend = await detectStorageBackend('auto');
+        expect(backend.name).toBe('blob');
+    });
+
+    it('returns OpfsStorageBackend when OPFS is available', async () => {
+        const mockRoot = createMockDirectoryHandle('');
+        Object.defineProperty(globalThis, 'navigator', {
+            value: {
+                storage: {
+                    getDirectory: () => Promise.resolve(mockRoot),
+                },
+            },
+            writable: true,
+            configurable: true,
+        });
+
+        const backend = await detectStorageBackend('auto');
+        expect(backend.name).toBe('opfs');
+        await backend.dispose();
+    });
+});


### PR DESCRIPTION
Right now, `RdpFileTransferProvider` accumulates every download chunk in a `Uint8Array[]` in memory. For a 500 MB file, that means ~1 GB of RAM (the chunks plus the final Blob copy). This PR introduces a `FileStorageBackend` abstraction with two implementations so we can do better when the browser supports it.

### What's new

**`BlobStorageBackend`** - wraps the existing in-memory chunk accumulation behind the new interface. This is the universal fallback and behaves identically to the old code path.

**`OpfsStorageBackend`** - streams download chunks directly to the [Origin Private File System](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API/Origin_private_file_system) via `FileSystemWritableFileStream`. Peak RAM drops from ~2x file size to roughly one chunk (~64 KB). On finalize, `getFile()` returns a lazy `File` handle backed by disk -- no bulk read into memory.

**Automatic detection** - by default, the first download triggers an OPFS probe (create file, open writable, close, delete). If it works, OPFS is used for the session. If not, Blob kicks in silently. Consumers can also force a backend via the new `storageBackend` option on `RdpFileTransferProviderOptions`:

```typescript
// Auto-detect (default)
new RdpFileTransferProvider({ storageBackend: 'auto' })

// Force in-memory
new RdpFileTransferProvider({ storageBackend: 'blob' })

// Bring your own backend
new RdpFileTransferProvider({ storageBackend: myCustomBackend })
```

### OPFS housekeeping

- Each session gets its own subdirectory under `ironrdp-transfers/` in the OPFS root.
- On startup, stale session directories older than 24 hours (from crashed tabs, etc.) are cleaned up in the background.
- On dispose, the session directory is deleted recursively. If that fails, individual files are cleaned up as a fallback.
- Quota exhaustion surfaces as an actionable error on the download, not a silent failure.

### Browser support

The writable stream APIs this depends on reached Baseline across all major browsers in September 2025 (Chrome 86+, Firefox 111+, Safari 17.2+, Edge 86+). Older browsers get the Blob fallback automatically via the probe -- no breakage.

### API surface

All new types are re-exported from the package entry point:

- `FileStorageBackend` (interface)
- `FileWriteHandle` (interface)
- `StorageBackendPreference` (type: `'auto' | 'blob'`)
- `BlobStorageBackend` (class)
- `OpfsStorageBackend` (class)
- `detectStorageBackend` (function)

The only change to the existing public API is the new optional `storageBackend` field on `RdpFileTransferProviderOptions`. No breaking changes.

## Testing

97 tests covering both backends, detection/fallback logic, download flow integration, sanitization of adversarial file names, dispose/abort lifecycle edge cases, and error paths (quota, timeouts, init failures). No new runtime dependencies.