### PR TITLE
ci(xtask): add dependency-invariant guard for ironrdp-session

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,9 @@ jobs:
       - name: Lints
         run: cargo xtask check lints -v
 
+      - name: Dependencies
+        run: cargo xtask check dependencies -v
+
       - name: WASM (prepare)
         run: cargo xtask wasm install -v
 

--- a/xtask/src/check.rs
+++ b/xtask/src/check.rs
@@ -66,13 +66,19 @@ pub fn dependencies(sh: &Shell) -> anyhow::Result<()> {
             .output()?;
 
         let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let expected_no_match = format!("package ID specification `{banned}` did not match any packages");
 
         if output.status.success() && !stdout.trim().is_empty() {
             println!("Forbidden dependency edge: `{package}` depends on `{banned}`");
             print!("{stdout}");
             violations.push((package, banned));
-        } else {
+        } else if output.status.success() || stderr.contains(expected_no_match.as_str()) {
             println!("`{package}` has no dependency on `{banned}` (good)");
+        } else {
+            print!("{stdout}");
+            eprint!("{stderr}");
+            anyhow::bail!("failed to inspect dependency edge `{package}` -> `{banned}`");
         }
     }
 

--- a/xtask/src/check.rs
+++ b/xtask/src/check.rs
@@ -44,6 +44,47 @@ pub fn typos(sh: &Shell) -> anyhow::Result<()> {
     Ok(())
 }
 
+pub fn dependencies(sh: &Shell) -> anyhow::Result<()> {
+    let _s = Section::new("DEPENDENCIES");
+
+    // Dependency-graph invariants that must hold to keep crate boundaries slim.
+    // Each pair `(package, banned)` asserts that `package` has no transitive
+    // (non-dev) edge to `banned`, ensuring consumers can depend on the
+    // former without pulling in the latter’s graph.
+    const FORBIDDEN: &[(&str, &str)] = &[("ironrdp-session", "ironrdp-connector"), ("ironrdp-session", "sspi")];
+
+    let mut violations = Vec::new();
+
+    for &(package, banned) in FORBIDDEN {
+        // `cargo tree -i` inverts the graph to show what depends on `banned`,
+        // scoped to `package`’s subtree. When there is no such edge, cargo exits
+        // non-zero with a "did not match any packages" error; a successful,
+        // non-empty output means the forbidden edge is present.
+        let output = cmd!(sh, "{CARGO} tree -p {package} -e no-dev -i {banned}")
+            .ignore_status()
+            .quiet()
+            .output()?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        if output.status.success() && !stdout.trim().is_empty() {
+            println!("Forbidden dependency edge: `{package}` depends on `{banned}`");
+            print!("{stdout}");
+            violations.push((package, banned));
+        } else {
+            println!("`{package}` has no dependency on `{banned}` (good)");
+        }
+    }
+
+    if !violations.is_empty() {
+        anyhow::bail!("forbidden dependency edge(s) detected, see output above");
+    }
+
+    println!("All good!");
+
+    Ok(())
+}
+
 pub fn install(sh: &Shell) -> anyhow::Result<()> {
     let _s = Section::new("CHECK-INSTALL");
 

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -13,6 +13,7 @@ TASKS:
   check fmt               Check formatting
   check lints             Check lints
   check locks             Check for dirty or staged lock files not yet committed
+  check dependencies      Check dependency-graph invariants between crates
   check tests [--no-run]  Compile tests and, unless specified otherwise, run them
   check typos             Check for typos in the codebase
   check features          Run every feature-matrix case sequentially
@@ -80,6 +81,7 @@ pub enum Action {
     CheckFmt,
     CheckLints,
     CheckLocks,
+    CheckDependencies,
     CheckTests {
         no_run: bool,
     },
@@ -132,6 +134,7 @@ pub fn parse_args() -> anyhow::Result<Args> {
                 Some("fmt") => Action::CheckFmt,
                 Some("lints") => Action::CheckLints,
                 Some("locks") => Action::CheckLocks,
+                Some("dependencies") => Action::CheckDependencies,
                 Some("tests") => Action::CheckTests {
                     no_run: args.contains("--no-run"),
                 },

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -61,6 +61,7 @@ fn main() -> anyhow::Result<()> {
         Action::CheckFmt => check::fmt(&sh)?,
         Action::CheckLints => check::lints(&sh)?,
         Action::CheckLocks => check::lock_files(&sh)?,
+        Action::CheckDependencies => check::dependencies(&sh)?,
         Action::CheckTests { no_run } => {
             if no_run {
                 check::tests_compile(&sh)?;
@@ -93,6 +94,7 @@ fn main() -> anyhow::Result<()> {
             check::tests_run(&sh)?;
             check::lints(&sh)?;
             features::run_all(&sh)?;
+            check::dependencies(&sh)?;
             wasm::check(&sh)?;
             fuzz::run(&sh, None, None)?;
             web::install(&sh)?;


### PR DESCRIPTION
Add `cargo xtask check dependencies`, asserting `ironrdp-session` has no transitive (non-dev) edge to `ironrdp-connector` or `sspi`. Each forbidden `(package, banned)` pair is checked via `cargo tree -p <pkg> -e no-dev -i <banned>`: a successful, non-empty output means the edge is present and fails the check.

This locks the invariant introduced in #1423 so decode-only consumers can depend on `ironrdp-session` alone with the slim graph, without it regressing.

The guard runs in the CI `checks` job and is included in the `ci` sweep.

Closes #1424