### PR TITLE
fix(rdpsnd): isolate malformed encrypted waves

### DIFF
--- a/crates/ironrdp-rdpsnd/src/client.rs
+++ b/crates/ironrdp-rdpsnd/src/client.rs
@@ -164,11 +164,7 @@ impl SvcProcessor for Rdpsnd {
         let pdu = match pdu::ServerAudioOutputPdu::decode(&mut ReadCursor::new(payload)) {
             Ok(pdu) => pdu,
             Err(error) => {
-                // Audio is optional. A malformed server audio PDU must not tear down the primary
-                // desktop session; stop this channel and retain the client in a safe no-audio state.
-                error!(?error, "Disabling RDPSND after an invalid server audio PDU");
-                self.handler.close();
-                self.state = RdpsndState::Stop;
+                error!(?error, "Ignoring malformed RDPSND PDU");
                 return Ok(vec![]);
             }
         };

--- a/crates/ironrdp-rdpsnd/src/client.rs
+++ b/crates/ironrdp-rdpsnd/src/client.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 
 use ironrdp_core::{Decode as _, EncodeResult, ReadCursor, cast_length, impl_as_any};
 use ironrdp_pdu::gcc::ChannelName;
-use ironrdp_pdu::{PduResult, decode_err, encode_err, pdu_other_err};
+use ironrdp_pdu::{PduResult, encode_err, pdu_other_err};
 use ironrdp_svc::{CompressionCondition, SvcClientProcessor, SvcMessage, SvcProcessor};
 use tracing::{debug, error};
 
@@ -161,7 +161,17 @@ impl SvcProcessor for Rdpsnd {
     }
 
     fn process(&mut self, payload: &[u8]) -> PduResult<Vec<SvcMessage>> {
-        let pdu = pdu::ServerAudioOutputPdu::decode(&mut ReadCursor::new(payload)).map_err(|e| decode_err!(e))?;
+        let pdu = match pdu::ServerAudioOutputPdu::decode(&mut ReadCursor::new(payload)) {
+            Ok(pdu) => pdu,
+            Err(error) => {
+                // Audio is optional. A malformed server audio PDU must not tear down the primary
+                // desktop session; stop this channel and retain the client in a safe no-audio state.
+                error!(?error, "Disabling RDPSND after an invalid server audio PDU");
+                self.handler.close();
+                self.state = RdpsndState::Stop;
+                return Ok(vec![]);
+            }
+        };
 
         debug!(?pdu, ?self.state);
         let msg = match self.state {

--- a/crates/ironrdp-testsuite-core/tests/rdpsnd/client.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpsnd/client.rs
@@ -129,6 +129,28 @@ fn assert_in_stop_state(client: &mut Rdpsnd) {
     assert!(responses.is_empty(), "Stop state should produce no responses");
 }
 
+#[test]
+fn malformed_encrypted_wave_disables_only_the_audio_channel() {
+    let mut client = client_in_start();
+
+    // SNDWAVECRYPT carries its eight-byte fixed part but omits the mandatory v5 signature.
+    let malformed_wave_encrypt = [
+        0x09, 0x00, 0x08, 0x00, // SNDWAVECRYPT, body size 8
+        0x00, 0x00, // wTimeStamp
+        0x00, 0x00, // wFormatNo
+        0x00, // cBlockNo
+        0x00, 0x00, 0x00, // bPad
+    ];
+
+    assert!(
+        client
+            .process(&malformed_wave_encrypt)
+            .expect("a malformed optional audio PDU must not fail the session")
+            .is_empty()
+    );
+    assert_in_stop_state(&mut client);
+}
+
 fn decode_single_response(responses: &[ironrdp_svc::SvcMessage]) -> pdu::ClientAudioOutputPdu {
     assert_eq!(responses.len(), 1);
     let encoded = responses[0].encode_unframed_pdu().unwrap();

--- a/crates/ironrdp-testsuite-core/tests/rdpsnd/client.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpsnd/client.rs
@@ -130,8 +130,8 @@ fn assert_in_stop_state(client: &mut Rdpsnd) {
 }
 
 #[test]
-fn malformed_encrypted_wave_disables_only_the_audio_channel() {
-    let mut client = client_in_start();
+fn malformed_encrypted_wave_is_ignored() {
+    let mut client = client_in_ready(pdu::Version::V8);
 
     // SNDWAVECRYPT carries its eight-byte fixed part but omits the mandatory v5 signature.
     let malformed_wave_encrypt = [
@@ -145,10 +145,12 @@ fn malformed_encrypted_wave_disables_only_the_audio_channel() {
     assert!(
         client
             .process(&malformed_wave_encrypt)
-            .expect("a malformed optional audio PDU must not fail the session")
+            .expect("a malformed RDPSND PDU must be ignored")
             .is_empty()
     );
-    assert_in_stop_state(&mut client);
+
+    let confirm = decode_single_response(&client.process(&encoded_wave2(1)).unwrap());
+    assert!(matches!(confirm, pdu::ClientAudioOutputPdu::WaveConfirm(_)));
 }
 
 fn decode_single_response(responses: &[ironrdp_svc::SvcMessage]) -> pdu::ClientAudioOutputPdu {


### PR DESCRIPTION
## Summary

- Treat malformed RDPSND server-audio PDUs as recoverable channel input and ignore them without failing the desktop session.
- Preserve the RDPSND state after a decode failure so valid subsequent audio continues normally.
- Add a regression test for an encrypted wave missing its required v5 signature.

## Testing

- `cargo test -p ironrdp-testsuite-core --test integration_tests_core -- rdpsnd::client`
- `cargo fmt --all -- --check`