### PR TITLE
ci: fix Claude structured output schemas

### DIFF
--- a/.github/pr-automation/schemas/classifier.json
+++ b/.github/pr-automation/schemas/classifier.json
@@ -30,49 +30,5 @@
     "breaking_change_surface": { "type": "string", "maxLength": 200 },
     "protocol_related": { "type": "boolean" },
     "summary": { "type": "string", "maxLength": 1000 }
-  },
-  "allOf": [
-    {
-      "if": { "properties": { "likely_non_legitimate": { "const": true } } },
-      "then": {
-        "properties": {
-          "non_legitimate_confidence": { "minimum": 0.9 },
-          "non_legitimate_reason": { "minLength": 1 }
-        }
-      },
-      "else": {
-        "properties": {
-          "non_legitimate_confidence": { "const": 0 },
-          "non_legitimate_reason": { "const": "" }
-        }
-      }
-    },
-    {
-      "if": { "properties": { "duplicate": { "properties": { "detected": { "const": true } } } } },
-      "then": {
-        "properties": {
-          "duplicate": {
-            "properties": {
-              "similar_pr_number": { "type": "integer", "minimum": 1 },
-              "similar_pr_url": { "type": "string", "pattern": "^https://github\\.com/Devolutions/IronRDP/pull/[1-9][0-9]*$" },
-              "confidence": { "minimum": 0.85 },
-              "rationale": { "minLength": 1 }
-            }
-          }
-        }
-      },
-      "else": {
-        "properties": {
-          "duplicate": {
-            "properties": {
-              "similar_pr_number": { "const": null },
-              "similar_pr_url": { "const": null },
-              "confidence": { "const": 0 },
-              "rationale": { "const": "" }
-            }
-          }
-        }
-      }
-    }
-  ]
+  }
 }

--- a/.github/pr-automation/schemas/protocol-reviewer.json
+++ b/.github/pr-automation/schemas/protocol-reviewer.json
@@ -67,19 +67,5 @@
       "maxItems": 20,
       "items": { "type": "string", "minLength": 1, "maxLength": 300 }
     }
-  },
-  "allOf": [
-    {
-      "if": { "properties": { "protocol_relevance": { "const": "none" } }, "required": ["protocol_relevance"] },
-      "then": {
-        "properties": {
-          "protocols_consulted": { "maxItems": 0 },
-          "change_mappings": { "maxItems": 0 },
-          "potential_discrepancies": { "maxItems": 0 },
-          "required_or_valuable_tests": { "maxItems": 0 }
-        }
-      },
-      "else": { "properties": { "protocols_consulted": { "minItems": 1 } } }
-    }
-  ]
+  }
 }

--- a/.github/pr-automation/schemas/reviewer.json
+++ b/.github/pr-automation/schemas/reviewer.json
@@ -56,12 +56,5 @@
         ]
       }
     }
-  },
-  "allOf": [
-    {
-      "if": { "properties": { "has_findings": { "const": true } }, "required": ["has_findings"] },
-      "then": { "properties": { "findings": { "minItems": 1 } } },
-      "else": { "properties": { "findings": { "maxItems": 0 } } }
-    }
-  ]
+  }
 }


### PR DESCRIPTION
Claude rejects structured-output tool schemas that use a top-level `allOf`, which prevented PR classification from running. Remove those top-level conditional constraints from the classifier and both reviewer schemas; the existing runtime validators continue to enforce the same cross-field invariants.