### PR TITLE
refactor(client): drive RdpClient configuration from the PropertySet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2502,6 +2502,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "futures-util",
+ "ironrdp-cfg",
  "ironrdp-cliprdr",
  "ironrdp-cliprdr-native",
  "ironrdp-connector",
@@ -2514,6 +2515,7 @@ dependencies = [
  "ironrdp-graphics",
  "ironrdp-mstsgu",
  "ironrdp-pdu",
+ "ironrdp-propertyset",
  "ironrdp-rdcleanpath",
  "ironrdp-rdpdr",
  "ironrdp-rdpsnd",

--- a/crates/ironrdp-cfg/src/lib.rs
+++ b/crates/ironrdp-cfg/src/lib.rs
@@ -224,6 +224,50 @@ pub trait PropertySetExt {
 
     /// Target RDP server password - use for testing only
     fn clear_text_password(&self) -> Option<&str>;
+
+    /// RDCleanPath proxy URL (IronRDP extension).
+    fn rdcleanpath_url(&self) -> Option<&str>;
+
+    /// RDCleanPath authentication token (IronRDP extension) - secret, use for testing only.
+    fn rdcleanpath_token(&self) -> Option<&str>;
+
+    /// DVC pipe proxy specifications (IronRDP extension).
+    ///
+    /// Comma-separated list of `<name>=<pipe>` entries.
+    fn dvc_pipe_proxies(&self) -> Option<&str>;
+
+    /// Idle anti-lock fake events interval in minutes (IronRDP extension).
+    fn fake_events_interval(&self) -> Option<u32>;
+
+    /// Enable RDPDR device redirection (IronRDP extension).
+    fn rdpdr_enabled(&self) -> Option<bool>;
+
+    /// Enable smart-card redirection within RDPDR (IronRDP extension).
+    fn smartcard_enabled(&self) -> Option<bool>;
+
+    /// Enable the QOI bitmap codec (IronRDP extension).
+    fn qoi_enabled(&self) -> Option<bool>;
+
+    /// Enable the QOIZ bitmap codec (IronRDP extension).
+    fn qoiz_enabled(&self) -> Option<bool>;
+
+    /// Enable TLS + graphical login (IronRDP extension; default enabled).
+    fn enable_tls(&self) -> Option<bool>;
+
+    /// Render the server-side pointer (IronRDP extension; default enabled).
+    fn server_pointer(&self) -> Option<bool>;
+
+    /// Automatically log on by passing the INFO_AUTOLOGON flag (IronRDP extension).
+    fn autologon(&self) -> Option<bool>;
+
+    /// Bulk compression level (IronRDP extension): 0=K8, 1=K64, 2=Rdp6, 3=Rdp61.
+    fn compression_level(&self) -> Option<u32>;
+
+    /// Color depth in bits per pixel (IronRDP extension), e.g. 16 or 32.
+    fn color_depth(&self) -> Option<u32>;
+
+    /// DVC client plugin DLL paths (IronRDP extension; Windows only). Comma-separated.
+    fn dvc_plugins(&self) -> Option<&str>;
 }
 
 impl PropertySetExt for PropertySet {
@@ -337,5 +381,61 @@ impl PropertySetExt for PropertySet {
 
     fn clear_text_password(&self) -> Option<&str> {
         self.get::<&str>("ClearTextPassword")
+    }
+
+    fn rdcleanpath_url(&self) -> Option<&str> {
+        self.get::<&str>("ironrdp_rdcleanpathurl")
+    }
+
+    fn rdcleanpath_token(&self) -> Option<&str> {
+        self.get::<&str>("ironrdp_rdcleanpathtoken")
+    }
+
+    fn dvc_pipe_proxies(&self) -> Option<&str> {
+        self.get::<&str>("ironrdp_dvcpipeproxy")
+    }
+
+    fn fake_events_interval(&self) -> Option<u32> {
+        self.get::<u32>("ironrdp_fakeeventsinterval")
+    }
+
+    fn rdpdr_enabled(&self) -> Option<bool> {
+        self.get::<bool>("ironrdp_rdpdr")
+    }
+
+    fn smartcard_enabled(&self) -> Option<bool> {
+        self.get::<bool>("ironrdp_smartcard")
+    }
+
+    fn qoi_enabled(&self) -> Option<bool> {
+        self.get::<bool>("ironrdp_qoi")
+    }
+
+    fn qoiz_enabled(&self) -> Option<bool> {
+        self.get::<bool>("ironrdp_qoiz")
+    }
+
+    fn enable_tls(&self) -> Option<bool> {
+        self.get::<bool>("ironrdp_tls")
+    }
+
+    fn server_pointer(&self) -> Option<bool> {
+        self.get::<bool>("ironrdp_serverpointer")
+    }
+
+    fn autologon(&self) -> Option<bool> {
+        self.get::<bool>("ironrdp_autologon")
+    }
+
+    fn compression_level(&self) -> Option<u32> {
+        self.get::<u32>("ironrdp_compressionlevel")
+    }
+
+    fn color_depth(&self) -> Option<u32> {
+        self.get::<u32>("ironrdp_colordepth")
+    }
+
+    fn dvc_plugins(&self) -> Option<&str> {
+        self.get::<&str>("ironrdp_dvcplugin")
     }
 }

--- a/crates/ironrdp-cfg/src/lib.rs
+++ b/crates/ironrdp-cfg/src/lib.rs
@@ -268,6 +268,27 @@ pub trait PropertySetExt {
 
     /// DVC client plugin DLL paths (IronRDP extension; Windows only). Comma-separated.
     fn dvc_plugins(&self) -> Option<&str>;
+
+    // --- Setters (mirror the getters above; write the same keys) ---
+
+    fn set_enable_credssp_support(&mut self, enabled: bool);
+    fn set_compression(&mut self, enabled: bool);
+    fn set_enable_tls(&mut self, enabled: bool);
+    fn set_server_pointer(&mut self, enabled: bool);
+    fn set_autologon(&mut self, enabled: bool);
+    fn set_compression_level(&mut self, level: u32);
+    fn set_color_depth(&mut self, depth: u32);
+    fn set_fake_events_interval(&mut self, minutes: u32);
+    fn set_dvc_plugins(&mut self, value: impl Into<String>);
+    fn set_dvc_pipe_proxies(&mut self, value: impl Into<String>);
+    fn set_rdcleanpath_url(&mut self, value: impl Into<String>);
+    fn set_rdcleanpath_token(&mut self, value: impl Into<String>);
+    fn clear_rdcleanpath(&mut self);
+    fn set_gateway_hostname(&mut self, value: impl Into<String>);
+    fn set_gateway_usage_method(&mut self, method: GatewayUsageMethod);
+    fn set_gateway_credentials(&mut self, username: impl Into<String>, password: impl Into<String>);
+    fn clear_gateway(&mut self);
+    fn set_kdc_proxy_url(&mut self, value: impl Into<String>);
 }
 
 impl PropertySetExt for PropertySet {
@@ -437,5 +458,83 @@ impl PropertySetExt for PropertySet {
 
     fn dvc_plugins(&self) -> Option<&str> {
         self.get::<&str>("ironrdp_dvcplugin")
+    }
+
+    fn set_enable_credssp_support(&mut self, enabled: bool) {
+        self.insert("enablecredsspsupport", i64::from(enabled));
+    }
+
+    fn set_compression(&mut self, enabled: bool) {
+        self.insert("compression", enabled);
+    }
+
+    fn set_enable_tls(&mut self, enabled: bool) {
+        self.insert("ironrdp_tls", enabled);
+    }
+
+    fn set_server_pointer(&mut self, enabled: bool) {
+        self.insert("ironrdp_serverpointer", enabled);
+    }
+
+    fn set_autologon(&mut self, enabled: bool) {
+        self.insert("ironrdp_autologon", enabled);
+    }
+
+    fn set_compression_level(&mut self, level: u32) {
+        self.insert("ironrdp_compressionlevel", i64::from(level));
+    }
+
+    fn set_color_depth(&mut self, depth: u32) {
+        self.insert("ironrdp_colordepth", i64::from(depth));
+    }
+
+    fn set_fake_events_interval(&mut self, minutes: u32) {
+        self.insert("ironrdp_fakeeventsinterval", i64::from(minutes));
+    }
+
+    fn set_dvc_plugins(&mut self, value: impl Into<String>) {
+        self.insert("ironrdp_dvcplugin", value.into());
+    }
+
+    fn set_dvc_pipe_proxies(&mut self, value: impl Into<String>) {
+        self.insert("ironrdp_dvcpipeproxy", value.into());
+    }
+
+    fn set_rdcleanpath_url(&mut self, value: impl Into<String>) {
+        self.insert("ironrdp_rdcleanpathurl", value.into());
+    }
+
+    fn set_rdcleanpath_token(&mut self, value: impl Into<String>) {
+        self.insert("ironrdp_rdcleanpathtoken", value.into());
+    }
+
+    fn clear_rdcleanpath(&mut self) {
+        self.remove("ironrdp_rdcleanpathurl");
+        self.remove("ironrdp_rdcleanpathtoken");
+    }
+
+    fn set_gateway_hostname(&mut self, value: impl Into<String>) {
+        self.insert("gatewayhostname", value.into());
+    }
+
+    fn set_gateway_usage_method(&mut self, method: GatewayUsageMethod) {
+        self.insert("gatewayusagemethod", method.as_i64());
+    }
+
+    fn set_gateway_credentials(&mut self, username: impl Into<String>, password: impl Into<String>) {
+        self.insert("gatewayusername", username.into());
+        self.insert("gatewaypassword", password.into());
+    }
+
+    fn clear_gateway(&mut self) {
+        self.remove("gatewayhostname");
+        self.remove("gatewayusagemethod");
+        self.remove("gatewayusername");
+        self.remove("gatewaypassword");
+        self.remove("GatewayPassword");
+    }
+
+    fn set_kdc_proxy_url(&mut self, value: impl Into<String>) {
+        self.insert("kdcproxyurl", value.into());
     }
 }

--- a/crates/ironrdp-client/Cargo.toml
+++ b/crates/ironrdp-client/Cargo.toml
@@ -67,6 +67,8 @@ ironrdp-echo = { path = "../ironrdp-echo", version = "0.3" }
 ironrdp-tls = { path = "../ironrdp-tls", version = "0.2" }
 ironrdp-tokio = { path = "../ironrdp-tokio", version = "0.9", features = ["reqwest"] }
 ironrdp-rdcleanpath = { path = "../ironrdp-rdcleanpath" }
+ironrdp-cfg = { path = "../ironrdp-cfg" }
+ironrdp-propertyset = { path = "../ironrdp-propertyset" }
 
 # Optional protocol crates (activated by features above)
 ironrdp-cliprdr = { path = "../ironrdp-cliprdr", version = "0.6", optional = true }

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -6,12 +6,13 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::Context as _;
+use ironrdp_propertyset::PropertySet;
 use url::Url;
 
 // ── Extension registry ────────────────────────────────────────────────────────
 
-type StaticChannelFn = Arc<dyn Fn(&mut ironrdp_connector::ClientConnector) + Send + Sync>;
-type DvcChannelFn = Arc<dyn Fn(&mut ironrdp_dvc::DrdynvcClient) + Send + Sync>;
+type StaticChannelFn = Arc<dyn Fn(&mut ironrdp_connector::ClientConnector, &PropertySet) + Send + Sync>;
+type DvcChannelFn = Arc<dyn Fn(&mut ironrdp_dvc::DrdynvcClient, &PropertySet) + Send + Sync>;
 
 /// Private registry of user-supplied static and dynamic virtual channel factories.
 ///
@@ -47,35 +48,86 @@ impl fmt::Debug for ExtensionRegistry {
 /// This is the typed surface consumed by [`crate::rdp::RdpClient`]. Build it with
 /// [`ConfigBuilder`]; producing a `Config` from CLI arguments, `.rdp` files, or interactive
 /// prompts is the consumer's responsibility (see `ironrdp-viewer` for a reference front-end).
+///
+/// The struct is opaque: fields are read-only via accessors so a built `Config` cannot drift into
+/// an inconsistent state (e.g. mutating the connector without updating the originating
+/// [`PropertySet`]).
 #[derive(Clone)]
-#[expect(
-    clippy::partial_pub_fields,
-    reason = "extensions must stay crate-private because its type ExtensionRegistry is pub(crate)"
-)]
 pub struct Config {
-    pub connector: ironrdp_connector::Config,
-    pub destination: Destination,
-    pub transport: Transport,
-    pub kerberos_config: Option<ironrdp_connector::credssp::KerberosConfig>,
-    pub log_file: Option<String>,
-    pub fake_events_interval: Option<Duration>,
-    pub channels: ChannelConfig,
+    pub(crate) connector: ironrdp_connector::Config,
+    pub(crate) destination: Destination,
+    pub(crate) transport: Transport,
+    pub(crate) kerberos_config: Option<ironrdp_connector::credssp::KerberosConfig>,
+    pub(crate) fake_events_interval: Option<Duration>,
+    pub(crate) channels: ChannelConfig,
 
     /// DVC channel ↔ named-pipe proxy configuration.
     ///
     /// Each entry causes IronRDP to forward that DVC channel's traffic to/from the
     /// named pipe, allowing out-of-process DVC logic.
     #[cfg(feature = "dvc-pipe-proxy")]
-    pub dvc_pipe_proxies: Vec<DvcProxyInfo>,
+    pub(crate) dvc_pipe_proxies: Vec<DvcProxyInfo>,
 
     /// Paths to DVC client plugin DLLs to load (Windows only).
     ///
     /// Each DLL is loaded via `LoadLibraryW` and its `VirtualChannelGetInstance` export is
     /// called to obtain DVC plugin COM objects.  Example: `C:\Windows\System32\webauthn.dll`.
     #[cfg(all(windows, feature = "dvc-com-plugin"))]
-    pub dvc_plugins: Vec<PathBuf>,
+    pub(crate) dvc_plugins: Vec<PathBuf>,
+
+    /// The merged PropertySet that produced this config, shared (read-only) with channel factories.
+    pub(crate) properties: PropertySet,
 
     pub(crate) extensions: ExtensionRegistry,
+}
+
+impl Config {
+    /// Connector configuration handed to the RDP connection sequence.
+    pub fn connector(&self) -> &ironrdp_connector::Config {
+        &self.connector
+    }
+
+    /// Resolved RDP target (host + port).
+    pub fn destination(&self) -> &Destination {
+        &self.destination
+    }
+
+    /// Selected transport (Direct, Gateway, or RDCleanPath).
+    pub fn transport(&self) -> &Transport {
+        &self.transport
+    }
+
+    /// Optional Kerberos/KDC proxy configuration.
+    pub fn kerberos_config(&self) -> Option<&ironrdp_connector::credssp::KerberosConfig> {
+        self.kerberos_config.as_ref()
+    }
+
+    /// Idle anti-lock fake-events interval, if enabled.
+    pub fn fake_events_interval(&self) -> Option<Duration> {
+        self.fake_events_interval
+    }
+
+    /// Channel/codec runtime toggles.
+    pub fn channels(&self) -> &ChannelConfig {
+        &self.channels
+    }
+
+    /// DVC named-pipe proxy mappings.
+    #[cfg(feature = "dvc-pipe-proxy")]
+    pub fn dvc_pipe_proxies(&self) -> &[DvcProxyInfo] {
+        &self.dvc_pipe_proxies
+    }
+
+    /// DVC client plugin DLL paths (Windows only).
+    #[cfg(all(windows, feature = "dvc-com-plugin"))]
+    pub fn dvc_plugins(&self) -> &[PathBuf] {
+        &self.dvc_plugins
+    }
+
+    /// Merged `.rdp` PropertySet that produced this config.
+    pub fn properties(&self) -> &PropertySet {
+        &self.properties
+    }
 }
 
 impl fmt::Debug for Config {
@@ -85,7 +137,6 @@ impl fmt::Debug for Config {
         s.field("destination", &self.destination);
         s.field("transport", &self.transport);
         s.field("kerberos_config", &self.kerberos_config);
-        s.field("log_file", &self.log_file);
         s.field("fake_events_interval", &self.fake_events_interval);
         s.field("channels", &self.channels);
         #[cfg(feature = "dvc-pipe-proxy")]
@@ -109,6 +160,12 @@ pub enum ClipboardType {
     /// Disable clipboard redirection entirely.
     Disable,
     /// Use a stub clipboard backend (for testing or headless usage).
+    // FIXME: the `Stub` concept arguably shouldn't live in ironrdp-client. Investigate whether it
+    // can move out via the extension/backend API, so the stub backend stays in ironrdp-viewer as a
+    // debugging tool. Note that other consumers (e.g. ironrdp-agent) may need their own custom
+    // backend that is not integrated with the host system's clipboard either; the design should
+    // accommodate plugging in arbitrary CliprdrBackendFactory implementations rather than baking
+    // specific variants into the client.
     Stub,
 }
 
@@ -190,9 +247,10 @@ impl Default for RdpdrConfig {
 }
 
 /// Transport selection for the RDP connection.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub enum Transport {
     /// Plain TCP → TLS direct connection to the RDP server.
+    #[default]
     Direct,
 
     /// Connect via an RDS gateway (MS-TSGU / MSTSGU).
@@ -349,7 +407,58 @@ impl FromStr for DvcProxyInfo {
 
 // ── ConfigBuilder ─────────────────────────────────────────────────────────────
 
+const RDP_DEFAULT_PORT: u16 = 3389;
+const DEFAULT_WIDTH: u16 = 1280;
+const DEFAULT_HEIGHT: u16 = 720;
+
+/// A configuration value that the consumer must supply before [`ConfigBuilder::build`] can succeed.
+///
+/// Query the outstanding ones with [`ConfigBuilder::missing`], resolve each (prompt the user, or
+/// derive a value), set it via the matching `with_*` method, then build.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MissingField {
+    /// Target server address (host[:port]).
+    ServerAddress,
+    /// RDP account user name.
+    Username,
+    /// RDP account password.
+    Password,
+    /// Gateway user name (only when a gateway transport is selected).
+    GatewayUsername,
+    /// Gateway password (only when a gateway transport is selected).
+    GatewayPassword,
+    /// Client build number (frontend-derived).
+    ClientBuild,
+    /// Client directory path (frontend-derived).
+    ClientDir,
+    /// Client platform (frontend-derived).
+    Platform,
+    /// Client computer name (frontend-derived).
+    ClientName,
+}
+
+impl fmt::Display for MissingField {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::ServerAddress => "server address",
+            Self::Username => "username",
+            Self::Password => "password",
+            Self::GatewayUsername => "gateway username",
+            Self::GatewayPassword => "gateway password",
+            Self::ClientBuild => "client build",
+            Self::ClientDir => "client dir",
+            Self::Platform => "platform",
+            Self::ClientName => "client name",
+        };
+        f.write_str(s)
+    }
+}
+
 /// Builder for [`Config`].
+///
+/// No defaults are created up-front for required values; they are tracked as unset until provided.
+/// Truly optional settings receive sensible defaults inside [`build`](ConfigBuilder::build). Use
+/// [`missing`](ConfigBuilder::missing) to discover which required fields still need a value.
 ///
 /// # Duplicate-channel behaviour
 ///
@@ -358,51 +467,218 @@ impl FromStr for DvcProxyInfo {
 ///   [`ironrdp_connector::ClientConnector::attach_static_channel`].
 /// * **DVC channels** are keyed by channel name; duplicate names follow
 ///   [`ironrdp_dvc::DrdynvcClient`]'s overwrite semantics.
+///
+/// # Custom-channel configuration keys
+///
+/// Factory closures registered with [`with_static_channel`](Self::with_static_channel) and
+/// [`with_dvc`](Self::with_dvc) receive the merged [`PropertySet`], so a custom channel can read
+/// its own settings (enabled/disabled, endpoints, flags) straight from the `.rdp` file. Which keys
+/// to read is entirely up to the channel: there is no enforced naming scheme. By convention,
+/// IronRDP's own extension keys use an `ironrdp_` prefix to avoid colliding with standard Microsoft
+/// keys, and custom channels are encouraged (but not required) to namespace their keys similarly
+/// (e.g. `mycorp_mychannel_enabled`). A channel may equally reuse a standard MS key when that fits,
+/// or adopt a completely different pattern if warranted — these are only conventions.
+#[derive(Default)]
 pub struct ConfigBuilder {
-    config: Config,
+    // Required (no default).
+    destination: Option<Destination>,
+    username: Option<String>,
+    password: Option<String>,
+    client_build: Option<u32>,
+    client_dir: Option<String>,
+    client_name: Option<String>,
+    platform: Option<ironrdp_pdu::rdp::capability_sets::MajorPlatformType>,
+    gateway_username: Option<String>,
+    gateway_password: Option<String>,
+
+    // Optional (defaulted at build time).
+    domain: Option<String>,
+    enable_tls: Option<bool>,
+    enable_credssp: Option<bool>,
+    keyboard_type: Option<ironrdp_pdu::gcc::KeyboardType>,
+    keyboard_subtype: Option<u32>,
+    keyboard_functional_keys_count: Option<u32>,
+    ime_file_name: Option<String>,
+    dig_product_id: Option<String>,
+    desktop_width: Option<u16>,
+    desktop_height: Option<u16>,
+    desktop_scale_factor: Option<u32>,
+    color_depth: Option<u32>,
+    codecs: Vec<String>,
+    autologon: Option<bool>,
+    enable_server_pointer: Option<bool>,
+    enable_audio_playback: Option<bool>,
+    compression_type: Option<ironrdp_pdu::rdp::client_info::CompressionType>,
+    compression_enabled: Option<bool>,
+    alternate_shell: Option<String>,
+    work_dir: Option<String>,
+
+    transport: Transport,
+    kerberos_config: Option<ironrdp_connector::credssp::KerberosConfig>,
+    fake_events_interval: Option<Duration>,
+    channels: ChannelConfig,
+    #[cfg(feature = "dvc-pipe-proxy")]
+    dvc_pipe_proxies: Vec<DvcProxyInfo>,
+    #[cfg(all(windows, feature = "dvc-com-plugin"))]
+    dvc_plugins: Vec<PathBuf>,
+    properties: PropertySet,
+    extensions: ExtensionRegistry,
 }
 
 impl ConfigBuilder {
-    pub fn new(connector: ironrdp_connector::Config, destination: Destination) -> Self {
-        Self {
-            config: Config {
-                connector,
-                destination,
-                transport: Transport::Direct,
-                kerberos_config: None,
-                log_file: None,
-                fake_events_interval: None,
-                channels: ChannelConfig::default(),
-                #[cfg(feature = "dvc-pipe-proxy")]
-                dvc_pipe_proxies: Vec::new(),
-                #[cfg(all(windows, feature = "dvc-com-plugin"))]
-                dvc_plugins: Vec::new(),
-                extensions: ExtensionRegistry::default(),
-            },
-        }
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    pub fn with_destination(mut self, destination: Destination) -> Self {
+        self.destination = Some(destination);
+        self
+    }
+
+    #[must_use]
+    pub fn with_credentials(mut self, username: impl Into<String>, password: impl Into<String>) -> Self {
+        self.username = Some(username.into());
+        self.password = Some(password.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_username(mut self, username: impl Into<String>) -> Self {
+        self.username = Some(username.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_password(mut self, password: impl Into<String>) -> Self {
+        self.password = Some(password.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_gateway_credentials(mut self, username: impl Into<String>, password: impl Into<String>) -> Self {
+        self.gateway_username = Some(username.into());
+        self.gateway_password = Some(password.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_gateway_username(mut self, username: impl Into<String>) -> Self {
+        self.gateway_username = Some(username.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_gateway_password(mut self, password: impl Into<String>) -> Self {
+        self.gateway_password = Some(password.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_client_build(mut self, build: u32) -> Self {
+        self.client_build = Some(build);
+        self
+    }
+
+    #[must_use]
+    pub fn with_client_dir(mut self, dir: impl Into<String>) -> Self {
+        self.client_dir = Some(dir.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_client_name(mut self, name: impl Into<String>) -> Self {
+        self.client_name = Some(name.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_platform(mut self, platform: ironrdp_pdu::rdp::capability_sets::MajorPlatformType) -> Self {
+        self.platform = Some(platform);
+        self
+    }
+
+    #[must_use]
+    pub fn with_keyboard_type(mut self, ty: ironrdp_pdu::gcc::KeyboardType) -> Self {
+        self.keyboard_type = Some(ty);
+        self
+    }
+
+    #[must_use]
+    pub fn with_keyboard_subtype(mut self, subtype: u32) -> Self {
+        self.keyboard_subtype = Some(subtype);
+        self
+    }
+
+    #[must_use]
+    pub fn with_keyboard_functional_keys_count(mut self, count: u32) -> Self {
+        self.keyboard_functional_keys_count = Some(count);
+        self
+    }
+
+    #[must_use]
+    pub fn with_ime_file_name(mut self, name: impl Into<String>) -> Self {
+        self.ime_file_name = Some(name.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_dig_product_id(mut self, id: impl Into<String>) -> Self {
+        self.dig_product_id = Some(id.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_color_depth(mut self, depth: u32) -> Self {
+        self.color_depth = Some(depth);
+        self
+    }
+
+    #[must_use]
+    pub fn with_codecs(mut self, codecs: Vec<String>) -> Self {
+        self.codecs = codecs;
+        self
+    }
+
+    #[must_use]
+    pub fn with_autologon(mut self, enabled: bool) -> Self {
+        self.autologon = Some(enabled);
+        self
+    }
+
+    #[must_use]
+    pub fn with_enable_tls(mut self, enabled: bool) -> Self {
+        self.enable_tls = Some(enabled);
+        self
+    }
+
+    #[must_use]
+    pub fn with_server_pointer(mut self, enabled: bool) -> Self {
+        self.enable_server_pointer = Some(enabled);
+        self
+    }
+
+    #[must_use]
+    pub fn with_compression_type(mut self, ty: Option<ironrdp_pdu::rdp::client_info::CompressionType>) -> Self {
+        self.compression_type = ty;
+        self
     }
 
     #[must_use]
     pub fn with_transport(mut self, transport: Transport) -> Self {
-        self.config.transport = transport;
+        self.transport = transport;
         self
     }
 
     #[must_use]
     pub fn with_kerberos_config(mut self, cfg: ironrdp_connector::credssp::KerberosConfig) -> Self {
-        self.config.kerberos_config = Some(cfg);
-        self
-    }
-
-    #[must_use]
-    pub fn with_log_file(mut self, path: impl Into<String>) -> Self {
-        self.config.log_file = Some(path.into());
+        self.kerberos_config = Some(cfg);
         self
     }
 
     #[must_use]
     pub fn with_fake_events_interval(mut self, interval: Duration) -> Self {
-        self.config.fake_events_interval = Some(interval);
+        self.fake_events_interval = Some(interval);
         self
     }
 
@@ -410,7 +686,7 @@ impl ConfigBuilder {
     #[cfg(feature = "sound")]
     #[must_use]
     pub fn with_sound(mut self, enabled: bool) -> Self {
-        self.config.channels.sound = enabled;
+        self.channels.sound = enabled;
         self
     }
 
@@ -418,7 +694,7 @@ impl ConfigBuilder {
     #[cfg(feature = "clipboard")]
     #[must_use]
     pub fn with_clipboard(mut self, mode: ClipboardType) -> Self {
-        self.config.channels.clipboard = mode;
+        self.channels.clipboard = mode;
         self
     }
 
@@ -426,7 +702,7 @@ impl ConfigBuilder {
     #[cfg(feature = "rdpdr")]
     #[must_use]
     pub fn with_rdpdr(mut self, enabled: bool) -> Self {
-        self.config.channels.rdpdr.enabled = enabled;
+        self.channels.rdpdr.enabled = enabled;
         self
     }
 
@@ -434,7 +710,7 @@ impl ConfigBuilder {
     #[cfg(feature = "smartcard")]
     #[must_use]
     pub fn with_smartcard(mut self, enabled: bool) -> Self {
-        self.config.channels.rdpdr.smartcard = enabled;
+        self.channels.rdpdr.smartcard = enabled;
         self
     }
 
@@ -442,7 +718,7 @@ impl ConfigBuilder {
     #[cfg(feature = "qoi")]
     #[must_use]
     pub fn with_qoi(mut self, enabled: bool) -> Self {
-        self.config.channels.qoi = enabled;
+        self.channels.qoi = enabled;
         self
     }
 
@@ -450,7 +726,7 @@ impl ConfigBuilder {
     #[cfg(feature = "qoiz")]
     #[must_use]
     pub fn with_qoiz(mut self, enabled: bool) -> Self {
-        self.config.channels.qoiz = enabled;
+        self.channels.qoiz = enabled;
         self
     }
 
@@ -458,7 +734,7 @@ impl ConfigBuilder {
     #[cfg(feature = "dvc-pipe-proxy")]
     #[must_use]
     pub fn with_dvc_pipe_proxy(mut self, info: DvcProxyInfo) -> Self {
-        self.config.dvc_pipe_proxies.push(info);
+        self.dvc_pipe_proxies.push(info);
         self
     }
 
@@ -466,43 +742,411 @@ impl ConfigBuilder {
     #[cfg(all(windows, feature = "dvc-com-plugin"))]
     #[must_use]
     pub fn with_dvc_plugin(mut self, path: impl Into<PathBuf>) -> Self {
-        self.config.dvc_plugins.push(path.into());
+        self.dvc_plugins.push(path.into());
         self
     }
 
     /// Register a factory for a user-defined static virtual channel.
     ///
-    /// `factory` is called once per connection attempt to create a fresh channel instance.
-    /// Duplicate processor types follow `attach_static_channel` overwrite semantics.
+    /// `factory` is called once per connection attempt with the shared (read-only) [`PropertySet`],
+    /// so the channel can parametrize itself from the standard frontend config. Return `None` to
+    /// disable the channel. Duplicate processor types follow `attach_static_channel` overwrite semantics.
     #[must_use]
     pub fn with_static_channel<P, F>(mut self, factory: F) -> Self
     where
-        F: Fn() -> P + Send + Sync + 'static,
+        F: Fn(&PropertySet) -> Option<P> + Send + Sync + 'static,
         P: ironrdp_svc::SvcClientProcessor + 'static,
     {
-        let cb: StaticChannelFn = Arc::new(move |connector: &mut ironrdp_connector::ClientConnector| {
-            connector.attach_static_channel(factory())
+        let cb: StaticChannelFn = Arc::new(move |connector: &mut ironrdp_connector::ClientConnector, ps| {
+            if let Some(processor) = factory(ps) {
+                connector.attach_static_channel(processor);
+            }
         });
-        self.config.extensions.static_channels.push(cb);
+        self.extensions.static_channels.push(cb);
         self
     }
 
     /// Register a factory for a user-defined dynamic virtual channel.
     ///
-    /// `factory` is called once per connection attempt to create a fresh channel instance.
-    /// Duplicate channel names follow `DrdynvcClient` overwrite semantics.
+    /// `factory` is called once per connection attempt with the shared (read-only) [`PropertySet`],
+    /// so the channel can parametrize itself from the standard frontend config. Return `None` to
+    /// disable the channel. Duplicate channel names follow `DrdynvcClient` overwrite semantics.
     #[must_use]
     pub fn with_dvc<P, F>(mut self, factory: F) -> Self
     where
-        F: Fn() -> P + Send + Sync + 'static,
+        F: Fn(&PropertySet) -> Option<P> + Send + Sync + 'static,
         P: ironrdp_dvc::DvcProcessor + 'static,
     {
-        let cb: DvcChannelFn = Arc::new(move |drdynvc| drdynvc.attach_dynamic_channel(factory()));
-        self.config.extensions.dvc_channels.push(cb);
+        let cb: DvcChannelFn = Arc::new(move |drdynvc, ps| {
+            if let Some(processor) = factory(ps) {
+                drdynvc.attach_dynamic_channel(processor);
+            }
+        });
+        self.extensions.dvc_channels.push(cb);
         self
     }
 
-    pub fn build(self) -> Config {
-        self.config
+    /// List the required fields that still need a value before [`build`](Self::build) can succeed.
+    ///
+    /// Gateway credentials are only required when a gateway transport is selected.
+    pub fn missing(&self) -> Vec<MissingField> {
+        let mut missing = Vec::new();
+        if self.destination.is_none() {
+            missing.push(MissingField::ServerAddress);
+        }
+        if self.username.is_none() {
+            missing.push(MissingField::Username);
+        }
+        if self.password.is_none() {
+            missing.push(MissingField::Password);
+        }
+        if matches!(self.transport, Transport::Gateway(_)) {
+            if self.gateway_username.is_none() {
+                missing.push(MissingField::GatewayUsername);
+            }
+            if self.gateway_password.is_none() {
+                missing.push(MissingField::GatewayPassword);
+            }
+        }
+        if self.client_build.is_none() {
+            missing.push(MissingField::ClientBuild);
+        }
+        if self.client_dir.is_none() {
+            missing.push(MissingField::ClientDir);
+        }
+        if self.platform.is_none() {
+            missing.push(MissingField::Platform);
+        }
+        if self.client_name.is_none() {
+            missing.push(MissingField::ClientName);
+        }
+        missing
     }
+
+    /// Build the [`Config`], filling optional settings with sensible defaults.
+    ///
+    /// Fails if any required field is unset; inspect [`missing`](Self::missing) beforehand to resolve them.
+    pub fn build(self) -> anyhow::Result<Config> {
+        use ironrdp_pdu::rdp::capability_sets::client_codecs_capabilities;
+        use ironrdp_pdu::rdp::client_info::{PerformanceFlags, TimezoneInfo};
+
+        let missing = self.missing();
+        if !missing.is_empty() {
+            anyhow::bail!(
+                "missing required configuration: {}",
+                missing
+                    .iter()
+                    .map(MissingField::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
+
+        let codecs: Vec<&str> = self.codecs.iter().map(String::as_str).collect();
+        let codecs = client_codecs_capabilities(&codecs).map_err(|help| anyhow::anyhow!("{help}"))?;
+        let color_depth = self.color_depth.unwrap_or(32);
+        if color_depth != 16 && color_depth != 32 {
+            anyhow::bail!("invalid color depth: only 16 and 32 bit color depths are supported");
+        }
+        let bitmap = ironrdp_connector::BitmapConfig {
+            color_depth,
+            lossy_compression: true,
+            codecs,
+        };
+
+        let mut transport = self.transport;
+        if let Transport::Gateway(ref mut gw) = transport {
+            gw.username = self.gateway_username.unwrap_or_default();
+            gw.password = self.gateway_password.unwrap_or_default();
+        }
+
+        let client_name = self.client_name.unwrap_or_default();
+        let kerberos_config = self
+            .kerberos_config
+            .or_else(|| kerberos_config_from_properties(&self.properties, &client_name));
+
+        // Bulk compression is enabled by default. We default to MPPC 64K (RDP5) rather than the
+        // richer XCRUSH (RDP6.1) because it is the most universally supported and lowest-state
+        // codec, and FastPath decompression is the only fully wired path.
+        // FIXME: bump the default to RDP6.1 (XCRUSH) once slow-path bulk decompression is wired
+        // (see ironrdp-session x224 path); until then a stateful codec risks silent corruption.
+        let compression_type = if self.compression_enabled.unwrap_or(true) {
+            Some(
+                self.compression_type
+                    .unwrap_or(ironrdp_pdu::rdp::client_info::CompressionType::K64),
+            )
+        } else {
+            None
+        };
+
+        let connector = ironrdp_connector::Config {
+            credentials: ironrdp_connector::Credentials::UsernamePassword {
+                username: self.username.unwrap_or_default(),
+                password: self.password.unwrap_or_default(),
+            },
+            domain: self.domain,
+            enable_tls: self.enable_tls.unwrap_or(true),
+            enable_credssp: self.enable_credssp.unwrap_or(true),
+            keyboard_type: self
+                .keyboard_type
+                .unwrap_or(ironrdp_pdu::gcc::KeyboardType::IbmEnhanced),
+            keyboard_subtype: self.keyboard_subtype.unwrap_or(0),
+            keyboard_layout: 0,
+            keyboard_functional_keys_count: self.keyboard_functional_keys_count.unwrap_or(12),
+            ime_file_name: self.ime_file_name.unwrap_or_default(),
+            dig_product_id: self.dig_product_id.unwrap_or_default(),
+            desktop_size: ironrdp_connector::DesktopSize {
+                width: self.desktop_width.unwrap_or(DEFAULT_WIDTH),
+                height: self.desktop_height.unwrap_or(DEFAULT_HEIGHT),
+            },
+            desktop_scale_factor: self.desktop_scale_factor.unwrap_or(0),
+            bitmap: Some(bitmap),
+            client_build: self.client_build.unwrap_or_default(),
+            client_name,
+            client_dir: self.client_dir.unwrap_or_default(),
+            platform: self
+                .platform
+                .unwrap_or(ironrdp_pdu::rdp::capability_sets::MajorPlatformType::UNSPECIFIED),
+            hardware_id: None,
+            license_cache: None,
+            enable_server_pointer: self.enable_server_pointer.unwrap_or(true),
+            autologon: self.autologon.unwrap_or(false),
+            enable_audio_playback: self.enable_audio_playback.unwrap_or(true),
+            request_data: None,
+            pointer_software_rendering: false,
+            multitransport_flags: None,
+            compression_type,
+            performance_flags: PerformanceFlags::default(),
+            timezone_info: TimezoneInfo::default(),
+            alternate_shell: self.alternate_shell.unwrap_or_default(),
+            work_dir: self.work_dir.unwrap_or_default(),
+        };
+
+        Ok(Config {
+            connector,
+            destination: self.destination.context("server address is required")?,
+            transport,
+            kerberos_config,
+            fake_events_interval: self.fake_events_interval,
+            channels: self.channels,
+            #[cfg(feature = "dvc-pipe-proxy")]
+            dvc_pipe_proxies: self.dvc_pipe_proxies,
+            #[cfg(all(windows, feature = "dvc-com-plugin"))]
+            dvc_plugins: self.dvc_plugins,
+            properties: self.properties,
+            extensions: self.extensions,
+        })
+    }
+
+    /// Build a [`Config`] from a `.rdp` [`PropertySet`], leaving anything not expressible as a
+    /// property unset (query [`missing`](Self::missing) to resolve the rest).
+    pub fn from_property_set(ps: &PropertySet) -> anyhow::Result<Self> {
+        ConfigBuilder::new().with_property_set(ps)
+    }
+
+    /// Overlay a `.rdp` [`PropertySet`] on top of the current builder.
+    ///
+    /// Only properties present in `ps` set values, so this can be layered:
+    /// `explicit setters → PropertySet → more setters`, last writer wins. Resolution rules:
+    /// `full address` beats `alternate full address`, an embedded port beats `server port`, and
+    /// transport precedence is RDCleanPath > Gateway > Direct.
+    pub fn with_property_set(mut self, ps: &PropertySet) -> anyhow::Result<Self> {
+        use ironrdp_cfg::{AudioMode, GatewayUsageMethod, PropertySetExt as _, TargetHost};
+
+        self.properties.merge(ps);
+
+        let target = ps.full_address().context("invalid 'full address'")?.or(ps
+            .alternate_full_address()
+            .context("invalid 'alternate full address'")?);
+        if let Some(target) = target {
+            let port = target
+                .port
+                .or(ps.server_port().context("invalid 'server port'")?)
+                .unwrap_or(RDP_DEFAULT_PORT);
+            let name = match target.host {
+                TargetHost::Ip(ip) => ip.to_string(),
+                TargetHost::Domain(host) => host,
+            };
+            self.destination = Some(Destination::from_parts(name, port));
+        }
+
+        if let Some(username) = ps.username() {
+            self.username = Some(username.to_owned());
+        }
+        if let Some(password) = ps.clear_text_password() {
+            self.password = Some(password.to_owned());
+        }
+        if let Some(domain) = ps.domain() {
+            self.domain = Some(domain.to_owned());
+        }
+        if let Some(enable_credssp) = ps.enable_credssp_support() {
+            self.enable_credssp = Some(enable_credssp);
+        }
+        if let Some(enable_tls) = ps.enable_tls() {
+            self.enable_tls = Some(enable_tls);
+        }
+        if let Some(server_pointer) = ps.server_pointer() {
+            self.enable_server_pointer = Some(server_pointer);
+        }
+        if let Some(autologon) = ps.autologon() {
+            self.autologon = Some(autologon);
+        }
+        if let Some(scale) = ps.desktop_scale_factor().ok().flatten() {
+            self.desktop_scale_factor = Some(scale);
+        }
+        if let Some(width) = ps.desktop_width().ok().flatten() {
+            self.desktop_width = Some(width);
+        }
+        if let Some(height) = ps.desktop_height().ok().flatten() {
+            self.desktop_height = Some(height);
+        }
+        if let Some(shell) = ps.alternate_shell() {
+            self.alternate_shell = Some(shell.to_owned());
+        }
+        if let Some(dir) = ps.shell_working_directory() {
+            self.work_dir = Some(dir.to_owned());
+        }
+        if let Some(minutes) = ps.fake_events_interval() {
+            self.fake_events_interval = Some(Duration::from_secs(u64::from(minutes) * 60));
+        }
+        if let Some(level) = ps.compression_level() {
+            self.compression_type = Some(compression_type_from_level(level)?);
+        }
+        if let Some(enabled) = ps.compression() {
+            self.compression_enabled = Some(enabled);
+        }
+        if let Some(depth) = ps.color_depth() {
+            self.color_depth = Some(depth);
+        }
+        match ps.audio_mode() {
+            Ok(Some(AudioMode::PlayOnServer | AudioMode::Disabled)) => self.enable_audio_playback = Some(false),
+            Ok(Some(AudioMode::RedirectToClient)) => self.enable_audio_playback = Some(true),
+            _ => {}
+        }
+
+        // Transport: RDCleanPath > Gateway > Direct.
+        if let Some((url, token)) = ps.rdcleanpath_url().zip(ps.rdcleanpath_token()) {
+            let url = Url::parse(url).context("invalid 'ironrdp_rdcleanpathurl'")?;
+            self.transport = Transport::RDCleanPath(RDCleanPathConfig {
+                url,
+                auth_token: token.to_owned(),
+            });
+        } else {
+            #[cfg(feature = "gateway")]
+            {
+                let use_gateway = ps
+                    .gateway_usage_method()
+                    .ok()
+                    .flatten()
+                    .map_or(ps.gateway_hostname().is_some(), GatewayUsageMethod::is_gateway_required);
+                if let Some(endpoint) = use_gateway.then(|| ps.gateway_hostname()).flatten() {
+                    self.transport = Transport::Gateway(GatewayConfig {
+                        endpoint: endpoint.to_owned(),
+                        username: String::new(),
+                        password: String::new(),
+                    });
+                    if let Some(user) = ps.gateway_username() {
+                        self.gateway_username = Some(user.to_owned());
+                    }
+                    if let Some(pass) = ps.gateway_password() {
+                        self.gateway_password = Some(pass.to_owned());
+                    }
+                }
+            }
+        }
+
+        if let Some(redirect) = ps.redirect_clipboard() {
+            #[cfg(feature = "clipboard")]
+            {
+                self.channels.clipboard = if redirect {
+                    ClipboardType::Enable
+                } else {
+                    ClipboardType::Disable
+                };
+            }
+            let _ = redirect;
+        }
+        #[cfg(feature = "sound")]
+        if matches!(ps.audio_mode(), Ok(Some(AudioMode::Disabled))) {
+            self.channels.sound = false;
+        }
+        #[cfg(feature = "rdpdr")]
+        if let Some(enabled) = ps.rdpdr_enabled() {
+            self.channels.rdpdr.enabled = enabled;
+        }
+        #[cfg(feature = "smartcard")]
+        if let Some(enabled) = ps.smartcard_enabled() {
+            self.channels.rdpdr.smartcard = enabled;
+        }
+        #[cfg(feature = "qoi")]
+        if let Some(enabled) = ps.qoi_enabled() {
+            self.channels.qoi = enabled;
+        }
+        #[cfg(feature = "qoiz")]
+        if let Some(enabled) = ps.qoiz_enabled() {
+            self.channels.qoiz = enabled;
+        }
+
+        #[cfg(feature = "dvc-pipe-proxy")]
+        for proxy in ps.dvc_pipe_proxies().into_iter().flat_map(|s| s.split(',')) {
+            let proxy = proxy.trim();
+            if !proxy.is_empty() {
+                self.dvc_pipe_proxies
+                    .push(proxy.parse().context("invalid DVC pipe proxy spec")?);
+            }
+        }
+
+        #[cfg(all(windows, feature = "dvc-com-plugin"))]
+        for plugin in ps.dvc_plugins().into_iter().flat_map(|s| s.split(',')) {
+            let plugin = plugin.trim();
+            if !plugin.is_empty() {
+                self.dvc_plugins.push(PathBuf::from(plugin));
+            }
+        }
+
+        Ok(self)
+    }
+}
+
+/// Map a bulk-compression level (0–3) to the corresponding [`CompressionType`].
+///
+/// 0 = MPPC 8K (RDP4), 1 = MPPC 64K (RDP5), 2 = NCRUSH (RDP6), 3 = XCRUSH (RDP6.1).
+///
+/// [`CompressionType`]: ironrdp_pdu::rdp::client_info::CompressionType
+fn compression_type_from_level(level: u32) -> anyhow::Result<ironrdp_pdu::rdp::client_info::CompressionType> {
+    use ironrdp_pdu::rdp::client_info::CompressionType;
+
+    match level {
+        0 => Ok(CompressionType::K8),
+        1 => Ok(CompressionType::K64),
+        2 => Ok(CompressionType::Rdp6),
+        3 => Ok(CompressionType::Rdp61),
+        _ => anyhow::bail!("invalid compression level: valid values are 0, 1, 2, 3"),
+    }
+}
+
+/// Derive a Kerberos/KDC-proxy config from `kdcproxyurl`/`kdcproxyname`, using `client_name` as the
+/// SPN hostname. Returns `None` if no KDC proxy is configured or the URL is invalid.
+fn kerberos_config_from_properties(
+    ps: &PropertySet,
+    client_name: &str,
+) -> Option<ironrdp_connector::credssp::KerberosConfig> {
+    use ironrdp_cfg::PropertySetExt as _;
+
+    let kdc_proxy_url = ps.kdc_proxy_url().map(str::to_owned).or_else(|| {
+        ps.kdc_proxy_name().map(|name| {
+            if name.starts_with("http://") || name.starts_with("https://") {
+                name.to_owned()
+            } else {
+                format!("https://{name}/KdcProxy")
+            }
+        })
+    })?;
+
+    Url::parse(&kdc_proxy_url)
+        .ok()
+        .map(|url| ironrdp_connector::credssp::KerberosConfig {
+            kdc_proxy_url: Some(url),
+            hostname: client_name.to_owned(),
+        })
 }

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::Context as _;
+use ironrdp_cfg::PropertySetExt as _;
 use ironrdp_propertyset::PropertySet;
 use url::Url;
 
@@ -631,9 +632,11 @@ impl ConfigBuilder {
     #[must_use]
     pub fn with_color_depth(mut self, depth: u32) -> Self {
         self.color_depth = Some(depth);
+        self.properties.set_color_depth(depth);
         self
     }
 
+    /// Set the bitmap codecs (e.g. `["remotefx:on"]`). Not reflected in the PropertySet.
     #[must_use]
     pub fn with_codecs(mut self, codecs: Vec<String>) -> Self {
         self.codecs = codecs;
@@ -643,35 +646,71 @@ impl ConfigBuilder {
     #[must_use]
     pub fn with_autologon(mut self, enabled: bool) -> Self {
         self.autologon = Some(enabled);
+        self.properties.set_autologon(enabled);
         self
     }
 
     #[must_use]
     pub fn with_enable_tls(mut self, enabled: bool) -> Self {
         self.enable_tls = Some(enabled);
+        self.properties.set_enable_tls(enabled);
         self
     }
 
     #[must_use]
     pub fn with_server_pointer(mut self, enabled: bool) -> Self {
         self.enable_server_pointer = Some(enabled);
+        self.properties.set_server_pointer(enabled);
         self
     }
 
+    /// Set the bulk compression type directly. Upserts the `ironrdp_compressionlevel` property.
     #[must_use]
     pub fn with_compression_type(mut self, ty: Option<ironrdp_pdu::rdp::client_info::CompressionType>) -> Self {
         self.compression_type = ty;
+        if let Some(ty) = ty {
+            self.properties.set_compression_level(level_from_compression_type(ty));
+        }
         self
     }
 
+    /// Set the transport. Upserts the corresponding properties (`ironrdp_rdcleanpathurl`/token,
+    /// `gatewayhostname`/usage/credentials), clearing the others so the PropertySet stays consistent.
     #[must_use]
     pub fn with_transport(mut self, transport: Transport) -> Self {
+        match &transport {
+            Transport::Direct => {
+                self.properties.clear_rdcleanpath();
+                #[cfg(feature = "gateway")]
+                self.properties.clear_gateway();
+            }
+            Transport::RDCleanPath(rdcp) => {
+                self.properties.set_rdcleanpath_url(rdcp.url.to_string());
+                self.properties.set_rdcleanpath_token(rdcp.auth_token.clone());
+                #[cfg(feature = "gateway")]
+                self.properties.clear_gateway();
+            }
+            #[cfg(feature = "gateway")]
+            Transport::Gateway(gw) => {
+                self.properties.clear_rdcleanpath();
+                self.properties.set_gateway_hostname(gw.endpoint.clone());
+                self.properties
+                    .set_gateway_usage_method(ironrdp_cfg::GatewayUsageMethod::UseAlways);
+                self.properties
+                    .set_gateway_credentials(gw.username.clone(), gw.password.clone());
+            }
+        }
         self.transport = transport;
         self
     }
 
+    /// Set the kerberos config. Upserts the `kdcproxyurl` property; `hostname` is derived from the
+    /// client name and not stored separately.
     #[must_use]
     pub fn with_kerberos_config(mut self, cfg: ironrdp_connector::credssp::KerberosConfig) -> Self {
+        if let Some(url) = &cfg.kdc_proxy_url {
+            self.properties.set_kdc_proxy_url(url.to_string());
+        }
         self.kerberos_config = Some(cfg);
         self
     }
@@ -679,6 +718,8 @@ impl ConfigBuilder {
     #[must_use]
     pub fn with_fake_events_interval(mut self, interval: Duration) -> Self {
         self.fake_events_interval = Some(interval);
+        self.properties
+            .set_fake_events_interval(u32::try_from(interval.as_secs() / 60).unwrap_or(u32::MAX));
         self
     }
 
@@ -800,6 +841,7 @@ impl ConfigBuilder {
         if self.password.is_none() {
             missing.push(MissingField::Password);
         }
+        #[cfg(feature = "gateway")]
         if matches!(self.transport, Transport::Gateway(_)) {
             if self.gateway_username.is_none() {
                 missing.push(MissingField::GatewayUsername);
@@ -854,8 +896,8 @@ impl ConfigBuilder {
             codecs,
         };
 
-        let mut transport = self.transport;
-        if let Transport::Gateway(ref mut gw) = transport {
+        #[cfg(feature = "gateway")]
+        if let Transport::Gateway(gw) = self.transport {
             gw.username = self.gateway_username.unwrap_or_default();
             gw.password = self.gateway_password.unwrap_or_default();
         }
@@ -951,7 +993,9 @@ impl ConfigBuilder {
     /// `full address` beats `alternate full address`, an embedded port beats `server port`, and
     /// transport precedence is RDCleanPath > Gateway > Direct.
     pub fn with_property_set(mut self, ps: &PropertySet) -> anyhow::Result<Self> {
-        use ironrdp_cfg::{AudioMode, GatewayUsageMethod, PropertySetExt as _, TargetHost};
+        #[cfg(feature = "gateway")]
+        use ironrdp_cfg::GatewayUsageMethod;
+        use ironrdp_cfg::{AudioMode, TargetHost};
 
         self.properties.merge(ps);
 
@@ -1122,6 +1166,17 @@ fn compression_type_from_level(level: u32) -> anyhow::Result<ironrdp_pdu::rdp::c
         2 => Ok(CompressionType::Rdp6),
         3 => Ok(CompressionType::Rdp61),
         _ => anyhow::bail!("invalid compression level: valid values are 0, 1, 2, 3"),
+    }
+}
+
+fn level_from_compression_type(ty: ironrdp_pdu::rdp::client_info::CompressionType) -> u32 {
+    use ironrdp_pdu::rdp::client_info::CompressionType;
+
+    match ty {
+        CompressionType::K8 => 0,
+        CompressionType::K64 => 1,
+        CompressionType::Rdp6 => 2,
+        CompressionType::Rdp61 => 3,
     }
 }
 

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -896,8 +896,10 @@ impl ConfigBuilder {
             codecs,
         };
 
+        #[cfg_attr(not(feature = "gateway"), allow(unused_mut))]
+        let mut transport = self.transport;
         #[cfg(feature = "gateway")]
-        if let Transport::Gateway(gw) = self.transport {
+        if let Transport::Gateway(gw) = &mut transport {
             gw.username = self.gateway_username.unwrap_or_default();
             gw.password = self.gateway_password.unwrap_or_default();
         }

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -1,5 +1,6 @@
 use core::net::SocketAddr;
 use core::num::NonZeroU16;
+use core::time::Duration;
 use std::sync::Arc;
 
 use ironrdp_connector::connection_activation::ConnectionActivationState;
@@ -12,7 +13,9 @@ use ironrdp_dvc::DvcProcessor as _;
 use ironrdp_echo::client::EchoClient;
 use ironrdp_graphics::image_processing::PixelFormat;
 use ironrdp_graphics::pointer::DecodedPointer;
+use ironrdp_pdu::input::MousePdu;
 use ironrdp_pdu::input::fast_path::FastPathInputEvent;
+use ironrdp_pdu::input::mouse::PointerFlags;
 #[cfg(any(feature = "dvc-pipe-proxy", all(windows, feature = "dvc-com-plugin")))]
 use ironrdp_pdu::pdu_other_err;
 use ironrdp_session::image::DecodedImage;
@@ -234,6 +237,7 @@ impl RdpClient {
                 connection_result,
                 &self.output_event_sender,
                 &mut self.input_event_receiver,
+                self.config.fake_events_interval,
             )
             .await
             {
@@ -338,7 +342,7 @@ fn build_connector(
 
     // Attach user-defined DVC channels from the extension registry.
     for attach_dvc in &config.extensions.dvc_channels {
-        attach_dvc(&mut drdynvc);
+        attach_dvc(&mut drdynvc, &config.properties);
     }
 
     // Clone the connector config so we can apply runtime overrides before handing it to the
@@ -411,7 +415,7 @@ fn build_connector(
 
     // Attach user-defined static channels from the extension registry.
     for attach_sc in &config.extensions.static_channels {
-        attach_sc(&mut connector);
+        attach_sc(&mut connector, &config.properties);
     }
 
     connector
@@ -723,17 +727,24 @@ async fn active_session(
     connection_result: ConnectionResult,
     output_event_sender: &mpsc::Sender<RdpOutputEvent>,
     input_event_receiver: &mut mpsc::UnboundedReceiver<RdpInputEvent>,
+    fake_events_interval: Option<Duration>,
 ) -> SessionResult<RdpControlFlow> {
     let (mut reader, mut writer) = split_tokio_framed(framed);
-    let mut image = DecodedImage::new(
-        PixelFormat::RgbA32,
-        connection_result.desktop_size.width,
-        connection_result.desktop_size.height,
-    );
+    let desktop_size = connection_result.desktop_size;
+    let mut image = DecodedImage::new(PixelFormat::RgbA32, desktop_size.width, desktop_size.height);
     let mut active_stage = ActiveStage::new(connection_result);
 
     // Timer interval for driving clipboard lock timeouts.
-    let mut cleanup_interval = tokio::time::interval(core::time::Duration::from_secs(5));
+    let mut cleanup_interval = tokio::time::interval(Duration::from_secs(5));
+
+    // Anti-idle: track the time of the last real input and the last known mouse position so we can
+    // synthesize a no-op mouse move when the session has been idle for too long. Default to the
+    // middle of the screen so a synthetic move before any real input doesn't snap the pointer to a
+    // corner.
+    let mut last_input = tokio::time::Instant::now();
+    let mut last_mouse_pos = (desktop_size.width / 2, desktop_size.height / 2);
+    let mut fake_events_interval =
+        fake_events_interval.map(|interval| tokio::time::interval(core::cmp::max(interval, Duration::from_secs(1))));
 
     let disconnect_reason = 'outer: loop {
         let outputs = tokio::select! {
@@ -744,6 +755,8 @@ async fn active_session(
             }
             input_event = input_event_receiver.recv() => {
                 let input_event = input_event.ok_or_else(|| ironrdp_session::general_err!("GUI is stopped"))?;
+
+                last_input = tokio::time::Instant::now();
 
                 match input_event {
                     RdpInputEvent::Resize { width, height, scale_factor, physical_size } => {
@@ -767,6 +780,11 @@ async fn active_session(
                     }
                     RdpInputEvent::FastPath(events) => {
                         trace!(?events);
+                        for event in &events {
+                            if let FastPathInputEvent::MouseEvent(mouse) = event {
+                                last_mouse_pos = (mouse.x_position, mouse.y_position);
+                            }
+                        }
                         active_stage.process_fastpath_input(&mut image, &events)?
                     }
                     RdpInputEvent::Close => {
@@ -841,6 +859,26 @@ async fn active_session(
                 }
                 #[cfg(not(feature = "clipboard"))]
                 Vec::new()
+            }
+            _ = async { match fake_events_interval.as_mut() {
+                Some(interval) => interval.tick().await,
+                None => core::future::pending().await,
+            }} => {
+                // Anti-idle: synthesize a no-op mouse move if the session has been idle for at least
+                // the configured interval, keeping the connection alive without user interaction.
+                if last_input.elapsed() >= fake_events_interval.as_ref().map_or(Duration::MAX, |i| i.period()) {
+                    last_input = tokio::time::Instant::now();
+                    let mut events = SmallVec::<[FastPathInputEvent; 2]>::new();
+                    events.push(FastPathInputEvent::MouseEvent(MousePdu {
+                        flags: PointerFlags::MOVE,
+                        number_of_wheel_rotation_units: 0,
+                        x_position: last_mouse_pos.0,
+                        y_position: last_mouse_pos.1,
+                    }));
+                    active_stage.process_fastpath_input(&mut image, &events)?
+                } else {
+                    Vec::new()
+                }
             }
         };
 

--- a/crates/ironrdp-pdu/src/rdp/capability_sets/bitmap_codecs/mod.rs
+++ b/crates/ironrdp-pdu/src/rdp/capability_sets/bitmap_codecs/mod.rs
@@ -739,6 +739,9 @@ fn parse_codecs_config<'a>(codecs: &'a [&'a str]) -> Result<HashMap<&'a str, boo
     Ok(result)
 }
 
+// FIXME(#api): this is a CLI-shaped API (string slices like "codec:on"/"codec:off", help string,
+// errors as `String`). A programmatic API would be warranted, especially for servers; the
+// `ConfigBuilder::with_codecs` method may also be too low-level and should be revisited.
 /// This function generates a list of client codec capabilities based on the
 /// provided configuration.
 ///
@@ -809,6 +812,8 @@ List of codecs:
     Ok(BitmapCodecs(codecs))
 }
 
+// FIXME(#api): this is a CLI-shaped API (string slices like "codec:on"/"codec:off", help string,
+// errors as `String`). A more programmatic API is warranted for server use cases.
 /// This function generates a list of server codec capabilities based on the
 /// provided configuration.
 ///

--- a/crates/ironrdp-propertyset/src/lib.rs
+++ b/crates/ironrdp-propertyset/src/lib.rs
@@ -55,6 +55,13 @@ impl PropertySet {
     pub fn iter(&self) -> impl Iterator<Item = (&Key, &Value)> {
         self.inner.iter()
     }
+
+    /// Merges all entries from `other` into this set, overwriting existing keys (last writer wins).
+    pub fn merge(&mut self, other: &PropertySet) {
+        for (key, value) in &other.inner {
+            self.inner.insert(key.clone(), value.clone());
+        }
+    }
 }
 
 impl IntoIterator for PropertySet {

--- a/crates/ironrdp-session/src/x224/mod.rs
+++ b/crates/ironrdp-session/src/x224/mod.rs
@@ -221,6 +221,9 @@ impl Processor {
                     // ClientInfoFlags::COMPRESSION is negotiated. Decompression
                     // should happen here before passing data downstream. Currently
                     // IronRDP does not wire bulk decompression into this path.
+                    // FIXME: until this is wired, the client deliberately defaults to the simple,
+                    // stateless-friendly MPPC 64K (RDP5) compression level rather than XCRUSH; a
+                    // stateful codec would risk silent corruption on slow-path updates.
                     ShareDataPdu::Update(data) => {
                         debug!("Got slow-path graphics update ({} bytes)", data.len());
                         Ok(vec![ProcessorOutput::GraphicsUpdate(data)])

--- a/crates/ironrdp-testsuite-extra/tests/config_rdp.rs
+++ b/crates/ironrdp-testsuite-extra/tests/config_rdp.rs
@@ -48,7 +48,7 @@ fn gateway_is_disabled_when_gateway_usage_method_is_zero() {
         &[],
     );
 
-    assert!(!matches!(config.transport, Transport::Gateway(_)));
+    assert!(!matches!(config.transport(), Transport::Gateway(_)));
 }
 
 #[test]
@@ -58,7 +58,7 @@ fn gateway_is_disabled_when_gateway_usage_method_is_four() {
         &[],
     );
 
-    assert!(!matches!(config.transport, Transport::Gateway(_)));
+    assert!(!matches!(config.transport(), Transport::Gateway(_)));
 }
 
 #[test]
@@ -68,7 +68,7 @@ fn gateway_is_enabled_with_usage_method_one_and_file_credentials() {
         &[],
     );
 
-    let Transport::Gateway(gw) = config.transport else {
+    let Transport::Gateway(gw) = config.transport() else {
         panic!("gateway should be configured");
     };
     assert_eq!(gw.endpoint, "gw.example.com:443");
@@ -83,7 +83,7 @@ fn no_credssp_cli_flag_overrides_rdp_enable_credssp_property() {
         &["--no-credssp"],
     );
 
-    assert!(!config.connector.enable_credssp);
+    assert!(!config.connector().enable_credssp);
 }
 
 #[test]
@@ -93,8 +93,11 @@ fn kdc_proxy_name_is_normalized_to_https_url() {
         &[],
     );
 
-    let kerberos = config.kerberos_config.expect("kerberos config should be present");
-    let kdc_proxy_url = kerberos.kdc_proxy_url.expect("kdc proxy url should be present");
+    let kerberos = config.kerberos_config().expect("kerberos config should be present");
+    let kdc_proxy_url = kerberos
+        .kdc_proxy_url
+        .as_ref()
+        .expect("kdc proxy url should be present");
     assert_eq!(kdc_proxy_url.as_str(), "https://kdc.example.com/KdcProxy");
 }
 
@@ -105,7 +108,7 @@ fn redirectclipboard_zero_disables_clipboard_for_default_mode() {
         &[],
     );
 
-    assert!(matches!(config.channels.clipboard, ClipboardType::Disable));
+    assert!(matches!(config.channels().clipboard, ClipboardType::Disable));
 }
 
 #[test]
@@ -115,7 +118,7 @@ fn audiomode_two_disables_audio_playback() {
         &[],
     );
 
-    assert!(!config.connector.enable_audio_playback);
+    assert!(!config.connector().enable_audio_playback);
 }
 
 #[test]
@@ -125,7 +128,7 @@ fn invalid_audiomode_falls_back_to_audio_playback_enabled() {
         &[],
     );
 
-    assert!(config.connector.enable_audio_playback);
+    assert!(config.connector().enable_audio_playback);
 }
 
 #[test]
@@ -135,9 +138,9 @@ fn desktop_dimensions_are_parsed_from_rdp_file() {
         &[],
     );
 
-    assert_eq!(config.connector.desktop_size.width, 1024);
-    assert_eq!(config.connector.desktop_size.height, 768);
-    assert_eq!(config.connector.desktop_scale_factor, 125);
+    assert_eq!(config.connector().desktop_size.width, 1024);
+    assert_eq!(config.connector().desktop_size.height, 768);
+    assert_eq!(config.connector().desktop_scale_factor, 125);
 }
 
 #[test]
@@ -152,11 +155,11 @@ fn out_of_range_desktop_dimensions_fall_back_to_defaults() {
     );
 
     assert_eq!(
-        invalid_config.connector.desktop_size.width,
-        default_config.connector.desktop_size.width
+        invalid_config.connector().desktop_size.width,
+        default_config.connector().desktop_size.width
     );
     assert_eq!(
-        invalid_config.connector.desktop_size.height,
-        default_config.connector.desktop_size.height
+        invalid_config.connector().desktop_size.height,
+        default_config.connector().desktop_size.height
     );
 }

--- a/crates/ironrdp-viewer/src/app.rs
+++ b/crates/ironrdp-viewer/src/app.rs
@@ -7,9 +7,7 @@ use std::time::Instant;
 
 use anyhow::Context as _;
 use ironrdp::client::rdp::{RdpInputEvent, RdpOutputEvent};
-use ironrdp::pdu::input::MousePdu;
 use ironrdp::pdu::input::fast_path::FastPathInputEvent;
-use ironrdp::pdu::input::mouse::PointerFlags;
 use raw_window_handle::{DisplayHandle, HasDisplayHandle as _};
 use smallvec::SmallVec;
 use tokio::sync::mpsc;
@@ -33,15 +31,12 @@ pub struct App {
     input_database: ironrdp::input::Database,
     last_size: Option<PhysicalSize<u32>>,
     resize_timeout: Option<Instant>,
-    last_event: Option<Instant>,
-    fake_events_interval: Option<Duration>,
 }
 
 impl App {
     pub fn new(
         event_loop: &EventLoop<RdpOutputEvent>,
         input_event_sender: &mpsc::UnboundedSender<RdpInputEvent>,
-        fake_events_interval: Option<Duration>,
         initial_window_size: PhysicalSize<u32>,
     ) -> anyhow::Result<Self> {
         // SAFETY: We drop the softbuffer context right before the event loop is stopped, thus making this safe.
@@ -65,8 +60,6 @@ impl App {
             input_database,
             last_size: None,
             resize_timeout: None,
-            last_event: None,
-            fake_events_interval,
         })
     }
 
@@ -106,30 +99,10 @@ impl App {
         sb_buffer.copy_from_slice(self.buffer.as_slice());
         sb_buffer.present().expect("buffer present");
     }
-
-    pub fn fake_mouse_move(&mut self) {
-        let (Some(last_event), Some(fake_events_interval)) = (self.last_event, self.fake_events_interval) else {
-            return;
-        };
-
-        if last_event.elapsed() > fake_events_interval {
-            let mut events = SmallVec::new();
-            let curr_pos = self.input_database.mouse_position();
-            events.push(FastPathInputEvent::MouseEvent(MousePdu {
-                flags: PointerFlags::MOVE,
-                number_of_wheel_rotation_units: 0,
-                x_position: curr_pos.x,
-                y_position: curr_pos.y,
-            }));
-            let _ = self.input_event_sender.send(RdpInputEvent::FastPath(events));
-        }
-    }
 }
 
 impl ApplicationHandler<RdpOutputEvent> for App {
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
-        self.fake_mouse_move();
-
         if let Some(timeout) = self.resize_timeout {
             if let Some(timeout) = timeout.checked_duration_since(Instant::now()) {
                 event_loop.set_control_flow(ControlFlow::wait_duration(timeout));
@@ -216,7 +189,7 @@ impl ApplicationHandler<RdpOutputEvent> for App {
 
                     let input_events = self.input_database.apply(core::iter::once(operation));
 
-                    send_fast_path_events(&self.input_event_sender, input_events, &mut self.last_event);
+                    send_fast_path_events(&self.input_event_sender, input_events);
                 }
             }
             WindowEvent::ModifiersChanged(modifiers) => {
@@ -252,7 +225,7 @@ impl ApplicationHandler<RdpOutputEvent> for App {
 
                 let input_events = self.input_database.apply(operations);
 
-                send_fast_path_events(&self.input_event_sender, input_events, &mut self.last_event);
+                send_fast_path_events(&self.input_event_sender, input_events);
             }
             WindowEvent::CursorMoved { position, .. } => {
                 let win_size = window.inner_size();
@@ -264,7 +237,7 @@ impl ApplicationHandler<RdpOutputEvent> for App {
 
                 let input_events = self.input_database.apply(core::iter::once(operation));
 
-                send_fast_path_events(&self.input_event_sender, input_events, &mut self.last_event);
+                send_fast_path_events(&self.input_event_sender, input_events);
             }
             WindowEvent::MouseWheel { delta, .. } => {
                 let mut operations = SmallVec::<[ironrdp::input::Operation; 2]>::new();
@@ -316,7 +289,7 @@ impl ApplicationHandler<RdpOutputEvent> for App {
 
                 let input_events = self.input_database.apply(operations);
 
-                send_fast_path_events(&self.input_event_sender, input_events, &mut self.last_event);
+                send_fast_path_events(&self.input_event_sender, input_events);
             }
             WindowEvent::MouseInput { state, button, .. } => {
                 let mouse_button = match button {
@@ -341,7 +314,7 @@ impl ApplicationHandler<RdpOutputEvent> for App {
 
                 let input_events = self.input_database.apply(core::iter::once(operation));
 
-                send_fast_path_events(&self.input_event_sender, input_events, &mut self.last_event);
+                send_fast_path_events(&self.input_event_sender, input_events);
             }
             WindowEvent::RedrawRequested => {
                 self.draw();
@@ -440,10 +413,8 @@ impl ApplicationHandler<RdpOutputEvent> for App {
 fn send_fast_path_events(
     input_event_sender: &mpsc::UnboundedSender<RdpInputEvent>,
     input_events: SmallVec<[FastPathInputEvent; 2]>,
-    last_event: &mut Option<Instant>,
 ) {
     if !input_events.is_empty() {
         let _ = input_event_sender.send(RdpInputEvent::FastPath(input_events));
     }
-    *last_event = Some(Instant::now());
 }

--- a/crates/ironrdp-viewer/src/config.rs
+++ b/crates/ironrdp-viewer/src/config.rs
@@ -10,6 +10,7 @@ use ironrdp::client::config::{
     ClipboardType as ResolvedClipboardType, Config, ConfigBuilder, Destination, DvcProxyInfo, MissingField,
 };
 use ironrdp::pdu::rdp::capability_sets::{MajorPlatformType, client_codecs_capabilities};
+use ironrdp_cfg::PropertySetExt as _;
 use tap::prelude::*;
 use url::Url;
 
@@ -104,31 +105,31 @@ fn apply_cli_args_to_properties(properties: &mut ironrdp_propertyset::PropertySe
     }
 
     if args.no_credssp {
-        properties.insert("enablecredsspsupport", 0i64);
+        properties.set_enable_credssp_support(false);
     }
 
     if args.no_tls {
-        properties.insert("ironrdp_tls", false);
+        properties.set_enable_tls(false);
     }
 
     if args.no_server_pointer {
-        properties.insert("ironrdp_serverpointer", false);
+        properties.set_server_pointer(false);
     }
 
     if args.autologon {
-        properties.insert("ironrdp_autologon", true);
+        properties.set_autologon(true);
     }
 
     if let Some(enabled) = args.compression_enabled {
-        properties.insert("compression", enabled);
+        properties.set_compression(enabled);
     }
 
     if let Some(level) = args.compression_level {
-        properties.insert("ironrdp_compressionlevel", i64::from(level));
+        properties.set_compression_level(level);
     }
 
     if let Some(color_depth) = args.color_depth {
-        properties.insert("ironrdp_colordepth", i64::from(color_depth));
+        properties.set_color_depth(color_depth);
     }
 
     #[cfg(windows)]
@@ -139,19 +140,19 @@ fn apply_cli_args_to_properties(properties: &mut ironrdp_propertyset::PropertySe
             .map(|p| p.display().to_string())
             .collect::<Vec<_>>()
             .join(",");
-        properties.insert("ironrdp_dvcplugin", value);
+        properties.set_dvc_plugins(value);
     }
 
     if let Some(url) = &args.rdcleanpath_url {
-        properties.insert("ironrdp_rdcleanpathurl", url.as_str());
+        properties.set_rdcleanpath_url(url.as_str());
     }
 
     if let Some(token) = &args.rdcleanpath_token {
-        properties.insert("ironrdp_rdcleanpathtoken", token.as_str());
+        properties.set_rdcleanpath_token(token.as_str());
     }
 
     if let Some(minutes) = args.prevent_session_lock {
-        properties.insert("ironrdp_fakeeventsinterval", i64::from(minutes));
+        properties.set_fake_events_interval(minutes);
     }
 
     if !args.dvc_proxy.is_empty() {
@@ -161,7 +162,7 @@ fn apply_cli_args_to_properties(properties: &mut ironrdp_propertyset::PropertySe
             .map(|p| format!("{}={}", p.channel_name, p.pipe_name))
             .collect::<Vec<_>>()
             .join(",");
-        properties.insert("ironrdp_dvcpipeproxy", value);
+        properties.set_dvc_pipe_proxies(value);
     }
 }
 

--- a/crates/ironrdp-viewer/src/config.rs
+++ b/crates/ironrdp-viewer/src/config.rs
@@ -1,24 +1,17 @@
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
 use core::num::ParseIntError;
-use core::time::Duration;
 use std::path::PathBuf;
 
 use anyhow::Context as _;
 use clap::Parser;
 use clap::clap_derive::ValueEnum;
 use ironrdp::client::config::{
-    ClipboardType as ResolvedClipboardType, Config, ConfigBuilder, Destination, DvcProxyInfo, GatewayConfig,
-    RDCleanPathConfig, Transport,
+    ClipboardType as ResolvedClipboardType, Config, ConfigBuilder, Destination, DvcProxyInfo, MissingField,
 };
-use ironrdp::connector::{self, Credentials};
 use ironrdp::pdu::rdp::capability_sets::{MajorPlatformType, client_codecs_capabilities};
-use ironrdp::pdu::rdp::client_info::{PerformanceFlags, TimezoneInfo};
 use tap::prelude::*;
 use url::Url;
-
-const DEFAULT_WIDTH: u16 = 1920;
-const DEFAULT_HEIGHT: u16 = 1080;
 
 /// CLI selection for the clipboard backend.
 ///
@@ -114,20 +107,61 @@ fn apply_cli_args_to_properties(properties: &mut ironrdp_propertyset::PropertySe
         properties.insert("enablecredsspsupport", 0i64);
     }
 
+    if args.no_tls {
+        properties.insert("ironrdp_tls", false);
+    }
+
+    if args.no_server_pointer {
+        properties.insert("ironrdp_serverpointer", false);
+    }
+
+    if args.autologon {
+        properties.insert("ironrdp_autologon", true);
+    }
+
     if let Some(enabled) = args.compression_enabled {
         properties.insert("compression", enabled);
     }
-}
 
-fn compression_type_from_level(level: u32) -> anyhow::Result<ironrdp::pdu::rdp::client_info::CompressionType> {
-    use ironrdp::pdu::rdp::client_info::CompressionType;
+    if let Some(level) = args.compression_level {
+        properties.insert("ironrdp_compressionlevel", i64::from(level));
+    }
 
-    match level {
-        0 => Ok(CompressionType::K8),
-        1 => Ok(CompressionType::K64),
-        2 => Ok(CompressionType::Rdp6),
-        3 => Ok(CompressionType::Rdp61),
-        _ => anyhow::bail!("Invalid compression level. Valid values are 0, 1, 2, 3."),
+    if let Some(color_depth) = args.color_depth {
+        properties.insert("ironrdp_colordepth", i64::from(color_depth));
+    }
+
+    #[cfg(windows)]
+    if !args.dvc_plugin.is_empty() {
+        let value = args
+            .dvc_plugin
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+        properties.insert("ironrdp_dvcplugin", value);
+    }
+
+    if let Some(url) = &args.rdcleanpath_url {
+        properties.insert("ironrdp_rdcleanpathurl", url.as_str());
+    }
+
+    if let Some(token) = &args.rdcleanpath_token {
+        properties.insert("ironrdp_rdcleanpathtoken", token.as_str());
+    }
+
+    if let Some(minutes) = args.prevent_session_lock {
+        properties.insert("ironrdp_fakeeventsinterval", i64::from(minutes));
+    }
+
+    if !args.dvc_proxy.is_empty() {
+        let value = args
+            .dvc_proxy
+            .iter()
+            .map(|p| format!("{}={}", p.channel_name, p.pipe_name))
+            .collect::<Vec<_>>()
+            .join(",");
+        properties.insert("ironrdp_dvcpipeproxy", value);
     }
 }
 
@@ -280,8 +314,8 @@ struct Args {
     ///   1 — MPPC with 64 KB history (RDP 5.0)
     ///   2 — NCRUSH (RDP 6.0)
     ///   3 — XCRUSH (RDP 6.1)
-    #[clap(long, value_parser = clap::value_parser!(u32).range(0..=3), default_value_t = 3)]
-    compression_level: u32,
+    #[clap(long, value_parser = clap::value_parser!(u32).range(0..=3))]
+    compression_level: Option<u32>,
 
     /// Prevents session locking by injecting fake mouse movement events when
     /// the connection is idle (interval in minutes)
@@ -324,7 +358,6 @@ pub struct PartialConfig {
     // CLI-only settings that are not representable as `.rdp` file properties.
     pub log_file: Option<String>,
     pub dump_rdp: Option<PathBuf>,
-    pub rdcleanpath: Option<RDCleanPathConfig>,
     pub keyboard_type: KeyboardType,
     pub keyboard_subtype: u32,
     pub keyboard_functional_keys_count: u32,
@@ -332,18 +365,9 @@ pub struct PartialConfig {
     pub dig_product_id: String,
     pub thin_client: bool,
     pub small_cache: bool,
-    pub color_depth: Option<u32>,
-    pub no_server_pointer: bool,
     pub capabilities: u32,
-    pub autologon: bool,
-    pub no_tls: bool,
     pub clipboard_type: ClipboardType,
     pub codecs: Vec<String>,
-    pub compression_level: u32,
-    pub prevent_session_lock: Option<u32>,
-    pub dvc_pipe_proxies: Vec<DvcProxyInfo>,
-    #[cfg(windows)]
-    pub dvc_plugins: Vec<PathBuf>,
 }
 
 impl PartialConfig {
@@ -374,16 +398,10 @@ impl PartialConfig {
         // CLI arguments take precedence: upsert them after the .rdp file is loaded.
         apply_cli_args_to_properties(&mut properties, &args);
 
-        let rdcleanpath = args
-            .rdcleanpath_url
-            .zip(args.rdcleanpath_token)
-            .map(|(url, auth_token)| RDCleanPathConfig { url, auth_token });
-
         Ok(Self {
             properties,
             log_file: args.log_file,
             dump_rdp: args.dump_rdp,
-            rdcleanpath,
             keyboard_type: args.keyboard_type,
             keyboard_subtype: args.keyboard_subtype,
             keyboard_functional_keys_count: args.keyboard_functional_keys_count,
@@ -391,285 +409,112 @@ impl PartialConfig {
             dig_product_id: args.dig_product_id,
             thin_client: args.thin_client,
             small_cache: args.small_cache,
-            color_depth: args.color_depth,
-            no_server_pointer: args.no_server_pointer,
             capabilities: args.capabilities,
-            autologon: args.autologon,
-            no_tls: args.no_tls,
             clipboard_type: args.clipboard_type,
             codecs: args.codecs,
-            compression_level: args.compression_level,
-            prevent_session_lock: args.prevent_session_lock,
-            dvc_pipe_proxies: args.dvc_proxy,
-            #[cfg(windows)]
-            dvc_plugins: args.dvc_plugin,
         })
     }
 
     pub fn into_config(self) -> anyhow::Result<Config> {
-        use ironrdp_cfg::{AudioMode, PropertySetExt as _};
+        use ironrdp_cfg::PropertySetExt as _;
 
-        let properties = &self.properties;
+        // The library overlays everything expressible as a `.rdp` property: destination, credentials,
+        // transport, channels, desktop size, audio, DVC proxies, etc.
+        let mut builder = ConfigBuilder::from_property_set(&self.properties)?;
 
-        let has_gateway_host = properties.gateway_hostname().is_some();
-        let use_gateway = properties
-            .gateway_usage_method()
-            .unwrap_or_else(|e| {
-                eprintln!("Warning: {e}, assuming no gateway");
-                Some(ironrdp_cfg::GatewayUsageMethod::Direct)
-            })
-            .map_or(has_gateway_host, ironrdp_cfg::GatewayUsageMethod::is_gateway_required);
+        // CLI-only knobs that are not representable as `.rdp` properties.
+        builder = builder
+            .with_keyboard_type(self.keyboard_type.into_pdu())
+            .with_keyboard_subtype(self.keyboard_subtype)
+            .with_keyboard_functional_keys_count(self.keyboard_functional_keys_count)
+            .with_ime_file_name(self.ime_file_name)
+            .with_dig_product_id(self.dig_product_id)
+            .with_codecs(self.codecs.clone());
 
-        let mut gw_config: Option<GatewayConfig> =
-            use_gateway
-                .then(|| properties.gateway_hostname())
-                .flatten()
-                .map(|gw_addr| GatewayConfig {
-                    endpoint: gw_addr.to_owned(),
-                    username: String::new(),
-                    password: String::new(),
-                });
+        // Validate the codecs early to surface help text before connecting.
+        let codecs: Vec<_> = self.codecs.iter().map(String::as_str).collect();
+        if let Err(help) = client_codecs_capabilities(&codecs) {
+            print!("{help}");
+            std::process::exit(0);
+        }
 
-        if let Some(ref mut gw) = gw_config {
-            if let Ok(Some(gateway_credentials_source)) = properties.gateway_credentials_source() {
-                // All known credential sources fall through to username/password prompts.
-                // The value is available for future differentiation if needed.
-                let _ = gateway_credentials_source;
-            }
+        let redirect_clipboard = self.properties.redirect_clipboard().unwrap_or(true);
+        builder = builder.with_clipboard(resolve_clipboard_type(self.clipboard_type, redirect_clipboard));
 
-            gw.username = if let Some(gw_user) = properties.gateway_username() {
-                gw_user.to_owned()
-            } else {
-                inquire::Text::new("Gateway username:")
+        prompt_missing(builder)
+    }
+}
+
+/// Resolve the remaining [`MissingField`]s by prompting for credentials/addresses and deriving the
+/// frontend-specific client identity, then build the [`Config`].
+fn prompt_missing(mut builder: ConfigBuilder) -> anyhow::Result<Config> {
+    for field in builder.missing() {
+        builder = match field {
+            MissingField::ServerAddress => {
+                let dest = inquire::Text::new("Server address:")
                     .prompt()
-                    .context("Username prompt")?
-            };
-
-            gw.password = if let Some(gw_pass) = properties.gateway_password() {
-                gw_pass.to_owned()
-            } else {
-                inquire::Password::new("Gateway password:")
+                    .context("Address prompt")?
+                    .pipe(Destination::new)?;
+                builder.with_destination(dest)
+            }
+            MissingField::Username => {
+                let username = inquire::Text::new("Username:").prompt().context("Username prompt")?;
+                builder.with_username(username)
+            }
+            MissingField::Password => {
+                let password = inquire::Password::new("Password:")
                     .without_confirmation()
                     .prompt()
-                    .context("Password prompt")?
-            };
-        };
-
-        let target = match properties.full_address().context("invalid 'full address' property")? {
-            Some(addr) => Some(addr),
-            None => properties
-                .alternate_full_address()
-                .context("invalid 'alternate full address' property")?,
-        };
-
-        let destination = if let Some(target) = target {
-            const RDP_DEFAULT_PORT: u16 = 3389;
-            let port = match target.port {
-                Some(p) => p,
-                None => properties
-                    .server_port()
-                    .context("invalid 'server port' property")?
-                    .unwrap_or(RDP_DEFAULT_PORT),
-            };
-            let name = match target.host {
-                ironrdp_cfg::TargetHost::Ip(ip) => ip.to_string(),
-                ironrdp_cfg::TargetHost::Domain(host) => host,
-            };
-            Destination::from_parts(name, port)
-        } else {
-            inquire::Text::new("Server address:")
-                .prompt()
-                .context("Address prompt")?
-                .pipe(Destination::new)?
-        };
-
-        let username = if let Some(username) = properties.username() {
-            username.to_owned()
-        } else {
-            inquire::Text::new("Username:").prompt().context("Username prompt")?
-        };
-
-        let password = if let Some(password) = properties.clear_text_password() {
-            password.to_owned()
-        } else {
-            inquire::Password::new("Password:")
-                .without_confirmation()
-                .prompt()
-                .context("Password prompt")?
-        };
-
-        let codecs: Vec<_> = self.codecs.iter().map(|s| s.as_str()).collect();
-        let codecs = match client_codecs_capabilities(&codecs) {
-            Ok(codecs) => codecs,
-            Err(help) => {
-                print!("{help}");
-                std::process::exit(0);
+                    .context("Password prompt")?;
+                builder.with_password(password)
             }
-        };
-        let mut bitmap = connector::BitmapConfig {
-            color_depth: 32,
-            lossy_compression: true,
-            codecs,
-        };
-
-        if let Some(color_depth) = self.color_depth {
-            if color_depth != 16 && color_depth != 32 {
-                anyhow::bail!("Invalid color depth. Only 16 and 32 bit color depths are supported.");
+            MissingField::GatewayUsername => {
+                let username = inquire::Text::new("Gateway username:")
+                    .prompt()
+                    .context("Gateway username prompt")?;
+                builder.with_gateway_username(username)
             }
-            bitmap.color_depth = color_depth;
-        };
-
-        // make a duration from cmdline argument (minutes)
-        let fake_events_interval = self
-            .prevent_session_lock
-            .map(|v| Duration::from_secs(u64::from(v) * 60));
-
-        let enable_credssp = properties.enable_credssp_support().unwrap_or(true);
-
-        let redirect_clipboard = properties.redirect_clipboard().unwrap_or(true);
-        let clipboard_type = resolve_clipboard_type(self.clipboard_type, redirect_clipboard);
-
-        let enable_audio_playback = match properties.audio_mode() {
-            Ok(None) | Ok(Some(AudioMode::RedirectToClient)) => true,
-            Ok(Some(AudioMode::PlayOnServer | AudioMode::Disabled)) => false,
-            Err(e) => {
-                eprintln!("Warning: {e}, defaulting to audio playback enabled");
-                true
+            MissingField::GatewayPassword => {
+                let password = inquire::Password::new("Gateway password:")
+                    .without_confirmation()
+                    .prompt()
+                    .context("Gateway password prompt")?;
+                builder.with_gateway_password(password)
             }
+            // Frontend-derived identity: never prompted.
+            MissingField::ClientBuild => builder.with_client_build(client_build()),
+            MissingField::ClientDir => {
+                // NOTE: hardcode this value like in freerdp
+                // https://github.com/FreeRDP/FreeRDP/blob/4e24b966c86fdf494a782f0dfcfc43a057a2ea60/libfreerdp/core/settings.c#LL49C34-L49C70
+                builder.with_client_dir("C:\\Windows\\System32\\mstscax.dll")
+            }
+            MissingField::Platform => builder.with_platform(current_platform()),
+            MissingField::ClientName => builder.with_client_name(client_name()),
         };
+    }
 
-        let compression_enabled = properties.compression().unwrap_or(true);
+    builder.build()
+}
 
-        let compression_type = if compression_enabled {
-            Some(compression_type_from_level(self.compression_level)?)
-        } else {
-            None
-        };
+fn client_build() -> u32 {
+    semver::Version::parse(env!("CARGO_PKG_VERSION"))
+        .map_or(0, |v| v.major * 100 + v.minor * 10 + v.patch)
+        .try_into()
+        .unwrap_or(0)
+}
 
-        let desktop_width = properties
-            .desktop_width()
-            .unwrap_or_else(|_| {
-                eprintln!("Warning: ignored out-of-range 'desktopwidth' property");
-                None
-            })
-            .unwrap_or(DEFAULT_WIDTH);
-        let desktop_height = properties
-            .desktop_height()
-            .unwrap_or_else(|_| {
-                eprintln!("Warning: ignored out-of-range 'desktopheight' property");
-                None
-            })
-            .unwrap_or(DEFAULT_HEIGHT);
-        let desktop_scale_factor = properties
-            .desktop_scale_factor()
-            .unwrap_or_else(|_| {
-                eprintln!("Warning: ignored out-of-range 'desktopscalefactor' property");
-                None
-            })
-            .unwrap_or(0);
+fn client_name() -> String {
+    whoami::hostname().unwrap_or_else(|_| "ironrdp".to_owned())
+}
 
-        let kdc_proxy_url = properties
-            .kdc_proxy_url()
-            .map(str::to_owned)
-            .or_else(|| properties.kdc_proxy_name().map(normalize_kdc_proxy_url_from_name));
-
-        let kerberos_config = kdc_proxy_url.and_then(|kdc_proxy_url| {
-            Url::parse(&kdc_proxy_url)
-                .ok()
-                .map(|url| connector::credssp::KerberosConfig {
-                    kdc_proxy_url: Some(url),
-                    // The hostname field is the client computer name used for Kerberos SPN negotiation.
-                    hostname: whoami::hostname().unwrap_or_else(|_| "ironrdp".to_owned()),
-                })
-                .or_else(|| {
-                    eprintln!("Warning: ignored invalid KDC proxy URL in 'kdcproxyname'/'KDCProxyURL' property");
-                    None
-                })
-        });
-
-        let connector = connector::Config {
-            credentials: Credentials::UsernamePassword { username, password },
-            domain: properties.domain().map(str::to_owned),
-            enable_tls: !self.no_tls,
-            enable_credssp,
-            keyboard_type: self.keyboard_type.into_pdu(),
-            keyboard_subtype: self.keyboard_subtype,
-            keyboard_layout: 0, // the server SHOULD use the default active input locale identifier
-            keyboard_functional_keys_count: self.keyboard_functional_keys_count,
-            ime_file_name: self.ime_file_name,
-            dig_product_id: self.dig_product_id,
-            desktop_size: connector::DesktopSize {
-                width: desktop_width,
-                height: desktop_height,
-            },
-            desktop_scale_factor,
-            bitmap: Some(bitmap),
-            client_build: semver::Version::parse(env!("CARGO_PKG_VERSION"))
-                .map_or(0, |version| version.major * 100 + version.minor * 10 + version.patch)
-                .pipe(u32::try_from)
-                .context("cargo package version")?,
-            client_name: whoami::hostname().unwrap_or_else(|_| "ironrdp".to_owned()),
-            // NOTE: hardcode this value like in freerdp
-            // https://github.com/FreeRDP/FreeRDP/blob/4e24b966c86fdf494a782f0dfcfc43a057a2ea60/libfreerdp/core/settings.c#LL49C34-L49C70
-            client_dir: "C:\\Windows\\System32\\mstscax.dll".to_owned(),
-            platform: match whoami::platform() {
-                whoami::Platform::Windows => MajorPlatformType::WINDOWS,
-                whoami::Platform::Linux => MajorPlatformType::UNIX,
-                whoami::Platform::Mac => MajorPlatformType::MACINTOSH,
-                whoami::Platform::Ios => MajorPlatformType::IOS,
-                whoami::Platform::Android => MajorPlatformType::ANDROID,
-                _ => MajorPlatformType::UNSPECIFIED,
-            },
-            hardware_id: None,
-            license_cache: None,
-            enable_server_pointer: !self.no_server_pointer,
-            autologon: self.autologon,
-            enable_audio_playback,
-            request_data: None,
-            pointer_software_rendering: false,
-            multitransport_flags: None,
-            compression_type,
-            performance_flags: PerformanceFlags::default(),
-            timezone_info: TimezoneInfo::default(),
-            alternate_shell: properties.alternate_shell().unwrap_or_default().to_owned(),
-            work_dir: properties.shell_working_directory().unwrap_or_default().to_owned(),
-        };
-
-        // Determine the transport. RDCleanPath takes precedence over gateway.
-        let transport = if let Some(rdcp) = self.rdcleanpath {
-            Transport::RDCleanPath(rdcp)
-        } else if let Some(gw) = gw_config {
-            Transport::Gateway(gw)
-        } else {
-            Transport::Direct
-        };
-
-        let mut builder = ConfigBuilder::new(connector, destination)
-            .with_transport(transport)
-            .with_clipboard(clipboard_type);
-
-        if let Some(kerberos_config) = kerberos_config {
-            builder = builder.with_kerberos_config(kerberos_config);
-        }
-
-        if let Some(log_file) = self.log_file {
-            builder = builder.with_log_file(log_file);
-        }
-
-        if let Some(fake_events_interval) = fake_events_interval {
-            builder = builder.with_fake_events_interval(fake_events_interval);
-        }
-
-        for proxy in self.dvc_pipe_proxies {
-            builder = builder.with_dvc_pipe_proxy(proxy);
-        }
-
-        #[cfg(windows)]
-        for plugin in self.dvc_plugins {
-            builder = builder.with_dvc_plugin(plugin);
-        }
-
-        Ok(builder.build())
+fn current_platform() -> MajorPlatformType {
+    match whoami::platform() {
+        whoami::Platform::Windows => MajorPlatformType::WINDOWS,
+        whoami::Platform::Linux => MajorPlatformType::UNIX,
+        whoami::Platform::Mac => MajorPlatformType::MACINTOSH,
+        whoami::Platform::Ios => MajorPlatformType::IOS,
+        whoami::Platform::Android => MajorPlatformType::ANDROID,
+        _ => MajorPlatformType::UNSPECIFIED,
     }
 }
 
@@ -694,13 +539,5 @@ fn resolve_clipboard_type(cli: ClipboardType, redirect_clipboard: bool) -> Resol
         ClipboardType::Enable => ResolvedClipboardType::Enable,
         ClipboardType::Disable => ResolvedClipboardType::Disable,
         ClipboardType::Stub => ResolvedClipboardType::Stub,
-    }
-}
-
-fn normalize_kdc_proxy_url_from_name(name: &str) -> String {
-    if name.starts_with("http://") || name.starts_with("https://") {
-        name.to_owned()
-    } else {
-        format!("https://{name}/KdcProxy")
     }
 }

--- a/crates/ironrdp-viewer/src/main.rs
+++ b/crates/ironrdp-viewer/src/main.rs
@@ -28,21 +28,15 @@ fn main() -> anyhow::Result<()> {
     let event_loop_proxy = event_loop.create_proxy();
     let (output_event_sender, mut output_event_receiver) = mpsc::channel::<RdpOutputEvent>(64);
     let initial_window_size = PhysicalSize::new(
-        u32::from(config.connector.desktop_size.width),
-        u32::from(config.connector.desktop_size.height),
+        u32::from(config.connector().desktop_size.width),
+        u32::from(config.connector().desktop_size.height),
     );
-    let fake_events_interval = config.fake_events_interval;
 
     let client = RdpClient::new(config, output_event_sender);
     let input_event_sender = client.input_sender();
 
-    let mut app = App::new(
-        &event_loop,
-        &input_event_sender,
-        fake_events_interval,
-        initial_window_size,
-    )
-    .context("unable to initialize App")?;
+    let mut app =
+        App::new(&event_loop, &input_event_sender, initial_window_size).context("unable to initialize App")?;
 
     let rt = runtime::Builder::new_multi_thread()
         .enable_all()


### PR DESCRIPTION
Make ironrdp-client configurable almost entirely from a .rdp PropertySet so that a single ConfigBuilder::from_property_set overlay can build a working client, enabling fully reproducible sessions from .rdp files. Viewer-only settings remain in PartialConfig with special treatment.

- cfg: add ironrdp_ vendor properties for compressionlevel, colordepth, dvcplugin, tls, serverpointer and autologon.
- client: read compression level, color depth, DVC plugins and kerberos from the PropertySet; default bulk compression to K64 unless disabled or specified otherwise.
- client: move anti-idle "fake events" into active_session; consumed via fake_events_interval, dropping it from the viewer GUI
- viewer: upsert CLI flags into the PropertySet; prune PartialConfig to CLI-only fields