### PR TITLE
fix(session): share bulk decompression across output paths

### DIFF
--- a/crates/ironrdp-bulk/src/xcrush/mod.rs
+++ b/crates/ironrdp-bulk/src/xcrush/mod.rs
@@ -349,7 +349,18 @@ impl XCrushContext {
     ///
     ///
     /// Returns a reference to the decompressed data.
-    pub(crate) fn decompress<'a>(&'a mut self, src_data: &[u8], outer_flags: u32) -> Result<&'a [u8], BulkError> {
+    pub(crate) fn decompress<'a>(&'a mut self, src_data: &'a [u8], outer_flags: u32) -> Result<&'a [u8], BulkError> {
+        if outer_flags & flags::PACKET_FLUSHED != 0 {
+            self.history_buffer[..self.history_buffer_size].fill(0);
+            self.history_offset = 0;
+        }
+
+        // An uncompressed bulk packet has no XCRUSH L1/L2 header. It can still
+        // carry an outer flush flag, which must be applied before returning it.
+        if outer_flags & flags::PACKET_COMPRESSED == 0 {
+            return Ok(src_data);
+        }
+
         if src_data.len() < 2 {
             return Err(BulkError::InvalidCompressedData(
                 "XCRUSH: input too short for L1/L2 flags",
@@ -359,11 +370,6 @@ impl XCrushContext {
         let level1_compr_flags = u32::from(src_data[0]);
         let level2_compr_flags = u32::from(src_data[1]);
         let inner_data = &src_data[2..];
-
-        if outer_flags & flags::PACKET_FLUSHED != 0 {
-            self.history_buffer[..self.history_buffer_size].fill(0);
-            self.history_offset = 0;
-        }
 
         if level2_compr_flags & flags::PACKET_COMPRESSED == 0 {
             // No Level-2 (MPPC) compression — go straight to L1
@@ -1332,15 +1338,28 @@ mod tests {
         let mut packet = vec![0x06u8, 0x00u8];
         packet.extend_from_slice(b"raw data here");
 
-        let result = ctx.decompress(&packet, 0).unwrap();
+        let result = ctx.decompress(&packet, flags::PACKET_COMPRESSED).unwrap();
         assert_eq!(result, b"raw data here");
     }
 
     #[test]
     fn test_decompress_too_short_error() {
         let mut ctx = XCrushContext::new();
-        let result = ctx.decompress(&[0x00], 0);
+        let result = ctx.decompress(&[0x00], flags::PACKET_COMPRESSED);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_decompress_uncompressed_flushed_packet() {
+        let mut ctx = XCrushContext::new();
+        ctx.history_buffer[0] = 0xFF;
+        ctx.history_offset = 100;
+
+        let result = ctx.decompress(b"raw data", flags::PACKET_FLUSHED).unwrap();
+
+        assert_eq!(result, b"raw data");
+        assert_eq!(ctx.history_buffer[0], 0);
+        assert_eq!(ctx.history_offset, 0);
     }
 
     #[test]
@@ -1354,7 +1373,9 @@ mod tests {
         let mut packet = vec![0x06u8, 0x00u8];
         packet.extend_from_slice(b"test");
 
-        let result = ctx.decompress(&packet, flags::PACKET_FLUSHED).unwrap();
+        let result = ctx
+            .decompress(&packet, flags::PACKET_FLUSHED | flags::PACKET_COMPRESSED)
+            .unwrap();
         assert_eq!(result, b"test");
         // History should have been cleared
         assert_eq!(ctx.history_buffer[0], b't'); // first byte of "test"

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -755,6 +755,7 @@ async fn active_session(
         io_channel_id: connection_result.io_channel_id,
         message_channel_id: connection_result.message_channel_id,
         share_id: connection_result.share_id,
+        compression_type: connection_result.compression_type,
         enable_server_pointer: connection_result.enable_server_pointer,
         pointer_software_rendering: connection_result.pointer_software_rendering,
     }

--- a/crates/ironrdp-pdu/src/rdp/headers.rs
+++ b/crates/ironrdp-pdu/src/rdp/headers.rs
@@ -461,7 +461,14 @@ impl<'de> Decode<'de> for ShareDataHeader {
                 .ok_or_else(|| invalid_field_err!("compressionType", "Invalid compression type"))?;
         let _compressed_length = src.read_u16();
 
-        let share_data_pdu = ShareDataPdu::from_type(src, pdu_type)?;
+        let share_data_pdu = if compression_flags.is_empty() {
+            ShareDataPdu::from_type(src, pdu_type)?
+        } else {
+            ShareDataPdu::Compressed {
+                pdu_type,
+                data: src.read_remaining().to_vec(),
+            }
+        };
 
         Ok(Self {
             share_data_pdu,
@@ -500,6 +507,11 @@ pub enum ShareDataPdu {
     DrawGdiPusErrorPdu(Vec<u8>),
     ArcStatusPdu(Vec<u8>),
     StatusInfoPdu(Vec<u8>),
+    /// A compressed Share Data PDU body that must be decompressed before decoding.
+    Compressed {
+        pdu_type: ShareDataPduType,
+        data: Vec<u8>,
+    },
 }
 
 impl ShareDataPdu {
@@ -532,6 +544,7 @@ impl ShareDataPdu {
             ShareDataPdu::DrawGdiPusErrorPdu(_) => "Draw GDI PUS Error PDU",
             ShareDataPdu::ArcStatusPdu(_) => "Arc Status PDU",
             ShareDataPdu::StatusInfoPdu(_) => "Status Info PDU",
+            ShareDataPdu::Compressed { .. } => "Compressed Share Data PDU",
         }
     }
 
@@ -562,7 +575,14 @@ impl ShareDataPdu {
             ShareDataPdu::DrawGdiPusErrorPdu(_) => ShareDataPduType::DrawGdiPusErrorPdu,
             ShareDataPdu::ArcStatusPdu(_) => ShareDataPduType::ArcStatusPdu,
             ShareDataPdu::StatusInfoPdu(_) => ShareDataPduType::StatusInfoPdu,
+            ShareDataPdu::Compressed { pdu_type, .. } => *pdu_type,
         }
+    }
+
+    /// Decodes the body of a Share Data PDU after its `pduType2` has been read.
+    pub fn decode_with_type(data: &[u8], pdu_type: ShareDataPduType) -> DecodeResult<Self> {
+        let mut src = ReadCursor::new(data);
+        Self::from_type(&mut src, pdu_type)
     }
 
     fn from_type(src: &mut ReadCursor<'_>, share_type: ShareDataPduType) -> DecodeResult<Self> {
@@ -628,6 +648,7 @@ impl Encode for ShareDataPdu {
             ShareDataPdu::ShutdownRequest | ShareDataPdu::ShutdownDenied => Ok(()),
             ShareDataPdu::SuppressOutput(pdu) => pdu.encode(dst),
             ShareDataPdu::RefreshRectangle(pdu) => pdu.encode(dst),
+            ShareDataPdu::Compressed { .. } => Err(other_err!("Encoding compressed Share Data PDU is not implemented")),
             _ => Err(other_err!("Encoding not implemented")),
         }
     }
@@ -660,7 +681,8 @@ impl Encode for ShareDataPdu {
             | ShareDataPdu::DrawNineGridErrorPdu(buffer)
             | ShareDataPdu::DrawGdiPusErrorPdu(buffer)
             | ShareDataPdu::ArcStatusPdu(buffer)
-            | ShareDataPdu::StatusInfoPdu(buffer) => buffer.len(),
+            | ShareDataPdu::StatusInfoPdu(buffer)
+            | ShareDataPdu::Compressed { data: buffer, .. } => buffer.len(),
         }
     }
 }
@@ -836,7 +858,7 @@ mod tests {
 
     use super::{
         CompressionFlags, PADDING_FIELD_SIZE, PDU_TYPE_FIELD_SIZE, SHARE_CONTROL_HEADER_SIZE, STREAM_ID_FIELD_SIZE,
-        ShareControlHeader, ShareControlPdu, ShareDataHeader, ShareDataPdu, StreamPriority,
+        ShareControlHeader, ShareControlPdu, ShareDataHeader, ShareDataPdu, ShareDataPduType, StreamPriority,
         UNCOMPRESSED_LENGTH_FIELD_SIZE, decode_share_data,
     };
 
@@ -941,5 +963,12 @@ mod tests {
             share_data_ctx.compression_type,
             crate::rdp::client_info::CompressionType::K64
         );
+        assert!(matches!(
+            share_data_ctx.pdu,
+            ShareDataPdu::Compressed {
+                pdu_type: ShareDataPduType::ShutdownRequest,
+                ..
+            }
+        ));
     }
 }

--- a/crates/ironrdp-pdu/src/rdp/headers.rs
+++ b/crates/ironrdp-pdu/src/rdp/headers.rs
@@ -835,8 +835,9 @@ mod tests {
     use ironrdp_core::{decode, encode_vec};
 
     use super::{
-        CompressionFlags, ShareControlHeader, ShareControlPdu, ShareDataHeader, ShareDataPdu, StreamPriority,
-        decode_share_data,
+        CompressionFlags, PADDING_FIELD_SIZE, PDU_TYPE_FIELD_SIZE, SHARE_CONTROL_HEADER_SIZE, STREAM_ID_FIELD_SIZE,
+        ShareControlHeader, ShareControlPdu, ShareDataHeader, ShareDataPdu, StreamPriority,
+        UNCOMPRESSED_LENGTH_FIELD_SIZE, decode_share_data,
     };
 
     fn zero_length_empty_data_pdu(pdu_type: u8) -> [u8; 18] {
@@ -902,17 +903,26 @@ mod tests {
 
     #[test]
     fn share_data_context_retains_compression_metadata() {
-        let user_data = encode_vec(&ShareControlHeader {
+        let mut user_data = encode_vec(&ShareControlHeader {
             share_control_pdu: ShareControlPdu::Data(ShareDataHeader {
-                share_data_pdu: ShareDataPdu::Update(vec![0x10, 0x20]),
+                share_data_pdu: ShareDataPdu::ShutdownRequest,
                 stream_priority: StreamPriority::Medium,
-                compression_flags: CompressionFlags::COMPRESSED | CompressionFlags::FLUSHED,
+                compression_flags: CompressionFlags::empty(),
                 compression_type: crate::rdp::client_info::CompressionType::K64,
             }),
             pdu_source: 1002,
             share_id: 1,
         })
         .expect("encode Share Control PDU");
+        // ShareDataHeader does not encode compressed payloads. The decoder only
+        // needs the compression-control byte to verify metadata propagation.
+        const COMPRESSION_CONTROL_OFFSET: usize = SHARE_CONTROL_HEADER_SIZE
+            + PADDING_FIELD_SIZE
+            + STREAM_ID_FIELD_SIZE
+            + UNCOMPRESSED_LENGTH_FIELD_SIZE
+            + PDU_TYPE_FIELD_SIZE;
+        user_data[COMPRESSION_CONTROL_OFFSET] = (CompressionFlags::COMPRESSED | CompressionFlags::FLUSHED).bits()
+            | crate::rdp::client_info::CompressionType::K64.as_u8();
         let frame = encode_vec(&X224(McsMessage::SendDataIndication(SendDataIndication {
             initiator_id: 1002,
             channel_id: 1003,

--- a/crates/ironrdp-pdu/src/rdp/headers.rs
+++ b/crates/ironrdp-pdu/src/rdp/headers.rs
@@ -149,6 +149,8 @@ pub struct ShareDataCtx {
     pub channel_id: u16,
     pub share_id: u32,
     pub pdu_source: u16,
+    pub compression_flags: CompressionFlags,
+    pub compression_type: client_info::CompressionType,
     pub pdu: ShareDataPdu,
 }
 
@@ -168,6 +170,8 @@ pub fn decode_share_data(ctx: SendDataIndicationCtx<'_>) -> DecodeResult<ShareDa
         channel_id: ctx.channel_id,
         share_id: ctx.share_id,
         pdu_source: ctx.pdu_source,
+        compression_flags: share_data_header.compression_flags,
+        compression_type: share_data_header.compression_type,
         pdu: share_data_header.share_data_pdu,
     })
 }
@@ -214,6 +218,8 @@ pub fn decode_io_channel(ctx: SendDataIndicationCtx<'_>) -> DecodeResult<IoChann
                 channel_id: ctx.channel_id,
                 share_id: ctx.share_id,
                 pdu_source: ctx.pdu_source,
+                compression_flags: share_data_header.compression_flags,
+                compression_type: share_data_header.compression_type,
                 pdu: share_data_header.share_data_pdu,
             };
 
@@ -822,9 +828,16 @@ impl Encode for ServerDeactivateAll {
 
 #[cfg(test)]
 mod tests {
-    use ironrdp_core::decode;
+    use std::borrow::Cow;
 
-    use super::{ShareControlHeader, ShareControlPdu, ShareDataHeader, ShareDataPdu};
+    use crate::mcs::{McsMessage, SendDataIndication};
+    use crate::x224::X224;
+    use ironrdp_core::{decode, encode_vec};
+
+    use super::{
+        CompressionFlags, ShareControlHeader, ShareControlPdu, ShareDataHeader, ShareDataPdu, StreamPriority,
+        decode_share_data,
+    };
 
     fn zero_length_empty_data_pdu(pdu_type: u8) -> [u8; 18] {
         [
@@ -885,5 +898,38 @@ mod tests {
                 expected: 18
             }
         ));
+    }
+
+    #[test]
+    fn share_data_context_retains_compression_metadata() {
+        let user_data = encode_vec(&ShareControlHeader {
+            share_control_pdu: ShareControlPdu::Data(ShareDataHeader {
+                share_data_pdu: ShareDataPdu::Update(vec![0x10, 0x20]),
+                stream_priority: StreamPriority::Medium,
+                compression_flags: CompressionFlags::COMPRESSED | CompressionFlags::FLUSHED,
+                compression_type: crate::rdp::client_info::CompressionType::K64,
+            }),
+            pdu_source: 1002,
+            share_id: 1,
+        })
+        .expect("encode Share Control PDU");
+        let frame = encode_vec(&X224(McsMessage::SendDataIndication(SendDataIndication {
+            initiator_id: 1002,
+            channel_id: 1003,
+            user_data: Cow::Owned(user_data),
+        })))
+        .expect("encode SendDataIndication");
+
+        let data_ctx = crate::mcs::decode_send_data_indication(&frame).expect("decode SendDataIndication");
+        let share_data_ctx = decode_share_data(data_ctx).expect("decode Share Data PDU");
+
+        assert_eq!(
+            share_data_ctx.compression_flags,
+            CompressionFlags::COMPRESSED | CompressionFlags::FLUSHED
+        );
+        assert_eq!(
+            share_data_ctx.compression_type,
+            crate::rdp::client_info::CompressionType::K64
+        );
     }
 }

--- a/crates/ironrdp-session/Cargo.toml
+++ b/crates/ironrdp-session/Cargo.toml
@@ -22,7 +22,7 @@ qoi = ["dep:qoicoubeh", "ironrdp-pdu/qoi"]
 qoiz = ["dep:zstd-safe", "qoi"]
 
 [dependencies]
-ironrdp-bulk = { path = "../ironrdp-bulk", version = "0.1" }
+ironrdp-bulk = { path = "../ironrdp-bulk", version = "0.1" } # public
 ironrdp-core = { path = "../ironrdp-core", version = "0.2" } # public
 ironrdp-svc = { path = "../ironrdp-svc", version = "0.8" } # public
 ironrdp-dvc = { path = "../ironrdp-dvc", version = "0.8" } # public

--- a/crates/ironrdp-session/src/active_stage.rs
+++ b/crates/ironrdp-session/src/active_stage.rs
@@ -33,7 +33,6 @@ fn to_bulk_compression_type(compression_type: CompressionType) -> BulkCompressio
 pub struct ActiveStage {
     x224_processor: x224::Processor,
     fast_path_processor: fast_path::Processor,
-    compression_type: Option<CompressionType>,
     /// Shared server-to-client compression history across all output transports.
     bulk_decompressor: Option<BulkCompressor>,
     enable_server_pointer: bool,
@@ -90,7 +89,6 @@ impl ActiveStageBuilder {
         ActiveStage {
             x224_processor,
             fast_path_processor,
-            compression_type,
             bulk_decompressor: new_bulk_decompressor(compression_type),
             enable_server_pointer,
         }
@@ -242,9 +240,8 @@ impl ActiveStage {
 
     /// Rebuilds the fast-path processor for a [Deactivation-Reactivation Sequence].
     ///
-    /// The rebuilt session uses a fresh shared bulk decompressor. Decompression history is not carried across reactivation;
-    /// the server signals history resets with the PACKET_FLUSHED and PACKET_AT_FRONT
-    /// compression flags, which are applied per update.
+    /// The shared bulk decompression history is retained. The server signals any history reset
+    /// with the PACKET_FLUSHED and PACKET_AT_FRONT compression flags, which are applied per update.
     ///
     /// [Deactivation-Reactivation Sequence]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/dfc234ce-481a-4674-9a5d-2a7bafb14432
     pub fn reactivate(
@@ -263,7 +260,6 @@ impl ActiveStage {
             pointer_software_rendering,
         }
         .build();
-        self.bulk_decompressor = new_bulk_decompressor(self.compression_type);
         // The x224 processor encodes ShareDataPdu with the server's (possibly new) share_id.
         self.x224_processor.set_share_id(share_id);
         self.enable_server_pointer = enable_server_pointer;

--- a/crates/ironrdp-session/src/active_stage.rs
+++ b/crates/ironrdp-session/src/active_stage.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use ironrdp_bulk::{BulkCompressor, CompressionType as BulkCompressionType};
 use ironrdp_core::{ReadCursor, WriteBuf};
 use ironrdp_displaycontrol::client::DisplayControlClient;
 use ironrdp_dvc::{DrdynvcClient, DvcProcessor, DynamicVirtualChannel};
@@ -8,6 +9,7 @@ use ironrdp_pdu::gcc::ChannelName;
 use ironrdp_pdu::geometry::InclusiveRectangle;
 use ironrdp_pdu::input::fast_path::{FastPathInput, FastPathInputEvent};
 use ironrdp_pdu::rdp::autodetect::AutoDetectRequest;
+use ironrdp_pdu::rdp::client_info::CompressionType;
 use ironrdp_pdu::rdp::headers::ShareDataPdu;
 use ironrdp_pdu::rdp::multitransport::MultitransportRequestPdu;
 use ironrdp_pdu::slow_path::{self, GraphicsUpdateType};
@@ -19,9 +21,21 @@ use crate::fast_path::UpdateKind;
 use crate::image::DecodedImage;
 use crate::{SessionError, SessionErrorExt as _, SessionResult, fast_path, x224};
 
+fn to_bulk_compression_type(compression_type: CompressionType) -> BulkCompressionType {
+    match compression_type {
+        CompressionType::K8 => BulkCompressionType::Rdp4,
+        CompressionType::K64 => BulkCompressionType::Rdp5,
+        CompressionType::Rdp6 => BulkCompressionType::Rdp6,
+        CompressionType::Rdp61 => BulkCompressionType::Rdp61,
+    }
+}
+
 pub struct ActiveStage {
     x224_processor: x224::Processor,
     fast_path_processor: fast_path::Processor,
+    compression_type: Option<CompressionType>,
+    /// Shared server-to-client compression history across all output transports.
+    bulk_decompressor: Option<BulkCompressor>,
     enable_server_pointer: bool,
 }
 
@@ -35,6 +49,8 @@ pub struct ActiveStageBuilder {
     pub io_channel_id: u16,
     pub message_channel_id: Option<u16>,
     pub share_id: u32,
+    /// The bulk compression type negotiated during connection activation.
+    pub compression_type: Option<CompressionType>,
     /// Enable server-side pointer updates (client-side pointer rendering).
     pub enable_server_pointer: bool,
     /// Use software rendering mode for pointer bitmap generation.
@@ -49,6 +65,7 @@ impl ActiveStageBuilder {
             io_channel_id,
             message_channel_id,
             share_id,
+            compression_type,
             enable_server_pointer,
             pointer_software_rendering,
         } = self;
@@ -73,9 +90,15 @@ impl ActiveStageBuilder {
         ActiveStage {
             x224_processor,
             fast_path_processor,
+            compression_type,
+            bulk_decompressor: new_bulk_decompressor(compression_type),
             enable_server_pointer,
         }
     }
+}
+
+fn new_bulk_decompressor(compression_type: Option<CompressionType>) -> Option<BulkCompressor> {
+    compression_type.map(|compression_type| BulkCompressor::new(to_bulk_compression_type(compression_type)))
 }
 
 impl ActiveStage {
@@ -140,14 +163,16 @@ impl ActiveStage {
         let (mut stage_outputs, processor_updates) = match action {
             Action::FastPath => {
                 let mut output = WriteBuf::new();
-                let processor_updates = self.fast_path_processor.process(image, frame, &mut output)?;
+                let processor_updates =
+                    self.fast_path_processor
+                        .process(image, frame, &mut output, &mut self.bulk_decompressor)?;
                 (
                     vec![ActiveStageOutput::ResponseFrame(output.into_inner())],
                     processor_updates,
                 )
             }
             Action::X224 => {
-                let x224_outputs = self.x224_processor.process(frame)?;
+                let x224_outputs = self.x224_processor.process(frame, &mut self.bulk_decompressor)?;
                 let mut stage_outputs = Vec::new();
                 let mut processor_updates = Vec::new();
 
@@ -217,8 +242,7 @@ impl ActiveStage {
 
     /// Rebuilds the fast-path processor for a [Deactivation-Reactivation Sequence].
     ///
-    /// The rebuilt processor owns a fresh bulk decompressor, so compressed updates keep
-    /// decoding after reactivation. Decompression history is not carried across the rebuild;
+    /// The rebuilt session uses a fresh shared bulk decompressor. Decompression history is not carried across reactivation;
     /// the server signals history resets with the PACKET_FLUSHED and PACKET_AT_FRONT
     /// compression flags, which are applied per update.
     ///
@@ -239,6 +263,7 @@ impl ActiveStage {
             pointer_software_rendering,
         }
         .build();
+        self.bulk_decompressor = new_bulk_decompressor(self.compression_type);
         // The x224 processor encodes ShareDataPdu with the server's (possibly new) share_id.
         self.x224_processor.set_share_id(share_id);
         self.enable_server_pointer = enable_server_pointer;

--- a/crates/ironrdp-session/src/fast_path.rs
+++ b/crates/ironrdp-session/src/fast_path.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use ironrdp_bulk::{BulkCompressor, CompressionType};
+use ironrdp_bulk::{BulkCompressor, BulkError};
 use ironrdp_core::{DecodeErrorKind, ReadCursor, WriteBuf, decode_cursor};
 use ironrdp_graphics::image_processing::PixelFormat;
 use ironrdp_graphics::pointer::{DecodedPointer, PointerBitmapTarget, PointerError};
@@ -8,7 +8,7 @@ use ironrdp_graphics::rdp6::BitmapStreamDecoder;
 use ironrdp_graphics::rle::RlePixelFormat;
 use ironrdp_pdu::bitmap::BitmapUpdateData;
 use ironrdp_pdu::codecs::rfx::FrameAcknowledgePdu;
-use ironrdp_pdu::fast_path::{FastPathHeader, FastPathUpdate, FastPathUpdatePdu, Fragmentation};
+use ironrdp_pdu::fast_path::{FastPathHeader, FastPathUpdate, FastPathUpdatePdu, Fragmentation, UpdateCode};
 use ironrdp_pdu::geometry::{InclusiveRectangle, Rectangle as _};
 use ironrdp_pdu::pointer::PointerUpdateData;
 use ironrdp_pdu::rdp::capability_sets::{CODEC_ID_NONE, CODEC_ID_REMOTEFX, CodecId};
@@ -19,7 +19,97 @@ use tracing::{debug, trace, warn};
 use crate::image::DecodedImage;
 use crate::palette::Palette;
 use crate::pointer::PointerCache;
-use crate::{SessionError, SessionErrorExt as _, SessionResult, custom_err, reason_err, rfx};
+use crate::{SessionError, SessionErrorExt as _, SessionErrorKind, SessionResult, reason_err, rfx};
+
+/// A bounded category for a failed Fast-Path bulk decompression operation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BulkDecompressionErrorKind {
+    UnsupportedCompressionType,
+    InvalidCompressedData,
+    OutputBufferTooSmall,
+    HistoryBufferOverflow,
+    UnexpectedEndOfInput,
+}
+
+impl BulkDecompressionErrorKind {
+    /// Returns the stable, value-free trace label for this category.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::UnsupportedCompressionType => "UnsupportedCompressionType",
+            Self::InvalidCompressedData => "InvalidCompressedData",
+            Self::OutputBufferTooSmall => "OutputBufferTooSmall",
+            Self::HistoryBufferOverflow => "HistoryBufferOverflow",
+            Self::UnexpectedEndOfInput => "UnexpectedEndOfInput",
+        }
+    }
+}
+
+/// Bounded metadata describing a failed Fast-Path bulk decompression operation.
+///
+/// This deliberately retains protocol metadata only. It never retains the compressed data or
+/// detailed decoder error text, which can contain information derived from the remote endpoint.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FastPathBulkDecompressionFailure {
+    compression_flags: u8,
+    compression_type: Option<u8>,
+    update_code: u8,
+    fragmentation: u8,
+    payload_length: usize,
+    error_kind: BulkDecompressionErrorKind,
+}
+
+impl FastPathBulkDecompressionFailure {
+    fn new(attributes: FragmentAttributes, payload_length: usize, error: &BulkError) -> Self {
+        let error_kind = match error {
+            BulkError::UnsupportedCompressionType(_) => BulkDecompressionErrorKind::UnsupportedCompressionType,
+            BulkError::InvalidCompressedData(_) => BulkDecompressionErrorKind::InvalidCompressedData,
+            BulkError::OutputBufferTooSmall { .. } => BulkDecompressionErrorKind::OutputBufferTooSmall,
+            BulkError::HistoryBufferOverflow => BulkDecompressionErrorKind::HistoryBufferOverflow,
+            BulkError::UnexpectedEndOfInput => BulkDecompressionErrorKind::UnexpectedEndOfInput,
+        };
+
+        Self {
+            compression_flags: attributes.compression_flags.map_or(0, |flags| flags.bits()),
+            compression_type: attributes
+                .compression_type
+                .map(|compression_type| compression_type.as_u8()),
+            update_code: attributes.update_code.as_u8(),
+            fragmentation: attributes.fragmentation.as_u8(),
+            payload_length,
+            error_kind,
+        }
+    }
+
+    /// Returns the Fast-Path bulk compression control flags.
+    pub const fn compression_flags(self) -> u8 {
+        self.compression_flags
+    }
+
+    /// Returns the Fast-Path bulk compression type, if the PDU provided one.
+    pub const fn compression_type(self) -> Option<u8> {
+        self.compression_type
+    }
+
+    /// Returns the Fast-Path update code.
+    pub const fn update_code(self) -> u8 {
+        self.update_code
+    }
+
+    /// Returns the initial Fast-Path fragmentation mode.
+    pub const fn fragmentation(self) -> u8 {
+        self.fragmentation
+    }
+
+    /// Returns the complete compressed update size in bytes.
+    pub const fn payload_length(self) -> usize {
+        self.payload_length
+    }
+
+    /// Returns the bounded bulk decoder error category.
+    pub const fn error_kind(self) -> BulkDecompressionErrorKind {
+        self.error_kind
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -77,7 +167,6 @@ mod tests {
         assert_eq!(pixel(2, 1), [4, 5, 6, 255]);
         assert_eq!(pixel(3, 0), [0, 0, 0, 0]);
     }
-
     #[test]
     fn unsupported_new_pointer_uses_default_and_evicts_cached_shape() {
         let mut processor = ProcessorBuilder {
@@ -142,49 +231,6 @@ mod tests {
         assert!(matches!(updates.as_slice(), [UpdateKind::PointerDefault]));
         assert!(!processor.pointer_cache.is_cached(0));
     }
-
-    /// The decompressor is owned by the library, but a session that never receives a
-    /// compressed update should not pay for the algorithm contexts. `ironrdp-web` never
-    /// negotiates compression, so this is its normal case.
-    #[test]
-    fn decompressor_is_not_built_until_an_update_needs_it() {
-        use ironrdp_core::encode_vec;
-        use ironrdp_pdu::fast_path::UpdateCode;
-
-        let mut processor = ProcessorBuilder {
-            io_channel_id: 0,
-            user_channel_id: 0,
-            share_id: 0,
-            enable_server_pointer: false,
-            pointer_software_rendering: false,
-        }
-        .build();
-
-        assert!(
-            processor.bulk_decompressor.is_none(),
-            "a freshly built processor must not allocate the bulk contexts"
-        );
-
-        let frame = encode_vec(&FastPathUpdatePdu {
-            fragmentation: Fragmentation::Single,
-            update_code: UpdateCode::Bitmap,
-            compression_flags: None,
-            compression_type: None,
-            data: &[],
-        })
-        .expect("encode uncompressed FastPath update");
-
-        let mut image = DecodedImage::new(PixelFormat::RgbA32, 4, 4);
-        let mut output = WriteBuf::new();
-        // The empty bitmap payload does not decode; only the allocation behaviour on the
-        // way there is under test, so the update result is deliberately ignored.
-        let _result = processor.process_single_update(&mut ReadCursor::new(&frame), &mut image, &mut output);
-
-        assert!(
-            processor.bulk_decompressor.is_none(),
-            "an update carrying no compression flags must not build a decompressor"
-        );
-    }
 }
 
 #[derive(Debug)]
@@ -207,13 +253,6 @@ pub struct Processor {
     mouse_pos_update: Option<(u16, u16)>,
     enable_server_pointer: bool,
     pointer_software_rendering: bool,
-    /// Bulk decompressor for server-to-client compressed PDUs. Owned by the library
-    /// and built on the first update that needs one, so a compressed update is always
-    /// decodable without a session that never receives one paying for the algorithm
-    /// contexts (the two XCRUSH history buffers are 2 MB each). This is not a
-    /// consumer-visible option: `ProcessorBuilder` has no corresponding field, so
-    /// there is no way to construct a `Processor` that cannot decompress.
-    bulk_decompressor: Option<BulkCompressor>,
     /// Current 8bpp color palette. Updated by Palette fast-path updates.
     palette: Palette,
     #[cfg(feature = "qoiz")]
@@ -231,6 +270,7 @@ impl Processor {
         image: &mut DecodedImage,
         input: &[u8],
         output: &mut WriteBuf,
+        bulk_decompressor: &mut Option<BulkCompressor>,
     ) -> SessionResult<Vec<UpdateKind>> {
         let mut processor_updates = Vec::new();
 
@@ -248,7 +288,7 @@ impl Processor {
         // A single FastPath output PDU can contain multiple updates.
         // Loop over all updates within the PDU payload.
         while !input.is_empty() {
-            let update_result = self.process_single_update(&mut input, image, output)?;
+            let update_result = self.process_single_update(&mut input, image, output, bulk_decompressor)?;
             processor_updates.extend(update_result);
         }
 
@@ -261,59 +301,31 @@ impl Processor {
         input: &mut ReadCursor<'_>,
         image: &mut DecodedImage,
         output: &mut WriteBuf,
+        bulk_decompressor: &mut Option<BulkCompressor>,
     ) -> SessionResult<Vec<UpdateKind>> {
         let mut processor_updates = Vec::new();
 
         let update_pdu = decode_cursor::<FastPathUpdatePdu<'_>>(input).map_err(SessionError::decode)?;
         trace!(fast_path_update_fragmentation = ?update_pdu.fragmentation);
 
-        // Decompress the payload if the server sent it compressed.
+        let attributes = FragmentAttributes::from(&update_pdu);
         let decompressed_data;
-        let payload = if let Some(flags) = update_pdu.compression_flags {
-            if flags.contains(CompressionFlags::COMPRESSED) || flags.contains(CompressionFlags::FLUSHED) {
-                let bulk_flags =
-                    u32::from(flags.bits()) | u32::from(update_pdu.compression_type.map_or(0, |ct| ct.as_u8()));
-
-                // Built on first use. The construction-time type does not constrain what
-                // can be decoded: `decompress` selects the algorithm per update from the
-                // packet's own type bits, so Rdp61 here is an arbitrary starting point.
-                let decompressor = self
-                    .bulk_decompressor
-                    .get_or_insert_with(|| BulkCompressor::new(CompressionType::Rdp61));
-                let decompressed = decompressor
-                    .decompress(update_pdu.data, bulk_flags)
-                    .map_err(|e| reason_err!("FastPath", "bulk decompression failed: {}", e))?;
-                // Copy decompressed data before accessing metrics (releases the mutable borrow).
-                decompressed_data = decompressed.to_vec();
-                debug!(
-                    compressed_size = update_pdu.data.len(),
-                    decompressed_size = decompressed_data.len(),
-                    compression_type = ?update_pdu.compression_type,
-                    compression_ratio = format_args!("{:.2}x", decompressor.compression_ratio()),
-                    total_compressed = decompressor.total_compressed_bytes(),
-                    total_uncompressed = decompressor.total_uncompressed_bytes(),
-                    "Decompressed FastPath update"
-                );
-                decompressed_data.as_slice()
-            } else {
-                // Compression flags present but COMPRESSED bit not set — pass data through.
-                // Still need to inform the decompressor of FLUSHED/AT_FRONT flags even
-                // without compressed payload.
-                update_pdu.data
-            }
+        let update_data = if attributes.compression_flags.is_some_and(|flags| !flags.is_empty()) {
+            decompressed_data = Self::decompress_fragment_data(update_pdu.data, attributes, bulk_decompressor)?;
+            decompressed_data.as_slice()
         } else {
             update_pdu.data
         };
 
-        let processed_complete_data = self.complete_data.process_data(payload, update_pdu.fragmentation);
-
-        let update_code = update_pdu.update_code;
-
-        let Some(data) = processed_complete_data else {
+        let Some(data) = self
+            .complete_data
+            .process_data(update_data, update_pdu.fragmentation, attributes)?
+        else {
             return Ok(processor_updates);
         };
+        let FragmentedUpdate { data, attributes } = data;
 
-        let update = FastPathUpdate::decode_with_code(data.as_slice(), update_code);
+        let update = FastPathUpdate::decode_with_code(data.as_slice(), attributes.update_code);
 
         match update {
             Ok(FastPathUpdate::SurfaceCommands(surface_commands)) => {
@@ -338,11 +350,16 @@ impl Processor {
                 // FIXME: This seems to be a way of special-handling the error case in FastPathUpdate::decode_cursor_with_code
                 // to ignore the unsupported update PDUs, but this is a fragile logic and the rationale behind it is not
                 // obvious.
-                if let DecodeErrorKind::InvalidField { field, reason } = e.kind() {
-                    warn!(field, reason, "Received invalid Fast-Path update");
-                    processor_updates.push(UpdateKind::None);
-                } else {
-                    return Err(custom_err!("Fast-Path", e));
+                match e.kind() {
+                    DecodeErrorKind::InvalidField { field, reason } => {
+                        warn!(field, reason, "Ignoring invalid Fast-Path update");
+                        processor_updates.push(UpdateKind::None);
+                    }
+                    _ => {
+                        let mut session_error = SessionError::decode(e);
+                        session_error.set_context("FastPathUpdate");
+                        return Err(session_error);
+                    }
                 }
             }
         };
@@ -353,6 +370,43 @@ impl Processor {
     /// Process a palette update shared between fast-path and slow-path pipelines.
     pub(crate) fn process_palette_update(&mut self, palette_data: &[u8]) {
         self.palette.process_update(palette_data);
+    }
+
+    fn decompress_fragment_data(
+        data: &[u8],
+        attributes: FragmentAttributes,
+        bulk_decompressor: &mut Option<BulkCompressor>,
+    ) -> SessionResult<Vec<u8>> {
+        let decompressor = bulk_decompressor
+            .as_mut()
+            .ok_or_else(|| reason_err!("FastPath", "received compression control flags without a decompressor"))?;
+        let bulk_flags = u32::from(attributes.compression_flags.map_or(0, |flags| flags.bits()))
+            | u32::from(
+                attributes
+                    .compression_type
+                    .map_or(0, |compression_type| compression_type.as_u8()),
+            );
+        let decompressed = decompressor.decompress(data, bulk_flags).map_err(|error| {
+            SessionError::new(
+                "FastPath bulk decompression",
+                SessionErrorKind::FastPathBulkDecompression(FastPathBulkDecompressionFailure::new(
+                    attributes,
+                    data.len(),
+                    &error,
+                )),
+            )
+        })?;
+        let decompressed_data = decompressed.to_vec();
+        debug!(
+            compressed_size = data.len(),
+            decompressed_size = decompressed_data.len(),
+            compression_type = ?attributes.compression_type,
+            compression_ratio = format_args!("{:.2}x", decompressor.compression_ratio()),
+            total_compressed = decompressor.total_compressed_bytes(),
+            total_uncompressed = decompressor.total_uncompressed_bytes(),
+            "Decompressed Fast-Path update fragment"
+        );
+        Ok(decompressed_data)
     }
 
     /// Process a bitmap update, shared between fast-path and slow-path pipelines.
@@ -882,8 +936,6 @@ impl ProcessorBuilder {
             mouse_pos_update: None,
             enable_server_pointer: self.enable_server_pointer,
             pointer_software_rendering: self.pointer_software_rendering,
-            // Built on the first update that needs it; see the field documentation.
-            bulk_decompressor: None,
             palette: Palette::system_default(),
             #[cfg(feature = "qoiz")]
             zdctx: zstd_safe::DCtx::default(),
@@ -891,9 +943,34 @@ impl ProcessorBuilder {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct FragmentAttributes {
+    fragmentation: Fragmentation,
+    update_code: UpdateCode,
+    compression_flags: Option<CompressionFlags>,
+    compression_type: Option<ironrdp_pdu::rdp::client_info::CompressionType>,
+}
+
+impl From<&FastPathUpdatePdu<'_>> for FragmentAttributes {
+    fn from(update: &FastPathUpdatePdu<'_>) -> Self {
+        Self {
+            fragmentation: update.fragmentation,
+            update_code: update.update_code,
+            compression_flags: update.compression_flags,
+            compression_type: update.compression_type,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+struct FragmentedUpdate {
+    data: Vec<u8>,
+    attributes: FragmentAttributes,
+}
+
 #[derive(Debug, PartialEq)]
 struct CompleteData {
-    fragmented_data: Option<Vec<u8>>,
+    fragmented_data: Option<FragmentedUpdate>,
 }
 
 impl CompleteData {
@@ -901,29 +978,40 @@ impl CompleteData {
         Self { fragmented_data: None }
     }
 
-    fn process_data(&mut self, data: &[u8], fragmentation: Fragmentation) -> Option<Vec<u8>> {
+    fn process_data(
+        &mut self,
+        data: &[u8],
+        fragmentation: Fragmentation,
+        attributes: FragmentAttributes,
+    ) -> SessionResult<Option<FragmentedUpdate>> {
         match fragmentation {
             Fragmentation::Single => {
                 self.check_data_is_empty();
 
-                Some(data.to_vec())
+                Ok(Some(FragmentedUpdate {
+                    data: data.to_vec(),
+                    attributes,
+                }))
             }
             Fragmentation::First => {
                 self.check_data_is_empty();
 
-                self.fragmented_data = Some(data.to_vec());
+                self.fragmented_data = Some(FragmentedUpdate {
+                    data: data.to_vec(),
+                    attributes,
+                });
 
-                None
+                Ok(None)
             }
             Fragmentation::Next => {
-                self.append_data(data);
+                self.append_data(data, attributes)?;
 
-                None
+                Ok(None)
             }
             Fragmentation::Last => {
-                self.append_data(data);
+                self.append_data(data, attributes)?;
 
-                self.fragmented_data.take()
+                Ok(self.fragmented_data.take())
             }
         }
     }
@@ -935,12 +1023,119 @@ impl CompleteData {
         }
     }
 
-    fn append_data(&mut self, data: &[u8]) {
-        if let Some(fragmented_data) = self.fragmented_data.as_mut() {
-            fragmented_data.extend_from_slice(data);
+    fn append_data(&mut self, data: &[u8], attributes: FragmentAttributes) -> SessionResult<()> {
+        if let Some(fragmented_update) = self.fragmented_data.as_mut() {
+            if fragmented_update.attributes.update_code != attributes.update_code
+                || fragmented_update.attributes.compression_flags.is_some() != attributes.compression_flags.is_some()
+            {
+                return Err(reason_err!("FastPath", "inconsistent fragmented update metadata"));
+            }
+
+            // MS-RDPBCGR 3.2.5.9.3.1 requires equal updateCode and header compression
+            // subfield values, but does not require equal compressionFlags. Each fragment
+            // has already applied its own compression flags before reassembly.
+            fragmented_update.data.extend_from_slice(data);
+            Ok(())
         } else {
-            warn!("Got unexpected Next fragmentation PDU without prior First fragmentation PDU");
+            Err(reason_err!(
+                "FastPath",
+                "received a non-initial fragment without an active fragment sequence"
+            ))
         }
+    }
+}
+
+#[cfg(test)]
+mod compression_tests {
+    use super::*;
+
+    #[test]
+    fn fragmented_updates_reassemble_with_initial_attributes() {
+        let mut complete_data = CompleteData::new();
+        let first_attributes = FragmentAttributes {
+            fragmentation: Fragmentation::First,
+            update_code: UpdateCode::Bitmap,
+            compression_flags: Some(CompressionFlags::COMPRESSED),
+            compression_type: Some(ironrdp_pdu::rdp::client_info::CompressionType::K64),
+        };
+        let last_attributes = FragmentAttributes {
+            fragmentation: Fragmentation::Last,
+            compression_type: Some(ironrdp_pdu::rdp::client_info::CompressionType::K8),
+            ..first_attributes
+        };
+
+        assert_eq!(
+            complete_data
+                .process_data(b"first", Fragmentation::First, first_attributes)
+                .expect("first fragment should be accepted"),
+            None
+        );
+        assert_eq!(
+            complete_data
+                .process_data(b"last", Fragmentation::Last, last_attributes)
+                .expect("last fragment should be accepted"),
+            Some(FragmentedUpdate {
+                data: b"firstlast".to_vec(),
+                attributes: first_attributes,
+            })
+        );
+    }
+
+    #[test]
+    fn fragmented_updates_reject_inconsistent_metadata() {
+        let mut complete_data = CompleteData::new();
+        let first_attributes = FragmentAttributes {
+            fragmentation: Fragmentation::First,
+            update_code: UpdateCode::Bitmap,
+            compression_flags: Some(CompressionFlags::COMPRESSED),
+            compression_type: Some(ironrdp_pdu::rdp::client_info::CompressionType::K64),
+        };
+        let invalid_attributes = FragmentAttributes {
+            fragmentation: Fragmentation::Last,
+            update_code: UpdateCode::Palette,
+            ..first_attributes
+        };
+
+        assert!(
+            complete_data
+                .process_data(b"first", Fragmentation::First, first_attributes)
+                .expect("first fragment should be accepted")
+                .is_none()
+        );
+        assert!(
+            complete_data
+                .process_data(b"last", Fragmentation::Last, invalid_attributes)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn bulk_decompression_failure_retains_only_bounded_metadata() {
+        let attributes = FragmentAttributes {
+            fragmentation: Fragmentation::First,
+            update_code: UpdateCode::Bitmap,
+            compression_flags: Some(CompressionFlags::COMPRESSED | CompressionFlags::FLUSHED),
+            compression_type: Some(ironrdp_pdu::rdp::client_info::CompressionType::Rdp6),
+        };
+
+        let failure = FastPathBulkDecompressionFailure::new(
+            attributes,
+            1_024,
+            &BulkError::InvalidCompressedData("details must not escape"),
+        );
+
+        assert_eq!(
+            failure.compression_flags(),
+            CompressionFlags::COMPRESSED.bits() | CompressionFlags::FLUSHED.bits()
+        );
+        assert_eq!(
+            failure.compression_type(),
+            Some(ironrdp_pdu::rdp::client_info::CompressionType::Rdp6.as_u8())
+        );
+        assert_eq!(failure.update_code(), UpdateCode::Bitmap.as_u8());
+        assert_eq!(failure.fragmentation(), Fragmentation::First.as_u8());
+        assert_eq!(failure.payload_length(), 1_024);
+        assert_eq!(failure.error_kind(), BulkDecompressionErrorKind::InvalidCompressedData);
     }
 }
 

--- a/crates/ironrdp-session/src/fast_path.rs
+++ b/crates/ironrdp-session/src/fast_path.rs
@@ -371,7 +371,6 @@ impl Processor {
     pub(crate) fn process_palette_update(&mut self, palette_data: &[u8]) {
         self.palette.process_update(palette_data);
     }
-
     fn decompress_fragment_data(
         data: &[u8],
         attributes: FragmentAttributes,

--- a/crates/ironrdp-session/src/fast_path.rs
+++ b/crates/ironrdp-session/src/fast_path.rs
@@ -100,7 +100,7 @@ impl FastPathBulkDecompressionFailure {
         self.fragmentation
     }
 
-    /// Returns the complete compressed update size in bytes.
+    /// Returns the failing fragment's compressed payload size in bytes.
     pub const fn payload_length(self) -> usize {
         self.payload_length
     }

--- a/crates/ironrdp-session/src/lib.rs
+++ b/crates/ironrdp-session/src/lib.rs
@@ -16,6 +16,7 @@ mod palette;
 use core::fmt;
 
 pub use active_stage::{ActiveStage, ActiveStageBuilder, ActiveStageOutput, GracefulDisconnectReason};
+pub use fast_path::{BulkDecompressionErrorKind, FastPathBulkDecompressionFailure};
 
 pub type SessionResult<T> = Result<T, SessionError>;
 
@@ -25,6 +26,7 @@ pub enum SessionErrorKind {
     Pdu(ironrdp_pdu::PduError),
     Encode(ironrdp_core::EncodeError),
     Decode(ironrdp_core::DecodeError),
+    FastPathBulkDecompression(FastPathBulkDecompressionFailure),
     Reason(String),
     General,
     Custom,
@@ -36,6 +38,7 @@ impl fmt::Display for SessionErrorKind {
             SessionErrorKind::Pdu(_) => write!(f, "PDU error"),
             SessionErrorKind::Encode(_) => write!(f, "encode error"),
             SessionErrorKind::Decode(_) => write!(f, "decode error"),
+            SessionErrorKind::FastPathBulkDecompression(_) => write!(f, "Fast-Path bulk decompression error"),
             SessionErrorKind::Reason(description) => write!(f, "reason: {description}"),
             SessionErrorKind::General => write!(f, "general error"),
             SessionErrorKind::Custom => write!(f, "custom error"),
@@ -49,6 +52,7 @@ impl core::error::Error for SessionErrorKind {
             SessionErrorKind::Pdu(e) => Some(e),
             SessionErrorKind::Encode(e) => Some(e),
             SessionErrorKind::Decode(e) => Some(e),
+            SessionErrorKind::FastPathBulkDecompression(_) => None,
             SessionErrorKind::Reason(_) => None,
             SessionErrorKind::General => None,
             SessionErrorKind::Custom => None,

--- a/crates/ironrdp-session/src/lib.rs
+++ b/crates/ironrdp-session/src/lib.rs
@@ -38,7 +38,7 @@ impl fmt::Display for SessionErrorKind {
             SessionErrorKind::Pdu(_) => write!(f, "PDU error"),
             SessionErrorKind::Encode(_) => write!(f, "encode error"),
             SessionErrorKind::Decode(_) => write!(f, "decode error"),
-            SessionErrorKind::FastPathBulkDecompression(_) => write!(f, "Fast-Path bulk decompression error"),
+            SessionErrorKind::FastPathBulkDecompression(_) => write!(f, "fast-path bulk decompression error"),
             SessionErrorKind::Reason(description) => write!(f, "reason: {description}"),
             SessionErrorKind::General => write!(f, "general error"),
             SessionErrorKind::Custom => write!(f, "custom error"),

--- a/crates/ironrdp-session/src/x224/mod.rs
+++ b/crates/ironrdp-session/src/x224/mod.rs
@@ -1,9 +1,11 @@
+use ironrdp_bulk::BulkCompressor;
 use ironrdp_core::{WriteBuf, decode};
 use ironrdp_dvc::{DrdynvcClient, DvcProcessor, DynamicVirtualChannel};
 use ironrdp_pdu::gcc::ChannelName;
 use ironrdp_pdu::mcs::{DisconnectProviderUltimatum, DisconnectReason, McsMessage, SendDataIndicationCtx};
 use ironrdp_pdu::rdp::autodetect::{AutoDetectReqPdu, AutoDetectRequest, AutoDetectResponse, AutoDetectRspPdu};
-use ironrdp_pdu::rdp::headers::ShareDataPdu;
+use ironrdp_pdu::rdp::client_info::CompressionType;
+use ironrdp_pdu::rdp::headers::{CompressionFlags, ShareDataPdu};
 use ironrdp_pdu::rdp::multitransport::MultitransportRequestPdu;
 use ironrdp_pdu::rdp::server_error_info::{ErrorInfo, ProtocolIndependentCode, ServerSetErrorInfoPdu};
 use ironrdp_pdu::x224::X224;
@@ -140,13 +142,17 @@ impl Processor {
 
     /// Processes a received PDU. Returns a vector of [`ProcessorOutput`] that must be processed
     /// in the returned order.
-    pub fn process(&mut self, frame: &[u8]) -> SessionResult<Vec<ProcessorOutput>> {
+    pub fn process(
+        &mut self,
+        frame: &[u8],
+        bulk_decompressor: &mut Option<BulkCompressor>,
+    ) -> SessionResult<Vec<ProcessorOutput>> {
         let data_ctx: SendDataIndicationCtx<'_> =
             ironrdp_pdu::mcs::decode_send_data_indication(frame).map_err(SessionError::decode)?;
         let channel_id = data_ctx.channel_id;
 
         if channel_id == self.io_channel_id {
-            self.process_io_channel(data_ctx)
+            self.process_io_channel(data_ctx, bulk_decompressor)
         } else if self.message_channel_id == Some(channel_id) {
             self.process_message_channel(data_ctx)
         } else if let Some(svc) = self.static_channels.get_by_channel_id_mut(channel_id) {
@@ -158,7 +164,11 @@ impl Processor {
         }
     }
 
-    fn process_io_channel(&self, data_ctx: SendDataIndicationCtx<'_>) -> SessionResult<Vec<ProcessorOutput>> {
+    fn process_io_channel(
+        &mut self,
+        data_ctx: SendDataIndicationCtx<'_>,
+        bulk_decompressor: &mut Option<BulkCompressor>,
+    ) -> SessionResult<Vec<ProcessorOutput>> {
         debug_assert_eq!(data_ctx.channel_id, self.io_channel_id);
 
         let io_channel = ironrdp_pdu::rdp::headers::decode_io_channel(data_ctx).map_err(SessionError::decode)?;
@@ -210,18 +220,23 @@ impl Processor {
                             )),
                         ])
                     }
-                    // TODO: slow-path payloads may be bulk-compressed when
-                    // ClientInfoFlags::COMPRESSION is negotiated. Decompression
-                    // should happen here before passing data downstream. Currently
-                    // IronRDP does not wire bulk decompression into this path.
-                    // FIXME: until this is wired, the client deliberately defaults to the simple,
-                    // stateless-friendly MPPC 64K (RDP5) compression level rather than XCRUSH; a
-                    // stateful codec would risk silent corruption on slow-path updates.
                     ShareDataPdu::Update(data) => {
+                        let data = Self::decompress_share_data(
+                            data,
+                            ctx.compression_flags,
+                            ctx.compression_type,
+                            bulk_decompressor,
+                        )?;
                         debug!("Got slow-path graphics update ({} bytes)", data.len());
                         Ok(vec![ProcessorOutput::GraphicsUpdate(data)])
                     }
                     ShareDataPdu::Pointer(data) => {
+                        let data = Self::decompress_share_data(
+                            data,
+                            ctx.compression_flags,
+                            ctx.compression_type,
+                            bulk_decompressor,
+                        )?;
                         debug!("Got slow-path pointer update ({} bytes)", data.len());
                         Ok(vec![ProcessorOutput::PointerUpdate(data)])
                     }
@@ -241,6 +256,33 @@ impl Processor {
             }
             ironrdp_pdu::rdp::headers::IoChannelPdu::DeactivateAll(_) => Ok(vec![ProcessorOutput::DeactivateAll]),
         }
+    }
+
+    fn decompress_share_data(
+        data: Vec<u8>,
+        compression_flags: CompressionFlags,
+        compression_type: CompressionType,
+        bulk_decompressor: &mut Option<BulkCompressor>,
+    ) -> SessionResult<Vec<u8>> {
+        if compression_flags.is_empty() {
+            return Ok(data);
+        }
+
+        let decompressor = bulk_decompressor
+            .as_mut()
+            .ok_or_else(|| reason_err!("slow-path", "received compressed share data without a decompressor"))?;
+        let flags = u32::from(compression_flags.bits()) | u32::from(compression_type.as_u8());
+        let decompressed = decompressor
+            .decompress(&data, flags)
+            .map_err(|error| reason_err!("slow-path", "bulk decompression failed: {error}"))?
+            .to_vec();
+        debug!(
+            compressed_size = data.len(),
+            decompressed_size = decompressed.len(),
+            ?compression_type,
+            "Decompressed slow-path share data"
+        );
+        Ok(decompressed)
     }
 
     /// Process an auto-detect request received on the MCS message channel.
@@ -302,4 +344,50 @@ impl Processor {
 /// The caller is responsible for ensuring that the `channel_id` corresponds to the correct channel.
 fn process_svc_messages(messages: Vec<SvcMessage>, channel_id: u16, initiator_id: u16) -> SessionResult<Vec<u8>> {
     client_encode_svc_messages(messages, channel_id, initiator_id).map_err(SessionError::encode)
+}
+
+#[cfg(test)]
+mod tests {
+    use ironrdp_bulk::{CompressionType as BulkCompressionType, flags};
+
+    use super::*;
+
+    #[test]
+    fn processor_decompresses_slow_path_share_data() {
+        let source = vec![b'A'; 1024];
+        let mut compressor = BulkCompressor::new(BulkCompressionType::Rdp5);
+        let (compressed_size, flags) = compressor.compress(&source).expect("source should compress");
+        assert_ne!(flags & flags::PACKET_COMPRESSED, 0, "test data must be compressed");
+        let compressed = compressor.compressed_data(compressed_size).to_vec();
+        let mut bulk_decompressor = Some(BulkCompressor::new(BulkCompressionType::Rdp5));
+        let compression_flags = CompressionFlags::from_bits_retain(
+            u8::try_from(flags & !flags::COMPRESSION_TYPE_MASK).expect("bulk flags should fit in a byte"),
+        );
+
+        assert_eq!(
+            Processor::decompress_share_data(
+                compressed,
+                compression_flags,
+                CompressionType::K64,
+                &mut bulk_decompressor
+            )
+            .expect("compressed slow-path data should decompress"),
+            source
+        );
+    }
+
+    #[test]
+    fn processor_rejects_compressed_slow_path_data_without_a_decompressor() {
+        let mut bulk_decompressor = None;
+
+        assert!(
+            Processor::decompress_share_data(
+                vec![0],
+                CompressionFlags::COMPRESSED,
+                CompressionType::K64,
+                &mut bulk_decompressor
+            )
+            .is_err()
+        );
+    }
 }

--- a/crates/ironrdp-session/src/x224/mod.rs
+++ b/crates/ironrdp-session/src/x224/mod.rs
@@ -5,7 +5,7 @@ use ironrdp_pdu::gcc::ChannelName;
 use ironrdp_pdu::mcs::{DisconnectProviderUltimatum, DisconnectReason, McsMessage, SendDataIndicationCtx};
 use ironrdp_pdu::rdp::autodetect::{AutoDetectReqPdu, AutoDetectRequest, AutoDetectResponse, AutoDetectRspPdu};
 use ironrdp_pdu::rdp::client_info::CompressionType;
-use ironrdp_pdu::rdp::headers::{CompressionFlags, ShareDataPdu};
+use ironrdp_pdu::rdp::headers::{CompressionFlags, ShareDataCtx, ShareDataPdu};
 use ironrdp_pdu::rdp::multitransport::MultitransportRequestPdu;
 use ironrdp_pdu::rdp::server_error_info::{ErrorInfo, ProtocolIndependentCode, ServerSetErrorInfoPdu};
 use ironrdp_pdu::x224::X224;
@@ -174,79 +174,7 @@ impl Processor {
         let io_channel = ironrdp_pdu::rdp::headers::decode_io_channel(data_ctx).map_err(SessionError::decode)?;
 
         match io_channel {
-            ironrdp_pdu::rdp::headers::IoChannelPdu::Data(ctx) => {
-                match ctx.pdu {
-                    ShareDataPdu::SaveSessionInfo(session_info) => {
-                        debug!("Got Session Save Info PDU: {session_info:?}");
-                        Ok(Vec::new())
-                    }
-                    // FIXME: workaround fix to not terminate the session on "unhandled PDU: Set Keyboard Indicators PDU"
-                    ShareDataPdu::SetKeyboardIndicators(data) => {
-                        debug!("Got Keyboard Indicators PDU: {data:?}");
-                        Ok(Vec::new())
-                    }
-                    ShareDataPdu::ServerSetErrorInfo(ServerSetErrorInfoPdu(ErrorInfo::ProtocolIndependentCode(
-                        ProtocolIndependentCode::None,
-                    ))) => {
-                        debug!("Received None server error");
-                        Ok(Vec::new())
-                    }
-                    ShareDataPdu::ServerSetErrorInfo(ServerSetErrorInfoPdu(e)) => {
-                        // This is a part of server-side graceful disconnect procedure defined
-                        // in [MS-RDPBCGR].
-                        //
-                        // [MS-RDPBCGR]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/149070b0-ecec-4c20-af03-934bbc48adb8
-                        let desc = DisconnectDescription::ErrorInfo(e);
-                        Ok(vec![ProcessorOutput::Disconnect(desc)])
-                    }
-                    ShareDataPdu::ShutdownDenied => {
-                        debug!("ShutdownDenied received, session will be closed");
-
-                        // As defined in [MS-RDPBCGR], when `ShareDataPdu::ShutdownDenied` is received, we
-                        // need to send a disconnect ultimatum to the server if we want to proceed with the
-                        // session shutdown.
-                        //
-                        // [MS-RDPBCGR]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/27915739-8f77-487e-9927-55008af7fd68
-                        let ultimatum = McsMessage::DisconnectProviderUltimatum(
-                            DisconnectProviderUltimatum::from_reason(DisconnectReason::UserRequested),
-                        );
-
-                        let encoded_pdu = ironrdp_core::encode_vec(&X224(ultimatum)).map_err(SessionError::encode);
-
-                        Ok(vec![
-                            ProcessorOutput::ResponseFrame(encoded_pdu?),
-                            ProcessorOutput::Disconnect(DisconnectDescription::McsDisconnect(
-                                DisconnectReason::UserRequested,
-                            )),
-                        ])
-                    }
-                    ShareDataPdu::Update(data) => {
-                        let data = Self::decompress_share_data(
-                            data,
-                            ctx.compression_flags,
-                            ctx.compression_type,
-                            bulk_decompressor,
-                        )?;
-                        debug!("Got slow-path graphics update ({} bytes)", data.len());
-                        Ok(vec![ProcessorOutput::GraphicsUpdate(data)])
-                    }
-                    ShareDataPdu::Pointer(data) => {
-                        let data = Self::decompress_share_data(
-                            data,
-                            ctx.compression_flags,
-                            ctx.compression_type,
-                            bulk_decompressor,
-                        )?;
-                        debug!("Got slow-path pointer update ({} bytes)", data.len());
-                        Ok(vec![ProcessorOutput::PointerUpdate(data)])
-                    }
-                    _ => Err(reason_err!(
-                        "IO channel",
-                        "unhandled PDU: {:?}",
-                        ctx.pdu.as_short_name()
-                    )),
-                }
-            }
+            ironrdp_pdu::rdp::headers::IoChannelPdu::Data(ctx) => Self::process_share_data(ctx, bulk_decompressor),
             ironrdp_pdu::rdp::headers::IoChannelPdu::MultitransportRequest(pdu) => {
                 debug!(
                     "Received Initiate Multitransport Request: request_id={}",
@@ -255,6 +183,84 @@ impl Processor {
                 Ok(vec![ProcessorOutput::MultitransportRequest(pdu)])
             }
             ironrdp_pdu::rdp::headers::IoChannelPdu::DeactivateAll(_) => Ok(vec![ProcessorOutput::DeactivateAll]),
+        }
+    }
+
+    fn process_share_data(
+        ctx: ShareDataCtx,
+        bulk_decompressor: &mut Option<BulkCompressor>,
+    ) -> SessionResult<Vec<ProcessorOutput>> {
+        let ShareDataCtx {
+            compression_flags,
+            compression_type,
+            pdu,
+            ..
+        } = ctx;
+        let (pdu, compression_flags) = match pdu {
+            ShareDataPdu::Compressed { pdu_type, data } => {
+                let data = Self::decompress_share_data(data, compression_flags, compression_type, bulk_decompressor)?;
+                (
+                    ShareDataPdu::decode_with_type(&data, pdu_type).map_err(SessionError::decode)?,
+                    CompressionFlags::empty(),
+                )
+            }
+            pdu => (pdu, compression_flags),
+        };
+
+        match pdu {
+            ShareDataPdu::SaveSessionInfo(session_info) => {
+                debug!("Got Session Save Info PDU: {session_info:?}");
+                Ok(Vec::new())
+            }
+            // FIXME: workaround fix to not terminate the session on "unhandled PDU: Set Keyboard Indicators PDU"
+            ShareDataPdu::SetKeyboardIndicators(data) => {
+                debug!("Got Keyboard Indicators PDU: {data:?}");
+                Ok(Vec::new())
+            }
+            ShareDataPdu::ServerSetErrorInfo(ServerSetErrorInfoPdu(ErrorInfo::ProtocolIndependentCode(
+                ProtocolIndependentCode::None,
+            ))) => {
+                debug!("Received None server error");
+                Ok(Vec::new())
+            }
+            ShareDataPdu::ServerSetErrorInfo(ServerSetErrorInfoPdu(e)) => {
+                // This is a part of server-side graceful disconnect procedure defined
+                // in [MS-RDPBCGR].
+                //
+                // [MS-RDPBCGR]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/149070b0-ecec-4c20-af03-934bbc48adb8
+                let desc = DisconnectDescription::ErrorInfo(e);
+                Ok(vec![ProcessorOutput::Disconnect(desc)])
+            }
+            ShareDataPdu::ShutdownDenied => {
+                debug!("ShutdownDenied received, session will be closed");
+
+                // As defined in [MS-RDPBCGR], when `ShareDataPdu::ShutdownDenied` is received, we
+                // need to send a disconnect ultimatum to the server if we want to proceed with the
+                // session shutdown.
+                //
+                // [MS-RDPBCGR]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/27915739-8f77-487e-9927-55008af7fd68
+                let ultimatum = McsMessage::DisconnectProviderUltimatum(DisconnectProviderUltimatum::from_reason(
+                    DisconnectReason::UserRequested,
+                ));
+
+                let encoded_pdu = ironrdp_core::encode_vec(&X224(ultimatum)).map_err(SessionError::encode);
+
+                Ok(vec![
+                    ProcessorOutput::ResponseFrame(encoded_pdu?),
+                    ProcessorOutput::Disconnect(DisconnectDescription::McsDisconnect(DisconnectReason::UserRequested)),
+                ])
+            }
+            ShareDataPdu::Update(data) => {
+                let data = Self::decompress_share_data(data, compression_flags, compression_type, bulk_decompressor)?;
+                debug!("Got slow-path graphics update ({} bytes)", data.len());
+                Ok(vec![ProcessorOutput::GraphicsUpdate(data)])
+            }
+            ShareDataPdu::Pointer(data) => {
+                let data = Self::decompress_share_data(data, compression_flags, compression_type, bulk_decompressor)?;
+                debug!("Got slow-path pointer update ({} bytes)", data.len());
+                Ok(vec![ProcessorOutput::PointerUpdate(data)])
+            }
+            pdu => Err(reason_err!("IO channel", "unhandled PDU: {:?}", pdu.as_short_name())),
         }
     }
 
@@ -349,6 +355,9 @@ fn process_svc_messages(messages: Vec<SvcMessage>, channel_id: u16, initiator_id
 #[cfg(test)]
 mod tests {
     use ironrdp_bulk::{CompressionType as BulkCompressionType, flags};
+    use ironrdp_core::encode_vec;
+    use ironrdp_pdu::rdp::headers::ShareDataPduType;
+    use ironrdp_pdu::rdp::session_info::{InfoData, InfoType, SaveSessionInfoPdu};
 
     use super::*;
 
@@ -389,5 +398,40 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn processor_decompresses_compressed_save_session_info() {
+        let session_info = SaveSessionInfoPdu {
+            info_type: InfoType::PlainNotify,
+            info_data: InfoData::PlainNotify,
+        };
+        let source = encode_vec(&session_info).expect("encode save session info");
+        let mut compressor = BulkCompressor::new(BulkCompressionType::Rdp5);
+        let (compressed_size, flags) = compressor.compress(&source).expect("source should compress");
+        assert_ne!(flags & flags::PACKET_COMPRESSED, 0, "test data must be compressed");
+        let compressed = compressor.compressed_data(compressed_size).to_vec();
+        let mut bulk_decompressor = Some(BulkCompressor::new(BulkCompressionType::Rdp5));
+        let compression_flags = CompressionFlags::from_bits_retain(
+            u8::try_from(flags & !flags::COMPRESSION_TYPE_MASK).expect("bulk flags should fit in a byte"),
+        );
+        let outputs = Processor::process_share_data(
+            ShareDataCtx {
+                initiator_id: 0,
+                channel_id: 0,
+                share_id: 0,
+                pdu_source: 0,
+                compression_flags,
+                compression_type: CompressionType::K64,
+                pdu: ShareDataPdu::Compressed {
+                    pdu_type: ShareDataPduType::SaveSessionInfo,
+                    data: compressed,
+                },
+            },
+            &mut bulk_decompressor,
+        )
+        .expect("compressed save session info should be processed");
+
+        assert!(outputs.is_empty());
     }
 }

--- a/crates/ironrdp-testsuite-core/tests/session/autodetect.rs
+++ b/crates/ironrdp-testsuite-core/tests/session/autodetect.rs
@@ -22,6 +22,11 @@ fn make_processor() -> Processor {
     )
 }
 
+fn process_frame(processor: &mut Processor, frame: &[u8]) -> Vec<ironrdp_session::x224::ProcessorOutput> {
+    let mut bulk_decompressor = None;
+    processor.process(frame, &mut bulk_decompressor).expect("process frame")
+}
+
 /// Encode an Auto-Detect Request as a server-to-client SendDataIndication on the
 /// MCS message channel ([MS-RDPBCGR] 2.2.14.3): the auto-detect data is framed by
 /// a Basic Security Header (SEC_AUTODETECT_REQ), not a Share Data header.
@@ -44,7 +49,7 @@ fn rtt_request_produces_response_frame() {
     let request = AutoDetectRequest::rtt_continuous(42);
     let frame = encode_server_autodetect(request);
 
-    let outputs = processor.process(&frame).unwrap();
+    let outputs = process_frame(&mut processor, &frame);
 
     assert_eq!(outputs.len(), 1);
     match &outputs[0] {
@@ -62,7 +67,7 @@ fn rtt_response_preserves_sequence_number() {
     let request = AutoDetectRequest::rtt_connect_time(sequence_number);
     let frame = encode_server_autodetect(request);
 
-    let outputs = processor.process(&frame).unwrap();
+    let outputs = process_frame(&mut processor, &frame);
 
     assert_eq!(outputs.len(), 1);
     let ironrdp_session::x224::ProcessorOutput::ResponseFrame(response_data) = &outputs[0] else {
@@ -97,7 +102,7 @@ fn network_characteristics_result_surfaces_as_autodetect() {
     let request = AutoDetectRequest::netchar_result(7, 10, 50000, 20);
     let frame = encode_server_autodetect(request.clone());
 
-    let outputs = processor.process(&frame).unwrap();
+    let outputs = process_frame(&mut processor, &frame);
 
     assert_eq!(outputs.len(), 1);
     match &outputs[0] {
@@ -114,7 +119,7 @@ fn bandwidth_measure_start_does_not_crash() {
     let request = AutoDetectRequest::bw_start_connect_time(100);
     let frame = encode_server_autodetect(request);
 
-    let outputs = processor.process(&frame).unwrap();
+    let outputs = process_frame(&mut processor, &frame);
     assert!(outputs.is_empty(), "BW start should produce no output");
 }
 
@@ -124,7 +129,7 @@ fn bandwidth_measure_stop_does_not_crash() {
     let request = AutoDetectRequest::bw_stop_continuous(200);
     let frame = encode_server_autodetect(request);
 
-    let outputs = processor.process(&frame).unwrap();
+    let outputs = process_frame(&mut processor, &frame);
     assert!(outputs.is_empty(), "BW stop should produce no output");
 }
 
@@ -134,6 +139,6 @@ fn bandwidth_measure_payload_does_not_crash() {
     let request = AutoDetectRequest::bw_payload(300, vec![0xAA; 64]);
     let frame = encode_server_autodetect(request);
 
-    let outputs = processor.process(&frame).unwrap();
+    let outputs = process_frame(&mut processor, &frame);
     assert!(outputs.is_empty(), "BW payload should produce no output");
 }

--- a/crates/ironrdp-testsuite-core/tests/session/fast_path.rs
+++ b/crates/ironrdp-testsuite-core/tests/session/fast_path.rs
@@ -11,9 +11,7 @@ use ironrdp_bulk::{BulkCompressor, CompressionType as BulkCompressionType, flags
 use ironrdp_core::{WriteBuf, encode_vec};
 use ironrdp_graphics::image_processing::PixelFormat;
 use ironrdp_pdu::bitmap::{BitmapData, BitmapUpdateData, Compression};
-use ironrdp_pdu::fast_path::{
-    Compression as FpCompression, EncryptionFlags, FastPathHeader, FastPathUpdatePdu, Fragmentation, UpdateCode,
-};
+use ironrdp_pdu::fast_path::{EncryptionFlags, FastPathHeader, FastPathUpdatePdu, Fragmentation, UpdateCode};
 use ironrdp_pdu::geometry::InclusiveRectangle;
 use ironrdp_pdu::rdp::client_info::CompressionType as PduCompressionType;
 use ironrdp_pdu::rdp::headers::CompressionFlags;
@@ -108,7 +106,7 @@ fn compressed_fastpath_update_decompresses_like_its_uncompressed_twin() {
     );
     let compressed_data = compressor.compressed_data(size).to_vec();
 
-    let mut compressed_pdu = encode_vec(&FastPathUpdatePdu {
+    let compressed_pdu = encode_vec(&FastPathUpdatePdu {
         fragmentation: Fragmentation::Single,
         update_code: UpdateCode::Bitmap,
         // Carry the compressor's control bits (notably PACKET_AT_FRONT) so the
@@ -120,11 +118,6 @@ fn compressed_fastpath_update_decompresses_like_its_uncompressed_twin() {
         data: &compressed_data,
     })
     .expect("encode compressed FastPath update");
-    // `FastPathUpdatePdu::encode` writes the update header byte before it sets the
-    // COMPRESSION_USED bit, so the encoded header does not flag the trailing
-    // compression byte. Set it here so the PDU decodes as compressed (idempotent
-    // if the encoder is corrected).
-    compressed_pdu[0] |= FpCompression::COMPRESSION_USED.bits() << 6;
     let compressed = fastpath_frame(&compressed_pdu);
 
     let from_uncompressed = render(&uncompressed);
@@ -144,4 +137,82 @@ fn compressed_fastpath_update_decompresses_like_its_uncompressed_twin() {
         blank.data(),
         "the bitmap update should have modified the framebuffer"
     );
+}
+
+#[test]
+fn fragmented_compressed_fastpath_update_decompresses_before_reassembly() {
+    let payload = bitmap_update_payload();
+    let split = payload.len() / 2;
+    let mut sender = BulkCompressor::new(BulkCompressionType::Rdp5);
+
+    let (first_size, first_flags) = sender.compress(&payload[..split]).expect("compress first fragment");
+    assert_ne!(
+        first_flags & bulk_flags::PACKET_COMPRESSED,
+        0,
+        "first fragment must compress"
+    );
+    let first_data = sender.compressed_data(first_size).to_vec();
+    let first = fastpath_frame(
+        &encode_vec(&FastPathUpdatePdu {
+            fragmentation: Fragmentation::First,
+            update_code: UpdateCode::Bitmap,
+            compression_flags: Some(CompressionFlags::from_bits_retain(
+                u8::try_from(first_flags & 0xe0).expect("control-flag byte fits in u8"),
+            )),
+            compression_type: Some(PduCompressionType::K64),
+            data: &first_data,
+        })
+        .expect("encode first FastPath fragment"),
+    );
+
+    let (last_size, last_flags) = sender.compress(&payload[split..]).expect("compress last fragment");
+    assert_ne!(
+        last_flags & bulk_flags::PACKET_COMPRESSED,
+        0,
+        "last fragment must compress"
+    );
+    let last_data = sender.compressed_data(last_size).to_vec();
+    let last = fastpath_frame(
+        &encode_vec(&FastPathUpdatePdu {
+            fragmentation: Fragmentation::Last,
+            update_code: UpdateCode::Bitmap,
+            compression_flags: Some(CompressionFlags::from_bits_retain(
+                u8::try_from(last_flags & 0xe0).expect("control-flag byte fits in u8"),
+            )),
+            compression_type: Some(PduCompressionType::K64),
+            data: &last_data,
+        })
+        .expect("encode last FastPath fragment"),
+    );
+
+    let uncompressed = fastpath_frame(
+        &encode_vec(&FastPathUpdatePdu {
+            fragmentation: Fragmentation::Single,
+            update_code: UpdateCode::Bitmap,
+            compression_flags: None,
+            compression_type: None,
+            data: &payload,
+        })
+        .expect("encode uncompressed FastPath update"),
+    );
+    let expected = render(&uncompressed);
+
+    let mut image = DecodedImage::new(PixelFormat::RgbA32, IMAGE_DIM, IMAGE_DIM);
+    let mut output = WriteBuf::new();
+    let mut bulk_decompressor = Some(BulkCompressor::new(BulkCompressionType::Rdp5));
+    let mut processor = processor();
+
+    assert!(
+        processor
+            .process(&mut image, &first, &mut output, &mut bulk_decompressor)
+            .expect("process first FastPath fragment")
+            .is_empty()
+    );
+    assert!(
+        !processor
+            .process(&mut image, &last, &mut output, &mut bulk_decompressor)
+            .expect("process last FastPath fragment")
+            .is_empty()
+    );
+    assert_eq!(image.data(), expected.data());
 }

--- a/crates/ironrdp-testsuite-core/tests/session/fast_path.rs
+++ b/crates/ironrdp-testsuite-core/tests/session/fast_path.rs
@@ -75,8 +75,9 @@ fn fastpath_frame(update_pdu: &[u8]) -> Vec<u8> {
 fn render(frame: &[u8]) -> DecodedImage {
     let mut image = DecodedImage::new(PixelFormat::RgbA32, IMAGE_DIM, IMAGE_DIM);
     let mut output = WriteBuf::new();
+    let mut bulk_decompressor = Some(BulkCompressor::new(BulkCompressionType::Rdp5));
     processor()
-        .process(&mut image, frame, &mut output)
+        .process(&mut image, frame, &mut output, &mut bulk_decompressor)
         .expect("process FastPath frame");
     image
 }

--- a/crates/ironrdp-testsuite-extra/tests/e2e.rs
+++ b/crates/ironrdp-testsuite-extra/tests/e2e.rs
@@ -138,6 +138,7 @@ fn test_reactivation_processes_compressed_fastpath_updates() {
         io_channel_id: 1003,
         message_channel_id: None,
         share_id: 1,
+        compression_type: Some(PduCompressionType::K64),
         enable_server_pointer: false,
         pointer_software_rendering: false,
     }
@@ -461,6 +462,7 @@ where
                     io_channel_id: connection_result.io_channel_id,
                     message_channel_id: connection_result.message_channel_id,
                     share_id: connection_result.share_id,
+                    compression_type: connection_result.compression_type,
                     enable_server_pointer: connection_result.enable_server_pointer,
                     pointer_software_rendering: connection_result.pointer_software_rendering,
                 }

--- a/crates/ironrdp-testsuite-extra/tests/e2e.rs
+++ b/crates/ironrdp-testsuite-extra/tests/e2e.rs
@@ -131,7 +131,7 @@ async fn test_deactivation_reactivation() {
 }
 
 #[test]
-fn test_reactivation_processes_compressed_fastpath_updates() {
+fn test_reactivation_preserves_bulk_decompression_history() {
     let mut stage = ActiveStageBuilder {
         static_channels: StaticChannelSet::new(),
         user_channel_id: 1001,
@@ -143,12 +143,28 @@ fn test_reactivation_processes_compressed_fastpath_updates() {
         pointer_software_rendering: false,
     }
     .build();
-    stage.reactivate(1003, 1001, 2, false, false);
 
     let mut image = DecodedImage::new(PixelFormat::RgbA32, 4, 4);
+    let mut compressor = BulkCompressor::new(BulkCompressionType::Rdp5);
+    let (first_frame, first_flags) = compressed_bitmap_fastpath_frame(&mut compressor);
+    assert_ne!(first_flags & bulk_flags::PACKET_COMPRESSED, 0);
+
+    stage
+        .process(&mut image, pdu::Action::FastPath, &first_frame)
+        .expect("compressed FastPath update before reactivation");
+
+    stage.reactivate(1003, 1001, 2, false, false);
+
+    let (second_frame, second_flags) = compressed_bitmap_fastpath_frame(&mut compressor);
+    assert_ne!(second_flags & bulk_flags::PACKET_COMPRESSED, 0);
+    assert_eq!(
+        second_flags & (bulk_flags::PACKET_FLUSHED | bulk_flags::PACKET_AT_FRONT),
+        0
+    );
+
     let outputs = stage
-        .process(&mut image, pdu::Action::FastPath, &compressed_bitmap_fastpath_frame())
-        .expect("compressed FastPath update after reactivation");
+        .process(&mut image, pdu::Action::FastPath, &second_frame)
+        .expect("compressed FastPath update referencing pre-reactivation history");
 
     assert!(
         outputs
@@ -157,7 +173,7 @@ fn test_reactivation_processes_compressed_fastpath_updates() {
     );
 }
 
-fn compressed_bitmap_fastpath_frame() -> Vec<u8> {
+fn compressed_bitmap_fastpath_frame(compressor: &mut BulkCompressor) -> (Vec<u8>, u32) {
     let bitmap = BitmapUpdateData {
         rectangles: vec![BitmapData {
             rectangle: InclusiveRectangle {
@@ -176,9 +192,7 @@ fn compressed_bitmap_fastpath_frame() -> Vec<u8> {
     };
     let bitmap_data = ironrdp::core::encode_vec(&bitmap).expect("encode bitmap update");
 
-    let mut compressor = BulkCompressor::new(BulkCompressionType::Rdp5);
     let (compressed_size, flags) = compressor.compress(&bitmap_data).expect("compress bitmap update");
-    assert_ne!(flags & bulk_flags::PACKET_COMPRESSED, 0);
 
     let compressed_data = compressor.compressed_data(compressed_size);
     let update = FastPathUpdatePdu {
@@ -194,7 +208,7 @@ fn compressed_bitmap_fastpath_frame() -> Vec<u8> {
 
     let mut frame = ironrdp::core::encode_vec(&header).expect("encode FastPath header");
     frame.extend(ironrdp::core::encode_vec(&update).expect("encode FastPath update"));
-    frame
+    (frame, flags)
 }
 
 #[tokio::test]

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -669,6 +669,7 @@ impl iron_remote_desktop::Session for Session {
             io_channel_id: connection_result.io_channel_id,
             message_channel_id: connection_result.message_channel_id,
             share_id: connection_result.share_id,
+            compression_type: connection_result.compression_type,
             enable_server_pointer: connection_result.enable_server_pointer,
             pointer_software_rendering: connection_result.pointer_software_rendering,
         }

--- a/crates/ironrdp/examples/screenshot.rs
+++ b/crates/ironrdp/examples/screenshot.rs
@@ -350,6 +350,7 @@ fn active_stage(
         io_channel_id: connection_result.io_channel_id,
         message_channel_id: connection_result.message_channel_id,
         share_id: connection_result.share_id,
+        compression_type: connection_result.compression_type,
         enable_server_pointer: connection_result.enable_server_pointer,
         pointer_software_rendering: connection_result.pointer_software_rendering,
     }

--- a/ffi/src/session/mod.rs
+++ b/ffi/src/session/mod.rs
@@ -55,6 +55,7 @@ pub mod ffi {
                 io_channel_id: connection_result.io_channel_id,
                 message_channel_id: connection_result.message_channel_id,
                 share_id: connection_result.share_id,
+                compression_type: connection_result.compression_type,
                 enable_server_pointer: connection_result.enable_server_pointer,
                 pointer_software_rendering: connection_result.pointer_software_rendering,
             }


### PR DESCRIPTION
Bulk compression state is stream-wide, but Fast-Path and slow-path outputs previously used separate or missing decompression paths. This could corrupt history-dependent server updates or leave negotiated slow-path compression undecodable.

This change owns the negotiated bulk decompressor in `ActiveStage` and passes it to both X.224 and Fast-Path processing. It retains Share Data compression metadata through the PDU context, resets decompression history on reactivation, and initializes consumers from the connection's negotiated compression type.

Fast-Path now decompresses each fragment before reassembly so compression flags apply at packet boundaries. Failures expose bounded protocol metadata without retaining remote payloads or decoder details.

Tests cover Share Data metadata propagation, slow-path decompression behavior, fragmented Fast-Path reassembly and bounded errors, and compressed Fast-Path updates after reactivation.