### PR TITLE
fix(client): correct binding and error macro in SendInitiateFileCopy arm

### DIFF
--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -799,8 +799,8 @@ async fn active_session(
                                         .map_err(|e| ironrdp_session::custom_err!("CLIPRDR", e))?)
                                 }
                                 ClipboardMessage::SendInitiateFileCopy(files) => {
-                                    Some(cliprdr.initiate_file_copy(files)
-                                        .map_err(|e| session::custom_err!("CLIPRDR", e))?)
+                                    Some(cliprdr_client.initiate_file_copy(files)
+                                        .map_err(|e| ironrdp_session::custom_err!("CLIPRDR", e))?)
                                 }
                                 ClipboardMessage::SendFormatData(response) => {
                                     Some(cliprdr_client.submit_format_data(response)


### PR DESCRIPTION
The `ClipboardMessage::SendInitiateFileCopy` arm in the clipboard event handler refers to a `cliprdr` binding and a `session::custom_err!` macro that are not in scope. The surrounding handler binds the processor as `cliprdr_client`, and every other arm in the same match uses `ironrdp_session::custom_err!`. With the `clipboard` feature enabled this fails to compile:

```
error[E0425]: cannot find value `cliprdr` in this scope
error[E0433]: failed to resolve: use of unresolved module or unlinked crate `session`
```

so master does not build with the clipboard feature on. This aligns the arm with its siblings.

Verified with `cargo check -p ironrdp-client --features rustls,clipboard`.
