### PR TITLE
fix(bulk,session)!: always own a bulk decompressor for FastPath updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2942,6 +2942,7 @@ dependencies = [
  "expect-test",
  "hex",
  "ironrdp-acceptor",
+ "ironrdp-bulk",
  "ironrdp-cfg",
  "ironrdp-cliprdr",
  "ironrdp-cliprdr-format",

--- a/crates/ironrdp-bulk/benches/bulk_compression.rs
+++ b/crates/ironrdp-bulk/benches/bulk_compression.rs
@@ -71,7 +71,7 @@ fn bench_compress_decompress(c: &mut Criterion, ct: CompressionType, data: &[u8]
     let name = algo_name(ct);
 
     // Verify data actually compresses with this algorithm
-    let mut test_comp = BulkCompressor::new(ct).expect("bulk compressor should initialize");
+    let mut test_comp = BulkCompressor::new(ct);
     let (test_size, test_flags) = test_comp.compress(data).expect("bulk compression should succeed");
     let is_compressed = test_flags & flags::PACKET_COMPRESSED != 0;
 
@@ -85,7 +85,7 @@ fn bench_compress_decompress(c: &mut Criterion, ct: CompressionType, data: &[u8]
 
             group.bench_function(BenchmarkId::new("compress", data.len()), |b| {
                 b.iter_batched(
-                    || BulkCompressor::new(ct).expect("bulk compressor should initialize"),
+                    || BulkCompressor::new(ct),
                     |mut compressor| {
                         black_box(
                             compressor
@@ -107,7 +107,7 @@ fn bench_compress_decompress(c: &mut Criterion, ct: CompressionType, data: &[u8]
 
             group.bench_function(BenchmarkId::new("decompress", data.len()), |b| {
                 b.iter_batched(
-                    || BulkCompressor::new(ct).expect("bulk compressor should initialize"),
+                    || BulkCompressor::new(ct),
                     |mut decompressor| {
                         black_box(
                             decompressor

--- a/crates/ironrdp-bulk/src/bulk.rs
+++ b/crates/ironrdp-bulk/src/bulk.rs
@@ -72,12 +72,12 @@ impl BulkCompressor {
     /// - `Rdp6` (0x02): NCRUSH (Huffman-based)
     /// - `Rdp61` (0x03): XCRUSH (two-level: chunk matching + MPPC)
     ///
-    pub fn new(compression_level: CompressionType) -> Result<Self, BulkError> {
+    pub fn new(compression_level: CompressionType) -> Self {
         // MPPC contexts are created with level 1 by default and adjusted dynamically.
         let mppc_send = MppcContext::new(1);
         let mppc_recv = MppcContext::new(1);
-        let ncrush_send = NCrushContext::new()?;
-        let ncrush_recv = NCrushContext::new()?;
+        let ncrush_send = NCrushContext::new();
+        let ncrush_recv = NCrushContext::new();
         let xcrush_send = XCrushContext::new();
         let xcrush_recv = XCrushContext::new();
 
@@ -88,7 +88,7 @@ impl BulkCompressor {
             v.into_boxed_slice().try_into().unwrap_or_else(|_| unreachable!())
         };
 
-        Ok(Self {
+        Self {
             compression_level,
             mppc_send,
             mppc_recv,
@@ -99,7 +99,7 @@ impl BulkCompressor {
             output_buffer,
             total_uncompressed_bytes: 0,
             total_compressed_bytes: 0,
-        })
+        }
     }
 
     /// Returns the configured compression level.
@@ -271,25 +271,25 @@ mod tests {
 
     #[test]
     fn test_bulk_compressor_new_rdp4() {
-        let bulk = BulkCompressor::new(CompressionType::Rdp4).unwrap();
+        let bulk = BulkCompressor::new(CompressionType::Rdp4);
         assert_eq!(bulk.compression_level(), CompressionType::Rdp4);
     }
 
     #[test]
     fn test_bulk_compressor_new_rdp5() {
-        let bulk = BulkCompressor::new(CompressionType::Rdp5).unwrap();
+        let bulk = BulkCompressor::new(CompressionType::Rdp5);
         assert_eq!(bulk.compression_level(), CompressionType::Rdp5);
     }
 
     #[test]
     fn test_bulk_compressor_new_rdp6() {
-        let bulk = BulkCompressor::new(CompressionType::Rdp6).unwrap();
+        let bulk = BulkCompressor::new(CompressionType::Rdp6);
         assert_eq!(bulk.compression_level(), CompressionType::Rdp6);
     }
 
     #[test]
     fn test_bulk_compressor_new_rdp61() {
-        let bulk = BulkCompressor::new(CompressionType::Rdp61).unwrap();
+        let bulk = BulkCompressor::new(CompressionType::Rdp61);
         assert_eq!(bulk.compression_level(), CompressionType::Rdp61);
     }
 
@@ -314,14 +314,14 @@ mod tests {
 
     #[test]
     fn test_bulk_compressor_reset() {
-        let mut bulk = BulkCompressor::new(CompressionType::Rdp61).unwrap();
+        let mut bulk = BulkCompressor::new(CompressionType::Rdp61);
         // Should not panic
         bulk.reset();
     }
 
     #[test]
     fn test_bulk_compressor_contexts_independent() {
-        let bulk = BulkCompressor::new(CompressionType::Rdp6).unwrap();
+        let bulk = BulkCompressor::new(CompressionType::Rdp6);
         // Send and receive NCRUSH contexts should be separate instances
         // (we can only verify they exist and the struct was created)
         assert_eq!(bulk.compression_level(), CompressionType::Rdp6);
@@ -333,7 +333,7 @@ mod tests {
 
     #[test]
     fn test_bulk_compress_skip_small_input() {
-        let mut bulk = BulkCompressor::new(CompressionType::Rdp5).unwrap();
+        let mut bulk = BulkCompressor::new(CompressionType::Rdp5);
         let data = b"tiny"; // 4 bytes, below threshold
         let (size, flags) = bulk.compress(data).unwrap();
         assert_eq!(size, data.len());
@@ -342,7 +342,7 @@ mod tests {
 
     #[test]
     fn test_bulk_compress_skip_empty() {
-        let mut bulk = BulkCompressor::new(CompressionType::Rdp5).unwrap();
+        let mut bulk = BulkCompressor::new(CompressionType::Rdp5);
         let data = b"";
         let (size, flags) = bulk.compress(data).unwrap();
         assert_eq!(size, 0);
@@ -355,7 +355,7 @@ mod tests {
 
     #[test]
     fn test_bulk_decompress_no_flags() {
-        let mut bulk = BulkCompressor::new(CompressionType::Rdp5).unwrap();
+        let mut bulk = BulkCompressor::new(CompressionType::Rdp5);
         let data = b"uncompressed data";
         let result = bulk.decompress(data, 0x00).unwrap();
         assert_eq!(result, data);
@@ -363,7 +363,7 @@ mod tests {
 
     #[test]
     fn test_bulk_decompress_unsupported_type() {
-        let mut bulk = BulkCompressor::new(CompressionType::Rdp5).unwrap();
+        let mut bulk = BulkCompressor::new(CompressionType::Rdp5);
         // flags = PACKET_COMPRESSED | type 0x0F (invalid)
         let result = bulk.decompress(b"data", 0x2F);
         assert!(result.is_err());
@@ -376,8 +376,8 @@ mod tests {
     /// Helper: compress with one BulkCompressor (sender) and decompress
     /// with another (receiver). Returns the decompressed data as a Vec.
     fn bulk_roundtrip(compression_level: CompressionType, input: &[u8]) -> Vec<u8> {
-        let mut sender = BulkCompressor::new(compression_level).unwrap();
-        let mut receiver = BulkCompressor::new(compression_level).unwrap();
+        let mut sender = BulkCompressor::new(compression_level);
+        let mut receiver = BulkCompressor::new(compression_level);
 
         let (comp_size, flags) = sender.compress(input).unwrap();
 
@@ -451,7 +451,7 @@ mod tests {
 
     #[test]
     fn test_bulk_compress_rdp5_sets_type_bits() {
-        let mut bulk = BulkCompressor::new(CompressionType::Rdp5).unwrap();
+        let mut bulk = BulkCompressor::new(CompressionType::Rdp5);
         let input = b"Some data that should compress with MPPC level 1 algorithm!!";
         let (_size, flags) = bulk.compress(input).unwrap();
 
@@ -464,7 +464,7 @@ mod tests {
 
     #[test]
     fn test_bulk_compress_rdp6_sets_type_bits() {
-        let mut bulk = BulkCompressor::new(CompressionType::Rdp6).unwrap();
+        let mut bulk = BulkCompressor::new(CompressionType::Rdp6);
         let input = b"for.whom.the.bell.tolls,.the.bell.tolls.for.thee!xx";
         let (_size, flags) = bulk.compress(input).unwrap();
 
@@ -481,7 +481,7 @@ mod tests {
 
     #[test]
     fn test_metrics_start_at_zero() {
-        let bulk = BulkCompressor::new(CompressionType::Rdp5).unwrap();
+        let bulk = BulkCompressor::new(CompressionType::Rdp5);
         assert_eq!(bulk.total_compressed_bytes(), 0);
         assert_eq!(bulk.total_uncompressed_bytes(), 0);
         assert!(bulk.compression_ratio().abs() < f64::EPSILON);
@@ -489,7 +489,7 @@ mod tests {
 
     #[test]
     fn test_metrics_accumulate_on_compress() {
-        let mut bulk = BulkCompressor::new(CompressionType::Rdp5).unwrap();
+        let mut bulk = BulkCompressor::new(CompressionType::Rdp5);
         let input = b"Hello world! Hello world! Hello world! Hello world! x";
         let (comp_size, flags) = bulk.compress(input).unwrap();
 
@@ -509,8 +509,8 @@ mod tests {
 
     #[test]
     fn test_metrics_accumulate_on_decompress() {
-        let mut sender = BulkCompressor::new(CompressionType::Rdp5).unwrap();
-        let mut receiver = BulkCompressor::new(CompressionType::Rdp5).unwrap();
+        let mut sender = BulkCompressor::new(CompressionType::Rdp5);
+        let mut receiver = BulkCompressor::new(CompressionType::Rdp5);
 
         let input = b"Hello world! Hello world! Hello world! Hello world! x";
         let (comp_size, flags) = sender.compress(input).unwrap();
@@ -533,8 +533,8 @@ mod tests {
 
     #[test]
     fn test_metrics_accumulate_across_multiple_calls() {
-        let mut sender = BulkCompressor::new(CompressionType::Rdp5).unwrap();
-        let mut receiver = BulkCompressor::new(CompressionType::Rdp5).unwrap();
+        let mut sender = BulkCompressor::new(CompressionType::Rdp5);
+        let mut receiver = BulkCompressor::new(CompressionType::Rdp5);
 
         let inputs: &[&[u8]] = &[
             b"Hello world! Hello world! Hello world! Hello world! x",
@@ -557,7 +557,7 @@ mod tests {
 
     #[test]
     fn test_metrics_not_reset_by_context_reset() {
-        let mut bulk = BulkCompressor::new(CompressionType::Rdp5).unwrap();
+        let mut bulk = BulkCompressor::new(CompressionType::Rdp5);
         let input = b"Hello world! Hello world! Hello world! Hello world! x";
         let _ = bulk.compress(input).unwrap();
         let before = bulk.total_uncompressed_bytes();
@@ -569,7 +569,7 @@ mod tests {
 
     #[test]
     fn test_bulk_compress_rdp61_sets_type_bits() {
-        let mut bulk = BulkCompressor::new(CompressionType::Rdp61).unwrap();
+        let mut bulk = BulkCompressor::new(CompressionType::Rdp61);
         let input = b"XCRUSH test data with repeated XCRUSH patterns for compression!!";
         let (_size, flags) = bulk.compress(input).unwrap();
 

--- a/crates/ironrdp-bulk/src/lib.rs
+++ b/crates/ironrdp-bulk/src/lib.rs
@@ -17,8 +17,8 @@
 //! use ironrdp_bulk::{BulkCompressor, CompressionType, flags};
 //!
 //! // Create sender (compressor) and receiver (decompressor)
-//! let mut sender = BulkCompressor::new(CompressionType::Rdp5).unwrap();
-//! let mut receiver = BulkCompressor::new(CompressionType::Rdp5).unwrap();
+//! let mut sender = BulkCompressor::new(CompressionType::Rdp5);
+//! let mut receiver = BulkCompressor::new(CompressionType::Rdp5);
 //!
 //! let input = b"Hello world! Hello world! Hello world! Hello world! x";
 //!

--- a/crates/ironrdp-bulk/src/ncrush/mod.rs
+++ b/crates/ironrdp-bulk/src/ncrush/mod.rs
@@ -175,7 +175,7 @@ impl NCrushContext {
     /// Allocates the history, hash, and match buffers on the heap, generates
     /// the runtime Huffman tables, and calls `reset(false)`.
     ///
-    pub(crate) fn new() -> Result<Self, BulkError> {
+    pub(crate) fn new() -> Self {
         let mut ctx = Self {
             history_offset: 0,
             history_end_offset: HISTORY_BUFFER_SIZE - 1,
@@ -189,10 +189,10 @@ impl NCrushContext {
             huff_table_lom: heap_zeroed_array::<HUFF_TABLE_LOM_SIZE, u8>(),
         };
 
-        ctx.generate_tables()?;
+        ctx.generate_tables();
         ctx.reset(false);
 
-        Ok(ctx)
+        ctx
     }
 
     /// Generates the runtime Huffman lookup tables for CopyOffset and
@@ -206,7 +206,7 @@ impl NCrushContext {
         clippy::cast_possible_truncation,
         reason = "table generation: k (usize ≤4096) safely cast to u32 for verification"
     )]
-    fn generate_tables(&mut self) -> Result<(), BulkError> {
+    fn generate_tables(&mut self) {
         // --- Generate HuffTableLOM ---
         // For each LOM index i (0..28), fill entries for all values that
         // map to that index (based on LOMBitsLUT).
@@ -232,20 +232,18 @@ impl NCrushContext {
                 28usize
             };
 
-            if i >= tables::LOMBitsLUT.len() || i >= tables::LOMBaseLUT.len() {
-                return Err(BulkError::InvalidCompressedData(
-                    "NCRUSH: generate_tables LOM index out of range",
-                ));
-            }
+            debug_assert!(
+                i < tables::LOMBitsLUT.len() && i < tables::LOMBaseLUT.len(),
+                "NCRUSH: generate_tables LOM index out of range (static-table invariant)"
+            );
 
             let mask = (1u32 << tables::LOMBitsLUT[i]) - 1;
             let base = tables::LOMBaseLUT[i];
             let reconstructed = (mask & (k as u32 - 2)) + base;
-            if reconstructed != k as u32 {
-                return Err(BulkError::InvalidCompressedData(
-                    "NCRUSH: generate_tables LOM verification failed",
-                ));
-            }
+            debug_assert_eq!(
+                reconstructed, k as u32,
+                "NCRUSH: generate_tables LOM verification failed (static-table invariant)"
+            );
         }
 
         // --- Generate HuffTableCopyOffset ---
@@ -279,13 +277,10 @@ impl NCrushContext {
             }
         }
 
-        if (k + 256) > HUFF_TABLE_COPY_OFFSET_SIZE {
-            return Err(BulkError::InvalidCompressedData(
-                "NCRUSH: generate_tables CopyOffset overflow",
-            ));
-        }
-
-        Ok(())
+        debug_assert!(
+            (k + 256) <= HUFF_TABLE_COPY_OFFSET_SIZE,
+            "NCRUSH: generate_tables CopyOffset overflow (static-table invariant)"
+        );
     }
 
     /// Refills the bit accumulator from the source data.
@@ -1456,7 +1451,7 @@ mod tests {
 
     #[test]
     fn test_ncrush_context_new() {
-        let ctx = NCrushContext::new().unwrap();
+        let ctx = NCrushContext::new();
         assert_eq!(ctx.history_buffer_size, HISTORY_BUFFER_SIZE);
         assert_eq!(ctx.history_end_offset, HISTORY_BUFFER_SIZE - 1);
         assert_eq!(ctx.history_offset, 0);
@@ -1466,7 +1461,7 @@ mod tests {
 
     #[test]
     fn test_ncrush_context_reset_no_flush() {
-        let mut ctx = NCrushContext::new().unwrap();
+        let mut ctx = NCrushContext::new();
         ctx.history_offset = 12345;
         ctx.offset_cache[0] = 42;
         ctx.offset_cache[1] = 99;
@@ -1481,7 +1476,7 @@ mod tests {
 
     #[test]
     fn test_ncrush_context_reset_flush() {
-        let mut ctx = NCrushContext::new().unwrap();
+        let mut ctx = NCrushContext::new();
         ctx.reset(true);
 
         assert_eq!(ctx.history_offset, HISTORY_BUFFER_SIZE + 1);
@@ -1489,7 +1484,7 @@ mod tests {
 
     #[test]
     fn test_ncrush_generate_tables_lom() {
-        let ctx = NCrushContext::new().unwrap();
+        let ctx = NCrushContext::new();
 
         // First entry at index 2 should be 0 (LOM index 0)
         assert_eq!(ctx.huff_table_lom[2], 0);
@@ -1503,7 +1498,7 @@ mod tests {
 
     #[test]
     fn test_ncrush_generate_tables_copy_offset() {
-        let ctx = NCrushContext::new().unwrap();
+        let ctx = NCrushContext::new();
 
         // First entry at index 2 should be 0
         assert_eq!(ctx.huff_table_copy_offset[2], 0);
@@ -1521,7 +1516,7 @@ mod tests {
     fn test_ncrush_decompress_uncompressed_passthrough() {
         use crate::flags;
 
-        let mut ctx = NCrushContext::new().unwrap();
+        let mut ctx = NCrushContext::new();
         let data = b"hello world";
 
         // No PACKET_COMPRESSED flag → should return source data directly
@@ -1535,7 +1530,7 @@ mod tests {
     fn test_ncrush_decompress_flushed_clears_state() {
         use crate::flags;
 
-        let mut ctx = NCrushContext::new().unwrap();
+        let mut ctx = NCrushContext::new();
         ctx.history_offset = 1000;
         ctx.offset_cache[0] = 42;
         ctx.history_buffer[500] = 0xFF;
@@ -1553,7 +1548,7 @@ mod tests {
     fn test_ncrush_decompress_compressed_too_short() {
         use crate::flags;
 
-        let mut ctx = NCrushContext::new().unwrap();
+        let mut ctx = NCrushContext::new();
         let data = [0u8; 3]; // less than 4 bytes
 
         let result = ctx.decompress(&data, flags::PACKET_FLUSHED | flags::PACKET_COMPRESSED);
@@ -1635,7 +1630,7 @@ mod tests {
     fn test_ncrush_decompress_bells() {
         use crate::flags;
 
-        let mut ctx = NCrushContext::new().unwrap();
+        let mut ctx = NCrushContext::new();
 
         // flags: PACKET_COMPRESSED | 2 (compression type NCRUSH)
         let flags_value = flags::PACKET_COMPRESSED | 0x02;
@@ -1661,7 +1656,7 @@ mod tests {
 
     #[test]
     fn test_ncrush_hash_table_add_basic() {
-        let mut ctx = NCrushContext::new().unwrap();
+        let mut ctx = NCrushContext::new();
 
         // Write "ABABAB..." into history at offset 100
         let data = b"ABABABABAB"; // 10 bytes
@@ -1698,7 +1693,7 @@ mod tests {
 
     #[test]
     fn test_ncrush_hash_table_add_chain() {
-        let mut ctx = NCrushContext::new().unwrap();
+        let mut ctx = NCrushContext::new();
 
         // Insert two blocks with the same starting bytes to create a chain
         let data1 = b"XYXYXYXYXY"; // 10 bytes at offset 50
@@ -1718,7 +1713,7 @@ mod tests {
 
     #[test]
     fn test_ncrush_find_match_length_basic() {
-        let mut ctx = NCrushContext::new().unwrap();
+        let mut ctx = NCrushContext::new();
 
         // Write identical data at two positions
         ctx.history_buffer[10] = b'A';
@@ -1742,7 +1737,7 @@ mod tests {
 
     #[test]
     fn test_ncrush_find_match_length_limit() {
-        let mut ctx = NCrushContext::new().unwrap();
+        let mut ctx = NCrushContext::new();
 
         // Write identical data at two positions
         for i in 0..10 {
@@ -1759,7 +1754,7 @@ mod tests {
 
     #[test]
     fn test_ncrush_find_match_length_immediate_limit() {
-        let ctx = NCrushContext::new().unwrap();
+        let ctx = NCrushContext::new();
 
         // offset1 > limit immediately → returns -1
         let len = ctx.find_match_length(10, 20, 5);
@@ -1768,7 +1763,7 @@ mod tests {
 
     #[test]
     fn test_ncrush_find_best_match_no_chain() {
-        let mut ctx = NCrushContext::new().unwrap();
+        let mut ctx = NCrushContext::new();
 
         // match_table[100] = 0 → no chain
         let result = ctx.find_best_match(100).unwrap();
@@ -1777,7 +1772,7 @@ mod tests {
 
     #[test]
     fn test_ncrush_find_best_match_simple() {
-        let mut ctx = NCrushContext::new().unwrap();
+        let mut ctx = NCrushContext::new();
 
         // Set up: write "ABCDEF" at position 50 and "ABCDXY" at position 100
         let pattern1 = b"ABCDEF";
@@ -1807,7 +1802,7 @@ mod tests {
 
     #[test]
     fn test_ncrush_move_encoder_windows_basic() {
-        let mut ctx = NCrushContext::new().unwrap();
+        let mut ctx = NCrushContext::new();
 
         // Write some data in the second half of the buffer
         for i in 0..100 {
@@ -1837,7 +1832,7 @@ mod tests {
 
     #[test]
     fn test_ncrush_move_encoder_windows_clamps_negative() {
-        let mut ctx = NCrushContext::new().unwrap();
+        let mut ctx = NCrushContext::new();
 
         // Entry pointing before the offset should be clamped to 0
         ctx.hash_table[42] = 50; // 50 < offset (say, 100)
@@ -1993,7 +1988,7 @@ mod tests {
 
     #[test]
     fn test_ncrush_encode_length_of_match_simple() {
-        let ctx = NCrushContext::new().unwrap();
+        let ctx = NCrushContext::new();
         let mut buf = [0u8; 16];
         let mut writer = NCrushBitWriter::new(&mut buf);
 
@@ -2009,7 +2004,7 @@ mod tests {
 
     #[test]
     fn test_ncrush_encode_copy_offset_small() {
-        let ctx = NCrushContext::new().unwrap();
+        let ctx = NCrushContext::new();
         let mut buf = [0u8; 16];
         let mut writer = NCrushBitWriter::new(&mut buf);
 
@@ -2038,7 +2033,7 @@ mod tests {
 
     #[test]
     fn test_ncrush_compress_basic() {
-        let mut ctx = NCrushContext::new().unwrap();
+        let mut ctx = NCrushContext::new();
         let data = b"hello world";
         let mut dst = vec![0u8; 256];
 
@@ -2053,7 +2048,7 @@ mod tests {
 
     #[test]
     fn test_ncrush_compress_with_repeats() {
-        let mut ctx = NCrushContext::new().unwrap();
+        let mut ctx = NCrushContext::new();
         // Repetitive data should compress well
         let data = b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
         let mut dst = vec![0u8; 256];
@@ -2069,7 +2064,7 @@ mod tests {
 
     #[test]
     fn test_ncrush_compress_empty() {
-        let mut ctx = NCrushContext::new().unwrap();
+        let mut ctx = NCrushContext::new();
         let data = b"";
         let mut dst = vec![0u8; 256];
 
@@ -2080,7 +2075,7 @@ mod tests {
 
     #[test]
     fn test_ncrush_compress_updates_history_offset() {
-        let mut ctx = NCrushContext::new().unwrap();
+        let mut ctx = NCrushContext::new();
         let data = b"some test data for ncrush compression";
         let mut dst = vec![0u8; 256];
 
@@ -2095,7 +2090,7 @@ mod tests {
 
     #[test]
     fn test_ncrush_compress_offset_cache_updated() {
-        let mut ctx = NCrushContext::new().unwrap();
+        let mut ctx = NCrushContext::new();
         // Use data with a repeated pattern to trigger back-references
         let data = b"for.whom.the.bell.tolls,.the.bell.tolls.for.thee!";
         let mut dst = vec![0u8; 256];
@@ -2116,7 +2111,7 @@ mod tests {
     /// and verifies the output matches the expected compressed bytes exactly.
     #[test]
     fn test_ncrush_compress_bells() {
-        let mut ctx = NCrushContext::new().unwrap();
+        let mut ctx = NCrushContext::new();
         let mut dst = vec![0u8; 65536];
 
         let (size, flags_out) = ctx.compress(test_data::TEST_BELLS_DATA, &mut dst).unwrap();
@@ -2152,8 +2147,8 @@ mod tests {
     /// Compress → decompress → verify output matches original input.
     #[test]
     fn test_ncrush_roundtrip_bells() {
-        let mut compressor = NCrushContext::new().unwrap();
-        let mut decompressor = NCrushContext::new().unwrap();
+        let mut compressor = NCrushContext::new();
+        let mut decompressor = NCrushContext::new();
 
         let input = test_data::TEST_BELLS_DATA;
         let mut compressed = vec![0u8; 65536];
@@ -2179,8 +2174,8 @@ mod tests {
     /// Round-trip test with a short repetitive pattern.
     #[test]
     fn test_ncrush_roundtrip_repetitive() {
-        let mut compressor = NCrushContext::new().unwrap();
-        let mut decompressor = NCrushContext::new().unwrap();
+        let mut compressor = NCrushContext::new();
+        let mut decompressor = NCrushContext::new();
 
         let input = b"ABCABCABCABCABCABCABCABCABCABCABCABC";
         let mut compressed = vec![0u8; 65536];
@@ -2196,8 +2191,8 @@ mod tests {
     /// Round-trip test with a longer text block containing varied content.
     #[test]
     fn test_ncrush_roundtrip_prose() {
-        let mut compressor = NCrushContext::new().unwrap();
-        let mut decompressor = NCrushContext::new().unwrap();
+        let mut compressor = NCrushContext::new();
+        let mut decompressor = NCrushContext::new();
 
         let input = b"The quick brown fox jumps over the lazy dog. \
                        The quick brown fox jumps over the lazy dog again. \
@@ -2215,8 +2210,8 @@ mod tests {
     /// Round-trip test with binary-like data (all byte values 0-255).
     #[test]
     fn test_ncrush_roundtrip_binary() {
-        let mut compressor = NCrushContext::new().unwrap();
-        let mut decompressor = NCrushContext::new().unwrap();
+        let mut compressor = NCrushContext::new();
+        let mut decompressor = NCrushContext::new();
 
         // Create a pattern with all 256 byte values repeated
         let mut input = Vec::new();
@@ -2239,8 +2234,8 @@ mod tests {
     /// (tests that history buffer state carries across calls).
     #[test]
     fn test_ncrush_roundtrip_sequential() {
-        let mut compressor = NCrushContext::new().unwrap();
-        let mut decompressor = NCrushContext::new().unwrap();
+        let mut compressor = NCrushContext::new();
+        let mut decompressor = NCrushContext::new();
 
         let inputs: &[&[u8]] = &[
             b"first.message.to.compress",

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -742,7 +742,6 @@ async fn active_session(
         io_channel_id: connection_result.io_channel_id,
         message_channel_id: connection_result.message_channel_id,
         share_id: connection_result.share_id,
-        compression_type: connection_result.compression_type,
         enable_server_pointer: connection_result.enable_server_pointer,
         pointer_software_rendering: connection_result.pointer_software_rendering,
     }

--- a/crates/ironrdp-fuzzing/src/oracles/mod.rs
+++ b/crates/ironrdp-fuzzing/src/oracles/mod.rs
@@ -33,27 +33,21 @@ pub fn bulk_decompress_mppc(data: &[u8]) {
     } else {
         (CompressionType::Rdp5, 0x01)
     };
-    let Ok(mut bulk) = BulkCompressor::new(comp_type) else {
-        return;
-    };
+    let mut bulk = BulkCompressor::new(comp_type);
     let _ = bulk.decompress(payload, flags::PACKET_COMPRESSED | algo_bits);
 }
 
 pub fn bulk_decompress_ncrush(data: &[u8]) {
     use ironrdp_bulk::{BulkCompressor, CompressionType, flags};
 
-    let Ok(mut bulk) = BulkCompressor::new(CompressionType::Rdp6) else {
-        return;
-    };
+    let mut bulk = BulkCompressor::new(CompressionType::Rdp6);
     let _ = bulk.decompress(data, flags::PACKET_COMPRESSED | 0x02);
 }
 
 pub fn bulk_decompress_xcrush(data: &[u8]) {
     use ironrdp_bulk::{BulkCompressor, CompressionType, flags};
 
-    let Ok(mut bulk) = BulkCompressor::new(CompressionType::Rdp61) else {
-        return;
-    };
+    let mut bulk = BulkCompressor::new(CompressionType::Rdp61);
     let _ = bulk.decompress(data, flags::PACKET_COMPRESSED | 0x03);
 }
 
@@ -84,9 +78,7 @@ pub fn bulk_round_trip(data: &[u8]) {
         _ => CompressionType::Rdp61,
     };
 
-    let Ok(mut sender) = BulkCompressor::new(algo) else {
-        return;
-    };
+    let mut sender = BulkCompressor::new(algo);
     let Ok((compressed_size, compress_flags)) = sender.compress(src) else {
         return;
     };
@@ -101,9 +93,7 @@ pub fn bulk_round_trip(data: &[u8]) {
         sender.compressed_data(compressed_size)
     };
 
-    let Ok(mut receiver) = BulkCompressor::new(algo) else {
-        return;
-    };
+    let mut receiver = BulkCompressor::new(algo);
     let decompressed = receiver
         .decompress(payload, compress_flags)
         .unwrap_or_else(|e| panic!("bulk round-trip decompress failed for {algo:?}: {e:?}"));

--- a/crates/ironrdp-session/src/active_stage.rs
+++ b/crates/ironrdp-session/src/active_stage.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use ironrdp_bulk::BulkCompressor;
 use ironrdp_core::{ReadCursor, WriteBuf};
 use ironrdp_displaycontrol::client::DisplayControlClient;
 use ironrdp_dvc::{DrdynvcClient, DvcProcessor, DynamicVirtualChannel};
@@ -8,52 +7,21 @@ use ironrdp_graphics::pointer::DecodedPointer;
 use ironrdp_pdu::geometry::InclusiveRectangle;
 use ironrdp_pdu::input::fast_path::{FastPathInput, FastPathInputEvent};
 use ironrdp_pdu::rdp::autodetect::AutoDetectRequest;
-use ironrdp_pdu::rdp::client_info::CompressionType as PduCompressionType;
 use ironrdp_pdu::rdp::headers::ShareDataPdu;
 use ironrdp_pdu::rdp::multitransport::MultitransportRequestPdu;
 use ironrdp_pdu::slow_path::{self, GraphicsUpdateType};
 use ironrdp_pdu::{Action, mcs};
 use ironrdp_svc::{StaticChannelSet, SvcMessage, SvcProcessor, SvcProcessorMessages};
-use tracing::{debug, error, warn};
+use tracing::{debug, warn};
 
 use crate::fast_path::UpdateKind;
 use crate::image::DecodedImage;
 use crate::{SessionError, SessionErrorExt as _, SessionResult, fast_path, x224};
 
-/// Converts the PDU-layer compression type to the bulk crate's compression type.
-fn to_bulk_compression_type(ct: PduCompressionType) -> ironrdp_bulk::CompressionType {
-    match ct {
-        PduCompressionType::K8 => ironrdp_bulk::CompressionType::Rdp4,
-        PduCompressionType::K64 => ironrdp_bulk::CompressionType::Rdp5,
-        PduCompressionType::Rdp6 => ironrdp_bulk::CompressionType::Rdp6,
-        PduCompressionType::Rdp61 => ironrdp_bulk::CompressionType::Rdp61,
-    }
-}
-
-/// Creates the fast-path bulk decompressor for a negotiated compression type, if any.
-fn make_bulk_decompressor(compression_type: Option<PduCompressionType>) -> Option<BulkCompressor> {
-    compression_type.and_then(|ct| {
-        let bulk_ct = to_bulk_compression_type(ct);
-        match BulkCompressor::new(bulk_ct) {
-            Ok(compressor) => {
-                debug!(compression_type = %bulk_ct, "Bulk decompressor initialized for FastPath");
-                Some(compressor)
-            }
-            Err(e) => {
-                error!(error = %e, "Failed to create bulk decompressor, compression disabled");
-                None
-            }
-        }
-    })
-}
-
 pub struct ActiveStage {
     x224_processor: x224::Processor,
     fast_path_processor: fast_path::Processor,
     enable_server_pointer: bool,
-    /// The bulk compression type negotiated for the connection, retained so the fast-path
-    /// decompressor can be recreated when the fast-path processor is rebuilt (reactivation).
-    compression_type: Option<PduCompressionType>,
 }
 
 /// Builder for [`ActiveStage`].
@@ -66,8 +34,6 @@ pub struct ActiveStageBuilder {
     pub io_channel_id: u16,
     pub message_channel_id: Option<u16>,
     pub share_id: u32,
-    /// The bulk compression type that was negotiated, if any.
-    pub compression_type: Option<PduCompressionType>,
     /// Enable server-side pointer updates (client-side pointer rendering).
     pub enable_server_pointer: bool,
     /// Use software rendering mode for pointer bitmap generation.
@@ -82,7 +48,6 @@ impl ActiveStageBuilder {
             io_channel_id,
             message_channel_id,
             share_id,
-            compression_type,
             enable_server_pointer,
             pointer_software_rendering,
         } = self;
@@ -101,7 +66,6 @@ impl ActiveStageBuilder {
             share_id,
             enable_server_pointer,
             pointer_software_rendering,
-            bulk_decompressor: make_bulk_decompressor(compression_type),
         }
         .build();
 
@@ -109,7 +73,6 @@ impl ActiveStageBuilder {
             x224_processor,
             fast_path_processor,
             enable_server_pointer,
-            compression_type,
         }
     }
 }
@@ -233,9 +196,8 @@ impl ActiveStage {
 
     /// Replaces the fast-path processor wholesale.
     ///
-    /// Prefer [`ActiveStage::reactivate`] for a Deactivation-Reactivation Sequence: a processor
-    /// built here carries whatever decompressor the caller supplied, so passing none silently
-    /// disables bulk decompression for the rest of the session.
+    /// Prefer [`ActiveStage::reactivate`] for a Deactivation-Reactivation Sequence: it also
+    /// updates the share_id and the server-pointer setting, which a bare replacement does not.
     pub fn set_fastpath_processor(&mut self, processor: fast_path::Processor) {
         self.fast_path_processor = processor;
     }
@@ -254,10 +216,10 @@ impl ActiveStage {
 
     /// Rebuilds the fast-path processor for a [Deactivation-Reactivation Sequence].
     ///
-    /// The negotiated bulk compression is preserved by recreating the decompressor from the
-    /// retained compression type — the fast-path processor is stateless across reactivation except
-    /// for that, so rebuilding it without the decompressor (as a naive rebuild would) silently
-    /// breaks decoding of every subsequent compressed update.
+    /// The rebuilt processor owns a fresh bulk decompressor, so compressed updates keep
+    /// decoding after reactivation. Decompression history is not carried across the rebuild;
+    /// the server signals history resets with the PACKET_FLUSHED and PACKET_AT_FRONT
+    /// compression flags, which are applied per update.
     ///
     /// [Deactivation-Reactivation Sequence]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/dfc234ce-481a-4674-9a5d-2a7bafb14432
     pub fn reactivate(
@@ -274,7 +236,6 @@ impl ActiveStage {
             share_id,
             enable_server_pointer,
             pointer_software_rendering,
-            bulk_decompressor: make_bulk_decompressor(self.compression_type),
         }
         .build();
         // The x224 processor encodes ShareDataPdu with the server's (possibly new) share_id.

--- a/crates/ironrdp-session/src/fast_path.rs
+++ b/crates/ironrdp-session/src/fast_path.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use ironrdp_bulk::BulkCompressor;
+use ironrdp_bulk::{BulkCompressor, CompressionType};
 use ironrdp_core::{DecodeErrorKind, ReadCursor, WriteBuf, decode_cursor};
 use ironrdp_graphics::image_processing::PixelFormat;
 use ironrdp_graphics::pointer::{DecodedPointer, PointerBitmapTarget};
@@ -35,7 +35,6 @@ mod tests {
             share_id: 0,
             enable_server_pointer: false,
             pointer_software_rendering: false,
-            bulk_decompressor: None,
         }
         .build();
         let mut image = DecodedImage::new(PixelFormat::RgbA32, 4, 3);
@@ -77,6 +76,49 @@ mod tests {
         assert_eq!(pixel(2, 1), [4, 5, 6, 255]);
         assert_eq!(pixel(3, 0), [0, 0, 0, 0]);
     }
+
+    /// The decompressor is owned by the library, but a session that never receives a
+    /// compressed update should not pay for the algorithm contexts. `ironrdp-web` never
+    /// negotiates compression, so this is its normal case.
+    #[test]
+    fn decompressor_is_not_built_until_an_update_needs_it() {
+        use ironrdp_core::encode_vec;
+        use ironrdp_pdu::fast_path::UpdateCode;
+
+        let mut processor = ProcessorBuilder {
+            io_channel_id: 0,
+            user_channel_id: 0,
+            share_id: 0,
+            enable_server_pointer: false,
+            pointer_software_rendering: false,
+        }
+        .build();
+
+        assert!(
+            processor.bulk_decompressor.is_none(),
+            "a freshly built processor must not allocate the bulk contexts"
+        );
+
+        let frame = encode_vec(&FastPathUpdatePdu {
+            fragmentation: Fragmentation::Single,
+            update_code: UpdateCode::Bitmap,
+            compression_flags: None,
+            compression_type: None,
+            data: &[],
+        })
+        .expect("encode uncompressed FastPath update");
+
+        let mut image = DecodedImage::new(PixelFormat::RgbA32, 4, 4);
+        let mut output = WriteBuf::new();
+        // The empty bitmap payload does not decode; only the allocation behaviour on the
+        // way there is under test, so the update result is deliberately ignored.
+        let _result = processor.process_single_update(&mut ReadCursor::new(&frame), &mut image, &mut output);
+
+        assert!(
+            processor.bulk_decompressor.is_none(),
+            "an update carrying no compression flags must not build a decompressor"
+        );
+    }
 }
 
 #[derive(Debug)]
@@ -99,8 +141,12 @@ pub struct Processor {
     mouse_pos_update: Option<(u16, u16)>,
     enable_server_pointer: bool,
     pointer_software_rendering: bool,
-    /// Bulk decompressor for server-to-client compressed PDUs.
-    /// `None` when compression was not negotiated.
+    /// Bulk decompressor for server-to-client compressed PDUs. Owned by the library
+    /// and built on the first update that needs one, so a compressed update is always
+    /// decodable without a session that never receives one paying for the algorithm
+    /// contexts (the two XCRUSH history buffers are 2 MB each). This is not a
+    /// consumer-visible option: `ProcessorBuilder` has no corresponding field, so
+    /// there is no way to construct a `Processor` that cannot decompress.
     bulk_decompressor: Option<BulkCompressor>,
     /// Current 8bpp color palette. Updated by Palette fast-path updates.
     palette: Palette,
@@ -162,26 +208,27 @@ impl Processor {
                 let bulk_flags =
                     u32::from(flags.bits()) | u32::from(update_pdu.compression_type.map_or(0, |ct| ct.as_u8()));
 
-                if let Some(ref mut decompressor) = self.bulk_decompressor {
-                    let decompressed = decompressor
-                        .decompress(update_pdu.data, bulk_flags)
-                        .map_err(|e| reason_err!("FastPath", "bulk decompression failed: {}", e))?;
-                    // Copy decompressed data before accessing metrics (releases the mutable borrow).
-                    decompressed_data = decompressed.to_vec();
-                    debug!(
-                        compressed_size = update_pdu.data.len(),
-                        decompressed_size = decompressed_data.len(),
-                        compression_type = ?update_pdu.compression_type,
-                        compression_ratio = format_args!("{:.2}x", decompressor.compression_ratio()),
-                        total_compressed = decompressor.total_compressed_bytes(),
-                        total_uncompressed = decompressor.total_uncompressed_bytes(),
-                        "Decompressed FastPath update"
-                    );
-                    decompressed_data.as_slice()
-                } else {
-                    warn!("Received compressed FastPath data but no decompressor is configured");
-                    update_pdu.data
-                }
+                // Built on first use. The construction-time type does not constrain what
+                // can be decoded: `decompress` selects the algorithm per update from the
+                // packet's own type bits, so Rdp61 here is an arbitrary starting point.
+                let decompressor = self
+                    .bulk_decompressor
+                    .get_or_insert_with(|| BulkCompressor::new(CompressionType::Rdp61));
+                let decompressed = decompressor
+                    .decompress(update_pdu.data, bulk_flags)
+                    .map_err(|e| reason_err!("FastPath", "bulk decompression failed: {}", e))?;
+                // Copy decompressed data before accessing metrics (releases the mutable borrow).
+                decompressed_data = decompressed.to_vec();
+                debug!(
+                    compressed_size = update_pdu.data.len(),
+                    decompressed_size = decompressed_data.len(),
+                    compression_type = ?update_pdu.compression_type,
+                    compression_ratio = format_args!("{:.2}x", decompressor.compression_ratio()),
+                    total_compressed = decompressor.total_compressed_bytes(),
+                    total_uncompressed = decompressor.total_uncompressed_bytes(),
+                    "Decompressed FastPath update"
+                );
+                decompressed_data.as_slice()
             } else {
                 // Compression flags present but COMPRESSED bit not set — pass data through.
                 // Still need to inform the decompressor of FLUSHED/AT_FRONT flags even
@@ -706,9 +753,6 @@ pub struct ProcessorBuilder {
     /// `UpdateKind::PointerBitmap` will not be generated. Remote pointer will be drawn
     /// via software rendering on top of the output image.
     pub pointer_software_rendering: bool,
-    /// Bulk decompressor for server-to-client compressed PDUs.
-    /// `None` when compression was not negotiated.
-    pub bulk_decompressor: Option<BulkCompressor>,
 }
 
 impl ProcessorBuilder {
@@ -723,7 +767,8 @@ impl ProcessorBuilder {
             mouse_pos_update: None,
             enable_server_pointer: self.enable_server_pointer,
             pointer_software_rendering: self.pointer_software_rendering,
-            bulk_decompressor: self.bulk_decompressor,
+            // Built on the first update that needs it; see the field documentation.
+            bulk_decompressor: None,
             palette: Palette::system_default(),
             #[cfg(feature = "qoiz")]
             zdctx: zstd_safe::DCtx::default(),

--- a/crates/ironrdp-testsuite-core/Cargo.toml
+++ b/crates/ironrdp-testsuite-core/Cargo.toml
@@ -40,6 +40,7 @@ hex = "0.4"
 ironrdp-cliprdr-format.path = "../ironrdp-cliprdr-format"
 ironrdp-cliprdr = { path = "../ironrdp-cliprdr", features = ["__test"] }
 ironrdp-acceptor.path = "../ironrdp-acceptor"
+ironrdp-bulk.path = "../ironrdp-bulk"
 ironrdp-connector.path = "../ironrdp-connector"
 ironrdp-displaycontrol.path = "../ironrdp-displaycontrol"
 ironrdp-dvc.path = "../ironrdp-dvc"

--- a/crates/ironrdp-testsuite-core/tests/session/fast_path.rs
+++ b/crates/ironrdp-testsuite-core/tests/session/fast_path.rs
@@ -1,0 +1,146 @@
+//! Regression tests for bulk-compressed FastPath updates.
+//!
+//! A FastPath `Processor` always owns a bulk decompressor: the library builds
+//! one in `ProcessorBuilder::build`. A server can send a compressed FastPath
+//! update (for example a full-frame redraw after a resize) regardless of what
+//! the client advertised, so the decompressor must always be present. These
+//! tests pin that a compressed update decodes to exactly the same pixels as its
+//! uncompressed twin rather than being dropped or aborting the session.
+
+use ironrdp_bulk::{BulkCompressor, CompressionType as BulkCompressionType, flags as bulk_flags};
+use ironrdp_core::{WriteBuf, encode_vec};
+use ironrdp_graphics::image_processing::PixelFormat;
+use ironrdp_pdu::bitmap::{BitmapData, BitmapUpdateData, Compression};
+use ironrdp_pdu::fast_path::{
+    Compression as FpCompression, EncryptionFlags, FastPathHeader, FastPathUpdatePdu, Fragmentation, UpdateCode,
+};
+use ironrdp_pdu::geometry::InclusiveRectangle;
+use ironrdp_pdu::rdp::client_info::CompressionType as PduCompressionType;
+use ironrdp_pdu::rdp::headers::CompressionFlags;
+use ironrdp_session::fast_path::{Processor, ProcessorBuilder};
+use ironrdp_session::image::DecodedImage;
+
+const IMAGE_DIM: u16 = 64;
+const RECT_DIM: u16 = 8;
+
+fn processor() -> Processor {
+    ProcessorBuilder {
+        io_channel_id: 0,
+        user_channel_id: 0,
+        share_id: 0,
+        enable_server_pointer: false,
+        pointer_software_rendering: false,
+    }
+    .build()
+}
+
+/// Encodes the inner FastPath Bitmap update: a single uncompressed 8x8 32bpp
+/// rectangle filled with a repetitive (and therefore compressible) pattern.
+fn bitmap_update_payload() -> Vec<u8> {
+    let pixels: Vec<u8> = (0..RECT_DIM * RECT_DIM)
+        .flat_map(|_| [0x11u8, 0x22, 0x33, 0xff])
+        .collect();
+
+    let update = BitmapUpdateData {
+        rectangles: vec![BitmapData {
+            rectangle: InclusiveRectangle {
+                left: 0,
+                top: 0,
+                right: RECT_DIM - 1,
+                bottom: RECT_DIM - 1,
+            },
+            width: RECT_DIM,
+            height: RECT_DIM,
+            bits_per_pixel: 32,
+            compression_flags: Compression::empty(),
+            compressed_data_header: None,
+            bitmap_data: &pixels,
+        }],
+    };
+
+    encode_vec(&update).expect("encode bitmap update")
+}
+
+/// Wraps an encoded `FastPathUpdatePdu` in a FastPath output frame (the
+/// `FastPathHeader` that `Processor::process` expects to read first).
+fn fastpath_frame(update_pdu: &[u8]) -> Vec<u8> {
+    let header = FastPathHeader::new(EncryptionFlags::empty(), update_pdu.len());
+    let mut frame = encode_vec(&header).expect("encode FastPath header");
+    frame.extend_from_slice(update_pdu);
+    frame
+}
+
+/// Runs one FastPath frame through a fresh processor and returns the resulting
+/// framebuffer.
+fn render(frame: &[u8]) -> DecodedImage {
+    let mut image = DecodedImage::new(PixelFormat::RgbA32, IMAGE_DIM, IMAGE_DIM);
+    let mut output = WriteBuf::new();
+    processor()
+        .process(&mut image, frame, &mut output)
+        .expect("process FastPath frame");
+    image
+}
+
+#[test]
+fn compressed_fastpath_update_decompresses_like_its_uncompressed_twin() {
+    let payload = bitmap_update_payload();
+
+    let uncompressed = fastpath_frame(
+        &encode_vec(&FastPathUpdatePdu {
+            fragmentation: Fragmentation::Single,
+            update_code: UpdateCode::Bitmap,
+            compression_flags: None,
+            compression_type: None,
+            data: &payload,
+        })
+        .expect("encode uncompressed FastPath update"),
+    );
+
+    // Bulk-compress the same payload (RDP5 / MPPC) and wrap it as a compressed
+    // FastPath update.
+    let mut compressor = BulkCompressor::new(BulkCompressionType::Rdp5);
+    let (size, flags) = compressor.compress(&payload).expect("bulk compress payload");
+    assert_ne!(
+        flags & bulk_flags::PACKET_COMPRESSED,
+        0,
+        "test payload must actually compress; adjust it if MPPC declines to compress"
+    );
+    let compressed_data = compressor.compressed_data(size).to_vec();
+
+    let mut compressed_pdu = encode_vec(&FastPathUpdatePdu {
+        fragmentation: Fragmentation::Single,
+        update_code: UpdateCode::Bitmap,
+        // Carry the compressor's control bits (notably PACKET_AT_FRONT) so the
+        // decompressor resets its history at the start of the stream.
+        compression_flags: Some(CompressionFlags::from_bits_retain(
+            u8::try_from(flags & 0xe0).expect("control-flag byte fits in u8"),
+        )),
+        compression_type: Some(PduCompressionType::K64),
+        data: &compressed_data,
+    })
+    .expect("encode compressed FastPath update");
+    // `FastPathUpdatePdu::encode` writes the update header byte before it sets the
+    // COMPRESSION_USED bit, so the encoded header does not flag the trailing
+    // compression byte. Set it here so the PDU decodes as compressed (idempotent
+    // if the encoder is corrected).
+    compressed_pdu[0] |= FpCompression::COMPRESSION_USED.bits() << 6;
+    let compressed = fastpath_frame(&compressed_pdu);
+
+    let from_uncompressed = render(&uncompressed);
+    let from_compressed = render(&compressed);
+
+    assert_eq!(
+        from_uncompressed.data(),
+        from_compressed.data(),
+        "compressed FastPath update rendered differently from its uncompressed twin"
+    );
+
+    // Sanity check: the update actually drew something, so the equality above
+    // compares real pixels rather than two blank frames.
+    let blank = DecodedImage::new(PixelFormat::RgbA32, IMAGE_DIM, IMAGE_DIM);
+    assert_ne!(
+        from_uncompressed.data(),
+        blank.data(),
+        "the bitmap update should have modified the framebuffer"
+    );
+}

--- a/crates/ironrdp-testsuite-core/tests/session/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/session/mod.rs
@@ -1,5 +1,6 @@
 mod autodetect;
 mod connection_activation;
+mod fast_path;
 mod rfx;
 
 #[cfg(test)]

--- a/crates/ironrdp-testsuite-extra/tests/e2e.rs
+++ b/crates/ironrdp-testsuite-extra/tests/e2e.rs
@@ -136,7 +136,6 @@ fn test_reactivation_processes_compressed_fastpath_updates() {
         io_channel_id: 1003,
         message_channel_id: None,
         share_id: 1,
-        compression_type: Some(PduCompressionType::K64),
         enable_server_pointer: false,
         pointer_software_rendering: false,
     }
@@ -174,7 +173,7 @@ fn compressed_bitmap_fastpath_frame() -> Vec<u8> {
     };
     let bitmap_data = ironrdp::core::encode_vec(&bitmap).expect("encode bitmap update");
 
-    let mut compressor = BulkCompressor::new(BulkCompressionType::Rdp5).expect("create bulk compressor");
+    let mut compressor = BulkCompressor::new(BulkCompressionType::Rdp5);
     let (compressed_size, flags) = compressor.compress(&bitmap_data).expect("compress bitmap update");
     assert_ne!(flags & bulk_flags::PACKET_COMPRESSED, 0);
 
@@ -399,7 +398,6 @@ where
                     io_channel_id: connection_result.io_channel_id,
                     message_channel_id: connection_result.message_channel_id,
                     share_id: connection_result.share_id,
-                    compression_type: connection_result.compression_type,
                     enable_server_pointer: connection_result.enable_server_pointer,
                     pointer_software_rendering: connection_result.pointer_software_rendering,
                 }

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -669,7 +669,6 @@ impl iron_remote_desktop::Session for Session {
             io_channel_id: connection_result.io_channel_id,
             message_channel_id: connection_result.message_channel_id,
             share_id: connection_result.share_id,
-            compression_type: connection_result.compression_type,
             enable_server_pointer: connection_result.enable_server_pointer,
             pointer_software_rendering: connection_result.pointer_software_rendering,
         }

--- a/crates/ironrdp/examples/screenshot.rs
+++ b/crates/ironrdp/examples/screenshot.rs
@@ -350,7 +350,6 @@ fn active_stage(
         io_channel_id: connection_result.io_channel_id,
         message_channel_id: connection_result.message_channel_id,
         share_id: connection_result.share_id,
-        compression_type: connection_result.compression_type,
         enable_server_pointer: connection_result.enable_server_pointer,
         pointer_software_rendering: connection_result.pointer_software_rendering,
     }

--- a/ffi/src/session/mod.rs
+++ b/ffi/src/session/mod.rs
@@ -55,7 +55,6 @@ pub mod ffi {
                 io_channel_id: connection_result.io_channel_id,
                 message_channel_id: connection_result.message_channel_id,
                 share_id: connection_result.share_id,
-                compression_type: connection_result.compression_type,
                 enable_server_pointer: connection_result.enable_server_pointer,
                 pointer_software_rendering: connection_result.pointer_software_rendering,
             }


### PR DESCRIPTION
## Summary

- A compressed FastPath update is dropped whenever the client did not negotiate compression, because the decompressor is only built when a compression type was negotiated. Servers send compressed updates regardless, for example on a full-frame redraw after a resize, and the session then fails. Closes #1193.
- The negotiated type is the wrong thing to condition on. It describes what the client would send, and nothing in `ironrdp-session`, `ironrdp-client`, `ironrdp-web` or the FFI ever compresses outbound. On the receive path `BulkCompressor` holds a context per algorithm and `decompress` selects one per update from the packet's own type bits, so a decompressor built with any type decodes all of them.
- The `Processor` now owns the decompressor and builds it on the first update that needs one. `ProcessorBuilder` has no corresponding field, so there is no `None` a consumer can pass and no path that drops a compressed update.
- On demand rather than at construction because `ironrdp-web` hardcodes `compression_type: None` in `build_config` and so never negotiates compression. Constructing eagerly would charge every web session for a full set of algorithm contexts, and the two XCRUSH history buffers alone are 2 MB each, for a decompressor most of those sessions never use. That consumer is also the one most exposed to this bug, for the same reason.
- `BulkCompressor::new` is now infallible. Its only failure path was a self-check over NCRUSH's static Huffman tables, a compile-time invariant, now a `debug_assert`.

## Relationship to #1474

#1474 is kept, not reverted. `ActiveStage::reactivate` is adopted as the reactivation entry point at all four call sites it introduced: native client, web, FFI and the e2e test.

What this PR removes is the `compression_type` retained on `ActiveStage` and the `make_bulk_decompressor` helper, because an on-demand decompressor makes both unnecessary. `reactivate` keeps its behaviour and loses only the compression plumbing.

#1474 closed the reactivation instance of #1193, where a rebuild passed `None` and silently disabled decompression for the rest of the session. The general case is still open on master: when compression was never negotiated the retained type is `None`, `make_bulk_decompressor` returns `None`, and every compressed update takes the drop path in `fast_path.rs` for the lifetime of the session. Conditioning on the negotiated type gates the ability to receive on what was negotiated to send, and nothing sends.

The evidence that removing the field is safe is #1474's own test. `test_reactivation_processes_compressed_fastpath_updates` passes unchanged with `compression_type` gone from the builder: the rebuilt processor decompresses because every processor can, not because a type was carried across the rebuild.

## Validation

`cargo xtask check fmt/lints/tests/typos/locks` all pass.

The gated regression test is `testsuite-core/tests/session/fast_path.rs`, which renders the same bitmap update plain and bulk-compressed through fresh processors and asserts identical framebuffers. #1474's `test_reactivation_processes_compressed_fastpath_updates` in `testsuite-extra` passes unchanged.

There is also an inline test in `fast_path.rs` pinning the allocation invariant, that no contexts are built until an update needs them. Note that `ironrdp-session` sets `[lib] test = false`, so inline tests in this crate are not run by `cargo test --workspace`; it runs under `cargo test -p ironrdp-session --lib`.

## Notes

- This addresses the four points from the 2026-06-24 review. Point 4, that the `Option` is misleading, is the shape of this change: it is gone from the public API, and the private one that remains carries no implication that a consumer could choose not to decompress. Point 1, whether a cold `Rdp61` context decodes `RDP40` and `RDP50` updates correctly, is a non-issue: `decompress` selects the algorithm per update through `CompressionType::from_flags` against per-algorithm receive contexts, so the construction-time type never constrains the receive path. Point 3, silent degradation if the constructor fails, is removed by making `new` infallible. Point 2 is the tests above.
- Breaking across two crates, hence the `fix(bulk,session)!` scope: `ProcessorBuilder` loses `bulk_decompressor`, `ActiveStageBuilder` loses `compression_type`, and `ironrdp_bulk::BulkCompressor::new` returns `Self`.
- Incidental: `ironrdp-session` no longer exposes any `ironrdp_bulk` type in its public API, so that dependency's lack of a `# public` marker in `Cargo.toml` is now correct.
