### PR TITLE
test(fuzz): add egfx_round_trip oracle and target

### DIFF
--- a/crates/ironrdp-fuzzing/src/oracles/mod.rs
+++ b/crates/ironrdp-fuzzing/src/oracles/mod.rs
@@ -314,6 +314,49 @@ pub fn pdu_round_trip(data: &[u8]) {
     pdu_round_trip_one!(data, ironrdp_rdpsnd::pdu::ClientAudioOutputPdu);
 }
 
+/// Round-trip oracle for `ironrdp-egfx` PDU types: `decode` → `encode_vec` → re-`decode`.
+///
+/// Same shape and property as [`pdu_round_trip`] but scoped to `ironrdp-egfx`'s
+/// own encoder surface. This is the egfx-scoped sibling of the `pdu_round_trip`
+/// oracle and the first target under the egfx fuzz-coverage umbrella tracked at
+/// the egfx-fuzz issue.
+///
+/// Coverage:
+///
+/// - `GfxPdu` is the top-level egfx command dispatch and transitively covers
+///   `WireToSurface1Pdu`, `WireToSurface2Pdu`, `SolidFillPdu`,
+///   `SurfaceToSurfacePdu`, `SurfaceToCachePdu`, `CacheToSurfacePdu`,
+///   `EvictCacheEntryPdu`, `CreateSurfacePdu`, `DeleteSurfacePdu`,
+///   `StartFramePdu`, `EndFramePdu`, `ResetGraphicsPdu`,
+///   `MapSurfaceToOutputPdu`, `MapSurfaceToWindowPdu`,
+///   `MapSurfaceToScaledOutputPdu`, `MapSurfaceToScaledWindowPdu`,
+///   `FrameAcknowledgePdu`, `QoeFrameAcknowledgePdu`,
+///   `DeleteEncodingContextPdu`, `CacheImportOfferPdu`, `CacheImportReplyPdu`.
+/// - `CapabilitiesAdvertisePdu` and `CapabilitiesConfirmPdu` exercise the
+///   capability-negotiation encoder surface (with `RawCapabilitySet` payloads
+///   post-#1305's wire/typed split).
+/// - `Avc420BitmapStream` and `Avc444BitmapStream` exercise the H.264 wire
+///   container encoder.
+///
+/// What this catches: same as `pdu_round_trip` — `unreachable!()` reached on
+/// decoder-accepted inputs, integer overflow / OOB in egfx encoders, panics
+/// in the decoder when fed encoder-produced bytes.
+///
+/// What this does NOT catch: the OpenH264 input-construction wrapper, ZGFX
+/// decompression, multi-frame H.264 state. Those are sibling targets in the
+/// egfx fuzz-coverage umbrella.
+pub fn egfx_round_trip(data: &[u8]) {
+    use ironrdp_egfx::pdu::{
+        Avc420BitmapStream, Avc444BitmapStream, CapabilitiesAdvertisePdu, CapabilitiesConfirmPdu, GfxPdu,
+    };
+
+    pdu_round_trip_one!(data, GfxPdu);
+    pdu_round_trip_one!(data, CapabilitiesAdvertisePdu);
+    pdu_round_trip_one!(data, CapabilitiesConfirmPdu);
+    pdu_round_trip_one!(data, Avc420BitmapStream<'_>);
+    pdu_round_trip_one!(data, Avc444BitmapStream<'_>);
+}
+
 pub fn rle_decompress_bitmap(input: BitmapInput<'_>) {
     let mut out = Vec::new();
 

--- a/crates/ironrdp-testsuite-core/tests/fuzz_regression.rs
+++ b/crates/ironrdp-testsuite-core/tests/fuzz_regression.rs
@@ -51,3 +51,8 @@ fn check_bulk_round_trip() {
 fn check_pdu_round_trip() {
     check!(pdu_round_trip);
 }
+
+#[test]
+fn check_egfx_round_trip() {
+    check!(egfx_round_trip);
+}

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -90,3 +90,10 @@ test = false
 doc = false
 bench = false
 
+[[bin]]
+name = "egfx_round_trip"
+path = "fuzz_targets/egfx_round_trip.rs"
+test = false
+doc = false
+bench = false
+

--- a/fuzz/fuzz_targets/egfx_round_trip.rs
+++ b/fuzz/fuzz_targets/egfx_round_trip.rs
@@ -1,0 +1,7 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    ironrdp_fuzzing::oracles::egfx_round_trip(data);
+});


### PR DESCRIPTION
Extends the round-trip fuzzing pattern from PR #1291 (`pdu_round_trip`)
to `ironrdp-egfx`'s own encoder surface. Same shape and property as
`pdu_round_trip`: decode -> encode_vec -> re-decode, silently dropping
Err results from any stage, surfacing internal panics from inside the
egfx encoder or decoder on decoder-accepted inputs.

Coverage:

- `GfxPdu` (top-level egfx command dispatch, transitively covers
  WireToSurface1/2, SolidFill, SurfaceToSurface, SurfaceToCache,
  CacheToSurface, EvictCacheEntry, CreateSurface, DeleteSurface,
  StartFrame, EndFrame, ResetGraphics, MapSurfaceToOutput,
  MapSurfaceToWindow, MapSurfaceToScaledOutput,
  MapSurfaceToScaledWindow, FrameAcknowledge, QoeFrameAcknowledge,
  DeleteEncodingContext, CacheImportOffer, CacheImportReply).
- `CapabilitiesAdvertisePdu` and `CapabilitiesConfirmPdu`
  (capability-negotiation encoder surface with `RawCapabilitySet`
  payloads post-#1305 wire/typed split).
- `Avc420BitmapStream<'_>` and `Avc444BitmapStream<'_>` (H.264 wire
  container encoder/decoder symmetry).

New target auto-discovers into CI via `cargo xtask fuzz list` per
PR #1290's dynamic CI fan-out.

Smoke fuzz: 71,757 iterations in 6 seconds on the empty seed corpus,
zero crashes, 787 lines of coverage, 635 corpus entries auto-generated.
Extended fuzz: 14,982,181 iterations in 121 seconds at ~125K exec/s
sustained, zero crashes; coverage plateaued at 1,564 lines.

Catches: `unreachable!()` reached on decoder-accepted inputs in any
egfx encoder, integer overflow / OOB inside egfx encoders, panics in
the decoder when fed encoder-produced bytes. Does NOT catch: OpenH264
input-construction wrapper, ZGFX decompression, multi-frame H.264
state. Those are sibling targets in the egfx fuzz-coverage umbrella.

Test plan: `cargo xtask check fmt/lints/tests/typos/locks` all pass;
new `check_egfx_round_trip` regression-replay test in
`crates/ironrdp-testsuite-core/tests/fuzz_regression.rs` runs and
passes against the seed corpus.

Refs #1316. Target 4 (round_trip) from the egfx fuzz coverage
umbrella. Sibling shape under #1124 task 1 narrowed to egfx encoders.