### PR TITLE
refactor(pdu): make the CapabilitySet encoder exhaustive

### DIFF
--- a/crates/ironrdp-pdu/src/rdp/capability_sets/bitmap_codecs/mod.rs
+++ b/crates/ironrdp-pdu/src/rdp/capability_sets/bitmap_codecs/mod.rs
@@ -281,7 +281,12 @@ impl<'de> Decode<'de> for Codec {
                 match guid {
                     GUID_REMOTEFX => CodecProperty::RemoteFx(property),
                     GUID_IMAGE_REMOTEFX => CodecProperty::ImageRemoteFx(property),
-                    _ => unreachable!(),
+                    // `guid` is validated as RemoteFX or ImageRemoteFX by the outer
+                    // match arm, so the `_` branch is genuinely dead. Keep it as a
+                    // redundant correctness check that fires loudly under tests and
+                    // fuzzing if a future change to the outer arm breaks that
+                    // invariant. Not reachable from the wire.
+                    _ => unreachable!("guid validated as RemoteFX or ImageRemoteFX by the outer match"),
                 }
             }
             GUID_IGNORE => CodecProperty::Ignore,

--- a/crates/ironrdp-pdu/src/rdp/capability_sets/mod.rs
+++ b/crates/ironrdp-pdu/src/rdp/capability_sets/mod.rs
@@ -445,7 +445,34 @@ impl Encode for CapabilitySet {
                     CapabilitySet::Rail(buffer) => (CapabilitySetType::Rail, buffer),
                     CapabilitySet::WindowList(buffer) => (CapabilitySetType::WindowList, buffer),
                     CapabilitySet::BitmapCacheV3(buffer) => (CapabilitySetType::BitmapCacheV3CodecID, buffer),
-                    _ => unreachable!(),
+                    // Structured variants are routed through the outer match's
+                    // specific arms above this block and cannot reach this
+                    // inner match. Listing them explicitly (instead of using
+                    // `_ =>`) makes a future addition to `CapabilitySet` a
+                    // compile error here until the new variant is routed in
+                    // this `Encode` impl. PR #1313 (BitmapCacheV3 encoder
+                    // `unreachable!()` reached on decoder-accepted input)
+                    // demonstrated why a runtime catch-all is the wrong shape
+                    // for this match.
+                    CapabilitySet::General(_)
+                    | CapabilitySet::Bitmap(_)
+                    | CapabilitySet::Order(_)
+                    | CapabilitySet::BitmapCache(_)
+                    | CapabilitySet::BitmapCacheRev2(_)
+                    | CapabilitySet::Pointer(_)
+                    | CapabilitySet::Sound(_)
+                    | CapabilitySet::Input(_)
+                    | CapabilitySet::Brush(_)
+                    | CapabilitySet::GlyphCache(_)
+                    | CapabilitySet::OffscreenBitmapCache(_)
+                    | CapabilitySet::VirtualChannel(_)
+                    | CapabilitySet::MultiFragmentUpdate(_)
+                    | CapabilitySet::LargePointer(_)
+                    | CapabilitySet::SurfaceCommands(_)
+                    | CapabilitySet::BitmapCodecs(_)
+                    | CapabilitySet::FrameAcknowledge(_) => {
+                        unreachable!("structured variant routed to raw-buffer encoder arm")
+                    }
                 };
 
                 dst.write_u16(capability_set_type.as_u16());


### PR DESCRIPTION
Part of the `unreachable!()` / `panic!()` audit pass on #1314, scoped to `crates/ironrdp-pdu/src/rdp/capability_sets/`.

**`mod.rs` (`CapabilitySet::Encode::encode` raw-buffer fallback):** the inner `_ => unreachable!()` catch-all is replaced with an explicit enumeration of the 17 structured `CapabilitySet` variants already handled by the outer match. Adding a new variant to `CapabilitySet` is now a compile error here until it is routed in this `Encode` impl. The arm body stays `unreachable!()` (genuinely unreachable under the current outer-match structure). PR #1313 (BitmapCacheV3 encoder `unreachable!()` reached on decoder-accepted input) is why a runtime catch-all is the wrong shape here.

**`bitmap_codecs/mod.rs` (`CodecProperty` decode for `GUID_REMOTEFX | GUID_IMAGE_REMOTEFX`):** keeps its `match guid { ... _ => unreachable!() }` structure per review. `guid` is already validated by the outer arm, so the `_` branch is a redundant correctness check that fires under tests and fuzzing if a future change breaks the invariant. The only change is an inline message documenting that invariant.

Both sites are class (a) (provably unreachable in current code), confirmed by `pdu_round_trip` (#1291) and `message_decoding_invariants` (#1320) exercising `CapabilitySet` and `ShareControlHeader` for millions of iterations post-#1313 with no panics.

Refs #1314.
