### PR TITLE
feat(cliprdr): dispatch initiate_file_copy via ClipboardMessage

### DIFF
--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -640,6 +640,10 @@ async fn active_session(
                                     Some(cliprdr.initiate_copy(&formats)
                                         .map_err(|e| session::custom_err!("CLIPRDR", e))?)
                                 }
+                                ClipboardMessage::SendInitiateFileCopy(files) => {
+                                    Some(cliprdr.initiate_file_copy(files)
+                                        .map_err(|e| session::custom_err!("CLIPRDR", e))?)
+                                }
                                 ClipboardMessage::SendFormatData(response) => {
                                     Some(cliprdr.submit_format_data(response)
                                     .map_err(|e| session::custom_err!("CLIPRDR", e))?)

--- a/crates/ironrdp-cliprdr/src/backend.rs
+++ b/crates/ironrdp-cliprdr/src/backend.rs
@@ -43,6 +43,13 @@ pub enum ClipboardMessage {
     /// Implementation should send file contents response on `CLIPRDR` SVC when received.
     SendFileContentsResponse(FileContentsResponse<'static>),
 
+    /// Sent by clipboard backend when a local file list is ready to be offered to the remote.
+    ///
+    /// Implementation should initiate a file copy on `CLIPRDR` SVC when this message is
+    /// received. Unlike [`ClipboardMessage::SendInitiateCopy`], this records the file list so
+    /// later `FileContentsRequest`s from the remote can be serviced.
+    SendInitiateFileCopy(Vec<FileDescriptor>),
+
     /// Failure received from the OS clipboard event loop.
     ///
     /// Client implementation should log/display this error.

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -1011,6 +1011,7 @@ impl RdpServer {
                     };
                     let msgs = match c {
                         ClipboardMessage::SendInitiateCopy(formats) => cliprdr.initiate_copy(&formats),
+                        ClipboardMessage::SendInitiateFileCopy(files) => cliprdr.initiate_file_copy(files),
                         ClipboardMessage::SendFormatData(data) => cliprdr.submit_format_data(data),
                         ClipboardMessage::SendInitiatePaste(format) => cliprdr.initiate_paste(format),
                         ClipboardMessage::SendFileContentsRequest(request) => cliprdr.request_file_contents(request),

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -684,6 +684,10 @@ impl iron_remote_desktop::Session for Session {
                                         cliprdr.initiate_copy(&formats)
                                             .context("cliprdr initiate copy")?
                                     ),
+                                    ClipboardMessage::SendInitiateFileCopy(files) => Some(
+                                        cliprdr.initiate_file_copy(files)
+                                            .context("cliprdr initiate file copy")?
+                                    ),
                                     ClipboardMessage::SendFormatData(response) => Some(
                                         cliprdr.submit_format_data(response)
                                             .context("cliprdr submit format data")?

--- a/ffi/src/clipboard/message.rs
+++ b/ffi/src/clipboard/message.rs
@@ -13,6 +13,9 @@ pub mod ffi {
                 ironrdp::cliprdr::backend::ClipboardMessage::SendInitiateCopy(_) => {
                     ClipboardMessageType::SendInitiateCopy
                 }
+                ironrdp::cliprdr::backend::ClipboardMessage::SendInitiateFileCopy(_) => {
+                    ClipboardMessageType::SendInitiateFileCopy
+                }
                 ironrdp::cliprdr::backend::ClipboardMessage::SendFormatData(_) => ClipboardMessageType::SendFormatData,
                 ironrdp::cliprdr::backend::ClipboardMessage::SendInitiatePaste(_) => {
                     ClipboardMessageType::SendInitiatePaste
@@ -86,6 +89,7 @@ pub mod ffi {
 
     pub enum ClipboardMessageType {
         SendInitiateCopy,
+        SendInitiateFileCopy,
         SendFormatData,
         SendInitiatePaste,
         SendFileContentsRequest,


### PR DESCRIPTION
## Summary

- `Cliprdr::initiate_file_copy` (added in #1166) records a local file list so the peer's `FileContentsRequest` can be serviced. #1166 wired it through the web client and FFI but not through the `ClipboardMessage` backend API.
- A server or client built on that API can receive files but cannot offer them: `SendInitiateCopy` calls `initiate_copy`, leaving `local_file_list` empty, so an incoming `FileContentsRequest` is rejected with "no file list available" (MS-RDPECLIP 3.1.5.4.6) before the backend is consulted.
- Adds `ClipboardMessage::SendInitiateFileCopy(Vec<FileDescriptor>)` and dispatches it to `Cliprdr::initiate_file_copy` in every `ClipboardMessage` consumer: `ironrdp-server`, `ironrdp-client`, `ironrdp-web`, and the `ffi` message-type mapping.

## Validation

- `cargo xtask check fmt/lints/tests/typos/locks` pass.
- `ironrdp-web` additionally checked on `wasm32-unknown-unknown`.

## Notes

- Non-breaking, following the precedent of #194, #1065, and #1166, which added `ClipboardMessage` variants as `feat` while updating every in-tree consumer (done here). The receive-side path (`request_file_contents` / `submit_file_contents`) is unchanged.
- The `ffi` binding categorizes the new message (`ClipboardMessageType::SendInitiateFileCopy`); surfacing the `FileDescriptor` payload through FFI accessors would add a new opaque type surface and is left as a follow-up.
