### PR TITLE
ci: publish CLI binary release assets

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -56,14 +56,16 @@ jobs:
             target: x86_64-pc-windows-msvc
           - runner: windows-11-arm
             target: aarch64-pc-windows-msvc
-          - runner: ubuntu-24.04
+          - runner: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-          - runner: ubuntu-24.04-arm
+          - runner: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
           - runner: macos-15-intel
             target: x86_64-apple-darwin
+            macos_deployment_target: '10.13'
           - runner: macos-14
             target: aarch64-apple-darwin
+            macos_deployment_target: '11.0'
 
     steps:
       - name: Checkout release tag
@@ -93,6 +95,10 @@ jobs:
         run: |
           if ($env:RUNNER_OS -eq 'Windows') {
             $env:RUSTFLAGS = '-C target-feature=+crt-static'
+          }
+
+          if ($env:RUNNER_OS -eq 'macOS') {
+            $env:MACOSX_DEPLOYMENT_TARGET = '${{ matrix.macos_deployment_target }}'
           }
 
           cargo build --locked --release --package '${{ needs.select-package.outputs.package }}'

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -90,7 +90,12 @@ jobs:
 
       - name: Build release binary
         shell: pwsh
-        run: cargo build --locked --release --package '${{ needs.select-package.outputs.package }}'
+        run: |
+          if ($env:RUNNER_OS -eq 'Windows') {
+            $env:RUSTFLAGS = '-C target-feature=+crt-static'
+          }
+
+          cargo build --locked --release --package '${{ needs.select-package.outputs.package }}'
 
       - name: Package binary
         shell: pwsh

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -115,7 +115,7 @@ jobs:
           Pop-Location
 
       - name: Upload release asset
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-assets-${{ matrix.target }}
           path: release-assets/*

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,143 @@
+name: Release binaries
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUSTUP_MAX_RETRIES: 10
+  RUST_BACKTRACE: short
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+
+jobs:
+  select-package:
+    name: Select package
+    runs-on: ubuntu-latest
+    outputs:
+      package: ${{ steps.select.outputs.package }}
+      version: ${{ steps.select.outputs.version }}
+
+    steps:
+      - name: Select released CLI
+        id: select
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          case "$TAG_NAME" in
+            ironrdp-agent-v*)
+              package=ironrdp-agent
+              ;;
+            ironrdp-viewer-v*)
+              package=ironrdp-viewer
+              ;;
+            *)
+              exit 0
+              ;;
+          esac
+
+          echo "package=$package" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG_NAME#"$package-v"}" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build ${{ needs.select-package.outputs.package }} [${{ matrix.target }}]
+    needs: select-package
+    if: ${{ needs.select-package.outputs.package != '' }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: windows-2022
+            target: x86_64-pc-windows-msvc
+          - runner: windows-11-arm
+            target: aarch64-pc-windows-msvc
+          - runner: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - runner: macos-15-intel
+            target: x86_64-apple-darwin
+          - runner: macos-14
+            target: aarch64-apple-darwin
+
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Install Linux build dependencies
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get -y install libasound2-dev
+
+      - name: Install NASM
+        if: ${{ runner.os == 'Windows' }}
+        run: |
+          choco install nasm
+          $Env:PATH += ";$Env:ProgramFiles\NASM"
+          echo "PATH=$Env:PATH" >> $Env:GITHUB_ENV
+        shell: pwsh
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2.7.3
+
+      - name: Build release binary
+        shell: pwsh
+        run: cargo build --locked --release --package '${{ needs.select-package.outputs.package }}'
+
+      - name: Package binary
+        shell: pwsh
+        env:
+          PACKAGE: ${{ needs.select-package.outputs.package }}
+          VERSION: ${{ needs.select-package.outputs.version }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          $extension = if ($env:RUNNER_OS -eq 'Windows') { '.exe' } else { '' }
+          $binary = Join-Path (Join-Path 'target' 'release') "$env:PACKAGE$extension"
+          $assetName = "$env:PACKAGE-$env:VERSION-$env:TARGET.tar.gz"
+          $assetDirectory = 'release-assets'
+
+          New-Item -ItemType Directory -Force -Path $assetDirectory | Out-Null
+          Copy-Item $binary (Join-Path $assetDirectory "$env:PACKAGE$extension")
+
+          Push-Location $assetDirectory
+          tar -czf $assetName "$env:PACKAGE$extension"
+          $hash = (Get-FileHash -Algorithm SHA256 $assetName).Hash.ToLowerInvariant()
+          "$hash  $assetName" | Set-Content -NoNewline -Encoding ascii "$assetName.sha256"
+          Remove-Item "$env:PACKAGE$extension"
+          Pop-Location
+
+      - name: Upload release asset
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-assets-${{ matrix.target }}
+          path: release-assets/*
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Upload release assets
+    needs: [select-package, build]
+    if: ${{ always() && needs.select-package.outputs.package != '' && needs.build.result == 'success' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download release assets
+        uses: actions/download-artifact@v8
+        with:
+          pattern: release-assets-*
+          path: release-assets
+          merge-multiple: true
+
+      - name: Upload release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: gh release upload "$TAG_NAME" release-assets/* --clobber

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -79,3 +79,5 @@ jobs:
         with:
           command: release
           registry-token: ${{ steps.auth.outputs.token }}
+          # Ensure the published GitHub Release triggers release-binaries.yml.
+          github-token: ${{ secrets.DEVOLUTIONSBOT_WRITE_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -28,6 +28,39 @@ It is built on top of the reusable [`ironrdp-client`](https://github.com/Devolut
 cargo run --bin ironrdp-viewer -- <HOSTNAME> --username <USERNAME> --password <PASSWORD>
 ```
 
+## Binary releases
+
+Standalone archives are attached to GitHub Releases for the executable packages:
+
+- [`ironrdp-agent`](./crates/ironrdp-agent) provides the agentic, daemon-backed CLI.
+- [`ironrdp-viewer`](./crates/ironrdp-viewer) provides the windowed RDP client CLI.
+
+Each release provides one `.tar.gz` archive and a SHA-256 sidecar for these native target triples:
+
+| Platform | Target triple |
+| --- | --- |
+| Windows x64 | `x86_64-pc-windows-msvc` |
+| Windows ARM64 | `aarch64-pc-windows-msvc` |
+| Linux x64 | `x86_64-unknown-linux-gnu` |
+| Linux ARM64 | `aarch64-unknown-linux-gnu` |
+| macOS x64 | `x86_64-apple-darwin` |
+| macOS ARM64 | `aarch64-apple-darwin` |
+
+For example, download and extract the Linux x64 agent from its release:
+
+```shell
+VERSION=<VERSION>
+ASSET="ironrdp-agent-${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+curl -fLO "https://github.com/Devolutions/IronRDP/releases/download/ironrdp-agent-v${VERSION}/${ASSET}"
+curl -fLO "https://github.com/Devolutions/IronRDP/releases/download/ironrdp-agent-v${VERSION}/${ASSET}.sha256"
+sha256sum --check "${ASSET}.sha256"
+tar -xzf "${ASSET}"
+```
+
+Replace `ironrdp-agent` with `ironrdp-viewer` to download the windowed client from its corresponding
+package release. Windows archives contain an `.exe`; all other archives contain the executable without
+an extension.
+
 ### [`screenshot`](https://github.com/Devolutions/IronRDP/blob/master/crates/ironrdp/examples/screenshot.rs)
 
 Example of utilizing IronRDP in a blocking, synchronous fashion.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ Each release provides one `.tar.gz` archive and a SHA-256 sidecar for these nati
 | macOS x64 | `x86_64-apple-darwin` |
 | macOS ARM64 | `aarch64-apple-darwin` |
 
+Linux archives use an Ubuntu 22.04 build baseline and require glibc 2.35 or later. macOS archives
+target macOS 10.13 or later on Intel and macOS 11.0 or later on Apple Silicon.
+
 For example, download and extract the Linux x64 agent from its release:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -28,39 +28,6 @@ It is built on top of the reusable [`ironrdp-client`](https://github.com/Devolut
 cargo run --bin ironrdp-viewer -- <HOSTNAME> --username <USERNAME> --password <PASSWORD>
 ```
 
-## Binary releases
-
-Standalone archives are attached to GitHub Releases for the executable packages:
-
-- [`ironrdp-agent`](./crates/ironrdp-agent) provides the agentic, daemon-backed CLI.
-- [`ironrdp-viewer`](./crates/ironrdp-viewer) provides the windowed RDP client CLI.
-
-Each release provides one `.tar.gz` archive and a SHA-256 sidecar for these native target triples:
-
-| Platform | Target triple |
-| --- | --- |
-| Windows x64 | `x86_64-pc-windows-msvc` |
-| Windows ARM64 | `aarch64-pc-windows-msvc` |
-| Linux x64 | `x86_64-unknown-linux-gnu` |
-| Linux ARM64 | `aarch64-unknown-linux-gnu` |
-| macOS x64 | `x86_64-apple-darwin` |
-| macOS ARM64 | `aarch64-apple-darwin` |
-
-For example, download and extract the Linux x64 agent from its release:
-
-```shell
-VERSION=<VERSION>
-ASSET="ironrdp-agent-${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
-curl -fLO "https://github.com/Devolutions/IronRDP/releases/download/ironrdp-agent-v${VERSION}/${ASSET}"
-curl -fLO "https://github.com/Devolutions/IronRDP/releases/download/ironrdp-agent-v${VERSION}/${ASSET}.sha256"
-sha256sum --check "${ASSET}.sha256"
-tar -xzf "${ASSET}"
-```
-
-Replace `ironrdp-agent` with `ironrdp-viewer` to download the windowed client from its corresponding
-package release. Windows archives contain an `.exe`; all other archives contain the executable without
-an extension.
-
 ### [`screenshot`](https://github.com/Devolutions/IronRDP/blob/master/crates/ironrdp/examples/screenshot.rs)
 
 Example of utilizing IronRDP in a blocking, synchronous fashion.
@@ -97,6 +64,39 @@ Alternatively, you may change a few group policies using `gpedit.msc`:
 4. Enable `Computer Configuration/Administrative Templates/Windows Components/Remote Desktop Services/Remote Desktop Session Host/Remote Session Environment/Limit maximum color depth`
 
 5. Reboot.
+
+## Binary releases
+
+Standalone archives are attached to GitHub Releases for the executable packages:
+
+- [`ironrdp-agent`](./crates/ironrdp-agent) provides the agentic, daemon-backed CLI.
+- [`ironrdp-viewer`](./crates/ironrdp-viewer) provides the windowed RDP client CLI.
+
+Each release provides one `.tar.gz` archive and a SHA-256 sidecar for these native target triples:
+
+| Platform | Target triple |
+| --- | --- |
+| Windows x64 | `x86_64-pc-windows-msvc` |
+| Windows ARM64 | `aarch64-pc-windows-msvc` |
+| Linux x64 | `x86_64-unknown-linux-gnu` |
+| Linux ARM64 | `aarch64-unknown-linux-gnu` |
+| macOS x64 | `x86_64-apple-darwin` |
+| macOS ARM64 | `aarch64-apple-darwin` |
+
+For example, download and extract the Linux x64 agent from its release:
+
+```shell
+VERSION=<VERSION>
+ASSET="ironrdp-agent-${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+curl -fLO "https://github.com/Devolutions/IronRDP/releases/download/ironrdp-agent-v${VERSION}/${ASSET}"
+curl -fLO "https://github.com/Devolutions/IronRDP/releases/download/ironrdp-agent-v${VERSION}/${ASSET}.sha256"
+sha256sum --check "${ASSET}.sha256"
+tar -xzf "${ASSET}"
+```
+
+Replace `ironrdp-agent` with `ironrdp-viewer` to download the windowed client from its corresponding
+package release. Windows archives contain an `.exe`; all other archives contain the executable without
+an extension.
 
 ## Rust version (MSRV)
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -9,6 +9,11 @@ release_commits = "^(feat|docs|fix|build|perf)"
 
 # Flagship crate for which we push a GitHub release.
 [[package]]
+name = "ironrdp-agent"
+git_release_enable = true
+publish = false # TODO: enable publishing when ready.
+
+[[package]]
 name = "ironrdp-viewer"
 git_release_enable = true
 publish = false # TODO: enable publishing when ready.


### PR DESCRIPTION
## Summary
- publish GitHub Release assets for `ironrdp-agent` and `ironrdp-viewer` Cargo release tags
- build native Windows, Linux, and macOS x64/ARM64 archives with SHA-256 sidecars
- document binary archive download and extraction

## Validation
- `actionlint .github/workflows/release-binaries.yml .github/workflows/release-crates.yml`
- `cargo +1.90.0 xtask check fmt -v`
- `cargo +1.90.0 xtask check locks -v`
- release builds and archive dry run for both executables