### PR TITLE
fix(bulk): gate alloc-dependent modules behind the alloc feature

### DIFF
--- a/crates/ironrdp-bulk/src/lib.rs
+++ b/crates/ironrdp-bulk/src/lib.rs
@@ -57,13 +57,20 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-mod bitstream;
-mod bulk;
 mod error;
+
+#[cfg(feature = "alloc")]
+mod bitstream;
+#[cfg(feature = "alloc")]
+mod bulk;
+#[cfg(feature = "alloc")]
 mod mppc;
+#[cfg(feature = "alloc")]
 mod ncrush;
+#[cfg(feature = "alloc")]
 mod xcrush;
 
+#[cfg(feature = "alloc")]
 pub use self::bulk::BulkCompressor;
 pub use self::error::BulkError;
 


### PR DESCRIPTION
## Summary

Completes the no_std + alloc cascade plumbing that `ironrdp-bulk`'s
`[features]` table has advertised but the source did not implement.
Reported as Category A of the workspace feature-matrix scan in #1123
(https://github.com/Devolutions/IronRDP/issues/1123#issuecomment-4464512384).

## Approach

`ironrdp-bulk` declares the workspace's std/alloc cascade idiom in
`Cargo.toml`:

```toml
default = ["std"]
std = ["alloc"]
alloc = []
```

`lib.rs` carries `#![cfg_attr(not(feature = "std"), no_std)]` and
`#[cfg(feature = "alloc")] extern crate alloc;`, matching the idiom. But
the `bulk`, `mppc`, `ncrush`, and `xcrush` modules use `alloc::vec!`,
`Vec`, `Box`, and `&[u8]::to_vec()` unconditionally. With
`--no-default-features` neither `std` nor `alloc` is enabled, the `alloc`
crate is not linked, and nine `E0433`/`E0599` errors fire.

This PR gates those four modules — and the `BulkCompressor` re-export —
on `#[cfg(feature = "alloc")]`. The `bitstream` module follows: its only
consumers are the four compression modules, so gating it on `alloc` keeps
the dead-code lint quiet when alloc is off. `error::BulkError` stays
unconditional because it uses only `core::fmt` and `core::error::Error`
and has no alloc dependency.

## Behaviour

| Feature combo | Before | After |
|---|---|---|
| `default` (= `std`) | compiles | compiles, unchanged API |
| `--features std` | compiles | compiles, unchanged API |
| `--no-default-features --features alloc` | **failed** (`E0433`/`E0599`) | compiles, full API |
| `--no-default-features` | **failed** (`E0433`/`E0599`) | compiles, exposes `BulkError`, `CompressionType`, `flags` |

Users on `default`, `std`, or `--features alloc --no-default-features`
see no API change. The `--no-default-features` path — which the
`Cargo.toml` design implies but the source previously broke — now
exposes the alloc-free parts of the API (`BulkError`,
`CompressionType`, and the `flags` module).

## Alternatives considered

- **Make `alloc` unconditional** (drop the `alloc = []` feature). Would
  remove a feature from the public API, which is SemVer-breaking. The
  current approach preserves the existing feature surface.
- **Add `compile_error!`** when neither `std` nor `alloc` is enabled.
  Would clearly signal the requirement but still fail
  `cargo check --no-default-features`, leaving Category A of the
  feature-matrix scan unresolved.

## Verification

- `cargo check -p ironrdp-bulk` — green
- `cargo check -p ironrdp-bulk --features std` — green
- `cargo check -p ironrdp-bulk --no-default-features --features alloc` — green
- `cargo check -p ironrdp-bulk --no-default-features` — green
- `cargo xtask check fmt -v` — green
- `cargo xtask check lints -v` — green
- `cargo xtask check tests -v` — green
- `cargo xtask check typos -v` — green

## References

- #1123 Category A: https://github.com/Devolutions/IronRDP/issues/1123#issuecomment-4464512384