### PR TITLE
feat(fuzz): add egfx PDU decoders to pdu_decode oracle + fix two surfaced bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2643,6 +2643,7 @@ dependencies = [
  "ironrdp-cliprdr-format",
  "ironrdp-core",
  "ironrdp-displaycontrol",
+ "ironrdp-egfx",
  "ironrdp-graphics",
  "ironrdp-pdu",
  "ironrdp-rdpdr",

--- a/crates/ironrdp-egfx/src/pdu/avc.rs
+++ b/crates/ironrdp-egfx/src/pdu/avc.rs
@@ -117,8 +117,15 @@ impl<'de> Decode<'de> for Avc420BitmapStream<'de> {
         let num_regions = src.read_u32();
         #[expect(clippy::as_conversions, reason = "num_regions bounded by practical limits")]
         let num_regions_usize = num_regions as usize;
-        let mut rectangles = Vec::with_capacity(num_regions_usize);
-        let mut quant_qual_vals = Vec::with_capacity(num_regions_usize);
+        // Cap pre-allocation against the remaining buffer to avoid OOM from a
+        // malicious num_regions: each region needs at least one rectangle
+        // (8 bytes) plus one QuantQuality entry (2 bytes). The actual read
+        // loop will fail with NotEnoughBytes if num_regions is bogus.
+        let per_region = InclusiveRectangle::FIXED_PART_SIZE + QuantQuality::FIXED_PART_SIZE;
+        let max_possible = src.len() / per_region;
+        let bounded_capacity = num_regions_usize.min(max_possible);
+        let mut rectangles = Vec::with_capacity(bounded_capacity);
+        let mut quant_qual_vals = Vec::with_capacity(bounded_capacity);
         for _ in 0..num_regions {
             rectangles.push(InclusiveRectangle::decode(src)?);
         }

--- a/crates/ironrdp-egfx/src/pdu/avc.rs
+++ b/crates/ironrdp-egfx/src/pdu/avc.rs
@@ -215,7 +215,13 @@ impl<'de> Decode<'de> for Avc444BitmapStream<'de> {
             })
         } else {
             #[expect(clippy::as_conversions, reason = "30-bit value fits in usize")]
-            let (mut stream1, mut stream2) = src.split_at(stream_len as usize);
+            let stream_len = stream_len as usize;
+            // Validate that the declared stream length fits in the remaining
+            // buffer; src.split_at panics on overflow, so a malformed
+            // streamLen field would otherwise crash the decoder. Surfaced
+            // by the pdu_decode fuzz target.
+            ensure_size!(ctx: Self::NAME, in: src, size: stream_len);
+            let (mut stream1, mut stream2) = src.split_at(stream_len);
             let stream1 = Avc420BitmapStream::decode(&mut stream1)?;
             let stream2 = if encoding == Encoding::LUMA_AND_CHROMA {
                 Some(Avc420BitmapStream::decode(&mut stream2)?)

--- a/crates/ironrdp-fuzzing/Cargo.toml
+++ b/crates/ironrdp-fuzzing/Cargo.toml
@@ -19,6 +19,7 @@ ironrdp-rdpdr.path = "../ironrdp-rdpdr"
 ironrdp-rdpsnd.path = "../ironrdp-rdpsnd"
 ironrdp-cliprdr-format.path = "../ironrdp-cliprdr-format"
 ironrdp-displaycontrol.path = "../ironrdp-displaycontrol"
+ironrdp-egfx.path = "../ironrdp-egfx"
 ironrdp-svc.path = "../ironrdp-svc"
 
 [lints]

--- a/crates/ironrdp-fuzzing/src/oracles/mod.rs
+++ b/crates/ironrdp-fuzzing/src/oracles/mod.rs
@@ -14,6 +14,10 @@ use crate::generators::BitmapInput;
 
 pub fn pdu_decode(data: &[u8]) {
     use ironrdp_core::decode;
+    use ironrdp_egfx::pdu::{
+        Avc420BitmapStream, Avc444BitmapStream, CacheToSurfacePdu, CapabilitySet as EgfxCapabilitySet, Color, GfxPdu,
+        Point, QuantQuality,
+    };
     use ironrdp_pdu::mcs::{ConnectInitial, ConnectResponse, McsMessage};
     use ironrdp_pdu::nego::{ConnectionConfirm, ConnectionRequest};
     use ironrdp_pdu::rdp::{ClientInfoPdu, capability_sets, headers, server_error_info, server_license, vc};
@@ -80,6 +84,15 @@ pub fn pdu_decode(data: &[u8]) {
 
     let _ = decode::<ironrdp_rdpsnd::pdu::ServerAudioOutputPdu<'_>>(data);
     let _ = decode::<ironrdp_rdpsnd::pdu::ClientAudioOutputPdu>(data);
+
+    let _ = decode::<GfxPdu>(data);
+    let _ = decode::<CacheToSurfacePdu>(data);
+    let _ = decode::<EgfxCapabilitySet>(data);
+    let _ = decode::<Avc420BitmapStream<'_>>(data);
+    let _ = decode::<Avc444BitmapStream<'_>>(data);
+    let _ = decode::<QuantQuality>(data);
+    let _ = decode::<Point>(data);
+    let _ = decode::<Color>(data);
 }
 
 pub fn rle_decompress_bitmap(input: BitmapInput<'_>) {

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -334,6 +334,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ironrdp-egfx"
+version = "0.1.0"
+dependencies = [
+ "bit_field",
+ "bitflags",
+ "ironrdp-core",
+ "ironrdp-dvc",
+ "ironrdp-graphics",
+ "ironrdp-pdu",
+ "tracing",
+]
+
+[[package]]
 name = "ironrdp-error"
 version = "0.1.3"
 
@@ -354,6 +367,7 @@ dependencies = [
  "ironrdp-cliprdr-format",
  "ironrdp-core",
  "ironrdp-displaycontrol",
+ "ironrdp-egfx",
  "ironrdp-graphics",
  "ironrdp-pdu",
  "ironrdp-rdpdr",


### PR DESCRIPTION
## Summary

Extends the existing `pdu_decode` oracle in `ironrdp-fuzzing::oracles` with EGFX coverage, satisfying the Core Tier "must be fuzzed" invariant (per `ARCHITECTURE.md`) for the graphics-pipeline DVC parsing. Two pre-existing bugs in `ironrdp-egfx`'s `Avc444BitmapStream` / `Avc420BitmapStream` decoders that the new coverage immediately surfaced are fixed in the same series.

## What the oracle exercises

The EGFX decode list added to `pdu_decode` runs the input through:

- `GfxPdu` (umbrella enum covering all 23 EGFX message types — primary entry point)
- `CacheToSurfacePdu` (sole sub-PDU with an independent `Decode` impl)
- `EgfxCapabilitySet` (aliased to disambiguate against `capability_sets::CapabilitySet` from `ironrdp-pdu`)
- `Avc420BitmapStream<'_>` and `Avc444BitmapStream<'_>`
- `QuantQuality`, `Point`, `Color`

## Shape

Folded into the existing `pdu_decode` oracle in `c5211e46` per your suggestion on the original filing ("I think it's fine to add this directly to `pdu_decode`, so we don't have an extra target for essentially the same logic"). No separate `egfx_pdu_decoding.rs` target / `[[bin]]` entry; the EGFX decoders sit alongside the existing PDU decoders in the same oracle and share the corpus.

## Bug fixes surfaced by the new coverage

Both pre-existing in `ironrdp-egfx`; surfaced by the EGFX decode additions before this PR could merge cleanly.

- **`f96ba08e fix(egfx): bound stream_len before split_at in Avc444BitmapStream`**: `Avc444BitmapStream::decode` read a 30-bit `streamLen` field and called `src.split_at(stream_len as usize)` without bounds-checking. `ReadCursor::split_at` panics on offset overflow. Fixed with `ensure_size!(ctx: Self::NAME, in: src, size: stream_len)` before the split, so a malformed `streamLen` returns `NotEnoughBytes` instead of panicking.
- **`f741fb26 fix(egfx): cap Avc420BitmapStream pre-allocation against remaining bytes`**: `Avc420BitmapStream::decode` read a u32 `num_regions` and called `Vec::with_capacity(num_regions as usize)` twice without bounding. ASan tripped on a ~33 GB allocation for `num_regions = 0xF7_00_AC_7E`. Fixed by capping `with_capacity` at `src.len() / (InclusiveRectangle::FIXED_PART_SIZE + QuantQuality::FIXED_PART_SIZE)`, matching the bounded-pre-allocation pattern in `cliprdr/format_data/file_list.rs`. The actual decode loop is unchanged.

## Verification

- `cargo xtask check fmt` ✓
- `cargo xtask check lints` ✓
- `cargo xtask check locks` ✓
- `cargo xtask check typos` ✓
- `cargo xtask check tests` ✓
- `cargo check --manifest-path fuzz/Cargo.toml` builds the `pdu_decoding` target cleanly
- CI on `f741fb26`: all 9 jobs green including Fuzzing 5m21s (the same 5-minute fuzz budget that previously surfaced both bugs now passes clean)

Refs #1120.
