### PR TITLE
feat(activex): add OLE clipboard snapshots

### DIFF
--- a/crates/ironrdp-activex/README.md
+++ b/crates/ironrdp-activex/README.md
@@ -522,8 +522,7 @@ The control emits `OnViewChange(DVASPECT_CONTENT, -1)` after a rendered-frame in
 change, `OnSave` after a successful persistence write, and `OnClose` during `IOleObject::Close`.
 Its extent and misc-status contracts support `DVASPECT_CONTENT` only; unsupported drawing aspects
 return `DV_E_DVASPECT` rather than claiming unavailable static rendering.
-It does not emit `OnDataChange` or `OnRename` because it does not implement `IDataObject` exchange or
-moniker support.
+It does not emit `OnDataChange` or `OnRename` because clipboard snapshots are immutable and the control does not implement moniker support.
 `IViewObject`, `IViewObject2`, and `IViewObjectEx` report the same content extent, opaque/solid
 view status, content bounds, natural extent, and view-advise notifications. They intentionally
 return `E_NOTIMPL` for detached-HDC drawing, palette enumeration, and frozen snapshots: the
@@ -568,8 +567,13 @@ connection while the RDP worker owns the protocol backend; shutdown removes the 
 `IMsRdpClipboard` reports synchronization available only after that enabled connection completes
 activation; its explicit sync methods succeed at that point because the backend performs
 synchronization automatically. They return `E_UNEXPECTED` before connection or when clipboard
-redirection was disabled for the session. The separate OLE `IDataObject` clipboard contract remains a
-TODO and is not claimed as supported.
+redirection was disabled for the session.
+For the same active state, `IOleObject::GetClipboardData(0)` returns an immutable OLE `IDataObject` snapshot of the current Windows clipboard's valid `CF_UNICODETEXT` payload.
+The object supports source retrieval only (`DATADIR_GET`) with `DVASPECT_CONTENT`, `lindex = -1`, no target device, and `TYMED_HGLOBAL`.
+It validates those `FORMATETC` fields and returns a newly allocated `STGMEDIUM` for each `GetData` call, so the caller owns and must release that medium.
+Delayed rendering remains in the STA-bound native CLIPRDR backend while the snapshot is created; after creation the object has no live clipboard or RDP-worker dependency.
+No other clipboard format, conversion, inbound `SetData`, destination enumeration, `GetDataHere`, or data-advisory contract is claimed.
+`GetClipboardData` rejects a nonzero reserved value and reports `OLE_E_NOTRUNNING` before clipboard redirection is active.
 
 `IMsRdpClientNonScriptable5` reports one remote monitor only after an active remote framebuffer is
 available and returns its `(0, 0, width, height)` bounding box. Multi-monitor mode is not
@@ -653,7 +657,7 @@ The worker translates supported Automation settings into `ironrdp-client::Config
 Connection points retain sinks through `Advise`/`Unadvise`, enumerate correctly, and query the supplied
 sink for the event interface IID before retaining its `IDispatch`.
 
-This is an Automation, lifecycle, hosting, framebuffer, basic input, persistence, and static
-virtual-channel foundation. It does not yet implement RemoteApp, OLE `IDataObject` clipboard exchange,
-monikers, RDPDR device redirection, or arbitrary persisted designer state. Those contracts must be
-added as exact ABI implementations before advertising their individual methods as supported.
+This is an Automation, lifecycle, hosting, framebuffer, basic input, persistence, static
+virtual-channel, and Unicode-text OLE clipboard-snapshot foundation.
+It does not yet implement RemoteApp, non-text or writable OLE clipboard exchange, monikers, RDPDR device redirection, or arbitrary persisted designer state.
+Those contracts must be added as exact ABI implementations before advertising their individual methods as supported.

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -3963,10 +3963,11 @@ impl ClipboardDataObject {
                         .ok_or_else(|| Error::from_hresult(E_OUTOFMEMORY))?;
                     Ok(Some(data[..text_byte_count].to_vec()))
                 })();
-                if let Err(error) = unsafe { GlobalUnlock(handle) } {
-                    tracing::debug!(?error, "Unable to unlock OLE clipboard snapshot");
+                match (snapshot, unlock_global_memory(handle)) {
+                    (Err(error), _) => Err(error),
+                    (Ok(_), Err(error)) => Err(error),
+                    (Ok(data), Ok(())) => Ok(data),
                 }
-                snapshot
             })();
 
             let close_result = unsafe { CloseClipboard() };
@@ -4036,9 +4037,7 @@ impl IDataObject_Impl for ClipboardDataObject_Impl {
         unsafe {
             ptr::copy_nonoverlapping(data.as_ptr(), destination, data.len());
         }
-        if let Err(error) = unsafe { GlobalUnlock(memory) } {
-            tracing::debug!(?error, "Unable to unlock OLE clipboard medium");
-        }
+        unlock_global_memory(memory)?;
 
         Ok(STGMEDIUM {
             tymed: TYMED_HGLOBAL.0 as u32,
@@ -4067,7 +4066,14 @@ impl IDataObject_Impl for ClipboardDataObject_Impl {
         if canonical.is_null() {
             return E_POINTER;
         }
-        if let Err(error) = self.validate_format(format) {
+        if format.is_null() {
+            unsafe {
+                canonical.write(FORMATETC::default());
+            }
+            return E_POINTER;
+        }
+        let format = unsafe { format.read() };
+        if let Err(error) = self.validate_format(&format) {
             unsafe {
                 canonical.write(FORMATETC::default());
             }
@@ -4075,7 +4081,10 @@ impl IDataObject_Impl for ClipboardDataObject_Impl {
         }
 
         unsafe {
-            canonical.write(unicode_text_format());
+            canonical.write(FORMATETC {
+                ptd: ptr::null_mut(),
+                ..format
+            });
         }
         DATA_S_SAMEFORMATETC
     }
@@ -4117,6 +4126,14 @@ fn unicode_text_format() -> FORMATETC {
         dwAspect: DVASPECT_CONTENT.0,
         lindex: -1,
         tymed: TYMED_HGLOBAL.0 as u32,
+    }
+}
+
+fn unlock_global_memory(memory: HGLOBAL) -> Result<()> {
+    match unsafe { GlobalUnlock(memory) } {
+        Ok(()) => Ok(()),
+        Err(error) if error.code() == S_OK => Ok(()),
+        Err(error) => Err(error),
     }
 }
 
@@ -14017,6 +14034,27 @@ mod tests {
         assert_eq!(unsafe { enumerator.Next(&mut formats, Some(&mut fetched)) }, S_FALSE);
         assert_eq!(fetched, 0);
 
+        let alternate_tymed = FORMATETC {
+            tymed: TYMED_HGLOBAL.0 as u32 | windows::Win32::System::Com::TYMED_FILE.0 as u32,
+            ..format
+        };
+        let mut canonical = FORMATETC::default();
+        assert_eq!(
+            unsafe { data_object.GetCanonicalFormatEtc(&alternate_tymed, &mut canonical) },
+            DATA_S_SAMEFORMATETC
+        );
+        assert_eq!(canonical.tymed, alternate_tymed.tymed);
+        assert!(canonical.ptd.is_null());
+
+        let mut aliasing_format = alternate_tymed;
+        let aliasing_format_pointer = &mut aliasing_format as *mut FORMATETC;
+        assert_eq!(
+            unsafe { data_object.GetCanonicalFormatEtc(aliasing_format_pointer, aliasing_format_pointer) },
+            DATA_S_SAMEFORMATETC
+        );
+        assert_eq!(aliasing_format.tymed, alternate_tymed.tymed);
+        assert!(aliasing_format.ptd.is_null());
+
         let mut medium = unsafe { data_object.GetData(&format) }.expect("retrieve clipboard snapshot");
         assert_eq!(medium.tymed, TYMED_HGLOBAL.0 as u32);
         let memory = unsafe { medium.u.hGlobal };
@@ -14024,7 +14062,7 @@ mod tests {
         assert!(!source.is_null());
         let copied = unsafe { slice::from_raw_parts(source, GlobalSize(memory)) };
         assert_eq!(copied, [b'i', 0, b'r', 0, b'o', 0, b'n', 0, 0, 0]);
-        let _ = unsafe { GlobalUnlock(memory) };
+        unlock_global_memory(memory).expect("unlock returned clipboard medium");
         unsafe {
             ReleaseStgMedium(&mut medium);
         }

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -29,10 +29,12 @@ use ironrdp_tls::CertificateValidation;
 use sha2::{Digest as _, Sha256};
 use tokio::sync::mpsc;
 use windows::Win32::Foundation::{
-    DISP_E_BADPARAMCOUNT, DISP_E_MEMBERNOTFOUND, DISP_E_TYPEMISMATCH, DISP_E_UNKNOWNNAME, DV_E_DVASPECT, DV_E_LINDEX,
-    E_FAIL, E_INVALIDARG, E_NOTIMPL, E_OUTOFMEMORY, E_POINTER, E_UNEXPECTED, ERROR_CANCELLED,
-    ERROR_CLASS_DOES_NOT_EXIST, FreeLibrary, HMODULE, HWND, LPARAM, LRESULT, OLE_E_NOCONNECTION, OLEOBJ_S_INVALIDVERB,
-    POINT, RECT, RECTL, S_FALSE, S_OK, SIZE, SysStringLen, VARIANT_BOOL, VARIANT_FALSE, VARIANT_TRUE, WPARAM,
+    DATA_S_SAMEFORMATETC, DISP_E_BADPARAMCOUNT, DISP_E_MEMBERNOTFOUND, DISP_E_TYPEMISMATCH, DISP_E_UNKNOWNNAME,
+    DV_E_DVASPECT, DV_E_DVTARGETDEVICE, DV_E_FORMATETC, DV_E_LINDEX, DV_E_TYMED, E_FAIL, E_INVALIDARG, E_NOTIMPL,
+    E_OUTOFMEMORY, E_POINTER, E_UNEXPECTED, ERROR_CANCELLED, ERROR_CLASS_DOES_NOT_EXIST, FreeLibrary, GlobalFree,
+    HGLOBAL, HMODULE, HWND, LPARAM, LRESULT, OLE_E_ADVISENOTSUPPORTED, OLE_E_NOCONNECTION, OLE_E_NOTRUNNING,
+    OLEOBJ_S_INVALIDVERB, POINT, RECT, RECTL, S_FALSE, S_OK, SIZE, SysStringLen, VARIANT_BOOL, VARIANT_FALSE,
+    VARIANT_TRUE, WPARAM,
 };
 use windows::Win32::Graphics::Gdi::{
     BI_RGB, BITMAPINFO, BITMAPINFOHEADER, BLACKNESS, BeginPaint, CreateCompatibleDC, CreateDIBSection, CreateRectRgn,
@@ -44,17 +46,22 @@ use windows::Win32::Security::Credentials::{
     CredUIPromptForCredentialsW,
 };
 use windows::Win32::System::Com::{
-    CONNECTDATA, CoTaskMemAlloc, DISPATCH_FLAGS, DISPATCH_METHOD, DISPATCH_PROPERTYGET, DISPATCH_PROPERTYPUT,
-    DISPPARAMS, DVASPECT, DVASPECT_CONTENT, DVTARGETDEVICE, EXCEPINFO, FORMATETC, IAdviseSink, IConnectionPoint,
-    IConnectionPoint_Impl, IConnectionPointContainer, IConnectionPointContainer_Impl, IDispatch, IDispatch_Impl,
-    IDispatch_Vtbl, IEnumConnectionPoints, IEnumConnectionPoints_Impl, IEnumConnections, IEnumConnections_Impl,
-    IEnumSTATDATA, IEnumSTATDATA_Impl, IPersist_Impl, IPersistStreamInit, IPersistStreamInit_Impl, IStream, ITypeInfo,
-    STATDATA,
+    CONNECTDATA, CoTaskMemAlloc, DATADIR_GET, DATADIR_SET, DISPATCH_FLAGS, DISPATCH_METHOD, DISPATCH_PROPERTYGET,
+    DISPATCH_PROPERTYPUT, DISPPARAMS, DVASPECT, DVASPECT_CONTENT, DVTARGETDEVICE, EXCEPINFO, FORMATETC, IAdviseSink,
+    IConnectionPoint, IConnectionPoint_Impl, IConnectionPointContainer, IConnectionPointContainer_Impl, IDataObject,
+    IDataObject_Impl, IDispatch, IDispatch_Impl, IDispatch_Vtbl, IEnumConnectionPoints, IEnumConnectionPoints_Impl,
+    IEnumConnections, IEnumConnections_Impl, IEnumFORMATETC, IEnumFORMATETC_Impl, IEnumSTATDATA, IEnumSTATDATA_Impl,
+    IPersist_Impl, IPersistStreamInit, IPersistStreamInit_Impl, IStream, ITypeInfo, STATDATA, STGMEDIUM, STGMEDIUM_0,
+    TYMED_HGLOBAL,
+};
+use windows::Win32::System::DataExchange::{
+    CloseClipboard, GetClipboardData, IsClipboardFormatAvailable, OpenClipboard,
 };
 use windows::Win32::System::LibraryLoader::{GetModuleHandleW, GetProcAddress, LoadLibraryW};
+use windows::Win32::System::Memory::{GMEM_MOVEABLE, GlobalAlloc, GlobalLock, GlobalSize, GlobalUnlock};
 use windows::Win32::System::Ole::{
-    CONTROLINFO, DVEXTENTINFO, HITRESULT_HIT, HITRESULT_OUTSIDE, IEnumOLEVERB, IEnumOLEVERB_Impl, IOleClientSite,
-    IOleControl, IOleControl_Impl, IOleControlSite, IOleControlSite_Vtbl, IOleInPlaceActiveObject,
+    CF_UNICODETEXT, CONTROLINFO, DVEXTENTINFO, HITRESULT_HIT, HITRESULT_OUTSIDE, IEnumOLEVERB, IEnumOLEVERB_Impl,
+    IOleClientSite, IOleControl, IOleControl_Impl, IOleControlSite, IOleControlSite_Vtbl, IOleInPlaceActiveObject,
     IOleInPlaceActiveObject_Impl, IOleInPlaceObject, IOleInPlaceObject_Impl, IOleInPlaceSite, IOleInPlaceUIWindow,
     IOleObject, IOleObject_Impl, IOleWindow_Impl, IViewObject, IViewObject_Impl, IViewObject2, IViewObject2_Impl,
     IViewObjectEx, IViewObjectEx_Impl, KEYMODIFIERS, OLECLOSE, OLEGETMONIKER, OLEMISC, OLEVERB, OLEVERB_PRIMARY,
@@ -3576,6 +3583,8 @@ struct ClipboardState {
     connected: Cell<bool>,
 }
 
+const MAX_OLE_CLIPBOARD_TEXT_BYTES: usize = 16 * 1024 * 1024;
+
 impl ClipboardState {
     fn is_available(&self) -> bool {
         self.enabled_for_session.get() && self.connected.get()
@@ -3831,6 +3840,283 @@ impl IMsRdpClipboard_Impl for ClipboardCapabilities_Impl {
         } else {
             Err(Error::from_hresult(E_UNEXPECTED))
         }
+    }
+}
+
+#[implement(IEnumFORMATETC)]
+struct ClipboardFormatEnumerator {
+    _lifetime: ServerObjectLifetime,
+    has_unicode_text: bool,
+    consumed: Cell<bool>,
+}
+
+impl ClipboardFormatEnumerator {
+    fn new(has_unicode_text: bool, consumed: bool) -> Self {
+        Self {
+            _lifetime: ServerObjectLifetime::new(),
+            has_unicode_text,
+            consumed: Cell::new(consumed),
+        }
+    }
+}
+
+impl IEnumFORMATETC_Impl for ClipboardFormatEnumerator_Impl {
+    fn Next(&self, celt: u32, formats: *mut FORMATETC, fetched: *mut u32) -> HRESULT {
+        if celt != 0 && formats.is_null() {
+            return E_POINTER;
+        }
+        if celt != 1 && fetched.is_null() {
+            return E_POINTER;
+        }
+        if !fetched.is_null() {
+            unsafe {
+                fetched.write(0);
+            }
+        }
+        if celt == 0 {
+            return S_OK;
+        }
+        if self.consumed.get() || !self.has_unicode_text {
+            return S_FALSE;
+        }
+
+        unsafe {
+            formats.write(unicode_text_format());
+        }
+        self.consumed.set(true);
+        if !fetched.is_null() {
+            unsafe {
+                fetched.write(1);
+            }
+        }
+        if celt == 1 { S_OK } else { S_FALSE }
+    }
+
+    fn Skip(&self, celt: u32) -> Result<()> {
+        if celt == 0 {
+            return Ok(());
+        }
+        if self.consumed.get() || !self.has_unicode_text {
+            return Err(Error::from_hresult(S_FALSE));
+        }
+
+        self.consumed.set(true);
+        if celt == 1 {
+            Ok(())
+        } else {
+            Err(Error::from_hresult(S_FALSE))
+        }
+    }
+
+    fn Reset(&self) -> Result<()> {
+        self.consumed.set(false);
+        Ok(())
+    }
+
+    fn Clone(&self) -> Result<IEnumFORMATETC> {
+        Ok(ClipboardFormatEnumerator::new(self.has_unicode_text, self.consumed.get()).into())
+    }
+}
+
+#[implement(IDataObject)]
+struct ClipboardDataObject {
+    _lifetime: ServerObjectLifetime,
+    unicode_text: Option<Vec<u8>>,
+}
+
+impl ClipboardDataObject {
+    fn snapshot() -> Result<Self> {
+        let unicode_text = if unsafe { IsClipboardFormatAvailable(u32::from(CF_UNICODETEXT.0)) }.is_ok() {
+            unsafe {
+                OpenClipboard(None)?;
+            }
+
+            let result = (|| {
+                let handle = match unsafe { GetClipboardData(u32::from(CF_UNICODETEXT.0)) } {
+                    Ok(handle) => HGLOBAL(handle.0),
+                    Err(_) => return Ok(None),
+                };
+                let byte_count = unsafe { GlobalSize(handle) };
+                if !(2..=MAX_OLE_CLIPBOARD_TEXT_BYTES).contains(&byte_count) || byte_count % 2 != 0 {
+                    return Ok(None);
+                }
+
+                let source = unsafe { GlobalLock(handle) }.cast::<u8>();
+                if source.is_null() {
+                    return Ok(None);
+                }
+                let snapshot = (|| {
+                    let data = unsafe { slice::from_raw_parts(source, byte_count) };
+                    let units = data
+                        .chunks_exact(2)
+                        .map(|unit| u16::from_le_bytes([unit[0], unit[1]]))
+                        .collect::<Vec<_>>();
+
+                    let Some(terminator) = units.iter().position(|unit| *unit == 0) else {
+                        return Ok(None);
+                    };
+                    if !char::decode_utf16(units[..terminator].iter().copied()).all(|character| character.is_ok()) {
+                        return Ok(None);
+                    }
+                    let text_byte_count = (terminator + 1)
+                        .checked_mul(2)
+                        .ok_or_else(|| Error::from_hresult(E_OUTOFMEMORY))?;
+                    Ok(Some(data[..text_byte_count].to_vec()))
+                })();
+                if let Err(error) = unsafe { GlobalUnlock(handle) } {
+                    tracing::debug!(?error, "Unable to unlock OLE clipboard snapshot");
+                }
+                snapshot
+            })();
+
+            let close_result = unsafe { CloseClipboard() };
+            match (result, close_result) {
+                (Ok(data), Ok(())) => data,
+                (Ok(_), Err(error)) => return Err(error),
+                (Err(error), _) => return Err(error),
+            }
+        } else {
+            None
+        };
+
+        Ok(Self {
+            _lifetime: ServerObjectLifetime::new(),
+            unicode_text,
+        })
+    }
+
+    #[cfg(test)]
+    fn from_unicode_text(unicode_text: Option<Vec<u8>>) -> Self {
+        Self {
+            _lifetime: ServerObjectLifetime::new(),
+            unicode_text,
+        }
+    }
+
+    fn validate_format(&self, format: *const FORMATETC) -> Result<()> {
+        let format = unsafe { format.as_ref() }.ok_or_else(|| Error::from_hresult(E_POINTER))?;
+        if format.cfFormat != CF_UNICODETEXT.0 {
+            return Err(Error::from_hresult(DV_E_FORMATETC));
+        }
+        if !format.ptd.is_null() {
+            return Err(Error::from_hresult(DV_E_DVTARGETDEVICE));
+        }
+        if format.dwAspect != DVASPECT_CONTENT.0 {
+            return Err(Error::from_hresult(DV_E_DVASPECT));
+        }
+        if format.lindex != -1 {
+            return Err(Error::from_hresult(DV_E_LINDEX));
+        }
+        if format.tymed & TYMED_HGLOBAL.0 as u32 == 0 {
+            return Err(Error::from_hresult(DV_E_TYMED));
+        }
+        if self.unicode_text.is_none() {
+            return Err(Error::from_hresult(DV_E_FORMATETC));
+        }
+        Ok(())
+    }
+}
+
+impl IDataObject_Impl for ClipboardDataObject_Impl {
+    fn GetData(&self, format: *const FORMATETC) -> Result<STGMEDIUM> {
+        self.validate_format(format)?;
+        let data = self
+            .unicode_text
+            .as_ref()
+            .ok_or_else(|| Error::from_hresult(DV_E_FORMATETC))?;
+
+        let memory = unsafe { GlobalAlloc(GMEM_MOVEABLE, data.len()) }?;
+        let destination = unsafe { GlobalLock(memory) }.cast::<u8>();
+        if destination.is_null() {
+            unsafe {
+                GlobalFree(Some(memory))?;
+            }
+            return Err(Error::from_hresult(E_OUTOFMEMORY));
+        }
+        unsafe {
+            ptr::copy_nonoverlapping(data.as_ptr(), destination, data.len());
+        }
+        if let Err(error) = unsafe { GlobalUnlock(memory) } {
+            tracing::debug!(?error, "Unable to unlock OLE clipboard medium");
+        }
+
+        Ok(STGMEDIUM {
+            tymed: TYMED_HGLOBAL.0 as u32,
+            u: STGMEDIUM_0 { hGlobal: memory },
+            pUnkForRelease: ManuallyDrop::new(None),
+        })
+    }
+
+    fn GetDataHere(&self, format: *const FORMATETC, medium: *mut STGMEDIUM) -> Result<()> {
+        self.validate_format(format)?;
+        let medium = unsafe { medium.as_ref() }.ok_or_else(|| Error::from_hresult(E_POINTER))?;
+        if medium.tymed != TYMED_HGLOBAL.0 as u32 {
+            return Err(Error::from_hresult(DV_E_TYMED));
+        }
+        Err(Error::from_hresult(E_NOTIMPL))
+    }
+
+    fn QueryGetData(&self, format: *const FORMATETC) -> HRESULT {
+        match self.validate_format(format) {
+            Ok(()) => S_OK,
+            Err(error) => error.code(),
+        }
+    }
+
+    fn GetCanonicalFormatEtc(&self, format: *const FORMATETC, canonical: *mut FORMATETC) -> HRESULT {
+        if canonical.is_null() {
+            return E_POINTER;
+        }
+        if let Err(error) = self.validate_format(format) {
+            unsafe {
+                canonical.write(FORMATETC::default());
+            }
+            return error.code();
+        }
+
+        unsafe {
+            canonical.write(unicode_text_format());
+        }
+        DATA_S_SAMEFORMATETC
+    }
+
+    fn SetData(&self, format: *const FORMATETC, medium: *const STGMEDIUM, _release: WinBool) -> Result<()> {
+        if format.is_null() || medium.is_null() {
+            return Err(Error::from_hresult(E_POINTER));
+        }
+        Err(Error::from_hresult(E_NOTIMPL))
+    }
+
+    fn EnumFormatEtc(&self, direction: u32) -> Result<IEnumFORMATETC> {
+        if direction == DATADIR_GET.0 as u32 {
+            Ok(ClipboardFormatEnumerator::new(self.unicode_text.is_some(), false).into())
+        } else if direction == DATADIR_SET.0 as u32 {
+            Err(Error::from_hresult(E_NOTIMPL))
+        } else {
+            Err(Error::from_hresult(E_INVALIDARG))
+        }
+    }
+
+    fn DAdvise(&self, _format: *const FORMATETC, _advf: u32, _sink: Ref<'_, IAdviseSink>) -> Result<u32> {
+        Err(Error::from_hresult(OLE_E_ADVISENOTSUPPORTED))
+    }
+
+    fn DUnadvise(&self, _connection: u32) -> Result<()> {
+        Err(Error::from_hresult(OLE_E_NOCONNECTION))
+    }
+
+    fn EnumDAdvise(&self) -> Result<IEnumSTATDATA> {
+        Err(Error::from_hresult(OLE_E_ADVISENOTSUPPORTED))
+    }
+}
+
+fn unicode_text_format() -> FORMATETC {
+    FORMATETC {
+        cfFormat: CF_UNICODETEXT.0,
+        ptd: ptr::null_mut(),
+        dwAspect: DVASPECT_CONTENT.0,
+        lindex: -1,
+        tymed: TYMED_HGLOBAL.0 as u32,
     }
 }
 
@@ -9314,15 +9600,21 @@ impl IOleObject_Impl for Control_Impl {
 
     fn InitFromData(
         &self,
-        _data_object: Ref<'_, windows::Win32::System::Com::IDataObject>,
+        _data_object: Ref<'_, IDataObject>,
         _creation: windows_core::BOOL,
         _reserved: u32,
     ) -> Result<()> {
         unsupported()
     }
 
-    fn GetClipboardData(&self, _reserved: u32) -> Result<windows::Win32::System::Com::IDataObject> {
-        unsupported_value()
+    fn GetClipboardData(&self, reserved: u32) -> Result<IDataObject> {
+        if reserved != 0 {
+            return Err(Error::from_hresult(E_INVALIDARG));
+        }
+        if !self.clipboard_state.is_available() {
+            return Err(Error::from_hresult(OLE_E_NOTRUNNING));
+        }
+        ClipboardDataObject::snapshot().map(Into::into)
     }
 
     fn DoVerb(
@@ -11623,12 +11915,10 @@ mod tests {
     use super::*;
     use ironrdp_pdu::input::fast_path::{FastPathInputEvent, KeyboardFlags};
     use ironrdp_pdu::rdp::capability_sets::{CodecProperty, client_codecs_capabilities};
-    use windows::Win32::Foundation::HGLOBAL;
     use windows::Win32::System::Com::{
-        CoTaskMemFree, IAdviseSink_Impl, IMoniker, IPersist, STGMEDIUM, STREAM_SEEK_SET,
-        StructuredStorage::CreateStreamOnHGlobal,
+        CoTaskMemFree, IAdviseSink_Impl, IMoniker, IPersist, STREAM_SEEK_SET, StructuredStorage::CreateStreamOnHGlobal,
     };
-    use windows::Win32::System::Ole::OLECLOSE_NOSAVE;
+    use windows::Win32::System::Ole::{OLECLOSE_NOSAVE, ReleaseStgMedium};
     use windows::Win32::UI::WindowsAndMessaging::WS_OVERLAPPEDWINDOW;
 
     use crate::mstsc::{
@@ -13706,6 +13996,80 @@ mod tests {
         unsafe { non_scriptable.get_RemoteMonitorCount(&mut remote_monitor_count) }
             .expect("empty remote monitor collection");
         assert_eq!(remote_monitor_count, 0);
+    }
+
+    #[test]
+    fn ole_clipboard_data_object_is_a_unicode_text_snapshot() {
+        let data_object: IDataObject =
+            ClipboardDataObject::from_unicode_text(Some(vec![b'i', 0, b'r', 0, b'o', 0, b'n', 0, 0, 0])).into();
+        let format = unicode_text_format();
+
+        assert_eq!(unsafe { data_object.QueryGetData(&format) }, S_OK);
+
+        let enumerator =
+            unsafe { data_object.EnumFormatEtc(DATADIR_GET.0 as u32) }.expect("enumerate source clipboard formats");
+        let mut formats = [FORMATETC::default()];
+        let mut fetched = 0;
+        assert_eq!(unsafe { enumerator.Next(&mut formats, Some(&mut fetched)) }, S_OK);
+        assert_eq!(fetched, 1);
+        assert_eq!(formats[0].cfFormat, CF_UNICODETEXT.0);
+        assert_eq!(formats[0].tymed, TYMED_HGLOBAL.0 as u32);
+        assert_eq!(unsafe { enumerator.Next(&mut formats, Some(&mut fetched)) }, S_FALSE);
+        assert_eq!(fetched, 0);
+
+        let mut medium = unsafe { data_object.GetData(&format) }.expect("retrieve clipboard snapshot");
+        assert_eq!(medium.tymed, TYMED_HGLOBAL.0 as u32);
+        let memory = unsafe { medium.u.hGlobal };
+        let source = unsafe { GlobalLock(memory) }.cast::<u8>();
+        assert!(!source.is_null());
+        let copied = unsafe { slice::from_raw_parts(source, GlobalSize(memory)) };
+        assert_eq!(copied, [b'i', 0, b'r', 0, b'o', 0, b'n', 0, 0, 0]);
+        let _ = unsafe { GlobalUnlock(memory) };
+        unsafe {
+            ReleaseStgMedium(&mut medium);
+        }
+
+        let invalid_tymed = FORMATETC { tymed: 0, ..format };
+        assert_eq!(unsafe { data_object.QueryGetData(&invalid_tymed) }, DV_E_TYMED);
+        let mut caller_medium = STGMEDIUM::default();
+        assert_eq!(
+            unsafe { data_object.GetDataHere(&format, &mut caller_medium) }
+                .expect_err("GetDataHere requires the supported storage medium")
+                .code(),
+            DV_E_TYMED
+        );
+        caller_medium.tymed = TYMED_HGLOBAL.0 as u32;
+        assert_eq!(
+            unsafe { data_object.GetDataHere(&format, &mut caller_medium) }
+                .expect_err("the snapshot does not accept caller-owned output storage")
+                .code(),
+            E_NOTIMPL
+        );
+        assert_eq!(
+            unsafe { data_object.EnumFormatEtc(DATADIR_SET.0 as u32) }
+                .expect_err("the snapshot must not advertise a destination")
+                .code(),
+            E_NOTIMPL
+        );
+    }
+
+    #[test]
+    fn ole_clipboard_data_requires_active_redirection() {
+        let control: IMsRdpClient10 = Control::new().into();
+        let ole_object = control.cast::<IOleObject>().expect("control supports OLE data access");
+
+        assert_eq!(
+            unsafe { ole_object.GetClipboardData(0) }
+                .expect_err("disconnected control must not expose a clipboard snapshot")
+                .code(),
+            OLE_E_NOTRUNNING
+        );
+        assert_eq!(
+            unsafe { ole_object.GetClipboardData(1) }
+                .expect_err("GetClipboardData reserved parameter must be zero")
+                .code(),
+            E_INVALIDARG
+        );
     }
 
     #[test]

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -3945,24 +3945,10 @@ impl ClipboardDataObject {
                 if source.is_null() {
                     return Ok(None);
                 }
-                let snapshot = (|| {
+                let snapshot = {
                     let data = unsafe { slice::from_raw_parts(source, byte_count) };
-                    let units = data
-                        .chunks_exact(2)
-                        .map(|unit| u16::from_le_bytes([unit[0], unit[1]]))
-                        .collect::<Vec<_>>();
-
-                    let Some(terminator) = units.iter().position(|unit| *unit == 0) else {
-                        return Ok(None);
-                    };
-                    if !char::decode_utf16(units[..terminator].iter().copied()).all(|character| character.is_ok()) {
-                        return Ok(None);
-                    }
-                    let text_byte_count = (terminator + 1)
-                        .checked_mul(2)
-                        .ok_or_else(|| Error::from_hresult(E_OUTOFMEMORY))?;
-                    Ok(Some(data[..text_byte_count].to_vec()))
-                })();
+                    validated_unicode_text_snapshot(data)
+                };
                 match (snapshot, unlock_global_memory(handle)) {
                     (Err(error), _) => Err(error),
                     (Ok(_), Err(error)) => Err(error),
@@ -4037,7 +4023,12 @@ impl IDataObject_Impl for ClipboardDataObject_Impl {
         unsafe {
             ptr::copy_nonoverlapping(data.as_ptr(), destination, data.len());
         }
-        unlock_global_memory(memory)?;
+        if let Err(error) = unlock_global_memory(memory) {
+            unsafe {
+                GlobalFree(Some(memory))?;
+            }
+            return Err(error);
+        }
 
         Ok(STGMEDIUM {
             tymed: TYMED_HGLOBAL.0 as u32,
@@ -4135,6 +4126,28 @@ fn unlock_global_memory(memory: HGLOBAL) -> Result<()> {
         Err(error) if error.code() == S_OK => Ok(()),
         Err(error) => Err(error),
     }
+}
+
+fn validated_unicode_text_snapshot(data: &[u8]) -> Result<Option<Vec<u8>>> {
+    if !(2..=MAX_OLE_CLIPBOARD_TEXT_BYTES).contains(&data.len()) || !data.len().is_multiple_of(2) {
+        return Ok(None);
+    }
+
+    let Some(terminator) = data.chunks_exact(2).position(|unit| unit == [0, 0]) else {
+        return Ok(None);
+    };
+    let utf16 = data[..terminator * 2]
+        .chunks_exact(2)
+        .map(|unit| u16::from_le_bytes([unit[0], unit[1]]));
+    if !char::decode_utf16(utf16).all(|character| character.is_ok()) {
+        return Ok(None);
+    }
+
+    let text_byte_count = terminator
+        .checked_add(1)
+        .and_then(|units| units.checked_mul(2))
+        .ok_or_else(|| Error::from_hresult(E_OUTOFMEMORY))?;
+    Ok(Some(data[..text_byte_count].to_vec()))
 }
 
 #[implement(
@@ -14089,6 +14102,39 @@ mod tests {
                 .code(),
             E_NOTIMPL
         );
+    }
+
+    #[test]
+    fn ole_clipboard_snapshot_validation_rejects_malformed_text() {
+        assert_eq!(
+            validated_unicode_text_snapshot(&[0]).expect("reject undersized text"),
+            None
+        );
+        assert_eq!(
+            validated_unicode_text_snapshot(&[b'i', 0, 0]).expect("reject odd-length text"),
+            None
+        );
+        assert_eq!(
+            validated_unicode_text_snapshot(&vec![0; MAX_OLE_CLIPBOARD_TEXT_BYTES + 2]).expect("reject oversized text"),
+            None
+        );
+        assert_eq!(
+            validated_unicode_text_snapshot(&[b'i', 0, b'r', 0]).expect("reject unterminated text"),
+            None
+        );
+        assert_eq!(
+            validated_unicode_text_snapshot(&[0, 0xd8, 0, 0]).expect("reject invalid UTF-16"),
+            None
+        );
+    }
+
+    #[test]
+    fn ole_clipboard_snapshot_stops_at_first_terminator() {
+        let snapshot = validated_unicode_text_snapshot(&[b'i', 0, 0, 0, b'r', 0])
+            .expect("accept valid Unicode text")
+            .expect("return the text before the terminator");
+
+        assert_eq!(snapshot, [b'i', 0, 0, 0]);
     }
 
     #[test]

--- a/typos.toml
+++ b/typos.toml
@@ -31,6 +31,8 @@ Pn = "Pn"
 writeable = "writeable"
 
 [default.extend-identifiers]
+# COM FORMATETC target-device field.
+ptd = "ptd"
 # Windows TRACKMOUSEEVENT flag.
 TME_LEAVE = "TME_LEAVE"
 


### PR DESCRIPTION
## Summary
- implement a capability-gated `IOleObject::GetClipboardData` source-only `IDataObject` snapshot
- expose only validated `CF_UNICODETEXT` via caller-owned `TYMED_HGLOBAL` media
- preserve canonical `FORMATETC` negotiation and safely handle global-memory ownership
- document the supported surface and deliberate exclusions

## Deliberately unsupported
Non-text formats and conversions, `SetData`, `DATADIR_SET`, `GetDataHere`, and clipboard data advisories remain unsupported.

## Validation
- `cargo test -p ironrdp-activex --lib ole_clipboard`
- `cargo clippy -p ironrdp-activex --lib --tests -- -D warnings`
- `cargo fmt -p ironrdp-activex`