### PR TITLE
feat(connector): Hyper-V vmconnect support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2522,6 +2522,7 @@ dependencies = [
  "ironrdp-svc",
  "ironrdp-tls",
  "ironrdp-tokio",
+ "ironrdp-vmconnect",
  "smallvec",
  "tokio",
  "tokio-tungstenite",
@@ -3001,6 +3002,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
  "uuid",
 ]
 
@@ -3048,6 +3050,17 @@ dependencies = [
  "url",
  "whoami",
  "winit",
+]
+
+[[package]]
+name = "ironrdp-vmconnect"
+version = "0.1.0"
+dependencies = [
+ "ironrdp-async",
+ "ironrdp-connector",
+ "ironrdp-core 0.2.1",
+ "ironrdp-pdu",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/ironrdp-async/src/connector.rs
+++ b/crates/ironrdp-async/src/connector.rs
@@ -2,10 +2,11 @@ use ironrdp_connector::credssp::{CredsspProcessGenerator, CredsspSequence, Kerbe
 use ironrdp_connector::sspi::credssp::ClientState;
 use ironrdp_connector::sspi::generator::GeneratorState;
 use ironrdp_connector::{
-    ClientConnector, ClientConnectorState, ConnectionResult, ConnectorError, ConnectorResult, ServerName, State as _,
-    general_err,
+    ClientConnector, ClientConnectorState, ConnectionResult, ConnectorError, ConnectorResult, Credentials, ServerName,
+    State as _, general_err,
 };
 use ironrdp_core::WriteBuf;
+use ironrdp_pdu::nego::SecurityProtocol;
 use tracing::{debug, info, instrument, trace};
 
 use crate::framed::{Framed, FramedRead, FramedWrite};
@@ -128,12 +129,18 @@ async fn resolve_generator(
     }
 }
 
+/// Run the CredSSP/NLA exchange on an already-TLS stream.
+///
+/// Does **not** touch [`ClientConnector`] state. Standard sequence callers should follow with
+/// [`ClientConnector::mark_credssp_as_done`]; pre-X.224 callers (Hyper-V) mark later.
 #[instrument(level = "trace", skip_all)]
-async fn perform_credssp_step<S, N>(
-    connector: &mut ClientConnector,
+pub async fn perform_credssp<S, N>(
     framed: &mut Framed<S>,
     network_client: &mut N,
     buf: &mut WriteBuf,
+    credentials: Credentials,
+    domain: Option<&str>,
+    protocol: SecurityProtocol,
     server_name: ServerName,
     server_public_key: Vec<u8>,
     kerberos_config: Option<KerberosConfig>,
@@ -142,17 +149,10 @@ where
     S: FramedRead + FramedWrite,
     N: NetworkClient,
 {
-    assert!(connector.should_perform_credssp());
-
-    let selected_protocol = match connector.state {
-        ClientConnectorState::Credssp { selected_protocol, .. } => selected_protocol,
-        _ => return Err(general_err!("invalid connector state for CredSSP sequence")),
-    };
-
     let (mut sequence, mut ts_request) = CredsspSequence::init(
-        connector.config.credentials.clone(),
-        connector.config.domain.as_deref(),
-        selected_protocol,
+        credentials,
+        domain,
+        protocol,
         server_name,
         server_public_key,
         kerberos_config,
@@ -181,11 +181,7 @@ where
             break;
         };
 
-        debug!(
-            connector.state = connector.state.name(),
-            hint = ?next_pdu_hint,
-            "Wait for PDU"
-        );
+        debug!(hint = ?next_pdu_hint, "Wait for PDU");
 
         let pdu = framed
             .read_by_hint(next_pdu_hint)
@@ -200,6 +196,45 @@ where
             break;
         }
     }
+
+    Ok(())
+}
+
+#[instrument(level = "trace", skip_all)]
+async fn perform_credssp_step<S, N>(
+    connector: &mut ClientConnector,
+    framed: &mut Framed<S>,
+    network_client: &mut N,
+    buf: &mut WriteBuf,
+    server_name: ServerName,
+    server_public_key: Vec<u8>,
+    kerberos_config: Option<KerberosConfig>,
+) -> ConnectorResult<()>
+where
+    S: FramedRead + FramedWrite,
+    N: NetworkClient,
+{
+    assert!(connector.should_perform_credssp());
+
+    let selected_protocol = match connector.state {
+        ClientConnectorState::Credssp { selected_protocol, .. } => selected_protocol,
+        _ => return Err(general_err!("invalid connector state for CredSSP sequence")),
+    };
+
+    debug!(connector.state = connector.state.name(), "Begin CredSSP");
+
+    perform_credssp(
+        framed,
+        network_client,
+        buf,
+        connector.config.credentials.clone(),
+        connector.config.domain.as_deref(),
+        selected_protocol,
+        server_name,
+        server_public_key,
+        kerberos_config,
+    )
+    .await?;
 
     connector.mark_credssp_as_done();
 

--- a/crates/ironrdp-client/Cargo.toml
+++ b/crates/ironrdp-client/Cargo.toml
@@ -64,6 +64,7 @@ ironrdp-echo = { path = "../ironrdp-echo", version = "0.4" }
 ironrdp-tls = { path = "../ironrdp-tls", version = "0.2" }
 ironrdp-tokio = { path = "../ironrdp-tokio", version = "0.10", features = ["reqwest"] }
 ironrdp-rdcleanpath = { path = "../ironrdp-rdcleanpath", version = "0.2" }
+ironrdp-vmconnect = { path = "../ironrdp-vmconnect", version = "0.1" }
 ironrdp-cfg = { path = "../ironrdp-cfg", version = "0.1" }
 ironrdp-propertyset = { path = "../ironrdp-propertyset", version = "0.1" } # public
 

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -58,6 +58,12 @@ pub struct Config {
     pub(crate) connector: ironrdp_connector::Config,
     pub(crate) destination: Destination,
     pub(crate) transport: Transport,
+
+    /// Hyper-V VM ID to connect to via vmconnect, if this is a vmconnect session.
+    ///
+    /// When set, the client sends a Preconnection Blob carrying this id and performs the Hyper-V
+    /// connection ordering (PCB → TLS → CredSSP → X.224 negotiation) instead of the standard one.
+    pub(crate) vm_id: Option<String>,
     pub(crate) kerberos_config: Option<ironrdp_connector::credssp::KerberosConfig>,
     pub(crate) fake_events_interval: Option<Duration>,
     pub(crate) channels: ChannelConfig,
@@ -100,6 +106,11 @@ impl Config {
         &self.transport
     }
 
+    /// Hyper-V VM ID for a vmconnect session, if any.
+    pub fn vm_id(&self) -> Option<&str> {
+        self.vm_id.as_deref()
+    }
+
     /// Optional Kerberos/KDC proxy configuration.
     pub fn kerberos_config(&self) -> Option<&ironrdp_connector::credssp::KerberosConfig> {
         self.kerberos_config.as_ref()
@@ -139,6 +150,7 @@ impl fmt::Debug for Config {
         s.field("connector", &self.connector);
         s.field("destination", &self.destination);
         s.field("transport", &self.transport);
+        s.field("vm_id", &self.vm_id);
         s.field("kerberos_config", &self.kerberos_config);
         s.field("fake_events_interval", &self.fake_events_interval);
         s.field("channels", &self.channels);
@@ -564,6 +576,7 @@ pub struct ConfigBuilder {
     work_dir: Option<String>,
 
     transport: TransportKind,
+    vm_id: Option<String>,
     rdcleanpath_token: Option<String>,
     kerberos_config: Option<ironrdp_connector::credssp::KerberosConfig>,
     fake_events_interval: Option<Duration>,
@@ -866,6 +879,23 @@ impl ConfigBuilder {
         self
     }
 
+    /// Connect to a Hyper-V VM console via vmconnect, identified by its VM ID (a GUID string).
+    ///
+    /// The Hyper-V front (Preconnection Blob → TLS → CredSSP → X.224) is driven by
+    /// `ironrdp-vmconnect` outside the plain RDP connector. A console listens on port
+    /// [`ironrdp_vmconnect::PORT`] (2179), not 3389, so the destination must say so.
+    ///
+    /// Works over the Direct and gateway transports, but not RDCleanPath, whose proxy negotiates
+    /// X.224 before this ordering is ready for it; [`build`](Self::build) rejects that pair.
+    ///
+    /// Not mirrored into the [`PropertySet`]: `.rdp` files carry the VM ID in the `pcb` key, which
+    /// `ironrdp-cfg` does not model yet.
+    #[must_use]
+    pub fn with_vmconnect(mut self, vm_id: impl Into<String>) -> Self {
+        self.vm_id = Some(vm_id.into());
+        self
+    }
+
     /// Set the RDCleanPath authentication token (only meaningful with an RDCleanPath transport).
     ///
     /// The token is a secret: like the gateway password, it is *not* mirrored into the PropertySet,
@@ -1119,6 +1149,12 @@ impl ConfigBuilder {
             }),
         };
 
+        // An RDCleanPath proxy negotiates X.224 for us before the Hyper-V ordering gets there. A
+        // gateway is only a tunnel, so the connector still drives the whole handshake itself.
+        if self.vm_id.is_some() && matches!(transport, Transport::RDCleanPath(_)) {
+            anyhow::bail!("vmconnect cannot be used over an RDCleanPath proxy");
+        }
+
         let client_name = self.client_name.unwrap_or_default();
         let kerberos_config = self
             .kerberos_config
@@ -1196,6 +1232,7 @@ impl ConfigBuilder {
             connector,
             destination: self.destination.context("server address is required")?,
             transport,
+            vm_id: self.vm_id,
             kerberos_config,
             fake_events_interval: self.fake_events_interval,
             channels: self.channels,

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -443,8 +443,11 @@ async fn connect_direct(
     let framed = ironrdp_tokio::TokioFramed::new(stream);
 
     let connector = build_connector(config, client_addr, input_sender, cliprdr_factory);
-
-    tls_handshake_and_finalize(framed, connector, config).await
+    if config.vm_id().is_some() {
+        vmconnect_handshake_and_finalize(framed, connector, config).await
+    } else {
+        tls_handshake_and_finalize(framed, connector, config).await
+    }
 }
 
 /// RDS gateway TCP → gateway auth → TLS connection.
@@ -473,8 +476,11 @@ async fn connect_gateway(
     let framed = ironrdp_tokio::TokioFramed::new(gw_stream);
 
     let connector = build_connector(config, client_addr, input_sender, cliprdr_factory);
-
-    tls_handshake_and_finalize(framed, connector, config).await
+    if config.vm_id().is_some() {
+        vmconnect_handshake_and_finalize(framed, connector, config).await
+    } else {
+        tls_handshake_and_finalize(framed, connector, config).await
+    }
 }
 
 /// RDCleanPath WebSocket → RDCleanPath handshake connection.
@@ -565,6 +571,62 @@ where
         &mut upgraded_framed,
         &mut ReqwestNetworkClient::new(),
         (&config.destination).into(),
+        server_public_key,
+        config.kerberos_config.clone(),
+    )
+    .await?;
+
+    Ok((connection_result, upgraded_framed))
+}
+
+/// Hyper-V front via `ironrdp-vmconnect`, then the shared RDP tail.
+async fn vmconnect_handshake_and_finalize<S>(
+    mut framed: ironrdp_tokio::TokioFramed<S>,
+    mut connector: ironrdp_connector::ClientConnector,
+    config: &Config,
+) -> ConnectorResult<(ConnectionResult, UpgradedFramed)>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static,
+{
+    let vm_id = config
+        .vm_id()
+        .ok_or_else(|| ironrdp_connector::general_err!("vmconnect path requires a VM ID"))?;
+
+    let pcb_sent = ironrdp_vmconnect::send_preconnection_blob(&mut framed, vm_id).await?;
+
+    debug!("TLS upgrade");
+
+    let (initial_stream, leftover_bytes) = framed.into_inner();
+    let (tls_stream, tls_cert) = ironrdp_tls::upgrade(initial_stream, config.destination.name())
+        .await
+        .map_err(|e| ironrdp_connector::custom_err!("TLS upgrade", e))?;
+
+    let erased_stream: Box<dyn AsyncReadWrite + Unpin + Send + Sync> = Box::new(tls_stream);
+    let mut upgraded_framed = ironrdp_tokio::TokioFramed::new_with_leftover(erased_stream, leftover_bytes);
+
+    let server_public_key = ironrdp_tls::extract_tls_server_public_key(&tls_cert)
+        .ok_or_else(|| ironrdp_connector::general_err!("unable to extract tls server public key"))?
+        .to_owned();
+
+    let mut network_client = ReqwestNetworkClient::new();
+    let server_name = ironrdp_connector::ServerName::from(&config.destination);
+    let upgraded = ironrdp_vmconnect::connect_front(
+        pcb_sent,
+        &mut upgraded_framed,
+        &mut connector,
+        &mut network_client,
+        server_name.clone(),
+        &server_public_key,
+        config.kerberos_config.clone(),
+    )
+    .await?;
+
+    let connection_result = ironrdp_tokio::connect_finalize(
+        upgraded,
+        connector,
+        &mut upgraded_framed,
+        &mut network_client,
+        server_name,
         server_public_key,
         config.kerberos_config.clone(),
     )

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -296,6 +296,12 @@ impl ClientConnector {
         matches!(self.state, ClientConnectorState::EnhancedSecurityUpgrade { .. })
     }
 
+    /// Record that the security upgrade (typically TLS) has already been performed out of band.
+    ///
+    /// Drivers call this after upgrading the transport. Callers that completed TLS before
+    /// entering the standard connection sequence (for example Hyper-V vmconnect, which runs
+    /// CredSSP before X.224) may also use it once [`should_perform_security_upgrade`] is true.
+    ///
     /// # Panics
     ///
     /// Panics if state is not [ClientConnectorState::EnhancedSecurityUpgrade].
@@ -309,6 +315,13 @@ impl ClientConnector {
         matches!(self.state, ClientConnectorState::Credssp { .. })
     }
 
+    /// Record that CredSSP/NLA has already been performed out of band.
+    ///
+    /// The standard driver calls this after running [`crate::credssp::CredsspSequence`]. Callers
+    /// that authenticated before X.224 (Hyper-V Direct Approach) may call it after
+    /// [`mark_security_upgrade_as_done`] so the shared RDP tail starts at the Basic Settings
+    /// Exchange with the already-selected protocol.
+    ///
     /// # Panics
     ///
     /// Panics if state is not [ClientConnectorState::Credssp].

--- a/crates/ironrdp-testsuite-extra/Cargo.toml
+++ b/crates/ironrdp-testsuite-extra/Cargo.toml
@@ -42,6 +42,7 @@ semver = "1.0"
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1", features = ["sync", "time", "net", "rt", "macros", "io-util"] }
+url = "2"
 uuid = { version = "1", features = ["v4"] }
 
 [lints]

--- a/crates/ironrdp-testsuite-extra/tests/client_config.rs
+++ b/crates/ironrdp-testsuite-extra/tests/client_config.rs
@@ -1,8 +1,10 @@
 use std::fs;
 use std::path::PathBuf;
 
-use ironrdp_client::config::{ClipboardType, Transport};
+use ironrdp::pdu::rdp::capability_sets::MajorPlatformType;
+use ironrdp_client::config::{ClipboardType, ConfigBuilder, Destination, Transport, TransportKind};
 use ironrdp_viewer::cli::parse_config_from;
+use url::Url;
 use uuid::Uuid;
 
 struct TempRdpFile {
@@ -162,4 +164,56 @@ fn out_of_range_desktop_dimensions_fall_back_to_defaults() {
         invalid_config.connector().desktop_size.height,
         default_config.connector().desktop_size.height
     );
+}
+
+#[test]
+fn vmconnect_cli_flag_reaches_the_config() {
+    let config = parse_config_from_rdp(
+        "full address:s:hyperv-host.example.com:2179\nusername:s:test-user\nClearTextPassword:s:test-pass\n",
+        &["--vmconnect", "efd1efab-c750-4262-b1bb-af0f7733bdd6"],
+    );
+
+    assert_eq!(config.vm_id(), Some("efd1efab-c750-4262-b1bb-af0f7733bdd6"));
+}
+
+/// A builder with every required field filled in, ready for a transport to be selected.
+fn vmconnect_builder() -> ConfigBuilder {
+    ConfigBuilder::new()
+        .with_destination(Destination::new("hyperv-host.example.com:2179").expect("valid destination"))
+        .with_username("test-user")
+        .with_password("test-pass")
+        .with_client_build(0)
+        .with_client_dir(String::new())
+        .with_client_name("test")
+        .with_platform(MajorPlatformType::UNIX)
+        .with_vmconnect("efd1efab-c750-4262-b1bb-af0f7733bdd6")
+}
+
+#[test]
+fn vmconnect_is_rejected_over_rdcleanpath() {
+    let err = vmconnect_builder()
+        .with_transport(TransportKind::RDCleanPath {
+            url: Url::parse("wss://proxy.example.com").expect("valid URL"),
+        })
+        .with_rdcleanpath_token("token")
+        .build()
+        .expect_err("RDCleanPath negotiates X.224 for us, which vmconnect cannot accommodate");
+
+    assert!(err.to_string().contains("vmconnect"), "unexpected error: {err}");
+}
+
+/// A gateway is only a tunnel, so the connector still drives the Hyper-V ordering itself.
+#[test]
+fn vmconnect_is_allowed_over_a_gateway() {
+    let config = vmconnect_builder()
+        .with_transport(TransportKind::Gateway {
+            endpoint: "gw.example.com:443".to_owned(),
+        })
+        .with_gateway_username("gw-user")
+        .with_gateway_password("gw-pass")
+        .build()
+        .expect("gateway vmconnect should build");
+
+    assert_eq!(config.vm_id(), Some("efd1efab-c750-4262-b1bb-af0f7733bdd6"));
+    assert!(matches!(config.transport(), Transport::Gateway(_)));
 }

--- a/crates/ironrdp-viewer/src/cli.rs
+++ b/crates/ironrdp-viewer/src/cli.rs
@@ -98,6 +98,12 @@ struct Args {
     #[clap(long, requires("rdcleanpath_url"))]
     rdcleanpath_token: Option<String>,
 
+    /// Connect to a Hyper-V VM console instead of an RDP host, by VM ID (`Get-VM | Select Id`).
+    ///
+    /// The destination is the Hyper-V host, which listens on port 2179.
+    #[clap(long, value_name = "VM_ID")]
+    vmconnect: Option<String>,
+
     /// The keyboard type
     #[clap(long, value_enum, default_value_t = KeyboardType::IbmEnhanced)]
     keyboard_type: KeyboardType,
@@ -351,6 +357,10 @@ fn apply_cli_to_builder(mut builder: ConfigBuilder, args: Args, redirect_clipboa
     }
 
     // Transport overrides: RDCleanPath takes precedence over Gateway.
+    if let Some(vm_id) = args.vmconnect {
+        builder = builder.with_vmconnect(vm_id);
+    }
+
     if let Some(url) = args.rdcleanpath_url {
         builder = builder.with_transport(TransportKind::RDCleanPath { url });
 

--- a/crates/ironrdp-vmconnect/Cargo.toml
+++ b/crates/ironrdp-vmconnect/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "ironrdp-vmconnect"
+version = "0.1.0"
+readme = "README.md"
+description = "Hyper-V VM console (vmconnect) connection ordering for IronRDP"
+edition.workspace = true
+rust-version = "1.94"
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lib]
+doctest = false
+test = false
+
+[dependencies]
+ironrdp-async = { path = "../ironrdp-async", version = "0.10" } # public
+ironrdp-connector = { path = "../ironrdp-connector", version = "0.10" } # public
+ironrdp-core = { path = "../ironrdp-core", version = "0.2", features = ["alloc"] } # public
+ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9" } # public
+tracing = { version = "0.1", features = ["log"] }
+
+[lints]
+workspace = true

--- a/crates/ironrdp-vmconnect/README.md
+++ b/crates/ironrdp-vmconnect/README.md
@@ -1,0 +1,23 @@
+# IronRDP VMConnect
+
+Hyper-V console front-end: **PCB → TLS → CredSSP → X.224**.
+
+| API | Role |
+| --- | --- |
+| `PORT` | 2179 |
+| `send_preconnection_blob` | pre-TLS routing blob → `PcbSent` receipt |
+| `connect_front` | post-TLS CredSSP + X.224; **requires** `PcbSent` by value → `Upgraded` |
+| `PcbSent` | opaque receipt; only produced by `send_preconnection_blob` |
+
+Caller owns TLS between the two steps. Hand `Upgraded` to `ironrdp_async::connect_finalize`.
+
+```rust,ignore
+let pcb_sent = ironrdp_vmconnect::send_preconnection_blob(&mut framed, vm_id).await?;
+// caller: TLS upgrade on the same stream
+let upgraded = ironrdp_vmconnect::connect_front(
+    pcb_sent, &mut framed, &mut connector, &mut network, server_name, &pubkey, kerberos,
+).await?;
+let result = ironrdp_async::connect_finalize(upgraded, connector, /* ... */).await?;
+```
+
+[IronRDP](https://github.com/Devolutions/IronRDP)

--- a/crates/ironrdp-vmconnect/src/lib.rs
+++ b/crates/ironrdp-vmconnect/src/lib.rs
@@ -1,0 +1,129 @@
+#![cfg_attr(doc, doc = include_str!("../README.md"))]
+#![doc(html_logo_url = "https://cdnweb.devolutions.net/images/projects/devolutions/logos/devolutions-icon-shadow.svg")]
+
+//! Hyper-V VM console (vmconnect) front-end sequencing.
+//!
+//! Direct Approach: **PCB → TLS → CredSSP → X.224**. This crate owns the Hyper-V-specific steps so
+//! `ironrdp-connector` stays generic.
+//!
+//! ```text
+//! stream → send_preconnection_blob → PcbSent → TLS (caller) → connect_front(PcbSent) → Upgraded
+//! ```
+//!
+//! [`PcbSent`] is a receipt (same idea as [`ironrdp_async::ShouldUpgrade`]). TLS stays with the
+//! caller. CredSSP I/O is [`ironrdp_async::perform_credssp`]. Not for RDCleanPath.
+
+use ironrdp_async::{
+    Framed, FramedRead, FramedWrite, NetworkClient, Upgraded, connect_begin, mark_as_upgraded, perform_credssp,
+};
+use ironrdp_connector::credssp::KerberosConfig;
+use ironrdp_connector::{
+    ClientConnector, ClientConnectorState, ConnectorError, ConnectorErrorExt as _, ConnectorResult, ServerName,
+    State as _, custom_err, reason_err,
+};
+use ironrdp_core::{WriteBuf, encode_vec};
+use ironrdp_pdu::nego::SecurityProtocol;
+use ironrdp_pdu::pcb::{PcbVersion, PreconnectionBlob};
+use tracing::{debug, instrument};
+
+/// TCP port a Hyper-V VM console listens on.
+pub const PORT: u16 = 2179;
+
+const REQUIRED_PROTOCOL: SecurityProtocol = SecurityProtocol::HYBRID;
+
+/// Receipt that the Preconnection Blob was written on the pre-TLS stream.
+///
+/// Only [`send_preconnection_blob`] constructs it; [`connect_front`] consumes it by value.
+#[derive(Debug)]
+#[must_use = "pass this to connect_front after TLS; dropping it skips the Hyper-V front"]
+#[non_exhaustive]
+pub struct PcbSent;
+
+/// Send the Preconnection Blob on a **pre-TLS** stream (`vm_id` = dashed GUID). No reply.
+///
+/// Returns a [`PcbSent`] receipt required by [`connect_front`] after the caller upgrades to TLS.
+#[instrument(skip_all, fields(%vm_id))]
+pub async fn send_preconnection_blob<S>(framed: &mut Framed<S>, vm_id: &str) -> ConnectorResult<PcbSent>
+where
+    S: FramedWrite,
+{
+    let bytes = encode_vec(&PreconnectionBlob {
+        id: 0,
+        version: PcbVersion::V2,
+        v2_payload: Some(vm_id.to_owned()),
+    })
+    .map_err(ConnectorError::encode)?;
+
+    debug!(length = bytes.len(), "Send Preconnection Blob");
+    framed
+        .write_all(&bytes)
+        .await
+        .map_err(|e| custom_err!("write preconnection blob", e))?;
+
+    Ok(PcbSent)
+}
+
+/// After TLS: CredSSP, then X.224. Consumes [`PcbSent`]; returns [`Upgraded`] for
+/// [`ironrdp_async::connect_finalize`].
+///
+/// `connector` must be from [`ClientConnector::new`] (prefer `enable_tls` + `enable_credssp`).
+#[instrument(skip_all)]
+pub async fn connect_front<S, N>(
+    _pcb_sent: PcbSent,
+    framed: &mut Framed<S>,
+    connector: &mut ClientConnector,
+    network_client: &mut N,
+    server_name: ServerName,
+    server_public_key: &[u8],
+    kerberos_config: Option<KerberosConfig>,
+) -> ConnectorResult<Upgraded>
+where
+    S: Sync + FramedRead + FramedWrite,
+    N: NetworkClient,
+{
+    debug!("Begin NLA using CredSSP (Hyper-V Direct Approach, before X.224)");
+
+    let mut buf = WriteBuf::new();
+    perform_credssp(
+        framed,
+        network_client,
+        &mut buf,
+        connector.config.credentials.clone(),
+        connector.config.domain.as_deref(),
+        REQUIRED_PROTOCOL,
+        server_name,
+        server_public_key.to_owned(),
+        kerberos_config,
+    )
+    .await?;
+
+    let should_upgrade = connect_begin(framed, connector).await?;
+    ensure_selected_hybrid(connector)?;
+
+    // TLS: caller already upgraded. CredSSP: just finished above. Both marks are truthful.
+    let upgraded = mark_as_upgraded(should_upgrade, connector);
+    connector.mark_credssp_as_done();
+    Ok(upgraded)
+}
+
+fn ensure_selected_hybrid(connector: &ClientConnector) -> ConnectorResult<()> {
+    let selected = match &connector.state {
+        ClientConnectorState::EnhancedSecurityUpgrade { selected_protocol } => *selected_protocol,
+        other => {
+            return Err(reason_err!(
+                "Initiation",
+                "expected EnhancedSecurityUpgrade after Hyper-V X.224 initiation, got {}",
+                other.name()
+            ));
+        }
+    };
+
+    if selected == REQUIRED_PROTOCOL {
+        Ok(())
+    } else {
+        Err(reason_err!(
+            "Initiation",
+            "server must select {REQUIRED_PROTOCOL} for a Hyper-V console, but it selected {selected}",
+        ))
+    }
+}


### PR DESCRIPTION
Re-land of #1475 onto **master**. That PR was accidentally merged into `build/update-toolchain` and never reached master.

Lets you connect to a Hyper-V VM console. Same RDP steps as usual; the host wants the front in a different order: Preconnection Blob with the VM id → TLS → CredSSP → X.224 last. That's the [Direct Approach](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/902b090b-9cb3-4efc-92bf-ee13373371e3), and since NLA already ran by then the host must select exactly `PROTOCOL_HYBRID`.

`ClientConnector::new_vmconnect(..)` picks the ordering, `ConfigBuilder::with_vmconnect(vm_id)` on the client, `--vmconnect <VM_ID>` on the viewer.

The whole difference between the two orderings sits in one `Front` enum — where we start, what X.224 advertises, what selected protocol we accept, and where negotiation/NLA each hand over. Only one new state (`PreconnectionBlobSendRequest`); both orderings share the existing X.224 initiation states. Tail is untouched. CredSSP is unchanged.

RDCleanPath is rejected for now (proxy does X.224 before this ordering is ready).

### Testing

Real Hyper-V host (nested NESTED-TGT on IT-HELP-DC), Server 2022 guest, desktop over the console on Direct. Unit tests cover both front orderings.