### PR TITLE
feat(server): send the Server Auto-Reconnect Cookie during logon

### DIFF
--- a/crates/ironrdp-server/src/builder.rs
+++ b/crates/ironrdp-server/src/builder.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use ironrdp_pdu::rdp::capability_sets::{BitmapCodecs, server_codecs_capabilities};
+use ironrdp_pdu::rdp::session_info::ServerAutoReconnect;
 use tokio_rustls::TlsAcceptor;
 
 use super::clipboard::CliprdrServerFactory;
@@ -43,6 +44,7 @@ pub struct BuilderDone {
     display_suppressed: Option<Arc<AtomicBool>>,
     autodetect_rtt: Option<Arc<AtomicU32>>,
     honor_client_desktop_size: bool,
+    auto_reconnect_cookie: Option<ServerAutoReconnect>,
 }
 
 pub struct RdpServerBuilder<State> {
@@ -144,6 +146,7 @@ impl RdpServerBuilder<WantsDisplay> {
                 display_suppressed: None,
                 autodetect_rtt: None,
                 honor_client_desktop_size: false,
+                auto_reconnect_cookie: None,
             },
         }
     }
@@ -166,6 +169,7 @@ impl RdpServerBuilder<WantsDisplay> {
                 display_suppressed: None,
                 autodetect_rtt: None,
                 honor_client_desktop_size: false,
+                auto_reconnect_cookie: None,
             },
         }
     }
@@ -289,6 +293,23 @@ impl RdpServerBuilder<BuilderDone> {
         self
     }
 
+    /// Provision the Server Auto-Reconnect Cookie (MS-RDPBCGR 2.2.4.3
+    /// `ARC_SC_PRIVATE_PACKET`) handed to the client during logon.
+    ///
+    /// When set to `Some`, the server sends a Save Session Info PDU carrying the
+    /// cookie once per connection, right after activation, which is what lets a
+    /// client automatically re-establish the session after an *ungraceful*
+    /// disconnect (MS-RDPBCGR 1.3.1.5, "Automatic Reconnection") rather than
+    /// reporting the connection as simply lost. Generate the cookie's 16-byte
+    /// `random_bits` from a CSPRNG. `None` (the default) sends no cookie.
+    ///
+    /// See [`RdpServer::set_auto_reconnect_cookie`] for the runtime equivalent
+    /// and a note on the (unvalidated) returning `ARC_CS_PRIVATE_PACKET`.
+    pub fn with_auto_reconnect_cookie(mut self, cookie: Option<ServerAutoReconnect>) -> Self {
+        self.state.auto_reconnect_cookie = cookie;
+        self
+    }
+
     pub fn build(self) -> RdpServer {
         let mut server = RdpServer::new(
             RdpServerOptions {
@@ -309,6 +330,7 @@ impl RdpServerBuilder<BuilderDone> {
             self.state.autodetect_rtt,
         );
         server.set_credential_validator(self.state.credential_validator);
+        server.set_auto_reconnect_cookie(self.state.auto_reconnect_cookie);
         server
     }
 }

--- a/crates/ironrdp-server/src/builder.rs
+++ b/crates/ironrdp-server/src/builder.rs
@@ -293,7 +293,7 @@ impl RdpServerBuilder<BuilderDone> {
         self
     }
 
-    /// Provision the Server Auto-Reconnect Cookie (MS-RDPBCGR 2.2.4.3
+    /// Provision the Server Auto-Reconnect Cookie (MS-RDPBCGR 2.2.4.2
     /// `ARC_SC_PRIVATE_PACKET`) handed to the client during logon.
     ///
     /// When set to `Some`, the server sends a Save Session Info PDU carrying the

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -477,9 +477,9 @@ pub struct RdpServer {
     /// client only enters its automatic reconnection sequence (MS-RDPBCGR
     /// 1.3.1.5) on an *ungraceful* disconnect if it was handed this cookie
     /// during logon; without it, a dropped connection simply reports as
-    /// disconnected. `None` (the default) sends nothing. Configure via
-    /// [`RdpServerBuilder::with_auto_reconnect_cookie`](crate::RdpServerBuilder::with_auto_reconnect_cookie)
-    /// or [`Self::set_auto_reconnect_cookie`].
+    /// disconnected. `None` (the default) sends nothing. Configure it on the
+    /// builder ([`RdpServer::builder`]) via `with_auto_reconnect_cookie`, or at
+    /// runtime via [`Self::set_auto_reconnect_cookie`].
     auto_reconnect_cookie: Option<rdp::session_info::ServerAutoReconnect>,
     /// Per-connection guard so the auto-reconnect cookie is sent exactly once,
     /// after the first activation — not again on a Deactivation-Reactivation
@@ -613,9 +613,9 @@ impl RdpServer {
     ///
     /// Pass `None` (the default) to send no cookie.
     ///
-    /// Most callers should configure this at construction time via the builder's
-    /// [`with_auto_reconnect_cookie`](crate::RdpServerBuilder::with_auto_reconnect_cookie);
-    /// this setter exists for dynamic post-construction reconfiguration.
+    /// Most callers should configure this at construction time via the builder
+    /// ([`RdpServer::builder`])'s `with_auto_reconnect_cookie`; this setter exists
+    /// for dynamic post-construction reconfiguration.
     ///
     /// # Note on the returning cookie
     ///

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -471,7 +471,7 @@ pub struct RdpServer {
     /// RTT for flow control.
     autodetect_rtt: Arc<AtomicU32>,
 
-    /// Optional Server Auto-Reconnect Cookie (MS-RDPBCGR 2.2.4.3
+    /// Optional Server Auto-Reconnect Cookie (MS-RDPBCGR 2.2.4.2
     /// `ARC_SC_PRIVATE_PACKET`). When `Some`, the server sends a Save Session
     /// Info PDU carrying it once per connection, right after activation. A
     /// client only enters its automatic reconnection sequence (MS-RDPBCGR
@@ -599,7 +599,7 @@ impl RdpServer {
         self.credential_validator = validator;
     }
 
-    /// Set or clear the Server Auto-Reconnect Cookie (MS-RDPBCGR 2.2.4.3
+    /// Set or clear the Server Auto-Reconnect Cookie (MS-RDPBCGR 2.2.4.2
     /// `ARC_SC_PRIVATE_PACKET`) handed to the client during logon.
     ///
     /// When set to `Some`, the server sends a Save Session Info PDU carrying the
@@ -621,7 +621,7 @@ impl RdpServer {
     ///
     /// This only *enables* the client's automatic reconnection; it does not
     /// validate the `ARC_CS_PRIVATE_PACKET` the client sends back on reconnect
-    /// (MS-RDPBCGR 2.2.4.4). A server that re-authenticates every connection by
+    /// (MS-RDPBCGR 2.2.4.3). A server that re-authenticates every connection by
     /// other means (e.g. NLA/CredSSP) does not need to; a server that wants the
     /// cookie itself to be an authentication factor must verify the returned
     /// value.

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -470,6 +470,21 @@ pub struct RdpServer {
     /// so display backends can read a fresh, frame-traffic-independent network
     /// RTT for flow control.
     autodetect_rtt: Arc<AtomicU32>,
+
+    /// Optional Server Auto-Reconnect Cookie (MS-RDPBCGR 2.2.4.3
+    /// `ARC_SC_PRIVATE_PACKET`). When `Some`, the server sends a Save Session
+    /// Info PDU carrying it once per connection, right after activation. A
+    /// client only enters its automatic reconnection sequence (MS-RDPBCGR
+    /// 1.3.1.5) on an *ungraceful* disconnect if it was handed this cookie
+    /// during logon; without it, a dropped connection simply reports as
+    /// disconnected. `None` (the default) sends nothing. Configure via
+    /// [`RdpServerBuilder::with_auto_reconnect_cookie`](crate::RdpServerBuilder::with_auto_reconnect_cookie)
+    /// or [`Self::set_auto_reconnect_cookie`].
+    auto_reconnect_cookie: Option<rdp::session_info::ServerAutoReconnect>,
+    /// Per-connection guard so the auto-reconnect cookie is sent exactly once,
+    /// after the first activation — not again on a Deactivation-Reactivation
+    /// sequence. Reset at the start of every connection.
+    auto_reconnect_sent: bool,
 }
 
 #[derive(Debug)]
@@ -556,6 +571,8 @@ impl RdpServer {
                 handle.store(u32::MAX, Ordering::Relaxed);
                 handle
             },
+            auto_reconnect_cookie: None,
+            auto_reconnect_sent: false,
         }
     }
 
@@ -580,6 +597,38 @@ impl RdpServer {
     /// Not used for CredSSP/Hybrid connections (those use pre-loaded credentials).
     pub fn set_credential_validator(&mut self, validator: Option<Arc<dyn CredentialValidator>>) {
         self.credential_validator = validator;
+    }
+
+    /// Set or clear the Server Auto-Reconnect Cookie (MS-RDPBCGR 2.2.4.3
+    /// `ARC_SC_PRIVATE_PACKET`) handed to the client during logon.
+    ///
+    /// When set to `Some`, the server sends a Save Session Info PDU carrying the
+    /// cookie once per connection, right after activation. This is what lets a
+    /// client (e.g. mstsc) automatically re-establish the session after an
+    /// *ungraceful* disconnect (MS-RDPBCGR 1.3.1.5, "Automatic Reconnection")
+    /// instead of reporting the connection as simply lost; a graceful logoff is
+    /// unaffected. The [`ServerAutoReconnect`] carries a `logon_id` identifying
+    /// the session and a 16-byte `random_bits` auto-reconnect random — generate
+    /// `random_bits` from a CSPRNG.
+    ///
+    /// Pass `None` (the default) to send no cookie.
+    ///
+    /// Most callers should configure this at construction time via the builder's
+    /// [`with_auto_reconnect_cookie`](crate::RdpServerBuilder::with_auto_reconnect_cookie);
+    /// this setter exists for dynamic post-construction reconfiguration.
+    ///
+    /// # Note on the returning cookie
+    ///
+    /// This only *enables* the client's automatic reconnection; it does not
+    /// validate the `ARC_CS_PRIVATE_PACKET` the client sends back on reconnect
+    /// (MS-RDPBCGR 2.2.4.4). A server that re-authenticates every connection by
+    /// other means (e.g. NLA/CredSSP) does not need to; a server that wants the
+    /// cookie itself to be an authentication factor must verify the returned
+    /// value.
+    ///
+    /// [`ServerAutoReconnect`]: ironrdp_pdu::rdp::session_info::ServerAutoReconnect
+    pub fn set_auto_reconnect_cookie(&mut self, cookie: Option<rdp::session_info::ServerAutoReconnect>) {
+        self.auto_reconnect_cookie = cookie;
     }
 
     pub fn event_sender(&self) -> &mpsc::UnboundedSender<ServerEvent> {
@@ -807,6 +856,11 @@ impl RdpServer {
         // here also covers backends that share an externally-created Arc via
         // `set_display_suppressed_handle()`.
         self.display_suppressed.store(false, Ordering::Relaxed);
+
+        // The Server Auto-Reconnect Cookie is sent once per connection after
+        // activation; clear the "already sent" guard so this new connection
+        // sends it (a previous connection would have left it `true`).
+        self.auto_reconnect_sent = false;
 
         let framed = TokioFramed::new(stream);
 
@@ -1483,6 +1537,29 @@ impl RdpServer {
         let encoder = UpdateEncoder::new(desktop_size, surface_flags, update_codecs, self.opts.max_request_size)
             .context("failed to initialize update encoder")?;
 
+        // If configured, hand the client its Server Auto-Reconnect Cookie now
+        // that activation is complete (Confirm Active processed, encoder built),
+        // once per connection. This Save Session Info PDU is what lets a client
+        // automatically re-establish the session after an ungraceful disconnect
+        // (MS-RDPBCGR 1.3.1.5). Not re-sent on a Deactivation-Reactivation
+        // sequence (`auto_reconnect_sent` guard, reset per connection).
+        if !self.auto_reconnect_sent {
+            if let Some(cookie) = self.auto_reconnect_cookie.clone() {
+                let pdu = rdp::headers::ShareDataPdu::SaveSessionInfo(rdp::session_info::SaveSessionInfoPdu {
+                    info_type: rdp::session_info::InfoType::LogonExtended,
+                    info_data: rdp::session_info::InfoData::LogonExtended(rdp::session_info::LogonInfoExtended {
+                        present_fields_flags: rdp::session_info::LogonExFlags::AUTO_RECONNECT_COOKIE,
+                        auto_reconnect: Some(cookie),
+                        errors_info: None,
+                    }),
+                });
+                let data = encode_share_data_pdu(pdu, result.io_channel_id, result.user_channel_id)?;
+                writer.write_all(&data).await.context("send auto-reconnect cookie")?;
+                self.auto_reconnect_sent = true;
+                debug!("Sent Server Auto-Reconnect Cookie (Save Session Info PDU)");
+            }
+        }
+
         let state = self
             .client_loop(
                 reader,
@@ -1780,6 +1857,38 @@ fn encode_autodetect_request(
     let mcs_pdu = SendDataIndication {
         initiator_id: user_channel_id,
         channel_id: message_channel_id,
+        user_data,
+    };
+    Ok(encode_vec(&X224(mcs_pdu))?)
+}
+
+/// Encode a Share Data PDU wrapped in a Share Control header and carried in an
+/// MCS Send Data Indication on the I/O channel.
+///
+/// A general `encode_share_data_pdu` helper previously lived here for the
+/// auto-detect path; #1348 rerouted auto-detect onto the message channel (see
+/// [`encode_autodetect_request`]), leaving this Save Session Info sender as the
+/// sole user, so the encoder now lives with it.
+fn encode_share_data_pdu(
+    share_data_pdu: rdp::headers::ShareDataPdu,
+    io_channel_id: u16,
+    user_channel_id: u16,
+) -> Result<Vec<u8>> {
+    let header = rdp::headers::ShareDataHeader {
+        share_data_pdu,
+        stream_priority: rdp::headers::StreamPriority::Medium,
+        compression_flags: rdp::headers::CompressionFlags::empty(),
+        compression_type: rdp::client_info::CompressionType::K8,
+    };
+    let pdu = rdp::headers::ShareControlHeader {
+        share_id: 0,
+        pdu_source: user_channel_id,
+        share_control_pdu: ShareControlPdu::Data(header),
+    };
+    let user_data = encode_vec(&pdu)?.into();
+    let mcs_pdu = SendDataIndication {
+        initiator_id: user_channel_id,
+        channel_id: io_channel_id,
         user_data,
     };
     Ok(encode_vec(&X224(mcs_pdu))?)


### PR DESCRIPTION
## What

Adds an optional **Server Auto-Reconnect Cookie** (MS-RDPBCGR 2.2.4.3 `ARC_SC_PRIVATE_PACKET`) to `ironrdp-server`. When set, `RdpServer` sends a Save Session Info PDU (`LogonExtended` + `AUTO_RECONNECT_COOKIE`) carrying it once per connection, right after activation (Confirm Active processed, encoder built), on the IO channel.

## Why

A client only enters its **automatic reconnection sequence** (MS-RDPBCGR 1.3.1.5) on an *ungraceful* disconnect if it was handed this cookie during logon. Without it, a dropped connection just reports as disconnected — **mstsc in particular won't auto-reconnect at all**. Today `ironrdp-server` never sends the cookie, so there's no way for a server to opt into that behavior.

The concrete use case: a server that *intentionally* drops a connection and expects the client to come straight back — e.g. a recovery path that cycles the session — currently forces the user to reconnect by hand. With the cookie provisioned, the client re-establishes on its own (re-authenticating via NLA/CredSSP from cached credentials). It's also just standard behavior a real RDP server provides.

## API

Mirrors the existing `credential_validator` pattern exactly — a builder method plus a runtime setter:

```rust
// build time
RdpServer::builder()
    .with_auto_reconnect_cookie(Some(ServerAutoReconnect { logon_id, random_bits }))
    // ...

// or dynamically
server.set_auto_reconnect_cookie(Some(cookie));
```

`ServerAutoReconnect` (already public in `ironrdp-pdu::rdp::session_info`) carries a `logon_id` and a 16-byte `random_bits` (generate from a CSPRNG). A per-connection guard (`auto_reconnect_sent`, reset in `run_connection_with`) sends it exactly once — not again on a Deactivation-Reactivation.

## Scope / additive

- **Additive, non-breaking.** Default is `None` (send nothing); existing servers are byte-for-byte unaffected.
- All PDU types already exist in `ironrdp-pdu` (`rdp::session_info::{SaveSessionInfoPdu, LogonInfoExtended, LogonExFlags, ServerAutoReconnect, InfoType, InfoData}`) — this is purely wiring the server-side send.
- Reuses the existing `encode_share_data_pdu` helper.

## Design point for review — the returning cookie

This PR implements the **send** side only: it *enables* the client's automatic reconnection. It does **not** validate the `ARC_CS_PRIVATE_PACKET` the client sends back on reconnect (MS-RDPBCGR 2.2.4.4). For a server that re-authenticates every connection by other means (NLA/CredSSP) that's sufficient and safe, and it's documented as such on the setter. If you'd prefer the crate to also offer *validation* of the returning cookie (so it can be an authentication factor — the server would store issued `(logon_id, random_bits)` and verify the client's `SecurityData`/`ARC_CS` on the next connect), I'm happy to do that as a follow-up, or fold it in here — it's a larger, stateful feature so I kept this PR to the send path. Let me know which you'd prefer.

Built + `clippy --features egfx -D warnings` clean; tests compile.