### PR TITLE
refactor(rdpeusb): split PDU and TS_URB enum wrapper

### DIFF
--- a/crates/ironrdp-rdpeusb/src/pdu/caps.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/caps.rs
@@ -44,7 +44,7 @@ impl RimExchangeCapabilityRequest {
 
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: InterfaceId::CAPABILITIES.with_mask(Mask::None),
+            iface_id: InterfaceId::CAPABILITIES.with_mask(Mask::None),
             msg_id: self.msg_id,
             function_id: Some(FunctionId::RIM_EXCHANGE_CAPABILITY_REQUEST),
         }
@@ -106,7 +106,7 @@ impl RimExchangeCapabilityResponse {
 
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: InterfaceId::CAPABILITIES.with_mask(Mask::None),
+            iface_id: InterfaceId::CAPABILITIES.with_mask(Mask::None),
             msg_id: self.msg_id,
             function_id: None,
         }

--- a/crates/ironrdp-rdpeusb/src/pdu/caps.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/caps.rs
@@ -44,8 +44,7 @@ impl RimExchangeCapabilityRequest {
 
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: InterfaceId::CAPABILITIES,
-            mask: Mask::StreamIdNone,
+            interface_id: InterfaceId::CAPABILITIES.with_mask(Mask::None),
             msg_id: self.msg_id,
             function_id: Some(FunctionId::RIM_EXCHANGE_CAPABILITY_REQUEST),
         }
@@ -107,8 +106,7 @@ impl RimExchangeCapabilityResponse {
 
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: InterfaceId::CAPABILITIES,
-            mask: Mask::StreamIdNone,
+            interface_id: InterfaceId::CAPABILITIES.with_mask(Mask::None),
             msg_id: self.msg_id,
             function_id: None,
         }

--- a/crates/ironrdp-rdpeusb/src/pdu/completion/mod.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/completion/mod.rs
@@ -86,35 +86,37 @@ impl IoControlCompletion {
         let information = src.read_u32();
         let output_buffer_size = src.read_u32();
 
-        // Should this stuff be part of some validate() function?
-        if hresult == 0 {
-            if information != output_buffer_size {
-                return Err(invalid_field_err!(
-                    "Information != OutputBufferSize",
-                    "HResult is: 0x0 (IOCTL success), but Information != OutputBufferSize"
-                ));
-            }
-        } else if hresult != HRESULT_FROM_WIN32_ERROR_INSUFFICIENT_BUFFER && output_buffer_size != 0 {
-            // > If the HResult field is equal to HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER)
-            // > then ... . For any other case `OutputBufferSize` **MUST** be set to 0 ...
-            //
-            // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeusb/b1722374-0658-47ba-8368-87bf9d3db4d4
-            return Err(invalid_field_err!(
-                "OutputBufferSize",
-                "HResult is not one of: 0x0 (success), 0x8007007A (insufficient buffer error), \
-                    so expected OutputBufferSize: 0x0"
-            ));
-        }
+        let n = output_buffer_size.try_into().map_err(|e| other_err!(source: e))?;
 
         let output_buffer = match hresult {
-            // #[expect(clippy::as_conversions)]
-            0 | HRESULT_FROM_WIN32_ERROR_INSUFFICIENT_BUFFER => {
-                let n = information.try_into().map_err(|e| other_err!(source: e))?;
-                Vec::from(src.read_slice(n))
+            0 => {
+                if information != output_buffer_size {
+                    return Err(invalid_field_err!(
+                        "Information != OutputBufferSize",
+                        "HResult is: 0x0 (IOCTL success), but Information != OutputBufferSize"
+                    ));
+                }
+                ensure_size!(in: src, size: n);
+                src.read_slice(n).to_vec()
             }
-            // > For any other case [OutputBufferSize] MUST be set to 0
-            // Which means empty output_buffer
-            _ => Vec::new(),
+            HRESULT_FROM_WIN32_ERROR_INSUFFICIENT_BUFFER => {
+                ensure_size!(in: src, size: n);
+                src.read_slice(n).to_vec()
+            }
+            _ => {
+                if output_buffer_size != 0 {
+                    // > If the HResult field is equal to HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER)
+                    // > then ... . For any other case `OutputBufferSize` **MUST** be set to 0 ...
+                    //
+                    // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeusb/b1722374-0658-47ba-8368-87bf9d3db4d4
+                    return Err(invalid_field_err!(
+                        "OutputBufferSize",
+                        "HResult is not one of: 0x0 (success), 0x8007007A (insufficient buffer error), \
+                    so expected OutputBufferSize: 0x0"
+                    ));
+                }
+                Vec::new()
+            }
         };
 
         Ok(Self {
@@ -150,24 +152,14 @@ impl Encode for IoControlCompletion {
     }
 
     fn size(&self) -> usize {
-        #[expect(clippy::as_conversions)]
-        let out_buf = if self.hresult == 0 {
-            assert_eq!(self.information, self.output_buffer_size);
-            self.output_buffer.len()
-        } else if self.hresult == HRESULT_FROM_WIN32_ERROR_INSUFFICIENT_BUFFER {
-            self.information as usize
-        } else {
-            0
-        };
-
         strict_sum(&[SharedMsgHeader::SIZE_REQ
             + const {
                 size_of::<RequestIdIoctl>(/* RequestId */)
                     + size_of::<HResult>()
-                    + size_of::<u32>(/* Information */)
-                    + size_of::<u32>(/* OutputBufferSize */)
+                    + 4 /* Information */
+                    + 4 /* OutputBufferSize */
             }
-            + out_buf])
+            + self.output_buffer.len()])
     }
 }
 

--- a/crates/ironrdp-rdpeusb/src/pdu/completion/mod.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/completion/mod.rs
@@ -71,7 +71,7 @@ pub struct IoControlCompletion {
 impl IoControlCompletion {
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: self.completion_iface.with_mask(Mask::Proxy),
+            iface_id: self.completion_iface.with_mask(Mask::Proxy),
             msg_id: self.msg_id,
             function_id: Some(FunctionId::IOCONTROL_COMPLETION),
         }
@@ -193,7 +193,7 @@ pub struct UrbCompletion {
 impl UrbCompletion {
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: self.completion_iface.with_mask(Mask::Proxy),
+            iface_id: self.completion_iface.with_mask(Mask::Proxy),
             msg_id: self.msg_id,
             function_id: Some(FunctionId::URB_COMPLETION),
         }
@@ -295,7 +295,7 @@ pub struct UrbCompletionNoData {
 impl UrbCompletionNoData {
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: self.completion_iface.with_mask(Mask::Proxy),
+            iface_id: self.completion_iface.with_mask(Mask::Proxy),
             msg_id: self.msg_id,
             function_id: Some(FunctionId::URB_COMPLETION_NO_DATA),
         }

--- a/crates/ironrdp-rdpeusb/src/pdu/completion/mod.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/completion/mod.rs
@@ -71,14 +71,13 @@ pub struct IoControlCompletion {
 impl IoControlCompletion {
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: self.completion_iface,
-            mask: Mask::StreamIdProxy,
+            interface_id: self.completion_iface.with_mask(Mask::Proxy),
             msg_id: self.msg_id,
             function_id: Some(FunctionId::IOCONTROL_COMPLETION),
         }
     }
 
-    pub(crate) fn decode(src: &mut ReadCursor<'_>, header: SharedMsgHeader) -> DecodeResult<Self> {
+    pub(crate) fn decode(src: &mut ReadCursor<'_>, msg_id: MessageId, udev_iface: InterfaceId) -> DecodeResult<Self> {
         const FIXED: usize = 4 /* RequestId */ + 4 /* HResult */ + 4 /* Information */ + 4 /* OutputBufferSize */;
         ensure_size!(in: src, size: FIXED);
 
@@ -119,8 +118,8 @@ impl IoControlCompletion {
         };
 
         Ok(Self {
-            msg_id: header.msg_id,
-            completion_iface: header.interface_id,
+            msg_id,
+            completion_iface: udev_iface,
             request_id,
             hresult,
             information,
@@ -194,14 +193,13 @@ pub struct UrbCompletion {
 impl UrbCompletion {
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: self.completion_iface,
-            mask: Mask::StreamIdProxy,
+            interface_id: self.completion_iface.with_mask(Mask::Proxy),
             msg_id: self.msg_id,
             function_id: Some(FunctionId::URB_COMPLETION),
         }
     }
 
-    pub(crate) fn decode(src: &mut ReadCursor<'_>, header: SharedMsgHeader) -> DecodeResult<Self> {
+    pub(crate) fn decode(src: &mut ReadCursor<'_>, msg_id: MessageId, udev_iface: InterfaceId) -> DecodeResult<Self> {
         ensure_size!(in: src, size: 4 /* RequestId */ + 4 /* CbTsUrbResult */);
         let req_id = RequestIdTransferInOut::try_from(src.read_u32())
             .map_err(|reason| invalid_field_err!("URB_COMPLETION::RequestId", reason))?;
@@ -225,8 +223,8 @@ impl UrbCompletion {
         ensure_size!(in: src, size: output_buffer_size);
         let output_buffer = src.read_slice(output_buffer_size).to_vec();
         Ok(Self {
-            msg_id: header.msg_id,
-            completion_iface: header.interface_id,
+            msg_id,
+            completion_iface: udev_iface,
             req_id,
             ts_urb_result,
             hresult,
@@ -297,14 +295,13 @@ pub struct UrbCompletionNoData {
 impl UrbCompletionNoData {
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: self.completion_iface,
-            mask: Mask::StreamIdProxy,
+            interface_id: self.completion_iface.with_mask(Mask::Proxy),
             msg_id: self.msg_id,
             function_id: Some(FunctionId::URB_COMPLETION_NO_DATA),
         }
     }
 
-    pub(crate) fn decode(src: &mut ReadCursor<'_>, header: SharedMsgHeader) -> DecodeResult<Self> {
+    pub(crate) fn decode(src: &mut ReadCursor<'_>, msg_id: MessageId, udev_iface: InterfaceId) -> DecodeResult<Self> {
         ensure_size!(in: src, size: 4 /* RequestId */ + 4 /* CbTsUrbResult */);
         let req_id = RequestIdTransferInOut::try_from(src.read_u32())
             .map_err(|reason| invalid_field_err!("URB_COMPLETION_NO_DATA::RequestId", reason))?;
@@ -316,8 +313,8 @@ impl UrbCompletionNoData {
         let hresult = src.read_u32();
         let output_buffer_size = src.read_u32();
         Ok(Self {
-            msg_id: header.msg_id,
-            completion_iface: header.interface_id,
+            msg_id,
+            completion_iface: udev_iface,
             req_id,
             ts_urb_result,
             hresult,

--- a/crates/ironrdp-rdpeusb/src/pdu/completion/ts_urb_result.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/completion/ts_urb_result.rs
@@ -43,7 +43,9 @@ impl Decode<'_> for TsUrbResult {
         if urb_size < ACTUAL_HEADER_SIZE {
             return Err(invalid_field_err!("TS_URB_RESULT_HEADER::Size", "is smaller than 8"));
         }
-        let payload = TsUrbResultPayload::decode(&mut ReadCursor::new(src.read_slice(urb_size - ACTUAL_HEADER_SIZE)))?;
+        let payload_size = urb_size - ACTUAL_HEADER_SIZE;
+        ensure_size!(in: src, size: payload_size);
+        let payload = TsUrbResultPayload::decode(&mut ReadCursor::new(src.read_slice(payload_size)))?;
         Ok(Self { header, payload })
     }
 }
@@ -426,7 +428,9 @@ impl Decode<'_> for TsUsbdInterfaceInfoResult {
                 "is less than min reqd value of 16"
             ));
         };
-        let mut src = ReadCursor::new(src.read_slice(usize::from(length) - 2));
+        let remaining_length = usize::from(length) - 2 /* Length */;
+        ensure_size!(in: src, size: remaining_length);
+        let mut src = ReadCursor::new(src.read_slice(remaining_length));
         let interface_number = src.read_u8();
         let alternate_setting = src.read_u8();
         let class = src.read_u8();

--- a/crates/ironrdp-rdpeusb/src/pdu/completion/ts_urb_result.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/completion/ts_urb_result.rs
@@ -1,4 +1,4 @@
-//! Packets sent as responses to [`TsUrb`]s received from the server as part of
+//! Packets sent as responses to [`TsUrbIn`] and [`TsUrbOut`] received from the server as part of
 //! [`TransferInRequest`] and [`TransferOutRequest`] messages.
 //!
 //! The [`TsUrbResult`] packets are sent as part of [`UrbCompletion`] or [`UrbCompletionNoData`].

--- a/crates/ironrdp-rdpeusb/src/pdu/header.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/header.rs
@@ -242,7 +242,7 @@ impl core::fmt::Display for FunctionId {
 #[doc(alias = "SHARED_MSG_HEADER")]
 #[derive(Debug, PartialEq, Clone)]
 pub struct SharedMsgHeader {
-    pub interface_id: u32,
+    pub iface_id: u32,
     pub msg_id: MessageId,
     pub function_id: Option<FunctionId>,
 }
@@ -255,7 +255,7 @@ impl SharedMsgHeader {
     pub(super) fn decode_with_function_id(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
         ensure_size!(in: src, size: Self::SIZE_REQ);
         Ok(Self {
-            interface_id: src.read_u32(),
+            iface_id: src.read_u32(),
             msg_id: src.read_u32(),
             function_id: Some(FunctionId(src.read_u32())),
         })
@@ -266,7 +266,7 @@ impl Encode for SharedMsgHeader {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         ensure_size!(in: dst, size: self.size());
 
-        dst.write_u32(self.interface_id);
+        dst.write_u32(self.iface_id);
         dst.write_u32(self.msg_id);
 
         if let Some(id) = self.function_id {
@@ -293,7 +293,7 @@ impl Decode<'_> for SharedMsgHeader {
     fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
         ensure_size!(in: src, size: Self::SIZE_RSP );
         Ok(Self {
-            interface_id: src.read_u32(),
+            iface_id: src.read_u32(),
             msg_id: src.read_u32(),
             function_id: None,
         })

--- a/crates/ironrdp-rdpeusb/src/pdu/header.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/header.rs
@@ -16,20 +16,20 @@ pub type MessageId = u32;
 #[repr(u8)]
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum Mask {
+pub(crate) enum Mask {
     /// Indicates that the [`SharedMsgHeader`] is being used in a response message.
     #[doc(alias = "STREAM_ID_STUB")]
-    StreamIdStub = 0x2,
+    Stub = 0x2,
 
     /// Indicates that the [`SharedMsgHeader`] is not being used in a response message.
     #[doc(alias = "STREAM_ID_PROXY")]
-    StreamIdProxy = 0x1,
+    Proxy = 0x1,
 
     /// Indicates that the [`SharedMsgHeader`] is being used in a message for capabilities exchange
     /// ([`RimExchangeCapabilityRequest`], [`RimExchangeCapabilityResponse`]). This value **MUST
     /// NOT** be used for any other messages.
     #[doc(alias = "STREAM_ID_NONE")]
-    StreamIdNone = 0x0,
+    None = 0x0,
 }
 
 impl From<Mask> for u32 {
@@ -44,9 +44,9 @@ impl TryFrom<u8> for Mask {
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            0x0 => Ok(Self::StreamIdNone),
-            0x1 => Ok(Self::StreamIdProxy),
-            0x2 => Ok(Self::StreamIdStub),
+            0x0 => Ok(Self::None),
+            0x1 => Ok(Self::Proxy),
+            0x2 => Ok(Self::Stub),
             _ => Err(invalid_field_err!("try_from", "Mask", "invalid mask")),
         }
     }
@@ -100,6 +100,15 @@ impl InterfaceId {
     ///
     /// [1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeusb/a7ea1b33-80bb-4197-a502-ee62
     pub const NOTIFY_SERVER: Self = Self(0x3);
+
+    #[inline]
+    pub(crate) fn with_mask(self, mask: Mask) -> u32 {
+        self.0 | (u32::from(mask) << 30)
+    }
+
+    const fn from_raw(value: u32) -> Self {
+        Self(value & 0x3F_FF_FF_FF)
+    }
 }
 
 impl TryFrom<u32> for InterfaceId {
@@ -128,6 +137,12 @@ impl core::fmt::Display for InterfaceId {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.0)
     }
+}
+
+#[inline]
+pub(crate) fn unpack(id: u32) -> DecodeResult<(InterfaceId, Mask)> {
+    #[expect(clippy::as_conversions)]
+    Ok((InterfaceId::from_raw(id), Mask::try_from((id >> 30) as u8)?))
 }
 
 /// Indicates a task/function to perform.
@@ -166,9 +181,9 @@ pub struct FunctionId(pub(in crate::pdu) u32);
 
 impl FunctionId {
     pub const FIXED_PART_SIZE: usize = size_of::<Self>();
-    // // Needed for QI_REQ and QI_RSP
+    // Needed for QI_REQ and QI_RSP
     //
-    // /// Release the given interface ID.
+    /// Release the given interface ID.
     pub const RIMCALL_RELEASE: Self = Self(0x00000001);
     pub const RIMCALL_QUERYINTERFACE: Self = Self(0x00000002);
 
@@ -209,15 +224,9 @@ impl FunctionId {
     pub const CHANNEL_CREATED: Self = Self(0x100);
 }
 
-impl TryFrom<u32> for FunctionId {
-    type Error = DecodeError;
-
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        if matches!(value, 0x001 | 0x002 | 0x100..=0x107) {
-            Ok(Self(value))
-        } else {
-            Err(invalid_field_err!("FunctionId", "invalid FunctionId"))
-        }
+impl From<u32> for FunctionId {
+    fn from(value: u32) -> Self {
+        Self(value)
     }
 }
 
@@ -233,8 +242,7 @@ impl core::fmt::Display for FunctionId {
 #[doc(alias = "SHARED_MSG_HEADER")]
 #[derive(Debug, PartialEq, Clone)]
 pub struct SharedMsgHeader {
-    pub interface_id: InterfaceId,
-    pub mask: Mask,
+    pub interface_id: u32,
     pub msg_id: MessageId,
     pub function_id: Option<FunctionId>,
 }
@@ -243,14 +251,22 @@ impl SharedMsgHeader {
     pub const SIZE_RSP: usize = size_of::<u32>(/* InterfaceId, Mask */) + size_of::<MessageId>();
 
     pub const SIZE_REQ: usize = Self::SIZE_RSP + FunctionId::FIXED_PART_SIZE;
+
+    pub(super) fn decode_with_function_id(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: Self::SIZE_REQ);
+        Ok(Self {
+            interface_id: src.read_u32(),
+            msg_id: src.read_u32(),
+            function_id: Some(FunctionId(src.read_u32())),
+        })
+    }
 }
 
 impl Encode for SharedMsgHeader {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         ensure_size!(in: dst, size: self.size());
 
-        let first32 = u32::from(self.interface_id) | (u32::from(self.mask) << 30);
-        dst.write_u32(first32);
+        dst.write_u32(self.interface_id);
         dst.write_u32(self.msg_id);
 
         if let Some(id) = self.function_id {
@@ -276,33 +292,10 @@ impl Encode for SharedMsgHeader {
 impl Decode<'_> for SharedMsgHeader {
     fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
         ensure_size!(in: src, size: Self::SIZE_RSP );
-
-        let first32 = src.read_u32();
-        let interface_id = InterfaceId::try_from(first32 & 0x3F_FF_FF_FF)?;
-        #[expect(clippy::as_conversions)]
-        let mask = Mask::try_from((first32 >> 30) as u8)?;
-
-        let msg_id = src.read_u32();
-
-        let function_id = match mask {
-            Mask::StreamIdStub => None,
-            Mask::StreamIdProxy => {
-                ensure_size!(in: src, size: FunctionId::FIXED_PART_SIZE);
-                let id = FunctionId::try_from(src.read_u32())?;
-                Some(id)
-            }
-            Mask::StreamIdNone => {
-                ensure_size!(in: src, size: FunctionId::FIXED_PART_SIZE);
-                // either 0x100 (FunctionId) or 0x001 (CapabilityValue)
-                (src.peek_u32() == FunctionId::RIM_EXCHANGE_CAPABILITY_REQUEST.0).then(|| FunctionId(src.read_u32()))
-            }
-        };
-
-        Ok(SharedMsgHeader {
-            interface_id,
-            mask,
-            msg_id,
-            function_id,
+        Ok(Self {
+            interface_id: src.read_u32(),
+            msg_id: src.read_u32(),
+            function_id: None,
         })
     }
 }

--- a/crates/ironrdp-rdpeusb/src/pdu/iface_manipulation.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/iface_manipulation.rs
@@ -74,10 +74,9 @@ impl Encode for InterfaceRelease {
 
 /// [\[MS-RDPEXPS\] 2.2.2.1.1 Query Interface Request (QI_REQ)][1] message.
 ///
-/// Asks the receiver whether it supports the interface identified by
-/// [`new_interface_guid`](Self::new_interface_guid). Per [MS-RDPEXPS § 3.1.5.2.1.1] the server
-/// MUST NOT send `QI_REQ`; MS-RDPEUSB inherits this restriction. We decode incoming `QI_REQ` for
-/// ecosystem tolerance and answer with a failure [`QueryInterfaceFailureResponse`].
+/// Request a new interface ID. Per [MS-RDPEXPS § 3.1.5.2.1.1] the server MUST NOT send `QI_REQ`;
+/// MS-RDPEUSB inherits this restriction. We decode incoming `QI_REQ` for ecosystem tolerance and
+/// answer with a failure [`QueryInterfaceFailureResponse`].
 ///
 /// [1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpexps/10757445-d7dd-4602-b75f-772540c01a5d
 #[doc(alias = "QI_REQ")]

--- a/crates/ironrdp-rdpeusb/src/pdu/iface_manipulation.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/iface_manipulation.rs
@@ -1,0 +1,7 @@
+//! Messages specific to [Interface Manipulation][1] interface.
+//!
+//! MS-RDPEUSB utilizes the same Interface Query and Interface Release messages that are defined in
+//! [MS-RDPEXPS][2].
+//!
+//! [1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeusb/6dd37383-9aed-4f9e-ba74-febe3a21f0f5
+//! [2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpexps/ebe401f0-f22e-4de4-9cd3-2a55e5493500

--- a/crates/ironrdp-rdpeusb/src/pdu/iface_manipulation.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/iface_manipulation.rs
@@ -5,3 +5,177 @@
 //!
 //! [1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeusb/6dd37383-9aed-4f9e-ba74-febe3a21f0f5
 //! [2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpexps/ebe401f0-f22e-4de4-9cd3-2a55e5493500
+
+use ironrdp_core::{Decode, Encode, ensure_fixed_part_size, ensure_size, invalid_field_err};
+
+use crate::pdu::header::{FunctionId, MessageId, SharedMsgHeader};
+
+/// [\[MS-RDPEXPS\] 2.2.2.2 Interface Release (IFACE_RELEASE)][1] message.
+///
+/// One-way message that terminates an interface's lifetime.
+///
+/// [1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpexps/5db96fd4-617f-432f-b4ec-58f75564eb06
+#[doc(alias = "IFACE_RELEASE")]
+#[derive(Debug, PartialEq)]
+pub struct InterfaceRelease {
+    pub iface_id: u32,
+    pub msg_id: MessageId,
+}
+
+impl InterfaceRelease {
+    pub const FIXED_PART_SIZE: usize = SharedMsgHeader::SIZE_RSP;
+
+    pub fn header(&self) -> SharedMsgHeader {
+        SharedMsgHeader {
+            iface_id: self.iface_id,
+            msg_id: self.msg_id,
+            function_id: Some(FunctionId::RIMCALL_RELEASE),
+        }
+    }
+
+    pub(super) fn from_header(header: SharedMsgHeader) -> Self {
+        debug_assert!(header.function_id == Some(FunctionId::RIMCALL_RELEASE));
+        Self {
+            iface_id: header.iface_id,
+            msg_id: header.msg_id,
+        }
+    }
+}
+
+impl Decode<'_> for InterfaceRelease {
+    fn decode(src: &mut ironrdp_core::ReadCursor<'_>) -> ironrdp_core::DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+        let iface_id = src.read_u32();
+        let msg_id = src.read_u32();
+        if FunctionId(src.read_u32()) != FunctionId::RIMCALL_RELEASE {
+            return Err(invalid_field_err!(
+                "SHARED_MSG_HEADER::FunctionId",
+                "must be 0x1 (RIMCALL_RELEASE)"
+            ));
+        }
+
+        Ok(Self { iface_id, msg_id })
+    }
+}
+
+impl Encode for InterfaceRelease {
+    fn encode(&self, dst: &mut ironrdp_core::WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
+        self.header().encode(dst)
+    }
+
+    fn name(&self) -> &'static str {
+        "IFACE_RELEASE"
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+/// [\[MS-RDPEXPS\] 2.2.2.1.1 Query Interface Request (QI_REQ)][1] message.
+///
+/// Asks the receiver whether it supports the interface identified by
+/// [`new_interface_guid`](Self::new_interface_guid). Per [MS-RDPEXPS § 3.1.5.2.1.1] the server
+/// MUST NOT send `QI_REQ`; MS-RDPEUSB inherits this restriction. We decode incoming `QI_REQ` for
+/// ecosystem tolerance and answer with a failure [`QueryInterfaceFailureResponse`].
+///
+/// [1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpexps/10757445-d7dd-4602-b75f-772540c01a5d
+#[doc(alias = "QI_REQ")]
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct QueryInterfaceRequest {
+    pub iface_id: u32,
+    pub msg_id: MessageId,
+    pub new_interface_guid: u128,
+}
+
+impl QueryInterfaceRequest {
+    pub const FIXED_PART_SIZE: usize = SharedMsgHeader::SIZE_REQ + 16 /* NewInterfaceGUID */;
+
+    pub fn header(&self) -> SharedMsgHeader {
+        SharedMsgHeader {
+            iface_id: self.iface_id,
+            msg_id: self.msg_id,
+            function_id: Some(FunctionId::RIMCALL_QUERYINTERFACE),
+        }
+    }
+
+    pub(super) fn decode(
+        src: &mut ironrdp_core::ReadCursor<'_>,
+        header: SharedMsgHeader,
+    ) -> ironrdp_core::DecodeResult<Self> {
+        ensure_size!(in: src, size: 16);
+        Ok(Self {
+            iface_id: header.iface_id,
+            msg_id: header.msg_id,
+            new_interface_guid: src.read_u128(),
+        })
+    }
+}
+
+impl Encode for QueryInterfaceRequest {
+    fn encode(&self, dst: &mut ironrdp_core::WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
+        self.header().encode(dst)?;
+        ensure_size!(in: dst, size: 16);
+        dst.write_u128(self.new_interface_guid);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "QI_REQ"
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+/// [\[MS-RDPEXPS\] 2.2.2.1.2 Query Interface Response (QI_RSP)][1] — **failure** variant.
+///
+/// Per [MS-RDPEXPS § 3.1.5.2.1.2], on receiving a `QI_REQ` the receiver SHOULD return the failure
+/// version of `QI_RSP` — a `QI_RSP` **omitting** the optional `NewInterfaceId` field. The
+/// originating side MUST interpret this as "interface not supported".
+///
+/// We never advertise any negotiable interface, so we always reply with this failure variant;
+/// there is no `QueryInterfaceSuccessResponse` type.
+///
+/// [1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpexps/bcf53670-4db2-450a-b53e-879756ca18a8
+#[doc(alias = "QI_RSP")]
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct QueryInterfaceFailureResponse {
+    pub iface_id: u32,
+    pub msg_id: MessageId,
+}
+
+impl QueryInterfaceFailureResponse {
+    pub const FIXED_PART_SIZE: usize = SharedMsgHeader::SIZE_RSP;
+
+    pub fn for_request(req: &QueryInterfaceRequest) -> Self {
+        Self {
+            iface_id: req.iface_id,
+            msg_id: req.msg_id,
+        }
+    }
+
+    pub fn header(&self) -> SharedMsgHeader {
+        SharedMsgHeader {
+            iface_id: self.iface_id,
+            msg_id: self.msg_id,
+            function_id: None,
+        }
+    }
+}
+
+impl Encode for QueryInterfaceFailureResponse {
+    fn encode(&self, dst: &mut ironrdp_core::WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
+        // Failure QI_RSP = SHARED_MSG_HEADER only, no body.
+        self.header().encode(dst)
+    }
+
+    fn name(&self) -> &'static str {
+        "QI_RSP"
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}

--- a/crates/ironrdp-rdpeusb/src/pdu/iface_manipulation.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/iface_manipulation.rs
@@ -23,7 +23,7 @@ pub struct InterfaceRelease {
 }
 
 impl InterfaceRelease {
-    pub const FIXED_PART_SIZE: usize = SharedMsgHeader::SIZE_RSP;
+    pub const FIXED_PART_SIZE: usize = SharedMsgHeader::SIZE_REQ;
 
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
@@ -34,7 +34,6 @@ impl InterfaceRelease {
     }
 
     pub(super) fn from_header(header: SharedMsgHeader) -> Self {
-        debug_assert!(header.function_id == Some(FunctionId::RIMCALL_RELEASE));
         Self {
             iface_id: header.iface_id,
             msg_id: header.msg_id,

--- a/crates/ironrdp-rdpeusb/src/pdu/mod.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/mod.rs
@@ -46,7 +46,7 @@ impl Decode<'_> for UrbdrcServerPdu {
         let header = SharedMsgHeader::decode_with_function_id(src)?;
         let f_id = header.function_id.expect("missing function id");
 
-        match unpack(header.interface_id)? {
+        match unpack(header.iface_id)? {
             (InterfaceId::CAPABILITIES, Mask::None) => {
                 if f_id == FunctionId::RIM_EXCHANGE_CAPABILITY_REQUEST {
                     RimExchangeCapabilityRequest::decode(src, header).map(Self::Caps)
@@ -147,7 +147,7 @@ impl Decode<'_> for UrbdrcClientPdu {
         let header = SharedMsgHeader::decode(src)?;
         ensure_size!(in: src, size: 4 /* function id */);
 
-        match unpack(header.interface_id)? {
+        match unpack(header.iface_id)? {
             (InterfaceId::CAPABILITIES, Mask::None) => {
                 RimExchangeCapabilityResponse::decode(src, header).map(Self::Caps)
             }

--- a/crates/ironrdp-rdpeusb/src/pdu/mod.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/mod.rs
@@ -4,11 +4,13 @@
 //!
 //! [1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeusb/a1004d0e-99e9-4968-894b-0b924ef2f125
 
-use ironrdp_core::{Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, invalid_field_err};
+use ironrdp_core::{
+    Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, ensure_size, invalid_field_err,
+};
 
 use crate::pdu::caps::{RimExchangeCapabilityRequest, RimExchangeCapabilityResponse};
 use crate::pdu::completion::{IoControlCompletion, UrbCompletion, UrbCompletionNoData};
-use crate::pdu::header::{FunctionId, InterfaceId, Mask, SharedMsgHeader};
+use crate::pdu::header::{FunctionId, InterfaceId, Mask, SharedMsgHeader, unpack};
 use crate::pdu::notify::ChannelCreated;
 use crate::pdu::sink::{AddDevice, AddVirtualChannel};
 use crate::pdu::usb_dev::{
@@ -19,6 +21,7 @@ use crate::pdu::usb_dev::{
 pub mod caps;
 pub mod completion;
 pub mod header;
+pub mod iface_manipulation;
 pub mod notify;
 pub mod sink;
 pub mod usb_dev;
@@ -39,16 +42,13 @@ pub enum UrbdrcServerPdu {
 }
 
 impl Decode<'_> for UrbdrcServerPdu {
-    // TODO: QI_RSP
     fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
-        let header = SharedMsgHeader::decode(src)?;
-        let f_id = header
-            .function_id
-            .ok_or_else(|| invalid_field_err!("SHARED_MSG_HEADER::FunctionId", "is absent"))?;
+        let header = SharedMsgHeader::decode_with_function_id(src)?;
+        let f_id = header.function_id.expect("missing function id");
 
-        match header.interface_id {
-            InterfaceId::CAPABILITIES => {
-                if f_id == FunctionId::RIM_EXCHANGE_CAPABILITY_REQUEST && header.mask == Mask::StreamIdNone {
+        match unpack(header.interface_id)? {
+            (InterfaceId::CAPABILITIES, Mask::None) => {
+                if f_id == FunctionId::RIM_EXCHANGE_CAPABILITY_REQUEST {
                     RimExchangeCapabilityRequest::decode(src, header).map(Self::Caps)
                 } else {
                     Err(invalid_field_err!(
@@ -57,8 +57,8 @@ impl Decode<'_> for UrbdrcServerPdu {
                     ))
                 }
             }
-            InterfaceId::NOTIFY_CLIENT => {
-                if f_id == FunctionId::CHANNEL_CREATED && header.mask == Mask::StreamIdProxy {
+            (InterfaceId::NOTIFY_CLIENT, Mask::Proxy) => {
+                if f_id == FunctionId::CHANNEL_CREATED {
                     ChannelCreated::decode(src, header).map(Self::ChanCreated)
                 } else {
                     Err(invalid_field_err!(
@@ -67,34 +67,33 @@ impl Decode<'_> for UrbdrcServerPdu {
                     ))
                 }
             }
-            InterfaceId::NOTIFY_SERVER | InterfaceId::DEVICE_SINK => Err(invalid_field_err!(
-                "SHARED_MSG_HEADER",
-                "reserved interface ID is not valid for server-to-client messages"
-            )),
-            _udev_iface => {
-                if header.mask != Mask::StreamIdProxy {
-                    return Err(invalid_field_err!(
-                        "SHARED_MSG_HEADER::Mask",
-                        "is not 0x1 (STREAM_ID_PROXY)"
-                    ));
+            (udev_iface, Mask::Proxy) => match f_id {
+                FunctionId::CANCEL_REQUEST => {
+                    CancelRequest::decode(src, header.msg_id, udev_iface).map(Self::CancelReq)
                 }
-                match f_id {
-                    FunctionId::CANCEL_REQUEST => CancelRequest::decode(src, header).map(Self::CancelReq),
-                    FunctionId::REGISTER_REQUEST_CALLBACK => {
-                        RegisterRequestCallback::decode(src, header).map(Self::RegReqCb)
-                    }
-                    FunctionId::IO_CONTROL => IoControl::decode(src, header).map(Self::IoCtl),
-                    FunctionId::INTERNAL_IO_CONTROL => InternalIoControl::decode(src, header).map(Self::InternalIoCtl),
-                    FunctionId::QUERY_DEVICE_TEXT => QueryDeviceText::decode(src, header).map(Self::DevText),
-                    FunctionId::TRANSFER_IN_REQUEST => TransferInRequest::decode(src, header).map(Self::TransferIn),
-                    FunctionId::TRANSFER_OUT_REQUEST => TransferOutRequest::decode(src, header).map(Self::TransferOut),
-                    FunctionId::RETRACT_DEVICE => RetractDevice::decode(src, header).map(Self::Retract),
-                    _ => Err(invalid_field_err!(
-                        "SHARED_MSG_HEADER::FunctionId",
-                        "unsupported function id for USB device interface"
-                    )),
+                FunctionId::REGISTER_REQUEST_CALLBACK => {
+                    RegisterRequestCallback::decode(src, header.msg_id, udev_iface).map(Self::RegReqCb)
                 }
-            }
+                FunctionId::IO_CONTROL => IoControl::decode(src, header.msg_id, udev_iface).map(Self::IoCtl),
+                FunctionId::INTERNAL_IO_CONTROL => {
+                    InternalIoControl::decode(src, header.msg_id, udev_iface).map(Self::InternalIoCtl)
+                }
+                FunctionId::QUERY_DEVICE_TEXT => {
+                    QueryDeviceText::decode(src, header.msg_id, udev_iface).map(Self::DevText)
+                }
+                FunctionId::TRANSFER_IN_REQUEST => {
+                    TransferInRequest::decode(src, header.msg_id, udev_iface).map(Self::TransferIn)
+                }
+                FunctionId::TRANSFER_OUT_REQUEST => {
+                    TransferOutRequest::decode(src, header.msg_id, udev_iface).map(Self::TransferOut)
+                }
+                FunctionId::RETRACT_DEVICE => RetractDevice::decode(src, header.msg_id, udev_iface).map(Self::Retract),
+                _ => Err(invalid_field_err!(
+                    "SHARED_MSG_HEADER::FunctionId",
+                    "unsupported function id for USB device interface"
+                )),
+            },
+            _ => Err(invalid_field_err!("SHARED_MSG_HEADER", "invalid header")),
         }
     }
 }
@@ -146,29 +145,22 @@ pub enum UrbdrcClientPdu {
 impl Decode<'_> for UrbdrcClientPdu {
     fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
         let header = SharedMsgHeader::decode(src)?;
-        match header.interface_id {
-            InterfaceId::CAPABILITIES => {
-                if header.function_id.is_none() && header.mask == Mask::StreamIdNone {
-                    RimExchangeCapabilityResponse::decode(src, header).map(Self::Caps)
-                } else {
-                    Err(invalid_field_err!(
-                        "SHARED_MSG_HEADER",
-                        "invalid RIM_EXCHANGE_CAPABILITY_RESPONSE header"
-                    ))
-                }
+        ensure_size!(in: src, size: 4 /* function id */);
+
+        match unpack(header.interface_id)? {
+            (InterfaceId::CAPABILITIES, Mask::None) => {
+                RimExchangeCapabilityResponse::decode(src, header).map(Self::Caps)
             }
-            InterfaceId::DEVICE_SINK => match (header.function_id, header.mask) {
-                (Some(FunctionId::ADD_VIRTUAL_CHANNEL), Mask::StreamIdProxy) => {
-                    AddVirtualChannel::decode(src, header).map(Self::AddChan)
-                }
-                (Some(FunctionId::ADD_DEVICE), Mask::StreamIdProxy) => AddDevice::decode(src, header).map(Self::AddDev),
+            (InterfaceId::DEVICE_SINK, Mask::Proxy) => match FunctionId(src.read_u32()) {
+                FunctionId::ADD_VIRTUAL_CHANNEL => AddVirtualChannel::decode(src, header).map(Self::AddChan),
+                FunctionId::ADD_DEVICE => AddDevice::decode(src, header).map(Self::AddDev),
                 _ => Err(invalid_field_err!(
                     "SHARED_MSG_HEADER",
                     "invalid Device Sink interface header"
                 )),
             },
-            InterfaceId::NOTIFY_SERVER => {
-                if header.function_id == Some(FunctionId::CHANNEL_CREATED) && header.mask == Mask::StreamIdProxy {
+            (InterfaceId::NOTIFY_SERVER, Mask::Proxy) => {
+                if FunctionId(src.read_u32()) == FunctionId::CHANNEL_CREATED {
                     ChannelCreated::decode(src, header).map(Self::ChanCreated)
                 } else {
                     Err(invalid_field_err!(
@@ -177,26 +169,21 @@ impl Decode<'_> for UrbdrcClientPdu {
                     ))
                 }
             }
-            InterfaceId::NOTIFY_CLIENT => Err(invalid_field_err!(
-                "SHARED_MSG_HEADER",
-                "reserved interface ID is not valid for client-to-server messages"
-            )),
-            _id => match (header.function_id, header.mask) {
-                (None, Mask::StreamIdStub) => QueryDeviceTextRsp::decode(src, header).map(Self::DevTextRsp),
-                (Some(FunctionId::IOCONTROL_COMPLETION), Mask::StreamIdProxy) => {
-                    IoControlCompletion::decode(src, header).map(Self::IoctlComp)
+            (udev_iface, Mask::Stub) => QueryDeviceTextRsp::decode(src, header.msg_id, udev_iface).map(Self::DevTextRsp),
+            (udev_iface, Mask::Proxy) => match FunctionId(src.read_u32()) {
+                FunctionId::IOCONTROL_COMPLETION => {
+                    IoControlCompletion::decode(src, header.msg_id, udev_iface).map(Self::IoctlComp)
                 }
-                (Some(FunctionId::URB_COMPLETION), Mask::StreamIdProxy) => {
-                    UrbCompletion::decode(src, header).map(Self::UrbComp)
-                }
-                (Some(FunctionId::URB_COMPLETION_NO_DATA), Mask::StreamIdProxy) => {
-                    UrbCompletionNoData::decode(src, header).map(Self::UrbCompNoData)
+                FunctionId::URB_COMPLETION => UrbCompletion::decode(src, header.msg_id, udev_iface).map(Self::UrbComp),
+                FunctionId::URB_COMPLETION_NO_DATA => {
+                    UrbCompletionNoData::decode(src, header.msg_id, udev_iface).map(Self::UrbCompNoData)
                 }
                 _ => Err(invalid_field_err!(
                     "SHARED_MSG_HEADER::InterfaceId",
                     "unknown interface id"
                 )),
             },
+            _ => Err(invalid_field_err!("SHARED_MSG_HEADER", "invalid header")),
         }
     }
 }

--- a/crates/ironrdp-rdpeusb/src/pdu/mod.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/mod.rs
@@ -1,6 +1,8 @@
 //! Message packets from [\[MS-RDPEUSB\]][1], and helpers for encoding and decoding from wire.
 //!
-//! These messages are divided into [`UrbdrcServerPdu`] and [`UrbdrcClientPdu`].
+//! These messages are split into four enums by direction (server, client) and DVC role
+//! (the singleton control DVC vs. per-device DVCs): [`UrbdrcServerControlPdu`],
+//! [`UrbdrcServerDevicePdu`], [`UrbdrcClientControlPdu`], [`UrbdrcClientDevicePdu`].
 //!
 //! [1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeusb/a1004d0e-99e9-4968-894b-0b924ef2f125
 
@@ -11,6 +13,7 @@ use ironrdp_core::{
 use crate::pdu::caps::{RimExchangeCapabilityRequest, RimExchangeCapabilityResponse};
 use crate::pdu::completion::{IoControlCompletion, UrbCompletion, UrbCompletionNoData};
 use crate::pdu::header::{FunctionId, InterfaceId, Mask, SharedMsgHeader, unpack};
+use crate::pdu::iface_manipulation::{InterfaceRelease, QueryInterfaceRequest};
 use crate::pdu::notify::ChannelCreated;
 use crate::pdu::sink::{AddDevice, AddVirtualChannel};
 use crate::pdu::usb_dev::{
@@ -28,9 +31,45 @@ pub mod usb_dev;
 pub mod utils;
 
 /// A message sent from the server to the client.
-pub enum UrbdrcServerPdu {
+pub enum UrbdrcServerControlPdu {
     Caps(RimExchangeCapabilityRequest),
     ChanCreated(ChannelCreated),
+    IfaceRelease(InterfaceRelease),
+    QueryIfaceReq(QueryInterfaceRequest),
+}
+
+impl UrbdrcServerControlPdu {
+    fn decode_caps(src: &mut ReadCursor<'_>, f_id: FunctionId, header: SharedMsgHeader) -> DecodeResult<Self> {
+        match f_id {
+            FunctionId::RIM_EXCHANGE_CAPABILITY_REQUEST => {
+                RimExchangeCapabilityRequest::decode(src, header).map(Self::Caps)
+            }
+            FunctionId::RIMCALL_RELEASE => Ok(Self::IfaceRelease(InterfaceRelease::from_header(header))),
+            FunctionId::RIMCALL_QUERYINTERFACE => QueryInterfaceRequest::decode(src, header).map(Self::QueryIfaceReq),
+            _ => Err(invalid_field_err!(
+                "SHARED_MSG_HEADER",
+                "invalid RIM_EXCHANGE_CAPABILITY_REQUEST header"
+            )),
+        }
+    }
+
+    fn decode_notification(src: &mut ReadCursor<'_>, f_id: FunctionId, header: SharedMsgHeader) -> DecodeResult<Self> {
+        match f_id {
+            FunctionId::CHANNEL_CREATED => ChannelCreated::decode(src, header).map(Self::ChanCreated),
+            FunctionId::RIMCALL_RELEASE => Ok(Self::IfaceRelease(InterfaceRelease::from_header(header))),
+            FunctionId::RIMCALL_QUERYINTERFACE => QueryInterfaceRequest::decode(src, header).map(Self::QueryIfaceReq),
+            _ => Err(invalid_field_err!(
+                "SHARED_MSG_HEADER",
+                "invalid CHANNEL_CREATED header"
+            )),
+        }
+    }
+}
+
+pub enum UrbdrcServerDevicePdu {
+    ChanCreated(ChannelCreated),
+    IfaceRelease(InterfaceRelease),
+    QueryIfaceReq(QueryInterfaceRequest),
     CancelReq(CancelRequest),
     RegReqCb(RegisterRequestCallback),
     IoCtl(IoControl),
@@ -41,33 +80,45 @@ pub enum UrbdrcServerPdu {
     Retract(RetractDevice),
 }
 
-impl Decode<'_> for UrbdrcServerPdu {
+impl UrbdrcServerDevicePdu {
+    fn decode_notification(src: &mut ReadCursor<'_>, f_id: FunctionId, header: SharedMsgHeader) -> DecodeResult<Self> {
+        match f_id {
+            FunctionId::CHANNEL_CREATED => ChannelCreated::decode(src, header).map(Self::ChanCreated),
+            FunctionId::RIMCALL_RELEASE => Ok(Self::IfaceRelease(InterfaceRelease::from_header(header))),
+            FunctionId::RIMCALL_QUERYINTERFACE => QueryInterfaceRequest::decode(src, header).map(Self::QueryIfaceReq),
+            _ => Err(invalid_field_err!(
+                "SHARED_MSG_HEADER",
+                "invalid CHANNEL_CREATED header"
+            )),
+        }
+    }
+}
+
+impl Decode<'_> for UrbdrcServerControlPdu {
     fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
         let header = SharedMsgHeader::decode_with_function_id(src)?;
         let f_id = header.function_id.expect("missing function id");
 
         match unpack(header.iface_id)? {
-            (InterfaceId::CAPABILITIES, Mask::None) => {
-                if f_id == FunctionId::RIM_EXCHANGE_CAPABILITY_REQUEST {
-                    RimExchangeCapabilityRequest::decode(src, header).map(Self::Caps)
-                } else {
-                    Err(invalid_field_err!(
-                        "SHARED_MSG_HEADER",
-                        "invalid RIM_EXCHANGE_CAPABILITY_REQUEST header"
-                    ))
-                }
-            }
-            (InterfaceId::NOTIFY_CLIENT, Mask::Proxy) => {
-                if f_id == FunctionId::CHANNEL_CREATED {
-                    ChannelCreated::decode(src, header).map(Self::ChanCreated)
-                } else {
-                    Err(invalid_field_err!(
-                        "SHARED_MSG_HEADER",
-                        "invalid CHANNEL_CREATED header"
-                    ))
-                }
-            }
+            (InterfaceId::CAPABILITIES, Mask::None) => Self::decode_caps(src, f_id, header),
+            (InterfaceId::NOTIFY_CLIENT, Mask::Proxy) => Self::decode_notification(src, f_id, header),
+            _ => Err(invalid_field_err!("SHARED_MSG_HEADER", "invalid header")),
+        }
+    }
+}
+
+impl Decode<'_> for UrbdrcServerDevicePdu {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        let header = SharedMsgHeader::decode_with_function_id(src)?;
+        let f_id = header.function_id.expect("missing function id");
+
+        match unpack(header.iface_id)? {
+            (InterfaceId::NOTIFY_CLIENT, Mask::Proxy) => Self::decode_notification(src, f_id, header),
             (udev_iface, Mask::Proxy) => match f_id {
+                FunctionId::RIMCALL_RELEASE => Ok(Self::IfaceRelease(InterfaceRelease::from_header(header))),
+                FunctionId::RIMCALL_QUERYINTERFACE => {
+                    QueryInterfaceRequest::decode(src, header).map(Self::QueryIfaceReq)
+                }
                 FunctionId::CANCEL_REQUEST => {
                     CancelRequest::decode(src, header.msg_id, udev_iface).map(Self::CancelReq)
                 }
@@ -98,12 +149,25 @@ impl Decode<'_> for UrbdrcServerPdu {
     }
 }
 
-macro_rules! fill_server_pdu_arms {
+macro_rules! fill_server_ctl_pdu_arms {
     ($pdu:expr, $($tokens:tt)*) => {{
-        use UrbdrcServerPdu::*;
-        match <&UrbdrcServerPdu>::from($pdu) {
+        use UrbdrcServerControlPdu::*;
+        match <&UrbdrcServerControlPdu>::from($pdu) {
             Caps(rim_exchange_capability_request) => rim_exchange_capability_request$($tokens)*,
             ChanCreated(channel_created) => channel_created$($tokens)*,
+            IfaceRelease(iface_release) => iface_release$($tokens)*,
+            QueryIfaceReq(query_iface_req) => query_iface_req$($tokens)*,
+        }
+    }};
+}
+
+macro_rules! fill_server_dev_pdu_arms {
+    ($pdu:expr, $($tokens:tt)*) => {{
+        use UrbdrcServerDevicePdu::*;
+        match <&UrbdrcServerDevicePdu>::from($pdu) {
+            ChanCreated(channel_created) => channel_created$($tokens)*,
+            IfaceRelease(iface_release) => iface_release$($tokens)*,
+            QueryIfaceReq(query_iface_req) => query_iface_req$($tokens)*,
             CancelReq(cancel_request) => cancel_request$($tokens)*,
             RegReqCb(register_request_callback) => register_request_callback$($tokens)*,
             IoCtl(io_control) => io_control$($tokens)*,
@@ -116,86 +180,185 @@ macro_rules! fill_server_pdu_arms {
     }};
 }
 
-impl Encode for UrbdrcServerPdu {
+impl Encode for UrbdrcServerControlPdu {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        fill_server_pdu_arms!(self, .encode(dst))
+        fill_server_ctl_pdu_arms!(self, .encode(dst))
     }
 
     fn name(&self) -> &'static str {
-        fill_server_pdu_arms!(self, .name())
+        fill_server_ctl_pdu_arms!(self, .name())
     }
 
     fn size(&self) -> usize {
-        fill_server_pdu_arms!(self, .size())
+        fill_server_ctl_pdu_arms!(self, .size())
+    }
+}
+
+impl Encode for UrbdrcServerDevicePdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        fill_server_dev_pdu_arms!(self, .encode(dst))
+    }
+
+    fn name(&self) -> &'static str {
+        fill_server_dev_pdu_arms!(self, .name())
+    }
+
+    fn size(&self) -> usize {
+        fill_server_dev_pdu_arms!(self, .size())
     }
 }
 
 /// A message sent from the client to the server.
-pub enum UrbdrcClientPdu {
+pub enum UrbdrcClientControlPdu {
     Caps(RimExchangeCapabilityResponse),
-    AddChan(AddVirtualChannel),
-    AddDev(AddDevice),
     ChanCreated(ChannelCreated),
+    AddChan(AddVirtualChannel),
+    IfaceRelease(InterfaceRelease),
+    QueryIfaceReq(QueryInterfaceRequest),
+}
+
+pub enum UrbdrcClientDevicePdu {
+    ChanCreated(ChannelCreated),
+    AddDev(AddDevice),
     DevTextRsp(QueryDeviceTextRsp),
     IoctlComp(IoControlCompletion),
     UrbComp(UrbCompletion),
     UrbCompNoData(UrbCompletionNoData),
+    IfaceRelease(InterfaceRelease),
+    QueryIfaceReq(QueryInterfaceRequest),
 }
 
-impl Decode<'_> for UrbdrcClientPdu {
+impl UrbdrcClientControlPdu {
+    fn decode_sink(src: &mut ReadCursor<'_>, header: SharedMsgHeader) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 4 /* function id */);
+        let f_id = FunctionId(src.read_u32());
+        match f_id {
+            FunctionId::ADD_VIRTUAL_CHANNEL => AddVirtualChannel::decode(src, header).map(Self::AddChan),
+            FunctionId::RIMCALL_RELEASE => Ok(Self::IfaceRelease(InterfaceRelease::from_header(header))),
+            FunctionId::RIMCALL_QUERYINTERFACE => QueryInterfaceRequest::decode(src, header).map(Self::QueryIfaceReq),
+            _ => Err(invalid_field_err!(
+                "SHARED_MSG_HEADER",
+                "invalid function id in DEVICE_SINK"
+            )),
+        }
+    }
+    fn decode_notification(src: &mut ReadCursor<'_>, header: SharedMsgHeader) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 4 /* function id */);
+        let f_id = FunctionId(src.read_u32());
+        match f_id {
+            FunctionId::CHANNEL_CREATED => ChannelCreated::decode(src, header).map(Self::ChanCreated),
+            FunctionId::RIMCALL_RELEASE => Ok(Self::IfaceRelease(InterfaceRelease::from_header(header))),
+            FunctionId::RIMCALL_QUERYINTERFACE => QueryInterfaceRequest::decode(src, header).map(Self::QueryIfaceReq),
+            _ => Err(invalid_field_err!(
+                "SHARED_MSG_HEADER",
+                "invalid function id in CHANNEL_CREATED"
+            )),
+        }
+    }
+}
+
+impl Decode<'_> for UrbdrcClientControlPdu {
     fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
         let header = SharedMsgHeader::decode(src)?;
-        ensure_size!(in: src, size: 4 /* function id */);
 
         match unpack(header.iface_id)? {
             (InterfaceId::CAPABILITIES, Mask::None) => {
                 RimExchangeCapabilityResponse::decode(src, header).map(Self::Caps)
             }
-            (InterfaceId::DEVICE_SINK, Mask::Proxy) => match FunctionId(src.read_u32()) {
-                FunctionId::ADD_VIRTUAL_CHANNEL => AddVirtualChannel::decode(src, header).map(Self::AddChan),
-                FunctionId::ADD_DEVICE => AddDevice::decode(src, header).map(Self::AddDev),
-                _ => Err(invalid_field_err!(
-                    "SHARED_MSG_HEADER",
-                    "invalid Device Sink interface header"
-                )),
-            },
-            (InterfaceId::NOTIFY_SERVER, Mask::Proxy) => {
-                if FunctionId(src.read_u32()) == FunctionId::CHANNEL_CREATED {
-                    ChannelCreated::decode(src, header).map(Self::ChanCreated)
-                } else {
-                    Err(invalid_field_err!(
-                        "SHARED_MSG_HEADER",
-                        "invalid CHANNEL_CREATED header"
-                    ))
-                }
-            }
-            (udev_iface, Mask::Stub) => QueryDeviceTextRsp::decode(src, header.msg_id, udev_iface).map(Self::DevTextRsp),
-            (udev_iface, Mask::Proxy) => match FunctionId(src.read_u32()) {
-                FunctionId::IOCONTROL_COMPLETION => {
-                    IoControlCompletion::decode(src, header.msg_id, udev_iface).map(Self::IoctlComp)
-                }
-                FunctionId::URB_COMPLETION => UrbCompletion::decode(src, header.msg_id, udev_iface).map(Self::UrbComp),
-                FunctionId::URB_COMPLETION_NO_DATA => {
-                    UrbCompletionNoData::decode(src, header.msg_id, udev_iface).map(Self::UrbCompNoData)
-                }
-                _ => Err(invalid_field_err!(
-                    "SHARED_MSG_HEADER::InterfaceId",
-                    "unknown interface id"
-                )),
-            },
+            (InterfaceId::DEVICE_SINK, Mask::Proxy) => Self::decode_sink(src, header),
+            (InterfaceId::NOTIFY_SERVER, Mask::Proxy) => Self::decode_notification(src, header),
             _ => Err(invalid_field_err!("SHARED_MSG_HEADER", "invalid header")),
         }
     }
 }
 
-macro_rules! fill_client_pdu_arms {
+impl UrbdrcClientDevicePdu {
+    fn decode_sink(src: &mut ReadCursor<'_>, header: SharedMsgHeader) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 4 /* function id */);
+        let f_id = FunctionId(src.read_u32());
+        match f_id {
+            FunctionId::ADD_DEVICE => AddDevice::decode(src, header).map(Self::AddDev),
+            FunctionId::RIMCALL_RELEASE => Ok(Self::IfaceRelease(InterfaceRelease::from_header(header))),
+            FunctionId::RIMCALL_QUERYINTERFACE => QueryInterfaceRequest::decode(src, header).map(Self::QueryIfaceReq),
+            _ => Err(invalid_field_err!(
+                "SHARED_MSG_HEADER",
+                "invalid function id in DEVICE_SINK"
+            )),
+        }
+    }
+    fn decode_notification(src: &mut ReadCursor<'_>, header: SharedMsgHeader) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 4 /* function id */);
+        let f_id = FunctionId(src.read_u32());
+        match f_id {
+            FunctionId::CHANNEL_CREATED => ChannelCreated::decode(src, header).map(Self::ChanCreated),
+            FunctionId::RIMCALL_RELEASE => Ok(Self::IfaceRelease(InterfaceRelease::from_header(header))),
+            FunctionId::RIMCALL_QUERYINTERFACE => QueryInterfaceRequest::decode(src, header).map(Self::QueryIfaceReq),
+            _ => Err(invalid_field_err!(
+                "SHARED_MSG_HEADER",
+                "invalid function id in CHANNEL_CREATED"
+            )),
+        }
+    }
+}
+
+impl Decode<'_> for UrbdrcClientDevicePdu {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        let header = SharedMsgHeader::decode(src)?;
+
+        match unpack(header.iface_id)? {
+            (InterfaceId::DEVICE_SINK, Mask::Proxy) => Self::decode_sink(src, header),
+            (InterfaceId::NOTIFY_SERVER, Mask::Proxy) => Self::decode_notification(src, header),
+            (udev_iface, Mask::Stub) => {
+                QueryDeviceTextRsp::decode(src, header.msg_id, udev_iface).map(Self::DevTextRsp)
+            }
+            (udev_iface, Mask::Proxy) => {
+                ensure_size!(in: src, size: 4 /* function id */);
+                match FunctionId(src.read_u32()) {
+                    FunctionId::RIMCALL_RELEASE => Ok(Self::IfaceRelease(InterfaceRelease::from_header(header))),
+                    FunctionId::RIMCALL_QUERYINTERFACE => {
+                        QueryInterfaceRequest::decode(src, header).map(Self::QueryIfaceReq)
+                    }
+                    FunctionId::IOCONTROL_COMPLETION => {
+                        IoControlCompletion::decode(src, header.msg_id, udev_iface).map(Self::IoctlComp)
+                    }
+                    FunctionId::URB_COMPLETION => {
+                        UrbCompletion::decode(src, header.msg_id, udev_iface).map(Self::UrbComp)
+                    }
+                    FunctionId::URB_COMPLETION_NO_DATA => {
+                        UrbCompletionNoData::decode(src, header.msg_id, udev_iface).map(Self::UrbCompNoData)
+                    }
+                    _ => Err(invalid_field_err!(
+                        "SHARED_MSG_HEADER::InterfaceId",
+                        "unknown interface id"
+                    )),
+                }
+            }
+            _ => Err(invalid_field_err!("SHARED_MSG_HEADER", "invalid header")),
+        }
+    }
+}
+
+macro_rules! fill_client_ctl_pdu_arms {
     ($pdu:expr, $($tokens:tt)*) => {{
-        use UrbdrcClientPdu::*;
-        match <&UrbdrcClientPdu>::from($pdu) {
+        use UrbdrcClientControlPdu::*;
+        match <&UrbdrcClientControlPdu>::from($pdu) {
             Caps(rim_exchange_capability_response) => rim_exchange_capability_response$($tokens)*,
             AddChan(add_virtual_channel) => add_virtual_channel$($tokens)*,
-            AddDev(add_device) => add_device$($tokens)*,
             ChanCreated(channel_created) => channel_created$($tokens)*,
+            IfaceRelease(iface_release) => iface_release$($tokens)*,
+            QueryIfaceReq(query_iface_req) => query_iface_req$($tokens)*,
+        }
+    }};
+}
+
+macro_rules! fill_client_dev_pdu_arms {
+    ($pdu:expr, $($tokens:tt)*) => {{
+        use UrbdrcClientDevicePdu::*;
+        match <&UrbdrcClientDevicePdu>::from($pdu) {
+            ChanCreated(channel_created) => channel_created$($tokens)*,
+            IfaceRelease(iface_release) => iface_release$($tokens)*,
+            QueryIfaceReq(query_iface_req) => query_iface_req$($tokens)*,
+            AddDev(add_dev) => add_dev$($tokens)*,
             DevTextRsp(query_device_text_rsp) => query_device_text_rsp$($tokens)*,
             IoctlComp(iocontrol_completion) => iocontrol_completion$($tokens)*,
             UrbComp(urb_completion) => urb_completion$($tokens)*,
@@ -204,16 +367,30 @@ macro_rules! fill_client_pdu_arms {
     }};
 }
 
-impl Encode for UrbdrcClientPdu {
+impl Encode for UrbdrcClientControlPdu {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        fill_client_pdu_arms!(self, .encode(dst))
+        fill_client_ctl_pdu_arms!(self, .encode(dst))
     }
 
     fn name(&self) -> &'static str {
-        fill_client_pdu_arms!(self, .name())
+        fill_client_ctl_pdu_arms!(self, .name())
     }
 
     fn size(&self) -> usize {
-        fill_client_pdu_arms!(self, .size())
+        fill_client_ctl_pdu_arms!(self, .size())
+    }
+}
+
+impl Encode for UrbdrcClientDevicePdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        fill_client_dev_pdu_arms!(self, .encode(dst))
+    }
+
+    fn name(&self) -> &'static str {
+        fill_client_dev_pdu_arms!(self, .name())
+    }
+
+    fn size(&self) -> usize {
+        fill_client_dev_pdu_arms!(self, .size())
     }
 }

--- a/crates/ironrdp-rdpeusb/src/pdu/notify.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/notify.rs
@@ -13,7 +13,7 @@ use ironrdp_core::{
     unsupported_value_err,
 };
 
-use crate::pdu::header::{unpack, FunctionId, InterfaceId, Mask, MessageId, SharedMsgHeader};
+use crate::pdu::header::{FunctionId, InterfaceId, Mask, MessageId, SharedMsgHeader, unpack};
 
 /// [\[MS-RDPEUSB\] 2.2.5.1 Channel Created Message (CHANNEL_CREATED)][1] packet.
 ///

--- a/crates/ironrdp-rdpeusb/src/pdu/notify.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/notify.rs
@@ -54,7 +54,7 @@ impl ChannelCreated {
 
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: if let Direction::ToServer = self.direction {
+            iface_id: if let Direction::ToServer = self.direction {
                 InterfaceId::NOTIFY_SERVER
             } else {
                 InterfaceId::NOTIFY_CLIENT
@@ -83,7 +83,7 @@ impl ChannelCreated {
 
         Ok(Self {
             msg_id: header.msg_id,
-            direction: match unpack(header.interface_id)?.0 {
+            direction: match unpack(header.iface_id)?.0 {
                 InterfaceId::NOTIFY_CLIENT => Direction::ToClient,
                 InterfaceId::NOTIFY_SERVER => Direction::ToServer,
                 _ => unreachable!("dispatcher must filter interface_id to NOTIFY_CLIENT/NOTIFY_SERVER"),

--- a/crates/ironrdp-rdpeusb/src/pdu/notify.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/notify.rs
@@ -13,7 +13,7 @@ use ironrdp_core::{
     unsupported_value_err,
 };
 
-use crate::pdu::header::{FunctionId, InterfaceId, Mask, MessageId, SharedMsgHeader};
+use crate::pdu::header::{unpack, FunctionId, InterfaceId, Mask, MessageId, SharedMsgHeader};
 
 /// [\[MS-RDPEUSB\] 2.2.5.1 Channel Created Message (CHANNEL_CREATED)][1] packet.
 ///
@@ -58,8 +58,8 @@ impl ChannelCreated {
                 InterfaceId::NOTIFY_SERVER
             } else {
                 InterfaceId::NOTIFY_CLIENT
-            },
-            mask: Mask::StreamIdProxy,
+            }
+            .with_mask(Mask::Proxy),
             msg_id: self.msg_id,
             function_id: Some(FunctionId::CHANNEL_CREATED),
         }
@@ -83,7 +83,7 @@ impl ChannelCreated {
 
         Ok(Self {
             msg_id: header.msg_id,
-            direction: match header.interface_id {
+            direction: match unpack(header.interface_id)?.0 {
                 InterfaceId::NOTIFY_CLIENT => Direction::ToClient,
                 InterfaceId::NOTIFY_SERVER => Direction::ToServer,
                 _ => unreachable!("dispatcher must filter interface_id to NOTIFY_CLIENT/NOTIFY_SERVER"),

--- a/crates/ironrdp-rdpeusb/src/pdu/sink.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/sink.rs
@@ -33,8 +33,7 @@ impl AddVirtualChannel {
 
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: InterfaceId::DEVICE_SINK,
-            mask: Mask::StreamIdProxy,
+            interface_id: InterfaceId::DEVICE_SINK.with_mask(Mask::Proxy),
             msg_id: self.msg_id,
             function_id: Some(FunctionId::ADD_VIRTUAL_CHANNEL),
         }
@@ -84,8 +83,7 @@ impl AddDevice {
 
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: InterfaceId::DEVICE_SINK,
-            mask: Mask::StreamIdProxy,
+            interface_id: InterfaceId::DEVICE_SINK.with_mask(Mask::Proxy),
             msg_id: self.msg_id,
             function_id: Some(FunctionId::ADD_DEVICE),
         }

--- a/crates/ironrdp-rdpeusb/src/pdu/sink.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/sink.rs
@@ -9,7 +9,7 @@ use alloc::format;
 
 use ironrdp_core::{
     Decode, DecodeOwned as _, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, ensure_fixed_part_size,
-    ensure_size, other_err, unsupported_value_err,
+    ensure_size, invalid_field_err, unsupported_value_err,
 };
 use ironrdp_pdu::utils::strict_sum;
 use ironrdp_str::multi_sz::MultiSzString;
@@ -98,11 +98,10 @@ impl AddDevice {
 
         ensure_size!(in: src, size: InterfaceId::FIXED_PART_SIZE);
         let usb_device = match src.read_u32() {
-            interface_id @ 0x0..=0x3 => return Err(unsupported_value_err!("UsbDevice", format!("{interface_id}"))),
-            value @ 0x4..=0x3F_FF_FF_FF => InterfaceId::try_from(value).map_err(|e|
-                // Only a map_err and not expect (value clamped) cause clippy complains
-                other_err!(source: e))?,
-            value @ 0x40_00_00_00.. => return Err(unsupported_value_err!("UsbDevice", format!("{value}"))),
+            0x0..=0x3 => {
+                return Err(invalid_field_err!("UsbDevice", "conflict with default interfaces"));
+            }
+            value => InterfaceId::try_from(value)?,
         };
 
         let device_instance_id = Cch32String::decode_owned(src)?;
@@ -210,10 +209,24 @@ impl UsbDeviceCaps {
 
     #[expect(clippy::as_conversions)]
     pub const FIXED_PART_SIZE: usize = Self::CB_SIZE as usize;
+
+    const fn check_device_speed(
+        usb_bus_iface_ver: UsbBusIfaceVer,
+        device_speed: DeviceSpeed,
+    ) -> Result<(), &'static str> {
+        if matches!(usb_bus_iface_ver, UsbBusIfaceVer::V0) && matches!(device_speed, DeviceSpeed::HighSpeed) {
+            Err("must be 0x00000000 when UsbBusInterfaceVersion is 0x00000000")
+        } else {
+            Ok(())
+        }
+    }
 }
 
 impl Encode for UsbDeviceCaps {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        Self::check_device_speed(self.usb_bus_iface_ver, self.device_speed)
+            .map_err(|reason| invalid_field_err!("USB_DEVICE_CAPABILITIES::DeviceIsHighSpeed", reason))?;
+
         ensure_fixed_part_size!(in: dst);
 
         dst.write_u32(Self::CB_SIZE);
@@ -278,6 +291,8 @@ impl Decode<'_> for UsbDeviceCaps {
             0x1 => DeviceSpeed::HighSpeed,
             value => return Err(unsupported_value_err!("DeviceIsHighSpeed", format!("{value}"))),
         };
+        Self::check_device_speed(usb_bus_iface_ver, device_speed)
+            .map_err(|reason| invalid_field_err!("USB_DEVICE_CAPABILITIES::DeviceIsHighSpeed", reason))?;
         let no_ack_isoch_write_jitter_buf_size = match src.read_u32() {
             0 => NoAckIsochWriteJitterBufSizeInMs::TS_URB_ISOCH_TRANSFER_NOT_SUPPORTED,
             value @ 10..=512 => NoAckIsochWriteJitterBufSizeInMs(value),

--- a/crates/ironrdp-rdpeusb/src/pdu/sink.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/sink.rs
@@ -33,7 +33,7 @@ impl AddVirtualChannel {
 
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: InterfaceId::DEVICE_SINK.with_mask(Mask::Proxy),
+            iface_id: InterfaceId::DEVICE_SINK.with_mask(Mask::Proxy),
             msg_id: self.msg_id,
             function_id: Some(FunctionId::ADD_VIRTUAL_CHANNEL),
         }
@@ -83,7 +83,7 @@ impl AddDevice {
 
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: InterfaceId::DEVICE_SINK.with_mask(Mask::Proxy),
+            iface_id: InterfaceId::DEVICE_SINK.with_mask(Mask::Proxy),
             msg_id: self.msg_id,
             function_id: Some(FunctionId::ADD_DEVICE),
         }

--- a/crates/ironrdp-rdpeusb/src/pdu/usb_dev/mod.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/usb_dev/mod.rs
@@ -8,13 +8,13 @@ use alloc::format;
 use alloc::vec::Vec;
 
 use ironrdp_core::{
-    DecodeOwned as _, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, ensure_fixed_part_size, ensure_size,
-    invalid_field_err, other_err, unsupported_value_err,
+    Decode as _, DecodeOwned as _, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, ensure_fixed_part_size,
+    ensure_size, invalid_field_err, other_err, unsupported_value_err,
 };
 use ironrdp_str::prefixed::Cch32String;
 
 use crate::pdu::header::{FunctionId, InterfaceId, Mask, MessageId, SharedMsgHeader};
-use crate::pdu::usb_dev::ts_urb::{TransferDirection, TsUrb};
+use crate::pdu::usb_dev::ts_urb::{TsUrbIn, TsUrbOut};
 use crate::pdu::utils::{HResult, RequestId, RequestIdIoctl};
 #[cfg(doc)]
 use crate::pdu::{
@@ -645,7 +645,7 @@ impl Encode for QueryDeviceTextRsp {
 pub struct TransferInRequest {
     pub msg_id: MessageId,
     pub udev_iface: InterfaceId,
-    pub ts_urb: TsUrb,
+    pub ts_urb: TsUrbIn,
     pub output_buffer_size: u32,
 }
 
@@ -659,7 +659,7 @@ impl TransferInRequest {
     }
 
     pub fn check_output_buffer_size(&self) -> Result<(), &'static str> {
-        use TsUrb::*;
+        use TsUrbIn::*;
 
         match self.ts_urb {
             SelectConfig(_) if self.output_buffer_size != 0 => {
@@ -699,7 +699,7 @@ impl TransferInRequest {
         let cb_ts_urb = src.read_u32().try_into().map_err(|e| other_err!(source: e))?;
 
         ensure_size!(in: src, size: cb_ts_urb);
-        let ts_urb = TsUrb::decode(&mut ReadCursor::new(src.read_slice(cb_ts_urb)), TransferDirection::In)?;
+        let ts_urb = TsUrbIn::decode(&mut ReadCursor::new(src.read_slice(cb_ts_urb)))?;
 
         ensure_size!(in: src, size: 4 /* OutputBufferSize */);
         let output_buffer_size = src.read_u32();
@@ -727,7 +727,7 @@ impl Encode for TransferInRequest {
 
         self.header().encode(dst)?;
         dst.write_u32(self.ts_urb.size().try_into().map_err(|e| other_err!(source: e))?);
-        self.ts_urb.encode(dst, TransferDirection::In)?;
+        self.ts_urb.encode(dst)?;
         dst.write_u32(self.output_buffer_size);
 
         Ok(())
@@ -755,7 +755,7 @@ impl Encode for TransferInRequest {
 pub struct TransferOutRequest {
     pub msg_id: MessageId,
     pub udev_iface: InterfaceId,
-    pub ts_urb: TsUrb,
+    pub ts_urb: TsUrbOut,
     pub output_buffer: Vec<u8>,
 }
 
@@ -774,7 +774,7 @@ impl TransferOutRequest {
             let cb_ts_urb = src.read_u32().try_into().map_err(|e| other_err!(source: e))?;
             ensure_size!(in: src, size: cb_ts_urb);
             let mut src = ReadCursor::new(src.read_slice(cb_ts_urb));
-            TsUrb::decode(&mut src, TransferDirection::Out)?
+            TsUrbOut::decode(&mut src)?
         };
 
         ensure_size!(in: src, size: 4 /* OutputBufferSize */);
@@ -800,7 +800,7 @@ impl Encode for TransferOutRequest {
 
         dst.write_u32(self.ts_urb.size().try_into().map_err(|e| other_err!(source: e))?);
 
-        self.ts_urb.encode(dst, TransferDirection::Out)?;
+        self.ts_urb.encode(dst)?;
 
         dst.write_u32(self.output_buffer.len().try_into().map_err(|e| other_err!(source: e))?);
 

--- a/crates/ironrdp-rdpeusb/src/pdu/usb_dev/mod.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/usb_dev/mod.rs
@@ -44,7 +44,7 @@ impl CancelRequest {
 
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: self.udev_iface.with_mask(Mask::Proxy),
+            iface_id: self.udev_iface.with_mask(Mask::Proxy),
             msg_id: self.msg_id,
             function_id: Some(FunctionId::CANCEL_REQUEST),
         }
@@ -97,7 +97,7 @@ pub struct RegisterRequestCallback {
 impl RegisterRequestCallback {
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: self.udev_iface.with_mask(Mask::Proxy),
+            iface_id: self.udev_iface.with_mask(Mask::Proxy),
             msg_id: self.msg_id,
             function_id: Some(FunctionId::REGISTER_REQUEST_CALLBACK),
         }
@@ -174,7 +174,7 @@ impl IoControl {
 
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: self.udev_iface.with_mask(Mask::Proxy),
+            iface_id: self.udev_iface.with_mask(Mask::Proxy),
             msg_id: self.msg_id,
             function_id: Some(FunctionId::IO_CONTROL),
         }
@@ -417,7 +417,7 @@ impl InternalIoControl {
 
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: self.udev_iface.with_mask(Mask::Proxy),
+            iface_id: self.udev_iface.with_mask(Mask::Proxy),
             msg_id: self.msg_id,
             function_id: Some(FunctionId::INTERNAL_IO_CONTROL),
         }
@@ -511,7 +511,7 @@ impl QueryDeviceText {
 
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: self.udev_iface.with_mask(Mask::Proxy),
+            iface_id: self.udev_iface.with_mask(Mask::Proxy),
             msg_id: self.msg_id,
             function_id: Some(FunctionId::QUERY_DEVICE_TEXT),
         }
@@ -593,7 +593,7 @@ pub struct QueryDeviceTextRsp {
 impl QueryDeviceTextRsp {
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: self.udev_iface.with_mask(Mask::Stub),
+            iface_id: self.udev_iface.with_mask(Mask::Stub),
             msg_id: self.msg_id,
             function_id: None,
         }
@@ -672,7 +672,7 @@ pub struct TransferInRequest {
 impl TransferInRequest {
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: self.udev_iface.with_mask(Mask::Proxy),
+            iface_id: self.udev_iface.with_mask(Mask::Proxy),
             msg_id: self.msg_id,
             function_id: Some(FunctionId::TRANSFER_IN_REQUEST),
         }
@@ -781,7 +781,7 @@ pub struct TransferOutRequest {
 impl TransferOutRequest {
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: self.udev_iface.with_mask(Mask::Proxy),
+            iface_id: self.udev_iface.with_mask(Mask::Proxy),
             msg_id: self.msg_id,
             function_id: Some(FunctionId::TRANSFER_OUT_REQUEST),
         }
@@ -858,7 +858,7 @@ impl RetractDevice {
 
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: self.udev_iface.with_mask(Mask::Proxy),
+            iface_id: self.udev_iface.with_mask(Mask::Proxy),
             msg_id: self.msg_id,
             function_id: Some(FunctionId::RETRACT_DEVICE),
         }

--- a/crates/ironrdp-rdpeusb/src/pdu/usb_dev/mod.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/usb_dev/mod.rs
@@ -44,20 +44,19 @@ impl CancelRequest {
 
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: self.udev_iface,
-            mask: Mask::StreamIdProxy,
+            interface_id: self.udev_iface.with_mask(Mask::Proxy),
             msg_id: self.msg_id,
             function_id: Some(FunctionId::CANCEL_REQUEST),
         }
     }
 
-    pub(crate) fn decode(src: &mut ReadCursor<'_>, header: SharedMsgHeader) -> DecodeResult<Self> {
+    pub(crate) fn decode(src: &mut ReadCursor<'_>, msg_id: MessageId, udev_iface: InterfaceId) -> DecodeResult<Self> {
         ensure_size!(in: src, size: Self::PAYLOAD_SIZE);
         let req_id = src.read_u32();
 
         Ok(Self {
-            msg_id: header.msg_id,
-            udev_iface: header.interface_id,
+            msg_id,
+            udev_iface,
             req_id,
         })
     }
@@ -98,14 +97,13 @@ pub struct RegisterRequestCallback {
 impl RegisterRequestCallback {
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: self.udev_iface,
-            mask: Mask::StreamIdProxy,
+            interface_id: self.udev_iface.with_mask(Mask::Proxy),
             msg_id: self.msg_id,
             function_id: Some(FunctionId::REGISTER_REQUEST_CALLBACK),
         }
     }
 
-    pub(crate) fn decode(src: &mut ReadCursor<'_>, header: SharedMsgHeader) -> DecodeResult<Self> {
+    pub(crate) fn decode(src: &mut ReadCursor<'_>, msg_id: MessageId, udev_iface: InterfaceId) -> DecodeResult<Self> {
         ensure_size!(in: src, size: 4 /* NumRequestCompletion */);
         let request_completion = match src.read_u32() {
             0x0 => None,
@@ -120,8 +118,8 @@ impl RegisterRequestCallback {
             }
         };
         Ok(Self {
-            msg_id: header.msg_id,
-            udev_iface: header.interface_id,
+            msg_id,
+            udev_iface,
             request_completion,
         })
     }
@@ -176,8 +174,7 @@ impl IoControl {
 
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: self.udev_iface,
-            mask: Mask::StreamIdProxy,
+            interface_id: self.udev_iface.with_mask(Mask::Proxy),
             msg_id: self.msg_id,
             function_id: Some(FunctionId::IO_CONTROL),
         }
@@ -209,7 +206,7 @@ impl IoControl {
         }
     }
 
-    pub(crate) fn decode(src: &mut ReadCursor<'_>, header: SharedMsgHeader) -> DecodeResult<Self> {
+    pub(crate) fn decode(src: &mut ReadCursor<'_>, msg_id: MessageId, udev_iface: InterfaceId) -> DecodeResult<Self> {
         ensure_size!(in: src, size: Self::PAYLOAD_MIN_SIZE);
         let ioctl_code = match src.read_u32() {
             0x220_007 => IoctlInternalUsb::ResetPort,
@@ -228,8 +225,8 @@ impl IoControl {
         let output_buffer_size = src.read_u32();
         let req_id = src.read_u32();
         let io_control = Self {
-            msg_id: header.msg_id,
-            udev_iface: header.interface_id,
+            msg_id,
+            udev_iface,
             ioctl_code,
             input_buffer,
             output_buffer_size,
@@ -420,14 +417,13 @@ impl InternalIoControl {
 
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: self.udev_iface,
-            mask: Mask::StreamIdProxy,
+            interface_id: self.udev_iface.with_mask(Mask::Proxy),
             msg_id: self.msg_id,
             function_id: Some(FunctionId::INTERNAL_IO_CONTROL),
         }
     }
 
-    pub(crate) fn decode(src: &mut ReadCursor<'_>, header: SharedMsgHeader) -> DecodeResult<Self> {
+    pub(crate) fn decode(src: &mut ReadCursor<'_>, msg_id: MessageId, udev_iface: InterfaceId) -> DecodeResult<Self> {
         ensure_size!(in: src, size: Self::PAYLOAD_SIZE);
 
         {
@@ -458,8 +454,8 @@ impl InternalIoControl {
         let req_id = src.read_u32();
 
         Ok(Self {
-            msg_id: header.msg_id,
-            udev_iface: header.interface_id,
+            msg_id,
+            udev_iface,
             ioctl_code: UsbInternalIoctlCode::IoctlTsusbgdIoctlUsbdiQueryBusTime,
             input_buffer: Vec::new(),
             output_buffer_size,
@@ -515,14 +511,13 @@ impl QueryDeviceText {
 
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: self.udev_iface,
-            mask: Mask::StreamIdProxy,
+            interface_id: self.udev_iface.with_mask(Mask::Proxy),
             msg_id: self.msg_id,
             function_id: Some(FunctionId::QUERY_DEVICE_TEXT),
         }
     }
 
-    pub(crate) fn decode(src: &mut ReadCursor<'_>, header: SharedMsgHeader) -> DecodeResult<Self> {
+    pub(crate) fn decode(src: &mut ReadCursor<'_>, msg_id: MessageId, udev_iface: InterfaceId) -> DecodeResult<Self> {
         ensure_size!(in: src, size: Self::PAYLOAD_SIZE);
 
         let text_type = match src.read_u32() {
@@ -538,8 +533,8 @@ impl QueryDeviceText {
         let locale_id = src.read_u32();
 
         Ok(Self {
-            msg_id: header.msg_id,
-            udev_iface: header.interface_id,
+            msg_id,
+            udev_iface,
             text_type,
             locale_id,
         })
@@ -598,22 +593,21 @@ pub struct QueryDeviceTextRsp {
 impl QueryDeviceTextRsp {
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: self.udev_iface,
-            mask: Mask::StreamIdStub,
+            interface_id: self.udev_iface.with_mask(Mask::Stub),
             msg_id: self.msg_id,
             function_id: None,
         }
     }
 
-    pub(crate) fn decode(src: &mut ReadCursor<'_>, header: SharedMsgHeader) -> DecodeResult<Self> {
+    pub(crate) fn decode(src: &mut ReadCursor<'_>, msg_id: MessageId, udev_iface: InterfaceId) -> DecodeResult<Self> {
         let device_description = Cch32String::decode_owned(src)?;
 
         ensure_size!(in: src, size: 4 /* HResult */);
         let hresult = src.read_u32();
 
         Ok(Self {
-            msg_id: header.msg_id,
-            udev_iface: header.interface_id,
+            msg_id,
+            udev_iface,
             device_description,
             hresult,
         })
@@ -678,8 +672,7 @@ pub struct TransferInRequest {
 impl TransferInRequest {
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: self.udev_iface,
-            mask: Mask::StreamIdProxy,
+            interface_id: self.udev_iface.with_mask(Mask::Proxy),
             msg_id: self.msg_id,
             function_id: Some(FunctionId::TRANSFER_IN_REQUEST),
         }
@@ -721,7 +714,7 @@ impl TransferInRequest {
         }
     }
 
-    pub(crate) fn decode(src: &mut ReadCursor<'_>, header: SharedMsgHeader) -> DecodeResult<Self> {
+    pub(crate) fn decode(src: &mut ReadCursor<'_>, msg_id: MessageId, udev_iface: InterfaceId) -> DecodeResult<Self> {
         ensure_size!(in: src, size: 4 /* CbTsUrb */);
         let cb_ts_urb = src.read_u32().try_into().map_err(|e| other_err!(source: e))?;
 
@@ -731,8 +724,8 @@ impl TransferInRequest {
         let output_buffer_size = src.read_u32();
 
         let transfer_in_req = Self {
-            msg_id: header.msg_id,
-            udev_iface: header.interface_id,
+            msg_id,
+            udev_iface,
             ts_urb,
             output_buffer_size,
         };
@@ -788,14 +781,13 @@ pub struct TransferOutRequest {
 impl TransferOutRequest {
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: self.udev_iface,
-            mask: Mask::StreamIdProxy,
+            interface_id: self.udev_iface.with_mask(Mask::Proxy),
             msg_id: self.msg_id,
             function_id: Some(FunctionId::TRANSFER_OUT_REQUEST),
         }
     }
 
-    pub(crate) fn decode(src: &mut ReadCursor<'_>, header: SharedMsgHeader) -> DecodeResult<Self> {
+    pub(crate) fn decode(src: &mut ReadCursor<'_>, msg_id: MessageId, udev_iface: InterfaceId) -> DecodeResult<Self> {
         let ts_urb = {
             ensure_size!(in: src, size: 4 /* CbTsUrb */);
             let cb_ts_urb = src.read_u32().try_into().map_err(|e| other_err!(source: e))?;
@@ -808,8 +800,8 @@ impl TransferOutRequest {
         let output_buffer = src.read_slice(output_buffer_size).to_vec();
 
         Ok(Self {
-            msg_id: header.msg_id,
-            udev_iface: header.interface_id,
+            msg_id,
+            udev_iface,
             ts_urb,
             output_buffer,
         })
@@ -866,14 +858,13 @@ impl RetractDevice {
 
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
-            interface_id: self.udev_iface,
-            mask: Mask::StreamIdProxy,
+            interface_id: self.udev_iface.with_mask(Mask::Proxy),
             msg_id: self.msg_id,
             function_id: Some(FunctionId::RETRACT_DEVICE),
         }
     }
 
-    pub(crate) fn decode(src: &mut ReadCursor<'_>, header: SharedMsgHeader) -> DecodeResult<Self> {
+    pub(crate) fn decode(src: &mut ReadCursor<'_>, msg_id: MessageId, udev_iface: InterfaceId) -> DecodeResult<Self> {
         ensure_size!(in: src, size: Self::PAYLOAD_SIZE);
 
         let reason = src.read_u32();
@@ -883,8 +874,8 @@ impl RetractDevice {
         }
 
         Ok(Self {
-            msg_id: header.msg_id,
-            udev_iface: header.interface_id,
+            msg_id,
+            udev_iface,
             reason: UsbRetractReason::BlockedByPolicy,
         })
     }

--- a/crates/ironrdp-rdpeusb/src/pdu/usb_dev/mod.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/usb_dev/mod.rs
@@ -8,8 +8,8 @@ use alloc::format;
 use alloc::vec::Vec;
 
 use ironrdp_core::{
-    DecodeError, DecodeOwned as _, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, ensure_fixed_part_size,
-    ensure_size, invalid_field_err, other_err, unsupported_value_err,
+    DecodeOwned as _, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, ensure_fixed_part_size, ensure_size,
+    invalid_field_err, other_err, unsupported_value_err,
 };
 use ironrdp_str::prefixed::Cch32String;
 
@@ -109,12 +109,15 @@ impl RegisterRequestCallback {
             0x0 => None,
             _ => {
                 ensure_size!(in: src, size: InterfaceId::FIXED_PART_SIZE);
-                let interface = InterfaceId::try_from(src.read_u32()).map_err(|source| {
-                    let e: DecodeError =
-                        invalid_field_err!("REGISTER_REQUEST_CALLBACK::RequestCompletion", "more than 30 bits");
-                    e.with_source(source)
-                })?;
-                Some(interface)
+                match src.read_u32() {
+                    0x0..=0x3 => {
+                        return Err(invalid_field_err!(
+                            "RequestCompletion",
+                            "conflict with default interfaces"
+                        ));
+                    }
+                    value => Some(InterfaceId::try_from(value)?),
+                }
             }
         };
         Ok(Self {
@@ -221,6 +224,7 @@ impl IoControl {
         let input_buffer_size = src.read_u32().try_into().map_err(|e| other_err!(source: e))?;
         ensure_size!(in: src,
             size: input_buffer_size /* InputBuffer */ + 4 /* OutputBufferSize */ + 4 /* RequestId */);
+        // TODO: size limit
         let input_buffer = src.read_slice(input_buffer_size).to_vec();
         let output_buffer_size = src.read_u32();
         let req_id = src.read_u32();
@@ -499,7 +503,7 @@ impl Encode for InternalIoControl {
 pub struct QueryDeviceText {
     pub msg_id: MessageId,
     pub udev_iface: InterfaceId,
-    pub text_type: DeviceTextType,
+    pub text_type: u32,
     // TODO: Find out if MS-LCID and USB language ID's are same
     pub locale_id: u32,
 }
@@ -520,16 +524,7 @@ impl QueryDeviceText {
     pub(crate) fn decode(src: &mut ReadCursor<'_>, msg_id: MessageId, udev_iface: InterfaceId) -> DecodeResult<Self> {
         ensure_size!(in: src, size: Self::PAYLOAD_SIZE);
 
-        let text_type = match src.read_u32() {
-            0 => DeviceTextType::Description,
-            1 => DeviceTextType::LocationInformation,
-            value => {
-                return Err(unsupported_value_err!(
-                    "QUERY_DEVICE_TEXT::TextType",
-                    format!("{value}")
-                ));
-            }
-        };
+        let text_type = src.read_u32();
         let locale_id = src.read_u32();
 
         Ok(Self {
@@ -546,8 +541,7 @@ impl Encode for QueryDeviceText {
         ensure_fixed_part_size!(in: dst);
 
         self.header().encode(dst)?;
-        #[expect(clippy::as_conversions)]
-        dst.write_u32(self.text_type as u32);
+        dst.write_u32(self.text_type);
         dst.write_u32(self.locale_id);
 
         Ok(())
@@ -560,20 +554,6 @@ impl Encode for QueryDeviceText {
     fn size(&self) -> usize {
         Self::FIXED_PART_SIZE
     }
-}
-
-/// Indicates what kind of text/information is to be requested.
-#[repr(u32)]
-#[doc(alias = "DEVICE_TEXT_TYPE")]
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub enum DeviceTextType {
-    /// Basic description like manufacturer or product name.
-    #[doc(alias = "DeviceTextDescription")]
-    Description = 0x0,
-
-    /// Information such as where/what is the device connected to (bus or device number).
-    #[doc(alias = "DeviceTextLocationInformation")]
-    LocationInformation = 0x1,
 }
 
 /// [\[MS-RDPEUSB\] 2.2.6.6 Query Device Text Response Message (QUERY_DEVICE_TEXT_RSP)][1] message.
@@ -718,6 +698,7 @@ impl TransferInRequest {
         ensure_size!(in: src, size: 4 /* CbTsUrb */);
         let cb_ts_urb = src.read_u32().try_into().map_err(|e| other_err!(source: e))?;
 
+        ensure_size!(in: src, size: cb_ts_urb);
         let ts_urb = TsUrb::decode(&mut ReadCursor::new(src.read_slice(cb_ts_urb)), TransferDirection::In)?;
 
         ensure_size!(in: src, size: 4 /* OutputBufferSize */);
@@ -791,12 +772,15 @@ impl TransferOutRequest {
         let ts_urb = {
             ensure_size!(in: src, size: 4 /* CbTsUrb */);
             let cb_ts_urb = src.read_u32().try_into().map_err(|e| other_err!(source: e))?;
+            ensure_size!(in: src, size: cb_ts_urb);
             let mut src = ReadCursor::new(src.read_slice(cb_ts_urb));
             TsUrb::decode(&mut src, TransferDirection::Out)?
         };
 
         ensure_size!(in: src, size: 4 /* OutputBufferSize */);
         let output_buffer_size = src.read_u32().try_into().map_err(|e| other_err!(source: e))?;
+        // TODO: limit size
+        ensure_size!(in: src, size: output_buffer_size);
         let output_buffer = src.read_slice(output_buffer_size).to_vec();
 
         Ok(Self {

--- a/crates/ironrdp-rdpeusb/src/pdu/usb_dev/ts_urb/mod.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/usb_dev/ts_urb/mod.rs
@@ -1,14 +1,15 @@
 //! Packets sent to the client as part of [`TransferInRequest`] and [`TransferOutRequest`] messages
 //! when the server receives a URB request from its system.
 //!
-//! A [`TsUrb`] packet is sent as part of a [`TransferInRequest`] or [`TransferOutRequest`].
+//! A [`TsUrbIn`] packet is sent as part of a [`TransferInRequest`], a [`TsUrbOut`] packet is sent
+//! as part of a [`TransferOutRequest`].
 
 use alloc::format;
 use alloc::vec::Vec;
 
 use ironrdp_core::{
-    Decode as _, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, ensure_fixed_part_size, ensure_size,
-    invalid_field_err, other_err, read_padding, unsupported_value_err, write_padding,
+    Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, ensure_fixed_part_size, ensure_size,
+    invalid_field_err, read_padding, unsupported_value_err, write_padding,
 };
 
 use crate::pdu::usb_dev::ts_urb::utils::{SetupPacket, TsUrbHeader, TsUsbdInterfaceInfo, UrbFunction, UsbConfigDesc};
@@ -36,28 +37,11 @@ macro_rules! ensure_transfer_flag {
     };
 }
 
-macro_rules! ctl_desc_func_err {
-    (OUT, $func:expr) => {{
-        invalid_field_err!(
-            "TRANSFER_OUT_REQUEST::TsUrb: TS_URB_CONTROL_DESCRIPTOR_REQUEST::TS_URB_HEADER::URB Function",
-            concat!("is ", $func, " (only used with TRANSFER_IN_REQUEST)")
-        )
-    }};
-    (IN, $func:expr) => {{
-        invalid_field_err!(
-            "TRANSFER_IN_REQUEST::TsUrb: TS_URB_CONTROL_DESCRIPTOR_REQUEST::TS_URB_HEADER::URB Function",
-            concat!("is ", $func, " (only used with TRANSFER_OUT_REQUEST)")
-        )
-    }};
-}
-
-/// Enumeration of all the [\[MS-RDPEUSB\] 2.2.9 TS_URB Structures][1].
+/// Enumeration of all the [\[MS-RDPEUSB\] 2.2.9 TS_URB TRANSFER_IN_REQUEST Structures][1].
 ///
 /// [1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeusb/eed35296-3ca1-4271-bd0a-597138131b47
-#[non_exhaustive]
-#[doc(alias = "TS_URB")]
 #[derive(Debug, PartialEq, Clone)]
-pub enum TsUrb {
+pub enum TsUrbIn {
     SelectConfig(TsUrbSelectConfig),
     SelectIface(TsUrbSelectInterface),
     PipeReq(TsUrbPipeRequest),
@@ -75,112 +59,17 @@ pub enum TsUrb {
     CtlTransferEx(TsUrbControlTransferEx),
 }
 
-impl TsUrb {
-    pub(crate) fn decode(src: &mut ReadCursor<'_>, direction: TransferDirection) -> DecodeResult<Self> {
-        const ACTUAL_HEADER_SIZE: usize = 2 /* TS_URB_HEADER::Size */ + TsUrbHeader::FIXED_PART_SIZE;
-
-        ensure_size!(in: src, size: 2 /* TS_URB_HEADER::Size */ );
-        let ts_urb_size = usize::from(src.read_u16(/* TS_URB_HEADER::Size */));
-        if ts_urb_size < ACTUAL_HEADER_SIZE {
-            return Err(invalid_field_err!("TS_URB_HEADER::Size", "is smaller than 8"));
-        }
-
+impl Decode<'_> for TsUrbIn {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
         let header = TsUrbHeader::decode(src)?;
-
-        if matches!(direction, TransferDirection::In) {
-            if header.no_ack {
-                return Err(invalid_field_err!(
-                    "TRANSFER_IN_REQUEST::TsUrb::TS_URB_HEADER::NoAck",
-                    "is non-zero: NoAck MUST be set to zero for TRANSFER_IN_REQUEST"
-                ));
-            }
-            match header.func {
-                UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_DEVICE => {
-                    return Err(ctl_desc_func_err!(IN, "URB_FUNCTION_SET_DESCRIPTOR_TO_DEVICE"));
-                }
-                UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_ENDPOINT => {
-                    return Err(ctl_desc_func_err!(IN, "URB_FUNCTION_SET_DESCRIPTOR_TO_ENDPOINT"));
-                }
-                UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_INTERFACE => {
-                    return Err(ctl_desc_func_err!(IN, "URB_FUNCTION_SET_DESCRIPTOR_TO_INTERFACE"));
-                }
-                _ => (),
-            }
+        if header.no_ack {
+            return Err(invalid_field_err!(
+                "TRANSFER_IN_REQUEST::TsUrb::TS_URB_HEADER::NoAck",
+                "is non-zero: NoAck MUST be set to zero for TRANSFER_IN_REQUEST"
+            ));
         }
 
-        // Weed out all URBs that are only used with TRANSFER_IN_REQUEST
-        if matches!(direction, TransferDirection::Out) {
-            macro_rules! invalid_tsurb_err {
-                ($reflected_ts_urb:expr) => {{
-                    invalid_field_err!(
-                        "TRANSFER_OUT_REQUEST::TsUrb::TS_URB_HEADER::URB_Function",
-                        concat!(
-                            "URB Function reflects that TsUrb is ",
-                            $reflected_ts_urb,
-                            " (only used with TRANSFER_IN_REQUEST)"
-                        )
-                    )
-                }};
-            }
-
-            match header.func {
-                UrbFunction::URB_FUNCTION_SELECT_CONFIGURATION => {
-                    return Err(invalid_tsurb_err!("TS_URB_SELECT_CONFIGURATION"));
-                }
-                UrbFunction::URB_FUNCTION_SELECT_INTERFACE => {
-                    return Err(invalid_tsurb_err!("TS_URB_SELECT_CONFIGURATION"));
-                }
-                UrbFunction::URB_FUNCTION_ABORT_PIPE
-                | UrbFunction::URB_FUNCTION_SYNC_RESET_PIPE_AND_CLEAR_STALL
-                | UrbFunction::URB_FUNCTION_SYNC_RESET_PIPE
-                | UrbFunction::URB_FUNCTION_SYNC_CLEAR_STALL
-                | UrbFunction::URB_FUNCTION_CLOSE_STATIC_STREAMS => {
-                    return Err(invalid_tsurb_err!("TS_URB_PIPE_REQUEST"));
-                }
-                UrbFunction::URB_FUNCTION_GET_CURRENT_FRAME_NUMBER => {
-                    return Err(invalid_tsurb_err!("TS_URB_GET_CURRENT_FRAME_NUMBER"));
-                }
-
-                UrbFunction::URB_FUNCTION_GET_DESCRIPTOR_FROM_DEVICE => {
-                    return Err(ctl_desc_func_err!(OUT, "URB_FUNCTION_GET_DESCRIPTOR_FROM_DEVICE"));
-                }
-                UrbFunction::URB_FUNCTION_GET_DESCRIPTOR_FROM_ENDPOINT => {
-                    return Err(ctl_desc_func_err!(OUT, "URB_FUNCTION_GET_DESCRIPTOR_FROM_ENDPOINT"));
-                }
-                UrbFunction::URB_FUNCTION_GET_DESCRIPTOR_FROM_INTERFACE => {
-                    return Err(ctl_desc_func_err!(OUT, "URB_FUNCTION_GET_DESCRIPTOR_FROM_INTERFACE"));
-                }
-                #[expect(unused_parens)]
-                (UrbFunction::URB_FUNCTION_SET_FEATURE_TO_DEVICE
-                | UrbFunction::URB_FUNCTION_SET_FEATURE_TO_INTERFACE
-                | UrbFunction::URB_FUNCTION_SET_FEATURE_TO_ENDPOINT
-                | UrbFunction::URB_FUNCTION_SET_FEATURE_TO_OTHER)
-                | (UrbFunction::URB_FUNCTION_CLEAR_FEATURE_TO_DEVICE
-                | UrbFunction::URB_FUNCTION_CLEAR_FEATURE_TO_INTERFACE
-                | UrbFunction::URB_FUNCTION_CLEAR_FEATURE_TO_ENDPOINT
-                | UrbFunction::URB_FUNCTION_CLEAR_FEATURE_TO_OTHER) => {
-                    return Err(invalid_tsurb_err!("TS_URB_CONTROL_FEATURE_REQUEST"));
-                }
-                UrbFunction::URB_FUNCTION_GET_STATUS_FROM_DEVICE
-                | UrbFunction::URB_FUNCTION_GET_STATUS_FROM_INTERFACE
-                | UrbFunction::URB_FUNCTION_GET_STATUS_FROM_ENDPOINT
-                | UrbFunction::URB_FUNCTION_GET_STATUS_FROM_OTHER => {
-                    return Err(invalid_tsurb_err!("TS_URB_CONTROL_GET_STATUS_REQUEST"));
-                }
-                UrbFunction::URB_FUNCTION_GET_CONFIGURATION => {
-                    return Err(invalid_tsurb_err!("TS_URB_CONTROL_GET_CONFIGURATION_REQUEST"));
-                }
-                UrbFunction::URB_FUNCTION_GET_INTERFACE => {
-                    return Err(invalid_tsurb_err!("TS_URB_CONTROL_GET_INTERFACE_REQUEST"));
-                }
-                UrbFunction::URB_FUNCTION_GET_MS_FEATURE_DESCRIPTOR => {
-                    return Err(invalid_tsurb_err!("TS_URB_OS_FEATURE_DESCRIPTOR_REQUEST"));
-                }
-                _ => (),
-            }
-        }
-
-        let payload_size = ts_urb_size - ACTUAL_HEADER_SIZE;
+        let payload_size = usize::from(header.ts_urb_size) - header.size();
         ensure_size!(in: src, size: payload_size);
         let mut src = ReadCursor::new(src.read_slice(payload_size));
 
@@ -205,23 +94,27 @@ impl TsUrb {
             }
             UrbFunction::URB_FUNCTION_CONTROL_TRANSFER => {
                 let urb = TsUrbControlTransfer::decode(&mut src, header)?;
-                ensure_transfer_flag!(direction, urb.transfer_flags, "TS_URB_CONTROL_TRANSFER");
+                ensure_transfer_flag!(TransferDirection::In, urb.transfer_flags, "TS_URB_CONTROL_TRANSFER");
                 Self::CtlTransfer(urb)
             }
             UrbFunction::URB_FUNCTION_CONTROL_TRANSFER_EX => {
                 let urb = TsUrbControlTransferEx::decode(&mut src, header)?;
-                ensure_transfer_flag!(direction, urb.transfer_flags, "TS_URB_CONTROL_TRANSFER_EX");
+                ensure_transfer_flag!(TransferDirection::In, urb.transfer_flags, "TS_URB_CONTROL_TRANSFER_EX");
                 Self::CtlTransferEx(urb)
             }
             UrbFunction::URB_FUNCTION_BULK_OR_INTERRUPT_TRANSFER
             | UrbFunction::URB_FUNCTION_BULK_OR_INTERRUPT_TRANSFER_USING_CHAINED_MDL => {
                 let urb = TsUrbBulkOrInterruptTransfer::decode(&mut src, header)?;
-                ensure_transfer_flag!(direction, urb.transfer_flags, "TS_URB_BULK_OR_INTERRUPT_TRANSFER");
+                ensure_transfer_flag!(
+                    TransferDirection::In,
+                    urb.transfer_flags,
+                    "TS_URB_BULK_OR_INTERRUPT_TRANSFER"
+                );
                 Self::BulkInterruptTransfer(urb)
             }
             UrbFunction::URB_FUNCTION_ISOCH_TRANSFER | UrbFunction::URB_FUNCTION_ISOCH_TRANSFER_USING_CHAINED_MDL => {
                 let urb = TsUrbIsochTransfer::decode(&mut src, header)?;
-                ensure_transfer_flag!(direction, urb.transfer_flags, "TS_URB_ISOCH_TRANSFER");
+                ensure_transfer_flag!(TransferDirection::In, urb.transfer_flags, "TS_URB_ISOCH_TRANSFER");
                 Self::IsochTransfer(urb)
             }
             UrbFunction::URB_FUNCTION_GET_DESCRIPTOR_FROM_DEVICE
@@ -229,20 +122,14 @@ impl TsUrb {
             | UrbFunction::URB_FUNCTION_GET_DESCRIPTOR_FROM_INTERFACE => {
                 Self::CtlDescReq(TsUrbControlDescRequest::decode(&mut src, header)?)
             }
-            UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_DEVICE
-            | UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_ENDPOINT
-            | UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_INTERFACE => {
-                Self::CtlDescReq(TsUrbControlDescRequest::decode(&mut src, header)?)
-            }
-            #[expect(unused_parens)]
-            (UrbFunction::URB_FUNCTION_SET_FEATURE_TO_DEVICE
+            UrbFunction::URB_FUNCTION_SET_FEATURE_TO_DEVICE
             | UrbFunction::URB_FUNCTION_SET_FEATURE_TO_INTERFACE
             | UrbFunction::URB_FUNCTION_SET_FEATURE_TO_ENDPOINT
-            | UrbFunction::URB_FUNCTION_SET_FEATURE_TO_OTHER)
-            | (UrbFunction::URB_FUNCTION_CLEAR_FEATURE_TO_DEVICE
+            | UrbFunction::URB_FUNCTION_SET_FEATURE_TO_OTHER
+            | UrbFunction::URB_FUNCTION_CLEAR_FEATURE_TO_DEVICE
             | UrbFunction::URB_FUNCTION_CLEAR_FEATURE_TO_INTERFACE
             | UrbFunction::URB_FUNCTION_CLEAR_FEATURE_TO_ENDPOINT
-            | UrbFunction::URB_FUNCTION_CLEAR_FEATURE_TO_OTHER) => {
+            | UrbFunction::URB_FUNCTION_CLEAR_FEATURE_TO_OTHER => {
                 Self::CtlFeatReq(TsUrbControlFeatRequest::decode(&mut src, header)?)
             }
             UrbFunction::URB_FUNCTION_GET_STATUS_FROM_DEVICE
@@ -251,17 +138,20 @@ impl TsUrb {
             | UrbFunction::URB_FUNCTION_GET_STATUS_FROM_OTHER => {
                 Self::CtlGetStatus(TsUrbControlGetStatusRequest::decode(&mut src, header)?)
             }
-            #[expect(unused_parens)]
-            (UrbFunction::URB_FUNCTION_VENDOR_DEVICE
+            UrbFunction::URB_FUNCTION_VENDOR_DEVICE
             | UrbFunction::URB_FUNCTION_VENDOR_INTERFACE
             | UrbFunction::URB_FUNCTION_VENDOR_ENDPOINT
-            | UrbFunction::URB_FUNCTION_VENDOR_OTHER)
-            | (UrbFunction::URB_FUNCTION_CLASS_DEVICE
+            | UrbFunction::URB_FUNCTION_VENDOR_OTHER
+            | UrbFunction::URB_FUNCTION_CLASS_DEVICE
             | UrbFunction::URB_FUNCTION_CLASS_INTERFACE
             | UrbFunction::URB_FUNCTION_CLASS_ENDPOINT
-            | UrbFunction::URB_FUNCTION_CLASS_OTHER) => {
+            | UrbFunction::URB_FUNCTION_CLASS_OTHER => {
                 let urb = TsUrbControlVendorClassRequest::decode(&mut src, header)?;
-                ensure_transfer_flag!(direction, urb.transfer_flags, "TS_URB_CONTROL_VENDOR_OR_CLASS_REQUEST");
+                ensure_transfer_flag!(
+                    TransferDirection::In,
+                    urb.transfer_flags,
+                    "TS_URB_CONTROL_VENDOR_OR_CLASS_REQUEST"
+                );
                 Self::VendorClassReq(urb)
             }
             UrbFunction::URB_FUNCTION_GET_CONFIGURATION => {
@@ -280,125 +170,59 @@ impl TsUrb {
 
         Ok(ts_urb)
     }
+}
 
-    pub(crate) fn encode(&self, dst: &mut WriteCursor<'_>, direction: TransferDirection) -> EncodeResult<()> {
-        use TsUrb::*;
-
-        if matches!(direction, TransferDirection::In) {
-            if let CtlDescReq(ctl_desc_req) = self {
-                match ctl_desc_req.header.func {
-                    UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_DEVICE => {
-                        return Err(ctl_desc_func_err!(IN, "URB_FUNCTION_SET_DESCRIPTOR_TO_DEVICE"));
-                    }
-                    UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_ENDPOINT => {
-                        return Err(ctl_desc_func_err!(IN, "URB_FUNCTION_SET_DESCRIPTOR_TO_ENDPOINT"));
-                    }
-                    UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_INTERFACE => {
-                        return Err(ctl_desc_func_err!(IN, "URB_FUNCTION_SET_DESCRIPTOR_TO_INTERFACE"));
-                    }
-                    _ => (),
-                }
-            }
-        }
-
-        // Weed out all URBs that are only used with TRANSFER_IN_REQUEST
-        if matches!(direction, TransferDirection::Out) {
-            macro_rules! invalid_tsurb_err {
-                ($reflected_ts_urb:expr) => {{
-                    invalid_field_err!(
-                        "TRANSFER_OUT_REQUEST::TsUrb",
-                        concat!("is ", $reflected_ts_urb, " (only used with TRANSFER_IN_REQUEST)")
-                    )
-                }};
-            }
-
-            match self {
-                SelectConfig(_) => return Err(invalid_tsurb_err!("TS_URB_SELECT_CONFIGURATION")),
-                SelectIface(_) => return Err(invalid_tsurb_err!("TS_URB_SELECT_CONFIGURATION")),
-                PipeReq(_) => return Err(invalid_tsurb_err!("TS_URB_PIPE_REQUEST")),
-                GetCurFrameNum(_) => return Err(invalid_tsurb_err!("TS_URB_GET_CURRENT_FRAME_NUMBER")),
-                CtlDescReq(ctl_desc_req) => match ctl_desc_req.header.func {
-                    UrbFunction::URB_FUNCTION_GET_DESCRIPTOR_FROM_DEVICE => {
-                        return Err(ctl_desc_func_err!(OUT, "URB_FUNCTION_GET_DESCRIPTOR_FROM_DEVICE"));
-                    }
-                    UrbFunction::URB_FUNCTION_GET_DESCRIPTOR_FROM_ENDPOINT => {
-                        return Err(ctl_desc_func_err!(OUT, "URB_FUNCTION_GET_DESCRIPTOR_FROM_ENDPOINT"));
-                    }
-                    UrbFunction::URB_FUNCTION_GET_DESCRIPTOR_FROM_INTERFACE => {
-                        return Err(ctl_desc_func_err!(OUT, "URB_FUNCTION_GET_DESCRIPTOR_FROM_INTERFACE"));
-                    }
-                    _ => (),
-                },
-                CtlFeatReq(_) => return Err(invalid_tsurb_err!("TS_URB_CONTROL_FEATURE_REQUEST")),
-                CtlGetStatus(_) => return Err(invalid_tsurb_err!("TS_URB_CONTROL_GET_STATUS_REQUEST")),
-                CtlGetConfig(_) => return Err(invalid_tsurb_err!("TS_URB_CONTROL_GET_CONFIGURATION_REQUEST")),
-                CtlGetIface(_) => return Err(invalid_tsurb_err!("TS_URB_CONTROL_GET_INTERFACE_REQUEST")),
-                OsFeatDescReq(_) => return Err(invalid_tsurb_err!("TS_URB_OS_FEATURE_DESCRIPTOR_REQUEST")),
-                _ => (),
-            }
-        }
-
-        macro_rules! ensure_no_ack {
-            ($direction:expr, $no_ack:expr, $ts_urb_name:expr) => {{
-                if matches!($direction, TransferDirection::In) && $no_ack {
-                    return Err(invalid_field_err!(
-                        concat!(
-                            "TRANSFER_IN_REQUEST::TsUrb: ",
-                            $ts_urb_name,
-                            "::TS_URB_HEADER::NoAck"
-                        ),
-                        "is non-zero: NoAck MUST be set to zero for TRANSFER_IN_REQUEST"
-                    ));
-                }
-            }};
-        }
-
+impl Encode for TsUrbIn {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        use TsUrbIn::*;
         match self {
             SelectConfig(urb) => urb.encode(dst),
             SelectIface(urb) => urb.encode(dst),
             PipeReq(urb) => urb.encode(dst),
             GetCurFrameNum(urb) => urb.encode(dst),
             CtlTransfer(urb) => {
-                ensure_no_ack!(direction, urb.header.no_ack, "TS_URB_CONTROL_TRANSFER");
-                ensure_transfer_flag!(direction, urb.transfer_flags, "TS_URB_CONTROL_TRANSFER");
+                ensure_transfer_flag!(TransferDirection::In, urb.transfer_flags, "TS_URB_CONTROL_TRANSFER");
                 urb.encode(dst)
             }
             BulkInterruptTransfer(urb) => {
-                ensure_no_ack!(direction, urb.header.no_ack, "TS_URB_BULK_OR_INTERRUPT_TRANSFER");
-                ensure_transfer_flag!(direction, urb.transfer_flags, "TS_URB_BULK_OR_INTERRUPT_TRANSFER");
+                ensure_transfer_flag!(
+                    TransferDirection::In,
+                    urb.transfer_flags,
+                    "TS_URB_BULK_OR_INTERRUPT_TRANSFER"
+                );
                 urb.encode(dst)
             }
             IsochTransfer(urb) => {
-                ensure_no_ack!(direction, urb.header.no_ack, "TS_URB_ISOCH_TRANSFER");
-                ensure_transfer_flag!(direction, urb.transfer_flags, "TS_URB_ISOCH_TRANSFER");
+                ensure_transfer_flag!(TransferDirection::In, urb.transfer_flags, "TS_URB_ISOCH_TRANSFER");
                 urb.encode(dst)
             }
             CtlDescReq(urb) => urb.encode(dst),
             CtlFeatReq(urb) => urb.encode(dst),
             CtlGetStatus(urb) => urb.encode(dst),
             VendorClassReq(urb) => {
-                ensure_no_ack!(direction, urb.header.no_ack, "TS_URB_CONTROL_VENDOR_OR_CLASS_REQUEST");
-                ensure_transfer_flag!(direction, urb.transfer_flags, "TS_URB_CONTROL_VENDOR_OR_CLASS_REQUEST");
+                ensure_transfer_flag!(
+                    TransferDirection::In,
+                    urb.transfer_flags,
+                    "TS_URB_CONTROL_VENDOR_OR_CLASS_REQUEST"
+                );
                 urb.encode(dst)
             }
             CtlGetConfig(urb) => urb.encode(dst),
             CtlGetIface(urb) => urb.encode(dst),
             OsFeatDescReq(urb) => urb.encode(dst),
             CtlTransferEx(urb) => {
-                ensure_no_ack!(direction, urb.header.no_ack, "TS_URB_CONTROL_TRANSFER_EX");
-                ensure_transfer_flag!(direction, urb.transfer_flags, "TS_URB_CONTROL_TRANSFER_EX");
+                ensure_transfer_flag!(TransferDirection::In, urb.transfer_flags, "TS_URB_CONTROL_TRANSFER_EX");
                 urb.encode(dst)
             }
         }
     }
 
-    pub fn name(&self) -> &'static str {
+    fn name(&self) -> &'static str {
         "TS_URB"
     }
 
-    pub fn size(&self) -> usize {
-        use TsUrb::*;
-
+    fn size(&self) -> usize {
+        use TsUrbIn::*;
         match self {
             SelectConfig(urb) => urb.size(),
             SelectIface(urb) => urb.size(),
@@ -419,19 +243,139 @@ impl TsUrb {
     }
 }
 
+/// Enumeration of all the [\[MS-RDPEUSB\] 2.2.9 TS_URB TRANSFER_OUT_REQUEST Structures][1].
+///
+/// [1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeusb/eed35296-3ca1-4271-bd0a-597138131b47
+#[derive(Debug, PartialEq, Clone)]
+pub enum TsUrbOut {
+    CtlTransfer(TsUrbControlTransfer),
+    BulkInterruptTransfer(TsUrbBulkOrInterruptTransfer),
+    IsochTransfer(TsUrbIsochTransfer),
+    CtlDescReq(TsUrbControlDescRequest),
+    VendorClassReq(TsUrbControlVendorClassRequest),
+    CtlTransferEx(TsUrbControlTransferEx),
+}
+
+impl Decode<'_> for TsUrbOut {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        let header = TsUrbHeader::decode(src)?;
+
+        let payload_size = usize::from(header.ts_urb_size) - header.size();
+        ensure_size!(in: src, size: payload_size);
+        let mut src = ReadCursor::new(src.read_slice(payload_size));
+
+        let ts_urb = match header.func {
+            UrbFunction::URB_FUNCTION_CONTROL_TRANSFER => {
+                let urb = TsUrbControlTransfer::decode(&mut src, header)?;
+                ensure_transfer_flag!(TransferDirection::Out, urb.transfer_flags, "TS_URB_CONTROL_TRANSFER");
+                Self::CtlTransfer(urb)
+            }
+            UrbFunction::URB_FUNCTION_CONTROL_TRANSFER_EX => {
+                let urb = TsUrbControlTransferEx::decode(&mut src, header)?;
+                ensure_transfer_flag!(TransferDirection::Out, urb.transfer_flags, "TS_URB_CONTROL_TRANSFER_EX");
+                Self::CtlTransferEx(urb)
+            }
+            UrbFunction::URB_FUNCTION_BULK_OR_INTERRUPT_TRANSFER
+            | UrbFunction::URB_FUNCTION_BULK_OR_INTERRUPT_TRANSFER_USING_CHAINED_MDL => {
+                let urb = TsUrbBulkOrInterruptTransfer::decode(&mut src, header)?;
+                ensure_transfer_flag!(
+                    TransferDirection::Out,
+                    urb.transfer_flags,
+                    "TS_URB_BULK_OR_INTERRUPT_TRANSFER"
+                );
+                Self::BulkInterruptTransfer(urb)
+            }
+            UrbFunction::URB_FUNCTION_ISOCH_TRANSFER | UrbFunction::URB_FUNCTION_ISOCH_TRANSFER_USING_CHAINED_MDL => {
+                let urb = TsUrbIsochTransfer::decode(&mut src, header)?;
+                ensure_transfer_flag!(TransferDirection::Out, urb.transfer_flags, "TS_URB_ISOCH_TRANSFER");
+                Self::IsochTransfer(urb)
+            }
+            UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_DEVICE
+            | UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_ENDPOINT
+            | UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_INTERFACE => {
+                Self::CtlDescReq(TsUrbControlDescRequest::decode(&mut src, header)?)
+            }
+            UrbFunction::URB_FUNCTION_VENDOR_DEVICE
+            | UrbFunction::URB_FUNCTION_VENDOR_INTERFACE
+            | UrbFunction::URB_FUNCTION_VENDOR_ENDPOINT
+            | UrbFunction::URB_FUNCTION_VENDOR_OTHER
+            | UrbFunction::URB_FUNCTION_CLASS_DEVICE
+            | UrbFunction::URB_FUNCTION_CLASS_INTERFACE
+            | UrbFunction::URB_FUNCTION_CLASS_ENDPOINT
+            | UrbFunction::URB_FUNCTION_CLASS_OTHER => {
+                let urb = TsUrbControlVendorClassRequest::decode(&mut src, header)?;
+                ensure_transfer_flag!(
+                    TransferDirection::Out,
+                    urb.transfer_flags,
+                    "TS_URB_CONTROL_VENDOR_OR_CLASS_REQUEST"
+                );
+                Self::VendorClassReq(urb)
+            }
+            func => return Err(unsupported_value_err!("URB Function", format!("{}", u16::from(func)))),
+        };
+
+        Ok(ts_urb)
+    }
+}
+
+impl Encode for TsUrbOut {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        use TsUrbOut::*;
+        match self {
+            CtlTransfer(urb) => {
+                ensure_transfer_flag!(TransferDirection::Out, urb.transfer_flags, "TS_URB_CONTROL_TRANSFER");
+                urb.encode(dst)
+            }
+            BulkInterruptTransfer(urb) => {
+                ensure_transfer_flag!(
+                    TransferDirection::Out,
+                    urb.transfer_flags,
+                    "TS_URB_BULK_OR_INTERRUPT_TRANSFER"
+                );
+                urb.encode(dst)
+            }
+            IsochTransfer(urb) => {
+                ensure_transfer_flag!(TransferDirection::Out, urb.transfer_flags, "TS_URB_ISOCH_TRANSFER");
+                urb.encode(dst)
+            }
+            CtlDescReq(urb) => urb.encode(dst),
+            VendorClassReq(urb) => {
+                ensure_transfer_flag!(
+                    TransferDirection::Out,
+                    urb.transfer_flags,
+                    "TS_URB_CONTROL_VENDOR_OR_CLASS_REQUEST"
+                );
+                urb.encode(dst)
+            }
+            CtlTransferEx(urb) => {
+                ensure_transfer_flag!(TransferDirection::Out, urb.transfer_flags, "TS_URB_CONTROL_TRANSFER_EX");
+                urb.encode(dst)
+            }
+        }
+    }
+
+    fn size(&self) -> usize {
+        use TsUrbOut::*;
+        match self {
+            CtlTransfer(urb) => urb.size(),
+            BulkInterruptTransfer(urb) => urb.size(),
+            IsochTransfer(urb) => urb.size(),
+            CtlDescReq(urb) => urb.size(),
+            VendorClassReq(urb) => urb.size(),
+            CtlTransferEx(urb) => urb.size(),
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        "TS_URB"
+    }
+}
+
 #[repr(u8)]
 #[derive(PartialEq, Clone, Copy)]
 pub(crate) enum TransferDirection {
     Out = 0x0,
     In = 0x1,
-}
-
-macro_rules! encode_ts_urb_size {
-    ($dst:expr, $size:expr) => { {
-            let size = u16::try_from($size).map_err(|e| other_err!(source: e))?;
-            $dst.write_u16(size);
-        }
-    };
 }
 
 /// [\[MS-RDPEUSB\] 2.2.9.2 TS_URB_SELECT_CONFIGURATION][1] packet.
@@ -492,8 +436,7 @@ impl Encode for TsUrbSelectConfig {
             ));
         }
         ensure_size!(in: dst, size: self.size());
-        encode_ts_urb_size!(dst, self.size());
-        self.header.encode(dst)?;
+        self.header.encode_with_size(dst, self.size())?;
 
         // ConfigurationDescriptorIsValid
         dst.write_u8(self.desc.is_some().into());
@@ -525,8 +468,7 @@ impl Encode for TsUrbSelectConfig {
     }
 
     fn size(&self) -> usize {
-        size_of::<u16>(/* TS_URB_HEADER::Size */)
-            + TsUrbHeader::FIXED_PART_SIZE
+        TsUrbHeader::FIXED_PART_SIZE
             + const {
                 size_of::<u8>(/* ConfigurationDescriptorIsValid */)
                     + (3 * size_of::<u8>()/* Padding */)
@@ -586,8 +528,7 @@ impl Encode for TsUrbSelectInterface {
         }
 
         ensure_size!(in: dst, size: self.size());
-        encode_ts_urb_size!(dst, self.size());
-        self.header.encode(dst)?;
+        self.header.encode_with_size(dst, self.size())?;
         dst.write_u32(self.config_handle);
         self.usbd_iface.encode(dst)
     }
@@ -597,8 +538,7 @@ impl Encode for TsUrbSelectInterface {
     }
 
     fn size(&self) -> usize {
-        size_of::<u16>(/* TS_URB_HEADER::Size */)
-            + TsUrbHeader::FIXED_PART_SIZE
+        TsUrbHeader::FIXED_PART_SIZE
             + const {
                 size_of::<u32>(/* ConfigurationHandle */)
             }
@@ -621,8 +561,7 @@ pub struct TsUrbPipeRequest {
 }
 
 impl TsUrbPipeRequest {
-    pub const FIXED_PART_SIZE: usize =
-        size_of::<u16>(/* TS_URB_HEADER::Size */) + TsUrbHeader::FIXED_PART_SIZE + size_of::<u32>(/* PipeHandle */);
+    pub const FIXED_PART_SIZE: usize = TsUrbHeader::FIXED_PART_SIZE + size_of::<u32>(/* PipeHandle */);
 
     pub fn decode(src: &mut ReadCursor<'_>, header: TsUrbHeader) -> DecodeResult<Self> {
         ensure_size!(in: src, size: const { size_of::<ConfigHandle>(/* PipeHandle */) });
@@ -661,8 +600,7 @@ impl Encode for TsUrbPipeRequest {
         }
 
         ensure_fixed_part_size!(in: dst);
-        encode_ts_urb_size!(dst, self.size());
-        self.header.encode(dst)?;
+        self.header.encode_with_size(dst, self.size())?;
         dst.write_u32(self.pipe_handle);
 
         Ok(())
@@ -691,7 +629,7 @@ pub struct TsUrbGetCurrFrameNum {
 }
 
 impl TsUrbGetCurrFrameNum {
-    pub const FIXED_PART_SIZE: usize = size_of::<u16>(/* TS_URB_HEADER::Size */) + TsUrbHeader::FIXED_PART_SIZE;
+    pub const FIXED_PART_SIZE: usize = TsUrbHeader::FIXED_PART_SIZE;
 
     #[inline]
     pub fn decode(_: &mut ReadCursor<'_>, header: TsUrbHeader) -> DecodeResult<Self> {
@@ -713,8 +651,7 @@ impl Encode for TsUrbGetCurrFrameNum {
                 "is non-zero"
             ));
         }
-        encode_ts_urb_size!(dst, self.size());
-        self.header.encode(dst)
+        self.header.encode_with_size(dst, self.size())
     }
 
     fn name(&self) -> &'static str {
@@ -747,8 +684,7 @@ impl TsUrbControlTransfer {
     pub const PAYLOAD_SIZE: usize =
         size_of::<u32>(/* PipeHandle */) + size_of::<u32>(/* TransferFlags */) + SetupPacket::FIXED_PART_SIZE;
 
-    pub const FIXED_PART_SIZE: usize =
-        size_of::<u16>(/* TS_URB_HEADER::Size */) + TsUrbHeader::FIXED_PART_SIZE + Self::PAYLOAD_SIZE;
+    pub const FIXED_PART_SIZE: usize = TsUrbHeader::FIXED_PART_SIZE + Self::PAYLOAD_SIZE;
 
     pub fn decode(src: &mut ReadCursor<'_>, header: TsUrbHeader) -> DecodeResult<Self> {
         ensure_size!(in: src, size: Self::PAYLOAD_SIZE);
@@ -775,8 +711,7 @@ impl Encode for TsUrbControlTransfer {
             ));
         }
         ensure_fixed_part_size!(in: dst);
-        encode_ts_urb_size!(dst, self.size());
-        self.header.encode(dst)?;
+        self.header.encode_with_size(dst, self.size())?;
         dst.write_u32(self.pipe);
         dst.write_u32(self.transfer_flags);
         self.setup_packet.encode(dst)
@@ -810,8 +745,7 @@ pub struct TsUrbBulkOrInterruptTransfer {
 impl TsUrbBulkOrInterruptTransfer {
     pub const PAYLOAD_SIZE: usize = size_of::<u32>(/* PipeHandle */) + size_of::<u32>(/* TransferFlags */);
 
-    pub const FIXED_PART_SIZE: usize =
-        size_of::<u16>(/* TS_URB_HEADER::Size */) + TsUrbHeader::FIXED_PART_SIZE + Self::PAYLOAD_SIZE;
+    pub const FIXED_PART_SIZE: usize = TsUrbHeader::FIXED_PART_SIZE + Self::PAYLOAD_SIZE;
 
     pub fn decode(src: &mut ReadCursor<'_>, header: TsUrbHeader) -> DecodeResult<Self> {
         ensure_size!(in: src, size: Self::PAYLOAD_SIZE);
@@ -840,9 +774,8 @@ impl Encode for TsUrbBulkOrInterruptTransfer {
             ));
         }
         ensure_fixed_part_size!(in: dst);
-        encode_ts_urb_size!(dst, self.size());
 
-        self.header.encode(dst)?;
+        self.header.encode_with_size(dst, self.size())?;
         dst.write_u32(self.pipe_handle);
         dst.write_u32(self.transfer_flags);
 
@@ -915,9 +848,8 @@ impl Encode for TsUrbIsochTransfer {
             ));
         }
         ensure_size!(in: dst, size: self.size());
-        encode_ts_urb_size!(dst, self.size());
 
-        self.header.encode(dst)?;
+        self.header.encode_with_size(dst, self.size())?;
         dst.write_u32(self.pipe_handle);
         dst.write_u32(self.transfer_flags);
         dst.write_u32(self.start_frame);
@@ -936,8 +868,7 @@ impl Encode for TsUrbIsochTransfer {
     }
 
     fn size(&self) -> usize {
-        size_of::<u16>(/* TS_URB_HEADER::Size */)
-            + TsUrbHeader::FIXED_PART_SIZE
+        TsUrbHeader::FIXED_PART_SIZE
             + const {
                 size_of::<PipeHandle>()
                     + size_of::<u32>(/* TransferFlags */)
@@ -973,8 +904,7 @@ impl TsUrbControlDescRequest {
     pub const PAYLOAD_SIZE: usize =
         size_of::<u8>(/* Index */) + size_of::<u8>(/* DescriptorType */) + size_of::<u16>(/* LanguageId */);
 
-    pub const FIXED_PART_SIZE: usize =
-        size_of::<u16>(/* TS_URB_HEADER::Size */) + TsUrbHeader::FIXED_PART_SIZE + Self::PAYLOAD_SIZE;
+    pub const FIXED_PART_SIZE: usize = TsUrbHeader::FIXED_PART_SIZE + Self::PAYLOAD_SIZE;
 
     pub fn decode(src: &mut ReadCursor<'_>, header: TsUrbHeader) -> DecodeResult<Self> {
         ensure_size!(in: src, size: Self::PAYLOAD_SIZE);
@@ -1017,8 +947,7 @@ impl Encode for TsUrbControlDescRequest {
         }
         ensure_fixed_part_size!(in: dst);
 
-        encode_ts_urb_size!(dst, self.size());
-        self.header.encode(dst)?;
+        self.header.encode_with_size(dst, self.size())?;
         dst.write_u8(self.index);
         dst.write_u8(self.desc_type);
         dst.write_u16(self.lang_id);
@@ -1053,8 +982,7 @@ pub struct TsUrbControlFeatRequest {
 impl TsUrbControlFeatRequest {
     pub const PAYLOAD_SIZE: usize = size_of::<u16>(/* FeatureSelector */) + size_of::<u16>(/* Index */);
 
-    pub const FIXED_PART_SIZE: usize =
-        size_of::<u16>(/* TS_URB_HEADER::Size */) + TsUrbHeader::FIXED_PART_SIZE + Self::PAYLOAD_SIZE;
+    pub const FIXED_PART_SIZE: usize = TsUrbHeader::FIXED_PART_SIZE + Self::PAYLOAD_SIZE;
 
     pub fn decode(src: &mut ReadCursor<'_>, header: TsUrbHeader) -> DecodeResult<Self> {
         ensure_size!(in: src, size: Self::PAYLOAD_SIZE);
@@ -1105,8 +1033,7 @@ impl Encode for TsUrbControlFeatRequest {
         }
         ensure_fixed_part_size!(in: dst);
 
-        encode_ts_urb_size!(dst, self.size());
-        self.header.encode(dst)?;
+        self.header.encode_with_size(dst, self.size())?;
         dst.write_u16(self.feat_selector);
         dst.write_u16(self.index);
 
@@ -1139,8 +1066,7 @@ pub struct TsUrbControlGetStatusRequest {
 impl TsUrbControlGetStatusRequest {
     pub const PAYLOAD_SIZE: usize = size_of::<u16>(/* Index */) + size_of::<u16>(/* Padding */);
 
-    pub const FIXED_PART_SIZE: usize =
-        size_of::<u16>(/* TS_URB_HEADER::Size */) + TsUrbHeader::FIXED_PART_SIZE + Self::PAYLOAD_SIZE;
+    pub const FIXED_PART_SIZE: usize = TsUrbHeader::FIXED_PART_SIZE + Self::PAYLOAD_SIZE;
 
     pub fn decode(src: &mut ReadCursor<'_>, header: TsUrbHeader) -> DecodeResult<Self> {
         ensure_size!(in: src, size: Self::PAYLOAD_SIZE);
@@ -1178,8 +1104,7 @@ impl Encode for TsUrbControlGetStatusRequest {
         }
         ensure_fixed_part_size!(in: dst);
 
-        encode_ts_urb_size!(dst, self.size());
-        self.header.encode(dst)?;
+        self.header.encode_with_size(dst, self.size())?;
         dst.write_u16(self.index);
         write_padding!(dst, 2);
 
@@ -1221,8 +1146,7 @@ impl TsUrbControlVendorClassRequest {
         + size_of::<u16>(/* Index */)
         + size_of::<u16>(/* Padding */);
 
-    pub const FIXED_PART_SIZE: usize =
-        size_of::<u16>(/* TS_URB_HEADER::Size */) + TsUrbHeader::FIXED_PART_SIZE + Self::PAYLOAD_SIZE;
+    pub const FIXED_PART_SIZE: usize = TsUrbHeader::FIXED_PART_SIZE + Self::PAYLOAD_SIZE;
 
     pub fn decode(src: &mut ReadCursor<'_>, header: TsUrbHeader) -> DecodeResult<Self> {
         ensure_size!(in: src, size: Self::PAYLOAD_SIZE);
@@ -1273,8 +1197,7 @@ impl Encode for TsUrbControlVendorClassRequest {
         }
         ensure_fixed_part_size!(in: dst);
 
-        encode_ts_urb_size!(dst, self.size());
-        self.header.encode(dst)?;
+        self.header.encode_with_size(dst, self.size())?;
         dst.write_u32(self.transfer_flags);
         write_padding!(dst, 1); // RequestTypeReservedBits
         dst.write_u8(self.request);
@@ -1307,7 +1230,7 @@ pub struct TsUrbControlGetConfigRequest {
 }
 
 impl TsUrbControlGetConfigRequest {
-    pub const FIXED_PART_SIZE: usize = size_of::<u16>(/* TS_URB_HEADER::Size */) + TsUrbHeader::FIXED_PART_SIZE;
+    pub const FIXED_PART_SIZE: usize = TsUrbHeader::FIXED_PART_SIZE;
 
     #[inline]
     pub fn decode(_: &mut ReadCursor<'_>, header: TsUrbHeader) -> DecodeResult<Self> {
@@ -1330,8 +1253,7 @@ impl Encode for TsUrbControlGetConfigRequest {
             ));
         }
         ensure_fixed_part_size!(in: dst);
-        encode_ts_urb_size!(dst, self.size());
-        self.header.encode(dst)
+        self.header.encode_with_size(dst, self.size())
     }
 
     fn name(&self) -> &'static str {
@@ -1360,8 +1282,7 @@ pub struct TsUrbControlGetInterfaceRequest {
 impl TsUrbControlGetInterfaceRequest {
     pub const PAYLOAD_SIZE: usize = size_of::<u16>(/* Interface */) + size_of::<u16>(/* Padding */);
 
-    pub const FIXED_PART_SIZE: usize =
-        size_of::<u16>(/* TS_URB_HEADER::Size */) + TsUrbHeader::FIXED_PART_SIZE + Self::PAYLOAD_SIZE;
+    pub const FIXED_PART_SIZE: usize = TsUrbHeader::FIXED_PART_SIZE + Self::PAYLOAD_SIZE;
 
     pub fn decode(src: &mut ReadCursor<'_>, header: TsUrbHeader) -> DecodeResult<Self> {
         ensure_size!(in: src, size: Self::PAYLOAD_SIZE);
@@ -1387,8 +1308,7 @@ impl Encode for TsUrbControlGetInterfaceRequest {
             ));
         }
         ensure_fixed_part_size!(in: dst);
-        encode_ts_urb_size!(dst, self.size());
-        self.header.encode(dst)?;
+        self.header.encode_with_size(dst, self.size())?;
         dst.write_u16(self.interface);
         write_padding!(dst, 2);
 
@@ -1427,8 +1347,7 @@ impl TsUrbOsFeatDescRequest {
         + size_of::<u16>(/* MS_FeatureDescriptorIndex */)
         + (3 * size_of::<u8>()/* Padding2 */);
 
-    pub const FIXED_PART_SIZE: usize =
-        size_of::<u16>(/* TS_URB_HEADER::Size */) + TsUrbHeader::FIXED_PART_SIZE + Self::PAYLOAD_SIZE;
+    pub const FIXED_PART_SIZE: usize = TsUrbHeader::FIXED_PART_SIZE + Self::PAYLOAD_SIZE;
 
     pub fn decode(src: &mut ReadCursor<'_>, header: TsUrbHeader) -> DecodeResult<Self> {
         ensure_size!(in: src, size: Self::PAYLOAD_SIZE);
@@ -1469,8 +1388,7 @@ impl Encode for TsUrbOsFeatDescRequest {
             ));
         }
         ensure_fixed_part_size!(in: dst);
-        encode_ts_urb_size!(dst, self.size());
-        self.header.encode(dst)?;
+        self.header.encode_with_size(dst, self.size())?;
         dst.write_u8(self.recipient & 0x1F);
         dst.write_u8(self.interface_number);
         dst.write_u8(0x0); // MS_PageIndex
@@ -1513,8 +1431,7 @@ impl TsUrbControlTransferEx {
         + size_of::<u32>(/* Timeout */)
         + SetupPacket::FIXED_PART_SIZE;
 
-    pub const FIXED_PART_SIZE: usize =
-        size_of::<u16>(/* TS_URB_HEADER::Size */) + TsUrbHeader::FIXED_PART_SIZE + Self::PAYLOAD_SIZE;
+    pub const FIXED_PART_SIZE: usize = TsUrbHeader::FIXED_PART_SIZE + Self::PAYLOAD_SIZE;
 
     pub fn decode(src: &mut ReadCursor<'_>, header: TsUrbHeader) -> DecodeResult<Self> {
         ensure_size!(in: src, size: Self::PAYLOAD_SIZE);
@@ -1543,8 +1460,7 @@ impl Encode for TsUrbControlTransferEx {
             ));
         }
         ensure_fixed_part_size!(in: dst);
-        encode_ts_urb_size!(dst, self.size());
-        self.header.encode(dst)?;
+        self.header.encode_with_size(dst, self.size())?;
         dst.write_u32(self.pipe);
         dst.write_u32(self.transfer_flags);
         dst.write_u32(self.timeout);

--- a/crates/ironrdp-rdpeusb/src/pdu/usb_dev/ts_urb/mod.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/usb_dev/ts_urb/mod.rs
@@ -3,11 +3,12 @@
 //!
 //! A [`TsUrb`] packet is sent as part of a [`TransferInRequest`] or [`TransferOutRequest`].
 
+use alloc::format;
 use alloc::vec::Vec;
 
 use ironrdp_core::{
     Decode as _, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, ensure_fixed_part_size, ensure_size,
-    invalid_field_err, other_err, read_padding, write_padding,
+    invalid_field_err, other_err, read_padding, unsupported_value_err, write_padding,
 };
 
 use crate::pdu::usb_dev::ts_urb::utils::{SetupPacket, TsUrbHeader, TsUsbdInterfaceInfo, UrbFunction, UsbConfigDesc};
@@ -76,11 +77,15 @@ pub enum TsUrb {
 
 impl TsUrb {
     pub(crate) fn decode(src: &mut ReadCursor<'_>, direction: TransferDirection) -> DecodeResult<Self> {
-        use UrbFunction::*;
+        const ACTUAL_HEADER_SIZE: usize = 2 /* TS_URB_HEADER::Size */ + TsUrbHeader::FIXED_PART_SIZE;
 
-        let ts_urb_size = src.read_u16(/* TS_URB_HEADER::Size */);
+        ensure_size!(in: src, size: 2 /* TS_URB_HEADER::Size */ );
+        let ts_urb_size = usize::from(src.read_u16(/* TS_URB_HEADER::Size */));
+        if ts_urb_size < ACTUAL_HEADER_SIZE {
+            return Err(invalid_field_err!("TS_URB_HEADER::Size", "is smaller than 8"));
+        }
 
-        let header = TsUrbHeader::decode(&mut ReadCursor::new(src.read_slice(TsUrbHeader::FIXED_PART_SIZE)))?;
+        let header = TsUrbHeader::decode(src)?;
 
         if matches!(direction, TransferDirection::In) {
             if header.no_ack {
@@ -90,11 +95,13 @@ impl TsUrb {
                 ));
             }
             match header.func {
-                SetDescriptorToDevice => return Err(ctl_desc_func_err!(IN, "URB_FUNCTION_SET_DESCRIPTOR_TO_DEVICE")),
-                SetDescriptorToEndpoint => {
+                UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_DEVICE => {
+                    return Err(ctl_desc_func_err!(IN, "URB_FUNCTION_SET_DESCRIPTOR_TO_DEVICE"));
+                }
+                UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_ENDPOINT => {
                     return Err(ctl_desc_func_err!(IN, "URB_FUNCTION_SET_DESCRIPTOR_TO_ENDPOINT"));
                 }
-                SetDescriptorToInterface => {
+                UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_INTERFACE => {
                     return Err(ctl_desc_func_err!(IN, "URB_FUNCTION_SET_DESCRIPTOR_TO_INTERFACE"));
                 }
                 _ => (),
@@ -117,96 +124,158 @@ impl TsUrb {
             }
 
             match header.func {
-                SelectConfiguration => return Err(invalid_tsurb_err!("TS_URB_SELECT_CONFIGURATION")),
-                SelectInterface => return Err(invalid_tsurb_err!("TS_URB_SELECT_CONFIGURATION")),
-                AbortPipe | SyncResetPipeAndClearStall | SyncResetPipe | SyncClearStall | CloseStaticStreams => {
+                UrbFunction::URB_FUNCTION_SELECT_CONFIGURATION => {
+                    return Err(invalid_tsurb_err!("TS_URB_SELECT_CONFIGURATION"));
+                }
+                UrbFunction::URB_FUNCTION_SELECT_INTERFACE => {
+                    return Err(invalid_tsurb_err!("TS_URB_SELECT_CONFIGURATION"));
+                }
+                UrbFunction::URB_FUNCTION_ABORT_PIPE
+                | UrbFunction::URB_FUNCTION_SYNC_RESET_PIPE_AND_CLEAR_STALL
+                | UrbFunction::URB_FUNCTION_SYNC_RESET_PIPE
+                | UrbFunction::URB_FUNCTION_SYNC_CLEAR_STALL
+                | UrbFunction::URB_FUNCTION_CLOSE_STATIC_STREAMS => {
                     return Err(invalid_tsurb_err!("TS_URB_PIPE_REQUEST"));
                 }
-                GetCurrentFrameNumber => return Err(invalid_tsurb_err!("TS_URB_GET_CURRENT_FRAME_NUMBER")),
+                UrbFunction::URB_FUNCTION_GET_CURRENT_FRAME_NUMBER => {
+                    return Err(invalid_tsurb_err!("TS_URB_GET_CURRENT_FRAME_NUMBER"));
+                }
 
-                GetDescriptorFromDevice => {
+                UrbFunction::URB_FUNCTION_GET_DESCRIPTOR_FROM_DEVICE => {
                     return Err(ctl_desc_func_err!(OUT, "URB_FUNCTION_GET_DESCRIPTOR_FROM_DEVICE"));
                 }
-                GetDescriptorFromEndpoint => {
+                UrbFunction::URB_FUNCTION_GET_DESCRIPTOR_FROM_ENDPOINT => {
                     return Err(ctl_desc_func_err!(OUT, "URB_FUNCTION_GET_DESCRIPTOR_FROM_ENDPOINT"));
                 }
-                GetDescriptorFromInterface => {
+                UrbFunction::URB_FUNCTION_GET_DESCRIPTOR_FROM_INTERFACE => {
                     return Err(ctl_desc_func_err!(OUT, "URB_FUNCTION_GET_DESCRIPTOR_FROM_INTERFACE"));
                 }
                 #[expect(unused_parens)]
-                (SetFeatureToDevice | SetFeatureToInterface | SetFeatureToEndpoint | SetFeatureToOther)
-                | (ClearFeatureToDevice | ClearFeatureToInterface | ClearFeatureToEndpoint | ClearFeatureToOther) => {
+                (UrbFunction::URB_FUNCTION_SET_FEATURE_TO_DEVICE
+                | UrbFunction::URB_FUNCTION_SET_FEATURE_TO_INTERFACE
+                | UrbFunction::URB_FUNCTION_SET_FEATURE_TO_ENDPOINT
+                | UrbFunction::URB_FUNCTION_SET_FEATURE_TO_OTHER)
+                | (UrbFunction::URB_FUNCTION_CLEAR_FEATURE_TO_DEVICE
+                | UrbFunction::URB_FUNCTION_CLEAR_FEATURE_TO_INTERFACE
+                | UrbFunction::URB_FUNCTION_CLEAR_FEATURE_TO_ENDPOINT
+                | UrbFunction::URB_FUNCTION_CLEAR_FEATURE_TO_OTHER) => {
                     return Err(invalid_tsurb_err!("TS_URB_CONTROL_FEATURE_REQUEST"));
                 }
-                GetStatusFromDevice | GetStatusFromInterface | GetStatusFromEndpoint | GetStatusFromOther => {
+                UrbFunction::URB_FUNCTION_GET_STATUS_FROM_DEVICE
+                | UrbFunction::URB_FUNCTION_GET_STATUS_FROM_INTERFACE
+                | UrbFunction::URB_FUNCTION_GET_STATUS_FROM_ENDPOINT
+                | UrbFunction::URB_FUNCTION_GET_STATUS_FROM_OTHER => {
                     return Err(invalid_tsurb_err!("TS_URB_CONTROL_GET_STATUS_REQUEST"));
                 }
-                GetConfiguration => return Err(invalid_tsurb_err!("TS_URB_CONTROL_GET_CONFIGURATION_REQUEST")),
-                GetInterface => return Err(invalid_tsurb_err!("TS_URB_CONTROL_GET_INTERFACE_REQUEST")),
-                GetMsFeatureDescriptor => return Err(invalid_tsurb_err!("TS_URB_OS_FEATURE_DESCRIPTOR_REQUEST")),
+                UrbFunction::URB_FUNCTION_GET_CONFIGURATION => {
+                    return Err(invalid_tsurb_err!("TS_URB_CONTROL_GET_CONFIGURATION_REQUEST"));
+                }
+                UrbFunction::URB_FUNCTION_GET_INTERFACE => {
+                    return Err(invalid_tsurb_err!("TS_URB_CONTROL_GET_INTERFACE_REQUEST"));
+                }
+                UrbFunction::URB_FUNCTION_GET_MS_FEATURE_DESCRIPTOR => {
+                    return Err(invalid_tsurb_err!("TS_URB_OS_FEATURE_DESCRIPTOR_REQUEST"));
+                }
                 _ => (),
             }
         }
 
-        let mut src = ReadCursor::new(
-            src.read_slice(usize::from(ts_urb_size) - size_of::<u16>(/* ts_urb_size */) - header.size()),
-        );
+        let payload_size = ts_urb_size - ACTUAL_HEADER_SIZE;
+        ensure_size!(in: src, size: payload_size);
+        let mut src = ReadCursor::new(src.read_slice(payload_size));
 
         let ts_urb = match header.func {
-            SelectConfiguration => Self::SelectConfig(TsUrbSelectConfig::decode(&mut src, header)?),
+            UrbFunction::URB_FUNCTION_SELECT_CONFIGURATION => {
+                Self::SelectConfig(TsUrbSelectConfig::decode(&mut src, header)?)
+            }
 
-            SelectInterface => Self::SelectIface(TsUrbSelectInterface::decode(&mut src, header)?),
+            UrbFunction::URB_FUNCTION_SELECT_INTERFACE => {
+                Self::SelectIface(TsUrbSelectInterface::decode(&mut src, header)?)
+            }
 
-            AbortPipe | SyncResetPipeAndClearStall | SyncResetPipe | SyncClearStall | CloseStaticStreams => {
+            UrbFunction::URB_FUNCTION_ABORT_PIPE
+            | UrbFunction::URB_FUNCTION_SYNC_RESET_PIPE_AND_CLEAR_STALL
+            | UrbFunction::URB_FUNCTION_SYNC_RESET_PIPE
+            | UrbFunction::URB_FUNCTION_SYNC_CLEAR_STALL
+            | UrbFunction::URB_FUNCTION_CLOSE_STATIC_STREAMS => {
                 Self::PipeReq(TsUrbPipeRequest::decode(&mut src, header)?)
             }
-            GetCurrentFrameNumber => Self::GetCurFrameNum(TsUrbGetCurrFrameNum::decode(&mut src, header)?),
-            ControlTransfer => {
+            UrbFunction::URB_FUNCTION_GET_CURRENT_FRAME_NUMBER => {
+                Self::GetCurFrameNum(TsUrbGetCurrFrameNum::decode(&mut src, header)?)
+            }
+            UrbFunction::URB_FUNCTION_CONTROL_TRANSFER => {
                 let urb = TsUrbControlTransfer::decode(&mut src, header)?;
                 ensure_transfer_flag!(direction, urb.transfer_flags, "TS_URB_CONTROL_TRANSFER");
                 Self::CtlTransfer(urb)
             }
-            ControlTransferEx => {
+            UrbFunction::URB_FUNCTION_CONTROL_TRANSFER_EX => {
                 let urb = TsUrbControlTransferEx::decode(&mut src, header)?;
                 ensure_transfer_flag!(direction, urb.transfer_flags, "TS_URB_CONTROL_TRANSFER_EX");
                 Self::CtlTransferEx(urb)
             }
-            BulkOrInterruptTransfer | BulkOrInterruptTransferUsingChainedMdl => {
+            UrbFunction::URB_FUNCTION_BULK_OR_INTERRUPT_TRANSFER
+            | UrbFunction::URB_FUNCTION_BULK_OR_INTERRUPT_TRANSFER_USING_CHAINED_MDL => {
                 let urb = TsUrbBulkOrInterruptTransfer::decode(&mut src, header)?;
                 ensure_transfer_flag!(direction, urb.transfer_flags, "TS_URB_BULK_OR_INTERRUPT_TRANSFER");
                 Self::BulkInterruptTransfer(urb)
             }
-            IsochTransfer | IsochTransferUsingChainedMdl => {
+            UrbFunction::URB_FUNCTION_ISOCH_TRANSFER | UrbFunction::URB_FUNCTION_ISOCH_TRANSFER_USING_CHAINED_MDL => {
                 let urb = TsUrbIsochTransfer::decode(&mut src, header)?;
                 ensure_transfer_flag!(direction, urb.transfer_flags, "TS_URB_ISOCH_TRANSFER");
                 Self::IsochTransfer(urb)
             }
-            GetDescriptorFromDevice | GetDescriptorFromEndpoint | GetDescriptorFromInterface => {
+            UrbFunction::URB_FUNCTION_GET_DESCRIPTOR_FROM_DEVICE
+            | UrbFunction::URB_FUNCTION_GET_DESCRIPTOR_FROM_ENDPOINT
+            | UrbFunction::URB_FUNCTION_GET_DESCRIPTOR_FROM_INTERFACE => {
                 Self::CtlDescReq(TsUrbControlDescRequest::decode(&mut src, header)?)
             }
-            SetDescriptorToDevice | SetDescriptorToEndpoint | SetDescriptorToInterface => {
+            UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_DEVICE
+            | UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_ENDPOINT
+            | UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_INTERFACE => {
                 Self::CtlDescReq(TsUrbControlDescRequest::decode(&mut src, header)?)
             }
             #[expect(unused_parens)]
-            (SetFeatureToDevice | SetFeatureToInterface | SetFeatureToEndpoint | SetFeatureToOther)
-            | (ClearFeatureToDevice | ClearFeatureToInterface | ClearFeatureToEndpoint | ClearFeatureToOther) => {
+            (UrbFunction::URB_FUNCTION_SET_FEATURE_TO_DEVICE
+            | UrbFunction::URB_FUNCTION_SET_FEATURE_TO_INTERFACE
+            | UrbFunction::URB_FUNCTION_SET_FEATURE_TO_ENDPOINT
+            | UrbFunction::URB_FUNCTION_SET_FEATURE_TO_OTHER)
+            | (UrbFunction::URB_FUNCTION_CLEAR_FEATURE_TO_DEVICE
+            | UrbFunction::URB_FUNCTION_CLEAR_FEATURE_TO_INTERFACE
+            | UrbFunction::URB_FUNCTION_CLEAR_FEATURE_TO_ENDPOINT
+            | UrbFunction::URB_FUNCTION_CLEAR_FEATURE_TO_OTHER) => {
                 Self::CtlFeatReq(TsUrbControlFeatRequest::decode(&mut src, header)?)
             }
-            GetStatusFromDevice | GetStatusFromInterface | GetStatusFromEndpoint | GetStatusFromOther => {
+            UrbFunction::URB_FUNCTION_GET_STATUS_FROM_DEVICE
+            | UrbFunction::URB_FUNCTION_GET_STATUS_FROM_INTERFACE
+            | UrbFunction::URB_FUNCTION_GET_STATUS_FROM_ENDPOINT
+            | UrbFunction::URB_FUNCTION_GET_STATUS_FROM_OTHER => {
                 Self::CtlGetStatus(TsUrbControlGetStatusRequest::decode(&mut src, header)?)
             }
             #[expect(unused_parens)]
-            (VendorDevice | VendorInterface | VendorEndpoint | VendorOther)
-            | (ClassDevice | ClassInterface | ClassEndpoint | ClassOther) => {
+            (UrbFunction::URB_FUNCTION_VENDOR_DEVICE
+            | UrbFunction::URB_FUNCTION_VENDOR_INTERFACE
+            | UrbFunction::URB_FUNCTION_VENDOR_ENDPOINT
+            | UrbFunction::URB_FUNCTION_VENDOR_OTHER)
+            | (UrbFunction::URB_FUNCTION_CLASS_DEVICE
+            | UrbFunction::URB_FUNCTION_CLASS_INTERFACE
+            | UrbFunction::URB_FUNCTION_CLASS_ENDPOINT
+            | UrbFunction::URB_FUNCTION_CLASS_OTHER) => {
                 let urb = TsUrbControlVendorClassRequest::decode(&mut src, header)?;
                 ensure_transfer_flag!(direction, urb.transfer_flags, "TS_URB_CONTROL_VENDOR_OR_CLASS_REQUEST");
                 Self::VendorClassReq(urb)
             }
-            GetConfiguration => Self::CtlGetConfig(TsUrbControlGetConfigRequest::decode(&mut src, header)?),
+            UrbFunction::URB_FUNCTION_GET_CONFIGURATION => {
+                Self::CtlGetConfig(TsUrbControlGetConfigRequest::decode(&mut src, header)?)
+            }
 
-            GetInterface => Self::CtlGetIface(TsUrbControlGetInterfaceRequest::decode(&mut src, header)?),
+            UrbFunction::URB_FUNCTION_GET_INTERFACE => {
+                Self::CtlGetIface(TsUrbControlGetInterfaceRequest::decode(&mut src, header)?)
+            }
 
-            GetMsFeatureDescriptor => Self::OsFeatDescReq(TsUrbOsFeatDescRequest::decode(&mut src, header)?),
+            UrbFunction::URB_FUNCTION_GET_MS_FEATURE_DESCRIPTOR => {
+                Self::OsFeatDescReq(TsUrbOsFeatDescRequest::decode(&mut src, header)?)
+            }
+            func => return Err(unsupported_value_err!("URB Function", format!("{}", u16::from(func)))),
         };
 
         Ok(ts_urb)
@@ -218,13 +287,13 @@ impl TsUrb {
         if matches!(direction, TransferDirection::In) {
             if let CtlDescReq(ctl_desc_req) = self {
                 match ctl_desc_req.header.func {
-                    UrbFunction::SetDescriptorToDevice => {
+                    UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_DEVICE => {
                         return Err(ctl_desc_func_err!(IN, "URB_FUNCTION_SET_DESCRIPTOR_TO_DEVICE"));
                     }
-                    UrbFunction::SetDescriptorToEndpoint => {
+                    UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_ENDPOINT => {
                         return Err(ctl_desc_func_err!(IN, "URB_FUNCTION_SET_DESCRIPTOR_TO_ENDPOINT"));
                     }
-                    UrbFunction::SetDescriptorToInterface => {
+                    UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_INTERFACE => {
                         return Err(ctl_desc_func_err!(IN, "URB_FUNCTION_SET_DESCRIPTOR_TO_INTERFACE"));
                     }
                     _ => (),
@@ -249,13 +318,13 @@ impl TsUrb {
                 PipeReq(_) => return Err(invalid_tsurb_err!("TS_URB_PIPE_REQUEST")),
                 GetCurFrameNum(_) => return Err(invalid_tsurb_err!("TS_URB_GET_CURRENT_FRAME_NUMBER")),
                 CtlDescReq(ctl_desc_req) => match ctl_desc_req.header.func {
-                    UrbFunction::GetDescriptorFromDevice => {
+                    UrbFunction::URB_FUNCTION_GET_DESCRIPTOR_FROM_DEVICE => {
                         return Err(ctl_desc_func_err!(OUT, "URB_FUNCTION_GET_DESCRIPTOR_FROM_DEVICE"));
                     }
-                    UrbFunction::GetDescriptorFromEndpoint => {
+                    UrbFunction::URB_FUNCTION_GET_DESCRIPTOR_FROM_ENDPOINT => {
                         return Err(ctl_desc_func_err!(OUT, "URB_FUNCTION_GET_DESCRIPTOR_FROM_ENDPOINT"));
                     }
-                    UrbFunction::GetDescriptorFromInterface => {
+                    UrbFunction::URB_FUNCTION_GET_DESCRIPTOR_FROM_INTERFACE => {
                         return Err(ctl_desc_func_err!(OUT, "URB_FUNCTION_GET_DESCRIPTOR_FROM_INTERFACE"));
                     }
                     _ => (),
@@ -410,7 +479,7 @@ impl TsUrbSelectConfig {
 
 impl Encode for TsUrbSelectConfig {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        if !matches!(self.header.func, UrbFunction::SelectConfiguration) {
+        if !matches!(self.header.func, UrbFunction::URB_FUNCTION_SELECT_CONFIGURATION) {
             return Err(invalid_field_err!(
                 "TS_URB_SELECT_CONFIGURATION::TS_URB_HEADER::URB_Function",
                 "is not URB_FUNCTION_SELECT_CONFIGURATION"
@@ -503,7 +572,7 @@ impl TsUrbSelectInterface {
 
 impl Encode for TsUrbSelectInterface {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        if !matches!(self.header.func, UrbFunction::SelectInterface) {
+        if !matches!(self.header.func, UrbFunction::URB_FUNCTION_SELECT_INTERFACE) {
             return Err(invalid_field_err!(
                 "TS_URB_SELECT_INTERFACE::TS_URB_HEADER::URB_Function",
                 "is not URB_FUNCTION_SELECT_INTERFACE"
@@ -566,10 +635,13 @@ impl TsUrbPipeRequest {
 
 impl Encode for TsUrbPipeRequest {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        use UrbFunction::*;
         if !matches!(
             self.header.func,
-            AbortPipe | SyncResetPipeAndClearStall | SyncResetPipe | SyncClearStall | CloseStaticStreams
+            UrbFunction::URB_FUNCTION_ABORT_PIPE
+                | UrbFunction::URB_FUNCTION_SYNC_RESET_PIPE_AND_CLEAR_STALL
+                | UrbFunction::URB_FUNCTION_SYNC_RESET_PIPE
+                | UrbFunction::URB_FUNCTION_SYNC_CLEAR_STALL
+                | UrbFunction::URB_FUNCTION_CLOSE_STATIC_STREAMS
         ) {
             return Err(invalid_field_err!(
                 "TS_URB_PIPE_REQUEST::TS_URB_HEADER::URB_Function",
@@ -629,7 +701,7 @@ impl TsUrbGetCurrFrameNum {
 
 impl Encode for TsUrbGetCurrFrameNum {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        if !matches!(self.header.func, UrbFunction::GetCurrentFrameNumber) {
+        if !matches!(self.header.func, UrbFunction::URB_FUNCTION_GET_CURRENT_FRAME_NUMBER) {
             return Err(invalid_field_err!(
                 "TS_URB_GET_CURRENT_FRAME_NUMBER::TS_URB_HEADER::URB_Function",
                 "is not URB_FUNCTION_GET_CURRENT_FRAME_NUMBER"
@@ -696,7 +768,7 @@ impl TsUrbControlTransfer {
 
 impl Encode for TsUrbControlTransfer {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        if !matches!(self.header.func, UrbFunction::ControlTransfer) {
+        if !matches!(self.header.func, UrbFunction::URB_FUNCTION_CONTROL_TRANSFER) {
             return Err(invalid_field_err!(
                 "TS_URB_CONTROL_TRANSFER::TS_URB_HEADER::URB_Function",
                 "is not URB_FUNCTION_CONTROL_TRANSFER"
@@ -759,7 +831,8 @@ impl Encode for TsUrbBulkOrInterruptTransfer {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         if !matches!(
             self.header.func,
-            UrbFunction::BulkOrInterruptTransfer | UrbFunction::BulkOrInterruptTransferUsingChainedMdl
+            UrbFunction::URB_FUNCTION_BULK_OR_INTERRUPT_TRANSFER
+                | UrbFunction::URB_FUNCTION_BULK_OR_INTERRUPT_TRANSFER_USING_CHAINED_MDL
         ) {
             return Err(invalid_field_err!(
                 "TS_URB_BULK_OR_INTERRUPT_TRANSFER::TS_URB_HEADER::URB_Function",
@@ -800,10 +873,8 @@ pub struct TsUrbIsochTransfer {
     pub pipe_handle: PipeHandle,
     pub transfer_flags: u32,
     pub start_frame: FrameNumber,
-    // /// Unused.
     pub error_count: u32,
-    // pub iso_packet: Vec<UsbdIsoPacketDesc>,
-    pub iso_packet_offsets: Vec<usize>,
+    pub iso_packet: Vec<UsbdIsoPacketDesc>,
 }
 
 impl TsUrbIsochTransfer {
@@ -815,15 +886,11 @@ impl TsUrbIsochTransfer {
         let start_frame = src.read_u32();
         let number_of_packets = src.read_u32();
         let error_count = src.read_u32();
-        // src.advance(4); // ErrorCount
 
         #[expect(clippy::map_with_unused_argument_over_ranges)]
-        let iso_packet_offsets = (0..number_of_packets)
-            .map(|_| {
-                UsbdIsoPacketDesc::decode(src)
-                    .and_then(|iso| usize::try_from(iso.offset).map_err(|e| other_err!(source: e)))
-            })
-            .collect::<Result<Vec<usize>, _>>()?;
+        let iso_packet = (0..number_of_packets)
+            .map(|_| UsbdIsoPacketDesc::decode(src))
+            .collect::<Result<Vec<UsbdIsoPacketDesc>, _>>()?;
 
         Ok(Self {
             header,
@@ -831,16 +898,17 @@ impl TsUrbIsochTransfer {
             transfer_flags,
             start_frame,
             error_count,
-            // iso_packet,
-            iso_packet_offsets,
+            iso_packet,
         })
     }
 }
 
 impl Encode for TsUrbIsochTransfer {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        use UrbFunction::{IsochTransfer, IsochTransferUsingChainedMdl};
-        if !matches!(self.header.func, IsochTransfer | IsochTransferUsingChainedMdl) {
+        if !matches!(
+            self.header.func,
+            UrbFunction::URB_FUNCTION_ISOCH_TRANSFER | UrbFunction::URB_FUNCTION_ISOCH_TRANSFER_USING_CHAINED_MDL
+        ) {
             return Err(invalid_field_err!(
                 "TS_URB_ISOCH_TRANSFER::TS_URB_HEADER::URB_Function",
                 "is not one of: URB_FUNCTION_ISOCH_TRANSFER, URB_FUNCTION_ISOCH_TRANSFER_USING_CHAINED_MDL"
@@ -853,37 +921,14 @@ impl Encode for TsUrbIsochTransfer {
         dst.write_u32(self.pipe_handle);
         dst.write_u32(self.transfer_flags);
         dst.write_u32(self.start_frame);
-        // dst.write_u32(self.iso_packet.len().try_into().map_err(|_| {
-        //     invalid_field_err!(
-        //         "TS_URB_ISOCH_TRANSFER::IsoPacket",
-        //         "too many packets: count exceeded field NumberOfPackets (4 bytes)"
-        //     )
-        // })?);
-        dst.write_u32(self.iso_packet_offsets.len().try_into().map_err(|_| {
+        dst.write_u32(self.iso_packet.len().try_into().map_err(|_| {
             invalid_field_err!(
                 "TS_URB_ISOCH_TRANSFER::IsoPacket",
                 "too many packets: count exceeded field NumberOfPackets (4 bytes)"
             )
         })?);
         dst.write_u32(self.error_count);
-        // self.iso_packet.iter().try_for_each(|packet| packet.encode(dst))?;
-        self.iso_packet_offsets.iter().try_for_each(|offset| {
-            u32::try_from(*offset)
-                .map_err(|e| other_err!(source: e))
-                .and_then(|offset| {
-                    UsbdIsoPacketDesc {
-                        offset,
-                        length: 0,
-                        status: 0,
-                    }
-                    .encode(dst)
-                })
-            // u32::try_from(*offset)
-            //     .map(|offset| dst.write_u32(offset))
-            //     .map_err(|e| other_err!(source: e))
-        })?;
-
-        Ok(())
+        self.iso_packet.iter().try_for_each(|packet| packet.encode(dst))
     }
 
     fn name(&self) -> &'static str {
@@ -900,8 +945,7 @@ impl Encode for TsUrbIsochTransfer {
                     + size_of::<u32>(/* NumberOfPackets */)
                     + size_of::<u32>(/* ErrorCount */)
             }
-            // + self.iso_packet.len() * UsbdIsoPacketDesc::FIXED_PART_SIZE
-            + self.iso_packet_offsets.len() * UsbdIsoPacketDesc::FIXED_PART_SIZE
+            + self.iso_packet.len() * UsbdIsoPacketDesc::FIXED_PART_SIZE
     }
 }
 
@@ -909,10 +953,10 @@ impl Encode for TsUrbIsochTransfer {
 ///
 /// This packet represents [`URB_CONTROL_DESCRIPTOR_REQUEST`][2], and is sent using
 /// [`TransferInRequest`] if URB Function in header is one of
-/// [`UrbFunction::GetDescriptorFromDevice`], [`UrbFunction::GetDescriptorFromEndpoint`] or
-/// [`UrbFunction::GetDescriptorFromInterface`]; otherwise sent using  [`TransferOutRequest`] if
-/// URB Function in header is one of [`UrbFunction::SetDescriptorToDevice`],
-/// [`UrbFunction::SetDescriptorToEndpoint`] or [`UrbFunction::SetDescriptorToInterface`].
+/// [`UrbFunction::URB_FUNCTION_GET_DESCRIPTOR_FROM_DEVICE`], [`UrbFunction::URB_FUNCTION_GET_DESCRIPTOR_FROM_ENDPOINT`] or
+/// [`UrbFunction::URB_FUNCTION_GET_DESCRIPTOR_FROM_INTERFACE`]; otherwise sent using  [`TransferOutRequest`] if
+/// URB Function in header is one of [`UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_DEVICE`],
+/// [`UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_ENDPOINT`] or [`UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_INTERFACE`].
 ///
 /// [1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeusb/c6096d89-01e6-40e1-b1c7-9327487c5fff
 /// [2]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_control_descriptor_request
@@ -950,12 +994,15 @@ impl TsUrbControlDescRequest {
 
 impl Encode for TsUrbControlDescRequest {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        use UrbFunction::*;
         #[expect(unused_parens)]
         if !matches!(
             self.header.func,
-            (GetDescriptorFromDevice | GetDescriptorFromEndpoint | GetDescriptorFromInterface)
-                | (SetDescriptorToDevice | SetDescriptorToEndpoint | SetDescriptorToInterface)
+            (UrbFunction::URB_FUNCTION_GET_DESCRIPTOR_FROM_DEVICE
+                | UrbFunction::URB_FUNCTION_GET_DESCRIPTOR_FROM_ENDPOINT
+                | UrbFunction::URB_FUNCTION_GET_DESCRIPTOR_FROM_INTERFACE)
+                | (UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_DEVICE
+                    | UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_ENDPOINT
+                    | UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_INTERFACE)
         ) {
             return Err(invalid_field_err!(
                 "TS_URB_CONTROL_DESCRIPTOR_REQUEST::TS_URB_HEADER::URB_Function",
@@ -1025,13 +1072,17 @@ impl TsUrbControlFeatRequest {
 
 impl Encode for TsUrbControlFeatRequest {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        use UrbFunction::*;
-
         #[expect(unused_parens)]
         if !matches!(
             self.header.func,
-            (SetFeatureToDevice | SetFeatureToInterface | SetFeatureToEndpoint | SetFeatureToOther)
-                | (ClearFeatureToDevice | ClearFeatureToInterface | ClearFeatureToEndpoint | ClearFeatureToOther)
+            (UrbFunction::URB_FUNCTION_SET_FEATURE_TO_DEVICE
+                | UrbFunction::URB_FUNCTION_SET_FEATURE_TO_INTERFACE
+                | UrbFunction::URB_FUNCTION_SET_FEATURE_TO_ENDPOINT
+                | UrbFunction::URB_FUNCTION_SET_FEATURE_TO_OTHER)
+                | (UrbFunction::URB_FUNCTION_CLEAR_FEATURE_TO_DEVICE
+                    | UrbFunction::URB_FUNCTION_CLEAR_FEATURE_TO_INTERFACE
+                    | UrbFunction::URB_FUNCTION_CLEAR_FEATURE_TO_ENDPOINT
+                    | UrbFunction::URB_FUNCTION_CLEAR_FEATURE_TO_OTHER)
         ) {
             return Err(invalid_field_err!(
                 "TS_URB_CONTROL_FEATURE_REQUEST::TS_URB_HEADER::URB_Function",
@@ -1103,11 +1154,12 @@ impl TsUrbControlGetStatusRequest {
 
 impl Encode for TsUrbControlGetStatusRequest {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        use UrbFunction::*;
-
         if !matches!(
             self.header.func,
-            GetStatusFromDevice | GetStatusFromInterface | GetStatusFromEndpoint | GetStatusFromOther
+            UrbFunction::URB_FUNCTION_GET_STATUS_FROM_DEVICE
+                | UrbFunction::URB_FUNCTION_GET_STATUS_FROM_INTERFACE
+                | UrbFunction::URB_FUNCTION_GET_STATUS_FROM_ENDPOINT
+                | UrbFunction::URB_FUNCTION_GET_STATUS_FROM_OTHER
         ) {
             return Err(invalid_field_err!(
                 "TS_URB_CONTROL_GET_STATUS_REQUEST::TS_URB_HEADER::URB_Function",
@@ -1194,13 +1246,17 @@ impl TsUrbControlVendorClassRequest {
 
 impl Encode for TsUrbControlVendorClassRequest {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        use UrbFunction::*;
-
         #[expect(unused_parens)]
         if !matches!(
             self.header.func,
-            (VendorDevice | VendorInterface | VendorEndpoint | VendorOther)
-                | (ClassDevice | ClassInterface | ClassEndpoint | ClassOther)
+            (UrbFunction::URB_FUNCTION_VENDOR_DEVICE
+                | UrbFunction::URB_FUNCTION_VENDOR_INTERFACE
+                | UrbFunction::URB_FUNCTION_VENDOR_ENDPOINT
+                | UrbFunction::URB_FUNCTION_VENDOR_OTHER)
+                | (UrbFunction::URB_FUNCTION_CLASS_DEVICE
+                    | UrbFunction::URB_FUNCTION_CLASS_INTERFACE
+                    | UrbFunction::URB_FUNCTION_CLASS_ENDPOINT
+                    | UrbFunction::URB_FUNCTION_CLASS_OTHER)
         ) {
             return Err(invalid_field_err!(
                 "TS_URB_CONTROL_VENDOR_OR_CLASS_REQUEST::TS_URB_HEADER::URB_Function",
@@ -1261,7 +1317,7 @@ impl TsUrbControlGetConfigRequest {
 
 impl Encode for TsUrbControlGetConfigRequest {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        if !matches!(self.header.func, UrbFunction::GetConfiguration) {
+        if !matches!(self.header.func, UrbFunction::URB_FUNCTION_GET_CONFIGURATION) {
             return Err(invalid_field_err!(
                 "TS_URB_CONTROL_GET_CONFIGURATION_REQUEST::TS_URB_HEADER::URB_Function",
                 "is not URB_FUNCTION_GET_CONFIGURATION"
@@ -1318,7 +1374,7 @@ impl TsUrbControlGetInterfaceRequest {
 
 impl Encode for TsUrbControlGetInterfaceRequest {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        if !matches!(self.header.func, UrbFunction::GetInterface) {
+        if !matches!(self.header.func, UrbFunction::URB_FUNCTION_GET_INTERFACE) {
             return Err(invalid_field_err!(
                 "TS_URB_CONTROL_GET_INTERFACE_REQUEST::TS_URB_HEADER::URB_Function",
                 "is not URB_FUNCTION_GET_INTERFACE"
@@ -1379,10 +1435,11 @@ impl TsUrbOsFeatDescRequest {
 
         let recipient = src.read_u8() & 0x1F;
         let interface_number = src.read_u8();
+        // WDK requires MS_PageIndex to be 0; current Windows support is limited to 4 KiB.
         if src.read_u8(/* MS_PageIndex */) != 0 {
             return Err(invalid_field_err!(
                 "TRANSFER_IN_REQUEST::TsUrb: TS_URB_OS_FEATURE_DESCRIPTOR_REQUEST::MS_PageIndex",
-                "should be: 0x0"
+                "must be: 0x0"
             ));
         }
         let ms_feat_desc_index = src.read_u16();
@@ -1399,7 +1456,7 @@ impl TsUrbOsFeatDescRequest {
 
 impl Encode for TsUrbOsFeatDescRequest {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        if !matches!(self.header.func, UrbFunction::GetMsFeatureDescriptor) {
+        if !matches!(self.header.func, UrbFunction::URB_FUNCTION_GET_MS_FEATURE_DESCRIPTOR) {
             return Err(invalid_field_err!(
                 "TS_URB_OS_FEATURE_DESCRIPTOR_REQUEST::TS_URB_HEADER::URB_Function",
                 "is not URB_FUNCTION_GET_MS_FEATURE_DESCRIPTOR"
@@ -1479,7 +1536,7 @@ impl TsUrbControlTransferEx {
 
 impl Encode for TsUrbControlTransferEx {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        if !matches!(self.header.func, UrbFunction::ControlTransferEx) {
+        if !matches!(self.header.func, UrbFunction::URB_FUNCTION_CONTROL_TRANSFER_EX) {
             return Err(invalid_field_err!(
                 "TS_URB_CONTROL_TRANSFER_EX::TS_URB_HEADER::URB_Function",
                 "is not URB_FUNCTION_CONTROL_TRANSFER_EX"

--- a/crates/ironrdp-rdpeusb/src/pdu/usb_dev/ts_urb/utils.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/usb_dev/ts_urb/utils.rs
@@ -1,5 +1,5 @@
-//! Contains valid URB Functions, the common header [`TsUrbHeader`] for all [`TsUrb`] structures,
-//! and utility data types.
+//! Contains valid URB Functions, the common header [`TsUrbHeader`] for all [`TsUrbIn`] and
+//! [`TsUrbOut`] structures, and utility data types.
 
 use alloc::vec::Vec;
 
@@ -13,10 +13,10 @@ use crate::pdu::utils::RequestIdTransferInOut;
 use crate::pdu::{
     header::SharedMsgHeader,
     usb_dev::ts_urb::{
-        TsUrb, TsUrbBulkOrInterruptTransfer, TsUrbControlDescRequest, TsUrbControlFeatRequest,
-        TsUrbControlGetConfigRequest, TsUrbControlGetInterfaceRequest, TsUrbControlGetStatusRequest,
-        TsUrbControlTransfer, TsUrbControlTransferEx, TsUrbControlVendorClassRequest, TsUrbGetCurrFrameNum,
-        TsUrbIsochTransfer, TsUrbOsFeatDescRequest, TsUrbPipeRequest, TsUrbSelectConfig, TsUrbSelectInterface,
+        TsUrbBulkOrInterruptTransfer, TsUrbControlDescRequest, TsUrbControlFeatRequest, TsUrbControlGetConfigRequest,
+        TsUrbControlGetInterfaceRequest, TsUrbControlGetStatusRequest, TsUrbControlTransfer, TsUrbControlTransferEx,
+        TsUrbControlVendorClassRequest, TsUrbGetCurrFrameNum, TsUrbIn, TsUrbIsochTransfer, TsUrbOsFeatDescRequest,
+        TsUrbOut, TsUrbPipeRequest, TsUrbSelectConfig, TsUrbSelectInterface,
     },
 };
 
@@ -292,13 +292,15 @@ impl From<UrbFunction> for u16 {
 
 /// [\[MS-RDPEUSB\] 2.2.9.1.1 TS_URB_HEADER][1].
 ///
-/// Common header for all of the [`TsUrb`] variants. Analogous to how [`SharedMsgHeader`] is for
-/// all the "top-level" packets defined in the spec.
+/// Common header for all of the [`TsUrbIn`] and [`TsUrbOut`] variants. Analogous to how
+/// [`SharedMsgHeader`] is for all the "top-level" packets defined in the spec.
 ///
 /// [1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeusb/578da9ca-3116-4608-9737-1bf3df4de3d1
 #[doc(alias = "TS_URB_HEADER")]
 #[derive(Debug, PartialEq, Clone)]
 pub struct TsUrbHeader {
+    /// The size in bytes of the TS_URB structure.
+    pub ts_urb_size: u16,
     /// Indicates what function to perform (see [`UrbFunction`]).
     pub func: UrbFunction,
     // pub(crate) urb_function: u16,
@@ -335,14 +337,28 @@ pub struct TsUrbHeader {
 
 impl TsUrbHeader {
     pub const FIXED_PART_SIZE: usize =
-        /* size_of::<u16>(/* Size */) + */ /* SHOULD BE managed by the outer TS_URB */
-        size_of::<u16>(/* URB Function */) + size_of::<u32>(/* RequestId, NoAck */);
+        2 /* Size */ + 2 /* URB Function */ + 4 /* RequestId, NoAck */;
+
+    pub(super) fn encode_with_size(&self, dst: &mut WriteCursor<'_>, ts_urb_size: usize) -> EncodeResult<()> {
+        let ts_urb_size = ts_urb_size
+            .try_into()
+            .map_err(|_| invalid_field_err!("TS_URB_HEADER::Size", "too large: exceeded 2-byte size field"))?;
+
+        Self {
+            ts_urb_size,
+            func: self.func,
+            req_id: self.req_id,
+            no_ack: self.no_ack,
+        }
+        .encode(dst)
+    }
 }
 
 impl Encode for TsUrbHeader {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         ensure_fixed_part_size!(in: dst);
 
+        dst.write_u16(self.ts_urb_size);
         dst.write_u16(self.func.into());
 
         let no_ack = u32::from(self.no_ack) << 31;
@@ -364,13 +380,33 @@ impl Encode for TsUrbHeader {
 impl Decode<'_> for TsUrbHeader {
     fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
         ensure_fixed_part_size!(in: src);
+        let size = src.read_u16();
+        if usize::from(size) < Self::FIXED_PART_SIZE {
+            return Err(invalid_field_err!("TS_URB_HEADER::Size", "is smaller than 8"));
+        }
 
         let func = UrbFunction::from(src.read_u16());
         let last32 = src.read_u32();
         let req_id = RequestIdTransferInOut::try_from(last32 & 0x7F_FF_FF_FF).expect("value clamped");
         let no_ack = (last32 >> 31) != 0;
+        if no_ack
+            && !matches!(
+                func,
+                UrbFunction::URB_FUNCTION_ISOCH_TRANSFER | UrbFunction::URB_FUNCTION_ISOCH_TRANSFER_USING_CHAINED_MDL
+            )
+        {
+            return Err(invalid_field_err!(
+                "TS_URB_HEADER::NoAck",
+                "this bit can only be set when URB Function is an isochronous transfer"
+            ));
+        }
 
-        Ok(Self { func, req_id, no_ack })
+        Ok(Self {
+            ts_urb_size: size,
+            func,
+            req_id,
+            no_ack,
+        })
     }
 }
 

--- a/crates/ironrdp-rdpeusb/src/pdu/usb_dev/ts_urb/utils.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/usb_dev/ts_urb/utils.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 
 use ironrdp_core::{
     Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, ensure_fixed_part_size, ensure_size,
-    invalid_field_err, other_err, read_padding, unsupported_value_err, write_padding,
+    invalid_field_err, other_err, read_padding, write_padding,
 };
 
 use crate::pdu::utils::RequestIdTransferInOut;
@@ -33,297 +33,260 @@ use crate::pdu::{
 // like it did not receive any of the MDL variants? Cause the client receives the data buffer over
 // the network, so MDL's don't really make a point. [EDIT] Same behavior for MDL and non-MDL
 // variants.
-#[repr(u16)]
-#[non_exhaustive]
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub enum UrbFunction {
+#[repr(transparent)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct UrbFunction(u16);
+
+impl UrbFunction {
     /// Represents [`URB_FUNCTION_SELECT_CONFIGURATION`][1]. Used with [`TsUrbSelectConfig`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_select_configuration
-    #[doc(alias = "URB_FUNCTION_SELECT_CONFIGURATION")]
-    SelectConfiguration = 0,
+    pub const URB_FUNCTION_SELECT_CONFIGURATION: Self = Self(0);
 
     /// Represents [`URB_FUNCTION_SELECT_INTERFACE`][1]. Used with [`TsUrbSelectInterface`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_select_interface
-    #[doc(alias = "URB_FUNCTION_SELECT_INTERFACE")]
-    SelectInterface = 1,
+    pub const URB_FUNCTION_SELECT_INTERFACE: Self = Self(1);
 
     /// Represents [`URB_FUNCTION_ABORT_PIPE`][1]. Used with [`TsUrbPipeRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_abort_pipe
-    #[doc(alias = "URB_FUNCTION_ABORT_PIPE")]
-    AbortPipe = 2,
+    pub const URB_FUNCTION_ABORT_PIPE: Self = Self(2);
 
     /// Represents [`URB_FUNCTION_SYNC_RESET_PIPE_AND_CLEAR_STALL`][1]. Used with [`TsUrbPipeRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_sync_reset_pipe_and_clear_stall
-    #[doc(alias = "URB_FUNCTION_SYNC_RESET_PIPE_AND_CLEAR_STALL")]
-    SyncResetPipeAndClearStall = 30,
+    pub const URB_FUNCTION_SYNC_RESET_PIPE_AND_CLEAR_STALL: Self = Self(30);
 
     /// Represents [`URB_FUNCTION_SYNC_RESET_PIPE`][1]. Used with [`TsUrbPipeRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_sync_reset_pipe
-    #[doc(alias = "URB_FUNCTION_SYNC_RESET_PIPE")]
-    SyncResetPipe = 48,
+    pub const URB_FUNCTION_SYNC_RESET_PIPE: Self = Self(48);
 
     /// Represents [`URB_FUNCTION_SYNC_CLEAR_STALL`][1]. Used with [`TsUrbPipeRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_sync_clear_stall
-    #[doc(alias = "URB_FUNCTION_SYNC_CLEAR_STALL")]
-    SyncClearStall = 49,
+    pub const URB_FUNCTION_SYNC_CLEAR_STALL: Self = Self(49);
 
     /// Represents [`URB_FUNCTION_CLOSE_STATIC_STREAMS`][1]. Used with [`TsUrbPipeRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_close_static_streams
-    #[doc(alias = "URB_FUNCTION_CLOSE_STATIC_STREAMS")]
-    CloseStaticStreams = 54,
+    pub const URB_FUNCTION_CLOSE_STATIC_STREAMS: Self = Self(54);
 
     /// Represents [`URB_FUNCTION_GET_CURRENT_FRAME_NUMBER`][1]. Used with [`TsUrbGetCurrFrameNum`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_get_current_frame_number
-    #[doc(alias = "URB_FUNCTION_GET_CURRENT_FRAME_NUMBER")]
-    GetCurrentFrameNumber = 7,
+    pub const URB_FUNCTION_GET_CURRENT_FRAME_NUMBER: Self = Self(7);
 
     /// Represents [`URB_FUNCTION_CONTROL_TRANSFER`][1]. Used with [`TsUrbControlTransfer`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_control_transfer
-    #[doc(alias = "URB_FUNCTION_CONTROL_TRANSFER")]
-    ControlTransfer = 8,
+    pub const URB_FUNCTION_CONTROL_TRANSFER: Self = Self(8);
 
     /// Represents [`URB_FUNCTION_CONTROL_TRANSFER_EX`][1]. Used with [`TsUrbControlTransferEx`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_control_transfer_ex
-    #[doc(alias = "URB_FUNCTION_CONTROL_TRANSFER_EX")]
-    ControlTransferEx = 50,
+    pub const URB_FUNCTION_CONTROL_TRANSFER_EX: Self = Self(50);
 
     /// Represents [`URB_FUNCTION_BULK_OR_INTERRUPT_TRANSFER`][1]. Used with
     /// [`TsUrbBulkOrInterruptTransfer`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_bulk_or_interrupt_transfer
-    #[doc(alias = "URB_FUNCTION_BULK_OR_INTERRUPT_TRANSFER")]
-    BulkOrInterruptTransfer = 9,
+    pub const URB_FUNCTION_BULK_OR_INTERRUPT_TRANSFER: Self = Self(9);
 
     /// Represents [`URB_FUNCTION_BULK_OR_INTERRUPT_TRANSFER_USING_CHAINED_MDL`][1]. Used with
     /// [`TsUrbBulkOrInterruptTransfer`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_bulk_or_interrupt_transfer_using_chained_mdl
-    #[doc(alias = "URB_FUNCTION_BULK_OR_INTERRUPT_TRANSFER_USING_CHAINED_MDL")]
-    BulkOrInterruptTransferUsingChainedMdl = 55,
+    pub const URB_FUNCTION_BULK_OR_INTERRUPT_TRANSFER_USING_CHAINED_MDL: Self = Self(55);
 
     /// Represents [`URB_FUNCTION_ISOCH_TRANSFER`][1]. Used with [`TsUrbIsochTransfer`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_isoch_transfer
-    #[doc(alias = "URB_FUNCTION_ISOCH_TRANSFER")]
-    IsochTransfer = 10,
+    pub const URB_FUNCTION_ISOCH_TRANSFER: Self = Self(10);
 
     /// Represents [`URB_FUNCTION_ISOCH_TRANSFER_USING_CHAINED_MDL`][1]. Used with
     /// [`TsUrbIsochTransfer`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_isoch_transfer_using_chained_mdl
-    #[doc(alias = "URB_FUNCTION_ISOCH_TRANSFER_USING_CHAINED_MDL")]
-    IsochTransferUsingChainedMdl = 56,
+    pub const URB_FUNCTION_ISOCH_TRANSFER_USING_CHAINED_MDL: Self = Self(56);
 
     /// Represents [`URB_FUNCTION_GET_DESCRIPTOR_FROM_DEVICE`][1]. Used with
     /// [`TsUrbControlDescRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_get_descriptor_from_device
-    #[doc(alias = "URB_FUNCTION_GET_DESCRIPTOR_FROM_DEVICE")]
-    GetDescriptorFromDevice = 11,
+    pub const URB_FUNCTION_GET_DESCRIPTOR_FROM_DEVICE: Self = Self(11);
 
     /// Represents [`URB_FUNCTION_GET_DESCRIPTOR_FROM_ENDPOINT`][1]. Used with
     /// [`TsUrbControlDescRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_get_descriptor_from_endpoint
-    #[doc(alias = "URB_FUNCTION_GET_DESCRIPTOR_FROM_ENDPOINT")]
-    GetDescriptorFromEndpoint = 36,
+    pub const URB_FUNCTION_GET_DESCRIPTOR_FROM_ENDPOINT: Self = Self(36);
 
     /// Represents [`URB_FUNCTION_GET_DESCRIPTOR_FROM_INTERFACE`][1]. Used with
     /// [`TsUrbControlDescRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_get_descriptor_from_interface
-    #[doc(alias = "URB_FUNCTION_GET_DESCRIPTOR_FROM_INTERFACE")]
-    GetDescriptorFromInterface = 40,
+    pub const URB_FUNCTION_GET_DESCRIPTOR_FROM_INTERFACE: Self = Self(40);
 
     /// Represents [`URB_FUNCTION_SET_DESCRIPTOR_TO_DEVICE`][1]. Used with
     /// [`TsUrbControlDescRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_set_descriptor_to_device
-    #[doc(alias = "URB_FUNCTION_SET_DESCRIPTOR_TO_DEVICE")]
-    SetDescriptorToDevice = 12,
+    pub const URB_FUNCTION_SET_DESCRIPTOR_TO_DEVICE: Self = Self(12);
 
     /// Represents [`URB_FUNCTION_SET_DESCRIPTOR_TO_ENDPOINT`][1]. Used with
     /// [`TsUrbControlDescRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_set_descriptor_to_endpoint
-    #[doc(alias = "URB_FUNCTION_SET_DESCRIPTOR_TO_ENDPOINT")]
-    SetDescriptorToEndpoint = 37,
+    pub const URB_FUNCTION_SET_DESCRIPTOR_TO_ENDPOINT: Self = Self(37);
 
     /// Represents [`URB_FUNCTION_SET_DESCRIPTOR_TO_INTERFACE`][1]. Used with
     /// [`TsUrbControlDescRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_set_descriptor_to_interface
-    #[doc(alias = "URB_FUNCTION_SET_DESCRIPTOR_TO_INTERFACE")]
-    SetDescriptorToInterface = 41,
+    pub const URB_FUNCTION_SET_DESCRIPTOR_TO_INTERFACE: Self = Self(41);
 
     /// Represents [`URB_FUNCTION_SET_FEATURE_TO_DEVICE`][1]. Used with [`TsUrbControlFeatRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_set_feature_to_device
-    #[doc(alias = "URB_FUNCTION_SET_FEATURE_TO_DEVICE")]
-    SetFeatureToDevice = 13,
+    pub const URB_FUNCTION_SET_FEATURE_TO_DEVICE: Self = Self(13);
 
     /// Represents [`URB_FUNCTION_SET_FEATURE_TO_INTERFACE`][1]. Used with
     /// [`TsUrbControlFeatRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_set_feature_to_interface
-    #[doc(alias = "URB_FUNCTION_SET_FEATURE_TO_INTERFACE")]
-    SetFeatureToInterface = 14,
+    pub const URB_FUNCTION_SET_FEATURE_TO_INTERFACE: Self = Self(14);
 
     /// Represents [`URB_FUNCTION_SET_FEATURE_TO_ENDPOINT`][1]. Used with
     /// [`TsUrbControlFeatRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_set_feature_to_endpoint
-    #[doc(alias = "URB_FUNCTION_SET_FEATURE_TO_ENDPOINT")]
-    SetFeatureToEndpoint = 15,
+    pub const URB_FUNCTION_SET_FEATURE_TO_ENDPOINT: Self = Self(15);
 
     /// Represents [`URB_FUNCTION_SET_FEATURE_TO_OTHER`][1]. Used with [`TsUrbControlFeatRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_set_feature_to_other
-    #[doc(alias = "URB_FUNCTION_SET_FEATURE_TO_OTHER")]
-    SetFeatureToOther = 35,
+    pub const URB_FUNCTION_SET_FEATURE_TO_OTHER: Self = Self(35);
 
     /// Represents [`URB_FUNCTION_CLEAR_FEATURE_TO_DEVICE`][1]. Used with
     /// [`TsUrbControlFeatRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_clear_feature_to_device
-    #[doc(alias = "URB_FUNCTION_CLEAR_FEATURE_TO_DEVICE")]
-    ClearFeatureToDevice = 16,
+    pub const URB_FUNCTION_CLEAR_FEATURE_TO_DEVICE: Self = Self(16);
 
     /// Represents [`URB_FUNCTION_CLEAR_FEATURE_TO_INTERFACE`][1]. Used with
     /// [`TsUrbControlFeatRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_clear_feature_to_interface
-    #[doc(alias = "URB_FUNCTION_CLEAR_FEATURE_TO_INTERFACE")]
-    ClearFeatureToInterface = 17,
+    pub const URB_FUNCTION_CLEAR_FEATURE_TO_INTERFACE: Self = Self(17);
 
     /// Represents [`URB_FUNCTION_CLEAR_FEATURE_TO_ENDPOINT`][1]. Used with
     /// [`TsUrbControlFeatRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_clear_feature_to_endpoint
-    #[doc(alias = "URB_FUNCTION_CLEAR_FEATURE_TO_ENDPOINT")]
-    ClearFeatureToEndpoint = 18,
+    pub const URB_FUNCTION_CLEAR_FEATURE_TO_ENDPOINT: Self = Self(18);
 
     /// Represents [`URB_FUNCTION_CLEAR_FEATURE_TO_OTHER`][1]. Used with
     /// [`TsUrbControlFeatRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_clear_feature_to_other
-    #[doc(alias = "URB_FUNCTION_CLEAR_FEATURE_TO_OTHER")]
-    ClearFeatureToOther = 34,
+    pub const URB_FUNCTION_CLEAR_FEATURE_TO_OTHER: Self = Self(34);
 
     /// Represents [`URB_FUNCTION_GET_STATUS_FROM_DEVICE`][1]. Used with
     /// [`TsUrbControlGetStatusRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_get_status_from_device
-    #[doc(alias = "URB_FUNCTION_GET_STATUS_FROM_DEVICE")]
-    GetStatusFromDevice = 19,
+    pub const URB_FUNCTION_GET_STATUS_FROM_DEVICE: Self = Self(19);
 
     /// Represents [`URB_FUNCTION_GET_STATUS_FROM_INTERFACE`][1]. Used with
     /// [`TsUrbControlGetStatusRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_get_status_from_interface
-    #[doc(alias = "URB_FUNCTION_GET_STATUS_FROM_INTERFACE")]
-    GetStatusFromInterface = 20,
+    pub const URB_FUNCTION_GET_STATUS_FROM_INTERFACE: Self = Self(20);
 
     /// Represents [`URB_FUNCTION_GET_STATUS_FROM_ENDPOINT`][1]. Used with
     /// [`TsUrbControlGetStatusRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_get_status_from_endpoint
-    #[doc(alias = "URB_FUNCTION_GET_STATUS_FROM_ENDPOINT")]
-    GetStatusFromEndpoint = 21,
+    pub const URB_FUNCTION_GET_STATUS_FROM_ENDPOINT: Self = Self(21);
 
     /// Represents [`URB_FUNCTION_GET_STATUS_FROM_OTHER`][1]. Used with
     /// [`TsUrbControlGetStatusRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_get_status_from_other
-    #[doc(alias = "URB_FUNCTION_GET_STATUS_FROM_OTHER")]
-    GetStatusFromOther = 33,
+    pub const URB_FUNCTION_GET_STATUS_FROM_OTHER: Self = Self(33);
 
     /// Represents [`URB_FUNCTION_VENDOR_DEVICE`][1]. Used with [`TsUrbControlVendorClassRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_vendor_device
-    #[doc(alias = "URB_FUNCTION_VENDOR_DEVICE")]
-    VendorDevice = 23,
+    pub const URB_FUNCTION_VENDOR_DEVICE: Self = Self(23);
 
     /// Represents [`URB_FUNCTION_VENDOR_INTERFACE`][1]. Used with
     /// [`TsUrbControlVendorClassRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_vendor_interface
-    #[doc(alias = "URB_FUNCTION_VENDOR_INTERFACE")]
-    VendorInterface = 24,
+    pub const URB_FUNCTION_VENDOR_INTERFACE: Self = Self(24);
 
     /// Represents [`URB_FUNCTION_VENDOR_ENDPOINT`][1]. Used with
     /// [`TsUrbControlVendorClassRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_vendor_endpoint
-    #[doc(alias = "URB_FUNCTION_VENDOR_ENDPOINT")]
-    VendorEndpoint = 25,
+    pub const URB_FUNCTION_VENDOR_ENDPOINT: Self = Self(25);
 
     /// Represents [`URB_FUNCTION_VENDOR_OTHER`][1]. Used with [`TsUrbControlVendorClassRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_vendor_other
-    #[doc(alias = "URB_FUNCTION_VENDOR_OTHER")]
-    VendorOther = 32,
+    pub const URB_FUNCTION_VENDOR_OTHER: Self = Self(32);
 
     /// Represents [`URB_FUNCTION_CLASS_DEVICE`][1]. Used with [`TsUrbControlVendorClassRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_class_device
-    #[doc(alias = "URB_FUNCTION_CLASS_DEVICE")]
-    ClassDevice = 26,
+    pub const URB_FUNCTION_CLASS_DEVICE: Self = Self(26);
 
     /// Represents [`URB_FUNCTION_CLASS_INTERFACE`][1]. Used with
     /// [`TsUrbControlVendorClassRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_class_interface
-    #[doc(alias = "URB_FUNCTION_CLASS_INTERFACE")]
-    ClassInterface = 27,
+    pub const URB_FUNCTION_CLASS_INTERFACE: Self = Self(27);
 
     /// Represents [`URB_FUNCTION_CLASS_ENDPOINT`][1]. Used with [`TsUrbControlVendorClassRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_class_endpoint
-    #[doc(alias = "URB_FUNCTION_CLASS_ENDPOINT")]
-    ClassEndpoint = 28,
+    pub const URB_FUNCTION_CLASS_ENDPOINT: Self = Self(28);
 
     /// Represents [`URB_FUNCTION_CLASS_OTHER`][1]. Used with [`TsUrbControlVendorClassRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_class_other
-    #[doc(alias = "URB_FUNCTION_CLASS_OTHER")]
-    ClassOther = 31,
+    pub const URB_FUNCTION_CLASS_OTHER: Self = Self(31);
 
     /// Represents [`URB_FUNCTION_GET_CONFIGURATION`][1]. Used with
     /// [`TsUrbControlGetConfigRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_get_configuration
-    #[doc(alias = "URB_FUNCTION_GET_CONFIGURATION")]
-    GetConfiguration = 38,
+    pub const URB_FUNCTION_GET_CONFIGURATION: Self = Self(38);
 
     /// Represents [`URB_FUNCTION_GET_INTERFACE`][1]. Used with [`TsUrbControlGetInterfaceRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_get_interface
-    #[doc(alias = "URB_FUNCTION_GET_INTERFACE")]
-    GetInterface = 39,
+    pub const URB_FUNCTION_GET_INTERFACE: Self = Self(39);
 
     /// Represents [`URB_FUNCTION_GET_MS_FEATURE_DESCRIPTOR`][1]. Used with
     /// [`TsUrbOsFeatDescRequest`].
     ///
     /// [1]: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/usb/ns-usb-_urb_header#urb_function_get_ms_feature_descriptor
-    #[doc(alias = "URB_FUNCTION_GET_MS_FEATURE_DESCRIPTOR")]
-    GetMsFeatureDescriptor = 42,
+    pub const URB_FUNCTION_GET_MS_FEATURE_DESCRIPTOR: Self = Self(42);
+}
+
+impl From<u16> for UrbFunction {
+    fn from(value: u16) -> Self {
+        Self(value)
+    }
 }
 
 impl From<UrbFunction> for u16 {
-    #[expect(clippy::as_conversions)]
     fn from(value: UrbFunction) -> Self {
-        value as Self
+        value.0
     }
 }
 
@@ -380,8 +343,7 @@ impl Encode for TsUrbHeader {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         ensure_fixed_part_size!(in: dst);
 
-        #[expect(clippy::as_conversions)]
-        dst.write_u16(self.func as u16);
+        dst.write_u16(self.func.into());
 
         let no_ack = u32::from(self.no_ack) << 31;
         let last32 = u32::from(self.req_id) | no_ack;
@@ -403,53 +365,7 @@ impl Decode<'_> for TsUrbHeader {
     fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
         ensure_fixed_part_size!(in: src);
 
-        let func = match src.read_u16() {
-            0 => UrbFunction::SelectConfiguration,
-            1 => UrbFunction::SelectInterface,
-            2 => UrbFunction::AbortPipe,
-            7 => UrbFunction::GetCurrentFrameNumber,
-            8 => UrbFunction::ControlTransfer,
-            9 => UrbFunction::BulkOrInterruptTransfer,
-            10 => UrbFunction::IsochTransfer,
-            11 => UrbFunction::GetDescriptorFromDevice,
-            12 => UrbFunction::SetDescriptorToDevice,
-            13 => UrbFunction::SetFeatureToDevice,
-            14 => UrbFunction::SetFeatureToInterface,
-            15 => UrbFunction::SetFeatureToEndpoint,
-            16 => UrbFunction::ClearFeatureToDevice,
-            17 => UrbFunction::ClearFeatureToInterface,
-            18 => UrbFunction::ClearFeatureToEndpoint,
-            19 => UrbFunction::GetStatusFromDevice,
-            20 => UrbFunction::GetStatusFromInterface,
-            21 => UrbFunction::GetStatusFromEndpoint,
-            23 => UrbFunction::VendorDevice,
-            24 => UrbFunction::VendorInterface,
-            25 => UrbFunction::VendorEndpoint,
-            26 => UrbFunction::ClassDevice,
-            27 => UrbFunction::ClassInterface,
-            28 => UrbFunction::ClassEndpoint,
-            30 => UrbFunction::SyncResetPipeAndClearStall,
-            31 => UrbFunction::ClassOther,
-            32 => UrbFunction::VendorOther,
-            33 => UrbFunction::GetStatusFromOther,
-            34 => UrbFunction::ClearFeatureToOther,
-            35 => UrbFunction::SetFeatureToOther,
-            36 => UrbFunction::GetDescriptorFromEndpoint,
-            37 => UrbFunction::SetDescriptorToEndpoint,
-            38 => UrbFunction::GetConfiguration,
-            39 => UrbFunction::GetInterface,
-            40 => UrbFunction::GetDescriptorFromInterface,
-            41 => UrbFunction::SetDescriptorToInterface,
-            42 => UrbFunction::GetMsFeatureDescriptor,
-            48 => UrbFunction::SyncResetPipe,
-            49 => UrbFunction::SyncClearStall,
-            50 => UrbFunction::ControlTransferEx,
-            54 => UrbFunction::CloseStaticStreams,
-            55 => UrbFunction::BulkOrInterruptTransferUsingChainedMdl,
-            56 => UrbFunction::IsochTransferUsingChainedMdl,
-            value => return Err(unsupported_value_err!("URB Function", alloc::format!("{value}"))),
-        };
-        // let urb_function = src.read_u16();
+        let func = UrbFunction::from(src.read_u16());
         let last32 = src.read_u32();
         let req_id = RequestIdTransferInOut::try_from(last32 & 0x7F_FF_FF_FF).expect("value clamped");
         let no_ack = (last32 >> 31) != 0;
@@ -604,7 +520,9 @@ impl Decode<'_> for TsUsbdInterfaceInfo {
             ));
         };
 
-        let mut src = ReadCursor::new(src.read_slice(usize::from(length) - 2));
+        let remaining_length = usize::from(length) - 2 /* Length */;
+        ensure_size!(in: src, size: remaining_length);
+        let mut src = ReadCursor::new(src.read_slice(remaining_length));
 
         let number_of_pipes_expected = src.read_u16();
         let interface_number = src.read_u8();


### PR DESCRIPTION
- Add interface manipulation PDUs from [MS-RDPEXPS 2.2.2](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpexps/ebe401f0-f22e-4de4-9cd3-2a55e5493500) that MS-RDPEUSB inherits
- Split `UrbdrcServerPdu` / `UrbdrcClientPdu` by DVC roles, see #1077
- Pack `InterfaceId` and `Mask` into a single `u32` on `SharedMsgHeader`, align with MS-RDPEXPS
- Split `TsUrb` into `TsUrbIn` and `TsUrbOut`
- `TsUrbHeader` contains `ts_urb_size`
- Turn `UrbFunction` and `DeviceTextType` to raw u32

TODO:
- [x] Check TS_URB, refine in this PR if necessary