### PR TITLE
fix(graphics): don't require CONTEXT block on every progressive frame

### DIFF
--- a/crates/ironrdp-graphics/src/progressive.rs
+++ b/crates/ironrdp-graphics/src/progressive.rs
@@ -1076,16 +1076,30 @@ impl ProgressiveDecoder {
 
         let blocks = decode_progressive_stream(bitmap_data)?;
 
-        // Extract context flags from the CONTEXT block. Per MS-RDPEGFX 2.2.4.2
-        // a Progressive stream MUST begin with SYNC + CONTEXT; treat absence as
-        // a malformed stream rather than silently defaulting band layout.
-        let use_reduce_extrapolate = blocks
-            .iter()
-            .find_map(|block| match block {
-                ProgressiveBlock::Context(ctx) => Some(ctx.uses_reduce_extrapolate()),
-                _ => None,
-            })
-            .ok_or(ProgressiveDecodeError::MissingBlock("CONTEXT"))?;
+        // Extract the band-layout flag from the CONTEXT block when present.
+        // Per MS-RDPEGFX 2.2.4.2 the SYNC + CONTEXT blocks establish a codec
+        // context once (keyed by `codec_context_id`) and are not required to be
+        // repeated on subsequent frames that reference the same context.
+        // Real-world servers (xrdp, GNOME Remote Desktop) omit the CONTEXT
+        // block on every frame after the first one that established the
+        // context. The strict requirement rejected each of those frames with
+        // `MissingBlock("CONTEXT")`, freezing the image on the coarse first
+        // pass.
+        //
+        // Fall back to the value stored when the context was first created.
+        // Only error when neither source is available, i.e. the very first
+        // frame for a context arrived without a CONTEXT block.
+        let use_reduce_extrapolate = match blocks.iter().find_map(|block| match block {
+            ProgressiveBlock::Context(ctx) => Some(ctx.uses_reduce_extrapolate()),
+            _ => None,
+        }) {
+            Some(v) => v,
+            None => self
+                .contexts
+                .get(&codec_context_id)
+                .map(|c| c.surface.use_reduce_extrapolate)
+                .ok_or(ProgressiveDecodeError::MissingBlock("CONTEXT"))?,
+        };
 
         // Get or create the context for this codec_context_id
         let context = match self.contexts.entry(codec_context_id) {


### PR DESCRIPTION
When a server sends a WireToSurface2 PDU for a codec context that's already been established, the CONTEXT block is often omitted. MS-RDPEGFX 2.2.4.2 specifies SYNC + CONTEXT as the establishment sequence for a context (keyed by codec_context_id); frames after that point reference the existing context and don't carry a fresh CONTEXT.

The current decoder treats CONTEXT as mandatory on every decode_bitmap call. Servers that follow the spec and omit it on subsequent frames get rejected with MissingBlock(\"CONTEXT\"), and the image is stuck on the coarse first pass for the rest of the session.

Confirmed against real servers: xrdp and GNOME Remote Desktop both send the CONTEXT block on the first frame only. Reproducing it requires a multi-frame progressive stream from one of those servers, so there's no test in this PR. The fix has been verified end to end against both xrdp and GNOME Remote Desktop.

The change is small. If the current frame has a CONTEXT block, use it (unchanged). If not, fall back to the use_reduce_extrapolate value stored when the context was first created. Only when neither is available, i.e. the very first frame for a context arrived without a CONTEXT block, do we still error out.

Relates to the progressive codec introduced in #1197 / #1198. Open to adding a regression test if there's a preferred way to fixture a multi-frame stream here, or if maintainers want me to generate one from FreeRDP's vectors.