### PR TITLE
perf(graphics): portable SIMD inverse DWT (wide + SWAR)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2696,6 +2696,7 @@ dependencies = [
  "ironrdp-pdu",
  "num-derive",
  "num-traits",
+ "wide",
  "yuv",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2696,7 +2696,7 @@ dependencies = [
  "ironrdp-pdu",
  "num-derive",
  "num-traits",
- "wide",
+ "wide 0.7.33",
  "yuv",
 ]
 
@@ -3947,7 +3947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6b2b561d2103303e233779545da757ecd35bad82188d619a6d8901f3007e1ff"
 dependencies = [
  "openh264-sys2",
- "wide",
+ "wide 1.5.0",
 ]
 
 [[package]]
@@ -5131,6 +5131,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "safe_arch"
@@ -6620,12 +6629,22 @@ dependencies = [
 
 [[package]]
 name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch 0.7.4",
+]
+
+[[package]]
+name = "wide"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfdfe6a32973f2d1b268b8895845a8a96cac2f0191e72c27cc929036060dbf89"
 dependencies = [
  "bytemuck",
- "safe_arch",
+ "safe_arch 1.0.0",
 ]
 
 [[package]]

--- a/crates/ironrdp-graphics/Cargo.toml
+++ b/crates/ironrdp-graphics/Cargo.toml
@@ -26,6 +26,7 @@ byteorder = "1.5" # TODO: remove
 num-derive.workspace = true # TODO: remove
 num-traits.workspace = true # TODO: remove
 yuv = { version = "0.8", features = ["rdp"] }
+wide = "0.7" # portable SIMD for the inverse DWT (wasm/x86/ARM); `std::simd` is still nightly-only
 
 [dev-dependencies]
 bmp = "0.5"

--- a/crates/ironrdp-graphics/src/dwt.rs
+++ b/crates/ironrdp-graphics/src/dwt.rs
@@ -1,4 +1,33 @@
 use ironrdp_pdu::utils::SplitTo as _;
+use wide::i16x8;
+
+/// Max RFX sub-band width. The 8-wide tiling and the `[_; MAX_SUBBAND_WIDTH + 1]` scratch in the
+/// inverse passes rely on `subband_width` being one of {8, 16, 32}.
+const MAX_SUBBAND_WIDTH: usize = 32;
+
+/// Loads 8 contiguous `i16` from `s[off..]` into a vector. The caller guarantees `off + 8 <= s.len()`.
+#[inline]
+fn vld(s: &[i16], off: usize) -> i16x8 {
+    i16x8::from(<[i16; 8]>::try_from(&s[off..off + 8]).expect("off + 8 within bounds"))
+}
+
+/// Stores a vector into `s[off..]`.
+#[inline]
+fn vst(s: &mut [i16], off: usize, v: i16x8) {
+    s[off..off + 8].copy_from_slice(&v.to_array());
+}
+
+/// Ceil average `(a + b + 1) >> 1`, overflow-free (SWAR; arithmetic shift).
+#[inline]
+fn ceil_avg(a: i16x8, b: i16x8) -> i16x8 {
+    (a | b) - ((a ^ b) >> 1)
+}
+
+/// Floor average `(a + b) >> 1`, overflow-free (SWAR; arithmetic shift).
+#[inline]
+fn floor_avg(a: i16x8, b: i16x8) -> i16x8 {
+    (a & b) + ((a ^ b) >> 1)
+}
 
 pub fn encode(buffer: &mut [i16], temp_buffer: &mut [i16]) {
     encode_block::<32>(&mut *buffer, temp_buffer);
@@ -119,94 +148,119 @@ fn decode_block(buffer: &mut [i16], temp_buffer: &mut [i16], subband_width: usiz
     inverse_vertical(buffer, temp_buffer, subband_width);
 }
 
-// Inverse DWT in horizontal direction, results in 2 sub-bands in L, H order in output buffer
-// The 4 sub-bands are stored in HL(0), LH(1), HH(2), LL(3) order.
-// The lower part L uses LL(3) and HL(0).
-// The higher part H uses LH(1) and HH(2).
-fn inverse_horizontal(mut buffer: &[i16], temp_buffer: &mut [i16], subband_width: usize) {
-    let total_width = subband_width * 2;
-    let squared_subband_width = subband_width.pow(2);
+// Inverse DWT horizontal pass (portable `wide`). The 4 sub-bands are stored HL(0), LH(1), HH(2),
+// LL(3); the L band reconstructs from LL+HL, the H band from LH+HH. Each row is reconstructed by
+// `horizontal_band`.
+fn inverse_horizontal(buffer: &[i16], temp_buffer: &mut [i16], subband_width: usize) {
+    let sw = subband_width;
+    let tw = sw * 2;
+    let ssw = sw * sw;
+    let hl = &buffer[0..ssw];
+    let lh = &buffer[ssw..2 * ssw];
+    let hh = &buffer[2 * ssw..3 * ssw];
+    let ll = &buffer[3 * ssw..4 * ssw];
+    let (l_dst, h_dst) = temp_buffer.split_at_mut(ssw * 2);
 
-    let mut hl = buffer.split_to(squared_subband_width);
-    let mut lh = buffer.split_to(squared_subband_width);
-    let mut hh = buffer.split_to(squared_subband_width);
-    let mut ll = buffer;
-
-    let (mut l_dst, mut h_dst) = temp_buffer.split_at_mut(squared_subband_width * 2);
-
-    for _ in 0..subband_width {
-        // Even coefficients
-        l_dst[0] = i32_to_i16_possible_truncation(i32::from(ll[0]) - ((i32::from(hl[0]) + i32::from(hl[0]) + 1) >> 1));
-        h_dst[0] = i32_to_i16_possible_truncation(i32::from(lh[0]) - ((i32::from(hh[0]) + i32::from(hh[0]) + 1) >> 1));
-        for n in 1..subband_width {
-            let x = n * 2;
-            l_dst[x] =
-                i32_to_i16_possible_truncation(i32::from(ll[n]) - ((i32::from(hl[n - 1]) + i32::from(hl[n]) + 1) >> 1));
-            h_dst[x] =
-                i32_to_i16_possible_truncation(i32::from(lh[n]) - ((i32::from(hh[n - 1]) + i32::from(hh[n]) + 1) >> 1));
-        }
-
-        // Odd coefficients
-        for n in 0..subband_width - 1 {
-            let x = n * 2;
-            l_dst[x + 1] = i32_to_i16_possible_truncation(
-                i32::from(hl[n] << 1) + ((i32::from(l_dst[x]) + i32::from(l_dst[x + 2])) >> 1),
-            );
-            h_dst[x + 1] = i32_to_i16_possible_truncation(
-                i32::from(hh[n] << 1) + ((i32::from(h_dst[x]) + i32::from(h_dst[x + 2])) >> 1),
-            );
-        }
-        let n = subband_width - 1;
-        let x = n * 2;
-        l_dst[x + 1] = i32_to_i16_possible_truncation(i32::from(hl[n] << 1) + i32::from(l_dst[x]));
-        h_dst[x + 1] = i32_to_i16_possible_truncation(i32::from(hh[n] << 1) + i32::from(h_dst[x]));
-
-        hl = &hl[subband_width..];
-        lh = &lh[subband_width..];
-        hh = &hh[subband_width..];
-        ll = &ll[subband_width..];
-
-        l_dst = &mut l_dst[total_width..];
-        h_dst = &mut h_dst[total_width..];
+    for r in 0..sw {
+        let row = r * sw;
+        horizontal_band(
+            &ll[row..row + sw],
+            &hl[row..row + sw],
+            &mut l_dst[r * tw..r * tw + tw],
+            sw,
+        );
+        horizontal_band(
+            &lh[row..row + sw],
+            &hh[row..row + sw],
+            &mut h_dst[r * tw..r * tw + tw],
+            sw,
+        );
     }
 }
 
-fn inverse_vertical(mut buffer: &mut [i16], mut temp_buffer: &[i16], subband_width: usize) {
-    let total_width = subband_width * 2;
+// One band of the inverse horizontal pass, vectorized along `n` (`wide`): `low`/`high` are the two
+// source subband rows (len `sw`), `dst` the reconstructed row (len `2*sw`, even/odd interleaved).
+// Bit-exact with the former scalar code (SWAR averages + wrapping `i16` arithmetic). `sw` is a
+// multiple of 8 and ≤ 32.
+fn horizontal_band(low: &[i16], high: &[i16], dst: &mut [i16], sw: usize) {
+    debug_assert!(
+        sw % 8 == 0 && sw <= MAX_SUBBAND_WIDTH,
+        "sw must be a multiple of 8 and <= MAX_SUBBAND_WIDTH"
+    );
 
-    for _ in 0..total_width {
-        buffer[0] = i32_to_i16_possible_truncation(
-            i32::from(temp_buffer[0]) - ((i32::from(temp_buffer[subband_width * total_width]) * 2 + 1) >> 1),
+    // Left-shifted copy so `high_pad[n] == high[n-1]` (and `high[0]` for n == 0): lets the even
+    // pass load the left neighbour contiguously instead of shuffling.
+    let mut high_pad = [0i16; MAX_SUBBAND_WIDTH + 1];
+    high_pad[0] = high[0];
+    high_pad[1..sw].copy_from_slice(&high[0..sw - 1]);
+
+    // `ev`/`od` padded so the odd pass can read `ev[n+1]` at n = sw-1 in bounds.
+    let mut ev = [0i16; MAX_SUBBAND_WIDTH + 1];
+    let mut od = [0i16; MAX_SUBBAND_WIDTH + 1];
+
+    // EVEN: ev[n] = low[n] - ceil_avg(high[n-1], high[n]).
+    let mut n = 0;
+    while n < sw {
+        vst(&mut ev, n, vld(low, n) - ceil_avg(vld(&high_pad, n), vld(high, n)));
+        n += 8;
+    }
+
+    // ODD: od[n] = (high[n] << 1) + floor_avg(ev[n], ev[n+1]).
+    let mut n = 0;
+    while n < sw {
+        vst(
+            &mut od,
+            n,
+            (vld(high, n) << 1) + floor_avg(vld(&ev, n), vld(&ev, n + 1)),
         );
+        n += 8;
+    }
+    // n = sw-1 has no right neighbour.
+    od[sw - 1] = i32_to_i16_possible_truncation((i32::from(high[sw - 1]) << 1) + i32::from(ev[sw - 1]));
 
-        let mut l = temp_buffer;
-        let mut lh = &temp_buffer[(subband_width - 1) * total_width..];
-        let mut h = &temp_buffer[subband_width * total_width..];
-        let mut dst = &mut *buffer;
+    // INTERLEAVE: dst[2n] = ev[n], dst[2n+1] = od[n].
+    for n in 0..sw {
+        dst[2 * n] = ev[n];
+        dst[2 * n + 1] = od[n];
+    }
+}
 
-        for _ in 1..subband_width {
-            l = &l[total_width..];
-            lh = &lh[total_width..];
-            h = &h[total_width..];
+// Inverse DWT vertical pass, vectorized over 8 contiguous columns per step (portable `wide`).
+// Bit-exact with the former scalar code: `(2*x+1)>>1 == x` and `(x+x)>>1 == x` simplify the
+// first/last rows, the averages use the overflow-free SWAR `ceil_avg`/`floor_avg`, and every other
+// op is wrapping `i16` arithmetic (identical to i32-intermediate-then-truncate).
+// Precondition: `subband_width` is a multiple of 8 and <= MAX_SUBBAND_WIDTH (for the 8-wide tiling).
+fn inverse_vertical(buffer: &mut [i16], temp_buffer: &[i16], subband_width: usize) {
+    let sw = subband_width;
+    let tw = sw * 2;
+    debug_assert!(
+        sw % 8 == 0 && sw <= MAX_SUBBAND_WIDTH,
+        "sw must be a multiple of 8 and <= MAX_SUBBAND_WIDTH"
+    );
 
-            // Even coefficients
-            dst[2 * total_width] =
-                i32_to_i16_possible_truncation(i32::from(l[0]) - ((i32::from(lh[0]) + i32::from(h[0]) + 1) >> 1));
+    let mut cb = 0;
+    while cb < tw {
+        // Row 0: L0 - ((H0*2 + 1) >> 1) == L0 - H0.
+        vst(buffer, cb, vld(temp_buffer, cb) - vld(temp_buffer, cb + sw * tw));
 
-            // Odd coefficients
-            dst[total_width] = i32_to_i16_possible_truncation(
-                i32::from(lh[0] << 1) + ((i32::from(dst[0]) + i32::from(dst[2 * total_width])) >> 1),
-            );
+        for k in 1..sw {
+            let l = vld(temp_buffer, cb + k * tw);
+            let h = vld(temp_buffer, cb + (sw + k) * tw);
+            let lh = vld(temp_buffer, cb + (sw - 1 + k) * tw);
 
-            dst = &mut dst[2 * total_width..];
+            let even = l - ceil_avg(lh, h);
+            vst(buffer, cb + k * 2 * tw, even);
+
+            let d0 = vld(buffer, cb + (k - 1) * 2 * tw);
+            vst(buffer, cb + (2 * k - 1) * tw, (lh << 1) + floor_avg(d0, even));
         }
 
-        dst[total_width] = i32_to_i16_possible_truncation(
-            i32::from(lh[total_width] << 1) + ((i32::from(dst[0]) + i32::from(dst[0])) >> 1),
-        );
+        // Final odd row: (lhN << 1) + ((d0 + d0) >> 1) == (lhN << 1) + d0.
+        let lhn = vld(temp_buffer, cb + (2 * sw - 1) * tw);
+        let dl = vld(buffer, cb + (2 * sw - 2) * tw);
+        vst(buffer, cb + (2 * sw - 1) * tw, (lhn << 1) + dl);
 
-        temp_buffer = &temp_buffer[1..];
-        buffer = &mut buffer[1..];
+        cb += 8;
     }
 }
 

--- a/crates/ironrdp-graphics/src/dwt.rs
+++ b/crates/ironrdp-graphics/src/dwt.rs
@@ -155,16 +155,15 @@ fn inverse_horizontal<const SUBBAND_WIDTH: usize>(buffer: &[i16], temp_buffer: &
     let sw = SUBBAND_WIDTH;
     let tw = sw * 2;
     let ssw = sw * sw;
-    let hl = &buffer[0..ssw];
-    let lh = &buffer[ssw..2 * ssw];
-    let hh = &buffer[2 * ssw..3 * ssw];
-    let ll = &buffer[3 * ssw..4 * ssw];
+    let (hl, rest) = buffer.split_at(ssw);
+    let (lh, rest) = rest.split_at(ssw);
+    let (hh, ll) = rest.split_at(ssw);
     let (l_dst, h_dst) = temp_buffer.split_at_mut(ssw * 2);
 
     for r in 0..sw {
         let row = r * sw;
-        horizontal_band::<SUBBAND_WIDTH>(&ll[row..row + sw], &hl[row..row + sw], &mut l_dst[r * tw..r * tw + tw]);
-        horizontal_band::<SUBBAND_WIDTH>(&lh[row..row + sw], &hh[row..row + sw], &mut h_dst[r * tw..r * tw + tw]);
+        horizontal_band::<SUBBAND_WIDTH>(&ll[row..][..sw], &hl[row..][..sw], &mut l_dst[r * tw..][..tw]);
+        horizontal_band::<SUBBAND_WIDTH>(&lh[row..][..sw], &hh[row..][..sw], &mut h_dst[r * tw..][..tw]);
     }
 }
 

--- a/crates/ironrdp-graphics/src/dwt.rs
+++ b/crates/ironrdp-graphics/src/dwt.rs
@@ -163,16 +163,8 @@ fn inverse_horizontal<const SUBBAND_WIDTH: usize>(buffer: &[i16], temp_buffer: &
 
     for r in 0..sw {
         let row = r * sw;
-        horizontal_band::<SUBBAND_WIDTH>(
-            &ll[row..row + sw],
-            &hl[row..row + sw],
-            &mut l_dst[r * tw..r * tw + tw],
-        );
-        horizontal_band::<SUBBAND_WIDTH>(
-            &lh[row..row + sw],
-            &hh[row..row + sw],
-            &mut h_dst[r * tw..r * tw + tw],
-        );
+        horizontal_band::<SUBBAND_WIDTH>(&ll[row..row + sw], &hl[row..row + sw], &mut l_dst[r * tw..r * tw + tw]);
+        horizontal_band::<SUBBAND_WIDTH>(&lh[row..row + sw], &hh[row..row + sw], &mut h_dst[r * tw..r * tw + tw]);
     }
 }
 

--- a/crates/ironrdp-graphics/src/dwt.rs
+++ b/crates/ironrdp-graphics/src/dwt.rs
@@ -8,13 +8,13 @@ const MAX_SUBBAND_WIDTH: usize = 32;
 /// Loads 8 contiguous `i16` from `s[off..]` into a vector. The caller guarantees `off + 8 <= s.len()`.
 #[inline]
 fn vld(s: &[i16], off: usize) -> i16x8 {
-    i16x8::from(<[i16; 8]>::try_from(&s[off..off + 8]).expect("off + 8 within bounds"))
+    i16x8::from_slice_unaligned(&s[off..][..8])
 }
 
 /// Stores a vector into `s[off..]`.
 #[inline]
 fn vst(s: &mut [i16], off: usize, v: i16x8) {
-    s[off..off + 8].copy_from_slice(&v.to_array());
+    s[off..][..8].copy_from_slice(v.as_array_ref());
 }
 
 /// Ceil average `(a + b + 1) >> 1`, overflow-free (SWAR; arithmetic shift).
@@ -138,21 +138,21 @@ fn dwt_horizontal<const SUBBAND_WIDTH: usize>(mut buffer: &mut [i16], dwt: &[i16
 }
 
 pub fn decode(buffer: &mut [i16], temp_buffer: &mut [i16]) {
-    decode_block(&mut buffer[3840..], temp_buffer, 8);
-    decode_block(&mut buffer[3072..], temp_buffer, 16);
-    decode_block(&mut *buffer, temp_buffer, 32);
+    decode_block::<8>(&mut buffer[3840..], temp_buffer);
+    decode_block::<16>(&mut buffer[3072..], temp_buffer);
+    decode_block::<32>(&mut *buffer, temp_buffer);
 }
 
-fn decode_block(buffer: &mut [i16], temp_buffer: &mut [i16], subband_width: usize) {
-    inverse_horizontal(buffer, temp_buffer, subband_width);
-    inverse_vertical(buffer, temp_buffer, subband_width);
+fn decode_block<const SUBBAND_WIDTH: usize>(buffer: &mut [i16], temp_buffer: &mut [i16]) {
+    inverse_horizontal::<SUBBAND_WIDTH>(buffer, temp_buffer);
+    inverse_vertical::<SUBBAND_WIDTH>(buffer, temp_buffer);
 }
 
 // Inverse DWT horizontal pass (portable `wide`). The 4 sub-bands are stored HL(0), LH(1), HH(2),
 // LL(3); the L band reconstructs from LL+HL, the H band from LH+HH. Each row is reconstructed by
 // `horizontal_band`.
-fn inverse_horizontal(buffer: &[i16], temp_buffer: &mut [i16], subband_width: usize) {
-    let sw = subband_width;
+fn inverse_horizontal<const SUBBAND_WIDTH: usize>(buffer: &[i16], temp_buffer: &mut [i16]) {
+    let sw = SUBBAND_WIDTH;
     let tw = sw * 2;
     let ssw = sw * sw;
     let hl = &buffer[0..ssw];
@@ -163,17 +163,15 @@ fn inverse_horizontal(buffer: &[i16], temp_buffer: &mut [i16], subband_width: us
 
     for r in 0..sw {
         let row = r * sw;
-        horizontal_band(
+        horizontal_band::<SUBBAND_WIDTH>(
             &ll[row..row + sw],
             &hl[row..row + sw],
             &mut l_dst[r * tw..r * tw + tw],
-            sw,
         );
-        horizontal_band(
+        horizontal_band::<SUBBAND_WIDTH>(
             &lh[row..row + sw],
             &hh[row..row + sw],
             &mut h_dst[r * tw..r * tw + tw],
-            sw,
         );
     }
 }
@@ -182,11 +180,14 @@ fn inverse_horizontal(buffer: &[i16], temp_buffer: &mut [i16], subband_width: us
 // source subband rows (len `sw`), `dst` the reconstructed row (len `2*sw`, even/odd interleaved).
 // Bit-exact with the former scalar code (SWAR averages + wrapping `i16` arithmetic). `sw` is a
 // multiple of 8 and ≤ 32.
-fn horizontal_band(low: &[i16], high: &[i16], dst: &mut [i16], sw: usize) {
-    debug_assert!(
-        sw % 8 == 0 && sw <= MAX_SUBBAND_WIDTH,
-        "sw must be a multiple of 8 and <= MAX_SUBBAND_WIDTH"
-    );
+fn horizontal_band<const SUBBAND_WIDTH: usize>(low: &[i16], high: &[i16], dst: &mut [i16]) {
+    const {
+        assert!(
+            SUBBAND_WIDTH == 8 || SUBBAND_WIDTH == 16 || SUBBAND_WIDTH == 32,
+            "subband width must be one of 8, 16, or 32"
+        )
+    };
+    let sw = SUBBAND_WIDTH;
 
     // Left-shifted copy so `high_pad[n] == high[n-1]` (and `high[0]` for n == 0): lets the even
     // pass load the left neighbour contiguously instead of shuffling.
@@ -230,13 +231,15 @@ fn horizontal_band(low: &[i16], high: &[i16], dst: &mut [i16], sw: usize) {
 // first/last rows, the averages use the overflow-free SWAR `ceil_avg`/`floor_avg`, and every other
 // op is wrapping `i16` arithmetic (identical to i32-intermediate-then-truncate).
 // Precondition: `subband_width` is a multiple of 8 and <= MAX_SUBBAND_WIDTH (for the 8-wide tiling).
-fn inverse_vertical(buffer: &mut [i16], temp_buffer: &[i16], subband_width: usize) {
-    let sw = subband_width;
+fn inverse_vertical<const SUBBAND_WIDTH: usize>(buffer: &mut [i16], temp_buffer: &[i16]) {
+    const {
+        assert!(
+            SUBBAND_WIDTH == 8 || SUBBAND_WIDTH == 16 || SUBBAND_WIDTH == 32,
+            "subband width must be one of 8, 16, or 32"
+        )
+    };
+    let sw = SUBBAND_WIDTH;
     let tw = sw * 2;
-    debug_assert!(
-        sw % 8 == 0 && sw <= MAX_SUBBAND_WIDTH,
-        "sw must be a multiple of 8 and <= MAX_SUBBAND_WIDTH"
-    );
 
     let mut cb = 0;
     while cb < tw {

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -102,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
 
 [[package]]
 name = "byteorder"
@@ -114,9 +114,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -668,9 +668,9 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "spki"
@@ -684,9 +684,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -802,15 +802,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wide"
 version = "0.7.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,12 +810,6 @@ dependencies = [
  "bytemuck",
  "safe_arch",
 ]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wyz"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -101,6 +101,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,6 +396,7 @@ dependencies = [
  "ironrdp-pdu",
  "num-derive",
  "num-traits",
+ "wide",
  "yuv",
 ]
 
@@ -634,6 +641,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,6 +800,31 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wyz"


### PR DESCRIPTION
## Summary

On the WASM web client, frame **decode** dominates (~93% of frame time on a 1080p RemoteFX replay), and within decode the **RFX inverse DWT was ~48%** (the YCbCr→RGBA convert is already SIMD via `yuv`; the entropy/RLE stages are inherently sequential). This vectorizes the inverse DWT with the portable [`wide`](https://crates.io/crates/wide) crate (`i16x8`), so the same code lowers to **wasm `simd128`, x86 SSE/AVX, and ARM NEON** — desktop and browser both benefit.

The encode path is unchanged.

## How it stays bit-exact (no `unsafe`, no `cfg` split)

The lifting steps need i32 intermediates only for the averages. Overflow-free SWAR identities let the whole kernel stay in `i16` lanes (no widen/narrow):

- `ceil_avg(a,b)  = (a|b) - ((a^b)>>1)`  ≡ `(a + b + 1) >> 1`
- `floor_avg(a,b) = (a&b) + ((a^b)>>1)`  ≡ `(a + b) >> 1`

and `(2x+1)>>1 == x` / `(x+x)>>1 == x` simplify the first/last rows. Every other op is wrapping `i16` arithmetic, identical to the old `i32`-intermediate-then-`as i16` truncation.

## Performance

1080p RemoteFX replay, headless Chromium, wasm release `+simd128`, 8-pass median:

| inverse DWT | decode (ms) |
|---|--:|
| scalar (baseline) | ~1598 |
| **portable `wide` SIMD** | **~985** |

→ inverse DWT ~2×, **~39% off the decode stage**. (Absolute ms carry ~±15% machine-load noise; the ratio is stable. Per-frame this is a throughput win — decode was already within real-time budget.)

## Correctness

Verified bit-exact three ways:
- the replay-bench **framebuffer CRC32** is unchanged,
- the existing **native DWT tests** pass (so it's exact on x86 too, not just wasm),
- an **exhaustive** check of the SWAR identities over all `i16 × i16` pairs (0 mismatches).

## Notes

- `wide` is a single-user dep in `ironrdp-graphics`; chosen over `std::simd` (still nightly-only) and over per-arch intrinsics (one portable kernel vs three).
- Reproducible bench branches: `bench/draw-*` (renderer) and the DWT measurements were taken on the replay-bench harness branch (the capture corpus is gitignored).
