### PR TITLE
fix(pdu): scope Font Map leniency

### DIFF
--- a/crates/ironrdp-pdu/src/rdp/headers.rs
+++ b/crates/ironrdp-pdu/src/rdp/headers.rs
@@ -558,7 +558,15 @@ impl ShareDataPdu {
             ShareDataPduType::Synchronize => Ok(ShareDataPdu::Synchronize(SynchronizePdu::decode(src)?)),
             ShareDataPduType::Control => Ok(ShareDataPdu::Control(ControlPdu::decode(src)?)),
             ShareDataPduType::FontList => Ok(ShareDataPdu::FontList(FontPdu::decode(src)?)),
-            ShareDataPduType::FontMap => Ok(ShareDataPdu::FontMap(FontPdu::decode(src)?)),
+            ShareDataPduType::FontMap => {
+                let font_pdu = if src.is_empty() {
+                    FontPdu::default()
+                } else {
+                    FontPdu::decode(src)?
+                };
+
+                Ok(ShareDataPdu::FontMap(font_pdu))
+            }
             ShareDataPduType::MonitorLayoutPdu => Ok(ShareDataPdu::MonitorLayout(MonitorLayoutPdu::decode(src)?)),
             ShareDataPduType::SaveSessionInfo => Ok(ShareDataPdu::SaveSessionInfo(SaveSessionInfoPdu::decode(src)?)),
             ShareDataPduType::FrameAcknowledgePdu => {

--- a/crates/ironrdp-testsuite-core/tests/pdu/rdp.rs
+++ b/crates/ironrdp-testsuite-core/tests/pdu/rdp.rs
@@ -72,6 +72,18 @@ fn from_buffer_correctly_parses_rdp_pdu_server_font_map() {
 }
 
 #[test]
+fn from_header_only_buffer_defaults_rdp_pdu_server_font_map() {
+    let buf = &SERVER_FONT_MAP_BUFFER[..18];
+
+    assert_eq!(SERVER_FONT_MAP.clone(), decode(buf).unwrap());
+}
+
+#[test]
+fn from_header_only_buffer_rejects_rdp_pdu_client_font_list() {
+    assert!(decode::<ironrdp_pdu::rdp::headers::ShareControlHeader>(&CLIENT_FONT_LIST_BUFFER[..18]).is_err());
+}
+
+#[test]
 fn from_buffer_correctly_parses_rdp_pdu_server_monitor_layout() {
     let buf = MONITOR_LAYOUT_PDU_BUFFER.clone();
 


### PR DESCRIPTION
## Summary

Supersedes #1472. The prior approach made `FontPdu::decode` accept empty input, but `FontPdu` is shared by Font List and Font Map. A malformed header-only client Font List could therefore decode successfully and advance acceptor finalization.

This PR keeps `FontPdu::decode` strict and defaults only a fully empty Server Font Map body in the `ShareDataPduType::FontMap` dispatch arm. Header-only Font Map decoding succeeds with `FontPdu` defaults; header-only Font List remains rejected.

## Tests

- `cargo test -p ironrdp-testsuite-core --test integration_tests_core pdu::rdp` 
- `cargo clippy -p ironrdp-pdu --all-targets -- -D warnings`