### PR TITLE
fix(pdu): tolerate an empty Server Font Map body

### DIFF
--- a/crates/ironrdp-pdu/src/rdp/finalization_messages.rs
+++ b/crates/ironrdp-pdu/src/rdp/finalization_messages.rs
@@ -164,6 +164,15 @@ impl Encode for FontPdu {
 
 impl<'de> Decode<'de> for FontPdu {
     fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        // Some servers (e.g. VirtualBox VRDP) send the Server Font Map PDU with
+        // an empty body. Its fields are unused by the client — the Font Map only
+        // signals the end of the connection finalization sequence (MS-RDPBCGR
+        // 1.3.1.1) — so an empty body decodes to the recommended defaults rather
+        // than failing the whole connection, matching mstsc/FreeRDP leniency.
+        if src.is_empty() {
+            return Ok(Self::default());
+        }
+
         ensure_fixed_part_size!(in: src);
 
         let number = src.read_u16();
@@ -262,5 +271,32 @@ bitflags! {
     pub struct SequenceFlags: u16 {
         const FIRST = 1;
         const LAST = 2;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ironrdp_core::decode;
+
+    use super::*;
+
+    #[test]
+    fn font_pdu_decodes_full_body() {
+        // number=1, total_number=1, flags=FIRST|LAST, entry_size=4
+        let bytes = [0x01, 0x00, 0x01, 0x00, 0x03, 0x00, 0x04, 0x00];
+        let pdu: FontPdu = decode(&bytes).unwrap();
+        assert_eq!(pdu.number, 1);
+        assert_eq!(pdu.total_number, 1);
+        assert_eq!(pdu.flags, SequenceFlags::FIRST | SequenceFlags::LAST);
+        assert_eq!(pdu.entry_size, 4);
+    }
+
+    #[test]
+    fn font_pdu_decodes_empty_body_to_defaults() {
+        // Some servers (e.g. VirtualBox VRDP) send the Server Font Map with an
+        // empty body. It must decode to the recommended defaults rather than
+        // failing with NotEnoughBytes.
+        let pdu: FontPdu = decode(&[]).unwrap();
+        assert_eq!(pdu, FontPdu::default());
     }
 }


### PR DESCRIPTION
## Problem

`FontPdu::decode` requires the full 8-byte fixed part (`number`, `total_number`, `flags`, `entry_size`). Some RDP servers — notably VirtualBox's built-in VRDP server — end the connection finalization sequence with a Server Font Map PDU that carries an **empty** body. Against those servers `decode` fails with `NotEnoughBytes`, and because the Font Map is the final step of finalization (MS-RDPBCGR 1.3.1.1), the whole connection is aborted immediately after a successful logon.

The failure surfaces downstream as a connect that authenticates and then dies at finalization.

## Fix

The Server Font Map's fields are unused by the client — it only signals that finalization is complete and the server may begin sending graphics. So an empty body now decodes to the spec-recommended defaults (the existing `FontPdu::default()`: `number 0`, `total_number 0`, `flags FIRST|LAST`, `entry_size 4`) instead of erroring. A present-but-truncated body still errors via `ensure_fixed_part_size!`, so this only relaxes the fully-empty case.

This matches `mstsc` and FreeRDP, both of which accept a short/empty Font Map.

## Scope note

`FontPdu` is shared by `FontList` (client→server, encode-only) and `FontMap` (server→client, decode-only), so this decode-side leniency only affects the received Font Map in practice. If you'd rather scope it strictly to the `ShareDataPduType::FontMap` arm in `rdp/headers.rs` and keep `FontPdu::decode` itself strict, I'm happy to move it there — just let me know your preference.

## Tests

Adds unit tests for both decode paths (full 8-byte body → parsed fields; empty body → defaults). `cargo test -p ironrdp-pdu` is green (374 passing); `cargo clippy -p ironrdp-pdu --all-targets` clean.

## Context

Sibling to #1237 — both are small connector/pdu changes that let a downstream (an Android RDP client) drop a vendored `ironrdp-connector` fork it currently carries solely to work around VirtualBox VRDP quirks. This one removes the Font Map workaround; #1237 removes the EGFX early-capability workaround.
