### PR TITLE
feat(rdpeusb)!: carry the full configuration descriptor in UsbConfigDesc

### DIFF
--- a/crates/ironrdp-rdpeusb/src/pdu/usb_dev/ts_urb/utils.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/usb_dev/ts_urb/utils.rs
@@ -617,6 +617,15 @@ pub struct UsbConfigDesc {
     pub configuration: u8,
     pub attributes: u8,
     pub max_power: u8,
+    /// The remainder of the configuration descriptor **after** the 9-byte header —
+    /// all interface / endpoint / class-specific descriptors, i.e. bytes
+    /// `9..total_length`.
+    ///
+    /// [MS-RDPEUSB] 2.2.9.2 requires the *full* configuration descriptor when
+    /// `ConfigurationDescriptorIsValid` is set; real Windows (mstsc) walks
+    /// `wTotalLength` bytes and rejects a header-only descriptor with `0x80070057`
+    /// (`E_INVALIDARG`). Empty means header-only.
+    pub trailing: Vec<u8>,
 }
 
 impl UsbConfigDesc {
@@ -632,7 +641,27 @@ impl UsbConfigDesc {
 
 impl Encode for UsbConfigDesc {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        ensure_fixed_part_size!(in: dst);
+        // Keep the header self-consistent with the bytes that actually follow:
+        // `bLength` is the 9-byte header length, and `wTotalLength` must span the
+        // header plus every trailing byte. Real Windows walks `wTotalLength` and
+        // rejects `URB_SELECT_CONFIGURATION` with `0x80070057` when it disagrees
+        // with the payload, so catch a mismatched value here instead of emitting a
+        // descriptor the peer will reject. (This also rejects a `trailing` too
+        // large for `wTotalLength` to address, since no u16 can then match.)
+        if usize::from(self.length) != Self::FIXED_PART_SIZE {
+            return Err(invalid_field_err!(
+                "USB_CONFIGURATION_DESCRIPTOR::bLength",
+                "must be the 9-byte configuration-descriptor header length"
+            ));
+        }
+        if usize::from(self.total_length) != Self::FIXED_PART_SIZE + self.trailing.len() {
+            return Err(invalid_field_err!(
+                "USB_CONFIGURATION_DESCRIPTOR::wTotalLength",
+                "must equal the 9-byte header plus the trailing descriptor bytes"
+            ));
+        }
+
+        ensure_size!(in: dst, size: self.size());
 
         dst.write_u8(self.length);
         dst.write_u8(self.descriptor_type);
@@ -642,6 +671,7 @@ impl Encode for UsbConfigDesc {
         dst.write_u8(self.configuration);
         dst.write_u8(self.attributes);
         dst.write_u8(self.max_power);
+        dst.write_slice(&self.trailing);
 
         Ok(())
     }
@@ -651,7 +681,7 @@ impl Encode for UsbConfigDesc {
     }
 
     fn size(&self) -> usize {
-        Self::FIXED_PART_SIZE
+        Self::FIXED_PART_SIZE + self.trailing.len()
     }
 }
 
@@ -667,6 +697,13 @@ impl Decode<'_> for UsbConfigDesc {
         let attributes = src.read_u8();
         let max_power = src.read_u8();
 
+        // The remaining interface/endpoint/class-specific descriptors, when the sender
+        // included the full configuration descriptor (bytes 9..total_length). Clamp to
+        // what is actually present so a header-only descriptor still decodes.
+        let trailing_len = usize::from(total_length).saturating_sub(Self::FIXED_PART_SIZE);
+        let trailing_len = trailing_len.min(src.len());
+        let trailing = src.read_slice(trailing_len).to_vec();
+
         Ok(Self {
             length,
             descriptor_type,
@@ -676,6 +713,7 @@ impl Decode<'_> for UsbConfigDesc {
             configuration,
             attributes,
             max_power,
+            trailing,
         })
     }
 }

--- a/crates/ironrdp-testsuite-core/tests/rdpeusb/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeusb/mod.rs
@@ -50,3 +50,4 @@ mod device;
 mod io;
 mod server;
 mod sink;
+mod ts_urb;

--- a/crates/ironrdp-testsuite-core/tests/rdpeusb/ts_urb.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeusb/ts_urb.rs
@@ -1,0 +1,78 @@
+use ironrdp_core::{decode, encode_vec};
+use ironrdp_rdpeusb::pdu::usb_dev::ts_urb::TsUrbSelectConfig;
+use ironrdp_rdpeusb::pdu::usb_dev::ts_urb::utils::UsbConfigDesc;
+
+/// An interface descriptor (9 bytes, mass-storage/SCSI/BOT) followed by a bulk-IN
+/// endpoint descriptor (7 bytes) — the kind of payload that follows the 9-byte
+/// configuration-descriptor header on a real device.
+const TRAILING: [u8; 16] = [
+    0x09, 0x04, 0x00, 0x00, 0x01, 0x08, 0x06, 0x50, 0x00, // interface descriptor
+    0x07, 0x05, 0x81, 0x02, 0x00, 0x02, 0x00, // endpoint descriptor (bulk IN, 512)
+];
+
+fn full_config_desc() -> UsbConfigDesc {
+    UsbConfigDesc {
+        length: 9,
+        descriptor_type: 0x02,
+        total_length: u16::try_from(9 + TRAILING.len()).expect("fits in u16"),
+        num_interfaces: 1,
+        configuration_value: 1,
+        configuration: 0,
+        attributes: 0x80,
+        max_power: 50,
+        trailing: TRAILING.to_vec(),
+    }
+}
+
+/// [MS-RDPEUSB] 2.2.9.2 requires the full configuration descriptor (all
+/// interface/endpoint/class-specific bytes, `wTotalLength` in total) when
+/// `ConfigurationDescriptorIsValid` is set — real Windows walks `wTotalLength`
+/// and rejects a header-only descriptor with `0x80070057`. The encoded form must
+/// therefore span `total_length` bytes and round-trip.
+#[test]
+fn full_config_descriptor_round_trips() {
+    let original = full_config_desc();
+    let encoded = encode_vec(&original).expect("encode should succeed");
+    assert_eq!(encoded.len(), usize::from(original.total_length));
+    let decoded: UsbConfigDesc = decode(&encoded).expect("full descriptor should decode");
+    assert_eq!(original, decoded);
+}
+
+/// A header-only descriptor (only 9 bytes present even though `wTotalLength`
+/// claims more) must still decode, with `trailing` left empty.
+#[test]
+fn header_only_descriptor_still_decodes() {
+    // 9-byte header claiming wTotalLength = 759 (0x02F7), with no trailing bytes.
+    let header_only = [0x09, 0x02, 0xF7, 0x02, 0x03, 0x01, 0x00, 0x80, 0x32];
+    let decoded: UsbConfigDesc = decode(&header_only).expect("header-only descriptor should decode");
+    assert_eq!(decoded.total_length, 759);
+    assert!(decoded.trailing.is_empty());
+}
+
+/// Encoding must refuse a descriptor whose header disagrees with the bytes that
+/// follow — a mismatched `wTotalLength`, or a `bLength` that is not the 9-byte
+/// header. Real Windows rejects such a descriptor with `0x80070057`, so the
+/// inconsistency is caught before it reaches the wire.
+#[test]
+fn inconsistent_header_fails_to_encode() {
+    let mut wrong_total = full_config_desc();
+    wrong_total.total_length += 4; // claims more than `trailing` provides
+    assert!(encode_vec(&wrong_total).is_err());
+
+    let mut wrong_length = full_config_desc();
+    wrong_length.length = 10; // bLength must be the 9-byte header length
+    assert!(encode_vec(&wrong_length).is_err());
+}
+
+/// The descriptor is the last field of TS_URB_SELECT_CONFIGURATION; the full
+/// (trailing-carrying) form must round-trip through the containing URB too.
+#[test]
+fn select_configuration_carries_full_descriptor() {
+    let original = TsUrbSelectConfig {
+        usbd_ifaces: Vec::new(),
+        desc: Some(full_config_desc()),
+    };
+    let encoded = encode_vec(&original).expect("encode should succeed");
+    let decoded: TsUrbSelectConfig = decode(&encoded).expect("URB with full descriptor should decode");
+    assert_eq!(original, decoded);
+}


### PR DESCRIPTION
## What

`TS_URB_SELECT_CONFIGURATION` sets `ConfigurationDescriptorIsValid` and then encodes a `UsbConfigDesc`, but only the 9-byte `USB_CONFIGURATION_DESCRIPTOR` **header** was modelled — `wTotalLength` would claim e.g. 759 bytes with only 9 following.

Per [MS-RDPEUSB] 2.2.9.2 the field must carry the **full** configuration descriptor (all interface / endpoint / class-specific bytes) when the flag is set. Real Windows (mstsc) walks `wTotalLength` and rejects a header-only descriptor with `0x80070057` (E_INVALIDARG), so `URB_SELECT_CONFIGURATION` fails against a real Windows peer. FreeRDP uses the interface array and ignores the descriptor bytes, which masks this.

## Change

Adds a `trailing: Vec<u8>` field holding bytes `9..wTotalLength`:
- `encode` writes it after the 9-byte header.
- `decode` reads `wTotalLength - 9` bytes, clamped to what is present — so a header-only descriptor still decodes (with `trailing` empty), and a spec-conformant full descriptor's trailing bytes are now **consumed** from the cursor instead of left dangling.

`BREAKING CHANGE`: `UsbConfigDesc` gains the public field `trailing: Vec<u8>` (all fields are public, so struct-literal constructors need it).

## Tests

Adds `tests/rdpeusb/ts_urb.rs` (wired into the rdpeusb testsuite): `full_config_descriptor_round_trips`, `header_only_descriptor_still_decodes`, and `select_configuration_carries_full_descriptor`.

## Context

Found while building a server-direction (client-redirected-USB) consumer of this crate, and verified live: mstsc `SelectConfiguration` succeeds (pipe handles returned) for a redirected camera + audio/HID device; FreeRDP mass storage is unaffected. Independent of #1418 (a different file/type in the same crate) — this branch is rebased on current `master`, not stacked on it.

Gates run locally: `cargo fmt --all -- --check`, `cargo clippy -p ironrdp-rdpeusb --all-targets --locked -D warnings`, and the rdpeusb testsuite (all green).