### PR TITLE
feat(acceptor): honor the client-requested desktop size

### DIFF
--- a/crates/ironrdp-acceptor/src/connection.rs
+++ b/crates/ironrdp-acceptor/src/connection.rs
@@ -38,6 +38,37 @@ pub struct Acceptor {
     pub(crate) creds: Option<Credentials>,
     received_credentials: Option<Credentials>,
     reactivation: bool,
+    honor_client_desktop_size: bool,
+}
+
+/// Minimum and maximum desktop dimension accepted from a client.
+///
+/// A desktop dimension in RDP is a `u16`; [MS-RDPBCGR] caps it at 8192, and
+/// 200 is a conservative floor below which a request is treated as malformed.
+const MIN_DESKTOP_DIM: u16 = 200;
+const MAX_DESKTOP_DIM: u16 = 8192;
+
+/// Returns the client-requested desktop size if both dimensions are within the
+/// protocol-legal range, otherwise `None`.
+fn validate_desktop_size(width: u16, height: u16) -> Option<DesktopSize> {
+    if (MIN_DESKTOP_DIM..=MAX_DESKTOP_DIM).contains(&width) && (MIN_DESKTOP_DIM..=MAX_DESKTOP_DIM).contains(&height) {
+        Some(DesktopSize { width, height })
+    } else {
+        None
+    }
+}
+
+/// Writes `size` into every Bitmap capability set in `capabilities`.
+///
+/// The server advertises its desktop size in the Bitmap capability set of the
+/// Demand Active PDU; this keeps that advertisement in sync with `size`.
+fn set_bitmap_desktop_size(capabilities: &mut [CapabilitySet], size: DesktopSize) {
+    for cap in capabilities.iter_mut() {
+        if let CapabilitySet::Bitmap(cap) = cap {
+            cap.desktop_width = size.width;
+            cap.desktop_height = size.height;
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -95,7 +126,27 @@ impl Acceptor {
             creds,
             received_credentials: None,
             reactivation: false,
+            honor_client_desktop_size: false,
         }
+    }
+
+    /// Adopt the desktop size requested by the client in its Client Core Data
+    /// instead of the size this acceptor was constructed with.
+    ///
+    /// The client's requested resolution is only carried in the GCC Client
+    /// Core Data of the MCS Connect Initial PDU; the desktop size echoed back
+    /// later in the client's Confirm Active is, per [MS-RDPBCGR] 2.2.1.13.2,
+    /// the value the client copied from the *server's* Demand Active, so it
+    /// cannot be used to discover what the client originally asked for. When
+    /// this is enabled and the client's request is within the protocol-legal
+    /// range, the acceptor negotiates that size from the start (it is written
+    /// into the server's Bitmap capability set before Demand Active is sent),
+    /// avoiding a Deactivation-Reactivation resize round trip.
+    ///
+    /// Disabled by default, preserving the previous behavior of always
+    /// enforcing the server-provided size.
+    pub fn set_honor_client_desktop_size(&mut self, honor: bool) {
+        self.honor_client_desktop_size = honor;
     }
 
     pub fn new_deactivation_reactivation(
@@ -111,12 +162,7 @@ impl Acceptor {
             return Err(general_err!("invalid acceptor state"));
         };
 
-        for cap in consumed.server_capabilities.iter_mut() {
-            if let CapabilitySet::Bitmap(cap) = cap {
-                cap.desktop_width = desktop_size.width;
-                cap.desktop_height = desktop_size.height;
-            }
-        }
+        set_bitmap_desktop_size(&mut consumed.server_capabilities, desktop_size);
         let state = AcceptorState::CapabilitiesSendServer {
             early_capability,
             channels: channels.clone(),
@@ -139,6 +185,7 @@ impl Acceptor {
             creds: consumed.creds,
             received_credentials: consumed.received_credentials,
             reactivation: true,
+            honor_client_desktop_size: consumed.honor_client_desktop_size,
         })
     }
 
@@ -451,6 +498,26 @@ impl Sequence for Acceptor {
                 let early_capability = gcc_blocks.core.optional_data.early_capability_flags;
                 let client_wants_message_channel = gcc_blocks.message_channel.is_some();
                 self.keyboard_layout = gcc_blocks.core.keyboard_layout;
+
+                // Adopt the client's requested desktop size (from its Client
+                // Core Data) before Demand Active is sent, so the session is
+                // negotiated at that size without a Deactivation-Reactivation
+                // resize. See `set_honor_client_desktop_size`.
+                if self.honor_client_desktop_size {
+                    if let Some(client_size) =
+                        validate_desktop_size(gcc_blocks.core.desktop_width, gcc_blocks.core.desktop_height)
+                    {
+                        if client_size != self.desktop_size {
+                            debug!(
+                                requested = ?client_size,
+                                previous = ?self.desktop_size,
+                                "Honoring client-requested desktop size"
+                            );
+                            self.desktop_size = client_size;
+                            set_bitmap_desktop_size(&mut self.server_capabilities, client_size);
+                        }
+                    }
+                }
 
                 let joined: Vec<_> = gcc_blocks
                     .network

--- a/crates/ironrdp-acceptor/src/connection.rs
+++ b/crates/ironrdp-acceptor/src/connection.rs
@@ -41,10 +41,12 @@ pub struct Acceptor {
     honor_client_desktop_size: bool,
 }
 
-/// Minimum and maximum desktop dimension accepted from a client.
+/// Minimum and maximum desktop dimension honored from a client.
 ///
 /// A desktop dimension in RDP is a `u16`; [MS-RDPBCGR] caps it at 8192, and
-/// 200 is a conservative floor below which a request is treated as malformed.
+/// 200 is a conservative floor. A client-requested dimension outside this
+/// range is not honored: the acceptor keeps the server-provided desktop size
+/// rather than treating the request as an error.
 const MIN_DESKTOP_DIM: u16 = 200;
 const MAX_DESKTOP_DIM: u16 = 8192;
 
@@ -145,6 +147,19 @@ impl Acceptor {
     ///
     /// Disabled by default, preserving the previous behavior of always
     /// enforcing the server-provided size.
+    ///
+    /// # Precondition
+    ///
+    /// Enabling this only makes sense together with a display handler
+    /// ([`RdpServerDisplay`]) whose `request_initial_size` actually adopts (or
+    /// at least intersects) the size it is given. The acceptor negotiates the
+    /// client's size, but the server still builds its framebuffer/encoder from
+    /// the size the display handler reports; if that handler ignores the
+    /// requested size and returns a fixed, smaller framebuffer, the resulting
+    /// mismatch can cause the client to be dropped. With a fixed-size display
+    /// handler, leave this disabled.
+    ///
+    /// [`RdpServerDisplay`]: <https://docs.rs/ironrdp-server/latest/ironrdp_server/trait.RdpServerDisplay.html>
     pub fn set_honor_client_desktop_size(&mut self, honor: bool) {
         self.honor_client_desktop_size = honor;
     }
@@ -516,6 +531,12 @@ impl Sequence for Acceptor {
                             self.desktop_size = client_size;
                             set_bitmap_desktop_size(&mut self.server_capabilities, client_size);
                         }
+                    } else {
+                        debug!(
+                            width = gcc_blocks.core.desktop_width,
+                            height = gcc_blocks.core.desktop_height,
+                            "Client requested an out-of-range desktop size; keeping the server-provided size"
+                        );
                     }
                 }
 

--- a/crates/ironrdp-server/src/builder.rs
+++ b/crates/ironrdp-server/src/builder.rs
@@ -42,6 +42,7 @@ pub struct BuilderDone {
     gfx_factory: Option<Box<dyn GfxServerFactory>>,
     display_suppressed: Option<Arc<AtomicBool>>,
     autodetect_rtt: Option<Arc<AtomicU32>>,
+    honor_client_desktop_size: bool,
 }
 
 pub struct RdpServerBuilder<State> {
@@ -142,6 +143,7 @@ impl RdpServerBuilder<WantsDisplay> {
                 gfx_factory: None,
                 display_suppressed: None,
                 autodetect_rtt: None,
+                honor_client_desktop_size: false,
             },
         }
     }
@@ -163,6 +165,7 @@ impl RdpServerBuilder<WantsDisplay> {
                 gfx_factory: None,
                 display_suppressed: None,
                 autodetect_rtt: None,
+                honor_client_desktop_size: false,
             },
         }
     }
@@ -229,6 +232,25 @@ impl RdpServerBuilder<BuilderDone> {
         self
     }
 
+    /// Negotiate each session at the desktop size the client requests in its
+    /// Client Core Data, rather than the size reported by the display handler.
+    ///
+    /// The client's requested resolution is only carried in the GCC Client
+    /// Core Data of the connection handshake; the size echoed back in the
+    /// client's Confirm Active is the value it copied from the server's Demand
+    /// Active (per [MS-RDPBCGR] 2.2.1.13.2) and so cannot reveal what the
+    /// client asked for. With this enabled the acceptor adopts the requested
+    /// size (when within the protocol-legal range) before Demand Active is
+    /// sent, so the session starts at that size with no Deactivation-
+    /// Reactivation resize. The display handler observes the negotiated size
+    /// through [`RdpServerDisplay::request_initial_size`].
+    ///
+    /// Defaults to `false`, enforcing the size reported by the display handler.
+    pub fn with_honor_client_desktop_size(mut self, honor: bool) -> Self {
+        self.state.honor_client_desktop_size = honor;
+        self
+    }
+
     /// Set a credential validator for TLS-mode connections.
     ///
     /// When set, credentials received from the client during
@@ -262,6 +284,7 @@ impl RdpServerBuilder<BuilderDone> {
                 security: self.state.security,
                 codecs: self.state.codecs,
                 max_request_size: self.state.max_request_size,
+                honor_client_desktop_size: self.state.honor_client_desktop_size,
             },
             self.state.handler,
             self.state.display,

--- a/crates/ironrdp-server/src/builder.rs
+++ b/crates/ironrdp-server/src/builder.rs
@@ -246,6 +246,18 @@ impl RdpServerBuilder<BuilderDone> {
     /// through [`RdpServerDisplay::request_initial_size`].
     ///
     /// Defaults to `false`, enforcing the size reported by the display handler.
+    ///
+    /// # Precondition
+    ///
+    /// Only enable this with a [`RdpServerDisplay`] whose
+    /// [`request_initial_size`] actually adopts (or at least intersects) the
+    /// size it is given: the acceptor negotiates the client's size, but the
+    /// server still builds its framebuffer/encoder from the size the display
+    /// handler reports. A fixed-size handler that ignores the requested size
+    /// can produce a mismatch that drops the client. Leave this disabled when
+    /// the display handler serves a fixed framebuffer.
+    ///
+    /// [`request_initial_size`]: crate::RdpServerDisplay::request_initial_size
     pub fn with_honor_client_desktop_size(mut self, honor: bool) -> Self {
         self.state.honor_client_desktop_size = honor;
         self

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -223,6 +223,12 @@ pub struct RdpServerOptions {
     pub security: RdpServerSecurity,
     pub codecs: BitmapCodecs,
     pub max_request_size: u32,
+    /// When `true`, each connection's acceptor adopts the desktop size the
+    /// client requests in its Client Core Data (instead of the size reported
+    /// by the display handler), negotiating that size from the start without a
+    /// Deactivation-Reactivation resize. Defaults to `false`. Set via
+    /// [`RdpServerBuilder::with_honor_client_desktop_size`](crate::RdpServerBuilder::with_honor_client_desktop_size).
+    pub honor_client_desktop_size: bool,
 }
 
 impl RdpServerOptions {
@@ -711,6 +717,7 @@ impl RdpServer {
         let size = self.display.lock().await.size().await;
         let capabilities = capabilities::capabilities(&self.opts, size);
         let mut acceptor = Acceptor::new(self.opts.security.flag(), size, capabilities, self.creds.clone());
+        acceptor.set_honor_client_desktop_size(self.opts.honor_client_desktop_size);
 
         self.attach_channels(&mut acceptor);
 

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -218,6 +218,7 @@ impl CredentialValidator for ExactMatchCredentialValidator {
 }
 
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct RdpServerOptions {
     pub addr: SocketAddr,
     pub security: RdpServerSecurity,


### PR DESCRIPTION
## Problem

An `ironrdp-server` always serves the desktop size reported by its
`RdpServerDisplay`, regardless of what the client asked for. When that size
differs from the client's actual display resolution, the client rescales every
decoded frame — which on mstsc costs noticeable typing latency and, with H.264
over EGFX, contributes to audio drift. The only workaround today is to know the
client's resolution out-of-band and hard-code the display handler to match it.

The natural-looking hook — `RdpServerDisplay::request_initial_size`, added in
#1083 — can't actually be used to detect the client's request. It's fed the
desktop size from the client's **Confirm Active**, but per [MS-RDPBCGR]
2.2.1.13.2 a conformant client copies the server's **Demand Active** size into
its Confirm Active and echoes that back. Verified live: FreeRDP launched with
`/size:1024x768` echoes the server's size, not `1024x768` (this matches
FreeRDP's `rdp_apply_bitmap_capability_set`, and mstsc follows the same
`desktopResizeFlag` contract). The client's own requested resolution is carried
**only** in the GCC Client Core Data of the MCS Connect Initial — which the
acceptor parses and currently discards — and the acceptor commits a size in
Demand Active before any server-side code runs.

(This is also, I think, the substance of the question @CBenoit raised on #1083
about whether `request_initial_size` during reactivation is the right shape.)

## Approach

Adopt the client's Core Data desktop size in the acceptor, **before** Demand
Active is sent, gated behind an opt-in flag. Because it happens pre-Demand-
Active, the session is negotiated at the client's resolution from the start —
no Deactivation-Reactivation resize round trip. The display handler still
learns the negotiated size through the existing `request_initial_size` call
(the Confirm Active echo now equals the adopted size).

Opt-in, default off → no behavior change for existing servers.

## API

- **`ironrdp-acceptor`**: new `Acceptor::set_honor_client_desktop_size(bool)`
  (additive). When set, the `BasicSettingsWaitInitial` step adopts the Core
  Data size if it's within the protocol-legal range (200..=8192) and writes it
  into the server Bitmap capability set before Demand Active. Also factors the
  existing bitmap-capset desktop-size mutation (previously inline in
  `new_deactivation_reactivation`) into a shared `set_bitmap_desktop_size`
  helper, and adds a small pure `validate_desktop_size` helper.
- **`ironrdp-server`**: new builder method
  `RdpServerBuilder::with_honor_client_desktop_size(bool)`, backed by a new
  `RdpServerOptions::honor_client_desktop_size` field, forwarded to each
  connection's acceptor in `run_connection`.

## Notes / questions for review

1. **Where the server option lives.** I put it on `RdpServerOptions` (the
   config bag, next to `max_request_size`) rather than threading a new
   parameter through `RdpServer::new` as `display_suppressed` does. That adds a
   public field to `RdpServerOptions`, which is a minor-version breaking change
   for anyone constructing it by struct literal (the builder is unaffected).
   Happy to move it to a `new` parameter instead if you'd prefer to keep
   `RdpServerOptions` stable — let me know which you'd like.
2. **Tests.** `ironrdp-acceptor`'s lib sets `test = false`, so I didn't add
   inline unit tests (they wouldn't run). The two new helpers are pure and
   trivial; I verified the end-to-end behavior against real clients (below). If
   there's a preferred place for acceptor coverage, I'll add it there.

## Testing

Built and `clippy`-clean (`-D warnings`) for `ironrdp-acceptor` and
`ironrdp-server --features egfx` against current `master`. Exercised through a
downstream server with real clients:

- sdl-freerdp `/size:1024x768` — legacy bitmap path, session negotiated at
  1024×768 from the first frame.
- sdl-freerdp `/size:1280x800` then reconnect `/size:800x600` — H.264/EGFX,
  surface + encoder created at the requested size each connection.
- mstsc full-screen on a 1920×1080 monitor — session served at 1920×1080,
  client presents 1:1, typing latency gone.
