### PR TITLE
ci: sanitize symlinks in untrusted PR checkout to prevent LLM secret exfiltration

### DIFF
--- a/.github/PR_AUTOMATION.md
+++ b/.github/PR_AUTOMATION.md
@@ -45,11 +45,13 @@ pull request context of its own, and `Bash` is denied, so a model cannot derive 
 The script therefore writes `pr-evidence/changed-files.txt` and `pr-evidence/pull-request.diff`,
 both computed against the merge base so that unrelated commits landing on `master` are not
 attributed to the pull request, and the head tree stays available in `pr-head` for surrounding
-context. It also removes contributor-controlled agent instruction files — `CLAUDE.md`,
-`CLAUDE.local.md`, `AGENTS.md`, `.claude`, `.cursor`, `.cursorrules` — recursively rather than only
-at the checkout root, because Claude Code discovers them in every directory it reads and a nested
-copy would otherwise escape the evidence-only boundary. Those files still appear in the diff, where
-they are reviewable data rather than instructions.
+context. Before exposing that tree to filesystem-reading tools, it removes all symlinks so a pull
+request cannot redirect a read outside the checkout. It also removes contributor-controlled agent
+instruction files — `CLAUDE.md`, `CLAUDE.local.md`, `AGENTS.md`, `.claude`, `.cursor`,
+`.cursorrules` — recursively rather than only at the checkout root, because Claude Code discovers
+them in every directory it reads and a nested copy would otherwise escape the evidence-only
+boundary. Those files still appear in the diff, where they are reviewable data rather than
+instructions.
 
 Model output is likewise treated as hostile on the way out. Text published in a bot comment or
 review is escaped so that HTML, code spans, mentions, issue references, and the Markdown constructs

--- a/.github/pr-automation/fetch-pr-evidence.sh
+++ b/.github/pr-automation/fetch-pr-evidence.sh
@@ -27,6 +27,10 @@ git -C pr-head fetch --no-tags origin "+$head_sha:refs/remotes/origin/pull-reque
 git -C pr-head fetch --no-tags origin +master:refs/remotes/origin/master
 git -C pr-head checkout --detach origin/pull-request-head
 
+# The head tree is contributor-controlled. Remove symlinks before granting filesystem-reading tools
+# access so they cannot escape the checkout and disclose runner-local files or environment secrets.
+find pr-head -type l -delete
+
 # Claude Code discovers agent instruction files in every directory it reads, not just the root of
 # the tree it is given. These files are contributor-controlled here, so a nested pr-head/sub/CLAUDE.md
 # or pr-head/sub/.claude would otherwise escape the evidence-only boundary. The removal is recursive.


### PR DESCRIPTION
### Motivation
- Prevent a malicious forked pull request from creating symlinks in the `pr-head` checkout that could be followed by filesystem-reading LLM tooling and disclose runner-local secrets such as API keys.

### Description
- Remove all symbolic links in the untrusted checkout by running `find pr-head -type l -delete` immediately after checking out the head in `.github/pr-automation/fetch-pr-evidence.sh`.
- Document the symlink-sanitization security boundary in `.github/PR_AUTOMATION.md` while preserving symlink changes in the generated diff evidence.

### Testing
- Ran `bash -n .github/pr-automation/fetch-pr-evidence.sh` which succeeded.
- Ran `git diff --check` which reported no issues.
- Ran `node --test .github/pr-automation/automation.test.js` and all 34 tests passed.
- Executed an automated end-to-end malicious-symlink checkout test that verified `pr-head/leak` symlink is removed while the change still appears in `pr-evidence/changed-files.txt`.
- Attempted `cargo xtask check typos -v` but it could not run because `typos-cli` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a70cce561308329b74fd5dc01e146ec)