### PR TITLE
ci: add shared skills synchronization

### DIFF
--- a/.github/actions/sync-skills/action.yml
+++ b/.github/actions/sync-skills/action.yml
@@ -31,7 +31,8 @@ runs:
         validate_relative_path() {
           local path="$1"
 
-          if [[ -z "$path" || "$path" == /* || "$path" == *'\'* || "/$path/" == *'//'* ||
+          if [[ -z "$path" || "$path" == /* || "$path" == *'\'* || "$path" == *'*'* ||
+            "$path" == *'?'* || "$path" == *'['* || "/$path/" == *'//'* ||
             "/$path/" == *'/./'* || "/$path/" == *'/../'* ]]; then
             echo "Expected a non-empty relative path without '.' or '..' segments: $path" >&2
             exit 1
@@ -122,7 +123,7 @@ runs:
             sparse_paths+=("$source_path/$skill")
           done
 
-          git -C "$clone_directory" sparse-checkout set --no-cone "${sparse_paths[@]}"
+          git -C "$clone_directory" sparse-checkout set --cone "${sparse_paths[@]}"
 
           for skill in "${skills[@]}"; do
             source_skill="$clone_directory/$source_path/$skill"

--- a/.github/actions/sync-skills/action.yml
+++ b/.github/actions/sync-skills/action.yml
@@ -1,0 +1,156 @@
+name: Sync skills
+description: Mirror configured skills from public GitHub repositories
+
+inputs:
+  configuration-path:
+    description: Path to the YAML configuration file, relative to the repository root
+    required: false
+    default: .github/skills-sync.yml
+  destination-path:
+    description: Destination directory for mirrored skills, relative to the repository root
+    required: false
+    default: .agents/skills
+
+outputs:
+  changed:
+    description: Whether mirroring changed a configured skill directory
+    value: ${{ steps.sync.outputs.changed }}
+
+runs:
+  using: composite
+  steps:
+    - id: sync
+      name: Mirror configured skills
+      shell: bash
+      env:
+        CONFIGURATION_PATH: ${{ inputs.configuration-path }}
+        DESTINATION_PATH: ${{ inputs.destination-path }}
+      run: |
+        set -euo pipefail
+
+        validate_relative_path() {
+          local path="$1"
+
+          if [[ -z "$path" || "$path" == /* || "$path" == *'\'* || "/$path/" == *'//'* ||
+            "/$path/" == *'/./'* || "/$path/" == *'/../'* ]]; then
+            echo "Expected a non-empty relative path without '.' or '..' segments: $path" >&2
+            exit 1
+          fi
+        }
+
+        repository_root="$(git rev-parse --show-toplevel)"
+        validate_relative_path "$CONFIGURATION_PATH"
+        validate_relative_path "$DESTINATION_PATH"
+
+        configuration_path="$repository_root/$CONFIGURATION_PATH"
+        destination_path="$repository_root/$DESTINATION_PATH"
+
+        if [[ ! -f "$configuration_path" ]]; then
+          echo "Skills synchronization configuration does not exist: $CONFIGURATION_PATH" >&2
+          exit 1
+        fi
+
+        temporary_directory="$(mktemp -d)"
+        trap 'rm -rf "$temporary_directory"' EXIT
+
+        configuration_records="$temporary_directory/configuration.records"
+        CONFIGURATION_PATH="$configuration_path" ruby -r yaml -e '
+          configuration = YAML.safe_load_file(ENV.fetch("CONFIGURATION_PATH"), permitted_classes: [], aliases: false)
+          repositories = configuration.fetch("repositories")
+          raise "repositories must be an array" unless repositories.is_a?(Array)
+
+          selected_skills = {}
+          repositories.each do |entry|
+            raise "repository entry must be a mapping" unless entry.is_a?(Hash)
+
+            repository = entry.fetch("repository")
+            source_path = entry.fetch("source_path")
+            skills = entry.fetch("skills")
+            raise "repository must be a string" unless repository.is_a?(String)
+            raise "source_path must be a string" unless source_path.is_a?(String)
+            raise "skills must be an array" unless skills.is_a?(Array)
+            raise "skills must not be empty" if skills.empty?
+            raise "every skill name must be a string" unless skills.all?(String)
+
+            skills.each do |skill|
+              if selected_skills.key?(skill)
+                raise "skill #{skill.inspect} is configured more than once"
+              end
+
+              selected_skills[skill] = true
+            end
+
+            print repository, "\0", source_path, "\0", skills.length, "\0"
+            skills.each { |skill| print skill, "\0" }
+          end
+        ' > "$configuration_records"
+
+        changed=false
+
+        while IFS= read -r -d '' repository &&
+          IFS= read -r -d '' source_path &&
+          IFS= read -r -d '' skill_count; do
+          if [[ ! "$repository" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+            echo "Invalid GitHub repository name: $repository" >&2
+            exit 1
+          fi
+
+          validate_relative_path "$source_path"
+
+          if [[ ! "$skill_count" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Expected at least one skill for $repository" >&2
+            exit 1
+          fi
+
+          skills=()
+          for ((index = 0; index < skill_count; index++)); do
+            IFS= read -r -d '' skill
+
+            if [[ ! "$skill" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+              echo "Invalid skill name in $repository: $skill" >&2
+              exit 1
+            fi
+
+            skills+=("$skill")
+          done
+
+          clone_directory="$temporary_directory/${repository//\//__}"
+          git clone --quiet --depth 1 --filter=blob:none --sparse "https://github.com/$repository.git" "$clone_directory"
+
+          sparse_paths=()
+          for skill in "${skills[@]}"; do
+            sparse_paths+=("$source_path/$skill")
+          done
+
+          git -C "$clone_directory" sparse-checkout set --no-cone "${sparse_paths[@]}"
+
+          for skill in "${skills[@]}"; do
+            source_skill="$clone_directory/$source_path/$skill"
+            destination_skill="$destination_path/$skill"
+
+            if [[ ! -f "$source_skill/SKILL.md" ]]; then
+              echo "Configured skill is missing SKILL.md: $repository/$source_path/$skill" >&2
+              exit 1
+            fi
+
+            if [[ -d "$destination_skill" ]]; then
+              if git diff --no-index --quiet -- "$source_skill" "$destination_skill"; then
+                continue
+              else
+                comparison_status=$?
+              fi
+
+              if [[ "$comparison_status" -ne 1 ]]; then
+                echo "Unable to compare $source_skill with $destination_skill" >&2
+                exit "$comparison_status"
+              fi
+            fi
+
+            rm -rf "$destination_skill"
+            mkdir -p "$destination_path"
+            cp -a "$source_skill" "$destination_skill"
+            changed=true
+          done
+        done < "$configuration_records"
+
+        echo "changed=$changed" >> "$GITHUB_OUTPUT"

--- a/.github/skills-sync.yml
+++ b/.github/skills-sync.yml
@@ -1,0 +1,6 @@
+repositories:
+  - repository: Devolutions/devolutions-gateway
+    source_path: .agents/skills
+    skills:
+      - commit-and-pr-conventions
+      - tessl-skill-linting

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -1,0 +1,72 @@
+name: Sync shared skills
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 23 * * 0' # Sunday at 23:00 UTC
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: sync-shared-skills
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Sync shared skills
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Synchronize configured skills
+        id: synchronize
+        uses: ./.github/actions/sync-skills
+
+      - name: Report no changes
+        if: steps.synchronize.outputs.changed != 'true'
+        run: echo "Configured skills are already synchronized."
+
+      - name: Create or update pull request
+        if: steps.synchronize.outputs.changed == 'true'
+        shell: bash
+        env:
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+          GH_TOKEN: ${{ github.token }}
+          PULL_REQUEST_BODY: |
+            Synchronizes configured shared skills from their upstream repositories.
+          PULL_REQUEST_TITLE: 'chore(skills): sync shared skills'
+          SYNCHRONIZATION_BRANCH: automation/sync-shared-skills
+        run: |
+          set -euo pipefail
+
+          if git ls-remote --exit-code --heads origin "$SYNCHRONIZATION_BRANCH" >/dev/null; then
+            git fetch --no-tags origin "refs/heads/$SYNCHRONIZATION_BRANCH:refs/remotes/origin/$SYNCHRONIZATION_BRANCH"
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -C "$SYNCHRONIZATION_BRANCH"
+          git add --force -- .agents/skills
+          git commit -m "$PULL_REQUEST_TITLE"
+          git push --force-with-lease origin "HEAD:$SYNCHRONIZATION_BRANCH"
+
+          pull_request_url="$(
+            gh pr list --head "$SYNCHRONIZATION_BRANCH" --state open --json url --jq '.[0].url'
+          )"
+
+          if [[ -n "$pull_request_url" ]]; then
+            gh pr edit "$pull_request_url" --title "$PULL_REQUEST_TITLE" --body "$PULL_REQUEST_BODY"
+          else
+            gh pr create \
+              --base "$BASE_BRANCH" \
+              --head "$SYNCHRONIZATION_BRANCH" \
+              --title "$PULL_REQUEST_TITLE" \
+              --body "$PULL_REQUEST_BODY"
+          fi

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -52,14 +52,22 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git switch -C "$SYNCHRONIZATION_BRANCH"
           git add --force -- .agents/skills
-          git commit -m "$PULL_REQUEST_TITLE"
-          git push --force-with-lease origin "HEAD:$SYNCHRONIZATION_BRANCH"
 
           pull_request_url="$(
             gh pr list --head "$SYNCHRONIZATION_BRANCH" --state open --json url --jq '.[0].url'
           )"
+
+          if [[ -n "$pull_request_url" ]] &&
+            git show-ref --verify --quiet "refs/remotes/origin/$SYNCHRONIZATION_BRANCH" &&
+            git diff --cached --quiet "origin/$SYNCHRONIZATION_BRANCH" -- .agents/skills; then
+            echo "The open synchronization pull request already contains the desired skills."
+            exit 0
+          fi
+
+          git switch -C "$SYNCHRONIZATION_BRANCH"
+          git commit -m "$PULL_REQUEST_TITLE"
+          git push --force-with-lease origin "HEAD:$SYNCHRONIZATION_BRANCH"
 
           if [[ -n "$pull_request_url" ]]; then
             gh pr edit "$pull_request_url" --title "$PULL_REQUEST_TITLE" --body "$PULL_REQUEST_BODY"


### PR DESCRIPTION
Shared skills need a repeatable way to stay aligned with their upstream repositories without creating unnecessary pull requests.

## Summary

- Add YAML configuration for selected Gateway skills and their source path.
- Add a reusable local composite action that validates, mirrors, and detects changes in `.agents/skills`.
- Add a manual and Sunday 23:00 UTC workflow that uses `gh` to create or update one synchronization PR only when content differs.

The workflow uses only `actions/checkout` and repository-local logic; an empty diff completes successfully without creating a branch or PR.