### PR TITLE
feat(server): accept connections with TLS terminated at a lower layer

### DIFF
--- a/crates/ironrdp-server/src/lib.rs
+++ b/crates/ironrdp-server/src/lib.rs
@@ -35,7 +35,7 @@ pub use helper::TlsIdentityCtx;
 pub use server::{
     ConnectionHandler, CredentialDecision, CredentialValidationError, CredentialValidator, Credentials,
     ExactMatchCredentialValidator, PostConnectionAction, RdpServer, RdpServerOptions, RdpServerSecurity, ServerEvent,
-    ServerEventSender,
+    ServerEventSender, TransportTls,
 };
 pub use sound::{RdpsndServerHandler, RdpsndServerMessage, SoundServerFactory};
 

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -349,6 +349,20 @@ impl DisplayControlHandler for DisplayControlBackend {
     }
 }
 
+/// Selects who performs the TLS handshake for a connection accepted via
+/// [`RdpServer::run_connection_with`].
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub enum TransportTls {
+    /// IronRDP performs the TLS accept on the stream (standard TCP+TLS).
+    Managed,
+    /// The stream is already past TLS, terminated by a lower layer (e.g. a WSS
+    /// terminator). IronRDP skips the TLS handshake. The caller MUST guarantee
+    /// the transport is already encrypted; see the preconditions on
+    /// [`RdpServer::run_connection_with`].
+    AlreadyDone,
+}
+
 /// RDP Server
 ///
 /// A server is created to listen for connections.
@@ -690,20 +704,101 @@ impl RdpServer {
         acceptor.attach_static_channel(dvc);
     }
 
+    /// Run a single RDP connection over `stream`, performing the
+    /// IronRDP-managed TLS handshake on `ShouldUpgrade` (standard TCP+TLS).
+    ///
+    /// Equivalent to [`run_connection_with`](Self::run_connection_with) with
+    /// [`TransportTls::Managed`].
     pub async fn run_connection<S>(&mut self, stream: S) -> Result<()>
+    where
+        S: AsyncRead + AsyncWrite + Send + Sync + Unpin,
+    {
+        self.run_connection_with(stream, TransportTls::Managed).await
+    }
+
+    /// Run a single RDP connection over `stream`, choosing who performs the TLS
+    /// handshake with `tls`.
+    ///
+    /// With [`TransportTls::Managed`], IronRDP performs the TLS accept on
+    /// `ShouldUpgrade`, exactly as [`run_connection`](Self::run_connection).
+    ///
+    /// With [`TransportTls::AlreadyDone`], the caller's `stream` has ALREADY
+    /// been transport-encrypted at a lower layer (typically a WSS terminator in
+    /// a proxy-shaped deployment), so IronRDP skips the TLS handshake and
+    /// advances the state machine via [`Acceptor::mark_security_upgrade_as_done`].
+    /// Everything past the handshake, including the optional Hybrid CredSSP
+    /// exchange and finalization, is identical to the managed path.
+    ///
+    /// # Use case for [`TransportTls::AlreadyDone`]
+    ///
+    /// The motivating use case is the [RDCleanPath] protocol used by
+    /// Devolutions Gateway and Cloudflare's IronRDP-WASM deployment: an
+    /// RDCleanPath-aware client connects via WSS to a proxy (or, in the
+    /// embedded shape, to a server that has its own WSS terminator). The WSS
+    /// layer terminates TLS end-to-end with the client; the server side sees a
+    /// post-TLS plaintext byte stream and must not re-run TLS on it.
+    ///
+    /// # Preconditions for [`TransportTls::AlreadyDone`] (caller MUST guarantee)
+    ///
+    /// 1. The `stream` is already transport-encrypted by another layer
+    ///    (WSS, in-process, etc.). Passing a plain TCP stream here exposes
+    ///    RDP traffic in plaintext on the wire.
+    ///
+    /// 2. The connecting RDP client speaks a proxy protocol that informs
+    ///    it that TLS happened at a lower layer (e.g. RDCleanPath). Vanilla
+    ///    RDP clients (mstsc, xfreerdp) negotiate TLS based on the X.224
+    ///    selectedProtocol and have no concept of "TLS already done at a
+    ///    lower layer": they will hang or fail. Vanilla clients must use
+    ///    [`TransportTls::Managed`].
+    ///
+    /// 3. If `self.opts.security` is [`RdpServerSecurity::Hybrid`], two things
+    ///    must hold. First, the client must support CredSSP over this
+    ///    transport; the SPNEGO exchange itself is transport-independent
+    ///    (CredSSP carries its own crypto via TSRequest), so it runs the same
+    ///    as on the managed path. Second, and less obvious: the CredSSP
+    ///    server-public-key confirmation (`pubKeyAuth`, per MS-CSSP) binds to
+    ///    the certificate the client validated at the lower TLS layer, not to
+    ///    anything IronRDP does here. So the public key configured in
+    ///    [`RdpServerSecurity::Hybrid`] MUST be the public key of the
+    ///    certificate that lower layer (e.g. the WSS terminator) presented to
+    ///    the client, otherwise the client's `pubKeyAuth` check fails and
+    ///    Hybrid is rejected. In an embedded-terminator deployment this means
+    ///    terminating TLS with the same certificate configured for Hybrid; in
+    ///    an RDCleanPath proxy deployment it holds by construction, because the
+    ///    proxy relays the backend server's certificate to the client.
+    ///
+    /// [RDCleanPath]: https://docs.rs/ironrdp-rdcleanpath
+    ///
+    /// # Wire-level invariant
+    ///
+    /// This method does NOT alter the X.224 negotiation. The acceptor still
+    /// advertises whatever `SecurityProtocol` it was constructed with, and the
+    /// connecting client still negotiates as normal. The only behaviour change
+    /// under [`TransportTls::AlreadyDone`] is that after the negotiation reaches
+    /// the security-upgrade gate, no TLS handshake is performed on the byte
+    /// stream, because the caller's stream is already past TLS at a lower layer.
+    ///
+    /// Earlier attempts to express "TLS already done" via wire-level signalling
+    /// (a new `RdpServerSecurity::PreSecured` variant that advertised
+    /// `PROTOCOL_SSL` while skipping the actual TLS handshake) failed
+    /// interop with vanilla clients: `PROTOCOL_SSL` selected on the X.224
+    /// wire is a mandatory TLS signal per MS-RDPBCGR, with no provision for
+    /// "TLS already happened elsewhere". RDCleanPath sidesteps this at a
+    /// higher layer rather than at the wire layer; that distinction is the
+    /// invariant this method preserves.
+    pub async fn run_connection_with<S>(&mut self, stream: S, tls: TransportTls) -> Result<()>
     where
         S: AsyncRead + AsyncWrite + Send + Sync + Unpin,
     {
         // Per-connection state must start fresh: if the previous client
         // disconnected while it had sent `SuppressOutput { None }` (e.g.,
         // closed the mstsc window while minimized so the matching resume
-        // PDU never arrived), the flag would still read `true` here and
-        // the display backend would silently drop frames for the entire
-        // new session until/unless the new client happens to send a
+        // PDU never arrived), the flag would still read `true` here and the
+        // display backend would silently drop frames for the entire new
+        // session until/unless the new client happens to send a
         // `RefreshRectangle` or `SuppressOutput { Some(rect) }`. Resetting
-        // here also covers backends that share an externally-created Arc
-        // via `set_display_suppressed_handle()` — they get the same
-        // per-connection clean slate.
+        // here also covers backends that share an externally-created Arc via
+        // `set_display_suppressed_handle()`.
         self.display_suppressed.store(false, Ordering::Relaxed);
 
         let framed = TokioFramed::new(stream);
@@ -719,52 +814,81 @@ impl RdpServer {
             .context("accept_begin failed")?;
 
         match res {
-            BeginResult::ShouldUpgrade(stream) => {
-                let tls_acceptor = match &self.opts.security {
-                    RdpServerSecurity::Tls(acceptor) => acceptor,
-                    RdpServerSecurity::Hybrid((acceptor, _)) => acceptor,
-                    RdpServerSecurity::None => unreachable!(),
-                };
-                let accept = match tls_acceptor.accept(stream).await {
-                    Ok(accept) => accept,
-                    Err(e) => {
-                        warn!("Failed to TLS accept: {}", e);
-                        return Ok(());
-                    }
-                };
-                let mut framed = TokioFramed::new(accept);
-
-                acceptor.mark_security_upgrade_as_done();
-
-                if let RdpServerSecurity::Hybrid((_, pub_key)) = &self.opts.security {
-                    // Generic streams don't expose peer address. Use a neutral
-                    // placeholder; it's unclear whether CredSSP/NTLM actually
-                    // uses this value in practice.
-                    let client_name = "rdp-client".to_owned();
-
-                    ironrdp_acceptor::accept_credssp(
-                        &mut framed,
-                        &mut acceptor,
-                        &mut ironrdp_tokio::reqwest::ReqwestNetworkClient::new(),
-                        client_name.into(),
-                        pub_key.clone(),
-                        None,
-                    )
-                    .await?;
+            // The only thing that varies between the two modes is who performs
+            // the TLS handshake; everything past it is `finalize_after_upgrade`.
+            BeginResult::ShouldUpgrade(stream) => match tls {
+                TransportTls::Managed => {
+                    let tls_acceptor = match &self.opts.security {
+                        RdpServerSecurity::Tls(acceptor) => acceptor,
+                        RdpServerSecurity::Hybrid((acceptor, _)) => acceptor,
+                        RdpServerSecurity::None => unreachable!(),
+                    };
+                    let accept = match tls_acceptor.accept(stream).await {
+                        Ok(accept) => accept,
+                        Err(e) => {
+                            warn!("Failed to TLS accept: {}", e);
+                            return Ok(());
+                        }
+                    };
+                    self.finalize_after_upgrade(TokioFramed::new(accept), acceptor, "TLS connection")
+                        .await?;
                 }
-
-                let framed = self.accept_finalize(framed, acceptor).await?;
-                debug!("Shutting down TLS connection");
-                let (mut tls_stream, _) = framed.into_inner();
-                if let Err(e) = tls_stream.shutdown().await {
-                    debug!(?e, "TLS shutdown error");
+                TransportTls::AlreadyDone => {
+                    // The stream is already past TLS (terminated at a lower
+                    // layer, e.g. a WSS terminator); do NOT call
+                    // tls_acceptor.accept on it.
+                    self.finalize_after_upgrade(TokioFramed::new(stream), acceptor, "TLS-offloaded stream")
+                        .await?;
                 }
-            }
+            },
 
             BeginResult::Continue(framed) => {
                 self.accept_finalize(framed, acceptor).await?;
             }
         };
+
+        Ok(())
+    }
+
+    /// Shared post-handshake tail for both [`TransportTls`] modes: mark the
+    /// security upgrade complete, run the optional Hybrid CredSSP exchange,
+    /// finalize, and shut the stream down. Single-sourcing this is what keeps
+    /// the managed and TLS-offloaded paths structurally identical past the
+    /// handshake, so per-connection state handling cannot drift between them.
+    async fn finalize_after_upgrade<S>(
+        &mut self,
+        mut framed: TokioFramed<S>,
+        mut acceptor: Acceptor,
+        shutdown_label: &str,
+    ) -> Result<()>
+    where
+        S: AsyncRead + AsyncWrite + Sync + Send + Unpin,
+    {
+        acceptor.mark_security_upgrade_as_done();
+
+        if let RdpServerSecurity::Hybrid((_, pub_key)) = &self.opts.security {
+            // Generic streams don't expose peer address. Use a neutral
+            // placeholder; it's unclear whether CredSSP/NTLM actually
+            // uses this value in practice.
+            let client_name = "rdp-client".to_owned();
+
+            ironrdp_acceptor::accept_credssp(
+                &mut framed,
+                &mut acceptor,
+                &mut ironrdp_tokio::reqwest::ReqwestNetworkClient::new(),
+                client_name.into(),
+                pub_key.clone(),
+                None,
+            )
+            .await?;
+        }
+
+        let framed = self.accept_finalize(framed, acceptor).await?;
+        debug!("Shutting down {}", shutdown_label);
+        let (mut inner, _) = framed.into_inner();
+        if let Err(e) = inner.shutdown().await {
+            debug!(?e, "{} shutdown error", shutdown_label);
+        }
 
         Ok(())
     }

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -723,20 +723,29 @@ impl RdpServer {
     /// `ShouldUpgrade`, exactly as [`run_connection`](Self::run_connection).
     ///
     /// With [`TransportTls::AlreadyDone`], the caller's `stream` has ALREADY
-    /// been transport-encrypted at a lower layer (typically a WSS terminator in
-    /// a proxy-shaped deployment), so IronRDP skips the TLS handshake and
+    /// been transport-encrypted at a lower layer that the embedder owns
+    /// (typically a WSS terminator in the same process, or a TLS stream the
+    /// embedder accepted up front), so IronRDP skips the TLS handshake and
     /// advances the state machine via [`Acceptor::mark_security_upgrade_as_done`].
     /// Everything past the handshake, including the optional Hybrid CredSSP
     /// exchange and finalization, is identical to the managed path.
     ///
     /// # Use case for [`TransportTls::AlreadyDone`]
     ///
-    /// The motivating use case is the [RDCleanPath] protocol used by
-    /// Devolutions Gateway and Cloudflare's IronRDP-WASM deployment: an
-    /// RDCleanPath-aware client connects via WSS to a proxy (or, in the
-    /// embedded shape, to a server that has its own WSS terminator). The WSS
-    /// layer terminates TLS end-to-end with the client; the server side sees a
-    /// post-TLS plaintext byte stream and must not re-run TLS on it.
+    /// This mode decouples transport encryption from the RDP security-upgrade
+    /// step. It is for ironrdp-server endpoints that terminate transport
+    /// encryption themselves before the RDP state machine runs — for example a
+    /// server that accepts WSS directly, or one fronted by an in-process TLS
+    /// terminator — and therefore must not perform a second, inner TLS
+    /// handshake when the X.224 negotiation selects `PROTOCOL_SSL`.
+    ///
+    /// This is distinct from a [RDCleanPath] proxy deployment (e.g.
+    /// Devolutions Gateway), where the proxy performs a real TLS handshake with
+    /// a *separate* backend RDP server and relays that server's certificate
+    /// chain to the client. In that topology the backend server owns its own
+    /// TLS and uses [`TransportTls::Managed`]; this mode does not apply to it.
+    /// RDCleanPath is relevant here only as one client-side mechanism (see
+    /// precondition 2) for telling a client not to expect an inner handshake.
     ///
     /// # Preconditions for [`TransportTls::AlreadyDone`] (caller MUST guarantee)
     ///
@@ -744,12 +753,13 @@ impl RdpServer {
     ///    (WSS, in-process, etc.). Passing a plain TCP stream here exposes
     ///    RDP traffic in plaintext on the wire.
     ///
-    /// 2. The connecting RDP client speaks a proxy protocol that informs
-    ///    it that TLS happened at a lower layer (e.g. RDCleanPath). Vanilla
-    ///    RDP clients (mstsc, xfreerdp) negotiate TLS based on the X.224
-    ///    selectedProtocol and have no concept of "TLS already done at a
-    ///    lower layer": they will hang or fail. Vanilla clients must use
-    ///    [`TransportTls::Managed`].
+    /// 2. The connecting client must not expect an inner TLS handshake on this
+    ///    stream. Vanilla RDP clients (mstsc, xfreerdp) negotiate TLS from the
+    ///    X.224 `selectedProtocol` and have no concept of "TLS already done at a
+    ///    lower layer": they will hang or fail, and must use
+    ///    [`TransportTls::Managed`]. Arranging for a client to skip the inner
+    ///    handshake is the embedder's responsibility; RDCleanPath is one such
+    ///    mechanism, but this method does not depend on it.
     ///
     /// 3. If `self.opts.security` is [`RdpServerSecurity::Hybrid`], two things
     ///    must hold. First, the client must support CredSSP over this
@@ -757,15 +767,14 @@ impl RdpServer {
     ///    (CredSSP carries its own crypto via TSRequest), so it runs the same
     ///    as on the managed path. Second, and less obvious: the CredSSP
     ///    server-public-key confirmation (`pubKeyAuth`, per MS-CSSP) binds to
-    ///    the certificate the client validated at the lower TLS layer, not to
-    ///    anything IronRDP does here. So the public key configured in
+    ///    the certificate the client validated at the lower transport layer,
+    ///    not to anything IronRDP does here. So the public key configured in
     ///    [`RdpServerSecurity::Hybrid`] MUST be the public key of the
     ///    certificate that lower layer (e.g. the WSS terminator) presented to
     ///    the client, otherwise the client's `pubKeyAuth` check fails and
-    ///    Hybrid is rejected. In an embedded-terminator deployment this means
-    ///    terminating TLS with the same certificate configured for Hybrid; in
-    ///    an RDCleanPath proxy deployment it holds by construction, because the
-    ///    proxy relays the backend server's certificate to the client.
+    ///    Hybrid is rejected. This is the embedder's responsibility; it does
+    ///    not hold automatically. In practice it means terminating transport
+    ///    TLS with the same certificate configured for Hybrid.
     ///
     /// [RDCleanPath]: https://docs.rs/ironrdp-rdcleanpath
     ///
@@ -777,15 +786,6 @@ impl RdpServer {
     /// under [`TransportTls::AlreadyDone`] is that after the negotiation reaches
     /// the security-upgrade gate, no TLS handshake is performed on the byte
     /// stream, because the caller's stream is already past TLS at a lower layer.
-    ///
-    /// Earlier attempts to express "TLS already done" via wire-level signalling
-    /// (a new `RdpServerSecurity::PreSecured` variant that advertised
-    /// `PROTOCOL_SSL` while skipping the actual TLS handshake) failed
-    /// interop with vanilla clients: `PROTOCOL_SSL` selected on the X.224
-    /// wire is a mandatory TLS signal per MS-RDPBCGR, with no provision for
-    /// "TLS already happened elsewhere". RDCleanPath sidesteps this at a
-    /// higher layer rather than at the wire layer; that distinction is the
-    /// invariant this method preserves.
     pub async fn run_connection_with<S>(&mut self, stream: S, tls: TransportTls) -> Result<()>
     where
         S: AsyncRead + AsyncWrite + Send + Sync + Unpin,


### PR DESCRIPTION
## Summary

- Adds `RdpServer::run_connection_with(stream, tls: TransportTls)`, one per-connection entry point that selects who performs the TLS handshake.
- New `#[non_exhaustive] enum TransportTls`: `Managed` (IronRDP performs the TLS accept, standard TCP+TLS) and `AlreadyDone` (stream already past TLS at a lower layer such as a WSS terminator, so IronRDP skips the handshake).
- `run_connection` is now a thin delegate that calls it with `TransportTls::Managed`; behavior unchanged. Additive and non-breaking.
- Both modes share one body: the only branch is the TLS accept, and the post-handshake tail (mark upgrade done, optional Hybrid CredSSP, finalize, shutdown) is single-sourced, so per-connection state cannot drift between them.
- Motivation: RDCleanPath (Gateway, Cloudflare IronRDP-WASM) and embedded WSS-terminator servers, where the client terminates TLS below RDP. X.224 negotiation is untouched.

## Validation

- `cargo xtask check fmt/lints/tests/typos/locks` all pass.

## Notes

- Reshaped during review: this began as a separate sibling method and was collapsed into the single `run_connection_with` + `TransportTls` shape so the two paths cannot rot out of sync.
- Hybrid over `AlreadyDone`: CredSSP `pubKeyAuth` binds to the certificate the client validated at the lower TLS layer, so the `RdpServerSecurity::Hybrid` key must match that certificate (holds by construction under an RDCleanPath proxy). Documented as a precondition.
- Wire-level `PreSecured` was tried and closed (#1210); RDCleanPath solves this above the wire. Builds on #1181.
