### PR TITLE
feat(agent): add durable NOW operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2416,6 +2416,7 @@ name = "ironrdp-agent"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "clap",
  "ironrdp-cfg",
  "ironrdp-client",
@@ -2427,6 +2428,7 @@ dependencies = [
  "libc",
  "now-proto-pdu",
  "png",
+ "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,7 +1609,7 @@ dependencies = [
  "embed-resource",
  "ironrdp",
  "ironrdp-cliprdr-native",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-dvc-pipe-proxy",
  "ironrdp-rdcleanpath",
  "sspi",
@@ -2376,7 +2376,7 @@ dependencies = [
  "ironrdp-cliprdr",
  "ironrdp-cliprdr-native",
  "ironrdp-connector",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-displaycontrol",
  "ironrdp-dvc",
  "ironrdp-echo",
@@ -2405,7 +2405,7 @@ version = "0.10.0"
 dependencies = [
  "ironrdp-async",
  "ironrdp-connector",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-pdu",
  "ironrdp-svc",
  "tracing",
@@ -2419,12 +2419,13 @@ dependencies = [
  "clap",
  "ironrdp-cfg",
  "ironrdp-client",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-input",
  "ironrdp-pdu",
  "ironrdp-propertyset",
  "ironrdp-rdpfile",
  "libc",
+ "now-proto-pdu",
  "png",
  "tokio",
  "tracing",
@@ -2437,7 +2438,7 @@ name = "ironrdp-ainput"
 version = "0.8.0"
 dependencies = [
  "bitflags 2.13.0",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-dvc",
  "num-derive",
  "num-traits",
@@ -2449,7 +2450,7 @@ version = "0.10.0"
 dependencies = [
  "bytes",
  "ironrdp-connector",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-pdu",
  "tracing",
 ]
@@ -2470,7 +2471,7 @@ version = "0.10.0"
 dependencies = [
  "bytes",
  "ironrdp-connector",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-pdu",
  "tracing",
 ]
@@ -2499,7 +2500,7 @@ dependencies = [
  "ironrdp-cliprdr",
  "ironrdp-cliprdr-native",
  "ironrdp-connector",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-displaycontrol",
  "ironrdp-dvc",
  "ironrdp-dvc-com-plugin",
@@ -2530,7 +2531,7 @@ name = "ironrdp-cliprdr"
 version = "0.7.0"
 dependencies = [
  "bitflags 2.13.0",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-pdu",
  "ironrdp-svc",
  "tracing",
@@ -2541,7 +2542,7 @@ dependencies = [
 name = "ironrdp-cliprdr-format"
 version = "0.2.0"
 dependencies = [
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "png",
 ]
 
@@ -2550,7 +2551,7 @@ name = "ironrdp-cliprdr-native"
 version = "0.7.0"
 dependencies = [
  "ironrdp-cliprdr",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "tracing",
  "windows",
 ]
@@ -2559,8 +2560,8 @@ dependencies = [
 name = "ironrdp-connector"
 version = "0.10.0"
 dependencies = [
- "ironrdp-core",
- "ironrdp-error",
+ "ironrdp-core 0.2.1",
+ "ironrdp-error 0.2.0",
  "ironrdp-pdu",
  "ironrdp-svc",
  "picky",
@@ -2574,16 +2575,25 @@ dependencies = [
 
 [[package]]
 name = "ironrdp-core"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2db60a59716a84d09040d29c9e75e81545842510fccb0934c09b28e78b46680"
+dependencies = [
+ "ironrdp-error 0.1.3",
+]
+
+[[package]]
+name = "ironrdp-core"
 version = "0.2.1"
 dependencies = [
- "ironrdp-error",
+ "ironrdp-error 0.2.0",
 ]
 
 [[package]]
 name = "ironrdp-displaycontrol"
 version = "0.8.0"
 dependencies = [
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-dvc",
  "ironrdp-pdu",
  "ironrdp-svc",
@@ -2594,7 +2604,7 @@ dependencies = [
 name = "ironrdp-dvc"
 version = "0.8.0"
 dependencies = [
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-pdu",
  "ironrdp-svc",
  "tracing",
@@ -2604,7 +2614,7 @@ dependencies = [
 name = "ironrdp-dvc-com-plugin"
 version = "0.1.3"
 dependencies = [
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-dvc",
  "ironrdp-pdu",
  "ironrdp-svc",
@@ -2618,7 +2628,7 @@ name = "ironrdp-dvc-pipe-proxy"
 version = "0.5.0"
 dependencies = [
  "async-trait",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-dvc",
  "ironrdp-pdu",
  "ironrdp-svc",
@@ -2630,7 +2640,7 @@ dependencies = [
 name = "ironrdp-echo"
 version = "0.4.0"
 dependencies = [
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-dvc",
  "ironrdp-pdu",
  "tracing",
@@ -2643,13 +2653,19 @@ dependencies = [
  "arbitrary",
  "bit_field",
  "bitflags 2.13.0",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-dvc",
  "ironrdp-graphics",
  "ironrdp-pdu",
  "openh264",
  "tracing",
 ]
+
+[[package]]
+name = "ironrdp-error"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9d7794e854eef2f13fdf79c8502bcc567a75a15fd0522885f37739386a4cef"
 
 [[package]]
 name = "ironrdp-error"
@@ -2671,7 +2687,7 @@ dependencies = [
  "ironrdp-bulk",
  "ironrdp-cliprdr",
  "ironrdp-cliprdr-format",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-displaycontrol",
  "ironrdp-egfx",
  "ironrdp-graphics",
@@ -2692,7 +2708,7 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "expect-test",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-pdu",
  "num-derive",
  "num-traits",
@@ -2718,8 +2734,8 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "ironrdp-core",
- "ironrdp-error",
+ "ironrdp-core 0.2.1",
+ "ironrdp-error 0.2.0",
  "ironrdp-tls",
  "log",
  "tokio",
@@ -2745,8 +2761,8 @@ dependencies = [
  "byteorder",
  "der-parser",
  "expect-test",
- "ironrdp-core",
- "ironrdp-error",
+ "ironrdp-core 0.2.1",
+ "ironrdp-error 0.2.0",
  "md-5 0.10.6",
  "num-bigint 0.4.8",
  "num-derive",
@@ -2778,8 +2794,8 @@ name = "ironrdp-rdpdr"
 version = "0.7.0"
 dependencies = [
  "bitflags 2.13.0",
- "ironrdp-core",
- "ironrdp-error",
+ "ironrdp-core 0.2.1",
+ "ironrdp-error 0.2.0",
  "ironrdp-pdu",
  "ironrdp-svc",
  "tracing",
@@ -2789,7 +2805,7 @@ dependencies = [
 name = "ironrdp-rdpdr-native"
 version = "0.7.0"
 dependencies = [
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-pdu",
  "ironrdp-rdpdr",
  "ironrdp-svc",
@@ -2801,7 +2817,7 @@ dependencies = [
 name = "ironrdp-rdpeusb"
 version = "0.1.0"
 dependencies = [
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-dvc",
  "ironrdp-pdu",
  "ironrdp-str",
@@ -2819,7 +2835,7 @@ name = "ironrdp-rdpsnd"
 version = "0.9.0"
 dependencies = [
  "bitflags 2.13.0",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-pdu",
  "ironrdp-svc",
  "tracing",
@@ -2833,7 +2849,7 @@ dependencies = [
  "anyhow",
  "bytemuck",
  "cpal",
- "ironrdp-error",
+ "ironrdp-error 0.2.0",
  "ironrdp-rdpsnd",
  "opus2",
  "tracing",
@@ -2851,7 +2867,7 @@ dependencies = [
  "ironrdp-ainput",
  "ironrdp-async",
  "ironrdp-cliprdr",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-displaycontrol",
  "ironrdp-dvc",
  "ironrdp-echo",
@@ -2878,10 +2894,10 @@ name = "ironrdp-session"
 version = "0.11.0"
 dependencies = [
  "ironrdp-bulk",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-displaycontrol",
  "ironrdp-dvc",
- "ironrdp-error",
+ "ironrdp-error 0.2.0",
  "ironrdp-graphics",
  "ironrdp-pdu",
  "ironrdp-svc",
@@ -2899,7 +2915,7 @@ name = "ironrdp-str"
 version = "0.1.1"
 dependencies = [
  "bytemuck",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
 ]
 
 [[package]]
@@ -2907,7 +2923,7 @@ name = "ironrdp-svc"
 version = "0.8.0"
 dependencies = [
  "bitflags 2.13.0",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-pdu",
 ]
 
@@ -2925,7 +2941,7 @@ dependencies = [
  "ironrdp-cliprdr",
  "ironrdp-cliprdr-format",
  "ironrdp-connector",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-displaycontrol",
  "ironrdp-dvc",
  "ironrdp-echo",
@@ -2964,7 +2980,7 @@ dependencies = [
  "ironrdp-agent",
  "ironrdp-async",
  "ironrdp-client",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-input",
  "ironrdp-propertyset",
  "ironrdp-tls",
@@ -3040,7 +3056,7 @@ dependencies = [
  "iron-remote-desktop",
  "ironrdp",
  "ironrdp-cliprdr-format",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-futures",
  "ironrdp-pdu",
  "ironrdp-propertyset",
@@ -3490,6 +3506,18 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "now-proto-pdu"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bc774bac11db918c7a66a05e26771567f0968e0e0bf69c116fa8a5ae91f06b8"
+dependencies = [
+ "bitflags 2.13.0",
+ "ironrdp-core 0.1.5",
+ "ironrdp-error 0.1.3",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/ironrdp-agent/Cargo.toml
+++ b/crates/ironrdp-agent/Cargo.toml
@@ -43,6 +43,8 @@ tokio = { version = "1", features = ["rt-multi-thread", "net", "sync", "macros",
 
 # CLI
 clap = { version = "4.6", features = ["derive", "cargo"] }
+base64 = "0.22"
+serde_json = "1"
 
 # Logging (ring-buffer tracing layer)
 tracing = "0.1"

--- a/crates/ironrdp-agent/Cargo.toml
+++ b/crates/ironrdp-agent/Cargo.toml
@@ -27,7 +27,7 @@ internal = []
 
 [dependencies]
 # RDP client engine: only the TLS backend is mandated
-ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["rustls"] }
+ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["rustls", "dvc-pipe-proxy"] }
 
 # Configuration model and codecs
 ironrdp-core = { path = "../ironrdp-core", version = "0.2", features = ["alloc"] }
@@ -36,6 +36,7 @@ ironrdp-propertyset = { path = "../ironrdp-propertyset", version = "0.1" }
 ironrdp-cfg = { path = "../ironrdp-cfg", version = "0.1" }
 ironrdp-rdpfile = { path = "../ironrdp-rdpfile", version = "0.1" }
 ironrdp-input = { path = "../ironrdp-input", version = "0.7" }
+now-proto-pdu = { version = "0.4.3", features = ["std"] }
 
 # Async runtime and IPC transport
 tokio = { version = "1", features = ["rt-multi-thread", "net", "sync", "macros", "io-util", "time", "signal"] }

--- a/crates/ironrdp-agent/README.md
+++ b/crates/ironrdp-agent/README.md
@@ -49,9 +49,11 @@ ironrdp-agent now capabilities
 ironrdp-agent now powershell '$PSVersionTable.PSVersion'
 ironrdp-agent now pwsh --directory C:\work --timeout 60 '$PSVersionTable.PSVersion'
 ironrdp-agent now pwsh --file ./script.ps1 --stdin ./input.bin
-ironrdp-agent now exec process C:\Tools\tool.exe --parameters '--json'
+ironrdp-agent now exec process C:\Tools\tool.exe --arg '--json' --arg 'value with spaces'
 ironrdp-agent now exec shell 'uname -a'
 ironrdp-agent now exec batch 'dir /b'
+ironrdp-agent now list --format json
+ironrdp-agent now attach 42 --after-sequence 17 --format ndjson
 ```
 
 `now capabilities` waits for the NOW DVC and prints the protocol version, named system/session
@@ -63,9 +65,26 @@ execution operations. Each command is capability-gated before it is sent.
 `powershell` and `pwsh` accept an inline command or a UTF-8 `--file` script. They use `-NoProfile`
 and `-NonInteractive` by default; use `--profile` and/or `--interactive` to opt out. All tracked
 execution modes accept `--directory`, `--timeout SECONDS`, `--stdin PATH` (or `--stdin -` for raw
-local stdin), and `--operation-id-file PATH`. Standard output and standard error are forwarded
+local stdin), and `--operation-id-file PATH`. `--stdin` buffers its complete source before
+execution; for live bounded input, start an operation, then pipe bytes into `now stdin ID` from a
+second CLI process. Standard output and standard error are forwarded
 unchanged, as individual byte chunks, to the matching local stream. A nonzero remote exit code from
 1 through 255 becomes the CLI process exit status; wider nonzero remote codes map to 255.
+
+NOW operations are daemon-owned, so losing a CLI connection does not terminate the remote process.
+Use `now list`, `now status ID`, and `now attach ID [--after-sequence N]` to inspect, replay bounded
+output, and continue following a running operation. Each operation retains at most 8 MiB of output;
+the daemon retains at most 32 completed records and 32 MiB total retained output, evicting the
+oldest terminal records first. Crossing an operation limit requests normal NOW cancellation rather
+than growing daemon memory without bound. Live stdin is fragmented into 64 KiB messages and retries
+explicit protocol backpressure. `now diagnostics` reports the local DVC endpoint, active operation,
+readiness deadlines, and these bounds.
+
+The default `--format text` preserves raw stdout and stderr bytes. Use `--format json` for one-shot
+NOW queries, or `--format ndjson` for streaming execution/attachment: every object has
+`schema: "ironrdp-agent.now.v1"` and output bytes are carried in `data_base64` with an operation
+sequence number. IPC failures include a stable category such as `not_found`, `session_not_ready`,
+`capability_unavailable`, `timeout`, or `cancelled`, plus human-readable detail.
 
 The CLI forwards the exit code carried by the terminal NOW result; it does not reinterpret a
 PowerShell script's `exit` statement. A remote NOW implementation can map script failures before
@@ -77,9 +96,10 @@ Output is not aggregated for the CLI, so long-running operations are not constra
 `--timeout` requests normal protocol cancellation with `NOW_EXEC_CANCEL_REQ` when the duration
 expires. To cancel a command from another process, supply `--operation-id-file PATH` and run
 `ironrdp-agent now cancel <OPERATION_ID>`. Cancellation waits for the remote terminal result to keep
-the NOW byte stream synchronized. `--detached` is explicit, cannot be combined with stdin or a
-timeout, and returns once the request has been written; it has no remote output or exit-status
-tracking.
+the NOW byte stream synchronized. The execution CLI also turns Ctrl-C into this same cancellation
+request and continues draining until its terminal result. `--detached` is explicit, cannot be
+combined with stdin or a timeout, and returns once the request has been written; it has no remote
+output or exit-status tracking.
 
 If the remote session does not open `Devolutions::Now::Agent`, the first command waits at most 30
 seconds for its local DVC proxy endpoint, allowing delayed post-logon channel startup, then exits

--- a/crates/ironrdp-agent/README.md
+++ b/crates/ironrdp-agent/README.md
@@ -9,7 +9,8 @@ The single `ironrdp-agent` binary bundles two roles:
   serves requests over a local IPC transport (a Unix domain socket on Unix, a named pipe on
   Windows).
 - **CLI** (`ironrdp-agent <op> …`): a short-lived invocation that opens the IPC endpoint, sends a
-  single request, prints the response, and exits.
+  request, prints the response, and exits. NOW execution keeps its local connection open to
+  forward raw output chunks until the remote operation reaches a terminal result.
 
 Run `ironrdp-agent --help-agent` for a structured, machine-readable description of every operation.
 
@@ -38,6 +39,52 @@ The daemon never exposes secrets to the IPC reader. `ConfigBuilder::build` strip
 token, …) before producing the `Config`, and the daemon seeds its live property bag from that
 post-build configuration. Secrets therefore never reach the live bag, so property dumps, status,
 and logs cannot leak them — no separate redaction pass is needed.
+
+## Remote NOW execution
+
+After connecting, run a command through the remote Devolutions NOW agent:
+
+```text
+ironrdp-agent now capabilities
+ironrdp-agent now powershell '$PSVersionTable.PSVersion'
+ironrdp-agent now pwsh --directory C:\work --timeout 60 '$PSVersionTable.PSVersion'
+ironrdp-agent now pwsh --file ./script.ps1 --stdin ./input.bin
+ironrdp-agent now exec process C:\Tools\tool.exe --parameters '--json'
+ironrdp-agent now exec shell 'uname -a'
+ironrdp-agent now exec batch 'dir /b'
+```
+
+`now capabilities` waits for the NOW DVC and prints the protocol version, named system/session
+capabilities, and the execution capability intersection available to IronRDP Agent. It is the
+recommended preflight for automation. The system and session entries are discovery-only in this
+release; `powershell`, `pwsh`, `exec process`, `exec shell`, and `exec batch` are the exposed
+execution operations. Each command is capability-gated before it is sent.
+
+`powershell` and `pwsh` accept an inline command or a UTF-8 `--file` script. They use `-NoProfile`
+and `-NonInteractive` by default; use `--profile` and/or `--interactive` to opt out. All tracked
+execution modes accept `--directory`, `--timeout SECONDS`, `--stdin PATH` (or `--stdin -` for raw
+local stdin), and `--operation-id-file PATH`. Standard output and standard error are forwarded
+unchanged, as individual byte chunks, to the matching local stream. A nonzero remote exit code from
+1 through 255 becomes the CLI process exit status; wider nonzero remote codes map to 255.
+
+The CLI forwards the exit code carried by the terminal NOW result; it does not reinterpret a
+PowerShell script's `exit` statement. A remote NOW implementation can map script failures before
+returning its result code.
+
+Output is not aggregated for the CLI, so long-running operations are not constrained by the former
+15 MiB aggregate response limit. Each individual local IPC and NOW frame remains bounded at 16 MiB.
+
+`--timeout` requests normal protocol cancellation with `NOW_EXEC_CANCEL_REQ` when the duration
+expires. To cancel a command from another process, supply `--operation-id-file PATH` and run
+`ironrdp-agent now cancel <OPERATION_ID>`. Cancellation waits for the remote terminal result to keep
+the NOW byte stream synchronized. `--detached` is explicit, cannot be combined with stdin or a
+timeout, and returns once the request has been written; it has no remote output or exit-status
+tracking.
+
+If the remote session does not open `Devolutions::Now::Agent`, the first command waits at most 30
+seconds for its local DVC proxy endpoint, allowing delayed post-logon channel startup, then exits
+with an error. Later reconnects wait at most 10 seconds. The daemon remains available for `status`
+and `disconnect` while either wait is in progress.
 
 ## Preloaded overlay
 

--- a/crates/ironrdp-agent/src/cli.rs
+++ b/crates/ironrdp-agent/src/cli.rs
@@ -12,16 +12,20 @@
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
 use core::str::FromStr;
-use std::io::{Read as _, Write as _};
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::Context as _;
+use base64::Engine as _;
 use clap::{Args, CommandFactory as _, Parser, Subcommand, ValueEnum};
 use ironrdp_cfg::{PropertySetExt as _, TargetAddr};
 use ironrdp_input::MouseButton;
 use ironrdp_propertyset::{PropertySet, Value};
 
-use crate::ipc::{KeyFilter, NowExecutionKind, NowExecutionRequest, NowStream, Payload, PropValue, Request, Response};
+use crate::ipc::{
+    KeyFilter, NowDiagnostics, NowExecutionKind, NowExecutionRequest, NowOperationInfo, NowOperationState, NowStream,
+    Payload, PropValue, Request, Response,
+};
 use crate::transport::{self, Endpoint};
 
 /// IronRDP agent: a CLI-driven, daemon-backed RDP client.
@@ -35,6 +39,10 @@ pub struct Cli {
     /// Override the IPC endpoint (defaults to the per-user socket/pipe).
     #[arg(long, global = true)]
     endpoint: Option<String>,
+
+    /// Render NOW responses as text (default), JSON snapshots, or streaming NDJSON.
+    #[arg(long, global = true, value_enum, default_value_t = NowOutputFormat::Text)]
+    format: NowOutputFormat,
 
     #[command(subcommand)]
     command: Option<Command>,
@@ -187,8 +195,33 @@ enum NowCommand {
     Capabilities,
     /// Request normal cancellation of a streamed NOW operation.
     Cancel {
-        /// Operation ID emitted through --operation-id-file.
+        /// Operation ID emitted when execution starts.
         operation_id: u64,
+    },
+    /// List daemon-owned NOW operations, including retained-output and terminal metadata.
+    List,
+    /// Show the durable state and result metadata for one NOW operation.
+    Status {
+        /// Locally assigned NOW operation ID.
+        operation_id: u64,
+    },
+    /// Replay retained output after a sequence and continue until the operation finishes.
+    Attach {
+        /// Locally assigned NOW operation ID.
+        operation_id: u64,
+        /// Do not replay events at or below this operation-local sequence number.
+        #[arg(long, default_value_t = 0)]
+        after_sequence: u64,
+    },
+    /// Show local DVC endpoint readiness and operation-manager limits.
+    Diagnostics,
+    /// Stream local input to a running NOW operation without buffering it in the command that started it.
+    Stdin {
+        /// Locally assigned NOW operation ID.
+        operation_id: u64,
+        /// Read input from PATH instead of this command's standard input.
+        #[arg(long, value_name = "PATH")]
+        file: Option<PathBuf>,
     },
     /// Execute with Windows PowerShell 5 (`powershell.exe`).
     Powershell(NowPowerShellArgs),
@@ -224,7 +257,8 @@ struct NowExecutionOptions {
     /// Cancel after this many seconds.
     #[arg(long, value_name = "SECONDS")]
     timeout: Option<u32>,
-    /// Read raw bytes from PATH and forward them to the remote standard input. Use `-` for local stdin.
+    /// Buffer raw bytes from PATH and forward them after the operation starts. Use `-` for local
+    /// stdin. For live, bounded input to a separately started operation, use `now stdin`.
     #[arg(long, value_name = "PATH")]
     stdin: Option<PathBuf>,
     /// Start without waiting for a remote result or receiving redirected output.
@@ -255,9 +289,13 @@ enum NowExecCommand {
 struct NowProcessArgs {
     /// Executable path.
     filename: String,
-    /// Command-line parameters passed to the executable.
-    #[arg(long)]
+    /// Raw command-line parameters passed to the executable. Mutually exclusive with `--arg`.
+    #[arg(long, conflicts_with = "arg")]
     parameters: Option<String>,
+    /// One Windows command-line argument. Repeat to build `--parameters` using deterministic
+    /// CreateProcess-compatible quoting. The remote program still owns final argument parsing.
+    #[arg(long, conflicts_with = "parameters")]
+    arg: Vec<String>,
     #[command(flatten)]
     execution: NowExecutionOptions,
 }
@@ -265,7 +303,11 @@ struct NowProcessArgs {
 #[derive(Args, Debug)]
 struct NowShellArgs {
     /// Shell command text.
-    command: String,
+    #[arg(required_unless_present = "file", conflicts_with = "file")]
+    command: Option<String>,
+    /// Read UTF-8 shell command text from PATH instead of the positional command.
+    #[arg(long, value_name = "PATH", conflicts_with = "command")]
+    file: Option<PathBuf>,
     /// Optional remote shell executable.
     #[arg(long)]
     shell: Option<String>,
@@ -276,7 +318,11 @@ struct NowShellArgs {
 #[derive(Args, Debug)]
 struct NowBatchArgs {
     /// Batch command text.
-    command: String,
+    #[arg(required_unless_present = "file", conflicts_with = "file")]
+    command: Option<String>,
+    /// Read UTF-8 batch command text from PATH instead of the positional command.
+    #[arg(long, value_name = "PATH", conflicts_with = "command")]
+    file: Option<PathBuf>,
     #[command(flatten)]
     execution: NowExecutionOptions,
 }
@@ -288,6 +334,17 @@ enum CliMouseButton {
     Right,
     X1,
     X2,
+}
+
+#[derive(Clone, Copy, Debug, Default, ValueEnum)]
+enum NowOutputFormat {
+    /// Human-oriented output; execution writes remote stdout/stderr bytes unchanged.
+    #[default]
+    Text,
+    /// One JSON object for a non-streaming NOW query.
+    Json,
+    /// One JSON object per NOW lifecycle/output event.
+    Ndjson,
 }
 
 impl CliMouseButton {
@@ -364,6 +421,7 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
         return Ok(());
     }
 
+    let format = cli.format;
     let endpoint = endpoint_from_arg(cli.endpoint);
 
     let Some(command) = cli.command else {
@@ -394,7 +452,7 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
             let response = transport::send_request(&endpoint, &Request::Screenshot).await?;
             let payload = match response {
                 Response::Ok(payload) => payload,
-                Response::Err(message) => anyhow::bail!("{message}"),
+                Response::Err(error) => anyhow::bail!("{}", error.message),
             };
             let Payload::Screenshot { width, height, png } = payload else {
                 anyhow::bail!("unexpected response to screenshot request");
@@ -413,11 +471,32 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
         Command::Resize { width, height } => Request::Resize { width, height },
         Command::Now(args) => {
             return match args.command {
-                NowCommand::Capabilities => {
-                    print_response(transport::send_request(&endpoint, &Request::NowCapabilities).await?)
-                }
-                NowCommand::Cancel { operation_id } => {
-                    print_response(transport::send_request(&endpoint, &Request::NowCancel { operation_id }).await?)
+                NowCommand::Capabilities => print_now_response(
+                    transport::send_request(&endpoint, &Request::NowCapabilities).await?,
+                    format,
+                ),
+                NowCommand::Cancel { operation_id } => print_now_response(
+                    transport::send_request(&endpoint, &Request::NowCancel { operation_id }).await?,
+                    format,
+                ),
+                NowCommand::List => print_now_response(
+                    transport::send_request(&endpoint, &Request::NowOperations).await?,
+                    format,
+                ),
+                NowCommand::Status { operation_id } => print_now_response(
+                    transport::send_request(&endpoint, &Request::NowOperationStatus { operation_id }).await?,
+                    format,
+                ),
+                NowCommand::Attach {
+                    operation_id,
+                    after_sequence,
+                } => execute_now_attachment(&endpoint, operation_id, after_sequence, format).await,
+                NowCommand::Diagnostics => print_now_response(
+                    transport::send_request(&endpoint, &Request::NowDiagnostics).await?,
+                    format,
+                ),
+                NowCommand::Stdin { operation_id, file } => {
+                    send_now_stdin(&endpoint, operation_id, file.as_deref(), format).await
                 }
                 NowCommand::Powershell(args) => {
                     let command = read_powershell_command(args.command, args.file)?;
@@ -435,6 +514,7 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
                             stdin: read_standard_input(args.execution.stdin.as_deref())?,
                         },
                         args.execution.operation_id_file.as_deref(),
+                        format,
                     )
                     .await
                 }
@@ -454,21 +534,30 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
                             stdin: read_standard_input(args.execution.stdin.as_deref())?,
                         },
                         args.execution.operation_id_file.as_deref(),
+                        format,
                     )
                     .await
                 }
                 NowCommand::Exec(NowExecArgs { command }) => {
                     let (kind, command, parameters, execution) = match command {
-                        NowExecCommand::Process(args) => (
-                            NowExecutionKind::Process,
-                            args.filename,
-                            args.parameters,
+                        NowExecCommand::Process(args) => {
+                            let parameters = args
+                                .parameters
+                                .or_else(|| (!args.arg.is_empty()).then(|| windows_command_line(&args.arg)));
+                            (NowExecutionKind::Process, args.filename, parameters, args.execution)
+                        }
+                        NowExecCommand::Shell(args) => (
+                            NowExecutionKind::Shell,
+                            read_powershell_command(args.command, args.file)?,
+                            args.shell,
                             args.execution,
                         ),
-                        NowExecCommand::Shell(args) => {
-                            (NowExecutionKind::Shell, args.command, args.shell, args.execution)
-                        }
-                        NowExecCommand::Batch(args) => (NowExecutionKind::Batch, args.command, None, args.execution),
+                        NowExecCommand::Batch(args) => (
+                            NowExecutionKind::Batch,
+                            read_powershell_command(args.command, args.file)?,
+                            None,
+                            args.execution,
+                        ),
                     };
                     execute_now(
                         &endpoint,
@@ -484,6 +573,7 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
                             stdin: read_standard_input(execution.stdin.as_deref())?,
                         },
                         execution.operation_id_file.as_deref(),
+                        format,
                     )
                     .await
                 }
@@ -586,7 +676,7 @@ fn print_response(response: Response) -> anyhow::Result<()> {
             print_payload(payload);
             Ok(())
         }
-        Response::Err(message) => anyhow::bail!("{message}"),
+        Response::Err(error) => anyhow::bail!("{}", error.message),
     }
 }
 
@@ -594,7 +684,7 @@ fn print_response(response: Response) -> anyhow::Result<()> {
 fn write_powershell_response(response: Response) -> anyhow::Result<()> {
     let payload = match response {
         Response::Ok(payload) => payload,
-        Response::Err(message) => anyhow::bail!("{message}"),
+        Response::Err(error) => anyhow::bail!("{}", error.message),
     };
     let Payload::PowerShell {
         stdout,
@@ -636,58 +726,457 @@ fn read_standard_input(path: Option<&Path>) -> anyhow::Result<Option<Vec<u8>>> {
         stdin.read_to_end(&mut bytes).context("read local standard input")?;
         return Ok(Some(bytes));
     }
+
     std::fs::read(path)
         .map(Some)
         .with_context(|| format!("read NOW standard input {}", path.display()))
+}
+
+/// Builds a Windows command line from explicitly delimited arguments. This follows the
+/// `CommandLineToArgvW` backslash/quote rules used by common Windows C runtimes; callers that need
+/// shell-specific syntax must use the explicit `--parameters` string instead.
+fn windows_command_line(arguments: &[String]) -> String {
+    arguments
+        .iter()
+        .map(|argument| {
+            if !argument.is_empty() && !argument.bytes().any(|byte| matches!(byte, b' ' | b'\t' | b'"')) {
+                return argument.clone();
+            }
+            let mut quoted = String::with_capacity(argument.len() + 2);
+            quoted.push('"');
+            let mut backslashes = 0;
+            for character in argument.chars() {
+                if character == '\\' {
+                    backslashes += 1;
+                } else if character == '"' {
+                    quoted.extend(core::iter::repeat_n('\\', backslashes * 2 + 1));
+                    quoted.push('"');
+                    backslashes = 0;
+                } else {
+                    quoted.extend(core::iter::repeat_n('\\', backslashes));
+                    quoted.push(character);
+                    backslashes = 0;
+                }
+            }
+            quoted.extend(core::iter::repeat_n('\\', backslashes * 2));
+            quoted.push('"');
+            quoted
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+async fn send_now_stdin(
+    endpoint: &Endpoint,
+    operation_id: u64,
+    file: Option<&Path>,
+    format: NowOutputFormat,
+) -> anyhow::Result<()> {
+    let mut source: Box<dyn Read> = match file {
+        Some(path) => {
+            Box::new(std::fs::File::open(path).with_context(|| format!("open NOW standard input {}", path.display()))?)
+        }
+        None => Box::new(std::io::stdin()),
+    };
+    let mut buffer = vec![0; 64 * 1024];
+    loop {
+        let count = source.read(&mut buffer).context("read local standard input")?;
+        if count == 0 {
+            send_now_stdin_chunk(endpoint, operation_id, Vec::new(), true).await?;
+            if matches!(format, NowOutputFormat::Ndjson) {
+                print_ndjson(serde_json::json!({
+                    "schema": "ironrdp-agent.now.v1",
+                    "type": "stdin_closed",
+                    "operation_id": operation_id,
+                }))?;
+            }
+            return Ok(());
+        }
+        send_now_stdin_chunk(endpoint, operation_id, buffer[..count].to_vec(), false).await?;
+    }
+}
+
+async fn send_now_stdin_chunk(endpoint: &Endpoint, operation_id: u64, data: Vec<u8>, last: bool) -> anyhow::Result<()> {
+    loop {
+        let response = transport::send_request(
+            endpoint,
+            &Request::NowWriteStdin {
+                operation_id,
+                data: data.clone(),
+                last,
+            },
+        )
+        .await?;
+        match response {
+            Response::Ok(Payload::NowStdinAccepted { .. }) => return Ok(()),
+            Response::Err(error) if error.message.contains("backpressured") => {
+                tokio::time::sleep(core::time::Duration::from_millis(10)).await;
+            }
+            Response::Err(error) => anyhow::bail!("{}", error.message),
+            Response::Ok(payload) => anyhow::bail!("unexpected response to NOW standard input: {payload:?}"),
+        }
+    }
 }
 
 async fn execute_now(
     endpoint: &Endpoint,
     request: NowExecutionRequest,
     operation_id_file: Option<&Path>,
+    format: NowOutputFormat,
 ) -> anyhow::Result<()> {
-    let mut exit_code = None;
-    transport::send_streaming_request(endpoint, &Request::NowExecute(request), |response| match response {
-        Response::Err(message) => anyhow::bail!("{message}"),
-        Response::Ok(Payload::NowExecutionStarted { operation_id }) => {
-            if let Some(path) = operation_id_file {
-                std::fs::write(path, operation_id.to_string())
-                    .with_context(|| format!("write NOW operation ID {}", path.display()))?;
-            }
-            Ok(false)
-        }
-        Response::Ok(Payload::NowExecutionData {
-            stream: NowStream::Stdout,
-            data,
-            ..
-        }) => {
-            std::io::stdout().write_all(&data).context("write remote stdout")?;
-            std::io::stdout().flush().context("flush remote stdout")?;
-            Ok(false)
-        }
-        Response::Ok(Payload::NowExecutionData {
-            stream: NowStream::Stderr,
-            data,
-            ..
-        }) => {
-            std::io::stderr().write_all(&data).context("write remote stderr")?;
-            std::io::stderr().flush().context("flush remote stderr")?;
-            Ok(false)
-        }
-        Response::Ok(Payload::NowExecutionResult {
-            exit_code: result_exit_code,
-            ..
-        }) => {
-            exit_code = Some(result_exit_code);
-            Ok(true)
-        }
-        Response::Ok(payload) => anyhow::bail!("unexpected response to streamed NOW execution: {payload:?}"),
-    })
-    .await?;
+    if matches!(format, NowOutputFormat::Json) {
+        anyhow::bail!("NOW execution is streamed; use --format text or --format ndjson");
+    }
+    stream_now_request(endpoint, Request::NowExecute(request), operation_id_file, None, format).await
+}
 
-    let exit_code = exit_code.context("NOW execution ended without an exit code")?;
-    if exit_code != 0 {
-        return Err(RemoteExit { code: exit_code }.into());
+async fn execute_now_attachment(
+    endpoint: &Endpoint,
+    operation_id: u64,
+    after_sequence: u64,
+    format: NowOutputFormat,
+) -> anyhow::Result<()> {
+    if matches!(format, NowOutputFormat::Json) {
+        anyhow::bail!("NOW operation attachment is streamed; use --format text or --format ndjson");
+    }
+    stream_now_request(
+        endpoint,
+        Request::NowOperationAttach {
+            operation_id,
+            after_sequence,
+        },
+        None,
+        Some(operation_id),
+        format,
+    )
+    .await
+}
+
+async fn stream_now_request(
+    endpoint: &Endpoint,
+    request: Request,
+    operation_id_file: Option<&Path>,
+    known_operation_id: Option<u64>,
+    format: NowOutputFormat,
+) -> anyhow::Result<()> {
+    let mut stream = transport::connect(endpoint)
+        .await
+        .with_context(|| format!("connect to daemon at {endpoint}"))?;
+    transport::write_message(&mut stream, &request).await?;
+    let mut operation_id = known_operation_id;
+    let mut cancellation_requested = false;
+    let interrupt = tokio::signal::ctrl_c();
+    tokio::pin!(interrupt);
+
+    loop {
+        let response = tokio::select! {
+            response = transport::read_message(&mut stream) => response?,
+            _ = &mut interrupt, if !cancellation_requested && operation_id.is_some() => {
+                let operation_id = operation_id.expect("select guard checked operation ID");
+                let response = transport::send_request(endpoint, &Request::NowCancel { operation_id }).await?;
+                match response {
+                    Response::Ok(Payload::NowCancelAccepted { .. }) => {
+                        emit_now_control_event("cancellation_requested", operation_id, format)?;
+                    }
+                    Response::Err(error) => anyhow::bail!("{}", error.message),
+                    Response::Ok(payload) => anyhow::bail!("unexpected response to NOW cancellation: {payload:?}"),
+                }
+                cancellation_requested = true;
+                continue;
+            }
+        };
+        match response {
+            Response::Err(error) => {
+                if matches!(format, NowOutputFormat::Ndjson) {
+                    print_ndjson(serde_json::json!({
+                        "schema": "ironrdp-agent.now.v1",
+                        "type": "error",
+                        "code": error.code.as_str(),
+                        "message": error.message,
+                        "operation_id": operation_id,
+                    }))?;
+                }
+                anyhow::bail!("{}", error.message)
+            }
+            Response::Ok(Payload::NowExecutionStarted {
+                operation_id: started_id,
+            }) => {
+                operation_id = Some(started_id);
+                if let Some(path) = operation_id_file {
+                    std::fs::write(path, started_id.to_string())
+                        .with_context(|| format!("write NOW operation ID {}", path.display()))?;
+                }
+                emit_now_control_event("started", started_id, format)?;
+            }
+            Response::Ok(Payload::NowExecutionData {
+                operation_id,
+                sequence,
+                stream: NowStream::Stdout,
+                data,
+            }) => {
+                emit_now_data(operation_id, sequence, NowStream::Stdout, &data, format)?;
+            }
+            Response::Ok(Payload::NowExecutionData {
+                operation_id,
+                sequence,
+                stream: NowStream::Stderr,
+                data,
+            }) => {
+                emit_now_data(operation_id, sequence, NowStream::Stderr, &data, format)?;
+            }
+            Response::Ok(Payload::NowExecutionResult {
+                operation_id,
+                exit_code: result_exit_code,
+            }) => {
+                emit_now_result(operation_id, result_exit_code, format)?;
+                if result_exit_code != 0 {
+                    return Err(RemoteExit { code: result_exit_code }.into());
+                }
+                return Ok(());
+            }
+            Response::Ok(Payload::NowOperationInfo(info)) => {
+                print_now_info(&info, format)?;
+                if matches!(info.state, NowOperationState::Detached) {
+                    return Ok(());
+                }
+                anyhow::bail!("unexpected non-terminal NOW operation attachment response")
+            }
+            Response::Ok(payload) => anyhow::bail!("unexpected response to streamed NOW execution: {payload:?}"),
+        }
+    }
+}
+
+fn emit_now_control_event(kind: &str, operation_id: u64, format: NowOutputFormat) -> anyhow::Result<()> {
+    match format {
+        // Text execution remains byte-for-byte compatible: only remote stdout/stderr are emitted.
+        NowOutputFormat::Text => {}
+        NowOutputFormat::Ndjson => print_ndjson(serde_json::json!({
+            "schema": "ironrdp-agent.now.v1",
+            "type": kind,
+            "operation_id": operation_id,
+        }))?,
+        NowOutputFormat::Json => print_ndjson(serde_json::json!({
+            "schema": "ironrdp-agent.now.v1",
+            "type": kind,
+            "operation_id": operation_id,
+        }))?,
+    }
+    Ok(())
+}
+
+fn emit_now_data(
+    operation_id: u64,
+    sequence: u64,
+    stream: NowStream,
+    data: &[u8],
+    format: NowOutputFormat,
+) -> anyhow::Result<()> {
+    match format {
+        NowOutputFormat::Text => {
+            let output: &mut dyn Write = match stream {
+                NowStream::Stdout => &mut std::io::stdout(),
+                NowStream::Stderr => &mut std::io::stderr(),
+            };
+            output.write_all(data).context("write remote NOW output")?;
+            output.flush().context("flush remote NOW output")?;
+        }
+        NowOutputFormat::Ndjson => print_ndjson(now_data_json(operation_id, sequence, stream, data))?,
+        NowOutputFormat::Json => unreachable!("streaming mode rejects JSON"),
+    }
+    Ok(())
+}
+
+fn now_data_json(operation_id: u64, sequence: u64, stream: NowStream, data: &[u8]) -> serde_json::Value {
+    serde_json::json!({
+        "schema": "ironrdp-agent.now.v1",
+        "type": "data",
+        "operation_id": operation_id,
+        "sequence": sequence,
+        "stream": match stream { NowStream::Stdout => "stdout", NowStream::Stderr => "stderr" },
+        "data_base64": base64::engine::general_purpose::STANDARD.encode(data),
+    })
+}
+
+fn emit_now_result(operation_id: u64, exit_code: u32, format: NowOutputFormat) -> anyhow::Result<()> {
+    match format {
+        // Text execution remains byte-for-byte compatible: only remote stdout/stderr are emitted.
+        NowOutputFormat::Text => {}
+        NowOutputFormat::Ndjson => print_ndjson(serde_json::json!({
+            "schema": "ironrdp-agent.now.v1",
+            "type": "result",
+            "operation_id": operation_id,
+            "exit_code": exit_code,
+        }))?,
+        NowOutputFormat::Json => unreachable!("streaming mode rejects JSON"),
+    }
+    Ok(())
+}
+
+fn print_ndjson(value: serde_json::Value) -> anyhow::Result<()> {
+    println!("{}", serde_json::to_string(&value).context("serialize NOW NDJSON")?);
+    Ok(())
+}
+
+fn print_now_response(response: Response, format: NowOutputFormat) -> anyhow::Result<()> {
+    match response {
+        Response::Ok(payload) => print_now_payload(payload, format),
+        Response::Err(error) => {
+            if matches!(format, NowOutputFormat::Json | NowOutputFormat::Ndjson) {
+                print_ndjson(serde_json::json!({
+                    "schema": "ironrdp-agent.now.v1",
+                    "type": "error",
+                    "code": error.code.as_str(),
+                    "message": error.message,
+                }))?;
+            }
+            anyhow::bail!("{}", error.message)
+        }
+    }
+}
+
+fn print_now_payload(payload: Payload, format: NowOutputFormat) -> anyhow::Result<()> {
+    match payload {
+        Payload::NowCapabilities(capabilities) => match format {
+            NowOutputFormat::Text => print_now_capabilities(&capabilities),
+            NowOutputFormat::Json | NowOutputFormat::Ndjson => print_ndjson(serde_json::json!({
+                "schema": "ironrdp-agent.now.v1",
+                "type": "capabilities",
+                "version": { "major": capabilities.major, "minor": capabilities.minor },
+                "server": {
+                    "system_capset": capabilities.system_capset,
+                    "session_capset": capabilities.session_capset,
+                    "exec_capset": capabilities.server_exec_capset,
+                },
+                "agent_advertised_exec_capset": capabilities.client_exec_capset,
+                "agent_exposed_exec_capset": capabilities.exec_capset,
+                "heartbeat_secs": capabilities.heartbeat_secs,
+            }))?,
+        },
+        Payload::NowCancelAccepted { operation_id } => {
+            emit_now_control_event("cancellation_requested", operation_id, format)?
+        }
+        Payload::NowOperationInfo(info) => print_now_info(&info, format)?,
+        Payload::NowOperations(operations) => match format {
+            NowOutputFormat::Text => {
+                for info in &operations {
+                    print_now_info_text(info);
+                }
+            }
+            NowOutputFormat::Json | NowOutputFormat::Ndjson => {
+                let operations = operations.iter().map(now_operation_json).collect::<Vec<_>>();
+                print_ndjson(serde_json::json!({
+                    "schema": "ironrdp-agent.now.v1",
+                    "type": "operations",
+                    "operations": operations,
+                }))?;
+            }
+        },
+        Payload::NowDiagnostics(diagnostics) => print_now_diagnostics(&diagnostics, format)?,
+        Payload::NowStdinAccepted { operation_id, last } => {
+            if matches!(format, NowOutputFormat::Ndjson) {
+                print_ndjson(serde_json::json!({
+                    "schema": "ironrdp-agent.now.v1",
+                    "type": if last { "stdin_closed" } else { "stdin_accepted" },
+                    "operation_id": operation_id,
+                }))?;
+            }
+        }
+        payload => anyhow::bail!("unexpected response to NOW request: {payload:?}"),
+    }
+    Ok(())
+}
+
+fn print_now_info(info: &NowOperationInfo, format: NowOutputFormat) -> anyhow::Result<()> {
+    match format {
+        NowOutputFormat::Text => print_now_info_text(info),
+        NowOutputFormat::Json | NowOutputFormat::Ndjson => print_ndjson(serde_json::json!({
+            "schema": "ironrdp-agent.now.v1",
+            "type": "operation",
+            "operation": now_operation_json(info),
+        }))?,
+    }
+    Ok(())
+}
+
+fn print_now_info_text(info: &NowOperationInfo) {
+    println!("operation id: {}", info.operation_id);
+    println!("kind: {:?}", info.kind);
+    println!("state: {:?}", info.state);
+    println!("started unix ms: {}", info.started_unix_ms);
+    if let Some(finished) = info.finished_unix_ms {
+        println!("finished unix ms: {finished}");
+    }
+    if let Some(exit_code) = info.exit_code {
+        println!("exit code: {exit_code}");
+    }
+    if let Some(error) = &info.error {
+        println!("error: {error}");
+    }
+    println!("stdout bytes: {}", info.stdout_bytes);
+    println!("stderr bytes: {}", info.stderr_bytes);
+    println!("retained bytes: {}", info.retained_bytes);
+    println!("dropped bytes: {}", info.dropped_bytes);
+    println!("next sequence: {}", info.next_sequence);
+}
+
+fn now_operation_json(info: &NowOperationInfo) -> serde_json::Value {
+    serde_json::json!({
+        "operation_id": info.operation_id,
+        "kind": match info.kind {
+            NowExecutionKind::WindowsPowerShell => "powershell",
+            NowExecutionKind::PowerShell => "pwsh",
+            NowExecutionKind::Process => "process",
+            NowExecutionKind::Shell => "shell",
+            NowExecutionKind::Batch => "batch",
+        },
+        "state": match info.state {
+            NowOperationState::Running => "running",
+            NowOperationState::Cancelling => "cancelling",
+            NowOperationState::Succeeded => "succeeded",
+            NowOperationState::Failed => "failed",
+            NowOperationState::Cancelled => "cancelled",
+            NowOperationState::Detached => "detached",
+        },
+        "started_unix_ms": info.started_unix_ms,
+        "finished_unix_ms": info.finished_unix_ms,
+        "exit_code": info.exit_code,
+        "error": info.error,
+        "stdout_bytes": info.stdout_bytes,
+        "stderr_bytes": info.stderr_bytes,
+        "retained_bytes": info.retained_bytes,
+        "dropped_bytes": info.dropped_bytes,
+        "next_sequence": info.next_sequence,
+    })
+}
+
+fn print_now_diagnostics(diagnostics: &NowDiagnostics, format: NowOutputFormat) -> anyhow::Result<()> {
+    match format {
+        NowOutputFormat::Text => {
+            println!("endpoint: {}", diagnostics.endpoint);
+            println!(
+                "active operation id: {}",
+                diagnostics
+                    .active_operation_id
+                    .map_or_else(|| "none".to_owned(), |id| id.to_string())
+            );
+            println!("output retention bytes: {}", diagnostics.output_retention_bytes);
+            println!("event queue capacity: {}", diagnostics.event_queue_capacity);
+            println!(
+                "initial connect timeout seconds: {}",
+                diagnostics.initial_connect_timeout_secs
+            );
+            println!("reconnect timeout seconds: {}", diagnostics.reconnect_timeout_secs);
+        }
+        NowOutputFormat::Json | NowOutputFormat::Ndjson => print_ndjson(serde_json::json!({
+            "schema": "ironrdp-agent.now.v1",
+            "type": "diagnostics",
+            "endpoint": diagnostics.endpoint,
+            "active_operation_id": diagnostics.active_operation_id,
+            "output_retention_bytes": diagnostics.output_retention_bytes,
+            "event_queue_capacity": diagnostics.event_queue_capacity,
+            "initial_connect_timeout_secs": diagnostics.initial_connect_timeout_secs,
+            "reconnect_timeout_secs": diagnostics.reconnect_timeout_secs,
+        }))?,
     }
     Ok(())
 }
@@ -739,6 +1228,21 @@ fn print_payload(payload: Payload) {
             exit_code,
         } => println!("NOW operation {operation_id} exited with status {exit_code}"),
         Payload::NowCancelAccepted { operation_id } => println!("NOW operation {operation_id} cancellation requested"),
+        Payload::NowOperationInfo(info) => print_now_info_text(&info),
+        Payload::NowOperations(operations) => {
+            for info in &operations {
+                print_now_info_text(info);
+            }
+        }
+        Payload::NowDiagnostics(diagnostics) => {
+            let _ = print_now_diagnostics(&diagnostics, NowOutputFormat::Text);
+        }
+        Payload::NowStdinAccepted { operation_id, last } => {
+            println!(
+                "NOW operation {operation_id} standard input {}",
+                if last { "closed" } else { "accepted" }
+            );
+        }
     }
 }
 
@@ -781,7 +1285,12 @@ fn print_now_capabilities(capabilities: &crate::ipc::NowCapabilities) {
     println!("execution: {}", execution.join(", "));
     println!("system capset: 0x{:04x}", capabilities.system_capset);
     println!("session capset: 0x{:04x}", capabilities.session_capset);
-    println!("exec capset: 0x{:04x}", capabilities.exec_capset);
+    println!("server exec capset: 0x{:04x}", capabilities.server_exec_capset);
+    println!(
+        "agent advertised exec capset: 0x{:04x}",
+        capabilities.client_exec_capset
+    );
+    println!("agent exposed exec capset: 0x{:04x}", capabilities.exec_capset);
     if let Some(heartbeat_secs) = capabilities.heartbeat_secs {
         println!("heartbeat seconds: {heartbeat_secs}");
     }
@@ -898,5 +1407,29 @@ mod tests {
         let error = write_powershell_response(Response::error("NOW DVC pipe unavailable"))
             .expect_err("agent error must fail the CLI command");
         assert_eq!(error.to_string(), "NOW DVC pipe unavailable");
+    }
+
+    #[test]
+    fn structured_process_arguments_use_windows_compatible_quoting() {
+        assert_eq!(
+            windows_command_line(&[
+                "plain".to_owned(),
+                "two words".to_owned(),
+                r#"embedded"quote"#.to_owned(),
+                r"C:\path with spaces\".to_owned(),
+                String::new(),
+            ]),
+            r#"plain "two words" "embedded\"quote" "C:\path with spaces\\" """#
+        );
+    }
+
+    #[test]
+    fn ndjson_data_envelope_preserves_non_utf8_stream_bytes() {
+        let value = now_data_json(17, 3, NowStream::Stderr, &[0, 0xff]);
+        assert_eq!(value["schema"], "ironrdp-agent.now.v1");
+        assert_eq!(value["sequence"], 3);
+        assert_eq!(value["stream"], "stderr");
+        assert_eq!(value["data_base64"], "AP8=");
+        assert!(serde_json::from_str::<serde_json::Value>(&value.to_string()).is_ok());
     }
 }

--- a/crates/ironrdp-agent/src/cli.rs
+++ b/crates/ironrdp-agent/src/cli.rs
@@ -11,8 +11,9 @@
 
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
+use core::str::FromStr;
+use std::io::{Read as _, Write as _};
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
 
 use anyhow::Context as _;
 use clap::{Args, CommandFactory as _, Parser, Subcommand, ValueEnum};
@@ -20,7 +21,7 @@ use ironrdp_cfg::{PropertySetExt as _, TargetAddr};
 use ironrdp_input::MouseButton;
 use ironrdp_propertyset::{PropertySet, Value};
 
-use crate::ipc::{KeyFilter, Payload, PropValue, Request, Response};
+use crate::ipc::{KeyFilter, NowExecutionKind, NowExecutionRequest, NowStream, Payload, PropValue, Request, Response};
 use crate::transport::{self, Endpoint};
 
 /// IronRDP agent: a CLI-driven, daemon-backed RDP client.
@@ -97,6 +98,8 @@ enum Command {
         #[arg(long)]
         height: u16,
     },
+    /// Execute a PowerShell command through the remote NOW agent.
+    Now(NowArgs),
 }
 
 #[derive(Args, Debug)]
@@ -170,6 +173,112 @@ struct QueryLogsArgs {
 struct ScreenshotArgs {
     /// Destination PNG path (defaults to `screenshot.png` in the current directory).
     path: Option<PathBuf>,
+}
+
+#[derive(Args, Debug)]
+struct NowArgs {
+    #[command(subcommand)]
+    command: NowCommand,
+}
+
+#[derive(Subcommand, Debug)]
+enum NowCommand {
+    /// Report the NOW DVC protocol version and remote capability bitsets.
+    Capabilities,
+    /// Request normal cancellation of a streamed NOW operation.
+    Cancel {
+        /// Operation ID emitted through --operation-id-file.
+        operation_id: u64,
+    },
+    /// Execute with Windows PowerShell 5 (`powershell.exe`).
+    Powershell(NowPowerShellArgs),
+    /// Execute with PowerShell 7 (`pwsh.exe`).
+    Pwsh(NowPowerShellArgs),
+    /// Execute a capability-gated non-PowerShell NOW operation.
+    Exec(NowExecArgs),
+}
+
+#[derive(Args, Debug)]
+struct NowPowerShellArgs {
+    /// Load the remote user's PowerShell profile instead of the safe default `-NoProfile`.
+    #[arg(long)]
+    profile: bool,
+    /// Permit interactive PowerShell behavior instead of the safe default `-NonInteractive`.
+    #[arg(long)]
+    interactive: bool,
+    /// The PowerShell command to run. Quote it when it contains spaces or shell metacharacters.
+    #[arg(required_unless_present = "file", conflicts_with = "file")]
+    command: Option<String>,
+    /// Read the PowerShell command from a UTF-8 script file instead of the positional command.
+    #[arg(long, value_name = "PATH", conflicts_with = "command")]
+    file: Option<PathBuf>,
+    #[command(flatten)]
+    execution: NowExecutionOptions,
+}
+
+#[derive(Args, Debug)]
+struct NowExecutionOptions {
+    /// Remote working directory.
+    #[arg(long)]
+    directory: Option<String>,
+    /// Cancel after this many seconds.
+    #[arg(long, value_name = "SECONDS")]
+    timeout: Option<u32>,
+    /// Read raw bytes from PATH and forward them to the remote standard input. Use `-` for local stdin.
+    #[arg(long, value_name = "PATH")]
+    stdin: Option<PathBuf>,
+    /// Start without waiting for a remote result or receiving redirected output.
+    #[arg(long)]
+    detached: bool,
+    /// Write the locally assigned operation ID to PATH as soon as the daemon accepts it.
+    #[arg(long, value_name = "PATH")]
+    operation_id_file: Option<PathBuf>,
+}
+
+#[derive(Args, Debug)]
+struct NowExecArgs {
+    #[command(subcommand)]
+    command: NowExecCommand,
+}
+
+#[derive(Subcommand, Debug)]
+enum NowExecCommand {
+    /// Invoke a remote executable using CreateProcess.
+    Process(NowProcessArgs),
+    /// Invoke a command through the remote host's configured shell.
+    Shell(NowShellArgs),
+    /// Invoke a Windows batch command.
+    Batch(NowBatchArgs),
+}
+
+#[derive(Args, Debug)]
+struct NowProcessArgs {
+    /// Executable path.
+    filename: String,
+    /// Command-line parameters passed to the executable.
+    #[arg(long)]
+    parameters: Option<String>,
+    #[command(flatten)]
+    execution: NowExecutionOptions,
+}
+
+#[derive(Args, Debug)]
+struct NowShellArgs {
+    /// Shell command text.
+    command: String,
+    /// Optional remote shell executable.
+    #[arg(long)]
+    shell: Option<String>,
+    #[command(flatten)]
+    execution: NowExecutionOptions,
+}
+
+#[derive(Args, Debug)]
+struct NowBatchArgs {
+    /// Batch command text.
+    command: String,
+    #[command(flatten)]
+    execution: NowExecutionOptions,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -302,10 +411,116 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
         Command::KeyScancode { scancode, pressed } => Request::KeyScancode { scancode, pressed },
         Command::KeyUnicode { character, pressed } => Request::KeyUnicode { ch: character, pressed },
         Command::Resize { width, height } => Request::Resize { width, height },
+        Command::Now(args) => {
+            return match args.command {
+                NowCommand::Capabilities => {
+                    print_response(transport::send_request(&endpoint, &Request::NowCapabilities).await?)
+                }
+                NowCommand::Cancel { operation_id } => {
+                    print_response(transport::send_request(&endpoint, &Request::NowCancel { operation_id }).await?)
+                }
+                NowCommand::Powershell(args) => {
+                    let command = read_powershell_command(args.command, args.file)?;
+                    execute_now(
+                        &endpoint,
+                        NowExecutionRequest {
+                            kind: NowExecutionKind::WindowsPowerShell,
+                            command,
+                            parameters: None,
+                            directory: args.execution.directory,
+                            no_profile: !args.profile,
+                            non_interactive: !args.interactive,
+                            detached: args.execution.detached,
+                            timeout_secs: args.execution.timeout,
+                            stdin: read_standard_input(args.execution.stdin.as_deref())?,
+                        },
+                        args.execution.operation_id_file.as_deref(),
+                    )
+                    .await
+                }
+                NowCommand::Pwsh(args) => {
+                    let command = read_powershell_command(args.command, args.file)?;
+                    execute_now(
+                        &endpoint,
+                        NowExecutionRequest {
+                            kind: NowExecutionKind::PowerShell,
+                            command,
+                            parameters: None,
+                            directory: args.execution.directory,
+                            no_profile: !args.profile,
+                            non_interactive: !args.interactive,
+                            detached: args.execution.detached,
+                            timeout_secs: args.execution.timeout,
+                            stdin: read_standard_input(args.execution.stdin.as_deref())?,
+                        },
+                        args.execution.operation_id_file.as_deref(),
+                    )
+                    .await
+                }
+                NowCommand::Exec(NowExecArgs { command }) => {
+                    let (kind, command, parameters, execution) = match command {
+                        NowExecCommand::Process(args) => (
+                            NowExecutionKind::Process,
+                            args.filename,
+                            args.parameters,
+                            args.execution,
+                        ),
+                        NowExecCommand::Shell(args) => {
+                            (NowExecutionKind::Shell, args.command, args.shell, args.execution)
+                        }
+                        NowExecCommand::Batch(args) => (NowExecutionKind::Batch, args.command, None, args.execution),
+                    };
+                    execute_now(
+                        &endpoint,
+                        NowExecutionRequest {
+                            kind,
+                            command,
+                            parameters,
+                            directory: execution.directory,
+                            no_profile: true,
+                            non_interactive: true,
+                            detached: execution.detached,
+                            timeout_secs: execution.timeout,
+                            stdin: read_standard_input(execution.stdin.as_deref())?,
+                        },
+                        execution.operation_id_file.as_deref(),
+                    )
+                    .await
+                }
+            };
+        }
     };
 
     let response = transport::send_request(&endpoint, &request).await?;
     print_response(response)
+}
+
+#[derive(Debug)]
+struct RemoteExit {
+    code: u32,
+}
+
+impl core::fmt::Display for RemoteExit {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "remote NOW command exited with status {}", self.code)
+    }
+}
+
+impl core::error::Error for RemoteExit {}
+
+/// Returns a process exit status for a nonzero remote PowerShell exit, if this is such an error.
+pub fn remote_exit_code(error: &anyhow::Error) -> Option<i32> {
+    error
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<RemoteExit>())
+        .map(|exit| {
+            // Shells conventionally expose only 8-bit process statuses. Preserve the remote
+            // code where that is portable and map wider nonzero values to a nonzero failure.
+            i32::try_from(exit.code)
+                .ok()
+                .filter(|code| (1..=255).contains(code))
+                .unwrap_or(255)
+        })
 }
 
 /// Loads an operator-provided overlay [`PropertySet`] from an optional `.rdp` file, then layers
@@ -375,6 +590,108 @@ fn print_response(response: Response) -> anyhow::Result<()> {
     }
 }
 
+#[cfg(test)]
+fn write_powershell_response(response: Response) -> anyhow::Result<()> {
+    let payload = match response {
+        Response::Ok(payload) => payload,
+        Response::Err(message) => anyhow::bail!("{message}"),
+    };
+    let Payload::PowerShell {
+        stdout,
+        stderr,
+        exit_code,
+    } = payload
+    else {
+        anyhow::bail!("unexpected response to NOW PowerShell request");
+    };
+
+    std::io::stdout().write_all(&stdout).context("write remote stdout")?;
+    std::io::stdout().flush().context("flush remote stdout")?;
+    std::io::stderr().write_all(&stderr).context("write remote stderr")?;
+    std::io::stderr().flush().context("flush remote stderr")?;
+    if exit_code != 0 {
+        return Err(RemoteExit { code: exit_code }.into());
+    }
+    Ok(())
+}
+
+fn read_powershell_command(command: Option<String>, file: Option<PathBuf>) -> anyhow::Result<String> {
+    match (command, file) {
+        (Some(command), None) => Ok(command),
+        (None, Some(path)) => {
+            std::fs::read_to_string(&path).with_context(|| format!("read PowerShell script {}", path.display()))
+        }
+        (Some(_), Some(_)) => anyhow::bail!("provide either a PowerShell command or --file, not both"),
+        (None, None) => anyhow::bail!("provide a PowerShell command or --file"),
+    }
+}
+
+fn read_standard_input(path: Option<&Path>) -> anyhow::Result<Option<Vec<u8>>> {
+    let Some(path) = path else {
+        return Ok(None);
+    };
+    if path == Path::new("-") {
+        let mut stdin = std::io::stdin().lock();
+        let mut bytes = Vec::new();
+        stdin.read_to_end(&mut bytes).context("read local standard input")?;
+        return Ok(Some(bytes));
+    }
+    std::fs::read(path)
+        .map(Some)
+        .with_context(|| format!("read NOW standard input {}", path.display()))
+}
+
+async fn execute_now(
+    endpoint: &Endpoint,
+    request: NowExecutionRequest,
+    operation_id_file: Option<&Path>,
+) -> anyhow::Result<()> {
+    let mut exit_code = None;
+    transport::send_streaming_request(endpoint, &Request::NowExecute(request), |response| match response {
+        Response::Err(message) => anyhow::bail!("{message}"),
+        Response::Ok(Payload::NowExecutionStarted { operation_id }) => {
+            if let Some(path) = operation_id_file {
+                std::fs::write(path, operation_id.to_string())
+                    .with_context(|| format!("write NOW operation ID {}", path.display()))?;
+            }
+            Ok(false)
+        }
+        Response::Ok(Payload::NowExecutionData {
+            stream: NowStream::Stdout,
+            data,
+            ..
+        }) => {
+            std::io::stdout().write_all(&data).context("write remote stdout")?;
+            std::io::stdout().flush().context("flush remote stdout")?;
+            Ok(false)
+        }
+        Response::Ok(Payload::NowExecutionData {
+            stream: NowStream::Stderr,
+            data,
+            ..
+        }) => {
+            std::io::stderr().write_all(&data).context("write remote stderr")?;
+            std::io::stderr().flush().context("flush remote stderr")?;
+            Ok(false)
+        }
+        Response::Ok(Payload::NowExecutionResult {
+            exit_code: result_exit_code,
+            ..
+        }) => {
+            exit_code = Some(result_exit_code);
+            Ok(true)
+        }
+        Response::Ok(payload) => anyhow::bail!("unexpected response to streamed NOW execution: {payload:?}"),
+    })
+    .await?;
+
+    let exit_code = exit_code.context("NOW execution ended without an exit code")?;
+    if exit_code != 0 {
+        return Err(RemoteExit { code: exit_code }.into());
+    }
+    Ok(())
+}
+
 fn print_payload(payload: Payload) {
     match payload {
         Payload::Empty => println!("ok"),
@@ -412,6 +729,61 @@ fn print_payload(payload: Payload) {
         }
         // Screenshots are handled out-of-band by `write_screenshot`, never printed.
         Payload::Screenshot { width, height, .. } => println!("frame {width}x{height}"),
+        // NOW PowerShell byte streams are handled out-of-band by `write_powershell_response`.
+        Payload::PowerShell { .. } => {}
+        Payload::NowCapabilities(capabilities) => print_now_capabilities(&capabilities),
+        Payload::NowExecutionStarted { operation_id } => println!("NOW operation {operation_id} started"),
+        Payload::NowExecutionData { .. } => {}
+        Payload::NowExecutionResult {
+            operation_id,
+            exit_code,
+        } => println!("NOW operation {operation_id} exited with status {exit_code}"),
+        Payload::NowCancelAccepted { operation_id } => println!("NOW operation {operation_id} cancellation requested"),
+    }
+}
+
+fn print_now_capabilities(capabilities: &crate::ipc::NowCapabilities) {
+    let mut system = Vec::new();
+    if capabilities.system_capset & 0x0001 != 0 {
+        system.push("shutdown");
+    }
+    let mut session = Vec::new();
+    for (flag, name) in [
+        (0x0001, "lock"),
+        (0x0002, "logoff"),
+        (0x0004, "message-box"),
+        (0x0008, "set-keyboard-layout"),
+        (0x0010, "window-recording"),
+    ] {
+        if capabilities.session_capset & flag != 0 {
+            session.push(name);
+        }
+    }
+    let mut execution = Vec::new();
+    for (flag, name) in [
+        (0x0001, "run"),
+        (0x0002, "process"),
+        (0x0004, "shell"),
+        (0x0008, "batch"),
+        (0x0010, "powershell"),
+        (0x0020, "pwsh"),
+        (0x0040, "unicode-console"),
+        (0x1000, "io-redirection"),
+    ] {
+        if capabilities.exec_capset & flag != 0 {
+            execution.push(name);
+        }
+    }
+
+    println!("version: {}.{}", capabilities.major, capabilities.minor);
+    println!("system: {}", system.join(", "));
+    println!("session: {}", session.join(", "));
+    println!("execution: {}", execution.join(", "));
+    println!("system capset: 0x{:04x}", capabilities.system_capset);
+    println!("session capset: 0x{:04x}", capabilities.session_capset);
+    println!("exec capset: 0x{:04x}", capabilities.exec_capset);
+    if let Some(heartbeat_secs) = capabilities.heartbeat_secs {
+        println!("heartbeat seconds: {heartbeat_secs}");
     }
 }
 
@@ -497,4 +869,34 @@ fn property_description(key: &str) -> Option<&'static str> {
         _ => return None,
     };
     Some(description)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remote_exit_status_is_preserved() {
+        let error = anyhow::Error::new(RemoteExit { code: 37 });
+        assert_eq!(remote_exit_code(&error), Some(37));
+    }
+
+    #[test]
+    fn remote_exit_status_is_preserved_through_anyhow_context() {
+        let error = anyhow::Error::new(RemoteExit { code: 7 }).context("write NOW PowerShell response");
+        assert_eq!(remote_exit_code(&error), Some(7));
+    }
+
+    #[test]
+    fn wide_remote_exit_status_maps_to_portable_failure() {
+        let error = anyhow::Error::new(RemoteExit { code: 256 });
+        assert_eq!(remote_exit_code(&error), Some(255));
+    }
+
+    #[test]
+    fn powershell_agent_errors_are_returned_to_the_cli() {
+        let error = write_powershell_response(Response::error("NOW DVC pipe unavailable"))
+            .expect_err("agent error must fail the CLI command");
+        assert_eq!(error.to_string(), "NOW DVC pipe unavailable");
+    }
 }

--- a/crates/ironrdp-agent/src/daemon.rs
+++ b/crates/ironrdp-agent/src/daemon.rs
@@ -18,13 +18,12 @@ use tokio::sync::mpsc;
 use tracing::{debug, error, info, trace, warn};
 
 use crate::ipc::{
-    ConnState, KeyFilter, NowExecutionRequest, NowStream, Payload, PropValue, PropertyDump, PropertyEntry, Request,
-    Response, StatusInfo,
+    ConnState, KeyFilter, NowExecutionRequest, Payload, PropValue, PropertyDump, PropertyEntry, Request, Response,
+    StatusInfo,
 };
 use crate::logbuf::{self, LogBuffer};
-use crate::now::{
-    DVC_CHANNEL_NAME, NowClient, NowOperationEvent, PowerShellKind as NowPowerShellKind, PowerShellRequest,
-};
+use crate::now::{DVC_CHANNEL_NAME, NowClient, PowerShellKind as NowPowerShellKind, PowerShellRequest};
+use crate::operations::{NowOperationManager, OUTPUT_RETENTION_BYTES};
 use crate::transport::{Endpoint, Listener, read_message, write_message};
 
 /// Binds the IPC endpoint and serves requests until a shutdown signal is received.
@@ -86,12 +85,21 @@ where
 {
     let request: Request = read_message(&mut stream).await?;
     trace!(?request, "Handling IPC request");
-    if let Request::NowExecute(request) = request {
-        daemon.stream_now_execution(request, &mut stream).await?;
-    } else {
-        let response = daemon.handle(request).await;
-        trace!(ok = response.is_ok(), "Replying to IPC request");
-        write_message(&mut stream, &response).await?;
+    match request {
+        Request::NowExecute(request) => daemon.stream_now_execution(request, &mut stream).await?,
+        Request::NowOperationAttach {
+            operation_id,
+            after_sequence,
+        } => {
+            daemon
+                .attach_now_operation(operation_id, after_sequence, &mut stream)
+                .await?
+        }
+        request => {
+            let response = daemon.handle(request).await;
+            trace!(ok = response.is_ok(), "Replying to IPC request");
+            write_message(&mut stream, &response).await?;
+        }
     }
     Ok(())
 }
@@ -115,6 +123,7 @@ struct Session {
     destination: String,
     live: Arc<Mutex<Live>>,
     now: Arc<NowClient>,
+    now_operations: Arc<NowOperationManager>,
 }
 
 /// Per-session state shared with the output-consumer task.
@@ -205,6 +214,17 @@ impl Daemon {
             Request::NowCapabilities => self.now_capabilities().await,
             Request::NowExecute(_) => Response::error("NOW execution must use a streaming IPC connection"),
             Request::NowCancel { operation_id } => self.cancel_now(operation_id),
+            Request::NowOperations => self.now_operations(),
+            Request::NowOperationStatus { operation_id } => self.now_operation_status(operation_id),
+            Request::NowOperationAttach { .. } => {
+                Response::error("NOW operation attachment must use a streaming IPC connection")
+            }
+            Request::NowDiagnostics => self.now_diagnostics(),
+            Request::NowWriteStdin {
+                operation_id,
+                data,
+                last,
+            } => self.now_write_stdin(operation_id, data, last).await,
         }
     }
 
@@ -311,12 +331,14 @@ impl Daemon {
 
         info!(%destination, "Started RDP session");
 
+        let now_operations = Arc::new(NowOperationManager::new(Arc::clone(&now)));
         *self.state.lock().expect("daemon state poisoned") = Some(Session {
             input_tx,
             input_db: Database::new(),
             destination,
             live,
             now,
+            now_operations,
         });
 
         Response::ok()
@@ -491,12 +513,12 @@ impl Daemon {
     }
 
     fn cancel_now(&self, operation_id: u64) -> Response {
-        let now = match self.now_client() {
-            Ok(now) => now,
+        let operations = match self.now_operation_manager() {
+            Ok(operations) => operations,
             Err(response) => return response,
         };
-        match now.cancel(operation_id) {
-            Ok(()) => Response::Ok(Payload::NowCancelAccepted { operation_id }),
+        match operations.cancel(operation_id) {
+            Ok(_) => Response::Ok(Payload::NowCancelAccepted { operation_id }),
             Err(error) => Response::error(format!("{error:#}")),
         }
     }
@@ -505,14 +527,14 @@ impl Daemon {
     where
         S: AsyncWrite + Unpin,
     {
-        let now = match self.now_client() {
-            Ok(now) => now,
+        let operations = match self.now_operation_manager_connected() {
+            Ok(operations) => operations,
             Err(response) => {
                 write_message(stream, &response).await?;
                 return Ok(());
             }
         };
-        let mut operation = match now.start_execution(request) {
+        let operation = match operations.start(request) {
             Ok(operation) => operation,
             Err(error) => {
                 write_message(stream, &Response::error(format!("{error:#}"))).await?;
@@ -522,50 +544,71 @@ impl Daemon {
         write_message(
             stream,
             &Response::Ok(Payload::NowExecutionStarted {
-                operation_id: operation.id,
+                operation_id: operation.operation_id,
             }),
         )
         .await?;
+        operations.attach(operation.operation_id, 0, stream).await
+    }
 
-        while let Some(event) = operation.events.recv().await {
-            let response = match event {
-                NowOperationEvent::Data {
-                    stream: NowStream::Stdout,
-                    data,
-                } => Response::Ok(Payload::NowExecutionData {
-                    operation_id: operation.id,
-                    stream: NowStream::Stdout,
-                    data,
-                }),
-                NowOperationEvent::Data {
-                    stream: NowStream::Stderr,
-                    data,
-                } => Response::Ok(Payload::NowExecutionData {
-                    operation_id: operation.id,
-                    stream: NowStream::Stderr,
-                    data,
-                }),
-                NowOperationEvent::Finished { exit_code } => Response::Ok(Payload::NowExecutionResult {
-                    operation_id: operation.id,
-                    exit_code,
-                }),
-                NowOperationEvent::Failed { message } => Response::error(message),
-            };
-            let terminal = matches!(
-                response,
-                Response::Err(_) | Response::Ok(Payload::NowExecutionResult { .. })
-            );
-            write_message(stream, &response).await?;
-            if terminal {
+    async fn attach_now_operation<S>(
+        &self,
+        operation_id: u64,
+        after_sequence: u64,
+        stream: &mut S,
+    ) -> anyhow::Result<()>
+    where
+        S: AsyncWrite + Unpin,
+    {
+        let operations = match self.now_operation_manager() {
+            Ok(operations) => operations,
+            Err(response) => {
+                write_message(stream, &response).await?;
                 return Ok(());
             }
+        };
+        match operations.attach(operation_id, after_sequence, stream).await {
+            Ok(()) => Ok(()),
+            Err(error) => write_message(stream, &Response::error(format!("{error:#}"))).await,
         }
+    }
 
-        write_message(
-            stream,
-            &Response::error("NOW execution ended without a terminal result"),
-        )
-        .await
+    fn now_operations(&self) -> Response {
+        match self.now_operation_manager() {
+            Ok(operations) => Response::Ok(Payload::NowOperations(operations.list())),
+            Err(response) => response,
+        }
+    }
+
+    fn now_operation_status(&self, operation_id: u64) -> Response {
+        match self.now_operation_manager() {
+            Ok(operations) => match operations.status(operation_id) {
+                Ok(info) => Response::Ok(Payload::NowOperationInfo(info)),
+                Err(error) => Response::error(format!("{error:#}")),
+            },
+            Err(response) => response,
+        }
+    }
+
+    fn now_diagnostics(&self) -> Response {
+        let guard = self.state.lock().expect("daemon state poisoned");
+        let Some(session) = guard.as_ref() else {
+            return Response::error("no active session");
+        };
+        Response::Ok(Payload::NowDiagnostics(session.now.diagnostics(
+            u32::try_from(OUTPUT_RETENTION_BYTES).expect("retention cap fits in u32"),
+        )))
+    }
+
+    async fn now_write_stdin(&self, operation_id: u64, data: Vec<u8>, last: bool) -> Response {
+        let operations = match self.now_operation_manager() {
+            Ok(operations) => operations,
+            Err(response) => return response,
+        };
+        match operations.write_stdin(operation_id, data, last).await {
+            Ok(()) => Response::Ok(Payload::NowStdinAccepted { operation_id, last }),
+            Err(error) => Response::error(format!("{error:#}")),
+        }
     }
 
     fn now_client(&self) -> Result<Arc<NowClient>, Response> {
@@ -577,6 +620,25 @@ impl Daemon {
             return Err(Response::error("NOW execution requires a connected RDP session"));
         }
         Ok(Arc::clone(&session.now))
+    }
+
+    fn now_operation_manager(&self) -> Result<Arc<NowOperationManager>, Response> {
+        let guard = self.state.lock().expect("daemon state poisoned");
+        let Some(session) = guard.as_ref() else {
+            return Err(Response::error("no active session"));
+        };
+        Ok(Arc::clone(&session.now_operations))
+    }
+
+    fn now_operation_manager_connected(&self) -> Result<Arc<NowOperationManager>, Response> {
+        let guard = self.state.lock().expect("daemon state poisoned");
+        let Some(session) = guard.as_ref() else {
+            return Err(Response::error("no active session"));
+        };
+        if session.live.lock().expect("session live state poisoned").state != ConnState::Connected {
+            return Err(Response::error("NOW execution requires a connected RDP session"));
+        }
+        Ok(Arc::clone(&session.now_operations))
     }
 
     fn input(&self, operation: Operation) -> Response {

--- a/crates/ironrdp-agent/src/daemon.rs
+++ b/crates/ironrdp-agent/src/daemon.rs
@@ -8,7 +8,7 @@
 use std::sync::{Arc, Mutex};
 
 use anyhow::Context as _;
-use ironrdp_client::config::{ConfigBuilder, MissingField};
+use ironrdp_client::config::{ConfigBuilder, DvcProxyInfo, MissingField};
 use ironrdp_client::rdp::{RdpClient, RdpInputEvent, RdpOutputEvent};
 use ironrdp_input::{Database, MousePosition, Operation, Scancode, WheelRotations};
 use ironrdp_pdu::rdp::capability_sets::MajorPlatformType;
@@ -18,9 +18,13 @@ use tokio::sync::mpsc;
 use tracing::{debug, error, info, trace, warn};
 
 use crate::ipc::{
-    ConnState, KeyFilter, Payload, PropValue, PropertyDump, PropertyEntry, Request, Response, StatusInfo,
+    ConnState, KeyFilter, NowExecutionRequest, NowStream, Payload, PropValue, PropertyDump, PropertyEntry, Request,
+    Response, StatusInfo,
 };
 use crate::logbuf::{self, LogBuffer};
+use crate::now::{
+    DVC_CHANNEL_NAME, NowClient, NowOperationEvent, PowerShellKind as NowPowerShellKind, PowerShellRequest,
+};
 use crate::transport::{Endpoint, Listener, read_message, write_message};
 
 /// Binds the IPC endpoint and serves requests until a shutdown signal is received.
@@ -51,7 +55,7 @@ pub async fn run(endpoint: Endpoint, overlay: PropertySet) -> anyhow::Result<()>
     let logs = LogBuffer::new();
 
     let mut listener = Listener::bind(&endpoint).with_context(|| format!("bind IPC endpoint {endpoint}"))?;
-    let daemon = Daemon::new(logs, overlay);
+    let daemon = Arc::new(Daemon::new(logs, overlay));
 
     info!(%endpoint, "Daemon listening");
 
@@ -59,9 +63,12 @@ pub async fn run(endpoint: Endpoint, overlay: PropertySet) -> anyhow::Result<()>
         tokio::select! {
             result = listener.accept() => {
                 let stream = result.context("accept IPC connection")?;
-                if let Err(error) = handle_connection(stream, &daemon).await {
-                    debug!(error = format!("{error:#}"), "IPC connection error");
-                }
+                let daemon = Arc::clone(&daemon);
+                tokio::spawn(async move {
+                    if let Err(error) = handle_connection(stream, &daemon).await {
+                        debug!(error = format!("{error:#}"), "IPC connection error");
+                    }
+                });
             }
             _ = tokio::signal::ctrl_c() => {
                 info!("Received shutdown signal, stopping");
@@ -79,9 +86,13 @@ where
 {
     let request: Request = read_message(&mut stream).await?;
     trace!(?request, "Handling IPC request");
-    let response = daemon.handle(request);
-    trace!(ok = response.is_ok(), "Replying to IPC request");
-    write_message(&mut stream, &response).await?;
+    if let Request::NowExecute(request) = request {
+        daemon.stream_now_execution(request, &mut stream).await?;
+    } else {
+        let response = daemon.handle(request).await;
+        trace!(ok = response.is_ok(), "Replying to IPC request");
+        write_message(&mut stream, &response).await?;
+    }
     Ok(())
 }
 
@@ -103,6 +114,7 @@ struct Session {
     input_db: Database,
     destination: String,
     live: Arc<Mutex<Live>>,
+    now: Arc<NowClient>,
 }
 
 /// Per-session state shared with the output-consumer task.
@@ -137,7 +149,7 @@ impl Daemon {
         }
     }
 
-    fn handle(&self, request: Request) -> Response {
+    async fn handle(&self, request: Request) -> Response {
         match request {
             Request::Connect {
                 properties,
@@ -172,6 +184,27 @@ impl Daemon {
                 Operation::UnicodeKeyReleased(ch)
             }),
             Request::Resize { width, height } => self.resize(width, height),
+            Request::PowerShell {
+                kind,
+                command,
+                no_profile,
+                non_interactive,
+            } => {
+                let kind = match kind {
+                    crate::ipc::PowerShellKind::WindowsPowerShell => NowPowerShellKind::WindowsPowerShell,
+                    crate::ipc::PowerShellKind::PowerShell => NowPowerShellKind::PowerShell,
+                };
+                self.powershell(PowerShellRequest {
+                    kind,
+                    command,
+                    no_profile,
+                    non_interactive,
+                })
+                .await
+            }
+            Request::NowCapabilities => self.now_capabilities().await,
+            Request::NowExecute(_) => Response::error("NOW execution must use a streaming IPC connection"),
+            Request::NowCancel { operation_id } => self.cancel_now(operation_id),
         }
     }
 
@@ -204,6 +237,10 @@ impl Daemon {
 
         // Derive the headless client identity. These fields are never representable as `.rdp`
         // properties and are never prompted; the daemon supplies them itself.
+        let now = match NowClient::new() {
+            Ok(now) => Arc::new(now),
+            Err(error) => return Response::error(format!("create NOW endpoint: {error:#}")),
+        };
         let builder = builder
             .with_client_build(client_build())
             .with_client_dir("C:\\Windows\\System32\\mstscax.dll")
@@ -211,7 +248,11 @@ impl Daemon {
             .with_client_name(client_name())
             // Headless: composite the remote cursor into the framebuffer so it appears in
             // screenshots (there is no separate overlay to draw it).
-            .with_pointer_software_rendering(true);
+            .with_pointer_software_rendering(true)
+            .with_dvc_pipe_proxy(DvcProxyInfo {
+                channel_name: DVC_CHANNEL_NAME.to_owned(),
+                pipe_name: now.endpoint().to_owned(),
+            });
 
         let missing = builder.missing();
         if !missing.is_empty() {
@@ -275,6 +316,7 @@ impl Daemon {
             input_db: Database::new(),
             destination,
             live,
+            now,
         });
 
         Response::ok()
@@ -419,6 +461,122 @@ impl Daemon {
             Ok(()) => Response::ok(),
             Err(_) => Response::error("session input channel is closed"),
         }
+    }
+
+    async fn powershell(&self, request: PowerShellRequest) -> Response {
+        let now = match self.now_client() {
+            Ok(now) => now,
+            Err(response) => return response,
+        };
+
+        match now.execute(request).await {
+            Ok(result) => Response::Ok(Payload::PowerShell {
+                stdout: result.stdout,
+                stderr: result.stderr,
+                exit_code: result.exit_code,
+            }),
+            Err(error) => Response::error(format!("{error:#}")),
+        }
+    }
+
+    async fn now_capabilities(&self) -> Response {
+        let now = match self.now_client() {
+            Ok(now) => now,
+            Err(response) => return response,
+        };
+        match now.capabilities().await {
+            Ok(capabilities) => Response::Ok(Payload::NowCapabilities(capabilities)),
+            Err(error) => Response::error(format!("{error:#}")),
+        }
+    }
+
+    fn cancel_now(&self, operation_id: u64) -> Response {
+        let now = match self.now_client() {
+            Ok(now) => now,
+            Err(response) => return response,
+        };
+        match now.cancel(operation_id) {
+            Ok(()) => Response::Ok(Payload::NowCancelAccepted { operation_id }),
+            Err(error) => Response::error(format!("{error:#}")),
+        }
+    }
+
+    async fn stream_now_execution<S>(&self, request: NowExecutionRequest, stream: &mut S) -> anyhow::Result<()>
+    where
+        S: AsyncWrite + Unpin,
+    {
+        let now = match self.now_client() {
+            Ok(now) => now,
+            Err(response) => {
+                write_message(stream, &response).await?;
+                return Ok(());
+            }
+        };
+        let mut operation = match now.start_execution(request) {
+            Ok(operation) => operation,
+            Err(error) => {
+                write_message(stream, &Response::error(format!("{error:#}"))).await?;
+                return Ok(());
+            }
+        };
+        write_message(
+            stream,
+            &Response::Ok(Payload::NowExecutionStarted {
+                operation_id: operation.id,
+            }),
+        )
+        .await?;
+
+        while let Some(event) = operation.events.recv().await {
+            let response = match event {
+                NowOperationEvent::Data {
+                    stream: NowStream::Stdout,
+                    data,
+                } => Response::Ok(Payload::NowExecutionData {
+                    operation_id: operation.id,
+                    stream: NowStream::Stdout,
+                    data,
+                }),
+                NowOperationEvent::Data {
+                    stream: NowStream::Stderr,
+                    data,
+                } => Response::Ok(Payload::NowExecutionData {
+                    operation_id: operation.id,
+                    stream: NowStream::Stderr,
+                    data,
+                }),
+                NowOperationEvent::Finished { exit_code } => Response::Ok(Payload::NowExecutionResult {
+                    operation_id: operation.id,
+                    exit_code,
+                }),
+                NowOperationEvent::Failed { message } => Response::error(message),
+            };
+            let terminal = matches!(
+                response,
+                Response::Err(_) | Response::Ok(Payload::NowExecutionResult { .. })
+            );
+            write_message(stream, &response).await?;
+            if terminal {
+                return Ok(());
+            }
+        }
+
+        write_message(
+            stream,
+            &Response::error("NOW execution ended without a terminal result"),
+        )
+        .await
+    }
+
+    fn now_client(&self) -> Result<Arc<NowClient>, Response> {
+        let guard = self.state.lock().expect("daemon state poisoned");
+        let Some(session) = guard.as_ref() else {
+            return Err(Response::error("no active session"));
+        };
+        if session.live.lock().expect("session live state poisoned").state != ConnState::Connected {
+            return Err(Response::error("NOW execution requires a connected RDP session"));
+        }
+        Ok(Arc::clone(&session.now))
     }
 
     fn input(&self, operation: Operation) -> Response {

--- a/crates/ironrdp-agent/src/help.rs
+++ b/crates/ironrdp-agent/src/help.rs
@@ -7,8 +7,8 @@ A CLI-driven, daemon-backed RDP client. One binary plays two roles:
 
 - DAEMON: `ironrdp-agent daemon-start` runs a long-lived foreground process that owns the RDP
   engine and one RDP session. Background it yourself (e.g. `ironrdp-agent daemon-start &`).
-- CLI: every other subcommand opens the local IPC endpoint, sends one request, prints the
-  response, and exits.
+- CLI: every other subcommand opens the local IPC endpoint, sends a request, prints the response,
+  and exits. NOW execution keeps this connection open to forward raw output chunks.
 
 The daemon stays alive across CLI invocations. One daemon serves one RDP session.
 
@@ -67,6 +67,42 @@ Override with `--endpoint <PATH-OR-PIPE>` on any subcommand.
                                  as a PNG and write it to PATH (default `screenshot.png`). Prints
                                  `wrote PATH (WxH, N bytes)`. Errors with `no frame available yet`
                                  until the first frame arrives.
+
+## Remote NOW execution (requires an active session)
+
+- `now capabilities`                 Print the negotiated NOW version and named system, session,
+                                    and execution capabilities. System/session entries are
+                                    discovery-only; this release exposes the execution operations
+                                    below.
+- `now powershell [--profile] [--interactive] [--file PATH] [COMMAND]`
+                                 Execute COMMAND with the remote Windows PowerShell 5
+                                 (`powershell.exe`) through the `Devolutions::Now::Agent` DVC.
+- `now pwsh [--profile] [--interactive] [--file PATH] [COMMAND]`
+                                 Execute COMMAND with the remote PowerShell 7 (`pwsh.exe`) through
+                                 the `Devolutions::Now::Agent` DVC.
+- `now exec process FILE [--parameters ARGS]`
+                                 Execute FILE with the remote CreateProcess style.
+- `now exec shell COMMAND [--shell PATH]`
+                                 Execute COMMAND with the remote host's configured shell.
+- `now exec batch COMMAND`           Execute a remote Windows batch command.
+- `now cancel OPERATION_ID`          Request normal cancellation of a running operation.
+
+All tracked execution commands require their corresponding remote NOW capability and I/O
+redirection. They accept `--directory PATH`, `--timeout SECONDS`, `--stdin PATH` (or `-` for raw
+local stdin), and `--operation-id-file PATH`; use the written ID with `now cancel` from another
+process. PowerShell commands also accept `--profile` and `--interactive`, and accept an inline
+command or one UTF-8 `--file` script.
+
+Stdout/stderr are forwarded as raw bytes to the matching local stream as they arrive; the CLI does
+not aggregate output. A nonzero remote exit code from 1 through 255 is this CLI's exit status;
+wide nonzero codes map to 255. `--timeout` uses normal NOW cancellation and waits for the terminal
+result. `--detached` is explicit, cannot use stdin or a timeout, and does not provide remote output
+or exit tracking.
+
+The agent uses a fresh local DVC pipe endpoint for each RDP session, negotiates before its first
+NOW command, and handles fragmented or coalesced frames. If the NOW DVC is unavailable, the first
+command fails after a 30-second local proxy wait (later reconnects use 10 seconds); `status` and
+`disconnect` remain available.
 
 ## Input (require an active session)
 

--- a/crates/ironrdp-agent/src/help.rs
+++ b/crates/ironrdp-agent/src/help.rs
@@ -70,7 +70,8 @@ Override with `--endpoint <PATH-OR-PIPE>` on any subcommand.
 
 ## Remote NOW execution (requires an active session)
 
-- `now capabilities`                 Print the negotiated NOW version and named system, session,
+- `now capabilities [--format text|json|ndjson]`
+                                    Print the negotiated NOW version and named system, session,
                                     and execution capabilities. System/session entries are
                                     discovery-only; this release exposes the execution operations
                                     below.
@@ -80,24 +81,38 @@ Override with `--endpoint <PATH-OR-PIPE>` on any subcommand.
 - `now pwsh [--profile] [--interactive] [--file PATH] [COMMAND]`
                                  Execute COMMAND with the remote PowerShell 7 (`pwsh.exe`) through
                                  the `Devolutions::Now::Agent` DVC.
-- `now exec process FILE [--parameters ARGS]`
+- `now exec process FILE [--parameters ARGS|--arg ARG...]`
                                  Execute FILE with the remote CreateProcess style.
-- `now exec shell COMMAND [--shell PATH]`
+- `now exec shell [--file PATH] [COMMAND] [--shell PATH]`
                                  Execute COMMAND with the remote host's configured shell.
-- `now exec batch COMMAND`           Execute a remote Windows batch command.
+- `now exec batch [--file PATH] [COMMAND]`
+                                 Execute a remote Windows batch command.
 - `now cancel OPERATION_ID`          Request normal cancellation of a running operation.
+- `now list` / `now status OPERATION_ID`
+                                 Inspect daemon-owned operation metadata.
+- `now attach OPERATION_ID [--after-sequence N]`
+                                 Replay retained output, then follow until completion.
+- `now stdin OPERATION_ID [--file PATH]`
+                                 Stream local stdin or PATH to an active operation.
+- `now diagnostics`                  Print DVC endpoint readiness and operation bounds.
 
 All tracked execution commands require their corresponding remote NOW capability and I/O
-redirection. They accept `--directory PATH`, `--timeout SECONDS`, `--stdin PATH` (or `-` for raw
-local stdin), and `--operation-id-file PATH`; use the written ID with `now cancel` from another
-process. PowerShell commands also accept `--profile` and `--interactive`, and accept an inline
-command or one UTF-8 `--file` script.
+redirection. They accept `--directory PATH`, `--timeout SECONDS`, buffered `--stdin PATH` (or `-`
+for raw local stdin), and `--operation-id-file PATH`; use the written ID with `now cancel` or
+`now stdin` from another process. PowerShell commands also accept `--profile` and `--interactive`,
+and accept an inline command or one UTF-8 `--file` script.
 
 Stdout/stderr are forwarded as raw bytes to the matching local stream as they arrive; the CLI does
 not aggregate output. A nonzero remote exit code from 1 through 255 is this CLI's exit status;
 wide nonzero codes map to 255. `--timeout` uses normal NOW cancellation and waits for the terminal
 result. `--detached` is explicit, cannot use stdin or a timeout, and does not provide remote output
-or exit tracking.
+or exit tracking. The daemon retains at most 8 MiB per operation, 32 terminal records, and 32 MiB
+total output, evicting oldest completed records; it requests normal cancellation on an
+operation-output overflow. Live stdin uses 64 KiB bounded fragments and retryable backpressure. A
+disconnected CLI does not terminate a tracked operation; use `now attach` to replay/continue.
+`--format text` preserves raw output, `--format json` emits
+one-shot snapshots, and `--format ndjson` emits versioned (`ironrdp-agent.now.v1`) lifecycle/data
+records with base64 raw bytes and stable typed error categories.
 
 The agent uses a fresh local DVC pipe endpoint for each RDP session, negotiates before its first
 NOW command, and handles fragmented or coalesced frames. If the NOW DVC is unavailable, the first

--- a/crates/ironrdp-agent/src/ipc.rs
+++ b/crates/ironrdp-agent/src/ipc.rs
@@ -81,6 +81,20 @@ pub enum Request {
     NowExecute(NowExecutionRequest),
     /// Request normal cancellation of a running NOW execution.
     NowCancel { operation_id: u64 },
+    /// List durable NOW operations for the active RDP session.
+    NowOperations,
+    /// Return a durable NOW operation snapshot.
+    NowOperationStatus { operation_id: u64 },
+    /// Replay retained output after `after_sequence` and continue until a terminal result.
+    NowOperationAttach { operation_id: u64, after_sequence: u64 },
+    /// Report local NOW endpoint and operation-management readiness details.
+    NowDiagnostics,
+    /// Deliver one bounded standard-input fragment to a running NOW operation.
+    NowWriteStdin {
+        operation_id: u64,
+        data: Vec<u8>,
+        last: bool,
+    },
     // TODO: add clipboard support (CLIPRDR), e.g. requests to read the remote clipboard text and to
     // set it, so an LLM can copy/paste to and from the session.
 }
@@ -150,6 +164,30 @@ impl fmt::Debug for Request {
             Self::NowCancel { operation_id } => {
                 f.debug_struct("NowCancel").field("operation_id", operation_id).finish()
             }
+            Self::NowOperations => f.write_str("NowOperations"),
+            Self::NowOperationStatus { operation_id } => f
+                .debug_struct("NowOperationStatus")
+                .field("operation_id", operation_id)
+                .finish(),
+            Self::NowOperationAttach {
+                operation_id,
+                after_sequence,
+            } => f
+                .debug_struct("NowOperationAttach")
+                .field("operation_id", operation_id)
+                .field("after_sequence", after_sequence)
+                .finish(),
+            Self::NowDiagnostics => f.write_str("NowDiagnostics"),
+            Self::NowWriteStdin {
+                operation_id,
+                data,
+                last,
+            } => f
+                .debug_struct("NowWriteStdin")
+                .field("operation_id", operation_id)
+                .field("data_len", &data.len())
+                .field("last", last)
+                .finish(),
         }
     }
 }
@@ -237,10 +275,153 @@ pub struct NowCapabilities {
     pub system_capset: u16,
     /// Server-advertised session capability bitset.
     pub session_capset: u16,
-    /// Execution capabilities available to this agent after intersection.
+    /// Execution capability bitset advertised by the remote NOW server.
+    pub server_exec_capset: u16,
+    /// Execution capability bitset advertised by this agent during negotiation.
+    pub client_exec_capset: u16,
+    /// Execution capabilities available to this agent after the server/client intersection.
     pub exec_capset: u16,
     /// Negotiated channel heartbeat interval in seconds, if set.
     pub heartbeat_secs: Option<u32>,
+}
+
+/// Lifecycle state of a daemon-owned NOW operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NowOperationState {
+    /// The NOW protocol worker is running.
+    Running,
+    /// A cancellation request has been sent to the NOW protocol worker.
+    Cancelling,
+    /// The worker completed with a remote exit code.
+    Succeeded,
+    /// The worker completed with a local or remote protocol error.
+    Failed,
+    /// The operation was cancelled and the remote worker returned a terminal response.
+    Cancelled,
+    /// The remote command was intentionally launched without I/O redirection or completion tracking.
+    Detached,
+}
+
+/// A machine-readable, durable snapshot of one NOW operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NowOperationInfo {
+    /// Locally assigned operation identity, unique for the daemon lifetime.
+    pub operation_id: u64,
+    /// Remote execution style.
+    pub kind: NowExecutionKind,
+    /// Current lifecycle state.
+    pub state: NowOperationState,
+    /// UNIX epoch millisecond timestamp when the daemon accepted the operation.
+    pub started_unix_ms: u64,
+    /// UNIX epoch millisecond terminal timestamp, if complete.
+    pub finished_unix_ms: Option<u64>,
+    /// Remote terminal exit code, if one was received.
+    pub exit_code: Option<u32>,
+    /// Stable human-readable terminal failure detail, if any.
+    pub error: Option<String>,
+    /// Total stdout bytes received from NOW.
+    pub stdout_bytes: u64,
+    /// Total stderr bytes received from NOW.
+    pub stderr_bytes: u64,
+    /// Output bytes still retained for later replay.
+    pub retained_bytes: u64,
+    /// Output bytes not retained because the bounded limit was exceeded.
+    pub dropped_bytes: u64,
+    /// Sequence number assigned to the next output event.
+    pub next_sequence: u64,
+}
+
+/// Local NOW transport and operation-manager diagnostics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NowDiagnostics {
+    /// The local named-pipe or Unix-socket endpoint injected into the RDP DVC configuration.
+    pub endpoint: String,
+    /// Active NOW protocol operation, if one currently owns the byte stream.
+    pub active_operation_id: Option<u64>,
+    /// Bounded retained output size per operation.
+    pub output_retention_bytes: u32,
+    /// Bounded protocol-to-manager event queue depth.
+    pub event_queue_capacity: u16,
+    /// First connection readiness deadline after RDP connection.
+    pub initial_connect_timeout_secs: u32,
+    /// Endpoint reconnect deadline after the first successful connection.
+    pub reconnect_timeout_secs: u32,
+}
+
+/// Stable category assigned to an agent IPC failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentErrorCode {
+    /// Input was invalid or contradicted another requested option.
+    InvalidRequest,
+    /// A requested session, operation, or resource does not exist.
+    NotFound,
+    /// The RDP session has not reached a state that permits the requested operation.
+    SessionNotReady,
+    /// The negotiated NOW capability set does not permit the request.
+    CapabilityUnavailable,
+    /// A bounded connection or operation deadline elapsed.
+    Timeout,
+    /// A cancellation request completed or prevented execution.
+    Cancelled,
+    /// The requested operation conflicts with an existing in-progress operation.
+    Conflict,
+    /// A local IPC/DVC/NOW transport operation failed.
+    Transport,
+    /// The failure does not fit a more specific public category.
+    Internal,
+}
+
+impl AgentErrorCode {
+    /// Stable machine-readable spelling used by JSON/NDJSON output.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::InvalidRequest => "invalid_request",
+            Self::NotFound => "not_found",
+            Self::SessionNotReady => "session_not_ready",
+            Self::CapabilityUnavailable => "capability_unavailable",
+            Self::Timeout => "timeout",
+            Self::Cancelled => "cancelled",
+            Self::Conflict => "conflict",
+            Self::Transport => "transport",
+            Self::Internal => "internal",
+        }
+    }
+}
+
+/// Structured daemon error envelope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentError {
+    /// Stable error category.
+    pub code: AgentErrorCode,
+    /// Human-readable detail.
+    pub message: String,
+}
+
+impl AgentError {
+    /// Classifies the daemon's established error messages without changing its text contract.
+    pub fn from_message(message: impl Into<String>) -> Self {
+        let message = message.into();
+        let code = if message.contains("not found") {
+            AgentErrorCode::NotFound
+        } else if message.contains("connected RDP") || message.contains("no active session") {
+            AgentErrorCode::SessionNotReady
+        } else if message.contains("does not support") || message.contains("capability") {
+            AgentErrorCode::CapabilityUnavailable
+        } else if message.contains("timeout") {
+            AgentErrorCode::Timeout
+        } else if message.contains("cancel") {
+            AgentErrorCode::Cancelled
+        } else if message.contains("already") || message.contains("in progress") || message.contains("backpressured") {
+            AgentErrorCode::Conflict
+        } else if message.contains("endpoint") || message.contains("pipe") || message.contains("transport") {
+            AgentErrorCode::Transport
+        } else if message.contains("invalid") || message.contains("must") || message.contains("provide") {
+            AgentErrorCode::InvalidRequest
+        } else {
+            AgentErrorCode::Internal
+        };
+        Self { code, message }
+    }
 }
 
 /// A [`PropertySet`] whose `Debug` output lists only the keys, never the (possibly secret) values.
@@ -258,7 +439,7 @@ pub enum Response {
     /// Success, carrying an operation-specific [`Payload`].
     Ok(Payload),
     /// Failure. The message is lowercase with no trailing punctuation.
-    Err(String),
+    Err(AgentError),
 }
 
 impl Response {
@@ -269,7 +450,7 @@ impl Response {
 
     /// A failure response.
     pub fn error(message: impl Into<String>) -> Self {
-        Self::Err(message.into())
+        Self::Err(AgentError::from_message(message))
     }
 
     /// Whether this is a success response.
@@ -304,6 +485,8 @@ pub enum Payload {
     /// A raw stdout or stderr chunk emitted by a streamed execution.
     NowExecutionData {
         operation_id: u64,
+        /// Monotonically increasing operation-local event sequence for replay/reattachment.
+        sequence: u64,
         stream: NowStream,
         data: Vec<u8>,
     },
@@ -311,6 +494,14 @@ pub enum Payload {
     NowExecutionResult { operation_id: u64, exit_code: u32 },
     /// Cancellation was requested for a streamed execution.
     NowCancelAccepted { operation_id: u64 },
+    /// Snapshot of one durable NOW operation.
+    NowOperationInfo(NowOperationInfo),
+    /// Snapshots of all durable NOW operations.
+    NowOperations(Vec<NowOperationInfo>),
+    /// Local NOW transport and operation-manager diagnostics.
+    NowDiagnostics(NowDiagnostics),
+    /// Standard-input fragment accepted by a running NOW operation.
+    NowStdinAccepted { operation_id: u64, last: bool },
 }
 
 impl fmt::Debug for Payload {
@@ -344,11 +535,13 @@ impl fmt::Debug for Payload {
                 .finish(),
             Self::NowExecutionData {
                 operation_id,
+                sequence,
                 stream,
                 data,
             } => f
                 .debug_struct("NowExecutionData")
                 .field("operation_id", operation_id)
+                .field("sequence", sequence)
                 .field("stream", stream)
                 .field("data_len", &data.len())
                 .finish(),
@@ -363,6 +556,14 @@ impl fmt::Debug for Payload {
             Self::NowCancelAccepted { operation_id } => f
                 .debug_struct("NowCancelAccepted")
                 .field("operation_id", operation_id)
+                .finish(),
+            Self::NowOperationInfo(info) => f.debug_tuple("NowOperationInfo").field(info).finish(),
+            Self::NowOperations(operations) => f.debug_tuple("NowOperations").field(operations).finish(),
+            Self::NowDiagnostics(diagnostics) => f.debug_tuple("NowDiagnostics").field(diagnostics).finish(),
+            Self::NowStdinAccepted { operation_id, last } => f
+                .debug_struct("NowStdinAccepted")
+                .field("operation_id", operation_id)
+                .field("last", last)
                 .finish(),
         }
     }
@@ -716,6 +917,8 @@ impl Encode for NowCapabilities {
         dst.write_u16(self.minor);
         dst.write_u16(self.system_capset);
         dst.write_u16(self.session_capset);
+        dst.write_u16(self.server_exec_capset);
+        dst.write_u16(self.client_exec_capset);
         dst.write_u16(self.exec_capset);
         match self.heartbeat_secs {
             Some(heartbeat_secs) => {
@@ -736,6 +939,8 @@ impl Encode for NowCapabilities {
             + 2 /* minor */
             + 2 /* system_capset */
             + 2 /* session_capset */
+            + 2 /* server_exec_capset */
+            + 2 /* client_exec_capset */
             + 2 /* exec_capset */
             + 1 /* heartbeat presence */
             + self.heartbeat_secs.map_or(0, |_| 4)
@@ -744,11 +949,13 @@ impl Encode for NowCapabilities {
 
 impl Decode<'_> for NowCapabilities {
     fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
-        ensure_size!(in: src, size: 10);
+        ensure_size!(in: src, size: 14);
         let major = src.read_u16();
         let minor = src.read_u16();
         let system_capset = src.read_u16();
         let session_capset = src.read_u16();
+        let server_exec_capset = src.read_u16();
+        let client_exec_capset = src.read_u16();
         let exec_capset = src.read_u16();
         ensure_size!(in: src, size: 1);
         let heartbeat_secs = match src.read_u8() {
@@ -769,6 +976,8 @@ impl Decode<'_> for NowCapabilities {
             minor,
             system_capset,
             session_capset,
+            server_exec_capset,
+            client_exec_capset,
             exec_capset,
             heartbeat_secs,
         })
@@ -776,6 +985,291 @@ impl Decode<'_> for NowCapabilities {
 }
 
 impl_pdu_pod!(NowCapabilities);
+
+impl Encode for NowOperationState {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u8(match self {
+            Self::Running => 0,
+            Self::Cancelling => 1,
+            Self::Succeeded => 2,
+            Self::Failed => 3,
+            Self::Cancelled => 4,
+            Self::Detached => 5,
+        });
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_agent::NowOperationState"
+    }
+
+    fn size(&self) -> usize {
+        1
+    }
+}
+
+impl Decode<'_> for NowOperationState {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 1);
+        match src.read_u8() {
+            0 => Ok(Self::Running),
+            1 => Ok(Self::Cancelling),
+            2 => Ok(Self::Succeeded),
+            3 => Ok(Self::Failed),
+            4 => Ok(Self::Cancelled),
+            5 => Ok(Self::Detached),
+            _ => Err(ironrdp_core::invalid_field_err!("NOW operation state", "unknown tag")),
+        }
+    }
+}
+
+impl_pdu_pod!(NowOperationState);
+
+impl Encode for NowOperationInfo {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u64(self.operation_id);
+        self.kind.encode(dst)?;
+        self.state.encode(dst)?;
+        dst.write_u64(self.started_unix_ms);
+        match self.finished_unix_ms {
+            Some(value) => {
+                dst.write_u8(1);
+                dst.write_u64(value);
+            }
+            None => dst.write_u8(0),
+        }
+        match self.exit_code {
+            Some(value) => {
+                dst.write_u8(1);
+                dst.write_u32(value);
+            }
+            None => dst.write_u8(0),
+        }
+        write_opt_string(dst, self.error.as_deref())?;
+        dst.write_u64(self.stdout_bytes);
+        dst.write_u64(self.stderr_bytes);
+        dst.write_u64(self.retained_bytes);
+        dst.write_u64(self.dropped_bytes);
+        dst.write_u64(self.next_sequence);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_agent::NowOperationInfo"
+    }
+
+    fn size(&self) -> usize {
+        8 /* operation_id */
+            + self.kind.size()
+            + self.state.size()
+            + 8 /* started_unix_ms */
+            + 1 /* finished presence */
+            + self.finished_unix_ms.map_or(0, |_| 8)
+            + 1 /* exit presence */
+            + self.exit_code.map_or(0, |_| 4)
+            + opt_string_size(self.error.as_deref())
+            + 8 /* stdout_bytes */
+            + 8 /* stderr_bytes */
+            + 8 /* retained_bytes */
+            + 8 /* dropped_bytes */
+            + 8 /* next_sequence */
+    }
+}
+
+impl Decode<'_> for NowOperationInfo {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 18);
+        let operation_id = src.read_u64();
+        let kind = NowExecutionKind::decode(src)?;
+        let state = NowOperationState::decode(src)?;
+        let started_unix_ms = src.read_u64();
+        ensure_size!(in: src, size: 1);
+        let finished_unix_ms = match src.read_u8() {
+            0 => None,
+            1 => {
+                ensure_size!(in: src, size: 8);
+                Some(src.read_u64())
+            }
+            _ => {
+                return Err(ironrdp_core::invalid_field_err!(
+                    "NOW operation finish",
+                    "invalid presence flag"
+                ));
+            }
+        };
+        ensure_size!(in: src, size: 1);
+        let exit_code = match src.read_u8() {
+            0 => None,
+            1 => {
+                ensure_size!(in: src, size: 4);
+                Some(src.read_u32())
+            }
+            _ => {
+                return Err(ironrdp_core::invalid_field_err!(
+                    "NOW operation exit",
+                    "invalid presence flag"
+                ));
+            }
+        };
+        let error = read_opt_string(src)?;
+        ensure_size!(in: src, size: 40);
+        Ok(Self {
+            operation_id,
+            kind,
+            state,
+            started_unix_ms,
+            finished_unix_ms,
+            exit_code,
+            error,
+            stdout_bytes: src.read_u64(),
+            stderr_bytes: src.read_u64(),
+            retained_bytes: src.read_u64(),
+            dropped_bytes: src.read_u64(),
+            next_sequence: src.read_u64(),
+        })
+    }
+}
+
+impl_pdu_pod!(NowOperationInfo);
+
+impl Encode for NowDiagnostics {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        write_string(dst, &self.endpoint)?;
+        match self.active_operation_id {
+            Some(value) => {
+                dst.write_u8(1);
+                dst.write_u64(value);
+            }
+            None => dst.write_u8(0),
+        }
+        dst.write_u32(self.output_retention_bytes);
+        dst.write_u16(self.event_queue_capacity);
+        dst.write_u32(self.initial_connect_timeout_secs);
+        dst.write_u32(self.reconnect_timeout_secs);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_agent::NowDiagnostics"
+    }
+
+    fn size(&self) -> usize {
+        string_size(&self.endpoint)
+            + 1 /* active operation presence */
+            + self.active_operation_id.map_or(0, |_| 8)
+            + 4 /* output_retention_bytes */
+            + 2 /* event_queue_capacity */
+            + 4 /* initial_connect_timeout_secs */
+            + 4 /* reconnect_timeout_secs */
+    }
+}
+
+impl Decode<'_> for NowDiagnostics {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        let endpoint = read_string(src)?;
+        ensure_size!(in: src, size: 1);
+        let active_operation_id = match src.read_u8() {
+            0 => None,
+            1 => {
+                ensure_size!(in: src, size: 8);
+                Some(src.read_u64())
+            }
+            _ => {
+                return Err(ironrdp_core::invalid_field_err!(
+                    "NOW active operation",
+                    "invalid presence flag"
+                ));
+            }
+        };
+        ensure_size!(in: src, size: 14);
+        Ok(Self {
+            endpoint,
+            active_operation_id,
+            output_retention_bytes: src.read_u32(),
+            event_queue_capacity: src.read_u16(),
+            initial_connect_timeout_secs: src.read_u32(),
+            reconnect_timeout_secs: src.read_u32(),
+        })
+    }
+}
+
+impl_pdu_pod!(NowDiagnostics);
+
+impl Encode for AgentErrorCode {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u8(match self {
+            Self::InvalidRequest => 0,
+            Self::NotFound => 1,
+            Self::SessionNotReady => 2,
+            Self::CapabilityUnavailable => 3,
+            Self::Timeout => 4,
+            Self::Cancelled => 5,
+            Self::Conflict => 6,
+            Self::Transport => 7,
+            Self::Internal => 8,
+        });
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_agent::AgentErrorCode"
+    }
+
+    fn size(&self) -> usize {
+        1
+    }
+}
+
+impl Decode<'_> for AgentErrorCode {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 1);
+        match src.read_u8() {
+            0 => Ok(Self::InvalidRequest),
+            1 => Ok(Self::NotFound),
+            2 => Ok(Self::SessionNotReady),
+            3 => Ok(Self::CapabilityUnavailable),
+            4 => Ok(Self::Timeout),
+            5 => Ok(Self::Cancelled),
+            6 => Ok(Self::Conflict),
+            7 => Ok(Self::Transport),
+            8 => Ok(Self::Internal),
+            _ => Err(ironrdp_core::invalid_field_err!("agent error code", "unknown tag")),
+        }
+    }
+}
+
+impl_pdu_pod!(AgentErrorCode);
+
+impl Encode for AgentError {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        self.code.encode(dst)?;
+        write_string(dst, &self.message)
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_agent::AgentError"
+    }
+
+    fn size(&self) -> usize {
+        self.code.size() + string_size(&self.message)
+    }
+}
+
+impl Decode<'_> for AgentError {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        Ok(Self {
+            code: AgentErrorCode::decode(src)?,
+            message: read_string(src)?,
+        })
+    }
+}
+
+impl_pdu_pod!(AgentError);
 
 // ── PropValue / PropertyEntry / PropertyDump codec ──────────────────────────
 
@@ -982,11 +1476,13 @@ impl Encode for Payload {
             }
             Self::NowExecutionData {
                 operation_id,
+                sequence,
                 stream,
                 data,
             } => {
                 dst.write_u8(8);
                 dst.write_u64(*operation_id);
+                dst.write_u64(*sequence);
                 stream.encode(dst)?;
                 write_bytes(dst, data)?;
             }
@@ -1001,6 +1497,27 @@ impl Encode for Payload {
             Self::NowCancelAccepted { operation_id } => {
                 dst.write_u8(10);
                 dst.write_u64(*operation_id);
+            }
+            Self::NowOperationInfo(info) => {
+                dst.write_u8(11);
+                info.encode(dst)?;
+            }
+            Self::NowOperations(operations) => {
+                dst.write_u8(12);
+                let count: u32 = cast_length!("NOW operation count", operations.len())?;
+                dst.write_u32(count);
+                for operation in operations {
+                    operation.encode(dst)?;
+                }
+            }
+            Self::NowDiagnostics(diagnostics) => {
+                dst.write_u8(13);
+                diagnostics.encode(dst)?;
+            }
+            Self::NowStdinAccepted { operation_id, last } => {
+                dst.write_u8(14);
+                dst.write_u64(*operation_id);
+                write_bool(dst, *last)?;
             }
         }
         Ok(())
@@ -1024,9 +1541,13 @@ impl Encode for Payload {
                 Self::NowCapabilities(capabilities) => capabilities.size(),
                 Self::NowExecutionStarted { .. } | Self::NowCancelAccepted { .. } => 8 /* operation_id */,
                 Self::NowExecutionData { stream, data, .. } => {
-                    8 /* operation_id */ + stream.size() + bytes_size(data)
+                    8 /* operation_id */ + 8 /* sequence */ + stream.size() + bytes_size(data)
                 }
                 Self::NowExecutionResult { .. } => 8 /* operation_id */ + 4 /* exit_code */,
+                Self::NowOperationInfo(info) => info.size(),
+                Self::NowOperations(operations) => 4 + operations.iter().map(Encode::size).sum::<usize>(),
+                Self::NowDiagnostics(diagnostics) => diagnostics.size(),
+                Self::NowStdinAccepted { .. } => 8 /* operation_id */ + 1 /* last */,
             }
     }
 }
@@ -1073,12 +1594,14 @@ impl Decode<'_> for Payload {
                 })
             }
             8 => {
-                ensure_size!(in: src, size: 8);
+                ensure_size!(in: src, size: 16);
                 let operation_id = src.read_u64();
+                let sequence = src.read_u64();
                 let stream = NowStream::decode(src)?;
                 let data = read_bytes(src)?;
                 Ok(Self::NowExecutionData {
                     operation_id,
+                    sequence,
                     stream,
                     data,
                 })
@@ -1094,6 +1617,24 @@ impl Decode<'_> for Payload {
                 ensure_size!(in: src, size: 8);
                 Ok(Self::NowCancelAccepted {
                     operation_id: src.read_u64(),
+                })
+            }
+            11 => Ok(Self::NowOperationInfo(NowOperationInfo::decode(src)?)),
+            12 => {
+                ensure_size!(in: src, size: 4);
+                let count = src.read_u32();
+                let mut operations = Vec::new();
+                for _ in 0..count {
+                    operations.push(NowOperationInfo::decode(src)?);
+                }
+                Ok(Self::NowOperations(operations))
+            }
+            13 => Ok(Self::NowDiagnostics(NowDiagnostics::decode(src)?)),
+            14 => {
+                ensure_size!(in: src, size: 8);
+                Ok(Self::NowStdinAccepted {
+                    operation_id: src.read_u64(),
+                    last: read_bool(src)?,
                 })
             }
             _ => Err(ironrdp_core::invalid_field_err!("payload", "unknown tag")),
@@ -1113,9 +1654,9 @@ impl Encode for Response {
                 dst.write_u8(0);
                 payload.encode(dst)
             }
-            Self::Err(message) => {
+            Self::Err(error) => {
                 dst.write_u8(1);
-                write_string(dst, message)
+                error.encode(dst)
             }
         }
     }
@@ -1128,7 +1669,7 @@ impl Encode for Response {
         1 /* tag */
             + match self {
                 Self::Ok(payload) => payload.size(),
-                Self::Err(message) => string_size(message),
+                Self::Err(error) => error.size(),
             }
     }
 }
@@ -1138,7 +1679,7 @@ impl Decode<'_> for Response {
         ensure_size!(in: src, size: 1);
         match src.read_u8() {
             0 => Ok(Self::Ok(Payload::decode(src)?)),
-            1 => Ok(Self::Err(read_string(src)?)),
+            1 => Ok(Self::Err(AgentError::decode(src)?)),
             _ => Err(ironrdp_core::invalid_field_err!("response", "unknown tag")),
         }
     }
@@ -1235,6 +1776,30 @@ impl Encode for Request {
                 dst.write_u8(15);
                 dst.write_u64(*operation_id);
             }
+            Self::NowOperations => dst.write_u8(16),
+            Self::NowOperationStatus { operation_id } => {
+                dst.write_u8(17);
+                dst.write_u64(*operation_id);
+            }
+            Self::NowOperationAttach {
+                operation_id,
+                after_sequence,
+            } => {
+                dst.write_u8(18);
+                dst.write_u64(*operation_id);
+                dst.write_u64(*after_sequence);
+            }
+            Self::NowDiagnostics => dst.write_u8(19),
+            Self::NowWriteStdin {
+                operation_id,
+                data,
+                last,
+            } => {
+                dst.write_u8(20);
+                dst.write_u64(*operation_id);
+                write_bytes(dst, data)?;
+                write_bool(dst, *last)?;
+            }
         }
         Ok(())
     }
@@ -1269,6 +1834,10 @@ impl Encode for Request {
                 Self::NowCapabilities => 0,
                 Self::NowExecute(request) => request.size(),
                 Self::NowCancel { .. } => 8 /* operation_id */,
+                Self::NowOperations | Self::NowDiagnostics => 0,
+                Self::NowOperationStatus { .. } => 8 /* operation_id */,
+                Self::NowOperationAttach { .. } => 8 /* operation_id */ + 8 /* after_sequence */,
+                Self::NowWriteStdin { data, .. } => 8 /* operation_id */ + bytes_size(data) + 1 /* last */,
             }
     }
 }
@@ -1365,6 +1934,32 @@ impl Decode<'_> for Request {
                     operation_id: src.read_u64(),
                 })
             }
+            16 => Ok(Self::NowOperations),
+            17 => {
+                ensure_size!(in: src, size: 8);
+                Ok(Self::NowOperationStatus {
+                    operation_id: src.read_u64(),
+                })
+            }
+            18 => {
+                ensure_size!(in: src, size: 16);
+                Ok(Self::NowOperationAttach {
+                    operation_id: src.read_u64(),
+                    after_sequence: src.read_u64(),
+                })
+            }
+            19 => Ok(Self::NowDiagnostics),
+            20 => {
+                ensure_size!(in: src, size: 8);
+                let operation_id = src.read_u64();
+                let data = read_bytes(src)?;
+                let last = read_bool(src)?;
+                Ok(Self::NowWriteStdin {
+                    operation_id,
+                    data,
+                    last,
+                })
+            }
             _ => Err(ironrdp_core::invalid_field_err!("request", "unknown tag")),
         }
     }
@@ -1422,6 +2017,7 @@ mod tests {
 
         let response = Response::Ok(Payload::NowExecutionData {
             operation_id: 17,
+            sequence: 3,
             stream: NowStream::Stderr,
             data: vec![0, 0xff],
         });
@@ -1437,11 +2033,54 @@ mod tests {
             minor: 6,
             system_capset: 1,
             session_capset: 0x1f,
+            server_exec_capset: 0x107f,
+            client_exec_capset: 0x107f,
             exec_capset: 0x107f,
             heartbeat_secs: Some(60),
         }));
         let bytes = ironrdp_core::encode_vec(&response).expect("encode response");
         let decoded = ironrdp_core::decode_owned::<Response>(&bytes).expect("decode response");
         assert_eq!(decoded, response);
+    }
+
+    #[test]
+    fn durable_now_operation_protocol_roundtrips_with_typed_errors() {
+        let request = Request::NowOperationAttach {
+            operation_id: 17,
+            after_sequence: 8,
+        };
+        let bytes = ironrdp_core::encode_vec(&request).expect("encode request");
+        let decoded = ironrdp_core::decode_owned::<Request>(&bytes).expect("decode request");
+        assert_eq!(decoded, request);
+
+        let response = Response::Ok(Payload::NowOperationInfo(NowOperationInfo {
+            operation_id: 17,
+            kind: NowExecutionKind::PowerShell,
+            state: NowOperationState::Succeeded,
+            started_unix_ms: 10,
+            finished_unix_ms: Some(20),
+            exit_code: Some(7),
+            error: None,
+            stdout_bytes: 3,
+            stderr_bytes: 4,
+            retained_bytes: 7,
+            dropped_bytes: 0,
+            next_sequence: 3,
+        }));
+        let bytes = ironrdp_core::encode_vec(&response).expect("encode response");
+        let decoded = ironrdp_core::decode_owned::<Response>(&bytes).expect("decode response");
+        assert_eq!(decoded, response);
+
+        let error = Response::error("NOW operation 17 was not found");
+        let bytes = ironrdp_core::encode_vec(&error).expect("encode error");
+        let decoded = ironrdp_core::decode_owned::<Response>(&bytes).expect("decode error");
+        assert_eq!(decoded, error);
+        assert!(matches!(
+            decoded,
+            Response::Err(AgentError {
+                code: AgentErrorCode::NotFound,
+                ..
+            })
+        ));
     }
 }

--- a/crates/ironrdp-agent/src/ipc.rs
+++ b/crates/ironrdp-agent/src/ipc.rs
@@ -19,11 +19,10 @@ use ironrdp_input::MouseButton;
 use ironrdp_pdu::impl_pdu_pod;
 use ironrdp_propertyset::PropertySet;
 
-use crate::wire::propertyset;
 use crate::wire::{
-    bytes_size, opt_string_size, opt_u16_size, read_bool, read_bytes, read_char, read_mouse_button, read_opt_string,
-    read_opt_u16, read_string, string_size, write_bool, write_bytes, write_char, write_mouse_button, write_opt_string,
-    write_opt_u16, write_string,
+    bytes_size, opt_string_size, opt_u16_size, propertyset, read_bool, read_bytes, read_char, read_mouse_button,
+    read_opt_string, read_opt_u16, read_string, string_size, write_bool, write_bytes, write_char, write_mouse_button,
+    write_opt_string, write_opt_u16, write_string,
 };
 
 /// A request sent by the CLI to the daemon.
@@ -69,6 +68,19 @@ pub enum Request {
     KeyUnicode { ch: char, pressed: bool },
     /// Resize the remote desktop.
     Resize { width: u16, height: u16 },
+    /// Execute a PowerShell command through the negotiated NOW DVC channel.
+    PowerShell {
+        kind: PowerShellKind,
+        command: String,
+        no_profile: bool,
+        non_interactive: bool,
+    },
+    /// Report the NOW protocol capabilities negotiated with the remote agent.
+    NowCapabilities,
+    /// Start one capability-gated NOW execution and stream its events on this IPC connection.
+    NowExecute(NowExecutionRequest),
+    /// Request normal cancellation of a running NOW execution.
+    NowCancel { operation_id: u64 },
     // TODO: add clipboard support (CLIPRDR), e.g. requests to read the remote clipboard text and to
     // set it, so an LLM can copy/paste to and from the session.
 }
@@ -121,8 +133,114 @@ impl fmt::Debug for Request {
                 .field("width", width)
                 .field("height", height)
                 .finish(),
+            Self::PowerShell {
+                kind,
+                command,
+                no_profile,
+                non_interactive,
+            } => f
+                .debug_struct("PowerShell")
+                .field("kind", kind)
+                .field("command_len", &command.len())
+                .field("no_profile", no_profile)
+                .field("non_interactive", non_interactive)
+                .finish(),
+            Self::NowCapabilities => f.write_str("NowCapabilities"),
+            Self::NowExecute(request) => f.debug_tuple("NowExecute").field(request).finish(),
+            Self::NowCancel { operation_id } => {
+                f.debug_struct("NowCancel").field("operation_id", operation_id).finish()
+            }
         }
     }
+}
+
+/// The remote PowerShell implementation selected for a NOW execution request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PowerShellKind {
+    /// Windows PowerShell 5 (`powershell.exe`).
+    WindowsPowerShell,
+    /// PowerShell 7 (`pwsh.exe`).
+    PowerShell,
+}
+
+/// Execution style selected for a NOW request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NowExecutionKind {
+    /// Windows PowerShell 5 (`powershell.exe`).
+    WindowsPowerShell,
+    /// PowerShell 7 (`pwsh.exe`).
+    PowerShell,
+    /// A Windows CreateProcess invocation.
+    Process,
+    /// A command interpreted by the remote host's configured shell.
+    Shell,
+    /// A Windows batch command.
+    Batch,
+}
+
+/// Typed arguments shared by streamed NOW execution styles.
+#[derive(Clone, PartialEq, Eq)]
+pub struct NowExecutionRequest {
+    /// The remote execution style.
+    pub kind: NowExecutionKind,
+    /// Command text or executable filename, depending on `kind`.
+    pub command: String,
+    /// Process parameters or an optional shell executable.
+    pub parameters: Option<String>,
+    /// Remote working directory.
+    pub directory: Option<String>,
+    /// Use `-NoProfile` for PowerShell styles.
+    pub no_profile: bool,
+    /// Use `-NonInteractive` for PowerShell styles.
+    pub non_interactive: bool,
+    /// Start without a terminal result or redirected output.
+    pub detached: bool,
+    /// Cancel the execution after this many seconds.
+    pub timeout_secs: Option<u32>,
+    /// Bytes to forward to the redirected remote standard input after the operation starts.
+    pub stdin: Option<Vec<u8>>,
+}
+
+impl fmt::Debug for NowExecutionRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("NowExecutionRequest")
+            .field("kind", &self.kind)
+            .field("command_len", &self.command.len())
+            .field("parameters_len", &self.parameters.as_ref().map(String::len))
+            .field("directory", &self.directory)
+            .field("no_profile", &self.no_profile)
+            .field("non_interactive", &self.non_interactive)
+            .field("detached", &self.detached)
+            .field("timeout_secs", &self.timeout_secs)
+            .field("stdin_len", &self.stdin.as_ref().map(Vec::len))
+            .finish()
+    }
+}
+
+/// A redirected NOW execution stream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NowStream {
+    /// Standard output.
+    Stdout,
+    /// Standard error.
+    Stderr,
+}
+
+/// Snapshot of the remote NOW protocol capabilities after negotiation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NowCapabilities {
+    /// Negotiated NOW protocol major version.
+    pub major: u16,
+    /// Negotiated NOW protocol minor version.
+    pub minor: u16,
+    /// Server-advertised system capability bitset.
+    pub system_capset: u16,
+    /// Server-advertised session capability bitset.
+    pub session_capset: u16,
+    /// Execution capabilities available to this agent after intersection.
+    pub exec_capset: u16,
+    /// Negotiated channel heartbeat interval in seconds, if set.
+    pub heartbeat_secs: Option<u32>,
 }
 
 /// A [`PropertySet`] whose `Debug` output lists only the keys, never the (possibly secret) values.
@@ -173,6 +291,26 @@ pub enum Payload {
     Logs(Vec<String>),
     /// The most recent frame encoded as a PNG (cursor included), with its dimensions.
     Screenshot { width: u16, height: u16, png: Vec<u8> },
+    /// The byte streams and exit status returned by a NOW PowerShell invocation.
+    PowerShell {
+        stdout: Vec<u8>,
+        stderr: Vec<u8>,
+        exit_code: u32,
+    },
+    /// NOW capability snapshot.
+    NowCapabilities(NowCapabilities),
+    /// A streamed execution has been accepted with this local operation ID.
+    NowExecutionStarted { operation_id: u64 },
+    /// A raw stdout or stderr chunk emitted by a streamed execution.
+    NowExecutionData {
+        operation_id: u64,
+        stream: NowStream,
+        data: Vec<u8>,
+    },
+    /// Terminal result for a streamed execution.
+    NowExecutionResult { operation_id: u64, exit_code: u32 },
+    /// Cancellation was requested for a streamed execution.
+    NowCancelAccepted { operation_id: u64 },
 }
 
 impl fmt::Debug for Payload {
@@ -188,6 +326,43 @@ impl fmt::Debug for Payload {
                 .field("width", width)
                 .field("height", height)
                 .field("png_len", &png.len())
+                .finish(),
+            Self::PowerShell {
+                stdout,
+                stderr,
+                exit_code,
+            } => f
+                .debug_struct("PowerShell")
+                .field("stdout_len", &stdout.len())
+                .field("stderr_len", &stderr.len())
+                .field("exit_code", exit_code)
+                .finish(),
+            Self::NowCapabilities(capabilities) => f.debug_tuple("NowCapabilities").field(capabilities).finish(),
+            Self::NowExecutionStarted { operation_id } => f
+                .debug_struct("NowExecutionStarted")
+                .field("operation_id", operation_id)
+                .finish(),
+            Self::NowExecutionData {
+                operation_id,
+                stream,
+                data,
+            } => f
+                .debug_struct("NowExecutionData")
+                .field("operation_id", operation_id)
+                .field("stream", stream)
+                .field("data_len", &data.len())
+                .finish(),
+            Self::NowExecutionResult {
+                operation_id,
+                exit_code,
+            } => f
+                .debug_struct("NowExecutionResult")
+                .field("operation_id", operation_id)
+                .field("exit_code", exit_code)
+                .finish(),
+            Self::NowCancelAccepted { operation_id } => f
+                .debug_struct("NowCancelAccepted")
+                .field("operation_id", operation_id)
                 .finish(),
         }
     }
@@ -341,6 +516,266 @@ impl Decode<'_> for KeyFilter {
 }
 
 impl_pdu_pod!(KeyFilter);
+
+// ── PowerShellKind codec ─────────────────────────────────────────────────────
+
+impl Encode for PowerShellKind {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u8(match self {
+            Self::WindowsPowerShell => 0,
+            Self::PowerShell => 1,
+        });
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_agent::PowerShellKind"
+    }
+
+    fn size(&self) -> usize {
+        1
+    }
+}
+
+impl Decode<'_> for PowerShellKind {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 1);
+        match src.read_u8() {
+            0 => Ok(Self::WindowsPowerShell),
+            1 => Ok(Self::PowerShell),
+            _ => Err(ironrdp_core::invalid_field_err!("PowerShell kind", "unknown tag")),
+        }
+    }
+}
+
+impl_pdu_pod!(PowerShellKind);
+
+// ── NOW streamed execution codec ────────────────────────────────────────────
+
+impl Encode for NowExecutionKind {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u8(match self {
+            Self::WindowsPowerShell => 0,
+            Self::PowerShell => 1,
+            Self::Process => 2,
+            Self::Shell => 3,
+            Self::Batch => 4,
+        });
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_agent::NowExecutionKind"
+    }
+
+    fn size(&self) -> usize {
+        1
+    }
+}
+
+impl Decode<'_> for NowExecutionKind {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 1);
+        match src.read_u8() {
+            0 => Ok(Self::WindowsPowerShell),
+            1 => Ok(Self::PowerShell),
+            2 => Ok(Self::Process),
+            3 => Ok(Self::Shell),
+            4 => Ok(Self::Batch),
+            _ => Err(ironrdp_core::invalid_field_err!("NOW execution kind", "unknown tag")),
+        }
+    }
+}
+
+impl_pdu_pod!(NowExecutionKind);
+
+impl Encode for NowStream {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u8(match self {
+            Self::Stdout => 0,
+            Self::Stderr => 1,
+        });
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_agent::NowStream"
+    }
+
+    fn size(&self) -> usize {
+        1
+    }
+}
+
+impl Decode<'_> for NowStream {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 1);
+        match src.read_u8() {
+            0 => Ok(Self::Stdout),
+            1 => Ok(Self::Stderr),
+            _ => Err(ironrdp_core::invalid_field_err!("NOW stream", "unknown tag")),
+        }
+    }
+}
+
+impl_pdu_pod!(NowStream);
+
+impl Encode for NowExecutionRequest {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        self.kind.encode(dst)?;
+        write_string(dst, &self.command)?;
+        write_opt_string(dst, self.parameters.as_deref())?;
+        write_opt_string(dst, self.directory.as_deref())?;
+        write_bool(dst, self.no_profile)?;
+        write_bool(dst, self.non_interactive)?;
+        write_bool(dst, self.detached)?;
+        match self.timeout_secs {
+            Some(timeout_secs) => {
+                dst.write_u8(1);
+                dst.write_u32(timeout_secs);
+            }
+            None => dst.write_u8(0),
+        }
+        match &self.stdin {
+            Some(stdin) => {
+                dst.write_u8(1);
+                write_bytes(dst, stdin)?;
+            }
+            None => dst.write_u8(0),
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_agent::NowExecutionRequest"
+    }
+
+    fn size(&self) -> usize {
+        self.kind.size()
+            + string_size(&self.command)
+            + opt_string_size(self.parameters.as_deref())
+            + opt_string_size(self.directory.as_deref())
+            + 1 /* no_profile */
+            + 1 /* non_interactive */
+            + 1 /* detached */
+            + 1 /* timeout presence */
+            + self.timeout_secs.map_or(0, |_| 4)
+            + 1 /* stdin presence */
+            + self.stdin.as_ref().map_or(0, |stdin| bytes_size(stdin))
+    }
+}
+
+impl Decode<'_> for NowExecutionRequest {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        let kind = NowExecutionKind::decode(src)?;
+        let command = read_string(src)?;
+        let parameters = read_opt_string(src)?;
+        let directory = read_opt_string(src)?;
+        let no_profile = read_bool(src)?;
+        let non_interactive = read_bool(src)?;
+        let detached = read_bool(src)?;
+        ensure_size!(in: src, size: 1);
+        let timeout_secs = match src.read_u8() {
+            0 => None,
+            1 => {
+                ensure_size!(in: src, size: 4);
+                Some(src.read_u32())
+            }
+            _ => return Err(ironrdp_core::invalid_field_err!("NOW timeout", "invalid presence flag")),
+        };
+        ensure_size!(in: src, size: 1);
+        let stdin = match src.read_u8() {
+            0 => None,
+            1 => Some(read_bytes(src)?),
+            _ => return Err(ironrdp_core::invalid_field_err!("NOW stdin", "invalid presence flag")),
+        };
+        Ok(Self {
+            kind,
+            command,
+            parameters,
+            directory,
+            no_profile,
+            non_interactive,
+            detached,
+            timeout_secs,
+            stdin,
+        })
+    }
+}
+
+impl_pdu_pod!(NowExecutionRequest);
+
+impl Encode for NowCapabilities {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u16(self.major);
+        dst.write_u16(self.minor);
+        dst.write_u16(self.system_capset);
+        dst.write_u16(self.session_capset);
+        dst.write_u16(self.exec_capset);
+        match self.heartbeat_secs {
+            Some(heartbeat_secs) => {
+                dst.write_u8(1);
+                dst.write_u32(heartbeat_secs);
+            }
+            None => dst.write_u8(0),
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_agent::NowCapabilities"
+    }
+
+    fn size(&self) -> usize {
+        2 /* major */
+            + 2 /* minor */
+            + 2 /* system_capset */
+            + 2 /* session_capset */
+            + 2 /* exec_capset */
+            + 1 /* heartbeat presence */
+            + self.heartbeat_secs.map_or(0, |_| 4)
+    }
+}
+
+impl Decode<'_> for NowCapabilities {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 10);
+        let major = src.read_u16();
+        let minor = src.read_u16();
+        let system_capset = src.read_u16();
+        let session_capset = src.read_u16();
+        let exec_capset = src.read_u16();
+        ensure_size!(in: src, size: 1);
+        let heartbeat_secs = match src.read_u8() {
+            0 => None,
+            1 => {
+                ensure_size!(in: src, size: 4);
+                Some(src.read_u32())
+            }
+            _ => {
+                return Err(ironrdp_core::invalid_field_err!(
+                    "NOW heartbeat",
+                    "invalid presence flag"
+                ));
+            }
+        };
+        Ok(Self {
+            major,
+            minor,
+            system_capset,
+            session_capset,
+            exec_capset,
+            heartbeat_secs,
+        })
+    }
+}
+
+impl_pdu_pod!(NowCapabilities);
 
 // ── PropValue / PropertyEntry / PropertyDump codec ──────────────────────────
 
@@ -527,6 +962,46 @@ impl Encode for Payload {
                 dst.write_u16(*height);
                 write_bytes(dst, png)?;
             }
+            Self::PowerShell {
+                stdout,
+                stderr,
+                exit_code,
+            } => {
+                dst.write_u8(5);
+                write_bytes(dst, stdout)?;
+                write_bytes(dst, stderr)?;
+                dst.write_u32(*exit_code);
+            }
+            Self::NowCapabilities(capabilities) => {
+                dst.write_u8(6);
+                capabilities.encode(dst)?;
+            }
+            Self::NowExecutionStarted { operation_id } => {
+                dst.write_u8(7);
+                dst.write_u64(*operation_id);
+            }
+            Self::NowExecutionData {
+                operation_id,
+                stream,
+                data,
+            } => {
+                dst.write_u8(8);
+                dst.write_u64(*operation_id);
+                stream.encode(dst)?;
+                write_bytes(dst, data)?;
+            }
+            Self::NowExecutionResult {
+                operation_id,
+                exit_code,
+            } => {
+                dst.write_u8(9);
+                dst.write_u64(*operation_id);
+                dst.write_u32(*exit_code);
+            }
+            Self::NowCancelAccepted { operation_id } => {
+                dst.write_u8(10);
+                dst.write_u64(*operation_id);
+            }
         }
         Ok(())
     }
@@ -543,6 +1018,15 @@ impl Encode for Payload {
                 Self::Properties(dump) => dump.size(),
                 Self::Logs(lines) => 4 + lines.iter().map(|line| string_size(line)).sum::<usize>(),
                 Self::Screenshot { png, .. } => 2 /* width */ + 2 /* height */ + bytes_size(png),
+                Self::PowerShell { stdout, stderr, .. } => {
+                    bytes_size(stdout) + bytes_size(stderr) + 4 /* exit_code */
+                }
+                Self::NowCapabilities(capabilities) => capabilities.size(),
+                Self::NowExecutionStarted { .. } | Self::NowCancelAccepted { .. } => 8 /* operation_id */,
+                Self::NowExecutionData { stream, data, .. } => {
+                    8 /* operation_id */ + stream.size() + bytes_size(data)
+                }
+                Self::NowExecutionResult { .. } => 8 /* operation_id */ + 4 /* exit_code */,
             }
     }
 }
@@ -569,6 +1053,48 @@ impl Decode<'_> for Payload {
                 let height = src.read_u16();
                 let png = read_bytes(src)?;
                 Ok(Self::Screenshot { width, height, png })
+            }
+            5 => {
+                let stdout = read_bytes(src)?;
+                let stderr = read_bytes(src)?;
+                ensure_size!(in: src, size: 4);
+                let exit_code = src.read_u32();
+                Ok(Self::PowerShell {
+                    stdout,
+                    stderr,
+                    exit_code,
+                })
+            }
+            6 => Ok(Self::NowCapabilities(NowCapabilities::decode(src)?)),
+            7 => {
+                ensure_size!(in: src, size: 8);
+                Ok(Self::NowExecutionStarted {
+                    operation_id: src.read_u64(),
+                })
+            }
+            8 => {
+                ensure_size!(in: src, size: 8);
+                let operation_id = src.read_u64();
+                let stream = NowStream::decode(src)?;
+                let data = read_bytes(src)?;
+                Ok(Self::NowExecutionData {
+                    operation_id,
+                    stream,
+                    data,
+                })
+            }
+            9 => {
+                ensure_size!(in: src, size: 12);
+                Ok(Self::NowExecutionResult {
+                    operation_id: src.read_u64(),
+                    exit_code: src.read_u32(),
+                })
+            }
+            10 => {
+                ensure_size!(in: src, size: 8);
+                Ok(Self::NowCancelAccepted {
+                    operation_id: src.read_u64(),
+                })
             }
             _ => Err(ironrdp_core::invalid_field_err!("payload", "unknown tag")),
         }
@@ -688,6 +1214,27 @@ impl Encode for Request {
                 dst.write_u16(*width);
                 dst.write_u16(*height);
             }
+            Self::PowerShell {
+                kind,
+                command,
+                no_profile,
+                non_interactive,
+            } => {
+                dst.write_u8(12);
+                kind.encode(dst)?;
+                write_string(dst, command)?;
+                write_bool(dst, *no_profile)?;
+                write_bool(dst, *non_interactive)?;
+            }
+            Self::NowCapabilities => dst.write_u8(13),
+            Self::NowExecute(request) => {
+                dst.write_u8(14);
+                request.encode(dst)?;
+            }
+            Self::NowCancel { operation_id } => {
+                dst.write_u8(15);
+                dst.write_u64(*operation_id);
+            }
         }
         Ok(())
     }
@@ -713,6 +1260,15 @@ impl Encode for Request {
                 Self::KeyScancode { .. } => 2 /* scancode */ + 1 /* pressed */,
                 Self::KeyUnicode { .. } => 4 /* ch */ + 1 /* pressed */,
                 Self::Resize { .. } => 2 /* width */ + 2 /* height */,
+                Self::PowerShell {
+                    kind,
+                    command,
+                    no_profile: _,
+                    non_interactive: _,
+                } => kind.size() + string_size(command) + 1 /* no_profile */ + 1 /* non_interactive */,
+                Self::NowCapabilities => 0,
+                Self::NowExecute(request) => request.size(),
+                Self::NowCancel { .. } => 8 /* operation_id */,
             }
     }
 }
@@ -789,9 +1345,103 @@ impl Decode<'_> for Request {
                 let height = src.read_u16();
                 Ok(Self::Resize { width, height })
             }
+            12 => {
+                let kind = PowerShellKind::decode(src)?;
+                let command = read_string(src)?;
+                let no_profile = read_bool(src)?;
+                let non_interactive = read_bool(src)?;
+                Ok(Self::PowerShell {
+                    kind,
+                    command,
+                    no_profile,
+                    non_interactive,
+                })
+            }
+            13 => Ok(Self::NowCapabilities),
+            14 => Ok(Self::NowExecute(NowExecutionRequest::decode(src)?)),
+            15 => {
+                ensure_size!(in: src, size: 8);
+                Ok(Self::NowCancel {
+                    operation_id: src.read_u64(),
+                })
+            }
             _ => Err(ironrdp_core::invalid_field_err!("request", "unknown tag")),
         }
     }
 }
 
 impl_pdu_pod!(Request);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn powershell_request_roundtrips_without_exposing_command_in_debug() {
+        let request = Request::PowerShell {
+            kind: PowerShellKind::PowerShell,
+            command: "Write-Output secret".to_owned(),
+            no_profile: true,
+            non_interactive: true,
+        };
+        let bytes = ironrdp_core::encode_vec(&request).expect("encode request");
+        let decoded = ironrdp_core::decode_owned::<Request>(&bytes).expect("decode request");
+        assert_eq!(decoded, request);
+        assert!(!format!("{request:?}").contains("secret"));
+    }
+
+    #[test]
+    fn powershell_result_roundtrips_raw_stream_bytes() {
+        let response = Response::Ok(Payload::PowerShell {
+            stdout: vec![0, 0x80, b'a'],
+            stderr: vec![b'e', 0xff],
+            exit_code: 23,
+        });
+        let bytes = ironrdp_core::encode_vec(&response).expect("encode response");
+        let decoded = ironrdp_core::decode_owned::<Response>(&bytes).expect("decode response");
+        assert_eq!(decoded, response);
+    }
+
+    #[test]
+    fn streamed_now_execution_roundtrips_raw_stdin_and_output() {
+        let request = Request::NowExecute(NowExecutionRequest {
+            kind: NowExecutionKind::Process,
+            command: r"C:\Program Files\Tool\tool.exe".to_owned(),
+            parameters: Some("--input -".to_owned()),
+            directory: Some(r"C:\work".to_owned()),
+            no_profile: true,
+            non_interactive: true,
+            detached: false,
+            timeout_secs: Some(45),
+            stdin: Some(vec![0, 0x80, b'\n']),
+        });
+        let bytes = ironrdp_core::encode_vec(&request).expect("encode request");
+        let decoded = ironrdp_core::decode_owned::<Request>(&bytes).expect("decode request");
+        assert_eq!(decoded, request);
+        assert!(!format!("{request:?}").contains("tool.exe"));
+
+        let response = Response::Ok(Payload::NowExecutionData {
+            operation_id: 17,
+            stream: NowStream::Stderr,
+            data: vec![0, 0xff],
+        });
+        let bytes = ironrdp_core::encode_vec(&response).expect("encode response");
+        let decoded = ironrdp_core::decode_owned::<Response>(&bytes).expect("decode response");
+        assert_eq!(decoded, response);
+    }
+
+    #[test]
+    fn now_capabilities_roundtrip() {
+        let response = Response::Ok(Payload::NowCapabilities(NowCapabilities {
+            major: 1,
+            minor: 6,
+            system_capset: 1,
+            session_capset: 0x1f,
+            exec_capset: 0x107f,
+            heartbeat_secs: Some(60),
+        }));
+        let bytes = ironrdp_core::encode_vec(&response).expect("encode response");
+        let decoded = ironrdp_core::decode_owned::<Response>(&bytes).expect("decode response");
+        assert_eq!(decoded, response);
+    }
+}

--- a/crates/ironrdp-agent/src/lib.rs
+++ b/crates/ironrdp-agent/src/lib.rs
@@ -17,6 +17,7 @@ pub mod transport;
 
 pub(crate) mod help;
 pub(crate) mod logbuf;
+pub(crate) mod now;
 
 // The wire codec helpers are internal, but the `internal` feature exposes them (hidden from docs)
 // so they can be unit tested from the workspace test suite.

--- a/crates/ironrdp-agent/src/lib.rs
+++ b/crates/ironrdp-agent/src/lib.rs
@@ -18,6 +18,7 @@ pub mod transport;
 pub(crate) mod help;
 pub(crate) mod logbuf;
 pub(crate) mod now;
+pub(crate) mod operations;
 
 // The wire codec helpers are internal, but the `internal` feature exposes them (hidden from docs)
 // so they can be unit tested from the workspace test suite.

--- a/crates/ironrdp-agent/src/main.rs
+++ b/crates/ironrdp-agent/src/main.rs
@@ -6,5 +6,12 @@ use ironrdp_agent::cli::Cli;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    ironrdp_agent::cli::run(Cli::parse()).await
+    let result = ironrdp_agent::cli::run(Cli::parse()).await;
+    if let Err(error) = result {
+        if let Some(exit_code) = ironrdp_agent::cli::remote_exit_code(&error) {
+            std::process::exit(exit_code);
+        }
+        return Err(error);
+    }
+    Ok(())
 }

--- a/crates/ironrdp-agent/src/now.rs
+++ b/crates/ironrdp-agent/src/now.rs
@@ -15,7 +15,7 @@ use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio::sync::{Mutex, Notify, mpsc};
 use tracing::{debug, info};
 
-use crate::ipc::{NowCapabilities, NowExecutionKind, NowExecutionRequest, NowStream};
+use crate::ipc::{NowCapabilities, NowDiagnostics, NowExecutionKind, NowExecutionRequest, NowStream};
 
 pub(crate) const DVC_CHANNEL_NAME: &str = "Devolutions::Now::Agent";
 const MAX_MESSAGE_BODY_LEN: usize = 16 * 1024 * 1024;
@@ -26,6 +26,8 @@ const NON_INTERACTIVE_FLAG: u16 = 0x0020;
 const INITIAL_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 const RECONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(60);
+/// Bounds protocol data that can be queued while the daemon operation collector is scheduled.
+const OPERATION_EVENT_QUEUE_CAPACITY: usize = 8;
 
 static NEXT_ENDPOINT_ID: AtomicU64 = AtomicU64::new(0);
 static NEXT_OPERATION_ID: AtomicU64 = AtomicU64::new(1);
@@ -76,10 +78,18 @@ pub(crate) enum NowOperationEvent {
     Failed { message: String },
 }
 
+/// One bounded standard-input fragment delivered to an active NOW operation.
+#[derive(Debug)]
+pub(crate) struct NowStdinChunk {
+    pub(crate) data: Vec<u8>,
+    pub(crate) last: bool,
+}
+
 /// A running NOW operation with a local ID and a stream of protocol events.
 pub(crate) struct NowOperation {
     pub(crate) id: u64,
-    pub(crate) events: mpsc::UnboundedReceiver<NowOperationEvent>,
+    pub(crate) events: mpsc::Receiver<NowOperationEvent>,
+    pub(crate) stdin: mpsc::Sender<NowStdinChunk>,
 }
 
 struct NowState {
@@ -91,6 +101,13 @@ struct NowState {
     heartbeat_interval: Option<Duration>,
     next_session_id: u32,
     connected_once: bool,
+}
+
+enum StreamEvent<'a> {
+    Message(anyhow::Result<NowMessage<'a>>),
+    Cancellation,
+    Timeout,
+    Stdin(Option<NowStdinChunk>),
 }
 
 impl NowClient {
@@ -188,6 +205,25 @@ impl NowClient {
         state.capabilities()
     }
 
+    /// Returns transport diagnostics that do not require opening the DVC endpoint.
+    pub(crate) fn diagnostics(&self, output_retention_bytes: u32) -> NowDiagnostics {
+        let active_operation_id = self
+            .active
+            .lock()
+            .expect("NOW operation state poisoned")
+            .as_ref()
+            .map(|operation| operation.id);
+        NowDiagnostics {
+            endpoint: self.endpoint.clone(),
+            active_operation_id,
+            output_retention_bytes,
+            event_queue_capacity: u16::try_from(OPERATION_EVENT_QUEUE_CAPACITY).expect("queue capacity fits in u16"),
+            initial_connect_timeout_secs: u32::try_from(INITIAL_CONNECT_TIMEOUT.as_secs())
+                .expect("initial connect timeout fits in u32"),
+            reconnect_timeout_secs: u32::try_from(RECONNECT_TIMEOUT.as_secs()).expect("reconnect timeout fits in u32"),
+        }
+    }
+
     /// Starts a streamed execution. Only one execution can own a NOW transport at a time, but the
     /// returned operation can be cancelled from another daemon IPC connection.
     pub(crate) fn start_execution(self: &Arc<Self>, request: NowExecutionRequest) -> anyhow::Result<NowOperation> {
@@ -212,21 +248,24 @@ impl NowClient {
             *guard = Some(active.clone());
         }
 
-        let (events_tx, events) = mpsc::unbounded_channel();
+        let (events_tx, events) = mpsc::channel(OPERATION_EVENT_QUEUE_CAPACITY);
+        let (stdin, stdin_rx) = mpsc::channel(OPERATION_EVENT_QUEUE_CAPACITY);
         let client = Arc::clone(self);
         tokio::spawn(async move {
             let result = {
                 let mut state = client.state.lock().await;
-                state.execute_streamed(request, &active, &events_tx).await
+                state.execute_streamed(request, &active, &events_tx, stdin_rx).await
             };
             match result {
                 Ok(exit_code) => {
-                    let _ = events_tx.send(NowOperationEvent::Finished { exit_code });
+                    let _ = events_tx.send(NowOperationEvent::Finished { exit_code }).await;
                 }
                 Err(error) => {
-                    let _ = events_tx.send(NowOperationEvent::Failed {
-                        message: format!("{error:#}"),
-                    });
+                    let _ = events_tx
+                        .send(NowOperationEvent::Failed {
+                            message: format!("{error:#}"),
+                        })
+                        .await;
                 }
             }
             let mut guard = client.active.lock().expect("NOW operation state poisoned");
@@ -235,7 +274,7 @@ impl NowClient {
             }
         });
 
-        Ok(NowOperation { id, events })
+        Ok(NowOperation { id, events, stdin })
     }
 
     /// Requests normal NOW cancellation. The active worker sends `CANCEL_REQ` while continuing to
@@ -400,6 +439,8 @@ impl NowState {
             minor: server.version().minor,
             system_capset: server.system_capset().bits(),
             session_capset: server.session_capset().bits(),
+            server_exec_capset: server.exec_capset().bits(),
+            client_exec_capset: requested.exec_capset().bits(),
             exec_capset: exec_capset.bits(),
             heartbeat_secs: server
                 .heartbeat_interval()
@@ -411,7 +452,8 @@ impl NowState {
         &mut self,
         request: NowExecutionRequest,
         active: &ActiveOperation,
-        events: &mpsc::UnboundedSender<NowOperationEvent>,
+        events: &mpsc::Sender<NowOperationEvent>,
+        mut stdin: mpsc::Receiver<NowStdinChunk>,
     ) -> anyhow::Result<u32> {
         self.ensure_connected().await?;
         self.negotiate().await?;
@@ -445,6 +487,7 @@ impl NowState {
         let mut cancellation_sent = false;
         let mut cancellation_requested = false;
         let mut stdin_sent = false;
+        let mut stdin_closed = false;
 
         loop {
             if active.cancellation_requested.load(Ordering::Acquire) && !cancellation_sent {
@@ -455,27 +498,42 @@ impl NowState {
                 cancellation_requested = true;
             }
 
-            let message = match deadline {
+            let event = match deadline {
                 Some(deadline) if !cancellation_sent => {
                     tokio::select! {
-                        message = self.read_message() => Some(message?),
-                        _ = active.cancellation.notified() => None,
+                        message = self.read_message() => StreamEvent::Message(message),
+                        _ = active.cancellation.notified() => StreamEvent::Cancellation,
                         _ = tokio::time::sleep_until(deadline) => {
-                            active.cancellation_requested.store(true, Ordering::Release);
-                            None
+                            StreamEvent::Timeout
                         }
+                        chunk = stdin.recv(), if stdin_sent && !stdin_closed => StreamEvent::Stdin(chunk),
                     }
                 }
                 _ if !cancellation_sent => {
                     tokio::select! {
-                        message = self.read_message() => Some(message?),
-                        _ = active.cancellation.notified() => None,
+                        message = self.read_message() => StreamEvent::Message(message),
+                        _ = active.cancellation.notified() => StreamEvent::Cancellation,
+                        chunk = stdin.recv(), if stdin_sent && !stdin_closed => StreamEvent::Stdin(chunk),
                     }
                 }
-                _ => Some(self.read_message().await?),
+                _ => StreamEvent::Message(self.read_message().await),
             };
-            let Some(message) = message else {
-                continue;
+            let message = match event {
+                StreamEvent::Message(message) => message?,
+                StreamEvent::Cancellation => continue,
+                StreamEvent::Timeout => {
+                    active.cancellation_requested.store(true, Ordering::Release);
+                    continue;
+                }
+                StreamEvent::Stdin(Some(chunk)) => {
+                    self.write_stdin_chunk(session_id, &chunk.data, chunk.last).await?;
+                    stdin_closed = chunk.last;
+                    continue;
+                }
+                StreamEvent::Stdin(None) => {
+                    stdin_closed = true;
+                    continue;
+                }
             };
 
             match message {
@@ -483,6 +541,7 @@ impl NowState {
                     if !stdin_sent {
                         if let Some(stdin) = request.stdin.as_deref() {
                             self.write_stdin(session_id, stdin).await?;
+                            stdin_closed = true;
                         }
                         stdin_sent = true;
                     }
@@ -498,7 +557,8 @@ impl NowState {
                             stream,
                             data: data.data().to_vec(),
                         })
-                        .map_err(|_| anyhow::anyhow!("NOW execution output consumer disconnected"))?;
+                        .await
+                        .map_err(|_| anyhow::anyhow!("NOW operation collector stopped"))?;
                 }
                 NowMessage::Exec(NowExecMessage::CancelRsp(response)) if response.session_id() == session_id => {
                     response
@@ -527,20 +587,20 @@ impl NowState {
     async fn write_stdin(&mut self, session_id: u32, stdin: &[u8]) -> anyhow::Result<()> {
         for (index, chunk) in stdin.chunks(IO_BUFFER_LEN).enumerate() {
             let is_last = (index + 1) * IO_BUFFER_LEN >= stdin.len();
-            self.write_message(NowMessage::from(
-                NowExecDataMsg::new(session_id, NowExecDataStreamKind::Stdin, is_last, chunk)
-                    .context("encode NOW standard input")?,
-            ))
-            .await?;
+            self.write_stdin_chunk(session_id, chunk, is_last).await?;
         }
         if stdin.is_empty() {
-            self.write_message(NowMessage::from(
-                NowExecDataMsg::new(session_id, NowExecDataStreamKind::Stdin, true, &[])
-                    .context("encode NOW empty standard input")?,
-            ))
-            .await?;
+            self.write_stdin_chunk(session_id, &[], true).await?;
         }
         Ok(())
+    }
+
+    async fn write_stdin_chunk(&mut self, session_id: u32, data: &[u8], is_last: bool) -> anyhow::Result<()> {
+        self.write_message(NowMessage::from(
+            NowExecDataMsg::new(session_id, NowExecDataStreamKind::Stdin, is_last, data)
+                .context("encode NOW standard input")?,
+        ))
+        .await
     }
 }
 

--- a/crates/ironrdp-agent/src/now.rs
+++ b/crates/ironrdp-agent/src/now.rs
@@ -1,0 +1,1442 @@
+//! Client-side NOW protocol support over the agent's per-session DVC pipe proxy.
+
+use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use core::time::Duration;
+use std::sync::{Arc, Mutex as StdMutex};
+
+use anyhow::{Context as _, bail};
+use now_proto_pdu::ironrdp_core::{Decode as _, DecodeErrorKind, IntoOwned as _, ReadCursor};
+use now_proto_pdu::{
+    NowChannelCapsetMsg, NowChannelHeartbeatMsg, NowChannelMessage, NowExecBatchMsg, NowExecCancelReqMsg,
+    NowExecCapsetFlags, NowExecDataMsg, NowExecDataStreamKind, NowExecMessage, NowExecProcessMsg, NowExecPwshMsg,
+    NowExecShellMsg, NowExecWinPsMsg, NowMessage, NowProtoVersion,
+};
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+use tokio::sync::{Mutex, Notify, mpsc};
+use tracing::{debug, info};
+
+use crate::ipc::{NowCapabilities, NowExecutionKind, NowExecutionRequest, NowStream};
+
+pub(crate) const DVC_CHANNEL_NAME: &str = "Devolutions::Now::Agent";
+const MAX_MESSAGE_BODY_LEN: usize = 16 * 1024 * 1024;
+/// Leaves 1 MiB for IPC framing and conservative future response overhead.
+pub(crate) const MAX_POWERSHELL_OUTPUT_LEN: usize = 15 * 1024 * 1024;
+const IO_BUFFER_LEN: usize = 64 * 1024;
+const NON_INTERACTIVE_FLAG: u16 = 0x0020;
+const INITIAL_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+const RECONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(60);
+
+static NEXT_ENDPOINT_ID: AtomicU64 = AtomicU64::new(0);
+static NEXT_OPERATION_ID: AtomicU64 = AtomicU64::new(1);
+
+/// The remote PowerShell implementation to invoke.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PowerShellKind {
+    WindowsPowerShell,
+    PowerShell,
+}
+
+/// A PowerShell invocation sent to the NOW agent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PowerShellRequest {
+    pub(crate) kind: PowerShellKind,
+    pub(crate) command: String,
+    pub(crate) no_profile: bool,
+    pub(crate) non_interactive: bool,
+}
+
+/// The byte streams and exit status emitted by a remote PowerShell invocation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PowerShellResult {
+    pub(crate) stdout: Vec<u8>,
+    pub(crate) stderr: Vec<u8>,
+    pub(crate) exit_code: u32,
+}
+
+/// Owns the unique local endpoint used by IronRDP's DVC pipe proxy for one RDP session.
+pub(crate) struct NowClient {
+    endpoint: String,
+    state: Arc<Mutex<NowState>>,
+    active: Arc<StdMutex<Option<ActiveOperation>>>,
+}
+
+#[derive(Clone)]
+struct ActiveOperation {
+    id: u64,
+    cancellation_requested: Arc<AtomicBool>,
+    cancellation: Arc<Notify>,
+}
+
+/// A raw NOW execution event sent from the protocol worker to the daemon IPC connection.
+#[derive(Debug)]
+pub(crate) enum NowOperationEvent {
+    Data { stream: NowStream, data: Vec<u8> },
+    Finished { exit_code: u32 },
+    Failed { message: String },
+}
+
+/// A running NOW operation with a local ID and a stream of protocol events.
+pub(crate) struct NowOperation {
+    pub(crate) id: u64,
+    pub(crate) events: mpsc::UnboundedReceiver<NowOperationEvent>,
+}
+
+struct NowState {
+    endpoint: LocalEndpoint,
+    stream: Option<LocalStream>,
+    buffer: MessageBuffer,
+    read_buffer: Box<[u8; IO_BUFFER_LEN]>,
+    caps: Option<NowChannelCapsetMsg>,
+    heartbeat_interval: Option<Duration>,
+    next_session_id: u32,
+    connected_once: bool,
+}
+
+impl NowClient {
+    pub(crate) fn new() -> anyhow::Result<Self> {
+        let endpoint = LocalEndpoint::new()?;
+        let endpoint_name = endpoint.name().to_owned();
+        Ok(Self {
+            endpoint: endpoint_name,
+            state: Arc::new(Mutex::new(NowState {
+                endpoint,
+                stream: None,
+                buffer: MessageBuffer::default(),
+                read_buffer: Box::new([0; IO_BUFFER_LEN]),
+                caps: None,
+                heartbeat_interval: None,
+                next_session_id: 1,
+                connected_once: false,
+            })),
+            active: Arc::new(StdMutex::new(None)),
+        })
+    }
+
+    /// Returns the unique DVC proxy endpoint to add to the RDP client configuration.
+    pub(crate) fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    pub(crate) async fn execute(&self, request: PowerShellRequest) -> anyhow::Result<PowerShellResult> {
+        let mut state = self.state.lock().await;
+        state.ensure_connected().await?;
+        state.negotiate().await?;
+
+        let required_style = match request.kind {
+            PowerShellKind::WindowsPowerShell => NowExecCapsetFlags::STYLE_WINPS,
+            PowerShellKind::PowerShell => NowExecCapsetFlags::STYLE_PWSH,
+        };
+        // Gateway currently replies with its full capability set rather than the negotiated
+        // intersection, so retain the client's advertised limit when gating optional behavior.
+        let caps =
+            state.caps.as_ref().expect("NOW capabilities negotiated").exec_capset() & client_capset()?.exec_capset();
+        if !caps.contains(required_style) {
+            let shell = match request.kind {
+                PowerShellKind::WindowsPowerShell => "Windows PowerShell",
+                PowerShellKind::PowerShell => "PowerShell 7",
+            };
+            bail!("remote NOW agent does not support {shell}");
+        }
+        if !caps.contains(NowExecCapsetFlags::IO_REDIRECTION) {
+            bail!("remote NOW agent does not support execution stream redirection");
+        }
+
+        let session_id = state.allocate_session_id();
+        let encoded_request = encode_powershell_request(session_id, &request, caps)?;
+        state.write_raw(&encoded_request).await?;
+
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        loop {
+            match state.read_message().await? {
+                NowMessage::Exec(NowExecMessage::Started(started)) if started.session_id() == session_id => {
+                    // A started notification is advisory; the matching result below is authoritative.
+                }
+                NowMessage::Exec(NowExecMessage::Data(data)) if data.session_id() == session_id => {
+                    match data.stream_kind().context("invalid NOW execution stream kind")? {
+                        NowExecDataStreamKind::Stdout => append_output(&mut stdout, stderr.len(), data.data())?,
+                        NowExecDataStreamKind::Stderr => append_output(&mut stderr, stdout.len(), data.data())?,
+                        NowExecDataStreamKind::Stdin => bail!("remote NOW agent returned unexpected stdin data"),
+                    }
+                }
+                NowMessage::Exec(NowExecMessage::Result(result)) if result.session_id() == session_id => {
+                    let exit_code = result
+                        .to_result()
+                        .map_err(|error| anyhow::anyhow!("remote NOW execution failed: {error}"))?;
+                    debug!(session_id, exit_code, "Received NOW PowerShell execution result");
+                    return Ok(PowerShellResult {
+                        stdout,
+                        stderr,
+                        exit_code,
+                    });
+                }
+                NowMessage::Channel(NowChannelMessage::Capset(caps)) => {
+                    state.caps = Some(caps);
+                }
+                NowMessage::Channel(NowChannelMessage::Heartbeat(_)) => {}
+                message => bail!("unexpected NOW message while waiting for execution result: {message:?}"),
+            }
+        }
+    }
+
+    /// Establishes the local NOW transport and returns its negotiated capabilities.
+    pub(crate) async fn capabilities(&self) -> anyhow::Result<NowCapabilities> {
+        let mut state = self.state.lock().await;
+        state.ensure_connected().await?;
+        state.negotiate().await?;
+        state.capabilities()
+    }
+
+    /// Starts a streamed execution. Only one execution can own a NOW transport at a time, but the
+    /// returned operation can be cancelled from another daemon IPC connection.
+    pub(crate) fn start_execution(self: &Arc<Self>, request: NowExecutionRequest) -> anyhow::Result<NowOperation> {
+        validate_execution_request(&request)?;
+
+        let id = NEXT_OPERATION_ID.fetch_add(1, Ordering::Relaxed);
+        let id = if id == 0 {
+            NEXT_OPERATION_ID.fetch_add(1, Ordering::Relaxed)
+        } else {
+            id
+        };
+        let active = ActiveOperation {
+            id,
+            cancellation_requested: Arc::new(AtomicBool::new(false)),
+            cancellation: Arc::new(Notify::new()),
+        };
+        {
+            let mut guard = self.active.lock().expect("NOW operation state poisoned");
+            if guard.is_some() {
+                bail!("a NOW execution is already running");
+            }
+            *guard = Some(active.clone());
+        }
+
+        let (events_tx, events) = mpsc::unbounded_channel();
+        let client = Arc::clone(self);
+        tokio::spawn(async move {
+            let result = {
+                let mut state = client.state.lock().await;
+                state.execute_streamed(request, &active, &events_tx).await
+            };
+            match result {
+                Ok(exit_code) => {
+                    let _ = events_tx.send(NowOperationEvent::Finished { exit_code });
+                }
+                Err(error) => {
+                    let _ = events_tx.send(NowOperationEvent::Failed {
+                        message: format!("{error:#}"),
+                    });
+                }
+            }
+            let mut guard = client.active.lock().expect("NOW operation state poisoned");
+            if guard.as_ref().is_some_and(|current| current.id == id) {
+                *guard = None;
+            }
+        });
+
+        Ok(NowOperation { id, events })
+    }
+
+    /// Requests normal NOW cancellation. The active worker sends `CANCEL_REQ` while continuing to
+    /// read until its matching result, so the byte stream remains protocol-synchronized.
+    pub(crate) fn cancel(&self, operation_id: u64) -> anyhow::Result<()> {
+        let guard = self.active.lock().expect("NOW operation state poisoned");
+        let Some(active) = guard.as_ref() else {
+            bail!("no NOW execution is running");
+        };
+        if active.id != operation_id {
+            bail!("NOW operation {operation_id} is not running");
+        }
+        active.cancellation_requested.store(true, Ordering::Release);
+        active.cancellation.notify_waiters();
+        Ok(())
+    }
+}
+
+impl NowState {
+    async fn ensure_connected(&mut self) -> anyhow::Result<()> {
+        if self.stream.is_none() {
+            let timeout = if self.connected_once {
+                RECONNECT_TIMEOUT
+            } else {
+                INITIAL_CONNECT_TIMEOUT
+            };
+            info!(
+                endpoint = %self.endpoint.display_name(),
+                proxy_name = self.endpoint.name(),
+                timeout_secs = timeout.as_secs(),
+                reconnect = self.connected_once,
+                "Waiting for NOW DVC proxy endpoint"
+            );
+            let started = tokio::time::Instant::now();
+            self.stream = Some(self.endpoint.connect_with_timeout(timeout).await?);
+            self.connected_once = true;
+            info!(
+                endpoint = %self.endpoint.display_name(),
+                proxy_name = self.endpoint.name(),
+                wait_ms = started.elapsed().as_millis(),
+                "Connected to NOW DVC proxy endpoint"
+            );
+        }
+        Ok(())
+    }
+
+    async fn negotiate(&mut self) -> anyhow::Result<()> {
+        if self.caps.is_some() {
+            return Ok(());
+        }
+
+        let requested = client_capset()?;
+        info!("Sending NOW capability request");
+        self.write_message(NowMessage::from(requested)).await?;
+
+        loop {
+            match self.read_message().await? {
+                NowMessage::Channel(NowChannelMessage::Capset(caps)) => {
+                    if caps.version().major != NowProtoVersion::CURRENT.major {
+                        bail!(
+                            "incompatible NOW protocol version {}.{}",
+                            caps.version().major,
+                            caps.version().minor
+                        );
+                    }
+                    self.heartbeat_interval = caps.heartbeat_interval();
+                    info!(
+                        major = caps.version().major,
+                        minor = caps.version().minor,
+                        heartbeat_secs = ?self.heartbeat_interval.map(|interval| interval.as_secs()),
+                        "Negotiated NOW capabilities"
+                    );
+                    self.caps = Some(caps);
+                    return Ok(());
+                }
+                NowMessage::Channel(NowChannelMessage::Heartbeat(_)) => {}
+                message => bail!("expected NOW capability response, received {message:?}"),
+            }
+        }
+    }
+
+    fn allocate_session_id(&mut self) -> u32 {
+        let session_id = self.next_session_id;
+        self.next_session_id = self.next_session_id.wrapping_add(1);
+        if self.next_session_id == 0 {
+            self.next_session_id = 1;
+        }
+        session_id
+    }
+
+    async fn write_message(&mut self, message: NowMessage<'_>) -> anyhow::Result<()> {
+        let bytes = now_proto_pdu::ironrdp_core::encode_vec(&message).context("encode NOW message")?;
+        self.write_raw(&bytes).await
+    }
+
+    async fn write_raw(&mut self, bytes: &[u8]) -> anyhow::Result<()> {
+        let result = {
+            let stream = self.stream.as_mut().expect("NOW stream connected");
+            async {
+                stream.write_all(bytes).await.context("write NOW message")?;
+                stream.flush().await.context("flush NOW message")
+            }
+            .await
+        };
+        if result.is_err() {
+            self.reset_connection();
+        }
+        result
+    }
+
+    async fn read_message(&mut self) -> anyhow::Result<NowMessage<'static>> {
+        loop {
+            if let Some(message) = self.buffer.next()? {
+                return Ok(message);
+            }
+
+            let result = {
+                let (stream, read_buffer) = (&mut self.stream, &mut self.read_buffer);
+                let stream = stream.as_mut().expect("NOW stream connected");
+                match self.heartbeat_interval {
+                    Some(interval) => match tokio::time::timeout(interval, stream.read(&mut **read_buffer)).await {
+                        Ok(result) => Some(result.context("read NOW message")),
+                        Err(_) => None,
+                    },
+                    None => Some(stream.read(&mut **read_buffer).await.context("read NOW message")),
+                }
+            };
+            let Some(result) = result else {
+                self.write_message(NowMessage::from(NowChannelHeartbeatMsg::default()))
+                    .await
+                    .context("send NOW heartbeat")?;
+                continue;
+            };
+            let read = match result {
+                Ok(read) if read != 0 => read,
+                Ok(_) => {
+                    self.reset_connection();
+                    bail!("NOW DVC pipe closed");
+                }
+                Err(error) => {
+                    self.reset_connection();
+                    return Err(error);
+                }
+            };
+            self.buffer.push(&self.read_buffer[..read]);
+        }
+    }
+
+    fn reset_connection(&mut self) {
+        self.stream = None;
+        self.buffer = MessageBuffer::default();
+        self.caps = None;
+        self.heartbeat_interval = None;
+    }
+
+    fn capabilities(&self) -> anyhow::Result<NowCapabilities> {
+        let server = self.caps.as_ref().context("NOW capabilities not negotiated")?;
+        let requested = client_capset()?;
+        let exec_capset = server.exec_capset() & requested.exec_capset();
+        Ok(NowCapabilities {
+            major: server.version().major,
+            minor: server.version().minor,
+            system_capset: server.system_capset().bits(),
+            session_capset: server.session_capset().bits(),
+            exec_capset: exec_capset.bits(),
+            heartbeat_secs: server
+                .heartbeat_interval()
+                .map(|interval| u32::try_from(interval.as_secs()).unwrap_or(u32::MAX)),
+        })
+    }
+
+    async fn execute_streamed(
+        &mut self,
+        request: NowExecutionRequest,
+        active: &ActiveOperation,
+        events: &mpsc::UnboundedSender<NowOperationEvent>,
+    ) -> anyhow::Result<u32> {
+        self.ensure_connected().await?;
+        self.negotiate().await?;
+
+        let caps = self.capabilities()?.exec_capset;
+        let caps = NowExecCapsetFlags::from_bits_retain(caps);
+        let required_style = execution_style_capability(request.kind);
+        if !caps.contains(required_style) {
+            bail!(
+                "remote NOW agent does not support {}",
+                execution_kind_name(request.kind)
+            );
+        }
+        if !request.detached && !caps.contains(NowExecCapsetFlags::IO_REDIRECTION) {
+            bail!("remote NOW agent does not support execution stream redirection");
+        }
+        if active.cancellation_requested.load(Ordering::Acquire) {
+            bail!("NOW execution was cancelled before it started");
+        }
+
+        let session_id = self.allocate_session_id();
+        self.write_raw(&encode_execution_request(session_id, &request, caps)?)
+            .await?;
+        if request.detached {
+            return Ok(0);
+        }
+
+        let deadline = request
+            .timeout_secs
+            .map(|timeout_secs| tokio::time::Instant::now() + Duration::from_secs(u64::from(timeout_secs)));
+        let mut cancellation_sent = false;
+        let mut cancellation_requested = false;
+        let mut stdin_sent = false;
+
+        loop {
+            if active.cancellation_requested.load(Ordering::Acquire) && !cancellation_sent {
+                self.write_message(NowMessage::from(NowExecCancelReqMsg::new(session_id)))
+                    .await
+                    .context("send NOW execution cancellation")?;
+                cancellation_sent = true;
+                cancellation_requested = true;
+            }
+
+            let message = match deadline {
+                Some(deadline) if !cancellation_sent => {
+                    tokio::select! {
+                        message = self.read_message() => Some(message?),
+                        _ = active.cancellation.notified() => None,
+                        _ = tokio::time::sleep_until(deadline) => {
+                            active.cancellation_requested.store(true, Ordering::Release);
+                            None
+                        }
+                    }
+                }
+                _ if !cancellation_sent => {
+                    tokio::select! {
+                        message = self.read_message() => Some(message?),
+                        _ = active.cancellation.notified() => None,
+                    }
+                }
+                _ => Some(self.read_message().await?),
+            };
+            let Some(message) = message else {
+                continue;
+            };
+
+            match message {
+                NowMessage::Exec(NowExecMessage::Started(started)) if started.session_id() == session_id => {
+                    if !stdin_sent {
+                        if let Some(stdin) = request.stdin.as_deref() {
+                            self.write_stdin(session_id, stdin).await?;
+                        }
+                        stdin_sent = true;
+                    }
+                }
+                NowMessage::Exec(NowExecMessage::Data(data)) if data.session_id() == session_id => {
+                    let stream = match data.stream_kind().context("invalid NOW execution stream kind")? {
+                        NowExecDataStreamKind::Stdout => NowStream::Stdout,
+                        NowExecDataStreamKind::Stderr => NowStream::Stderr,
+                        NowExecDataStreamKind::Stdin => bail!("remote NOW agent returned unexpected stdin data"),
+                    };
+                    events
+                        .send(NowOperationEvent::Data {
+                            stream,
+                            data: data.data().to_vec(),
+                        })
+                        .map_err(|_| anyhow::anyhow!("NOW execution output consumer disconnected"))?;
+                }
+                NowMessage::Exec(NowExecMessage::CancelRsp(response)) if response.session_id() == session_id => {
+                    response
+                        .to_result()
+                        .map_err(|error| anyhow::anyhow!("remote NOW cancellation failed: {error}"))?;
+                }
+                NowMessage::Exec(NowExecMessage::Result(result)) if result.session_id() == session_id => {
+                    let exit_code = result
+                        .to_result()
+                        .map_err(|error| anyhow::anyhow!("remote NOW execution failed: {error}"))?;
+                    debug!(session_id, exit_code, "Received NOW execution result");
+                    if cancellation_requested {
+                        bail!("NOW execution was cancelled");
+                    }
+                    return Ok(exit_code);
+                }
+                NowMessage::Channel(NowChannelMessage::Capset(caps)) => {
+                    self.caps = Some(caps);
+                }
+                NowMessage::Channel(NowChannelMessage::Heartbeat(_)) => {}
+                message => bail!("unexpected NOW message while waiting for execution result: {message:?}"),
+            }
+        }
+    }
+
+    async fn write_stdin(&mut self, session_id: u32, stdin: &[u8]) -> anyhow::Result<()> {
+        for (index, chunk) in stdin.chunks(IO_BUFFER_LEN).enumerate() {
+            let is_last = (index + 1) * IO_BUFFER_LEN >= stdin.len();
+            self.write_message(NowMessage::from(
+                NowExecDataMsg::new(session_id, NowExecDataStreamKind::Stdin, is_last, chunk)
+                    .context("encode NOW standard input")?,
+            ))
+            .await?;
+        }
+        if stdin.is_empty() {
+            self.write_message(NowMessage::from(
+                NowExecDataMsg::new(session_id, NowExecDataStreamKind::Stdin, true, &[])
+                    .context("encode NOW empty standard input")?,
+            ))
+            .await?;
+        }
+        Ok(())
+    }
+}
+
+fn append_output(output: &mut Vec<u8>, other_output_len: usize, data: &[u8]) -> anyhow::Result<()> {
+    let output_len = output
+        .len()
+        .checked_add(other_output_len)
+        .and_then(|len| len.checked_add(data.len()))
+        .context("NOW PowerShell output length overflow")?;
+    if output_len > MAX_POWERSHELL_OUTPUT_LEN {
+        bail!(
+            "NOW PowerShell output exceeds the {} MiB IPC limit",
+            MAX_POWERSHELL_OUTPUT_LEN / (1024 * 1024)
+        );
+    }
+    output.extend_from_slice(data);
+    Ok(())
+}
+
+fn encode_powershell_request(
+    session_id: u32,
+    request: &PowerShellRequest,
+    caps: NowExecCapsetFlags,
+) -> anyhow::Result<Vec<u8>> {
+    let message = match request.kind {
+        PowerShellKind::WindowsPowerShell => {
+            let mut message = NowExecWinPsMsg::new(session_id, request.command.as_str())
+                .context("encode Windows PowerShell command")?;
+            if request.no_profile {
+                message = message.set_no_profile();
+            }
+
+            message = message.with_io_redirection();
+            if caps.contains(NowExecCapsetFlags::UNICODE_CONSOLE) {
+                message = message.with_raw_encoding().with_unicode_console();
+            }
+            NowMessage::from(message)
+        }
+        PowerShellKind::PowerShell => {
+            let mut message =
+                NowExecPwshMsg::new(session_id, request.command.as_str()).context("encode PowerShell command")?;
+            if request.no_profile {
+                message = message.set_no_profile();
+            }
+            message = message.with_io_redirection();
+            if caps.contains(NowExecCapsetFlags::UNICODE_CONSOLE) {
+                message = message.with_raw_encoding().with_unicode_console();
+            }
+            NowMessage::from(message)
+        }
+    };
+
+    let mut encoded = now_proto_pdu::ironrdp_core::encode_vec(&message).context("encode NOW PowerShell request")?;
+    if request.non_interactive {
+        // now-proto-pdu exposes the decoder for this standard flag but not a builder setter yet.
+        // The common NOW header stores flags as a little-endian u16 at byte offset 6.
+        let flag_bytes = encoded
+            .get_mut(6..8)
+            .context("encoded NOW PowerShell request is missing header flags")?;
+        let flags = u16::from_le_bytes([flag_bytes[0], flag_bytes[1]]) | NON_INTERACTIVE_FLAG;
+        flag_bytes.copy_from_slice(&flags.to_le_bytes());
+    }
+    Ok(encoded)
+}
+
+fn validate_execution_request(request: &NowExecutionRequest) -> anyhow::Result<()> {
+    if request.command.is_empty() {
+        bail!("NOW execution command must not be empty");
+    }
+    if request.timeout_secs == Some(0) {
+        bail!("NOW execution timeout must be greater than zero");
+    }
+    if request.detached && request.stdin.is_some() {
+        bail!("detached NOW execution does not support standard input");
+    }
+    if request.detached && request.timeout_secs.is_some() {
+        bail!("detached NOW execution does not support a timeout");
+    }
+    match request.kind {
+        NowExecutionKind::Process if request.parameters.is_none() => {}
+        NowExecutionKind::Shell if request.parameters.is_none() => {}
+        NowExecutionKind::Batch if request.parameters.is_some() => {
+            bail!("NOW batch execution does not support --parameters");
+        }
+        NowExecutionKind::WindowsPowerShell | NowExecutionKind::PowerShell if request.parameters.is_some() => {
+            bail!("NOW PowerShell execution does not support --parameters");
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn execution_style_capability(kind: NowExecutionKind) -> NowExecCapsetFlags {
+    match kind {
+        NowExecutionKind::WindowsPowerShell => NowExecCapsetFlags::STYLE_WINPS,
+        NowExecutionKind::PowerShell => NowExecCapsetFlags::STYLE_PWSH,
+        NowExecutionKind::Process => NowExecCapsetFlags::STYLE_PROCESS,
+        NowExecutionKind::Shell => NowExecCapsetFlags::STYLE_SHELL,
+        NowExecutionKind::Batch => NowExecCapsetFlags::STYLE_BATCH,
+    }
+}
+
+fn execution_kind_name(kind: NowExecutionKind) -> &'static str {
+    match kind {
+        NowExecutionKind::WindowsPowerShell => "Windows PowerShell",
+        NowExecutionKind::PowerShell => "PowerShell 7",
+        NowExecutionKind::Process => "CreateProcess execution",
+        NowExecutionKind::Shell => "shell execution",
+        NowExecutionKind::Batch => "batch execution",
+    }
+}
+
+fn encode_execution_request(
+    session_id: u32,
+    request: &NowExecutionRequest,
+    caps: NowExecCapsetFlags,
+) -> anyhow::Result<Vec<u8>> {
+    let message = match request.kind {
+        NowExecutionKind::WindowsPowerShell => {
+            let mut message = NowExecWinPsMsg::new(session_id, request.command.as_str())
+                .context("encode Windows PowerShell command")?;
+            if request.no_profile {
+                message = message.set_no_profile();
+            }
+            if let Some(directory) = request.directory.as_deref() {
+                message = message
+                    .with_directory(directory)
+                    .context("encode Windows PowerShell directory")?;
+            }
+            if !request.detached {
+                message = message.with_io_redirection();
+            } else {
+                message = message.with_detached();
+            }
+            if caps.contains(NowExecCapsetFlags::UNICODE_CONSOLE) {
+                message = message.with_raw_encoding().with_unicode_console();
+            }
+            let mut encoded =
+                now_proto_pdu::ironrdp_core::encode_vec(&NowMessage::from(message)).context("encode NOW request")?;
+            if request.non_interactive {
+                set_non_interactive(&mut encoded)?;
+            }
+            return Ok(encoded);
+        }
+        NowExecutionKind::PowerShell => {
+            let mut message =
+                NowExecPwshMsg::new(session_id, request.command.as_str()).context("encode PowerShell command")?;
+            if request.no_profile {
+                message = message.set_no_profile();
+            }
+            if let Some(directory) = request.directory.as_deref() {
+                message = message
+                    .with_directory(directory)
+                    .context("encode PowerShell directory")?;
+            }
+            if !request.detached {
+                message = message.with_io_redirection();
+            } else {
+                message = message.with_detached();
+            }
+            if caps.contains(NowExecCapsetFlags::UNICODE_CONSOLE) {
+                message = message.with_raw_encoding().with_unicode_console();
+            }
+            let mut encoded =
+                now_proto_pdu::ironrdp_core::encode_vec(&NowMessage::from(message)).context("encode NOW request")?;
+            if request.non_interactive {
+                set_non_interactive(&mut encoded)?;
+            }
+            return Ok(encoded);
+        }
+        NowExecutionKind::Process => {
+            let mut message =
+                NowExecProcessMsg::new(session_id, request.command.as_str()).context("encode NOW process filename")?;
+            if let Some(parameters) = request.parameters.as_deref() {
+                message = message
+                    .with_parameters(parameters)
+                    .context("encode NOW process parameters")?;
+            }
+            if let Some(directory) = request.directory.as_deref() {
+                message = message
+                    .with_directory(directory)
+                    .context("encode NOW process directory")?;
+            }
+            if request.detached {
+                message = message.with_detached();
+            } else {
+                message = message.with_io_redirection();
+            }
+            if caps.contains(NowExecCapsetFlags::UNICODE_CONSOLE) {
+                message = message.with_encoding_utf8();
+            }
+            NowMessage::from(message)
+        }
+        NowExecutionKind::Shell => {
+            let mut message =
+                NowExecShellMsg::new(session_id, request.command.as_str()).context("encode NOW shell command")?;
+            if let Some(shell) = request.parameters.as_deref() {
+                message = message.with_shell(shell).context("encode NOW shell path")?;
+            }
+            if let Some(directory) = request.directory.as_deref() {
+                message = message
+                    .with_directory(directory)
+                    .context("encode NOW shell directory")?;
+            }
+            if request.detached {
+                message = message.with_detached();
+            } else {
+                message = message.with_io_redirection();
+            }
+            NowMessage::from(message)
+        }
+        NowExecutionKind::Batch => {
+            let mut message =
+                NowExecBatchMsg::new(session_id, request.command.as_str()).context("encode NOW batch command")?;
+            if let Some(directory) = request.directory.as_deref() {
+                message = message
+                    .with_directory(directory)
+                    .context("encode NOW batch directory")?;
+            }
+            if request.detached {
+                message = message.with_detached();
+            } else {
+                message = message.with_io_redirection();
+            }
+            if caps.contains(NowExecCapsetFlags::UNICODE_CONSOLE) {
+                message = message.with_raw_encoding().with_unicode_console();
+            }
+            NowMessage::from(message)
+        }
+    };
+    now_proto_pdu::ironrdp_core::encode_vec(&message).context("encode NOW execution request")
+}
+
+fn set_non_interactive(encoded: &mut [u8]) -> anyhow::Result<()> {
+    // now-proto-pdu exposes the decoder for this standard flag but not a builder setter yet.
+    // The common NOW header stores flags as a little-endian u16 at byte offset 6.
+    let flag_bytes = encoded
+        .get_mut(6..8)
+        .context("encoded NOW PowerShell request is missing header flags")?;
+    let flags = u16::from_le_bytes([flag_bytes[0], flag_bytes[1]]) | NON_INTERACTIVE_FLAG;
+    flag_bytes.copy_from_slice(&flags.to_le_bytes());
+    Ok(())
+}
+
+fn client_capset() -> anyhow::Result<NowChannelCapsetMsg> {
+    NowChannelCapsetMsg::default()
+        .with_exec_capset(
+            NowExecCapsetFlags::STYLE_PROCESS
+                | NowExecCapsetFlags::STYLE_SHELL
+                | NowExecCapsetFlags::STYLE_BATCH
+                | NowExecCapsetFlags::STYLE_WINPS
+                | NowExecCapsetFlags::STYLE_PWSH
+                | NowExecCapsetFlags::IO_REDIRECTION
+                | NowExecCapsetFlags::UNICODE_CONSOLE,
+        )
+        .with_heartbeat_interval(HEARTBEAT_INTERVAL)
+        .context("set NOW heartbeat interval")
+}
+
+/// Buffered NOW message decoder that handles DVC fragmentation and coalescing.
+#[derive(Default)]
+struct MessageBuffer {
+    bytes: Vec<u8>,
+    start: usize,
+}
+
+impl MessageBuffer {
+    fn push(&mut self, data: &[u8]) {
+        self.bytes.extend_from_slice(data);
+    }
+
+    fn next(&mut self) -> anyhow::Result<Option<NowMessage<'static>>> {
+        let available = &self.bytes[self.start..];
+        if available.len() >= 4 {
+            let body_len = u32::from_le_bytes(available[..4].try_into().expect("slice length checked"));
+            let body_len = usize::try_from(body_len).expect("u32 fits in usize on supported platforms");
+            if body_len > MAX_MESSAGE_BODY_LEN {
+                bail!("NOW message body length {body_len} exceeds the {MAX_MESSAGE_BODY_LEN}-byte limit");
+            }
+        }
+
+        let mut cursor = ReadCursor::new(available);
+        match NowMessage::decode(&mut cursor) {
+            Ok(message) => {
+                let consumed = cursor.pos();
+                let message = message.into_owned();
+                let _ = cursor;
+                self.start += consumed;
+                if self.start == self.bytes.len() {
+                    self.bytes.clear();
+                    self.start = 0;
+                } else if self.start >= self.bytes.len() / 2 {
+                    let remaining = self.bytes.len() - self.start;
+                    self.bytes.copy_within(self.start.., 0);
+                    self.bytes.truncate(remaining);
+                    self.start = 0;
+                }
+                Ok(Some(message))
+            }
+            Err(error) if matches!(error.kind, DecodeErrorKind::NotEnoughBytes { .. }) => Ok(None),
+            Err(error) => Err(error).context("decode NOW message"),
+        }
+    }
+}
+
+#[cfg(unix)]
+type LocalStream = tokio::net::UnixStream;
+#[cfg(windows)]
+type LocalStream = tokio::net::windows::named_pipe::NamedPipeClient;
+
+#[cfg(unix)]
+struct LocalEndpoint {
+    path: std::path::PathBuf,
+    name: String,
+}
+
+#[cfg(unix)]
+impl LocalEndpoint {
+    fn new() -> anyhow::Result<Self> {
+        let directory = std::env::var_os("XDG_RUNTIME_DIR")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(std::env::temp_dir);
+        let id = NEXT_ENDPOINT_ID.fetch_add(1, Ordering::Relaxed);
+        let path = directory.join(format!("ironrdp-agent-now-{}-{id}.sock", std::process::id()));
+        let name = path.to_string_lossy().into_owned();
+        Ok(Self { path, name })
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn display_name(&self) -> String {
+        self.path.display().to_string()
+    }
+
+    async fn connect_with_timeout(&self, timeout: Duration) -> anyhow::Result<LocalStream> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            match tokio::net::UnixStream::connect(&self.path).await {
+                Ok(stream) => return Ok(stream),
+                Err(_) if tokio::time::Instant::now() < deadline => {
+                    let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+                    tokio::time::sleep(remaining.min(Duration::from_millis(100))).await;
+                }
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!(
+                            "NOW DVC pipe {} did not connect within {} seconds",
+                            self.path.display(),
+                            timeout.as_secs()
+                        )
+                    });
+                }
+            }
+        }
+    }
+}
+
+#[cfg(windows)]
+struct LocalEndpoint {
+    name: String,
+}
+
+#[cfg(windows)]
+impl LocalEndpoint {
+    fn new() -> anyhow::Result<Self> {
+        let id = NEXT_ENDPOINT_ID.fetch_add(1, Ordering::Relaxed);
+        // DvcNamedPipeProxy adds the Windows pipe namespace itself.
+        let name = format!("ironrdp-agent-now-{}-{id}", std::process::id());
+        Ok(Self { name })
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn display_name(&self) -> String {
+        format!(r"\\.\pipe\{}", self.name)
+    }
+
+    async fn connect_with_timeout(&self, timeout: Duration) -> anyhow::Result<LocalStream> {
+        use tokio::net::windows::named_pipe::ClientOptions;
+
+        let pipe_path = format!(r"\\.\pipe\{}", self.name);
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            match ClientOptions::new().open(&pipe_path) {
+                Ok(pipe) => return Ok(pipe),
+                Err(_) if tokio::time::Instant::now() < deadline => {
+                    let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+                    tokio::time::sleep(remaining.min(Duration::from_millis(100))).await;
+                }
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!(
+                            "NOW DVC pipe {} did not connect within {} seconds",
+                            pipe_path,
+                            timeout.as_secs()
+                        )
+                    });
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn message_buffer_reassembles_fragmented_and_coalesced_messages() {
+        let capset = NowMessage::from(
+            NowChannelCapsetMsg::default()
+                .with_exec_capset(NowExecCapsetFlags::STYLE_WINPS | NowExecCapsetFlags::IO_REDIRECTION),
+        );
+        let started = NowMessage::from(now_proto_pdu::NowExecStartedMsg::new(7));
+        let stdout = NowMessage::from(
+            NowExecDataMsg::new(7, NowExecDataStreamKind::Stdout, false, b"stdout".as_slice()).expect("valid output"),
+        );
+        let result = NowMessage::from(now_proto_pdu::NowExecResultMsg::new_success(7, 0));
+
+        let mut bytes = now_proto_pdu::ironrdp_core::encode_vec(&capset).expect("encode capset");
+        bytes.extend(now_proto_pdu::ironrdp_core::encode_vec(&started).expect("encode started"));
+        bytes.extend(now_proto_pdu::ironrdp_core::encode_vec(&stdout).expect("encode stdout"));
+        bytes.extend(now_proto_pdu::ironrdp_core::encode_vec(&result).expect("encode result"));
+
+        let split = 5;
+        let mut buffer = MessageBuffer::default();
+        buffer.push(&bytes[..split]);
+        assert!(buffer.next().expect("decode fragment").is_none());
+        buffer.push(&bytes[split..]);
+
+        let mut messages = Vec::new();
+        while let Some(message) = buffer.next().expect("decode message") {
+            messages.push(message);
+        }
+        assert_eq!(messages.len(), 4);
+        assert!(matches!(messages[0], NowMessage::Channel(NowChannelMessage::Capset(_))));
+        assert!(matches!(messages[1], NowMessage::Exec(NowExecMessage::Started(_))));
+        assert!(matches!(messages[2], NowMessage::Exec(NowExecMessage::Data(_))));
+        assert!(matches!(messages[3], NowMessage::Exec(NowExecMessage::Result(_))));
+    }
+
+    #[test]
+    fn powershell_request_defaults_to_no_profile_and_non_interactive() {
+        let request = PowerShellRequest {
+            kind: PowerShellKind::WindowsPowerShell,
+            command: "$PSVersionTable.PSVersion".to_owned(),
+            no_profile: true,
+            non_interactive: true,
+        };
+        let encoded = encode_powershell_request(
+            42,
+            &request,
+            NowExecCapsetFlags::STYLE_WINPS | NowExecCapsetFlags::IO_REDIRECTION | NowExecCapsetFlags::UNICODE_CONSOLE,
+        )
+        .expect("encode PowerShell request");
+        let mut cursor = ReadCursor::new(&encoded);
+        let message = NowMessage::decode(&mut cursor).expect("decode PowerShell request");
+        let NowMessage::Exec(NowExecMessage::WinPs(message)) = message else {
+            panic!("expected Windows PowerShell request");
+        };
+        assert!(message.is_no_profile());
+        assert!(message.is_non_interactive());
+        assert!(message.is_with_io_redirection());
+        assert!(message.is_raw_encoding());
+        assert!(message.is_unicode_console());
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn now_exec_result_preserves_exit_code() {
+        use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+        use tokio::net::windows::named_pipe::ServerOptions;
+
+        let client = NowClient::new().expect("create NOW client");
+        let pipe_path = format!(r"\\.\pipe\{}", client.endpoint());
+        let mut server = ServerOptions::new()
+            .first_pipe_instance(true)
+            .create(pipe_path)
+            .expect("create DVC proxy endpoint");
+
+        let server_task = tokio::spawn(async move {
+            server.connect().await.expect("accept NOW client");
+            let mut buffer = MessageBuffer::default();
+            let mut read_buffer = [0; 1024];
+
+            let capset = loop {
+                let read = server.read(&mut read_buffer).await.expect("read capability request");
+                buffer.push(&read_buffer[..read]);
+                if let Some(message) = buffer.next().expect("decode capability request") {
+                    break message;
+                }
+            };
+            assert!(matches!(capset, NowMessage::Channel(NowChannelMessage::Capset(_))));
+
+            let caps = NowChannelCapsetMsg::default()
+                .with_exec_capset(NowExecCapsetFlags::STYLE_PWSH | NowExecCapsetFlags::IO_REDIRECTION);
+            let caps = now_proto_pdu::ironrdp_core::encode_vec(&NowMessage::from(caps)).expect("encode capabilities");
+            server.write_all(&caps).await.expect("write capabilities");
+
+            let request = loop {
+                let read = server.read(&mut read_buffer).await.expect("read PowerShell request");
+                buffer.push(&read_buffer[..read]);
+                if let Some(message) = buffer.next().expect("decode PowerShell request") {
+                    break message;
+                }
+            };
+            assert!(matches!(request, NowMessage::Exec(NowExecMessage::Pwsh(_))));
+
+            let result = NowMessage::from(now_proto_pdu::NowExecResultMsg::new_success(1, 7));
+            let result = now_proto_pdu::ironrdp_core::encode_vec(&result).expect("encode result");
+            server.write_all(&result).await.expect("write result");
+            server.flush().await.expect("flush result");
+        });
+
+        let result = client
+            .execute(PowerShellRequest {
+                kind: PowerShellKind::PowerShell,
+                command: "exit 7".to_owned(),
+                no_profile: true,
+                non_interactive: true,
+            })
+            .await
+            .expect("execute NOW PowerShell request");
+        server_task.await.expect("join DVC proxy endpoint");
+        assert_eq!(result.exit_code, 7);
+
+        let payload = crate::ipc::Payload::PowerShell {
+            stdout: result.stdout,
+            stderr: result.stderr,
+            exit_code: result.exit_code,
+        };
+        let crate::ipc::Payload::PowerShell { exit_code, .. } = payload else {
+            panic!("expected PowerShell payload");
+        };
+        assert_eq!(exit_code, 7);
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn streamed_execution_forwards_stdin_and_raw_output() {
+        use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+        use tokio::net::windows::named_pipe::ServerOptions;
+
+        let client = Arc::new(NowClient::new().expect("create NOW client"));
+        let pipe_path = format!(r"\\.\pipe\{}", client.endpoint());
+        let mut server = ServerOptions::new()
+            .first_pipe_instance(true)
+            .create(pipe_path)
+            .expect("create DVC proxy endpoint");
+
+        let server_task = tokio::spawn(async move {
+            server.connect().await.expect("accept NOW client");
+            let mut buffer = MessageBuffer::default();
+            let mut read_buffer = [0; 1024];
+
+            async fn read_next(
+                server: &mut tokio::net::windows::named_pipe::NamedPipeServer,
+                buffer: &mut MessageBuffer,
+                read_buffer: &mut [u8],
+            ) -> NowMessage<'static> {
+                loop {
+                    if let Some(message) = buffer.next().expect("decode NOW message") {
+                        return message;
+                    }
+                    let read = server.read(read_buffer).await.expect("read NOW message");
+                    buffer.push(&read_buffer[..read]);
+                }
+            }
+
+            assert!(matches!(
+                read_next(&mut server, &mut buffer, &mut read_buffer).await,
+                NowMessage::Channel(NowChannelMessage::Capset(_))
+            ));
+            let caps = NowChannelCapsetMsg::default().with_exec_capset(
+                NowExecCapsetFlags::STYLE_PWSH
+                    | NowExecCapsetFlags::IO_REDIRECTION
+                    | NowExecCapsetFlags::UNICODE_CONSOLE,
+            );
+            let caps = now_proto_pdu::ironrdp_core::encode_vec(&NowMessage::from(caps)).expect("encode capabilities");
+            server.write_all(&caps).await.expect("write capabilities");
+
+            assert!(matches!(
+                read_next(&mut server, &mut buffer, &mut read_buffer).await,
+                NowMessage::Exec(NowExecMessage::Pwsh(_))
+            ));
+            let started =
+                now_proto_pdu::ironrdp_core::encode_vec(&NowMessage::from(now_proto_pdu::NowExecStartedMsg::new(1)))
+                    .expect("encode started");
+            server.write_all(&started).await.expect("write started");
+
+            let stdin = read_next(&mut server, &mut buffer, &mut read_buffer).await;
+            let NowMessage::Exec(NowExecMessage::Data(stdin)) = stdin else {
+                panic!("expected standard input data");
+            };
+            assert_eq!(stdin.stream_kind().expect("stdin stream"), NowExecDataStreamKind::Stdin);
+            assert!(stdin.is_last());
+            assert_eq!(stdin.data(), b"input\x00");
+
+            let stdout = NowMessage::from(
+                NowExecDataMsg::new(1, NowExecDataStreamKind::Stdout, false, b"stdout\x80".as_slice())
+                    .expect("encode stdout"),
+            );
+            let stderr = NowMessage::from(
+                NowExecDataMsg::new(1, NowExecDataStreamKind::Stderr, true, b"stderr\xff".as_slice())
+                    .expect("encode stderr"),
+            );
+            let result = NowMessage::from(now_proto_pdu::NowExecResultMsg::new_success(1, 7));
+            for message in [stdout, stderr, result] {
+                let bytes = now_proto_pdu::ironrdp_core::encode_vec(&message).expect("encode response");
+                server.write_all(&bytes).await.expect("write response");
+            }
+            server.flush().await.expect("flush responses");
+        });
+
+        let request = NowExecutionRequest {
+            kind: NowExecutionKind::PowerShell,
+            command: "ignored".to_owned(),
+            parameters: None,
+            directory: None,
+            no_profile: true,
+            non_interactive: true,
+            detached: false,
+            timeout_secs: Some(30),
+            stdin: Some(b"input\x00".to_vec()),
+        };
+        let mut operation = client.start_execution(request).expect("start streamed execution");
+        let mut events = Vec::new();
+        while let Some(event) = operation.events.recv().await {
+            events.push(event);
+        }
+        server_task.await.expect("join DVC proxy endpoint");
+
+        assert!(matches!(
+            events.as_slice(),
+            [
+                NowOperationEvent::Data {
+                    stream: NowStream::Stdout,
+                    data,
+                },
+                NowOperationEvent::Data {
+                    stream: NowStream::Stderr,
+                    data: _,
+                },
+                NowOperationEvent::Finished { exit_code: 7 },
+            ] if data == b"stdout\x80"
+        ));
+        let NowOperationEvent::Data { data, .. } = &events[1] else {
+            panic!("expected stderr event");
+        };
+        assert_eq!(data, b"stderr\xff");
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn streamed_execution_sends_cancel_request_and_waits_for_terminal_result() {
+        use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+        use tokio::net::windows::named_pipe::ServerOptions;
+        use tokio::sync::oneshot;
+
+        let client = Arc::new(NowClient::new().expect("create NOW client"));
+        let pipe_path = format!(r"\\.\pipe\{}", client.endpoint());
+        let mut server = ServerOptions::new()
+            .first_pipe_instance(true)
+            .create(pipe_path)
+            .expect("create DVC proxy endpoint");
+        let (request_seen_tx, request_seen_rx) = oneshot::channel();
+
+        let server_task = tokio::spawn(async move {
+            server.connect().await.expect("accept NOW client");
+            let mut buffer = MessageBuffer::default();
+            let mut read_buffer = [0; 1024];
+
+            async fn read_next(
+                server: &mut tokio::net::windows::named_pipe::NamedPipeServer,
+                buffer: &mut MessageBuffer,
+                read_buffer: &mut [u8],
+            ) -> NowMessage<'static> {
+                loop {
+                    if let Some(message) = buffer.next().expect("decode NOW message") {
+                        return message;
+                    }
+                    let read = server.read(read_buffer).await.expect("read NOW message");
+                    buffer.push(&read_buffer[..read]);
+                }
+            }
+
+            assert!(matches!(
+                read_next(&mut server, &mut buffer, &mut read_buffer).await,
+                NowMessage::Channel(NowChannelMessage::Capset(_))
+            ));
+            let caps = NowChannelCapsetMsg::default()
+                .with_exec_capset(NowExecCapsetFlags::STYLE_PWSH | NowExecCapsetFlags::IO_REDIRECTION);
+            let caps = now_proto_pdu::ironrdp_core::encode_vec(&NowMessage::from(caps)).expect("encode capabilities");
+            server.write_all(&caps).await.expect("write capabilities");
+
+            assert!(matches!(
+                read_next(&mut server, &mut buffer, &mut read_buffer).await,
+                NowMessage::Exec(NowExecMessage::Pwsh(_))
+            ));
+            request_seen_tx.send(()).expect("notify request");
+
+            let cancel = read_next(&mut server, &mut buffer, &mut read_buffer).await;
+            let NowMessage::Exec(NowExecMessage::CancelReq(cancel)) = cancel else {
+                panic!("expected NOW cancellation request");
+            };
+            assert_eq!(cancel.session_id(), 1);
+
+            for message in [
+                NowMessage::from(now_proto_pdu::NowExecCancelRspMsg::new_success(1)),
+                NowMessage::from(now_proto_pdu::NowExecResultMsg::new_success(1, 0)),
+            ] {
+                let bytes = now_proto_pdu::ironrdp_core::encode_vec(&message).expect("encode response");
+                server.write_all(&bytes).await.expect("write response");
+            }
+            server.flush().await.expect("flush responses");
+        });
+
+        let mut operation = client
+            .start_execution(NowExecutionRequest {
+                kind: NowExecutionKind::PowerShell,
+                command: "Start-Sleep 60".to_owned(),
+                parameters: None,
+                directory: None,
+                no_profile: true,
+                non_interactive: true,
+                detached: false,
+                timeout_secs: None,
+                stdin: None,
+            })
+            .expect("start streamed execution");
+        request_seen_rx.await.expect("wait for request");
+        client.cancel(operation.id).expect("request cancellation");
+
+        let event = operation.events.recv().await.expect("terminal event");
+        let NowOperationEvent::Failed { message } = event else {
+            panic!("cancellation must produce a terminal error");
+        };
+        assert!(message.contains("was cancelled"));
+        assert!(operation.events.recv().await.is_none());
+        server_task.await.expect("join DVC proxy endpoint");
+    }
+
+    #[test]
+    fn client_capset_advertises_power_shell_and_heartbeat_support() {
+        let capset = client_capset().expect("build client capset");
+        let capabilities = capset.exec_capset();
+        assert!(capabilities.contains(NowExecCapsetFlags::STYLE_PROCESS));
+        assert!(capabilities.contains(NowExecCapsetFlags::STYLE_SHELL));
+        assert!(capabilities.contains(NowExecCapsetFlags::STYLE_BATCH));
+        assert!(capabilities.contains(NowExecCapsetFlags::STYLE_WINPS));
+        assert!(capabilities.contains(NowExecCapsetFlags::STYLE_PWSH));
+        assert!(capabilities.contains(NowExecCapsetFlags::IO_REDIRECTION));
+        assert_eq!(capset.heartbeat_interval(), Some(HEARTBEAT_INTERVAL));
+    }
+
+    #[test]
+    fn generic_process_request_uses_redirection_and_utf8_when_available() {
+        let request = NowExecutionRequest {
+            kind: NowExecutionKind::Process,
+            command: r"C:\tool.exe".to_owned(),
+            parameters: Some("--json".to_owned()),
+            directory: Some(r"C:\work".to_owned()),
+            no_profile: true,
+            non_interactive: true,
+            detached: false,
+            timeout_secs: None,
+            stdin: None,
+        };
+        let encoded = encode_execution_request(
+            12,
+            &request,
+            NowExecCapsetFlags::STYLE_PROCESS
+                | NowExecCapsetFlags::IO_REDIRECTION
+                | NowExecCapsetFlags::UNICODE_CONSOLE,
+        )
+        .expect("encode process request");
+        let mut cursor = ReadCursor::new(&encoded);
+        let message = NowMessage::decode(&mut cursor).expect("decode process request");
+        let NowMessage::Exec(NowExecMessage::Process(message)) = message else {
+            panic!("expected process request");
+        };
+        assert_eq!(message.filename(), r"C:\tool.exe");
+        assert_eq!(message.parameters(), Some("--json"));
+        assert_eq!(message.directory(), Some(r"C:\work"));
+        assert!(message.is_with_io_redirection());
+        assert!(message.is_encoding_utf8());
+    }
+
+    #[test]
+    fn detached_execution_rejects_stdin_and_timeout() {
+        let request = NowExecutionRequest {
+            kind: NowExecutionKind::Batch,
+            command: "start cmd".to_owned(),
+            parameters: None,
+            directory: None,
+            no_profile: true,
+            non_interactive: true,
+            detached: true,
+            timeout_secs: None,
+            stdin: Some(vec![1]),
+        };
+        assert!(
+            validate_execution_request(&request)
+                .expect_err("detached stdin must be rejected")
+                .to_string()
+                .contains("does not support standard input")
+        );
+
+        let request = NowExecutionRequest {
+            stdin: None,
+            timeout_secs: Some(1),
+            ..request
+        };
+        assert!(
+            validate_execution_request(&request)
+                .expect_err("detached timeout must be rejected")
+                .to_string()
+                .contains("does not support a timeout")
+        );
+    }
+
+    #[test]
+    fn cancellation_marks_the_matching_running_operation() {
+        let client = NowClient::new().expect("create NOW client");
+        let active = ActiveOperation {
+            id: 22,
+            cancellation_requested: Arc::new(AtomicBool::new(false)),
+            cancellation: Arc::new(Notify::new()),
+        };
+        *client.active.lock().expect("operation state") = Some(active.clone());
+        client.cancel(22).expect("cancel matching operation");
+        assert!(active.cancellation_requested.load(Ordering::Acquire));
+        assert!(
+            client
+                .cancel(23)
+                .expect_err("wrong operation must fail")
+                .to_string()
+                .contains("not running")
+        );
+    }
+
+    #[test]
+    fn powershell_output_limit_is_shared_across_streams() {
+        let mut stdout = Vec::new();
+        append_output(&mut stdout, MAX_POWERSHELL_OUTPUT_LEN - 1, b"x").expect("output below limit");
+
+        let error =
+            append_output(&mut stdout, MAX_POWERSHELL_OUTPUT_LEN, b"x").expect_err("output above limit must fail");
+        assert!(error.to_string().contains("15 MiB IPC limit"));
+    }
+
+    #[tokio::test]
+    async fn endpoint_fails_when_dvc_proxy_does_not_open() {
+        assert_eq!(INITIAL_CONNECT_TIMEOUT, Duration::from_secs(30));
+        assert_eq!(RECONNECT_TIMEOUT, Duration::from_secs(10));
+        let endpoint = LocalEndpoint::new().expect("create endpoint");
+        let error = endpoint
+            .connect_with_timeout(Duration::ZERO)
+            .await
+            .expect_err("missing DVC proxy endpoint must fail");
+        assert!(error.to_string().contains("NOW DVC pipe"));
+        assert!(error.to_string().contains("did not connect within 0 seconds"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn endpoint_connects_as_the_now_client() {
+        let endpoint = LocalEndpoint::new().expect("create endpoint");
+        let listener = tokio::net::UnixListener::bind(&endpoint.path).expect("bind DVC proxy endpoint");
+        let (client, server) = tokio::join!(
+            endpoint.connect_with_timeout(INITIAL_CONNECT_TIMEOUT),
+            listener.accept()
+        );
+        client.expect("connect NOW client");
+        server.expect("accept NOW client");
+        std::fs::remove_file(&endpoint.path).expect("remove test endpoint");
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn endpoint_connects_as_the_now_client() {
+        use tokio::net::windows::named_pipe::ServerOptions;
+
+        let endpoint = LocalEndpoint::new().expect("create endpoint");
+        assert!(!endpoint.name().starts_with(r"\\.\pipe\"));
+        let pipe_path = format!(r"\\.\pipe\{}", endpoint.name());
+        let server = ServerOptions::new()
+            .first_pipe_instance(true)
+            .create(pipe_path)
+            .expect("create DVC proxy endpoint");
+        let (client, accepted) = tokio::join!(endpoint.connect_with_timeout(INITIAL_CONNECT_TIMEOUT), server.connect());
+        client.expect("connect NOW client");
+        accepted.expect("accept NOW client");
+    }
+}

--- a/crates/ironrdp-agent/src/operations.rs
+++ b/crates/ironrdp-agent/src/operations.rs
@@ -1,0 +1,450 @@
+//! Durable, daemon-owned NOW operation records.
+//!
+//! The NOW byte stream has one active execution at a time. This module intentionally separates that
+//! transport lifetime from an IPC client lifetime: a client may disconnect and later replay retained
+//! output or observe the terminal status without affecting the remote operation.
+
+use std::collections::{BTreeMap, VecDeque};
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context as _, bail};
+use tokio::io::AsyncWrite;
+use tokio::sync::Notify;
+
+use crate::ipc::{NowExecutionRequest, NowOperationInfo, NowOperationState, NowStream, Payload, Response};
+use crate::now::{NowClient, NowOperation, NowOperationEvent, NowStdinChunk};
+use crate::transport::write_message;
+
+/// Bounded output available for a later operation replay.
+pub(crate) const OUTPUT_RETENTION_BYTES: usize = 8 * 1024 * 1024;
+const MAX_RETAINED_OPERATIONS: usize = 32;
+const MAX_TOTAL_RETAINED_OUTPUT_BYTES: usize = 32 * 1024 * 1024;
+const MAX_STDIN_FRAGMENT_BYTES: usize = 64 * 1024;
+
+#[derive(Clone)]
+pub(crate) struct NowOperationManager {
+    now: Arc<NowClient>,
+    records: Arc<Mutex<BTreeMap<u64, OperationRecord>>>,
+}
+
+struct OperationRecord {
+    info: NowOperationInfo,
+    output: VecDeque<OutputEvent>,
+    notifier: Arc<Notify>,
+    stdin: Option<tokio::sync::mpsc::Sender<NowStdinChunk>>,
+    stdin_closed: bool,
+}
+
+#[derive(Clone)]
+struct OutputEvent {
+    sequence: u64,
+    stream: NowStream,
+    data: Vec<u8>,
+}
+
+impl NowOperationManager {
+    pub(crate) fn new(now: Arc<NowClient>) -> Self {
+        Self {
+            now,
+            records: Arc::new(Mutex::new(BTreeMap::new())),
+        }
+    }
+
+    fn prune_records(&self) {
+        let mut records = self.records.lock().expect("NOW operation records poisoned");
+        prune_records(&mut records);
+    }
+
+    pub(crate) fn start(&self, request: NowExecutionRequest) -> anyhow::Result<NowOperationInfo> {
+        let kind = request.kind;
+        let detached = request.detached;
+        let stdin_closed = request.stdin.is_some();
+        let operation = self.now.start_execution(request)?;
+        let info = NowOperationInfo {
+            operation_id: operation.id,
+            kind,
+            state: if detached {
+                NowOperationState::Detached
+            } else {
+                NowOperationState::Running
+            },
+            started_unix_ms: unix_time_ms(),
+            finished_unix_ms: None,
+            exit_code: None,
+            error: None,
+            stdout_bytes: 0,
+            stderr_bytes: 0,
+            retained_bytes: 0,
+            dropped_bytes: 0,
+            next_sequence: 1,
+        };
+        self.records.lock().expect("NOW operation records poisoned").insert(
+            operation.id,
+            OperationRecord {
+                info: info.clone(),
+                output: VecDeque::new(),
+                notifier: Arc::new(Notify::new()),
+                stdin: Some(operation.stdin.clone()),
+                stdin_closed,
+            },
+        );
+        self.prune_records();
+        let manager = self.clone();
+        tokio::spawn(async move {
+            manager.collect(operation).await;
+        });
+        Ok(info)
+    }
+
+    pub(crate) fn list(&self) -> Vec<NowOperationInfo> {
+        self.records
+            .lock()
+            .expect("NOW operation records poisoned")
+            .values()
+            .map(|record| record.info.clone())
+            .collect()
+    }
+
+    pub(crate) fn status(&self, operation_id: u64) -> anyhow::Result<NowOperationInfo> {
+        self.records
+            .lock()
+            .expect("NOW operation records poisoned")
+            .get(&operation_id)
+            .map(|record| record.info.clone())
+            .with_context(|| format!("NOW operation {operation_id} was not found"))
+    }
+
+    pub(crate) fn cancel(&self, operation_id: u64) -> anyhow::Result<NowOperationInfo> {
+        {
+            let records = self.records.lock().expect("NOW operation records poisoned");
+            let record = records
+                .get(&operation_id)
+                .with_context(|| format!("NOW operation {operation_id} was not found"))?;
+            if is_terminal(record.info.state) {
+                bail!("NOW operation {operation_id} is already complete");
+            }
+
+            if record.info.state == NowOperationState::Detached {
+                bail!("detached NOW operation {operation_id} cannot be cancelled or observed");
+            }
+        }
+        self.now.cancel(operation_id)?;
+        let mut records = self.records.lock().expect("NOW operation records poisoned");
+        let record = records
+            .get_mut(&operation_id)
+            .expect("operation exists after cancellation validation");
+        record.info.state = NowOperationState::Cancelling;
+        record.notifier.notify_waiters();
+        Ok(record.info.clone())
+    }
+
+    /// Delivers a bounded stdin fragment while the protocol worker owns the NOW byte stream.
+    pub(crate) async fn write_stdin(&self, operation_id: u64, data: Vec<u8>, last: bool) -> anyhow::Result<()> {
+        if data.len() > MAX_STDIN_FRAGMENT_BYTES {
+            bail!(
+                "NOW standard input fragment exceeds the {} KiB limit",
+                MAX_STDIN_FRAGMENT_BYTES / 1024
+            );
+        }
+        let sender = {
+            let mut records = self.records.lock().expect("NOW operation records poisoned");
+            let record = records
+                .get_mut(&operation_id)
+                .with_context(|| format!("NOW operation {operation_id} was not found"))?;
+            if record.info.state != NowOperationState::Running {
+                bail!("NOW operation {operation_id} is not accepting standard input");
+            }
+            if record.stdin_closed {
+                bail!("NOW operation {operation_id} standard input is already closed");
+            }
+            if last {
+                record.stdin_closed = true;
+            }
+            record
+                .stdin
+                .as_ref()
+                .cloned()
+                .context("NOW operation standard input is unavailable")?
+        };
+        sender
+            .try_send(NowStdinChunk { data, last })
+            .map_err(|error| match error {
+                tokio::sync::mpsc::error::TrySendError::Full(_) => {
+                    anyhow::anyhow!("NOW operation standard input is backpressured; retry")
+                }
+                tokio::sync::mpsc::error::TrySendError::Closed(_) => {
+                    anyhow::anyhow!("NOW operation standard input worker stopped")
+                }
+            })
+    }
+
+    pub(crate) async fn attach<S>(
+        &self,
+        operation_id: u64,
+        mut after_sequence: u64,
+        stream: &mut S,
+    ) -> anyhow::Result<()>
+    where
+        S: AsyncWrite + Unpin,
+    {
+        loop {
+            let notifier = {
+                let records = self.records.lock().expect("NOW operation records poisoned");
+                let record = records
+                    .get(&operation_id)
+                    .with_context(|| format!("NOW operation {operation_id} was not found"))?;
+                Arc::clone(&record.notifier)
+            };
+            // Register before taking the snapshot. `enable` closes the otherwise subtle race where
+            // a producer notifies between observing no events and awaiting this attachment.
+            let notification = notifier.notified();
+            tokio::pin!(notification);
+            notification.as_mut().enable();
+            let (events, info) = {
+                let records = self.records.lock().expect("NOW operation records poisoned");
+                let record = records
+                    .get(&operation_id)
+                    .with_context(|| format!("NOW operation {operation_id} was not found"))?;
+                (
+                    record
+                        .output
+                        .iter()
+                        .filter(|event| event.sequence > after_sequence)
+                        .cloned()
+                        .collect::<Vec<_>>(),
+                    record.info.clone(),
+                )
+            };
+
+            for event in events {
+                after_sequence = event.sequence;
+                write_message(
+                    stream,
+                    &Response::Ok(Payload::NowExecutionData {
+                        operation_id,
+                        sequence: event.sequence,
+                        stream: event.stream,
+                        data: event.data,
+                    }),
+                )
+                .await?;
+            }
+
+            if is_terminal(info.state) {
+                return write_terminal(stream, info).await;
+            }
+
+            notification.await;
+        }
+    }
+
+    async fn collect(&self, mut operation: NowOperation) {
+        while let Some(event) = operation.events.recv().await {
+            let mut request_cancel = false;
+            {
+                let mut records = self.records.lock().expect("NOW operation records poisoned");
+                let Some(record) = records.get_mut(&operation.id) else {
+                    return;
+                };
+                match event {
+                    NowOperationEvent::Data { stream, data } => {
+                        request_cancel = retain_data(record, stream, data);
+                    }
+                    NowOperationEvent::Finished { exit_code } => {
+                        if record.info.state != NowOperationState::Detached {
+                            record.info.state = NowOperationState::Succeeded;
+                            record.info.exit_code = Some(exit_code);
+                        }
+                        record.info.finished_unix_ms = Some(unix_time_ms());
+                        record.stdin = None;
+                    }
+                    NowOperationEvent::Failed { message } => {
+                        record.info.finished_unix_ms = Some(unix_time_ms());
+                        if record.info.state == NowOperationState::Cancelling {
+                            record.info.state = NowOperationState::Cancelled;
+                            if record.info.error.is_none() {
+                                record.info.error = Some(message);
+                            }
+                        } else {
+                            record.info.state = NowOperationState::Failed;
+                            record.info.error = Some(message);
+                        }
+                        record.stdin = None;
+                    }
+                }
+                record.notifier.notify_waiters();
+            }
+            self.prune_records();
+            if request_cancel {
+                if let Err(error) = self.now.cancel(operation.id) {
+                    let mut records = self.records.lock().expect("NOW operation records poisoned");
+                    if let Some(record) = records.get_mut(&operation.id) {
+                        record.info.state = NowOperationState::Failed;
+                        record.info.finished_unix_ms = Some(unix_time_ms());
+                        record.info.error = Some(format!(
+                            "NOW output retention limit reached and cancellation failed: {error:#}"
+                        ));
+                        record.notifier.notify_waiters();
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn prune_records(records: &mut BTreeMap<u64, OperationRecord>) {
+    while records.len() > MAX_RETAINED_OPERATIONS
+        || records.values().map(|record| record.info.retained_bytes).sum::<u64>()
+            > u64::try_from(MAX_TOTAL_RETAINED_OUTPUT_BYTES).expect("retention budget fits in u64")
+    {
+        let Some(operation_id) = records
+            .iter()
+            .find_map(|(operation_id, record)| is_terminal(record.info.state).then_some(*operation_id))
+        else {
+            return;
+        };
+        records.remove(&operation_id);
+    }
+}
+
+fn retain_data(record: &mut OperationRecord, stream: NowStream, data: Vec<u8>) -> bool {
+    match stream {
+        NowStream::Stdout => record.info.stdout_bytes += u64::try_from(data.len()).unwrap_or(u64::MAX),
+        NowStream::Stderr => record.info.stderr_bytes += u64::try_from(data.len()).unwrap_or(u64::MAX),
+    }
+    let data_len = data.len();
+    if record.info.retained_bytes + u64::try_from(data_len).unwrap_or(u64::MAX)
+        <= u64::try_from(OUTPUT_RETENTION_BYTES).expect("retention cap fits in u64")
+    {
+        let sequence = record.info.next_sequence;
+        record.info.next_sequence += 1;
+        record.info.retained_bytes += u64::try_from(data_len).unwrap_or(u64::MAX);
+        record.output.push_back(OutputEvent { sequence, stream, data });
+        false
+    } else {
+        record.info.dropped_bytes += u64::try_from(data_len).unwrap_or(u64::MAX);
+        if record.info.state == NowOperationState::Running {
+            record.info.state = NowOperationState::Cancelling;
+            record.info.error = Some(format!(
+                "NOW output exceeded the {} MiB retained operation limit; cancellation requested",
+                OUTPUT_RETENTION_BYTES / (1024 * 1024)
+            ));
+            true
+        } else {
+            false
+        }
+    }
+}
+
+async fn write_terminal<S>(stream: &mut S, info: NowOperationInfo) -> anyhow::Result<()>
+where
+    S: AsyncWrite + Unpin,
+{
+    match info.state {
+        NowOperationState::Succeeded => {
+            write_message(
+                stream,
+                &Response::Ok(Payload::NowExecutionResult {
+                    operation_id: info.operation_id,
+                    exit_code: info.exit_code.unwrap_or(0),
+                }),
+            )
+            .await
+        }
+        NowOperationState::Detached => write_message(stream, &Response::Ok(Payload::NowOperationInfo(info))).await,
+        NowOperationState::Cancelled | NowOperationState::Failed => {
+            write_message(
+                stream,
+                &Response::error(info.error.unwrap_or_else(|| "NOW operation failed".to_owned())),
+            )
+            .await
+        }
+        NowOperationState::Running | NowOperationState::Cancelling => unreachable!("terminal state checked above"),
+    }
+}
+
+fn is_terminal(state: NowOperationState) -> bool {
+    matches!(
+        state,
+        NowOperationState::Succeeded
+            | NowOperationState::Failed
+            | NowOperationState::Cancelled
+            | NowOperationState::Detached
+    )
+}
+
+fn unix_time_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record() -> OperationRecord {
+        OperationRecord {
+            info: NowOperationInfo {
+                operation_id: 17,
+                kind: crate::ipc::NowExecutionKind::PowerShell,
+                state: NowOperationState::Running,
+                started_unix_ms: 1,
+                finished_unix_ms: None,
+                exit_code: None,
+                error: None,
+                stdout_bytes: 0,
+                stderr_bytes: 0,
+                retained_bytes: 0,
+                dropped_bytes: 0,
+                next_sequence: 1,
+            },
+            output: VecDeque::new(),
+            notifier: Arc::new(Notify::new()),
+            stdin: None,
+            stdin_closed: false,
+        }
+    }
+
+    #[test]
+    fn retained_output_is_sequenced_and_bounded() {
+        let mut record = record();
+        assert!(!retain_data(&mut record, NowStream::Stdout, b"one".to_vec()));
+        assert!(!retain_data(&mut record, NowStream::Stderr, b"two".to_vec()));
+        assert_eq!(record.info.stdout_bytes, 3);
+        assert_eq!(record.info.stderr_bytes, 3);
+        assert_eq!(record.info.retained_bytes, 6);
+        assert_eq!(record.info.next_sequence, 3);
+        assert_eq!(record.output[0].sequence, 1);
+        assert_eq!(record.output[1].sequence, 2);
+    }
+
+    #[test]
+    fn overflowing_retention_requests_cancellation_without_unbounded_storage() {
+        let mut record = record();
+        record.info.retained_bytes = u64::try_from(OUTPUT_RETENTION_BYTES).expect("retention cap fits");
+        assert!(retain_data(&mut record, NowStream::Stdout, vec![0]));
+        assert_eq!(record.info.state, NowOperationState::Cancelling);
+        assert_eq!(record.info.dropped_bytes, 1);
+        assert!(record.output.is_empty());
+    }
+
+    #[test]
+    fn terminal_record_retention_evicts_oldest_operations() {
+        let mut records = BTreeMap::new();
+        for operation_id in 1..=MAX_RETAINED_OPERATIONS + 1 {
+            let mut value = record();
+            value.info.operation_id = u64::try_from(operation_id).expect("operation ID fits");
+            value.info.state = NowOperationState::Succeeded;
+            records.insert(value.info.operation_id, value);
+        }
+        prune_records(&mut records);
+        assert_eq!(records.len(), MAX_RETAINED_OPERATIONS);
+        assert!(!records.contains_key(&1));
+        assert!(records.contains_key(&u64::try_from(MAX_RETAINED_OPERATIONS + 1).expect("operation ID fits")));
+    }
+}

--- a/crates/ironrdp-agent/src/transport.rs
+++ b/crates/ironrdp-agent/src/transport.rs
@@ -62,6 +62,26 @@ pub async fn send_request(endpoint: &Endpoint, request: &Request) -> anyhow::Res
     read_message(&mut stream).await
 }
 
+/// Opens the endpoint, sends one request, then delivers every response frame to `on_response`.
+///
+/// The callback returns `true` after the terminal frame. This is deliberately separate from
+/// [`send_request`]: only NOW execution produces multiple response frames.
+pub async fn send_streaming_request<F>(endpoint: &Endpoint, request: &Request, mut on_response: F) -> anyhow::Result<()>
+where
+    F: FnMut(Response) -> anyhow::Result<bool>,
+{
+    let mut stream = connect(endpoint)
+        .await
+        .with_context(|| format!("connect to daemon at {endpoint}"))?;
+    write_message(&mut stream, request).await?;
+    loop {
+        let response = read_message(&mut stream).await?;
+        if on_response(response)? {
+            return Ok(());
+        }
+    }
+}
+
 #[cfg(unix)]
 mod imp {
     use std::io;

--- a/crates/ironrdp-agent/tests/remote_exit.rs
+++ b/crates/ironrdp-agent/tests/remote_exit.rs
@@ -37,11 +37,13 @@ async fn now_process_preserves_remote_exit_code() {
             Response::Ok(Payload::NowExecutionStarted { operation_id: 9 }),
             Response::Ok(Payload::NowExecutionData {
                 operation_id: 9,
+                sequence: 1,
                 stream: ironrdp_agent::ipc::NowStream::Stdout,
                 data: b"stdout".to_vec(),
             }),
             Response::Ok(Payload::NowExecutionData {
                 operation_id: 9,
+                sequence: 2,
                 stream: ironrdp_agent::ipc::NowStream::Stderr,
                 data: b"stderr".to_vec(),
             }),

--- a/crates/ironrdp-agent/tests/remote_exit.rs
+++ b/crates/ironrdp-agent/tests/remote_exit.rs
@@ -1,0 +1,78 @@
+#![cfg(windows)]
+#![expect(
+    unused_crate_dependencies,
+    reason = "the package's library dependencies are also linked into this integration test"
+)]
+
+use std::process::Command;
+
+use ironrdp_agent::ipc::{NowExecutionKind, Payload, Request, Response};
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+use tokio::net::windows::named_pipe::ServerOptions;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn now_process_preserves_remote_exit_code() {
+    let endpoint = format!(r"\\.\pipe\ironrdp-agent-remote-exit-{}", std::process::id());
+    let server = ServerOptions::new()
+        .first_pipe_instance(true)
+        .create(&endpoint)
+        .expect("create test IPC endpoint");
+
+    let server_task = tokio::spawn(async move {
+        server.connect().await.expect("accept CLI connection");
+
+        let mut server = server;
+        let mut len = [0u8; 4];
+        server.read_exact(&mut len).await.expect("read request length");
+        let body_len = usize::try_from(u32::from_le_bytes(len)).expect("request length fits usize");
+        let mut body = vec![0; body_len];
+        server.read_exact(&mut body).await.expect("read request body");
+        let request = ironrdp_core::decode_owned::<Request>(&body).expect("decode request");
+        assert!(matches!(
+            request,
+            Request::NowExecute(ref request) if request.kind == NowExecutionKind::PowerShell
+        ));
+
+        for response in [
+            Response::Ok(Payload::NowExecutionStarted { operation_id: 9 }),
+            Response::Ok(Payload::NowExecutionData {
+                operation_id: 9,
+                stream: ironrdp_agent::ipc::NowStream::Stdout,
+                data: b"stdout".to_vec(),
+            }),
+            Response::Ok(Payload::NowExecutionData {
+                operation_id: 9,
+                stream: ironrdp_agent::ipc::NowStream::Stderr,
+                data: b"stderr".to_vec(),
+            }),
+            Response::Ok(Payload::NowExecutionResult {
+                operation_id: 9,
+                exit_code: 7,
+            }),
+        ] {
+            let body = ironrdp_core::encode_vec(&response).expect("encode response");
+            let body_len = u32::try_from(body.len()).expect("response length fits u32");
+            server
+                .write_all(&body_len.to_le_bytes())
+                .await
+                .expect("write response length");
+            server.write_all(&body).await.expect("write response body");
+        }
+        server.flush().await.expect("flush response");
+    });
+
+    let endpoint_for_cli = endpoint.clone();
+    let output = tokio::task::spawn_blocking(move || {
+        Command::new(env!("CARGO_BIN_EXE_ironrdp-agent"))
+            .args(["--endpoint", &endpoint_for_cli, "now", "pwsh", "Write-Output ignored"])
+            .output()
+            .expect("run ironrdp-agent")
+    })
+    .await
+    .expect("join CLI process");
+
+    server_task.await.expect("join IPC server");
+    assert_eq!(output.status.code(), Some(7));
+    assert_eq!(output.stdout, b"stdout");
+    assert_eq!(output.stderr, b"stderr");
+}

--- a/crates/ironrdp-dvc-pipe-proxy/src/platform/windows.rs
+++ b/crates/ironrdp-dvc-pipe-proxy/src/platform/windows.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio::net::windows::named_pipe;
+use tracing::{error, info};
 
 use crate::error::DvcPipeProxyError;
 use crate::os_pipe::OsPipe;
@@ -15,7 +16,8 @@ pub(crate) struct WindowsPipe {
 #[async_trait]
 impl OsPipe for WindowsPipe {
     async fn connect(pipe_name: &str) -> Result<Self, DvcPipeProxyError> {
-        let pipe_name = format!("\\\\.\\pipe\\{pipe_name}");
+        let pipe_path = format!("\\\\.\\pipe\\{pipe_name}");
+        info!(%pipe_name, %pipe_path, "Creating DVC proxy Windows named pipe");
 
         let pipe_server = named_pipe::ServerOptions::new()
             .first_pipe_instance(true)
@@ -25,10 +27,18 @@ impl OsPipe for WindowsPipe {
             .in_buffer_size(PIPE_BUFFER_SIZE)
             .out_buffer_size(PIPE_BUFFER_SIZE)
             .pipe_mode(named_pipe::PipeMode::Byte)
-            .create(pipe_name)
-            .map_err(DvcPipeProxyError::Io)?;
+            .create(&pipe_path)
+            .map_err(|error| {
+                error!(%pipe_name, %pipe_path, %error, "Failed to create DVC proxy Windows named pipe");
+                DvcPipeProxyError::Io(error)
+            })?;
 
-        pipe_server.connect().await.map_err(DvcPipeProxyError::Io)?;
+        info!(%pipe_name, %pipe_path, "Waiting for DVC proxy Windows named-pipe client");
+        pipe_server.connect().await.map_err(|error| {
+            error!(%pipe_name, %pipe_path, %error, "Failed to accept DVC proxy Windows named-pipe client");
+            DvcPipeProxyError::Io(error)
+        })?;
+        info!(%pipe_name, %pipe_path, "Connected DVC proxy Windows named-pipe client");
 
         Ok(Self { pipe_server })
     }

--- a/crates/ironrdp-dvc-pipe-proxy/src/proxy.rs
+++ b/crates/ironrdp-dvc-pipe-proxy/src/proxy.rs
@@ -4,7 +4,7 @@ use ironrdp_core::impl_as_any;
 use ironrdp_dvc::{DvcClientProcessor, DvcMessage, DvcProcessor};
 use ironrdp_pdu::{PduResult, pdu_other_err};
 use ironrdp_svc::SvcMessage;
-use tracing::debug;
+use tracing::{debug, error};
 
 use crate::worker::{OnWriteDvcMessage, WorkerCtx, run_worker};
 
@@ -60,12 +60,14 @@ impl DvcProcessor for DvcNamedPipeProxy {
 
         let abort_event = Arc::new(tokio::sync::Notify::new());
 
+        let channel_name = self.channel_name.clone();
+        let pipe_name = self.named_pipe_name.clone();
         let ctx = WorkerCtx {
             on_write_dvc,
             to_pipe_rx,
             abort_event: Arc::clone(&abort_event),
-            pipe_name: self.named_pipe_name.clone(),
-            channel_name: self.channel_name.clone(),
+            pipe_name: pipe_name.clone(),
+            channel_name: channel_name.clone(),
             channel_id,
         };
 
@@ -75,10 +77,15 @@ impl DvcProcessor for DvcNamedPipeProxy {
         });
 
         #[cfg(not(target_os = "windows"))]
-        run_worker::<crate::platform::unix::UnixPipe>(ctx);
+        let worker = run_worker::<crate::platform::unix::UnixPipe>(ctx);
 
         #[cfg(target_os = "windows")]
-        run_worker::<crate::platform::windows::WindowsPipe>(ctx);
+        let worker = run_worker::<crate::platform::windows::WindowsPipe>(ctx);
+
+        if let Err(worker_error) = worker {
+            error!(%channel_name, %pipe_name, %worker_error, "DVC pipe proxy worker thread failed to start");
+            return Err(pdu_other_err!("start DVC pipe proxy worker: {worker_error}"));
+        }
 
         Ok(vec![])
     }

--- a/crates/ironrdp-dvc-pipe-proxy/src/worker.rs
+++ b/crates/ironrdp-dvc-pipe-proxy/src/worker.rs
@@ -1,16 +1,18 @@
+use core::time::Duration;
 use std::sync::{Arc, mpsc};
 
 use ironrdp_dvc::encode_dvc_messages;
 use ironrdp_pdu::PduResult;
 use ironrdp_svc::{ChannelFlags, SvcMessage};
 use tokio::sync::Notify;
-use tracing::{debug, error};
+use tracing::{debug, error, info};
 
 use crate::error::DvcPipeProxyError;
 use crate::message::RawDataDvcMessage;
 use crate::os_pipe::OsPipe;
 
 const IO_BUFFER_SIZE: usize = 1024 * 64; // 64K
+const RECONNECT_DELAY: Duration = Duration::from_millis(100);
 
 pub(crate) type OnWriteDvcMessage = Box<dyn Fn(u32, Vec<SvcMessage>) -> PduResult<()> + Send>;
 
@@ -23,10 +25,12 @@ pub(crate) struct WorkerCtx {
     pub(crate) channel_id: u32,
 }
 
-pub(crate) fn run_worker<P: OsPipe>(ctx: WorkerCtx) {
-    let _ = std::thread::spawn(move || {
+pub(crate) fn run_worker<P: OsPipe>(ctx: WorkerCtx) -> std::io::Result<()> {
+    let thread_name = format!("ironrdp-dvc-pipe-{}", ctx.channel_id);
+    std::thread::Builder::new().name(thread_name).spawn(move || {
         let channel_name = ctx.channel_name.clone();
         let pipe_name = ctx.pipe_name.clone();
+        info!(%channel_name, %pipe_name, "DVC pipe proxy worker thread started");
 
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -54,7 +58,8 @@ pub(crate) fn run_worker<P: OsPipe>(ctx: WorkerCtx) {
                 "DVC pipe proxy worker thread has failed"
             );
         }
-    });
+    })?;
+    Ok(())
 }
 
 enum NextWorkerState {
@@ -175,8 +180,18 @@ async fn worker<P: OsPipe>(ctx: WorkerCtx) -> Result<(), DvcPipeProxyError> {
         channel_id,
     };
     loop {
-        match process_client::<P>(&mut bridged_ctx).await? {
-            NextWorkerState::Abort => {
+        match process_client::<P>(&mut bridged_ctx).await {
+            Err(error) => {
+                error!(
+                    channel_name = %bridged_ctx.channel_name,
+                    pipe_name = %bridged_ctx.pipe_name,
+                    ?error,
+                    retry_delay_ms = RECONNECT_DELAY.as_millis(),
+                    "DVC pipe proxy connection failed; retrying"
+                );
+                std::thread::sleep(RECONNECT_DELAY);
+            }
+            Ok(NextWorkerState::Abort) => {
                 debug!(
                     channel_name = %bridged_ctx.channel_name,
                     pipe_name = %bridged_ctx.pipe_name,
@@ -184,7 +199,7 @@ async fn worker<P: OsPipe>(ctx: WorkerCtx) -> Result<(), DvcPipeProxyError> {
                 );
                 break;
             }
-            NextWorkerState::Reconnect => {
+            Ok(NextWorkerState::Reconnect) => {
                 debug!(
                     channel_name = %bridged_ctx.channel_name,
                     pipe_name = %bridged_ctx.pipe_name,

--- a/crates/ironrdp-dvc-pipe-proxy/tests/windows_pipe.rs
+++ b/crates/ironrdp-dvc-pipe-proxy/tests/windows_pipe.rs
@@ -1,0 +1,31 @@
+#![cfg(windows)]
+#![expect(
+    unused_crate_dependencies,
+    reason = "the package's library dependencies are also linked into this integration test"
+)]
+
+use core::time::Duration;
+
+use ironrdp_dvc::DvcProcessor as _;
+use ironrdp_dvc_pipe_proxy::DvcNamedPipeProxy;
+use tokio::net::windows::named_pipe::ClientOptions;
+
+#[tokio::test]
+async fn starts_a_connectable_windows_pipe() {
+    let name = format!("ironrdp-dvc-pipe-proxy-test-{}", std::process::id());
+    let mut proxy = DvcNamedPipeProxy::new("test", &name, |_, _| Ok(()));
+    proxy.start(1).expect("start DVC pipe proxy");
+
+    let pipe_path = format!(r"\\.\pipe\{name}");
+    let client = (0..200)
+        .find_map(|_| match ClientOptions::new().open(&pipe_path) {
+            Ok(client) => Some(client),
+            Err(_) => {
+                std::thread::sleep(Duration::from_millis(10));
+                None
+            }
+        })
+        .expect("DVC pipe proxy must create the pipe within two seconds");
+
+    drop(client);
+}


### PR DESCRIPTION
## Summary
- add daemon-owned, bounded NOW operation records with list, status, attach, cancel, and live stdin
- add JSON/NDJSON output, typed errors, diagnostics, Ctrl-C cancellation, and structured process arguments
- document the AI-oriented NOW operation workflow and retention/backpressure limits

## Validation
- `cargo +stable test -p ironrdp-agent --lib`
- `cargo +stable clippy -p ironrdp-agent --all-targets --no-deps -- -D warnings`
- `cargo +stable test -p ironrdp-agent --test remote_exit`
- `cargo +stable test -p ironrdp-testsuite-extra --test integration_tests_extra agent`