### PR TITLE
feat(svc): support runtime-defined static virtual channels

### DIFF
--- a/crates/ironrdp-acceptor/src/connection.rs
+++ b/crates/ironrdp-acceptor/src/connection.rs
@@ -1,3 +1,4 @@
+use core::any::TypeId;
 use core::mem;
 
 use ironrdp_connector::{
@@ -8,7 +9,7 @@ use ironrdp_core::{WriteBuf, decode};
 use ironrdp_pdu as pdu;
 use ironrdp_pdu::nego::SecurityProtocol;
 use ironrdp_pdu::x224::X224;
-use ironrdp_svc::{StaticChannelSet, SvcServerProcessor};
+use ironrdp_svc::{MAX_STATIC_CHANNELS, StaticChannelKey, StaticChannelSet, SvcServerProcessor};
 use pdu::rdp::capability_sets::CapabilitySet;
 use pdu::rdp::client_info::Credentials;
 use pdu::rdp::headers::ShareControlPdu;
@@ -230,7 +231,38 @@ impl Acceptor {
     where
         T: SvcServerProcessor + 'static,
     {
+        let channel_name = channel.channel_name();
+        let channel_key = StaticChannelKey::Typed(TypeId::of::<T>());
+        if self.static_channels.get_by_type::<T>().is_none() && self.static_channels.len() >= MAX_STATIC_CHANNELS {
+            warn!(max_channels = MAX_STATIC_CHANNELS, "Static channel limit reached");
+            return;
+        }
+        if let Some((existing_key, _)) = self.static_channels.get_by_channel_name_key(&channel_name)
+            && existing_key != channel_key
+        {
+            warn!(?channel_name, "Static channel name is already registered");
+            return;
+        }
         self.static_channels.insert(channel);
+    }
+
+    /// Attaches a runtime-defined static virtual channel.
+    ///
+    /// This permits multiple instances of the same processor type, each with its own negotiated
+    /// channel name. `false` means the static-channel limit was reached or the name is already
+    /// registered.
+    pub fn attach_dynamic_static_channel<T>(&mut self, channel: T) -> bool
+    where
+        T: SvcServerProcessor + 'static,
+    {
+        let channel_name = channel.channel_name();
+        if self.static_channels.len() >= MAX_STATIC_CHANNELS
+            || self.static_channels.get_by_channel_name_key(&channel_name).is_some()
+        {
+            return false;
+        }
+
+        self.static_channels.insert_dynamic(channel).is_some()
     }
 
     pub fn reached_security_upgrade(&self) -> Option<SecurityProtocol> {
@@ -584,8 +616,8 @@ impl Sequence for Acceptor {
                             .into_iter()
                             .map(|c| {
                                 self.static_channels
-                                    .get_by_channel_name(&c.name)
-                                    .map(|(type_id, _)| (type_id, c))
+                                    .get_by_channel_name_key(&c.name)
+                                    .map(|(key, _)| (key, c))
                             })
                             .collect()
                     })
@@ -597,8 +629,8 @@ impl Sequence for Acceptor {
                     .enumerate()
                     .map(|(i, channel)| {
                         let channel_id = u16::try_from(i).expect("always in the range") + self.io_channel_id + 1;
-                        if let Some((type_id, c)) = channel {
-                            self.static_channels.attach_channel_id(type_id, channel_id);
+                        if let Some((key, c)) = channel {
+                            self.static_channels.attach_channel_id_by_key(key, channel_id);
                             (channel_id, Some(c))
                         } else {
                             (channel_id, None)

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -1,3 +1,4 @@
+use core::any::TypeId;
 use core::mem;
 use core::net::SocketAddr;
 use std::borrow::Cow;
@@ -6,8 +7,8 @@ use std::sync::Arc;
 use ironrdp_core::{Encode, WriteBuf, decode, encode_vec};
 use ironrdp_pdu::x224::X224;
 use ironrdp_pdu::{PduHint, gcc, mcs, nego, rdp};
-use ironrdp_svc::{StaticChannelSet, StaticVirtualChannel, SvcClientProcessor};
-use tracing::{debug, error, info};
+use ironrdp_svc::{MAX_STATIC_CHANNELS, StaticChannelKey, StaticChannelSet, StaticVirtualChannel, SvcClientProcessor};
+use tracing::{debug, error, info, warn};
 
 use crate::channel_connection::{ChannelConnectionSequence, ChannelConnectionState};
 use crate::connection_activation::{
@@ -263,7 +264,7 @@ impl ClientConnector {
     where
         T: SvcClientProcessor + 'static,
     {
-        self.static_channels.insert(channel);
+        self.attach_static_channel(channel);
         self
     }
 
@@ -271,7 +272,38 @@ impl ClientConnector {
     where
         T: SvcClientProcessor + 'static,
     {
+        let channel_name = channel.channel_name();
+        let channel_key = StaticChannelKey::Typed(TypeId::of::<T>());
+        if self.static_channels.get_by_type::<T>().is_none() && self.static_channels.len() >= MAX_STATIC_CHANNELS {
+            warn!(max_channels = MAX_STATIC_CHANNELS, "Static channel limit reached");
+            return;
+        }
+        if let Some((existing_key, _)) = self.static_channels.get_by_channel_name_key(&channel_name)
+            && existing_key != channel_key
+        {
+            warn!(?channel_name, "Static channel name is already registered");
+            return;
+        }
         self.static_channels.insert(channel);
+    }
+
+    /// Attaches a runtime-defined static virtual channel.
+    ///
+    /// This permits multiple instances of the same processor type, each with its own negotiated
+    /// channel name. `false` means the static-channel limit was reached or the name is already
+    /// registered.
+    pub fn attach_dynamic_static_channel<T>(&mut self, channel: T) -> bool
+    where
+        T: SvcClientProcessor + 'static,
+    {
+        let channel_name = channel.channel_name();
+        if self.static_channels.len() >= MAX_STATIC_CHANNELS
+            || self.static_channels.get_by_channel_name_key(&channel_name).is_some()
+        {
+            return false;
+        }
+
+        self.static_channels.insert_dynamic(channel).is_some()
     }
 
     pub fn get_static_channel_processor<T>(&mut self) -> Option<&T>
@@ -766,12 +798,12 @@ impl Sequence for ClientConnector {
 
                 let zipped: Vec<_> = self
                     .static_channels
-                    .type_ids()
+                    .keys()
                     .zip(static_channel_ids.iter().copied())
                     .collect();
 
                 zipped.into_iter().for_each(|(channel, channel_id)| {
-                    self.static_channels.attach_channel_id(channel, channel_id);
+                    self.static_channels.attach_channel_id_by_key(channel, channel_id);
                 });
 
                 let skip_channel_join = server_gcc_blocks

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -1440,7 +1440,7 @@ impl RdpServer {
 
         self.static_channels = result.static_channels;
         if !result.reactivation {
-            for (_type_id, channel, channel_id) in self.static_channels.iter_mut() {
+            for (_channel_key, channel, channel_id) in self.static_channels.iter_by_key_mut() {
                 debug!(?channel, ?channel_id, "Start");
                 let Some(channel_id) = channel_id else {
                     continue;

--- a/crates/ironrdp-session/src/active_stage.rs
+++ b/crates/ironrdp-session/src/active_stage.rs
@@ -4,6 +4,7 @@ use ironrdp_core::{ReadCursor, WriteBuf};
 use ironrdp_displaycontrol::client::DisplayControlClient;
 use ironrdp_dvc::{DrdynvcClient, DvcProcessor, DynamicVirtualChannel};
 use ironrdp_graphics::pointer::DecodedPointer;
+use ironrdp_pdu::gcc::ChannelName;
 use ironrdp_pdu::geometry::InclusiveRectangle;
 use ironrdp_pdu::input::fast_path::{FastPathInput, FastPathInputEvent};
 use ironrdp_pdu::rdp::autodetect::AutoDetectRequest;
@@ -285,6 +286,15 @@ impl ActiveStage {
         messages: SvcProcessorMessages<C>,
     ) -> SessionResult<Vec<u8>> {
         self.x224_processor.process_svc_processor_messages(messages)
+    }
+
+    /// Completes an SVC request for a runtime-defined channel name.
+    pub fn process_svc_messages_by_name(
+        &self,
+        channel_name: &ChannelName,
+        messages: Vec<SvcMessage>,
+    ) -> SessionResult<Vec<u8>> {
+        self.x224_processor.process_svc_messages_by_name(channel_name, messages)
     }
 
     /// Fully encodes a resize request for sending over the Display Control Virtual Channel.

--- a/crates/ironrdp-session/src/x224/mod.rs
+++ b/crates/ironrdp-session/src/x224/mod.rs
@@ -1,5 +1,6 @@
 use ironrdp_core::{WriteBuf, decode};
 use ironrdp_dvc::{DrdynvcClient, DvcProcessor, DynamicVirtualChannel};
+use ironrdp_pdu::gcc::ChannelName;
 use ironrdp_pdu::mcs::{DisconnectProviderUltimatum, DisconnectReason, McsMessage, SendDataIndicationCtx};
 use ironrdp_pdu::rdp::autodetect::{AutoDetectReqPdu, AutoDetectRequest, AutoDetectResponse, AutoDetectRspPdu};
 use ironrdp_pdu::rdp::headers::ShareDataPdu;
@@ -112,6 +113,20 @@ impl Processor {
             .ok_or_else(|| reason_err!("SVC", "channel not found"))?;
 
         process_svc_messages(messages.into(), channel_id, self.user_channel_id)
+    }
+
+    /// Completes an SVC request for a runtime-defined channel name.
+    pub fn process_svc_messages_by_name(
+        &self,
+        channel_name: &ChannelName,
+        messages: Vec<SvcMessage>,
+    ) -> SessionResult<Vec<u8>> {
+        let channel_id = self
+            .static_channels
+            .get_channel_id_by_channel_name(channel_name)
+            .ok_or_else(|| reason_err!("SVC", "channel not found"))?;
+
+        process_svc_messages(messages, channel_id, self.user_channel_id)
     }
 
     pub fn get_dvc<T: DvcProcessor + 'static>(&self) -> Option<&DynamicVirtualChannel> {

--- a/crates/ironrdp-svc/src/lib.rs
+++ b/crates/ironrdp-svc/src/lib.rs
@@ -434,6 +434,7 @@ impl ChunkProcessor {
         let mut chunks = Vec::new();
 
         let total_len = encoded_pdu.filled_len();
+        let is_chunked = total_len > max_chunk_len;
         let mut chunk_start_index: usize = 0;
         let mut chunk_end_index = core::cmp::min(total_len, max_chunk_len);
         loop {
@@ -455,6 +456,9 @@ impl ChunkProcessor {
                 }
                 if last {
                     flags |= ChannelFlags::LAST;
+                }
+                if is_chunked {
+                    flags |= ChannelFlags::SHOW_PROTOCOL;
                 }
 
                 flags |= message.flags;

--- a/crates/ironrdp-svc/src/lib.rs
+++ b/crates/ironrdp-svc/src/lib.rs
@@ -37,6 +37,9 @@ pub use ironrdp_core::impl_as_any;
 /// The integer type representing a static virtual channel ID.
 pub type StaticChannelId = u16;
 
+/// The maximum number of optional static virtual channels negotiated in one RDP session.
+pub const MAX_STATIC_CHANNELS: usize = 31;
+
 /// SVC data to be sent to the server. See [`SvcMessage`] for more information.
 /// Usually returned by the channel-specific methods.
 pub struct SvcProcessorMessages<P: SvcProcessor> {
@@ -270,6 +273,18 @@ pub trait SvcProcessor: AsAny + fmt::Debug + Send {
         CompressionCondition::Never
     }
 
+    /// Defines the channel options sent in the GCC Client Network Data block.
+    ///
+    /// The default preserves the legacy compression-only configuration. Processors that need
+    /// additional static-channel options can override this method.
+    fn channel_options(&self) -> ChannelOptions {
+        match self.compression_condition() {
+            CompressionCondition::Never => ChannelOptions::empty(),
+            CompressionCondition::WhenRdpDataIsCompressed => ChannelOptions::COMPRESS_RDP,
+            CompressionCondition::Always => ChannelOptions::COMPRESS,
+        }
+    }
+
     /// Start a channel, after the connection is established and the channel is joined.
     ///
     /// Returns a list of PDUs to be sent back.
@@ -300,12 +315,15 @@ struct ChunkProcessor {
     /// Buffer for de-chunkification of clipboard PDUs. Everything bigger than ~1600 bytes is
     /// usually chunked when transferred over svc.
     chunked_pdu: Vec<u8>,
+    /// Declared total length of the current chunk sequence.
+    expected_length: Option<usize>,
 }
 
 impl ChunkProcessor {
     fn new() -> Self {
         Self {
             chunked_pdu: Vec::new(),
+            expected_length: None,
         }
     }
 
@@ -327,26 +345,78 @@ impl ChunkProcessor {
     /// it returns `Ok(Some(payload))`.
     fn dechunkify(&mut self, payload: &[u8]) -> DecodeResult<Option<Vec<u8>>> {
         let mut cursor = ReadCursor::new(payload);
-        let last = Self::process_header(&mut cursor)?;
+        let header: ironrdp_pdu::rdp::vc::ChannelPduHeader = decode_cursor(&mut cursor)?;
+        let chunk = cursor.remaining();
+        let expected_length = usize::try_from(header.length)
+            .map_err(|_| ironrdp_core::invalid_field_err!("length", "channel data length is too large"))?;
+        let first = header.flags.contains(ChannelControlFlags::FLAG_FIRST);
+        let last = header.flags.contains(ChannelControlFlags::FLAG_LAST);
 
-        // Extend the chunked_pdu buffer with the payload
-        self.chunked_pdu.extend_from_slice(cursor.remaining());
+        if !first && !last && self.expected_length.is_none() {
+            if !header.flags.contains(ChannelControlFlags::PACKET_COMPRESSED) && chunk.len() != expected_length {
+                return Err(ironrdp_core::invalid_field_err!(
+                    "length",
+                    "unfragmented channel data does not match its declared length"
+                ));
+            }
 
-        // If this was an unchunked message, or the last in a series of chunks, return the payload
-        if last {
-            // Take the chunked_pdu buffer and replace it with an empty one
-            return Ok(Some(core::mem::take(&mut self.chunked_pdu)));
+            return Ok(Some(chunk.to_vec()));
         }
 
-        // This was an intermediate chunk, return None
-        Ok(None)
+        if first {
+            if self.expected_length.is_some() {
+                self.clear_sequence();
+                return Err(ironrdp_core::invalid_field_err!(
+                    "flags",
+                    "received an initial channel fragment before completing the previous sequence"
+                ));
+            }
+
+            self.expected_length = Some(expected_length);
+        } else if self.expected_length != Some(expected_length) {
+            self.clear_sequence();
+            return Err(ironrdp_core::invalid_field_err!(
+                "length",
+                "received a channel fragment without a matching initial fragment"
+            ));
+        }
+
+        self.chunked_pdu.extend_from_slice(chunk);
+
+        if !header.flags.contains(ChannelControlFlags::PACKET_COMPRESSED) && self.chunked_pdu.len() > expected_length {
+            self.clear_sequence();
+            return Err(ironrdp_core::invalid_field_err!(
+                "length",
+                "channel fragment sequence exceeds its declared length"
+            ));
+        }
+
+        if !last {
+            return Ok(None);
+        }
+
+        let Some(sequence_length) = self.expected_length else {
+            return Err(ironrdp_core::invalid_field_err!(
+                "flags",
+                "received a terminal channel fragment without an initial fragment"
+            ));
+        };
+
+        if !header.flags.contains(ChannelControlFlags::PACKET_COMPRESSED) && self.chunked_pdu.len() != sequence_length {
+            self.clear_sequence();
+            return Err(ironrdp_core::invalid_field_err!(
+                "length",
+                "terminal channel fragment does not match its declared length"
+            ));
+        }
+
+        self.expected_length = None;
+        Ok(Some(core::mem::take(&mut self.chunked_pdu)))
     }
 
-    /// Returns whether this was the last chunk based on the flags in the channel header.
-    fn process_header(payload: &mut ReadCursor<'_>) -> DecodeResult<bool> {
-        let channel_header: ironrdp_pdu::rdp::vc::ChannelPduHeader = decode_cursor(payload)?;
-
-        Ok(channel_header.flags.contains(ChannelControlFlags::FLAG_LAST))
+    fn clear_sequence(&mut self) {
+        self.chunked_pdu.clear();
+        self.expected_length = None;
     }
 
     /// Takes a single PDU and breaks it into chunks prefixed with a [`ChannelPduHeader`].
@@ -424,11 +494,7 @@ impl Default for ChunkProcessor {
 
 /// Builds the [`ChannelOptions`] bitfield to be used in the [`ChannelDef`] structure.
 pub fn make_channel_options(channel: &StaticVirtualChannel) -> ChannelOptions {
-    match channel.compression_condition() {
-        CompressionCondition::Never => ChannelOptions::empty(),
-        CompressionCondition::WhenRdpDataIsCompressed => ChannelOptions::COMPRESS_RDP,
-        CompressionCondition::Always => ChannelOptions::COMPRESS,
-    }
+    channel.channel_processor.channel_options()
 }
 
 /// Builds the [`ChannelDef`] structure containing information for this channel.
@@ -438,12 +504,22 @@ pub fn make_channel_definition(channel: &StaticVirtualChannel) -> ChannelDef {
     ChannelDef { name, options }
 }
 
-/// A set holding at most one [`StaticVirtualChannel`] for any given type
-/// implementing [`SvcProcessor`].
+/// A key identifying a static virtual channel in a [`StaticChannelSet`].
 ///
-/// To ensure uniqueness, each trait object is associated to the [`TypeId`] of it’s original type.
-/// Once joined, channels may have their ID attached using [`Self::attach_channel_id()`], effectively
-/// associating them together.
+/// Typed channels retain their historical [`TypeId`]-based identity. Runtime-defined channel
+/// instances receive a unique dynamic key, allowing multiple instances of one processor type.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum StaticChannelKey {
+    Typed(TypeId),
+    Dynamic(u64),
+}
+
+/// A set holding static virtual channels.
+///
+/// Typed processors are associated with their [`TypeId`], preserving the existing typed lookup
+/// API. Runtime-defined processor instances receive unique keys through [`Self::insert_dynamic`].
+/// Once joined, channels may have their ID attached using [`Self::attach_channel_id()`] or
+/// [`Self::attach_channel_id_by_key`], effectively associating them together.
 ///
 /// At this point, it’s possible to retrieve the trait object using either
 /// the type ID ([`Self::get_by_type_id()`]), the original type ([`Self::get_by_type()`]) or
@@ -453,9 +529,10 @@ pub fn make_channel_definition(channel: &StaticVirtualChannel) -> ChannelDef {
 /// since all [`SvcProcessor`]s are also implementing the [`AsAny`] trait.
 #[derive(Debug)]
 pub struct StaticChannelSet {
-    channels: BTreeMap<TypeId, StaticVirtualChannel>,
-    to_channel_id: BTreeMap<TypeId, StaticChannelId>,
-    to_type_id: BTreeMap<StaticChannelId, TypeId>,
+    channels: BTreeMap<StaticChannelKey, StaticVirtualChannel>,
+    to_channel_id: BTreeMap<StaticChannelKey, StaticChannelId>,
+    to_channel_key: BTreeMap<StaticChannelId, StaticChannelKey>,
+    next_dynamic_key: u64,
 }
 
 impl StaticChannelSet {
@@ -464,7 +541,8 @@ impl StaticChannelSet {
         Self {
             channels: BTreeMap::new(),
             to_channel_id: BTreeMap::new(),
-            to_type_id: BTreeMap::new(),
+            to_channel_key: BTreeMap::new(),
+            next_dynamic_key: 0,
         }
     }
 
@@ -472,17 +550,47 @@ impl StaticChannelSet {
     ///
     /// If a static virtual channel of this type already exists, it is returned.
     pub fn insert<T: SvcProcessor + 'static>(&mut self, val: T) -> Option<StaticVirtualChannel> {
-        self.channels.insert(TypeId::of::<T>(), StaticVirtualChannel::new(val))
+        self.channels.insert(
+            StaticChannelKey::Typed(TypeId::of::<T>()),
+            StaticVirtualChannel::new(val),
+        )
+    }
+
+    /// Inserts a runtime-defined static virtual channel.
+    ///
+    /// Unlike [`Self::insert`], this never replaces an existing processor of the same Rust type.
+    /// `None` indicates that the static-channel limit or dynamic key space was exhausted.
+    pub fn insert_dynamic<T: SvcProcessor + 'static>(&mut self, val: T) -> Option<StaticChannelKey> {
+        if self.len() >= MAX_STATIC_CHANNELS {
+            return None;
+        }
+
+        let next_dynamic_key = self.next_dynamic_key.checked_add(1)?;
+        let key = StaticChannelKey::Dynamic(self.next_dynamic_key);
+        self.next_dynamic_key = next_dynamic_key;
+        let replaced = self.channels.insert(key, StaticVirtualChannel::new(val));
+        debug_assert!(replaced.is_none());
+        Some(key)
     }
 
     /// Gets a reference to a [`StaticVirtualChannel`] by looking up its internal [`SvcProcessor`]'s [`TypeId`].
     pub fn get_by_type_id(&self, type_id: TypeId) -> Option<&StaticVirtualChannel> {
-        self.channels.get(&type_id)
+        self.channels.get(&StaticChannelKey::Typed(type_id))
     }
 
     /// Gets a mutable reference to a [`StaticVirtualChannel`] by looking up its internal [`SvcProcessor`]'s [`TypeId`].
     pub fn get_by_type_id_mut(&mut self, type_id: TypeId) -> Option<&mut StaticVirtualChannel> {
-        self.channels.get_mut(&type_id)
+        self.channels.get_mut(&StaticChannelKey::Typed(type_id))
+    }
+
+    /// Gets a reference to a static virtual channel by its key.
+    pub fn get_by_key(&self, key: StaticChannelKey) -> Option<&StaticVirtualChannel> {
+        self.channels.get(&key)
+    }
+
+    /// Gets a mutable reference to a static virtual channel by its key.
+    pub fn get_by_key_mut(&mut self, key: StaticChannelKey) -> Option<&mut StaticVirtualChannel> {
+        self.channels.get_mut(&key)
     }
 
     /// Gets a reference to a [`StaticVirtualChannel`] by looking up its internal [`SvcProcessor`]'s [`TypeId`].
@@ -500,25 +608,32 @@ impl StaticChannelSet {
         self.iter().find(|(_, x)| x.channel_processor.channel_name() == *name)
     }
 
+    /// Gets a reference to a static virtual channel by name, including runtime-defined channels.
+    pub fn get_by_channel_name_key(&self, name: &ChannelName) -> Option<(StaticChannelKey, &StaticVirtualChannel)> {
+        self.iter_by_key()
+            .find(|(_, x)| x.channel_processor.channel_name() == *name)
+    }
+
     /// Gets a reference to a [`StaticVirtualChannel`] by looking up its channel ID.
     pub fn get_by_channel_id(&self, channel_id: StaticChannelId) -> Option<&StaticVirtualChannel> {
-        self.get_type_id_by_channel_id(channel_id)
-            .and_then(|type_id| self.get_by_type_id(type_id))
+        self.get_key_by_channel_id(channel_id)
+            .and_then(|key| self.get_by_key(key))
     }
 
     /// Gets a mutable reference to a [`StaticVirtualChannel`] by looking up its channel ID.
     pub fn get_by_channel_id_mut(&mut self, channel_id: StaticChannelId) -> Option<&mut StaticVirtualChannel> {
-        self.get_type_id_by_channel_id(channel_id)
-            .and_then(|type_id| self.get_by_type_id_mut(type_id))
+        self.get_key_by_channel_id(channel_id)
+            .and_then(|key| self.get_by_key_mut(key))
     }
 
     /// Removes a [`StaticVirtualChannel`] from this [`StaticChannelSet`].
     ///
     /// If a static virtual channel of this type existed, it will be returned.
     pub fn remove_by_type_id(&mut self, type_id: TypeId) -> Option<StaticVirtualChannel> {
-        let svc = self.channels.remove(&type_id);
-        if let Some(channel_id) = self.to_channel_id.remove(&type_id) {
-            self.to_type_id.remove(&channel_id);
+        let key = StaticChannelKey::Typed(type_id);
+        let svc = self.channels.remove(&key);
+        if let Some(channel_id) = self.to_channel_id.remove(&key) {
+            self.to_channel_key.remove(&channel_id);
         }
         svc
     }
@@ -535,13 +650,34 @@ impl StaticChannelSet {
     ///
     /// If a channel ID was already attached, it will be returned.
     pub fn attach_channel_id(&mut self, type_id: TypeId, channel_id: StaticChannelId) -> Option<StaticChannelId> {
-        self.to_type_id.insert(channel_id, type_id);
-        self.to_channel_id.insert(type_id, channel_id)
+        self.attach_channel_id_by_key(StaticChannelKey::Typed(type_id), channel_id)
+    }
+
+    /// Attaches a channel ID to a static virtual channel identified by its key.
+    ///
+    /// If a channel ID was already attached, it will be returned.
+    pub fn attach_channel_id_by_key(
+        &mut self,
+        key: StaticChannelKey,
+        channel_id: StaticChannelId,
+    ) -> Option<StaticChannelId> {
+        let previous_channel_id = self.to_channel_id.insert(key, channel_id);
+        if let Some(previous_channel_id) = previous_channel_id.filter(|previous| *previous != channel_id) {
+            self.to_channel_key.remove(&previous_channel_id);
+        }
+        if let Some(previous_key) = self
+            .to_channel_key
+            .insert(channel_id, key)
+            .filter(|previous| *previous != key)
+        {
+            self.to_channel_id.remove(&previous_key);
+        }
+        previous_channel_id
     }
 
     /// Gets the attached channel ID for a given static virtual channel.
     pub fn get_channel_id_by_type_id(&self, type_id: TypeId) -> Option<StaticChannelId> {
-        self.to_channel_id.get(&type_id).copied()
+        self.to_channel_id.get(&StaticChannelKey::Typed(type_id)).copied()
     }
 
     /// Gets the attached channel ID for a given static virtual channel.
@@ -551,13 +687,28 @@ impl StaticChannelSet {
 
     /// Gets the [`TypeId`] of the static virtual channel associated to this channel ID.
     pub fn get_type_id_by_channel_id(&self, channel_id: StaticChannelId) -> Option<TypeId> {
-        self.to_type_id.get(&channel_id).copied()
+        match self.get_key_by_channel_id(channel_id)? {
+            StaticChannelKey::Typed(type_id) => Some(type_id),
+            StaticChannelKey::Dynamic(_) => None,
+        }
+    }
+
+    /// Gets the key of the static virtual channel associated to this channel ID.
+    pub fn get_key_by_channel_id(&self, channel_id: StaticChannelId) -> Option<StaticChannelKey> {
+        self.to_channel_key.get(&channel_id).copied()
+    }
+
+    /// Gets the attached channel ID for a channel name.
+    pub fn get_channel_id_by_channel_name(&self, name: &ChannelName) -> Option<StaticChannelId> {
+        self.get_by_channel_name_key(name)
+            .and_then(|(key, _)| self.to_channel_id.get(&key).copied())
     }
 
     /// Detaches the channel ID associated to a given static virtual channel.
     pub fn detach_channel_id(&mut self, type_id: TypeId) -> Option<StaticChannelId> {
-        if let Some(channel_id) = self.to_channel_id.remove(&type_id) {
-            self.to_type_id.remove(&channel_id);
+        let key = StaticChannelKey::Typed(type_id);
+        if let Some(channel_id) = self.to_channel_id.remove(&key) {
+            self.to_channel_key.remove(&channel_id);
             Some(channel_id)
         } else {
             None
@@ -566,15 +717,36 @@ impl StaticChannelSet {
 
     #[inline]
     pub fn iter(&self) -> impl Iterator<Item = (TypeId, &StaticVirtualChannel)> {
-        self.channels.iter().map(|(type_id, svc)| (*type_id, svc))
+        self.channels.iter().filter_map(|(key, svc)| match key {
+            StaticChannelKey::Typed(type_id) => Some((*type_id, svc)),
+            StaticChannelKey::Dynamic(_) => None,
+        })
+    }
+
+    /// Iterates over all static virtual channels, including runtime-defined channels.
+    #[inline]
+    pub fn iter_by_key(&self) -> impl Iterator<Item = (StaticChannelKey, &StaticVirtualChannel)> {
+        self.channels.iter().map(|(key, svc)| (*key, svc))
     }
 
     #[inline]
     pub fn iter_mut(&mut self) -> impl Iterator<Item = (TypeId, &mut StaticVirtualChannel, Option<StaticChannelId>)> {
         let to_channel_id = self.to_channel_id.clone();
+        self.channels.iter_mut().filter_map(move |(key, svc)| match key {
+            StaticChannelKey::Typed(type_id) => Some((*type_id, svc, to_channel_id.get(key).copied())),
+            StaticChannelKey::Dynamic(_) => None,
+        })
+    }
+
+    /// Mutably iterates over all static virtual channels, including runtime-defined channels.
+    #[inline]
+    pub fn iter_by_key_mut(
+        &mut self,
+    ) -> impl Iterator<Item = (StaticChannelKey, &mut StaticVirtualChannel, Option<StaticChannelId>)> {
+        let to_channel_id = self.to_channel_id.clone();
         self.channels
             .iter_mut()
-            .map(move |(type_id, svc)| (*type_id, svc, to_channel_id.get(type_id).copied()))
+            .map(move |(key, svc)| (*key, svc, to_channel_id.get(key).copied()))
     }
 
     #[inline]
@@ -582,8 +754,29 @@ impl StaticChannelSet {
         self.channels.values()
     }
 
+    /// Returns the number of registered static virtual channels.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.channels.len()
+    }
+
+    /// Returns true if no static virtual channels are registered.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.channels.is_empty()
+    }
+
     #[inline]
     pub fn type_ids(&self) -> impl Iterator<Item = TypeId> + '_ {
+        self.channels.keys().filter_map(|key| match key {
+            StaticChannelKey::Typed(type_id) => Some(*type_id),
+            StaticChannelKey::Dynamic(_) => None,
+        })
+    }
+
+    /// Iterates over all static channel keys in channel-negotiation order.
+    #[inline]
+    pub fn keys(&self) -> impl Iterator<Item = StaticChannelKey> + '_ {
         self.channels.keys().copied()
     }
 
@@ -596,7 +789,7 @@ impl StaticChannelSet {
     pub fn clear(&mut self) {
         self.channels.clear();
         self.to_channel_id.clear();
-        self.to_type_id.clear();
+        self.to_channel_key.clear();
     }
 }
 

--- a/crates/ironrdp-svc/src/lib.rs
+++ b/crates/ironrdp-svc/src/lib.rs
@@ -661,6 +661,10 @@ impl StaticChannelSet {
         key: StaticChannelKey,
         channel_id: StaticChannelId,
     ) -> Option<StaticChannelId> {
+        if !self.channels.contains_key(&key) {
+            return None;
+        }
+
         let previous_channel_id = self.to_channel_id.insert(key, channel_id);
         if let Some(previous_channel_id) = previous_channel_id.filter(|previous| *previous != channel_id) {
             self.to_channel_key.remove(&previous_channel_id);

--- a/crates/ironrdp-svc/src/lib.rs
+++ b/crates/ironrdp-svc/src/lib.rs
@@ -552,12 +552,15 @@ impl StaticChannelSet {
 
     /// Inserts a [`StaticVirtualChannel`] into this [`StaticChannelSet`].
     ///
-    /// If a static virtual channel of this type already exists, it is returned.
+    /// If a static virtual channel of this type already exists, it is returned. A new channel is
+    /// not inserted after reaching [`MAX_STATIC_CHANNELS`].
     pub fn insert<T: SvcProcessor + 'static>(&mut self, val: T) -> Option<StaticVirtualChannel> {
-        self.channels.insert(
-            StaticChannelKey::Typed(TypeId::of::<T>()),
-            StaticVirtualChannel::new(val),
-        )
+        let key = StaticChannelKey::Typed(TypeId::of::<T>());
+        if !self.channels.contains_key(&key) && self.len() >= MAX_STATIC_CHANNELS {
+            return None;
+        }
+
+        self.channels.insert(key, StaticVirtualChannel::new(val))
     }
 
     /// Inserts a runtime-defined static virtual channel.

--- a/crates/ironrdp-testsuite-core/tests/main.rs
+++ b/crates/ironrdp-testsuite-core/tests/main.rs
@@ -34,3 +34,4 @@ mod server;
 mod server_name;
 mod session;
 mod str_types;
+mod svc;

--- a/crates/ironrdp-testsuite-core/tests/svc.rs
+++ b/crates/ironrdp-testsuite-core/tests/svc.rs
@@ -5,8 +5,8 @@ use ironrdp_pdu::rdp::vc::{ChannelControlFlags, ChannelPduHeader};
 use ironrdp_pdu::x224::X224;
 use ironrdp_session::x224::Processor;
 use ironrdp_svc::{
-    MAX_STATIC_CHANNELS, StaticChannelSet, StaticVirtualChannel, SvcClientProcessor, SvcMessage, SvcProcessor,
-    SvcServerProcessor, make_channel_options,
+    MAX_STATIC_CHANNELS, StaticChannelKey, StaticChannelSet, StaticVirtualChannel, SvcClientProcessor, SvcMessage,
+    SvcProcessor, SvcServerProcessor, make_channel_options,
 };
 
 #[derive(Debug)]
@@ -83,6 +83,12 @@ fn runtime_channels_have_independent_keys_options_and_ids() {
     channels.attach_channel_id_by_key(second, 1006);
     assert_eq!(channels.get_channel_id_by_channel_name(&first_name), Some(1005));
     assert_eq!(channels.get_channel_id_by_channel_name(&second_name), Some(1006));
+
+    assert_eq!(
+        channels.attach_channel_id_by_key(StaticChannelKey::Dynamic(u64::MAX), 1005),
+        None
+    );
+    assert_eq!(channels.get_channel_id_by_channel_name(&first_name), Some(1005));
 
     channels.attach_channel_id_by_key(second, 1005);
     assert_eq!(channels.get_channel_id_by_channel_name(&first_name), None);

--- a/crates/ironrdp-testsuite-core/tests/svc.rs
+++ b/crates/ironrdp-testsuite-core/tests/svc.rs
@@ -43,6 +43,50 @@ impl SvcProcessor for RuntimeChannel {
 impl SvcClientProcessor for RuntimeChannel {}
 impl SvcServerProcessor for RuntimeChannel {}
 
+#[derive(Debug)]
+struct StartingRuntimeChannel;
+
+ironrdp_svc::impl_as_any!(StartingRuntimeChannel);
+
+impl SvcProcessor for StartingRuntimeChannel {
+    fn channel_name(&self) -> ChannelName {
+        ChannelName::from_utf8("start").expect("valid static channel name")
+    }
+
+    fn start(&mut self) -> ironrdp_pdu::PduResult<Vec<SvcMessage>> {
+        Ok(vec![SvcMessage::from(vec![1])])
+    }
+
+    fn process(&mut self, _payload: &[u8]) -> ironrdp_pdu::PduResult<Vec<SvcMessage>> {
+        Ok(Vec::new())
+    }
+}
+
+impl SvcServerProcessor for StartingRuntimeChannel {}
+
+#[derive(Debug)]
+struct TypedChannel<const ID: usize>;
+
+impl<const ID: usize> ironrdp_core::AsAny for TypedChannel<ID> {
+    fn as_any(&self) -> &dyn core::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn core::any::Any {
+        self
+    }
+}
+
+impl<const ID: usize> SvcProcessor for TypedChannel<ID> {
+    fn channel_name(&self) -> ChannelName {
+        ChannelName::from_utf8("typed").expect("valid static channel name")
+    }
+
+    fn process(&mut self, _payload: &[u8]) -> ironrdp_pdu::PduResult<Vec<SvcMessage>> {
+        Ok(Vec::new())
+    }
+}
+
 fn channel_chunk(data: &[u8], length: u32, flags: ChannelControlFlags) -> Vec<u8> {
     let mut chunk = encode_vec(&ChannelPduHeader { length, flags }).expect("channel header should encode");
     chunk.extend_from_slice(data);
@@ -113,6 +157,45 @@ fn runtime_channels_enforce_the_static_channel_limit() {
             .insert_dynamic(RuntimeChannel::new("overflow", ChannelOptions::empty()))
             .is_none()
     );
+}
+
+#[test]
+fn typed_channels_enforce_the_static_channel_limit() {
+    macro_rules! insert_typed_channels {
+        ($channels:expr; $($id:literal),+ $(,)?) => {
+            $(
+                assert!($channels.insert(TypedChannel::<$id>).is_none());
+            )+
+        };
+    }
+
+    let mut channels = StaticChannelSet::new();
+    insert_typed_channels!(
+        channels;
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+        25, 26, 27, 28, 29, 30
+    );
+
+    assert!(channels.insert(TypedChannel::<31>).is_none());
+    assert_eq!(channels.len(), MAX_STATIC_CHANNELS);
+    assert!(channels.get_by_type::<TypedChannel<31>>().is_none());
+}
+
+#[test]
+fn dynamic_channels_are_included_in_startup_iteration() {
+    let mut channels = StaticChannelSet::new();
+    let key = channels.insert_dynamic(StartingRuntimeChannel).expect("dynamic key");
+    channels.attach_channel_id_by_key(key, 1005);
+
+    let startup_message_count = channels
+        .iter_by_key_mut()
+        .map(|(_, channel, channel_id)| {
+            assert_eq!(channel_id, Some(1005));
+            channel.start().expect("channel should start").len()
+        })
+        .sum::<usize>();
+
+    assert_eq!(startup_message_count, 1);
 }
 
 #[test]

--- a/crates/ironrdp-testsuite-core/tests/svc.rs
+++ b/crates/ironrdp-testsuite-core/tests/svc.rs
@@ -5,8 +5,8 @@ use ironrdp_pdu::rdp::vc::{ChannelControlFlags, ChannelPduHeader};
 use ironrdp_pdu::x224::X224;
 use ironrdp_session::x224::Processor;
 use ironrdp_svc::{
-    MAX_STATIC_CHANNELS, StaticChannelKey, StaticChannelSet, StaticVirtualChannel, SvcClientProcessor, SvcMessage,
-    SvcProcessor, SvcServerProcessor, make_channel_options,
+    CHANNEL_CHUNK_LENGTH, MAX_STATIC_CHANNELS, StaticChannelKey, StaticChannelSet, StaticVirtualChannel,
+    SvcClientProcessor, SvcMessage, SvcProcessor, SvcServerProcessor, make_channel_options,
 };
 
 #[derive(Debug)]
@@ -157,6 +157,18 @@ fn static_channel_rejects_malformed_chunk_sequences() {
             ))
             .is_ok()
     );
+}
+
+#[test]
+fn static_channel_chunks_show_protocol_header() {
+    let chunks = StaticVirtualChannel::chunkify(vec![SvcMessage::from(vec![0; CHANNEL_CHUNK_LENGTH + 1])])
+        .expect("static channel message should chunk");
+
+    assert_eq!(chunks.len(), 2);
+    for chunk in chunks {
+        let header = decode::<ChannelPduHeader>(chunk.filled()).expect("channel header should decode");
+        assert!(header.flags.contains(ChannelControlFlags::FLAG_SHOW_PROTOCOL));
+    }
 }
 
 #[test]

--- a/crates/ironrdp-testsuite-core/tests/svc.rs
+++ b/crates/ironrdp-testsuite-core/tests/svc.rs
@@ -1,0 +1,174 @@
+use ironrdp_core::{decode, encode_vec};
+use ironrdp_pdu::gcc::{ChannelName, ChannelOptions};
+use ironrdp_pdu::mcs;
+use ironrdp_pdu::rdp::vc::{ChannelControlFlags, ChannelPduHeader};
+use ironrdp_pdu::x224::X224;
+use ironrdp_session::x224::Processor;
+use ironrdp_svc::{
+    MAX_STATIC_CHANNELS, StaticChannelSet, StaticVirtualChannel, SvcClientProcessor, SvcMessage, SvcProcessor,
+    SvcServerProcessor, make_channel_options,
+};
+
+#[derive(Debug)]
+struct RuntimeChannel {
+    name: ChannelName,
+    options: ChannelOptions,
+}
+
+impl RuntimeChannel {
+    fn new(name: &str, options: ChannelOptions) -> Self {
+        Self {
+            name: ChannelName::from_utf8(name).expect("valid static channel name"),
+            options,
+        }
+    }
+}
+
+ironrdp_svc::impl_as_any!(RuntimeChannel);
+
+impl SvcProcessor for RuntimeChannel {
+    fn channel_name(&self) -> ChannelName {
+        self.name.clone()
+    }
+
+    fn channel_options(&self) -> ChannelOptions {
+        self.options
+    }
+
+    fn process(&mut self, _payload: &[u8]) -> ironrdp_pdu::PduResult<Vec<SvcMessage>> {
+        Ok(Vec::new())
+    }
+}
+
+impl SvcClientProcessor for RuntimeChannel {}
+impl SvcServerProcessor for RuntimeChannel {}
+
+fn channel_chunk(data: &[u8], length: u32, flags: ChannelControlFlags) -> Vec<u8> {
+    let mut chunk = encode_vec(&ChannelPduHeader { length, flags }).expect("channel header should encode");
+    chunk.extend_from_slice(data);
+    chunk
+}
+
+#[test]
+fn runtime_channels_have_independent_keys_options_and_ids() {
+    let first_name = ChannelName::from_utf8("first").expect("valid static channel name");
+    let second_name = ChannelName::from_utf8("second").expect("valid static channel name");
+    let mut channels = StaticChannelSet::new();
+    let first = channels
+        .insert_dynamic(RuntimeChannel::new("first", ChannelOptions::COMPRESS))
+        .expect("dynamic key");
+    let second = channels
+        .insert_dynamic(RuntimeChannel::new("second", ChannelOptions::PRI_HIGH))
+        .expect("dynamic key");
+
+    assert_ne!(first, second);
+    assert_eq!(channels.len(), 2);
+    assert!(channels.get_by_key(first).is_some());
+    assert!(channels.get_by_key(second).is_some());
+    assert_eq!(
+        make_channel_options(channels.get_by_channel_name_key(&first_name).expect("first channel").1),
+        ChannelOptions::COMPRESS
+    );
+    assert_eq!(
+        make_channel_options(
+            channels
+                .get_by_channel_name_key(&second_name)
+                .expect("second channel")
+                .1
+        ),
+        ChannelOptions::PRI_HIGH
+    );
+
+    channels.attach_channel_id_by_key(first, 1005);
+    channels.attach_channel_id_by_key(second, 1006);
+    assert_eq!(channels.get_channel_id_by_channel_name(&first_name), Some(1005));
+    assert_eq!(channels.get_channel_id_by_channel_name(&second_name), Some(1006));
+
+    channels.attach_channel_id_by_key(second, 1005);
+    assert_eq!(channels.get_channel_id_by_channel_name(&first_name), None);
+    assert_eq!(channels.get_channel_id_by_channel_name(&second_name), Some(1005));
+    assert_eq!(channels.get_key_by_channel_id(1005), Some(second));
+}
+
+#[test]
+fn runtime_channels_enforce_the_static_channel_limit() {
+    let mut channels = StaticChannelSet::new();
+
+    for index in 0..MAX_STATIC_CHANNELS {
+        assert!(
+            channels
+                .insert_dynamic(RuntimeChannel::new(&format!("ch{index:02}"), ChannelOptions::empty()))
+                .is_some()
+        );
+    }
+
+    assert!(
+        channels
+            .insert_dynamic(RuntimeChannel::new("overflow", ChannelOptions::empty()))
+            .is_none()
+    );
+}
+
+#[test]
+fn static_channel_rejects_malformed_chunk_sequences() {
+    let mut channel = StaticVirtualChannel::new(RuntimeChannel::new("chunk", ChannelOptions::empty()));
+
+    assert!(
+        channel
+            .process(&channel_chunk(b"last", 4, ChannelControlFlags::FLAG_LAST))
+            .is_err()
+    );
+    assert!(
+        channel
+            .process(&channel_chunk(b"first", 10, ChannelControlFlags::FLAG_FIRST))
+            .is_ok()
+    );
+    assert!(
+        channel
+            .process(&channel_chunk(b"nested", 10, ChannelControlFlags::FLAG_FIRST))
+            .is_err()
+    );
+    assert!(
+        channel
+            .process(&channel_chunk(
+                b"wrong",
+                6,
+                ChannelControlFlags::FLAG_FIRST | ChannelControlFlags::FLAG_LAST
+            ))
+            .is_err()
+    );
+    assert!(
+        channel
+            .process(&channel_chunk(b"plain", 6, ChannelControlFlags::empty()))
+            .is_err()
+    );
+    assert!(
+        channel
+            .process(&channel_chunk(
+                b"complete",
+                8,
+                ChannelControlFlags::FLAG_FIRST | ChannelControlFlags::FLAG_LAST
+            ))
+            .is_ok()
+    );
+}
+
+#[test]
+fn session_encodes_messages_for_runtime_channel_name() {
+    let channel_name = ChannelName::from_utf8("runtime").expect("valid static channel name");
+    let mut channels = StaticChannelSet::new();
+    let key = channels
+        .insert_dynamic(RuntimeChannel::new("runtime", ChannelOptions::empty()))
+        .expect("dynamic key");
+    channels.attach_channel_id_by_key(key, 1005);
+
+    let processor = Processor::new(channels, 1002, 1003, None, 1);
+    let frame = processor
+        .process_svc_messages_by_name(&channel_name, vec![SvcMessage::from(vec![1, 2, 3])])
+        .expect("runtime channel should be encodable");
+    let request = decode::<X224<mcs::SendDataRequest<'_>>>(&frame)
+        .expect("encoded runtime channel frame should decode")
+        .0;
+
+    assert_eq!(request.channel_id, 1005);
+}


### PR DESCRIPTION
## Summary
- add keyed runtime-defined static-channel registration, lookup, and negotiated ID attachment
- enforce the static-channel limit and reject malformed SVC fragment sequences
- wire generic connector, acceptor, and session name-based dispatch support

## Testing
- `cargo test -p ironrdp-testsuite-core --test integration_tests_core svc::`
- `cargo clippy -p ironrdp-testsuite-core --test integration_tests_core -- -D warnings`