### PR TITLE
fix(connector): surface server error-info disconnect during reactivation

### DIFF
--- a/crates/ironrdp-connector/src/connection_activation.rs
+++ b/crates/ironrdp-connector/src/connection_activation.rs
@@ -163,6 +163,38 @@ impl Sequence for ConnectionActivationSequence {
                 {
                     server_demand_active.pdu.capability_sets
                 } else {
+                    // Instead of reactivating after a Deactivate-All, a server may end the
+                    // session (MS-RDPBCGR §1.3.1.3) by sending a Set Error Info PDU carrying the
+                    // disconnect reason. FreeRDP-based servers such as GNOME Remote Desktop do
+                    // this, for example when the backend screencast session cannot be created.
+                    // Surface that reason so the disconnect is explained rather than reported as
+                    // an unexpected PDU.
+                    if let rdp::headers::ShareControlPdu::Data(rdp::headers::ShareDataHeader {
+                        share_data_pdu:
+                            rdp::headers::ShareDataPdu::ServerSetErrorInfo(rdp::server_error_info::ServerSetErrorInfoPdu(
+                                error_info,
+                            )),
+                        ..
+                    }) = share_control_ctx.pdu
+                    {
+                        // ERRINFO_NONE is informational (it clears a previously reported error),
+                        // not a disconnect. Skip it and keep waiting for the Demand Active PDU,
+                        // matching how the connection finalization sequence treats it.
+                        if let rdp::server_error_info::ErrorInfo::ProtocolIndependentCode(
+                            rdp::server_error_info::ProtocolIndependentCode::None,
+                        ) = error_info
+                        {
+                            self.state = ConnectionActivationState::CapabilitiesExchange;
+                            return Ok(Written::Nothing);
+                        }
+
+                        return Err(reason_err!(
+                            "ConnectionActivation::CapabilitiesExchange",
+                            "server ended the session with error info: {}",
+                            error_info.description()
+                        ));
+                    }
+
                     return Err(reason_err!(
                         "ConnectionActivation::CapabilitiesExchange",
                         "unexpected Share Control PDU during capabilities exchange: got {} (expected Server Demand Active PDU)",

--- a/crates/ironrdp-testsuite-core/tests/session/connection_activation.rs
+++ b/crates/ironrdp-testsuite-core/tests/session/connection_activation.rs
@@ -6,7 +6,12 @@ use ironrdp_core::{WriteBuf, encode_vec};
 use ironrdp_pdu::gcc;
 use ironrdp_pdu::mcs::{McsMessage, SendDataIndication};
 use ironrdp_pdu::rdp::capability_sets::MajorPlatformType;
-use ironrdp_pdu::rdp::headers::{ServerDeactivateAll, ShareControlHeader, ShareControlPdu};
+use ironrdp_pdu::rdp::client_info::CompressionType;
+use ironrdp_pdu::rdp::headers::{
+    CompressionFlags, ServerDeactivateAll, ShareControlHeader, ShareControlPdu, ShareDataHeader, ShareDataPdu,
+    StreamPriority,
+};
+use ironrdp_pdu::rdp::server_error_info::{ErrorInfo, ProtocolIndependentCode, ServerSetErrorInfoPdu};
 use ironrdp_pdu::x224::X224;
 
 use ironrdp_testsuite_core::capsets::SERVER_DEMAND_ACTIVE;
@@ -112,6 +117,72 @@ fn client_connector_stays_in_capabilities_exchange_on_deactivate_all() {
     assert!(
         matches!(connector.state, ClientConnectorState::CapabilitiesExchange { .. }),
         "outer connector state should remain CapabilitiesExchange after DeactivateAll"
+    );
+}
+
+#[test]
+fn set_error_info_during_capabilities_exchange_surfaces_the_disconnect_reason() {
+    // Instead of reactivating after a Deactivate-All, a server may end the session
+    // (MS-RDPBCGR §1.3.1.3) by sending a Set Error Info PDU carrying the disconnect
+    // reason. The sequence must surface that reason rather than a generic
+    // "unexpected Share Control PDU" error.
+    let config = test_config();
+    let mut seq = ConnectionActivationSequence::new(config, IO_CHANNEL_ID, USER_CHANNEL_ID);
+
+    let error_info = ShareControlPdu::Data(ShareDataHeader {
+        share_data_pdu: ShareDataPdu::ServerSetErrorInfo(ServerSetErrorInfoPdu(ErrorInfo::ProtocolIndependentCode(
+            ProtocolIndependentCode::RpcInitiatedDisconnect,
+        ))),
+        stream_priority: StreamPriority::Medium,
+        compression_flags: CompressionFlags::empty(),
+        compression_type: CompressionType::K8,
+    });
+    let frame = encode_server_share_control(error_info);
+    let mut output = WriteBuf::new();
+
+    let err = seq
+        .step(&frame, &mut output)
+        .expect_err("a Set Error Info PDU during capabilities exchange must end the sequence with an error");
+
+    let message = err.to_string();
+    assert!(
+        message.contains("error info"),
+        "the error should surface the server's disconnect reason, got: {message}"
+    );
+    assert!(
+        !message.contains("unexpected Share Control PDU"),
+        "the disconnect reason must not be masked by the generic unexpected-PDU error, got: {message}"
+    );
+}
+
+#[test]
+fn none_error_info_during_capabilities_exchange_is_skipped() {
+    // An ERRINFO_NONE Set Error Info PDU is informational, not a disconnect. It must
+    // be skipped (staying in Capabilities Exchange to await Demand Active), not treated
+    // as a session-ending error.
+    let config = test_config();
+    let mut seq = ConnectionActivationSequence::new(config, IO_CHANNEL_ID, USER_CHANNEL_ID);
+
+    let none_error_info = ShareControlPdu::Data(ShareDataHeader {
+        share_data_pdu: ShareDataPdu::ServerSetErrorInfo(ServerSetErrorInfoPdu(ErrorInfo::ProtocolIndependentCode(
+            ProtocolIndependentCode::None,
+        ))),
+        stream_priority: StreamPriority::Medium,
+        compression_flags: CompressionFlags::empty(),
+        compression_type: CompressionType::K8,
+    });
+    let frame = encode_server_share_control(none_error_info);
+    let mut output = WriteBuf::new();
+
+    let written = seq.step(&frame, &mut output).unwrap();
+
+    assert_eq!(written, Written::Nothing);
+    assert!(
+        matches!(
+            seq.connection_activation_state(),
+            ConnectionActivationState::CapabilitiesExchange
+        ),
+        "state should remain CapabilitiesExchange after a benign ERRINFO_NONE PDU"
     );
 }
 


### PR DESCRIPTION
## Summary

After a Deactivate-All, a server may end the session (MS-RDPBCGR 1.3.1.3) instead of reactivating, sending a Set Error Info PDU that carries the disconnect reason. `ConnectionActivationSequence`'s Capabilities Exchange step only recognized `ServerDemandActive` (and skipped `ServerDeactivateAll`), so the Error Info PDU fell through to a generic "unexpected Share Control PDU" error and the real reason was lost.

- Handle `ServerSetErrorInfo` in Capabilities Exchange the way `ConnectionFinalizationSequence` already does: return a `reason` error carrying the error-info description.
- `ERRINFO_NONE` is informational, so it is skipped (stay in Capabilities Exchange, await Demand Active) rather than treated as fatal, matching the finalization sequence.

Found while validating the client against GNOME Remote Desktop (#1446): grd ends the session right after activation when its backend screencast session cannot be created (for example a locked desktop), and the client surfaced only an opaque error at that point.

## Validation

`cargo xtask check fmt`, `lints`, `tests`, `typos`, `locks` all pass. Two new integration tests in `tests/session/connection_activation.rs` cover the disconnect-reason path and the benign `ERRINFO_NONE` path.

## Notes

No wire-format or public-API change: this only improves the error surfaced on an existing failure path.
