### PR TITLE
Add ActiveX RPC backend for ironrdp-agent

### DIFF
--- a/.github/workflows/agentic-rdp.yml
+++ b/.github/workflows/agentic-rdp.yml
@@ -1,7 +1,6 @@
 name: Agentic RDP
 
 on:
-  push:
   workflow_dispatch:
     inputs:
       desktop_size:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,6 +2424,7 @@ dependencies = [
 name = "ironrdp-activex"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "embed-resource",
  "ironrdp-cfg",
  "ironrdp-client",
@@ -2431,11 +2432,15 @@ dependencies = [
  "ironrdp-cliprdr-native",
  "ironrdp-connector",
  "ironrdp-core 0.2.1",
+ "ironrdp-daemon",
  "ironrdp-input",
  "ironrdp-pdu",
+ "ironrdp-propertyset",
+ "ironrdp-rpc",
  "ironrdp-session",
  "ironrdp-svc",
  "ironrdp-tls",
+ "png",
  "sha2 0.10.9",
  "tokio",
  "tracing",

--- a/crates/ironrdp-activex/Cargo.toml
+++ b/crates/ironrdp-activex/Cargo.toml
@@ -19,19 +19,24 @@ crate-type = ["cdylib", "rlib"]
 doctest = false
 
 [target.'cfg(windows)'.dependencies]
+anyhow = "1"
 ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["clipboard", "dvc-com-plugin", "gateway", "rustls", "sound"] }
 ironrdp-cliprdr = { path = "../ironrdp-cliprdr", version = "0.7" }
 ironrdp-cliprdr-native = { path = "../ironrdp-cliprdr-native", version = "0.7" }
 ironrdp-cfg = { path = "../ironrdp-cfg", version = "0.1" }
 ironrdp-connector = { path = "../ironrdp-connector", version = "0.10" }
 ironrdp-core = { path = "../ironrdp-core", version = "0.2" }
+ironrdp-daemon = { path = "../ironrdp-daemon", version = "0.1" }
 ironrdp-input = { path = "../ironrdp-input", version = "0.7" }
 ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9" }
+ironrdp-propertyset = { path = "../ironrdp-propertyset", version = "0.1" }
+ironrdp-rpc = { path = "../ironrdp-rpc", version = "0.1" }
 ironrdp-session = { path = "../ironrdp-session", version = "0.11" }
 ironrdp-svc = { path = "../ironrdp-svc", version = "0.8" }
 ironrdp-tls = { path = "../ironrdp-tls", version = "0.2" }
+png = "0.18"
 sha2 = "0.10"
-tokio = { version = "1", features = ["rt-multi-thread", "sync"] }
+tokio = { version = "1", features = ["io-util", "macros", "rt-multi-thread", "sync"] }
 tracing = { version = "0.1", features = ["log"] }
 windows = { version = "0.62", features = [
     "Win32_Foundation",

--- a/crates/ironrdp-activex/README.md
+++ b/crates/ironrdp-activex/README.md
@@ -26,6 +26,19 @@ Unsupported Automation and raw-interface members return `DISP_E_MEMBERNOTFOUND` 
 rather than a false success result. A small set of mstsc-compatible status and lifecycle defaults is
 provided where the published control accepts the operation without starting an unavailable feature.
 
+## Local agent RPC
+
+Set `IRONRDP_ACTIVEX_RPC=1` in the ActiveX host process before creating the control to expose the
+current-user-only RPC service from `ironrdpax.dll`. On Windows, the named pipe has a protected DACL
+that permits only the current user. Its default endpoint is `\\.\pipe\ironrdp-activex-<user>`; set
+`IRONRDP_ACTIVEX_RPC_ENDPOINT` to select another endpoint. The listener dispatches connection,
+disconnect, input, resize, and configuration requests through the control's message-only window,
+never directly from its listener thread.
+
+Use an already-hosted control from the agent with `ironrdp-agent --backend active-x <operation>`.
+The ActiveX backend is never auto-started: its owner must create the control with the opt-in
+environment variable before the agent connects.
+
 ## Registration
 
 Register a bitness-matching build with:
@@ -94,6 +107,17 @@ the bridge pre-populates the corresponding CredUI fields. It never auto-submits 
 operator must still approve it. These values are used only to initialize CredUI's local buffers,
 are not traced or persisted, and should be supplied only through a suitably protected process
 environment.
+
+For an explicitly authorized unattended test, set `RDP_AUTOLOGON=1` together with nonempty
+`RDP_USERNAME` and `RDP_PASSWORD` in the `mstscex.exe` process environment. This exact opt-in
+bypasses CredUI, provides the values directly to the in-memory connection, and enables RDP
+autologon. Missing credentials fail closed without opening CredUI. The values must not be written
+to `.rdp` files, traces, arguments, or persistent credential storage.
+
+For an authorized RDP-file launch, `RDP_HOSTNAME` supplies the destination only when the native
+Computer form is unavailable; credentials remain process-local. With `RDP_AUTOLOGON=1`, the native
+host can display a nonfatal post-preflight error. Leave that dialog open while using the ActiveX
+RPC endpoint because its **OK** action closes the host and session.
 
 In this explicit bridge mode, non-minimized native-shell container size changes become a 250 ms
 debounced `IMsRdpClient9::UpdateSessionDisplaySettings` request. IronRDP uses the negotiated Display

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -12,16 +12,17 @@ use std::sync::{Arc, Mutex, mpsc as std_mpsc};
 use std::time::Duration;
 
 use ironrdp_cfg::{AudioMode, GatewayCredentialsSource, GatewayUsageMethod};
-use ironrdp_client::config::{ClipboardType, ConfigBuilder, Destination, TransportKind};
+use ironrdp_client::config::{ClipboardType, ConfigBuilder, Destination, Transport, TransportKind};
 use ironrdp_client::rdp::{CliprdrBackendFactory, RdpClient, RdpInputEvent, RdpInputSender, RdpOutputEvent};
 use ironrdp_cliprdr::backend::{ClipboardMessage, ClipboardMessageProxy};
 use ironrdp_cliprdr_native::WinClipboard;
-use ironrdp_connector::{ConnectorError, ConnectorErrorKind};
+use ironrdp_connector::{ConnectorError, ConnectorErrorKind, Credentials};
 use ironrdp_core::{DecodeError, DecodeErrorKind};
 use ironrdp_input::{Database as InputDatabase, MouseButton, MousePosition, Operation, Scancode, WheelRotations};
 use ironrdp_pdu::PduResult;
 use ironrdp_pdu::gcc::{ChannelName, ChannelOptions, ConnectionType, KeyboardType};
 use ironrdp_pdu::rdp::{capability_sets::MajorPlatformType, client_info::PerformanceFlags};
+use ironrdp_propertyset::PropertySet;
 use ironrdp_session::{GracefulDisconnectReason, SessionError, SessionErrorKind};
 use ironrdp_svc::{SvcClientProcessor, SvcMessage, SvcProcessor, impl_as_any};
 use ironrdp_tls::CertificateValidation;
@@ -111,6 +112,8 @@ use crate::mstsc::{
     IMsRdpExtendedSettings_Impl, IMsRdpPreferredRedirectionInfo, IMsRdpPreferredRedirectionInfo_Impl, IMsTscAx_Impl,
     IMsTscAx_Redist_Impl, IMsTscNonScriptable, IMsTscNonScriptable_Impl, InterfaceOut,
 };
+use crate::rpc::{self, ActiveXRpc, Command as RpcCommand};
+use ironrdp_rpc as ironrdp_agent;
 
 /// The IronRDP-owned class identifier registered by this DLL.
 pub(crate) const CLSID_IRONRDP_ACTIVEX: GUID = GUID::from_u128(0x5d3e_2b4c_6860_462e_8e9d_0c4d_2b09_4c5f);
@@ -432,6 +435,16 @@ fn credential_prompt_buffer(value: &str, capacity: usize) -> Vec<u16> {
 
 fn native_mstsc_credential_bridge_enabled() -> bool {
     environment_flag_enabled("IRONRDP_ACTIVEX_NATIVE_MSTSC_CREDENTIAL_BRIDGE")
+}
+
+fn native_mstsc_autologon_enabled() -> bool {
+    environment_flag_enabled("RDP_AUTOLOGON")
+}
+
+fn autologon_credentials(username: Option<String>, password: Option<String>) -> Option<(String, String)> {
+    let username = username.filter(|value| !value.is_empty())?;
+    let password = password.filter(|value| !value.is_empty())?;
+    Some((username, password))
 }
 
 fn activex_dvc_plugins_enabled() -> bool {
@@ -1207,18 +1220,23 @@ struct NativeMstscCredentialBridge {
     control: *const Control_Impl,
 }
 
+enum NativeMstscStartProgramIntercept {
+    NotHandled,
+    Handled,
+}
+
 impl NativeMstscCredentialBridge {
-    fn intercept_start_program(&self) -> bool {
+    fn intercept_start_program(&self) -> NativeMstscStartProgramIntercept {
         // SAFETY: `_owner` owns an IUnknown reference to the containing Control, whose immutable
         // implementation address remains valid until this bridge is dropped.
         let Some(control) = (unsafe { self.control.as_ref() }) else {
-            return false;
+            return NativeMstscStartProgramIntercept::NotHandled;
         };
         if !should_intercept_native_mstsc_start_program(
             native_mstsc_credential_bridge_enabled(),
             control.state.get() == ConnectionState::Disconnected,
         ) {
-            return false;
+            return NativeMstscStartProgramIntercept::NotHandled;
         }
 
         // Do not let the legacy empty-property fallback show a second prompt after this observed
@@ -1234,7 +1252,12 @@ impl NativeMstscCredentialBridge {
         if !started {
             trace_host_call("NativeMstscCredentialBridge::StartProgramNotStarted");
         }
-        true
+        if started && native_mstsc_autologon_enabled() {
+            // CredUI normally supplies a modal delay before the native shell observes the bridge's
+            // preflight failure. Give the unattended worker the same bounded initialization window.
+            std::thread::sleep(Duration::from_secs(3));
+        }
+        NativeMstscStartProgramIntercept::Handled
     }
 }
 
@@ -2488,15 +2511,16 @@ unsafe extern "system" fn secured_put_start_program(this: *mut c_void, value: Bs
             "NativeMstscCredentialBridge::StartProgramBridgeUnavailable"
         });
     }
-    if object
-        .native_mstsc_credential_bridge
-        .as_ref()
-        .is_some_and(NativeMstscCredentialBridge::intercept_start_program)
-    {
-        // Native mstsc has been observed passing a preflight payload that is not a valid BSTR.
-        // The bridge uses this call solely as its explicit prompt trigger, so it must take
-        // ownership before deserializing that unrelated payload.
-        return E_INVALIDARG;
+    if let Some(bridge) = object.native_mstsc_credential_bridge.as_ref() {
+        match bridge.intercept_start_program() {
+            NativeMstscStartProgramIntercept::NotHandled => {}
+            NativeMstscStartProgramIntercept::Handled => {
+                // Native mstsc has been observed passing a preflight payload that is not a valid BSTR.
+                // The bridge uses this call solely as its explicit prompt trigger, so it must take
+                // ownership before deserializing that unrelated payload.
+                return E_INVALIDARG;
+            }
+        }
     }
 
     let value = match string_from_bstr(value) {
@@ -3891,6 +3915,50 @@ pub(crate) struct Control {
     presentation_layout_generation: Cell<u64>,
     traced_frame_layout_generation: Cell<u64>,
     traced_paint_layout_generation: Cell<u64>,
+    rpc: Option<ActiveXRpc>,
+    rpc_properties: RefCell<Option<PropertySet>>,
+    rpc_kerberos_config: RefCell<Option<ironrdp_connector::credssp::KerberosConfig>>,
+    rpc_log_directive: RefCell<Option<String>>,
+}
+
+fn rpc_control_error(error: Error) -> ironrdp_agent::ipc::Response {
+    let category = if error.code() == E_INVALIDARG || error.code() == E_NOTIMPL {
+        ironrdp_agent::ipc::AgentErrorCategory::InvalidRequest
+    } else {
+        ironrdp_agent::ipc::AgentErrorCategory::Unavailable
+    };
+    ironrdp_agent::ipc::Response::typed_error(category, format!("ActiveX control rejected the request: {error}"))
+}
+
+fn active_x_property_snapshot(settings: &Settings, compatibility: &CompatibilitySettings) -> PropertySet {
+    let mut properties = PropertySet::new();
+    if !settings.server.is_empty() {
+        properties.insert("full address", settings.server.clone());
+    }
+    if !settings.username.is_empty() {
+        properties.insert("username", settings.username.clone());
+    }
+    if !settings.domain.is_empty() {
+        properties.insert("domain", settings.domain.clone());
+    }
+    properties.insert("desktopwidth", settings.desktop_width);
+    properties.insert("desktopheight", settings.desktop_height);
+    properties.insert("ironrdp_colordepth", settings.color_depth);
+    if let Some(value) = compatibility.enable_credssp {
+        properties.insert("enablecredsspsupport", value);
+    }
+    if let Some(value) = compatibility.enable_tls {
+        properties.insert("ironrdp_tls", value);
+    }
+    if let Some(value) = compatibility.autologon {
+        properties.insert("ironrdp_autologon", value);
+    }
+    if let Some(value) = compatibility.desktop_scale_factor {
+        properties.insert("desktopscalefactor", value);
+    }
+    properties.insert("redirectclipboard", compatibility.redirect_clipboard);
+    properties.insert("compression", compatibility.compression.unwrap_or(true));
+    properties
 }
 
 impl Control {
@@ -3956,11 +4024,21 @@ impl Control {
             presentation_layout_generation: Cell::new(0),
             traced_frame_layout_generation: Cell::new(0),
             traced_paint_layout_generation: Cell::new(0),
+            rpc: ActiveXRpc::from_environment(),
+            rpc_properties: RefCell::new(None),
+            rpc_kerberos_config: RefCell::new(None),
+            rpc_log_directive: RefCell::new(None),
         }
     }
 
     fn remember_callback_owner(&self, owner: *const Control_Impl) {
         self.callback_owner.set(owner);
+        if let Some(rpc) = &self.rpc
+            && let Ok(dispatcher) = self.ensure_dispatcher()
+            && let Err(error) = rpc.start(dispatcher)
+        {
+            tracing::warn!(?error, "Unable to start ActiveX RPC listener");
+        }
     }
 
     fn connection_bar_owner(&self) -> Option<HWND> {
@@ -5118,7 +5196,13 @@ impl Control {
         let (server, configured_username) = {
             let settings = self.settings.borrow();
             let server = if settings.server.trim().is_empty() {
-                self.native_mstsc_server_from_host_ui().unwrap_or_default()
+                self.native_mstsc_server_from_host_ui().unwrap_or_else(|| {
+                    let server = std::env::var("RDP_HOSTNAME").unwrap_or_default();
+                    if !server.trim().is_empty() {
+                        trace_host_call("NativeMstscCredentialBridge::ServerFromEnvironment");
+                    }
+                    server
+                })
             } else {
                 settings.server.clone()
             };
@@ -5127,6 +5211,25 @@ impl Control {
         if server.trim().is_empty() {
             trace_host_call("NativeMstscCredentialBridge::MissingServer");
             return Ok(false);
+        }
+        if native_mstsc_autologon_enabled() {
+            let Some((username, password)) =
+                autologon_credentials(std::env::var("RDP_USERNAME").ok(), std::env::var("RDP_PASSWORD").ok())
+            else {
+                trace_host_call("NativeMstscCredentialBridge::AutoLogonMissingCredentials");
+                return Ok(false);
+            };
+            {
+                let mut settings = self.settings.borrow_mut();
+                settings.server = server;
+                settings.domain.clear();
+                settings.username = username;
+                settings.password = Some(password);
+            }
+            self.compatibility.borrow_mut().autologon = Some(true);
+            trace_host_call("NativeMstscCredentialBridge::AutoLogon");
+            self.start_connection()?;
+            return Ok(self.state.get() != ConnectionState::Disconnected);
         }
         let target = HSTRING::from(format!("IronRDP:{server}"));
         let message = HSTRING::from(format!("Enter credentials for {server}"));
@@ -5749,6 +5852,9 @@ impl Control {
                 WorkerEvent::Connected { .. } => {
                     if self.state.get() == ConnectionState::Connecting {
                         self.state.set(ConnectionState::Connected);
+                        if let Some(rpc) = &self.rpc {
+                            rpc.session_connected();
+                        }
                         self.clipboard_state.connected.set(true);
                         self.fire_event(DISPID_ON_CONNECTED, &[]);
                         self.clear_connection_health_window();
@@ -5785,10 +5891,17 @@ impl Control {
                     {
                         self.fire_event(DISPID_ON_REMOTE_DESKTOP_SIZE_CHANGE, &[width, height]);
                     }
+                    if let (Some(rpc), Ok(width), Ok(height)) = (&self.rpc, u16::try_from(width), u16::try_from(height))
+                    {
+                        rpc.retain_frame(width, height, &buffer);
+                    }
                     self.present_frame(buffer, width, height);
                 }
                 WorkerEvent::DisplayResizeFallback { .. } => self.report_display_resize_fallback(),
                 WorkerEvent::FatalError { disconnect, .. } => {
+                    if let Some(rpc) = &self.rpc {
+                        rpc.session_failed(disconnect.description.to_owned());
+                    }
                     self.state.set(ConnectionState::Stopping);
                     self.clear_connection_health_window();
                     if let Err(error) = self.destroy_connection_bar() {
@@ -5806,6 +5919,9 @@ impl Control {
                     self.show_connection_failure_dialog();
                 }
                 WorkerEvent::Disconnected { disconnect, .. } => {
+                    if let Some(rpc) = &self.rpc {
+                        rpc.session_disconnected(disconnect.description.to_owned());
+                    }
                     self.state.set(ConnectionState::Stopping);
                     self.clear_connection_health_window();
                     if let Err(error) = self.destroy_connection_bar() {
@@ -5836,9 +5952,286 @@ impl Control {
                     self.state.set(ConnectionState::Disconnected);
                     self.native_mstsc_preflight.set(NativeMstscPreflight::Idle);
                     self.compatibility.borrow_mut().connection_settings_sealed = false;
+                    if let Some(rpc) = &self.rpc {
+                        rpc.session_stopped();
+                    }
                 }
             }
         }
+    }
+
+    fn dispatch_rpc_commands(&self) {
+        let Some(rpc) = &self.rpc else {
+            return;
+        };
+        rpc.drain_commands(|command| self.handle_rpc_command(command));
+    }
+
+    fn handle_rpc_command(&self, command: RpcCommand) {
+        match command {
+            RpcCommand::Connect {
+                properties,
+                log_directive,
+                response,
+            } => {
+                let _ = response.send(self.rpc_connect(properties, log_directive));
+            }
+            RpcCommand::Disconnect { response } => {
+                let response_value = if self.state.get() == ConnectionState::Disconnected {
+                    ironrdp_agent::ipc::Response::typed_error(
+                        ironrdp_agent::ipc::AgentErrorCategory::Unavailable,
+                        "no active RDP session",
+                    )
+                } else {
+                    self.stop_connection()
+                        .map_or_else(rpc_control_error, |_| ironrdp_agent::ipc::Response::ok())
+                };
+                let _ = response.send(response_value);
+            }
+            RpcCommand::Input { operation, response } => {
+                let _ = response.send(self.rpc_input(operation));
+            }
+            RpcCommand::Resize {
+                width,
+                height,
+                response,
+            } => {
+                let response_value = if width == 0 || height == 0 {
+                    ironrdp_agent::ipc::Response::typed_error(
+                        ironrdp_agent::ipc::AgentErrorCategory::InvalidRequest,
+                        "width and height must be non-zero",
+                    )
+                } else {
+                    self.update_display_layout(DisplayLayout {
+                        desktop_width: u32::from(width),
+                        desktop_height: u32::from(height),
+                        physical_width: 0,
+                        physical_height: 0,
+                        orientation: 0,
+                        desktop_scale_factor: 100,
+                        device_scale_factor: 100,
+                    })
+                    .map_or_else(rpc_control_error, |_| ironrdp_agent::ipc::Response::ok())
+                };
+                let _ = response.send(response_value);
+            }
+        }
+    }
+
+    fn rpc_connect(&self, properties: PropertySet, log_directive: Option<String>) -> ironrdp_agent::ipc::Response {
+        if self.state.get() != ConnectionState::Disconnected {
+            return ironrdp_agent::ipc::Response::typed_error(
+                ironrdp_agent::ipc::AgentErrorCategory::Conflict,
+                "a session is already active; disconnect first",
+            );
+        }
+        if [
+            "ironrdp_dvcpipeproxy",
+            "ironrdp_dvcplugin",
+            "ironrdp_rdcleanpathurl",
+            "ironrdp_rdcleanpathtoken",
+            "ironrdp_qoi",
+            "ironrdp_qoiz",
+            "ironrdp_rdpdr",
+            "ironrdp_smartcard",
+            "ironrdp_serverpointer",
+        ]
+        .into_iter()
+        .any(|key| properties.get::<&str>(key).is_some() || properties.get::<i64>(key).is_some())
+        {
+            return ironrdp_agent::ipc::Response::typed_error(
+                ironrdp_agent::ipc::AgentErrorCategory::InvalidRequest,
+                "the requested transport extension is not supported by the ActiveX host",
+            );
+        };
+
+        let certificate_validation = match properties.get::<&str>("ironrdp_certificate_validation") {
+            None | Some("strict") => CertificateValidation::Strict,
+            Some("dangerously_accept_invalid_certificate") => {
+                CertificateValidation::DangerouslyAcceptInvalidCertificate
+            }
+            Some(_) => {
+                return ironrdp_agent::ipc::Response::typed_error(
+                    ironrdp_agent::ipc::AgentErrorCategory::InvalidRequest,
+                    "invalid certificate validation policy",
+                );
+            }
+        };
+        let builder = match ConfigBuilder::from_property_set(&properties) {
+            Ok(builder) => builder,
+            Err(error) => {
+                return ironrdp_agent::ipc::Response::typed_error(
+                    ironrdp_agent::ipc::AgentErrorCategory::InvalidRequest,
+                    format!("invalid configuration: {error:#}"),
+                );
+            }
+        }
+        .with_client_build(self.compatibility.borrow().client_build)
+        .with_client_dir(self.compatibility.borrow().client_dir.clone())
+        .with_client_name(
+            self.compatibility
+                .borrow()
+                .client_name
+                .clone()
+                .unwrap_or_else(|| "IronRDP ActiveX".to_owned()),
+        )
+        .with_platform(MajorPlatformType::WINDOWS)
+        .with_certificate_validation(certificate_validation)
+        .with_pointer_software_rendering(true);
+        let missing = builder.missing();
+        if !missing.is_empty() {
+            return ironrdp_agent::ipc::Response::typed_error(
+                ironrdp_agent::ipc::AgentErrorCategory::InvalidRequest,
+                format!(
+                    "missing required fields: {}",
+                    missing
+                        .iter()
+                        .map(ironrdp_client::config::MissingField::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+            );
+        }
+        let config = match builder.build() {
+            Ok(config) => config,
+            Err(error) => {
+                return ironrdp_agent::ipc::Response::typed_error(
+                    ironrdp_agent::ipc::AgentErrorCategory::InvalidRequest,
+                    format!("{error:#}"),
+                );
+            }
+        };
+        if matches!(config.transport(), Transport::RDCleanPath(_)) {
+            return ironrdp_agent::ipc::Response::typed_error(
+                ironrdp_agent::ipc::AgentErrorCategory::InvalidRequest,
+                "RDCleanPath is not supported by the ActiveX host",
+            );
+        }
+        let Credentials::UsernamePassword { username, password } = &config.connector().credentials else {
+            return ironrdp_agent::ipc::Response::typed_error(
+                ironrdp_agent::ipc::AgentErrorCategory::InvalidRequest,
+                "smart card credentials are not supported by the ActiveX host",
+            );
+        };
+
+        {
+            let mut settings = self.settings.borrow_mut();
+            settings.server = config.destination().name().to_owned();
+            settings.username = username.clone();
+            settings.password = Some(password.clone());
+            settings.domain = config.connector().domain.clone().unwrap_or_default();
+            settings.desktop_width = config.connector().desktop_size.width;
+            settings.desktop_height = config.connector().desktop_size.height;
+            settings.color_depth = config
+                .connector()
+                .bitmap
+                .as_ref()
+                .map(|bitmap| bitmap.color_depth)
+                .unwrap_or(32);
+        }
+        {
+            let connector = config.connector();
+            let mut compatibility = self.compatibility.borrow_mut();
+            compatibility.enable_credssp = Some(connector.enable_credssp);
+            compatibility.enable_tls = Some(connector.enable_tls);
+            compatibility.compression = Some(connector.compression_type.is_some());
+            compatibility.compression_level = connector.compression_type.map(|compression| match compression {
+                ironrdp_pdu::rdp::client_info::CompressionType::K8 => 0,
+                ironrdp_pdu::rdp::client_info::CompressionType::K64 => 1,
+                ironrdp_pdu::rdp::client_info::CompressionType::Rdp6 => 2,
+                ironrdp_pdu::rdp::client_info::CompressionType::Rdp61 => 3,
+            });
+            compatibility.redirect_clipboard = matches!(config.channels().clipboard, ClipboardType::Enable);
+            compatibility.performance_flags = connector.performance_flags;
+            compatibility.keyboard_type = connector.keyboard_type;
+            compatibility.keyboard_subtype = connector.keyboard_subtype;
+            compatibility.keyboard_functional_keys_count = connector.keyboard_functional_keys_count;
+            compatibility.keyboard_layout = connector.keyboard_layout;
+            compatibility.network_connection_type = connector.connection_type;
+            compatibility.desktop_scale_factor = Some(connector.desktop_scale_factor);
+            compatibility.client_build = connector.client_build;
+            compatibility.client_dir = connector.client_dir.clone();
+            compatibility.client_name = Some(connector.client_name.clone());
+            compatibility.ime_file_name = connector.ime_file_name.clone();
+            compatibility.digital_product_id = connector.dig_product_id.clone();
+            compatibility.autologon = Some(connector.autologon);
+            compatibility.rdp_port = Some(config.destination().port());
+            compatibility.fake_events_interval_minutes = config
+                .fake_events_interval()
+                .map(|interval| u32::try_from(interval.as_secs() / 60).unwrap_or(u32::MAX));
+            compatibility.audio_redirection_mode = if connector.enable_audio_playback { 0 } else { 2 };
+            compatibility.secured_start_program = connector.alternate_shell.clone();
+            compatibility.secured_work_dir = connector.work_dir.clone();
+            compatibility.authentication_level_set =
+                certificate_validation == CertificateValidation::DangerouslyAcceptInvalidCertificate;
+            compatibility.authentication_level = if compatibility.authentication_level_set { 0 } else { 1 };
+            match config.transport() {
+                Transport::Direct => {
+                    compatibility.gateway_usage_method = GatewayUsageMethod::Direct.as_i64() as u32;
+                }
+                Transport::Gateway(gateway) => {
+                    compatibility.gateway_hostname = gateway.endpoint.clone();
+                    compatibility.gateway_username = gateway.username.clone();
+                    compatibility.gateway_password = gateway.password.clone();
+                    compatibility.gateway_domain.clear();
+                    compatibility.gateway_usage_method = GatewayUsageMethod::UseAlways.as_i64() as u32;
+                    compatibility.gateway_creds_source = GatewayCredentialsSource::UseUserCredentials.as_i64() as u32;
+                }
+                Transport::RDCleanPath(_) => unreachable!("RDCleanPath was rejected above"),
+            }
+        }
+
+        *self.rpc_properties.borrow_mut() = Some(config.properties().clone());
+        *self.rpc_kerberos_config.borrow_mut() = config.kerberos_config().cloned();
+        *self.rpc_log_directive.borrow_mut() = log_directive;
+        match self.start_connection() {
+            Ok(()) if self.state.get() == ConnectionState::Disconnected => {
+                self.rpc_properties.borrow_mut().take();
+                self.rpc_kerberos_config.borrow_mut().take();
+                let _ = self.rpc_log_directive.borrow_mut().take();
+                ironrdp_agent::ipc::Response::typed_error(
+                    ironrdp_agent::ipc::AgentErrorCategory::Unavailable,
+                    "connection cancelled",
+                )
+            }
+            Ok(()) => ironrdp_agent::ipc::Response::ok(),
+            Err(error) => {
+                self.rpc_properties.borrow_mut().take();
+                self.rpc_kerberos_config.borrow_mut().take();
+                let _ = self.rpc_log_directive.borrow_mut().take();
+                rpc_control_error(error)
+            }
+        }
+    }
+
+    fn rpc_input(&self, operation: Operation) -> ironrdp_agent::ipc::Response {
+        if self.state.get() != ConnectionState::Connected {
+            return ironrdp_agent::ipc::Response::typed_error(
+                ironrdp_agent::ipc::AgentErrorCategory::Unavailable,
+                "no active RDP session",
+            );
+        }
+        let Some(sender) = self.input_sender.borrow().as_ref().cloned() else {
+            return ironrdp_agent::ipc::Response::typed_error(
+                ironrdp_agent::ipc::AgentErrorCategory::Unavailable,
+                "session input channel is unavailable",
+            );
+        };
+        let permit = match sender.try_reserve() {
+            Ok(permit) => permit,
+            Err(_) => {
+                return ironrdp_agent::ipc::Response::typed_error(
+                    ironrdp_agent::ipc::AgentErrorCategory::Unavailable,
+                    "session input channel is unavailable",
+                );
+            }
+        };
+        let fast_path = self.input_database.borrow_mut().apply([operation]);
+        if fast_path.is_empty() {
+            return ironrdp_agent::ipc::Response::ok();
+        }
+        permit.send(RdpInputEvent::FastPath(fast_path));
+        ironrdp_agent::ipc::Response::ok()
     }
 
     fn start_connection(&self) -> Result<()> {
@@ -5911,6 +6304,7 @@ impl Control {
         let authentication_level = compatibility.authentication_level;
         let authentication_level_set = compatibility.authentication_level_set;
         let public_mode = compatibility.public_mode;
+        let direct_rpc_properties = active_x_property_snapshot(&settings, &compatibility);
         drop(compatibility);
         if !self.confirm_connection_security_warnings(warn_about_credentials, warn_about_clipboard)? {
             return Ok(());
@@ -5984,6 +6378,15 @@ impl Control {
         let channel_events = Arc::clone(&self.events);
         let channel_event_posted = Arc::clone(&self.event_posted);
         let static_channel_dispatcher = hwnd.0 as isize;
+        let rpc_now_endpoint = self
+            .rpc
+            .as_ref()
+            .map(|_| ActiveXRpc::allocate_now_endpoint())
+            .transpose()
+            .map_err(|response| match response {
+                ironrdp_agent::ipc::Response::Err(error) => Error::new(E_FAIL, error.message),
+                ironrdp_agent::ipc::Response::Ok(_) => Error::from_hresult(E_FAIL),
+            })?;
         let builder = ConfigBuilder::new()
             .with_destination(destination)
             .with_username(settings.username.clone())
@@ -6025,6 +6428,11 @@ impl Control {
             } else {
                 ClipboardType::Disable
             });
+        let builder = if let Some(kerberos_config) = self.rpc_kerberos_config.borrow_mut().take() {
+            builder.with_kerberos_config(kerberos_config)
+        } else {
+            builder
+        };
         let builder = if let Some(callback) = certificate_validation_callback {
             builder.with_certificate_validation_callback(callback)
         } else {
@@ -6092,9 +6500,15 @@ impl Control {
                 })
                 .collect()
         });
+        let builder = if let Some(now_endpoint) = &rpc_now_endpoint {
+            builder.with_dvc_pipe_proxy(now_endpoint.dvc_proxy_info())
+        } else {
+            builder
+        };
         let config = builder
             .build()
             .map_err(|error| Error::new(E_INVALIDARG, format!("invalid RDP configuration: {error}")))?;
+        let rpc_destination = config.destination().to_string();
         drop(settings);
         let (output_sender, mut output_receiver) = mpsc::channel(32);
         let client = RdpClient::new(config, output_sender);
@@ -6113,6 +6527,11 @@ impl Control {
         let events = Arc::clone(&self.events);
         let event_posted = Arc::clone(&self.event_posted);
         let hwnd_raw = hwnd.0 as isize;
+        let rpc_log_directive = self.rpc_log_directive.borrow().clone();
+        let rpc_dispatch = self
+            .rpc
+            .as_ref()
+            .map(|rpc| rpc.session_dispatch(rpc_log_directive.as_deref()));
         let module = match com::retain_module_for_worker() {
             Ok(module) => module,
             Err(error) => {
@@ -6122,6 +6541,12 @@ impl Control {
             }
         };
         let module_raw = module.0 as isize;
+
+        let rpc_properties = self.rpc_properties.borrow_mut().take().unwrap_or(direct_rpc_properties);
+        self.rpc_log_directive.borrow_mut().take();
+        if let (Some(rpc), Some(now_endpoint)) = (&self.rpc, rpc_now_endpoint.as_ref()) {
+            rpc.session_started(rpc_destination, rpc_properties, Arc::clone(now_endpoint));
+        }
 
         com::add_worker();
         let spawn = std::thread::Builder::new()
@@ -6139,7 +6564,7 @@ impl Control {
                         match runtime {
                             Ok(runtime) => {
                                 let local = tokio::task::LocalSet::new();
-                                runtime.block_on(local.run_until(async move {
+                                let worker = local.run_until(async move {
                                     let client_task = tokio::task::spawn_local(client.run());
                                     let mut connection_failed = false;
                                     let mut terminal_received = false;
@@ -6257,7 +6682,12 @@ impl Control {
                                         hwnd,
                                         WorkerEvent::Stopped { generation },
                                     );
-                                }));
+                                });
+                                if let Some(dispatch) = rpc_dispatch {
+                                    tracing::dispatcher::with_default(&dispatch, || runtime.block_on(worker));
+                                } else {
+                                    runtime.block_on(worker);
+                                }
                             }
                             Err(error) => {
                                 tracing::error!(?error, "Unable to create RDP worker runtime");
@@ -6302,7 +6732,12 @@ impl Control {
             com::release_module_reference(module);
             self.stop_clipboard_redirection();
             self.compatibility.borrow_mut().connection_settings_sealed = false;
-            return Err(Error::new(E_FAIL, format!("unable to start RDP worker: {error}")));
+            let message = format!("unable to start RDP worker: {error}");
+            if let Some(rpc) = &self.rpc {
+                rpc.session_failed(message.clone());
+                rpc.session_stopped();
+            }
+            return Err(Error::new(E_FAIL, message));
         }
 
         *self.input_sender.borrow_mut() = Some(input_sender);
@@ -6330,6 +6765,9 @@ impl Control {
         self.last_disconnect.set(DisconnectInfo::api_initiated());
         sender.request_close();
         self.state.set(ConnectionState::Stopping);
+        if let Some(rpc) = &self.rpc {
+            rpc.session_disconnecting();
+        }
         self.clear_connection_health_window();
         Ok(())
     }
@@ -7329,6 +7767,9 @@ impl Control {
 impl Drop for Control {
     fn drop(&mut self) {
         trace_host_call("Control::Drop");
+        if let Some(rpc) = &self.rpc {
+            rpc.stop();
+        }
         let _ = self.stop_connection();
         self.stop_clipboard_redirection();
         if let Err(error) = self.destroy_connection_bar() {
@@ -8808,7 +9249,9 @@ impl IViewObjectEx_Impl for Control_Impl {
 impl IOleObject_Impl for Control_Impl {
     fn SetClientSite(&self, site: Ref<'_, IOleClientSite>) -> Result<()> {
         trace_host_call("IOleObject::SetClientSite");
-        if site.is_none() {
+        if site.is_some() {
+            self.remember_callback_owner(self);
+        } else {
             self.release_input();
         }
         *self.client_site.borrow_mut() = site.cloned();
@@ -8888,6 +9331,7 @@ impl IOleObject_Impl for Control_Impl {
         position: *const RECT,
     ) -> Result<()> {
         trace_host_call("IOleObject::DoVerb");
+        self.remember_callback_owner(self);
         let action = ole_verb_action(verb)?;
         let active_site = active_site.cloned();
         let recorded_site = self.client_site.borrow().clone();
@@ -10941,6 +11385,14 @@ unsafe extern "system" fn dispatcher_window_proc(hwnd: HWND, message: u32, _wpar
             }
             LRESULT(0)
         }
+        rpc::WM_DISPATCH_RPC => {
+            if let Some(owner) = unsafe { control_from_window(hwnd).as_ref() } {
+                let _keep_alive: IUnknown = owner.to_interface();
+                let control: &Control = owner;
+                control.dispatch_rpc_commands();
+            }
+            LRESULT(0)
+        }
         WM_NCDESTROY => {
             let context = unsafe { GetWindowLongPtrW(hwnd, GWLP_USERDATA) } as *const ControlWindowContext;
             unsafe {
@@ -12262,6 +12714,24 @@ mod tests {
             [u16::from(b'l'), u16::from(b'o'), u16::from(b'n'), u16::from(b'g'), 0]
         );
         assert!(credential_prompt_buffer("ignored", 0).is_empty());
+    }
+
+    #[test]
+    fn autologon_credentials_require_nonempty_username_and_password() {
+        assert_eq!(
+            autologon_credentials(Some("user".to_owned()), Some("password".to_owned())),
+            Some(("user".to_owned(), "password".to_owned()))
+        );
+        assert_eq!(autologon_credentials(None, Some("password".to_owned())), None);
+        assert_eq!(autologon_credentials(Some("user".to_owned()), None), None);
+        assert_eq!(
+            autologon_credentials(Some(String::new()), Some("password".to_owned())),
+            None
+        );
+        assert_eq!(
+            autologon_credentials(Some("user".to_owned()), Some(String::new())),
+            None
+        );
     }
 
     #[test]

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -6030,14 +6030,18 @@ impl Control {
             "ironrdp_dvcplugin",
             "ironrdp_rdcleanpathurl",
             "ironrdp_rdcleanpathtoken",
-            "ironrdp_qoi",
-            "ironrdp_qoiz",
-            "ironrdp_rdpdr",
-            "ironrdp_smartcard",
-            "ironrdp_serverpointer",
         ]
         .into_iter()
-        .any(|key| properties.get::<&str>(key).is_some() || properties.get::<i64>(key).is_some())
+        .any(|key| properties.get::<&str>(key).is_some())
+            || [
+                "ironrdp_qoi",
+                "ironrdp_qoiz",
+                "ironrdp_rdpdr",
+                "ironrdp_smartcard",
+                "ironrdp_serverpointer",
+            ]
+            .into_iter()
+            .any(|key| properties.get::<i64>(key).is_some_and(|value| value != 0))
         {
             return ironrdp_agent::ipc::Response::typed_error(
                 ironrdp_agent::ipc::AgentErrorCategory::InvalidRequest,

--- a/crates/ironrdp-activex/src/lib.rs
+++ b/crates/ironrdp-activex/src/lib.rs
@@ -29,6 +29,8 @@ mod control;
 mod mstsc;
 #[cfg(windows)]
 mod registration;
+#[cfg(windows)]
+mod rpc;
 
 #[cfg(windows)]
 pub use com::{

--- a/crates/ironrdp-activex/src/rpc.rs
+++ b/crates/ironrdp-activex/src/rpc.rs
@@ -6,6 +6,7 @@
 
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 
@@ -118,28 +119,49 @@ impl ActiveXRpc {
 
     pub(crate) fn start(&self, dispatcher: HWND) -> anyhow::Result<()> {
         let mut listener = lock(&self.listener);
-        if listener.is_some() {
+        if listener.as_ref().is_some_and(|handle| !handle.join.is_finished()) {
             return Ok(());
+        }
+        if let Some(handle) = listener.take()
+            && handle.join.join().is_err()
+        {
+            tracing::warn!("ActiveX RPC listener thread panicked");
         }
 
         let endpoint = endpoint_from_environment();
         let shared = Arc::clone(&self.shared);
         let dispatcher = dispatcher.0 as isize;
         let (shutdown, shutdown_rx) = watch::channel(());
+        let (ready_tx, ready_rx) = mpsc::sync_channel(1);
         let join = std::thread::Builder::new()
             .name("ironrdp-activex-rpc".to_owned())
             .spawn(move || {
-                let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build();
-                match runtime {
-                    Ok(runtime) => {
-                        if let Err(error) = runtime.block_on(serve(endpoint, shared, dispatcher, shutdown_rx)) {
-                            tracing::warn!(?error, "ActiveX RPC listener stopped with an error");
-                        }
+                let runtime = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
+                    Ok(runtime) => runtime,
+                    Err(error) => {
+                        let _ = ready_tx.send(Err(error.into()));
+                        return;
                     }
-                    Err(error) => tracing::warn!(?error, "Unable to create ActiveX RPC runtime"),
+                };
+                let listener = match runtime.block_on(async {
+                    transport::prepare_endpoint(&endpoint).await?;
+                    Listener::bind(&endpoint).with_context(|| format!("bind ActiveX RPC endpoint {endpoint}"))
+                }) {
+                    Ok(listener) => listener,
+                    Err(error) => {
+                        let _ = ready_tx.send(Err(error));
+                        return;
+                    }
+                };
+                if ready_tx.send(Ok(())).is_err() {
+                    return;
+                }
+                if let Err(error) = runtime.block_on(serve(endpoint, listener, shared, dispatcher, shutdown_rx)) {
+                    tracing::warn!(?error, "ActiveX RPC listener stopped with an error");
                 }
             })
             .context("start ActiveX RPC listener")?;
+        ready_rx.recv().context("wait for ActiveX RPC listener startup")??;
         *listener = Some(ListenerHandle { shutdown, join });
         Ok(())
     }
@@ -252,12 +274,11 @@ impl ActiveXRpc {
 
 async fn serve(
     endpoint: Endpoint,
+    mut listener: Listener,
     shared: Arc<Shared>,
     dispatcher: isize,
     mut shutdown: watch::Receiver<()>,
 ) -> anyhow::Result<()> {
-    transport::prepare_endpoint(&endpoint).await?;
-    let mut listener = Listener::bind(&endpoint).with_context(|| format!("bind ActiveX RPC endpoint {endpoint}"))?;
     tracing::info!(%endpoint, "ActiveX RPC listener started");
 
     loop {

--- a/crates/ironrdp-activex/src/rpc.rs
+++ b/crates/ironrdp-activex/src/rpc.rs
@@ -1,0 +1,778 @@
+//! Opt-in local RPC service for an ActiveX-hosted session.
+//!
+//! The service owns no COM state. Requests which need the apartment-bound control are carried to
+//! its message-only dispatcher and completed there; status, frame, log, and NOW state are shared
+//! independently with the listener threads.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+
+use anyhow::Context as _;
+use ironrdp_agent::ipc::{
+    AgentErrorCategory, ConnState, KeyFilter, NowDiagnostics, Payload, PropValue, PropertyDump, PropertyEntry, Request,
+    Response, StatusInfo,
+};
+use ironrdp_daemon::logbuf::{self, LogBuffer};
+use ironrdp_daemon::now::NowEndpoint;
+use ironrdp_daemon::operations::{OperationAttachment, OperationManager};
+use ironrdp_input::Operation;
+use ironrdp_propertyset::{PropertySet, Value};
+use ironrdp_rpc as ironrdp_agent;
+use ironrdp_rpc::transport::{self, Endpoint, Listener, read_message, write_message};
+use tokio::sync::{oneshot, watch};
+use windows::Win32::Foundation::{HWND, LPARAM, WPARAM};
+use windows::Win32::UI::WindowsAndMessaging::PostMessageW;
+
+pub(crate) const WM_DISPATCH_RPC: u32 = windows::Win32::UI::WindowsAndMessaging::WM_APP + 0x54;
+const COMMAND_QUEUE_CAPACITY: usize = 64;
+const MAX_SCREENSHOT_PIXELS: usize = 16 * 1024 * 1024;
+
+#[derive(Clone)]
+pub(crate) struct ActiveXRpc {
+    shared: Arc<Shared>,
+    listener: Arc<Mutex<Option<ListenerHandle>>>,
+}
+
+struct ListenerHandle {
+    shutdown: watch::Sender<()>,
+    join: JoinHandle<()>,
+}
+
+struct Shared {
+    live: Mutex<Live>,
+    logs: Arc<LogBuffer>,
+    commands: Mutex<VecDeque<Command>>,
+    command_posted: AtomicBool,
+    closing: AtomicBool,
+}
+
+struct Live {
+    state: ConnState,
+    destination: Option<String>,
+    properties: PropertySet,
+    frame: Option<Frame>,
+    error: Option<String>,
+    now_endpoint: Option<Arc<NowEndpoint>>,
+    operations: Option<OperationManager>,
+}
+
+#[derive(Clone)]
+struct Frame {
+    width: u16,
+    height: u16,
+    pixels: Vec<u32>,
+}
+
+pub(crate) enum Command {
+    Connect {
+        properties: PropertySet,
+        log_directive: Option<String>,
+        response: oneshot::Sender<Response>,
+    },
+    Disconnect {
+        response: oneshot::Sender<Response>,
+    },
+    Input {
+        operation: Operation,
+        response: oneshot::Sender<Response>,
+    },
+    Resize {
+        width: u16,
+        height: u16,
+        response: oneshot::Sender<Response>,
+    },
+}
+
+enum ConnectionResponse {
+    Single(Response),
+    Stream(Response, OperationAttachment),
+}
+
+impl ActiveXRpc {
+    pub(crate) fn from_environment() -> Option<Self> {
+        if std::env::var_os("IRONRDP_ACTIVEX_RPC").as_deref() != Some(std::ffi::OsStr::new("1")) {
+            return None;
+        }
+
+        Some(Self {
+            shared: Arc::new(Shared {
+                live: Mutex::new(Live {
+                    state: ConnState::NoSession,
+                    destination: None,
+                    properties: PropertySet::new(),
+                    frame: None,
+                    error: None,
+                    now_endpoint: None,
+                    operations: None,
+                }),
+                logs: LogBuffer::new(),
+                commands: Mutex::new(VecDeque::with_capacity(COMMAND_QUEUE_CAPACITY)),
+                command_posted: AtomicBool::new(false),
+                closing: AtomicBool::new(false),
+            }),
+            listener: Arc::new(Mutex::new(None)),
+        })
+    }
+
+    pub(crate) fn start(&self, dispatcher: HWND) -> anyhow::Result<()> {
+        let mut listener = lock(&self.listener);
+        if listener.is_some() {
+            return Ok(());
+        }
+
+        let endpoint = endpoint_from_environment();
+        let shared = Arc::clone(&self.shared);
+        let dispatcher = dispatcher.0 as isize;
+        let (shutdown, shutdown_rx) = watch::channel(());
+        let join = std::thread::Builder::new()
+            .name("ironrdp-activex-rpc".to_owned())
+            .spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build();
+                match runtime {
+                    Ok(runtime) => {
+                        if let Err(error) = runtime.block_on(serve(endpoint, shared, dispatcher, shutdown_rx)) {
+                            tracing::warn!(?error, "ActiveX RPC listener stopped with an error");
+                        }
+                    }
+                    Err(error) => tracing::warn!(?error, "Unable to create ActiveX RPC runtime"),
+                }
+            })
+            .context("start ActiveX RPC listener")?;
+        *listener = Some(ListenerHandle { shutdown, join });
+        Ok(())
+    }
+
+    pub(crate) fn stop(&self) {
+        self.shared.closing.store(true, Ordering::Release);
+        self.fail_pending("ActiveX control is closing");
+        let handle = lock(&self.listener).take();
+        if let Some(handle) = handle {
+            let _ = handle.shutdown.send(());
+            if handle.join.join().is_err() {
+                tracing::warn!("ActiveX RPC listener thread panicked");
+            }
+        }
+    }
+
+    pub(crate) fn drain_commands<F>(&self, mut execute: F)
+    where
+        F: FnMut(Command),
+    {
+        self.shared.command_posted.store(false, Ordering::Release);
+        let commands = {
+            let mut commands = lock(&self.shared.commands);
+            core::mem::take(&mut *commands)
+        };
+        for command in commands {
+            execute(command);
+        }
+    }
+
+    pub(crate) fn session_started(&self, destination: String, properties: PropertySet, endpoint: Arc<NowEndpoint>) {
+        self.shared.logs.clear();
+        let mut live = lock(&self.shared.live);
+        live.state = ConnState::Connecting;
+        live.destination = Some(destination);
+        live.properties = properties;
+        live.frame = None;
+        live.error = None;
+        live.operations = Some(OperationManager::new(Arc::clone(&endpoint)));
+        live.now_endpoint = Some(endpoint);
+    }
+
+    pub(crate) fn session_connected(&self) {
+        let mut live = lock(&self.shared.live);
+        live.state = ConnState::Connected;
+        live.error = None;
+    }
+
+    pub(crate) fn session_disconnecting(&self) {
+        let mut live = lock(&self.shared.live);
+        if matches!(live.state, ConnState::Connecting | ConnState::Connected) {
+            live.state = ConnState::Disconnecting;
+        }
+    }
+
+    pub(crate) fn session_failed(&self, message: String) {
+        let mut live = lock(&self.shared.live);
+        live.state = ConnState::Failed;
+        live.error = Some(message);
+    }
+
+    pub(crate) fn session_disconnected(&self, message: String) {
+        let mut live = lock(&self.shared.live);
+        live.state = ConnState::Disconnecting;
+        live.error = Some(message);
+    }
+
+    pub(crate) fn session_stopped(&self) {
+        let mut live = lock(&self.shared.live);
+        if !matches!(live.state, ConnState::Failed) {
+            live.state = ConnState::Disconnected;
+        }
+        live.frame = None;
+        live.now_endpoint = None;
+        live.operations = None;
+    }
+
+    pub(crate) fn retain_frame(&self, width: u16, height: u16, pixels: &[u32]) {
+        let mut live = lock(&self.shared.live);
+        live.properties.insert("desktopwidth", i64::from(width));
+        live.properties.insert("desktopheight", i64::from(height));
+        live.frame = Some(Frame {
+            width,
+            height,
+            pixels: pixels.to_vec(),
+        });
+    }
+
+    pub(crate) fn session_dispatch(&self, directive: Option<&str>) -> tracing::Dispatch {
+        logbuf::session_dispatch(Arc::clone(&self.shared.logs), directive)
+    }
+
+    pub(crate) fn allocate_now_endpoint() -> Result<Arc<NowEndpoint>, Response> {
+        NowEndpoint::new().map(Arc::new).map_err(|error| {
+            Response::typed_error(
+                AgentErrorCategory::Internal,
+                format!("failed to allocate NOW endpoint: {error}"),
+            )
+        })
+    }
+
+    fn fail_pending(&self, message: &str) {
+        let pending = {
+            let mut commands = lock(&self.shared.commands);
+            core::mem::take(&mut *commands)
+        };
+        for command in pending {
+            respond(command, Response::typed_error(AgentErrorCategory::Unavailable, message));
+        }
+    }
+}
+
+async fn serve(
+    endpoint: Endpoint,
+    shared: Arc<Shared>,
+    dispatcher: isize,
+    mut shutdown: watch::Receiver<()>,
+) -> anyhow::Result<()> {
+    transport::prepare_endpoint(&endpoint).await?;
+    let mut listener = Listener::bind(&endpoint).with_context(|| format!("bind ActiveX RPC endpoint {endpoint}"))?;
+    tracing::info!(%endpoint, "ActiveX RPC listener started");
+
+    loop {
+        tokio::select! {
+            result = listener.accept() => {
+                let stream = result.context("accept ActiveX RPC connection")?;
+                let shared = Arc::clone(&shared);
+                tokio::spawn(async move {
+                    if let Err(error) = handle_connection(stream, shared, dispatcher).await {
+                        tracing::debug!(error = format!("{error:#}"), "ActiveX RPC connection error");
+                    }
+                });
+            }
+            _ = shutdown.changed() => break,
+        }
+    }
+    Ok(())
+}
+
+async fn handle_connection<S>(mut stream: S, shared: Arc<Shared>, dispatcher: isize) -> anyhow::Result<()>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    let request: Request = read_message(&mut stream).await?;
+    let response = handle_request(&shared, dispatcher, request).await;
+    match response {
+        ConnectionResponse::Single(response) => write_message(&mut stream, &response).await?,
+        ConnectionResponse::Stream(response, mut attachment) => {
+            write_message(&mut stream, &response).await?;
+            for event in attachment.replay {
+                write_message(&mut stream, &Response::Ok(Payload::NowEvent(event))).await?;
+            }
+            while let Some(event) = attachment.live.recv().await {
+                write_message(&mut stream, &Response::Ok(Payload::NowEvent(event))).await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn handle_request(shared: &Arc<Shared>, dispatcher: isize, request: Request) -> ConnectionResponse {
+    let response = match request {
+        Request::Connect {
+            properties,
+            log_directive,
+        } => {
+            queue_command(shared, dispatcher, |response| Command::Connect {
+                properties,
+                log_directive,
+                response,
+            })
+            .await
+        }
+        Request::Disconnect => queue_command(shared, dispatcher, |response| Command::Disconnect { response }).await,
+        Request::Status => status(shared),
+        Request::QueryProps { filter } => query_props(shared, filter.as_ref()),
+        Request::QueryLogs { substring, last } => query_logs(shared, substring.as_deref(), last),
+        Request::Screenshot => screenshot(shared),
+        Request::MouseMove { x, y } => {
+            queue_command(shared, dispatcher, |response| Command::Input {
+                operation: Operation::MouseMove(ironrdp_input::MousePosition { x, y }),
+                response,
+            })
+            .await
+        }
+        Request::MouseButton { button, pressed } => {
+            queue_command(shared, dispatcher, |response| Command::Input {
+                operation: if pressed {
+                    Operation::MouseButtonPressed(button)
+                } else {
+                    Operation::MouseButtonReleased(button)
+                },
+                response,
+            })
+            .await
+        }
+        Request::Wheel { delta, horizontal } => {
+            queue_command(shared, dispatcher, |response| Command::Input {
+                operation: Operation::WheelRotations(ironrdp_input::WheelRotations {
+                    is_vertical: !horizontal,
+                    rotation_units: delta,
+                }),
+                response,
+            })
+            .await
+        }
+        Request::KeyScancode { scancode, pressed } => {
+            queue_command(shared, dispatcher, |response| Command::Input {
+                operation: if pressed {
+                    Operation::KeyPressed(ironrdp_input::Scancode::from_u16(scancode))
+                } else {
+                    Operation::KeyReleased(ironrdp_input::Scancode::from_u16(scancode))
+                },
+                response,
+            })
+            .await
+        }
+        Request::KeyUnicode { ch, pressed } => {
+            queue_command(shared, dispatcher, |response| Command::Input {
+                operation: if pressed {
+                    Operation::UnicodeKeyPressed(ch)
+                } else {
+                    Operation::UnicodeKeyReleased(ch)
+                },
+                response,
+            })
+            .await
+        }
+        Request::Resize { width, height } => {
+            queue_command(shared, dispatcher, |response| Command::Resize {
+                width,
+                height,
+                response,
+            })
+            .await
+        }
+        Request::NowCapabilities => return ConnectionResponse::Single(now_capabilities(shared).await),
+        Request::NowRun { command, directory } => {
+            return ConnectionResponse::Single(now_run(shared, command, directory).await);
+        }
+        Request::NowExecute(request) => return now_execute(shared, request).await,
+        Request::NowCancel { operation_id } => {
+            return ConnectionResponse::Single(now_cancel(shared, operation_id).await);
+        }
+        Request::NowList => return now_list(shared),
+        Request::NowStatus { operation_id } => return now_status(shared, operation_id),
+        Request::NowAttach {
+            operation_id,
+            after_sequence,
+        } => return now_attach(shared, operation_id, after_sequence),
+        Request::NowStdin {
+            operation_id,
+            data,
+            last,
+        } => return ConnectionResponse::Single(now_stdin(shared, operation_id, data, last).await),
+        Request::NowDiagnostics => return ConnectionResponse::Single(now_diagnostics(shared).await),
+    };
+    ConnectionResponse::Single(response)
+}
+
+async fn queue_command<F>(shared: &Arc<Shared>, dispatcher: isize, command: F) -> Response
+where
+    F: FnOnce(oneshot::Sender<Response>) -> Command,
+{
+    if shared.closing.load(Ordering::Acquire) {
+        return Response::typed_error(AgentErrorCategory::Unavailable, "ActiveX RPC listener is stopped");
+    }
+    let (response_tx, response_rx) = oneshot::channel();
+    {
+        let mut commands = lock(&shared.commands);
+        if commands.len() == COMMAND_QUEUE_CAPACITY {
+            return Response::typed_error(AgentErrorCategory::Unavailable, "ActiveX RPC command queue is full");
+        }
+        commands.push_back(command(response_tx));
+        if !shared.command_posted.swap(true, Ordering::AcqRel)
+            && unsafe {
+                PostMessageW(
+                    Some(HWND(dispatcher as *mut core::ffi::c_void)),
+                    WM_DISPATCH_RPC,
+                    WPARAM(0),
+                    LPARAM(0),
+                )
+            }
+            .is_err()
+        {
+            shared.command_posted.store(false, Ordering::Release);
+            let _ = commands.pop_back();
+            return Response::typed_error(AgentErrorCategory::Unavailable, "ActiveX dispatcher is unavailable");
+        }
+    }
+    response_rx
+        .await
+        .unwrap_or_else(|_| Response::typed_error(AgentErrorCategory::Unavailable, "ActiveX control is unavailable"))
+}
+
+fn status(shared: &Shared) -> Response {
+    let live = lock(&shared.live);
+    let (width, height) = live
+        .frame
+        .as_ref()
+        .map(|frame| (Some(frame.width), Some(frame.height)))
+        .unwrap_or((None, None));
+    Response::Ok(Payload::Status(StatusInfo {
+        state: live.state,
+        destination: live.destination.clone(),
+        width,
+        height,
+        message: live.error.clone(),
+        credentials_loaded: false,
+    }))
+}
+
+fn query_props(shared: &Shared, filter: Option<&KeyFilter>) -> Response {
+    let live = lock(&shared.live);
+    if live.state == ConnState::NoSession {
+        return unavailable_session();
+    }
+    let entries = live
+        .properties
+        .iter()
+        .filter(|(key, _)| filter.is_none_or(|filter| filter.matches(key)))
+        .map(|(key, value)| PropertyEntry {
+            key: key.to_string(),
+            value: match value {
+                Value::Int(value) => PropValue::Int(*value),
+                Value::Str(value) => PropValue::Str(value.clone()),
+            },
+        })
+        .collect();
+    Response::Ok(Payload::Properties(PropertyDump { entries }))
+}
+
+fn query_logs(shared: &Shared, substring: Option<&str>, last: Option<u32>) -> Response {
+    let mut lines = shared.logs.query(substring);
+    if let Some(last) = last
+        && let Ok(last) = usize::try_from(last)
+        && last < lines.len()
+    {
+        lines.drain(..lines.len() - last);
+    }
+    Response::Ok(Payload::Logs(lines))
+}
+
+fn screenshot(shared: &Shared) -> Response {
+    let frame = match lock(&shared.live).frame.clone() {
+        Some(frame) => frame,
+        None => return Response::typed_error(AgentErrorCategory::Unavailable, "no frame available yet"),
+    };
+    let frame = downscale_frame(frame, MAX_SCREENSHOT_PIXELS);
+    match encode_png(frame.width, frame.height, &frame.pixels) {
+        Ok(png) => Response::Ok(Payload::Screenshot {
+            width: frame.width,
+            height: frame.height,
+            png,
+        }),
+        Err(error) => Response::typed_error(
+            AgentErrorCategory::Internal,
+            format!("failed to encode screenshot: {error:#}"),
+        ),
+    }
+}
+
+fn operations(shared: &Shared) -> Result<OperationManager, Response> {
+    lock(&shared.live).operations.clone().ok_or_else(unavailable_session)
+}
+
+async fn now_capabilities(shared: &Shared) -> Response {
+    let operations = match operations(shared) {
+        Ok(operations) => operations,
+        Err(response) => return response,
+    };
+    match operations.capabilities().await {
+        Ok(capabilities) => Response::Ok(Payload::NowCapabilities(capabilities)),
+        Err(error) => Response::Err(error),
+    }
+}
+
+async fn now_run(shared: &Shared, command: String, directory: Option<String>) -> Response {
+    let operations = match operations(shared) {
+        Ok(operations) => operations,
+        Err(response) => return response,
+    };
+    match operations.run(command, directory).await {
+        Ok(()) => Response::ok(),
+        Err(error) => Response::Err(error),
+    }
+}
+
+async fn now_execute(shared: &Shared, request: ironrdp_agent::ipc::NowExecutionRequest) -> ConnectionResponse {
+    let operations = match operations(shared) {
+        Ok(operations) => operations,
+        Err(response) => return ConnectionResponse::Single(response),
+    };
+    match operations.execute(request).await {
+        Ok(info) if info.detached => ConnectionResponse::Single(Response::Ok(Payload::NowOperation(info))),
+        Ok(info) => match operations.attach(info.id, None) {
+            Ok(attachment) => ConnectionResponse::Stream(Response::Ok(Payload::NowOperation(info)), attachment),
+            Err(error) => ConnectionResponse::Single(Response::Err(error)),
+        },
+        Err(error) => ConnectionResponse::Single(Response::Err(error)),
+    }
+}
+
+async fn now_cancel(shared: &Shared, operation_id: u64) -> Response {
+    let operations = match operations(shared) {
+        Ok(operations) => operations,
+        Err(response) => return response,
+    };
+    operations
+        .cancel(operation_id)
+        .await
+        .map_or_else(Response::Err, |_| Response::ok())
+}
+
+fn now_list(shared: &Shared) -> ConnectionResponse {
+    match operations(shared) {
+        Ok(operations) => ConnectionResponse::Single(Response::Ok(Payload::NowOperations(operations.list()))),
+        Err(response) => ConnectionResponse::Single(response),
+    }
+}
+
+fn now_status(shared: &Shared, operation_id: u64) -> ConnectionResponse {
+    match operations(shared).and_then(|operations| {
+        operations
+            .status(operation_id)
+            .map(|operation| Response::Ok(Payload::NowOperation(operation)))
+            .map_err(Response::Err)
+    }) {
+        Ok(response) | Err(response) => ConnectionResponse::Single(response),
+    }
+}
+
+fn now_attach(shared: &Shared, operation_id: u64, after_sequence: Option<u64>) -> ConnectionResponse {
+    match operations(shared).and_then(|operations| {
+        operations
+            .attach(operation_id, after_sequence)
+            .map(|attachment| (attachment.info.clone(), attachment))
+            .map_err(Response::Err)
+    }) {
+        Ok((info, attachment)) => ConnectionResponse::Stream(Response::Ok(Payload::NowOperation(info)), attachment),
+        Err(response) => ConnectionResponse::Single(response),
+    }
+}
+
+async fn now_stdin(shared: &Shared, operation_id: u64, data: Vec<u8>, last: bool) -> Response {
+    let operations = match operations(shared) {
+        Ok(operations) => operations,
+        Err(response) => return response,
+    };
+    operations
+        .send_stdin(operation_id, data, last)
+        .await
+        .map_or_else(Response::Err, |_| Response::ok())
+}
+
+async fn now_diagnostics(shared: &Shared) -> Response {
+    let endpoint = match lock(&shared.live).now_endpoint.clone() {
+        Some(endpoint) => endpoint,
+        None => return unavailable_session(),
+    };
+    let (connected, capabilities) = endpoint.diagnostic_snapshot().await;
+    Response::Ok(Payload::NowDiagnostics(NowDiagnostics {
+        endpoint_allocated: true,
+        connected,
+        capabilities: capabilities.map(|capabilities| ironrdp_agent::ipc::NowCapabilities {
+            version_major: capabilities.version_major,
+            version_minor: capabilities.version_minor,
+            heartbeat_ms: capabilities.heartbeat_ms,
+            run: capabilities.run,
+            process: capabilities.process,
+            batch: capabilities.batch,
+            powershell: capabilities.powershell,
+            pwsh: capabilities.pwsh,
+            io_redirection: capabilities.io_redirection,
+            unicode_console: capabilities.unicode_console,
+        }),
+    }))
+}
+
+fn downscale_frame(frame: Frame, max_pixels: usize) -> Frame {
+    let source_width = usize::from(frame.width);
+    let source_height = usize::from(frame.height);
+    let source_pixels = source_width * source_height;
+    if source_pixels <= max_pixels {
+        return frame;
+    }
+
+    let mut lower = 1usize;
+    let mut upper = source_width;
+    while lower < upper {
+        let candidate = (lower + upper).div_ceil(2);
+        let candidate_height = (source_height * candidate / source_width).max(1);
+        if candidate * candidate_height <= max_pixels {
+            lower = candidate;
+        } else {
+            upper = candidate - 1;
+        }
+    }
+
+    let width = lower;
+    let height = (source_height * width / source_width).max(1);
+    let mut pixels = Vec::with_capacity(width * height);
+    for y in 0..height {
+        let source_y = y * source_height / height;
+        for x in 0..width {
+            let source_x = x * source_width / width;
+            pixels.push(frame.pixels[source_y * source_width + source_x]);
+        }
+    }
+
+    Frame {
+        width: u16::try_from(width).expect("scaled frame width fits source width"),
+        height: u16::try_from(height).expect("scaled frame height fits source height"),
+        pixels,
+    }
+}
+
+fn unavailable_session() -> Response {
+    Response::typed_error(AgentErrorCategory::Unavailable, "no active RDP session")
+}
+
+fn respond(command: Command, response: Response) {
+    let sender = match command {
+        Command::Connect { response, .. }
+        | Command::Disconnect { response }
+        | Command::Input { response, .. }
+        | Command::Resize { response, .. } => response,
+    };
+    let _ = sender.send(response);
+}
+
+fn endpoint_from_environment() -> Endpoint {
+    std::env::var("IRONRDP_ACTIVEX_RPC_ENDPOINT")
+        .map(transport::endpoint_from_string)
+        .unwrap_or_else(|_| transport::default_endpoint_named("ironrdp-activex"))
+}
+
+fn encode_png(width: u16, height: u16, pixels: &[u32]) -> anyhow::Result<Vec<u8>> {
+    let mut rgb = Vec::with_capacity(pixels.len() * 3 /* RGB */);
+    for pixel in pixels {
+        let [_, r, g, b] = pixel.to_be_bytes();
+        rgb.extend_from_slice(&[r, g, b]);
+    }
+    let mut png = Vec::new();
+    let mut encoder = png::Encoder::new(&mut png, u32::from(width), u32::from(height));
+    encoder.set_color(png::ColorType::Rgb);
+    encoder.set_depth(png::BitDepth::Eight);
+    let mut writer = encoder.write_header().context("write PNG header")?;
+    writer.write_image_data(&rgb).context("write PNG image data")?;
+    writer.finish().context("finish PNG stream")?;
+    Ok(png)
+}
+
+fn lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    mutex.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rpc() -> ActiveXRpc {
+        ActiveXRpc {
+            shared: Arc::new(Shared {
+                live: Mutex::new(Live {
+                    state: ConnState::NoSession,
+                    destination: None,
+                    properties: PropertySet::new(),
+                    frame: None,
+                    error: None,
+                    now_endpoint: None,
+                    operations: None,
+                }),
+                logs: LogBuffer::new(),
+                commands: Mutex::new(VecDeque::new()),
+                command_posted: AtomicBool::new(false),
+                closing: AtomicBool::new(false),
+            }),
+            listener: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    #[test]
+    fn screenshot_without_a_frame_is_unavailable() {
+        let rpc = rpc();
+        assert!(!screenshot(&rpc.shared).is_ok());
+    }
+
+    #[test]
+    fn session_lifecycle_retains_and_clears_cursor_composited_frames() {
+        let rpc = rpc();
+        let mut properties = PropertySet::new();
+        properties.insert("username", "alice");
+        let endpoint = Arc::new(NowEndpoint::new().expect("allocate NOW endpoint"));
+        rpc.session_started("server.example:3389".to_owned(), properties, endpoint);
+        rpc.session_connected();
+        rpc.retain_frame(1, 1, &[0x0011_2233]);
+
+        let Response::Ok(Payload::Status(initial_status)) = status(&rpc.shared) else {
+            panic!("status must be available");
+        };
+        assert_eq!(initial_status.state, ConnState::Connected);
+        assert_eq!(initial_status.destination.as_deref(), Some("server.example:3389"));
+        assert_eq!((initial_status.width, initial_status.height), (Some(1), Some(1)));
+        assert!(matches!(
+            screenshot(&rpc.shared),
+            Response::Ok(Payload::Screenshot {
+                width: 1,
+                height: 1,
+                ..
+            })
+        ));
+
+        rpc.session_stopped();
+        let Response::Ok(Payload::Status(stopped_status)) = status(&rpc.shared) else {
+            panic!("status must be available");
+        };
+        assert_eq!(stopped_status.state, ConnState::Disconnected);
+        assert!(!screenshot(&rpc.shared).is_ok());
+    }
+
+    #[test]
+    fn downscale_frame_preserves_aspect_ratio_within_pixel_limit() {
+        let frame = Frame {
+            width: 4,
+            height: 2,
+            pixels: (0..8).collect(),
+        };
+
+        let scaled = downscale_frame(frame, 3);
+
+        assert_eq!((scaled.width, scaled.height), (3, 1));
+        assert_eq!(scaled.pixels, vec![0, 1, 2]);
+    }
+}

--- a/crates/ironrdp-activex/src/rpc.rs
+++ b/crates/ironrdp-activex/src/rpc.rs
@@ -213,8 +213,6 @@ impl ActiveXRpc {
             live.state = ConnState::Disconnected;
         }
         live.frame = None;
-        live.now_endpoint = None;
-        live.operations = None;
     }
 
     pub(crate) fn retain_frame(&self, width: u16, height: u16, pixels: &[u32]) {

--- a/crates/ironrdp-agent/Cargo.toml
+++ b/crates/ironrdp-agent/Cargo.toml
@@ -32,7 +32,7 @@ ironrdp-rpc = { path = "../ironrdp-rpc", version = "0.1" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 
 # CLI
-clap = { version = "4.6", features = ["derive", "cargo"] }
+clap = { version = "4.6", features = ["derive", "cargo", "env"] }
 
 # Utils
 anyhow = "1"

--- a/crates/ironrdp-agent/README.md
+++ b/crates/ironrdp-agent/README.md
@@ -14,6 +14,18 @@ The `ironrdp-agent` binary is the CLI for the persistent daemon support:
 
 Run `ironrdp-agent --help-agent` for a structured, machine-readable description of every operation.
 
+## ActiveX backend
+
+On Windows, an ActiveX host can expose its session through the same local RPC protocol. Start the
+host with `IRONRDP_ACTIVEX_RPC=1`, then use `--backend active-x` for agent operations. The agent
+uses the per-user `ironrdp-activex` endpoint by default and never attempts to start an ActiveX host.
+Use `--endpoint` when the host selected `IRONRDP_ACTIVEX_RPC_ENDPOINT`.
+
+`connect` accepts `RDP_HOSTNAME`, `RDP_USERNAME`, and `RDP_PASSWORD` as defaults for its named
+connection flags. Explicit flags override those process-local values. The native MSTSC bridge uses
+these only when it is explicitly enabled; `RDP_AUTOLOGON` is active only when its value is exactly
+`1`, and requires nonempty username and password values.
+
 ## Prebuilt binaries
 
 Prebuilt, checksummed archives are attached to each GitHub Release under the `ironrdp-agent-v*`

--- a/crates/ironrdp-agent/src/cli.rs
+++ b/crates/ironrdp-agent/src/cli.rs
@@ -303,7 +303,7 @@ struct ConnectArgs {
     #[arg(short, long, env = "RDP_USERNAME")]
     username: Option<String>,
     /// RDP account password. Overrides the .rdp file.
-    #[arg(short, long, env = "RDP_PASSWORD")]
+    #[arg(short, long, env = "RDP_PASSWORD", hide_env_values = true)]
     password: Option<String>,
     /// RDP account domain. Overrides the .rdp file.
     #[arg(short, long)]

--- a/crates/ironrdp-agent/src/cli.rs
+++ b/crates/ironrdp-agent/src/cli.rs
@@ -40,6 +40,10 @@ pub struct Cli {
     #[arg(long, global = true)]
     endpoint: Option<String>,
 
+    /// Select the local RPC backend.
+    #[arg(long, global = true, value_enum, default_value_t = Backend::Daemon)]
+    backend: Backend,
+
     #[command(subcommand)]
     command: Option<Command>,
 }
@@ -104,6 +108,12 @@ enum Command {
     },
     /// Execute commands over the session's NOW DVC endpoint.
     Now(NowArgs),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub enum Backend {
+    Daemon,
+    ActiveX,
 }
 
 #[derive(Args, Debug)]
@@ -287,13 +297,13 @@ struct ConnectArgs {
     #[arg(long = "prop", value_name = "KEY:TYPE:VALUE")]
     prop: Vec<PropOverride>,
     /// RDP server address (host[:port]). Overrides the .rdp file.
-    #[arg(long)]
+    #[arg(long, env = "RDP_HOSTNAME")]
     server: Option<String>,
     /// RDP account user name. Overrides the .rdp file.
-    #[arg(short, long)]
+    #[arg(short, long, env = "RDP_USERNAME")]
     username: Option<String>,
     /// RDP account password. Overrides the .rdp file.
-    #[arg(short, long)]
+    #[arg(short, long, env = "RDP_PASSWORD")]
     password: Option<String>,
     /// RDP account domain. Overrides the .rdp file.
     #[arg(short, long)]
@@ -414,7 +424,7 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let endpoint = endpoint_from_arg(cli.endpoint);
+    let endpoint = endpoint_from_arg(cli.endpoint, cli.backend);
 
     let Some(command) = cli.command else {
         let _ = Cli::command().print_help();
@@ -422,8 +432,15 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
         return Ok(());
     };
 
+    if cli.backend == Backend::ActiveX && !matches!(&command, Command::DaemonStart(_)) {
+        ensure_activex_backend(&endpoint).await?;
+    }
+
     let request = match command {
         Command::DaemonStart(args) => {
+            if cli.backend != Backend::Daemon {
+                anyhow::bail!("daemon-start requires --backend daemon");
+            }
             let overlay = load_overlay(args.overlay.as_deref(), args.prop)?;
             return ironrdp_daemon::daemon::run(endpoint, overlay).await;
         }
@@ -1119,19 +1136,23 @@ fn write_screenshot(width: u16, height: u16, png: &[u8], path: &Path) -> anyhow:
     Ok(())
 }
 
-#[cfg(unix)]
-fn endpoint_from_arg(arg: Option<String>) -> Endpoint {
+fn endpoint_from_arg(arg: Option<String>, backend: Backend) -> Endpoint {
     match arg {
-        Some(value) => Endpoint(PathBuf::from(value)),
-        None => transport::default_endpoint(),
+        Some(value) => transport::endpoint_from_string(value),
+        None => match backend {
+            Backend::Daemon => transport::default_endpoint_named("ironrdp-agent"),
+            Backend::ActiveX => transport::default_endpoint_named("ironrdp-activex"),
+        },
     }
 }
 
-#[cfg(windows)]
-fn endpoint_from_arg(arg: Option<String>) -> Endpoint {
-    match arg {
-        Some(value) => Endpoint(value),
-        None => transport::default_endpoint(),
+async fn ensure_activex_backend(endpoint: &Endpoint) -> anyhow::Result<()> {
+    match transport::send_request(endpoint, &Request::Status).await {
+        Ok(Response::Ok(_)) => Ok(()),
+        Ok(Response::Err(error)) => anyhow::bail!("ActiveX RPC endpoint at {endpoint} rejected status: {error}"),
+        Err(_) => anyhow::bail!(
+            "ActiveX RPC endpoint is unavailable at {endpoint}; start an ActiveX host with IRONRDP_ACTIVEX_RPC=1"
+        ),
     }
 }
 
@@ -1201,9 +1222,50 @@ fn property_description(key: &str) -> Option<&'static str> {
 
 #[cfg(test)]
 mod tests {
-    use clap::Parser as _;
+    use clap::{CommandFactory as _, Parser as _};
 
-    use super::{Cli, CommonExecutionArgs, NowExecutionKind, build_now_execution};
+    use super::{Backend, Cli, CommonExecutionArgs, NowExecutionKind, build_now_execution, endpoint_from_arg};
+
+    #[test]
+    fn backend_endpoint_selection_is_distinct_and_overridable() {
+        let daemon = endpoint_from_arg(None, Backend::Daemon).to_string();
+        let activex = endpoint_from_arg(None, Backend::ActiveX).to_string();
+
+        assert_ne!(daemon, activex);
+        assert!(daemon.contains("ironrdp-agent"));
+        assert!(activex.contains("ironrdp-activex"));
+        #[cfg(windows)]
+        assert_eq!(
+            endpoint_from_arg(Some("custom-rpc-endpoint".to_owned()), Backend::ActiveX).to_string(),
+            r"\\.\pipe\custom-rpc-endpoint"
+        );
+        #[cfg(unix)]
+        assert_eq!(
+            endpoint_from_arg(Some("custom-rpc-endpoint".to_owned()), Backend::ActiveX).to_string(),
+            "custom-rpc-endpoint"
+        );
+    }
+
+    #[test]
+    fn connection_flags_use_process_local_environment_defaults() {
+        let command = Cli::command();
+        let connect = command
+            .get_subcommands()
+            .find(|command| command.get_name() == "connect")
+            .expect("connect subcommand must be registered");
+
+        for (argument, variable) in [
+            ("server", "RDP_HOSTNAME"),
+            ("username", "RDP_USERNAME"),
+            ("password", "RDP_PASSWORD"),
+        ] {
+            let environment = connect
+                .get_arguments()
+                .find(|candidate| candidate.get_id() == argument)
+                .and_then(clap::Arg::get_env);
+            assert_eq!(environment, Some(variable.as_ref()));
+        }
+    }
 
     #[test]
     fn shell_is_not_an_agent_command() {

--- a/crates/ironrdp-agent/src/help.rs
+++ b/crates/ironrdp-agent/src/help.rs
@@ -46,10 +46,10 @@ Override with `--endpoint <PATH-OR-PIPE>` on any subcommand.
                                  `RDP_PASSWORD` supply their respective values; explicit flags
                                  override the environment. `--prop` is repeatable and lets you set
                                  any property without a dedicated flag existing for it, e.g.
-                                 `--prop username:s:admin`. The config is validated by the daemon,
-                                 which replies with an error listing any missing or invalid fields.
+                                 `--prop username:s:admin`. The selected backend validates the
+                                 config and replies with an error listing any missing or invalid fields.
                                  If `status` reports `credentials loaded: true`, omit
-                                 `-p/--password` (and any other preloaded secret) -- the daemon
+                                 `-p/--password` (and any other preloaded secret) -- the backend
                                  supplies it. `--log-directive` refines this session's log capture
                                  (e.g. `ironrdp_connector=trace`) on top of the default `debug`
                                  level; use it to troubleshoot a connection, then read the result

--- a/crates/ironrdp-agent/src/help.rs
+++ b/crates/ironrdp-agent/src/help.rs
@@ -18,6 +18,14 @@ Unix: `$XDG_RUNTIME_DIR/ironrdp-agent-<uid>.sock` (falls back to `/tmp/ironrdp-a
 Windows: `\\.\pipe\ironrdp-agent-<user>`.
 Override with `--endpoint <PATH-OR-PIPE>` on any subcommand.
 
+## Backends
+
+- `--backend daemon` (default) uses `ironrdp-agent daemon-start` and its per-user endpoint.
+- `--backend active-x` attaches to an already-hosted ActiveX control at its per-user
+  `ironrdp-activex` endpoint. The host must set `IRONRDP_ACTIVEX_RPC=1` before creating the
+  control; the agent never starts an ActiveX host. Use `--endpoint` when the host uses
+  `IRONRDP_ACTIVEX_RPC_ENDPOINT`.
+
 ## Lifecycle
 
 - `daemon-start [--overlay FILE] [--prop KEY:TYPE:VALUE]...`
@@ -33,16 +41,19 @@ Override with `--endpoint <PATH-OR-PIPE>` on any subcommand.
 - `connect [--rdp-file F] [--prop KEY:TYPE:VALUE]... [--server H[:PORT]] [-u USER] [-p PASS] [-d DOMAIN] [--log-directive D]`
                                  Merge an optional .rdp file with CLI overrides into one config and
                                  open a session. Precedence (low to high): .rdp file -> `--prop`
-                                 overrides -> named flags (`--server`/`-u`/`-p`/`-d`). `--prop` is
-                                 repeatable and lets you set any property without a dedicated flag
-                                 existing for it, e.g. `--prop username:s:admin`. The config is
-                                 validated by the daemon, which replies with an error listing any
-                                 missing or invalid fields. If `status` reports
-                                 `credentials loaded: true`, omit `-p/--password` (and any other
-                                 preloaded secret) -- the daemon supplies it. `--log-directive`
-                                 refines this session's log capture (e.g. `ironrdp_connector=trace`)
-                                 on top of the default `debug` level; use it to troubleshoot a
-                                 connection, then read the result with `query-logs`.
+                                 overrides -> named flags (`--server`/`-u`/`-p`/`-d`). When those
+                                 flags are omitted, `RDP_HOSTNAME`, `RDP_USERNAME`, and
+                                 `RDP_PASSWORD` supply their respective values; explicit flags
+                                 override the environment. `--prop` is repeatable and lets you set
+                                 any property without a dedicated flag existing for it, e.g.
+                                 `--prop username:s:admin`. The config is validated by the daemon,
+                                 which replies with an error listing any missing or invalid fields.
+                                 If `status` reports `credentials loaded: true`, omit
+                                 `-p/--password` (and any other preloaded secret) -- the daemon
+                                 supplies it. `--log-directive` refines this session's log capture
+                                 (e.g. `ironrdp_connector=trace`) on top of the default `debug`
+                                 level; use it to troubleshoot a connection, then read the result
+                                 with `query-logs`.
 - `disconnect`                   Tear down the current session (daemon keeps running).
 - `status`                       Report connection state, destination, last frame size, and whether
                                  credentials are preloaded (`credentials loaded: true|false`). Query

--- a/crates/ironrdp-daemon/src/logbuf.rs
+++ b/crates/ironrdp-daemon/src/logbuf.rs
@@ -23,7 +23,7 @@ use tracing_subscriber::layer::Context;
 const DEFAULT_CAPACITY: usize = 100;
 
 /// A bounded ring buffer of formatted log lines.
-pub(crate) struct LogBuffer {
+pub struct LogBuffer {
     inner: Mutex<Inner>,
 }
 
@@ -33,11 +33,11 @@ struct Inner {
 }
 
 impl LogBuffer {
-    pub(crate) fn new() -> Arc<Self> {
+    pub fn new() -> Arc<Self> {
         Self::with_capacity(DEFAULT_CAPACITY)
     }
 
-    pub(crate) fn with_capacity(capacity: usize) -> Arc<Self> {
+    pub fn with_capacity(capacity: usize) -> Arc<Self> {
         Arc::new(Self {
             inner: Mutex::new(Inner {
                 capacity: capacity.max(1),
@@ -56,7 +56,11 @@ impl LogBuffer {
     }
 
     /// Returns retained lines, optionally filtered to those containing `substring`.
-    pub(crate) fn query(&self, substring: Option<&str>) -> Vec<String> {
+    ///
+    /// # Panics
+    ///
+    /// Panics if another thread holding the log buffer lock panicked.
+    pub fn query(&self, substring: Option<&str>) -> Vec<String> {
         let inner = self.inner.lock().expect("log buffer poisoned");
         inner
             .lines
@@ -64,6 +68,15 @@ impl LogBuffer {
             .filter(|line| substring.is_none_or(|needle| line.contains(needle)))
             .cloned()
             .collect()
+    }
+
+    /// Removes every retained line.
+    ///
+    /// # Panics
+    ///
+    /// Panics if another thread holding the log buffer lock panicked.
+    pub fn clear(&self) {
+        self.inner.lock().expect("log buffer poisoned").lines.clear();
     }
 }
 
@@ -74,7 +87,7 @@ impl LogBuffer {
 /// in the ring buffer instead. The default level is `DEBUG`; `directive` (carried by
 /// `Request::Connect`) refines it per-session — a bare level sets the global session level, while a
 /// targeted directive (e.g. `ironrdp_connector=trace`) layers on top of the `DEBUG` default.
-pub(crate) fn session_dispatch(buffer: Arc<LogBuffer>, directive: Option<&str>) -> Dispatch {
+pub fn session_dispatch(buffer: Arc<LogBuffer>, directive: Option<&str>) -> Dispatch {
     use tracing::level_filters::LevelFilter;
     use tracing_subscriber::EnvFilter;
     use tracing_subscriber::prelude::*;

--- a/crates/ironrdp-rpc/src/transport.rs
+++ b/crates/ironrdp-rpc/src/transport.rs
@@ -88,14 +88,46 @@ mod imp {
         }
     }
 
-    /// Returns the default per-user endpoint.
-    pub fn default_endpoint() -> Endpoint {
+    /// Returns a per-user endpoint for `name`.
+    pub fn default_endpoint_named(name: &str) -> Endpoint {
         // SAFETY: `getuid` has no preconditions and is always safe to call.
         let uid = unsafe { libc::getuid() };
         let dir = std::env::var_os("XDG_RUNTIME_DIR")
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from("/tmp"));
-        Endpoint(dir.join(format!("ironrdp-agent-{uid}.sock")))
+        Endpoint(dir.join(format!("{name}-{uid}.sock")))
+    }
+
+    /// Returns the default per-user endpoint.
+    pub fn default_endpoint() -> Endpoint {
+        default_endpoint_named("ironrdp-agent")
+    }
+
+    /// Resolves an explicit endpoint supplied by a local client.
+    pub fn endpoint_from_string(value: String) -> Endpoint {
+        Endpoint(PathBuf::from(value))
+    }
+
+    /// Removes a stale socket endpoint while refusing to touch non-socket paths.
+    pub async fn prepare_endpoint(endpoint: &Endpoint) -> io::Result<()> {
+        if !endpoint.0.exists() {
+            return Ok(());
+        }
+        if connect(endpoint).await.is_ok() {
+            return Err(io::Error::new(
+                io::ErrorKind::AddrInUse,
+                format!("an RPC listener already appears to be running at {endpoint}"),
+            ));
+        }
+        use std::os::unix::fs::FileTypeExt as _;
+        let metadata = std::fs::symlink_metadata(&endpoint.0)?;
+        if !metadata.file_type().is_socket() {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                format!("refusing to remove {endpoint}: path exists and is not a socket"),
+            ));
+        }
+        std::fs::remove_file(&endpoint.0)
     }
 
     /// Connects to a listening daemon.
@@ -164,10 +196,29 @@ mod imp {
         }
     }
 
+    /// Returns a per-user endpoint for `name`.
+    pub fn default_endpoint_named(name: &str) -> Endpoint {
+        let user = whoami::username().unwrap_or_else(|_| "user".to_owned());
+        Endpoint(format!(r"\\.\pipe\{name}-{user}"))
+    }
+
     /// Returns the default per-user endpoint.
     pub fn default_endpoint() -> Endpoint {
-        let user = whoami::username().unwrap_or_else(|_| "user".to_owned());
-        Endpoint(format!(r"\\.\pipe\ironrdp-agent-{user}"))
+        default_endpoint_named("ironrdp-agent")
+    }
+
+    /// Resolves an explicit endpoint supplied by a local client.
+    pub fn endpoint_from_string(value: String) -> Endpoint {
+        if value.starts_with(r"\\.\pipe\") {
+            Endpoint(value)
+        } else {
+            Endpoint(format!(r"\\.\pipe\{value}"))
+        }
+    }
+
+    /// Named pipes require no stale-path cleanup.
+    pub async fn prepare_endpoint(_endpoint: &Endpoint) -> io::Result<()> {
+        Ok(())
     }
 
     /// Connects to a listening daemon.
@@ -491,7 +542,9 @@ mod imp {
     }
 }
 
-pub use imp::{Endpoint, Listener, connect, default_endpoint};
+pub use imp::{
+    Endpoint, Listener, connect, default_endpoint, default_endpoint_named, endpoint_from_string, prepare_endpoint,
+};
 
 #[cfg(unix)]
 pub type ClientStream = tokio::net::UnixStream;


### PR DESCRIPTION
## Summary
- add the opt-in ActiveX local-RPC listener and message-window command dispatch
- add `ironrdp-agent --backend active-x` selection and process-local ActiveX guidance
- support native MSTSC/RDP-file launch flows with strict `RDP_AUTOLOGON=1` credentials and preserve Kerberos/KDC configuration

## Validation
- `cargo fmt --check`
- `cargo clippy -p ironrdp-agent -p ironrdp-activex --all-targets -- -D warnings`
- `cargo test -p ironrdp-agent --lib`
- `cargo test -p ironrdp-activex --lib`
- `cargo test -p ironrdp-rpc`