### PR TITLE
ci: pin Swatinem/rust-cache to v2.9.1 for release workflow compliance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         uses: ./.github/actions/install-build-deps
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2.7.3
+        uses: Swatinem/rust-cache@v2.9.1
 
       - name: Binary cache
         uses: actions/cache@v5
@@ -118,7 +118,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2.7.3
+        uses: Swatinem/rust-cache@v2.9.1
         with:
           workspaces: fuzz -> target
 
@@ -147,7 +147,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2.7.3
+        uses: Swatinem/rust-cache@v2.9.1
 
       - name: Binary cache
         uses: actions/cache@v5
@@ -173,7 +173,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2.7.3
+        uses: Swatinem/rust-cache@v2.9.1
 
       - name: Binary cache
         uses: actions/cache@v5
@@ -204,7 +204,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2.7.3
+        uses: Swatinem/rust-cache@v2.9.1
 
       - name: Setup matrix
         id: setup-matrix
@@ -228,7 +228,7 @@ jobs:
         uses: ./.github/actions/install-build-deps
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2.7.3
+        uses: Swatinem/rust-cache@v2.9.1
 
       - name: Binary cache
         uses: actions/cache@v5

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2.7.3
+        uses: Swatinem/rust-cache@v2.9.1
 
       - name: Setup matrix
         id: setup-matrix
@@ -80,7 +80,7 @@ jobs:
           tree ./fuzz/artifacts
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2.7.3
+        uses: Swatinem/rust-cache@v2.9.1
         with:
           workspaces: fuzz -> target
 

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -96,7 +96,7 @@ jobs:
         uses: ./.github/actions/install-build-deps
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2.7.3
+        uses: Swatinem/rust-cache@v2.9.1
 
       - name: Build release binary
         shell: pwsh


### PR DESCRIPTION
Updates all `Swatinem/rust-cache` usages from v2.7.3 to v2.9.1 across CI, fuzz, and release-binaries workflows.

Follows the same change made in Devolutions/devolutions-gateway#1868.