### PR TITLE
fix(rdp6): use actual bitmap dimensions instead of rectangle dimensions

### DIFF
--- a/crates/ironrdp-session/src/fast_path.rs
+++ b/crates/ironrdp-session/src/fast_path.rs
@@ -203,24 +203,33 @@ impl Processor {
                     // Compressed bitmaps at a color depth of 32 bpp are compressed using RDP 6.0
                     // Bitmap Compression and stored inside an RDP 6.0 Bitmap Compressed Stream
                     // structure ([MS-RDPEGDI] section 2.2.2.5.1).
+                    let source_width = usize::from(update.width);
+                    let source_height = usize::from(update.height);
+                    let rect_width = usize::from(update.rectangle.width());
+                    let rect_height = usize::from(update.rectangle.height());
+
                     debug!(
-                        "32 bpp compressed RDP6_BITMAP_STREAM: {}x{} at {:?}, data_len={}, expected={}",
-                        update.width,
-                        update.height,
+                        "32 bpp compressed RDP6_BITMAP_STREAM: source={}x{}, rectangle={}x{} at {:?}, data_len={}, expected={}",
+                        source_width,
+                        source_height,
+                        rect_width,
+                        rect_height,
                         update.rectangle,
                         update.bitmap_data.len(),
-                        usize::from(update.width) * usize::from(update.height) * 3
+                        source_width * source_height * 3
                     );
 
                     match self.bitmap_stream_decoder.decode_bitmap_stream_to_rgb24(
                         update.bitmap_data,
                         &mut buf,
-                        usize::from(update.width),
-                        usize::from(update.height),
+                        source_width,
+                        source_height,
                     ) {
                         Ok(()) => {
-                            debug!("RDP6 decoded to {} bytes (expected {})", buf.len(), usize::from(update.width) * usize::from(update.height) * 3);
-                            image.apply_rgb24(&buf, &update.rectangle, true)?
+                            debug!("RDP6 decoded to {} bytes (expected {})", buf.len(), source_width * source_height * 3);
+                            // Use actual decoded dimensions (source_width), not rectangle width
+                            // The rectangle tells us WHERE to place the bitmap, not HOW BIG it is
+                            image.apply_rgb24_with_dimensions(&buf, &update.rectangle, source_width, true)?
                         }
                         Err(err) => {
                             warn!("Invalid RDP6_BITMAP_STREAM: {err}");

--- a/crates/ironrdp-session/src/fast_path.rs
+++ b/crates/ironrdp-session/src/fast_path.rs
@@ -209,14 +209,14 @@ impl Processor {
                     let rect_height = usize::from(update.rectangle.height());
 
                     debug!(
-                        "32 bpp compressed RDP6_BITMAP_STREAM: source={}x{}, rectangle={}x{} at {:?}, data_len={}, expected={}",
                         source_width,
                         source_height,
                         rect_width,
                         rect_height,
-                        update.rectangle,
-                        update.bitmap_data.len(),
-                        source_width * source_height * 3
+                        rect = ?update.rectangle,
+                        data_len = update.bitmap_data.len(),
+                        expected_len = source_width * source_height * 3,
+                        "Compressed RDP6 bitmap stream (32 bpp)"
                     );
 
                     match self.bitmap_stream_decoder.decode_bitmap_stream_to_rgb24(
@@ -226,7 +226,11 @@ impl Processor {
                         source_height,
                     ) {
                         Ok(()) => {
-                            debug!("RDP6 decoded to {} bytes (expected {})", buf.len(), source_width * source_height * 3);
+                            debug!(
+                                decoded_len = buf.len(),
+                                expected_len = source_width * source_height * 3,
+                                "RDP6 bitmap decoded"
+                            );
                             // Use actual decoded dimensions (source_width), not rectangle width
                             // The rectangle tells us WHERE to place the bitmap, not HOW BIG it is
                             image.apply_rgb24_with_dimensions(&buf, &update.rectangle, source_width, true)?

--- a/crates/ironrdp-session/src/fast_path.rs
+++ b/crates/ironrdp-session/src/fast_path.rs
@@ -203,7 +203,14 @@ impl Processor {
                     // Compressed bitmaps at a color depth of 32 bpp are compressed using RDP 6.0
                     // Bitmap Compression and stored inside an RDP 6.0 Bitmap Compressed Stream
                     // structure ([MS-RDPEGDI] section 2.2.2.5.1).
-                    debug!("32 bpp compressed RDP6_BITMAP_STREAM");
+                    debug!(
+                        "32 bpp compressed RDP6_BITMAP_STREAM: {}x{} at {:?}, data_len={}, expected={}",
+                        update.width,
+                        update.height,
+                        update.rectangle,
+                        update.bitmap_data.len(),
+                        usize::from(update.width) * usize::from(update.height) * 3
+                    );
 
                     match self.bitmap_stream_decoder.decode_bitmap_stream_to_rgb24(
                         update.bitmap_data,
@@ -211,7 +218,10 @@ impl Processor {
                         usize::from(update.width),
                         usize::from(update.height),
                     ) {
-                        Ok(()) => image.apply_rgb24(&buf, &update.rectangle, false)?, // RDP6 decoder outputs top-down, don't flip
+                        Ok(()) => {
+                            debug!("RDP6 decoded to {} bytes (expected {})", buf.len(), usize::from(update.width) * usize::from(update.height) * 3);
+                            image.apply_rgb24(&buf, &update.rectangle, true)?
+                        }
                         Err(err) => {
                             warn!("Invalid RDP6_BITMAP_STREAM: {err}");
                             update.rectangle.clone()

--- a/crates/ironrdp-session/src/fast_path.rs
+++ b/crates/ironrdp-session/src/fast_path.rs
@@ -211,7 +211,7 @@ impl Processor {
                         usize::from(update.width),
                         usize::from(update.height),
                     ) {
-                        Ok(()) => image.apply_rgb24(&buf, &update.rectangle, true)?,
+                        Ok(()) => image.apply_rgb24(&buf, &update.rectangle, false)?, // RDP6 decoder outputs top-down, don't flip
                         Err(err) => {
                             warn!("Invalid RDP6_BITMAP_STREAM: {err}");
                             update.rectangle.clone()

--- a/crates/ironrdp-session/src/image.rs
+++ b/crates/ironrdp-session/src/image.rs
@@ -807,20 +807,34 @@ impl DecodedImage {
         Ok(update_rectangle)
     }
 
+    /// Apply RGB24 bitmap with explicit source dimensions.
+    /// `rgb24` contains `source_width × source_height` pixels in RGB24 format.
+    /// `update_rectangle` specifies WHERE to place the bitmap, not its size.
+    pub(crate) fn apply_rgb24_with_dimensions(
+        &mut self,
+        rgb24: &[u8],
+        update_rectangle: &InclusiveRectangle,
+        source_width: usize,
+        flip: bool,
+    ) -> SessionResult<InclusiveRectangle> {
+        const SRC_COLOR_DEPTH: usize = 3;
+        let lines = rgb24.chunks_exact(source_width * SRC_COLOR_DEPTH);
+        if flip {
+            self.apply_rgb24_iter(lines.rev(), update_rectangle)
+        } else {
+            self.apply_rgb24_iter(lines, update_rectangle)
+        }
+    }
+
     pub(crate) fn apply_rgb24(
         &mut self,
         rgb24: &[u8],
         update_rectangle: &InclusiveRectangle,
         flip: bool,
     ) -> SessionResult<InclusiveRectangle> {
-        const SRC_COLOR_DEPTH: usize = 3;
+        // Legacy API: assume source width matches rectangle width
         let rectangle_width = usize::from(update_rectangle.width());
-        let lines = rgb24.chunks_exact(rectangle_width * SRC_COLOR_DEPTH);
-        if flip {
-            self.apply_rgb24_iter(lines.rev(), update_rectangle)
-        } else {
-            self.apply_rgb24_iter(lines, update_rectangle)
-        }
+        self.apply_rgb24_with_dimensions(rgb24, update_rectangle, rectangle_width, flip)
     }
 
     #[cfg(feature = "qoi")]

--- a/crates/ironrdp-session/src/image.rs
+++ b/crates/ironrdp-session/src/image.rs
@@ -661,6 +661,18 @@ impl DecodedImage {
         bgr24: &[u8],
         update_rectangle: &InclusiveRectangle,
     ) -> SessionResult<InclusiveRectangle> {
+        self.apply_bgr24_bitmap_with_order(bgr24, update_rectangle, true)
+    }
+
+    /// Apply a 24-bit BGR bitmap with configurable row order.
+    /// If `bottom_up` is true, rows are reversed (standard RDP bitmap order).
+    /// If false, rows are kept in top-down order (RDP6 decompressed output).
+    pub(crate) fn apply_bgr24_bitmap_with_order(
+        &mut self,
+        bgr24: &[u8],
+        update_rectangle: &InclusiveRectangle,
+        bottom_up: bool,
+    ) -> SessionResult<InclusiveRectangle> {
         if !self.rect_fits(update_rectangle) {
             debug!(
                 "Skipping bgr24 update {:?} outside image bounds {}x{}",
@@ -680,11 +692,13 @@ impl DecodedImage {
 
         let pointer_rendering_state = self.pointer_rendering_begin(update_rectangle)?;
 
-        bgr24
-            .chunks_exact(rectangle_width * SRC_COLOR_DEPTH)
-            .rev()
-            .enumerate()
-            .for_each(|(row_idx, row)| {
+        let rows: Box<dyn Iterator<Item = (usize, &[u8])>> = if bottom_up {
+            Box::new(bgr24.chunks_exact(rectangle_width * SRC_COLOR_DEPTH).rev().enumerate())
+        } else {
+            Box::new(bgr24.chunks_exact(rectangle_width * SRC_COLOR_DEPTH).enumerate())
+        };
+
+        rows.for_each(|(row_idx, row)| {
                 row.chunks_exact(SRC_COLOR_DEPTH)
                     .enumerate()
                     .for_each(|(col_idx, src_pixel)| {

--- a/crates/ironrdp-session/src/image.rs
+++ b/crates/ironrdp-session/src/image.rs
@@ -692,25 +692,42 @@ impl DecodedImage {
 
         let pointer_rendering_state = self.pointer_rendering_begin(update_rectangle)?;
 
-        let rows: Box<dyn Iterator<Item = (usize, &[u8])>> = if bottom_up {
-            Box::new(bgr24.chunks_exact(rectangle_width * SRC_COLOR_DEPTH).rev().enumerate())
+        if bottom_up {
+            bgr24
+                .chunks_exact(rectangle_width * SRC_COLOR_DEPTH)
+                .rev()
+                .enumerate()
+                .for_each(|(row_idx, row)| {
+                    row.chunks_exact(SRC_COLOR_DEPTH)
+                        .enumerate()
+                        .for_each(|(col_idx, src_pixel)| {
+                            let dst_idx = ((top + row_idx) * image_width + left + col_idx) * DST_COLOR_DEPTH;
+
+                            // BGR -> RGB channel swap
+                            self.data[dst_idx + ri] = src_pixel[2];
+                            self.data[dst_idx + gi] = src_pixel[1];
+                            self.data[dst_idx + bi] = src_pixel[0];
+                            self.data[dst_idx + ai] = 0xff;
+                        })
+                });
         } else {
-            Box::new(bgr24.chunks_exact(rectangle_width * SRC_COLOR_DEPTH).enumerate())
-        };
+            bgr24
+                .chunks_exact(rectangle_width * SRC_COLOR_DEPTH)
+                .enumerate()
+                .for_each(|(row_idx, row)| {
+                    row.chunks_exact(SRC_COLOR_DEPTH)
+                        .enumerate()
+                        .for_each(|(col_idx, src_pixel)| {
+                            let dst_idx = ((top + row_idx) * image_width + left + col_idx) * DST_COLOR_DEPTH;
 
-        rows.for_each(|(row_idx, row)| {
-                row.chunks_exact(SRC_COLOR_DEPTH)
-                    .enumerate()
-                    .for_each(|(col_idx, src_pixel)| {
-                        let dst_idx = ((top + row_idx) * image_width + left + col_idx) * DST_COLOR_DEPTH;
-
-                        // BGR -> RGB channel swap
-                        self.data[dst_idx + ri] = src_pixel[2];
-                        self.data[dst_idx + gi] = src_pixel[1];
-                        self.data[dst_idx + bi] = src_pixel[0];
-                        self.data[dst_idx + ai] = 0xff;
-                    })
-            });
+                            // BGR -> RGB channel swap
+                            self.data[dst_idx + ri] = src_pixel[2];
+                            self.data[dst_idx + gi] = src_pixel[1];
+                            self.data[dst_idx + bi] = src_pixel[0];
+                            self.data[dst_idx + ai] = 0xff;
+                        })
+                });
+        }
 
         let update_rectangle = self.pointer_rendering_end(pointer_rendering_state)?;
 
@@ -810,6 +827,8 @@ impl DecodedImage {
     /// Apply RGB24 bitmap with explicit source dimensions.
     /// `rgb24` contains `source_width × source_height` pixels in RGB24 format.
     /// `update_rectangle` specifies WHERE to place the bitmap, not its size.
+    ///
+    /// When source dimensions exceed the rectangle, only the overlapping region is copied.
     pub(crate) fn apply_rgb24_with_dimensions(
         &mut self,
         rgb24: &[u8],
@@ -817,13 +836,61 @@ impl DecodedImage {
         source_width: usize,
         flip: bool,
     ) -> SessionResult<InclusiveRectangle> {
-        const SRC_COLOR_DEPTH: usize = 3;
-        let lines = rgb24.chunks_exact(source_width * SRC_COLOR_DEPTH);
-        if flip {
-            self.apply_rgb24_iter(lines.rev(), update_rectangle)
-        } else {
-            self.apply_rgb24_iter(lines, update_rectangle)
+        if source_width == 0 {
+            return Ok(InclusiveRectangle::empty());
         }
+
+        if !self.rect_fits(update_rectangle) {
+            debug!(
+                "Skipping rgb24 update {:?} outside image bounds {}x{}",
+                update_rectangle, self.width, self.height,
+            );
+            return Ok(InclusiveRectangle::empty());
+        }
+
+        const SRC_COLOR_DEPTH: usize = 3;
+        const DST_COLOR_DEPTH: usize = 4;
+
+        let image_width = usize::from(self.width);
+        let rect_width = usize::from(update_rectangle.width());
+        let rect_height = usize::from(update_rectangle.height());
+        let top = usize::from(update_rectangle.top);
+        let left = usize::from(update_rectangle.left);
+        let [ri, gi, bi, ai] = self.pixel_format.channel_offsets();
+
+        // Clamp copy dimensions to the smaller of source and rectangle
+        let copy_width = source_width.min(rect_width);
+        let copy_height = (rgb24.len() / (source_width * SRC_COLOR_DEPTH)).min(rect_height);
+
+        let pointer_rendering_state = self.pointer_rendering_begin(update_rectangle)?;
+
+        let source_row_stride = source_width * SRC_COLOR_DEPTH;
+        let rows = rgb24.chunks_exact(source_row_stride).take(copy_height);
+
+        let row_iter: Box<dyn Iterator<Item = (usize, &[u8])>> = if flip {
+            Box::new(rows.rev().enumerate())
+        } else {
+            Box::new(rows.enumerate())
+        };
+
+        row_iter.for_each(|(row_idx, row)| {
+            // Only copy copy_width pixels from each row (not the entire source_width)
+            row[..copy_width * SRC_COLOR_DEPTH]
+                .chunks_exact(SRC_COLOR_DEPTH)
+                .enumerate()
+                .for_each(|(col_idx, src_pixel)| {
+                    let dst_idx = ((top + row_idx) * image_width + left + col_idx) * DST_COLOR_DEPTH;
+
+                    self.data[dst_idx + ri] = src_pixel[0];
+                    self.data[dst_idx + gi] = src_pixel[1];
+                    self.data[dst_idx + bi] = src_pixel[2];
+                    self.data[dst_idx + ai] = 0xFF;
+                })
+        });
+
+        let update_rectangle = self.pointer_rendering_end(pointer_rendering_state)?;
+
+        Ok(update_rectangle)
     }
 
     pub(crate) fn apply_rgb24(


### PR DESCRIPTION
## Problem

When connecting to servers that send RDP6 compressed bitmaps with tiled updates (e.g., NVIDIA DGX), the rendered display shows horizontal striping and blur artifacts.

## Root Cause

RDP6 `BitmapUpdate` PDUs can have different dimensions than their placement rectangles:
- `update.width` × `update.height` = actual decoded bitmap size
- `update.rectangle` = where to place the bitmap on screen

The current implementation of `apply_rgb24()` chunks the decoded RGB24 data using `rectangle.width()`, but the decoder produces data with `update.width` pixels per row. When these values differ, it causes stride mismatches and pixel data misalignment.

## Example from Real Traffic

Connecting to NVIDIA DGX server at 1920x1080:

```
32 bpp compressed RDP6_BITMAP_STREAM: source=348x11, rectangle=345x11
  update.width = 348
  Rectangle (left:788, right:1132) width = 1132 - 788 + 1 = 345
```

The decoder produces 348 pixels/row, but `apply_rgb24()` chunks at 345 pixels/row → pixel misalignment → horizontal stripes.

## Changes

1. Add `apply_rgb24_with_dimensions()` that accepts explicit `source_width` parameter
2. Update RDP6 handler in `fast_path.rs` to use `update.width` (not `rectangle.width()`) for chunking
3. Keep `apply_rgb24()` for backward compatibility (delegates to new function)

## Testing

- ✅ Verified clean rendering at 1920x1080 against NVIDIA DGX server
- ✅ No horizontal striping or blur artifacts
- ✅ No regressions on other RDP servers