### PR TITLE
feat(cliprdr): always set FD_PROGRESSUI in FileDescriptor::encode

### DIFF
--- a/crates/ironrdp-cliprdr/src/pdu/format_data/file_list.rs
+++ b/crates/ironrdp-cliprdr/src/pdu/format_data/file_list.rs
@@ -151,7 +151,14 @@ impl Encode for FileDescriptor {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         ensure_fixed_part_size!(in: dst);
 
-        let mut flags = ClipboardFileFlags::empty();
+        // Always advertise FD_PROGRESSUI (SHOW_PROGRESS_UI = 0x4000) so the
+        // remote knows it MAY show a progress indicator for this file. The
+        // flag is benign if the remote doesn't honor it; for clipboard file
+        // paste into Windows Explorer it is the actual trigger that makes
+        // the native "Copying… items" progress dialog appear (otherwise the
+        // paste falls back to a synchronous IStream read with no progress
+        // UI, only a busy cursor — same UX as pasting an Outlook attachment).
+        let mut flags = ClipboardFileFlags::SHOW_PROGRESS_UI;
         if self.attributes.is_some() {
             flags |= ClipboardFileFlags::ATTRIBUTES;
         }


### PR DESCRIPTION
Set `ClipboardFileFlags::SHOW_PROGRESS_UI` (FD_PROGRESSUI = 0x4000) on every emitted `FILEDESCRIPTORW`. The flag hints to the remote that a progress indicator should be shown for the copy.

### Why this matters

This flag is what makes **Windows Explorer show its native "Copying… items" progress dialog** when a file pasted via CLIPRDR is dropped into a local Explorer window. Without it, Explorer falls back to a plain synchronous `IStream` read with no progress UI — only a busy cursor — even for large files. (Same UX as pasting an Outlook attachment, which uses the same `CFSTR_FILECONTENTS` path.)

The flag is benign if the remote doesn't honor it, so always setting it on encode is safe and matches the intent of an `initiate_file_copy` operation.

### Use case / verification

Verified end-to-end in [macrdp](https://github.com/clintcan/macrdp), a Rust RDP server for macOS, during clipboard file copy development:

- Without this flag: copying a file in the Mac Finder (via an in-session view), minimizing mstsc, and pasting in local Windows Explorer → file copies, but the user sees only a busy cursor for the duration. No native progress dialog.
- With this flag: same workflow → native "Copying… items" progress dialog appears, file copies promptly.

This is the canonical Windows clipboard-file-paste UX that users expect when copying from any remote source.

### Related

Pairs naturally with [`CFSTR_PREFERREDDROPEFFECT` advertising in `initiate_file_copy`](https://github.com/Devolutions/IronRDP/pull/_TBD_) — together they produce the full "native progress UI on clipboard file paste" behavior — but is independently useful and can be merged on its own.