### PR TITLE
feat(acceptor)!: clamp honored client desktop size to an operator maximum

### DIFF
--- a/crates/ironrdp-acceptor/src/connection.rs
+++ b/crates/ironrdp-acceptor/src/connection.rs
@@ -150,10 +150,11 @@ impl Acceptor {
     /// later in the client's Confirm Active is, per [MS-RDPBCGR] 2.2.1.13.2,
     /// the value the client copied from the *server's* Demand Active, so it
     /// cannot be used to discover what the client originally asked for. When
-    /// this is enabled and the client's request is within the protocol-legal
-    /// range, the acceptor negotiates that size from the start (it is written
-    /// into the server's Bitmap capability set before Demand Active is sent),
-    /// avoiding a Deactivation-Reactivation resize round trip.
+    /// this is enabled, the client's request is first clamped per dimension to
+    /// the operator maximum and then validated against the protocol-legal range;
+    /// if the clamped size is legal the acceptor negotiates it from the start (it
+    /// is written into the server's Bitmap capability set before Demand Active is
+    /// sent), avoiding a Deactivation-Reactivation resize round trip.
     ///
     /// Pass `Some(max)` to honor the client's request, clamped per dimension to
     /// `max`: the client can ask for a *smaller* desktop than `max`, but never a
@@ -567,9 +568,10 @@ impl Sequence for Acceptor {
                         }
                     } else {
                         debug!(
-                            width = requested_width,
-                            height = requested_height,
-                            "Client requested an out-of-range desktop size; keeping the server-provided size"
+                            requested = ?DesktopSize { width: requested_width, height: requested_height },
+                            clamped = ?DesktopSize { width: clamped_width, height: clamped_height },
+                            max = ?max,
+                            "Client-requested desktop size is out of protocol range after clamping to the operator maximum; keeping the server-provided size"
                         );
                     }
                 }

--- a/crates/ironrdp-acceptor/src/connection.rs
+++ b/crates/ironrdp-acceptor/src/connection.rs
@@ -39,7 +39,7 @@ pub struct Acceptor {
     pub(crate) creds: Option<Credentials>,
     received_credentials: Option<Credentials>,
     reactivation: bool,
-    honor_client_desktop_size: bool,
+    honor_client_desktop_size: Option<DesktopSize>,
 }
 
 /// Minimum and maximum desktop dimension honored from a client.
@@ -137,12 +137,13 @@ impl Acceptor {
             creds,
             received_credentials: None,
             reactivation: false,
-            honor_client_desktop_size: false,
+            honor_client_desktop_size: None,
         }
     }
 
     /// Adopt the desktop size requested by the client in its Client Core Data
-    /// instead of the size this acceptor was constructed with.
+    /// instead of the size this acceptor was constructed with, clamped to an
+    /// operator-configured maximum.
     ///
     /// The client's requested resolution is only carried in the GCC Client
     /// Core Data of the MCS Connect Initial PDU; the desktop size echoed back
@@ -154,7 +155,17 @@ impl Acceptor {
     /// into the server's Bitmap capability set before Demand Active is sent),
     /// avoiding a Deactivation-Reactivation resize round trip.
     ///
-    /// Disabled by default, preserving the previous behavior of always
+    /// Pass `Some(max)` to honor the client's request, clamped per dimension to
+    /// `max`: the client can ask for a *smaller* desktop than `max`, but never a
+    /// larger one. The desktop size is a client-controlled `u16` bounded only by
+    /// the protocol ([200, 8192]); without a ceiling, a client could request
+    /// e.g. 8192×8192 and drive the server's framebuffer/encoder allocation off
+    /// that untrusted number (~256 MiB per frame buffer). `max` is that ceiling
+    /// — set it to what the server is actually willing to render (for instance
+    /// the host display's native resolution). Pass `None` to disable honoring
+    /// entirely and always enforce the server-provided size.
+    ///
+    /// `None` is the default, preserving the previous behavior of always
     /// enforcing the server-provided size.
     ///
     /// # Precondition
@@ -169,8 +180,8 @@ impl Acceptor {
     /// handler, leave this disabled.
     ///
     /// [`RdpServerDisplay`]: <https://docs.rs/ironrdp-server/latest/ironrdp_server/trait.RdpServerDisplay.html>
-    pub fn set_honor_client_desktop_size(&mut self, honor: bool) {
-        self.honor_client_desktop_size = honor;
+    pub fn set_honor_client_desktop_size(&mut self, max: Option<DesktopSize>) {
+        self.honor_client_desktop_size = max;
     }
 
     pub fn new_deactivation_reactivation(
@@ -533,24 +544,31 @@ impl Sequence for Acceptor {
                 // Adopt the client's requested desktop size (from its Client
                 // Core Data) before Demand Active is sent, so the session is
                 // negotiated at that size without a Deactivation-Reactivation
-                // resize. See `set_honor_client_desktop_size`.
-                if self.honor_client_desktop_size {
-                    if let Some(client_size) =
-                        validate_desktop_size(gcc_blocks.core.desktop_width, gcc_blocks.core.desktop_height)
-                    {
+                // resize. The request is clamped to the operator-configured
+                // maximum first, so an untrusted client can't drive the
+                // framebuffer/encoder allocation past that ceiling. See
+                // `set_honor_client_desktop_size`.
+                if let Some(max) = self.honor_client_desktop_size {
+                    let requested_width = gcc_blocks.core.desktop_width;
+                    let requested_height = gcc_blocks.core.desktop_height;
+                    let clamped_width = requested_width.min(max.width);
+                    let clamped_height = requested_height.min(max.height);
+                    if let Some(client_size) = validate_desktop_size(clamped_width, clamped_height) {
                         if client_size != self.desktop_size {
                             debug!(
-                                requested = ?client_size,
+                                requested = ?DesktopSize { width: requested_width, height: requested_height },
+                                max = ?max,
+                                adopted = ?client_size,
                                 previous = ?self.desktop_size,
-                                "Honoring client-requested desktop size"
+                                "Honoring client-requested desktop size (clamped to operator maximum)"
                             );
                             self.desktop_size = client_size;
                             set_bitmap_desktop_size(&mut self.server_capabilities, client_size);
                         }
                     } else {
                         debug!(
-                            width = gcc_blocks.core.desktop_width,
-                            height = gcc_blocks.core.desktop_height,
+                            width = requested_width,
+                            height = requested_height,
                             "Client requested an out-of-range desktop size; keeping the server-provided size"
                         );
                     }

--- a/crates/ironrdp-server/src/builder.rs
+++ b/crates/ironrdp-server/src/builder.rs
@@ -43,7 +43,7 @@ pub struct BuilderDone {
     gfx_factory: Option<Box<dyn GfxServerFactory>>,
     display_suppressed: Option<Arc<AtomicBool>>,
     autodetect_rtt: Option<Arc<AtomicU32>>,
-    honor_client_desktop_size: bool,
+    honor_client_desktop_size: Option<DesktopSize>,
     auto_reconnect_cookie: Option<ServerAutoReconnect>,
 }
 
@@ -145,7 +145,7 @@ impl RdpServerBuilder<WantsDisplay> {
                 gfx_factory: None,
                 display_suppressed: None,
                 autodetect_rtt: None,
-                honor_client_desktop_size: false,
+                honor_client_desktop_size: None,
                 auto_reconnect_cookie: None,
             },
         }
@@ -168,7 +168,7 @@ impl RdpServerBuilder<WantsDisplay> {
                 gfx_factory: None,
                 display_suppressed: None,
                 autodetect_rtt: None,
-                honor_client_desktop_size: false,
+                honor_client_desktop_size: None,
                 auto_reconnect_cookie: None,
             },
         }
@@ -249,7 +249,14 @@ impl RdpServerBuilder<BuilderDone> {
     /// Reactivation resize. The display handler observes the negotiated size
     /// through [`RdpServerDisplay::request_initial_size`].
     ///
-    /// Defaults to `false`, enforcing the size reported by the display handler.
+    /// Pass `Some(max)` to honor the client's request, clamped per dimension to
+    /// `max`: the client may ask for a smaller desktop, but never a larger one.
+    /// The desktop size is a client-controlled `u16` bounded only by the
+    /// protocol ([200, 8192]); `max` is the ceiling the server is willing to
+    /// render (for instance the host display's native resolution) so an
+    /// untrusted client can't drive the framebuffer/encoder allocation off that
+    /// number. Pass `None` (the default) to disable honoring and enforce the
+    /// size reported by the display handler.
     ///
     /// # Precondition
     ///
@@ -262,8 +269,8 @@ impl RdpServerBuilder<BuilderDone> {
     /// the display handler serves a fixed framebuffer.
     ///
     /// [`request_initial_size`]: crate::RdpServerDisplay::request_initial_size
-    pub fn with_honor_client_desktop_size(mut self, honor: bool) -> Self {
-        self.state.honor_client_desktop_size = honor;
+    pub fn with_honor_client_desktop_size(mut self, max: Option<DesktopSize>) -> Self {
+        self.state.honor_client_desktop_size = max;
         self
     }
 

--- a/crates/ironrdp-server/src/builder.rs
+++ b/crates/ironrdp-server/src/builder.rs
@@ -243,11 +243,12 @@ impl RdpServerBuilder<BuilderDone> {
     /// Core Data of the connection handshake; the size echoed back in the
     /// client's Confirm Active is the value it copied from the server's Demand
     /// Active (per [MS-RDPBCGR] 2.2.1.13.2) and so cannot reveal what the
-    /// client asked for. With this enabled the acceptor adopts the requested
-    /// size (when within the protocol-legal range) before Demand Active is
-    /// sent, so the session starts at that size with no Deactivation-
-    /// Reactivation resize. The display handler observes the negotiated size
-    /// through [`RdpServerDisplay::request_initial_size`].
+    /// client asked for. With this enabled the acceptor first clamps the
+    /// requested size to the operator maximum and then, if the clamped size is
+    /// within the protocol-legal range, adopts it before Demand Active is sent,
+    /// so the session starts at that size with no Deactivation-Reactivation
+    /// resize. The display handler observes the negotiated size through
+    /// [`RdpServerDisplay::request_initial_size`].
     ///
     /// Pass `Some(max)` to honor the client's request, clamped per dimension to
     /// `max`: the client may ask for a smaller desktop, but never a larger one.

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -224,12 +224,15 @@ pub struct RdpServerOptions {
     pub security: RdpServerSecurity,
     pub codecs: BitmapCodecs,
     pub max_request_size: u32,
-    /// When `true`, each connection's acceptor adopts the desktop size the
-    /// client requests in its Client Core Data (instead of the size reported
-    /// by the display handler), negotiating that size from the start without a
-    /// Deactivation-Reactivation resize. Defaults to `false`. Set via
+    /// When `Some(max)`, each connection's acceptor adopts the desktop size the
+    /// client requests in its Client Core Data (instead of the size reported by
+    /// the display handler), negotiating that size from the start without a
+    /// Deactivation-Reactivation resize. The request is clamped per dimension to
+    /// `max` so an untrusted client can't drive the framebuffer/encoder
+    /// allocation past that ceiling. `None` (the default) always enforces the
+    /// server-provided size. Set via
     /// [`RdpServerBuilder::with_honor_client_desktop_size`](crate::RdpServerBuilder::with_honor_client_desktop_size).
-    pub honor_client_desktop_size: bool,
+    pub honor_client_desktop_size: Option<DesktopSize>,
 }
 
 impl RdpServerOptions {


### PR DESCRIPTION
Follow-up to #1373 (the resource-hardening angle you flagged in review — thanks for the go-ahead 🙂).

## Problem

`#1373` gated honor-client-desktop-size behind a bare `bool`. With it on, the acceptor adopts the client-requested desktop size bounded only by the protocol range `[200, 8192]`. But the desktop size is a client-controlled `u16`, and the server still builds its framebuffer/encoder from the negotiated size — so a client could request e.g. `8192x8192` and drive the server's allocation off an untrusted number (~256 MiB per frame buffer). Mild, and only on an opt-in default-off path, but it's a resource-exhaustion vector driven purely by a number the client picks.

Your review comment: *"[200, 8192] is a protocol ceiling, not a resource guard … tracked the 'clamp/range policy rather than a bare bool' idea as a future follow-up (an operator-set max size)."* This is that PR.

## Change

Replace the `bool` with `Option<DesktopSize>` carrying an **operator-set maximum**:

- `None` (default) — disabled; always enforce the server-provided size (unchanged behavior).
- `Some(max)` — honor the client's request, **clamped per dimension to `max`**. The client can ask for a smaller desktop, never a larger one.

The acceptor clamps the requested `width`/`height` to `max` *before* the existing `validate_desktop_size` protocol-range check, so the negotiated size can never exceed what the operator is willing to render — set `max` to the host display's native resolution (or whatever ceiling the server can afford).

Touches:
- `ironrdp-acceptor`: field + `set_honor_client_desktop_size(Option<DesktopSize>)` + clamp-then-validate in the Client Core Data adopt path.
- `ironrdp-server`: `RdpServerOptions::honor_client_desktop_size: Option<DesktopSize>` + `RdpServerBuilder::with_honor_client_desktop_size(Option<DesktopSize>)`.

## Breaking (pre-v1)

`RdpServerOptions::honor_client_desktop_size` is now `Option<DesktopSize>`; the acceptor setter and the builder method take `Option<DesktopSize>` instead of `bool`. Callers migrate `true` → `Some(max)` (choosing a ceiling) and `false` → `None`. Same set of downstream server impls as before (lamco-rdp-server, hypr-rdp, cosmic-ext-rdp-server, ARISU, macrdp).

## Design points for review

1. **Clamp vs reject.** I clamp per dimension (`min(requested, max)`), so a client over the cap gets the largest allowed size rather than falling back to the server default. Per-dimension clamping can shift the aspect ratio (e.g. client `1600x1200`, max `1920x1080` → `1600x1080`); the display handler + client-side scaling absorb that, and it keeps honoring useful right up to the ceiling. Happy to switch to reject-if-over-max (keep server size) if you'd prefer no aspect change.
2. **No inline test**, same as #1373 — the acceptor lib is `test = false` and there's no acceptor harness in `ironrdp-testsuite-core`. The clamp is a two-line `min` ahead of the existing `validate_desktop_size`; I'm glad to add coverage wherever you'd want acceptor tests to live (a pure `clamp_desktop_size` helper + a testsuite-core case, if useful).

Built + `clippy --features egfx -D warnings` clean on `ironrdp-acceptor` + `ironrdp-server`.