### PR TITLE
ci: clean up pull request labeler workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -157,9 +157,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_SEMVER_CHECKS_VERSION: "0.49.0"
-    permissions:
-      contents: read
-      pull-requests: read
+    permissions: {}
     outputs:
       breaking_change: ${{ steps.semver-checks.outputs.breaking-change }}
       sspi_label_required: ${{ steps.sspi-label.outputs.required }}
@@ -171,6 +169,7 @@ jobs:
           ref: ${{ needs.label.outputs.head-sha }}
           fetch-depth: 0
           persist-credentials: false
+          token: ""
 
       - name: Determine merge base
         id: merge-base

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           script: |
             const pullRequestNumber = Number("${{ steps.pull-request.outputs.number }}");
-            const sourceFile = /\.(?:rs|cs|[cm]?js|jsx|[cm]?ts|tsx|svelte)$/i;
+            const sourceFile = /\.(?:rs|cs|[cm]?js|jsx|[cm]?ts|tsx|svelte|ya?ml|toml)$/i;
             let changedLines = 0;
 
             for await (const response of github.paginate.iterator(github.rest.pulls.listFiles, {
@@ -178,6 +178,12 @@ jobs:
         run: |
           git fetch origin master
           echo "base=$(git merge-base HEAD origin/master)" >> "$GITHUB_OUTPUT"
+
+      - name: Install build dependencies
+        shell: bash
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get -y install libasound2-dev
 
       - name: Install cargo-semver-checks
         shell: bash

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,6 +10,10 @@ on:
         required: true
         type: number
 
+concurrency:
+  group: labeler-${{ github.event.pull_request.number || inputs.pr-number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write
@@ -157,6 +161,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_SEMVER_CHECKS_VERSION: "0.49.0"
+      CARGO_SEMVER_CHECKS_SHA256: "72f6834d75d28a66e02c9fd6a230ce901bb30eee6067b85867a97445df040e4a"
     permissions: {}
     outputs:
       breaking_change: ${{ steps.semver-checks.outputs.breaking-change }}
@@ -193,6 +198,8 @@ jobs:
             --output /tmp/cargo-semver-checks.tar.gz \
             --fail \
             --location
+          echo "$CARGO_SEMVER_CHECKS_SHA256  /tmp/cargo-semver-checks.tar.gz" |
+            sha256sum --check --strict
           tar -xzvf /tmp/cargo-semver-checks.tar.gz -C "$HOME/.local/bin" cargo-semver-checks
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
@@ -273,6 +280,26 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Verify pull request head
+        uses: actions/github-script@v8
+        env:
+          PULL_REQUEST_NUMBER: ${{ needs.label.outputs.pr-number }}
+          EXPECTED_HEAD_SHA: ${{ needs.label.outputs.head-sha }}
+        with:
+          script: |
+            const pullRequestNumber = Number(process.env.PULL_REQUEST_NUMBER);
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullRequestNumber,
+            });
+
+            if (pullRequest.head.sha !== process.env.EXPECTED_HEAD_SHA) {
+              throw new Error(
+                `pull request head changed from ${process.env.EXPECTED_HEAD_SHA} to ${pullRequest.head.sha}`,
+              );
+            }
+
       - name: Add breaking change label
         if: needs.semver.outputs.breaking_change == 'true'
         uses: actions/github-script@v8

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -160,7 +160,6 @@ jobs:
     permissions: {}
     outputs:
       breaking_change: ${{ steps.semver-checks.outputs.breaking-change }}
-      sspi_label_required: ${{ steps.sspi-label.outputs.required }}
 
     steps:
       - name: Fetch pull request head
@@ -179,32 +178,6 @@ jobs:
         run: |
           git fetch origin master
           echo "base=$(git merge-base HEAD origin/master)" >> "$GITHUB_OUTPUT"
-
-      - name: Detect SSPI changes
-        id: sspi-label
-        shell: bash
-        run: |
-          BASE="${{ steps.merge-base.outputs.base }}"
-          sspi_path_changed=false
-
-          if ! git diff --quiet "$BASE" HEAD -- \
-            ':(glob)**/*credssp*' \
-            ':(glob)**/*sspi*' \
-            crates/ironrdp-pdu/src/nego.rs; then
-            sspi_path_changed=true
-          fi
-
-          sspi_dependency_changed=false
-          if git diff --unified=0 "$BASE" HEAD -- Cargo.toml ':(glob)**/Cargo.toml' |
-            grep -Eq '^[+-][[:space:]]*"?sspi"?[[:space:]]*='; then
-            sspi_dependency_changed=true
-          fi
-
-          if [ "$sspi_path_changed" = true ] || [ "$sspi_dependency_changed" = true ]; then
-            echo "required=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "required=false" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Install cargo-semver-checks
         shell: bash
@@ -241,9 +214,54 @@ jobs:
               ;;
           esac
 
+  sspi:
+    name: Detect SSPI changes
+    needs: label
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      label_required: ${{ steps.sspi-label.outputs.required }}
+
+    steps:
+      - name: Fetch pull request history
+        shell: bash
+        env:
+          HEAD_SHA: ${{ needs.label.outputs.head-sha }}
+        run: |
+          git init .
+          git remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
+          git fetch --no-tags origin "+$HEAD_SHA:refs/remotes/origin/pull-request-head"
+          git fetch --no-tags origin master
+
+      - name: Detect SSPI changes
+        id: sspi-label
+        shell: bash
+        run: |
+          BASE="$(git merge-base origin/pull-request-head origin/master)"
+          sspi_path_changed=false
+
+          if ! git diff --quiet "$BASE" origin/pull-request-head -- \
+            ':(glob)**/*credssp*' \
+            ':(glob)**/*sspi*' \
+            crates/ironrdp-pdu/src/nego.rs; then
+            sspi_path_changed=true
+          fi
+
+          sspi_dependency_changed=false
+          if git diff --unified=0 "$BASE" origin/pull-request-head -- Cargo.toml ':(glob)**/Cargo.toml' |
+            grep -Eq '^[+-][[:space:]]*"?sspi"?[[:space:]]*='; then
+            sspi_dependency_changed=true
+          fi
+
+          if [ "$sspi_path_changed" = true ] || [ "$sspi_dependency_changed" = true ]; then
+            echo "required=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "required=false" >> "$GITHUB_OUTPUT"
+          fi
+
   label-derived-changes:
     name: Label derived changes
-    needs: [label, semver]
+    needs: [label, semver, sspi]
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -290,7 +308,7 @@ jobs:
             }
 
       - name: Add SSPI label
-        if: needs.semver.outputs.sspi_label_required == 'true'
+        if: needs.sspi.outputs.label_required == 'true'
         uses: actions/github-script@v8
         env:
           PULL_REQUEST_NUMBER: ${{ needs.label.outputs.pr-number }}
@@ -306,7 +324,7 @@ jobs:
             });
 
       - name: Remove SSPI label
-        if: needs.semver.outputs.sspi_label_required != 'true'
+        if: needs.sspi.outputs.label_required != 'true'
         uses: actions/github-script@v8
         env:
           PULL_REQUEST_NUMBER: ${{ needs.label.outputs.pr-number }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -155,6 +155,8 @@ jobs:
     name: Check public API compatibility
     needs: label
     runs-on: ubuntu-latest
+    env:
+      CARGO_SEMVER_CHECKS_VERSION: "0.49.0"
     permissions:
       contents: read
       pull-requests: read
@@ -204,7 +206,15 @@ jobs:
           fi
 
       - name: Install cargo-semver-checks
-        run: cargo install cargo-semver-checks --locked
+        shell: bash
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl "https://github.com/obi1kenobi/cargo-semver-checks/releases/download/v${CARGO_SEMVER_CHECKS_VERSION}/cargo-semver-checks-x86_64-unknown-linux-gnu.tar.gz" \
+            --output /tmp/cargo-semver-checks.tar.gz \
+            --fail \
+            --location
+          tar -xzvf /tmp/cargo-semver-checks.tar.gz -C "$HOME/.local/bin" cargo-semver-checks
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Check public API compatibility
         id: semver-checks

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -247,51 +247,82 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Label breaking change and SSPI changes
+      - name: Add breaking change label
+        if: needs.semver.outputs.breaking_change == 'true'
         uses: actions/github-script@v8
+        env:
+          PULL_REQUEST_NUMBER: ${{ needs.label.outputs.pr-number }}
         with:
           script: |
-            const pullRequestNumber = Number("${{ needs.label.outputs.pr-number }}");
-            const breakingChange = "${{ needs.semver.outputs.breaking_change }}" === "true";
-            const sspiLabelRequired = "${{ needs.semver.outputs.sspi_label_required }}" === "true";
-            const breakingChangeLabel = "breaking-change";
-            const sspiLabel = "A-sspi";
+            const pullRequestNumber = Number(process.env.PULL_REQUEST_NUMBER);
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pullRequestNumber,
+              labels: ["breaking-change"],
+            });
+
+      - name: Remove breaking change label
+        if: needs.semver.outputs.breaking_change != 'true'
+        uses: actions/github-script@v8
+        env:
+          PULL_REQUEST_NUMBER: ${{ needs.label.outputs.pr-number }}
+        with:
+          script: |
+            const pullRequestNumber = Number(process.env.PULL_REQUEST_NUMBER);
 
             const { data: issue } = await github.rest.issues.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pullRequestNumber,
             });
-            const existingLabels = new Set(issue.labels.map((label) => label.name));
 
-            if (breakingChange && !existingLabels.has(breakingChangeLabel)) {
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pullRequestNumber,
-                labels: [breakingChangeLabel],
-              });
-            } else if (!breakingChange && existingLabels.has(breakingChangeLabel)) {
+            if (issue.labels.some((label) => label.name === "breaking-change")) {
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pullRequestNumber,
-                name: breakingChangeLabel,
+                name: "breaking-change",
               });
             }
 
-            if (sspiLabelRequired && !existingLabels.has(sspiLabel)) {
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pullRequestNumber,
-                labels: [sspiLabel],
-              });
-            } else if (!sspiLabelRequired && existingLabels.has(sspiLabel)) {
+      - name: Add SSPI label
+        if: needs.semver.outputs.sspi_label_required == 'true'
+        uses: actions/github-script@v8
+        env:
+          PULL_REQUEST_NUMBER: ${{ needs.label.outputs.pr-number }}
+        with:
+          script: |
+            const pullRequestNumber = Number(process.env.PULL_REQUEST_NUMBER);
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pullRequestNumber,
+              labels: ["A-sspi"],
+            });
+
+      - name: Remove SSPI label
+        if: needs.semver.outputs.sspi_label_required != 'true'
+        uses: actions/github-script@v8
+        env:
+          PULL_REQUEST_NUMBER: ${{ needs.label.outputs.pr-number }}
+        with:
+          script: |
+            const pullRequestNumber = Number(process.env.PULL_REQUEST_NUMBER);
+
+            const { data: issue } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pullRequestNumber,
+            });
+
+            if (issue.labels.some((label) => label.name === "A-sspi")) {
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pullRequestNumber,
-                name: sspiLabel,
+                name: "A-sspi",
               });
             }

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -201,10 +201,10 @@ jobs:
         shell: bash
         run: |
           BASE="${{ steps.merge-base.outputs.base }}"
-          echo "Checking compatibility against $BASE"
+          echo "Checking ironrdp compatibility against $BASE"
 
           set +e
-          cargo semver-checks --baseline-rev "$BASE"
+          cargo semver-checks --package ironrdp --baseline-rev "$BASE"
           status=$?
           set -e
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -211,7 +211,7 @@ jobs:
           echo "Checking ironrdp compatibility against $BASE"
 
           set +e
-          cargo semver-checks --package ironrdp --baseline-rev "$BASE"
+          cargo semver-checks --package ironrdp --default-features --baseline-rev "$BASE"
           status=$?
           set -e
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -162,6 +162,7 @@ jobs:
     env:
       CARGO_SEMVER_CHECKS_VERSION: "0.49.0"
       CARGO_SEMVER_CHECKS_SHA256: "72f6834d75d28a66e02c9fd6a230ce901bb30eee6067b85867a97445df040e4a"
+      CARGO_SEMVER_CHECKS_FEATURES: "core,pdu,cliprdr,connector,acceptor,session,graphics,input,server,svc,dvc,rdpdr,rdpsnd,displaycontrol,echo,mstsgu,client,rustls,client-all,qoi,qoiz"
     permissions: {}
     outputs:
       breaking_change: ${{ steps.semver-checks.outputs.breaking-change }}
@@ -211,7 +212,11 @@ jobs:
           echo "Checking ironrdp compatibility against $BASE"
 
           set +e
-          cargo semver-checks --package ironrdp --default-features --baseline-rev "$BASE"
+          cargo semver-checks \
+            --package ironrdp \
+            --only-explicit-features \
+            --features "$CARGO_SEMVER_CHECKS_FEATURES" \
+            --baseline-rev "$BASE"
           status=$?
           set -e
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -163,13 +163,15 @@ jobs:
       sspi_label_required: ${{ steps.sspi-label.outputs.required }}
 
     steps:
-      - name: Check out pull request head
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.label.outputs.head-sha }}
-          fetch-depth: 0
-          persist-credentials: false
-          token: ""
+      - name: Fetch pull request head
+        shell: bash
+        env:
+          HEAD_SHA: ${{ needs.label.outputs.head-sha }}
+        run: |
+          git init .
+          git remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
+          git fetch --no-tags origin "+$HEAD_SHA:refs/remotes/origin/pull-request-head"
+          git checkout --detach origin/pull-request-head
 
       - name: Determine merge base
         id: merge-base


### PR DESCRIPTION
Cleans up and hardens the pull request labeler workflow:

- cancel obsolete per-PR runs and verify the analyzed head before derived label writes
- pin, SHA-256 verify, and install cargo-semver-checks from its upstream Linux release archive
- install the same ALSA development dependency as CI before semver checks
- check the broad `ironrdp` meta-crate facade with explicit public features and a single Rustls TLS backend
- contain untrusted PR code in a credentialless, zero-permission semver job
- prevent untrusted job outputs from being interpolated into privileged scripts
- split Git-only SSPI diff analysis from public API compatibility checking
- include YAML and TOML changes in pull request size labels