### PR TITLE
feat(server): handle SuppressOutput, RefreshRectangle, FrameAcknowledge PDUs

### DIFF
--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -11,6 +11,7 @@ use ironrdp_cliprdr::backend::ClipboardMessage;
 use ironrdp_core::{decode, encode_vec, impl_as_any};
 use ironrdp_displaycontrol::pdu::DisplayControlMonitorLayout;
 use ironrdp_displaycontrol::server::{DisplayControlHandler, DisplayControlServer};
+use ironrdp_pdu::geometry::InclusiveRectangle;
 use ironrdp_pdu::input::InputEventPdu;
 use ironrdp_pdu::input::fast_path::{FastPathInput, FastPathInputEvent};
 use ironrdp_pdu::mcs::{SendDataIndication, SendDataRequest};
@@ -58,11 +59,12 @@ pub enum PostConnectionAction {
 /// Hooks for connection lifecycle events in [`RdpServer::run`].
 ///
 /// Implement this trait to add pre-accept filtering (rate limiting,
-/// IP allowlists) and post-disconnect logic (cleanup, session validity
-/// checks, metrics).
+/// IP allowlists), post-disconnect logic (cleanup, session validity
+/// checks, metrics), and per-connection responses to client share-data
+/// PDUs that the server core does not consume directly.
 ///
-/// All methods have default implementations that accept all connections
-/// and continue unconditionally.
+/// All methods have default implementations that accept all connections,
+/// continue unconditionally, and ignore client share-data signals.
 pub trait ConnectionHandler: Send {
     /// Called after `accept()` returns but before `run_connection()`.
     ///
@@ -84,6 +86,50 @@ pub trait ConnectionHandler: Send {
     ) -> PostConnectionAction {
         let _ = (peer, duration, error);
         PostConnectionAction::Continue
+    }
+
+    /// Called when the client sends a [Suppress Output PDU][2.2.11.3].
+    ///
+    /// `allow` is `true` when the client wants display updates resumed
+    /// and `false` when it wants them suspended (typically because the
+    /// client window is minimized or fully occluded). When `allow` is
+    /// `true`, `desktop_rect` carries the region the client wants
+    /// updates within; when `allow` is `false`, `desktop_rect` is `None`.
+    ///
+    /// The server core does not act on this PDU. Implementations should
+    /// pause their capture pipeline when `allow` is `false` and resume
+    /// when it is `true`, to save bandwidth and CPU.
+    ///
+    /// [2.2.11.3]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/47b1ace4-f2ba-4d11-93ed-c0e1c8e62221
+    fn on_suppress_output(&mut self, allow: bool, desktop_rect: Option<&InclusiveRectangle>) {
+        let _ = (allow, desktop_rect);
+    }
+
+    /// Called when the client sends a [Refresh Rectangle PDU][2.2.11.2].
+    ///
+    /// `areas` is the list of regions the client is asking the server to
+    /// retransmit. Typical triggers include unminimize, restore from
+    /// occlusion, and explicit user-driven refresh.
+    ///
+    /// The server core does not act on this PDU. Implementations should
+    /// invalidate the listed regions in their capture pipeline so the
+    /// next encoded frame includes them.
+    ///
+    /// [2.2.11.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/15679f83-0e1e-4a36-a4e6-3cb7b6e0a6ce
+    fn on_refresh_rectangle(&mut self, areas: &[InclusiveRectangle]) {
+        let _ = areas;
+    }
+
+    /// Called when the client sends a slow-path Frame Acknowledge PDU.
+    ///
+    /// `frame_id` is the most recently rendered frame the client has
+    /// acknowledged. Implementations can use this for slow-path flow
+    /// control to limit unacknowledged in-flight frames.
+    ///
+    /// EGFX (graphics pipeline) Frame Acknowledge is delivered through
+    /// the dynamic virtual channel, not this trait.
+    fn on_frame_acknowledge(&mut self, frame_id: u32) {
+        let _ = frame_id;
     }
 }
 
@@ -1140,6 +1186,34 @@ impl RdpServer {
                         } else {
                             trace!(seq = response.sequence_number(), "Unmatched auto-detect response");
                         }
+                    }
+                }
+
+                rdp::headers::ShareDataPdu::SuppressOutput(pdu) => {
+                    let allow = pdu.desktop_rect.is_some();
+                    if let Some(ref mut handler) = self.connection_handler {
+                        handler.on_suppress_output(allow, pdu.desktop_rect.as_ref());
+                    } else {
+                        trace!(allow, "Suppress Output PDU (no handler installed)");
+                    }
+                }
+
+                rdp::headers::ShareDataPdu::RefreshRectangle(pdu) => {
+                    if let Some(ref mut handler) = self.connection_handler {
+                        handler.on_refresh_rectangle(&pdu.areas_to_refresh);
+                    } else {
+                        trace!(
+                            count = pdu.areas_to_refresh.len(),
+                            "Refresh Rectangle PDU (no handler installed)"
+                        );
+                    }
+                }
+
+                rdp::headers::ShareDataPdu::FrameAcknowledge(pdu) => {
+                    if let Some(ref mut handler) = self.connection_handler {
+                        handler.on_frame_acknowledge(pdu.frame_id);
+                    } else {
+                        trace!(frame_id = pdu.frame_id, "Frame Acknowledge PDU (no handler installed)");
                     }
                 }
 


### PR DESCRIPTION
## Summary

These three slow-path share-data PDUs are well-defined parts of MS-RDPBCGR and modern Windows clients send them routinely, but the server core has been logging them as `Unexpected share data pdu` and dropping them on the floor:

- **SuppressOutput** ([2.2.11.3]): client signals it does not want display updates while minimized or fully occluded.
- **RefreshRectangle** ([2.2.11.2]): client asks the server to retransmit specific regions, typically after unminimize.
- **FrameAcknowledge** (slow-path): legacy flow-control acknowledgment for non-EGFX update paths.

This PR adds three default-implementation methods to `ConnectionHandler` so server consumers can react to these signals (pause capture, mark regions dirty, throttle frame rate). Default impls ignore the PDU, preserving current behavior for consumers that have not opted in.

## Why a `ConnectionHandler` extension rather than internal handling

The right behavior for SuppressOutput is to stop encoding frames at the capture source, not the wire. RefreshRectangle similarly needs to invalidate at the capture layer. The server core does not own the capture pipeline; the consumer (via `RdpServerDisplay` and friends) does. Putting hooks on the existing lifecycle trait keeps the consumer in control while the server core stops dropping useful signals.

The slow-path FrameAcknowledge is independent of EGFX's own DVC-channel FrameAcknowledge handled by `ironrdp-egfx`. Documented in the doc-comment to avoid confusion.

## Adjacent work

@maurerdietmar has a `add-server-session-handler-trait` branch in his fork (not yet a PR) that proposes a similar `RdpServerSessionHandler` trait with `connect()`, `disconnect()`, and `suppress_output(allow: bool)` callbacks. The shapes are different (this PR extends the existing `ConnectionHandler` rather than introducing a new trait, and passes the `desktop_rect` through rather than collapsing to a bool) but the underlying need is the same. Happy to align on naming or structure if @maurerdietmar prefers his shape, this PR is the smallest change that closes the dropped-PDU gap.

## Coordinates with #1244

#1244 changes the signature of `ConnectionHandler::on_disconnected` (from `Option<&anyhow::Error>` to `Option<&ServerError>`) as part of the typed-error migration (#1242 / #1209). The three new methods this PR adds are independent of `on_disconnected` and unaffected by that signature change. Either PR can land first; whichever lands second is a trivial rebase to the new trait shape.

## Test plan

- [x] `cargo xtask check fmt -v` clean
- [x] `cargo xtask check lints -v` clean (workspace, all-targets, with helper + __bench features)
- [x] `cargo xtask check tests -v` passes
- [ ] Manual smoke against mstsc (suppress output observed when minimizing the RDP window) is downstream test plan; consumer of `ConnectionHandler` decides what to do with the signal.

## Out of scope

Spec-compliant behavior for the three PDUs (actually pausing capture under SuppressOutput, marking regions dirty under RefreshRectangle, throttling under FrameAcknowledge) lives in the consumer. This PR is "stop dropping the signal," not "implement the behavior."

[2.2.11.3]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/47b1ace4-f2ba-4d11-93ed-c0e1c8e62221
[2.2.11.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/15679f83-0e1e-4a36-a4e6-3cb7b6e0a6ce