### PR TITLE
test(cliprdr): cover Preferred DropEffect advertise + inline DROPEFFECT_COPY response

### DIFF
--- a/crates/ironrdp-testsuite-core/tests/clipboard/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/clipboard/mod.rs
@@ -9,6 +9,7 @@ mod lock_lifecycle;
 mod lock_strategy;
 mod lock_timeout;
 mod path_sanitization;
+mod preferred_drop_effect;
 mod server_role;
 mod test_helpers;
 mod upload_and_cleanup;

--- a/crates/ironrdp-testsuite-core/tests/clipboard/preferred_drop_effect.rs
+++ b/crates/ironrdp-testsuite-core/tests/clipboard/preferred_drop_effect.rs
@@ -42,7 +42,11 @@ fn initiate_file_copy_advertises_drop_effect_alongside_file_group_descriptor() {
     ];
     let messages: Vec<SvcMessage> = cliprdr.initiate_file_copy(files).unwrap().into();
 
-    assert_eq!(messages.len(), 1, "initiate_file_copy should send a single FormatList PDU");
+    assert_eq!(
+        messages.len(),
+        1,
+        "initiate_file_copy should send a single FormatList PDU"
+    );
 
     decode_pdu!(&messages[0] => bytes, pdu);
     let ClipboardPdu::FormatList(format_list) = pdu else {
@@ -89,8 +93,10 @@ fn format_data_request_for_drop_effect_returns_dropeffect_copy_inline() {
     // re-driving the call would be circular; instead, key off the format
     // *name* by walking the FormatList we just emitted. Easier and
     // wire-faithful since the remote keys off the name too.
-    let initiate_msgs: Vec<SvcMessage> =
-        cliprdr.initiate_file_copy(vec![FileDescriptor::new("d.txt").with_file_size(1)]).unwrap().into();
+    let initiate_msgs: Vec<SvcMessage> = cliprdr
+        .initiate_file_copy(vec![FileDescriptor::new("d.txt").with_file_size(1)])
+        .unwrap()
+        .into();
     decode_pdu!(&initiate_msgs[0] => initiate_bytes, initiate_pdu);
     let ClipboardPdu::FormatList(format_list) = initiate_pdu else {
         panic!("expected FormatList");
@@ -108,9 +114,7 @@ fn format_data_request_for_drop_effect_returns_dropeffect_copy_inline() {
     let drop_effect_id = drop_effect_format.id;
 
     // Simulate the remote asking for the drop-effect format.
-    let request_pdu = ClipboardPdu::FormatDataRequest(FormatDataRequest {
-        format: drop_effect_id,
-    });
+    let request_pdu = ClipboardPdu::FormatDataRequest(FormatDataRequest { format: drop_effect_id });
     let request_bytes = ironrdp_core::encode_vec(&request_pdu).unwrap();
     let responses: Vec<SvcMessage> = cliprdr.process(&request_bytes).unwrap();
 

--- a/crates/ironrdp-testsuite-core/tests/clipboard/preferred_drop_effect.rs
+++ b/crates/ironrdp-testsuite-core/tests/clipboard/preferred_drop_effect.rs
@@ -1,17 +1,12 @@
-//! Regression tests for the `Preferred DropEffect` companion format
-//! advertised alongside `FileGroupDescriptorW` by [`Cliprdr::initiate_file_copy`].
-//!
-//! Follows up on [PR #1301]: the merge landed without test coverage and
-//! the Copilot review flagged this. The two behaviors covered here:
+//! Tests for the `Preferred DropEffect` companion format that
+//! [`Cliprdr::initiate_file_copy`] advertises alongside
+//! `FileGroupDescriptorW`:
 //!
 //! 1. `initiate_file_copy` advertises BOTH `FileGroupDescriptorW` and
 //!    `Preferred DropEffect` in the outgoing `FormatList`.
 //! 2. A subsequent `FormatDataRequest` for the drop-effect format id is
 //!    answered inline with the 4-byte little-endian `DROPEFFECT_COPY`
 //!    payload (`0x01 0x00 0x00 0x00`), not forwarded to the backend.
-//!
-//! [PR #1301]: https://github.com/Devolutions/IronRDP/pull/1301
-//! [Copilot review comment]: https://github.com/Devolutions/IronRDP/pull/1301#discussion_r2169280717
 
 use ironrdp_cliprdr::pdu::{ClipboardFormatName, ClipboardPdu, FileDescriptor, FormatDataRequest};
 use ironrdp_svc::{SvcMessage, SvcProcessor as _};

--- a/crates/ironrdp-testsuite-core/tests/clipboard/preferred_drop_effect.rs
+++ b/crates/ironrdp-testsuite-core/tests/clipboard/preferred_drop_effect.rs
@@ -79,29 +79,31 @@ fn initiate_file_copy_advertises_drop_effect_alongside_file_group_descriptor() {
 /// A `FormatDataRequest` for the drop-effect format id is answered
 /// inline by `Cliprdr` itself (not forwarded to the backend) with the
 /// 4-byte little-endian `DROPEFFECT_COPY = 0x00000001` payload.
+///
+/// Keys off the format *name* (`PREFERRED_DROP_EFFECT`) when looking up
+/// the id — wire-faithful (the remote keys off the name too), and
+/// resilient to any internal-id constant changes upstream.
+///
+/// If `local_drop_effect_format_id` ever stops being set by
+/// `initiate_file_copy` (or the inline short-circuit in
+/// `handle_format_data_request` is removed), this test fails because
+/// `TestBackend::on_format_data_request` is a no-op — the request
+/// would fall through to the backend, no response would be emitted,
+/// and `responses.len()` would be `0`.
 #[test]
 fn format_data_request_for_drop_effect_returns_dropeffect_copy_inline() {
     let mut cliprdr = init_ready_client();
 
-    // Drive `initiate_file_copy` so the server sets its
-    // `local_drop_effect_format_id` and starts recognizing requests for
-    // it. Discard the outbound FormatList — covered by the test above.
+    // Drive `initiate_file_copy`; the returned FormatList carries the
+    // drop-effect format we need to query.
     let files = vec![FileDescriptor::new("doc.txt").with_file_size(42)];
-    let _ = cliprdr.initiate_file_copy(files).unwrap();
+    let initiate_msgs: Vec<SvcMessage> = cliprdr.initiate_file_copy(files).unwrap().into();
 
-    // Find the drop-effect format id from the advertised FormatList by
-    // re-driving the call would be circular; instead, key off the format
-    // *name* by walking the FormatList we just emitted. Easier and
-    // wire-faithful since the remote keys off the name too.
-    let initiate_msgs: Vec<SvcMessage> = cliprdr
-        .initiate_file_copy(vec![FileDescriptor::new("d.txt").with_file_size(1)])
-        .unwrap()
-        .into();
     decode_pdu!(&initiate_msgs[0] => initiate_bytes, initiate_pdu);
     let ClipboardPdu::FormatList(format_list) = initiate_pdu else {
-        panic!("expected FormatList");
+        panic!("expected FormatList, got {initiate_pdu:?}");
     };
-    let drop_effect_format = format_list
+    let drop_effect_id = format_list
         .get_formats(true)
         .unwrap()
         .into_iter()
@@ -110,8 +112,8 @@ fn format_data_request_for_drop_effect_returns_dropeffect_copy_inline() {
                 .as_ref()
                 .is_some_and(|n| n == &ClipboardFormatName::PREFERRED_DROP_EFFECT)
         })
-        .expect("Preferred DropEffect must be advertised");
-    let drop_effect_id = drop_effect_format.id;
+        .expect("initiate_file_copy must advertise Preferred DropEffect")
+        .id;
 
     // Simulate the remote asking for the drop-effect format.
     let request_pdu = ClipboardPdu::FormatDataRequest(FormatDataRequest { format: drop_effect_id });
@@ -121,7 +123,7 @@ fn format_data_request_for_drop_effect_returns_dropeffect_copy_inline() {
     assert_eq!(
         responses.len(),
         1,
-        "drop-effect FormatDataRequest should be answered inline with one FormatDataResponse"
+        "drop-effect FormatDataRequest must be answered inline with one FormatDataResponse"
     );
 
     decode_pdu!(&responses[0] => resp_bytes, resp_pdu);
@@ -131,8 +133,8 @@ fn format_data_request_for_drop_effect_returns_dropeffect_copy_inline() {
     assert!(!response.is_error(), "response must not be an error");
 
     // [MS-RDPECLIP] Preferred DropEffect payload is a 4-byte u32 LE.
-    // `DROPEFFECT_COPY = 0x00000001` is what we advertise as the only
-    // value `initiate_file_copy` ever produces.
+    // `DROPEFFECT_COPY = 0x00000001` is what `initiate_file_copy`
+    // semantically always means.
     assert_eq!(
         response.data(),
         &[0x01, 0x00, 0x00, 0x00],

--- a/crates/ironrdp-testsuite-core/tests/clipboard/preferred_drop_effect.rs
+++ b/crates/ironrdp-testsuite-core/tests/clipboard/preferred_drop_effect.rs
@@ -1,0 +1,137 @@
+//! Regression tests for the `Preferred DropEffect` companion format
+//! advertised alongside `FileGroupDescriptorW` by [`Cliprdr::initiate_file_copy`].
+//!
+//! Follows up on [PR #1301]: the merge landed without test coverage and
+//! the Copilot review flagged this. The two behaviors covered here:
+//!
+//! 1. `initiate_file_copy` advertises BOTH `FileGroupDescriptorW` and
+//!    `Preferred DropEffect` in the outgoing `FormatList`.
+//! 2. A subsequent `FormatDataRequest` for the drop-effect format id is
+//!    answered inline with the 4-byte little-endian `DROPEFFECT_COPY`
+//!    payload (`0x01 0x00 0x00 0x00`), not forwarded to the backend.
+//!
+//! [PR #1301]: https://github.com/Devolutions/IronRDP/pull/1301
+//! [Copilot review comment]: https://github.com/Devolutions/IronRDP/pull/1301#discussion_r2169280717
+
+use ironrdp_cliprdr::pdu::{ClipboardFormatName, ClipboardPdu, FileDescriptor, FormatDataRequest};
+use ironrdp_svc::{SvcMessage, SvcProcessor as _};
+
+use super::test_helpers::init_ready_client;
+
+/// Decode an SvcMessage back into a ClipboardPdu for assertion.
+/// Two `let` bindings are required so the byte buffer outlives the
+/// borrowing PDU.
+macro_rules! decode_pdu {
+    ($msg:expr => $bytes:ident, $pdu:ident) => {
+        let $bytes = ($msg).encode_unframed_pdu().unwrap();
+        let $pdu = ironrdp_core::decode::<ClipboardPdu<'_>>(&$bytes).unwrap();
+    };
+}
+
+/// `initiate_file_copy` must advertise BOTH `FileGroupDescriptorW`
+/// (the file list itself) AND `Preferred DropEffect` (the companion
+/// format Windows Explorer pairs with file lists to engage its shell
+/// file-copy machinery + native progress dialog).
+#[test]
+fn initiate_file_copy_advertises_drop_effect_alongside_file_group_descriptor() {
+    let mut cliprdr = init_ready_client();
+
+    let files = vec![
+        FileDescriptor::new("alpha.txt").with_file_size(100),
+        FileDescriptor::new("beta.bin").with_file_size(200),
+    ];
+    let messages: Vec<SvcMessage> = cliprdr.initiate_file_copy(files).unwrap().into();
+
+    assert_eq!(messages.len(), 1, "initiate_file_copy should send a single FormatList PDU");
+
+    decode_pdu!(&messages[0] => bytes, pdu);
+    let ClipboardPdu::FormatList(format_list) = pdu else {
+        panic!("expected FormatList PDU, got {pdu:?}");
+    };
+
+    let formats = format_list
+        .get_formats(true)
+        .expect("FormatList should decode under long-format-names");
+
+    let has_file_group_descriptor = formats
+        .iter()
+        .any(|f| f.name.as_ref().is_some_and(|n| n == &ClipboardFormatName::FILE_LIST));
+    let has_drop_effect = formats.iter().any(|f| {
+        f.name
+            .as_ref()
+            .is_some_and(|n| n == &ClipboardFormatName::PREFERRED_DROP_EFFECT)
+    });
+
+    assert!(
+        has_file_group_descriptor,
+        "FormatList must advertise FileGroupDescriptorW; got {formats:#?}"
+    );
+    assert!(
+        has_drop_effect,
+        "FormatList must advertise Preferred DropEffect; got {formats:#?}"
+    );
+}
+
+/// A `FormatDataRequest` for the drop-effect format id is answered
+/// inline by `Cliprdr` itself (not forwarded to the backend) with the
+/// 4-byte little-endian `DROPEFFECT_COPY = 0x00000001` payload.
+#[test]
+fn format_data_request_for_drop_effect_returns_dropeffect_copy_inline() {
+    let mut cliprdr = init_ready_client();
+
+    // Drive `initiate_file_copy` so the server sets its
+    // `local_drop_effect_format_id` and starts recognizing requests for
+    // it. Discard the outbound FormatList — covered by the test above.
+    let files = vec![FileDescriptor::new("doc.txt").with_file_size(42)];
+    let _ = cliprdr.initiate_file_copy(files).unwrap();
+
+    // Find the drop-effect format id from the advertised FormatList by
+    // re-driving the call would be circular; instead, key off the format
+    // *name* by walking the FormatList we just emitted. Easier and
+    // wire-faithful since the remote keys off the name too.
+    let initiate_msgs: Vec<SvcMessage> =
+        cliprdr.initiate_file_copy(vec![FileDescriptor::new("d.txt").with_file_size(1)]).unwrap().into();
+    decode_pdu!(&initiate_msgs[0] => initiate_bytes, initiate_pdu);
+    let ClipboardPdu::FormatList(format_list) = initiate_pdu else {
+        panic!("expected FormatList");
+    };
+    let drop_effect_format = format_list
+        .get_formats(true)
+        .unwrap()
+        .into_iter()
+        .find(|f| {
+            f.name
+                .as_ref()
+                .is_some_and(|n| n == &ClipboardFormatName::PREFERRED_DROP_EFFECT)
+        })
+        .expect("Preferred DropEffect must be advertised");
+    let drop_effect_id = drop_effect_format.id;
+
+    // Simulate the remote asking for the drop-effect format.
+    let request_pdu = ClipboardPdu::FormatDataRequest(FormatDataRequest {
+        format: drop_effect_id,
+    });
+    let request_bytes = ironrdp_core::encode_vec(&request_pdu).unwrap();
+    let responses: Vec<SvcMessage> = cliprdr.process(&request_bytes).unwrap();
+
+    assert_eq!(
+        responses.len(),
+        1,
+        "drop-effect FormatDataRequest should be answered inline with one FormatDataResponse"
+    );
+
+    decode_pdu!(&responses[0] => resp_bytes, resp_pdu);
+    let ClipboardPdu::FormatDataResponse(response) = resp_pdu else {
+        panic!("expected FormatDataResponse, got {resp_pdu:?}");
+    };
+    assert!(!response.is_error(), "response must not be an error");
+
+    // [MS-RDPECLIP] Preferred DropEffect payload is a 4-byte u32 LE.
+    // `DROPEFFECT_COPY = 0x00000001` is what we advertise as the only
+    // value `initiate_file_copy` ever produces.
+    assert_eq!(
+        response.data(),
+        &[0x01, 0x00, 0x00, 0x00],
+        "Preferred DropEffect payload must be exactly 4 bytes DROPEFFECT_COPY (LE)"
+    );
+}


### PR DESCRIPTION
## Summary

Adds the regression test requested by the [Copilot review on #1301](https://github.com/Devolutions/IronRDP/pull/1301#discussion_r2169280717) (the PR merged without test coverage for the new behavior).

Two cases:

1. `initiate_file_copy` advertises both \`FileGroupDescriptorW\` **and** \`Preferred DropEffect\` in the outgoing \`FormatList\`.
2. A \`FormatDataRequest\` for the drop-effect format id is answered inline by \`Cliprdr\` (not forwarded to the backend) with exactly 4 bytes \`0x01 0x00 0x00 0x00\` (\`DROPEFFECT_COPY\`, u32 LE).

Test #2 keys off the format **name** (\`ClipboardFormatName::PREFERRED_DROP_EFFECT\`) rather than the hardcoded \`0xC0FD\` id — wire-faithful (the remote keys off the name too), and resilient if the internal id constant ever shifts.

Test uses the existing \`init_ready_client()\` helper from \`test_helpers.rs\` (which advertises \`STREAM_FILECLIP_ENABLED\`, required for \`initiate_file_copy\` to succeed).

## Test plan
- [x] Both new tests pass: \`cargo test -p ironrdp-testsuite-core --test integration_tests_core preferred_drop_effect\`
- [x] The wider clipboard suite (175 tests) is unaffected: \`cargo test -p ironrdp-testsuite-core clipboard\` → 175 passed