### PR TITLE
ci: preserve deterministic pull request labels

### DIFF
--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -1,8 +1,10 @@
 "use strict";
 
+const fs = require("node:fs");
+const path = require("node:path");
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { addedLinesByPath, analyzeFiles, parseLabelerRules } = require("./deterministic-analysis");
+const { SIZE_LABELS, addedLinesByPath, analyzeFiles, parseLabelerRules } = require("./deterministic-analysis");
 const { validateClassifier } = require("./validate-classifier");
 const { validateReviewer } = require("./validate-reviewer");
 const { resolveClassificationState, resolveReviewState, reviewPolicyEligible, DUPLICATE_MARKER, LEGITIMACY_MARKER, XL_MARKER } = require("./resolve-state");
@@ -36,6 +38,33 @@ const review = (changes = {}) => ({
   protocol_handoff: { received: false, disposition: "not_applicable", rationale: "" },
   findings: [finding()],
   ...changes,
+});
+
+test("workflow does not overwrite github-script result outputs", () => {
+  const workflow = fs.readFileSync(path.join(__dirname, "..", "workflows", "labeler.yml"), "utf8");
+  assert.doesNotMatch(workflow, /core\.setOutput\("result"/);
+  assert.doesNotMatch(workflow, /^\s{6}result:\s+\$\{\{\s*steps\./m);
+  assert.doesNotMatch(workflow, /needs\.[\w-]+\.outputs\.result\b/);
+});
+
+test("every deterministic label is declared and the repository rules classify tooling changes", () => {
+  const githubDirectory = path.join(__dirname, "..");
+  const rules = parseLabelerRules(fs.readFileSync(path.join(githubDirectory, "labeler.yml"), "utf8"));
+  const declaredLabels = new Set(JSON.parse(
+    fs.readFileSync(path.join(__dirname, "labels.json"), "utf8"),
+  ).map((label) => label.name));
+  for (const label of [...Object.keys(rules), ...SIZE_LABELS, "contributor/first-time"]) {
+    assert.equal(declaredLabels.has(label), true, `${label} is missing from labels.json`);
+  }
+  for (const [label, patterns] of Object.entries(rules)) {
+    assert.notEqual(patterns.length, 0, `${label} has no path patterns`);
+  }
+  const result = analyzeFiles([
+    { filename: ".github/workflows/labeler.yml", additions: 5, deletions: 1 },
+  ], { labelerRules: rules, authorAssociation: "MEMBER" });
+  assert.deepEqual(result.pathLabels, ["scope/tooling"]);
+  assert.equal(result.sizeLabel, "size/XS");
+  assert.equal(result.firstTime, false);
 });
 
 test("deterministic analysis applies trusted scopes and source size", () => {

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -155,7 +155,8 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      result: ${{ steps.analyze.outputs.result }}
+      # github-script owns the result output and overwrites it with the script return value.
+      analysis: ${{ steps.analyze.outputs.analysis }}
       ok: ${{ steps.analyze.outputs.ok }}
       size-label: ${{ steps.analyze.outputs.size-label }}
     steps:
@@ -184,7 +185,7 @@ jobs:
               authorAssociation: pullRequest.author_association,
               labelerPath: "./.github/labeler.yml",
             });
-            core.setOutput("result", JSON.stringify(result));
+            core.setOutput("analysis", JSON.stringify(result));
             core.setOutput("ok", result.ok === true);
             core.setOutput("size-label", result.sizeLabel || "");
             core.info(JSON.stringify({ event: "pr-automation.deterministic-analysis", decision: result }));
@@ -198,7 +199,7 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      result: ${{ steps.limit.outputs.result }}
+      quota: ${{ steps.limit.outputs.quota }}
       allowed: ${{ steps.limit.outputs.allowed }}
     steps:
       - uses: actions/checkout@v6
@@ -233,7 +234,7 @@ jobs:
             } catch {
               result = { status: "unavailable", scope: "unknown", reason: "GitHub API unavailable" };
             }
-            core.setOutput("result", JSON.stringify(result));
+            core.setOutput("quota", JSON.stringify(result));
             core.setOutput("allowed", result.status === "allowed");
             core.info(JSON.stringify({ event: "pr-automation.fork-rate-limit", decision: result }));
 
@@ -249,7 +250,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     outputs:
-      result: ${{ steps.semver.outputs.result }}
+      compatibility: ${{ steps.semver.outputs.compatibility }}
     env:
       CARGO_SEMVER_CHECKS_VERSION: "0.49.0"
       CARGO_SEMVER_CHECKS_SHA256: "72f6834d75d28a66e02c9fd6a230ce901bb30eee6067b85867a97445df040e4a"
@@ -329,7 +330,7 @@ jobs:
             100) status=suspected ;;
             *) exit "$status" ;;
           esac
-          echo "result={\"head_sha\":\"$HEAD_SHA\",\"status\":\"$status\"}" >> "$GITHUB_OUTPUT"
+          echo "compatibility={\"head_sha\":\"$HEAD_SHA\",\"status\":\"$status\"}" >> "$GITHUB_OUTPUT"
           echo "::notice title=PR automation semver decision::head_sha=$HEAD_SHA status=$status"
 
   classifier:
@@ -494,10 +495,10 @@ jobs:
           HEAD_SHA: ${{ needs.resolve-pr.outputs.head-sha }}
           LABELS: ${{ needs.resolve-pr.outputs.labels }}
           PR_NUMBER: ${{ needs.resolve-pr.outputs.pr-number }}
-          DETERMINISTIC: ${{ needs.deterministic-analysis.outputs.result }}
+          DETERMINISTIC: ${{ needs.deterministic-analysis.outputs.analysis }}
           CLASSIFIER: ${{ needs.classifier.outputs.output }}
-          FORK_RATE_LIMIT: ${{ needs.fork-rate-limit.outputs.result }}
-          SEMVER: ${{ needs.semver.outputs.result }}
+          FORK_RATE_LIMIT: ${{ needs.fork-rate-limit.outputs.quota }}
+          SEMVER: ${{ needs.semver.outputs.compatibility }}
         with:
           script: |
             const { resolveClassificationState } = require("./.github/pr-automation/resolve-state");
@@ -625,7 +626,7 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      result: ${{ steps.history.outputs.result }}
+      history: ${{ steps.history.outputs.history }}
       eligible: ${{ steps.history.outputs.eligible }}
     steps:
       - uses: actions/checkout@v6
@@ -647,7 +648,7 @@ jobs:
               github, owner: context.repo.owner, repo: context.repo.repo, author,
               currentPrNumber: Number(process.env.PULL_REQUEST_NUMBER),
             });
-            core.setOutput("result", JSON.stringify(result));
+            core.setOutput("history", JSON.stringify(result));
             core.setOutput("eligible", result.status === "eligible");
             core.info(JSON.stringify({ event: "pr-automation.contributor-history", decision: result }));
 
@@ -1008,8 +1009,8 @@ jobs:
         env:
           HEAD_SHA: ${{ needs.resolve-pr.outputs.head-sha }}
           GATE: ${{ needs.review-gate.outputs.gate }}
-          CONTRIBUTOR: ${{ needs.contributor-history.outputs.result }}
-          FORK_RATE_LIMIT: ${{ needs.fork-rate-limit.outputs.result }}
+          CONTRIBUTOR: ${{ needs.contributor-history.outputs.history }}
+          FORK_RATE_LIMIT: ${{ needs.fork-rate-limit.outputs.quota }}
           PROTOCOL_STATUS: ${{ needs.validate-protocol-review.outputs.status }}
           RAW_OUTPUT: ${{ needs.skeptical-reviewer.outputs.output }}
           PULL_REQUEST_NUMBER: ${{ needs.resolve-pr.outputs.pr-number }}


### PR DESCRIPTION
Recent PR automation runs calculated deterministic labels correctly but discarded their structured output, leaving PRs with only `maintainer-required` and `risk/unknown`. `actions/github-script` owns its `result` output and overwrote the workflow's custom value.

Use distinct structured output names for deterministic analysis, quota, semver, and contributor history so the normalized state receives every signal. Regression coverage verifies that all deterministic labels exist in the bootstrap catalog and that a small `.github/**` change receives `scope/tooling` and `size/XS`.

**Validation:** `node --test .github/pr-automation/automation.test.js`