### PR TITLE
refactor(core): derive Display and Error via thiserror in DecodeErrorKind and EncodeErrorKind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2547,6 +2547,7 @@ name = "ironrdp-core"
 version = "0.1.5"
 dependencies = [
  "ironrdp-error",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/crates/ironrdp-core/Cargo.toml
+++ b/crates/ironrdp-core/Cargo.toml
@@ -18,8 +18,9 @@ test = false
 
 [features]
 default = []
-std = ["alloc", "ironrdp-error/std"]
+std = ["alloc", "ironrdp-error/std", "thiserror/std"]
 alloc = ["ironrdp-error/alloc"]
 
 [dependencies]
 ironrdp-error = { path = "../ironrdp-error", version = "0.1" } # public
+thiserror = { version = "2", default-features = false }

--- a/crates/ironrdp-core/src/decode.rs
+++ b/crates/ironrdp-core/src/decode.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "alloc")]
 use alloc::string::String;
-use core::fmt;
 
 use crate::{
     InvalidFieldErr, NotEnoughBytesErr, OtherErr, ReadCursor, UnexpectedMessageTypeErr, UnsupportedValueErr,
@@ -16,9 +15,10 @@ pub type DecodeError = ironrdp_error::Error<DecodeErrorKind>;
 
 /// Enum representing different kinds of decode errors.
 #[non_exhaustive]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, thiserror::Error)]
 pub enum DecodeErrorKind {
     /// Error when there are not enough bytes to decode.
+    #[error("not enough bytes provided to decode: received {received} bytes, expected {expected} bytes")]
     NotEnoughBytes {
         /// Number of bytes received.
         received: usize,
@@ -26,6 +26,7 @@ pub enum DecodeErrorKind {
         expected: usize,
     },
     /// Error when a field is invalid.
+    #[error("invalid `{field}`: {reason}")]
     InvalidField {
         /// Name of the invalid field.
         field: &'static str,
@@ -33,17 +34,20 @@ pub enum DecodeErrorKind {
         reason: &'static str,
     },
     /// Error when an unexpected message type is encountered.
+    #[error("invalid message type ({got})")]
     UnexpectedMessageType {
         /// The unexpected message type received.
         got: u8,
     },
     /// Error when an unsupported version is encountered.
+    #[error("unsupported version ({got})")]
     UnsupportedVersion {
         /// The unsupported version received.
         got: u8,
     },
     /// Error when an unsupported value is encountered (with allocation feature).
     #[cfg(feature = "alloc")]
+    #[error("unsupported {name} ({value})")]
     UnsupportedValue {
         /// Name of the unsupported value.
         name: &'static str,
@@ -52,49 +56,17 @@ pub enum DecodeErrorKind {
     },
     /// Error when an unsupported value is encountered (without allocation feature).
     #[cfg(not(feature = "alloc"))]
+    #[error("unsupported {name}")]
     UnsupportedValue {
         /// Name of the unsupported value.
         name: &'static str,
     },
     /// Generic error for other cases.
+    #[error("other ({description})")]
     Other {
         /// Description of the error.
         description: &'static str,
     },
-}
-
-#[cfg(feature = "std")]
-impl core::error::Error for DecodeErrorKind {}
-
-impl fmt::Display for DecodeErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::NotEnoughBytes { received, expected } => write!(
-                f,
-                "not enough bytes provided to decode: received {received} bytes, expected {expected} bytes"
-            ),
-            Self::InvalidField { field, reason } => {
-                write!(f, "invalid `{field}`: {reason}")
-            }
-            Self::UnexpectedMessageType { got } => {
-                write!(f, "invalid message type ({got})")
-            }
-            Self::UnsupportedVersion { got } => {
-                write!(f, "unsupported version ({got})")
-            }
-            #[cfg(feature = "alloc")]
-            Self::UnsupportedValue { name, value } => {
-                write!(f, "unsupported {name} ({value})")
-            }
-            #[cfg(not(feature = "alloc"))]
-            Self::UnsupportedValue { name } => {
-                write!(f, "unsupported {name}")
-            }
-            Self::Other { description } => {
-                write!(f, "other ({description})")
-            }
-        }
-    }
 }
 
 impl NotEnoughBytesErr for DecodeError {

--- a/crates/ironrdp-core/src/encode.rs
+++ b/crates/ironrdp-core/src/encode.rs
@@ -2,7 +2,6 @@
 use alloc::string::String;
 #[cfg(feature = "alloc")]
 use alloc::{vec, vec::Vec};
-use core::fmt;
 
 #[cfg(feature = "alloc")]
 use crate::WriteBuf;
@@ -20,9 +19,10 @@ pub type EncodeError = ironrdp_error::Error<EncodeErrorKind>;
 
 /// Represents the different kinds of errors that can occur during encoding operations.
 #[non_exhaustive]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, thiserror::Error)]
 pub enum EncodeErrorKind {
     /// Indicates that there were not enough bytes to complete the encoding operation.
+    #[error("not enough bytes provided to decode: received {received} bytes, expected {expected} bytes")]
     NotEnoughBytes {
         /// The number of bytes actually received.
         received: usize,
@@ -30,6 +30,7 @@ pub enum EncodeErrorKind {
         expected: usize,
     },
     /// Indicates that a field in the data being encoded is invalid.
+    #[error("invalid `{field}`: {reason}")]
     InvalidField {
         /// The name of the invalid field.
         field: &'static str,
@@ -37,17 +38,20 @@ pub enum EncodeErrorKind {
         reason: &'static str,
     },
     /// Indicates that an unexpected message type was encountered during encoding.
+    #[error("invalid message type ({got})")]
     UnexpectedMessageType {
         /// The unexpected message type that was received.
         got: u8,
     },
     /// Indicates that an unsupported version was encountered during encoding.
+    #[error("unsupported version ({got})")]
     UnsupportedVersion {
         /// The unsupported version that was received.
         got: u8,
     },
     /// Indicates that an unsupported value was encountered during encoding.
     #[cfg(feature = "alloc")]
+    #[error("unsupported {name} ({value})")]
     UnsupportedValue {
         /// The name of the field or parameter with the unsupported value.
         name: &'static str,
@@ -56,49 +60,17 @@ pub enum EncodeErrorKind {
     },
     /// Indicates that an unsupported value was encountered during encoding (no-alloc version).
     #[cfg(not(feature = "alloc"))]
+    #[error("unsupported {name}")]
     UnsupportedValue {
         /// The name of the field or parameter with the unsupported value.
         name: &'static str,
     },
     /// Represents any other error that doesn't fit into the above categories.
+    #[error("other ({description})")]
     Other {
         /// A description of the error.
         description: &'static str,
     },
-}
-
-#[cfg(feature = "std")]
-impl core::error::Error for EncodeErrorKind {}
-
-impl fmt::Display for EncodeErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::NotEnoughBytes { received, expected } => write!(
-                f,
-                "not enough bytes provided to decode: received {received} bytes, expected {expected} bytes"
-            ),
-            Self::InvalidField { field, reason } => {
-                write!(f, "invalid `{field}`: {reason}")
-            }
-            Self::UnexpectedMessageType { got } => {
-                write!(f, "invalid message type ({got})")
-            }
-            Self::UnsupportedVersion { got } => {
-                write!(f, "unsupported version ({got})")
-            }
-            #[cfg(feature = "alloc")]
-            Self::UnsupportedValue { name, value } => {
-                write!(f, "unsupported {name} ({value})")
-            }
-            #[cfg(not(feature = "alloc"))]
-            Self::UnsupportedValue { name } => {
-                write!(f, "unsupported {name}")
-            }
-            Self::Other { description } => {
-                write!(f, "other ({description})")
-            }
-        }
-    }
 }
 
 impl NotEnoughBytesErr for EncodeError {

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -309,6 +309,7 @@ name = "ironrdp-core"
 version = "0.1.5"
 dependencies = [
  "ironrdp-error",
+ "thiserror",
 ]
 
 [[package]]


### PR DESCRIPTION
Refs #1257. Companion to #1260.

Companion to the std-only `thiserror` migration in #1260. `ironrdp-core` is split off because it is `no_std`-aware and the change requires Cargo.toml feature wiring that the other crates do not need.

### Changes

- Adds `thiserror = { version = "2", default-features = false }` to dependencies.
- Wires `thiserror/std` into the existing `std` feature: `std = ["alloc", "ironrdp-error/std", "thiserror/std"]`.
- Derives `thiserror::Error` on `DecodeErrorKind` and `EncodeErrorKind` with per-variant `#[error("...")]` attributes that match the prior `write!(f, "...")` format strings exactly.
- Each cfg-gated `UnsupportedValue` variant (with/without `alloc`) receives its own `#[error("...")]` attribute.
- Removes the `#[cfg(feature = "std")] impl core::error::Error for *ErrorKind {}` gates. `core::error::Error` lives in `core` (stabilized Rust 1.81, well below MSRV 1.89), and `thiserror`'s derive emits an unconditional impl. The behaviour change is from "Error impl available only with std" to "Error impl always available", which is a strict superset.

### Public API impact

None. The `pub type DecodeError = ironrdp_error::Error<DecodeErrorKind>` and `pub type EncodeError = ironrdp_error::Error<EncodeErrorKind>` aliases are unchanged. Consumers see no source-level break.

### no_std verification

All three feature combinations build cleanly:

- `cargo check -p ironrdp-core --no-default-features` (no_std, no alloc)
- `cargo check -p ironrdp-core --no-default-features --features alloc` (no_std + alloc)
- `cargo check -p ironrdp-core --features std`

### xtask verification

- `cargo xtask check fmt`: clean
- `cargo xtask check lints`: clean
- `cargo xtask check locks`: clean (both root `Cargo.lock` and `fuzz/Cargo.lock` updated and included; the missing fuzz lock was the failure mode of the earlier #1259 attempt)
- `cargo xtask check typos`: clean
- `cargo xtask check tests`: clean

### Diff size

5 files changed, +20 −73 (net −53 lines of code removed).