### PR TITLE
Add agentic RDP CLI and localhost CI workflow

### DIFF
--- a/.github/workflows/agentic-rdp.yml
+++ b/.github/workflows/agentic-rdp.yml
@@ -1,0 +1,91 @@
+name: Agentic RDP
+
+on:
+  push:
+  workflow_dispatch:
+    inputs:
+      desktop_size:
+        description: RDP desktop size requested through ironrdp-agent
+        required: true
+        default: 1920x1080
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUSTUP_MAX_RETRIES: 10
+  RUST_BACKTRACE: short
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+  CARGO_PROFILE_DEV_DEBUG: 0
+
+jobs:
+  localhost-rdp:
+    name: Localhost RDP automation
+    runs-on: windows-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2.7.3
+
+      - name: Build ironrdp-agent
+        run: cargo build -p ironrdp-agent --release
+
+      - name: Probe test VM RDP endpoint
+        shell: pwsh
+        run: |
+          $artifactsDir = Join-Path $env:GITHUB_WORKSPACE 'artifacts\agentic-rdp'
+          New-Item -Path $artifactsDir -ItemType Directory -Force | Out-Null
+          $hostName = '${{ vars.IRONRDP_AGENT_E2E_HOST }}'
+          if ([string]::IsNullOrWhiteSpace($hostName)) {
+            $hostName = 'IT-HELP-TEST'
+          }
+
+          $addresses = @()
+          try {
+            $addresses = @(Resolve-DnsName -Name $hostName -ErrorAction Stop | Select-Object -ExpandProperty IPAddress -ErrorAction SilentlyContinue)
+          }
+          catch {
+            Write-Warning "DNS lookup failed for ${hostName}: $($_.Exception.Message)"
+          }
+
+          $tcp = Test-NetConnection -ComputerName $hostName -Port 3389 -WarningAction SilentlyContinue
+          [pscustomobject]@{
+            HostName = $hostName
+            Addresses = @($addresses)
+            TcpTestSucceeded = [bool] $tcp.TcpTestSucceeded
+            RemoteAddress = [string] $tcp.RemoteAddress
+            RemotePort = [int] $tcp.RemotePort
+            InterfaceAlias = [string] $tcp.InterfaceAlias
+            SourceAddress = [string] $tcp.SourceAddress
+          } | ConvertTo-Json -Depth 6 | Tee-Object -FilePath (Join-Path $artifactsDir 'test-vm-probe.json')
+
+      - name: Run agentic RDP scenario
+        shell: pwsh
+        run: |
+          $desktopSize = '${{ github.event.inputs.desktop_size }}'
+          if ([string]::IsNullOrWhiteSpace($desktopSize)) {
+            $desktopSize = '1920x1080'
+          }
+
+          .\testing\agentic-rdp\Invoke-AgenticRdpTest.ps1 `
+            -DesktopSize $desktopSize `
+            -ArtifactsDir (Join-Path $env:GITHUB_WORKSPACE 'artifacts\agentic-rdp')
+
+      - name: Upload screenshots
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: agentic-rdp-screenshots
+          path: artifacts\agentic-rdp\*.png
+          if-no-files-found: warn
+
+      - name: Upload logs and metadata
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: agentic-rdp-logs
+          path: artifacts\agentic-rdp
+          if-no-files-found: warn

--- a/.github/workflows/agentic-rdp.yml
+++ b/.github/workflows/agentic-rdp.yml
@@ -33,35 +33,6 @@ jobs:
       - name: Build ironrdp-agent
         run: cargo build -p ironrdp-agent --release
 
-      - name: Probe test VM RDP endpoint
-        shell: pwsh
-        run: |
-          $artifactsDir = Join-Path $env:GITHUB_WORKSPACE 'artifacts\agentic-rdp'
-          New-Item -Path $artifactsDir -ItemType Directory -Force | Out-Null
-          $hostName = '${{ vars.IRONRDP_AGENT_E2E_HOST }}'
-          if ([string]::IsNullOrWhiteSpace($hostName)) {
-            $hostName = 'IT-HELP-TEST'
-          }
-
-          $addresses = @()
-          try {
-            $addresses = @(Resolve-DnsName -Name $hostName -ErrorAction Stop | Select-Object -ExpandProperty IPAddress -ErrorAction SilentlyContinue)
-          }
-          catch {
-            Write-Warning "DNS lookup failed for ${hostName}: $($_.Exception.Message)"
-          }
-
-          $tcp = Test-NetConnection -ComputerName $hostName -Port 3389 -WarningAction SilentlyContinue
-          [pscustomobject]@{
-            HostName = $hostName
-            Addresses = @($addresses)
-            TcpTestSucceeded = [bool] $tcp.TcpTestSucceeded
-            RemoteAddress = [string] $tcp.RemoteAddress
-            RemotePort = [int] $tcp.RemotePort
-            InterfaceAlias = [string] $tcp.InterfaceAlias
-            SourceAddress = [string] $tcp.SourceAddress
-          } | ConvertTo-Json -Depth 6 | Tee-Object -FilePath (Join-Path $artifactsDir 'test-vm-probe.json')
-
       - name: Run agentic RDP scenario
         shell: pwsh
         run: |

--- a/crates/ironrdp-agent/README.md
+++ b/crates/ironrdp-agent/README.md
@@ -116,6 +116,30 @@ The local DVC endpoint is connected only on a NOW request. Its first readiness d
 seconds; a replacement after a worker/transport failure has a 10-second deadline. No Shell command,
 IPC request, capability, or execution mapping is exposed, even when a remote peer supports Shell.
 
+## Localhost RDP workflow
+
+The manual `.github/workflows/agentic-rdp.yml` workflow builds `ironrdp-agent`, enables localhost
+RDP on a Windows runner, connects at the requested desktop size, drives the desktop through the
+agent, and uploads logs and screenshots. Run the same scenario from an elevated Windows shell with:
+
+```powershell
+cargo build -p ironrdp-agent --release
+.\testing\agentic-rdp\Invoke-AgenticRdpTest.ps1 -DesktopSize 1920x1080
+```
+
+The script temporarily changes local RDP settings and the current user's password. Use it only on a
+disposable test machine.
+
+## Live end-to-end test
+
+The ignored live test uses `IRONRDP_AGENT_E2E_HOST`, `IRONRDP_AGENT_E2E_USERNAME`,
+`IRONRDP_AGENT_E2E_PASSWORD`, and optional `IRONRDP_AGENT_E2E_DOMAIN`:
+
+```powershell
+$env:IRONRDP_AGENT_E2E = '1'
+cargo test -p ironrdp-agent --test live_e2e -- --ignored
+```
+
 [`ironrdp-client`]: ../ironrdp-client
 [`ironrdp-core`]: ../ironrdp-core
 [`ironrdp-propertyset`]: ../ironrdp-propertyset

--- a/crates/ironrdp-agent/tests/ipc.rs
+++ b/crates/ironrdp-agent/tests/ipc.rs
@@ -1,0 +1,78 @@
+#![allow(unused_crate_dependencies)]
+#![allow(clippy::panic)]
+#![allow(clippy::std_instead_of_core)]
+
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn test_endpoint(name: &str) -> String {
+    #[cfg(windows)]
+    {
+        format!(r"\\.\pipe\ironrdp-agent-{name}-{}", std::process::id())
+    }
+
+    #[cfg(unix)]
+    {
+        let path = std::env::temp_dir().join(format!("ironrdp-agent-{name}-{}.sock", std::process::id()));
+        path.display().to_string()
+    }
+}
+
+fn spawn_daemon(endpoint: &str) -> Child {
+    Command::new(env!("CARGO_BIN_EXE_ironrdp-agent"))
+        .arg("--endpoint")
+        .arg(endpoint)
+        .arg("daemon-start")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn daemon")
+}
+
+fn agent(endpoint: &str, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_ironrdp-agent"))
+        .arg("--endpoint")
+        .arg(endpoint)
+        .args(args)
+        .output()
+        .expect("run agent")
+}
+
+fn wait_for_daemon(endpoint: &str) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+
+    while Instant::now() < deadline {
+        let output = agent(endpoint, &["status"]);
+        if output.status.success() {
+            return;
+        }
+
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    panic!("daemon did not become ready");
+}
+
+#[test]
+fn daemon_reports_no_active_session() {
+    let endpoint = test_endpoint("ipc");
+    let mut daemon = spawn_daemon(&endpoint);
+
+    let result = std::panic::catch_unwind(|| {
+        wait_for_daemon(&endpoint);
+
+        let output = agent(&endpoint, &["status"]);
+        assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+
+        let stdout = String::from_utf8(output.stdout).expect("stdout");
+        assert!(stdout.contains("state: NoSession"), "{stdout}");
+    });
+
+    let _ = daemon.kill();
+    let _ = daemon.wait();
+
+    if let Err(error) = result {
+        std::panic::resume_unwind(error);
+    }
+}

--- a/crates/ironrdp-agent/tests/live_e2e.rs
+++ b/crates/ironrdp-agent/tests/live_e2e.rs
@@ -1,0 +1,200 @@
+#![allow(unused_crate_dependencies)]
+#![allow(clippy::panic)]
+#![allow(clippy::std_instead_of_core)]
+
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn test_endpoint(name: &str) -> String {
+    #[cfg(windows)]
+    {
+        format!(r"\\.\pipe\ironrdp-agent-{name}-{}", std::process::id())
+    }
+
+    #[cfg(unix)]
+    {
+        let path = std::env::temp_dir().join(format!("ironrdp-agent-{name}-{}.sock", std::process::id()));
+        path.display().to_string()
+    }
+}
+
+fn spawn_daemon(endpoint: &str) -> Child {
+    Command::new(env!("CARGO_BIN_EXE_ironrdp-agent"))
+        .arg("--endpoint")
+        .arg(endpoint)
+        .arg("daemon-start")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn daemon")
+}
+
+fn agent(endpoint: &str, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_ironrdp-agent"))
+        .arg("--endpoint")
+        .arg(endpoint)
+        .args(args)
+        .output()
+        .expect("run agent")
+}
+
+fn wait_for_daemon(endpoint: &str) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+
+    while Instant::now() < deadline {
+        let output = agent(endpoint, &["status"]);
+        if output.status.success() {
+            return;
+        }
+
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    panic!("daemon did not become ready");
+}
+
+fn env(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|value| !value.is_empty())
+}
+
+fn assert_success(output: &std::process::Output) {
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn wait_for_frame(endpoint: &str) {
+    let deadline = Instant::now() + Duration::from_secs(60);
+
+    while Instant::now() < deadline {
+        let output = agent(endpoint, &["status"]);
+        if output.status.success() && String::from_utf8_lossy(&output.stdout).contains("state: Connected") {
+            return;
+        }
+
+        std::thread::sleep(Duration::from_millis(250));
+    }
+
+    panic!("RDP session did not produce a frame");
+}
+
+fn send_unicode_text(endpoint: &str, text: &str) {
+    for character in text.chars() {
+        let character = character.to_string();
+        assert_success(&agent(
+            endpoint,
+            &["key-unicode", "--char", &character, "--pressed", "true"],
+        ));
+        assert_success(&agent(
+            endpoint,
+            &["key-unicode", "--char", &character, "--pressed", "false"],
+        ));
+    }
+}
+
+#[test]
+#[ignore = "requires a reachable RDP host and IRONRDP_AGENT_E2E_* environment variables"]
+fn connect_launch_browser_and_capture_screenshot() {
+    if env("IRONRDP_AGENT_E2E").as_deref() != Some("1") {
+        return;
+    }
+
+    let host = env("IRONRDP_AGENT_E2E_HOST").expect("IRONRDP_AGENT_E2E_HOST");
+    let username = env("IRONRDP_AGENT_E2E_USERNAME").expect("IRONRDP_AGENT_E2E_USERNAME");
+    let domain = env("IRONRDP_AGENT_E2E_DOMAIN");
+    let password = env("IRONRDP_AGENT_E2E_PASSWORD").expect("IRONRDP_AGENT_E2E_PASSWORD");
+
+    let endpoint = test_endpoint("live");
+    let mut daemon = spawn_daemon(&endpoint);
+    let screenshot = std::env::temp_dir().join(format!("ironrdp-agent-live-{}.png", std::process::id()));
+
+    let result = std::panic::catch_unwind(|| {
+        wait_for_daemon(&endpoint);
+
+        let mut connect_args = vec![
+            "connect",
+            "--server",
+            host.as_str(),
+            "--username",
+            username.as_str(),
+            "--password",
+            password.as_str(),
+            "--prop",
+            "desktopwidth:i:1280",
+            "--prop",
+            "desktopheight:i:720",
+        ];
+        if let Some(domain) = domain.as_deref() {
+            connect_args.push("--domain");
+            connect_args.push(domain);
+        }
+
+        let output = agent(&endpoint, &connect_args);
+        assert_success(&output);
+        wait_for_frame(&endpoint);
+
+        assert_success(&agent(&endpoint, &["mouse-move", "--x", "200", "--y", "200"]));
+        assert_success(&agent(
+            &endpoint,
+            &["mouse-button", "--button", "left", "--pressed", "true"],
+        ));
+        assert_success(&agent(
+            &endpoint,
+            &["mouse-button", "--button", "left", "--pressed", "false"],
+        ));
+
+        assert_success(&agent(
+            &endpoint,
+            &["key-scancode", "--scancode", "0xE05B", "--pressed", "true"],
+        ));
+        assert_success(&agent(
+            &endpoint,
+            &["key-scancode", "--scancode", "0x13", "--pressed", "true"],
+        ));
+        assert_success(&agent(
+            &endpoint,
+            &["key-scancode", "--scancode", "0x13", "--pressed", "false"],
+        ));
+        assert_success(&agent(
+            &endpoint,
+            &["key-scancode", "--scancode", "0xE05B", "--pressed", "false"],
+        ));
+        std::thread::sleep(Duration::from_secs(1));
+        send_unicode_text(&endpoint, "msedge.exe https://example.com");
+        assert_success(&agent(
+            &endpoint,
+            &["key-scancode", "--scancode", "0x1c", "--pressed", "true"],
+        ));
+        assert_success(&agent(
+            &endpoint,
+            &["key-scancode", "--scancode", "0x1c", "--pressed", "false"],
+        ));
+        std::thread::sleep(Duration::from_secs(5));
+
+        assert_success(&agent(
+            &endpoint,
+            &["screenshot", screenshot.to_str().expect("screenshot path")],
+        ));
+        assert_png(&screenshot);
+        assert_success(&agent(&endpoint, &["disconnect"]));
+    });
+
+    let _ = daemon.kill();
+    let _ = daemon.wait();
+    let _ = std::fs::remove_file(&screenshot);
+
+    if let Err(error) = result {
+        std::panic::resume_unwind(error);
+    }
+}
+
+fn assert_png(path: &PathBuf) {
+    let bytes = std::fs::read(path).expect("read screenshot");
+    assert!(bytes.len() > 8);
+    assert_eq!(&bytes[..8], b"\x89PNG\r\n\x1a\n");
+}

--- a/testing/agentic-rdp/Connect-AgentSession.ps1
+++ b/testing/agentic-rdp/Connect-AgentSession.ps1
@@ -1,0 +1,128 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string] $UserName,
+
+    [Parameter(Mandatory)]
+    [string] $Password,
+
+    [string] $HostName = '127.0.0.1',
+
+    [int] $Port = 3389,
+
+    [string] $DesktopSize = '1920x1080',
+
+    [string] $AgentPath = (Join-Path $env:GITHUB_WORKSPACE 'target\release\ironrdp-agent.exe'),
+
+    [string] $Endpoint = "\\.\pipe\ironrdp-agent-ci-$PID",
+
+    [string] $ArtifactsDir = (Join-Path $env:GITHUB_WORKSPACE 'artifacts\agentic-rdp'),
+
+    [string] $StatePath = (Join-Path $ArtifactsDir 'agent-session.json')
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Agent {
+    param(
+        [Parameter(ValueFromRemainingArguments)]
+        [string[]] $Arguments
+    )
+
+    & $AgentPath --endpoint $Endpoint @Arguments
+}
+
+function Get-SessionStatus {
+    $statusOutput = Invoke-Agent status
+    $statusText = $statusOutput -join "`n"
+    $statusText | Set-Content -Path (Join-Path $ArtifactsDir 'agent-session-status.txt') -Encoding utf8NoBOM
+
+    $state = if ($statusText -match '(?m)^state:\s*(\S+)') { $Matches[1] } else { $null }
+    $width = $null
+    $height = $null
+    if ($statusText -match '(?m)^resolution:\s*(\d+)x(\d+)') {
+        $width = [int] $Matches[1]
+        $height = [int] $Matches[2]
+    }
+
+    return [pscustomobject]@{
+        state = $state
+        width = $width
+        height = $height
+    }
+}
+
+function Assert-DesktopSize {
+    param(
+        [Parameter(Mandatory)]
+        [object] $Status,
+
+        [Parameter(Mandatory)]
+        [int] $ExpectedWidth,
+
+        [Parameter(Mandatory)]
+        [int] $ExpectedHeight
+    )
+
+    if ([int] $Status.width -ne $ExpectedWidth -or [int] $Status.height -ne $ExpectedHeight) {
+        throw "RDP framebuffer is $($Status.width)x$($Status.height), expected ${ExpectedWidth}x${ExpectedHeight}"
+    }
+}
+
+New-Item -Path $ArtifactsDir -ItemType Directory -Force | Out-Null
+
+if ($DesktopSize -notmatch '^(?<width>[1-9][0-9]*)[xX](?<height>[1-9][0-9]*)$') {
+    throw "DesktopSize must use WxH format, got '$DesktopSize'"
+}
+
+$expectedWidth = [int] $Matches.width
+$expectedHeight = [int] $Matches.height
+$destination = "${HostName}:$Port"
+$connectOutput = Invoke-Agent connect `
+        --server $destination `
+        --username $UserName `
+        --password $Password `
+        --prop "desktopwidth:i:$expectedWidth" `
+        --prop "desktopheight:i:$expectedHeight" `
+        --prop 'enablecredsspsupport:i:0' `
+        --prop 'ironrdp_autologon:i:1' `
+        --prop 'compression:i:0' `
+        --prop 'ironrdp_colordepth:i:16' `
+        --prop 'ironrdp_serverpointer:i:0'
+$connectOutput | Set-Content -Path (Join-Path $ArtifactsDir 'agent-connect.txt') -Encoding utf8NoBOM
+
+$deadline = (Get-Date).AddSeconds(120)
+do {
+    $status = Get-SessionStatus
+    if ($status.state -eq 'Connected') {
+        break
+    }
+
+    if ($status.state -eq 'Failed') {
+        throw 'RDP connection failed; inspect the agent session log'
+    }
+
+    Start-Sleep -Milliseconds 500
+} while ((Get-Date) -lt $deadline)
+
+if ($status.state -ne 'Connected') {
+    throw 'Timed out waiting for the RDP session to produce a frame'
+}
+
+Assert-DesktopSize -Status $status -ExpectedWidth $expectedWidth -ExpectedHeight $expectedHeight
+
+$state = [pscustomobject]@{
+    SessionId = 'current'
+    Endpoint = $Endpoint
+    HostName = $HostName
+    Port = $Port
+    UserName = $UserName
+    RequestedDesktopSize = $DesktopSize
+    Width = $status.width
+    Height = $status.height
+    StatePath = $StatePath
+}
+
+$state | ConvertTo-Json -Depth 6 | Set-Content -Path $StatePath -Encoding utf8NoBOM
+$state | ConvertTo-Json -Compress

--- a/testing/agentic-rdp/Enable-LocalRdp.ps1
+++ b/testing/agentic-rdp/Enable-LocalRdp.ps1
@@ -1,0 +1,172 @@
+[CmdletBinding(DefaultParameterSetName = 'Enable')]
+param(
+    [Parameter(ParameterSetName = 'Enable')]
+    [Parameter(ParameterSetName = 'Cleanup')]
+    [string] $StatePath = (Join-Path $env:RUNNER_TEMP 'ironrdp-agentic-rdp-state.json'),
+
+    [Parameter(ParameterSetName = 'Cleanup')]
+    [switch] $Cleanup
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$terminalServerPath = 'HKLM:\System\CurrentControlSet\Control\Terminal Server'
+$rdpTcpPath = Join-Path $terminalServerPath 'WinStations\RDP-Tcp'
+$rdpGroupName = 'Remote Desktop Users'
+
+function Get-RegistryValue {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Path,
+
+        [Parameter(Mandatory)]
+        [string] $Name
+    )
+
+    $property = Get-ItemProperty -Path $Path -Name $Name -ErrorAction SilentlyContinue
+    if ($null -eq $property) {
+        return $null
+    }
+
+    return $property.$Name
+}
+
+function Write-JsonFile {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Path,
+
+        [Parameter(Mandatory)]
+        [object] $Value
+    )
+
+    $directory = Split-Path -Path $Path -Parent
+    New-Item -Path $directory -ItemType Directory -Force | Out-Null
+    $Value | ConvertTo-Json -Depth 8 | Set-Content -Path $Path -Encoding utf8NoBOM
+}
+
+function Test-TcpPort {
+    param(
+        [Parameter(Mandatory)]
+        [string] $HostName,
+
+        [Parameter(Mandatory)]
+        [int] $Port
+    )
+
+    $client = [System.Net.Sockets.TcpClient]::new()
+    try {
+        $connect = $client.BeginConnect($HostName, $Port, $null, $null)
+        if (-not $connect.AsyncWaitHandle.WaitOne([TimeSpan]::FromSeconds(1))) {
+            return $false
+        }
+
+        $client.EndConnect($connect)
+        return $true
+    }
+    catch {
+        return $false
+    }
+    finally {
+        $client.Dispose()
+    }
+}
+
+function Wait-TcpPort {
+    param(
+        [Parameter(Mandatory)]
+        [string] $HostName,
+
+        [Parameter(Mandatory)]
+        [int] $Port,
+
+        [int] $TimeoutSeconds = 30
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    do {
+        if (Test-TcpPort -HostName $HostName -Port $Port) {
+            return
+        }
+
+        Start-Sleep -Seconds 1
+    } while ((Get-Date) -lt $deadline)
+
+    throw "Timed out waiting for $HostName`:$Port to accept TCP connections"
+}
+
+if ($Cleanup) {
+    if (-not (Test-Path $StatePath)) {
+        return
+    }
+
+    $state = Get-Content -Path $StatePath -Raw | ConvertFrom-Json
+
+    if ($null -ne $state.fDenyTSConnections) {
+        Set-ItemProperty -Path $terminalServerPath -Name 'fDenyTSConnections' -Value ([int] $state.fDenyTSConnections)
+    }
+
+    if ($null -ne $state.UserAuthentication) {
+        Set-ItemProperty -Path $rdpTcpPath -Name 'UserAuthentication' -Value ([int] $state.UserAuthentication)
+    }
+
+    foreach ($rule in @($state.FirewallRules)) {
+        if ($null -ne $rule.Name -and $null -ne $rule.Enabled) {
+            Set-NetFirewallRule -Name $rule.Name -Enabled $rule.Enabled -ErrorAction SilentlyContinue
+        }
+    }
+
+    if ($state.AddedToRemoteDesktopUsers) {
+        Remove-LocalGroupMember -Group $rdpGroupName -Member $state.LocalUserName -ErrorAction SilentlyContinue
+    }
+
+    Remove-Item -Path $StatePath -Force -ErrorAction SilentlyContinue
+    return
+}
+
+$localUserName = $env:USERNAME
+if ([string]::IsNullOrWhiteSpace($localUserName)) {
+    throw 'USERNAME is not set; cannot configure a local RDP user'
+}
+
+$passwordBytes = [System.Security.Cryptography.RandomNumberGenerator]::GetBytes(24)
+$temporaryPassword = 'RdpAgent!' + [Convert]::ToBase64String($passwordBytes) + 'aA1!'
+Write-Host "::add-mask::$temporaryPassword"
+
+$currentMembers = @(Get-LocalGroupMember -Group $rdpGroupName -ErrorAction SilentlyContinue | ForEach-Object { $_.Name })
+$memberNames = @($localUserName, "$env:COMPUTERNAME\$localUserName")
+$wasRdpMember = [bool]($currentMembers | Where-Object { $memberNames -contains $_ } | Select-Object -First 1)
+
+$state = [pscustomobject]@{
+    LocalUserName = $localUserName
+    DomainUserName = "$env:COMPUTERNAME\$localUserName"
+    fDenyTSConnections = Get-RegistryValue -Path $terminalServerPath -Name 'fDenyTSConnections'
+    UserAuthentication = Get-RegistryValue -Path $rdpTcpPath -Name 'UserAuthentication'
+    FirewallRules = @(Get-NetFirewallRule -DisplayGroup 'Remote Desktop' -ErrorAction SilentlyContinue | Select-Object -Property Name, Enabled)
+    AddedToRemoteDesktopUsers = (-not $wasRdpMember)
+}
+Write-JsonFile -Path $StatePath -Value $state
+
+$securePassword = ConvertTo-SecureString -String $temporaryPassword -AsPlainText -Force
+Set-LocalUser -Name $localUserName -Password $securePassword
+
+if (-not $wasRdpMember) {
+    Add-LocalGroupMember -Group $rdpGroupName -Member $localUserName
+}
+
+Set-ItemProperty -Path $terminalServerPath -Name 'fDenyTSConnections' -Value 0
+Set-ItemProperty -Path $rdpTcpPath -Name 'UserAuthentication' -Value 0
+Set-Service -Name TermService -StartupType Automatic
+Start-Service -Name TermService
+Enable-NetFirewallRule -DisplayGroup 'Remote Desktop' | Out-Null
+Wait-TcpPort -HostName '127.0.0.1' -Port 3389
+
+[pscustomobject]@{
+    UserName = $localUserName
+    DomainUserName = "$env:COMPUTERNAME\$localUserName"
+    Password = $temporaryPassword
+    HostName = '127.0.0.1'
+    Port = 3389
+    StatePath = $StatePath
+} | ConvertTo-Json -Compress

--- a/testing/agentic-rdp/Enable-LocalRdp.ps1
+++ b/testing/agentic-rdp/Enable-LocalRdp.ps1
@@ -2,7 +2,14 @@
 param(
     [Parameter(ParameterSetName = 'Enable')]
     [Parameter(ParameterSetName = 'Cleanup')]
-    [string] $StatePath = (Join-Path $env:RUNNER_TEMP 'ironrdp-agentic-rdp-state.json'),
+    [string] $StatePath = (Join-Path $(
+            if ([string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) {
+                [System.IO.Path]::GetTempPath()
+            }
+            else {
+                $env:RUNNER_TEMP
+            }
+        ) 'ironrdp-agentic-rdp-state.json'),
 
     [Parameter(ParameterSetName = 'Cleanup')]
     [switch] $Cleanup
@@ -111,9 +118,14 @@ if ($Cleanup) {
         Set-ItemProperty -Path $rdpTcpPath -Name 'UserAuthentication' -Value ([int] $state.UserAuthentication)
     }
 
-    foreach ($rule in @($state.FirewallRules)) {
-        if ($null -ne $rule.Name -and $null -ne $rule.Enabled) {
-            Set-NetFirewallRule -Name $rule.Name -Enabled $rule.Enabled -ErrorAction SilentlyContinue
+    if ($state.PSObject.Properties.Name -contains 'FirewallRuleName') {
+        Remove-NetFirewallRule -Name $state.FirewallRuleName -ErrorAction SilentlyContinue
+    }
+    else {
+        foreach ($rule in @($state.FirewallRules)) {
+            if ($null -ne $rule.Name -and $null -ne $rule.Enabled) {
+                Set-NetFirewallRule -Name $rule.Name -Enabled $rule.Enabled -ErrorAction SilentlyContinue
+            }
         }
     }
 
@@ -137,13 +149,14 @@ Write-Host "::add-mask::$temporaryPassword"
 $currentMembers = @(Get-LocalGroupMember -Group $rdpGroupName -ErrorAction SilentlyContinue | ForEach-Object { $_.Name })
 $memberNames = @($localUserName, "$env:COMPUTERNAME\$localUserName")
 $wasRdpMember = [bool]($currentMembers | Where-Object { $memberNames -contains $_ } | Select-Object -First 1)
+$firewallRuleName = "IronRdpAgenticRdp-$PID"
 
 $state = [pscustomobject]@{
     LocalUserName = $localUserName
     DomainUserName = "$env:COMPUTERNAME\$localUserName"
     fDenyTSConnections = Get-RegistryValue -Path $terminalServerPath -Name 'fDenyTSConnections'
     UserAuthentication = Get-RegistryValue -Path $rdpTcpPath -Name 'UserAuthentication'
-    FirewallRules = @(Get-NetFirewallRule -DisplayGroup 'Remote Desktop' -ErrorAction SilentlyContinue | Select-Object -Property Name, Enabled)
+    FirewallRuleName = $firewallRuleName
     AddedToRemoteDesktopUsers = (-not $wasRdpMember)
 }
 Write-JsonFile -Path $StatePath -Value $state
@@ -159,7 +172,14 @@ Set-ItemProperty -Path $terminalServerPath -Name 'fDenyTSConnections' -Value 0
 Set-ItemProperty -Path $rdpTcpPath -Name 'UserAuthentication' -Value 0
 Set-Service -Name TermService -StartupType Automatic
 Start-Service -Name TermService
-Enable-NetFirewallRule -DisplayGroup 'Remote Desktop' | Out-Null
+New-NetFirewallRule `
+    -Name $firewallRuleName `
+    -DisplayName 'IronRDP agentic RDP loopback' `
+    -Direction Inbound `
+    -Action Allow `
+    -Protocol TCP `
+    -LocalPort 3389 `
+    -RemoteAddress '127.0.0.1' | Out-Null
 Wait-TcpPort -HostName '127.0.0.1' -Port 3389
 
 [pscustomobject]@{

--- a/testing/agentic-rdp/Invoke-AgenticDesktopScenario.ps1
+++ b/testing/agentic-rdp/Invoke-AgenticDesktopScenario.ps1
@@ -1,0 +1,139 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string] $SessionId,
+
+    [string] $AgentPath = (Join-Path $env:GITHUB_WORKSPACE 'target\release\ironrdp-agent.exe'),
+
+    [string] $Endpoint = "\\.\pipe\ironrdp-agent-ci-$PID",
+
+    [string] $ArtifactsDir = (Join-Path $env:GITHUB_WORKSPACE 'artifacts\agentic-rdp'),
+
+    [string] $DesktopSize = '1920x1080'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Agent {
+    param(
+        [Parameter(ValueFromRemainingArguments)]
+        [string[]] $Arguments
+    )
+
+    & $AgentPath --endpoint $Endpoint @Arguments
+}
+
+function Get-AgentStatus {
+    $statusText = (Invoke-Agent status) -join "`n"
+    $state = if ($statusText -match '(?m)^state:\s*(\S+)') { $Matches[1] } else { $null }
+    $width = $null
+    $height = $null
+    if ($statusText -match '(?m)^resolution:\s*(\d+)x(\d+)') {
+        $width = [int] $Matches[1]
+        $height = [int] $Matches[2]
+    }
+
+    return [pscustomobject]@{
+        state = $state
+        width = $width
+        height = $height
+    }
+}
+
+function Send-Scancode {
+    param([string] $Scancode, [bool] $Pressed)
+    Invoke-Agent key-scancode --scancode $Scancode --pressed $Pressed.ToString().ToLowerInvariant() | Out-Null
+}
+
+function Send-Text {
+    param([string] $Text)
+    foreach ($character in $Text.ToCharArray()) {
+        Invoke-Agent key-unicode --char ([string] $character) --pressed true | Out-Null
+        Invoke-Agent key-unicode --char ([string] $character) --pressed false | Out-Null
+    }
+}
+
+function Test-PngScreenshot {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Path,
+
+        [Parameter(Mandatory)]
+        [int] $ExpectedWidth,
+
+        [Parameter(Mandatory)]
+        [int] $ExpectedHeight
+    )
+
+    Add-Type -AssemblyName System.Drawing
+    $bitmap = [System.Drawing.Bitmap]::new($Path)
+    try {
+        if ($bitmap.Width -ne $ExpectedWidth -or $bitmap.Height -ne $ExpectedHeight) {
+            throw "Screenshot is $($bitmap.Width)x$($bitmap.Height), expected ${ExpectedWidth}x${ExpectedHeight}"
+        }
+
+        $firstPixel = $bitmap.GetPixel(0, 0).ToArgb()
+        $hasDifferentPixel = $false
+        $stepX = [Math]::Max(1, [Math]::Floor($bitmap.Width / 64))
+        $stepY = [Math]::Max(1, [Math]::Floor($bitmap.Height / 64))
+
+        for ($y = 0; $y -lt $bitmap.Height; $y += $stepY) {
+            for ($x = 0; $x -lt $bitmap.Width; $x += $stepX) {
+                if ($bitmap.GetPixel($x, $y).ToArgb() -ne $firstPixel) {
+                    $hasDifferentPixel = $true
+                    break
+                }
+            }
+
+            if ($hasDifferentPixel) {
+                break
+            }
+        }
+
+        if (-not $hasDifferentPixel) {
+            throw 'Screenshot appears uniform; the framebuffer is likely blank'
+        }
+    }
+    finally {
+        $bitmap.Dispose()
+    }
+}
+
+New-Item -Path $ArtifactsDir -ItemType Directory -Force | Out-Null
+
+if ($DesktopSize -notmatch '^(?<width>[1-9][0-9]*)[xX](?<height>[1-9][0-9]*)$') {
+    throw "DesktopSize must use WxH format, got '$DesktopSize'"
+}
+
+$expectedWidth = [int] $Matches.width
+$expectedHeight = [int] $Matches.height
+
+Invoke-Agent mouse-move --x 200 --y 200 | Out-Null
+Invoke-Agent mouse-button --button left --pressed true | Out-Null
+Invoke-Agent mouse-button --button left --pressed false | Out-Null
+Send-Scancode -Scancode '0xE05B' -Pressed $true
+Send-Scancode -Scancode '0x13' -Pressed $true
+Send-Scancode -Scancode '0x13' -Pressed $false
+Send-Scancode -Scancode '0xE05B' -Pressed $false
+Start-Sleep -Seconds 1
+Send-Text -Text 'msedge.exe about:blank'
+Send-Scancode -Scancode '0x1c' -Pressed $true
+Send-Scancode -Scancode '0x1c' -Pressed $false
+
+Start-Sleep -Seconds 8
+
+$screenshotPath = Join-Path $ArtifactsDir 'agent-desktop.png'
+Invoke-Agent screenshot $screenshotPath | Out-Null
+Test-PngScreenshot -Path $screenshotPath -ExpectedWidth $expectedWidth -ExpectedHeight $expectedHeight
+
+$finalStatus = Get-AgentStatus
+$result = [pscustomobject]@{
+    SessionId = $SessionId
+    Width = $finalStatus.width
+    Height = $finalStatus.height
+    ScreenshotPath = $screenshotPath
+}
+
+$result | ConvertTo-Json -Depth 6 | Set-Content -Path (Join-Path $ArtifactsDir 'agentic-desktop-scenario.json') -Encoding utf8NoBOM
+$result | ConvertTo-Json -Compress

--- a/testing/agentic-rdp/Invoke-AgenticRdpTest.ps1
+++ b/testing/agentic-rdp/Invoke-AgenticRdpTest.ps1
@@ -5,9 +5,18 @@ param(
 
     [string] $DesktopSize = '1920x1080',
 
-    [string] $AgentPath = (Join-Path $env:GITHUB_WORKSPACE 'target\release\ironrdp-agent.exe'),
+    [string] $WorkspaceRoot = $(
+        if ([string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE)) {
+            [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..'))
+        }
+        else {
+            $env:GITHUB_WORKSPACE
+        }
+    ),
 
-    [string] $ArtifactsDir = (Join-Path $env:GITHUB_WORKSPACE 'artifacts\agentic-rdp'),
+    [string] $AgentPath = (Join-Path $WorkspaceRoot 'target\release\ironrdp-agent.exe'),
+
+    [string] $ArtifactsDir = (Join-Path $WorkspaceRoot 'artifacts\agentic-rdp'),
 
     [switch] $CleanupOnly
 )

--- a/testing/agentic-rdp/Invoke-AgenticRdpTest.ps1
+++ b/testing/agentic-rdp/Invoke-AgenticRdpTest.ps1
@@ -1,0 +1,221 @@
+[CmdletBinding()]
+param(
+    [ValidateSet('rdp', 'daemon', 'connect', 'remoting-server', 'remote-command', 'desktop-scenario')]
+    [string] $MaxStage = 'desktop-scenario',
+
+    [string] $DesktopSize = '1920x1080',
+
+    [string] $AgentPath = (Join-Path $env:GITHUB_WORKSPACE 'target\release\ironrdp-agent.exe'),
+
+    [string] $ArtifactsDir = (Join-Path $env:GITHUB_WORKSPACE 'artifacts\agentic-rdp'),
+
+    [switch] $CleanupOnly
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$stageOrder = @('rdp', 'daemon', 'connect', 'remoting-server', 'remote-command', 'desktop-scenario')
+$maxStageIndex = [array]::IndexOf($stageOrder, $MaxStage)
+$scriptsRoot = $PSScriptRoot
+$endpoint = "\\.\pipe\ironrdp-agent-ci-$PID"
+$rdpStatePath = Join-Path $ArtifactsDir 'rdp-state.json'
+$daemonStatePath = Join-Path $ArtifactsDir 'agent-daemon.json'
+$sessionStatePath = Join-Path $ArtifactsDir 'agent-session.json'
+$psHostEndpointPath = Join-Path $ArtifactsDir 'pshost-endpoint.json'
+$taskName = 'IronRdpAgenticPSHost'
+$psHostPort = 45985
+
+function Test-ShouldRunStage {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Stage
+    )
+
+    return ([array]::IndexOf($stageOrder, $Stage) -le $maxStageIndex)
+}
+
+function Stop-ProcessFromState {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Path
+    )
+
+    if (-not (Test-Path $Path)) {
+        return
+    }
+
+    $state = Get-Content -Path $Path -Raw | ConvertFrom-Json
+    if ($null -eq $state.ProcessId) {
+        return
+    }
+
+    $process = Get-Process -Id ([int] $state.ProcessId) -ErrorAction SilentlyContinue
+    if ($null -ne $process) {
+        Stop-Process -Id $process.Id -Force
+    }
+}
+
+function Invoke-Agent {
+    param(
+        [Parameter(ValueFromRemainingArguments)]
+        [string[]] $Arguments
+    )
+
+    & $AgentPath --endpoint $endpoint @Arguments
+}
+
+function Invoke-Cleanup {
+    Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction SilentlyContinue
+
+    if (Test-Path $sessionStatePath) {
+        $sessionState = Get-Content -Path $sessionStatePath -Raw | ConvertFrom-Json
+        try {
+            Invoke-Agent disconnect | Out-Null
+        }
+        catch {
+            Write-Warning "Could not disconnect the agent session: $($_.Exception.Message)"
+        }
+    }
+
+    try {
+        Stop-ProcessFromState -Path $daemonStatePath
+    }
+    catch {
+        Write-Warning "Could not stop agent daemon: $($_.Exception.Message)"
+    }
+
+    if (Test-Path $psHostEndpointPath) {
+        $endpointInfo = Get-Content -Path $psHostEndpointPath -Raw | ConvertFrom-Json
+        if ($endpointInfo.PSObject.Properties.Name -contains 'ProcessId') {
+            $process = Get-Process -Id ([int] $endpointInfo.ProcessId) -ErrorAction SilentlyContinue
+            if ($null -ne $process) {
+                Stop-Process -Id $process.Id -Force
+            }
+        }
+    }
+
+    try {
+        & (Join-Path $scriptsRoot 'Enable-LocalRdp.ps1') -Cleanup -StatePath $rdpStatePath
+    }
+    catch {
+        Write-Warning "Could not restore local RDP settings: $($_.Exception.Message)"
+    }
+}
+
+if ($CleanupOnly) {
+    Invoke-Cleanup
+    return
+}
+
+New-Item -Path $ArtifactsDir -ItemType Directory -Force | Out-Null
+$rdpInfo = $null
+$sessionInfo = $null
+
+try {
+    if (Test-ShouldRunStage -Stage 'rdp') {
+        Write-Host '::group::Enable local RDP'
+        $rdpInfoJson = & (Join-Path $scriptsRoot 'Enable-LocalRdp.ps1') -StatePath $rdpStatePath
+        $rdpInfo = $rdpInfoJson | ConvertFrom-Json
+        Write-Host '::endgroup::'
+    }
+
+    if (Test-ShouldRunStage -Stage 'daemon') {
+        Write-Host '::group::Start ironrdp-agent daemon'
+        & (Join-Path $scriptsRoot 'Start-AgentDaemon.ps1') `
+            -AgentPath $AgentPath `
+            -Endpoint $endpoint `
+            -ArtifactsDir $ArtifactsDir `
+            -StatePath $daemonStatePath | Write-Host
+        Write-Host '::endgroup::'
+    }
+
+    if (Test-ShouldRunStage -Stage 'remoting-server') {
+        Write-Host '::group::Register interactive PSHostServer'
+        & (Join-Path $scriptsRoot 'Start-InteractivePSHostServer.ps1') `
+            -Register `
+            -EndpointPath $psHostEndpointPath `
+            -Port $psHostPort `
+            -ArtifactsDir $ArtifactsDir `
+            -TaskName $taskName | Write-Host
+        Write-Host '::endgroup::'
+    }
+
+    if (Test-ShouldRunStage -Stage 'connect') {
+        if ($null -eq $rdpInfo) {
+            throw 'RDP stage did not produce connection information'
+        }
+
+        Write-Host '::group::Connect ironrdp-agent session'
+        $sessionJson = & (Join-Path $scriptsRoot 'Connect-AgentSession.ps1') `
+            -AgentPath $AgentPath `
+            -Endpoint $endpoint `
+            -UserName $rdpInfo.DomainUserName `
+            -Password $rdpInfo.Password `
+            -HostName $rdpInfo.HostName `
+            -Port ([int] $rdpInfo.Port) `
+            -DesktopSize $DesktopSize `
+            -ArtifactsDir $ArtifactsDir `
+            -StatePath $sessionStatePath
+        $sessionInfo = $sessionJson | ConvertFrom-Json
+        Write-Host $sessionJson
+        Write-Host '::endgroup::'
+    }
+
+    if (Test-ShouldRunStage -Stage 'remoting-server') {
+        Write-Host '::group::Start interactive PSHostServer task'
+        Start-ScheduledTask -TaskName $taskName
+        Start-Sleep -Seconds 5
+        Get-ScheduledTask -TaskName $taskName | Get-ScheduledTaskInfo | Format-List | Out-String | Write-Host
+        Write-Host '::endgroup::'
+
+        Write-Host '::group::Wait for interactive PSHostServer'
+        & (Join-Path $scriptsRoot 'Start-InteractivePSHostServer.ps1') `
+            -Wait `
+            -EndpointPath $psHostEndpointPath `
+            -TimeoutSeconds 180 | Write-Host
+        Write-Host '::endgroup::'
+    }
+
+    if (Test-ShouldRunStage -Stage 'remote-command') {
+        Write-Host '::group::Verify interactive remoting'
+        & (Join-Path $scriptsRoot 'Invoke-InteractiveCommand.ps1') `
+            -Mode Verify `
+            -EndpointPath $psHostEndpointPath `
+            -ArtifactsDir $ArtifactsDir | Write-Host
+        Write-Host '::endgroup::'
+    }
+
+    if (Test-ShouldRunStage -Stage 'desktop-scenario') {
+        if ($null -eq $sessionInfo) {
+            throw 'Connect stage did not produce session information'
+        }
+
+        Write-Host '::group::Run agentic desktop scenario'
+        & (Join-Path $scriptsRoot 'Invoke-AgenticDesktopScenario.ps1') `
+            -AgentPath $AgentPath `
+            -Endpoint $endpoint `
+            -SessionId $sessionInfo.SessionId `
+            -ArtifactsDir $ArtifactsDir `
+            -DesktopSize $DesktopSize | Write-Host
+        Write-Host '::endgroup::'
+    }
+}
+catch {
+    Write-Host '::error::Agentic RDP test failed'
+    if ($null -ne $sessionInfo) {
+        try {
+            $failureScreenshotPath = Join-Path $ArtifactsDir 'agent-failure.png'
+            Invoke-Agent screenshot $failureScreenshotPath | Out-Null
+            Write-Warning "Captured failure screenshot at $failureScreenshotPath"
+        }
+        catch {
+            Write-Warning "Could not capture failure screenshot: $($_.Exception.Message)"
+        }
+    }
+
+    throw
+}
+finally {
+    Invoke-Cleanup
+}

--- a/testing/agentic-rdp/Invoke-InteractiveCommand.ps1
+++ b/testing/agentic-rdp/Invoke-InteractiveCommand.ps1
@@ -1,0 +1,52 @@
+[CmdletBinding()]
+param(
+    [ValidateSet('Verify')]
+    [string] $Mode = 'Verify',
+
+    [string] $EndpointPath = (Join-Path $env:GITHUB_WORKSPACE 'artifacts\agentic-rdp\pshost-endpoint.json'),
+
+    [string] $ArtifactsDir = (Join-Path $env:GITHUB_WORKSPACE 'artifacts\agentic-rdp')
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $EndpointPath)) {
+    throw "Endpoint marker was not found: $EndpointPath"
+}
+
+New-Item -Path $ArtifactsDir -ItemType Directory -Force | Out-Null
+Import-Module AwakeCoding.PSRemoting -ErrorAction Stop
+
+$endpoint = Get-Content -Path $EndpointPath -Raw | ConvertFrom-Json
+$session = New-PSHostSession -HostName $endpoint.HostName -Port ([int] $endpoint.Port)
+
+try {
+    $result = Invoke-Command -Session $session -ScriptBlock {
+        $process = Get-Process -Id $PID
+        $notepad = Start-Process -FilePath (Join-Path $env:WINDIR 'System32\notepad.exe') -PassThru
+        Start-Sleep -Seconds 3
+        $notepadProcess = Get-Process -Id $notepad.Id -ErrorAction Stop
+        Stop-Process -Id $notepad.Id -Force
+
+        [pscustomobject]@{
+            ProcessId = $PID
+            SessionId = $process.SessionId
+            UserName = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+            UserInteractive = [Environment]::UserInteractive
+            Desktop = $env:USERPROFILE
+            GuiProbeProcessId = $notepadProcess.Id
+            GuiProbeSessionId = $notepadProcess.SessionId
+        }
+    }
+
+    if (-not $result.UserInteractive) {
+        throw 'Remote command did not report an interactive user session'
+    }
+
+    $result | ConvertTo-Json -Depth 6 | Set-Content -Path (Join-Path $ArtifactsDir 'remote-command-verification.json') -Encoding utf8NoBOM
+    $result | ConvertTo-Json -Compress
+}
+finally {
+    Remove-PSSession -Session $session -ErrorAction SilentlyContinue
+}

--- a/testing/agentic-rdp/Invoke-InteractiveCommand.ps1
+++ b/testing/agentic-rdp/Invoke-InteractiveCommand.ps1
@@ -3,9 +3,18 @@ param(
     [ValidateSet('Verify')]
     [string] $Mode = 'Verify',
 
-    [string] $EndpointPath = (Join-Path $env:GITHUB_WORKSPACE 'artifacts\agentic-rdp\pshost-endpoint.json'),
+    [string] $WorkspaceRoot = $(
+        if ([string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE)) {
+            [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..'))
+        }
+        else {
+            $env:GITHUB_WORKSPACE
+        }
+    ),
 
-    [string] $ArtifactsDir = (Join-Path $env:GITHUB_WORKSPACE 'artifacts\agentic-rdp')
+    [string] $EndpointPath = (Join-Path $WorkspaceRoot 'artifacts\agentic-rdp\pshost-endpoint.json'),
+
+    [string] $ArtifactsDir = (Join-Path $WorkspaceRoot 'artifacts\agentic-rdp')
 )
 
 Set-StrictMode -Version Latest

--- a/testing/agentic-rdp/Start-AgentDaemon.ps1
+++ b/testing/agentic-rdp/Start-AgentDaemon.ps1
@@ -1,0 +1,66 @@
+[CmdletBinding()]
+param(
+    [string] $AgentPath = (Join-Path $env:GITHUB_WORKSPACE 'target\release\ironrdp-agent.exe'),
+
+    [string] $Endpoint = "\\.\pipe\ironrdp-agent-ci-$PID",
+
+    [string] $ArtifactsDir = (Join-Path $env:GITHUB_WORKSPACE 'artifacts\agentic-rdp'),
+
+    [string] $StatePath = (Join-Path $ArtifactsDir 'agent-daemon.json'),
+
+    [string] $LogLevel = 'debug'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Agent {
+    param(
+        [Parameter(ValueFromRemainingArguments)]
+        [string[]] $Arguments
+    )
+
+    & $AgentPath --endpoint $Endpoint @Arguments
+}
+
+New-Item -Path $ArtifactsDir -ItemType Directory -Force | Out-Null
+
+$stdoutPath = Join-Path $ArtifactsDir 'ironrdp-agent.stdout.log'
+$stderrPath = Join-Path $ArtifactsDir 'ironrdp-agent.stderr.log'
+
+$previousLogFilter = $env:IRONRDP_LOG
+$env:IRONRDP_LOG = $LogLevel
+try {
+    $process = Start-Process `
+        -FilePath $AgentPath `
+        -ArgumentList @('--endpoint', $Endpoint, 'daemon-start') `
+        -RedirectStandardOutput $stdoutPath `
+        -RedirectStandardError $stderrPath `
+        -PassThru
+}
+finally {
+    $env:IRONRDP_LOG = $previousLogFilter
+}
+
+$deadline = (Get-Date).AddSeconds(30)
+do {
+    try {
+        Invoke-Agent status | Out-Null
+        $state = [pscustomobject]@{
+            ProcessId = $process.Id
+            Endpoint = $Endpoint
+            AgentPath = $AgentPath
+            LogPath = $stderrPath
+            StandardOutputPath = $stdoutPath
+            StandardErrorPath = $stderrPath
+        }
+        $state | ConvertTo-Json -Depth 4 | Set-Content -Path $StatePath -Encoding utf8NoBOM
+        $state | ConvertTo-Json -Compress
+        return
+    }
+    catch {
+        Start-Sleep -Milliseconds 250
+    }
+} while ((Get-Date) -lt $deadline)
+
+throw "Timed out waiting for ironrdp-agent daemon on $Endpoint"

--- a/testing/agentic-rdp/Start-AgentDaemon.ps1
+++ b/testing/agentic-rdp/Start-AgentDaemon.ps1
@@ -1,10 +1,19 @@
 [CmdletBinding()]
 param(
-    [string] $AgentPath = (Join-Path $env:GITHUB_WORKSPACE 'target\release\ironrdp-agent.exe'),
+    [string] $WorkspaceRoot = $(
+        if ([string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE)) {
+            [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..'))
+        }
+        else {
+            $env:GITHUB_WORKSPACE
+        }
+    ),
+
+    [string] $AgentPath = (Join-Path $WorkspaceRoot 'target\release\ironrdp-agent.exe'),
 
     [string] $Endpoint = "\\.\pipe\ironrdp-agent-ci-$PID",
 
-    [string] $ArtifactsDir = (Join-Path $env:GITHUB_WORKSPACE 'artifacts\agentic-rdp'),
+    [string] $ArtifactsDir = (Join-Path $WorkspaceRoot 'artifacts\agentic-rdp'),
 
     [string] $StatePath = (Join-Path $ArtifactsDir 'agent-daemon.json'),
 
@@ -42,19 +51,20 @@ finally {
     $env:IRONRDP_LOG = $previousLogFilter
 }
 
+$state = [pscustomobject]@{
+    ProcessId = $process.Id
+    Endpoint = $Endpoint
+    AgentPath = $AgentPath
+    LogPath = $stderrPath
+    StandardOutputPath = $stdoutPath
+    StandardErrorPath = $stderrPath
+}
+$state | ConvertTo-Json -Depth 4 | Set-Content -Path $StatePath -Encoding utf8NoBOM
+
 $deadline = (Get-Date).AddSeconds(30)
 do {
     try {
         Invoke-Agent status | Out-Null
-        $state = [pscustomobject]@{
-            ProcessId = $process.Id
-            Endpoint = $Endpoint
-            AgentPath = $AgentPath
-            LogPath = $stderrPath
-            StandardOutputPath = $stdoutPath
-            StandardErrorPath = $stderrPath
-        }
-        $state | ConvertTo-Json -Depth 4 | Set-Content -Path $StatePath -Encoding utf8NoBOM
         $state | ConvertTo-Json -Compress
         return
     }
@@ -62,5 +72,14 @@ do {
         Start-Sleep -Milliseconds 250
     }
 } while ((Get-Date) -lt $deadline)
+
+try {
+    if (-not $process.HasExited) {
+        Stop-Process -Id $process.Id -Force
+    }
+}
+catch {
+    Write-Warning "Could not stop ironrdp-agent after startup timeout: $($_.Exception.Message)"
+}
 
 throw "Timed out waiting for ironrdp-agent daemon on $Endpoint"

--- a/testing/agentic-rdp/Start-InteractivePSHostServer.ps1
+++ b/testing/agentic-rdp/Start-InteractivePSHostServer.ps1
@@ -1,0 +1,150 @@
+[CmdletBinding(DefaultParameterSetName = 'Register')]
+param(
+    [Parameter(ParameterSetName = 'Register')]
+    [switch] $Register,
+
+    [Parameter(ParameterSetName = 'RunServer')]
+    [switch] $RunServer,
+
+    [Parameter(ParameterSetName = 'Wait')]
+    [switch] $Wait,
+
+    [Parameter(ParameterSetName = 'Register')]
+    [Parameter(ParameterSetName = 'RunServer')]
+    [Parameter(ParameterSetName = 'Wait')]
+    [string] $EndpointPath = (Join-Path $env:GITHUB_WORKSPACE 'artifacts\agentic-rdp\pshost-endpoint.json'),
+
+    [Parameter(ParameterSetName = 'Register')]
+    [Parameter(ParameterSetName = 'RunServer')]
+    [int] $Port = 45985,
+
+    [Parameter(ParameterSetName = 'Register')]
+    [Parameter(ParameterSetName = 'RunServer')]
+    [string] $ArtifactsDir = (Join-Path $env:GITHUB_WORKSPACE 'artifacts\agentic-rdp'),
+
+    [Parameter(ParameterSetName = 'Register')]
+    [string] $TaskName = 'IronRdpAgenticPSHost',
+
+    [Parameter(ParameterSetName = 'Wait')]
+    [int] $TimeoutSeconds = 120
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Ensure-AwakeCodingModule {
+    if (Get-Module -ListAvailable -Name AwakeCoding.PSRemoting) {
+        return
+    }
+
+    $repository = Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue
+    if ($null -ne $repository -and $repository.InstallationPolicy -ne 'Trusted') {
+        Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+    }
+
+    $installModuleParameters = @{
+        Name = 'AwakeCoding.PSRemoting'
+        Scope = 'CurrentUser'
+        Repository = 'PSGallery'
+        Force = $true
+        AllowClobber = $true
+    }
+
+    if ((Get-Command Install-Module).Parameters.ContainsKey('AcceptLicense')) {
+        $installModuleParameters['AcceptLicense'] = $true
+    }
+
+    Install-Module @installModuleParameters
+}
+
+if ($Register) {
+    New-Item -Path $ArtifactsDir -ItemType Directory -Force | Out-Null
+    Remove-Item -Path $EndpointPath -Force -ErrorAction SilentlyContinue
+    Ensure-AwakeCodingModule
+
+    $pwshPath = (Get-Command pwsh -ErrorAction Stop).Source
+    $actionArguments = @(
+        '-NoLogo',
+        '-NoProfile',
+        '-ExecutionPolicy', 'Bypass',
+        '-File', "`"$PSCommandPath`"",
+        '-RunServer',
+        '-EndpointPath', "`"$EndpointPath`"",
+        '-Port', $Port,
+        '-ArtifactsDir', "`"$ArtifactsDir`""
+    ) -join ' '
+
+    $taskAction = New-ScheduledTaskAction -Execute $pwshPath -Argument $actionArguments
+    $taskTrigger = New-ScheduledTaskTrigger -AtLogOn -User "$env:COMPUTERNAME\$env:USERNAME"
+    $taskPrincipal = New-ScheduledTaskPrincipal -UserId "$env:COMPUTERNAME\$env:USERNAME" -LogonType Interactive -RunLevel Highest
+    $taskSettings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -ExecutionTimeLimit ([TimeSpan]::Zero)
+    Register-ScheduledTask -TaskName $TaskName -Action $taskAction -Trigger $taskTrigger -Principal $taskPrincipal -Settings $taskSettings -Force | Out-Null
+
+    [pscustomobject]@{
+        TaskName = $TaskName
+        EndpointPath = $EndpointPath
+        Port = $Port
+    } | ConvertTo-Json -Compress
+    return
+}
+
+if ($RunServer) {
+    New-Item -Path $ArtifactsDir -ItemType Directory -Force | Out-Null
+    $serverLogPath = Join-Path $ArtifactsDir 'pshost-server.log'
+
+    try {
+        Start-Transcript -Path $serverLogPath -Force | Out-Null
+        Import-Module AwakeCoding.PSRemoting -ErrorAction Stop
+        $server = Start-PSHostServer -TransportType TCP -Port $Port
+        $process = Get-Process -Id $PID
+
+        [pscustomobject]@{
+            Transport = 'TCP'
+            HostName = '127.0.0.1'
+            Port = $Port
+            ProcessId = $PID
+            SessionId = $process.SessionId
+            UserName = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+            State = [string] $server.State
+            StartedAt = (Get-Date).ToString('o')
+        } | ConvertTo-Json -Depth 4 | Set-Content -Path $EndpointPath -Encoding utf8NoBOM
+
+        while ($true) {
+            Start-Sleep -Seconds 5
+            $current = Get-PSHostServer -Port $Port -ErrorAction SilentlyContinue
+            if ($null -eq $current -or [string] $current.State -ne 'Running') {
+                throw "PSHostServer on port $Port is no longer running"
+            }
+        }
+    }
+    catch {
+        [pscustomobject]@{
+            Error = $_.Exception.Message
+            ProcessId = $PID
+            FailedAt = (Get-Date).ToString('o')
+        } | ConvertTo-Json -Depth 4 | Set-Content -Path $EndpointPath -Encoding utf8NoBOM
+        throw
+    }
+    finally {
+        Stop-Transcript -ErrorAction SilentlyContinue | Out-Null
+    }
+}
+
+if ($Wait) {
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    do {
+        if (Test-Path $EndpointPath) {
+            $endpoint = Get-Content -Path $EndpointPath -Raw | ConvertFrom-Json
+            if ($endpoint.PSObject.Properties.Name -contains 'Error') {
+                throw "Interactive PSHostServer failed: $($endpoint.Error)"
+            }
+
+            $endpoint | ConvertTo-Json -Compress
+            return
+        }
+
+        Start-Sleep -Seconds 2
+    } while ((Get-Date) -lt $deadline)
+
+    throw "Timed out waiting for interactive PSHostServer endpoint marker: $EndpointPath"
+}

--- a/testing/agentic-rdp/Start-InteractivePSHostServer.ps1
+++ b/testing/agentic-rdp/Start-InteractivePSHostServer.ps1
@@ -12,7 +12,19 @@ param(
     [Parameter(ParameterSetName = 'Register')]
     [Parameter(ParameterSetName = 'RunServer')]
     [Parameter(ParameterSetName = 'Wait')]
-    [string] $EndpointPath = (Join-Path $env:GITHUB_WORKSPACE 'artifacts\agentic-rdp\pshost-endpoint.json'),
+    [string] $WorkspaceRoot = $(
+        if ([string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE)) {
+            [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\..'))
+        }
+        else {
+            $env:GITHUB_WORKSPACE
+        }
+    ),
+
+    [Parameter(ParameterSetName = 'Register')]
+    [Parameter(ParameterSetName = 'RunServer')]
+    [Parameter(ParameterSetName = 'Wait')]
+    [string] $EndpointPath = (Join-Path $WorkspaceRoot 'artifacts\agentic-rdp\pshost-endpoint.json'),
 
     [Parameter(ParameterSetName = 'Register')]
     [Parameter(ParameterSetName = 'RunServer')]
@@ -20,7 +32,7 @@ param(
 
     [Parameter(ParameterSetName = 'Register')]
     [Parameter(ParameterSetName = 'RunServer')]
-    [string] $ArtifactsDir = (Join-Path $env:GITHUB_WORKSPACE 'artifacts\agentic-rdp'),
+    [string] $ArtifactsDir = (Join-Path $WorkspaceRoot 'artifacts\agentic-rdp'),
 
     [Parameter(ParameterSetName = 'Register')]
     [string] $TaskName = 'IronRdpAgenticPSHost',


### PR DESCRIPTION
## Summary

- Add `ironrdp-agent`, a daemon-backed CLI for agentic/headless RDP automation over local IPC
- Add mouse, keyboard, resize, wait-frame, screenshot, status, sessions, connect/disconnect commands
- Support `.rdp` files, logging controls, and `--desktop-size WxH`
- Add a push/manual Windows workflow that enables localhost RDP, drives `ironrdp-agent`, verifies PSRemoting, and uploads screenshot/log artifacts

## Validation

- `cargo check -p ironrdp-agent`
- `cargo test -p ironrdp-agent`
- `cargo clippy -p ironrdp-agent --all-targets -- -D warnings`
- `cargo xtask check fmt -v`
- `cargo test -p ironrdp-agent --test ipc`
- PowerShell script parse checks
- GitHub Actions Agentic RDP workflow passed on push: run `26121877104`
  - Connected to localhost RDP at `127.0.0.1:3389`
  - Verified `1920x1080` framebuffer
  - Uploaded non-blank screenshot artifact

## Notes

Full workspace `cargo xtask check lints -v` / `cargo xtask check tests --no-run -v` were blocked locally by the existing Windows `libopus_sys` CMake generator issue (`Visual Studio 18 2026`), unrelated to the agent crate path.
