### PR TITLE
fix(connector): stay in CapabilitiesExchange when activation handles DeactivateAll

### DIFF
--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -558,6 +558,14 @@ impl Sequence for ClientConnector {
                         written,
                         ClientConnectorState::ConnectionFinalization { connection_activation },
                     ),
+                    // The inner sequence stays in CapabilitiesExchange when it receives a
+                    // Server Deactivate All PDU before the Server Demand Active PDU (sent
+                    // by e.g. Windows Server and gnome-remote-desktop); mirror it here and
+                    // wait for the next input.
+                    ConnectionActivationState::CapabilitiesExchange { .. } => (
+                        written,
+                        ClientConnectorState::CapabilitiesExchange { connection_activation },
+                    ),
                     _ => return Err(general_err!("invalid state (this is a bug)")),
                 }
             }

--- a/crates/ironrdp-testsuite-core/tests/session/connection_activation.rs
+++ b/crates/ironrdp-testsuite-core/tests/session/connection_activation.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use ironrdp_connector::connection_activation::{ConnectionActivationSequence, ConnectionActivationState};
-use ironrdp_connector::{Credentials, DesktopSize, Sequence as _, Written};
+use ironrdp_connector::{ClientConnector, ClientConnectorState, Credentials, DesktopSize, Sequence as _, Written};
 use ironrdp_core::{WriteBuf, encode_vec};
 use ironrdp_pdu::gcc;
 use ironrdp_pdu::mcs::{McsMessage, SendDataIndication};
@@ -92,6 +92,26 @@ fn deactivate_all_during_capabilities_exchange_stays_in_same_state() {
             ConnectionActivationState::CapabilitiesExchange { .. }
         ),
         "state should remain CapabilitiesExchange after DeactivateAll"
+    );
+}
+
+#[test]
+fn client_connector_stays_in_capabilities_exchange_on_deactivate_all() {
+    let config = test_config();
+    let mut connector = ClientConnector::new(config.clone(), "127.0.0.1:3389".parse().unwrap());
+    connector.state = ClientConnectorState::CapabilitiesExchange {
+        connection_activation: ConnectionActivationSequence::new(config, IO_CHANNEL_ID, USER_CHANNEL_ID),
+    };
+
+    let frame = encode_server_share_control(ShareControlPdu::ServerDeactivateAll(ServerDeactivateAll));
+    let mut output = WriteBuf::new();
+
+    let written = connector.step(&frame, &mut output).unwrap();
+
+    assert_eq!(written, Written::Nothing);
+    assert!(
+        matches!(connector.state, ClientConnectorState::CapabilitiesExchange { .. }),
+        "outer connector state should remain CapabilitiesExchange after DeactivateAll"
     );
 }
 


### PR DESCRIPTION
Fixes #1362

## Problem

#1254 taught the inner `ConnectionActivationSequence` to skip a Server Deactivate All PDU received before Server Demand Active (sent by e.g. Windows Server and gnome-remote-desktop as part of a Deactivation-Reactivation Sequence, MS-RDPBCGR 1.3.1.3): it returns `Written::Nothing` and remains in `CapabilitiesExchange`.

However, the outer `ClientConnector::step()` only accepts `ConnectionFinalization` as the resulting inner state after calling `connection_activation.step()`, so the same scenario still fails with `invalid state (this is a bug)` when it happens during the initial connection sequence — exactly the symptom reported in #1362.

## Changes

- Add the missing match arm in `ClientConnector::step()`: when the inner sequence stays in `CapabilitiesExchange`, the outer connector stays in `CapabilitiesExchange` too and waits for the next input.
- Add a regression test mirroring the existing #1254 tests, driving the outer `ClientConnector` instead of the inner sequence (fails with `invalid state` before the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)