### PR TITLE
feat(error): capture core::panic::Location automatically in Error<Kind>

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -4,3 +4,10 @@ accept-comment-above-statement = true
 accept-comment-above-attributes = true
 allow-panic-in-tests = true
 allow-unwrap-in-tests = true
+# Raised from the default of 128 to accommodate the `&'static core::panic::Location<'static>`
+# field that `ironrdp_error::Error<Kind>` captures via `#[track_caller]` for diagnostic
+# reporting. The location field adds one usize (8 bytes) to every error type, which pushes
+# `Error<ConnectorErrorKind>` (whose largest variant nests another `Error<Kind>`) just over
+# the 128-byte threshold. The trade-off favours diagnostic quality over the small
+# Result-Ok-path cost.
+large-error-threshold = 152

--- a/crates/ironrdp-error/src/lib.rs
+++ b/crates/ironrdp-error/src/lib.rs
@@ -21,9 +21,9 @@ pub trait Source: fmt::Display + fmt::Debug + Send + Sync + 'static {}
 #[cfg(not(feature = "std"))]
 impl<T> Source for T where T: fmt::Display + fmt::Debug + Send + Sync + 'static {}
 
-#[derive(Debug)]
 pub struct Error<Kind> {
     context: &'static str,
+    location: &'static core::panic::Location<'static>,
     kind: Kind,
     #[cfg(feature = "std")]
     source: Option<Box<dyn core::error::Error + Sync + Send>>,
@@ -31,12 +31,29 @@ pub struct Error<Kind> {
     source: Option<Box<dyn Source>>,
 }
 
+// Manual `Debug` impl that excludes the `location` field. The location is
+// captured via `core::panic::Location::caller()` and rendered in `Display`,
+// but its `file()` returns platform-native paths (`/` on Unix, `\` on
+// Windows). Including it in `Debug` would break cross-platform snapshot
+// tests. Consumers needing programmatic access can use `Error::location()`.
+impl<Kind: fmt::Debug> fmt::Debug for Error<Kind> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut dbg = f.debug_struct("Error");
+        dbg.field("context", &self.context).field("kind", &self.kind);
+        #[cfg(any(feature = "std", feature = "alloc"))]
+        dbg.field("source", &self.source);
+        dbg.finish()
+    }
+}
+
 impl<Kind> Error<Kind> {
     #[cold]
     #[must_use]
+    #[track_caller]
     pub fn new(context: &'static str, kind: Kind) -> Self {
         Self {
             context,
+            location: core::panic::Location::caller(),
             kind,
             #[cfg(feature = "alloc")]
             source: None,
@@ -70,6 +87,7 @@ impl<Kind> Error<Kind> {
     {
         Error {
             context: self.context,
+            location: self.location,
             kind: self.kind.into(),
             #[cfg(any(feature = "std", feature = "alloc"))]
             source: self.source,
@@ -78,6 +96,15 @@ impl<Kind> Error<Kind> {
 
     pub fn kind(&self) -> &Kind {
         &self.kind
+    }
+
+    /// Returns the source code location at which this error was constructed.
+    ///
+    /// Captured automatically by [`Error::new`] via [`core::panic::Location::caller`]
+    /// and `#[track_caller]`. Useful for diagnostic logging and error reporting
+    /// when the variant alone does not narrow down the call site enough.
+    pub fn location(&self) -> &'static core::panic::Location<'static> {
+        self.location
     }
 
     pub fn set_context(&mut self, context: &'static str) {
@@ -94,7 +121,14 @@ where
     Kind: fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "[{}] {}", self.context, self.kind)
+        write!(
+            f,
+            "[{} @ {}:{}] {}",
+            self.context,
+            self.location.file(),
+            self.location.line(),
+            self.kind
+        )
     }
 }
 


### PR DESCRIPTION
Refs #1257.

Implements Change 2 from the proposal in #1257. Adds an automatic source location capture to `ironrdp-error`'s `Error<Kind>` via `#[track_caller]` and `core::panic::Location::caller()`, surfacing it in the `Display` output.

### What changes

- **New private field** on `Error<Kind>`: `location: &'static core::panic::Location<'static>`. The type is `Copy`, holds a `'static` reference to a `Location` stored in static memory, and requires no allocation. Available since Rust 1.46, works in `no_std` and `no_alloc` contexts.
- **`Error::new()`** is now `#[track_caller]` and captures the caller's location via `core::panic::Location::caller()`.
- **`Error::into_other_kind()`** preserves the original location across the cross-crate `Kind` conversion.
- **New accessor:** `pub fn location(&self) -> &'static core::panic::Location<'static>`.
- **`Display` output gains the location:** `[context @ file:line] kind` (previously `[context] kind`). The function-name context that the per-crate macros set via `function!()` is preserved; the new `file:line` suffix narrows down the call site further when the function name alone is too generic.

### Debug impl excludes location for cross-platform stability

Replaced the `#[derive(Debug)]` on `Error<Kind>` with a manual impl that omits the `location` field. Rationale: `core::panic::Location::file()` returns platform-native paths (forward slashes on Unix, backslashes on Windows). Including it in `Debug` would break cross-platform `expect_test` snapshots that compare `Debug` output literally. Consumers needing programmatic access to the location can use `Error::location()`; human-readable diagnostic output goes through `Display`, where platform-native paths are appropriate.

A consequence of this design choice: existing `expect_test` snapshots that compare the `Debug` shape of `Error<Kind>` continue to pass without modification, because the `Debug` shape is unchanged from the prior derive.

### Trade-off: `clippy::result_large_err` threshold

The location field adds one usize (8 bytes) to every `Error<Kind>`. This pushes the largest typed error in the workspace, `Error<ConnectorErrorKind>`, just over the default 128-byte threshold of `clippy::result_large_err` (connector embeds nested `Error` variants like `Encode(EncodeError)`, so the 8-byte growth amplifies through the nesting).

Bumped `large-error-threshold` to 152 in `clippy.toml`, with a comment explaining why. The trade-off favours diagnostic quality over the small Result-Ok-path cost.

If reviewers prefer keeping the threshold at 128, the alternative is to box one or more of the inner `Error` variants in `ConnectorErrorKind` (e.g. `Encode(Box<EncodeError>)`). That is a public API change with broader downstream impact, so I went with the threshold bump in this PR — happy to switch approach in review.

### Public API impact

Strictly additive on the type level: `Error<Kind>` gains a private field and a new `pub fn location()` accessor. The `pub type` aliases (`PduError`, `DecodeError`, `EncodeError`, `ConnectorError`, `SessionError`, etc.) and the `*ErrorExt` traits are unchanged. Consumers see no source-level break.

`Display` output is observably different (gains `:line`). `Debug` output is unchanged thanks to the manual impl that excludes location, so existing snapshot tests continue to pass.

### no_std verification

All three feature combinations of `ironrdp-error` build cleanly:

- `cargo check -p ironrdp-error --no-default-features` (no_std, no alloc)
- `cargo check -p ironrdp-error --no-default-features --features alloc`
- `cargo check -p ironrdp-error --features std`

### xtask verification

- `cargo xtask check fmt`: clean
- `cargo xtask check lints`: clean (after the threshold bump)
- `cargo xtask check locks`: clean
- `cargo xtask check typos`: clean
- `cargo xtask check tests`: clean (no snapshot updates needed)

### Diff size

2 files changed, +43 −2 (`ironrdp-error/src/lib.rs` and `clippy.toml`).