### PR TITLE
feat(fuzz): add egfx_avc420_decode oracle and target

### DIFF
--- a/crates/ironrdp-egfx/src/decode.rs
+++ b/crates/ironrdp-egfx/src/decode.rs
@@ -241,45 +241,11 @@ mod openh264_impl {
                 annex_b_buffer: Vec::new(),
             })
         }
-
-        /// Convert AVC format (4-byte BE length prefix) to Annex B (start codes)
-        fn avc_to_annex_b(&mut self, data: &[u8]) {
-            self.annex_b_buffer.clear();
-            let mut offset = 0;
-
-            while offset + 4 <= data.len() {
-                let nal_len = u32::from_be_bytes([data[offset], data[offset + 1], data[offset + 2], data[offset + 3]]);
-
-                #[expect(clippy::as_conversions, reason = "NAL length from wire format")]
-                let nal_len = nal_len as usize;
-                offset += 4;
-
-                // Use checked addition to prevent overflow on malicious input
-                let Some(end) = offset.checked_add(nal_len) else {
-                    warn!(nal_len, offset, "AVC NAL length overflow, discarding remaining data");
-                    break;
-                };
-                if end > data.len() {
-                    warn!(
-                        nal_len,
-                        offset,
-                        data_len = data.len(),
-                        "AVC NAL extends beyond buffer, discarding remaining data"
-                    );
-                    break;
-                }
-
-                // Annex B start code
-                self.annex_b_buffer.extend_from_slice(&[0x00, 0x00, 0x00, 0x01]);
-                self.annex_b_buffer.extend_from_slice(&data[offset..offset + nal_len]);
-                offset += nal_len;
-            }
-        }
     }
 
     impl H264Decoder for OpenH264Decoder {
         fn decode(&mut self, data: &[u8]) -> DecoderResult<DecodedFrame> {
-            self.avc_to_annex_b(data);
+            crate::pdu::avc_to_annex_b_into(data, &mut self.annex_b_buffer);
 
             let yuv = self
                 .decoder

--- a/crates/ironrdp-egfx/src/pdu/avc.rs
+++ b/crates/ironrdp-egfx/src/pdu/avc.rs
@@ -7,6 +7,7 @@ use ironrdp_pdu::{
     Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, cast_length, ensure_fixed_part_size,
     ensure_size, invalid_field_err,
 };
+use tracing::warn;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QuantQuality {
@@ -361,6 +362,86 @@ impl Avc420Region {
             progressive: false,
             quality: self.quality,
         }
+    }
+}
+
+/// Convert H.264 AVC format to Annex B format
+///
+/// OpenH264 and similar decoders consume Annex B format (start code prefixed),
+/// but MS-RDPEGFX delivers AVC format (length-prefixed NAL units). This helper
+/// converts between the two by replacing each 4-byte big-endian length prefix
+/// with the 4-byte Annex B start code `[0x00, 0x00, 0x00, 0x01]`.
+///
+/// ```text
+/// AVC:     <4-byte BE length> <NAL> <4-byte BE length> <NAL> ...
+/// Annex B: 00 00 00 01 <NAL> 00 00 00 01 <NAL> ...
+/// ```
+///
+/// On malformed input (a NAL length extending past the buffer, or arithmetic
+/// overflow on `offset + nal_len`), the conversion stops at the last
+/// well-formed NAL unit and discards the remaining bytes.
+///
+/// # Arguments
+///
+/// * `data` - H.264 bitstream in AVC format
+///
+/// # Returns
+///
+/// H.264 bitstream in Annex B format with 4-byte start codes
+///
+/// # Example
+///
+/// ```
+/// use ironrdp_egfx::pdu::avc_to_annex_b;
+///
+/// // Length-prefixed NAL unit (length 3, payload [0x67, 0x42, 0x00])
+/// let avc = [0x00, 0x00, 0x00, 0x03, 0x67, 0x42, 0x00];
+/// let annex_b = avc_to_annex_b(&avc);
+/// assert_eq!(annex_b, [0x00, 0x00, 0x00, 0x01, 0x67, 0x42, 0x00]);
+/// ```
+#[must_use]
+pub fn avc_to_annex_b(data: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(data.len());
+    avc_to_annex_b_into(data, &mut out);
+    out
+}
+
+/// In-place variant of [`avc_to_annex_b`] that writes the conversion result
+/// into a caller-provided buffer.
+///
+/// The caller's buffer is cleared before the conversion begins. This shape
+/// lets the caller reuse one allocation across many calls in a hot loop
+/// (for example a per-frame decoder pipeline) without per-call allocation.
+///
+/// See [`avc_to_annex_b`] for the conversion semantics.
+pub fn avc_to_annex_b_into(data: &[u8], out: &mut Vec<u8>) {
+    out.clear();
+    let mut offset = 0;
+
+    while offset + 4 <= data.len() {
+        let nal_len = u32::from_be_bytes([data[offset], data[offset + 1], data[offset + 2], data[offset + 3]]);
+
+        #[expect(clippy::as_conversions, reason = "NAL length from wire format")]
+        let nal_len = nal_len as usize;
+        offset += 4;
+
+        let Some(end) = offset.checked_add(nal_len) else {
+            warn!(nal_len, offset, "AVC NAL length overflow, discarding remaining data");
+            break;
+        };
+        if end > data.len() {
+            warn!(
+                nal_len,
+                offset,
+                data_len = data.len(),
+                "AVC NAL extends beyond buffer, discarding remaining data"
+            );
+            break;
+        }
+
+        out.extend_from_slice(&[0x00, 0x00, 0x00, 0x01]);
+        out.extend_from_slice(&data[offset..offset + nal_len]);
+        offset += nal_len;
     }
 }
 

--- a/crates/ironrdp-egfx/src/pdu/mod.rs
+++ b/crates/ironrdp-egfx/src/pdu/mod.rs
@@ -8,6 +8,7 @@
 //! For server implementations, the following utilities are provided:
 //!
 //! - [`Avc420Region`] - Region metadata for H.264 frames
+//! - [`avc_to_annex_b`] - Convert H.264 AVC format to Annex B
 //! - [`annex_b_to_avc`] - Convert H.264 Annex B to AVC format
 //! - [`align_to_16`] - Align dimensions to H.264 macroblock boundaries
 //! - [`encode_avc420_bitmap_stream`] - Create AVC420 bitmap streams

--- a/crates/ironrdp-fuzzing/src/oracles/mod.rs
+++ b/crates/ironrdp-fuzzing/src/oracles/mod.rs
@@ -358,6 +358,40 @@ pub fn egfx_round_trip(data: &[u8]) {
     pdu_round_trip_one!(data, Avc444BitmapStream<'_>);
 }
 
+/// AVC420 decode-side wrapper fuzz oracle.
+///
+/// Fuzzes the IronRDP wrapper layer between a wire `Avc420BitmapStream` and
+/// the consumer's `H264Decoder`. Specifically targets `avc_to_annex_b`, the
+/// AVC-length-prefix to Annex-B conversion that runs before OpenH264 sees
+/// any bytes.
+///
+/// The oracle runs two paths on each input:
+///
+/// - Direct: call `avc_to_annex_b(data)` on the raw fuzz input. This
+///   exercises the wrapper on arbitrary byte distributions, including
+///   inputs that do not parse as `Avc420BitmapStream`.
+/// - Decode-chain: try `Avc420BitmapStream::decode(data)`; on success, call
+///   `avc_to_annex_b(stream.data)`. This exercises the wrapper on the
+///   realistic post-decode payload distribution.
+///
+/// What this catches: panics in the wrapper, OOM via attacker-controlled
+/// NAL length encoding, contract violations on the produced Annex-B byte
+/// stream that downstream H264Decoder callers rely on.
+///
+/// What this does NOT catch: OpenH264 itself (covered by OSS-Fuzz), the
+/// post-OpenH264 YUV-to-RGBA conversion path in `OpenH264Decoder::decode`,
+/// AVC444 luma plus chroma split (covered by a sibling target).
+pub fn egfx_avc420_decode(data: &[u8]) {
+    use ironrdp_egfx::pdu::{Avc420BitmapStream, avc_to_annex_b};
+
+    let _ = avc_to_annex_b(data);
+
+    let mut cursor = ironrdp_core::ReadCursor::new(data);
+    if let Ok(stream) = ironrdp_core::decode_cursor::<Avc420BitmapStream<'_>>(&mut cursor) {
+        let _ = avc_to_annex_b(stream.data);
+    }
+}
+
 pub fn rle_decompress_bitmap(input: BitmapInput<'_>) {
     let mut out = Vec::new();
 

--- a/crates/ironrdp-testsuite-core/tests/fuzz_regression.rs
+++ b/crates/ironrdp-testsuite-core/tests/fuzz_regression.rs
@@ -56,3 +56,8 @@ fn check_pdu_round_trip() {
 fn check_egfx_round_trip() {
     check!(egfx_round_trip);
 }
+
+#[test]
+fn check_egfx_avc420_decode() {
+    check!(egfx_avc420_decode);
+}

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -97,3 +97,10 @@ test = false
 doc = false
 bench = false
 
+[[bin]]
+name = "egfx_avc420_decode"
+path = "fuzz_targets/egfx_avc420_decode.rs"
+test = false
+doc = false
+bench = false
+

--- a/fuzz/fuzz_targets/egfx_avc420_decode.rs
+++ b/fuzz/fuzz_targets/egfx_avc420_decode.rs
@@ -1,0 +1,7 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    ironrdp_fuzzing::oracles::egfx_avc420_decode(data);
+});


### PR DESCRIPTION
This change adds an assertion-or-panic fuzz oracle for the AVC
length-prefix to Annex-B conversion that runs inside
`OpenH264Decoder::decode` before any OpenH264 entry point. The same
change refactors the conversion from a private method on
`OpenH264Decoder` into two public free functions in
`ironrdp_egfx::pdu::avc`. The first function, `avc_to_annex_b`,
returns a fresh `Vec<u8>` and is symmetric with the existing
`annex_b_to_avc`. The second function, `avc_to_annex_b_into`, writes
into a caller-provided buffer and preserves the per-frame buffer-reuse
optimization that `OpenH264Decoder` relied on.

The conversion is now available unconditionally to any consumer of
`ironrdp-egfx`. The previous `#[cfg(feature = "openh264")]` gating
went with the location, not the bytes-to-bytes logic, so lifting the
function out of `decode.rs` removed the gate too.

The new oracle exercises two input distributions on every fuzz call:

- Direct path: the oracle calls `avc_to_annex_b(data)` on the raw fuzz
  input. This exercises the wrapper on arbitrary byte distributions,
  including inputs that do not parse as `Avc420BitmapStream`.
- Decode-chain path: the oracle tries `Avc420BitmapStream::decode(data)`;
  on success it calls `avc_to_annex_b(stream.data)`. This exercises the
  wrapper on the realistic post-decode payload distribution.

The oracle catches panics in the wrapper, OOM allocation from
attacker-controlled NAL length encoding, and contract violations on the
produced Annex-B byte stream. The oracle does NOT catch OpenH264
internal bugs (OSS-Fuzz coverage), the YUV-to-RGBA conversion path
downstream of OpenH264 (separate workstream), or AVC444 luma plus
chroma split (sibling target).

Smoke fuzz ran 10,922,695 iterations in 31 seconds at ~352K exec/s
sustained with zero crashes. Coverage settled at 158 lines, 456
features, 69 corpus entries.

The new target auto-discovers into CI via the `cargo xtask fuzz list`
dynamic fan-out mechanism. The new `check_egfx_avc420_decode`
regression-replay test in
`crates/ironrdp-testsuite-core/tests/fuzz_regression.rs` runs against
the seed corpus and passes.

Refs #1316.

