### PR TITLE
feat(web): supersede a stuck upload and complete zero-byte files

### DIFF
--- a/web-client/iron-remote-desktop-rdp/src/RdpFileTransferProvider.test.ts
+++ b/web-client/iron-remote-desktop-rdp/src/RdpFileTransferProvider.test.ts
@@ -526,12 +526,215 @@ describe('RdpFileTransferProvider', () => {
             // @ts-expect-error - private callback the WASM layer drives via unlockCallback
             p.handleUnlock(0);
 
-            // No error, and the upload state is intact (a second attempt still hits the guard).
+            // No error, and the upload state is intact (Unlock is ignored).
             expect(errorHandler).not.toHaveBeenCalled();
-            expect(() => p.uploadFiles(files)).toThrow('Upload already in progress');
+            expect(p.isUploadInProgress()).toBe(true);
 
             p.dispose();
             await expect(completion).rejects.toThrow('RdpFileTransferProvider disposed');
+        });
+
+        it('completes a 0-byte file from its SIZE request alone (no RANGE follows)', async () => {
+            // A 0-byte file has no bytes, so the remote asks for its size and never
+            // sends a RANGE -- the only path that otherwise marks a file complete.
+            // Without explicit handling the batch never reaches expectedFileCount,
+            // finishUploadBatch never runs, and uploadState wedges every later upload.
+            const { provider: p, session: s } = setupProvider();
+            const errorHandler = vi.fn();
+            const completeHandler = vi.fn();
+            p.on('error', errorHandler);
+            p.on('upload-complete', completeHandler);
+
+            const files = [new File([], 'empty.txt', { type: 'text/plain' })];
+            const { completion } = p.uploadFiles(files);
+
+            // Remote requests only the size (8 bytes) for the lone empty file.
+            // @ts-expect-error - private callback the WASM layer drives
+            p.handleFileContentsRequest({ streamId: 1, index: 0, flags: 1, position: 0, size: 8 });
+
+            await expect(completion).resolves.toBeUndefined();
+            expect(completeHandler).toHaveBeenCalledTimes(1);
+            expect(errorHandler).not.toHaveBeenCalled();
+
+            // finishUploadBatch released uploadState: a fresh upload is not wedged
+            // ("Upload already in progress"). Reaching a handle plus the
+            // initiateFileCopy call proves it restarted.
+            s.invokeExtension.mockClear();
+            const second = p.uploadFiles([new File(['x'], 'y.txt', { type: 'text/plain' })]);
+            expect(s.invokeExtension).toHaveBeenCalledTimes(1);
+            p.dispose();
+            await expect(second.completion).rejects.toThrow('RdpFileTransferProvider disposed');
+        });
+
+        it('lets a 0-byte file finish a mixed batch after the data files are served', async () => {
+            // The realistic case: a folder of tiny files where the empty ones are the
+            // last to "complete". The empty file's SIZE request must finish the batch
+            // once every data file has been fully served.
+            vi.useFakeTimers();
+            try {
+                const { provider: p } = setupProvider();
+                const errorHandler = vi.fn();
+                const completeHandler = vi.fn();
+                p.on('error', errorHandler);
+                p.on('upload-complete', completeHandler);
+
+                const files = [
+                    new File(['data'], 'a.txt', { type: 'text/plain' }),
+                    new File([], 'empty.txt', { type: 'text/plain' }),
+                ];
+                const { completion } = p.uploadFiles(files);
+                let resolved = false;
+                void completion.then(() => {
+                    resolved = true;
+                });
+
+                // Data file: SIZE then RANGE. jsdom runs the FileReader on a timer, so
+                // flush it -- index 0 completes but the batch is not done (1 of 2).
+                // @ts-expect-error - private callback the WASM layer drives
+                p.handleFileContentsRequest({ streamId: 1, index: 0, flags: 1, position: 0, size: 8 });
+                // @ts-expect-error - private callback the WASM layer drives
+                p.handleFileContentsRequest({ streamId: 2, index: 0, flags: 2, position: 0, size: 4 });
+                await vi.advanceTimersByTimeAsync(100);
+                expect(resolved).toBe(false);
+
+                // Empty file: SIZE only. This completes the second (and last) counted
+                // file, so the batch finishes.
+                // @ts-expect-error - private callback the WASM layer drives
+                p.handleFileContentsRequest({ streamId: 3, index: 1, flags: 1, position: 0, size: 8 });
+                await Promise.resolve();
+                expect(resolved).toBe(true);
+
+                expect(completeHandler).toHaveBeenCalledTimes(2);
+                const completedNames = completeHandler.mock.calls.map((c) => (c[0] as File).name);
+                expect(completedNames).toContain('empty.txt');
+                expect(errorHandler).not.toHaveBeenCalled();
+
+                // finishUploadBatch disarmed the inactivity watchdog: no timer lingers.
+                expect(vi.getTimerCount()).toBe(0);
+
+                p.dispose();
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it('completes a directory-only batch on paste-ack without waiting for the inactivity watchdog', async () => {
+            // A directory entry carries no data: the remote requests SIZE (answered with 0) but
+            // never a RANGE, so no file is ever marked complete and expectedFileCount is 0. Without
+            // explicit handling, finishUploadBatch never runs, the inactivity watchdog fires after
+            // 60s, and an empty-folder paste that actually succeeded is reported as a failure.
+            vi.useFakeTimers();
+            try {
+                const { provider: p } = setupProvider();
+                const errorHandler = vi.fn();
+                p.on('error', errorHandler);
+
+                const { completion } = p.uploadFiles([
+                    { file: null, name: 'folder', size: 0, lastModified: 0, isDirectory: true },
+                ]);
+                let resolved = false;
+                void completion.then(() => {
+                    resolved = true;
+                });
+                expect(p.isUploadInProgress()).toBe(true);
+
+                // Remote acknowledges the paste by requesting the directory's size.
+                // @ts-expect-error - private callback the WASM layer drives
+                p.handleFileContentsRequest({ streamId: 1, index: 0, flags: 1, position: 0, size: 8 });
+                await Promise.resolve();
+                expect(resolved).toBe(true);
+                expect(errorHandler).not.toHaveBeenCalled();
+
+                // The batch finished on acknowledgment, so the inactivity watchdog never fires:
+                // letting the full window elapse must not surface an error.
+                await vi.advanceTimersByTimeAsync(60_000);
+                expect(errorHandler).not.toHaveBeenCalled();
+
+                p.dispose();
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it('reports isUploadInProgress across an upload lifecycle (idle -> advertised -> complete)', async () => {
+            vi.useFakeTimers();
+            try {
+                const { provider: p } = setupProvider();
+                expect(p.isUploadInProgress()).toBe(false);
+
+                const { completion } = p.uploadFiles([new File(['data'], 'x.txt', { type: 'text/plain' })]);
+                expect(p.isUploadInProgress()).toBe(true);
+
+                // Remote pulls the whole file -> batch completes -> upload state released.
+                // @ts-expect-error - private callback the WASM layer drives
+                p.handleFileContentsRequest({ streamId: 1, index: 0, flags: 2, position: 0, size: 4 });
+                await vi.advanceTimersByTimeAsync(100);
+                await completion;
+                expect(p.isUploadInProgress()).toBe(false);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it('clears isUploadInProgress once a stalled upload is failed', async () => {
+            vi.useFakeTimers();
+            try {
+                const { provider: p } = setupProvider();
+                const { completion } = p.uploadFiles([new File(['x'], 'x.txt', { type: 'text/plain' })]);
+                const rejected = expect(completion).rejects.toThrow();
+                expect(p.isUploadInProgress()).toBe(true);
+
+                // Remote never pulls -> the watchdog fails the upload and releases the state.
+                await vi.advanceTimersByTimeAsync(60_000);
+                await rejected;
+                expect(p.isUploadInProgress()).toBe(false);
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it('reports isUploadInProgress again during a remote re-paste', async () => {
+            vi.useFakeTimers();
+            try {
+                const { provider: p } = setupProvider();
+                const { completion } = p.uploadFiles([new File(['data'], 'x.txt', { type: 'text/plain' })]);
+                // @ts-expect-error - private callback the WASM layer drives
+                p.handleFileContentsRequest({ streamId: 1, index: 0, flags: 2, position: 0, size: 4 });
+                await vi.advanceTimersByTimeAsync(100);
+                await completion;
+                expect(p.isUploadInProgress()).toBe(false);
+
+                // The remote re-pastes the retained file: state is rebuilt, so it's in progress again.
+                // @ts-expect-error - private callback the WASM layer drives
+                p.handleFileContentsRequest({ streamId: 2, index: 0, flags: 1, position: 0, size: 8 });
+                expect(p.isUploadInProgress()).toBe(true);
+
+                p.dispose();
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it('supersedes an in-flight upload when a new one starts (old completion resolves, new batch advertised)', async () => {
+            const { provider: p, session: s } = setupProvider();
+            const { completion: firstCompletion } = p.uploadFiles([
+                new File(['data'], 'first.txt', { type: 'text/plain' }),
+            ]);
+            expect(p.isUploadInProgress()).toBe(true);
+
+            // A new paste arrives while the first is still advertised. The old completion resolves
+            // cleanly and the new batch is advertised in its place.
+            s.invokeExtension.mockClear();
+            const { completion: secondCompletion } = p.uploadFiles([
+                new File(['more'], 'second.txt', { type: 'text/plain' }),
+            ]);
+
+            await expect(firstCompletion).resolves.toBeUndefined();
+            expect(p.isUploadInProgress()).toBe(true); // now the second batch
+            expect(s.invokeExtension).toHaveBeenCalledTimes(1); // a fresh initiateFileCopy
+
+            p.dispose();
+            await expect(secondCompletion).rejects.toThrow('RdpFileTransferProvider disposed');
         });
 
         it('should call onUploadFinished even on initiateFileCopy failure', async () => {
@@ -617,8 +820,8 @@ describe('RdpFileTransferProvider', () => {
 
             fireFormatListResponse(p, true);
 
-            // Upload is still in progress: a second attempt still hits the guard.
-            expect(() => p.uploadFiles(files)).toThrow('Upload already in progress');
+            // Upload is still in progress.
+            expect(p.isUploadInProgress()).toBe(true);
 
             p.dispose();
             await expect(completion).rejects.toThrow('RdpFileTransferProvider disposed');

--- a/web-client/iron-remote-desktop-rdp/src/RdpFileTransferProvider.ts
+++ b/web-client/iron-remote-desktop-rdp/src/RdpFileTransferProvider.ts
@@ -634,8 +634,10 @@ export class RdpFileTransferProvider {
      * ```
      */
     uploadFiles(files: File[] | DroppedFile[]): UploadHandle {
+        // A new paste supersedes the previous offer (MS-RDPECLIP §3.1.1.1), so tear down any
+        // existing batch instead of throwing.
         if (this.uploadState !== undefined) {
-            throw new Error('Upload already in progress');
+            this.supersedeUpload();
         }
 
         // New upload supersedes any retained files from a previous batch
@@ -722,8 +724,18 @@ export class RdpFileTransferProvider {
         return { transferIds, completion };
     }
 
-    /** Suppress clipboard monitoring for the duration of an upload's paste window. */
+    /** Whether an upload batch is currently advertised or in flight (a fresh upload, or a re-paste
+     *  rebuilt from retained files). */
+    isUploadInProgress(): boolean {
+        return this.uploadState !== undefined;
+    }
+
+    /** Suppress clipboard monitoring for an upload's paste window. Idempotent: a supersede keeps
+     *  monitoring suppressed across the old->new upload, so this must not re-fire `onUploadStarted`. */
     private suppressUploadMonitoring(): void {
+        if (this.uploadMonitoringSuppressed) {
+            return;
+        }
         // Flip the flag before the callback so it holds even if the callback throws.
         this.uploadMonitoringSuppressed = true;
         try {
@@ -812,7 +824,36 @@ export class RdpFileTransferProvider {
             this.clearPasteAckWatchdog();
             this.resumeUploadMonitoring();
         }
+
+        // A directory-only batch (expectedFileCount === 0) gets a SIZE request per directory but
+        // never a RANGE -- the only path that marks a file complete -- so finishUploadBatch would
+        // never run and the inactivity watchdog below would fail an upload that actually succeeded.
+        // The remote acknowledging the paste is the only completion signal a data-less batch can
+        // get, so finish it now. (Mirrors the 0-byte file SIZE-path completion; here there are no
+        // counted files at all.) Re-pastes are left alone, like the watchdog itself.
+        const state = this.uploadState;
+        if (state !== undefined && state.isRePaste !== true && state.expectedFileCount === 0) {
+            this.finishUploadBatch(state);
+            return;
+        }
+
         this.resetUploadInactivityWatchdog();
+    }
+
+    /**
+     * Abort any in-flight chunk reads for a batch and clear their timeouts. Without this, a read
+     * still running when the batch is torn down keeps its FileReader and a 60s reader-timeout
+     * alive. Shared by every upload teardown path (fail, supersede, dispose).
+     */
+    private abortInFlightReads(state: UploadState): void {
+        for (const timeout of state.readerTimeouts.values()) {
+            clearTimeout(timeout);
+        }
+        state.readerTimeouts.clear();
+        for (const reader of state.activeReaders.values()) {
+            reader.abort();
+        }
+        state.activeReaders.clear();
     }
 
     /**
@@ -829,24 +870,32 @@ export class RdpFileTransferProvider {
         if (state === undefined) {
             return;
         }
-        // Abort any in-flight chunk reads and clear their timeouts before releasing the
-        // state (mirrors dispose()). Otherwise a read still running when the paste is torn
-        // down keeps its FileReader and a 60s reader-timeout alive for an upload that has
-        // already been rejected.
-        for (const timeout of state.readerTimeouts.values()) {
-            clearTimeout(timeout);
-        }
-        state.readerTimeouts.clear();
-        for (const reader of state.activeReaders.values()) {
-            reader.abort();
-        }
-        state.activeReaders.clear();
+        this.abortInFlightReads(state);
 
         const err: FileTransferError = { message, direction: 'upload' };
         this.emit('error', err);
         const { reject } = state;
         this.uploadState = undefined;
         reject(new Error(message));
+    }
+
+    /**
+     * Tear down the current upload because a new paste is replacing it. Unlike
+     * {@link failPendingUpload}, this emits no error and leaves monitoring suppressed (a new upload
+     * is starting); it aborts in-flight reads, clears the state, and *resolves* the old completion
+     * (a replacement, not a failure).
+     */
+    private supersedeUpload(): void {
+        this.clearPasteAckWatchdog();
+        this.clearUploadInactivityWatchdog();
+        const state = this.uploadState;
+        if (state === undefined) {
+            return;
+        }
+        this.abortInFlightReads(state);
+        const { resolve } = state;
+        this.uploadState = undefined;
+        resolve();
     }
 
     /**
@@ -1156,16 +1205,7 @@ export class RdpFileTransferProvider {
 
         // Clean up active FileReaders, clear timeouts, and reject upload promise
         if (this.uploadState !== undefined) {
-            for (const timeout of this.uploadState.readerTimeouts.values()) {
-                clearTimeout(timeout);
-            }
-            this.uploadState.readerTimeouts.clear();
-
-            for (const reader of this.uploadState.activeReaders.values()) {
-                reader.abort();
-            }
-            this.uploadState.activeReaders.clear();
-
+            this.abortInFlightReads(this.uploadState);
             this.uploadState.reject(new Error('RdpFileTransferProvider disposed'));
         }
         this.uploadState = undefined;
@@ -1322,6 +1362,13 @@ export class RdpFileTransferProvider {
             const view = new DataView(sizeBytes.buffer);
             view.setBigUint64(0, BigInt(file.size), true);
             this.sendSubmitFileContents(request.streamId, false, sizeBytes);
+
+            // A 0-byte file gets no RANGE request (no bytes to read), so complete it here --
+            // otherwise it never reaches completedFiles and the batch never finishes. Mirrors
+            // the download path's size===0 handling.
+            if (file.size === 0) {
+                this.markUploadFileComplete(request.index, file, state.transferIds.get(request.index) ?? -1);
+            }
         } else if ((request.flags & FileContentsFlags.RANGE) !== 0) {
             // RANGE request: read file chunk
             const chunk = file.slice(request.position, request.position + request.size);
@@ -1395,20 +1442,7 @@ export class RdpFileTransferProvider {
 
                     // Check if all bytes for this file have been served
                     if (served >= file.size) {
-                        const alreadyCompleted = this.uploadState.completedFiles.has(request.index);
-
-                        this.uploadState.completedFiles.add(request.index);
-
-                        if (!alreadyCompleted) {
-                            this.emit('upload-complete', file, request.index, uploadTransferId);
-                        }
-
-                        if (this.uploadState.completedFiles.size === this.uploadState.expectedFileCount) {
-                            // All files uploaded successfully. finishUploadBatch retains the
-                            // DroppedFile metadata so a re-paste from the remote can serve the
-                            // data again, and stops the inactivity watchdog.
-                            this.finishUploadBatch(this.uploadState);
-                        }
+                        this.markUploadFileComplete(request.index, file, uploadTransferId);
                     }
                 }
             };
@@ -1452,6 +1486,23 @@ export class RdpFileTransferProvider {
             };
 
             reader.readAsArrayBuffer(chunk);
+        }
+    }
+
+    /**
+     * Mark a single upload file as fully served: record it, emit upload-complete once, and
+     * finalize the batch once every counted file is accounted for. Shared by the RANGE onload
+     * path (final chunk served) and the SIZE path for 0-byte files (which get no RANGE request).
+     */
+    private markUploadFileComplete(index: number, file: File, transferId: number): void {
+        const state = this.uploadState;
+        if (state === undefined || state.completedFiles.has(index)) {
+            return;
+        }
+        state.completedFiles.add(index);
+        this.emit('upload-complete', file, index, transferId);
+        if (state.completedFiles.size === state.expectedFileCount) {
+            this.finishUploadBatch(state);
         }
     }
 


### PR DESCRIPTION
## Problem

#1372 made `RdpFileTransferProvider` **recover** `uploadState` when a paste is interrupted or never
pulled (paste-ack + inactivity watchdogs), so a stuck paste no longer wedges every later upload. But
recovery is only automatic and only after the ~60s watchdog windows. Two gaps remain:

- **A stuck upload still hard-blocks a new one.** `uploadFiles()` throws `Upload already in progress`
  while `uploadState` is set. So a user who cancels the copy on the remote (no CLIPRDR signal for
  that) or hits a stalled paste can't just retry — they wait for a watchdog. There's also no way for
  a host to *ask* whether an upload is in progress, so hosts track a parallel flag that can drift
  from `uploadState`.
- **Zero-byte files never complete.** A file is marked complete when its bytes are served (the RANGE
  `onload`). A 0-byte file has no bytes, so the remote requests only `FILECONTENTS_SIZE` and never a
  `FILECONTENTS_RANGE` — the file is counted in `expectedFileCount` but never added to
  `completedFiles`, the batch never finishes, and `uploadState` sticks (which #1372's watchdog then
  fails after ~60s). Pasting a folder containing empty files  hangs.

## Fix

A natural extension of #1372's recovery model — same `uploadState` lifecycle, two more terminal
paths:

- **Supersede instead of refuse.** When `uploadState` is already set, `uploadFiles()` tears the stale
  batch down (new `supersedeUpload()`: abort in-flight reads, clear #1372's watchdogs, **resolve** the
  old `completion` — no error, since it's a replacement, not a failure) and advertises the new files.
  A new Format List supersedes the previous offer anyway per [[MS-RDPECLIP] 3.1.1.1](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeclip/680788b3-2bd8-4e2b-9806-589aba7cf814). The superseding
  upload re-arms #1372's watchdogs, so all of its recovery still applies. `suppressUploadMonitoring`
  is made idempotent for the old→new handoff. The in-flight-read teardown shared by `supersedeUpload`,
  `failPendingUpload`, and `dispose` is factored into one `abortInFlightReads()` helper (was copied in
  all three).
- **`isUploadInProgress(): boolean`** — small getter (`uploadState !== undefined`) so a host can use
  the provider as the single source of truth for its own one-upload-at-a-time decision (covering both
  host uploads and remote re-pastes), and decide *when* to supersede.
- **Complete zero-byte files.** A 0-byte file gets a `FILECONTENTS_SIZE` request but never a RANGE, so
  in the SIZE branch it's marked complete right after replying — mirroring the download path's existing
  `size === 0` handling. The "mark one file complete" step (record it, emit `upload-complete` once,
  `finishUploadBatch` when the batch is fully accounted) is a single `markUploadFileComplete()` helper
  shared by the RANGE-onload path and this SIZE path, so the two can't drift. Purely client-side; the
  protocol already delivers the SIZE request.

Where #1372 *recovers* a stuck upload automatically, this lets a new paste *replace* it immediately —
and stops empty files from getting stuck in the first place.

## Scope

- `iron-remote-desktop-rdp` (web) only. No `ironrdp-cliprdr` / `ironrdp-web` / binding changes. Builds
  on #1372. The internal helpers (`markUploadFileComplete`, `abortInFlightReads`) are pure
  refactors that de-duplicate existing logic — no behavior change from them.
- **Public API addition:** `isUploadInProgress(): boolean`.
- **Behavioral change to `uploadFiles()` — note for existing callers:** it no longer throws
  `Upload already in progress` when a batch is already in flight; it supersedes the prior batch and
  **resolves** that batch's `completion`. A caller that wrapped `uploadFiles()` in a try/catch for that
  specific error can drop it — the call now always starts the new batch. Callers that want
  one-upload-at-a-time semantics should gate on the new `isUploadInProgress()` and decide whether to
  refuse or supersede (this is exactly what the getter enables). No other behavior changes.

## Tests

`RdpFileTransferProvider.test.ts`:

- `isUploadInProgress` across a lifecycle (idle → advertised → complete), released after a stalled
  failure, and true again during a re-paste.
- Superseding an in-flight upload resolves the old `completion` and advertises a new batch in its
  place.
- A lone 0-byte file completes from its `FILECONTENTS_SIZE` request alone (no RANGE); a 0-byte file
  finishes a mixed batch only after the data files are served.
- The two #1372 tests that asserted the `Upload already in progress` throw now assert
  `isUploadInProgress()` (the supersede behavior).
