### PR TITLE
fix(pdu): key auto-detect optional fields off requestType, not the Option

### DIFF
--- a/crates/ironrdp-pdu/src/rdp/autodetect.rs
+++ b/crates/ironrdp-pdu/src/rdp/autodetect.rs
@@ -305,7 +305,14 @@ impl Encode for AutoDetectRequest {
                 request_type,
                 payload,
             } => {
-                if let Some(data) = payload {
+                // Whether the payload fields appear on the wire is decided by
+                // `requestType`, not by whether a payload was supplied: MS-RDPBCGR
+                // 2.2.14.1.4 puts `payloadLength` and `payload` on the connect-time stop
+                // and on no other. Branching on the `Option` let this disagree with the
+                // decoder, which reads those fields back for `BW_STOP_CONNECT_TIME` and
+                // never for the UDP variants.
+                if *request_type == BW_STOP_CONNECT_TIME {
+                    let data = payload.as_deref().unwrap_or(&[]);
                     dst.write_u8(0x08); // headerLength (with payload)
                     dst.write_u8(TYPE_ID_AUTODETECT_REQUEST);
                     dst.write_u16(*sequence_number);
@@ -361,10 +368,16 @@ impl Encode for AutoDetectRequest {
                 HEADER_MIN_SIZE + 2 /* payloadLength */ + payload.len()
             }
 
-            Self::BandwidthMeasureStop { payload, .. } => match payload {
-                Some(data) => HEADER_MIN_SIZE + 2 /* payloadLength */ + data.len(),
-                None => HEADER_MIN_SIZE,
-            },
+            // Mirrors `encode`: the payload fields are keyed off `requestType`.
+            Self::BandwidthMeasureStop {
+                request_type, payload, ..
+            } => {
+                if *request_type == BW_STOP_CONNECT_TIME {
+                    HEADER_MIN_SIZE + 2 /* payloadLength */ + payload.as_ref().map_or(0, Vec::len)
+                } else {
+                    HEADER_MIN_SIZE
+                }
+            }
 
             Self::NetworkCharacteristicsResult {
                 base_rtt_ms,

--- a/crates/ironrdp-pdu/src/rdp/autodetect.rs
+++ b/crates/ironrdp-pdu/src/rdp/autodetect.rs
@@ -84,6 +84,20 @@ pub const BW_STOP_RELIABLE_UDP: u16 = 0x0429;
 /// Bandwidth Measure Stop for continuous detection over lossy UDP.
 pub const BW_STOP_LOSSY_UDP: u16 = 0x0629;
 
+/// Which optional fields a Network Characteristics Result carries, as
+/// `(baseRTT, bandwidth)`.
+///
+/// [MS-RDPBCGR] 2.2.14.1.5 assigns these by `requestType` alone, so encode,
+/// `size` and decode all consult this rather than inspecting the values.
+fn netchar_fields(request_type: u16) -> (bool, bool) {
+    match request_type {
+        NETCHAR_RESULT_RTT => (true, false),
+        NETCHAR_RESULT_BW_RTT => (false, true),
+        NETCHAR_RESULT_ALL => (true, true),
+        _ => (false, false),
+    }
+}
+
 /// Network Characteristics Result: baseRTT + averageRTT (no bandwidth).
 ///
 /// [\[MS-RDPBCGR\] 2.2.14.1.5]
@@ -223,6 +237,11 @@ impl AutoDetectRequest {
     }
 
     /// Construct a Bandwidth Measure Stop for connect-time detection.
+    ///
+    /// `payload` must be non-empty: [MS-RDPBCGR] 2.2.14.1.4 requires `payloadLength`
+    /// to be greater than zero for this request type, so an empty one has no
+    /// conforming encoding and is refused by [`Encode`] rather than written as a
+    /// zero length.
     pub fn bw_stop_connect_time(sequence_number: u16, payload: Vec<u8>) -> Self {
         Self::BandwidthMeasureStop {
             sequence_number,
@@ -312,7 +331,17 @@ impl Encode for AutoDetectRequest {
                 // decoder, which reads those fields back for `BW_STOP_CONNECT_TIME` and
                 // never for the UDP variants.
                 if *request_type == BW_STOP_CONNECT_TIME {
+                    // 2.2.14.1.4 does not merely make `payloadLength` present for the
+                    // connect-time stop, it requires a value "greater than zero". An
+                    // absent or empty payload has no conforming encoding, so it is
+                    // refused rather than written as a zero length.
                     let data = payload.as_deref().unwrap_or(&[]);
+                    if data.is_empty() {
+                        return Err(invalid_field_err!(
+                            "payload",
+                            "connect-time Bandwidth Measure Stop requires a non-empty payload"
+                        ));
+                    }
                     dst.write_u8(0x08); // headerLength (with payload)
                     dst.write_u8(TYPE_ID_AUTODETECT_REQUEST);
                     dst.write_u16(*sequence_number);
@@ -343,11 +372,26 @@ impl Encode for AutoDetectRequest {
                 dst.write_u16(*sequence_number);
                 dst.write_u16(*request_type);
 
-                if let Some(rtt) = base_rtt_ms {
-                    dst.write_u32(*rtt);
+                // Same rule as the stop above: which fields appear is decided by
+                // `requestType`, not by which `Option`s happen to be set. MS-RDPBCGR
+                // 2.2.14.1.5 assigns 0x0840 baseRTT + averageRTT, 0x0880 bandwidth +
+                // averageRTT, and 0x08C0 all three, and the decoder reads them back on
+                // exactly that basis. Branching on the `Option`s let the two disagree:
+                // a `NETCHAR_RESULT_RTT` with no `base_rtt_ms` wrote a body the decoder
+                // could not read, and one carrying `bandwidth_kbps` instead wrote the
+                // bandwidth where the decoder expects baseRTT, corrupting it silently.
+                let (want_base_rtt, want_bandwidth) = netchar_fields(*request_type);
+                if want_base_rtt {
+                    dst.write_u32(
+                        base_rtt_ms
+                            .ok_or_else(|| invalid_field_err!("baseRTT", "requestType requires a baseRTT value"))?,
+                    );
                 }
-                if let Some(bw) = bandwidth_kbps {
-                    dst.write_u32(*bw);
+                if want_bandwidth {
+                    dst.write_u32(
+                        bandwidth_kbps
+                            .ok_or_else(|| invalid_field_err!("bandwidth", "requestType requires a bandwidth value"))?,
+                    );
                 }
                 dst.write_u32(*average_rtt_ms);
             }
@@ -379,15 +423,10 @@ impl Encode for AutoDetectRequest {
                 }
             }
 
-            Self::NetworkCharacteristicsResult {
-                base_rtt_ms,
-                bandwidth_kbps,
-                ..
-            } => {
-                HEADER_MIN_SIZE
-                    + if base_rtt_ms.is_some() { 4 } else { 0 }
-                    + if bandwidth_kbps.is_some() { 4 } else { 0 }
-                    + 4 /* averageRTT */
+            // Mirrors `encode`: which fields are present is keyed off `requestType`.
+            Self::NetworkCharacteristicsResult { request_type, .. } => {
+                let (want_base_rtt, want_bandwidth) = netchar_fields(*request_type);
+                HEADER_MIN_SIZE + if want_base_rtt { 4 } else { 0 } + if want_bandwidth { 4 } else { 0 } + 4 /* averageRTT */
             }
         }
     }
@@ -438,6 +477,16 @@ impl<'de> Decode<'de> for AutoDetectRequest {
                 // Connect-time stop has payloadLength + payload.
                 ensure_size!(in: src, size: 2);
                 let payload_length = src.read_u16();
+                // Same rule as the encoder: 2.2.14.1.4 requires a value greater than
+                // zero here, so a zero length is a malformed PDU rather than an empty
+                // payload. Accepting what we refuse to emit would leave the two sides
+                // disagreeing about what the wire permits.
+                if payload_length == 0 {
+                    return Err(invalid_field_err!(
+                        "payloadLength",
+                        "connect-time Bandwidth Measure Stop requires a payload length greater than zero"
+                    ));
+                }
                 ensure_size!(in: src, size: usize::from(payload_length));
                 let payload = src.read_slice(usize::from(payload_length)).to_vec();
                 Ok(Self::BandwidthMeasureStop {

--- a/crates/ironrdp-testsuite-core/tests/pdu/autodetect.rs
+++ b/crates/ironrdp-testsuite-core/tests/pdu/autodetect.rs
@@ -1,0 +1,109 @@
+//! Codec tests for the Network Auto-Detect PDUs ([MS-RDPBCGR] 2.2.14).
+
+use ironrdp_core::{Encode as _, decode, encode_vec};
+use ironrdp_pdu::rdp::autodetect::{AutoDetectRequest, BW_STOP_CONNECT_TIME, BW_STOP_LOSSY_UDP, BW_STOP_RELIABLE_UDP};
+
+/// Round-trip a request and hand back what came out plus the bytes it produced.
+fn round_trip(request: &AutoDetectRequest) -> (AutoDetectRequest, Vec<u8>) {
+    let encoded = encode_vec(request).expect("encode");
+    let decoded = decode::<AutoDetectRequest>(&encoded).expect("decode");
+    (decoded, encoded)
+}
+
+#[test]
+fn connect_time_stop_without_a_payload_round_trips() {
+    // MS-RDPBCGR 2.2.14.1.4 puts `payloadLength` on the connect-time stop
+    // unconditionally, so the encoder must emit it even when no payload was supplied.
+    // Omitting it produced bytes the decoder rejected, because the decoder reads that
+    // field back for every `BW_STOP_CONNECT_TIME`.
+    let request = AutoDetectRequest::BandwidthMeasureStop {
+        sequence_number: 7,
+        request_type: BW_STOP_CONNECT_TIME,
+        payload: None,
+    };
+
+    let (decoded, encoded) = round_trip(&request);
+
+    assert_eq!(encoded.len(), request.size(), "size() must agree with encode()");
+    match decoded {
+        AutoDetectRequest::BandwidthMeasureStop {
+            sequence_number,
+            request_type,
+            payload,
+        } => {
+            assert_eq!(sequence_number, 7);
+            assert_eq!(request_type, BW_STOP_CONNECT_TIME);
+            // An absent payload is indistinguishable on the wire from an empty one,
+            // so it comes back as `Some(empty)`. The bytes are what has to be stable.
+            assert_eq!(payload.as_deref(), Some(&[][..]));
+        }
+        other => panic!("expected a BandwidthMeasureStop, got {other:?}"),
+    }
+}
+
+#[test]
+fn udp_stop_carrying_a_payload_does_not_emit_it() {
+    // The UDP stops have no payload fields at all. Emitting them wrote bytes the
+    // decoder never reads back, so the payload was silently dropped on the way through
+    // rather than rejected: a round trip that loses data without erroring.
+    for request_type in [BW_STOP_RELIABLE_UDP, BW_STOP_LOSSY_UDP] {
+        let request = AutoDetectRequest::BandwidthMeasureStop {
+            sequence_number: 3,
+            request_type,
+            payload: Some(vec![0xAA; 16]),
+        };
+
+        let (decoded, encoded) = round_trip(&request);
+
+        assert_eq!(
+            encoded.len(),
+            6,
+            "a UDP stop is header-only; a payload must not reach the wire"
+        );
+        assert_eq!(encoded.len(), request.size(), "size() must agree with encode()");
+        assert!(
+            matches!(decoded, AutoDetectRequest::BandwidthMeasureStop { payload: None, .. }),
+            "the decoder yields no payload for a UDP stop, so encode must not write one"
+        );
+    }
+}
+
+#[test]
+fn connect_time_stop_preserves_its_payload() {
+    let request = AutoDetectRequest::BandwidthMeasureStop {
+        sequence_number: 9,
+        request_type: BW_STOP_CONNECT_TIME,
+        payload: Some(vec![1, 2, 3, 4]),
+    };
+
+    let (decoded, encoded) = round_trip(&request);
+
+    assert_eq!(encoded.len(), request.size());
+    assert!(matches!(
+        decoded,
+        AutoDetectRequest::BandwidthMeasureStop { ref payload, .. } if payload.as_deref() == Some(&[1, 2, 3, 4][..])
+    ));
+}
+
+#[test]
+fn encoding_a_stop_is_stable_across_a_second_round_trip() {
+    // What the wire form has to guarantee is byte stability, since the type can express
+    // states the protocol cannot (an absent payload on a connect-time stop, a present
+    // one on a UDP stop). Decoding then re-encoding must reproduce the same bytes.
+    for request in [
+        AutoDetectRequest::BandwidthMeasureStop {
+            sequence_number: 1,
+            request_type: BW_STOP_CONNECT_TIME,
+            payload: None,
+        },
+        AutoDetectRequest::BandwidthMeasureStop {
+            sequence_number: 2,
+            request_type: BW_STOP_RELIABLE_UDP,
+            payload: Some(vec![9; 8]),
+        },
+    ] {
+        let (decoded, first) = round_trip(&request);
+        let second = encode_vec(&decoded).expect("re-encode");
+        assert_eq!(first, second, "decode then encode must reproduce the same bytes");
+    }
+}

--- a/crates/ironrdp-testsuite-core/tests/pdu/autodetect.rs
+++ b/crates/ironrdp-testsuite-core/tests/pdu/autodetect.rs
@@ -1,7 +1,10 @@
 //! Codec tests for the Network Auto-Detect PDUs ([MS-RDPBCGR] 2.2.14).
 
 use ironrdp_core::{Encode as _, decode, encode_vec};
-use ironrdp_pdu::rdp::autodetect::{AutoDetectRequest, BW_STOP_CONNECT_TIME, BW_STOP_LOSSY_UDP, BW_STOP_RELIABLE_UDP};
+use ironrdp_pdu::rdp::autodetect::{
+    AutoDetectRequest, BW_STOP_CONNECT_TIME, BW_STOP_LOSSY_UDP, BW_STOP_RELIABLE_UDP, NETCHAR_RESULT_ALL,
+    NETCHAR_RESULT_BW_RTT, NETCHAR_RESULT_RTT,
+};
 
 /// Round-trip a request and hand back what came out plus the bytes it produced.
 fn round_trip(request: &AutoDetectRequest) -> (AutoDetectRequest, Vec<u8>) {
@@ -10,35 +13,46 @@ fn round_trip(request: &AutoDetectRequest) -> (AutoDetectRequest, Vec<u8>) {
     (decoded, encoded)
 }
 
+/// MS-RDPBCGR 2.2.14.1.4 does not merely make `payloadLength` present for the
+/// connect-time stop, it requires a value "greater than zero". So an absent or
+/// empty payload has no conforming encoding and must be refused rather than
+/// written as a zero length.
 #[test]
-fn connect_time_stop_without_a_payload_round_trips() {
-    // MS-RDPBCGR 2.2.14.1.4 puts `payloadLength` on the connect-time stop
-    // unconditionally, so the encoder must emit it even when no payload was supplied.
-    // Omitting it produced bytes the decoder rejected, because the decoder reads that
-    // field back for every `BW_STOP_CONNECT_TIME`.
-    let request = AutoDetectRequest::BandwidthMeasureStop {
+fn connect_time_stop_without_a_payload_is_refused() {
+    for (label, payload) in [("absent", None), ("empty", Some(Vec::new()))] {
+        let request = AutoDetectRequest::BandwidthMeasureStop {
+            sequence_number: 7,
+            request_type: BW_STOP_CONNECT_TIME,
+            payload,
+        };
+
+        assert!(
+            encode_vec(&request).is_err(),
+            "an {label} payload on a connect-time stop must not encode"
+        );
+    }
+}
+
+/// The decoder enforces the same rule, so the two sides agree on what the wire
+/// permits. Accepting a zero length here would mean accepting what we refuse to
+/// emit.
+#[test]
+fn connect_time_stop_with_a_zero_payload_length_is_rejected() {
+    // A well-formed connect-time stop, then its payloadLength forced to zero.
+    let valid = AutoDetectRequest::BandwidthMeasureStop {
         sequence_number: 7,
         request_type: BW_STOP_CONNECT_TIME,
-        payload: None,
+        payload: Some(vec![0xAA; 4]),
     };
+    let mut wire = encode_vec(&valid).expect("encode");
 
-    let (decoded, encoded) = round_trip(&request);
+    // headerLength(1) + headerTypeId(1) + sequenceNumber(2) + requestType(2) = 6,
+    // so payloadLength is the u16 at offset 6.
+    wire[6] = 0;
+    wire[7] = 0;
+    wire.truncate(8);
 
-    assert_eq!(encoded.len(), request.size(), "size() must agree with encode()");
-    match decoded {
-        AutoDetectRequest::BandwidthMeasureStop {
-            sequence_number,
-            request_type,
-            payload,
-        } => {
-            assert_eq!(sequence_number, 7);
-            assert_eq!(request_type, BW_STOP_CONNECT_TIME);
-            // An absent payload is indistinguishable on the wire from an empty one,
-            // so it comes back as `Some(empty)`. The bytes are what has to be stable.
-            assert_eq!(payload.as_deref(), Some(&[][..]));
-        }
-        other => panic!("expected a BandwidthMeasureStop, got {other:?}"),
-    }
+    assert!(decode::<AutoDetectRequest>(&wire).is_err());
 }
 
 #[test]
@@ -87,14 +101,16 @@ fn connect_time_stop_preserves_its_payload() {
 
 #[test]
 fn encoding_a_stop_is_stable_across_a_second_round_trip() {
-    // What the wire form has to guarantee is byte stability, since the type can express
-    // states the protocol cannot (an absent payload on a connect-time stop, a present
-    // one on a UDP stop). Decoding then re-encoding must reproduce the same bytes.
+    // What the wire form has to guarantee is byte stability, since the type can still
+    // express one state the protocol cannot: a payload on a UDP stop, which is dropped
+    // rather than emitted. (The other such state, an absent payload on a connect-time
+    // stop, is now refused outright rather than normalised, so it has no bytes to be
+    // stable about.) Decoding then re-encoding must reproduce the same bytes.
     for request in [
         AutoDetectRequest::BandwidthMeasureStop {
             sequence_number: 1,
             request_type: BW_STOP_CONNECT_TIME,
-            payload: None,
+            payload: Some(vec![7; 3]),
         },
         AutoDetectRequest::BandwidthMeasureStop {
             sequence_number: 2,
@@ -106,4 +122,91 @@ fn encoding_a_stop_is_stable_across_a_second_round_trip() {
         let second = encode_vec(&decoded).expect("re-encode");
         assert_eq!(first, second, "decode then encode must reproduce the same bytes");
     }
+}
+
+/// MS-RDPBCGR 2.2.14.1.5 assigns the optional fields by `requestType`: 0x0840
+/// carries baseRTT, 0x0880 carries bandwidth, 0x08C0 carries both. The decoder
+/// already read them back on that basis, so the encoder must write them on the
+/// same basis or the two disagree about the wire.
+#[test]
+fn netchar_result_fields_follow_the_request_type() {
+    for (label, request_type, base_rtt, bandwidth) in [
+        ("RTT", NETCHAR_RESULT_RTT, Some(11), None),
+        ("BW_RTT", NETCHAR_RESULT_BW_RTT, None, Some(22)),
+        ("ALL", NETCHAR_RESULT_ALL, Some(33), Some(44)),
+    ] {
+        let request = AutoDetectRequest::NetworkCharacteristicsResult {
+            sequence_number: 5,
+            request_type,
+            base_rtt_ms: base_rtt,
+            bandwidth_kbps: bandwidth,
+            average_rtt_ms: 99,
+        };
+
+        let (decoded, encoded) = round_trip(&request);
+        assert_eq!(
+            encoded.len(),
+            request.size(),
+            "{label}: size() must agree with encode()"
+        );
+        assert_eq!(decoded, request, "{label}: must survive a round trip");
+    }
+}
+
+/// A value the `requestType` does not call for is dropped rather than written.
+///
+/// This is the case that distinguishes the two rules: with the fields keyed off
+/// the `Option`s, a `NETCHAR_RESULT_RTT` carrying a bandwidth wrote twelve bytes
+/// of body that the decoder reads as eight, so the extra value both corrupted
+/// the frame and disagreed with `headerLength`, which was always derived from
+/// `requestType`.
+#[test]
+fn netchar_result_drops_a_value_its_request_type_does_not_carry() {
+    let extra = AutoDetectRequest::NetworkCharacteristicsResult {
+        sequence_number: 5,
+        request_type: NETCHAR_RESULT_RTT,
+        base_rtt_ms: Some(11),
+        bandwidth_kbps: Some(22), // not carried by 0x0840
+        average_rtt_ms: 99,
+    };
+
+    let (decoded, encoded) = round_trip(&extra);
+
+    assert_eq!(encoded.len(), extra.size(), "size() must agree with encode()");
+    match decoded {
+        AutoDetectRequest::NetworkCharacteristicsResult {
+            base_rtt_ms,
+            bandwidth_kbps,
+            average_rtt_ms,
+            ..
+        } => {
+            assert_eq!(base_rtt_ms, Some(11));
+            assert_eq!(bandwidth_kbps, None, "the uncarried bandwidth must not reach the wire");
+            assert_eq!(
+                average_rtt_ms, 99,
+                "averageRTT must not be displaced by the extra value"
+            );
+        }
+        other => panic!("expected a NetworkCharacteristicsResult, got {other:?}"),
+    }
+}
+
+/// A value the `requestType` does not call for is not silently written into the
+/// slot of one it does. Before this, a `NETCHAR_RESULT_RTT` carrying only a
+/// bandwidth wrote that bandwidth where the decoder expects baseRTT, so the
+/// value came back corrupted rather than rejected.
+#[test]
+fn netchar_result_rejects_a_payload_that_contradicts_its_request_type() {
+    let mismatched = AutoDetectRequest::NetworkCharacteristicsResult {
+        sequence_number: 5,
+        request_type: NETCHAR_RESULT_RTT,
+        base_rtt_ms: None,
+        bandwidth_kbps: Some(22),
+        average_rtt_ms: 99,
+    };
+
+    assert!(
+        encode_vec(&mismatched).is_err(),
+        "a baseRTT-carrying request type with no baseRTT must not encode"
+    );
 }

--- a/crates/ironrdp-testsuite-core/tests/pdu/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/pdu/mod.rs
@@ -1,3 +1,4 @@
+mod autodetect;
 mod gcc;
 mod gfx;
 mod input;


### PR DESCRIPTION
## Summary

MS-RDPBCGR decides which optional fields an auto-detect message carries by its `requestType`. Two of these message types encoded them by inspecting which `Option`s happened to be set instead, so the encoder and the decoder disagreed about the wire.

This started as a fix for `BandwidthMeasureStop` alone. Review found the connect-time fallback was still non-compliant, and checking whether the same shape appeared elsewhere in the file turned up `NetworkCharacteristicsResult` with the identical defect and a worse consequence, so both are fixed here rather than one now and one later.

## The two failure modes

**Connect-time stop with no payload: encodes to bytes the decoder rejects.**

```rust
AutoDetectRequest::BandwidthMeasureStop {
    sequence_number: 7,
    request_type: BW_STOP_CONNECT_TIME,
    payload: None,
}
```

encodes to ten bytes with `headerLength` 0x06 and no length field. Decoding those bytes
fails with `not enough bytes provided to decode: received 0 bytes, expected 2 bytes`,
because the decoder reads `payloadLength` back for every `BW_STOP_CONNECT_TIME`.

**UDP stop with a payload: silently loses it.**

```rust
AutoDetectRequest::BandwidthMeasureStop {
    sequence_number: 3,
    request_type: BW_STOP_RELIABLE_UDP,
    payload: Some(vec![0xAA; 16]),
}
```

encodes the length and the sixteen bytes, which the decoder never reads back for
`BW_STOP_RELIABLE_UDP` or `BW_STOP_LOSSY_UDP`. `AutoDetectReqPdu::decode` does not check
for trailing bytes, so the payload is dropped in transit without an error rather than
refused.

The second is the worse of the two: a round trip that loses data and reports success.

## Network Characteristics Result (2.2.14.1.5)

The same defect, found by sweeping the file rather than reported.

`0x0840` carries baseRTT and averageRTT, `0x0880` carries bandwidth and averageRTT, `0x08C0` carries all three, and the decoder already read them on that basis. Encoding from the `Option`s meant:

- a `0x0840` result with no `base_rtt_ms` wrote a body the decoder cannot read;
- a `0x0840` result carrying `bandwidth_kbps` instead wrote that bandwidth into the slot the decoder reads as baseRTT, so the value came back **silently corrupted** rather than rejected;
- `headerLength` was always derived from `requestType`, so it could contradict the body it described.

Encode and `size()` now consult `requestType` through a shared helper, a value the type does not carry is dropped rather than written, and a missing one that the type requires is an error.

## Fix

`Encode` and `size()` now key off `requestType`, matching the decoder. That makes the
wire form canonical:

- an absent payload on a connect-time stop encodes as a zero length and reads back as an
  empty one;
- a payload on a UDP stop never reaches the wire.

Decoding and re-encoding reproduces the same bytes in every case. The types can still
express states the protocol cannot, so value-level identity is not achievable, but byte
stability is, and that is what a decoder consuming real traffic depends on.

No public signatures change; this is a behaviour fix inside the existing `Encode` impl.

## Tests

New `pdu/autodetect.rs` in `ironrdp-testsuite-core`:

- a connect-time stop with no payload round-trips, and `size()` agrees with `encode()`;
- a UDP stop carrying a payload encodes header-only and comes back with `payload: None`,
  for both the reliable and lossy request types;
- a connect-time stop preserves a real payload;
- decode-then-encode reproduces identical bytes for both shapes.

Three of the four fail against the current encoder and pass with the fix. The fourth is
a control that passed before and after.

Note the existing `pdu_round_trip` fuzz oracle would not have caught this even with
auto-detect added to it, since it discards the result of the re-decode (`let _ =`). That
is deliberate in the oracle's design and out of scope here, but it is why this went
unnoticed.

## How this was found

Writing a test for the connect-time bandwidth measurement in #1465, which needs to answer
a connect-time stop. The `None` case was constructed to check the reply path stayed
lenient and turned out not to be constructible on the wire at all.

## Verification

- `cargo xtask check fmt -v` green
- `cargo xtask check lints -v` green
- `cargo xtask check tests -v` green
- `cargo xtask check typos -v` green
- `cargo xtask check locks -v` green

[MS-RDPBCGR]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/515150db-4e7a-4c9b-88d8-63f9fe79981f

