### PR TITLE
feat(egfx)!: surface total_frames_decoded on the frame-ack callback

### DIFF
--- a/crates/ironrdp-egfx/src/server.rs
+++ b/crates/ironrdp-egfx/src/server.rs
@@ -767,7 +767,10 @@ pub trait GraphicsPipelineHandler: Send {
     fn on_ready(&mut self, negotiated: &CapabilitySet);
 
     /// Called when a frame has been acknowledged by the client
-    fn on_frame_ack(&mut self, _frame_id: u32, _queue_depth: u32) {}
+    ///
+    /// `total_frames_decoded` is the client's running decoded-frame count
+    /// (MS-RDPEGFX 2.2.2.13), for decode-backlog flow control.
+    fn on_frame_ack(&mut self, _frame_id: u32, _queue_depth: u32, _total_frames_decoded: u32) {}
 
     /// Called when QoE metrics are received from client (V10+)
     fn on_qoe_metrics(&mut self, _metrics: QoeMetrics) {}
@@ -1685,7 +1688,8 @@ impl GraphicsPipelineServer {
             trace!(frame_id = pdu.frame_id, latency = ?rtt);
         }
 
-        self.handler.on_frame_ack(pdu.frame_id, queue_depth);
+        self.handler
+            .on_frame_ack(pdu.frame_id, queue_depth, pdu.total_frames_decoded);
     }
 
     fn handle_qoe_frame_acknowledge(&mut self, pdu: QoeFrameAcknowledgePdu) {

--- a/crates/ironrdp-egfx/src/server.rs
+++ b/crates/ironrdp-egfx/src/server.rs
@@ -770,7 +770,11 @@ pub trait GraphicsPipelineHandler: Send {
     ///
     /// `total_frames_decoded` is the client's running decoded-frame count
     /// (MS-RDPEGFX 2.2.2.13), for decode-backlog flow control.
-    fn on_frame_ack(&mut self, _frame_id: u32, _queue_depth: u32, _total_frames_decoded: u32) {}
+    fn on_frame_ack(&mut self, frame_id: u32, queue_depth: u32, total_frames_decoded: u32) {
+        let _ = frame_id;
+        let _ = queue_depth;
+        let _ = total_frames_decoded;
+    }
 
     /// Called when QoE metrics are received from client (V10+)
     fn on_qoe_metrics(&mut self, _metrics: QoeMetrics) {}

--- a/crates/ironrdp-testsuite-core/tests/egfx/server.rs
+++ b/crates/ironrdp-testsuite-core/tests/egfx/server.rs
@@ -13,7 +13,7 @@ use ironrdp_egfx::server::{GraphicsPipelineHandler, GraphicsPipelineServer, QoeM
 struct TestHandler {
     ready_called: bool,
     negotiated: Option<CapabilitySet>,
-    frame_acks: Vec<(u32, u32)>,
+    frame_acks: Vec<(u32, u32, u32)>,
     surfaces_created: Vec<u16>,
     surfaces_deleted: Vec<u16>,
 }
@@ -38,8 +38,8 @@ impl GraphicsPipelineHandler for TestHandler {
         self.negotiated = Some(negotiated.clone());
     }
 
-    fn on_frame_ack(&mut self, frame_id: u32, queue_depth: u32) {
-        self.frame_acks.push((frame_id, queue_depth));
+    fn on_frame_ack(&mut self, frame_id: u32, queue_depth: u32, total_frames_decoded: u32) {
+        self.frame_acks.push((frame_id, queue_depth, total_frames_decoded));
     }
 
     fn on_qoe_metrics(&mut self, _metrics: QoeMetrics) {}


### PR DESCRIPTION
Summary

GraphicsPipelineHandler::on_frame_ack already receives frame_id and queue_depth, but handle_frame_acknowledge drops the third field the client sends in FrameAcknowledgePdu (MS-RDPEGFX 2.2.2.13): total_frames_decoded, the client's running decoded-frame count. encoded_count - total_frames_decoded is an instant measure of the client's decode backlog, which a server needs for closed-loop EGFX flow control. Issue #790 (ironrdp-web becomes unresponsive under rapid framebuffer updates) is the user-facing symptom of having no such signal.

This extends on_frame_ack to pass total_frames_decoded through. The field is already decoded; the handler just dropped it before the callback. ironrdp-egfx is unpublished (publish = false), so the breaking signature change has no external SemVer impact; the only in-tree consumers are the trait default and the egfx testsuite handler, both updated here. ironrdp-server inherits the default and is unchanged.

Validation

cargo xtask check fmt/lints/tests/typos/locks all pass.

Notes

Breaking on the GraphicsPipelineHandler trait (hence feat!), scoped to ironrdp-egfx plus its testsuite. This surfaces the field only; it adds no flow-control policy.
