### PR TITLE
fix(web): include Meta keys in WebKit scancode dispatch

### DIFF
--- a/web-client/iron-remote-desktop/src/lib/scancodes.ts
+++ b/web-client/iron-remote-desktop/src/lib/scancodes.ts
@@ -157,7 +157,7 @@ const scanCodeToKeyCode = {
     '0xE06D': 'MediaSelect',
 };
 
-const codeToScanCodeBlinkOverride = {
+const scanCodeToKeyCodeExtras = {
     '0x0077': 'Lang4',
     '0x0078': 'Lang3',
     '0xE008': 'Undo',
@@ -175,7 +175,7 @@ const codeToScanCodeBlinkOverride = {
     '0xE063': 'WakeUp',
 };
 
-const scanCodeToKeyCodeGeckoOverride = {
+const scanCodeToKeyCodeGeckoExtras = {
     '0x0054': 'PrintScreen',
     '0xE020': 'VolumeMute', // The documentation says it's 'AudioVolumeMute', but the actual test shows that it's 'VolumeMute'.
     '0xE02E': 'VolumeDown',
@@ -185,9 +185,9 @@ const scanCodeToKeyCodeGeckoOverride = {
 };
 
 const KeyCodeToScanCode = {
-    blink: invertCodesMapping({ ...scanCodeToKeyCode, ...codeToScanCodeBlinkOverride }),
-    gecko: invertCodesMapping({ ...scanCodeToKeyCode, ...scanCodeToKeyCodeGeckoOverride }),
-    webkit: invertCodesMapping(scanCodeToKeyCode),
+    blink: invertCodesMapping({ ...scanCodeToKeyCode, ...scanCodeToKeyCodeExtras }),
+    gecko: invertCodesMapping({ ...scanCodeToKeyCode, ...scanCodeToKeyCodeGeckoExtras }),
+    webkit: invertCodesMapping({ ...scanCodeToKeyCode, ...scanCodeToKeyCodeExtras }),
 };
 
 function invertCodesMapping(obj: CodeMap) {


### PR DESCRIPTION
## Symptom

On macOS WebKit (Safari and any WKWebView embedder), pressing Cmd or Cmd+letter inside an `iron-remote-desktop` session isn't delivered to the remote. Cmd alone does nothing on the Windows host; Cmd+R selects the first desktop icon starting with "R" instead of opening the Run dialog — `R` arrives without the Win modifier held.

## Root cause

In `web-client/iron-remote-desktop/src/lib/scancodes.ts`, `KeyCodeToScanCode.webkit` only loaded the base `scanCodeToKeyCode` table. Blink and Gecko each extend the base with entries that carry `MetaLeft (0xE05B)` / `MetaRight (0xE05C)`; WebKit was left out. So `scanCode("MetaLeft")` returned `NaN` on WebKit and the keydown was silently dropped in `sendKeyboard`. KeyR arrived alone, hence the desktop-icon-jump behavior.

## Fix

Extend the WebKit branch with the same extras Blink already uses. The entries (`MetaLeft`/`MetaRight`, `AudioVolume*`, `Lang3`/`4`, etc.) are [W3C UI Events Code spec](https://www.w3.org/TR/uievents-code/) values; WebKit emits them per spec, same as Blink.

Verified manually on macOS WebKit:

- `Cmd` alone → Start menu opens
- `Cmd+R` → Run dialog
- `Cmd+E` → File Explorer
- `Cmd+D` → Show Desktop

## Secondary rename

While in the file, renamed two tables to better reflect their semantics:

- `codeToScanCodeBlinkOverride` → `scanCodeToKeyCodeExtras` — the old name was a double misnomer (table direction is `scanCode → keyCode`, not `code → scanCode`; entries are W3C-spec codes shared by Blink and WebKit, not Blink-private).
- `scanCodeToKeyCodeGeckoOverride` → `scanCodeToKeyCodeGeckoExtras` — both tables are purely additive against the base (verified: 0 scancode collisions).

Happy to drop the rename if you'd prefer the PR strictly to the bug fix.

## Related

Likely addresses #667 — that issue reports a Safari user-agent (`AppleWebKit/605.1.15`) but its title says "Blink", which has probably kept it from being triaged.