### PR TITLE
feat(connector): send ClientClusterData with REDIRECTION_SUPPORTED

### DIFF
--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -646,9 +646,10 @@ fn create_gcc_blocks<'a>(
     static_channels: impl Iterator<Item = &'a StaticVirtualChannel>,
 ) -> ConnectorResult<gcc::ClientGccBlocks> {
     use ironrdp_pdu::gcc::{
-        ClientCoreData, ClientCoreOptionalData, ClientEarlyCapabilityFlags, ClientGccBlocks, ClientNetworkData,
-        ClientSecurityData, ColorDepth, ConnectionType, EncryptionMethod, HighColorDepth, MonitorOrientation,
-        RdpVersion, SecureAccessSequence, SupportedColorDepths,
+        ClientClusterData, ClientCoreData, ClientCoreOptionalData, ClientEarlyCapabilityFlags, ClientGccBlocks,
+        ClientNetworkData, ClientSecurityData, ColorDepth, ConnectionType, EncryptionMethod, HighColorDepth,
+        MonitorOrientation, RdpVersion, RedirectionFlags, RedirectionVersion, SecureAccessSequence,
+        SupportedColorDepths,
     };
 
     let max_color_depth = config.bitmap.as_ref().map(|bitmap| bitmap.color_depth).unwrap_or(32);
@@ -740,8 +741,14 @@ fn create_gcc_blocks<'a>(
         } else {
             Some(ClientNetworkData { channels })
         },
-        // TODO(#139): support for Some(ClientClusterData { flags: RedirectionFlags::REDIRECTION_SUPPORTED, redirection_version: RedirectionVersion::V4, redirected_session_id: 0, }),
-        cluster: None,
+        // Send the cluster data block that session brokers and terminal-server
+        // farms use to route the connection (MS-RDPBCGR 2.2.1.3.6). These are
+        // the values mstsc sends on a fresh connection.
+        cluster: Some(ClientClusterData {
+            flags: RedirectionFlags::REDIRECTION_SUPPORTED,
+            redirection_version: RedirectionVersion::V4,
+            redirected_session_id: 0,
+        }),
         monitor: None,
         // TODO(#140): support for Client Message Channel Data (https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/f50e791c-de03-4b25-b17e-e914c9020bc3)
         message_channel: None,


### PR DESCRIPTION
The cluster field in create_gcc_blocks has been left at \`None\` with a TODO(#139) note for as long as the file has existed. This fills it in.

Sends the values mstsc sends on a fresh connection: \`REDIRECTION_SUPPORTED\`, \`RedirectionVersion::V4\`, \`redirected_session_id\` of 0. Session brokers and terminal-server farms rely on this block (MS-RDPBCGR 2.2.1.3.6) to route the connection; without it the client can be misrouted or dropped on brokered setups.

The field was already optional, so existing servers that don't care about cluster data keep working.

Closes #139.