### PR TITLE
fix(pdu): set COMPRESSION_USED on the FastPath update header when compressed

### DIFF
--- a/crates/ironrdp-pdu/src/basic_output/fast_path/mod.rs
+++ b/crates/ironrdp-pdu/src/basic_output/fast_path/mod.rs
@@ -141,11 +141,15 @@ impl Encode for FastPathUpdatePdu<'_> {
         let mut header = 0u8;
         header.set_bits(0..4, self.update_code.as_u8());
         header.set_bits(4..6, self.fragmentation.as_u8());
+        if self.compression_flags.is_some() {
+            // The COMPRESSION_USED bit must be set on the header byte before it
+            // is written, so the decoder knows a compression flags byte follows.
+            header.set_bits(6..8, Compression::COMPRESSION_USED.bits());
+        }
 
         dst.write_u8(header);
 
         if self.compression_flags.is_some() {
-            header.set_bits(6..8, Compression::COMPRESSION_USED.bits());
             let compression_flags_with_type =
                 self.compression_flags.map(|f| f.bits()).unwrap_or(0) | self.compression_type.map_or(0, |f| f.as_u8());
             dst.write_u8(compression_flags_with_type);

--- a/crates/ironrdp-pdu/src/basic_output/fast_path/tests.rs
+++ b/crates/ironrdp-pdu/src/basic_output/fast_path/tests.rs
@@ -196,3 +196,23 @@ fn palette_decode_with_code_returns_palette_variant() {
         other => panic!("Expected Palette variant, got: {other:?}"),
     }
 }
+
+#[test]
+fn compressed_update_round_trips() {
+    // The encoder must set the COMPRESSION_USED bit on the update header when
+    // compression flags are present, otherwise the decoder does not consume the
+    // trailing compression flags byte and misreads the data length.
+    let data = [0xAAu8; 8];
+    let pdu = FastPathUpdatePdu {
+        fragmentation: Fragmentation::Single,
+        update_code: UpdateCode::SurfaceCommands,
+        compression_flags: Some(CompressionFlags::COMPRESSED),
+        compression_type: Some(CompressionType::K64),
+        data: &data,
+    };
+
+    let mut buffer = vec![0u8; pdu.size()];
+    encode(&pdu, buffer.as_mut_slice()).unwrap();
+
+    assert_eq!(pdu, decode::<FastPathUpdatePdu<'_>>(&buffer).unwrap());
+}


### PR DESCRIPTION
`FastPathUpdatePdu::encode` writes the update header byte before setting the `COMPRESSION_USED` bit, so a PDU encoded with `compression_flags` set emits the trailing compression flags byte but never marks it in the header.

`FastPathUpdatePdu::decode` keys on that bit (bits 6..7 of the update header) to decide whether to consume the compression flags byte. With the bit clear, it skips that byte and reads the data length from the wrong offset, so a compressed FastPath update does not round-trip through encode/decode.

This is currently latent: nothing in the workspace encodes a compressed fast-path output PDU (the server only decompresses, on the client side), so the path is never exercised. It surfaces as soon as anything does (it turned up while writing a bulk-decompression round-trip test).

The fix sets the bit on the header before it is written, and adds a round-trip test (`compressed_update_round_trips`) covering the compressed case.
