### PR TITLE
feat(client): expose generic session configuration and lifecycle APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2434,6 +2434,7 @@ dependencies = [
  "ironrdp-pdu",
  "ironrdp-propertyset",
  "ironrdp-rdpfile",
+ "ironrdp-tls",
  "libc",
  "now-client",
  "now-proto-pdu",

--- a/crates/ironrdp-agent/Cargo.toml
+++ b/crates/ironrdp-agent/Cargo.toml
@@ -35,6 +35,7 @@ ironrdp-propertyset = { path = "../ironrdp-propertyset", version = "0.1" }
 ironrdp-cfg = { path = "../ironrdp-cfg", version = "0.1" }
 ironrdp-rdpfile = { path = "../ironrdp-rdpfile", version = "0.1" }
 ironrdp-input = { path = "../ironrdp-input", version = "0.7" }
+ironrdp-tls = { path = "../ironrdp-tls", version = "0.2" }
 
 # Async runtime and IPC transport
 tokio = { version = "1", features = ["rt-multi-thread", "net", "sync", "macros", "io-util", "time", "signal"] }

--- a/crates/ironrdp-agent/src/cli.rs
+++ b/crates/ironrdp-agent/src/cli.rs
@@ -1187,6 +1187,9 @@ fn property_description(key: &str) -> Option<&'static str> {
         "ironrdp_rdpdr" => "enable the RDPDR device-redirection channel (0/1)",
         "ironrdp_smartcard" => "enable smart-card device redirection (0/1)",
         "ironrdp_tls" => "use plain TLS security instead of CredSSP/Hybrid (0/1)",
+        "ironrdp_certificate_validation" => {
+            "TLS certificate validation policy: strict or dangerously_accept_invalid_certificate (disables certificate and hostname validation; testing only)"
+        }
         "ironrdp_fakeeventsinterval" => "interval in minutes between synthetic keep-alive input events",
         "ironrdp_rdcleanpathtoken" => "RDCleanPath authentication token (secret)",
         "ironrdp_rdcleanpathurl" => "RDCleanPath proxy URL",

--- a/crates/ironrdp-agent/src/daemon.rs
+++ b/crates/ironrdp-agent/src/daemon.rs
@@ -13,6 +13,7 @@ use ironrdp_client::rdp::{RdpClient, RdpInputEvent, RdpInputSender, RdpOutputEve
 use ironrdp_input::{Database, MousePosition, Operation, Scancode, WheelRotations};
 use ironrdp_pdu::rdp::capability_sets::MajorPlatformType;
 use ironrdp_propertyset::{PropertySet, Value};
+use ironrdp_tls::CertificateValidation;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, trace, warn};
@@ -270,6 +271,21 @@ impl Daemon {
                 );
             }
         };
+        let certificate_validation = match properties.get::<&str>("ironrdp_certificate_validation") {
+            None | Some("strict") => CertificateValidation::Strict,
+            Some("dangerously_accept_invalid_certificate") => {
+                CertificateValidation::DangerouslyAcceptInvalidCertificate
+            }
+            Some(value) => {
+                return Response::typed_error(
+                    crate::ipc::AgentErrorCategory::InvalidRequest,
+                    format!(
+                        "invalid certificate validation policy '{value}'; expected 'strict' or 'dangerously_accept_invalid_certificate'"
+                    ),
+                );
+            }
+        };
+
         let builder = match ConfigBuilder::from_property_set(&properties) {
             Ok(builder) => builder,
             Err(error) => {
@@ -288,6 +304,7 @@ impl Daemon {
             .with_platform(current_platform())
             .with_client_name(client_name())
             .with_dvc_pipe_proxy(now_endpoint.dvc_proxy_info())
+            .with_certificate_validation(certificate_validation)
             // Headless: composite the remote cursor into the framebuffer so it appears in
             // screenshots (there is no separate overlay to draw it).
             .with_pointer_software_rendering(true);

--- a/crates/ironrdp-agent/src/daemon.rs
+++ b/crates/ironrdp-agent/src/daemon.rs
@@ -396,13 +396,15 @@ impl Daemon {
             Some(session) => {
                 let mut live = session.live.lock().expect("session live state poisoned");
                 match live.state {
-                    ConnState::Connecting | ConnState::Connected => {
-                        info!(destination = %session.destination, "Disconnecting RDP session");
-                        // Request a graceful shutdown and move to `Disconnecting`. The engine thread
-                        // keeps running until it drains the close; `consume_output` flips the state
-                        // to a terminal one once it does, which is what re-enables `connect`. Leaving
-                        // it `Connected` here would let a new `connect` race the still-live thread.
+                    ConnState::Connecting => {
+                        info!(destination = %session.destination, "Cancelling RDP connection");
                         session.input_tx.request_close();
+                        live.state = ConnState::Disconnecting;
+                        Response::ok()
+                    }
+                    ConnState::Connected => {
+                        info!(destination = %session.destination, "Disconnecting RDP session");
+                        session.input_tx.request_graceful_close();
                         live.state = ConnState::Disconnecting;
                         Response::ok()
                     }

--- a/crates/ironrdp-agent/src/daemon.rs
+++ b/crates/ironrdp-agent/src/daemon.rs
@@ -272,10 +272,10 @@ impl Daemon {
             }
         };
         let certificate_validation = match properties.get::<&str>("ironrdp_certificate_validation") {
-            None | Some("strict") => CertificateValidation::Strict,
-            Some("dangerously_accept_invalid_certificate") => {
+            None | Some("dangerously_accept_invalid_certificate") => {
                 CertificateValidation::DangerouslyAcceptInvalidCertificate
             }
+            Some("strict") => CertificateValidation::Strict,
             Some(value) => {
                 return Response::typed_error(
                     crate::ipc::AgentErrorCategory::InvalidRequest,

--- a/crates/ironrdp-agent/src/daemon.rs
+++ b/crates/ironrdp-agent/src/daemon.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::Context as _;
 use ironrdp_client::config::{ConfigBuilder, MissingField};
-use ironrdp_client::rdp::{RdpClient, RdpInputEvent, RdpOutputEvent};
+use ironrdp_client::rdp::{RdpClient, RdpInputEvent, RdpInputSender, RdpOutputEvent};
 use ironrdp_input::{Database, MousePosition, Operation, Scancode, WheelRotations};
 use ironrdp_pdu::rdp::capability_sets::MajorPlatformType;
 use ironrdp_propertyset::{PropertySet, Value};
@@ -132,7 +132,7 @@ struct Daemon {
 
 /// Per-session state owned by the request handler.
 struct Session {
-    input_tx: mpsc::UnboundedSender<RdpInputEvent>,
+    input_tx: RdpInputSender,
     input_db: Database,
     destination: String,
     live: Arc<Mutex<Live>>,
@@ -385,7 +385,7 @@ impl Daemon {
                         // keeps running until it drains the close; `consume_output` flips the state
                         // to a terminal one once it does, which is what re-enables `connect`. Leaving
                         // it `Connected` here would let a new `connect` race the still-live thread.
-                        let _ = session.input_tx.send(RdpInputEvent::Close);
+                        session.input_tx.request_close();
                         live.state = ConnState::Disconnecting;
                         Response::ok()
                     }
@@ -504,7 +504,7 @@ impl Daemon {
         let Some(session) = guard.as_ref() else {
             return Response::typed_error(crate::ipc::AgentErrorCategory::Unavailable, "no active session");
         };
-        match session.input_tx.send(RdpInputEvent::Resize {
+        match session.input_tx.try_send(RdpInputEvent::Resize {
             width,
             height,
             // No window/DPI concept in a headless agent: request the plain pixel size unscaled.
@@ -524,17 +524,21 @@ impl Daemon {
         let Some(session) = guard.as_mut() else {
             return Response::typed_error(crate::ipc::AgentErrorCategory::Unavailable, "no active session");
         };
+        let permit = match session.input_tx.try_reserve() {
+            Ok(permit) => permit,
+            Err(_) => {
+                return Response::typed_error(
+                    crate::ipc::AgentErrorCategory::Unavailable,
+                    "session input channel is unavailable",
+                );
+            }
+        };
         let events = session.input_db.apply([operation]);
         if events.is_empty() {
             return Response::ok();
         }
-        match session.input_tx.send(RdpInputEvent::FastPath(events)) {
-            Ok(()) => Response::ok(),
-            Err(_) => Response::typed_error(
-                crate::ipc::AgentErrorCategory::Unavailable,
-                "session input channel is closed",
-            ),
-        }
+        permit.send(RdpInputEvent::FastPath(events));
+        Response::ok()
     }
 
     fn operations(&self) -> Result<OperationManager, Response> {
@@ -679,6 +683,14 @@ async fn consume_output(mut output_rx: mpsc::Receiver<RdpOutputEvent>, live: Arc
         let mut guard = live.lock().expect("session live state poisoned");
         let previous = guard.state;
         match event {
+            RdpOutputEvent::Connected => {
+                guard.state = ConnState::Connected;
+                guard.error = None;
+                if previous != ConnState::Connected {
+                    info!("Session connected");
+                }
+            }
+            RdpOutputEvent::LoginComplete => {}
             RdpOutputEvent::Image { buffer, width, height } => {
                 let width = width.get();
                 let height = height.get();

--- a/crates/ironrdp-client/src/clipboard.rs
+++ b/crates/ironrdp-client/src/clipboard.rs
@@ -1,7 +1,7 @@
 use ironrdp_cliprdr::backend::{ClipboardMessage, ClipboardMessageProxy};
 use tracing::error;
 
-use crate::rdp::{RdpInputEvent, RdpInputSender};
+use crate::rdp::RdpInputSender;
 
 /// Shim that forwards CLIPRDR events into the `RdpInputEvent` channel.
 #[derive(Clone, Debug)]
@@ -17,10 +17,8 @@ impl ClientClipboardMessageProxy {
 
 impl ClipboardMessageProxy for ClientClipboardMessageProxy {
     fn send_clipboard_message(&self, message: ClipboardMessage) {
-        if self.tx.try_send(RdpInputEvent::Clipboard(message)).is_err() {
-            // Continuing after losing a clipboard protocol message can desynchronize the channel.
-            self.tx.request_close();
-            error!("Unable to enqueue clipboard message; cancelling RDP session");
+        if self.tx.send_clipboard(message).is_err() {
+            error!("Unable to enqueue clipboard message because the RDP session is closed");
         }
     }
 }

--- a/crates/ironrdp-client/src/clipboard.rs
+++ b/crates/ironrdp-client/src/clipboard.rs
@@ -1,25 +1,26 @@
 use ironrdp_cliprdr::backend::{ClipboardMessage, ClipboardMessageProxy};
-use tokio::sync::mpsc;
 use tracing::error;
 
-use crate::rdp::RdpInputEvent;
+use crate::rdp::{RdpInputEvent, RdpInputSender};
 
 /// Shim that forwards CLIPRDR events into the `RdpInputEvent` channel.
 #[derive(Clone, Debug)]
 pub(crate) struct ClientClipboardMessageProxy {
-    tx: mpsc::UnboundedSender<RdpInputEvent>,
+    tx: RdpInputSender,
 }
 
 impl ClientClipboardMessageProxy {
-    pub(crate) fn new(tx: mpsc::UnboundedSender<RdpInputEvent>) -> Self {
+    pub(crate) fn new(tx: RdpInputSender) -> Self {
         Self { tx }
     }
 }
 
 impl ClipboardMessageProxy for ClientClipboardMessageProxy {
     fn send_clipboard_message(&self, message: ClipboardMessage) {
-        if self.tx.send(RdpInputEvent::Clipboard(message)).is_err() {
-            error!("Failed to send clipboard message; receiver is closed");
+        if self.tx.try_send(RdpInputEvent::Clipboard(message)).is_err() {
+            // Continuing after losing a clipboard protocol message can desynchronize the channel.
+            self.tx.request_close();
+            error!("Unable to enqueue clipboard message; cancelling RDP session");
         }
     }
 }

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -1127,9 +1127,14 @@ impl ConfigBuilder {
     {
         let cb: StaticChannelFn = Arc::new(move |connector: &mut ironrdp_connector::ClientConnector, ps| {
             for processor in factory(ps) {
-                if !connector.attach_dynamic_static_channel(processor) {
-                    tracing::error!("Unable to register runtime-defined static channel: key space exhausted");
-                    break;
+                match connector.try_attach_dynamic_static_channel(processor) {
+                    Ok(()) => {}
+                    Err(ironrdp_connector::DynamicStaticChannelAttachError::ChannelLimitReached) => {
+                        tracing::error!("Unable to register runtime-defined static channel: key space exhausted");
+                    }
+                    Err(ironrdp_connector::DynamicStaticChannelAttachError::DuplicateChannelName) => {
+                        tracing::warn!("Unable to register runtime-defined static channel: duplicate channel name");
+                    }
                 }
             }
         });

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -566,16 +566,20 @@ pub struct ConfigBuilder {
     keyboard_type: Option<ironrdp_pdu::gcc::KeyboardType>,
     keyboard_subtype: Option<u32>,
     keyboard_functional_keys_count: Option<u32>,
+    keyboard_layout: Option<u32>,
+    connection_type: Option<ironrdp_pdu::gcc::ConnectionType>,
     ime_file_name: Option<String>,
     dig_product_id: Option<String>,
     desktop_width: Option<u16>,
     desktop_height: Option<u16>,
     desktop_scale_factor: Option<u32>,
     color_depth: Option<u32>,
+    lossy_compression: Option<bool>,
     codecs: Vec<String>,
     autologon: Option<bool>,
     enable_server_pointer: Option<bool>,
     pointer_software_rendering: Option<bool>,
+    performance_flags: Option<ironrdp_pdu::rdp::client_info::PerformanceFlags>,
     enable_audio_playback: Option<bool>,
     compression_type: Option<ironrdp_pdu::rdp::client_info::CompressionType>,
     compression_enabled: Option<bool>,
@@ -696,6 +700,20 @@ impl ConfigBuilder {
         self
     }
 
+    /// Set the keyboard layout (HKL) advertised in the GCC Client Core Data block.
+    #[must_use]
+    pub fn with_keyboard_layout(mut self, keyboard_layout: u32) -> Self {
+        self.keyboard_layout = Some(keyboard_layout);
+        self
+    }
+
+    /// Set the network profile advertised in the GCC Client Core Data block.
+    #[must_use]
+    pub fn with_connection_type(mut self, connection_type: ironrdp_pdu::gcc::ConnectionType) -> Self {
+        self.connection_type = Some(connection_type);
+        self
+    }
+
     #[must_use]
     pub fn with_ime_file_name(mut self, name: impl Into<String>) -> Self {
         self.ime_file_name = Some(name.into());
@@ -712,6 +730,13 @@ impl ConfigBuilder {
     pub fn with_color_depth(mut self, depth: u32) -> Self {
         self.color_depth = Some(depth);
         self.properties.set_color_depth(depth);
+        self
+    }
+
+    /// Permit dynamic color fidelity and chroma subsampling in RDP 6.0 bitmap updates.
+    #[must_use]
+    pub fn with_lossy_compression(mut self, enabled: bool) -> Self {
+        self.lossy_compression = Some(enabled);
         self
     }
 
@@ -777,6 +802,38 @@ impl ConfigBuilder {
         self
     }
 
+    /// Set the alternate shell to start after logon. Upserts the `alternate shell` property.
+    ///
+    /// An empty value clears the alternate shell and requests the server's normal user shell.
+    #[must_use]
+    pub fn with_alternate_shell(mut self, shell: impl Into<String>) -> Self {
+        let shell = shell.into();
+        if shell.is_empty() {
+            self.alternate_shell = None;
+            self.properties.clear_alternate_shell();
+        } else {
+            self.properties.set_alternate_shell(shell.clone());
+            self.alternate_shell = Some(shell);
+        }
+        self
+    }
+
+    /// Set the working directory for the alternate shell. Upserts the `shell working directory` property.
+    ///
+    /// An empty value clears the working directory.
+    #[must_use]
+    pub fn with_work_dir(mut self, work_dir: impl Into<String>) -> Self {
+        let work_dir = work_dir.into();
+        if work_dir.is_empty() {
+            self.work_dir = None;
+            self.properties.clear_shell_working_directory();
+        } else {
+            self.properties.set_shell_working_directory(work_dir.clone());
+            self.work_dir = Some(work_dir);
+        }
+        self
+    }
+
     /// Enable or disable TLS + Graphical login (legacy security protocol; also called SSL). Upserts
     /// the `ironrdp_tls` property.
     ///
@@ -831,6 +888,13 @@ impl ConfigBuilder {
     #[must_use]
     pub fn with_pointer_software_rendering(mut self, enabled: bool) -> Self {
         self.pointer_software_rendering = Some(enabled);
+        self
+    }
+
+    /// Set the Client Info PDU performance flags.
+    #[must_use]
+    pub fn with_performance_flags(mut self, flags: ironrdp_pdu::rdp::client_info::PerformanceFlags) -> Self {
+        self.performance_flags = Some(flags);
         self
     }
 
@@ -944,13 +1008,21 @@ impl ConfigBuilder {
     /// Enable or disable RDPSND (audio) playback.
     #[cfg(feature = "sound")]
     #[must_use]
-    pub fn with_sound(mut self, enabled: bool) -> Self {
-        self.channels.sound = enabled;
-        self.properties.set_audio_mode(if enabled {
+    pub fn with_sound(self, enabled: bool) -> Self {
+        self.with_audio_mode(if enabled {
             ironrdp_cfg::AudioMode::RedirectToClient
         } else {
             ironrdp_cfg::AudioMode::Disabled
-        });
+        })
+    }
+
+    /// Set the public RDP audio redirection mode.
+    #[cfg(feature = "sound")]
+    #[must_use]
+    pub fn with_audio_mode(mut self, mode: ironrdp_cfg::AudioMode) -> Self {
+        self.channels.sound = matches!(mode, ironrdp_cfg::AudioMode::RedirectToClient);
+        self.enable_audio_playback = Some(matches!(mode, ironrdp_cfg::AudioMode::RedirectToClient));
+        self.properties.set_audio_mode(mode);
         self
     }
 
@@ -1046,6 +1118,25 @@ impl ConfigBuilder {
         self
     }
 
+    /// Register a factory for multiple runtime-defined instances of one static-channel processor.
+    #[must_use]
+    pub fn with_static_channel_instances<P, F>(mut self, factory: F) -> Self
+    where
+        F: Fn(&PropertySet) -> Vec<P> + Send + Sync + 'static,
+        P: ironrdp_svc::SvcClientProcessor + 'static,
+    {
+        let cb: StaticChannelFn = Arc::new(move |connector: &mut ironrdp_connector::ClientConnector, ps| {
+            for processor in factory(ps) {
+                if !connector.attach_dynamic_static_channel(processor) {
+                    tracing::error!("Unable to register runtime-defined static channel: key space exhausted");
+                    break;
+                }
+            }
+        });
+        self.extensions.static_channels.push(cb);
+        self
+    }
+
     /// Register a factory for a user-defined dynamic virtual channel.
     ///
     /// `factory` is called once per connection attempt with the shared (read-only) [`PropertySet`],
@@ -1116,7 +1207,7 @@ impl ConfigBuilder {
     )]
     pub fn build(self) -> anyhow::Result<Config> {
         use ironrdp_pdu::rdp::capability_sets::client_codecs_capabilities;
-        use ironrdp_pdu::rdp::client_info::{PerformanceFlags, TimezoneInfo};
+        use ironrdp_pdu::rdp::client_info::TimezoneInfo;
 
         let missing = self.missing();
         if !missing.is_empty() {
@@ -1144,7 +1235,7 @@ impl ConfigBuilder {
         }
         let bitmap = ironrdp_connector::BitmapConfig {
             color_depth,
-            lossy_compression: true,
+            lossy_compression: self.lossy_compression.unwrap_or(true),
             codecs,
         };
 
@@ -1206,8 +1297,9 @@ impl ConfigBuilder {
                 .keyboard_type
                 .unwrap_or(ironrdp_pdu::gcc::KeyboardType::IbmEnhanced),
             keyboard_subtype: self.keyboard_subtype.unwrap_or(0),
-            keyboard_layout: 0,
+            keyboard_layout: self.keyboard_layout.unwrap_or(0),
             keyboard_functional_keys_count: self.keyboard_functional_keys_count.unwrap_or(12),
+            connection_type: self.connection_type.unwrap_or(ironrdp_pdu::gcc::ConnectionType::Lan),
             ime_file_name: self.ime_file_name.unwrap_or_default(),
             dig_product_id: self.dig_product_id.unwrap_or_default(),
             desktop_size: ironrdp_connector::DesktopSize {
@@ -1231,7 +1323,7 @@ impl ConfigBuilder {
             pointer_software_rendering: self.pointer_software_rendering.unwrap_or(false),
             multitransport_flags: None,
             compression_type,
-            performance_flags: PerformanceFlags::default(),
+            performance_flags: self.performance_flags.unwrap_or_default(),
             timezone_info: TimezoneInfo::default(),
             alternate_shell: self.alternate_shell.unwrap_or_default(),
             work_dir: self.work_dir.unwrap_or_default(),

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -1049,7 +1049,6 @@ async fn active_session(
     let disconnect_reason = 'outer: loop {
         let resize_deadline = resize_queue.deadline();
         let outputs = tokio::select! {
-            biased;
             _ = close_receiver.changed() => {
                 break 'outer GracefulDisconnectReason::UserInitiated;
             }
@@ -1316,7 +1315,7 @@ async fn active_session(
                         ));
                     }
                 }
-                ActiveStageOutput::SaveSessionInfo => {
+                ActiveStageOutput::SaveSessionInfo { logon_complete: true } => {
                     if !send_active_output_event(output_event_sender, RdpOutputEvent::LoginComplete, close_receiver)
                         .await?
                     {
@@ -1325,6 +1324,7 @@ async fn active_session(
                         ));
                     }
                 }
+                ActiveStageOutput::SaveSessionInfo { logon_complete: false } => {}
                 ActiveStageOutput::DeactivateAll => {
                     // Deactivation-Reactivation Sequence:
                     // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/dfc234ce-481a-4674-9a5d-2a7bafb14432

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -21,7 +21,7 @@ use ironrdp_pdu::input::mouse::PointerFlags;
 #[cfg(any(feature = "dvc-pipe-proxy", all(windows, feature = "dvc-com-plugin")))]
 use ironrdp_pdu::pdu_other_err;
 use ironrdp_session::image::DecodedImage;
-use ironrdp_session::{ActiveStageBuilder, ActiveStageOutput, GracefulDisconnectReason, SessionResult};
+use ironrdp_session::{ActiveStage, ActiveStageBuilder, ActiveStageOutput, GracefulDisconnectReason, SessionResult};
 use ironrdp_svc::SvcMessage;
 use ironrdp_tokio::reqwest::ReqwestNetworkClient;
 use ironrdp_tokio::{FramedWrite, single_sequence_step_read, split_tokio_framed};
@@ -118,7 +118,9 @@ pub const RDP_INPUT_EVENT_QUEUE_CAPACITY: usize = 128;
 #[derive(Clone, Debug)]
 pub struct RdpInputSender {
     input_sender: mpsc::Sender<RdpInputEvent>,
+    clipboard_sender: mpsc::UnboundedSender<RdpInputEvent>,
     close_sender: watch::Sender<bool>,
+    graceful_close_sender: watch::Sender<bool>,
 }
 
 impl RdpInputSender {
@@ -128,20 +130,34 @@ impl RdpInputSender {
     ///
     /// Panics if `capacity` is zero.
     pub fn channel(capacity: usize) -> (Self, mpsc::Receiver<RdpInputEvent>) {
-        let (sender, receiver, _) = Self::channel_with_close_signal(capacity);
+        let (sender, receiver, _, _, _) = Self::channel_with_close_signal(capacity);
         (sender, receiver)
     }
 
-    fn channel_with_close_signal(capacity: usize) -> (Self, mpsc::Receiver<RdpInputEvent>, watch::Receiver<bool>) {
+    fn channel_with_close_signal(
+        capacity: usize,
+    ) -> (
+        Self,
+        mpsc::Receiver<RdpInputEvent>,
+        mpsc::UnboundedReceiver<RdpInputEvent>,
+        watch::Receiver<bool>,
+        watch::Receiver<bool>,
+    ) {
         let (input_sender, input_receiver) = mpsc::channel(capacity);
+        let (clipboard_sender, clipboard_receiver) = mpsc::unbounded_channel();
         let (close_sender, close_receiver) = watch::channel(false);
+        let (graceful_close_sender, graceful_close_receiver) = watch::channel(false);
         (
             Self {
                 input_sender,
+                clipboard_sender,
                 close_sender,
+                graceful_close_sender,
             },
             input_receiver,
+            clipboard_receiver,
             close_receiver,
+            graceful_close_receiver,
         )
     }
 
@@ -158,9 +174,27 @@ impl RdpInputSender {
         self.input_sender.try_reserve()
     }
 
+    /// Enqueues a clipboard protocol message independently of ordinary bounded input.
+    ///
+    /// Clipboard messages form an ordered CLIPRDR transaction, so dropping one while applying
+    /// backpressure to keyboard and pointer input can desynchronize the clipboard channel.
+    #[cfg(feature = "clipboard")]
+    pub fn send_clipboard(&self, message: ClipboardMessage) -> Result<(), mpsc::error::SendError<RdpInputEvent>> {
+        self.clipboard_sender.send(RdpInputEvent::Clipboard(message))
+    }
+
     /// Requests immediate session cancellation, bypassing the bounded input queue.
     pub fn request_close(&self) {
         self.close_sender.send_replace(true);
+    }
+
+    /// Requests a graceful RDP shutdown after the connection becomes active.
+    ///
+    /// This bypasses the bounded input queue so a full queue cannot prevent the client from
+    /// sending the RDP Shutdown Request PDU. Use [`request_close`](Self::request_close) to
+    /// immediately cancel a connection attempt or active session instead.
+    pub fn request_graceful_close(&self) {
+        self.graceful_close_sender.send_replace(true);
     }
 }
 
@@ -239,21 +273,30 @@ pub struct RdpClient {
     output_event_sender: mpsc::Sender<RdpOutputEvent>,
     input_event_sender: RdpInputSender,
     input_event_receiver: mpsc::Receiver<RdpInputEvent>,
+    clipboard_event_receiver: mpsc::UnboundedReceiver<RdpInputEvent>,
     close_receiver: watch::Receiver<bool>,
+    graceful_close_receiver: watch::Receiver<bool>,
     #[cfg(feature = "clipboard")]
     cliprdr_backend_factory: Option<Box<dyn CliprdrBackendFactory + Send>>,
 }
 
 impl RdpClient {
     pub fn new(config: Config, output_event_sender: mpsc::Sender<RdpOutputEvent>) -> Self {
-        let (input_event_sender, input_event_receiver, close_receiver) =
-            RdpInputSender::channel_with_close_signal(RDP_INPUT_EVENT_QUEUE_CAPACITY);
+        let (
+            input_event_sender,
+            input_event_receiver,
+            clipboard_event_receiver,
+            close_receiver,
+            graceful_close_receiver,
+        ) = RdpInputSender::channel_with_close_signal(RDP_INPUT_EVENT_QUEUE_CAPACITY);
         Self {
             config,
             output_event_sender,
             input_event_sender,
             input_event_receiver,
+            clipboard_event_receiver,
             close_receiver,
+            graceful_close_receiver,
             #[cfg(feature = "clipboard")]
             cliprdr_backend_factory: None,
         }
@@ -439,7 +482,9 @@ impl RdpClient {
                 connection_result,
                 &self.output_event_sender,
                 &mut self.input_event_receiver,
+                &mut self.clipboard_event_receiver,
                 &mut self.close_receiver,
+                &mut self.graceful_close_receiver,
                 self.config.fake_events_interval,
             )
             .await
@@ -998,12 +1043,18 @@ enum RdpControlFlow {
     TerminatedGracefully(GracefulDisconnectReason),
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the active loop owns independent transport, input, clipboard, and cancellation sources"
+)]
 async fn active_session(
     framed: UpgradedFramed,
     connection_result: ConnectionResult,
     output_event_sender: &mpsc::Sender<RdpOutputEvent>,
     input_event_receiver: &mut mpsc::Receiver<RdpInputEvent>,
+    clipboard_event_receiver: &mut mpsc::UnboundedReceiver<RdpInputEvent>,
     close_receiver: &mut watch::Receiver<bool>,
+    graceful_close_receiver: &mut watch::Receiver<bool>,
     fake_events_interval: Option<Duration>,
 ) -> SessionResult<RdpControlFlow> {
     let (mut reader, mut writer) = split_tokio_framed(framed);
@@ -1039,40 +1090,81 @@ async fn active_session(
     let mut fake_events_interval =
         fake_events_interval.map(|interval| tokio::time::interval(core::cmp::max(interval, Duration::from_secs(1))));
     let mut resize_queue = ResizeQueue::default();
+    let mut graceful_shutdown_sent = false;
+    let mut initial_outputs = if *graceful_close_receiver.borrow_and_update() {
+        graceful_shutdown_sent = true;
+        Some(active_stage.graceful_shutdown()?)
+    } else {
+        None
+    };
 
     if *close_receiver.borrow_and_update() {
         return Ok(RdpControlFlow::TerminatedGracefully(
             GracefulDisconnectReason::UserInitiated,
         ));
     }
+    #[cfg(not(feature = "clipboard"))]
+    let _ = clipboard_event_receiver;
 
     let disconnect_reason = 'outer: loop {
         let resize_deadline = resize_queue.deadline();
-        let outputs = tokio::select! {
-            _ = close_receiver.changed() => {
-                break 'outer GracefulDisconnectReason::UserInitiated;
+        let clipboard_event = async {
+            #[cfg(feature = "clipboard")]
+            {
+                clipboard_event_receiver.recv().await
             }
-            frame = reader.read_pdu() => {
-                let (action, payload) = frame.map_err(|e| ironrdp_session::custom_err!("read frame", e))?;
-                trace!(?action, frame_length = payload.len(), "Frame received");
-                let mut outputs = active_stage.process(&mut image, action, &payload)?;
-                if active_stage.take_bitmap_recovery_request() {
-                    let redraw_frames = active_stage.request_full_redraw(
-                        image.width(),
-                        image.height(),
-                        refresh_rect_support,
-                        suppress_output_support,
-                    )?;
-                    outputs.extend(redraw_frames.into_iter().map(ActiveStageOutput::ResponseFrame));
+            #[cfg(not(feature = "clipboard"))]
+            {
+                core::future::pending::<Option<RdpInputEvent>>().await
+            }
+        };
+        let outputs = if let Some(outputs) = initial_outputs.take() {
+            outputs
+        } else {
+            tokio::select! {
+                _ = close_receiver.changed() => {
+                    break 'outer GracefulDisconnectReason::UserInitiated;
                 }
-                outputs
-            }
-            input_event = input_event_receiver.recv() => {
-                let input_event = input_event.ok_or_else(|| ironrdp_session::general_err!("GUI is stopped"))?;
+                _ = graceful_close_receiver.changed() => {
+                    if *graceful_close_receiver.borrow_and_update() && !graceful_shutdown_sent {
+                        graceful_shutdown_sent = true;
+                        active_stage.graceful_shutdown()?
+                    } else {
+                        Vec::new()
+                    }
+                }
+                frame = reader.read_pdu() => {
+                    let (action, payload) = frame.map_err(|e| ironrdp_session::custom_err!("read frame", e))?;
+                    trace!(?action, frame_length = payload.len(), "Frame received");
+                    let mut outputs = active_stage.process(&mut image, action, &payload)?;
+                    if active_stage.take_bitmap_recovery_request() {
+                        let redraw_frames = active_stage.request_full_redraw(
+                            image.width(),
+                            image.height(),
+                            refresh_rect_support,
+                            suppress_output_support,
+                        )?;
+                        outputs.extend(redraw_frames.into_iter().map(ActiveStageOutput::ResponseFrame));
+                    }
+                    outputs
+                }
+                clipboard_event = clipboard_event => {
+                    #[cfg(feature = "clipboard")]
+                    {
+                        let Some(RdpInputEvent::Clipboard(event)) = clipboard_event else {
+                            return Err(ironrdp_session::general_err!("clipboard event channel closed"));
+                        };
+                        process_clipboard_message(&mut active_stage, event)?
+                    }
+                    #[cfg(not(feature = "clipboard"))]
+                    unreachable!("clipboard receive is pending without the clipboard feature")
+                }
+                input_event = input_event_receiver.recv() => {
+                    let input_event = input_event.ok_or_else(|| ironrdp_session::general_err!("GUI is stopped"))?;
 
-                last_input = tokio::time::Instant::now();
+                    last_input = tokio::time::Instant::now();
 
-                match input_event {
+                    match input_event {
                     RdpInputEvent::Resize { width, height, scale_factor, physical_size } => {
                         trace!(width, height, "Resize event");
                         let width = u32::from(width);
@@ -1123,55 +1215,16 @@ async fn active_session(
                     }
                     #[cfg(feature = "clipboard")]
                     RdpInputEvent::Clipboard(event) => {
-                        if let Some(cliprdr_client) = active_stage.get_svc_processor_mut::<ironrdp_cliprdr::CliprdrClient>() {
-                            if let Some(svc_messages) = match event {
-                                ClipboardMessage::SendInitiateCopy(formats) => {
-                                    Some(cliprdr_client.initiate_copy(&formats)
-                                        .map_err(|e| ironrdp_session::custom_err!("CLIPRDR", e))?)
-                                }
-                                ClipboardMessage::SendInitiateFileCopy(files) => {
-                                    Some(cliprdr_client.initiate_file_copy(files)
-                                        .map_err(|e| ironrdp_session::custom_err!("CLIPRDR", e))?)
-                                }
-                                ClipboardMessage::SendFormatData(response) => {
-                                    Some(cliprdr_client.submit_format_data(response)
-                                        .map_err(|e| ironrdp_session::custom_err!("CLIPRDR", e))?)
-                                }
-                                ClipboardMessage::SendInitiatePaste(format) => {
-                                    Some(cliprdr_client.initiate_paste(format)
-                                        .map_err(|e| ironrdp_session::custom_err!("CLIPRDR", e))?)
-                                }
-                                ClipboardMessage::SendFileContentsRequest(request) => {
-                                    Some(cliprdr_client.request_file_contents(request)
-                                        .map_err(|e| ironrdp_session::custom_err!("CLIPRDR", e))?)
-                                }
-                                ClipboardMessage::SendFileContentsResponse(response) => {
-                                    Some(cliprdr_client.submit_file_contents(response)
-                                        .map_err(|e| ironrdp_session::custom_err!("CLIPRDR", e))?)
-                                }
-                                ClipboardMessage::Error(e) => {
-                                    error!("Clipboard backend error: {}", e);
-                                    None
-                                }
-                            } {
-                                let frame = active_stage.process_svc_processor_messages(svc_messages)?;
-                                vec![ActiveStageOutput::ResponseFrame(frame)]
-                            } else {
-                                Vec::new()
-                            }
-                        } else {
-                            warn!("Clipboard event received, but Cliprdr is not available");
-                            Vec::new()
-                        }
+                        process_clipboard_message(&mut active_stage, event)?
                     }
                     RdpInputEvent::SendDvcMessages { channel_id, messages } => {
                         trace!(channel_id, ?messages, "Send DVC messages");
                         let frame = active_stage.encode_dvc_messages(messages)?;
                         vec![ActiveStageOutput::ResponseFrame(frame)]
                     }
+                    }
                 }
-            }
-            _ = cleanup_interval.tick() => {
+                _ = cleanup_interval.tick() => {
                 // Drive clipboard lock timeout cleanup.
                 #[cfg(feature = "clipboard")]
                 if let Some(cliprdr_client) = active_stage.get_svc_processor_mut::<ironrdp_cliprdr::CliprdrClient>() {
@@ -1194,13 +1247,13 @@ async fn active_session(
                 }
                 #[cfg(not(feature = "clipboard"))]
                 Vec::new()
-            }
-            _ = async {
+                }
+                _ = async {
                 match resize_deadline {
                     Some(deadline) => tokio::time::sleep_until(deadline).await,
                     None => core::future::pending().await,
                 }
-            } => {
+                } => {
                 let (request, reason) = resize_queue
                     .timed_out_request(tokio::time::Instant::now())
                     .expect("resize deadline must correspond to a queued request");
@@ -1209,11 +1262,11 @@ async fn active_session(
                     height: request.height,
                     reason,
                 });
-            }
-            _ = async { match fake_events_interval.as_mut() {
+                }
+                _ = async { match fake_events_interval.as_mut() {
                 Some(interval) => interval.tick().await,
                 None => core::future::pending().await,
-            }} => {
+                }} => {
                 // Anti-idle: synthesize a no-op mouse move if the session has been idle for at least
                 // the configured interval, keeping the connection alive without user interaction.
                 if last_input.elapsed() >= fake_events_interval.as_ref().map_or(Duration::MAX, |i| i.period()) {
@@ -1228,6 +1281,7 @@ async fn active_session(
                     active_stage.process_fastpath_input(&mut image, &events)?
                 } else {
                     Vec::new()
+                }
                 }
             }
         };
@@ -1459,6 +1513,61 @@ async fn active_session(
     Ok(RdpControlFlow::TerminatedGracefully(disconnect_reason))
 }
 
+#[cfg(feature = "clipboard")]
+fn process_clipboard_message(
+    active_stage: &mut ActiveStage,
+    event: ClipboardMessage,
+) -> SessionResult<Vec<ActiveStageOutput>> {
+    let Some(cliprdr_client) = active_stage.get_svc_processor_mut::<ironrdp_cliprdr::CliprdrClient>() else {
+        warn!("Clipboard event received, but Cliprdr is not available");
+        return Ok(Vec::new());
+    };
+
+    let svc_messages = match event {
+        ClipboardMessage::SendInitiateCopy(formats) => Some(
+            cliprdr_client
+                .initiate_copy(&formats)
+                .map_err(|e| ironrdp_session::custom_err!("CLIPRDR", e))?,
+        ),
+        ClipboardMessage::SendInitiateFileCopy(files) => Some(
+            cliprdr_client
+                .initiate_file_copy(files)
+                .map_err(|e| ironrdp_session::custom_err!("CLIPRDR", e))?,
+        ),
+        ClipboardMessage::SendFormatData(response) => Some(
+            cliprdr_client
+                .submit_format_data(response)
+                .map_err(|e| ironrdp_session::custom_err!("CLIPRDR", e))?,
+        ),
+        ClipboardMessage::SendInitiatePaste(format) => Some(
+            cliprdr_client
+                .initiate_paste(format)
+                .map_err(|e| ironrdp_session::custom_err!("CLIPRDR", e))?,
+        ),
+        ClipboardMessage::SendFileContentsRequest(request) => Some(
+            cliprdr_client
+                .request_file_contents(request)
+                .map_err(|e| ironrdp_session::custom_err!("CLIPRDR", e))?,
+        ),
+        ClipboardMessage::SendFileContentsResponse(response) => Some(
+            cliprdr_client
+                .submit_file_contents(response)
+                .map_err(|e| ironrdp_session::custom_err!("CLIPRDR", e))?,
+        ),
+        ClipboardMessage::Error(error) => {
+            error!("Clipboard backend error: {error}");
+            None
+        }
+    };
+
+    let Some(svc_messages) = svc_messages else {
+        return Ok(Vec::new());
+    };
+
+    let frame = active_stage.process_svc_processor_messages(svc_messages)?;
+    Ok(vec![ActiveStageOutput::ResponseFrame(frame)])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1506,7 +1615,7 @@ mod tests {
 
     #[test]
     fn input_sender_bounds_events_but_close_bypasses_the_queue() {
-        let (sender, mut receiver, mut close_receiver) = RdpInputSender::channel_with_close_signal(1);
+        let (sender, mut receiver, _, mut close_receiver, _) = RdpInputSender::channel_with_close_signal(1);
         sender
             .try_send(RdpInputEvent::Resize {
                 width: 1024,
@@ -1533,6 +1642,31 @@ mod tests {
     }
 
     #[test]
+    fn graceful_close_bypasses_the_input_queue_without_cancelling_the_session() {
+        let (sender, mut receiver, _, close_receiver, mut graceful_close_receiver) =
+            RdpInputSender::channel_with_close_signal(1);
+        sender
+            .try_send(RdpInputEvent::Resize {
+                width: 1024,
+                height: 768,
+                scale_factor: 100,
+                physical_size: None,
+            })
+            .expect("the first event fits");
+
+        sender.request_graceful_close();
+
+        assert!(!close_receiver.has_changed().expect("close sender is alive"));
+        assert!(
+            graceful_close_receiver
+                .has_changed()
+                .expect("graceful close sender is alive")
+        );
+        assert!(*graceful_close_receiver.borrow_and_update());
+        assert!(matches!(receiver.try_recv(), Ok(RdpInputEvent::Resize { .. })));
+    }
+
+    #[test]
     fn input_sender_reservation_prevents_state_changes_without_queue_capacity() {
         let (sender, mut receiver) = RdpInputSender::channel(1);
         let permit = sender.try_reserve().expect("the empty queue has capacity");
@@ -1546,6 +1680,31 @@ mod tests {
         });
 
         assert!(matches!(receiver.try_recv(), Ok(RdpInputEvent::Resize { .. })));
+    }
+
+    #[cfg(feature = "clipboard")]
+    #[test]
+    fn clipboard_messages_bypass_the_bounded_input_queue() {
+        let (sender, _, mut clipboard_receiver, _, _) = RdpInputSender::channel_with_close_signal(1);
+        sender
+            .try_send(RdpInputEvent::Resize {
+                width: 1024,
+                height: 768,
+                scale_factor: 100,
+                physical_size: None,
+            })
+            .expect("the first event fits");
+
+        sender
+            .send_clipboard(ClipboardMessage::Error(Box::new(std::io::Error::other(
+                "test clipboard message",
+            ))))
+            .expect("clipboard messages use a dedicated queue");
+
+        assert!(matches!(
+            clipboard_receiver.try_recv(),
+            Ok(RdpInputEvent::Clipboard(ClipboardMessage::Error(_)))
+        ));
     }
 
     #[tokio::test]

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -3,6 +3,8 @@ use core::num::NonZeroU16;
 use core::time::Duration;
 use std::sync::Arc;
 
+#[cfg(feature = "clipboard")]
+pub use ironrdp_cliprdr::backend::CliprdrBackendFactory;
 use ironrdp_connector::connection_activation::ConnectionActivationState;
 use ironrdp_connector::{ConnectionResult, ConnectorResult};
 use ironrdp_core::WriteBuf;
@@ -26,7 +28,7 @@ use ironrdp_tokio::{FramedWrite, single_sequence_step_read, split_tokio_framed};
 use smallvec::SmallVec;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::TcpStream;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 #[cfg(any(feature = "clipboard", all(windows, feature = "dvc-com-plugin")))]
 use tracing::error;
 #[cfg(feature = "clipboard")]
@@ -36,7 +38,7 @@ use tracing::{debug, info, trace};
 #[cfg(feature = "clipboard")]
 use crate::config::ClipboardType;
 #[cfg(feature = "clipboard")]
-use ironrdp_cliprdr::backend::{ClipboardMessage, CliprdrBackendFactory};
+use ironrdp_cliprdr::backend::ClipboardMessage;
 #[cfg(all(windows, feature = "dvc-com-plugin"))]
 use ironrdp_dvc_com_plugin::load_dvc_plugin;
 #[cfg(feature = "dvc-pipe-proxy")]
@@ -48,8 +50,25 @@ use crate::config::{Config, RDCleanPathConfig, Transport};
 
 // ── Public event types ────────────────────────────────────────────────────────
 
+/// Explains why a dynamic display update must reconnect instead of completing in-session.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DisplayResizeFallbackReason {
+    /// Display Control is not configured or its dynamic channel became unavailable.
+    DisplayControlUnavailable,
+    /// The server did not send the required Display Control capabilities PDU in time.
+    CapabilitiesTimedOut,
+    /// The server did not reactivate the session after a monitor-layout request in time.
+    ReactivationTimedOut,
+}
+
 #[derive(Debug)]
 pub enum RdpOutputEvent {
+    /// Connection negotiation and activation have completed.
+    Connected,
+    /// Server Save Session Info notification.
+    ///
+    /// The PDU can contain sensitive session data, so this event does not expose its contents.
+    LoginComplete,
     Image {
         buffer: Vec<u32>,
         width: NonZeroU16,
@@ -63,6 +82,10 @@ pub enum RdpOutputEvent {
         y: u16,
     },
     PointerBitmap(Arc<DecodedPointer>),
+    /// Dynamic Display Control could not update the session in place.
+    ///
+    /// The next connection attempt uses the requested desktop size.
+    DisplayResizeFallback(DisplayResizeFallbackReason),
     Terminated(SessionResult<GracefulDisconnectReason>),
 }
 
@@ -85,33 +108,178 @@ pub enum RdpInputEvent {
     },
 }
 
+/// Maximum number of ordinary input events retained while the session is unable to process them.
+pub const RDP_INPUT_EVENT_QUEUE_CAPACITY: usize = 128;
+
+/// Sends input to an [`RdpClient`] without allowing an unbounded queue to accumulate.
+///
+/// [`Self::request_close`] is independent of this bounded queue, so a host can always cancel a
+/// connection attempt or active session even when ordinary input is backpressured.
+#[derive(Clone, Debug)]
+pub struct RdpInputSender {
+    input_sender: mpsc::Sender<RdpInputEvent>,
+    close_sender: watch::Sender<bool>,
+}
+
+impl RdpInputSender {
+    /// Creates a bounded input queue for integration tests.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `capacity` is zero.
+    pub fn channel(capacity: usize) -> (Self, mpsc::Receiver<RdpInputEvent>) {
+        let (sender, receiver, _) = Self::channel_with_close_signal(capacity);
+        (sender, receiver)
+    }
+
+    fn channel_with_close_signal(capacity: usize) -> (Self, mpsc::Receiver<RdpInputEvent>, watch::Receiver<bool>) {
+        let (input_sender, input_receiver) = mpsc::channel(capacity);
+        let (close_sender, close_receiver) = watch::channel(false);
+        (
+            Self {
+                input_sender,
+                close_sender,
+            },
+            input_receiver,
+            close_receiver,
+        )
+    }
+
+    /// Attempts to enqueue ordinary input without blocking the calling thread.
+    pub fn try_send(&self, event: RdpInputEvent) -> Result<(), mpsc::error::TrySendError<RdpInputEvent>> {
+        self.input_sender.try_send(event)
+    }
+
+    /// Reserves capacity for ordinary input without blocking.
+    ///
+    /// Callers that maintain local input state can reserve first, then update that state only after
+    /// the input event is guaranteed to fit in the bounded queue.
+    pub fn try_reserve(&self) -> Result<mpsc::Permit<'_, RdpInputEvent>, mpsc::error::TrySendError<()>> {
+        self.input_sender.try_reserve()
+    }
+
+    /// Requests immediate session cancellation, bypassing the bounded input queue.
+    pub fn request_close(&self) {
+        self.close_sender.send_replace(true);
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ResizeRequest {
+    width: u16,
+    height: u16,
+    scale_factor: u32,
+    physical_size: Option<(u32, u32)>,
+}
+
+struct TimedResizeRequest {
+    request: ResizeRequest,
+    deadline: tokio::time::Instant,
+}
+
+const DISPLAY_CONTROL_READY_TIMEOUT: Duration = Duration::from_secs(3);
+
+#[derive(Default)]
+struct ResizeQueue {
+    in_flight: Option<TimedResizeRequest>,
+    pending: Option<TimedResizeRequest>,
+}
+
+impl ResizeQueue {
+    fn deadline(&self) -> Option<tokio::time::Instant> {
+        match (self.in_flight.as_ref(), self.pending.as_ref()) {
+            (Some(in_flight), Some(pending)) => Some(core::cmp::min(in_flight.deadline, pending.deadline)),
+            (Some(in_flight), None) => Some(in_flight.deadline),
+            (None, Some(pending)) => Some(pending.deadline),
+            (None, None) => None,
+        }
+    }
+
+    fn defer(&mut self, request: ResizeRequest) {
+        self.pending = Some(TimedResizeRequest {
+            request,
+            deadline: tokio::time::Instant::now() + DISPLAY_CONTROL_READY_TIMEOUT,
+        });
+    }
+
+    fn mark_in_flight(&mut self, request: ResizeRequest) {
+        self.in_flight = Some(TimedResizeRequest {
+            request,
+            deadline: tokio::time::Instant::now() + DISPLAY_CONTROL_READY_TIMEOUT,
+        });
+    }
+
+    fn completed(&mut self) {
+        self.in_flight = None;
+    }
+
+    fn timed_out_request(&self, now: tokio::time::Instant) -> Option<(ResizeRequest, DisplayResizeFallbackReason)> {
+        if let Some(in_flight) = self.in_flight.as_ref()
+            && now >= in_flight.deadline
+        {
+            return Some((
+                self.pending
+                    .as_ref()
+                    .map_or(in_flight.request, |pending| pending.request),
+                DisplayResizeFallbackReason::ReactivationTimedOut,
+            ));
+        }
+
+        self.pending
+            .as_ref()
+            .filter(|pending| now >= pending.deadline)
+            .map(|pending| (pending.request, DisplayResizeFallbackReason::CapabilitiesTimedOut))
+    }
+}
+
 // ── RdpClient ─────────────────────────────────────────────────────────────────
 
 pub struct RdpClient {
     config: Config,
     output_event_sender: mpsc::Sender<RdpOutputEvent>,
-    input_event_sender: mpsc::UnboundedSender<RdpInputEvent>,
-    input_event_receiver: mpsc::UnboundedReceiver<RdpInputEvent>,
+    input_event_sender: RdpInputSender,
+    input_event_receiver: mpsc::Receiver<RdpInputEvent>,
+    close_receiver: watch::Receiver<bool>,
+    #[cfg(feature = "clipboard")]
+    cliprdr_backend_factory: Option<Box<dyn CliprdrBackendFactory + Send>>,
 }
 
 impl RdpClient {
     pub fn new(config: Config, output_event_sender: mpsc::Sender<RdpOutputEvent>) -> Self {
-        let (input_event_sender, input_event_receiver) = mpsc::unbounded_channel();
+        let (input_event_sender, input_event_receiver, close_receiver) =
+            RdpInputSender::channel_with_close_signal(RDP_INPUT_EVENT_QUEUE_CAPACITY);
         Self {
             config,
             output_event_sender,
             input_event_sender,
             input_event_receiver,
+            close_receiver,
+            #[cfg(feature = "clipboard")]
+            cliprdr_backend_factory: None,
         }
+    }
+
+    /// Supplies a CLIPRDR backend whose owner remains on the embedding application's event-loop
+    /// thread for the lifetime of this client.
+    #[cfg(feature = "clipboard")]
+    #[must_use]
+    pub fn with_cliprdr_backend_factory(mut self, factory: Box<dyn CliprdrBackendFactory + Send>) -> Self {
+        self.cliprdr_backend_factory = Some(factory);
+        self
     }
 
     /// Return a clone of the input-event sender for injecting keyboard, mouse, and clipboard
     /// events from the GUI thread.
-    pub fn input_sender(&self) -> mpsc::UnboundedSender<RdpInputEvent> {
+    pub fn input_sender(&self) -> RdpInputSender {
         self.input_event_sender.clone()
     }
 
     pub async fn run(mut self) {
+        if *self.close_receiver.borrow_and_update() {
+            self.emit_user_initiated_termination();
+            return;
+        }
+
         // ── Clipboard initialisation (compile-time gated) ─────────────────────
         //
         // On Windows the WinClipboard object must outlive the entire connection loop, so we
@@ -129,15 +297,23 @@ impl RdpClient {
 
         #[cfg(feature = "clipboard")]
         {
-            match self.config.channels.clipboard {
-                ClipboardType::Disable => {
+            let host_factory = self.cliprdr_backend_factory.take();
+            match (self.config.channels.clipboard, host_factory) {
+                (ClipboardType::Enable, Some(factory)) => {
+                    cliprdr_factory = Some(factory);
+                    #[cfg(windows)]
+                    {
+                        _win_clipboard = None;
+                    }
+                }
+                (ClipboardType::Disable, _) => {
                     cliprdr_factory = None;
                     #[cfg(windows)]
                     {
                         _win_clipboard = None;
                     }
                 }
-                ClipboardType::Stub => {
+                (ClipboardType::Stub, _) => {
                     use ironrdp_cliprdr_native::StubClipboard;
                     let stub = StubClipboard::new();
                     cliprdr_factory = Some(stub.backend_factory());
@@ -146,7 +322,7 @@ impl RdpClient {
                         _win_clipboard = None;
                     }
                 }
-                ClipboardType::Enable => {
+                (ClipboardType::Enable, None) => {
                     #[cfg(windows)]
                     {
                         use crate::clipboard::ClientClipboardMessageProxy;
@@ -188,77 +364,160 @@ impl RdpClient {
 
         // ── Connection + session loop ─────────────────────────────────────────
         loop {
+            if *self.close_receiver.borrow_and_update() {
+                self.emit_user_initiated_termination();
+                break;
+            }
+
             let (connection_result, framed) = match &self.config.transport {
-                Transport::Direct => {
-                    match connect_direct(&self.config, &self.input_event_sender, cliprdr_factory).await {
-                        Ok(r) => r,
-                        Err(e) => {
-                            let _ = self
-                                .output_event_sender
-                                .send(RdpOutputEvent::ConnectionFailure(e))
-                                .await;
-                            break;
+                Transport::Direct => match Box::pin(cancelable_operation(
+                    connect_direct(&self.config, &self.input_event_sender, cliprdr_factory),
+                    &mut self.close_receiver,
+                ))
+                .await
+                {
+                    Some(Ok(result)) => result,
+                    Some(Err(error)) => {
+                        if !self.send_output_event(RdpOutputEvent::ConnectionFailure(error)).await {
+                            self.emit_user_initiated_termination();
                         }
+                        break;
                     }
-                }
+                    None => {
+                        self.emit_user_initiated_termination();
+                        break;
+                    }
+                },
 
                 #[cfg(feature = "gateway")]
-                Transport::Gateway(gw) => {
-                    match connect_gateway(&self.config, gw, &self.input_event_sender, cliprdr_factory).await {
-                        Ok(r) => r,
-                        Err(e) => {
-                            let _ = self
-                                .output_event_sender
-                                .send(RdpOutputEvent::ConnectionFailure(e))
-                                .await;
-                            break;
+                Transport::Gateway(gw) => match Box::pin(cancelable_operation(
+                    connect_gateway(&self.config, gw, &self.input_event_sender, cliprdr_factory),
+                    &mut self.close_receiver,
+                ))
+                .await
+                {
+                    Some(Ok(result)) => result,
+                    Some(Err(error)) => {
+                        if !self.send_output_event(RdpOutputEvent::ConnectionFailure(error)).await {
+                            self.emit_user_initiated_termination();
                         }
+                        break;
                     }
-                }
+                    None => {
+                        self.emit_user_initiated_termination();
+                        break;
+                    }
+                },
 
-                Transport::RDCleanPath(rdcp) => {
-                    match connect_rdcleanpath_transport(&self.config, rdcp, &self.input_event_sender, cliprdr_factory)
-                        .await
-                    {
-                        Ok(r) => r,
-                        Err(e) => {
-                            let _ = self
-                                .output_event_sender
-                                .send(RdpOutputEvent::ConnectionFailure(e))
-                                .await;
-                            break;
+                Transport::RDCleanPath(rdcp) => match Box::pin(cancelable_operation(
+                    connect_rdcleanpath_transport(&self.config, rdcp, &self.input_event_sender, cliprdr_factory),
+                    &mut self.close_receiver,
+                ))
+                .await
+                {
+                    Some(Ok(result)) => result,
+                    Some(Err(error)) => {
+                        if !self.send_output_event(RdpOutputEvent::ConnectionFailure(error)).await {
+                            self.emit_user_initiated_termination();
                         }
+                        break;
                     }
-                }
+                    None => {
+                        self.emit_user_initiated_termination();
+                        break;
+                    }
+                },
             };
+
+            if !self.send_output_event(RdpOutputEvent::Connected).await {
+                self.emit_user_initiated_termination();
+                break;
+            }
 
             match active_session(
                 framed,
                 connection_result,
                 &self.output_event_sender,
                 &mut self.input_event_receiver,
+                &mut self.close_receiver,
                 self.config.fake_events_interval,
             )
             .await
             {
-                Ok(RdpControlFlow::ReconnectWithNewSize { width, height }) => {
+                Ok(RdpControlFlow::ReconnectWithNewSize { width, height, reason }) => {
+                    if !self
+                        .send_output_event(RdpOutputEvent::DisplayResizeFallback(reason))
+                        .await
+                    {
+                        self.emit_user_initiated_termination();
+                        break;
+                    }
                     self.config.connector.desktop_size.width = width;
                     self.config.connector.desktop_size.height = height;
                 }
                 Ok(RdpControlFlow::TerminatedGracefully(reason)) => {
-                    let _ = self
-                        .output_event_sender
-                        .send(RdpOutputEvent::Terminated(Ok(reason)))
-                        .await;
+                    if !self.send_output_event(RdpOutputEvent::Terminated(Ok(reason))).await {
+                        self.emit_user_initiated_termination();
+                    }
                     break;
                 }
                 Err(e) => {
-                    let _ = self.output_event_sender.send(RdpOutputEvent::Terminated(Err(e))).await;
+                    if !self.send_output_event(RdpOutputEvent::Terminated(Err(e))).await {
+                        self.emit_user_initiated_termination();
+                    }
                     break;
                 }
             }
         }
     }
+
+    async fn send_output_event(&mut self, event: RdpOutputEvent) -> bool {
+        send_cancellable_output_event(&self.output_event_sender, event, &mut self.close_receiver)
+            .await
+            .unwrap_or(false)
+    }
+
+    fn emit_user_initiated_termination(&self) {
+        let _ = self
+            .output_event_sender
+            .try_send(RdpOutputEvent::Terminated(Ok(GracefulDisconnectReason::UserInitiated)));
+    }
+}
+
+async fn cancelable_operation<T>(
+    operation: impl Future<Output = T>,
+    close_receiver: &mut watch::Receiver<bool>,
+) -> Option<T> {
+    if *close_receiver.borrow_and_update() {
+        return None;
+    }
+
+    tokio::select! {
+        biased;
+        _ = close_receiver.changed() => None,
+        result = operation => Some(result),
+    }
+}
+
+async fn send_cancellable_output_event(
+    output_event_sender: &mpsc::Sender<RdpOutputEvent>,
+    event: RdpOutputEvent,
+    close_receiver: &mut watch::Receiver<bool>,
+) -> Result<bool, mpsc::error::SendError<RdpOutputEvent>> {
+    match cancelable_operation(output_event_sender.send(event), close_receiver).await {
+        Some(result) => result.map(|()| true),
+        None => Ok(false),
+    }
+}
+
+async fn send_active_output_event(
+    output_event_sender: &mpsc::Sender<RdpOutputEvent>,
+    event: RdpOutputEvent,
+    close_receiver: &mut watch::Receiver<bool>,
+) -> SessionResult<bool> {
+    send_cancellable_output_event(output_event_sender, event, close_receiver)
+        .await
+        .map_err(|error| ironrdp_session::custom_err!("output_event_sender", error))
 }
 
 // ── Connector builder ─────────────────────────────────────────────────────────
@@ -279,7 +538,7 @@ type CliprdrFactoryRef<'a> = core::marker::PhantomData<&'a ()>;
 fn build_connector(
     config: &Config,
     client_addr: SocketAddr,
-    input_sender: &mpsc::UnboundedSender<RdpInputEvent>,
+    input_sender: &RdpInputSender,
     cliprdr_factory: CliprdrFactoryRef<'_>,
 ) -> ironrdp_connector::ClientConnector {
     // `input_sender` is only consumed by the optional DVC wirings below, and `cliprdr_factory`
@@ -305,7 +564,7 @@ fn build_connector(
             &pipe_name,
             move |channel_id, messages| {
                 sender
-                    .send(RdpInputEvent::SendDvcMessages { channel_id, messages })
+                    .try_send(RdpInputEvent::SendDvcMessages { channel_id, messages })
                     .map_err(|_| pdu_other_err!("send DVC messages to the event loop"))?;
                 Ok(())
             },
@@ -322,7 +581,7 @@ fn build_connector(
                 let sender = sender_clone.clone();
                 Box::new(move |channel_id, messages| {
                     sender
-                        .send(RdpInputEvent::SendDvcMessages { channel_id, messages })
+                        .try_send(RdpInputEvent::SendDvcMessages { channel_id, messages })
                         .map_err(|_| pdu_other_err!("send COM DVC messages to the event loop"))?;
                     Ok(())
                 })
@@ -430,7 +689,7 @@ type UpgradedFramed = ironrdp_tokio::TokioFramed<Box<dyn AsyncReadWrite + Unpin 
 /// Direct TCP → TLS connection (no gateway).
 async fn connect_direct(
     config: &Config,
-    input_sender: &mpsc::UnboundedSender<RdpInputEvent>,
+    input_sender: &RdpInputSender,
     cliprdr_factory: CliprdrFactoryRef<'_>,
 ) -> ConnectorResult<(ConnectionResult, UpgradedFramed)> {
     let dest = config.destination.to_string();
@@ -452,7 +711,7 @@ async fn connect_direct(
 async fn connect_gateway(
     config: &Config,
     gw: &crate::config::GatewayConfig,
-    input_sender: &mpsc::UnboundedSender<RdpInputEvent>,
+    input_sender: &RdpInputSender,
     cliprdr_factory: CliprdrFactoryRef<'_>,
 ) -> ConnectorResult<(ConnectionResult, UpgradedFramed)> {
     use ironrdp_mstsgu::GwConnectTarget;
@@ -481,7 +740,7 @@ async fn connect_gateway(
 async fn connect_rdcleanpath_transport(
     config: &Config,
     rdcp: &RDCleanPathConfig,
-    input_sender: &mpsc::UnboundedSender<RdpInputEvent>,
+    input_sender: &RdpInputSender,
     cliprdr_factory: CliprdrFactoryRef<'_>,
 ) -> ConnectorResult<(ConnectionResult, UpgradedFramed)> {
     let hostname = rdcp
@@ -731,7 +990,11 @@ where
 // ── Active session ────────────────────────────────────────────────────────────
 
 enum RdpControlFlow {
-    ReconnectWithNewSize { width: u16, height: u16 },
+    ReconnectWithNewSize {
+        width: u16,
+        height: u16,
+        reason: DisplayResizeFallbackReason,
+    },
     TerminatedGracefully(GracefulDisconnectReason),
 }
 
@@ -739,7 +1002,8 @@ async fn active_session(
     framed: UpgradedFramed,
     connection_result: ConnectionResult,
     output_event_sender: &mpsc::Sender<RdpOutputEvent>,
-    input_event_receiver: &mut mpsc::UnboundedReceiver<RdpInputEvent>,
+    input_event_receiver: &mut mpsc::Receiver<RdpInputEvent>,
+    close_receiver: &mut watch::Receiver<bool>,
     fake_events_interval: Option<Duration>,
 ) -> SessionResult<RdpControlFlow> {
     let (mut reader, mut writer) = split_tokio_framed(framed);
@@ -774,9 +1038,21 @@ async fn active_session(
     let mut last_mouse_pos = (desktop_size.width / 2, desktop_size.height / 2);
     let mut fake_events_interval =
         fake_events_interval.map(|interval| tokio::time::interval(core::cmp::max(interval, Duration::from_secs(1))));
+    let mut resize_queue = ResizeQueue::default();
+
+    if *close_receiver.borrow_and_update() {
+        return Ok(RdpControlFlow::TerminatedGracefully(
+            GracefulDisconnectReason::UserInitiated,
+        ));
+    }
 
     let disconnect_reason = 'outer: loop {
+        let resize_deadline = resize_queue.deadline();
         let outputs = tokio::select! {
+            biased;
+            _ = close_receiver.changed() => {
+                break 'outer GracefulDisconnectReason::UserInitiated;
+            }
             frame = reader.read_pdu() => {
                 let (action, payload) = frame.map_err(|e| ironrdp_session::custom_err!("read frame", e))?;
                 trace!(?action, frame_length = payload.len(), "Frame received");
@@ -807,14 +1083,31 @@ async fn active_session(
                         // Therefore, we can remove unnecessary casts from u16 to u32 and back.
                         let (width, height) = MonitorLayoutEntry::adjust_display_size(width, height);
                         debug!(width, height, "Adjusted display size");
-                        if let Some(response_frame) = active_stage.encode_resize(width, height, Some(scale_factor), physical_size) {
+                        let request = ResizeRequest {
+                            width: u16::try_from(width).expect("always in the range"),
+                            height: u16::try_from(height).expect("always in the range"),
+                            scale_factor,
+                            physical_size,
+                        };
+                        if resize_queue.in_flight.is_some() || active_stage.display_control_ready() == Some(false) {
+                            resize_queue.defer(request);
+                            Vec::new()
+                        } else if let Some(response_frame) = active_stage.encode_resize(
+                            u32::from(request.width),
+                            u32::from(request.height),
+                            Some(request.scale_factor),
+                            request.physical_size,
+                        ) {
+                            resize_queue.mark_in_flight(request);
                             vec![ActiveStageOutput::ResponseFrame(response_frame?)]
                         } else {
                             // TODO(#271): use the "auto-reconnect cookie": https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/15b0d1c9-2891-4adb-a45e-deb4aeeeab7c
                             debug!("Reconnecting with new size");
-                            let width = u16::try_from(width).expect("always in the range");
-                            let height = u16::try_from(height).expect("always in the range");
-                            return Ok(RdpControlFlow::ReconnectWithNewSize { width, height })
+                            return Ok(RdpControlFlow::ReconnectWithNewSize {
+                                width: request.width,
+                                height: request.height,
+                                reason: DisplayResizeFallbackReason::DisplayControlUnavailable,
+                            })
                         }
                     }
                     RdpInputEvent::FastPath(events) => {
@@ -903,6 +1196,21 @@ async fn active_session(
                 #[cfg(not(feature = "clipboard"))]
                 Vec::new()
             }
+            _ = async {
+                match resize_deadline {
+                    Some(deadline) => tokio::time::sleep_until(deadline).await,
+                    None => core::future::pending().await,
+                }
+            } => {
+                let (request, reason) = resize_queue
+                    .timed_out_request(tokio::time::Instant::now())
+                    .expect("resize deadline must correspond to a queued request");
+                return Ok(RdpControlFlow::ReconnectWithNewSize {
+                    width: request.width,
+                    height: request.height,
+                    reason,
+                });
+            }
             _ = async { match fake_events_interval.as_mut() {
                 Some(interval) => interval.tick().await,
                 None => core::future::pending().await,
@@ -927,10 +1235,14 @@ async fn active_session(
 
         for out in outputs {
             match out {
-                ActiveStageOutput::ResponseFrame(frame) => writer
-                    .write_all(&frame)
-                    .await
-                    .map_err(|e| ironrdp_session::custom_err!("write response", e))?,
+                ActiveStageOutput::ResponseFrame(frame) => {
+                    let Some(result) = cancelable_operation(writer.write_all(&frame), close_receiver).await else {
+                        return Ok(RdpControlFlow::TerminatedGracefully(
+                            GracefulDisconnectReason::UserInitiated,
+                        ));
+                    };
+                    result.map_err(|e| ironrdp_session::custom_err!("write response", e))?;
+                }
                 ActiveStageOutput::GraphicsUpdate(_region) => {
                     let buffer: Vec<u32> = image
                         .data()
@@ -942,40 +1254,76 @@ async fn active_session(
                             u32::from_be_bytes([0, r, g, b])
                         })
                         .collect();
-                    output_event_sender
-                        .send(RdpOutputEvent::Image {
+                    if !send_active_output_event(
+                        output_event_sender,
+                        RdpOutputEvent::Image {
                             buffer,
                             width: NonZeroU16::new(image.width())
                                 .ok_or_else(|| ironrdp_session::general_err!("width is zero"))?,
                             height: NonZeroU16::new(image.height())
                                 .ok_or_else(|| ironrdp_session::general_err!("height is zero"))?,
-                        })
-                        .await
-                        .map_err(|e| ironrdp_session::custom_err!("output_event_sender", e))?;
+                        },
+                        close_receiver,
+                    )
+                    .await?
+                    {
+                        return Ok(RdpControlFlow::TerminatedGracefully(
+                            GracefulDisconnectReason::UserInitiated,
+                        ));
+                    }
                 }
                 ActiveStageOutput::PointerDefault => {
-                    output_event_sender
-                        .send(RdpOutputEvent::PointerDefault)
-                        .await
-                        .map_err(|e| ironrdp_session::custom_err!("output_event_sender", e))?;
+                    if !send_active_output_event(output_event_sender, RdpOutputEvent::PointerDefault, close_receiver)
+                        .await?
+                    {
+                        return Ok(RdpControlFlow::TerminatedGracefully(
+                            GracefulDisconnectReason::UserInitiated,
+                        ));
+                    }
                 }
                 ActiveStageOutput::PointerHidden => {
-                    output_event_sender
-                        .send(RdpOutputEvent::PointerHidden)
-                        .await
-                        .map_err(|e| ironrdp_session::custom_err!("output_event_sender", e))?;
+                    if !send_active_output_event(output_event_sender, RdpOutputEvent::PointerHidden, close_receiver)
+                        .await?
+                    {
+                        return Ok(RdpControlFlow::TerminatedGracefully(
+                            GracefulDisconnectReason::UserInitiated,
+                        ));
+                    }
                 }
                 ActiveStageOutput::PointerPosition { x, y } => {
-                    output_event_sender
-                        .send(RdpOutputEvent::PointerPosition { x, y })
-                        .await
-                        .map_err(|e| ironrdp_session::custom_err!("output_event_sender", e))?;
+                    if !send_active_output_event(
+                        output_event_sender,
+                        RdpOutputEvent::PointerPosition { x, y },
+                        close_receiver,
+                    )
+                    .await?
+                    {
+                        return Ok(RdpControlFlow::TerminatedGracefully(
+                            GracefulDisconnectReason::UserInitiated,
+                        ));
+                    }
                 }
                 ActiveStageOutput::PointerBitmap(pointer) => {
-                    output_event_sender
-                        .send(RdpOutputEvent::PointerBitmap(pointer))
-                        .await
-                        .map_err(|e| ironrdp_session::custom_err!("output_event_sender", e))?;
+                    if !send_active_output_event(
+                        output_event_sender,
+                        RdpOutputEvent::PointerBitmap(pointer),
+                        close_receiver,
+                    )
+                    .await?
+                    {
+                        return Ok(RdpControlFlow::TerminatedGracefully(
+                            GracefulDisconnectReason::UserInitiated,
+                        ));
+                    }
+                }
+                ActiveStageOutput::SaveSessionInfo => {
+                    if !send_active_output_event(output_event_sender, RdpOutputEvent::LoginComplete, close_receiver)
+                        .await?
+                    {
+                        return Ok(RdpControlFlow::TerminatedGracefully(
+                            GracefulDisconnectReason::UserInitiated,
+                        ));
+                    }
                 }
                 ActiveStageOutput::DeactivateAll => {
                     // Deactivation-Reactivation Sequence:
@@ -984,13 +1332,50 @@ async fn active_session(
                     let mut connection_activation = activation_factory.create();
                     let mut buf = WriteBuf::new();
                     'activation_seq: loop {
-                        let written = single_sequence_step_read(&mut reader, &mut connection_activation, &mut buf)
+                        let step = single_sequence_step_read(&mut reader, &mut connection_activation, &mut buf);
+                        let written = if let Some(in_flight) = resize_queue.in_flight.as_ref() {
+                            match cancelable_operation(
+                                tokio::time::timeout_at(in_flight.deadline, step),
+                                close_receiver,
+                            )
                             .await
-                            .map_err(|e| {
-                                ironrdp_session::custom_err!("read deactivation-reactivation sequence step", e)
-                            })?;
+                            {
+                                Some(Ok(result)) => result,
+                                Some(Err(_)) => {
+                                    let request = resize_queue
+                                        .pending
+                                        .as_ref()
+                                        .map_or(in_flight.request, |pending| pending.request);
+                                    return Ok(RdpControlFlow::ReconnectWithNewSize {
+                                        width: request.width,
+                                        height: request.height,
+                                        reason: DisplayResizeFallbackReason::ReactivationTimedOut,
+                                    });
+                                }
+                                None => {
+                                    return Ok(RdpControlFlow::TerminatedGracefully(
+                                        GracefulDisconnectReason::UserInitiated,
+                                    ));
+                                }
+                            }
+                        } else {
+                            let Some(result) = cancelable_operation(step, close_receiver).await else {
+                                return Ok(RdpControlFlow::TerminatedGracefully(
+                                    GracefulDisconnectReason::UserInitiated,
+                                ));
+                            };
+                            result
+                        }
+                        .map_err(|e| ironrdp_session::custom_err!("read deactivation-reactivation sequence step", e))?;
                         if written.size().is_some() {
-                            writer.write_all(buf.filled()).await.map_err(|e| {
+                            let Some(result) =
+                                cancelable_operation(writer.write_all(buf.filled()), close_receiver).await
+                            else {
+                                return Ok(RdpControlFlow::TerminatedGracefully(
+                                    GracefulDisconnectReason::UserInitiated,
+                                ));
+                            };
+                            result.map_err(|e| {
                                 ironrdp_session::custom_err!("write deactivation-reactivation sequence step", e)
                             })?;
                         }
@@ -1006,6 +1391,7 @@ async fn active_session(
                         {
                             debug!(?desktop_size, "Deactivation-Reactivation Sequence completed");
                             image = DecodedImage::new(PixelFormat::RgbA32, desktop_size.width, desktop_size.height);
+                            resize_queue.completed();
                             active_stage.reactivate(
                                 connection_activation.io_channel_id(),
                                 connection_activation.user_channel_id(),
@@ -1032,7 +1418,151 @@ async fn active_session(
                 ActiveStageOutput::Terminate(reason) => break 'outer reason,
             }
         }
+
+        if resize_queue.in_flight.is_none()
+            && let Some(pending) = resize_queue.pending.as_ref()
+        {
+            let request = pending.request;
+            match active_stage.display_control_ready() {
+                Some(true) => {
+                    let response_frame = active_stage
+                        .encode_resize(
+                            u32::from(request.width),
+                            u32::from(request.height),
+                            Some(request.scale_factor),
+                            request.physical_size,
+                        )
+                        .ok_or_else(|| ironrdp_session::general_err!("Display Control became unavailable"))??;
+                    resize_queue.pending = None;
+                    resize_queue.mark_in_flight(request);
+                    let Some(result) = cancelable_operation(writer.write_all(&response_frame), close_receiver).await
+                    else {
+                        return Ok(RdpControlFlow::TerminatedGracefully(
+                            GracefulDisconnectReason::UserInitiated,
+                        ));
+                    };
+                    result.map_err(|e| ironrdp_session::custom_err!("write pending resize", e))?;
+                }
+                None => {
+                    debug!("Reconnecting because Display Control is unavailable");
+                    return Ok(RdpControlFlow::ReconnectWithNewSize {
+                        width: request.width,
+                        height: request.height,
+                        reason: DisplayResizeFallbackReason::DisplayControlUnavailable,
+                    });
+                }
+                Some(false) => {}
+            }
+        }
     };
 
     Ok(RdpControlFlow::TerminatedGracefully(disconnect_reason))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn resize_request(width: u16, height: u16) -> ResizeRequest {
+        ResizeRequest {
+            width,
+            height,
+            scale_factor: 100,
+            physical_size: None,
+        }
+    }
+
+    #[test]
+    fn resize_queue_coalesces_later_requests_until_reactivation() {
+        let first = resize_request(1024, 768);
+        let latest = resize_request(1600, 900);
+        let mut queue = ResizeQueue::default();
+        queue.mark_in_flight(first);
+        let deadline = queue.deadline().expect("in-flight resize must have a deadline");
+        queue.defer(latest);
+
+        assert_eq!(
+            queue.timed_out_request(deadline),
+            Some((latest, DisplayResizeFallbackReason::ReactivationTimedOut))
+        );
+        queue.completed();
+        assert!(queue.in_flight.is_none());
+        assert_eq!(queue.pending.as_ref().map(|pending| pending.request), Some(latest));
+    }
+
+    #[test]
+    fn resize_queue_times_out_while_waiting_for_display_control_capabilities() {
+        let request = resize_request(1280, 720);
+        let mut queue = ResizeQueue::default();
+        queue.defer(request);
+        let deadline = queue.deadline().expect("pending resize must have a deadline");
+
+        assert_eq!(queue.timed_out_request(deadline - Duration::from_millis(1)), None);
+        assert_eq!(
+            queue.timed_out_request(deadline),
+            Some((request, DisplayResizeFallbackReason::CapabilitiesTimedOut))
+        );
+    }
+
+    #[test]
+    fn input_sender_bounds_events_but_close_bypasses_the_queue() {
+        let (sender, mut receiver, mut close_receiver) = RdpInputSender::channel_with_close_signal(1);
+        sender
+            .try_send(RdpInputEvent::Resize {
+                width: 1024,
+                height: 768,
+                scale_factor: 100,
+                physical_size: None,
+            })
+            .expect("the first event fits");
+        assert!(
+            sender
+                .try_send(RdpInputEvent::Resize {
+                    width: 1280,
+                    height: 720,
+                    scale_factor: 100,
+                    physical_size: None,
+                })
+                .is_err()
+        );
+
+        sender.request_close();
+        assert!(close_receiver.has_changed().expect("close sender is alive"));
+        assert!(*close_receiver.borrow_and_update());
+        assert!(matches!(receiver.try_recv(), Ok(RdpInputEvent::Resize { .. })));
+    }
+
+    #[test]
+    fn input_sender_reservation_prevents_state_changes_without_queue_capacity() {
+        let (sender, mut receiver) = RdpInputSender::channel(1);
+        let permit = sender.try_reserve().expect("the empty queue has capacity");
+        assert!(sender.try_reserve().is_err());
+
+        permit.send(RdpInputEvent::Resize {
+            width: 1024,
+            height: 768,
+            scale_factor: 100,
+            physical_size: None,
+        });
+
+        assert!(matches!(receiver.try_recv(), Ok(RdpInputEvent::Resize { .. })));
+    }
+
+    #[tokio::test]
+    async fn output_send_is_cancelled_when_the_consumer_is_backpressured() {
+        let (output_sender, _output_receiver) = mpsc::channel(1);
+        output_sender
+            .try_send(RdpOutputEvent::Connected)
+            .expect("the first output event fills the queue");
+        let (close_sender, mut close_receiver) = watch::channel(false);
+
+        let send = send_cancellable_output_event(&output_sender, RdpOutputEvent::LoginComplete, &mut close_receiver);
+        let close = async {
+            tokio::task::yield_now().await;
+            close_sender.send_replace(true);
+        };
+        let (delivered, ()) = tokio::join!(send, close);
+
+        assert!(!delivered.expect("cancellation is not an output error"));
+    }
 }

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -1233,8 +1233,8 @@ fn create_gcc_blocks<'a>(
 ) -> ConnectorResult<gcc::ClientGccBlocks> {
     use ironrdp_pdu::gcc::{
         ClientCoreData, ClientCoreOptionalData, ClientEarlyCapabilityFlags, ClientGccBlocks, ClientNetworkData,
-        ClientSecurityData, ColorDepth, ConnectionType, EncryptionMethod, HighColorDepth, MonitorOrientation,
-        RdpVersion, SecureAccessSequence, SupportedColorDepths,
+        ClientSecurityData, ColorDepth, EncryptionMethod, HighColorDepth, MonitorOrientation, RdpVersion,
+        SecureAccessSequence, SupportedColorDepths,
     };
 
     let max_color_depth = config.bitmap.as_ref().map(|bitmap| bitmap.color_depth).unwrap_or(32);
@@ -1301,7 +1301,7 @@ fn create_gcc_blocks<'a>(
                     Some(early_capability_flags)
                 },
                 dig_product_id: Some(config.dig_product_id.clone()),
-                connection_type: Some(ConnectionType::Lan),
+                connection_type: Some(config.connection_type),
                 server_selected_protocol: Some(selected_protocol),
                 desktop_physical_width: Some(0),  // 0 per FreeRDP
                 desktop_physical_height: Some(0), // 0 per FreeRDP

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -41,6 +41,15 @@ pub enum MultitransportResult {
     Failure(u32),
 }
 
+/// Why a runtime-defined static virtual channel could not be registered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DynamicStaticChannelAttachError {
+    /// The negotiated static-channel key space has no remaining entries.
+    ChannelLimitReached,
+    /// Another static channel already uses the requested channel name.
+    DuplicateChannelName,
+}
+
 #[derive(Debug)]
 pub struct ConnectionResult {
     pub io_channel_id: u16,
@@ -300,14 +309,26 @@ impl ClientConnector {
     where
         T: SvcClientProcessor + 'static,
     {
-        let channel_name = channel.channel_name();
-        if self.static_channels.len() >= MAX_STATIC_CHANNELS
-            || self.static_channels.get_by_channel_name_key(&channel_name).is_some()
-        {
-            return false;
-        }
+        self.try_attach_dynamic_static_channel(channel).is_ok()
+    }
 
-        self.static_channels.insert_dynamic(channel).is_some()
+    /// Attaches a runtime-defined static virtual channel, returning the reason when it cannot be
+    /// registered.
+    pub fn try_attach_dynamic_static_channel<T>(&mut self, channel: T) -> Result<(), DynamicStaticChannelAttachError>
+    where
+        T: SvcClientProcessor + 'static,
+    {
+        let channel_name = channel.channel_name();
+        if self.static_channels.len() >= MAX_STATIC_CHANNELS {
+            return Err(DynamicStaticChannelAttachError::ChannelLimitReached);
+        }
+        if self.static_channels.get_by_channel_name_key(&channel_name).is_some() {
+            return Err(DynamicStaticChannelAttachError::DuplicateChannelName);
+        }
+        self.static_channels
+            .insert_dynamic(channel)
+            .map(|_| ())
+            .ok_or(DynamicStaticChannelAttachError::ChannelLimitReached)
     }
 
     pub fn get_static_channel_processor<T>(&mut self) -> Option<&T>

--- a/crates/ironrdp-connector/src/lib.rs
+++ b/crates/ironrdp-connector/src/lib.rs
@@ -202,6 +202,8 @@ pub struct Config {
     pub keyboard_subtype: u32,
     pub keyboard_functional_keys_count: u32,
     pub keyboard_layout: u32,
+    /// Network profile advertised in the Client Core Data GCC block.
+    pub connection_type: gcc::ConnectionType,
     pub ime_file_name: String,
     pub bitmap: Option<BitmapConfig>,
     pub dig_product_id: String,

--- a/crates/ironrdp-connector/src/lib.rs
+++ b/crates/ironrdp-connector/src/lib.rs
@@ -25,7 +25,8 @@ pub use sspi;
 
 pub use self::channel_connection::{ChannelConnectionSequence, ChannelConnectionState};
 pub use self::connection::{
-    ClientConnector, ClientConnectorState, ConnectionResult, MultitransportResult, encode_send_data_request,
+    ClientConnector, ClientConnectorState, ConnectionResult, DynamicStaticChannelAttachError, MultitransportResult,
+    encode_send_data_request,
 };
 pub use self::connection_finalization::{ConnectionFinalizationSequence, ConnectionFinalizationState};
 pub use self::license_exchange::{LicenseExchangeSequence, LicenseExchangeState};

--- a/crates/ironrdp-dvc/src/client.rs
+++ b/crates/ironrdp-dvc/src/client.rs
@@ -157,6 +157,14 @@ impl DrdynvcClient {
         self.dynamic_channels.get_by_type_id(TypeId::of::<T>())
     }
 
+    /// Returns whether a dynamic channel of type `T` was pre-registered with this client.
+    pub fn has_registered_dvc<T>(&self) -> bool
+    where
+        T: DvcProcessor,
+    {
+        self.dynamic_channels.has_listener_by_type_id(TypeId::of::<T>())
+    }
+
     pub fn get_dvc_by_channel_id(&self, channel_id: u32) -> Option<&DynamicVirtualChannel> {
         self.dynamic_channels.get_by_channel_id(channel_id)
     }
@@ -347,6 +355,10 @@ impl DynamicChannelSet {
         self.type_id_to_channel_id
             .get(&type_id)
             .and_then(|id| self.active_channels.get(id))
+    }
+
+    fn has_listener_by_type_id(&self, type_id: TypeId) -> bool {
+        self.listeners.values().any(|entry| entry.type_id == Some(type_id))
     }
 
     fn get_by_channel_id(&self, id: DynamicChannelId) -> Option<&DynamicVirtualChannel> {

--- a/crates/ironrdp-dvc/src/client.rs
+++ b/crates/ironrdp-dvc/src/client.rs
@@ -26,6 +26,11 @@ pub trait DvcChannelListener: Send {
     /// Called for each incoming DYNVC_CREATE_REQ matching this name.
     /// Return `None` to reject (NO_LISTENER).
     fn create(&mut self, channel_id: DynamicChannelId) -> Option<Box<dyn DvcProcessor>>;
+
+    /// Returns whether this listener can still create a channel.
+    fn is_available(&self) -> bool {
+        true
+    }
 }
 
 pub type DynamicChannelListener = Box<dyn DvcChannelListener>;
@@ -53,6 +58,10 @@ impl DvcChannelListener for OnceListener {
 
     fn create(&mut self, _channel_id: DynamicChannelId) -> Option<Box<dyn DvcProcessor>> {
         self.inner.take()
+    }
+
+    fn is_available(&self) -> bool {
+        self.inner.is_some()
     }
 }
 
@@ -358,7 +367,9 @@ impl DynamicChannelSet {
     }
 
     fn has_listener_by_type_id(&self, type_id: TypeId) -> bool {
-        self.listeners.values().any(|entry| entry.type_id == Some(type_id))
+        self.listeners
+            .values()
+            .any(|entry| entry.type_id == Some(type_id) && entry.listener.is_available())
     }
 
     fn get_by_channel_id(&self, id: DynamicChannelId) -> Option<&DynamicVirtualChannel> {
@@ -391,4 +402,37 @@ impl SvcClientProcessor for DrdynvcClient {}
 
 fn decode_dvc_message(user_data: &[u8]) -> DecodeResult<DrdynvcServerPdu> {
     DrdynvcServerPdu::decode(&mut ReadCursor::new(user_data))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestDvc;
+
+    impl_as_any!(TestDvc);
+
+    impl DvcProcessor for TestDvc {
+        fn channel_name(&self) -> &str {
+            "test"
+        }
+
+        fn start(&mut self, _channel_id: u32) -> PduResult<Vec<crate::DvcMessage>> {
+            Ok(Vec::new())
+        }
+
+        fn process(&mut self, _channel_id: u32, _payload: &[u8]) -> PduResult<Vec<crate::DvcMessage>> {
+            Ok(Vec::new())
+        }
+    }
+
+    #[test]
+    fn consumed_typed_listener_is_not_registered() {
+        let mut channels = DynamicChannelSet::new();
+        channels.register_once(TestDvc);
+
+        assert!(channels.has_listener_by_type_id(TypeId::of::<TestDvc>()));
+        assert!(channels.try_create_channel(&"test".to_owned(), 1).is_some());
+        assert!(!channels.has_listener_by_type_id(TypeId::of::<TestDvc>()));
+    }
 }

--- a/crates/ironrdp-session/src/active_stage.rs
+++ b/crates/ironrdp-session/src/active_stage.rs
@@ -477,7 +477,10 @@ pub enum ActiveStageOutput {
     ///
     /// This value-free event deliberately excludes server-provided session details, which can
     /// include credentials and auto-reconnect cookies.
-    SaveSessionInfo,
+    SaveSessionInfo {
+        /// Whether the notification unambiguously reports a completed logon.
+        logon_complete: bool,
+    },
     /// Received a Server Deactivate All PDU. The consumer should execute the [Deactivation-Reactivation Sequence].
     ///
     /// [Deactivation-Reactivation Sequence]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/dfc234ce-481a-4674-9a5d-2a7bafb14432
@@ -518,7 +521,7 @@ impl TryFrom<x224::ProcessorOutput> for ActiveStageOutput {
 
                 Ok(Self::Terminate(desc))
             }
-            x224::ProcessorOutput::SaveSessionInfo => Ok(Self::SaveSessionInfo),
+            x224::ProcessorOutput::SaveSessionInfo { logon_complete } => Ok(Self::SaveSessionInfo { logon_complete }),
             x224::ProcessorOutput::DeactivateAll => Ok(Self::DeactivateAll),
             x224::ProcessorOutput::MultitransportRequest(pdu) => Ok(Self::MultitransportRequest(pdu)),
             x224::ProcessorOutput::AutoDetect(request) => Ok(Self::AutoDetect(request)),

--- a/crates/ironrdp-session/src/active_stage.rs
+++ b/crates/ironrdp-session/src/active_stage.rs
@@ -371,6 +371,22 @@ impl ActiveStage {
         self.x224_processor.get_dvc_by_channel_id(channel_id)
     }
 
+    /// Returns whether the Display Control channel is available and has received server capabilities.
+    ///
+    /// `None` means no Display Control client is configured. `Some(false)` means it is configured
+    /// but its dynamic channel is still opening or has not received its capabilities PDU.
+    pub fn display_control_ready(&mut self) -> Option<bool> {
+        let Some(dvc) = self.get_dvc::<DisplayControlClient>() else {
+            return self
+                .get_svc_processor::<DrdynvcClient>()
+                .and_then(|drdynvc| drdynvc.has_registered_dvc::<DisplayControlClient>().then_some(false));
+        };
+        let Some(_) = dvc.channel_id() else {
+            return Some(false);
+        };
+        Some(dvc.channel_processor_downcast_ref::<DisplayControlClient>()?.ready())
+    }
+
     /// Completes user's SVC request with data, required to sent it over the network and returns
     /// a buffer with encoded data.
     pub fn process_svc_processor_messages<C: SvcProcessor + 'static>(
@@ -391,8 +407,8 @@ impl ActiveStage {
 
     /// Fully encodes a resize request for sending over the Display Control Virtual Channel.
     ///
-    /// If the Display Control Virtual Channel is not available, or not yet connected, this method
-    /// will return `None`.
+    /// If the Display Control Virtual Channel is not available, not yet connected, or has not
+    /// received its required server capabilities PDU, this method returns `None`.
     ///
     /// Per [2.2.2.2.1]:
     /// - The `width` MUST be greater than or equal to 200 pixels and less than or equal to 8192 pixels, and MUST NOT be an odd value.
@@ -412,25 +428,27 @@ impl ActiveStage {
         physical_dims: Option<(u32, u32)>,
     ) -> Option<SessionResult<Vec<u8>>> {
         if let Some(dvc) = self.get_dvc::<DisplayControlClient>() {
-            if let Some(channel_id) = dvc.channel_id() {
-                let display_control = dvc.channel_processor_downcast_ref::<DisplayControlClient>()?;
-                let svc_messages = match display_control.encode_single_primary_monitor(
-                    channel_id,
-                    width,
-                    height,
-                    scale_factor,
-                    physical_dims,
-                ) {
-                    Ok(messages) => messages,
-                    Err(e) => return Some(Err(SessionError::encode(e))),
-                };
-
-                return Some(
-                    self.process_svc_processor_messages(SvcProcessorMessages::<DrdynvcClient>::new(svc_messages)),
-                );
-            } else {
+            let Some(channel_id) = dvc.channel_id() else {
                 debug!("Could not encode a resize: Display Control Virtual Channel is not yet connected");
+                return None;
+            };
+            let display_control = dvc.channel_processor_downcast_ref::<DisplayControlClient>()?;
+            if !display_control.ready() {
+                debug!("Could not encode a resize: Display Control capabilities have not been received");
+                return None;
             }
+            let svc_messages = match display_control.encode_single_primary_monitor(
+                channel_id,
+                width,
+                height,
+                scale_factor,
+                physical_dims,
+            ) {
+                Ok(messages) => messages,
+                Err(e) => return Some(Err(SessionError::encode(e))),
+            };
+
+            return Some(self.process_svc_processor_messages(SvcProcessorMessages::<DrdynvcClient>::new(svc_messages)));
         } else {
             debug!("Could not encode a resize: Display Control Virtual Channel is not available");
         }
@@ -455,6 +473,11 @@ pub enum ActiveStageOutput {
     },
     PointerBitmap(Arc<DecodedPointer>),
     Terminate(GracefulDisconnectReason),
+    /// Server Save Session Info notification ([MS-RDPBCGR] 2.2.10.1).
+    ///
+    /// This value-free event deliberately excludes server-provided session details, which can
+    /// include credentials and auto-reconnect cookies.
+    SaveSessionInfo,
     /// Received a Server Deactivate All PDU. The consumer should execute the [Deactivation-Reactivation Sequence].
     ///
     /// [Deactivation-Reactivation Sequence]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/dfc234ce-481a-4674-9a5d-2a7bafb14432
@@ -495,6 +518,7 @@ impl TryFrom<x224::ProcessorOutput> for ActiveStageOutput {
 
                 Ok(Self::Terminate(desc))
             }
+            x224::ProcessorOutput::SaveSessionInfo => Ok(Self::SaveSessionInfo),
             x224::ProcessorOutput::DeactivateAll => Ok(Self::DeactivateAll),
             x224::ProcessorOutput::MultitransportRequest(pdu) => Ok(Self::MultitransportRequest(pdu)),
             x224::ProcessorOutput::AutoDetect(request) => Ok(Self::AutoDetect(request)),

--- a/crates/ironrdp-session/src/x224/mod.rs
+++ b/crates/ironrdp-session/src/x224/mod.rs
@@ -26,6 +26,8 @@ pub enum ProcessorOutput {
     ///
     /// [Deactivation-Reactivation Sequence]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/dfc234ce-481a-4674-9a5d-2a7bafb14432
     DeactivateAll,
+    /// Server Save Session Info notification.
+    SaveSessionInfo,
     /// Server Initiate Multitransport Request. The application should establish a
     /// sideband UDP transport using the request ID and security cookie, then send
     /// a [`MultitransportResponsePdu`] back on the IO channel.
@@ -210,7 +212,7 @@ impl Processor {
         match pdu {
             ShareDataPdu::SaveSessionInfo(session_info) => {
                 debug!("Got Session Save Info PDU: {session_info:?}");
-                Ok(Vec::new())
+                Ok(vec![ProcessorOutput::SaveSessionInfo])
             }
             // FIXME: workaround fix to not terminate the session on "unhandled PDU: Set Keyboard Indicators PDU"
             ShareDataPdu::SetKeyboardIndicators(data) => {

--- a/crates/ironrdp-session/src/x224/mod.rs
+++ b/crates/ironrdp-session/src/x224/mod.rs
@@ -373,7 +373,7 @@ mod tests {
     use ironrdp_bulk::{CompressionType as BulkCompressionType, flags};
     use ironrdp_core::encode_vec;
     use ironrdp_pdu::rdp::headers::ShareDataPduType;
-    use ironrdp_pdu::rdp::session_info::{InfoData, InfoType, LogonExFlags, LogonInfoExtended, SaveSessionInfoPdu};
+    use ironrdp_pdu::rdp::session_info::{InfoType, LogonExFlags, LogonInfoExtended};
 
     use super::*;
 
@@ -448,12 +448,10 @@ mod tests {
         )
         .expect("compressed save session info should be processed");
 
-        assert_eq!(
-            outputs,
-            vec![ProcessorOutput::SaveSessionInfo {
-                logon_complete: true,
-            }]
-        );
+        assert!(matches!(
+            outputs.as_slice(),
+            [ProcessorOutput::SaveSessionInfo { logon_complete: true }]
+        ));
     }
 
     #[test]

--- a/crates/ironrdp-session/src/x224/mod.rs
+++ b/crates/ironrdp-session/src/x224/mod.rs
@@ -8,6 +8,7 @@ use ironrdp_pdu::rdp::client_info::CompressionType;
 use ironrdp_pdu::rdp::headers::{CompressionFlags, ShareDataCtx, ShareDataPdu};
 use ironrdp_pdu::rdp::multitransport::MultitransportRequestPdu;
 use ironrdp_pdu::rdp::server_error_info::{ErrorInfo, ProtocolIndependentCode, ServerSetErrorInfoPdu};
+use ironrdp_pdu::rdp::session_info::{InfoData, SaveSessionInfoPdu};
 use ironrdp_pdu::x224::X224;
 use ironrdp_svc::{StaticChannelSet, SvcMessage, SvcProcessor, SvcProcessorMessages, client_encode_svc_messages};
 use tracing::debug;
@@ -27,7 +28,11 @@ pub enum ProcessorOutput {
     /// [Deactivation-Reactivation Sequence]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/dfc234ce-481a-4674-9a5d-2a7bafb14432
     DeactivateAll,
     /// Server Save Session Info notification.
-    SaveSessionInfo,
+    ///
+    /// `logon_complete` is only set for PDU variants that unambiguously report a completed
+    /// logon; the source PDU is not retained because it can contain user details and
+    /// auto-reconnect cookies.
+    SaveSessionInfo { logon_complete: bool },
     /// Server Initiate Multitransport Request. The application should establish a
     /// sideband UDP transport using the request ID and security cookie, then send
     /// a [`MultitransportResponsePdu`] back on the IO channel.
@@ -212,7 +217,9 @@ impl Processor {
         match pdu {
             ShareDataPdu::SaveSessionInfo(session_info) => {
                 debug!("Got Session Save Info PDU: {session_info:?}");
-                Ok(vec![ProcessorOutput::SaveSessionInfo])
+                Ok(vec![ProcessorOutput::SaveSessionInfo {
+                    logon_complete: is_logon_complete(&session_info),
+                }])
             }
             // FIXME: workaround fix to not terminate the session on "unhandled PDU: Set Keyboard Indicators PDU"
             ShareDataPdu::SetKeyboardIndicators(data) => {
@@ -344,6 +351,13 @@ impl Processor {
     }
 }
 
+fn is_logon_complete(session_info: &SaveSessionInfoPdu) -> bool {
+    matches!(
+        session_info.info_data,
+        InfoData::LogonInfoV1(_) | InfoData::LogonInfoV2(_) | InfoData::PlainNotify
+    )
+}
+
 /// Processes a vector of [`SvcMessage`] in preparation for sending them to the server on the `channel_id` channel.
 ///
 /// This includes chunkifying the messages, adding MCS, x224, and tpkt headers, and encoding them into a buffer.
@@ -359,7 +373,7 @@ mod tests {
     use ironrdp_bulk::{CompressionType as BulkCompressionType, flags};
     use ironrdp_core::encode_vec;
     use ironrdp_pdu::rdp::headers::ShareDataPduType;
-    use ironrdp_pdu::rdp::session_info::{InfoData, InfoType, SaveSessionInfoPdu};
+    use ironrdp_pdu::rdp::session_info::{InfoData, InfoType, LogonExFlags, LogonInfoExtended, SaveSessionInfoPdu};
 
     use super::*;
 
@@ -434,6 +448,35 @@ mod tests {
         )
         .expect("compressed save session info should be processed");
 
-        assert!(outputs.is_empty());
+        assert_eq!(
+            outputs,
+            vec![ProcessorOutput::SaveSessionInfo {
+                logon_complete: true,
+            }]
+        );
+    }
+
+    #[test]
+    fn extended_session_info_does_not_signal_login_completion() {
+        let session_info = SaveSessionInfoPdu {
+            info_type: InfoType::LogonExtended,
+            info_data: InfoData::LogonExtended(LogonInfoExtended {
+                present_fields_flags: LogonExFlags::AUTO_RECONNECT_COOKIE,
+                auto_reconnect: None,
+                errors_info: None,
+            }),
+        };
+
+        assert!(!is_logon_complete(&session_info));
+    }
+
+    #[test]
+    fn plain_notify_signals_login_completion() {
+        let session_info = SaveSessionInfoPdu {
+            info_type: InfoType::PlainNotify,
+            info_data: InfoData::PlainNotify,
+        };
+
+        assert!(is_logon_complete(&session_info));
     }
 }

--- a/crates/ironrdp-testsuite-core/tests/connector/autodetect.rs
+++ b/crates/ironrdp-testsuite-core/tests/connector/autodetect.rs
@@ -46,6 +46,7 @@ fn test_config() -> ironrdp_connector::Config {
         keyboard_subtype: 0,
         keyboard_layout: 0,
         keyboard_functional_keys_count: 12,
+        connection_type: gcc::ConnectionType::Lan,
         ime_file_name: String::new(),
         bitmap: None,
         dig_product_id: String::new(),

--- a/crates/ironrdp-testsuite-core/tests/session/connection_activation.rs
+++ b/crates/ironrdp-testsuite-core/tests/session/connection_activation.rs
@@ -44,6 +44,7 @@ fn test_config() -> ironrdp_connector::Config {
         keyboard_subtype: 0,
         keyboard_layout: 0,
         keyboard_functional_keys_count: 12,
+        connection_type: gcc::ConnectionType::Lan,
         ime_file_name: String::new(),
         bitmap: None,
         dig_product_id: String::new(),

--- a/crates/ironrdp-testsuite-extra/tests/client_config.rs
+++ b/crates/ironrdp-testsuite-extra/tests/client_config.rs
@@ -181,6 +181,44 @@ fn desktop_dimensions_are_parsed_from_rdp_file() {
 }
 
 #[test]
+fn generic_builder_options_reach_connector_configuration() {
+    use ironrdp::pdu::gcc::ConnectionType;
+    use ironrdp::pdu::rdp::client_info::PerformanceFlags;
+
+    let performance_flags = PerformanceFlags::DISABLE_WALLPAPER | PerformanceFlags::DISABLE_THEMING;
+    let config = ConfigBuilder::new()
+        .with_destination(Destination::from_parts("rdp.example.com", 3389))
+        .with_username("test-user")
+        .with_password("test-pass")
+        .with_client_build(1)
+        .with_client_dir("C:\\Windows\\System32")
+        .with_client_name("ironrdp-tests")
+        .with_platform(ironrdp::pdu::rdp::capability_sets::MajorPlatformType::WINDOWS)
+        .with_keyboard_layout(0x0000_0409)
+        .with_connection_type(ConnectionType::BroadbandHigh)
+        .with_lossy_compression(false)
+        .with_performance_flags(performance_flags)
+        .with_alternate_shell("powershell.exe")
+        .with_work_dir("C:\\Users\\test-user")
+        .build()
+        .expect("valid generic configuration");
+
+    assert_eq!(config.connector().keyboard_layout, 0x0000_0409);
+    assert_eq!(config.connector().connection_type, ConnectionType::BroadbandHigh);
+    assert!(
+        !config
+            .connector()
+            .bitmap
+            .as_ref()
+            .expect("bitmap config")
+            .lossy_compression
+    );
+    assert_eq!(config.connector().performance_flags, performance_flags);
+    assert_eq!(config.connector().alternate_shell, "powershell.exe");
+    assert_eq!(config.connector().work_dir, "C:\\Users\\test-user");
+}
+
+#[test]
 fn out_of_range_desktop_dimensions_fall_back_to_defaults() {
     let default_config = parse_config_from_rdp(
         "full address:s:rdp.example.com\nusername:s:test-user\nClearTextPassword:s:test-pass\n",

--- a/crates/ironrdp-testsuite-extra/tests/e2e.rs
+++ b/crates/ironrdp-testsuite-extra/tests/e2e.rs
@@ -536,6 +536,7 @@ fn default_client_config() -> connector::Config {
         keyboard_subtype: 0,
         keyboard_layout: 0,
         keyboard_functional_keys_count: 12,
+        connection_type: gcc::ConnectionType::Lan,
         ime_file_name: "".into(),
         bitmap: None,
         dig_product_id: "".into(),

--- a/crates/ironrdp-viewer/src/app.rs
+++ b/crates/ironrdp-viewer/src/app.rs
@@ -62,7 +62,7 @@ impl App {
     }
 
     fn send_resize_event(&mut self) {
-        let Some(size) = self.last_size.take() else {
+        let Some(size) = self.last_size else {
             return;
         };
         let Some((window, _)) = self.window.as_mut() else {
@@ -74,7 +74,7 @@ impl App {
         let width = u16::try_from(size.width).expect("reasonable width");
         let height = u16::try_from(size.height).expect("reasonable height");
 
-        let _ = self.input_event_sender.try_send(RdpInputEvent::Resize {
+        match self.input_event_sender.try_send(RdpInputEvent::Resize {
             width,
             height,
             scale_factor,
@@ -83,7 +83,16 @@ impl App {
             // https://github.com/FreeRDP/FreeRDP/blob/ba8cf8cf2158018fb7abbedb51ab245f369be813/client/SDL/sdl_monitor.cpp#L250-L262
             // See also: https://github.com/rust-windowing/winit/issues/826
             physical_size: None,
-        });
+        }) {
+            Ok(()) => self.last_size = None,
+            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                self.resize_timeout = Some(Instant::now() + Duration::from_millis(10));
+            }
+            Err(_) => {
+                self.last_size = None;
+                warn!("Unable to enqueue resize event because the RDP session is closed");
+            }
+        }
     }
 
     fn draw(&mut self) {
@@ -105,9 +114,15 @@ impl ApplicationHandler<RdpOutputEvent> for App {
             if let Some(timeout) = timeout.checked_duration_since(Instant::now()) {
                 event_loop.set_control_flow(ControlFlow::wait_duration(timeout));
             } else {
-                self.send_resize_event();
                 self.resize_timeout = None;
-                event_loop.set_control_flow(ControlFlow::Wait);
+                self.send_resize_event();
+                if let Some(retry_timeout) = self.resize_timeout {
+                    event_loop.set_control_flow(ControlFlow::wait_duration(
+                        retry_timeout.saturating_duration_since(Instant::now()),
+                    ));
+                } else {
+                    event_loop.set_control_flow(ControlFlow::Wait);
+                }
             }
         }
     }
@@ -143,7 +158,7 @@ impl ApplicationHandler<RdpOutputEvent> for App {
                 self.resize_timeout = Some(Instant::now() + Duration::from_secs(1));
             }
             WindowEvent::CloseRequested => {
-                self.input_event_sender.request_close();
+                self.input_event_sender.request_graceful_close();
             }
             WindowEvent::DroppedFile(_) => {
                 // TODO(#110): File upload

--- a/crates/ironrdp-viewer/src/app.rs
+++ b/crates/ironrdp-viewer/src/app.rs
@@ -6,12 +6,11 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::Context as _;
-use ironrdp::client::rdp::{RdpInputEvent, RdpOutputEvent};
+use ironrdp::client::rdp::{RdpInputEvent, RdpInputSender, RdpOutputEvent};
 use ironrdp::pdu::input::fast_path::FastPathInputEvent;
 use raw_window_handle::{DisplayHandle, HasDisplayHandle as _};
 use smallvec::SmallVec;
-use tokio::sync::mpsc;
-use tracing::{debug, error, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 use winit::application::ApplicationHandler;
 use winit::dpi::{LogicalPosition, PhysicalSize};
 use winit::event::{self, WindowEvent};
@@ -22,7 +21,7 @@ use winit::window::{CursorIcon, CustomCursor, Window, WindowAttributes};
 type WindowSurface = (Arc<Window>, softbuffer::Surface<DisplayHandle<'static>, Arc<Window>>);
 
 pub struct App {
-    input_event_sender: mpsc::UnboundedSender<RdpInputEvent>,
+    input_event_sender: RdpInputSender,
     context: softbuffer::Context<DisplayHandle<'static>>,
     initial_window_size: PhysicalSize<u32>,
     window: Option<WindowSurface>,
@@ -36,7 +35,7 @@ pub struct App {
 impl App {
     pub fn new(
         event_loop: &EventLoop<RdpOutputEvent>,
-        input_event_sender: &mpsc::UnboundedSender<RdpInputEvent>,
+        input_event_sender: &RdpInputSender,
         initial_window_size: PhysicalSize<u32>,
     ) -> anyhow::Result<Self> {
         // SAFETY: We drop the softbuffer context right before the event loop is stopped, thus making this safe.
@@ -76,7 +75,7 @@ impl App {
         let width = u16::try_from(size.width).expect("reasonable width");
         let height = u16::try_from(size.height).expect("reasonable height");
 
-        let _ = self.input_event_sender.send(RdpInputEvent::Resize {
+        let _ = self.input_event_sender.try_send(RdpInputEvent::Resize {
             width,
             height,
             scale_factor,
@@ -131,7 +130,7 @@ impl ApplicationHandler<RdpOutputEvent> for App {
         }
     }
 
-    fn window_event(&mut self, event_loop: &ActiveEventLoop, window_id: winit::window::WindowId, event: WindowEvent) {
+    fn window_event(&mut self, _event_loop: &ActiveEventLoop, window_id: winit::window::WindowId, event: WindowEvent) {
         let Some((window, _)) = self.window.as_mut() else {
             return;
         };
@@ -145,10 +144,7 @@ impl ApplicationHandler<RdpOutputEvent> for App {
                 self.resize_timeout = Some(Instant::now() + Duration::from_secs(1));
             }
             WindowEvent::CloseRequested => {
-                if self.input_event_sender.send(RdpInputEvent::Close).is_err() {
-                    error!("Failed to send graceful shutdown event, closing the window");
-                    event_loop.exit();
-                }
+                self.input_event_sender.request_close();
             }
             WindowEvent::DroppedFile(_) => {
                 // TODO(#110): File upload
@@ -348,6 +344,8 @@ impl ApplicationHandler<RdpOutputEvent> for App {
             return;
         };
         match event {
+            RdpOutputEvent::Connected => info!("RDP session connected"),
+            RdpOutputEvent::LoginComplete => info!("RDP login complete"),
             RdpOutputEvent::Image { buffer, width, height } => {
                 trace!(width = ?width, height = ?height, "Received image with size");
                 trace!(window_physical_size = ?window.inner_size(), "Drawing image to the window with size");
@@ -406,15 +404,18 @@ impl ApplicationHandler<RdpOutputEvent> for App {
                 }
                 window.set_cursor_visible(true);
             }
+            RdpOutputEvent::DisplayResizeFallback(reason) => {
+                warn!(
+                    ?reason,
+                    "Reconnecting because dynamic display resize could not complete"
+                );
+            }
         }
     }
 }
 
-fn send_fast_path_events(
-    input_event_sender: &mpsc::UnboundedSender<RdpInputEvent>,
-    input_events: SmallVec<[FastPathInputEvent; 2]>,
-) {
+fn send_fast_path_events(input_event_sender: &RdpInputSender, input_events: SmallVec<[FastPathInputEvent; 2]>) {
     if !input_events.is_empty() {
-        let _ = input_event_sender.send(RdpInputEvent::FastPath(input_events));
+        let _ = input_event_sender.try_send(RdpInputEvent::FastPath(input_events));
     }
 }

--- a/crates/ironrdp-viewer/src/app.rs
+++ b/crates/ironrdp-viewer/src/app.rs
@@ -7,7 +7,6 @@ use std::time::Instant;
 
 use anyhow::Context as _;
 use ironrdp::client::rdp::{RdpInputEvent, RdpInputSender, RdpOutputEvent};
-use ironrdp::pdu::input::fast_path::FastPathInputEvent;
 use raw_window_handle::{DisplayHandle, HasDisplayHandle as _};
 use smallvec::SmallVec;
 use tracing::{debug, error, info, trace, warn};
@@ -183,9 +182,11 @@ impl ApplicationHandler<RdpOutputEvent> for App {
                         event::ElementState::Released => ironrdp::input::Operation::KeyReleased(scancode),
                     };
 
-                    let input_events = self.input_database.apply(core::iter::once(operation));
-
-                    send_fast_path_events(&self.input_event_sender, input_events);
+                    apply_and_send_fast_path_events(
+                        &self.input_event_sender,
+                        &mut self.input_database,
+                        core::iter::once(operation),
+                    );
                 }
             }
             WindowEvent::ModifiersChanged(modifiers) => {
@@ -219,9 +220,7 @@ impl ApplicationHandler<RdpOutputEvent> for App {
                 add_operation(modifiers.state().alt_key(), ALT_LEFT);
                 add_operation(modifiers.state().super_key(), LOGO_LEFT);
 
-                let input_events = self.input_database.apply(operations);
-
-                send_fast_path_events(&self.input_event_sender, input_events);
+                apply_and_send_fast_path_events(&self.input_event_sender, &mut self.input_database, operations);
             }
             WindowEvent::CursorMoved { position, .. } => {
                 let win_size = window.inner_size();
@@ -231,9 +230,11 @@ impl ApplicationHandler<RdpOutputEvent> for App {
                 let y = (position.y / f64::from(win_size.height) * f64::from(self.buffer_size.1)) as u16;
                 let operation = ironrdp::input::Operation::MouseMove(ironrdp::input::MousePosition { x, y });
 
-                let input_events = self.input_database.apply(core::iter::once(operation));
-
-                send_fast_path_events(&self.input_event_sender, input_events);
+                apply_and_send_fast_path_events(
+                    &self.input_event_sender,
+                    &mut self.input_database,
+                    core::iter::once(operation),
+                );
             }
             WindowEvent::MouseWheel { delta, .. } => {
                 let mut operations = SmallVec::<[ironrdp::input::Operation; 2]>::new();
@@ -283,9 +284,7 @@ impl ApplicationHandler<RdpOutputEvent> for App {
                     }
                 };
 
-                let input_events = self.input_database.apply(operations);
-
-                send_fast_path_events(&self.input_event_sender, input_events);
+                apply_and_send_fast_path_events(&self.input_event_sender, &mut self.input_database, operations);
             }
             WindowEvent::MouseInput { state, button, .. } => {
                 let mouse_button = match button {
@@ -308,9 +307,11 @@ impl ApplicationHandler<RdpOutputEvent> for App {
                     event::ElementState::Released => ironrdp::input::Operation::MouseButtonReleased(mouse_button),
                 };
 
-                let input_events = self.input_database.apply(core::iter::once(operation));
-
-                send_fast_path_events(&self.input_event_sender, input_events);
+                apply_and_send_fast_path_events(
+                    &self.input_event_sender,
+                    &mut self.input_database,
+                    core::iter::once(operation),
+                );
             }
             WindowEvent::RedrawRequested => {
                 self.draw();
@@ -414,8 +415,16 @@ impl ApplicationHandler<RdpOutputEvent> for App {
     }
 }
 
-fn send_fast_path_events(input_event_sender: &RdpInputSender, input_events: SmallVec<[FastPathInputEvent; 2]>) {
+fn apply_and_send_fast_path_events(
+    input_event_sender: &RdpInputSender,
+    input_database: &mut ironrdp::input::Database,
+    operations: impl IntoIterator<Item = ironrdp::input::Operation>,
+) {
+    let Ok(permit) = input_event_sender.try_reserve() else {
+        return;
+    };
+    let input_events = input_database.apply(operations);
     if !input_events.is_empty() {
-        let _ = input_event_sender.try_send(RdpInputEvent::FastPath(input_events));
+        permit.send(RdpInputEvent::FastPath(input_events));
     }
 }

--- a/crates/ironrdp-viewer/src/clipboard.rs
+++ b/crates/ironrdp-viewer/src/clipboard.rs
@@ -1,24 +1,24 @@
 use ironrdp::cliprdr::backend::{ClipboardMessage, ClipboardMessageProxy};
-use ironrdp::client::rdp::RdpInputEvent;
-use tokio::sync::mpsc;
+use ironrdp::client::rdp::{RdpInputEvent, RdpInputSender};
 use tracing::error;
 
 /// Shim for sending and receiving CLIPRDR events as `RdpInputEvent`
 #[derive(Clone, Debug)]
 pub struct ClientClipboardMessageProxy {
-    tx: mpsc::UnboundedSender<RdpInputEvent>,
+    tx: RdpInputSender,
 }
 
 impl ClientClipboardMessageProxy {
-    pub fn new(tx: mpsc::UnboundedSender<RdpInputEvent>) -> Self {
+    pub fn new(tx: RdpInputSender) -> Self {
         Self { tx }
     }
 }
 
 impl ClipboardMessageProxy for ClientClipboardMessageProxy {
     fn send_clipboard_message(&self, message: ClipboardMessage) {
-        if self.tx.send(RdpInputEvent::Clipboard(message)).is_err() {
-            error!("Failed to send os clipboard message, receiver is closed");
+        if self.tx.try_send(RdpInputEvent::Clipboard(message)).is_err() {
+            self.tx.request_close();
+            error!("Unable to enqueue OS clipboard message; cancelling RDP session");
         }
     }
 }

--- a/crates/ironrdp-viewer/src/clipboard.rs
+++ b/crates/ironrdp-viewer/src/clipboard.rs
@@ -1,5 +1,5 @@
 use ironrdp::cliprdr::backend::{ClipboardMessage, ClipboardMessageProxy};
-use ironrdp::client::rdp::{RdpInputEvent, RdpInputSender};
+use ironrdp::client::rdp::RdpInputSender;
 use tracing::error;
 
 /// Shim for sending and receiving CLIPRDR events as `RdpInputEvent`
@@ -16,9 +16,11 @@ impl ClientClipboardMessageProxy {
 
 impl ClipboardMessageProxy for ClientClipboardMessageProxy {
     fn send_clipboard_message(&self, message: ClipboardMessage) {
-        if self.tx.try_send(RdpInputEvent::Clipboard(message)).is_err() {
-            self.tx.request_close();
-            error!("Unable to enqueue OS clipboard message; cancelling RDP session");
+        match self.tx.send_clipboard(message) {
+            Ok(()) => {}
+            Err(_) => {
+                error!("Unable to enqueue OS clipboard message because the RDP session is closed");
+            }
         }
     }
 }

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -1056,6 +1056,9 @@ impl iron_remote_desktop::Session for Session {
                     ActiveStageOutput::AutoDetect(request) => {
                         debug!(?request, "Auto-detect");
                     }
+                    ActiveStageOutput::SaveSessionInfo => {
+                        debug!("RDP login complete");
+                    }
                     ActiveStageOutput::Terminate(reason) => break 'outer reason,
                 }
             }
@@ -1414,6 +1417,7 @@ fn build_config(
         keyboard_subtype: 0,
         keyboard_layout: 0, // the server SHOULD use the default active input locale identifier
         keyboard_functional_keys_count: 12,
+        connection_type: ironrdp::pdu::gcc::ConnectionType::Lan,
         ime_file_name: String::new(),
         dig_product_id: String::new(),
         desktop_size: connector::DesktopSize {

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -1056,8 +1056,11 @@ impl iron_remote_desktop::Session for Session {
                     ActiveStageOutput::AutoDetect(request) => {
                         debug!(?request, "Auto-detect");
                     }
-                    ActiveStageOutput::SaveSessionInfo => {
+                    ActiveStageOutput::SaveSessionInfo { logon_complete: true } => {
                         debug!("RDP login complete");
+                    }
+                    ActiveStageOutput::SaveSessionInfo { logon_complete: false } => {
+                        debug!("RDP session info notification");
                     }
                     ActiveStageOutput::Terminate(reason) => break 'outer reason,
                 }

--- a/crates/ironrdp/examples/screenshot.rs
+++ b/crates/ironrdp/examples/screenshot.rs
@@ -26,7 +26,7 @@ use anyhow::Context as _;
 use connector::Credentials;
 use ironrdp::connector;
 use ironrdp::connector::ConnectionResult;
-use ironrdp::pdu::gcc::KeyboardType;
+use ironrdp::pdu::gcc::{ConnectionType, KeyboardType};
 use ironrdp::pdu::rdp::capability_sets::MajorPlatformType;
 use ironrdp::session::image::DecodedImage;
 use ironrdp::session::{ActiveStageBuilder, ActiveStageOutput};

--- a/crates/ironrdp/examples/screenshot.rs
+++ b/crates/ironrdp/examples/screenshot.rs
@@ -228,6 +228,7 @@ fn build_config(
         keyboard_subtype: 0,
         keyboard_layout: 0,
         keyboard_functional_keys_count: 12,
+        connection_type: ConnectionType::Lan,
         ime_file_name: String::new(),
         dig_product_id: String::new(),
         desktop_size: connector::DesktopSize {

--- a/ffi/src/connector/config.rs
+++ b/ffi/src/connector/config.rs
@@ -182,6 +182,7 @@ pub mod ffi {
                     .unwrap_or(ironrdp::pdu::gcc::KeyboardType::IbmEnhanced),
                 keyboard_subtype: self.keyboard_subtype.unwrap_or(0),
                 keyboard_functional_keys_count: self.keyboard_functional_keys_count.unwrap_or(12),
+                connection_type: ironrdp::pdu::gcc::ConnectionType::Lan,
                 ime_file_name: self.ime_file_name.clone().unwrap_or_default(),
                 dig_product_id: self.dig_product_id.clone().unwrap_or_default(),
                 desktop_size: self.desktop_size.ok_or("desktop size not set")?,

--- a/ffi/src/session/mod.rs
+++ b/ffi/src/session/mod.rs
@@ -245,7 +245,7 @@ pub mod ffi {
                     ActiveStageOutputType::MultitransportRequest
                 }
                 ironrdp::session::ActiveStageOutput::AutoDetect { .. } => ActiveStageOutputType::AutoDetect,
-                ironrdp::session::ActiveStageOutput::SaveSessionInfo => ActiveStageOutputType::SaveSessionInfo,
+                ironrdp::session::ActiveStageOutput::SaveSessionInfo { .. } => ActiveStageOutputType::SaveSessionInfo,
             }
         }
 

--- a/ffi/src/session/mod.rs
+++ b/ffi/src/session/mod.rs
@@ -227,6 +227,7 @@ pub mod ffi {
         /// Use `get_autodetect_network_characteristics()` to retrieve
         /// RTT and bandwidth values for connection quality monitoring.
         AutoDetect,
+        SaveSessionInfo,
     }
 
     impl ActiveStageOutput {
@@ -244,6 +245,7 @@ pub mod ffi {
                     ActiveStageOutputType::MultitransportRequest
                 }
                 ironrdp::session::ActiveStageOutput::AutoDetect { .. } => ActiveStageOutputType::AutoDetect,
+                ironrdp::session::ActiveStageOutput::SaveSessionInfo => ActiveStageOutputType::SaveSessionInfo,
             }
         }
 

--- a/testing/agentic-rdp/Connect-AgentSession.ps1
+++ b/testing/agentic-rdp/Connect-AgentSession.ps1
@@ -96,7 +96,7 @@ $connectOutput | Set-Content -Path (Join-Path $ArtifactsDir 'agent-connect.txt')
 $deadline = (Get-Date).AddSeconds(120)
 do {
     $status = Get-SessionStatus
-    if ($status.state -eq 'Connected') {
+    if ($status.state -eq 'Connected' -and $null -ne $status.width -and $null -ne $status.height) {
         break
     }
 

--- a/testing/agentic-rdp/Connect-AgentSession.ps1
+++ b/testing/agentic-rdp/Connect-AgentSession.ps1
@@ -86,7 +86,7 @@ $connectOutput = Invoke-Agent connect `
         --prop "desktopwidth:i:$expectedWidth" `
         --prop "desktopheight:i:$expectedHeight" `
         --prop 'enablecredsspsupport:i:0' `
-        --prop 'ironrdp_tls:i:0' `
+        --prop 'ironrdp_certificate_validation:s:dangerously_accept_invalid_certificate' `
         --prop 'ironrdp_autologon:i:1' `
         --prop 'compression:i:0' `
         --prop 'ironrdp_colordepth:i:16' `

--- a/testing/agentic-rdp/Connect-AgentSession.ps1
+++ b/testing/agentic-rdp/Connect-AgentSession.ps1
@@ -86,6 +86,7 @@ $connectOutput = Invoke-Agent connect `
         --prop "desktopwidth:i:$expectedWidth" `
         --prop "desktopheight:i:$expectedHeight" `
         --prop 'enablecredsspsupport:i:0' `
+        --prop 'ironrdp_tls:i:0' `
         --prop 'ironrdp_autologon:i:1' `
         --prop 'compression:i:0' `
         --prop 'ironrdp_colordepth:i:16' `


### PR DESCRIPTION
## Summary
- expose generic client configuration for connection metadata, compression, shell/work directory, audio, and runtime static-channel factories
- add bounded input delivery with independent close cancellation, host clipboard plumbing, lifecycle events, and Display Control resize readiness/fallback handling
- update agent, viewer, web, FFI, examples, and tests for the generic APIs

## Stack dependencies
This PR is stacked on `copilot/tls-validation-policy` (`b2bbcece`), which already includes the merged runtime static-channel support from `master`. It intentionally contains no TLS implementation/policy, ActiveX/COM, SVC implementation, decompression, or bitmap-recovery changes.

## Validation
- `cargo fmt --check --all`
- `cargo xtask check tests --no-run -v`
- `cargo xtask check lints -v`
- `cargo test -p ironrdp-client --lib --features rustls`
- `cargo check -p ironrdp-agent -p ironrdp-viewer -p ironrdp-web -p ffi`