### PR TITLE
ci: allow semver job to access Rust toolchain

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -304,10 +304,14 @@ jobs:
           semver_target="$SEMVER_STATE_DIR/target"
           semver_bin="$CARGO_SEMVER_CHECKS_DIR/cargo-semver-checks"
           workspace="$SEMVER_WORKSPACE"
-          rust_bin_dir="$(dirname "$(rustup which rustc)")"
+          rustc_bin="$(rustup which rustc)"
+          rust_toolchain_dir="$(dirname "$(dirname "$rustc_bin")")"
+          rust_bin_dir="$rust_toolchain_dir/bin"
           install -d -m 700 "$semver_home" "$semver_cargo" "$semver_target"
           chmod -R a+rX "$workspace"
           sudo chown -R nobody:nogroup "$workspace" "$semver_home" "$semver_cargo" "$semver_target"
+          sudo chmod o+x "$HOME" "$HOME/.rustup" "$HOME/.rustup/toolchains"
+          sudo chmod -R a+rX "$rust_toolchain_dir"
           cd "$workspace"
 
           # Build scripts and proc macros run as nobody, which cannot read the runner command files.


### PR DESCRIPTION
Fix the isolated `cargo-semver-checks` invocation running as `nobody` by resolving the active Rust toolchain, granting traversal only through the required rustup parent directories, and granting read/execute access only to that toolchain. The untrusted checkout and isolated Cargo state remain owned by `nobody`.