### PR TITLE
fix(async): reject a zero-length unmatched PDU in read_by_hint

### DIFF
--- a/crates/ironrdp-async/src/framed.rs
+++ b/crates/ironrdp-async/src/framed.rs
@@ -170,6 +170,18 @@ where
         loop {
             match hint.find_size(self.peek()).map_err(io::Error::other)? {
                 Some((matched, length)) => {
+                    // Guard against a zero-length unmatched PDU. Skipping it (the `else`
+                    // branch below) consumes nothing via `read_exact(0)` and performs no
+                    // I/O, so the loop would spin forever at 100% CPU — never yielding to
+                    // the runtime and never observing EOF. This is reachable from a single
+                    // malformed frame if any `PduHint` reports `Some((false, 0))`, so fail
+                    // instead of hanging rather than relying on every hint to avoid it.
+                    if length == 0 && !matched {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "PduHint reported a zero-length unmatched PDU; cannot make progress",
+                        ));
+                    }
                     let bytes = self.read_exact(length).await?.freeze();
                     if matched {
                         return Ok(bytes);


### PR DESCRIPTION
## Problem

`Framed::read_by_hint` loops to skip PDUs that don't match the requested hint:

```rust
loop {
    match hint.find_size(self.peek()).map_err(io::Error::other)? {
        Some((matched, length)) => {
            let bytes = self.read_exact(length).await?.freeze();
            if matched { return Ok(bytes); } else { debug!("Received and lost an unexpected PDU"); }
        }
        None => { /* read more / handle EOF */ }
    }
}
```

If a `PduHint` reports `Some((false, 0))` — an unmatched, **zero-length** PDU — then `read_exact(0)` consumes nothing and performs no I/O, so the loop spins forever at 100% CPU: it never `.await`s a real read, so it never yields to the runtime and never observes EOF. Because it doesn't yield, it also starves whatever task drives it (e.g. an acceptor's connection loop), so a single malformed frame can take a whole server down.

I hit this in practice via the built-in X.224 hint: a 2-byte fast-path-shaped header (first byte with `& 0b11 == 0`, e.g. `04 00`) made `find_size` return a zero-length fast-path `PduInfo`, `read_by_hint` treated it as an unexpected PDU, and spun — unauthenticated, before TLS, from one connection.

#1515 hardened `find_size` so the built-in X.224 / fast-path hint no longer returns a zero-length PDU, which resolves that concrete trigger. This PR is defense-in-depth for the primitive itself: `read_by_hint` accepts arbitrary `dyn PduHint` implementations, so it shouldn't rely on every hint avoiding the degenerate case to avoid an infinite loop.

## Fix

Guard the single non-progress case — an unmatched zero-length PDU can't be skipped, so fail instead of looping:

```rust
if length == 0 && !matched {
    return Err(io::Error::new(
        io::ErrorKind::InvalidData,
        "PduHint reported a zero-length unmatched PDU; cannot make progress",
    ));
}
```

The invariant becomes: `read_by_hint` always makes forward progress or returns an error.

## Testing

`ironrdp-async` and `ironrdp-tokio` are both `test = false`, and there are currently no async-framing unit tests in the repo (`find_size`, where the parsing lives, has the regression coverage added in #1515). Verified manually that `04 00` / `00 00` no longer spin. Happy to add a `read_by_hint` regression test in `ironrdp-testsuite-core` (it would need `ironrdp-async` / `ironrdp-tokio` dev-deps + a small mock `PduHint`) if you'd prefer one included.