### PR TITLE
fix(pdu): tolerate unknown GCC user-data blocks instead of failing

### DIFF
--- a/crates/ironrdp-pdu/src/gcc/mod.rs
+++ b/crates/ironrdp-pdu/src/gcc/mod.rs
@@ -149,7 +149,17 @@ impl<'de> Decode<'de> for ClientGccBlocks {
         let mut monitor_extended = None;
 
         loop {
-            let (ty, cur) = user_header_try!(UserDataHeader::decode(src));
+            let (raw_ty, cur) = user_header_try!(UserDataHeader::decode_raw(src));
+            let Some(ty) = ClientGccType::from_u16(raw_ty) else {
+                // Forward-compat: a user-data block with a type IronRDP does not
+                // model is skipped rather than rejected. The block table in
+                // MS-RDPBCGR 2.2.1.3.1 is not closed: current Microsoft clients
+                // emit blocks absent from the public spec (e.g. 0xC00D from
+                // recent mstsc/Windows App, mirroring the historical 0xC009 sent
+                // by the Lync client), and rejecting them would break the
+                // connection. The block length lets us advance past the body.
+                continue;
+            };
 
             match ty {
                 ClientGccType::CoreData => core = Some(decode(cur)?),
@@ -160,6 +170,8 @@ impl<'de> Decode<'de> for ClientGccBlocks {
                 ClientGccType::MessageChannelData => message_channel = Some(decode(cur)?),
                 ClientGccType::MonitorExtendedData => monitor_extended = Some(decode(cur)?),
                 ClientGccType::MultiTransportChannelData => multi_transport_channel = Some(decode(cur)?),
+                // Padding-only block the server is told to ignore (2.2.1.3.9).
+                ClientGccType::Unused1 => {}
             };
         }
 
@@ -244,7 +256,13 @@ impl<'de> Decode<'de> for ServerGccBlocks {
         let mut multi_transport_channel = None;
 
         loop {
-            let (ty, cur) = user_header_try!(UserDataHeader::decode(src));
+            let (raw_ty, cur) = user_header_try!(UserDataHeader::decode_raw(src));
+            let Some(ty) = ServerGccType::from_u16(raw_ty) else {
+                // Forward-compat: skip server user-data blocks IronRDP does not
+                // model rather than rejecting the connection (see the matching
+                // note on `ClientGccBlocks::decode`).
+                continue;
+            };
 
             match ty {
                 ServerGccType::CoreData => core = Some(decode(cur)?),
@@ -277,6 +295,13 @@ pub enum ClientGccType {
     MessageChannelData = 0xC006,
     MonitorExtendedData = 0xC008,
     MultiTransportChannelData = 0xC00A,
+    /// TS_UD_CS_UNUSED1, a padding-only block that, per [MS-RDPBCGR 2.2.1.3.9],
+    /// "SHOULD be ignored by the server if sent by the client". It carries no
+    /// data IronRDP consumes, so it is recognised purely so it can be skipped
+    /// explicitly rather than treated as an unknown type.
+    ///
+    /// [MS-RDPBCGR 2.2.1.3.9]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/bd4c2741-8842-4a43-8770-791b50dd2207
+    Unused1 = 0xC00C,
 }
 
 impl ClientGccType {
@@ -331,14 +356,16 @@ impl UserDataHeader {
         Ok(())
     }
 
-    pub fn decode<'de, T>(src: &mut ReadCursor<'de>) -> DecodeResult<(T, &'de [u8])>
-    where
-        T: FromPrimitive,
-    {
+    /// Decodes a GCC user-data block header, returning the raw `blockType` and
+    /// the block body without mapping the type to an enum.
+    ///
+    /// Unlike [`decode`](Self::decode), an unrecognised `blockType` is not an
+    /// error: the raw value is returned so the caller can skip blocks it does
+    /// not recognise, as MS-RDPBCGR requires for forward-compatibility.
+    pub fn decode_raw<'de>(src: &mut ReadCursor<'de>) -> DecodeResult<(u16, &'de [u8])> {
         ensure_fixed_part_size!(in: src);
 
-        let block_type =
-            T::from_u16(src.read_u16()).ok_or_else(|| invalid_field_err!("blockType", "invalid GCC type"))?;
+        let block_type = src.read_u16();
         let block_length: usize = cast_length!("blockLen", src.read_u16())?;
 
         if block_length <= USER_DATA_HEADER_SIZE {
@@ -349,5 +376,15 @@ impl UserDataHeader {
         ensure_size!(in: src, size: len);
 
         Ok((block_type, src.read_slice(len)))
+    }
+
+    pub fn decode<'de, T>(src: &mut ReadCursor<'de>) -> DecodeResult<(T, &'de [u8])>
+    where
+        T: FromPrimitive,
+    {
+        let (raw_type, body) = Self::decode_raw(src)?;
+        let block_type = T::from_u16(raw_type).ok_or_else(|| invalid_field_err!("blockType", "invalid GCC type"))?;
+
+        Ok((block_type, body))
     }
 }

--- a/crates/ironrdp-testsuite-core/tests/pdu/gcc.rs
+++ b/crates/ironrdp-testsuite-core/tests/pdu/gcc.rs
@@ -184,6 +184,44 @@ fn from_buffer_correctly_handles_invalid_lengths_in_user_data_header() {
 }
 
 #[test]
+fn decode_raw_returns_raw_block_type_for_unknown_type() {
+    // blockType = 0xC00D (an undocumented type not modelled by IronRDP),
+    // blockLen = 8, then 4 body bytes. decode_raw returns the raw type instead
+    // of rejecting it, so block decoders can skip unrecognised blocks
+    // (MS-RDPBCGR forward-compat).
+    let buffer: [u8; 8] = [0x0d, 0xc0, 0x08, 0x00, 0xde, 0xad, 0xbe, 0xef];
+    let mut cur = ReadCursor::new(&buffer);
+
+    let (block_type, body) = UserDataHeader::decode_raw(&mut cur).unwrap();
+
+    assert_eq!(block_type, 0xc00d);
+    assert_eq!(body, [0xde, 0xad, 0xbe, 0xef]);
+}
+
+#[test]
+fn from_buffer_skips_unknown_client_gcc_block_and_parses_known_blocks() {
+    // An undocumented block (type 0xC00D, blockLen 8, 4 body bytes) trailing an
+    // otherwise valid set must be skipped without affecting the known blocks.
+    // Recent Microsoft clients emit such blocks; rejecting them would break the
+    // connection (see ClientGccBlocks::decode).
+    let mut buffer = CLIENT_GCC_WITHOUT_OPTIONAL_FIELDS_BUFFER.to_vec();
+    buffer.extend_from_slice(&[0x0d, 0xc0, 0x08, 0x00, 0xde, 0xad, 0xbe, 0xef]);
+
+    assert_eq!(*CLIENT_GCC_WITHOUT_OPTIONAL_FIELDS, decode(buffer.as_slice()).unwrap());
+}
+
+#[test]
+fn from_buffer_ignores_cs_unused1_client_gcc_block() {
+    // TS_UD_CS_UNUSED1 (type 0xC00C, blockLen 6, 2 pad octets) is a documented
+    // padding block the server "SHOULD ignore" (MS-RDPBCGR 2.2.1.3.9). It is
+    // recognised and dropped, leaving the parsed blocks unchanged.
+    let mut buffer = CLIENT_GCC_WITHOUT_OPTIONAL_FIELDS_BUFFER.to_vec();
+    buffer.extend_from_slice(&[0x0c, 0xc0, 0x06, 0x00, 0x00, 0x00]);
+
+    assert_eq!(*CLIENT_GCC_WITHOUT_OPTIONAL_FIELDS, decode(buffer.as_slice()).unwrap());
+}
+
+#[test]
 fn from_buffer_correctly_parses_client_cluster_data() {
     let buffer = CLUSTER_DATA_BUFFER.as_ref();
 


### PR DESCRIPTION
## Summary

As an RDP server, IronRDP currently fails to negotiate a connection with
current Microsoft clients (the Windows App / `msrdc`): it aborts the
whole GCC decode the moment it encounters a user-data block whose
`blockType` it does not model, dropping the connection during the
Conference Create exchange. This change makes the GCC block decoders skip
blocks they do not recognise and continue, which is what the protocol's
wire format is designed for and what other implementations already do.

## Problem

When decoding a GCC Conference Create Request/Response, `ClientGccBlocks`
and `ServerGccBlocks` return an error on the first user-data block whose
`blockType` is not one of the variants IronRDP models, which aborts the
entire decode and fails the connection.

The current Windows App (the `msrdc` client) trips this in two ways:

1. It sends a `TS_UD_CS_UNUSED1` block (`blockType` `0xC00C`). This block
   is documented, and [MS-RDPBCGR 2.2.1.3.9] states it "SHOULD be ignored
   by the server if sent by the client", but IronRDP did not model it
   (the `ClientGccType` set stopped at `0xC00A`), so it was rejected
   rather than ignored.
2. It also sends a block with `blockType` `0xC00D`, which is undocumented:
   it is in neither the User Data Header type list in [MS-RDPBCGR 2.2.1.3.1]
   nor FreeRDP's parser. This follows the pattern of the `0xC009` block
   historically sent by the Lync RDP client, also absent from the spec.

Either block causes the decoder to reject the connection, so an
`ironrdp-server` peer cannot complete the connection sequence with this
client at all.

## Why tolerate unknown blocks

GCC user-data blocks are a length-prefixed TLV structure: `TS_UD_HEADER`
is `type` (2 bytes) + `length` (2 bytes) + value. The length exists
precisely so a reader that does not recognise a `type` can seek past the
payload and continue with the next block, which is the standard
forward-compatibility contract for this wire format. Rejecting on an
unknown type forfeits that.

This is also how the most widely used open-source RDP implementation
behaves. FreeRDP's GCC parser logs the unknown block and continues
rather than aborting the handshake:

```c
default:
    WLog_Print(mcs->log, WLOG_ERROR, "Unknown GCC client data block: 0x%04" PRIX16 "", type);
    winpr_HexLogDump(mcs->log, WLOG_TRACE, Stream_Pointer(sub), Stream_GetRemainingLength(sub));
    break;
```

It advances by the block's length and proceeds. FreeRDP also models
`CS_UNUSED1` (`0xC00C`) as a named case and carries `0xC009` as a literal
case, matching the approach this PR takes.

## Change

- Add `UserDataHeader::decode_raw`, which returns the raw `u16`
  `blockType` and the block body without mapping the type to an enum.
  The block length is honoured, so the cursor can always advance past a
  block the caller does not recognise.
- `ClientGccBlocks::decode` and `ServerGccBlocks::decode` now use it and
  skip user-data blocks they do not model instead of erroring.
- Model `TS_UD_CS_UNUSED1` (`blockType` `0xC00C`) explicitly. Per
  [MS-RDPBCGR 2.2.1.3.9] it is a padding block that "SHOULD be ignored
  by the server if sent by the client", so it is handled as a named
  no-op rather than going through the generic unknown-block path.

The existing generic `UserDataHeader::decode` is kept as a thin wrapper
over `decode_raw`, so its signature and behaviour are unchanged. This PR
is non-breaking.

## Tests

- `from_buffer_skips_unknown_client_gcc_block_and_parses_known_blocks`
  verifies an undocumented `0xC00D` block is skipped while the known
  blocks still parse.
- `from_buffer_ignores_cs_unused1_client_gcc_block` verifies a
  `CS_UNUSED1` block is recognised and ignored.
- `decode_raw_returns_raw_block_type_for_unknown_type` verifies
  `decode_raw` surfaces the raw unrecognised `blockType`.

[MS-RDPBCGR 2.2.1.3.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/8a36630c-9c8e-4864-9382-2ec9d6f368ca
[MS-RDPBCGR 2.2.1.3.9]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/bd4c2741-8842-4a43-8770-791b50dd2207
