### PR TITLE
feat(acceptor): negotiate the MCS message channel

### DIFF
--- a/crates/ironrdp-acceptor/src/connection.rs
+++ b/crates/ironrdp-acceptor/src/connection.rs
@@ -29,6 +29,7 @@ pub struct Acceptor {
     security: SecurityProtocol,
     io_channel_id: u16,
     user_channel_id: u16,
+    message_channel_id: Option<u16>,
     desktop_size: DesktopSize,
     server_capabilities: Vec<CapabilitySet>,
     static_channels: StaticChannelSet,
@@ -45,6 +46,13 @@ pub struct AcceptorResult {
     pub input_events: Vec<Vec<u8>>,
     pub user_channel_id: u16,
     pub io_channel_id: u16,
+    /// MCS channel ID of the message channel, present when the client requested
+    /// one via Client Message Channel Data (section 2.2.1.3.7).
+    ///
+    /// Server-initiated PDUs that ride the message channel (network auto-detect
+    /// per section 2.2.14, multitransport bootstrap, heartbeat) are sent on this
+    /// channel. `None` when the client did not request it.
+    pub message_channel_id: Option<u16>,
     pub reactivation: bool,
     /// Credentials received from the client during SecureSettingsExchange.
     ///
@@ -69,6 +77,7 @@ impl Acceptor {
             state: AcceptorState::InitiationWaitRequest,
             user_channel_id: USER_CHANNEL_ID,
             io_channel_id: IO_CHANNEL_ID,
+            message_channel_id: None,
             desktop_size,
             server_capabilities: capabilities,
             static_channels: StaticChannelSet::new(),
@@ -111,6 +120,7 @@ impl Acceptor {
             state,
             user_channel_id: consumed.user_channel_id,
             io_channel_id: consumed.io_channel_id,
+            message_channel_id: consumed.message_channel_id,
             desktop_size,
             server_capabilities: consumed.server_capabilities,
             static_channels,
@@ -170,6 +180,7 @@ impl Acceptor {
                 input_events,
                 user_channel_id: self.user_channel_id,
                 io_channel_id: self.io_channel_id,
+                message_channel_id: self.message_channel_id,
                 reactivation: self.reactivation,
                 credentials: self.received_credentials.take(),
             }),
@@ -364,7 +375,7 @@ impl Sequence for Acceptor {
                     ));
                 };
                 let connection_confirm = nego::ConnectionConfirm::Response {
-                    flags: nego::ResponseFlags::empty(),
+                    flags: nego::ResponseFlags::EXTENDED_CLIENT_DATA_SUPPORTED,
                     protocol,
                 };
 
@@ -426,6 +437,7 @@ impl Sequence for Acceptor {
 
                 let gcc_blocks = settings_initial.conference_create_request.into_gcc_blocks();
                 let early_capability = gcc_blocks.core.optional_data.early_capability_flags;
+                let client_wants_message_channel = gcc_blocks.message_channel.is_some();
 
                 let joined: Vec<_> = gcc_blocks
                     .network
@@ -443,7 +455,7 @@ impl Sequence for Acceptor {
                     .unwrap_or_default();
 
                 #[expect(clippy::arithmetic_side_effects)] // IO channel ID is not big enough for overflowing.
-                let channels = joined
+                let channels: Vec<_> = joined
                     .into_iter()
                     .enumerate()
                     .map(|(i, channel)| {
@@ -456,6 +468,16 @@ impl Sequence for Acceptor {
                         }
                     })
                     .collect();
+
+                if client_wants_message_channel {
+                    // Allocate the message channel ID after the I/O channel and
+                    // any static virtual channels. It is advertised in Server
+                    // Message Channel Data and joined alongside the others.
+                    #[expect(clippy::arithmetic_side_effects)] // IO channel ID is not big enough for overflowing.
+                    let channel_id =
+                        u16::try_from(channels.len()).expect("always in the range") + self.io_channel_id + 1;
+                    self.message_channel_id = Some(channel_id);
+                }
 
                 (
                     Written::Nothing,
@@ -484,6 +506,7 @@ impl Sequence for Acceptor {
                     channel_ids.clone(),
                     requested_protocol,
                     skip_channel_join,
+                    self.message_channel_id,
                 );
 
                 let settings_response = mcs::ConnectResponse {
@@ -507,7 +530,9 @@ impl Sequence for Acceptor {
                         connection: if skip_channel_join {
                             ChannelConnectionSequence::skip_channel_join(self.user_channel_id)
                         } else {
-                            ChannelConnectionSequence::new(self.user_channel_id, self.io_channel_id, channel_ids)
+                            let mut join_channel_ids = channel_ids;
+                            join_channel_ids.extend(self.message_channel_id);
+                            ChannelConnectionSequence::new(self.user_channel_id, self.io_channel_id, join_channel_ids)
                         },
                     },
                 )
@@ -781,6 +806,7 @@ fn create_gcc_blocks(
     channel_ids: Vec<u16>,
     requested: SecurityProtocol,
     skip_channel_join: bool,
+    message_channel_id: Option<u16>,
 ) -> gcc::ServerGccBlocks {
     gcc::ServerGccBlocks {
         core: gcc::ServerCoreData {
@@ -796,7 +822,9 @@ fn create_gcc_blocks(
             channel_ids,
             io_channel,
         },
-        message_channel: None,
+        message_channel: message_channel_id.map(|id| gcc::ServerMessageChannelData {
+            mcs_message_channel_id: id,
+        }),
         multi_transport_channel: None,
     }
 }

--- a/crates/ironrdp-testsuite-core/tests/server/acceptor.rs
+++ b/crates/ironrdp-testsuite-core/tests/server/acceptor.rs
@@ -1,8 +1,11 @@
 use ironrdp_acceptor::Acceptor;
-use ironrdp_connector::{DesktopSize, Sequence as _, Written};
+use ironrdp_connector::{DesktopSize, Sequence as _, Written, encode_x224_packet};
 use ironrdp_core::{WriteBuf, decode};
+use ironrdp_pdu::gcc::ClientMessageChannelData;
+use ironrdp_pdu::mcs::{self, ConnectInitial};
 use ironrdp_pdu::nego::{self, SecurityProtocol};
-use ironrdp_pdu::x224::X224;
+use ironrdp_pdu::x224::{X224, X224Data};
+use ironrdp_testsuite_core::gcc::CLIENT_GCC_WITHOUT_OPTIONAL_FIELDS;
 
 /// Build a minimal ConnectionRequest with the given protocols and encode it.
 fn encode_connection_request(protocol: SecurityProtocol) -> Vec<u8> {
@@ -83,13 +86,72 @@ fn neg_success_when_protocols_match() {
     let response_bytes = output.filled();
     let confirm = decode::<X224<nego::ConnectionConfirm>>(response_bytes).unwrap().0;
     match confirm {
-        nego::ConnectionConfirm::Response { protocol, .. } => {
+        nego::ConnectionConfirm::Response { protocol, flags } => {
             assert_eq!(protocol, SecurityProtocol::SSL);
+            // The acceptor advertises support for Extended Client Data Blocks so the
+            // client sends its Client Message Channel Data, enabling the message
+            // channel to be negotiated.
+            assert!(flags.contains(nego::ResponseFlags::EXTENDED_CLIENT_DATA_SUPPORTED));
         }
         nego::ConnectionConfirm::Failure { .. } => {
             panic!("expected Response, got Failure");
         }
     }
+}
+
+/// When the client advertises the message channel (Client Message Channel Data),
+/// the acceptor allocates an MCS channel ID for it and returns it in Server
+/// Message Channel Data. The ID is allocated after the I/O channel and any
+/// static virtual channels, so the expected value is derived from the server's
+/// network block rather than hard-coded.
+#[test]
+fn message_channel_advertised_when_client_requests_it() {
+    let mut acceptor = Acceptor::new(
+        SecurityProtocol::SSL,
+        DesktopSize {
+            width: 1920,
+            height: 1080,
+        },
+        Vec::new(),
+        None,
+    );
+
+    // Connection request -> confirm -> (TLS upgrade) -> ready for ConnectInitial.
+    let request_bytes = encode_connection_request(SecurityProtocol::SSL);
+    acceptor.step(&request_bytes, &mut WriteBuf::new()).unwrap();
+    acceptor.step(&[], &mut WriteBuf::new()).unwrap();
+    acceptor.mark_security_upgrade_as_done();
+
+    // Client GCC with the message channel block and no network channels, so the
+    // allocated ID is deterministic.
+    let mut blocks = CLIENT_GCC_WITHOUT_OPTIONAL_FIELDS.clone();
+    blocks.network = None;
+    blocks.message_channel = Some(ClientMessageChannelData);
+    let connect_initial = ConnectInitial::with_gcc_blocks(blocks).unwrap();
+    let mut initial_buf = WriteBuf::new();
+    encode_x224_packet(&connect_initial, &mut initial_buf).unwrap();
+
+    acceptor.step(initial_buf.filled(), &mut WriteBuf::new()).unwrap();
+
+    let mut output = WriteBuf::new();
+    acceptor.step(&[], &mut output).unwrap();
+
+    let payload = decode::<X224<X224Data<'_>>>(output.filled()).unwrap().0;
+    let response = decode::<mcs::ConnectResponse>(payload.data.as_ref()).unwrap();
+    let server_blocks = response.conference_create_response.gcc_blocks();
+
+    let message_channel = server_blocks
+        .message_channel
+        .as_ref()
+        .expect("acceptor must advertise Server Message Channel Data");
+
+    // The message channel is allocated after the I/O channel and any static
+    // virtual channels, so derive the expected ID from the server's network
+    // block instead of coupling the assertion to the I/O channel base.
+    let network = &server_blocks.network;
+    let channel_count = u16::try_from(network.channel_ids.len()).expect("channel count fits in u16");
+    let expected = network.io_channel + channel_count + 1;
+    assert_eq!(message_channel.mcs_message_channel_id, expected);
 }
 
 /// When server requires HYBRID but client only offers SSL, the failure code


### PR DESCRIPTION
The acceptor never advertised support for Extended Client Data Blocks, so a
spec-compliant client withheld its Client Message Channel Data and the MCS
message channel was never negotiated. Server-initiated PDUs that must ride the
message channel per MS-RDPBCGR (network auto-detect in section 2.2.14,
multitransport bootstrap, heartbeat) therefore had no transport.

This change:

- Sets the EXTENDED_CLIENT_DATA_SUPPORTED flag in the RDP Negotiation Response
  so the client sends Client Message Channel Data (section 2.2.1.3.7).
- When the client requests the message channel, allocates an MCS channel ID for
  it after the I/O channel and any static virtual channels, and returns it in
  Server Message Channel Data (section 2.2.1.4.5).
- Joins the message channel during the MCS channel join phase (skipped when the
  client advertises SUPPORT_SKIP_CHANNELJOIN).
- Surfaces the allocated ID on AcceptorResult so a server can route the PDUs
  that ride this channel.

The immediate consumer is server-side network auto-detect, which a follow-up
will frame correctly and route over this channel. AcceptorResult gains a
message_channel_id field, mirroring the additive shape of the credentials field
added in #1155.

Tested in crates/ironrdp-testsuite-core/tests/server/acceptor.rs: the test
drives the acceptor to the ConnectResponse and asserts Server Message Channel
Data is advertised with the allocated ID, plus the EXTENDED_CLIENT_DATA_SUPPORTED
flag on the connection confirm.
