### PR TITLE
ci: fix Claude JSON schema compatibility

### DIFF
--- a/.github/pr-automation/schemas/classifier.json
+++ b/.github/pr-automation/schemas/classifier.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/Devolutions/IronRDP/pr-automation/classifier-v1",
   "type": "object",
   "additionalProperties": false,

--- a/.github/pr-automation/schemas/protocol-reviewer.json
+++ b/.github/pr-automation/schemas/protocol-reviewer.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "additionalProperties": false,
   "required": ["schema_version", "head_sha", "protocol_relevance", "relevance_reason", "protocols_consulted", "change_mappings", "potential_discrepancies", "required_or_valuable_tests", "uncertainty"],

--- a/.github/pr-automation/schemas/reviewer.json
+++ b/.github/pr-automation/schemas/reviewer.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/Devolutions/IronRDP/pr-automation/reviewer-v1",
   "type": "object",
   "additionalProperties": false,


### PR DESCRIPTION
## Summary
- remove the unsupported Draft 2020-12 declaration from AI structured-output schemas
- let the Claude action SDK use its supported default schema dialect for classifier, protocol reviewer, and reviewer jobs

## Testing
- `node --test .github/pr-automation/automation.test.js`