### PR TITLE
feat(rdpeusb)!: type URB completion payloads

### DIFF
--- a/crates/ironrdp-rdpeusb/src/client.rs
+++ b/crates/ironrdp-rdpeusb/src/client.rs
@@ -464,11 +464,16 @@ fn build_transfer_in_completion(
             output_buffer_size,
         }))
     } else {
+        let ts_urb_result = response
+            .ts_urb_result
+            .try_into_isoch()
+            .map_err(|_| pdu_other_err!("URB_COMPLETION result payload must be header-only or isochronous"))?;
+
         Ok(Box::new(UrbCompletion {
             msg_id: pending.msg_id,
             completion_iface,
             req_id,
-            ts_urb_result: response.ts_urb_result,
+            ts_urb_result,
             hresult: response.hresult,
             output_buffer: response.output_buffer,
         }))

--- a/crates/ironrdp-rdpeusb/src/io/mod.rs
+++ b/crates/ironrdp-rdpeusb/src/io/mod.rs
@@ -35,6 +35,7 @@ pub use crate::pdu::{
     utils::{HResult, RequestId},
 };
 use crate::pdu::{
+    completion::ts_urb_result::TsUrbResultPayload,
     header::{InterfaceId, MessageId},
     sink::{AddDevice, NoAckIsochWriteJitterBufSizeInMs},
     usb_dev::ts_urb::{TsUrbIn, TsUrbOut, utils::TsUrbHeader},
@@ -79,7 +80,7 @@ pub struct IoControlCompletionResult {
 #[derive(Debug, Clone)]
 pub struct TransferInCompletionResult {
     /// USB request-block result, including the USBD status and any operation-specific result.
-    pub ts_urb_result: TsUrbResult,
+    pub ts_urb_result: TsUrbResult<TsUrbResultPayload>,
     /// HRESULT returned by the transfer operation.
     pub hresult: HResult,
     /// Data read from the USB device.
@@ -95,7 +96,7 @@ pub struct TransferInCompletionResult {
 #[derive(Debug, Clone)]
 pub struct TransferOutCompletionResult {
     /// USB request-block result, including the USBD status and any operation-specific result.
-    pub ts_urb_result: TsUrbResult,
+    pub ts_urb_result: TsUrbResult<TsUrbResultPayload>,
     /// HRESULT returned by the transfer operation.
     pub hresult: HResult,
     /// Number of bytes written to the USB device.

--- a/crates/ironrdp-rdpeusb/src/pdu/completion/mod.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/completion/mod.rs
@@ -14,7 +14,7 @@ use ironrdp_core::{
 use ironrdp_dvc::DvcEncode;
 use ironrdp_pdu::utils::strict_sum;
 
-use crate::pdu::completion::ts_urb_result::{TsUrbIsochTransferResult, TsUrbResult, TsUrbResultPayload};
+use crate::pdu::completion::ts_urb_result::{Raw, TsUrbIsochTransferResult, TsUrbResult, TsUrbResultPayload};
 use crate::pdu::header::{FunctionId, InterfaceId, Mask, MessageId, SharedMsgHeader};
 #[cfg(doc)]
 use crate::pdu::usb_dev::{
@@ -166,6 +166,20 @@ impl Encode for IoControlCompletion {
 
 impl DvcEncode for IoControlCompletion {}
 
+fn decode_raw_ts_urb_result(src: &mut ReadCursor<'_>, size: usize) -> DecodeResult<TsUrbResult<Raw>> {
+    ensure_size!(in: src, size: size);
+    let mut result_src = ReadCursor::new(src.read_slice(size));
+    let result = TsUrbResult::decode(&mut result_src)?;
+    if !result_src.is_empty() {
+        return Err(invalid_field_err!(
+            "CbTsUrbResult",
+            "does not match TS_URB_RESULT_HEADER::Size"
+        ));
+    }
+
+    Ok(result)
+}
+
 /// [\[MS-RDPEUSB\] 2.2.7.2 URB Completion (URB_COMPLETION)][1] packet.
 ///
 /// Sent from the client to the server as the final result of a [`TransferInRequest`] that contains
@@ -180,7 +194,7 @@ pub struct UrbCompletion {
     /// [`RegisterRequestCallback`] message.
     pub completion_iface: InterfaceId,
     pub req_id: RequestIdTransferInOut,
-    pub ts_urb_result: TsUrbResult,
+    pub ts_urb_result: TsUrbResult<TsUrbIsochTransferResult>,
     pub hresult: HResult,
     pub output_buffer: Vec<u8>,
 }
@@ -193,23 +207,12 @@ impl UrbCompletion {
             function_id: Some(FunctionId::URB_COMPLETION),
         }
     }
-
     pub(crate) fn decode(src: &mut ReadCursor<'_>, msg_id: MessageId, udev_iface: InterfaceId) -> DecodeResult<Self> {
         ensure_size!(in: src, size: 4 /* RequestId */ + 4 /* CbTsUrbResult */);
         let req_id = RequestIdTransferInOut::try_from(src.read_u32())?;
 
         let cb_ts_urb_result: usize = src.read_u32().try_into().map_err(|e| other_err!(source: e))?;
-        ensure_size!(in: src, size: cb_ts_urb_result);
-        let mut ts_urb_result = TsUrbResult::decode(&mut ReadCursor::new(src.read_slice(cb_ts_urb_result)))?;
-        let TsUrbResultPayload::Raw(bytes) = ts_urb_result.payload else {
-            unreachable!("TsUrbResultPayload::decode always returns Raw(_)")
-        };
-        ts_urb_result.payload = if bytes.is_empty() {
-            TsUrbResultPayload::Raw(bytes)
-        } else {
-            // URB_COMPLETION's TsUrbResult can only have a payload iff it's isoch
-            TsUrbResultPayload::Isoch(TsUrbIsochTransferResult::decode(&mut ReadCursor::new(&bytes))?)
-        };
+        let ts_urb_result = decode_raw_ts_urb_result(src, cb_ts_urb_result)?.into_isoch()?;
 
         ensure_size!(in: src, size: 4 /* HResult */ + 4 /* OutputBufferSize */);
         let hresult = src.read_u32();
@@ -235,14 +238,6 @@ impl Encode for UrbCompletion {
         match u32::try_from(self.ts_urb_result.size()) {
             Ok(cb_ts_urb_result) => dst.write_u32(cb_ts_urb_result),
             Err(e) => return Err(other_err!(source: e)),
-        }
-        if !matches!(self.ts_urb_result.payload, TsUrbResultPayload::Isoch(_))
-            && self.ts_urb_result.payload != TsUrbResultPayload::Raw(Vec::new())
-        {
-            return Err(invalid_field_err!(
-                "URB_COMPLETION::TsUrbResult",
-                "has non-empty payload but payload is not TS_URB_ISOCH_TRANSFER_RESULT"
-            ));
         }
 
         self.ts_urb_result.encode(dst)?;
@@ -277,18 +272,18 @@ impl DvcEncode for UrbCompletion {}
 /// [1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeusb/994fac8f-d258-47a6-aa35-48783abe49ec
 #[doc(alias = "URB_COMPLETION_NO_DATA")]
 #[derive(Debug, PartialEq, Clone)]
-pub struct UrbCompletionNoData {
+pub struct UrbCompletionNoData<P> {
     pub msg_id: MessageId,
     /// The interface ID provided by the server in the `RequestCompletion` field of the prior
     /// [`RegisterRequestCallback`] message.
     pub completion_iface: InterfaceId,
     pub req_id: RequestIdTransferInOut,
-    pub ts_urb_result: TsUrbResult,
+    pub ts_urb_result: TsUrbResult<P>,
     pub hresult: HResult,
     pub output_buffer_size: u32,
 }
 
-impl UrbCompletionNoData {
+impl<T> UrbCompletionNoData<T> {
     pub fn header(&self) -> SharedMsgHeader {
         SharedMsgHeader {
             iface_id: self.completion_iface.with_mask(Mask::Proxy),
@@ -296,14 +291,15 @@ impl UrbCompletionNoData {
             function_id: Some(FunctionId::URB_COMPLETION_NO_DATA),
         }
     }
+}
 
+impl UrbCompletionNoData<Raw> {
     pub(crate) fn decode(src: &mut ReadCursor<'_>, msg_id: MessageId, udev_iface: InterfaceId) -> DecodeResult<Self> {
         ensure_size!(in: src, size: 4 /* RequestId */ + 4 /* CbTsUrbResult */);
         let req_id = RequestIdTransferInOut::try_from(src.read_u32())?;
 
         let cb_ts_urb_result = usize::try_from(src.read_u32()).map_err(|e| other_err!(source: e))?;
-        ensure_size!(in: src, size: cb_ts_urb_result);
-        let ts_urb_result = TsUrbResult::decode(&mut ReadCursor::new(src.read_slice(cb_ts_urb_result)))?;
+        let ts_urb_result = decode_raw_ts_urb_result(src, cb_ts_urb_result)?;
         ensure_size!(in: src, size: 4 /* HResult */ + 4 /* OutputBufferSize */);
         let hresult = src.read_u32();
         let output_buffer_size = src.read_u32();
@@ -318,7 +314,7 @@ impl UrbCompletionNoData {
     }
 }
 
-impl Encode for UrbCompletionNoData {
+impl Encode for UrbCompletionNoData<TsUrbResultPayload> {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         ensure_size!(in: dst, size: self.size());
         self.header().encode(dst)?;
@@ -347,4 +343,4 @@ impl Encode for UrbCompletionNoData {
     }
 }
 
-impl DvcEncode for UrbCompletionNoData {}
+impl DvcEncode for UrbCompletionNoData<TsUrbResultPayload> {}

--- a/crates/ironrdp-rdpeusb/src/pdu/completion/ts_urb_result.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/completion/ts_urb_result.rs
@@ -17,7 +17,9 @@ use crate::pdu::{
     header::SharedMsgHeader,
     usb_dev::{
         InternalIoControl, IoControl, RegisterRequestCallback, TransferInRequest, TransferOutRequest,
-        ts_urb::{TsUrb, TsUrbGetCurrFrameNum, TsUrbIsochTransfer, TsUrbSelectConfig, TsUrbSelectInterface},
+        ts_urb::{
+            TsUrbGetCurrFrameNum, TsUrbIn, TsUrbIsochTransfer, TsUrbOut, TsUrbSelectConfig, TsUrbSelectInterface,
+        },
     },
 };
 
@@ -29,12 +31,100 @@ use crate::pdu::{
 /// [1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeusb/5a797c73-8ea0-46db-901c-cfb56f1a04a0
 #[doc(alias = "TS_URB_RESULT")]
 #[derive(Debug, PartialEq, Clone)]
-pub struct TsUrbResult {
+pub struct TsUrbResult<P> {
     pub header: TsUrbResultHeader,
-    pub payload: TsUrbResultPayload,
+    pub payload: Option<P>,
 }
 
-impl Decode<'_> for TsUrbResult {
+#[derive(Debug, PartialEq, Clone)]
+pub struct Raw(Vec<u8>);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExpectedTsUrbResult {
+    HeaderOnly,
+    SelectConfig,
+    SelectIface,
+    FrameNum,
+    Isoch,
+}
+
+impl Raw {
+    fn into_option(self) -> Option<Self> {
+        if self.0.is_empty() { None } else { Some(self) }
+    }
+}
+
+impl Decode<'_> for Raw {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        Ok(Self(src.remaining().into()))
+    }
+}
+
+fn decode_exact<T>(raw: Raw, decode: impl FnOnce(&mut ReadCursor<'_>) -> DecodeResult<T>) -> DecodeResult<T> {
+    let mut src = ReadCursor::new(&raw.0);
+    let value = decode(&mut src)?;
+    if !src.is_empty() {
+        return Err(invalid_field_err!("TS_URB_RESULT::Payload", "contains trailing bytes"));
+    }
+
+    Ok(value)
+}
+
+impl TsUrbResult<Raw> {
+    pub(crate) fn into_isoch(self) -> DecodeResult<TsUrbResult<TsUrbIsochTransferResult>> {
+        let payload = self
+            .payload
+            .map(|raw| decode_exact(raw, TsUrbIsochTransferResult::decode))
+            .transpose()?;
+
+        Ok(TsUrbResult {
+            header: self.header,
+            payload,
+        })
+    }
+
+    pub(crate) fn into_expected(self, expected: ExpectedTsUrbResult) -> DecodeResult<TsUrbResult<TsUrbResultPayload>> {
+        let Self { header, payload } = self;
+
+        if expected == ExpectedTsUrbResult::HeaderOnly {
+            if payload.is_some() {
+                return Err(invalid_field_err!(
+                    "TS_URB_RESULT::Payload",
+                    "expected a header-only result"
+                ));
+            }
+
+            return Ok(TsUrbResult { header, payload: None });
+        }
+
+        let raw = payload.ok_or_else(|| {
+            invalid_field_err!("TS_URB_RESULT::Payload", "operation-specific result payload is missing")
+        })?;
+
+        let payload = match expected {
+            ExpectedTsUrbResult::SelectConfig => {
+                TsUrbResultPayload::SelectConfig(decode_exact(raw, TsUrbSelectConfigResult::decode)?)
+            }
+            ExpectedTsUrbResult::SelectIface => {
+                TsUrbResultPayload::SelectIface(decode_exact(raw, TsUrbSelectInterfaceResult::decode)?)
+            }
+            ExpectedTsUrbResult::FrameNum => {
+                TsUrbResultPayload::FrameNum(decode_exact(raw, TsUrbGetCurrFrameNumResult::decode)?)
+            }
+            ExpectedTsUrbResult::Isoch => {
+                TsUrbResultPayload::Isoch(decode_exact(raw, TsUrbIsochTransferResult::decode)?)
+            }
+            ExpectedTsUrbResult::HeaderOnly => unreachable!("handled above"),
+        };
+
+        Ok(TsUrbResult {
+            header,
+            payload: Some(payload),
+        })
+    }
+}
+
+impl Decode<'_> for TsUrbResult<Raw> {
     fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
         ensure_size!(in: src, size: size_of::<u16>(/* TS_URB_RESULT_HEADER::Size */));
         let urb_size: usize = src.read_u16().into();
@@ -45,17 +135,54 @@ impl Decode<'_> for TsUrbResult {
         }
         let payload_size = urb_size - ACTUAL_HEADER_SIZE;
         ensure_size!(in: src, size: payload_size);
-        let payload = TsUrbResultPayload::decode(&mut ReadCursor::new(src.read_slice(payload_size)))?;
+        let payload = Raw::decode(&mut ReadCursor::new(src.read_slice(payload_size)))?.into_option();
         Ok(Self { header, payload })
     }
 }
 
-impl Encode for TsUrbResult {
+impl TsUrbResult<TsUrbIsochTransferResult> {
+    pub(crate) fn into_expected(self, expected: ExpectedTsUrbResult) -> DecodeResult<TsUrbResult<TsUrbResultPayload>> {
+        let payload = match (expected, self.payload) {
+            (ExpectedTsUrbResult::HeaderOnly, None) => None,
+            (ExpectedTsUrbResult::Isoch, Some(payload)) => Some(TsUrbResultPayload::Isoch(payload)),
+            _ => {
+                return Err(invalid_field_err!(
+                    "URB_COMPLETION::TsUrbResult",
+                    "result payload does not match the original TS_URB request"
+                ));
+            }
+        };
+
+        Ok(TsUrbResult {
+            header: self.header,
+            payload,
+        })
+    }
+}
+
+impl TsUrbResult<TsUrbResultPayload> {
+    pub(crate) fn try_into_isoch(self) -> Result<TsUrbResult<TsUrbIsochTransferResult>, Self> {
+        let Self { header, payload } = self;
+        match payload {
+            None => Ok(TsUrbResult { header, payload: None }),
+            Some(TsUrbResultPayload::Isoch(payload)) => Ok(TsUrbResult {
+                header,
+                payload: Some(payload),
+            }),
+            payload => Err(TsUrbResult { header, payload }),
+        }
+    }
+}
+
+impl<P: Encode> Encode for TsUrbResult<P> {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         ensure_size!(in: dst, size: self.size());
         dst.write_u16(self.size().try_into().map_err(|e| other_err!(source: e))?);
         self.header.encode(dst)?;
-        self.payload.encode(dst)
+        if let Some(p) = &self.payload {
+            p.encode(dst)?;
+        }
+        Ok(())
     }
 
     fn name(&self) -> &'static str {
@@ -63,7 +190,9 @@ impl Encode for TsUrbResult {
     }
 
     fn size(&self) -> usize {
-        size_of::<u16>(/* TS_URB_RESULT_HEADER::Size */) + self.header.size() + self.payload.size()
+        size_of::<u16>(/* TS_URB_RESULT_HEADER::Size */)
+            + self.header.size()
+            + self.payload.as_ref().map_or(0, Encode::size)
     }
 }
 
@@ -111,21 +240,11 @@ impl Encode for TsUrbResultHeader {
     }
 }
 
-/// Extra payload for (any of) the [`TsUrbResult`] structures in addition to the header.
+/// Operation-specific payload for a [`TsUrbResult`].
 ///
-/// While encoding, any of the non-[`Raw`][1] variants should be used. On decoding, always gives a
-/// [`Raw`][1] variant. The raw bytes will have to be decoded to any of the non-raw variants
-/// depending upon the `RequestId` field of the outer [`UrbCompletionNoData`] packet. For a
-/// [`UrbCompletion`] packet, the payload can, and should, always be decoded to
-/// [`TsUrbIsochTransferResult`]. In the case there's no extra payload, this will decode to a
-/// `Raw(vec![])`.
-///
-/// [1]: TsUrbResultPayload::Raw
-//
-// The Raw variant exists cause successfully decoding to an actual result variant will require
-// request id's for all four variants, passed by the state machine from outside mod pdu. Instead,
-// we could return Raw variant by default while decoding (or merely "reading" in this case) and
-// using request ID the raw bytes can be synthesized into actual variants.
+/// A result with no operation-specific fields is represented by `TsUrbResult::payload == None`.
+/// A raw [`UrbCompletionNoData`] payload is resolved to one of these variants by correlating its
+/// request ID with the original TS_URB request.
 #[non_exhaustive]
 #[doc(alias = "TS_URB_RESULT")]
 #[derive(Debug, PartialEq, Clone)]
@@ -134,14 +253,6 @@ pub enum TsUrbResultPayload {
     SelectIface(TsUrbSelectInterfaceResult),
     FrameNum(TsUrbGetCurrFrameNumResult),
     Isoch(TsUrbIsochTransferResult),
-    Raw(Vec<u8>),
-}
-
-impl Decode<'_> for TsUrbResultPayload {
-    /// Reads all remaining bytes. Decode to the [`Raw`][TsUrbResultPayload::Raw] variant.
-    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
-        Ok(Self::Raw(src.remaining().into()))
-    }
 }
 
 impl Encode for TsUrbResultPayload {
@@ -151,11 +262,6 @@ impl Encode for TsUrbResultPayload {
             Self::SelectIface(select_iface_res_payload) => select_iface_res_payload.encode(dst),
             Self::FrameNum(frame_num_res_payload) => frame_num_res_payload.encode(dst),
             Self::Isoch(isoch_transfer_res_payload) => isoch_transfer_res_payload.encode(dst),
-            Self::Raw(bytes) => {
-                ensure_size!(in: dst, size: bytes.len());
-                dst.write_slice(bytes);
-                Ok(())
-            }
         }
     }
 
@@ -165,7 +271,6 @@ impl Encode for TsUrbResultPayload {
             Self::SelectIface(payload) => payload.name(),
             Self::FrameNum(payload) => payload.name(),
             Self::Isoch(payload) => payload.name(),
-            Self::Raw(_) => "TS_URB_RESULT (raw payload)",
         }
     }
 
@@ -175,7 +280,6 @@ impl Encode for TsUrbResultPayload {
             Self::SelectIface(payload) => payload.size(),
             Self::FrameNum(payload) => payload.size(),
             Self::Isoch(payload) => payload.size(),
-            Self::Raw(bytes) => bytes.len(),
         }
     }
 }

--- a/crates/ironrdp-rdpeusb/src/pdu/mod.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/mod.rs
@@ -11,6 +11,7 @@ use ironrdp_core::{
 };
 
 use crate::pdu::caps::{RimExchangeCapabilityRequest, RimExchangeCapabilityResponse};
+use crate::pdu::completion::ts_urb_result::{Raw, TsUrbResultPayload};
 use crate::pdu::completion::{IoControlCompletion, UrbCompletion, UrbCompletionNoData};
 use crate::pdu::header::{FunctionId, InterfaceId, Mask, SharedMsgHeader, unpack};
 use crate::pdu::iface_manipulation::{InterfaceRelease, QueryInterfaceRequest};
@@ -217,13 +218,13 @@ pub enum UrbdrcClientControlPdu {
     QueryIfaceReq(QueryInterfaceRequest),
 }
 
-pub enum UrbdrcClientDevicePdu {
+pub enum UrbdrcClientDevicePdu<P> {
     ChanCreated(ChannelCreated),
     AddDev(AddDevice),
     DevTextRsp(QueryDeviceTextRsp),
     IoctlComp(IoControlCompletion),
     UrbComp(UrbCompletion),
-    UrbCompNoData(UrbCompletionNoData),
+    UrbCompNoData(UrbCompletionNoData<P>),
     IfaceRelease(InterfaceRelease),
     QueryIfaceReq(QueryInterfaceRequest),
 }
@@ -272,7 +273,7 @@ impl Decode<'_> for UrbdrcClientControlPdu {
     }
 }
 
-impl UrbdrcClientDevicePdu {
+impl<P> UrbdrcClientDevicePdu<P> {
     fn decode_sink(src: &mut ReadCursor<'_>, header: SharedMsgHeader) -> DecodeResult<Self> {
         ensure_size!(in: src, size: 4 /* function id */);
         let f_id = FunctionId(src.read_u32());
@@ -301,7 +302,7 @@ impl UrbdrcClientDevicePdu {
     }
 }
 
-impl Decode<'_> for UrbdrcClientDevicePdu {
+impl Decode<'_> for UrbdrcClientDevicePdu<Raw> {
     fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
         let header = SharedMsgHeader::decode(src)?;
 
@@ -354,7 +355,7 @@ macro_rules! fill_client_ctl_pdu_arms {
 macro_rules! fill_client_dev_pdu_arms {
     ($pdu:expr, $($tokens:tt)*) => {{
         use UrbdrcClientDevicePdu::*;
-        match <&UrbdrcClientDevicePdu>::from($pdu) {
+        match <&UrbdrcClientDevicePdu<TsUrbResultPayload>>::from($pdu) {
             ChanCreated(channel_created) => channel_created$($tokens)*,
             IfaceRelease(iface_release) => iface_release$($tokens)*,
             QueryIfaceReq(query_iface_req) => query_iface_req$($tokens)*,
@@ -381,7 +382,7 @@ impl Encode for UrbdrcClientControlPdu {
     }
 }
 
-impl Encode for UrbdrcClientDevicePdu {
+impl Encode for UrbdrcClientDevicePdu<TsUrbResultPayload> {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         fill_client_dev_pdu_arms!(self, .encode(dst))
     }

--- a/crates/ironrdp-rdpeusb/src/server.rs
+++ b/crates/ironrdp-rdpeusb/src/server.rs
@@ -10,6 +10,7 @@ use crate::io::{
     TransferInCompletionResult, TransferInPacket, TransferOutCompletionResult, TransferOutPacket, UsbRetractReason,
 };
 use crate::pdu::caps::RimExchangeCapabilityRequest;
+use crate::pdu::completion::ts_urb_result::{ExpectedTsUrbResult, Raw};
 use crate::pdu::completion::{IoControlCompletion, UrbCompletion, UrbCompletionNoData};
 use crate::pdu::header::{InterfaceId, Mask, MessageId};
 use crate::pdu::iface_manipulation::{InterfaceRelease, QueryInterfaceFailureResponse};
@@ -17,6 +18,7 @@ use crate::pdu::notify::ChannelCreated;
 use crate::pdu::sink::NoAckIsochWriteJitterBufSizeInMs;
 use crate::pdu::usb_dev::{
     CancelRequest, QueryDeviceText, RegisterRequestCallback, RetractDevice, TransferInRequest, TransferOutRequest,
+    ts_urb::{TsUrbInKind, TsUrbOutKind},
 };
 use crate::pdu::utils::RequestId;
 use crate::pdu::{UrbdrcClientControlPdu, UrbdrcClientDevicePdu};
@@ -231,10 +233,51 @@ pub struct UrbdrcDeviceServer {
 }
 
 enum Pending {
-    IoCtl { max_output_buf_size: u32 },
-    InternalIoCtl { max_output_buf_size: u32 },
-    TransferIn { max_output_buf_size: u32 },
-    TransferOut { max_output_buf_size: u32 },
+    IoCtl {
+        max_output_buf_size: u32,
+    },
+    InternalIoCtl {
+        max_output_buf_size: u32,
+    },
+    TransferIn {
+        max_output_buf_size: u32,
+        expected_result: ExpectedTsUrbResult,
+    },
+    TransferOut {
+        max_output_buf_size: u32,
+        expected_result: ExpectedTsUrbResult,
+    },
+}
+
+fn expected_result_for_in(kind: &TsUrbInKind) -> ExpectedTsUrbResult {
+    match kind {
+        TsUrbInKind::SelectConfig(_) => ExpectedTsUrbResult::SelectConfig,
+        TsUrbInKind::SelectIface(_) => ExpectedTsUrbResult::SelectIface,
+        TsUrbInKind::GetCurFrameNum(_) => ExpectedTsUrbResult::FrameNum,
+        TsUrbInKind::IsochTransfer(_) => ExpectedTsUrbResult::Isoch,
+        TsUrbInKind::PipeReq(_)
+        | TsUrbInKind::CtlTransfer(_)
+        | TsUrbInKind::BulkInterruptTransfer(_)
+        | TsUrbInKind::CtlDescReq(_)
+        | TsUrbInKind::CtlFeatReq(_)
+        | TsUrbInKind::CtlGetStatus(_)
+        | TsUrbInKind::VendorClassReq(_)
+        | TsUrbInKind::CtlGetConfig(_)
+        | TsUrbInKind::CtlGetIface(_)
+        | TsUrbInKind::OsFeatDescReq(_)
+        | TsUrbInKind::CtlTransferEx(_) => ExpectedTsUrbResult::HeaderOnly,
+    }
+}
+
+fn expected_result_for_out(kind: &TsUrbOutKind) -> ExpectedTsUrbResult {
+    match kind {
+        TsUrbOutKind::IsochTransfer(_) => ExpectedTsUrbResult::Isoch,
+        TsUrbOutKind::CtlTransfer(_)
+        | TsUrbOutKind::BulkInterruptTransfer(_)
+        | TsUrbOutKind::CtlDescReq(_)
+        | TsUrbOutKind::VendorClassReq(_)
+        | TsUrbOutKind::CtlTransferEx(_) => ExpectedTsUrbResult::HeaderOnly,
+    }
 }
 
 impl UrbdrcDeviceServer {
@@ -331,6 +374,7 @@ impl UrbdrcDeviceServer {
         let udev_iface = self.usb_device_iface()?;
         let request_id = self.request_id_alloc.alloc();
         let output_buffer_size = request.output_buffer_size;
+        let expected_result = expected_result_for_in(&request.ts_urb.kind);
         let ts_urb = request.ts_urb.into_ts_urb(request_id)?;
         let pdu = TransferInRequest {
             msg_id: self.msg_alloc.alloc(),
@@ -345,6 +389,7 @@ impl UrbdrcDeviceServer {
             request_id,
             Pending::TransferIn {
                 max_output_buf_size: output_buffer_size,
+                expected_result,
             },
         )?;
 
@@ -367,6 +412,7 @@ impl UrbdrcDeviceServer {
 
         let request_id = self.request_id_alloc.alloc();
         let no_ack = request.ts_urb.no_ack;
+        let expected_result = expected_result_for_out(&request.ts_urb.kind);
         let no_ack_isoch_write_jitter_buf_size = self
             .no_ack_isoch_write_jitter_buf_size
             .ok_or_else(|| pdu_other_err!("USB device capabilities uninitialized"))?;
@@ -385,6 +431,7 @@ impl UrbdrcDeviceServer {
                 request_id,
                 Pending::TransferOut {
                     max_output_buf_size: output_buffer_size,
+                    expected_result,
                 },
             )?;
         }
@@ -488,7 +535,11 @@ impl UrbdrcDeviceServer {
 
         let request_id = RequestId::from(completion.req_id);
 
-        let Some(Pending::TransferIn { max_output_buf_size }) = self.pending_io.remove(&request_id) else {
+        let Some(Pending::TransferIn {
+            max_output_buf_size,
+            expected_result,
+        }) = self.pending_io.remove(&request_id)
+        else {
             return Err(pdu_other_err!("completion mismatch"));
         };
 
@@ -498,11 +549,16 @@ impl UrbdrcDeviceServer {
             return Err(pdu_other_err!("output buffer exceeds maximum amount"));
         }
 
+        let ts_urb_result = completion
+            .ts_urb_result
+            .into_expected(expected_result)
+            .map_err(|e| decode_err!(e))?;
+
         self.backend.transfer_in_completed(
             channel_id,
             request_id,
             TransferInCompletionResult {
-                ts_urb_result: completion.ts_urb_result,
+                ts_urb_result,
                 hresult: completion.hresult,
                 output_buffer: completion.output_buffer,
             },
@@ -514,7 +570,7 @@ impl UrbdrcDeviceServer {
     fn handle_urb_completion_no_data(
         &mut self,
         channel_id: u32,
-        completion: UrbCompletionNoData,
+        completion: UrbCompletionNoData<Raw>,
     ) -> PduResult<Vec<DvcMessage>> {
         if completion.completion_iface != self.comp_iface {
             return Ok(Vec::new());
@@ -525,30 +581,38 @@ impl UrbdrcDeviceServer {
             return Err(pdu_other_err!("completion mismatch"));
         };
 
-        let is_transfer_out = match pending {
-            Pending::TransferIn { .. } => {
+        let (is_transfer_out, expected_result) = match pending {
+            Pending::TransferIn { expected_result, .. } => {
                 if completion.output_buffer_size != 0 {
                     return Err(pdu_other_err!("output buffer size must be zero"));
                 }
-                false
+                (false, expected_result)
             }
-            Pending::TransferOut { max_output_buf_size } => {
+            Pending::TransferOut {
+                max_output_buf_size,
+                expected_result,
+            } => {
                 if completion.output_buffer_size > max_output_buf_size {
                     return Err(pdu_other_err!("output buffer exceeds maximum amount"));
                 }
-                true
+                (true, expected_result)
             }
             Pending::IoCtl { .. } | Pending::InternalIoCtl { .. } => {
                 return Err(pdu_other_err!("completion mismatch"));
             }
         };
 
+        let ts_urb_result = completion
+            .ts_urb_result
+            .into_expected(expected_result)
+            .map_err(|e| decode_err!(e))?;
+
         if is_transfer_out {
             self.backend.transfer_out_completed(
                 channel_id,
                 request_id,
                 TransferOutCompletionResult {
-                    ts_urb_result: completion.ts_urb_result,
+                    ts_urb_result,
                     hresult: completion.hresult,
                     output_buffer_size: completion.output_buffer_size,
                 },
@@ -558,7 +622,7 @@ impl UrbdrcDeviceServer {
                 channel_id,
                 request_id,
                 TransferInCompletionResult {
-                    ts_urb_result: completion.ts_urb_result,
+                    ts_urb_result,
                     hresult: completion.hresult,
                     output_buffer: Vec::new(),
                 },

--- a/crates/ironrdp-testsuite-core/tests/rdpeusb/client.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeusb/client.rs
@@ -10,6 +10,7 @@ use ironrdp_rdpeusb::client::{
 };
 use ironrdp_rdpeusb::io::*;
 use ironrdp_rdpeusb::pdu::caps::{Capability, RimExchangeCapabilityRequest};
+use ironrdp_rdpeusb::pdu::completion::ts_urb_result::Raw;
 use ironrdp_rdpeusb::pdu::header::InterfaceId;
 use ironrdp_rdpeusb::pdu::iface_manipulation::InterfaceRelease;
 use ironrdp_rdpeusb::pdu::notify::{ChannelCreated, Direction};
@@ -25,7 +26,7 @@ fn decode_control_msg(message: &DvcMessage) -> UrbdrcClientControlPdu {
     decode(&encoded).expect("decode should succeed")
 }
 
-fn decode_device_msg(message: &DvcMessage) -> UrbdrcClientDevicePdu {
+fn decode_device_msg(message: &DvcMessage) -> UrbdrcClientDevicePdu<Raw> {
     let encoded = encode_vec(message.as_ref()).expect("encode should succeed");
     decode(&encoded).expect("decode should succeed")
 }

--- a/crates/ironrdp-testsuite-core/tests/rdpeusb/io/transfers.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeusb/io/transfers.rs
@@ -13,10 +13,10 @@ use rstest::rstest;
 
 use super::{CHANNEL_ID, ClientEvent, ConnectedDevice, ServerEvent};
 
-fn successful_urb_result() -> TsUrbResult {
+fn successful_urb_result() -> TsUrbResult<TsUrbResultPayload> {
     TsUrbResult {
         header: TsUrbResultHeader { usbd_status: 0 },
-        payload: TsUrbResultPayload::Raw(Vec::new()),
+        payload: None,
     }
 }
 


### PR DESCRIPTION
## Why

URB result types are determined by their originating requests. Keeping results as raw bytes leaked wire details into the backend and allowed invalid request/result combinations.

## Impact

Pending requests now record the expected result type, and raw wire payloads are converted into typed results at the server boundary. Header-only results use `None`, while isochronous completions use `TsUrbIsochTransferResult` directly.

This is a breaking API change for RDPEUSB completion types.

cc @elmarco 