### PR TITLE
fix(rdpeusb): accept UsbDevice == 0 in AddDevice

### DIFF
--- a/crates/ironrdp-rdpeusb/src/pdu/sink.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/sink.rs
@@ -101,7 +101,14 @@ impl AddDevice {
 
         ensure_size!(in: src, size: InterfaceId::FIXED_PART_SIZE);
         let usb_device = match src.read_u32() {
-            0x0..=0x3 => {
+            // `1..=3` are the RDPEUSB default Device Sink / Channel Notification
+            // interface IDs; a device announced with one collides with this crate's
+            // fixed dispatch paths (later completion PDUs would decode as the wrong
+            // message type), so keep them rejected. `0` is the deliberate exception:
+            // a real Windows client (mstsc) assigns `UsbDevice == 0` to a redirected
+            // device, addressed by its own per-device DVC, and rejecting it made every
+            // mstsc ADD_DEVICE fail to parse.
+            0x1..=0x3 => {
                 return Err(invalid_field_err!("UsbDevice", "conflict with default interfaces"));
             }
             value => InterfaceId::try_from(value)?,

--- a/crates/ironrdp-testsuite-core/tests/rdpeusb/device.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeusb/device.rs
@@ -1,8 +1,9 @@
-use ironrdp_core::encode_vec;
+use ironrdp_core::{DecodeResult, decode, encode_vec};
 use ironrdp_rdpeusb::io::device::{
     DeviceInfo, UsbBcdVersion, UsbClassCodes, UsbConfigInfo, UsbConnectionSpeed, UsbDeviceDescriptorInfo,
     UsbDeviceLocation, UsbInterfaceInfo, add_device_from_info,
 };
+use ironrdp_rdpeusb::pdu::UrbdrcClientDevicePdu;
 use ironrdp_rdpeusb::pdu::header::InterfaceId;
 use rstest::rstest;
 
@@ -105,4 +106,37 @@ fn add_device_from_protocol_agnostic_device_info(#[case] info: DeviceInfo) {
 
     assert_eq!(add_device.usb_device, udev_iface);
     encode_vec(&add_device).expect("ADD_DEVICE should encode");
+}
+
+// A real Windows client (mstsc) assigns `UsbDevice == 0` to a redirected device.
+// `InterfaceId` already permits it (0 <= 0x3FFF_FFFF), so ADD_DEVICE must
+// round-trip with that id rather than rejecting it as a "default interface".
+#[test]
+fn add_device_accepts_usb_device_zero() {
+    let udev_iface = InterfaceId::try_from(0).expect("interface id 0 is valid");
+    let add_device = add_device_from_info(udev_iface, &simple_device_info()).expect("ADD_DEVICE should be generated");
+    assert_eq!(add_device.usb_device, udev_iface);
+
+    let encoded = encode_vec(&add_device).expect("ADD_DEVICE should encode");
+    let decoded = decode(&encoded).expect("ADD_DEVICE with UsbDevice == 0 should decode");
+
+    let UrbdrcClientDevicePdu::AddDev(decoded) = decoded else {
+        panic!("expected an AddDev PDU");
+    };
+    assert_eq!(decoded.usb_device, udev_iface);
+}
+
+// `1..=3` are the RDPEUSB default Device Sink / Channel Notification interface
+// IDs; only `0` is the mstsc compatibility exception, so those must stay rejected.
+#[rstest]
+#[case(1)]
+#[case(2)]
+#[case(3)]
+fn add_device_rejects_reserved_default_interface(#[case] reserved: u32) {
+    let iface = InterfaceId::try_from(reserved).expect("interface id is representable");
+    let add_device = add_device_from_info(iface, &simple_device_info()).expect("ADD_DEVICE should be generated");
+    let encoded = encode_vec(&add_device).expect("ADD_DEVICE should encode");
+
+    let decoded: DecodeResult<UrbdrcClientDevicePdu> = decode(&encoded);
+    assert!(decoded.is_err(), "UsbDevice == {reserved} must be rejected");
 }


### PR DESCRIPTION
## Problem

A real Windows client (mstsc) assigns `UsbDevice == 0` to a redirected device. Since #1321, `AddDevice::decode` rejects the `0x0..=0x3` range as a *"conflict with default interfaces"*, so **every mstsc `ADD_DEVICE` fails to parse and no device is ever presented**. FreeRDP happens to use an id `>= 0x4`, which is why this went unnoticed.

## Fix

Drop the special-case reject and let `InterfaceId::try_from` validate the field. This is both a correctness fix and a simplification:

- `UsbDevice` is a plain interface ID **scoped to the device's own per-device DVC**, so id 0 is unambiguous there and does not clash with the control-channel default interface IDs (`CAPABILITIES` / `DEVICE_SINK` / …).
- `InterfaceId::try_from` **already enforces the valid range** (`value <= 0x3FFF_FFFF`, which includes 0) and rejects the high/mask range — so the `0x0..=0x3` arm was redundant on top of being wrong.

FreeRDP (`>= 0x4`) and the invalid mask range are unchanged.

## Verification

Verified downstream (macrdp) against **real mstsc**: a redirected camera / HID device enumerates only once `UsbDevice == 0` is accepted. Added a round-trip test (`add_device_accepts_usb_device_zero`) that encodes + decodes an `ADD_DEVICE` carrying `UsbDevice == 0`.

Not a breaking change — the decoder simply accepts a value it previously rejected.
