### PR TITLE
feat(server): measure and report network characteristics

### DIFF
--- a/crates/ironrdp-pdu/src/rdp/autodetect.rs
+++ b/crates/ironrdp-pdu/src/rdp/autodetect.rs
@@ -965,6 +965,15 @@ mod tests {
         0x12, 0x00, 0x00, 0x00, // averageRTT = 18
     ];
 
+    const NETCHAR_BW_RTT_WIRE: &[u8] = &[
+        0x0E, // headerLength
+        0x00, // headerTypeId
+        0x08, 0x00, // sequenceNumber = 8
+        0x80, 0x08, // requestType = NETCHAR_RESULT_BW_RTT (0x0880)
+        0xF4, 0x01, 0x00, 0x00, // bandwidth = 500
+        0x16, 0x00, 0x00, 0x00, // averageRTT = 22
+    ];
+
     #[test]
     fn decode_rtt_request() {
         let pdu = ironrdp_core::decode::<AutoDetectRequest>(RTT_REQUEST_WIRE).unwrap();
@@ -1123,6 +1132,27 @@ mod tests {
                 assert_eq!(base_rtt_ms, Some(8));
                 assert_eq!(bandwidth_kbps, None);
                 assert_eq!(average_rtt_ms, 18);
+            }
+            other => panic!("expected NetworkCharacteristicsResult, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_netchar_bw_rtt() {
+        let pdu = ironrdp_core::decode::<AutoDetectRequest>(NETCHAR_BW_RTT_WIRE).unwrap();
+        match pdu {
+            AutoDetectRequest::NetworkCharacteristicsResult {
+                sequence_number,
+                request_type,
+                base_rtt_ms,
+                bandwidth_kbps,
+                average_rtt_ms,
+            } => {
+                assert_eq!(sequence_number, 8);
+                assert_eq!(request_type, NETCHAR_RESULT_BW_RTT);
+                assert_eq!(base_rtt_ms, None);
+                assert_eq!(bandwidth_kbps, Some(500));
+                assert_eq!(average_rtt_ms, 22);
             }
             other => panic!("expected NetworkCharacteristicsResult, got {other:?}"),
         }

--- a/crates/ironrdp-pdu/src/rdp/autodetect.rs
+++ b/crates/ironrdp-pdu/src/rdp/autodetect.rs
@@ -956,6 +956,15 @@ mod tests {
         0x14, 0x00, 0x00, 0x00, // averageRTT = 20
     ];
 
+    const NETCHAR_RTT_WIRE: &[u8] = &[
+        0x0E, // headerLength
+        0x00, // headerTypeId
+        0x07, 0x00, // sequenceNumber = 7
+        0x40, 0x08, // requestType = NETCHAR_RESULT_RTT (0x0840)
+        0x08, 0x00, 0x00, 0x00, // baseRTT = 8
+        0x12, 0x00, 0x00, 0x00, // averageRTT = 18
+    ];
+
     #[test]
     fn decode_rtt_request() {
         let pdu = ironrdp_core::decode::<AutoDetectRequest>(RTT_REQUEST_WIRE).unwrap();
@@ -1096,6 +1105,27 @@ mod tests {
         let pdu = AutoDetectRequest::netchar_result(6, 10, 1000, 20);
         let encoded = ironrdp_core::encode_vec(&pdu).unwrap();
         assert_eq!(encoded.as_slice(), NETCHAR_ALL_WIRE);
+    }
+
+    #[test]
+    fn decode_netchar_rtt() {
+        let pdu = ironrdp_core::decode::<AutoDetectRequest>(NETCHAR_RTT_WIRE).unwrap();
+        match pdu {
+            AutoDetectRequest::NetworkCharacteristicsResult {
+                sequence_number,
+                request_type,
+                base_rtt_ms,
+                bandwidth_kbps,
+                average_rtt_ms,
+            } => {
+                assert_eq!(sequence_number, 7);
+                assert_eq!(request_type, NETCHAR_RESULT_RTT);
+                assert_eq!(base_rtt_ms, Some(8));
+                assert_eq!(bandwidth_kbps, None);
+                assert_eq!(average_rtt_ms, 18);
+            }
+            other => panic!("expected NetworkCharacteristicsResult, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/ironrdp-pdu/src/rdp/autodetect.rs
+++ b/crates/ironrdp-pdu/src/rdp/autodetect.rs
@@ -270,6 +270,20 @@ impl AutoDetectRequest {
         }
     }
 
+    /// Construct a Network Characteristics Result carrying RTT only (no bandwidth).
+    ///
+    /// Emits the `NETCHAR_RESULT_RTT` form (baseRTT + averageRTT) for servers
+    /// that measure round-trip time but do not run a bandwidth measurement.
+    pub fn netchar_result_rtt(sequence_number: u16, base_rtt_ms: u32, average_rtt_ms: u32) -> Self {
+        Self::NetworkCharacteristicsResult {
+            sequence_number,
+            request_type: NETCHAR_RESULT_RTT,
+            base_rtt_ms: Some(base_rtt_ms),
+            bandwidth_kbps: None,
+            average_rtt_ms,
+        }
+    }
+
     /// Get the sequence number of this request.
     pub fn sequence_number(&self) -> u16 {
         match self {
@@ -956,6 +970,15 @@ mod tests {
         0x14, 0x00, 0x00, 0x00, // averageRTT = 20
     ];
 
+    const NETCHAR_RTT_WIRE: &[u8] = &[
+        0x0E, // headerLength
+        0x00, // headerTypeId
+        0x07, 0x00, // sequenceNumber = 7
+        0x40, 0x08, // requestType = NETCHAR_RESULT_RTT (0x0840)
+        0x08, 0x00, 0x00, 0x00, // baseRTT = 8
+        0x12, 0x00, 0x00, 0x00, // averageRTT = 18
+    ];
+
     #[test]
     fn decode_rtt_request() {
         let pdu = ironrdp_core::decode::<AutoDetectRequest>(RTT_REQUEST_WIRE).unwrap();
@@ -1099,6 +1122,34 @@ mod tests {
     }
 
     #[test]
+    fn decode_netchar_rtt() {
+        let pdu = ironrdp_core::decode::<AutoDetectRequest>(NETCHAR_RTT_WIRE).unwrap();
+        match pdu {
+            AutoDetectRequest::NetworkCharacteristicsResult {
+                sequence_number,
+                request_type,
+                base_rtt_ms,
+                bandwidth_kbps,
+                average_rtt_ms,
+            } => {
+                assert_eq!(sequence_number, 7);
+                assert_eq!(request_type, NETCHAR_RESULT_RTT);
+                assert_eq!(base_rtt_ms, Some(8));
+                assert_eq!(bandwidth_kbps, None);
+                assert_eq!(average_rtt_ms, 18);
+            }
+            other => panic!("expected NetworkCharacteristicsResult, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn encode_netchar_rtt() {
+        let pdu = AutoDetectRequest::netchar_result_rtt(7, 8, 18);
+        let encoded = ironrdp_core::encode_vec(&pdu).unwrap();
+        assert_eq!(encoded.as_slice(), NETCHAR_RTT_WIRE);
+    }
+
+    #[test]
     fn request_round_trip() {
         let cases = vec![
             AutoDetectRequest::rtt_connect_time(100),
@@ -1109,6 +1160,7 @@ mod tests {
             AutoDetectRequest::bw_stop_connect_time(600, vec![0xFF; 10]),
             AutoDetectRequest::bw_stop_continuous(700),
             AutoDetectRequest::netchar_result(800, 5, 50000, 15),
+            AutoDetectRequest::netchar_result_rtt(900, 5, 15),
         ];
 
         for original in cases {

--- a/crates/ironrdp-server/src/autodetect.rs
+++ b/crates/ironrdp-server/src/autodetect.rs
@@ -16,6 +16,24 @@ const RTT_WINDOW_SIZE: usize = 8;
 /// Probes older than this are discarded as unresponsive.
 pub(crate) const RTT_PROBE_MAX_AGE_MS: u64 = 30_000;
 
+/// Run a bandwidth measurement once every this many RTT ticks. Bandwidth
+/// changes far more slowly than RTT and each measurement sends a payload, so it
+/// is sampled less often than the per-tick RTT probe.
+const BW_MEASURE_INTERVAL_TICKS: u32 = 8;
+
+/// Minimum spacing between Network Characteristics Result PDUs.
+///
+/// The reported figures are averaged over a window and change far more slowly
+/// than the RTT probe cadence, so pacing the result independently keeps an
+/// aggressive probe rate from turning into an equally aggressive stream of
+/// unsolicited PDUs.
+const NETCHAR_RESULT_MIN_INTERVAL_MS: u64 = 1_000;
+
+/// Size of the synthetic Bandwidth Measure Payload, in bytes. Large enough that
+/// the client's measured time delta is meaningful on a real link, small enough
+/// not to be a noticeable periodic cost.
+const BW_PAYLOAD_LEN: usize = 8192;
+
 /// Server-side auto-detect state machine.
 ///
 /// Tracks outstanding RTT probes and computes round-trip statistics from
@@ -35,6 +53,30 @@ pub struct AutoDetectManager {
     /// Outstanding probes as `(sequence_number, sent_at_ms)`.
     pending_probes: Vec<(u16, u64)>,
     rtt_samples: VecDeque<u32>,
+    /// Sequence number of an in-flight bandwidth measurement, if any. A new
+    /// measurement is not started while one is outstanding.
+    pending_bw: Option<u16>,
+    /// Most recently measured bandwidth in kilobits per second.
+    bandwidth_kbps: Option<u32>,
+    /// Counts RTT ticks to pace bandwidth measurements (see [`BW_MEASURE_INTERVAL_TICKS`]).
+    bw_tick_count: u32,
+    /// When the last Network Characteristics Result was built, for pacing.
+    last_netchar_result_ms: Option<u64>,
+    /// Lowest RTT observed over the whole session, for the wire `baseRTT`.
+    ///
+    /// [MS-RDPBCGR] 2.2.14.1.5 defines that field as "the lowest detected
+    /// round-trip time" with no window scoping, so it is tracked separately from
+    /// the sliding window behind [`snapshot()`](Self::snapshot). A floor derived
+    /// from the window can rise once a low sample is evicted, which would make
+    /// the baseRTT / averageRTT pair unusable for the queueing-delay difference
+    /// a client computes from it.
+    min_rtt_ms: Option<u32>,
+    /// Set when a client response updates the measured figures, cleared when a
+    /// Network Characteristics Result reports them.
+    ///
+    /// Without it a client that stops answering leaves the last window values
+    /// being advertised indefinitely, since they never age out of `rtt_samples`.
+    measurement_is_fresh: bool,
 }
 
 impl AutoDetectManager {
@@ -43,14 +85,21 @@ impl AutoDetectManager {
             next_sequence: 0,
             pending_probes: Vec::new(),
             rtt_samples: VecDeque::with_capacity(RTT_WINDOW_SIZE),
+            pending_bw: None,
+            bandwidth_kbps: None,
+            bw_tick_count: 0,
+            last_netchar_result_ms: None,
+            measurement_is_fresh: false,
+            min_rtt_ms: None,
         }
     }
 
     /// Generate an RTT Measure Request PDU for continuous detection.
     ///
-    /// The caller must encode and send the returned [`AutoDetectRequest`] as
-    /// a Share Data PDU on the IO channel. `now_ms` is recorded as the send time and
-    /// is what [`handle_response()`](Self::handle_response) measures against.
+    /// The caller must encode and send the returned [`AutoDetectRequest`] on
+    /// the MCS message channel, framed by a `SEC_AUTODETECT_REQ` security
+    /// header ([MS-RDPBCGR] 2.2.14.3). `now_ms` is recorded as the send time
+    /// and is what [`handle_response()`](Self::handle_response) measures against.
     pub fn send_rtt_request(&mut self, now_ms: u64) -> AutoDetectRequest {
         let seq = self.next_sequence;
         self.next_sequence = seq.wrapping_add(1);
@@ -58,30 +107,123 @@ impl AutoDetectManager {
         AutoDetectRequest::rtt_continuous(seq)
     }
 
-    /// Process an RTT Measure Response from the client.
+    /// Build a Bandwidth Measure transaction (Start → Payload → Stop) when one
+    /// is due, or `None` otherwise.
     ///
-    /// Returns the measured RTT in milliseconds if the sequence number
-    /// matches an outstanding probe, or `None` if it was unexpected.
+    /// Paced to one measurement per [`BW_MEASURE_INTERVAL_TICKS`] calls and
+    /// suppressed while a prior measurement is still outstanding. The three PDUs
+    /// must be sent back-to-back on the MCS message channel; the client counts
+    /// the bytes received between Start and Stop and replies with a Bandwidth
+    /// Measure Results PDU, processed by [`handle_response()`](Self::handle_response).
+    pub fn build_bandwidth_measure(&mut self) -> Option<[AutoDetectRequest; 3]> {
+        self.bw_tick_count = self.bw_tick_count.wrapping_add(1);
+        if self.pending_bw.is_some() || !self.bw_tick_count.is_multiple_of(BW_MEASURE_INTERVAL_TICKS) {
+            return None;
+        }
+        let seq = self.next_sequence;
+        self.next_sequence = seq.wrapping_add(1);
+        self.pending_bw = Some(seq);
+        Some([
+            AutoDetectRequest::bw_start_continuous(seq),
+            AutoDetectRequest::bw_payload(seq, vec![0u8; BW_PAYLOAD_LEN]),
+            AutoDetectRequest::bw_stop_continuous(seq),
+        ])
+    }
+
+    /// Build a Network Characteristics Result reporting the measured network.
+    ///
+    /// Returns `None` until the network has actually been characterised, which
+    /// means both an RTT sample and a completed bandwidth measurement. A result
+    /// carrying RTT alone reports part of the picture as though it were the
+    /// whole, so it is not sent; the same is true of the reference
+    /// implementations, which return early with no bandwidth figure to report.
+    ///
+    /// Also returns `None` when one was sent less than
+    /// [`NETCHAR_RESULT_MIN_INTERVAL_MS`] ago. The RTT probe cadence is set by
+    /// the caller and can be far faster than the rate at which the reported
+    /// figures meaningfully change, so the result is paced independently rather
+    /// than emitted once per probe.
+    ///
+    /// Finally, returns `None` unless a client response has updated the figures
+    /// since the last result. Samples do not age out of the window, so a client
+    /// that stops answering would otherwise leave the last values being
+    /// advertised forever. `snapshot()` still reports them, where staleness is
+    /// the embedder's to judge, but they are not put on the wire as a current
+    /// claim.
+    ///
+    /// `baseRTT` is the lowest RTT seen over the whole session, not the lowest in
+    /// the current window, so it never rises. `averageRTT` is the window average
+    /// and does track current conditions; the difference between the two is what
+    /// a client reads as queueing delay.
+    ///
+    /// Like [`send_rtt_request()`](Self::send_rtt_request), the caller sends the
+    /// returned PDU on the MCS message channel. The client does not reply to it.
+    pub fn build_netchar_result(&mut self, now_ms: u64) -> Option<AutoDetectRequest> {
+        if !self.measurement_is_fresh {
+            return None;
+        }
+        let bandwidth_kbps = self.bandwidth_kbps?;
+        let base_rtt_ms = self.min_rtt_ms?;
+        let snapshot = self.snapshot()?;
+
+        if let Some(last) = self.last_netchar_result_ms {
+            if now_ms.saturating_sub(last) < NETCHAR_RESULT_MIN_INTERVAL_MS {
+                return None;
+            }
+        }
+        self.last_netchar_result_ms = Some(now_ms);
+        self.measurement_is_fresh = false;
+
+        let seq = self.next_sequence;
+        self.next_sequence = seq.wrapping_add(1);
+        Some(AutoDetectRequest::netchar_result(
+            seq,
+            base_rtt_ms,
+            bandwidth_kbps,
+            snapshot.avg_ms,
+        ))
+    }
+
+    /// Process an Auto-Detect Response from the client.
+    ///
+    /// For an RTT Measure Response, records the sample and returns the measured
+    /// RTT in milliseconds. For a Bandwidth Measure Results, records the
+    /// computed bandwidth internally and returns `None`. Returns `None` for an
+    /// unexpected or unmatched response.
+    ///
     /// `now_ms` is the receipt time on the same clock passed to
     /// [`send_rtt_request()`](Self::send_rtt_request).
     pub fn handle_response(&mut self, response: &AutoDetectResponse, now_ms: u64) -> Option<u32> {
-        let AutoDetectResponse::RttResponse { sequence_number } = response else {
-            return None;
-        };
+        match response {
+            AutoDetectResponse::RttResponse { sequence_number } => {
+                let idx = self.pending_probes.iter().position(|(s, _)| *s == *sequence_number)?;
+                let (_, sent_at_ms) = self.pending_probes.remove(idx);
 
-        let idx = self.pending_probes.iter().position(|(s, _)| *s == *sequence_number)?;
-        let (_, sent_at_ms) = self.pending_probes.remove(idx);
+                // Saturating rather than wrapping: a caller whose clock went backwards gets
+                // a zero sample, not a nonsense one near u32::MAX.
+                let rtt_ms = u32::try_from(now_ms.saturating_sub(sent_at_ms)).unwrap_or(u32::MAX);
 
-        // Saturating rather than wrapping: a caller whose clock went backwards gets a
-        // zero sample, not a nonsense one near u32::MAX.
-        let rtt_ms = u32::try_from(now_ms.saturating_sub(sent_at_ms)).unwrap_or(u32::MAX);
+                if self.rtt_samples.len() >= RTT_WINDOW_SIZE {
+                    self.rtt_samples.pop_front();
+                }
+                self.rtt_samples.push_back(rtt_ms);
+                self.min_rtt_ms = Some(self.min_rtt_ms.map_or(rtt_ms, |m| m.min(rtt_ms)));
+                self.measurement_is_fresh = true;
 
-        if self.rtt_samples.len() >= RTT_WINDOW_SIZE {
-            self.rtt_samples.pop_front();
+                Some(rtt_ms)
+            }
+            AutoDetectResponse::BandwidthMeasureResults { sequence_number, .. } => {
+                if self.pending_bw == Some(*sequence_number) {
+                    self.pending_bw = None;
+                    if let Some(kbps) = response.computed_bandwidth_kbps() {
+                        self.bandwidth_kbps = Some(kbps);
+                        self.measurement_is_fresh = true;
+                    }
+                }
+                None
+            }
+            _ => None,
         }
-        self.rtt_samples.push_back(rtt_ms);
-
-        Some(rtt_ms)
     }
 
     /// Get current RTT statistics, or `None` if no measurements yet.
@@ -132,7 +274,10 @@ impl Default for AutoDetectManager {
 /// Snapshot of RTT measurement results.
 #[derive(Debug, Clone, Copy)]
 pub struct RttSnapshot {
-    /// Minimum observed RTT in milliseconds.
+    /// Minimum RTT in milliseconds over the current window.
+    ///
+    /// Not the `baseRTT` sent on the wire, which is the session-lifetime lowest
+    /// per [MS-RDPBCGR] 2.2.14.1.5. This one can rise as low samples age out.
     pub min_ms: u32,
     /// Maximum observed RTT in milliseconds.
     pub max_ms: u32,

--- a/crates/ironrdp-server/src/autodetect.rs
+++ b/crates/ironrdp-server/src/autodetect.rs
@@ -48,14 +48,33 @@ impl AutoDetectManager {
 
     /// Generate an RTT Measure Request PDU for continuous detection.
     ///
-    /// The caller must encode and send the returned [`AutoDetectRequest`] as
-    /// a Share Data PDU on the IO channel. `now_ms` is recorded as the send time and
-    /// is what [`handle_response()`](Self::handle_response) measures against.
+    /// The caller must encode and send the returned [`AutoDetectRequest`] on
+    /// the MCS message channel, framed by a `SEC_AUTODETECT_REQ` security
+    /// header ([MS-RDPBCGR] 2.2.14.3). `now_ms` is recorded as the send time
+    /// and is what [`handle_response()`](Self::handle_response) measures against.
     pub fn send_rtt_request(&mut self, now_ms: u64) -> AutoDetectRequest {
         let seq = self.next_sequence;
         self.next_sequence = seq.wrapping_add(1);
         self.pending_probes.push((seq, now_ms));
         AutoDetectRequest::rtt_continuous(seq)
+    }
+
+    /// Build a Network Characteristics Result reporting the measured RTT.
+    ///
+    /// Returns `None` until at least one RTT sample has been recorded. The
+    /// result carries baseRTT (lowest observed) and averageRTT over the current
+    /// window; bandwidth is omitted. Like [`send_rtt_request()`](Self::send_rtt_request),
+    /// the caller sends the returned PDU on the MCS message channel. The client
+    /// does not reply to it.
+    pub fn build_netchar_result(&mut self) -> Option<AutoDetectRequest> {
+        let snapshot = self.snapshot()?;
+        let seq = self.next_sequence;
+        self.next_sequence = seq.wrapping_add(1);
+        Some(AutoDetectRequest::netchar_result_rtt(
+            seq,
+            snapshot.min_ms,
+            snapshot.avg_ms,
+        ))
     }
 
     /// Process an RTT Measure Response from the client.
@@ -250,6 +269,38 @@ mod tests {
             sequence_number: req.sequence_number(),
         };
         assert_eq!(mgr.handle_response(&response, u64::from(u32::MAX) + 1), Some(u32::MAX));
+    }
+
+    #[test]
+    fn netchar_result_none_without_samples() {
+        let mut mgr = AutoDetectManager::new();
+        assert!(mgr.build_netchar_result().is_none());
+    }
+
+    #[test]
+    fn netchar_result_reports_measured_rtt() {
+        let mut mgr = AutoDetectManager::new();
+
+        let req = mgr.send_rtt_request(0);
+        let response = AutoDetectResponse::RttResponse {
+            sequence_number: req.sequence_number(),
+        };
+        let _ = mgr.handle_response(&response, 20);
+
+        let snap = mgr.snapshot().expect("one sample recorded");
+        match mgr.build_netchar_result().expect("result once samples exist") {
+            AutoDetectRequest::NetworkCharacteristicsResult {
+                base_rtt_ms,
+                bandwidth_kbps,
+                average_rtt_ms,
+                ..
+            } => {
+                assert_eq!(base_rtt_ms, Some(snap.min_ms));
+                assert_eq!(average_rtt_ms, snap.avg_ms);
+                assert_eq!(bandwidth_kbps, None, "RTT-only variant omits bandwidth");
+            }
+            other => panic!("expected NetworkCharacteristicsResult, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/ironrdp-server/src/autodetect.rs
+++ b/crates/ironrdp-server/src/autodetect.rs
@@ -1,8 +1,11 @@
-//! Server-side auto-detect (RTT measurement) per [MS-RDPBCGR 2.2.14].
+//! Server-side auto-detect (RTT and bandwidth measurement) per [MS-RDPBCGR 2.2.14].
 //!
 //! The server periodically sends RTT Measure Request PDUs and records the
-//! round-trip time from the client's response. Results are exposed via
-//! [`AutoDetectManager::snapshot()`].
+//! round-trip time from the client's response, and periodically brackets
+//! ordinary traffic with a Bandwidth Measure Start/Stop pair so the client
+//! can report the bandwidth it observed. RTT results are exposed via
+//! [`AutoDetectManager::snapshot()`]; both RTT and bandwidth are reported to
+//! the client via [`AutoDetectManager::build_netchar_result()`].
 //!
 //! [MS-RDPBCGR 2.2.14]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/dc672839-4f4e-40b1-a71c-cd6a959baa38
 
@@ -17,9 +20,19 @@ const RTT_WINDOW_SIZE: usize = 8;
 pub(crate) const RTT_PROBE_MAX_AGE_MS: u64 = 30_000;
 
 /// Run a bandwidth measurement once every this many RTT ticks. Bandwidth
-/// changes far more slowly than RTT and each measurement sends a payload, so it
-/// is sampled less often than the per-tick RTT probe.
+/// changes far more slowly than RTT, so it is sampled less often than the
+/// per-tick RTT probe.
 const BW_MEASURE_INTERVAL_TICKS: u32 = 8;
+
+/// Number of RTT ticks a bandwidth window stays open between Start and Stop.
+///
+/// [MS-RDPBCGR] 1.3.9 and 2.2.14.2.2 scope the Bandwidth Measure Payload
+/// message to the connect-time transaction only; after the RDP Connection
+/// Sequence, "the PDUs sent from server to client (between start and stop
+/// messages) replace the payload messages". So the window has to stay open
+/// long enough for ordinary traffic to fill it, rather than closing
+/// immediately the way a synthetic payload would allow.
+const BW_WINDOW_TICKS: u32 = 4;
 
 /// Minimum spacing between Network Characteristics Result PDUs.
 ///
@@ -28,11 +41,6 @@ const BW_MEASURE_INTERVAL_TICKS: u32 = 8;
 /// aggressive probe rate from turning into an equally aggressive stream of
 /// unsolicited PDUs.
 const NETCHAR_RESULT_MIN_INTERVAL_MS: u64 = 1_000;
-
-/// Size of the synthetic Bandwidth Measure Payload, in bytes. Large enough that
-/// the client's measured time delta is meaningful on a real link, small enough
-/// not to be a noticeable periodic cost.
-const BW_PAYLOAD_LEN: usize = 8192;
 
 /// Server-side auto-detect state machine.
 ///
@@ -53,9 +61,9 @@ pub struct AutoDetectManager {
     /// Outstanding probes as `(sequence_number, sent_at_ms)`.
     pending_probes: Vec<(u16, u64)>,
     rtt_samples: VecDeque<u32>,
-    /// Sequence number of an in-flight bandwidth measurement, if any. A new
-    /// measurement is not started while one is outstanding.
-    pending_bw: Option<u16>,
+    /// State of an in-flight bandwidth measurement, if any. A new measurement
+    /// is not started while one is outstanding.
+    pending_bw: Option<PendingBandwidth>,
     /// Most recently measured bandwidth in kilobits per second.
     bandwidth_kbps: Option<u32>,
     /// Counts RTT ticks to pace bandwidth measurements (see [`BW_MEASURE_INTERVAL_TICKS`]).
@@ -71,12 +79,29 @@ pub struct AutoDetectManager {
     /// the baseRTT / averageRTT pair unusable for the queueing-delay difference
     /// a client computes from it.
     min_rtt_ms: Option<u32>,
-    /// Set when a client response updates the measured figures, cleared when a
+    /// Set when an RTT response updates the measured figures, cleared when a
     /// Network Characteristics Result reports them.
     ///
     /// Without it a client that stops answering leaves the last window values
     /// being advertised indefinitely, since they never age out of `rtt_samples`.
-    measurement_is_fresh: bool,
+    rtt_is_fresh: bool,
+    /// Set when a bandwidth measurement completes, cleared when a Network
+    /// Characteristics Result reports it.
+    ///
+    /// Tracked separately from [`rtt_is_fresh`](Self::rtt_is_fresh): bandwidth
+    /// measurements complete far less often than RTT samples arrive, so an RTT
+    /// response alone must not re-arm reporting of a bandwidth figure that may
+    /// be several measurements stale.
+    bandwidth_is_fresh: bool,
+}
+
+/// State of an in-flight continuous bandwidth measurement.
+enum PendingBandwidth {
+    /// Start has been sent; the window stays open for this many more ticks
+    /// before Stop is sent, so ordinary traffic can fill it.
+    Open { sequence: u16, ticks_remaining: u32 },
+    /// Stop has been sent; awaiting the client's Bandwidth Measure Results.
+    AwaitingResults { sequence: u16 },
 }
 
 impl AutoDetectManager {
@@ -89,7 +114,8 @@ impl AutoDetectManager {
             bandwidth_kbps: None,
             bw_tick_count: 0,
             last_netchar_result_ms: None,
-            measurement_is_fresh: false,
+            rtt_is_fresh: false,
+            bandwidth_is_fresh: false,
             min_rtt_ms: None,
         }
     }
@@ -107,27 +133,49 @@ impl AutoDetectManager {
         AutoDetectRequest::rtt_continuous(seq)
     }
 
-    /// Build a Bandwidth Measure transaction (Start → Payload → Stop) when one
-    /// is due, or `None` otherwise.
+    /// Advance the bandwidth measurement state machine by one tick, returning
+    /// a PDU to send when the machine has one, or `None` otherwise.
     ///
-    /// Paced to one measurement per [`BW_MEASURE_INTERVAL_TICKS`] calls and
-    /// suppressed while a prior measurement is still outstanding. The three PDUs
-    /// must be sent back-to-back on the MCS message channel; the client counts
-    /// the bytes received between Start and Stop and replies with a Bandwidth
-    /// Measure Results PDU, processed by [`handle_response()`](Self::handle_response).
-    pub fn build_bandwidth_measure(&mut self) -> Option<[AutoDetectRequest; 3]> {
-        self.bw_tick_count = self.bw_tick_count.wrapping_add(1);
-        if self.pending_bw.is_some() || !self.bw_tick_count.is_multiple_of(BW_MEASURE_INTERVAL_TICKS) {
-            return None;
+    /// A measurement is a Start sent when one is due (paced to once every
+    /// [`BW_MEASURE_INTERVAL_TICKS`] calls and suppressed while a prior one is
+    /// outstanding), followed by a Stop sent [`BW_WINDOW_TICKS`] calls later.
+    /// No payload PDU is sent between them: per [MS-RDPBCGR] 1.3.9, Continuous
+    /// Auto-Detection's server-to-client message set for bandwidth measurement
+    /// is Start and Stop only, and 2.2.14.2.2 states that after the RDP
+    /// Connection Sequence the ordinary PDUs the server sends between them
+    /// are what the client counts. The caller sends whichever PDU this
+    /// returns on the MCS message channel; the client eventually replies with
+    /// a Bandwidth Measure Results PDU, processed by
+    /// [`handle_response()`](Self::handle_response).
+    pub fn build_bandwidth_measure(&mut self) -> Option<AutoDetectRequest> {
+        match &mut self.pending_bw {
+            Some(PendingBandwidth::Open {
+                sequence,
+                ticks_remaining,
+            }) => {
+                if *ticks_remaining == 0 {
+                    let sequence = *sequence;
+                    self.pending_bw = Some(PendingBandwidth::AwaitingResults { sequence });
+                    return Some(AutoDetectRequest::bw_stop_continuous(sequence));
+                }
+                *ticks_remaining -= 1;
+                None
+            }
+            Some(PendingBandwidth::AwaitingResults { .. }) => None,
+            None => {
+                self.bw_tick_count = self.bw_tick_count.wrapping_add(1);
+                if !self.bw_tick_count.is_multiple_of(BW_MEASURE_INTERVAL_TICKS) {
+                    return None;
+                }
+                let seq = self.next_sequence;
+                self.next_sequence = seq.wrapping_add(1);
+                self.pending_bw = Some(PendingBandwidth::Open {
+                    sequence: seq,
+                    ticks_remaining: BW_WINDOW_TICKS,
+                });
+                Some(AutoDetectRequest::bw_start_continuous(seq))
+            }
         }
-        let seq = self.next_sequence;
-        self.next_sequence = seq.wrapping_add(1);
-        self.pending_bw = Some(seq);
-        Some([
-            AutoDetectRequest::bw_start_continuous(seq),
-            AutoDetectRequest::bw_payload(seq, vec![0u8; BW_PAYLOAD_LEN]),
-            AutoDetectRequest::bw_stop_continuous(seq),
-        ])
     }
 
     /// Build a Network Characteristics Result reporting the measured network.
@@ -144,12 +192,17 @@ impl AutoDetectManager {
     /// figures meaningfully change, so the result is paced independently rather
     /// than emitted once per probe.
     ///
-    /// Finally, returns `None` unless a client response has updated the figures
-    /// since the last result. Samples do not age out of the window, so a client
-    /// that stops answering would otherwise leave the last values being
-    /// advertised forever. `snapshot()` still reports them, where staleness is
-    /// the embedder's to judge, but they are not put on the wire as a current
-    /// claim.
+    /// Finally, returns `None` unless a client response has updated either
+    /// figure since the last result. RTT samples do not age out of the
+    /// window, and a completed bandwidth measurement is never invalidated by
+    /// a later failed one on its own, so a client that stops answering would
+    /// otherwise leave the last values being advertised forever. `snapshot()`
+    /// still reports them, where staleness is the embedder's to judge, but
+    /// they are not put on the wire as a current claim; a bandwidth
+    /// measurement that completes without a usable figure clears
+    /// `bandwidth_kbps` rather than leaving the previous one in place, so a
+    /// run of failures withholds the result entirely instead of reporting an
+    /// increasingly stale number.
     ///
     /// `baseRTT` is the lowest RTT seen over the whole session, not the lowest in
     /// the current window, so it never rises. `averageRTT` is the window average
@@ -159,7 +212,7 @@ impl AutoDetectManager {
     /// Like [`send_rtt_request()`](Self::send_rtt_request), the caller sends the
     /// returned PDU on the MCS message channel. The client does not reply to it.
     pub fn build_netchar_result(&mut self, now_ms: u64) -> Option<AutoDetectRequest> {
-        if !self.measurement_is_fresh {
+        if !self.rtt_is_fresh && !self.bandwidth_is_fresh {
             return None;
         }
         let bandwidth_kbps = self.bandwidth_kbps?;
@@ -172,7 +225,8 @@ impl AutoDetectManager {
             }
         }
         self.last_netchar_result_ms = Some(now_ms);
-        self.measurement_is_fresh = false;
+        self.rtt_is_fresh = false;
+        self.bandwidth_is_fresh = false;
 
         let seq = self.next_sequence;
         self.next_sequence = seq.wrapping_add(1);
@@ -208,16 +262,24 @@ impl AutoDetectManager {
                 }
                 self.rtt_samples.push_back(rtt_ms);
                 self.min_rtt_ms = Some(self.min_rtt_ms.map_or(rtt_ms, |m| m.min(rtt_ms)));
-                self.measurement_is_fresh = true;
+                self.rtt_is_fresh = true;
 
                 Some(rtt_ms)
             }
             AutoDetectResponse::BandwidthMeasureResults { sequence_number, .. } => {
-                if self.pending_bw == Some(*sequence_number) {
+                let awaiting = matches!(
+                    self.pending_bw,
+                    Some(PendingBandwidth::AwaitingResults { sequence }) if sequence == *sequence_number
+                );
+                if awaiting {
                     self.pending_bw = None;
-                    if let Some(kbps) = response.computed_bandwidth_kbps() {
-                        self.bandwidth_kbps = Some(kbps);
-                        self.measurement_is_fresh = true;
+                    // A transaction that completes without a usable figure clears the
+                    // previous one rather than leaving it in place, so a run of failures
+                    // withholds the result (see `build_netchar_result`) instead of
+                    // reporting an increasingly stale bandwidth.
+                    self.bandwidth_kbps = response.computed_bandwidth_kbps();
+                    if self.bandwidth_kbps.is_some() {
+                        self.bandwidth_is_fresh = true;
                     }
                 }
                 None

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -1495,15 +1495,13 @@ impl RdpServer {
                             writer.write_all(&data).await?;
                         }
 
-                        // Periodically measure bandwidth: Start → Payload → Stop sent
-                        // back-to-back so the client counts only the payload window, then
-                        // replies with a Bandwidth Measure Results PDU. Until one has
-                        // completed there is no characteristics result to send at all.
-                        if let Some(bw_pdus) = ad.build_bandwidth_measure() {
-                            for pdu in bw_pdus {
-                                let data = encode_autodetect_request(pdu, message_channel_id, user_channel_id)?;
-                                writer.write_all(&data).await?;
-                            }
+                        // Periodically measure bandwidth: Start on one tick, Stop several
+                        // ticks later, with ordinary traffic in between counted by the
+                        // client, then a Bandwidth Measure Results PDU in reply. Until one
+                        // has completed there is no characteristics result to send at all.
+                        if let Some(pdu) = ad.build_bandwidth_measure() {
+                            let data = encode_autodetect_request(pdu, message_channel_id, user_channel_id)?;
+                            writer.write_all(&data).await?;
                         }
                     }
                 }

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -1484,6 +1484,27 @@ impl RdpServer {
                         let request = ad.send_rtt_request(now_ms);
                         let data = encode_autodetect_request(request, message_channel_id, user_channel_id)?;
                         writer.write_all(&data).await?;
+
+                        // Report the measured characteristics to the client
+                        // ([MS-RDPBCGR] 2.2.14.1.5). The client does not reply. Sent only
+                        // once both RTT and bandwidth are known, and paced independently
+                        // of this probe cadence, so a fast caller does not turn into a
+                        // fast stream of unsolicited PDUs.
+                        if let Some(result) = ad.build_netchar_result(now_ms) {
+                            let data = encode_autodetect_request(result, message_channel_id, user_channel_id)?;
+                            writer.write_all(&data).await?;
+                        }
+
+                        // Periodically measure bandwidth: Start → Payload → Stop sent
+                        // back-to-back so the client counts only the payload window, then
+                        // replies with a Bandwidth Measure Results PDU. Until one has
+                        // completed there is no characteristics result to send at all.
+                        if let Some(bw_pdus) = ad.build_bandwidth_measure() {
+                            for pdu in bw_pdus {
+                                let data = encode_autodetect_request(pdu, message_channel_id, user_channel_id)?;
+                                writer.write_all(&data).await?;
+                            }
+                        }
                     }
                 }
             }

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -1468,6 +1468,15 @@ impl RdpServer {
                         let request = ad.send_rtt_request(now_ms);
                         let data = encode_autodetect_request(request, message_channel_id, user_channel_id)?;
                         writer.write_all(&data).await?;
+
+                        // Report the measured characteristics back to the client so it
+                        // can size its receive buffers ([MS-RDPBCGR] 2.2.14.1.5). Skipped
+                        // until RTT samples exist; the client does not reply. The emission
+                        // cadence follows the caller's request cadence.
+                        if let Some(result) = ad.build_netchar_result() {
+                            let data = encode_autodetect_request(result, message_channel_id, user_channel_id)?;
+                            writer.write_all(&data).await?;
+                        }
                     }
                 }
             }

--- a/crates/ironrdp-testsuite-core/tests/server/autodetect.rs
+++ b/crates/ironrdp-testsuite-core/tests/server/autodetect.rs
@@ -1,6 +1,42 @@
 use ironrdp_pdu::rdp::autodetect::{AutoDetectRequest, AutoDetectResponse};
 use ironrdp_server::autodetect::AutoDetectManager;
 
+/// Upper bound on ticks to drive while waiting for a bandwidth transaction:
+/// generous enough to cover the pacing plus the window, tight enough that a
+/// regression that stops `build_bandwidth_measure` from ever completing a
+/// transaction fails the test instead of hanging CI.
+const MAX_BANDWIDTH_TICKS: usize = 64;
+
+/// Drives `build_bandwidth_measure` until it has produced both a Start and a
+/// Stop, asserting the transaction shape along the way: exactly those two
+/// PDUs, sharing one sequence number, with nothing in between. Pinning the
+/// PDU types here is what would have caught a synthetic payload PDU sent
+/// between them, which is off-spec for continuous detection per
+/// [MS-RDPBCGR] 1.3.9. Returns the transaction's sequence number.
+fn drive_bandwidth_start_and_stop(mgr: &mut AutoDetectManager) -> u16 {
+    let mut start_sequence = None;
+    for _ in 0..MAX_BANDWIDTH_TICKS {
+        let Some(pdu) = mgr.build_bandwidth_measure() else {
+            continue;
+        };
+        match (start_sequence, pdu) {
+            (None, AutoDetectRequest::BandwidthMeasureStart { sequence_number, .. }) => {
+                start_sequence = Some(sequence_number);
+            }
+            (Some(start), AutoDetectRequest::BandwidthMeasureStop { sequence_number, .. }) => {
+                assert_eq!(
+                    sequence_number, start,
+                    "Start and Stop must share the transaction sequence"
+                );
+                return start;
+            }
+            (None, other) => panic!("expected Start first, got {other:?}"),
+            (Some(_), other) => panic!("expected Stop after Start, got {other:?}"),
+        }
+    }
+    panic!("bandwidth transaction did not complete within {MAX_BANDWIDTH_TICKS} ticks");
+}
+
 #[test]
 fn rtt_request_increments_sequence() {
     let mut mgr = AutoDetectManager::new();
@@ -99,19 +135,9 @@ fn bandwidth_measure_transacts_and_enables_netchar() {
         20,
     );
 
-    // Drive a bandwidth measurement to completion (paced internally).
-    let pdus = loop {
-        if let Some(p) = mgr.build_bandwidth_measure() {
-            break p;
-        }
-    };
-    assert_eq!(
-        pdus[0].sequence_number(),
-        pdus[2].sequence_number(),
-        "Start and Stop share the transaction sequence"
-    );
+    let bw_seq = drive_bandwidth_start_and_stop(&mut mgr);
     let results = AutoDetectResponse::BandwidthMeasureResults {
-        sequence_number: pdus[0].sequence_number(),
+        sequence_number: bw_seq,
         response_type: ironrdp_pdu::rdp::autodetect::BW_RESULTS_CONTINUOUS,
         time_delta_ms: 10,
         byte_count: 100_000,
@@ -127,6 +153,125 @@ fn bandwidth_measure_transacts_and_enables_netchar() {
         }
         other => panic!("expected NetworkCharacteristicsResult, got {other:?}"),
     }
+}
+
+/// A second call to `build_bandwidth_measure` after Stop has been sent, while
+/// the client's Bandwidth Measure Results is still outstanding, must not
+/// start a new transaction. `drive_bandwidth_start_and_stop` already pins
+/// that nothing is sent between Start and Stop themselves; this covers the
+/// phase after Stop that it does not drive into.
+#[test]
+fn a_second_measurement_does_not_start_while_awaiting_results() {
+    let mut mgr = AutoDetectManager::new();
+    let _ = drive_bandwidth_start_and_stop(&mut mgr);
+
+    for _ in 0..MAX_BANDWIDTH_TICKS {
+        assert!(
+            mgr.build_bandwidth_measure().is_none(),
+            "no new transaction while the prior one awaits results"
+        );
+    }
+}
+
+/// A Bandwidth Measure Results whose sequence number does not match the
+/// outstanding transaction must be ignored: no bandwidth recorded, and the
+/// transaction stays outstanding rather than being cleared by an unrelated
+/// reply.
+#[test]
+fn mismatched_bandwidth_sequence_is_ignored() {
+    let mut mgr = AutoDetectManager::new();
+    let req = mgr.send_rtt_request(0);
+    let _ = mgr.handle_response(
+        &AutoDetectResponse::RttResponse {
+            sequence_number: req.sequence_number(),
+        },
+        20,
+    );
+    let bw_seq = drive_bandwidth_start_and_stop(&mut mgr);
+
+    // A reply for a different sequence must not be treated as completing the
+    // outstanding transaction.
+    let mismatched = AutoDetectResponse::BandwidthMeasureResults {
+        sequence_number: bw_seq.wrapping_add(1),
+        response_type: ironrdp_pdu::rdp::autodetect::BW_RESULTS_CONTINUOUS,
+        time_delta_ms: 10,
+        byte_count: 100_000,
+    };
+    assert!(mgr.handle_response(&mismatched, 20).is_none());
+    assert!(
+        mgr.build_netchar_result(1_000).is_none(),
+        "a mismatched reply must not have recorded a bandwidth figure"
+    );
+
+    // The real transaction is still outstanding, so its own reply still
+    // completes it. If the mismatched reply above had been accepted, this
+    // second reply would find no outstanding transaction to match and the
+    // measurement would never complete.
+    let matching = AutoDetectResponse::BandwidthMeasureResults {
+        sequence_number: bw_seq,
+        response_type: ironrdp_pdu::rdp::autodetect::BW_RESULTS_CONTINUOUS,
+        time_delta_ms: 10,
+        byte_count: 100_000,
+    };
+    assert!(mgr.handle_response(&matching, 20).is_none());
+    assert!(
+        mgr.build_netchar_result(1_000).is_some(),
+        "the outstanding transaction's own reply must still complete it"
+    );
+}
+
+/// A Bandwidth Measure Results with `time_delta_ms: 0` cannot compute a
+/// figure. It must not be reported, and it must not leave a stale
+/// `bandwidth_kbps` from an earlier successful measurement on the wire as if
+/// it were current.
+#[test]
+fn zero_time_delta_ages_out_a_previous_bandwidth_figure() {
+    let mut mgr = AutoDetectManager::new();
+    let req = mgr.send_rtt_request(0);
+    let _ = mgr.handle_response(
+        &AutoDetectResponse::RttResponse {
+            sequence_number: req.sequence_number(),
+        },
+        20,
+    );
+
+    // First measurement succeeds.
+    let bw_seq = drive_bandwidth_start_and_stop(&mut mgr);
+    let good_results = AutoDetectResponse::BandwidthMeasureResults {
+        sequence_number: bw_seq,
+        response_type: ironrdp_pdu::rdp::autodetect::BW_RESULTS_CONTINUOUS,
+        time_delta_ms: 10,
+        byte_count: 100_000,
+    };
+    assert!(mgr.handle_response(&good_results, 20).is_none());
+    assert!(
+        mgr.build_netchar_result(1_000).is_some(),
+        "a real bandwidth figure is known"
+    );
+
+    // Second measurement fails: timeDelta 0.
+    let req = mgr.send_rtt_request(1_000);
+    let _ = mgr.handle_response(
+        &AutoDetectResponse::RttResponse {
+            sequence_number: req.sequence_number(),
+        },
+        1_020,
+    );
+    let bw_seq = drive_bandwidth_start_and_stop(&mut mgr);
+    let zero_delta_results = AutoDetectResponse::BandwidthMeasureResults {
+        sequence_number: bw_seq,
+        response_type: ironrdp_pdu::rdp::autodetect::BW_RESULTS_CONTINUOUS,
+        time_delta_ms: 0,
+        byte_count: 100_000,
+    };
+    assert!(mgr.handle_response(&zero_delta_results, 1_020).is_none());
+
+    // The RTT sample is fresh, but the old bandwidth figure must not ride
+    // along as though it were still current.
+    assert!(
+        mgr.build_netchar_result(2_000).is_none(),
+        "the aged-out bandwidth figure must withhold the result, not report the stale one"
+    );
 }
 
 #[test]
@@ -219,11 +364,7 @@ fn netchar_result_is_paced_independently_of_the_probe_cadence() {
     };
     let _ = mgr.handle_response(&response, 20);
 
-    let bw_seq = loop {
-        if let Some(pdus) = mgr.build_bandwidth_measure() {
-            break pdus[0].sequence_number();
-        }
-    };
+    let bw_seq = drive_bandwidth_start_and_stop(&mut mgr);
     let results = AutoDetectResponse::BandwidthMeasureResults {
         sequence_number: bw_seq,
         response_type: ironrdp_pdu::rdp::autodetect::BW_RESULTS_CONTINUOUS,
@@ -268,11 +409,7 @@ fn netchar_result_stops_when_the_client_stops_answering() {
         },
         20,
     );
-    let bw_seq = loop {
-        if let Some(pdus) = mgr.build_bandwidth_measure() {
-            break pdus[0].sequence_number();
-        }
-    };
+    let bw_seq = drive_bandwidth_start_and_stop(&mut mgr);
     let results = AutoDetectResponse::BandwidthMeasureResults {
         sequence_number: bw_seq,
         response_type: ironrdp_pdu::rdp::autodetect::BW_RESULTS_CONTINUOUS,
@@ -339,11 +476,7 @@ fn base_rtt_is_the_session_low_not_the_window_low() {
         "the 5 ms sample has aged out of the window"
     );
 
-    let bw_seq = loop {
-        if let Some(pdus) = mgr.build_bandwidth_measure() {
-            break pdus[0].sequence_number();
-        }
-    };
+    let bw_seq = drive_bandwidth_start_and_stop(&mut mgr);
     let results = AutoDetectResponse::BandwidthMeasureResults {
         sequence_number: bw_seq,
         response_type: ironrdp_pdu::rdp::autodetect::BW_RESULTS_CONTINUOUS,
@@ -387,11 +520,7 @@ fn netchar_result_maps_each_measurement_to_its_own_field() {
     assert_eq!(snap.min_ms, 10, "the 5 ms sample has left the window");
     assert_eq!(snap.avg_ms, 45, "average of 10 through 80");
 
-    let bw_seq = loop {
-        if let Some(pdus) = mgr.build_bandwidth_measure() {
-            break pdus[0].sequence_number();
-        }
-    };
+    let bw_seq = drive_bandwidth_start_and_stop(&mut mgr);
     let results = AutoDetectResponse::BandwidthMeasureResults {
         sequence_number: bw_seq,
         response_type: ironrdp_pdu::rdp::autodetect::BW_RESULTS_CONTINUOUS,

--- a/crates/ironrdp-testsuite-core/tests/server/autodetect.rs
+++ b/crates/ironrdp-testsuite-core/tests/server/autodetect.rs
@@ -1,4 +1,4 @@
-use ironrdp_pdu::rdp::autodetect::AutoDetectResponse;
+use ironrdp_pdu::rdp::autodetect::{AutoDetectRequest, AutoDetectResponse};
 use ironrdp_server::autodetect::AutoDetectManager;
 
 #[test]
@@ -58,6 +58,43 @@ fn snapshot_reflects_measurements() {
     assert_eq!(snap.min_ms, 10);
     assert_eq!(snap.max_ms, 30);
     assert_eq!(snap.avg_ms, 20);
+}
+
+#[test]
+fn netchar_result_none_without_measurements() {
+    let mut mgr = AutoDetectManager::new();
+    assert!(
+        mgr.build_netchar_result().is_none(),
+        "no result should be produced before any RTT sample"
+    );
+}
+
+#[test]
+fn netchar_result_reports_measured_rtt() {
+    let mut mgr = AutoDetectManager::new();
+
+    for _ in 0..3 {
+        let req = mgr.send_rtt_request(0);
+        let response = AutoDetectResponse::RttResponse {
+            sequence_number: req.sequence_number(),
+        };
+        let _ = mgr.handle_response(&response, 20);
+    }
+
+    let snap = mgr.snapshot().expect("should have data");
+    match mgr.build_netchar_result().expect("result once samples exist") {
+        AutoDetectRequest::NetworkCharacteristicsResult {
+            base_rtt_ms,
+            bandwidth_kbps,
+            average_rtt_ms,
+            ..
+        } => {
+            assert_eq!(base_rtt_ms, Some(snap.min_ms), "baseRTT is the lowest observed RTT");
+            assert_eq!(average_rtt_ms, snap.avg_ms, "averageRTT matches the window average");
+            assert_eq!(bandwidth_kbps, None, "RTT-only variant omits bandwidth");
+        }
+        other => panic!("expected NetworkCharacteristicsResult, got {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/ironrdp-testsuite-core/tests/server/autodetect.rs
+++ b/crates/ironrdp-testsuite-core/tests/server/autodetect.rs
@@ -1,4 +1,4 @@
-use ironrdp_pdu::rdp::autodetect::AutoDetectResponse;
+use ironrdp_pdu::rdp::autodetect::{AutoDetectRequest, AutoDetectResponse};
 use ironrdp_server::autodetect::AutoDetectManager;
 
 #[test]
@@ -58,6 +58,75 @@ fn snapshot_reflects_measurements() {
     assert_eq!(snap.min_ms, 10);
     assert_eq!(snap.max_ms, 30);
     assert_eq!(snap.avg_ms, 20);
+}
+
+#[test]
+fn netchar_result_none_without_measurements() {
+    let mut mgr = AutoDetectManager::new();
+    assert!(
+        mgr.build_netchar_result(0).is_none(),
+        "no result should be produced before the network has been characterised"
+    );
+}
+
+#[test]
+fn netchar_result_withheld_until_bandwidth_is_known() {
+    let mut mgr = AutoDetectManager::new();
+
+    for _ in 0..3 {
+        let req = mgr.send_rtt_request(0);
+        let response = AutoDetectResponse::RttResponse {
+            sequence_number: req.sequence_number(),
+        };
+        let _ = mgr.handle_response(&response, 20);
+    }
+
+    assert!(mgr.snapshot().is_some(), "RTT samples were recorded");
+    assert!(
+        mgr.build_netchar_result(20).is_none(),
+        "RTT without a bandwidth measurement is not a characterisation of the network"
+    );
+}
+
+#[test]
+fn bandwidth_measure_transacts_and_enables_netchar() {
+    let mut mgr = AutoDetectManager::new();
+    let req = mgr.send_rtt_request(0);
+    let _ = mgr.handle_response(
+        &AutoDetectResponse::RttResponse {
+            sequence_number: req.sequence_number(),
+        },
+        20,
+    );
+
+    // Drive a bandwidth measurement to completion (paced internally).
+    let pdus = loop {
+        if let Some(p) = mgr.build_bandwidth_measure() {
+            break p;
+        }
+    };
+    assert_eq!(
+        pdus[0].sequence_number(),
+        pdus[2].sequence_number(),
+        "Start and Stop share the transaction sequence"
+    );
+    let results = AutoDetectResponse::BandwidthMeasureResults {
+        sequence_number: pdus[0].sequence_number(),
+        response_type: ironrdp_pdu::rdp::autodetect::BW_RESULTS_CONTINUOUS,
+        time_delta_ms: 10,
+        byte_count: 100_000,
+    };
+    assert!(mgr.handle_response(&results, 20).is_none());
+
+    match mgr
+        .build_netchar_result(20)
+        .expect("result once RTT and bandwidth are known")
+    {
+        AutoDetectRequest::NetworkCharacteristicsResult { bandwidth_kbps, .. } => {
+            assert_eq!(bandwidth_kbps, Some(80_000), "byte_count * 8 / time_delta_ms");
+        }
+        other => panic!("expected NetworkCharacteristicsResult, got {other:?}"),
+    }
 }
 
 #[test]
@@ -129,4 +198,219 @@ fn stale_probe_expiry() {
 
     mgr.expire_stale_probes(1, 0);
     assert_eq!(mgr.pending_count(), 0);
+}
+
+/// Mirrors the crate-private `NETCHAR_RESULT_MIN_INTERVAL_MS`, which is not
+/// reachable across the crate boundary.
+const NETCHAR_RESULT_INTERVAL_MS: u64 = 1_000;
+
+/// Mirrors the crate-private `RTT_WINDOW_SIZE`.
+const RTT_WINDOW: usize = 8;
+
+/// The result is paced on its own clock, not on the probe cadence: a caller
+/// probing far faster than the interval still emits at most one per interval.
+#[test]
+fn netchar_result_is_paced_independently_of_the_probe_cadence() {
+    let mut mgr = AutoDetectManager::new();
+
+    let req = mgr.send_rtt_request(0);
+    let response = AutoDetectResponse::RttResponse {
+        sequence_number: req.sequence_number(),
+    };
+    let _ = mgr.handle_response(&response, 20);
+
+    let bw_seq = loop {
+        if let Some(pdus) = mgr.build_bandwidth_measure() {
+            break pdus[0].sequence_number();
+        }
+    };
+    let results = AutoDetectResponse::BandwidthMeasureResults {
+        sequence_number: bw_seq,
+        response_type: ironrdp_pdu::rdp::autodetect::BW_RESULTS_CONTINUOUS,
+        time_delta_ms: 10,
+        byte_count: 100_000,
+    };
+    assert!(mgr.handle_response(&results, 20).is_none());
+
+    assert!(mgr.build_netchar_result(1_000).is_some(), "the first one is due");
+
+    // Feed a fresh sample so only the interval is under test here.
+    let req = mgr.send_rtt_request(1_000);
+    let _ = mgr.handle_response(
+        &AutoDetectResponse::RttResponse {
+            sequence_number: req.sequence_number(),
+        },
+        1_020,
+    );
+
+    assert!(
+        mgr.build_netchar_result(1_000 + NETCHAR_RESULT_INTERVAL_MS - 1)
+            .is_none(),
+        "a probe inside the interval does not emit another"
+    );
+    assert!(
+        mgr.build_netchar_result(1_000 + NETCHAR_RESULT_INTERVAL_MS).is_some(),
+        "the interval having elapsed, the next one is due"
+    );
+}
+
+/// A client that stops answering must stop producing results. Samples never
+/// age out of the window, so without this the last values would be
+/// advertised forever.
+#[test]
+fn netchar_result_stops_when_the_client_stops_answering() {
+    let mut mgr = AutoDetectManager::new();
+
+    let req = mgr.send_rtt_request(0);
+    let _ = mgr.handle_response(
+        &AutoDetectResponse::RttResponse {
+            sequence_number: req.sequence_number(),
+        },
+        20,
+    );
+    let bw_seq = loop {
+        if let Some(pdus) = mgr.build_bandwidth_measure() {
+            break pdus[0].sequence_number();
+        }
+    };
+    let results = AutoDetectResponse::BandwidthMeasureResults {
+        sequence_number: bw_seq,
+        response_type: ironrdp_pdu::rdp::autodetect::BW_RESULTS_CONTINUOUS,
+        time_delta_ms: 10,
+        byte_count: 100_000,
+    };
+    assert!(mgr.handle_response(&results, 20).is_none());
+
+    let mut now = 1_000;
+    assert!(mgr.build_netchar_result(now).is_some(), "the first one is due");
+
+    // The client has gone quiet. The interval keeps elapsing and the window
+    // still holds its samples, but there is nothing new to report.
+    for _ in 0..5 {
+        now += NETCHAR_RESULT_INTERVAL_MS;
+        assert!(
+            mgr.build_netchar_result(now).is_none(),
+            "no response has arrived since the last result"
+        );
+    }
+    assert!(mgr.snapshot().is_some(), "the samples are still there for the embedder");
+
+    // One reply, and reporting resumes.
+    let req = mgr.send_rtt_request(now);
+    let _ = mgr.handle_response(
+        &AutoDetectResponse::RttResponse {
+            sequence_number: req.sequence_number(),
+        },
+        now + 20,
+    );
+    now += NETCHAR_RESULT_INTERVAL_MS;
+    assert!(
+        mgr.build_netchar_result(now).is_some(),
+        "a fresh sample resumes reporting"
+    );
+}
+
+/// [MS-RDPBCGR] 2.2.14.1.5 defines baseRTT as the lowest detected RTT, with no
+/// window scoping, so it must not rise when a low sample ages out of the
+/// window. This is the reviewer's sequence: one 5 ms sample, then eight of
+/// 100 ms, which evicts it.
+#[test]
+fn base_rtt_is_the_session_low_not_the_window_low() {
+    let mut mgr = AutoDetectManager::new();
+
+    let sample = |mgr: &mut AutoDetectManager, rtt: u64| {
+        let req = mgr.send_rtt_request(0);
+        let _ = mgr.handle_response(
+            &AutoDetectResponse::RttResponse {
+                sequence_number: req.sequence_number(),
+            },
+            rtt,
+        );
+    };
+
+    sample(&mut mgr, 5);
+    for _ in 0..RTT_WINDOW {
+        sample(&mut mgr, 100);
+    }
+
+    assert_eq!(
+        mgr.snapshot().expect("samples recorded").min_ms,
+        100,
+        "the 5 ms sample has aged out of the window"
+    );
+
+    let bw_seq = loop {
+        if let Some(pdus) = mgr.build_bandwidth_measure() {
+            break pdus[0].sequence_number();
+        }
+    };
+    let results = AutoDetectResponse::BandwidthMeasureResults {
+        sequence_number: bw_seq,
+        response_type: ironrdp_pdu::rdp::autodetect::BW_RESULTS_CONTINUOUS,
+        time_delta_ms: 10,
+        byte_count: 100_000,
+    };
+    assert!(mgr.handle_response(&results, 20).is_none());
+
+    match mgr.build_netchar_result(1_000).expect("RTT and bandwidth are known") {
+        AutoDetectRequest::NetworkCharacteristicsResult { base_rtt_ms, .. } => {
+            assert_eq!(base_rtt_ms, Some(5), "baseRTT stays at the lowest ever detected");
+        }
+        other => panic!("expected NetworkCharacteristicsResult, got {other:?}"),
+    }
+}
+
+/// Pins which measured quantity lands in which wire field.
+///
+/// The session minimum, the window minimum and the window average are all
+/// different here, so no swap between them leaves both assertions holding.
+#[test]
+fn netchar_result_maps_each_measurement_to_its_own_field() {
+    let mut mgr = AutoDetectManager::new();
+
+    let sample = |mgr: &mut AutoDetectManager, rtt: u64| {
+        let req = mgr.send_rtt_request(0);
+        let _ = mgr.handle_response(
+            &AutoDetectResponse::RttResponse {
+                sequence_number: req.sequence_number(),
+            },
+            rtt,
+        );
+    };
+
+    sample(&mut mgr, 5);
+    for rtt in [10, 20, 30, 40, 50, 60, 70, 80] {
+        sample(&mut mgr, rtt);
+    }
+
+    let snap = mgr.snapshot().expect("samples recorded");
+    assert_eq!(snap.min_ms, 10, "the 5 ms sample has left the window");
+    assert_eq!(snap.avg_ms, 45, "average of 10 through 80");
+
+    let bw_seq = loop {
+        if let Some(pdus) = mgr.build_bandwidth_measure() {
+            break pdus[0].sequence_number();
+        }
+    };
+    let results = AutoDetectResponse::BandwidthMeasureResults {
+        sequence_number: bw_seq,
+        response_type: ironrdp_pdu::rdp::autodetect::BW_RESULTS_CONTINUOUS,
+        time_delta_ms: 10,
+        byte_count: 100_000,
+    };
+    assert!(mgr.handle_response(&results, 20).is_none());
+
+    match mgr.build_netchar_result(1_000).expect("RTT and bandwidth are known") {
+        AutoDetectRequest::NetworkCharacteristicsResult {
+            base_rtt_ms,
+            bandwidth_kbps,
+            average_rtt_ms,
+            ..
+        } => {
+            assert_eq!(base_rtt_ms, Some(5), "baseRTT is the session low, not the window low");
+            assert_eq!(average_rtt_ms, 45, "averageRTT is the window average");
+            assert_eq!(bandwidth_kbps, Some(80_000), "byte_count * 8 / time_delta_ms");
+        }
+        other => panic!("expected NetworkCharacteristicsResult, got {other:?}"),
+    }
 }


### PR DESCRIPTION
## Summary

- The server measures round-trip time and bandwidth from the continuous
  auto-detect exchange and reports both to the client in a Network
  Characteristics Result on the MCS message channel ([MS-RDPBCGR] 2.2.14.1.5).
- Nothing is sent until both are known. A result carrying RTT alone reports part
  of the picture as though it were the whole, which is what krdp and grd avoid by
  returning early when they have no bandwidth figure.
- The result is paced at one per second on its own clock rather than once per
  probe, and is withheld unless a client response has arrived since the last one.
  A client that stops answering stops producing results instead of leaving the
  last window values advertised indefinitely.
- `baseRTT` is the lowest RTT seen over the session, per 2.2.14.1.5's "lowest
  detected round-trip time". `averageRTT` is the window average, so the
  difference between them is queueing delay.

## Validation

- `cargo xtask check fmt/lints/tests/typos/locks` and `cargo xtask wasm check`
  all pass.
- `cargo semver-checks -p ironrdp-server --baseline-rev master`: no update
  required.
- Tests live in `ironrdp-testsuite-core`. `ironrdp-server` sets
  `[lib] test = false`, so an inline module would compile and never run. Each new
  test was checked by planting the corresponding regression and confirming it
  fails.

## Notes

- Supersedes #1471, which added bandwidth as a follow-up. With the gate above,
  this PR alone could only ever emit the form it now declines to send, so the two
  are one change.
- #1487 has merged, so the earlier dependency note no longer applies.
