### PR TITLE
fix(egfx)!: make DecodedFrame fields private with getters to enforce size invariant

### DIFF
--- a/crates/ironrdp-egfx/src/client.rs
+++ b/crates/ironrdp-egfx/src/client.rs
@@ -751,10 +751,10 @@ impl GraphicsPipelineClient {
         // Decoded frame must be at least as large as the destination rectangle.
         // Larger is expected (macroblock alignment) and handled by cropping.
         // Smaller means the server sent mismatched dimensions.
-        if frame.width < u32::from(dest_width) || frame.height < u32::from(dest_height) {
+        if frame.width() < u32::from(dest_width) || frame.height() < u32::from(dest_height) {
             warn!(
-                frame_width = frame.width,
-                frame_height = frame.height,
+                frame_width = frame.width(),
+                frame_height = frame.height(),
                 dest_width,
                 dest_height,
                 "decoded frame smaller than destination rectangle"
@@ -762,7 +762,7 @@ impl GraphicsPipelineClient {
             return Err(pdu_other_err!("decoded frame smaller than destination rectangle"));
         }
 
-        let cropped_data = crop_decoded_frame(&frame.data, frame.width, frame.height, dest_width, dest_height);
+        let cropped_data = crop_decoded_frame(frame.data(), frame.width(), frame.height(), dest_width, dest_height);
 
         let update = BitmapUpdate {
             surface_id,

--- a/crates/ironrdp-egfx/src/decode.rs
+++ b/crates/ironrdp-egfx/src/decode.rs
@@ -29,12 +29,9 @@ use core::fmt;
 #[derive(Clone)]
 #[non_exhaustive]
 pub struct DecodedFrame {
-    /// RGBA pixel data (4 bytes per pixel)
-    pub data: Vec<u8>,
-    /// Frame width in pixels
-    pub width: u32,
-    /// Frame height in pixels
-    pub height: u32,
+    data: Vec<u8>,
+    width: u32,
+    height: u32,
 }
 
 impl DecodedFrame {
@@ -49,6 +46,26 @@ impl DecodedFrame {
             "DecodedFrame buffer must be RGBA8888 (width * height * 4 bytes)",
         );
         Self { data, width, height }
+    }
+
+    /// RGBA pixel data (4 bytes per pixel).
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    /// Frame width in pixels.
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    /// Frame height in pixels.
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+
+    /// Consume the frame and return the owned RGBA buffer.
+    pub fn into_data(self) -> Vec<u8> {
+        self.data
     }
 }
 
@@ -286,11 +303,7 @@ mod openh264_impl {
             let mut rgba = vec![0u8; rgba_size];
             yuv.write_rgba8(&mut rgba);
 
-            Ok(DecodedFrame {
-                data: rgba,
-                width: w32,
-                height: h32,
-            })
+            Ok(DecodedFrame::new(rgba, w32, h32))
         }
 
         fn reset(&mut self) {
@@ -309,3 +322,24 @@ mod openh264_impl {
 
 #[cfg(feature = "openh264")]
 pub use openh264_impl::OpenH264Decoder;
+
+#[cfg(test)]
+mod tests {
+    use super::DecodedFrame;
+
+    #[test]
+    fn getters_return_constructor_inputs() {
+        let data = vec![0u8; 2 * 3 * 4];
+        let frame = DecodedFrame::new(data.clone(), 2, 3);
+        assert_eq!(frame.data(), data.as_slice());
+        assert_eq!(frame.width(), 2);
+        assert_eq!(frame.height(), 3);
+    }
+
+    #[test]
+    fn into_data_yields_owned_buffer() {
+        let data = vec![0xAAu8; 4 * 4 * 4];
+        let frame = DecodedFrame::new(data.clone(), 4, 4);
+        assert_eq!(frame.into_data(), data);
+    }
+}

--- a/crates/ironrdp-testsuite-core/tests/egfx/decode.rs
+++ b/crates/ironrdp-testsuite-core/tests/egfx/decode.rs
@@ -86,8 +86,8 @@ fn test_openh264_decode_sps_pps() {
 
     let mut decoder = OpenH264Decoder::new().expect("decoder should initialize");
     let frame = decoder.decode(&avc_data).expect("decode should succeed");
-    assert!(frame.width >= 16, "decoded width should be at least 16");
-    assert!(frame.height >= 16, "decoded height should be at least 16");
+    assert!(frame.width() >= 16, "decoded width should be at least 16");
+    assert!(frame.height() >= 16, "decoded height should be at least 16");
 }
 
 #[test]
@@ -98,9 +98,9 @@ fn test_openh264_decode_iframe() {
     let frame = decoder.decode(&avc_data).expect("decode should succeed");
 
     // Verify RGBA output dimensions and data
-    assert_eq!(frame.width, 16);
-    assert_eq!(frame.height, 16);
-    assert_eq!(frame.data.len(), 16 * 16 * 4, "RGBA data should be 16x16x4 bytes");
+    assert_eq!(frame.width(), 16);
+    assert_eq!(frame.height(), 16);
+    assert_eq!(frame.data().len(), 16 * 16 * 4, "RGBA data should be 16x16x4 bytes");
 }
 
 #[test]
@@ -116,8 +116,8 @@ fn test_openh264_decoder_reset() {
 
     // Decoder should still be usable after reset
     let frame = decoder.decode(&avc_data).expect("decode after reset should succeed");
-    assert_eq!(frame.width, 16);
-    assert_eq!(frame.height, 16);
+    assert_eq!(frame.width(), 16);
+    assert_eq!(frame.height(), 16);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Picks up the follow-up CBenoit invited via `thought:` on #1284 (`discussion_r3271919807`); acknowledged inline as `discussion_r3273666208` with a commitment to file the follow-up.
- After #1284, `DecodedFrame` in `crates/ironrdp-egfx/src/decode.rs` is `#[non_exhaustive]` with public `data`, `width`, `height` fields. `DecodedFrame::new()` enforces the `data.len() == width * height * 4` RGBA8888 invariant via `debug_assert_eq!`, but the `pub` fields let consumers bypass the guard via post-construction mutation. `#[non_exhaustive]` closes struct-literal construction from outside the crate but does not lock down field-level writes.
- This PR makes the three fields private and exposes them via read-only getters: `data() -> &[u8]`, `width() -> u32`, `height() -> u32`. A consume accessor `into_data(self) -> Vec<u8>` covers callers needing owned ownership transfer without an extra clone.
- `DecodedFrame::new()` remains the sole construction path. The internal `openh264_impl::decode` previously used a struct literal; this PR routes it through `new()` so the same-crate path also benefits from the invariant guard.

## Validation

- Two unit tests in `ironrdp_egfx::decode::tests` cover the new surface: `getters_return_constructor_inputs` verifies the three getters round-trip the constructor inputs, and `into_data_yields_owned_buffer` verifies the consume path returns the original RGBA buffer.
- All 12 internal call sites in `crates/ironrdp-egfx/src/client.rs` and `crates/ironrdp-testsuite-core/tests/egfx/decode.rs` updated to use the getters; a workspace grep confirms no remaining field-style accesses on `DecodedFrame` instances.
- `cargo xtask ci` clean locally on `1.89.0`: fmt, lints, tests, typos, locks all green.

## Notes

- Breaking change for external consumers reading the public fields directly. Migration path is mechanical:
  - `frame.data` becomes `frame.data()` (returns `&[u8]` rather than `&Vec<u8>`; callers needing `Vec` go through `into_data()` or `.to_vec()`)
  - `frame.width` becomes `frame.width()`
  - `frame.height` becomes `frame.height()`
- `!` marker on the conventional commit subject so release-plz computes a breaking-version bump on the next `ironrdp-egfx` cut.
- Resolves the follow-up commitment from `discussion_r3273666208` on the merged #1284 thread; the original `thought:` is at `discussion_r3271919807`.