### PR TITLE
fix(connector): answer connect-time Bandwidth Measure to unblock FreeRDP servers

### DIFF
--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -1252,7 +1252,9 @@ fn respond_to_connect_time_autodetect(
     user_channel_id: u16,
     output: &mut WriteBuf,
 ) -> ConnectorResult<Written> {
-    use ironrdp_pdu::rdp::autodetect::{AutoDetectRequest, AutoDetectResponse, AutoDetectRspPdu};
+    use ironrdp_pdu::rdp::autodetect::{
+        AutoDetectRequest, AutoDetectResponse, AutoDetectRspPdu, BW_RESULTS_CONNECT_TIME,
+    };
 
     match request {
         AutoDetectRequest::RttRequest { sequence_number, .. } => {
@@ -1260,14 +1262,34 @@ fn respond_to_connect_time_autodetect(
             let written = encode_send_data_request(user_channel_id, message_channel_id, &response, output)?;
             Written::from_size(written)
         }
-        // Only RTT is answered at connect time. A connect-time Bandwidth Measure
-        // Stop ([MS-RDPBCGR] 2.2.14.1.4) is defined to warrant a Bandwidth Measure
-        // Results reply, and the Network Characteristics Result is informational.
-        // We deliberately send neither: connect-time auto-detect is informational
-        // and the server proceeds to licensing whether or not it receives them, so
-        // skipping them does not stall the sequence. Full connect-time bandwidth
-        // measurement (replying to Bandwidth Measure Stop with Bandwidth Measure
-        // Results) is left for a follow-up.
+        // A connect-time Bandwidth Measure Stop ([MS-RDPBCGR] 2.2.14.1.4) warrants a
+        // Bandwidth Measure Results reply ([MS-RDPBCGR] 2.2.14.2.2). This reply must
+        // be sent: FreeRDP-based servers (for example GNOME Remote Desktop) block in
+        // their AWAIT_BW_RESULT state until they receive it and never proceed to
+        // licensing without it, so omitting it stalls the whole connection. We do not
+        // run a stateful connect-time measurement, so we report the payload the
+        // server handed us over a nominal interval; the figure is an informational
+        // QoS hint and the server proceeds on receipt. A precise measurement (timing
+        // the Start/Payload/Stop window) can refine the reported bandwidth later.
+        AutoDetectRequest::BandwidthMeasureStop {
+            sequence_number,
+            payload,
+            ..
+        } => {
+            let byte_count = payload
+                .as_ref()
+                .map_or(0, |p| u32::try_from(p.len()).unwrap_or(u32::MAX));
+            let response = AutoDetectRspPdu::new(AutoDetectResponse::BandwidthMeasureResults {
+                sequence_number,
+                response_type: BW_RESULTS_CONNECT_TIME,
+                time_delta_ms: 1,
+                byte_count,
+            });
+            let written = encode_send_data_request(user_channel_id, message_channel_id, &response, output)?;
+            Written::from_size(written)
+        }
+        // Bandwidth Measure Start and Payload carry no client reply, and the Network
+        // Characteristics Result is informational; nothing to send for those.
         _ => Ok(Written::Nothing),
     }
 }

--- a/crates/ironrdp-testsuite-core/tests/connector/autodetect.rs
+++ b/crates/ironrdp-testsuite-core/tests/connector/autodetect.rs
@@ -171,3 +171,31 @@ fn first_licensing_pdu_leaves_autodetect_for_the_licensing_path() {
         "a completed licensing exchange advances the connector out of auto-detection"
     );
 }
+
+#[test]
+fn connect_time_bandwidth_measure_stop_is_answered_and_phase_continues() {
+    let mut connector = connect_time_autodetect_connector();
+
+    // A connect-time Bandwidth Measure Stop ([MS-RDPBCGR] 2.2.14.1.4) must be
+    // answered with a Bandwidth Measure Results reply. FreeRDP-based servers (for
+    // example GNOME Remote Desktop) block in their AWAIT_BW_RESULT state until they
+    // receive it, so no response stalls the whole connection.
+    let user_data = encode_vec(&AutoDetectReqPdu::new(AutoDetectRequest::bw_stop_connect_time(
+        0x5678,
+        vec![0u8; 1024],
+    )))
+    .unwrap();
+    let frame = server_send_data_indication(MESSAGE_CHANNEL_ID, user_data);
+
+    let mut output = WriteBuf::new();
+    let written = connector.step(&frame, &mut output).unwrap();
+
+    assert!(
+        written.size().is_some(),
+        "a connect-time Bandwidth Measure Stop must produce a Bandwidth Measure Results response frame"
+    );
+    assert!(
+        matches!(connector.state, ClientConnectorState::ConnectTimeAutoDetection { .. }),
+        "the connector keeps listening after answering the bandwidth measurement"
+    );
+}


### PR DESCRIPTION
## Summary

- The connector answers only the RTT auto-detect request at connect time and returns nothing for the Bandwidth Measure Stop, on the assumption that skipping it does not stall the sequence.
- That assumption fails for FreeRDP-based servers: GNOME Remote Desktop blocks in its `AWAIT_BW_RESULT` state until it receives a Bandwidth Measure Results reply and never proceeds to licensing, so the connection hangs right after the Client Info PDU. Windows servers tolerate the omission, which hid it.
- Reply to a connect-time `BandwidthMeasureStop` with a `BandwidthMeasureResults` PDU carrying the payload size the server handed us, over a nominal interval.

## Scope

This is the unblock alone. The reported interval is nominal (`time_delta_ms: 1`) because the sans-I/O layer has no time source: nothing reaches the connector that says when the bytes arrived. The figure is an informational QoS hint and the server proceeds on receipt, which is what unsticks the connection.

Measuring it properly needs an arrival time threaded down from the I/O driver, which is a breaking change to `Sequence::step` and does not belong in a fix aimed at getting FreeRDP servers connecting. It is #1530, stacked on this branch: it introduces `MonotonicInstant`, has `Framed` record when each read completed, and replaces the nominal figure here with the real Start-to-Stop interval and accumulated byte count.

Split out at @CBenoit's suggestion in review.

## Validation

- `cargo xtask check fmt/typos/lints/tests/locks` all pass on the pinned toolchain.
- Regression test: a connect-time Bandwidth Measure Stop produces a response frame and the auto-detect phase continues.
- Reproduced and fixed live against gnome-remote-desktop 49: before, the connector stalled after Client Info with grd in `AWAIT_BW_RESULT`; after, grd proceeds through licensing and DEMAND_ACTIVE to an active session.

## Notes

- Found while bringing up the client-side Graphics Pipeline against grd (#1446), but it is an independent connector bug affecting any connection to a FreeRDP-based server, not specific to EGFX.
- Previously depended on #1511 for a zero-`payloadLength` regression test. #1511 has merged, and that test moved out with the rest of the measurement work, so there is no dependency left here.
