### PR TITLE
feat(rdpdr): add filesystem PDU foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2851,6 +2851,7 @@ name = "ironrdp-rdpdr"
 version = "0.7.0"
 dependencies = [
  "bitflags 2.13.1",
+ "getrandom 0.3.4",
  "ironrdp-core 0.2.1",
  "ironrdp-error 0.2.0",
  "ironrdp-pdu",

--- a/crates/ironrdp-rdpdr/Cargo.toml
+++ b/crates/ironrdp-rdpdr/Cargo.toml
@@ -14,7 +14,6 @@ categories.workspace = true
 
 [lib]
 doctest = false
-test = false
 
 [dependencies]
 ironrdp-core = { path = "../ironrdp-core", version = "0.2" } # public

--- a/crates/ironrdp-rdpdr/Cargo.toml
+++ b/crates/ironrdp-rdpdr/Cargo.toml
@@ -22,6 +22,7 @@ ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9" } # public
 ironrdp-svc = { path = "../ironrdp-svc", version = "0.8" } # public
 tracing = { version = "0.1", features = ["log"] }
 bitflags = "2.11"
+getrandom = { version = "0.3", features = ["std"] }
 
 [lints]
 workspace = true

--- a/crates/ironrdp-rdpdr/src/lib.rs
+++ b/crates/ironrdp-rdpdr/src/lib.rs
@@ -11,7 +11,7 @@ use pdu::efs::{
     ClientNameRequestUnicodeFlag, CoreCapability, CoreCapabilityKind, DEFAULT_PRINTER_DRIVER_NAME,
     DeviceAnnounceHeader, DeviceCloseResponse, DeviceControlRequest, DeviceControlResponse, DeviceIoRequest,
     DeviceIoResponse, DeviceType, Devices, MajorFunction, NtStatus, PrinterIoRequest, ServerDeviceAnnounceResponse,
-    VERSION_MINOR_RDP51, VersionAndIdPdu, VersionAndIdPduKind,
+    VERSION_MINOR_12, VERSION_MINOR_RDP51, VersionAndIdPdu, VersionAndIdPduKind,
 };
 use pdu::esc::{ScardCall, ScardIoCtlCode};
 use pdu::{PacketId, RdpdrPdu, SharedHeader};
@@ -44,6 +44,7 @@ pub struct Rdpdr {
     ///
     /// All devices not of the type [`DeviceType::Filesystem`] must be declared here.
     device_list: Devices,
+    client_id: Option<u32>,
     post_logon_devices_announced: bool,
     backend: Option<Box<dyn RdpdrBackend>>,
 }
@@ -59,6 +60,7 @@ impl Rdpdr {
             computer_name,
             capabilities: Capabilities::new(),
             device_list: Devices::new(),
+            client_id: None,
             post_logon_devices_announced: false,
             backend: Some(backend),
         }
@@ -136,8 +138,19 @@ impl Rdpdr {
     }
 
     fn handle_server_announce(&mut self, req: VersionAndIdPdu) -> PduResult<Vec<SvcMessage>> {
-        let client_announce_reply =
-            RdpdrPdu::VersionAndIdPdu(VersionAndIdPdu::new_client_announce_reply(req).map_err(|e| decode_err!(e))?);
+        let client_id = if req.version_minor < VERSION_MINOR_12 {
+            let mut bytes = [0; size_of::<u32>()];
+            getrandom::fill(&mut bytes)
+                .map_err(|err| pdu_other_err!("generating rdpdr legacy client id", source: err))?;
+            u32::from_le_bytes(bytes)
+        } else {
+            req.client_id
+        };
+        self.client_id = Some(client_id);
+        let client_announce_reply = RdpdrPdu::VersionAndIdPdu(
+            VersionAndIdPdu::new_client_announce_reply_with_legacy_client_id(req, client_id)
+                .map_err(|e| decode_err!(e))?,
+        );
         trace!("sending {:?}", client_announce_reply);
 
         let client_name_request = RdpdrPdu::ClientNameRequest(ClientNameRequest::new(
@@ -160,6 +173,12 @@ impl Rdpdr {
     }
 
     fn handle_client_id_confirm(&mut self, req: VersionAndIdPdu) -> PduResult<Vec<SvcMessage>> {
+        if self.client_id != Some(req.client_id) {
+            return Err(pdu_other_err!(
+                "received RDPDR client ID confirm for an unexpected client ID"
+            ));
+        }
+
         let announce_all_devices = req.version_minor == VERSION_MINOR_RDP51;
         if announce_all_devices {
             self.post_logon_devices_announced = true;
@@ -373,3 +392,48 @@ impl SvcProcessor for Rdpdr {
 }
 
 impl SvcClientProcessor for Rdpdr {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_server_announce_generates_and_validates_a_client_id() {
+        let mut rdpdr = Rdpdr::new(Box::new(NoopRdpdrBackend), "test".to_owned());
+        let server_announce = VersionAndIdPdu {
+            version_major: 1,
+            version_minor: VERSION_MINOR_RDP51,
+            client_id: 0,
+            kind: VersionAndIdPduKind::ServerAnnounceRequest,
+        };
+
+        assert_eq!(
+            rdpdr
+                .handle_server_announce(server_announce.clone())
+                .expect("handle legacy server announce")
+                .len(),
+            2
+        );
+
+        let client_id = rdpdr.client_id.expect("generated client ID");
+        assert!(
+            rdpdr
+                .handle_client_id_confirm(VersionAndIdPdu {
+                    client_id: client_id.wrapping_add(1),
+                    kind: VersionAndIdPduKind::ServerClientIdConfirm,
+                    ..server_announce
+                })
+                .is_err()
+        );
+        assert!(
+            rdpdr
+                .handle_client_id_confirm(VersionAndIdPdu {
+                    client_id,
+                    kind: VersionAndIdPduKind::ServerClientIdConfirm,
+                    ..server_announce
+                })
+                .expect("confirm generated client ID")
+                .is_empty()
+        );
+    }
+}

--- a/crates/ironrdp-rdpdr/src/pdu/efs.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/efs.rs
@@ -996,10 +996,6 @@ impl Devices {
         self.push(DeviceAnnounceHeader::new_drive(device_id, name));
     }
 
-    pub(crate) fn contains_device(&self, device_id: u32) -> bool {
-        self.0.iter().any(|device| device.device_id == device_id)
-    }
-
     /// Announce a virtual printer device to the server.
     ///
     /// Uses sensible defaults for web-client / virtual-printer scenarios:
@@ -1100,10 +1096,6 @@ impl DeviceAnnounceHeader {
             preferred_dos_name: PreferredDosName::for_drive(&name),
             device_data: utf16le_with_nul(&name),
         }
-    }
-
-    pub(crate) fn device_id(&self) -> u32 {
-        self.device_id
     }
 
     /// Construct a printer announce with sensible defaults; see

--- a/crates/ironrdp-rdpdr/src/pdu/efs.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/efs.rs
@@ -17,7 +17,7 @@ use tracing::error;
 use super::esc::rpce;
 use super::{PacketId, SharedHeader};
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum VersionAndIdPduKind {
     /// [2.2.2.2] Server Announce Request (DR_CORE_SERVER_ANNOUNCE_REQ)
     ///
@@ -59,9 +59,21 @@ impl VersionAndIdPdu {
     const FIXED_PART_SIZE: usize = (size_of::<u16>() * 2) + size_of::<u32>();
 
     pub fn new_client_announce_reply(req: VersionAndIdPdu) -> DecodeResult<Self> {
+        let legacy_client_id = req.client_id;
+        Self::new_client_announce_reply_with_legacy_client_id(req, legacy_client_id)
+    }
+
+    /// Creates a client announce reply with an ID for pre-version-12 servers.
+    ///
+    /// MS-RDPEFS requires the client to generate a new, unique client ID when
+    /// the server announces a minor version before 12.
+    pub fn new_client_announce_reply_with_legacy_client_id(
+        req: VersionAndIdPdu,
+        legacy_client_id: u32,
+    ) -> DecodeResult<Self> {
         if req.kind != VersionAndIdPduKind::ServerAnnounceRequest {
             return Err(invalid_field_err!(
-                "VersionAndIdPdu::new_client_announce_reply",
+                "VersionAndIdPdu::new_client_announce_reply_with_legacy_client_id",
                 "VersionAndIdPduKind",
                 "invalid value"
             ));
@@ -69,8 +81,12 @@ impl VersionAndIdPdu {
 
         Ok(Self {
             version_major: VERSION_MAJOR,
-            version_minor: VERSION_MINOR_12,
-            client_id: req.client_id,
+            version_minor: VERSION_MINOR_13,
+            client_id: if req.version_minor < VERSION_MINOR_12 {
+                legacy_client_id
+            } else {
+                req.client_id
+            },
             kind: VersionAndIdPduKind::ClientAnnounceReply,
         })
     }
@@ -346,6 +362,16 @@ impl Capabilities {
         self.push(CapabilityMessage::new_drive());
     }
 
+    pub fn add_drive_security(&mut self) {
+        for capability in self.0.iter_mut() {
+            if let CapabilityData::General(general) = &mut capability.capability_data {
+                general.io_code_1.insert(IoCode1::RDPDR_IRP_MJ_QUERY_SECURITY);
+                general.io_code_1.insert(IoCode1::RDPDR_IRP_MJ_SET_SECURITY);
+                break;
+            }
+        }
+    }
+
     pub fn add_printer(&mut self) {
         self.push(CapabilityMessage::new_printer());
     }
@@ -404,7 +430,7 @@ impl CapabilityMessage {
                 os_type: 0,
                 os_version: 0,
                 protocol_major_version: 1,
-                protocol_minor_version: VERSION_MINOR_12,
+                protocol_minor_version: VERSION_MINOR_13,
                 io_code_1: IoCode1::REQUIRED,
                 io_code_2: 0,
                 extended_pdu: ExtendedPdu::RDPDR_DEVICE_REMOVE_PDUS
@@ -455,6 +481,14 @@ impl CapabilityMessage {
 
     fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
         let header = CapabilityHeader::decode(src)?;
+        let expected_length = CapabilityHeader::SIZE + header.data_size()?;
+        if usize::from(header.length) != expected_length {
+            return Err(invalid_field_err!(
+                "CapabilityMessage::decode",
+                "CapabilityLength",
+                "does not match the capability type and version"
+            ));
+        }
         let capability_data = CapabilityData::decode(src, &header)?;
 
         Ok(Self {
@@ -533,6 +567,13 @@ impl CapabilityHeader {
         dst.write_u32(self.version);
         Ok(())
     }
+
+    fn data_size(&self) -> DecodeResult<usize> {
+        match self.cap_type {
+            CapabilityType::General => GeneralCapabilitySet::size_for_version(self.version),
+            CapabilityType::Printer | CapabilityType::Port | CapabilityType::Drive | CapabilityType::Smartcard => Ok(0),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Copy)]
@@ -560,6 +601,8 @@ impl From<CapabilityType> for u16 {
     }
 }
 
+/// GENERAL_CAPABILITY_VERSION_01
+pub const GENERAL_CAPABILITY_VERSION_01: u32 = 0x0000_0001;
 /// GENERAL_CAPABILITY_VERSION_02
 pub const GENERAL_CAPABILITY_VERSION_02: u32 = 0x0000_0002;
 /// SMARTCARD_CAPABILITY_VERSION_01
@@ -690,6 +733,7 @@ struct GeneralCapabilitySet {
 impl GeneralCapabilitySet {
     #[expect(clippy::manual_bits)]
     const SIZE: usize = size_of::<u32>() * 8 + size_of::<u16>() * 2;
+    const VERSION_01_SIZE: usize = Self::SIZE - size_of::<u32>();
 
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         ensure_size!(in: dst, size: Self::SIZE);
@@ -707,7 +751,7 @@ impl GeneralCapabilitySet {
     }
 
     fn decode(src: &mut ReadCursor<'_>, version: u32) -> DecodeResult<Self> {
-        ensure_size!(in: src, size: Self::SIZE);
+        ensure_size!(in: src, size: Self::size_for_version(version)?);
         let os_type = src.read_u32();
         let os_version = src.read_u32();
         let protocol_major_version = src.read_u16();
@@ -735,6 +779,18 @@ impl GeneralCapabilitySet {
             extra_flags_2,
             special_type_device_cap,
         })
+    }
+
+    fn size_for_version(version: u32) -> DecodeResult<usize> {
+        match version {
+            GENERAL_CAPABILITY_VERSION_01 => Ok(Self::VERSION_01_SIZE),
+            GENERAL_CAPABILITY_VERSION_02 => Ok(Self::SIZE),
+            _ => Err(invalid_field_err!(
+                "GeneralCapabilitySet::decode",
+                "Version",
+                "invalid value"
+            )),
+        }
     }
 }
 
@@ -831,14 +887,14 @@ bitflags! {
 
 /// From VersionMinor in [Server Client ID Confirm (section 2.2.2.6)], [2.2.2.3 Client Announce Reply (DR_CORE_CLIENT_ANNOUNCE_RSP)]
 ///
-/// VERSION_MINOR_12 is what Teleport has successfully been using.
-/// There is a version 13 as well, but it's not clear to me what
-/// the difference is.
+/// VERSION_MINOR_13 enables the all-ones write-offset append sentinel defined
+/// in MS-RDPEFS section 2.2.1.4.4.
 ///
 /// [Server Client ID Confirm (section 2.2.2.6)]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/bbbb9666-6994-4cf6-8e65-0d46eb319c6e
 /// [2.2.2.3]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/d6fe6d1b-c145-4a6f-99aa-4fe3cdcea398
 pub const VERSION_MINOR_RDP51: u16 = 0x0005;
 pub const VERSION_MINOR_12: u16 = 0x000C;
+pub const VERSION_MINOR_13: u16 = 0x000D;
 pub const VERSION_MAJOR: u16 = 0x0001;
 
 /// [2.2.2.9] Client Device List Announce Request (DR_CORE_DEVICELIST_ANNOUNCE_REQ)
@@ -940,6 +996,10 @@ impl Devices {
         self.push(DeviceAnnounceHeader::new_drive(device_id, name));
     }
 
+    pub(crate) fn contains_device(&self, device_id: u32) -> bool {
+        self.0.iter().any(|device| device.device_id == device_id)
+    }
+
     /// Announce a virtual printer device to the server.
     ///
     /// Uses sensible defaults for web-client / virtual-printer scenarios:
@@ -1031,22 +1091,19 @@ impl DeviceAnnounceHeader {
     }
 
     fn new_drive(device_id: u32, name: String) -> Self {
-        // The spec says Unicode but empirically this wants null terminated UTF-8.
-        let mut device_data = name.into_bytes();
-        device_data.push(0u8);
-
         Self {
             device_type: DeviceType::Filesystem,
             device_id,
-            // "The drive name MUST be specified in the PreferredDosName field; however, if the drive name is larger than the allocated size of the PreferredDosName field,
-            // then the drive name MUST be truncated to fit. If the client supports DRIVE_CAPABILITY_VERSION_02 in the Drive Capability Set, then the full name MUST also
-            // be specified in the DeviceData field, as a null-terminated Unicode string. If the DeviceDataLength field is nonzero, the content of the PreferredDosName field
-            // is ignored."
-            //
-            // Since we do support DRIVE_CAPABILITY_VERSION_02, we'll put the full name in the DeviceData field.
-            preferred_dos_name: PreferredDosName("ignored".to_owned()),
-            device_data,
+            // With DRIVE_CAPABILITY_VERSION_02, DeviceData contains the complete
+            // null-terminated Unicode name. The field remains mandatory even
+            // though the server ignores it when DeviceDataLength is nonzero.
+            preferred_dos_name: PreferredDosName::for_drive(&name),
+            device_data: utf16le_with_nul(&name),
         }
+    }
+
+    pub(crate) fn device_id(&self) -> u32 {
+        self.device_id
     }
 
     /// Construct a printer announce with sensible defaults; see
@@ -1149,7 +1206,7 @@ impl DeviceAnnounceHeader {
         device_data.extend_from_slice(&driver_name_bytes);
         device_data.extend_from_slice(&print_name_bytes);
 
-        return Self {
+        Self {
             device_type: DeviceType::Print,
             device_id,
             // Per spec: when DeviceDataLength is non-zero PreferredDosName
@@ -1159,15 +1216,6 @@ impl DeviceAnnounceHeader {
             // redirected printer.
             preferred_dos_name: PreferredDosName("PRN1".to_owned()),
             device_data,
-        };
-
-        fn utf16le_with_nul(s: &str) -> Vec<u8> {
-            let mut out = Vec::with_capacity((s.len() + 1) * 2 /* 2 bytes per UTF-16 unit */);
-            for unit in s.encode_utf16() {
-                out.extend_from_slice(&unit.to_le_bytes());
-            }
-            out.extend_from_slice(&[0, 0] /* UTF-16 NUL terminator */);
-            out
         }
     }
 
@@ -1193,6 +1241,15 @@ impl DeviceAnnounceHeader {
     }
 }
 
+fn utf16le_with_nul(s: &str) -> Vec<u8> {
+    let mut out = Vec::with_capacity((s.len() + 1) * 2 /* 2 bytes per UTF-16 unit */);
+    for unit in s.encode_utf16() {
+        out.extend_from_slice(&unit.to_le_bytes());
+    }
+    out.extend_from_slice(&[0, 0] /* UTF-16 NUL terminator */);
+    out
+}
+
 /// From ["PreferredDosName"](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/32e34332-774b-4ead-8c9d-5d64720d6bf9):
 ///
 /// PreferredDosName (8 bytes): A string of ASCII characters (with a maximum length of eight characters) that represents the name of the device as it appears on the client. This field MUST be null-terminated, so the maximum device name is 7 characters long. The following characters are considered invalid for the PreferredDosName field:
@@ -1208,6 +1265,30 @@ impl DeviceAnnounceHeader {
 struct PreferredDosName(String);
 
 impl PreferredDosName {
+    fn for_drive(name: &str) -> Self {
+        let mut preferred = String::with_capacity(7);
+        for ch in name.chars() {
+            if ch.is_ascii_alphanumeric() || matches!(ch, ' ' | '_' | '-' | '.') {
+                preferred.push(ch);
+            } else if ch == ':' && preferred.len() < 7 {
+                preferred.push(ch);
+                break;
+            } else {
+                break;
+            }
+
+            if preferred.len() == 7 {
+                break;
+            }
+        }
+
+        if preferred.is_empty() {
+            preferred.push_str("DRIVE");
+        }
+
+        Self(preferred)
+    }
+
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         write_string_to_cursor(dst, &self.format(), CharacterSet::Ansi, false)
     }
@@ -1317,12 +1398,20 @@ impl NtStatus {
     pub const UNSUCCESSFUL: Self = Self(0xC000_0001);
     /// STATUS_NOT_IMPLEMENTED
     pub const NOT_IMPLEMENTED: Self = Self(0xC000_0002);
+    /// STATUS_INVALID_DEVICE_REQUEST
+    pub const INVALID_DEVICE_REQUEST: Self = Self(0xC000_0010);
     /// STATUS_NO_MORE_FILES
     pub const NO_MORE_FILES: Self = Self(0x8000_0006);
     /// STATUS_OBJECT_NAME_COLLISION
     pub const OBJECT_NAME_COLLISION: Self = Self(0xC000_0035);
     /// STATUS_ACCESS_DENIED
     pub const ACCESS_DENIED: Self = Self(0xC000_0022);
+    /// STATUS_BUFFER_TOO_SMALL
+    pub const BUFFER_TOO_SMALL: Self = Self(0xC000_0023);
+    /// STATUS_BUFFER_OVERFLOW
+    pub const BUFFER_OVERFLOW: Self = Self(0x8000_0005);
+    /// STATUS_PRIVILEGE_NOT_HELD
+    pub const PRIVILEGE_NOT_HELD: Self = Self(0xC000_0061);
     /// STATUS_NOT_A_DIRECTORY
     pub const NOT_A_DIRECTORY: Self = Self(0xC000_0103);
     /// STATUS_NO_SUCH_FILE
@@ -1331,6 +1420,30 @@ impl NtStatus {
     pub const NOT_SUPPORTED: Self = Self(0xC000_00BB);
     /// STATUS_DIRECTORY_NOT_EMPTY
     pub const DIRECTORY_NOT_EMPTY: Self = Self(0xC000_0101);
+    /// STATUS_INVALID_HANDLE
+    pub const INVALID_HANDLE: Self = Self(0xC000_0008);
+    /// STATUS_INVALID_PARAMETER
+    pub const INVALID_PARAMETER: Self = Self(0xC000_000D);
+    /// STATUS_END_OF_FILE
+    pub const END_OF_FILE: Self = Self(0xC000_0011);
+    /// STATUS_OBJECT_NAME_INVALID
+    pub const OBJECT_NAME_INVALID: Self = Self(0xC000_0033);
+    /// STATUS_OBJECT_PATH_NOT_FOUND
+    pub const OBJECT_PATH_NOT_FOUND: Self = Self(0xC000_003A);
+    /// STATUS_SHARING_VIOLATION
+    pub const SHARING_VIOLATION: Self = Self(0xC000_0043);
+    /// STATUS_LOCK_NOT_GRANTED
+    pub const LOCK_NOT_GRANTED: Self = Self(0xC000_0055);
+    /// STATUS_DISK_FULL
+    pub const DISK_FULL: Self = Self(0xC000_007F);
+    /// STATUS_FILE_IS_A_DIRECTORY
+    pub const FILE_IS_A_DIRECTORY: Self = Self(0xC000_00BA);
+    /// STATUS_CANCELLED
+    pub const CANCELLED: Self = Self(0xC000_0120);
+    /// STATUS_DELETE_PENDING
+    pub const DELETE_PENDING: Self = Self(0xC000_0056);
+    /// STATUS_MEDIA_WRITE_PROTECTED
+    pub const MEDIA_WRITE_PROTECTED: Self = Self(0xC000_00A2);
 }
 
 impl Debug for NtStatus {
@@ -1339,13 +1452,29 @@ impl Debug for NtStatus {
             NtStatus::SUCCESS => write!(f, "STATUS_SUCCESS"),
             NtStatus::UNSUCCESSFUL => write!(f, "STATUS_UNSUCCESSFUL"),
             NtStatus::NOT_IMPLEMENTED => write!(f, "STATUS_NOT_IMPLEMENTED"),
+            NtStatus::INVALID_DEVICE_REQUEST => write!(f, "STATUS_INVALID_DEVICE_REQUEST"),
             NtStatus::NO_MORE_FILES => write!(f, "STATUS_NO_MORE_FILES"),
             NtStatus::OBJECT_NAME_COLLISION => write!(f, "STATUS_OBJECT_NAME_COLLISION"),
             NtStatus::ACCESS_DENIED => write!(f, "STATUS_ACCESS_DENIED"),
+            NtStatus::BUFFER_TOO_SMALL => write!(f, "STATUS_BUFFER_TOO_SMALL"),
+            NtStatus::BUFFER_OVERFLOW => write!(f, "STATUS_BUFFER_OVERFLOW"),
+            NtStatus::PRIVILEGE_NOT_HELD => write!(f, "STATUS_PRIVILEGE_NOT_HELD"),
             NtStatus::NOT_A_DIRECTORY => write!(f, "STATUS_NOT_A_DIRECTORY"),
             NtStatus::NO_SUCH_FILE => write!(f, "STATUS_NO_SUCH_FILE"),
             NtStatus::NOT_SUPPORTED => write!(f, "STATUS_NOT_SUPPORTED"),
             NtStatus::DIRECTORY_NOT_EMPTY => write!(f, "STATUS_DIRECTORY_NOT_EMPTY"),
+            NtStatus::INVALID_HANDLE => write!(f, "STATUS_INVALID_HANDLE"),
+            NtStatus::INVALID_PARAMETER => write!(f, "STATUS_INVALID_PARAMETER"),
+            NtStatus::END_OF_FILE => write!(f, "STATUS_END_OF_FILE"),
+            NtStatus::OBJECT_NAME_INVALID => write!(f, "STATUS_OBJECT_NAME_INVALID"),
+            NtStatus::OBJECT_PATH_NOT_FOUND => write!(f, "STATUS_OBJECT_PATH_NOT_FOUND"),
+            NtStatus::SHARING_VIOLATION => write!(f, "STATUS_SHARING_VIOLATION"),
+            NtStatus::LOCK_NOT_GRANTED => write!(f, "STATUS_LOCK_NOT_GRANTED"),
+            NtStatus::DISK_FULL => write!(f, "STATUS_DISK_FULL"),
+            NtStatus::FILE_IS_A_DIRECTORY => write!(f, "STATUS_FILE_IS_A_DIRECTORY"),
+            NtStatus::CANCELLED => write!(f, "STATUS_CANCELLED"),
+            NtStatus::DELETE_PENDING => write!(f, "STATUS_DELETE_PENDING"),
+            NtStatus::MEDIA_WRITE_PROTECTED => write!(f, "STATUS_MEDIA_WRITE_PROTECTED"),
             _ => write!(f, "NtStatus({:#010X})", self.0),
         }
     }
@@ -1416,7 +1545,7 @@ impl DeviceIoRequest {
 }
 
 /// See [`DeviceIoRequest`].
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[repr(u32)]
 pub enum MajorFunction {
     /// IRP_MJ_CREATE
@@ -1427,6 +1556,8 @@ pub enum MajorFunction {
     Read = 0x0000_0003,
     /// IRP_MJ_WRITE
     Write = 0x0000_0004,
+    /// IRP_MJ_FLUSH_BUFFERS
+    FlushBuffers = 0x0000_0009,
     /// IRP_MJ_DEVICE_CONTROL
     DeviceControl = 0x0000_000e,
     /// IRP_MJ_QUERY_VOLUME_INFORMATION
@@ -1441,6 +1572,10 @@ pub enum MajorFunction {
     DirectoryControl = 0x0000_000c,
     /// IRP_MJ_LOCK_CONTROL
     LockControl = 0x0000_0011,
+    /// IRP_MJ_QUERY_SECURITY
+    QuerySecurity = 0x0000_0014,
+    /// IRP_MJ_SET_SECURITY
+    SetSecurity = 0x0000_0015,
 }
 
 impl TryFrom<u32> for MajorFunction {
@@ -1452,6 +1587,7 @@ impl TryFrom<u32> for MajorFunction {
             0x0000_0002 => Ok(MajorFunction::Close),
             0x0000_0003 => Ok(MajorFunction::Read),
             0x0000_0004 => Ok(MajorFunction::Write),
+            0x0000_0009 => Ok(MajorFunction::FlushBuffers),
             0x0000_000e => Ok(MajorFunction::DeviceControl),
             0x0000_000a => Ok(MajorFunction::QueryVolumeInformation),
             0x0000_000b => Ok(MajorFunction::SetVolumeInformation),
@@ -1459,6 +1595,8 @@ impl TryFrom<u32> for MajorFunction {
             0x0000_0006 => Ok(MajorFunction::SetInformation),
             0x0000_000c => Ok(MajorFunction::DirectoryControl),
             0x0000_0011 => Ok(MajorFunction::LockControl),
+            0x0000_0014 => Ok(MajorFunction::QuerySecurity),
+            0x0000_0015 => Ok(MajorFunction::SetSecurity),
             _ => Err(invalid_field_err!("try_from", "MajorFunction", "unsupported value")),
         }
     }
@@ -1522,6 +1660,17 @@ pub struct DeviceControlRequest<T: IoCtlCode> {
     pub io_control_code: T,
 }
 
+/// A decoded device-control request together with its opaque input payload.
+///
+/// This preserves the established [`DeviceControlRequest`] public struct shape
+/// for downstream source compatibility while letting consumers that need
+/// control data retain the exact bytes declared on the wire.
+#[derive(Debug, PartialEq, Clone)]
+pub struct DecodedDeviceControlRequest<T: IoCtlCode> {
+    pub request: DeviceControlRequest<T>,
+    pub input_buffer: Vec<u8>,
+}
+
 impl<T: IoCtlCode> DeviceControlRequest<T>
 where
     T::Error: ironrdp_error::Source,
@@ -1532,6 +1681,14 @@ where
         + 20; // Additional 20 bytes for padding
 
     pub fn decode(header: DeviceIoRequest, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        Ok(Self::decode_with_input_buffer(header, src)?.request)
+    }
+
+    /// Decodes a request and returns its exact opaque input buffer.
+    pub fn decode_with_input_buffer(
+        header: DeviceIoRequest,
+        src: &mut ReadCursor<'_>,
+    ) -> DecodeResult<DecodedDeviceControlRequest<T>> {
         ensure_size!(ctx: "DeviceControlRequest", in: src, size: Self::HEADERLESS_SIZE);
         let output_buffer_length = src.read_u32();
         let input_buffer_length = src.read_u32();
@@ -1542,12 +1699,19 @@ where
 
         // Padding (20 bytes): An array of 20 bytes. Reserved. This field can be set to any value and MUST be ignored.
         read_padding!(src, 20);
+        let input_buffer_size: usize =
+            cast_length!("DeviceControlRequest", "input_buffer_length", input_buffer_length)?;
+        ensure_size!(ctx: "DeviceControlRequest", in: src, size: input_buffer_size);
+        let input_buffer = src.read_slice(input_buffer_size).to_vec();
 
-        Ok(Self {
-            header,
-            output_buffer_length,
-            input_buffer_length,
-            io_control_code,
+        Ok(DecodedDeviceControlRequest {
+            request: Self {
+                header,
+                output_buffer_length,
+                input_buffer_length,
+                io_control_code,
+            },
+            input_buffer,
         })
     }
 }
@@ -1695,11 +1859,15 @@ pub enum ServerDriveIoRequest {
     ServerDriveQueryDirectoryRequest(ServerDriveQueryDirectoryRequest),
     ServerDriveNotifyChangeDirectoryRequest(ServerDriveNotifyChangeDirectoryRequest),
     ServerDriveQueryVolumeInformationRequest(ServerDriveQueryVolumeInformationRequest),
+    ServerDriveSetVolumeInformationRequest(ServerDriveSetVolumeInformationRequest),
     DeviceControlRequest(DeviceControlRequest<AnyIoCtlCode>),
     DeviceReadRequest(DeviceReadRequest),
     DeviceWriteRequest(DeviceWriteRequest),
+    DeviceFlushBuffersRequest(DeviceFlushBuffersRequest),
     ServerDriveSetInformationRequest(ServerDriveSetInformationRequest),
     ServerDriveLockControlRequest(ServerDriveLockControlRequest),
+    ServerDriveQuerySecurityRequest(ServerDriveQuerySecurityRequest),
+    ServerDriveSetSecurityRequest(ServerDriveSetSecurityRequest),
 }
 
 impl ServerDriveIoRequest {
@@ -1709,15 +1877,14 @@ impl ServerDriveIoRequest {
             MajorFunction::Close => Ok(DeviceCloseRequest::decode(dev_io_req).into()),
             MajorFunction::Read => Ok(DeviceReadRequest::decode(dev_io_req, src)?.into()),
             MajorFunction::Write => Ok(DeviceWriteRequest::decode(dev_io_req, src)?.into()),
+            MajorFunction::FlushBuffers => Ok(DeviceFlushBuffersRequest::decode(dev_io_req).into()),
             MajorFunction::DeviceControl => Ok(DeviceControlRequest::<AnyIoCtlCode>::decode(dev_io_req, src)?.into()),
             MajorFunction::QueryVolumeInformation => {
                 Ok(ServerDriveQueryVolumeInformationRequest::decode(dev_io_req, src)?.into())
             }
-            MajorFunction::SetVolumeInformation => Err(unsupported_value_err!(
-                "ServerDriveIoRequest::decode",
-                "MajorFunction",
-                "SetVolumeInformation".to_owned()
-            )), // FreeRDP doesn't implement this
+            MajorFunction::SetVolumeInformation => {
+                Ok(ServerDriveSetVolumeInformationRequest::decode(dev_io_req, src)?.into())
+            }
             MajorFunction::QueryInformation => Ok(ServerDriveQueryInformationRequest::decode(dev_io_req, src)?.into()),
             MajorFunction::SetInformation => Ok(ServerDriveSetInformationRequest::decode(dev_io_req, src)?.into()),
             MajorFunction::DirectoryControl => match dev_io_req.minor_function {
@@ -1735,6 +1902,8 @@ impl ServerDriveIoRequest {
                 )),
             },
             MajorFunction::LockControl => Ok(ServerDriveLockControlRequest::decode(dev_io_req, src)?.into()),
+            MajorFunction::QuerySecurity => Ok(ServerDriveQuerySecurityRequest::decode(dev_io_req, src)?.into()),
+            MajorFunction::SetSecurity => Ok(ServerDriveSetSecurityRequest::decode(dev_io_req, src)?.into()),
         }
     }
 }
@@ -1775,6 +1944,12 @@ impl From<ServerDriveQueryVolumeInformationRequest> for ServerDriveIoRequest {
     }
 }
 
+impl From<ServerDriveSetVolumeInformationRequest> for ServerDriveIoRequest {
+    fn from(req: ServerDriveSetVolumeInformationRequest) -> Self {
+        Self::ServerDriveSetVolumeInformationRequest(req)
+    }
+}
+
 impl From<DeviceControlRequest<AnyIoCtlCode>> for ServerDriveIoRequest {
     fn from(req: DeviceControlRequest<AnyIoCtlCode>) -> Self {
         Self::DeviceControlRequest(req)
@@ -1793,6 +1968,12 @@ impl From<DeviceWriteRequest> for ServerDriveIoRequest {
     }
 }
 
+impl From<DeviceFlushBuffersRequest> for ServerDriveIoRequest {
+    fn from(req: DeviceFlushBuffersRequest) -> Self {
+        Self::DeviceFlushBuffersRequest(req)
+    }
+}
+
 impl From<ServerDriveSetInformationRequest> for ServerDriveIoRequest {
     fn from(req: ServerDriveSetInformationRequest) -> Self {
         Self::ServerDriveSetInformationRequest(req)
@@ -1802,6 +1983,18 @@ impl From<ServerDriveSetInformationRequest> for ServerDriveIoRequest {
 impl From<ServerDriveLockControlRequest> for ServerDriveIoRequest {
     fn from(req: ServerDriveLockControlRequest) -> Self {
         Self::ServerDriveLockControlRequest(req)
+    }
+}
+
+impl From<ServerDriveQuerySecurityRequest> for ServerDriveIoRequest {
+    fn from(req: ServerDriveQuerySecurityRequest) -> Self {
+        Self::ServerDriveQuerySecurityRequest(req)
+    }
+}
+
+impl From<ServerDriveSetSecurityRequest> for ServerDriveIoRequest {
+    fn from(req: ServerDriveSetSecurityRequest) -> Self {
+        Self::ServerDriveSetSecurityRequest(req)
     }
 }
 
@@ -2119,10 +2312,34 @@ bitflags! {
         const FILE_SUPERSEDED = 0x00000000;
         /// An existing file was opened.
         const FILE_OPENED = 0x00000001;
+        /// A new file was created.
+        const FILE_CREATED = 0x00000002;
         /// An existing file was overwritten.
         const FILE_OVERWRITTEN = 0x00000003;
 
         const _ = !0;
+    }
+}
+
+impl Information {
+    /// FILE_SUPERSEDED
+    pub fn file_superseded() -> Self {
+        Self::FILE_SUPERSEDED
+    }
+
+    /// FILE_OPENED
+    pub fn file_opened() -> Self {
+        Self::FILE_OPENED
+    }
+
+    /// FILE_CREATED
+    pub fn file_created() -> Self {
+        Self::FILE_CREATED
+    }
+
+    /// FILE_OVERWRITTEN
+    pub fn file_overwritten() -> Self {
+        Self::FILE_OVERWRITTEN
     }
 }
 
@@ -2179,6 +2396,8 @@ impl FileInformationClassLevel {
     pub const FILE_RENAME_INFORMATION: Self = Self(10);
     /// FileAllocationInformation
     pub const FILE_ALLOCATION_INFORMATION: Self = Self(19);
+    /// FileStreamInformation
+    pub const FILE_STREAM_INFORMATION: Self = Self(22);
 }
 
 impl Display for FileInformationClassLevel {
@@ -2195,6 +2414,7 @@ impl Display for FileInformationClassLevel {
             FileInformationClassLevel::FILE_DISPOSITION_INFORMATION => write!(f, "FileDispositionInformation"),
             FileInformationClassLevel::FILE_RENAME_INFORMATION => write!(f, "FileRenameInformation"),
             FileInformationClassLevel::FILE_ALLOCATION_INFORMATION => write!(f, "FileAllocationInformation"),
+            FileInformationClassLevel::FILE_STREAM_INFORMATION => write!(f, "FileStreamInformation"),
             _ => write!(f, "FileInformationClassLevel({})", self.0),
         }
     }
@@ -2209,6 +2429,7 @@ impl Debug for FileInformationClassLevel {
             FileInformationClassLevel::FILE_DIRECTORY_INFORMATION => write!(f, "FileDirectoryInformation"),
             FileInformationClassLevel::FILE_FULL_DIRECTORY_INFORMATION => write!(f, "FileFullDirectoryInformation"),
             FileInformationClassLevel::FILE_BOTH_DIRECTORY_INFORMATION => write!(f, "FileBothDirectoryInformation"),
+            FileInformationClassLevel::FILE_STREAM_INFORMATION => write!(f, "FileStreamInformation"),
             FileInformationClassLevel::FILE_NAMES_INFORMATION => write!(f, "FileNamesInformation"),
             _ => write!(f, "FileInformationClassLevel({})", self.0),
         }
@@ -2224,6 +2445,42 @@ impl From<u32> for FileInformationClassLevel {
 impl From<FileInformationClassLevel> for u32 {
     fn from(file_info_class_lvl: FileInformationClassLevel) -> Self {
         file_info_class_lvl.0
+    }
+}
+
+/// [2.2.3.4.7] Client Drive Set Volume Information Response (DR_DRIVE_SET_VOLUME_INFORMATION_RSP)
+///
+/// [2.2.3.4.7]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/e0e57e87-5e7e-4ae6-9f66-4e0a64e2b5d1
+#[derive(Debug, PartialEq, Clone)]
+pub struct ClientDriveSetVolumeInformationResponse {
+    pub device_io_reply: DeviceIoResponse,
+    pub length: u32,
+}
+
+impl ClientDriveSetVolumeInformationResponse {
+    const NAME: &'static str = "DR_DRIVE_SET_VOLUME_INFORMATION_RSP";
+
+    pub fn new(req: ServerDriveSetVolumeInformationRequest, io_status: NtStatus) -> Self {
+        Self {
+            device_io_reply: DeviceIoResponse::new(req.device_io_request, io_status),
+            length: req.set_volume_buffer_length,
+        }
+    }
+
+    pub fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    pub fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        self.device_io_reply.encode(dst)?;
+        dst.write_u32(self.length);
+        Ok(())
+    }
+
+    pub fn size(&self) -> usize {
+        self.device_io_reply.size() // DeviceIoResponse
+        + 4 // Length
     }
 }
 
@@ -2272,6 +2529,174 @@ impl ClientDriveQueryInformationResponse {
     }
 }
 
+/// [2.2.3.3] Query Security request extension (IRP_MJ_QUERY_SECURITY).
+///
+/// The native `mstscax.dll` handler consumes only the security-information
+/// mask. Any trailing bytes are ignored rather than treated as a length-bound
+/// response buffer.
+#[derive(Debug, PartialEq, Clone)]
+pub struct ServerDriveQuerySecurityRequest {
+    pub device_io_request: DeviceIoRequest,
+    pub security_information: SecurityInformation,
+}
+
+impl ServerDriveQuerySecurityRequest {
+    const FIXED_PART_SIZE: usize = 4; // SecurityInformation
+
+    fn decode(dev_io_req: DeviceIoRequest, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(ctx: "ServerDriveQuerySecurityRequest", in: src, size: Self::FIXED_PART_SIZE);
+        let security_information = SecurityInformation::from_bits_retain(src.read_u32());
+
+        Ok(Self {
+            device_io_request: dev_io_req,
+            security_information,
+        })
+    }
+}
+
+bitflags! {
+    /// Security information mask shared by Query Security and Set Security IRPs.
+    ///
+    /// The Windows object-security flags are kept as bit flags rather than an
+    /// enum: protection and inheritance bits are meaningful alongside owner,
+    /// group, DACL, and SACL selection bits.
+    #[derive(Debug, PartialEq, Clone, Copy)]
+    pub struct SecurityInformation: u32 {
+        /// OWNER_SECURITY_INFORMATION
+        const OWNER = 0x0000_0001;
+        /// GROUP_SECURITY_INFORMATION
+        const GROUP = 0x0000_0002;
+        /// DACL_SECURITY_INFORMATION
+        const DACL = 0x0000_0004;
+        /// SACL_SECURITY_INFORMATION
+        const SACL = 0x0000_0008;
+        /// LABEL_SECURITY_INFORMATION
+        const LABEL = 0x0000_0010;
+        /// ATTRIBUTE_SECURITY_INFORMATION
+        const ATTRIBUTE = 0x0000_0020;
+        /// SCOPE_SECURITY_INFORMATION
+        const SCOPE = 0x0000_0040;
+        /// PROCESS_TRUST_LABEL_SECURITY_INFORMATION
+        const PROCESS_TRUST_LABEL = 0x0000_0080;
+        /// BACKUP_SECURITY_INFORMATION
+        const BACKUP = 0x0001_0000;
+        /// UNPROTECTED_SACL_SECURITY_INFORMATION
+        const UNPROTECTED_SACL = 0x1000_0000;
+        /// UNPROTECTED_DACL_SECURITY_INFORMATION
+        const UNPROTECTED_DACL = 0x2000_0000;
+        /// PROTECTED_SACL_SECURITY_INFORMATION
+        const PROTECTED_SACL = 0x4000_0000;
+        /// PROTECTED_DACL_SECURITY_INFORMATION
+        const PROTECTED_DACL = 0x8000_0000;
+
+        const _ = !0;
+    }
+}
+
+/// Query Security response carrying a self-relative security descriptor.
+#[derive(Debug, PartialEq, Clone)]
+pub struct ClientDriveQuerySecurityResponse {
+    pub device_io_response: DeviceIoResponse,
+    /// This field is omitted for unsuccessful requests.
+    pub security_descriptor: Option<Vec<u8>>,
+}
+
+impl ClientDriveQuerySecurityResponse {
+    const NAME: &'static str = "DR_DRIVE_QUERY_SECURITY_RSP";
+
+    pub fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    pub fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        self.device_io_response.encode(dst)?;
+        let security_descriptor = self.security_descriptor.as_deref().unwrap_or_default();
+        dst.write_u32(cast_length!(
+            "ClientDriveQuerySecurityResponse",
+            "security_descriptor.len()",
+            security_descriptor.len()
+        )?);
+        dst.write_slice(security_descriptor);
+        Ok(())
+    }
+
+    pub fn size(&self) -> usize {
+        self.device_io_response.size() // DeviceIoResponse
+            + 4 // Length
+            + self.security_descriptor.as_ref().map_or(0, Vec::len) // SecurityDescriptor
+    }
+}
+
+/// [2.2.3.3] Set Security request extension (IRP_MJ_SET_SECURITY).
+#[derive(Debug, PartialEq, Clone)]
+pub struct ServerDriveSetSecurityRequest {
+    pub device_io_request: DeviceIoRequest,
+    pub security_information: SecurityInformation,
+    pub security_descriptor: Vec<u8>,
+}
+
+impl ServerDriveSetSecurityRequest {
+    const FIXED_PART_SIZE: usize = 4 /* SecurityInformation */ + 4 /* Length */ + 24 /* Padding */;
+
+    fn decode(dev_io_req: DeviceIoRequest, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(
+            ctx: "ServerDriveSetSecurityRequest",
+            in: src,
+            size: Self::FIXED_PART_SIZE
+        );
+        let security_information = SecurityInformation::from_bits_retain(src.read_u32());
+        let length = cast_length!("ServerDriveSetSecurityRequest", "length", src.read_u32())?;
+        read_padding!(src, 24); // Padding
+        ensure_size!(ctx: "ServerDriveSetSecurityRequest", in: src, size: length);
+        let security_descriptor = src.read_slice(length).to_vec();
+
+        Ok(Self {
+            device_io_request: dev_io_req,
+            security_information,
+            security_descriptor,
+        })
+    }
+}
+
+/// Set Security completion.
+#[derive(Debug, PartialEq, Clone)]
+pub struct ClientDriveSetSecurityResponse {
+    pub device_io_response: DeviceIoResponse,
+    pub length: u32,
+}
+
+impl ClientDriveSetSecurityResponse {
+    const NAME: &'static str = "DR_DRIVE_SET_SECURITY_RSP";
+
+    pub fn new(req: &ServerDriveSetSecurityRequest, io_status: NtStatus) -> EncodeResult<Self> {
+        Ok(Self {
+            device_io_response: DeviceIoResponse::new(req.device_io_request.clone(), io_status),
+            length: cast_length!(
+                "ClientDriveSetSecurityResponse",
+                "security_descriptor.len()",
+                req.security_descriptor.len()
+            )?,
+        })
+    }
+
+    pub fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    pub fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        self.device_io_response.encode(dst)?;
+        dst.write_u32(self.length);
+        Ok(())
+    }
+
+    pub fn size(&self) -> usize {
+        self.device_io_response.size() // DeviceIoResponse
+            + 4 // Length
+    }
+}
+
 /// [2.4] File Information Classes \[MS-FSCC\]
 ///
 /// [2.4]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/4718fc40-e539-4014-8e33-b675af74e3e1
@@ -2288,6 +2713,7 @@ pub enum FileInformationClass {
     Disposition(FileDispositionInformation),
     Rename(FileRenameInformation),
     Allocation(FileAllocationInformation),
+    Stream(FileStreamInformation),
 }
 
 impl FileInformationClass {
@@ -2301,6 +2727,7 @@ impl FileInformationClass {
             Self::FullDirectory(f) => f.encode(dst),
             Self::Names(f) => f.encode(dst),
             Self::Directory(f) => f.encode(dst),
+            Self::Stream(f) => f.encode(dst),
             _ => Err(unsupported_value_err!(
                 "FileInformationClass::encode",
                 "FileInformationClass",
@@ -2347,6 +2774,7 @@ impl FileInformationClass {
             Self::Disposition(_) => FileDispositionInformation::size(),
             Self::Rename(f) => f.size(),
             Self::Allocation(_) => FileAllocationInformation::size(),
+            Self::Stream(f) => f.size(),
         }
     }
 }
@@ -2365,6 +2793,7 @@ impl Display for FileInformationClass {
             Self::Disposition(_) => write!(f, "FileDispositionInformation"),
             Self::Rename(_) => write!(f, "FileRenameInformation"),
             Self::Allocation(_) => write!(f, "FileAllocationInformation"),
+            Self::Stream(_) => write!(f, "FileStreamInformation"),
         }
     }
 }
@@ -2432,6 +2861,46 @@ impl From<FileRenameInformation> for FileInformationClass {
 impl From<FileAllocationInformation> for FileInformationClass {
     fn from(f: FileAllocationInformation) -> Self {
         Self::Allocation(f)
+    }
+}
+
+impl From<FileStreamInformation> for FileInformationClass {
+    fn from(f: FileStreamInformation) -> Self {
+        Self::Stream(f)
+    }
+}
+
+/// [2.4.49] FileStreamInformation [MS-FSCC].
+///
+/// `buffer` contains one or more native `FILE_STREAM_INFORMATION` elements.
+/// Each element carries a stream name, size, and allocation size. The Windows
+/// backend returns this opaque buffer directly from `NtQueryInformationFile`,
+/// preserving the required 8-byte alignment between entries.
+///
+/// [MS-FSCC]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc
+#[derive(Debug, PartialEq, Clone)]
+pub struct FileStreamInformation {
+    buffer: Vec<u8>,
+}
+
+impl FileStreamInformation {
+    /// Creates a response from a valid `FILE_STREAM_INFORMATION` buffer.
+    ///
+    /// The buffer is intentionally opaque because the RDPDR query-information
+    /// response has the same wire representation as the native Windows query.
+    /// Callers must supply entries encoded according to MS-FSCC section 2.4.49.
+    pub fn from_buffer(buffer: Vec<u8>) -> Self {
+        Self { buffer }
+    }
+
+    pub fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_slice(&self.buffer);
+        Ok(())
+    }
+
+    pub fn size(&self) -> usize {
+        self.buffer.len()
     }
 }
 
@@ -2886,6 +3355,48 @@ impl DeviceCloseRequest {
     }
 }
 
+/// [2.2.1.4] Device I/O Request (DR_DEVICE_IOREQUEST) for an `IRP_MJ_FLUSH_BUFFERS` operation.
+///
+/// Flush requests have no operation-specific payload beyond the shared Device I/O Request header.
+///
+/// [2.2.1.4]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/89bb51af-c54d-40fb-81c1-d1bb353c4536
+#[derive(Debug, PartialEq, Clone)]
+pub struct DeviceFlushBuffersRequest {
+    pub device_io_request: DeviceIoRequest,
+}
+
+impl DeviceFlushBuffersRequest {
+    pub fn decode(device_io_request: DeviceIoRequest) -> Self {
+        Self { device_io_request }
+    }
+}
+
+/// [2.2.1.5] Device I/O Response (DR_DEVICE_IOCOMPLETION) for an `IRP_MJ_FLUSH_BUFFERS` operation.
+///
+/// Flush responses have no operation-specific payload beyond the shared Device I/O Response header.
+///
+/// [2.2.1.5]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/1c412a84-0776-4984-b35c-3f0445fcae65
+#[derive(Debug, PartialEq, Clone)]
+pub struct DeviceFlushBuffersResponse {
+    pub device_io_response: DeviceIoResponse,
+}
+
+impl DeviceFlushBuffersResponse {
+    const NAME: &'static str = "DR_FLUSH_BUFFERS_RSP";
+
+    pub fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    pub fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        self.device_io_response.encode(dst)
+    }
+
+    pub fn size(&self) -> usize {
+        self.device_io_response.size()
+    }
+}
+
 /// [2.2.1.5.2] Device Close Response (DR_CLOSE_RSP)
 ///
 /// [2.2.1.5.2]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/0dae7031-cfd8-4f14-908c-ec06e14997b5
@@ -2954,7 +3465,14 @@ impl ServerDriveQueryDirectoryRequest {
         read_padding!(src, 23);
 
         ensure_size!(in: src, size: path_length);
-        let path = decode_string(src.read_slice(path_length), CharacterSet::Unicode, true)?;
+        let path = if initial_query == 0 {
+            // MS-RDPEFS explicitly ignores the continuation path, including its
+            // declared length and contents.
+            read_padding!(src, path_length);
+            String::new()
+        } else {
+            decode_string(src.read_slice(path_length), CharacterSet::Unicode, true)?
+        };
 
         Ok(Self {
             device_io_request,
@@ -3087,6 +3605,79 @@ impl ServerDriveQueryVolumeInformationRequest {
     }
 }
 
+/// [2.2.3.3.7] Server Drive Set Volume Information Request (DR_DRIVE_SET_VOLUME_INFORMATION_REQ)
+///
+/// [2.2.3.3.7]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/1bd714f0-2ca6-4651-97f2-778c22d5e36e
+#[derive(Debug, PartialEq, Clone)]
+pub struct ServerDriveSetVolumeInformationRequest {
+    pub device_io_request: DeviceIoRequest,
+    pub set_volume_buffer_length: u32,
+    /// Requested volume label decoded from `FileFsLabelInformation`.
+    ///
+    /// Native backends may reject relabeling according to their local security
+    /// policy, but retaining the value keeps the request fully decoded.
+    pub volume_label: String,
+}
+
+impl ServerDriveSetVolumeInformationRequest {
+    const FIXED_PART_SIZE: usize = 4 /* FsInformationClass */ + 4 /* Length */ + 24 /* Padding */;
+
+    fn decode(device_io_request: DeviceIoRequest, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+        let fs_info_class_lvl = FileSystemInformationClassLevel::from(src.read_u32());
+        if fs_info_class_lvl != FileSystemInformationClassLevel::FILE_FS_LABEL_INFORMATION {
+            return Err(invalid_field_err!(
+                "ServerDriveSetVolumeInformationRequest::decode",
+                "fs_info_class_lvl",
+                "received invalid level"
+            ));
+        }
+
+        let set_volume_buffer_length = src.read_u32();
+        read_padding!(src, 24);
+        let length = cast_length!(
+            "ServerDriveSetVolumeInformationRequest",
+            "set_volume_buffer_length",
+            set_volume_buffer_length
+        )?;
+        ensure_size!(in: src, size: length);
+        let buffer = src.read_slice(length);
+        if buffer.len() < 4 {
+            return Err(invalid_field_err!(
+                "ServerDriveSetVolumeInformationRequest::decode",
+                "set_volume_buffer_length",
+                "buffer is shorter than FileFsLabelInformation"
+            ));
+        }
+        let label_length = cast_length!(
+            "ServerDriveSetVolumeInformationRequest",
+            "volume_label_length",
+            u32::from_le_bytes(buffer[..4].try_into().expect("slice length was checked"))
+        )?;
+        let label_end = 4usize.checked_add(label_length).ok_or_else(|| {
+            invalid_field_err!(
+                "ServerDriveSetVolumeInformationRequest::decode",
+                "volume_label_length",
+                "too large"
+            )
+        })?;
+        if label_end > buffer.len() || label_length % 2 != 0 {
+            return Err(invalid_field_err!(
+                "ServerDriveSetVolumeInformationRequest::decode",
+                "volume_label_length",
+                "invalid label length"
+            ));
+        }
+        let volume_label = decode_string(&buffer[4..label_end], CharacterSet::Unicode, false)?;
+
+        Ok(Self {
+            device_io_request,
+            set_volume_buffer_length,
+            volume_label,
+        })
+    }
+}
+
 /// [2.5] File System Information Classes [MS-FSCC]
 ///
 /// [2.5] <https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/ee12042a-9352-46e3-9f67-c094b75fe6c3>
@@ -3197,8 +3788,6 @@ pub struct FileFsVolumeInformation {
     pub volume_creation_time: i64,
     pub volume_serial_number: u32,
     pub supports_objects: Boolean,
-    // reserved is omitted
-    // https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_main.c#L495
     pub volume_label: String,
 }
 
@@ -3213,6 +3802,8 @@ impl FileFsVolumeInformation {
             encoded_str_len(&self.volume_label, CharacterSet::Unicode, true)
         )?);
         dst.write_u8(self.supports_objects.into());
+        // MS-RDPEFS requires the FileFsVolumeInformation reserved byte to be
+        // omitted from the RDPDR query-volume response.
         write_string_to_cursor(dst, &self.volume_label, CharacterSet::Unicode, true)?;
         Ok(())
     }
@@ -3273,9 +3864,9 @@ impl FileFsAttributeInformation {
         dst.write_u32(cast_length!(
             "FileFsAttributeInformation::encode",
             "file_system_name_length",
-            encoded_str_len(&self.file_system_name, CharacterSet::Unicode, true)
+            encoded_str_len(&self.file_system_name, CharacterSet::Unicode, false)
         )?);
-        write_string_to_cursor(dst, &self.file_system_name, CharacterSet::Unicode, true)?;
+        write_string_to_cursor(dst, &self.file_system_name, CharacterSet::Unicode, false)?;
         Ok(())
     }
 
@@ -3283,7 +3874,7 @@ impl FileFsAttributeInformation {
         4 // FileSystemAttributes
         + 4 // MaximumComponentNameLength
         + 4 // FileSystemNameLength
-        + encoded_str_len(&self.file_system_name, CharacterSet::Unicode, true)
+        + encoded_str_len(&self.file_system_name, CharacterSet::Unicode, false)
     }
 }
 
@@ -3777,22 +4368,577 @@ impl ClientDriveSetInformationResponse {
     }
 }
 
+/// [2.2.3.4.11] Client Drive NotifyChange Directory Response (DR_DRIVE_NOTIFY_CHANGE_DIRECTORY_RSP)
+///
+/// [2.2.3.4.11]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/099ae8f2-f761-496e-a407-5e2dbe3b80cb
+#[derive(Debug, PartialEq, Clone)]
+pub struct ClientDriveNotifyChangeDirectoryResponse {
+    pub device_io_reply: DeviceIoResponse,
+    pub buffer: Vec<u8>,
+}
+
+impl ClientDriveNotifyChangeDirectoryResponse {
+    const NAME: &'static str = "DR_DRIVE_NOTIFY_CHANGE_DIRECTORY_RSP";
+
+    pub fn new(device_io_request: DeviceIoRequest, io_status: NtStatus, buffer: Vec<u8>) -> Self {
+        Self {
+            device_io_reply: DeviceIoResponse::new(device_io_request, io_status),
+            buffer,
+        }
+    }
+
+    pub fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    pub fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        self.device_io_reply.encode(dst)?;
+        dst.write_u32(cast_length!(
+            "ClientDriveNotifyChangeDirectoryResponse",
+            "length",
+            self.buffer.len()
+        )?);
+        dst.write_slice(&self.buffer);
+        Ok(())
+    }
+
+    pub fn size(&self) -> usize {
+        self.device_io_reply.size() // DeviceIoResponse
+        + 4 // Length
+        + self.buffer.len() // Buffer
+    }
+}
+
 /// 2.2.3.3.12 Server Drive Lock Control Request (DR_DRIVE_LOCK_REQ)
 ///
 /// [2.2.3.3.12]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/a96fe85c-620c-40ce-8858-a6bc38609b0a
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum LockOperation {
+    /// RDP_LOWIO_OP_SHAREDLOCK
+    Shared,
+    /// RDP_LOWIO_OP_EXCLUSIVELOCK
+    Exclusive,
+    /// RDP_LOWIO_OP_UNLOCK
+    Unlock,
+    /// RDP_LOWIO_OP_UNLOCK_MULTIPLE
+    UnlockMultiple,
+}
+
+impl TryFrom<u32> for LockOperation {
+    type Error = DecodeError;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            0x0000_0002 => Ok(Self::Shared),
+            0x0000_0003 => Ok(Self::Exclusive),
+            0x0000_0004 => Ok(Self::Unlock),
+            0x0000_0005 => Ok(Self::UnlockMultiple),
+            _ => Err(invalid_field_err!(
+                "LockOperation::try_from",
+                "value",
+                "invalid lock operation"
+            )),
+        }
+    }
+}
+
+/// [2.2.1.6] RDP_LOCK_INFO
+///
+/// [2.2.1.6]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/2e02e6c5-2c00-4a25-aea6-5f5f5d8a8912
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct RdpLockInfo {
+    pub length: u64,
+    pub offset: u64,
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct ServerDriveLockControlRequest {
     pub device_io_request: DeviceIoRequest,
+    pub operation: LockOperation,
+    pub wait: bool,
+    pub locks: Vec<RdpLockInfo>,
 }
 
 impl ServerDriveLockControlRequest {
+    const FIXED_PART_SIZE: usize = 4 /* Operation */
+        + 4 /* Flags */
+        + 4 /* NumLocks */
+        + 20 /* Padding2 */;
+    const LOCK_INFO_SIZE: usize = 8 /* Length */ + 8 /* Offset */;
+
     fn decode(dev_io_req: DeviceIoRequest, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
-        // It's not quite clear why this is done this way, but it's what FreeRDP does:
-        // https://github.com/FreeRDP/FreeRDP/blob/dfa231c0a55b005af775b833f92f6bcd30363d77/channels/drive/client/drive_main.c#L600
-        ensure_size!(in: src, size: 4);
-        let _ = src.read_u32();
+        ensure_size!(in: src, size: Self::FIXED_PART_SIZE);
+        let operation = LockOperation::try_from(src.read_u32())?;
+        let wait = src.read_u32() & 1 != 0;
+        let locks_count: usize = cast_length!("ServerDriveLockControlRequest", "num_locks", src.read_u32())?;
+        // Padding2 (20 bytes): This field is unused and MUST be ignored.
+        read_padding!(src, 20);
+        let locks_size = locks_count.checked_mul(Self::LOCK_INFO_SIZE).ok_or_else(|| {
+            invalid_field_err!("ServerDriveLockControlRequest::decode", "num_locks", "too many locks")
+        })?;
+        ensure_size!(in: src, size: locks_size);
+
+        let mut locks = Vec::with_capacity(locks_count);
+        for _ in 0..locks_count {
+            locks.push(RdpLockInfo {
+                length: src.read_u64(),
+                offset: src.read_u64(),
+            });
+        }
+
         Ok(Self {
             device_io_request: dev_io_req,
+            operation,
+            wait,
+            locks,
         })
+    }
+}
+
+/// [2.2.3.4.12] Client Drive Lock Control Response (DR_DRIVE_LOCK_RSP)
+///
+/// [2.2.3.4.12]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/f79e76cc-bb96-4e94-a677-1971edf97057
+#[derive(Debug, PartialEq, Clone)]
+pub struct ClientDriveLockControlResponse {
+    pub device_io_reply: DeviceIoResponse,
+}
+
+impl ClientDriveLockControlResponse {
+    const NAME: &'static str = "DR_DRIVE_LOCK_RSP";
+
+    pub fn new(device_io_request: DeviceIoRequest, io_status: NtStatus) -> Self {
+        Self {
+            device_io_reply: DeviceIoResponse::new(device_io_request, io_status),
+        }
+    }
+
+    pub fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    pub fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        self.device_io_reply.encode(dst)?;
+        write_padding!(dst, 5);
+        Ok(())
+    }
+
+    pub fn size(&self) -> usize {
+        self.device_io_reply.size() // DeviceIoResponse
+        + 5 // Padding
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn client_capabilities_advertise_minor_version_13() {
+        let reply = VersionAndIdPdu::new_client_announce_reply(VersionAndIdPdu {
+            version_major: VERSION_MAJOR,
+            version_minor: VERSION_MINOR_12,
+            client_id: 42,
+            kind: VersionAndIdPduKind::ServerAnnounceRequest,
+        })
+        .expect("valid server announce request");
+        assert_eq!(reply.version_minor, VERSION_MINOR_13);
+
+        let CapabilityData::General(general) = CapabilityMessage::new_general(0).capability_data else {
+            panic!("new general capability must contain general data");
+        };
+        assert_eq!(general.protocol_minor_version, VERSION_MINOR_13);
+        assert_eq!(general.io_code_1, IoCode1::REQUIRED);
+        // Without ENABLE_ASYNCIO, MS-RDPEFS requires the server to serialize
+        // reads and writes for each redirected file.
+        assert!(general.extra_flags_1.is_empty());
+    }
+
+    #[test]
+    fn client_announce_reply_uses_a_generated_id_for_legacy_servers() {
+        let server_announce = VersionAndIdPdu {
+            version_major: VERSION_MAJOR,
+            version_minor: VERSION_MINOR_RDP51,
+            client_id: 42,
+            kind: VersionAndIdPduKind::ServerAnnounceRequest,
+        };
+
+        let reply = VersionAndIdPdu::new_client_announce_reply_with_legacy_client_id(server_announce, 7)
+            .expect("valid server announce");
+
+        assert_eq!(reply.client_id, 7);
+        assert_eq!(reply.version_minor, VERSION_MINOR_13);
+    }
+
+    #[test]
+    fn general_capability_version_one_decodes_without_special_device_count() {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&(u16::from(CapabilityType::General)).to_le_bytes());
+        payload.extend_from_slice(&40u16.to_le_bytes()); // CapabilityHeader + v1 GeneralCapabilitySet
+        payload.extend_from_slice(&GENERAL_CAPABILITY_VERSION_01.to_le_bytes());
+        payload.resize(40, 0);
+        let mut cursor = ReadCursor::new(&payload);
+
+        let capability = CapabilityMessage::decode(&mut cursor).expect("valid version one general capability");
+
+        assert!(cursor.is_empty());
+        let CapabilityData::General(general) = capability.capability_data else {
+            panic!("decoded capability must be general");
+        };
+        assert_eq!(general.special_type_device_cap, 0);
+    }
+
+    #[test]
+    fn general_capability_rejects_a_length_for_the_wrong_version() {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&(u16::from(CapabilityType::General)).to_le_bytes());
+        payload.extend_from_slice(&44u16.to_le_bytes()); // v2 length with a v1 header
+        payload.extend_from_slice(&GENERAL_CAPABILITY_VERSION_01.to_le_bytes());
+        payload.resize(40, 0);
+
+        assert!(CapabilityMessage::decode(&mut ReadCursor::new(&payload)).is_err());
+    }
+
+    #[test]
+    fn continuation_directory_queries_ignore_the_path_contents() {
+        let request = DeviceIoRequest {
+            device_id: 1,
+            file_id: 2,
+            completion_id: 3,
+            major_function: MajorFunction::DirectoryControl,
+            minor_function: MinorFunction::from(0),
+        };
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&u32::from(FileInformationClassLevel::FILE_NAMES_INFORMATION).to_le_bytes());
+        payload.push(0); // InitialQuery
+        payload.extend_from_slice(&1u32.to_le_bytes()); // ignored PathLength
+        payload.extend_from_slice(&[0; 23]); // Padding
+        payload.push(0xFF); // invalid UTF-16 and not null-terminated, but ignored
+
+        let decoded = ServerDriveQueryDirectoryRequest::decode(request, &mut ReadCursor::new(&payload))
+            .expect("continuation query with an ignored path");
+
+        assert_eq!(decoded.initial_query, 0);
+        assert!(decoded.path.is_empty());
+    }
+
+    #[test]
+    fn volume_information_label_uses_the_rdpdr_layout() {
+        let volume = FileFsVolumeInformation {
+            volume_creation_time: 0,
+            volume_serial_number: 0,
+            supports_objects: Boolean::from(0),
+            volume_label: "C".to_owned(),
+        };
+        let attributes = FileFsAttributeInformation {
+            file_system_attributes: FileSystemAttributes::empty(),
+            max_component_name_len: 255,
+            file_system_name: "NTFS".to_owned(),
+        };
+
+        let mut volume_bytes = vec![0; volume.size()];
+        volume
+            .encode(&mut WriteCursor::new(&mut volume_bytes))
+            .expect("encode volume information");
+        assert_eq!(
+            u32::from_le_bytes(volume_bytes[12..16].try_into().expect("volume label length")),
+            4
+        );
+        assert_eq!(&volume_bytes[17..], &[b'C', 0, 0, 0]);
+
+        let mut attribute_bytes = vec![0; attributes.size()];
+        attributes
+            .encode(&mut WriteCursor::new(&mut attribute_bytes))
+            .expect("encode attribute information");
+        assert_eq!(
+            u32::from_le_bytes(attribute_bytes[8..12].try_into().expect("file-system name length")),
+            8
+        );
+        assert_eq!(attribute_bytes.len(), 20);
+    }
+
+    #[test]
+    fn query_volume_response_preserves_named_stream_attributes() {
+        let request = DeviceIoRequest {
+            device_id: 1,
+            file_id: 2,
+            completion_id: 3,
+            major_function: MajorFunction::QueryVolumeInformation,
+            minor_function: MinorFunction::from(0),
+        };
+        let response = ClientDriveQueryVolumeInformationResponse::new(
+            request,
+            NtStatus::SUCCESS,
+            Some(
+                FileFsAttributeInformation {
+                    file_system_attributes: FileSystemAttributes::FILE_NAMED_STREAMS,
+                    max_component_name_len: 255,
+                    file_system_name: "NTFS".to_owned(),
+                }
+                .into(),
+            ),
+        );
+        let mut bytes = vec![0; response.size()];
+
+        response
+            .encode(&mut WriteCursor::new(&mut bytes))
+            .expect("encode volume information response");
+
+        assert_eq!(bytes.len(), 36);
+        assert_eq!(u32::from_le_bytes(bytes[12..16].try_into().expect("buffer length")), 20);
+        assert_eq!(
+            u32::from_le_bytes(bytes[16..20].try_into().expect("file-system attributes")),
+            FileSystemAttributes::FILE_NAMED_STREAMS.bits()
+        );
+        assert_eq!(&bytes[28..], &[b'N', 0, b'T', 0, b'F', 0, b'S', 0]);
+    }
+
+    #[test]
+    fn directory_notification_response_omits_optional_trailing_padding() {
+        let request = DeviceIoRequest {
+            device_id: 1,
+            file_id: 2,
+            completion_id: 3,
+            major_function: MajorFunction::DirectoryControl,
+            minor_function: MinorFunction::from(2),
+        };
+        let response = ClientDriveNotifyChangeDirectoryResponse::new(
+            request,
+            NtStatus::SUCCESS,
+            vec![
+                0, 0, 0, 0, // NextEntryOffset
+                1, 0, 0, 0, // Action
+                2, 0, 0, 0, // FileNameLength
+                b'a', 0, // FileName
+            ],
+        );
+        let mut bytes = vec![0; response.size()];
+        response
+            .encode(&mut WriteCursor::new(&mut bytes))
+            .expect("encode directory notification response");
+
+        assert_eq!(u32::from_le_bytes(bytes[12..16].try_into().expect("buffer length")), 14);
+        assert_eq!(&bytes[16..30], &[0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, b'a', 0]);
+        assert_eq!(bytes.len(), 30);
+    }
+
+    #[test]
+    fn lock_control_request_decodes_all_ranges() {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&0x0000_0003u32.to_le_bytes()); // Operation: exclusive
+        payload.extend_from_slice(&0x0000_0001u32.to_le_bytes()); // Wait
+        payload.extend_from_slice(&2u32.to_le_bytes()); // NumLocks
+        payload.extend_from_slice(&[0; 20]); // Padding2
+        payload.extend_from_slice(&0x20u64.to_le_bytes()); // First length
+        payload.extend_from_slice(&0x40u64.to_le_bytes()); // First offset
+        payload.extend_from_slice(&0x80u64.to_le_bytes()); // Second length
+        payload.extend_from_slice(&0x100u64.to_le_bytes()); // Second offset
+        let mut cursor = ReadCursor::new(&payload);
+        let request = DeviceIoRequest {
+            device_id: 1,
+            file_id: 2,
+            completion_id: 3,
+            major_function: MajorFunction::LockControl,
+            minor_function: MinorFunction::from(0),
+        };
+
+        let decoded = ServerDriveLockControlRequest::decode(request, &mut cursor).expect("valid lock request");
+
+        assert_eq!(decoded.operation, LockOperation::Exclusive);
+        assert!(decoded.wait);
+        assert_eq!(
+            decoded.locks,
+            [
+                RdpLockInfo {
+                    length: 0x20,
+                    offset: 0x40,
+                },
+                RdpLockInfo {
+                    length: 0x80,
+                    offset: 0x100,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn security_requests_decode_and_responses_preserve_lengths() {
+        let request = DeviceIoRequest {
+            device_id: 1,
+            file_id: 2,
+            completion_id: 3,
+            major_function: MajorFunction::QuerySecurity,
+            minor_function: MinorFunction::from(0),
+        };
+        let mut query_payload = Vec::new();
+        query_payload.extend_from_slice(&SecurityInformation::OWNER.bits().to_le_bytes());
+
+        let query = ServerDriveIoRequest::decode(request.clone(), &mut ReadCursor::new(&query_payload))
+            .expect("valid query security request");
+        let ServerDriveIoRequest::ServerDriveQuerySecurityRequest(query) = query else {
+            panic!("decoded request must be query security");
+        };
+        assert_eq!(query.security_information, SecurityInformation::OWNER);
+
+        let descriptor = vec![1, 2, 3, 4];
+        let mut set_payload = Vec::new();
+        set_payload.extend_from_slice(&SecurityInformation::DACL.bits().to_le_bytes());
+        set_payload.extend_from_slice(&4u32.to_le_bytes()); // Length
+        set_payload.extend_from_slice(&[0; 24]); // Padding
+        set_payload.extend_from_slice(&descriptor);
+        let set_request = DeviceIoRequest {
+            major_function: MajorFunction::SetSecurity,
+            ..request
+        };
+        let set = ServerDriveIoRequest::decode(set_request, &mut ReadCursor::new(&set_payload))
+            .expect("valid set security request");
+        let ServerDriveIoRequest::ServerDriveSetSecurityRequest(set) = set else {
+            panic!("decoded request must be set security");
+        };
+        assert_eq!(set.security_descriptor, descriptor);
+
+        let query_response = ClientDriveQuerySecurityResponse {
+            device_io_response: DeviceIoResponse::new(query.device_io_request, NtStatus::SUCCESS),
+            security_descriptor: Some(descriptor.clone()),
+        };
+        let mut query_bytes = vec![0; query_response.size()];
+        query_response
+            .encode(&mut WriteCursor::new(&mut query_bytes))
+            .expect("encode query security response");
+        assert_eq!(
+            u32::from_le_bytes(query_bytes[12..16].try_into().expect("response length")),
+            4
+        );
+        assert_eq!(&query_bytes[16..], descriptor.as_slice());
+
+        let set_response =
+            ClientDriveSetSecurityResponse::new(&set, NtStatus::SUCCESS).expect("construct set security response");
+        let mut set_bytes = vec![0; set_response.size()];
+        set_response
+            .encode(&mut WriteCursor::new(&mut set_bytes))
+            .expect("encode set security response");
+        assert_eq!(
+            u32::from_le_bytes(set_bytes[12..16].try_into().expect("response length")),
+            4
+        );
+    }
+
+    #[test]
+    fn lock_control_request_rejects_unknown_operation() {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&0x0000_0001u32.to_le_bytes()); // Operation
+        payload.extend_from_slice(&0u32.to_le_bytes()); // Flags
+        payload.extend_from_slice(&0u32.to_le_bytes()); // NumLocks
+        payload.extend_from_slice(&[0; 20]); // Padding2
+        let mut cursor = ReadCursor::new(&payload);
+        let request = DeviceIoRequest {
+            device_id: 1,
+            file_id: 2,
+            completion_id: 3,
+            major_function: MajorFunction::LockControl,
+            minor_function: MinorFunction::from(0),
+        };
+
+        assert!(ServerDriveLockControlRequest::decode(request, &mut cursor).is_err());
+    }
+
+    #[test]
+    fn device_control_request_retains_declared_input_buffer() {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&64u32.to_le_bytes()); // OutputBufferLength
+        payload.extend_from_slice(&3u32.to_le_bytes()); // InputBufferLength
+        payload.extend_from_slice(&0xDEAD_BEEFu32.to_le_bytes()); // IoControlCode
+        payload.extend_from_slice(&[0; 20]); // Padding
+        payload.extend_from_slice(&[1, 2, 3]); // InputBuffer
+        let mut cursor = ReadCursor::new(&payload);
+        let request = DeviceIoRequest {
+            device_id: 1,
+            file_id: 2,
+            completion_id: 3,
+            major_function: MajorFunction::DeviceControl,
+            minor_function: MinorFunction::from(0),
+        };
+
+        let decoded = DeviceControlRequest::<AnyIoCtlCode>::decode_with_input_buffer(request, &mut cursor)
+            .expect("valid control request");
+
+        assert_eq!(decoded.request.output_buffer_length, 64);
+        assert_eq!(decoded.input_buffer, [1, 2, 3]);
+    }
+
+    #[test]
+    fn device_control_request_keeps_its_public_struct_literal_shape() {
+        let request = DeviceControlRequest {
+            header: DeviceIoRequest {
+                device_id: 1,
+                file_id: 2,
+                completion_id: 3,
+                major_function: MajorFunction::DeviceControl,
+                minor_function: MinorFunction::from(0),
+            },
+            output_buffer_length: 64,
+            input_buffer_length: 0,
+            io_control_code: AnyIoCtlCode(0),
+        };
+
+        assert_eq!(request.output_buffer_length, 64);
+    }
+
+    #[test]
+    fn flush_buffers_request_decodes_without_an_operation_payload() {
+        let request = DeviceIoRequest {
+            device_id: 1,
+            file_id: 2,
+            completion_id: 3,
+            major_function: MajorFunction::FlushBuffers,
+            minor_function: MinorFunction::from(0),
+        };
+
+        let decoded =
+            ServerDriveIoRequest::decode(request.clone(), &mut ReadCursor::new(&[])).expect("valid flush request");
+
+        assert_eq!(
+            decoded,
+            ServerDriveIoRequest::DeviceFlushBuffersRequest(DeviceFlushBuffersRequest {
+                device_io_request: request,
+            })
+        );
+    }
+
+    #[test]
+    fn file_stream_information_query_response_preserves_the_native_buffer() {
+        let mut stream_information = Vec::new();
+        stream_information.extend_from_slice(&0u32.to_le_bytes()); // NextEntryOffset
+        stream_information.extend_from_slice(&14u32.to_le_bytes()); // StreamNameLength
+        stream_information.extend_from_slice(&5i64.to_le_bytes()); // StreamSize
+        stream_information.extend_from_slice(&4_096i64.to_le_bytes()); // StreamAllocationSize
+        for code_unit in "::$DATA".encode_utf16() {
+            stream_information.extend_from_slice(&code_unit.to_le_bytes());
+        }
+        let response = ClientDriveQueryInformationResponse {
+            device_io_response: DeviceIoResponse::new(
+                DeviceIoRequest {
+                    device_id: 1,
+                    file_id: 2,
+                    completion_id: 3,
+                    major_function: MajorFunction::QueryInformation,
+                    minor_function: MinorFunction::from(0),
+                },
+                NtStatus::SUCCESS,
+            ),
+            buffer: Some(FileStreamInformation::from_buffer(stream_information.clone()).into()),
+        };
+        let mut encoded = vec![0; response.size()];
+
+        response
+            .encode(&mut WriteCursor::new(&mut encoded))
+            .expect("encode stream information response");
+
+        assert_eq!(
+            u32::from_le_bytes(encoded[12..16].try_into().expect("response length")),
+            u32::try_from(stream_information.len()).expect("test buffer fits in u32")
+        );
+        assert_eq!(&encoded[16..], stream_information.as_slice());
     }
 }

--- a/crates/ironrdp-rdpdr/src/pdu/efs.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/efs.rs
@@ -427,6 +427,7 @@ impl CapabilityMessage {
         Self {
             header: CapabilityHeader::new_general(),
             capability_data: CapabilityData::General(GeneralCapabilitySet {
+                version: GENERAL_CAPABILITY_VERSION_02,
                 os_type: 0,
                 os_version: 0,
                 protocol_major_version: 1,
@@ -687,7 +688,7 @@ impl CapabilityData {
 
     fn size(&self) -> usize {
         match self {
-            CapabilityData::General(_) => GeneralCapabilitySet::SIZE,
+            CapabilityData::General(general) => general.size(),
             CapabilityData::Printer => 0,
             CapabilityData::Port => 0,
             CapabilityData::Drive => 0,
@@ -701,6 +702,7 @@ impl CapabilityData {
 /// [2.2.2.7.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/06c7cb30-303d-4fa2-b396-806df8ac1501
 #[derive(Debug, PartialEq, Clone, Copy)]
 struct GeneralCapabilitySet {
+    version: u32,
     /// MUST be ignored.
     os_type: u32,
     /// SHOULD be ignored.
@@ -736,7 +738,7 @@ impl GeneralCapabilitySet {
     const VERSION_01_SIZE: usize = Self::SIZE - size_of::<u32>();
 
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        ensure_size!(in: dst, size: Self::SIZE);
+        ensure_size!(in: dst, size: self.size());
         dst.write_u32(self.os_type);
         dst.write_u32(self.os_version);
         dst.write_u16(self.protocol_major_version);
@@ -746,7 +748,9 @@ impl GeneralCapabilitySet {
         dst.write_u32(self.extended_pdu.bits());
         dst.write_u32(self.extra_flags_1.bits());
         dst.write_u32(self.extra_flags_2);
-        dst.write_u32(self.special_type_device_cap);
+        if self.version == GENERAL_CAPABILITY_VERSION_02 {
+            dst.write_u32(self.special_type_device_cap);
+        }
         Ok(())
     }
 
@@ -768,6 +772,7 @@ impl GeneralCapabilitySet {
         };
 
         Ok(Self {
+            version,
             os_type,
             os_version,
             protocol_major_version,
@@ -779,6 +784,14 @@ impl GeneralCapabilitySet {
             extra_flags_2,
             special_type_device_cap,
         })
+    }
+
+    fn size(&self) -> usize {
+        if self.version == GENERAL_CAPABILITY_VERSION_01 {
+            Self::VERSION_01_SIZE
+        } else {
+            Self::SIZE
+        }
     }
 
     fn size_for_version(version: u32) -> DecodeResult<usize> {
@@ -1673,14 +1686,6 @@ where
         + 20; // Additional 20 bytes for padding
 
     pub fn decode(header: DeviceIoRequest, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
-        Ok(Self::decode_with_input_buffer(header, src)?.request)
-    }
-
-    /// Decodes a request and returns its exact opaque input buffer.
-    pub fn decode_with_input_buffer(
-        header: DeviceIoRequest,
-        src: &mut ReadCursor<'_>,
-    ) -> DecodeResult<DecodedDeviceControlRequest<T>> {
         ensure_size!(ctx: "DeviceControlRequest", in: src, size: Self::HEADERLESS_SIZE);
         let output_buffer_length = src.read_u32();
         let input_buffer_length = src.read_u32();
@@ -1691,20 +1696,30 @@ where
 
         // Padding (20 bytes): An array of 20 bytes. Reserved. This field can be set to any value and MUST be ignored.
         read_padding!(src, 20);
-        let input_buffer_size: usize =
-            cast_length!("DeviceControlRequest", "input_buffer_length", input_buffer_length)?;
+
+        Ok(Self {
+            header,
+            output_buffer_length,
+            input_buffer_length,
+            io_control_code,
+        })
+    }
+
+    /// Decodes a request and returns its exact opaque input buffer.
+    pub fn decode_with_input_buffer(
+        header: DeviceIoRequest,
+        src: &mut ReadCursor<'_>,
+    ) -> DecodeResult<DecodedDeviceControlRequest<T>> {
+        let request = Self::decode(header, src)?;
+        let input_buffer_size: usize = cast_length!(
+            "DeviceControlRequest",
+            "input_buffer_length",
+            request.input_buffer_length
+        )?;
         ensure_size!(ctx: "DeviceControlRequest", in: src, size: input_buffer_size);
         let input_buffer = src.read_slice(input_buffer_size).to_vec();
 
-        Ok(DecodedDeviceControlRequest {
-            request: Self {
-                header,
-                output_buffer_length,
-                input_buffer_length,
-                io_control_code,
-            },
-            input_buffer,
-        })
+        Ok(DecodedDeviceControlRequest { request, input_buffer })
     }
 }
 
@@ -4553,6 +4568,12 @@ mod tests {
             panic!("decoded capability must be general");
         };
         assert_eq!(general.special_type_device_cap, 0);
+
+        let mut encoded = vec![0; capability.size()];
+        capability
+            .encode(&mut WriteCursor::new(&mut encoded))
+            .expect("encode version one general capability");
+        assert_eq!(encoded, payload);
     }
 
     #[test]
@@ -4825,6 +4846,30 @@ mod tests {
 
         assert_eq!(decoded.request.output_buffer_length, 64);
         assert_eq!(decoded.input_buffer, [1, 2, 3]);
+    }
+
+    #[test]
+    fn device_control_request_decode_leaves_the_input_buffer_for_the_caller() {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&64u32.to_le_bytes()); // OutputBufferLength
+        payload.extend_from_slice(&3u32.to_le_bytes()); // InputBufferLength
+        payload.extend_from_slice(&0xDEAD_BEEFu32.to_le_bytes()); // IoControlCode
+        payload.extend_from_slice(&[0; 20]); // Padding
+        payload.extend_from_slice(&[1, 2, 3]); // InputBuffer
+        let mut cursor = ReadCursor::new(&payload);
+        let request = DeviceIoRequest {
+            device_id: 1,
+            file_id: 2,
+            completion_id: 3,
+            major_function: MajorFunction::DeviceControl,
+            minor_function: MinorFunction::from(0),
+        };
+
+        let decoded =
+            DeviceControlRequest::<AnyIoCtlCode>::decode(request, &mut cursor).expect("valid control request");
+
+        assert_eq!(decoded.input_buffer_length, 3);
+        assert_eq!(cursor.read_slice(3), [1, 2, 3]);
     }
 
     #[test]

--- a/crates/ironrdp-rdpdr/src/pdu/efs.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/efs.rs
@@ -1851,15 +1851,11 @@ pub enum ServerDriveIoRequest {
     ServerDriveQueryDirectoryRequest(ServerDriveQueryDirectoryRequest),
     ServerDriveNotifyChangeDirectoryRequest(ServerDriveNotifyChangeDirectoryRequest),
     ServerDriveQueryVolumeInformationRequest(ServerDriveQueryVolumeInformationRequest),
-    ServerDriveSetVolumeInformationRequest(ServerDriveSetVolumeInformationRequest),
     DeviceControlRequest(DeviceControlRequest<AnyIoCtlCode>),
     DeviceReadRequest(DeviceReadRequest),
     DeviceWriteRequest(DeviceWriteRequest),
-    DeviceFlushBuffersRequest(DeviceFlushBuffersRequest),
     ServerDriveSetInformationRequest(ServerDriveSetInformationRequest),
     ServerDriveLockControlRequest(ServerDriveLockControlRequest),
-    ServerDriveQuerySecurityRequest(ServerDriveQuerySecurityRequest),
-    ServerDriveSetSecurityRequest(ServerDriveSetSecurityRequest),
 }
 
 impl ServerDriveIoRequest {
@@ -1869,13 +1865,9 @@ impl ServerDriveIoRequest {
             MajorFunction::Close => Ok(DeviceCloseRequest::decode(dev_io_req).into()),
             MajorFunction::Read => Ok(DeviceReadRequest::decode(dev_io_req, src)?.into()),
             MajorFunction::Write => Ok(DeviceWriteRequest::decode(dev_io_req, src)?.into()),
-            MajorFunction::FlushBuffers => Ok(DeviceFlushBuffersRequest::decode(dev_io_req).into()),
             MajorFunction::DeviceControl => Ok(DeviceControlRequest::<AnyIoCtlCode>::decode(dev_io_req, src)?.into()),
             MajorFunction::QueryVolumeInformation => {
                 Ok(ServerDriveQueryVolumeInformationRequest::decode(dev_io_req, src)?.into())
-            }
-            MajorFunction::SetVolumeInformation => {
-                Ok(ServerDriveSetVolumeInformationRequest::decode(dev_io_req, src)?.into())
             }
             MajorFunction::QueryInformation => Ok(ServerDriveQueryInformationRequest::decode(dev_io_req, src)?.into()),
             MajorFunction::SetInformation => Ok(ServerDriveSetInformationRequest::decode(dev_io_req, src)?.into()),
@@ -1894,8 +1886,14 @@ impl ServerDriveIoRequest {
                 )),
             },
             MajorFunction::LockControl => Ok(ServerDriveLockControlRequest::decode(dev_io_req, src)?.into()),
-            MajorFunction::QuerySecurity => Ok(ServerDriveQuerySecurityRequest::decode(dev_io_req, src)?.into()),
-            MajorFunction::SetSecurity => Ok(ServerDriveSetSecurityRequest::decode(dev_io_req, src)?.into()),
+            MajorFunction::FlushBuffers
+            | MajorFunction::SetVolumeInformation
+            | MajorFunction::QuerySecurity
+            | MajorFunction::SetSecurity => Err(unsupported_value_err!(
+                "ServerDriveIoRequest::decode",
+                "MajorFunction",
+                "unsupported value".to_owned()
+            )),
         }
     }
 }
@@ -1936,12 +1934,6 @@ impl From<ServerDriveQueryVolumeInformationRequest> for ServerDriveIoRequest {
     }
 }
 
-impl From<ServerDriveSetVolumeInformationRequest> for ServerDriveIoRequest {
-    fn from(req: ServerDriveSetVolumeInformationRequest) -> Self {
-        Self::ServerDriveSetVolumeInformationRequest(req)
-    }
-}
-
 impl From<DeviceControlRequest<AnyIoCtlCode>> for ServerDriveIoRequest {
     fn from(req: DeviceControlRequest<AnyIoCtlCode>) -> Self {
         Self::DeviceControlRequest(req)
@@ -1960,12 +1952,6 @@ impl From<DeviceWriteRequest> for ServerDriveIoRequest {
     }
 }
 
-impl From<DeviceFlushBuffersRequest> for ServerDriveIoRequest {
-    fn from(req: DeviceFlushBuffersRequest) -> Self {
-        Self::DeviceFlushBuffersRequest(req)
-    }
-}
-
 impl From<ServerDriveSetInformationRequest> for ServerDriveIoRequest {
     fn from(req: ServerDriveSetInformationRequest) -> Self {
         Self::ServerDriveSetInformationRequest(req)
@@ -1975,18 +1961,6 @@ impl From<ServerDriveSetInformationRequest> for ServerDriveIoRequest {
 impl From<ServerDriveLockControlRequest> for ServerDriveIoRequest {
     fn from(req: ServerDriveLockControlRequest) -> Self {
         Self::ServerDriveLockControlRequest(req)
-    }
-}
-
-impl From<ServerDriveQuerySecurityRequest> for ServerDriveIoRequest {
-    fn from(req: ServerDriveQuerySecurityRequest) -> Self {
-        Self::ServerDriveQuerySecurityRequest(req)
-    }
-}
-
-impl From<ServerDriveSetSecurityRequest> for ServerDriveIoRequest {
-    fn from(req: ServerDriveSetSecurityRequest) -> Self {
-        Self::ServerDriveSetSecurityRequest(req)
     }
 }
 
@@ -2535,7 +2509,7 @@ pub struct ServerDriveQuerySecurityRequest {
 impl ServerDriveQuerySecurityRequest {
     const FIXED_PART_SIZE: usize = 4; // SecurityInformation
 
-    fn decode(dev_io_req: DeviceIoRequest, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+    pub fn decode(dev_io_req: DeviceIoRequest, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
         ensure_size!(ctx: "ServerDriveQuerySecurityRequest", in: src, size: Self::FIXED_PART_SIZE);
         let security_information = SecurityInformation::from_bits_retain(src.read_u32());
 
@@ -2631,7 +2605,7 @@ pub struct ServerDriveSetSecurityRequest {
 impl ServerDriveSetSecurityRequest {
     const FIXED_PART_SIZE: usize = 4 /* SecurityInformation */ + 4 /* Length */ + 24 /* Padding */;
 
-    fn decode(dev_io_req: DeviceIoRequest, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+    pub fn decode(dev_io_req: DeviceIoRequest, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
         ensure_size!(
             ctx: "ServerDriveSetSecurityRequest",
             in: src,
@@ -3606,7 +3580,7 @@ pub struct ServerDriveSetVolumeInformationRequest {
     pub set_volume_buffer_length: u32,
     /// Requested volume label decoded from `FileFsLabelInformation`.
     ///
-    /// Native backends may reject relabeling according to their local security
+    /// Implementations may reject relabeling according to their local security
     /// policy, but retaining the value keeps the request fully decoded.
     pub volume_label: String,
 }
@@ -3614,7 +3588,7 @@ pub struct ServerDriveSetVolumeInformationRequest {
 impl ServerDriveSetVolumeInformationRequest {
     const FIXED_PART_SIZE: usize = 4 /* FsInformationClass */ + 4 /* Length */ + 24 /* Padding */;
 
-    fn decode(device_io_request: DeviceIoRequest, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+    pub fn decode(device_io_request: DeviceIoRequest, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
         ensure_fixed_part_size!(in: src);
         let fs_info_class_lvl = FileSystemInformationClassLevel::from(src.read_u32());
         if fs_info_class_lvl != FileSystemInformationClassLevel::FILE_FS_LABEL_INFORMATION {
@@ -3644,7 +3618,7 @@ impl ServerDriveSetVolumeInformationRequest {
         let label_length = cast_length!(
             "ServerDriveSetVolumeInformationRequest",
             "volume_label_length",
-            u32::from_le_bytes(buffer[..4].try_into().expect("slice length was checked"))
+            u32::from_le_bytes([buffer[0], buffer[1], buffer[2], buffer[3]])
         )?;
         let label_end = 4usize.checked_add(label_length).ok_or_else(|| {
             invalid_field_err!(
@@ -4766,11 +4740,8 @@ mod tests {
         let mut query_payload = Vec::new();
         query_payload.extend_from_slice(&SecurityInformation::OWNER.bits().to_le_bytes());
 
-        let query = ServerDriveIoRequest::decode(request.clone(), &mut ReadCursor::new(&query_payload))
+        let query = ServerDriveQuerySecurityRequest::decode(request.clone(), &mut ReadCursor::new(&query_payload))
             .expect("valid query security request");
-        let ServerDriveIoRequest::ServerDriveQuerySecurityRequest(query) = query else {
-            panic!("decoded request must be query security");
-        };
         assert_eq!(query.security_information, SecurityInformation::OWNER);
 
         let descriptor = vec![1, 2, 3, 4];
@@ -4783,11 +4754,8 @@ mod tests {
             major_function: MajorFunction::SetSecurity,
             ..request
         };
-        let set = ServerDriveIoRequest::decode(set_request, &mut ReadCursor::new(&set_payload))
+        let set = ServerDriveSetSecurityRequest::decode(set_request, &mut ReadCursor::new(&set_payload))
             .expect("valid set security request");
-        let ServerDriveIoRequest::ServerDriveSetSecurityRequest(set) = set else {
-            panic!("decoded request must be set security");
-        };
         assert_eq!(set.security_descriptor, descriptor);
 
         let query_response = ClientDriveQuerySecurityResponse {
@@ -4887,15 +4855,60 @@ mod tests {
             minor_function: MinorFunction::from(0),
         };
 
-        let decoded =
-            ServerDriveIoRequest::decode(request.clone(), &mut ReadCursor::new(&[])).expect("valid flush request");
+        let decoded = DeviceFlushBuffersRequest::decode(request.clone());
 
         assert_eq!(
             decoded,
-            ServerDriveIoRequest::DeviceFlushBuffersRequest(DeviceFlushBuffersRequest {
+            DeviceFlushBuffersRequest {
                 device_io_request: request,
-            })
+            }
         );
+    }
+
+    #[test]
+    fn set_volume_information_request_validates_the_label_buffer_length() {
+        let request = DeviceIoRequest {
+            device_id: 1,
+            file_id: 2,
+            completion_id: 3,
+            major_function: MajorFunction::SetVolumeInformation,
+            minor_function: MinorFunction::from(0),
+        };
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&2u32.to_le_bytes()); // FsInformationClass
+        payload.extend_from_slice(&8u32.to_le_bytes()); // Length
+        payload.extend_from_slice(&[0; 24]); // Padding
+        payload.extend_from_slice(&4u32.to_le_bytes()); // VolumeLabelLength
+        payload.extend_from_slice(&[b'C', 0, b'D', 0]); // VolumeLabel
+
+        let decoded = ServerDriveSetVolumeInformationRequest::decode(request.clone(), &mut ReadCursor::new(&payload))
+            .expect("valid set-volume request");
+
+        assert_eq!(decoded.device_io_request, request);
+        assert_eq!(decoded.volume_label, "CD");
+
+        payload[4..8].copy_from_slice(&4u32.to_le_bytes()); // Length
+        assert!(ServerDriveSetVolumeInformationRequest::decode(request, &mut ReadCursor::new(&payload)).is_err());
+    }
+
+    #[test]
+    fn filesystem_foundation_requests_remain_outside_drive_dispatch() {
+        for major_function in [
+            MajorFunction::FlushBuffers,
+            MajorFunction::SetVolumeInformation,
+            MajorFunction::QuerySecurity,
+            MajorFunction::SetSecurity,
+        ] {
+            let request = DeviceIoRequest {
+                device_id: 1,
+                file_id: 2,
+                completion_id: 3,
+                major_function,
+                minor_function: MinorFunction::from(0),
+            };
+
+            assert!(ServerDriveIoRequest::decode(request, &mut ReadCursor::new(&[])).is_err());
+        }
     }
 
     #[test]

--- a/crates/ironrdp-testsuite-core/tests/rdpdr/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpdr/mod.rs
@@ -42,24 +42,42 @@ fn encoded_printer_announce(device: DeviceAnnounceHeader) -> Vec<u8> {
     .unwrap()
 }
 
-fn encoded_server_client_id_confirm() -> Vec<u8> {
+fn encoded_server_client_id_confirm(client_id: u32) -> Vec<u8> {
     encode_vec(&RdpdrPdu::VersionAndIdPdu(VersionAndIdPdu {
         version_major: 1,
         version_minor: 12,
-        client_id: 0x1234,
+        client_id,
         kind: VersionAndIdPduKind::ServerClientIdConfirm,
     }))
     .unwrap()
 }
 
-fn encoded_server_client_id_confirm_with_minor(version_minor: u16) -> Vec<u8> {
+fn encoded_server_client_id_confirm_with_minor(version_minor: u16, client_id: u32) -> Vec<u8> {
     encode_vec(&RdpdrPdu::VersionAndIdPdu(VersionAndIdPdu {
         version_major: 1,
         version_minor,
-        client_id: 0x1234,
+        client_id,
         kind: VersionAndIdPduKind::ServerClientIdConfirm,
     }))
     .unwrap()
+}
+
+fn announce_client_id(rdpdr: &mut Rdpdr, version_minor: u16) -> u32 {
+    let responses = rdpdr
+        .process(
+            &encode_vec(&RdpdrPdu::VersionAndIdPdu(VersionAndIdPdu {
+                version_major: 1,
+                version_minor,
+                client_id: 0x1234,
+                kind: VersionAndIdPduKind::ServerAnnounceRequest,
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+    assert_eq!(responses.len(), 2);
+
+    let encoded = responses[0].encode_unframed_pdu().unwrap();
+    read_u32(&encoded[8..])
 }
 
 fn encoded_printer_device_io_request(major_function: MajorFunction) -> Vec<u8> {
@@ -242,7 +260,13 @@ fn devices_add_printer_appends_printer_entry() {
 fn printer_device_announce_is_deferred_until_user_loggedon() {
     let mut rdpdr = Rdpdr::new(Box::new(NoopRdpdrBackend), "IronRDP".to_owned()).with_printer(42, "PrintMe".to_owned());
 
-    assert!(rdpdr.process(&encoded_server_client_id_confirm()).unwrap().is_empty());
+    let client_id = announce_client_id(&mut rdpdr, 12);
+    assert!(
+        rdpdr
+            .process(&encoded_server_client_id_confirm(client_id))
+            .unwrap()
+            .is_empty()
+    );
 
     let responses = rdpdr.process(&encode_vec(&RdpdrPdu::UserLoggedon).unwrap()).unwrap();
     assert_eq!(responses.len(), 1);
@@ -263,7 +287,8 @@ fn smartcard_device_announce_remains_pre_logon() {
         .with_smartcard(1)
         .with_printer(42, "PrintMe".to_owned());
 
-    let responses = rdpdr.process(&encoded_server_client_id_confirm()).unwrap();
+    let client_id = announce_client_id(&mut rdpdr, 12);
+    let responses = rdpdr.process(&encoded_server_client_id_confirm(client_id)).unwrap();
     assert_eq!(responses.len(), 1);
 
     assert_eq!(announced_devices(&responses[0]), vec![(1, DeviceType::Smartcard)]);
@@ -280,8 +305,12 @@ fn rdp51_client_id_confirm_announces_all_devices_pre_logon() {
         .with_smartcard(1)
         .with_printer(42, "PrintMe".to_owned());
 
+    let client_id = announce_client_id(&mut rdpdr, VERSION_MINOR_RDP51);
     let responses = rdpdr
-        .process(&encoded_server_client_id_confirm_with_minor(VERSION_MINOR_RDP51))
+        .process(&encoded_server_client_id_confirm_with_minor(
+            VERSION_MINOR_RDP51,
+            client_id,
+        ))
         .unwrap();
     assert_eq!(responses.len(), 1);
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -330,13 +330,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -497,6 +509,7 @@ name = "ironrdp-rdpdr"
 version = "0.7.0"
 dependencies = [
  "bitflags",
+ "getrandom 0.3.4",
  "ironrdp-core",
  "ironrdp-error",
  "ironrdp-pdu",
@@ -530,7 +543,7 @@ version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.3",
  "libc",
 ]
 
@@ -700,6 +713,12 @@ checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -911,6 +930,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wide"
 version = "0.7.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,6 +947,12 @@ dependencies = [
  "bytemuck",
  "safe_arch",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wyz"


### PR DESCRIPTION
## Summary
- Add portable MS-RDPEFS/MS-FSCC filesystem request and completion codecs with malformed-input validation and wire tests.
- Keep RDPDR runtime dispatch, Windows-native backend implementation, and client/session integration out of this foundation.

## Follow-up
Later stacked PRs provide the backend implementation and runtime integration.