### PR TITLE
feat(tls): make the rustls crypto provider selectable

### DIFF
--- a/crates/ironrdp-tls/Cargo.toml
+++ b/crates/ironrdp-tls/Cargo.toml
@@ -18,7 +18,16 @@ test = false
 
 [features]
 default = [] # No default feature, the user must choose a TLS backend by enabling the appropriate feature.
-rustls = ["dep:tokio-rustls", "dep:x509-cert", "tokio/io-util"]
+# The rustls backend. `rustls` keeps using the aws-lc-rs crypto provider (unchanged
+# default); the crypto provider is otherwise selectable so downstream crates are not
+# forced onto a specific one.
+rustls = ["rustls-aws-lc-rs"]
+rustls-aws-lc-rs = ["rustls-no-provider", "tokio-rustls/aws_lc_rs"]
+rustls-ring = ["rustls-no-provider", "tokio-rustls/ring"]
+# rustls backend without a bundled crypto provider: the downstream must install a
+# rustls CryptoProvider as the process default before opening a connection, otherwise
+# building the client configuration panics.
+rustls-no-provider = ["dep:tokio-rustls", "dep:x509-cert", "tokio/io-util", "tokio-rustls/logging", "tokio-rustls/tls12"]
 native-tls = ["dep:tokio-native-tls", "dep:x509-cert", "tokio/io-util"]
 stub = []
 
@@ -26,7 +35,7 @@ stub = []
 tokio = { version = "1.52" }
 x509-cert = { version = "0.2", default-features = false, features = ["std"], optional = true } # public
 tokio-native-tls = { version = "0.3", optional = true } # public
-tokio-rustls =  { version = "0.26", optional = true } # public
+tokio-rustls = { version = "0.26", default-features = false, optional = true } # public
 
 [lints]
 workspace = true

--- a/crates/ironrdp-tls/README.md
+++ b/crates/ironrdp-tls/README.md
@@ -2,15 +2,26 @@
 
 TLS boilerplate common with most IronRDP clients.
 
-This crate exposes three features for selecting the TLS backend:
+This crate exposes features for selecting the TLS backend:
 
-- `rustls`: use the rustls crate.
+- `rustls`: use the rustls crate (with the default aws-lc-rs crypto provider).
 - `native-tls`: use the native-tls crate.
 - `stub`: use a stubbed backend which fail at runtime when used.
 
-These features are mutually exclusive and only one may be enabled at a time.
+These backends are mutually exclusive and only one may be enabled at a time.
 When more than one backend is enabled, a compile-time error is emitted.
 For this reason, no feature is enabled by default.
+
+When the rustls backend is used, its crypto provider is selectable so downstream
+crates are not forced onto a specific one:
+
+- `rustls` or `rustls-aws-lc-rs`: the aws-lc-rs provider. `rustls` is an alias for
+  `rustls-aws-lc-rs`, so the default backend is unchanged.
+- `rustls-ring`: the ring provider.
+- `rustls-no-provider`: no provider is bundled. The downstream must install a rustls
+  `CryptoProvider` as the process default before opening a connection, otherwise
+  building the client configuration panics. Use this to plug in a custom or pure-Rust
+  provider.
 
 The rationale is two-fold:
 

--- a/crates/ironrdp-tls/src/lib.rs
+++ b/crates/ironrdp-tls/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(doc, doc = include_str!("../README.md"))]
 #![doc(html_logo_url = "https://cdnweb.devolutions.net/images/projects/devolutions/logos/devolutions-icon-shadow.svg")]
 
-#[cfg(feature = "rustls")]
+#[cfg(feature = "rustls-no-provider")]
 #[path = "rustls.rs"]
 mod impl_;
 
@@ -14,15 +14,17 @@ mod impl_;
 mod impl_;
 
 #[cfg(any(
-    not(any(feature = "stub", feature = "native-tls", feature = "rustls")),
+    not(any(feature = "stub", feature = "native-tls", feature = "rustls-no-provider")),
     all(feature = "stub", feature = "native-tls"),
-    all(feature = "stub", feature = "rustls"),
-    all(feature = "rustls", feature = "native-tls"),
+    all(feature = "stub", feature = "rustls-no-provider"),
+    all(feature = "rustls-no-provider", feature = "native-tls"),
 ))]
-compile_error!("a TLS backend must be selected by enabling a single feature out of: `rustls`, `native-tls`, `stub`");
+compile_error!(
+    "a TLS backend must be selected by enabling a single feature out of: `rustls`, `native-tls`, `stub` (the rustls crypto provider is chosen via `rustls`/`rustls-aws-lc-rs`/`rustls-ring`/`rustls-no-provider`)"
+);
 
 // The whole public API of this crate.
-#[cfg(any(feature = "stub", feature = "native-tls", feature = "rustls"))]
+#[cfg(any(feature = "stub", feature = "native-tls", feature = "rustls-no-provider"))]
 pub use impl_::{TlsStream, negotiated, upgrade};
 
 /// TLS parameters negotiated during the handshake, to the extent the active


### PR DESCRIPTION
## What

Make the rustls crypto provider selectable in `ironrdp-tls`. The `rustls`
feature pulled `tokio-rustls` with its default features, which forces the
aws-lc-rs provider on every downstream that selects the rustls backend.
`tokio-rustls` is now depended on with `default-features = false` and the
provider is chosen by a feature:

- `rustls` / `rustls-aws-lc-rs`: the aws-lc-rs provider. `rustls` is kept as
  an alias for `rustls-aws-lc-rs`, so the default backend and its resolved
  dependencies are unchanged.
- `rustls-ring`: the ring provider.
- `rustls-no-provider`: no provider is bundled; the downstream installs a
  rustls `CryptoProvider` as the process default before connecting.

No runtime code changes. The rustls backend already builds its config from
the process-default provider (`ClientConfig::builder`) and uses a
provider-agnostic certificate verifier, so only the feature definitions and
the backend `cfg` gate change. `Cargo.lock` is unchanged for the default build.

## Why

A downstream RDP tool wants a pure-Rust TLS build (a RustCrypto provider) to
simplify cross-compilation, which is only possible if `ironrdp-tls` does not
force the aws-lc-rs provider. Making the provider selectable follows the
convention already used across the rustls ecosystem (reqwest, hyper-rustls,
tonic), which expose provider features and keep a default rather than imposing
one. The default stays aws-lc-rs.

## Notes

This is provider build-shape selection, not gating of a protocol capability,
and the default behavior is preserved. `cargo xtask check fmt/lints/tests/typos/locks`
all pass. Happy to rename the features if you prefer a different convention.
