### PR TITLE
feat(tls): expose negotiated TLS version and cipher suite

### DIFF
--- a/crates/ironrdp-tls/src/lib.rs
+++ b/crates/ironrdp-tls/src/lib.rs
@@ -23,7 +23,21 @@ compile_error!("a TLS backend must be selected by enabling a single feature out 
 
 // The whole public API of this crate.
 #[cfg(any(feature = "stub", feature = "native-tls", feature = "rustls"))]
-pub use impl_::{TlsStream, upgrade};
+pub use impl_::{TlsStream, negotiated, upgrade};
+
+/// TLS parameters negotiated during the handshake, to the extent the active
+/// backend exposes them.
+///
+/// The `rustls` backend reports both fields. The `native-tls` and `stub`
+/// backends cannot introspect the negotiated parameters, so both are `None`
+/// there.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct NegotiatedTls {
+    /// Negotiated protocol version, e.g. `"TLSv1_3"`.
+    pub version: Option<String>,
+    /// Negotiated cipher suite, e.g. `"TLS13_AES_256_GCM_SHA384"`.
+    pub cipher_suite: Option<String>,
+}
 
 pub fn extract_tls_server_public_key(cert: &x509_cert::Certificate) -> Option<&[u8]> {
     cert.tbs_certificate

--- a/crates/ironrdp-tls/src/native_tls.rs
+++ b/crates/ironrdp-tls/src/native_tls.rs
@@ -39,3 +39,8 @@ where
 
     Ok((tls_stream, tls_cert))
 }
+
+/// The `native-tls` backend does not expose the negotiated version or cipher.
+pub fn negotiated<S>(_stream: &TlsStream<S>) -> crate::NegotiatedTls {
+    crate::NegotiatedTls::default()
+}

--- a/crates/ironrdp-tls/src/rustls.rs
+++ b/crates/ironrdp-tls/src/rustls.rs
@@ -51,6 +51,17 @@ where
     Ok((tls_stream, tls_cert))
 }
 
+/// Report the TLS version and cipher suite negotiated for `stream`.
+pub fn negotiated<S>(stream: &TlsStream<S>) -> crate::NegotiatedTls {
+    let (_, connection) = stream.get_ref();
+    crate::NegotiatedTls {
+        version: connection.protocol_version().map(|version| format!("{version:?}")),
+        cipher_suite: connection
+            .negotiated_cipher_suite()
+            .map(|suite| format!("{:?}", suite.suite())),
+    }
+}
+
 mod danger {
     use tokio_rustls::rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
     use tokio_rustls::rustls::{DigitallySignedStruct, Error, SignatureScheme, pki_types};

--- a/crates/ironrdp-tls/src/stub.rs
+++ b/crates/ironrdp-tls/src/stub.rs
@@ -37,3 +37,8 @@ where
     let _ = (stream, server_name);
     Err(io::Error::other("no TLS backend enabled for this build"))
 }
+
+/// The stub backend performs no handshake and reports nothing.
+pub fn negotiated<S>(_stream: &TlsStream<S>) -> crate::NegotiatedTls {
+    crate::NegotiatedTls::default()
+}


### PR DESCRIPTION
## What

Add `NegotiatedTls` and a backend-neutral `negotiated()` accessor to
`ironrdp-tls`, reporting the TLS protocol version and cipher suite
negotiated for an established `TlsStream`.

- rustls: reports both, read from the live `ClientConnection`.
- native-tls: returns `None` for both (the wrapper only exposes the peer
  certificate, ALPN, and the channel-binding token).
- stub: returns `None`.

`upgrade()` is unchanged, so this is purely additive.

## Why

Downstream RDP diagnostic tooling wants to report a server's negotiated
TLS parameters alongside the certificate `upgrade()` already returns;
today that information is discarded even though rustls exposes it. This
follows the crate's existing pattern of normalizing backend-specific
output into a neutral type, as `upgrade()` already does for the
certificate via `x509-cert`.

## Notes

Version and cipher are returned as their standard string names (e.g.
`TLSv1_3`, `TLS13_AES_256_GCM_SHA384`). Happy to reshape into a typed
form if you prefer.
