### PR TITLE
fix(egfx): tolerate unknown capability versions instead of failing decode

### DIFF
--- a/crates/ironrdp-egfx/src/pdu/cmd.rs
+++ b/crates/ironrdp-egfx/src/pdu/cmd.rs
@@ -1593,11 +1593,24 @@ impl<'de> Decode<'de> for CapabilitySet {
     fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
         ensure_fixed_part_size!(in: src);
 
-        let version = CapabilityVersion::try_from(src.read_u32())?;
+        let version_raw = src.read_u32();
         let data_length: usize = cast_length!("dataLength", src.read_u32())?;
 
         ensure_size!(in: src, size: data_length);
         let data = src.read_slice(data_length);
+
+        // Tolerate capability versions this build doesn't recognize instead of
+        // failing the whole PDU. A strict error here aborts decoding of the
+        // entire CapabilitiesAdvertise during EGFX negotiation, which can
+        // prevent a connection from being established at all when a client
+        // advertises a capset version outside the set enumerated below
+        // (observed with the macOS "Windows App" / Microsoft Remote Desktop
+        // client). Preserving the raw bytes as `Unknown` lets negotiation
+        // complete so the server can still select a mutually supported version.
+        let Ok(version) = CapabilityVersion::try_from(version_raw) else {
+            return Ok(CapabilitySet::Unknown(data.to_vec()));
+        };
+
         let mut cur = ReadCursor::new(data);
 
         let size = match version {


### PR DESCRIPTION
`CapabilitySet::decode` propagated `CapabilityVersion::try_from`'s error via `?`, so a single unrecognized capability version aborted decoding of the entire CapabilitiesAdvertise PDU during EGFX negotiation.

Some clients advertise a capset version outside the enumerated set — notably the macOS "Windows App" / Microsoft Remote Desktop client — which made the EGFX channel fail to negotiate and could prevent the connection from being established at all when the server enables EGFX.

The `CapabilitySet::Unknown(Vec<u8>)` variant already exists and round-trips raw bytes through `encode`/`size`. This routes the unrecognized-version case into it instead of erroring, so negotiation completes and the server can still select a mutually supported capability version.

Verified against a real macOS Windows App client connecting to an EGFX/AVC420 server: without this change the connection aborts during negotiation; with it, negotiation completes and H.264 renders.