### PR TITLE
feat(server): measure bandwidth and report it in NetworkCharacteristicsResult

### DIFF
--- a/crates/ironrdp-pdu/src/rdp/autodetect.rs
+++ b/crates/ironrdp-pdu/src/rdp/autodetect.rs
@@ -270,6 +270,20 @@ impl AutoDetectRequest {
         }
     }
 
+    /// Construct a Network Characteristics Result carrying RTT only (no bandwidth).
+    ///
+    /// Emits the `NETCHAR_RESULT_RTT` form (baseRTT + averageRTT) for servers
+    /// that measure round-trip time but do not run a bandwidth measurement.
+    pub fn netchar_result_rtt(sequence_number: u16, base_rtt_ms: u32, average_rtt_ms: u32) -> Self {
+        Self::NetworkCharacteristicsResult {
+            sequence_number,
+            request_type: NETCHAR_RESULT_RTT,
+            base_rtt_ms: Some(base_rtt_ms),
+            bandwidth_kbps: None,
+            average_rtt_ms,
+        }
+    }
+
     /// Get the sequence number of this request.
     pub fn sequence_number(&self) -> u16 {
         match self {
@@ -956,6 +970,15 @@ mod tests {
         0x14, 0x00, 0x00, 0x00, // averageRTT = 20
     ];
 
+    const NETCHAR_RTT_WIRE: &[u8] = &[
+        0x0E, // headerLength
+        0x00, // headerTypeId
+        0x07, 0x00, // sequenceNumber = 7
+        0x40, 0x08, // requestType = NETCHAR_RESULT_RTT (0x0840)
+        0x08, 0x00, 0x00, 0x00, // baseRTT = 8
+        0x12, 0x00, 0x00, 0x00, // averageRTT = 18
+    ];
+
     #[test]
     fn decode_rtt_request() {
         let pdu = ironrdp_core::decode::<AutoDetectRequest>(RTT_REQUEST_WIRE).unwrap();
@@ -1099,6 +1122,34 @@ mod tests {
     }
 
     #[test]
+    fn decode_netchar_rtt() {
+        let pdu = ironrdp_core::decode::<AutoDetectRequest>(NETCHAR_RTT_WIRE).unwrap();
+        match pdu {
+            AutoDetectRequest::NetworkCharacteristicsResult {
+                sequence_number,
+                request_type,
+                base_rtt_ms,
+                bandwidth_kbps,
+                average_rtt_ms,
+            } => {
+                assert_eq!(sequence_number, 7);
+                assert_eq!(request_type, NETCHAR_RESULT_RTT);
+                assert_eq!(base_rtt_ms, Some(8));
+                assert_eq!(bandwidth_kbps, None);
+                assert_eq!(average_rtt_ms, 18);
+            }
+            other => panic!("expected NetworkCharacteristicsResult, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn encode_netchar_rtt() {
+        let pdu = AutoDetectRequest::netchar_result_rtt(7, 8, 18);
+        let encoded = ironrdp_core::encode_vec(&pdu).unwrap();
+        assert_eq!(encoded.as_slice(), NETCHAR_RTT_WIRE);
+    }
+
+    #[test]
     fn request_round_trip() {
         let cases = vec![
             AutoDetectRequest::rtt_connect_time(100),
@@ -1109,6 +1160,7 @@ mod tests {
             AutoDetectRequest::bw_stop_connect_time(600, vec![0xFF; 10]),
             AutoDetectRequest::bw_stop_continuous(700),
             AutoDetectRequest::netchar_result(800, 5, 50000, 15),
+            AutoDetectRequest::netchar_result_rtt(900, 5, 15),
         ];
 
         for original in cases {

--- a/crates/ironrdp-server/src/autodetect.rs
+++ b/crates/ironrdp-server/src/autodetect.rs
@@ -48,14 +48,33 @@ impl AutoDetectManager {
 
     /// Generate an RTT Measure Request PDU for continuous detection.
     ///
-    /// The caller must encode and send the returned [`AutoDetectRequest`] as
-    /// a Share Data PDU on the IO channel. `now_ms` is recorded as the send time and
-    /// is what [`handle_response()`](Self::handle_response) measures against.
+    /// The caller must encode and send the returned [`AutoDetectRequest`] on
+    /// the MCS message channel, framed by a `SEC_AUTODETECT_REQ` security
+    /// header ([MS-RDPBCGR] 2.2.14.3). `now_ms` is recorded as the send time
+    /// and is what [`handle_response()`](Self::handle_response) measures against.
     pub fn send_rtt_request(&mut self, now_ms: u64) -> AutoDetectRequest {
         let seq = self.next_sequence;
         self.next_sequence = seq.wrapping_add(1);
         self.pending_probes.push((seq, now_ms));
         AutoDetectRequest::rtt_continuous(seq)
+    }
+
+    /// Build a Network Characteristics Result reporting the measured RTT.
+    ///
+    /// Returns `None` until at least one RTT sample has been recorded. The
+    /// result carries baseRTT (lowest observed) and averageRTT over the current
+    /// window; bandwidth is omitted. Like [`send_rtt_request()`](Self::send_rtt_request),
+    /// the caller sends the returned PDU on the MCS message channel. The client
+    /// does not reply to it.
+    pub fn build_netchar_result(&mut self) -> Option<AutoDetectRequest> {
+        let snapshot = self.snapshot()?;
+        let seq = self.next_sequence;
+        self.next_sequence = seq.wrapping_add(1);
+        Some(AutoDetectRequest::netchar_result_rtt(
+            seq,
+            snapshot.min_ms,
+            snapshot.avg_ms,
+        ))
     }
 
     /// Process an RTT Measure Response from the client.
@@ -250,6 +269,38 @@ mod tests {
             sequence_number: req.sequence_number(),
         };
         assert_eq!(mgr.handle_response(&response, u64::from(u32::MAX) + 1), Some(u32::MAX));
+    }
+
+    #[test]
+    fn netchar_result_none_without_samples() {
+        let mut mgr = AutoDetectManager::new();
+        assert!(mgr.build_netchar_result().is_none());
+    }
+
+    #[test]
+    fn netchar_result_reports_measured_rtt() {
+        let mut mgr = AutoDetectManager::new();
+
+        let req = mgr.send_rtt_request(0);
+        let response = AutoDetectResponse::RttResponse {
+            sequence_number: req.sequence_number(),
+        };
+        let _ = mgr.handle_response(&response, 20);
+
+        let snap = mgr.snapshot().expect("one sample recorded");
+        match mgr.build_netchar_result().expect("result once samples exist") {
+            AutoDetectRequest::NetworkCharacteristicsResult {
+                base_rtt_ms,
+                bandwidth_kbps,
+                average_rtt_ms,
+                ..
+            } => {
+                assert_eq!(base_rtt_ms, Some(snap.min_ms));
+                assert_eq!(average_rtt_ms, snap.avg_ms);
+                assert_eq!(bandwidth_kbps, None, "RTT-only variant omits bandwidth");
+            }
+            other => panic!("expected NetworkCharacteristicsResult, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/ironrdp-server/src/autodetect.rs
+++ b/crates/ironrdp-server/src/autodetect.rs
@@ -16,6 +16,16 @@ const RTT_WINDOW_SIZE: usize = 8;
 /// Probes older than this are discarded as unresponsive.
 pub(crate) const RTT_PROBE_MAX_AGE_MS: u64 = 30_000;
 
+/// Run a bandwidth measurement once every this many RTT ticks. Bandwidth
+/// changes far more slowly than RTT and each measurement sends a payload, so it
+/// is sampled less often than the per-tick RTT probe.
+const BW_MEASURE_INTERVAL_TICKS: u32 = 8;
+
+/// Size of the synthetic Bandwidth Measure Payload, in bytes. Large enough that
+/// the client's measured time delta is meaningful on a real link, small enough
+/// not to be a noticeable periodic cost.
+const BW_PAYLOAD_LEN: usize = 8192;
+
 /// Server-side auto-detect state machine.
 ///
 /// Tracks outstanding RTT probes and computes round-trip statistics from
@@ -35,6 +45,13 @@ pub struct AutoDetectManager {
     /// Outstanding probes as `(sequence_number, sent_at_ms)`.
     pending_probes: Vec<(u16, u64)>,
     rtt_samples: VecDeque<u32>,
+    /// Sequence number of an in-flight bandwidth measurement, if any. A new
+    /// measurement is not started while one is outstanding.
+    pending_bw: Option<u16>,
+    /// Most recently measured bandwidth in kilobits per second.
+    bandwidth_kbps: Option<u32>,
+    /// Counts RTT ticks to pace bandwidth measurements (see [`BW_MEASURE_INTERVAL_TICKS`]).
+    bw_tick_count: u32,
 }
 
 impl AutoDetectManager {
@@ -43,6 +60,9 @@ impl AutoDetectManager {
             next_sequence: 0,
             pending_probes: Vec::new(),
             rtt_samples: VecDeque::with_capacity(RTT_WINDOW_SIZE),
+            pending_bw: None,
+            bandwidth_kbps: None,
+            bw_tick_count: 0,
         }
     }
 
@@ -59,48 +79,86 @@ impl AutoDetectManager {
         AutoDetectRequest::rtt_continuous(seq)
     }
 
-    /// Build a Network Characteristics Result reporting the measured RTT.
+    /// Build a Bandwidth Measure transaction (Start → Payload → Stop) when one
+    /// is due, or `None` otherwise.
+    ///
+    /// Paced to one measurement per [`BW_MEASURE_INTERVAL_TICKS`] calls and
+    /// suppressed while a prior measurement is still outstanding. The three PDUs
+    /// must be sent back-to-back on the MCS message channel; the client counts
+    /// the bytes received between Start and Stop and replies with a Bandwidth
+    /// Measure Results PDU, processed by [`handle_response()`](Self::handle_response).
+    pub fn build_bandwidth_measure(&mut self) -> Option<[AutoDetectRequest; 3]> {
+        self.bw_tick_count = self.bw_tick_count.wrapping_add(1);
+        if self.pending_bw.is_some() || !self.bw_tick_count.is_multiple_of(BW_MEASURE_INTERVAL_TICKS) {
+            return None;
+        }
+        let seq = self.next_sequence;
+        self.next_sequence = seq.wrapping_add(1);
+        self.pending_bw = Some(seq);
+        Some([
+            AutoDetectRequest::bw_start_continuous(seq),
+            AutoDetectRequest::bw_payload(seq, vec![0u8; BW_PAYLOAD_LEN]),
+            AutoDetectRequest::bw_stop_continuous(seq),
+        ])
+    }
+
+    /// Build a Network Characteristics Result reporting the measured network.
     ///
     /// Returns `None` until at least one RTT sample has been recorded. The
     /// result carries baseRTT (lowest observed) and averageRTT over the current
-    /// window; bandwidth is omitted. Like [`send_rtt_request()`](Self::send_rtt_request),
-    /// the caller sends the returned PDU on the MCS message channel. The client
-    /// does not reply to it.
+    /// window; once a bandwidth measurement has completed it also carries the
+    /// measured bandwidth (the all-fields form). Like
+    /// [`send_rtt_request()`](Self::send_rtt_request), the caller sends the
+    /// returned PDU on the MCS message channel. The client does not reply to it.
     pub fn build_netchar_result(&mut self) -> Option<AutoDetectRequest> {
         let snapshot = self.snapshot()?;
         let seq = self.next_sequence;
         self.next_sequence = seq.wrapping_add(1);
-        Some(AutoDetectRequest::netchar_result_rtt(
-            seq,
-            snapshot.min_ms,
-            snapshot.avg_ms,
-        ))
+        Some(match self.bandwidth_kbps {
+            Some(bandwidth_kbps) => {
+                AutoDetectRequest::netchar_result(seq, snapshot.min_ms, bandwidth_kbps, snapshot.avg_ms)
+            }
+            None => AutoDetectRequest::netchar_result_rtt(seq, snapshot.min_ms, snapshot.avg_ms),
+        })
     }
 
-    /// Process an RTT Measure Response from the client.
+    /// Process an Auto-Detect Response from the client.
     ///
-    /// Returns the measured RTT in milliseconds if the sequence number
-    /// matches an outstanding probe, or `None` if it was unexpected.
+    /// For an RTT Measure Response, records the sample and returns the measured
+    /// RTT in milliseconds. For a Bandwidth Measure Results, records the
+    /// computed bandwidth internally and returns `None`. Returns `None` for an
+    /// unexpected or unmatched response.
+    ///
     /// `now_ms` is the receipt time on the same clock passed to
     /// [`send_rtt_request()`](Self::send_rtt_request).
     pub fn handle_response(&mut self, response: &AutoDetectResponse, now_ms: u64) -> Option<u32> {
-        let AutoDetectResponse::RttResponse { sequence_number } = response else {
-            return None;
-        };
+        match response {
+            AutoDetectResponse::RttResponse { sequence_number } => {
+                let idx = self.pending_probes.iter().position(|(s, _)| *s == *sequence_number)?;
+                let (_, sent_at_ms) = self.pending_probes.remove(idx);
 
-        let idx = self.pending_probes.iter().position(|(s, _)| *s == *sequence_number)?;
-        let (_, sent_at_ms) = self.pending_probes.remove(idx);
+                // Saturating rather than wrapping: a caller whose clock went backwards gets
+                // a zero sample, not a nonsense one near u32::MAX.
+                let rtt_ms = u32::try_from(now_ms.saturating_sub(sent_at_ms)).unwrap_or(u32::MAX);
 
-        // Saturating rather than wrapping: a caller whose clock went backwards gets a
-        // zero sample, not a nonsense one near u32::MAX.
-        let rtt_ms = u32::try_from(now_ms.saturating_sub(sent_at_ms)).unwrap_or(u32::MAX);
+                if self.rtt_samples.len() >= RTT_WINDOW_SIZE {
+                    self.rtt_samples.pop_front();
+                }
+                self.rtt_samples.push_back(rtt_ms);
 
-        if self.rtt_samples.len() >= RTT_WINDOW_SIZE {
-            self.rtt_samples.pop_front();
+                Some(rtt_ms)
+            }
+            AutoDetectResponse::BandwidthMeasureResults { sequence_number, .. } => {
+                if self.pending_bw == Some(*sequence_number) {
+                    self.pending_bw = None;
+                    if let Some(kbps) = response.computed_bandwidth_kbps() {
+                        self.bandwidth_kbps = Some(kbps);
+                    }
+                }
+                None
+            }
+            _ => None,
         }
-        self.rtt_samples.push_back(rtt_ms);
-
-        Some(rtt_ms)
     }
 
     /// Get current RTT statistics, or `None` if no measurements yet.
@@ -298,6 +356,64 @@ mod tests {
                 assert_eq!(base_rtt_ms, Some(snap.min_ms));
                 assert_eq!(average_rtt_ms, snap.avg_ms);
                 assert_eq!(bandwidth_kbps, None, "RTT-only variant omits bandwidth");
+            }
+            other => panic!("expected NetworkCharacteristicsResult, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bandwidth_measure_paced_and_transacts() {
+        let mut mgr = AutoDetectManager::new();
+        // Not due until the interval elapses.
+        for _ in 0..BW_MEASURE_INTERVAL_TICKS - 1 {
+            assert!(mgr.build_bandwidth_measure().is_none());
+        }
+        let pdus = mgr.build_bandwidth_measure().expect("due on the interval tick");
+        // Start, Payload and Stop share one transaction sequence number.
+        assert_eq!(pdus[0].sequence_number(), pdus[1].sequence_number());
+        assert_eq!(pdus[1].sequence_number(), pdus[2].sequence_number());
+        // No overlapping measurement while one is outstanding.
+        for _ in 0..BW_MEASURE_INTERVAL_TICKS {
+            assert!(
+                mgr.build_bandwidth_measure().is_none(),
+                "no overlap while a measurement is pending"
+            );
+        }
+    }
+
+    #[test]
+    fn bandwidth_result_upgrades_netchar_to_all_fields() {
+        let mut mgr = AutoDetectManager::new();
+        let req = mgr.send_rtt_request(0);
+        let _ = mgr.handle_response(
+            &AutoDetectResponse::RttResponse {
+                sequence_number: req.sequence_number(),
+            },
+            20,
+        );
+
+        // Drive a bandwidth measurement to completion.
+        let bw_seq = loop {
+            if let Some(pdus) = mgr.build_bandwidth_measure() {
+                break pdus[0].sequence_number();
+            }
+        };
+        let results = AutoDetectResponse::BandwidthMeasureResults {
+            sequence_number: bw_seq,
+            response_type: ironrdp_pdu::rdp::autodetect::BW_RESULTS_CONTINUOUS,
+            time_delta_ms: 10,
+            byte_count: 100_000,
+        };
+        assert!(mgr.handle_response(&results, 20).is_none());
+
+        match mgr.build_netchar_result().expect("result once samples exist") {
+            AutoDetectRequest::NetworkCharacteristicsResult {
+                base_rtt_ms,
+                bandwidth_kbps,
+                ..
+            } => {
+                assert_eq!(bandwidth_kbps, Some(80_000), "byte_count * 8 / time_delta_ms");
+                assert!(base_rtt_ms.is_some());
             }
             other => panic!("expected NetworkCharacteristicsResult, got {other:?}"),
         }

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -1468,6 +1468,15 @@ impl RdpServer {
                         let request = ad.send_rtt_request(now_ms);
                         let data = encode_autodetect_request(request, message_channel_id, user_channel_id)?;
                         writer.write_all(&data).await?;
+
+                        // Report the measured characteristics back to the client so it
+                        // can size its receive buffers ([MS-RDPBCGR] 2.2.14.1.5). Skipped
+                        // until RTT samples exist; the client does not reply. The emission
+                        // cadence follows the caller's request cadence.
+                        if let Some(result) = ad.build_netchar_result() {
+                            let data = encode_autodetect_request(result, message_channel_id, user_channel_id)?;
+                            writer.write_all(&data).await?;
+                        }
                     }
                 }
             }

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -1477,6 +1477,17 @@ impl RdpServer {
                             let data = encode_autodetect_request(result, message_channel_id, user_channel_id)?;
                             writer.write_all(&data).await?;
                         }
+
+                        // Periodically measure bandwidth: Start → Payload → Stop sent
+                        // back-to-back so the client counts only the payload window, then
+                        // replies with a Bandwidth Measure Results PDU. The measured value
+                        // upgrades the next characteristics result to the all-fields form.
+                        if let Some(bw_pdus) = ad.build_bandwidth_measure() {
+                            for pdu in bw_pdus {
+                                let data = encode_autodetect_request(pdu, message_channel_id, user_channel_id)?;
+                                writer.write_all(&data).await?;
+                            }
+                        }
                     }
                 }
             }

--- a/crates/ironrdp-testsuite-core/tests/server/autodetect.rs
+++ b/crates/ironrdp-testsuite-core/tests/server/autodetect.rs
@@ -1,4 +1,4 @@
-use ironrdp_pdu::rdp::autodetect::AutoDetectResponse;
+use ironrdp_pdu::rdp::autodetect::{AutoDetectRequest, AutoDetectResponse};
 use ironrdp_server::autodetect::AutoDetectManager;
 
 #[test]
@@ -58,6 +58,43 @@ fn snapshot_reflects_measurements() {
     assert_eq!(snap.min_ms, 10);
     assert_eq!(snap.max_ms, 30);
     assert_eq!(snap.avg_ms, 20);
+}
+
+#[test]
+fn netchar_result_none_without_measurements() {
+    let mut mgr = AutoDetectManager::new();
+    assert!(
+        mgr.build_netchar_result().is_none(),
+        "no result should be produced before any RTT sample"
+    );
+}
+
+#[test]
+fn netchar_result_reports_measured_rtt() {
+    let mut mgr = AutoDetectManager::new();
+
+    for _ in 0..3 {
+        let req = mgr.send_rtt_request(0);
+        let response = AutoDetectResponse::RttResponse {
+            sequence_number: req.sequence_number(),
+        };
+        let _ = mgr.handle_response(&response, 20);
+    }
+
+    let snap = mgr.snapshot().expect("should have data");
+    match mgr.build_netchar_result().expect("result once samples exist") {
+        AutoDetectRequest::NetworkCharacteristicsResult {
+            base_rtt_ms,
+            bandwidth_kbps,
+            average_rtt_ms,
+            ..
+        } => {
+            assert_eq!(base_rtt_ms, Some(snap.min_ms), "baseRTT is the lowest observed RTT");
+            assert_eq!(average_rtt_ms, snap.avg_ms, "averageRTT matches the window average");
+            assert_eq!(bandwidth_kbps, None, "RTT-only variant omits bandwidth");
+        }
+        other => panic!("expected NetworkCharacteristicsResult, got {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/ironrdp-testsuite-core/tests/server/autodetect.rs
+++ b/crates/ironrdp-testsuite-core/tests/server/autodetect.rs
@@ -98,6 +98,44 @@ fn netchar_result_reports_measured_rtt() {
 }
 
 #[test]
+fn bandwidth_measure_transacts_and_upgrades_netchar() {
+    let mut mgr = AutoDetectManager::new();
+    let req = mgr.send_rtt_request(0);
+    let _ = mgr.handle_response(
+        &AutoDetectResponse::RttResponse {
+            sequence_number: req.sequence_number(),
+        },
+        20,
+    );
+
+    // Drive a bandwidth measurement to completion (paced internally).
+    let pdus = loop {
+        if let Some(p) = mgr.build_bandwidth_measure() {
+            break p;
+        }
+    };
+    assert_eq!(
+        pdus[0].sequence_number(),
+        pdus[2].sequence_number(),
+        "Start and Stop share the transaction sequence"
+    );
+    let results = AutoDetectResponse::BandwidthMeasureResults {
+        sequence_number: pdus[0].sequence_number(),
+        response_type: ironrdp_pdu::rdp::autodetect::BW_RESULTS_CONTINUOUS,
+        time_delta_ms: 10,
+        byte_count: 100_000,
+    };
+    assert!(mgr.handle_response(&results, 20).is_none());
+
+    match mgr.build_netchar_result().expect("result once samples exist") {
+        AutoDetectRequest::NetworkCharacteristicsResult { bandwidth_kbps, .. } => {
+            assert_eq!(bandwidth_kbps, Some(80_000), "byte_count * 8 / time_delta_ms");
+        }
+        other => panic!("expected NetworkCharacteristicsResult, got {other:?}"),
+    }
+}
+
+#[test]
 fn sequence_number_wraps_at_u16_max() {
     let mut mgr = AutoDetectManager::new();
     // Advance sequence counter through all values, resolving each probe immediately


### PR DESCRIPTION
Stacked on #1470, which is itself stacked on #1487, so the merge order is #1487, then #1470, then this. This branch carries both ancestors' commits, so it builds and tests green on its own. The breaking signature changes visible against master come from #1487; baselined against it, this PR reports no semver update required.

Extends the server-side auto-detect added by #1470. The RTT-only Network Characteristics Result becomes the full baseRTT plus bandwidth plus averageRTT report by adding a continuous Bandwidth Measure over the MCS message channel.

Change: once per N auto-detect ticks, AutoDetectManager emits a Bandwidth Measure transaction (Start, Payload, Stop; continuous request type 0x0014 / 0x0429) back to back on the message channel. The client counts the payload window and replies with a Bandwidth Measure Results PDU (timeDelta plus byteCount); the manager turns that into a kbps figure and upgrades the next Network Characteristics Result from the RTT-only form to the all-fields form (NETCHAR_RESULT_ALL). A new measurement is never started while one is outstanding. It reuses the message-channel framing from #1348 and adds no new PDU types.

Testing: unit and integration tests cover pacing, the Start/Payload/Stop transaction sharing one sequence number, bandwidth-results handling, and the RTT-only to all-fields upgrade. `cargo xtask check fmt/lints/tests/typos/locks` all pass.

## Rebased

Rebased onto `master` on 2026-08-02 as one `--update-refs` operation with the rest of the stack, so the checks run against the current tree rather than the state before that day's merges. No conflicts, no content change. All five gates green on this head independently, not only at the stack tip.
