### PR TITLE
fix(pdu): tolerate an under-declared Share Control totalLength

### DIFF
--- a/crates/ironrdp-pdu/src/rdp/headers.rs
+++ b/crates/ironrdp-pdu/src/rdp/headers.rs
@@ -333,13 +333,32 @@ impl<'de> Decode<'de> for ShareControlHeader {
 
             if header_length != total_length && !(total_length == 0 && is_empty_output_pdu) {
                 if total_length < header_length {
-                    return Err(not_enough_bytes_err!(total_length, header_length));
+                    // `totalLength` is consulted here for exactly one purpose: to
+                    // locate trailing padding after the inner unit. A value smaller
+                    // than what we decoded therefore means there is no padding to
+                    // skip, and nothing more.
+                    //
+                    // It is not grounds to reject the PDU. The inner unit already
+                    // decoded within the cursor's bounds, and where this PDU ends is
+                    // decided by the transport framing — the TPKT or fast-path
+                    // length — never by this field. Servers do get it wrong:
+                    // VirtualBox VRDP declares 24 on a complete 8550-byte pointer
+                    // update, and failing there costs the whole session over a field
+                    // we were only going to use to skip zero bytes.
+                    //
+                    // A totalLength of zero stays rejected for anything but the
+                    // no-op output PDUs handled above: a field that is absent
+                    // entirely is a different signal from one that is merely wrong,
+                    // and #1515 drew that line deliberately.
+                    if total_length == 0 {
+                        return Err(not_enough_bytes_err!(total_length, header_length));
+                    }
+                } else {
+                    // Some Windows versions append padding that is not part of the inner unit.
+                    let padding = total_length - header_length;
+                    ensure_size!(in: src, size: padding);
+                    read_padding!(src, padding);
                 }
-
-                // Some Windows versions append padding that is not part of the inner unit.
-                let padding = total_length - header_length;
-                ensure_size!(in: src, size: padding);
-                read_padding!(src, padding);
             }
         }
 
@@ -945,6 +964,57 @@ mod tests {
                 expected: 18
             }
         ));
+    }
+
+    /// A Data PDU whose payload is decoded to the end of the cursor, declaring
+    /// `total_length` — the shape VirtualBox VRDP sends.
+    fn data_pdu_declaring(total_length: u16, pdu_type: u8, payload_len: usize) -> Vec<u8> {
+        let mut encoded = zero_length_empty_data_pdu(pdu_type).to_vec();
+        encoded[0..2].copy_from_slice(&total_length.to_le_bytes());
+        encoded.resize(encoded.len() + payload_len, 0);
+        encoded
+    }
+
+    /// VirtualBox VRDP under-declares `totalLength` on a complete slow-path
+    /// pointer update: the reporter's frame was 8565 bytes on the wire — 8550 of
+    /// MCS user data after TPKT(4) + X224(3) + Send Data Indication(8) — with
+    /// `totalLength` set to 24. Nothing was missing, so this must decode.
+    #[test]
+    fn decode_under_declared_total_length() {
+        const USER_DATA: usize = 8565 - 15;
+        let encoded = data_pdu_declaring(24, 0x1B, USER_DATA - 18);
+        assert_eq!(encoded.len(), USER_DATA);
+
+        let decoded: ShareControlHeader =
+            decode(&encoded).expect("the PDU is complete; only its length field is wrong");
+
+        assert!(matches!(
+            decoded.share_control_pdu,
+            ShareControlPdu::Data(ShareDataHeader {
+                share_data_pdu: ShareDataPdu::Pointer(data),
+                ..
+            }) if data.len() == USER_DATA - 18
+        ));
+    }
+
+    /// The leniency is for a length that is wrong, not for one that is absent:
+    /// `reject_zero_length_non_output_data_pdu` must keep holding.
+    #[test]
+    fn under_declared_leniency_does_not_extend_to_zero() {
+        let encoded = data_pdu_declaring(0, 0x25, 0);
+
+        decode::<ShareControlHeader>(&encoded).expect_err("zero total length is only accepted for no-op output");
+    }
+
+    /// Over-declared still means padding, and padding that was promised but not
+    /// sent is still an error — neither behaviour moves.
+    #[test]
+    fn over_declared_total_length_still_consumes_padding() {
+        let with_padding = data_pdu_declaring(22, 0x25, 4);
+        decode::<ShareControlHeader>(&with_padding).expect("4 bytes of padding are present and consumed");
+
+        let missing_padding = data_pdu_declaring(22, 0x25, 0);
+        decode::<ShareControlHeader>(&missing_padding).expect_err("padding was declared but not sent");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`ShareControlHeader::decode` rejects a Data PDU whose `totalLength` is smaller than the unit it decoded. That check ends sessions against VirtualBox VRDP, which declares **24** on a complete **8550-byte** slow-path pointer update.

`totalLength` is consulted here for exactly one purpose: locating trailing padding after the inner unit ([MS-RDPBCGR] 2.2.8.1.1.1.1). A value smaller than what was decoded therefore means there is no padding to skip, and nothing more. It is not grounds to reject the PDU — the inner unit already decoded within the cursor's bounds, and where the PDU ends is decided by the transport framing (the TPKT or fast-path length), never by this field. Failing there costs the session over a field that was only going to be used to skip zero bytes.

## Scope

Deliberately narrow. A `totalLength` of **zero** stays rejected for anything but the no-op output PDUs #1515 allowed: a field that is absent entirely is a different signal from one that is merely wrong, and #1515 drew that line three days ago. This does not move it, and all three of its tests pass unchanged.

I did consider generalising — `checked_sub` collapses both cases into one branch and is a smaller diff — but that would have quietly reversed `reject_zero_length_non_output_data_pdu`. If you'd prefer the general form, say so and I'll switch it; it seemed wrong to make that call inside an unrelated bug fix.

## Diagnosis

Worth recording, because the error is actively misleading. The failure surfaces as:

```
NotEnoughBytes { received: 24, expected: 8550 }
```

which reads as a truncated PDU, and isn't one. The call site is `not_enough_bytes_err!(total_length, header_length)`, so `received` is the **server's declared length** and `expected` is the **size IronRDP decoded** — neither is a count of bytes off the wire. Three sites in that one function emit `NotEnoughBytes` under the same context string, and two of them fit any given pair of numbers, so it was settled by rebuilding the frame rather than by reading:

- 8565 bytes on the wire, minus TPKT(4) + X224(3) + MCS Send Data Indication(8) = **8550 bytes of user data**
- `expected` is exactly that 8550, because a `Pointer` payload decodes greedily to the end of the cursor

`expected == frame_len - 15` is the discriminator: when it holds, the PDU is entirely present and only the length field is wrong.

A downstream Android client spent two releases implementing PDU reassembly against the other reading before this was pinned down, so the misleading pair of numbers has cost real time.

## Tests

Added to the existing inline `mod tests`:

- `decode_under_declared_total_length` — the reporter's real frame shape decodes
- `under_declared_leniency_does_not_extend_to_zero` — the leniency did not widen to the zero case
- `over_declared_total_length_still_consumes_padding` — padding is still consumed, and declared-but-absent padding still errors

Verified to actually fail: restoring the strict branch reddens the first and leaves the three guard tests (including #1515's) green.

`cargo test -p ironrdp-pdu` — 394 passed. `cargo fmt --all --check` and `cargo clippy -p ironrdp-pdu --all-targets -- -D warnings` clean (the `clippy.toml` MSRV notice is pre-existing).
