### PR TITLE
feat(connector): Hyper-V vmconnect support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3001,6 +3001,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
  "uuid",
 ]
 

--- a/crates/ironrdp-async/src/connector.rs
+++ b/crates/ironrdp-async/src/connector.rs
@@ -136,6 +136,7 @@ where
         connector.config.domain.as_deref(),
         selected_protocol,
         server_name,
+        connector.spn_service_class(),
         server_public_key,
         kerberos_config,
     )?;

--- a/crates/ironrdp-blocking/src/connector.rs
+++ b/crates/ironrdp-blocking/src/connector.rs
@@ -141,6 +141,7 @@ where
         connector.config.domain.as_deref(),
         selected_protocol,
         server_name,
+        connector.spn_service_class(),
         server_public_key,
         kerberos_config,
     )?;

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -883,7 +883,13 @@ impl ConfigBuilder {
     ///
     /// This switches the client to the Hyper-V connection ordering: a Preconnection Blob carrying
     /// `vm_id` is sent first, then TLS, CredSSP, and X.224 negotiation run in the order the Hyper-V
-    /// host expects. Requires the Direct transport; [`build`](Self::build) fails otherwise.
+    /// host expects. A console listens on port 2179, not 3389, so the destination must say so.
+    ///
+    /// Works over the Direct and gateway transports, but not RDCleanPath, whose proxy negotiates
+    /// X.224 before this ordering is ready for it; [`build`](Self::build) rejects that pair.
+    ///
+    /// Not mirrored into the [`PropertySet`]: `.rdp` files carry the VM ID in the `pcb` key, which
+    /// `ironrdp-cfg` does not model yet.
     #[must_use]
     pub fn with_vmconnect(mut self, vm_id: impl Into<String>) -> Self {
         self.vm_id = Some(vm_id.into());
@@ -1143,10 +1149,10 @@ impl ConfigBuilder {
             }),
         };
 
-        // A gateway or RDCleanPath proxy performs the connection initiation itself, which the
-        // Hyper-V ordering moves after authentication; the two cannot be combined.
-        if self.vm_id.is_some() && !matches!(transport, Transport::Direct) {
-            anyhow::bail!("vmconnect requires the Direct transport");
+        // An RDCleanPath proxy negotiates X.224 for us before the Hyper-V ordering gets there. A
+        // gateway is only a tunnel, so the connector still drives the whole handshake itself.
+        if self.vm_id.is_some() && matches!(transport, Transport::RDCleanPath(_)) {
+            anyhow::bail!("vmconnect cannot be used over an RDCleanPath proxy");
         }
 
         let client_name = self.client_name.unwrap_or_default();

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -59,7 +59,7 @@ pub struct Config {
     pub(crate) destination: Destination,
     pub(crate) transport: Transport,
 
-    /// Hyper-V VM id to connect to via vmconnect, if this is a vmconnect session.
+    /// Hyper-V VM ID to connect to via vmconnect, if this is a vmconnect session.
     ///
     /// When set, the client sends a Preconnection Blob carrying this id and performs the Hyper-V
     /// connection ordering (PCB → TLS → CredSSP → X.224 negotiation) instead of the standard one.
@@ -106,7 +106,7 @@ impl Config {
         &self.transport
     }
 
-    /// Hyper-V VM id for a vmconnect session, if any.
+    /// Hyper-V VM ID for a vmconnect session, if any.
     pub fn vm_id(&self) -> Option<&str> {
         self.vm_id.as_deref()
     }
@@ -879,11 +879,11 @@ impl ConfigBuilder {
         self
     }
 
-    /// Connect to a Hyper-V VM console via vmconnect, identified by its VM id (a GUID string).
+    /// Connect to a Hyper-V VM console via vmconnect, identified by its VM ID (a GUID string).
     ///
     /// This switches the client to the Hyper-V connection ordering: a Preconnection Blob carrying
     /// `vm_id` is sent first, then TLS, CredSSP, and X.224 negotiation run in the order the Hyper-V
-    /// host expects. Only meaningful over the Direct transport.
+    /// host expects. Requires the Direct transport; [`build`](Self::build) fails otherwise.
     #[must_use]
     pub fn with_vmconnect(mut self, vm_id: impl Into<String>) -> Self {
         self.vm_id = Some(vm_id.into());
@@ -1142,6 +1142,12 @@ impl ConfigBuilder {
                 auth_token: self.rdcleanpath_token.unwrap(),
             }),
         };
+
+        // A gateway or RDCleanPath proxy performs the connection initiation itself, which the
+        // Hyper-V ordering moves after authentication; the two cannot be combined.
+        if self.vm_id.is_some() && !matches!(transport, Transport::Direct) {
+            anyhow::bail!("vmconnect requires the Direct transport");
+        }
 
         let client_name = self.client_name.unwrap_or_default();
         let kerberos_config = self

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -58,6 +58,12 @@ pub struct Config {
     pub(crate) connector: ironrdp_connector::Config,
     pub(crate) destination: Destination,
     pub(crate) transport: Transport,
+
+    /// Hyper-V VM id to connect to via vmconnect, if this is a vmconnect session.
+    ///
+    /// When set, the client sends a Preconnection Blob carrying this id and performs the Hyper-V
+    /// connection ordering (PCB → TLS → CredSSP → X.224 negotiation) instead of the standard one.
+    pub(crate) vm_id: Option<String>,
     pub(crate) kerberos_config: Option<ironrdp_connector::credssp::KerberosConfig>,
     pub(crate) fake_events_interval: Option<Duration>,
     pub(crate) channels: ChannelConfig,
@@ -100,6 +106,11 @@ impl Config {
         &self.transport
     }
 
+    /// Hyper-V VM id for a vmconnect session, if any.
+    pub fn vm_id(&self) -> Option<&str> {
+        self.vm_id.as_deref()
+    }
+
     /// Optional Kerberos/KDC proxy configuration.
     pub fn kerberos_config(&self) -> Option<&ironrdp_connector::credssp::KerberosConfig> {
         self.kerberos_config.as_ref()
@@ -139,6 +150,7 @@ impl fmt::Debug for Config {
         s.field("connector", &self.connector);
         s.field("destination", &self.destination);
         s.field("transport", &self.transport);
+        s.field("vm_id", &self.vm_id);
         s.field("kerberos_config", &self.kerberos_config);
         s.field("fake_events_interval", &self.fake_events_interval);
         s.field("channels", &self.channels);
@@ -564,6 +576,7 @@ pub struct ConfigBuilder {
     work_dir: Option<String>,
 
     transport: TransportKind,
+    vm_id: Option<String>,
     rdcleanpath_token: Option<String>,
     kerberos_config: Option<ironrdp_connector::credssp::KerberosConfig>,
     fake_events_interval: Option<Duration>,
@@ -863,6 +876,17 @@ impl ConfigBuilder {
             }
         }
         self.transport = transport;
+        self
+    }
+
+    /// Connect to a Hyper-V VM console via vmconnect, identified by its VM id (a GUID string).
+    ///
+    /// This switches the client to the Hyper-V connection ordering: a Preconnection Blob carrying
+    /// `vm_id` is sent first, then TLS, CredSSP, and X.224 negotiation run in the order the Hyper-V
+    /// host expects. Only meaningful over the Direct transport.
+    #[must_use]
+    pub fn with_vmconnect(mut self, vm_id: impl Into<String>) -> Self {
+        self.vm_id = Some(vm_id.into());
         self
     }
 
@@ -1196,6 +1220,7 @@ impl ConfigBuilder {
             connector,
             destination: self.destination.context("server address is required")?,
             transport,
+            vm_id: self.vm_id,
             kerberos_config,
             fake_events_interval: self.fake_events_interval,
             channels: self.channels,

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -376,8 +376,11 @@ fn build_connector(
         });
     }
 
-    let mut connector =
-        ironrdp_connector::ClientConnector::new(connector_config, client_addr).with_static_channel(drdynvc);
+    let base = match config.vm_id.clone() {
+        Some(vm_id) => ironrdp_connector::ClientConnector::new_vmconnect(connector_config, client_addr, vm_id),
+        None => ironrdp_connector::ClientConnector::new(connector_config, client_addr),
+    };
+    let mut connector = base.with_static_channel(drdynvc);
 
     // Attach RDPSND (audio).
     #[cfg(feature = "sound")]

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -13,6 +13,7 @@ use crate::channel_connection::{ChannelConnectionSequence, ChannelConnectionStat
 use crate::connection_activation::{
     ConnectionActivationFactory, ConnectionActivationSequence, ConnectionActivationState,
 };
+use crate::credssp::DEFAULT_SPN_SERVICE_CLASS;
 use crate::license_exchange::{LicenseExchangeSequence, NoopLicenseCache};
 use crate::{
     Config, ConnectorError, ConnectorErrorExt as _, ConnectorErrorKind, ConnectorResult, DesktopSize,
@@ -22,7 +23,7 @@ use crate::{
 /// Security protocols advertised in the Hyper-V X.224 connection request.
 ///
 /// Matches what mstsc offers for a Hyper-V console; a Direct Approach host answers with plain
-/// `HYBRID`.
+/// `HYBRID`. Wider than [`HYPERV_REQUIRED_PROTOCOL`], which is the only answer we accept.
 ///
 /// [2.2.1.1.1] RDP Negotiation Request (RDP_NEG_REQ)
 ///
@@ -32,8 +33,17 @@ const HYPERV_SECURITY_PROTOCOL: nego::SecurityProtocol = nego::SecurityProtocol:
     .union(nego::SecurityProtocol::HYBRID);
 
 /// The one protocol a Hyper-V console connection actually performs: NLA runs with it, and the host
-/// must confirm exactly it.
+/// must confirm exactly it. We advertise `HYBRID_EX` but refuse it if selected, because it would
+/// have the host answer CredSSP with an Early User Authorization Result PDU that nothing reads —
+/// by the time the negotiation happens here, CredSSP is long finished.
 const HYPERV_REQUIRED_PROTOCOL: nego::SecurityProtocol = nego::SecurityProtocol::HYBRID;
+
+/// SPN service class for a Hyper-V console. The console is a separate service from the Remote
+/// Desktop host and registers its own SPN, so [`DEFAULT_SPN_SERVICE_CLASS`] fails Kerberos here.
+///
+/// See the SPNs `setspn` registers for VMConnect.exe: [Missing or incorrect service principal
+/// names](https://learn.microsoft.com/en-us/troubleshoot/system-center/vmm/authentication-authorization-problems).
+const HYPERV_SPN_SERVICE_CLASS: &str = "Microsoft Virtual Console Service";
 
 /// How the beginning of the connection is ordered.
 ///
@@ -72,6 +82,14 @@ impl Front {
         match self {
             Self::Standard => ClientConnectorState::BasicSettingsExchangeSendInitial { selected_protocol },
             Self::HyperV { .. } => ClientConnectorState::ConnectionInitiationSendRequest,
+        }
+    }
+
+    /// The service we authenticate against.
+    fn spn_service_class(&self) -> &'static str {
+        match self {
+            Self::Standard => DEFAULT_SPN_SERVICE_CLASS,
+            Self::HyperV { .. } => HYPERV_SPN_SERVICE_CLASS,
         }
     }
 
@@ -262,6 +280,7 @@ impl State for ClientConnectorState {
 }
 
 #[derive(Debug)]
+#[expect(clippy::partial_pub_fields, reason = "`Front` is an implementation detail")]
 pub struct ClientConnector {
     pub config: Config,
     pub state: ClientConnectorState,
@@ -288,6 +307,10 @@ impl ClientConnector {
     ///
     /// A Hyper-V console only accepts TLS and NLA, so [`Config::enable_tls`] and
     /// [`Config::enable_credssp`] are not consulted: both always happen.
+    ///
+    /// The transport underneath must be plain bytes to the host: a socket, or a tunnel such as an
+    /// RDS gateway. A proxy that negotiates X.224 for you, the way RDCleanPath does, expects that
+    /// to happen first, but here it happens last — `skip_connect_begin` panics on the mismatch.
     pub fn new_vmconnect(config: Config, client_addr: SocketAddr, vm_id: String) -> Self {
         Self::with_front(config, client_addr, Front::HyperV { vm_id })
     }
@@ -335,6 +358,14 @@ impl ClientConnector {
         self.static_channels
             .get_by_type_mut::<T>()
             .and_then(|channel| channel.channel_processor_downcast_mut())
+    }
+
+    /// The SPN service class to authenticate against, for [`CredsspSequence::init`]. Only the
+    /// connector knows whether this connection targets a Hyper-V console or a Remote Desktop host.
+    ///
+    /// [`CredsspSequence::init`]: crate::credssp::CredsspSequence::init
+    pub fn spn_service_class(&self) -> &'static str {
+        self.front.spn_service_class()
     }
 
     pub fn should_perform_security_upgrade(&self) -> bool {

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -285,6 +285,9 @@ impl ClientConnector {
     /// then CredSSP, then the X.224 negotiation — after which it rejoins the shared sequence at the
     /// Basic Settings Exchange. The async and blocking drivers run it exactly like a standard
     /// connection.
+    ///
+    /// A Hyper-V console only accepts TLS and NLA, so [`Config::enable_tls`] and
+    /// [`Config::enable_credssp`] are not consulted: both always happen.
     pub fn new_vmconnect(config: Config, client_addr: SocketAddr, vm_id: String) -> Self {
         Self::with_front(config, client_addr, Front::HyperV { vm_id })
     }
@@ -523,6 +526,8 @@ impl Sequence for ClientConnector {
 
                 let written = ironrdp_core::encode_buf(&pcb, output).map_err(ConnectorError::encode)?;
 
+                // Nothing is negotiated yet, so this is the protocol we are going to perform rather
+                // than one the host picked; the X.224 exchange later holds the host to it.
                 (
                     Written::from_size(written)?,
                     ClientConnectorState::EnhancedSecurityUpgrade {

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -19,13 +19,15 @@ use crate::{
     NegotiationFailure, Sequence, State, Written, encode_x224_packet, general_err, reason_err,
 };
 
-/// Security protocols advertised in the vmconnect X.224 connection request.
+/// Security protocols advertised in the Hyper-V X.224 connection request.
 ///
-/// Matches what mstsc/FreeRDP offer for a Hyper-V console; a Direct Approach host answers with
-/// plain `HYBRID` (see the [RDP Negotiation Request]).
+/// Matches what mstsc offers for a Hyper-V console; a Direct Approach host answers with plain
+/// `HYBRID`.
 ///
-/// [RDP Negotiation Request]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/902b090b-9cb3-4efc-92bf-ee13373371e3
-pub const HYPERV_SECURITY_PROTOCOL: nego::SecurityProtocol = nego::SecurityProtocol::HYBRID_EX
+/// [2.2.1.1.1] RDP Negotiation Request (RDP_NEG_REQ)
+///
+/// [2.2.1.1.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/902b090b-9cb3-4efc-92bf-ee13373371e3
+const HYPERV_SECURITY_PROTOCOL: nego::SecurityProtocol = nego::SecurityProtocol::HYBRID_EX
     .union(nego::SecurityProtocol::SSL)
     .union(nego::SecurityProtocol::HYBRID);
 
@@ -52,7 +54,7 @@ impl Front {
     fn initial_state(&self) -> ClientConnectorState {
         match self {
             Self::Standard => ClientConnectorState::ConnectionInitiationSendRequest,
-            Self::HyperV { .. } => ClientConnectorState::SendPreconnectionBlob,
+            Self::HyperV { .. } => ClientConnectorState::PreconnectionBlobSendRequest,
         }
     }
 
@@ -121,15 +123,13 @@ impl Front {
                     ));
                 }
             }
-            // NLA already ran with plain HYBRID before this exchange, so the host must confirm
-            // exactly that. Anything else — SSL, or HYBRID_EX, which would imply an Early User
-            // Authorization Result we never negotiated — would be echoed into Client Core Data as a
-            // protocol we did not actually perform.
+            // Accepting anything else would echo a protocol we never performed into Client Core
+            // Data: NLA already ran with plain HYBRID by this point.
             Self::HyperV { .. } => {
                 if selected_protocol != HYPERV_REQUIRED_PROTOCOL {
                     return Err(reason_err!(
                         "Initiation",
-                        "Hyper-V requires the server to select {HYPERV_REQUIRED_PROTOCOL}, but it selected {selected_protocol}",
+                        "server must select {HYPERV_REQUIRED_PROTOCOL} for a Hyper-V console, but it selected {selected_protocol}",
                     ));
                 }
             }
@@ -181,7 +181,7 @@ pub enum ClientConnectorState {
     ConnectionInitiationWaitConfirm {
         requested_protocol: nego::SecurityProtocol,
     },
-    SendPreconnectionBlob,
+    PreconnectionBlobSendRequest,
     EnhancedSecurityUpgrade {
         selected_protocol: nego::SecurityProtocol,
     },
@@ -232,7 +232,7 @@ impl State for ClientConnectorState {
             Self::Consumed => "Consumed",
             Self::ConnectionInitiationSendRequest => "ConnectionInitiationSendRequest",
             Self::ConnectionInitiationWaitConfirm { .. } => "ConnectionInitiationWaitResponse",
-            Self::SendPreconnectionBlob => "SendPreconnectionBlob",
+            Self::PreconnectionBlobSendRequest => "PreconnectionBlobSendRequest",
             Self::EnhancedSecurityUpgrade { .. } => "EnhancedSecurityUpgrade",
             Self::Credssp { .. } => "Credssp",
             Self::BasicSettingsExchangeSendInitial { .. } => "BasicSettingsExchangeSendInitial",
@@ -387,11 +387,9 @@ fn advance_licensing_exchange(
     Ok((written, next_state))
 }
 
-/// Decodes an X.224 Connection Confirm, mapping a negotiation Failure to an error.
-///
-/// Shared by the standard connection initiation and the Hyper-V vmconnect negotiation, which
-/// differ only in which selected protocol they then accept.
-fn decode_connection_confirm(input: &[u8]) -> ConnectorResult<(nego::ResponseFlags, nego::SecurityProtocol)> {
+/// Decodes an X.224 Connection Confirm and returns the protocol the server selected, mapping a
+/// negotiation Failure to an error.
+fn decode_connection_confirm(input: &[u8]) -> ConnectorResult<nego::SecurityProtocol> {
     let connection_confirm = decode::<X224<nego::ConnectionConfirm>>(input)
         .map_err(ConnectorError::decode)
         .map(|p| p.0)?;
@@ -411,7 +409,7 @@ fn decode_connection_confirm(input: &[u8]) -> ConnectorResult<(nego::ResponseFla
 
     info!(?selected_protocol, ?flags, "Server confirmed connection");
 
-    Ok((flags, selected_protocol))
+    Ok(selected_protocol)
 }
 
 impl Sequence for ClientConnector {
@@ -420,7 +418,7 @@ impl Sequence for ClientConnector {
             ClientConnectorState::Consumed => None,
             ClientConnectorState::ConnectionInitiationSendRequest => None,
             ClientConnectorState::ConnectionInitiationWaitConfirm { .. } => Some(&ironrdp_pdu::X224_HINT),
-            ClientConnectorState::SendPreconnectionBlob => None,
+            ClientConnectorState::PreconnectionBlobSendRequest => None,
             ClientConnectorState::EnhancedSecurityUpgrade { .. } => None,
             ClientConnectorState::Credssp { .. } => None,
             ClientConnectorState::BasicSettingsExchangeSendInitial { .. } => None,
@@ -496,7 +494,7 @@ impl Sequence for ClientConnector {
                 )
             }
             ClientConnectorState::ConnectionInitiationWaitConfirm { requested_protocol } => {
-                let (_flags, selected_protocol) = decode_connection_confirm(input)?;
+                let selected_protocol = decode_connection_confirm(input)?;
 
                 self.front
                     .accept_selected_protocol(selected_protocol, requested_protocol)?;
@@ -505,13 +503,13 @@ impl Sequence for ClientConnector {
             }
 
             //== Preconnection Blob ==//
-            // Routes the connection to a Hyper-V VM console before anything else is exchanged. The
-            // shared EnhancedSecurityUpgrade and Credssp states below then service TLS and NLA, so
-            // the standard drivers run this ordering untouched.
-            ClientConnectorState::SendPreconnectionBlob => {
+            // The host needs this to route the connection to the VM console before anything else is
+            // exchanged.
+            ClientConnectorState::PreconnectionBlobSendRequest => {
+                // `Front::initial_state` only reaches this state for `Front::HyperV`.
                 let Front::HyperV { vm_id } = &self.front else {
                     return Err(general_err!(
-                        "Preconnection Blob is only sent for a Hyper-V connection (this is a bug)"
+                        "preconnection blob is only sent for a Hyper-V connection (this is a bug)"
                     ));
                 };
 

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use ironrdp_core::{Encode, WriteBuf, decode, encode_vec};
 use ironrdp_pdu::x224::X224;
-use ironrdp_pdu::{PduHint, gcc, mcs, nego, rdp};
+use ironrdp_pdu::{PduHint, gcc, mcs, nego, pcb, rdp};
 use ironrdp_svc::{StaticChannelSet, StaticVirtualChannel, SvcClientProcessor};
 use tracing::{debug, error, info, warn};
 
@@ -18,6 +18,126 @@ use crate::{
     Config, ConnectorError, ConnectorErrorExt as _, ConnectorErrorKind, ConnectorResult, DesktopSize,
     NegotiationFailure, Sequence, State, Written, encode_x224_packet, general_err, reason_err,
 };
+
+/// Security protocols advertised in the vmconnect X.224 connection request.
+///
+/// Matches what mstsc/FreeRDP offer for a Hyper-V console; a Direct Approach host answers with
+/// plain `HYBRID` (see the [RDP Negotiation Request]).
+///
+/// [RDP Negotiation Request]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/902b090b-9cb3-4efc-92bf-ee13373371e3
+pub const HYPERV_SECURITY_PROTOCOL: nego::SecurityProtocol = nego::SecurityProtocol::HYBRID_EX
+    .union(nego::SecurityProtocol::SSL)
+    .union(nego::SecurityProtocol::HYBRID);
+
+/// The one protocol a Hyper-V console connection actually performs: NLA runs with it, and the host
+/// must confirm exactly it.
+const HYPERV_REQUIRED_PROTOCOL: nego::SecurityProtocol = nego::SecurityProtocol::HYBRID;
+
+/// How the beginning of the connection is ordered.
+///
+/// Standard RDP and a Hyper-V console run the same steps; they only disagree about when the X.224
+/// negotiation happens. Everything from the Basic Settings Exchange onward is shared, so this is the
+/// whole difference between the two — see the transition table in the [`Front`] methods below.
+#[derive(Debug)]
+enum Front {
+    /// Negotiate X.224 first, then upgrade security and authenticate.
+    Standard,
+    /// Route to the VM console with a Preconnection Blob, upgrade security and authenticate, and
+    /// negotiate X.224 last (the Direct Approach).
+    HyperV { vm_id: String },
+}
+
+impl Front {
+    /// Where the connection starts.
+    fn initial_state(&self) -> ClientConnectorState {
+        match self {
+            Self::Standard => ClientConnectorState::ConnectionInitiationSendRequest,
+            Self::HyperV { .. } => ClientConnectorState::SendPreconnectionBlob,
+        }
+    }
+
+    /// Where the X.224 negotiation leads.
+    fn after_initiation(&self, selected_protocol: nego::SecurityProtocol) -> ClientConnectorState {
+        match self {
+            Self::Standard => ClientConnectorState::EnhancedSecurityUpgrade { selected_protocol },
+            Self::HyperV { .. } => ClientConnectorState::BasicSettingsExchangeSendInitial { selected_protocol },
+        }
+    }
+
+    /// Where authentication leads. Mirrors [`Front::after_initiation`]: whichever of the two ran
+    /// last hands over to the Basic Settings Exchange.
+    fn after_credssp(&self, selected_protocol: nego::SecurityProtocol) -> ClientConnectorState {
+        match self {
+            Self::Standard => ClientConnectorState::BasicSettingsExchangeSendInitial { selected_protocol },
+            Self::HyperV { .. } => ClientConnectorState::ConnectionInitiationSendRequest,
+        }
+    }
+
+    /// The security protocols to advertise in the X.224 connection request.
+    fn advertised_protocol(&self, config: &Config) -> ConnectorResult<nego::SecurityProtocol> {
+        match self {
+            Self::HyperV { .. } => Ok(HYPERV_SECURITY_PROTOCOL),
+            Self::Standard => {
+                let mut security_protocol = nego::SecurityProtocol::empty();
+
+                if config.enable_tls {
+                    security_protocol.insert(nego::SecurityProtocol::SSL);
+                }
+
+                if config.enable_credssp {
+                    // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/902b090b-9cb3-4efc-92bf-ee13373371e3
+                    // The spec is stating that `PROTOCOL_SSL` "SHOULD" also be set when using `PROTOCOL_HYBRID`.
+                    // > PROTOCOL_HYBRID (0x00000002)
+                    // > Credential Security Support Provider protocol (CredSSP) (section 5.4.5.2).
+                    // > If this flag is set, then the PROTOCOL_SSL (0x00000001) flag SHOULD also be set
+                    // > because Transport Layer Security (TLS) is a subset of CredSSP.
+                    // However, crucially, it’s not strictly required (not "MUST").
+                    // In fact, we purposefully choose to not set `PROTOCOL_SSL` unless `enable_winlogon` is `true`.
+                    // This tells the server that we are not going to accept downgrading NLA to TLS security.
+                    security_protocol.insert(nego::SecurityProtocol::HYBRID | nego::SecurityProtocol::HYBRID_EX);
+                }
+
+                if security_protocol.is_standard_rdp_security() {
+                    return Err(reason_err!("Initiation", "standard RDP security is not supported",));
+                }
+
+                Ok(security_protocol)
+            }
+        }
+    }
+
+    /// Checks the protocol the server selected against what this ordering can accept.
+    fn accept_selected_protocol(
+        &self,
+        selected_protocol: nego::SecurityProtocol,
+        requested_protocol: nego::SecurityProtocol,
+    ) -> ConnectorResult<()> {
+        match self {
+            Self::Standard => {
+                if !selected_protocol.intersects(requested_protocol) {
+                    return Err(reason_err!(
+                        "Initiation",
+                        "client advertised {requested_protocol}, but server selected {selected_protocol}",
+                    ));
+                }
+            }
+            // NLA already ran with plain HYBRID before this exchange, so the host must confirm
+            // exactly that. Anything else — SSL, or HYBRID_EX, which would imply an Early User
+            // Authorization Result we never negotiated — would be echoed into Client Core Data as a
+            // protocol we did not actually perform.
+            Self::HyperV { .. } => {
+                if selected_protocol != HYPERV_REQUIRED_PROTOCOL {
+                    return Err(reason_err!(
+                        "Initiation",
+                        "Hyper-V requires the server to select {HYPERV_REQUIRED_PROTOCOL}, but it selected {selected_protocol}",
+                    ));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
 
 #[derive(Debug)]
 pub struct ConnectionResult {
@@ -61,6 +181,7 @@ pub enum ClientConnectorState {
     ConnectionInitiationWaitConfirm {
         requested_protocol: nego::SecurityProtocol,
     },
+    SendPreconnectionBlob,
     EnhancedSecurityUpgrade {
         selected_protocol: nego::SecurityProtocol,
     },
@@ -111,6 +232,7 @@ impl State for ClientConnectorState {
             Self::Consumed => "Consumed",
             Self::ConnectionInitiationSendRequest => "ConnectionInitiationSendRequest",
             Self::ConnectionInitiationWaitConfirm { .. } => "ConnectionInitiationWaitResponse",
+            Self::SendPreconnectionBlob => "SendPreconnectionBlob",
             Self::EnhancedSecurityUpgrade { .. } => "EnhancedSecurityUpgrade",
             Self::Credssp { .. } => "Credssp",
             Self::BasicSettingsExchangeSendInitial { .. } => "BasicSettingsExchangeSendInitial",
@@ -148,16 +270,33 @@ pub struct ClientConnector {
     pub static_channels: StaticChannelSet,
     /// MCS message channel ID assigned by the server, once negotiated.
     pub message_channel_id: Option<u16>,
+    /// How the front of this connection is ordered.
+    front: Front,
 }
 
 impl ClientConnector {
     pub fn new(config: Config, client_addr: SocketAddr) -> Self {
+        Self::with_front(config, client_addr, Front::Standard)
+    }
+
+    /// Creates a connector for a Hyper-V console session, identified by `vm_id` (a VM GUID).
+    ///
+    /// The connection runs the Hyper-V ordering: a Preconnection Blob carrying `vm_id`, then TLS,
+    /// then CredSSP, then the X.224 negotiation — after which it rejoins the shared sequence at the
+    /// Basic Settings Exchange. The async and blocking drivers run it exactly like a standard
+    /// connection.
+    pub fn new_vmconnect(config: Config, client_addr: SocketAddr, vm_id: String) -> Self {
+        Self::with_front(config, client_addr, Front::HyperV { vm_id })
+    }
+
+    fn with_front(config: Config, client_addr: SocketAddr, front: Front) -> Self {
         Self {
             config,
-            state: ClientConnectorState::ConnectionInitiationSendRequest,
+            state: front.initial_state(),
             client_addr,
             static_channels: StaticChannelSet::new(),
             message_channel_id: None,
+            front,
         }
     }
 
@@ -248,12 +387,40 @@ fn advance_licensing_exchange(
     Ok((written, next_state))
 }
 
+/// Decodes an X.224 Connection Confirm, mapping a negotiation Failure to an error.
+///
+/// Shared by the standard connection initiation and the Hyper-V vmconnect negotiation, which
+/// differ only in which selected protocol they then accept.
+fn decode_connection_confirm(input: &[u8]) -> ConnectorResult<(nego::ResponseFlags, nego::SecurityProtocol)> {
+    let connection_confirm = decode::<X224<nego::ConnectionConfirm>>(input)
+        .map_err(ConnectorError::decode)
+        .map(|p| p.0)?;
+
+    debug!(message = ?connection_confirm, "Received");
+
+    let (flags, selected_protocol) = match connection_confirm {
+        nego::ConnectionConfirm::Response { flags, protocol } => (flags, protocol),
+        nego::ConnectionConfirm::Failure { code } => {
+            error!(?code, "Received connection failure code");
+            return Err(ConnectorError::new(
+                "negotiation failure",
+                ConnectorErrorKind::Negotiation(NegotiationFailure::from(code)),
+            ));
+        }
+    };
+
+    info!(?selected_protocol, ?flags, "Server confirmed connection");
+
+    Ok((flags, selected_protocol))
+}
+
 impl Sequence for ClientConnector {
     fn next_pdu_hint(&self) -> Option<&dyn PduHint> {
         match &self.state {
             ClientConnectorState::Consumed => None,
             ClientConnectorState::ConnectionInitiationSendRequest => None,
             ClientConnectorState::ConnectionInitiationWaitConfirm { .. } => Some(&ironrdp_pdu::X224_HINT),
+            ClientConnectorState::SendPreconnectionBlob => None,
             ClientConnectorState::EnhancedSecurityUpgrade { .. } => None,
             ClientConnectorState::Credssp { .. } => None,
             ClientConnectorState::BasicSettingsExchangeSendInitial { .. } => None,
@@ -298,32 +465,12 @@ impl Sequence for ClientConnector {
             }
 
             //== Connection Initiation ==//
-            // Exchange supported security protocols and a few other connection flags.
+            // Exchange supported security protocols and a few other connection flags. Runs first for
+            // a standard connection, and last in the front for a Hyper-V console.
             ClientConnectorState::ConnectionInitiationSendRequest => {
                 debug!("Connection Initiation");
 
-                let mut security_protocol = nego::SecurityProtocol::empty();
-
-                if self.config.enable_tls {
-                    security_protocol.insert(nego::SecurityProtocol::SSL);
-                }
-
-                if self.config.enable_credssp {
-                    // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/902b090b-9cb3-4efc-92bf-ee13373371e3
-                    // The spec is stating that `PROTOCOL_SSL` "SHOULD" also be set when using `PROTOCOL_HYBRID`.
-                    // > PROTOCOL_HYBRID (0x00000002)
-                    // > Credential Security Support Provider protocol (CredSSP) (section 5.4.5.2).
-                    // > If this flag is set, then the PROTOCOL_SSL (0x00000001) flag SHOULD also be set
-                    // > because Transport Layer Security (TLS) is a subset of CredSSP.
-                    // However, crucially, it’s not strictly required (not "MUST").
-                    // In fact, we purposefully choose to not set `PROTOCOL_SSL` unless `enable_winlogon` is `true`.
-                    // This tells the server that we are not going to accept downgrading NLA to TLS security.
-                    security_protocol.insert(nego::SecurityProtocol::HYBRID | nego::SecurityProtocol::HYBRID_EX);
-                }
-
-                if security_protocol.is_standard_rdp_security() {
-                    return Err(reason_err!("Initiation", "standard RDP security is not supported",));
-                }
+                let security_protocol = self.front.advertised_protocol(&self.config)?;
 
                 let connection_request = nego::ConnectionRequest {
                     nego_data: self.config.request_data.clone().or_else(|| {
@@ -349,35 +496,40 @@ impl Sequence for ClientConnector {
                 )
             }
             ClientConnectorState::ConnectionInitiationWaitConfirm { requested_protocol } => {
-                let connection_confirm = decode::<X224<nego::ConnectionConfirm>>(input)
-                    .map_err(ConnectorError::decode)
-                    .map(|p| p.0)?;
+                let (_flags, selected_protocol) = decode_connection_confirm(input)?;
 
-                debug!(message = ?connection_confirm, "Received");
+                self.front
+                    .accept_selected_protocol(selected_protocol, requested_protocol)?;
 
-                let (flags, selected_protocol) = match connection_confirm {
-                    nego::ConnectionConfirm::Response { flags, protocol } => (flags, protocol),
-                    nego::ConnectionConfirm::Failure { code } => {
-                        error!(?code, "Received connection failure code");
-                        return Err(ConnectorError::new(
-                            "negotiation failure",
-                            ConnectorErrorKind::Negotiation(NegotiationFailure::from(code)),
-                        ));
-                    }
+                (Written::Nothing, self.front.after_initiation(selected_protocol))
+            }
+
+            //== Preconnection Blob ==//
+            // Routes the connection to a Hyper-V VM console before anything else is exchanged. The
+            // shared EnhancedSecurityUpgrade and Credssp states below then service TLS and NLA, so
+            // the standard drivers run this ordering untouched.
+            ClientConnectorState::SendPreconnectionBlob => {
+                let Front::HyperV { vm_id } = &self.front else {
+                    return Err(general_err!(
+                        "Preconnection Blob is only sent for a Hyper-V connection (this is a bug)"
+                    ));
                 };
 
-                info!(?selected_protocol, ?flags, "Server confirmed connection");
+                debug!("Send Preconnection Blob");
 
-                if !selected_protocol.intersects(requested_protocol) {
-                    return Err(reason_err!(
-                        "Initiation",
-                        "client advertised {requested_protocol}, but server selected {selected_protocol}",
-                    ));
-                }
+                let pcb = pcb::PreconnectionBlob {
+                    id: 0,
+                    version: pcb::PcbVersion::V2,
+                    v2_payload: Some(vm_id.clone()),
+                };
+
+                let written = ironrdp_core::encode_buf(&pcb, output).map_err(ConnectorError::encode)?;
 
                 (
-                    Written::Nothing,
-                    ClientConnectorState::EnhancedSecurityUpgrade { selected_protocol },
+                    Written::from_size(written)?,
+                    ClientConnectorState::EnhancedSecurityUpgrade {
+                        selected_protocol: HYPERV_REQUIRED_PROTOCOL,
+                    },
                 )
             }
 
@@ -399,10 +551,9 @@ impl Sequence for ClientConnector {
             }
 
             //== CredSSP ==//
-            ClientConnectorState::Credssp { selected_protocol } => (
-                Written::Nothing,
-                ClientConnectorState::BasicSettingsExchangeSendInitial { selected_protocol },
-            ),
+            ClientConnectorState::Credssp { selected_protocol } => {
+                (Written::Nothing, self.front.after_credssp(selected_protocol))
+            }
 
             //== Basic Settings Exchange ==//
             // Exchange basic settings including Core Data, Security Data and Network Data.

--- a/crates/ironrdp-connector/src/credssp.rs
+++ b/crates/ironrdp-connector/src/credssp.rs
@@ -11,6 +11,9 @@ use crate::{
     ConnectorError, ConnectorErrorKind, ConnectorResult, Credentials, ServerName, Written, custom_err, general_err,
 };
 
+/// SPN service class for a Remote Desktop host, the service a normal RDP connection targets.
+pub const DEFAULT_SPN_SERVICE_CLASS: &str = "TERMSRV";
+
 #[derive(Debug, Clone)]
 pub struct KerberosConfig {
     pub kdc_proxy_url: Option<url::Url>,
@@ -90,12 +93,20 @@ impl CredsspSequence {
         }
     }
 
-    /// `server_name` must be the actual target server hostname (as opposed to the proxy)
+    /// `server_name` must be the actual target server hostname (as opposed to the proxy).
+    ///
+    /// `spn_service_class` is joined with `server_name` to form the SPN. Driving a
+    /// [`ClientConnector`]? Use [`ClientConnector::spn_service_class`]. Otherwise
+    /// [`DEFAULT_SPN_SERVICE_CLASS`] targets a Remote Desktop host.
+    ///
+    /// [`ClientConnector`]: crate::ClientConnector
+    /// [`ClientConnector::spn_service_class`]: crate::ClientConnector::spn_service_class
     pub fn init(
         credentials: Credentials,
         domain: Option<&str>,
         protocol: nego::SecurityProtocol,
         server_name: ServerName,
+        spn_service_class: &str,
         server_public_key: Vec<u8>,
         kerberos_config: Option<KerberosConfig>,
     ) -> ConnectorResult<(Self, credssp::TsRequest)> {
@@ -140,7 +151,7 @@ impl CredsspSequence {
 
         let server_name = server_name.into_inner();
 
-        let service_principal_name = format!("TERMSRV/{}", &server_name);
+        let service_principal_name = format!("{spn_service_class}/{server_name}");
 
         let client_mode = match kerberos_config {
             Some(ref krb_config) => {

--- a/crates/ironrdp-connector/src/lib.rs
+++ b/crates/ironrdp-connector/src/lib.rs
@@ -24,9 +24,7 @@ use ironrdp_pdu::{PduHint, gcc, x224};
 pub use sspi;
 
 pub use self::channel_connection::{ChannelConnectionSequence, ChannelConnectionState};
-pub use self::connection::{
-    ClientConnector, ClientConnectorState, ConnectionResult, HYPERV_SECURITY_PROTOCOL, encode_send_data_request,
-};
+pub use self::connection::{ClientConnector, ClientConnectorState, ConnectionResult, encode_send_data_request};
 pub use self::connection_finalization::{ConnectionFinalizationSequence, ConnectionFinalizationState};
 pub use self::license_exchange::{LicenseExchangeSequence, LicenseExchangeState};
 pub use self::server_name::ServerName;

--- a/crates/ironrdp-connector/src/lib.rs
+++ b/crates/ironrdp-connector/src/lib.rs
@@ -24,7 +24,9 @@ use ironrdp_pdu::{PduHint, gcc, x224};
 pub use sspi;
 
 pub use self::channel_connection::{ChannelConnectionSequence, ChannelConnectionState};
-pub use self::connection::{ClientConnector, ClientConnectorState, ConnectionResult, encode_send_data_request};
+pub use self::connection::{
+    ClientConnector, ClientConnectorState, ConnectionResult, HYPERV_SECURITY_PROTOCOL, encode_send_data_request,
+};
 pub use self::connection_finalization::{ConnectionFinalizationSequence, ConnectionFinalizationState};
 pub use self::license_exchange::{LicenseExchangeSequence, LicenseExchangeState};
 pub use self::server_name::ServerName;

--- a/crates/ironrdp-testsuite-core/tests/connector/autodetect.rs
+++ b/crates/ironrdp-testsuite-core/tests/connector/autodetect.rs
@@ -9,12 +9,10 @@
 
 use std::borrow::Cow;
 
-use ironrdp_connector::{ClientConnector, ClientConnectorState, Credentials, DesktopSize, Sequence as _, Written};
+use ironrdp_connector::{ClientConnector, ClientConnectorState, Sequence as _, Written};
 use ironrdp_core::{WriteBuf, encode_vec};
-use ironrdp_pdu::gcc;
 use ironrdp_pdu::mcs::{McsMessage, SendDataIndication};
 use ironrdp_pdu::rdp::autodetect::{AutoDetectReqPdu, AutoDetectRequest};
-use ironrdp_pdu::rdp::capability_sets::MajorPlatformType;
 use ironrdp_pdu::rdp::headers::{BasicSecurityHeader, BasicSecurityHeaderFlags};
 use ironrdp_pdu::rdp::server_license::{
     LicenseErrorCode, LicenseHeader, LicensePdu, LicensingErrorMessage, LicensingStateTransition, PreambleFlags,
@@ -22,50 +20,11 @@ use ironrdp_pdu::rdp::server_license::{
 };
 use ironrdp_pdu::x224::X224;
 
+use super::test_config;
+
 const USER_CHANNEL_ID: u16 = 1002;
 const IO_CHANNEL_ID: u16 = 1003;
 const MESSAGE_CHANNEL_ID: u16 = 1004;
-
-fn test_config() -> ironrdp_connector::Config {
-    ironrdp_connector::Config {
-        desktop_size: DesktopSize {
-            width: 1024,
-            height: 768,
-        },
-        desktop_scale_factor: 0,
-        enable_tls: true,
-        enable_credssp: false,
-        credentials: Credentials::UsernamePassword {
-            username: "test".into(),
-            password: "test".into(),
-        },
-        domain: None,
-        client_build: 0,
-        client_name: "test".into(),
-        keyboard_type: gcc::KeyboardType::IbmEnhanced,
-        keyboard_subtype: 0,
-        keyboard_layout: 0,
-        keyboard_functional_keys_count: 12,
-        ime_file_name: String::new(),
-        bitmap: None,
-        dig_product_id: String::new(),
-        client_dir: String::new(),
-        platform: MajorPlatformType::UNIX,
-        hardware_id: None,
-        request_data: None,
-        autologon: false,
-        enable_audio_playback: false,
-        license_cache: None,
-        compression_type: None,
-        enable_server_pointer: false,
-        pointer_software_rendering: false,
-        multitransport_flags: None,
-        performance_flags: Default::default(),
-        timezone_info: Default::default(),
-        alternate_shell: String::new(),
-        work_dir: String::new(),
-    }
-}
 
 /// A client connector parked in `ConnectTimeAutoDetection` with a negotiated
 /// message channel, ready to receive the first PDU of that phase.

--- a/crates/ironrdp-testsuite-core/tests/connector/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/connector/mod.rs
@@ -1,1 +1,48 @@
 mod autodetect;
+mod vmconnect;
+
+use ironrdp_connector::{Credentials, DesktopSize};
+use ironrdp_pdu::gcc;
+use ironrdp_pdu::rdp::capability_sets::MajorPlatformType;
+
+/// A minimal client configuration: TLS advertised, NLA off, no bitmap codecs.
+pub(crate) fn test_config() -> ironrdp_connector::Config {
+    ironrdp_connector::Config {
+        desktop_size: DesktopSize {
+            width: 1024,
+            height: 768,
+        },
+        desktop_scale_factor: 0,
+        enable_tls: true,
+        enable_credssp: false,
+        credentials: Credentials::UsernamePassword {
+            username: "test".into(),
+            password: "test".into(),
+        },
+        domain: None,
+        client_build: 0,
+        client_name: "test".into(),
+        keyboard_type: gcc::KeyboardType::IbmEnhanced,
+        keyboard_subtype: 0,
+        keyboard_layout: 0,
+        keyboard_functional_keys_count: 12,
+        ime_file_name: String::new(),
+        bitmap: None,
+        dig_product_id: String::new(),
+        client_dir: String::new(),
+        platform: MajorPlatformType::UNIX,
+        hardware_id: None,
+        request_data: None,
+        autologon: false,
+        enable_audio_playback: false,
+        license_cache: None,
+        compression_type: None,
+        enable_server_pointer: false,
+        pointer_software_rendering: false,
+        multitransport_flags: None,
+        performance_flags: Default::default(),
+        timezone_info: Default::default(),
+        alternate_shell: String::new(),
+        work_dir: String::new(),
+    }
+}

--- a/crates/ironrdp-testsuite-core/tests/connector/vmconnect.rs
+++ b/crates/ironrdp-testsuite-core/tests/connector/vmconnect.rs
@@ -1,0 +1,148 @@
+//! Front ordering of the client connector.
+//!
+//! A standard connection negotiates X.224 first and upgrades security afterwards. A Hyper-V console
+//! sends a Preconnection Blob, upgrades security, authenticates, and only then negotiates X.224 —
+//! and the host must select plain `HYBRID`, since NLA has already run by that point. Both orderings
+//! share the X.224 initiation states, so the standard path is covered here too.
+
+use ironrdp_connector::{ClientConnector, ClientConnectorState, Sequence as _};
+use ironrdp_core::{WriteBuf, encode_vec};
+use ironrdp_pdu::nego::{ConnectionConfirm, ResponseFlags, SecurityProtocol};
+use ironrdp_pdu::x224::X224;
+
+use super::test_config;
+
+const VM_ID: &str = "efd1efab-c750-4262-b1bb-af0f7733bdd6";
+
+fn vmconnect_connector() -> ClientConnector {
+    ClientConnector::new_vmconnect(test_config(), "127.0.0.1:12345".parse().unwrap(), VM_ID.to_owned())
+}
+
+fn server_connection_confirm(protocol: SecurityProtocol) -> Vec<u8> {
+    encode_vec(&X224(ConnectionConfirm::Response {
+        flags: ResponseFlags::empty(),
+        protocol,
+    }))
+    .unwrap()
+}
+
+/// Drives a vmconnect connector up to the point where it awaits the X.224 connection confirm.
+fn vmconnect_connector_awaiting_confirm() -> ClientConnector {
+    let mut connector = vmconnect_connector();
+    let mut output = WriteBuf::new();
+
+    connector.step_no_input(&mut output).unwrap();
+    connector.mark_security_upgrade_as_done();
+    connector.mark_credssp_as_done();
+    output.clear();
+    connector.step_no_input(&mut output).unwrap();
+
+    connector
+}
+
+#[test]
+fn vmconnect_sends_preconnection_blob_then_negotiates_x224_after_nla() {
+    let mut connector = vmconnect_connector();
+    let mut output = WriteBuf::new();
+
+    assert!(matches!(
+        connector.state,
+        ClientConnectorState::PreconnectionBlobSendRequest
+    ));
+
+    let written = connector.step_no_input(&mut output).unwrap();
+    assert!(written.size().is_some(), "the preconnection blob must be written");
+
+    let vm_id_utf16: Vec<u8> = VM_ID.encode_utf16().flat_map(u16::to_le_bytes).collect();
+    assert!(
+        output
+            .filled()
+            .windows(vm_id_utf16.len())
+            .any(|window| window == vm_id_utf16),
+        "the preconnection blob must carry the VM ID"
+    );
+
+    // TLS and NLA both run before the negotiation, exactly as for a standard connection.
+    assert!(connector.should_perform_security_upgrade());
+    connector.mark_security_upgrade_as_done();
+    assert!(connector.should_perform_credssp());
+    connector.mark_credssp_as_done();
+
+    assert!(
+        matches!(connector.state, ClientConnectorState::ConnectionInitiationSendRequest),
+        "the X.224 negotiation happens last for a Hyper-V console"
+    );
+
+    output.clear();
+    let written = connector.step_no_input(&mut output).unwrap();
+    assert!(written.size().is_some(), "the connection request must be written");
+
+    output.clear();
+    connector
+        .step(&server_connection_confirm(SecurityProtocol::HYBRID), &mut output)
+        .unwrap();
+
+    assert!(
+        matches!(
+            connector.state,
+            ClientConnectorState::BasicSettingsExchangeSendInitial { .. }
+        ),
+        "a confirmed negotiation hands over to the shared tail"
+    );
+}
+
+#[test]
+fn vmconnect_rejects_a_host_that_does_not_select_plain_hybrid() {
+    // NLA already ran with plain HYBRID, so anything else would be echoed into Client Core Data as
+    // a protocol that was never performed.
+    for protocol in [
+        SecurityProtocol::HYBRID_EX,
+        SecurityProtocol::SSL,
+        SecurityProtocol::HYBRID | SecurityProtocol::SSL,
+    ] {
+        let mut connector = vmconnect_connector_awaiting_confirm();
+        let mut output = WriteBuf::new();
+
+        let result = connector.step(&server_connection_confirm(protocol), &mut output);
+
+        assert!(result.is_err(), "{protocol} must be rejected for a Hyper-V console");
+    }
+}
+
+#[test]
+fn standard_connection_still_negotiates_x224_first() {
+    let mut connector = ClientConnector::new(test_config(), "127.0.0.1:12345".parse().unwrap());
+    let mut output = WriteBuf::new();
+
+    assert!(matches!(
+        connector.state,
+        ClientConnectorState::ConnectionInitiationSendRequest
+    ));
+
+    let written = connector.step_no_input(&mut output).unwrap();
+    assert!(written.size().is_some(), "the connection request must be written");
+
+    // `test_config` advertises TLS only, so the server selecting it is accepted.
+    output.clear();
+    connector
+        .step(&server_connection_confirm(SecurityProtocol::SSL), &mut output)
+        .unwrap();
+
+    assert!(
+        matches!(connector.state, ClientConnectorState::EnhancedSecurityUpgrade { .. }),
+        "a standard connection upgrades security after the negotiation"
+    );
+}
+
+#[test]
+fn standard_connection_rejects_a_protocol_it_did_not_advertise() {
+    let mut connector = ClientConnector::new(test_config(), "127.0.0.1:12345".parse().unwrap());
+    let mut output = WriteBuf::new();
+
+    connector.step_no_input(&mut output).unwrap();
+    output.clear();
+
+    let result = connector.step(&server_connection_confirm(SecurityProtocol::HYBRID_EX), &mut output);
+
+    assert!(result.is_err(), "the server must not select an unadvertised protocol");
+}

--- a/crates/ironrdp-testsuite-core/tests/connector/vmconnect.rs
+++ b/crates/ironrdp-testsuite-core/tests/connector/vmconnect.rs
@@ -109,6 +109,20 @@ fn vmconnect_rejects_a_host_that_does_not_select_plain_hybrid() {
     }
 }
 
+/// The console is a separate service from the Remote Desktop host and registers its own SPN, so
+/// asking for `TERMSRV` would fail Kerberos against a Hyper-V host.
+#[test]
+fn vmconnect_authenticates_against_the_virtual_console_service() {
+    assert_eq!(
+        vmconnect_connector().spn_service_class(),
+        "Microsoft Virtual Console Service"
+    );
+    assert_eq!(
+        ClientConnector::new(test_config(), "127.0.0.1:12345".parse().unwrap()).spn_service_class(),
+        "TERMSRV"
+    );
+}
+
 #[test]
 fn standard_connection_still_negotiates_x224_first() {
     let mut connector = ClientConnector::new(test_config(), "127.0.0.1:12345".parse().unwrap());

--- a/crates/ironrdp-testsuite-extra/Cargo.toml
+++ b/crates/ironrdp-testsuite-extra/Cargo.toml
@@ -42,6 +42,7 @@ semver = "1.0"
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1", features = ["sync", "time", "net", "rt", "macros", "io-util"] }
+url = "2"
 uuid = { version = "1", features = ["v4"] }
 
 [lints]

--- a/crates/ironrdp-testsuite-extra/tests/client_config.rs
+++ b/crates/ironrdp-testsuite-extra/tests/client_config.rs
@@ -1,8 +1,10 @@
 use std::fs;
 use std::path::PathBuf;
 
-use ironrdp_client::config::{ClipboardType, Transport};
+use ironrdp::pdu::rdp::capability_sets::MajorPlatformType;
+use ironrdp_client::config::{ClipboardType, ConfigBuilder, Destination, Transport, TransportKind};
 use ironrdp_viewer::cli::parse_config_from;
+use url::Url;
 use uuid::Uuid;
 
 struct TempRdpFile {
@@ -162,4 +164,46 @@ fn out_of_range_desktop_dimensions_fall_back_to_defaults() {
         invalid_config.connector().desktop_size.height,
         default_config.connector().desktop_size.height
     );
+}
+
+/// A builder with every required field filled in, ready for a transport to be selected.
+fn vmconnect_builder() -> ConfigBuilder {
+    ConfigBuilder::new()
+        .with_destination(Destination::new("hyperv-host.example.com:2179").expect("valid destination"))
+        .with_username("test-user")
+        .with_password("test-pass")
+        .with_client_build(0)
+        .with_client_dir(String::new())
+        .with_client_name("test")
+        .with_platform(MajorPlatformType::UNIX)
+        .with_vmconnect("efd1efab-c750-4262-b1bb-af0f7733bdd6")
+}
+
+#[test]
+fn vmconnect_is_rejected_over_rdcleanpath() {
+    let err = vmconnect_builder()
+        .with_transport(TransportKind::RDCleanPath {
+            url: Url::parse("wss://proxy.example.com").expect("valid URL"),
+        })
+        .with_rdcleanpath_token("token")
+        .build()
+        .expect_err("RDCleanPath negotiates X.224 for us, which vmconnect cannot accommodate");
+
+    assert!(err.to_string().contains("vmconnect"), "unexpected error: {err}");
+}
+
+/// A gateway is only a tunnel, so the connector still drives the Hyper-V ordering itself.
+#[test]
+fn vmconnect_is_allowed_over_a_gateway() {
+    let config = vmconnect_builder()
+        .with_transport(TransportKind::Gateway {
+            endpoint: "gw.example.com:443".to_owned(),
+        })
+        .with_gateway_username("gw-user")
+        .with_gateway_password("gw-pass")
+        .build()
+        .expect("gateway vmconnect should build");
+
+    assert_eq!(config.vm_id(), Some("efd1efab-c750-4262-b1bb-af0f7733bdd6"));
+    assert!(matches!(config.transport(), Transport::Gateway(_)));
 }

--- a/crates/ironrdp-testsuite-extra/tests/client_config.rs
+++ b/crates/ironrdp-testsuite-extra/tests/client_config.rs
@@ -166,6 +166,16 @@ fn out_of_range_desktop_dimensions_fall_back_to_defaults() {
     );
 }
 
+#[test]
+fn vmconnect_cli_flag_reaches_the_config() {
+    let config = parse_config_from_rdp(
+        "full address:s:hyperv-host.example.com:2179\nusername:s:test-user\nClearTextPassword:s:test-pass\n",
+        &["--vmconnect", "efd1efab-c750-4262-b1bb-af0f7733bdd6"],
+    );
+
+    assert_eq!(config.vm_id(), Some("efd1efab-c750-4262-b1bb-af0f7733bdd6"));
+}
+
 /// A builder with every required field filled in, ready for a transport to be selected.
 fn vmconnect_builder() -> ConfigBuilder {
     ConfigBuilder::new()

--- a/crates/ironrdp-viewer/src/cli.rs
+++ b/crates/ironrdp-viewer/src/cli.rs
@@ -98,6 +98,12 @@ struct Args {
     #[clap(long, requires("rdcleanpath_url"))]
     rdcleanpath_token: Option<String>,
 
+    /// Connect to a Hyper-V VM console instead of an RDP host, by VM ID (`Get-VM | Select Id`).
+    ///
+    /// The destination is the Hyper-V host, which listens on port 2179.
+    #[clap(long, value_name = "VM_ID")]
+    vmconnect: Option<String>,
+
     /// The keyboard type
     #[clap(long, value_enum, default_value_t = KeyboardType::IbmEnhanced)]
     keyboard_type: KeyboardType,
@@ -351,6 +357,10 @@ fn apply_cli_to_builder(mut builder: ConfigBuilder, args: Args, redirect_clipboa
     }
 
     // Transport overrides: RDCleanPath takes precedence over Gateway.
+    if let Some(vm_id) = args.vmconnect {
+        builder = builder.with_vmconnect(vm_id);
+    }
+
     if let Some(url) = args.rdcleanpath_url {
         builder = builder.with_transport(TransportKind::RDCleanPath { url });
 

--- a/ffi/src/credssp/mod.rs
+++ b/ffi/src/credssp/mod.rs
@@ -66,6 +66,7 @@ pub mod ffi {
                         connector.config.domain.as_deref(),
                         selected_protocol,
                         server_name.into(),
+                        connector.spn_service_class(),
                         server_public_key.to_owned(),
                         kerbero_configs.map(|config| config.0.clone()),
                     )?;


### PR DESCRIPTION
Stacked on #1495 (`build/update-toolchain`). **Do not retarget this PR's base.**

Replaces #1475. That PR was accidentally base-retargeted onto the toolchain branch and squash-merged there; the toolchain branch was restored, and #1475 is left as a historical MERGED shell with no code on `master`. This is a clean re-open of the same VMConnect work, properly stacked.

Lets you connect to a Hyper-V VM console. Same RDP steps as usual, the host just wants the front in a different order: Preconnection Blob with the VM id → TLS → CredSSP → X.224 last. That's the [Direct Approach](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/902b090b-9cb3-4efc-92bf-ee13373371e3), and since NLA already ran by then the host has to select exactly `PROTOCOL_HYBRID`.

`ClientConnector::new_vmconnect(..)` picks the ordering, `ConfigBuilder::with_vmconnect(vm_id)` on the client, `--vmconnect <VM_ID>` on the viewer.

The bit I'd like eyes on: the whole difference between the two orderings sits in one `Front` enum — where we start, what X.224 advertises, what selected protocol we accept, and where negotiation/NLA each hand over. `after_initiation` and `after_credssp` are mirrors of each other, because whichever runs last is the one handing over to Basic Settings. Only one new state (`PreconnectionBlobSendRequest`); both orderings share the existing X.224 initiation states. Tail is untouched and the existing drivers run it as-is.

**Breaking:** `CredsspSequence::init` now takes the SPN service class. A Hyper-V console registers [`Microsoft Virtual Console Service/<host>`](https://learn.microsoft.com/en-us/troubleshoot/system-center/vmm/authentication-authorization-problems), not `TERMSRV/<host>`, so Kerberos couldn't work against one before. Pass `connector.spn_service_class()`, or `credssp::DEFAULT_SPN_SERVICE_CLASS` for a normal host.

Works over a gateway too — that's just a tunnel, we still drive the whole handshake. Only RDCleanPath is rejected, since its proxy negotiates X.224 before this ordering is ready for it.

### Stack

1. #1495 — Rust toolchain 1.94.1 (base: `master`)
2. **This PR** — Hyper-V vmconnect (base: `build/update-toolchain`)

Merge bottom-up. After #1495 lands, GitHub should retarget this PR onto `master` automatically.

### Testing

Real Hyper-V host, Server 2022 guest, 1080p desktop rendering over the console. Both negative controls fail where they should: standard ordering gets reset on the first read, wrong VM id dies at TLS.

Not covered: the Kerberos SPN itself. We only go Negotiate when a KDC proxy is configured, so this all ran on NTLM.

Known annoyance, not fixed here: a Hyper-V console has no Display Control channel, so the first window resize falls through to `ReconnectWithNewSize` and redoes the whole handshake. Fires once per session because the window comes up DPI-scaled. Happy to do it in a follow-up.