### PR TITLE
ci: harden LLM output validation

### DIFF
--- a/.github/PR_AUTOMATION.md
+++ b/.github/PR_AUTOMATION.md
@@ -25,7 +25,12 @@ is unchanged, and the PR stays `maintainer-required`. A classification check tha
 machine-readable protocol state is treated as unavailable; the next classification event rewrites
 it.
 
-Each stage selects its model and effort through `--model` and `--effort` in the `claude-args` step
+The trusted LLM validators normalize exact empty-string representation artifacts consistently.
+An invalid classifier result keeps the pull request `risk/unknown` and
+`maintainer-required`, and publishes a neutral `AI classification` check containing the local
+validation reason so the review remains blocked without hiding why.
+
+Each analytical stage selects its model and effort through `--model` and `--effort` in the `claude-args` step
 that builds its `claude_args`. The classifier runs Sonnet at `low` effort: it runs on every push and
 only has to fill a small, schema-bound triage record, so it buys Sonnet-class judgement at a
 fraction of the default token spend. Both heavy stages run Opus at its default `high` effort, since

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -365,6 +365,24 @@ test("deterministic semver outranks the model and a model-only break cannot stay
   });
   assert.equal(malformed.check.conclusion, "neutral");
   assert.match(malformed.check.summary, /invalid classifier object/);
+  const deterministicFailure = resolveClassificationState({
+    expectedSha: SHA,
+    labels: [],
+    deterministic: { ok: false, reason: "invalid file metadata" },
+    classifier: "",
+    semver: { head_sha: SHA, status: "not-suspected" },
+  });
+  assert.match(deterministicFailure.check.summary, /invalid file metadata/);
+  const gateFailure = resolveClassificationState({
+    expectedSha: SHA,
+    labels: [],
+    deterministic,
+    classifier: "",
+    classificationGate: { available: false, reason: "GitHub checks API unavailable" },
+    semver: {},
+  });
+  assert.match(gateFailure.check.summary, /GitHub checks API unavailable/);
+  assert.doesNotMatch(gateFailure.check.summary, /invalid classifier object/);
   const failedWithSemverBreak = resolveClassificationState({
     expectedSha: SHA,
     labels: [],

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -122,11 +122,42 @@ test("classifier requires a high-confidence coherent legitimacy signal", () => {
   }), { expectedSha: SHA }).ok, true);
 });
 
+test("classifier normalizes PR 1564 quoted-empty-string output", () => {
+  const malformed = classifier({
+    risk: "high",
+    likely_non_legitimate: false,
+    non_legitimate_confidence: 0,
+    non_legitimate_reason: '""',
+    breaking_change_suspected: true,
+    breaking_change_rationale: "The default capability set changes.",
+    breaking_change_surface: "GraphicsPipelineHandler::capabilities",
+    protocol_related: true,
+    summary: "Stops advertising AVC444 without a decoder.",
+  });
+  const result = validateClassifier(JSON.stringify(malformed), { expectedSha: SHA });
+  assert.equal(result.ok, true);
+  assert.equal(result.value.non_legitimate_reason, "");
+});
+
 test("reviewer requires validated paths and paired lines", () => {
   const output = review();
   assert.equal(validateReviewer(output, { expectedSha: SHA, changedPaths: ["src/lib.rs"], changedLines: { "src/lib.rs": [4] } }).ok, true);
   output.findings[0].end_line = null;
   assert.equal(validateReviewer(output, { expectedSha: SHA, changedPaths: ["src/lib.rs"] }).ok, false);
+});
+
+test("reviewer canonicalizes quoted empty text and rejects it where prose is required", () => {
+  const noProtocol = validateReviewer(review({
+    has_findings: false,
+    protocol_handoff: { received: false, disposition: "not_applicable", rationale: '""' },
+    findings: [],
+  }), { expectedSha: SHA });
+  assert.equal(noProtocol.ok, true);
+  assert.equal(noProtocol.value.protocol_handoff.rationale, "");
+
+  assert.equal(validateReviewer(review({
+    findings: [finding({ rationale: '""' })],
+  }), { expectedSha: SHA, changedPaths: ["src/lib.rs"], changedLines: { "src/lib.rs": [4] } }).ok, false);
 });
 
 test("reviewer keeps line numbers only when the whole range is inside the diff", () => {
@@ -238,6 +269,12 @@ test("protocol handoff relevance must match the reported evidence", () => {
   assert.equal(notApplicableHandoff().status, "not_applicable");
 });
 
+test("protocol handoff treats quoted empty required prose as empty", () => {
+  assert.equal(validateProtocolReview(protocolReview({
+    relevance_reason: '""',
+  }), { expectedSha: SHA, changedPaths: ["src/lib.rs"], corpus }).ok, false);
+});
+
 test("corpus reader indexes real headings and refuses traversal", () => {
   const fs = require("node:fs");
   const os = require("node:os");
@@ -316,6 +353,18 @@ test("deterministic semver outranks the model and a model-only break cannot stay
   assert.equal(unavailable.failed, true);
   assert.deepEqual(unavailable.addLabels, ["maintainer-required"]);
   assert.deepEqual(unavailable.labelSets.at(-1).desired, ["risk/unknown"]);
+  assert.equal(unavailable.check.title, "Classification unavailable");
+  assert.equal(unavailable.check.conclusion, "neutral");
+  assert.match(unavailable.check.summary, /public API compatibility unavailable/);
+  const malformed = resolveClassificationState({
+    expectedSha: SHA,
+    labels: [],
+    deterministic,
+    classifier: "",
+    semver: { head_sha: SHA, status: "not-suspected" },
+  });
+  assert.equal(malformed.check.conclusion, "neutral");
+  assert.match(malformed.check.summary, /invalid classifier object/);
   const failedWithSemverBreak = resolveClassificationState({
     expectedSha: SHA,
     labels: [],
@@ -617,6 +666,7 @@ test("writer batches the label delta and tolerates an absent label removal", asy
 
 test("writer reads normalized check-run pages and updates the newest matching run", async () => {
   let updatedCheckRun = null;
+  let updatedConclusion = null;
   const github = {
     paginate: { iterator: async function* () {
       yield { data: [
@@ -630,7 +680,10 @@ test("writer reads normalized check-run pages and updates the newest matching ru
     rest: {
       checks: {
         listForRef: () => {},
-        update: async ({ check_run_id }) => { updatedCheckRun = check_run_id; },
+        update: async ({ check_run_id, conclusion }) => {
+          updatedCheckRun = check_run_id;
+          updatedConclusion = conclusion;
+        },
       },
       pulls: { get: async () => ({ data: { state: "open", head: { sha: SHA } } }) },
       issues: { get: async () => ({ data: { labels: [] } }) },
@@ -643,12 +696,14 @@ test("writer reads normalized check-run pages and updates the newest matching ru
       comments: [], removeCommentMarkers: [],
       check: {
         name: "AI classification", externalId: `classifier-v2:${SHA}`,
-        title: "Automation stopped", summary: "Maintainer review is required.",
+        title: "Classification unavailable", summary: "Classifier output invalid.",
         machineState: { protocolRelated: false },
+        conclusion: "neutral",
       },
     },
   });
   assert.equal(updatedCheckRun, 3);
+  assert.equal(updatedConclusion, "neutral");
 });
 
 function paginated(pages) {

--- a/.github/pr-automation/resolve-state.js
+++ b/.github/pr-automation/resolve-state.js
@@ -105,7 +105,7 @@ function xlClassification(expectedSha, deterministic, semverStatus) {
 }
 
 function resolveClassificationState({
-  expectedSha, labels, deterministic, classifier, changedPaths, prNumber, semver, rateLimit,
+  expectedSha, labels, deterministic, classifier, classificationGate, changedPaths, prNumber, semver, rateLimit,
 } = {}) {
   const existing = labelsOf(labels);
   if (typeof expectedSha !== "string") return { ok: false, reason: "missing expected SHA" };
@@ -118,15 +118,20 @@ function resolveClassificationState({
   if (deterministic?.ok && deterministic.sizeLabel === "size/XL") {
     return xlClassification(expectedSha, deterministic, semverStatus);
   }
-  const classifierResult = validateClassifier(classifier, {
-    expectedSha, changedPaths, documentationOnlyPaths: deterministic?.documentationOnlyPaths, prNumber,
-  });
   if (rateLimit && rateLimit.status !== "allowed") {
     return failedClassification(expectedSha, deterministic, "fork LLM quota unavailable", rateLimit, semverStatus);
   }
   if (!deterministic?.ok) {
-    return failedClassification(expectedSha, deterministic, "deterministic analysis unavailable", rateLimit, semverStatus);
+    const reason = deterministic?.reason || "deterministic analysis unavailable";
+    return failedClassification(expectedSha, deterministic, reason, rateLimit, semverStatus);
   }
+  if (classificationGate?.available === false) {
+    const reason = classificationGate.reason || "classification gate unavailable";
+    return failedClassification(expectedSha, deterministic, reason, rateLimit, semverStatus);
+  }
+  const classifierResult = validateClassifier(classifier, {
+    expectedSha, changedPaths, documentationOnlyPaths: deterministic.documentationOnlyPaths, prNumber,
+  });
   if (!classifierResult?.ok || classifierResult.value?.head_sha !== expectedSha) {
     const reason = classifierResult?.reason || "classifier output unavailable";
     return failedClassification(expectedSha, deterministic, reason, rateLimit, semverStatus);

--- a/.github/pr-automation/resolve-state.js
+++ b/.github/pr-automation/resolve-state.js
@@ -65,6 +65,14 @@ function failedClassification(expectedSha, deterministic, reason, rateLimit, sem
         : []),
     ],
     addLabels: ["maintainer-required"], comments: comment ? [comment] : [],
+    check: {
+      name: "AI classification",
+      externalId: `${CLASSIFIER_SCHEMA_VERSION}:${expectedSha}`,
+      title: "Classification unavailable",
+      summary: `Automated classification was unavailable: ${reason}. Maintainer review is required.`,
+      machineState: { protocolRelated: false },
+      conclusion: "neutral",
+    },
   };
 }
 
@@ -116,9 +124,15 @@ function resolveClassificationState({
   if (rateLimit && rateLimit.status !== "allowed") {
     return failedClassification(expectedSha, deterministic, "fork LLM quota unavailable", rateLimit, semverStatus);
   }
-  if (!deterministic?.ok || !classifierResult?.ok || classifierResult.value?.head_sha !== expectedSha ||
-      semverStatus === "unavailable") {
-    return failedClassification(expectedSha, deterministic, "classification prerequisite unavailable", rateLimit, semverStatus);
+  if (!deterministic?.ok) {
+    return failedClassification(expectedSha, deterministic, "deterministic analysis unavailable", rateLimit, semverStatus);
+  }
+  if (!classifierResult?.ok || classifierResult.value?.head_sha !== expectedSha) {
+    const reason = classifierResult?.reason || "classifier output unavailable";
+    return failedClassification(expectedSha, deterministic, reason, rateLimit, semverStatus);
+  }
+  if (semverStatus === "unavailable") {
+    return failedClassification(expectedSha, deterministic, "public API compatibility unavailable", rateLimit, semverStatus);
   }
   const model = classifierResult.value;
   const breaking = semverStatus === "suspected" || model.breaking_change_suspected;

--- a/.github/pr-automation/validate-reviewer.js
+++ b/.github/pr-automation/validate-reviewer.js
@@ -67,7 +67,7 @@ function validateReviewer(raw, {
       Number.isSafeInteger(finding.end_line) && finding.end_line >= finding.start_line;
     if (!linesAreNull && !linesAreIntegers) continue;
     const rationale = normalizeText(finding.rationale, 1200);
-    if (rationale === null || !paths.has(path)) continue;
+    if (!rationale || !paths.has(path)) continue;
     const locationIsValidated = linesAreNull ||
       linesAreValidated(path, finding.start_line, finding.end_line, changedLines);
     findings.push({

--- a/.github/pr-automation/validation.js
+++ b/.github/pr-automation/validation.js
@@ -27,7 +27,8 @@ function exactKeys(value, keys) {
 
 function normalizeText(value, maximum) {
   if (typeof value !== "string") return null;
-  const normalized = value.replace(/\s+/g, " ").trim();
+  // Structured output occasionally represents an empty string as the literal text `""`.
+  const normalized = (value === '""' ? "" : value).replace(/\s+/g, " ").trim();
   if (Buffer.byteLength(normalized, "utf8") > maximum ||
       /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/.test(normalized) ||
       COMMAND_OR_INSTRUCTION.test(normalized)) return null;

--- a/.github/pr-automation/write-state.js
+++ b/.github/pr-automation/write-state.js
@@ -133,13 +133,14 @@ async function findCheck(github, owner, repo, expectedSha, check) {
 
 async function ensureClassificationCheck(github, owner, repo, prNumber, expectedSha, check) {
   const summary = `${check.summary}\n\n${encodeCheckState(check.machineState)}`;
+  const conclusion = check.conclusion ?? "success";
   const existing = await findCheck(github, owner, repo, expectedSha, check);
-  if (existing?.conclusion === "success" && existing.output?.title === check.title &&
+  if (existing?.conclusion === conclusion && existing.output?.title === check.title &&
       existing.output?.summary === summary) return false;
   await assertCurrentHead(github, owner, repo, prNumber, expectedSha);
   const payload = {
     owner, repo, name: check.name, head_sha: expectedSha, external_id: check.externalId,
-    status: "completed", conclusion: "success",
+    status: "completed", conclusion,
     output: { title: check.title, summary },
   };
   if (existing) {

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -104,6 +104,7 @@ jobs:
     outputs:
       required: ${{ steps.gate.outputs.required }}
       available: ${{ steps.gate.outputs.available }}
+      reason: ${{ steps.gate.outputs.reason }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -130,6 +131,7 @@ jobs:
                 run.app?.slug === "github-actions" && parseCheckState(run.output?.summary) !== null);
               core.setOutput("required", !completed);
               core.setOutput("available", true);
+              core.setOutput("reason", "");
               core.info(JSON.stringify({
                 event: "pr-automation.classification-gate",
                 decision: { available: true, required: !completed, externalId, completed },
@@ -138,6 +140,7 @@ jobs:
               core.warning(`Classification gate unavailable: ${error.message}`);
               core.setOutput("required", false);
               core.setOutput("available", false);
+              core.setOutput("reason", "GitHub checks API unavailable");
               core.info(JSON.stringify({
                 event: "pr-automation.classification-gate",
                 decision: { available: false, required: false, reason: error.message },
@@ -501,6 +504,8 @@ jobs:
           PR_NUMBER: ${{ needs.resolve-pr.outputs.pr-number }}
           DETERMINISTIC: ${{ needs.deterministic-analysis.outputs.analysis }}
           CLASSIFIER: ${{ needs.classifier.outputs.output }}
+          CLASSIFICATION_GATE_AVAILABLE: ${{ needs.classification-gate.outputs.available }}
+          CLASSIFICATION_GATE_REASON: ${{ needs.classification-gate.outputs.reason }}
           FORK_RATE_LIMIT: ${{ needs.fork-rate-limit.outputs.quota }}
           SEMVER: ${{ needs.semver.outputs.compatibility }}
         with:
@@ -513,6 +518,10 @@ jobs:
               prNumber: Number(process.env.PR_NUMBER),
               deterministic: parse(process.env.DETERMINISTIC, {}),
               classifier: process.env.CLASSIFIER || "",
+              classificationGate: {
+                available: process.env.CLASSIFICATION_GATE_AVAILABLE === "true",
+                reason: process.env.CLASSIFICATION_GATE_REASON || "",
+              },
               rateLimit: parse(process.env.FORK_RATE_LIMIT, {}),
               semver: parse(process.env.SEMVER, {}),
             });


### PR DESCRIPTION
A valid classifier result for PR #1564 was discarded because structured output represented an empty string as the literal text `""`. That left the PR at `risk/unknown` and hid the concrete validation failure from maintainers.

This change canonicalizes that exact empty-string artifact in the shared text normalizer used by classifier, protocol-analysis, and reviewer outputs. Required prose still fails closed, while optional empty fields normalize consistently. Classification failures now publish a neutral SHA-bound `AI classification` check containing the precise validator or prerequisite reason, without opening the automated review gate.

Regression coverage includes the PR #1564 payload, reviewer and protocol text behavior, and neutral diagnostic check publication.