### PR TITLE
feat(dvc): close channel API for server and client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2568,7 +2568,6 @@ dependencies = [
  "ironrdp-core",
  "ironrdp-pdu",
  "ironrdp-svc",
- "slab",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,9 +253,9 @@ checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
 name = "asn1-rs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -347,15 +347,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -363,9 +363,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -518,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
@@ -609,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -862,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "coreaudio-rs"
-version = "0.14.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15c3c3cee7c087938f7ad1c3098840b3ef1f1bdc7f6e496336c3b1e7a6f3914"
+checksum = "7d5d7dca3ebcf65a035582c9ad4385371a9d9ee6537474d2a278f4e1e475bb58"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
@@ -1102,10 +1102,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor-lite"
-version = "0.1.2"
+name = "ctor"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e162d0c2e2068eb736b71e5597eff0b9944e6b973cd9f37b6a288ab9bf20e300"
+checksum = "83cf0d42651b16c6dfe68685716d18480d18a9c39c62d76e8cf3eb6ed5d8bcbf"
+dependencies = [
+ "dtor",
+]
 
 [[package]]
 name = "ctr"
@@ -1167,9 +1170,9 @@ checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
@@ -1433,6 +1436,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtor"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edf234dd1594d6dd434a8fb8cada51ddbbc593e40e4a01556a0b31c62da2775b"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1485,9 +1494,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
@@ -1554,9 +1563,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fdeflate"
@@ -1767,9 +1776,9 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -1930,9 +1939,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1969,9 +1978,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heapless"
@@ -2063,9 +2072,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.9"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a79f2aff40c18ab8615ddc5caa9eb5b96314aef18fe5823090f204ad988e813"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "subtle",
  "typenum",
@@ -2095,15 +2104,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -2177,12 +2185,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -2190,9 +2199,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2203,9 +2212,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2217,15 +2226,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -2237,15 +2246,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2269,9 +2278,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2292,9 +2301,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -2329,16 +2338,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "iron-remote-desktop"
@@ -2378,7 +2377,7 @@ dependencies = [
  "ironrdp-svc",
  "opus2",
  "pico-args",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sspi",
  "tokio-rustls",
  "tracing",
@@ -2537,7 +2536,7 @@ dependencies = [
  "picky",
  "picky-asn1-der",
  "picky-asn1-x509",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sspi",
  "tracing",
  "url",
@@ -3119,9 +3118,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3186,14 +3185,14 @@ dependencies = [
  "bitflags 2.11.1",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
 name = "libz-sys"
-version = "1.1.25"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3220,9 +3219,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -3241,9 +3240,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru-slab"
@@ -3450,9 +3449,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -3888,15 +3887,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -3920,9 +3918,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -3941,9 +3939,9 @@ dependencies = [
 
 [[package]]
 name = "orbclient"
-version = "0.3.51"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59aed3b33578edcfa1bc96a321d590d31832b6ad55a26f0313362ce687e9abd6"
+checksum = "5df339f526ea9a60e371768d50efc2f2508c7203290731565d1f7a6f71d21747"
 dependencies = [
  "libc",
  "libredox",
@@ -4219,18 +4217,18 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4281,9 +4279,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -4363,14 +4361,14 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be97d76faf1bfab666e1375477b23fde79eccf0276e9b63b92a39d676a889ba9"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -4456,7 +4454,7 @@ dependencies = [
  "bit-vec",
  "bitflags 2.11.1",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -4467,9 +4465,9 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "qoicoubeh"
@@ -4488,9 +4486,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
@@ -4524,7 +4522,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -4573,9 +4571,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4584,9 +4582,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4711,9 +4709,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -4959,9 +4957,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4996,9 +4994,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -5006,9 +5004,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -5186,9 +5184,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -5220,9 +5218,9 @@ dependencies = [
 
 [[package]]
 name = "serdect"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9af4a3e75ebd5599b30d4de5768e00b5095d518a79fefc3ecbaf77e665d1ec06"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
 dependencies = [
  "base16ct",
  "serde",
@@ -5764,12 +5762,12 @@ dependencies = [
 
 [[package]]
 name = "tiny-xlib"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0324504befd01cab6e0c994f34b2ffa257849ee019d3fb3b64fb2c858887d89e"
+checksum = "a90a0ca3ee6a69f2ad28fd11621a4c3f03b371f366be500b64df260c4ffbafb4"
 dependencies = [
  "as-raw-xcb-connection",
- "ctor-lite",
+ "ctor",
  "libloading",
  "pkg-config",
  "tracing",
@@ -5783,9 +5781,9 @@ checksum = "9ab95735ea2c8fd51154d01e39cf13912a78071c2d89abc49a7ef102a7dd725a"
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -5942,9 +5940,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.8+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -5984,20 +5982,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -6127,7 +6125,7 @@ dependencies = [
  "httparse",
  "log",
  "native-tls",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
  "sha1 0.10.6",
@@ -6136,9 +6134,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unarray"
@@ -6310,9 +6308,9 @@ dependencies = [
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
  "wit-bindgen",
 ]
@@ -6328,9 +6326,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6341,9 +6339,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.65"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6351,9 +6349,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6361,9 +6359,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6374,18 +6372,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa75f400b7f719bcd68b3f47cd939ba654cedeef690f486db71331eec4c6a406"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -6397,9 +6395,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.13"
+version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab51d9f7c071abeee76007e2b742499e535148035bb835f97aaed1338cf516c3"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
  "bitflags 2.11.1",
  "rustix 1.1.4",
@@ -6420,9 +6418,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-cursor"
-version = "0.31.13"
+version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b3298683470fbdc6ca40151dfc48c8f2fd4c41a26e13042f801f85002384091"
+checksum = "4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d"
 dependencies = [
  "rustix 1.1.4",
  "wayland-client",
@@ -6431,9 +6429,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.11"
+version = "0.32.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b23b5df31ceff1328f06ac607591d5ba360cf58f90c8fad4ac8d3a55a3c4aec7"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
 dependencies = [
  "bitflags 2.11.1",
  "wayland-backend",
@@ -6443,9 +6441,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-plasma"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d392fc283a87774afc9beefcd6f931582bb97fe0e6ced0b306a62cb1d026527c"
+checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
 dependencies = [
  "bitflags 2.11.1",
  "wayland-backend",
@@ -6456,9 +6454,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78248e4cc0eff8163370ba5c158630dcae1f3497a586b826eca2ef5f348d6235"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
  "bitflags 2.11.1",
  "wayland-backend",
@@ -6469,9 +6467,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.9"
+version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86287151a309799b821ca709b7345a048a2956af05957c89cb824ab919fa4e3"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -6480,9 +6478,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.10"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374f6b70e8e0d6bf9461a32988fd553b59ff630964924dad6e4a4eb6bd538d17"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
  "dlib",
  "log",
@@ -6492,9 +6490,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.92"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6512,9 +6510,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6985,9 +6983,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -7004,9 +7002,9 @@ dependencies = [
 
 [[package]]
 name = "winscard"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4395eea3e74c69a89c5b9fd63d7b7446ddbcf8d7381b70791f8e28939dbef18b"
+checksum = "339bcf57dd0c2341c7ac559b146a4d7e35378cefe3d8729bf028820e856bd578"
 dependencies = [
  "bitflags 2.11.1",
  "crypto-bigint",
@@ -7022,19 +7020,20 @@ dependencies = [
  "time",
  "tracing",
  "uuid",
+ "widestring",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"
@@ -7158,9 +7157,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -7169,9 +7168,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7210,18 +7209,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7251,9 +7250,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -7262,9 +7261,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -7273,9 +7272,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/ironrdp-dvc/Cargo.toml
+++ b/crates/ironrdp-dvc/Cargo.toml
@@ -25,7 +25,6 @@ ironrdp-core = { path = "../ironrdp-core", version = "0.1", features = ["alloc"]
 ironrdp-svc = { path = "../ironrdp-svc", version = "0.6" } # public
 ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.7", features = ["alloc"] } # public
 tracing = { version = "0.1", features = ["log"] }
-slab = "0.4"
 
 [lints]
 workspace = true

--- a/crates/ironrdp-dvc/src/client.rs
+++ b/crates/ironrdp-dvc/src/client.rs
@@ -215,7 +215,17 @@ impl SvcProcessor for DrdynvcClient {
 
                 let (creation_status, start_messages) =
                     if let Some(dvc) = self.dynamic_channels.try_create_channel(&channel_name, channel_id) {
-                        (CreationStatus::OK, dvc.start()?)
+                        match dvc.start(channel_id) {
+                            Ok(messages) => (CreationStatus::OK, messages),
+                            Err(e) => {
+                                debug!(
+                                    ?channel_id, error = %e,
+                                    "DVC start failed; removing channel and reporting NO_LISTENER"
+                                );
+                                self.dynamic_channels.remove_by_channel_id(channel_id);
+                                (CreationStatus::NO_LISTENER, Vec::new())
+                            }
+                        }
                     } else {
                         (CreationStatus::NO_LISTENER, Vec::new())
                     };
@@ -316,8 +326,9 @@ impl DynamicChannelSet {
             self.type_id_to_channel_id.insert(type_id, channel_id);
         }
 
-        let mut dvc = DynamicVirtualChannel::from_boxed(processor);
-        dvc.channel_id = Some(channel_id);
+        let dvc = DynamicVirtualChannel::from_boxed(processor);
+        // `dvc.channel_id` stays `None` here — it is set by `DynamicVirtualChannel::start`
+        // on success, so `Drop` only invokes `close` for channels that were actually opened.
         let dvc = match self.active_channels.entry(channel_id) {
             alloc::collections::btree_map::Entry::Occupied(mut e) => {
                 e.insert(dvc);

--- a/crates/ironrdp-dvc/src/client.rs
+++ b/crates/ironrdp-dvc/src/client.rs
@@ -167,6 +167,11 @@ impl DrdynvcClient {
         self.cap_handshake_done = true;
         SvcMessage::from(caps_response)
     }
+
+    pub fn close_channel(&mut self, channel_id: u32) -> SvcMessage {
+        self.dynamic_channels.remove_by_channel_id(channel_id);
+        SvcMessage::from(DrdynvcClientPdu::Close(ClosePdu::new(channel_id)))
+    }
 }
 
 impl_as_any!(DrdynvcClient);

--- a/crates/ironrdp-dvc/src/client.rs
+++ b/crates/ironrdp-dvc/src/client.rs
@@ -227,14 +227,14 @@ impl SvcProcessor for DrdynvcClient {
                     );
                 }
             }
-            DrdynvcServerPdu::Close(close_request) => {
-                debug!("Got DVC Close Request PDU: {close_request:?}");
-                self.dynamic_channels.remove_by_channel_id(close_request.channel_id());
-
-                let close_response = DrdynvcClientPdu::Close(ClosePdu::new(close_request.channel_id()));
-
-                debug!("Send DVC Close Response PDU: {close_response:?}");
-                responses.push(SvcMessage::from(close_response));
+            DrdynvcServerPdu::Close(close) => {
+                debug!("Got DVC Close PDU: {close:?}");
+                let channel_id = close.channel_id();
+                if self.dynamic_channels.remove_by_channel_id(channel_id).is_some() {
+                    let close_response = DrdynvcClientPdu::Close(ClosePdu::new(channel_id));
+                    debug!("Send DVC Close Response PDU: {close_response:?}");
+                    responses.push(SvcMessage::from(close_response));
+                }
             }
             DrdynvcServerPdu::Data(data) => {
                 let channel_id = data.channel_id();
@@ -337,8 +337,8 @@ impl DynamicChannelSet {
         self.active_channels.get_mut(&id)
     }
 
-    fn remove_by_channel_id(&mut self, id: DynamicChannelId) {
-        if let Some(dvc) = self.active_channels.remove(&id) {
+    fn remove_by_channel_id(&mut self, id: DynamicChannelId) -> Option<DynamicVirtualChannel> {
+        self.active_channels.remove(&id).inspect(|dvc| {
             let type_id = dvc.processor_type_id();
 
             // Only matters for pre-registered channels
@@ -347,7 +347,7 @@ impl DynamicChannelSet {
             {
                 entry.remove();
             }
-        }
+        })
     }
 
     #[inline]

--- a/crates/ironrdp-dvc/src/client.rs
+++ b/crates/ironrdp-dvc/src/client.rs
@@ -168,10 +168,10 @@ impl DrdynvcClient {
         SvcMessage::from(caps_response)
     }
 
-pub fn close_channel(&mut self, channel_id: u32) -> Option<SvcMessage> {
-    self.dynamic_channels.remove_by_channel_id(channel_id)?;
-    Some(SvcMessage::from(DrdynvcClientPdu::Close(ClosePdu::new(channel_id))))
-}
+    pub fn close_channel(&mut self, channel_id: u32) -> Option<SvcMessage> {
+        self.dynamic_channels.remove_by_channel_id(channel_id)?;
+        Some(SvcMessage::from(DrdynvcClientPdu::Close(ClosePdu::new(channel_id))))
+    }
 }
 
 impl_as_any!(DrdynvcClient);

--- a/crates/ironrdp-dvc/src/client.rs
+++ b/crates/ironrdp-dvc/src/client.rs
@@ -168,10 +168,10 @@ impl DrdynvcClient {
         SvcMessage::from(caps_response)
     }
 
-    pub fn close_channel(&mut self, channel_id: u32) -> SvcMessage {
-        self.dynamic_channels.remove_by_channel_id(channel_id);
-        SvcMessage::from(DrdynvcClientPdu::Close(ClosePdu::new(channel_id)))
-    }
+pub fn close_channel(&mut self, channel_id: u32) -> Option<SvcMessage> {
+    self.dynamic_channels.remove_by_channel_id(channel_id)?;
+    Some(SvcMessage::from(DrdynvcClientPdu::Close(ClosePdu::new(channel_id))))
+}
 }
 
 impl_as_any!(DrdynvcClient);

--- a/crates/ironrdp-dvc/src/lib.rs
+++ b/crates/ironrdp-dvc/src/lib.rs
@@ -109,6 +109,14 @@ pub struct DynamicVirtualChannel {
     channel_id: Option<DynamicChannelId>,
 }
 
+impl Drop for DynamicVirtualChannel {
+    fn drop(&mut self) {
+        if let Some(id) = self.channel_id {
+            self.channel_processor.close(id);
+        }
+    }
+}
+
 impl DynamicVirtualChannel {
     fn from_boxed(processor: Box<dyn DvcProcessor + Send>) -> Self {
         Self {

--- a/crates/ironrdp-dvc/src/lib.rs
+++ b/crates/ironrdp-dvc/src/lib.rs
@@ -16,7 +16,7 @@ use pdu::DrdynvcDataPdu;
 #[rustfmt::skip] // do not re-order this pub use
 pub use ironrdp_pdu;
 use ironrdp_core::{AsAny, Encode, EncodeResult, assert_obj_safe, cast_length, encode_vec, other_err};
-use ironrdp_pdu::{PduResult, decode_err, pdu_other_err};
+use ironrdp_pdu::{PduResult, decode_err};
 use ironrdp_svc::SvcMessage;
 
 mod complete_data;
@@ -105,7 +105,7 @@ pub struct DynamicVirtualChannel {
     complete_data: CompleteData,
     /// The channel ID assigned by the server.
     ///
-    /// This field is `None` until the server assigns a channel ID.
+    /// `Some` only after [`DynamicVirtualChannel::start`] has succeeded. This invariant
     channel_id: Option<DynamicChannelId>,
 }
 
@@ -142,12 +142,10 @@ impl DynamicVirtualChannel {
         self.channel_processor.as_any().downcast_ref()
     }
 
-    fn start(&mut self) -> PduResult<Vec<DvcMessage>> {
-        if let Some(channel_id) = self.channel_id {
-            self.channel_processor.start(channel_id)
-        } else {
-            Err(pdu_other_err!("DynamicVirtualChannel::start", "channel ID not set"))
-        }
+    fn start(&mut self, channel_id: DynamicChannelId) -> PduResult<Vec<DvcMessage>> {
+        let messages = self.channel_processor.start(channel_id)?;
+        self.channel_id = Some(channel_id);
+        Ok(messages)
     }
 
     fn process(&mut self, pdu: DrdynvcDataPdu) -> PduResult<Vec<DvcMessage>> {

--- a/crates/ironrdp-dvc/src/server.rs
+++ b/crates/ironrdp-dvc/src/server.rs
@@ -215,10 +215,13 @@ impl DrdynvcServer {
         })
     }
 
-    pub fn close_channel(&mut self, channel_id: u32) -> Option<SvcMessage> {
-        self.remove_by_channel_id(channel_id)?;
-        Some(SvcMessage::from(DrdynvcServerPdu::Close(ClosePdu::new(channel_id))))
-    }
+pub fn close_channel(&mut self, channel_id: u32) -> Option<SvcMessage> {
+    self.remove_by_channel_id(channel_id)?;
+    Some(
+        SvcMessage::from(DrdynvcServerPdu::Close(ClosePdu::new(channel_id)))
+            .with_flags(ChannelFlags::SHOW_PROTOCOL),
+    )
+}
 }
 
 impl_as_any!(DrdynvcServer);

--- a/crates/ironrdp-dvc/src/server.rs
+++ b/crates/ironrdp-dvc/src/server.rs
@@ -201,14 +201,15 @@ impl SvcProcessor for DrdynvcServer {
                 let msg = c.processor.start(create_resp.channel_id())?;
                 resp.extend(encode_dvc_messages(id, msg, ChannelFlags::SHOW_PROTOCOL).map_err(|e| encode_err!(e))?);
             }
-            DrdynvcClientPdu::Close(close_resp) => {
-                debug!("Got DVC Close Response PDU: {close_resp:?}");
-                let c = self
-                    .channel_by_id(close_resp.channel_id())
-                    .map_err(|e| decode_err!(e))?;
+            DrdynvcClientPdu::Close(close) => {
+                debug!("Got DVC Close PDU: {close:?}");
+                let channel_id = close.channel_id();
+                let c = self.channel_by_id(channel_id).map_err(|e| decode_err!(e))?;
                 if c.state != ChannelState::Opened {
-                    return Err(pdu_other_err!("invalid channel state"));
+                    debug!(?channel_id, ?c.state, "Ignoring close for channel not in Opened state");
+                    return Ok(resp);
                 }
+                c.processor.close(channel_id);
                 c.state = ChannelState::Closed;
             }
             DrdynvcClientPdu::Data(data) => {

--- a/crates/ironrdp-dvc/src/server.rs
+++ b/crates/ironrdp-dvc/src/server.rs
@@ -215,13 +215,13 @@ impl DrdynvcServer {
         })
     }
 
-pub fn close_channel(&mut self, channel_id: u32) -> Option<SvcMessage> {
-    self.remove_by_channel_id(channel_id)?;
-    Some(
-        SvcMessage::from(DrdynvcServerPdu::Close(ClosePdu::new(channel_id)))
-            .with_flags(ChannelFlags::SHOW_PROTOCOL),
-    )
-}
+    pub fn close_channel(&mut self, channel_id: u32) -> Option<SvcMessage> {
+        self.remove_by_channel_id(channel_id)?;
+        Some(
+            SvcMessage::from(DrdynvcServerPdu::Close(ClosePdu::new(channel_id)))
+                .with_flags(ChannelFlags::SHOW_PROTOCOL),
+        )
+    }
 }
 
 impl_as_any!(DrdynvcServer);

--- a/crates/ironrdp-dvc/src/server.rs
+++ b/crates/ironrdp-dvc/src/server.rs
@@ -4,16 +4,15 @@ use alloc::vec::Vec;
 use core::any::TypeId;
 use core::fmt;
 
-use ironrdp_core::{Decode as _, DecodeResult, ReadCursor, cast_length, impl_as_any, invalid_field_err};
+use ironrdp_core::{Decode as _, DecodeResult, ReadCursor, impl_as_any, invalid_field_err};
 use ironrdp_pdu::{self as pdu, decode_err, encode_err, pdu_other_err};
 use ironrdp_svc::{ChannelFlags, CompressionCondition, SvcMessage, SvcProcessor, SvcServerProcessor};
 use pdu::PduResult;
 use pdu::gcc::ChannelName;
-use slab::Slab;
 use tracing::debug;
 
 use crate::pdu::{
-    CapabilitiesRequestPdu, CapsVersion, CreateRequestPdu, CreationStatus, DrdynvcClientPdu, DrdynvcServerPdu,
+    CapabilitiesRequestPdu, CapsVersion, ClosePdu, CreateRequestPdu, CreationStatus, DrdynvcClientPdu, DrdynvcServerPdu,
 };
 use crate::{CompleteData, DvcProcessor, encode_dvc_messages};
 
@@ -21,7 +20,8 @@ pub trait DvcServerProcessor: DvcProcessor {}
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 enum ChannelState {
-    Closed,
+    Pending,
+    /// `Create Request` has been sent; awaiting `Create Response` from the client.
     Creation,
     Opened,
     CreationFailed(u32),
@@ -31,25 +31,97 @@ struct DynamicChannel {
     state: ChannelState,
     processor: Box<dyn DvcProcessor>,
     complete_data: CompleteData,
+    channel_id: u32,
+}
+
+impl Drop for DynamicChannel {
+    fn drop(&mut self) {
+        if self.state == ChannelState::Opened {
+            self.processor.close(self.channel_id);
+        }
+    }
+}
+
+struct DynamicChannelAllocator {
+    dynamic_channels: BTreeMap<u32, DynamicChannel>,
+    next_channel_id: u32,
+}
+
+impl<'a> IntoIterator for &'a DynamicChannelAllocator {
+    type Item = (&'a u32, &'a DynamicChannel);
+
+    type IntoIter = alloc::collections::btree_map::Iter<'a, u32, DynamicChannel>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.dynamic_channels.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut DynamicChannelAllocator {
+    type Item = (&'a u32, &'a mut DynamicChannel);
+    type IntoIter = alloc::collections::btree_map::IterMut<'a, u32, DynamicChannel>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.dynamic_channels.iter_mut()
+    }
+}
+
+impl DynamicChannelAllocator {
+    fn new() -> Self {
+        Self {
+            dynamic_channels: BTreeMap::new(),
+            next_channel_id: 0,
+        }
+    }
+
+    fn insert_channel<T>(&mut self, processor: T, state: ChannelState) -> u32
+    where
+        T: DvcServerProcessor + 'static,
+    {
+        let channel_id = self.next_channel_id;
+        self.dynamic_channels
+            .insert(channel_id, DynamicChannel::new(processor, channel_id, state));
+        self.next_channel_id = self
+            .next_channel_id
+            .checked_add(1)
+            .expect("dynamic channels reaches `u32::MAX`");
+        channel_id
+    }
+
+    fn get(&self, channel_id: u32) -> Option<&DynamicChannel> {
+        self.dynamic_channels.get(&channel_id)
+    }
+
+    fn get_mut(&mut self, channel_id: u32) -> Option<&mut DynamicChannel> {
+        self.dynamic_channels.get_mut(&channel_id)
+    }
+
+    fn remove(&mut self, channel_id: u32) -> Option<DynamicChannel> {
+        self.dynamic_channels.remove(&channel_id)
+    }
 }
 
 impl DynamicChannel {
-    fn new<T>(processor: T) -> Self
+    fn new<T>(processor: T, channel_id: u32, state: ChannelState) -> Self
     where
         T: DvcServerProcessor + 'static,
     {
         Self {
-            state: ChannelState::Closed,
+            state,
             processor: Box::new(processor),
             complete_data: CompleteData::new(),
+            channel_id,
         }
+    }
+
+    fn processor_type_id(&self) -> TypeId {
+        self.processor.as_any().type_id()
     }
 }
 /// DRDYNVC Static Virtual Channel (the Remote Desktop Protocol: Dynamic Virtual Channel Extension)
 ///
 /// It adds support for dynamic virtual channels (DVC).
 pub struct DrdynvcServer {
-    dynamic_channels: Slab<DynamicChannel>,
+    dynamic_channels: DynamicChannelAllocator,
     type_id_to_channel_id: BTreeMap<TypeId, u32>,
 }
 
@@ -57,7 +129,7 @@ impl fmt::Debug for DrdynvcServer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "DrdynvcServer([")?;
 
-        for (i, (id, channel)) in self.dynamic_channels.iter().enumerate() {
+        for (i, (id, channel)) in self.dynamic_channels.into_iter().enumerate() {
             if i > 0 {
                 write!(f, ", ")?;
             }
@@ -73,7 +145,7 @@ impl DrdynvcServer {
 
     pub fn new() -> Self {
         Self {
-            dynamic_channels: Slab::new(),
+            dynamic_channels: DynamicChannelAllocator::new(),
             type_id_to_channel_id: BTreeMap::new(),
         }
     }
@@ -88,11 +160,8 @@ impl DrdynvcServer {
     /// Returns `true` if the DVC channel with the given ID has completed
     /// its creation handshake and is in the `Opened` state.
     pub fn is_channel_opened(&self, channel_id: u32) -> bool {
-        let Ok(id) = usize::try_from(channel_id) else {
-            return false;
-        };
         self.dynamic_channels
-            .get(id)
+            .get(channel_id)
             .is_some_and(|c| c.state == ChannelState::Opened)
     }
 
@@ -100,21 +169,18 @@ impl DrdynvcServer {
     ///
     /// # Panics
     ///
-    /// Panics if the number of registered dynamic channels exceeds `u32::MAX`.
+    /// Panics if the number of registered dynamic channels reaches `u32::MAX`.
     #[must_use]
     pub fn with_dynamic_channel<T>(mut self, channel: T) -> Self
     where
         T: DvcServerProcessor + 'static,
     {
-        let id = self.dynamic_channels.insert(DynamicChannel::new(channel));
-        // The slab index is used as the DVC channel ID (a u32).
-        let channel_id = u32::try_from(id).expect("DVC channel count should not exceed u32::MAX");
+        let channel_id = self.dynamic_channels.insert_channel(channel, ChannelState::Pending);
         self.type_id_to_channel_id.insert(TypeId::of::<T>(), channel_id);
         self
     }
 
     fn channel_by_id(&mut self, id: u32) -> DecodeResult<&mut DynamicChannel> {
-        let id = cast_length!("DRDYNVC", "", id)?;
         self.dynamic_channels
             .get_mut(id)
             .ok_or_else(|| invalid_field_err!("DRDYNVC", "", "invalid channel id"))
@@ -124,21 +190,34 @@ impl DrdynvcServer {
     ///
     /// # Panics
     ///
-    /// Panics if the number of registered dynamic channels exceeds `u32::MAX`.
+    /// Panics if the number of registered dynamic channels reaches `u32::MAX`.
     pub fn create_channel<T>(&mut self, channel: T) -> PduResult<SvcMessage>
     where
         T: DvcServerProcessor + 'static,
     {
         let channel_name = channel.channel_name().into();
-        let mut dvc = DynamicChannel::new(channel);
-        dvc.state = ChannelState::Creation;
 
-        let id = self.dynamic_channels.insert(dvc);
-        // The slab index is used as the DVC channel ID (a u32).
-        let channel_id = u32::try_from(id).expect("DVC channel count should not exceed u32::MAX");
-
+        let channel_id = self.dynamic_channels.insert_channel(channel, ChannelState::Creation);
         let req = DrdynvcServerPdu::Create(CreateRequestPdu::new(channel_id, channel_name));
         as_svc_msg_with_flag(req)
+    }
+
+    fn remove_by_channel_id(&mut self, id: u32) -> Option<DynamicChannel> {
+        self.dynamic_channels.remove(id).inspect(|dvc| {
+            let type_id = dvc.processor_type_id();
+
+            // Only matters for pre-registered channels
+            if let alloc::collections::btree_map::Entry::Occupied(entry) = self.type_id_to_channel_id.entry(type_id)
+                && entry.get() == &id
+            {
+                entry.remove();
+            }
+        })
+    }
+
+    pub fn close_channel(&mut self, channel_id: u32) -> Option<SvcMessage> {
+        self.remove_by_channel_id(channel_id)?;
+        Some(SvcMessage::from(DrdynvcServerPdu::Close(ClosePdu::new(channel_id))))
     }
 }
 
@@ -173,15 +252,11 @@ impl SvcProcessor for DrdynvcServer {
         match pdu {
             DrdynvcClientPdu::Capabilities(caps_resp) => {
                 debug!("Got DVC Capabilities Response PDU: {caps_resp:?}");
-                for (id, c) in self.dynamic_channels.iter_mut() {
-                    if c.state != ChannelState::Closed {
+                for (id, c) in &mut self.dynamic_channels {
+                    if c.state != ChannelState::Pending {
                         continue;
                     }
-                    let req = DrdynvcServerPdu::Create(CreateRequestPdu::new(
-                        id.try_into()
-                            .map_err(|e| pdu_other_err!("invalid channel id", source: e))?,
-                        c.processor.channel_name().into(),
-                    ));
+                    let req = DrdynvcServerPdu::Create(CreateRequestPdu::new(*id, c.processor.channel_name().into()));
                     c.state = ChannelState::Creation;
                     resp.push(as_svc_msg_with_flag(req)?);
                 }
@@ -204,13 +279,7 @@ impl SvcProcessor for DrdynvcServer {
             DrdynvcClientPdu::Close(close) => {
                 debug!("Got DVC Close PDU: {close:?}");
                 let channel_id = close.channel_id();
-                let c = self.channel_by_id(channel_id).map_err(|e| decode_err!(e))?;
-                if c.state != ChannelState::Opened {
-                    debug!(?channel_id, ?c.state, "Ignoring close for channel not in Opened state");
-                    return Ok(resp);
-                }
-                c.processor.close(channel_id);
-                c.state = ChannelState::Closed;
+                self.remove_by_channel_id(channel_id);
             }
             DrdynvcClientPdu::Data(data) => {
                 let channel_id = data.channel_id();

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -333,7 +333,6 @@ dependencies = [
  "ironrdp-core",
  "ironrdp-pdu",
  "ironrdp-svc",
- "slab",
  "tracing",
 ]
 
@@ -657,12 +656,6 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
-
-[[package]]
-name = "slab"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "spki"


### PR DESCRIPTION
## Summary

1. Align with [MS-RDPEDYC 3.2.5.2](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpedyc/2c46cdee-9dc7-4c3f-b196-56b4ce24113b) spec:

> If the client receives a DYNVC_CLOSE (section 2.2.4) PDU for a channel that is not in the list of active ChannelIds, the client MUST ignore the PDU and SHOULD NOT respond with a DYNVC_CLOSE (section 2.2.4) PDU.

2. Add close_channel API for both DrdynvcServer and DrdynvcClient. According to the spec, both the server and client can initiate a close channel request.

---

## Quesions

The server-side `close_channel` is not implemented yet.

1. A server-initiated `DYNVC_CLOSE` may receive a response from the client. Should the server perform the local channel teardown when *sending* the request, or only after the client's response arrives?

2. When the server currently handles an incoming `ClosePdu`, it just marks `ChannelState::Closed`. Should it instead remove the DVC instance entirely?

@elmarco 