### PR TITLE
fix(graphics): apply YCbCr->RGB fixed-point descale in progressive decoder/encoder

### DIFF
--- a/crates/ironrdp-graphics/src/progressive.rs
+++ b/crates/ironrdp-graphics/src/progressive.rs
@@ -449,9 +449,14 @@ pub fn rgba_to_ycbcr(pixels: &[u8], y_out: &mut [i16], cb_out: &mut [i16], cr_ou
         let cb = (-11059 * r - 21709 * g + 32768 * b + 32768) >> 16;
         let cr = (32768 * r - 27439 * g - 5329 * b + 32768) >> 16;
 
-        y_out[i] = clamp_i16(y);
-        cb_out[i] = clamp_i16(cb);
-        cr_out[i] = clamp_i16(cr);
+        // Add the 5-bit fixed-point headroom the decoder removes with `>> 5` in
+        // `reconstruct_to_rgba`. The base dequant retains +5 bits (matching
+        // FreeRDP's `/* -6 + 5 = -1 */`); scaling up here keeps the
+        // encode->decode round-trip an identity. Range after `<< 5` is
+        // [-4096, 4064], well within i16.
+        y_out[i] = clamp_i16(y << 5);
+        cb_out[i] = clamp_i16(cb << 5);
+        cr_out[i] = clamp_i16(cr << 5);
     }
 }
 
@@ -830,9 +835,17 @@ impl TileState {
 
         // YCbCr to RGBA conversion
         for i in 0..64 * 64 {
-            let y = i32::from(y_buf[i]) + 128;
-            let cb = i32::from(cb_buf[i]);
-            let cr = i32::from(cr_buf[i]);
+            // The base dequantization (`<< (quant - 1)`) retains +5 bits of
+            // fixed-point headroom by design (the DWT itself is unity-gain --
+            // see tests/dwt_gain.rs), so the spatial coefficients arrive scaled
+            // up by 2^5. FreeRDP folds this descale into its colour primitive
+            // (yCbCrToRGB_16s8u_P3AC4R shifts by `divisor + 5`); we apply the
+            // matching `>> 5` here. Without it every value overflows the ±128
+            // range and clamps to 0/255 -- luma loses mid-tones and chroma
+            // collapses to pure primaries (the posterised image).
+            let y = (i32::from(y_buf[i]) >> 5) + 128;
+            let cb = i32::from(cb_buf[i]) >> 5;
+            let cr = i32::from(cr_buf[i]) >> 5;
 
             // ITU-R BT.601 YCbCr to RGB conversion
             let r = y + ((cr * 91881 + 32768) >> 16);
@@ -1689,12 +1702,11 @@ mod tests {
         rgba_to_ycbcr(&pixels, &mut y, &mut cb, &mut cr);
 
         // Pure white: R=G=B=255
-        // Y = (19595*255 + 38470*255 + 7471*255 + 32768) >> 16 - 128
-        //   = (65536*255 + 32768) >> 16 - 128 = 255 - 128 = 127
-        // Cb and Cr should be ~0 (achromatic)
-        assert!((y[0] - 127).abs() <= 1, "Y for white: got {}", y[0]);
-        assert!(cb[0].abs() <= 1, "Cb for white: got {}", cb[0]);
-        assert!(cr[0].abs() <= 1, "Cr for white: got {}", cr[0]);
+        // Y = ((65536*255 + 32768) >> 16 - 128) << 5 = 127 << 5 = 4064
+        // Cb and Cr should be ~0 (achromatic), unaffected by the << 5 scale
+        assert!((y[0] - 4064).abs() <= 32, "Y for white: got {}", y[0]);
+        assert!(cb[0].abs() <= 32, "Cb for white: got {}", cb[0]);
+        assert!(cr[0].abs() <= 32, "Cr for white: got {}", cr[0]);
     }
 
     #[test]
@@ -1706,8 +1718,8 @@ mod tests {
 
         rgba_to_ycbcr(&pixels, &mut y, &mut cb, &mut cr);
 
-        // Pure black: Y = -128, Cb = 0, Cr = 0
-        assert_eq!(y[0], -128);
+        // Pure black: Y = -128 << 5 = -4096, Cb = 0, Cr = 0
+        assert_eq!(y[0], -4096);
         assert_eq!(cb[0], 0);
         assert_eq!(cr[0], 0);
     }

--- a/crates/ironrdp-graphics/tests/dwt_gain.rs
+++ b/crates/ironrdp-graphics/tests/dwt_gain.rs
@@ -1,0 +1,65 @@
+//! Regression lock for the progressive colour descale: proves the RFX
+//! progressive DWT is unity-gain, so the `>> 5` descale in `reconstruct_to_rgba`
+//! compensates the fixed-point headroom retained by the base dequant
+//! (`<< (quant - 1)`), not any scale introduced by the transform.
+//! Run: cargo test -p ironrdp-graphics --test dwt_gain -- --nocapture
+//!
+//! Reasoning: the wire carries forward-DWT coefficients. If a flat pixel tile of
+//! value P forward-transforms to an LL/DC coefficient of ~P, wire coeffs are at
+//! pixel scale and the inverse DWT must return pixel scale (no descale needed).
+//! If it transformed to ~32*P, the transform would be 2^5 non-normalized. It
+//! does not: the ~32x seen on real streams comes from dequant headroom.
+
+// This integration-test binary only exercises `ironrdp_graphics`; the crate's
+// other dev-dependencies are for its unit tests.
+#![allow(unused_crate_dependencies)]
+
+use ironrdp_graphics::dwt;
+
+const N: usize = 4096; // 64x64
+
+#[test]
+fn forward_dc_gain_and_roundtrip() {
+    let p: i16 = 100;
+
+    // Flat tile, all pixels = P.
+    let mut buf = [p; N];
+    let mut tmp = [0i16; N];
+    dwt::encode(&mut buf, &mut tmp);
+
+    let (min, max) = buf
+        .iter()
+        .fold((i16::MAX, i16::MIN), |(lo, hi), &v| (lo.min(v), hi.max(v)));
+    let peak = buf.iter().map(|c| c.unsigned_abs()).max().unwrap_or(0);
+    eprintln!("flat P={p}: full coeff range after forward DWT = [{min}, {max}]  peak|coeff|={peak}");
+
+    // Round-trip must be identity.
+    let mut rt = [p; N];
+    let mut tmp2 = [0i16; N];
+    dwt::encode(&mut rt, &mut tmp2);
+    dwt::decode(&mut rt, &mut tmp2);
+    let (rmin, rmax) = rt
+        .iter()
+        .fold((i16::MAX, i16::MIN), |(lo, hi), &v| (lo.min(v), hi.max(v)));
+    eprintln!("round-trip flat P={p}: recovered range = [{rmin}, {rmax}] (expect ~{p})");
+
+    // Inverse-only gain: feed a pure DC coefficient and see the spatial amplitude.
+    let mut dc_only = [0i16; N];
+    dc_only[0] = 100;
+    let mut tmp3 = [0i16; N];
+    dwt::decode(&mut dc_only, &mut tmp3);
+    let (imin, imax) = dc_only
+        .iter()
+        .fold((i16::MAX, i16::MIN), |(lo, hi), &v| (lo.min(v), hi.max(v)));
+    eprintln!("inverse-only DC=100: spatial output range = [{imin}, {imax}]");
+
+    // Guard: unity-gain. No forward coefficient exceeds the input magnitude P
+    // (a 2^5 transform would push the peak to ~32*P = ~3200), and the round-trip
+    // is identity within integer-lifting rounding.
+    assert!(
+        i32::from(peak) <= i32::from(p) + 2,
+        "DWT is not unity-gain: peak|coeff|={peak} for P={p}"
+    );
+    assert!((i32::from(rmin) - i32::from(p)).abs() <= 2, "round-trip low drift");
+    assert!((i32::from(rmax) - i32::from(p)).abs() <= 2, "round-trip high drift");
+}

--- a/crates/ironrdp-graphics/tests/dwt_gain.rs
+++ b/crates/ironrdp-graphics/tests/dwt_gain.rs
@@ -2,7 +2,6 @@
 //! progressive DWT is unity-gain, so the `>> 5` descale in `reconstruct_to_rgba`
 //! compensates the fixed-point headroom retained by the base dequant
 //! (`<< (quant - 1)`), not any scale introduced by the transform.
-//! Run: cargo test -p ironrdp-graphics --test dwt_gain -- --nocapture
 //!
 //! Reasoning: the wire carries forward-DWT coefficients. If a flat pixel tile of
 //! value P forward-transforms to an LL/DC coefficient of ~P, wire coeffs are at
@@ -27,11 +26,7 @@ fn forward_dc_gain_and_roundtrip() {
     let mut tmp = [0i16; N];
     dwt::encode(&mut buf, &mut tmp);
 
-    let (min, max) = buf
-        .iter()
-        .fold((i16::MAX, i16::MIN), |(lo, hi), &v| (lo.min(v), hi.max(v)));
     let peak = buf.iter().map(|c| c.unsigned_abs()).max().unwrap_or(0);
-    eprintln!("flat P={p}: full coeff range after forward DWT = [{min}, {max}]  peak|coeff|={peak}");
 
     // Round-trip must be identity.
     let mut rt = [p; N];
@@ -41,17 +36,6 @@ fn forward_dc_gain_and_roundtrip() {
     let (rmin, rmax) = rt
         .iter()
         .fold((i16::MAX, i16::MIN), |(lo, hi), &v| (lo.min(v), hi.max(v)));
-    eprintln!("round-trip flat P={p}: recovered range = [{rmin}, {rmax}] (expect ~{p})");
-
-    // Inverse-only gain: feed a pure DC coefficient and see the spatial amplitude.
-    let mut dc_only = [0i16; N];
-    dc_only[0] = 100;
-    let mut tmp3 = [0i16; N];
-    dwt::decode(&mut dc_only, &mut tmp3);
-    let (imin, imax) = dc_only
-        .iter()
-        .fold((i16::MAX, i16::MIN), |(lo, hi), &v| (lo.min(v), hi.max(v)));
-    eprintln!("inverse-only DC=100: spatial output range = [{imin}, {imax}]");
 
     // Guard: unity-gain. No forward coefficient exceeds the input magnitude P
     // (a 2^5 transform would push the peak to ~32*P = ~3200), and the round-trip


### PR DESCRIPTION
## Problem

Against some real-world EGFX servers (xrdp, GNOME Remote Desktop), the progressive (RemoteFX) decoder produces posterised output. Smooth colour gradients collapse to a handful of saturated primaries and luma loses its mid-tones. Spatial detail (text, icons) stays crisp, which points away from a scaling issue and toward colour conversion.

## Root cause

`reconstruct_to_rgba()` passes the dequantized Y/Cb/Cr values into the BT.601 YCbCr->RGB conversion, but the fixed-point headroom that `dequantize_component_ccq` intentionally retains isn't removed before conversion.

`dequantize_component_ccq` applies the spec-defined `<< (quant_value - 1)` shift. For the wire quant table this works out to +5 bits of headroom, which matches FreeRDP's reference decoder (see the `/* -6 + 5 = -1 */` comment in `libfreerdp/primitives/prim_colors.c`). The colour-conversion stage is the natural place to remove that headroom (`R = ((CrR + Y) >> divisor) >> 5`). This PR adds the missing `>> 5` and the corresponding `128 << 5 = 4096` luma offset. Without them, each channel exceeds the legal ±128 range and `clamp_u8` pins it to 0 or 255.

Worth noting: this isn't the integer inverse DWT. The DWT is unity-gain, verified separately below.

## Verification

1. **DWT unity-gain check.** A flat 64×64 tile of value 100 forward-transforms with no coefficient exceeding ~100 and round-trips back to exactly 100, so the `×2^5` scale doesn't originate there. Added `tests/dwt_gain.rs` to lock this in.
2. **Live server quant trace.** Against an xrdp stream, the per-band `<< (q-1)` factors land at +5 bits of headroom (max coefficient scaled ~32×). The +5 bits come from the dequant table.
3. **FreeRDP cross-check.** `libfreerdp/codec/progressive.c` and `libfreerdp/primitives/prim_colors.c` apply the same `<< (q-1)` shift and the matching `>> 5` removal at the colour stage, so this patch's math lines up with the reference.
4. **Visual confirmation.** With the `>> 5` descale applied, xrdp and GNOME RD streams render with correct colour gradients; without it, the same streams are posterised.

## Scope of this PR

Kept symmetric so the crate's internal encode<->decode round-trip test stays identity:
- **Decoder:** `>> 5` plus `+128` luma offset in `reconstruct_to_rgba` (matching FreeRDP).
- **Encoder:** matching `<< 5` plus offset on the RGB->YCbCr path in `rgba_to_ycbcr`, so the round-trip doesn't regress.

## Files
- `crates/ironrdp-graphics/src/progressive.rs` — decoder descale and encoder scale-up
- `crates/ironrdp-graphics/tests/dwt_gain.rs` — regression test confirming the DWT is unity-gain
