### PR TITLE
fix(pdu): accept a zero-length connect-time bandwidth payload on decode

### DIFF
--- a/crates/ironrdp-pdu/src/rdp/autodetect.rs
+++ b/crates/ironrdp-pdu/src/rdp/autodetect.rs
@@ -477,16 +477,15 @@ impl<'de> Decode<'de> for AutoDetectRequest {
                 // Connect-time stop has payloadLength + payload.
                 ensure_size!(in: src, size: 2);
                 let payload_length = src.read_u16();
-                // Same rule as the encoder: 2.2.14.1.4 requires a value greater than
-                // zero here, so a zero length is a malformed PDU rather than an empty
-                // payload. Accepting what we refuse to emit would leave the two sides
-                // disagreeing about what the wire permits.
-                if payload_length == 0 {
-                    return Err(invalid_field_err!(
-                        "payloadLength",
-                        "connect-time Bandwidth Measure Stop requires a payload length greater than zero"
-                    ));
-                }
+                // A zero length does not conform: 2.2.14.1.4 requires a value greater
+                // than zero, which is why `encode` refuses to emit one. It is still
+                // accepted here, deliberately, because the two directions answer
+                // different questions. Emitting asks what we are permitted to put on the
+                // wire; accepting asks whether we can act on what a peer already sent.
+                // The sequence number and request type are intact, so the Bandwidth
+                // Measure Results reply this PDU asks for is fully determined, and
+                // rejecting it would drop a measurement a server is blocking on rather
+                // than correct anything.
                 ensure_size!(in: src, size: usize::from(payload_length));
                 let payload = src.read_slice(usize::from(payload_length)).to_vec();
                 Ok(Self::BandwidthMeasureStop {

--- a/crates/ironrdp-testsuite-core/tests/pdu/autodetect.rs
+++ b/crates/ironrdp-testsuite-core/tests/pdu/autodetect.rs
@@ -33,11 +33,12 @@ fn connect_time_stop_without_a_payload_is_refused() {
     }
 }
 
-/// The decoder enforces the same rule, so the two sides agree on what the wire
-/// permits. Accepting a zero length here would mean accepting what we refuse to
-/// emit.
+/// The decoder does not enforce the same rule, and that asymmetry is the point: a
+/// zero length is refused on the way out and accepted on the way in. The sequence
+/// number and request type survive intact, so the Bandwidth Measure Results reply
+/// is fully determined and there is nothing a rejection would protect.
 #[test]
-fn connect_time_stop_with_a_zero_payload_length_is_rejected() {
+fn connect_time_stop_with_a_zero_payload_length_is_accepted() {
     // A well-formed connect-time stop, then its payloadLength forced to zero.
     let valid = AutoDetectRequest::BandwidthMeasureStop {
         sequence_number: 7,
@@ -52,7 +53,37 @@ fn connect_time_stop_with_a_zero_payload_length_is_rejected() {
     wire[7] = 0;
     wire.truncate(8);
 
-    assert!(decode::<AutoDetectRequest>(&wire).is_err());
+    let decoded = decode::<AutoDetectRequest>(&wire).expect("a zero payload length must still decode");
+
+    let AutoDetectRequest::BandwidthMeasureStop {
+        sequence_number,
+        request_type,
+        payload,
+    } = decoded
+    else {
+        panic!("expected a BandwidthMeasureStop, got {decoded:?}");
+    };
+    assert_eq!(sequence_number, 7);
+    assert_eq!(request_type, BW_STOP_CONNECT_TIME);
+    assert_eq!(
+        payload,
+        Some(Vec::new()),
+        "the payload is present and empty, not absent: the wire carried a length field"
+    );
+}
+
+/// What the peer sent is answerable, but it is not something we will echo back:
+/// re-encoding the decoded value still fails, which is the asymmetry stated as a
+/// test rather than only as a comment.
+#[test]
+fn a_decoded_zero_length_stop_does_not_re_encode() {
+    let request = AutoDetectRequest::BandwidthMeasureStop {
+        sequence_number: 7,
+        request_type: BW_STOP_CONNECT_TIME,
+        payload: Some(Vec::new()),
+    };
+
+    assert!(encode_vec(&request).is_err());
 }
 
 #[test]


### PR DESCRIPTION
## What

A connect-time Bandwidth Measure Stop with `payloadLength` of zero now decodes, as a present-but-empty payload. `Encode` still refuses to emit one.

## Why

[MS-RDPBCGR] 2.2.14.1.4 says of `payloadLength`: "It MUST be present (and have a value greater than zero) if the value of the **requestType** field is set to 0x002B." #1491 read that as a rule for both directions and made encode and decode refuse a zero. The encode half is right. The decode half is not.

The two directions answer different questions. Encoding asks what we are permitted to put on the wire, and a zero length has no conforming encoding, so refusing is correct. Decoding asks whether we can act on what a peer already sent. Here we can: `sequenceNumber` and `requestType` arrive intact, and those fully determine the Bandwidth Measure Results reply the PDU is asking for. The payload is random measurement filler per the same section, and its length is the only thing the reply reports about it.

Rejecting therefore discards a PDU we could have answered without gaining any protection. FreeRDP-based servers, including gnome-remote-desktop, block in `AWAIT_BW_RESULT` until the results arrive, so a server that sends a zero length stalls the whole connection rather than getting a diagnostic.

The fix #1491 was actually titled for, keying the optional fields off `requestType` instead of the `Option`, is untouched. Only the added zero-length rejection moves, and only on the receive side.

## Tests

`connect_time_stop_with_a_zero_payload_length_is_rejected` becomes `..._is_accepted` and now asserts the decoded value: `payload: Some(vec![])`, present and empty rather than absent, since the wire carried a length field.

Added `a_decoded_zero_length_stop_does_not_re_encode`, so the asymmetry is stated as a test rather than only as a comment.

`connect_time_stop_without_a_payload_is_refused` is unchanged and still covers the encode side.

## Note

This does not break the `pdu_round_trip` oracle in #1492: a failing `encode` after a successful `decode` is already tolerated there, and the re-decode assertion only fires on a successful encode.

## Verification

`cargo xtask check fmt/lints/tests/typos/locks` all pass. `cargo semver-checks` reports no update required for `ironrdp-pdu`.

## Unblocks #1465

#1465 carries a regression test for a zero-`payloadLength` Stop, which cannot pass until this lands: #1491 made `AutoDetectRequest`'s decoder reject `payloadLength = 0`, so such a PDU is refused before it reaches the connector. Its `connect_time_bandwidth_answers_a_stop_carrying_an_empty_payload` is red today and that red is this dependency, not a defect there.

Verified against current `master`: #1465 alone fails that one case out of 1032; #1465 with this applied passes all of them. Merging this first turns #1465 green with no change on its side.

## Rebased

Rebased onto `master` on 2026-08-02 so the checks run against the current tree rather than the state before that day's merges. No conflicts, no content change.
