### PR TITLE
fix(egfx): preserve AVC_DISABLED during negotiation

### DIFF
--- a/crates/ironrdp-egfx/src/server.rs
+++ b/crates/ironrdp-egfx/src/server.rs
@@ -713,35 +713,136 @@ fn negotiate_capabilities(client_caps: &[CapabilitySet], server_caps: &[Capabili
 
 /// Intersect flags for matching capability set versions
 fn intersect_flags(client: &CapabilitySet, server: &CapabilitySet) -> CapabilitySet {
+    // AVC_DISABLED describes a client-side decoder constraint rather than a
+    // mutually supported feature. Preserve it in CapsConfirm while continuing
+    // to intersect all positive capability flags.
     match (client, server) {
         (CapabilitySet::V8 { flags: cf }, CapabilitySet::V8 { flags: sf }) => CapabilitySet::V8 { flags: *cf & *sf },
         (CapabilitySet::V8_1 { flags: cf }, CapabilitySet::V8_1 { flags: sf }) => {
             CapabilitySet::V8_1 { flags: *cf & *sf }
         }
-        (CapabilitySet::V10 { flags: cf }, CapabilitySet::V10 { flags: sf }) => CapabilitySet::V10 { flags: *cf & *sf },
-        (CapabilitySet::V10_2 { flags: cf }, CapabilitySet::V10_2 { flags: sf }) => {
-            CapabilitySet::V10_2 { flags: *cf & *sf }
-        }
-        (CapabilitySet::V10_3 { flags: cf }, CapabilitySet::V10_3 { flags: sf }) => {
-            CapabilitySet::V10_3 { flags: *cf & *sf }
-        }
-        (CapabilitySet::V10_4 { flags: cf }, CapabilitySet::V10_4 { flags: sf }) => {
-            CapabilitySet::V10_4 { flags: *cf & *sf }
-        }
-        (CapabilitySet::V10_5 { flags: cf }, CapabilitySet::V10_5 { flags: sf }) => {
-            CapabilitySet::V10_5 { flags: *cf & *sf }
-        }
-        (CapabilitySet::V10_6 { flags: cf }, CapabilitySet::V10_6 { flags: sf }) => {
-            CapabilitySet::V10_6 { flags: *cf & *sf }
-        }
-        (CapabilitySet::V10_6Err { flags: cf }, CapabilitySet::V10_6Err { flags: sf }) => {
-            CapabilitySet::V10_6Err { flags: *cf & *sf }
-        }
-        (CapabilitySet::V10_7 { flags: cf }, CapabilitySet::V10_7 { flags: sf }) => {
-            CapabilitySet::V10_7 { flags: *cf & *sf }
-        }
+        (CapabilitySet::V10 { flags: cf }, CapabilitySet::V10 { flags: sf }) => CapabilitySet::V10 {
+            flags: (*cf & *sf) | (*cf & CapabilitiesV10Flags::AVC_DISABLED),
+        },
+        (CapabilitySet::V10_2 { flags: cf }, CapabilitySet::V10_2 { flags: sf }) => CapabilitySet::V10_2 {
+            flags: (*cf & *sf) | (*cf & CapabilitiesV10Flags::AVC_DISABLED),
+        },
+        (CapabilitySet::V10_3 { flags: cf }, CapabilitySet::V10_3 { flags: sf }) => CapabilitySet::V10_3 {
+            flags: (*cf & *sf) | (*cf & CapabilitiesV103Flags::AVC_DISABLED),
+        },
+        (CapabilitySet::V10_4 { flags: cf }, CapabilitySet::V10_4 { flags: sf }) => CapabilitySet::V10_4 {
+            flags: (*cf & *sf) | (*cf & CapabilitiesV104Flags::AVC_DISABLED),
+        },
+        (CapabilitySet::V10_5 { flags: cf }, CapabilitySet::V10_5 { flags: sf }) => CapabilitySet::V10_5 {
+            flags: (*cf & *sf) | (*cf & CapabilitiesV104Flags::AVC_DISABLED),
+        },
+        (CapabilitySet::V10_6 { flags: cf }, CapabilitySet::V10_6 { flags: sf }) => CapabilitySet::V10_6 {
+            flags: (*cf & *sf) | (*cf & CapabilitiesV104Flags::AVC_DISABLED),
+        },
+        (CapabilitySet::V10_6Err { flags: cf }, CapabilitySet::V10_6Err { flags: sf }) => CapabilitySet::V10_6Err {
+            flags: (*cf & *sf) | (*cf & CapabilitiesV104Flags::AVC_DISABLED),
+        },
+        (CapabilitySet::V10_7 { flags: cf }, CapabilitySet::V10_7 { flags: sf }) => CapabilitySet::V10_7 {
+            flags: (*cf & *sf) | (*cf & CapabilitiesV107Flags::AVC_DISABLED),
+        },
         // V10_1 has no flags; mismatched variants return server as-is.
         _ => server.clone(),
+    }
+}
+
+#[cfg(test)]
+mod capability_negotiation_tests {
+    use super::*;
+
+    #[test]
+    fn preserves_client_avc_disabled_constraint() {
+        let cases = [
+            (
+                CapabilitySet::V10 {
+                    flags: CapabilitiesV10Flags::AVC_DISABLED | CapabilitiesV10Flags::SMALL_CACHE,
+                },
+                CapabilitySet::V10 {
+                    flags: CapabilitiesV10Flags::SMALL_CACHE,
+                },
+            ),
+            (
+                CapabilitySet::V10_2 {
+                    flags: CapabilitiesV10Flags::AVC_DISABLED | CapabilitiesV10Flags::SMALL_CACHE,
+                },
+                CapabilitySet::V10_2 {
+                    flags: CapabilitiesV10Flags::SMALL_CACHE,
+                },
+            ),
+            (
+                CapabilitySet::V10_3 {
+                    flags: CapabilitiesV103Flags::AVC_DISABLED | CapabilitiesV103Flags::AVC_THIN_CLIENT,
+                },
+                CapabilitySet::V10_3 {
+                    flags: CapabilitiesV103Flags::AVC_THIN_CLIENT,
+                },
+            ),
+            (
+                CapabilitySet::V10_4 {
+                    flags: CapabilitiesV104Flags::AVC_DISABLED | CapabilitiesV104Flags::SMALL_CACHE,
+                },
+                CapabilitySet::V10_4 {
+                    flags: CapabilitiesV104Flags::SMALL_CACHE,
+                },
+            ),
+            (
+                CapabilitySet::V10_5 {
+                    flags: CapabilitiesV104Flags::AVC_DISABLED | CapabilitiesV104Flags::SMALL_CACHE,
+                },
+                CapabilitySet::V10_5 {
+                    flags: CapabilitiesV104Flags::SMALL_CACHE,
+                },
+            ),
+            (
+                CapabilitySet::V10_6 {
+                    flags: CapabilitiesV104Flags::AVC_DISABLED | CapabilitiesV104Flags::SMALL_CACHE,
+                },
+                CapabilitySet::V10_6 {
+                    flags: CapabilitiesV104Flags::SMALL_CACHE,
+                },
+            ),
+            (
+                CapabilitySet::V10_6Err {
+                    flags: CapabilitiesV104Flags::AVC_DISABLED | CapabilitiesV104Flags::SMALL_CACHE,
+                },
+                CapabilitySet::V10_6Err {
+                    flags: CapabilitiesV104Flags::SMALL_CACHE,
+                },
+            ),
+            (
+                CapabilitySet::V10_7 {
+                    flags: CapabilitiesV107Flags::AVC_DISABLED | CapabilitiesV107Flags::SMALL_CACHE,
+                },
+                CapabilitySet::V10_7 {
+                    flags: CapabilitiesV107Flags::SMALL_CACHE,
+                },
+            ),
+        ];
+
+        for (client, server) in cases {
+            assert_eq!(intersect_flags(&client, &server), client);
+        }
+    }
+
+    #[test]
+    fn continues_to_intersect_positive_capability_flags() {
+        let client = CapabilitySet::V10_4 {
+            flags: CapabilitiesV104Flags::SMALL_CACHE,
+        };
+        let server = CapabilitySet::V10_4 {
+            flags: CapabilitiesV104Flags::empty(),
+        };
+
+        assert_eq!(
+            intersect_flags(&client, &server),
+            CapabilitySet::V10_4 {
+                flags: CapabilitiesV104Flags::empty(),
+            }
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Preserve the client-provided `AVC_DISABLED` flag when negotiating EGFX capability sets while continuing to intersect normal positive feature flags.

The fix covers every typed capability version that defines `AVC_DISABLED`:

- V10 and V10.2
- V10.3
- V10.4, V10.5, V10.6, and the V10.6 compatibility variant
- V10.7

## Why

`AVC_DISABLED` is different from ordinary capability bits: it describes a client-side decoder constraint. A client sets it to state that AVC420/AVC444 decoding is unavailable.

The current negotiation code treats every flag as a mutually supported positive feature and computes:

```text
client_flags & server_flags
```

A server normally does not advertise that its own AVC decoder is disabled, so this operation removes the client's constraint from `CapabilitiesConfirm`. The negotiated state can then report AVC support even though the client explicitly disabled it.

This was reproduced with Microsoft Remote Desktop for Android advertising a V10.4 capability set containing `AVC_DISABLED | SMALL_CACHE`. After the flag was removed during confirmation, the server and client disagreed about the available codec path. Preserving the constraint keeps the negotiated state faithful to the client and allows the server to select a non-AVC path such as Planar.

The relevant capability definitions are documented in MS-RDPEGFX:

- [RDPGFX_CAPSET_VERSION10](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpegfx/d1899912-2b84-4e0d-9e6d-da0fd25d14bc)
- [RDPGFX_CAPSET_VERSION103](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpegfx/a73e87d5-10c3-4d3f-b00c-fd5579570a0b)
- [RDPGFX_CAPSET_VERSION104](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpegfx/be5ea8da-44db-478d-b55c-d42d82f11d26)
- [RDPGFX_CAPSET_VERSION107](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpegfx/ba94595b-04de-4fbd-8ee4-89d8ff8f5cf1)

## Implementation

For capability versions containing `AVC_DISABLED`, negotiation now computes:

```text
(client_flags & server_flags) | (client_flags & AVC_DISABLED)
```

This preserves only the negative client constraint. All other flags retain the existing intersection behavior.

## Validation

Added unit tests that verify:

- `AVC_DISABLED` survives negotiation for every supported capability version that defines it
- mutually supported positive flags are retained
- unsupported positive flags are still removed

Commands run:

- `cargo test -p ironrdp-egfx capability_negotiation_tests`
- `cargo check -p ironrdp-egfx`
- `cargo fmt --all -- --check`
- `git diff --check`

The V10.4 behavior was also validated downstream with Microsoft Remote Desktop for Android through `lamco-rdp-server`.

## Relationship to Planar support

This fix is independent of, but complementary to, #1454. That PR exposes a Planar frame sender; this PR ensures an AVC-disabled client remains identified as such after capability negotiation.