### PR TITLE
fix(server): emit RGB-channel QOI for opaque captures so ironrdp-session can decode

### DIFF
--- a/crates/ironrdp-server/src/encoder/mod.rs
+++ b/crates/ironrdp-server/src/encoder/mod.rs
@@ -651,15 +651,26 @@ impl BitmapUpdateHandler for QoizHandler {
 #[cfg(feature = "qoi")]
 fn qoi_encode(bitmap: &BitmapUpdate) -> Result<Vec<u8>> {
     use ironrdp_graphics::image_processing::PixelFormat::*;
+    // Map every 4-byte input — whether it nominally has an alpha byte or
+    // an "X" filler — to the 3-channel-output `*x` variant of
+    // `RawChannels`. The qoi crate selects `Channels::Rgb` vs
+    // `Channels::Rgba` for the QOI header from this enum: `*x` and `*r/g/b`
+    // produce `Rgb`; `*a` produces `Rgba`. The `ironrdp-session` NSCodec-
+    // free decode path in `fast_path.rs::qoi_apply` only supports
+    // `Channels::Rgb` and explicitly drops `Channels::Rgba` frames with
+    // `WARN: Unsupported RGBA QOI data`, so the previous "honest" mapping
+    // (`BgrA32 -> Bgra`, etc.) produced output that no IronRDP client
+    // could decode — every QOI session rendered a blank screen.
+    //
+    // Server-side bitmap captures are functionally opaque (the alpha byte
+    // is either always 0xFF or treated as filler), so discarding it is
+    // safe and matches what every successful legacy bitmap path
+    // already does.
     let raw_channels = match bitmap.format {
-        ARgb32 => qoi::RawChannels::Argb,
-        XRgb32 => qoi::RawChannels::Xrgb,
-        ABgr32 => qoi::RawChannels::Abgr,
-        XBgr32 => qoi::RawChannels::Xbgr,
-        BgrA32 => qoi::RawChannels::Bgra,
-        BgrX32 => qoi::RawChannels::Bgrx,
-        RgbA32 => qoi::RawChannels::Rgba,
-        RgbX32 => qoi::RawChannels::Rgbx,
+        ARgb32 | XRgb32 => qoi::RawChannels::Xrgb,
+        ABgr32 | XBgr32 => qoi::RawChannels::Xbgr,
+        BgrA32 | BgrX32 => qoi::RawChannels::Bgrx,
+        RgbA32 | RgbX32 => qoi::RawChannels::Rgbx,
     };
     let enc = qoi::EncoderBuilder::new(&bitmap.data, bitmap.width.get().into(), bitmap.height.get().into())
         .stride(bitmap.stride.get())


### PR DESCRIPTION
Fixes the broken QOI codec path between `ironrdp-server` and `ironrdp-client`/`ironrdp-session`. Found while answering @elmarco's "did you try [QOI]?" question on [#1322](https://github.com/Devolutions/IronRDP/discussions/1322).

## What's broken

In `crates/ironrdp-server/src/encoder/mod.rs::qoi_encode`, the four `*A32` `PixelFormat` variants (`ARgb32`, `ABgr32`, `BgrA32`, `RgbA32`) map to the matching `*a` variant of `qoi::RawChannels`. In `qoicoubeh`, those variants produce a QOI header with `channels = Rgba`. The decoder in `ironrdp-session/src/fast_path.rs::qoi_apply` only supports `Channels::Rgb`; the `Channels::Rgba` arm is literally `warn!("Unsupported RGBA QOI data")` and drops the frame.

So the moment QOI actually gets negotiated between an `ironrdp-server`-based server and an `ironrdp-client`/`ironrdp-session`-based client, the server emits a header the client refuses, and the client renders a blank window plus one warning per frame.

## Reproduction (before the fix)

Loopback against `macrdp` 0.5.49 (which uses `ironrdp-server` from `Devolutions/IronRDP` rev `879ffed8`):

```
$ ironrdp-viewer --features qoi,qoiz ... 127.0.0.1:3390
WARN ironrdp_session::fast_path: Unsupported RGBA QOI data
WARN ironrdp_session::fast_path: Unsupported RGBA QOI data
... (412 warnings in ~12s; viewer renders nothing)
```

From the connector trace, the server advertised `[NsCodec, RemoteFx, ImageRemoteFx, Qoi, QoiZ]`, the client confirmed `[RemoteFx, Qoi, QoiZ]`, and the server picked QOI per its codec selection ladder. Every encoded frame was emitted as RGBA.

## Fix

Map every 4-byte input format — whether it nominally has an alpha byte or an "X" filler — to the `*x` sibling of `RawChannels`. The qoi crate picks `Channels::Rgb` for `*x`/`*r`/`*g`/`*b` and `Channels::Rgba` only for `*a`, so this forces 3-channel output that the existing decoder accepts.

Server-side bitmap captures are functionally opaque (the alpha byte from a screen capture is either premultiplied to 0 or set to 0xFF), so discarding it at encode time is consistent with how the rest of the legacy bitmap path already handles these formats.

## After the fix

Same loopback session:

- 0 `Unsupported RGBA QOI data` warnings
- viewer renders the desktop normally

## Test plan

- [x] `cargo build -p ironrdp-server --features qoi` — clean
- [x] `cargo build -p ironrdp-server` (default) — clean
- [x] `cargo clippy -p ironrdp-server --features qoi,qoiz,helper,__bench --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Loopback reproduction with `ironrdp-viewer --features qoi,qoiz` against `macrdp` (a `ironrdp-server` consumer) — 412 → 0 RGBA warnings

## Notes

- The four `*X32` variants are unchanged; they already mapped to the `*x` `RawChannels` and produced correct RGB output.
- No client-side change. A future PR could *also* add a real `Channels::Rgba` decode path in `qoi_apply` (just ignore the alpha plane), which would let clients consume RGBA QOI from third-party encoders if any exist. Out of scope here.