### PR TITLE
feat(error): add shared bail! and ensure! macros to ironrdp-error

### DIFF
--- a/crates/ironrdp-error/src/lib.rs
+++ b/crates/ironrdp-error/src/lib.rs
@@ -166,3 +166,59 @@ where
         Ok(())
     }
 }
+
+/// Returns from the enclosing function with an [`Error`] built from a kind variant.
+///
+/// Three forms are supported:
+///
+/// - `bail!(kind)` — empty context.
+/// - `bail!(context, kind)` — explicit `&'static str` context.
+/// - `bail!(context, kind, source: source)` — explicit context plus a chained source error.
+///
+/// The kind type is inferred from the enclosing function's return type, which must be
+/// `Result<_, Error<Kind>>` (or any type alias resolving to it).
+///
+/// Mirrors the call-site shape of [`anyhow::bail!`] but produces a typed
+/// `Error<Kind>` rather than a type-erased `anyhow::Error`.
+///
+/// [`anyhow::bail!`]: https://docs.rs/anyhow/latest/anyhow/macro.bail.html
+#[macro_export]
+macro_rules! bail {
+    ($kind:expr $(,)?) => {
+        return ::core::result::Result::Err($crate::Error::new("", $kind))
+    };
+    ($context:expr, $kind:expr $(,)?) => {
+        return ::core::result::Result::Err($crate::Error::new($context, $kind))
+    };
+    ($context:expr, $kind:expr, source: $source:expr $(,)?) => {
+        return ::core::result::Result::Err($crate::Error::new($context, $kind).with_source($source))
+    };
+}
+
+/// Returns from the enclosing function with an [`Error`] if the given condition is false.
+///
+/// Two forms are supported:
+///
+/// - `ensure!(condition, kind)` — empty context.
+/// - `ensure!(condition, context, kind)` — explicit `&'static str` context.
+///
+/// The kind type is inferred from the enclosing function's return type, which must be
+/// `Result<_, Error<Kind>>` (or any type alias resolving to it).
+///
+/// Mirrors the call-site shape of [`anyhow::ensure!`] but produces a typed
+/// `Error<Kind>` rather than a type-erased `anyhow::Error`.
+///
+/// [`anyhow::ensure!`]: https://docs.rs/anyhow/latest/anyhow/macro.ensure.html
+#[macro_export]
+macro_rules! ensure {
+    ($condition:expr, $kind:expr $(,)?) => {
+        if !$condition {
+            return ::core::result::Result::Err($crate::Error::new("", $kind));
+        }
+    };
+    ($condition:expr, $context:expr, $kind:expr $(,)?) => {
+        if !$condition {
+            return ::core::result::Result::Err($crate::Error::new($context, $kind));
+        }
+    };
+}

--- a/crates/ironrdp-error/src/lib.rs
+++ b/crates/ironrdp-error/src/lib.rs
@@ -212,12 +212,12 @@ macro_rules! bail {
 #[macro_export]
 macro_rules! ensure {
     ($condition:expr, $kind:expr $(,)?) => {
-        if !$condition {
+        if !($condition) {
             return ::core::result::Result::Err($crate::Error::new("", $kind));
         }
     };
     ($condition:expr, $context:expr, $kind:expr $(,)?) => {
-        if !$condition {
+        if !($condition) {
             return ::core::result::Result::Err($crate::Error::new($context, $kind));
         }
     };


### PR DESCRIPTION
Refs #1257.

Implements Change 3 from the proposal in #1257. Adds workspace-shared `bail!` and `ensure!` macros to `ironrdp-error` so call-site verbosity for typed errors matches `anyhow::bail!`/`anyhow::ensure!`.

### What changes

- `bail!(kind)` — empty context.
- `bail!(context, kind)` — explicit `&'static str` context.
- `bail!(context, kind, source: source)` — explicit context plus a chained source error.
- `ensure!(condition, kind)` — empty context.
- `ensure!(condition, context, kind)` — explicit context.

Both macros are `#[macro_export]`ed at the `ironrdp-error` crate root and use `$crate::Error::new(...)` for hygiene. The kind type is inferred from the enclosing function's return type (which must be `Result<_, Error<Kind>>` or any alias resolving to it).

### Composition with `#[track_caller]`

Once Change 2 (#1262) lands and `Error::new` is annotated `#[track_caller]`, these macros automatically capture the location at the macro use site (because the `Error::new` call expanded inside the macro is the caller of its own constructor, and `#[track_caller]` resolves to the macro's caller). This is the intended composition: Change 2 supplies the location, Change 3 supplies the call-site ergonomics, both compose without coordination.

### No deprecation of per-crate macros

The existing per-crate constructor macros (`decode_err!`, `encode_err!`, `pdu_other_err!`, etc.) serve a different ergonomic pattern: they construct an error to be passed to `?` or `.map_err(...)`, rather than performing an early return. The shared `bail!`/`ensure!` are additive — they cover the early-return patterns that previously required hand-written `return Err(Error::new(...))` boilerplate. The per-crate constructor macros remain useful for `.map_err(decode_err!(...))` style and are not deprecated by this change.

### Public API impact

Strictly additive. Two new exported macros at the `ironrdp-error` crate root. No changes to existing types, traits, or methods.

### no_std verification

All three feature combinations of `ironrdp-error` build cleanly:

- `cargo check -p ironrdp-error --no-default-features`
- `cargo check -p ironrdp-error --no-default-features --features alloc`
- `cargo check -p ironrdp-error --features std`

The macros use only fully-pathed std-free constructs (`::core::result::Result::Err`, `$crate::Error::new`), so they work identically across feature combinations.

### xtask verification

- `cargo xtask check fmt`: clean
- `cargo xtask check lints`: clean
- `cargo xtask check locks`: clean
- `cargo xtask check typos`: clean
- `cargo xtask check tests`: clean

### Diff size

1 file changed, +56 lines, no deletions.