### PR TITLE
fix(dvc)!: replace DVC wrappers with typed accessors

### DIFF
--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -1151,7 +1151,7 @@ impl ConfigBuilder {
     pub fn with_dvc<P, F>(mut self, factory: F) -> Self
     where
         F: Fn(&PropertySet) -> Option<P> + Send + Sync + 'static,
-        P: ironrdp_dvc::DvcProcessor + 'static,
+        P: ironrdp_dvc::DvcClientProcessor + 'static,
     {
         let cb: DvcChannelFn = Arc::new(move |drdynvc, ps| {
             if let Some(processor) = factory(ps) {

--- a/crates/ironrdp-dvc/src/client.rs
+++ b/crates/ironrdp-dvc/src/client.rs
@@ -5,6 +5,7 @@ use core::any::TypeId;
 use core::fmt;
 
 use crate::alloc::borrow::ToOwned as _;
+use crate::complete_data::CompleteData;
 use ironrdp_core::{Decode as _, DecodeResult, ReadCursor, impl_as_any};
 use ironrdp_pdu::{self as pdu, decode_err, encode_err, pdu_other_err};
 use ironrdp_svc::{ChannelFlags, CompressionCondition, SvcClientProcessor, SvcMessage, SvcProcessor};
@@ -14,9 +15,12 @@ use tracing::debug;
 
 use crate::pdu::{
     CapabilitiesResponsePdu, CapsVersion, ClosePdu, CreateResponsePdu, CreationStatus, DrdynvcClientPdu,
-    DrdynvcServerPdu,
+    DrdynvcDataPdu, DrdynvcServerPdu,
 };
-use crate::{DvcProcessor, DynamicChannelId, DynamicChannelName, DynamicVirtualChannel, encode_dvc_messages};
+use crate::{
+    DvcMessage, DvcProcessor, DynamicChannelId, DynamicChannelMut, DynamicChannelName, DynamicChannelRef,
+    encode_dvc_messages,
+};
 
 pub trait DvcClientProcessor: DvcProcessor {}
 
@@ -62,6 +66,57 @@ impl DvcChannelListener for OnceListener {
 
     fn is_available(&self) -> bool {
         self.inner.is_some()
+    }
+}
+
+struct DynamicVirtualChannel {
+    channel_processor: Box<dyn DvcProcessor + Send>,
+    complete_data: CompleteData,
+    /// The channel ID assigned by the server.
+    ///
+    /// `Some` only after [`DynamicVirtualChannel::start`] has succeeded. This invariant
+    channel_id: Option<DynamicChannelId>,
+}
+
+impl Drop for DynamicVirtualChannel {
+    fn drop(&mut self) {
+        if let Some(id) = self.channel_id {
+            self.channel_processor.close(id);
+        }
+    }
+}
+
+impl DynamicVirtualChannel {
+    fn from_boxed(processor: Box<dyn DvcProcessor + Send>) -> Self {
+        Self {
+            channel_processor: processor,
+            complete_data: CompleteData::new(),
+            channel_id: None,
+        }
+    }
+
+    fn processor_type_id(&self) -> TypeId {
+        self.channel_processor.as_any().type_id()
+    }
+
+    fn start(&mut self, channel_id: DynamicChannelId) -> PduResult<Vec<DvcMessage>> {
+        let messages = self.channel_processor.start(channel_id)?;
+        self.channel_id = Some(channel_id);
+        Ok(messages)
+    }
+
+    fn process(&mut self, pdu: DrdynvcDataPdu) -> PduResult<Vec<DvcMessage>> {
+        let channel_id = pdu.channel_id();
+        let complete_data = self.complete_data.process_data(pdu).map_err(|e| decode_err!(e))?;
+        if let Some(complete_data) = complete_data {
+            self.channel_processor.process(channel_id, &complete_data)
+        } else {
+            Ok(Vec::new())
+        }
+    }
+
+    fn channel_name(&self) -> &str {
+        self.channel_processor.channel_name()
     }
 }
 
@@ -133,7 +188,7 @@ impl DrdynvcClient {
     ///
     /// # Note
     ///
-    /// * Doesn't support [TypeId] lookup via [DrdynvcClient::get_dvc_by_type_id].
+    /// * Doesn't support [TypeId] lookup via [DrdynvcClient::get_dvc].
     /// * If a listener or a pre-registered channel with the same name already exists,
     ///   it will be silently overwritten.
     #[must_use]
@@ -149,7 +204,7 @@ impl DrdynvcClient {
     ///
     /// # Note
     ///
-    /// * Doesn't support [TypeId] lookup via [DrdynvcClient::get_dvc_by_type_id].
+    /// * Doesn't support [TypeId] lookup via [DrdynvcClient::get_dvc].
     /// * If a listener or a pre-registered channel with the same name already exists,
     ///   it will be silently overwritten.
     pub fn attach_listener<T>(&mut self, listener: T)
@@ -159,27 +214,58 @@ impl DrdynvcClient {
         self.dynamic_channels.register_listener(listener);
     }
 
-    pub fn get_dvc_by_type_id<T>(&self) -> Option<&DynamicVirtualChannel>
+    /// Returns a typed accessor for a pre-registered client DVC.
+    ///
+    /// Type lookup is available only for channels registered with
+    /// [`DrdynvcClient::with_dynamic_channel`] or [`DrdynvcClient::attach_dynamic_channel`].
+    /// Listener-created channels can be retrieved with [`DrdynvcClient::get_dvc_by_channel_id`].
+    ///
+    /// Returns `None` until the server has created the channel and the processor has started.
+    pub fn get_dvc<T>(&self) -> Option<DynamicChannelRef<'_, T>>
     where
-        T: DvcProcessor,
+        T: DvcClientProcessor,
     {
-        self.dynamic_channels.get_by_type_id(TypeId::of::<T>())
+        let dvc_channel = self.dynamic_channels.get_by_type_id(TypeId::of::<T>())?;
+        let channel_id = dvc_channel.channel_id?;
+        dvc_channel
+            .channel_processor
+            .as_any()
+            .downcast_ref()
+            .map(|p| DynamicChannelRef::new(channel_id, p))
     }
 
     /// Returns whether a dynamic channel of type `T` was pre-registered with this client.
     pub fn has_registered_dvc<T>(&self) -> bool
     where
-        T: DvcProcessor,
+        T: DvcClientProcessor,
     {
         self.dynamic_channels.has_listener_by_type_id(TypeId::of::<T>())
     }
 
-    pub fn get_dvc_by_channel_id(&self, channel_id: u32) -> Option<&DynamicVirtualChannel> {
-        self.dynamic_channels.get_by_channel_id(channel_id)
+    /// Returns a typed accessor for an active client DVC by channel ID.
+    ///
+    /// Returns `None` when the channel ID is unknown or the processor has a different type.
+    pub fn get_dvc_by_channel_id<T>(&self, channel_id: u32) -> Option<DynamicChannelRef<'_, T>>
+    where
+        T: DvcClientProcessor,
+    {
+        self.dynamic_channels
+            .get_by_channel_id(channel_id)
+            .and_then(|dvc| dvc.channel_processor.as_any().downcast_ref())
+            .map(|p| DynamicChannelRef::new(channel_id, p))
     }
 
-    pub fn get_dvc_by_channel_id_mut(&mut self, channel_id: u32) -> Option<&mut DynamicVirtualChannel> {
-        self.dynamic_channels.get_by_channel_id_mut(channel_id)
+    /// Returns a mutable typed accessor for an active client DVC by channel ID.
+    ///
+    /// Returns `None` when the channel ID is unknown or the processor has a different type.
+    pub fn get_dvc_by_channel_id_mut<T>(&mut self, channel_id: u32) -> Option<DynamicChannelMut<'_, T>>
+    where
+        T: DvcClientProcessor,
+    {
+        self.dynamic_channels
+            .get_by_channel_id_mut(channel_id)
+            .and_then(|dvc| dvc.channel_processor.as_any_mut().downcast_mut())
+            .map(|p| DynamicChannelMut::new(channel_id, p))
     }
 
     fn create_capabilities_response(&mut self, server_version: CapsVersion) -> SvcMessage {

--- a/crates/ironrdp-dvc/src/client.rs
+++ b/crates/ironrdp-dvc/src/client.rs
@@ -29,7 +29,7 @@ pub trait DvcChannelListener: Send {
 
     /// Called for each incoming DYNVC_CREATE_REQ matching this name.
     /// Return `None` to reject (NO_LISTENER).
-    fn create(&mut self, channel_id: DynamicChannelId) -> Option<Box<dyn DvcProcessor>>;
+    fn create(&mut self, channel_id: DynamicChannelId) -> Option<Box<dyn DvcClientProcessor>>;
 
     /// Returns whether this listener can still create a channel.
     fn is_available(&self) -> bool {
@@ -41,11 +41,11 @@ pub type DynamicChannelListener = Box<dyn DvcChannelListener>;
 
 /// For pre-registered DVC
 struct OnceListener {
-    inner: Option<Box<dyn DvcProcessor>>,
+    inner: Option<Box<dyn DvcClientProcessor>>,
 }
 
 impl OnceListener {
-    fn new(dvc_processor: impl DvcProcessor + 'static) -> Self {
+    fn new(dvc_processor: impl DvcClientProcessor + 'static) -> Self {
         Self {
             inner: Some(Box::new(dvc_processor)),
         }
@@ -60,7 +60,7 @@ impl DvcChannelListener for OnceListener {
             .channel_name()
     }
 
-    fn create(&mut self, _channel_id: DynamicChannelId) -> Option<Box<dyn DvcProcessor>> {
+    fn create(&mut self, _channel_id: DynamicChannelId) -> Option<Box<dyn DvcClientProcessor>> {
         self.inner.take()
     }
 
@@ -70,11 +70,11 @@ impl DvcChannelListener for OnceListener {
 }
 
 struct DynamicVirtualChannel {
-    channel_processor: Box<dyn DvcProcessor + Send>,
+    channel_processor: Box<dyn DvcClientProcessor + Send>,
     complete_data: CompleteData,
     /// The channel ID assigned by the server.
     ///
-    /// `Some` only after [`DynamicVirtualChannel::start`] has succeeded. This invariant
+    /// `Some` only after [`DynamicVirtualChannel::start`] has succeeded.
     channel_id: Option<DynamicChannelId>,
 }
 
@@ -87,7 +87,7 @@ impl Drop for DynamicVirtualChannel {
 }
 
 impl DynamicVirtualChannel {
-    fn from_boxed(processor: Box<dyn DvcProcessor + Send>) -> Self {
+    fn from_boxed(processor: Box<dyn DvcClientProcessor + Send>) -> Self {
         Self {
             channel_processor: processor,
             complete_data: CompleteData::new(),
@@ -164,7 +164,7 @@ impl DrdynvcClient {
     #[must_use]
     pub fn with_dynamic_channel<T>(mut self, channel: T) -> Self
     where
-        T: DvcProcessor + 'static,
+        T: DvcClientProcessor + 'static,
     {
         self.dynamic_channels.register_once(channel);
         self
@@ -179,7 +179,7 @@ impl DrdynvcClient {
     /// it will be silently overwritten.
     pub fn attach_dynamic_channel<T>(&mut self, channel: T)
     where
-        T: DvcProcessor + 'static,
+        T: DvcClientProcessor + 'static,
     {
         self.dynamic_channels.register_once(channel);
     }
@@ -410,7 +410,7 @@ impl DynamicChannelSet {
         );
     }
 
-    fn register_once<T: DvcProcessor + 'static>(&mut self, channel: T) {
+    fn register_once<T: DvcClientProcessor + 'static>(&mut self, channel: T) {
         let name = channel.channel_name().to_owned();
         self.listeners.insert(
             name,
@@ -511,6 +511,8 @@ mod tests {
             Ok(Vec::new())
         }
     }
+
+    impl DvcClientProcessor for TestDvc {}
 
     #[test]
     fn consumed_typed_listener_is_not_registered() {

--- a/crates/ironrdp-dvc/src/client.rs
+++ b/crates/ironrdp-dvc/src/client.rs
@@ -503,11 +503,11 @@ mod tests {
             "test"
         }
 
-        fn start(&mut self, _channel_id: u32) -> PduResult<Vec<crate::DvcMessage>> {
+        fn start(&mut self, _channel_id: u32) -> PduResult<Vec<DvcMessage>> {
             Ok(Vec::new())
         }
 
-        fn process(&mut self, _channel_id: u32, _payload: &[u8]) -> PduResult<Vec<crate::DvcMessage>> {
+        fn process(&mut self, _channel_id: u32, _payload: &[u8]) -> PduResult<Vec<DvcMessage>> {
             Ok(Vec::new())
         }
     }

--- a/crates/ironrdp-dvc/src/lib.rs
+++ b/crates/ironrdp-dvc/src/lib.rs
@@ -4,8 +4,6 @@
 
 extern crate alloc;
 
-use core::any::TypeId;
-
 use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::vec::Vec;
@@ -16,7 +14,7 @@ use pdu::DrdynvcDataPdu;
 #[rustfmt::skip] // do not re-order this pub use
 pub use ironrdp_pdu;
 use ironrdp_core::{AsAny, Encode, EncodeResult, assert_obj_safe, cast_length, encode_vec, other_err};
-use ironrdp_pdu::{PduResult, decode_err};
+use ironrdp_pdu::PduResult;
 use ironrdp_svc::SvcMessage;
 
 mod complete_data;
@@ -100,69 +98,7 @@ pub fn encode_dvc_messages(
     Ok(res)
 }
 
-pub struct DynamicVirtualChannel {
-    channel_processor: Box<dyn DvcProcessor + Send>,
-    complete_data: CompleteData,
-    /// The channel ID assigned by the server.
-    ///
-    /// `Some` only after [`DynamicVirtualChannel::start`] has succeeded. This invariant
-    channel_id: Option<DynamicChannelId>,
-}
-
-impl Drop for DynamicVirtualChannel {
-    fn drop(&mut self) {
-        if let Some(id) = self.channel_id {
-            self.channel_processor.close(id);
-        }
-    }
-}
-
-impl DynamicVirtualChannel {
-    fn from_boxed(processor: Box<dyn DvcProcessor + Send>) -> Self {
-        Self {
-            channel_processor: processor,
-            complete_data: CompleteData::new(),
-            channel_id: None,
-        }
-    }
-
-    fn processor_type_id(&self) -> TypeId {
-        self.channel_processor.as_any().type_id()
-    }
-
-    pub fn is_open(&self) -> bool {
-        self.channel_id.is_some()
-    }
-
-    pub fn channel_id(&self) -> Option<DynamicChannelId> {
-        self.channel_id
-    }
-
-    pub fn channel_processor_downcast_ref<T: DvcProcessor>(&self) -> Option<&T> {
-        self.channel_processor.as_any().downcast_ref()
-    }
-
-    fn start(&mut self, channel_id: DynamicChannelId) -> PduResult<Vec<DvcMessage>> {
-        let messages = self.channel_processor.start(channel_id)?;
-        self.channel_id = Some(channel_id);
-        Ok(messages)
-    }
-
-    fn process(&mut self, pdu: DrdynvcDataPdu) -> PduResult<Vec<DvcMessage>> {
-        let channel_id = pdu.channel_id();
-        let complete_data = self.complete_data.process_data(pdu).map_err(|e| decode_err!(e))?;
-        if let Some(complete_data) = complete_data {
-            self.channel_processor.process(channel_id, &complete_data)
-        } else {
-            Ok(Vec::new())
-        }
-    }
-
-    fn channel_name(&self) -> &str {
-        self.channel_processor.channel_name()
-    }
-}
-
+/// Borrowed typed view of a dynamic virtual channel.
 #[derive(Debug, Clone, Copy)]
 pub struct DynamicChannelRef<'a, T> {
     channel_id: DynamicChannelId,
@@ -185,6 +121,7 @@ impl<'a, T: DvcProcessor> DynamicChannelRef<'a, T> {
     }
 }
 
+/// Mutable borrowed typed view of a dynamic virtual channel.
 #[derive(Debug)]
 pub struct DynamicChannelMut<'a, T> {
     channel_id: DynamicChannelId,

--- a/crates/ironrdp-dvc/src/server.rs
+++ b/crates/ironrdp-dvc/src/server.rs
@@ -29,7 +29,7 @@ enum ChannelState {
 
 struct DynamicChannel {
     state: ChannelState,
-    processor: Box<dyn DvcProcessor>,
+    processor: Box<dyn DvcServerProcessor>,
     complete_data: CompleteData,
     channel_id: u32,
 }

--- a/crates/ironrdp-dvc/src/server.rs
+++ b/crates/ironrdp-dvc/src/server.rs
@@ -186,6 +186,7 @@ impl DrdynvcServer {
             .ok_or_else(|| invalid_field_err!("DRDYNVC", "", "invalid channel id"))
     }
 
+    /// Returns a typed accessor for an active server DVC by channel ID.
     pub fn dvc_by_id<T: DvcServerProcessor>(&self, id: u32) -> Option<DynamicChannelRef<'_, T>> {
         let channel = self.dynamic_channels.get(id)?;
         if channel.state != ChannelState::Opened {
@@ -198,6 +199,7 @@ impl DrdynvcServer {
             .map(|p| DynamicChannelRef::new(id, p))
     }
 
+    /// Returns a mutable typed accessor for an active server DVC by channel ID.
     pub fn dvc_by_id_mut<T: DvcServerProcessor>(&mut self, id: u32) -> Option<DynamicChannelMut<'_, T>> {
         let channel = self.dynamic_channels.get_mut(id)?;
         if channel.state != ChannelState::Opened {

--- a/crates/ironrdp-rdpeusb/src/client.rs
+++ b/crates/ironrdp-rdpeusb/src/client.rs
@@ -80,7 +80,7 @@ impl DvcChannelListener for UrbdrcListener {
         CHANNEL_NAME
     }
 
-    fn create(&mut self, channel_id: u32) -> Option<Box<dyn DvcProcessor>> {
+    fn create(&mut self, channel_id: u32) -> Option<Box<dyn DvcClientProcessor>> {
         if let Some(callback) = self.on_capability_exchanged.take() {
             self.device_man.control_channel_assigned(channel_id);
             Some(Box::new(UrbdrcControlClient::new(callback)))
@@ -89,7 +89,7 @@ impl DvcChannelListener for UrbdrcListener {
             #[expect(clippy::as_conversions)]
             self.device_man.take_device_for_channel(channel_id).map(|backend| {
                 Box::new(UrbdrcDeviceClient::new(udev_iface, backend).expect("invalid interface id"))
-                    as Box<dyn DvcProcessor>
+                    as Box<dyn DvcClientProcessor>
             })
         }
     }

--- a/crates/ironrdp-session/src/active_stage.rs
+++ b/crates/ironrdp-session/src/active_stage.rs
@@ -364,12 +364,12 @@ impl ActiveStage {
         self.x224_processor.get_svc_processor_mut()
     }
 
-    pub fn get_dvc<T: DvcClientProcessor + 'static>(&mut self) -> Option<DynamicChannelRef<'_, T>> {
+    pub fn get_dvc<T: DvcClientProcessor + 'static>(&self) -> Option<DynamicChannelRef<'_, T>> {
         self.x224_processor.get_dvc::<T>()
     }
 
     pub fn get_dvc_by_channel_id<T: DvcClientProcessor + 'static>(
-        &mut self,
+        &self,
         channel_id: u32,
     ) -> Option<DynamicChannelRef<'_, T>> {
         self.x224_processor.get_dvc_by_channel_id(channel_id)

--- a/crates/ironrdp-session/src/active_stage.rs
+++ b/crates/ironrdp-session/src/active_stage.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use ironrdp_bulk::{BulkCompressor, CompressionType as BulkCompressionType};
 use ironrdp_core::{ReadCursor, WriteBuf};
 use ironrdp_displaycontrol::client::DisplayControlClient;
-use ironrdp_dvc::{DrdynvcClient, DvcProcessor, DynamicVirtualChannel};
+use ironrdp_dvc::{DrdynvcClient, DvcClientProcessor, DynamicChannelRef};
 use ironrdp_graphics::pointer::DecodedPointer;
 use ironrdp_pdu::gcc::ChannelName;
 use ironrdp_pdu::geometry::InclusiveRectangle;
@@ -364,11 +364,14 @@ impl ActiveStage {
         self.x224_processor.get_svc_processor_mut()
     }
 
-    pub fn get_dvc<T: DvcProcessor + 'static>(&mut self) -> Option<&DynamicVirtualChannel> {
+    pub fn get_dvc<T: DvcClientProcessor + 'static>(&mut self) -> Option<DynamicChannelRef<'_, T>> {
         self.x224_processor.get_dvc::<T>()
     }
 
-    pub fn get_dvc_by_channel_id(&mut self, channel_id: u32) -> Option<&DynamicVirtualChannel> {
+    pub fn get_dvc_by_channel_id<T: DvcClientProcessor + 'static>(
+        &mut self,
+        channel_id: u32,
+    ) -> Option<DynamicChannelRef<'_, T>> {
         self.x224_processor.get_dvc_by_channel_id(channel_id)
     }
 
@@ -382,10 +385,7 @@ impl ActiveStage {
                 .get_svc_processor::<DrdynvcClient>()
                 .and_then(|drdynvc| drdynvc.has_registered_dvc::<DisplayControlClient>().then_some(false));
         };
-        let Some(_) = dvc.channel_id() else {
-            return Some(false);
-        };
-        Some(dvc.channel_processor_downcast_ref::<DisplayControlClient>()?.ready())
+        Some(dvc.processor().ready())
     }
 
     /// Completes user's SVC request with data, required to sent it over the network and returns
@@ -429,11 +429,8 @@ impl ActiveStage {
         physical_dims: Option<(u32, u32)>,
     ) -> Option<SessionResult<Vec<u8>>> {
         if let Some(dvc) = self.get_dvc::<DisplayControlClient>() {
-            let Some(channel_id) = dvc.channel_id() else {
-                debug!("Could not encode a resize: Display Control Virtual Channel is not yet connected");
-                return None;
-            };
-            let display_control = dvc.channel_processor_downcast_ref::<DisplayControlClient>()?;
+            let channel_id = dvc.channel_id();
+            let display_control = dvc.processor();
             if !display_control.ready() {
                 debug!("Could not encode a resize: Display Control capabilities have not been received");
                 return None;

--- a/crates/ironrdp-session/src/x224/mod.rs
+++ b/crates/ironrdp-session/src/x224/mod.rs
@@ -1,6 +1,6 @@
 use ironrdp_bulk::BulkCompressor;
 use ironrdp_core::{WriteBuf, decode};
-use ironrdp_dvc::{DrdynvcClient, DvcProcessor, DynamicVirtualChannel};
+use ironrdp_dvc::{DrdynvcClient, DvcClientProcessor, DynamicChannelRef};
 use ironrdp_pdu::gcc::ChannelName;
 use ironrdp_pdu::mcs::{DisconnectProviderUltimatum, DisconnectReason, McsMessage, SendDataIndicationCtx};
 use ironrdp_pdu::rdp::autodetect::{AutoDetectReqPdu, AutoDetectRequest, AutoDetectResponse, AutoDetectRspPdu};
@@ -154,11 +154,14 @@ impl Processor {
         process_svc_messages(messages, channel_id, self.user_channel_id)
     }
 
-    pub fn get_dvc<T: DvcProcessor + 'static>(&self) -> Option<&DynamicVirtualChannel> {
-        self.get_svc_processor::<DrdynvcClient>()?.get_dvc_by_type_id::<T>()
+    pub fn get_dvc<T: DvcClientProcessor + 'static>(&self) -> Option<DynamicChannelRef<'_, T>> {
+        self.get_svc_processor::<DrdynvcClient>()?.get_dvc::<T>()
     }
 
-    pub fn get_dvc_by_channel_id(&self, channel_id: u32) -> Option<&DynamicVirtualChannel> {
+    pub fn get_dvc_by_channel_id<T: DvcClientProcessor + 'static>(
+        &self,
+        channel_id: u32,
+    ) -> Option<DynamicChannelRef<'_, T>> {
         self.get_svc_processor::<DrdynvcClient>()?
             .get_dvc_by_channel_id(channel_id)
     }

--- a/ffi/src/connector/mod.rs
+++ b/ffi/src/connector/mod.rs
@@ -10,7 +10,7 @@ pub mod ffi {
     use diplomat_runtime::DiplomatWriteable;
     use ironrdp::connector::Sequence as _;
     use ironrdp::displaycontrol::client::DisplayControlClient;
-    use ironrdp::dvc::DvcProcessor;
+    use ironrdp::dvc::DvcClientProcessor;
     use ironrdp_dvc_pipe_proxy::DvcNamedPipeProxy;
     use tracing::info;
 
@@ -74,7 +74,7 @@ pub mod ffi {
 
         fn with_dvc<T>(&mut self, processor: T) -> Result<(), Box<IronRdpError>>
         where
-            T: DvcProcessor + 'static,
+            T: DvcClientProcessor + 'static,
         {
             let Some(connector) = &mut self.0 else {
                 return Err(ValueConsumedError::for_item("connector").into());


### PR DESCRIPTION
Follow-up to #1368. This is not urgent; review whenever the DVC API direction is worth revisiting.

Rework DVC channel access APIs so callers can recover a typed processor together with its dynamic channel id, without exposing internal channel wrapper types.

- Add typed borrowed DVC accessors carrying both channel id and processor borrow for `DrdynvcClient`.
- Keep dynamic channel wrapper types private.
- Align client listener/registration APIs on `DvcClientProcessor`.

BREAKING CHANGE: `DynamicVirtualChannel` is no longer public. Client DVC listener/registration APIs now use `DvcClientProcessor`.