### PR TITLE
feat(server)!: introduce typed ServerError on the public API boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2912,6 +2912,7 @@ dependencies = [
  "ironrdp-dvc",
  "ironrdp-echo",
  "ironrdp-egfx",
+ "ironrdp-error 0.2.0",
  "ironrdp-graphics",
  "ironrdp-nscodec",
  "ironrdp-pdu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3270,6 +3270,7 @@ dependencies = [
  "ironrdp-dvc",
  "ironrdp-echo",
  "ironrdp-egfx",
+ "ironrdp-error 0.2.0",
  "ironrdp-graphics",
  "ironrdp-nscodec",
  "ironrdp-pdu",

--- a/crates/ironrdp-server/Cargo.toml
+++ b/crates/ironrdp-server/Cargo.toml
@@ -42,6 +42,7 @@ ironrdp-async = { path = "../ironrdp-async", version = "0.10" }
 ironrdp-ainput = { path = "../ironrdp-ainput", version = "0.8" }
 ironrdp-core = { path = "../ironrdp-core", version = "0.2" }
 ironrdp-egfx = { path = "../ironrdp-egfx", version = "0.3", optional = true }
+ironrdp-error = { path = "../ironrdp-error", version = "0.2", features = ["std"] } # public
 ironrdp-nscodec = { path = "../ironrdp-nscodec", version = "0.2", optional = true, features = ["encoder"] }
 ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9" } # public
 ironrdp-svc = { path = "../ironrdp-svc", version = "0.8" } # public

--- a/crates/ironrdp-server/Cargo.toml
+++ b/crates/ironrdp-server/Cargo.toml
@@ -43,6 +43,7 @@ ironrdp-async = { path = "../ironrdp-async", version = "0.10" }
 ironrdp-ainput = { path = "../ironrdp-ainput", version = "0.8" }
 ironrdp-core = { path = "../ironrdp-core", version = "0.2" }
 ironrdp-egfx = { path = "../ironrdp-egfx", version = "0.3", optional = true }
+ironrdp-error = { path = "../ironrdp-error", version = "0.2", features = ["std"] } # public
 ironrdp-nscodec = { path = "../ironrdp-nscodec", version = "0.2", optional = true, features = ["encoder"] }
 ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9" } # public
 ironrdp-svc = { path = "../ironrdp-svc", version = "0.8" } # public

--- a/crates/ironrdp-server/src/echo.rs
+++ b/crates/ironrdp-server/src/echo.rs
@@ -3,13 +3,14 @@ use std::collections::{BTreeMap, VecDeque};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Instant;
 
-use anyhow::{Context as _, Result, bail};
+use anyhow::{Context as _, Result};
 use ironrdp_core::impl_as_any;
 use ironrdp_dvc::{DvcMessage, DvcProcessor, DvcServerProcessor};
 use ironrdp_echo::server::EchoServer;
 use ironrdp_pdu::PduResult;
 use tokio::sync::mpsc;
 
+use crate::error::{ServerError, ServerErrorExt as _, ServerResult};
 use crate::server::ServerEvent;
 
 #[derive(Debug, Clone)]
@@ -55,14 +56,14 @@ impl EchoServerHandle {
     /// Sends a runtime ECHO request.
     ///
     /// The payload must be at least one byte, as required by MS-RDPEECO section 3.1.5.1.
-    pub fn send_request(&self, payload: Vec<u8>) -> Result<()> {
+    pub fn send_request(&self, payload: Vec<u8>) -> ServerResult<()> {
         if payload.is_empty() {
-            bail!("echoRequest payload must be at least one byte");
+            return Err(ServerError::reason("echo request", "payload must be at least one byte"));
         }
 
         self.sender
             .send(ServerEvent::Echo(EchoServerMessage::SendRequest { payload }))
-            .map_err(|_error| anyhow::anyhow!("send ECHO request event"))
+            .map_err(|_error| ServerError::channel("send ECHO request event"))
     }
 
     /// Drains collected RTT measurements.

--- a/crates/ironrdp-server/src/error.rs
+++ b/crates/ironrdp-server/src/error.rs
@@ -1,0 +1,209 @@
+//! Typed error types for the public API of the `ironrdp-server` crate.
+//!
+//! Mirrors the shape of [`ironrdp_connector::ConnectorError`]: a thin
+//! [`ironrdp_error::Error`] wrapper around a typed [`ServerErrorKind`] enum,
+//! with a static `&'static str` context and an opaque `source` for arbitrary
+//! upstream errors. The wrapper provides `with_source` so concrete errors
+//! from consumer-supplied components can be attached without forcing the
+//! variant taxonomy to encode every possible source type.
+//!
+//! See [#1209] for the migration discussion.
+//!
+//! [#1209]: https://github.com/Devolutions/IronRDP/issues/1209
+
+use core::fmt;
+use std::io;
+
+use ironrdp_core::{DecodeError, EncodeError};
+
+/// Categorizes the failure modes the server crate exposes through
+/// [`ServerError`].
+///
+/// Marked `#[non_exhaustive]` so additional variants do not constitute a
+/// breaking change.
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum ServerErrorKind {
+    /// PDU encoding failed.
+    Encode(EncodeError),
+    /// PDU decoding failed.
+    Decode(DecodeError),
+    /// I/O error during TLS setup, listener setup, or client communication.
+    Io(io::Error),
+    /// A required virtual channel was missing or a channel send failed.
+    /// The specific channel and failure mode is named in the [`ServerError`]
+    /// context.
+    Channel,
+    /// A feature requested by the client is not supported by this server.
+    /// The specific feature is named in the [`ServerError`] context.
+    Unsupported,
+    /// Generic failure with a runtime description. Prefer a specific variant.
+    Reason(String),
+    /// Catch-all with no specific cause. Prefer a specific variant.
+    General,
+    /// Custom failure with the actual source attached via
+    /// [`ironrdp_error::Error::with_source`].
+    Custom,
+}
+
+impl fmt::Display for ServerErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Encode(_) => write!(f, "encode error"),
+            Self::Decode(_) => write!(f, "decode error"),
+            Self::Io(_) => write!(f, "I/O error"),
+            Self::Channel => write!(f, "channel error"),
+            Self::Unsupported => write!(f, "unsupported"),
+            Self::Reason(reason) => write!(f, "reason: {reason}"),
+            Self::General => write!(f, "general error"),
+            Self::Custom => write!(f, "custom error"),
+        }
+    }
+}
+
+impl core::error::Error for ServerErrorKind {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::Encode(e) => Some(e),
+            Self::Decode(e) => Some(e),
+            Self::Io(e) => Some(e),
+            Self::Channel | Self::Unsupported | Self::Reason(_) | Self::General | Self::Custom => None,
+        }
+    }
+}
+
+/// Server-side failure type.
+///
+/// A typed alias of [`ironrdp_error::Error`] specialized to
+/// [`ServerErrorKind`]. The wrapper adds a static `&'static str` context and
+/// an optional opaque `source` to whichever kind of failure occurred.
+pub type ServerError = ironrdp_error::Error<ServerErrorKind>;
+
+/// Convenience alias for `Result<T, ServerError>`.
+pub type ServerResult<T> = Result<T, ServerError>;
+
+/// Constructors for [`ServerError`] that match the shape of
+/// [`ironrdp_connector::ConnectorErrorExt`].
+pub trait ServerErrorExt {
+    /// Build a [`ServerErrorKind::Encode`] error from an [`EncodeError`].
+    fn encode(error: EncodeError) -> Self;
+    /// Build a [`ServerErrorKind::Decode`] error from a [`DecodeError`].
+    fn decode(error: DecodeError) -> Self;
+    /// Build a [`ServerErrorKind::Io`] error with a static context and an
+    /// [`io::Error`] source.
+    fn io(context: &'static str, error: io::Error) -> Self;
+    /// Build a [`ServerErrorKind::Channel`] error with the channel name or
+    /// failure description carried in the context.
+    fn channel(context: &'static str) -> Self;
+    /// Build a [`ServerErrorKind::Unsupported`] error with the unsupported
+    /// feature named in the context.
+    fn unsupported(context: &'static str) -> Self;
+    /// Build a [`ServerErrorKind::General`] error with a static context.
+    fn general(context: &'static str) -> Self;
+    /// Build a [`ServerErrorKind::Reason`] error with a static context and a
+    /// runtime description.
+    fn reason(context: &'static str, reason: impl Into<String>) -> Self;
+    /// Build a [`ServerErrorKind::Custom`] error with a static context and an
+    /// arbitrary source.
+    fn custom<E>(context: &'static str, error: E) -> Self
+    where
+        E: core::error::Error + Sync + Send + 'static;
+}
+
+impl ServerErrorExt for ServerError {
+    fn encode(error: EncodeError) -> Self {
+        Self::new("encode error", ServerErrorKind::Encode(error))
+    }
+
+    fn decode(error: DecodeError) -> Self {
+        Self::new("decode error", ServerErrorKind::Decode(error))
+    }
+
+    fn io(context: &'static str, error: io::Error) -> Self {
+        Self::new(context, ServerErrorKind::Io(error))
+    }
+
+    fn channel(context: &'static str) -> Self {
+        Self::new(context, ServerErrorKind::Channel)
+    }
+
+    fn unsupported(context: &'static str) -> Self {
+        Self::new(context, ServerErrorKind::Unsupported)
+    }
+
+    fn general(context: &'static str) -> Self {
+        Self::new(context, ServerErrorKind::General)
+    }
+
+    fn reason(context: &'static str, reason: impl Into<String>) -> Self {
+        Self::new(context, ServerErrorKind::Reason(reason.into()))
+    }
+
+    fn custom<E>(context: &'static str, error: E) -> Self
+    where
+        E: core::error::Error + Sync + Send + 'static,
+    {
+        Self::new(context, ServerErrorKind::Custom).with_source(error)
+    }
+}
+
+/// Result-side helpers mirroring [`ironrdp_connector::ConnectorResultExt`].
+pub trait ServerResultExt {
+    /// Replace the `&'static str` context on any error in `Self`.
+    #[must_use]
+    fn with_context(self, context: &'static str) -> Self;
+    /// Attach a source to any error in `Self`.
+    #[must_use]
+    fn with_source<E>(self, source: E) -> Self
+    where
+        E: core::error::Error + Sync + Send + 'static;
+}
+
+impl<T> ServerResultExt for ServerResult<T> {
+    fn with_context(self, context: &'static str) -> Self {
+        self.map_err(|mut e| {
+            e.set_context(context);
+            e
+        })
+    }
+
+    fn with_source<E>(self, source: E) -> Self
+    where
+        E: core::error::Error + Sync + Send + 'static,
+    {
+        self.map_err(|e| e.with_source(source))
+    }
+}
+
+/// Bridges anyhow errors at the public API boundary while the migration to
+/// typed errors is staged.
+///
+/// Internal call sites still use `anyhow::Result`; conversion happens here so
+/// the public signatures can advertise [`ServerResult`] today without forcing
+/// every internal site to convert in this PR. PR #2 in the staged migration
+/// (see [#1209]) removes the remaining `anyhow` usage and this helper.
+///
+/// [#1209]: https://github.com/Devolutions/IronRDP/issues/1209
+pub(crate) fn from_anyhow(error: anyhow::Error) -> ServerError {
+    ServerError::new("server error", ServerErrorKind::Custom).with_source(AnyhowError(error))
+}
+
+/// Newtype wrapper that gives [`anyhow::Error`] a `core::error::Error` impl
+/// suitable for `ironrdp_error::Error::with_source`.
+#[derive(Debug)]
+struct AnyhowError(anyhow::Error);
+
+impl fmt::Display for AnyhowError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:#}", self.0)
+    }
+}
+
+impl core::error::Error for AnyhowError {
+    /// Forwards to the wrapped [`anyhow::Error`]'s cause chain so callers
+    /// traversing [`core::error::Error::source`] reach the original root
+    /// cause rather than stopping at this newtype.
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        self.0.source()
+    }
+}

--- a/crates/ironrdp-server/src/error.rs
+++ b/crates/ironrdp-server/src/error.rs
@@ -14,7 +14,7 @@
 use core::fmt;
 use std::io;
 
-use ironrdp_core::EncodeError;
+use ironrdp_core::{DecodeError, EncodeError};
 
 /// Categorizes the failure modes the server crate exposes through
 /// [`ServerError`].
@@ -26,6 +26,8 @@ use ironrdp_core::EncodeError;
 pub enum ServerErrorKind {
     /// PDU encoding failed.
     Encode(EncodeError),
+    /// PDU decoding failed.
+    Decode(DecodeError),
     /// I/O error during TLS setup, listener setup, or client communication.
     Io(io::Error),
     /// A required virtual channel was missing or a channel send failed.
@@ -46,6 +48,7 @@ impl fmt::Display for ServerErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Encode(_) => write!(f, "encode error"),
+            Self::Decode(_) => write!(f, "decode error"),
             Self::Io(_) => write!(f, "I/O error"),
             Self::Channel => write!(f, "channel error"),
             Self::Unsupported => write!(f, "unsupported"),
@@ -59,6 +62,7 @@ impl core::error::Error for ServerErrorKind {
     fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
             Self::Encode(e) => Some(e),
+            Self::Decode(e) => Some(e),
             Self::Io(e) => Some(e),
             Self::Channel | Self::Unsupported | Self::Reason(_) | Self::Custom => None,
         }
@@ -80,6 +84,8 @@ pub type ServerResult<T> = Result<T, ServerError>;
 pub trait ServerErrorExt {
     /// Build a [`ServerErrorKind::Encode`] error from an [`EncodeError`].
     fn encode(error: EncodeError) -> Self;
+    /// Build a [`ServerErrorKind::Decode`] error from a [`DecodeError`].
+    fn decode(error: DecodeError) -> Self;
     /// Build a [`ServerErrorKind::Io`] error with a static context and an
     /// [`io::Error`] source.
     fn io(context: &'static str, error: io::Error) -> Self;
@@ -103,6 +109,11 @@ impl ServerErrorExt for ServerError {
     #[track_caller]
     fn encode(error: EncodeError) -> Self {
         Self::new("encode error", ServerErrorKind::Encode(error))
+    }
+
+    #[track_caller]
+    fn decode(error: DecodeError) -> Self {
+        Self::new("decode error", ServerErrorKind::Decode(error))
     }
 
     #[track_caller]

--- a/crates/ironrdp-server/src/error.rs
+++ b/crates/ironrdp-server/src/error.rs
@@ -14,7 +14,7 @@
 use core::fmt;
 use std::io;
 
-use ironrdp_core::{DecodeError, EncodeError};
+use ironrdp_core::EncodeError;
 
 /// Categorizes the failure modes the server crate exposes through
 /// [`ServerError`].
@@ -26,8 +26,6 @@ use ironrdp_core::{DecodeError, EncodeError};
 pub enum ServerErrorKind {
     /// PDU encoding failed.
     Encode(EncodeError),
-    /// PDU decoding failed.
-    Decode(DecodeError),
     /// I/O error during TLS setup, listener setup, or client communication.
     Io(io::Error),
     /// A required virtual channel was missing or a channel send failed.
@@ -48,7 +46,6 @@ impl fmt::Display for ServerErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Encode(_) => write!(f, "encode error"),
-            Self::Decode(_) => write!(f, "decode error"),
             Self::Io(_) => write!(f, "I/O error"),
             Self::Channel => write!(f, "channel error"),
             Self::Unsupported => write!(f, "unsupported"),
@@ -62,7 +59,6 @@ impl core::error::Error for ServerErrorKind {
     fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
             Self::Encode(e) => Some(e),
-            Self::Decode(e) => Some(e),
             Self::Io(e) => Some(e),
             Self::Channel | Self::Unsupported | Self::Reason(_) | Self::Custom => None,
         }
@@ -84,8 +80,6 @@ pub type ServerResult<T> = Result<T, ServerError>;
 pub trait ServerErrorExt {
     /// Build a [`ServerErrorKind::Encode`] error from an [`EncodeError`].
     fn encode(error: EncodeError) -> Self;
-    /// Build a [`ServerErrorKind::Decode`] error from a [`DecodeError`].
-    fn decode(error: DecodeError) -> Self;
     /// Build a [`ServerErrorKind::Io`] error with a static context and an
     /// [`io::Error`] source.
     fn io(context: &'static str, error: io::Error) -> Self;
@@ -106,30 +100,32 @@ pub trait ServerErrorExt {
 }
 
 impl ServerErrorExt for ServerError {
+    #[track_caller]
     fn encode(error: EncodeError) -> Self {
         Self::new("encode error", ServerErrorKind::Encode(error))
     }
 
-    fn decode(error: DecodeError) -> Self {
-        Self::new("decode error", ServerErrorKind::Decode(error))
-    }
-
+    #[track_caller]
     fn io(context: &'static str, error: io::Error) -> Self {
         Self::new(context, ServerErrorKind::Io(error))
     }
 
+    #[track_caller]
     fn channel(context: &'static str) -> Self {
         Self::new(context, ServerErrorKind::Channel)
     }
 
+    #[track_caller]
     fn unsupported(context: &'static str) -> Self {
         Self::new(context, ServerErrorKind::Unsupported)
     }
 
+    #[track_caller]
     fn reason(context: &'static str, reason: impl Into<String>) -> Self {
         Self::new(context, ServerErrorKind::Reason(reason.into()))
     }
 
+    #[track_caller]
     fn custom<E>(context: &'static str, error: E) -> Self
     where
         E: core::error::Error + Sync + Send + 'static,
@@ -143,11 +139,6 @@ pub trait ServerResultExt {
     /// Replace the `&'static str` context on any error in `Self`.
     #[must_use]
     fn with_context(self, context: &'static str) -> Self;
-    /// Attach a source to any error in `Self`.
-    #[must_use]
-    fn with_source<E>(self, source: E) -> Self
-    where
-        E: core::error::Error + Sync + Send + 'static;
 }
 
 impl<T> ServerResultExt for ServerResult<T> {
@@ -157,17 +148,11 @@ impl<T> ServerResultExt for ServerResult<T> {
             e
         })
     }
-
-    fn with_source<E>(self, source: E) -> Self
-    where
-        E: core::error::Error + Sync + Send + 'static,
-    {
-        self.map_err(|e| e.with_source(source))
-    }
 }
 
-/// Bridges anyhow errors at the public API boundary while the migration to
-/// typed errors is staged.
+/// Bridges an anyhow error at the public API boundary while the migration to
+/// typed errors is staged, tagging it with `context` naming the operation
+/// that failed.
 ///
 /// Internal call sites still use `anyhow::Result`; conversion happens here so
 /// the public signatures can advertise [`ServerResult`] today without forcing
@@ -175,8 +160,9 @@ impl<T> ServerResultExt for ServerResult<T> {
 /// (see [#1209]) remove the remaining `anyhow` usage and this helper.
 ///
 /// [#1209]: https://github.com/Devolutions/IronRDP/issues/1209
-pub(crate) fn from_anyhow(error: anyhow::Error) -> ServerError {
-    ServerError::new("server error", ServerErrorKind::Custom).with_source(AnyhowError(error))
+#[track_caller]
+pub(crate) fn from_anyhow_with_context(error: anyhow::Error, context: &'static str) -> ServerError {
+    ServerError::new(context, ServerErrorKind::Custom).with_source(AnyhowError(error))
 }
 
 /// Newtype wrapper that gives [`anyhow::Error`] a `core::error::Error` impl

--- a/crates/ironrdp-server/src/error.rs
+++ b/crates/ironrdp-server/src/error.rs
@@ -1,6 +1,6 @@
 //! Typed error types for the public API of the `ironrdp-server` crate.
 //!
-//! Mirrors the shape of [`ironrdp_connector::ConnectorError`]: a thin
+//! Mirrors the shape of `ironrdp_connector::ConnectorError`: a thin
 //! [`ironrdp_error::Error`] wrapper around a typed [`ServerErrorKind`] enum,
 //! with a static `&'static str` context and an opaque `source` for arbitrary
 //! upstream errors. The wrapper provides `with_source` so concrete errors
@@ -39,8 +39,6 @@ pub enum ServerErrorKind {
     Unsupported,
     /// Generic failure with a runtime description. Prefer a specific variant.
     Reason(String),
-    /// Catch-all with no specific cause. Prefer a specific variant.
-    General,
     /// Custom failure with the actual source attached via
     /// [`ironrdp_error::Error::with_source`].
     Custom,
@@ -55,7 +53,6 @@ impl fmt::Display for ServerErrorKind {
             Self::Channel => write!(f, "channel error"),
             Self::Unsupported => write!(f, "unsupported"),
             Self::Reason(reason) => write!(f, "reason: {reason}"),
-            Self::General => write!(f, "general error"),
             Self::Custom => write!(f, "custom error"),
         }
     }
@@ -67,7 +64,7 @@ impl core::error::Error for ServerErrorKind {
             Self::Encode(e) => Some(e),
             Self::Decode(e) => Some(e),
             Self::Io(e) => Some(e),
-            Self::Channel | Self::Unsupported | Self::Reason(_) | Self::General | Self::Custom => None,
+            Self::Channel | Self::Unsupported | Self::Reason(_) | Self::Custom => None,
         }
     }
 }
@@ -83,7 +80,7 @@ pub type ServerError = ironrdp_error::Error<ServerErrorKind>;
 pub type ServerResult<T> = Result<T, ServerError>;
 
 /// Constructors for [`ServerError`] that match the shape of
-/// [`ironrdp_connector::ConnectorErrorExt`].
+/// `ironrdp_connector::ConnectorErrorExt`.
 pub trait ServerErrorExt {
     /// Build a [`ServerErrorKind::Encode`] error from an [`EncodeError`].
     fn encode(error: EncodeError) -> Self;
@@ -98,8 +95,6 @@ pub trait ServerErrorExt {
     /// Build a [`ServerErrorKind::Unsupported`] error with the unsupported
     /// feature named in the context.
     fn unsupported(context: &'static str) -> Self;
-    /// Build a [`ServerErrorKind::General`] error with a static context.
-    fn general(context: &'static str) -> Self;
     /// Build a [`ServerErrorKind::Reason`] error with a static context and a
     /// runtime description.
     fn reason(context: &'static str, reason: impl Into<String>) -> Self;
@@ -131,10 +126,6 @@ impl ServerErrorExt for ServerError {
         Self::new(context, ServerErrorKind::Unsupported)
     }
 
-    fn general(context: &'static str) -> Self {
-        Self::new(context, ServerErrorKind::General)
-    }
-
     fn reason(context: &'static str, reason: impl Into<String>) -> Self {
         Self::new(context, ServerErrorKind::Reason(reason.into()))
     }
@@ -147,7 +138,7 @@ impl ServerErrorExt for ServerError {
     }
 }
 
-/// Result-side helpers mirroring [`ironrdp_connector::ConnectorResultExt`].
+/// Result-side helpers mirroring `ironrdp_connector::ConnectorResultExt`.
 pub trait ServerResultExt {
     /// Replace the `&'static str` context on any error in `Self`.
     #[must_use]
@@ -180,8 +171,8 @@ impl<T> ServerResultExt for ServerResult<T> {
 ///
 /// Internal call sites still use `anyhow::Result`; conversion happens here so
 /// the public signatures can advertise [`ServerResult`] today without forcing
-/// every internal site to convert in this PR. PR #2 in the staged migration
-/// (see [#1209]) removes the remaining `anyhow` usage and this helper.
+/// every internal site to convert in this PR. Later steps of the migration
+/// (see [#1209]) remove the remaining `anyhow` usage and this helper.
 ///
 /// [#1209]: https://github.com/Devolutions/IronRDP/issues/1209
 pub(crate) fn from_anyhow(error: anyhow::Error) -> ServerError {
@@ -194,8 +185,12 @@ pub(crate) fn from_anyhow(error: anyhow::Error) -> ServerError {
 struct AnyhowError(anyhow::Error);
 
 impl fmt::Display for AnyhowError {
+    /// Prints only the outermost context. Anyhow's alternate form (`{:#}`)
+    /// would flatten the whole cause chain here, and since [`Self::source`]
+    /// exposes that same chain, every level below the outermost would then be
+    /// printed twice by `ErrorReport`.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:#}", self.0)
+        write!(f, "{}", self.0)
     }
 }
 

--- a/crates/ironrdp-server/src/helper.rs
+++ b/crates/ironrdp-server/src/helper.rs
@@ -9,6 +9,8 @@ use tokio_rustls::rustls::pki_types::pem::PemObject as _;
 use tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use tokio_rustls::{TlsAcceptor, rustls};
 
+use crate::error::{ServerResult, from_anyhow};
+
 pub struct TlsIdentityCtx {
     pub certs: Vec<CertificateDer<'static>>,
     pub priv_key: PrivateKeyDer<'static>,
@@ -19,7 +21,11 @@ impl TlsIdentityCtx {
     /// A constructor to create a `TlsIdentityCtx` from the given certificate and key paths.
     ///
     /// The file format can be either PEM (if the file extension ends with .pem) or DER.
-    pub fn init_from_paths(cert_path: &Path, key_path: &Path) -> anyhow::Result<Self> {
+    pub fn init_from_paths(cert_path: &Path, key_path: &Path) -> ServerResult<Self> {
+        Self::init_from_paths_inner(cert_path, key_path).map_err(from_anyhow)
+    }
+
+    fn init_from_paths_inner(cert_path: &Path, key_path: &Path) -> anyhow::Result<Self> {
         let certs = if cert_path.extension().is_some_and(|ext| ext == "pem") {
             CertificateDer::pem_file_iter(cert_path)
                 .with_context(|| format!("reading server cert `{cert_path:?}`"))?
@@ -62,7 +68,11 @@ impl TlsIdentityCtx {
         })
     }
 
-    pub fn make_acceptor(&self) -> anyhow::Result<TlsAcceptor> {
+    pub fn make_acceptor(&self) -> ServerResult<TlsAcceptor> {
+        self.make_acceptor_inner().map_err(from_anyhow)
+    }
+
+    fn make_acceptor_inner(&self) -> anyhow::Result<TlsAcceptor> {
         let mut server_config = rustls::ServerConfig::builder()
             .with_no_client_auth()
             .with_single_cert(self.certs.clone(), self.priv_key.clone_key())

--- a/crates/ironrdp-server/src/helper.rs
+++ b/crates/ironrdp-server/src/helper.rs
@@ -9,7 +9,7 @@ use tokio_rustls::rustls::pki_types::pem::PemObject as _;
 use tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use tokio_rustls::{TlsAcceptor, rustls};
 
-use crate::error::{ServerResult, from_anyhow};
+use crate::error::{ServerResult, from_anyhow_with_context};
 
 pub struct TlsIdentityCtx {
     pub certs: Vec<CertificateDer<'static>>,
@@ -22,7 +22,8 @@ impl TlsIdentityCtx {
     ///
     /// The file format can be either PEM (if the file extension ends with .pem) or DER.
     pub fn init_from_paths(cert_path: &Path, key_path: &Path) -> ServerResult<Self> {
-        Self::init_from_paths_inner(cert_path, key_path).map_err(from_anyhow)
+        Self::init_from_paths_inner(cert_path, key_path)
+            .map_err(|e| from_anyhow_with_context(e, "loading TLS identity"))
     }
 
     fn init_from_paths_inner(cert_path: &Path, key_path: &Path) -> anyhow::Result<Self> {
@@ -69,7 +70,8 @@ impl TlsIdentityCtx {
     }
 
     pub fn make_acceptor(&self) -> ServerResult<TlsAcceptor> {
-        self.make_acceptor_inner().map_err(from_anyhow)
+        self.make_acceptor_inner()
+            .map_err(|e| from_anyhow_with_context(e, "building TLS acceptor"))
     }
 
     fn make_acceptor_inner(&self) -> anyhow::Result<TlsAcceptor> {

--- a/crates/ironrdp-server/src/lib.rs
+++ b/crates/ironrdp-server/src/lib.rs
@@ -13,6 +13,7 @@ mod clipboard;
 mod display;
 mod echo;
 mod encoder;
+mod error;
 #[cfg(feature = "egfx")]
 mod gfx;
 mod handler;
@@ -27,6 +28,7 @@ pub use display::{
     RdpServerDisplayUpdates,
 };
 pub use echo::{EchoDvcBridge, EchoRoundTripMeasurement, EchoServerHandle, EchoServerMessage};
+pub use error::{ServerError, ServerErrorExt, ServerErrorKind, ServerResult, ServerResultExt};
 #[cfg(feature = "egfx")]
 pub use gfx::{EgfxServerMessage, GfxDvcBridge, GfxServerFactory, GfxServerHandle};
 pub use handler::{KeyboardEvent, MouseEvent, RdpServerInputHandler};

--- a/crates/ironrdp-server/src/lib.rs
+++ b/crates/ironrdp-server/src/lib.rs
@@ -13,6 +13,7 @@ mod clipboard;
 mod display;
 mod echo;
 mod encoder;
+mod error;
 #[cfg(feature = "egfx")]
 mod gfx;
 mod handler;
@@ -30,6 +31,7 @@ pub use display::{
     RdpServerDisplayUpdates,
 };
 pub use echo::{EchoDvcBridge, EchoRoundTripMeasurement, EchoServerHandle, EchoServerMessage};
+pub use error::{ServerError, ServerErrorExt, ServerErrorKind, ServerResult, ServerResultExt};
 #[cfg(feature = "egfx")]
 pub use gfx::{EgfxServerMessage, GfxDvcBridge, GfxServerFactory, GfxServerHandle};
 pub use handler::{KeyboardEvent, MouseButton, MouseEvent, RdpServerInputHandler};

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -51,7 +51,7 @@ use crate::clipboard::CliprdrServerFactory;
 use crate::display::{DisplayUpdate, RdpServerDisplay};
 use crate::echo::{EchoDvcBridge, EchoServerHandle, EchoServerMessage, build_echo_request};
 use crate::encoder::{UpdateEncoder, UpdateEncoderCodecs};
-use crate::error::{ServerResult, from_anyhow};
+use crate::error::{ServerResult, from_anyhow_with_context};
 #[cfg(feature = "egfx")]
 use crate::gfx::{EgfxServerMessage, GfxServerFactory};
 use crate::handler::RdpServerInputHandler;
@@ -1273,15 +1273,17 @@ impl RdpServer {
     where
         S: AsyncRead + AsyncWrite + Send + Sync + Unpin,
     {
-        self.run_connection_with_inner(stream, tls).await.map_err(from_anyhow)
+        self.run_connection_with_inner(stream, tls)
+            .await
+            .map_err(|e| from_anyhow_with_context(e, "running connection"))
     }
 
     /// The anyhow-returning body behind [`Self::run_connection_with`].
     ///
     /// Kept private and untyped only because the accept loop feeds its error to
-    /// [`ServerConnectionHandler::on_disconnected`], whose parameter is still
-    /// `Option<&anyhow::Error>`. Migrating that callback is tracked under #1209;
-    /// once it takes a `ServerError` this helper collapses into its caller.
+    /// [`ConnectionHandler::on_disconnected`], whose parameter is still
+    /// `Option<&anyhow::Error>`. #1244 migrates that callback and collapses this
+    /// helper into its caller once it takes a `ServerError`.
     async fn run_connection_with_inner<S>(&mut self, stream: S, tls: TransportTls) -> Result<()>
     where
         S: AsyncRead + AsyncWrite + Send + Sync + Unpin,
@@ -1408,7 +1410,9 @@ impl RdpServer {
     }
 
     pub async fn run(&mut self) -> ServerResult<()> {
-        self.run_inner().await.map_err(from_anyhow)
+        self.run_inner()
+            .await
+            .map_err(|e| from_anyhow_with_context(e, "running accept loop"))
     }
 
     async fn run_inner(&mut self) -> Result<()> {
@@ -1482,8 +1486,9 @@ impl RdpServer {
                         let started = tokio::time::Instant::now();
                         // Internal accept loop uses the anyhow-returning inner method so the
                         // existing `on_disconnected(error: Option<&anyhow::Error>)` parameter
-                        // continues to receive an anyhow value. Migration of that parameter
-                        // to ServerError is tracked as a follow-up PR per #1209.
+                        // continues to receive an anyhow value. #1244, already filed and
+                        // stacked on this PR, converts that parameter to `ServerError` and
+                        // removes this indirection.
                         let result = self.run_connection_with_inner(stream, TransportTls::Managed).await;
                         let duration = started.elapsed();
 

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -42,6 +42,7 @@ use crate::clipboard::CliprdrServerFactory;
 use crate::display::{DisplayUpdate, RdpServerDisplay};
 use crate::echo::{EchoDvcBridge, EchoServerHandle, EchoServerMessage, build_echo_request};
 use crate::encoder::{UpdateEncoder, UpdateEncoderCodecs};
+use crate::error::{ServerResult, from_anyhow};
 #[cfg(feature = "egfx")]
 use crate::gfx::{EgfxServerMessage, GfxServerFactory};
 use crate::handler::RdpServerInputHandler;
@@ -964,7 +965,7 @@ impl RdpServer {
     ///
     /// Equivalent to [`run_connection_with`](Self::run_connection_with) with
     /// [`TransportTls::Managed`].
-    pub async fn run_connection<S>(&mut self, stream: S) -> Result<()>
+    pub async fn run_connection<S>(&mut self, stream: S) -> ServerResult<()>
     where
         S: AsyncRead + AsyncWrite + Send + Sync + Unpin,
     {
@@ -1041,7 +1042,20 @@ impl RdpServer {
     /// under [`TransportTls::AlreadyDone`] is that after the negotiation reaches
     /// the security-upgrade gate, no TLS handshake is performed on the byte
     /// stream, because the caller's stream is already past TLS at a lower layer.
-    pub async fn run_connection_with<S>(&mut self, stream: S, tls: TransportTls) -> Result<()>
+    pub async fn run_connection_with<S>(&mut self, stream: S, tls: TransportTls) -> ServerResult<()>
+    where
+        S: AsyncRead + AsyncWrite + Send + Sync + Unpin,
+    {
+        self.run_connection_with_inner(stream, tls).await.map_err(from_anyhow)
+    }
+
+    /// The anyhow-returning body behind [`Self::run_connection_with`].
+    ///
+    /// Kept private and untyped only because the accept loop feeds its error to
+    /// [`ServerConnectionHandler::on_disconnected`], whose parameter is still
+    /// `Option<&anyhow::Error>`. Migrating that callback is tracked under #1209;
+    /// once it takes a `ServerError` this helper collapses into its caller.
+    async fn run_connection_with_inner<S>(&mut self, stream: S, tls: TransportTls) -> Result<()>
     where
         S: AsyncRead + AsyncWrite + Send + Sync + Unpin,
     {
@@ -1149,7 +1163,11 @@ impl RdpServer {
         Ok(())
     }
 
-    pub async fn run(&mut self) -> Result<()> {
+    pub async fn run(&mut self) -> ServerResult<()> {
+        self.run_inner().await.map_err(from_anyhow)
+    }
+
+    async fn run_inner(&mut self) -> Result<()> {
         // Create socket with control over options before binding.
         // Using TcpSocket instead of TcpListener::bind() allows setting
         // SO_REUSEADDR and IPv6 dual-stack mode.
@@ -1218,7 +1236,11 @@ impl RdpServer {
                         drop(stream);
                     } else {
                         let started = tokio::time::Instant::now();
-                        let result = self.run_connection(stream).await;
+                        // Internal accept loop uses the anyhow-returning inner method so the
+                        // existing `on_disconnected(error: Option<&anyhow::Error>)` parameter
+                        // continues to receive an anyhow value. Migration of that parameter
+                        // to ServerError is tracked as a follow-up PR per #1209.
+                        let result = self.run_connection_with_inner(stream, TransportTls::Managed).await;
                         let duration = started.elapsed();
 
                         if let Err(ref error) = result {

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -51,6 +51,7 @@ use crate::clipboard::CliprdrServerFactory;
 use crate::display::{DisplayUpdate, RdpServerDisplay};
 use crate::echo::{EchoDvcBridge, EchoServerHandle, EchoServerMessage, build_echo_request};
 use crate::encoder::{UpdateEncoder, UpdateEncoderCodecs};
+use crate::error::{ServerResult, from_anyhow};
 #[cfg(feature = "egfx")]
 use crate::gfx::{EgfxServerMessage, GfxServerFactory};
 use crate::handler::RdpServerInputHandler;
@@ -1191,7 +1192,7 @@ impl RdpServer {
     ///
     /// Equivalent to [`run_connection_with`](Self::run_connection_with) with
     /// [`TransportTls::Managed`].
-    pub async fn run_connection<S>(&mut self, stream: S) -> Result<()>
+    pub async fn run_connection<S>(&mut self, stream: S) -> ServerResult<()>
     where
         S: AsyncRead + AsyncWrite + Send + Sync + Unpin,
     {
@@ -1268,7 +1269,20 @@ impl RdpServer {
     /// under [`TransportTls::AlreadyDone`] is that after the negotiation reaches
     /// the security-upgrade gate, no TLS handshake is performed on the byte
     /// stream, because the caller's stream is already past TLS at a lower layer.
-    pub async fn run_connection_with<S>(&mut self, stream: S, tls: TransportTls) -> Result<()>
+    pub async fn run_connection_with<S>(&mut self, stream: S, tls: TransportTls) -> ServerResult<()>
+    where
+        S: AsyncRead + AsyncWrite + Send + Sync + Unpin,
+    {
+        self.run_connection_with_inner(stream, tls).await.map_err(from_anyhow)
+    }
+
+    /// The anyhow-returning body behind [`Self::run_connection_with`].
+    ///
+    /// Kept private and untyped only because the accept loop feeds its error to
+    /// [`ServerConnectionHandler::on_disconnected`], whose parameter is still
+    /// `Option<&anyhow::Error>`. Migrating that callback is tracked under #1209;
+    /// once it takes a `ServerError` this helper collapses into its caller.
+    async fn run_connection_with_inner<S>(&mut self, stream: S, tls: TransportTls) -> Result<()>
     where
         S: AsyncRead + AsyncWrite + Send + Sync + Unpin,
     {
@@ -1393,7 +1407,11 @@ impl RdpServer {
         Ok(())
     }
 
-    pub async fn run(&mut self) -> Result<()> {
+    pub async fn run(&mut self) -> ServerResult<()> {
+        self.run_inner().await.map_err(from_anyhow)
+    }
+
+    async fn run_inner(&mut self) -> Result<()> {
         // Create socket with control over options before binding.
         // Using TcpSocket instead of TcpListener::bind() allows setting
         // SO_REUSEADDR and IPv6 dual-stack mode.
@@ -1462,7 +1480,11 @@ impl RdpServer {
                         drop(stream);
                     } else {
                         let started = tokio::time::Instant::now();
-                        let result = self.run_connection(stream).await;
+                        // Internal accept loop uses the anyhow-returning inner method so the
+                        // existing `on_disconnected(error: Option<&anyhow::Error>)` parameter
+                        // continues to receive an anyhow value. Migration of that parameter
+                        // to ServerError is tracked as a follow-up PR per #1209.
+                        let result = self.run_connection_with_inner(stream, TransportTls::Managed).await;
                         let duration = started.elapsed();
 
                         if let Err(ref error) = result {

--- a/crates/ironrdp/examples/server.rs
+++ b/crates/ironrdp/examples/server.rs
@@ -429,5 +429,5 @@ async fn run(
         domain: None,
     }));
 
-    server.run().await
+    server.run().await.map_err(|e| anyhow::anyhow!(e))
 }

--- a/crates/ironrdp/examples/server.rs
+++ b/crates/ironrdp/examples/server.rs
@@ -429,5 +429,5 @@ async fn run(
         domain: None,
     }));
 
-    server.run().await.map_err(|e| anyhow::anyhow!(e))
+    Ok(server.run().await?)
 }


### PR DESCRIPTION
## Summary

First in a staged migration toward a typed public error story for `ironrdp-server`, addressing #1209. Introduces:

```rust
pub type ServerError = ironrdp_error::Error<ServerErrorKind>;
pub type ServerResult<T> = Result<T, ServerError>;
```

`ServerErrorKind` is a `#[non_exhaustive]` enum with concretely typed variants (`Encode`, `Io`, `Channel`, `Unsupported`, `Reason`, `Custom`). Sources are attached through `ironrdp_error::Error::with_source` rather than embedded as `Box<dyn Error>` in variant data. This mirrors the shape of `ConnectorErrorKind` in `ironrdp-connector`, so the connection-management layer stays internally consistent.

## Why this shape

The audit before drafting found that `ironrdp-connector`, `ironrdp-session`, `ironrdp-pdu`, `ironrdp-mstsgu`, and `ironrdp-core` (`EncodeError`/`DecodeError`) all use the same `ironrdp_error::Error<Kind>` pattern. The `thiserror`-based bare enums elsewhere in the workspace (`GccError`, `BulkError`, etc.) are leaf-layer errors at the PDU/codec level; the connection-management layer sister crate to `ironrdp-server` is the right template.

## Scope of this PR

Public function signatures only:

- `RdpServer::run` → `ServerResult<()>`
- `RdpServer::run_connection<S>` → `ServerResult<()>`
- `RdpServer::run_connection_with<S>` → `ServerResult<()>`
- `TlsIdentityCtx::init_from_paths` → `ServerResult<Self>`
- `TlsIdentityCtx::make_acceptor` → `ServerResult<TlsAcceptor>`
- `EchoServerHandle::send_request` → `ServerResult<()>`

Internal call sites continue to use `anyhow::Result`. A private `from_anyhow_with_context` helper bridges at the public boundary, tagging each call site with the operation that failed. The `ConnectionHandler::on_disconnected(error: Option<&anyhow::Error>)` parameter is unchanged in this PR.

`run_connection_with` keeps its anyhow body in a private `run_connection_with_inner`, which the accept loop calls directly so `on_disconnected` still receives an `anyhow::Error`. That helper is transitional and its removal is inside this stack rather than deferred indefinitely: #1244 converts `on_disconnected` to `ServerError` and deletes it, with the accept loop calling `run_connection` from there. `TlsIdentityCtx::init_from_paths` and `make_acceptor` use the same wrapper-plus-private-body shape, matching the `run` / `run_inner` pair this PR already introduces.

## Companion ext traits

```rust
pub trait ServerErrorExt {
    fn encode(error: EncodeError) -> Self;
    fn io(context: &'static str, error: io::Error) -> Self;
    fn channel(context: &'static str) -> Self;
    fn unsupported(context: &'static str) -> Self;
    fn reason(context: &'static str, reason: impl Into<String>) -> Self;
    fn custom<E>(context: &'static str, error: E) -> Self
    where E: core::error::Error + Sync + Send + 'static;
}
pub trait ServerResultExt {
    fn with_context(self, context: &'static str) -> Self;
}
```

Mirrors `ConnectorErrorExt` / `ConnectorResultExt`, trimmed to the constructors and the one result-side helper that have call sites in this stack (`decode` and `with_source` did not, so neither shipped).

## Stack ordering

This is step 1 of 4. The full chain (must merge in PR-number order):

| Step | PR | Scope |
|------|-----|-------|
| **1** | **this PR** | Add `ServerError` / `ServerErrorKind` / ext traits, convert 5 public functions, internal anyhow stays via private bridge |
| 2 | #1243 | Convert encoder/helper/echo internals (anyhow → typed) |
| 3 | #1244 | Convert server.rs internals + `on_disconnected` parameter (breaking) |
| 4 | #1245 | Convert display traits, drop anyhow dep, finish (breaking) |

All four close #1209 together. Each step is independently reviewable but is rebased onto its predecessor as a Stacked branch; please merge in the order above so the rebases land cleanly.

## Breaking change

Marked with `!` in the conventional commit. Consumers of the five listed public functions need to update their `Result` types. Pre-1.0, and per @elmarco's note on #1209: "I am ok with breaking API at this point :)".

## Test plan

- `cargo xtask check fmt -v` clean
- `cargo xtask check lints -v` clean (workspace, all-targets, with helper + __bench features)
- `cargo xtask check tests -v` passes
- `cargo build --workspace --all-targets` clean (one example consumer in `crates/ironrdp/examples/server.rs` updated to convert at its own boundary)

Closes part of #1209.
