### PR TITLE
fix(error): propagate caller location through error constructor helpers

### DIFF
--- a/crates/ironrdp-connector/src/lib.rs
+++ b/crates/ironrdp-connector/src/lib.rs
@@ -393,22 +393,27 @@ pub trait ConnectorErrorExt {
 }
 
 impl ConnectorErrorExt for ConnectorError {
+    #[track_caller]
     fn encode(error: ironrdp_core::EncodeError) -> Self {
         Self::new("encode error", ConnectorErrorKind::Encode(error))
     }
 
+    #[track_caller]
     fn decode(error: ironrdp_core::DecodeError) -> Self {
         Self::new("decode error", ConnectorErrorKind::Decode(error))
     }
 
+    #[track_caller]
     fn general(context: &'static str) -> Self {
         Self::new(context, ConnectorErrorKind::General)
     }
 
+    #[track_caller]
     fn reason(context: &'static str, reason: impl Into<String>) -> Self {
         Self::new(context, ConnectorErrorKind::Reason(reason.into()))
     }
 
+    #[track_caller]
     fn custom<E>(context: &'static str, e: E) -> Self
     where
         E: core::error::Error + Sync + Send + 'static,

--- a/crates/ironrdp-core/src/decode.rs
+++ b/crates/ironrdp-core/src/decode.rs
@@ -98,24 +98,28 @@ impl fmt::Display for DecodeErrorKind {
 }
 
 impl NotEnoughBytesErr for DecodeError {
+    #[track_caller]
     fn not_enough_bytes(context: &'static str, received: usize, expected: usize) -> Self {
         Self::new(context, DecodeErrorKind::NotEnoughBytes { received, expected })
     }
 }
 
 impl InvalidFieldErr for DecodeError {
+    #[track_caller]
     fn invalid_field(context: &'static str, field: &'static str, reason: &'static str) -> Self {
         Self::new(context, DecodeErrorKind::InvalidField { field, reason })
     }
 }
 
 impl UnexpectedMessageTypeErr for DecodeError {
+    #[track_caller]
     fn unexpected_message_type(context: &'static str, got: u8) -> Self {
         Self::new(context, DecodeErrorKind::UnexpectedMessageType { got })
     }
 }
 
 impl UnsupportedVersionErr for DecodeError {
+    #[track_caller]
     fn unsupported_version(context: &'static str, got: u8) -> Self {
         Self::new(context, DecodeErrorKind::UnsupportedVersion { got })
     }
@@ -123,16 +127,19 @@ impl UnsupportedVersionErr for DecodeError {
 
 impl UnsupportedValueErr for DecodeError {
     #[cfg(feature = "alloc")]
+    #[track_caller]
     fn unsupported_value(context: &'static str, name: &'static str, value: String) -> Self {
         Self::new(context, DecodeErrorKind::UnsupportedValue { name, value })
     }
     #[cfg(not(feature = "alloc"))]
+    #[track_caller]
     fn unsupported_value(context: &'static str, name: &'static str) -> Self {
         Self::new(context, DecodeErrorKind::UnsupportedValue { name })
     }
 }
 
 impl OtherErr for DecodeError {
+    #[track_caller]
     fn other(context: &'static str, description: &'static str) -> Self {
         Self::new(context, DecodeErrorKind::Other { description })
     }

--- a/crates/ironrdp-core/src/encode.rs
+++ b/crates/ironrdp-core/src/encode.rs
@@ -102,24 +102,28 @@ impl fmt::Display for EncodeErrorKind {
 }
 
 impl NotEnoughBytesErr for EncodeError {
+    #[track_caller]
     fn not_enough_bytes(context: &'static str, received: usize, expected: usize) -> Self {
         Self::new(context, EncodeErrorKind::NotEnoughBytes { received, expected })
     }
 }
 
 impl InvalidFieldErr for EncodeError {
+    #[track_caller]
     fn invalid_field(context: &'static str, field: &'static str, reason: &'static str) -> Self {
         Self::new(context, EncodeErrorKind::InvalidField { field, reason })
     }
 }
 
 impl UnexpectedMessageTypeErr for EncodeError {
+    #[track_caller]
     fn unexpected_message_type(context: &'static str, got: u8) -> Self {
         Self::new(context, EncodeErrorKind::UnexpectedMessageType { got })
     }
 }
 
 impl UnsupportedVersionErr for EncodeError {
+    #[track_caller]
     fn unsupported_version(context: &'static str, got: u8) -> Self {
         Self::new(context, EncodeErrorKind::UnsupportedVersion { got })
     }
@@ -127,16 +131,19 @@ impl UnsupportedVersionErr for EncodeError {
 
 impl UnsupportedValueErr for EncodeError {
     #[cfg(feature = "alloc")]
+    #[track_caller]
     fn unsupported_value(context: &'static str, name: &'static str, value: String) -> Self {
         Self::new(context, EncodeErrorKind::UnsupportedValue { name, value })
     }
     #[cfg(not(feature = "alloc"))]
+    #[track_caller]
     fn unsupported_value(context: &'static str, name: &'static str) -> Self {
         Self::new(context, EncodeErrorKind::UnsupportedValue { name })
     }
 }
 
 impl OtherErr for EncodeError {
+    #[track_caller]
     fn other(context: &'static str, description: &'static str) -> Self {
         Self::new(context, EncodeErrorKind::Other { description })
     }

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -65,6 +65,7 @@ trait GwErrorExt {
 }
 
 impl GwErrorExt for ironrdp_error::Error<GwErrorKind> {
+    #[track_caller]
     fn custom<E>(context: &'static str, e: E) -> Self
     where
         E: core::error::Error + Sync + Send + 'static,

--- a/crates/ironrdp-pdu/src/lib.rs
+++ b/crates/ironrdp-pdu/src/lib.rs
@@ -50,10 +50,12 @@ pub trait PduErrorExt {
 }
 
 impl PduErrorExt for PduError {
+    #[track_caller]
     fn decode<E: Source>(context: &'static str, source: E) -> Self {
         Self::new(context, PduErrorKind::Decode).with_source(source)
     }
 
+    #[track_caller]
     fn encode<E: Source>(context: &'static str, source: E) -> Self {
         Self::new(context, PduErrorKind::Encode).with_source(source)
     }

--- a/crates/ironrdp-session/src/lib.rs
+++ b/crates/ironrdp-session/src/lib.rs
@@ -71,26 +71,32 @@ pub trait SessionErrorExt {
 }
 
 impl SessionErrorExt for SessionError {
+    #[track_caller]
     fn pdu(error: ironrdp_pdu::PduError) -> Self {
         Self::new("payload error", SessionErrorKind::Pdu(error))
     }
 
+    #[track_caller]
     fn encode(error: ironrdp_core::EncodeError) -> Self {
         Self::new("encode error", SessionErrorKind::Encode(error))
     }
 
+    #[track_caller]
     fn decode(error: ironrdp_core::DecodeError) -> Self {
         Self::new("decode error", SessionErrorKind::Decode(error))
     }
 
+    #[track_caller]
     fn general(context: &'static str) -> Self {
         Self::new(context, SessionErrorKind::General)
     }
 
+    #[track_caller]
     fn reason(context: &'static str, reason: impl Into<String>) -> Self {
         Self::new(context, SessionErrorKind::Reason(reason.into()))
     }
 
+    #[track_caller]
     fn custom<E>(context: &'static str, e: E) -> Self
     where
         E: core::error::Error + Sync + Send + 'static,


### PR DESCRIPTION
The error constructor helpers in several crates wrap the #[track_caller] ironrdp_error::Error::new, but were not themselves marked #[track_caller]. As a result, the captured location pointed at the helper body instead of the real call site, giving misleading "@ file:line" info in error reports.