### PR TITLE
chore(activex): mark ironrdp-activex as unpublished

### DIFF
--- a/crates/ironrdp-activex/Cargo.toml
+++ b/crates/ironrdp-activex/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "ironrdp-activex"
 version = "0.1.0"
+publish = false
 readme = "README.md"
 description = "Windows COM Automation server foundation for IronRDP"
 edition.workspace = true


### PR DESCRIPTION
## Why

`ironrdp-activex` is a new crate that is not yet ready to be published to crates.io. Its presence in the workspace was breaking the release/publish workflow (`release-plz`), which attempts to publish every workspace crate that doesn't opt out.

## What

Set `publish = false` in `crates/ironrdp-activex/Cargo.toml`, following the same convention already used by other internal/dev-only crates (`ironrdp-web`, `ironrdp-bench`, `ironrdp-fuzzing`, `ironrdp-testsuite-core`, etc.).

## Validation

- `cargo xtask check locks -v` passes.