### PR TITLE
ci: add `check features` matrix gate with dynamic CI fan-out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,10 +201,64 @@ jobs:
       - name: Build .NET projects
         run: cd ./ffi/dotnet && dotnet build
 
+  feature-matrix-setup:
+    name: feature matrix setup
+    needs: [formatting]
+    runs-on: ubuntu-latest
+    outputs:
+      feature-matrix: ${{ steps.setup-matrix.outputs.feature-matrix }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2.7.3
+
+      - name: Setup matrix
+        id: setup-matrix
+        run: |
+          MATRIX="$(cargo xtask check features --list --format github-matrix)"
+          echo "feature-matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
+  feature-matrix:
+    name: feature matrix [${{ matrix.case }}]
+    needs: [formatting, feature-matrix-setup]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.feature-matrix-setup.outputs.feature-matrix) }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install devel packages
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get -y install libasound2-dev
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2.7.3
+
+      - name: Binary cache
+        uses: actions/cache@v5
+        with:
+          path: ./.cargo/local_root/bin
+          key: ${{ runner.os }}-bin-${{ github.job }}-${{ hashFiles('xtask/src/bin_version.rs') }}
+
+      - name: Prepare
+        run: cargo xtask check install -v
+
+      - name: Run feature-matrix case
+        run: cargo xtask check features --case '${{ matrix.case }}' -v
+
+      - name: Lock files
+        run: cargo xtask check locks -v
+
   success:
     name: Success
     if: ${{ always() }}
-    needs: [formatting, typos, checks, fuzz, web, ffi]
+    needs: [formatting, typos, checks, fuzz, web, ffi, feature-matrix-setup, feature-matrix]
     runs-on: ubuntu-latest
 
     steps:

--- a/xtask/src/bin_version.rs
+++ b/xtask/src/bin_version.rs
@@ -4,6 +4,7 @@
 use crate::bin_install::CargoPackage;
 
 pub const CARGO_FUZZ: CargoPackage = CargoPackage::new("cargo-fuzz", "0.12.0");
+pub const CARGO_HACK: CargoPackage = CargoPackage::new("cargo-hack", "0.6.44");
 pub const CARGO_LLVM_COV: CargoPackage = CargoPackage::new("cargo-llvm-cov", "0.6.16");
 pub const GRCOV: CargoPackage = CargoPackage::new("grcov", "0.8.20");
 pub const WASM_PACK: CargoPackage = CargoPackage::new("wasm-pack", "0.13.1");

--- a/xtask/src/check.rs
+++ b/xtask/src/check.rs
@@ -45,9 +45,10 @@ pub fn typos(sh: &Shell) -> anyhow::Result<()> {
 }
 
 pub fn install(sh: &Shell) -> anyhow::Result<()> {
-    let _s = Section::new("TYPOS-CLI-INSTALL");
+    let _s = Section::new("CHECK-INSTALL");
 
     cargo_install(sh, &TYPOS_CLI)?;
+    cargo_install(sh, &CARGO_HACK)?;
 
     Ok(())
 }

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -15,6 +15,11 @@ TASKS:
   check locks             Check for dirty or staged lock files not yet committed
   check tests [--no-run]  Compile tests and, unless specified otherwise, run them
   check typos             Check for typos in the codebase
+  check features          Run every feature-matrix case sequentially
+  check features --case <NAME>
+                          Run a single feature-matrix case
+  check features --list [--format <FMT>]
+                          List feature-matrix cases (fmt: human (default) | github-matrix)
   check install           Install all requirements for check tasks
   ci                      Run all checks required on CI
   clean                   Clean workspace
@@ -62,6 +67,11 @@ pub enum Action {
         no_run: bool,
     },
     CheckTypos,
+    CheckFeatures {
+        case: Option<String>,
+        list: bool,
+        format: Option<String>,
+    },
     CheckInstall,
     Ci,
     Clean,
@@ -116,6 +126,11 @@ pub fn parse_args() -> anyhow::Result<Args> {
                     no_run: args.contains("--no-run"),
                 },
                 Some("typos") => Action::CheckTypos,
+                Some("features") => Action::CheckFeatures {
+                    case: args.opt_value_from_str("--case")?,
+                    list: args.contains("--list"),
+                    format: args.opt_value_from_str("--format")?,
+                },
                 Some("install") => Action::CheckInstall,
                 Some(unknown) => anyhow::bail!("unknown check action: {unknown}"),
                 None => Action::ShowHelp,

--- a/xtask/src/features.rs
+++ b/xtask/src/features.rs
@@ -1,0 +1,292 @@
+use core::fmt::Write as _;
+use std::collections::HashMap;
+use std::io::Write as _;
+
+use tinyjson::JsonValue;
+
+use crate::prelude::*;
+
+/// One feature-check case in the matrix. Each case is independently runnable via
+/// `cargo xtask check features --case <name>`, which is the local reproducer for
+/// any failure surfaced by the CI fan-out.
+pub struct FeatureCheckCase {
+    /// Case identifier of the form `scope/feature-or-strategy`.
+    pub name: &'static str,
+    pub invocation: Invocation,
+}
+
+/// What the case actually runs.
+pub enum Invocation {
+    /// Direct `cargo check` for a single package with explicit feature selection.
+    /// Locks the curated invariants (notably the `arbitrary` discipline and the
+    /// std/alloc/no_std cascade paths) that the powerset alone does not pin down.
+    CargoCheck {
+        package: &'static str,
+        no_default_features: bool,
+        features: &'static [&'static str],
+    },
+    /// `cargo hack check --feature-powerset` over a package group with a depth cap.
+    /// The workspace-level `EXCLUDE_FEATURES` list applies to every powerset case
+    /// so internal-only flags do not skew the matrix. `extra_args` is appended
+    /// verbatim, for cases that need to skip `--no-default-features` (TLS) or
+    /// otherwise diverge from the default invocation.
+    CargoHack {
+        packages: &'static [&'static str],
+        depth: u8,
+        extra_args: &'static [&'static str],
+    },
+}
+
+/// Features that the powerset should never enumerate.
+///   `__bench` and `__test` are private features that pull `visibility` for the
+///   testsuite; the existing lints job exercises them via `--features helper,__bench`.
+const EXCLUDE_FEATURES: &[&str] = &["__bench", "__test"];
+
+/// The canonical case set. Adding a new feature-matrix check means adding an entry
+/// here; the CI matrix discovers it automatically through `--list`.
+pub fn cases() -> &'static [FeatureCheckCase] {
+    CASES
+}
+
+const CASES: &[FeatureCheckCase] = &[
+    // Per-crate curated invariants.
+    FeatureCheckCase {
+        name: "ironrdp-core/alloc",
+        invocation: Invocation::CargoCheck {
+            package: "ironrdp-core",
+            no_default_features: true,
+            features: &["alloc"],
+        },
+    },
+    FeatureCheckCase {
+        name: "ironrdp-core/std",
+        invocation: Invocation::CargoCheck {
+            package: "ironrdp-core",
+            no_default_features: false,
+            features: &["std"],
+        },
+    },
+    FeatureCheckCase {
+        name: "ironrdp-pdu/std",
+        invocation: Invocation::CargoCheck {
+            package: "ironrdp-pdu",
+            no_default_features: false,
+            features: &["std"],
+        },
+    },
+    FeatureCheckCase {
+        name: "ironrdp-pdu/arbitrary",
+        invocation: Invocation::CargoCheck {
+            package: "ironrdp-pdu",
+            no_default_features: false,
+            features: &["arbitrary"],
+        },
+    },
+    FeatureCheckCase {
+        name: "ironrdp-pdu/arbitrary-alloc",
+        invocation: Invocation::CargoCheck {
+            package: "ironrdp-pdu",
+            no_default_features: true,
+            features: &["arbitrary", "alloc"],
+        },
+    },
+    // Workspace powerset, partitioned by layer so each fan-out worker stays bounded.
+    // Adding a new crate to a group means the powerset picks it up on the next run.
+    FeatureCheckCase {
+        name: "workspace/powerset-foundation",
+        invocation: Invocation::CargoHack {
+            packages: &["ironrdp-core", "ironrdp-error", "ironrdp-str", "ironrdp-bulk"],
+            depth: 2,
+            extra_args: &[],
+        },
+    },
+    FeatureCheckCase {
+        name: "workspace/powerset-pdu",
+        invocation: Invocation::CargoHack {
+            packages: &["ironrdp-pdu", "ironrdp-graphics"],
+            depth: 2,
+            extra_args: &[],
+        },
+    },
+    FeatureCheckCase {
+        name: "workspace/powerset-channels",
+        invocation: Invocation::CargoHack {
+            packages: &[
+                "ironrdp-cliprdr",
+                "ironrdp-rdpdr",
+                "ironrdp-rdpsnd",
+                "ironrdp-egfx",
+                "ironrdp-dvc",
+                "ironrdp-svc",
+                "ironrdp-input",
+                "ironrdp-ainput",
+                "ironrdp-displaycontrol",
+                "ironrdp-rdpeusb",
+            ],
+            depth: 2,
+            extra_args: &[],
+        },
+    },
+    FeatureCheckCase {
+        name: "workspace/powerset-connector-session",
+        invocation: Invocation::CargoHack {
+            packages: &["ironrdp-connector", "ironrdp-session", "ironrdp-acceptor"],
+            depth: 2,
+            extra_args: &[],
+        },
+    },
+    FeatureCheckCase {
+        name: "workspace/powerset-runtime",
+        invocation: Invocation::CargoHack {
+            packages: &["ironrdp-async", "ironrdp-blocking", "ironrdp-tokio", "ironrdp-server"],
+            depth: 2,
+            extra_args: &[],
+        },
+    },
+    // `ironrdp-tls`, `ironrdp-client`, `ironrdp-mstsgu` are intentionally
+    // outside this initial case set. The `exactly-one-of` TLS-backend
+    // constraint on `ironrdp-tls` needs `--mutually-exclusive-features`,
+    // `--at-least-one-of`, and `--exclude-no-default-features` on the
+    // cargo-hack invocation (cargo-hack does not honor
+    // `package.metadata.cargo-hack`), and the powerset surfaces a latent
+    // bug in `extract_tls_server_public_key` that uses `x509_cert::*`
+    // unconditionally instead of gating on `rustls | native-tls`. Both
+    // are tractable but out of scope for this gate's initial landing.
+    // The regular `Checks` job already exercises all three crates with
+    // their default features.
+];
+
+/// Run every case sequentially. Mirrors what a contributor gets locally with
+/// `cargo xtask check features`; CI uses the per-case mode instead.
+pub fn run_all(sh: &Shell) -> anyhow::Result<()> {
+    let _s = Section::new("FEATURE-MATRIX");
+
+    if !is_installed(sh, &CARGO_HACK) {
+        anyhow::bail!("`cargo-hack` is missing. Please run `cargo xtask check install`.");
+    }
+
+    for case in cases() {
+        run_one(sh, case)?;
+    }
+
+    println!("All good!");
+    Ok(())
+}
+
+/// Run a single case. Equivalent to `cargo xtask check features --case <name>`.
+pub fn run_case(sh: &Shell, case_name: &str) -> anyhow::Result<()> {
+    let case = cases().iter().find(|c| c.name == case_name).with_context(|| {
+        format!("unknown case: `{case_name}`; run `cargo xtask check features --list` to enumerate")
+    })?;
+
+    let result = run_one(sh, case);
+    let status = if result.is_ok() { "pass" } else { "fail" };
+    let _ = write_step_summary(case, status);
+    result
+}
+
+fn run_one(sh: &Shell, case: &FeatureCheckCase) -> anyhow::Result<()> {
+    let _s = Section::new(case.name);
+
+    match &case.invocation {
+        Invocation::CargoCheck {
+            package,
+            no_default_features,
+            features,
+        } => {
+            let mut args: Vec<String> = vec!["check".into(), "-p".into(), (*package).into(), "--locked".into()];
+            if *no_default_features {
+                args.push("--no-default-features".into());
+            }
+            if !features.is_empty() {
+                args.push("--features".into());
+                args.push(features.join(","));
+            }
+            cmd!(sh, "{CARGO}").args(&args).run()?;
+        }
+        Invocation::CargoHack {
+            packages,
+            depth,
+            extra_args,
+        } => {
+            if !is_installed(sh, &CARGO_HACK) {
+                anyhow::bail!("`cargo-hack` is missing. Please run `cargo xtask check install`.");
+            }
+
+            let depth_str = depth.to_string();
+            let exclude_features = EXCLUDE_FEATURES.join(",");
+            // `--no-dev-deps` mutates `Cargo.toml` while cargo-hack runs,
+            // which would force Cargo.lock to drift and conflict with
+            // `--locked`. Keeping dev-deps in the resolution costs a small
+            // amount of extra type-checking but preserves lockfile
+            // reproducibility for the powerset.
+            let mut args: Vec<String> = vec![
+                "hack".into(),
+                "check".into(),
+                "--locked".into(),
+                "--feature-powerset".into(),
+                "--depth".into(),
+                depth_str,
+                "--exclude-features".into(),
+                exclude_features,
+            ];
+            for pkg in *packages {
+                args.push("-p".into());
+                args.push((*pkg).into());
+            }
+            for extra in *extra_args {
+                args.push((*extra).into());
+            }
+            cmd!(sh, "{CARGO}").args(&args).run()?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Print each case, one per line. Useful for local discovery.
+pub fn list_human() -> anyhow::Result<()> {
+    for case in cases() {
+        println!("{}", case.name);
+    }
+    Ok(())
+}
+
+/// Emit a `matrix.include`-compatible JSON array on stdout. CI consumes this via
+/// `fromJson(steps.setup.outputs.feature-matrix)`.
+pub fn list_github_matrix() -> anyhow::Result<()> {
+    let items: Vec<JsonValue> = cases()
+        .iter()
+        .map(|c| {
+            let mut obj = HashMap::new();
+            obj.insert("case".to_owned(), JsonValue::String(c.name.to_owned()));
+            JsonValue::Object(obj)
+        })
+        .collect();
+
+    let json = JsonValue::Array(items);
+    let stringified = json
+        .stringify()
+        .context("serialize feature-matrix include array as JSON")?;
+    println!("{stringified}");
+    Ok(())
+}
+
+/// Append a brief markdown line to `$GITHUB_STEP_SUMMARY` so the matrix fan-out
+/// surfaces in the workflow summary view without expanding logs. No-op locally.
+fn write_step_summary(case: &FeatureCheckCase, status: &str) -> anyhow::Result<()> {
+    let Ok(path) = std::env::var("GITHUB_STEP_SUMMARY") else {
+        return Ok(());
+    };
+
+    let mut line = String::new();
+    writeln!(line, "- `{}`: **{}**", case.name, status)?;
+
+    std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)?
+        .write_all(line.as_bytes())?;
+
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -10,6 +10,7 @@ mod check;
 mod clean;
 mod cli;
 mod cov;
+mod features;
 mod ffi;
 mod fuzz;
 mod prelude;
@@ -81,6 +82,19 @@ fn main() -> anyhow::Result<()> {
         Action::CheckTypos => {
             check::typos(&sh)?;
         }
+        Action::CheckFeatures { case, list, format } => {
+            if list {
+                match format.as_deref() {
+                    Some("github-matrix") => features::list_github_matrix()?,
+                    Some("human") | None => features::list_human()?,
+                    Some(other) => anyhow::bail!("unknown --format value: {other}"),
+                }
+            } else if let Some(case_name) = case {
+                features::run_case(&sh, &case_name)?;
+            } else {
+                features::run_all(&sh)?;
+            }
+        }
         Action::CheckInstall => {
             check::install(&sh)?;
         }
@@ -90,6 +104,7 @@ fn main() -> anyhow::Result<()> {
             check::tests_compile(&sh)?;
             check::tests_run(&sh)?;
             check::lints(&sh)?;
+            features::run_all(&sh)?;
             wasm::check(&sh)?;
             fuzz::run(&sh, None, None)?;
             web::install(&sh)?;


### PR DESCRIPTION
Closes the matrix-gate items (3-5) from #1123. The case enumeration lives in `xtask` so the matrix is self-documenting and locally reproducible; CI fans out via a preflight job emitting a JSON `matrix.include` array, per [#1123 (comment)](https://github.com/Devolutions/IronRDP/issues/1123#issuecomment-4477304535).

## What it adds

**`cargo xtask check features` subcommand** with three modes:

| Mode | What it does |
|---|---|
| `cargo xtask check features` | Run every case sequentially. Mirrors what CI does in aggregate. |
| `cargo xtask check features --case <NAME>` | Run one case. CI matrix workers use this; the case name doubles as the local repro for any failure. |
| `cargo xtask check features --list [--format <FMT>]` | Enumerate cases. `--format github-matrix` emits a JSON include array suitable for `strategy.matrix.include: ${{ fromJson(...) }}`. |

**Two new CI jobs in `.github/workflows/ci.yml`:**

- `feature-matrix-setup` preflight runs the list step, emits `feature-matrix` via `$GITHUB_OUTPUT`.
- `feature-matrix [${{ matrix.case }}]` fan-out consumes the preflight output via `fromJson` and runs one case per worker.

Both join the existing `success` job's `needs` list so branch protection keeps a single required status check. Each worker writes a one-line markdown entry to `$GITHUB_STEP_SUMMARY` so per-case results show in the run summary view without expanding logs.

## Initial case set (10)

Per-crate curated invariants (the `arbitrary` and std/alloc discipline that the powerset alone does not pin down):

- `ironrdp-core/alloc`, `ironrdp-core/std`
- `ironrdp-pdu/std`, `ironrdp-pdu/arbitrary`, `ironrdp-pdu/arbitrary-alloc`

Workspace powersets, partitioned by layer so each fan-out worker stays bounded:

- `workspace/powerset-foundation` (ironrdp-core, ironrdp-error, ironrdp-str, ironrdp-bulk)
- `workspace/powerset-pdu` (ironrdp-pdu, ironrdp-graphics)
- `workspace/powerset-channels` (ironrdp-cliprdr, ironrdp-rdpdr, ironrdp-rdpsnd, ironrdp-egfx, ironrdp-dvc, ironrdp-svc, ironrdp-input, ironrdp-ainput, ironrdp-displaycontrol, ironrdp-rdpeusb)
- `workspace/powerset-connector-session` (ironrdp-connector, ironrdp-session, ironrdp-acceptor)
- `workspace/powerset-runtime` (ironrdp-async, ironrdp-blocking, ironrdp-tokio, ironrdp-server)

Adding a new check is one entry in `CASES` in `xtask/src/features.rs`; the CI matrix discovers it automatically.

## Mapping to the #1123 remediation set

| Item | Status |
|---|---|
| 1. `ironrdp-bulk` alloc plumbing | Closed by #1279 (merged) |
| 2. `ironrdp-str` `ToOwned` import | Closed by #1280 (merged) |
| 3. cargo-hack TLS exclusivity flags | Handled per-case via `extra_args` (see comment in `features.rs` re. TLS scope) |
| 4. `ironrdp-web` exclusion | Naturally excluded: no case includes `ironrdp-web` (the existing `web` job covers it on wasm32) |
| 5. Matrix-gate xtask + CI yaml + cargo-hack pin | This PR |

## TLS coverage gap (documented limitation)

`ironrdp-tls`, `ironrdp-client`, `ironrdp-mstsgu` are intentionally outside the initial case set. Two reasons, both tractable but out of scope for this gate's initial landing:

1. cargo-hack does not honor `package.metadata.cargo-hack`, so the exactly-one-of TLS-backend constraint needs `--mutually-exclusive-features`, `--at-least-one-of`, and `--exclude-no-default-features` re-stated on the invocation.
2. The powerset surfaces a latent bug in `crates/ironrdp-tls/src/lib.rs::extract_tls_server_public_key` that uses `x509_cert::Certificate` unconditionally instead of gating on `cfg(any(feature = "rustls", feature = "native-tls"))`. Visible under `--features stub` alone.

The regular `Checks` job already exercises all three crates with their default features, so the new gate's omission is not a coverage regression.

## Local validation

```
$ cargo xtask check fmt           # all good
$ cargo xtask check lints         # all good
$ cargo xtask check features --list                              # 10 cases
$ cargo xtask check features --list --format github-matrix       # valid JSON for fromJson
$ cargo xtask check features --case ironrdp-pdu/arbitrary        # 2.2s, pass
$ cargo xtask check features --case workspace/powerset-foundation # 3.2s, 20 combos, pass
$ cargo xtask check features --case workspace/powerset-pdu        # 21.2s, pass
$ cargo xtask check features --case workspace/powerset-connector-session  # 8.0s, pass
```

## Provenance and tooling

This change originated from the #1123 workspace feature-matrix scan and the design discussion at [#1123 (comment)](https://github.com/Devolutions/IronRDP/issues/1123#issuecomment-4477304535). I agree to the Developer Certificate of Origin and disclose use of Claude Code (Opus) per the LLM use policy; trailers on the commit reflect both.