### PR TITLE
refactor(mstsgu): derive Display and Error for GwErrorKind via thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2690,6 +2690,7 @@ dependencies = [
  "ironrdp-error",
  "ironrdp-tls",
  "log",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
  "tokio-util",

--- a/crates/ironrdp-mstsgu/Cargo.toml
+++ b/crates/ironrdp-mstsgu/Cargo.toml
@@ -33,6 +33,7 @@ ironrdp-core = { path = "../ironrdp-core", version = "0.1", features = ["std"] }
 ironrdp-error = { path = "../ironrdp-error", version = "0.1" }
 ironrdp-tls = { path = "../ironrdp-tls", version = "0.2" }
 log = "0.4"
+thiserror = "2"
 tokio-tungstenite = { version = "0.29" }
 tokio-util = { version = "0.7" }
 tokio = { version = "1.52", features = ["macros", "rt"] }

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -6,8 +6,6 @@ mod macros;
 
 mod proto;
 
-use core::fmt;
-use core::fmt::Display;
 use core::pin::Pin;
 use core::task::Poll;
 use core::time::Duration;
@@ -46,15 +44,22 @@ pub struct GwConnectTarget {
 
 type Error = ironrdp_error::Error<GwErrorKind>;
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum GwErrorKind {
+    #[error("invalid GW Target")]
     InvalidGwTarget,
+    #[error("connection error")]
     Connect,
+    #[error("PacketEOF")]
     PacketEof,
+    #[error("unsupported feature")]
     UnsupportedFeature,
+    #[error("custom")]
     Custom,
+    #[error("encode")]
     Encode,
+    #[error("decode")]
     Decode,
 }
 
@@ -72,23 +77,6 @@ impl GwErrorExt for ironrdp_error::Error<GwErrorKind> {
         Self::new(context, GwErrorKind::Custom).with_source(e)
     }
 }
-
-impl Display for GwErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let x = match self {
-            GwErrorKind::InvalidGwTarget => "invalid GW Target",
-            GwErrorKind::Connect => "connection error",
-            GwErrorKind::PacketEof => "PacketEOF",
-            GwErrorKind::UnsupportedFeature => "unsupported feature",
-            GwErrorKind::Custom => "custom",
-            GwErrorKind::Encode => "encode",
-            GwErrorKind::Decode => "decode",
-        };
-        f.write_str(x)
-    }
-}
-
-impl core::error::Error for GwErrorKind {}
 
 struct GwConn {
     client_name: String,


### PR DESCRIPTION
Refs #1257.

First proof-of-concept for the broader `thiserror` migration proposed in #1257. `GwErrorKind` is the smallest hand-written `*ErrorKind` enum in the workspace at 7 variants, so it is suitable for verifying that the migration is byte-identity-preserving and that the workspace `thiserror` dep lands cleanly.

### What this changes

Replaces the hand-written `impl Display for GwErrorKind` and `impl core::error::Error for GwErrorKind` blocks with `#[derive(thiserror::Error)]` and per-variant `#[error("...")]` attributes. Adds `thiserror = "2"` to `crates/ironrdp-mstsgu/Cargo.toml` as a direct dependency, following the same pattern that `ironrdp-pdu` already uses for its internal `thiserror` types.

### Public API impact

None. The `pub type Error = ironrdp_error::Error<GwErrorKind>` alias and the `GwErrorExt::custom()` helper are unchanged. Consumers see no source-level break.

### Display byte-identity verification

Verified via `cargo expand`. Both the prior hand-written implementation and the `thiserror`-derived implementation call `formatter.write_str("literal")` with the same string for each of the 7 variants:

| Variant | String |
|---|---|
| `InvalidGwTarget` | `"invalid GW Target"` |
| `Connect` | `"connection error"` |
| `PacketEof` | `"PacketEOF"` |
| `UnsupportedFeature` | `"unsupported feature"` |
| `Custom` | `"custom"` |
| `Encode` | `"encode"` |
| `Decode` | `"decode"` |

### Verification

- `cargo xtask check fmt`: clean
- `cargo xtask check lints`: clean
- `cargo xtask check locks`: clean
- `cargo xtask check typos`: clean
- `cargo xtask check tests`: clean

### MSRV

Unaffected. `thiserror` 2.0 requires Rust 1.61, well below IronRDP's MSRV of 1.89.