### PR TITLE
fix(error,session)!: remove Error::into_other_kind

### DIFF
--- a/crates/ironrdp-error/src/lib.rs
+++ b/crates/ironrdp-error/src/lib.rs
@@ -106,21 +106,6 @@ impl<Kind> Error<Kind> {
         }
     }
 
-    pub fn into_other_kind<OtherKind>(self) -> Error<OtherKind>
-    where
-        Kind: Into<OtherKind>,
-    {
-        Error {
-            kind: self.kind.into(),
-            #[cfg(feature = "alloc")]
-            meta: self.meta,
-            #[cfg(not(feature = "alloc"))]
-            context: self.context,
-            #[cfg(not(feature = "alloc"))]
-            location: self.location,
-        }
-    }
-
     pub fn kind(&self) -> &Kind {
         &self.kind
     }

--- a/crates/ironrdp-session/src/legacy.rs
+++ b/crates/ironrdp-session/src/legacy.rs
@@ -1,18 +1,5 @@
-use crate::SessionError;
-
-// FIXME: code should be fixed so that we never need this conversion
-// For that, some code from this ironrdp_session::legacy and ironrdp_connector::legacy modules should be moved to ironrdp_pdu itself
-impl From<ironrdp_connector::ConnectorErrorKind> for crate::SessionErrorKind {
-    fn from(value: ironrdp_connector::ConnectorErrorKind) -> Self {
-        match value {
-            ironrdp_connector::ConnectorErrorKind::Custom | ironrdp_connector::ConnectorErrorKind::Credssp(_) => {
-                crate::SessionErrorKind::Custom
-            }
-            _ => crate::SessionErrorKind::General,
-        }
-    }
-}
+use crate::{SessionError, SessionErrorExt as _};
 
 pub(crate) fn map_error(error: ironrdp_connector::ConnectorError) -> SessionError {
-    error.into_other_kind()
+    SessionError::custom("connector error", error)
 }


### PR DESCRIPTION
## Summary

Removes `Error::into_other_kind` from `ironrdp-error` and its sole in-tree caller's adjacent dead code in `ironrdp-session::legacy`.

## Approach

- `ironrdp-error`: deletes `Error::into_other_kind` entirely. It was a generic kind-conversion shortcut with one workspace caller; not part of an API consumers were expected to use.
- `ironrdp-session/src/legacy.rs`: `map_error` now calls `SessionError::custom("connector error", error)`, wrapping the full `ConnectorError` as a typed source via `Error::with_source`. Consumers walking `core::error::Error::source()` reach the original kind, context, and location.
- `ironrdp-session/src/legacy.rs`: the `impl From<ironrdp_connector::ConnectorErrorKind> for crate::SessionErrorKind` block was the lossy collapse-to-`Custom`-or-`General` impl that `into_other_kind` required. With `into_other_kind` gone it has no callers and is removed too.

## Why

`into_other_kind`'s `Kind: Into<OtherKind>` bound is what forced the lossy `From<ConnectorErrorKind>` impl in `legacy.rs`. The wrap-as-source pattern (`SessionErrorExt::custom`, used elsewhere in the workspace) preserves the full inner error through the source chain without any kind-collapsing impl.

## Breaking change

Removes two `pub` items:

- `ironrdp_error::Error::<Kind>::into_other_kind`
- `impl From<ironrdp_connector::ConnectorErrorKind> for ironrdp_session::SessionErrorKind`

The `!` in the commit subject reflects this.

## Provenance and tooling

Reshaped from the original `deprecate` framing per CBenoit's review at #1278 (review comment at `crates/ironrdp-session/src/legacy.rs:8`). Signed-off-by and Assisted-by trailers on the commit per the LLM-use disclosure pattern.