### PR TITLE
refactor(egfx)!: mark consumer-facing types as `#[non_exhaustive]` for pre-publish API stability

### DIFF
--- a/crates/ironrdp-egfx/src/client.rs
+++ b/crates/ironrdp-egfx/src/client.rs
@@ -86,6 +86,7 @@ const MAX_DECOMPRESSED_BUFFER_CAPACITY: usize = 16384; // 16 KiB
 ///
 /// [MS-RDPEGFX 3.3.1.6]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpegfx/83cb08ff-c97f-4d08-b834-7aa69cdea6c5
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct Surface {
     /// Surface identifier (assigned by server)
     pub id: u16,
@@ -109,6 +110,7 @@ pub struct Surface {
 
 /// Codec capabilities determined from negotiated capability set
 #[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct CodecCapabilities {
     /// AVC420 (H.264 4:2:0) is available
     pub avc420: bool,
@@ -183,6 +185,7 @@ impl CodecCapabilities {
 /// Delivered to [`GraphicsPipelineHandler::on_bitmap_updated`] when
 /// a `WireToSurface1` PDU is processed with decoded pixel data.
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct BitmapUpdate {
     /// Surface this update applies to
     pub surface_id: u16,

--- a/crates/ironrdp-egfx/src/decode.rs
+++ b/crates/ironrdp-egfx/src/decode.rs
@@ -27,6 +27,7 @@ use core::fmt;
 /// The pixel data is in RGBA format (4 bytes per pixel),
 /// row-major, top-to-bottom, left-to-right.
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct DecodedFrame {
     /// RGBA pixel data (4 bytes per pixel)
     pub data: Vec<u8>,
@@ -34,6 +35,21 @@ pub struct DecodedFrame {
     pub width: u32,
     /// Frame height in pixels
     pub height: u32,
+}
+
+impl DecodedFrame {
+    #[expect(
+        clippy::as_conversions,
+        reason = "usize to u64 is lossless on all supported platforms (32/64-bit)"
+    )]
+    pub fn new(data: Vec<u8>, width: u32, height: u32) -> Self {
+        debug_assert_eq!(
+            data.len() as u64,
+            u64::from(width).saturating_mul(u64::from(height)).saturating_mul(4),
+            "DecodedFrame buffer must be RGBA8888 (width * height * 4 bytes)",
+        );
+        Self { data, width, height }
+    }
 }
 
 impl fmt::Debug for DecodedFrame {
@@ -52,6 +68,7 @@ impl fmt::Debug for DecodedFrame {
 
 /// Error type for decoder operations
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct DecoderError {
     context: String,
     source: Option<Box<dyn core::error::Error + Send + Sync>>,
@@ -149,8 +166,9 @@ pub trait H264Decoder: Send {
 
 #[cfg(feature = "openh264")]
 mod openh264_impl {
-    use super::{DecodedFrame, DecoderError, DecoderResult, H264Decoder};
     use tracing::warn;
+
+    use super::{DecodedFrame, DecoderError, DecoderResult, H264Decoder};
 
     /// H.264 decoder backed by Cisco's OpenH264 library
     ///

--- a/crates/ironrdp-egfx/src/pdu/cmd.rs
+++ b/crates/ironrdp-egfx/src/pdu/cmd.rs
@@ -45,6 +45,7 @@ const RESET_GRAPHICS_PDU_SIZE: usize = 340 - GfxPdu::FIXED_PART_SIZE;
 ///
 /// INVARIANTS: size of encoded inner PDU is always less than `u32::MAX - Self::FIXED_PART_SIZE`
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum GfxPdu {
     WireToSurface1(WireToSurface1Pdu),
     WireToSurface2(WireToSurface2Pdu),

--- a/crates/ironrdp-egfx/src/server.rs
+++ b/crates/ironrdp-egfx/src/server.rs
@@ -120,6 +120,7 @@ impl DvcEncode for ZgfxWrappedBytes {}
 /// Per MS-RDPEGFX, the server maintains an "Offscreen Surfaces ADM element"
 /// which is a list of surfaces created on the client.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct Surface {
     /// Surface identifier (unique per session)
     pub id: u16,
@@ -229,6 +230,7 @@ impl Surfaces {
 /// Per MS-RDPEGFX, the server maintains an "Unacknowledged Frames ADM element"
 /// which tracks frames sent but not yet acknowledged.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct FrameInfo {
     /// Frame identifier
     pub frame_id: u32,
@@ -242,6 +244,7 @@ pub struct FrameInfo {
 
 /// Quality of Experience metrics from client
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct QoeMetrics {
     /// Frame ID this relates to
     pub frame_id: u32,
@@ -423,6 +426,7 @@ impl Default for QoeCollector {
 ///
 /// Returned by [`GraphicsPipelineServer::qoe_snapshot()`].
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct QoeSnapshot {
     /// Total QoE reports received from client.
     pub total_qoe_reports: u64,
@@ -607,6 +611,7 @@ impl FrameTracker {
 
 /// Codec capabilities determined from negotiation
 #[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct CodecCapabilities {
     /// AVC420 (H.264 4:2:0) is available
     pub avc420: bool,

--- a/crates/ironrdp-testsuite-core/tests/egfx/client.rs
+++ b/crates/ironrdp-testsuite-core/tests/egfx/client.rs
@@ -70,11 +70,7 @@ impl H264Decoder for MockH264Decoder {
             pixel[0] = 255; // R
             pixel[3] = 255; // A
         }
-        Ok(DecodedFrame {
-            data,
-            width: 16,
-            height: 16,
-        })
+        Ok(DecodedFrame::new(data, 16, 16))
     }
 }
 


### PR DESCRIPTION
Closes the API-stability item of #1229 (egfx pre-publish hardening). Marks consumer-facing aggregates and the top-level dispatch enum so future field/variant additions don't constitute breaking changes for downstream crates.

## Marked

- **Consumer-facing state with pub fields**: `Surface` (client + server), `BitmapUpdate`, `DecodedFrame`, `CodecCapabilities` (client + server), `FrameInfo`, `QoeMetrics`, `QoeSnapshot`.
- **Errors**: `DecoderError`.
- **Dispatch enum**: `GfxPdu` (consumers must add `_ =>` arms).

## Intentionally not marked

- **Spec-defined wire PDUs**: shape is fixed by MS-RDPEGFX; spec growth comes via new `GfxPdu` variants, not field-adds to existing PDUs.
- **Spec primitives** (`Timestamp`, `Point`, `Color`, `QuantQuality`, `Avc420Region`, `CacheEntryMetadata`, AVC bitmap streams): shape fixed by spec.
- **Spec-discriminant enums** (`CapabilitySet`, `Codec1Type`, `Codec2Type`, `PixelFormat`, `QueueDepth`): to be addressed separately via the wrapper-struct-around-integer pattern documented in `crates/ironrdp-pdu/README.md` (cf. `ironrdp_graphics::rle::Code`, `ironrdp_cliprdr::pdu::format_list::ClipboardFormatId`).
- **Tuple-struct PDU wrappers**: same logic as wire PDUs.
- **All-private-field aggregates** (`Surfaces`, `FrameTracker`, `GraphicsPipelineClient`, `GraphicsPipelineServer`): `#[non_exhaustive]` has no mechanical effect when fields are private.

## DecodedFrame::new

Adds `debug_assert_eq!` on the RGBA8888 size invariant (`data.len() == width * height * 4`) so contract-violating decoder impls surface in debug builds.

## Breaking change

External crates can no longer construct the marked structs via struct-literal syntax; exhaustive match on `GfxPdu` now requires a `_ =>` arm. Marked with `!` in the subject. Internal-to-workspace construction is unaffected.

## Local validation

`cargo xtask check fmt / lints / tests / typos / locks` — all good.