### PR TITLE
feat(egfx): add Planar frame sender

### DIFF
--- a/crates/ironrdp-egfx/src/server.rs
+++ b/crates/ironrdp-egfx/src/server.rs
@@ -1323,6 +1323,53 @@ impl GraphicsPipelineServer {
         Some(frame_id)
     }
 
+    /// Queue a pre-encoded RDP6 Planar bitmap stream for transmission via EGFX.
+    ///
+    /// Planar is used by clients such as Microsoft Remote Desktop for Android
+    /// when they negotiate EGFX with AVC disabled.
+    ///
+    /// Returns `Some(frame_id)` if queued, `None` if the server is not ready,
+    /// the surface does not exist, or backpressure is active.
+    pub fn send_planar_frame(
+        &mut self,
+        surface_id: u16,
+        planar_data: &[u8],
+        dest_width: u16,
+        dest_height: u16,
+        timestamp_ms: u32,
+    ) -> Option<u32> {
+        if !self.is_ready() {
+            return None;
+        }
+        if self.should_backpressure() {
+            self.qoe.record_backpressure();
+            return None;
+        }
+
+        let surface = self.surfaces.get(surface_id)?;
+        let timestamp = Self::make_timestamp(timestamp_ms);
+        let frame_id = self.frames.begin_frame(timestamp);
+        let dest_rect = ExclusiveRectangle {
+            left: 0,
+            top: 0,
+            right: dest_width.min(surface.width),
+            bottom: dest_height.min(surface.height),
+        };
+
+        self.output_queue
+            .push_back(GfxPdu::StartFrame(StartFramePdu { timestamp, frame_id }));
+        self.output_queue.push_back(GfxPdu::WireToSurface1(WireToSurface1Pdu {
+            surface_id,
+            codec_id: Codec1Type::Planar,
+            pixel_format: surface.pixel_format,
+            destination_rectangle: dest_rect,
+            bitmap_data: planar_data.to_vec(),
+        }));
+        self.output_queue.push_back(GfxPdu::EndFrame(EndFramePdu { frame_id }));
+
+        Some(frame_id)
+    }
+
     /// Queue an H.264 AVC444 frame for transmission
     ///
     /// AVC444 uses two streams: luma (Y) and chroma (UV). Set `chroma_data` to

--- a/crates/ironrdp-testsuite-core/tests/egfx/server.rs
+++ b/crates/ironrdp-testsuite-core/tests/egfx/server.rs
@@ -1,10 +1,11 @@
-use ironrdp_core::{Encode, WriteCursor};
+use ironrdp_core::{Decode, Encode, ReadCursor, WriteCursor, encode_vec};
 use ironrdp_dvc::DvcProcessor as _;
 use ironrdp_egfx::pdu::{
     Avc420Region, CapabilitiesAdvertisePdu, CapabilitiesV8Flags, CapabilitiesV10Flags, CapabilitiesV81Flags,
     CapabilitySet, GfxPdu,
 };
 use ironrdp_egfx::server::{GraphicsPipelineHandler, GraphicsPipelineServer, QoeMetrics, Surface};
+use ironrdp_graphics::zgfx::Decompressor;
 
 // ============================================================================
 // Test Handler
@@ -145,6 +146,44 @@ fn test_server_not_ready_before_capabilities() {
 
     let result = server.send_avc420_frame(0, &h264_data, &regions, 0);
     assert!(result.is_none());
+}
+
+#[test]
+fn test_planar_frame_uses_planar_codec() {
+    let handler = Box::new(TestHandler::new());
+    let mut server = GraphicsPipelineServer::new(handler);
+
+    let client_caps_pdu = GfxPdu::CapabilitiesAdvertise(CapabilitiesAdvertisePdu::from_typed(&[CapabilitySet::V10 {
+        flags: CapabilitiesV10Flags::AVC_DISABLED,
+    }]));
+    let payload = encode_pdu(&client_caps_pdu);
+    server.process(0, &payload).expect("process failed");
+
+    let surface_id = server.create_surface(1280, 720).expect("surface creation failed");
+    server.drain_output();
+
+    let planar_data = [0x20, 0x00, 0x01, 0x02];
+    let frame_id = server.send_planar_frame(surface_id, &planar_data, 1280, 720, 42);
+    assert!(frame_id.is_some());
+
+    let output = server.drain_output();
+    assert_eq!(output.len(), 3);
+    let encoded = encode_vec(output[1].as_ref()).expect("encode should succeed");
+    let mut decoded = Vec::new();
+    Decompressor::new()
+        .decompress(&encoded, &mut decoded)
+        .expect("ZGFX decode should succeed");
+    let mut cursor = ReadCursor::new(&decoded);
+    let pdu = GfxPdu::decode(&mut cursor).expect("decode should succeed");
+    match pdu {
+        GfxPdu::WireToSurface1(pdu) => {
+            assert_eq!(pdu.codec_id, ironrdp_egfx::pdu::Codec1Type::Planar);
+            assert_eq!(pdu.bitmap_data, planar_data);
+            assert_eq!(pdu.destination_rectangle.right, 1280);
+            assert_eq!(pdu.destination_rectangle.bottom, 720);
+        }
+        pdu => panic!("expected WireToSurface1, got {pdu:?}"),
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Add a server-side `GraphicsPipelineServer::send_planar_frame` API for transmitting pre-encoded RDP6 Planar bitmap streams through EGFX `WireToSurface1`.

The method follows the existing AVC and uncompressed frame APIs:

- waits for EGFX capability negotiation to complete
- respects frame-acknowledgement backpressure and records it in QoE metrics
- validates the target surface
- clips the destination size to the surface dimensions
- queues the required `StartFrame` / `WireToSurface1` / `EndFrame` sequence
- uses `Codec1Type::Planar` (`0x0a`)

## Why

Some EGFX clients, including Microsoft Remote Desktop on Android, advertise `AVC_DISABLED`. They can still consume compressed desktop graphics through the RDP6 Planar codec, but IronRDP currently exposes no server-side API for sending a Planar payload.

Without this path, downstream servers must either fall back to uncompressed EGFX frames, leave the managed EGFX pipeline, or construct protocol PDUs outside `GraphicsPipelineServer`. Exposing Planar alongside the existing AVC, uncompressed, and progressive APIs keeps frame sequencing, acknowledgement-based flow control, surface validation, and QoE accounting inside the library.

This is also a small step toward the multi-codec server API discussed in #1158.

## Validation

- Added an integration test that negotiates an AVC-disabled EGFX session, sends a Planar frame, decompresses the ZGFX output, decodes the PDU, and verifies:
  - `WireToSurface1` is used
  - codec ID is Planar
  - the payload is preserved
  - the destination rectangle is correct
- `cargo test -p ironrdp-testsuite-core --test integration_tests_core planar_frame_uses_planar_codec`
- `cargo check -p ironrdp-egfx`
- `cargo fmt --all -- --check`
- Tested downstream with Microsoft Remote Desktop for Android through `lamco-rdp-server`

## Notes

This PR only exposes transmission of an already encoded Planar stream. It intentionally does not add a Planar encoder or downstream-specific codec-selection policy.