### PR TITLE
fix(graphics): decode indexed pointers and foreground RLE runs

### DIFF
--- a/crates/ironrdp-graphics/src/pointer.rs
+++ b/crates/ironrdp-graphics/src/pointer.rs
@@ -12,7 +12,7 @@
 //! mask is used co control pixel's full transparency (`src_color.a = 0`), full opacity
 //! (`src_color.a = 255`) or pixel inversion (`dst_color.rgb = vec3(255) - dst_color.rgb`).
 //!
-//! Xor basks could be 1, 8, 16, 24 or 32 bits per pixel, and andMask is always 1 bit per pixel.
+//! XOR masks can be 1, 4, 8, 16, 24, or 32 bits per pixel, and andMask is always 1 bit per pixel.
 //!
 //! Rules for decoding masks:
 //! - `andMask == 0` -> dst_color Copy pixel from xorMask
@@ -24,7 +24,7 @@ use ironrdp_pdu::pointer::{ColorPointerAttribute, LargePointerAttribute, Pointer
 
 use crate::color_conversion::rdp_16bit_to_rgb;
 
-const SUPPORTED_COLOR_BPP: [u16; 4] = [1, 16, 24, 32];
+const SUPPORTED_COLOR_BPP: [u16; 6] = [1, 4, 8, 16, 24, 32];
 
 #[derive(Debug)]
 pub enum PointerError {
@@ -130,6 +130,15 @@ impl DecodedPointer {
         src: &PointerAttribute<'_>,
         target: PointerBitmapTarget,
     ) -> Result<Self, PointerError> {
+        Self::decode_pointer_attribute_with_palette(src, target, None)
+    }
+
+    /// Decode a New Pointer Update using the session color palette for indexed XOR pixels.
+    pub fn decode_pointer_attribute_with_palette(
+        src: &PointerAttribute<'_>,
+        target: PointerBitmapTarget,
+        palette: Option<&[[u8; 3]; 256]>,
+    ) -> Result<Self, PointerError> {
         Self::decode_pointer(
             PointerData {
                 width: src.color_pointer.width,
@@ -141,6 +150,7 @@ impl DecodedPointer {
                 hot_spot_y: src.color_pointer.hot_spot.y,
             },
             target,
+            palette,
         )
     }
 
@@ -159,12 +169,22 @@ impl DecodedPointer {
                 hot_spot_y: src.hot_spot.y,
             },
             target,
+            None,
         )
     }
 
     pub fn decode_large_pointer_attribute(
         src: &LargePointerAttribute<'_>,
         target: PointerBitmapTarget,
+    ) -> Result<Self, PointerError> {
+        Self::decode_large_pointer_attribute_with_palette(src, target, None)
+    }
+
+    /// Decode a Large Pointer Update using the session color palette for indexed XOR pixels.
+    pub fn decode_large_pointer_attribute_with_palette(
+        src: &LargePointerAttribute<'_>,
+        target: PointerBitmapTarget,
+        palette: Option<&[[u8; 3]; 256]>,
     ) -> Result<Self, PointerError> {
         Self::decode_pointer(
             PointerData {
@@ -177,17 +197,20 @@ impl DecodedPointer {
                 hot_spot_y: src.hot_spot.y,
             },
             target,
+            palette,
         )
     }
 
-    fn decode_pointer(data: PointerData<'_>, target: PointerBitmapTarget) -> Result<Self, PointerError> {
+    fn decode_pointer(
+        data: PointerData<'_>,
+        target: PointerBitmapTarget,
+        palette: Option<&[[u8; 3]; 256]>,
+    ) -> Result<Self, PointerError> {
         if data.width == 0 || data.height == 0 {
             return Ok(Self::new_invisible());
         }
 
         if !SUPPORTED_COLOR_BPP.contains(&data.xor_bpp) {
-            // 8bpp indexed colors are not supported yet (palette messages are not implemented)
-            // Other unknown bpps are not supported either
             return Err(PointerError::NotSupportedBpp { bpp: data.xor_bpp });
         }
 
@@ -230,7 +253,7 @@ impl DecodedPointer {
                 (xor_stride_cursor, and_stride_cursor)
             };
 
-            let mut color_reader = ColorStrideReader::new(data.xor_bpp, xor_stride)?;
+            let mut color_reader = ColorStrideReader::new(data.xor_bpp, xor_stride, palette)?;
             let mut bitmask_reader = BitmaskStrideReader::new(and_stride);
 
             let compute_inverted_pixel = if target.should_invert_pixels_using_check_pattern() {
@@ -341,7 +364,7 @@ impl BitmaskStrideReader {
     }
 }
 
-enum ColorStrideReader {
+enum ColorStrideReader<'a> {
     Color {
         /// INVARIANT: `bpp == 16 || bpp == 24 || bpp == 32`
         bpp: u16,
@@ -349,13 +372,15 @@ enum ColorStrideReader {
         stride_data_bytes: usize,
         stride_padding: usize,
     },
+    Indexed(IndexedStrideReader<'a>),
     Bitmask(BitmaskStrideReader),
 }
 
-impl ColorStrideReader {
-    fn new(bpp: u16, stride: Stride) -> Result<Self, PointerError> {
+impl<'a> ColorStrideReader<'a> {
+    fn new(bpp: u16, stride: Stride, palette: Option<&'a [[u8; 3]; 256]>) -> Result<Self, PointerError> {
         Ok(match bpp {
             1 => Self::Bitmask(BitmaskStrideReader::new(stride)),
+            4 | 8 => Self::Indexed(IndexedStrideReader::new(bpp, stride, palette)?),
             bpp => Self::Color {
                 bpp: {
                     // Enforce the bpp == 16 || bpp == 24 || bpp == 32 invariant.
@@ -406,14 +431,74 @@ impl ColorStrideReader {
                     _ => unreachable!("per the invariant on self.bpp, this path is unreachable"),
                 }
             }
-            ColorStrideReader::Bitmask(bitask) => {
-                if bitask.next_bit(cursor) == 1 {
+            ColorStrideReader::Indexed(indexed) => {
+                let [r, g, b] = indexed.next_color(cursor);
+                [r, g, b, 0xff]
+            }
+            ColorStrideReader::Bitmask(bitmask) => {
+                if bitmask.next_bit(cursor) == 1 {
                     [0xff, 0xff, 0xff, 0xff]
                 } else {
                     [0, 0, 0, 0xff]
                 }
             }
         }
+    }
+}
+
+struct IndexedStrideReader<'a> {
+    bpp: u16,
+    palette: &'a [[u8; 3]; 256],
+    current_byte: u8,
+    next_high_nibble: bool,
+    read_stride_bytes: usize,
+    stride_data_bytes: usize,
+    stride_padding: usize,
+}
+
+impl<'a> IndexedStrideReader<'a> {
+    fn new(bpp: u16, stride: Stride, palette: Option<&'a [[u8; 3]; 256]>) -> Result<Self, PointerError> {
+        let palette = palette.ok_or(PointerError::NotSupportedBpp { bpp })?;
+
+        Ok(Self {
+            bpp,
+            palette,
+            current_byte: 0,
+            next_high_nibble: true,
+            read_stride_bytes: 0,
+            stride_data_bytes: stride.data_bytes,
+            stride_padding: stride.padding,
+        })
+    }
+
+    fn next_color(&mut self, cursor: &mut ReadCursor<'_>) -> [u8; 3] {
+        let index = match self.bpp {
+            8 => usize::from(self.read_next_byte(cursor)),
+            4 => {
+                if self.next_high_nibble {
+                    self.current_byte = self.read_next_byte(cursor);
+                    self.next_high_nibble = false;
+                    usize::from(self.current_byte >> 4)
+                } else {
+                    self.next_high_nibble = true;
+                    usize::from(self.current_byte & 0x0f)
+                }
+            }
+            _ => unreachable!("per the invariant on self.bpp, this path is unreachable"),
+        };
+
+        self.palette[index]
+    }
+
+    fn read_next_byte(&mut self, cursor: &mut ReadCursor<'_>) -> u8 {
+        if self.read_stride_bytes == self.stride_data_bytes {
+            self.read_stride_bytes = 0;
+            self.next_high_nibble = true;
+            cursor.read_slice(self.stride_padding);
+        }
+
+        self.read_stride_bytes += 1;
+        cursor.read_u8()
     }
 }
 
@@ -434,4 +519,62 @@ struct PointerData<'a> {
     and_mask: &'a [u8],
     hot_spot_x: u16,
     hot_spot_y: u16,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironrdp_pdu::pointer::Point16;
+
+    #[test]
+    fn decodes_indexed_new_pointer_with_palette() {
+        let mut palette = [[0u8; 3]; 256];
+        palette[1] = [0x10, 0x20, 0x30];
+        palette[2] = [0x40, 0x50, 0x60];
+        palette[3] = [0x70, 0x80, 0x90];
+
+        let pointer_8bpp = PointerAttribute {
+            xor_bpp: 8,
+            color_pointer: ColorPointerAttribute {
+                cache_index: 0,
+                hot_spot: Point16 { x: 0, y: 0 },
+                width: 2,
+                height: 1,
+                xor_mask: &[1, 2],
+                and_mask: &[0, 0],
+            },
+        };
+        let pointer_4bpp = PointerAttribute {
+            xor_bpp: 4,
+            color_pointer: ColorPointerAttribute {
+                cache_index: 1,
+                hot_spot: Point16 { x: 0, y: 0 },
+                width: 3,
+                height: 1,
+                xor_mask: &[0x12, 0x30],
+                and_mask: &[0, 0],
+            },
+        };
+
+        assert_eq!(
+            DecodedPointer::decode_pointer_attribute_with_palette(
+                &pointer_8bpp,
+                PointerBitmapTarget::Accelerated,
+                Some(&palette),
+            )
+            .expect("8bpp pointer should decode")
+            .bitmap_data,
+            vec![0x10, 0x20, 0x30, 0xff, 0x40, 0x50, 0x60, 0xff],
+        );
+        assert_eq!(
+            DecodedPointer::decode_pointer_attribute_with_palette(
+                &pointer_4bpp,
+                PointerBitmapTarget::Accelerated,
+                Some(&palette),
+            )
+            .expect("4bpp pointer should decode")
+            .bitmap_data,
+            vec![0x10, 0x20, 0x30, 0xff, 0x40, 0x50, 0x60, 0xff, 0x70, 0x80, 0x90, 0xff,],
+        );
+    }
 }

--- a/crates/ironrdp-graphics/src/rle.rs
+++ b/crates/ironrdp-graphics/src/rle.rs
@@ -259,9 +259,8 @@ fn decompress_impl<Mode: DepthMode>(src: &[u8], dst: &mut [u8], row_delta: usize
         {
             // Handle Foreground Run Orders.
 
-            ensure_size!(from: src, size: Mode::COLOR_DEPTH);
-
             if code == Code::LITE_SET_FG_FG_RUN || code == Code::MEGA_MEGA_SET_FG_RUN {
+                ensure_size!(from: src, size: Mode::COLOR_DEPTH);
                 fg_pel = Mode::read_pixel(&mut src);
             }
 
@@ -859,5 +858,17 @@ mod tests {
     #[test]
     fn buf_mut_24_bpp() {
         test_buf_mut!(Mode24Bpp);
+    }
+
+    #[test]
+    fn regular_foreground_run_does_not_consume_a_pixel() {
+        // [MS-RDPBCGR] 3.1.9 defines a regular foreground run entirely in
+        // its order header; only the set-foreground variants carry a pixel.
+        let mut output = Vec::new();
+
+        let format = decompress_16_bpp(&[0x22], &mut output, 1, 2).expect("regular foreground run");
+
+        assert_eq!(format, RlePixelFormat::Rgb16);
+        assert_eq!(output, [0xFF, 0xFF, 0xFF, 0xFF]);
     }
 }

--- a/crates/ironrdp-session/src/active_stage.rs
+++ b/crates/ironrdp-session/src/active_stage.rs
@@ -459,7 +459,7 @@ fn process_slow_path_graphics(
             Ok(Vec::new())
         }
         GraphicsUpdateType::Palette => {
-            warn!("Slow-path palette update not supported (8bpp)");
+            fast_path_processor.process_palette_update(data);
             Ok(Vec::new())
         }
         // Synchronize is an artifact from the T.128 multipoint protocol
@@ -480,4 +480,54 @@ fn process_slow_path_pointer(
     let mut src = ReadCursor::new(data);
     let pointer = slow_path::decode_slow_path_pointer(&mut src).map_err(SessionError::decode)?;
     fast_path_processor.process_pointer_update(image, pointer)
+}
+
+#[cfg(test)]
+mod tests {
+    use ironrdp_graphics::image_processing::PixelFormat;
+    use ironrdp_pdu::pointer::{ColorPointerAttribute, Point16, PointerAttribute, PointerUpdateData};
+
+    use super::*;
+
+    #[test]
+    fn slow_path_palette_applies_to_indexed_pointer() {
+        let mut palette_data = vec![0; 8 + 256 * 3];
+        palette_data[0..2].copy_from_slice(&0x0002u16.to_le_bytes());
+        palette_data[4..8].copy_from_slice(&256u32.to_le_bytes());
+        palette_data[8 + 3..8 + 6].copy_from_slice(&[0x10, 0x20, 0x30]);
+
+        let mut processor = fast_path::ProcessorBuilder {
+            io_channel_id: 0,
+            user_channel_id: 0,
+            share_id: 0,
+            enable_server_pointer: true,
+            pointer_software_rendering: false,
+        }
+        .build();
+        let mut image = DecodedImage::new(PixelFormat::RgbA32, 1, 1);
+
+        let palette_updates = process_slow_path_graphics(&mut processor, &mut image, &palette_data)
+            .expect("slow-path palette update should succeed");
+        assert!(palette_updates.is_empty());
+
+        let pointer = PointerAttribute {
+            xor_bpp: 8,
+            color_pointer: ColorPointerAttribute {
+                cache_index: 0,
+                hot_spot: Point16 { x: 0, y: 0 },
+                width: 1,
+                height: 1,
+                xor_mask: &[1, 0],
+                and_mask: &[0, 0],
+            },
+        };
+        let pointer_updates = processor
+            .process_pointer_update(&mut image, PointerUpdateData::New(pointer))
+            .expect("indexed pointer should decode with slow-path palette");
+
+        let [UpdateKind::PointerBitmap(pointer)] = pointer_updates.as_slice() else {
+            panic!("expected an accelerated pointer bitmap");
+        };
+        assert_eq!(pointer.bitmap_data, [0x10, 0x20, 0x30, 0xff]);
+    }
 }

--- a/crates/ironrdp-session/src/fast_path.rs
+++ b/crates/ironrdp-session/src/fast_path.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use ironrdp_bulk::{BulkCompressor, CompressionType};
 use ironrdp_core::{DecodeErrorKind, ReadCursor, WriteBuf, decode_cursor};
 use ironrdp_graphics::image_processing::PixelFormat;
-use ironrdp_graphics::pointer::{DecodedPointer, PointerBitmapTarget};
+use ironrdp_graphics::pointer::{DecodedPointer, PointerBitmapTarget, PointerError};
 use ironrdp_graphics::rdp6::BitmapStreamDecoder;
 use ironrdp_graphics::rle::RlePixelFormat;
 use ironrdp_pdu::bitmap::BitmapUpdateData;
@@ -24,6 +24,7 @@ use crate::{SessionError, SessionErrorExt as _, SessionResult, custom_err, reaso
 #[cfg(test)]
 mod tests {
     use ironrdp_pdu::bitmap::{BitmapData, Compression};
+    use ironrdp_pdu::pointer::{ColorPointerAttribute, Point16, PointerAttribute};
 
     use super::*;
 
@@ -75,6 +76,40 @@ mod tests {
         assert_eq!(pixel(1, 1), [1, 2, 3, 255]);
         assert_eq!(pixel(2, 1), [4, 5, 6, 255]);
         assert_eq!(pixel(3, 0), [0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn unsupported_new_pointer_uses_default_and_evicts_cached_shape() {
+        let mut processor = ProcessorBuilder {
+            io_channel_id: 0,
+            user_channel_id: 0,
+            share_id: 0,
+            enable_server_pointer: true,
+            pointer_software_rendering: false,
+        }
+        .build();
+        processor
+            .pointer_cache
+            .insert(0, Arc::new(DecodedPointer::new_invisible()));
+        let mut image = DecodedImage::new(PixelFormat::RgbA32, 4, 3);
+        let pointer = PointerAttribute {
+            xor_bpp: 2,
+            color_pointer: ColorPointerAttribute {
+                cache_index: 0,
+                hot_spot: Point16 { x: 0, y: 0 },
+                width: 1,
+                height: 1,
+                xor_mask: &[],
+                and_mask: &[],
+            },
+        };
+
+        let updates = processor
+            .process_pointer_update(&mut image, PointerUpdateData::New(pointer))
+            .expect("unsupported pointer must not fail the session");
+
+        assert!(matches!(updates.as_slice(), [UpdateKind::PointerDefault]));
+        assert!(!processor.pointer_cache.is_cached(0));
     }
 
     /// The decompressor is owned by the library, but a session that never receives a
@@ -540,10 +575,17 @@ impl Processor {
             PointerUpdateData::New(pointer) => {
                 let cache_index = pointer.color_pointer.cache_index;
 
-                let decoded_pointer = Arc::new(
-                    DecodedPointer::decode_pointer_attribute(&pointer, bitmap_target)
-                        .map_err(|e| SessionError::custom("failed to decode pointer attribute", e))?,
-                );
+                let decoded_pointer = match DecodedPointer::decode_pointer_attribute_with_palette(
+                    &pointer,
+                    bitmap_target,
+                    Some(self.palette.colors()),
+                ) {
+                    Ok(pointer) => Arc::new(pointer),
+                    Err(error) => {
+                        self.fallback_after_pointer_decode_failure(image, &mut processor_updates, cache_index, error)?;
+                        return Ok(processor_updates);
+                    }
+                };
 
                 let _ = self
                     .pointer_cache
@@ -558,10 +600,17 @@ impl Processor {
             PointerUpdateData::Large(pointer) => {
                 let cache_index = pointer.cache_index;
 
-                let decoded_pointer: Arc<DecodedPointer> = Arc::new(
-                    DecodedPointer::decode_large_pointer_attribute(&pointer, bitmap_target)
-                        .map_err(|e| SessionError::custom("failed to decode large pointer attribute", e))?,
-                );
+                let decoded_pointer = match DecodedPointer::decode_large_pointer_attribute_with_palette(
+                    &pointer,
+                    bitmap_target,
+                    Some(self.palette.colors()),
+                ) {
+                    Ok(pointer) => Arc::new(pointer),
+                    Err(error) => {
+                        self.fallback_after_pointer_decode_failure(image, &mut processor_updates, cache_index, error)?;
+                        return Ok(processor_updates);
+                    }
+                };
 
                 let _ = self
                     .pointer_cache
@@ -576,6 +625,33 @@ impl Processor {
         };
 
         Ok(processor_updates)
+    }
+
+    fn fallback_after_pointer_decode_failure(
+        &mut self,
+        image: &mut DecodedImage,
+        processor_updates: &mut Vec<UpdateKind>,
+        cache_index: u16,
+        error: PointerError,
+    ) -> SessionResult<()> {
+        let error_kind = match error {
+            PointerError::InvalidXorMaskSize { .. } => "InvalidXorMaskSize",
+            PointerError::InvalidAndMaskSize { .. } => "InvalidAndMaskSize",
+            PointerError::NotSupportedBpp { .. } => "NotSupportedBpp",
+            PointerError::Pdu(_) => "Pdu",
+        };
+        warn!(pointer_error = error_kind, "Ignoring unsupported pointer update");
+        let _ = self.pointer_cache.remove(usize::from(cache_index));
+
+        if self.pointer_software_rendering && !self.use_system_pointer {
+            self.use_system_pointer = true;
+            if let Some(rect) = image.hide_pointer()? {
+                processor_updates.push(UpdateKind::Region(rect));
+            }
+        }
+
+        processor_updates.push(UpdateKind::PointerDefault);
+        Ok(())
     }
 
     fn process_surface_commands(

--- a/crates/ironrdp-session/src/fast_path.rs
+++ b/crates/ironrdp-session/src/fast_path.rs
@@ -301,7 +301,7 @@ impl Processor {
             }
             Ok(FastPathUpdate::Palette(palette_data)) => {
                 trace!("Received palette update");
-                self.palette.process_update(palette_data);
+                self.process_palette_update(palette_data);
             }
             Err(e) => {
                 // FIXME: This seems to be a way of special-handling the error case in FastPathUpdate::decode_cursor_with_code
@@ -317,6 +317,11 @@ impl Processor {
         };
 
         Ok(processor_updates)
+    }
+
+    /// Process a palette update shared between fast-path and slow-path pipelines.
+    pub(crate) fn process_palette_update(&mut self, palette_data: &[u8]) {
+        self.palette.process_update(palette_data);
     }
 
     /// Process a bitmap update, shared between fast-path and slow-path pipelines.

--- a/crates/ironrdp-session/src/fast_path.rs
+++ b/crates/ironrdp-session/src/fast_path.rs
@@ -112,6 +112,37 @@ mod tests {
         assert!(!processor.pointer_cache.is_cached(0));
     }
 
+    #[test]
+    fn malformed_color_pointer_uses_default_and_evicts_cached_shape() {
+        let mut processor = ProcessorBuilder {
+            io_channel_id: 0,
+            user_channel_id: 0,
+            share_id: 0,
+            enable_server_pointer: true,
+            pointer_software_rendering: false,
+        }
+        .build();
+        processor
+            .pointer_cache
+            .insert(0, Arc::new(DecodedPointer::new_invisible()));
+        let mut image = DecodedImage::new(PixelFormat::RgbA32, 4, 3);
+        let pointer = ColorPointerAttribute {
+            cache_index: 0,
+            hot_spot: Point16 { x: 0, y: 0 },
+            width: 1,
+            height: 1,
+            xor_mask: &[],
+            and_mask: &[],
+        };
+
+        let updates = processor
+            .process_pointer_update(&mut image, PointerUpdateData::Color(pointer))
+            .expect("malformed pointer must not fail the session");
+
+        assert!(matches!(updates.as_slice(), [UpdateKind::PointerDefault]));
+        assert!(!processor.pointer_cache.is_cached(0));
+    }
+
     /// The decompressor is owned by the library, but a session that never receives a
     /// compressed update should not pay for the algorithm contexts. `ironrdp-web` never
     /// negotiates compression, so this is its normal case.
@@ -540,10 +571,13 @@ impl Processor {
             PointerUpdateData::Color(pointer) => {
                 let cache_index = pointer.cache_index;
 
-                let decoded_pointer = Arc::new(
-                    DecodedPointer::decode_color_pointer_attribute(&pointer, bitmap_target)
-                        .map_err(|e| SessionError::custom("failed to decode color pointer attribute", e))?,
-                );
+                let decoded_pointer = match DecodedPointer::decode_color_pointer_attribute(&pointer, bitmap_target) {
+                    Ok(pointer) => Arc::new(pointer),
+                    Err(error) => {
+                        self.fallback_after_pointer_decode_failure(image, &mut processor_updates, cache_index, error)?;
+                        return Ok(processor_updates);
+                    }
+                };
 
                 let _ = self
                     .pointer_cache

--- a/crates/ironrdp-session/src/palette.rs
+++ b/crates/ironrdp-session/src/palette.rs
@@ -4,7 +4,7 @@ use tracing::{debug, warn};
 ///
 /// Initialized with the default Windows system palette (VGA colors)
 /// per MS-RDPBCGR 2.2.9.1.1.3.1.1. Updated by TS_UPDATE_PALETTE_DATA
-/// fast-path updates during the session.
+/// updates during the session.
 #[derive(Debug, Clone)]
 pub(crate) struct Palette {
     colors: [[u8; 3]; 256],
@@ -44,46 +44,70 @@ impl Palette {
     }
 
     /// Parse TS_UPDATE_PALETTE_DATA and update palette entries.
-    /// Wire format: pad(2) + numberColors(u32) + N x TS_COLOR_QUAD [B, G, R, pad].
+    /// Wire format: updateType(u16) + pad(u16) + numberColors(u32) + N x RGB triplet.
     pub(crate) fn process_update(&mut self, data: &[u8]) {
-        if data.len() < 6 {
+        const UPDATE_TYPE_PALETTE: u16 = 0x0002;
+        const PALETTE_ENTRY_COUNT: usize = 256;
+        const PALETTE_ENTRY_SIZE: usize = 3;
+
+        if data.len() < 8 {
             warn!("Palette update too short: {} bytes", data.len());
             return;
         }
 
-        let raw_count = u32::from_le_bytes([data[2], data[3], data[4], data[5]]);
-        // Palette can have at most 256 entries; clamp before any arithmetic
-        // to prevent overflow on untrusted input
-        let clamped = raw_count.min(256);
-        let number_colors = usize::try_from(clamped).unwrap_or(256);
-        let entry_data = &data[6..];
-
-        let Some(required_len) = number_colors.checked_mul(4) else {
-            warn!("Palette entry count overflow");
+        let update_type = u16::from_le_bytes([data[0], data[1]]);
+        if update_type != UPDATE_TYPE_PALETTE {
+            warn!(update_type, "Ignoring palette update with unexpected type");
             return;
-        };
+        }
 
+        let number_colors = u32::from_le_bytes([data[4], data[5], data[6], data[7]]);
+        if number_colors != 256 {
+            warn!(number_colors, "Ignoring palette update with unexpected entry count");
+            return;
+        }
+
+        let entry_data = &data[8..];
+        let required_len = PALETTE_ENTRY_COUNT * PALETTE_ENTRY_SIZE;
         if entry_data.len() < required_len {
             warn!(
                 "Palette data truncated: expected {} bytes for {} colors, got {}",
                 required_len,
-                number_colors,
+                PALETTE_ENTRY_COUNT,
                 entry_data.len()
             );
             return;
         }
 
-        for i in 0..number_colors {
-            let offset = i * 4;
-            // TS_COLOR_QUAD: Blue, Green, Red, Pad
-            self.colors[i] = [entry_data[offset + 2], entry_data[offset + 1], entry_data[offset]];
+        for (color, rgb) in self.colors.iter_mut().zip(entry_data.chunks_exact(PALETTE_ENTRY_SIZE)) {
+            *color = [rgb[0], rgb[1], rgb[2]];
         }
 
-        debug!("Updated palette with {} colors", number_colors);
+        debug!("Updated palette with {} colors", PALETTE_ENTRY_COUNT);
     }
 
     /// Borrow the underlying color table for bitmap application.
     pub(crate) fn colors(&self) -> &[[u8; 3]; 256] {
         &self.colors
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn processes_spec_palette_data() {
+        let mut data = vec![0; 8 + 256 * 3];
+        data[0..2].copy_from_slice(&0x0002u16.to_le_bytes());
+        data[4..8].copy_from_slice(&256u32.to_le_bytes());
+        data[8..11].copy_from_slice(&[0x10, 0x20, 0x30]);
+        data[11..14].copy_from_slice(&[0x40, 0x50, 0x60]);
+
+        let mut palette = Palette::system_default();
+        palette.process_update(&data);
+
+        assert_eq!(palette.colors()[0], [0x10, 0x20, 0x30]);
+        assert_eq!(palette.colors()[1], [0x40, 0x50, 0x60]);
     }
 }

--- a/crates/ironrdp-session/src/pointer.rs
+++ b/crates/ironrdp-session/src/pointer.rs
@@ -18,6 +18,10 @@ impl PointerCache {
         self.cache.get(&id).cloned()
     }
 
+    pub fn remove(&mut self, id: usize) -> Option<Arc<DecodedPointer>> {
+        self.cache.remove(&id)
+    }
+
     pub fn is_cached(&self, id: usize) -> bool {
         self.cache.contains_key(&id)
     }


### PR DESCRIPTION
## Summary

4bpp and 8bpp New/Large pointer shapes previously could not use the active session palette, and malformed or unsupported pointer data could terminate the session. This decodes indexed XOR masks with the current palette and falls back to the default cursor while evicting stale cached data when decoding fails.

It also corrects RLE foreground runs so only set-foreground variants consume a foreground pixel.

Palette updates now follow the RDP wire format (type, padding, 256 packed RGB triplets) and are applied from both fast- and slow-path updates, ensuring indexed pointer decoding uses the negotiated palette.

## Tests

- `cargo test -p ironrdp-graphics -p ironrdp-session`
- `cargo test -p ironrdp-session palette`
- `cargo clippy -p ironrdp-graphics -p ironrdp-session --all-targets -- -D warnings`