### PR TITLE
ci: exclude release-plz bot PRs

### DIFF
--- a/.github/PR_AUTOMATION.md
+++ b/.github/PR_AUTOMATION.md
@@ -34,9 +34,9 @@ twice per pull request. `haiku` is cheaper than Sonnet at `low` effort but suppo
 at all, which is why the classifier does not use it. The model names are floating aliases, so each
 stage tracks the latest model of its tier.
 
-Bot-authored pull requests, including Dependabot's, are excluded from this workflow. Dependabot is
-the sole owner of dependency and language labels, so this automation never adds, removes, or
-reconciles labels on bot pull requests.
+Bot-authored pull requests, including Dependabot's and `devolutionsbot`'s release-plz PRs, are
+excluded from this workflow. Dependabot is the sole owner of dependency and language labels, so
+this automation never adds, removes, or reconciles labels on bot pull requests.
 
 Every LLM stage is given the same evidence, prepared by `.github/pr-automation/fetch-pr-evidence.sh`
 running from the trusted base checkout. The action is used in explicit-prompt mode, which injects no

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -285,7 +285,10 @@ test("bot authors are excluded from automation", async () => {
   const bot = await resolve({ node_id: "U_1", login: "dependabot[bot]", type: "Bot" });
   assert.equal(bot.ok, false);
   assert.equal(bot.reason, "bot-authored pull request");
-  const human = await resolve({ node_id: "U_2", login: "contributor", type: "User" });
+  const releaseBot = await resolve({ node_id: "U_2", login: "devolutionsbot", type: "User" });
+  assert.equal(releaseBot.ok, false);
+  assert.equal(releaseBot.reason, "bot-authored pull request");
+  const human = await resolve({ node_id: "U_3", login: "contributor", type: "User" });
   assert.equal(human.ok, true);
   assert.equal(human.reviewRoute, true);
 });

--- a/.github/pr-automation/resolve-pr.js
+++ b/.github/pr-automation/resolve-pr.js
@@ -83,9 +83,11 @@ async function resolvePr({ github, context, inputs = {} }) {
   }
   if (!pr) return noResult("pull request is closed or stale", route);
   if (pr.draft) return noResult("pull request is draft", route);
-  // Dependabot owns dependency and language labels. This automation must not mutate bot-authored
-  // pull requests, because its path-based classification would otherwise overwrite that taxonomy.
-  const authorIsBot = pr.user?.type === "Bot" || /\[bot\]$/i.test(pr.user?.login || "");
+  // Dependabot owns dependency and language labels, while devolutionsbot opens release-plz PRs.
+  // This automation must not mutate either kind of automated pull request.
+  const authorLogin = pr.user?.login || "";
+  const authorIsBot = pr.user?.type === "Bot" || /\[bot\]$/i.test(authorLogin) ||
+    authorLogin.toLowerCase() === "devolutionsbot";
   if (authorIsBot) return noResult("bot-authored pull request", route);
   return {
     ok: true, route, prNumber: pr.number, headSha: pr.head.sha, baseSha: pr.base.sha,


### PR DESCRIPTION
`devolutionsbot` release-plz pull requests are reported as user accounts, so they could enter PR classification and review automation. Treat that account as a bot explicitly, alongside standard GitHub bot identities.

Adds regression coverage for the user-typed release bot and documents the exclusion.