### PR TITLE
feat(cliprdr): add CliprdrBackend::on_format_list_response(ok) hook

### DIFF
--- a/crates/ironrdp-cliprdr/src/backend.rs
+++ b/crates/ironrdp-cliprdr/src/backend.rs
@@ -83,6 +83,23 @@ pub trait CliprdrBackend: AsAny + core::fmt::Debug + Send {
     /// client's clipboard prior to `CLIPRDR` SVC initialization.
     fn on_request_format_list(&mut self);
 
+    /// Called by [`crate::Cliprdr`] when the remote responds to a `FormatList` we
+    /// sent (i.e. an outbound advertise of our own clipboard contents).
+    ///
+    /// `ok = true` means the remote accepted the list (`CB_RESPONSE_OK`);
+    /// `ok = false` means it rejected it (`CB_RESPONSE_FAIL`), and
+    /// [`crate::Cliprdr`] has already cleared
+    /// `local_file_list` / `local_file_list_format_id` per MS-RDPECLIP 3.1.5.2.4.
+    ///
+    /// Backends can use this to retry on `Fail` (e.g. ride out a transient
+    /// rejection caused by the remote window being inactive at the instant we
+    /// advertised) and, equally important, to **stop** re-advertising once an
+    /// `Ok` is seen — a later blind re-advertise that gets rejected would wipe
+    /// already-accepted state and silently break a paste that was about to work.
+    ///
+    /// Default impl is a no-op, so this is non-breaking for existing backends.
+    fn on_format_list_response(&mut self, _ok: bool) {}
+
     /// Adjusts [crate::Cliprdr] backend capabilities based on capabilities negotiated with a server.
     ///
     /// Called by [crate::Cliprdr] when capability negotiation is finished and server capabilities are

--- a/crates/ironrdp-cliprdr/src/backend.rs
+++ b/crates/ironrdp-cliprdr/src/backend.rs
@@ -96,8 +96,6 @@ pub trait CliprdrBackend: AsAny + core::fmt::Debug + Send {
     /// advertised) and, equally important, to **stop** re-advertising once an
     /// `Ok` is seen — a later blind re-advertise that gets rejected would wipe
     /// already-accepted state and silently break a paste that was about to work.
-    ///
-    /// Default impl is a no-op, so this is non-breaking for existing backends.
     fn on_format_list_response(&mut self, ok: bool) {
         let _ = ok;
     }

--- a/crates/ironrdp-cliprdr/src/backend.rs
+++ b/crates/ironrdp-cliprdr/src/backend.rs
@@ -98,7 +98,9 @@ pub trait CliprdrBackend: AsAny + core::fmt::Debug + Send {
     /// already-accepted state and silently break a paste that was about to work.
     ///
     /// Default impl is a no-op, so this is non-breaking for existing backends.
-    fn on_format_list_response(&mut self, _ok: bool) {}
+    fn on_format_list_response(&mut self, ok: bool) {
+        let _ = ok;
+    }
 
     /// Adjusts [crate::Cliprdr] backend capabilities based on capabilities negotiated with a server.
     ///

--- a/crates/ironrdp-cliprdr/src/lib.rs
+++ b/crates/ironrdp-cliprdr/src/lib.rs
@@ -619,6 +619,7 @@ impl<R: Role> Cliprdr<R> {
                         info!("Remote accepted format list");
                     }
                 }
+                self.backend.on_format_list_response(true);
             }
             FormatListResponse::Fail => {
                 // [MS-RDPECLIP] 3.1.5.2.4 - The remote rejected our FormatList but the
@@ -645,6 +646,7 @@ impl<R: Role> Cliprdr<R> {
 
                     self.sent_file_contents_requests.clear();
                 }
+                self.backend.on_format_list_response(false);
             }
         }
 


### PR DESCRIPTION
Add a non-breaking backend hook that fires when the remote responds to a `FormatList` we sent (an outbound advertise of our own clipboard contents):

```rust
fn on_format_list_response(&mut self, _ok: bool) {}
```

Called from `handle_format_list_response` on both branches:
- `Ok`  → `on_format_list_response(true)`
- `Fail` → `on_format_list_response(false)` *(after `Cliprdr` has cleared `local_file_list` per MS-RDPECLIP 3.1.5.2.4)*

Default impl is a no-op, so this is non-breaking for existing backends.

### Why

Without this signal, a backend has no way to learn whether an outbound `FormatList` was accepted or rejected. That's a real problem because the `Fail` branch silently wipes `local_file_list` / `local_file_list_format_id` per the spec — so a rejected advertise breaks the paste with **no recovery and no way to detect it**.

Worse: a naive timed-retry strategy can actively **wipe** an already-`Ok` state by sending a follow-up advertise that happens to be rejected. Observed live (without the hook, so no way to stop):

```
advertise #1 → Fail
advertise #2 (retry) → Ok (file present on remote clipboard)
advertise #3 (retry) → Fail   ← wiped the accepted state from #2
                                paste then fails
```

With the hook, a backend can retry on `Fail` **and** stop the moment `Ok` arrives, preserving the success.

### Use case / verification

Used in [macrdp](https://github.com/clintcan/macrdp) (a Rust RDP server for macOS) to implement reliable Mac→Windows file copy. mstsc commonly rejects the first `FormatList` right after an in-session `Cmd-C` (it's still processing the input) and accepts one ~0.5–1s later. With this hook, the macrdp poller's retry loop fires retries on `Fail` and stops on `Ok` (via a shared generation/locked-gen pair), fixing the silent-paste-failure case while still recovering from a transient initial `Fail`. Verified end-to-end with real mstsc.

### Related

Pairs naturally with the upcoming `PreferredDropEffect` and `FD_PROGRESSUI` PRs to deliver the full "Mac→Windows clipboard file paste with native progress dialog" UX, but is independently useful and can be merged on its own.