### PR TITLE
feat(error): add ErrorClassification trait for triage-friendly Error<Kind> categories

### DIFF
--- a/crates/ironrdp-core/src/decode.rs
+++ b/crates/ironrdp-core/src/decode.rs
@@ -2,6 +2,8 @@
 use alloc::string::String;
 use core::fmt;
 
+use ironrdp_error::{ErrorCategory, ErrorClassification};
+
 use crate::{
     InvalidFieldErr, NotEnoughBytesErr, OtherErr, ReadCursor, UnexpectedMessageTypeErr, UnsupportedValueErr,
     UnsupportedVersionErr,
@@ -65,6 +67,23 @@ pub enum DecodeErrorKind {
 
 #[cfg(feature = "std")]
 impl core::error::Error for DecodeErrorKind {}
+
+impl ErrorClassification for DecodeErrorKind {
+    fn classify(&self) -> ErrorCategory {
+        // All structured variants are peer-driven: the input came from the
+        // wire and failed to conform to the spec at some level. `Other` is
+        // a free-form catch-all that cannot be classified without inspecting
+        // the description, so it stays `Unknown`.
+        match self {
+            Self::NotEnoughBytes { .. }
+            | Self::InvalidField { .. }
+            | Self::UnexpectedMessageType { .. }
+            | Self::UnsupportedVersion { .. }
+            | Self::UnsupportedValue { .. } => ErrorCategory::Protocol,
+            Self::Other { .. } => ErrorCategory::Unknown,
+        }
+    }
+}
 
 impl fmt::Display for DecodeErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/ironrdp-core/src/encode.rs
+++ b/crates/ironrdp-core/src/encode.rs
@@ -4,6 +4,8 @@ use alloc::string::String;
 use alloc::{vec, vec::Vec};
 use core::fmt;
 
+use ironrdp_error::{ErrorCategory, ErrorClassification};
+
 #[cfg(feature = "alloc")]
 use crate::WriteBuf;
 use crate::{
@@ -69,6 +71,24 @@ pub enum EncodeErrorKind {
 
 #[cfg(feature = "std")]
 impl core::error::Error for EncodeErrorKind {}
+
+impl ErrorClassification for EncodeErrorKind {
+    fn classify(&self) -> ErrorCategory {
+        // Encode errors are produced by our own code while serialising data
+        // we constructed; every structured variant indicates we hit an
+        // internal invariant violation (under-sized buffer, attempting to
+        // write an out-of-range value, etc.). `Other` is a free-form
+        // catch-all and stays `Unknown`.
+        match self {
+            Self::NotEnoughBytes { .. }
+            | Self::InvalidField { .. }
+            | Self::UnexpectedMessageType { .. }
+            | Self::UnsupportedVersion { .. }
+            | Self::UnsupportedValue { .. } => ErrorCategory::InternalBug,
+            Self::Other { .. } => ErrorCategory::Unknown,
+        }
+    }
+}
 
 impl fmt::Display for EncodeErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/ironrdp-core/src/lib.rs
+++ b/crates/ironrdp-core/src/lib.rs
@@ -22,6 +22,8 @@ mod write_buf;
 
 // Flat API hierarchy of common traits and types
 
+pub use ironrdp_error::{ErrorCategory, ErrorClassification};
+
 pub use self::as_any::*;
 pub use self::cursor::*;
 pub use self::decode::*;

--- a/crates/ironrdp-error/src/lib.rs
+++ b/crates/ironrdp-error/src/lib.rs
@@ -26,6 +26,65 @@ struct ErrorMeta {
     source: Option<Box<dyn Source>>,
 }
 
+/// Coarse category assigned to a `*ErrorKind` variant by [`ErrorClassification`],
+/// used to drive triage logic that does not depend on the specific kind shape.
+///
+/// The intended primary consumer is the structured-fuzzing oracle code in
+/// `ironrdp-fuzzing`, which uses the category to distinguish "the decoder
+/// correctly rejected malformed input" from "the decoder hit an internal
+/// invariant violation" without parsing `Display` strings.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ErrorCategory {
+    /// Wire-protocol violation by the peer: the input does not conform to the
+    /// specification (invalid field, unsupported version, unexpected message
+    /// type, premature end of input, etc.).
+    ///
+    /// For a fuzz oracle, this is the expected outcome when fuzzing decoders
+    /// with arbitrary bytes: the decoder caught a malformed input.
+    Protocol,
+
+    /// Logical inconsistency in otherwise spec-conformant data: the peer
+    /// sent something whose individual fields parse but whose meaning is
+    /// internally contradictory (e.g. mismatched lengths, impossible
+    /// references, failed integrity checks).
+    ///
+    /// For a fuzz oracle, this is also an expected rejection; treated
+    /// separately from [`ErrorCategory::Protocol`] because the diagnostic
+    /// implications differ (deeper validation logic was reached before the
+    /// rejection).
+    DataCorruption,
+
+    /// Internal invariant violation in our own code: an unexpected state
+    /// was reached that should not occur for any valid or invalid input.
+    ///
+    /// For a fuzz oracle, this is the bug signal: the kind of failure that
+    /// should be minimized to a crasher and reported.
+    InternalBug,
+
+    /// Classification not specified for this variant. Either the `Kind`
+    /// type has not yet been audited to assign categories to all its
+    /// variants, or the variant is intentionally left uncategorized
+    /// pending design decisions.
+    Unknown,
+}
+
+/// Assigns an [`ErrorCategory`] to each variant of a `*ErrorKind` enum.
+///
+/// Implement on the `Kind` type carried by [`Error<Kind>`]. Once implemented,
+/// [`Error::classify`] becomes available on `Error<Kind>` and forwards to this
+/// trait's [`classify`](Self::classify) method.
+///
+/// Per the [`ErrorCategory`] documentation, the primary consumer is the
+/// structured-fuzzing oracle code. Other consumers may include diagnostic
+/// logging that routes errors to different sinks based on category, or
+/// integration tests that assert on the expected category of an induced
+/// failure without depending on the specific variant shape.
+pub trait ErrorClassification {
+    /// Returns the category for this variant.
+    fn classify(&self) -> ErrorCategory;
+}
+
 /// A typed error wrapper carrying a `Kind` discriminant plus diagnostic metadata.
 ///
 /// # `no_alloc` platforms
@@ -154,6 +213,19 @@ impl<Kind> Error<Kind> {
 
     pub fn report(&self) -> ErrorReport<'_, Kind> {
         ErrorReport(self)
+    }
+}
+
+impl<Kind> Error<Kind>
+where
+    Kind: ErrorClassification,
+{
+    /// Returns the [`ErrorCategory`] of this error, forwarded from the
+    /// inner `Kind` via its [`ErrorClassification`] impl.
+    ///
+    /// Only available when `Kind` implements [`ErrorClassification`].
+    pub fn classify(&self) -> ErrorCategory {
+        self.kind.classify()
     }
 }
 


### PR DESCRIPTION
## Summary

Introduces `ironrdp_error::ErrorClassification`, a trait that assigns each `*ErrorKind` variant a coarse [`ErrorCategory`] (one of `Protocol`, `DataCorruption`, `InternalBug`, `Unknown`). A convenience `Error<Kind>::classify()` method becomes available on `Error<Kind>` when `Kind: ErrorClassification`, forwarding to the inner kind.

Implements the trait for `DecodeErrorKind` and `EncodeErrorKind` in `ironrdp-core`, and re-exports `ErrorCategory` and `ErrorClassification` from `ironrdp-core` so consumers can pull them via the same crate they already use for `DecodeError` / `EncodeError`.

Closes out the third of the substantive ironrdp-error follow-ons from #1257 (after #1262 location capture, #1263 bail!/ensure! macros, and the position-aware metadata in #1266). Primary consumer is the structured-fuzzing oracle code in [#1120](https://github.com/Devolutions/IronRDP/issues/1120).

## Why this matters for fuzzing

Structured-fuzz oracles need to distinguish:

- **Expected outcome:** the decoder correctly rejected a malformed input (`Protocol`, `DataCorruption`).
- **Bug signal:** the decoder reached an internal invariant violation that should not happen for any input (`InternalBug`).

Today, an oracle can only differentiate by parsing the `Display` string of an error, which is fragile and tightly couples oracle code to formatting choices. After this PR, the oracle calls `error.classify()` and matches on an enum.

## API

```rust
#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
#[non_exhaustive]
pub enum ErrorCategory {
    Protocol,
    DataCorruption,
    InternalBug,
    Unknown,
}

pub trait ErrorClassification {
    fn classify(&self) -> ErrorCategory;
}

impl<Kind: ErrorClassification> Error<Kind> {
    pub fn classify(&self) -> ErrorCategory;
}
```

## Initial impls in ironrdp-core

| Kind | Structured variants | `Other` |
|---|---|---|
| `DecodeErrorKind` | `Protocol` (peer-driven wire-format failures) | `Unknown` |
| `EncodeErrorKind` | `InternalBug` (we miscalculated something in our own serialisation path) | `Unknown` |

`Other` is intentionally `Unknown` because it carries a free-form `description: &'static str` and cannot be classified without inspecting that string at compile time.

`DataCorruption` is defined now but not used by `DecodeErrorKind` / `EncodeErrorKind` because those enums only carry low-level wire-format variants. It is reserved for the deeper-validation variants that other `*ErrorKind` enums in the workspace will adopt in follow-on PRs (e.g. session-layer integrity checks, license validation, capability negotiation mismatches).

## Adoption pattern for other crates

The trait is intentionally **not** given a default impl returning `Unknown`. Per-crate adoption is opt-in: an `*ErrorKind` that wants classification implements the trait, and `Error<Kind>::classify()` becomes available on `Error<Kind>` accordingly. Kinds that have not been audited yet simply do not expose the convenience method. This forces classification work to be deliberate rather than silently degrading to `Unknown` for unaudited variants.

## Scope

Strictly additive: no existing `*ErrorKind` enum signature changes, no existing constructor changes, no `Display` / `Debug` changes. The new trait method is purely opt-in for consumers who need categorisation.

This PR limits the per-crate impl work to `ironrdp-core`'s two foundational kinds. Follow-on PRs may extend the impl to other workspace `*ErrorKind` types as their owners audit them.

## Diff

- `crates/ironrdp-error/src/lib.rs` (+73): `ErrorCategory` enum, `ErrorClassification` trait, `Error<Kind>::classify()` convenience impl block
- `crates/ironrdp-core/src/lib.rs` (+2): re-exports `ErrorCategory` and `ErrorClassification`
- `crates/ironrdp-core/src/decode.rs` (+19): `ErrorClassification` impl for `DecodeErrorKind`
- `crates/ironrdp-core/src/encode.rs` (+20): `ErrorClassification` impl for `EncodeErrorKind`

Total: 4 files, +114, 0 deletions.

## CI

`cargo xtask check fmt | lints | locks | typos | tests` all pass locally. `ironrdp-core` builds clean under `--no-default-features` (no_std) and `--all-features`.

## Relationship to the other open error PRs

| PR | What it does | Independent? |
|---|---|---|
| #1264 | Removes the existing `thiserror` dependency from `ironrdp-pdu` by hand-rolling Display/Error impls | Yes, independent |
| #1266 | Adds optional byte-offset + symbolic field-context metadata to `Error<Kind>` | Yes, independent |
| #1267 (this) | Adds `ErrorClassification` trait + category enum + initial impls | Yes, independent |

All three are independent and can land in any order.