### PR TITLE
feat(connector): expose the server's Input capability flags on ConnectionResult

### DIFF
--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -972,6 +972,7 @@ async fn active_session(
                         if let ConnectionActivationState::Finalized {
                             desktop_size,
                             share_id,
+                            input_flags: _,
                             enable_server_pointer,
                             pointer_software_rendering,
                         } = connection_activation.connection_activation_state()

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -28,6 +28,16 @@ pub struct ConnectionResult {
     pub share_id: u32,
     pub static_channels: StaticChannelSet,
     pub desktop_size: DesktopSize,
+    /// The server's Input capability flags from the Server Demand Active PDU.
+    ///
+    /// Per [MS-RDPBCGR] 2.2.8.1.2, fast-path input events may only be sent when
+    /// `INPUT_FLAG_FASTPATH_INPUT` or `INPUT_FLAG_FASTPATH_INPUT2` is present; some
+    /// servers (e.g. VirtualBox VRDP) close the connection on unsolicited fast-path
+    /// input, so clients should fall back to slow-path input PDUs when neither flag
+    /// is set.
+    ///
+    /// [MS-RDPBCGR]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/b8e7c588-51cb-455b-bb73-92d480903133
+    pub input_flags: rdp::capability_sets::InputFlags,
     pub enable_server_pointer: bool,
     pub pointer_software_rendering: bool,
     /// Factory for producing connection activation sequences.
@@ -689,6 +699,7 @@ impl Sequence for ClientConnector {
                         ConnectionActivationState::Finalized {
                             desktop_size,
                             share_id,
+                            input_flags,
                             enable_server_pointer,
                             pointer_software_rendering,
                         } => ClientConnectorState::Connected {
@@ -699,6 +710,7 @@ impl Sequence for ClientConnector {
                                 share_id,
                                 static_channels: mem::take(&mut self.static_channels),
                                 desktop_size,
+                                input_flags,
                                 enable_server_pointer,
                                 pointer_software_rendering,
                                 activation_factory: ConnectionActivationFactory::new(

--- a/crates/ironrdp-connector/src/connection_activation.rs
+++ b/crates/ironrdp-connector/src/connection_activation.rs
@@ -1,7 +1,7 @@
 use core::mem;
 
 use ironrdp_pdu::rdp;
-use ironrdp_pdu::rdp::capability_sets::CapabilitySet;
+use ironrdp_pdu::rdp::capability_sets::{CapabilitySet, InputFlags};
 use tracing::{debug, warn};
 
 use crate::{
@@ -211,6 +211,19 @@ impl Sequence for ConnectionActivationSequence {
                     }
                 }
 
+                // Keep the server's Input capability flags so the session layer can tell whether
+                // fast-path input was negotiated: per [MS-RDPBCGR] 2.2.8.1.2, the client MUST NOT
+                // send fast-path input events unless the server advertised
+                // `INPUT_FLAG_FASTPATH_INPUT` or `INPUT_FLAG_FASTPATH_INPUT2`. Servers that omit
+                // both (e.g. VirtualBox VRDP) may reject fast-path input PDUs outright.
+                let input_flags = capability_sets
+                    .iter()
+                    .find_map(|c| match c {
+                        CapabilitySet::Input(i) => Some(i.input_flags),
+                        _ => None,
+                    })
+                    .unwrap_or_else(InputFlags::empty);
+
                 // At this point we have already sent a requested desktop size to the server -- either as a part of the
                 // [`TS_UD_CS_CORE`] (on initial connection) or the [`DISPLAYCONTROL_MONITOR_LAYOUT`] (on resize event).
                 //
@@ -256,6 +269,7 @@ impl Sequence for ConnectionActivationSequence {
                     ConnectionActivationState::ConnectionFinalization {
                         desktop_size,
                         share_id,
+                        input_flags,
                         connection_finalization: ConnectionFinalizationSequence::new(
                             self.io_channel_id,
                             self.user_channel_id,
@@ -267,6 +281,7 @@ impl Sequence for ConnectionActivationSequence {
             ConnectionActivationState::ConnectionFinalization {
                 desktop_size,
                 share_id,
+                input_flags,
                 mut connection_finalization,
             } => {
                 debug!("Connection Finalization");
@@ -277,12 +292,14 @@ impl Sequence for ConnectionActivationSequence {
                     ConnectionActivationState::ConnectionFinalization {
                         desktop_size,
                         share_id,
+                        input_flags,
                         connection_finalization,
                     }
                 } else {
                     ConnectionActivationState::Finalized {
                         desktop_size,
                         share_id,
+                        input_flags,
                         enable_server_pointer: self.config.enable_server_pointer,
                         pointer_software_rendering: self.config.pointer_software_rendering,
                     }
@@ -306,11 +323,20 @@ pub enum ConnectionActivationState {
     ConnectionFinalization {
         desktop_size: DesktopSize,
         share_id: u32,
+        /// The server's Input capability flags from the Server Demand Active PDU.
+        input_flags: InputFlags,
         connection_finalization: ConnectionFinalizationSequence,
     },
     Finalized {
         desktop_size: DesktopSize,
         share_id: u32,
+        /// The server's Input capability flags from the Server Demand Active PDU.
+        ///
+        /// Per [MS-RDPBCGR] 2.2.8.1.2, fast-path input events may only be sent when
+        /// `INPUT_FLAG_FASTPATH_INPUT` or `INPUT_FLAG_FASTPATH_INPUT2` is present.
+        ///
+        /// [MS-RDPBCGR]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/b8e7c588-51cb-455b-bb73-92d480903133
+        input_flags: InputFlags,
         enable_server_pointer: bool,
         pointer_software_rendering: bool,
     },
@@ -345,7 +371,7 @@ fn create_client_confirm_active(
     use ironrdp_pdu::rdp::capability_sets::{
         BITMAP_CACHE_ENTRIES_NUM, Bitmap, BitmapCache, BitmapDrawingFlags, Brush, CacheDefinition, CacheEntry,
         ClientConfirmActive, CmdFlags, DemandActive, FrameAcknowledge, GLYPH_CACHE_NUM, General, GeneralExtraFlags,
-        GlyphCache, GlyphSupportLevel, Input, InputFlags, LargePointer, LargePointerSupportFlags, MultifragmentUpdate,
+        GlyphCache, GlyphSupportLevel, Input, LargePointer, LargePointerSupportFlags, MultifragmentUpdate,
         OffscreenBitmapCache, Order, OrderFlags, OrderSupportExFlags, Pointer, SERVER_CHANNEL_ID, Sound, SoundFlags,
         SupportLevel, SurfaceCommands, VirtualChannel, VirtualChannelFlags, client_codecs_capabilities,
     };

--- a/crates/ironrdp-testsuite-core/tests/session/connection_activation.rs
+++ b/crates/ironrdp-testsuite-core/tests/session/connection_activation.rs
@@ -211,3 +211,51 @@ fn demand_active_after_deactivate_all_transitions_to_connection_finalization() {
         "state should transition to ConnectionFinalization after DemandActive"
     );
 }
+
+#[test]
+fn demand_active_captures_server_input_flags() {
+    use ironrdp_pdu::rdp::capability_sets::InputFlags;
+
+    let config = test_config();
+    let mut seq = ConnectionActivationSequence::new(config, IO_CHANNEL_ID, USER_CHANNEL_ID);
+    let mut output = WriteBuf::new();
+
+    let frame = encode_server_share_control(ShareControlPdu::ServerDemandActive(SERVER_DEMAND_ACTIVE.clone()));
+    seq.step(&frame, &mut output).unwrap();
+
+    match seq.connection_activation_state() {
+        ConnectionActivationState::ConnectionFinalization { input_flags, .. } => {
+            assert_eq!(
+                input_flags,
+                InputFlags::SCANCODES | InputFlags::MOUSEX | InputFlags::UNICODE | InputFlags::FASTPATH_INPUT_2,
+                "input_flags should mirror the Input capability in the Server Demand Active"
+            );
+        }
+        other => panic!("expected ConnectionFinalization, got: {other:?}"),
+    }
+}
+
+#[test]
+fn demand_active_without_input_capability_yields_empty_input_flags() {
+    use ironrdp_pdu::rdp::capability_sets::{CapabilitySet, InputFlags};
+
+    let config = test_config();
+    let mut seq = ConnectionActivationSequence::new(config, IO_CHANNEL_ID, USER_CHANNEL_ID);
+    let mut output = WriteBuf::new();
+
+    let mut demand_active = SERVER_DEMAND_ACTIVE.clone();
+    demand_active
+        .pdu
+        .capability_sets
+        .retain(|c| !matches!(c, CapabilitySet::Input(_)));
+
+    let frame = encode_server_share_control(ShareControlPdu::ServerDemandActive(demand_active));
+    seq.step(&frame, &mut output).unwrap();
+
+    match seq.connection_activation_state() {
+        ConnectionActivationState::ConnectionFinalization { input_flags, .. } => {
+            assert_eq!(input_flags, InputFlags::empty());
+        }
+        other => panic!("expected ConnectionFinalization, got: {other:?}"),
+    }
+}

--- a/crates/ironrdp-testsuite-extra/tests/e2e.rs
+++ b/crates/ironrdp-testsuite-extra/tests/e2e.rs
@@ -100,6 +100,7 @@ async fn test_deactivation_reactivation() {
                             if let connector::connection_activation::ConnectionActivationState::Finalized {
                                 desktop_size,
                                 share_id,
+                                input_flags: _,
                                 enable_server_pointer,
                                 pointer_software_rendering,
                             } = connection_activation.connection_activation_state()

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -1027,6 +1027,7 @@ impl iron_remote_desktop::Session for Session {
                             if let ConnectionActivationState::Finalized {
                                 desktop_size,
                                 share_id,
+                                input_flags: _,
                                 enable_server_pointer,
                                 pointer_software_rendering,
                             } = connection_activation.connection_activation_state()

--- a/ffi/src/connector/activation.rs
+++ b/ffi/src/connector/activation.rs
@@ -82,6 +82,7 @@ pub mod ffi {
                 ironrdp::connector::connection_activation::ConnectionActivationState::ConnectionFinalization {
                     desktop_size,
                     share_id: _,
+                    input_flags: _,
                     connection_finalization,
                 } => Ok(Box::new(ConnectionActivationStateConnectionFinalization {
                     desktop_size,
@@ -98,6 +99,7 @@ pub mod ffi {
                 ironrdp::connector::connection_activation::ConnectionActivationState::Finalized {
                     desktop_size,
                     share_id,
+                    input_flags: _,
                     enable_server_pointer,
                     pointer_software_rendering,
                 } => Ok(Box::new(ConnectionActivationStateFinalized {


### PR DESCRIPTION
Per [MS-RDPBCGR] 2.2.8.1.2, a client must not send fast-path input events unless the server advertised `INPUT_FLAG_FASTPATH_INPUT` or `INPUT_FLAG_FASTPATH_INPUT2` in its Input Capability Set. Today the connector discards the server's capability sets after Demand Active, so client code has no way to honour that requirement.

This PR captures the server's Input capability flags during capabilities exchange, carries them through the `ConnectionFinalization`/`Finalized` activation states (so they are refreshed correctly across a Deactivation-Reactivation Sequence too), and surfaces them as `ConnectionResult::input_flags`. The session layer can then choose between fast-path and slow-path input per server.

### Motivation / real-world interop

This is not theoretical: VirtualBox's VRDP server closes the connection outright on receiving a fast-path input PDU — its `VBox.log` reports

```
VRDP: Network packet length is incorrect 0x0004. Closing connection.
```

(a single fast-path scancode event is a 4-byte packet). VirtualBox never advertises fast-path input; its Demand Active offers `InputFlags(SCANCODES)` alone. mstsc and FreeRDP honour the negotiation and fall back to slow-path `TS_INPUT_PDU`s, which is why they work against VRDE.

Haven (Android RDP client built on IronRDP) has been shipping this exact change as a vendored-connector patch since v5.86.1, with the slow-path fallback keyed off `ConnectionResult::input_flags`. Verified against a real VirtualBox 7.2.6 VRDE server: before the gate, the first arrow-key press killed the session with the log line above; with the gate, extended input sessions run clean, and a fast-path-capable server on the same host still takes the fast-path branch. (Discussed in #1158; this is the third and last piece Haven carries in its connector fork, alongside #1237 and #1472.)

### Changes

- `connection_activation.rs`: capture `input_flags` from the `CapabilitySet::Input` in Server Demand Active (empty if absent); add the field to `ConnectionActivationState::{ConnectionFinalization, Finalized}`.
- `connection.rs`: add `ConnectionResult::input_flags`, populated from the `Finalized` state.
- Call sites in `ironrdp-client`, `ironrdp-web`, ffi, and the e2e test updated for the new variant field (all currently ignore it).

### Testing

- Two new integration tests in `ironrdp-testsuite-core/tests/session/connection_activation.rs`: the fixture's Demand Active yields `SCANCODES | MOUSEX | UNICODE | FASTPATH_INPUT_2` in the `ConnectionFinalization` state, and a Demand Active with the Input capability stripped yields `InputFlags::empty()`.
- `cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets`, and `cargo fmt --check` are clean; the 7 activation tests pass.
