### PR TITLE
refactor(async,blocking)!: make Framed::read_exact crate-private

### DIFF
--- a/crates/ironrdp-async/src/framed.rs
+++ b/crates/ironrdp-async/src/framed.rs
@@ -110,12 +110,11 @@ where
     /// `tokio::select!` statement and some other branch
     /// completes first, then it is safe to drop the future and re-create it later.
     /// Data may have been read, but it will be stored in the internal buffer.
-    pub async fn read_exact(&mut self, length: usize) -> io::Result<BytesMut> {
+    pub(crate) async fn read_exact(&mut self, length: usize) -> io::Result<BytesMut> {
         loop {
             if self.buf.len() >= length {
                 return Ok(self.buf.split_to(length));
             } else {
-                #[expect(clippy::missing_panics_doc, reason = "unreachable panic (checked integer underflow)")]
                 self.buf
                     .reserve(length.checked_sub(self.buf.len()).expect("length > self.buf.len()"));
             }

--- a/crates/ironrdp-blocking/src/framed.rs
+++ b/crates/ironrdp-blocking/src/framed.rs
@@ -46,12 +46,11 @@ where
     S: Read,
 {
     /// Accumulates at least `length` bytes and returns exactly `length` bytes, keeping the leftover in the internal buffer.
-    pub fn read_exact(&mut self, length: usize) -> io::Result<BytesMut> {
+    pub(crate) fn read_exact(&mut self, length: usize) -> io::Result<BytesMut> {
         loop {
             if self.buf.len() >= length {
                 return Ok(self.buf.split_to(length));
             } else {
-                #[expect(clippy::missing_panics_doc, reason = "unreachable panic (checked underflow)")]
                 self.buf
                     .reserve(length.checked_sub(self.buf.len()).expect("length > self.buf.len()"));
             }


### PR DESCRIPTION
## Summary

Closes #1226.

`Framed` holds an invariant that `buf` starts at the first byte of a PDU message. `read_pdu` and `read_by_hint` maintain that invariant. `Framed::read_exact` also maintains it for its own callers, but exposing it as `pub` lets external callers leave `buf` misaligned by passing an arbitrary length, which then breaks subsequent `read_pdu` calls.

Both `ironrdp_async::framed::Framed` and `ironrdp_blocking::framed::Framed` have the same shape and the same exposure. Audit shows **no external consumers** across the workspace; the four call sites are all internal:

| Crate | Call site |
|-------|-----------|
| `ironrdp-async` | `framed.rs:145` (`read_pdu`) |
| `ironrdp-async` | `framed.rs:174` (`read_by_hint`) |
| `ironrdp-blocking` | `framed.rs:74` (`read_pdu`) |
| `ironrdp-blocking` | `framed.rs:96` (`read_by_hint`) |

Both visibility changes use `pub(crate)`.

Also drops the `#[expect(clippy::missing_panics_doc)]` annotation that was placed on the inline `expect("length > self.buf.len()")` because the lint only fires on public APIs; with the methods now `pub(crate)`, the expectation is unfulfilled and clippy fails the build.

## Breaking change

Marked with `!` in the conventional commit. Affects any out-of-workspace consumer that called `Framed::read_exact` directly. The audit was workspace-only; if someone has a private consumer that relied on this, the migration is to use `read_pdu` (when reading a structured PDU) or `read_by_hint` (when the length comes from a header peek) — both maintain the buffer invariant correctly.

Pre-1.0 (`ironrdp-async` 0.8, `ironrdp-blocking` 0.8); per Cargo SemVer a 0.8 → 0.9 minor bump covers this.

## Test plan

- [x] `cargo xtask check fmt -v` clean
- [x] `cargo xtask check lints -v` clean
- [x] `cargo xtask check tests -v` passes
- [x] `cargo build --workspace --all-targets` clean
