### PR TITLE
feat(agent): introduce ironrdp-agent crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2453,6 +2453,7 @@ dependencies = [
  "ironrdp-propertyset",
  "ironrdp-rdpfile",
  "libc",
+ "png",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2440,6 +2440,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ironrdp-agent"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "ironrdp-cfg",
+ "ironrdp-client",
+ "ironrdp-core",
+ "ironrdp-input",
+ "ironrdp-pdu",
+ "ironrdp-propertyset",
+ "ironrdp-rdpfile",
+ "libc",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "whoami",
+]
+
+[[package]]
 name = "ironrdp-ainput"
 version = "0.7.0"
 dependencies = [
@@ -2969,8 +2989,12 @@ dependencies = [
  "anyhow",
  "async-trait",
  "ironrdp",
+ "ironrdp-agent",
  "ironrdp-async",
  "ironrdp-client",
+ "ironrdp-core",
+ "ironrdp-input",
+ "ironrdp-propertyset",
  "ironrdp-tls",
  "ironrdp-tokio",
  "ironrdp-viewer",

--- a/crates/ironrdp-agent/Cargo.toml
+++ b/crates/ironrdp-agent/Cargo.toml
@@ -1,0 +1,61 @@
+[package]
+name = "ironrdp-agent"
+version = "0.0.0"
+readme = "README.md"
+description = "CLI-driven, daemon-backed agentic RDP client suitable for LLM consumption"
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+# Not publishing for now.
+publish = false
+
+[lib]
+doctest = false
+test = false
+
+[[bin]]
+name = "ironrdp-agent"
+path = "src/main.rs"
+test = false
+
+[features]
+# Exposes otherwise-internal modules (e.g. the wire codec helpers) for unit testing from the
+# workspace test suite. Hidden from docs; not intended for downstream use.
+internal = []
+
+[dependencies]
+# RDP client engine: only the TLS backend is mandated
+ironrdp-client = { path = "../ironrdp-client", features = ["rustls"] }
+
+# Configuration model and codecs
+ironrdp-core = { path = "../ironrdp-core", features = ["alloc"] }
+ironrdp-pdu = { path = "../ironrdp-pdu" }
+ironrdp-propertyset = { path = "../ironrdp-propertyset" }
+ironrdp-cfg = { path = "../ironrdp-cfg" }
+ironrdp-rdpfile = { path = "../ironrdp-rdpfile" }
+ironrdp-input = { path = "../ironrdp-input" }
+
+# Async runtime and IPC transport
+tokio = { version = "1", features = ["rt-multi-thread", "net", "sync", "macros", "io-util", "time", "signal"] }
+
+# CLI
+clap = { version = "4.6", features = ["derive", "cargo"] }
+
+# Logging (ring-buffer tracing layer)
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# Utils
+anyhow = "1"
+whoami = "2.1"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[lints]
+workspace = true

--- a/crates/ironrdp-agent/Cargo.toml
+++ b/crates/ironrdp-agent/Cargo.toml
@@ -50,6 +50,9 @@ clap = { version = "4.6", features = ["derive", "cargo"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+# PNG encoding for screenshots
+png = "0.18"
+
 # Utils
 anyhow = "1"
 whoami = "2.1"

--- a/crates/ironrdp-agent/README.md
+++ b/crates/ironrdp-agent/README.md
@@ -1,0 +1,59 @@
+# IronRDP Agent
+
+A CLI-driven, daemon-backed RDP client designed for programmatic (e.g. LLM) consumption.
+
+The single `ironrdp-agent` binary bundles two roles:
+
+- **Daemon** (`ironrdp-agent daemon-start`): a long-lived, foreground process that owns the
+  [`ironrdp-client`] engine and one RDP session. It stays alive across many CLI invocations and
+  serves requests over a local IPC transport (a Unix domain socket on Unix, a named pipe on
+  Windows).
+- **CLI** (`ironrdp-agent <op> …`): a short-lived invocation that opens the IPC endpoint, sends a
+  single request, prints the response, and exits.
+
+Run `ironrdp-agent --help-agent` for a structured, machine-readable description of every operation.
+
+## Wire format
+
+Messages are encoded with [`ironrdp-core`]'s `Encode`/`Decode` traits, length-delimited with a
+little-endian `u32` byte-count prefix. There is no JSON anywhere. Both ends are the same binary at
+the same version, so the format carries no version byte.
+
+Connection configuration travels as a binary-encoded [`PropertySet`][`ironrdp-propertyset`] inside a
+strictly-typed `Request::Connect`. Runtime operations (mouse, keyboard, status, logs, …) are
+strictly-typed messages.
+
+## Secrets
+
+The daemon never exposes secrets to the IPC reader. `ConfigBuilder::build` strips every
+`ironrdp_cfg::is_secret_key` property (`ClearTextPassword`, `GatewayPassword`, the RDCleanPath
+token, …) before producing the `Config`, and the daemon seeds its live property bag from that
+post-build configuration. Secrets therefore never reach the live bag, so property dumps, status,
+and logs cannot leak them — no separate redaction pass is needed.
+
+## Preloaded overlay
+
+An operator can preconfigure any settings — credentials in particular — without handing them to the
+IPC caller. Pass an overlay [`PropertySet`][`ironrdp-propertyset`] to `daemon-start --overlay FILE`;
+the daemon layers it on top of every `Request::Connect` before building the configuration (overlay
+wins). When the overlay carries a secret (password/token), `Request::Status` reports
+`credentials_loaded`, so a caller should check the status first to learn whether it still needs to
+supply a password.
+
+## Logging
+
+Two logging concerns are kept separate:
+
+- **Daemon logging** is the daemon's own operational logging (IPC handling, lifecycle). It is the
+  global `tracing` subscriber: a compact formatter writing to stderr, defaulting to `info` and
+  tunable with the `IRONRDP_LOG` environment variable, mirroring [`ironrdp-viewer`].
+- **RDP session logging** is captured into a small, queryable in-memory ring buffer (read via
+  `Request::QueryLogs`) instead of the terminal. It is installed as a thread-local subscriber for
+  the session thread only (`tracing::dispatcher::with_default`), so it never becomes the global
+  subscriber. It defaults to `debug`; a per-`Connect` `log_directive` (e.g. `ironrdp_connector=trace`)
+  refines the filter to troubleshoot IronRDP itself.
+
+[`ironrdp-client`]: ../ironrdp-client
+[`ironrdp-core`]: ../ironrdp-core
+[`ironrdp-propertyset`]: ../ironrdp-propertyset
+[`ironrdp-viewer`]: ../ironrdp-viewer

--- a/crates/ironrdp-agent/README.md
+++ b/crates/ironrdp-agent/README.md
@@ -21,7 +21,9 @@ the same version, so the format carries no version byte.
 
 Connection configuration travels as a binary-encoded [`PropertySet`][`ironrdp-propertyset`] inside a
 strictly-typed `Request::Connect`. Runtime operations (mouse, keyboard, status, logs, …) are
-strictly-typed messages.
+strictly-typed messages. `Request::Screenshot` returns the most recent frame as PNG bytes (with the
+mouse cursor composited in — the agent enables software pointer rendering), which the CLI writes to
+disk.
 
 ## Secrets
 

--- a/crates/ironrdp-agent/src/cli.rs
+++ b/crates/ironrdp-agent/src/cli.rs
@@ -45,7 +45,7 @@ enum Command {
     Status,
     /// Query the live session properties.
     QueryProps(QueryPropsArgs),
-    /// Print retained daemon log lines.
+    /// Print the RDP session's captured log lines (from the daemon's in-memory ring buffer).
     QueryLogs(QueryLogsArgs),
     /// Capture the current frame (cursor included) as a PNG written to disk.
     Screenshot(ScreenshotArgs),
@@ -251,7 +251,8 @@ fn load_overlay(path: Option<&Path>) -> anyhow::Result<PropertySet> {
 }
 
 /// Builds a `Connect` request by merging an optional `.rdp` file with CLI overrides into one
-/// [`PropertySet`], then pre-validating it locally.
+/// [`PropertySet`]. Configuration validation happens daemon-side (via
+/// `ConfigBuilder::from_property_set`); this only parses and merges the inputs.
 fn build_connect_request(args: ConnectArgs) -> anyhow::Result<Request> {
     let mut properties = PropertySet::new();
 

--- a/crates/ironrdp-agent/src/cli.rs
+++ b/crates/ironrdp-agent/src/cli.rs
@@ -1,0 +1,392 @@
+//! The short-lived CLI: parse arguments, build a request (merging a `.rdp` file with overrides for
+//! `connect`), send it to the daemon, and print the response.
+//!
+//! The CLI operates purely at the [`PropertySet`] level for connection config — it never calls
+//! typed `ConfigBuilder` setters.
+
+#![allow(clippy::print_stdout, clippy::print_stderr)]
+
+use std::path::PathBuf;
+
+use anyhow::Context as _;
+use clap::{Args, CommandFactory as _, Parser, Subcommand, ValueEnum};
+use ironrdp_client::config::{ConfigBuilder, MissingField};
+use ironrdp_input::MouseButton;
+use ironrdp_propertyset::PropertySet;
+
+use crate::ipc::{KeyFilter, Payload, PropValue, Request, Response};
+use crate::transport::{self, Endpoint};
+
+/// IronRDP agent: a CLI-driven, daemon-backed RDP client.
+#[derive(Parser, Debug)]
+#[command(name = "ironrdp-agent", version, about, long_about = None)]
+pub struct Cli {
+    /// Print a structured, LLM-friendly guide to every operation and exit.
+    #[arg(long, global = true)]
+    help_agent: bool,
+
+    /// Override the IPC endpoint (defaults to the per-user socket/pipe).
+    #[arg(long, global = true)]
+    endpoint: Option<String>,
+
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Run the long-lived daemon in the foreground (owns the RDP session).
+    DaemonStart(DaemonArgs),
+    /// Open an RDP session from a .rdp file and/or CLI overrides.
+    Connect(ConnectArgs),
+    /// Tear down the current RDP session (the daemon keeps running).
+    Disconnect,
+    /// Report the current session status.
+    Status,
+    /// Query the live session properties.
+    QueryProps(QueryPropsArgs),
+    /// Print retained daemon log lines.
+    QueryLogs(QueryLogsArgs),
+    /// Print the most recent frame dimensions.
+    Screenshot,
+    /// Move the mouse pointer to an absolute position.
+    MouseMove {
+        #[arg(long)]
+        x: u16,
+        #[arg(long)]
+        y: u16,
+    },
+    /// Press or release a mouse button.
+    MouseButton {
+        #[arg(long, value_enum)]
+        button: CliMouseButton,
+        #[arg(long, action = clap::ArgAction::Set)]
+        pressed: bool,
+    },
+    /// Rotate the mouse wheel (negative delta scrolls down/left).
+    Wheel {
+        #[arg(long, allow_hyphen_values = true)]
+        delta: i16,
+        #[arg(long)]
+        horizontal: bool,
+    },
+    /// Press or release a key identified by its RDP scancode.
+    KeyScancode {
+        #[arg(long, value_parser = parse_scancode)]
+        scancode: u16,
+        #[arg(long, action = clap::ArgAction::Set)]
+        pressed: bool,
+    },
+    /// Press or release a key identified by a Unicode character.
+    KeyUnicode {
+        #[arg(long = "char")]
+        character: char,
+        #[arg(long, action = clap::ArgAction::Set)]
+        pressed: bool,
+    },
+}
+
+#[derive(Args, Debug)]
+struct DaemonArgs {
+    /// Path to a .rdp file whose properties are preloaded as an overlay applied to every `connect`
+    /// (overlay wins). Use this to provision any setting out of band — credentials in particular
+    /// (e.g. `ClearTextPassword`), so a caller never needs to supply them; `status` then reports
+    /// `credentials loaded: true`.
+    #[arg(long)]
+    overlay: Option<PathBuf>,
+}
+
+#[derive(Args, Debug)]
+struct ConnectArgs {
+    /// Path to a .rdp file to read the base configuration from.
+    #[arg(long)]
+    rdp_file: Option<PathBuf>,
+    /// RDP server address (host[:port]). Overrides the .rdp file.
+    #[arg(long)]
+    server: Option<String>,
+    /// RDP account user name. Overrides the .rdp file.
+    #[arg(short, long)]
+    username: Option<String>,
+    /// RDP account password. Overrides the .rdp file.
+    #[arg(short, long)]
+    password: Option<String>,
+    /// RDP account domain. Overrides the .rdp file.
+    #[arg(short, long)]
+    domain: Option<String>,
+    /// Tracing filter directive applied to this session's log capture (e.g.
+    /// `ironrdp_connector=trace`), layered on top of the default `debug` level. Use it to raise
+    /// verbosity up-front when troubleshooting a connection.
+    #[arg(long)]
+    log_directive: Option<String>,
+}
+
+#[derive(Args, Debug)]
+struct QueryPropsArgs {
+    /// Only show keys containing this substring (case-insensitive).
+    #[arg(long, conflicts_with = "prefix")]
+    filter: Option<String>,
+    /// Only show keys starting with this prefix (case-insensitive).
+    #[arg(long)]
+    prefix: Option<String>,
+}
+
+#[derive(Args, Debug)]
+struct QueryLogsArgs {
+    /// Only show lines containing this substring.
+    #[arg(long)]
+    substring: Option<String>,
+    /// Only show the last N retained lines.
+    #[arg(long)]
+    last: Option<u32>,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum CliMouseButton {
+    Left,
+    Middle,
+    Right,
+    X1,
+    X2,
+}
+
+impl CliMouseButton {
+    fn into_button(self) -> MouseButton {
+        match self {
+            Self::Left => MouseButton::Left,
+            Self::Middle => MouseButton::Middle,
+            Self::Right => MouseButton::Right,
+            Self::X1 => MouseButton::X1,
+            Self::X2 => MouseButton::X2,
+        }
+    }
+}
+
+/// Parses an RDP scancode in decimal or `0x`-prefixed hexadecimal.
+fn parse_scancode(input: &str) -> Result<u16, core::num::ParseIntError> {
+    if let Some(hex) = input.strip_prefix("0x").or_else(|| input.strip_prefix("0X")) {
+        u16::from_str_radix(hex, 16)
+    } else {
+        input.parse()
+    }
+}
+
+/// Entry point shared by the binary: dispatches the parsed [`Cli`].
+pub async fn run(cli: Cli) -> anyhow::Result<()> {
+    if cli.help_agent {
+        print!("{}", crate::help::AGENT_GUIDE);
+        return Ok(());
+    }
+
+    let endpoint = endpoint_from_arg(cli.endpoint);
+
+    let Some(command) = cli.command else {
+        let _ = Cli::command().print_help();
+        println!();
+        return Ok(());
+    };
+
+    let request = match command {
+        Command::DaemonStart(args) => {
+            let overlay = load_overlay(args.overlay.as_deref())?;
+            return crate::daemon::run(endpoint, overlay).await;
+        }
+        Command::Connect(args) => build_connect_request(args)?,
+        Command::Disconnect => Request::Disconnect,
+        Command::Status => Request::Status,
+        Command::QueryProps(args) => Request::QueryProps {
+            filter: args
+                .filter
+                .map(KeyFilter::Substring)
+                .or_else(|| args.prefix.map(KeyFilter::Prefix)),
+        },
+        Command::QueryLogs(args) => Request::QueryLogs {
+            substring: args.substring,
+            last: args.last,
+        },
+        Command::Screenshot => Request::Screenshot,
+        Command::MouseMove { x, y } => Request::MouseMove { x, y },
+        Command::MouseButton { button, pressed } => Request::MouseButton {
+            button: button.into_button(),
+            pressed,
+        },
+        Command::Wheel { delta, horizontal } => Request::Wheel { delta, horizontal },
+        Command::KeyScancode { scancode, pressed } => Request::KeyScancode { scancode, pressed },
+        Command::KeyUnicode { character, pressed } => Request::KeyUnicode { ch: character, pressed },
+    };
+
+    let response = transport::send_request(&endpoint, &request).await?;
+    print_response(response)
+}
+
+/// Loads an operator-provided overlay [`PropertySet`] from an optional `.rdp` file. Returns an
+/// empty set when no path is given.
+fn load_overlay(path: Option<&std::path::Path>) -> anyhow::Result<PropertySet> {
+    let mut properties = PropertySet::new();
+    if let Some(path) = path {
+        let text = std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+        if let Err(errors) = ironrdp_rdpfile::load(&mut properties, &text) {
+            for error in &errors {
+                eprintln!("warning: skipped entry in {}: {error}", path.display());
+            }
+        }
+    }
+    Ok(properties)
+}
+
+/// Builds a `Connect` request by merging an optional `.rdp` file with CLI overrides into one
+/// [`PropertySet`], then pre-validating it locally.
+fn build_connect_request(args: ConnectArgs) -> anyhow::Result<Request> {
+    let mut properties = PropertySet::new();
+
+    if let Some(path) = &args.rdp_file {
+        let text = std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+        if let Err(errors) = ironrdp_rdpfile::load(&mut properties, &text) {
+            for error in &errors {
+                eprintln!("warning: skipped entry in {}: {error}", path.display());
+            }
+        }
+    }
+
+    // CLI overrides win: plain inserts with canonical .rdp keys.
+    if let Some(server) = args.server {
+        properties.set_full_address(server);
+    }
+    if let Some(username) = args.username {
+        properties.set_username("username", username);
+    }
+    if let Some(password) = args.password {
+        properties.set_clear_text_password(password);
+    }
+    if let Some(domain) = args.domain {
+        properties.set_domain(domain);
+    }
+
+    Ok(Request::Connect {
+        properties,
+        log_directive: args.log_directive,
+    })
+}
+
+fn print_response(response: Response) -> anyhow::Result<()> {
+    match response {
+        Response::Ok(payload) => {
+            print_payload(payload);
+            Ok(())
+        }
+        Response::Err(message) => anyhow::bail!("{message}"),
+    }
+}
+
+fn print_payload(payload: Payload) {
+    match payload {
+        Payload::Empty => println!("ok"),
+        Payload::Status(status) => {
+            println!("state: {:?}", status.state);
+            if let Some(destination) = status.destination {
+                println!("destination: {destination}");
+            }
+            if let (Some(width), Some(height)) = (status.width, status.height) {
+                println!("resolution: {width}x{height}");
+            }
+            if let Some(message) = status.message {
+                println!("detail: {message}");
+            }
+            println!("credentials loaded: {}", status.credentials_loaded);
+        }
+        Payload::Properties(dump) => {
+            for entry in dump.entries {
+                let value = match entry.value {
+                    PropValue::Int(value) => value.to_string(),
+                    PropValue::Str(value) => value,
+                };
+                // Descriptions are derived locally from the key: they are a static function of the
+                // property name, so there is no reason to carry them over the wire.
+                match property_description(&entry.key) {
+                    Some(description) => println!("{} = {value}  # {description}", entry.key),
+                    None => println!("{} = {value}", entry.key),
+                }
+            }
+        }
+        Payload::Logs(lines) => {
+            for line in lines {
+                println!("{line}");
+            }
+        }
+        Payload::Screenshot { width, height } => println!("frame {width}x{height}"),
+    }
+}
+
+#[cfg(unix)]
+fn endpoint_from_arg(arg: Option<String>) -> Endpoint {
+    match arg {
+        Some(value) => Endpoint(PathBuf::from(value)),
+        None => transport::default_endpoint(),
+    }
+}
+
+#[cfg(windows)]
+fn endpoint_from_arg(arg: Option<String>) -> Endpoint {
+    match arg {
+        Some(value) => Endpoint(value),
+        None => transport::default_endpoint(),
+    }
+}
+
+/// Short, LLM-facing descriptions for the configuration keys recognized by [`ironrdp_cfg`], derived
+/// locally from the key name when printing a dump (kept out of the wire protocol on purpose).
+///
+/// Keys are the canonical lowercase `.rdp` names. Secret keys are listed for completeness even
+/// though `ConfigBuilder::build` strips them before a session starts, so they never appear in a
+/// dump.
+fn property_description(key: &str) -> Option<&'static str> {
+    let description = match key {
+        // ── Standard .rdp keys ──────────────────────────────────────────────
+        "full address" => "RDP server address as host[:port]",
+        "alternate full address" => "fallback RDP server address (host[:port]) tried if 'full address' fails",
+        "server port" => "RDP server TCP port (default 3389)",
+        "username" => "RDP account user name",
+        "domain" => "RDP account domain",
+        "cleartextpassword" => "plaintext RDP account password (secret)",
+        "desktopwidth" => "requested remote desktop width in pixels",
+        "desktopheight" => "requested remote desktop height in pixels",
+        "desktopscalefactor" => "remote desktop DPI scale factor, in percent (e.g. 100, 150)",
+        "compression" => "enable bulk data compression (0/1)",
+        "audiomode" => "remote audio mode (0 = play on client, 1 = play on server, 2 = disabled)",
+        "redirectclipboard" => "enable clipboard redirection (0/1)",
+        "enablecredsspsupport" => "enable CredSSP/NLA authentication (0/1)",
+        "alternate shell" => "program to launch on connect instead of the desktop shell",
+        "shell working directory" => "working directory for the alternate shell or RemoteApp program",
+        "remoteapplicationname" => "RemoteApp display name",
+        "remoteapplicationprogram" => "RemoteApp program path to launch",
+        // ── RD gateway ──────────────────────────────────────────────────────
+        "gatewayhostname" => "RD gateway host name",
+        "gatewayusername" => "RD gateway user name",
+        "gatewaypassword" => "RD gateway password (secret)",
+        "gatewayusagemethod" => {
+            "when to use the RD gateway (0 = direct, 1 = always, 2 = detect, 3 = default, 4 = direct, bypass for local)"
+        }
+        "gatewaycredentialssource" => {
+            "RD gateway credential source (0 = server, 1 = user, 2 = profile, 3 = prompt, 4 = smart card, 5 = logon)"
+        }
+        // ── Kerberos ────────────────────────────────────────────────────────
+        "kdcproxyname" => "Kerberos KDC proxy name",
+        "kdcproxyurl" => "Kerberos KDC proxy URL",
+        // ── IronRDP extensions (ironrdp_ prefix) ────────────────────────────
+        "ironrdp_autologon" => "attempt automatic logon with the supplied credentials (0/1)",
+        "ironrdp_colordepth" => "color depth in bits per pixel (e.g. 16 or 32)",
+        "ironrdp_compressionlevel" => "bulk compression level",
+        "ironrdp_dvcpipeproxy" => "DVC pipe proxy specs, comma-separated 'channel=pipe' pairs",
+        "ironrdp_dvcplugin" => "DVC plugin library paths, comma-separated",
+        "ironrdp_qoi" => "enable the QOI graphics codec (0/1)",
+        "ironrdp_qoiz" => "enable the QOIZ (compressed QOI) graphics codec (0/1)",
+        "ironrdp_rdpdr" => "enable the RDPDR device-redirection channel (0/1)",
+        "ironrdp_smartcard" => "enable smart-card device redirection (0/1)",
+        "ironrdp_tls" => "use plain TLS security instead of CredSSP/Hybrid (0/1)",
+        "ironrdp_fakeeventsinterval" => "interval in minutes between synthetic keep-alive input events",
+        "ironrdp_rdcleanpathtoken" => "RDCleanPath authentication token (secret)",
+        "ironrdp_rdcleanpathurl" => "RDCleanPath proxy URL",
+        "ironrdp_serverpointer" => "render the server-side pointer instead of a client-drawn pointer (0/1)",
+        _ => return None,
+    };
+    Some(description)
+}

--- a/crates/ironrdp-agent/src/cli.rs
+++ b/crates/ironrdp-agent/src/cli.rs
@@ -6,11 +6,11 @@
 
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::Context as _;
 use clap::{Args, CommandFactory as _, Parser, Subcommand, ValueEnum};
-use ironrdp_client::config::{ConfigBuilder, MissingField};
+use ironrdp_cfg::{PropertySetExt as _, TargetAddr};
 use ironrdp_input::MouseButton;
 use ironrdp_propertyset::PropertySet;
 
@@ -47,8 +47,8 @@ enum Command {
     QueryProps(QueryPropsArgs),
     /// Print retained daemon log lines.
     QueryLogs(QueryLogsArgs),
-    /// Print the most recent frame dimensions.
-    Screenshot,
+    /// Capture the current frame (cursor included) as a PNG written to disk.
+    Screenshot(ScreenshotArgs),
     /// Move the mouse pointer to an absolute position.
     MouseMove {
         #[arg(long)]
@@ -140,6 +140,12 @@ struct QueryLogsArgs {
     last: Option<u32>,
 }
 
+#[derive(Args, Debug)]
+struct ScreenshotArgs {
+    /// Destination PNG path (defaults to `screenshot.png` in the current directory).
+    path: Option<PathBuf>,
+}
+
 #[derive(Clone, Copy, Debug, ValueEnum)]
 enum CliMouseButton {
     Left,
@@ -203,7 +209,18 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
             substring: args.substring,
             last: args.last,
         },
-        Command::Screenshot => Request::Screenshot,
+        Command::Screenshot(args) => {
+            let response = transport::send_request(&endpoint, &Request::Screenshot).await?;
+            let payload = match response {
+                Response::Ok(payload) => payload,
+                Response::Err(message) => anyhow::bail!("{message}"),
+            };
+            let Payload::Screenshot { width, height, png } = payload else {
+                anyhow::bail!("unexpected response to screenshot request");
+            };
+            let path = args.path.unwrap_or_else(|| PathBuf::from("screenshot.png"));
+            return write_screenshot(width, height, &png, &path);
+        }
         Command::MouseMove { x, y } => Request::MouseMove { x, y },
         Command::MouseButton { button, pressed } => Request::MouseButton {
             button: button.into_button(),
@@ -220,7 +237,7 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
 
 /// Loads an operator-provided overlay [`PropertySet`] from an optional `.rdp` file. Returns an
 /// empty set when no path is given.
-fn load_overlay(path: Option<&std::path::Path>) -> anyhow::Result<PropertySet> {
+fn load_overlay(path: Option<&Path>) -> anyhow::Result<PropertySet> {
     let mut properties = PropertySet::new();
     if let Some(path) = path {
         let text = std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
@@ -247,12 +264,15 @@ fn build_connect_request(args: ConnectArgs) -> anyhow::Result<Request> {
         }
     }
 
-    // CLI overrides win: plain inserts with canonical .rdp keys.
+    // CLI overrides win.
     if let Some(server) = args.server {
-        properties.set_full_address(server);
+        let address: TargetAddr = server
+            .parse()
+            .with_context(|| format!("invalid server address: {server}"))?;
+        properties.set_full_address(&address);
     }
     if let Some(username) = args.username {
-        properties.set_username("username", username);
+        properties.set_username(username);
     }
     if let Some(password) = args.password {
         properties.set_clear_text_password(password);
@@ -312,8 +332,16 @@ fn print_payload(payload: Payload) {
                 println!("{line}");
             }
         }
-        Payload::Screenshot { width, height } => println!("frame {width}x{height}"),
+        // Screenshots are handled out-of-band by `write_screenshot`, never printed.
+        Payload::Screenshot { width, height, .. } => println!("frame {width}x{height}"),
     }
+}
+
+/// Writes screenshot PNG bytes to disk, defaulting to `screenshot.png`.
+fn write_screenshot(width: u16, height: u16, png: &[u8], path: &Path) -> anyhow::Result<()> {
+    std::fs::write(path, png).with_context(|| format!("write {}", path.display()))?;
+    println!("wrote {} ({width}x{height}, {} bytes)", path.display(), png.len());
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -339,7 +367,9 @@ fn endpoint_from_arg(arg: Option<String>) -> Endpoint {
 /// though `ConfigBuilder::build` strips them before a session starts, so they never appear in a
 /// dump.
 fn property_description(key: &str) -> Option<&'static str> {
-    let description = match key {
+    // PropertySet keys are case-sensitive and ironrdp-cfg mixes casings (e.g. `ClearTextPassword`),
+    // so normalize to lowercase to match the canonical lowercase arms below.
+    let description = match key.to_ascii_lowercase().as_str() {
         // ── Standard .rdp keys ──────────────────────────────────────────────
         "full address" => "RDP server address as host[:port]",
         "alternate full address" => "fallback RDP server address (host[:port]) tried if 'full address' fails",

--- a/crates/ironrdp-agent/src/daemon.rs
+++ b/crates/ironrdp-agent/src/daemon.rs
@@ -182,7 +182,10 @@ impl Daemon {
             let guard = self.state.lock().expect("daemon state poisoned");
             if let Some(session) = guard.as_ref() {
                 let state = session.live.lock().expect("session live state poisoned").state;
-                if matches!(state, ConnState::Connecting | ConnState::Connected) {
+                if matches!(
+                    state,
+                    ConnState::Connecting | ConnState::Connected | ConnState::Disconnecting
+                ) {
                     debug!("Refusing connect: a session is already active");
                     return Response::error("a session is already active; disconnect first");
                 }
@@ -284,11 +287,21 @@ impl Daemon {
                 Response::error("no active session")
             }
             Some(session) => {
-                info!(destination = %session.destination, "Disconnecting RDP session");
-                // Request a graceful shutdown; ignore send errors (the session may already be gone).
-                let _ = session.input_tx.send(RdpInputEvent::Close);
-                session.live.lock().expect("session live state poisoned").state = ConnState::Disconnected;
-                Response::ok()
+                let mut live = session.live.lock().expect("session live state poisoned");
+                match live.state {
+                    ConnState::Connecting | ConnState::Connected => {
+                        info!(destination = %session.destination, "Disconnecting RDP session");
+                        // Request a graceful shutdown and move to `Disconnecting`. The engine thread
+                        // keeps running until it drains the close; `consume_output` flips the state
+                        // to a terminal one once it does, which is what re-enables `connect`. Leaving
+                        // it `Connected` here would let a new `connect` race the still-live thread.
+                        let _ = session.input_tx.send(RdpInputEvent::Close);
+                        live.state = ConnState::Disconnecting;
+                        Response::ok()
+                    }
+                    // Already shutting down or terminated: nothing to do (idempotent).
+                    _ => Response::ok(),
+                }
             }
         }
     }
@@ -444,6 +457,16 @@ async fn consume_output(mut output_rx: mpsc::Receiver<RdpOutputEvent>, live: Arc
             // above; the remaining pointer events (default/hidden) carry no live state we track.
             _ => {}
         }
+    }
+
+    // The engine thread has ended (channel closed). Resolve any transient state so a subsequent
+    // `connect` is not blocked indefinitely, even if no explicit `Terminated` event was emitted.
+    let mut guard = live.lock().expect("session live state poisoned");
+    if matches!(
+        guard.state,
+        ConnState::Connecting | ConnState::Connected | ConnState::Disconnecting
+    ) {
+        guard.state = ConnState::Disconnected;
     }
 }
 

--- a/crates/ironrdp-agent/src/daemon.rs
+++ b/crates/ironrdp-agent/src/daemon.rs
@@ -1,0 +1,461 @@
+//! The long-lived daemon: owns the [`RdpClient`] engine and one RDP session, and serves IPC
+//! requests until shut down.
+//!
+//! One daemon serves one RDP session (multi-session is out of scope for V1). It is started
+//! explicitly with `daemon-start` and runs in the foreground; the caller is expected to background
+//! it. On a clean shutdown the Unix socket file is removed (see [`crate::transport`]).
+
+use std::sync::{Arc, Mutex};
+
+use anyhow::Context as _;
+use ironrdp_client::config::{ConfigBuilder, MissingField};
+use ironrdp_client::rdp::{RdpClient, RdpInputEvent, RdpOutputEvent};
+use ironrdp_input::{Database, MousePosition, Operation, Scancode, WheelRotations};
+use ironrdp_pdu::rdp::capability_sets::MajorPlatformType;
+use ironrdp_propertyset::{PropertySet, Value};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::sync::mpsc;
+use tracing::{debug, error, info, trace, warn};
+
+use crate::ipc::{
+    ConnState, KeyFilter, Payload, PropValue, PropertyDump, PropertyEntry, Request, Response, StatusInfo,
+};
+use crate::logbuf::{self, LogBuffer};
+use crate::transport::{Endpoint, Listener, read_message, write_message};
+
+/// Binds the IPC endpoint and serves requests until a shutdown signal is received.
+///
+/// `overlay` is an operator-provided [`PropertySet`] layered on top of every `Connect` request
+/// (overlay wins), so any setting — credentials in particular — can be preconfigured without the
+/// caller ever supplying it. Pass an empty set when no overlay is desired.
+pub async fn run(endpoint: Endpoint, overlay: PropertySet) -> anyhow::Result<()> {
+    // On Unix a leftover socket file would make `bind` fail; clear it if no daemon is alive.
+    #[cfg(unix)]
+    if endpoint.0.exists() {
+        if crate::transport::connect(&endpoint).await.is_ok() {
+            anyhow::bail!("a daemon already appears to be running at {endpoint}");
+        }
+        let _ = std::fs::remove_file(&endpoint.0);
+    }
+
+    init_daemon_logging();
+    let logs = LogBuffer::new();
+
+    let listener = Listener::bind(&endpoint).with_context(|| format!("bind IPC endpoint {endpoint}"))?;
+    let daemon = Daemon::new(logs, overlay);
+
+    info!(%endpoint, "Daemon listening");
+
+    loop {
+        tokio::select! {
+            result = listener.accept() => {
+                let stream = result.context("accept IPC connection")?;
+                if let Err(error) = handle_connection(stream, &daemon).await {
+                    debug!(error = format!("{error:#}"), "IPC connection error");
+                }
+            }
+            _ = tokio::signal::ctrl_c() => {
+                info!("Received shutdown signal, stopping");
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn handle_connection<S>(mut stream: S, daemon: &Daemon) -> anyhow::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let request: Request = read_message(&mut stream).await?;
+    trace!(?request, "Handling IPC request");
+    let response = daemon.handle(request);
+    trace!(ok = response.is_ok(), "Replying to IPC request");
+    write_message(&mut stream, &response).await?;
+    Ok(())
+}
+
+/// The daemon's mutable state: the (single) current session, plus the shared log buffer.
+struct Daemon {
+    state: Mutex<Option<Session>>,
+    logs: Arc<LogBuffer>,
+    /// Operator-provided overlay layered on top of every `Connect` (overlay wins). Holds any
+    /// preconfigured settings, credentials in particular.
+    overlay: PropertySet,
+    /// Whether [`Self::overlay`] contributes any secret (password/token) value, i.e. whether the
+    /// caller can omit credentials of its own.
+    credentials_loaded: bool,
+}
+
+/// Per-session state owned by the request handler.
+struct Session {
+    input_tx: mpsc::UnboundedSender<RdpInputEvent>,
+    input_db: Database,
+    destination: String,
+    live: Arc<Mutex<Live>>,
+}
+
+/// Per-session state shared with the output-consumer task.
+struct Live {
+    /// Live property bag, seeded from `Config::properties` and updated on (re)negotiation.
+    properties: PropertySet,
+    state: ConnState,
+    error: Option<String>,
+    /// Most recent frame dimensions (the raw framebuffer is intentionally dropped for V1).
+    frame_size: Option<(u16, u16)>,
+}
+
+impl Daemon {
+    fn new(logs: Arc<LogBuffer>, overlay: PropertySet) -> Self {
+        // Credentials are considered "loaded" when the overlay provides at least one secret value,
+        // which is what frees the caller from supplying a password.
+        let credentials_loaded = overlay.iter().any(|(key, _)| ironrdp_cfg::is_secret_key(key));
+        Self {
+            state: Mutex::new(None),
+            logs,
+            overlay,
+            credentials_loaded,
+        }
+    }
+
+    fn handle(&self, request: Request) -> Response {
+        match request {
+            Request::Connect {
+                properties,
+                log_directive,
+            } => self.connect(properties, log_directive),
+            Request::Disconnect => self.disconnect(),
+            Request::Status => self.status(),
+            Request::QueryProps { filter } => self.query_props(filter.as_ref()),
+            Request::QueryLogs { substring, last } => self.query_logs(substring.as_deref(), last),
+            Request::Screenshot => self.screenshot(),
+            Request::MouseMove { x, y } => self.input(Operation::MouseMove(MousePosition { x, y })),
+            Request::MouseButton { button, pressed } => self.input(if pressed {
+                Operation::MouseButtonPressed(button)
+            } else {
+                Operation::MouseButtonReleased(button)
+            }),
+            Request::Wheel { delta, horizontal } => self.input(Operation::WheelRotations(WheelRotations {
+                is_vertical: !horizontal,
+                rotation_units: delta,
+            })),
+            Request::KeyScancode { scancode, pressed } => {
+                let scancode = Scancode::from_u16(scancode);
+                self.input(if pressed {
+                    Operation::KeyPressed(scancode)
+                } else {
+                    Operation::KeyReleased(scancode)
+                })
+            }
+            Request::KeyUnicode { ch, pressed } => self.input(if pressed {
+                Operation::UnicodeKeyPressed(ch)
+            } else {
+                Operation::UnicodeKeyReleased(ch)
+            }),
+        }
+    }
+
+    fn connect(&self, mut properties: PropertySet, log_directive: Option<String>) -> Response {
+        debug!(?log_directive, "Received connect request");
+        // Refuse to clobber a live session: the previous RDP engine runs on its own thread and is
+        // not torn down by simply replacing the session slot. Require an explicit `disconnect` first.
+        {
+            let guard = self.state.lock().expect("daemon state poisoned");
+            if let Some(session) = guard.as_ref() {
+                let state = session.live.lock().expect("session live state poisoned").state;
+                if matches!(state, ConnState::Connecting | ConnState::Connected) {
+                    debug!("Refusing connect: a session is already active");
+                    return Response::error("a session is already active; disconnect first");
+                }
+            }
+        }
+
+        // Layer the operator-provided overlay on top (overlay wins), so any setting — credentials
+        // in particular — can be preconfigured without the (possibly untrusted) caller supplying it.
+        properties.merge(&self.overlay);
+
+        let builder = match ConfigBuilder::from_property_set(&properties) {
+            Ok(builder) => builder,
+            Err(error) => return Response::error(format!("invalid configuration: {error:#}")),
+        };
+
+        // Derive the headless client identity. These fields are never representable as `.rdp`
+        // properties and are never prompted; the daemon supplies them itself.
+        let builder = builder
+            .with_client_build(client_build())
+            .with_client_dir("C:\\Windows\\System32\\mstscax.dll")
+            .with_platform(current_platform())
+            .with_client_name(client_name());
+
+        let missing = builder.missing();
+        if !missing.is_empty() {
+            return Response::error(format!(
+                "missing required fields: {}",
+                missing
+                    .iter()
+                    .map(MissingField::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+
+        let config = match builder.build() {
+            Ok(config) => config,
+            Err(error) => return Response::error(format!("{error:#}")),
+        };
+
+        // `ConfigBuilder::build` strips every secret property, so the live bag carries no secrets.
+        let live_seed = config.properties().clone();
+        let destination = config.destination().to_string();
+
+        let (output_tx, output_rx) = mpsc::channel(16);
+        let client = RdpClient::new(config, output_tx);
+        let input_tx = client.input_sender();
+
+        let live = Arc::new(Mutex::new(Live {
+            properties: live_seed,
+            state: ConnState::Connecting,
+            error: None,
+            frame_size: None,
+        }));
+
+        // Capture this session's logs into the ring buffer (queryable via `Request::QueryLogs`)
+        // instead of the daemon's terminal, refined by the caller-supplied directive. The dispatch
+        // is installed as the session thread's thread-local default below.
+        let dispatch = logbuf::session_dispatch(Arc::clone(&self.logs), log_directive.as_deref());
+
+        // The RDP client engine runs on its own thread with a current-thread runtime, mirroring
+        // `ironrdp-viewer`. This sidesteps any `Send` requirement on the connection future.
+        let spawn_result = std::thread::Builder::new()
+            .name("ironrdp-agent-session".to_owned())
+            .spawn(move || {
+                tracing::dispatcher::with_default(&dispatch, || {
+                    match tokio::runtime::Builder::new_current_thread().enable_all().build() {
+                        Ok(runtime) => runtime.block_on(client.run()),
+                        Err(error) => error!(%error, "Failed to build the session runtime"),
+                    }
+                });
+            });
+        if let Err(error) = spawn_result {
+            return Response::error(format!("failed to spawn session thread: {error}"));
+        }
+
+        tokio::spawn(consume_output(output_rx, Arc::clone(&live)));
+
+        info!(%destination, "Started RDP session");
+
+        *self.state.lock().expect("daemon state poisoned") = Some(Session {
+            input_tx,
+            input_db: Database::new(),
+            destination,
+            live,
+        });
+
+        Response::ok()
+    }
+
+    fn disconnect(&self) -> Response {
+        let mut guard = self.state.lock().expect("daemon state poisoned");
+        match guard.as_mut() {
+            None => {
+                debug!("Disconnect requested but no session is active");
+                Response::error("no active session")
+            }
+            Some(session) => {
+                info!(destination = %session.destination, "Disconnecting RDP session");
+                // Request a graceful shutdown; ignore send errors (the session may already be gone).
+                let _ = session.input_tx.send(RdpInputEvent::Close);
+                session.live.lock().expect("session live state poisoned").state = ConnState::Disconnected;
+                Response::ok()
+            }
+        }
+    }
+
+    fn status(&self) -> Response {
+        let guard = self.state.lock().expect("daemon state poisoned");
+        let info = match guard.as_ref() {
+            None => StatusInfo {
+                state: ConnState::NoSession,
+                destination: None,
+                width: None,
+                height: None,
+                message: None,
+                credentials_loaded: self.credentials_loaded,
+            },
+            Some(session) => {
+                let live = session.live.lock().expect("session live state poisoned");
+                let (width, height) = match live.frame_size {
+                    Some((width, height)) => (Some(width), Some(height)),
+                    None => (None, None),
+                };
+                StatusInfo {
+                    state: live.state,
+                    destination: Some(session.destination.clone()),
+                    width,
+                    height,
+                    message: live.error.clone(),
+                    credentials_loaded: self.credentials_loaded,
+                }
+            }
+        };
+        Response::Ok(Payload::Status(info))
+    }
+
+    fn query_props(&self, filter: Option<&KeyFilter>) -> Response {
+        let guard = self.state.lock().expect("daemon state poisoned");
+        let Some(session) = guard.as_ref() else {
+            return Response::error("no active session");
+        };
+        let live = session.live.lock().expect("session live state poisoned");
+
+        let mut entries = Vec::new();
+        for (key, value) in live.properties.iter() {
+            let key = key.as_ref();
+            if filter.is_some_and(|filter| !filter.matches(key)) {
+                continue;
+            }
+            let value = match value {
+                Value::Int(value) => PropValue::Int(*value),
+                Value::Str(value) => PropValue::Str(value.clone()),
+            };
+            entries.push(PropertyEntry {
+                key: key.to_owned(),
+                value,
+            });
+        }
+
+        Response::Ok(Payload::Properties(PropertyDump { entries }))
+    }
+
+    fn query_logs(&self, substring: Option<&str>, last: Option<u32>) -> Response {
+        let mut lines = self.logs.query(substring);
+        if let Some(last) = last {
+            let last = usize::try_from(last).unwrap_or(usize::MAX);
+            if last < lines.len() {
+                lines.drain(0..lines.len() - last);
+            }
+        }
+        Response::Ok(Payload::Logs(lines))
+    }
+
+    fn screenshot(&self) -> Response {
+        let guard = self.state.lock().expect("daemon state poisoned");
+        let Some(session) = guard.as_ref() else {
+            return Response::error("no active session");
+        };
+        let live = session.live.lock().expect("session live state poisoned");
+        match live.frame_size {
+            Some((width, height)) => Response::Ok(Payload::Screenshot { width, height }),
+            None => Response::error("no frame available yet"),
+        }
+    }
+
+    fn input(&self, operation: Operation) -> Response {
+        let mut guard = self.state.lock().expect("daemon state poisoned");
+        let Some(session) = guard.as_mut() else {
+            return Response::error("no active session");
+        };
+        let events = session.input_db.apply([operation]);
+        if events.is_empty() {
+            return Response::ok();
+        }
+        match session.input_tx.send(RdpInputEvent::FastPath(events)) {
+            Ok(()) => Response::ok(),
+            Err(_) => Response::error("session input channel is closed"),
+        }
+    }
+}
+
+/// Consumes the bounded output-event stream, keeping the live state current.
+async fn consume_output(mut output_rx: mpsc::Receiver<RdpOutputEvent>, live: Arc<Mutex<Live>>) {
+    while let Some(event) = output_rx.recv().await {
+        let mut guard = live.lock().expect("session live state poisoned");
+        let previous = guard.state;
+        match event {
+            RdpOutputEvent::Image { width, height, .. } => {
+                let width = width.get();
+                let height = height.get();
+                guard.properties.insert("desktopwidth", width);
+                guard.properties.insert("desktopheight", height);
+                guard.frame_size = Some((width, height));
+                guard.state = ConnState::Connected;
+                guard.error = None;
+                if previous != ConnState::Connected {
+                    info!(width, height, "Session connected");
+                }
+            }
+            RdpOutputEvent::ConnectionFailure(error) => {
+                guard.state = ConnState::Failed;
+                guard.error = Some(format!("{error}"));
+                error!(%error, "Session connection failed");
+            }
+            RdpOutputEvent::Terminated(Ok(reason)) => {
+                guard.state = ConnState::Disconnected;
+                guard.error = Some(format!("{reason:?}"));
+                info!(?reason, "Session terminated");
+            }
+            RdpOutputEvent::Terminated(Err(error)) => {
+                guard.state = ConnState::Failed;
+                guard.error = Some(format!("{error}"));
+                warn!(%error, "Session terminated with an error");
+            }
+            // Pointer events carry no live state we track for V1.
+            _ => {}
+        }
+    }
+}
+
+/// Installs the daemon's global tracing subscriber: a compact formatter to stderr, defaulting to
+/// `INFO` and tunable via `IRONRDP_LOG`.
+///
+/// This is the daemon's *own* operational logging (IPC handling, lifecycle), mirroring
+/// `ironrdp-viewer` but quieter by default. The RDP session's logs are captured separately into a
+/// ring buffer (see [`logbuf::session_dispatch`]). Best-effort: a no-op if a global subscriber is
+/// already set.
+fn init_daemon_logging() {
+    use tracing::level_filters::LevelFilter;
+    use tracing_subscriber::EnvFilter;
+    use tracing_subscriber::prelude::*;
+
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::INFO.into())
+        .with_env_var("IRONRDP_LOG")
+        .from_env_lossy();
+
+    let fmt_layer = tracing_subscriber::fmt::layer().compact().with_writer(std::io::stderr);
+
+    let _ = tracing_subscriber::registry()
+        .with(env_filter)
+        .with(fmt_layer)
+        .try_init();
+}
+
+/// Derives a build number from the crate version (`major*100 + minor*10 + patch`).
+fn client_build() -> u32 {
+    let mut parts = env!("CARGO_PKG_VERSION")
+        .split('.')
+        .map(|part| part.parse::<u32>().unwrap_or(0));
+    let major = parts.next().unwrap_or(0);
+    let minor = parts.next().unwrap_or(0);
+    let patch = parts.next().unwrap_or(0);
+    major
+        .saturating_mul(100)
+        .saturating_add(minor.saturating_mul(10))
+        .saturating_add(patch)
+}
+
+fn client_name() -> String {
+    whoami::hostname().unwrap_or_else(|_| "ironrdp-agent".to_owned())
+}
+
+fn current_platform() -> MajorPlatformType {
+    match whoami::platform() {
+        whoami::Platform::Windows => MajorPlatformType::WINDOWS,
+        whoami::Platform::Linux => MajorPlatformType::UNIX,
+        whoami::Platform::Mac => MajorPlatformType::MACINTOSH,
+        whoami::Platform::Ios => MajorPlatformType::IOS,
+        whoami::Platform::Android => MajorPlatformType::ANDROID,
+        _ => MajorPlatformType::UNSPECIFIED,
+    }
+}

--- a/crates/ironrdp-agent/src/daemon.rs
+++ b/crates/ironrdp-agent/src/daemon.rs
@@ -35,13 +35,22 @@ pub async fn run(endpoint: Endpoint, overlay: PropertySet) -> anyhow::Result<()>
         if crate::transport::connect(&endpoint).await.is_ok() {
             anyhow::bail!("a daemon already appears to be running at {endpoint}");
         }
-        let _ = std::fs::remove_file(&endpoint.0);
+        // No daemon answered, so the path is a stale socket we can reclaim. Guard against deleting
+        // an unrelated regular file (or following a symlink) when `--endpoint` points elsewhere:
+        // inspect the path itself and only remove genuine sockets.
+        use std::os::unix::fs::FileTypeExt as _;
+        let metadata =
+            std::fs::symlink_metadata(&endpoint.0).with_context(|| format!("stat IPC endpoint {endpoint}"))?;
+        if !metadata.file_type().is_socket() {
+            anyhow::bail!("refusing to remove {endpoint}: path exists and is not a socket");
+        }
+        std::fs::remove_file(&endpoint.0).with_context(|| format!("remove stale socket {endpoint}"))?;
     }
 
     init_daemon_logging();
     let logs = LogBuffer::new();
 
-    let listener = Listener::bind(&endpoint).with_context(|| format!("bind IPC endpoint {endpoint}"))?;
+    let mut listener = Listener::bind(&endpoint).with_context(|| format!("bind IPC endpoint {endpoint}"))?;
     let daemon = Daemon::new(logs, overlay);
 
     info!(%endpoint, "Daemon listening");
@@ -102,8 +111,17 @@ struct Live {
     properties: PropertySet,
     state: ConnState,
     error: Option<String>,
-    /// Most recent frame dimensions (the raw framebuffer is intentionally dropped for V1).
-    frame_size: Option<(u16, u16)>,
+    /// Most recent frame (with the cursor already composited in by the session). Replaced on every
+    /// graphics update; `None` until the first frame arrives.
+    frame: Option<Frame>,
+}
+
+/// A decoded frame retained for screenshots. `pixels` are `0x00RRGGBB` (`to_be_bytes()` yields
+/// `[0, R, G, B]`), row-major, `width * height` entries, with the remote cursor blended in.
+struct Frame {
+    width: u16,
+    height: u16,
+    pixels: Vec<u32>,
 }
 
 impl Daemon {
@@ -186,7 +204,10 @@ impl Daemon {
             .with_client_build(client_build())
             .with_client_dir("C:\\Windows\\System32\\mstscax.dll")
             .with_platform(current_platform())
-            .with_client_name(client_name());
+            .with_client_name(client_name())
+            // Headless: composite the remote cursor into the framebuffer so it appears in
+            // screenshots (there is no separate overlay to draw it).
+            .with_pointer_software_rendering(true);
 
         let missing = builder.missing();
         if !missing.is_empty() {
@@ -217,7 +238,7 @@ impl Daemon {
             properties: live_seed,
             state: ConnState::Connecting,
             error: None,
-            frame_size: None,
+            frame: None,
         }));
 
         // Capture this session's logs into the ring buffer (queryable via `Request::QueryLogs`)
@@ -285,8 +306,8 @@ impl Daemon {
             },
             Some(session) => {
                 let live = session.live.lock().expect("session live state poisoned");
-                let (width, height) = match live.frame_size {
-                    Some((width, height)) => (Some(width), Some(height)),
+                let (width, height) = match &live.frame {
+                    Some(frame) => (Some(frame.width), Some(frame.height)),
                     None => (None, None),
                 };
                 StatusInfo {
@@ -345,9 +366,24 @@ impl Daemon {
             return Response::error("no active session");
         };
         let live = session.live.lock().expect("session live state poisoned");
-        match live.frame_size {
-            Some((width, height)) => Response::Ok(Payload::Screenshot { width, height }),
-            None => Response::error("no frame available yet"),
+        let Some(frame) = live.frame.as_ref() else {
+            return Response::error("no frame available yet");
+        };
+        match encode_png(frame.width, frame.height, &frame.pixels) {
+            Ok(png) => {
+                debug!(
+                    width = frame.width,
+                    height = frame.height,
+                    bytes = png.len(),
+                    "Encoded screenshot"
+                );
+                Response::Ok(Payload::Screenshot {
+                    width: frame.width,
+                    height: frame.height,
+                    png,
+                })
+            }
+            Err(error) => Response::error(format!("failed to encode screenshot: {error:#}")),
         }
     }
 
@@ -373,12 +409,16 @@ async fn consume_output(mut output_rx: mpsc::Receiver<RdpOutputEvent>, live: Arc
         let mut guard = live.lock().expect("session live state poisoned");
         let previous = guard.state;
         match event {
-            RdpOutputEvent::Image { width, height, .. } => {
+            RdpOutputEvent::Image { buffer, width, height } => {
                 let width = width.get();
                 let height = height.get();
                 guard.properties.insert("desktopwidth", width);
                 guard.properties.insert("desktopheight", height);
-                guard.frame_size = Some((width, height));
+                guard.frame = Some(Frame {
+                    width,
+                    height,
+                    pixels: buffer,
+                });
                 guard.state = ConnState::Connected;
                 guard.error = None;
                 if previous != ConnState::Connected {
@@ -400,10 +440,32 @@ async fn consume_output(mut output_rx: mpsc::Receiver<RdpOutputEvent>, live: Arc
                 guard.error = Some(format!("{error}"));
                 warn!(%error, "Session terminated with an error");
             }
-            // Pointer events carry no live state we track for V1.
+            // With software pointer rendering the cursor is composited into the `Image` frames
+            // above; the remaining pointer events (default/hidden) carry no live state we track.
             _ => {}
         }
     }
+}
+
+/// Encodes a retained framebuffer to PNG bytes.
+///
+/// `pixels` are `0x00RRGGBB` (`to_be_bytes()` yields `[0, R, G, B]`); the leading byte is the unused
+/// alpha placeholder, so we emit opaque 8-bit RGB.
+fn encode_png(width: u16, height: u16, pixels: &[u32]) -> anyhow::Result<Vec<u8>> {
+    let mut rgb = Vec::with_capacity(pixels.len() * 3 /* RGB */);
+    for pixel in pixels {
+        let [_, r, g, b] = pixel.to_be_bytes();
+        rgb.extend_from_slice(&[r, g, b]);
+    }
+
+    let mut png = Vec::new();
+    let mut encoder = png::Encoder::new(&mut png, u32::from(width), u32::from(height));
+    encoder.set_color(png::ColorType::Rgb);
+    encoder.set_depth(png::BitDepth::Eight);
+    let mut writer = encoder.write_header().context("write PNG header")?;
+    writer.write_image_data(&rgb).context("write PNG image data")?;
+    writer.finish().context("finish PNG stream")?;
+    Ok(png)
 }
 
 /// Installs the daemon's global tracing subscriber: a compact formatter to stderr, defaulting to

--- a/crates/ironrdp-agent/src/help.rs
+++ b/crates/ironrdp-agent/src/help.rs
@@ -1,0 +1,74 @@
+//! The `--help-agent` guide: a concise, structured, LLM-friendly description of every operation.
+
+/// Structured guide printed by `ironrdp-agent --help-agent`.
+pub(crate) const AGENT_GUIDE: &str = r#"# ironrdp-agent
+
+A CLI-driven, daemon-backed RDP client. One binary plays two roles:
+
+- DAEMON: `ironrdp-agent daemon-start` runs a long-lived foreground process that owns the RDP
+  engine and one RDP session. Background it yourself (e.g. `ironrdp-agent daemon-start &`).
+- CLI: every other subcommand opens the local IPC endpoint, sends one request, prints the
+  response, and exits.
+
+The daemon stays alive across CLI invocations. One daemon serves one RDP session.
+
+## Endpoint
+
+Unix: `$XDG_RUNTIME_DIR/ironrdp-agent-<uid>.sock` (falls back to `/tmp/ironrdp-agent-<uid>.sock`).
+Windows: `\\.\pipe\ironrdp-agent-<user>`.
+Override with `--endpoint <PATH-OR-PIPE>` on any subcommand.
+
+## Lifecycle
+
+- `daemon-start [--overlay FILE]`
+                                 Start the daemon (foreground). Run this first. `--overlay`
+                                 preloads a .rdp file as an overlay applied to every `connect`
+                                 (overlay wins), letting an operator provision any setting out of
+                                 band -- credentials in particular (e.g. the password). Check
+                                 `status` to see whether credentials are already loaded before
+                                 supplying any yourself.
+- `connect [--rdp-file F] [--server H[:PORT]] [-u USER] [-p PASS] [-d DOMAIN] [--log-directive D]`
+                                 Merge an optional .rdp file with CLI overrides into one config and
+                                 open a session. CLI flags win over the .rdp file. The config is
+                                 pre-validated locally before being sent. If `status` reports
+                                 `credentials loaded: true`, omit `-p/--password` (and any other
+                                 preloaded secret) -- the daemon supplies it. `--log-directive`
+                                 refines this session's log capture (e.g. `ironrdp_connector=trace`)
+                                 on top of the default `debug` level; use it to troubleshoot a
+                                 connection, then read the result with `query-logs`.
+- `disconnect`                   Tear down the current session (daemon keeps running).
+- `status`                       Report connection state, destination, last frame size, and whether
+                                 credentials are preloaded (`credentials loaded: true|false`). Query
+                                 this first to decide whether you must supply a password.
+
+## Inspection
+
+- `query-props [--filter SUBSTR] [--prefix PREFIX]`
+                                 Print the live session property bag, one `key = value` per line.
+                                 Secrets are stripped from the configuration before a session
+                                 starts, so the dump never contains passwords or tokens.
+                                 `--filter` matches keys by substring; `--prefix` by prefix
+                                 (both case-insensitive).
+- `query-logs [--substring S] [--last N]`
+                                 Print retained RDP session log lines (a bounded in-memory ring
+                                 buffer, default level `debug`). `--substring` filters to matching
+                                 lines; `--last N` keeps the last N. Raise verbosity for a specific
+                                 session with `connect --log-directive`. This is the session's own
+                                 log; the daemon's operational log goes to stderr (default `info`,
+                                 tune with the `IRONRDP_LOG` env var).
+- `screenshot`                   Print the most recent frame dimensions (`frame WxH`). Errors with
+                                 `no frame available yet` until the first frame arrives.
+
+## Input (require an active session)
+
+- `mouse-move --x X --y Y`                       Move the pointer to an absolute position.
+- `mouse-button --button <left|middle|right|x1|x2> --pressed <true|false>`
+- `wheel --delta N [--horizontal]`               Rotate the wheel (negative N scrolls down/left).
+- `key-scancode --scancode <0x1D|29> --pressed <true|false>`
+- `key-unicode --char C --pressed <true|false>`  Type by Unicode character.
+
+## Errors
+
+Failures print a single lowercase message (no trailing punctuation) and exit non-zero. A failed
+`connect` carries the list of missing required fields.
+"#;

--- a/crates/ironrdp-agent/src/help.rs
+++ b/crates/ironrdp-agent/src/help.rs
@@ -30,7 +30,8 @@ Override with `--endpoint <PATH-OR-PIPE>` on any subcommand.
 - `connect [--rdp-file F] [--server H[:PORT]] [-u USER] [-p PASS] [-d DOMAIN] [--log-directive D]`
                                  Merge an optional .rdp file with CLI overrides into one config and
                                  open a session. CLI flags win over the .rdp file. The config is
-                                 pre-validated locally before being sent. If `status` reports
+                                 validated by the daemon, which replies with an error listing any
+                                 missing or invalid fields. If `status` reports
                                  `credentials loaded: true`, omit `-p/--password` (and any other
                                  preloaded secret) -- the daemon supplies it. `--log-directive`
                                  refines this session's log capture (e.g. `ironrdp_connector=trace`)

--- a/crates/ironrdp-agent/src/help.rs
+++ b/crates/ironrdp-agent/src/help.rs
@@ -56,8 +56,10 @@ Override with `--endpoint <PATH-OR-PIPE>` on any subcommand.
                                  session with `connect --log-directive`. This is the session's own
                                  log; the daemon's operational log goes to stderr (default `info`,
                                  tune with the `IRONRDP_LOG` env var).
-- `screenshot`                   Print the most recent frame dimensions (`frame WxH`). Errors with
-                                 `no frame available yet` until the first frame arrives.
+- `screenshot [PATH]`            Capture the most recent frame (with the mouse cursor composited in)
+                                 as a PNG and write it to PATH (default `screenshot.png`). Prints
+                                 `wrote PATH (WxH, N bytes)`. Errors with `no frame available yet`
+                                 until the first frame arrives.
 
 ## Input (require an active session)
 

--- a/crates/ironrdp-agent/src/ipc.rs
+++ b/crates/ironrdp-agent/src/ipc.rs
@@ -21,8 +21,9 @@ use ironrdp_propertyset::PropertySet;
 
 use crate::wire::propertyset;
 use crate::wire::{
-    opt_string_size, opt_u16_size, read_bool, read_char, read_mouse_button, read_opt_string, read_opt_u16, read_string,
-    string_size, write_bool, write_char, write_mouse_button, write_opt_string, write_opt_u16, write_string,
+    bytes_size, opt_string_size, opt_u16_size, read_bool, read_bytes, read_char, read_mouse_button, read_opt_string,
+    read_opt_u16, read_string, string_size, write_bool, write_bytes, write_char, write_mouse_button, write_opt_string,
+    write_opt_u16, write_string,
 };
 
 /// A request sent by the CLI to the daemon.
@@ -51,7 +52,7 @@ pub enum Request {
         substring: Option<String>,
         last: Option<u32>,
     },
-    /// Return the dimensions of the most recent frame (minimal for V1).
+    /// Capture the most recent frame (cursor composited in) as a PNG.
     Screenshot,
     /// Move the mouse pointer to an absolute position.
     MouseMove { x: u16, y: u16 },
@@ -153,7 +154,7 @@ impl Response {
 }
 
 /// The success payload carried by [`Response::Ok`].
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum Payload {
     /// No data.
     Empty,
@@ -163,8 +164,26 @@ pub enum Payload {
     Properties(PropertyDump),
     /// Retained log lines.
     Logs(Vec<String>),
-    /// Most recent frame dimensions.
-    Screenshot { width: u16, height: u16 },
+    /// The most recent frame encoded as a PNG (cursor included), with its dimensions.
+    Screenshot { width: u16, height: u16, png: Vec<u8> },
+}
+
+impl fmt::Debug for Payload {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => f.write_str("Empty"),
+            Self::Status(status) => f.debug_tuple("Status").field(status).finish(),
+            Self::Properties(dump) => f.debug_tuple("Properties").field(dump).finish(),
+            Self::Logs(lines) => f.debug_tuple("Logs").field(lines).finish(),
+            // Print the PNG byte length rather than the (large, binary) blob.
+            Self::Screenshot { width, height, png } => f
+                .debug_struct("Screenshot")
+                .field("width", width)
+                .field("height", height)
+                .field("png_len", &png.len())
+                .finish(),
+        }
+    }
 }
 
 /// Coarse connection state reported by [`Request::Status`].
@@ -491,10 +510,11 @@ impl Encode for Payload {
                     write_string(dst, line)?;
                 }
             }
-            Self::Screenshot { width, height } => {
+            Self::Screenshot { width, height, png } => {
                 dst.write_u8(4);
                 dst.write_u16(*width);
                 dst.write_u16(*height);
+                write_bytes(dst, png)?;
             }
         }
         Ok(())
@@ -511,7 +531,7 @@ impl Encode for Payload {
                 Self::Status(status) => status.size(),
                 Self::Properties(dump) => dump.size(),
                 Self::Logs(lines) => 4 + lines.iter().map(|line| string_size(line)).sum::<usize>(),
-                Self::Screenshot { .. } => 2 /* width */ + 2 /* height */,
+                Self::Screenshot { png, .. } => 2 /* width */ + 2 /* height */ + bytes_size(png),
             }
     }
 }
@@ -536,7 +556,8 @@ impl Decode<'_> for Payload {
                 ensure_size!(in: src, size: 4);
                 let width = src.read_u16();
                 let height = src.read_u16();
-                Ok(Self::Screenshot { width, height })
+                let png = read_bytes(src)?;
+                Ok(Self::Screenshot { width, height, png })
             }
             _ => Err(ironrdp_core::invalid_field_err!("payload", "unknown tag")),
         }

--- a/crates/ironrdp-agent/src/ipc.rs
+++ b/crates/ironrdp-agent/src/ipc.rs
@@ -195,6 +195,8 @@ pub enum ConnState {
     Connecting,
     /// A session is active (at least one frame received).
     Connected,
+    /// A graceful disconnect was requested; the engine thread is still shutting down.
+    Disconnecting,
     /// A session terminated gracefully.
     Disconnected,
     /// A session failed.
@@ -209,6 +211,7 @@ impl ConnState {
             Self::Connected => 2,
             Self::Disconnected => 3,
             Self::Failed => 4,
+            Self::Disconnecting => 5,
         }
     }
 
@@ -219,6 +222,7 @@ impl ConnState {
             2 => Ok(Self::Connected),
             3 => Ok(Self::Disconnected),
             4 => Ok(Self::Failed),
+            5 => Ok(Self::Disconnecting),
             _ => Err(ironrdp_core::invalid_field_err!("connection state", "unknown tag")),
         }
     }

--- a/crates/ironrdp-agent/src/ipc.rs
+++ b/crates/ironrdp-agent/src/ipc.rs
@@ -1,0 +1,753 @@
+//! Strictly-typed IPC schema (V1) and its binary codec.
+//!
+//! # Framing
+//!
+//! Every message is sent length-delimited: a little-endian `u32` byte-count prefix followed by the
+//! `Encode`d body. The framing is identical over Unix domain sockets and Windows named pipes (see
+//! [`crate::transport`]). Both ends are the same binary at the same version, so there is no version
+//! byte and no forward/backward-compatibility handling.
+//!
+//! # Schema
+//!
+//! Connection configuration travels as a binary-encoded [`PropertySet`] inside [`Request::Connect`];
+//! everything else is a strictly-typed message. See [`Request`]/[`Response`].
+
+use core::fmt;
+
+use ironrdp_core::{Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, cast_length, ensure_size};
+use ironrdp_input::MouseButton;
+use ironrdp_pdu::impl_pdu_pod;
+use ironrdp_propertyset::PropertySet;
+
+use crate::wire::propertyset;
+use crate::wire::{
+    opt_string_size, opt_u16_size, read_bool, read_char, read_mouse_button, read_opt_string, read_opt_u16, read_string,
+    string_size, write_bool, write_char, write_mouse_button, write_opt_string, write_opt_u16, write_string,
+};
+
+/// A request sent by the CLI to the daemon.
+///
+/// `Connect` carries a binary-encoded [`PropertySet`] — never `argv` or CLI strings. Runtime
+/// operations are strictly-typed.
+#[derive(Clone, PartialEq, Eq)]
+pub enum Request {
+    /// Start an RDP session from a fully-merged property bag.
+    ///
+    /// `log_directive`, when set, is a [`tracing`]-style filter directive applied to *this*
+    /// session's log capture (e.g. `ironrdp_connector=trace`), layered on top of the default
+    /// `DEBUG` level. It lets a caller raise verbosity up-front to troubleshoot a connection.
+    Connect {
+        properties: PropertySet,
+        log_directive: Option<String>,
+    },
+    /// Tear down the current RDP session (the daemon keeps running).
+    Disconnect,
+    /// Query the current session status.
+    Status,
+    /// Query the live session property bag, optionally filtered.
+    QueryProps { filter: Option<KeyFilter> },
+    /// Return retained log lines, optionally filtered by substring and/or limited to the last `n`.
+    QueryLogs {
+        substring: Option<String>,
+        last: Option<u32>,
+    },
+    /// Return the dimensions of the most recent frame (minimal for V1).
+    Screenshot,
+    /// Move the mouse pointer to an absolute position.
+    MouseMove { x: u16, y: u16 },
+    /// Press or release a mouse button.
+    MouseButton { button: MouseButton, pressed: bool },
+    /// Rotate the mouse wheel.
+    Wheel { delta: i16, horizontal: bool },
+    // TODO: questioning whether we need a way to send multiple keys at once, e.g. a small mini
+    // format to express in a single command that keys A and B are pressed while key C is released.
+    // This could save LLM tokens by collapsing several round-trips into one request.
+    /// Press or release a key identified by its RDP scancode.
+    KeyScancode { scancode: u16, pressed: bool },
+    /// Press or release a key identified by a Unicode character.
+    KeyUnicode { ch: char, pressed: bool },
+    // TODO: add clipboard support (CLIPRDR), e.g. requests to read the remote clipboard text and to
+    // set it, so an LLM can copy/paste to and from the session.
+}
+
+// Manual `Debug` so the `Connect` payload's property *values* (which may include a password before
+// it reaches `ConfigBuilder::build`) are never printed verbatim; only the keys are shown.
+impl fmt::Debug for Request {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Connect {
+                properties,
+                log_directive,
+            } => f
+                .debug_struct("Connect")
+                .field("properties", &PropertyKeys(properties))
+                .field("log_directive", log_directive)
+                .finish(),
+            Self::Disconnect => f.write_str("Disconnect"),
+            Self::Status => f.write_str("Status"),
+            Self::QueryProps { filter } => f.debug_struct("QueryProps").field("filter", filter).finish(),
+            Self::QueryLogs { substring, last } => f
+                .debug_struct("QueryLogs")
+                .field("substring", substring)
+                .field("last", last)
+                .finish(),
+            Self::Screenshot => f.write_str("Screenshot"),
+            Self::MouseMove { x, y } => f.debug_struct("MouseMove").field("x", x).field("y", y).finish(),
+            Self::MouseButton { button, pressed } => f
+                .debug_struct("MouseButton")
+                .field("button", button)
+                .field("pressed", pressed)
+                .finish(),
+            Self::Wheel { delta, horizontal } => f
+                .debug_struct("Wheel")
+                .field("delta", delta)
+                .field("horizontal", horizontal)
+                .finish(),
+            Self::KeyScancode { scancode, pressed } => f
+                .debug_struct("KeyScancode")
+                .field("scancode", scancode)
+                .field("pressed", pressed)
+                .finish(),
+            Self::KeyUnicode { ch, pressed } => f
+                .debug_struct("KeyUnicode")
+                .field("ch", ch)
+                .field("pressed", pressed)
+                .finish(),
+        }
+    }
+}
+
+/// A [`PropertySet`] whose `Debug` output lists only the keys, never the (possibly secret) values.
+struct PropertyKeys<'a>(&'a PropertySet);
+
+impl fmt::Debug for PropertyKeys<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_set().entries(self.0.iter().map(|(key, _)| key)).finish()
+    }
+}
+
+/// The daemon's reply to a [`Request`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Response {
+    /// Success, carrying an operation-specific [`Payload`].
+    Ok(Payload),
+    /// Failure. The message is lowercase with no trailing punctuation.
+    Err(String),
+}
+
+impl Response {
+    /// A successful response with no payload.
+    pub fn ok() -> Self {
+        Self::Ok(Payload::Empty)
+    }
+
+    /// A failure response.
+    pub fn error(message: impl Into<String>) -> Self {
+        Self::Err(message.into())
+    }
+
+    /// Whether this is a success response.
+    pub fn is_ok(&self) -> bool {
+        matches!(self, Self::Ok(_))
+    }
+}
+
+/// The success payload carried by [`Response::Ok`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Payload {
+    /// No data.
+    Empty,
+    /// Current session status.
+    Status(StatusInfo),
+    /// A dump of the live property bag.
+    Properties(PropertyDump),
+    /// Retained log lines.
+    Logs(Vec<String>),
+    /// Most recent frame dimensions.
+    Screenshot { width: u16, height: u16 },
+}
+
+/// Coarse connection state reported by [`Request::Status`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConnState {
+    /// No session has been started.
+    NoSession,
+    /// A session was started and is connecting.
+    Connecting,
+    /// A session is active (at least one frame received).
+    Connected,
+    /// A session terminated gracefully.
+    Disconnected,
+    /// A session failed.
+    Failed,
+}
+
+impl ConnState {
+    fn tag(self) -> u8 {
+        match self {
+            Self::NoSession => 0,
+            Self::Connecting => 1,
+            Self::Connected => 2,
+            Self::Disconnected => 3,
+            Self::Failed => 4,
+        }
+    }
+
+    fn from_tag(tag: u8) -> DecodeResult<Self> {
+        match tag {
+            0 => Ok(Self::NoSession),
+            1 => Ok(Self::Connecting),
+            2 => Ok(Self::Connected),
+            3 => Ok(Self::Disconnected),
+            4 => Ok(Self::Failed),
+            _ => Err(ironrdp_core::invalid_field_err!("connection state", "unknown tag")),
+        }
+    }
+}
+
+/// Status snapshot returned by [`Request::Status`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatusInfo {
+    /// Coarse connection state.
+    pub state: ConnState,
+    /// RDP target (`host:port`), if a session exists.
+    pub destination: Option<String>,
+    /// Most recent frame width, if any.
+    pub width: Option<u16>,
+    /// Most recent frame height, if any.
+    pub height: Option<u16>,
+    /// Human-readable detail, e.g. the failure reason.
+    pub message: Option<String>,
+    /// `true` when the daemon was started with preloaded credentials (an operator-provided overlay).
+    ///
+    /// When set, a caller driving `connect` does not need to supply a password (or other secrets):
+    /// the daemon layers the overlay on top of the request before building the configuration.
+    pub credentials_loaded: bool,
+}
+
+/// A bulk dump of live properties.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PropertyDump {
+    /// One entry per property, in key order.
+    pub entries: Vec<PropertyEntry>,
+}
+
+/// A single dumped property.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PropertyEntry {
+    /// Property key.
+    pub key: String,
+    /// Property value.
+    pub value: PropValue,
+}
+
+/// A dumped property value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PropValue {
+    /// Integer value.
+    Int(i64),
+    /// String value.
+    Str(String),
+}
+
+/// A small key filter for [`Request::QueryProps`]. Matching is case-insensitive.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KeyFilter {
+    /// Match keys containing this substring.
+    Substring(String),
+    /// Match keys starting with this prefix.
+    Prefix(String),
+}
+
+impl KeyFilter {
+    /// Returns `true` when `key` matches this filter (case-insensitive).
+    pub fn matches(&self, key: &str) -> bool {
+        let key = key.to_ascii_lowercase();
+        match self {
+            Self::Substring(needle) => key.contains(&needle.to_ascii_lowercase()),
+            Self::Prefix(prefix) => key.starts_with(&prefix.to_ascii_lowercase()),
+        }
+    }
+}
+
+// ── KeyFilter codec ─────────────────────────────────────────────────────────
+
+impl Encode for KeyFilter {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        match self {
+            Self::Substring(value) => {
+                dst.write_u8(0);
+                write_string(dst, value)
+            }
+            Self::Prefix(value) => {
+                dst.write_u8(1);
+                write_string(dst, value)
+            }
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_agent::KeyFilter"
+    }
+
+    fn size(&self) -> usize {
+        let value = match self {
+            Self::Substring(value) | Self::Prefix(value) => value,
+        };
+        1 /* tag */ + string_size(value)
+    }
+}
+
+impl Decode<'_> for KeyFilter {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 1);
+        match src.read_u8() {
+            0 => Ok(Self::Substring(read_string(src)?)),
+            1 => Ok(Self::Prefix(read_string(src)?)),
+            _ => Err(ironrdp_core::invalid_field_err!("key filter", "unknown tag")),
+        }
+    }
+}
+
+impl_pdu_pod!(KeyFilter);
+
+// ── PropValue / PropertyEntry / PropertyDump codec ──────────────────────────
+
+impl Encode for PropValue {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        match self {
+            Self::Int(value) => {
+                dst.write_u8(0);
+                dst.write_i64(*value);
+            }
+            Self::Str(value) => {
+                dst.write_u8(1);
+                write_string(dst, value)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_agent::PropValue"
+    }
+
+    fn size(&self) -> usize {
+        1 /* tag */
+            + match self {
+                Self::Int(_) => 8,
+                Self::Str(value) => string_size(value),
+            }
+    }
+}
+
+impl Decode<'_> for PropValue {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 1);
+        match src.read_u8() {
+            0 => {
+                ensure_size!(in: src, size: 8);
+                Ok(Self::Int(src.read_i64()))
+            }
+            1 => Ok(Self::Str(read_string(src)?)),
+            _ => Err(ironrdp_core::invalid_field_err!("property value", "unknown tag")),
+        }
+    }
+}
+
+impl_pdu_pod!(PropValue);
+
+impl Encode for PropertyEntry {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        write_string(dst, &self.key)?;
+        self.value.encode(dst)
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_agent::PropertyEntry"
+    }
+
+    fn size(&self) -> usize {
+        string_size(&self.key) + self.value.size()
+    }
+}
+
+impl Decode<'_> for PropertyEntry {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        let key = read_string(src)?;
+        let value = PropValue::decode(src)?;
+        Ok(Self { key, value })
+    }
+}
+
+impl_pdu_pod!(PropertyEntry);
+
+impl Encode for PropertyDump {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        let count: u32 = cast_length!("property count", self.entries.len())?;
+        dst.write_u32(count);
+        for entry in &self.entries {
+            entry.encode(dst)?;
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_agent::PropertyDump"
+    }
+
+    fn size(&self) -> usize {
+        4 /* count */ + self.entries.iter().map(Encode::size).sum::<usize>()
+    }
+}
+
+impl Decode<'_> for PropertyDump {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 4);
+        let count = src.read_u32();
+        let mut entries = Vec::new();
+        for _ in 0..count {
+            entries.push(PropertyEntry::decode(src)?);
+        }
+        Ok(Self { entries })
+    }
+}
+
+impl_pdu_pod!(PropertyDump);
+
+// ── StatusInfo codec ────────────────────────────────────────────────────────
+
+impl Encode for StatusInfo {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u8(self.state.tag());
+        write_opt_string(dst, self.destination.as_deref())?;
+        write_opt_u16(dst, self.width)?;
+        write_opt_u16(dst, self.height)?;
+        write_opt_string(dst, self.message.as_deref())?;
+        write_bool(dst, self.credentials_loaded)
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_agent::StatusInfo"
+    }
+
+    fn size(&self) -> usize {
+        1 /* state */
+            + opt_string_size(self.destination.as_deref())
+            + opt_u16_size(self.width)
+            + opt_u16_size(self.height)
+            + opt_string_size(self.message.as_deref())
+            + 1 /* credentials_loaded */
+    }
+}
+
+impl Decode<'_> for StatusInfo {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 1);
+        let state = ConnState::from_tag(src.read_u8())?;
+        let destination = read_opt_string(src)?;
+        let width = read_opt_u16(src)?;
+        let height = read_opt_u16(src)?;
+        let message = read_opt_string(src)?;
+        let credentials_loaded = read_bool(src)?;
+        Ok(Self {
+            state,
+            destination,
+            width,
+            height,
+            message,
+            credentials_loaded,
+        })
+    }
+}
+
+impl_pdu_pod!(StatusInfo);
+
+// ── Payload codec ───────────────────────────────────────────────────────────
+
+impl Encode for Payload {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        match self {
+            Self::Empty => dst.write_u8(0),
+            Self::Status(status) => {
+                dst.write_u8(1);
+                status.encode(dst)?;
+            }
+            Self::Properties(dump) => {
+                dst.write_u8(2);
+                dump.encode(dst)?;
+            }
+            Self::Logs(lines) => {
+                dst.write_u8(3);
+                let count: u32 = cast_length!("log line count", lines.len())?;
+                dst.write_u32(count);
+                for line in lines {
+                    write_string(dst, line)?;
+                }
+            }
+            Self::Screenshot { width, height } => {
+                dst.write_u8(4);
+                dst.write_u16(*width);
+                dst.write_u16(*height);
+            }
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_agent::Payload"
+    }
+
+    fn size(&self) -> usize {
+        1 /* tag */
+            + match self {
+                Self::Empty => 0,
+                Self::Status(status) => status.size(),
+                Self::Properties(dump) => dump.size(),
+                Self::Logs(lines) => 4 + lines.iter().map(|line| string_size(line)).sum::<usize>(),
+                Self::Screenshot { .. } => 2 /* width */ + 2 /* height */,
+            }
+    }
+}
+
+impl Decode<'_> for Payload {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 1);
+        match src.read_u8() {
+            0 => Ok(Self::Empty),
+            1 => Ok(Self::Status(StatusInfo::decode(src)?)),
+            2 => Ok(Self::Properties(PropertyDump::decode(src)?)),
+            3 => {
+                ensure_size!(in: src, size: 4);
+                let count = src.read_u32();
+                let mut lines = Vec::new();
+                for _ in 0..count {
+                    lines.push(read_string(src)?);
+                }
+                Ok(Self::Logs(lines))
+            }
+            4 => {
+                ensure_size!(in: src, size: 4);
+                let width = src.read_u16();
+                let height = src.read_u16();
+                Ok(Self::Screenshot { width, height })
+            }
+            _ => Err(ironrdp_core::invalid_field_err!("payload", "unknown tag")),
+        }
+    }
+}
+
+impl_pdu_pod!(Payload);
+
+// ── Response codec ──────────────────────────────────────────────────────────
+
+impl Encode for Response {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        match self {
+            Self::Ok(payload) => {
+                dst.write_u8(0);
+                payload.encode(dst)
+            }
+            Self::Err(message) => {
+                dst.write_u8(1);
+                write_string(dst, message)
+            }
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_agent::Response"
+    }
+
+    fn size(&self) -> usize {
+        1 /* tag */
+            + match self {
+                Self::Ok(payload) => payload.size(),
+                Self::Err(message) => string_size(message),
+            }
+    }
+}
+
+impl Decode<'_> for Response {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 1);
+        match src.read_u8() {
+            0 => Ok(Self::Ok(Payload::decode(src)?)),
+            1 => Ok(Self::Err(read_string(src)?)),
+            _ => Err(ironrdp_core::invalid_field_err!("response", "unknown tag")),
+        }
+    }
+}
+
+impl_pdu_pod!(Response);
+
+// ── Request codec ───────────────────────────────────────────────────────────
+
+impl Encode for Request {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        match self {
+            Self::Connect {
+                properties,
+                log_directive,
+            } => {
+                dst.write_u8(0);
+                propertyset::write(properties, dst)?;
+                write_opt_string(dst, log_directive.as_deref())?;
+            }
+            Self::Disconnect => dst.write_u8(1),
+            Self::Status => dst.write_u8(2),
+            Self::QueryProps { filter } => {
+                dst.write_u8(3);
+                match filter {
+                    Some(filter) => {
+                        dst.write_u8(1);
+                        filter.encode(dst)?;
+                    }
+                    None => dst.write_u8(0),
+                }
+            }
+            Self::QueryLogs { substring, last } => {
+                dst.write_u8(4);
+                write_opt_string(dst, substring.as_deref())?;
+                match last {
+                    Some(last) => {
+                        dst.write_u8(1);
+                        dst.write_u32(*last);
+                    }
+                    None => dst.write_u8(0),
+                }
+            }
+            Self::Screenshot => dst.write_u8(5),
+            Self::MouseMove { x, y } => {
+                dst.write_u8(6);
+                dst.write_u16(*x);
+                dst.write_u16(*y);
+            }
+            Self::MouseButton { button, pressed } => {
+                dst.write_u8(7);
+                write_mouse_button(dst, *button)?;
+                write_bool(dst, *pressed)?;
+            }
+            Self::Wheel { delta, horizontal } => {
+                dst.write_u8(8);
+                dst.write_i16(*delta);
+                write_bool(dst, *horizontal)?;
+            }
+            Self::KeyScancode { scancode, pressed } => {
+                dst.write_u8(9);
+                dst.write_u16(*scancode);
+                write_bool(dst, *pressed)?;
+            }
+            Self::KeyUnicode { ch, pressed } => {
+                dst.write_u8(10);
+                write_char(dst, *ch)?;
+                write_bool(dst, *pressed)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_agent::Request"
+    }
+
+    fn size(&self) -> usize {
+        1 /* tag */
+            + match self {
+                Self::Connect { properties, log_directive } => {
+                    propertyset::size(properties) + opt_string_size(log_directive.as_deref())
+                }
+                Self::Disconnect | Self::Status | Self::Screenshot => 0,
+                Self::QueryProps { filter } => 1 /* presence */ + filter.as_ref().map_or(0, Encode::size),
+                Self::QueryLogs { substring, last } => {
+                    opt_string_size(substring.as_deref()) + 1 /* presence */ + last.map_or(0, |_| 4)
+                }
+                Self::MouseMove { .. } => 2 /* x */ + 2 /* y */,
+                Self::MouseButton { .. } => 1 /* button */ + 1 /* pressed */,
+                Self::Wheel { .. } => 2 /* delta */ + 1 /* horizontal */,
+                Self::KeyScancode { .. } => 2 /* scancode */ + 1 /* pressed */,
+                Self::KeyUnicode { .. } => 4 /* ch */ + 1 /* pressed */,
+            }
+    }
+}
+
+impl Decode<'_> for Request {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 1);
+        match src.read_u8() {
+            0 => {
+                let mut properties = PropertySet::new();
+                propertyset::read(&mut properties, src)?;
+                let log_directive = read_opt_string(src)?;
+                Ok(Self::Connect {
+                    properties,
+                    log_directive,
+                })
+            }
+            1 => Ok(Self::Disconnect),
+            2 => Ok(Self::Status),
+            3 => {
+                ensure_size!(in: src, size: 1);
+                let filter = match src.read_u8() {
+                    0 => None,
+                    1 => Some(KeyFilter::decode(src)?),
+                    _ => return Err(ironrdp_core::invalid_field_err!("dump filter", "invalid presence flag")),
+                };
+                Ok(Self::QueryProps { filter })
+            }
+            4 => {
+                let substring = read_opt_string(src)?;
+                ensure_size!(in: src, size: 1);
+                let last = match src.read_u8() {
+                    0 => None,
+                    1 => {
+                        ensure_size!(in: src, size: 4);
+                        Some(src.read_u32())
+                    }
+                    _ => return Err(ironrdp_core::invalid_field_err!("query last", "invalid presence flag")),
+                };
+                Ok(Self::QueryLogs { substring, last })
+            }
+            5 => Ok(Self::Screenshot),
+            6 => {
+                ensure_size!(in: src, size: 4);
+                let x = src.read_u16();
+                let y = src.read_u16();
+                Ok(Self::MouseMove { x, y })
+            }
+            7 => {
+                let button = read_mouse_button(src)?;
+                let pressed = read_bool(src)?;
+                Ok(Self::MouseButton { button, pressed })
+            }
+            8 => {
+                ensure_size!(in: src, size: 2);
+                let delta = src.read_i16();
+                let horizontal = read_bool(src)?;
+                Ok(Self::Wheel { delta, horizontal })
+            }
+            9 => {
+                ensure_size!(in: src, size: 2);
+                let scancode = src.read_u16();
+                let pressed = read_bool(src)?;
+                Ok(Self::KeyScancode { scancode, pressed })
+            }
+            10 => {
+                let ch = read_char(src)?;
+                let pressed = read_bool(src)?;
+                Ok(Self::KeyUnicode { ch, pressed })
+            }
+            _ => Err(ironrdp_core::invalid_field_err!("request", "unknown tag")),
+        }
+    }
+}
+
+impl_pdu_pod!(Request);

--- a/crates/ironrdp-agent/src/lib.rs
+++ b/crates/ironrdp-agent/src/lib.rs
@@ -1,0 +1,27 @@
+#![cfg_attr(doc, doc = include_str!("../README.md"))]
+#![doc(html_logo_url = "https://cdnweb.devolutions.net/images/projects/devolutions/logos/devolutions-icon-shadow.svg")]
+
+//! A CLI-driven, daemon-backed agentic RDP client.
+//!
+//! The public surface is intentionally small and split into:
+//!
+//! - [`ipc`]: the strictly-typed request/response schema and its binary codec.
+//! - [`transport`]: the local IPC transport (Unix socket / Windows named pipe) and framing.
+//! - [`daemon`]: the long-lived daemon driver.
+//! - [`cli`]: the short-lived CLI driver.
+
+pub mod cli;
+pub mod daemon;
+pub mod ipc;
+pub mod transport;
+
+pub(crate) mod help;
+pub(crate) mod logbuf;
+
+// The wire codec helpers are internal, but the `internal` feature exposes them (hidden from docs)
+// so they can be unit tested from the workspace test suite.
+#[cfg(feature = "internal")]
+#[doc(hidden)]
+pub mod wire;
+#[cfg(not(feature = "internal"))]
+pub(crate) mod wire;

--- a/crates/ironrdp-agent/src/logbuf.rs
+++ b/crates/ironrdp-agent/src/logbuf.rs
@@ -1,0 +1,147 @@
+//! The RDP session log ring buffer and its [`tracing`] layer.
+//!
+//! The logs emitted while driving the RDP engine are captured into a small, queryable
+//! [`LogBuffer`] ring (read via `Request::QueryLogs`) instead of the terminal. The capture is
+//! installed as a thread-local subscriber for the session thread only (see [`session_dispatch`] and
+//! [`tracing::dispatcher::with_default`]), so it never becomes the global subscriber. It defaults
+//! to `DEBUG`, which is useful when inspecting a session, and a per-`Connect` directive can refine
+//! the filter (e.g. `ironrdp_connector=trace`) to troubleshoot IronRDP itself.
+//!
+//! The daemon's *own* operational logging is a separate concern; see
+//! [`crate::daemon`]'s global subscriber setup.
+
+use core::fmt::Write as _;
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use tracing::field::{Field, Visit};
+use tracing::{Dispatch, Event, Subscriber};
+use tracing_subscriber::Layer;
+use tracing_subscriber::layer::Context;
+
+/// Default ring-buffer capacity, in lines.
+const DEFAULT_CAPACITY: usize = 100;
+
+/// A bounded ring buffer of formatted log lines.
+pub(crate) struct LogBuffer {
+    inner: Mutex<Inner>,
+}
+
+struct Inner {
+    capacity: usize,
+    lines: VecDeque<String>,
+}
+
+impl LogBuffer {
+    pub(crate) fn new() -> Arc<Self> {
+        Self::with_capacity(DEFAULT_CAPACITY)
+    }
+
+    pub(crate) fn with_capacity(capacity: usize) -> Arc<Self> {
+        Arc::new(Self {
+            inner: Mutex::new(Inner {
+                capacity: capacity.max(1),
+                lines: VecDeque::new(),
+            }),
+        })
+    }
+
+    fn push(&self, line: String) {
+        let mut inner = self.inner.lock().expect("log buffer poisoned");
+
+        if inner.capacity <= inner.lines.len() {
+            inner.lines.pop_front();
+        }
+        inner.lines.push_back(line);
+    }
+
+    /// Returns retained lines, optionally filtered to those containing `substring`.
+    pub(crate) fn query(&self, substring: Option<&str>) -> Vec<String> {
+        let inner = self.inner.lock().expect("log buffer poisoned");
+        inner
+            .lines
+            .iter()
+            .filter(|line| substring.is_none_or(|needle| line.contains(needle)))
+            .cloned()
+            .collect()
+    }
+}
+
+/// Builds a session-scoped [`Dispatch`] that routes the RDP session's logs into `buffer`.
+///
+/// The session runs on its own thread; wrapping its execution in
+/// [`tracing::dispatcher::with_default`] keeps the engine's events out of the daemon's terminal and
+/// in the ring buffer instead. The default level is `DEBUG`; `directive` (carried by
+/// `Request::Connect`) refines it per-session — a bare level sets the global session level, while a
+/// targeted directive (e.g. `ironrdp_connector=trace`) layers on top of the `DEBUG` default.
+pub(crate) fn session_dispatch(buffer: Arc<LogBuffer>, directive: Option<&str>) -> Dispatch {
+    use tracing::level_filters::LevelFilter;
+    use tracing_subscriber::EnvFilter;
+    use tracing_subscriber::prelude::*;
+
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::DEBUG.into())
+        .parse_lossy(directive.unwrap_or(""));
+
+    let subscriber = tracing_subscriber::registry()
+        .with(env_filter)
+        .with(LogLayer::new(buffer));
+
+    Dispatch::new(subscriber)
+}
+
+/// A tracing [`Layer`] that formats each event into a single line and pushes it to a [`LogBuffer`].
+struct LogLayer {
+    buffer: Arc<LogBuffer>,
+}
+
+impl LogLayer {
+    fn new(buffer: Arc<LogBuffer>) -> Self {
+        Self { buffer }
+    }
+}
+
+impl<S: Subscriber> Layer<S> for LogLayer {
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let meta = event.metadata();
+
+        let mut visitor = LogVisitor {
+            message: None,
+            fields: String::new(),
+        };
+        event.record(&mut visitor);
+
+        let mut line = String::new();
+        let _ = write!(line, "{:>5} {}", meta.level(), meta.target());
+        if let Some(message) = &visitor.message {
+            let _ = write!(line, " {message}");
+        }
+        line.push_str(&visitor.fields);
+
+        self.buffer.push(line);
+    }
+}
+
+/// Collects an event's message and structured fields into strings.
+struct LogVisitor {
+    message: Option<String>,
+    fields: String,
+}
+
+impl Visit for LogVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn core::fmt::Debug) {
+        if field.name() == "message" {
+            self.message = Some(format!("{value:?}"));
+        } else {
+            let _ = write!(self.fields, " {}={:?}", field.name(), value);
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "message" {
+            self.message = Some(value.to_owned());
+        } else {
+            let _ = write!(self.fields, " {}={}", field.name(), value);
+        }
+    }
+}

--- a/crates/ironrdp-agent/src/main.rs
+++ b/crates/ironrdp-agent/src/main.rs
@@ -1,0 +1,10 @@
+// The binary uses only a subset of the library's dependencies; the rest are used by the lib target.
+#![allow(unused_crate_dependencies)]
+
+use clap::Parser as _;
+use ironrdp_agent::cli::Cli;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    ironrdp_agent::cli::run(Cli::parse()).await
+}

--- a/crates/ironrdp-agent/src/transport.rs
+++ b/crates/ironrdp-agent/src/transport.rs
@@ -1,0 +1,177 @@
+//! Local IPC transport and message framing.
+//!
+//! The daemon and CLI talk over a platform-native local transport:
+//!
+//! - **Unix**: a [`tokio::net::UnixListener`]/[`tokio::net::UnixStream`] at
+//!   `$XDG_RUNTIME_DIR/ironrdp-agent-<uid>.sock`, falling back to `/tmp/ironrdp-agent-<uid>.sock`
+//!   when `XDG_RUNTIME_DIR` is unset.
+//! - **Windows**: a named pipe at `\\.\pipe\ironrdp-agent-<user>`.
+//!
+//! Framing is identical on both: a little-endian `u32` byte-count prefix followed by the `Encode`d
+//! message body.
+
+use anyhow::{Context as _, bail};
+use ironrdp_core::{DecodeOwned, Encode};
+use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWrite, AsyncWriteExt as _};
+
+use crate::ipc::{Request, Response};
+
+/// Upper bound on a single framed message, guarding against absurd length prefixes.
+const MAX_MESSAGE_LEN: usize = 16 * 1024 * 1024;
+
+/// Writes `message` to `stream`, length-delimited.
+pub(crate) async fn write_message<S, M>(stream: &mut S, message: &M) -> anyhow::Result<()>
+where
+    S: AsyncWrite + Unpin,
+    M: Encode,
+{
+    let body = ironrdp_core::encode_vec(message).map_err(|e| anyhow::anyhow!("encode {}: {e}", message.name()))?;
+    let len = u32::try_from(body.len()).context("message too large to frame")?;
+    stream
+        .write_all(&len.to_le_bytes())
+        .await
+        .context("write frame length")?;
+    stream.write_all(&body).await.context("write frame body")?;
+    stream.flush().await.context("flush frame")?;
+    Ok(())
+}
+
+/// Reads a single length-delimited message from `stream`.
+pub(crate) async fn read_message<S, M>(stream: &mut S) -> anyhow::Result<M>
+where
+    S: AsyncRead + Unpin,
+    M: DecodeOwned,
+{
+    let mut len_buf = [0u8; 4];
+    stream.read_exact(&mut len_buf).await.context("read frame length")?;
+    let len = usize::try_from(u32::from_le_bytes(len_buf)).expect("u32 fits in usize on supported platforms");
+    if MAX_MESSAGE_LEN < len {
+        bail!("frame length {len} exceeds the {MAX_MESSAGE_LEN}-byte limit");
+    }
+    let mut body = vec![0u8; len];
+    stream.read_exact(&mut body).await.context("read frame body")?;
+    ironrdp_core::decode_owned(&body).map_err(|e| anyhow::anyhow!("decode: {e}"))
+}
+
+/// Opens the endpoint, sends one `request`, and returns the daemon's `Response`.
+pub async fn send_request(endpoint: &Endpoint, request: &Request) -> anyhow::Result<Response> {
+    let mut stream = connect(endpoint)
+        .await
+        .with_context(|| format!("connect to daemon at {endpoint}"))?;
+    write_message(&mut stream, request).await?;
+    read_message(&mut stream).await
+}
+
+#[cfg(unix)]
+mod imp {
+    use std::io;
+    use std::path::PathBuf;
+
+    use tokio::net::{UnixListener, UnixStream};
+
+    /// A resolved IPC endpoint (a Unix domain socket path).
+    #[derive(Debug, Clone)]
+    pub struct Endpoint(pub PathBuf);
+
+    impl core::fmt::Display for Endpoint {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            write!(f, "{}", self.0.display())
+        }
+    }
+
+    /// Returns the default per-user endpoint.
+    pub fn default_endpoint() -> Endpoint {
+        // SAFETY: `getuid` has no preconditions and is always safe to call.
+        let uid = unsafe { libc::getuid() };
+        let dir = std::env::var_os("XDG_RUNTIME_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("/tmp"));
+        Endpoint(dir.join(format!("ironrdp-agent-{uid}.sock")))
+    }
+
+    /// Connects to a listening daemon.
+    pub async fn connect(endpoint: &Endpoint) -> io::Result<UnixStream> {
+        UnixStream::connect(&endpoint.0).await
+    }
+
+    /// A bound listener that accepts client connections.
+    pub struct Listener {
+        inner: UnixListener,
+        path: PathBuf,
+    }
+
+    impl Listener {
+        /// Binds the listener at `endpoint`.
+        pub fn bind(endpoint: &Endpoint) -> io::Result<Self> {
+            let inner = UnixListener::bind(&endpoint.0)?;
+            Ok(Self {
+                inner,
+                path: endpoint.0.clone(),
+            })
+        }
+
+        /// Accepts the next client connection.
+        pub async fn accept(&self) -> io::Result<UnixStream> {
+            let (stream, _addr) = self.inner.accept().await?;
+            Ok(stream)
+        }
+    }
+
+    impl Drop for Listener {
+        fn drop(&mut self) {
+            // Best-effort removal of the socket file on shutdown (named pipes need no cleanup).
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+#[cfg(windows)]
+mod imp {
+    use std::io;
+
+    use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeClient, NamedPipeServer, ServerOptions};
+
+    /// A resolved IPC endpoint (a named pipe path).
+    #[derive(Debug, Clone)]
+    pub struct Endpoint(pub String);
+
+    impl core::fmt::Display for Endpoint {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            write!(f, "{}", self.0)
+        }
+    }
+
+    /// Returns the default per-user endpoint.
+    pub fn default_endpoint() -> Endpoint {
+        let user = whoami::username().unwrap_or_else(|_| "user".to_owned());
+        Endpoint(format!(r"\\.\pipe\ironrdp-agent-{user}"))
+    }
+
+    /// Connects to a listening daemon.
+    pub async fn connect(endpoint: &Endpoint) -> io::Result<NamedPipeClient> {
+        ClientOptions::new().open(&endpoint.0)
+    }
+
+    /// A named-pipe listener that creates a fresh server instance per accepted connection.
+    pub struct Listener {
+        name: String,
+    }
+
+    impl Listener {
+        /// Records the pipe name to serve.
+        pub fn bind(endpoint: &Endpoint) -> io::Result<Self> {
+            Ok(Self {
+                name: endpoint.0.clone(),
+            })
+        }
+
+        /// Creates a new pipe instance and waits for a client to connect to it.
+        pub async fn accept(&self) -> io::Result<NamedPipeServer> {
+            let server = ServerOptions::new().create(&self.name)?;
+            server.connect().await?;
+            Ok(server)
+        }
+    }
+}
+
+pub use imp::{Endpoint, Listener, connect, default_endpoint};

--- a/crates/ironrdp-agent/src/transport.rs
+++ b/crates/ironrdp-agent/src/transport.rs
@@ -104,6 +104,11 @@ mod imp {
         /// Binds the listener at `endpoint`.
         pub fn bind(endpoint: &Endpoint) -> io::Result<Self> {
             let inner = UnixListener::bind(&endpoint.0)?;
+            // Restrict the socket to the owner. The fallback directory is world-writable `/tmp`, so
+            // without this any local user could connect and drive the session (input, screenshots,
+            // logs). Fail loudly rather than serve on a world-accessible endpoint.
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(&endpoint.0, std::fs::Permissions::from_mode(0o600))?;
             Ok(Self {
                 inner,
                 path: endpoint.0.clone(),

--- a/crates/ironrdp-agent/src/transport.rs
+++ b/crates/ironrdp-agent/src/transport.rs
@@ -111,7 +111,7 @@ mod imp {
         }
 
         /// Accepts the next client connection.
-        pub async fn accept(&self) -> io::Result<UnixStream> {
+        pub async fn accept(&mut self) -> io::Result<UnixStream> {
             let (stream, _addr) = self.inner.accept().await?;
             Ok(stream)
         }
@@ -152,24 +152,37 @@ mod imp {
         ClientOptions::new().open(&endpoint.0)
     }
 
-    /// A named-pipe listener that creates a fresh server instance per accepted connection.
+    /// A named-pipe listener.
+    ///
+    /// It always keeps one ready (unconnected) server instance alive, which is both what serves the
+    /// next connection and what upholds the `first_pipe_instance` exclusivity (a pipe with no live
+    /// instance would let a second daemon claim the name).
     pub struct Listener {
         name: String,
+        ready: NamedPipeServer,
     }
 
     impl Listener {
-        /// Records the pipe name to serve.
+        /// Creates the first pipe instance, claiming the name exclusively.
+        ///
+        /// `first_pipe_instance(true)` makes this fail with `ERROR_ACCESS_DENIED` if another daemon
+        /// already owns the pipe, so two daemons cannot coexist on the same endpoint.
         pub fn bind(endpoint: &Endpoint) -> io::Result<Self> {
+            let ready = ServerOptions::new().first_pipe_instance(true).create(&endpoint.0)?;
             Ok(Self {
                 name: endpoint.0.clone(),
+                ready,
             })
         }
 
-        /// Creates a new pipe instance and waits for a client to connect to it.
-        pub async fn accept(&self) -> io::Result<NamedPipeServer> {
-            let server = ServerOptions::new().create(&self.name)?;
-            server.connect().await?;
-            Ok(server)
+        /// Waits for the next client to connect to the ready instance, then mints a replacement.
+        pub async fn accept(&mut self) -> io::Result<NamedPipeServer> {
+            // Connect by reference so a cancelled future leaves `ready` intact (and the pipe alive).
+            self.ready.connect().await?;
+            // Mint the next listening instance before returning so the pipe is never instance-less.
+            // Subsequent instances must omit `first_pipe_instance`, which is only valid on the first.
+            let next = ServerOptions::new().create(&self.name)?;
+            Ok(core::mem::replace(&mut self.ready, next))
         }
     }
 }

--- a/crates/ironrdp-agent/src/wire/mod.rs
+++ b/crates/ironrdp-agent/src/wire/mod.rs
@@ -1,0 +1,139 @@
+//! Binary wire primitives shared by the IPC message codecs.
+//!
+//! Everything is little-endian and cursor-based so it composes directly with [`ironrdp_core`]'s
+//! `Encode`/`Decode`/`DecodeOwned` traits. Strings (and string-shaped payloads) are length-delimited
+//! with a `u32` byte-count prefix.
+//!
+//! These helpers are `pub` so the [`internal`](crate) feature can expose them for unit testing in
+//! the workspace test suite; the [`wire`](crate::wire) module itself is only public under that
+//! feature.
+
+// The helpers are unconditionally `pub`; their effective visibility is the `wire` module's, which is
+// `pub(crate)` unless the `internal` feature exposes it.
+#![cfg_attr(not(feature = "internal"), allow(unreachable_pub))]
+
+pub mod propertyset;
+
+use ironrdp_core::{DecodeResult, EncodeResult, ReadCursor, WriteCursor, cast_length, ensure_size};
+use ironrdp_input::MouseButton;
+
+/// Size on the wire of a length-prefixed UTF-8 string.
+pub fn string_size(value: &str) -> usize {
+    4 /* length prefix */ + value.len() /* UTF-8 bytes */
+}
+
+/// Size on the wire of an optional length-prefixed UTF-8 string.
+pub fn opt_string_size(value: Option<&str>) -> usize {
+    1 /* presence flag */ + value.map_or(0, string_size)
+}
+
+pub fn write_string(dst: &mut WriteCursor<'_>, value: &str) -> EncodeResult<()> {
+    ensure_size!(in: dst, size: string_size(value));
+    let len: u32 = cast_length!("string length", value.len())?;
+    dst.write_u32(len);
+    dst.write_slice(value.as_bytes());
+    Ok(())
+}
+
+pub fn read_string(src: &mut ReadCursor<'_>) -> DecodeResult<String> {
+    ensure_size!(in: src, size: 4);
+    let len = src.read_u32();
+    let len = usize::try_from(len).map_err(|_| ironrdp_core::other_err!("string", "length does not fit in usize"))?;
+    ensure_size!(in: src, size: len);
+    let bytes = src.read_slice(len);
+    String::from_utf8(bytes.to_vec()).map_err(|_| ironrdp_core::invalid_field_err!("string", "not valid UTF-8"))
+}
+
+pub fn write_opt_string(dst: &mut WriteCursor<'_>, value: Option<&str>) -> EncodeResult<()> {
+    ensure_size!(in: dst, size: 1);
+    match value {
+        Some(value) => {
+            dst.write_u8(1);
+            write_string(dst, value)
+        }
+        None => {
+            dst.write_u8(0);
+            Ok(())
+        }
+    }
+}
+
+pub fn read_opt_string(src: &mut ReadCursor<'_>) -> DecodeResult<Option<String>> {
+    ensure_size!(in: src, size: 1);
+    match src.read_u8() {
+        0 => Ok(None),
+        1 => Ok(Some(read_string(src)?)),
+        _ => Err(ironrdp_core::invalid_field_err!(
+            "optional string",
+            "invalid presence flag"
+        )),
+    }
+}
+
+pub fn write_bool(dst: &mut WriteCursor<'_>, value: bool) -> EncodeResult<()> {
+    ensure_size!(in: dst, size: 1);
+    dst.write_u8(u8::from(value));
+    Ok(())
+}
+
+pub fn read_bool(src: &mut ReadCursor<'_>) -> DecodeResult<bool> {
+    ensure_size!(in: src, size: 1);
+    Ok(src.read_u8() != 0)
+}
+
+pub fn write_char(dst: &mut WriteCursor<'_>, value: char) -> EncodeResult<()> {
+    ensure_size!(in: dst, size: 4);
+    dst.write_u32(u32::from(value));
+    Ok(())
+}
+
+pub fn read_char(src: &mut ReadCursor<'_>) -> DecodeResult<char> {
+    ensure_size!(in: src, size: 4);
+    let code = src.read_u32();
+    char::from_u32(code).ok_or_else(|| ironrdp_core::invalid_field_err!("char", "not a valid Unicode scalar value"))
+}
+
+pub fn write_mouse_button(dst: &mut WriteCursor<'_>, button: MouseButton) -> EncodeResult<()> {
+    ensure_size!(in: dst, size: 1);
+    let idx: u8 = cast_length!("mouse button index", button.as_idx())?;
+    dst.write_u8(idx);
+    Ok(())
+}
+
+pub fn read_mouse_button(src: &mut ReadCursor<'_>) -> DecodeResult<MouseButton> {
+    ensure_size!(in: src, size: 1);
+    let idx = src.read_u8();
+    MouseButton::from_idx(usize::from(idx))
+        .ok_or_else(|| ironrdp_core::invalid_field_err!("mouse button", "unknown button index"))
+}
+
+pub fn opt_u16_size(value: Option<u16>) -> usize {
+    1 /* presence */ + value.map_or(0, |_| 2)
+}
+
+pub fn write_opt_u16(dst: &mut WriteCursor<'_>, value: Option<u16>) -> EncodeResult<()> {
+    ensure_size!(in: dst, size: opt_u16_size(value));
+    match value {
+        Some(value) => {
+            dst.write_u8(1);
+            dst.write_u16(value);
+        }
+        None => dst.write_u8(0),
+    }
+    Ok(())
+}
+
+pub fn read_opt_u16(src: &mut ReadCursor<'_>) -> DecodeResult<Option<u16>> {
+    ensure_size!(in: src, size: 1);
+    match src.read_u8() {
+        0 => Ok(None),
+        1 => {
+            ensure_size!(in: src, size: 2);
+            Ok(Some(src.read_u16()))
+        }
+        _ => Err(ironrdp_core::invalid_field_err!(
+            "optional u16",
+            "invalid presence flag"
+        )),
+    }
+}

--- a/crates/ironrdp-agent/src/wire/mod.rs
+++ b/crates/ironrdp-agent/src/wire/mod.rs
@@ -44,6 +44,27 @@ pub fn read_string(src: &mut ReadCursor<'_>) -> DecodeResult<String> {
     String::from_utf8(bytes.to_vec()).map_err(|_| ironrdp_core::invalid_field_err!("string", "not valid UTF-8"))
 }
 
+/// Size on the wire of a length-prefixed raw byte blob.
+pub fn bytes_size(value: &[u8]) -> usize {
+    4 /* length prefix */ + value.len() /* raw bytes */
+}
+
+pub fn write_bytes(dst: &mut WriteCursor<'_>, value: &[u8]) -> EncodeResult<()> {
+    ensure_size!(in: dst, size: bytes_size(value));
+    let len: u32 = cast_length!("bytes length", value.len())?;
+    dst.write_u32(len);
+    dst.write_slice(value);
+    Ok(())
+}
+
+pub fn read_bytes(src: &mut ReadCursor<'_>) -> DecodeResult<Vec<u8>> {
+    ensure_size!(in: src, size: 4);
+    let len = src.read_u32();
+    let len = usize::try_from(len).map_err(|_| ironrdp_core::other_err!("bytes", "length does not fit in usize"))?;
+    ensure_size!(in: src, size: len);
+    Ok(src.read_slice(len).to_vec())
+}
+
 pub fn write_opt_string(dst: &mut WriteCursor<'_>, value: Option<&str>) -> EncodeResult<()> {
     ensure_size!(in: dst, size: 1);
     match value {

--- a/crates/ironrdp-agent/src/wire/propertyset.rs
+++ b/crates/ironrdp-agent/src/wire/propertyset.rs
@@ -1,0 +1,83 @@
+//! Binary wire codec for [`PropertySet`].
+//!
+//! This mirrors the shape of [`ironrdp_rdpfile::load`]/[`ironrdp_rdpfile::write`] but is binary and
+//! cursor-based so it composes with [`ironrdp_core`]'s `Encode`/`DecodeOwned` traits.
+//!
+//! Layout: a `u32` entry count, then for each entry a length-prefixed UTF-8 key, a 1-byte value tag
+//! (`0` = `Int`, `1` = `Str`), and the value (an `i64`, or a length-prefixed UTF-8 string).
+//!
+//! [`ironrdp_rdpfile::load`]: https://docs.rs/ironrdp-rdpfile
+
+#![cfg_attr(not(feature = "internal"), allow(unreachable_pub))]
+
+use ironrdp_core::{DecodeResult, EncodeResult, ReadCursor, WriteCursor, cast_length, ensure_size};
+use ironrdp_propertyset::{PropertySet, Value};
+
+use crate::wire::{read_string, string_size, write_string};
+
+const TAG_INT: u8 = 0;
+const TAG_STR: u8 = 1;
+
+/// Size on the wire of `properties`, for use from an enclosing `Encode::size`.
+pub fn size(properties: &PropertySet) -> usize {
+    let mut total = 4; // Entry count.
+    for (key, value) in properties.iter() {
+        total += string_size(key); // Key.
+        total += 1; // Value tag.
+        total += match value {
+            Value::Int(_) => 8,                      // i64.
+            Value::Str(value) => string_size(value), // Length-prefixed string.
+        };
+    }
+    total
+}
+
+/// Encodes `properties` into `dst`.
+pub fn write(properties: &PropertySet, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+    ensure_size!(in: dst, size: size(properties));
+
+    let count: u32 = cast_length!("property count", properties.iter().count())?;
+    dst.write_u32(count);
+
+    for (key, value) in properties.iter() {
+        write_string(dst, key)?;
+        match value {
+            Value::Int(value) => {
+                dst.write_u8(TAG_INT);
+                dst.write_i64(*value);
+            }
+            Value::Str(value) => {
+                dst.write_u8(TAG_STR);
+                write_string(dst, value)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Decodes entries from `src`, inserting them into `properties` (layering onto any existing keys,
+/// matching the contract of [`ironrdp_rdpfile::load`]).
+pub fn read(properties: &mut PropertySet, src: &mut ReadCursor<'_>) -> DecodeResult<()> {
+    ensure_size!(in: src, size: 4);
+    let count = src.read_u32();
+
+    for _ in 0..count {
+        let key = read_string(src)?;
+
+        ensure_size!(in: src, size: 1);
+        match src.read_u8() {
+            TAG_INT => {
+                ensure_size!(in: src, size: 8);
+                properties.insert(key, src.read_i64());
+            }
+            TAG_STR => {
+                let value = read_string(src)?;
+                properties.insert(key, value);
+            }
+            _ => return Err(ironrdp_core::invalid_field_err!("property value tag", "unknown tag")),
+        }
+    }
+
+    Ok(())
+}

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -556,6 +556,7 @@ pub struct ConfigBuilder {
     codecs: Vec<String>,
     autologon: Option<bool>,
     enable_server_pointer: Option<bool>,
+    pointer_software_rendering: Option<bool>,
     enable_audio_playback: Option<bool>,
     compression_type: Option<ironrdp_pdu::rdp::client_info::CompressionType>,
     compression_enabled: Option<bool>,
@@ -777,6 +778,16 @@ impl ConfigBuilder {
     pub fn with_server_pointer(mut self, enabled: bool) -> Self {
         self.enable_server_pointer = Some(enabled);
         self.properties.set_server_pointer(enabled);
+        self
+    }
+
+    /// Enable or disable software pointer rendering. When enabled, the session composites the
+    /// remote cursor directly into the decoded framebuffer (instead of emitting it as separate
+    /// pointer events for a hardware/overlay cursor). Useful for headless clients that have no
+    /// overlay of their own and want the cursor captured in the frame.
+    #[must_use]
+    pub fn with_pointer_software_rendering(mut self, enabled: bool) -> Self {
+        self.pointer_software_rendering = Some(enabled);
         self
     }
 
@@ -1161,7 +1172,7 @@ impl ConfigBuilder {
             autologon: self.autologon.unwrap_or(false),
             enable_audio_playback: self.enable_audio_playback.unwrap_or(true),
             request_data: None,
-            pointer_software_rendering: false,
+            pointer_software_rendering: self.pointer_software_rendering.unwrap_or(false),
             multitransport_flags: None,
             compression_type,
             performance_flags: PerformanceFlags::default(),

--- a/crates/ironrdp-testsuite-extra/Cargo.toml
+++ b/crates/ironrdp-testsuite-extra/Cargo.toml
@@ -26,7 +26,11 @@ anyhow = "1.0"
 async-trait = "0.1"
 ironrdp = { path = "../ironrdp", features = ["server", "pdu", "connector", "session", "dvc", "echo"] }
 ironrdp-async.path = "../ironrdp-async"
+ironrdp-agent = { path = "../ironrdp-agent", features = ["internal"] }
 ironrdp-client.path = "../ironrdp-client"
+ironrdp-core.path = "../ironrdp-core"
+ironrdp-input.path = "../ironrdp-input"
+ironrdp-propertyset.path = "../ironrdp-propertyset"
 ironrdp-viewer.path = "../ironrdp-viewer"
 ironrdp-tokio.path = "../ironrdp-tokio"
 ironrdp-tls = { path = "../ironrdp-tls", features = ["rustls"] }

--- a/crates/ironrdp-testsuite-extra/tests/agent.rs
+++ b/crates/ironrdp-testsuite-extra/tests/agent.rs
@@ -125,6 +125,7 @@ fn response_variants_round_trip() {
         Response::Ok(Payload::Screenshot {
             width: 800,
             height: 600,
+            png: vec![0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A],
         }),
         Response::Ok(Payload::Empty),
     ];
@@ -157,4 +158,19 @@ fn property_set_wire_round_trips() {
     original_pairs.sort_by_key(|(key, _)| *key);
     decoded_pairs.sort_by_key(|(key, _)| *key);
     assert_eq!(original_pairs, decoded_pairs, "property set wire round-trip mismatch");
+}
+
+#[test]
+fn bytes_wire_round_trips() {
+    let original = vec![0x89, b'P', b'N', b'G', 0x00, 0xFF, 0x10, 0x20];
+
+    let size = wire::bytes_size(&original);
+    let mut buf = vec![0u8; size];
+    let mut cursor = ironrdp_core::WriteCursor::new(&mut buf);
+    wire::write_bytes(&mut cursor, &original).expect("write_bytes");
+    assert_eq!(cursor.pos(), size, "written length must match computed size");
+
+    let mut read_cursor = ironrdp_core::ReadCursor::new(&buf);
+    let decoded = wire::read_bytes(&mut read_cursor).expect("read_bytes");
+    assert_eq!(original, decoded, "bytes wire round-trip mismatch");
 }

--- a/crates/ironrdp-testsuite-extra/tests/agent.rs
+++ b/crates/ironrdp-testsuite-extra/tests/agent.rs
@@ -1,0 +1,160 @@
+//! Codec round-trip tests for the `ironrdp-agent` IPC and wire protocols.
+//!
+//! These exercise the crate's private wire format through its public (and `internal`-feature)
+//! API. They live here, in the shared test suite, rather than inside `ironrdp-agent` itself, per
+//! the workspace convention of keeping unit tests for protocol codecs in `ironrdp-testsuite-extra`.
+
+use core::fmt::Debug;
+
+use ironrdp_agent::ipc::{
+    ConnState, KeyFilter, Payload, PropValue, PropertyDump, PropertyEntry, Request, Response, StatusInfo,
+};
+use ironrdp_agent::wire;
+use ironrdp_core::{Decode, DecodeOwned, Encode, decode, decode_owned, encode_vec};
+use ironrdp_input::MouseButton;
+use ironrdp_propertyset::PropertySet;
+
+#[track_caller]
+fn round_trip<T>(value: &T)
+where
+    T: Encode + DecodeOwned + for<'de> Decode<'de> + PartialEq + Debug,
+{
+    let bytes = encode_vec(value).expect("encode");
+
+    let decoded_owned: T = decode_owned(&bytes).expect("decode_owned");
+    assert_eq!(value, &decoded_owned, "decode_owned round-trip mismatch");
+
+    let decoded: T = decode(&bytes).expect("decode");
+    assert_eq!(value, &decoded, "decode round-trip mismatch");
+}
+
+#[test]
+fn request_variants_round_trip() {
+    let mut props = PropertySet::new();
+    props.insert("FullAddress", "host.example:3389");
+    props.insert("Username", "operator");
+
+    let mut props2 = PropertySet::new();
+    props2.insert("FullAddress", "host.example:3389");
+
+    let requests = [
+        Request::Connect {
+            properties: props,
+            log_directive: None,
+        },
+        Request::Connect {
+            properties: props2,
+            log_directive: Some("ironrdp_connector=trace,debug".to_owned()),
+        },
+        Request::Disconnect,
+        Request::Status,
+        Request::QueryProps { filter: None },
+        Request::QueryProps {
+            filter: Some(KeyFilter::Substring("addr".to_owned())),
+        },
+        Request::QueryProps {
+            filter: Some(KeyFilter::Prefix("Full".to_owned())),
+        },
+        Request::QueryLogs {
+            substring: Some("error".to_owned()),
+            last: Some(50),
+        },
+        Request::QueryLogs {
+            substring: None,
+            last: None,
+        },
+        Request::Screenshot,
+        Request::MouseMove { x: 640, y: 480 },
+        Request::MouseButton {
+            button: MouseButton::Right,
+            pressed: true,
+        },
+        Request::Wheel {
+            delta: -120,
+            horizontal: false,
+        },
+        Request::KeyScancode {
+            scancode: 0x1C,
+            pressed: false,
+        },
+        Request::KeyUnicode {
+            ch: '\u{00e9}',
+            pressed: true,
+        },
+    ];
+
+    for request in &requests {
+        round_trip(request);
+    }
+}
+
+#[test]
+fn response_variants_round_trip() {
+    let responses = [
+        Response::ok(),
+        Response::error("connection refused"),
+        Response::Ok(Payload::Status(StatusInfo {
+            state: ConnState::NoSession,
+            destination: None,
+            width: None,
+            height: None,
+            message: None,
+            credentials_loaded: true,
+        })),
+        Response::Ok(Payload::Status(StatusInfo {
+            state: ConnState::Connected,
+            destination: Some("host.example:3389".to_owned()),
+            width: Some(1920),
+            height: Some(1080),
+            message: Some("ok".to_owned()),
+            credentials_loaded: false,
+        })),
+        Response::Ok(Payload::Properties(PropertyDump {
+            entries: vec![
+                PropertyEntry {
+                    key: "FullAddress".to_owned(),
+                    value: PropValue::Str("host.example:3389".to_owned()),
+                },
+                PropertyEntry {
+                    key: "ServerPort".to_owned(),
+                    value: PropValue::Int(3389),
+                },
+            ],
+        })),
+        Response::Ok(Payload::Logs(vec!["line one".to_owned(), "line two".to_owned()])),
+        Response::Ok(Payload::Screenshot {
+            width: 800,
+            height: 600,
+        }),
+        Response::Ok(Payload::Empty),
+    ];
+
+    for response in &responses {
+        round_trip(response);
+    }
+}
+
+#[test]
+fn property_set_wire_round_trips() {
+    let mut original = PropertySet::new();
+    original.insert("FullAddress", "host.example:3389");
+    original.insert("ServerPort", 3389i64);
+    original.insert("Username", "operator");
+    original.insert("ScreenModeId", 2i64);
+
+    let size = wire::propertyset::size(&original);
+    let mut buf = vec![0u8; size];
+    let mut cursor = ironrdp_core::WriteCursor::new(&mut buf);
+    wire::propertyset::write(&original, &mut cursor).expect("write");
+    assert_eq!(cursor.pos(), size, "written length must match computed size");
+
+    let mut decoded = PropertySet::new();
+    let mut read_cursor = ironrdp_core::ReadCursor::new(&buf);
+    wire::propertyset::read(&mut decoded, &mut read_cursor).expect("read");
+
+    let mut original_pairs: Vec<_> = original.iter().collect();
+    let mut decoded_pairs: Vec<_> = decoded.iter().collect();
+    original_pairs.sort_by_key(|(key, _)| *key);
+    decoded_pairs.sort_by_key(|(key, _)| *key);
+    assert_eq!(original_pairs, decoded_pairs, "property set wire round-trip mismatch");
+}

--- a/crates/ironrdp-testsuite-extra/tests/agent.rs
+++ b/crates/ironrdp-testsuite-extra/tests/agent.rs
@@ -31,11 +31,11 @@ where
 #[test]
 fn request_variants_round_trip() {
     let mut props = PropertySet::new();
-    props.insert("FullAddress", "host.example:3389");
-    props.insert("Username", "operator");
+    props.insert("full address", "host.example:3389");
+    props.insert("username", "operator");
 
     let mut props2 = PropertySet::new();
-    props2.insert("FullAddress", "host.example:3389");
+    props2.insert("full address", "host.example:3389");
 
     let requests = [
         Request::Connect {
@@ -112,11 +112,11 @@ fn response_variants_round_trip() {
         Response::Ok(Payload::Properties(PropertyDump {
             entries: vec![
                 PropertyEntry {
-                    key: "FullAddress".to_owned(),
+                    key: "full address".to_owned(),
                     value: PropValue::Str("host.example:3389".to_owned()),
                 },
                 PropertyEntry {
-                    key: "ServerPort".to_owned(),
+                    key: "server port".to_owned(),
                     value: PropValue::Int(3389),
                 },
             ],
@@ -138,10 +138,10 @@ fn response_variants_round_trip() {
 #[test]
 fn property_set_wire_round_trips() {
     let mut original = PropertySet::new();
-    original.insert("FullAddress", "host.example:3389");
-    original.insert("ServerPort", 3389i64);
-    original.insert("Username", "operator");
-    original.insert("ScreenModeId", 2i64);
+    original.insert("full address", "host.example:3389");
+    original.insert("server port", 3389i64);
+    original.insert("username", "operator");
+    original.insert("screen mode id", 2i64);
 
     let size = wire::propertyset::size(&original);
     let mut buf = vec![0u8; size];

--- a/crates/ironrdp-testsuite-extra/tests/main.rs
+++ b/crates/ironrdp-testsuite-extra/tests/main.rs
@@ -1,5 +1,6 @@
 #![allow(unused_crate_dependencies)] // false positives because there is both a library and a binary
 #![allow(clippy::unwrap_used, reason = "unwrap is fine in tests")]
 
+mod agent;
 mod client_config;
 mod e2e;


### PR DESCRIPTION
Add a CLI-driven, daemon-backed RDP client designed for programmatic
(e.g. LLM) consumption. A single binary plays two roles: a long-lived
daemon that owns the ironrdp-client engine and one RDP session, and a
short-lived CLI that drives it over a local IPC transport (Unix domain
socket / Windows named pipe).

Highlights:
- Binary, length-delimited IPC protocol using ironrdp-core's
  Encode/Decode traits (no JSON). Connection config travels as a
  binary-encoded PropertySet inside a strictly-typed Request::Connect;
  runtime input/query operations are strictly-typed messages.
- Secrets never reach the IPC reader: ConfigBuilder::build strips every
  ironrdp_cfg::is_secret_key property, and the daemon seeds its live bag
  from the post-build config, so dumps/status/logs cannot leak them.
- Operator overlay: daemon-start --overlay FILE preloads a .rdp file
  applied on top of every connect (overlay wins) to provision any
  setting out of band, credentials in particular. Status reports
  credentials_loaded so a caller knows whether it must supply a password.
- Separate logging: the daemon's own logs go to stderr (default INFO,
  IRONRDP_LOG), while each RDP session's logs are captured into a small
  queryable ring buffer (default DEBUG) via a thread-local subscriber,
  refinable per-connect with --log-directive for troubleshooting.
- --help-agent prints a structured, LLM-friendly operation guide.
