### PR TITLE
fix(connector): surface actual PDU type when an unexpected Share Control PDU arrives

### DIFF
--- a/crates/ironrdp-connector/src/connection_activation.rs
+++ b/crates/ironrdp-connector/src/connection_activation.rs
@@ -6,6 +6,7 @@ use tracing::{debug, warn};
 
 use crate::{
     Config, ConnectionFinalizationSequence, ConnectorResult, DesktopSize, Sequence, State, Written, general_err, legacy,
+    reason_err,
 };
 
 /// Represents the Capability Exchange and Connection Finalization phases
@@ -122,8 +123,10 @@ impl Sequence for ConnectionActivationSequence {
                 {
                     server_demand_active.pdu.capability_sets
                 } else {
-                    return Err(general_err!(
-                        "unexpected Share Control Pdu (expected ServerDemandActive)",
+                    return Err(reason_err!(
+                        "ConnectionActivation::CapabilitiesExchange",
+                        "unexpected Share Control PDU during capabilities exchange: got {} (expected Server Demand Active PDU)",
+                        share_control_ctx.pdu.as_short_name(),
                     ));
                 };
 

--- a/crates/ironrdp-connector/src/connection_activation.rs
+++ b/crates/ironrdp-connector/src/connection_activation.rs
@@ -5,8 +5,8 @@ use ironrdp_pdu::rdp::capability_sets::CapabilitySet;
 use tracing::{debug, warn};
 
 use crate::{
-    Config, ConnectionFinalizationSequence, ConnectorResult, DesktopSize, Sequence, State, Written, general_err, legacy,
-    reason_err,
+    Config, ConnectionFinalizationSequence, ConnectorResult, DesktopSize, Sequence, State, Written, general_err,
+    legacy, reason_err,
 };
 
 /// Represents the Capability Exchange and Connection Finalization phases

--- a/crates/ironrdp-connector/src/legacy.rs
+++ b/crates/ironrdp-connector/src/legacy.rs
@@ -6,7 +6,7 @@ use ironrdp_pdu::rdp::headers::{BASIC_SECURITY_HEADER_SIZE, BasicSecurityHeaderF
 use ironrdp_pdu::rdp::multitransport::MultitransportRequestPdu;
 use ironrdp_pdu::x224::X224;
 
-use crate::{ConnectorError, ConnectorErrorExt as _, ConnectorResult, general_err, reason_err};
+use crate::{ConnectorError, ConnectorErrorExt as _, ConnectorResult, reason_err};
 
 pub fn encode_send_data_request<T>(
     initiator_id: u16,
@@ -149,8 +149,10 @@ pub fn decode_share_data(ctx: SendDataIndicationCtx<'_>) -> ConnectorResult<Shar
     let ctx = decode_share_control(ctx)?;
 
     let rdp::headers::ShareControlPdu::Data(share_data_header) = ctx.pdu else {
-        return Err(general_err!(
-            "received unexpected Share Control Pdu (expected Share Data Header)"
+        return Err(reason_err!(
+            "decode_share_data",
+            "received unexpected Share Control PDU: got {} (expected Data PDU)",
+            ctx.pdu.as_short_name(),
         ));
     };
 
@@ -210,8 +212,10 @@ pub fn decode_io_channel(ctx: SendDataIndicationCtx<'_>) -> ConnectorResult<IoCh
 
             Ok(IoChannelPdu::Data(share_data_ctx))
         }
-        _ => Err(general_err!(
-            "received unexpected Share Control Pdu (expected Share Data Header or Server Deactivate All)"
+        other => Err(reason_err!(
+            "decode_io_channel",
+            "received unexpected Share Control PDU: got {} (expected Data PDU or Server Deactivate All PDU)",
+            other.as_short_name(),
         )),
     }
 }


### PR DESCRIPTION
Closes part of #1232.

## Why

Three error sites in the connector previously printed only the *expected* PDU type, dropping the actual type the server sent on the floor. That made interop bugs harder to diagnose than necessary.

Concrete case from #1232 (originally surfaced via [Haven#109](https://github.com/GlassHaven/Haven/issues/109) on a GNOME Remote Desktop server): when a client connects to GRD without advertising EGFX, GRD's \`freerdp_peer::Capabilities()\` callback fails — confirmed via journalctl on the server:

\`\`\`
gnome-remote-desktop-daemon: [RDP] Client did not advertise support for the Graphics Pipeline, closing connection
[ERROR] [rdp_peer_handle_state_demand_active]: 
  [CONNECTION_STATE_CAPABILITIES_EXCHANGE_DEMAND_ACTIVE] freerdp_peer::Capabilities() callback failed
\`\`\`

GRD then sends a Server Deactivate All PDU instead of Server Demand Active. The connector saw \`ServerDeactivateAll\`, didn't match \`ServerDemandActive\`, and reported \"unexpected Share Control Pdu (expected ServerDemandActive)\" — with no hint that the server had sent Deactivate All (which itself is a strong signal the server gave up during caps validation, e.g. because of a missing capability).

## What

Replaces three \`general_err!\` sites in the connector with \`reason_err!\` calls that include \`pdu.as_short_name()\` (the helper already exists on \`ShareControlPdu\`):

| File | Function | Diagnosis context |
|---|---|---|
| \`connection_activation.rs:125\` | \`ConnectionActivation::CapabilitiesExchange\` | server's reply to \`ConfirmActive\` |
| \`legacy.rs:152\` | \`decode_share_data\` | wraps \`decode_share_control\` for callers expecting Data |
| \`legacy.rs:213\` | \`decode_io_channel\` | I/O channel dispatcher for the session loop |

Now diagnoses look like:

> unexpected Share Control PDU during capabilities exchange: got Server Deactivate All PDU (expected Server Demand Active PDU)

vs. the previous:

> unexpected Share Control Pdu (expected ServerDemandActive)

which immediately points at GRD-style \"I rejected your caps and deactivated the share\" rather than leaving callers to guess from network traces.

## Scope

- No behavior change beyond the error string.
- Existing matches on \`ServerDemandActive\` / \`Data\` / \`ServerDeactivateAll\` continue to dispatch the same way.
- The wider EGFX-as-client work (so IronRDP-based clients can actually interop with GRD instead of just diagnosing the failure better) is a much larger separate effort — flagged in the issue thread.

## Verification

- \`cargo build -p ironrdp-connector\` clean.
- \`cargo clippy -p ironrdp-connector\` clean (no new warnings; pre-existing duplicates persist).
- \`cargo test -p ironrdp-connector --lib\` — 0 tests in the lib, no regressions.
- No tests grep for the old error strings.