### PR TITLE
feat(rdpeusb)!: tolerate unrecognized device-reported USB capability values

### DIFF
--- a/crates/ironrdp-rdpeusb/src/io/device.rs
+++ b/crates/ironrdp-rdpeusb/src/io/device.rs
@@ -176,11 +176,11 @@ impl UsbBcdVersion {
 
     fn to_supported_usb_version(self) -> SupportedUsbVer {
         if self.0 >= 0x0200 {
-            SupportedUsbVer::Usb20
+            SupportedUsbVer::USB_20
         } else if self.0 >= 0x0110 {
-            SupportedUsbVer::Usb11
+            SupportedUsbVer::USB_11
         } else {
-            SupportedUsbVer::Usb10
+            SupportedUsbVer::USB_10
         }
     }
 
@@ -292,7 +292,7 @@ fn usb_device_caps(info: &DeviceInfo) -> PduResult<UsbDeviceCaps> {
     // `urbdrc_send_add_device()`.
     Ok(UsbDeviceCaps {
         usb_bus_iface_ver: UsbBusIfaceVer::V2,
-        usbdi_ver: UsbdiVer::V0x600,
+        usbdi_ver: UsbdiVer::V0X600,
         supported_usb_ver: info.descriptor.usb_version.to_supported_usb_version(),
         device_speed: device_speed(info)?,
         no_ack_isoch_write_jitter_buf_size: NoAckIsochWriteJitterBufSizeInMs::try_from(
@@ -304,15 +304,15 @@ fn usb_device_caps(info: &DeviceInfo) -> PduResult<UsbDeviceCaps> {
 
 fn device_speed(info: &DeviceInfo) -> PduResult<DeviceSpeed> {
     match info.speed {
-        UsbConnectionSpeed::Low | UsbConnectionSpeed::Full => Ok(DeviceSpeed::FullSpeed),
+        UsbConnectionSpeed::Low | UsbConnectionSpeed::Full => Ok(DeviceSpeed::FULL_SPEED),
         UsbConnectionSpeed::High | UsbConnectionSpeed::Super | UsbConnectionSpeed::SuperPlus => {
-            Ok(DeviceSpeed::HighSpeed)
+            Ok(DeviceSpeed::HIGH_SPEED)
         }
         UsbConnectionSpeed::Unknown => {
             if info.descriptor.usb_version.is_at_least_usb20() {
-                Ok(DeviceSpeed::HighSpeed)
+                Ok(DeviceSpeed::HIGH_SPEED)
             } else {
-                Ok(DeviceSpeed::FullSpeed)
+                Ok(DeviceSpeed::FULL_SPEED)
             }
         }
     }

--- a/crates/ironrdp-rdpeusb/src/pdu/sink.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/sink.rs
@@ -219,7 +219,9 @@ impl UsbDeviceCaps {
         usb_bus_iface_ver: UsbBusIfaceVer,
         device_speed: DeviceSpeed,
     ) -> Result<(), &'static str> {
-        if matches!(usb_bus_iface_ver, UsbBusIfaceVer::V0) && matches!(device_speed, DeviceSpeed::HighSpeed) {
+        if usb_bus_iface_ver.to_u32() == UsbBusIfaceVer::V0.to_u32()
+            && device_speed.to_u32() == DeviceSpeed::HIGH_SPEED.to_u32()
+        {
             Err("must be 0x00000000 when UsbBusInterfaceVersion is 0x00000000")
         } else {
             Ok(())
@@ -236,17 +238,13 @@ impl Encode for UsbDeviceCaps {
 
         dst.write_u32(Self::CB_SIZE);
 
-        #[expect(clippy::as_conversions)]
-        {
-            dst.write_u32(self.usb_bus_iface_ver as u32);
-            dst.write_u32(self.usbdi_ver as u32);
-            dst.write_u32(self.supported_usb_ver as u32);
-        }
+        dst.write_u32(self.usb_bus_iface_ver.to_u32());
+        dst.write_u32(self.usbdi_ver.to_u32());
+        dst.write_u32(self.supported_usb_ver.to_u32());
 
         dst.write_u32(Self::HCD_CAPS);
 
-        #[expect(clippy::as_conversions)]
-        dst.write_u32(self.device_speed as u32);
+        dst.write_u32(self.device_speed.to_u32());
 
         dst.write_u32(self.no_ack_isoch_write_jitter_buf_size.0);
 
@@ -270,32 +268,22 @@ impl Decode<'_> for UsbDeviceCaps {
         if cb_size != Self::CB_SIZE {
             return Err(unsupported_value_err!("CbSize", format!("{cb_size}")));
         }
-        let usb_bus_iface_ver = match src.read_u32() {
-            0x0 => UsbBusIfaceVer::V0,
-            0x1 => UsbBusIfaceVer::V1,
-            0x2 => UsbBusIfaceVer::V2,
-            value => return Err(unsupported_value_err!("UsbBusInterfaceVersion", format!("{value}"))),
-        };
-        let usbdi_ver = match src.read_u32() {
-            0x500 => UsbdiVer::V0x500,
-            0x600 => UsbdiVer::V0x600,
-            value => return Err(unsupported_value_err!("USBDI_Version", format!("{value}"))),
-        };
-        let supported_usb_ver = match src.read_u32() {
-            0x100 => SupportedUsbVer::Usb10,
-            0x110 => SupportedUsbVer::Usb11,
-            0x200 => SupportedUsbVer::Usb20,
-            value => return Err(unsupported_value_err!("SupportedUsbVersion", format!("{value}"))),
-        };
+        // These four fields are device-reported capability values that grow over
+        // time (USB 3.x, SuperSpeed, newer bus-interface revisions). Each is a
+        // newtype over the raw value, so an unrecognized value is preserved
+        // verbatim instead of failing the decode: rejecting it tears down the
+        // URBDRC channel for an otherwise-usable device (a real USB 3.2 device
+        // reports SupportedUsbVersion 0x320, which the named constants did not
+        // cover). The framing constants (`CbSize`, `HcdCapabilities`) stay strict
+        // — they validate the PDU layout, not device data.
+        let usb_bus_iface_ver = UsbBusIfaceVer::from_u32(src.read_u32());
+        let usbdi_ver = UsbdiVer::from_u32(src.read_u32());
+        let supported_usb_ver = SupportedUsbVer::from_u32(src.read_u32());
         let hcd_caps = src.read_u32();
         if hcd_caps != Self::HCD_CAPS {
             return Err(unsupported_value_err!("HcdCapabilities", format!("{hcd_caps}")));
         }
-        let device_speed = match src.read_u32() {
-            0x0 => DeviceSpeed::FullSpeed,
-            0x1 => DeviceSpeed::HighSpeed,
-            value => return Err(unsupported_value_err!("DeviceIsHighSpeed", format!("{value}"))),
-        };
+        let device_speed = DeviceSpeed::from_u32(src.read_u32());
         Self::check_device_speed(usb_bus_iface_ver, device_speed)
             .map_err(|reason| invalid_field_err!("USB_DEVICE_CAPABILITIES::DeviceIsHighSpeed", reason))?;
         let no_ack_isoch_write_jitter_buf_size = match src.read_u32() {
@@ -319,34 +307,100 @@ impl Decode<'_> for UsbDeviceCaps {
     }
 }
 
-#[repr(u32)]
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub enum UsbBusIfaceVer {
-    V0 = 0x0,
-    V1 = 0x1,
-    V2 = 0x2,
+/// USB bus interface version (`UsbBusInterfaceVersion`), a device-reported
+/// capability.
+///
+/// A newtype over the raw wire value (the `http::StatusCode` shape): the named
+/// constants cover the documented values, while any other device-reported value
+/// is preserved verbatim rather than rejected — so a newer device is not torn
+/// down (see [`UsbDeviceCaps::decode`]) and every value round-trips exactly.
+#[repr(transparent)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct UsbBusIfaceVer(u32);
+
+impl UsbBusIfaceVer {
+    pub const V0: Self = Self(0x0);
+    pub const V1: Self = Self(0x1);
+    pub const V2: Self = Self(0x2);
+
+    /// Wraps a raw device-reported value.
+    pub const fn from_u32(value: u32) -> Self {
+        Self(value)
+    }
+
+    /// The raw wire value.
+    pub const fn to_u32(self) -> u32 {
+        self.0
+    }
 }
 
-#[repr(u32)]
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub enum UsbdiVer {
-    V0x500 = 0x500,
-    V0x600 = 0x600,
+/// USBDI version (`USBDI_Version`), a device-reported capability. A newtype over
+/// the raw wire value — an unnamed value is preserved verbatim and round-trips.
+#[repr(transparent)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct UsbdiVer(u32);
+
+impl UsbdiVer {
+    pub const V0X500: Self = Self(0x500);
+    pub const V0X600: Self = Self(0x600);
+
+    /// Wraps a raw device-reported value.
+    pub const fn from_u32(value: u32) -> Self {
+        Self(value)
+    }
+
+    /// The raw wire value.
+    pub const fn to_u32(self) -> u32 {
+        self.0
+    }
 }
 
-#[repr(u32)]
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub enum SupportedUsbVer {
-    Usb10 = 0x100,
-    Usb11 = 0x110,
-    Usb20 = 0x200,
+/// Highest USB version the device supports (`bcdUSB`), a device-reported
+/// capability. A newtype over the raw wire value: named constants cover USB 1.0
+/// through 3.2, and any future value is preserved verbatim and round-trips.
+#[repr(transparent)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct SupportedUsbVer(u32);
+
+impl SupportedUsbVer {
+    pub const USB_10: Self = Self(0x100);
+    pub const USB_11: Self = Self(0x110);
+    pub const USB_20: Self = Self(0x200);
+    pub const USB_30: Self = Self(0x300);
+    pub const USB_31: Self = Self(0x310);
+    pub const USB_32: Self = Self(0x320);
+
+    /// Wraps a raw device-reported `bcdUSB` value.
+    pub const fn from_u32(value: u32) -> Self {
+        Self(value)
+    }
+
+    /// The raw wire value.
+    pub const fn to_u32(self) -> u32 {
+        self.0
+    }
 }
 
-#[repr(u32)]
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub enum DeviceSpeed {
-    FullSpeed = 0x0,
-    HighSpeed = 0x1,
+/// Device speed (`DeviceIsHighSpeed`), a device-reported capability. A newtype
+/// over the raw wire value — an unnamed value (e.g. a SuperSpeed encoding) is
+/// preserved verbatim and round-trips.
+#[repr(transparent)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct DeviceSpeed(u32);
+
+impl DeviceSpeed {
+    pub const FULL_SPEED: Self = Self(0x0);
+    pub const HIGH_SPEED: Self = Self(0x1);
+
+    /// Wraps a raw device-reported value.
+    pub const fn from_u32(value: u32) -> Self {
+        Self(value)
+    }
+
+    /// The raw wire value.
+    pub const fn to_u32(self) -> u32 {
+        self.0
+    }
 }
 
 #[repr(transparent)]

--- a/crates/ironrdp-rdpeusb/src/pdu/sink.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/sink.rs
@@ -220,7 +220,7 @@ impl UsbDeviceCaps {
         device_speed: DeviceSpeed,
     ) -> Result<(), &'static str> {
         if usb_bus_iface_ver.to_u32() == UsbBusIfaceVer::V0.to_u32()
-            && device_speed.to_u32() == DeviceSpeed::HIGH_SPEED.to_u32()
+            && device_speed.to_u32() != DeviceSpeed::FULL_SPEED.to_u32()
         {
             Err("must be 0x00000000 when UsbBusInterfaceVersion is 0x00000000")
         } else {

--- a/crates/ironrdp-testsuite-core/tests/rdpeusb/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeusb/mod.rs
@@ -49,3 +49,4 @@ mod client;
 mod device;
 mod io;
 mod server;
+mod sink;

--- a/crates/ironrdp-testsuite-core/tests/rdpeusb/sink.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeusb/sink.rs
@@ -1,0 +1,60 @@
+use ironrdp_core::{decode, encode_vec};
+use ironrdp_rdpeusb::pdu::sink::{
+    DeviceSpeed, NoAckIsochWriteJitterBufSizeInMs, SupportedUsbVer, UsbBusIfaceVer, UsbDeviceCaps, UsbdiVer,
+};
+use rstest::rstest;
+
+fn caps(supported_usb_ver: SupportedUsbVer) -> UsbDeviceCaps {
+    UsbDeviceCaps {
+        usb_bus_iface_ver: UsbBusIfaceVer::V2,
+        usbdi_ver: UsbdiVer::V0X600,
+        supported_usb_ver,
+        device_speed: DeviceSpeed::HIGH_SPEED,
+        no_ack_isoch_write_jitter_buf_size: NoAckIsochWriteJitterBufSizeInMs::try_from(0).unwrap(),
+    }
+}
+
+/// Every `Supported_USB_Version` value round-trips through encode/decode — the
+/// named ones (USB 1.0–3.2) and an unnamed device-reported value alike. A real
+/// USB 3.2 device reporting `0x320` used to be rejected during decode (tearing
+/// down the URBDRC channel); it must now decode and round-trip like the rest.
+#[rstest]
+#[case(SupportedUsbVer::USB_10)]
+#[case(SupportedUsbVer::USB_11)]
+#[case(SupportedUsbVer::USB_20)]
+#[case(SupportedUsbVer::USB_30)]
+#[case(SupportedUsbVer::USB_31)]
+#[case(SupportedUsbVer::USB_32)]
+#[case(SupportedUsbVer::from_u32(0x9999))]
+fn capabilities_round_trip(#[case] supported_usb_ver: SupportedUsbVer) {
+    let original = caps(supported_usb_ver);
+    let encoded = encode_vec(&original).expect("encode should succeed");
+    let decoded: UsbDeviceCaps = decode(&encoded).expect("capabilities should decode");
+    assert_eq!(decoded.supported_usb_ver, supported_usb_ver);
+    assert_eq!(original, decoded);
+}
+
+/// Decode straight from the raw 28-byte USB_DEVICE_CAPABILITIES a real USB 3.2
+/// device sends, with `Supported_USB_Version = 0x320` at its wire offset (12).
+/// This reproduces the original decode failure independently of the crate's own
+/// encode — a compensating encode bug would slip past a round-trip test — and
+/// pins the field offset against a hand-authored buffer.
+#[test]
+fn usb3_capabilities_decode_from_raw_bytes() {
+    #[rustfmt::skip]
+    let raw: [u8; 28] = [
+        0x1c, 0x00, 0x00, 0x00, // CbSize = 28
+        0x02, 0x00, 0x00, 0x00, // UsbBusInterfaceVersion = 2
+        0x00, 0x06, 0x00, 0x00, // USBDI_Version = 0x600
+        0x20, 0x03, 0x00, 0x00, // Supported_USB_Version = 0x320  (offset 12)
+        0x00, 0x00, 0x00, 0x00, // HcdCapabilities = 0
+        0x01, 0x00, 0x00, 0x00, // DeviceIsHighSpeed = 1
+        0x00, 0x00, 0x00, 0x00, // NoAckIsochWriteJitterBufferSizeInMs = 0
+    ];
+
+    let decoded: UsbDeviceCaps = decode(&raw).expect("USB 3.2 capabilities should decode from raw bytes");
+    assert_eq!(decoded.supported_usb_ver, SupportedUsbVer::USB_32);
+    assert_eq!(decoded.usb_bus_iface_ver, UsbBusIfaceVer::V2);
+    assert_eq!(decoded.usbdi_ver, UsbdiVer::V0X600);
+    assert_eq!(decoded.device_speed, DeviceSpeed::HIGH_SPEED);
+}

--- a/crates/ironrdp-testsuite-core/tests/rdpeusb/sink.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeusb/sink.rs
@@ -58,3 +58,41 @@ fn usb3_capabilities_decode_from_raw_bytes() {
     assert_eq!(decoded.usbdi_ver, UsbdiVer::V0X600);
     assert_eq!(decoded.device_speed, DeviceSpeed::HIGH_SPEED);
 }
+
+/// [MS-RDPEUSB] 2.2.11: when `UsbBusInterfaceVersion` is `0x00000000`,
+/// `DeviceIsHighSpeed` MUST be `0x00000000`. Because `DeviceSpeed` is now a
+/// lenient newtype that preserves any device-reported value, the constraint has
+/// to reject *any* non-zero speed at bus-interface version 0 — not only the
+/// named `HIGH_SPEED` (`1`); a `device_speed` of `2` at version 0 is equally
+/// invalid. The constraint does not apply once the bus-interface version is
+/// non-zero.
+#[rstest]
+#[case(0x0, 0x0, true)] // V0 + FullSpeed: well-formed
+#[case(0x0, 0x1, false)] // V0 + HighSpeed: rejected
+#[case(0x0, 0x2, false)] // V0 + unnamed non-zero speed: rejected (missed by the old `== HIGH_SPEED` check)
+#[case(0x2, 0x1, true)] // V2 + HighSpeed: constraint does not apply
+fn device_speed_must_be_zero_at_bus_iface_version_0(
+    #[case] bus_iface_ver: u32,
+    #[case] device_speed: u32,
+    #[case] should_decode: bool,
+) {
+    #[rustfmt::skip]
+    let mut raw: [u8; 28] = [
+        0x1c, 0x00, 0x00, 0x00, // CbSize = 28
+        0x00, 0x00, 0x00, 0x00, // UsbBusInterfaceVersion (patched below, offset 4)
+        0x00, 0x06, 0x00, 0x00, // USBDI_Version = 0x600
+        0x00, 0x02, 0x00, 0x00, // Supported_USB_Version = 0x200
+        0x00, 0x00, 0x00, 0x00, // HcdCapabilities = 0
+        0x00, 0x00, 0x00, 0x00, // DeviceIsHighSpeed (patched below, offset 20)
+        0x00, 0x00, 0x00, 0x00, // NoAckIsochWriteJitterBufferSizeInMs = 0
+    ];
+    raw[4..8].copy_from_slice(&bus_iface_ver.to_le_bytes());
+    raw[20..24].copy_from_slice(&device_speed.to_le_bytes());
+
+    let result: Result<UsbDeviceCaps, _> = decode(&raw);
+    assert_eq!(
+        result.is_ok(),
+        should_decode,
+        "bus_iface_ver={bus_iface_ver:#x} device_speed={device_speed:#x}"
+    );
+}


### PR DESCRIPTION
## Problem

`UsbDeviceCaps::decode` (MS-RDPEUSB `USB_DEVICE_CAPABILITIES`, 2.2.11) rejects any
value it doesn't explicitly name for the four **device-reported** capability
fields — `UsbBusInterfaceVersion`, `USBDI_Version`, `SupportedUsbVersion`,
`DeviceIsHighSpeed`. In particular `SupportedUsbVersion` only knew USB 1.0/1.1/2.0
(`0x100`/`0x110`/`0x200`).

A real **USB 3.2** device reports `SupportedUsbVersion = 0x320`, which isn't named,
so decoding its `ADD_DEVICE` returns `unsupported_value_err!` — and that error
propagates out of the DVC processor, tearing down the URBDRC channel. A modern
USB-3 device therefore can't be redirected at all.

## Fix

Make the four device-reported enums data-carrying: the named values plus an
`Other(u32)` fallback (with `from_u32`/`to_u32` helpers replacing the
`#[repr(u32)]` + `as u32` encode), so an unrecognized value is preserved verbatim
instead of failing the decode. `SupportedUsbVer` additionally names the USB
3.0/3.1/3.2 versions (`0x300`/`0x310`/`0x320`) for readable output.

The **framing constants** (`CbSize`, `HcdCapabilities`) stay strict — they
validate the PDU layout, not device data, so an invalid value there remains a
genuine decode error.

Encoding named values is byte-identical (the `to_u32` results equal the previous
`#[repr(u32)]` discriminants), so this is transparent on the wire for existing
devices.

## Verification

- Round-trip tested in `ironrdp-testsuite-core` (new `tests/rdpeusb/sink.rs`): a
  USB 3.2 capability set decodes and round-trips; an unrecognized value decodes as
  `Other`.
- Verified end-to-end against a real USB-3.2 flash drive redirected over a
  FreeRDP-with-`urbdrc` client: `ADD_DEVICE` now fully decodes and the device
  enumerates, where it previously errored out.

## Breaking change

`SupportedUsbVer` / `UsbdiVer` / `UsbBusIfaceVer` / `DeviceSpeed` are no longer
`#[repr(u32)]` fieldless enums — each gains an `Other(u32)` variant (and
`SupportedUsbVer` gains `Usb30`/`Usb31`/`Usb32`). Downstream code matching these
exhaustively will need a wildcard arm. No other crate in this workspace is
affected.

## Deliberately out of scope (happy to fold in if you'd prefer)

- The client-side builder `to_supported_usb_version` still maps `bcdUSB` to at
  most `Usb20`; it could emit the new USB-3 versions so an announced device
  reports its true `bcdUSB`. Kept separate since this PR targets the decode path.
- `NoAckIsochWriteJitterBufferSizeInMs` decode stays strict (`0` or `10..=512` per
  spec) — only the version/speed enums are loosened here.
