### PR TITLE
docs(rdpsnd): document RdpsndServerHandler::start wFormatNo contract

### DIFF
--- a/crates/ironrdp-rdpsnd/src/server.rs
+++ b/crates/ironrdp-rdpsnd/src/server.rs
@@ -28,11 +28,37 @@ pub enum RdpsndServerMessage {
     Error(Box<dyn RdpsndError>),
 }
 
+/// Handler for the server side of the Audio Output Virtual Channel (`RDPSND`).
+///
+/// Implementations supply the list of audio formats the server offers, decide
+/// which format to use once the client replies, and produce the audio waves to
+/// stream (via [`RdpsndServer::wave`]).
 pub trait RdpsndServerHandler: Send + core::fmt::Debug {
+    /// The audio formats the server advertises in the Server Audio Formats and
+    /// Version PDU (MS-RDPEA 2.2.2.1).
     fn get_formats(&self) -> &[pdu::AudioFormat];
 
+    /// Called once the client has replied with the formats it accepts
+    /// (`client_format`, the Client Audio Formats and Version PDU). Returns the
+    /// `wFormatNo` to stamp on every subsequent Wave/Wave2 PDU, or [`None`] if
+    /// no offered format is acceptable (no audio is then streamed).
+    ///
+    /// **The returned index addresses `client_format.formats` — the formats the
+    /// client just echoed back — NOT the server's own [`get_formats`] list.**
+    /// The client resolves each wave's format as `ClientFormats[wFormatNo]`
+    /// against the list *it* sent, and a compliant client rejects any
+    /// `wFormatNo >= client_format.formats.len()`, silently dropping all audio.
+    /// The client's list is its accepted subset of the server's formats, so the
+    /// two lists generally differ in both length and ordering; an index into
+    /// [`get_formats`] only happens to work when the chosen format sits at the
+    /// same position in both. Pick the format you intend to send, then return
+    /// its position within `client_format.formats`.
+    ///
+    /// [`get_formats`]: RdpsndServerHandler::get_formats
     fn start(&mut self, client_format: &ClientAudioFormatPdu) -> Option<u16>;
 
+    /// Called when the audio stream is torn down (e.g. the client closed the
+    /// channel or the session ended).
     fn stop(&mut self);
 }
 


### PR DESCRIPTION
## What

`RdpsndServerHandler` and its methods are currently undocumented. This PR adds rustdoc to the trait, with the load-bearing detail on `start`'s return value.

## Why

The `Option<u16>` returned by `start` is stamped **directly** onto every `Wave`/`Wave2` PDU as `wFormatNo` (`RdpsndServer::wave`). The non-obvious part — with no doc to warn you — is *which list that index addresses*:

- A compliant client resolves each wave's format as `ClientFormats[wFormatNo]` against the list **it** sent in the Client Audio Formats PDU, and rejects any `wFormatNo >= NumberOfClientFormats`. FreeRDP does exactly this in [`rdpsnd_recv_wave2_pdu`](https://github.com/FreeRDP/FreeRDP/blob/master/channels/rdpsnd/client/rdpsnd_main.c) (and `rdpsnd_recv_wave_info_pdu`) — out-of-range is dropped, so **all audio silently disappears**.
- The client's list is its accepted *subset* of the server's offered formats, so it generally differs from `get_formats()` in both length and order. Returning a `get_formats()` index only works when the chosen format happens to sit at the same position in both lists.

This bites the moment a handler offers more than one format and a client accepts only some of them: indexing `get_formats()` sends the wrong (or out-of-range) `wFormatNo`, and the failure mode is silent — no error, just no sound. We hit this in a downstream server when adding a second (AAC) format alongside PCM: mstsc kept working (it lists the chosen format at the same index in both), but FreeRDP/Thincast clients that accepted only PCM got an out-of-range index and went silent. Picking the format and then returning its position within `client_format.formats` fixes it.

The doc makes the contract explicit so the next implementer doesn't have to rediscover it from a wire capture.

## Notes

- Docs only — no behavior change.
- `cargo check -p ironrdp-rdpsnd` and `RUSTDOCFLAGS="-D warnings" cargo doc -p ironrdp-rdpsnd --no-deps` both pass; no reformatting from `cargo fmt`.
- Possible follow-up (happy to discuss separately): make the contract harder to get wrong by having `start` return the chosen `AudioFormat` (or its `client_format.formats` index) and letting the crate compute/validate `wFormatNo`. That's an API/semver change, so I kept this PR to docs only.