### PR TITLE
fix(pdu): harden framing and empty output handling

### DIFF
--- a/crates/ironrdp-pdu/src/lib.rs
+++ b/crates/ironrdp-pdu/src/lib.rs
@@ -146,14 +146,21 @@ pub fn find_size(bytes: &[u8]) -> DecodeResult<Option<PduInfo>> {
             ensure_enough!(bytes, 2);
             let a = bytes[1];
 
-            let fast_path_length = if a & 0x80 != 0 {
+            let (fast_path_length, header_length) = if a & 0x80 != 0 {
                 ensure_enough!(bytes, 3);
                 let b = bytes[2];
 
-                ((u16::from(a) & !0x80) << 8) + u16::from(b)
+                (((u16::from(a) & !0x80) << 8) + u16::from(b), 3)
             } else {
-                u16::from(a)
+                (u16::from(a), 2)
             };
+
+            if usize::from(fast_path_length) < header_length {
+                return Err(invalid_field_err!(
+                    "fastPathLength",
+                    "length is smaller than the Fast-Path header"
+                ));
+            }
 
             Ok(Some(PduInfo {
                 action,
@@ -169,6 +176,18 @@ pub trait PduHint: Send + Sync + fmt::Debug + 'static {
     /// Returns `Some((hint_matching, size))` if the size is known.
     /// Returns `None` if the size cannot be determined yet.
     fn find_size(&self, bytes: &[u8]) -> DecodeResult<Option<(bool, usize)>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_size_rejects_undersized_frames() {
+        assert!(find_size(&[0x00, 0x01]).is_err());
+        assert!(find_size(&[0x00, 0x80, 0x02]).is_err());
+        assert!(find_size(&[0x03, 0x00, 0x00, 0x06]).is_err());
+    }
 }
 
 // Matches both X224 and FastPath pdus

--- a/crates/ironrdp-pdu/src/rdp/headers.rs
+++ b/crates/ironrdp-pdu/src/rdp/headers.rs
@@ -290,16 +290,22 @@ impl<'de> Decode<'de> for ShareControlHeader {
         };
 
         if pdu_type == ShareControlPduType::DataPdu {
-            // Some windows version have an issue where
-            // there is some padding not part of the inner unit.
-            // Consume that data
             let header_length = header.size();
 
-            if header_length != total_length {
+            let is_empty_output_pdu = matches!(
+                &header.share_control_pdu,
+                ShareControlPdu::Data(ShareDataHeader {
+                    share_data_pdu: ShareDataPdu::Update(data) | ShareDataPdu::Pointer(data),
+                    ..
+                }) if data.is_empty()
+            );
+
+            if header_length != total_length && !(total_length == 0 && is_empty_output_pdu) {
                 if total_length < header_length {
                     return Err(not_enough_bytes_err!(total_length, header_length));
                 }
 
+                // Some Windows versions append padding that is not part of the inner unit.
                 let padding = total_length - header_length;
                 ensure_size!(in: src, size: padding);
                 read_padding!(src, padding);
@@ -811,5 +817,73 @@ impl Encode for ServerDeactivateAll {
 
     fn size(&self) -> usize {
         Self::FIXED_PART_SIZE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ironrdp_core::decode;
+
+    use super::{ShareControlHeader, ShareControlPdu, ShareDataHeader, ShareDataPdu};
+
+    fn zero_length_empty_data_pdu(pdu_type: u8) -> [u8; 18] {
+        [
+            0x00, 0x00, // totalLength
+            0x17, 0x00, // pduType (Data PDU) + protocolVersion
+            0xE9, 0x03, // pduSource
+            0xDD, 0xCC, 0xBB, 0xAA, // shareId
+            0x00, // pad1
+            0x04, // streamId (Medium)
+            0x00, 0x00,     // uncompressedLength
+            pdu_type, // pduType2
+            0x00,     // compressedType
+            0x00, 0x00, // compressedLength
+        ]
+    }
+
+    #[test]
+    fn decode_zero_length_empty_output_update() {
+        let encoded = zero_length_empty_data_pdu(0x02);
+
+        let decoded: ShareControlHeader = decode(&encoded).expect("empty output PDU is a no-op");
+
+        assert!(matches!(
+            decoded.share_control_pdu,
+            ShareControlPdu::Data(ShareDataHeader {
+                share_data_pdu: ShareDataPdu::Update(data),
+                ..
+            }) if data.is_empty()
+        ));
+    }
+
+    #[test]
+    fn decode_zero_length_empty_output_pointer() {
+        let encoded = zero_length_empty_data_pdu(0x1B);
+
+        let decoded: ShareControlHeader = decode(&encoded).expect("empty output PDU is a no-op");
+
+        assert!(matches!(
+            decoded.share_control_pdu,
+            ShareControlPdu::Data(ShareDataHeader {
+                share_data_pdu: ShareDataPdu::Pointer(data),
+                ..
+            }) if data.is_empty()
+        ));
+    }
+
+    #[test]
+    fn reject_zero_length_non_output_data_pdu() {
+        let encoded = zero_length_empty_data_pdu(0x25);
+
+        let error =
+            decode::<ShareControlHeader>(&encoded).expect_err("zero total length is only accepted for no-op output");
+
+        assert!(matches!(
+            error.kind(),
+            ironrdp_core::DecodeErrorKind::NotEnoughBytes {
+                received: 0,
+                expected: 18
+            }
+        ));
     }
 }

--- a/crates/ironrdp-pdu/src/tpkt.rs
+++ b/crates/ironrdp-pdu/src/tpkt.rs
@@ -1,5 +1,6 @@
 use ironrdp_core::{
-    ReadCursor, WriteCursor, ensure_fixed_part_size, read_padding, unsupported_version_err, write_padding,
+    ReadCursor, WriteCursor, ensure_fixed_part_size, invalid_field_err, read_padding, unsupported_version_err,
+    write_padding,
 };
 
 use crate::{DecodeResult, EncodeResult};
@@ -62,6 +63,13 @@ impl TpktHeader {
         read_padding!(src, 1);
 
         let packet_length = src.read_u16_be();
+
+        if usize::from(packet_length) < 7 {
+            return Err(invalid_field_err!(
+                "packetLength",
+                "length is smaller than the minimum TPKT size"
+            ));
+        }
 
         Ok(Self { packet_length })
     }


### PR DESCRIPTION
Reject Fast-Path and TPKT frames whose declared length is smaller than their header or minimum packet size. Also tolerate the zero-length `totalLength` variation used by empty Update and Pointer output PDUs, while continuing to reject zero-length non-output data PDUs.

Adds regression coverage for malformed frame lengths and empty output compatibility.