### PR TITLE
refactor(core): replace wildcard re-exports with explicit lists

### DIFF
--- a/crates/ironrdp-core/src/lib.rs
+++ b/crates/ironrdp-core/src/lib.rs
@@ -20,14 +20,29 @@ mod padding;
 #[cfg(feature = "alloc")]
 mod write_buf;
 
-// Flat API hierarchy of common traits and types
+// Flat API hierarchy of common traits and types.
+//
+// Each `pub use` lists its exports explicitly so that adding a new `pub`
+// item to a module is a conscious public-API commitment rather than
+// auto-public via a wildcard.
 
-pub use self::as_any::*;
-pub use self::cursor::*;
-pub use self::decode::*;
-pub use self::encode::*;
-pub use self::error::*;
-pub use self::into_owned::*;
-pub use self::padding::*;
+pub use self::as_any::AsAny;
+pub use self::cursor::{NotEnoughBytesError, ReadCursor, WriteCursor};
+pub use self::decode::{
+    Decode, DecodeError, DecodeErrorKind, DecodeOwned, DecodeResult, decode, decode_cursor, decode_owned,
+    decode_owned_cursor,
+};
 #[cfg(feature = "alloc")]
-pub use self::write_buf::*;
+pub use self::encode::encode_buf;
+#[cfg(any(feature = "alloc", test))]
+pub use self::encode::encode_vec;
+pub use self::encode::{Encode, EncodeError, EncodeErrorKind, EncodeResult, encode, encode_cursor, name, size};
+pub use self::error::{
+    InvalidFieldErr, NotEnoughBytesErr, OtherErr, UnexpectedMessageTypeErr, UnsupportedValueErr, UnsupportedVersionErr,
+    WithSource, invalid_field_err, invalid_field_err_with_source, not_enough_bytes_err, other_err,
+    other_err_with_source, unexpected_message_type_err, unsupported_value_err, unsupported_version_err,
+};
+pub use self::into_owned::IntoOwned;
+pub use self::padding::{read_padding, write_padding};
+#[cfg(feature = "alloc")]
+pub use self::write_buf::WriteBuf;


### PR DESCRIPTION
## Summary

`crates/ironrdp-core/src/lib.rs` currently re-exports each of its nine internal modules via `pub use self::foo::*`. This PR converts each wildcard to an explicit list of items.

## Why

`ironrdp-core` is the foundational Core Tier crate. Per `ARCHITECTURE.md`, it is intended to be small and contain only "low-context building blocks" so other crates can depend on it without compile-time cost. The wildcards work against that intent: every new `pub fn`, `pub struct`, or `pub trait` added to any of the eight internal modules is automatically part of `ironrdp-core`'s public API surface, with no review trigger asking whether it should be.

Explicit lists make adding a new `pub` item a conscious `lib.rs` edit. The public commitment becomes visible at PR-review time.

## What changes

- `pub use self::as_any::*` becomes `pub use self::as_any::AsAny`
- `pub use self::cursor::*` becomes an explicit list of three structs
- `pub use self::decode::*` becomes an explicit list of nine items (free fns + traits + types)
- `pub use self::encode::*` becomes an explicit list of eight items, plus cfg-gated `encode_buf` (alloc) and `encode_vec` (alloc or test)
- `pub use self::error::*` becomes an explicit list of fifteen items (constructor fns + shape traits)
- `pub use self::into_owned::*` becomes `pub use self::into_owned::IntoOwned`
- `pub use self::padding::*` becomes `pub use self::padding::{read_padding, write_padding}`
- `#[cfg(feature = \"alloc\")] pub use self::write_buf::*` becomes `#[cfg(feature = \"alloc\")] pub use self::write_buf::WriteBuf`

Feature-flag gates preserved exactly.

## Behavioural change

None. Every item exported by the wildcards is still exported by name.

## Diff

1 file, +24 / -9.

## Verification

\`cargo xtask check fmt | lints | locks | typos | tests\` all pass. \`cargo check -p ironrdp-core\` builds clean under \`--all-features\`, \`--no-default-features\` (no_std), and \`--no-default-features --features alloc\`. Full workspace \`cargo check --workspace --features helper,__bench\` builds.