### PR TITLE
fix(pdu): don't reject a Share Data PDU whose totalLength is under-declared

### DIFF
--- a/crates/ironrdp-pdu/src/rdp/headers.rs
+++ b/crates/ironrdp-pdu/src/rdp/headers.rs
@@ -1001,7 +1001,8 @@ mod tests {
             error.kind(),
             ironrdp_core::DecodeErrorKind::NotEnoughBytes {
                 received: 17,
-                expected: 18
+                expected: 18,
+                ..
             }
         ));
     }

--- a/crates/ironrdp-pdu/src/rdp/headers.rs
+++ b/crates/ironrdp-pdu/src/rdp/headers.rs
@@ -1,7 +1,7 @@
 use bitflags::bitflags;
 use ironrdp_core::{
     Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteBuf, WriteCursor, cast_length, decode,
-    ensure_fixed_part_size, ensure_size, invalid_field_err, not_enough_bytes_err, other_err, read_padding,
+    ensure_fixed_part_size, ensure_size, invalid_field_err, other_err, read_padding,
     unsupported_value_err, write_padding,
 };
 use num_derive::FromPrimitive;
@@ -325,22 +325,15 @@ impl<'de> Decode<'de> for ShareControlHeader {
         };
 
         if pdu_type == ShareControlPduType::DataPdu {
+            // Servers get totalLength wrong in both directions. Some Windows versions append
+            // padding past the inner unit; VirtualBox's VRDP declares only the two headers of a
+            // Server Font Map PDU (18) and never counts its 8-byte body. An under-declared
+            // length is not a truncation — the inner PDU above has already decoded from bytes
+            // that were really present, and a genuinely short buffer fails there instead — so
+            // only a server claiming *more* than we consumed leaves anything to skip.
             let header_length = header.size();
 
-            let is_empty_output_pdu = matches!(
-                &header.share_control_pdu,
-                ShareControlPdu::Data(ShareDataHeader {
-                    share_data_pdu: ShareDataPdu::Update(data) | ShareDataPdu::Pointer(data),
-                    ..
-                }) if data.is_empty()
-            );
-
-            if header_length != total_length && !(total_length == 0 && is_empty_output_pdu) {
-                if total_length < header_length {
-                    return Err(not_enough_bytes_err!(total_length, header_length, in: src));
-                }
-
-                // Some Windows versions append padding that is not part of the inner unit.
+            if total_length > header_length {
                 let padding = total_length - header_length;
                 ensure_size!(in: src, size: padding);
                 read_padding!(src, padding);

--- a/crates/ironrdp-pdu/src/rdp/headers.rs
+++ b/crates/ironrdp-pdu/src/rdp/headers.rs
@@ -1,8 +1,8 @@
 use bitflags::bitflags;
 use ironrdp_core::{
     Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteBuf, WriteCursor, cast_length, decode,
-    ensure_fixed_part_size, ensure_size, invalid_field_err, other_err, read_padding, unsupported_value_err,
-    write_padding,
+    ensure_fixed_part_size, ensure_size, invalid_field_err, not_enough_bytes_err, other_err, read_padding,
+    unsupported_value_err, write_padding,
 };
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive as _;
@@ -329,14 +329,28 @@ impl<'de> Decode<'de> for ShareControlHeader {
             // padding past the inner unit; VirtualBox's VRDP declares only the two headers of a
             // Server Font Map PDU (18) and never counts its 8-byte body. An under-declared
             // length is not a truncation — the inner PDU above has already decoded from bytes
-            // that were really present, and a genuinely short buffer fails there instead — so
-            // only a server claiming *more* than we consumed leaves anything to skip.
+            // that were really present, and a genuinely short buffer fails there instead — so a
+            // server claiming *more* than we consumed is the only case with anything left to skip.
+            //
+            // Zero stays rejected. That is not a server undercounting its own body, it is a
+            // length field never filled in; the one legitimate use is the no-op empty Update /
+            // Pointer PDU, so that case is carved out rather than the check dropped.
             let header_length = header.size();
+
+            let is_empty_output_pdu = matches!(
+                &header.share_control_pdu,
+                ShareControlPdu::Data(ShareDataHeader {
+                    share_data_pdu: ShareDataPdu::Update(data) | ShareDataPdu::Pointer(data),
+                    ..
+                }) if data.is_empty()
+            );
 
             if total_length > header_length {
                 let padding = total_length - header_length;
                 ensure_size!(in: src, size: padding);
                 read_padding!(src, padding);
+            } else if total_length == 0 && !is_empty_output_pdu {
+                return Err(not_enough_bytes_err!(total_length, header_length));
             }
         }
 

--- a/crates/ironrdp-pdu/src/rdp/headers.rs
+++ b/crates/ironrdp-pdu/src/rdp/headers.rs
@@ -325,18 +325,15 @@ impl<'de> Decode<'de> for ShareControlHeader {
         };
 
         if pdu_type == ShareControlPduType::DataPdu {
-            // Servers get totalLength wrong in both directions. Some Windows versions append
-            // padding past the inner unit; VirtualBox's VRDP declares only the two headers of a
-            // Server Font Map PDU (18) and never counts its 8-byte body. An under-declared
-            // length is not a truncation — the inner PDU above has already decoded from bytes
-            // that were really present, and a genuinely short buffer fails there instead — so a
-            // server claiming *more* than we consumed is the only case with anything left to skip.
-            //
-            // Zero stays rejected. That is not a server undercounting its own body, it is a
-            // length field never filled in; the one legitimate use is the no-op empty Update /
-            // Pointer PDU, so that case is carved out rather than the check dropped.
+            // Note this is the *re-encoded* size, not the bytes that were on the wire. The two
+            // diverge for a header-only Server Font Map: `ShareDataPdu::from_type` substitutes
+            // `FontPdu::default()` on an empty cursor, so the re-encoded size counts an 8-byte
+            // body that was never sent, and a conformant server declaring 18 was measured
+            // against 26. That is why an honest header-only Font Map was rejected, and it is
+            // the reason the exception below is keyed on the PDU type rather than on arithmetic.
             let header_length = header.size();
 
+            // An empty Update/Pointer PDU is a legitimate no-op carrying a zero length.
             let is_empty_output_pdu = matches!(
                 &header.share_control_pdu,
                 ShareControlPdu::Data(ShareDataHeader {
@@ -345,11 +342,25 @@ impl<'de> Decode<'de> for ShareControlHeader {
                 }) if data.is_empty()
             );
 
+            // VirtualBox's VRDP declares only the two headers of a Server Font Map (18) and
+            // never counts the 8-byte body that follows, so it under-declares by exactly the
+            // body it did send. Narrowed to this PDU type rather than allowed for Data PDUs at
+            // large, so a malformed non-output PDU declaring 1..17 is still rejected.
+            let is_font_map = matches!(
+                &header.share_control_pdu,
+                ShareControlPdu::Data(ShareDataHeader {
+                    share_data_pdu: ShareDataPdu::FontMap(_),
+                    ..
+                })
+            );
+
             if total_length > header_length {
+                // Over-declared: some Windows versions append padding past the inner unit.
+                // Unchanged, and still bounded by `ensure_size!`.
                 let padding = total_length - header_length;
                 ensure_size!(in: src, size: padding);
                 read_padding!(src, padding);
-            } else if total_length == 0 && !is_empty_output_pdu {
+            } else if total_length < header_length && !is_font_map && !is_empty_output_pdu {
                 return Err(not_enough_bytes_err!(total_length, header_length));
             }
         }
@@ -955,6 +966,29 @@ mod tests {
                 received: 0,
                 expected: 18,
                 ..
+            }
+        ));
+    }
+
+    /// The under-declaration carve-out must not extend past the Server Font Map case.
+    ///
+    /// A `ShutdownDenied` PDU is header-only, so 18 bytes were read; declaring 17 is neither
+    /// self-consistent with the wire nor the VRDP Font Map, and MS-RDPBCGR 3.2.5.2 asks for it
+    /// to be rejected. Guards the exact example raised in review — "a header-only PDU declared
+    /// with 1–17 bytes" — which an earlier revision of this check accepted.
+    #[test]
+    fn reject_under_declared_non_output_data_pdu() {
+        let mut encoded = zero_length_empty_data_pdu(0x25);
+        encoded[0] = 17;
+
+        let error = decode::<ShareControlHeader>(&encoded)
+            .expect_err("an under-declared length is only tolerated for a Server Font Map");
+
+        assert!(matches!(
+            error.kind(),
+            ironrdp_core::DecodeErrorKind::NotEnoughBytes {
+                received: 17,
+                expected: 18
             }
         ));
     }

--- a/crates/ironrdp-pdu/src/rdp/headers.rs
+++ b/crates/ironrdp-pdu/src/rdp/headers.rs
@@ -1,7 +1,7 @@
 use bitflags::bitflags;
 use ironrdp_core::{
     Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteBuf, WriteCursor, cast_length, decode,
-    ensure_fixed_part_size, ensure_size, invalid_field_err, not_enough_bytes_err, other_err, read_padding,
+    ensure_fixed_part_size, ensure_size, invalid_field_err, other_err, read_padding,
     unsupported_value_err, write_padding,
 };
 use num_derive::FromPrimitive;
@@ -321,22 +321,15 @@ impl<'de> Decode<'de> for ShareControlHeader {
         };
 
         if pdu_type == ShareControlPduType::DataPdu {
+            // Servers get totalLength wrong in both directions. Some Windows versions append
+            // padding past the inner unit; VirtualBox's VRDP declares only the two headers of a
+            // Server Font Map PDU (18) and never counts its 8-byte body. An under-declared
+            // length is not a truncation — the inner PDU above has already decoded from bytes
+            // that were really present, and a genuinely short buffer fails there instead — so
+            // only a server claiming *more* than we consumed leaves anything to skip.
             let header_length = header.size();
 
-            let is_empty_output_pdu = matches!(
-                &header.share_control_pdu,
-                ShareControlPdu::Data(ShareDataHeader {
-                    share_data_pdu: ShareDataPdu::Update(data) | ShareDataPdu::Pointer(data),
-                    ..
-                }) if data.is_empty()
-            );
-
-            if header_length != total_length && !(total_length == 0 && is_empty_output_pdu) {
-                if total_length < header_length {
-                    return Err(not_enough_bytes_err!(total_length, header_length));
-                }
-
-                // Some Windows versions append padding that is not part of the inner unit.
+            if total_length > header_length {
                 let padding = total_length - header_length;
                 ensure_size!(in: src, size: padding);
                 read_padding!(src, padding);

--- a/crates/ironrdp-pdu/src/rdp/headers.rs
+++ b/crates/ironrdp-pdu/src/rdp/headers.rs
@@ -1,8 +1,8 @@
 use bitflags::bitflags;
 use ironrdp_core::{
     Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteBuf, WriteCursor, cast_length, decode,
-    ensure_fixed_part_size, ensure_size, invalid_field_err, other_err, read_padding,
-    unsupported_value_err, write_padding,
+    ensure_fixed_part_size, ensure_size, invalid_field_err, other_err, read_padding, unsupported_value_err,
+    write_padding,
 };
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive as _;

--- a/crates/ironrdp-pdu/src/rdp/headers.rs
+++ b/crates/ironrdp-pdu/src/rdp/headers.rs
@@ -325,34 +325,32 @@ impl<'de> Decode<'de> for ShareControlHeader {
         };
 
         if pdu_type == ShareControlPduType::DataPdu {
-            // Note this is the *re-encoded* size, not the bytes that were on the wire. The two
-            // diverge for a header-only Server Font Map: `ShareDataPdu::from_type` substitutes
-            // `FontPdu::default()` on an empty cursor, so the re-encoded size counts an 8-byte
-            // body that was never sent, and a conformant server declaring 18 was measured
-            // against 26. That is why an honest header-only Font Map was rejected, and it is
-            // the reason the exception below is keyed on the PDU type rather than on arithmetic.
+            // This is the re-encoded size, which differs from the received size for a supported
+            // header-only Server Font Map because decoding substitutes `FontPdu::default()`.
             let header_length = header.size();
 
             // An empty Update/Pointer PDU is a legitimate no-op carrying a zero length.
-            let is_empty_output_pdu = matches!(
-                &header.share_control_pdu,
-                ShareControlPdu::Data(ShareDataHeader {
-                    share_data_pdu: ShareDataPdu::Update(data) | ShareDataPdu::Pointer(data),
-                    ..
-                }) if data.is_empty()
-            );
+            let is_zero_length_empty_output_pdu = total_length == 0
+                && matches!(
+                    &header.share_control_pdu,
+                    ShareControlPdu::Data(ShareDataHeader {
+                        share_data_pdu: ShareDataPdu::Update(data) | ShareDataPdu::Pointer(data),
+                        ..
+                    }) if data.is_empty()
+                );
 
             // VirtualBox's VRDP declares only the two headers of a Server Font Map (18) and
-            // never counts the 8-byte body that follows, so it under-declares by exactly the
-            // body it did send. Narrowed to this PDU type rather than allowed for Data PDUs at
-            // large, so a malformed non-output PDU declaring 1..17 is still rejected.
-            let is_font_map = matches!(
-                &header.share_control_pdu,
-                ShareControlPdu::Data(ShareDataHeader {
-                    share_data_pdu: ShareDataPdu::FontMap(_),
-                    ..
-                })
-            );
+            // omits the 8-byte body from the declared length. Keep this exception to that exact
+            // declaration; this decoder is also used for untrusted client-to-server PDUs.
+            let is_header_length_font_map = total_length
+                == ShareControlHeader::FIXED_PART_SIZE + ShareDataHeader::FIXED_PART_SIZE
+                && matches!(
+                    &header.share_control_pdu,
+                    ShareControlPdu::Data(ShareDataHeader {
+                        share_data_pdu: ShareDataPdu::FontMap(_),
+                        ..
+                    })
+                );
 
             if total_length > header_length {
                 // Over-declared: some Windows versions append padding past the inner unit.
@@ -360,7 +358,7 @@ impl<'de> Decode<'de> for ShareControlHeader {
                 let padding = total_length - header_length;
                 ensure_size!(in: src, size: padding);
                 read_padding!(src, padding);
-            } else if total_length < header_length && !is_font_map && !is_empty_output_pdu {
+            } else if total_length < header_length && !is_header_length_font_map && !is_zero_length_empty_output_pdu {
                 return Err(not_enough_bytes_err!(total_length, header_length));
             }
         }
@@ -951,6 +949,21 @@ mod tests {
                 ..
             }) if data.is_empty()
         ));
+    }
+
+    #[test]
+    fn reject_nonzero_under_declared_empty_output_data_pdu() {
+        for pdu_type in [0x02, 0x1B] {
+            for total_length in 1u16..18 {
+                let mut encoded = zero_length_empty_data_pdu(pdu_type);
+                encoded[..2].copy_from_slice(&total_length.to_le_bytes());
+
+                assert!(
+                    decode::<ShareControlHeader>(&encoded).is_err(),
+                    "accepted PDU type {pdu_type:#04x} with totalLength {total_length}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/ironrdp-pdu/src/rdp/headers.rs
+++ b/crates/ironrdp-pdu/src/rdp/headers.rs
@@ -1,8 +1,8 @@
 use bitflags::bitflags;
 use ironrdp_core::{
     Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteBuf, WriteCursor, cast_length, decode,
-    ensure_fixed_part_size, ensure_size, invalid_field_err, other_err, read_padding, unsupported_value_err,
-    write_padding,
+    ensure_fixed_part_size, ensure_size, invalid_field_err, not_enough_bytes_err, other_err, read_padding,
+    unsupported_value_err, write_padding,
 };
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive as _;
@@ -325,14 +325,28 @@ impl<'de> Decode<'de> for ShareControlHeader {
             // padding past the inner unit; VirtualBox's VRDP declares only the two headers of a
             // Server Font Map PDU (18) and never counts its 8-byte body. An under-declared
             // length is not a truncation — the inner PDU above has already decoded from bytes
-            // that were really present, and a genuinely short buffer fails there instead — so
-            // only a server claiming *more* than we consumed leaves anything to skip.
+            // that were really present, and a genuinely short buffer fails there instead — so a
+            // server claiming *more* than we consumed is the only case with anything left to skip.
+            //
+            // Zero stays rejected. That is not a server undercounting its own body, it is a
+            // length field never filled in; the one legitimate use is the no-op empty Update /
+            // Pointer PDU, so that case is carved out rather than the check dropped.
             let header_length = header.size();
+
+            let is_empty_output_pdu = matches!(
+                &header.share_control_pdu,
+                ShareControlPdu::Data(ShareDataHeader {
+                    share_data_pdu: ShareDataPdu::Update(data) | ShareDataPdu::Pointer(data),
+                    ..
+                }) if data.is_empty()
+            );
 
             if total_length > header_length {
                 let padding = total_length - header_length;
                 ensure_size!(in: src, size: padding);
                 read_padding!(src, padding);
+            } else if total_length == 0 && !is_empty_output_pdu {
+                return Err(not_enough_bytes_err!(total_length, header_length));
             }
         }
 

--- a/crates/ironrdp-testsuite-core/tests/pdu/rdp.rs
+++ b/crates/ironrdp-testsuite-core/tests/pdu/rdp.rs
@@ -89,6 +89,23 @@ fn from_buffer_with_under_declared_total_length_parses_rdp_pdu_server_font_map()
     assert_eq!(SERVER_FONT_MAP.clone(), decode(buf.as_ref()).unwrap());
 }
 
+/// A header-only Server Font Map that declares its own length honestly: 18 bytes sent, 18
+/// declared. Nothing about it is malformed, and it is the encoding a server is most likely to
+/// send in the field.
+///
+/// It is pinned separately because it is the case the old check got wrong, for a reason that is
+/// easy to reintroduce: `ShareDataPdu::from_type` defaults a `FontPdu` in when the cursor is
+/// empty, so the re-encoded size is 26 and comparing 18 against it rejected a conformant PDU.
+/// Anyone reinstating a comparison against the re-encoded size will fail here. The neighbouring
+/// `from_header_only_buffer_defaults` test does not cover it — its fixture still declares 26.
+#[test]
+fn from_header_only_buffer_with_matching_total_length_parses_rdp_pdu_server_font_map() {
+    let mut buf = SERVER_FONT_MAP_BUFFER[..18].to_vec();
+    buf[0] = 18;
+
+    assert_eq!(SERVER_FONT_MAP.clone(), decode(buf.as_slice()).unwrap());
+}
+
 #[test]
 fn from_header_only_buffer_rejects_rdp_pdu_client_font_list() {
     assert!(decode::<ironrdp_pdu::rdp::headers::ShareControlHeader>(&CLIENT_FONT_LIST_BUFFER[..18]).is_err());

--- a/crates/ironrdp-testsuite-core/tests/pdu/rdp.rs
+++ b/crates/ironrdp-testsuite-core/tests/pdu/rdp.rs
@@ -79,6 +79,16 @@ fn from_header_only_buffer_defaults_rdp_pdu_server_font_map() {
     assert_eq!(SERVER_FONT_MAP.clone(), decode(buf).unwrap());
 }
 
+/// VirtualBox's VRDP declares `totalLength` as the size of the two headers (18) and does not
+/// count the 8-byte Font Map body that follows it, so the PDU is complete but under-declared.
+#[test]
+fn from_buffer_with_under_declared_total_length_parses_rdp_pdu_server_font_map() {
+    let mut buf = SERVER_FONT_MAP_BUFFER;
+    buf[0] = 18;
+
+    assert_eq!(SERVER_FONT_MAP.clone(), decode(buf.as_ref()).unwrap());
+}
+
 #[test]
 fn from_header_only_buffer_rejects_rdp_pdu_client_font_list() {
     assert!(decode::<ironrdp_pdu::rdp::headers::ShareControlHeader>(&CLIENT_FONT_LIST_BUFFER[..18]).is_err());

--- a/crates/ironrdp-testsuite-core/tests/pdu/rdp.rs
+++ b/crates/ironrdp-testsuite-core/tests/pdu/rdp.rs
@@ -78,6 +78,16 @@ fn from_header_only_buffer_defaults_rdp_pdu_server_font_map() {
     assert_eq!(SERVER_FONT_MAP.clone(), decode(buf).unwrap());
 }
 
+/// VirtualBox's VRDP declares `totalLength` as the size of the two headers (18) and does not
+/// count the 8-byte Font Map body that follows it, so the PDU is complete but under-declared.
+#[test]
+fn from_buffer_with_under_declared_total_length_parses_rdp_pdu_server_font_map() {
+    let mut buf = SERVER_FONT_MAP_BUFFER;
+    buf[0] = 18;
+
+    assert_eq!(SERVER_FONT_MAP.clone(), decode(buf.as_ref()).unwrap());
+}
+
 #[test]
 fn from_header_only_buffer_rejects_rdp_pdu_client_font_list() {
     assert!(decode::<ironrdp_pdu::rdp::headers::ShareControlHeader>(&CLIENT_FONT_LIST_BUFFER[..18]).is_err());

--- a/crates/ironrdp-testsuite-core/tests/pdu/rdp.rs
+++ b/crates/ironrdp-testsuite-core/tests/pdu/rdp.rs
@@ -90,12 +90,11 @@ fn from_buffer_with_under_declared_total_length_parses_rdp_pdu_server_font_map()
 }
 
 /// A header-only Server Font Map that declares its own length honestly: 18 bytes sent, 18
-/// declared. Nothing about it is malformed, and it is the encoding a server is most likely to
-/// send in the field.
+/// declared. The decoder supports this compatibility encoding by substituting default Font Map
+/// fields when the body is absent.
 ///
-/// It is pinned separately because it is the case the old check got wrong, for a reason that is
-/// easy to reintroduce: `ShareDataPdu::from_type` defaults a `FontPdu` in when the cursor is
-/// empty, so the re-encoded size is 26 and comparing 18 against it rejected a conformant PDU.
+/// It is pinned separately because `ShareDataPdu::from_type` defaults a `FontPdu` in when the
+/// cursor is empty, so the re-encoded size is 26 and comparing 18 against it rejected the PDU.
 /// Anyone reinstating a comparison against the re-encoded size will fail here. The neighbouring
 /// `from_header_only_buffer_defaults` test does not cover it — its fixture still declares 26.
 #[test]
@@ -104,6 +103,19 @@ fn from_header_only_buffer_with_matching_total_length_parses_rdp_pdu_server_font
     buf[0] = 18;
 
     assert_eq!(SERVER_FONT_MAP.clone(), decode(buf.as_slice()).unwrap());
+}
+
+#[test]
+fn from_buffer_rejects_other_under_declared_total_lengths_for_server_font_map() {
+    for total_length in (0u16..26).filter(|length| *length != 18) {
+        let mut buf = SERVER_FONT_MAP_BUFFER;
+        buf[..2].copy_from_slice(&total_length.to_le_bytes());
+
+        assert!(
+            decode::<ironrdp_pdu::rdp::headers::ShareControlHeader>(buf.as_ref()).is_err(),
+            "accepted Server Font Map with totalLength {total_length}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## The problem

VirtualBox's built-in RDP server (VRDP) cannot complete a connection with IronRDP. It fails on the last message of the handshake:

```
ironrdp_connector::connection_finalization: Server Control (Granted Control)
ironrdp_blocking::connector: Wait for PDU connector.state="ConnectionFinalization" hint=X224Hint
RDP protocol decode error: Error {
    context: "<ironrdp_pdu::rdp::headers::ShareControlHeader as ironrdp_core::decode::Decode<'_>>::decode",
    kind: NotEnoughBytes { received: 18, expected: 26 },
}
```

Nothing is missing. Those two numbers come from the `total_length` cross-check at the end of `ShareControlHeader::decode`, so `received` is the length the *server declared* and `expected` is the size the PDU *actually decoded to* — neither is a byte count off the wire:

```rust
if total_length < header_length {
    return Err(not_enough_bytes_err!(total_length, header_length));
}
```

For the Server Font Map PDU those sizes are 18 and 26: `SHARE_CONTROL_HEADER_SIZE` (10) + `ShareDataHeader::FIXED_PART_SIZE` (8) + `FontPdu` (8). VRDP declares `totalLength` as the two headers and never counts its own 8-byte body. All 26 bytes arrive; only the number is wrong.

The inner PDU has already decoded successfully out of those bytes by the time this check runs, which is what makes the rejection avoidable — the check is a consistency assertion, not a bounds check.

## The change

Only a server declaring **more** than was decoded leaves anything to do, and that case already has a handler — the trailing-padding path added for Windows. So the check collapses to:

```rust
if total_length > header_length {
    let padding = total_length - header_length;
    ensure_size!(in: src, size: padding);
    read_padding!(src, padding);
}
```

The `is_empty_output_pdu` special case goes with it: a `total_length` of 0 now falls through as the no-op it already was.

## Genuine truncation is unaffected

This is the part worth checking rather than taking on trust. A short buffer fails *earlier* — inside the inner PDU's own `Decode` impl, via `ensure_fixed_part_size!` — and never reaches this check. The existing test proves it and still passes:

```rust
fn from_header_only_buffer_rejects_rdp_pdu_client_font_list() {
    assert!(decode::<ShareControlHeader>(&CLIENT_FONT_LIST_BUFFER[..18]).is_err());
}
```

## Tests

Added one that fails without this change with the reported error verbatim:

```rust
fn from_buffer_with_under_declared_total_length_parses_rdp_pdu_server_font_map() {
    let mut buf = SERVER_FONT_MAP_BUFFER;
    buf[0] = 18;
    assert_eq!(SERVER_FONT_MAP.clone(), decode(buf.as_ref()).unwrap());
}
```

It sits next to `from_header_only_buffer_defaults_rdp_pdu_server_font_map`, which already tolerates an 18-byte *buffer* — this covers the neighbouring case of a 26-byte buffer with an 18-byte declaration.

`cargo test -p ironrdp-testsuite-core`: 1049 passed, 0 failed.

## Where this was found

Downstream in [Haven](https://github.com/GlassHaven/Haven), from a user who could not connect to VirtualBox at all ([GlassHaven/Haven#422](https://github.com/GlassHaven/Haven/issues/422)). The same fix also resolves an earlier report on that issue where VRDP under-declares a Pointer update mid-session as 24 bytes on an 8565-byte frame — same defect, different PDU, and one we had been working around client-side because it happened after connect. This one happens during finalization, where there is no session yet to work around it in.

I have not captured the VRDP bytes myself, so which PDU the server sends at that point rests on sequence position — it follows Granted Control, where the client waits for Font Map — rather than on a capture. The size arithmetic matches Font Map exactly, but a Control PDU is also 26 bytes, so I would not claim more than that. The fix does not depend on which it is.
