### PR TITLE
fix(session): preserve bulk compression across reactivation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2983,6 +2983,7 @@ dependencies = [
  "ironrdp",
  "ironrdp-agent",
  "ironrdp-async",
+ "ironrdp-bulk",
  "ironrdp-client",
  "ironrdp-core 0.2.1",
  "ironrdp-dvc",

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -19,7 +19,7 @@ use ironrdp_pdu::input::mouse::PointerFlags;
 #[cfg(any(feature = "dvc-pipe-proxy", all(windows, feature = "dvc-com-plugin")))]
 use ironrdp_pdu::pdu_other_err;
 use ironrdp_session::image::DecodedImage;
-use ironrdp_session::{ActiveStageBuilder, ActiveStageOutput, GracefulDisconnectReason, SessionResult, fast_path};
+use ironrdp_session::{ActiveStageBuilder, ActiveStageOutput, GracefulDisconnectReason, SessionResult};
 use ironrdp_svc::SvcMessage;
 use ironrdp_tokio::reqwest::ReqwestNetworkClient;
 use ironrdp_tokio::{FramedWrite, single_sequence_step_read, split_tokio_framed};
@@ -978,19 +978,13 @@ async fn active_session(
                         {
                             debug!(?desktop_size, "Deactivation-Reactivation Sequence completed");
                             image = DecodedImage::new(PixelFormat::RgbA32, desktop_size.width, desktop_size.height);
-                            active_stage.set_fastpath_processor(
-                                fast_path::ProcessorBuilder {
-                                    io_channel_id: connection_activation.io_channel_id(),
-                                    user_channel_id: connection_activation.user_channel_id(),
-                                    share_id,
-                                    enable_server_pointer,
-                                    pointer_software_rendering,
-                                    bulk_decompressor: None,
-                                }
-                                .build(),
+                            active_stage.reactivate(
+                                connection_activation.io_channel_id(),
+                                connection_activation.user_channel_id(),
+                                share_id,
+                                enable_server_pointer,
+                                pointer_software_rendering,
                             );
-                            active_stage.set_share_id(share_id);
-                            active_stage.set_enable_server_pointer(enable_server_pointer);
                             break 'activation_seq;
                         }
                     }

--- a/crates/ironrdp-session/src/active_stage.rs
+++ b/crates/ironrdp-session/src/active_stage.rs
@@ -14,7 +14,7 @@ use ironrdp_pdu::rdp::multitransport::MultitransportRequestPdu;
 use ironrdp_pdu::slow_path::{self, GraphicsUpdateType};
 use ironrdp_pdu::{Action, mcs};
 use ironrdp_svc::{StaticChannelSet, SvcMessage, SvcProcessor, SvcProcessorMessages};
-use tracing::{debug, info, warn};
+use tracing::{debug, error, warn};
 
 use crate::fast_path::UpdateKind;
 use crate::image::DecodedImage;
@@ -34,6 +34,26 @@ pub struct ActiveStage {
     x224_processor: x224::Processor,
     fast_path_processor: fast_path::Processor,
     enable_server_pointer: bool,
+    /// The bulk compression type negotiated for the connection, retained so the FastPath
+    /// decompressor can be recreated when the fast-path processor is rebuilt (reactivation).
+    compression_type: Option<PduCompressionType>,
+}
+
+/// Creates the FastPath bulk decompressor for a negotiated compression type, if any.
+fn make_bulk_decompressor(compression_type: Option<PduCompressionType>) -> Option<BulkCompressor> {
+    compression_type.and_then(|ct| {
+        let bulk_ct = to_bulk_compression_type(ct);
+        match BulkCompressor::new(bulk_ct) {
+            Ok(compressor) => {
+                debug!(compression_type = %bulk_ct, "Bulk decompressor initialized for FastPath");
+                Some(compressor)
+            }
+            Err(e) => {
+                error!(error = %e, "Failed to create bulk decompressor, compression disabled");
+                None
+            }
+        }
+    })
 }
 
 /// Builder for [`ActiveStage`].
@@ -75,28 +95,13 @@ impl ActiveStageBuilder {
             share_id,
         );
 
-        // Create bulk decompressor if compression was negotiated
-        let bulk_decompressor = compression_type.and_then(|ct| {
-            let bulk_ct = to_bulk_compression_type(ct);
-            match BulkCompressor::new(bulk_ct) {
-                Ok(compressor) => {
-                    info!(compression_type = %bulk_ct, "Bulk decompressor initialized for FastPath");
-                    Some(compressor)
-                }
-                Err(e) => {
-                    tracing::error!(error = %e, "Failed to create bulk decompressor, compression disabled");
-                    None
-                }
-            }
-        });
-
         let fast_path_processor = fast_path::ProcessorBuilder {
             io_channel_id,
             user_channel_id,
             share_id,
             enable_server_pointer,
             pointer_software_rendering,
-            bulk_decompressor,
+            bulk_decompressor: make_bulk_decompressor(compression_type),
         }
         .build();
 
@@ -104,6 +109,7 @@ impl ActiveStageBuilder {
             x224_processor,
             fast_path_processor,
             enable_server_pointer,
+            compression_type,
         }
     }
 }
@@ -236,6 +242,34 @@ impl ActiveStage {
     }
 
     pub fn set_enable_server_pointer(&mut self, enable_server_pointer: bool) {
+        self.enable_server_pointer = enable_server_pointer;
+    }
+
+    /// Rebuilds the fast-path processor for a Deactivation-Reactivation Sequence.
+    ///
+    /// The negotiated bulk compression is preserved by recreating the decompressor from the
+    /// retained compression type — the fast-path processor is stateless across reactivation except
+    /// for that, so rebuilding it without the decompressor (as a naive rebuild would) silently
+    /// breaks decoding of every subsequent compressed update.
+    pub fn reactivate(
+        &mut self,
+        io_channel_id: u16,
+        user_channel_id: u16,
+        share_id: u32,
+        enable_server_pointer: bool,
+        pointer_software_rendering: bool,
+    ) {
+        self.fast_path_processor = fast_path::ProcessorBuilder {
+            io_channel_id,
+            user_channel_id,
+            share_id,
+            enable_server_pointer,
+            pointer_software_rendering,
+            bulk_decompressor: make_bulk_decompressor(self.compression_type),
+        }
+        .build();
+        // The x224 processor encodes ShareDataPdu with the server's (possibly new) share_id.
+        self.x224_processor.set_share_id(share_id);
         self.enable_server_pointer = enable_server_pointer;
     }
 

--- a/crates/ironrdp-session/src/active_stage.rs
+++ b/crates/ironrdp-session/src/active_stage.rs
@@ -30,16 +30,7 @@ fn to_bulk_compression_type(ct: PduCompressionType) -> ironrdp_bulk::Compression
     }
 }
 
-pub struct ActiveStage {
-    x224_processor: x224::Processor,
-    fast_path_processor: fast_path::Processor,
-    enable_server_pointer: bool,
-    /// The bulk compression type negotiated for the connection, retained so the FastPath
-    /// decompressor can be recreated when the fast-path processor is rebuilt (reactivation).
-    compression_type: Option<PduCompressionType>,
-}
-
-/// Creates the FastPath bulk decompressor for a negotiated compression type, if any.
+/// Creates the fast-path bulk decompressor for a negotiated compression type, if any.
 fn make_bulk_decompressor(compression_type: Option<PduCompressionType>) -> Option<BulkCompressor> {
     compression_type.and_then(|ct| {
         let bulk_ct = to_bulk_compression_type(ct);
@@ -54,6 +45,15 @@ fn make_bulk_decompressor(compression_type: Option<PduCompressionType>) -> Optio
             }
         }
     })
+}
+
+pub struct ActiveStage {
+    x224_processor: x224::Processor,
+    fast_path_processor: fast_path::Processor,
+    enable_server_pointer: bool,
+    /// The bulk compression type negotiated for the connection, retained so the fast-path
+    /// decompressor can be recreated when the fast-path processor is rebuilt (reactivation).
+    compression_type: Option<PduCompressionType>,
 }
 
 /// Builder for [`ActiveStage`].
@@ -231,12 +231,19 @@ impl ActiveStage {
         Ok(stage_outputs)
     }
 
+    /// Replaces the fast-path processor wholesale.
+    ///
+    /// Prefer [`ActiveStage::reactivate`] for a Deactivation-Reactivation Sequence: a processor
+    /// built here carries whatever decompressor the caller supplied, so passing none silently
+    /// disables bulk decompression for the rest of the session.
     pub fn set_fastpath_processor(&mut self, processor: fast_path::Processor) {
         self.fast_path_processor = processor;
     }
 
     /// Updates the share_id used by the x224 processor for encoding ShareDataPdu.
-    /// Must be called during Deactivation-Reactivation if the server assigns a new share_id.
+    ///
+    /// [`ActiveStage::reactivate`] already does this, so a Deactivation-Reactivation Sequence does
+    /// not need to call it.
     pub fn set_share_id(&mut self, share_id: u32) {
         self.x224_processor.set_share_id(share_id);
     }
@@ -245,12 +252,14 @@ impl ActiveStage {
         self.enable_server_pointer = enable_server_pointer;
     }
 
-    /// Rebuilds the fast-path processor for a Deactivation-Reactivation Sequence.
+    /// Rebuilds the fast-path processor for a [Deactivation-Reactivation Sequence].
     ///
     /// The negotiated bulk compression is preserved by recreating the decompressor from the
     /// retained compression type — the fast-path processor is stateless across reactivation except
     /// for that, so rebuilding it without the decompressor (as a naive rebuild would) silently
     /// breaks decoding of every subsequent compressed update.
+    ///
+    /// [Deactivation-Reactivation Sequence]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/dfc234ce-481a-4674-9a5d-2a7bafb14432
     pub fn reactivate(
         &mut self,
         io_channel_id: u16,

--- a/crates/ironrdp-testsuite-extra/Cargo.toml
+++ b/crates/ironrdp-testsuite-extra/Cargo.toml
@@ -24,9 +24,10 @@ harness = true
 [dev-dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-ironrdp = { path = "../ironrdp", features = ["server", "pdu", "connector", "session", "dvc", "echo"] }
+ironrdp = { path = "../ironrdp", features = ["server", "pdu", "connector", "session", "svc", "dvc", "echo"] }
 ironrdp-async.path = "../ironrdp-async"
 ironrdp-agent = { path = "../ironrdp-agent", features = ["internal"] }
+ironrdp-bulk.path = "../ironrdp-bulk"
 ironrdp-client.path = "../ironrdp-client"
 ironrdp-core.path = "../ironrdp-core"
 ironrdp-dvc.path = "../ironrdp-dvc"

--- a/crates/ironrdp-testsuite-extra/tests/e2e.rs
+++ b/crates/ironrdp-testsuite-extra/tests/e2e.rs
@@ -7,9 +7,15 @@ use std::time::Instant;
 
 use anyhow::Result;
 use ironrdp::connector;
+use ironrdp::core::Encode as _;
 use ironrdp::dvc::DrdynvcClient;
 use ironrdp::echo::client::EchoClient;
+use ironrdp::pdu::bitmap::{BitmapData, BitmapUpdateData, Compression};
+use ironrdp::pdu::fast_path::{EncryptionFlags, FastPathHeader, FastPathUpdatePdu, Fragmentation, UpdateCode};
+use ironrdp::pdu::geometry::InclusiveRectangle;
 use ironrdp::pdu::rdp::capability_sets::MajorPlatformType;
+use ironrdp::pdu::rdp::client_info::CompressionType as PduCompressionType;
+use ironrdp::pdu::rdp::headers::CompressionFlags;
 use ironrdp::pdu::{self, gcc};
 use ironrdp::server::{
     self, DesktopSize, DisplayUpdate, KeyboardEvent, MouseEvent, PixelFormat, RdpServer, RdpServerDisplay,
@@ -17,7 +23,9 @@ use ironrdp::server::{
 };
 use ironrdp::session::image::DecodedImage;
 use ironrdp::session::{self, ActiveStage, ActiveStageBuilder, ActiveStageOutput};
+use ironrdp::svc::StaticChannelSet;
 use ironrdp_async::{Framed, FramedWrite as _};
+use ironrdp_bulk::{BulkCompressor, CompressionType as BulkCompressionType, flags as bulk_flags};
 use ironrdp_testsuite_extra as _;
 use ironrdp_tls::TlsStream;
 use ironrdp_tokio::TokioStream;
@@ -118,6 +126,73 @@ async fn test_deactivation_reactivation() {
         },
     )
     .await
+}
+
+#[test]
+fn test_reactivation_processes_compressed_fastpath_updates() {
+    let mut stage = ActiveStageBuilder {
+        static_channels: StaticChannelSet::new(),
+        user_channel_id: 1001,
+        io_channel_id: 1003,
+        message_channel_id: None,
+        share_id: 1,
+        compression_type: Some(PduCompressionType::K64),
+        enable_server_pointer: false,
+        pointer_software_rendering: false,
+    }
+    .build();
+    stage.reactivate(1003, 1001, 2, false, false);
+
+    let mut image = DecodedImage::new(PixelFormat::RgbA32, 4, 4);
+    let outputs = stage
+        .process(&mut image, pdu::Action::FastPath, &compressed_bitmap_fastpath_frame())
+        .expect("compressed FastPath update after reactivation");
+
+    assert!(
+        outputs
+            .iter()
+            .any(|output| matches!(output, ActiveStageOutput::GraphicsUpdate(_)))
+    );
+}
+
+fn compressed_bitmap_fastpath_frame() -> Vec<u8> {
+    let bitmap = BitmapUpdateData {
+        rectangles: vec![BitmapData {
+            rectangle: InclusiveRectangle {
+                left: 0,
+                top: 0,
+                right: 3,
+                bottom: 3,
+            },
+            width: 4,
+            height: 4,
+            bits_per_pixel: 32,
+            compression_flags: Compression::empty(),
+            compressed_data_header: None,
+            bitmap_data: &[0x40; 64],
+        }],
+    };
+    let bitmap_data = ironrdp::core::encode_vec(&bitmap).expect("encode bitmap update");
+
+    let mut compressor = BulkCompressor::new(BulkCompressionType::Rdp5).expect("create bulk compressor");
+    let (compressed_size, flags) = compressor.compress(&bitmap_data).expect("compress bitmap update");
+    assert_ne!(flags & bulk_flags::PACKET_COMPRESSED, 0);
+
+    let compressed_data = compressor.compressed_data(compressed_size);
+    let update = FastPathUpdatePdu {
+        fragmentation: Fragmentation::Single,
+        update_code: UpdateCode::Bitmap,
+        compression_flags: Some(CompressionFlags::from_bits_retain(
+            u8::try_from(flags & !bulk_flags::COMPRESSION_TYPE_MASK).expect("compression flags fit in u8"),
+        )),
+        compression_type: Some(PduCompressionType::K64),
+        data: compressed_data,
+    };
+    let header = FastPathHeader::new(EncryptionFlags::empty(), update.size());
+
+    let mut frame = ironrdp::core::encode_vec(&header).expect("encode FastPath header");
+    frame.extend(ironrdp::core::encode_vec(&update).expect("encode FastPath update"));
+    frame
 }
 
 #[tokio::test]

--- a/crates/ironrdp-testsuite-extra/tests/e2e.rs
+++ b/crates/ironrdp-testsuite-extra/tests/e2e.rs
@@ -100,19 +100,13 @@ async fn test_deactivation_reactivation() {
                                 // Update image size with the new desktop size.
                                 // image = DecodedImage::new(PixelFormat::RgbA32, desktop_size.width, desktop_size.height);
                                 // Update the active stage with the new channel IDs and pointer settings.
-                                stage.set_fastpath_processor(
-                                    session::fast_path::ProcessorBuilder {
-                                        io_channel_id: connection_activation.io_channel_id(),
-                                        user_channel_id: connection_activation.user_channel_id(),
-                                        share_id,
-                                        enable_server_pointer,
-                                        pointer_software_rendering,
-                                        bulk_decompressor: None,
-                                    }
-                                    .build(),
+                                stage.reactivate(
+                                    connection_activation.io_channel_id(),
+                                    connection_activation.user_channel_id(),
+                                    share_id,
+                                    enable_server_pointer,
+                                    pointer_software_rendering,
                                 );
-                                stage.set_share_id(share_id);
-                                stage.set_enable_server_pointer(enable_server_pointer);
                                 break 'activation_seq;
                             }
                         }

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -30,7 +30,7 @@ use ironrdp::rdpdr::Rdpdr;
 use ironrdp::rdpdr::pdu::efs::{DEFAULT_PRINTER_DRIVER_NAME, MICROSOFT_PRINT_TO_PDF_DRIVER_NAME};
 use ironrdp::rdpsnd::client::{NoopRdpsndBackend, Rdpsnd};
 use ironrdp::session::image::DecodedImage;
-use ironrdp::session::{ActiveStageBuilder, ActiveStageOutput, GracefulDisconnectReason, fast_path};
+use ironrdp::session::{ActiveStageBuilder, ActiveStageOutput, GracefulDisconnectReason};
 use ironrdp_core::WriteBuf;
 use ironrdp_futures::{FramedWrite, single_sequence_step_read};
 use rgb::AsPixels as _;
@@ -1033,21 +1033,13 @@ impl iron_remote_desktop::Session for Session {
                             {
                                 debug!("Deactivation-Reactivation Sequence completed");
                                 image = DecodedImage::new(PixelFormat::RgbA32, desktop_size.width, desktop_size.height);
-                                // Create a new [`FastPathProcessor`] with potentially updated
-                                // io/user channel ids.
-                                active_stage.set_fastpath_processor(
-                                    fast_path::ProcessorBuilder {
-                                        io_channel_id: connection_activation.io_channel_id(),
-                                        user_channel_id: connection_activation.user_channel_id(),
-                                        share_id,
-                                        enable_server_pointer,
-                                        pointer_software_rendering,
-                                        bulk_decompressor: None,
-                                    }
-                                    .build(),
+                                active_stage.reactivate(
+                                    connection_activation.io_channel_id(),
+                                    connection_activation.user_channel_id(),
+                                    share_id,
+                                    enable_server_pointer,
+                                    pointer_software_rendering,
                                 );
-                                active_stage.set_share_id(share_id);
-                                active_stage.set_enable_server_pointer(enable_server_pointer);
                                 break 'activation_seq;
                             }
                         }

--- a/ffi/src/session/mod.rs
+++ b/ffi/src/session/mod.rs
@@ -186,6 +186,11 @@ pub mod ffi {
                 .transpose()?)
         }
 
+        /// Rebuilds the fast-path processor for a Deactivation-Reactivation Sequence, keeping the
+        /// negotiated bulk compression alive.
+        ///
+        /// The name is kept for ABI compatibility; this now also applies `enable_server_pointer`,
+        /// which previously only reached the processor and not the active stage itself.
         pub fn set_fastpath_processor(
             &mut self,
             io_channel_id: u16,

--- a/ffi/src/session/mod.rs
+++ b/ffi/src/session/mod.rs
@@ -194,18 +194,13 @@ pub mod ffi {
             enable_server_pointer: bool,
             pointer_software_rendering: bool,
         ) {
-            self.0.set_fastpath_processor(
-                ironrdp::session::fast_path::ProcessorBuilder {
-                    io_channel_id,
-                    user_channel_id,
-                    share_id,
-                    enable_server_pointer,
-                    pointer_software_rendering,
-                    bulk_decompressor: None,
-                }
-                .build(),
+            self.0.reactivate(
+                io_channel_id,
+                user_channel_id,
+                share_id,
+                enable_server_pointer,
+                pointer_software_rendering,
             );
-            self.0.set_share_id(share_id);
         }
 
         pub fn set_enable_server_pointer(&mut self, enable_server_pointer: bool) {


### PR DESCRIPTION
Any session that reactivates (Deactivate All → re-activate) loses bulk decompression and dies right after. Windows consoles reactivate right after logon, and compression is on by default, so this hits pretty easily.

The reactivation path rebuilt the FastPath processor with [`bulk_decompressor: None`](https://github.com/Devolutions/IronRDP/blob/079b4842/crates/ironrdp-client/src/rdp.rs#L988). After that every compressed update got parsed as a raw bitmap:

```
Received compressed FastPath data but no decompressor is configured
BitmapData decode NotEnoughBytes: received 1662, expected 17134
```

Fix: `ActiveStage` keeps the negotiated compression type and gets a `reactivate(...)` that rebuilds the processor *with* a fresh decompressor. Native client, web, FFI and the e2e test all go through it now instead of hand-building a processor. The FFI one was the same bug — worth noting since RDM hits that path.

All additive, no API break (`compression_type` was already on `ActiveStageBuilder`).

### Testing

Hyper-V console on my lab box, default config (K64), before/after — first frame then dead vs. a session that keeps rendering. Compression ratio was ~24x on the initial paint, so this isn't a rare edge.

Also ran a normal RDP session to a Windows Server VM to be sure nothing regressed.

`cargo check`/`clippy` clean (session, client, web wasm32, ffi), fmt clean, testsuite-core 949 + testsuite-extra 21 green.