### PR TITLE
refactor: move inline tests to file ends

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,7 @@ Do not modify them unless specifically working on fixing their compilation.
 - **Doc comments:** link to spec sections using reference-style links.
 - **Avoid monomorphization:** use `&dyn` inner functions for large generic code; avoid `AsRef` polymorphism.
 - **No single-use helper functions:** use blocks instead; put nested helpers at end of enclosing function.
+- **Inline test modules:** place `#[cfg(test)] mod tests` (and other test-only modules) at the end of their enclosing source file or module, after all production items. Do not interleave them with normal source code.
 
 ### Dependency Policies
 

--- a/crates/ironrdp-egfx/src/server.rs
+++ b/crates/ironrdp-egfx/src/server.rs
@@ -776,174 +776,6 @@ fn sanitize_capabilities_for_confirm(mut capabilities: CapabilitySet) -> Capabil
     capabilities
 }
 
-#[cfg(test)]
-mod capability_negotiation_tests {
-    use super::*;
-
-    #[test]
-    fn preserves_client_avc_disabled_constraint() {
-        let cases = [
-            (
-                CapabilitySet::V10 {
-                    flags: CapabilitiesV10Flags::AVC_DISABLED | CapabilitiesV10Flags::SMALL_CACHE,
-                },
-                CapabilitySet::V10 {
-                    flags: CapabilitiesV10Flags::SMALL_CACHE,
-                },
-            ),
-            (
-                CapabilitySet::V10_2 {
-                    flags: CapabilitiesV10Flags::AVC_DISABLED | CapabilitiesV10Flags::SMALL_CACHE,
-                },
-                CapabilitySet::V10_2 {
-                    flags: CapabilitiesV10Flags::SMALL_CACHE,
-                },
-            ),
-            (
-                CapabilitySet::V10_3 {
-                    flags: CapabilitiesV103Flags::AVC_DISABLED,
-                },
-                CapabilitySet::V10_3 {
-                    flags: CapabilitiesV103Flags::empty(),
-                },
-            ),
-            (
-                CapabilitySet::V10_4 {
-                    flags: CapabilitiesV104Flags::AVC_DISABLED | CapabilitiesV104Flags::SMALL_CACHE,
-                },
-                CapabilitySet::V10_4 {
-                    flags: CapabilitiesV104Flags::SMALL_CACHE,
-                },
-            ),
-            (
-                CapabilitySet::V10_5 {
-                    flags: CapabilitiesV104Flags::AVC_DISABLED | CapabilitiesV104Flags::SMALL_CACHE,
-                },
-                CapabilitySet::V10_5 {
-                    flags: CapabilitiesV104Flags::SMALL_CACHE,
-                },
-            ),
-            (
-                CapabilitySet::V10_6 {
-                    flags: CapabilitiesV104Flags::AVC_DISABLED | CapabilitiesV104Flags::SMALL_CACHE,
-                },
-                CapabilitySet::V10_6 {
-                    flags: CapabilitiesV104Flags::SMALL_CACHE,
-                },
-            ),
-            (
-                CapabilitySet::V10_6Err {
-                    flags: CapabilitiesV104Flags::AVC_DISABLED | CapabilitiesV104Flags::SMALL_CACHE,
-                },
-                CapabilitySet::V10_6Err {
-                    flags: CapabilitiesV104Flags::SMALL_CACHE,
-                },
-            ),
-            (
-                CapabilitySet::V10_7 {
-                    flags: CapabilitiesV107Flags::AVC_DISABLED | CapabilitiesV107Flags::SMALL_CACHE,
-                },
-                CapabilitySet::V10_7 {
-                    flags: CapabilitiesV107Flags::SMALL_CACHE,
-                },
-            ),
-        ];
-
-        for (client, server) in cases {
-            assert_eq!(
-                negotiate_capabilities(core::slice::from_ref(&client), &[server]),
-                Some(client)
-            );
-        }
-    }
-
-    #[test]
-    fn removes_avc_thin_client_from_malformed_avc_disabled_capabilities() {
-        let cases = [
-            (
-                CapabilitySet::V10_3 {
-                    flags: CapabilitiesV103Flags::AVC_DISABLED | CapabilitiesV103Flags::AVC_THIN_CLIENT,
-                },
-                CapabilitySet::V10_3 {
-                    flags: CapabilitiesV103Flags::AVC_THIN_CLIENT,
-                },
-                CapabilitySet::V10_3 {
-                    flags: CapabilitiesV103Flags::AVC_DISABLED,
-                },
-            ),
-            (
-                CapabilitySet::V10_4 {
-                    flags: CapabilitiesV104Flags::AVC_DISABLED
-                        | CapabilitiesV104Flags::AVC_THIN_CLIENT
-                        | CapabilitiesV104Flags::SMALL_CACHE,
-                },
-                CapabilitySet::V10_4 {
-                    flags: CapabilitiesV104Flags::AVC_THIN_CLIENT | CapabilitiesV104Flags::SMALL_CACHE,
-                },
-                CapabilitySet::V10_4 {
-                    flags: CapabilitiesV104Flags::AVC_DISABLED | CapabilitiesV104Flags::SMALL_CACHE,
-                },
-            ),
-            (
-                CapabilitySet::V10_5 {
-                    flags: CapabilitiesV104Flags::AVC_DISABLED
-                        | CapabilitiesV104Flags::AVC_THIN_CLIENT
-                        | CapabilitiesV104Flags::SMALL_CACHE,
-                },
-                CapabilitySet::V10_5 {
-                    flags: CapabilitiesV104Flags::AVC_THIN_CLIENT | CapabilitiesV104Flags::SMALL_CACHE,
-                },
-                CapabilitySet::V10_5 {
-                    flags: CapabilitiesV104Flags::AVC_DISABLED | CapabilitiesV104Flags::SMALL_CACHE,
-                },
-            ),
-            (
-                CapabilitySet::V10_6 {
-                    flags: CapabilitiesV104Flags::AVC_DISABLED
-                        | CapabilitiesV104Flags::AVC_THIN_CLIENT
-                        | CapabilitiesV104Flags::SMALL_CACHE,
-                },
-                CapabilitySet::V10_6 {
-                    flags: CapabilitiesV104Flags::AVC_THIN_CLIENT | CapabilitiesV104Flags::SMALL_CACHE,
-                },
-                CapabilitySet::V10_6 {
-                    flags: CapabilitiesV104Flags::AVC_DISABLED | CapabilitiesV104Flags::SMALL_CACHE,
-                },
-            ),
-            (
-                CapabilitySet::V10_6Err {
-                    flags: CapabilitiesV104Flags::AVC_DISABLED
-                        | CapabilitiesV104Flags::AVC_THIN_CLIENT
-                        | CapabilitiesV104Flags::SMALL_CACHE,
-                },
-                CapabilitySet::V10_6Err {
-                    flags: CapabilitiesV104Flags::AVC_THIN_CLIENT | CapabilitiesV104Flags::SMALL_CACHE,
-                },
-                CapabilitySet::V10_6Err {
-                    flags: CapabilitiesV104Flags::AVC_DISABLED | CapabilitiesV104Flags::SMALL_CACHE,
-                },
-            ),
-            (
-                CapabilitySet::V10_7 {
-                    flags: CapabilitiesV107Flags::AVC_DISABLED
-                        | CapabilitiesV107Flags::AVC_THIN_CLIENT
-                        | CapabilitiesV107Flags::SMALL_CACHE,
-                },
-                CapabilitySet::V10_7 {
-                    flags: CapabilitiesV107Flags::AVC_THIN_CLIENT | CapabilitiesV107Flags::SMALL_CACHE,
-                },
-                CapabilitySet::V10_7 {
-                    flags: CapabilitiesV107Flags::AVC_DISABLED | CapabilitiesV107Flags::SMALL_CACHE,
-                },
-            ),
-        ];
-
-        for (client, server, expected) in cases {
-            assert_eq!(sanitize_capabilities_for_confirm(client.clone()), expected);
-            assert_eq!(negotiate_capabilities(&[client], &[server]), Some(expected));
-        }
-    }
-}
 
 // ============================================================================
 // Handler Trait
@@ -2082,4 +1914,173 @@ fn encode_avc444_bitmap_stream(stream: &Avc444BitmapStream<'_>) -> Vec<u8> {
         .expect("encode_avc444_bitmap_stream: encoding failed");
 
     buf
+}
+
+#[cfg(test)]
+mod capability_negotiation_tests {
+    use super::*;
+
+    #[test]
+    fn preserves_client_avc_disabled_constraint() {
+        let cases = [
+            (
+                CapabilitySet::V10 {
+                    flags: CapabilitiesV10Flags::AVC_DISABLED | CapabilitiesV10Flags::SMALL_CACHE,
+                },
+                CapabilitySet::V10 {
+                    flags: CapabilitiesV10Flags::SMALL_CACHE,
+                },
+            ),
+            (
+                CapabilitySet::V10_2 {
+                    flags: CapabilitiesV10Flags::AVC_DISABLED | CapabilitiesV10Flags::SMALL_CACHE,
+                },
+                CapabilitySet::V10_2 {
+                    flags: CapabilitiesV10Flags::SMALL_CACHE,
+                },
+            ),
+            (
+                CapabilitySet::V10_3 {
+                    flags: CapabilitiesV103Flags::AVC_DISABLED,
+                },
+                CapabilitySet::V10_3 {
+                    flags: CapabilitiesV103Flags::empty(),
+                },
+            ),
+            (
+                CapabilitySet::V10_4 {
+                    flags: CapabilitiesV104Flags::AVC_DISABLED | CapabilitiesV104Flags::SMALL_CACHE,
+                },
+                CapabilitySet::V10_4 {
+                    flags: CapabilitiesV104Flags::SMALL_CACHE,
+                },
+            ),
+            (
+                CapabilitySet::V10_5 {
+                    flags: CapabilitiesV104Flags::AVC_DISABLED | CapabilitiesV104Flags::SMALL_CACHE,
+                },
+                CapabilitySet::V10_5 {
+                    flags: CapabilitiesV104Flags::SMALL_CACHE,
+                },
+            ),
+            (
+                CapabilitySet::V10_6 {
+                    flags: CapabilitiesV104Flags::AVC_DISABLED | CapabilitiesV104Flags::SMALL_CACHE,
+                },
+                CapabilitySet::V10_6 {
+                    flags: CapabilitiesV104Flags::SMALL_CACHE,
+                },
+            ),
+            (
+                CapabilitySet::V10_6Err {
+                    flags: CapabilitiesV104Flags::AVC_DISABLED | CapabilitiesV104Flags::SMALL_CACHE,
+                },
+                CapabilitySet::V10_6Err {
+                    flags: CapabilitiesV104Flags::SMALL_CACHE,
+                },
+            ),
+            (
+                CapabilitySet::V10_7 {
+                    flags: CapabilitiesV107Flags::AVC_DISABLED | CapabilitiesV107Flags::SMALL_CACHE,
+                },
+                CapabilitySet::V10_7 {
+                    flags: CapabilitiesV107Flags::SMALL_CACHE,
+                },
+            ),
+        ];
+
+        for (client, server) in cases {
+            assert_eq!(
+                negotiate_capabilities(core::slice::from_ref(&client), &[server]),
+                Some(client)
+            );
+        }
+    }
+
+    #[test]
+    fn removes_avc_thin_client_from_malformed_avc_disabled_capabilities() {
+        let cases = [
+            (
+                CapabilitySet::V10_3 {
+                    flags: CapabilitiesV103Flags::AVC_DISABLED | CapabilitiesV103Flags::AVC_THIN_CLIENT,
+                },
+                CapabilitySet::V10_3 {
+                    flags: CapabilitiesV103Flags::AVC_THIN_CLIENT,
+                },
+                CapabilitySet::V10_3 {
+                    flags: CapabilitiesV103Flags::AVC_DISABLED,
+                },
+            ),
+            (
+                CapabilitySet::V10_4 {
+                    flags: CapabilitiesV104Flags::AVC_DISABLED
+                        | CapabilitiesV104Flags::AVC_THIN_CLIENT
+                        | CapabilitiesV104Flags::SMALL_CACHE,
+                },
+                CapabilitySet::V10_4 {
+                    flags: CapabilitiesV104Flags::AVC_THIN_CLIENT | CapabilitiesV104Flags::SMALL_CACHE,
+                },
+                CapabilitySet::V10_4 {
+                    flags: CapabilitiesV104Flags::AVC_DISABLED | CapabilitiesV104Flags::SMALL_CACHE,
+                },
+            ),
+            (
+                CapabilitySet::V10_5 {
+                    flags: CapabilitiesV104Flags::AVC_DISABLED
+                        | CapabilitiesV104Flags::AVC_THIN_CLIENT
+                        | CapabilitiesV104Flags::SMALL_CACHE,
+                },
+                CapabilitySet::V10_5 {
+                    flags: CapabilitiesV104Flags::AVC_THIN_CLIENT | CapabilitiesV104Flags::SMALL_CACHE,
+                },
+                CapabilitySet::V10_5 {
+                    flags: CapabilitiesV104Flags::AVC_DISABLED | CapabilitiesV104Flags::SMALL_CACHE,
+                },
+            ),
+            (
+                CapabilitySet::V10_6 {
+                    flags: CapabilitiesV104Flags::AVC_DISABLED
+                        | CapabilitiesV104Flags::AVC_THIN_CLIENT
+                        | CapabilitiesV104Flags::SMALL_CACHE,
+                },
+                CapabilitySet::V10_6 {
+                    flags: CapabilitiesV104Flags::AVC_THIN_CLIENT | CapabilitiesV104Flags::SMALL_CACHE,
+                },
+                CapabilitySet::V10_6 {
+                    flags: CapabilitiesV104Flags::AVC_DISABLED | CapabilitiesV104Flags::SMALL_CACHE,
+                },
+            ),
+            (
+                CapabilitySet::V10_6Err {
+                    flags: CapabilitiesV104Flags::AVC_DISABLED
+                        | CapabilitiesV104Flags::AVC_THIN_CLIENT
+                        | CapabilitiesV104Flags::SMALL_CACHE,
+                },
+                CapabilitySet::V10_6Err {
+                    flags: CapabilitiesV104Flags::AVC_THIN_CLIENT | CapabilitiesV104Flags::SMALL_CACHE,
+                },
+                CapabilitySet::V10_6Err {
+                    flags: CapabilitiesV104Flags::AVC_DISABLED | CapabilitiesV104Flags::SMALL_CACHE,
+                },
+            ),
+            (
+                CapabilitySet::V10_7 {
+                    flags: CapabilitiesV107Flags::AVC_DISABLED
+                        | CapabilitiesV107Flags::AVC_THIN_CLIENT
+                        | CapabilitiesV107Flags::SMALL_CACHE,
+                },
+                CapabilitySet::V10_7 {
+                    flags: CapabilitiesV107Flags::AVC_THIN_CLIENT | CapabilitiesV107Flags::SMALL_CACHE,
+                },
+                CapabilitySet::V10_7 {
+                    flags: CapabilitiesV107Flags::AVC_DISABLED | CapabilitiesV107Flags::SMALL_CACHE,
+                },
+            ),
+        ];
+
+        for (client, server, expected) in cases {
+            assert_eq!(sanitize_capabilities_for_confirm(client.clone()), expected);
+            assert_eq!(negotiate_capabilities(&[client], &[server]), Some(expected));
+        }
+    }
 }

--- a/crates/ironrdp-egfx/src/server.rs
+++ b/crates/ironrdp-egfx/src/server.rs
@@ -776,7 +776,6 @@ fn sanitize_capabilities_for_confirm(mut capabilities: CapabilitySet) -> Capabil
     capabilities
 }
 
-
 // ============================================================================
 // Handler Trait
 // ============================================================================

--- a/crates/ironrdp-pdu/src/lib.rs
+++ b/crates/ironrdp-pdu/src/lib.rs
@@ -178,7 +178,6 @@ pub trait PduHint: Send + Sync + fmt::Debug + 'static {
     fn find_size(&self, bytes: &[u8]) -> DecodeResult<Option<(bool, usize)>>;
 }
 
-
 // Matches both X224 and FastPath pdus
 #[derive(Clone, Copy, Debug)]
 pub struct RdpHint;

--- a/crates/ironrdp-pdu/src/lib.rs
+++ b/crates/ironrdp-pdu/src/lib.rs
@@ -178,17 +178,6 @@ pub trait PduHint: Send + Sync + fmt::Debug + 'static {
     fn find_size(&self, bytes: &[u8]) -> DecodeResult<Option<(bool, usize)>>;
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn find_size_rejects_undersized_frames() {
-        assert!(find_size(&[0x00, 0x01]).is_err());
-        assert!(find_size(&[0x00, 0x80, 0x02]).is_err());
-        assert!(find_size(&[0x03, 0x00, 0x00, 0x06]).is_err());
-    }
-}
 
 // Matches both X224 and FastPath pdus
 #[derive(Clone, Copy, Debug)]
@@ -278,3 +267,15 @@ macro_rules! custom_err {
 #[doc(hidden)]
 #[deprecated(since = "0.1.0", note = "use ironrdp_core::other_err")]
 pub use crate::pdu_other_err as other_err;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_size_rejects_undersized_frames() {
+        assert!(find_size(&[0x00, 0x01]).is_err());
+        assert!(find_size(&[0x00, 0x80, 0x02]).is_err());
+        assert!(find_size(&[0x03, 0x00, 0x00, 0x06]).is_err());
+    }
+}

--- a/crates/ironrdp-pdu/src/rdp/client_info.rs
+++ b/crates/ironrdp-pdu/src/rdp/client_info.rs
@@ -604,7 +604,6 @@ impl<'de> Decode<'de> for ExtendedClientOptionalInfo {
     }
 }
 
-
 /// [2.2.1.11.1.1.1.1] Time Zone Information (TS_TIME_ZONE_INFORMATION)
 ///
 /// The timezone info struct contains client time zone information.

--- a/crates/ironrdp-pdu/src/rdp/client_info.rs
+++ b/crates/ironrdp-pdu/src/rdp/client_info.rs
@@ -604,103 +604,6 @@ impl<'de> Decode<'de> for ExtendedClientOptionalInfo {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use ironrdp_core::{Decode as _, ReadCursor, decode, encode_vec};
-
-    use super::{ClientAutoReconnect, ExtendedClientOptionalInfo, PerformanceFlags, TimezoneInfo};
-
-    fn reconnect_cookie() -> [u8; 28] {
-        let mut cookie = [0; 28];
-        cookie[0..4].copy_from_slice(&28u32.to_le_bytes());
-        cookie[4..8].copy_from_slice(&1u32.to_le_bytes());
-        cookie[8..12].copy_from_slice(&0x1234_5678u32.to_le_bytes());
-        cookie[12..].copy_from_slice(&[0xA5; 16]);
-        cookie
-    }
-
-    #[test]
-    fn client_auto_reconnect_decodes() {
-        let cookie = reconnect_cookie();
-        let decoded = ClientAutoReconnect::decode(&mut ReadCursor::new(&cookie)).unwrap();
-
-        assert_eq!(decoded.logon_id, 0x1234_5678);
-        assert_eq!(decoded.security_verifier, [0xA5; 16]);
-    }
-
-    #[test]
-    fn client_auto_reconnect_rejects_invalid_length_and_version() {
-        let mut invalid_length = reconnect_cookie();
-        invalid_length[0..4].copy_from_slice(&27u32.to_le_bytes());
-        assert!(ClientAutoReconnect::decode(&mut ReadCursor::new(&invalid_length)).is_err());
-
-        let mut invalid_version = reconnect_cookie();
-        invalid_version[4..8].copy_from_slice(&2u32.to_le_bytes());
-        assert!(ClientAutoReconnect::decode(&mut ReadCursor::new(&invalid_version)).is_err());
-    }
-
-    /// The security verifier must not reach logs, in either of its two forms.
-    ///
-    /// `ClientInfoPdu` is logged whole by the connector when it sends it, which
-    /// is why `Credentials` above hand-writes `Debug`. The verifier belongs in
-    /// the same category: 5.5 computes it over a constant client random under
-    /// Enhanced RDP Security, so replaying it resumes the session.
-    #[test]
-    fn security_verifier_is_redacted_from_debug_output() {
-        let cookie = reconnect_cookie();
-        let parsed = ClientAutoReconnect::decode(&mut ReadCursor::new(&cookie)).unwrap();
-        let optional_info = ExtendedClientOptionalInfo {
-            timezone: Some(TimezoneInfo::default()),
-            session_id: Some(0),
-            performance_flags: Some(PerformanceFlags::default()),
-            reconnect_cookie: Some(cookie),
-            auto_reconnect: Some(parsed.clone()),
-        };
-
-        // 0xA5 renders as `165` in the derived byte-slice output.
-        for (label, rendered) in [
-            ("ClientAutoReconnect", format!("{parsed:?}")),
-            ("ExtendedClientOptionalInfo", format!("{optional_info:?}")),
-        ] {
-            assert!(!rendered.contains("165"), "{label} leaked the verifier: {rendered}");
-        }
-
-        // The session identifier is not secret and stays visible for diagnosis.
-        assert!(format!("{parsed:?}").contains(&0x1234_5678u32.to_string()));
-    }
-
-    #[test]
-    fn malformed_auto_reconnect_packet_is_preserved_but_not_offered() {
-        let mut reconnect_cookie = reconnect_cookie();
-        reconnect_cookie[4..8].copy_from_slice(&2u32.to_le_bytes());
-        let optional_info = ExtendedClientOptionalInfo {
-            timezone: Some(TimezoneInfo::default()),
-            session_id: Some(0),
-            performance_flags: Some(PerformanceFlags::default()),
-            reconnect_cookie: Some(reconnect_cookie),
-            auto_reconnect: None,
-        };
-
-        let decoded: ExtendedClientOptionalInfo = decode(&encode_vec(&optional_info).unwrap()).unwrap();
-        assert_eq!(decoded.reconnect_cookie(), Some(&reconnect_cookie));
-        assert!(decoded.auto_reconnect().is_none());
-    }
-
-    #[test]
-    fn builder_parses_valid_auto_reconnect_packet() {
-        let optional_info = ExtendedClientOptionalInfo::builder()
-            .timezone(TimezoneInfo::default())
-            .session_id(0)
-            .performance_flags(PerformanceFlags::default())
-            .reconnect_cookie(reconnect_cookie())
-            .build();
-
-        assert_eq!(
-            optional_info.auto_reconnect().map(|packet| packet.logon_id),
-            Some(0x1234_5678)
-        );
-    }
-}
 
 /// [2.2.1.11.1.1.1.1] Time Zone Information (TS_TIME_ZONE_INFORMATION)
 ///
@@ -1170,5 +1073,103 @@ pub mod builder {
                 _phantom_data: Default::default(),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ironrdp_core::{Decode as _, ReadCursor, decode, encode_vec};
+
+    use super::{ClientAutoReconnect, ExtendedClientOptionalInfo, PerformanceFlags, TimezoneInfo};
+
+    fn reconnect_cookie() -> [u8; 28] {
+        let mut cookie = [0; 28];
+        cookie[0..4].copy_from_slice(&28u32.to_le_bytes());
+        cookie[4..8].copy_from_slice(&1u32.to_le_bytes());
+        cookie[8..12].copy_from_slice(&0x1234_5678u32.to_le_bytes());
+        cookie[12..].copy_from_slice(&[0xA5; 16]);
+        cookie
+    }
+
+    #[test]
+    fn client_auto_reconnect_decodes() {
+        let cookie = reconnect_cookie();
+        let decoded = ClientAutoReconnect::decode(&mut ReadCursor::new(&cookie)).unwrap();
+
+        assert_eq!(decoded.logon_id, 0x1234_5678);
+        assert_eq!(decoded.security_verifier, [0xA5; 16]);
+    }
+
+    #[test]
+    fn client_auto_reconnect_rejects_invalid_length_and_version() {
+        let mut invalid_length = reconnect_cookie();
+        invalid_length[0..4].copy_from_slice(&27u32.to_le_bytes());
+        assert!(ClientAutoReconnect::decode(&mut ReadCursor::new(&invalid_length)).is_err());
+
+        let mut invalid_version = reconnect_cookie();
+        invalid_version[4..8].copy_from_slice(&2u32.to_le_bytes());
+        assert!(ClientAutoReconnect::decode(&mut ReadCursor::new(&invalid_version)).is_err());
+    }
+
+    /// The security verifier must not reach logs, in either of its two forms.
+    ///
+    /// `ClientInfoPdu` is logged whole by the connector when it sends it, which
+    /// is why `Credentials` above hand-writes `Debug`. The verifier belongs in
+    /// the same category: 5.5 computes it over a constant client random under
+    /// Enhanced RDP Security, so replaying it resumes the session.
+    #[test]
+    fn security_verifier_is_redacted_from_debug_output() {
+        let cookie = reconnect_cookie();
+        let parsed = ClientAutoReconnect::decode(&mut ReadCursor::new(&cookie)).unwrap();
+        let optional_info = ExtendedClientOptionalInfo {
+            timezone: Some(TimezoneInfo::default()),
+            session_id: Some(0),
+            performance_flags: Some(PerformanceFlags::default()),
+            reconnect_cookie: Some(cookie),
+            auto_reconnect: Some(parsed.clone()),
+        };
+
+        // 0xA5 renders as `165` in the derived byte-slice output.
+        for (label, rendered) in [
+            ("ClientAutoReconnect", format!("{parsed:?}")),
+            ("ExtendedClientOptionalInfo", format!("{optional_info:?}")),
+        ] {
+            assert!(!rendered.contains("165"), "{label} leaked the verifier: {rendered}");
+        }
+
+        // The session identifier is not secret and stays visible for diagnosis.
+        assert!(format!("{parsed:?}").contains(&0x1234_5678u32.to_string()));
+    }
+
+    #[test]
+    fn malformed_auto_reconnect_packet_is_preserved_but_not_offered() {
+        let mut reconnect_cookie = reconnect_cookie();
+        reconnect_cookie[4..8].copy_from_slice(&2u32.to_le_bytes());
+        let optional_info = ExtendedClientOptionalInfo {
+            timezone: Some(TimezoneInfo::default()),
+            session_id: Some(0),
+            performance_flags: Some(PerformanceFlags::default()),
+            reconnect_cookie: Some(reconnect_cookie),
+            auto_reconnect: None,
+        };
+
+        let decoded: ExtendedClientOptionalInfo = decode(&encode_vec(&optional_info).unwrap()).unwrap();
+        assert_eq!(decoded.reconnect_cookie(), Some(&reconnect_cookie));
+        assert!(decoded.auto_reconnect().is_none());
+    }
+
+    #[test]
+    fn builder_parses_valid_auto_reconnect_packet() {
+        let optional_info = ExtendedClientOptionalInfo::builder()
+            .timezone(TimezoneInfo::default())
+            .session_id(0)
+            .performance_flags(PerformanceFlags::default())
+            .reconnect_cookie(reconnect_cookie())
+            .build();
+
+        assert_eq!(
+            optional_info.auto_reconnect().map(|packet| packet.logon_id),
+            Some(0x1234_5678)
+        );
     }
 }

--- a/crates/ironrdp-session/src/fast_path.rs
+++ b/crates/ironrdp-session/src/fast_path.rs
@@ -111,350 +111,6 @@ impl FastPathBulkDecompressionFailure {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use ironrdp_pdu::bitmap::{BitmapData, Compression};
-    use ironrdp_pdu::geometry::ExclusiveRectangle;
-    use ironrdp_pdu::pointer::{ColorPointerAttribute, Point16, PointerAttribute};
-    use ironrdp_pdu::surface_commands::{ExtendedBitmapDataPdu, SurfaceBitsPdu};
-
-    use ironrdp_graphics::rdp6::{BitmapStreamEncoder, RgbChannels};
-
-    use super::*;
-
-    #[test]
-    fn raw_bitmap_removes_byte_padding_without_changing_source_stride() {
-        let mut processor = ProcessorBuilder {
-            io_channel_id: 0,
-            user_channel_id: 0,
-            share_id: 0,
-            enable_server_pointer: false,
-            pointer_software_rendering: false,
-        }
-        .build();
-        let mut image = DecodedImage::new(PixelFormat::RgbA32, 4, 3);
-
-        // Two bottom-up BGR rows of three source pixels each. The final source
-        // column is outside the destination and each row has three pad bytes.
-        let bitmap_data = [
-            3, 2, 1, 6, 5, 4, 9, 8, 7, 0xff, 0xff, 0xff, // bottom row
-            15, 14, 13, 18, 17, 16, 21, 20, 19, 0xff, 0xff, 0xff, // top row
-        ];
-        let bitmap_update = BitmapUpdateData {
-            rectangles: vec![BitmapData {
-                rectangle: InclusiveRectangle {
-                    left: 1,
-                    top: 0,
-                    right: 2,
-                    bottom: 1,
-                },
-                width: 3,
-                height: 2,
-                bits_per_pixel: 24,
-                compression_flags: Compression::empty(),
-                compressed_data_header: None,
-                bitmap_data: &bitmap_data,
-            }],
-        };
-
-        processor.process_bitmap_update(&mut image, bitmap_update).unwrap();
-
-        let pixel = |x: usize, y: usize| -> [u8; 4] {
-            let offset = (y * usize::from(image.width()) + x) * 4;
-            image.data()[offset..offset + 4]
-                .try_into()
-                .expect("pixel has four channels")
-        };
-        assert_eq!(pixel(1, 0), [13, 14, 15, 255]);
-        assert_eq!(pixel(2, 0), [16, 17, 18, 255]);
-        assert_eq!(pixel(1, 1), [1, 2, 3, 255]);
-        assert_eq!(pixel(2, 1), [4, 5, 6, 255]);
-        assert_eq!(pixel(3, 0), [0, 0, 0, 0]);
-    }
-
-    #[test]
-    fn rdp6_bitmap_update_flips_bottom_up_scanlines_before_blitting() {
-        for rle in [false, true] {
-            let mut processor = ProcessorBuilder {
-                io_channel_id: 0,
-                user_channel_id: 0,
-                share_id: 0,
-                enable_server_pointer: false,
-                pointer_software_rendering: false,
-            }
-            .build();
-            let mut image = DecodedImage::new(PixelFormat::RgbA32, 2, 2);
-
-            // Keep the first stream row distinct from the last so the row flip is observable.
-            let wire_rgb = [
-                30, 31, 32, 40, 41, 42, // first stream row
-                10, 11, 12, 20, 21, 22, // last stream row
-            ];
-            let mut bitmap_data = vec![0; wire_rgb.len() + 8];
-            let written = BitmapStreamEncoder::new(2, 2)
-                .encode_bitmap::<RgbChannels>(&wire_rgb, &mut bitmap_data, rle)
-                .unwrap();
-
-            let bitmap_update = BitmapUpdateData {
-                rectangles: vec![BitmapData {
-                    rectangle: InclusiveRectangle {
-                        left: 0,
-                        top: 0,
-                        right: 1,
-                        bottom: 1,
-                    },
-                    width: 2,
-                    height: 2,
-                    bits_per_pixel: 32,
-                    compression_flags: Compression::BITMAP_COMPRESSION,
-                    compressed_data_header: None,
-                    bitmap_data: &bitmap_data[..written],
-                }],
-            };
-
-            processor.process_bitmap_update(&mut image, bitmap_update).unwrap();
-
-            let pixel = |x: usize, y: usize| -> [u8; 4] {
-                let offset = (y * usize::from(image.width()) + x) * 4;
-                image.data()[offset..offset + 4]
-                    .try_into()
-                    .expect("pixel has four channels")
-            };
-            assert_eq!(pixel(0, 0), [10, 11, 12, 255], "RLE: {rle}");
-            assert_eq!(pixel(1, 0), [20, 21, 22, 255], "RLE: {rle}");
-            assert_eq!(pixel(0, 1), [30, 31, 32, 255], "RLE: {rle}");
-            assert_eq!(pixel(1, 1), [40, 41, 42, 255], "RLE: {rle}");
-        }
-    }
-
-    #[test]
-    fn malformed_bitmap_requests_one_recovery_without_terminating_the_session() {
-        let mut processor = ProcessorBuilder {
-            io_channel_id: 1003,
-            user_channel_id: 1001,
-            share_id: 1,
-            enable_server_pointer: false,
-            pointer_software_rendering: false,
-        }
-        .build();
-        let mut image = DecodedImage::new(PixelFormat::RgbA32, 1, 1);
-        let mut frame = ironrdp_core::encode_vec(&FastPathHeader::new(
-            ironrdp_pdu::fast_path::EncryptionFlags::empty(),
-            1 /* update header */ + 2 /* update data length */ + 3_200, /* truncated update data */
-        ))
-        .unwrap();
-        frame.push(UpdateCode::Bitmap.as_u8());
-        frame.extend_from_slice(&48_788u16.to_le_bytes());
-        frame.resize(frame.len() + 3_200, 0);
-        let mut output = WriteBuf::new();
-        let mut bulk_decompressor = None;
-
-        assert!(
-            processor
-                .process(&mut image, &frame, &mut output, &mut bulk_decompressor)
-                .is_ok()
-        );
-        assert!(processor.take_bitmap_recovery_request());
-        assert!(!processor.take_bitmap_recovery_request());
-
-        assert!(
-            processor
-                .process(&mut image, &frame, &mut output, &mut bulk_decompressor)
-                .is_ok()
-        );
-        assert!(!processor.take_bitmap_recovery_request());
-    }
-
-    #[test]
-    fn malformed_bitmap_content_requests_recovery_without_terminating_the_session() {
-        let mut processor = ProcessorBuilder {
-            io_channel_id: 1003,
-            user_channel_id: 1001,
-            share_id: 1,
-            enable_server_pointer: false,
-            pointer_software_rendering: false,
-        }
-        .build();
-        let mut image = DecodedImage::new(PixelFormat::RgbA32, 1, 1);
-        let bitmap_update = BitmapUpdateData {
-            rectangles: vec![BitmapData {
-                rectangle: InclusiveRectangle {
-                    left: 0,
-                    top: 0,
-                    right: 0,
-                    bottom: 0,
-                },
-                width: 1,
-                height: 1,
-                bits_per_pixel: 16,
-                compression_flags: Compression::empty(),
-                compressed_data_header: None,
-                bitmap_data: &[],
-            }],
-        };
-
-        assert!(processor.process_bitmap_update(&mut image, bitmap_update).is_ok());
-        assert!(processor.take_bitmap_recovery_request());
-    }
-
-    #[test]
-    fn malformed_surface_bitmap_requests_recovery_without_terminating_the_session() {
-        let mut processor = ProcessorBuilder {
-            io_channel_id: 1003,
-            user_channel_id: 1001,
-            share_id: 1,
-            enable_server_pointer: false,
-            pointer_software_rendering: false,
-        }
-        .build();
-        let mut image = DecodedImage::new(PixelFormat::RgbA32, 1, 1);
-        let mut output = WriteBuf::new();
-        let surface_bits = SurfaceBitsPdu {
-            destination: ExclusiveRectangle {
-                left: 0,
-                top: 0,
-                right: 1,
-                bottom: 1,
-            },
-            extended_bitmap_data: ExtendedBitmapDataPdu {
-                bpp: 16,
-                codec_id: 0,
-                width: 1,
-                height: 1,
-                header: None,
-                data: &[],
-            },
-        };
-
-        assert!(
-            processor
-                .process_surface_commands(
-                    &mut image,
-                    &mut output,
-                    vec![SurfaceCommand::SetSurfaceBits(surface_bits)]
-                )
-                .is_ok()
-        );
-        assert!(processor.take_bitmap_recovery_request());
-    }
-
-    #[test]
-    fn truncated_fast_path_pointer_updates_do_not_terminate_the_session() {
-        let mut processor = ProcessorBuilder {
-            io_channel_id: 1003,
-            user_channel_id: 1001,
-            share_id: 1,
-            enable_server_pointer: true,
-            pointer_software_rendering: false,
-        }
-        .build();
-        let mut image = DecodedImage::new(PixelFormat::RgbA32, 1, 1);
-        let mut output = WriteBuf::new();
-        let mut bulk_decompressor = None;
-
-        let mut truncated_outer = ironrdp_core::encode_vec(&FastPathHeader::new(
-            ironrdp_pdu::fast_path::EncryptionFlags::empty(),
-            1 /* update header */ + 2 /* update data length */ + 3_200, /* truncated update data */
-        ))
-        .unwrap();
-        truncated_outer.push(UpdateCode::ColorPointer.as_u8());
-        truncated_outer.extend_from_slice(&48_788u16.to_le_bytes());
-        truncated_outer.resize(truncated_outer.len() + 3_200, 0);
-
-        assert!(
-            processor
-                .process(&mut image, &truncated_outer, &mut output, &mut bulk_decompressor)
-                .is_ok()
-        );
-        assert!(!processor.take_bitmap_recovery_request());
-
-        let truncated_pointer = ironrdp_core::encode_vec(&FastPathUpdatePdu {
-            fragmentation: Fragmentation::Single,
-            update_code: UpdateCode::ColorPointer,
-            compression_flags: None,
-            compression_type: None,
-            data: &[],
-        })
-        .unwrap();
-        let mut truncated_inner = ironrdp_core::encode_vec(&FastPathHeader::new(
-            ironrdp_pdu::fast_path::EncryptionFlags::empty(),
-            truncated_pointer.len(),
-        ))
-        .unwrap();
-        truncated_inner.extend_from_slice(&truncated_pointer);
-
-        assert!(
-            processor
-                .process(&mut image, &truncated_inner, &mut output, &mut bulk_decompressor)
-                .is_ok()
-        );
-        assert!(!processor.take_bitmap_recovery_request());
-    }
-
-    #[test]
-    fn unsupported_new_pointer_uses_default_and_evicts_cached_shape() {
-        let mut processor = ProcessorBuilder {
-            io_channel_id: 0,
-            user_channel_id: 0,
-            share_id: 0,
-            enable_server_pointer: true,
-            pointer_software_rendering: false,
-        }
-        .build();
-        processor
-            .pointer_cache
-            .insert(0, Arc::new(DecodedPointer::new_invisible()));
-        let mut image = DecodedImage::new(PixelFormat::RgbA32, 4, 3);
-        let pointer = PointerAttribute {
-            xor_bpp: 2,
-            color_pointer: ColorPointerAttribute {
-                cache_index: 0,
-                hot_spot: Point16 { x: 0, y: 0 },
-                width: 1,
-                height: 1,
-                xor_mask: &[],
-                and_mask: &[],
-            },
-        };
-        let updates = processor
-            .process_pointer_update(&mut image, PointerUpdateData::New(pointer))
-            .expect("unsupported pointer must not fail the session");
-
-        assert!(matches!(updates.as_slice(), [UpdateKind::PointerDefault]));
-        assert!(!processor.pointer_cache.is_cached(0));
-    }
-
-    #[test]
-    fn malformed_color_pointer_uses_default_and_evicts_cached_shape() {
-        let mut processor = ProcessorBuilder {
-            io_channel_id: 0,
-            user_channel_id: 0,
-            share_id: 0,
-            enable_server_pointer: true,
-            pointer_software_rendering: false,
-        }
-        .build();
-        processor
-            .pointer_cache
-            .insert(0, Arc::new(DecodedPointer::new_invisible()));
-        let mut image = DecodedImage::new(PixelFormat::RgbA32, 4, 3);
-        let pointer = ColorPointerAttribute {
-            cache_index: 0,
-            hot_spot: Point16 { x: 0, y: 0 },
-            width: 1,
-            height: 1,
-            xor_mask: &[],
-            and_mask: &[],
-        };
-
-        let updates = processor
-            .process_pointer_update(&mut image, PointerUpdateData::Color(pointer))
-            .expect("malformed pointer must not fail the session");
-
-        assert!(matches!(updates.as_slice(), [UpdateKind::PointerDefault]));
-        assert!(!processor.pointer_cache.is_cached(0));
-    }
-}
 
 #[derive(Debug)]
 pub enum UpdateKind {
@@ -1374,6 +1030,387 @@ fn is_visual_update_code(update_code: u8) -> bool {
         )
 }
 
+
+struct FrameMarkerProcessor {
+    user_channel_id: u16,
+    io_channel_id: u16,
+    share_id: u32,
+}
+
+impl FrameMarkerProcessor {
+    fn new(user_channel_id: u16, io_channel_id: u16, share_id: u32) -> Self {
+        Self {
+            user_channel_id,
+            io_channel_id,
+            share_id,
+        }
+    }
+
+    fn process(&mut self, marker: &FrameMarkerPdu, output: &mut WriteBuf) -> SessionResult<()> {
+        match marker.frame_action {
+            FrameAction::Begin => Ok(()),
+            FrameAction::End => {
+                ironrdp_pdu::rdp::headers::encode_share_data(
+                    self.user_channel_id,
+                    self.io_channel_id,
+                    self.share_id,
+                    ShareDataPdu::FrameAcknowledge(FrameAcknowledgePdu {
+                        frame_id: marker.frame_id.unwrap_or(0),
+                    }),
+                    output,
+                )
+                .map_err(SessionError::encode)?;
+
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ironrdp_pdu::bitmap::{BitmapData, Compression};
+    use ironrdp_pdu::geometry::ExclusiveRectangle;
+    use ironrdp_pdu::pointer::{ColorPointerAttribute, Point16, PointerAttribute};
+    use ironrdp_pdu::surface_commands::{ExtendedBitmapDataPdu, SurfaceBitsPdu};
+
+    use ironrdp_graphics::rdp6::{BitmapStreamEncoder, RgbChannels};
+
+    use super::*;
+
+    #[test]
+    fn raw_bitmap_removes_byte_padding_without_changing_source_stride() {
+        let mut processor = ProcessorBuilder {
+            io_channel_id: 0,
+            user_channel_id: 0,
+            share_id: 0,
+            enable_server_pointer: false,
+            pointer_software_rendering: false,
+        }
+        .build();
+        let mut image = DecodedImage::new(PixelFormat::RgbA32, 4, 3);
+
+        // Two bottom-up BGR rows of three source pixels each. The final source
+        // column is outside the destination and each row has three pad bytes.
+        let bitmap_data = [
+            3, 2, 1, 6, 5, 4, 9, 8, 7, 0xff, 0xff, 0xff, // bottom row
+            15, 14, 13, 18, 17, 16, 21, 20, 19, 0xff, 0xff, 0xff, // top row
+        ];
+        let bitmap_update = BitmapUpdateData {
+            rectangles: vec![BitmapData {
+                rectangle: InclusiveRectangle {
+                    left: 1,
+                    top: 0,
+                    right: 2,
+                    bottom: 1,
+                },
+                width: 3,
+                height: 2,
+                bits_per_pixel: 24,
+                compression_flags: Compression::empty(),
+                compressed_data_header: None,
+                bitmap_data: &bitmap_data,
+            }],
+        };
+
+        processor.process_bitmap_update(&mut image, bitmap_update).unwrap();
+
+        let pixel = |x: usize, y: usize| -> [u8; 4] {
+            let offset = (y * usize::from(image.width()) + x) * 4;
+            image.data()[offset..offset + 4]
+                .try_into()
+                .expect("pixel has four channels")
+        };
+        assert_eq!(pixel(1, 0), [13, 14, 15, 255]);
+        assert_eq!(pixel(2, 0), [16, 17, 18, 255]);
+        assert_eq!(pixel(1, 1), [1, 2, 3, 255]);
+        assert_eq!(pixel(2, 1), [4, 5, 6, 255]);
+        assert_eq!(pixel(3, 0), [0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn rdp6_bitmap_update_flips_bottom_up_scanlines_before_blitting() {
+        for rle in [false, true] {
+            let mut processor = ProcessorBuilder {
+                io_channel_id: 0,
+                user_channel_id: 0,
+                share_id: 0,
+                enable_server_pointer: false,
+                pointer_software_rendering: false,
+            }
+            .build();
+            let mut image = DecodedImage::new(PixelFormat::RgbA32, 2, 2);
+
+            // Keep the first stream row distinct from the last so the row flip is observable.
+            let wire_rgb = [
+                30, 31, 32, 40, 41, 42, // first stream row
+                10, 11, 12, 20, 21, 22, // last stream row
+            ];
+            let mut bitmap_data = vec![0; wire_rgb.len() + 8];
+            let written = BitmapStreamEncoder::new(2, 2)
+                .encode_bitmap::<RgbChannels>(&wire_rgb, &mut bitmap_data, rle)
+                .unwrap();
+
+            let bitmap_update = BitmapUpdateData {
+                rectangles: vec![BitmapData {
+                    rectangle: InclusiveRectangle {
+                        left: 0,
+                        top: 0,
+                        right: 1,
+                        bottom: 1,
+                    },
+                    width: 2,
+                    height: 2,
+                    bits_per_pixel: 32,
+                    compression_flags: Compression::BITMAP_COMPRESSION,
+                    compressed_data_header: None,
+                    bitmap_data: &bitmap_data[..written],
+                }],
+            };
+
+            processor.process_bitmap_update(&mut image, bitmap_update).unwrap();
+
+            let pixel = |x: usize, y: usize| -> [u8; 4] {
+                let offset = (y * usize::from(image.width()) + x) * 4;
+                image.data()[offset..offset + 4]
+                    .try_into()
+                    .expect("pixel has four channels")
+            };
+            assert_eq!(pixel(0, 0), [10, 11, 12, 255], "RLE: {rle}");
+            assert_eq!(pixel(1, 0), [20, 21, 22, 255], "RLE: {rle}");
+            assert_eq!(pixel(0, 1), [30, 31, 32, 255], "RLE: {rle}");
+            assert_eq!(pixel(1, 1), [40, 41, 42, 255], "RLE: {rle}");
+        }
+    }
+
+    #[test]
+    fn malformed_bitmap_requests_one_recovery_without_terminating_the_session() {
+        let mut processor = ProcessorBuilder {
+            io_channel_id: 1003,
+            user_channel_id: 1001,
+            share_id: 1,
+            enable_server_pointer: false,
+            pointer_software_rendering: false,
+        }
+        .build();
+        let mut image = DecodedImage::new(PixelFormat::RgbA32, 1, 1);
+        let mut frame = ironrdp_core::encode_vec(&FastPathHeader::new(
+            ironrdp_pdu::fast_path::EncryptionFlags::empty(),
+            1 /* update header */ + 2 /* update data length */ + 3_200, /* truncated update data */
+        ))
+        .unwrap();
+        frame.push(UpdateCode::Bitmap.as_u8());
+        frame.extend_from_slice(&48_788u16.to_le_bytes());
+        frame.resize(frame.len() + 3_200, 0);
+        let mut output = WriteBuf::new();
+        let mut bulk_decompressor = None;
+
+        assert!(
+            processor
+                .process(&mut image, &frame, &mut output, &mut bulk_decompressor)
+                .is_ok()
+        );
+        assert!(processor.take_bitmap_recovery_request());
+        assert!(!processor.take_bitmap_recovery_request());
+
+        assert!(
+            processor
+                .process(&mut image, &frame, &mut output, &mut bulk_decompressor)
+                .is_ok()
+        );
+        assert!(!processor.take_bitmap_recovery_request());
+    }
+
+    #[test]
+    fn malformed_bitmap_content_requests_recovery_without_terminating_the_session() {
+        let mut processor = ProcessorBuilder {
+            io_channel_id: 1003,
+            user_channel_id: 1001,
+            share_id: 1,
+            enable_server_pointer: false,
+            pointer_software_rendering: false,
+        }
+        .build();
+        let mut image = DecodedImage::new(PixelFormat::RgbA32, 1, 1);
+        let bitmap_update = BitmapUpdateData {
+            rectangles: vec![BitmapData {
+                rectangle: InclusiveRectangle {
+                    left: 0,
+                    top: 0,
+                    right: 0,
+                    bottom: 0,
+                },
+                width: 1,
+                height: 1,
+                bits_per_pixel: 16,
+                compression_flags: Compression::empty(),
+                compressed_data_header: None,
+                bitmap_data: &[],
+            }],
+        };
+
+        assert!(processor.process_bitmap_update(&mut image, bitmap_update).is_ok());
+        assert!(processor.take_bitmap_recovery_request());
+    }
+
+    #[test]
+    fn malformed_surface_bitmap_requests_recovery_without_terminating_the_session() {
+        let mut processor = ProcessorBuilder {
+            io_channel_id: 1003,
+            user_channel_id: 1001,
+            share_id: 1,
+            enable_server_pointer: false,
+            pointer_software_rendering: false,
+        }
+        .build();
+        let mut image = DecodedImage::new(PixelFormat::RgbA32, 1, 1);
+        let mut output = WriteBuf::new();
+        let surface_bits = SurfaceBitsPdu {
+            destination: ExclusiveRectangle {
+                left: 0,
+                top: 0,
+                right: 1,
+                bottom: 1,
+            },
+            extended_bitmap_data: ExtendedBitmapDataPdu {
+                bpp: 16,
+                codec_id: 0,
+                width: 1,
+                height: 1,
+                header: None,
+                data: &[],
+            },
+        };
+
+        assert!(
+            processor
+                .process_surface_commands(
+                    &mut image,
+                    &mut output,
+                    vec![SurfaceCommand::SetSurfaceBits(surface_bits)]
+                )
+                .is_ok()
+        );
+        assert!(processor.take_bitmap_recovery_request());
+    }
+
+    #[test]
+    fn truncated_fast_path_pointer_updates_do_not_terminate_the_session() {
+        let mut processor = ProcessorBuilder {
+            io_channel_id: 1003,
+            user_channel_id: 1001,
+            share_id: 1,
+            enable_server_pointer: true,
+            pointer_software_rendering: false,
+        }
+        .build();
+        let mut image = DecodedImage::new(PixelFormat::RgbA32, 1, 1);
+        let mut output = WriteBuf::new();
+        let mut bulk_decompressor = None;
+
+        let mut truncated_outer = ironrdp_core::encode_vec(&FastPathHeader::new(
+            ironrdp_pdu::fast_path::EncryptionFlags::empty(),
+            1 /* update header */ + 2 /* update data length */ + 3_200, /* truncated update data */
+        ))
+        .unwrap();
+        truncated_outer.push(UpdateCode::ColorPointer.as_u8());
+        truncated_outer.extend_from_slice(&48_788u16.to_le_bytes());
+        truncated_outer.resize(truncated_outer.len() + 3_200, 0);
+
+        assert!(
+            processor
+                .process(&mut image, &truncated_outer, &mut output, &mut bulk_decompressor)
+                .is_ok()
+        );
+        assert!(!processor.take_bitmap_recovery_request());
+
+        let truncated_pointer = ironrdp_core::encode_vec(&FastPathUpdatePdu {
+            fragmentation: Fragmentation::Single,
+            update_code: UpdateCode::ColorPointer,
+            compression_flags: None,
+            compression_type: None,
+            data: &[],
+        })
+        .unwrap();
+        let mut truncated_inner = ironrdp_core::encode_vec(&FastPathHeader::new(
+            ironrdp_pdu::fast_path::EncryptionFlags::empty(),
+            truncated_pointer.len(),
+        ))
+        .unwrap();
+        truncated_inner.extend_from_slice(&truncated_pointer);
+
+        assert!(
+            processor
+                .process(&mut image, &truncated_inner, &mut output, &mut bulk_decompressor)
+                .is_ok()
+        );
+        assert!(!processor.take_bitmap_recovery_request());
+    }
+
+    #[test]
+    fn unsupported_new_pointer_uses_default_and_evicts_cached_shape() {
+        let mut processor = ProcessorBuilder {
+            io_channel_id: 0,
+            user_channel_id: 0,
+            share_id: 0,
+            enable_server_pointer: true,
+            pointer_software_rendering: false,
+        }
+        .build();
+        processor
+            .pointer_cache
+            .insert(0, Arc::new(DecodedPointer::new_invisible()));
+        let mut image = DecodedImage::new(PixelFormat::RgbA32, 4, 3);
+        let pointer = PointerAttribute {
+            xor_bpp: 2,
+            color_pointer: ColorPointerAttribute {
+                cache_index: 0,
+                hot_spot: Point16 { x: 0, y: 0 },
+                width: 1,
+                height: 1,
+                xor_mask: &[],
+                and_mask: &[],
+            },
+        };
+        let updates = processor
+            .process_pointer_update(&mut image, PointerUpdateData::New(pointer))
+            .expect("unsupported pointer must not fail the session");
+
+        assert!(matches!(updates.as_slice(), [UpdateKind::PointerDefault]));
+        assert!(!processor.pointer_cache.is_cached(0));
+    }
+
+    #[test]
+    fn malformed_color_pointer_uses_default_and_evicts_cached_shape() {
+        let mut processor = ProcessorBuilder {
+            io_channel_id: 0,
+            user_channel_id: 0,
+            share_id: 0,
+            enable_server_pointer: true,
+            pointer_software_rendering: false,
+        }
+        .build();
+        processor
+            .pointer_cache
+            .insert(0, Arc::new(DecodedPointer::new_invisible()));
+        let mut image = DecodedImage::new(PixelFormat::RgbA32, 4, 3);
+        let pointer = ColorPointerAttribute {
+            cache_index: 0,
+            hot_spot: Point16 { x: 0, y: 0 },
+            width: 1,
+            height: 1,
+            xor_mask: &[],
+            and_mask: &[],
+        };
+
+        let updates = processor
+            .process_pointer_update(&mut image, PointerUpdateData::Color(pointer))
+            .expect("malformed pointer must not fail the session");
+
+        assert!(matches!(updates.as_slice(), [UpdateKind::PointerDefault]));
+        assert!(!processor.pointer_cache.is_cached(0));
+    }
+}
 #[cfg(test)]
 mod compression_tests {
     use super::*;
@@ -1465,41 +1502,5 @@ mod compression_tests {
         assert_eq!(failure.fragmentation(), Fragmentation::First.as_u8());
         assert_eq!(failure.payload_length(), 1_024);
         assert_eq!(failure.error_kind(), BulkDecompressionErrorKind::InvalidCompressedData);
-    }
-}
-
-struct FrameMarkerProcessor {
-    user_channel_id: u16,
-    io_channel_id: u16,
-    share_id: u32,
-}
-
-impl FrameMarkerProcessor {
-    fn new(user_channel_id: u16, io_channel_id: u16, share_id: u32) -> Self {
-        Self {
-            user_channel_id,
-            io_channel_id,
-            share_id,
-        }
-    }
-
-    fn process(&mut self, marker: &FrameMarkerPdu, output: &mut WriteBuf) -> SessionResult<()> {
-        match marker.frame_action {
-            FrameAction::Begin => Ok(()),
-            FrameAction::End => {
-                ironrdp_pdu::rdp::headers::encode_share_data(
-                    self.user_channel_id,
-                    self.io_channel_id,
-                    self.share_id,
-                    ShareDataPdu::FrameAcknowledge(FrameAcknowledgePdu {
-                        frame_id: marker.frame_id.unwrap_or(0),
-                    }),
-                    output,
-                )
-                .map_err(SessionError::encode)?;
-
-                Ok(())
-            }
-        }
     }
 }

--- a/crates/ironrdp-session/src/fast_path.rs
+++ b/crates/ironrdp-session/src/fast_path.rs
@@ -111,7 +111,6 @@ impl FastPathBulkDecompressionFailure {
     }
 }
 
-
 #[derive(Debug)]
 pub enum UpdateKind {
     None,
@@ -1029,7 +1028,6 @@ fn is_visual_update_code(update_code: u8) -> bool {
                 || code == UpdateCode::LargePointer.as_u8()
         )
 }
-
 
 struct FrameMarkerProcessor {
     user_channel_id: u16,


### PR DESCRIPTION
Inline test modules were interleaved with production code, which made the affected source files harder to follow.

Relocate the affected test modules to the ends of their files while preserving their contents and behavior. This groups both Fast-Path test modules together and applies the same layout to the PDU and EGFX modules.

Tests: `cargo test -p ironrdp-session -p ironrdp-pdu -p ironrdp-egfx`