### PR TITLE
fix(egfx)!: separate wire-level RawCapabilitySet from typed CapabilitySet

### DIFF
--- a/crates/ironrdp-egfx/src/client.rs
+++ b/crates/ironrdp-egfx/src/client.rs
@@ -68,8 +68,8 @@ use crate::pdu::{
     Avc420BitmapStream, CacheImportReplyPdu, CacheToSurfacePdu, CapabilitiesAdvertisePdu, CapabilitiesV8Flags,
     CapabilitiesV81Flags, CapabilitiesV107Flags, CapabilitySet, Codec1Type, DeleteEncodingContextPdu,
     EvictCacheEntryPdu, FrameAcknowledgePdu, GfxPdu, MapSurfaceToScaledOutputPdu, MapSurfaceToScaledWindowPdu,
-    MapSurfaceToWindowPdu, PixelFormat, QueueDepth, SolidFillPdu, SurfaceToCachePdu, SurfaceToSurfacePdu,
-    WireToSurface2Pdu,
+    MapSurfaceToWindowPdu, PixelFormat, QueueDepth, RawCapabilitySet, SolidFillPdu, SurfaceToCachePdu,
+    SurfaceToSurfacePdu, WireToSurface2Pdu,
 };
 
 /// Max capacity to keep for decompressed buffer when cleared.
@@ -171,7 +171,6 @@ impl CodecCapabilities {
                 small_cache: flags.contains(CapabilitiesV107Flags::SMALL_CACHE),
                 thin_client: flags.contains(CapabilitiesV107Flags::AVC_THIN_CLIENT),
             },
-            CapabilitySet::Unknown(_) => Self::default(),
         }
     }
 }
@@ -581,10 +580,32 @@ impl GraphicsPipelineClient {
         }
     }
 
-    fn handle_capabilities_confirm(&mut self, cap: CapabilitySet) {
+    fn handle_capabilities_confirm(&mut self, cap: RawCapabilitySet) {
+        // Server confirms a single capability set. If we cannot interpret it
+        // (unknown version, or malformed body), we still transition to Active
+        // to avoid hanging the session, but we keep `negotiated_caps` empty
+        // and skip the typed callback so consumers don't observe a confirm
+        // they can't reason about.
+        let cap = match cap.parsed() {
+            Ok(Some(typed)) => typed,
+            Ok(None) => {
+                warn!(
+                    version = cap.version.0,
+                    "Server confirmed an unknown EGFX capability version; proceeding with defaults"
+                );
+                self.state = ClientState::Active;
+                return;
+            }
+            Err(e) => {
+                warn!(error = %e, "Failed to parse server's EGFX capabilities confirmation");
+                self.state = ClientState::Active;
+                return;
+            }
+        };
+
         self.codec_caps = CodecCapabilities::from_capability_set(&cap);
-        self.negotiated_caps = Some(cap.clone());
         self.state = ClientState::Active;
+        let cap = self.negotiated_caps.insert(cap);
 
         debug!(
             avc420 = self.codec_caps.avc420,
@@ -592,7 +613,7 @@ impl GraphicsPipelineClient {
             "EGFX capabilities confirmed"
         );
 
-        self.handler.on_capabilities_confirmed(&cap);
+        self.handler.on_capabilities_confirmed(cap);
     }
 
     fn handle_reset_graphics(&mut self, width: u32, height: u32) {
@@ -829,7 +850,7 @@ impl DvcProcessor for GraphicsPipelineClient {
             }
         };
 
-        let pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu(caps));
+        let pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu::from_typed(&caps));
 
         #[expect(clippy::as_conversions, reason = "Box<GfxPdu> to Box<dyn DvcEncode> coercion")]
         Ok(vec![Box::new(pdu) as DvcMessage])
@@ -972,11 +993,11 @@ mod tests {
         assert_eq!(client.state, ClientState::WaitingForConfirm);
         assert!(!client.is_active());
 
-        let _ = client.handle_pdu(GfxPdu::CapabilitiesConfirm(crate::pdu::CapabilitiesConfirmPdu(
-            CapabilitySet::V8 {
+        let _ = client.handle_pdu(GfxPdu::CapabilitiesConfirm(
+            crate::pdu::CapabilitiesConfirmPdu::from_typed(&CapabilitySet::V8 {
                 flags: CapabilitiesV8Flags::empty(),
-            },
-        )));
+            }),
+        ));
         assert_eq!(client.state, ClientState::Active);
         assert!(client.is_active());
 

--- a/crates/ironrdp-egfx/src/pdu/cmd.rs
+++ b/crates/ironrdp-egfx/src/pdu/cmd.rs
@@ -1413,12 +1413,17 @@ impl<'a> Decode<'a> for CacheEntryMetadata {
 ///
 /// [2.2.2.18]: <https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpegfx/9cc3cf56-148d-44bf-9dea-5f5e6970c00f>
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CapabilitiesAdvertisePdu(pub Vec<CapabilitySet>);
+pub struct CapabilitiesAdvertisePdu(pub Vec<RawCapabilitySet>);
 
 impl CapabilitiesAdvertisePdu {
     const NAME: &'static str = "CapabilitiesAdvertisePdu";
 
     const FIXED_PART_SIZE: usize  = 2 /* Count */;
+
+    /// Build the PDU from a list of typed capability sets.
+    pub fn from_typed(caps: &[CapabilitySet]) -> Self {
+        Self(caps.iter().map(RawCapabilitySet::from).collect())
+    }
 }
 
 impl Encode for CapabilitiesAdvertisePdu {
@@ -1449,9 +1454,9 @@ impl<'a> Decode<'a> for CapabilitiesAdvertisePdu {
 
         let capabilities_count = cast_length!("Count", src.read_u16())?;
 
-        ensure_size!(in: src, size: capabilities_count * CapabilitySet::FIXED_PART_SIZE);
+        ensure_size!(in: src, size: capabilities_count * RawCapabilitySet::FIXED_PART_SIZE);
 
-        let capabilities = iter::repeat_with(|| CapabilitySet::decode(src))
+        let capabilities = iter::repeat_with(|| RawCapabilitySet::decode(src))
             .take(capabilities_count)
             .collect::<Result<_, _>>()?;
 
@@ -1463,12 +1468,17 @@ impl<'a> Decode<'a> for CapabilitiesAdvertisePdu {
 ///
 /// [2.2.2.19]: <https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpegfx/4d1ced69-49ea-47dd-98d6-4b220f30db36>
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CapabilitiesConfirmPdu(pub CapabilitySet);
+pub struct CapabilitiesConfirmPdu(pub RawCapabilitySet);
 
 impl CapabilitiesConfirmPdu {
     const NAME: &'static str = "CapabilitiesConfirmPdu";
 
     const FIXED_PART_SIZE: usize = 0;
+
+    /// Build the PDU from a typed capability set.
+    pub fn from_typed(cap: &CapabilitySet) -> Self {
+        Self(RawCapabilitySet::from(cap))
+    }
 }
 
 impl Encode for CapabilitiesConfirmPdu {
@@ -1493,15 +1503,163 @@ impl<'a> Decode<'a> for CapabilitiesConfirmPdu {
     fn decode(src: &mut ReadCursor<'a>) -> DecodeResult<Self> {
         ensure_fixed_part_size!(in: src);
 
-        let cap = CapabilitySet::decode(src)?;
+        let cap = RawCapabilitySet::decode(src)?;
 
         Ok(Self(cap))
     }
 }
 
-/// 2.2.1.6 RDPGFX_CAPSET
+/// 2.2.1.6 RDPGFX_CAPSET — lossless wire-level representation.
+///
+/// Stores the original `version` alongside the raw body bytes (`data`). This
+/// is what [`CapabilitiesAdvertisePdu`] and [`CapabilitiesConfirmPdu`] hold on
+/// the wire, ensuring that `m == encode(decode(m))` even when this build does
+/// not recognize the advertised version.
+///
+/// Use [`Self::parsed`] to obtain a typed [`CapabilitySet`] when the version
+/// is known to this build.
 ///
 /// [2.2.1.6]: <https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpegfx/82e6dd00-914d-4dcc-bd17-985e1268ffb7>
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawCapabilitySet {
+    pub version: CapabilityVersion,
+    pub data: Vec<u8>,
+}
+
+impl RawCapabilitySet {
+    const NAME: &'static str = "GfxCapabilitySet";
+
+    const FIXED_PART_SIZE: usize = 4 /* version */ + 4 /* capsDataLength */;
+
+    pub fn new(version: CapabilityVersion, data: Vec<u8>) -> Self {
+        Self { version, data }
+    }
+
+    /// Parse the body into a typed [`CapabilitySet`] when the version is one
+    /// this build recognizes. Returns `Ok(None)` for unknown versions, leaving
+    /// the raw bytes available via [`Self::data`].
+    pub fn parsed(&self) -> DecodeResult<Option<CapabilitySet>> {
+        let mut cur = ReadCursor::new(&self.data);
+        let cap = match self.version {
+            CapabilityVersion::V8 => {
+                ensure_size!(in: cur, size: 4);
+                CapabilitySet::V8 {
+                    flags: CapabilitiesV8Flags::from_bits_retain(cur.read_u32()),
+                }
+            }
+            CapabilityVersion::V8_1 => {
+                ensure_size!(in: cur, size: 4);
+                CapabilitySet::V8_1 {
+                    flags: CapabilitiesV81Flags::from_bits_retain(cur.read_u32()),
+                }
+            }
+            CapabilityVersion::V10 => {
+                ensure_size!(in: cur, size: 4);
+                CapabilitySet::V10 {
+                    flags: CapabilitiesV10Flags::from_bits_retain(cur.read_u32()),
+                }
+            }
+            CapabilityVersion::V10_1 => {
+                ensure_size!(in: cur, size: 16);
+                cur.read_u128();
+                CapabilitySet::V10_1
+            }
+            CapabilityVersion::V10_2 => {
+                ensure_size!(in: cur, size: 4);
+                CapabilitySet::V10_2 {
+                    flags: CapabilitiesV10Flags::from_bits_retain(cur.read_u32()),
+                }
+            }
+            CapabilityVersion::V10_3 => {
+                ensure_size!(in: cur, size: 4);
+                CapabilitySet::V10_3 {
+                    flags: CapabilitiesV103Flags::from_bits_retain(cur.read_u32()),
+                }
+            }
+            CapabilityVersion::V10_4 => {
+                ensure_size!(in: cur, size: 4);
+                CapabilitySet::V10_4 {
+                    flags: CapabilitiesV104Flags::from_bits_retain(cur.read_u32()),
+                }
+            }
+            CapabilityVersion::V10_5 => {
+                ensure_size!(in: cur, size: 4);
+                CapabilitySet::V10_5 {
+                    flags: CapabilitiesV104Flags::from_bits_retain(cur.read_u32()),
+                }
+            }
+            CapabilityVersion::V10_6 => {
+                ensure_size!(in: cur, size: 4);
+                CapabilitySet::V10_6 {
+                    flags: CapabilitiesV104Flags::from_bits_retain(cur.read_u32()),
+                }
+            }
+            CapabilityVersion::V10_6_ERR => {
+                ensure_size!(in: cur, size: 4);
+                CapabilitySet::V10_6Err {
+                    flags: CapabilitiesV104Flags::from_bits_retain(cur.read_u32()),
+                }
+            }
+            CapabilityVersion::V10_7 => {
+                ensure_size!(in: cur, size: 4);
+                CapabilitySet::V10_7 {
+                    flags: CapabilitiesV107Flags::from_bits_retain(cur.read_u32()),
+                }
+            }
+            _ => return Ok(None),
+        };
+
+        Ok(Some(cap))
+    }
+}
+
+impl Encode for RawCapabilitySet {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+
+        dst.write_u32(self.version.into());
+        dst.write_u32(cast_length!("dataLength", self.data.len())?);
+        dst.write_slice(&self.data);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.data.len()
+    }
+}
+
+impl<'de> Decode<'de> for RawCapabilitySet {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let version = CapabilityVersion(src.read_u32());
+        let data_length: usize = cast_length!("dataLength", src.read_u32())?;
+
+        ensure_size!(in: src, size: data_length);
+        let data = src.read_slice(data_length).to_vec();
+
+        // Tolerate capability versions this build doesn't recognize instead of
+        // failing the whole PDU. A strict error here would abort decoding of
+        // the entire CapabilitiesAdvertise during EGFX negotiation, which can
+        // prevent a connection from being established at all when a client
+        // advertises a capset version outside the set enumerated in
+        // `CapabilityVersion`. Preserving the raw bytes lets
+        // negotiation complete so the server can still select a mutually
+        // supported version. Use `RawCapabilitySet::parsed` to obtain a typed
+        // view when needed.
+        Ok(Self { version, data })
+    }
+}
+
+/// 2.2.1.6 RDPGFX_CAPSET — typed view of a [`RawCapabilitySet`] body.
+///
+/// Holds only versions this build knows how to interpret. Obtained from
+/// [`RawCapabilitySet::parsed`], which returns `None` for unknown versions.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CapabilitySet {
     V8 { flags: CapabilitiesV8Flags },
@@ -1515,15 +1673,11 @@ pub enum CapabilitySet {
     V10_6 { flags: CapabilitiesV104Flags },
     V10_6Err { flags: CapabilitiesV104Flags },
     V10_7 { flags: CapabilitiesV107Flags },
-    Unknown(Vec<u8>),
 }
 
 impl CapabilitySet {
-    const NAME: &'static str = "GfxCapabilitySet";
-
-    const FIXED_PART_SIZE: usize = 4 /* version */ + 4 /* capsDataLength */;
-
-    fn version(&self) -> CapabilityVersion {
+    /// Wire `version` field corresponding to this typed variant.
+    pub fn version(&self) -> CapabilityVersion {
         match self {
             CapabilitySet::V8 { .. } => CapabilityVersion::V8,
             CapabilitySet::V8_1 { .. } => CapabilityVersion::V8_1,
@@ -1534,20 +1688,31 @@ impl CapabilitySet {
             CapabilitySet::V10_4 { .. } => CapabilityVersion::V10_4,
             CapabilitySet::V10_5 { .. } => CapabilityVersion::V10_5,
             CapabilitySet::V10_6 { .. } => CapabilityVersion::V10_6,
-            CapabilitySet::V10_6Err { .. } => CapabilityVersion::V10_6Err,
+            CapabilitySet::V10_6Err { .. } => CapabilityVersion::V10_6_ERR,
             CapabilitySet::V10_7 { .. } => CapabilityVersion::V10_7,
-            CapabilitySet::Unknown { .. } => CapabilityVersion::Unknown,
         }
     }
-}
 
-impl Encode for CapabilitySet {
-    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        ensure_size!(in: dst, size: self.size());
+    /// Size of the body bytes (no version/length header).
+    fn body_size(&self) -> usize {
+        match self {
+            CapabilitySet::V10_1 => 16,
+            CapabilitySet::V8 { .. }
+            | CapabilitySet::V8_1 { .. }
+            | CapabilitySet::V10 { .. }
+            | CapabilitySet::V10_2 { .. }
+            | CapabilitySet::V10_3 { .. }
+            | CapabilitySet::V10_4 { .. }
+            | CapabilitySet::V10_5 { .. }
+            | CapabilitySet::V10_6 { .. }
+            | CapabilitySet::V10_6Err { .. }
+            | CapabilitySet::V10_7 { .. } => 4,
+        }
+    }
 
-        dst.write_u32(self.version().into());
-        dst.write_u32(cast_length!("dataLength", self.size() - Self::FIXED_PART_SIZE)?);
-
+    /// Serialize just the body bytes (no version/length header).
+    fn write_body(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.body_size());
         match self {
             CapabilitySet::V8 { flags } => dst.write_u32(flags.bits()),
             CapabilitySet::V8_1 { flags } => dst.write_u32(flags.bits()),
@@ -1560,161 +1725,66 @@ impl Encode for CapabilitySet {
             CapabilitySet::V10_6 { flags } => dst.write_u32(flags.bits()),
             CapabilitySet::V10_6Err { flags } => dst.write_u32(flags.bits()),
             CapabilitySet::V10_7 { flags } => dst.write_u32(flags.bits()),
-            CapabilitySet::Unknown(data) => dst.write_slice(data),
         }
-
         Ok(())
     }
-
-    fn name(&self) -> &'static str {
-        Self::NAME
-    }
-
-    fn size(&self) -> usize {
-        Self::FIXED_PART_SIZE
-            + match self {
-                CapabilitySet::V8 { .. }
-                | CapabilitySet::V8_1 { .. }
-                | CapabilitySet::V10 { .. }
-                | CapabilitySet::V10_2 { .. }
-                | CapabilitySet::V10_3 { .. }
-                | CapabilitySet::V10_4 { .. }
-                | CapabilitySet::V10_5 { .. }
-                | CapabilitySet::V10_6 { .. }
-                | CapabilitySet::V10_6Err { .. }
-                | CapabilitySet::V10_7 { .. } => 4,
-                CapabilitySet::V10_1 => 16,
-                CapabilitySet::Unknown(data) => data.len(),
-            }
-    }
 }
 
-impl<'de> Decode<'de> for CapabilitySet {
-    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
-        ensure_fixed_part_size!(in: src);
-
-        let version_raw = src.read_u32();
-        let data_length: usize = cast_length!("dataLength", src.read_u32())?;
-
-        ensure_size!(in: src, size: data_length);
-        let data = src.read_slice(data_length);
-
-        // Tolerate capability versions this build doesn't recognize instead of
-        // failing the whole PDU. A strict error here aborts decoding of the
-        // entire CapabilitiesAdvertise during EGFX negotiation, which can
-        // prevent a connection from being established at all when a client
-        // advertises a capset version outside the set enumerated below
-        // (observed with the macOS "Windows App" / Microsoft Remote Desktop
-        // client). Preserving the raw bytes as `Unknown` lets negotiation
-        // complete so the server can still select a mutually supported version.
-        let Ok(version) = CapabilityVersion::try_from(version_raw) else {
-            return Ok(CapabilitySet::Unknown(data.to_vec()));
-        };
-
-        let mut cur = ReadCursor::new(data);
-
-        let size = match version {
-            CapabilityVersion::V8
-            | CapabilityVersion::V8_1
-            | CapabilityVersion::V10
-            | CapabilityVersion::V10_2
-            | CapabilityVersion::V10_3
-            | CapabilityVersion::V10_4
-            | CapabilityVersion::V10_5
-            | CapabilityVersion::V10_6
-            | CapabilityVersion::V10_6Err
-            | CapabilityVersion::V10_7 => 4,
-            CapabilityVersion::V10_1 => 16,
-            CapabilityVersion::Unknown => 0,
-        };
-
-        ensure_size!(in: cur, size: size);
-        match version {
-            CapabilityVersion::V8 => Ok(CapabilitySet::V8 {
-                flags: CapabilitiesV8Flags::from_bits_retain(cur.read_u32()),
-            }),
-            CapabilityVersion::V8_1 => Ok(CapabilitySet::V8_1 {
-                flags: CapabilitiesV81Flags::from_bits_retain(cur.read_u32()),
-            }),
-            CapabilityVersion::V10 => Ok(CapabilitySet::V10 {
-                flags: CapabilitiesV10Flags::from_bits_retain(cur.read_u32()),
-            }),
-            CapabilityVersion::V10_1 => {
-                cur.read_u128();
-
-                Ok(CapabilitySet::V10_1)
-            }
-            CapabilityVersion::V10_2 => Ok(CapabilitySet::V10_2 {
-                flags: CapabilitiesV10Flags::from_bits_retain(cur.read_u32()),
-            }),
-            CapabilityVersion::V10_3 => Ok(CapabilitySet::V10_3 {
-                flags: CapabilitiesV103Flags::from_bits_retain(cur.read_u32()),
-            }),
-            CapabilityVersion::V10_4 => Ok(CapabilitySet::V10_4 {
-                flags: CapabilitiesV104Flags::from_bits_retain(cur.read_u32()),
-            }),
-            CapabilityVersion::V10_5 => Ok(CapabilitySet::V10_5 {
-                flags: CapabilitiesV104Flags::from_bits_retain(cur.read_u32()),
-            }),
-            CapabilityVersion::V10_6 => Ok(CapabilitySet::V10_6 {
-                flags: CapabilitiesV104Flags::from_bits_retain(cur.read_u32()),
-            }),
-            CapabilityVersion::V10_6Err => Ok(CapabilitySet::V10_6Err {
-                flags: CapabilitiesV104Flags::from_bits_retain(cur.read_u32()),
-            }),
-            CapabilityVersion::V10_7 => Ok(CapabilitySet::V10_7 {
-                flags: CapabilitiesV107Flags::from_bits_retain(cur.read_u32()),
-            }),
-            CapabilityVersion::Unknown => Ok(CapabilitySet::Unknown(data.to_vec())),
+impl From<&CapabilitySet> for RawCapabilitySet {
+    fn from(cap: &CapabilitySet) -> Self {
+        let mut data = vec![0u8; cap.body_size()];
+        let mut cur = WriteCursor::new(&mut data);
+        cap.write_body(&mut cur)
+            .expect("buffer is sized to body_size; write cannot fail");
+        Self {
+            version: cap.version(),
+            data,
         }
     }
 }
 
-#[repr(u32)]
+/// Capability set version, as advertised in 2.2.1.6 RDPGFX_CAPSET.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub(crate) enum CapabilityVersion {
-    V8 = 0x8_0004,
-    V8_1 = 0x8_0105,
-    V10 = 0xa_0002,
-    V10_1 = 0xa_0100,
-    V10_2 = 0xa_0200,
-    V10_3 = 0xa_0301,
-    V10_4 = 0xa_0400,
-    V10_5 = 0xa_0502,
-    V10_6 = 0xa_0600,    // [MS-RDPEGFX-errata]
-    V10_6Err = 0xa_0601, // defined similar to FreeRDP to maintain best compatibility
-    V10_7 = 0xa_0701,
-    Unknown = 0xa_0702,
-}
+pub struct CapabilityVersion(pub u32);
 
-impl TryFrom<u32> for CapabilityVersion {
-    type Error = DecodeError;
+impl CapabilityVersion {
+    pub const V8: Self = Self(0x8_0004);
+    pub const V8_1: Self = Self(0x8_0105);
+    pub const V10: Self = Self(0xa_0002);
+    pub const V10_1: Self = Self(0xa_0100);
+    pub const V10_2: Self = Self(0xa_0200);
+    pub const V10_3: Self = Self(0xa_0301);
+    pub const V10_4: Self = Self(0xa_0400);
+    pub const V10_5: Self = Self(0xa_0502);
+    pub const V10_6: Self = Self(0xa_0600); // [MS-RDPEGFX-errata]
+    pub const V10_6_ERR: Self = Self(0xa_0601); // defined similar to FreeRDP to maintain best compatibility
+    pub const V10_7: Self = Self(0xa_0701);
 
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        let res = match value {
-            0x8_0004 => CapabilityVersion::V8,
-            0x8_0105 => CapabilityVersion::V8_1,
-            0xa_0002 => CapabilityVersion::V10,
-            0xa_0100 => CapabilityVersion::V10_1,
-            0xa_0200 => CapabilityVersion::V10_2,
-            0xa_0301 => CapabilityVersion::V10_3,
-            0xa_0400 => CapabilityVersion::V10_4,
-            0xa_0502 => CapabilityVersion::V10_5,
-            0xa_0600 => CapabilityVersion::V10_6,
-            0xa_0601 => CapabilityVersion::V10_6Err,
-            0xa_0701 => CapabilityVersion::V10_7,
-            0xa_0702 => CapabilityVersion::Unknown,
-            _ => return Err(invalid_field_err!("version", "invalid capability version")),
-        };
-
-        Ok(res)
+    /// Returns `true` if this version matches one of the constants defined on
+    /// `CapabilityVersion`, i.e. one this build knows how to decode into a
+    /// dedicated `CapabilitySet` variant.
+    #[must_use]
+    pub fn is_known(self) -> bool {
+        matches!(
+            self,
+            Self::V8
+                | Self::V8_1
+                | Self::V10
+                | Self::V10_1
+                | Self::V10_2
+                | Self::V10_3
+                | Self::V10_4
+                | Self::V10_5
+                | Self::V10_6
+                | Self::V10_6_ERR
+                | Self::V10_7
+        )
     }
 }
 
 impl From<CapabilityVersion> for u32 {
-    #[expect(clippy::as_conversions, reason = "repr(u32) enum discriminant")]
     fn from(value: CapabilityVersion) -> Self {
-        value as u32
+        value.0
     }
 }
 

--- a/crates/ironrdp-egfx/src/server.rs
+++ b/crates/ironrdp-egfx/src/server.rs
@@ -1635,9 +1635,21 @@ impl GraphicsPipelineServer {
         self.handler.capabilities_advertise(&pdu);
         let server_caps = self.handler.preferred_capabilities();
 
-        // Parse client raw caps into typed; silently drop unknown versions for
-        // negotiation purposes (the raw form is still observable in `pdu`).
-        let client_caps: Vec<CapabilitySet> = pdu.0.iter().filter_map(|raw| raw.parsed().ok().flatten()).collect();
+        // Parse client raw caps into typed. Silently skip unknown versions for
+        // negotiation purposes (the raw form is still observable in `pdu`), but
+        // treat parse failures for known versions as malformed input instead of
+        // negotiating as if the client never advertised them.
+        let mut client_caps = Vec::with_capacity(pdu.0.len());
+        for raw in &pdu.0 {
+            match raw.parsed() {
+                Ok(Some(cap)) => client_caps.push(cap),
+                Ok(None) => {}
+                Err(e) => {
+                    warn!(error = ?e, "Received malformed client capability set; aborting capability negotiation");
+                    return;
+                }
+            }
+        }
 
         // When no version overlaps with server preferences, confirm the client's
         // highest-priority capability to avoid confirming a version the client

--- a/crates/ironrdp-egfx/src/server.rs
+++ b/crates/ironrdp-egfx/src/server.rs
@@ -674,7 +674,6 @@ impl CodecCapabilities {
                 small_cache: flags.contains(CapabilitiesV107Flags::SMALL_CACHE),
                 thin_client: flags.contains(CapabilitiesV107Flags::AVC_THIN_CLIENT),
             },
-            CapabilitySet::Unknown(_) => Self::default(),
         }
     }
 }
@@ -693,7 +692,6 @@ fn capability_priority(cap: &CapabilitySet) -> u32 {
         CapabilitySet::V10 { .. } => 4,
         CapabilitySet::V8_1 { .. } => 3,
         CapabilitySet::V8 { .. } => 2,
-        _ => 0,
     }
 }
 
@@ -742,7 +740,7 @@ fn intersect_flags(client: &CapabilitySet, server: &CapabilitySet) -> Capability
         (CapabilitySet::V10_7 { flags: cf }, CapabilitySet::V10_7 { flags: sf }) => {
             CapabilitySet::V10_7 { flags: *cf & *sf }
         }
-        // V10_1 has no flags; Unknown and mismatched variants return server as-is.
+        // V10_1 has no flags; mismatched variants return server as-is.
         _ => server.clone(),
     }
 }
@@ -1637,12 +1635,16 @@ impl GraphicsPipelineServer {
         self.handler.capabilities_advertise(&pdu);
         let server_caps = self.handler.preferred_capabilities();
 
+        // Parse client raw caps into typed; silently drop unknown versions for
+        // negotiation purposes (the raw form is still observable in `pdu`).
+        let client_caps: Vec<CapabilitySet> = pdu.0.iter().filter_map(|raw| raw.parsed().ok().flatten()).collect();
+
         // When no version overlaps with server preferences, confirm the client's
         // highest-priority capability to avoid confirming a version the client
         // did not advertise.
-        let negotiated = negotiate_capabilities(&pdu.0, &server_caps).unwrap_or_else(|| {
+        let negotiated = negotiate_capabilities(&client_caps, &server_caps).unwrap_or_else(|| {
             warn!("No capability match with server preferences, selecting client's highest version");
-            let mut client_sorted = pdu.0.clone();
+            let mut client_sorted = client_caps.clone();
             client_sorted.sort_by_key(|cap| core::cmp::Reverse(capability_priority(cap)));
             client_sorted.into_iter().next().unwrap_or(CapabilitySet::V8 {
                 flags: CapabilitiesV8Flags::empty(),
@@ -1650,13 +1652,15 @@ impl GraphicsPipelineServer {
         });
 
         self.codec_caps = CodecCapabilities::from_capability_set(&negotiated);
-        self.negotiated_caps = Some(negotiated.clone());
+        self.state = ServerState::Ready;
+        let negotiated = self.negotiated_caps.insert(negotiated);
 
         self.output_queue
-            .push_back(GfxPdu::CapabilitiesConfirm(CapabilitiesConfirmPdu(negotiated.clone())));
+            .push_back(GfxPdu::CapabilitiesConfirm(CapabilitiesConfirmPdu::from_typed(
+                negotiated,
+            )));
 
-        self.state = ServerState::Ready;
-        self.handler.on_ready(&negotiated);
+        self.handler.on_ready(negotiated);
     }
 
     fn handle_frame_acknowledge(&mut self, pdu: FrameAcknowledgePdu) {

--- a/crates/ironrdp-fuzzing/src/oracles/mod.rs
+++ b/crates/ironrdp-fuzzing/src/oracles/mod.rs
@@ -113,8 +113,8 @@ pub fn bulk_round_trip(data: &[u8]) {
 pub fn pdu_decode(data: &[u8]) {
     use ironrdp_core::decode;
     use ironrdp_egfx::pdu::{
-        Avc420BitmapStream, Avc444BitmapStream, CacheToSurfacePdu, CapabilitySet as EgfxCapabilitySet, Color, GfxPdu,
-        Point, QuantQuality,
+        Avc420BitmapStream, Avc444BitmapStream, CacheToSurfacePdu, Color, GfxPdu, Point, QuantQuality,
+        RawCapabilitySet as EgfxRawCapabilitySet,
     };
     use ironrdp_pdu::mcs::{ConnectInitial, ConnectResponse, McsMessage};
     use ironrdp_pdu::nego::{ConnectionConfirm, ConnectionRequest};
@@ -185,7 +185,7 @@ pub fn pdu_decode(data: &[u8]) {
 
     let _ = decode::<GfxPdu>(data);
     let _ = decode::<CacheToSurfacePdu>(data);
-    let _ = decode::<EgfxCapabilitySet>(data);
+    let _ = decode::<EgfxRawCapabilitySet>(data);
     let _ = decode::<Avc420BitmapStream<'_>>(data);
     let _ = decode::<Avc444BitmapStream<'_>>(data);
     let _ = decode::<QuantQuality>(data);

--- a/crates/ironrdp-testsuite-core/src/graphics_messages.rs
+++ b/crates/ironrdp-testsuite-core/src/graphics_messages.rs
@@ -337,12 +337,12 @@ pub static START_FRAME: LazyLock<StartFramePdu> = LazyLock::new(|| StartFramePdu
 });
 pub static END_FRAME: LazyLock<EndFramePdu> = LazyLock::new(|| EndFramePdu { frame_id: 1 });
 pub static CAPABILITIES_CONFIRM: LazyLock<CapabilitiesConfirmPdu> = LazyLock::new(|| {
-    CapabilitiesConfirmPdu(CapabilitySet::V10_5 {
+    CapabilitiesConfirmPdu::from_typed(&CapabilitySet::V10_5 {
         flags: CapabilitiesV104Flags::AVC_DISABLED,
     })
 });
 pub static CAPABILITIES_ADVERTISE: LazyLock<CapabilitiesAdvertisePdu> = LazyLock::new(|| {
-    CapabilitiesAdvertisePdu(vec![
+    CapabilitiesAdvertisePdu::from_typed(&[
         CapabilitySet::V8 {
             flags: CapabilitiesV8Flags::THIN_CLIENT,
         },

--- a/crates/ironrdp-testsuite-core/tests/egfx/capabilities.rs
+++ b/crates/ironrdp-testsuite-core/tests/egfx/capabilities.rs
@@ -1,0 +1,73 @@
+//! Tests for resilient capability-set decoding, per the
+//! "Enumeration-like types should allow resilient parsing" section of
+//! `crates/ironrdp-pdu/README.md`.
+//!
+//! Two properties matter:
+//!
+//! - an unrecognized `CapabilityVersion` decodes into a
+//!   `RawCapabilitySet` whose `.parsed()` returns `None`, instead of
+//!   failing the whole PDU;
+//! - the original wire bytes (including the version value) are preserved so
+//!   that `encode(decode(m)) == m`.
+
+use ironrdp_core::{decode, encode_vec};
+use ironrdp_egfx::pdu::{CapabilitiesAdvertisePdu, CapabilityVersion};
+use proptest::{prelude::*, sample::select};
+
+/// Build a raw `RDPGFX_CAPS_ADVERTISE_PDU` carrying a single capset:
+/// `capsSetCount=1` then `version`, `dataLength`, `data`.
+fn raw_advertise_one(version: u32, data: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(2 + 8 + data.len());
+    buf.extend_from_slice(&1u16.to_le_bytes());
+    buf.extend_from_slice(&version.to_le_bytes());
+    let len = u32::try_from(data.len()).expect("test data length fits u32");
+    buf.extend_from_slice(&len.to_le_bytes());
+    buf.extend_from_slice(data);
+    buf
+}
+
+/// Choose a random version with a bias towards well-known ones.
+fn version() -> impl Strategy<Value = u32> {
+    prop_oneof![
+        select::<u32>(&[
+            CapabilityVersion::V8.0,
+            CapabilityVersion::V8_1.0,
+            CapabilityVersion::V10.0,
+            CapabilityVersion::V10_1.0,
+            CapabilityVersion::V10_2.0,
+            CapabilityVersion::V10_3.0,
+            CapabilityVersion::V10_4.0,
+            CapabilityVersion::V10_5.0,
+            CapabilityVersion::V10_6.0,
+            CapabilityVersion::V10_6_ERR.0,
+            CapabilityVersion::V10_7.0,
+        ]),
+        any::<u32>(),
+    ]
+}
+
+/// `encode(decode(wire)) == wire` for any version and any payload.
+#[test]
+fn capability_set_roundtrips() {
+    proptest!(|(
+        version in version(),
+        data in proptest::collection::vec(any::<u8>(), 0..32usize),
+    )| {
+        let wire = raw_advertise_one(version, &data);
+        let pdu: CapabilitiesAdvertisePdu = decode(&wire).expect("decode must tolerate unknown version");
+
+        let cap = &pdu.0[0];
+        if cap.version.is_known() {
+            // `parsed()` may fail because of invalid data format (length, etc) for known versions.
+            if let Ok(parsed) = cap.parsed() {
+                prop_assert!(parsed.is_some());
+            }
+        } else {
+            // `parsed()` never fails for unknown versions.
+            prop_assert!(cap.parsed().expect("parsed never errors for unknown versions").is_none());
+        }
+
+        let re_encoded = encode_vec(&pdu).expect("encode must succeed");
+        prop_assert_eq!(re_encoded, wire);
+    });
+}

--- a/crates/ironrdp-testsuite-core/tests/egfx/client.rs
+++ b/crates/ironrdp-testsuite-core/tests/egfx/client.rs
@@ -3,8 +3,9 @@ use ironrdp_dvc::DvcProcessor as _;
 use ironrdp_egfx::client::{BitmapUpdate, GraphicsPipelineClient, GraphicsPipelineHandler, Surface};
 use ironrdp_egfx::decode::{DecodedFrame, DecoderResult, H264Decoder};
 use ironrdp_egfx::pdu::{
-    CapabilitiesAdvertisePdu, CapabilitiesConfirmPdu, CapabilitiesV8Flags, CapabilitySet, Codec1Type, CreateSurfacePdu,
-    DeleteSurfacePdu, EndFramePdu, GfxPdu, PixelFormat, ResetGraphicsPdu, StartFramePdu, Timestamp, WireToSurface1Pdu,
+    CapabilitiesAdvertisePdu, CapabilitiesConfirmPdu, CapabilitiesV8Flags, CapabilitySet, CapabilityVersion,
+    Codec1Type, CreateSurfacePdu, DeleteSurfacePdu, EndFramePdu, GfxPdu, PixelFormat, ResetGraphicsPdu, StartFramePdu,
+    Timestamp, WireToSurface1Pdu,
 };
 use ironrdp_graphics::zgfx::wrap_uncompressed;
 use ironrdp_pdu::geometry::ExclusiveRectangle;
@@ -113,7 +114,7 @@ fn setup_active_client_with_surface(
     let mut client = GraphicsPipelineClient::new(Box::new(handler), decoder);
 
     // Activate via CapabilitiesConfirm
-    let confirm = GfxPdu::CapabilitiesConfirm(CapabilitiesConfirmPdu(CapabilitySet::V8 {
+    let confirm = GfxPdu::CapabilitiesConfirm(CapabilitiesConfirmPdu::from_typed(&CapabilitySet::V8 {
         flags: CapabilitiesV8Flags::empty(),
     }));
     client
@@ -160,7 +161,7 @@ fn client_filters_avc_caps_without_decoder() {
         "expected exactly one capability set when no decoder is present"
     );
     assert!(
-        matches!(caps_pdu.0[0], CapabilitySet::V8 { .. }),
+        caps_pdu.0[0].version == CapabilityVersion::V8,
         "expected only V8 capability set without decoder, got {:?}",
         caps_pdu.0[0]
     );
@@ -179,9 +180,9 @@ fn client_keeps_avc_caps_with_decoder() {
         3,
         "expected all three capability sets with decoder present"
     );
-    assert!(matches!(caps_pdu.0[0], CapabilitySet::V10_7 { .. }));
-    assert!(matches!(caps_pdu.0[1], CapabilitySet::V8_1 { .. }));
-    assert!(matches!(caps_pdu.0[2], CapabilitySet::V8 { .. }));
+    assert_eq!(caps_pdu.0[0].version, CapabilityVersion::V10_7);
+    assert_eq!(caps_pdu.0[1].version, CapabilityVersion::V8_1);
+    assert_eq!(caps_pdu.0[2].version, CapabilityVersion::V8);
 }
 
 // ============================================================================

--- a/crates/ironrdp-testsuite-core/tests/egfx/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/egfx/mod.rs
@@ -1,3 +1,4 @@
+mod capabilities;
 mod client;
 #[cfg(feature = "openh264-bundled")]
 mod decode;

--- a/crates/ironrdp-testsuite-core/tests/egfx/server.rs
+++ b/crates/ironrdp-testsuite-core/tests/egfx/server.rs
@@ -86,7 +86,7 @@ fn test_capability_negotiation_v8() {
     let mut server = GraphicsPipelineServer::new(handler);
 
     // Simulate client sending CapabilitiesAdvertise
-    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu(vec![CapabilitySet::V8 {
+    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu::from_typed(&[CapabilitySet::V8 {
         flags: CapabilitiesV8Flags::SMALL_CACHE,
     }]));
 
@@ -105,7 +105,7 @@ fn test_capability_negotiation_v81_avc420() {
     let handler = Box::new(TestHandler::new());
     let mut server = GraphicsPipelineServer::new(handler);
 
-    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu(vec![CapabilitySet::V8_1 {
+    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu::from_typed(&[CapabilitySet::V8_1 {
         flags: CapabilitiesV81Flags::AVC420_ENABLED | CapabilitiesV81Flags::SMALL_CACHE,
     }]));
 
@@ -122,7 +122,7 @@ fn test_capability_negotiation_v10_avc444() {
     let handler = Box::new(TestHandler::new());
     let mut server = GraphicsPipelineServer::new(handler);
 
-    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu(vec![CapabilitySet::V10 {
+    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu::from_typed(&[CapabilitySet::V10 {
         flags: CapabilitiesV10Flags::SMALL_CACHE,
     }]));
 
@@ -153,7 +153,7 @@ fn test_surface_lifecycle() {
     let mut server = GraphicsPipelineServer::new(handler);
 
     // Negotiate capabilities first
-    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu(vec![CapabilitySet::V8_1 {
+    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu::from_typed(&[CapabilitySet::V8_1 {
         flags: CapabilitiesV81Flags::AVC420_ENABLED,
     }]));
     let payload = encode_pdu(&client_caps_pdu);
@@ -191,7 +191,7 @@ fn test_resize() {
     let mut server = GraphicsPipelineServer::new(handler);
 
     // Negotiate capabilities
-    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu(vec![CapabilitySet::V8 {
+    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu::from_typed(&[CapabilitySet::V8 {
         flags: CapabilitiesV8Flags::SMALL_CACHE,
     }]));
     let payload = encode_pdu(&client_caps_pdu);
@@ -220,7 +220,7 @@ fn test_frame_flow_control() {
     server.set_max_frames_in_flight(2);
 
     // Negotiate capabilities with AVC420
-    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu(vec![CapabilitySet::V8_1 {
+    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu::from_typed(&[CapabilitySet::V8_1 {
         flags: CapabilitiesV81Flags::AVC420_ENABLED,
     }]));
     let payload = encode_pdu(&client_caps_pdu);
@@ -270,7 +270,7 @@ fn test_qoe_snapshot_after_frame_ack() {
     let mut server = GraphicsPipelineServer::new(handler);
 
     // Negotiate capabilities.
-    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu(vec![CapabilitySet::V8_1 {
+    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu::from_typed(&[CapabilitySet::V8_1 {
         flags: CapabilitiesV81Flags::AVC420_ENABLED,
     }]));
     let payload = encode_pdu(&client_caps_pdu);
@@ -314,7 +314,7 @@ fn test_qoe_snapshot_after_qoe_report() {
     let mut server = GraphicsPipelineServer::new(handler);
 
     // Negotiate capabilities (V10 for QoE support).
-    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu(vec![CapabilitySet::V10 {
+    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu::from_typed(&[CapabilitySet::V10 {
         flags: CapabilitiesV10Flags::SMALL_CACHE,
     }]));
     let payload = encode_pdu(&client_caps_pdu);
@@ -349,7 +349,7 @@ fn test_qoe_reset() {
     let mut server = GraphicsPipelineServer::new(handler);
 
     // Negotiate.
-    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu(vec![CapabilitySet::V10 {
+    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu::from_typed(&[CapabilitySet::V10 {
         flags: CapabilitiesV10Flags::SMALL_CACHE,
     }]));
     let payload = encode_pdu(&client_caps_pdu);
@@ -381,7 +381,7 @@ fn test_send_uncompressed_frame_queues_correctly() {
     let mut server = GraphicsPipelineServer::new(handler);
 
     // V8 client: EGFX but no H.264
-    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu(vec![CapabilitySet::V8 {
+    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu::from_typed(&[CapabilitySet::V8 {
         flags: CapabilitiesV8Flags::SMALL_CACHE,
     }]));
     let payload = encode_pdu(&client_caps_pdu);
@@ -407,7 +407,7 @@ fn test_send_uncompressed_frame_backpressure() {
     let mut server = GraphicsPipelineServer::new(handler);
     server.set_max_frames_in_flight(1);
 
-    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu(vec![CapabilitySet::V8 {
+    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu::from_typed(&[CapabilitySet::V8 {
         flags: CapabilitiesV8Flags::SMALL_CACHE,
     }]));
     let payload = encode_pdu(&client_caps_pdu);


### PR DESCRIPTION
Follow-up to #1298, which tolerated unknown EGFX capability versions by collapsing them onto a synthetic `CapabilityVersion::Unknown = 0xa_0702` discriminant. That approach violates the pattern documented in `crates/ironrdp-pdu/README.md` ("Enumeration-like types should allow resilient parsing"): the sentinel could legitimately collide with a real wire value, and `encode(decode(m))` was not byte-identical when a peer advertised any version outside the recognized set.

Make the lossless guarantee a property of the type system:

- `RawCapabilitySet { version, data }` is the wire-level representation held by `CapabilitiesAdvertisePdu` and `CapabilitiesConfirmPdu`. Its `Decode`/`Encode` impls preserve the original version + body bytes verbatim, so the round-trip property holds for any version.
- `CapabilitySet` is now a pure typed view, obtained on demand via `RawCapabilitySet::parsed() -> DecodeResult<Option<CapabilitySet>>` (returns `Ok(None)` for unknown versions). The `Unknown` variant is gone.
- `CapabilityVersion` is a newtype struct (`pub struct CapabilityVersion(pub u32)`) with `pub const` associated values, per the README pattern. Adds `is_known()` for downstream consumers.
- `CapabilitiesAdvertisePdu::from_typed(&[CapabilitySet])` and `CapabilitiesConfirmPdu::from_typed(&CapabilitySet)` keep the typed construction path ergonomic.
- Server negotiation: store the negotiated cap via `Option::insert`, removing two `.clone()` calls and tightening the order so the server state transitions to `Ready` before `on_ready` is invoked.

Add a proptest in `ironrdp-testsuite-core` covering the round-trip property over both known and unknown versions, biased to exercise both branches.