### PR TITLE
refactor(pdu): hand-roll Display/Error impls and remove thiserror dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2715,7 +2715,6 @@ dependencies = [
  "pkcs1 0.7.5",
  "sha1 0.10.6",
  "tap",
- "thiserror 2.0.18",
  "x509-cert",
 ]
 

--- a/crates/ironrdp-pdu/Cargo.toml
+++ b/crates/ironrdp-pdu/Cargo.toml
@@ -33,7 +33,6 @@ tap = "1"
 bit_field = "0.10"
 byteorder = "1.5" # TODO: remove
 der-parser = "10.0"
-thiserror = "2.0"
 md5 = { package = "md-5", version = "0.10" }
 num-bigint = "0.4"
 num-derive.workspace = true # TODO: remove

--- a/crates/ironrdp-pdu/src/gcc/cluster_data.rs
+++ b/crates/ironrdp-pdu/src/gcc/cluster_data.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use std::io;
 
 use bitflags::bitflags;
@@ -6,7 +7,6 @@ use ironrdp_core::{
 };
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive as _;
-use thiserror::Error;
 
 const REDIRECTION_VERSION_MASK: u32 = 0x0000_003C;
 
@@ -97,10 +97,32 @@ impl RedirectionVersion {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum ClusterDataError {
-    #[error("IO error")]
-    IOError(#[from] io::Error),
-    #[error("invalid redirection flags field")]
+    IOError(io::Error),
     InvalidRedirectionFlags,
+}
+
+impl fmt::Display for ClusterDataError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IOError(_) => f.write_str("IO error"),
+            Self::InvalidRedirectionFlags => f.write_str("invalid redirection flags field"),
+        }
+    }
+}
+
+impl core::error::Error for ClusterDataError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::IOError(e) => Some(e),
+            Self::InvalidRedirectionFlags => None,
+        }
+    }
+}
+
+impl From<io::Error> for ClusterDataError {
+    fn from(e: io::Error) -> Self {
+        Self::IOError(e)
+    }
 }

--- a/crates/ironrdp-pdu/src/gcc/core_data/mod.rs
+++ b/crates/ironrdp-pdu/src/gcc/core_data/mod.rs
@@ -1,9 +1,8 @@
 pub(crate) mod client;
 pub(crate) mod server;
 
+use core::fmt;
 use std::io;
-
-use thiserror::Error;
 
 use crate::PduError;
 
@@ -43,32 +42,64 @@ impl RdpVersion {
     pub const V10_12: Self = Self(0x0008_0011);
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum CoreDataError {
-    #[error("IO error")]
-    IOError(#[from] io::Error),
-    #[error("invalid version field")]
+    IOError(io::Error),
     InvalidVersion,
-    #[error("invalid color depth field")]
     InvalidColorDepth,
-    #[error("invalid post beta color depth field")]
     InvalidPostBetaColorDepth,
-    #[error("invalid high color depth field")]
     InvalidHighColorDepth,
-    #[error("invalid supported color depths field")]
     InvalidSupportedColorDepths,
-    #[error("invalid secure access sequence field")]
     InvalidSecureAccessSequence,
-    #[error("invalid keyboard type field")]
     InvalidKeyboardType,
-    #[error("invalid early capability flags field")]
     InvalidEarlyCapabilityFlags,
-    #[error("invalid connection type field")]
     InvalidConnectionType,
-    #[error("invalid server security protocol field")]
     InvalidServerSecurityProtocol,
-    #[error("PDU error: {0}")]
     Pdu(PduError),
+}
+
+impl fmt::Display for CoreDataError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IOError(_) => f.write_str("IO error"),
+            Self::InvalidVersion => f.write_str("invalid version field"),
+            Self::InvalidColorDepth => f.write_str("invalid color depth field"),
+            Self::InvalidPostBetaColorDepth => f.write_str("invalid post beta color depth field"),
+            Self::InvalidHighColorDepth => f.write_str("invalid high color depth field"),
+            Self::InvalidSupportedColorDepths => f.write_str("invalid supported color depths field"),
+            Self::InvalidSecureAccessSequence => f.write_str("invalid secure access sequence field"),
+            Self::InvalidKeyboardType => f.write_str("invalid keyboard type field"),
+            Self::InvalidEarlyCapabilityFlags => f.write_str("invalid early capability flags field"),
+            Self::InvalidConnectionType => f.write_str("invalid connection type field"),
+            Self::InvalidServerSecurityProtocol => f.write_str("invalid server security protocol field"),
+            Self::Pdu(e) => write!(f, "PDU error: {e}"),
+        }
+    }
+}
+
+impl core::error::Error for CoreDataError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::IOError(e) => Some(e),
+            Self::InvalidVersion
+            | Self::InvalidColorDepth
+            | Self::InvalidPostBetaColorDepth
+            | Self::InvalidHighColorDepth
+            | Self::InvalidSupportedColorDepths
+            | Self::InvalidSecureAccessSequence
+            | Self::InvalidKeyboardType
+            | Self::InvalidEarlyCapabilityFlags
+            | Self::InvalidConnectionType
+            | Self::InvalidServerSecurityProtocol
+            | Self::Pdu(_) => None,
+        }
+    }
+}
+
+impl From<io::Error> for CoreDataError {
+    fn from(e: io::Error) -> Self {
+        Self::IOError(e)
+    }
 }
 
 impl From<PduError> for CoreDataError {

--- a/crates/ironrdp-pdu/src/gcc/mod.rs
+++ b/crates/ironrdp-pdu/src/gcc/mod.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use std::io;
 
 use ironrdp_core::{
@@ -6,7 +7,6 @@ use ironrdp_core::{
 };
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
-use thiserror::Error;
 
 use crate::PduError;
 
@@ -356,30 +356,89 @@ impl UserDataHeader {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum GccError {
-    #[error("IO error")]
-    IOError(#[from] io::Error),
-    #[error("core data block error")]
-    CoreError(#[from] CoreDataError),
-    #[error("security data block error")]
-    SecurityError(#[from] SecurityDataError),
-    #[error("network data block error")]
-    NetworkError(#[from] NetworkDataError),
-    #[error("cluster data block error")]
-    ClusterError(#[from] ClusterDataError),
-    #[error("invalid GCC block type")]
+    IOError(io::Error),
+    CoreError(CoreDataError),
+    SecurityError(SecurityDataError),
+    NetworkError(NetworkDataError),
+    ClusterError(ClusterDataError),
     InvalidGccType,
-    #[error("invalid conference create request: {0}")]
     InvalidConferenceCreateRequest(String),
-    #[error("invalid Conference create response: {0}")]
     InvalidConferenceCreateResponse(String),
-    #[error("a server did not send the required GCC data block: {0:?}")]
     RequiredClientDataBlockIsAbsent(ClientGccType),
-    #[error("a client did not send the required GCC data block: {0:?}")]
     RequiredServerDataBlockIsAbsent(ServerGccType),
-    #[error("PDU error: {0}")]
     Pdu(PduError),
+}
+
+impl fmt::Display for GccError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IOError(_) => f.write_str("IO error"),
+            Self::CoreError(_) => f.write_str("core data block error"),
+            Self::SecurityError(_) => f.write_str("security data block error"),
+            Self::NetworkError(_) => f.write_str("network data block error"),
+            Self::ClusterError(_) => f.write_str("cluster data block error"),
+            Self::InvalidGccType => f.write_str("invalid GCC block type"),
+            Self::InvalidConferenceCreateRequest(s) => write!(f, "invalid conference create request: {s}"),
+            Self::InvalidConferenceCreateResponse(s) => write!(f, "invalid Conference create response: {s}"),
+            Self::RequiredClientDataBlockIsAbsent(ty) => {
+                write!(f, "a server did not send the required GCC data block: {ty:?}")
+            }
+            Self::RequiredServerDataBlockIsAbsent(ty) => {
+                write!(f, "a client did not send the required GCC data block: {ty:?}")
+            }
+            Self::Pdu(e) => write!(f, "PDU error: {e}"),
+        }
+    }
+}
+
+impl core::error::Error for GccError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::IOError(e) => Some(e),
+            Self::CoreError(e) => Some(e),
+            Self::SecurityError(e) => Some(e),
+            Self::NetworkError(e) => Some(e),
+            Self::ClusterError(e) => Some(e),
+            Self::InvalidGccType
+            | Self::InvalidConferenceCreateRequest(_)
+            | Self::InvalidConferenceCreateResponse(_)
+            | Self::RequiredClientDataBlockIsAbsent(_)
+            | Self::RequiredServerDataBlockIsAbsent(_)
+            | Self::Pdu(_) => None,
+        }
+    }
+}
+
+impl From<io::Error> for GccError {
+    fn from(e: io::Error) -> Self {
+        Self::IOError(e)
+    }
+}
+
+impl From<CoreDataError> for GccError {
+    fn from(e: CoreDataError) -> Self {
+        Self::CoreError(e)
+    }
+}
+
+impl From<SecurityDataError> for GccError {
+    fn from(e: SecurityDataError) -> Self {
+        Self::SecurityError(e)
+    }
+}
+
+impl From<NetworkDataError> for GccError {
+    fn from(e: NetworkDataError) -> Self {
+        Self::NetworkError(e)
+    }
+}
+
+impl From<ClusterDataError> for GccError {
+    fn from(e: ClusterDataError) -> Self {
+        Self::ClusterError(e)
+    }
 }
 
 impl From<PduError> for GccError {

--- a/crates/ironrdp-pdu/src/gcc/network_data.rs
+++ b/crates/ironrdp-pdu/src/gcc/network_data.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use std::borrow::Cow;
 use std::{io, str};
 
@@ -7,7 +8,6 @@ use ironrdp_core::{
     ensure_size, invalid_field_err, read_padding, write_padding,
 };
 use num_integer::Integer as _;
-use thiserror::Error;
 
 const CHANNELS_MAX: usize = 31;
 
@@ -289,14 +289,43 @@ bitflags! {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum NetworkDataError {
-    #[error("IO error")]
-    IOError(#[from] io::Error),
-    #[error("UTF-8 error")]
-    Utf8Error(#[from] str::Utf8Error),
-    #[error("invalid channel options field")]
+    IOError(io::Error),
+    Utf8Error(str::Utf8Error),
     InvalidChannelOptions,
-    #[error("invalid channel count field")]
     InvalidChannelCount,
+}
+
+impl fmt::Display for NetworkDataError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IOError(_) => f.write_str("IO error"),
+            Self::Utf8Error(_) => f.write_str("UTF-8 error"),
+            Self::InvalidChannelOptions => f.write_str("invalid channel options field"),
+            Self::InvalidChannelCount => f.write_str("invalid channel count field"),
+        }
+    }
+}
+
+impl core::error::Error for NetworkDataError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::IOError(e) => Some(e),
+            Self::Utf8Error(e) => Some(e),
+            Self::InvalidChannelOptions | Self::InvalidChannelCount => None,
+        }
+    }
+}
+
+impl From<io::Error> for NetworkDataError {
+    fn from(e: io::Error) -> Self {
+        Self::IOError(e)
+    }
+}
+
+impl From<str::Utf8Error> for NetworkDataError {
+    fn from(e: str::Utf8Error) -> Self {
+        Self::Utf8Error(e)
+    }
 }

--- a/crates/ironrdp-pdu/src/gcc/security_data.rs
+++ b/crates/ironrdp-pdu/src/gcc/security_data.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use std::io;
 
 use bitflags::bitflags;
@@ -7,7 +8,6 @@ use ironrdp_core::{
 };
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive as _;
-use thiserror::Error;
 
 const CLIENT_ENCRYPTION_METHODS_SIZE: usize = 4;
 const CLIENT_EXT_ENCRYPTION_METHODS_SIZE: usize = 4;
@@ -219,18 +219,44 @@ impl EncryptionLevel {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum SecurityDataError {
-    #[error("IO error")]
-    IOError(#[from] io::Error),
-    #[error("invalid encryption methods field")]
+    IOError(io::Error),
     InvalidEncryptionMethod,
-    #[error("invalid encryption level field")]
     InvalidEncryptionLevel,
-    #[error("invalid server random length field: {0}")]
     InvalidServerRandomLen(u32),
-    #[error("invalid input: {0}")]
     InvalidInput(String),
-    #[error("invalid server certificate length: {0}")]
     InvalidServerCertificateLen(u32),
+}
+
+impl fmt::Display for SecurityDataError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IOError(_) => f.write_str("IO error"),
+            Self::InvalidEncryptionMethod => f.write_str("invalid encryption methods field"),
+            Self::InvalidEncryptionLevel => f.write_str("invalid encryption level field"),
+            Self::InvalidServerRandomLen(n) => write!(f, "invalid server random length field: {n}"),
+            Self::InvalidInput(s) => write!(f, "invalid input: {s}"),
+            Self::InvalidServerCertificateLen(n) => write!(f, "invalid server certificate length: {n}"),
+        }
+    }
+}
+
+impl core::error::Error for SecurityDataError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::IOError(e) => Some(e),
+            Self::InvalidEncryptionMethod
+            | Self::InvalidEncryptionLevel
+            | Self::InvalidServerRandomLen(_)
+            | Self::InvalidInput(_)
+            | Self::InvalidServerCertificateLen(_) => None,
+        }
+    }
+}
+
+impl From<io::Error> for SecurityDataError {
+    fn from(e: io::Error) -> Self {
+        Self::IOError(e)
+    }
 }

--- a/crates/ironrdp-pdu/src/input/mod.rs
+++ b/crates/ironrdp-pdu/src/input/mod.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use std::io;
 
 use ironrdp_core::{
@@ -6,7 +7,6 @@ use ironrdp_core::{
 };
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive as _;
-use thiserror::Error;
 
 pub mod fast_path;
 pub mod mouse;
@@ -182,20 +182,47 @@ impl From<&InputEvent> for InputEventType {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum InputEventError {
-    #[error("IO error")]
-    IOError(#[from] io::Error),
-    #[error("invalid Input Event type: {0}")]
+    IOError(io::Error),
     InvalidInputEventType(u16),
-    #[error("encryption not supported")]
     EncryptionNotSupported,
-    #[error("event code not supported {0}")]
     EventCodeUnsupported(u8),
-    #[error("keyboard flags not supported {0}")]
     KeyboardFlagsUnsupported(u8),
-    #[error("synchronize flags not supported {0}")]
     SynchronizeFlagsUnsupported(u8),
-    #[error("Fast-Path Input Event PDU is empty")]
     EmptyFastPathInput,
+}
+
+impl fmt::Display for InputEventError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IOError(_) => f.write_str("IO error"),
+            Self::InvalidInputEventType(n) => write!(f, "invalid Input Event type: {n}"),
+            Self::EncryptionNotSupported => f.write_str("encryption not supported"),
+            Self::EventCodeUnsupported(n) => write!(f, "event code not supported {n}"),
+            Self::KeyboardFlagsUnsupported(n) => write!(f, "keyboard flags not supported {n}"),
+            Self::SynchronizeFlagsUnsupported(n) => write!(f, "synchronize flags not supported {n}"),
+            Self::EmptyFastPathInput => f.write_str("Fast-Path Input Event PDU is empty"),
+        }
+    }
+}
+
+impl core::error::Error for InputEventError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::IOError(e) => Some(e),
+            Self::InvalidInputEventType(_)
+            | Self::EncryptionNotSupported
+            | Self::EventCodeUnsupported(_)
+            | Self::KeyboardFlagsUnsupported(_)
+            | Self::SynchronizeFlagsUnsupported(_)
+            | Self::EmptyFastPathInput => None,
+        }
+    }
+}
+
+impl From<io::Error> for InputEventError {
+    fn from(e: io::Error) -> Self {
+        Self::IOError(e)
+    }
 }

--- a/crates/ironrdp-pdu/src/mcs.rs
+++ b/crates/ironrdp-pdu/src/mcs.rs
@@ -1196,7 +1196,7 @@ mod legacy {
                 Self::InvalidDisconnectProviderUltimatum => f.write_str("invalid disconnect provider ultimatum"),
                 Self::InvalidDomainMcsPdu => f.write_str("invalid domain MCS PDU"),
                 Self::InvalidPdu(_) => f.write_str("invalid MCS Connection Sequence PDU"),
-                Self::UnexpectedChannelId(_) => f.write_str("invalid invalid MCS channel id"),
+                Self::UnexpectedChannelId(_) => f.write_str("invalid MCS channel id"),
                 Self::Pdu(e) => write!(f, "PDU error: {e}"),
             }
         }

--- a/crates/ironrdp-pdu/src/mcs.rs
+++ b/crates/ironrdp-pdu/src/mcs.rs
@@ -940,10 +940,10 @@ mod legacy {
         reason = "Cannot move the implementation from the legacy module"
     )]
 
+    use core::fmt;
     use std::io;
 
     use ironrdp_core::{Decode, DecodeResult, Encode, cast_int};
-    use thiserror::Error;
 
     use super::{
         ConnectInitial, ConnectResponse, DomainParameters, PduError, RESULT_ENUM_LENGTH, ReadCursor, WriteCursor,
@@ -1177,22 +1177,55 @@ mod legacy {
         }
     }
 
-    #[derive(Debug, Error)]
+    #[derive(Debug)]
     pub enum McsError {
-        #[error("IO error")]
-        IOError(#[from] io::Error),
-        #[error("GCC block error")]
-        GccError(#[from] GccError),
-        #[error("invalid disconnect provider ultimatum")]
+        IOError(io::Error),
+        GccError(GccError),
         InvalidDisconnectProviderUltimatum,
-        #[error("invalid domain MCS PDU")]
         InvalidDomainMcsPdu,
-        #[error("invalid MCS Connection Sequence PDU")]
         InvalidPdu(String),
-        #[error("invalid invalid MCS channel id")]
         UnexpectedChannelId(String),
-        #[error("PDU error: {0}")]
         Pdu(PduError),
+    }
+
+    impl fmt::Display for McsError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match self {
+                Self::IOError(_) => f.write_str("IO error"),
+                Self::GccError(_) => f.write_str("GCC block error"),
+                Self::InvalidDisconnectProviderUltimatum => f.write_str("invalid disconnect provider ultimatum"),
+                Self::InvalidDomainMcsPdu => f.write_str("invalid domain MCS PDU"),
+                Self::InvalidPdu(_) => f.write_str("invalid MCS Connection Sequence PDU"),
+                Self::UnexpectedChannelId(_) => f.write_str("invalid invalid MCS channel id"),
+                Self::Pdu(e) => write!(f, "PDU error: {e}"),
+            }
+        }
+    }
+
+    impl core::error::Error for McsError {
+        fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+            match self {
+                Self::IOError(e) => Some(e),
+                Self::GccError(e) => Some(e),
+                Self::InvalidDisconnectProviderUltimatum
+                | Self::InvalidDomainMcsPdu
+                | Self::InvalidPdu(_)
+                | Self::UnexpectedChannelId(_)
+                | Self::Pdu(_) => None,
+            }
+        }
+    }
+
+    impl From<io::Error> for McsError {
+        fn from(e: io::Error) -> Self {
+            Self::IOError(e)
+        }
+    }
+
+    impl From<GccError> for McsError {
+        fn from(e: GccError) -> Self {
+            Self::GccError(e)
+        }
     }
 
     impl From<PduError> for McsError {

--- a/crates/ironrdp-pdu/src/rdp/capability_sets/mod.rs
+++ b/crates/ironrdp-pdu/src/rdp/capability_sets/mod.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use std::io;
 
 use ironrdp_core::{
@@ -6,7 +7,6 @@ use ironrdp_core::{
 };
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive as _;
-use thiserror::Error;
 
 use crate::{PduError, utils};
 
@@ -606,64 +606,118 @@ impl CapabilitySetType {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum CapabilitySetsError {
-    #[error("IO error")]
-    IOError(#[from] io::Error),
-    #[error("UTF-8 error")]
-    Utf8Error(#[from] std::string::FromUtf8Error),
-    #[error("invalid type field")]
+    IOError(io::Error),
+    Utf8Error(std::string::FromUtf8Error),
     InvalidType,
-    #[error("invalid bitmap compression field")]
     InvalidCompressionFlag,
-    #[error("invalid multiple rectangle support field")]
     InvalidMultipleRectSupport,
-    #[error("invalid protocol version field")]
     InvalidProtocolVersion,
-    #[error("invalid compression types field")]
     InvalidCompressionTypes,
-    #[error("invalid update capability flags field")]
     InvalidUpdateCapFlag,
-    #[error("invalid remote unshare flag field")]
     InvalidRemoteUnshareFlag,
-    #[error("invalid compression level field")]
     InvalidCompressionLevel,
-    #[error("invalid brush support level field")]
     InvalidBrushSupportLevel,
-    #[error("invalid glyph support level field")]
     InvalidGlyphSupportLevel,
-    #[error("invalid RemoteFX capability version")]
     InvalidRfxICapVersion,
-    #[error("invalid RemoteFX capability tile size")]
     InvalidRfxICapTileSize,
-    #[error("invalid RemoteFXICap color conversion bits")]
     InvalidRfxICapColorConvBits,
-    #[error("invalid RemoteFXICap transform bits")]
     InvalidRfxICapTransformBits,
-    #[error("invalid RemoteFXICap entropy bits field")]
     InvalidRfxICapEntropyBits,
-    #[error("invalid RemoteFX capability set block type")]
     InvalidRfxCapsetBlockType,
-    #[error("invalid RemoteFX capability set type")]
     InvalidRfxCapsetType,
-    #[error("invalid RemoteFX capabilities block type")]
     InvalidRfxCapsBlockType,
-    #[error("invalid RemoteFX capabilities block length")]
     InvalidRfxCapsBockLength,
-    #[error("invalid number of capability sets in RemoteFX capabilities")]
     InvalidRfxCapsNumCapsets,
-    #[error("invalid codec property field")]
     InvalidCodecProperty,
-    #[error("invalid codec ID")]
     InvalidCodecID,
-    #[error("invalid channel chunk size field")]
     InvalidChunkSize,
-    #[error("invalid codec property length for the current property ID")]
     InvalidPropertyLength,
-    #[error("invalid data length")]
     InvalidLength,
-    #[error("PDU error: {0}")]
     Pdu(PduError),
+}
+
+impl fmt::Display for CapabilitySetsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IOError(_) => f.write_str("IO error"),
+            Self::Utf8Error(_) => f.write_str("UTF-8 error"),
+            Self::InvalidType => f.write_str("invalid type field"),
+            Self::InvalidCompressionFlag => f.write_str("invalid bitmap compression field"),
+            Self::InvalidMultipleRectSupport => f.write_str("invalid multiple rectangle support field"),
+            Self::InvalidProtocolVersion => f.write_str("invalid protocol version field"),
+            Self::InvalidCompressionTypes => f.write_str("invalid compression types field"),
+            Self::InvalidUpdateCapFlag => f.write_str("invalid update capability flags field"),
+            Self::InvalidRemoteUnshareFlag => f.write_str("invalid remote unshare flag field"),
+            Self::InvalidCompressionLevel => f.write_str("invalid compression level field"),
+            Self::InvalidBrushSupportLevel => f.write_str("invalid brush support level field"),
+            Self::InvalidGlyphSupportLevel => f.write_str("invalid glyph support level field"),
+            Self::InvalidRfxICapVersion => f.write_str("invalid RemoteFX capability version"),
+            Self::InvalidRfxICapTileSize => f.write_str("invalid RemoteFX capability tile size"),
+            Self::InvalidRfxICapColorConvBits => f.write_str("invalid RemoteFXICap color conversion bits"),
+            Self::InvalidRfxICapTransformBits => f.write_str("invalid RemoteFXICap transform bits"),
+            Self::InvalidRfxICapEntropyBits => f.write_str("invalid RemoteFXICap entropy bits field"),
+            Self::InvalidRfxCapsetBlockType => f.write_str("invalid RemoteFX capability set block type"),
+            Self::InvalidRfxCapsetType => f.write_str("invalid RemoteFX capability set type"),
+            Self::InvalidRfxCapsBlockType => f.write_str("invalid RemoteFX capabilities block type"),
+            Self::InvalidRfxCapsBockLength => f.write_str("invalid RemoteFX capabilities block length"),
+            Self::InvalidRfxCapsNumCapsets => f.write_str("invalid number of capability sets in RemoteFX capabilities"),
+            Self::InvalidCodecProperty => f.write_str("invalid codec property field"),
+            Self::InvalidCodecID => f.write_str("invalid codec ID"),
+            Self::InvalidChunkSize => f.write_str("invalid channel chunk size field"),
+            Self::InvalidPropertyLength => f.write_str("invalid codec property length for the current property ID"),
+            Self::InvalidLength => f.write_str("invalid data length"),
+            Self::Pdu(e) => write!(f, "PDU error: {e}"),
+        }
+    }
+}
+
+impl core::error::Error for CapabilitySetsError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::IOError(e) => Some(e),
+            Self::Utf8Error(e) => Some(e),
+            Self::InvalidType
+            | Self::InvalidCompressionFlag
+            | Self::InvalidMultipleRectSupport
+            | Self::InvalidProtocolVersion
+            | Self::InvalidCompressionTypes
+            | Self::InvalidUpdateCapFlag
+            | Self::InvalidRemoteUnshareFlag
+            | Self::InvalidCompressionLevel
+            | Self::InvalidBrushSupportLevel
+            | Self::InvalidGlyphSupportLevel
+            | Self::InvalidRfxICapVersion
+            | Self::InvalidRfxICapTileSize
+            | Self::InvalidRfxICapColorConvBits
+            | Self::InvalidRfxICapTransformBits
+            | Self::InvalidRfxICapEntropyBits
+            | Self::InvalidRfxCapsetBlockType
+            | Self::InvalidRfxCapsetType
+            | Self::InvalidRfxCapsBlockType
+            | Self::InvalidRfxCapsBockLength
+            | Self::InvalidRfxCapsNumCapsets
+            | Self::InvalidCodecProperty
+            | Self::InvalidCodecID
+            | Self::InvalidChunkSize
+            | Self::InvalidPropertyLength
+            | Self::InvalidLength
+            | Self::Pdu(_) => None,
+        }
+    }
+}
+
+impl From<io::Error> for CapabilitySetsError {
+    fn from(e: io::Error) -> Self {
+        Self::IOError(e)
+    }
+}
+
+impl From<std::string::FromUtf8Error> for CapabilitySetsError {
+    fn from(e: std::string::FromUtf8Error) -> Self {
+        Self::Utf8Error(e)
+    }
 }
 
 impl From<PduError> for CapabilitySetsError {

--- a/crates/ironrdp-pdu/src/rdp/client_info.rs
+++ b/crates/ironrdp-pdu/src/rdp/client_info.rs
@@ -8,7 +8,6 @@ use ironrdp_core::{
 };
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive as _;
-use thiserror::Error;
 
 use crate::utils::CharacterSet;
 use crate::{PduError, utils};
@@ -757,22 +756,55 @@ impl CompressionType {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum ClientInfoError {
-    #[error("IO error")]
-    IOError(#[from] io::Error),
-    #[error("UTF-8 error")]
-    Utf8Error(#[from] std::string::FromUtf8Error),
-    #[error("invalid address family field")]
+    IOError(io::Error),
+    Utf8Error(std::string::FromUtf8Error),
     InvalidAddressFamily,
-    #[error("invalid flags field")]
     InvalidClientInfoFlags,
-    #[error("invalid performance flags field")]
     InvalidPerformanceFlags,
-    #[error("invalid reconnect cookie field")]
     InvalidReconnectCookie,
-    #[error("PDU error: {0}")]
     Pdu(PduError),
+}
+
+impl fmt::Display for ClientInfoError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IOError(_) => f.write_str("IO error"),
+            Self::Utf8Error(_) => f.write_str("UTF-8 error"),
+            Self::InvalidAddressFamily => f.write_str("invalid address family field"),
+            Self::InvalidClientInfoFlags => f.write_str("invalid flags field"),
+            Self::InvalidPerformanceFlags => f.write_str("invalid performance flags field"),
+            Self::InvalidReconnectCookie => f.write_str("invalid reconnect cookie field"),
+            Self::Pdu(e) => write!(f, "PDU error: {e}"),
+        }
+    }
+}
+
+impl core::error::Error for ClientInfoError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::IOError(e) => Some(e),
+            Self::Utf8Error(e) => Some(e),
+            Self::InvalidAddressFamily
+            | Self::InvalidClientInfoFlags
+            | Self::InvalidPerformanceFlags
+            | Self::InvalidReconnectCookie
+            | Self::Pdu(_) => None,
+        }
+    }
+}
+
+impl From<io::Error> for ClientInfoError {
+    fn from(e: io::Error) -> Self {
+        Self::IOError(e)
+    }
+}
+
+impl From<std::string::FromUtf8Error> for ClientInfoError {
+    fn from(e: std::string::FromUtf8Error) -> Self {
+        Self::Utf8Error(e)
+    }
 }
 
 impl From<PduError> for ClientInfoError {

--- a/crates/ironrdp-pdu/src/rdp/mod.rs
+++ b/crates/ironrdp-pdu/src/rdp/mod.rs
@@ -1,9 +1,9 @@
+use core::fmt;
 use std::io;
 
 use ironrdp_core::{
     Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, ensure_fixed_part_size, invalid_field_err,
 };
-use thiserror::Error;
 
 use crate::PduError;
 use crate::input::InputEventError;
@@ -74,36 +74,100 @@ impl<'de> Decode<'de> for ClientInfoPdu {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum RdpError {
-    #[error("IO error")]
-    IOError(#[from] io::Error),
-    #[error("client Info PDU error")]
-    ClientInfoError(#[from] ClientInfoError),
-    #[error("server License PDU error")]
-    ServerLicenseError(#[from] ServerLicenseError),
-    #[error("capability sets error")]
-    CapabilitySetsError(#[from] CapabilitySetsError),
-    #[error("invalid RDP security header")]
+    IOError(io::Error),
+    ClientInfoError(ClientInfoError),
+    ServerLicenseError(ServerLicenseError),
+    CapabilitySetsError(CapabilitySetsError),
     InvalidSecurityHeader,
-    #[error("invalid RDP Share Control Header: {0}")]
     InvalidShareControlHeader(String),
-    #[error("invalid RDP Share Data Header: {0}")]
     InvalidShareDataHeader(String),
-    #[error("invalid RDP Connection Sequence PDU")]
     InvalidPdu(String),
-    #[error("unexpected RDP Share Control Header PDU type: {0:?}")]
     UnexpectedShareControlPdu(ShareControlPduType),
-    #[error("unexpected RDP Share Data Header PDU type: {0:?}")]
     UnexpectedShareDataPdu(ShareDataPduType),
-    #[error("save session info PDU error")]
-    SaveSessionInfoError(#[from] session_info::SessionError),
-    #[error("input event PDU error")]
-    InputEventError(#[from] InputEventError),
-    #[error("not enough bytes")]
+    SaveSessionInfoError(session_info::SessionError),
+    InputEventError(InputEventError),
     NotEnoughBytes,
-    #[error("PDU error: {0}")]
     Pdu(PduError),
+}
+
+impl fmt::Display for RdpError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IOError(_) => f.write_str("IO error"),
+            Self::ClientInfoError(_) => f.write_str("client Info PDU error"),
+            Self::ServerLicenseError(_) => f.write_str("server License PDU error"),
+            Self::CapabilitySetsError(_) => f.write_str("capability sets error"),
+            Self::InvalidSecurityHeader => f.write_str("invalid RDP security header"),
+            Self::InvalidShareControlHeader(s) => write!(f, "invalid RDP Share Control Header: {s}"),
+            Self::InvalidShareDataHeader(s) => write!(f, "invalid RDP Share Data Header: {s}"),
+            Self::InvalidPdu(_) => f.write_str("invalid RDP Connection Sequence PDU"),
+            Self::UnexpectedShareControlPdu(ty) => write!(f, "unexpected RDP Share Control Header PDU type: {ty:?}"),
+            Self::UnexpectedShareDataPdu(ty) => write!(f, "unexpected RDP Share Data Header PDU type: {ty:?}"),
+            Self::SaveSessionInfoError(_) => f.write_str("save session info PDU error"),
+            Self::InputEventError(_) => f.write_str("input event PDU error"),
+            Self::NotEnoughBytes => f.write_str("not enough bytes"),
+            Self::Pdu(e) => write!(f, "PDU error: {e}"),
+        }
+    }
+}
+
+impl core::error::Error for RdpError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::IOError(e) => Some(e),
+            Self::ClientInfoError(e) => Some(e),
+            Self::ServerLicenseError(e) => Some(e),
+            Self::CapabilitySetsError(e) => Some(e),
+            Self::SaveSessionInfoError(e) => Some(e),
+            Self::InputEventError(e) => Some(e),
+            Self::InvalidSecurityHeader
+            | Self::InvalidShareControlHeader(_)
+            | Self::InvalidShareDataHeader(_)
+            | Self::InvalidPdu(_)
+            | Self::UnexpectedShareControlPdu(_)
+            | Self::UnexpectedShareDataPdu(_)
+            | Self::NotEnoughBytes
+            | Self::Pdu(_) => None,
+        }
+    }
+}
+
+impl From<io::Error> for RdpError {
+    fn from(e: io::Error) -> Self {
+        Self::IOError(e)
+    }
+}
+
+impl From<ClientInfoError> for RdpError {
+    fn from(e: ClientInfoError) -> Self {
+        Self::ClientInfoError(e)
+    }
+}
+
+impl From<ServerLicenseError> for RdpError {
+    fn from(e: ServerLicenseError) -> Self {
+        Self::ServerLicenseError(e)
+    }
+}
+
+impl From<CapabilitySetsError> for RdpError {
+    fn from(e: CapabilitySetsError) -> Self {
+        Self::CapabilitySetsError(e)
+    }
+}
+
+impl From<session_info::SessionError> for RdpError {
+    fn from(e: session_info::SessionError) -> Self {
+        Self::SaveSessionInfoError(e)
+    }
+}
+
+impl From<InputEventError> for RdpError {
+    fn from(e: InputEventError) -> Self {
+        Self::InputEventError(e)
+    }
 }
 
 impl From<PduError> for RdpError {

--- a/crates/ironrdp-pdu/src/rdp/server_license/mod.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_license/mod.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use std::io;
 
 use bitflags::bitflags;
@@ -8,7 +9,6 @@ use ironrdp_core::{
 use md5::Digest as _;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive as _;
-use thiserror::Error;
 
 use crate::PduError;
 use crate::rdp::headers::{BASIC_SECURITY_HEADER_SIZE, BasicSecurityHeader, BasicSecurityHeaderFlags};
@@ -199,87 +199,171 @@ impl BlobType {
     pub const CLIENT_MACHINE_NAME_BLOB: Self = Self(0x10);
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum ServerLicenseError {
-    #[error("IO error: {0}")]
-    IOError(#[from] io::Error),
-    #[error("UTF-8 error: {0}")]
-    Utf8Error(#[from] std::string::FromUtf8Error),
-    #[error("DER error: {0}")]
-    DerError(#[from] pkcs1::der::Error),
-    #[error("invalid `{0}`: out of range integral type conversion")]
+    IOError(io::Error),
+    Utf8Error(std::string::FromUtf8Error),
+    DerError(pkcs1::der::Error),
     InvalidField(&'static str),
-    #[error("invalid preamble field: {0}")]
     InvalidPreamble(String),
-    #[error("invalid preamble message type field")]
     InvalidLicenseType,
-    #[error("invalid error code field")]
     InvalidErrorCode,
-    #[error("invalid state transition field")]
     InvalidStateTransition,
-    #[error("invalid blob type field")]
     InvalidBlobType,
-    #[error("unable to generate random number {0}")]
     RandomNumberGenerationError(String),
-    #[error("unable to retrieve public key from the certificate")]
     UnableToGetPublicKey,
-    #[error("unable to encrypt RSA public key")]
     RsaKeyEncryptionError,
-    #[error("invalid License Request key exchange algorithm value")]
     InvalidKeyExchangeValue,
-    #[error("MAC checksum generated over decrypted data does not match the server's checksum")]
     InvalidMacData,
-    #[error("invalid platform challenge response data version")]
     InvalidChallengeResponseDataVersion,
-    #[error("invalid platform challenge response data client type")]
     InvalidChallengeResponseDataClientType,
-    #[error("invalid platform challenge response data license detail level")]
     InvalidChallengeResponseDataLicenseDetail,
-    #[error("invalid x509 certificate")]
     InvalidX509Certificate {
         source: x509_cert::der::Error,
         cert_der: Vec<u8>,
     },
-    #[error("invalid certificate version")]
     InvalidCertificateVersion,
-    #[error("invalid x509 certificates amount")]
     InvalidX509CertificatesAmount,
-    #[error("invalid proprietary certificate signature algorithm ID")]
     InvalidPropCertSignatureAlgorithmId,
-    #[error("invalid proprietary certificate key algorithm ID")]
     InvalidPropCertKeyAlgorithmId,
-    #[error("invalid RSA public key magic")]
     InvalidRsaPublicKeyMagic,
-    #[error("invalid RSA public key length")]
     InvalidRsaPublicKeyLength,
-    #[error("invalid RSA public key data length")]
     InvalidRsaPublicKeyDataLength,
-    #[error("invalid RSA public key bit length")]
     InvalidRsaPublicKeyBitLength,
-    #[error("invalid License Header security flags")]
     InvalidSecurityFlags,
-    #[error("the server returned unexpected error: {0:?}")]
     UnexpectedError(LicensingErrorMessage),
-    #[error("got unexpected license message")]
     UnexpectedLicenseMessage,
-    #[error("the server has returned an unexpected error")]
     UnexpectedServerError(LicensingErrorMessage),
-    #[error("the server has returned STATUS_VALID_CLIENT (not an error)")]
     ValidClientStatus(LicensingErrorMessage),
-    #[error("invalid Key Exchange List field")]
     InvalidKeyExchangeAlgorithm,
-    #[error("received invalid company name length (Product Information): {0}")]
     InvalidCompanyNameLength(u32),
-    #[error("received invalid product ID length (Product Information): {0}")]
     InvalidProductIdLength(u32),
-    #[error("received invalid scope count field: {0}")]
     InvalidScopeCount(u32),
-    #[error("received invalid certificate length: {0}")]
     InvalidCertificateLength(u32),
-    #[error("blob too small")]
     BlobTooSmall,
-    #[error("PDU error: {0}")]
     Pdu(PduError),
+}
+
+impl fmt::Display for ServerLicenseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IOError(e) => write!(f, "IO error: {e}"),
+            Self::Utf8Error(e) => write!(f, "UTF-8 error: {e}"),
+            Self::DerError(e) => write!(f, "DER error: {e}"),
+            Self::InvalidField(name) => write!(f, "invalid `{name}`: out of range integral type conversion"),
+            Self::InvalidPreamble(s) => write!(f, "invalid preamble field: {s}"),
+            Self::InvalidLicenseType => f.write_str("invalid preamble message type field"),
+            Self::InvalidErrorCode => f.write_str("invalid error code field"),
+            Self::InvalidStateTransition => f.write_str("invalid state transition field"),
+            Self::InvalidBlobType => f.write_str("invalid blob type field"),
+            Self::RandomNumberGenerationError(s) => write!(f, "unable to generate random number {s}"),
+            Self::UnableToGetPublicKey => f.write_str("unable to retrieve public key from the certificate"),
+            Self::RsaKeyEncryptionError => f.write_str("unable to encrypt RSA public key"),
+            Self::InvalidKeyExchangeValue => f.write_str("invalid License Request key exchange algorithm value"),
+            Self::InvalidMacData => {
+                f.write_str("MAC checksum generated over decrypted data does not match the server's checksum")
+            }
+            Self::InvalidChallengeResponseDataVersion => {
+                f.write_str("invalid platform challenge response data version")
+            }
+            Self::InvalidChallengeResponseDataClientType => {
+                f.write_str("invalid platform challenge response data client type")
+            }
+            Self::InvalidChallengeResponseDataLicenseDetail => {
+                f.write_str("invalid platform challenge response data license detail level")
+            }
+            Self::InvalidX509Certificate { .. } => f.write_str("invalid x509 certificate"),
+            Self::InvalidCertificateVersion => f.write_str("invalid certificate version"),
+            Self::InvalidX509CertificatesAmount => f.write_str("invalid x509 certificates amount"),
+            Self::InvalidPropCertSignatureAlgorithmId => {
+                f.write_str("invalid proprietary certificate signature algorithm ID")
+            }
+            Self::InvalidPropCertKeyAlgorithmId => f.write_str("invalid proprietary certificate key algorithm ID"),
+            Self::InvalidRsaPublicKeyMagic => f.write_str("invalid RSA public key magic"),
+            Self::InvalidRsaPublicKeyLength => f.write_str("invalid RSA public key length"),
+            Self::InvalidRsaPublicKeyDataLength => f.write_str("invalid RSA public key data length"),
+            Self::InvalidRsaPublicKeyBitLength => f.write_str("invalid RSA public key bit length"),
+            Self::InvalidSecurityFlags => f.write_str("invalid License Header security flags"),
+            Self::UnexpectedError(msg) => write!(f, "the server returned unexpected error: {msg:?}"),
+            Self::UnexpectedLicenseMessage => f.write_str("got unexpected license message"),
+            Self::UnexpectedServerError(_) => f.write_str("the server has returned an unexpected error"),
+            Self::ValidClientStatus(_) => f.write_str("the server has returned STATUS_VALID_CLIENT (not an error)"),
+            Self::InvalidKeyExchangeAlgorithm => f.write_str("invalid Key Exchange List field"),
+            Self::InvalidCompanyNameLength(n) => {
+                write!(f, "received invalid company name length (Product Information): {n}")
+            }
+            Self::InvalidProductIdLength(n) => {
+                write!(f, "received invalid product ID length (Product Information): {n}")
+            }
+            Self::InvalidScopeCount(n) => write!(f, "received invalid scope count field: {n}"),
+            Self::InvalidCertificateLength(n) => write!(f, "received invalid certificate length: {n}"),
+            Self::BlobTooSmall => f.write_str("blob too small"),
+            Self::Pdu(e) => write!(f, "PDU error: {e}"),
+        }
+    }
+}
+
+impl core::error::Error for ServerLicenseError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::IOError(e) => Some(e),
+            Self::Utf8Error(e) => Some(e),
+            Self::DerError(e) => Some(e),
+            Self::InvalidX509Certificate { source, .. } => Some(source),
+            Self::InvalidField(_)
+            | Self::InvalidPreamble(_)
+            | Self::InvalidLicenseType
+            | Self::InvalidErrorCode
+            | Self::InvalidStateTransition
+            | Self::InvalidBlobType
+            | Self::RandomNumberGenerationError(_)
+            | Self::UnableToGetPublicKey
+            | Self::RsaKeyEncryptionError
+            | Self::InvalidKeyExchangeValue
+            | Self::InvalidMacData
+            | Self::InvalidChallengeResponseDataVersion
+            | Self::InvalidChallengeResponseDataClientType
+            | Self::InvalidChallengeResponseDataLicenseDetail
+            | Self::InvalidCertificateVersion
+            | Self::InvalidX509CertificatesAmount
+            | Self::InvalidPropCertSignatureAlgorithmId
+            | Self::InvalidPropCertKeyAlgorithmId
+            | Self::InvalidRsaPublicKeyMagic
+            | Self::InvalidRsaPublicKeyLength
+            | Self::InvalidRsaPublicKeyDataLength
+            | Self::InvalidRsaPublicKeyBitLength
+            | Self::InvalidSecurityFlags
+            | Self::UnexpectedError(_)
+            | Self::UnexpectedLicenseMessage
+            | Self::UnexpectedServerError(_)
+            | Self::ValidClientStatus(_)
+            | Self::InvalidKeyExchangeAlgorithm
+            | Self::InvalidCompanyNameLength(_)
+            | Self::InvalidProductIdLength(_)
+            | Self::InvalidScopeCount(_)
+            | Self::InvalidCertificateLength(_)
+            | Self::BlobTooSmall
+            | Self::Pdu(_) => None,
+        }
+    }
+}
+
+impl From<io::Error> for ServerLicenseError {
+    fn from(e: io::Error) -> Self {
+        Self::IOError(e)
+    }
+}
+
+impl From<std::string::FromUtf8Error> for ServerLicenseError {
+    fn from(e: std::string::FromUtf8Error) -> Self {
+        Self::Utf8Error(e)
+    }
+}
+
+impl From<pkcs1::der::Error> for ServerLicenseError {
+    fn from(e: pkcs1::der::Error) -> Self {
+        Self::DerError(e)
+    }
 }
 
 impl From<PduError> for ServerLicenseError {

--- a/crates/ironrdp-pdu/src/rdp/session_info/mod.rs
+++ b/crates/ironrdp-pdu/src/rdp/session_info/mod.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use std::io;
 
 use ironrdp_core::{
@@ -6,7 +7,6 @@ use ironrdp_core::{
 };
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive as _;
-use thiserror::Error;
 
 use crate::PduError;
 
@@ -127,30 +127,61 @@ pub enum InfoData {
     LogonExtended(LogonInfoExtended),
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum SessionError {
-    #[error("IO error")]
-    IOError(#[from] io::Error),
-    #[error("invalid save session info type value")]
+    IOError(io::Error),
     InvalidSaveSessionInfoType,
-    #[error("invalid domain name size value")]
     InvalidDomainNameSize,
-    #[error("invalid user name size value")]
     InvalidUserNameSize,
-    #[error("invalid logon version value")]
     InvalidLogonVersion2,
-    #[error("invalid logon info version2 size value")]
     InvalidLogonVersion2Size,
-    #[error("invalid server auto-reconnect packet size value")]
     InvalidAutoReconnectPacketSize,
-    #[error("invalid server auto-reconnect version")]
     InvalidAutoReconnectVersion,
-    #[error("invalid logon error type value")]
     InvalidLogonErrorType,
-    #[error("invalid logon error data value")]
     InvalidLogonErrorData,
-    #[error("PDU error: {0}")]
     Pdu(PduError),
+}
+
+impl fmt::Display for SessionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IOError(_) => f.write_str("IO error"),
+            Self::InvalidSaveSessionInfoType => f.write_str("invalid save session info type value"),
+            Self::InvalidDomainNameSize => f.write_str("invalid domain name size value"),
+            Self::InvalidUserNameSize => f.write_str("invalid user name size value"),
+            Self::InvalidLogonVersion2 => f.write_str("invalid logon version value"),
+            Self::InvalidLogonVersion2Size => f.write_str("invalid logon info version2 size value"),
+            Self::InvalidAutoReconnectPacketSize => f.write_str("invalid server auto-reconnect packet size value"),
+            Self::InvalidAutoReconnectVersion => f.write_str("invalid server auto-reconnect version"),
+            Self::InvalidLogonErrorType => f.write_str("invalid logon error type value"),
+            Self::InvalidLogonErrorData => f.write_str("invalid logon error data value"),
+            Self::Pdu(e) => write!(f, "PDU error: {e}"),
+        }
+    }
+}
+
+impl core::error::Error for SessionError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::IOError(e) => Some(e),
+            Self::InvalidSaveSessionInfoType
+            | Self::InvalidDomainNameSize
+            | Self::InvalidUserNameSize
+            | Self::InvalidLogonVersion2
+            | Self::InvalidLogonVersion2Size
+            | Self::InvalidAutoReconnectPacketSize
+            | Self::InvalidAutoReconnectVersion
+            | Self::InvalidLogonErrorType
+            | Self::InvalidLogonErrorData
+            | Self::Pdu(_) => None,
+        }
+    }
+}
+
+impl From<io::Error> for SessionError {
+    fn from(e: io::Error) -> Self {
+        Self::IOError(e)
+    }
 }
 
 impl From<PduError> for SessionError {

--- a/crates/ironrdp-pdu/src/rdp/vc/mod.rs
+++ b/crates/ironrdp-pdu/src/rdp/vc/mod.rs
@@ -3,11 +3,11 @@ pub mod dvc;
 #[cfg(test)]
 mod tests;
 
+use core::fmt;
 use std::{io, str};
 
 use bitflags::bitflags;
 use ironrdp_core::{Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, ensure_fixed_part_size};
-use thiserror::Error;
 
 use crate::PduError;
 
@@ -79,30 +79,72 @@ bitflags! {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum ChannelError {
-    #[error("IO error")]
-    IOError(#[from] io::Error),
-    #[error("from UTF-8 error")]
-    FromUtf8Error(#[from] std::string::FromUtf8Error),
-    #[error("invalid channel PDU header")]
+    IOError(io::Error),
+    FromUtf8Error(std::string::FromUtf8Error),
     InvalidChannelPduHeader,
-    #[error("invalid channel total data length")]
     InvalidChannelTotalDataLength,
-    #[error("invalid DVC PDU type")]
     InvalidDvcPduType,
-    #[error("invalid DVC id length value")]
     InvalidDVChannelIdLength,
-    #[error("invalid DVC data length value")]
     InvalidDvcDataLength,
-    #[error("invalid DVC capabilities version")]
     InvalidDvcCapabilitiesVersion,
-    #[error("invalid DVC message size")]
     InvalidDvcMessageSize,
-    #[error("invalid DVC total message size: actual ({actual}) > expected ({expected})")]
     InvalidDvcTotalMessageSize { actual: usize, expected: usize },
-    #[error("PDU error: {0}")]
     Pdu(PduError),
+}
+
+impl fmt::Display for ChannelError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IOError(_) => f.write_str("IO error"),
+            Self::FromUtf8Error(_) => f.write_str("from UTF-8 error"),
+            Self::InvalidChannelPduHeader => f.write_str("invalid channel PDU header"),
+            Self::InvalidChannelTotalDataLength => f.write_str("invalid channel total data length"),
+            Self::InvalidDvcPduType => f.write_str("invalid DVC PDU type"),
+            Self::InvalidDVChannelIdLength => f.write_str("invalid DVC id length value"),
+            Self::InvalidDvcDataLength => f.write_str("invalid DVC data length value"),
+            Self::InvalidDvcCapabilitiesVersion => f.write_str("invalid DVC capabilities version"),
+            Self::InvalidDvcMessageSize => f.write_str("invalid DVC message size"),
+            Self::InvalidDvcTotalMessageSize { actual, expected } => {
+                write!(
+                    f,
+                    "invalid DVC total message size: actual ({actual}) > expected ({expected})"
+                )
+            }
+            Self::Pdu(e) => write!(f, "PDU error: {e}"),
+        }
+    }
+}
+
+impl core::error::Error for ChannelError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::IOError(e) => Some(e),
+            Self::FromUtf8Error(e) => Some(e),
+            Self::InvalidChannelPduHeader
+            | Self::InvalidChannelTotalDataLength
+            | Self::InvalidDvcPduType
+            | Self::InvalidDVChannelIdLength
+            | Self::InvalidDvcDataLength
+            | Self::InvalidDvcCapabilitiesVersion
+            | Self::InvalidDvcMessageSize
+            | Self::InvalidDvcTotalMessageSize { .. }
+            | Self::Pdu(_) => None,
+        }
+    }
+}
+
+impl From<io::Error> for ChannelError {
+    fn from(e: io::Error) -> Self {
+        Self::IOError(e)
+    }
+}
+
+impl From<std::string::FromUtf8Error> for ChannelError {
+    fn from(e: std::string::FromUtf8Error) -> Self {
+        Self::FromUtf8Error(e)
+    }
 }
 
 impl From<PduError> for ChannelError {

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -394,7 +394,6 @@ dependencies = [
  "pkcs1",
  "sha1",
  "tap",
- "thiserror",
  "x509-cert",
 ]
 


### PR DESCRIPTION
Closes the proc-macro architectural-invariant violation that issue #1257 surfaced and that I committed to addressing in https://github.com/Devolutions/IronRDP/issues/1257#issuecomment-4426485616.

## What changes

`ironrdp-pdu` is Core Tier per `ARCHITECTURE.md`. Core Tier carries the architectural invariant that no proc-macro dependency (`syn`) is allowed, so compilation stays fast for downstream consumers that build only the protocol-decode tree (the fuzzing infrastructure, the web client, `no_std` users).

`thiserror = "2.0"` was carried in the legacy block of `ironrdp-pdu/Cargo.toml` under the existing `# TODO: get rid of these dependencies` comment. This PR delivers on that TODO. Every `#[derive(thiserror::Error)]` in the crate is replaced with hand-written `impl Display`, `impl core::error::Error`, and `impl From<X>` blocks that preserve the exact `Display` output byte-for-byte and the exact `Error::source()` semantics that the derives generated.

## Enums converted (13 total across 13 files)

GCC family:
- `CoreDataError`, `GccError`, `NetworkDataError`, `ClusterDataError`, `SecurityDataError`

RDP family:
- `RdpError`, `CapabilitySetsError`, `ChannelError`, `SessionError`, `ServerLicenseError`, `ClientInfoError`

Other:
- `InputEventError`
- `McsError` (legacy submodule in `mcs.rs`)

Each enum keeps `#[derive(Debug)]`. The hand-written `Display` preserves every `#[error("...")]` format string verbatim, including `{0}` and `{0:?}` interpolations and the named-field interpolation in `ChannelError::InvalidDvcTotalMessageSize`. The `Error::source()` impl preserves the `#[from]`-driven source chain plus the named `source:` field on `ServerLicenseError::InvalidX509Certificate`. The existing manual `From<PduError>`, `From<RdpError> for io::Error`, `From<McsError> for io::Error`, `From<ChannelError> for io::Error`, and `From<LicensingErrorMessage> for ServerLicenseError` impls are preserved unchanged.

## Verification

- `cargo expand` against the post-change tree shows `Display` and `source` impls that are functionally equivalent to the thiserror-generated versions for every variant.
- `cargo check --workspace` clean.
- `cargo test --package ironrdp-pdu` 850 tests pass, 0 failures.
- `cargo clippy --package ironrdp-pdu --all-targets -- -D warnings` clean.
- `cargo xtask check fmt` clean.
- `cargo xtask check typos` clean.

## Downstream impact

External consumers of these types in the workspace (`ironrdp-connector` for `ServerLicenseError`, `ffi` and `ironrdp-session` for `RdpError` and `SessionError`) treat them as opaque error types. A workspace-wide grep finds no variant-level pattern matching on these enums outside `ironrdp-pdu` itself, so the preserved `From` conversions and `Display` output fully cover downstream expectations.

## Diff shape

15 files changed, +748 / -216 (net +532). Most of the added lines are the explicit `Display` match arms and the per-variant `From` and `source()` arms that the proc-macro previously generated at compile time.

Related: #1257.
