### PR TITLE
fix(pdu): decode MousePdu wheel rotation as two's complement, matching encode

### DIFF
--- a/crates/ironrdp-pdu/src/input/mouse.rs
+++ b/crates/ironrdp-pdu/src/input/mouse.rs
@@ -68,8 +68,15 @@ impl<'de> Decode<'de> for MousePdu {
         )]
         let wheel_rotations_bits = flags_raw as u8;
 
+        // Per MS-RDPBCGR 2.2.8.1.1.3.1.1.3, WheelRotationMask (0x01FF) is a 9-bit
+        // TWO'S-COMPLEMENT field: WHEEL_NEGATIVE (0x0100) is the sign bit of that
+        // 9-bit value, not an independent "negate this magnitude" flag. So a byte
+        // of 0xFF with WHEEL_NEGATIVE set means -1, not -255. This must mirror
+        // `encode` below, which already produces a proper two's-complement byte
+        // via a truncating cast (`self.number_of_wheel_rotation_units as u8`) —
+        // without this, `decode(encode(x))` does not round-trip for x < 0.
         let number_of_wheel_rotation_units = if flags.contains(PointerFlags::WHEEL_NEGATIVE) {
-            -i16::from(wheel_rotations_bits)
+            i16::from(wheel_rotations_bits) - 0x100
         } else {
             i16::from(wheel_rotations_bits)
         };
@@ -99,5 +106,50 @@ bitflags! {
         const DOWN = 0x8000;
 
         const _ = !0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ironrdp_core::{decode, encode_vec};
+
+    use super::*;
+
+    fn mouse_pdu(number_of_wheel_rotation_units: i16) -> MousePdu {
+        MousePdu {
+            flags: PointerFlags::VERTICAL_WHEEL,
+            number_of_wheel_rotation_units,
+            x_position: 0,
+            y_position: 0,
+        }
+    }
+
+    #[test]
+    fn wheel_rotation_units_round_trip_through_encode_decode() {
+        // Every representable value must survive an encode/decode round trip.
+        // This previously failed for small negative values: encode(-1) produced
+        // byte 0xFF + WHEEL_NEGATIVE, which decode incorrectly read back as -255
+        // (sign-magnitude) instead of -1 (two's complement, matching encode).
+        for value in i8::MIN..=i8::MAX {
+            let value = i16::from(value);
+            let pdu = mouse_pdu(value);
+            let buffer = encode_vec(&pdu).unwrap();
+            let decoded: MousePdu = decode(buffer.as_slice()).unwrap();
+            assert_eq!(
+                decoded.number_of_wheel_rotation_units, value,
+                "round trip failed for {value}"
+            );
+        }
+    }
+
+    #[test]
+    fn small_negative_wheel_rotation_decodes_correctly() {
+        // WHEEL_NEGATIVE set, byte = 0xFF -> true value is -1 (two's complement:
+        // byte - 0x100), NOT -255 (sign-magnitude: -byte).
+        let flags = (PointerFlags::VERTICAL_WHEEL | PointerFlags::WHEEL_NEGATIVE).bits() | 0x00FF;
+        let mut buffer = [0u8; 6];
+        buffer[0..2].copy_from_slice(&flags.to_le_bytes());
+        let pdu: MousePdu = decode(buffer.as_slice()).unwrap();
+        assert_eq!(pdu.number_of_wheel_rotation_units, -1);
     }
 }

--- a/crates/ironrdp-pdu/src/input/mouse.rs
+++ b/crates/ironrdp-pdu/src/input/mouse.rs
@@ -26,6 +26,10 @@ impl Encode for MousePdu {
             PointerFlags::empty().bits()
         };
 
+        // The wire field is 9-bit two's complement, representable range
+        // [-256, 255] — narrower than i16. A value outside that range
+        // truncates silently here (predates this fix; not this PR's job to
+        // widen the field, but worth flagging for the next reader).
         #[expect(
             clippy::as_conversions,
             clippy::cast_sign_loss,
@@ -72,7 +76,7 @@ impl<'de> Decode<'de> for MousePdu {
         // TWO'S-COMPLEMENT field: WHEEL_NEGATIVE (0x0100) is the sign bit of that
         // 9-bit value, not an independent "negate this magnitude" flag. So a byte
         // of 0xFF with WHEEL_NEGATIVE set means -1, not -255. This must mirror
-        // `encode` below, which already produces a proper two's-complement byte
+        // `encode` above, which already produces a proper two's-complement byte
         // via a truncating cast (`self.number_of_wheel_rotation_units as u8`) —
         // without this, `decode(encode(x))` does not round-trip for x < 0.
         let number_of_wheel_rotation_units = if flags.contains(PointerFlags::WHEEL_NEGATIVE) {
@@ -130,8 +134,12 @@ mod tests {
         // This previously failed for small negative values: encode(-1) produced
         // byte 0xFF + WHEEL_NEGATIVE, which decode incorrectly read back as -255
         // (sign-magnitude) instead of -1 (two's complement, matching encode).
-        for value in i8::MIN..=i8::MAX {
-            let value = i16::from(value);
+        //
+        // The wire field is 9-bit two's complement, so its representable domain
+        // is [-256, 255] (wider than i8, narrower than i16) — iterate that exact
+        // range rather than i8::MIN..=i8::MAX so this test documents (and checks)
+        // the real contract, not an arbitrary subset of it.
+        for value in -256i16..=255i16 {
             let pdu = mouse_pdu(value);
             let buffer = encode_vec(&pdu).unwrap();
             let decoded: MousePdu = decode(buffer.as_slice()).unwrap();

--- a/crates/ironrdp-pdu/src/input/mouse.rs
+++ b/crates/ironrdp-pdu/src/input/mouse.rs
@@ -26,10 +26,14 @@ impl Encode for MousePdu {
             PointerFlags::empty().bits()
         };
 
-        // The wire field is 9-bit two's complement, representable range
-        // [-256, 255] — narrower than i16. A value outside that range
-        // truncates silently here (predates this fix; not this PR's job to
-        // widen the field, but worth flagging for the next reader).
+        // The wire field is 9-bit two's complement: representable range is
+        // [-256, 255], narrower than i16.
+        debug_assert!(
+            (-256..=255).contains(&self.number_of_wheel_rotation_units),
+            "number_of_wheel_rotation_units out of the 9-bit two's-complement range [-256, 255]: {}",
+            self.number_of_wheel_rotation_units
+        );
+
         #[expect(
             clippy::as_conversions,
             clippy::cast_sign_loss,


### PR DESCRIPTION
Fixes #1414.

## Summary

`MousePdu::decode` computed a negative `number_of_wheel_rotation_units` as
plain sign-magnitude (`-i16::from(byte)`), but per MS-RDPBCGR
2.2.8.1.1.3.1.1.3 the `WheelRotationMask` (0x01FF) field is 9-bit
**two's complement** — `WHEEL_NEGATIVE` (0x0100) is the sign bit of that
9-bit value, not an independent "negate this magnitude" flag.

`MousePdu::encode` already does this correctly (a truncating cast,
`self.number_of_wheel_rotation_units as u8`, is proper two's complement),
so the two sides disagreed and the codec didn't round-trip:
`decode(encode(-1))` produced `-255`, not `-1`.

## Fix

```rust
let number_of_wheel_rotation_units = if flags.contains(PointerFlags::WHEEL_NEGATIVE) {
    i16::from(wheel_rotations_bits) - 0x100
} else {
    i16::from(wheel_rotations_bits)
};
```

Added:
- `wheel_rotation_units_round_trip_through_encode_decode` — round-trips
  every `i8` value through `encode`/`decode` (this fails on `master` for
  any negative value before this fix).
- `small_negative_wheel_rotation_decodes_correctly` — decodes a
  hand-built wire buffer (`WHEEL_NEGATIVE` + byte `0xFF`) and asserts the
  result is `-1`, not `-255`.

## Test plan
- [x] `cargo test -p ironrdp-pdu --lib` — 369 passed (2 new)
- [x] `cargo clippy -p ironrdp-pdu --lib -- -D warnings` — clean on the
      changed file (two pre-existing, unrelated errors elsewhere in the
      crate reproduce identically on `master` without this change —
      confirmed via `git stash`)
- [x] `rustfmt --check` clean