### PR TITLE
fix(server): drop raw user_data dump from McsMessage::SendDataRequest debug log

### DIFF
--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -1178,7 +1178,12 @@ impl RdpServer {
         let message = decode::<X224<mcs::McsMessage<'_>>>(frame)?;
         match message.0 {
             mcs::McsMessage::SendDataRequest(data) => {
-                debug!(?data, "McsMessage::SendDataRequest");
+                debug!(
+                    initiator_id = data.initiator_id,
+                    channel_id = data.channel_id,
+                    user_data_len = data.user_data.len(),
+                    "McsMessage::SendDataRequest"
+                );
                 if data.channel_id == io_channel_id {
                     return self.handle_io_channel_data(data).await;
                 }


### PR DESCRIPTION
## Summary

- `debug!(?data, "McsMessage::SendDataRequest")` invoked derived `Debug` on `SendDataRequest<'a>`, formatting `user_data: Cow<'a, [u8]>` as a decimal byte sequence.
- At DEBUG level this produced multi-hundred-byte log lines per MCS request, including every keystroke / mouse event / channel message.
- The raw bytes aren't actionable at this layer (channel processors log their own decoded PDUs); channel id, initiator, and payload length are.

## Validation

- `cargo xtask check fmt/lints/tests/typos/locks` all pass.
- One log statement changed; no API or behavior change.

## Notes

- Per STYLE.md "Logging" section: structured fields are preferred over whole-struct `?data` dumps.
- `user_data_len` field name matches existing `response_len` precedent in `ironrdp-async`, `ironrdp-acceptor`, `ironrdp-blocking`.