### PR TITLE
fix(pdu): keep auto-reconnect credential material out of Debug output

### DIFF
--- a/crates/ironrdp-pdu/src/rdp/client_info.rs
+++ b/crates/ironrdp-pdu/src/rdp/client_info.rs
@@ -300,13 +300,27 @@ impl ExtendedClientInfo {
 /// [2.2.4.3]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/2985e8e3-db10-4a92-9fd5-d5e742d2d0f2
 /// [2.2.1.11.1.1.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/05ada9e4-a468-494b-8694-eb806a0ecc89
 /// [`ServerAutoReconnect`]: crate::rdp::session_info::ServerAutoReconnect
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ClientAutoReconnect {
     /// Session identifier for reconnection, echoed from the server's cookie.
     pub logon_id: u32,
     /// Verifier derived from the server's auto-reconnect random.
     pub security_verifier: [u8; RECONNECT_SECURITY_VERIFIER_LEN],
+}
+
+impl fmt::Debug for ClientAutoReconnect {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // NOTE: do not show secret (auto-reconnect security verifier)
+        //
+        // Under Enhanced RDP Security there is no client random, so [MS-RDPBCGR]
+        // 5.5 computes this verifier over 32 zero bytes. It is therefore constant
+        // for a given cookie, and replaying it is sufficient to resume the
+        // session: possession of the verifier alone is the credential.
+        f.debug_struct("ClientAutoReconnect")
+            .field("logon_id", &self.logon_id)
+            .finish_non_exhaustive()
+    }
 }
 
 impl ClientAutoReconnect {
@@ -433,7 +447,7 @@ impl<'de> Decode<'de> for ClientAutoReconnect {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Clone, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ExtendedClientOptionalInfo {
     timezone: Option<TimezoneInfo>,
@@ -442,6 +456,23 @@ pub struct ExtendedClientOptionalInfo {
     reconnect_cookie: Option<[u8; RECONNECT_COOKIE_LEN]>,
     auto_reconnect: Option<ClientAutoReconnect>,
     // other fields are read by RdpVersion::Ten+
+}
+
+impl fmt::Debug for ExtendedClientOptionalInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // NOTE: do not show secret (raw auto-reconnect cookie)
+        //
+        // `reconnect_cookie` is the wire form of `auto_reconnect` and carries the
+        // same security verifier in the clear, so redacting only the parsed field
+        // would leave the bytes readable here. `auto_reconnect` is safe to show
+        // because its own `Debug` elides the verifier.
+        f.debug_struct("ExtendedClientOptionalInfo")
+            .field("timezone", &self.timezone)
+            .field("session_id", &self.session_id)
+            .field("performance_flags", &self.performance_flags)
+            .field("auto_reconnect", &self.auto_reconnect)
+            .finish_non_exhaustive()
+    }
 }
 
 impl ExtendedClientOptionalInfo {
@@ -606,6 +637,36 @@ mod tests {
         let mut invalid_version = reconnect_cookie();
         invalid_version[4..8].copy_from_slice(&2u32.to_le_bytes());
         assert!(ClientAutoReconnect::decode(&mut ReadCursor::new(&invalid_version)).is_err());
+    }
+
+    /// The security verifier must not reach logs, in either of its two forms.
+    ///
+    /// `ClientInfoPdu` is logged whole by the connector when it sends it, which
+    /// is why `Credentials` above hand-writes `Debug`. The verifier belongs in
+    /// the same category: 5.5 computes it over a constant client random under
+    /// Enhanced RDP Security, so replaying it resumes the session.
+    #[test]
+    fn security_verifier_is_redacted_from_debug_output() {
+        let cookie = reconnect_cookie();
+        let parsed = ClientAutoReconnect::decode(&mut ReadCursor::new(&cookie)).unwrap();
+        let optional_info = ExtendedClientOptionalInfo {
+            timezone: Some(TimezoneInfo::default()),
+            session_id: Some(0),
+            performance_flags: Some(PerformanceFlags::default()),
+            reconnect_cookie: Some(cookie),
+            auto_reconnect: Some(parsed.clone()),
+        };
+
+        // 0xA5 renders as `165` in the derived byte-slice output.
+        for (label, rendered) in [
+            ("ClientAutoReconnect", format!("{parsed:?}")),
+            ("ExtendedClientOptionalInfo", format!("{optional_info:?}")),
+        ] {
+            assert!(!rendered.contains("165"), "{label} leaked the verifier: {rendered}");
+        }
+
+        // The session identifier is not secret and stays visible for diagnosis.
+        assert!(format!("{parsed:?}").contains(&0x1234_5678u32.to_string()));
     }
 
     #[test]

--- a/crates/ironrdp-pdu/src/rdp/session_info/logon_extended.rs
+++ b/crates/ironrdp-pdu/src/rdp/session_info/logon_extended.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 use bitflags::bitflags;
 use ironrdp_core::{
     Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, cast_length, ensure_fixed_part_size,
@@ -97,11 +99,27 @@ impl<'de> Decode<'de> for LogonInfoExtended {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ServerAutoReconnect {
     pub logon_id: u32,
     pub random_bits: [u8; AUTO_RECONNECT_RANDOM_BITS_SIZE],
+}
+
+impl fmt::Debug for ServerAutoReconnect {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // NOTE: do not show secret (auto-reconnect random).
+        //
+        // These bytes key the HMAC that proves, on reconnect, that this client
+        // was the one last attached to the session ([MS-RDPBCGR] 5.5), so they
+        // are credential material: the spec has the client store the cookie
+        // "in memory, never allowing programmatic access to it". Printing them
+        // would put a live reconnect credential wherever the containing PDU or
+        // event is logged.
+        f.debug_struct("ServerAutoReconnect")
+            .field("logon_id", &self.logon_id)
+            .finish_non_exhaustive()
+    }
 }
 
 impl ServerAutoReconnect {

--- a/crates/ironrdp-pdu/src/rdp/session_info/tests.rs
+++ b/crates/ironrdp-pdu/src/rdp/session_info/tests.rs
@@ -432,3 +432,48 @@ fn from_buffer_parsing_with_invalid_logon_error_type_fails() {
         res => panic!("Expected InvalidLogonErrorType error, got: {res:?}"),
     };
 }
+
+/// The auto-reconnect random must not reach logs.
+///
+/// It keys the HMAC that proves, on reconnect, that this client was the one
+/// last attached to the session ([MS-RDPBCGR] 5.5), which is why the spec has
+/// the client store the cookie "in memory, never allowing programmatic access
+/// to it". `Debug` is the way it would otherwise escape, since the containing
+/// PDU is logged by both the session layer and the server's event dispatch.
+///
+/// The containing types are checked too: redaction is only useful if it
+/// survives being nested inside a `Debug`-derived parent.
+#[test]
+fn auto_reconnect_random_is_redacted_from_debug_output() {
+    const SECRET: [u8; 16] = [0xAB; 16];
+
+    let cookie = ServerAutoReconnect {
+        logon_id: 42,
+        random_bits: SECRET,
+    };
+    let extended = LogonInfoExtended {
+        present_fields_flags: LogonExFlags::AUTO_RECONNECT_COOKIE,
+        auto_reconnect: Some(cookie.clone()),
+        errors_info: None,
+    };
+    let pdu = SaveSessionInfoPdu {
+        info_type: InfoType::LogonExtended,
+        info_data: InfoData::LogonExtended(extended.clone()),
+    };
+
+    // 0xAB renders as `171` in the derived byte-slice output.
+    for (label, rendered) in [
+        ("ServerAutoReconnect", format!("{cookie:?}")),
+        ("LogonInfoExtended", format!("{extended:?}")),
+        ("SaveSessionInfoPdu", format!("{pdu:?}")),
+    ] {
+        assert!(
+            !rendered.contains("171"),
+            "{label} leaked the auto-reconnect random: {rendered}"
+        );
+    }
+
+    // The session identifier is not secret and stays visible, so the output is
+    // still useful for diagnosis.
+    assert!(format!("{cookie:?}").contains("42"));
+}


### PR DESCRIPTION
> **Rescoped.** This PR previously carried the mid-session cookie reissue feature. #1509 landed that, so I have dropped it and kept the one part #1509 did not take. The diff is now three `Debug` impls in `ironrdp-pdu`.

## What

`ServerAutoReconnect`, `ClientAutoReconnect` and `ExtendedClientOptionalInfo` derive `Debug` over auto-reconnect credential material. Hand-write those three impls so the secret is elided and `logon_id` is not.

## Why

The auto-reconnect cookie is credential material in both directions:

- `ServerAutoReconnect::random_bits` keys the HMAC that proves, on reconnect, that a client was the one last attached to the session ([MS-RDPBCGR] 5.5). 5.5 has the client hold the cookie in memory and never allow programmatic access to it.
- `ClientAutoReconnect::security_verifier` is that HMAC. Under Enhanced RDP Security there is no client random, so 5.5 computes the verifier over 32 zero bytes: it is constant for a given cookie, and replaying it is enough to resume the session.
- `ExtendedClientOptionalInfo::reconnect_cookie` is the wire form of the same verifier.

A client running at debug level writes both halves to its log today:

| Site | What it logs |
|---|---|
| `ironrdp-session/src/x224/mod.rs:212` | the whole `SaveSessionInfoPdu` it receives, so the random lands in the log |
| `ironrdp-connector/src/connection.rs:873` | the whole `ClientInfoPdu` it sends, so the verifier lands in the log |

That second line is why `Credentials` in `client_info.rs` already hand-writes `Debug` to hide the password. The verifier travels in the same PDU and deserves the same treatment, so this PR follows that impl exactly.

Not theoretical: while validating #1509 against mstsc, @clintcan posted a server log reading

```
auto-reconnect cookie provisioned ... random_bits=[44, 11, 95, ...]
```

which is a live reconnect credential in a public comment, produced by the derived impl.

## Why all three

Redacting the parsed field alone would not help, because `reconnect_cookie` carries the same bytes unparsed. Redacting the leaf alone would not help either if a `Debug`-derived parent reproduced them, so the tests assert the elision survives nesting inside `LogonInfoExtended`, `SaveSessionInfoPdu` and `ExtendedClientOptionalInfo`.

`logon_id` is not secret and stays visible, so the output remains useful for diagnosis.

## Not breaking

No public item is added, removed or changed. `cargo semver-checks -p ironrdp-pdu` reports the same two findings on this branch as on `master` (`ShareDataPdu::Compressed` and the `ShareDataCtx` fields, both from #1518), and none from this diff.

## Tests

Two, both in the existing inline modules beside the code they cover. `ExtendedClientOptionalInfo`'s fields are private, so the client-side test cannot be written from `ironrdp-testsuite-core`.

## Verification

`cargo xtask check fmt/lints/tests/typos/locks` all pass on 1.94.1.

## Rebased onto #1501

#1501 merged first and touched the same `ClientAutoReconnect` declaration, so this is rebased onto it. The resolution is the one-line change both PRs anticipated: #1501's fuller doc comment is kept and `Debug` comes off the derive list. Nothing else changed.

Redaction now covers what #1501 added as well, since the client half it introduced carries the verifier this PR elides.

[MS-RDPBCGR]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/e729948a-3f4e-4568-9aef-d355e30b5389
