### PR TITLE
fix(session): preserve bitmap source stride

### DIFF
--- a/crates/ironrdp-session/src/fast_path.rs
+++ b/crates/ironrdp-session/src/fast_path.rs
@@ -21,6 +21,64 @@ use crate::palette::Palette;
 use crate::pointer::PointerCache;
 use crate::{SessionError, SessionErrorExt as _, SessionResult, custom_err, reason_err, rfx};
 
+#[cfg(test)]
+mod tests {
+    use ironrdp_pdu::bitmap::{BitmapData, Compression};
+
+    use super::*;
+
+    #[test]
+    fn raw_bitmap_removes_byte_padding_without_changing_source_stride() {
+        let mut processor = ProcessorBuilder {
+            io_channel_id: 0,
+            user_channel_id: 0,
+            share_id: 0,
+            enable_server_pointer: false,
+            pointer_software_rendering: false,
+            bulk_decompressor: None,
+        }
+        .build();
+        let mut image = DecodedImage::new(PixelFormat::RgbA32, 4, 3);
+
+        // Two bottom-up BGR rows of three source pixels each. The final source
+        // column is outside the destination and each row has three pad bytes.
+        let bitmap_data = [
+            3, 2, 1, 6, 5, 4, 9, 8, 7, 0xff, 0xff, 0xff, // bottom row
+            15, 14, 13, 18, 17, 16, 21, 20, 19, 0xff, 0xff, 0xff, // top row
+        ];
+        let bitmap_update = BitmapUpdateData {
+            rectangles: vec![BitmapData {
+                rectangle: InclusiveRectangle {
+                    left: 1,
+                    top: 0,
+                    right: 2,
+                    bottom: 1,
+                },
+                width: 3,
+                height: 2,
+                bits_per_pixel: 24,
+                compression_flags: Compression::empty(),
+                compressed_data_header: None,
+                bitmap_data: &bitmap_data,
+            }],
+        };
+
+        processor.process_bitmap_update(&mut image, bitmap_update).unwrap();
+
+        let pixel = |x: usize, y: usize| -> [u8; 4] {
+            let offset = (y * usize::from(image.width()) + x) * 4;
+            image.data()[offset..offset + 4]
+                .try_into()
+                .expect("pixel has four channels")
+        };
+        assert_eq!(pixel(1, 0), [13, 14, 15, 255]);
+        assert_eq!(pixel(2, 0), [16, 17, 18, 255]);
+        assert_eq!(pixel(1, 1), [1, 2, 3, 255]);
+        assert_eq!(pixel(2, 1), [4, 5, 6, 255]);
+        assert_eq!(pixel(3, 0), [0, 0, 0, 0]);
+    }
+}
+
 #[derive(Debug)]
 pub enum UpdateKind {
     None,
@@ -192,6 +250,29 @@ impl Processor {
             trace!("{update:?}");
             buf.clear();
 
+            let width = update.width.min(update.rectangle.width());
+            let height = update.height.min(update.rectangle.height());
+            if width == 0 || height == 0 {
+                warn!(
+                    bitmap_width = update.width,
+                    bitmap_height = update.height,
+                    destination = ?update.rectangle,
+                    "Skipping bitmap with an empty source or destination"
+                );
+                continue;
+            }
+
+            // `width` and `height` describe the source bitmap layout, while
+            // destination bounds describe where its visible portion is drawn.
+            // Servers can send source rows wider than the destination; preserve
+            // that source stride and discard only the excess source extent.
+            let bitmap_rectangle = InclusiveRectangle {
+                left: update.rectangle.left,
+                top: update.rectangle.top,
+                right: update.rectangle.left + width - 1,
+                bottom: update.rectangle.top + height - 1,
+            };
+
             // Bitmap data is either compressed or uncompressed, depending
             // on whether the BITMAP_COMPRESSION flag is present in the
             // flags field.
@@ -211,7 +292,8 @@ impl Processor {
                         usize::from(update.width),
                         usize::from(update.height),
                     ) {
-                        Ok(()) => image.apply_rgb24(&buf, &update.rectangle, true)?,
+                        // The RDP 6 decoder writes its planes in row-major (top-down) order.
+                        Ok(()) => image.apply_rgb24(&buf, &bitmap_rectangle, update.width, false)?,
                         Err(err) => {
                             warn!("Invalid RDP6_BITMAP_STREAM: {err}");
                             update.rectangle.clone()
@@ -230,12 +312,15 @@ impl Processor {
                         usize::from(update.height),
                         usize::from(update.bits_per_pixel),
                     ) {
-                        Ok(RlePixelFormat::Rgb16) => image.apply_rgb16_bitmap(&buf, &update.rectangle)?,
-                        Ok(RlePixelFormat::Rgb15) => image.apply_rgb15_bitmap(&buf, &update.rectangle)?,
-                        Ok(RlePixelFormat::Rgb24) => image.apply_bgr24_bitmap(&buf, &update.rectangle)?,
-                        Ok(RlePixelFormat::Rgb8) => {
-                            image.apply_rgb8_with_palette(&buf, &update.rectangle, self.palette.colors())?
-                        }
+                        Ok(RlePixelFormat::Rgb16) => image.apply_rgb16_bitmap(&buf, &bitmap_rectangle, update.width)?,
+                        Ok(RlePixelFormat::Rgb15) => image.apply_rgb15_bitmap(&buf, &bitmap_rectangle, update.width)?,
+                        Ok(RlePixelFormat::Rgb24) => image.apply_bgr24_bitmap(&buf, &bitmap_rectangle, update.width)?,
+                        Ok(RlePixelFormat::Rgb8) => image.apply_rgb8_with_palette(
+                            &buf,
+                            &bitmap_rectangle,
+                            self.palette.colors(),
+                            update.width,
+                        )?,
 
                         Err(e) => {
                             warn!("Invalid RLE-compressed bitmap: {e}");
@@ -257,20 +342,28 @@ impl Processor {
                 let padded_row_bytes = (row_bytes + 3) & !3;
 
                 if padded_row_bytes != row_bytes {
-                    // Strip per-row padding before passing to the bitmap apply functions,
-                    // which expect tightly packed pixel data.
+                    // Strip only byte padding; the tightly packed rows still retain
+                    // `update.width` pixels and therefore their source stride.
                     buf.clear();
-                    for row in update.bitmap_data.chunks(padded_row_bytes) {
-                        let end = row_bytes.min(row.len());
-                        buf.extend_from_slice(&row[..end]);
+                    for row in update
+                        .bitmap_data
+                        .chunks_exact(padded_row_bytes)
+                        .take(usize::from(update.height))
+                    {
+                        buf.extend_from_slice(&row[..row_bytes]);
                     }
 
                     match update.bits_per_pixel {
-                        8 => image.apply_rgb8_with_palette(&buf, &update.rectangle, self.palette.colors())?,
-                        15 => image.apply_rgb15_bitmap(&buf, &update.rectangle)?,
-                        16 => image.apply_rgb16_bitmap(&buf, &update.rectangle)?,
-                        24 => image.apply_bgr24_bitmap(&buf, &update.rectangle)?,
-                        32 => image.apply_rgb32_bitmap(&buf, PixelFormat::BgrX32, &update.rectangle)?,
+                        8 => image.apply_rgb8_with_palette(
+                            &buf,
+                            &bitmap_rectangle,
+                            self.palette.colors(),
+                            update.width,
+                        )?,
+                        15 => image.apply_rgb15_bitmap(&buf, &bitmap_rectangle, update.width)?,
+                        16 => image.apply_rgb16_bitmap(&buf, &bitmap_rectangle, update.width)?,
+                        24 => image.apply_bgr24_bitmap(&buf, &bitmap_rectangle, update.width)?,
+                        32 => image.apply_rgb32_bitmap(&buf, PixelFormat::BgrX32, &bitmap_rectangle, update.width)?,
                         _ => {
                             warn!("Unsupported uncompressed bitmap depth: {bpp} bpp");
                             update.rectangle.clone()
@@ -280,13 +373,19 @@ impl Processor {
                     match update.bits_per_pixel {
                         8 => image.apply_rgb8_with_palette(
                             update.bitmap_data,
-                            &update.rectangle,
+                            &bitmap_rectangle,
                             self.palette.colors(),
+                            update.width,
                         )?,
-                        15 => image.apply_rgb15_bitmap(update.bitmap_data, &update.rectangle)?,
-                        16 => image.apply_rgb16_bitmap(update.bitmap_data, &update.rectangle)?,
-                        24 => image.apply_bgr24_bitmap(update.bitmap_data, &update.rectangle)?,
-                        32 => image.apply_rgb32_bitmap(update.bitmap_data, PixelFormat::BgrX32, &update.rectangle)?,
+                        15 => image.apply_rgb15_bitmap(update.bitmap_data, &bitmap_rectangle, update.width)?,
+                        16 => image.apply_rgb16_bitmap(update.bitmap_data, &bitmap_rectangle, update.width)?,
+                        24 => image.apply_bgr24_bitmap(update.bitmap_data, &bitmap_rectangle, update.width)?,
+                        32 => image.apply_rgb32_bitmap(
+                            update.bitmap_data,
+                            PixelFormat::BgrX32,
+                            &bitmap_rectangle,
+                            update.width,
+                        )?,
                         _ => {
                             warn!("Unsupported uncompressed bitmap depth: {bpp} bpp");
                             update.rectangle.clone()
@@ -467,14 +566,23 @@ impl Processor {
                     match codec_id {
                         CODEC_ID_NONE => {
                             let ext_data = bits.extended_bitmap_data;
+                            let source_width = destination.width();
                             let rectangle = match ext_data.bpp {
-                                8 => {
-                                    image.apply_rgb8_with_palette(ext_data.data, &destination, self.palette.colors())?
-                                }
-                                15 => image.apply_rgb15_bitmap(ext_data.data, &destination)?,
-                                16 => image.apply_rgb16_bitmap(ext_data.data, &destination)?,
-                                24 => image.apply_bgr24_bitmap(ext_data.data, &destination)?,
-                                32 => image.apply_rgb32_bitmap(ext_data.data, PixelFormat::BgrX32, &destination)?,
+                                8 => image.apply_rgb8_with_palette(
+                                    ext_data.data,
+                                    &destination,
+                                    self.palette.colors(),
+                                    source_width,
+                                )?,
+                                15 => image.apply_rgb15_bitmap(ext_data.data, &destination, source_width)?,
+                                16 => image.apply_rgb16_bitmap(ext_data.data, &destination, source_width)?,
+                                24 => image.apply_bgr24_bitmap(ext_data.data, &destination, source_width)?,
+                                32 => image.apply_rgb32_bitmap(
+                                    ext_data.data,
+                                    PixelFormat::BgrX32,
+                                    &destination,
+                                    source_width,
+                                )?,
                                 bpp => {
                                     warn!("Unsupported surface CODEC_ID_NONE bpp: {bpp}");
                                     continue;
@@ -577,7 +685,7 @@ fn qoi_apply(
     }
 
     let rectangle = match header.channels {
-        qoi::Channels::Rgb => image.apply_rgb24(&decoded, &destination, false)?,
+        qoi::Channels::Rgb => image.apply_rgb24(&decoded, &destination, destination.width(), false)?,
         qoi::Channels::Rgba => image.apply_rgba32(&decoded, &destination, false)?,
     };
 

--- a/crates/ironrdp-session/src/image.rs
+++ b/crates/ironrdp-session/src/image.rs
@@ -552,6 +552,7 @@ impl DecodedImage {
         &mut self,
         rgb16: &[u8],
         update_rectangle: &InclusiveRectangle,
+        source_width: u16,
     ) -> SessionResult<InclusiveRectangle> {
         if !self.rect_fits(update_rectangle) {
             debug!(
@@ -566,6 +567,8 @@ impl DecodedImage {
 
         let image_width = usize::from(self.width);
         let rectangle_width = usize::from(update_rectangle.width());
+        let source_width = usize::from(source_width);
+        let rectangle_height = usize::from(update_rectangle.height());
         let top = usize::from(update_rectangle.top);
         let left = usize::from(update_rectangle.left);
         let [ri, gi, bi, ai] = self.pixel_format.channel_offsets();
@@ -573,11 +576,13 @@ impl DecodedImage {
         let pointer_rendering_state = self.pointer_rendering_begin(update_rectangle)?;
 
         rgb16
-            .chunks_exact(rectangle_width * SRC_COLOR_DEPTH)
+            .chunks_exact(source_width * SRC_COLOR_DEPTH)
             .rev()
+            .take(rectangle_height)
             .enumerate()
             .for_each(|(row_idx, row)| {
                 row.chunks_exact(SRC_COLOR_DEPTH)
+                    .take(rectangle_width)
                     .enumerate()
                     .for_each(|(col_idx, src_pixel)| {
                         let rgb16_value = u16::from_le_bytes(
@@ -605,6 +610,7 @@ impl DecodedImage {
         &mut self,
         rgb15: &[u8],
         update_rectangle: &InclusiveRectangle,
+        source_width: u16,
     ) -> SessionResult<InclusiveRectangle> {
         if !self.rect_fits(update_rectangle) {
             debug!(
@@ -619,6 +625,8 @@ impl DecodedImage {
 
         let image_width = usize::from(self.width);
         let rectangle_width = usize::from(update_rectangle.width());
+        let source_width = usize::from(source_width);
+        let rectangle_height = usize::from(update_rectangle.height());
         let top = usize::from(update_rectangle.top);
         let left = usize::from(update_rectangle.left);
         let [ri, gi, bi, ai] = self.pixel_format.channel_offsets();
@@ -626,11 +634,13 @@ impl DecodedImage {
         let pointer_rendering_state = self.pointer_rendering_begin(update_rectangle)?;
 
         rgb15
-            .chunks_exact(rectangle_width * SRC_COLOR_DEPTH)
+            .chunks_exact(source_width * SRC_COLOR_DEPTH)
             .rev()
+            .take(rectangle_height)
             .enumerate()
             .for_each(|(row_idx, row)| {
                 row.chunks_exact(SRC_COLOR_DEPTH)
+                    .take(rectangle_width)
                     .enumerate()
                     .for_each(|(col_idx, src_pixel)| {
                         let rgb15_value = u16::from_le_bytes(
@@ -660,6 +670,7 @@ impl DecodedImage {
         &mut self,
         bgr24: &[u8],
         update_rectangle: &InclusiveRectangle,
+        source_width: u16,
     ) -> SessionResult<InclusiveRectangle> {
         if !self.rect_fits(update_rectangle) {
             debug!(
@@ -674,6 +685,8 @@ impl DecodedImage {
 
         let image_width = usize::from(self.width);
         let rectangle_width = usize::from(update_rectangle.width());
+        let source_width = usize::from(source_width);
+        let rectangle_height = usize::from(update_rectangle.height());
         let top = usize::from(update_rectangle.top);
         let left = usize::from(update_rectangle.left);
         let [ri, gi, bi, ai] = self.pixel_format.channel_offsets();
@@ -681,11 +694,13 @@ impl DecodedImage {
         let pointer_rendering_state = self.pointer_rendering_begin(update_rectangle)?;
 
         bgr24
-            .chunks_exact(rectangle_width * SRC_COLOR_DEPTH)
+            .chunks_exact(source_width * SRC_COLOR_DEPTH)
             .rev()
+            .take(rectangle_height)
             .enumerate()
             .for_each(|(row_idx, row)| {
                 row.chunks_exact(SRC_COLOR_DEPTH)
+                    .take(rectangle_width)
                     .enumerate()
                     .for_each(|(col_idx, src_pixel)| {
                         let dst_idx = ((top + row_idx) * image_width + left + col_idx) * DST_COLOR_DEPTH;
@@ -710,6 +725,7 @@ impl DecodedImage {
         indexed: &[u8],
         update_rectangle: &InclusiveRectangle,
         palette: &[[u8; 3]; 256],
+        source_width: u16,
     ) -> SessionResult<InclusiveRectangle> {
         if !self.rect_fits(update_rectangle) {
             debug!(
@@ -723,6 +739,8 @@ impl DecodedImage {
 
         let image_width = usize::from(self.width);
         let rectangle_width = usize::from(update_rectangle.width());
+        let source_width = usize::from(source_width);
+        let rectangle_height = usize::from(update_rectangle.height());
         let top = usize::from(update_rectangle.top);
         let left = usize::from(update_rectangle.left);
         let [ri, gi, bi, ai] = self.pixel_format.channel_offsets();
@@ -730,18 +748,22 @@ impl DecodedImage {
         let pointer_rendering_state = self.pointer_rendering_begin(update_rectangle)?;
 
         indexed
-            .chunks_exact(rectangle_width)
+            .chunks_exact(source_width)
             .rev()
+            .take(rectangle_height)
             .enumerate()
             .for_each(|(row_idx, row)| {
-                row.iter().enumerate().for_each(|(col_idx, &index)| {
-                    let dst_idx = ((top + row_idx) * image_width + left + col_idx) * DST_COLOR_DEPTH;
-                    let [r, g, b] = palette[usize::from(index)];
-                    self.data[dst_idx + ri] = r;
-                    self.data[dst_idx + gi] = g;
-                    self.data[dst_idx + bi] = b;
-                    self.data[dst_idx + ai] = 0xff;
-                })
+                row.iter()
+                    .take(rectangle_width)
+                    .enumerate()
+                    .for_each(|(col_idx, &index)| {
+                        let dst_idx = ((top + row_idx) * image_width + left + col_idx) * DST_COLOR_DEPTH;
+                        let [r, g, b] = palette[usize::from(index)];
+                        self.data[dst_idx + ri] = r;
+                        self.data[dst_idx + gi] = g;
+                        self.data[dst_idx + bi] = b;
+                        self.data[dst_idx + ai] = 0xff;
+                    })
             });
 
         let update_rectangle = self.pointer_rendering_end(pointer_rendering_state)?;
@@ -777,6 +799,7 @@ impl DecodedImage {
 
         rgb24.enumerate().for_each(|(row_idx, row)| {
             row.chunks_exact(SRC_COLOR_DEPTH)
+                .take(usize::from(update_rectangle.width()))
                 .enumerate()
                 .for_each(|(col_idx, src_pixel)| {
                     let dst_idx = ((top + row_idx) * image_width + left + col_idx) * DST_COLOR_DEPTH;
@@ -797,15 +820,17 @@ impl DecodedImage {
         &mut self,
         rgb24: &[u8],
         update_rectangle: &InclusiveRectangle,
+        source_width: u16,
         flip: bool,
     ) -> SessionResult<InclusiveRectangle> {
         const SRC_COLOR_DEPTH: usize = 3;
-        let rectangle_width = usize::from(update_rectangle.width());
-        let lines = rgb24.chunks_exact(rectangle_width * SRC_COLOR_DEPTH);
+        let source_width = usize::from(source_width);
+        let rectangle_height = usize::from(update_rectangle.height());
+        let lines = rgb24.chunks_exact(source_width * SRC_COLOR_DEPTH);
         if flip {
-            self.apply_rgb24_iter(lines.rev(), update_rectangle)
+            self.apply_rgb24_iter(lines.rev().take(rectangle_height), update_rectangle)
         } else {
-            self.apply_rgb24_iter(lines, update_rectangle)
+            self.apply_rgb24_iter(lines.take(rectangle_height), update_rectangle)
         }
     }
 
@@ -876,6 +901,7 @@ impl DecodedImage {
         rgb32: &[u8],
         format: PixelFormat,
         update_rectangle: &InclusiveRectangle,
+        source_width: u16,
     ) -> SessionResult<InclusiveRectangle> {
         if !self.rect_fits(update_rectangle) {
             debug!(
@@ -890,6 +916,8 @@ impl DecodedImage {
 
         let image_width = usize::from(self.width);
         let rectangle_width = usize::from(update_rectangle.width());
+        let source_width = usize::from(source_width);
+        let rectangle_height = usize::from(update_rectangle.height());
         let top = usize::from(update_rectangle.top);
         let left = usize::from(update_rectangle.left);
 
@@ -897,11 +925,13 @@ impl DecodedImage {
 
         if format == self.pixel_format {
             rgb32
-                .chunks_exact(rectangle_width * SRC_COLOR_DEPTH)
+                .chunks_exact(source_width * SRC_COLOR_DEPTH)
                 .rev()
+                .take(rectangle_height)
                 .enumerate()
                 .for_each(|(row_idx, row)| {
                     row.chunks_exact(SRC_COLOR_DEPTH)
+                        .take(rectangle_width)
                         .enumerate()
                         .for_each(|(col_idx, src_pixel)| {
                             let dst_idx = ((top + row_idx) * image_width + left + col_idx) * DST_COLOR_DEPTH;
@@ -912,11 +942,13 @@ impl DecodedImage {
         } else {
             let [ri, gi, bi, ai] = self.pixel_format.channel_offsets();
             rgb32
-                .chunks_exact(rectangle_width * SRC_COLOR_DEPTH)
+                .chunks_exact(source_width * SRC_COLOR_DEPTH)
                 .rev()
+                .take(rectangle_height)
                 .enumerate()
                 .try_for_each(|(row_idx, row)| {
                     row.chunks_exact(SRC_COLOR_DEPTH)
+                        .take(rectangle_width)
                         .enumerate()
                         .try_for_each(|(col_idx, src_pixel)| {
                             let dst_idx = ((top + row_idx) * image_width + left + col_idx) * DST_COLOR_DEPTH;
@@ -940,5 +972,67 @@ impl DecodedImage {
         let update_rectangle = self.pointer_rendering_end(pointer_rendering_state)?;
 
         Ok(update_rectangle)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pixel(image: &DecodedImage, x: usize, y: usize) -> [u8; 4] {
+        let offset = (y * usize::from(image.width()) + x) * 4;
+        image.data()[offset..offset + 4]
+            .try_into()
+            .expect("pixel has four channels")
+    }
+
+    #[test]
+    fn bgr_bitmap_crops_source_stride_and_preserves_bottom_up_orientation() {
+        let mut image = DecodedImage::new(PixelFormat::RgbA32, 4, 3);
+        let rectangle = InclusiveRectangle {
+            left: 1,
+            top: 0,
+            right: 2,
+            bottom: 1,
+        };
+
+        // The wire data is bottom-up, with two extra source columns per row.
+        let bgr = [
+            3, 2, 1, 6, 5, 4, 9, 8, 7, 12, 11, 10, // bottom row
+            15, 14, 13, 18, 17, 16, 21, 20, 19, 24, 23, 22, // top row
+        ];
+
+        image.apply_bgr24_bitmap(&bgr, &rectangle, 4).unwrap();
+
+        assert_eq!(pixel(&image, 1, 0), [13, 14, 15, 255]);
+        assert_eq!(pixel(&image, 2, 0), [16, 17, 18, 255]);
+        assert_eq!(pixel(&image, 1, 1), [1, 2, 3, 255]);
+        assert_eq!(pixel(&image, 2, 1), [4, 5, 6, 255]);
+        assert_eq!(pixel(&image, 3, 0), [0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn rgb24_bitmap_crops_source_stride_and_preserves_top_down_orientation() {
+        let mut image = DecodedImage::new(PixelFormat::RgbA32, 4, 3);
+        let rectangle = InclusiveRectangle {
+            left: 1,
+            top: 0,
+            right: 2,
+            bottom: 1,
+        };
+
+        // RDP6 decoding produces row-major RGB data, so no row flip is required.
+        let rgb = [
+            1, 2, 3, 4, 5, 6, 90, 91, 92, 93, 94, 95, // top row
+            13, 14, 15, 16, 17, 18, 96, 97, 98, 99, 100, 101, // bottom row
+        ];
+
+        image.apply_rgb24(&rgb, &rectangle, 4, false).unwrap();
+
+        assert_eq!(pixel(&image, 1, 0), [1, 2, 3, 255]);
+        assert_eq!(pixel(&image, 2, 0), [4, 5, 6, 255]);
+        assert_eq!(pixel(&image, 1, 1), [13, 14, 15, 255]);
+        assert_eq!(pixel(&image, 2, 1), [16, 17, 18, 255]);
+        assert_eq!(pixel(&image, 3, 1), [0, 0, 0, 0]);
     }
 }


### PR DESCRIPTION
## Summary

- Preserve `TS_BITMAP_DATA` source stride independently of destination bounds for raw, Interleaved RLE, and RDP6 bitmap updates.
- Remove raw 4-byte scanline padding without collapsing padded source columns into following rows.
- Crop only the source extent beyond the destination and reject empty dimensions explicitly; do not add framebuffer bounds suppression.
- Render decoded RDP6 RGB data top-down and retain bottom-up rendering for raw and RLE data.

## Why this supersedes the overlapping proposals

- #1252 identifies both dimensions but applies a clipped stride, which still misaddresses padded source rows; its broad framebuffer-clipping changes are intentionally excluded.
- #1398 correctly identifies the RDP6 stride/orientation issue, but leaves raw and RLE paths unresolved.
- #1408 includes the related stride issue but also mixes unrelated Win7 activation and web changes; its allocation/inference normalization is unnecessary once source stride is explicit.
- #1436 correctly crops padded rows but repacks each path into temporary buffers; this PR preserves the source stride directly and covers all bitmap codecs.

## Specification basis

- MS-RDPBCGR 2.2.9.1.1.3.1.2.2 (`TS_BITMAP_DATA`): separate destination bounds, dimensions, and bottom-up raw rows with 4-byte row padding.
- MS-RDPBCGR 2.2.9.1.1.3.1.2.3 and 2.2.9.1.1.3.1.2.4: compressed bitmap header and Interleaved RLE stream.
- MS-RDPEGDI 2.2.2.5.1: RDP 6.0 bitmap stream.

## Validation

- `cargo test -p ironrdp-session --lib`
- `cargo check -p ironrdp-session --all-features`
- `cargo clippy -p ironrdp-session --all-targets -- -D warnings`
- `cargo xtask check fmt -v`