### PR TITLE
ci: handle paginated check runs

### DIFF
--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -611,6 +611,42 @@ test("writer batches the label delta and tolerates an absent label removal", asy
   }), false);
 });
 
+test("writer reads normalized check-run pages and updates the newest matching run", async () => {
+  let updatedCheckRun = null;
+  const github = {
+    paginate: { iterator: async function* () {
+      yield { data: [
+        { id: 1, external_id: `classifier-v2:${SHA}`, conclusion: "failure" },
+        { id: 4, external_id: "unrelated", conclusion: "failure" },
+      ] };
+      yield { data: [
+        { id: 3, external_id: `classifier-v2:${SHA}`, conclusion: "failure" },
+      ] };
+    } },
+    rest: {
+      checks: {
+        listForRef: () => {},
+        update: async ({ check_run_id }) => { updatedCheckRun = check_run_id; },
+      },
+      pulls: { get: async () => ({ data: { state: "open", head: { sha: SHA } } }) },
+      issues: { get: async () => ({ data: { labels: [] } }) },
+    },
+  };
+  await writeState({
+    github, owner: "Devolutions", repo: "IronRDP", prNumber: 1, botLogin: "github-actions[bot]",
+    state: {
+      ok: true, mode: "classification", expectedSha: SHA, labelSets: [], addLabels: [],
+      comments: [], removeCommentMarkers: [],
+      check: {
+        name: "AI classification", externalId: `classifier-v2:${SHA}`,
+        title: "Automation stopped", summary: "Maintainer review is required.",
+        machineState: { protocolRelated: false },
+      },
+    },
+  });
+  assert.equal(updatedCheckRun, 3);
+});
+
 function paginated(pages) {
   return {
     paginate: { iterator: async function* (_method, options) {

--- a/.github/pr-automation/write-state.js
+++ b/.github/pr-automation/write-state.js
@@ -124,7 +124,7 @@ async function findCheck(github, owner, repo, expectedSha, check) {
   for await (const response of github.paginate.iterator(github.rest.checks.listForRef, {
     owner, repo, ref: expectedSha, check_name: check.name, per_page: 100,
   })) {
-    for (const run of response.data.check_runs) {
+    for (const run of response.data) {
       if (run.external_id === check.externalId && (!found || run.id > found.id)) found = run;
     }
   }


### PR DESCRIPTION
Octokit's pagination plugin normalizes check-run responses into page arrays, so the PR automation writer crashed while trying to read a nested `check_runs` property.

Consume the normalized arrays directly and add regression coverage that verifies multi-page results select the newest matching check run.