### PR TITLE
feat(server): validate auto-reconnect cookies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,6 +1302,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -2031,7 +2032,16 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
- "hmac",
+ "hmac 0.13.0",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2868,6 +2878,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
+ "hmac 0.12.1",
  "ironrdp-acceptor",
  "ironrdp-ainput",
  "ironrdp-async",
@@ -2883,7 +2894,9 @@ dependencies = [
  "ironrdp-rdpsnd",
  "ironrdp-svc",
  "ironrdp-tokio",
+ "md-5 0.10.6",
  "qoicoubeh",
+ "rand 0.9.4",
  "rayon",
  "rustls-pemfile",
  "tokio",
@@ -4168,7 +4181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
  "digest 0.11.3",
- "hmac",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -4215,7 +4228,7 @@ dependencies = [
  "ecdsa",
  "ed25519-dalek",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "http",
  "inout",
  "md-5 0.11.0",
@@ -4298,7 +4311,7 @@ dependencies = [
  "cipher",
  "crypto-bigint",
  "des",
- "hmac",
+ "hmac 0.13.0",
  "inout",
  "oid",
  "pbkdf2",
@@ -4935,7 +4948,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9935425142ac6e252364413291d96c8bc9898d0876a801824c7af4eae397b689"
 dependencies = [
  "ctutils",
- "hmac",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -5651,7 +5664,7 @@ dependencies = [
  "ed25519-dalek",
  "futures",
  "getrandom 0.3.4",
- "hmac",
+ "hmac 0.13.0",
  "md-5 0.11.0",
  "md4",
  "num-derive",

--- a/crates/ironrdp-acceptor/src/connection.rs
+++ b/crates/ironrdp-acceptor/src/connection.rs
@@ -10,7 +10,7 @@ use ironrdp_pdu::nego::SecurityProtocol;
 use ironrdp_pdu::x224::X224;
 use ironrdp_svc::{StaticChannelSet, SvcServerProcessor};
 use pdu::rdp::capability_sets::CapabilitySet;
-use pdu::rdp::client_info::Credentials;
+use pdu::rdp::client_info::{ClientAutoReconnect, Credentials};
 use pdu::rdp::headers::ShareControlPdu;
 use pdu::rdp::server_error_info::{ErrorInfo, ProtocolIndependentCode, ServerSetErrorInfoPdu};
 use pdu::rdp::server_license::{LicensePdu, LicensingErrorMessage};
@@ -38,6 +38,7 @@ pub struct Acceptor {
     saved_for_reactivation: AcceptorState,
     pub(crate) creds: Option<Credentials>,
     received_credentials: Option<Credentials>,
+    received_auto_reconnect: Option<ClientAutoReconnect>,
     reactivation: bool,
     honor_client_desktop_size: bool,
 }
@@ -113,6 +114,13 @@ pub struct AcceptorResult {
     /// Servers that need to validate credentials (e.g., via PAM or LDAP)
     /// can use this field for post-handshake validation.
     pub credentials: Option<Credentials>,
+    /// Client Auto-Reconnect Packet received in the Client Info PDU.
+    ///
+    /// This is present when the client resumes a session using an
+    /// `ARC_CS_PRIVATE_PACKET`. The packet has already passed wire-format
+    /// validation, but the server must still verify its security verifier
+    /// against the reconnect random for the target session.
+    pub auto_reconnect: Option<ClientAutoReconnect>,
 }
 
 impl Acceptor {
@@ -136,6 +144,7 @@ impl Acceptor {
             saved_for_reactivation: Default::default(),
             creds,
             received_credentials: None,
+            received_auto_reconnect: None,
             reactivation: false,
             honor_client_desktop_size: false,
         }
@@ -209,6 +218,7 @@ impl Acceptor {
             saved_for_reactivation,
             creds: consumed.creds,
             received_credentials: consumed.received_credentials,
+            received_auto_reconnect: consumed.received_auto_reconnect,
             reactivation: true,
             honor_client_desktop_size: consumed.honor_client_desktop_size,
         })
@@ -268,6 +278,7 @@ impl Acceptor {
                 multitransport_flags: self.multitransport_flags,
                 reactivation: self.reactivation,
                 credentials: self.received_credentials.take(),
+                auto_reconnect: self.received_auto_reconnect.take(),
             }),
             previous_state => {
                 self.state = previous_state;
@@ -705,6 +716,13 @@ impl Sequence for Acceptor {
                     decode(data.user_data.as_ref()).map_err(ConnectorError::decode)?;
 
                 debug!(message = ?client_info, "Received");
+
+                self.received_auto_reconnect = client_info
+                    .client_info
+                    .extra_info
+                    .optional_data
+                    .auto_reconnect()
+                    .cloned();
 
                 if !protocol.intersects(SecurityProtocol::HYBRID | SecurityProtocol::HYBRID_EX) {
                     let creds = client_info.client_info.credentials;

--- a/crates/ironrdp-acceptor/src/connection.rs
+++ b/crates/ironrdp-acceptor/src/connection.rs
@@ -715,14 +715,17 @@ impl Sequence for Acceptor {
                 let client_info: rdp::ClientInfoPdu =
                     decode(data.user_data.as_ref()).map_err(ConnectorError::decode)?;
 
-                debug!(message = ?client_info, "Received");
-
-                self.received_auto_reconnect = client_info
+                let auto_reconnect = client_info
                     .client_info
                     .extra_info
                     .optional_data
                     .auto_reconnect()
                     .cloned();
+                debug!(
+                    has_auto_reconnect = auto_reconnect.is_some(),
+                    "Received Client Info PDU"
+                );
+                self.received_auto_reconnect = auto_reconnect;
 
                 if !protocol.intersects(SecurityProtocol::HYBRID | SecurityProtocol::HYBRID_EX) {
                     let creds = client_info.client_info.credentials;

--- a/crates/ironrdp-pdu/src/rdp/client_info.rs
+++ b/crates/ironrdp-pdu/src/rdp/client_info.rs
@@ -281,6 +281,7 @@ impl ExtendedClientInfo {
 ///
 /// [2.2.4.3]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/ca0c58c8-b1a3-41f7-9f75-2f18c7f0b943
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ClientAutoReconnect {
     pub logon_id: u32,
     pub security_verifier: [u8; RECONNECT_SECURITY_VERIFIER_LEN],
@@ -346,7 +347,10 @@ impl ExtendedClientOptionalInfo {
         self.reconnect_cookie.as_ref()
     }
 
-    /// The validated Client Auto-Reconnect Packet, if supplied by the client.
+    /// The well-formed Client Auto-Reconnect Packet, if supplied by the client.
+    ///
+    /// This validates only the packet's internal length and version. The server
+    /// must validate its security verifier before accepting a reconnect.
     pub fn auto_reconnect(&self) -> Option<&ClientAutoReconnect> {
         self.auto_reconnect.as_ref()
     }
@@ -433,7 +437,7 @@ impl<'de> Decode<'de> for ExtendedClientOptionalInfo {
                 return Err(invalid_field_err!("cbAutoReconnectCookie", "missing cookie data"));
             }
             let reconnect_cookie = src.read_array();
-            optional_data.auto_reconnect = Some(ClientAutoReconnect::decode(&mut ReadCursor::new(&reconnect_cookie))?);
+            optional_data.auto_reconnect = ClientAutoReconnect::decode(&mut ReadCursor::new(&reconnect_cookie)).ok();
             optional_data.reconnect_cookie = Some(reconnect_cookie);
         }
 
@@ -449,9 +453,9 @@ impl<'de> Decode<'de> for ExtendedClientOptionalInfo {
 
 #[cfg(test)]
 mod tests {
-    use ironrdp_core::ReadCursor;
+    use ironrdp_core::{ReadCursor, decode, encode_vec};
 
-    use super::ClientAutoReconnect;
+    use super::{ClientAutoReconnect, ExtendedClientOptionalInfo, PerformanceFlags, TimezoneInfo};
 
     fn reconnect_cookie() -> [u8; 28] {
         let mut cookie = [0; 28];
@@ -480,6 +484,38 @@ mod tests {
         let mut invalid_version = reconnect_cookie();
         invalid_version[4..8].copy_from_slice(&2u32.to_le_bytes());
         assert!(ClientAutoReconnect::decode(&mut ReadCursor::new(&invalid_version)).is_err());
+    }
+
+    #[test]
+    fn malformed_auto_reconnect_packet_is_preserved_but_not_offered() {
+        let mut reconnect_cookie = reconnect_cookie();
+        reconnect_cookie[4..8].copy_from_slice(&2u32.to_le_bytes());
+        let optional_info = ExtendedClientOptionalInfo {
+            timezone: Some(TimezoneInfo::default()),
+            session_id: Some(0),
+            performance_flags: Some(PerformanceFlags::default()),
+            reconnect_cookie: Some(reconnect_cookie),
+            auto_reconnect: None,
+        };
+
+        let decoded: ExtendedClientOptionalInfo = decode(&encode_vec(&optional_info).unwrap()).unwrap();
+        assert_eq!(decoded.reconnect_cookie(), Some(&reconnect_cookie));
+        assert!(decoded.auto_reconnect().is_none());
+    }
+
+    #[test]
+    fn builder_parses_valid_auto_reconnect_packet() {
+        let optional_info = ExtendedClientOptionalInfo::builder()
+            .timezone(TimezoneInfo::default())
+            .session_id(0)
+            .performance_flags(PerformanceFlags::default())
+            .reconnect_cookie(reconnect_cookie())
+            .build();
+
+        assert_eq!(
+            optional_info.auto_reconnect().map(|packet| packet.logon_id),
+            Some(0x1234_5678)
+        );
     }
 }
 
@@ -859,7 +895,11 @@ fn string_len(value: &str, character_set: CharacterSet) -> usize {
 pub mod builder {
     use core::marker::PhantomData;
 
-    use super::{ExtendedClientOptionalInfo, PerformanceFlags, RECONNECT_COOKIE_LEN, TimezoneInfo};
+    use ironrdp_core::ReadCursor;
+
+    use super::{
+        ClientAutoReconnect, ExtendedClientOptionalInfo, PerformanceFlags, RECONNECT_COOKIE_LEN, TimezoneInfo,
+    };
 
     pub struct ExtendedClientOptionalInfoBuilderStateSetTimeZone;
     pub struct ExtendedClientOptionalInfoBuilderStateSetSessionId;
@@ -940,6 +980,7 @@ pub mod builder {
             mut self,
             reconnect_cookie: [u8; RECONNECT_COOKIE_LEN],
         ) -> ExtendedClientOptionalInfoBuilder<ExtendedClientOptionalInfoBuilderStateFinal> {
+            self.inner.auto_reconnect = ClientAutoReconnect::decode(&mut ReadCursor::new(&reconnect_cookie)).ok();
             self.inner.reconnect_cookie = Some(reconnect_cookie);
             ExtendedClientOptionalInfoBuilder {
                 inner: self.inner,

--- a/crates/ironrdp-pdu/src/rdp/client_info.rs
+++ b/crates/ironrdp-pdu/src/rdp/client_info.rs
@@ -12,6 +12,8 @@ use crate::utils;
 use crate::utils::CharacterSet;
 
 const RECONNECT_COOKIE_LEN: usize = 28;
+const RECONNECT_COOKIE_VERSION: u32 = 1;
+const RECONNECT_SECURITY_VERIFIER_LEN: usize = 16;
 const TIMEZONE_INFO_NAME_LEN: usize = 64;
 const COMPRESSION_TYPE_MASK: u32 = 0x0000_1E00;
 
@@ -275,6 +277,39 @@ impl ExtendedClientInfo {
     }
 }
 
+/// [2.2.4.3] Client Auto-Reconnect Packet (ARC_CS_PRIVATE_PACKET).
+///
+/// [2.2.4.3]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/ca0c58c8-b1a3-41f7-9f75-2f18c7f0b943
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClientAutoReconnect {
+    pub logon_id: u32,
+    pub security_verifier: [u8; RECONNECT_SECURITY_VERIFIER_LEN],
+}
+
+impl ClientAutoReconnect {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: RECONNECT_COOKIE_LEN);
+
+        let packet_length = src.read_u32();
+        if packet_length != u32::try_from(RECONNECT_COOKIE_LEN).expect("RECONNECT_COOKIE_LEN fits into u32") {
+            return Err(invalid_field_err!("cbLen", "invalid auto-reconnect cookie size"));
+        }
+
+        let version = src.read_u32();
+        if version != RECONNECT_COOKIE_VERSION {
+            return Err(invalid_field_err!("version", "invalid auto-reconnect cookie version"));
+        }
+
+        let logon_id = src.read_u32();
+        let security_verifier = src.read_array();
+
+        Ok(Self {
+            logon_id,
+            security_verifier,
+        })
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ExtendedClientOptionalInfo {
@@ -282,6 +317,7 @@ pub struct ExtendedClientOptionalInfo {
     session_id: Option<u32>,
     performance_flags: Option<PerformanceFlags>,
     reconnect_cookie: Option<[u8; RECONNECT_COOKIE_LEN]>,
+    auto_reconnect: Option<ClientAutoReconnect>,
     // other fields are read by RdpVersion::Ten+
 }
 
@@ -308,6 +344,11 @@ impl ExtendedClientOptionalInfo {
 
     pub fn reconnect_cookie(&self) -> Option<&[u8; RECONNECT_COOKIE_LEN]> {
         self.reconnect_cookie.as_ref()
+    }
+
+    /// The validated Client Auto-Reconnect Packet, if supplied by the client.
+    pub fn auto_reconnect(&self) -> Option<&ClientAutoReconnect> {
+        self.auto_reconnect.as_ref()
     }
 }
 
@@ -391,7 +432,9 @@ impl<'de> Decode<'de> for ExtendedClientOptionalInfo {
             if src.len() < RECONNECT_COOKIE_LEN {
                 return Err(invalid_field_err!("cbAutoReconnectCookie", "missing cookie data"));
             }
-            optional_data.reconnect_cookie = Some(src.read_array());
+            let reconnect_cookie = src.read_array();
+            optional_data.auto_reconnect = Some(ClientAutoReconnect::decode(&mut ReadCursor::new(&reconnect_cookie))?);
+            optional_data.reconnect_cookie = Some(reconnect_cookie);
         }
 
         if src.len() < 2 * 2 {
@@ -401,6 +444,42 @@ impl<'de> Decode<'de> for ExtendedClientOptionalInfo {
         src.read_u16(); // reserved2
 
         Ok(optional_data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ironrdp_core::ReadCursor;
+
+    use super::ClientAutoReconnect;
+
+    fn reconnect_cookie() -> [u8; 28] {
+        let mut cookie = [0; 28];
+        cookie[0..4].copy_from_slice(&28u32.to_le_bytes());
+        cookie[4..8].copy_from_slice(&1u32.to_le_bytes());
+        cookie[8..12].copy_from_slice(&0x1234_5678u32.to_le_bytes());
+        cookie[12..].copy_from_slice(&[0xA5; 16]);
+        cookie
+    }
+
+    #[test]
+    fn client_auto_reconnect_decodes() {
+        let cookie = reconnect_cookie();
+        let decoded = ClientAutoReconnect::decode(&mut ReadCursor::new(&cookie)).unwrap();
+
+        assert_eq!(decoded.logon_id, 0x1234_5678);
+        assert_eq!(decoded.security_verifier, [0xA5; 16]);
+    }
+
+    #[test]
+    fn client_auto_reconnect_rejects_invalid_length_and_version() {
+        let mut invalid_length = reconnect_cookie();
+        invalid_length[0..4].copy_from_slice(&27u32.to_le_bytes());
+        assert!(ClientAutoReconnect::decode(&mut ReadCursor::new(&invalid_length)).is_err());
+
+        let mut invalid_version = reconnect_cookie();
+        invalid_version[4..8].copy_from_slice(&2u32.to_le_bytes());
+        assert!(ClientAutoReconnect::decode(&mut ReadCursor::new(&invalid_version)).is_err());
     }
 }
 

--- a/crates/ironrdp-server/Cargo.toml
+++ b/crates/ironrdp-server/Cargo.toml
@@ -34,7 +34,10 @@ __bench = ["dep:visibility"]
 
 [dependencies]
 anyhow = "1.0"
-tokio = { version = "1", features = ["net", "macros", "sync", "rt"] } # public
+hmac = "0.12"
+md5 = { package = "md-5", version = "0.10" }
+rand = "0.9"
+tokio = { version = "1", features = ["net", "macros", "sync", "rt", "time"] } # public
 tokio-rustls = "0.26" # public
 async-trait = "0.1"
 ironrdp-async = { path = "../ironrdp-async", version = "0.10" }

--- a/crates/ironrdp-server/src/builder.rs
+++ b/crates/ironrdp-server/src/builder.rs
@@ -297,14 +297,15 @@ impl RdpServerBuilder<BuilderDone> {
     /// `ARC_SC_PRIVATE_PACKET`) handed to the client during logon.
     ///
     /// When set to `Some`, the server sends a Save Session Info PDU carrying the
-    /// cookie once per connection, right after activation, which is what lets a
-    /// client automatically re-establish the session after an *ungraceful*
-    /// disconnect (MS-RDPBCGR 1.3.1.5, "Automatic Reconnection") rather than
-    /// reporting the connection as simply lost. Generate the cookie's 16-byte
-    /// `random_bits` from a CSPRNG. `None` (the default) sends no cookie.
+    /// cookie right after activation. It validates the returning client cookie,
+    /// generates a fresh CSPRNG random whenever a client connects, and updates
+    /// the active client hourly. Automatic reconnection requires TLS or Hybrid
+    /// security, which provides the all-zero client random required for Enhanced
+    /// RDP Security. `None` (the default) sends no cookie.
     ///
-    /// See [`RdpServer::set_auto_reconnect_cookie`] for the runtime equivalent
-    /// and a note on the (unvalidated) returning `ARC_CS_PRIVATE_PACKET`.
+    /// See [`RdpServer::set_auto_reconnect_cookie`] for post-construction
+    /// configuration and [`RdpServer::auto_reconnect_cookie_handle`] for
+    /// updates while the server is running.
     pub fn with_auto_reconnect_cookie(mut self, cookie: Option<ServerAutoReconnect>) -> Self {
         self.state.auto_reconnect_cookie = cookie;
         self

--- a/crates/ironrdp-server/src/builder.rs
+++ b/crates/ironrdp-server/src/builder.rs
@@ -275,6 +275,10 @@ impl RdpServerBuilder<BuilderDone> {
     /// error closes the connection. Pass `None` (the default) to skip
     /// validation entirely.
     ///
+    /// A valid Server Auto-Reconnect Cookie bypasses this validator. Applications
+    /// that must validate every connection should leave automatic reconnection
+    /// disabled.
+    ///
     /// Not used for CredSSP/Hybrid connections (those use pre-loaded
     /// credentials for NTLM challenge-response).
     pub fn with_credential_validator(mut self, validator: Option<Arc<dyn CredentialValidator>>) -> Self {

--- a/crates/ironrdp-server/src/lib.rs
+++ b/crates/ironrdp-server/src/lib.rs
@@ -32,6 +32,7 @@ pub use gfx::{EgfxServerMessage, GfxDvcBridge, GfxServerFactory, GfxServerHandle
 pub use handler::{KeyboardEvent, MouseEvent, RdpServerInputHandler};
 #[cfg(feature = "helper")]
 pub use helper::TlsIdentityCtx;
+pub use ironrdp_pdu::rdp::session_info::ServerAutoReconnect;
 pub use server::{
     AutoReconnectCookieHandle, ConnectionHandler, CredentialDecision, CredentialValidationError, CredentialValidator,
     Credentials, ExactMatchCredentialValidator, PostConnectionAction, RdpServer, RdpServerOptions, RdpServerSecurity,

--- a/crates/ironrdp-server/src/lib.rs
+++ b/crates/ironrdp-server/src/lib.rs
@@ -33,9 +33,9 @@ pub use handler::{KeyboardEvent, MouseEvent, RdpServerInputHandler};
 #[cfg(feature = "helper")]
 pub use helper::TlsIdentityCtx;
 pub use server::{
-    ConnectionHandler, CredentialDecision, CredentialValidationError, CredentialValidator, Credentials,
-    ExactMatchCredentialValidator, PostConnectionAction, RdpServer, RdpServerOptions, RdpServerSecurity, ServerEvent,
-    ServerEventSender, TransportTls,
+    AutoReconnectCookieHandle, ConnectionHandler, CredentialDecision, CredentialValidationError, CredentialValidator,
+    Credentials, ExactMatchCredentialValidator, PostConnectionAction, RdpServer, RdpServerOptions, RdpServerSecurity,
+    ServerEvent, ServerEventSender, TransportTls,
 };
 pub use sound::{RdpsndServerHandler, RdpsndServerMessage, SoundServerFactory};
 

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -6,6 +6,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use anyhow::{Context as _, Result, bail};
+use hmac::{Hmac, Mac as _};
 use ironrdp_acceptor::{Acceptor, AcceptorResult, BeginResult, DesktopSize};
 use ironrdp_async::Framed;
 use ironrdp_cliprdr::CliprdrServer;
@@ -26,6 +27,8 @@ use ironrdp_pdu::{Action, PduResult, decode_err, mcs, nego, rdp};
 use ironrdp_rdpsnd as rdpsnd;
 use ironrdp_svc::{ChannelFlags, StaticChannelId, StaticChannelSet, SvcProcessor, server_encode_svc_messages};
 use ironrdp_tokio::{FramedRead, FramedWrite, TokioFramed, split_tokio_framed, unsplit_tokio_framed};
+use md5::Md5;
+use rand::RngCore as _;
 use rdpsnd::server::{RdpsndServer, RdpsndServerMessage};
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt as _};
 use tokio::net::TcpSocket;
@@ -46,6 +49,10 @@ use crate::{SoundServerFactory, builder, capabilities};
 
 /// TCP listen backlog size for the RDP server socket.
 const LISTENER_BACKLOG: u32 = 1024;
+const AUTO_RECONNECT_COOKIE_UPDATE_INTERVAL: Duration = Duration::from_secs(60 * 60);
+const AUTO_RECONNECT_CLIENT_RANDOM: [u8; 32] = [0; 32];
+
+type HmacMd5 = Hmac<Md5>;
 
 /// Action to take after a client disconnects.
 ///
@@ -472,19 +479,38 @@ pub struct RdpServer {
     autodetect_rtt: Arc<AtomicU32>,
 
     /// Optional Server Auto-Reconnect Cookie (MS-RDPBCGR 2.2.4.2
-    /// `ARC_SC_PRIVATE_PACKET`). When `Some`, the server sends a Save Session
-    /// Info PDU carrying it once per connection, right after activation. A
-    /// client only enters its automatic reconnection sequence (MS-RDPBCGR
-    /// 1.3.1.5) on an *ungraceful* disconnect if it was handed this cookie
-    /// during logon; without it, a dropped connection simply reports as
-    /// disconnected. `None` (the default) sends nothing. Configure it on the
-    /// builder ([`RdpServer::builder`]) via `with_auto_reconnect_cookie`, or at
-    /// runtime via [`Self::set_auto_reconnect_cookie`].
+    /// `ARC_SC_PRIVATE_PACKET`). When `Some`, the server validates a returning
+    /// `ARC_CS_PRIVATE_PACKET`, replaces its random after every connection, and
+    /// sends hourly updates to the active client. This requires TLS or Hybrid
+    /// security, which provides the all-zero client random required for Enhanced
+    /// RDP Security. `None` (the default) disables automatic reconnection.
+    /// Configure it on the builder
+    /// ([`RdpServer::builder`]) via `with_auto_reconnect_cookie`, or after
+    /// construction via [`Self::set_auto_reconnect_cookie`].
     auto_reconnect_cookie: Option<rdp::session_info::ServerAutoReconnect>,
-    /// Per-connection guard so the auto-reconnect cookie is sent exactly once,
-    /// after the first activation — not again on a Deactivation-Reactivation
-    /// sequence. Reset at the start of every connection.
+    /// Tracks whether the current cookie has reached a client. Subsequent
+    /// connections and hourly updates replace it with a new random.
     auto_reconnect_sent: bool,
+}
+
+/// Cloneable handle for updating the Server Auto-Reconnect Cookie while
+/// [`RdpServer::run`] owns the server.
+#[derive(Clone)]
+pub struct AutoReconnectCookieHandle {
+    sender: mpsc::UnboundedSender<ServerEvent>,
+}
+
+impl AutoReconnectCookieHandle {
+    /// Queue a replacement cookie for the active client or the next connection.
+    ///
+    /// `None` disables auto-reconnect and immediately invalidates the cookie
+    /// currently held by the server.
+    pub fn set(
+        &self,
+        cookie: Option<rdp::session_info::ServerAutoReconnect>,
+    ) -> Result<(), mpsc::error::SendError<ServerEvent>> {
+        self.sender.send(ServerEvent::SetAutoReconnectCookie(cookie))
+    }
 }
 
 #[derive(Debug)]
@@ -494,6 +520,8 @@ pub enum ServerEvent {
     Rdpsnd(RdpsndServerMessage),
     Echo(EchoServerMessage),
     SetCredentials(Credentials),
+    /// Replace or clear the Server Auto-Reconnect Cookie.
+    SetAutoReconnectCookie(Option<rdp::session_info::ServerAutoReconnect>),
     GetLocalAddr(oneshot::Sender<Option<SocketAddr>>),
     #[cfg(feature = "egfx")]
     Egfx(EgfxServerMessage),
@@ -603,32 +631,130 @@ impl RdpServer {
     /// `ARC_SC_PRIVATE_PACKET`) handed to the client during logon.
     ///
     /// When set to `Some`, the server sends a Save Session Info PDU carrying the
-    /// cookie once per connection, right after activation. This is what lets a
-    /// client (e.g. mstsc) automatically re-establish the session after an
-    /// *ungraceful* disconnect (MS-RDPBCGR 1.3.1.5, "Automatic Reconnection")
-    /// instead of reporting the connection as simply lost; a graceful logoff is
-    /// unaffected. The [`ServerAutoReconnect`] carries a `logon_id` identifying
-    /// the session and a 16-byte `random_bits` auto-reconnect random — generate
-    /// `random_bits` from a CSPRNG.
+    /// cookie right after activation. It verifies the returned
+    /// `ARC_CS_PRIVATE_PACKET` using the HMAC-MD5 verifier required by
+    /// MS-RDPBCGR 5.5, replaces the random after every accepted connection, and
+    /// sends an update every hour. Automatic reconnection requires TLS or Hybrid
+    /// security, which provides the all-zero client random required for Enhanced
+    /// RDP Security. The [`ServerAutoReconnect`] `logon_id` identifies the
+    /// session; the server generates replacement randoms with a CSPRNG.
     ///
     /// Pass `None` (the default) to send no cookie.
     ///
     /// Most callers should configure this at construction time via the builder
-    /// ([`RdpServer::builder`])'s `with_auto_reconnect_cookie`; this setter exists
-    /// for dynamic post-construction reconfiguration.
-    ///
-    /// # Note on the returning cookie
-    ///
-    /// This only *enables* the client's automatic reconnection; it does not
-    /// validate the `ARC_CS_PRIVATE_PACKET` the client sends back on reconnect
-    /// (MS-RDPBCGR 2.2.4.3). A server that re-authenticates every connection by
-    /// other means (e.g. NLA/CredSSP) does not need to; a server that wants the
-    /// cookie itself to be an authentication factor must verify the returned
-    /// value.
+    /// ([`RdpServer::builder`])'s `with_auto_reconnect_cookie`. To replace a
+    /// cookie while [`Self::run`] owns the server, use
+    /// [`Self::auto_reconnect_cookie_handle`].
     ///
     /// [`ServerAutoReconnect`]: ironrdp_pdu::rdp::session_info::ServerAutoReconnect
     pub fn set_auto_reconnect_cookie(&mut self, cookie: Option<rdp::session_info::ServerAutoReconnect>) {
         self.auto_reconnect_cookie = cookie;
+        self.auto_reconnect_sent = false;
+    }
+
+    /// Returns a handle for replacing the cookie while [`Self::run`] owns this
+    /// server.
+    pub fn auto_reconnect_cookie_handle(&self) -> AutoReconnectCookieHandle {
+        AutoReconnectCookieHandle {
+            sender: self.ev_sender.clone(),
+        }
+    }
+
+    fn supports_auto_reconnect(&self) -> bool {
+        matches!(
+            &self.opts.security,
+            RdpServerSecurity::Tls(_) | RdpServerSecurity::Hybrid(_)
+        )
+    }
+
+    fn verify_auto_reconnect_cookie(&self, reconnect: &rdp::client_info::ClientAutoReconnect) -> bool {
+        if !self.supports_auto_reconnect() {
+            return false;
+        }
+
+        self.auto_reconnect_cookie
+            .as_ref()
+            .is_some_and(|cookie| auto_reconnect_cookie_matches(cookie, reconnect))
+    }
+
+    fn generate_auto_reconnect_cookie(logon_id: u32) -> rdp::session_info::ServerAutoReconnect {
+        let mut random_bits = [0; 16];
+        rand::rng().fill_bytes(&mut random_bits);
+
+        rdp::session_info::ServerAutoReconnect { logon_id, random_bits }
+    }
+
+    fn next_auto_reconnect_cookie(&self) -> Option<rdp::session_info::ServerAutoReconnect> {
+        if !self.supports_auto_reconnect() {
+            return None;
+        }
+
+        let cookie = self.auto_reconnect_cookie.as_ref()?;
+
+        if self.auto_reconnect_sent {
+            Some(Self::generate_auto_reconnect_cookie(cookie.logon_id))
+        } else {
+            Some(cookie.clone())
+        }
+    }
+    async fn send_auto_reconnect_cookie(
+        cookie: rdp::session_info::ServerAutoReconnect,
+        writer: &mut impl FramedWrite,
+        io_channel_id: u16,
+        user_channel_id: u16,
+    ) -> Result<()> {
+        let pdu = rdp::headers::ShareDataPdu::SaveSessionInfo(rdp::session_info::SaveSessionInfoPdu {
+            info_type: rdp::session_info::InfoType::LogonExtended,
+            info_data: rdp::session_info::InfoData::LogonExtended(rdp::session_info::LogonInfoExtended {
+                present_fields_flags: rdp::session_info::LogonExFlags::AUTO_RECONNECT_COOKIE,
+                auto_reconnect: Some(cookie),
+                errors_info: None,
+            }),
+        });
+        let data = encode_share_data_pdu(pdu, io_channel_id, user_channel_id)?;
+        writer.write_all(&data).await.context("send auto-reconnect cookie")?;
+        debug!("Sent Server Auto-Reconnect Cookie (Save Session Info PDU)");
+
+        Ok(())
+    }
+
+    async fn send_next_auto_reconnect_cookie(
+        &mut self,
+        writer: &mut impl FramedWrite,
+        io_channel_id: u16,
+        user_channel_id: u16,
+    ) -> Result<()> {
+        let Some(cookie) = self.next_auto_reconnect_cookie() else {
+            return Ok(());
+        };
+
+        Self::send_auto_reconnect_cookie(cookie.clone(), writer, io_channel_id, user_channel_id).await?;
+        self.auto_reconnect_cookie = Some(cookie);
+        self.auto_reconnect_sent = true;
+
+        Ok(())
+    }
+
+    async fn rotate_auto_reconnect_cookie(
+        &mut self,
+        writer: &mut impl FramedWrite,
+        io_channel_id: u16,
+        user_channel_id: u16,
+    ) -> Result<()> {
+        if !self.supports_auto_reconnect() {
+            return Ok(());
+        }
+
+        let Some(cookie) = self.auto_reconnect_cookie.as_ref() else {
+            return Ok(());
+        };
+        let cookie = Self::generate_auto_reconnect_cookie(cookie.logon_id);
+
+        Self::send_auto_reconnect_cookie(cookie.clone(), writer, io_channel_id, user_channel_id).await?;
+        self.auto_reconnect_cookie = Some(cookie);
+        self.auto_reconnect_sent = true;
+
+        Ok(())
     }
 
     pub fn event_sender(&self) -> &mpsc::UnboundedSender<ServerEvent> {
@@ -857,11 +983,6 @@ impl RdpServer {
         // `set_display_suppressed_handle()`.
         self.display_suppressed.store(false, Ordering::Relaxed);
 
-        // The Server Auto-Reconnect Cookie is sent once per connection after
-        // activation; clear the "already sent" guard so this new connection
-        // sends it (a previous connection would have left it `true`).
-        self.auto_reconnect_sent = false;
-
         let framed = TokioFramed::new(stream);
 
         let size = self.display.lock().await.size().await;
@@ -1003,6 +1124,9 @@ impl RdpServer {
                         ServerEvent::SetCredentials(creds) => {
                             self.set_credentials(Some(creds));
                         }
+                        ServerEvent::SetAutoReconnectCookie(cookie) => {
+                            self.set_auto_reconnect_cookie(cookie);
+                        }
                         ev => {
                             debug!("Unexpected event {:?}", ev);
                         }
@@ -1131,6 +1255,7 @@ impl RdpServer {
         &mut self,
         events: &mut Vec<ServerEvent>,
         writer: &mut impl FramedWrite,
+        io_channel_id: u16,
         user_channel_id: u16,
         message_channel_id: Option<u16>,
     ) -> Result<RunState> {
@@ -1162,6 +1287,11 @@ impl RdpServer {
                 }
                 ServerEvent::SetCredentials(creds) => {
                     self.set_credentials(Some(creds));
+                }
+                ServerEvent::SetAutoReconnectCookie(cookie) => {
+                    self.set_auto_reconnect_cookie(cookie);
+                    self.send_next_auto_reconnect_cookie(writer, io_channel_id, user_channel_id)
+                        .await?;
                 }
                 ServerEvent::Rdpsnd(s) => {
                     let Some(rdpsnd) = self.get_svc_processor::<RdpsndServer>() else {
@@ -1291,6 +1421,7 @@ impl RdpServer {
         let mut writer = SharedWriter::new(writer);
         let mut display_writer = writer.clone();
         let mut event_writer = writer.clone();
+        let mut auto_reconnect_writer = writer.clone();
         let ev_receiver = Arc::clone(&self.ev_receiver);
         let s = Rc::new(Mutex::new(self));
 
@@ -1366,7 +1497,13 @@ impl RdpServer {
                 }
                 let mut this = this.lock().await;
                 match this
-                    .dispatch_server_events(&mut events, &mut event_writer, user_channel_id, message_channel_id)
+                    .dispatch_server_events(
+                        &mut events,
+                        &mut event_writer,
+                        io_channel_id,
+                        user_channel_id,
+                        message_channel_id,
+                    )
                     .await?
                 {
                     RunState::Continue => continue,
@@ -1375,10 +1512,24 @@ impl RdpServer {
             }
         };
 
+        let this = Rc::clone(&s);
+        let refresh_auto_reconnect_cookie = async move {
+            let mut interval = tokio::time::interval(AUTO_RECONNECT_COOKIE_UPDATE_INTERVAL);
+            interval.tick().await;
+
+            loop {
+                interval.tick().await;
+                let mut this = this.lock().await;
+                this.rotate_auto_reconnect_cookie(&mut auto_reconnect_writer, io_channel_id, user_channel_id)
+                    .await?;
+            }
+        };
+
         let state = tokio::select!(
             state = dispatch_pdu => state,
             state = dispatch_display => state,
             state = dispatch_events => state,
+            state = refresh_auto_reconnect_cookie => state,
         );
 
         debug!("End of client loop: {state:?}");
@@ -1397,11 +1548,24 @@ impl RdpServer {
     {
         debug!("Client accepted");
 
+        let is_auto_reconnect = if let Some(reconnect) = result.auto_reconnect.as_ref() {
+            if !self.verify_auto_reconnect_cookie(reconnect) {
+                warn!("Auto-reconnect cookie validation rejected");
+                send_access_denied(result.io_channel_id, result.user_channel_id, writer).await?;
+                bail!("auto-reconnect cookie validation rejected");
+            }
+
+            debug!("Auto-reconnect cookie validation accepted");
+            true
+        } else {
+            false
+        };
+
         // Validate credentials if a validator is configured. The validator runs here, in the
         // async server layer, rather than in the sans-I/O acceptor, because real validators
         // (PAM/LDAP/DB) are I/O-bound. On rejection, deny with a ServerSetErrorInfoPdu before
         // closing, matching the acceptor's exact-match denial path.
-        if let Some(validator) = self.credential_validator.clone() {
+        if !is_auto_reconnect && let Some(validator) = self.credential_validator.clone() {
             if let Some(creds) = &result.credentials {
                 match validator.validate(creds).await {
                     Ok(CredentialDecision::Accept) => {
@@ -1537,28 +1701,8 @@ impl RdpServer {
         let encoder = UpdateEncoder::new(desktop_size, surface_flags, update_codecs, self.opts.max_request_size)
             .context("failed to initialize update encoder")?;
 
-        // If configured, hand the client its Server Auto-Reconnect Cookie now
-        // that activation is complete (Confirm Active processed, encoder built),
-        // once per connection. This Save Session Info PDU is what lets a client
-        // automatically re-establish the session after an ungraceful disconnect
-        // (MS-RDPBCGR 1.3.1.5). Not re-sent on a Deactivation-Reactivation
-        // sequence (`auto_reconnect_sent` guard, reset per connection).
-        if !self.auto_reconnect_sent {
-            if let Some(cookie) = self.auto_reconnect_cookie.clone() {
-                let pdu = rdp::headers::ShareDataPdu::SaveSessionInfo(rdp::session_info::SaveSessionInfoPdu {
-                    info_type: rdp::session_info::InfoType::LogonExtended,
-                    info_data: rdp::session_info::InfoData::LogonExtended(rdp::session_info::LogonInfoExtended {
-                        present_fields_flags: rdp::session_info::LogonExFlags::AUTO_RECONNECT_COOKIE,
-                        auto_reconnect: Some(cookie),
-                        errors_info: None,
-                    }),
-                });
-                let data = encode_share_data_pdu(pdu, result.io_channel_id, result.user_channel_id)?;
-                writer.write_all(&data).await.context("send auto-reconnect cookie")?;
-                self.auto_reconnect_sent = true;
-                debug!("Sent Server Auto-Reconnect Cookie (Save Session Info PDU)");
-            }
-        }
+        self.send_next_auto_reconnect_cookie(writer, result.io_channel_id, result.user_channel_id)
+            .await?;
 
         let state = self
             .client_loop(
@@ -1860,6 +2004,22 @@ fn encode_autodetect_request(
         user_data,
     };
     Ok(encode_vec(&X224(mcs_pdu))?)
+}
+
+fn auto_reconnect_cookie_matches(
+    cookie: &rdp::session_info::ServerAutoReconnect,
+    reconnect: &rdp::client_info::ClientAutoReconnect,
+) -> bool {
+    reconnect.logon_id == cookie.logon_id
+        && auto_reconnect_verifier_matches(&cookie.random_bits, &reconnect.security_verifier)
+}
+
+fn auto_reconnect_verifier_matches(random_bits: &[u8; 16], security_verifier: &[u8; 16]) -> bool {
+    let Ok(mut verifier) = HmacMd5::new_from_slice(random_bits) else {
+        unreachable!("the auto-reconnect random has a valid HMAC-MD5 key length")
+    };
+    verifier.update(&AUTO_RECONNECT_CLIENT_RANDOM);
+    verifier.verify_slice(security_verifier).is_ok()
 }
 
 /// Encode a Share Data PDU wrapped in a Share Control header and carried in an

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -488,6 +488,12 @@ pub struct RdpServer {
     /// ([`RdpServer::builder`]) via `with_auto_reconnect_cookie`, or after
     /// construction via [`Self::set_auto_reconnect_cookie`].
     auto_reconnect_cookie: Option<rdp::session_info::ServerAutoReconnect>,
+    /// The cookie replaced by the current one, accepted until the next rotation.
+    ///
+    /// A successful socket write does not prove the client received the
+    /// replacement. Retaining one previous value lets a client that disconnects
+    /// during that window reconnect with the last cookie it knows.
+    previous_auto_reconnect_cookie: Option<rdp::session_info::ServerAutoReconnect>,
     /// Tracks whether the current cookie has reached a client. Subsequent
     /// connections and hourly updates replace it with a new random.
     auto_reconnect_sent: bool,
@@ -503,8 +509,9 @@ pub struct AutoReconnectCookieHandle {
 impl AutoReconnectCookieHandle {
     /// Queue a replacement cookie for the active client or the next connection.
     ///
-    /// `None` disables auto-reconnect and immediately invalidates the cookie
-    /// currently held by the server.
+    /// The change takes effect only after the server handles this event. `None`
+    /// then disables auto-reconnect and invalidates every cookie currently held
+    /// by the server.
     pub fn set(
         &self,
         cookie: Option<rdp::session_info::ServerAutoReconnect>,
@@ -513,7 +520,6 @@ impl AutoReconnectCookieHandle {
     }
 }
 
-#[derive(Debug)]
 pub enum ServerEvent {
     Quit(String),
     Clipboard(ClipboardMessage),
@@ -527,6 +533,24 @@ pub enum ServerEvent {
     Egfx(EgfxServerMessage),
     /// Trigger an RTT measurement probe (requires auto-detect enabled).
     AutoDetectRttRequest,
+}
+
+impl fmt::Debug for ServerEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Quit(reason) => f.debug_tuple("Quit").field(reason).finish(),
+            Self::Clipboard(..) => f.write_str("Clipboard(..)"),
+            Self::Rdpsnd(..) => f.write_str("Rdpsnd(..)"),
+            Self::Echo(..) => f.write_str("Echo(..)"),
+            Self::SetCredentials(..) => f.write_str("SetCredentials(..)"),
+            Self::SetAutoReconnectCookie(Some(..)) => f.write_str("SetAutoReconnectCookie(Some(..))"),
+            Self::SetAutoReconnectCookie(None) => f.write_str("SetAutoReconnectCookie(None)"),
+            Self::GetLocalAddr(..) => f.write_str("GetLocalAddr(..)"),
+            #[cfg(feature = "egfx")]
+            Self::Egfx(..) => f.write_str("Egfx(..)"),
+            Self::AutoDetectRttRequest => f.write_str("AutoDetectRttRequest"),
+        }
+    }
 }
 
 pub trait ServerEventSender {
@@ -600,6 +624,7 @@ impl RdpServer {
                 handle
             },
             auto_reconnect_cookie: None,
+            previous_auto_reconnect_cookie: None,
             auto_reconnect_sent: false,
         }
     }
@@ -616,6 +641,10 @@ impl RdpServer {
     /// [`CredentialDecision::Reject`] (or a [`CredentialValidationError`]),
     /// the connection is rejected. Passing `None` clears any previously
     /// configured validator.
+    ///
+    /// A valid Server Auto-Reconnect Cookie bypasses this validator. Applications
+    /// that must validate every connection should leave automatic reconnection
+    /// disabled.
     ///
     /// Most callers should configure the validator at construction time via
     /// the builder's `with_credential_validator` method
@@ -649,6 +678,7 @@ impl RdpServer {
     /// [`ServerAutoReconnect`]: ironrdp_pdu::rdp::session_info::ServerAutoReconnect
     pub fn set_auto_reconnect_cookie(&mut self, cookie: Option<rdp::session_info::ServerAutoReconnect>) {
         self.auto_reconnect_cookie = cookie;
+        self.previous_auto_reconnect_cookie = None;
         self.auto_reconnect_sent = false;
     }
 
@@ -672,9 +702,10 @@ impl RdpServer {
             return false;
         }
 
-        self.auto_reconnect_cookie
-            .as_ref()
-            .is_some_and(|cookie| auto_reconnect_cookie_matches(cookie, reconnect))
+        [&self.auto_reconnect_cookie, &self.previous_auto_reconnect_cookie]
+            .into_iter()
+            .flatten()
+            .any(|cookie| auto_reconnect_cookie_matches(cookie, reconnect))
     }
 
     fn generate_auto_reconnect_cookie(logon_id: u32) -> rdp::session_info::ServerAutoReconnect {
@@ -696,6 +727,15 @@ impl RdpServer {
         } else {
             Some(cookie.clone())
         }
+    }
+
+    fn commit_auto_reconnect_rotation(&mut self, cookie: rdp::session_info::ServerAutoReconnect) {
+        if self.auto_reconnect_sent {
+            self.previous_auto_reconnect_cookie = self.auto_reconnect_cookie.replace(cookie);
+        } else {
+            self.auto_reconnect_cookie = Some(cookie);
+        }
+        self.auto_reconnect_sent = true;
     }
     async fn send_auto_reconnect_cookie(
         cookie: rdp::session_info::ServerAutoReconnect,
@@ -729,8 +769,7 @@ impl RdpServer {
         };
 
         Self::send_auto_reconnect_cookie(cookie.clone(), writer, io_channel_id, user_channel_id).await?;
-        self.auto_reconnect_cookie = Some(cookie);
-        self.auto_reconnect_sent = true;
+        self.commit_auto_reconnect_rotation(cookie);
 
         Ok(())
     }
@@ -751,7 +790,31 @@ impl RdpServer {
         let cookie = Self::generate_auto_reconnect_cookie(cookie.logon_id);
 
         Self::send_auto_reconnect_cookie(cookie.clone(), writer, io_channel_id, user_channel_id).await?;
+        self.commit_auto_reconnect_rotation(cookie);
+
+        Ok(())
+    }
+
+    async fn update_auto_reconnect_cookie(
+        &mut self,
+        cookie: Option<rdp::session_info::ServerAutoReconnect>,
+        writer: &mut impl FramedWrite,
+        io_channel_id: u16,
+        user_channel_id: u16,
+    ) -> Result<()> {
+        let Some(cookie) = cookie else {
+            self.set_auto_reconnect_cookie(None);
+            return Ok(());
+        };
+
+        if !self.supports_auto_reconnect() {
+            self.set_auto_reconnect_cookie(Some(cookie));
+            return Ok(());
+        }
+
+        Self::send_auto_reconnect_cookie(cookie.clone(), writer, io_channel_id, user_channel_id).await?;
         self.auto_reconnect_cookie = Some(cookie);
+        self.previous_auto_reconnect_cookie = None;
         self.auto_reconnect_sent = true;
 
         Ok(())
@@ -1289,8 +1352,7 @@ impl RdpServer {
                     self.set_credentials(Some(creds));
                 }
                 ServerEvent::SetAutoReconnectCookie(cookie) => {
-                    self.set_auto_reconnect_cookie(cookie);
-                    self.send_next_auto_reconnect_cookie(writer, io_channel_id, user_channel_id)
+                    self.update_auto_reconnect_cookie(cookie, writer, io_channel_id, user_channel_id)
                         .await?;
                 }
                 ServerEvent::Rdpsnd(s) => {
@@ -2135,5 +2197,52 @@ impl<'a, W: FramedWrite> SharedWriter<'a, W> {
         Self {
             writer: Rc::new(Mutex::new(writer)),
         }
+    }
+}
+
+#[cfg(test)]
+mod auto_reconnect_tests {
+    use ironrdp_pdu::rdp::client_info::ClientAutoReconnect;
+    use ironrdp_pdu::rdp::session_info::ServerAutoReconnect;
+
+    use super::{auto_reconnect_cookie_matches, auto_reconnect_verifier_matches};
+
+    // Independently computed with Python's hmac/hashlib:
+    // HMAC-MD5(key = 01..10, msg = 32 zero bytes) = 894025a9...261c.
+    const RANDOM_BITS: [u8; 16] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+    const EXPECTED_VERIFIER: [u8; 16] = [
+        0x89, 0x40, 0x25, 0xa9, 0x9d, 0x64, 0xab, 0x96, 0x64, 0x19, 0xec, 0x1e, 0xf1, 0x3c, 0x26, 0x1c,
+    ];
+
+    #[test]
+    fn verifier_matches_reference_hmac_md5() {
+        assert!(auto_reconnect_verifier_matches(&RANDOM_BITS, &EXPECTED_VERIFIER));
+    }
+
+    #[test]
+    fn verifier_rejects_a_wrong_value() {
+        let mut wrong = EXPECTED_VERIFIER;
+        wrong[0] ^= 0xff;
+
+        assert!(!auto_reconnect_verifier_matches(&RANDOM_BITS, &wrong));
+    }
+
+    #[test]
+    fn cookie_match_requires_both_logon_id_and_verifier() {
+        let cookie = ServerAutoReconnect {
+            logon_id: 0x1234_5678,
+            random_bits: RANDOM_BITS,
+        };
+        let valid = ClientAutoReconnect {
+            logon_id: 0x1234_5678,
+            security_verifier: EXPECTED_VERIFIER,
+        };
+        assert!(auto_reconnect_cookie_matches(&cookie, &valid));
+
+        let wrong_logon_id = ClientAutoReconnect {
+            logon_id: 1,
+            security_verifier: EXPECTED_VERIFIER,
+        };
+        assert!(!auto_reconnect_cookie_matches(&cookie, &wrong_logon_id));
     }
 }


### PR DESCRIPTION
## Summary
- parse and carry `ARC_CS_PRIVATE_PACKET` data through the acceptor
- validate returning Enhanced RDP Security cookies with HMAC-MD5 before reconnecting
- rotate reconnect randoms per connection and hourly, with runtime cookie updates
- restrict cookie authentication to TLS/Hybrid and document the behavior

## Testing
- `cargo test -p ironrdp-pdu -p ironrdp-acceptor -p ironrdp-server`
- `cargo clippy -p ironrdp-pdu -p ironrdp-acceptor -p ironrdp-server --all-targets -- -D warnings`

Fixes: #1508