### PR TITLE
fix(pdu)!: remove unused legacy error types

### DIFF
--- a/crates/ironrdp-pdu/src/gcc/cluster_data.rs
+++ b/crates/ironrdp-pdu/src/gcc/cluster_data.rs
@@ -1,6 +1,3 @@
-use core::fmt;
-use std::io;
-
 use bitflags::bitflags;
 use ironrdp_core::{
     Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, ensure_fixed_part_size, invalid_field_err,
@@ -94,35 +91,5 @@ impl RedirectionVersion {
     )]
     fn as_u32(self) -> u32 {
         self as u32
-    }
-}
-
-#[derive(Debug)]
-pub enum ClusterDataError {
-    IOError(io::Error),
-    InvalidRedirectionFlags,
-}
-
-impl fmt::Display for ClusterDataError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::IOError(_) => f.write_str("IO error"),
-            Self::InvalidRedirectionFlags => f.write_str("invalid redirection flags field"),
-        }
-    }
-}
-
-impl core::error::Error for ClusterDataError {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match self {
-            Self::IOError(e) => Some(e),
-            Self::InvalidRedirectionFlags => None,
-        }
-    }
-}
-
-impl From<io::Error> for ClusterDataError {
-    fn from(e: io::Error) -> Self {
-        Self::IOError(e)
     }
 }

--- a/crates/ironrdp-pdu/src/gcc/core_data/mod.rs
+++ b/crates/ironrdp-pdu/src/gcc/core_data/mod.rs
@@ -1,11 +1,6 @@
 pub(crate) mod client;
 pub(crate) mod server;
 
-use core::fmt;
-use std::io;
-
-use crate::PduError;
-
 const VERSION_SIZE: usize = 4;
 
 #[repr(transparent)]
@@ -40,70 +35,4 @@ impl RdpVersion {
     pub const V10_10: Self = Self(0x0008_000F);
     pub const V10_11: Self = Self(0x0008_0010);
     pub const V10_12: Self = Self(0x0008_0011);
-}
-
-#[derive(Debug)]
-pub enum CoreDataError {
-    IOError(io::Error),
-    InvalidVersion,
-    InvalidColorDepth,
-    InvalidPostBetaColorDepth,
-    InvalidHighColorDepth,
-    InvalidSupportedColorDepths,
-    InvalidSecureAccessSequence,
-    InvalidKeyboardType,
-    InvalidEarlyCapabilityFlags,
-    InvalidConnectionType,
-    InvalidServerSecurityProtocol,
-    Pdu(PduError),
-}
-
-impl fmt::Display for CoreDataError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::IOError(_) => f.write_str("IO error"),
-            Self::InvalidVersion => f.write_str("invalid version field"),
-            Self::InvalidColorDepth => f.write_str("invalid color depth field"),
-            Self::InvalidPostBetaColorDepth => f.write_str("invalid post beta color depth field"),
-            Self::InvalidHighColorDepth => f.write_str("invalid high color depth field"),
-            Self::InvalidSupportedColorDepths => f.write_str("invalid supported color depths field"),
-            Self::InvalidSecureAccessSequence => f.write_str("invalid secure access sequence field"),
-            Self::InvalidKeyboardType => f.write_str("invalid keyboard type field"),
-            Self::InvalidEarlyCapabilityFlags => f.write_str("invalid early capability flags field"),
-            Self::InvalidConnectionType => f.write_str("invalid connection type field"),
-            Self::InvalidServerSecurityProtocol => f.write_str("invalid server security protocol field"),
-            Self::Pdu(e) => write!(f, "PDU error: {e}"),
-        }
-    }
-}
-
-impl core::error::Error for CoreDataError {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match self {
-            Self::IOError(e) => Some(e),
-            Self::InvalidVersion
-            | Self::InvalidColorDepth
-            | Self::InvalidPostBetaColorDepth
-            | Self::InvalidHighColorDepth
-            | Self::InvalidSupportedColorDepths
-            | Self::InvalidSecureAccessSequence
-            | Self::InvalidKeyboardType
-            | Self::InvalidEarlyCapabilityFlags
-            | Self::InvalidConnectionType
-            | Self::InvalidServerSecurityProtocol
-            | Self::Pdu(_) => None,
-        }
-    }
-}
-
-impl From<io::Error> for CoreDataError {
-    fn from(e: io::Error) -> Self {
-        Self::IOError(e)
-    }
-}
-
-impl From<PduError> for CoreDataError {
-    fn from(e: PduError) -> Self {
-        Self::Pdu(e)
-    }
 }

--- a/crates/ironrdp-pdu/src/gcc/mod.rs
+++ b/crates/ironrdp-pdu/src/gcc/mod.rs
@@ -1,14 +1,9 @@
-use core::fmt;
-use std::io;
-
 use ironrdp_core::{
     Decode, DecodeErrorKind, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, cast_length, decode,
     ensure_fixed_part_size, ensure_size, invalid_field_err,
 };
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
-
-use crate::PduError;
 
 pub mod conference_create;
 
@@ -21,26 +16,22 @@ mod multi_transport_channel_data;
 mod network_data;
 mod security_data;
 
-pub use self::cluster_data::{ClientClusterData, ClusterDataError, RedirectionFlags, RedirectionVersion};
+pub use self::cluster_data::{ClientClusterData, RedirectionFlags, RedirectionVersion};
 pub use self::conference_create::{ConferenceCreateRequest, ConferenceCreateResponse};
+pub use self::core_data::RdpVersion;
 pub use self::core_data::client::{
     ClientColorDepth, ClientCoreData, ClientCoreOptionalData, ClientEarlyCapabilityFlags, ColorDepth, ConnectionType,
     HighColorDepth, IME_FILE_NAME_SIZE, KeyboardType, SecureAccessSequence, SupportedColorDepths,
 };
 pub use self::core_data::server::{ServerCoreData, ServerCoreOptionalData, ServerEarlyCapabilityFlags};
-pub use self::core_data::{CoreDataError, RdpVersion};
 pub use self::message_channel_data::{ClientMessageChannelData, ServerMessageChannelData};
 pub use self::monitor_data::{
     ClientMonitorData, MONITOR_COUNT_SIZE, MONITOR_FLAGS_SIZE, MONITOR_SIZE, Monitor, MonitorFlags,
 };
 pub use self::monitor_extended_data::{ClientMonitorExtendedData, ExtendedMonitorInfo, MonitorOrientation};
 pub use self::multi_transport_channel_data::{MultiTransportChannelData, MultiTransportFlags};
-pub use self::network_data::{
-    ChannelDef, ChannelName, ChannelOptions, ClientNetworkData, NetworkDataError, ServerNetworkData,
-};
-pub use self::security_data::{
-    ClientSecurityData, EncryptionLevel, EncryptionMethod, SecurityDataError, ServerSecurityData,
-};
+pub use self::network_data::{ChannelDef, ChannelName, ChannelOptions, ClientNetworkData, ServerNetworkData};
+pub use self::security_data::{ClientSecurityData, EncryptionLevel, EncryptionMethod, ServerSecurityData};
 
 macro_rules! user_header_try {
     ($e:expr) => {
@@ -353,96 +344,5 @@ impl UserDataHeader {
         ensure_size!(in: src, size: len);
 
         Ok((block_type, src.read_slice(len)))
-    }
-}
-
-#[derive(Debug)]
-pub enum GccError {
-    IOError(io::Error),
-    CoreError(CoreDataError),
-    SecurityError(SecurityDataError),
-    NetworkError(NetworkDataError),
-    ClusterError(ClusterDataError),
-    InvalidGccType,
-    InvalidConferenceCreateRequest(String),
-    InvalidConferenceCreateResponse(String),
-    RequiredClientDataBlockIsAbsent(ClientGccType),
-    RequiredServerDataBlockIsAbsent(ServerGccType),
-    Pdu(PduError),
-}
-
-impl fmt::Display for GccError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::IOError(_) => f.write_str("IO error"),
-            Self::CoreError(_) => f.write_str("core data block error"),
-            Self::SecurityError(_) => f.write_str("security data block error"),
-            Self::NetworkError(_) => f.write_str("network data block error"),
-            Self::ClusterError(_) => f.write_str("cluster data block error"),
-            Self::InvalidGccType => f.write_str("invalid GCC block type"),
-            Self::InvalidConferenceCreateRequest(s) => write!(f, "invalid conference create request: {s}"),
-            Self::InvalidConferenceCreateResponse(s) => write!(f, "invalid Conference create response: {s}"),
-            Self::RequiredClientDataBlockIsAbsent(ty) => {
-                write!(f, "a server did not send the required GCC data block: {ty:?}")
-            }
-            Self::RequiredServerDataBlockIsAbsent(ty) => {
-                write!(f, "a client did not send the required GCC data block: {ty:?}")
-            }
-            Self::Pdu(e) => write!(f, "PDU error: {e}"),
-        }
-    }
-}
-
-impl core::error::Error for GccError {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match self {
-            Self::IOError(e) => Some(e),
-            Self::CoreError(e) => Some(e),
-            Self::SecurityError(e) => Some(e),
-            Self::NetworkError(e) => Some(e),
-            Self::ClusterError(e) => Some(e),
-            Self::InvalidGccType
-            | Self::InvalidConferenceCreateRequest(_)
-            | Self::InvalidConferenceCreateResponse(_)
-            | Self::RequiredClientDataBlockIsAbsent(_)
-            | Self::RequiredServerDataBlockIsAbsent(_)
-            | Self::Pdu(_) => None,
-        }
-    }
-}
-
-impl From<io::Error> for GccError {
-    fn from(e: io::Error) -> Self {
-        Self::IOError(e)
-    }
-}
-
-impl From<CoreDataError> for GccError {
-    fn from(e: CoreDataError) -> Self {
-        Self::CoreError(e)
-    }
-}
-
-impl From<SecurityDataError> for GccError {
-    fn from(e: SecurityDataError) -> Self {
-        Self::SecurityError(e)
-    }
-}
-
-impl From<NetworkDataError> for GccError {
-    fn from(e: NetworkDataError) -> Self {
-        Self::NetworkError(e)
-    }
-}
-
-impl From<ClusterDataError> for GccError {
-    fn from(e: ClusterDataError) -> Self {
-        Self::ClusterError(e)
-    }
-}
-
-impl From<PduError> for GccError {
-    fn from(e: PduError) -> Self {
-        Self::Pdu(e)
     }
 }

--- a/crates/ironrdp-pdu/src/gcc/network_data.rs
+++ b/crates/ironrdp-pdu/src/gcc/network_data.rs
@@ -1,6 +1,5 @@
-use core::fmt;
 use std::borrow::Cow;
-use std::{io, str};
+use std::str;
 
 use bitflags::bitflags;
 use ironrdp_core::{
@@ -286,46 +285,5 @@ bitflags! {
         const COMPRESS = 0x0040_0000;
         const SHOW_PROTOCOL = 0x0020_0000;
         const REMOTE_CONTROL_PERSISTENT = 0x0010_0000;
-    }
-}
-
-#[derive(Debug)]
-pub enum NetworkDataError {
-    IOError(io::Error),
-    Utf8Error(str::Utf8Error),
-    InvalidChannelOptions,
-    InvalidChannelCount,
-}
-
-impl fmt::Display for NetworkDataError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::IOError(_) => f.write_str("IO error"),
-            Self::Utf8Error(_) => f.write_str("UTF-8 error"),
-            Self::InvalidChannelOptions => f.write_str("invalid channel options field"),
-            Self::InvalidChannelCount => f.write_str("invalid channel count field"),
-        }
-    }
-}
-
-impl core::error::Error for NetworkDataError {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match self {
-            Self::IOError(e) => Some(e),
-            Self::Utf8Error(e) => Some(e),
-            Self::InvalidChannelOptions | Self::InvalidChannelCount => None,
-        }
-    }
-}
-
-impl From<io::Error> for NetworkDataError {
-    fn from(e: io::Error) -> Self {
-        Self::IOError(e)
-    }
-}
-
-impl From<str::Utf8Error> for NetworkDataError {
-    fn from(e: str::Utf8Error) -> Self {
-        Self::Utf8Error(e)
     }
 }

--- a/crates/ironrdp-pdu/src/gcc/security_data.rs
+++ b/crates/ironrdp-pdu/src/gcc/security_data.rs
@@ -1,6 +1,3 @@
-use core::fmt;
-use std::io;
-
 use bitflags::bitflags;
 use ironrdp_core::{
     Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, cast_length, ensure_fixed_part_size,
@@ -216,47 +213,5 @@ impl EncryptionLevel {
     )]
     fn as_u32(self) -> u32 {
         self as u32
-    }
-}
-
-#[derive(Debug)]
-pub enum SecurityDataError {
-    IOError(io::Error),
-    InvalidEncryptionMethod,
-    InvalidEncryptionLevel,
-    InvalidServerRandomLen(u32),
-    InvalidInput(String),
-    InvalidServerCertificateLen(u32),
-}
-
-impl fmt::Display for SecurityDataError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::IOError(_) => f.write_str("IO error"),
-            Self::InvalidEncryptionMethod => f.write_str("invalid encryption methods field"),
-            Self::InvalidEncryptionLevel => f.write_str("invalid encryption level field"),
-            Self::InvalidServerRandomLen(n) => write!(f, "invalid server random length field: {n}"),
-            Self::InvalidInput(s) => write!(f, "invalid input: {s}"),
-            Self::InvalidServerCertificateLen(n) => write!(f, "invalid server certificate length: {n}"),
-        }
-    }
-}
-
-impl core::error::Error for SecurityDataError {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match self {
-            Self::IOError(e) => Some(e),
-            Self::InvalidEncryptionMethod
-            | Self::InvalidEncryptionLevel
-            | Self::InvalidServerRandomLen(_)
-            | Self::InvalidInput(_)
-            | Self::InvalidServerCertificateLen(_) => None,
-        }
-    }
-}
-
-impl From<io::Error> for SecurityDataError {
-    fn from(e: io::Error) -> Self {
-        Self::IOError(e)
     }
 }

--- a/crates/ironrdp-pdu/src/input/mod.rs
+++ b/crates/ironrdp-pdu/src/input/mod.rs
@@ -1,6 +1,3 @@
-use core::fmt;
-use std::io;
-
 use ironrdp_core::{
     Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, cast_length, ensure_fixed_part_size,
     ensure_size, invalid_field_err, read_padding, write_padding,
@@ -179,50 +176,5 @@ impl From<&InputEvent> for InputEventType {
             InputEvent::MouseX(_) => Self::MouseX,
             InputEvent::MouseRel(_) => Self::MouseRel,
         }
-    }
-}
-
-#[derive(Debug)]
-pub enum InputEventError {
-    IOError(io::Error),
-    InvalidInputEventType(u16),
-    EncryptionNotSupported,
-    EventCodeUnsupported(u8),
-    KeyboardFlagsUnsupported(u8),
-    SynchronizeFlagsUnsupported(u8),
-    EmptyFastPathInput,
-}
-
-impl fmt::Display for InputEventError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::IOError(_) => f.write_str("IO error"),
-            Self::InvalidInputEventType(n) => write!(f, "invalid Input Event type: {n}"),
-            Self::EncryptionNotSupported => f.write_str("encryption not supported"),
-            Self::EventCodeUnsupported(n) => write!(f, "event code not supported {n}"),
-            Self::KeyboardFlagsUnsupported(n) => write!(f, "keyboard flags not supported {n}"),
-            Self::SynchronizeFlagsUnsupported(n) => write!(f, "synchronize flags not supported {n}"),
-            Self::EmptyFastPathInput => f.write_str("Fast-Path Input Event PDU is empty"),
-        }
-    }
-}
-
-impl core::error::Error for InputEventError {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match self {
-            Self::IOError(e) => Some(e),
-            Self::InvalidInputEventType(_)
-            | Self::EncryptionNotSupported
-            | Self::EventCodeUnsupported(_)
-            | Self::KeyboardFlagsUnsupported(_)
-            | Self::SynchronizeFlagsUnsupported(_)
-            | Self::EmptyFastPathInput => None,
-        }
-    }
-}
-
-impl From<io::Error> for InputEventError {
-    fn from(e: io::Error) -> Self {
-        Self::IOError(e)
     }
 }

--- a/crates/ironrdp-pdu/src/mcs.rs
+++ b/crates/ironrdp-pdu/src/mcs.rs
@@ -9,7 +9,7 @@ use crate::gcc::{ChannelDef, ClientGccBlocks, ConferenceCreateRequest, Conferenc
 use crate::tpdu::{TpduCode, TpduHeader};
 use crate::tpkt::TpktHeader;
 use crate::x224::{X224Pdu, user_data_size};
-use crate::{DecodeResult, EncodeResult, PduError, impl_x224_pdu_borrowing, impl_x224_pdu_pod, per};
+use crate::{DecodeResult, EncodeResult, impl_x224_pdu_borrowing, impl_x224_pdu_pod, per};
 
 // T.125 MCS is defined in:
 //
@@ -932,24 +932,19 @@ impl DomainParameters {
     }
 }
 
-pub use legacy::McsError;
-
 mod legacy {
     #![allow(
         clippy::multiple_inherent_impl,
         reason = "Cannot move the implementation from the legacy module"
     )]
 
-    use core::fmt;
-    use std::io;
-
     use ironrdp_core::{Decode, DecodeResult, Encode, cast_int};
 
     use super::{
-        ConnectInitial, ConnectResponse, DomainParameters, PduError, RESULT_ENUM_LENGTH, ReadCursor, WriteCursor,
-        cast_length, ensure_size,
+        ConnectInitial, ConnectResponse, DomainParameters, RESULT_ENUM_LENGTH, ReadCursor, WriteCursor, cast_length,
+        ensure_size,
     };
-    use crate::gcc::{ConferenceCreateRequest, ConferenceCreateResponse, GccError};
+    use crate::gcc::{ConferenceCreateRequest, ConferenceCreateResponse};
     use crate::{EncodeResult, ber};
 
     // impl<'de> McsPdu<'de> for ConnectInitial {
@@ -1174,69 +1169,6 @@ mod legacy {
                 max_mcs_pdu_size,
                 protocol_version,
             })
-        }
-    }
-
-    #[derive(Debug)]
-    pub enum McsError {
-        IOError(io::Error),
-        GccError(GccError),
-        InvalidDisconnectProviderUltimatum,
-        InvalidDomainMcsPdu,
-        InvalidPdu(String),
-        UnexpectedChannelId(String),
-        Pdu(PduError),
-    }
-
-    impl fmt::Display for McsError {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            match self {
-                Self::IOError(_) => f.write_str("IO error"),
-                Self::GccError(_) => f.write_str("GCC block error"),
-                Self::InvalidDisconnectProviderUltimatum => f.write_str("invalid disconnect provider ultimatum"),
-                Self::InvalidDomainMcsPdu => f.write_str("invalid domain MCS PDU"),
-                Self::InvalidPdu(_) => f.write_str("invalid MCS Connection Sequence PDU"),
-                Self::UnexpectedChannelId(_) => f.write_str("invalid MCS channel id"),
-                Self::Pdu(e) => write!(f, "PDU error: {e}"),
-            }
-        }
-    }
-
-    impl core::error::Error for McsError {
-        fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-            match self {
-                Self::IOError(e) => Some(e),
-                Self::GccError(e) => Some(e),
-                Self::InvalidDisconnectProviderUltimatum
-                | Self::InvalidDomainMcsPdu
-                | Self::InvalidPdu(_)
-                | Self::UnexpectedChannelId(_)
-                | Self::Pdu(_) => None,
-            }
-        }
-    }
-
-    impl From<io::Error> for McsError {
-        fn from(e: io::Error) -> Self {
-            Self::IOError(e)
-        }
-    }
-
-    impl From<GccError> for McsError {
-        fn from(e: GccError) -> Self {
-            Self::GccError(e)
-        }
-    }
-
-    impl From<PduError> for McsError {
-        fn from(e: PduError) -> Self {
-            Self::Pdu(e)
-        }
-    }
-
-    impl From<McsError> for io::Error {
-        fn from(e: McsError) -> io::Error {
-            io::Error::other(format!("MCS Connection Sequence error: {e}"))
         }
     }
 }

--- a/crates/ironrdp-pdu/src/rdp/capability_sets/mod.rs
+++ b/crates/ironrdp-pdu/src/rdp/capability_sets/mod.rs
@@ -1,6 +1,3 @@
-use core::fmt;
-use std::io;
-
 use ironrdp_core::{
     Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, cast_length, decode, ensure_fixed_part_size,
     ensure_size, invalid_field_err, unsupported_value_err, write_padding,
@@ -8,7 +5,7 @@ use ironrdp_core::{
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive as _;
 
-use crate::{PduError, utils};
+use crate::utils;
 
 mod bitmap;
 mod bitmap_cache;
@@ -603,125 +600,5 @@ impl CapabilitySetType {
     )]
     fn as_u16(self) -> u16 {
         self as u16
-    }
-}
-
-#[derive(Debug)]
-pub enum CapabilitySetsError {
-    IOError(io::Error),
-    Utf8Error(std::string::FromUtf8Error),
-    InvalidType,
-    InvalidCompressionFlag,
-    InvalidMultipleRectSupport,
-    InvalidProtocolVersion,
-    InvalidCompressionTypes,
-    InvalidUpdateCapFlag,
-    InvalidRemoteUnshareFlag,
-    InvalidCompressionLevel,
-    InvalidBrushSupportLevel,
-    InvalidGlyphSupportLevel,
-    InvalidRfxICapVersion,
-    InvalidRfxICapTileSize,
-    InvalidRfxICapColorConvBits,
-    InvalidRfxICapTransformBits,
-    InvalidRfxICapEntropyBits,
-    InvalidRfxCapsetBlockType,
-    InvalidRfxCapsetType,
-    InvalidRfxCapsBlockType,
-    InvalidRfxCapsBockLength,
-    InvalidRfxCapsNumCapsets,
-    InvalidCodecProperty,
-    InvalidCodecID,
-    InvalidChunkSize,
-    InvalidPropertyLength,
-    InvalidLength,
-    Pdu(PduError),
-}
-
-impl fmt::Display for CapabilitySetsError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::IOError(_) => f.write_str("IO error"),
-            Self::Utf8Error(_) => f.write_str("UTF-8 error"),
-            Self::InvalidType => f.write_str("invalid type field"),
-            Self::InvalidCompressionFlag => f.write_str("invalid bitmap compression field"),
-            Self::InvalidMultipleRectSupport => f.write_str("invalid multiple rectangle support field"),
-            Self::InvalidProtocolVersion => f.write_str("invalid protocol version field"),
-            Self::InvalidCompressionTypes => f.write_str("invalid compression types field"),
-            Self::InvalidUpdateCapFlag => f.write_str("invalid update capability flags field"),
-            Self::InvalidRemoteUnshareFlag => f.write_str("invalid remote unshare flag field"),
-            Self::InvalidCompressionLevel => f.write_str("invalid compression level field"),
-            Self::InvalidBrushSupportLevel => f.write_str("invalid brush support level field"),
-            Self::InvalidGlyphSupportLevel => f.write_str("invalid glyph support level field"),
-            Self::InvalidRfxICapVersion => f.write_str("invalid RemoteFX capability version"),
-            Self::InvalidRfxICapTileSize => f.write_str("invalid RemoteFX capability tile size"),
-            Self::InvalidRfxICapColorConvBits => f.write_str("invalid RemoteFXICap color conversion bits"),
-            Self::InvalidRfxICapTransformBits => f.write_str("invalid RemoteFXICap transform bits"),
-            Self::InvalidRfxICapEntropyBits => f.write_str("invalid RemoteFXICap entropy bits field"),
-            Self::InvalidRfxCapsetBlockType => f.write_str("invalid RemoteFX capability set block type"),
-            Self::InvalidRfxCapsetType => f.write_str("invalid RemoteFX capability set type"),
-            Self::InvalidRfxCapsBlockType => f.write_str("invalid RemoteFX capabilities block type"),
-            Self::InvalidRfxCapsBockLength => f.write_str("invalid RemoteFX capabilities block length"),
-            Self::InvalidRfxCapsNumCapsets => f.write_str("invalid number of capability sets in RemoteFX capabilities"),
-            Self::InvalidCodecProperty => f.write_str("invalid codec property field"),
-            Self::InvalidCodecID => f.write_str("invalid codec ID"),
-            Self::InvalidChunkSize => f.write_str("invalid channel chunk size field"),
-            Self::InvalidPropertyLength => f.write_str("invalid codec property length for the current property ID"),
-            Self::InvalidLength => f.write_str("invalid data length"),
-            Self::Pdu(e) => write!(f, "PDU error: {e}"),
-        }
-    }
-}
-
-impl core::error::Error for CapabilitySetsError {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match self {
-            Self::IOError(e) => Some(e),
-            Self::Utf8Error(e) => Some(e),
-            Self::InvalidType
-            | Self::InvalidCompressionFlag
-            | Self::InvalidMultipleRectSupport
-            | Self::InvalidProtocolVersion
-            | Self::InvalidCompressionTypes
-            | Self::InvalidUpdateCapFlag
-            | Self::InvalidRemoteUnshareFlag
-            | Self::InvalidCompressionLevel
-            | Self::InvalidBrushSupportLevel
-            | Self::InvalidGlyphSupportLevel
-            | Self::InvalidRfxICapVersion
-            | Self::InvalidRfxICapTileSize
-            | Self::InvalidRfxICapColorConvBits
-            | Self::InvalidRfxICapTransformBits
-            | Self::InvalidRfxICapEntropyBits
-            | Self::InvalidRfxCapsetBlockType
-            | Self::InvalidRfxCapsetType
-            | Self::InvalidRfxCapsBlockType
-            | Self::InvalidRfxCapsBockLength
-            | Self::InvalidRfxCapsNumCapsets
-            | Self::InvalidCodecProperty
-            | Self::InvalidCodecID
-            | Self::InvalidChunkSize
-            | Self::InvalidPropertyLength
-            | Self::InvalidLength
-            | Self::Pdu(_) => None,
-        }
-    }
-}
-
-impl From<io::Error> for CapabilitySetsError {
-    fn from(e: io::Error) -> Self {
-        Self::IOError(e)
-    }
-}
-
-impl From<std::string::FromUtf8Error> for CapabilitySetsError {
-    fn from(e: std::string::FromUtf8Error) -> Self {
-        Self::Utf8Error(e)
-    }
-}
-
-impl From<PduError> for CapabilitySetsError {
-    fn from(e: PduError) -> Self {
-        Self::Pdu(e)
     }
 }

--- a/crates/ironrdp-pdu/src/rdp/client_info.rs
+++ b/crates/ironrdp-pdu/src/rdp/client_info.rs
@@ -1,5 +1,4 @@
 use core::fmt;
-use std::io;
 
 use bitflags::bitflags;
 use ironrdp_core::{
@@ -9,8 +8,8 @@ use ironrdp_core::{
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive as _;
 
+use crate::utils;
 use crate::utils::CharacterSet;
-use crate::{PduError, utils};
 
 const RECONNECT_COOKIE_LEN: usize = 28;
 const TIMEZONE_INFO_NAME_LEN: usize = 64;
@@ -753,63 +752,6 @@ impl CompressionType {
     )]
     pub fn as_u8(self) -> u8 {
         self as u8
-    }
-}
-
-#[derive(Debug)]
-pub enum ClientInfoError {
-    IOError(io::Error),
-    Utf8Error(std::string::FromUtf8Error),
-    InvalidAddressFamily,
-    InvalidClientInfoFlags,
-    InvalidPerformanceFlags,
-    InvalidReconnectCookie,
-    Pdu(PduError),
-}
-
-impl fmt::Display for ClientInfoError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::IOError(_) => f.write_str("IO error"),
-            Self::Utf8Error(_) => f.write_str("UTF-8 error"),
-            Self::InvalidAddressFamily => f.write_str("invalid address family field"),
-            Self::InvalidClientInfoFlags => f.write_str("invalid flags field"),
-            Self::InvalidPerformanceFlags => f.write_str("invalid performance flags field"),
-            Self::InvalidReconnectCookie => f.write_str("invalid reconnect cookie field"),
-            Self::Pdu(e) => write!(f, "PDU error: {e}"),
-        }
-    }
-}
-
-impl core::error::Error for ClientInfoError {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match self {
-            Self::IOError(e) => Some(e),
-            Self::Utf8Error(e) => Some(e),
-            Self::InvalidAddressFamily
-            | Self::InvalidClientInfoFlags
-            | Self::InvalidPerformanceFlags
-            | Self::InvalidReconnectCookie
-            | Self::Pdu(_) => None,
-        }
-    }
-}
-
-impl From<io::Error> for ClientInfoError {
-    fn from(e: io::Error) -> Self {
-        Self::IOError(e)
-    }
-}
-
-impl From<std::string::FromUtf8Error> for ClientInfoError {
-    fn from(e: std::string::FromUtf8Error) -> Self {
-        Self::Utf8Error(e)
-    }
-}
-
-impl From<PduError> for ClientInfoError {
-    fn from(e: PduError) -> Self {
-        Self::Pdu(e)
     }
 }
 

--- a/crates/ironrdp-pdu/src/rdp/mod.rs
+++ b/crates/ironrdp-pdu/src/rdp/mod.rs
@@ -1,16 +1,9 @@
-use core::fmt;
-use std::io;
-
 use ironrdp_core::{
     Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, ensure_fixed_part_size, invalid_field_err,
 };
 
-use crate::PduError;
-use crate::input::InputEventError;
-use crate::rdp::capability_sets::CapabilitySetsError;
-use crate::rdp::client_info::{ClientInfo, ClientInfoError};
-use crate::rdp::headers::{BasicSecurityHeader, BasicSecurityHeaderFlags, ShareControlPduType, ShareDataPduType};
-use crate::rdp::server_license::ServerLicenseError;
+use crate::rdp::client_info::ClientInfo;
+use crate::rdp::headers::{BasicSecurityHeader, BasicSecurityHeaderFlags};
 
 pub mod autodetect;
 pub mod capability_sets;
@@ -71,113 +64,5 @@ impl<'de> Decode<'de> for ClientInfoPdu {
             security_header,
             client_info,
         })
-    }
-}
-
-#[derive(Debug)]
-pub enum RdpError {
-    IOError(io::Error),
-    ClientInfoError(ClientInfoError),
-    ServerLicenseError(ServerLicenseError),
-    CapabilitySetsError(CapabilitySetsError),
-    InvalidSecurityHeader,
-    InvalidShareControlHeader(String),
-    InvalidShareDataHeader(String),
-    InvalidPdu(String),
-    UnexpectedShareControlPdu(ShareControlPduType),
-    UnexpectedShareDataPdu(ShareDataPduType),
-    SaveSessionInfoError(session_info::SessionError),
-    InputEventError(InputEventError),
-    NotEnoughBytes,
-    Pdu(PduError),
-}
-
-impl fmt::Display for RdpError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::IOError(_) => f.write_str("IO error"),
-            Self::ClientInfoError(_) => f.write_str("client Info PDU error"),
-            Self::ServerLicenseError(_) => f.write_str("server License PDU error"),
-            Self::CapabilitySetsError(_) => f.write_str("capability sets error"),
-            Self::InvalidSecurityHeader => f.write_str("invalid RDP security header"),
-            Self::InvalidShareControlHeader(s) => write!(f, "invalid RDP Share Control Header: {s}"),
-            Self::InvalidShareDataHeader(s) => write!(f, "invalid RDP Share Data Header: {s}"),
-            Self::InvalidPdu(_) => f.write_str("invalid RDP Connection Sequence PDU"),
-            Self::UnexpectedShareControlPdu(ty) => write!(f, "unexpected RDP Share Control Header PDU type: {ty:?}"),
-            Self::UnexpectedShareDataPdu(ty) => write!(f, "unexpected RDP Share Data Header PDU type: {ty:?}"),
-            Self::SaveSessionInfoError(_) => f.write_str("save session info PDU error"),
-            Self::InputEventError(_) => f.write_str("input event PDU error"),
-            Self::NotEnoughBytes => f.write_str("not enough bytes"),
-            Self::Pdu(e) => write!(f, "PDU error: {e}"),
-        }
-    }
-}
-
-impl core::error::Error for RdpError {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match self {
-            Self::IOError(e) => Some(e),
-            Self::ClientInfoError(e) => Some(e),
-            Self::ServerLicenseError(e) => Some(e),
-            Self::CapabilitySetsError(e) => Some(e),
-            Self::SaveSessionInfoError(e) => Some(e),
-            Self::InputEventError(e) => Some(e),
-            Self::InvalidSecurityHeader
-            | Self::InvalidShareControlHeader(_)
-            | Self::InvalidShareDataHeader(_)
-            | Self::InvalidPdu(_)
-            | Self::UnexpectedShareControlPdu(_)
-            | Self::UnexpectedShareDataPdu(_)
-            | Self::NotEnoughBytes
-            | Self::Pdu(_) => None,
-        }
-    }
-}
-
-impl From<io::Error> for RdpError {
-    fn from(e: io::Error) -> Self {
-        Self::IOError(e)
-    }
-}
-
-impl From<ClientInfoError> for RdpError {
-    fn from(e: ClientInfoError) -> Self {
-        Self::ClientInfoError(e)
-    }
-}
-
-impl From<ServerLicenseError> for RdpError {
-    fn from(e: ServerLicenseError) -> Self {
-        Self::ServerLicenseError(e)
-    }
-}
-
-impl From<CapabilitySetsError> for RdpError {
-    fn from(e: CapabilitySetsError) -> Self {
-        Self::CapabilitySetsError(e)
-    }
-}
-
-impl From<session_info::SessionError> for RdpError {
-    fn from(e: session_info::SessionError) -> Self {
-        Self::SaveSessionInfoError(e)
-    }
-}
-
-impl From<InputEventError> for RdpError {
-    fn from(e: InputEventError) -> Self {
-        Self::InputEventError(e)
-    }
-}
-
-impl From<PduError> for RdpError {
-    fn from(e: PduError) -> Self {
-        Self::Pdu(e)
-    }
-}
-
-impl From<RdpError> for io::Error {
-    fn from(e: RdpError) -> io::Error {
-        io::Error::other(format!("RDP Connection Sequence error: {e}"))
     }
 }

--- a/crates/ironrdp-pdu/src/rdp/server_license/mod.rs
+++ b/crates/ironrdp-pdu/src/rdp/server_license/mod.rs
@@ -199,6 +199,8 @@ impl BlobType {
     pub const CLIENT_MACHINE_NAME_BLOB: Self = Self(0x10);
 }
 
+// FIXME: licensing logic and any code that is not purely about PDU
+// encoding/decoding concerns should be moved out of ironrdp-pdu.
 #[derive(Debug)]
 pub enum ServerLicenseError {
     IOError(io::Error),

--- a/crates/ironrdp-pdu/src/rdp/session_info/mod.rs
+++ b/crates/ironrdp-pdu/src/rdp/session_info/mod.rs
@@ -1,14 +1,9 @@
-use core::fmt;
-use std::io;
-
 use ironrdp_core::{
     Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, ensure_fixed_part_size, ensure_size,
     invalid_field_err, read_padding, write_padding,
 };
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive as _;
-
-use crate::PduError;
 
 #[cfg(test)]
 mod tests;
@@ -125,67 +120,4 @@ pub enum InfoData {
     LogonInfoV2(LogonInfoVersion2),
     PlainNotify,
     LogonExtended(LogonInfoExtended),
-}
-
-#[derive(Debug)]
-pub enum SessionError {
-    IOError(io::Error),
-    InvalidSaveSessionInfoType,
-    InvalidDomainNameSize,
-    InvalidUserNameSize,
-    InvalidLogonVersion2,
-    InvalidLogonVersion2Size,
-    InvalidAutoReconnectPacketSize,
-    InvalidAutoReconnectVersion,
-    InvalidLogonErrorType,
-    InvalidLogonErrorData,
-    Pdu(PduError),
-}
-
-impl fmt::Display for SessionError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::IOError(_) => f.write_str("IO error"),
-            Self::InvalidSaveSessionInfoType => f.write_str("invalid save session info type value"),
-            Self::InvalidDomainNameSize => f.write_str("invalid domain name size value"),
-            Self::InvalidUserNameSize => f.write_str("invalid user name size value"),
-            Self::InvalidLogonVersion2 => f.write_str("invalid logon version value"),
-            Self::InvalidLogonVersion2Size => f.write_str("invalid logon info version2 size value"),
-            Self::InvalidAutoReconnectPacketSize => f.write_str("invalid server auto-reconnect packet size value"),
-            Self::InvalidAutoReconnectVersion => f.write_str("invalid server auto-reconnect version"),
-            Self::InvalidLogonErrorType => f.write_str("invalid logon error type value"),
-            Self::InvalidLogonErrorData => f.write_str("invalid logon error data value"),
-            Self::Pdu(e) => write!(f, "PDU error: {e}"),
-        }
-    }
-}
-
-impl core::error::Error for SessionError {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match self {
-            Self::IOError(e) => Some(e),
-            Self::InvalidSaveSessionInfoType
-            | Self::InvalidDomainNameSize
-            | Self::InvalidUserNameSize
-            | Self::InvalidLogonVersion2
-            | Self::InvalidLogonVersion2Size
-            | Self::InvalidAutoReconnectPacketSize
-            | Self::InvalidAutoReconnectVersion
-            | Self::InvalidLogonErrorType
-            | Self::InvalidLogonErrorData
-            | Self::Pdu(_) => None,
-        }
-    }
-}
-
-impl From<io::Error> for SessionError {
-    fn from(e: io::Error) -> Self {
-        Self::IOError(e)
-    }
-}
-
-impl From<PduError> for SessionError {
-    fn from(e: PduError) -> Self {
-        Self::Pdu(e)
-    }
 }

--- a/crates/ironrdp-pdu/src/rdp/vc/mod.rs
+++ b/crates/ironrdp-pdu/src/rdp/vc/mod.rs
@@ -3,13 +3,8 @@ pub mod dvc;
 #[cfg(test)]
 mod tests;
 
-use core::fmt;
-use std::{io, str};
-
 use bitflags::bitflags;
 use ironrdp_core::{Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, ensure_fixed_part_size};
-
-use crate::PduError;
 
 const CHANNEL_PDU_HEADER_SIZE: usize = 8;
 
@@ -76,85 +71,5 @@ bitflags! {
         const COMPRESSION_TYPE_MASK = 0x000F_0000;
 
         const _ = !0;
-    }
-}
-
-#[derive(Debug)]
-pub enum ChannelError {
-    IOError(io::Error),
-    FromUtf8Error(std::string::FromUtf8Error),
-    InvalidChannelPduHeader,
-    InvalidChannelTotalDataLength,
-    InvalidDvcPduType,
-    InvalidDVChannelIdLength,
-    InvalidDvcDataLength,
-    InvalidDvcCapabilitiesVersion,
-    InvalidDvcMessageSize,
-    InvalidDvcTotalMessageSize { actual: usize, expected: usize },
-    Pdu(PduError),
-}
-
-impl fmt::Display for ChannelError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::IOError(_) => f.write_str("IO error"),
-            Self::FromUtf8Error(_) => f.write_str("from UTF-8 error"),
-            Self::InvalidChannelPduHeader => f.write_str("invalid channel PDU header"),
-            Self::InvalidChannelTotalDataLength => f.write_str("invalid channel total data length"),
-            Self::InvalidDvcPduType => f.write_str("invalid DVC PDU type"),
-            Self::InvalidDVChannelIdLength => f.write_str("invalid DVC id length value"),
-            Self::InvalidDvcDataLength => f.write_str("invalid DVC data length value"),
-            Self::InvalidDvcCapabilitiesVersion => f.write_str("invalid DVC capabilities version"),
-            Self::InvalidDvcMessageSize => f.write_str("invalid DVC message size"),
-            Self::InvalidDvcTotalMessageSize { actual, expected } => {
-                write!(
-                    f,
-                    "invalid DVC total message size: actual ({actual}) > expected ({expected})"
-                )
-            }
-            Self::Pdu(e) => write!(f, "PDU error: {e}"),
-        }
-    }
-}
-
-impl core::error::Error for ChannelError {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match self {
-            Self::IOError(e) => Some(e),
-            Self::FromUtf8Error(e) => Some(e),
-            Self::InvalidChannelPduHeader
-            | Self::InvalidChannelTotalDataLength
-            | Self::InvalidDvcPduType
-            | Self::InvalidDVChannelIdLength
-            | Self::InvalidDvcDataLength
-            | Self::InvalidDvcCapabilitiesVersion
-            | Self::InvalidDvcMessageSize
-            | Self::InvalidDvcTotalMessageSize { .. }
-            | Self::Pdu(_) => None,
-        }
-    }
-}
-
-impl From<io::Error> for ChannelError {
-    fn from(e: io::Error) -> Self {
-        Self::IOError(e)
-    }
-}
-
-impl From<std::string::FromUtf8Error> for ChannelError {
-    fn from(e: std::string::FromUtf8Error) -> Self {
-        Self::FromUtf8Error(e)
-    }
-}
-
-impl From<PduError> for ChannelError {
-    fn from(e: PduError) -> Self {
-        Self::Pdu(e)
-    }
-}
-
-impl From<ChannelError> for io::Error {
-    fn from(e: ChannelError) -> io::Error {
-        io::Error::other(format!("Virtual channel error: {e}"))
     }
 }


### PR DESCRIPTION
Remove GccError, McsError, RdpError, SecurityDataError, ClusterDataError, NetworkDataError, CoreDataError, InputEventError, ClientInfoError, CapabilitySetsError, SessionError, and ChannelError. All encode/decode functions had already been migrated to use DecodeResult/EncodeResult from ironrdp-core, leaving these error types as dead code.