### PR TITLE
fix(graphics)!: do not panic when the RLGR output buffer is too small

### DIFF
--- a/crates/ironrdp-graphics/src/rlgr.rs
+++ b/crates/ironrdp-graphics/src/rlgr.rs
@@ -39,22 +39,54 @@ macro_rules! try_split_bits {
 struct BitStream<'a> {
     bits: &'a mut BitSlice<u8, Msb0>,
     idx: usize,
+    /// Set once a write has been asked for that does not fit in `bits`.
+    ///
+    /// RLGR does not guarantee compression. A high-entropy tile paired with a
+    /// light quantization table can need more output than the caller reserved,
+    /// and callers size that buffer on an assumed ratio rather than a bound.
+    /// Indexing a `BitSlice` past its end panics, so the writers drop such a
+    /// write and record it here instead, and [`encode`] reports it as an error
+    /// once the tile is finished.
+    overflowed: bool,
 }
 
 impl<'a> BitStream<'a> {
     fn new(slice: &'a mut [u8]) -> Self {
         let bits = slice.view_bits_mut::<Msb0>();
-        Self { bits, idx: 0 }
+        Self {
+            bits,
+            idx: 0,
+            overflowed: false,
+        }
+    }
+
+    /// Reserves `count` bits, returning where to write them if they fit.
+    ///
+    /// `idx` advances whether or not the bits fit, so that after an overflow it
+    /// still counts what the tile would have needed and the error can say so.
+    fn reserve(&mut self, count: usize) -> Option<core::ops::Range<usize>> {
+        let start = self.idx;
+        let end = start.saturating_add(count);
+        self.idx = end;
+
+        if end <= self.bits.len() {
+            Some(start..end)
+        } else {
+            self.overflowed = true;
+            None
+        }
     }
 
     fn output_bit(&mut self, count: usize, val: bool) {
-        self.bits[self.idx..self.idx + count].fill(val);
-        self.idx += count;
+        if let Some(range) = self.reserve(count) {
+            self.bits[range].fill(val);
+        }
     }
 
     fn output_bits(&mut self, num_bits: usize, val: u32) {
-        self.bits[self.idx..self.idx + num_bits].store_be(val);
-        self.idx += num_bits;
+        if let Some(range) = self.reserve(num_bits) {
+            self.bits[range].store_be(val);
+        }
     }
 
     fn len(&self) -> usize {
@@ -71,6 +103,8 @@ pub fn encode(mode: EntropyAlgorithm, input: &[i16], tile: &mut [u8]) -> Result<
     if input.is_empty() {
         return Err(RlgrError::EmptyTile);
     }
+
+    let available = tile.len();
 
     let mut k: u32 = 1;
     let kr: u32 = 1;
@@ -150,6 +184,15 @@ pub fn encode(mode: EntropyAlgorithm, input: &[i16], tile: &mut [u8]) -> Result<
                 }
             }
         }
+    }
+
+    // The whole tile is walked even after an overflow, so `len` here is what the
+    // tile actually needed rather than where the buffer ran out.
+    if bits.overflowed {
+        return Err(RlgrError::OutputTooSmall {
+            needed: bits.len(),
+            available,
+        });
     }
 
     Ok(bits.len())
@@ -390,6 +433,14 @@ pub enum RlgrError {
     Yuv(YuvError),
     EmptyTile,
     InvalidIntegralConversion(&'static str),
+    /// The encoded tile did not fit in the buffer the caller provided.
+    ///
+    /// `needed` is the size the tile would have taken, so a caller that sizes
+    /// its buffer on an assumed compression ratio can tell how far off it was.
+    OutputTooSmall {
+        needed: usize,
+        available: usize,
+    },
 }
 
 impl core::fmt::Display for RlgrError {
@@ -399,6 +450,9 @@ impl core::fmt::Display for RlgrError {
             Self::Yuv(_) => write!(f, "YUV error"),
             Self::EmptyTile => write!(f, "the input tile is empty"),
             Self::InvalidIntegralConversion(s) => write!(f, "invalid `{s}`: out of range integral type conversion"),
+            Self::OutputTooSmall { needed, available } => {
+                write!(f, "encoded tile needs {needed} bytes, output buffer is {available}")
+            }
         }
     }
 }
@@ -410,6 +464,7 @@ impl core::error::Error for RlgrError {
             Self::Yuv(error) => Some(error),
             Self::EmptyTile => None,
             Self::InvalidIntegralConversion(_) => None,
+            Self::OutputTooSmall { .. } => None,
         }
     }
 }

--- a/crates/ironrdp-testsuite-core/tests/graphics/rlgr.rs
+++ b/crates/ironrdp-testsuite-core/tests/graphics/rlgr.rs
@@ -155,6 +155,50 @@ fn encode_correctly_encodes_rlgr1() {
     assert_eq!(expected.as_ref(), output.as_slice());
 }
 
+/// A tile whose entropy coding does not fit the caller's buffer, which RLGR
+/// gives no guarantee it will. Callers size the buffer on an assumed
+/// compression ratio, so the encoder has to say when the assumption fails
+/// rather than run off the end of it.
+#[test]
+fn encode_reports_an_undersized_output_buffer() {
+    // Full-range coefficients: nothing to run-length code, so the output is
+    // comfortably larger than the two bytes offered.
+    let input: Vec<i16> = (0..4096)
+        .map(|i| if i % 2 == 0 { i16::MAX } else { i16::MIN })
+        .collect();
+
+    for mode in [EntropyAlgorithm::Rlgr1, EntropyAlgorithm::Rlgr3] {
+        let mut output = vec![0; 2];
+        let err = encode(mode, input.as_ref(), output.as_mut_slice()).unwrap_err();
+
+        let RlgrError::OutputTooSmall { needed, available } = err else {
+            panic!("expected OutputTooSmall for {mode:?}, got {err:?}");
+        };
+        assert_eq!(available, 2, "the reported capacity is the buffer the caller passed");
+        assert!(
+            needed > available,
+            "the reported requirement must exceed the buffer, got {needed} against {available}"
+        );
+    }
+}
+
+/// The overflow check must not fire on a tile that fits exactly, which is the
+/// boundary a naive `>=` would get wrong.
+#[test]
+fn encode_accepts_an_output_buffer_of_exactly_the_required_size() {
+    let input = [0, 1, 4, 0];
+    let mode = EntropyAlgorithm::Rlgr1;
+
+    let mut probe = vec![0; 64];
+    let needed = encode(mode, input.as_ref(), probe.as_mut_slice()).unwrap();
+
+    let mut exact = vec![0; needed];
+    let written = encode(mode, input.as_ref(), exact.as_mut_slice()).unwrap();
+
+    assert_eq!(written, needed);
+    assert_eq!(exact.as_slice(), &probe[..needed]);
+}
+
 const Y_DATA_ENCODED: [u8; 942] = [
     0xc0, 0x01, 0x01, 0x15, 0x48, 0x99, 0xc7, 0x41, 0xa1, 0x12, 0x68, 0x11, 0xdc, 0x22, 0x29, 0x74, 0xef, 0xfd, 0x20,
     0x92, 0xe0, 0x4e, 0xa8, 0x69, 0x3b, 0xfd, 0x41, 0x83, 0xbf, 0x28, 0x53, 0x0c, 0x1f, 0xe2, 0x54, 0x0c, 0x77, 0x7c,


### PR DESCRIPTION
## Summary

- `BitStream::output_bit` and `output_bits` indexed the output `BitSlice` with no capacity check, so a tile whose entropy coding didn't fit the caller's buffer panicked inside a function that already returns `Result`.
- The RLGR decoder a few hundred lines down has been bounds-checked all along: `try_split_bits!` breaks when bits run short, the loop guards on `!bits.is_empty() && !output.is_empty()`, and run-length fills clamp with `min(run, output.len())`. Only the encoder was unguarded.
- The writers now reserve before writing and record an overflow rather than indexing past the end. `encode` turns that into `RlgrError::OutputTooSmall`.

## Why it's reachable

RLGR gives no compression guarantee, but callers size the output as though it did. `ironrdp-server` splits a 12288-byte tile buffer into three 4096-byte components, which is 2:1 against 4096 `i16` coefficients. That holds comfortably at the default quantization table and stops holding as the table gets lighter, so this is reachable from configuration rather than from malformed input.

The tile is still walked to completion after an overflow, so the error reports the size the tile would have needed. A caller sizing on a ratio needs that number to correct the ratio; it's the reason the variant carries data.

## Retrying at the size the encoder asks for

Detection alone was not a fix, which @mamoreau-devolutions was right to push back on. `alloc_data` gave every component exactly 4096 bytes, and the loop in `encoder/mod.rs` that grows a buffer on `NotEnoughBytes` grows the whole-frame one, so it could never have helped here. A tile that overflowed went from panicking to failing the update.

The per-component reserve is a parameter now, and the tile-set encode retries at exactly the size the encoder reports, growing monotonically and stopping at twice a component's raw `i16` size.

I did not take the fixed upper bound offered as an alternative. RLGR is adaptive and unary-dominated in its worst case, so a bound loose enough to be provable is megabytes per component, and anything small enough to allocate is a guess. Since the encoder can say exactly what it needs, retrying at that seemed better than inventing a constant.

The retry lives in `RfxEncoder::encode` because `rfx::Tile` borrows out of the buffer, so the buffer has to be sized before any borrow is taken. Widening `Tile` would reshape a wire PDU type, and a per-tile fallback needs the overflow buffers to outlive a `par_chunks_mut` borrow.

`OutputTooSmall` is deliberately not mapped onto `NotEnoughBytes` to reuse that existing loop, since the loop grows a different buffer and would look like a fix without being one.

## Breaking change

`RlgrError` gains an `OutputTooSmall` variant and isn't `#[non_exhaustive]`, so exhaustive matches need updating.

`ironrdp-graphics` is marked `# public` in `ironrdp-server`, `ironrdp-client`, `ironrdp-egfx`, `ironrdp-session`, and `ironrdp-nscodec` (under its `encoder` feature), so the bump cascades to those.

I considered reusing `RlgrError::Io(io::Error::from(ErrorKind::WriteZero))` to avoid the break. It discards both numbers the caller needs to act on, which defeats the point. Marking the enum `#[non_exhaustive]` is a separate breaking change and a wider policy question, so it isn't bundled here.

## Validation

- `cargo xtask check fmt/lints/tests/typos/locks` all pass on the pinned toolchain, `fuzz/` built before the lock check.
- Two tests added in `crates/ironrdp-testsuite-core/tests/graphics/rlgr.rs`: an undersized buffer reports `OutputTooSmall` with `needed > available` for both RLGR1 and RLGR3, and a buffer of exactly the required size still succeeds. The twelve existing `graphics::rlgr` tests are unchanged and still pass.
- Two more in `crates/ironrdp-testsuite-core/tests/server/rfx.rs` for the retry: the reported size must be sufficient rather than merely indicative, so encoding at a 64-byte reserve and retrying at exactly the size reported has to succeed; and the default reserve still handles a full-entropy tile, so the retry stays a fallback. Under-reporting the size by one byte fails the first of those.
- Those two started life inline in `encoder/rfx.rs`, where they never ran: `ironrdp-server` sets `[lib] test = false`, so `cargo test --workspace` builds no unittest binary for it. They reach the encoder through the crate's existing `__bench` feature, which now also exports `rfx_enc_at` next to the two helpers already there, so no type had to be widened.
- Driving the server pipeline (BGRA, `to_64x64_ycbcr_tile`, `dwt::encode`, `quantization::encode`, `rlgr::encode` into 4096 bytes) on a random-noise tile, a quantization table of all ones panics on master and now returns `encoded tile needs 6018 bytes, output buffer is 4096`.
- Spec-legal tables are unaffected, and that is measured rather than assumed. Binary-searching the minimum per-component reserve for a set of adversarial 64x64 tiles at `Quant::default()` gives a worst case of 2857 bytes of the 4096 available (per-channel independent noise at full swing, RLGR3); full-range noise needs 2379 under RLGR1. Taking that worst pattern across the whole legal range from [MS-RDPRFX] 2.2.2.1.5, RLGR1 needs 3768 bytes at quant 6, 2740 at 8, and 917 at 15. Nothing in spec overflows, which is why this PR fixes the panic and stops there.

## Notes

Found while looking at #1557, where an all-ones quantization table panicked the encoder. That table is out of spec ([MS-RDPRFX] 2.2.2.1.5 requires 6 to 15), and the configurability that issue asks for is separate work. This change is only about not panicking.

Touches `BitStream` and the tail of `encode`, deliberately staying clear of the body of `encode` where #1370 and #1179 both have hunks. It should rebase cleanly whichever of those lands first.

