### PR TITLE
fix(session): decode RGBA QOI bitmaps instead of dropping the frame

### DIFF
--- a/crates/ironrdp-session/src/fast_path.rs
+++ b/crates/ironrdp-session/src/fast_path.rs
@@ -552,19 +552,15 @@ fn qoi_apply(
     update_rectangle: &mut Option<InclusiveRectangle>,
 ) -> SessionResult<()> {
     let (header, decoded) = qoi::decode_to_vec(data).map_err(|e| reason_err!("QOI decode", "{}", e))?;
-    match header.channels {
-        qoi::Channels::Rgb => {
-            let rectangle = image.apply_rgb24(&decoded, &destination, false)?;
+    let rectangle = match header.channels {
+        qoi::Channels::Rgb => image.apply_rgb24(&decoded, &destination, false)?,
+        qoi::Channels::Rgba => image.apply_rgba32(&decoded, &destination, false)?,
+    };
 
-            *update_rectangle = update_rectangle
-                .as_ref()
-                .map(|rect: &InclusiveRectangle| rect.union(&rectangle))
-                .or(Some(rectangle));
-        }
-        qoi::Channels::Rgba => {
-            warn!("Unsupported RGBA QOI data");
-        }
-    }
+    *update_rectangle = update_rectangle
+        .as_ref()
+        .map(|rect: &InclusiveRectangle| rect.union(&rectangle))
+        .or(Some(rectangle));
     Ok(())
 }
 

--- a/crates/ironrdp-session/src/fast_path.rs
+++ b/crates/ironrdp-session/src/fast_path.rs
@@ -552,6 +552,30 @@ fn qoi_apply(
     update_rectangle: &mut Option<InclusiveRectangle>,
 ) -> SessionResult<()> {
     let (header, decoded) = qoi::decode_to_vec(data).map_err(|e| reason_err!("QOI decode", "{}", e))?;
+
+    // Guard against a decoded buffer that doesn't match the destination
+    // rectangle. `apply_rgb24`/`apply_rgba32` derive the row count from the
+    // decoded length, and the only bounds check downstream (`rect_fits`)
+    // validates the rectangle against the image, not the buffer against the
+    // rectangle. A malformed/oversized QOI payload would otherwise drive the
+    // per-row index past `self.data` and panic (client-side DoS).
+    let channels = match header.channels {
+        qoi::Channels::Rgb => 3,
+        qoi::Channels::Rgba => 4,
+    };
+    let expected = usize::from(destination.width()) * usize::from(destination.height()) * channels;
+    if decoded.len() != expected {
+        return Err(reason_err!(
+            "QOI decode",
+            "decoded {} bytes, expected {} for {}x{} ({} channels)",
+            decoded.len(),
+            expected,
+            destination.width(),
+            destination.height(),
+            channels
+        ));
+    }
+
     let rectangle = match header.channels {
         qoi::Channels::Rgb => image.apply_rgb24(&decoded, &destination, false)?,
         qoi::Channels::Rgba => image.apply_rgba32(&decoded, &destination, false)?,

--- a/crates/ironrdp-session/src/image.rs
+++ b/crates/ironrdp-session/src/image.rs
@@ -809,6 +809,68 @@ impl DecodedImage {
         }
     }
 
+    #[cfg(feature = "qoi")]
+    fn apply_rgba32_iter<'a, I>(
+        &mut self,
+        rgba32: I,
+        update_rectangle: &InclusiveRectangle,
+    ) -> SessionResult<InclusiveRectangle>
+    where
+        I: Iterator<Item = &'a [u8]>,
+    {
+        if !self.rect_fits(update_rectangle) {
+            debug!(
+                "Skipping rgba32 update {:?} outside image bounds {}x{}",
+                update_rectangle, self.width, self.height,
+            );
+            return Ok(InclusiveRectangle::empty());
+        }
+
+        const SRC_COLOR_DEPTH: usize = 4;
+        const DST_COLOR_DEPTH: usize = 4;
+
+        let image_width = usize::from(self.width);
+        let top = usize::from(update_rectangle.top);
+        let left = usize::from(update_rectangle.left);
+        let [ri, gi, bi, ai] = self.pixel_format.channel_offsets();
+
+        let pointer_rendering_state = self.pointer_rendering_begin(update_rectangle)?;
+
+        rgba32.enumerate().for_each(|(row_idx, row)| {
+            row.chunks_exact(SRC_COLOR_DEPTH)
+                .enumerate()
+                .for_each(|(col_idx, src_pixel)| {
+                    let dst_idx = ((top + row_idx) * image_width + left + col_idx) * DST_COLOR_DEPTH;
+
+                    self.data[dst_idx + ri] = src_pixel[0];
+                    self.data[dst_idx + gi] = src_pixel[1];
+                    self.data[dst_idx + bi] = src_pixel[2];
+                    self.data[dst_idx + ai] = src_pixel[3];
+                })
+        });
+
+        let update_rectangle = self.pointer_rendering_end(pointer_rendering_state)?;
+
+        Ok(update_rectangle)
+    }
+
+    #[cfg(feature = "qoi")]
+    pub(crate) fn apply_rgba32(
+        &mut self,
+        rgba32: &[u8],
+        update_rectangle: &InclusiveRectangle,
+        flip: bool,
+    ) -> SessionResult<InclusiveRectangle> {
+        const SRC_COLOR_DEPTH: usize = 4;
+        let rectangle_width = usize::from(update_rectangle.width());
+        let lines = rgba32.chunks_exact(rectangle_width * SRC_COLOR_DEPTH);
+        if flip {
+            self.apply_rgba32_iter(lines.rev(), update_rectangle)
+        } else {
+            self.apply_rgba32_iter(lines, update_rectangle)
+        }
+    }
+
     pub(crate) fn apply_rgb32_bitmap(
         &mut self,
         rgb32: &[u8],


### PR DESCRIPTION
Companion to [#1335](https://github.com/Devolutions/IronRDP/pull/1335) on the client side. Addresses @elmarco's review comment on that PR: *"if the server is correctly encoding RGBA bitmap, why not fix the client instead?"* — short answer: doing both, because they fix different things and reinforce each other (server-side is also a bandwidth optimization, client-side is correctness against third-party RDP servers).

## What's broken

In `crates/ironrdp-session/src/fast_path.rs::qoi_apply`, the `Channels::Rgba` arm is literally:

```rust
qoi::Channels::Rgba => {
    warn!("Unsupported RGBA QOI data");
}
```

So any server that emits an `*a`-channel QOI header — which is the natural mapping from a `BgrA32` / `ARgb32` / etc. screen capture in `ironrdp-server::encoder::qoi_encode` today — gets one warning per frame and a blank window on the viewer. #1335 fixes the server side of that for the in-tree `ironrdp-server`. But:

1. There's nothing in the QOI codec spec that forbids `Channels::Rgba`. A third-party RDP server that genuinely cares about alpha (layered composition, premultiplied content from a different capture path, etc.) is well within its rights to emit it.
2. Until #1335 lands **and** ships in a published `ironrdp-server` release, every other `ironrdp-server` consumer in the wild keeps emitting RGBA QOI. Clients carrying this patch render those sessions correctly; clients without it don't.

So the client-side fix is the durable one. The server-side fix in #1335 stands on its own merits (it's a bandwidth optimization — opaque-capture alpha is always `0xFF` and costs one byte per QOI literal chunk for zero information).

## Fix

Mirror the existing `apply_rgb24` / `apply_rgb24_iter` pair with a 4-bytes-per-pixel `apply_rgba32` / `apply_rgba32_iter` that passes the alpha byte through to the framebuffer (instead of forcing `0xFF` the way the rgb24 path does), and call it from the QOI Rgba arm. The Rgb arm is unchanged.

The screen framebuffer is a flat RGBA blit target with no blending, so for an opaque-capture server (everything carrying #1335, plus all current in-tree servers) the only observable effect is that the warning is gone and the frame renders. For a server that legitimately encodes translucent content, the alpha byte is now preserved end-to-end.

## Reproduction (before the fix)

Built `ironrdp-viewer` with `--features qoi` and pointed it at `macrdp` 0.5.50 with its vendored QOI Rgb-only workaround disabled (so it emits the natural RGBA mapping):

```
$ ironrdp-viewer 127.0.0.1:3390 -u $USER -p ...
WARN ironrdp_session::fast_path: Unsupported RGBA QOI data
WARN ironrdp_session::fast_path: Unsupported RGBA QOI data
... (412 warnings in ~12s; viewer renders nothing)
```

## After the fix

Same loopback session against the same `macrdp` build, no other changes:

- 0 `Unsupported RGBA QOI data` warnings
- viewer renders the desktop normally
- visual quality is identical to the pre-#1335 Rgb path (alpha is ignored by the framebuffer either way)

## Test plan

- [x] `cargo build -p ironrdp-session --features qoi` — clean
- [x] `cargo clippy -p ironrdp-session --features qoi --all-targets -- -D warnings` — clean (only pre-existing repo-wide MSRV-mismatch notice)
- [x] `cargo test -p ironrdp-session --features qoi` — clean
- [x] `cargo fmt --check` — clean
- [x] Loopback `ironrdp-viewer --features qoi` against a `macrdp` build emitting RGBA QOI: desktop renders, zero RGBA warnings

## Notes

- `apply_rgba32` takes the same `flip` parameter shape as `apply_rgb24` for symmetry; QOI calls it with `flip = false`.
- No format/codec advertisement changes — the client already accepts QOI without distinguishing Rgb vs. Rgba in the capability set. Only the apply path changes.
- If #1335 lands first, this PR still has value as the durable correctness fix described above.