### PR TITLE
feat(agent): integrate NOW client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,7 +1609,7 @@ dependencies = [
  "embed-resource",
  "ironrdp",
  "ironrdp-cliprdr-native",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-dvc-pipe-proxy",
  "ironrdp-rdcleanpath",
  "sspi",
@@ -2376,7 +2376,7 @@ dependencies = [
  "ironrdp-cliprdr",
  "ironrdp-cliprdr-native",
  "ironrdp-connector",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-displaycontrol",
  "ironrdp-dvc",
  "ironrdp-echo",
@@ -2405,7 +2405,7 @@ version = "0.10.0"
 dependencies = [
  "ironrdp-async",
  "ironrdp-connector",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-pdu",
  "ironrdp-svc",
  "tracing",
@@ -2419,13 +2419,16 @@ dependencies = [
  "clap",
  "ironrdp-cfg",
  "ironrdp-client",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-input",
  "ironrdp-pdu",
  "ironrdp-propertyset",
  "ironrdp-rdpfile",
  "libc",
+ "now-client",
+ "now-proto-pdu",
  "png",
+ "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2437,7 +2440,7 @@ name = "ironrdp-ainput"
 version = "0.8.0"
 dependencies = [
  "bitflags 2.13.0",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-dvc",
  "num-derive",
  "num-traits",
@@ -2449,7 +2452,7 @@ version = "0.10.0"
 dependencies = [
  "bytes",
  "ironrdp-connector",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-pdu",
  "tracing",
 ]
@@ -2470,7 +2473,7 @@ version = "0.10.0"
 dependencies = [
  "bytes",
  "ironrdp-connector",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-pdu",
  "tracing",
 ]
@@ -2499,7 +2502,7 @@ dependencies = [
  "ironrdp-cliprdr",
  "ironrdp-cliprdr-native",
  "ironrdp-connector",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-displaycontrol",
  "ironrdp-dvc",
  "ironrdp-dvc-com-plugin",
@@ -2530,7 +2533,7 @@ name = "ironrdp-cliprdr"
 version = "0.7.0"
 dependencies = [
  "bitflags 2.13.0",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-pdu",
  "ironrdp-svc",
  "tracing",
@@ -2541,7 +2544,7 @@ dependencies = [
 name = "ironrdp-cliprdr-format"
 version = "0.2.0"
 dependencies = [
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "png",
 ]
 
@@ -2550,7 +2553,7 @@ name = "ironrdp-cliprdr-native"
 version = "0.7.0"
 dependencies = [
  "ironrdp-cliprdr",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "tracing",
  "windows",
 ]
@@ -2559,8 +2562,8 @@ dependencies = [
 name = "ironrdp-connector"
 version = "0.10.0"
 dependencies = [
- "ironrdp-core",
- "ironrdp-error",
+ "ironrdp-core 0.2.1",
+ "ironrdp-error 0.2.0",
  "ironrdp-pdu",
  "ironrdp-svc",
  "picky",
@@ -2574,16 +2577,25 @@ dependencies = [
 
 [[package]]
 name = "ironrdp-core"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2db60a59716a84d09040d29c9e75e81545842510fccb0934c09b28e78b46680"
+dependencies = [
+ "ironrdp-error 0.1.3",
+]
+
+[[package]]
+name = "ironrdp-core"
 version = "0.2.1"
 dependencies = [
- "ironrdp-error",
+ "ironrdp-error 0.2.0",
 ]
 
 [[package]]
 name = "ironrdp-displaycontrol"
 version = "0.8.0"
 dependencies = [
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-dvc",
  "ironrdp-pdu",
  "ironrdp-svc",
@@ -2594,7 +2606,7 @@ dependencies = [
 name = "ironrdp-dvc"
 version = "0.8.0"
 dependencies = [
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-pdu",
  "ironrdp-svc",
  "tracing",
@@ -2604,7 +2616,7 @@ dependencies = [
 name = "ironrdp-dvc-com-plugin"
 version = "0.1.3"
 dependencies = [
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-dvc",
  "ironrdp-pdu",
  "ironrdp-svc",
@@ -2618,7 +2630,7 @@ name = "ironrdp-dvc-pipe-proxy"
 version = "0.5.0"
 dependencies = [
  "async-trait",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-dvc",
  "ironrdp-pdu",
  "ironrdp-svc",
@@ -2630,7 +2642,7 @@ dependencies = [
 name = "ironrdp-echo"
 version = "0.4.0"
 dependencies = [
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-dvc",
  "ironrdp-pdu",
  "tracing",
@@ -2643,13 +2655,19 @@ dependencies = [
  "arbitrary",
  "bit_field",
  "bitflags 2.13.0",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-dvc",
  "ironrdp-graphics",
  "ironrdp-pdu",
  "openh264",
  "tracing",
 ]
+
+[[package]]
+name = "ironrdp-error"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9d7794e854eef2f13fdf79c8502bcc567a75a15fd0522885f37739386a4cef"
 
 [[package]]
 name = "ironrdp-error"
@@ -2671,7 +2689,7 @@ dependencies = [
  "ironrdp-bulk",
  "ironrdp-cliprdr",
  "ironrdp-cliprdr-format",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-displaycontrol",
  "ironrdp-egfx",
  "ironrdp-graphics",
@@ -2692,7 +2710,7 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "expect-test",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-pdu",
  "num-derive",
  "num-traits",
@@ -2718,8 +2736,8 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "ironrdp-core",
- "ironrdp-error",
+ "ironrdp-core 0.2.1",
+ "ironrdp-error 0.2.0",
  "ironrdp-tls",
  "log",
  "tokio",
@@ -2745,8 +2763,8 @@ dependencies = [
  "byteorder",
  "der-parser",
  "expect-test",
- "ironrdp-core",
- "ironrdp-error",
+ "ironrdp-core 0.2.1",
+ "ironrdp-error 0.2.0",
  "md-5 0.10.6",
  "num-bigint 0.4.8",
  "num-derive",
@@ -2778,8 +2796,8 @@ name = "ironrdp-rdpdr"
 version = "0.7.0"
 dependencies = [
  "bitflags 2.13.0",
- "ironrdp-core",
- "ironrdp-error",
+ "ironrdp-core 0.2.1",
+ "ironrdp-error 0.2.0",
  "ironrdp-pdu",
  "ironrdp-svc",
  "tracing",
@@ -2789,7 +2807,7 @@ dependencies = [
 name = "ironrdp-rdpdr-native"
 version = "0.7.0"
 dependencies = [
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-pdu",
  "ironrdp-rdpdr",
  "ironrdp-svc",
@@ -2801,7 +2819,7 @@ dependencies = [
 name = "ironrdp-rdpeusb"
 version = "0.1.0"
 dependencies = [
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-dvc",
  "ironrdp-pdu",
  "ironrdp-str",
@@ -2819,7 +2837,7 @@ name = "ironrdp-rdpsnd"
 version = "0.9.0"
 dependencies = [
  "bitflags 2.13.0",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-pdu",
  "ironrdp-svc",
  "tracing",
@@ -2833,7 +2851,7 @@ dependencies = [
  "anyhow",
  "bytemuck",
  "cpal",
- "ironrdp-error",
+ "ironrdp-error 0.2.0",
  "ironrdp-rdpsnd",
  "opus2",
  "tracing",
@@ -2851,7 +2869,7 @@ dependencies = [
  "ironrdp-ainput",
  "ironrdp-async",
  "ironrdp-cliprdr",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-displaycontrol",
  "ironrdp-dvc",
  "ironrdp-echo",
@@ -2878,10 +2896,10 @@ name = "ironrdp-session"
 version = "0.11.0"
 dependencies = [
  "ironrdp-bulk",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-displaycontrol",
  "ironrdp-dvc",
- "ironrdp-error",
+ "ironrdp-error 0.2.0",
  "ironrdp-graphics",
  "ironrdp-pdu",
  "ironrdp-svc",
@@ -2899,7 +2917,7 @@ name = "ironrdp-str"
 version = "0.1.1"
 dependencies = [
  "bytemuck",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
 ]
 
 [[package]]
@@ -2907,7 +2925,7 @@ name = "ironrdp-svc"
 version = "0.8.0"
 dependencies = [
  "bitflags 2.13.0",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-pdu",
 ]
 
@@ -2925,7 +2943,7 @@ dependencies = [
  "ironrdp-cliprdr",
  "ironrdp-cliprdr-format",
  "ironrdp-connector",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-displaycontrol",
  "ironrdp-dvc",
  "ironrdp-echo",
@@ -2964,7 +2982,7 @@ dependencies = [
  "ironrdp-agent",
  "ironrdp-async",
  "ironrdp-client",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-dvc",
  "ironrdp-dvc-pipe-proxy",
  "ironrdp-input",
@@ -3042,7 +3060,7 @@ dependencies = [
  "iron-remote-desktop",
  "ironrdp",
  "ironrdp-cliprdr-format",
- "ironrdp-core",
+ "ironrdp-core 0.2.1",
  "ironrdp-futures",
  "ironrdp-pdu",
  "ironrdp-propertyset",
@@ -3492,6 +3510,29 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "now-client"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e4f1efbc5536f3e43f40e089abc7562b3e0bc48dfee57444558d45c31dee20"
+dependencies = [
+ "now-proto-pdu",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "now-proto-pdu"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bc774bac11db918c7a66a05e26771567f0968e0e0bf69c116fa8a5ae91f06b8"
+dependencies = [
+ "bitflags 2.13.0",
+ "ironrdp-core 0.1.5",
+ "ironrdp-error 0.1.3",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2432,6 +2432,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
  "whoami",
 ]
 

--- a/crates/ironrdp-agent/Cargo.toml
+++ b/crates/ironrdp-agent/Cargo.toml
@@ -13,7 +13,6 @@ categories.workspace = true
 
 [lib]
 doctest = false
-test = false
 
 [[bin]]
 name = "ironrdp-agent"
@@ -27,7 +26,7 @@ internal = []
 
 [dependencies]
 # RDP client engine: only the TLS backend is mandated
-ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["rustls"] }
+ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["rustls", "dvc-pipe-proxy"] }
 
 # Configuration model and codecs
 ironrdp-core = { path = "../ironrdp-core", version = "0.2", features = ["alloc"] }
@@ -39,6 +38,9 @@ ironrdp-input = { path = "../ironrdp-input", version = "0.7" }
 
 # Async runtime and IPC transport
 tokio = { version = "1", features = ["rt-multi-thread", "net", "sync", "macros", "io-util", "time", "signal"] }
+
+# NOW execution protocol client. The agent owns only its local DVC endpoint and durable operation state.
+now-client = "0.1.0"
 
 # CLI
 clap = { version = "4.6", features = ["derive", "cargo"] }
@@ -53,6 +55,11 @@ png = "0.18"
 # Utils
 anyhow = "1"
 whoami = "2.1"
+serde_json = "1"
+
+[dev-dependencies]
+# Test-only NOW peer fixture for the adapter boundary regression.
+now-proto-pdu = { version = "0.4", features = ["std"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/ironrdp-agent/Cargo.toml
+++ b/crates/ironrdp-agent/Cargo.toml
@@ -40,7 +40,8 @@ ironrdp-input = { path = "../ironrdp-input", version = "0.7" }
 tokio = { version = "1", features = ["rt-multi-thread", "net", "sync", "macros", "io-util", "time", "signal"] }
 
 # NOW execution protocol client. The agent owns only its local DVC endpoint and durable operation state.
-now-client = "0.1.0"
+now-client = "0.1.0" # public
+uuid = { version = "1", features = ["v4"] }
 
 # CLI
 clap = { version = "4.6", features = ["derive", "cargo"] }

--- a/crates/ironrdp-agent/README.md
+++ b/crates/ironrdp-agent/README.md
@@ -109,7 +109,8 @@ terminal records, and 32 MiB across retained records. `now attach --after-sequen
 bounded output then follows a running operation. Live attachments are bounded and disconnect when
 they cannot keep up; attach again with the last sequence number to resume from retained output. Use
 `now --format human|json|ndjson` for raw human streaming, a JSON result, or JSON event lines; JSON
-represents output bytes as arrays.
+represents output bytes as arrays and is bounded to 8,192 events and 2 MiB of output. Use NDJSON
+for unbounded streaming.
 
 The local DVC endpoint is connected only on a NOW request. Its first readiness deadline is 30
 seconds; a replacement after a worker/transport failure has a 10-second deadline. No Shell command,

--- a/crates/ironrdp-agent/README.md
+++ b/crates/ironrdp-agent/README.md
@@ -76,6 +76,45 @@ Two logging concerns are kept separate:
   subscriber. It defaults to `debug`; a per-`Connect` `log_directive` (e.g. `ironrdp_connector=trace`)
   refines the filter to troubleshoot IronRDP itself.
 
+## NOW remote execution
+
+After an RDP session connects, the daemon injects a per-session `Devolutions::Now::Agent` DVC
+endpoint. The endpoint is local to the daemon and is not shared between RDP sessions. NOW protocol
+framing, negotiation, heartbeats, capability gates, and command PDU handling are owned by the
+`now-client` dependency; the agent owns only the endpoint/reconnect boundary and durable operation
+state.
+
+Use the supported commands below after `connect`:
+
+```shell
+ironrdp-agent now capabilities
+ironrdp-agent now run "notepad.exe"
+ironrdp-agent now powershell "Get-Process"
+ironrdp-agent now pwsh "Get-Date"
+ironrdp-agent now exec process cmd.exe --parameters "/c echo hello"
+ironrdp-agent now exec batch "echo hello"
+```
+
+`now run` is deliberately untracked and reports only local submission. Process, Batch, PowerShell,
+and pwsh commands are daemon-tracked unless `--detached` is supplied. Tracked raw stdout and stderr
+chunks are streamed without line buffering; a terminal nonzero exit code is returned by the CLI
+(1–255 directly, wider values as 255). `now cancel`, `now stdin`, `now attach`, `now list`, and
+`now status` operate on daemon-owned operation IDs. Initial stdin comes from `--stdin FILE` (or
+`-`); live stdin is bounded to 1 MiB per request. Use `--operation-id-file FILE` to persist an
+operation ID immediately after local submission for a later attach, cancellation, or stdin call.
+
+PowerShell and pwsh use `-NoProfile` and `-NonInteractive` by default. `--profile` and
+`--interactive` are explicit opt-outs. The agent retains at most 8 MiB of output per operation, 32
+terminal records, and 32 MiB across retained records. `now attach --after-sequence N` replays
+bounded output then follows a running operation. Live attachments are bounded and disconnect when
+they cannot keep up; attach again with the last sequence number to resume from retained output. Use
+`now --format human|json|ndjson` for raw human streaming, a JSON result, or JSON event lines; JSON
+represents output bytes as arrays.
+
+The local DVC endpoint is connected only on a NOW request. Its first readiness deadline is 30
+seconds; a replacement after a worker/transport failure has a 10-second deadline. No Shell command,
+IPC request, capability, or execution mapping is exposed, even when a remote peer supports Shell.
+
 [`ironrdp-client`]: ../ironrdp-client
 [`ironrdp-core`]: ../ironrdp-core
 [`ironrdp-propertyset`]: ../ironrdp-propertyset

--- a/crates/ironrdp-agent/src/cli.rs
+++ b/crates/ironrdp-agent/src/cli.rs
@@ -11,8 +11,9 @@
 
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
+use core::str::FromStr;
+use std::io::Write as _;
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
 
 use anyhow::Context as _;
 use clap::{Args, CommandFactory as _, Parser, Subcommand, ValueEnum};
@@ -20,7 +21,10 @@ use ironrdp_cfg::{PropertySetExt as _, TargetAddr};
 use ironrdp_input::MouseButton;
 use ironrdp_propertyset::{PropertySet, Value};
 
-use crate::ipc::{KeyFilter, Payload, PropValue, Request, Response};
+use crate::ipc::{
+    KeyFilter, NowExecutionKind, NowExecutionRequest, NowStream, OperationEvent, OperationEventKind, OperationInfo,
+    Payload, PropValue, Request, Response,
+};
 use crate::transport::{self, Endpoint};
 
 /// IronRDP agent: a CLI-driven, daemon-backed RDP client.
@@ -97,6 +101,145 @@ enum Command {
         #[arg(long)]
         height: u16,
     },
+    /// Execute commands over the session's NOW DVC endpoint.
+    Now(NowArgs),
+}
+
+#[derive(Args, Debug)]
+struct NowArgs {
+    /// Output format for NOW metadata and events. Human output preserves stdout/stderr bytes.
+    #[arg(long, value_enum, default_value_t = OutputFormat::Human)]
+    format: OutputFormat,
+    #[command(subcommand)]
+    command: NowCommand,
+}
+
+#[derive(Subcommand, Debug)]
+enum NowCommand {
+    /// Negotiate and display supported NOW capabilities.
+    Capabilities,
+    /// Submit an untracked generic Run request.
+    Run(NowRunArgs),
+    /// Execute a Windows PowerShell command.
+    Powershell(PowerShellArgs),
+    /// Execute a PowerShell 7 command.
+    Pwsh(PowerShellArgs),
+    /// Execute a Process or Batch request.
+    Exec(NowExecArgs),
+    /// Cancel an active tracked operation.
+    Cancel { operation_id: u64 },
+    /// List retained daemon-owned operations.
+    List,
+    /// Show one retained operation.
+    Status { operation_id: u64 },
+    /// Replay retained output and follow a running operation.
+    Attach {
+        operation_id: u64,
+        /// Only replay events with a sequence greater than this value.
+        #[arg(long)]
+        after_sequence: Option<u64>,
+    },
+    /// Forward a raw stdin chunk to an active operation.
+    Stdin(NowStdinArgs),
+    /// Display the local NOW endpoint state without making a new connection.
+    Diagnostics,
+}
+
+#[derive(Args, Debug)]
+struct NowRunArgs {
+    /// Command line for the remote agent.
+    command: String,
+    /// Optional remote working directory.
+    #[arg(long)]
+    directory: Option<String>,
+}
+
+#[derive(Args, Debug)]
+struct NowExecArgs {
+    #[command(subcommand)]
+    command: NowExecCommand,
+}
+
+#[derive(Subcommand, Debug)]
+enum NowExecCommand {
+    /// Execute a program via Windows CreateProcess.
+    Process(ProcessArgs),
+    /// Execute a Windows batch command.
+    Batch(CommandArgs),
+}
+
+#[derive(Args, Debug)]
+struct ProcessArgs {
+    /// Program filename.
+    filename: String,
+    /// Command-line parameters passed to the program.
+    #[arg(long)]
+    parameters: Option<String>,
+    #[command(flatten)]
+    common: CommonExecutionArgs,
+}
+
+#[derive(Args, Debug)]
+struct PowerShellArgs {
+    /// PowerShell script or command.
+    command: String,
+    /// Opt out of the default `-NoProfile` behavior.
+    #[arg(long)]
+    profile: bool,
+    /// Opt out of the default `-NonInteractive` behavior.
+    #[arg(long)]
+    interactive: bool,
+    #[command(flatten)]
+    common: CommonExecutionArgs,
+}
+
+#[derive(Args, Debug)]
+struct CommandArgs {
+    /// Batch command.
+    command: String,
+    #[command(flatten)]
+    common: CommonExecutionArgs,
+}
+
+#[derive(Args, Debug)]
+struct CommonExecutionArgs {
+    /// Optional remote working directory.
+    #[arg(long)]
+    directory: Option<String>,
+    /// Read initial stdin bytes from this file. Use `-` for this CLI's standard input.
+    #[arg(long, value_name = "FILE")]
+    stdin: Option<PathBuf>,
+    /// Remote execution timeout in seconds.
+    #[arg(long)]
+    timeout: Option<u64>,
+    /// Submit the command detached. Detached commands cannot receive stdin, output, or results.
+    #[arg(long)]
+    detached: bool,
+    /// Write the daemon-owned operation ID to this file after local submission.
+    #[arg(long)]
+    operation_id_file: Option<PathBuf>,
+}
+
+#[derive(Args, Debug)]
+struct NowStdinArgs {
+    /// Daemon-owned operation identity.
+    operation_id: u64,
+    /// Read raw bytes from this file. Use `-` for this CLI's standard input.
+    #[arg(long, value_name = "FILE")]
+    input: PathBuf,
+    /// Mark this chunk as the final stdin chunk.
+    #[arg(long)]
+    last: bool,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum OutputFormat {
+    /// Human-readable metadata; raw stdout/stderr are written unchanged.
+    Human,
+    /// One JSON document for the reply or completed stream.
+    Json,
+    /// One JSON object per reply/event.
+    Ndjson,
 }
 
 #[derive(Args, Debug)]
@@ -268,6 +411,14 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
             let overlay = load_overlay(args.overlay.as_deref(), args.prop)?;
             return crate::daemon::run(endpoint, overlay).await;
         }
+        Command::Now(args) => {
+            if let Some(exit_code) = run_now(&endpoint, args).await? {
+                if exit_code != 0 {
+                    std::process::exit(remote_exit_status(exit_code));
+                }
+            }
+            return Ok(());
+        }
         Command::Connect(args) => build_connect_request(args)?,
         Command::Disconnect => Request::Disconnect,
         Command::Status => Request::Status,
@@ -365,6 +516,435 @@ fn build_connect_request(args: ConnectArgs) -> anyhow::Result<Request> {
     })
 }
 
+async fn run_now(endpoint: &Endpoint, args: NowArgs) -> anyhow::Result<Option<u32>> {
+    let NowArgs { format, command } = args;
+    match command {
+        NowCommand::Capabilities => now_single(endpoint, Request::NowCapabilities, format).await,
+        NowCommand::Run(args) => {
+            now_single(
+                endpoint,
+                Request::NowRun {
+                    command: args.command,
+                    directory: args.directory,
+                },
+                format,
+            )
+            .await
+        }
+        NowCommand::Powershell(args) => {
+            let operation_id_file = args.common.operation_id_file.clone();
+            let request = build_now_execution(
+                NowExecutionKind::PowerShell,
+                args.command,
+                None,
+                args.common,
+                !args.profile,
+                !args.interactive,
+            )?;
+            now_execution(endpoint, request, format, operation_id_file).await
+        }
+        NowCommand::Pwsh(args) => {
+            let operation_id_file = args.common.operation_id_file.clone();
+            let request = build_now_execution(
+                NowExecutionKind::Pwsh,
+                args.command,
+                None,
+                args.common,
+                !args.profile,
+                !args.interactive,
+            )?;
+            now_execution(endpoint, request, format, operation_id_file).await
+        }
+        NowCommand::Exec(NowExecArgs {
+            command: NowExecCommand::Process(args),
+        }) => {
+            let operation_id_file = args.common.operation_id_file.clone();
+            let request = build_now_execution(
+                NowExecutionKind::Process,
+                args.filename,
+                args.parameters,
+                args.common,
+                false,
+                false,
+            )?;
+            now_execution(endpoint, request, format, operation_id_file).await
+        }
+        NowCommand::Exec(NowExecArgs {
+            command: NowExecCommand::Batch(args),
+        }) => {
+            let operation_id_file = args.common.operation_id_file.clone();
+            let request = build_now_execution(NowExecutionKind::Batch, args.command, None, args.common, false, false)?;
+            now_execution(endpoint, request, format, operation_id_file).await
+        }
+        NowCommand::Cancel { operation_id } => now_single(endpoint, Request::NowCancel { operation_id }, format).await,
+        NowCommand::List => now_single(endpoint, Request::NowList, format).await,
+        NowCommand::Status { operation_id } => now_single(endpoint, Request::NowStatus { operation_id }, format).await,
+        NowCommand::Attach {
+            operation_id,
+            after_sequence,
+        } => {
+            now_stream(
+                endpoint,
+                Request::NowAttach {
+                    operation_id,
+                    after_sequence,
+                },
+                format,
+                None,
+                true,
+            )
+            .await
+        }
+        NowCommand::Stdin(args) => {
+            now_single(
+                endpoint,
+                Request::NowStdin {
+                    operation_id: args.operation_id,
+                    data: read_input(&args.input)?,
+                    last: args.last,
+                },
+                format,
+            )
+            .await
+        }
+        NowCommand::Diagnostics => now_single(endpoint, Request::NowDiagnostics, format).await,
+    }
+}
+
+fn build_now_execution(
+    kind: NowExecutionKind,
+    command: String,
+    parameters: Option<String>,
+    args: CommonExecutionArgs,
+    no_profile: bool,
+    non_interactive: bool,
+) -> anyhow::Result<NowExecutionRequest> {
+    let timeout_ms = args
+        .timeout
+        .map(|seconds| {
+            seconds
+                .checked_mul(1_000)
+                .ok_or_else(|| anyhow::anyhow!("timeout is too large"))
+        })
+        .transpose()?;
+    Ok(NowExecutionRequest {
+        kind,
+        command,
+        parameters,
+        directory: args.directory,
+        stdin: args.stdin.as_deref().map(read_input).transpose()?,
+        timeout_ms,
+        detached: args.detached,
+        no_profile,
+        non_interactive,
+    })
+}
+
+fn read_input(path: &Path) -> anyhow::Result<Vec<u8>> {
+    if path == Path::new("-") {
+        let mut data = Vec::new();
+        std::io::Read::read_to_end(&mut std::io::stdin(), &mut data).context("read standard input")?;
+        Ok(data)
+    } else {
+        std::fs::read(path).with_context(|| format!("read {}", path.display()))
+    }
+}
+
+async fn now_execution(
+    endpoint: &Endpoint,
+    request: NowExecutionRequest,
+    format: OutputFormat,
+    operation_id_file: Option<PathBuf>,
+) -> anyhow::Result<Option<u32>> {
+    if request.detached {
+        if let Some(path) = operation_id_file {
+            let response = transport::send_request(endpoint, &Request::NowExecute(request)).await?;
+            let payload = match response {
+                Response::Ok(payload) => payload,
+                Response::Err(error) => anyhow::bail!("{error}"),
+            };
+            let Payload::NowOperation(operation) = &payload else {
+                anyhow::bail!("unexpected response while writing operation ID");
+            };
+            std::fs::write(&path, format!("{}\n", operation.id))
+                .with_context(|| format!("write {}", path.display()))?;
+            print_now_payload(&payload, format)?;
+            return Ok(payload_remote_exit(&payload));
+        }
+        return now_single(endpoint, Request::NowExecute(request), format).await;
+    }
+    now_stream(endpoint, Request::NowExecute(request), format, operation_id_file, false).await
+}
+
+async fn now_single(endpoint: &Endpoint, request: Request, format: OutputFormat) -> anyhow::Result<Option<u32>> {
+    let response = transport::send_request(endpoint, &request).await?;
+    let payload = match response {
+        Response::Ok(payload) => payload,
+        Response::Err(error) => anyhow::bail!("{error}"),
+    };
+    print_now_payload(&payload, format)?;
+    Ok(payload_remote_exit(&payload))
+}
+
+async fn now_stream(
+    endpoint: &Endpoint,
+    request: Request,
+    format: OutputFormat,
+    operation_id_file: Option<PathBuf>,
+    print_initial_human: bool,
+) -> anyhow::Result<Option<u32>> {
+    let mut stream = transport::open_stream(endpoint, &request).await?;
+    let first: Response = transport::read_message(&mut stream).await?;
+    let first = match first {
+        Response::Ok(payload) => payload,
+        Response::Err(error) => anyhow::bail!("{error}"),
+    };
+
+    let mut exit_code = payload_remote_exit(&first);
+    if let Some(path) = operation_id_file {
+        let Payload::NowOperation(operation) = &first else {
+            anyhow::bail!("unexpected response while writing operation ID");
+        };
+        std::fs::write(&path, format!("{}\n", operation.id)).with_context(|| format!("write {}", path.display()))?;
+    }
+    let mut json_values = Vec::new();
+    match format {
+        OutputFormat::Human if print_initial_human => print_now_human(&first)?,
+        OutputFormat::Human => {}
+        OutputFormat::Ndjson => print_now_ndjson(&first)?,
+        OutputFormat::Json => json_values.push(now_payload_json(&first)),
+    }
+
+    loop {
+        let response: Response = match transport::read_message(&mut stream).await {
+            Ok(response) => response,
+            Err(error)
+                if error.downcast_ref::<std::io::Error>().is_some_and(|error| {
+                    matches!(
+                        error.kind(),
+                        std::io::ErrorKind::UnexpectedEof | std::io::ErrorKind::ConnectionReset
+                    )
+                }) =>
+            {
+                break;
+            }
+            Err(error) => return Err(error),
+        };
+        let payload = match response {
+            Response::Ok(payload) => payload,
+            Response::Err(error) => anyhow::bail!("{error}"),
+        };
+        if let Payload::NowEvent(event) = &payload {
+            match &event.kind {
+                OperationEventKind::Completed { exit_code: code } => exit_code = Some(*code),
+                OperationEventKind::Cancelled | OperationEventKind::Failed(_) => exit_code = Some(1),
+                OperationEventKind::Started
+                | OperationEventKind::Output { .. }
+                | OperationEventKind::CancelAccepted => {}
+            }
+        }
+        match format {
+            OutputFormat::Human => print_now_human(&payload)?,
+            OutputFormat::Ndjson => print_now_ndjson(&payload)?,
+            OutputFormat::Json => json_values.push(now_payload_json(&payload)),
+        }
+    }
+
+    if matches!(format, OutputFormat::Json) {
+        println!(
+            "{}",
+            serde_json::to_string(&json_values).context("serialize JSON output")?
+        );
+    }
+    Ok(exit_code)
+}
+
+fn print_now_payload(payload: &Payload, format: OutputFormat) -> anyhow::Result<()> {
+    match format {
+        OutputFormat::Human => print_now_human(payload),
+        OutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string(&now_payload_json(payload)).context("serialize JSON output")?
+            );
+            Ok(())
+        }
+        OutputFormat::Ndjson => print_now_ndjson(payload),
+    }
+}
+
+fn print_now_human(payload: &Payload) -> anyhow::Result<()> {
+    match payload {
+        Payload::Empty => println!("ok"),
+        Payload::NowCapabilities(capabilities) => {
+            println!("version: {}.{}", capabilities.version_major, capabilities.version_minor);
+            println!("run: {}", capabilities.run);
+            println!("process: {}", capabilities.process);
+            println!("batch: {}", capabilities.batch);
+            println!("powershell: {}", capabilities.powershell);
+            println!("pwsh: {}", capabilities.pwsh);
+            println!("io redirection: {}", capabilities.io_redirection);
+        }
+        Payload::NowOperation(operation) => print_operation_info(operation),
+        Payload::NowOperations(operations) => {
+            for operation in operations {
+                print_operation_info(operation);
+            }
+        }
+        Payload::NowEvent(event) => print_operation_event(event)?,
+        Payload::NowDiagnostics(diagnostics) => {
+            println!("endpoint allocated: {}", diagnostics.endpoint_allocated);
+            println!("connected: {}", diagnostics.connected);
+            if let Some(capabilities) = &diagnostics.capabilities {
+                println!("version: {}.{}", capabilities.version_major, capabilities.version_minor);
+            }
+        }
+        _ => print_payload(payload.clone()),
+    }
+    Ok(())
+}
+
+fn print_operation_info(operation: &OperationInfo) {
+    println!(
+        "operation {}: {:?} ({:?})",
+        operation.id, operation.kind, operation.state
+    );
+    if let Some(exit_code) = operation.exit_code {
+        println!("exit code: {exit_code}");
+    }
+    if let Some(error) = &operation.error {
+        eprintln!("{}", error.message);
+    }
+}
+
+fn print_operation_event(event: &OperationEvent) -> anyhow::Result<()> {
+    match &event.kind {
+        OperationEventKind::Output {
+            stream: NowStream::Stdout,
+            data,
+            ..
+        } => {
+            let mut stdout = std::io::stdout();
+            stdout.write_all(data).context("write remote stdout")?;
+            stdout.flush().context("flush remote stdout")?;
+        }
+        OperationEventKind::Output {
+            stream: NowStream::Stderr,
+            data,
+            ..
+        } => {
+            let mut stderr = std::io::stderr();
+            stderr.write_all(data).context("write remote stderr")?;
+            stderr.flush().context("flush remote stderr")?;
+        }
+        OperationEventKind::Failed(error) => eprintln!("{}", error.message),
+        _ => {}
+    }
+    Ok(())
+}
+
+fn print_now_ndjson(payload: &Payload) -> anyhow::Result<()> {
+    println!(
+        "{}",
+        serde_json::to_string(&now_payload_json(payload)).context("serialize NDJSON output")?
+    );
+    Ok(())
+}
+
+fn now_payload_json(payload: &Payload) -> serde_json::Value {
+    use serde_json::json;
+
+    match payload {
+        Payload::Empty => json!({"type": "ok"}),
+        Payload::NowCapabilities(capabilities) => json!({
+            "type": "capabilities",
+            "version": {"major": capabilities.version_major, "minor": capabilities.version_minor},
+            "heartbeat_ms": capabilities.heartbeat_ms,
+            "run": capabilities.run,
+            "process": capabilities.process,
+            "batch": capabilities.batch,
+            "powershell": capabilities.powershell,
+            "pwsh": capabilities.pwsh,
+            "io_redirection": capabilities.io_redirection,
+            "unicode_console": capabilities.unicode_console,
+        }),
+        Payload::NowOperation(operation) => operation_json(operation),
+        Payload::NowOperations(operations) => {
+            json!({"type": "operations", "operations": operations.iter().map(operation_json).collect::<Vec<_>>()})
+        }
+        Payload::NowEvent(event) => match &event.kind {
+            OperationEventKind::Output { stream, data, last } => json!({
+                "type": "output",
+                "operation_id": event.operation_id,
+                "sequence": event.sequence,
+                "stream": format!("{stream:?}").to_ascii_lowercase(),
+                "data": data,
+                "last": last,
+            }),
+            OperationEventKind::Completed { exit_code } => json!({
+                "type": "completed", "operation_id": event.operation_id, "sequence": event.sequence, "exit_code": exit_code
+            }),
+            OperationEventKind::Started => {
+                json!({"type": "started", "operation_id": event.operation_id, "sequence": event.sequence})
+            }
+            OperationEventKind::CancelAccepted => {
+                json!({"type": "cancel_accepted", "operation_id": event.operation_id, "sequence": event.sequence})
+            }
+            OperationEventKind::Cancelled => {
+                json!({"type": "cancelled", "operation_id": event.operation_id, "sequence": event.sequence})
+            }
+            OperationEventKind::Failed(error) => json!({
+                "type": "failed",
+                "operation_id": event.operation_id,
+                "sequence": event.sequence,
+                "error": {"category": format!("{:?}", error.category).to_ascii_lowercase(), "message": error.message},
+            }),
+        },
+        Payload::NowDiagnostics(diagnostics) => json!({
+            "type": "diagnostics",
+            "endpoint_allocated": diagnostics.endpoint_allocated,
+            "connected": diagnostics.connected,
+            "capabilities": diagnostics.capabilities.as_ref().map(|capabilities| json!({
+                "version": {"major": capabilities.version_major, "minor": capabilities.version_minor}
+            })),
+        }),
+        _ => json!({"type": "unsupported_payload"}),
+    }
+}
+
+fn operation_json(operation: &OperationInfo) -> serde_json::Value {
+    serde_json::json!({
+        "type": "operation",
+        "id": operation.id,
+        "kind": format!("{:?}", operation.kind).to_ascii_lowercase(),
+        "state": format!("{:?}", operation.state).to_ascii_lowercase(),
+        "detached": operation.detached,
+        "exit_code": operation.exit_code,
+        "retained_output_bytes": operation.retained_output_bytes,
+        "next_sequence": operation.next_sequence,
+        "error": operation.error.as_ref().map(|error| serde_json::json!({
+            "category": format!("{:?}", error.category).to_ascii_lowercase(),
+            "message": error.message,
+        })),
+    })
+}
+
+fn payload_remote_exit(payload: &Payload) -> Option<u32> {
+    match payload {
+        Payload::NowOperation(operation) => operation.exit_code,
+        _ => None,
+    }
+}
+
+/// Maps a remote `u32` process code to the CLI's platform process code contract.
+pub fn remote_exit_status(exit_code: u32) -> i32 {
+    match exit_code {
+        0 => 0,
+        1..=255 => i32::try_from(exit_code).unwrap_or(255),
+        _ => 255,
+    }
+}
+
 fn print_response(response: Response) -> anyhow::Result<()> {
     match response {
         Response::Ok(payload) => {
@@ -412,6 +992,22 @@ fn print_payload(payload: Payload) {
         }
         // Screenshots are handled out-of-band by `write_screenshot`, never printed.
         Payload::Screenshot { width, height, .. } => println!("frame {width}x{height}"),
+        Payload::NowCapabilities(capabilities) => {
+            println!("NOW {}.{}", capabilities.version_major, capabilities.version_minor);
+        }
+        Payload::NowOperation(operation) => print_operation_info(&operation),
+        Payload::NowOperations(operations) => {
+            for operation in &operations {
+                print_operation_info(operation);
+            }
+        }
+        Payload::NowEvent(event) => {
+            let _ = print_operation_event(&event);
+        }
+        Payload::NowDiagnostics(diagnostics) => {
+            println!("NOW endpoint allocated: {}", diagnostics.endpoint_allocated);
+            println!("NOW connected: {}", diagnostics.connected);
+        }
     }
 }
 
@@ -497,4 +1093,38 @@ fn property_description(key: &str) -> Option<&'static str> {
         _ => return None,
     };
     Some(description)
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser as _;
+
+    use super::{Cli, CommonExecutionArgs, NowExecutionKind, build_now_execution};
+
+    #[test]
+    fn shell_is_not_an_agent_command() {
+        assert!(Cli::try_parse_from(["ironrdp-agent", "now", "shell"]).is_err());
+    }
+
+    #[test]
+    fn powershell_request_defaults_are_safe() {
+        let request = build_now_execution(
+            NowExecutionKind::PowerShell,
+            "Get-Date".to_owned(),
+            None,
+            CommonExecutionArgs {
+                directory: None,
+                stdin: None,
+                timeout: None,
+                detached: false,
+                operation_id_file: None,
+            },
+            true,
+            true,
+        )
+        .expect("valid request");
+
+        assert!(request.no_profile);
+        assert!(request.non_interactive);
+    }
 }

--- a/crates/ironrdp-agent/src/cli.rs
+++ b/crates/ironrdp-agent/src/cli.rs
@@ -11,6 +11,7 @@
 
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
+use core::fmt;
 use core::str::FromStr;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
@@ -22,8 +23,8 @@ use ironrdp_input::MouseButton;
 use ironrdp_propertyset::{PropertySet, Value};
 
 use crate::ipc::{
-    KeyFilter, NowExecutionKind, NowExecutionRequest, NowStream, OperationEvent, OperationEventKind, OperationInfo,
-    Payload, PropValue, Request, Response,
+    AgentError, KeyFilter, NowExecutionKind, NowExecutionRequest, NowStream, OperationEvent, OperationEventKind,
+    OperationInfo, OperationState, Payload, PropValue, Request, Response,
 };
 use crate::transport::{self, Endpoint};
 
@@ -242,6 +243,21 @@ enum OutputFormat {
     Ndjson,
 }
 
+const MAX_JSON_STREAM_EVENTS: usize = 8 * 1024;
+const MAX_JSON_STREAM_OUTPUT: usize = 2 * 1024 * 1024;
+
+/// A daemon-provided error that must be rendered according to the selected NOW output format.
+#[derive(Debug)]
+struct NowRequestError(AgentError);
+
+impl fmt::Display for NowRequestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0.message)
+    }
+}
+
+impl core::error::Error for NowRequestError {}
+
 #[derive(Args, Debug)]
 struct DaemonArgs {
     /// Path to a .rdp file whose properties are preloaded as an overlay applied to every `connect`
@@ -412,7 +428,18 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
             return crate::daemon::run(endpoint, overlay).await;
         }
         Command::Now(args) => {
-            if let Some(exit_code) = run_now(&endpoint, args).await? {
+            let format = args.format;
+            let exit_code = match run_now(&endpoint, args).await {
+                Ok(exit_code) => exit_code,
+                Err(error) => {
+                    if let Some(error) = error.downcast_ref::<NowRequestError>() {
+                        print_now_error(&error.0, format)?;
+                        std::process::exit(1);
+                    }
+                    return Err(error);
+                }
+            };
+            if let Some(exit_code) = exit_code {
                 if exit_code != 0 {
                     std::process::exit(remote_exit_status(exit_code));
                 }
@@ -661,7 +688,7 @@ async fn now_execution(
             let response = transport::send_request(endpoint, &Request::NowExecute(request)).await?;
             let payload = match response {
                 Response::Ok(payload) => payload,
-                Response::Err(error) => anyhow::bail!("{error}"),
+                Response::Err(error) => return Err(NowRequestError(error).into()),
             };
             let Payload::NowOperation(operation) = &payload else {
                 anyhow::bail!("unexpected response while writing operation ID");
@@ -680,7 +707,7 @@ async fn now_single(endpoint: &Endpoint, request: Request, format: OutputFormat)
     let response = transport::send_request(endpoint, &request).await?;
     let payload = match response {
         Response::Ok(payload) => payload,
-        Response::Err(error) => anyhow::bail!("{error}"),
+        Response::Err(error) => return Err(NowRequestError(error).into()),
     };
     print_now_payload(&payload, format)?;
     Ok(payload_remote_exit(&payload))
@@ -697,10 +724,11 @@ async fn now_stream(
     let first: Response = transport::read_message(&mut stream).await?;
     let first = match first {
         Response::Ok(payload) => payload,
-        Response::Err(error) => anyhow::bail!("{error}"),
+        Response::Err(error) => return Err(NowRequestError(error).into()),
     };
 
     let mut exit_code = payload_remote_exit(&first);
+    let mut terminal_observed = payload_is_terminal_operation(&first);
     if let Some(path) = operation_id_file {
         let Payload::NowOperation(operation) = &first else {
             anyhow::bail!("unexpected response while writing operation ID");
@@ -708,11 +736,12 @@ async fn now_stream(
         std::fs::write(&path, format!("{}\n", operation.id)).with_context(|| format!("write {}", path.display()))?;
     }
     let mut json_values = Vec::new();
+    let mut json_output_bytes = 0;
     match format {
         OutputFormat::Human if print_initial_human => print_now_human(&first)?,
         OutputFormat::Human => {}
         OutputFormat::Ndjson => print_now_ndjson(&first)?,
-        OutputFormat::Json => json_values.push(now_payload_json(&first)),
+        OutputFormat::Json => push_json_payload(&mut json_values, &mut json_output_bytes, &first)?,
     }
 
     loop {
@@ -726,18 +755,27 @@ async fn now_stream(
                     )
                 }) =>
             {
+                if !terminal_observed {
+                    anyhow::bail!("NOW operation stream closed before a terminal event");
+                }
                 break;
             }
             Err(error) => return Err(error),
         };
         let payload = match response {
             Response::Ok(payload) => payload,
-            Response::Err(error) => anyhow::bail!("{error}"),
+            Response::Err(error) => return Err(NowRequestError(error).into()),
         };
         if let Payload::NowEvent(event) = &payload {
             match &event.kind {
-                OperationEventKind::Completed { exit_code: code } => exit_code = Some(*code),
-                OperationEventKind::Cancelled | OperationEventKind::Failed(_) => exit_code = Some(1),
+                OperationEventKind::Completed { exit_code: code } => {
+                    terminal_observed = true;
+                    exit_code = Some(*code);
+                }
+                OperationEventKind::Cancelled | OperationEventKind::Failed(_) => {
+                    terminal_observed = true;
+                    exit_code = Some(1);
+                }
                 OperationEventKind::Started
                 | OperationEventKind::Output { .. }
                 | OperationEventKind::CancelAccepted => {}
@@ -746,7 +784,7 @@ async fn now_stream(
         match format {
             OutputFormat::Human => print_now_human(&payload)?,
             OutputFormat::Ndjson => print_now_ndjson(&payload)?,
-            OutputFormat::Json => json_values.push(now_payload_json(&payload)),
+            OutputFormat::Json => push_json_payload(&mut json_values, &mut json_output_bytes, &payload)?,
         }
     }
 
@@ -757,6 +795,69 @@ async fn now_stream(
         );
     }
     Ok(exit_code)
+}
+
+fn print_now_error(error: &AgentError, format: OutputFormat) -> anyhow::Result<()> {
+    match format {
+        OutputFormat::Human => {
+            eprintln!("{}", error.message);
+            Ok(())
+        }
+        OutputFormat::Json | OutputFormat::Ndjson => {
+            println!(
+                "{}",
+                serde_json::to_string(&serde_json::json!({
+                    "type": "error",
+                    "category": error.category.as_str(),
+                    "message": error.message,
+                }))
+                .context("serialize NOW error")?
+            );
+            Ok(())
+        }
+    }
+}
+
+fn push_json_payload(
+    values: &mut Vec<serde_json::Value>,
+    output_bytes: &mut usize,
+    payload: &Payload,
+) -> anyhow::Result<()> {
+    if values.len() == MAX_JSON_STREAM_EVENTS {
+        anyhow::bail!("JSON stream exceeds the {MAX_JSON_STREAM_EVENTS}-event limit; use --format ndjson");
+    }
+    let bytes = payload_output_size(payload);
+    *output_bytes = output_bytes
+        .checked_add(bytes)
+        .ok_or_else(|| anyhow::anyhow!("JSON stream output length overflow"))?;
+    if *output_bytes > MAX_JSON_STREAM_OUTPUT {
+        anyhow::bail!("JSON stream exceeds the {MAX_JSON_STREAM_OUTPUT}-byte output limit; use --format ndjson");
+    }
+    values.push(now_payload_json(payload));
+    Ok(())
+}
+
+fn payload_output_size(payload: &Payload) -> usize {
+    match payload {
+        Payload::NowEvent(OperationEvent {
+            kind: OperationEventKind::Output { data, .. },
+            ..
+        }) => data.len(),
+        _ => 0,
+    }
+}
+
+fn payload_is_terminal_operation(payload: &Payload) -> bool {
+    matches!(
+        payload,
+        Payload::NowOperation(OperationInfo {
+            state: OperationState::Completed
+                | OperationState::Cancelled
+                | OperationState::Failed
+                | OperationState::Detached,
+            ..
+        })
+    )
 }
 
 fn print_now_payload(payload: &Payload, format: OutputFormat) -> anyhow::Result<()> {

--- a/crates/ironrdp-agent/src/daemon.rs
+++ b/crates/ironrdp-agent/src/daemon.rs
@@ -18,9 +18,12 @@ use tokio::sync::mpsc;
 use tracing::{debug, error, info, trace, warn};
 
 use crate::ipc::{
-    ConnState, KeyFilter, Payload, PropValue, PropertyDump, PropertyEntry, Request, Response, StatusInfo,
+    ConnState, KeyFilter, NowDiagnostics, Payload, PropValue, PropertyDump, PropertyEntry, Request, Response,
+    StatusInfo,
 };
 use crate::logbuf::{self, LogBuffer};
+use crate::now::NowEndpoint;
+use crate::operations::{OperationAttachment, OperationManager};
 use crate::transport::{Endpoint, Listener, read_message, write_message};
 
 /// Binds the IPC endpoint and serves requests until a shutdown signal is received.
@@ -51,7 +54,7 @@ pub async fn run(endpoint: Endpoint, overlay: PropertySet) -> anyhow::Result<()>
     let logs = LogBuffer::new();
 
     let mut listener = Listener::bind(&endpoint).with_context(|| format!("bind IPC endpoint {endpoint}"))?;
-    let daemon = Daemon::new(logs, overlay);
+    let daemon = Arc::new(Daemon::new(logs, overlay));
 
     info!(%endpoint, "Daemon listening");
 
@@ -59,9 +62,12 @@ pub async fn run(endpoint: Endpoint, overlay: PropertySet) -> anyhow::Result<()>
         tokio::select! {
             result = listener.accept() => {
                 let stream = result.context("accept IPC connection")?;
-                if let Err(error) = handle_connection(stream, &daemon).await {
-                    debug!(error = format!("{error:#}"), "IPC connection error");
-                }
+                let daemon = Arc::clone(&daemon);
+                tokio::spawn(async move {
+                    if let Err(error) = handle_connection(stream, daemon.as_ref()).await {
+                        debug!(error = format!("{error:#}"), "IPC connection error");
+                    }
+                });
             }
             _ = tokio::signal::ctrl_c() => {
                 info!("Received shutdown signal, stopping");
@@ -79,10 +85,34 @@ where
 {
     let request: Request = read_message(&mut stream).await?;
     trace!(?request, "Handling IPC request");
-    let response = daemon.handle(request);
-    trace!(ok = response.is_ok(), "Replying to IPC request");
-    write_message(&mut stream, &response).await?;
+    let response = daemon.handle(request).await;
+    trace!(ok = response.response().is_ok(), "Replying to IPC request");
+    match response {
+        DaemonResponse::Single(response) => write_message(&mut stream, &response).await?,
+        DaemonResponse::Stream(response, mut attachment) => {
+            write_message(&mut stream, &response).await?;
+            for event in attachment.replay {
+                write_message(&mut stream, &Response::Ok(Payload::NowEvent(event))).await?;
+            }
+            while let Some(event) = attachment.live.recv().await {
+                write_message(&mut stream, &Response::Ok(Payload::NowEvent(event))).await?;
+            }
+        }
+    }
     Ok(())
+}
+
+enum DaemonResponse {
+    Single(Response),
+    Stream(Response, OperationAttachment),
+}
+
+impl DaemonResponse {
+    fn response(&self) -> &Response {
+        match self {
+            Self::Single(response) | Self::Stream(response, _) => response,
+        }
+    }
 }
 
 /// The daemon's mutable state: the (single) current session, plus the shared log buffer.
@@ -103,6 +133,8 @@ struct Session {
     input_db: Database,
     destination: String,
     live: Arc<Mutex<Live>>,
+    now_endpoint: Arc<NowEndpoint>,
+    operations: OperationManager,
 }
 
 /// Per-session state shared with the output-consumer task.
@@ -137,41 +169,63 @@ impl Daemon {
         }
     }
 
-    fn handle(&self, request: Request) -> Response {
+    async fn handle(&self, request: Request) -> DaemonResponse {
         match request {
             Request::Connect {
                 properties,
                 log_directive,
-            } => self.connect(properties, log_directive),
-            Request::Disconnect => self.disconnect(),
-            Request::Status => self.status(),
-            Request::QueryProps { filter } => self.query_props(filter.as_ref()),
-            Request::QueryLogs { substring, last } => self.query_logs(substring.as_deref(), last),
-            Request::Screenshot => self.screenshot(),
-            Request::MouseMove { x, y } => self.input(Operation::MouseMove(MousePosition { x, y })),
-            Request::MouseButton { button, pressed } => self.input(if pressed {
+            } => DaemonResponse::Single(self.connect(properties, log_directive)),
+            Request::Disconnect => DaemonResponse::Single(self.disconnect()),
+            Request::Status => DaemonResponse::Single(self.status()),
+            Request::QueryProps { filter } => DaemonResponse::Single(self.query_props(filter.as_ref())),
+            Request::QueryLogs { substring, last } => {
+                DaemonResponse::Single(self.query_logs(substring.as_deref(), last))
+            }
+            Request::Screenshot => DaemonResponse::Single(self.screenshot()),
+            Request::MouseMove { x, y } => {
+                DaemonResponse::Single(self.input(Operation::MouseMove(MousePosition { x, y })))
+            }
+            Request::MouseButton { button, pressed } => DaemonResponse::Single(self.input(if pressed {
                 Operation::MouseButtonPressed(button)
             } else {
                 Operation::MouseButtonReleased(button)
-            }),
-            Request::Wheel { delta, horizontal } => self.input(Operation::WheelRotations(WheelRotations {
-                is_vertical: !horizontal,
-                rotation_units: delta,
             })),
+            Request::Wheel { delta, horizontal } => {
+                DaemonResponse::Single(self.input(Operation::WheelRotations(WheelRotations {
+                    is_vertical: !horizontal,
+                    rotation_units: delta,
+                })))
+            }
             Request::KeyScancode { scancode, pressed } => {
                 let scancode = Scancode::from_u16(scancode);
-                self.input(if pressed {
+                DaemonResponse::Single(self.input(if pressed {
                     Operation::KeyPressed(scancode)
                 } else {
                     Operation::KeyReleased(scancode)
-                })
+                }))
             }
-            Request::KeyUnicode { ch, pressed } => self.input(if pressed {
+            Request::KeyUnicode { ch, pressed } => DaemonResponse::Single(self.input(if pressed {
                 Operation::UnicodeKeyPressed(ch)
             } else {
                 Operation::UnicodeKeyReleased(ch)
-            }),
-            Request::Resize { width, height } => self.resize(width, height),
+            })),
+            Request::Resize { width, height } => DaemonResponse::Single(self.resize(width, height)),
+            Request::NowCapabilities => DaemonResponse::Single(self.now_capabilities().await),
+            Request::NowRun { command, directory } => DaemonResponse::Single(self.now_run(command, directory).await),
+            Request::NowExecute(request) => self.now_execute(request).await,
+            Request::NowCancel { operation_id } => DaemonResponse::Single(self.now_cancel(operation_id).await),
+            Request::NowList => DaemonResponse::Single(self.now_list()),
+            Request::NowStatus { operation_id } => DaemonResponse::Single(self.now_status(operation_id)),
+            Request::NowAttach {
+                operation_id,
+                after_sequence,
+            } => self.now_attach(operation_id, after_sequence),
+            Request::NowStdin {
+                operation_id,
+                data,
+                last,
+            } => DaemonResponse::Single(self.now_stdin(operation_id, data, last).await),
+            Request::NowDiagnostics => DaemonResponse::Single(self.now_diagnostics().await),
         }
     }
 
@@ -197,6 +251,9 @@ impl Daemon {
         // in particular — can be preconfigured without the (possibly untrusted) caller supplying it.
         properties.merge(&self.overlay);
 
+        // Each RDP session receives a distinct DVC endpoint. It is only contacted later by a NOW
+        // request, after the RDP engine has connected and the proxy has opened its local listener.
+        let now_endpoint = Arc::new(NowEndpoint::new());
         let builder = match ConfigBuilder::from_property_set(&properties) {
             Ok(builder) => builder,
             Err(error) => return Response::error(format!("invalid configuration: {error:#}")),
@@ -209,6 +266,7 @@ impl Daemon {
             .with_client_dir("C:\\Windows\\System32\\mstscax.dll")
             .with_platform(current_platform())
             .with_client_name(client_name())
+            .with_dvc_pipe_proxy(now_endpoint.dvc_proxy_info())
             // Headless: composite the remote cursor into the framebuffer so it appears in
             // screenshots (there is no separate overlay to draw it).
             .with_pointer_software_rendering(true);
@@ -275,6 +333,8 @@ impl Daemon {
             input_db: Database::new(),
             destination,
             live,
+            operations: OperationManager::new(Arc::clone(&now_endpoint)),
+            now_endpoint,
         });
 
         Response::ok()
@@ -434,6 +494,141 @@ impl Daemon {
             Ok(()) => Response::ok(),
             Err(_) => Response::error("session input channel is closed"),
         }
+    }
+
+    fn operations(&self) -> Result<OperationManager, Response> {
+        self.state
+            .lock()
+            .expect("daemon state poisoned")
+            .as_ref()
+            .map(|session| session.operations.clone())
+            .ok_or_else(|| Response::typed_error(crate::ipc::AgentErrorCategory::Unavailable, "no active RDP session"))
+    }
+
+    async fn now_capabilities(&self) -> Response {
+        let operations = match self.operations() {
+            Ok(operations) => operations,
+            Err(response) => return response,
+        };
+        match operations.capabilities().await {
+            Ok(capabilities) => Response::Ok(Payload::NowCapabilities(capabilities)),
+            Err(error) => Response::Err(error),
+        }
+    }
+
+    async fn now_run(&self, command: String, directory: Option<String>) -> Response {
+        let operations = match self.operations() {
+            Ok(operations) => operations,
+            Err(response) => return response,
+        };
+        match operations.run(command, directory).await {
+            Ok(()) => Response::ok(),
+            Err(error) => Response::Err(error),
+        }
+    }
+
+    async fn now_execute(&self, request: crate::ipc::NowExecutionRequest) -> DaemonResponse {
+        let operations = match self.operations() {
+            Ok(operations) => operations,
+            Err(response) => return DaemonResponse::Single(response),
+        };
+        match operations.execute(request).await {
+            Ok(info) if info.detached => DaemonResponse::Single(Response::Ok(Payload::NowOperation(info))),
+            Ok(info) => match operations.attach(info.id, None) {
+                Ok(attachment) => DaemonResponse::Stream(Response::Ok(Payload::NowOperation(info)), attachment),
+                Err(error) => DaemonResponse::Single(Response::Err(error)),
+            },
+            Err(error) => DaemonResponse::Single(Response::Err(error)),
+        }
+    }
+
+    async fn now_cancel(&self, operation_id: u64) -> Response {
+        let operations = match self.operations() {
+            Ok(operations) => operations,
+            Err(response) => return response,
+        };
+        match operations.cancel(operation_id).await {
+            Ok(()) => Response::ok(),
+            Err(error) => Response::Err(error),
+        }
+    }
+
+    fn now_list(&self) -> Response {
+        match self.operations() {
+            Ok(operations) => Response::Ok(Payload::NowOperations(operations.list())),
+            Err(response) => response,
+        }
+    }
+
+    fn now_status(&self, operation_id: u64) -> Response {
+        match self.operations().and_then(|operations| {
+            operations
+                .status(operation_id)
+                .map(|operation| Response::Ok(Payload::NowOperation(operation)))
+                .map_err(Response::Err)
+        }) {
+            Ok(response) | Err(response) => response,
+        }
+    }
+
+    fn now_attach(&self, operation_id: u64, after_sequence: Option<u64>) -> DaemonResponse {
+        match self.operations().and_then(|operations| {
+            operations
+                .attach(operation_id, after_sequence)
+                .map(|attachment| (attachment.info.clone(), attachment))
+                .map_err(Response::Err)
+        }) {
+            Ok((info, attachment)) => DaemonResponse::Stream(Response::Ok(Payload::NowOperation(info)), attachment),
+            Err(response) => DaemonResponse::Single(response),
+        }
+    }
+
+    async fn now_stdin(&self, operation_id: u64, data: Vec<u8>, last: bool) -> Response {
+        let operations = match self.operations() {
+            Ok(operations) => operations,
+            Err(response) => return response,
+        };
+        match operations.send_stdin(operation_id, data, last).await {
+            Ok(()) => Response::ok(),
+            Err(error) => Response::Err(error),
+        }
+    }
+
+    async fn now_diagnostics(&self) -> Response {
+        let endpoint = match self
+            .state
+            .lock()
+            .expect("daemon state poisoned")
+            .as_ref()
+            .map(|session| Arc::clone(&session.now_endpoint))
+        {
+            Some(endpoint) => endpoint,
+            None => {
+                return Response::typed_error(crate::ipc::AgentErrorCategory::Unavailable, "no active RDP session");
+            }
+        };
+        let connected = endpoint.is_connected().await;
+        let capabilities = endpoint.cached_capabilities().await.map(|capabilities| NowDiagnostics {
+            endpoint_allocated: true,
+            connected,
+            capabilities: Some(crate::ipc::NowCapabilities {
+                version_major: capabilities.version_major,
+                version_minor: capabilities.version_minor,
+                heartbeat_ms: capabilities.heartbeat_ms,
+                run: capabilities.run,
+                process: capabilities.process,
+                batch: capabilities.batch,
+                powershell: capabilities.powershell,
+                pwsh: capabilities.pwsh,
+                io_redirection: capabilities.io_redirection,
+                unicode_console: capabilities.unicode_console,
+            }),
+        });
+        Response::Ok(Payload::NowDiagnostics(capabilities.unwrap_or(NowDiagnostics {
+            endpoint_allocated: true,
+            connected,
+            capabilities: None,
+        })))
     }
 }
 

--- a/crates/ironrdp-agent/src/daemon.rs
+++ b/crates/ironrdp-agent/src/daemon.rs
@@ -118,6 +118,9 @@ impl DaemonResponse {
 /// The daemon's mutable state: the (single) current session, plus the shared log buffer.
 struct Daemon {
     state: Mutex<Option<Session>>,
+    /// Serializes synchronous RDP session construction so concurrent IPC `connect` requests cannot
+    /// both observe an empty session slot before either one installs its session.
+    connect_lock: Mutex<()>,
     logs: Arc<LogBuffer>,
     /// Operator-provided overlay layered on top of every `Connect` (overlay wins). Holds any
     /// preconfigured settings, credentials in particular.
@@ -163,6 +166,7 @@ impl Daemon {
         let credentials_loaded = overlay.iter().any(|(key, _)| ironrdp_cfg::is_secret_key(key));
         Self {
             state: Mutex::new(None),
+            connect_lock: Mutex::new(()),
             logs,
             overlay,
             credentials_loaded,
@@ -230,6 +234,7 @@ impl Daemon {
     }
 
     fn connect(&self, mut properties: PropertySet, log_directive: Option<String>) -> Response {
+        let _connect_guard = self.connect_lock.lock().expect("connect state poisoned");
         debug!(?log_directive, "Received connect request");
         // Refuse to clobber a live session: the previous RDP engine runs on its own thread and is
         // not torn down by simply replacing the session slot. Require an explicit `disconnect` first.
@@ -242,7 +247,10 @@ impl Daemon {
                     ConnState::Connecting | ConnState::Connected | ConnState::Disconnecting
                 ) {
                     debug!("Refusing connect: a session is already active");
-                    return Response::error("a session is already active; disconnect first");
+                    return Response::typed_error(
+                        crate::ipc::AgentErrorCategory::Conflict,
+                        "a session is already active; disconnect first",
+                    );
                 }
             }
         }
@@ -253,10 +261,23 @@ impl Daemon {
 
         // Each RDP session receives a distinct DVC endpoint. It is only contacted later by a NOW
         // request, after the RDP engine has connected and the proxy has opened its local listener.
-        let now_endpoint = Arc::new(NowEndpoint::new());
+        let now_endpoint = match NowEndpoint::new() {
+            Ok(endpoint) => Arc::new(endpoint),
+            Err(error) => {
+                return Response::typed_error(
+                    crate::ipc::AgentErrorCategory::Internal,
+                    format!("failed to allocate NOW endpoint: {error}"),
+                );
+            }
+        };
         let builder = match ConfigBuilder::from_property_set(&properties) {
             Ok(builder) => builder,
-            Err(error) => return Response::error(format!("invalid configuration: {error:#}")),
+            Err(error) => {
+                return Response::typed_error(
+                    crate::ipc::AgentErrorCategory::InvalidRequest,
+                    format!("invalid configuration: {error:#}"),
+                );
+            }
         };
 
         // Derive the headless client identity. These fields are never representable as `.rdp`
@@ -273,19 +294,24 @@ impl Daemon {
 
         let missing = builder.missing();
         if !missing.is_empty() {
-            return Response::error(format!(
-                "missing required fields: {}",
-                missing
-                    .iter()
-                    .map(MissingField::to_string)
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            ));
+            return Response::typed_error(
+                crate::ipc::AgentErrorCategory::InvalidRequest,
+                format!(
+                    "missing required fields: {}",
+                    missing
+                        .iter()
+                        .map(MissingField::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+            );
         }
 
         let config = match builder.build() {
             Ok(config) => config,
-            Err(error) => return Response::error(format!("{error:#}")),
+            Err(error) => {
+                return Response::typed_error(crate::ipc::AgentErrorCategory::InvalidRequest, format!("{error:#}"));
+            }
         };
 
         // `ConfigBuilder::build` strips every secret property, so the live bag carries no secrets.
@@ -321,7 +347,10 @@ impl Daemon {
                 });
             });
         if let Err(error) = spawn_result {
-            return Response::error(format!("failed to spawn session thread: {error}"));
+            return Response::typed_error(
+                crate::ipc::AgentErrorCategory::Internal,
+                format!("failed to spawn session thread: {error}"),
+            );
         }
 
         tokio::spawn(consume_output(output_rx, Arc::clone(&live)));
@@ -345,7 +374,7 @@ impl Daemon {
         match guard.as_mut() {
             None => {
                 debug!("Disconnect requested but no session is active");
-                Response::error("no active session")
+                Response::typed_error(crate::ipc::AgentErrorCategory::Unavailable, "no active session")
             }
             Some(session) => {
                 let mut live = session.live.lock().expect("session live state poisoned");
@@ -400,7 +429,7 @@ impl Daemon {
     fn query_props(&self, filter: Option<&KeyFilter>) -> Response {
         let guard = self.state.lock().expect("daemon state poisoned");
         let Some(session) = guard.as_ref() else {
-            return Response::error("no active session");
+            return Response::typed_error(crate::ipc::AgentErrorCategory::Unavailable, "no active session");
         };
         let live = session.live.lock().expect("session live state poisoned");
 
@@ -437,11 +466,11 @@ impl Daemon {
     fn screenshot(&self) -> Response {
         let guard = self.state.lock().expect("daemon state poisoned");
         let Some(session) = guard.as_ref() else {
-            return Response::error("no active session");
+            return Response::typed_error(crate::ipc::AgentErrorCategory::Unavailable, "no active session");
         };
         let live = session.live.lock().expect("session live state poisoned");
         let Some(frame) = live.frame.as_ref() else {
-            return Response::error("no frame available yet");
+            return Response::typed_error(crate::ipc::AgentErrorCategory::Unavailable, "no frame available yet");
         };
         match encode_png(frame.width, frame.height, &frame.pixels) {
             Ok(png) => {
@@ -457,17 +486,23 @@ impl Daemon {
                     png,
                 })
             }
-            Err(error) => Response::error(format!("failed to encode screenshot: {error:#}")),
+            Err(error) => Response::typed_error(
+                crate::ipc::AgentErrorCategory::Internal,
+                format!("failed to encode screenshot: {error:#}"),
+            ),
         }
     }
 
     fn resize(&self, width: u16, height: u16) -> Response {
         if width == 0 || height == 0 {
-            return Response::error("width and height must be non-zero");
+            return Response::typed_error(
+                crate::ipc::AgentErrorCategory::InvalidRequest,
+                "width and height must be non-zero",
+            );
         }
         let guard = self.state.lock().expect("daemon state poisoned");
         let Some(session) = guard.as_ref() else {
-            return Response::error("no active session");
+            return Response::typed_error(crate::ipc::AgentErrorCategory::Unavailable, "no active session");
         };
         match session.input_tx.send(RdpInputEvent::Resize {
             width,
@@ -477,14 +512,17 @@ impl Daemon {
             physical_size: None,
         }) {
             Ok(()) => Response::ok(),
-            Err(_) => Response::error("session input channel is closed"),
+            Err(_) => Response::typed_error(
+                crate::ipc::AgentErrorCategory::Unavailable,
+                "session input channel is closed",
+            ),
         }
     }
 
     fn input(&self, operation: Operation) -> Response {
         let mut guard = self.state.lock().expect("daemon state poisoned");
         let Some(session) = guard.as_mut() else {
-            return Response::error("no active session");
+            return Response::typed_error(crate::ipc::AgentErrorCategory::Unavailable, "no active session");
         };
         let events = session.input_db.apply([operation]);
         if events.is_empty() {
@@ -492,7 +530,10 @@ impl Daemon {
         }
         match session.input_tx.send(RdpInputEvent::FastPath(events)) {
             Ok(()) => Response::ok(),
-            Err(_) => Response::error("session input channel is closed"),
+            Err(_) => Response::typed_error(
+                crate::ipc::AgentErrorCategory::Unavailable,
+                "session input channel is closed",
+            ),
         }
     }
 
@@ -607,8 +648,8 @@ impl Daemon {
                 return Response::typed_error(crate::ipc::AgentErrorCategory::Unavailable, "no active RDP session");
             }
         };
-        let connected = endpoint.is_connected().await;
-        let capabilities = endpoint.cached_capabilities().await.map(|capabilities| NowDiagnostics {
+        let (connected, capabilities) = endpoint.diagnostic_snapshot().await;
+        let capabilities = capabilities.map(|capabilities| NowDiagnostics {
             endpoint_allocated: true,
             connected,
             capabilities: Some(crate::ipc::NowCapabilities {

--- a/crates/ironrdp-agent/src/help.rs
+++ b/crates/ironrdp-agent/src/help.rs
@@ -116,7 +116,8 @@ Live `now attach` output is bounded. If an attachment cannot keep up, it closes;
 the last sequence number to resume from retained output.
 
 Use `--format human|json|ndjson` with `now` for human-readable output, one JSON result, or JSON
-event lines. JSON output represents raw bytes as byte arrays.
+event lines. JSON output represents raw bytes as byte arrays and is bounded to 8,192 events and
+2 MiB of output. Use NDJSON for unbounded streaming.
 
 Shell execution is intentionally not exposed: there is no `now shell` command, IPC request,
 capability, or mapping, even if a peer advertises it.

--- a/crates/ironrdp-agent/src/help.rs
+++ b/crates/ironrdp-agent/src/help.rs
@@ -77,6 +77,50 @@ Override with `--endpoint <PATH-OR-PIPE>` on any subcommand.
 - `key-unicode --char C --pressed <true|false>`  Type by Unicode character.
 - `resize --width W --height H`                  Resize the remote desktop.
 
+## NOW remote execution (requires an active, connected RDP session)
+
+The daemon allocates one private `Devolutions::Now::Agent` DVC endpoint for each RDP session. It
+waits lazily for the endpoint only when a NOW request is made: up to 30 seconds for its first
+connection and up to 10 seconds after a worker/transport replacement. `status` and `disconnect`
+remain responsive while it waits.
+
+- `now capabilities`                 Negotiate and print the supported NOW styles.
+- `now run COMMAND [--directory DIR]`
+                                     Submit generic Run and return after local submission. Run is
+                                     intentionally untracked: it has no durable output or result.
+- `now powershell COMMAND [COMMON]`  Execute Windows PowerShell.
+- `now pwsh COMMAND [COMMON]`        Execute PowerShell 7.
+- `now exec process FILE [--parameters ARGS] [COMMON]`
+                                     Execute a Windows CreateProcess request.
+- `now exec batch COMMAND [COMMON]`  Execute a Windows batch request.
+
+`COMMON` is `--directory DIR`, `--stdin FILE` (use `-` for the CLI standard input), `--timeout
+SECONDS`, `--detached`, and `--operation-id-file FILE`. The operation-ID file is written after
+local submission and lets later CLI invocations attach, cancel, or send stdin. PowerShell and pwsh
+default to both `-NoProfile` and `-NonInteractive`; use `--profile` and/or `--interactive` only to
+explicitly opt out. Detached commands have no stdin, output, or terminal result.
+
+Tracked commands have one daemon-owned operation at a time. Their stdout and stderr chunks are
+forwarded as raw bytes (not line-buffered) and the CLI returns the remote nonzero exit code
+(1-255 directly; larger values as 255). Output is retained for `now attach`, `now list`, and `now
+status`: 8 MiB per operation, 32 terminal operations, and 32 MiB total. Use:
+
+- `now cancel OPERATION_ID`
+- `now stdin OPERATION_ID --input FILE [--last]`
+- `now attach OPERATION_ID [--after-sequence N]`
+- `now list`
+- `now status OPERATION_ID`
+- `now diagnostics`
+
+Live `now attach` output is bounded. If an attachment cannot keep up, it closes; attach again with
+the last sequence number to resume from retained output.
+
+Use `--format human|json|ndjson` with `now` for human-readable output, one JSON result, or JSON
+event lines. JSON output represents raw bytes as byte arrays.
+
+Shell execution is intentionally not exposed: there is no `now shell` command, IPC request,
+capability, or mapping, even if a peer advertises it.
+
 ## Errors
 
 Failures print a single lowercase message (no trailing punctuation) and exit non-zero. A failed

--- a/crates/ironrdp-agent/src/ipc.rs
+++ b/crates/ironrdp-agent/src/ipc.rs
@@ -19,11 +19,10 @@ use ironrdp_input::MouseButton;
 use ironrdp_pdu::impl_pdu_pod;
 use ironrdp_propertyset::PropertySet;
 
-use crate::wire::propertyset;
 use crate::wire::{
-    bytes_size, opt_string_size, opt_u16_size, read_bool, read_bytes, read_char, read_mouse_button, read_opt_string,
-    read_opt_u16, read_string, string_size, write_bool, write_bytes, write_char, write_mouse_button, write_opt_string,
-    write_opt_u16, write_string,
+    bytes_size, opt_string_size, opt_u16_size, opt_u64_size, propertyset, read_bool, read_bytes, read_char,
+    read_mouse_button, read_opt_string, read_opt_u16, read_opt_u64, read_string, string_size, write_bool, write_bytes,
+    write_char, write_mouse_button, write_opt_string, write_opt_u16, write_opt_u64, write_string,
 };
 
 /// A request sent by the CLI to the daemon.
@@ -69,6 +68,36 @@ pub enum Request {
     KeyUnicode { ch: char, pressed: bool },
     /// Resize the remote desktop.
     Resize { width: u16, height: u16 },
+    /// Query and negotiate the capabilities of the session's NOW endpoint.
+    NowCapabilities,
+    /// Submit an untracked generic NOW Run request.
+    NowRun {
+        /// Command line interpreted by the remote NOW agent.
+        command: String,
+        /// Optional remote working directory.
+        directory: Option<String>,
+    },
+    /// Submit a NOW operation that is tracked by the daemon unless `detached` is set.
+    NowExecute(NowExecutionRequest),
+    /// Request cancellation of the active tracked NOW operation.
+    NowCancel { operation_id: u64 },
+    /// List daemon-retained NOW operations.
+    NowList,
+    /// Inspect a retained NOW operation.
+    NowStatus { operation_id: u64 },
+    /// Replay retained operation events after `after_sequence` and then follow live output.
+    NowAttach {
+        operation_id: u64,
+        after_sequence: Option<u64>,
+    },
+    /// Forward a bounded raw stdin chunk to a tracked operation.
+    NowStdin {
+        operation_id: u64,
+        data: Vec<u8>,
+        last: bool,
+    },
+    /// Inspect the local NOW endpoint without exposing protocol internals.
+    NowDiagnostics,
     // TODO: add clipboard support (CLIPRDR), e.g. requests to read the remote clipboard text and to
     // set it, so an LLM can copy/paste to and from the session.
 }
@@ -121,6 +150,39 @@ impl fmt::Debug for Request {
                 .field("width", width)
                 .field("height", height)
                 .finish(),
+            Self::NowCapabilities => f.write_str("NowCapabilities"),
+            Self::NowRun { command, directory } => f
+                .debug_struct("NowRun")
+                .field("command_len", &command.len())
+                .field("directory", directory)
+                .finish(),
+            Self::NowExecute(request) => f.debug_tuple("NowExecute").field(request).finish(),
+            Self::NowCancel { operation_id } => {
+                f.debug_struct("NowCancel").field("operation_id", operation_id).finish()
+            }
+            Self::NowList => f.write_str("NowList"),
+            Self::NowStatus { operation_id } => {
+                f.debug_struct("NowStatus").field("operation_id", operation_id).finish()
+            }
+            Self::NowAttach {
+                operation_id,
+                after_sequence,
+            } => f
+                .debug_struct("NowAttach")
+                .field("operation_id", operation_id)
+                .field("after_sequence", after_sequence)
+                .finish(),
+            Self::NowStdin {
+                operation_id,
+                data,
+                last,
+            } => f
+                .debug_struct("NowStdin")
+                .field("operation_id", operation_id)
+                .field("data_len", &data.len())
+                .field("last", last)
+                .finish(),
+            Self::NowDiagnostics => f.write_str("NowDiagnostics"),
         }
     }
 }
@@ -140,7 +202,7 @@ pub enum Response {
     /// Success, carrying an operation-specific [`Payload`].
     Ok(Payload),
     /// Failure. The message is lowercase with no trailing punctuation.
-    Err(String),
+    Err(AgentError),
 }
 
 impl Response {
@@ -151,7 +213,15 @@ impl Response {
 
     /// A failure response.
     pub fn error(message: impl Into<String>) -> Self {
-        Self::Err(message.into())
+        Self::Err(AgentError::internal(message))
+    }
+
+    /// A typed failure response.
+    pub fn typed_error(category: AgentErrorCategory, message: impl Into<String>) -> Self {
+        Self::Err(AgentError {
+            category,
+            message: message.into(),
+        })
     }
 
     /// Whether this is a success response.
@@ -173,6 +243,16 @@ pub enum Payload {
     Logs(Vec<String>),
     /// The most recent frame encoded as a PNG (cursor included), with its dimensions.
     Screenshot { width: u16, height: u16, png: Vec<u8> },
+    /// Negotiated NOW capabilities.
+    NowCapabilities(NowCapabilities),
+    /// One durable NOW operation.
+    NowOperation(OperationInfo),
+    /// Retained NOW operations.
+    NowOperations(Vec<OperationInfo>),
+    /// A sequenced NOW operation event. Streaming requests receive one response per event.
+    NowEvent(OperationEvent),
+    /// Local NOW endpoint diagnostic state.
+    NowDiagnostics(NowDiagnostics),
 }
 
 impl fmt::Debug for Payload {
@@ -189,8 +269,256 @@ impl fmt::Debug for Payload {
                 .field("height", height)
                 .field("png_len", &png.len())
                 .finish(),
+            Self::NowCapabilities(capabilities) => f.debug_tuple("NowCapabilities").field(capabilities).finish(),
+            Self::NowOperation(operation) => f.debug_tuple("NowOperation").field(operation).finish(),
+            Self::NowOperations(operations) => f.debug_tuple("NowOperations").field(operations).finish(),
+            Self::NowEvent(event) => f.debug_tuple("NowEvent").field(event).finish(),
+            Self::NowDiagnostics(diagnostics) => f.debug_tuple("NowDiagnostics").field(diagnostics).finish(),
         }
     }
+}
+
+/// Machine-readable error category. The message is safe for display but must not include request
+/// command text or stdin.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentErrorCategory {
+    /// The caller supplied an invalid request.
+    InvalidRequest,
+    /// No suitable connected RDP/NOW session exists.
+    Unavailable,
+    /// A tracked operation conflicts with another active tracked operation.
+    Conflict,
+    /// The local transport or NOW worker failed.
+    Transport,
+    /// The remote peer rejected or failed an operation.
+    Remote,
+    /// An internal daemon operation failed.
+    Internal,
+}
+
+/// Typed IPC error response.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentError {
+    /// Error category for JSON/NDJSON clients.
+    pub category: AgentErrorCategory,
+    /// Display-safe lowercase error message.
+    pub message: String,
+}
+
+impl AgentError {
+    /// Creates an internal error.
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self {
+            category: AgentErrorCategory::Internal,
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for AgentError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl core::error::Error for AgentError {}
+
+/// NOW execution style intentionally exposed by the agent. Shell is not an option.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NowExecutionKind {
+    /// Windows CreateProcess.
+    Process,
+    /// Windows Batch.
+    Batch,
+    /// Windows PowerShell.
+    PowerShell,
+    /// PowerShell 7.
+    Pwsh,
+}
+
+/// Request for a supported NOW tracked or detached execution.
+#[derive(Clone, PartialEq, Eq)]
+pub struct NowExecutionRequest {
+    /// Exposed NOW execution style.
+    pub kind: NowExecutionKind,
+    /// Program path for Process, or script/command for the other styles.
+    pub command: String,
+    /// Process command-line parameters.
+    pub parameters: Option<String>,
+    /// Optional remote working directory.
+    pub directory: Option<String>,
+    /// Optional initial stdin.
+    pub stdin: Option<Vec<u8>>,
+    /// Optional command deadline in milliseconds.
+    pub timeout_ms: Option<u64>,
+    /// Ask the peer to detach. Detached commands have no retained output or result.
+    pub detached: bool,
+    /// Request PowerShell's `-NoProfile` mode.
+    pub no_profile: bool,
+    /// Request PowerShell's `-NonInteractive` mode.
+    pub non_interactive: bool,
+}
+
+impl fmt::Debug for NowExecutionRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("NowExecutionRequest")
+            .field("kind", &self.kind)
+            .field("command_len", &self.command.len())
+            .field("parameters_len", &self.parameters.as_ref().map(String::len))
+            .field("directory", &self.directory)
+            .field("stdin_len", &self.stdin.as_ref().map(Vec::len))
+            .field("timeout_ms", &self.timeout_ms)
+            .field("detached", &self.detached)
+            .field("no_profile", &self.no_profile)
+            .field("non_interactive", &self.non_interactive)
+            .finish()
+    }
+}
+
+/// Durable operation state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OperationState {
+    /// The remote operation is active.
+    Running,
+    /// Cancellation has been sent and accepted or is awaiting a terminal result.
+    Cancelling,
+    /// The remote operation completed normally.
+    Completed,
+    /// The remote operation was cancelled.
+    Cancelled,
+    /// The operation failed locally or remotely.
+    Failed,
+    /// A detached operation was submitted and cannot report further state.
+    Detached,
+}
+
+/// A stream associated with a raw output chunk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NowStream {
+    /// Standard output.
+    Stdout,
+    /// Standard error.
+    Stderr,
+}
+
+/// Daemon-retained metadata for one NOW operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OperationInfo {
+    /// Daemon-generated operation identity.
+    pub id: u64,
+    /// Submitted NOW style.
+    pub kind: NowExecutionKind,
+    /// Current or terminal state.
+    pub state: OperationState,
+    /// Whether this was submitted detached.
+    pub detached: bool,
+    /// Remote exit code, including nonzero values.
+    pub exit_code: Option<u32>,
+    /// Typed terminal failure, when any.
+    pub error: Option<AgentError>,
+    /// Bytes of raw stdout/stderr currently retained for this operation.
+    pub retained_output_bytes: u64,
+    /// Sequence assigned to the next operation event.
+    pub next_sequence: u64,
+}
+
+/// A replayable NOW operation event.
+#[derive(Clone, PartialEq, Eq)]
+pub struct OperationEvent {
+    /// Daemon-generated operation identity.
+    pub operation_id: u64,
+    /// Monotonically increasing sequence number scoped to the operation.
+    pub sequence: u64,
+    /// Event content.
+    pub kind: OperationEventKind,
+}
+
+impl fmt::Debug for OperationEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OperationEvent")
+            .field("operation_id", &self.operation_id)
+            .field("sequence", &self.sequence)
+            .field("kind", &self.kind)
+            .finish()
+    }
+}
+
+/// Content of a replayable NOW operation event.
+#[derive(Clone, PartialEq, Eq)]
+pub enum OperationEventKind {
+    /// The remote peer started the command.
+    Started,
+    /// A raw output chunk.
+    Output {
+        /// Output stream.
+        stream: NowStream,
+        /// Exact bytes received from NOW.
+        data: Vec<u8>,
+        /// Whether this is the final chunk on this stream.
+        last: bool,
+    },
+    /// The remote peer accepted a cancellation request.
+    CancelAccepted,
+    /// The command completed with an exit code.
+    Completed { exit_code: u32 },
+    /// The command was cancelled.
+    Cancelled,
+    /// The command terminated with a typed error.
+    Failed(AgentError),
+}
+
+impl fmt::Debug for OperationEventKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Started => f.write_str("Started"),
+            Self::Output { stream, data, last } => f
+                .debug_struct("Output")
+                .field("stream", stream)
+                .field("data_len", &data.len())
+                .field("last", last)
+                .finish(),
+            Self::CancelAccepted => f.write_str("CancelAccepted"),
+            Self::Completed { exit_code } => f.debug_struct("Completed").field("exit_code", exit_code).finish(),
+            Self::Cancelled => f.write_str("Cancelled"),
+            Self::Failed(error) => f.debug_tuple("Failed").field(error).finish(),
+        }
+    }
+}
+
+/// Local NOW endpoint diagnostic snapshot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NowDiagnostics {
+    /// Whether the RDP session has allocated a NOW DVC endpoint.
+    pub endpoint_allocated: bool,
+    /// Whether a NOW client handle is currently cached.
+    pub connected: bool,
+    /// Current cached capabilities, if a connection has already been established.
+    pub capabilities: Option<NowCapabilities>,
+}
+
+/// Negotiated NOW capabilities exposed without leaking the NOW PDU types.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NowCapabilities {
+    /// NOW protocol major version.
+    pub version_major: u16,
+    /// NOW protocol minor version.
+    pub version_minor: u16,
+    /// Negotiated heartbeat in milliseconds, if any.
+    pub heartbeat_ms: Option<u64>,
+    /// Generic Run support.
+    pub run: bool,
+    /// CreateProcess support.
+    pub process: bool,
+    /// Batch support.
+    pub batch: bool,
+    /// Windows PowerShell support.
+    pub powershell: bool,
+    /// PowerShell 7 support.
+    pub pwsh: bool,
+    /// Tracked I/O redirection support.
+    pub io_redirection: bool,
+    /// Unicode console support.
+    pub unicode_console: bool,
 }
 
 /// Coarse connection state reported by [`Request::Status`].
@@ -527,6 +855,30 @@ impl Encode for Payload {
                 dst.write_u16(*height);
                 write_bytes(dst, png)?;
             }
+            Self::NowCapabilities(capabilities) => {
+                dst.write_u8(5);
+                capabilities.encode(dst)?;
+            }
+            Self::NowOperation(operation) => {
+                dst.write_u8(6);
+                operation.encode(dst)?;
+            }
+            Self::NowOperations(operations) => {
+                dst.write_u8(7);
+                let count: u32 = cast_length!("operation count", operations.len())?;
+                dst.write_u32(count);
+                for operation in operations {
+                    operation.encode(dst)?;
+                }
+            }
+            Self::NowEvent(event) => {
+                dst.write_u8(8);
+                event.encode(dst)?;
+            }
+            Self::NowDiagnostics(diagnostics) => {
+                dst.write_u8(9);
+                diagnostics.encode(dst)?;
+            }
         }
         Ok(())
     }
@@ -543,6 +895,11 @@ impl Encode for Payload {
                 Self::Properties(dump) => dump.size(),
                 Self::Logs(lines) => 4 + lines.iter().map(|line| string_size(line)).sum::<usize>(),
                 Self::Screenshot { png, .. } => 2 /* width */ + 2 /* height */ + bytes_size(png),
+                Self::NowCapabilities(capabilities) => capabilities.size(),
+                Self::NowOperation(operation) => operation.size(),
+                Self::NowOperations(operations) => 4 + operations.iter().map(Encode::size).sum::<usize>(),
+                Self::NowEvent(event) => event.size(),
+                Self::NowDiagnostics(diagnostics) => diagnostics.size(),
             }
     }
 }
@@ -570,6 +927,19 @@ impl Decode<'_> for Payload {
                 let png = read_bytes(src)?;
                 Ok(Self::Screenshot { width, height, png })
             }
+            5 => Ok(Self::NowCapabilities(NowCapabilities::decode(src)?)),
+            6 => Ok(Self::NowOperation(OperationInfo::decode(src)?)),
+            7 => {
+                ensure_size!(in: src, size: 4);
+                let count = src.read_u32();
+                let mut operations = Vec::new();
+                for _ in 0..count {
+                    operations.push(OperationInfo::decode(src)?);
+                }
+                Ok(Self::NowOperations(operations))
+            }
+            8 => Ok(Self::NowEvent(OperationEvent::decode(src)?)),
+            9 => Ok(Self::NowDiagnostics(NowDiagnostics::decode(src)?)),
             _ => Err(ironrdp_core::invalid_field_err!("payload", "unknown tag")),
         }
     }
@@ -589,7 +959,7 @@ impl Encode for Response {
             }
             Self::Err(message) => {
                 dst.write_u8(1);
-                write_string(dst, message)
+                message.encode(dst)
             }
         }
     }
@@ -602,7 +972,7 @@ impl Encode for Response {
         1 /* tag */
             + match self {
                 Self::Ok(payload) => payload.size(),
-                Self::Err(message) => string_size(message),
+                Self::Err(error) => error.size(),
             }
     }
 }
@@ -612,7 +982,7 @@ impl Decode<'_> for Response {
         ensure_size!(in: src, size: 1);
         match src.read_u8() {
             0 => Ok(Self::Ok(Payload::decode(src)?)),
-            1 => Ok(Self::Err(read_string(src)?)),
+            1 => Ok(Self::Err(AgentError::decode(src)?)),
             _ => Err(ironrdp_core::invalid_field_err!("response", "unknown tag")),
         }
     }
@@ -688,6 +1058,44 @@ impl Encode for Request {
                 dst.write_u16(*width);
                 dst.write_u16(*height);
             }
+            Self::NowCapabilities => dst.write_u8(12),
+            Self::NowRun { command, directory } => {
+                dst.write_u8(13);
+                write_string(dst, command)?;
+                write_opt_string(dst, directory.as_deref())?;
+            }
+            Self::NowExecute(request) => {
+                dst.write_u8(14);
+                request.encode(dst)?;
+            }
+            Self::NowCancel { operation_id } => {
+                dst.write_u8(15);
+                dst.write_u64(*operation_id);
+            }
+            Self::NowList => dst.write_u8(16),
+            Self::NowStatus { operation_id } => {
+                dst.write_u8(17);
+                dst.write_u64(*operation_id);
+            }
+            Self::NowAttach {
+                operation_id,
+                after_sequence,
+            } => {
+                dst.write_u8(18);
+                dst.write_u64(*operation_id);
+                write_opt_u64(dst, *after_sequence)?;
+            }
+            Self::NowStdin {
+                operation_id,
+                data,
+                last,
+            } => {
+                dst.write_u8(19);
+                dst.write_u64(*operation_id);
+                write_bytes(dst, data)?;
+                write_bool(dst, *last)?;
+            }
+            Self::NowDiagnostics => dst.write_u8(20),
         }
         Ok(())
     }
@@ -702,7 +1110,12 @@ impl Encode for Request {
                 Self::Connect { properties, log_directive } => {
                     propertyset::size(properties) + opt_string_size(log_directive.as_deref())
                 }
-                Self::Disconnect | Self::Status | Self::Screenshot => 0,
+                Self::Disconnect
+                | Self::Status
+                | Self::Screenshot
+                | Self::NowCapabilities
+                | Self::NowList
+                | Self::NowDiagnostics => 0,
                 Self::QueryProps { filter } => 1 /* presence */ + filter.as_ref().map_or(0, Encode::size),
                 Self::QueryLogs { substring, last } => {
                     opt_string_size(substring.as_deref()) + 1 /* presence */ + last.map_or(0, |_| 4)
@@ -713,6 +1126,11 @@ impl Encode for Request {
                 Self::KeyScancode { .. } => 2 /* scancode */ + 1 /* pressed */,
                 Self::KeyUnicode { .. } => 4 /* ch */ + 1 /* pressed */,
                 Self::Resize { .. } => 2 /* width */ + 2 /* height */,
+                Self::NowRun { command, directory } => string_size(command) + opt_string_size(directory.as_deref()),
+                Self::NowExecute(request) => request.size(),
+                Self::NowCancel { .. } | Self::NowStatus { .. } => 8,
+                Self::NowAttach { after_sequence, .. } => 8 /* operation_id */ + opt_u64_size(*after_sequence),
+                Self::NowStdin { data, .. } => 8 /* operation_id */ + bytes_size(data) + 1 /* last */,
             }
     }
 }
@@ -789,9 +1207,517 @@ impl Decode<'_> for Request {
                 let height = src.read_u16();
                 Ok(Self::Resize { width, height })
             }
+            12 => Ok(Self::NowCapabilities),
+            13 => Ok(Self::NowRun {
+                command: read_string(src)?,
+                directory: read_opt_string(src)?,
+            }),
+            14 => Ok(Self::NowExecute(NowExecutionRequest::decode(src)?)),
+            15 => {
+                ensure_size!(in: src, size: 8);
+                Ok(Self::NowCancel {
+                    operation_id: src.read_u64(),
+                })
+            }
+            16 => Ok(Self::NowList),
+            17 => {
+                ensure_size!(in: src, size: 8);
+                Ok(Self::NowStatus {
+                    operation_id: src.read_u64(),
+                })
+            }
+            18 => {
+                ensure_size!(in: src, size: 8);
+                let operation_id = src.read_u64();
+                let after_sequence = read_opt_u64(src)?;
+                Ok(Self::NowAttach {
+                    operation_id,
+                    after_sequence,
+                })
+            }
+            19 => {
+                ensure_size!(in: src, size: 8);
+                let operation_id = src.read_u64();
+                let data = read_bytes(src)?;
+                let last = read_bool(src)?;
+                Ok(Self::NowStdin {
+                    operation_id,
+                    data,
+                    last,
+                })
+            }
+            20 => Ok(Self::NowDiagnostics),
             _ => Err(ironrdp_core::invalid_field_err!("request", "unknown tag")),
         }
     }
 }
 
 impl_pdu_pod!(Request);
+
+// ── NOW IPC codec ──────────────────────────────────────────────────────────
+
+fn write_error_category(dst: &mut WriteCursor<'_>, category: AgentErrorCategory) {
+    dst.write_u8(match category {
+        AgentErrorCategory::InvalidRequest => 0,
+        AgentErrorCategory::Unavailable => 1,
+        AgentErrorCategory::Conflict => 2,
+        AgentErrorCategory::Transport => 3,
+        AgentErrorCategory::Remote => 4,
+        AgentErrorCategory::Internal => 5,
+    });
+}
+
+fn read_error_category(src: &mut ReadCursor<'_>) -> DecodeResult<AgentErrorCategory> {
+    ensure_size!(in: src, size: 1);
+    match src.read_u8() {
+        0 => Ok(AgentErrorCategory::InvalidRequest),
+        1 => Ok(AgentErrorCategory::Unavailable),
+        2 => Ok(AgentErrorCategory::Conflict),
+        3 => Ok(AgentErrorCategory::Transport),
+        4 => Ok(AgentErrorCategory::Remote),
+        5 => Ok(AgentErrorCategory::Internal),
+        _ => Err(ironrdp_core::invalid_field_err!("agent error category", "unknown tag")),
+    }
+}
+
+impl Encode for AgentError {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        write_error_category(dst, self.category);
+        write_string(dst, &self.message)
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_agent::AgentError"
+    }
+
+    fn size(&self) -> usize {
+        1 /* category */ + string_size(&self.message)
+    }
+}
+
+impl Decode<'_> for AgentError {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        Ok(Self {
+            category: read_error_category(src)?,
+            message: read_string(src)?,
+        })
+    }
+}
+
+impl_pdu_pod!(AgentError);
+
+fn write_execution_kind(dst: &mut WriteCursor<'_>, kind: NowExecutionKind) {
+    dst.write_u8(match kind {
+        NowExecutionKind::Process => 0,
+        NowExecutionKind::Batch => 1,
+        NowExecutionKind::PowerShell => 2,
+        NowExecutionKind::Pwsh => 3,
+    });
+}
+
+fn read_execution_kind(src: &mut ReadCursor<'_>) -> DecodeResult<NowExecutionKind> {
+    ensure_size!(in: src, size: 1);
+    match src.read_u8() {
+        0 => Ok(NowExecutionKind::Process),
+        1 => Ok(NowExecutionKind::Batch),
+        2 => Ok(NowExecutionKind::PowerShell),
+        3 => Ok(NowExecutionKind::Pwsh),
+        _ => Err(ironrdp_core::invalid_field_err!("NOW execution kind", "unknown tag")),
+    }
+}
+
+impl Encode for NowExecutionRequest {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        write_execution_kind(dst, self.kind);
+        write_string(dst, &self.command)?;
+        write_opt_string(dst, self.parameters.as_deref())?;
+        write_opt_string(dst, self.directory.as_deref())?;
+        match &self.stdin {
+            Some(data) => {
+                dst.write_u8(1);
+                write_bytes(dst, data)?;
+            }
+            None => dst.write_u8(0),
+        }
+        write_opt_u64(dst, self.timeout_ms)?;
+        write_bool(dst, self.detached)?;
+        write_bool(dst, self.no_profile)?;
+        write_bool(dst, self.non_interactive)
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_agent::NowExecutionRequest"
+    }
+
+    fn size(&self) -> usize {
+        1 /* kind */
+            + string_size(&self.command)
+            + opt_string_size(self.parameters.as_deref())
+            + opt_string_size(self.directory.as_deref())
+            + 1 /* stdin presence */
+            + self.stdin.as_ref().map_or(0, |data| bytes_size(data))
+            + opt_u64_size(self.timeout_ms)
+            + 1 /* detached */
+            + 1 /* no_profile */
+            + 1 /* non_interactive */
+    }
+}
+
+impl Decode<'_> for NowExecutionRequest {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        let kind = read_execution_kind(src)?;
+        let command = read_string(src)?;
+        let parameters = read_opt_string(src)?;
+        let directory = read_opt_string(src)?;
+        ensure_size!(in: src, size: 1);
+        let stdin = match src.read_u8() {
+            0 => None,
+            1 => Some(read_bytes(src)?),
+            _ => return Err(ironrdp_core::invalid_field_err!("NOW stdin", "invalid presence flag")),
+        };
+        Ok(Self {
+            kind,
+            command,
+            parameters,
+            directory,
+            stdin,
+            timeout_ms: read_opt_u64(src)?,
+            detached: read_bool(src)?,
+            no_profile: read_bool(src)?,
+            non_interactive: read_bool(src)?,
+        })
+    }
+}
+
+impl_pdu_pod!(NowExecutionRequest);
+
+fn write_operation_state(dst: &mut WriteCursor<'_>, state: OperationState) {
+    dst.write_u8(match state {
+        OperationState::Running => 0,
+        OperationState::Cancelling => 1,
+        OperationState::Completed => 2,
+        OperationState::Cancelled => 3,
+        OperationState::Failed => 4,
+        OperationState::Detached => 5,
+    });
+}
+
+fn read_operation_state(src: &mut ReadCursor<'_>) -> DecodeResult<OperationState> {
+    ensure_size!(in: src, size: 1);
+    match src.read_u8() {
+        0 => Ok(OperationState::Running),
+        1 => Ok(OperationState::Cancelling),
+        2 => Ok(OperationState::Completed),
+        3 => Ok(OperationState::Cancelled),
+        4 => Ok(OperationState::Failed),
+        5 => Ok(OperationState::Detached),
+        _ => Err(ironrdp_core::invalid_field_err!("operation state", "unknown tag")),
+    }
+}
+
+impl Encode for OperationInfo {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u64(self.id);
+        write_execution_kind(dst, self.kind);
+        write_operation_state(dst, self.state);
+        write_bool(dst, self.detached)?;
+        match self.exit_code {
+            Some(exit_code) => {
+                dst.write_u8(1);
+                dst.write_u32(exit_code);
+            }
+            None => dst.write_u8(0),
+        }
+        match &self.error {
+            Some(error) => {
+                dst.write_u8(1);
+                error.encode(dst)?;
+            }
+            None => dst.write_u8(0),
+        }
+        dst.write_u64(self.retained_output_bytes);
+        dst.write_u64(self.next_sequence);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_agent::OperationInfo"
+    }
+
+    fn size(&self) -> usize {
+        8 /* id */
+            + 1 /* kind */
+            + 1 /* state */
+            + 1 /* detached */
+            + 1 /* exit-code presence */
+            + self.exit_code.map_or(0, |_| 4)
+            + 1 /* error presence */
+            + self.error.as_ref().map_or(0, Encode::size)
+            + 8 /* retained_output_bytes */
+            + 8 /* next_sequence */
+    }
+}
+
+impl Decode<'_> for OperationInfo {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 8);
+        let id = src.read_u64();
+        let kind = read_execution_kind(src)?;
+        let state = read_operation_state(src)?;
+        let detached = read_bool(src)?;
+        ensure_size!(in: src, size: 1);
+        let exit_code = match src.read_u8() {
+            0 => None,
+            1 => {
+                ensure_size!(in: src, size: 4);
+                Some(src.read_u32())
+            }
+            _ => return Err(ironrdp_core::invalid_field_err!("exit code", "invalid presence flag")),
+        };
+        ensure_size!(in: src, size: 1);
+        let error = match src.read_u8() {
+            0 => None,
+            1 => Some(AgentError::decode(src)?),
+            _ => {
+                return Err(ironrdp_core::invalid_field_err!(
+                    "operation error",
+                    "invalid presence flag"
+                ));
+            }
+        };
+        ensure_size!(in: src, size: 16);
+        Ok(Self {
+            id,
+            kind,
+            state,
+            detached,
+            exit_code,
+            error,
+            retained_output_bytes: src.read_u64(),
+            next_sequence: src.read_u64(),
+        })
+    }
+}
+
+impl_pdu_pod!(OperationInfo);
+
+fn write_stream(dst: &mut WriteCursor<'_>, stream: NowStream) {
+    dst.write_u8(match stream {
+        NowStream::Stdout => 0,
+        NowStream::Stderr => 1,
+    });
+}
+
+fn read_stream(src: &mut ReadCursor<'_>) -> DecodeResult<NowStream> {
+    ensure_size!(in: src, size: 1);
+    match src.read_u8() {
+        0 => Ok(NowStream::Stdout),
+        1 => Ok(NowStream::Stderr),
+        _ => Err(ironrdp_core::invalid_field_err!("NOW output stream", "unknown tag")),
+    }
+}
+
+impl Encode for OperationEventKind {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        match self {
+            Self::Started => dst.write_u8(0),
+            Self::Output { stream, data, last } => {
+                dst.write_u8(1);
+                write_stream(dst, *stream);
+                write_bytes(dst, data)?;
+                write_bool(dst, *last)?;
+            }
+            Self::CancelAccepted => dst.write_u8(2),
+            Self::Completed { exit_code } => {
+                dst.write_u8(3);
+                dst.write_u32(*exit_code);
+            }
+            Self::Cancelled => dst.write_u8(4),
+            Self::Failed(error) => {
+                dst.write_u8(5);
+                error.encode(dst)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_agent::OperationEventKind"
+    }
+
+    fn size(&self) -> usize {
+        1 /* tag */
+            + match self {
+                Self::Started | Self::CancelAccepted | Self::Cancelled => 0,
+                Self::Output { data, .. } => 1 /* stream */ + bytes_size(data) + 1 /* last */,
+                Self::Completed { .. } => 4,
+                Self::Failed(error) => error.size(),
+            }
+    }
+}
+
+impl Decode<'_> for OperationEventKind {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 1);
+        match src.read_u8() {
+            0 => Ok(Self::Started),
+            1 => Ok(Self::Output {
+                stream: read_stream(src)?,
+                data: read_bytes(src)?,
+                last: read_bool(src)?,
+            }),
+            2 => Ok(Self::CancelAccepted),
+            3 => {
+                ensure_size!(in: src, size: 4);
+                Ok(Self::Completed {
+                    exit_code: src.read_u32(),
+                })
+            }
+            4 => Ok(Self::Cancelled),
+            5 => Ok(Self::Failed(AgentError::decode(src)?)),
+            _ => Err(ironrdp_core::invalid_field_err!("operation event", "unknown tag")),
+        }
+    }
+}
+
+impl_pdu_pod!(OperationEventKind);
+
+impl Encode for OperationEvent {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u64(self.operation_id);
+        dst.write_u64(self.sequence);
+        self.kind.encode(dst)
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_agent::OperationEvent"
+    }
+
+    fn size(&self) -> usize {
+        8 /* operation_id */ + 8 /* sequence */ + self.kind.size()
+    }
+}
+
+impl Decode<'_> for OperationEvent {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 16);
+        Ok(Self {
+            operation_id: src.read_u64(),
+            sequence: src.read_u64(),
+            kind: OperationEventKind::decode(src)?,
+        })
+    }
+}
+
+impl_pdu_pod!(OperationEvent);
+
+impl Encode for NowCapabilities {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u16(self.version_major);
+        dst.write_u16(self.version_minor);
+        write_opt_u64(dst, self.heartbeat_ms)?;
+        for value in [
+            self.run,
+            self.process,
+            self.batch,
+            self.powershell,
+            self.pwsh,
+            self.io_redirection,
+            self.unicode_console,
+        ] {
+            write_bool(dst, value)?;
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_agent::NowCapabilities"
+    }
+
+    fn size(&self) -> usize {
+        2 /* version major */
+            + 2 /* version minor */
+            + opt_u64_size(self.heartbeat_ms)
+            + 7 /* feature flags */
+    }
+}
+
+impl Decode<'_> for NowCapabilities {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 4);
+        let version_major = src.read_u16();
+        let version_minor = src.read_u16();
+        Ok(Self {
+            version_major,
+            version_minor,
+            heartbeat_ms: read_opt_u64(src)?,
+            run: read_bool(src)?,
+            process: read_bool(src)?,
+            batch: read_bool(src)?,
+            powershell: read_bool(src)?,
+            pwsh: read_bool(src)?,
+            io_redirection: read_bool(src)?,
+            unicode_console: read_bool(src)?,
+        })
+    }
+}
+
+impl_pdu_pod!(NowCapabilities);
+
+impl Encode for NowDiagnostics {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        write_bool(dst, self.endpoint_allocated)?;
+        write_bool(dst, self.connected)?;
+        match &self.capabilities {
+            Some(capabilities) => {
+                dst.write_u8(1);
+                capabilities.encode(dst)?;
+            }
+            None => dst.write_u8(0),
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_agent::NowDiagnostics"
+    }
+
+    fn size(&self) -> usize {
+        1 /* endpoint_allocated */
+            + 1 /* connected */
+            + 1 /* capabilities presence */
+            + self.capabilities.as_ref().map_or(0, Encode::size)
+    }
+}
+
+impl Decode<'_> for NowDiagnostics {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        let endpoint_allocated = read_bool(src)?;
+        let connected = read_bool(src)?;
+        ensure_size!(in: src, size: 1);
+        let capabilities = match src.read_u8() {
+            0 => None,
+            1 => Some(NowCapabilities::decode(src)?),
+            _ => {
+                return Err(ironrdp_core::invalid_field_err!(
+                    "NOW capabilities",
+                    "invalid presence flag"
+                ));
+            }
+        };
+        Ok(Self {
+            endpoint_allocated,
+            connected,
+            capabilities,
+        })
+    }
+}
+
+impl_pdu_pod!(NowDiagnostics);

--- a/crates/ironrdp-agent/src/ipc.rs
+++ b/crates/ironrdp-agent/src/ipc.rs
@@ -296,6 +296,20 @@ pub enum AgentErrorCategory {
     Internal,
 }
 
+impl AgentErrorCategory {
+    /// Stable lowercase category used by structured CLI output.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::InvalidRequest => "invalid_request",
+            Self::Unavailable => "unavailable",
+            Self::Conflict => "conflict",
+            Self::Transport => "transport",
+            Self::Remote => "remote",
+            Self::Internal => "internal",
+        }
+    }
+}
+
 /// Typed IPC error response.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AgentError {

--- a/crates/ironrdp-agent/src/lib.rs
+++ b/crates/ironrdp-agent/src/lib.rs
@@ -13,6 +13,8 @@
 pub mod cli;
 pub mod daemon;
 pub mod ipc;
+pub mod now;
+pub mod operations;
 pub mod transport;
 
 pub(crate) mod help;

--- a/crates/ironrdp-agent/src/now.rs
+++ b/crates/ironrdp-agent/src/now.rs
@@ -1,0 +1,429 @@
+//! Agent-owned boundary between the RDP DVC proxy and `now-client`.
+//!
+//! NOW framing, negotiation, heartbeats, request encoding, and execution lifecycle all belong to
+//! `now-client`. This module deliberately only creates a per-session local endpoint, waits for the
+//! DVC proxy to expose it, and caches a connected client handle.
+
+use core::sync::atomic::{AtomicU64, Ordering};
+use core::time::Duration;
+use std::fmt;
+
+use ironrdp_client::config::DvcProxyInfo;
+use now_client::{NowCapabilities, NowClient, NowClientConfig, NowClientError, NowClientHandle};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::sync::Mutex;
+use tokio::time::{Instant, sleep};
+
+/// The fixed DVC channel exposed by the NOW agent plugin.
+pub const DVC_CHANNEL_NAME: &str = "Devolutions::Now::Agent";
+/// First local DVC endpoint readiness deadline.
+pub const INITIAL_ENDPOINT_TIMEOUT: Duration = Duration::from_secs(30);
+/// Replacement local DVC endpoint readiness deadline after a previous connection.
+pub const RECONNECT_ENDPOINT_TIMEOUT: Duration = Duration::from_secs(10);
+const RETRY_DELAY: Duration = Duration::from_millis(100);
+static NEXT_ENDPOINT_ID: AtomicU64 = AtomicU64::new(1);
+
+/// A summarized capability snapshot suitable for agent IPC.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Capabilities {
+    /// NOW protocol major version.
+    pub version_major: u16,
+    /// NOW protocol minor version.
+    pub version_minor: u16,
+    /// The negotiated heartbeat period in milliseconds, if one is active.
+    pub heartbeat_ms: Option<u64>,
+    /// Whether generic `Run` requests are supported.
+    pub run: bool,
+    /// Whether Windows CreateProcess requests are supported.
+    pub process: bool,
+    /// Whether batch requests are supported.
+    pub batch: bool,
+    /// Whether Windows PowerShell requests are supported.
+    pub powershell: bool,
+    /// Whether PowerShell 7 requests are supported.
+    pub pwsh: bool,
+    /// Whether tracked stdin/stdout/stderr redirection is supported.
+    pub io_redirection: bool,
+    /// Whether UTF-8 console output is supported.
+    pub unicode_console: bool,
+}
+
+impl From<NowCapabilities> for Capabilities {
+    fn from(value: NowCapabilities) -> Self {
+        let version = value.version();
+        Self {
+            version_major: version.major,
+            version_minor: version.minor,
+            heartbeat_ms: value
+                .heartbeat_interval()
+                .map(|interval| u64::try_from(interval.as_millis()).unwrap_or(u64::MAX)),
+            run: value.supports_run(),
+            process: value.supports_process(),
+            batch: value.supports_batch(),
+            powershell: value.supports_win_ps(),
+            pwsh: value.supports_pwsh(),
+            io_redirection: value.supports_io_redirection(),
+            unicode_console: value.supports_unicode_console(),
+        }
+    }
+}
+
+/// Failures at the local agent/DVC boundary.
+#[derive(Debug)]
+pub enum NowEndpointError {
+    /// The proxy did not expose its local endpoint by the prescribed deadline.
+    Unavailable {
+        /// The deadline used for this connection attempt.
+        timeout: Duration,
+        /// The last local connection error, when one was available.
+        last_error: Option<String>,
+    },
+    /// `now-client` rejected the local stream or its peer.
+    Client(NowClientError),
+}
+
+impl fmt::Display for NowEndpointError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unavailable {
+                timeout,
+                last_error: Some(error),
+            } => write!(
+                f,
+                "NOW DVC endpoint did not become available within {} seconds: {error}",
+                timeout.as_secs()
+            ),
+            Self::Unavailable {
+                timeout,
+                last_error: None,
+            } => write!(
+                f,
+                "NOW DVC endpoint did not become available within {} seconds",
+                timeout.as_secs()
+            ),
+            Self::Client(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl core::error::Error for NowEndpointError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::Client(error) => Some(error),
+            Self::Unavailable { .. } => None,
+        }
+    }
+}
+
+struct EndpointState {
+    handle: Option<NowClientHandle>,
+    connected_once: bool,
+}
+
+/// Per-RDP-session endpoint and cached NOW client.
+///
+/// Construct this before building an RDP [`ironrdp_client::config::Config`], inject
+/// [`Self::dvc_proxy_info`] into its builder, and retain the value for the lifetime of that
+/// session. It intentionally does no I/O until [`Self::handle`] is first called.
+pub struct NowEndpoint {
+    pipe_name: String,
+    state: Mutex<EndpointState>,
+}
+
+impl fmt::Debug for NowEndpoint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("NowEndpoint")
+            .field("pipe_name", &self.pipe_name)
+            .finish_non_exhaustive()
+    }
+}
+
+impl NowEndpoint {
+    /// Allocates a unique endpoint for one RDP session.
+    pub fn new() -> Self {
+        let id = NEXT_ENDPOINT_ID.fetch_add(1, Ordering::Relaxed);
+        let pid = std::process::id();
+        #[cfg(unix)]
+        let pipe_name = {
+            let root = std::env::var_os("XDG_RUNTIME_DIR")
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(std::env::temp_dir);
+            root.join(format!("ironrdp-now-agent-{pid}-{id}.sock"))
+                .to_string_lossy()
+                .into_owned()
+        };
+        #[cfg(windows)]
+        let pipe_name = format!("ironrdp-now-agent-{pid}-{id}");
+
+        Self {
+            pipe_name,
+            state: Mutex::new(EndpointState {
+                handle: None,
+                connected_once: false,
+            }),
+        }
+    }
+
+    /// Returns the agent's DVC proxy mapping for this endpoint.
+    pub fn dvc_proxy_info(&self) -> DvcProxyInfo {
+        DvcProxyInfo {
+            channel_name: DVC_CHANNEL_NAME.to_owned(),
+            pipe_name: self.pipe_name.clone(),
+        }
+    }
+
+    /// Returns the local endpoint name. Windows returns the intentionally unqualified pipe name.
+    pub fn pipe_name(&self) -> &str {
+        &self.pipe_name
+    }
+
+    /// Gets the cached handle or waits for the DVC proxy, connects it, and negotiates NOW.
+    ///
+    /// The first successful connection has a 30-second readiness deadline. Every later replacement
+    /// has a 10-second deadline.
+    pub async fn handle(&self) -> Result<NowClientHandle, NowEndpointError> {
+        let mut state = self.state.lock().await;
+        if let Some(handle) = &state.handle {
+            return Ok(handle.clone());
+        }
+
+        let timeout = if state.connected_once {
+            RECONNECT_ENDPOINT_TIMEOUT
+        } else {
+            INITIAL_ENDPOINT_TIMEOUT
+        };
+        let handle = self.connect(timeout).await?;
+        state.connected_once = true;
+        state.handle = Some(handle.clone());
+        Ok(handle)
+    }
+
+    /// Discards a potentially unusable worker. The next operation reconnects with the replacement
+    /// deadline rather than attempting to reuse a closed NOW command queue.
+    pub async fn invalidate(&self) {
+        self.state.lock().await.handle = None;
+    }
+
+    /// Returns the currently cached capability snapshot without initiating a local connection.
+    pub async fn cached_capabilities(&self) -> Option<Capabilities> {
+        self.state
+            .lock()
+            .await
+            .handle
+            .as_ref()
+            .map(|handle| handle.capabilities().into())
+    }
+
+    /// Whether a negotiated NOW client is currently cached.
+    pub async fn is_connected(&self) -> bool {
+        self.state.lock().await.handle.is_some()
+    }
+
+    async fn connect(&self, timeout: Duration) -> Result<NowClientHandle, NowEndpointError> {
+        let deadline = Instant::now() + timeout;
+        let mut last_error: Option<String>;
+
+        loop {
+            match self.connect_once().await {
+                Ok(handle) => return Ok(handle),
+                Err(ConnectAttemptError::Client(error)) => return Err(NowEndpointError::Client(error)),
+                Err(ConnectAttemptError::Io(error)) => last_error = Some(error.to_string()),
+            }
+
+            if Instant::now() >= deadline {
+                return Err(NowEndpointError::Unavailable { timeout, last_error });
+            }
+
+            sleep(RETRY_DELAY).await;
+        }
+    }
+
+    #[cfg(unix)]
+    async fn connect_once(&self) -> Result<NowClientHandle, ConnectAttemptError> {
+        let stream = tokio::net::UnixStream::connect(&self.pipe_name)
+            .await
+            .map_err(ConnectAttemptError::Io)?;
+        connect_stream(stream).await.map_err(ConnectAttemptError::Client)
+    }
+
+    #[cfg(windows)]
+    async fn connect_once(&self) -> Result<NowClientHandle, ConnectAttemptError> {
+        let path = format!(r"\\.\pipe\{}", self.pipe_name);
+        let stream = tokio::net::windows::named_pipe::ClientOptions::new()
+            .open(path)
+            .map_err(ConnectAttemptError::Io)?;
+        connect_stream(stream).await.map_err(ConnectAttemptError::Client)
+    }
+}
+
+async fn connect_stream<S>(stream: S) -> Result<NowClientHandle, NowClientError>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    NowClient::connect(stream, NowClientConfig::default()).await
+}
+
+impl Default for NowEndpoint {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+enum ConnectAttemptError {
+    Io(std::io::Error),
+    Client(NowClientError),
+}
+
+/// Whether an error means the cached client must be replaced before another request.
+pub fn invalidates_handle(error: &NowClientError) -> bool {
+    matches!(
+        error,
+        NowClientError::Io(_)
+            | NowClientError::PduEncode(_)
+            | NowClientError::PduDecode(_)
+            | NowClientError::Protocol(_)
+            | NowClientError::FrameTooLarge { .. }
+            | NowClientError::FrameBufferTooLarge { .. }
+            | NowClientError::WorkerClosed(_)
+            | NowClientError::EventQueueFull { .. }
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use now_client::{ExecutionEvent, ExecutionStatus, ProcessRequest, RunRequest};
+    use now_proto_pdu::ironrdp_core::{Decode as _, IntoOwned as _, ReadCursor, encode_vec};
+    use now_proto_pdu::{
+        NowChannelCapsetMsg, NowExecCapsetFlags, NowExecDataMsg, NowExecDataStreamKind, NowExecMessage,
+        NowExecResultMsg, NowExecStartedMsg, NowMessage,
+    };
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    use super::*;
+
+    fn encode(message: impl Into<NowMessage<'static>>) -> Vec<u8> {
+        encode_vec(&message.into()).expect("test NOW PDU must encode")
+    }
+
+    async fn read_message<S>(stream: &mut S) -> NowMessage<'static>
+    where
+        S: AsyncRead + Unpin,
+    {
+        let mut header = [0; 8];
+        stream
+            .read_exact(&mut header)
+            .await
+            .expect("test peer must receive a header");
+        let body_size = usize::try_from(u32::from_le_bytes(
+            header[..4].try_into().expect("header is four bytes"),
+        ))
+        .expect("u32 fits usize");
+        let mut bytes = header.to_vec();
+        bytes.resize(8 + body_size, 0);
+        stream
+            .read_exact(&mut bytes[8..])
+            .await
+            .expect("test peer must receive a body");
+        let mut cursor = ReadCursor::new(&bytes);
+        NowMessage::decode(&mut cursor)
+            .expect("test peer must decode a NOW PDU")
+            .into_owned()
+    }
+
+    async fn write_message<S>(stream: &mut S, message: impl Into<NowMessage<'static>>)
+    where
+        S: AsyncWrite + Unpin,
+    {
+        stream
+            .write_all(&encode(message))
+            .await
+            .expect("test peer must write a NOW PDU");
+    }
+
+    #[test]
+    fn endpoint_names_are_unique_and_use_the_agent_channel() {
+        let first = NowEndpoint::new();
+        let second = NowEndpoint::new();
+
+        assert_ne!(first.pipe_name(), second.pipe_name());
+        assert_eq!(first.dvc_proxy_info().channel_name, DVC_CHANNEL_NAME);
+        #[cfg(windows)]
+        assert!(!first.pipe_name().starts_with(r"\\.\pipe\"));
+    }
+
+    #[test]
+    fn connection_deadlines_match_the_reconnect_policy() {
+        assert_eq!(INITIAL_ENDPOINT_TIMEOUT, Duration::from_secs(30));
+        assert_eq!(RECONNECT_ENDPOINT_TIMEOUT, Duration::from_secs(10));
+    }
+
+    #[tokio::test]
+    async fn adapter_discards_immediate_run_frames_before_process() {
+        let (client_stream, mut peer_stream) = tokio::io::duplex(4096);
+        let peer = tokio::spawn(async move {
+            let _ = read_message(&mut peer_stream).await;
+            let capset = NowChannelCapsetMsg::default().with_exec_capset(
+                NowExecCapsetFlags::STYLE_RUN | NowExecCapsetFlags::STYLE_PROCESS | NowExecCapsetFlags::IO_REDIRECTION,
+            );
+            write_message(&mut peer_stream, capset).await;
+
+            let run_session = match read_message(&mut peer_stream).await {
+                NowMessage::Exec(NowExecMessage::Run(message)) => message.session_id(),
+                message => panic!("expected Run request, got {message:?}"),
+            };
+            write_message(&mut peer_stream, NowExecStartedMsg::new(run_session)).await;
+            write_message(
+                &mut peer_stream,
+                NowExecDataMsg::new(run_session, NowExecDataStreamKind::Stdout, true, vec![0xaa, 0xbb])
+                    .expect("test Run data PDU must encode"),
+            )
+            .await;
+            write_message(&mut peer_stream, NowExecResultMsg::new_success(run_session, 0)).await;
+
+            let process_session = match read_message(&mut peer_stream).await {
+                NowMessage::Exec(NowExecMessage::Process(message)) => message.session_id(),
+                message => panic!("expected Process request, got {message:?}"),
+            };
+            write_message(&mut peer_stream, NowExecStartedMsg::new(process_session)).await;
+            write_message(
+                &mut peer_stream,
+                NowExecDataMsg::new(
+                    process_session,
+                    NowExecDataStreamKind::Stdout,
+                    true,
+                    vec![0xff, 0x00, 0x80],
+                )
+                .expect("test Process data PDU must encode"),
+            )
+            .await;
+            write_message(&mut peer_stream, NowExecResultMsg::new_success(process_session, 17)).await;
+        });
+
+        let handle = connect_stream(client_stream)
+            .await
+            .expect("adapter connection must succeed");
+        handle
+            .run(RunRequest::new("run.exe"))
+            .await
+            .expect("Run request must be accepted");
+        let mut process = handle
+            .process(ProcessRequest::new("process.exe"))
+            .await
+            .expect("Process request must start");
+
+        assert_eq!(process.next_event().await, Some(ExecutionEvent::Started));
+        assert_eq!(
+            process.next_event().await,
+            Some(ExecutionEvent::Stdout {
+                data: vec![0xff, 0x00, 0x80],
+                last: true,
+            })
+        );
+        match process.wait().await {
+            Ok(ExecutionStatus::Completed { exit_code: 17 }) => {}
+            Ok(status) => panic!("Process returned unexpected status: {status:?}"),
+            Err(error) => panic!("Process must complete: {error}"),
+        }
+        peer.await.expect("test peer task must complete");
+    }
+}

--- a/crates/ironrdp-agent/src/now.rs
+++ b/crates/ironrdp-agent/src/now.rs
@@ -4,7 +4,6 @@
 //! `now-client`. This module deliberately only creates a per-session local endpoint, waits for the
 //! DVC proxy to expose it, and caches a connected client handle.
 
-use core::sync::atomic::{AtomicU64, Ordering};
 use core::time::Duration;
 use std::fmt;
 
@@ -13,6 +12,7 @@ use now_client::{NowCapabilities, NowClient, NowClientConfig, NowClientError, No
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::Mutex;
 use tokio::time::{Instant, sleep};
+use uuid::Uuid;
 
 /// The fixed DVC channel exposed by the NOW agent plugin.
 pub const DVC_CHANNEL_NAME: &str = "Devolutions::Now::Agent";
@@ -21,7 +21,6 @@ pub const INITIAL_ENDPOINT_TIMEOUT: Duration = Duration::from_secs(30);
 /// Replacement local DVC endpoint readiness deadline after a previous connection.
 pub const RECONNECT_ENDPOINT_TIMEOUT: Duration = Duration::from_secs(10);
 const RETRY_DELAY: Duration = Duration::from_millis(100);
-static NEXT_ENDPOINT_ID: AtomicU64 = AtomicU64::new(1);
 
 /// A summarized capability snapshot suitable for agent IPC.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -140,28 +139,23 @@ impl fmt::Debug for NowEndpoint {
 
 impl NowEndpoint {
     /// Allocates a unique endpoint for one RDP session.
-    pub fn new() -> Self {
-        let id = NEXT_ENDPOINT_ID.fetch_add(1, Ordering::Relaxed);
-        let pid = std::process::id();
+    pub fn new() -> std::io::Result<Self> {
+        let id = Uuid::new_v4();
         #[cfg(unix)]
         let pipe_name = {
-            let root = std::env::var_os("XDG_RUNTIME_DIR")
-                .map(std::path::PathBuf::from)
-                .unwrap_or_else(std::env::temp_dir);
-            root.join(format!("ironrdp-now-agent-{pid}-{id}.sock"))
-                .to_string_lossy()
-                .into_owned()
+            let root = private_runtime_directory()?;
+            root.join(format!("now-agent-{id}.sock")).to_string_lossy().into_owned()
         };
         #[cfg(windows)]
-        let pipe_name = format!("ironrdp-now-agent-{pid}-{id}");
+        let pipe_name = format!("ironrdp-now-agent-{id}");
 
-        Self {
+        Ok(Self {
             pipe_name,
             state: Mutex::new(EndpointState {
                 handle: None,
                 connected_once: false,
             }),
-        }
+        })
     }
 
     /// Returns the agent's DVC proxy mapping for this endpoint.
@@ -204,19 +198,11 @@ impl NowEndpoint {
         self.state.lock().await.handle = None;
     }
 
-    /// Returns the currently cached capability snapshot without initiating a local connection.
-    pub async fn cached_capabilities(&self) -> Option<Capabilities> {
-        self.state
-            .lock()
-            .await
-            .handle
-            .as_ref()
-            .map(|handle| handle.capabilities().into())
-    }
-
-    /// Whether a negotiated NOW client is currently cached.
-    pub async fn is_connected(&self) -> bool {
-        self.state.lock().await.handle.is_some()
+    /// Returns a consistent local diagnostic snapshot without initiating a connection.
+    pub async fn diagnostic_snapshot(&self) -> (bool, Option<Capabilities>) {
+        let state = self.state.lock().await;
+        let capabilities = state.handle.as_ref().map(|handle| handle.capabilities().into());
+        (state.handle.is_some(), capabilities)
     }
 
     async fn connect(&self, timeout: Duration) -> Result<NowClientHandle, NowEndpointError> {
@@ -263,15 +249,48 @@ where
     NowClient::connect(stream, NowClientConfig::default()).await
 }
 
-impl Default for NowEndpoint {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 enum ConnectAttemptError {
     Io(std::io::Error),
     Client(NowClientError),
+}
+
+#[cfg(unix)]
+fn private_runtime_directory() -> std::io::Result<std::path::PathBuf> {
+    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+    let root = match std::env::var_os("XDG_RUNTIME_DIR") {
+        Some(root) => std::path::PathBuf::from(root),
+        None => {
+            let home = std::env::var_os("HOME").ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "HOME is required when XDG_RUNTIME_DIR is unset",
+                )
+            })?;
+            std::path::PathBuf::from(home).join(".local").join("state")
+        }
+    };
+    let directory = root.join("ironrdp-agent");
+    std::fs::create_dir_all(&directory)?;
+    std::fs::set_permissions(&directory, std::fs::Permissions::from_mode(0o700))?;
+
+    let metadata = std::fs::symlink_metadata(&directory)?;
+    if metadata.file_type().is_symlink() || !metadata.file_type().is_dir() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "NOW runtime path is not a directory",
+        ));
+    }
+    // SAFETY: `getuid` has no preconditions and is always safe to call.
+    let uid = unsafe { libc::getuid() };
+    if metadata.uid() != uid || metadata.mode() & 0o077 != 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "NOW runtime directory is not private to the current user",
+        ));
+    }
+
+    Ok(directory)
 }
 
 /// Whether an error means the cached client must be replaced before another request.
@@ -342,8 +361,8 @@ mod tests {
 
     #[test]
     fn endpoint_names_are_unique_and_use_the_agent_channel() {
-        let first = NowEndpoint::new();
-        let second = NowEndpoint::new();
+        let first = NowEndpoint::new().expect("endpoint allocation must succeed");
+        let second = NowEndpoint::new().expect("endpoint allocation must succeed");
 
         assert_ne!(first.pipe_name(), second.pipe_name());
         assert_eq!(first.dvc_proxy_info().channel_name, DVC_CHANNEL_NAME);

--- a/crates/ironrdp-agent/src/operations.rs
+++ b/crates/ironrdp-agent/src/operations.rs
@@ -1,0 +1,907 @@
+//! Durable daemon-side NOW operation retention.
+//!
+//! The NOW protocol worker remains entirely in `now-client`; this module translates its public
+//! request/event API into daemon-owned operation IDs, bounded replay, and IPC subscriptions.
+
+use core::time::Duration;
+use std::collections::{BTreeMap, VecDeque};
+use std::sync::{Arc, Mutex};
+
+use now_client::{
+    BatchRequest, Execution, ExecutionEvent, ExecutionStatus, NowClientError, ProcessRequest, PwshRequest, RunRequest,
+    WinPsRequest,
+};
+use tokio::sync::{mpsc, oneshot};
+
+use crate::ipc::{
+    AgentError, AgentErrorCategory, NowCapabilities, NowExecutionKind, NowExecutionRequest, NowStream, OperationEvent,
+    OperationEventKind, OperationInfo, OperationState,
+};
+use crate::now::{Capabilities, NowEndpoint, NowEndpointError, invalidates_handle};
+
+const MAX_OPERATION_OUTPUT: usize = 8 * 1024 * 1024;
+const MAX_TERMINAL_OPERATIONS: usize = 32;
+const MAX_TOTAL_OUTPUT: usize = 32 * 1024 * 1024;
+const MAX_STDIN_CHUNK: usize = 1024 * 1024;
+const MAX_IPC_OUTPUT_CHUNK: usize = 1024 * 1024;
+const MAX_LIVE_SUBSCRIBERS: usize = 8;
+const LIVE_SUBSCRIBER_QUEUE_CAPACITY: usize = 1;
+
+/// Durable NOW operation manager for one RDP session.
+#[derive(Clone)]
+pub struct OperationManager {
+    endpoint: Arc<NowEndpoint>,
+    state: Arc<Mutex<OperationStateStore>>,
+}
+
+struct OperationStateStore {
+    next_id: u64,
+    starting: bool,
+    active: Option<ActiveOperation>,
+    records: BTreeMap<u64, OperationRecord>,
+    terminal_order: VecDeque<u64>,
+    total_output: usize,
+}
+
+struct ActiveOperation {
+    id: u64,
+    control: mpsc::Sender<Control>,
+    cancellation_requested: bool,
+}
+
+struct OperationRecord {
+    info: OperationInfo,
+    events: VecDeque<OperationEvent>,
+    subscribers: Vec<mpsc::Sender<OperationEvent>>,
+}
+
+enum Control {
+    Stdin {
+        data: Vec<u8>,
+        last: bool,
+        response: oneshot::Sender<Result<(), AgentError>>,
+    },
+    Cancel {
+        response: oneshot::Sender<Result<(), AgentError>>,
+    },
+}
+
+/// Snapshot and subscription returned by [`OperationManager::attach`].
+pub struct OperationAttachment {
+    /// Current operation metadata.
+    pub info: OperationInfo,
+    /// Retained events newer than the requested sequence.
+    pub replay: Vec<OperationEvent>,
+    /// Live events. It closes when the operation becomes terminal, the client disconnects, or the
+    /// client cannot keep up with remote output.
+    pub live: mpsc::Receiver<OperationEvent>,
+}
+
+impl OperationManager {
+    /// Creates a manager backed by a per-RDP-session NOW endpoint.
+    pub fn new(endpoint: Arc<NowEndpoint>) -> Self {
+        Self {
+            endpoint,
+            state: Arc::new(Mutex::new(OperationStateStore {
+                next_id: 1,
+                starting: false,
+                active: None,
+                records: BTreeMap::new(),
+                terminal_order: VecDeque::new(),
+                total_output: 0,
+            })),
+        }
+    }
+
+    /// Gets NOW capabilities, lazily connecting the DVC endpoint if necessary.
+    pub async fn capabilities(&self) -> Result<NowCapabilities, AgentError> {
+        let handle = self.endpoint.handle().await.map_err(endpoint_error)?;
+        Ok(capabilities(handle.capabilities().into()))
+    }
+
+    /// Submits a generic untracked NOW Run request.
+    pub async fn run(&self, command: String, directory: Option<String>) -> Result<(), AgentError> {
+        self.reserve_submission()?;
+        let request = match directory {
+            Some(directory) => RunRequest::new(command).with_directory(directory),
+            None => RunRequest::new(command),
+        };
+        let result = match self.endpoint.handle().await {
+            Ok(handle) => handle.run(request).await,
+            Err(error) => {
+                self.release_submission();
+                return Err(endpoint_error(error));
+            }
+        };
+        self.release_submission();
+        match result {
+            Ok(_) => Ok(()),
+            Err(error) => {
+                self.invalidate_if_needed(&error).await;
+                Err(client_error(error))
+            }
+        }
+    }
+
+    /// Submits a tracked or detached NOW execution.
+    pub async fn execute(&self, request: NowExecutionRequest) -> Result<OperationInfo, AgentError> {
+        if request.detached {
+            return self.execute_detached(request).await;
+        }
+
+        self.reserve_submission()?;
+        let result = self.start_tracked(request.clone()).await;
+        self.release_submission();
+        let mut state = lock(&self.state);
+        let (execution, info) = match result {
+            Ok(value) => value,
+            Err(error) => return Err(error),
+        };
+
+        let (control_tx, control_rx) = mpsc::channel(32);
+        let id = info.id;
+        state.records.insert(
+            id,
+            OperationRecord {
+                info: info.clone(),
+                events: VecDeque::new(),
+                subscribers: Vec::new(),
+            },
+        );
+        state.active = Some(ActiveOperation {
+            id,
+            control: control_tx,
+            cancellation_requested: false,
+        });
+        drop(state);
+
+        let manager = self.clone();
+        tokio::spawn(async move {
+            manager.drive_execution(id, execution, control_rx).await;
+        });
+
+        Ok(info)
+    }
+
+    /// Lists all daemon-retained operations in daemon ID order.
+    pub fn list(&self) -> Vec<OperationInfo> {
+        lock(&self.state)
+            .records
+            .values()
+            .map(|record| record.info.clone())
+            .collect()
+    }
+
+    /// Retrieves a retained operation.
+    pub fn status(&self, operation_id: u64) -> Result<OperationInfo, AgentError> {
+        lock(&self.state)
+            .records
+            .get(&operation_id)
+            .map(|record| record.info.clone())
+            .ok_or_else(operation_not_found)
+    }
+
+    /// Replays bounded retained output and subscribes to subsequent output.
+    pub fn attach(&self, operation_id: u64, after_sequence: Option<u64>) -> Result<OperationAttachment, AgentError> {
+        let mut state = lock(&self.state);
+        let record = state.records.get_mut(&operation_id).ok_or_else(operation_not_found)?;
+        record.subscribers.retain(|subscriber| !subscriber.is_closed());
+        if record.subscribers.len() == MAX_LIVE_SUBSCRIBERS {
+            return Err(AgentError {
+                category: AgentErrorCategory::Conflict,
+                message: "maximum live NOW subscribers reached".to_owned(),
+            });
+        }
+        let (sender, receiver) = mpsc::channel(LIVE_SUBSCRIBER_QUEUE_CAPACITY);
+        let replay = record
+            .events
+            .iter()
+            .filter(|event| after_sequence.is_none_or(|sequence| event.sequence > sequence))
+            .cloned()
+            .collect();
+        if matches!(record.info.state, OperationState::Running | OperationState::Cancelling) {
+            record.subscribers.push(sender);
+        }
+        Ok(OperationAttachment {
+            info: record.info.clone(),
+            replay,
+            live: receiver,
+        })
+    }
+
+    /// Forwards raw stdin to the active tracked execution.
+    pub async fn send_stdin(&self, operation_id: u64, data: Vec<u8>, last: bool) -> Result<(), AgentError> {
+        if data.len() > MAX_STDIN_CHUNK {
+            return Err(AgentError {
+                category: AgentErrorCategory::InvalidRequest,
+                message: format!("stdin chunk exceeds the {MAX_STDIN_CHUNK}-byte limit"),
+            });
+        }
+        let control = self.active_control(operation_id)?;
+        let (response_tx, response_rx) = oneshot::channel();
+        control
+            .send(Control::Stdin {
+                data,
+                last,
+                response: response_tx,
+            })
+            .await
+            .map_err(|_| operation_finished())?;
+        response_rx.await.map_err(|_| operation_finished())?
+    }
+
+    /// Submits a cancellation request while the operation driver continues draining remote output.
+    pub async fn cancel(&self, operation_id: u64) -> Result<(), AgentError> {
+        let control = {
+            let mut state = lock(&self.state);
+            let known_operation = state.records.contains_key(&operation_id);
+            let Some(active) = state.active.as_mut() else {
+                return if known_operation {
+                    Err(operation_finished())
+                } else {
+                    Err(operation_not_found())
+                };
+            };
+            if active.id != operation_id {
+                return if known_operation {
+                    Err(operation_finished())
+                } else {
+                    Err(operation_not_found())
+                };
+            }
+            if active.cancellation_requested {
+                return Err(AgentError {
+                    category: AgentErrorCategory::Conflict,
+                    message: "NOW operation cancellation is already pending".to_owned(),
+                });
+            }
+            active.cancellation_requested = true;
+            active.control.clone()
+        };
+        let (response_tx, response_rx) = oneshot::channel();
+        if control.send(Control::Cancel { response: response_tx }).await.is_err() {
+            self.clear_cancellation_requested(operation_id);
+            return Err(operation_finished());
+        }
+        response_rx.await.map_err(|_| operation_finished())?
+    }
+
+    fn active_control(&self, operation_id: u64) -> Result<mpsc::Sender<Control>, AgentError> {
+        let state = lock(&self.state);
+        match &state.active {
+            Some(active) if active.id == operation_id => Ok(active.control.clone()),
+            _ if state.records.contains_key(&operation_id) => Err(operation_finished()),
+            _ => Err(operation_not_found()),
+        }
+    }
+
+    async fn execute_detached(&self, request: NowExecutionRequest) -> Result<OperationInfo, AgentError> {
+        if request.stdin.is_some() || request.timeout_ms.is_some() {
+            return Err(AgentError {
+                category: AgentErrorCategory::InvalidRequest,
+                message: "detached execution cannot include stdin or a timeout".to_owned(),
+            });
+        }
+
+        self.reserve_submission()?;
+        let handle = match self.endpoint.handle().await {
+            Ok(handle) => handle,
+            Err(error) => {
+                self.release_submission();
+                return Err(endpoint_error(error));
+            }
+        };
+        let kind = request.kind;
+        let result = match kind {
+            NowExecutionKind::Process => handle.process_detached(build_process(request)).await,
+            NowExecutionKind::Batch => handle.batch_detached(build_batch(request)).await,
+            NowExecutionKind::PowerShell => handle.win_ps_detached(build_win_ps(request)).await,
+            NowExecutionKind::Pwsh => handle.pwsh_detached(build_pwsh(request)).await,
+        };
+        self.release_submission();
+        if let Err(error) = result {
+            self.invalidate_if_needed(&error).await;
+            return Err(client_error(error));
+        }
+
+        let mut state = lock(&self.state);
+        let info = OperationInfo {
+            id: next_id(&mut state),
+            kind,
+            state: OperationState::Detached,
+            detached: true,
+            exit_code: None,
+            error: None,
+            retained_output_bytes: 0,
+            next_sequence: 0,
+        };
+        state.records.insert(
+            info.id,
+            OperationRecord {
+                info: info.clone(),
+                events: VecDeque::new(),
+                subscribers: Vec::new(),
+            },
+        );
+        state.terminal_order.push_back(info.id);
+        trim_retention(&mut state);
+        Ok(info)
+    }
+
+    async fn start_tracked(&self, request: NowExecutionRequest) -> Result<(Execution, OperationInfo), AgentError> {
+        let handle = self.endpoint.handle().await.map_err(endpoint_error)?;
+        let kind = request.kind;
+        let result = match kind {
+            NowExecutionKind::Process => handle.process(build_process(request)).await,
+            NowExecutionKind::Batch => handle.batch(build_batch(request)).await,
+            NowExecutionKind::PowerShell => handle.win_ps(build_win_ps(request)).await,
+            NowExecutionKind::Pwsh => handle.pwsh(build_pwsh(request)).await,
+        };
+        let execution = match result {
+            Ok(execution) => execution,
+            Err(error) => {
+                self.invalidate_if_needed(&error).await;
+                return Err(client_error(error));
+            }
+        };
+        let id = {
+            let mut state = lock(&self.state);
+            next_id(&mut state)
+        };
+        Ok((
+            execution,
+            OperationInfo {
+                id,
+                kind,
+                state: OperationState::Running,
+                detached: false,
+                exit_code: None,
+                error: None,
+                retained_output_bytes: 0,
+                next_sequence: 0,
+            },
+        ))
+    }
+
+    async fn drive_execution(
+        &self,
+        operation_id: u64,
+        mut execution: Execution,
+        mut controls: mpsc::Receiver<Control>,
+    ) {
+        loop {
+            match tokio::time::timeout(Duration::from_millis(25), execution.next_event()).await {
+                Ok(Some(event)) => self.record_client_event(operation_id, event),
+                Ok(None) => break,
+                Err(_) => {}
+            }
+
+            while let Ok(control) = controls.try_recv() {
+                match control {
+                    Control::Stdin { data, last, response } => {
+                        let result = match execution.send_stdin(data, last).await {
+                            Ok(()) => Ok(()),
+                            Err(error) => {
+                                self.invalidate_if_needed(&error).await;
+                                Err(client_error(error))
+                            }
+                        };
+                        let _ = response.send(result);
+                    }
+                    Control::Cancel { response } => {
+                        let result = match submit_cancel(&execution).await {
+                            Ok(()) => Ok(()),
+                            Err(error) => {
+                                self.invalidate_if_needed(&error).await;
+                                self.clear_cancellation_requested(operation_id);
+                                Err(client_error(error))
+                            }
+                        };
+                        let _ = response.send(result);
+                    }
+                }
+            }
+        }
+
+        match execution.wait().await {
+            Ok(ExecutionStatus::Completed { exit_code }) => {
+                self.emit(operation_id, OperationEventKind::Completed { exit_code });
+                self.finish(operation_id, OperationState::Completed, Some(exit_code), None);
+            }
+            Ok(ExecutionStatus::Cancelled) => {
+                self.emit(operation_id, OperationEventKind::Cancelled);
+                self.finish(
+                    operation_id,
+                    OperationState::Cancelled,
+                    None,
+                    Some(AgentError {
+                        category: AgentErrorCategory::Remote,
+                        message: "now operation was cancelled".to_owned(),
+                    }),
+                );
+            }
+            Err(error) => {
+                self.invalidate_if_needed(&error).await;
+                let error = client_error(error);
+                self.emit(operation_id, OperationEventKind::Failed(error.clone()));
+                self.finish(operation_id, OperationState::Failed, None, Some(error));
+            }
+        }
+    }
+
+    fn record_client_event(&self, operation_id: u64, event: ExecutionEvent) {
+        match event {
+            ExecutionEvent::Started => self.emit(operation_id, OperationEventKind::Started),
+            ExecutionEvent::Stdout { data, last } => self.emit_output(operation_id, NowStream::Stdout, data, last),
+            ExecutionEvent::Stderr { data, last } => self.emit_output(operation_id, NowStream::Stderr, data, last),
+            ExecutionEvent::CancelAccepted => {
+                self.update_state(operation_id, OperationState::Cancelling);
+                self.emit(operation_id, OperationEventKind::CancelAccepted);
+            }
+        }
+    }
+
+    fn emit_output(&self, operation_id: u64, stream: NowStream, data: Vec<u8>, last: bool) {
+        if data.is_empty() {
+            self.emit(operation_id, OperationEventKind::Output { stream, data, last });
+            return;
+        }
+
+        let chunks = data.chunks(MAX_IPC_OUTPUT_CHUNK);
+        let chunk_count = chunks.len();
+        for (index, chunk) in chunks.enumerate() {
+            self.emit(
+                operation_id,
+                OperationEventKind::Output {
+                    stream,
+                    data: chunk.to_vec(),
+                    last: last && index + 1 == chunk_count,
+                },
+            );
+        }
+    }
+
+    fn update_state(&self, operation_id: u64, state: OperationState) {
+        if let Some(record) = lock(&self.state).records.get_mut(&operation_id) {
+            record.info.state = state;
+        }
+    }
+
+    fn emit(&self, operation_id: u64, kind: OperationEventKind) {
+        let mut state = lock(&self.state);
+        let (event, output_len) = {
+            let Some(record) = state.records.get_mut(&operation_id) else {
+                return;
+            };
+            let event = OperationEvent {
+                operation_id,
+                sequence: record.info.next_sequence,
+                kind,
+            };
+            record.info.next_sequence = record.info.next_sequence.saturating_add(1);
+            let output_len = output_size(&event.kind);
+            record.info.retained_output_bytes = record
+                .info
+                .retained_output_bytes
+                .saturating_add(u64::try_from(output_len).unwrap_or(u64::MAX));
+            record.events.push_back(event.clone());
+            record
+                .subscribers
+                .retain(|sender| sender.try_send(event.clone()).is_ok());
+            (event, output_len)
+        };
+        state.total_output = state.total_output.saturating_add(output_len);
+        trim_operation_output(&mut state, operation_id);
+        trim_retention(&mut state);
+        let _ = event;
+    }
+
+    fn finish(
+        &self,
+        operation_id: u64,
+        operation_state: OperationState,
+        exit_code: Option<u32>,
+        error: Option<AgentError>,
+    ) {
+        let mut state = lock(&self.state);
+        if let Some(record) = state.records.get_mut(&operation_id) {
+            record.info.state = operation_state;
+            record.info.exit_code = exit_code;
+            record.info.error = error;
+            record.subscribers.clear();
+        }
+        if state.active.as_ref().is_some_and(|active| active.id == operation_id) {
+            state.active = None;
+        }
+        state.terminal_order.push_back(operation_id);
+        trim_retention(&mut state);
+    }
+
+    async fn invalidate_if_needed(&self, error: &NowClientError) {
+        if invalidates_handle(error) {
+            self.endpoint.invalidate().await;
+        }
+    }
+
+    fn clear_cancellation_requested(&self, operation_id: u64) {
+        let mut state = lock(&self.state);
+        if let Some(active) = state.active.as_mut().filter(|active| active.id == operation_id) {
+            active.cancellation_requested = false;
+        }
+    }
+
+    fn reserve_submission(&self) -> Result<(), AgentError> {
+        let mut state = lock(&self.state);
+        if state.starting || state.active.is_some() {
+            return Err(AgentError {
+                category: AgentErrorCategory::Conflict,
+                message: "a NOW operation is already active".to_owned(),
+            });
+        }
+        state.starting = true;
+        Ok(())
+    }
+
+    fn release_submission(&self) {
+        lock(&self.state).starting = false;
+    }
+}
+
+/// Submits cancellation without waiting for the peer response so the execution event receiver keeps
+/// draining. The agent permits only one submission or tracked execution at a time, and serializes
+/// stdin requests, so its empty command queue accepts this first poll; the peer acknowledgement
+/// remains observable as `ExecutionEvent::CancelAccepted`.
+async fn submit_cancel(execution: &Execution) -> Result<(), NowClientError> {
+    let cancel = execution.cancel();
+    tokio::pin!(cancel);
+    tokio::select! {
+        biased;
+        result = &mut cancel => result,
+        _ = tokio::task::yield_now() => Ok(()),
+    }
+}
+
+fn build_process(request: NowExecutionRequest) -> ProcessRequest {
+    let mut output = ProcessRequest::new(request.command);
+    if let Some(parameters) = request.parameters {
+        output = output.with_parameters(parameters);
+    }
+    if let Some(directory) = request.directory {
+        output = output.with_directory(directory);
+    }
+    if let Some(stdin) = request.stdin {
+        output = output.with_stdin(stdin);
+    }
+    if let Some(timeout_ms) = request.timeout_ms {
+        output = output.with_timeout(Duration::from_millis(timeout_ms));
+    }
+    output
+}
+
+fn build_batch(request: NowExecutionRequest) -> BatchRequest {
+    let mut output = BatchRequest::new(request.command);
+    if let Some(directory) = request.directory {
+        output = output.with_directory(directory);
+    }
+    if let Some(stdin) = request.stdin {
+        output = output.with_stdin(stdin);
+    }
+    if let Some(timeout_ms) = request.timeout_ms {
+        output = output.with_timeout(Duration::from_millis(timeout_ms));
+    }
+    output
+}
+
+fn build_win_ps(request: NowExecutionRequest) -> WinPsRequest {
+    build_power_shell(WinPsRequest::new(request.command.clone()), request)
+}
+
+fn build_pwsh(request: NowExecutionRequest) -> PwshRequest {
+    build_power_shell(PwshRequest::new(request.command.clone()), request)
+}
+
+fn build_power_shell(mut output: WinPsRequest, request: NowExecutionRequest) -> WinPsRequest {
+    if let Some(directory) = request.directory {
+        output = output.with_directory(directory);
+    }
+    if let Some(stdin) = request.stdin {
+        output = output.with_stdin(stdin);
+    }
+    if let Some(timeout_ms) = request.timeout_ms {
+        output = output.with_timeout(Duration::from_millis(timeout_ms));
+    }
+    if request.no_profile {
+        output = output.with_no_profile();
+    }
+    if request.non_interactive {
+        output = output.with_non_interactive();
+    }
+    output
+}
+
+fn capabilities(value: Capabilities) -> NowCapabilities {
+    NowCapabilities {
+        version_major: value.version_major,
+        version_minor: value.version_minor,
+        heartbeat_ms: value.heartbeat_ms,
+        run: value.run,
+        process: value.process,
+        batch: value.batch,
+        powershell: value.powershell,
+        pwsh: value.pwsh,
+        io_redirection: value.io_redirection,
+        unicode_console: value.unicode_console,
+    }
+}
+
+fn endpoint_error(error: NowEndpointError) -> AgentError {
+    let category = match error {
+        NowEndpointError::Unavailable { .. } => AgentErrorCategory::Unavailable,
+        NowEndpointError::Client(_) => AgentErrorCategory::Transport,
+    };
+    AgentError {
+        category,
+        message: format!("now endpoint: {error}"),
+    }
+}
+
+fn client_error(error: NowClientError) -> AgentError {
+    let category = match error {
+        NowClientError::InvalidConfiguration(_) | NowClientError::InvalidRequest(_) => {
+            AgentErrorCategory::InvalidRequest
+        }
+        NowClientError::UnsupportedCapability(_) => AgentErrorCategory::Unavailable,
+        NowClientError::OperationInProgress => AgentErrorCategory::Conflict,
+        NowClientError::RemoteStatus { .. } => AgentErrorCategory::Remote,
+        NowClientError::Io(_)
+        | NowClientError::PduEncode(_)
+        | NowClientError::PduDecode(_)
+        | NowClientError::Protocol(_)
+        | NowClientError::FrameTooLarge { .. }
+        | NowClientError::FrameBufferTooLarge { .. }
+        | NowClientError::HandshakeTimeout
+        | NowClientError::IncompatibleVersion { .. }
+        | NowClientError::WorkerClosed(_)
+        | NowClientError::EventQueueFull { .. } => AgentErrorCategory::Transport,
+        NowClientError::SessionIdExhausted | NowClientError::OperationFinished { .. } => AgentErrorCategory::Internal,
+    };
+    AgentError {
+        category,
+        message: format!("now client: {error}"),
+    }
+}
+
+fn operation_not_found() -> AgentError {
+    AgentError {
+        category: AgentErrorCategory::InvalidRequest,
+        message: "unknown NOW operation".to_owned(),
+    }
+}
+
+fn operation_finished() -> AgentError {
+    AgentError {
+        category: AgentErrorCategory::Conflict,
+        message: "NOW operation is no longer active".to_owned(),
+    }
+}
+
+fn next_id(state: &mut OperationStateStore) -> u64 {
+    let id = state.next_id;
+    state.next_id = state.next_id.checked_add(1).unwrap_or(1);
+    id
+}
+
+fn output_size(kind: &OperationEventKind) -> usize {
+    match kind {
+        OperationEventKind::Output { data, .. } => data.len(),
+        _ => 0,
+    }
+}
+
+fn trim_operation_output(state: &mut OperationStateStore, operation_id: u64) {
+    let Some(record) = state.records.get_mut(&operation_id) else {
+        return;
+    };
+    while usize::try_from(record.info.retained_output_bytes).unwrap_or(usize::MAX) > MAX_OPERATION_OUTPUT {
+        let Some(position) = record.events.iter().position(|event| output_size(&event.kind) != 0) else {
+            break;
+        };
+        let Some(event) = record.events.remove(position) else {
+            break;
+        };
+        let bytes = output_size(&event.kind);
+        record.info.retained_output_bytes = record
+            .info
+            .retained_output_bytes
+            .saturating_sub(u64::try_from(bytes).unwrap_or(u64::MAX));
+        state.total_output = state.total_output.saturating_sub(bytes);
+    }
+}
+
+fn trim_retention(state: &mut OperationStateStore) {
+    while state.terminal_order.len() > MAX_TERMINAL_OPERATIONS || state.total_output > MAX_TOTAL_OUTPUT {
+        let Some(id) = state.terminal_order.pop_front() else {
+            break;
+        };
+        if let Some(record) = state.records.remove(&id) {
+            state.total_output = state
+                .total_output
+                .saturating_sub(usize::try_from(record.info.retained_output_bytes).unwrap_or(usize::MAX));
+        }
+    }
+}
+
+fn lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn operation_output_is_bounded_per_record() {
+        let mut state = OperationStateStore {
+            next_id: 2,
+            starting: false,
+            active: None,
+            records: BTreeMap::new(),
+            terminal_order: VecDeque::new(),
+            total_output: MAX_OPERATION_OUTPUT + 1,
+        };
+        let id = 1;
+        let data = vec![0; MAX_OPERATION_OUTPUT + 1];
+        state.records.insert(
+            id,
+            OperationRecord {
+                info: OperationInfo {
+                    id,
+                    kind: NowExecutionKind::Batch,
+                    state: OperationState::Running,
+                    detached: false,
+                    exit_code: None,
+                    error: None,
+                    retained_output_bytes: u64::try_from(data.len()).expect("usize fits u64"),
+                    next_sequence: 1,
+                },
+                events: VecDeque::from([OperationEvent {
+                    operation_id: id,
+                    sequence: 0,
+                    kind: OperationEventKind::Output {
+                        stream: NowStream::Stdout,
+                        data,
+                        last: false,
+                    },
+                }]),
+                subscribers: Vec::new(),
+            },
+        );
+
+        trim_operation_output(&mut state, id);
+        let record = state.records.get(&id).expect("record remains");
+        assert_eq!(record.info.retained_output_bytes, 0);
+        assert!(record.events.is_empty());
+        assert_eq!(state.total_output, 0);
+    }
+
+    #[test]
+    fn terminal_record_count_is_bounded() {
+        let mut state = OperationStateStore {
+            next_id: 34,
+            starting: false,
+            active: None,
+            records: BTreeMap::new(),
+            terminal_order: VecDeque::new(),
+            total_output: 0,
+        };
+        for id in 1..=33 {
+            state.terminal_order.push_back(id);
+            state.records.insert(
+                id,
+                OperationRecord {
+                    info: OperationInfo {
+                        id,
+                        kind: NowExecutionKind::Batch,
+                        state: OperationState::Completed,
+                        detached: false,
+                        exit_code: Some(0),
+                        error: None,
+                        retained_output_bytes: 0,
+                        next_sequence: 0,
+                    },
+                    events: VecDeque::new(),
+                    subscribers: Vec::new(),
+                },
+            );
+        }
+
+        trim_retention(&mut state);
+        assert_eq!(state.records.len(), MAX_TERMINAL_OPERATIONS);
+        assert!(!state.records.contains_key(&1));
+    }
+
+    #[tokio::test]
+    async fn slow_subscribers_are_disconnected_instead_of_buffering_output() {
+        let manager = OperationManager::new(Arc::new(NowEndpoint::new()));
+        let id = 1;
+        lock(&manager.state).records.insert(
+            id,
+            OperationRecord {
+                info: OperationInfo {
+                    id,
+                    kind: NowExecutionKind::Batch,
+                    state: OperationState::Running,
+                    detached: false,
+                    exit_code: None,
+                    error: None,
+                    retained_output_bytes: 0,
+                    next_sequence: 0,
+                },
+                events: VecDeque::new(),
+                subscribers: Vec::new(),
+            },
+        );
+
+        let attachments: Vec<_> =
+            core::iter::repeat_with(|| manager.attach(id, None).expect("subscription is accepted"))
+                .take(MAX_LIVE_SUBSCRIBERS)
+                .collect();
+        manager.emit(id, OperationEventKind::Started);
+        manager.emit(id, OperationEventKind::Started);
+
+        assert!(
+            lock(&manager.state)
+                .records
+                .get(&id)
+                .expect("operation remains")
+                .subscribers
+                .is_empty()
+        );
+        for mut attachment in attachments {
+            assert!(attachment.live.recv().await.is_some());
+            assert!(attachment.live.recv().await.is_none());
+        }
+    }
+
+    #[test]
+    fn output_is_split_to_fit_the_ipc_message_limit() {
+        let manager = OperationManager::new(Arc::new(NowEndpoint::new()));
+        let id = 1;
+        lock(&manager.state).records.insert(
+            id,
+            OperationRecord {
+                info: OperationInfo {
+                    id,
+                    kind: NowExecutionKind::Process,
+                    state: OperationState::Running,
+                    detached: false,
+                    exit_code: None,
+                    error: None,
+                    retained_output_bytes: 0,
+                    next_sequence: 0,
+                },
+                events: VecDeque::new(),
+                subscribers: Vec::new(),
+            },
+        );
+
+        manager.emit_output(id, NowStream::Stdout, vec![0; MAX_IPC_OUTPUT_CHUNK + 1], true);
+
+        let record = lock(&manager.state);
+        let events: Vec<_> = record
+            .records
+            .get(&id)
+            .expect("operation remains")
+            .events
+            .iter()
+            .collect();
+        assert_eq!(events.len(), 2);
+        assert_eq!(output_size(&events[0].kind), MAX_IPC_OUTPUT_CHUNK);
+        assert_eq!(output_size(&events[1].kind), 1);
+        assert!(matches!(
+            &events[0].kind,
+            OperationEventKind::Output { last: false, .. }
+        ));
+        assert!(matches!(&events[1].kind, OperationEventKind::Output { last: true, .. }));
+    }
+}

--- a/crates/ironrdp-agent/src/operations.rs
+++ b/crates/ironrdp-agent/src/operations.rs
@@ -24,6 +24,7 @@ const MAX_TERMINAL_OPERATIONS: usize = 32;
 const MAX_TOTAL_OUTPUT: usize = 32 * 1024 * 1024;
 const MAX_STDIN_CHUNK: usize = 1024 * 1024;
 const MAX_IPC_OUTPUT_CHUNK: usize = 1024 * 1024;
+const MAX_OPERATION_EVENTS: usize = 8 * 1024;
 const MAX_LIVE_SUBSCRIBERS: usize = 8;
 const LIVE_SUBSCRIBER_QUEUE_CAPACITY: usize = 1;
 
@@ -129,17 +130,30 @@ impl OperationManager {
             return self.execute_detached(request).await;
         }
 
+        let kind = request.kind;
         self.reserve_submission()?;
-        let result = self.start_tracked(request.clone()).await;
-        self.release_submission();
+        let result = self.start_tracked(request).await;
         let mut state = lock(&self.state);
-        let (execution, info) = match result {
-            Ok(value) => value,
-            Err(error) => return Err(error),
+        let execution = match result {
+            Ok(execution) => execution,
+            Err(error) => {
+                state.starting = false;
+                return Err(error);
+            }
         };
 
         let (control_tx, control_rx) = mpsc::channel(32);
-        let id = info.id;
+        let id = next_id(&mut state);
+        let info = OperationInfo {
+            id,
+            kind,
+            state: OperationState::Running,
+            detached: false,
+            exit_code: None,
+            error: None,
+            retained_output_bytes: 0,
+            next_sequence: 0,
+        };
         state.records.insert(
             id,
             OperationRecord {
@@ -153,6 +167,7 @@ impl OperationManager {
             control: control_tx,
             cancellation_requested: false,
         });
+        state.starting = false;
         drop(state);
 
         let manager = self.clone();
@@ -328,7 +343,7 @@ impl OperationManager {
         Ok(info)
     }
 
-    async fn start_tracked(&self, request: NowExecutionRequest) -> Result<(Execution, OperationInfo), AgentError> {
+    async fn start_tracked(&self, request: NowExecutionRequest) -> Result<Execution, AgentError> {
         let handle = self.endpoint.handle().await.map_err(endpoint_error)?;
         let kind = request.kind;
         let result = match kind {
@@ -344,23 +359,7 @@ impl OperationManager {
                 return Err(client_error(error));
             }
         };
-        let id = {
-            let mut state = lock(&self.state);
-            next_id(&mut state)
-        };
-        Ok((
-            execution,
-            OperationInfo {
-                id,
-                kind,
-                state: OperationState::Running,
-                detached: false,
-                exit_code: None,
-                error: None,
-                retained_output_bytes: 0,
-                next_sequence: 0,
-            },
-        ))
+        Ok(execution)
     }
 
     async fn drive_execution(
@@ -443,7 +442,9 @@ impl OperationManager {
 
     fn emit_output(&self, operation_id: u64, stream: NowStream, data: Vec<u8>, last: bool) {
         if data.is_empty() {
-            self.emit(operation_id, OperationEventKind::Output { stream, data, last });
+            if last {
+                self.emit(operation_id, OperationEventKind::Output { stream, data, last });
+            }
             return;
         }
 
@@ -491,7 +492,7 @@ impl OperationManager {
             (event, output_len)
         };
         state.total_output = state.total_output.saturating_add(output_len);
-        trim_operation_output(&mut state, operation_id);
+        trim_operation_events(&mut state, operation_id);
         trim_retention(&mut state);
         let _ = event;
     }
@@ -698,12 +699,18 @@ fn output_size(kind: &OperationEventKind) -> usize {
     }
 }
 
-fn trim_operation_output(state: &mut OperationStateStore, operation_id: u64) {
+fn trim_operation_events(state: &mut OperationStateStore, operation_id: u64) {
     let Some(record) = state.records.get_mut(&operation_id) else {
         return;
     };
-    while usize::try_from(record.info.retained_output_bytes).unwrap_or(usize::MAX) > MAX_OPERATION_OUTPUT {
-        let Some(position) = record.events.iter().position(|event| output_size(&event.kind) != 0) else {
+    while usize::try_from(record.info.retained_output_bytes).unwrap_or(usize::MAX) > MAX_OPERATION_OUTPUT
+        || record.events.len() > MAX_OPERATION_EVENTS
+    {
+        let Some(position) = record
+            .events
+            .iter()
+            .position(|event| matches!(event.kind, OperationEventKind::Output { .. }))
+        else {
             break;
         };
         let Some(event) = record.events.remove(position) else {
@@ -777,7 +784,7 @@ mod tests {
             },
         );
 
-        trim_operation_output(&mut state, id);
+        trim_operation_events(&mut state, id);
         let record = state.records.get(&id).expect("record remains");
         assert_eq!(record.info.retained_output_bytes, 0);
         assert!(record.events.is_empty());
@@ -822,7 +829,7 @@ mod tests {
 
     #[tokio::test]
     async fn slow_subscribers_are_disconnected_instead_of_buffering_output() {
-        let manager = OperationManager::new(Arc::new(NowEndpoint::new()));
+        let manager = OperationManager::new(Arc::new(NowEndpoint::new().expect("endpoint allocation must succeed")));
         let id = 1;
         lock(&manager.state).records.insert(
             id,
@@ -865,7 +872,7 @@ mod tests {
 
     #[test]
     fn output_is_split_to_fit_the_ipc_message_limit() {
-        let manager = OperationManager::new(Arc::new(NowEndpoint::new()));
+        let manager = OperationManager::new(Arc::new(NowEndpoint::new().expect("endpoint allocation must succeed")));
         let id = 1;
         lock(&manager.state).records.insert(
             id,
@@ -903,5 +910,78 @@ mod tests {
             OperationEventKind::Output { last: false, .. }
         ));
         assert!(matches!(&events[1].kind, OperationEventKind::Output { last: true, .. }));
+    }
+
+    #[test]
+    fn non_final_empty_output_is_not_retained() {
+        let manager = OperationManager::new(Arc::new(NowEndpoint::new().expect("endpoint allocation must succeed")));
+        let id = 1;
+        lock(&manager.state).records.insert(
+            id,
+            OperationRecord {
+                info: OperationInfo {
+                    id,
+                    kind: NowExecutionKind::Process,
+                    state: OperationState::Running,
+                    detached: false,
+                    exit_code: None,
+                    error: None,
+                    retained_output_bytes: 0,
+                    next_sequence: 0,
+                },
+                events: VecDeque::new(),
+                subscribers: Vec::new(),
+            },
+        );
+
+        for _ in 0..=MAX_OPERATION_EVENTS {
+            manager.emit_output(id, NowStream::Stdout, Vec::new(), false);
+        }
+
+        assert!(
+            lock(&manager.state)
+                .records
+                .get(&id)
+                .expect("operation remains")
+                .events
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn output_event_count_is_bounded() {
+        let manager = OperationManager::new(Arc::new(NowEndpoint::new().expect("endpoint allocation must succeed")));
+        let id = 1;
+        lock(&manager.state).records.insert(
+            id,
+            OperationRecord {
+                info: OperationInfo {
+                    id,
+                    kind: NowExecutionKind::Process,
+                    state: OperationState::Running,
+                    detached: false,
+                    exit_code: None,
+                    error: None,
+                    retained_output_bytes: 0,
+                    next_sequence: 0,
+                },
+                events: VecDeque::new(),
+                subscribers: Vec::new(),
+            },
+        );
+
+        for _ in 0..=MAX_OPERATION_EVENTS {
+            manager.emit_output(id, NowStream::Stdout, Vec::new(), true);
+        }
+
+        assert_eq!(
+            lock(&manager.state)
+                .records
+                .get(&id)
+                .expect("operation remains")
+                .events
+                .len(),
+            MAX_OPERATION_EVENTS
+        );
     }
 }

--- a/crates/ironrdp-agent/src/transport.rs
+++ b/crates/ironrdp-agent/src/transport.rs
@@ -55,11 +55,17 @@ where
 
 /// Opens the endpoint, sends one `request`, and returns the daemon's `Response`.
 pub async fn send_request(endpoint: &Endpoint, request: &Request) -> anyhow::Result<Response> {
+    let mut stream = open_stream(endpoint, request).await?;
+    read_message(&mut stream).await
+}
+
+/// Opens an IPC connection, sends `request`, and leaves the stream available for streamed replies.
+pub async fn open_stream(endpoint: &Endpoint, request: &Request) -> anyhow::Result<ClientStream> {
     let mut stream = connect(endpoint)
         .await
         .with_context(|| format!("connect to daemon at {endpoint}"))?;
     write_message(&mut stream, request).await?;
-    read_message(&mut stream).await
+    Ok(stream)
 }
 
 #[cfg(unix)]
@@ -193,3 +199,8 @@ mod imp {
 }
 
 pub use imp::{Endpoint, Listener, connect, default_endpoint};
+
+#[cfg(unix)]
+pub type ClientStream = tokio::net::UnixStream;
+#[cfg(windows)]
+pub type ClientStream = tokio::net::windows::named_pipe::NamedPipeClient;

--- a/crates/ironrdp-agent/src/wire/mod.rs
+++ b/crates/ironrdp-agent/src/wire/mod.rs
@@ -158,3 +158,35 @@ pub fn read_opt_u16(src: &mut ReadCursor<'_>) -> DecodeResult<Option<u16>> {
         )),
     }
 }
+
+/// Size on the wire of an optional `u64`.
+pub fn opt_u64_size(value: Option<u64>) -> usize {
+    1 /* presence */ + value.map_or(0, |_| 8)
+}
+
+pub fn write_opt_u64(dst: &mut WriteCursor<'_>, value: Option<u64>) -> EncodeResult<()> {
+    ensure_size!(in: dst, size: opt_u64_size(value));
+    match value {
+        Some(value) => {
+            dst.write_u8(1);
+            dst.write_u64(value);
+        }
+        None => dst.write_u8(0),
+    }
+    Ok(())
+}
+
+pub fn read_opt_u64(src: &mut ReadCursor<'_>) -> DecodeResult<Option<u64>> {
+    ensure_size!(in: src, size: 1);
+    match src.read_u8() {
+        0 => Ok(None),
+        1 => {
+            ensure_size!(in: src, size: 8);
+            Ok(Some(src.read_u64()))
+        }
+        _ => Err(ironrdp_core::invalid_field_err!(
+            "optional u64",
+            "invalid presence flag"
+        )),
+    }
+}

--- a/crates/ironrdp-testsuite-extra/tests/agent.rs
+++ b/crates/ironrdp-testsuite-extra/tests/agent.rs
@@ -7,8 +7,11 @@
 use core::fmt::Debug;
 
 use ironrdp_agent::ipc::{
-    ConnState, KeyFilter, Payload, PropValue, PropertyDump, PropertyEntry, Request, Response, StatusInfo,
+    AgentError, AgentErrorCategory, ConnState, KeyFilter, NowCapabilities, NowDiagnostics, NowExecutionKind,
+    NowExecutionRequest, NowStream, OperationEvent, OperationEventKind, OperationInfo, OperationState, Payload,
+    PropValue, PropertyDump, PropertyEntry, Request, Response, StatusInfo,
 };
+use ironrdp_agent::now::{DVC_CHANNEL_NAME, INITIAL_ENDPOINT_TIMEOUT, NowEndpoint, RECONNECT_ENDPOINT_TIMEOUT};
 use ironrdp_agent::wire;
 use ironrdp_core::{Decode, DecodeOwned, Encode, decode, decode_owned, encode_vec};
 use ironrdp_input::MouseButton;
@@ -81,6 +84,35 @@ fn request_variants_round_trip() {
             ch: '\u{00e9}',
             pressed: true,
         },
+        Request::NowCapabilities,
+        Request::NowRun {
+            command: "echo secret".to_owned(),
+            directory: Some("C:\\Temp".to_owned()),
+        },
+        Request::NowExecute(NowExecutionRequest {
+            kind: NowExecutionKind::PowerShell,
+            command: "$env:SECRET".to_owned(),
+            parameters: None,
+            directory: None,
+            stdin: Some(vec![0, 0xFF]),
+            timeout_ms: Some(3_000),
+            detached: false,
+            no_profile: true,
+            non_interactive: true,
+        }),
+        Request::NowCancel { operation_id: 42 },
+        Request::NowList,
+        Request::NowStatus { operation_id: 42 },
+        Request::NowAttach {
+            operation_id: 42,
+            after_sequence: Some(7),
+        },
+        Request::NowStdin {
+            operation_id: 42,
+            data: vec![0, 0xFF],
+            last: true,
+        },
+        Request::NowDiagnostics,
     ];
 
     for request in &requests {
@@ -128,6 +160,59 @@ fn response_variants_round_trip() {
             png: vec![0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A],
         }),
         Response::Ok(Payload::Empty),
+        Response::Err(AgentError {
+            category: AgentErrorCategory::Remote,
+            message: "remote command failed".to_owned(),
+        }),
+        Response::Ok(Payload::NowCapabilities(NowCapabilities {
+            version_major: 1,
+            version_minor: 4,
+            heartbeat_ms: Some(60_000),
+            run: true,
+            process: true,
+            batch: true,
+            powershell: true,
+            pwsh: true,
+            io_redirection: true,
+            unicode_console: true,
+        })),
+        Response::Ok(Payload::NowOperation(OperationInfo {
+            id: 7,
+            kind: NowExecutionKind::Batch,
+            state: OperationState::Completed,
+            detached: false,
+            exit_code: Some(17),
+            error: None,
+            retained_output_bytes: 3,
+            next_sequence: 2,
+        })),
+        Response::Ok(Payload::NowOperations(vec![OperationInfo {
+            id: 8,
+            kind: NowExecutionKind::Process,
+            state: OperationState::Failed,
+            detached: false,
+            exit_code: None,
+            error: Some(AgentError {
+                category: AgentErrorCategory::Transport,
+                message: "now worker closed".to_owned(),
+            }),
+            retained_output_bytes: 0,
+            next_sequence: 1,
+        }])),
+        Response::Ok(Payload::NowEvent(OperationEvent {
+            operation_id: 7,
+            sequence: 1,
+            kind: OperationEventKind::Output {
+                stream: NowStream::Stderr,
+                data: vec![0, 0xFF],
+                last: true,
+            },
+        })),
+        Response::Ok(Payload::NowDiagnostics(NowDiagnostics {
+            endpoint_allocated: true,
+            connected: false,
+            capabilities: None,
+        })),
     ];
 
     for response in &responses {
@@ -173,4 +258,43 @@ fn bytes_wire_round_trips() {
     let mut read_cursor = ironrdp_core::ReadCursor::new(&buf);
     let decoded = wire::read_bytes(&mut read_cursor).expect("read_bytes");
     assert_eq!(original, decoded, "bytes wire round-trip mismatch");
+}
+
+#[test]
+fn now_request_debug_redacts_command_and_stdin() {
+    let request = Request::NowExecute(NowExecutionRequest {
+        kind: NowExecutionKind::Batch,
+        command: "secret-command".to_owned(),
+        parameters: None,
+        directory: None,
+        stdin: Some(b"secret-stdin".to_vec()),
+        timeout_ms: None,
+        detached: false,
+        no_profile: false,
+        non_interactive: false,
+    });
+
+    let debug = format!("{request:?}");
+    assert!(!debug.contains("secret-command"));
+    assert!(!debug.contains("secret-stdin"));
+}
+
+#[test]
+fn remote_exit_codes_follow_the_cli_contract() {
+    assert_eq!(ironrdp_agent::cli::remote_exit_status(0), 0);
+    assert_eq!(ironrdp_agent::cli::remote_exit_status(1), 1);
+    assert_eq!(ironrdp_agent::cli::remote_exit_status(255), 255);
+    assert_eq!(ironrdp_agent::cli::remote_exit_status(256), 255);
+    assert_eq!(ironrdp_agent::cli::remote_exit_status(u32::MAX), 255);
+}
+
+#[test]
+fn now_endpoint_is_per_session_and_uses_documented_deadlines() {
+    let first = NowEndpoint::new();
+    let second = NowEndpoint::new();
+
+    assert_ne!(first.pipe_name(), second.pipe_name());
+    assert_eq!(first.dvc_proxy_info().channel_name, DVC_CHANNEL_NAME);
+    assert_eq!(INITIAL_ENDPOINT_TIMEOUT.as_secs(), 30);
+    assert_eq!(RECONNECT_ENDPOINT_TIMEOUT.as_secs(), 10);
 }

--- a/crates/ironrdp-testsuite-extra/tests/agent.rs
+++ b/crates/ironrdp-testsuite-extra/tests/agent.rs
@@ -290,8 +290,8 @@ fn remote_exit_codes_follow_the_cli_contract() {
 
 #[test]
 fn now_endpoint_is_per_session_and_uses_documented_deadlines() {
-    let first = NowEndpoint::new();
-    let second = NowEndpoint::new();
+    let first = NowEndpoint::new().expect("endpoint allocation must succeed");
+    let second = NowEndpoint::new().expect("endpoint allocation must succeed");
 
     assert_ne!(first.pipe_name(), second.pipe_name());
     assert_eq!(first.dvc_proxy_info().channel_name, DVC_CHANNEL_NAME);


### PR DESCRIPTION
## Summary
- Integrate the released registry `now-client = "0.1.0"` into `ironrdp-agent`; no Git, path, patch, or vendored dependency is used.
- Add a per-session `Devolutions::Now::Agent` DVC endpoint with 30-second initial readiness and 10-second reconnect deadlines.
- Add durable NOW operations, IPC streaming/retention, supported CLI forms (`run`, `powershell`, `pwsh`, `exec process`, `exec batch`), safe PowerShell defaults, raw output forwarding, and remote exit propagation.
- Add IPC/retention coverage and an adapter regression proving immediate Run frames are quarantined before a following Process execution.
- Do not modify Gateway or `ironrdp-dvc-pipe-proxy`.

## Validation
- `cargo test -p ironrdp-agent`
- `cargo test -p ironrdp-testsuite-extra --test integration_tests_extra agent`
- `cargo clippy -p ironrdp-agent --all-targets -- -D warnings`
- `cargo xtask check fmt -v`
- `cargo xtask check tests -v`
- `cargo xtask check locks -v`

`cargo xtask check lints -v` is blocked by a pre-existing `ironrdp-str` `manual_is_multiple_of` lint under the available Rust 1.90 toolchain. `cargo xtask check typos -v` cannot run because `typos-cli` is not installed. Authorized-VM end-to-end validation remains pending access to the designated RDP/NOW endpoint.