### PR TITLE
refactor(server)!: take auto-detect timestamps from the caller

### DIFF
--- a/crates/ironrdp-server/src/autodetect.rs
+++ b/crates/ironrdp-server/src/autodetect.rs
@@ -7,7 +7,6 @@
 //! [MS-RDPBCGR 2.2.14]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/dc672839-4f4e-40b1-a71c-cd6a959baa38
 
 use std::collections::VecDeque;
-use std::time::Instant;
 
 use ironrdp_pdu::rdp::autodetect::{AutoDetectRequest, AutoDetectResponse};
 
@@ -15,7 +14,7 @@ use ironrdp_pdu::rdp::autodetect::{AutoDetectRequest, AutoDetectResponse};
 const RTT_WINDOW_SIZE: usize = 8;
 
 /// Probes older than this are discarded as unresponsive.
-pub(crate) const RTT_PROBE_MAX_AGE: core::time::Duration = core::time::Duration::from_secs(30);
+pub(crate) const RTT_PROBE_MAX_AGE_MS: u64 = 30_000;
 
 /// Server-side auto-detect state machine.
 ///
@@ -23,9 +22,18 @@ pub(crate) const RTT_PROBE_MAX_AGE: core::time::Duration = core::time::Duration:
 /// client responses. Call [`send_rtt_request()`](Self::send_rtt_request) to
 /// generate a probe, then [`handle_response()`](Self::handle_response) when
 /// the client replies.
+///
+/// The manager reads no clock of its own. Every method that needs the current time
+/// takes `now_ms`, a caller-supplied monotonic millisecond counter whose epoch is
+/// arbitrary as long as it is consistent across calls. Keeping time out of the state
+/// machine makes RTT measurement exactly testable, leaves the type usable from targets
+/// where the standard library has no clock (`std::time::Instant::now` panics on
+/// `wasm32-unknown-unknown`), and keeps the crate a candidate for the no-I/O rules the
+/// Core Tier crates follow.
 pub struct AutoDetectManager {
     next_sequence: u16,
-    pending_probes: Vec<(u16, Instant)>,
+    /// Outstanding probes as `(sequence_number, sent_at_ms)`.
+    pending_probes: Vec<(u16, u64)>,
     rtt_samples: VecDeque<u32>,
 }
 
@@ -41,12 +49,12 @@ impl AutoDetectManager {
     /// Generate an RTT Measure Request PDU for continuous detection.
     ///
     /// The caller must encode and send the returned [`AutoDetectRequest`] as
-    /// a Share Data PDU on the IO channel. Timing information is tracked
-    /// internally by [`AutoDetectManager`].
-    pub fn send_rtt_request(&mut self) -> AutoDetectRequest {
+    /// a Share Data PDU on the IO channel. `now_ms` is recorded as the send time and
+    /// is what [`handle_response()`](Self::handle_response) measures against.
+    pub fn send_rtt_request(&mut self, now_ms: u64) -> AutoDetectRequest {
         let seq = self.next_sequence;
         self.next_sequence = seq.wrapping_add(1);
-        self.pending_probes.push((seq, Instant::now()));
+        self.pending_probes.push((seq, now_ms));
         AutoDetectRequest::rtt_continuous(seq)
     }
 
@@ -54,20 +62,19 @@ impl AutoDetectManager {
     ///
     /// Returns the measured RTT in milliseconds if the sequence number
     /// matches an outstanding probe, or `None` if it was unexpected.
-    #[expect(
-        clippy::as_conversions,
-        clippy::cast_possible_truncation,
-        reason = "RTT in ms fits in u32 for any plausible network latency"
-    )]
-    pub fn handle_response(&mut self, response: &AutoDetectResponse) -> Option<u32> {
+    /// `now_ms` is the receipt time on the same clock passed to
+    /// [`send_rtt_request()`](Self::send_rtt_request).
+    pub fn handle_response(&mut self, response: &AutoDetectResponse, now_ms: u64) -> Option<u32> {
         let AutoDetectResponse::RttResponse { sequence_number } = response else {
             return None;
         };
 
         let idx = self.pending_probes.iter().position(|(s, _)| *s == *sequence_number)?;
-        let (_, sent_at) = self.pending_probes.remove(idx);
+        let (_, sent_at_ms) = self.pending_probes.remove(idx);
 
-        let rtt_ms = sent_at.elapsed().as_millis() as u32;
+        // Saturating rather than wrapping: a caller whose clock went backwards gets a
+        // zero sample, not a nonsense one near u32::MAX.
+        let rtt_ms = u32::try_from(now_ms.saturating_sub(sent_at_ms)).unwrap_or(u32::MAX);
 
         if self.rtt_samples.len() >= RTT_WINDOW_SIZE {
             self.rtt_samples.pop_front();
@@ -106,9 +113,13 @@ impl AutoDetectManager {
         self.pending_probes.len()
     }
 
-    /// Discard probes older than the given threshold to prevent unbounded growth.
-    pub fn expire_stale_probes(&mut self, max_age: core::time::Duration) {
-        self.pending_probes.retain(|(_, sent_at)| sent_at.elapsed() < max_age);
+    /// Discard probes older than `max_age_ms` to prevent unbounded growth.
+    ///
+    /// `now_ms` is on the same clock passed to
+    /// [`send_rtt_request()`](Self::send_rtt_request).
+    pub fn expire_stale_probes(&mut self, now_ms: u64, max_age_ms: u64) {
+        self.pending_probes
+            .retain(|(_, sent_at_ms)| now_ms.saturating_sub(*sent_at_ms) < max_age_ms);
     }
 }
 
@@ -138,8 +149,8 @@ mod tests {
     #[test]
     fn rtt_request_increments_sequence() {
         let mut mgr = AutoDetectManager::new();
-        let req1 = mgr.send_rtt_request();
-        let req2 = mgr.send_rtt_request();
+        let req1 = mgr.send_rtt_request(0);
+        let req2 = mgr.send_rtt_request(0);
         assert_eq!(req1.sequence_number(), 0);
         assert_eq!(req2.sequence_number(), 1);
         assert_eq!(mgr.pending_count(), 2);
@@ -148,23 +159,24 @@ mod tests {
     #[test]
     fn rtt_response_computes_latency() {
         let mut mgr = AutoDetectManager::new();
-        let req = mgr.send_rtt_request();
+        let req = mgr.send_rtt_request(0);
 
         let response = AutoDetectResponse::RttResponse {
             sequence_number: req.sequence_number(),
         };
-        let rtt = mgr.handle_response(&response);
-        assert!(rtt.is_some(), "should match the outstanding probe");
+        // Both timestamps come from the caller, so the measurement is exact rather than
+        // dependent on how fast the test happens to run.
+        assert_eq!(mgr.handle_response(&response, 20), Some(20));
         assert_eq!(mgr.pending_count(), 0);
     }
 
     #[test]
     fn unknown_sequence_returns_none() {
         let mut mgr = AutoDetectManager::new();
-        let _ = mgr.send_rtt_request();
+        let _ = mgr.send_rtt_request(0);
 
         let response = AutoDetectResponse::RttResponse { sequence_number: 999 };
-        assert!(mgr.handle_response(&response).is_none());
+        assert!(mgr.handle_response(&response, 20).is_none());
         assert_eq!(mgr.pending_count(), 1, "original probe should remain");
     }
 
@@ -178,37 +190,86 @@ mod tests {
     fn snapshot_reflects_measurements() {
         let mut mgr = AutoDetectManager::new();
 
-        for _ in 0..3 {
-            let req = mgr.send_rtt_request();
+        for (sent_at, rtt) in [(0u64, 10u64), (100, 20), (200, 30)] {
+            let req = mgr.send_rtt_request(sent_at);
             let response = AutoDetectResponse::RttResponse {
                 sequence_number: req.sequence_number(),
             };
-            let _ = mgr.handle_response(&response);
+            let _ = mgr.handle_response(&response, sent_at + rtt);
         }
 
         let snap = mgr.snapshot().expect("should have data after 3 measurements");
         assert_eq!(snap.sample_count, 3);
-        assert!(snap.avg_ms < 100);
+        assert_eq!(snap.min_ms, 10);
+        assert_eq!(snap.max_ms, 30);
+        assert_eq!(snap.avg_ms, 20);
+    }
+
+    /// A caller whose clock ran backwards between the request and the response must
+    /// produce a zero sample. Wrapping subtraction here would yield a value near
+    /// `u32::MAX` and poison every statistic drawn from the window.
+    #[test]
+    fn backwards_clock_yields_a_zero_sample() {
+        let mut mgr = AutoDetectManager::new();
+        let req = mgr.send_rtt_request(1000);
+
+        let response = AutoDetectResponse::RttResponse {
+            sequence_number: req.sequence_number(),
+        };
+        assert_eq!(mgr.handle_response(&response, 400), Some(0));
+
+        // The zero has to reach the window, not just the return value, since the
+        // snapshot is what the peer eventually sees.
+        let snap = mgr.snapshot().expect("one measurement was recorded");
+        assert_eq!(snap.min_ms, 0);
+        assert_eq!(snap.max_ms, 0);
+        assert_eq!(snap.avg_ms, 0);
+    }
+
+    /// The same backwards clock reaches expiry, where the saturation has the opposite
+    /// shape: an age of zero is below any maximum, so the probe stays pending.
+    /// Wrapping subtraction would make it look older than any limit and drop a probe
+    /// whose response is still in flight.
+    #[test]
+    fn backwards_clock_keeps_the_probe_pending() {
+        let mut mgr = AutoDetectManager::new();
+        let _ = mgr.send_rtt_request(1000);
+
+        mgr.expire_stale_probes(400, 100);
+        assert_eq!(mgr.pending_count(), 1, "a probe from the future is not stale");
+    }
+
+    /// A gap wider than `u32::MAX` milliseconds (about 49.7 days) clamps rather than
+    /// truncating to the low 32 bits, which would report a small RTT for an enormous one.
+    #[test]
+    fn an_enormous_gap_clamps_to_u32_max() {
+        let mut mgr = AutoDetectManager::new();
+        let req = mgr.send_rtt_request(0);
+
+        let response = AutoDetectResponse::RttResponse {
+            sequence_number: req.sequence_number(),
+        };
+        assert_eq!(mgr.handle_response(&response, u64::from(u32::MAX) + 1), Some(u32::MAX));
     }
 
     #[test]
     fn sequence_number_wraps() {
         let mut mgr = AutoDetectManager::new();
         mgr.next_sequence = u16::MAX;
-        let req = mgr.send_rtt_request();
+        let req = mgr.send_rtt_request(0);
         assert_eq!(req.sequence_number(), u16::MAX);
 
-        let req2 = mgr.send_rtt_request();
+        let req2 = mgr.send_rtt_request(0);
         assert_eq!(req2.sequence_number(), 0, "should wrap around");
     }
 
     #[test]
     fn stale_probe_expiry() {
         let mut mgr = AutoDetectManager::new();
-        let _ = mgr.send_rtt_request();
+        let _ = mgr.send_rtt_request(0);
         assert_eq!(mgr.pending_count(), 1);
 
-        mgr.expire_stale_probes(core::time::Duration::ZERO);
+        mgr.expire_stale_probes(1, 0);
         assert_eq!(mgr.pending_count(), 0);
     }
 }

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -4,6 +4,8 @@ use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use core::time::Duration;
 use std::rc::Rc;
 use std::sync::Arc;
+use std::sync::LazyLock;
+use std::time::Instant;
 
 use anyhow::{Context as _, Result, bail};
 use hmac::{Hmac, Mac as _};
@@ -53,6 +55,16 @@ const AUTO_RECONNECT_COOKIE_UPDATE_INTERVAL: Duration = Duration::from_secs(60 *
 const AUTO_RECONNECT_CLIENT_RANDOM: [u8; 32] = [0; 32];
 
 type HmacMd5 = Hmac<Md5>;
+
+/// Monotonic milliseconds since first use, for feeding the auto-detect state machine.
+///
+/// The clock lives here, in the I/O driver, rather than inside [`AutoDetectManager`]:
+/// the state machine takes timestamps as arguments so it stays free of ambient time.
+/// Only differences are meaningful, so the epoch is arbitrary.
+fn monotonic_now_ms() -> u64 {
+    static EPOCH: LazyLock<Instant> = LazyLock::new(Instant::now);
+    u64::try_from(EPOCH.elapsed().as_millis()).unwrap_or(u64::MAX)
+}
 
 /// Action to take after a client disconnects.
 ///
@@ -1456,8 +1468,9 @@ impl RdpServer {
                     // ([MS-RDPBCGR] 2.2.14.3). With none negotiated (the client
                     // did not request it), there is nowhere to send them.
                     if let (Some(ad), Some(message_channel_id)) = (self.autodetect.as_mut(), message_channel_id) {
-                        ad.expire_stale_probes(crate::autodetect::RTT_PROBE_MAX_AGE);
-                        let request = ad.send_rtt_request();
+                        let now_ms = monotonic_now_ms();
+                        ad.expire_stale_probes(now_ms, crate::autodetect::RTT_PROBE_MAX_AGE_MS);
+                        let request = ad.send_rtt_request(now_ms);
                         let data = encode_autodetect_request(request, message_channel_id, user_channel_id)?;
                         writer.write_all(&data).await?;
                     }
@@ -1911,7 +1924,7 @@ impl RdpServer {
         match decode::<rdp::autodetect::AutoDetectRspPdu>(data.user_data.as_ref()) {
             Ok(pdu) => {
                 if let Some(ref mut ad) = self.autodetect {
-                    if let Some(rtt_ms) = ad.handle_response(&pdu.response) {
+                    if let Some(rtt_ms) = ad.handle_response(&pdu.response, monotonic_now_ms()) {
                         self.autodetect_rtt.store(rtt_ms, Ordering::Relaxed);
                         debug!(rtt_ms, seq = pdu.response.sequence_number(), "RTT measured");
                     } else {

--- a/crates/ironrdp-testsuite-core/tests/server/autodetect.rs
+++ b/crates/ironrdp-testsuite-core/tests/server/autodetect.rs
@@ -4,8 +4,8 @@ use ironrdp_server::autodetect::AutoDetectManager;
 #[test]
 fn rtt_request_increments_sequence() {
     let mut mgr = AutoDetectManager::new();
-    let req1 = mgr.send_rtt_request();
-    let req2 = mgr.send_rtt_request();
+    let req1 = mgr.send_rtt_request(0);
+    let req2 = mgr.send_rtt_request(0);
     assert_eq!(req1.sequence_number(), 0);
     assert_eq!(req2.sequence_number(), 1);
     assert_eq!(mgr.pending_count(), 2);
@@ -14,23 +14,24 @@ fn rtt_request_increments_sequence() {
 #[test]
 fn rtt_response_returns_latency() {
     let mut mgr = AutoDetectManager::new();
-    let req = mgr.send_rtt_request();
+    let req = mgr.send_rtt_request(0);
 
     let response = AutoDetectResponse::RttResponse {
         sequence_number: req.sequence_number(),
     };
-    let rtt = mgr.handle_response(&response);
-    assert!(rtt.is_some(), "should match the outstanding probe");
+    // Both timestamps come from the caller, so the measurement is exact rather than
+    // dependent on how fast the test happens to run.
+    assert_eq!(mgr.handle_response(&response, 20), Some(20));
     assert_eq!(mgr.pending_count(), 0);
 }
 
 #[test]
 fn unknown_sequence_returns_none() {
     let mut mgr = AutoDetectManager::new();
-    let _ = mgr.send_rtt_request();
+    let _ = mgr.send_rtt_request(0);
 
     let response = AutoDetectResponse::RttResponse { sequence_number: 999 };
-    assert!(mgr.handle_response(&response).is_none());
+    assert!(mgr.handle_response(&response, 20).is_none());
     assert_eq!(mgr.pending_count(), 1, "original probe should remain");
 }
 
@@ -44,18 +45,19 @@ fn snapshot_none_without_measurements() {
 fn snapshot_reflects_measurements() {
     let mut mgr = AutoDetectManager::new();
 
-    for _ in 0..3 {
-        let req = mgr.send_rtt_request();
+    for (sent_at, rtt) in [(0u64, 10u64), (100, 20), (200, 30)] {
+        let req = mgr.send_rtt_request(sent_at);
         let response = AutoDetectResponse::RttResponse {
             sequence_number: req.sequence_number(),
         };
-        let _ = mgr.handle_response(&response);
+        let _ = mgr.handle_response(&response, sent_at + rtt);
     }
 
     let snap = mgr.snapshot().expect("should have data");
     assert_eq!(snap.sample_count, 3);
-    // RTT should be ~0ms (same-process send/receive)
-    assert!(snap.avg_ms < 100);
+    assert_eq!(snap.min_ms, 10);
+    assert_eq!(snap.max_ms, 30);
+    assert_eq!(snap.avg_ms, 20);
 }
 
 #[test]
@@ -64,16 +66,16 @@ fn sequence_number_wraps_at_u16_max() {
     // Advance sequence counter through all values, resolving each probe immediately
     // to avoid growing pending_probes to 65k entries.
     for _ in 0..u16::MAX {
-        let req = mgr.send_rtt_request();
+        let req = mgr.send_rtt_request(0);
         let response = AutoDetectResponse::RttResponse {
             sequence_number: req.sequence_number(),
         };
-        let _ = mgr.handle_response(&response);
+        let _ = mgr.handle_response(&response, 20);
     }
-    let req = mgr.send_rtt_request();
+    let req = mgr.send_rtt_request(0);
     assert_eq!(req.sequence_number(), u16::MAX);
 
-    let req2 = mgr.send_rtt_request();
+    let req2 = mgr.send_rtt_request(0);
     assert_eq!(req2.sequence_number(), 0, "should wrap around");
 }
 
@@ -122,9 +124,9 @@ fn with_autodetect_rtt_handle_round_trips_the_same_arc() {
 #[test]
 fn stale_probe_expiry() {
     let mut mgr = AutoDetectManager::new();
-    let _ = mgr.send_rtt_request();
+    let _ = mgr.send_rtt_request(0);
     assert_eq!(mgr.pending_count(), 1);
 
-    mgr.expire_stale_probes(core::time::Duration::ZERO);
+    mgr.expire_stale_probes(1, 0);
     assert_eq!(mgr.pending_count(), 0);
 }


### PR DESCRIPTION
## Summary

- `AutoDetectManager` read the clock itself: `std::time::Instant` in `pending_probes`, `Instant::now()` in `send_rtt_request`, and `Instant::elapsed()` in `handle_response` and `expire_stale_probes`.
- It now takes `now_ms`, a caller-supplied monotonic millisecond counter whose epoch is arbitrary as long as it's consistent across calls. `ironrdp-server` supplies it from a process-wide monotonic origin in `server.rs`, so the clock lives in the I/O driver rather than in the state machine.

## Why

- **Testability.** The RTT assertions were wall-clock dependent. `snapshot_reflects_measurements` could only check that the average came out under an arbitrary 100 ms bound, which almost any bug would satisfy. It now supplies both timestamps and asserts exact values: samples of 10, 20 and 30 ms giving min 10, max 30, average 20.
- **Portability.** `std::time::Instant::now` panics on `wasm32-unknown-unknown`, so a type that reads it internally can't be reused from a WASM build.
- **Layering.** A state machine that reads ambient time can't satisfy the no-I/O rule the Core Tier crates follow, which forecloses moving this code in that direction later.

Also covers the edges of the arithmetic the injected clock exposes. There are two `saturating_sub` sites and they saturate in opposite directions:

- `handle_response`: a clock that ran backwards between request and response yields a zero sample rather than a wrapped value near `u32::MAX`, and the zero reaches the sample window, not just the return value.
- `expire_stale_probes`: the same backwards clock makes the age zero, which is below any maximum, so the probe stays pending. Wrapping would make it look older than any limit and drop a probe whose response is still in flight.

A third test covers the `u32::try_from(..).unwrap_or(u32::MAX)` on the first of those lines, where a gap wider than about 49.7 days clamps rather than truncating to the low 32 bits.

## Validation

`cargo xtask check fmt/lints/tests/typos/locks` all pass.

Each of the three new tests was checked against a mutation of the code it guards rather than only for passing: the two backwards-clock tests fail if either `saturating_sub` becomes `wrapping_sub`, and the clamp test fails if the `try_from` becomes a truncating `as u32`, which reports `Some(0)` for a 49.7 day gap.

## Notes

- Came out of the discussion on #1465, where the same question arises on the connector side. `ironrdp-connector` reads no clock at all today, and answering a connect-time Bandwidth Measure properly needs one; taking the timestamp from the caller is the shape that works on every target.
- `AutoDetectManager` arrived in #1177 with the internal clock, so this corrects code I wrote rather than anyone else's.

BREAKING CHANGE: `AutoDetectManager::send_rtt_request` now takes `now_ms`; `handle_response` takes `now_ms`; `expire_stale_probes` takes `now_ms` and a `max_age_ms` `u64` instead of a `core::time::Duration`. The `RTT_PROBE_MAX_AGE` constant is now `RTT_PROBE_MAX_AGE_MS`, a `u64` of milliseconds.

## Two PRs are stacked on this

#1470 and #1471 are built on this branch and cannot merge before it. The merge order is this PR, then #1470, then #1471.

This is also where the stack's breaking-change marker lives. The `!` here covers the arity changes to `AutoDetectManager::send_rtt_request` and `handle_response`; `cargo semver-checks` attributes both to this PR and reports no further update required for either of the two above when baselined against it.

## Rebased

Rebased onto `master` on 2026-08-02 as one `--update-refs` operation with the rest of the stack, so the checks run against the current tree rather than the state before that day's merges. No conflicts, no content change. All five gates green on this head independently, not only at the stack tip.
