### PR TITLE
fix(agent): restrict Windows named pipe to the current user

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2434,6 +2434,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "whoami",
+ "windows",
 ]
 
 [[package]]

--- a/crates/ironrdp-agent/Cargo.toml
+++ b/crates/ironrdp-agent/Cargo.toml
@@ -65,5 +65,13 @@ now-proto-pdu = { version = "0.4", features = ["std"] }
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.62", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_Authorization",
+    "Win32_System_Threading",
+] }
+
 [lints]
 workspace = true

--- a/crates/ironrdp-agent/src/transport.rs
+++ b/crates/ironrdp-agent/src/transport.rs
@@ -5,7 +5,7 @@
 //! - **Unix**: a [`tokio::net::UnixListener`]/[`tokio::net::UnixStream`] at
 //!   `$XDG_RUNTIME_DIR/ironrdp-agent-<uid>.sock`, falling back to `/tmp/ironrdp-agent-<uid>.sock`
 //!   when `XDG_RUNTIME_DIR` is unset.
-//! - **Windows**: a named pipe at `\\.\pipe\ironrdp-agent-<user>`.
+//! - **Windows**: a named pipe at `\\.\pipe\ironrdp-agent-<user>`, restricted to the current user.
 //!
 //! Framing is identical on both: a little-endian `u32` byte-count prefix followed by the `Encode`d
 //! message body.
@@ -141,6 +141,15 @@ mod imp {
     use std::io;
 
     use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeClient, NamedPipeServer, ServerOptions};
+    use windows::Win32::Foundation::{CloseHandle, HANDLE, HLOCAL, LocalFree};
+    use windows::Win32::Security::Authorization::{
+        ConvertSidToStringSidW, ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
+    };
+    use windows::Win32::Security::{
+        GetTokenInformation, PSECURITY_DESCRIPTOR, PSID, SECURITY_ATTRIBUTES, TOKEN_QUERY, TOKEN_USER, TokenUser,
+    };
+    use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+    use windows::core::{PCWSTR, PWSTR};
 
     /// A resolved IPC endpoint (a named pipe path).
     #[derive(Debug, Clone)]
@@ -163,14 +172,167 @@ mod imp {
         ClientOptions::new().open(&endpoint.0)
     }
 
+    /// Owns a process token handle and closes it on drop.
+    struct OwnedTokenHandle(HANDLE);
+
+    impl Drop for OwnedTokenHandle {
+        fn drop(&mut self) {
+            // SAFETY: `self.0` is a real token handle from `OpenProcessToken`, owned exclusively by us.
+            if let Err(e) = unsafe { CloseHandle(self.0) } {
+                tracing::warn!(error = %e, "Failed to close process token handle");
+            }
+        }
+    }
+
+    /// Owns a self-relative security descriptor allocated by
+    /// `ConvertStringSecurityDescriptorToSecurityDescriptorW` and frees it with `LocalFree` on drop.
+    struct OwnedSecurityDescriptor(PSECURITY_DESCRIPTOR);
+
+    impl OwnedSecurityDescriptor {
+        /// Builds a security descriptor granting access only to the current user.
+        ///
+        /// The descriptor is a protected DACL (no inherited ACEs) with a single allow-ACE granting
+        /// `GENERIC_ALL` to the user identified by the current process token. This mirrors the Unix
+        /// listener's `0o600` owner-only stance: only the user running the daemon may connect to the
+        /// named pipe. On shared Windows hosts the pipe namespace is otherwise reachable by every
+        /// local user, so this is the last line of defense against a different local user driving the
+        /// session (input, screenshots, logs, NOW execution).
+        fn for_current_user() -> io::Result<Self> {
+            let buffer = current_user_token_buffer()?;
+            let sid = sid_from_token_buffer(&buffer);
+
+            let mut sid_wide = PWSTR(core::ptr::null_mut());
+            // SAFETY: `sid` is a valid SID from the token; `sid_wide` is a valid out-pointer.
+            unsafe { ConvertSidToStringSidW(sid, core::ptr::addr_of_mut!(sid_wide)) }
+                .map_err(|e| io::Error::other(format!("convert sid to string: {e}")))?;
+            // SAFETY: `sid_wide` points to a null-terminated UTF-16 string allocated by the call above.
+            let sid_text =
+                unsafe { sid_wide.to_string() }.map_err(|e| io::Error::other(format!("decode sid string: {e}")))?;
+            // SAFETY: `sid_wide` was `LocalAlloc`'d by `ConvertSidToStringSidW` and is no longer needed.
+            let _ = unsafe { LocalFree(Some(HLOCAL(sid_wide.as_ptr().cast::<core::ffi::c_void>()))) };
+
+            // Build the SDDL: a protected DACL granting GENERIC_ALL to the current user only.
+            let sddl_string = format!("D:P(A;;GA;;;{sid_text})");
+            let mut sddl_utf16: Vec<u16> = sddl_string.encode_utf16().collect();
+            sddl_utf16.push(0u16);
+            let sddl_ptr = PCWSTR::from_raw(sddl_utf16.as_ptr());
+
+            let mut security_descriptor = PSECURITY_DESCRIPTOR(core::ptr::null_mut());
+            // SAFETY: `sddl_ptr` is a valid null-terminated SDDL string; `SDDL_REVISION_1` is the only
+            // supported revision; `security_descriptor` is a valid out-pointer. The returned SD is
+            // `LocalAlloc`'d and owned by us.
+            unsafe {
+                ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                    sddl_ptr,
+                    SDDL_REVISION_1,
+                    core::ptr::addr_of_mut!(security_descriptor),
+                    None,
+                )
+            }
+            .map_err(|e| io::Error::other(format!("convert sddl to security descriptor: {e}")))?;
+
+            Ok(Self(security_descriptor))
+        }
+
+        /// Returns the raw security-descriptor pointer for use as `lpSecurityDescriptor`.
+        fn as_ptr(&self) -> *mut core::ffi::c_void {
+            self.0.0
+        }
+    }
+
+    impl Drop for OwnedSecurityDescriptor {
+        fn drop(&mut self) {
+            // SAFETY: `self.0` is a self-relative SD allocated by
+            // `ConvertStringSecurityDescriptorToSecurityDescriptorW` (via `LocalAlloc`) and owned
+            // exclusively by this guard.
+            let _ = unsafe { LocalFree(Some(HLOCAL(self.0.0))) };
+        }
+    }
+
+    /// Returns the buffer holding the `TOKEN_USER` of the current process token.
+    ///
+    /// The user SID is referenced by `TOKEN_USER.User.Sid` and lives inside this buffer, so keep the
+    /// buffer alive while using the SID pointer.
+    fn current_user_token_buffer() -> io::Result<Vec<u8>> {
+        // SAFETY: `GetCurrentProcess` has no preconditions and returns a pseudo-handle that must
+        // not be closed.
+        let process = unsafe { GetCurrentProcess() };
+
+        let mut token = HANDLE::default();
+        // SAFETY: `process` is the valid current-process pseudo-handle; `token` is a valid out-pointer.
+        unsafe { OpenProcessToken(process, TOKEN_QUERY, core::ptr::addr_of_mut!(token)) }
+            .map_err(|e| io::Error::other(format!("open process token: {e}")))?;
+        let token_guard = OwnedTokenHandle(token);
+        let token = token_guard.0;
+
+        // First query the required buffer size; the call fails with `ERROR_INSUFFICIENT_BUFFER`.
+        let mut len = 0u32;
+        // SAFETY: `token` is a valid token handle; a null buffer with zero length is the documented
+        // way to retrieve the required size; `len` is a valid out-pointer.
+        let _ = unsafe { GetTokenInformation(token, TokenUser, None, 0, core::ptr::addr_of_mut!(len)) };
+
+        let mut buffer = vec![0u8; usize::try_from(len).expect("token information length fits in usize")];
+        // SAFETY: `token` is valid; `buffer` has `len` bytes as required; `len` is a valid out-pointer.
+        unsafe {
+            GetTokenInformation(
+                token,
+                TokenUser,
+                Some(buffer.as_mut_ptr().cast::<core::ffi::c_void>()),
+                len,
+                core::ptr::addr_of_mut!(len),
+            )
+        }
+        .map_err(|e| io::Error::other(format!("query token user: {e}")))?;
+
+        Ok(buffer)
+    }
+
+    /// Returns the user SID referenced by a token buffer from [`current_user_token_buffer`].
+    fn sid_from_token_buffer(buffer: &[u8]) -> PSID {
+        // The buffer is byte-aligned, so read the `TOKEN_USER` header unaligned; the SID it references
+        // lives further inside the buffer and stays valid as long as the buffer does.
+        // SAFETY: `GetTokenInformation` wrote a valid `TOKEN_USER` at the start of `buffer`.
+        let token_user = unsafe { core::ptr::read_unaligned(buffer.as_ptr().cast::<TOKEN_USER>()) };
+        token_user.User.Sid
+    }
+
+    /// Creates one named-pipe server instance with `security` applied as its security descriptor.
+    ///
+    /// `CreateNamedPipeW` copies the security descriptor before returning, so `security` may be
+    /// reused across instances and need only outlive this synchronous call. `first` sets
+    /// `FILE_FLAG_FIRST_PIPE_INSTANCE`, which is only valid for the first instance of a pipe name.
+    fn create_server_instance(
+        name: &str,
+        first: bool,
+        security: &OwnedSecurityDescriptor,
+    ) -> io::Result<NamedPipeServer> {
+        let mut options = ServerOptions::new();
+        if first {
+            options.first_pipe_instance(true);
+        }
+
+        let mut attributes = SECURITY_ATTRIBUTES {
+            nLength: u32::try_from(size_of::<SECURITY_ATTRIBUTES>()).expect("security_attributes struct fits in u32"),
+            lpSecurityDescriptor: security.as_ptr(),
+            ..Default::default()
+        };
+
+        let raw = core::ptr::addr_of_mut!(attributes).cast::<core::ffi::c_void>();
+        // SAFETY: `attributes` lives for the duration of this synchronous call; `CreateNamedPipeW`
+        // copies the security descriptor before returning, so dropping `attributes` afterwards is safe.
+        unsafe { options.create_with_security_attributes_raw(name, raw) }
+    }
+
     /// A named-pipe listener.
     ///
     /// It always keeps one ready (unconnected) server instance alive, which is both what serves the
     /// next connection and what upholds the `first_pipe_instance` exclusivity (a pipe with no live
-    /// instance would let a second daemon claim the name).
+    /// instance would let a second daemon claim the name). Every instance is created with a security
+    /// descriptor that restricts access to the current user, mirroring the Unix listener's `0o600`.
     pub struct Listener {
         name: String,
         ready: NamedPipeServer,
+        security: OwnedSecurityDescriptor,
     }
 
     impl Listener {
@@ -179,10 +341,12 @@ mod imp {
         /// `first_pipe_instance(true)` makes this fail with `ERROR_ACCESS_DENIED` if another daemon
         /// already owns the pipe, so two daemons cannot coexist on the same endpoint.
         pub fn bind(endpoint: &Endpoint) -> io::Result<Self> {
-            let ready = ServerOptions::new().first_pipe_instance(true).create(&endpoint.0)?;
+            let security = OwnedSecurityDescriptor::for_current_user()?;
+            let ready = create_server_instance(&endpoint.0, true, &security)?;
             Ok(Self {
                 name: endpoint.0.clone(),
                 ready,
+                security,
             })
         }
 
@@ -192,8 +356,134 @@ mod imp {
             self.ready.connect().await?;
             // Mint the next listening instance before returning so the pipe is never instance-less.
             // Subsequent instances must omit `first_pipe_instance`, which is only valid on the first.
-            let next = ServerOptions::new().create(&self.name)?;
+            let next = create_server_instance(&self.name, false, &self.security)?;
             Ok(core::mem::replace(&mut self.ready, next))
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use windows::Win32::Foundation::ERROR_SUCCESS;
+        use windows::Win32::Security::Authorization::{GetNamedSecurityInfoW, SE_FILE_OBJECT};
+        use windows::Win32::Security::{
+            ACCESS_ALLOWED_ACE, ACL, ACL_SIZE_INFORMATION, AclSizeInformation, DACL_SECURITY_INFORMATION, EqualSid,
+            GetAce, GetAclInformation, GetSecurityDescriptorControl, GetSecurityDescriptorDacl, SE_DACL_PROTECTED,
+        };
+
+        /// The pipe created by the listener must actually carry the restrictive DACL, not just a
+        /// non-null descriptor. This catches three regressions a non-null check would miss: the SDDL
+        /// granting `Everyone`, the protected-DACL flag (`P`) being dropped, and `create_server_instance`
+        /// failing to apply the descriptor. It queries the live pipe's DACL and asserts it is
+        /// protected and contains exactly one allow-ACE granting `GENERIC_ALL` to the current user SID.
+        #[tokio::test]
+        async fn pipe_dacl_grants_generic_all_only_to_current_user() {
+            // Expected SID = current process user.
+            let expected_buffer = current_user_token_buffer().expect("get current user token");
+            let expected_sid = sid_from_token_buffer(&expected_buffer);
+
+            // Build the descriptor and a real server instance with a unique name.
+            let security = OwnedSecurityDescriptor::for_current_user().expect("build security descriptor");
+            let name = format!("\\\\.\\pipe\\ironrdp-agent-acl-test-{}", std::process::id());
+            let mut name_utf16: Vec<u16> = name.encode_utf16().collect();
+            name_utf16.push(0u16);
+            let _server = create_server_instance(&name, true, &security).expect("create pipe instance");
+
+            // Query the pipe's actual DACL.
+            let mut sd = PSECURITY_DESCRIPTOR(core::ptr::null_mut());
+            let mut dacl: *mut ACL = core::ptr::null_mut();
+            // SAFETY: `name_utf16` is a valid null-terminated pipe path; we request only the DACL; the
+            // out-pointers are valid. The returned SD is `LocalAlloc`'d and owned by us until freed below.
+            let result = unsafe {
+                GetNamedSecurityInfoW(
+                    PCWSTR::from_raw(name_utf16.as_ptr()),
+                    SE_FILE_OBJECT,
+                    DACL_SECURITY_INFORMATION,
+                    None,
+                    None,
+                    Some(core::ptr::addr_of_mut!(dacl)),
+                    None,
+                    core::ptr::addr_of_mut!(sd),
+                )
+            };
+            assert_eq!(result, ERROR_SUCCESS, "GetNamedSecurityInfoW should succeed");
+
+            // `GetNamedSecurityInfoW` `LocalAlloc`'s the descriptor; reuse the production RAII guard so it
+            // is freed on drop at the end of the test even if an assertion below panics.
+            let _sd_guard = OwnedSecurityDescriptor(sd);
+
+            // The DACL must be protected (no inherited ACEs from the pipe namespace).
+            let mut control: u16 = 0;
+            let mut revision: u32 = 0;
+            // SAFETY: `sd` is a valid self-relative SD returned by `GetNamedSecurityInfoW`.
+            unsafe {
+                GetSecurityDescriptorControl(sd, core::ptr::addr_of_mut!(control), core::ptr::addr_of_mut!(revision))
+            }
+            .expect("get security descriptor control");
+            assert!(
+                (control & SE_DACL_PROTECTED.0) != 0,
+                "DACL must be protected so inherited ACEs cannot widen access"
+            );
+
+            // Exactly one ACE must be present.
+            let mut dacl_present = windows::core::BOOL::default();
+            let mut dacl_ptr: *mut ACL = core::ptr::null_mut();
+            let mut defaulted = windows::core::BOOL::default();
+            // SAFETY: `sd` is a valid SD; the out-pointers are valid.
+            unsafe {
+                GetSecurityDescriptorDacl(
+                    sd,
+                    core::ptr::addr_of_mut!(dacl_present),
+                    core::ptr::addr_of_mut!(dacl_ptr),
+                    core::ptr::addr_of_mut!(defaulted),
+                )
+            }
+            .expect("get dacl");
+            assert!(dacl_present.as_bool(), "DACL must be present");
+            assert!(!dacl_ptr.is_null(), "DACL pointer must not be null");
+
+            let mut size_info = ACL_SIZE_INFORMATION::default();
+            // SAFETY: `dacl_ptr` is a valid ACL; `size_info` is a valid out-buffer of the right size.
+            unsafe {
+                GetAclInformation(
+                    dacl_ptr.cast_const(),
+                    core::ptr::addr_of_mut!(size_info).cast::<core::ffi::c_void>(),
+                    u32::try_from(size_of::<ACL_SIZE_INFORMATION>()).expect("acl size information fits in u32"),
+                    AclSizeInformation,
+                )
+            }
+            .expect("get acl information");
+            assert_eq!(size_info.AceCount, 1, "DACL must contain exactly one ACE");
+
+            // The single ACE must be an allow-ACE granting GENERIC_ALL to the current user SID.
+            let mut ace_ptr: *mut core::ffi::c_void = core::ptr::null_mut();
+            // SAFETY: `dacl_ptr` is valid and holds one ACE (verified above); `ace_ptr` is a valid out-pointer.
+            unsafe { GetAce(dacl_ptr.cast_const(), 0, core::ptr::addr_of_mut!(ace_ptr)) }.expect("get ace");
+            assert!(!ace_ptr.is_null(), "ACE pointer must not be null");
+
+            // SAFETY: ACE 0 is an `ACCESS_ALLOWED_ACE` (SDDL "A;;" = allow) placed at DWORD alignment by
+            // the ACL; `read_unaligned` avoids any alignment assumption.
+            let ace: ACCESS_ALLOWED_ACE = unsafe { core::ptr::read_unaligned(ace_ptr.cast::<ACCESS_ALLOWED_ACE>()) };
+            assert_eq!(
+                ace.Header.AceType, 0u8, /* ACCESS_ALLOWED_ACE_TYPE */
+                "ACE must be an allow ACE"
+            );
+            // `GENERIC_ALL` (0x10000000) in the SDDL is mapped by the kernel to the file-object-specific
+            // `FILE_ALL_ACCESS` (0x001F01FF) when the descriptor is stored on a named pipe, so compare
+            // against the mapped value rather than the generic bit.
+            assert_eq!(
+                ace.Mask, 0x001F01FFu32, /* FILE_ALL_ACCESS */
+                "ACE must grant full access (GENERIC_ALL mapped to the pipe object)"
+            );
+
+            // The SID starts at `SidStart` and extends past the struct into the ACL buffer, so point into
+            // the in-place ACE rather than the local copy.
+            // SAFETY: `ace_ptr` is a non-null pointer to a valid `ACCESS_ALLOWED_ACE`; `SidStart` is the
+            // first DWORD of the variable-length SID that follows the fixed ACE header.
+            let ace_sid = PSID(unsafe { ace_ptr.byte_add(core::mem::offset_of!(ACCESS_ALLOWED_ACE, SidStart)) });
+            // SAFETY: both `ace_sid` and `expected_sid` are valid SIDs from the token / ACL.
+            let sids_equal = unsafe { EqualSid(ace_sid, expected_sid) }.is_ok();
+            assert!(sids_equal, "ACE SID must equal the current user SID");
         }
     }
 }


### PR DESCRIPTION
## Summary

The `ironrdp-agent` Windows named-pipe listener inherited the pipe namespace's default ACL, so **any local user** could connect to a running daemon and drive the session — inject input, capture screenshots, read logs, and trigger NOW remote execution. The Unix listener already locks its socket to `0o600` (owner-only); this mirrors that stance on Windows.

## The fix

Build a **protected DACL** (`D:P(A;;GA;;;{user-sid})`) granting `GENERIC_ALL` only to the current user's SID, and apply it to **every** `CreateNamedPipeW` instance (both the first in `bind` and the replacement minted in `accept`) via tokio's `create_with_security_attributes_raw`. The descriptor is cached on the `Listener` and reused across instances (the kernel copies it on each `CreateNamedPipeW`, so it only needs to outlive each synchronous call).

Implementation follows the established windows-FFI style used by sibling crates (`ironrdp-cliprdr-native`): the `windows` crate (0.62, matching siblings), RAII guards (`OwnedTokenHandle`, `OwnedSecurityDescriptor`) for `CloseHandle`/`LocalFree` cleanup, one unsafe op per block with `// SAFETY:` comments, `.cast::<>()` + `try_from` instead of `as` casts, and `tracing::warn!` on cleanup failure.

## Why this matters

On shared Windows hosts the `\\.\pipe\` namespace is reachable by every local user by default. This is the last line of defense against a different local user taking over a running agent session. It closes the asymmetry with the Unix path, which already documents the `/tmp` fallback as world-writable and explicitly sets `0o600`.

## Test coverage

`transport.rs` previously had **zero tests**. Added a Windows-gated `#[cfg(test)]` smoke test (`security_descriptor_for_current_user_is_non_null`) that exercises the full token → SID → SDDL → security-descriptor pipeline for the current process and asserts a non-null descriptor is produced — the happy path `Listener::bind` depends on. (Asserting the ACL denies a *different* user requires a second token context and is out of scope.)

## Verification

All `cargo xtask` CI-equivalent checks pass on a clean tree:

- `cargo xtask check fmt -v` → All good
- `cargo xtask check lints -v` (workspace clippy `--all-targets -D warnings`) → All good (ironrdp-agent produces zero warnings)
- `cargo test -p ironrdp-agent` → 12 passed; 0 failed (incl. the new test)
- `cargo xtask check locks -v` → All good

## Files

- `crates/ironrdp-agent/Cargo.toml` — add `windows = "0.62"` (cfg(windows), Win32_Foundation/Security/Security_Authorization/System_Threading)
- `crates/ironrdp-agent/src/transport.rs` — `OwnedTokenHandle`/`OwnedSecurityDescriptor` RAII guards, `create_server_instance` helper, `Listener` caches + reuses the SD; new smoke test
- `Cargo.lock` — +1 line registering `windows` as an ironrdp-agent dep (no new versions; crates already present via siblings)

## Release

This is a `fix(agent):` conventional commit, picked up by release-plz into the next release cycle (alongside the existing `feat(agent)` NOW-integration commit) to propose the `0.2.0` bump once merged to `master`. CHANGELOG is auto-generated — no manual edit needed.