### PR TITLE
fix(displaycontrol): decode the full headered DISPLAYCONTROL_CAPS_PDU

### DIFF
--- a/crates/ironrdp-displaycontrol/src/client.rs
+++ b/crates/ironrdp-displaycontrol/src/client.rs
@@ -1,6 +1,6 @@
-use ironrdp_core::{Decode as _, EncodeResult, ReadCursor, impl_as_any};
+use ironrdp_core::{EncodeResult, decode, impl_as_any};
 use ironrdp_dvc::{DvcClientProcessor, DvcMessage, DvcProcessor, encode_dvc_messages};
-use ironrdp_pdu::{PduResult, decode_err};
+use ironrdp_pdu::{PduResult, decode_err, pdu_other_err};
 use ironrdp_svc::{ChannelFlags, SvcMessage};
 use tracing::debug;
 
@@ -76,7 +76,17 @@ impl DvcProcessor for DisplayControlClient {
     }
 
     fn process(&mut self, _channel_id: u32, payload: &[u8]) -> PduResult<Vec<DvcMessage>> {
-        let caps = DisplayControlCapabilities::decode(&mut ReadCursor::new(payload)).map_err(|e| decode_err!(e))?;
+        // The server sends the full DISPLAYCONTROL_CAPS_PDU, i.e. the capability set prefixed
+        // with the DISPLAYCONTROL_HEADER (Type + Length), per MS-RDPEDISP 2.2.2.1.
+        let caps = match decode(payload).map_err(|e| decode_err!(e))? {
+            DisplayControlPdu::Caps(caps) => caps,
+            DisplayControlPdu::MonitorLayout(_) => {
+                return Err(pdu_other_err!(
+                    "DisplayControlClient::process",
+                    "received unexpected DISPLAYCONTROL_MONITOR_LAYOUT_PDU from server"
+                ));
+            }
+        };
         debug!("Received {:?}", caps);
         self.ready = true;
         (self.on_capabilities_received)(caps)

--- a/crates/ironrdp-displaycontrol/src/pdu/mod.rs
+++ b/crates/ironrdp-displaycontrol/src/pdu/mod.rs
@@ -98,17 +98,22 @@ impl<'de> Decode<'de> for DisplayControlPdu {
             ));
         }
 
-        match kind {
-            DISPLAYCONTROL_PDU_TYPE_CAPS => {
-                let caps = DisplayControlCapabilities::decode(src)?;
-                Ok(DisplayControlPdu::Caps(caps))
-            }
+        let pdu = match kind {
+            DISPLAYCONTROL_PDU_TYPE_CAPS => DisplayControlPdu::Caps(DisplayControlCapabilities::decode(src)?),
             DISPLAYCONTROL_PDU_TYPE_MONITOR_LAYOUT => {
-                let layout = DisplayControlMonitorLayout::decode(src)?;
-                Ok(DisplayControlPdu::MonitorLayout(layout))
+                DisplayControlPdu::MonitorLayout(DisplayControlMonitorLayout::decode(src)?)
             }
-            _ => Err(invalid_field_err!("Type", "Unknown display control PDU type")),
+            _ => return Err(invalid_field_err!("Type", "Unknown display control PDU type")),
+        };
+
+        if !src.is_empty() {
+            return Err(invalid_field_err!(
+                "Length",
+                "trailing bytes after display control PDU body"
+            ));
         }
+
+        Ok(pdu)
     }
 }
 

--- a/crates/ironrdp-displaycontrol/src/pdu/mod.rs
+++ b/crates/ironrdp-displaycontrol/src/pdu/mod.rs
@@ -87,9 +87,16 @@ impl<'de> Decode<'de> for DisplayControlPdu {
         let kind = src.read_u32();
         let pdu_length = src.read_u32();
 
-        let _payload_length = pdu_length
+        let payload_length = pdu_length
             .checked_sub(Self::FIXED_PART_SIZE.try_into().expect("always in range"))
             .ok_or_else(|| invalid_field_err!("Length", "Display control PDU length is too small"))?;
+
+        if usize::try_from(payload_length).unwrap_or(usize::MAX) != src.len() {
+            return Err(invalid_field_err!(
+                "Length",
+                "Display control PDU length does not match the payload size"
+            ));
+        }
 
         match kind {
             DISPLAYCONTROL_PDU_TYPE_CAPS => {

--- a/crates/ironrdp-testsuite-core/tests/displaycontrol/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/displaycontrol/mod.rs
@@ -182,3 +182,20 @@ fn client_process_rejects_monitor_layout_from_server() {
     );
     assert!(!client.ready());
 }
+
+#[test]
+fn client_process_rejects_caps_with_mismatched_length() {
+    let mut client = DisplayControlClient::new(|_caps| Ok(Vec::new()));
+
+    let mismatched_length = [
+        // Header: Type = Caps, Length = 0xffff_ffff
+        0x05, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, // Payload
+        0x03, 0x00, 0x00, 0x00, 0x80, 0x07, 0x00, 0x00, 0x38, 0x04, 0x00, 0x00,
+    ];
+
+    assert!(
+        client.process(0, &mismatched_length).is_err(),
+        "a Length that doesn't match the actual payload size should be rejected"
+    );
+    assert!(!client.ready());
+}

--- a/crates/ironrdp-testsuite-core/tests/displaycontrol/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/displaycontrol/mod.rs
@@ -199,3 +199,21 @@ fn client_process_rejects_caps_with_mismatched_length() {
     );
     assert!(!client.ready());
 }
+
+#[test]
+fn client_process_rejects_trailing_bytes_after_caps() {
+    let mut client = DisplayControlClient::new(|_caps| Ok(Vec::new()));
+
+    let trailing_bytes = [
+        // Header: Type = Caps, Length = 24 (matches the 16-byte payload below)
+        0x05, 0x00, 0x00, 0x00, 0x18, 0x00, 0x00, 0x00, // Payload: valid 12-byte caps body
+        0x03, 0x00, 0x00, 0x00, 0x80, 0x07, 0x00, 0x00, 0x38, 0x04, 0x00, 0x00, // + 4 trailing bytes
+        0xAA, 0xAA, 0xAA, 0xAA,
+    ];
+
+    assert!(
+        client.process(0, &trailing_bytes).is_err(),
+        "bytes left over after decoding the caps body should be rejected"
+    );
+    assert!(!client.ready());
+}

--- a/crates/ironrdp-testsuite-core/tests/displaycontrol/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/displaycontrol/mod.rs
@@ -1,5 +1,9 @@
+use std::sync::{Arc, Mutex};
+
 use ironrdp_core::decode;
+use ironrdp_displaycontrol::client::DisplayControlClient;
 use ironrdp_displaycontrol::pdu;
+use ironrdp_dvc::DvcProcessor as _;
 use ironrdp_testsuite_core::encode_decode_test;
 
 encode_decode_test! {
@@ -124,4 +128,57 @@ fn only_non_optional_layout_fields_required_to_be_valid() {
     assert!(decoded.orientation().is_none());
     assert!(decoded.physical_dimensions().is_none());
     assert!(decoded.position().is_none())
+}
+
+#[test]
+fn client_process_decodes_headered_caps() {
+    let received = Arc::new(Mutex::new(None));
+    let received_clone = Arc::clone(&received);
+    let mut client = DisplayControlClient::new(move |caps| {
+        *received_clone.lock().unwrap() = Some(caps);
+        Ok(Vec::new())
+    });
+
+    // DISPLAYCONTROL_HEADER (Type + Length) followed by the DISPLAYCONTROL_CAPS_PDU body,
+    // per MS-RDPEDISP 2.2.2.1 -- the same bytes as the `capabilities` case above.
+    let headered_caps = [
+        // Header
+        0x05, 0x00, 0x00, 0x00, 0x14, 0x00, 0x00, 0x00, // Payload
+        0x03, 0x00, 0x00, 0x00, 0x80, 0x07, 0x00, 0x00, 0x38, 0x04, 0x00, 0x00,
+    ];
+
+    assert!(!client.ready());
+    client
+        .process(0, &headered_caps)
+        .expect("headered caps PDU should be accepted");
+    assert!(client.ready());
+    assert_eq!(
+        received.lock().unwrap().as_ref(),
+        Some(&pdu::DisplayControlCapabilities::new(3, 1920, 1080).unwrap())
+    );
+}
+
+#[test]
+fn client_process_rejects_monitor_layout_from_server() {
+    let mut client = DisplayControlClient::new(|_caps| Ok(Vec::new()));
+
+    // A DISPLAYCONTROL_MONITOR_LAYOUT_PDU is a client-to-server message; the server should
+    // never send one, and process() must reject it rather than silently accepting it as caps.
+    let layout = [
+        // Header
+        0x02, 0x00, 0x00, 0x00, 0x60, 0x00, 0x00, 0x00, // Payload
+        0x28, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, // Monitor 1
+        0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x07, 0x00, 0x00, 0x38, 0x04,
+        0x00, 0x00, 0xE8, 0x03, 0x00, 0x00, 0xF4, 0x01, 0x00, 0x00, 0xB4, 0x00, 0x00, 0x00, 0x96, 0x00, 0x00, 0x00,
+        0x8C, 0x00, 0x00, 0x00, // Monitor 2
+        0x00, 0x00, 0x00, 0x00, 0x0C, 0xFE, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x03,
+        0x00, 0x00, 0xF4, 0x01, 0x00, 0x00, 0xF4, 0x01, 0x00, 0x00, 0x5A, 0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00,
+        0x64, 0x00, 0x00, 0x00,
+    ];
+
+    assert!(
+        client.process(0, &layout).is_err(),
+        "a MONITOR_LAYOUT_PDU from the server should be rejected"
+    );
+    assert!(!client.ready());
 }


### PR DESCRIPTION
## Summary

`DisplayControlClient::process()` decoded the server's capability payload as a raw `DisplayControlCapabilities` body. In reality, the server sends the capability set prefixed with a `DISPLAYCONTROL_HEADER` (Type + Length) as defined by [MS-RDPEDISP 2.2.2.1](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpedisp/1b23e942-3ea9-4685-a121-1dd9ee19b8c1) — the full `DISPLAYCONTROL_CAPS_PDU`, not a bare `DISPLAYCONTROL_MONITOR_LAYOUT_PDU`-style caps body.

Because the header bytes were being read as capability fields, `Type` (5) was misread as `MaxNumMonitors` and `Length` (20) was misread as `MaxMonitorAreaFactorA`. This made `max_monitor_area()` come out far too small, which silently dropped monitor layouts produced by the `on_capabilities_received` callback (they were rejected as exceeding the bogus max area).

This is an internal inconsistency, not an intentional design choice: `DisplayControlServer::start` in this same crate, and the `ironrdp-testsuite-core` golden vectors for `displaycontrol`, already assume/produce the headered shape. Only the client's decode path was wrong.

## Fix

`process()` now decodes the full `DisplayControlPdu` via `decode()` and matches on `DisplayControlPdu::Caps(..)`. A `DisplayControlPdu::MonitorLayout(..)` received from the server (which would be unexpected — that variant is client→server) is now rejected with an explicit error instead of being silently misparsed.

## How this was found

Found while running IronRDP as a client against [`gnome-remote-desktop`](https://gitlab.gnome.org/GNOME/gnome-remote-desktop) as the RDP server, which sends the full headered `DISPLAYCONTROL_CAPS_PDU`. The client's `max_monitor_area()` came out tiny, and dynamically-resized monitor layouts sent from the callback were silently dropped as "too large."

## Test plan

- [x] `cargo check -p ironrdp-displaycontrol`
- [x] `cargo test -p ironrdp-displaycontrol` (crate has no unit tests of its own; golden vectors live in `ironrdp-testsuite-core`)
- [x] `cargo test -p ironrdp-testsuite-core -- displaycontrol` — all 10 tests pass, including `capabilities_decode` and `invalid_caps`
- [x] `cargo clippy -p ironrdp-displaycontrol --all-targets -- -D warnings`
- [x] `cargo fmt -p ironrdp-displaycontrol -- --check`
