### PR TITLE
fix(web-client): add repository metadata to published package.json

### DIFF
--- a/web-client/iron-remote-desktop-rdp/public/package.json
+++ b/web-client/iron-remote-desktop-rdp/public/package.json
@@ -7,6 +7,15 @@
   ],
   "description": "RDP backend for iron-remote-desktop",
   "version": "0.7.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Devolutions/IronRDP.git"
+  },
+  "homepage": "https://github.com/Devolutions/IronRDP",
+  "bugs": {
+    "url": "https://github.com/Devolutions/IronRDP/issues"
+  },
+  "license": "MIT OR Apache-2.0",
   "main": "iron-remote-desktop-rdp.js",
   "types": "index.d.ts",
   "files": [

--- a/web-client/iron-remote-desktop/public/package.json
+++ b/web-client/iron-remote-desktop/public/package.json
@@ -11,6 +11,15 @@
   ],
   "description": "Backend-agnostic Web Component for remote desktop protocols",
   "version": "0.11.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Devolutions/IronRDP.git"
+  },
+  "homepage": "https://github.com/Devolutions/IronRDP",
+  "bugs": {
+    "url": "https://github.com/Devolutions/IronRDP/issues"
+  },
+  "license": "MIT OR Apache-2.0",
   "main": "iron-remote-desktop.js",
   "types": "index.d.ts",
   "files": [


### PR DESCRIPTION
npm's sigstore provenance verification rejected publishing with:

    E422 Unprocessable Entity - Error verifying sigstore provenance
    bundle: "repository.url" is "", expected to match
    "https://github.com/Devolutions/IronRDP" from provenance

Add `repository`, `homepage`, `bugs`, and `license` fields to the `public/package.json` of both `iron-remote-desktop` and `iron-remote-desktop-rdp` so the published tarballs satisfy npm's provenance checks.