### PR TITLE
fix(str): import alloc::borrow::ToOwned in no_std + alloc builds

### DIFF
--- a/crates/ironrdp-str/src/prefixed.rs
+++ b/crates/ironrdp-str/src/prefixed.rs
@@ -6,6 +6,8 @@
 
 use alloc::borrow::Cow;
 #[cfg(not(feature = "std"))]
+use alloc::borrow::ToOwned;
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;

--- a/crates/ironrdp-str/src/unframed.rs
+++ b/crates/ironrdp-str/src/unframed.rs
@@ -7,6 +7,8 @@
 
 use alloc::borrow::Cow;
 #[cfg(not(feature = "std"))]
+use alloc::borrow::ToOwned;
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;


### PR DESCRIPTION
## Summary

Closes the no_std + alloc compile failure in `ironrdp-str` flagged as
Category A of the workspace feature-matrix scan in #1123
(https://github.com/Devolutions/IronRDP/issues/1123#issuecomment-4464512384).

## Approach

`ironrdp-str/src/prefixed.rs` and `ironrdp-str/src/unframed.rs` both
define `impl From<&str>` blocks that call `s.to_owned()` to lift the
borrowed string into an owned representation. `.to_owned()` is a method
from the `alloc::borrow::ToOwned` trait. In std builds the std prelude
brings `ToOwned` into scope automatically; the alloc prelude does not.
With `--no-default-features --features alloc` the call sites fail with
`E0599: no method named 'to_owned' found for reference '&str' in the
current scope`.

Adds:

```rust
#[cfg(not(feature = "std"))]
use alloc::borrow::ToOwned;
```

to both files, matching the existing pattern that gates the
`use alloc::{string::String, vec::Vec};` imports on the same cfg.
`lib.rs` already gates these modules behind `#[cfg(feature = "alloc")]`,
so `alloc` is guaranteed available wherever the import compiles.

## Verification

- `cargo check -p ironrdp-str` — green
- `cargo check -p ironrdp-str --features std` — green
- `cargo check -p ironrdp-str --no-default-features --features alloc` — green (was failing before)
- `cargo check -p ironrdp-str --no-default-features` — green
- `cargo xtask check fmt -v` — green
- `cargo xtask check lints -v` — green
- `cargo xtask check tests -v` — green
- `cargo xtask check typos -v` — green

## References

- #1123 Category A: https://github.com/Devolutions/IronRDP/issues/1123#issuecomment-4464512384