### PR TITLE
feat(connector): advertise BPP16 fallback alongside BPP24

### DIFF
--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -648,10 +648,15 @@ fn create_gcc_blocks<'a>(
 
     let max_color_depth = config.bitmap.as_ref().map(|bitmap| bitmap.color_depth).unwrap_or(32);
 
+    // Always advertise BPP16 alongside the requested depth so the server can
+    // negotiate down if it doesn't support the preferred depth. Without a
+    // fallback, modern Windows hosts (which dropped BPP24 RDP support) reset
+    // the connection rather than negotiate, leaving xrdp-friendly clients
+    // stuck choosing between "works on Windows" and "smooth on xrdp".
     let supported_color_depths = match max_color_depth {
         15 => SupportedColorDepths::BPP15,
         16 => SupportedColorDepths::BPP16,
-        24 => SupportedColorDepths::BPP24,
+        24 => SupportedColorDepths::BPP24 | SupportedColorDepths::BPP16,
         32 => SupportedColorDepths::BPP32 | SupportedColorDepths::BPP16,
         _ => {
             return Err(reason_err!(

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -652,9 +652,11 @@ fn create_gcc_blocks<'a>(
     // negotiate down if it doesn't support the preferred depth. Without a
     // fallback, modern Windows hosts (which dropped BPP24 RDP support) reset
     // the connection rather than negotiate, leaving xrdp-friendly clients
-    // stuck choosing between "works on Windows" and "smooth on xrdp".
+    // stuck choosing between "works on Windows" and "smooth on xrdp". BPP15
+    // gets the same treatment for consistency — historic clients targeting
+    // 15bpp shouldn't fail outright on a server that only does 16bpp.
     let supported_color_depths = match max_color_depth {
-        15 => SupportedColorDepths::BPP15,
+        15 => SupportedColorDepths::BPP15 | SupportedColorDepths::BPP16,
         16 => SupportedColorDepths::BPP16,
         24 => SupportedColorDepths::BPP24 | SupportedColorDepths::BPP16,
         32 => SupportedColorDepths::BPP32 | SupportedColorDepths::BPP16,


### PR DESCRIPTION
## Summary

When a client requests `BitmapConfig::color_depth = 24`, `create_gcc_blocks` advertises `supportedColorDepths = BPP24` only. Modern Windows hosts (Windows 8 / Server 2012 onward dropped BPP24 RDP support) reset the connection during the early capability exchange rather than negotiating down — there's no fallback to pick.

The existing BPP32 case at the next match arm already pairs the preferred depth with `BPP16` as a safety net. This PR brings the BPP24 case in line with that pattern.

## Diff

```diff
-        24 => SupportedColorDepths::BPP24,
+        24 => SupportedColorDepths::BPP24 | SupportedColorDepths::BPP16,
```

## Why this matters

A common configuration is "client prefers 24bpp because the target is xrdp (where 24bpp is the smooth path), but the same client may sometimes connect to Windows." Today these cases are mutually exclusive: choose 24bpp and Windows ConnectionResets; choose 32bpp and xrdp returns a black screen (xrdp's 32bpp encoding uses a custom RLE variant ironrdp can't decode). After this change, a 24bpp profile works on both — Windows silently picks BPP16 from the offered set, xrdp picks BPP24.

## Reported via

Originally surfaced in [GlassHaven/Haven#109](https://github.com/GlassHaven/Haven/issues/109) where users get:

```
RDP connect finalize failed: Error { context: "read frame by hint", kind: Custom, source: Some(Os { code: 104, kind: ConnectionReset, message: "Connection reset by peer" }) }
```

against Windows Server 2025 with their RDP profile set to 24-bit colour depth.

## Test plan

- [x] `cargo build -p ironrdp-connector` clean
- [x] `cargo test -p ironrdp-connector` clean (crate has no unit tests; nothing regressed)
- [ ] Live verification against Windows Server 2025 with patched binary — pending. Diagnosis is from reading the connector's GCC-block construction; the change mirrors the existing BPP32 pattern, so the surface-level confidence is high. Happy to add a unit test asserting the match-arm behaviour if desired.

## Out of scope

`high_color_depth` is hardcoded to `Bpp24` for all non-32 cases. That's actually correct per [MS-RDPBCGR §2.2.1.3.2](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/00f1da4a-ee9c-421a-852f-c19f92343d73) — the spec doesn't define a 32-value for `highColorDepth`; 32bpp negotiation uses the `WANT_32_BPP_SESSION` bit in `earlyCapabilityFlags` (which `create_gcc_blocks` already sets correctly). Not changing here.