### PR TITLE
fix(ironrdp-pdu): tolerate unknown security header flags in BasicSecurityHeader

### DIFF
--- a/crates/ironrdp-pdu/src/rdp/headers.rs
+++ b/crates/ironrdp-pdu/src/rdp/headers.rs
@@ -68,8 +68,10 @@ impl<'de> Decode<'de> for BasicSecurityHeader {
     fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
         ensure_fixed_part_size!(in: src);
 
-        let flags = BasicSecurityHeaderFlags::from_bits(src.read_u16())
-            .ok_or_else(|| invalid_field_err!("securityHeader", "invalid basic security header"))?;
+        // Use from_bits_truncate to tolerate unknown flag bits that some servers
+        // (e.g., Windows Server 2019 with RDS licensing) may set.
+        // This matches FreeRDP behavior which masks for known flags without rejecting the PDU.
+        let flags = BasicSecurityHeaderFlags::from_bits_truncate(src.read_u16());
         let _flags_hi = src.read_u16(); // unused
 
         Ok(Self { flags })


### PR DESCRIPTION
## Summary

Use `from_bits_truncate()` instead of `from_bits()` when decoding `BasicSecurityHeader` flags. Some servers (e.g., Windows Server 2019 with RDS licensing / RD Connection Broker) send security header flag combinations that include bits not defined in the current bitflags enum. The strict `from_bits()` rejected these as invalid, causing connection failure during the `UpgradeLicense` license exchange phase.

This matches FreeRDP behavior which masks for known flags without rejecting the PDU when unrecognized bits are present.

## What was tested

- Existing unit tests pass (`cargo xtask check tests -v`)
- Lints pass (`cargo xtask check lints -v`)

Closes #1457