### PR TITLE
ci(fuzz): discover fuzz targets dynamically

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -34,14 +34,33 @@ jobs:
             ./fuzz/artifacts
           key: fuzz-corpus-${{ github.run_id }}
 
+  fuzz-setup:
+    name: Fuzz matrix setup
+    needs: [corpus-download]
+    runs-on: ubuntu-latest
+    outputs:
+      fuzz-matrix: ${{ steps.setup-matrix.outputs.fuzz-matrix }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2.7.3
+
+      - name: Setup matrix
+        id: setup-matrix
+        run: |
+          MATRIX="$(cargo xtask fuzz list --format github-matrix)"
+          echo "fuzz-matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
   fuzz:
     name: Fuzzing ${{ matrix.target }}
-    needs: [corpus-download]
+    needs: [corpus-download, fuzz-setup]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        target: [pdu_decoding, rle_decompression, bitmap_stream, cliprdr_format, cliprdr_channel_processing, channel_processing]
+        include: ${{ fromJson(needs.fuzz-setup.outputs.fuzz-matrix) }}
 
     steps:
       - uses: actions/checkout@v6

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -34,6 +34,8 @@ TASKS:
                           Minify fuzzing corpus for a specific target (or all if unspecified)
   fuzz corpus-push        Push fuzzing corpus to Azure storage
   fuzz install            Install dependencies required for fuzzing
+  fuzz list [--format <FMT>]
+                          List fuzz targets (fmt: human (default) | github-matrix)
   fuzz run [--duration <SECONDS>] [--target <NAME>]
                           Fuzz a specific target if any or all targets for a limited duration (default is 5s)
   wasm check              Ensure WASM module is compatible for the web
@@ -91,6 +93,9 @@ pub enum Action {
     },
     FuzzCorpusPush,
     FuzzInstall,
+    FuzzList {
+        format: Option<String>,
+    },
     FuzzRun {
         duration: Option<u32>,
         target: Option<String>,
@@ -157,6 +162,9 @@ pub fn parse_args() -> anyhow::Result<Args> {
                 },
                 Some("corpus-push") => Action::FuzzCorpusPush,
                 Some("install") => Action::FuzzInstall,
+                Some("list") => Action::FuzzList {
+                    format: args.opt_value_from_str("--format")?,
+                },
                 Some("run") => Action::FuzzRun {
                     duration: args.opt_value_from_str("--duration")?,
                     target: args.opt_value_from_str("--target")?,

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -155,9 +155,7 @@ pub fn parse_args() -> anyhow::Result<Args> {
                 Some("features") => Action::CheckFeatures {
                     case: args.opt_value_from_str("--case")?,
                     list: args.contains("--list"),
-                    format: args
-                        .opt_value_from_str("--format")?
-                        .unwrap_or(ListFormat::DEFAULT),
+                    format: args.opt_value_from_str("--format")?.unwrap_or(ListFormat::DEFAULT),
                 },
                 Some("install") => Action::CheckInstall,
                 Some(unknown) => anyhow::bail!("unknown check action: {unknown}"),
@@ -186,9 +184,7 @@ pub fn parse_args() -> anyhow::Result<Args> {
                 Some("corpus-push") => Action::FuzzCorpusPush,
                 Some("install") => Action::FuzzInstall,
                 Some("list") => Action::FuzzList {
-                    format: args
-                        .opt_value_from_str("--format")?
-                        .unwrap_or(ListFormat::DEFAULT),
+                    format: args.opt_value_from_str("--format")?.unwrap_or(ListFormat::DEFAULT),
                 },
                 Some("run") => Action::FuzzRun {
                     duration: args.opt_value_from_str("--duration")?,

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -59,6 +59,27 @@ pub struct Args {
     pub action: Action,
 }
 
+pub enum ListFormat {
+    Human,
+    GithubMatrix,
+}
+
+impl ListFormat {
+    pub const DEFAULT: Self = Self::Human;
+}
+
+impl core::str::FromStr for ListFormat {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> anyhow::Result<Self> {
+        match value {
+            "human" => Ok(Self::Human),
+            "github-matrix" => Ok(Self::GithubMatrix),
+            other => anyhow::bail!("unknown --format value: {other}"),
+        }
+    }
+}
+
 pub enum Action {
     ShowHelp,
     Bootstrap,
@@ -72,7 +93,7 @@ pub enum Action {
     CheckFeatures {
         case: Option<String>,
         list: bool,
-        format: Option<String>,
+        format: ListFormat,
     },
     CheckInstall,
     Ci,
@@ -94,7 +115,7 @@ pub enum Action {
     FuzzCorpusPush,
     FuzzInstall,
     FuzzList {
-        format: Option<String>,
+        format: ListFormat,
     },
     FuzzRun {
         duration: Option<u32>,
@@ -134,7 +155,9 @@ pub fn parse_args() -> anyhow::Result<Args> {
                 Some("features") => Action::CheckFeatures {
                     case: args.opt_value_from_str("--case")?,
                     list: args.contains("--list"),
-                    format: args.opt_value_from_str("--format")?,
+                    format: args
+                        .opt_value_from_str("--format")?
+                        .unwrap_or(ListFormat::DEFAULT),
                 },
                 Some("install") => Action::CheckInstall,
                 Some(unknown) => anyhow::bail!("unknown check action: {unknown}"),
@@ -163,7 +186,9 @@ pub fn parse_args() -> anyhow::Result<Args> {
                 Some("corpus-push") => Action::FuzzCorpusPush,
                 Some("install") => Action::FuzzInstall,
                 Some("list") => Action::FuzzList {
-                    format: args.opt_value_from_str("--format")?,
+                    format: args
+                        .opt_value_from_str("--format")?
+                        .unwrap_or(ListFormat::DEFAULT),
                 },
                 Some("run") => Action::FuzzRun {
                     duration: args.opt_value_from_str("--duration")?,

--- a/xtask/src/cov.rs
+++ b/xtask/src/cov.rs
@@ -184,7 +184,7 @@ pub fn grcov(sh: &Shell) -> anyhow::Result<()> {
 
         cmd!(sh, "{CARGO} clean").run()?;
 
-        for target in FUZZ_TARGETS {
+        for target in crate::fuzz::discover_targets()? {
             cmd!(sh, "rustup run {NIGHTLY_TOOLCHAIN} cargo fuzz coverage {target}").run()?;
         }
 

--- a/xtask/src/fuzz.rs
+++ b/xtask/src/fuzz.rs
@@ -1,5 +1,38 @@
+use std::collections::HashMap;
+
+use tinyjson::JsonValue;
+
 use crate::prelude::*;
 // NOTE: cargo-fuzz (libFuzzer) does not support Windows yet (coming soon?)
+
+/// Enumerate fuzz targets by scanning `fuzz/fuzz_targets/*.rs`.
+///
+/// The fuzz targets directory is the single source of truth: each `.rs` file
+/// there is a libFuzzer binary registered in `fuzz/Cargo.toml`. Discovering
+/// them dynamically means the CI matrix picks up new targets automatically.
+pub fn discover_targets() -> anyhow::Result<Vec<String>> {
+    let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(1)
+        .context("retrieve project root path")?
+        .join("fuzz")
+        .join("fuzz_targets");
+
+    let mut targets: Vec<String> = std::fs::read_dir(&dir)
+        .with_context(|| format!("read fuzz targets directory: {}", dir.display()))?
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            let path = entry.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+                return None;
+            }
+            path.file_stem().and_then(|stem| stem.to_str()).map(str::to_owned)
+        })
+        .collect();
+
+    targets.sort();
+    Ok(targets)
+}
 
 pub fn corpus_minify(sh: &Shell, target: Option<String>) -> anyhow::Result<()> {
     let _s = Section::new("FUZZ-CORPUS-MINIFY");
@@ -7,15 +40,12 @@ pub fn corpus_minify(sh: &Shell, target: Option<String>) -> anyhow::Result<()> {
 
     let _guard = sh.push_dir("./fuzz");
 
-    let target_from_user = target.as_deref().map(|value| [value]);
-
-    let targets = if let Some(targets) = &target_from_user {
-        targets
-    } else {
-        FUZZ_TARGETS
+    let targets = match target {
+        Some(value) => vec![value],
+        None => discover_targets()?,
     };
 
-    for target in targets {
+    for target in &targets {
         cmd!(sh, "rustup run {NIGHTLY_TOOLCHAIN} cargo fuzz cmin {target}").run()?;
     }
 
@@ -72,15 +102,12 @@ pub fn run(sh: &Shell, duration: Option<u32>, target: Option<String>) -> anyhow:
     let _guard = sh.push_dir("./fuzz");
 
     let duration = duration.unwrap_or(5).to_string();
-    let target_from_user = target.as_deref().map(|value| [value]);
-
-    let targets = if let Some(targets) = &target_from_user {
-        targets
-    } else {
-        FUZZ_TARGETS
+    let targets = match target {
+        Some(value) => vec![value],
+        None => discover_targets()?,
     };
 
-    for target in targets {
+    for target in &targets {
         cmd!(
             sh,
             "rustup run {NIGHTLY_TOOLCHAIN} cargo fuzz run {target} -- -max_total_time={duration} -timeout=10"
@@ -90,5 +117,34 @@ pub fn run(sh: &Shell, duration: Option<u32>, target: Option<String>) -> anyhow:
 
     println!("All good!");
 
+    Ok(())
+}
+
+/// Print each fuzz target, one per line. Useful for local discovery.
+pub fn list_human() -> anyhow::Result<()> {
+    for target in discover_targets()? {
+        println!("{target}");
+    }
+    Ok(())
+}
+
+/// Emit a `matrix.include`-compatible JSON array on stdout. CI consumes this
+/// via `fromJson(steps.setup.outputs.fuzz-matrix)` to fan out one job per
+/// fuzz target without hardcoding the list in the workflow.
+pub fn list_github_matrix() -> anyhow::Result<()> {
+    let items: Vec<JsonValue> = discover_targets()?
+        .into_iter()
+        .map(|name| {
+            let mut obj = HashMap::new();
+            obj.insert("target".to_owned(), JsonValue::String(name));
+            JsonValue::Object(obj)
+        })
+        .collect();
+
+    let json = JsonValue::Array(items);
+    let stringified = json
+        .stringify()
+        .context("serialize fuzz matrix include array as JSON")?;
+    println!("{stringified}");
     Ok(())
 }

--- a/xtask/src/fuzz.rs
+++ b/xtask/src/fuzz.rs
@@ -20,9 +20,13 @@ pub fn discover_targets() -> anyhow::Result<Vec<String>> {
 
     let mut targets: Vec<String> = std::fs::read_dir(&dir)
         .with_context(|| format!("read fuzz targets directory: {}", dir.display()))?
-        .filter_map(|entry| {
-            let entry = entry.ok()?;
-            let path = entry.path();
+        .map(|entry| {
+            let entry = entry.with_context(|| format!("read entry in {}", dir.display()))?;
+            Ok(entry.path())
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?
+        .into_iter()
+        .filter_map(|path| {
             if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
                 return None;
             }
@@ -128,9 +132,15 @@ pub fn list_human() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Emit a `matrix.include`-compatible JSON array on stdout. CI consumes this
-/// via `fromJson(steps.setup.outputs.fuzz-matrix)` to fan out one job per
-/// fuzz target without hardcoding the list in the workflow.
+/// Emit a `matrix.include`-compatible JSON array on stdout, one entry per
+/// discovered fuzz target. Suitable for piping into a GitHub Actions matrix:
+///
+/// ```yaml
+/// - id: setup
+///   run: echo "fuzz-matrix=$(cargo xtask fuzz list --format github-matrix)" >> "$GITHUB_OUTPUT"
+/// ```
+///
+/// Each entry has the shape `{ "target": "<name>" }`.
 pub fn list_github_matrix() -> anyhow::Result<()> {
     let items: Vec<JsonValue> = discover_targets()?
         .into_iter()

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -75,10 +75,9 @@ fn main() -> anyhow::Result<()> {
         }
         Action::CheckFeatures { case, list, format } => {
             if list {
-                match format.as_deref() {
-                    Some("github-matrix") => features::list_github_matrix()?,
-                    Some("human") | None => features::list_human()?,
-                    Some(other) => anyhow::bail!("unknown --format value: {other}"),
+                match format {
+                    cli::ListFormat::Human => features::list_human()?,
+                    cli::ListFormat::GithubMatrix => features::list_github_matrix()?,
                 }
             } else if let Some(case_name) = case {
                 features::run_case(&sh, &case_name)?;
@@ -112,10 +111,9 @@ fn main() -> anyhow::Result<()> {
         Action::FuzzCorpusMin { target } => fuzz::corpus_minify(&sh, target)?,
         Action::FuzzCorpusPush => fuzz::corpus_push(&sh)?,
         Action::FuzzInstall => fuzz::install(&sh)?,
-        Action::FuzzList { format } => match format.as_deref() {
-            Some("github-matrix") => fuzz::list_github_matrix()?,
-            Some("human") | None => fuzz::list_human()?,
-            Some(other) => anyhow::bail!("unknown --format value: {other}"),
+        Action::FuzzList { format } => match format {
+            cli::ListFormat::Human => fuzz::list_human()?,
+            cli::ListFormat::GithubMatrix => fuzz::list_github_matrix()?,
         },
         Action::FuzzRun { duration, target } => fuzz::run(&sh, duration, target)?,
         Action::WasmCheck => wasm::check(&sh)?,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -34,19 +34,6 @@ pub const CARGO: &str = env!("CARGO");
 
 pub const WASM_PACKAGES: &[&str] = &["ironrdp-web"];
 
-pub const FUZZ_TARGETS: &[&str] = &[
-    "pdu_decoding",
-    "rle_decompression",
-    "bitmap_stream",
-    "cliprdr_format",
-    "cliprdr_channel_processing",
-    "channel_processing",
-    "bulk_mppc",
-    "bulk_ncrush",
-    "bulk_xcrush",
-    "bulk_round_trip",
-];
-
 fn main() -> anyhow::Result<()> {
     let args = match cli::parse_args() {
         Ok(args) => args,
@@ -125,6 +112,11 @@ fn main() -> anyhow::Result<()> {
         Action::FuzzCorpusMin { target } => fuzz::corpus_minify(&sh, target)?,
         Action::FuzzCorpusPush => fuzz::corpus_push(&sh)?,
         Action::FuzzInstall => fuzz::install(&sh)?,
+        Action::FuzzList { format } => match format.as_deref() {
+            Some("github-matrix") => fuzz::list_github_matrix()?,
+            Some("human") | None => fuzz::list_human()?,
+            Some(other) => anyhow::bail!("unknown --format value: {other}"),
+        },
         Action::FuzzRun { duration, target } => fuzz::run(&sh, duration, target)?,
         Action::WasmCheck => wasm::check(&sh)?,
         Action::WasmInstall => wasm::install(&sh)?,

--- a/xtask/src/prelude.rs
+++ b/xtask/src/prelude.rs
@@ -5,4 +5,4 @@ pub use crate::bin_install::{cargo_install, is_installed};
 pub use crate::bin_version::*;
 pub(crate) use crate::macros::{run_cmd_in, trace, windows_skip};
 pub use crate::section::Section;
-pub use crate::{CARGO, FUZZ_TARGETS, WASM_PACKAGES, is_verbose, list_files};
+pub use crate::{CARGO, WASM_PACKAGES, is_verbose, list_files};


### PR DESCRIPTION
Mirror the `check features` pattern: expose `cargo xtask fuzz list` (with `--format github-matrix`) that enumerates fuzz targets by scanning `fuzz/fuzz_targets/*.rs`, and have the fuzz workflow build its matrix from that output. New targets dropped into the directory are picked up by CI automatically, with no workflow edits required.