### PR TITLE
feat(acceptor): expose client multitransport flags on AcceptorResult

### DIFF
--- a/crates/ironrdp-acceptor/src/connection.rs
+++ b/crates/ironrdp-acceptor/src/connection.rs
@@ -32,6 +32,7 @@ pub struct Acceptor {
     message_channel_id: Option<u16>,
     desktop_size: DesktopSize,
     keyboard_layout: u32,
+    multitransport_flags: gcc::MultiTransportFlags,
     server_capabilities: Vec<CapabilitySet>,
     static_channels: StaticChannelSet,
     saved_for_reactivation: AcceptorState,
@@ -96,6 +97,13 @@ pub struct AcceptorResult {
     /// announce one. Servers can use it to pick a server-side keyboard layout
     /// matching the client without changing any local input state.
     pub keyboard_layout: u32,
+    /// Multitransport (MS-RDPEMT) capability flags announced by the client in
+    /// its GCC `MultiTransportChannelData` block (section 2.2.1.3.8).
+    ///
+    /// Empty when the client did not send a multitransport block. Servers that
+    /// implement UDP multitransport can use it to decide whether to send a
+    /// Server Initiate Multitransport Request.
+    pub multitransport_flags: gcc::MultiTransportFlags,
     /// Credentials received from the client during SecureSettingsExchange.
     ///
     /// Present for TLS-mode connections where the client sends credentials
@@ -122,6 +130,7 @@ impl Acceptor {
             message_channel_id: None,
             desktop_size,
             keyboard_layout: 0,
+            multitransport_flags: gcc::MultiTransportFlags::empty(),
             server_capabilities: capabilities,
             static_channels: StaticChannelSet::new(),
             saved_for_reactivation: Default::default(),
@@ -194,6 +203,7 @@ impl Acceptor {
             message_channel_id: consumed.message_channel_id,
             desktop_size,
             keyboard_layout: consumed.keyboard_layout,
+            multitransport_flags: consumed.multitransport_flags,
             server_capabilities: consumed.server_capabilities,
             static_channels,
             saved_for_reactivation,
@@ -255,6 +265,7 @@ impl Acceptor {
                 io_channel_id: self.io_channel_id,
                 message_channel_id: self.message_channel_id,
                 keyboard_layout: self.keyboard_layout,
+                multitransport_flags: self.multitransport_flags,
                 reactivation: self.reactivation,
                 credentials: self.received_credentials.take(),
             }),
@@ -513,6 +524,11 @@ impl Sequence for Acceptor {
                 let early_capability = gcc_blocks.core.optional_data.early_capability_flags;
                 let client_wants_message_channel = gcc_blocks.message_channel.is_some();
                 self.keyboard_layout = gcc_blocks.core.keyboard_layout;
+                self.multitransport_flags = gcc_blocks
+                    .multi_transport_channel
+                    .as_ref()
+                    .map(|m| m.flags)
+                    .unwrap_or_else(gcc::MultiTransportFlags::empty);
 
                 // Adopt the client's requested desktop size (from its Client
                 // Core Data) before Demand Active is sent, so the session is


### PR DESCRIPTION
## What

The acceptor already parses the client's GCC `MultiTransportChannelData` block (MS-RDPBCGR §2.2.1.3.8) into `ClientGccBlocks` during `BasicSettingsWaitInitial` and then discards it, keeping only the early-capability flags, core desktop size, and keyboard layout. This surfaces the client's multitransport (MS-RDPEMT) capability flags on `AcceptorResult`.

## Why

A server implementing UDP multitransport needs to know whether the client advertised support (`SOFT_SYNC_TCP_TO_UDP`, `TRANSPORT_TYPE_UDP_FEC{R,L}`) before deciding whether to send a Server Initiate Multitransport Request. Today that information is parsed and thrown away, so there's no way for a downstream server to see it.

## Shape

Purely additive, mirroring the existing `keyboard_layout` (#1397) and desktop-size (#1373) surfacing of GCC client data the acceptor already parses:

- new private `multitransport_flags: gcc::MultiTransportFlags` field on `Acceptor`, captured from `gcc_blocks.multi_transport_channel`;
- new `pub multitransport_flags: gcc::MultiTransportFlags` field on `AcceptorResult`;
- empty when the client sends no multitransport block;
- carried across a deactivation-reactivation like the sibling fields.

No behavior change — the acceptor just stops discarding a block it already decodes.

`cargo clippy -p ironrdp-acceptor --all-targets` and `cargo fmt --check` are clean.
