### PR TITLE
refactor: derive Display and Error via thiserror in pdu, connector, session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2538,6 +2538,7 @@ dependencies = [
  "picky-asn1-x509",
  "rand 0.9.2",
  "sspi",
+ "thiserror 2.0.18",
  "tracing",
  "url",
 ]
@@ -2842,6 +2843,7 @@ dependencies = [
  "ironrdp-pdu",
  "ironrdp-svc",
  "qoicoubeh",
+ "thiserror 2.0.18",
  "tracing",
  "zstd-safe",
 ]

--- a/crates/ironrdp-connector/Cargo.toml
+++ b/crates/ironrdp-connector/Cargo.toml
@@ -35,6 +35,7 @@ tracing = { version = "0.1", features = ["log"] }
 picky-asn1-der = "0.5"
 picky-asn1-x509 = "0.15"
 picky = "=7.0.0-rc.22" # FIXME: We are pinning with = because the candidate version number counts as the minor number by Cargo, and will be automatically bumped in the Cargo.lock.
+thiserror = "2"
 
 [lints]
 workspace = true

--- a/crates/ironrdp-connector/src/lib.rs
+++ b/crates/ironrdp-connector/src/lib.rs
@@ -341,46 +341,24 @@ ironrdp_core::assert_obj_safe!(Sequence);
 pub type ConnectorResult<T> = Result<T, ConnectorError>;
 
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ConnectorErrorKind {
-    Encode(ironrdp_core::EncodeError),
-    Decode(ironrdp_core::DecodeError),
-    Credssp(sspi::Error),
+    #[error("encode error")]
+    Encode(#[source] ironrdp_core::EncodeError),
+    #[error("decode error")]
+    Decode(#[source] ironrdp_core::DecodeError),
+    #[error("CredSSP")]
+    Credssp(#[source] sspi::Error),
+    #[error("reason: {0}")]
     Reason(String),
+    #[error("access denied")]
     AccessDenied,
+    #[error("general error")]
     General,
+    #[error("custom error")]
     Custom,
-    Negotiation(NegotiationFailure),
-}
-
-impl fmt::Display for ConnectorErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self {
-            ConnectorErrorKind::Encode(_) => write!(f, "encode error"),
-            ConnectorErrorKind::Decode(_) => write!(f, "decode error"),
-            ConnectorErrorKind::Credssp(_) => write!(f, "CredSSP"),
-            ConnectorErrorKind::Reason(description) => write!(f, "reason: {description}"),
-            ConnectorErrorKind::AccessDenied => write!(f, "access denied"),
-            ConnectorErrorKind::General => write!(f, "general error"),
-            ConnectorErrorKind::Custom => write!(f, "custom error"),
-            ConnectorErrorKind::Negotiation(failure) => write!(f, "negotiation failure: {failure}"),
-        }
-    }
-}
-
-impl core::error::Error for ConnectorErrorKind {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match &self {
-            ConnectorErrorKind::Encode(e) => Some(e),
-            ConnectorErrorKind::Decode(e) => Some(e),
-            ConnectorErrorKind::Credssp(e) => Some(e),
-            ConnectorErrorKind::Reason(_) => None,
-            ConnectorErrorKind::AccessDenied => None,
-            ConnectorErrorKind::Custom => None,
-            ConnectorErrorKind::General => None,
-            ConnectorErrorKind::Negotiation(failure) => Some(failure),
-        }
-    }
+    #[error("negotiation failure: {0}")]
+    Negotiation(#[source] NegotiationFailure),
 }
 
 pub type ConnectorError = ironrdp_error::Error<ConnectorErrorKind>;

--- a/crates/ironrdp-pdu/src/lib.rs
+++ b/crates/ironrdp-pdu/src/lib.rs
@@ -37,10 +37,13 @@ pub type PduResult<T> = Result<T, PduError>;
 pub type PduError = ironrdp_error::Error<PduErrorKind>;
 
 #[non_exhaustive]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, thiserror::Error)]
 pub enum PduErrorKind {
+    #[error("encode error")]
     Encode,
+    #[error("decode error")]
     Decode,
+    #[error("other ({description})")]
     Other { description: &'static str },
 }
 
@@ -57,24 +60,6 @@ impl PduErrorExt for PduError {
 
     fn encode<E: Source>(context: &'static str, source: E) -> Self {
         Self::new(context, PduErrorKind::Encode).with_source(source)
-    }
-}
-
-impl core::error::Error for PduErrorKind {}
-
-impl fmt::Display for PduErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Encode => {
-                write!(f, "encode error")
-            }
-            Self::Decode => {
-                write!(f, "decode error")
-            }
-            Self::Other { description } => {
-                write!(f, "other ({description})")
-            }
-        }
     }
 }
 

--- a/crates/ironrdp-session/Cargo.toml
+++ b/crates/ironrdp-session/Cargo.toml
@@ -31,6 +31,7 @@ ironrdp-error = { path = "../ironrdp-error", version = "0.1" } # public
 ironrdp-graphics = { path = "../ironrdp-graphics", version = "0.7" } # public
 ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.7", features = ["std"] } # public
 ironrdp-displaycontrol = { path = "../ironrdp-displaycontrol", version = "0.5" }
+thiserror = "2"
 tracing = { version = "0.1", features = ["log"] }
 qoicoubeh = { version = "0.5", optional = true }
 zstd-safe = { version = "7.2", optional = true, features = ["std"] }

--- a/crates/ironrdp-session/src/lib.rs
+++ b/crates/ironrdp-session/src/lib.rs
@@ -14,47 +14,25 @@ pub mod x224;
 mod active_stage;
 mod palette;
 
-use core::fmt;
-
 pub use active_stage::{ActiveStage, ActiveStageOutput, GracefulDisconnectReason};
 
 pub type SessionResult<T> = Result<T, SessionError>;
 
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum SessionErrorKind {
-    Pdu(ironrdp_pdu::PduError),
-    Encode(ironrdp_core::EncodeError),
-    Decode(ironrdp_core::DecodeError),
+    #[error("PDU error")]
+    Pdu(#[source] ironrdp_pdu::PduError),
+    #[error("encode error")]
+    Encode(#[source] ironrdp_core::EncodeError),
+    #[error("decode error")]
+    Decode(#[source] ironrdp_core::DecodeError),
+    #[error("reason: {0}")]
     Reason(String),
+    #[error("general error")]
     General,
+    #[error("custom error")]
     Custom,
-}
-
-impl fmt::Display for SessionErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self {
-            SessionErrorKind::Pdu(_) => write!(f, "PDU error"),
-            SessionErrorKind::Encode(_) => write!(f, "encode error"),
-            SessionErrorKind::Decode(_) => write!(f, "decode error"),
-            SessionErrorKind::Reason(description) => write!(f, "reason: {description}"),
-            SessionErrorKind::General => write!(f, "general error"),
-            SessionErrorKind::Custom => write!(f, "custom error"),
-        }
-    }
-}
-
-impl core::error::Error for SessionErrorKind {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match &self {
-            SessionErrorKind::Pdu(e) => Some(e),
-            SessionErrorKind::Encode(e) => Some(e),
-            SessionErrorKind::Decode(e) => Some(e),
-            SessionErrorKind::Reason(_) => None,
-            SessionErrorKind::General => None,
-            SessionErrorKind::Custom => None,
-        }
-    }
 }
 
 pub type SessionError = ironrdp_error::Error<SessionErrorKind>;


### PR DESCRIPTION
Refs #1257. Replaces #1259 (closed for split).

Part of the thiserror migration proposed in #1257. The first proof-of-concept (#1258, mstsgu) verified the byte-identical Display approach. This PR applies the same mechanical pattern to the three std-only crates with hand-written `*ErrorKind` impls atop `ironrdp-error`. `ironrdp-core` is handled in a separate PR (incoming) because of its no_std-aware feature wiring.

### Per-crate notes

- **`ironrdp-pdu`**: `thiserror` was already pinned at `"2.0"` for some internal types. `PduErrorKind` is now derived. Hand-written `Display` and `Error` impls removed.
- **`ironrdp-connector`**: adds `thiserror = "2"` as a direct dep. `ConnectorErrorKind` is derived. Tuple variants (`Encode`, `Decode`, `Credssp`, `Negotiation`) receive `#[source]` attributes so the source chain that the prior hand-written `core::error::Error::source()` impl established is preserved.
- **`ironrdp-session`**: same pattern as connector. `SessionErrorKind` is derived with `#[source]` on `Pdu`, `Encode`, `Decode` tuple variants. Removes the now-unused `use core::fmt;` import.

### Public API impact

None. The `pub type FooError = ironrdp_error::Error<FooErrorKind>` aliases and the `*ErrorExt` traits are unchanged. Consumers see no source-level break.

### Display byte-identity verification

Verified via `cargo expand`. Each derived impl calls `formatter.write_str()` or `write_fmt(format_args!())` with the same literal/arguments as the prior hand-written code. Unit variants emit identical `write_str` calls; tuple variants with formatted source (e.g. `Reason(String)`, `Negotiation`) emit `format_args!("prefix: {0}", _0.as_display())` which calls `Display` on the inner field, identical to the prior `write!(f, "prefix: {field_name}")`.

### xtask verification

- `cargo xtask check fmt`: clean
- `cargo xtask check lints`: clean
- `cargo xtask check locks`: clean (root `Cargo.lock` updated and included)
- `cargo xtask check typos`: clean
- `cargo xtask check tests`: clean

### Diff size

6 files changed, +31 −86 (net −55 lines of code removed).