### PR TITLE
refactor: derive Display and Error via thiserror across core, pdu, connector, session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2538,6 +2538,7 @@ dependencies = [
  "picky-asn1-x509",
  "rand 0.9.2",
  "sspi",
+ "thiserror 2.0.18",
  "tracing",
  "url",
 ]
@@ -2547,6 +2548,7 @@ name = "ironrdp-core"
 version = "0.1.5"
 dependencies = [
  "ironrdp-error",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2842,6 +2844,7 @@ dependencies = [
  "ironrdp-pdu",
  "ironrdp-svc",
  "qoicoubeh",
+ "thiserror 2.0.18",
  "tracing",
  "zstd-safe",
 ]

--- a/crates/ironrdp-connector/Cargo.toml
+++ b/crates/ironrdp-connector/Cargo.toml
@@ -35,6 +35,7 @@ tracing = { version = "0.1", features = ["log"] }
 picky-asn1-der = "0.5"
 picky-asn1-x509 = "0.15"
 picky = "=7.0.0-rc.22" # FIXME: We are pinning with = because the candidate version number counts as the minor number by Cargo, and will be automatically bumped in the Cargo.lock.
+thiserror = "2"
 
 [lints]
 workspace = true

--- a/crates/ironrdp-connector/src/lib.rs
+++ b/crates/ironrdp-connector/src/lib.rs
@@ -341,46 +341,24 @@ ironrdp_core::assert_obj_safe!(Sequence);
 pub type ConnectorResult<T> = Result<T, ConnectorError>;
 
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ConnectorErrorKind {
-    Encode(ironrdp_core::EncodeError),
-    Decode(ironrdp_core::DecodeError),
-    Credssp(sspi::Error),
+    #[error("encode error")]
+    Encode(#[source] ironrdp_core::EncodeError),
+    #[error("decode error")]
+    Decode(#[source] ironrdp_core::DecodeError),
+    #[error("CredSSP")]
+    Credssp(#[source] sspi::Error),
+    #[error("reason: {0}")]
     Reason(String),
+    #[error("access denied")]
     AccessDenied,
+    #[error("general error")]
     General,
+    #[error("custom error")]
     Custom,
-    Negotiation(NegotiationFailure),
-}
-
-impl fmt::Display for ConnectorErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self {
-            ConnectorErrorKind::Encode(_) => write!(f, "encode error"),
-            ConnectorErrorKind::Decode(_) => write!(f, "decode error"),
-            ConnectorErrorKind::Credssp(_) => write!(f, "CredSSP"),
-            ConnectorErrorKind::Reason(description) => write!(f, "reason: {description}"),
-            ConnectorErrorKind::AccessDenied => write!(f, "access denied"),
-            ConnectorErrorKind::General => write!(f, "general error"),
-            ConnectorErrorKind::Custom => write!(f, "custom error"),
-            ConnectorErrorKind::Negotiation(failure) => write!(f, "negotiation failure: {failure}"),
-        }
-    }
-}
-
-impl core::error::Error for ConnectorErrorKind {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match &self {
-            ConnectorErrorKind::Encode(e) => Some(e),
-            ConnectorErrorKind::Decode(e) => Some(e),
-            ConnectorErrorKind::Credssp(e) => Some(e),
-            ConnectorErrorKind::Reason(_) => None,
-            ConnectorErrorKind::AccessDenied => None,
-            ConnectorErrorKind::Custom => None,
-            ConnectorErrorKind::General => None,
-            ConnectorErrorKind::Negotiation(failure) => Some(failure),
-        }
-    }
+    #[error("negotiation failure: {0}")]
+    Negotiation(#[source] NegotiationFailure),
 }
 
 pub type ConnectorError = ironrdp_error::Error<ConnectorErrorKind>;

--- a/crates/ironrdp-core/Cargo.toml
+++ b/crates/ironrdp-core/Cargo.toml
@@ -18,8 +18,9 @@ test = false
 
 [features]
 default = []
-std = ["alloc", "ironrdp-error/std"]
+std = ["alloc", "ironrdp-error/std", "thiserror/std"]
 alloc = ["ironrdp-error/alloc"]
 
 [dependencies]
 ironrdp-error = { path = "../ironrdp-error", version = "0.1" } # public
+thiserror = { version = "2", default-features = false }

--- a/crates/ironrdp-core/src/decode.rs
+++ b/crates/ironrdp-core/src/decode.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "alloc")]
 use alloc::string::String;
-use core::fmt;
 
 use crate::{
     InvalidFieldErr, NotEnoughBytesErr, OtherErr, ReadCursor, UnexpectedMessageTypeErr, UnsupportedValueErr,
@@ -16,9 +15,10 @@ pub type DecodeError = ironrdp_error::Error<DecodeErrorKind>;
 
 /// Enum representing different kinds of decode errors.
 #[non_exhaustive]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, thiserror::Error)]
 pub enum DecodeErrorKind {
     /// Error when there are not enough bytes to decode.
+    #[error("not enough bytes provided to decode: received {received} bytes, expected {expected} bytes")]
     NotEnoughBytes {
         /// Number of bytes received.
         received: usize,
@@ -26,6 +26,7 @@ pub enum DecodeErrorKind {
         expected: usize,
     },
     /// Error when a field is invalid.
+    #[error("invalid `{field}`: {reason}")]
     InvalidField {
         /// Name of the invalid field.
         field: &'static str,
@@ -33,17 +34,20 @@ pub enum DecodeErrorKind {
         reason: &'static str,
     },
     /// Error when an unexpected message type is encountered.
+    #[error("invalid message type ({got})")]
     UnexpectedMessageType {
         /// The unexpected message type received.
         got: u8,
     },
     /// Error when an unsupported version is encountered.
+    #[error("unsupported version ({got})")]
     UnsupportedVersion {
         /// The unsupported version received.
         got: u8,
     },
     /// Error when an unsupported value is encountered (with allocation feature).
     #[cfg(feature = "alloc")]
+    #[error("unsupported {name} ({value})")]
     UnsupportedValue {
         /// Name of the unsupported value.
         name: &'static str,
@@ -52,49 +56,17 @@ pub enum DecodeErrorKind {
     },
     /// Error when an unsupported value is encountered (without allocation feature).
     #[cfg(not(feature = "alloc"))]
+    #[error("unsupported {name}")]
     UnsupportedValue {
         /// Name of the unsupported value.
         name: &'static str,
     },
     /// Generic error for other cases.
+    #[error("other ({description})")]
     Other {
         /// Description of the error.
         description: &'static str,
     },
-}
-
-#[cfg(feature = "std")]
-impl core::error::Error for DecodeErrorKind {}
-
-impl fmt::Display for DecodeErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::NotEnoughBytes { received, expected } => write!(
-                f,
-                "not enough bytes provided to decode: received {received} bytes, expected {expected} bytes"
-            ),
-            Self::InvalidField { field, reason } => {
-                write!(f, "invalid `{field}`: {reason}")
-            }
-            Self::UnexpectedMessageType { got } => {
-                write!(f, "invalid message type ({got})")
-            }
-            Self::UnsupportedVersion { got } => {
-                write!(f, "unsupported version ({got})")
-            }
-            #[cfg(feature = "alloc")]
-            Self::UnsupportedValue { name, value } => {
-                write!(f, "unsupported {name} ({value})")
-            }
-            #[cfg(not(feature = "alloc"))]
-            Self::UnsupportedValue { name } => {
-                write!(f, "unsupported {name}")
-            }
-            Self::Other { description } => {
-                write!(f, "other ({description})")
-            }
-        }
-    }
 }
 
 impl NotEnoughBytesErr for DecodeError {

--- a/crates/ironrdp-core/src/encode.rs
+++ b/crates/ironrdp-core/src/encode.rs
@@ -2,7 +2,6 @@
 use alloc::string::String;
 #[cfg(feature = "alloc")]
 use alloc::{vec, vec::Vec};
-use core::fmt;
 
 #[cfg(feature = "alloc")]
 use crate::WriteBuf;
@@ -20,9 +19,10 @@ pub type EncodeError = ironrdp_error::Error<EncodeErrorKind>;
 
 /// Represents the different kinds of errors that can occur during encoding operations.
 #[non_exhaustive]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, thiserror::Error)]
 pub enum EncodeErrorKind {
     /// Indicates that there were not enough bytes to complete the encoding operation.
+    #[error("not enough bytes provided to decode: received {received} bytes, expected {expected} bytes")]
     NotEnoughBytes {
         /// The number of bytes actually received.
         received: usize,
@@ -30,6 +30,7 @@ pub enum EncodeErrorKind {
         expected: usize,
     },
     /// Indicates that a field in the data being encoded is invalid.
+    #[error("invalid `{field}`: {reason}")]
     InvalidField {
         /// The name of the invalid field.
         field: &'static str,
@@ -37,17 +38,20 @@ pub enum EncodeErrorKind {
         reason: &'static str,
     },
     /// Indicates that an unexpected message type was encountered during encoding.
+    #[error("invalid message type ({got})")]
     UnexpectedMessageType {
         /// The unexpected message type that was received.
         got: u8,
     },
     /// Indicates that an unsupported version was encountered during encoding.
+    #[error("unsupported version ({got})")]
     UnsupportedVersion {
         /// The unsupported version that was received.
         got: u8,
     },
     /// Indicates that an unsupported value was encountered during encoding.
     #[cfg(feature = "alloc")]
+    #[error("unsupported {name} ({value})")]
     UnsupportedValue {
         /// The name of the field or parameter with the unsupported value.
         name: &'static str,
@@ -56,49 +60,17 @@ pub enum EncodeErrorKind {
     },
     /// Indicates that an unsupported value was encountered during encoding (no-alloc version).
     #[cfg(not(feature = "alloc"))]
+    #[error("unsupported {name}")]
     UnsupportedValue {
         /// The name of the field or parameter with the unsupported value.
         name: &'static str,
     },
     /// Represents any other error that doesn't fit into the above categories.
+    #[error("other ({description})")]
     Other {
         /// A description of the error.
         description: &'static str,
     },
-}
-
-#[cfg(feature = "std")]
-impl core::error::Error for EncodeErrorKind {}
-
-impl fmt::Display for EncodeErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::NotEnoughBytes { received, expected } => write!(
-                f,
-                "not enough bytes provided to decode: received {received} bytes, expected {expected} bytes"
-            ),
-            Self::InvalidField { field, reason } => {
-                write!(f, "invalid `{field}`: {reason}")
-            }
-            Self::UnexpectedMessageType { got } => {
-                write!(f, "invalid message type ({got})")
-            }
-            Self::UnsupportedVersion { got } => {
-                write!(f, "unsupported version ({got})")
-            }
-            #[cfg(feature = "alloc")]
-            Self::UnsupportedValue { name, value } => {
-                write!(f, "unsupported {name} ({value})")
-            }
-            #[cfg(not(feature = "alloc"))]
-            Self::UnsupportedValue { name } => {
-                write!(f, "unsupported {name}")
-            }
-            Self::Other { description } => {
-                write!(f, "other ({description})")
-            }
-        }
-    }
 }
 
 impl NotEnoughBytesErr for EncodeError {

--- a/crates/ironrdp-pdu/src/lib.rs
+++ b/crates/ironrdp-pdu/src/lib.rs
@@ -37,10 +37,13 @@ pub type PduResult<T> = Result<T, PduError>;
 pub type PduError = ironrdp_error::Error<PduErrorKind>;
 
 #[non_exhaustive]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, thiserror::Error)]
 pub enum PduErrorKind {
+    #[error("encode error")]
     Encode,
+    #[error("decode error")]
     Decode,
+    #[error("other ({description})")]
     Other { description: &'static str },
 }
 
@@ -57,24 +60,6 @@ impl PduErrorExt for PduError {
 
     fn encode<E: Source>(context: &'static str, source: E) -> Self {
         Self::new(context, PduErrorKind::Encode).with_source(source)
-    }
-}
-
-impl core::error::Error for PduErrorKind {}
-
-impl fmt::Display for PduErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Encode => {
-                write!(f, "encode error")
-            }
-            Self::Decode => {
-                write!(f, "decode error")
-            }
-            Self::Other { description } => {
-                write!(f, "other ({description})")
-            }
-        }
     }
 }
 

--- a/crates/ironrdp-session/Cargo.toml
+++ b/crates/ironrdp-session/Cargo.toml
@@ -31,6 +31,7 @@ ironrdp-error = { path = "../ironrdp-error", version = "0.1" } # public
 ironrdp-graphics = { path = "../ironrdp-graphics", version = "0.7" } # public
 ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.7", features = ["std"] } # public
 ironrdp-displaycontrol = { path = "../ironrdp-displaycontrol", version = "0.5" }
+thiserror = "2"
 tracing = { version = "0.1", features = ["log"] }
 qoicoubeh = { version = "0.5", optional = true }
 zstd-safe = { version = "7.2", optional = true, features = ["std"] }

--- a/crates/ironrdp-session/src/lib.rs
+++ b/crates/ironrdp-session/src/lib.rs
@@ -14,47 +14,25 @@ pub mod x224;
 mod active_stage;
 mod palette;
 
-use core::fmt;
-
 pub use active_stage::{ActiveStage, ActiveStageOutput, GracefulDisconnectReason};
 
 pub type SessionResult<T> = Result<T, SessionError>;
 
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum SessionErrorKind {
-    Pdu(ironrdp_pdu::PduError),
-    Encode(ironrdp_core::EncodeError),
-    Decode(ironrdp_core::DecodeError),
+    #[error("PDU error")]
+    Pdu(#[source] ironrdp_pdu::PduError),
+    #[error("encode error")]
+    Encode(#[source] ironrdp_core::EncodeError),
+    #[error("decode error")]
+    Decode(#[source] ironrdp_core::DecodeError),
+    #[error("reason: {0}")]
     Reason(String),
+    #[error("general error")]
     General,
+    #[error("custom error")]
     Custom,
-}
-
-impl fmt::Display for SessionErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self {
-            SessionErrorKind::Pdu(_) => write!(f, "PDU error"),
-            SessionErrorKind::Encode(_) => write!(f, "encode error"),
-            SessionErrorKind::Decode(_) => write!(f, "decode error"),
-            SessionErrorKind::Reason(description) => write!(f, "reason: {description}"),
-            SessionErrorKind::General => write!(f, "general error"),
-            SessionErrorKind::Custom => write!(f, "custom error"),
-        }
-    }
-}
-
-impl core::error::Error for SessionErrorKind {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match &self {
-            SessionErrorKind::Pdu(e) => Some(e),
-            SessionErrorKind::Encode(e) => Some(e),
-            SessionErrorKind::Decode(e) => Some(e),
-            SessionErrorKind::Reason(_) => None,
-            SessionErrorKind::General => None,
-            SessionErrorKind::Custom => None,
-        }
-    }
 }
 
 pub type SessionError = ironrdp_error::Error<SessionErrorKind>;


### PR DESCRIPTION
Refs #1257.

Second batch in the `thiserror` migration proposed in #1257. The first batch (#1258, mstsgu) verified the byte-identical Display approach on the smallest hand-written `*ErrorKind` enum. This batch applies the same pattern to the four remaining crates with hand-written `Display + core::error::Error` impls atop `ironrdp-error::Error<Kind>`.

### What this changes per crate

- **`ironrdp-core`**: adds `thiserror = { version = "2", default-features = false }` and wires `thiserror/std` into the existing `std` feature. Both `DecodeErrorKind` and `EncodeErrorKind` are derived. The cfg-gated `UnsupportedValue` variants (with/without `alloc`) each receive their own `#[error("...")]` attribute matching the prior format string. The `#[cfg(feature = "std")] impl core::error::Error` gate is removed since `core::error::Error` is in core (stabilised Rust 1.81, well below MSRV 1.89) and thiserror's derive emits an unconditional impl.
- **`ironrdp-pdu`**: thiserror was already pinned at `"2.0"` for some internal types. `PduErrorKind` is now derived. Hand-written `Display` and `Error` impls removed.
- **`ironrdp-connector`**: adds `thiserror = "2"`. `ConnectorErrorKind` is derived. Tuple variants (`Encode`, `Decode`, `Credssp`, `Negotiation`) receive `#[source]` attributes so the source chain that the prior hand-written `source()` impl established is preserved.
- **`ironrdp-session`**: same pattern as connector. `SessionErrorKind` is derived with `#[source]` on `Pdu`, `Encode`, `Decode` tuple variants. Removes a now-unused `use core::fmt;` import.

### Public API impact

None. The `pub type FooError = ironrdp_error::Error<FooErrorKind>` aliases and the `*ErrorExt` traits are unchanged. Consumers see no source-level break.

### Display byte-identity verification

Verified via `cargo expand`. Each derived impl calls `formatter.write_str()` or `write_fmt(format_args!())` with the same literal/arguments as the prior hand-written code. Unit variants emit identical `write_str` calls; tuple variants with formatted source emit `format_args!("prefix: {0}", _0.as_display())` which calls `Display` on the inner field, identical to the prior `write!(f, "prefix: {field_name}")`.

### no_std verification (ironrdp-core)

All three feature combinations build clean:
- `cargo check -p ironrdp-core --no-default-features` (no_std, no alloc)
- `cargo check -p ironrdp-core --no-default-features --features alloc` (no_std + alloc)
- `cargo check -p ironrdp-core --features std` (std)

### xtask verification

- `cargo xtask check fmt`: clean
- `cargo xtask check lints`: clean
- `cargo xtask check locks`: clean
- `cargo xtask check typos`: clean
- `cargo xtask check tests`: clean

### Diff size

9 files changed, +50 −159 (net −109 lines of code removed).