### PR TITLE
feat(fuzz): add egfx_multi_frame oracle and target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2704,6 +2704,7 @@ dependencies = [
  "ironrdp-cliprdr-format",
  "ironrdp-core 0.2.1",
  "ironrdp-displaycontrol",
+ "ironrdp-dvc",
  "ironrdp-egfx",
  "ironrdp-graphics",
  "ironrdp-pdu",

--- a/crates/ironrdp-fuzzing/Cargo.toml
+++ b/crates/ironrdp-fuzzing/Cargo.toml
@@ -20,7 +20,8 @@ ironrdp-rdpdr.path = "../ironrdp-rdpdr"
 ironrdp-rdpsnd.path = "../ironrdp-rdpsnd"
 ironrdp-cliprdr-format.path = "../ironrdp-cliprdr-format"
 ironrdp-displaycontrol.path = "../ironrdp-displaycontrol"
-ironrdp-egfx.path = "../ironrdp-egfx"
+ironrdp-dvc.path = "../ironrdp-dvc"
+ironrdp-egfx = { path = "../ironrdp-egfx", features = ["arbitrary"] }
 ironrdp-svc.path = "../ironrdp-svc"
 
 [lints]

--- a/crates/ironrdp-fuzzing/src/oracles/mod.rs
+++ b/crates/ironrdp-fuzzing/src/oracles/mod.rs
@@ -421,6 +421,88 @@ pub fn egfx_avc420_decode(data: &[u8]) {
     }
 }
 
+/// Multi-frame oracle for the EGFX graphics pipeline client.
+///
+/// H.264 decoding maintains reference-picture state, SPS/PPS context, and
+/// decoder configuration across frames; surface caching and codec dispatch
+/// state in egfx all carry forward across PDUs. Single-shot fuzzers cannot
+/// reach frame-to-frame state corruption because they construct a fresh
+/// decoder per iteration. This oracle constructs ONE `GraphicsPipelineClient`
+/// at iteration start and drives a sequence of `GfxPdu`s through it, exposing
+/// cross-PDU state to the fuzzer.
+///
+/// Harness shape: `Arbitrary`-derived `Vec<GfxPdu>` (each variant `Arbitrary`
+/// via the cascade in PR #1334). Each PDU is encoded back to wire bytes,
+/// wrapped in a single uncompressed ZGFX segment, and fed to the client's
+/// public `DvcProcessor::process` entry point. This exercises the same path
+/// production traffic takes: ZGFX decompress -> `GfxPdu` decode -> dispatch
+/// to per-variant handler -> state machine + surface cache update.
+///
+/// What this catches: panics or sanitizer reports along the dispatch + state
+/// machine path when fed adversarially-ordered or malformed-payload PDUs;
+/// inconsistent surface-cache state under attacker-controlled
+/// CreateSurface / DeleteSurface / Map* orderings; corrupted frame-id state
+/// from interleaved StartFrame / EndFrame / FrameAcknowledge sequences;
+/// ZGFX-wrapper integration bugs separate from the standalone ZGFX coverage
+/// in `egfx_zgfx_decompress`.
+///
+/// What this does NOT catch: cross-frame H.264 decoder state corruption.
+/// The client is constructed with `h264_decoder: None`, so H264-bearing
+/// PDUs (WireToSurface1 with AVC codecs) don't reach the H.264 decoder.
+/// The standalone `egfx_avc420_decode` and `egfx_avc444_decode` targets
+/// cover the H.264 wrapper. Wiring a real (or mock) H.264 decoder into
+/// this harness can be a follow-up if frame-to-frame H.264 state coverage
+/// surfaces as a gap.
+pub fn egfx_multi_frame(data: &[u8]) {
+    use arbitrary::{Arbitrary as _, Unstructured};
+    use ironrdp_core::encode_vec;
+    use ironrdp_dvc::DvcProcessor as _;
+    use ironrdp_egfx::client::{GraphicsPipelineClient, GraphicsPipelineHandler};
+    use ironrdp_egfx::pdu::GfxPdu;
+    use ironrdp_graphics::zgfx::wrap_uncompressed;
+
+    /// No-op handler. Every callback default-impls in the trait, so the empty
+    /// struct gets all defaults for free. The handler exists to satisfy
+    /// `GraphicsPipelineClient::new`'s API; the fuzz oracle does not inspect
+    /// any of the dispatched events.
+    struct NoOpHandler;
+    impl GraphicsPipelineHandler for NoOpHandler {}
+
+    let mut unstructured = Unstructured::new(data);
+    let Ok(pdus) = Vec::<GfxPdu>::arbitrary(&mut unstructured) else {
+        return;
+    };
+
+    let mut client = GraphicsPipelineClient::new(Box::new(NoOpHandler), None);
+
+    // Initialise the channel state by invoking the DvcProcessor::start entry.
+    // The returned advertise message is discarded; the call's side effect is
+    // putting the client's internal state machine into its post-start state.
+    const FUZZ_CHANNEL_ID: u32 = 0;
+    let _ = client.start(FUZZ_CHANNEL_ID);
+
+    for pdu in pdus {
+        // Encode each PDU back to wire bytes so the client processes through
+        // the same decode + dispatch path real traffic takes. Skip PDUs whose
+        // encoder rejects the Arbitrary-generated values rather than aborting
+        // the iteration; the next PDU may still exercise interesting state.
+        let Ok(pdu_bytes) = encode_vec(&pdu) else {
+            continue;
+        };
+
+        // Wrap the encoded PDU in an uncompressed ZGFX segment so the client's
+        // ZGFX decompressor produces the PDU bytes unmodified. This bypasses
+        // the ZGFX decoder layer (covered separately by egfx_zgfx_decompress)
+        // and concentrates fuzz pressure on the dispatch + state machine.
+        let payload = wrap_uncompressed(&pdu_bytes);
+
+        // Errors and panics propagate to libFuzzer naturally; we discard the
+        // Result since the oracle's job is to surface bugs, not to enforce
+        // dispatcher semantics.
+        let _ = client.process(FUZZ_CHANNEL_ID, &payload);
+    }
+}
+
 pub fn rle_decompress_bitmap(input: BitmapInput<'_>) {
     let mut out = Vec::new();
 

--- a/crates/ironrdp-testsuite-core/tests/fuzz_regression.rs
+++ b/crates/ironrdp-testsuite-core/tests/fuzz_regression.rs
@@ -61,3 +61,8 @@ fn check_egfx_round_trip() {
 fn check_egfx_avc420_decode() {
     check!(egfx_avc420_decode);
 }
+
+#[test]
+fn check_egfx_multi_frame() {
+    check!(egfx_multi_frame);
+}

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -78,6 +78,9 @@ name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+dependencies = [
+ "arbitrary",
+]
 
 [[package]]
 name = "bitvec"
@@ -355,6 +358,7 @@ dependencies = [
 name = "ironrdp-egfx"
 version = "0.3.0"
 dependencies = [
+ "arbitrary",
  "bit_field",
  "bitflags",
  "ironrdp-core",
@@ -386,6 +390,7 @@ dependencies = [
  "ironrdp-cliprdr-format",
  "ironrdp-core",
  "ironrdp-displaycontrol",
+ "ironrdp-dvc",
  "ironrdp-egfx",
  "ironrdp-graphics",
  "ironrdp-pdu",
@@ -414,6 +419,7 @@ dependencies = [
 name = "ironrdp-pdu"
 version = "0.9.0"
 dependencies = [
+ "arbitrary",
  "bit_field",
  "bitflags",
  "byteorder",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -104,3 +104,10 @@ test = false
 doc = false
 bench = false
 
+[[bin]]
+name = "egfx_multi_frame"
+path = "fuzz_targets/egfx_multi_frame.rs"
+test = false
+doc = false
+bench = false
+

--- a/fuzz/fuzz_targets/egfx_multi_frame.rs
+++ b/fuzz/fuzz_targets/egfx_multi_frame.rs
@@ -1,0 +1,7 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    ironrdp_fuzzing::oracles::egfx_multi_frame(data);
+});


### PR DESCRIPTION
## Summary

- Implements target 5 of #1316 (egfx fuzz-coverage umbrella): the `egfx_multi_frame` oracle and target.
- Harness shape (per the design note posted as `issuecomment-4559459227` on #1316): an `Arbitrary`-derived `Vec<GfxPdu>` drives a single `GraphicsPipelineClient` + surface-cache pair across each fuzz iteration, exposing cross-PDU state corruption that single-shot fuzzers cannot reach.
- Each PDU is encoded back to wire bytes, wrapped in a single uncompressed ZGFX segment, and fed through the client's public `DvcProcessor::process` entry. The harness deliberately routes through `process()` rather than the private `handle_pdu` so production traffic's full path is exercised (ZGFX-decompress + GfxPdu-decode + per-variant dispatch + state machine + surface cache).
- The uncompressed ZGFX wrap bypasses the ZGFX decoder layer (covered separately by PR #1333) and concentrates fuzz pressure on dispatch + state machine.

## Validation

- `cargo xtask check fmt/lints/tests/typos/locks` all pass.
- `check_egfx_multi_frame` regression-replay test passes against the seed-empty corpus entry.
- 15-minute rigorous libFuzzer + ASan fuzz on the final SHA: **3,659,157 iterations in 901 seconds (~4,061 exec/s sustained), peak RSS 96 MB, zero panics, zero sanitizer reports, zero OOMs.** Corpus grew to ~4,558 entries via coverage discovery.

## What this catches

- Panics or sanitizer reports along the dispatch and state-machine path under adversarially-ordered PDU sequences.
- Inconsistent surface-cache state under attacker-controlled `CreateSurface` / `DeleteSurface` / `Map*` orderings.
- Corrupted frame-id state from interleaved `StartFrame` / `EndFrame` / `FrameAcknowledge` sequences.
- ZGFX-wrapper integration bugs separate from the standalone ZGFX coverage in `egfx_zgfx_decompress` (PR #1333).

## What this does NOT catch

- Cross-frame H.264 decoder state corruption. The client is constructed with `h264_decoder: None`, so `WireToSurface1` PDUs carrying AVC payloads skip the decoder. The standalone `egfx_avc420_decode` (PR #1326) and `egfx_avc444_decode` (PR #1327) targets cover the H.264 wrapper. Wiring a real or mock H.264 decoder into this harness can be a follow-up if frame-to-frame H.264 state coverage surfaces as a gap.

## Notes

- The first smoke fuzz on the in-progress harness surfaced a `bit_field::set_bits` panic in `Timestamp::encode` where `derive(Arbitrary)` generated `u8`/`u16` values exceeding the encoder's 6-bit and 10-bit pack widths. The fix landed preemptively in PR #1334 as manual `Arbitrary` impls for `Timestamp`, `QuantQuality`, and the `Encoding` bitflag (mapping each field to its wire-allowed range). That follows the `sanitize via mask` shape from #1122's body.
- The oracle uses `as _` imports for `Arbitrary` and `DvcProcessor` per clippy's `unused_trait_names` lint.
- `NoOpHandler` is an empty struct: every `GraphicsPipelineHandler` method has a default impl in the trait.

Refs #1316.
