### PR TITLE
feat(egfx)!: switch SolidFill/SurfaceToSurface/SurfaceToCache rectangles to exclusive bounds

### DIFF
--- a/crates/ironrdp-egfx/src/pdu/cmd.rs
+++ b/crates/ironrdp-egfx/src/pdu/cmd.rs
@@ -7,7 +7,7 @@ use ironrdp_core::{
 };
 use ironrdp_dvc::DvcEncode;
 use ironrdp_pdu::gcc::Monitor;
-use ironrdp_pdu::geometry::InclusiveRectangle;
+use ironrdp_pdu::geometry::{ExclusiveRectangle, InclusiveRectangle};
 use ironrdp_pdu::{DecodeError, cast_length, ensure_size, read_padding, write_padding};
 use tracing::warn;
 
@@ -510,7 +510,9 @@ impl<'a> Decode<'a> for DeleteEncodingContextPdu {
 pub struct SolidFillPdu {
     pub surface_id: u16,
     pub fill_pixel: Color,
-    pub rectangles: Vec<InclusiveRectangle>,
+    /// Filled regions; each is an exclusive `RDPGFX_RECT16` per
+    /// MS-RDPEGFX 2.2.1.4.1 (`right` / `bottom` are one-past-end).
+    pub rectangles: Vec<ExclusiveRectangle>,
 }
 
 impl SolidFillPdu {
@@ -551,8 +553,8 @@ impl<'a> Decode<'a> for SolidFillPdu {
         let fill_pixel = Color::decode(src)?;
         let rectangles_count = src.read_u16();
 
-        ensure_size!(in: src, size: usize::from(rectangles_count) * InclusiveRectangle::FIXED_PART_SIZE);
-        let rectangles = iter::repeat_with(|| InclusiveRectangle::decode(src))
+        ensure_size!(in: src, size: usize::from(rectangles_count) * ExclusiveRectangle::ENCODED_SIZE);
+        let rectangles = iter::repeat_with(|| ExclusiveRectangle::decode(src))
             .take(usize::from(rectangles_count))
             .collect::<Result<_, _>>()?;
 
@@ -571,14 +573,16 @@ impl<'a> Decode<'a> for SolidFillPdu {
 pub struct SurfaceToSurfacePdu {
     pub source_surface_id: u16,
     pub destination_surface_id: u16,
-    pub source_rectangle: InclusiveRectangle,
+    /// Source region; an exclusive `RDPGFX_RECT16` per MS-RDPEGFX 2.2.1.4.1
+    /// (`right` / `bottom` are one-past-end).
+    pub source_rectangle: ExclusiveRectangle,
     pub destination_points: Vec<Point>,
 }
 
 impl SurfaceToSurfacePdu {
     const NAME: &'static str = "SurfaceToSurfacePdu";
 
-    const FIXED_PART_SIZE: usize = 2 /* SourceId */ + 2 /* DestId */ + InclusiveRectangle::FIXED_PART_SIZE /* SourceRect */ + 2 /* DestPointsCount */;
+    const FIXED_PART_SIZE: usize = 2 /* SourceId */ + 2 /* DestId */ + ExclusiveRectangle::ENCODED_SIZE /* SourceRect */ + 2 /* DestPointsCount */;
 }
 
 impl Encode for SurfaceToSurfacePdu {
@@ -612,7 +616,7 @@ impl<'a> Decode<'a> for SurfaceToSurfacePdu {
 
         let source_surface_id = src.read_u16();
         let destination_surface_id = src.read_u16();
-        let source_rectangle = InclusiveRectangle::decode(src)?;
+        let source_rectangle = ExclusiveRectangle::decode(src)?;
         let destination_points_count = src.read_u16();
 
         let destination_points = iter::repeat_with(|| Point::decode(src))
@@ -636,13 +640,15 @@ pub struct SurfaceToCachePdu {
     pub surface_id: u16,
     pub cache_key: u64,
     pub cache_slot: u16,
-    pub source_rectangle: InclusiveRectangle,
+    /// Source region; an exclusive `RDPGFX_RECT16` per MS-RDPEGFX 2.2.1.4.1
+    /// (`right` / `bottom` are one-past-end).
+    pub source_rectangle: ExclusiveRectangle,
 }
 
 impl SurfaceToCachePdu {
     const NAME: &'static str = "SurfaceToCachePdu";
 
-    const FIXED_PART_SIZE: usize = 2 /* SurfaceId */ + 8 /* CacheKey */ + 2 /* CacheSlot */ + InclusiveRectangle::FIXED_PART_SIZE /* SourceRect */;
+    const FIXED_PART_SIZE: usize = 2 /* SurfaceId */ + 8 /* CacheKey */ + 2 /* CacheSlot */ + ExclusiveRectangle::ENCODED_SIZE /* SourceRect */;
 }
 
 impl Encode for SurfaceToCachePdu {
@@ -673,7 +679,7 @@ impl<'a> Decode<'a> for SurfaceToCachePdu {
         let surface_id = src.read_u16();
         let cache_key = src.read_u64();
         let cache_slot = src.read_u16();
-        let source_rectangle = InclusiveRectangle::decode(src)?;
+        let source_rectangle = ExclusiveRectangle::decode(src)?;
 
         Ok(Self {
             surface_id,


### PR DESCRIPTION
## Summary

Follow-up to #1238. The same MS-RDPEGFX 2.2.1.4.1 RDPGFX_RECT16 exclusive-bounds wire format applies to the source/destination rectangles in three more EGFX PDUs that were also typed as `InclusiveRectangle` on master:

| Section | PDU | Field | Before | After |
|---------|-----|-------|--------|-------|
| 2.2.2.4 | `RDPGFX_SOLID_FILL_PDU` | `rectangles: Vec<...>` | `InclusiveRectangle` | `ExclusiveRectangle` |
| 2.2.2.5 | `RDPGFX_SURFACE_TO_SURFACE_PDU` | `source_rectangle` | `InclusiveRectangle` | `ExclusiveRectangle` |
| 2.2.2.6 | `RDPGFX_SURFACE_TO_CACHE_PDU` | `source_rectangle` | `InclusiveRectangle` | `ExclusiveRectangle` |

Type changes only; the wire bytes on the network do not change. The `right - left` and `bottom - top` arithmetic in any consumer code that reads these fields now agrees with the spec and with the codec-internal dimension headers (per the Server 2025 captures @GlassOnTin attached on #1238 confirming the exclusive interpretation).

## Filing as one PR vs separate

Per the commitment in the #1238 description: *"will submit separate PRs for consideration of these additional spec-compliant breaking changes."* Filing as one cohesive follow-up because the three changes share an import line and the same justification; the diff is 16 additions / 10 deletions total. Happy to split into three single-PDU PRs if maintainers prefer.

## Breaking change

Marked with `!` in the conventional commit. Affects any direct construction of these three PDUs and any consumer iterating over their rectangle fields with `.width() / .height()` (the trait method now returns `right - left` instead of `right - left + 1`, which is the spec-correct value).

Pre-1.0; no crates.io consumers of `ironrdp-egfx` today since the crate has not yet published.

## Out of scope

`CacheToSurfacePdu` (2.2.2.7) carries `Vec<Point>` (`destination_points`), not rectangles, so it is unaffected.

The legacy duplicate definitions in `crates/ironrdp-pdu/src/rdp/vc/dvc/gfx/graphics_messages/server.rs` are untouched here. If those should also align (or be removed in favor of the `ironrdp-egfx` crate's definitions), a separate cleanup PR is the right place.

## Stacking

This PR touches `crates/ironrdp-egfx/src/pdu/cmd.rs` in different lines than #1238, so they apply cleanly in either order.

## Test plan

- [x] `cargo xtask check fmt -v` clean
- [x] `cargo xtask check lints -v` clean (workspace, all-targets, with helper + __bench features)
- [x] `cargo xtask check tests -v` passes
- [x] `cargo build --workspace --all-targets` clean

Tracking: #1209 / spec alignment with #1238.
