### PR TITLE
fix(error): make source locations opt-in

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2950,6 +2950,7 @@ dependencies = [
  "ironrdp-dvc",
  "ironrdp-echo",
  "ironrdp-egfx",
+ "ironrdp-error 0.2.0",
  "ironrdp-fuzzing",
  "ironrdp-graphics",
  "ironrdp-input",

--- a/crates/ironrdp-error/src/lib.rs
+++ b/crates/ironrdp-error/src/lib.rs
@@ -138,7 +138,10 @@ impl<Kind> Error<Kind> {
     }
 
     pub fn report(&self) -> ErrorReport<'_, Kind> {
-        ErrorReport(self)
+        ErrorReport {
+            error: self,
+            include_locations: false,
+        }
     }
 }
 
@@ -148,26 +151,14 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         #[cfg(feature = "alloc")]
-        {
-            write!(
-                f,
-                "[{} @ {}:{}] {}",
-                self.meta.context,
-                self.meta.location.file(),
-                self.meta.location.line(),
-                self.kind
-            )
-        }
+        let (context, location) = (self.meta.context, self.meta.location);
         #[cfg(not(feature = "alloc"))]
-        {
-            write!(
-                f,
-                "[{} @ {}:{}] {}",
-                self.context,
-                self.location.file(),
-                self.location.line(),
-                self.kind
-            )
+        let (context, location) = (self.context, self.location);
+
+        if f.alternate() {
+            write!(f, "[{context} @ {}:{}] {}", location.file(), location.line(), self.kind)
+        } else {
+            write!(f, "[{context}] {}", self.kind)
         }
     }
 }
@@ -201,7 +192,21 @@ where
     }
 }
 
-pub struct ErrorReport<'a, Kind>(&'a Error<Kind>);
+pub struct ErrorReport<'a, Kind> {
+    error: &'a Error<Kind>,
+    include_locations: bool,
+}
+
+impl<Kind> ErrorReport<'_, Kind> {
+    /// Includes source locations when formatting this error report.
+    ///
+    /// Alternate formatting (`{report:#}`) also includes source locations.
+    #[must_use]
+    pub fn with_locations(mut self) -> Self {
+        self.include_locations = true;
+        self
+    }
+}
 
 #[cfg(feature = "std")]
 impl<Kind> fmt::Display for ErrorReport<'_, Kind>
@@ -211,12 +216,22 @@ where
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use core::error::Error as _;
 
-        write!(f, "{}", self.0)?;
+        let include_locations = self.include_locations || f.alternate();
 
-        let mut next_source = self.0.source();
+        if include_locations {
+            write!(f, "{:#}", self.error)?;
+        } else {
+            write!(f, "{}", self.error)?;
+        }
+
+        let mut next_source = self.error.source();
 
         while let Some(e) = next_source {
-            write!(f, ", caused by: {e}")?;
+            if include_locations {
+                write!(f, ", caused by: {e:#}")?;
+            } else {
+                write!(f, ", caused by: {e}")?;
+            }
             next_source = e.source();
         }
 
@@ -230,11 +245,21 @@ where
     E: fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)?;
+        let include_locations = self.include_locations || f.alternate();
+
+        if include_locations {
+            write!(f, "{:#}", self.error)?;
+        } else {
+            write!(f, "{}", self.error)?;
+        }
 
         #[cfg(feature = "alloc")]
-        if let Some(source) = &self.0.meta.source {
-            write!(f, ", caused by: {source}")?;
+        if let Some(source) = &self.error.meta.source {
+            if include_locations {
+                write!(f, ", caused by: {source:#}")?;
+            } else {
+                write!(f, ", caused by: {source}")?;
+            }
         }
 
         Ok(())

--- a/crates/ironrdp-rdpsnd-native/src/cpal.rs
+++ b/crates/ironrdp-rdpsnd-native/src/cpal.rs
@@ -93,7 +93,7 @@ impl RdpsndClientHandler for RdpsndBackend {
                 let stream = match DecodeStream::new(&format, rx) {
                     Ok(stream) => stream,
                     Err(e) => {
-                        error!(error = %e.report());
+                        error!(error = %e.report().with_locations());
                         return;
                     }
                 };

--- a/crates/ironrdp-testsuite-core/Cargo.toml
+++ b/crates/ironrdp-testsuite-core/Cargo.toml
@@ -44,6 +44,7 @@ ironrdp-connector.path = "../ironrdp-connector"
 ironrdp-displaycontrol.path = "../ironrdp-displaycontrol"
 ironrdp-dvc.path = "../ironrdp-dvc"
 ironrdp-echo.path = "../ironrdp-echo"
+ironrdp-error = { path = "../ironrdp-error", features = ["std"] }
 ironrdp-fuzzing.path = "../ironrdp-fuzzing"
 ironrdp-graphics.path = "../ironrdp-graphics"
 ironrdp-str.path = "../ironrdp-str"

--- a/crates/ironrdp-testsuite-core/tests/error.rs
+++ b/crates/ironrdp-testsuite-core/tests/error.rs
@@ -1,0 +1,108 @@
+use core::fmt;
+
+use ironrdp_error::Error;
+
+#[derive(Debug)]
+struct TestKind(&'static str);
+
+impl fmt::Display for TestKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl core::error::Error for TestKind {}
+
+#[derive(Debug)]
+struct NestedKind {
+    source: Error<TestKind>,
+}
+
+impl fmt::Display for NestedKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "outer")
+    }
+}
+
+impl core::error::Error for NestedKind {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+#[test]
+fn display_omits_location_by_default() {
+    let error = Error::new("context", TestKind("kind"));
+
+    assert_eq!(error.to_string(), "[context] kind");
+}
+
+#[test]
+fn alternate_display_includes_location() {
+    let error = Error::new("context", TestKind("kind"));
+
+    assert_eq!(
+        format!("{error:#}"),
+        format!(
+            "[context @ {}:{}] kind",
+            error.location().file(),
+            error.location().line()
+        )
+    );
+}
+
+#[test]
+fn report_can_enable_locations_explicitly_or_with_alternate_formatting() {
+    let error = Error::new("context", TestKind("kind"));
+    let expected = format!(
+        "[context @ {}:{}] kind",
+        error.location().file(),
+        error.location().line()
+    );
+
+    assert_eq!(error.report().to_string(), "[context] kind");
+    assert_eq!(error.report().with_locations().to_string(), expected);
+    assert_eq!(format!("{:#}", error.report()), expected);
+}
+
+#[test]
+fn report_formats_nested_ironrdp_errors_with_locations() {
+    let source = Error::new("inner", TestKind("inner"));
+    let source_with_location = format!(
+        "[inner @ {}:{}] inner",
+        source.location().file(),
+        source.location().line()
+    );
+    let error = Error::new("outer", NestedKind { source });
+    let error_with_location = format!(
+        "[outer @ {}:{}] outer",
+        error.location().file(),
+        error.location().line()
+    );
+
+    assert_eq!(error.report().to_string(), "[outer] outer, caused by: [inner] inner");
+    assert_eq!(
+        error.report().with_locations().to_string(),
+        format!("{error_with_location}, caused by: {source_with_location}")
+    );
+    assert_eq!(
+        format!("{:#}", error.report()),
+        format!("{error_with_location}, caused by: {source_with_location}")
+    );
+}
+
+#[test]
+fn report_preserves_foreign_source_errors() {
+    let error = Error::new("context", TestKind("kind")).with_source(std::io::Error::other("foreign"));
+    let error_with_location = format!(
+        "[context @ {}:{}] kind",
+        error.location().file(),
+        error.location().line()
+    );
+
+    assert_eq!(error.report().to_string(), "[context] kind, caused by: foreign");
+    assert_eq!(
+        error.report().with_locations().to_string(),
+        format!("{error_with_location}, caused by: foreign")
+    );
+}

--- a/crates/ironrdp-testsuite-core/tests/main.rs
+++ b/crates/ironrdp-testsuite-core/tests/main.rs
@@ -19,6 +19,7 @@ mod displaycontrol;
 mod dvc;
 mod echo;
 mod egfx;
+mod error;
 mod fuzz_regression;
 mod graphics;
 mod input;

--- a/crates/ironrdp-viewer/src/app.rs
+++ b/crates/ironrdp-viewer/src/app.rs
@@ -361,7 +361,7 @@ impl ApplicationHandler<RdpOutputEvent> for App {
             }
             RdpOutputEvent::ConnectionFailure(error) => {
                 error!(?error);
-                eprintln!("Connection error: {}", error.report());
+                eprintln!("Connection error: {}", error.report().with_locations());
                 // TODO set proc_exit::sysexits::PROTOCOL_ERR.as_raw());
                 event_loop.exit();
             }
@@ -373,7 +373,7 @@ impl ApplicationHandler<RdpOutputEvent> for App {
                     }
                     Err(error) => {
                         error!(?error);
-                        eprintln!("Active session error: {}", error.report());
+                        eprintln!("Active session error: {}", error.report().with_locations());
                         proc_exit::sysexits::PROTOCOL_ERR
                     }
                 };

--- a/ffi/src/error.rs
+++ b/ffi/src/error.rs
@@ -45,7 +45,7 @@ impl From<ConnectorError> for Box<ffi::IronRdpError> {
             ironrdp::connector::ConnectorErrorKind::AccessDenied => IronRdpErrorKind::AccessDenied,
             _ => IronRdpErrorKind::Generic,
         };
-        let repr = value.report().to_string();
+        let repr = value.report().with_locations().to_string();
         make_ffi_error(repr, kind)
     }
 }
@@ -58,28 +58,28 @@ impl From<SessionError> for Box<ffi::IronRdpError> {
             ironrdp::session::SessionErrorKind::Decode(_) => IronRdpErrorKind::DecodeError,
             _ => IronRdpErrorKind::Generic,
         };
-        let repr = value.report().to_string();
+        let repr = value.report().with_locations().to_string();
         make_ffi_error(repr, kind)
     }
 }
 
 impl From<ironrdp::pdu::PduError> for Box<ffi::IronRdpError> {
     fn from(value: ironrdp::pdu::PduError) -> Self {
-        let repr = value.report().to_string();
+        let repr = value.report().with_locations().to_string();
         make_ffi_error(repr, IronRdpErrorKind::PduError)
     }
 }
 
 impl From<ironrdp::core::EncodeError> for Box<ffi::IronRdpError> {
     fn from(value: ironrdp::core::EncodeError) -> Self {
-        let repr = value.report().to_string();
+        let repr = value.report().with_locations().to_string();
         make_ffi_error(repr, IronRdpErrorKind::EncodeError)
     }
 }
 
 impl From<ironrdp::core::DecodeError> for Box<ffi::IronRdpError> {
     fn from(value: ironrdp::core::DecodeError) -> Self {
-        let repr = value.report().to_string();
+        let repr = value.report().with_locations().to_string();
         make_ffi_error(repr, IronRdpErrorKind::DecodeError)
     }
 }


### PR DESCRIPTION
Default error display omits locations; alternate formatting and reports with explicit location opt-in preserve diagnostic context.