### PR TITLE
feat(connector): implement multitransport bootstrapping handshake

### DIFF
--- a/crates/ironrdp-async/src/connector.rs
+++ b/crates/ironrdp-async/src/connector.rs
@@ -78,6 +78,24 @@ where
     }
 
     let result = loop {
+        if connector.should_perform_multitransport() {
+            // Auto-skip multitransport bootstrapping: this driver does not own
+            // UDP transport setup, so it declines on the application's behalf
+            // and the connection continues TCP-only. Applications that want to
+            // participate in multitransport must drive the connector directly
+            // using `ClientConnector::complete_multitransport()` instead of
+            // calling `connect_finalize`.
+            buf.clear();
+            let written = connector.skip_multitransport(&mut buf)?;
+            if written.size().is_some() {
+                framed
+                    .write_all(buf.filled())
+                    .await
+                    .map_err(|e| ironrdp_connector::custom_err!("write all", e))?;
+            }
+            continue;
+        }
+
         single_sequence_step(framed, &mut connector, &mut buf).await?;
 
         if let ClientConnectorState::Connected { result } = connector.state {

--- a/crates/ironrdp-blocking/src/connector.rs
+++ b/crates/ironrdp-blocking/src/connector.rs
@@ -82,6 +82,23 @@ where
     debug!("Remaining of connection sequence");
 
     let result = loop {
+        if connector.should_perform_multitransport() {
+            // Auto-skip multitransport bootstrapping: this driver does not own
+            // UDP transport setup, so it declines on the application's behalf
+            // and the connection continues TCP-only. Applications that want to
+            // participate in multitransport must drive the connector directly
+            // using `ClientConnector::complete_multitransport()` instead of
+            // calling `connect_finalize`.
+            buf.clear();
+            let written = connector.skip_multitransport(&mut buf)?;
+            if written.size().is_some() {
+                framed
+                    .write_all(buf.filled())
+                    .map_err(|e| ironrdp_connector::custom_err!("write all", e))?;
+            }
+            continue;
+        }
+
         single_sequence_step(framed, &mut connector, &mut buf)?;
 
         if let ClientConnectorState::Connected { result } = connector.state {

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -106,12 +106,21 @@ pub enum ClientConnectorState {
         /// Multitransport requests received from the server so far.
         requests: Vec<rdp::multitransport::MultitransportRequestPdu>,
     },
-    /// The server sent multitransport request(s) and the connector is paused
-    /// waiting for the application to establish UDP transport or decline.
+    /// State the connector enters after the server has sent multitransport
+    /// request(s) and before resuming with the Demand Active PDU. The
+    /// connector surfaces this as an API yield point so the caller can run
+    /// UDP transport setup and report the outcome.
     ///
     /// Call [`ClientConnector::complete_multitransport()`] or
     /// [`ClientConnector::skip_multitransport()`] to advance. The buffered
-    /// Demand Active PDU is replayed internally — no re-feeding needed.
+    /// Demand Active PDU is replayed internally on resume; the caller does
+    /// not need to re-feed it.
+    ///
+    /// On the wire, TCP and UDP negotiation happen in parallel: the UDP
+    /// transport is established alongside the ongoing TCP handshake, and
+    /// its completion is a signal to the dynamic-channel layer that
+    /// subsequent channels may migrate to UDP. The connector's suspension
+    /// here is a Rust-API affordance, not a spec-mandated TCP pause.
     MultitransportPending {
         io_channel_id: u16,
         user_channel_id: u16,

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -19,6 +19,11 @@ use crate::{
     NegotiationFailure, Sequence, State, Written, encode_x224_packet, general_err, reason_err,
 };
 
+/// Maximum number of `Initiate Multitransport Request` PDUs the server is
+/// permitted to send during bootstrapping, per MS-RDPBCGR 2.2.15.1 (one per
+/// transport protocol: reliable + lossy UDP).
+const MAX_MULTITRANSPORT_REQUESTS: usize = 2;
+
 /// Outcome of a single multitransport bootstrapping request, passed to
 /// [`ClientConnector::complete_multitransport()`].
 ///
@@ -408,7 +413,7 @@ fn advance_licensing_exchange(
         ClientConnectorState::MultitransportBootstrapping {
             io_channel_id,
             user_channel_id,
-            requests: Vec::new(),
+            requests: Vec::with_capacity(MAX_MULTITRANSPORT_REQUESTS),
         }
     } else {
         ClientConnectorState::LicensingExchange {
@@ -822,10 +827,10 @@ impl Sequence for ClientConnector {
             //== Optional Multitransport Bootstrapping ==//
             //
             // The server may send 0, 1, or 2 Initiate Multitransport Request PDUs
-            // after licensing. We distinguish them from the Demand Active PDU by
-            // attempting to decode as MultitransportRequestPdu first — it has a
-            // distinctive structure (SEC_TRANSPORT_REQ flag + request_id + protocol
-            // + cookie). If decode fails, this is the Demand Active.
+            // after licensing (MS-RDPBCGR 2.2.15.1). We distinguish them from the
+            // Demand Active PDU by attempting to decode as MultitransportRequestPdu
+            // first; the decoder validates SEC_TRANSPORT_REQ internally, so a Demand
+            // Active PDU fails cleanly without false positives.
             ClientConnectorState::MultitransportBootstrapping {
                 io_channel_id,
                 user_channel_id,
@@ -833,11 +838,17 @@ impl Sequence for ClientConnector {
             } => {
                 let ctx = mcs::decode_send_data_indication(input).map_err(ConnectorError::decode)?;
 
-                // Try decoding as a multitransport request. The decoder validates
-                // the SEC_TRANSPORT_REQ flag, so a Demand Active PDU will fail
-                // cleanly without false positives.
                 match decode::<rdp::multitransport::MultitransportRequestPdu>(ctx.user_data) {
                     Ok(pdu) => {
+                        if requests.len() >= MAX_MULTITRANSPORT_REQUESTS {
+                            return Err(reason_err!(
+                                "MultitransportBootstrapping",
+                                "server sent more than {} multitransport requests (MS-RDPBCGR 2.2.15.1 caps the count at {})",
+                                MAX_MULTITRANSPORT_REQUESTS,
+                                MAX_MULTITRANSPORT_REQUESTS,
+                            ));
+                        }
+
                         debug!(
                             request_id = pdu.request_id,
                             protocol = ?pdu.requested_protocol,

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -19,6 +19,20 @@ use crate::{
     NegotiationFailure, Sequence, State, Written, encode_x224_packet, general_err, reason_err,
 };
 
+/// Outcome of a single multitransport bootstrapping request, passed to
+/// [`ClientConnector::complete_multitransport()`].
+///
+/// The connector uses this to build the response PDU internally, paired with
+/// the request ID and cookie from the server's original request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MultitransportResult {
+    /// UDP transport was established successfully (`S_OK`).
+    Success,
+    /// UDP transport failed. The `u32` is the HRESULT error code (typically
+    /// [`MultitransportResponsePdu::E_ABORT`](rdp::multitransport::MultitransportResponsePdu::E_ABORT)).
+    Failure(u32),
+}
+
 #[derive(Debug)]
 pub struct ConnectionResult {
     pub io_channel_id: u16,
@@ -80,9 +94,32 @@ pub enum ClientConnectorState {
         user_channel_id: u16,
         license_exchange: LicenseExchangeSequence,
     },
+    /// Reading the server's optional Initiate Multitransport Request PDU(s).
+    ///
+    /// The server may send 0, 1, or 2 requests (one per transport protocol).
+    /// If the first PDU on the IO channel after licensing is a Demand Active
+    /// (capabilities exchange), the server sent no multitransport requests and
+    /// the connector transitions directly to `CapabilitiesExchange`.
     MultitransportBootstrapping {
         io_channel_id: u16,
         user_channel_id: u16,
+        /// Multitransport requests received from the server so far.
+        requests: Vec<rdp::multitransport::MultitransportRequestPdu>,
+    },
+    /// The server sent multitransport request(s) and the connector is paused
+    /// waiting for the application to establish UDP transport or decline.
+    ///
+    /// Call [`ClientConnector::complete_multitransport()`] or
+    /// [`ClientConnector::skip_multitransport()`] to advance. The buffered
+    /// Demand Active PDU is replayed internally — no re-feeding needed.
+    MultitransportPending {
+        io_channel_id: u16,
+        user_channel_id: u16,
+        requests: Vec<rdp::multitransport::MultitransportRequestPdu>,
+        /// The raw Demand Active PDU bytes that arrived after the last
+        /// multitransport request. Replayed through the activation sequence
+        /// when the application completes or skips multitransport.
+        buffered_demand_active: Vec<u8>,
     },
     CapabilitiesExchange {
         connection_activation: ConnectionActivationSequence,
@@ -110,6 +147,7 @@ impl State for ClientConnectorState {
             Self::ConnectTimeAutoDetection { .. } => "ConnectTimeAutoDetection",
             Self::LicensingExchange { .. } => "LicensingExchange",
             Self::MultitransportBootstrapping { .. } => "MultitransportBootstrapping",
+            Self::MultitransportPending { .. } => "MultitransportPending",
             Self::CapabilitiesExchange {
                 connection_activation, ..
             } => connection_activation.state().name(),
@@ -211,6 +249,141 @@ impl ClientConnector {
         debug_assert!(!self.should_perform_credssp());
         assert_eq!(res, Written::Nothing);
     }
+
+    /// Returns `true` when the connector has collected all multitransport
+    /// requests from the server and is waiting for the application to either
+    /// establish the UDP transport(s) or decline them.
+    ///
+    /// The application should:
+    ///
+    /// 1. Call [`multitransport_requests()`](Self::multitransport_requests) to
+    ///    get the server's request(s)
+    /// 2. Establish UDP transport (RDPEUDP2 + TLS + RDPEMT) for each, or decide
+    ///    not to
+    /// 3. Call [`complete_multitransport()`](Self::complete_multitransport) with
+    ///    a [`MultitransportResult`] for each request, or
+    ///    [`skip_multitransport()`](Self::skip_multitransport) to decline all
+    pub fn should_perform_multitransport(&self) -> bool {
+        matches!(self.state, ClientConnectorState::MultitransportPending { .. })
+    }
+
+    /// Returns the multitransport request PDUs received from the server.
+    ///
+    /// Only meaningful when
+    /// [`should_perform_multitransport()`](Self::should_perform_multitransport)
+    /// returns `true`.
+    pub fn multitransport_requests(&self) -> &[rdp::multitransport::MultitransportRequestPdu] {
+        match &self.state {
+            ClientConnectorState::MultitransportPending { requests, .. } => requests,
+            _ => &[],
+        }
+    }
+
+    /// Send multitransport response PDU(s) and advance past the bootstrapping
+    /// phase to capabilities exchange.
+    ///
+    /// Pass one [`MultitransportResult`] per request (in the same order as
+    /// [`multitransport_requests()`](Self::multitransport_requests)). The
+    /// connector builds the response PDUs internally using the stored request
+    /// IDs and cookies, then replays the buffered Demand Active PDU through
+    /// the activation sequence.
+    ///
+    /// Returns an error if the connector is not in `MultitransportPending`
+    /// state, or if `results.len()` does not match the number of pending
+    /// requests.
+    pub fn complete_multitransport(
+        &mut self,
+        results: &[MultitransportResult],
+        output: &mut WriteBuf,
+    ) -> ConnectorResult<Written> {
+        let ClientConnectorState::MultitransportPending {
+            io_channel_id,
+            user_channel_id,
+            requests,
+            buffered_demand_active,
+        } = mem::replace(&mut self.state, ClientConnectorState::Consumed)
+        else {
+            return Err(general_err!(
+                "complete_multitransport called outside MultitransportPending state"
+            ));
+        };
+
+        if results.len() != requests.len() {
+            return Err(general_err!(
+                "multitransport results count does not match requests count"
+            ));
+        }
+
+        let mut total_written = 0;
+
+        for (request, result) in requests.iter().zip(results) {
+            let response = match result {
+                MultitransportResult::Success => {
+                    rdp::multitransport::MultitransportResponsePdu::success(request.request_id)
+                }
+                MultitransportResult::Failure(hr) => rdp::multitransport::MultitransportResponsePdu {
+                    security_header: rdp::headers::BasicSecurityHeader {
+                        flags: rdp::headers::BasicSecurityHeaderFlags::TRANSPORT_RSP,
+                    },
+                    request_id: request.request_id,
+                    hr_response: *hr,
+                },
+            };
+            total_written += encode_send_data_request(user_channel_id, io_channel_id, &response, output)?;
+        }
+
+        // Replay the buffered Demand Active through the activation sequence
+        let mut connection_activation =
+            ConnectionActivationSequence::new(self.config.clone(), io_channel_id, user_channel_id);
+        let replay_written = connection_activation.step(&buffered_demand_active, output)?;
+        total_written += replay_written.size().unwrap_or(0);
+
+        self.state = match connection_activation.connection_activation_state() {
+            ConnectionActivationState::ConnectionFinalization { .. } => {
+                ClientConnectorState::ConnectionFinalization { connection_activation }
+            }
+            _ => ClientConnectorState::CapabilitiesExchange { connection_activation },
+        };
+
+        Written::from_size(total_written)
+    }
+
+    /// Skip multitransport bootstrapping without sending any responses.
+    ///
+    /// Use this when the application doesn't support or doesn't want UDP
+    /// transport. The server will continue with TCP-only operation.
+    ///
+    /// The buffered Demand Active PDU is replayed internally.
+    ///
+    /// Returns an error if the connector is not in `MultitransportPending`
+    /// state.
+    pub fn skip_multitransport(&mut self, output: &mut WriteBuf) -> ConnectorResult<Written> {
+        let ClientConnectorState::MultitransportPending {
+            io_channel_id,
+            user_channel_id,
+            buffered_demand_active,
+            ..
+        } = mem::replace(&mut self.state, ClientConnectorState::Consumed)
+        else {
+            return Err(general_err!(
+                "skip_multitransport called outside MultitransportPending state"
+            ));
+        };
+
+        // Replay the buffered Demand Active through the activation sequence
+        let mut connection_activation =
+            ConnectionActivationSequence::new(self.config.clone(), io_channel_id, user_channel_id);
+        let written = connection_activation.step(&buffered_demand_active, output)?;
+
+        self.state = match connection_activation.connection_activation_state() {
+            ConnectionActivationState::ConnectionFinalization { .. } => {
+                ClientConnectorState::ConnectionFinalization { connection_activation }
+            }
+            _ => ClientConnectorState::CapabilitiesExchange { connection_activation },
+        };
+
+        Ok(written)
+    }
 }
 
 fn advance_licensing_exchange(
@@ -226,6 +399,7 @@ fn advance_licensing_exchange(
         ClientConnectorState::MultitransportBootstrapping {
             io_channel_id,
             user_channel_id,
+            requests: Vec::new(),
         }
     } else {
         ClientConnectorState::LicensingExchange {
@@ -265,7 +439,8 @@ impl Sequence for ClientConnector {
                 }
             }
             ClientConnectorState::LicensingExchange { license_exchange, .. } => license_exchange.next_pdu_hint(),
-            ClientConnectorState::MultitransportBootstrapping { .. } => None,
+            ClientConnectorState::MultitransportBootstrapping { .. } => Some(&ironrdp_pdu::X224_HINT),
+            ClientConnectorState::MultitransportPending { .. } => None,
             ClientConnectorState::CapabilitiesExchange {
                 connection_activation, ..
             } => connection_activation.next_pdu_hint(),
@@ -636,20 +811,88 @@ impl Sequence for ClientConnector {
             }
 
             //== Optional Multitransport Bootstrapping ==//
-            // NOTE: our implementation is not expecting the Auto-Detect Request PDU from server
+            //
+            // The server may send 0, 1, or 2 Initiate Multitransport Request PDUs
+            // after licensing. We distinguish them from the Demand Active PDU by
+            // attempting to decode as MultitransportRequestPdu first — it has a
+            // distinctive structure (SEC_TRANSPORT_REQ flag + request_id + protocol
+            // + cookie). If decode fails, this is the Demand Active.
             ClientConnectorState::MultitransportBootstrapping {
                 io_channel_id,
                 user_channel_id,
-            } => (
-                Written::Nothing,
-                ClientConnectorState::CapabilitiesExchange {
-                    connection_activation: ConnectionActivationSequence::new(
-                        self.config.clone(),
-                        io_channel_id,
-                        user_channel_id,
-                    ),
-                },
-            ),
+                mut requests,
+            } => {
+                let ctx = mcs::decode_send_data_indication(input).map_err(ConnectorError::decode)?;
+
+                // Try decoding as a multitransport request. The decoder validates
+                // the SEC_TRANSPORT_REQ flag, so a Demand Active PDU will fail
+                // cleanly without false positives.
+                match decode::<rdp::multitransport::MultitransportRequestPdu>(ctx.user_data) {
+                    Ok(pdu) => {
+                        debug!(
+                            request_id = pdu.request_id,
+                            protocol = ?pdu.requested_protocol,
+                            "Received Initiate Multitransport Request"
+                        );
+
+                        requests.push(pdu);
+
+                        // Stay in this state to read more requests (server may send a second)
+                        (
+                            Written::Nothing,
+                            ClientConnectorState::MultitransportBootstrapping {
+                                io_channel_id,
+                                user_channel_id,
+                                requests,
+                            },
+                        )
+                    }
+                    Err(_) if !requests.is_empty() => {
+                        // Decode failed → this is the Demand Active PDU. Buffer it
+                        // and pause for the application to handle multitransport.
+                        info!(
+                            count = requests.len(),
+                            "Multitransport bootstrapping: pausing for application"
+                        );
+
+                        (
+                            Written::Nothing,
+                            ClientConnectorState::MultitransportPending {
+                                io_channel_id,
+                                user_channel_id,
+                                requests,
+                                buffered_demand_active: input.to_vec(),
+                            },
+                        )
+                    }
+                    Err(_) => {
+                        // No multitransport requests: the server went straight to
+                        // capabilities exchange. Forward the PDU.
+                        let mut connection_activation =
+                            ConnectionActivationSequence::new(self.config.clone(), io_channel_id, user_channel_id);
+                        let written = connection_activation.step(input, output)?;
+
+                        match connection_activation.connection_activation_state() {
+                            ConnectionActivationState::ConnectionFinalization { .. } => (
+                                written,
+                                ClientConnectorState::ConnectionFinalization { connection_activation },
+                            ),
+                            _ => (
+                                written,
+                                ClientConnectorState::CapabilitiesExchange { connection_activation },
+                            ),
+                        }
+                    }
+                }
+            }
+
+            // MultitransportPending: application should call complete_multitransport()
+            // or skip_multitransport() instead of step()
+            ClientConnectorState::MultitransportPending { .. } => {
+                return Err(general_err!(
+                    "multitransport pending: call complete_multitransport() or skip_multitransport()"
+                ));
+            }
 
             //== Capabilities Exchange ==/
             // The server sends the set of capabilities it supports to the client.

--- a/crates/ironrdp-connector/src/lib.rs
+++ b/crates/ironrdp-connector/src/lib.rs
@@ -24,7 +24,9 @@ use ironrdp_pdu::{PduHint, gcc, x224};
 pub use sspi;
 
 pub use self::channel_connection::{ChannelConnectionSequence, ChannelConnectionState};
-pub use self::connection::{ClientConnector, ClientConnectorState, ConnectionResult, encode_send_data_request};
+pub use self::connection::{
+    ClientConnector, ClientConnectorState, ConnectionResult, MultitransportResult, encode_send_data_request,
+};
 pub use self::connection_finalization::{ConnectionFinalizationSequence, ConnectionFinalizationState};
 pub use self::license_exchange::{LicenseExchangeSequence, LicenseExchangeState};
 pub use self::server_name::ServerName;

--- a/crates/ironrdp-fuzzing/src/oracles/mod.rs
+++ b/crates/ironrdp-fuzzing/src/oracles/mod.rs
@@ -118,7 +118,9 @@ pub fn pdu_decode(data: &[u8]) {
     };
     use ironrdp_pdu::mcs::{ConnectInitial, ConnectResponse, McsMessage};
     use ironrdp_pdu::nego::{ConnectionConfirm, ConnectionRequest};
-    use ironrdp_pdu::rdp::{ClientInfoPdu, capability_sets, headers, server_error_info, server_license, vc};
+    use ironrdp_pdu::rdp::{
+        ClientInfoPdu, capability_sets, headers, multitransport, server_error_info, server_license, vc,
+    };
     use ironrdp_pdu::x224::X224;
     use ironrdp_pdu::{bitmap, codecs, fast_path, gcc, input, pcb, surface_commands};
 
@@ -140,6 +142,11 @@ pub fn pdu_decode(data: &[u8]) {
     let _ = decode::<gcc::ConferenceCreateResponse>(data);
 
     let _ = decode::<server_license::LicensePdu>(data);
+
+    // Post-licensing multitransport bootstrapping: the connector try-decodes
+    // arbitrary server bytes as a request to distinguish it from Demand Active.
+    let _ = decode::<multitransport::MultitransportRequestPdu>(data);
+    let _ = decode::<multitransport::MultitransportResponsePdu>(data);
 
     let _ = decode::<vc::ChannelPduHeader>(data);
 
@@ -245,7 +252,7 @@ pub fn pdu_round_trip(data: &[u8]) {
     use ironrdp_pdu::nego::{ConnectionConfirm, ConnectionRequest};
     use ironrdp_pdu::rdp::capability_sets::CapabilitySet;
     use ironrdp_pdu::rdp::headers::ShareControlHeader;
-    use ironrdp_pdu::rdp::{ClientInfoPdu, server_error_info, server_license, vc};
+    use ironrdp_pdu::rdp::{ClientInfoPdu, multitransport, server_error_info, server_license, vc};
     use ironrdp_pdu::x224::X224;
     use ironrdp_pdu::{bitmap, codecs, fast_path, gcc, input, pcb, surface_commands};
 
@@ -272,6 +279,10 @@ pub fn pdu_round_trip(data: &[u8]) {
 
     // Licensing
     pdu_round_trip_one!(data, server_license::LicensePdu);
+
+    // Multitransport bootstrapping (server request / client response)
+    pdu_round_trip_one!(data, multitransport::MultitransportRequestPdu);
+    pdu_round_trip_one!(data, multitransport::MultitransportResponsePdu);
 
     // Virtual channel header
     pdu_round_trip_one!(data, vc::ChannelPduHeader);

--- a/crates/ironrdp-pdu/src/rdp/multitransport.rs
+++ b/crates/ironrdp-pdu/src/rdp/multitransport.rs
@@ -115,8 +115,17 @@ impl<'de> Decode<'de> for MultitransportRequestPdu {
 
         let security_header = BasicSecurityHeader::decode(src)?;
 
-        if !security_header.flags.contains(BasicSecurityHeaderFlags::TRANSPORT_REQ) {
-            return Err(invalid_field_err!("securityHeader", "expected TRANSPORT_REQ flag"));
+        // Must be EXACTLY SEC_TRANSPORT_REQ (MS-RDPBCGR 2.2.15.1), not merely
+        // contain the bit. A `contains` check false-positives when this decode
+        // is used to distinguish a request from another PDU: e.g. a Demand
+        // Active's leading `ShareControlHeader::totalLength` aliases onto this
+        // flags field and can carry the TRANSPORT_REQ bit as part of an
+        // otherwise-valid flag combination.
+        if security_header.flags != BasicSecurityHeaderFlags::TRANSPORT_REQ {
+            return Err(invalid_field_err!(
+                "securityHeader",
+                "expected securityHeader flags to be exactly SEC_TRANSPORT_REQ"
+            ));
         }
 
         let request_id = src.read_u32();
@@ -229,8 +238,13 @@ impl<'de> Decode<'de> for MultitransportResponsePdu {
 
         let security_header = BasicSecurityHeader::decode(src)?;
 
-        if !security_header.flags.contains(BasicSecurityHeaderFlags::TRANSPORT_RSP) {
-            return Err(invalid_field_err!("securityHeader", "expected TRANSPORT_RSP flag"));
+        // Must be EXACTLY SEC_TRANSPORT_RSP (MS-RDPBCGR 2.2.15.2), not merely
+        // contain the bit; see the note on `MultitransportRequestPdu::decode`.
+        if security_header.flags != BasicSecurityHeaderFlags::TRANSPORT_RSP {
+            return Err(invalid_field_err!(
+                "securityHeader",
+                "expected securityHeader flags to be exactly SEC_TRANSPORT_RSP"
+            ));
         }
 
         let request_id = src.read_u32();

--- a/crates/ironrdp-testsuite-core/tests/session/connection_activation.rs
+++ b/crates/ironrdp-testsuite-core/tests/session/connection_activation.rs
@@ -1,12 +1,17 @@
 use std::borrow::Cow;
 
 use ironrdp_connector::connection_activation::{ConnectionActivationSequence, ConnectionActivationState};
-use ironrdp_connector::{ClientConnector, ClientConnectorState, Credentials, DesktopSize, Sequence as _, Written};
-use ironrdp_core::{WriteBuf, encode_vec};
+use ironrdp_connector::{
+    ClientConnector, ClientConnectorState, Credentials, DesktopSize, MultitransportResult, Sequence as _, Written,
+};
+use ironrdp_core::{WriteBuf, decode, encode_vec};
 use ironrdp_pdu::gcc;
 use ironrdp_pdu::mcs::{McsMessage, SendDataIndication};
 use ironrdp_pdu::rdp::capability_sets::MajorPlatformType;
-use ironrdp_pdu::rdp::headers::{ServerDeactivateAll, ShareControlHeader, ShareControlPdu};
+use ironrdp_pdu::rdp::headers::{
+    BasicSecurityHeader, BasicSecurityHeaderFlags, ServerDeactivateAll, ShareControlHeader, ShareControlPdu,
+};
+use ironrdp_pdu::rdp::multitransport::{MultitransportRequestPdu, RequestedProtocol};
 use ironrdp_pdu::x224::X224;
 
 use ironrdp_testsuite_core::capsets::SERVER_DEMAND_ACTIVE;
@@ -138,5 +143,145 @@ fn demand_active_after_deactivate_all_transitions_to_connection_finalization() {
             ConnectionActivationState::ConnectionFinalization { .. }
         ),
         "state should transition to ConnectionFinalization after DemandActive"
+    );
+}
+
+fn multitransport_request(request_id: u32, requested_protocol: RequestedProtocol) -> MultitransportRequestPdu {
+    MultitransportRequestPdu {
+        security_header: BasicSecurityHeader {
+            flags: BasicSecurityHeaderFlags::TRANSPORT_REQ,
+        },
+        request_id,
+        requested_protocol,
+        security_cookie: [0u8; 16],
+    }
+}
+
+/// A connector parked in `MultitransportPending` with `requests` outstanding and
+/// a real Demand Active buffered, ready for `complete`/`skip` to replay.
+fn multitransport_pending_connector(requests: Vec<MultitransportRequestPdu>) -> ClientConnector {
+    let buffered_demand_active =
+        encode_server_share_control(ShareControlPdu::ServerDemandActive(SERVER_DEMAND_ACTIVE.clone()));
+    let mut connector = ClientConnector::new(test_config(), "127.0.0.1:3389".parse().unwrap());
+    connector.state = ClientConnectorState::MultitransportPending {
+        io_channel_id: IO_CHANNEL_ID,
+        user_channel_id: USER_CHANNEL_ID,
+        requests,
+        buffered_demand_active,
+    };
+    connector
+}
+
+#[test]
+fn should_perform_multitransport_reflects_pending_state() {
+    let connector = multitransport_pending_connector(vec![multitransport_request(1, RequestedProtocol::UdpFecR)]);
+    assert!(connector.should_perform_multitransport());
+    assert_eq!(connector.multitransport_requests().len(), 1);
+}
+
+#[test]
+fn complete_multitransport_replays_demand_active_and_advances() {
+    let mut connector = multitransport_pending_connector(vec![
+        multitransport_request(1, RequestedProtocol::UdpFecR),
+        multitransport_request(2, RequestedProtocol::UdpFecL),
+    ]);
+    let mut output = WriteBuf::new();
+
+    let written = connector
+        .complete_multitransport(
+            &[MultitransportResult::Success, MultitransportResult::Success],
+            &mut output,
+        )
+        .unwrap();
+
+    assert!(
+        written != Written::Nothing,
+        "responses plus the replayed ClientConfirmActive"
+    );
+    assert!(
+        matches!(connector.state, ClientConnectorState::ConnectionFinalization { .. }),
+        "connector must advance past the buffered Demand Active on completion"
+    );
+    assert!(!connector.should_perform_multitransport());
+}
+
+#[test]
+fn complete_multitransport_carries_failure_results() {
+    let mut connector = multitransport_pending_connector(vec![multitransport_request(7, RequestedProtocol::UdpFecR)]);
+    let mut output = WriteBuf::new();
+
+    let written = connector
+        .complete_multitransport(&[MultitransportResult::Failure(0x8000_0001)], &mut output)
+        .unwrap();
+
+    assert!(written != Written::Nothing);
+    assert!(matches!(
+        connector.state,
+        ClientConnectorState::ConnectionFinalization { .. }
+    ));
+}
+
+#[test]
+fn skip_multitransport_replays_demand_active_and_advances() {
+    let mut connector = multitransport_pending_connector(vec![multitransport_request(1, RequestedProtocol::UdpFecR)]);
+    let mut output = WriteBuf::new();
+
+    let written = connector.skip_multitransport(&mut output).unwrap();
+
+    assert!(written != Written::Nothing, "the replayed ClientConfirmActive");
+    assert!(matches!(
+        connector.state,
+        ClientConnectorState::ConnectionFinalization { .. }
+    ));
+    assert!(!connector.should_perform_multitransport());
+}
+
+#[test]
+fn complete_multitransport_rejects_result_count_mismatch() {
+    let mut connector = multitransport_pending_connector(vec![multitransport_request(1, RequestedProtocol::UdpFecR)]);
+    let mut output = WriteBuf::new();
+
+    // One outstanding request, zero results provided.
+    assert!(connector.complete_multitransport(&[], &mut output).is_err());
+}
+
+#[test]
+fn complete_multitransport_outside_pending_state_errors() {
+    let mut connector = ClientConnector::new(test_config(), "127.0.0.1:3389".parse().unwrap());
+    connector.state = ClientConnectorState::CapabilitiesExchange {
+        connection_activation: ConnectionActivationSequence::new(test_config(), IO_CHANNEL_ID, USER_CHANNEL_ID),
+    };
+    let mut output = WriteBuf::new();
+
+    assert!(connector.complete_multitransport(&[], &mut output).is_err());
+}
+
+#[test]
+fn skip_multitransport_outside_pending_state_errors() {
+    let mut connector = ClientConnector::new(test_config(), "127.0.0.1:3389".parse().unwrap());
+    connector.state = ClientConnectorState::CapabilitiesExchange {
+        connection_activation: ConnectionActivationSequence::new(test_config(), IO_CHANNEL_ID, USER_CHANNEL_ID),
+    };
+    let mut output = WriteBuf::new();
+
+    assert!(connector.skip_multitransport(&mut output).is_err());
+}
+
+#[test]
+fn demand_active_user_data_does_not_decode_as_multitransport_request() {
+    // The connector distinguishes a multitransport request from a Demand Active
+    // by try-decoding the SendDataIndication user_data as MultitransportRequestPdu.
+    // A Demand Active must fail cleanly (the decoder validates SEC_TRANSPORT_REQ),
+    // otherwise the bootstrapping state would swallow the Demand Active.
+    let share_control_header = ShareControlHeader {
+        share_control_pdu: ShareControlPdu::ServerDemandActive(SERVER_DEMAND_ACTIVE.clone()),
+        pdu_source: USER_CHANNEL_ID,
+        share_id: SHARE_ID,
+    };
+    let user_data = encode_vec(&share_control_header).unwrap();
+
+    assert!(
+        decode::<MultitransportRequestPdu>(&user_data).is_err(),
+        "a Demand Active must not be mistaken for a multitransport request"
     );
 }


### PR DESCRIPTION
> Supersedes #1098, rebased onto current master. Same change; opening fresh from the organization fork.

## Summary

Makes the MultitransportBootstrapping state functional instead of a no-op
pass-through. After licensing the server may send 0, 1, or 2 Initiate
Multitransport Request PDUs before capabilities exchange. The connector
reads those, pauses in a new MultitransportPending state, and surfaces
the requests for the application to establish UDP transport (RDPEUDP2 +
TLS + RDPEMT) or decline.

## API

Mirrors the existing `should_perform_X()` pause-point pattern used by TLS
upgrade and CredSSP, but uses `complete_X()` / `skip_X()` rather than
`mark_X_as_done()` because completion carries result data:

- `should_perform_multitransport()`: true when requests have been collected
- `multitransport_requests()`: access the server's request PDUs
- `complete_multitransport(results, output)`: send response PDUs, advance
- `skip_multitransport(output)`: decline, advance

`complete_multitransport` accepts `&[MultitransportResult]` (a `Success` /
`Failure(hresult)` enum) rather than caller-built response PDUs. The
connector builds the response PDUs internally using the stored request
IDs and validates that the result count matches the request count.

## Approach

**Detection.** The state machine try-decodes the incoming PDU as
`MultitransportRequestPdu`; a clean decode means multitransport, a decode
error means Demand Active. For that to be sound the request decoder must
reject a Demand Active, so this PR also tightens `MultitransportRequestPdu`
/ `MultitransportResponsePdu` decoding to require the `BasicSecurityHeader`
flags to equal `SEC_TRANSPORT_REQ` / `SEC_TRANSPORT_RSP` exactly rather than
merely contain the bit (`fix(pdu)` commit). The previous `contains` check
false-positived: a Demand Active's leading `ShareControlHeader` `totalLength`
aliases onto the security header flags field, and a length such as `0x016F`
is a valid flag combination that carries the `TRANSPORT_REQ` bit, so the
Demand Active decoded as a bogus request. The exact check is what
MS-RDPBCGR 2.2.15.1 / 2.2.15.2 specify (each PDU carries that single flag).
No flag-peeking on `BasicSecurityHeader` in the connector.

**Demand Active buffering.** The connector buffers the Demand Active PDU
internally in `MultitransportPending` and replays it through
`ConnectionActivationSequence::step()` when `complete_multitransport()`
or `skip_multitransport()` is called.

**Driver wiring.** Both `ironrdp-async` and `ironrdp-blocking`
`connect_finalize` loops now auto-skip multitransport: when the connector
reports `should_perform_multitransport()`, the driver calls
`skip_multitransport()` on the caller's behalf so the connection succeeds
TCP-only. Applications that want to participate in multitransport setup
must drive the connector directly rather than calling `connect_finalize`.

**Request count.** Per MS-RDPBCGR 2.2.15.1 the server may send 0, 1, or 2
requests (one per transport protocol). The connector rejects subsequent
requests with a `ConnectorError`.

**Wire behavior.** Per the doc-comment on `MultitransportPending`, TCP and
UDP negotiation happen in parallel. The UDP transport is established
alongside the ongoing TCP handshake; its completion is a signal to the
dynamic-channel layer that subsequent channels may migrate to UDP. The
connector's API yield point here is a Rust affordance, not a
spec-mandated TCP pause. Thanks to @hardening for the correction.

## Tests

Connector state-machine tests in `ironrdp-testsuite-core` drive the public
`MultitransportPending` API with the shared `SERVER_DEMAND_ACTIVE` fixture:

- `complete_multitransport()` writes the response PDUs and replays the
  buffered Demand Active, advancing the connector past bootstrapping;
- `skip_multitransport()` replays the Demand Active without responses;
- a `Failure` result is carried through;
- a result/request count mismatch is rejected;
- `complete` / `skip` outside `MultitransportPending` error;
- a Demand Active's user data does not decode as a `MultitransportRequestPdu`
  (regression test for the detection fix above).

Fuzzing: `MultitransportRequestPdu` and `MultitransportResponsePdu` are added
to the `pdu_decode` and `pdu_round_trip` oracles, so the post-licensing
try-decode surface is fuzzed against arbitrary input (auto-discovered into the
fuzz CI matrix). Both targets smoke-run clean.

Full end-to-end coverage against a live server still awaits server-side
`MultitransportRequestPdu` emission, which `ironrdp::server::RdpServer` does
not implement yet.

## Verification

- `cargo xtask check fmt -v` green
- `cargo xtask check lints -v` green
- `cargo xtask check tests -v` green
- `cargo xtask check typos -v` green
- `cargo xtask check locks -v` green

## References

Builds on: #1091
Related: #140

