### PR TITLE
feat(activex): support RDCleanPath transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2444,6 +2444,7 @@ dependencies = [
  "sha2 0.10.9",
  "tokio",
  "tracing",
+ "url",
  "windows",
  "windows-core",
 ]

--- a/crates/ironrdp-activex/Cargo.toml
+++ b/crates/ironrdp-activex/Cargo.toml
@@ -38,6 +38,7 @@ png = "0.18"
 sha2 = "0.10"
 tokio = { version = "1", features = ["io-util", "macros", "rt-multi-thread", "sync"] }
 tracing = { version = "0.1", features = ["log"] }
+url = "2.5"
 windows = { version = "0.62", features = [
     "Win32_Foundation",
     "Win32_Graphics_Gdi",

--- a/crates/ironrdp-activex/README.md
+++ b/crates/ironrdp-activex/README.md
@@ -39,6 +39,18 @@ Use an already-hosted control from the agent with `ironrdp-agent --backend activ
 The ActiveX backend is never auto-started: its owner must create the control with the opt-in
 environment variable before the agent connects.
 
+### RDCleanPath
+
+RDCleanPath is supported through this opt-in local RPC configuration path, not through the classic MSTSCLib Automation interfaces.
+Those published interfaces have no RDCleanPath URL or token members, so adding an unrelated Automation property would not provide a portable ActiveX contract.
+Supply `ironrdp_rdcleanpathurl` and `ironrdp_rdcleanpathtoken` in the RPC `connect` property set together with the normal destination and RDP credentials.
+Both values are required; the URL must use `ws` or `wss` and is validated as part of the connection configuration before it selects the WebSocket-based RDCleanPath transport.
+
+The token is write-only connection input.
+It is held only for the active connection, is not copied to the ActiveX persistence state or host trace, and is removed before `query-props` exposes the live session properties.
+Do not place it in an `.rdp` file, command line, or log directive.
+Certificate validation continues to use the same ActiveX `AuthenticationLevel` policy as direct and gateway sessions.
+
 ## Registration
 
 Register a bitness-matching build with:

--- a/crates/ironrdp-activex/README.md
+++ b/crates/ironrdp-activex/README.md
@@ -41,15 +41,22 @@ environment variable before the agent connects.
 
 ### RDCleanPath
 
-RDCleanPath is supported through this opt-in local RPC configuration path, not through the classic MSTSCLib Automation interfaces.
-Those published interfaces have no RDCleanPath URL or token members, so adding an unrelated Automation property would not provide a portable ActiveX contract.
-Supply `RDCleanPathUrl` and `RDCleanPathToken` in the RPC `connect` property set together with the normal destination and RDP credentials.
-Both values are required; the URL must use `ws` or `wss` and is validated as part of the connection configuration before it selects the WebSocket-based RDCleanPath transport.
-The client-standard `ironrdp_rdcleanpathurl` and `ironrdp_rdcleanpathtoken` names are not accepted by the ActiveX RPC surface.
+RDCleanPath is configured by the IronRDP extension to `IMsRdpExtendedSettings`: set
+`RDCleanPathUrl` and `RDCleanPathToken` as `VT_BSTR` properties while disconnected. This is the
+normal COM-host configuration route; `RDCleanPathUrl` is readable only while connection settings
+remain mutable, while `RDCleanPathToken` is write-only and its getter returns `E_NOTIMPL` with an
+empty `VARIANT`.
 
-The token is write-only connection input.
-It is held only for the active connection, is not copied to the ActiveX persistence state or host trace, and is removed before `query-props` exposes the live session properties.
-Do not place it in an `.rdp` file, command line, or log directive.
+Both values are required. The URL must use `ws` or `wss`, and the token must be nonempty. The
+settings are private, non-persisted connection input: they are not included in ActiveX persistence,
+host traces, or local RPC property queries. The token is discarded from the setting store after the
+connection configuration has been built. Do not place it in an `.rdp` file, command line, or log
+directive.
+
+The opt-in local RPC `connect` property set accepts the same `RDCleanPathUrl` and
+`RDCleanPathToken` names. Supplying a complete RPC pair replaces any staged COM pair; omitting it
+uses the staged COM configuration. The client-standard `ironrdp_rdcleanpathurl` and
+`ironrdp_rdcleanpathtoken` names are not accepted by the ActiveX RPC surface.
 Certificate validation continues to use the same ActiveX `AuthenticationLevel` policy as direct and gateway sessions.
 
 ## Registration

--- a/crates/ironrdp-activex/README.md
+++ b/crates/ironrdp-activex/README.md
@@ -43,8 +43,9 @@ environment variable before the agent connects.
 
 RDCleanPath is supported through this opt-in local RPC configuration path, not through the classic MSTSCLib Automation interfaces.
 Those published interfaces have no RDCleanPath URL or token members, so adding an unrelated Automation property would not provide a portable ActiveX contract.
-Supply `ironrdp_rdcleanpathurl` and `ironrdp_rdcleanpathtoken` in the RPC `connect` property set together with the normal destination and RDP credentials.
+Supply `RDCleanPathUrl` and `RDCleanPathToken` in the RPC `connect` property set together with the normal destination and RDP credentials.
 Both values are required; the URL must use `ws` or `wss` and is validated as part of the connection configuration before it selects the WebSocket-based RDCleanPath transport.
+The client-standard `ironrdp_rdcleanpathurl` and `ironrdp_rdcleanpathtoken` names are not accepted by the ActiveX RPC surface.
 
 The token is write-only connection input.
 It is held only for the active connection, is not copied to the ActiveX persistence state or host trace, and is removed before `query-props` exposes the live session properties.

--- a/crates/ironrdp-activex/README.md
+++ b/crates/ironrdp-activex/README.md
@@ -48,10 +48,11 @@ remain mutable, while `RDCleanPathToken` is write-only and its getter returns `E
 empty `VARIANT`.
 
 Both values are required. The URL must use `ws` or `wss`, and the token must be nonempty. The
-settings are private, non-persisted connection input: they are not included in ActiveX persistence,
-host traces, or local RPC property queries. The token is discarded from the setting store after the
-connection configuration has been built. Do not place it in an `.rdp` file, command line, or log
-directive.
+settings are non-persisted connection input and are not included in ActiveX persistence or host
+traces. The token is never returned through local RPC property queries and is discarded from the
+setting store after the connection configuration has been built. An RPC-supplied URL remains
+observable through the local RPC property query. Do not place the token in an `.rdp` file, command
+line, or log directive.
 
 The opt-in local RPC `connect` property set accepts the same `RDCleanPathUrl` and
 `RDCleanPathToken` names. Supplying a complete RPC pair replaces any staged COM pair; omitting it

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -12,7 +12,7 @@ use std::sync::{Arc, Mutex, mpsc as std_mpsc};
 use std::time::Duration;
 
 use ironrdp_cfg::{AudioMode, GatewayCredentialsSource, GatewayUsageMethod};
-use ironrdp_client::config::{ClipboardType, ConfigBuilder, Destination, Transport, TransportKind};
+use ironrdp_client::config::{ClipboardType, ConfigBuilder, Destination, RDCleanPathConfig, Transport, TransportKind};
 use ironrdp_client::rdp::{CliprdrBackendFactory, RdpClient, RdpInputEvent, RdpInputSender, RdpOutputEvent};
 use ironrdp_cliprdr::backend::{ClipboardMessage, ClipboardMessageProxy};
 use ironrdp_cliprdr_native::WinClipboard;
@@ -2318,6 +2318,7 @@ fn is_fullscreen_hotkey(virtual_key: VIRTUAL_KEY, control_and_alt_pressed: bool)
     control_and_alt_pressed && matches!(virtual_key, VK_CANCEL | VK_PAUSE)
 }
 
+#[derive(Clone)]
 enum ActiveXTransport {
     Direct,
     Gateway {
@@ -2325,6 +2326,31 @@ enum ActiveXTransport {
         username: String,
         password: String,
     },
+    RDCleanPath(RDCleanPathConfig),
+}
+
+fn active_x_transport_from_client_transport(transport: &Transport) -> ActiveXTransport {
+    match transport {
+        Transport::Direct => ActiveXTransport::Direct,
+        Transport::Gateway(gateway) => ActiveXTransport::Gateway {
+            endpoint: gateway.endpoint.clone(),
+            username: gateway.username.clone(),
+            password: gateway.password.clone(),
+        },
+        Transport::RDCleanPath(rdcleanpath) => ActiveXTransport::RDCleanPath(rdcleanpath.clone()),
+    }
+}
+
+fn rdcleanpath_rpc_configuration_error(properties: &PropertySet) -> Option<&'static str> {
+    match (
+        properties.get::<&str>("ironrdp_rdcleanpathurl"),
+        properties.get::<&str>("ironrdp_rdcleanpathtoken"),
+    ) {
+        (Some(_), None) => Some("RDCleanPath token is required when an RDCleanPath URL is configured"),
+        (None, Some(_)) => Some("RDCleanPath URL is required when an RDCleanPath token is configured"),
+        (_, Some("")) => Some("RDCleanPath token must not be empty"),
+        _ => None,
+    }
 }
 
 fn domain_qualified_username(domain: &str, username: &str) -> String {
@@ -4250,6 +4276,7 @@ pub(crate) struct Control {
     traced_paint_layout_generation: Cell<u64>,
     rpc: Option<ActiveXRpc>,
     rpc_properties: RefCell<Option<PropertySet>>,
+    rpc_transport: RefCell<Option<ActiveXTransport>>,
     rpc_kerberos_config: RefCell<Option<ironrdp_connector::credssp::KerberosConfig>>,
     rpc_log_directive: RefCell<Option<String>>,
 }
@@ -4359,6 +4386,7 @@ impl Control {
             traced_paint_layout_generation: Cell::new(0),
             rpc: ActiveXRpc::from_environment(),
             rpc_properties: RefCell::new(None),
+            rpc_transport: RefCell::new(None),
             rpc_kerberos_config: RefCell::new(None),
             rpc_log_directive: RefCell::new(None),
         }
@@ -6358,14 +6386,15 @@ impl Control {
                 "a session is already active; disconnect first",
             );
         }
-        if [
-            "ironrdp_dvcpipeproxy",
-            "ironrdp_dvcplugin",
-            "ironrdp_rdcleanpathurl",
-            "ironrdp_rdcleanpathtoken",
-        ]
-        .into_iter()
-        .any(|key| properties.get::<&str>(key).is_some())
+        if let Some(message) = rdcleanpath_rpc_configuration_error(&properties) {
+            return ironrdp_agent::ipc::Response::typed_error(
+                ironrdp_agent::ipc::AgentErrorCategory::InvalidRequest,
+                message,
+            );
+        }
+        if ["ironrdp_dvcpipeproxy", "ironrdp_dvcplugin"]
+            .into_iter()
+            .any(|key| properties.get::<&str>(key).is_some())
             || [
                 "ironrdp_qoi",
                 "ironrdp_qoiz",
@@ -6438,10 +6467,12 @@ impl Control {
                 );
             }
         };
-        if matches!(config.transport(), Transport::RDCleanPath(_)) {
+        if let Transport::RDCleanPath(rdcleanpath) = config.transport()
+            && !matches!(rdcleanpath.url.scheme(), "ws" | "wss")
+        {
             return ironrdp_agent::ipc::Response::typed_error(
                 ironrdp_agent::ipc::AgentErrorCategory::InvalidRequest,
-                "RDCleanPath is not supported by the ActiveX host",
+                "RDCleanPath URL must use the ws or wss scheme",
             );
         }
         let Credentials::UsernamePassword { username, password } = &config.connector().credentials else {
@@ -6451,6 +6482,7 @@ impl Control {
             );
         };
 
+        let rpc_transport = active_x_transport_from_client_transport(config.transport());
         {
             let mut settings = self.settings.borrow_mut();
             settings.server = config.destination().name().to_owned();
@@ -6514,16 +6546,25 @@ impl Control {
                     compatibility.gateway_usage_method = GatewayUsageMethod::UseAlways.as_i64() as u32;
                     compatibility.gateway_creds_source = GatewayCredentialsSource::UseUserCredentials.as_i64() as u32;
                 }
-                Transport::RDCleanPath(_) => unreachable!("RDCleanPath was rejected above"),
+                Transport::RDCleanPath(_) => {
+                    compatibility.gateway_hostname.clear();
+                    compatibility.gateway_username.clear();
+                    compatibility.gateway_password.clear();
+                    compatibility.gateway_domain.clear();
+                    compatibility.gateway_usage_method = GatewayUsageMethod::Direct.as_i64() as u32;
+                    compatibility.gateway_creds_source = GatewayCredentialsSource::UseServerCredentials.as_i64() as u32;
+                }
             }
         }
 
         *self.rpc_properties.borrow_mut() = Some(config.properties().clone());
+        *self.rpc_transport.borrow_mut() = Some(rpc_transport);
         *self.rpc_kerberos_config.borrow_mut() = config.kerberos_config().cloned();
         *self.rpc_log_directive.borrow_mut() = log_directive;
         match self.start_connection() {
             Ok(()) if self.state.get() == ConnectionState::Disconnected => {
                 self.rpc_properties.borrow_mut().take();
+                self.rpc_transport.borrow_mut().take();
                 self.rpc_kerberos_config.borrow_mut().take();
                 let _ = self.rpc_log_directive.borrow_mut().take();
                 ironrdp_agent::ipc::Response::typed_error(
@@ -6534,6 +6575,7 @@ impl Control {
             Ok(()) => ironrdp_agent::ipc::Response::ok(),
             Err(error) => {
                 self.rpc_properties.borrow_mut().take();
+                self.rpc_transport.borrow_mut().take();
                 self.rpc_kerberos_config.borrow_mut().take();
                 let _ = self.rpc_log_directive.borrow_mut().take();
                 rpc_control_error(error)
@@ -6620,7 +6662,10 @@ impl Control {
         let keyboard_functional_keys_count = compatibility.keyboard_functional_keys_count;
         let alternate_shell = compatibility.secured_start_program.clone();
         let work_dir = compatibility.secured_work_dir.clone();
-        let transport = active_x_transport(&settings, &compatibility)?;
+        let transport = match self.rpc_transport.borrow_mut().take() {
+            Some(transport) => transport,
+            None => active_x_transport(&settings, &compatibility)?,
+        };
         let performance_flags = compatibility.performance_flags;
         let keyboard_layout = compatibility.keyboard_layout;
         let connection_type = compatibility.network_connection_type;
@@ -6820,6 +6865,9 @@ impl Control {
                 .with_transport(TransportKind::Gateway { endpoint })
                 .with_gateway_username(username)
                 .with_gateway_password(password),
+            ActiveXTransport::RDCleanPath(rdcleanpath) => builder
+                .with_transport(TransportKind::RDCleanPath { url: rdcleanpath.url })
+                .with_rdcleanpath_token(rdcleanpath.auth_token),
         };
         let builder = dvc_plugin_paths
             .into_iter()
@@ -12058,6 +12106,59 @@ mod tests {
             .expect("ActiveX config includes bitmap capabilities");
         assert_eq!(bitmap.color_depth, 32);
         assert!(!bitmap.lossy_compression);
+    }
+
+    #[test]
+    fn activex_maps_client_rdcleanpath_transport() {
+        let config = ConfigBuilder::new()
+            .with_destination(Destination::from_parts("rdp.example.test", 3389))
+            .with_username("user")
+            .with_password("password")
+            .with_client_build(10_000)
+            .with_client_dir("C:\\")
+            .with_client_name("IronRDP ActiveX")
+            .with_platform(MajorPlatformType::WINDOWS)
+            .with_transport(TransportKind::RDCleanPath {
+                url: "wss://rdcleanpath.example.test/rdp"
+                    .parse()
+                    .expect("RDCleanPath URL is valid"),
+            })
+            .with_rdcleanpath_token("test-token")
+            .build()
+            .expect("ActiveX RDCleanPath configuration is valid");
+
+        let ActiveXTransport::RDCleanPath(rdcleanpath) = active_x_transport_from_client_transport(config.transport())
+        else {
+            panic!("client RDCleanPath transport must be retained");
+        };
+        assert_eq!(rdcleanpath.url.as_str(), "wss://rdcleanpath.example.test/rdp");
+        assert_eq!(rdcleanpath.auth_token, "test-token");
+    }
+
+    #[test]
+    fn activex_rpc_rdcleanpath_configuration_requires_a_url_and_token() {
+        let mut properties = PropertySet::new();
+        properties.insert("ironrdp_rdcleanpathurl", "wss://rdcleanpath.example.test/rdp");
+        assert_eq!(
+            rdcleanpath_rpc_configuration_error(&properties),
+            Some("RDCleanPath token is required when an RDCleanPath URL is configured")
+        );
+
+        properties.remove("ironrdp_rdcleanpathurl");
+        properties.insert("ironrdp_rdcleanpathtoken", "test-token");
+        assert_eq!(
+            rdcleanpath_rpc_configuration_error(&properties),
+            Some("RDCleanPath URL is required when an RDCleanPath token is configured")
+        );
+
+        properties.insert("ironrdp_rdcleanpathurl", "wss://rdcleanpath.example.test/rdp");
+        assert_eq!(rdcleanpath_rpc_configuration_error(&properties), None);
+
+        properties.insert("ironrdp_rdcleanpathtoken", "");
+        assert_eq!(
+            rdcleanpath_rpc_configuration_error(&properties),
+            Some("RDCleanPath token must not be empty")
+        );
     }
 
     #[implement(IDispatch)]

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -2341,15 +2341,37 @@ fn active_x_transport_from_client_transport(transport: &Transport) -> ActiveXTra
     }
 }
 
-fn rdcleanpath_rpc_configuration_error(properties: &PropertySet) -> Option<&'static str> {
-    match (
-        properties.get::<&str>("ironrdp_rdcleanpathurl"),
-        properties.get::<&str>("ironrdp_rdcleanpathtoken"),
-    ) {
-        (Some(_), None) => Some("RDCleanPath token is required when an RDCleanPath URL is configured"),
-        (None, Some(_)) => Some("RDCleanPath URL is required when an RDCleanPath token is configured"),
-        (_, Some("")) => Some("RDCleanPath token must not be empty"),
-        _ => None,
+fn rdcleanpath_rpc_client_properties(properties: &PropertySet) -> core::result::Result<PropertySet, &'static str> {
+    let has_legacy_property = properties
+        .iter()
+        .any(|(key, _)| matches!(key.as_ref(), "ironrdp_rdcleanpathurl" | "ironrdp_rdcleanpathtoken"));
+    if has_legacy_property {
+        return Err("use RDCleanPathUrl and RDCleanPathToken for ActiveX RPC connections");
+    }
+
+    let url = properties.get::<&str>("RDCleanPathUrl");
+    let token = properties.get::<&str>("RDCleanPathToken");
+    let has_url = properties.iter().any(|(key, _)| key.as_ref() == "RDCleanPathUrl");
+    let has_token = properties.iter().any(|(key, _)| key.as_ref() == "RDCleanPathToken");
+
+    if has_url && url.is_none() {
+        return Err("RDCleanPathUrl must be a string");
+    }
+    if has_token && token.is_none() {
+        return Err("RDCleanPathToken must be a string");
+    }
+
+    match (url, token) {
+        (Some(_), None) => Err("RDCleanPathToken is required when RDCleanPathUrl is configured"),
+        (None, Some(_)) => Err("RDCleanPathUrl is required when RDCleanPathToken is configured"),
+        (_, Some("")) => Err("RDCleanPathToken must not be empty"),
+        (Some(url), Some(token)) => {
+            let mut client_properties = properties.clone();
+            client_properties.insert("ironrdp_rdcleanpathurl", url.to_owned());
+            client_properties.insert("ironrdp_rdcleanpathtoken", token.to_owned());
+            Ok(client_properties)
+        }
+        (None, None) => Ok(properties.clone()),
     }
 }
 
@@ -6386,12 +6408,15 @@ impl Control {
                 "a session is already active; disconnect first",
             );
         }
-        if let Some(message) = rdcleanpath_rpc_configuration_error(&properties) {
-            return ironrdp_agent::ipc::Response::typed_error(
-                ironrdp_agent::ipc::AgentErrorCategory::InvalidRequest,
-                message,
-            );
-        }
+        let client_properties = match rdcleanpath_rpc_client_properties(&properties) {
+            Ok(properties) => properties,
+            Err(message) => {
+                return ironrdp_agent::ipc::Response::typed_error(
+                    ironrdp_agent::ipc::AgentErrorCategory::InvalidRequest,
+                    message,
+                );
+            }
+        };
         if ["ironrdp_dvcpipeproxy", "ironrdp_dvcplugin"]
             .into_iter()
             .any(|key| properties.get::<&str>(key).is_some())
@@ -6423,7 +6448,7 @@ impl Control {
                 );
             }
         };
-        let builder = match ConfigBuilder::from_property_set(&properties) {
+        let builder = match ConfigBuilder::from_property_set(&client_properties) {
             Ok(builder) => builder,
             Err(error) => {
                 return ironrdp_agent::ipc::Response::typed_error(
@@ -6557,7 +6582,7 @@ impl Control {
             }
         }
 
-        *self.rpc_properties.borrow_mut() = Some(config.properties().clone());
+        *self.rpc_properties.borrow_mut() = Some(properties);
         *self.rpc_transport.borrow_mut() = Some(rpc_transport);
         *self.rpc_kerberos_config.borrow_mut() = config.kerberos_config().cloned();
         *self.rpc_log_directive.borrow_mut() = log_directive;
@@ -12136,28 +12161,52 @@ mod tests {
     }
 
     #[test]
-    fn activex_rpc_rdcleanpath_configuration_requires_a_url_and_token() {
+    fn activex_rpc_rdcleanpath_configuration_uses_activex_property_names() {
         let mut properties = PropertySet::new();
+        properties.insert("RDCleanPathUrl", "wss://rdcleanpath.example.test/rdp");
+        assert_eq!(
+            rdcleanpath_rpc_client_properties(&properties),
+            Err("RDCleanPathToken is required when RDCleanPathUrl is configured")
+        );
+
+        properties.remove("RDCleanPathUrl");
+        properties.insert("RDCleanPathToken", "test-token");
+        assert_eq!(
+            rdcleanpath_rpc_client_properties(&properties),
+            Err("RDCleanPathUrl is required when RDCleanPathToken is configured")
+        );
+
+        properties.insert("RDCleanPathUrl", "wss://rdcleanpath.example.test/rdp");
+        let client_properties =
+            rdcleanpath_rpc_client_properties(&properties).expect("complete ActiveX configuration is valid");
+        assert_eq!(
+            client_properties.get::<&str>("ironrdp_rdcleanpathurl"),
+            Some("wss://rdcleanpath.example.test/rdp")
+        );
+        assert_eq!(
+            client_properties.get::<&str>("ironrdp_rdcleanpathtoken"),
+            Some("test-token")
+        );
+
+        properties.insert("RDCleanPathToken", "");
+        assert_eq!(
+            rdcleanpath_rpc_client_properties(&properties),
+            Err("RDCleanPathToken must not be empty")
+        );
+
+        properties.remove("RDCleanPathUrl");
+        properties.remove("RDCleanPathToken");
         properties.insert("ironrdp_rdcleanpathurl", "wss://rdcleanpath.example.test/rdp");
         assert_eq!(
-            rdcleanpath_rpc_configuration_error(&properties),
-            Some("RDCleanPath token is required when an RDCleanPath URL is configured")
+            rdcleanpath_rpc_client_properties(&properties),
+            Err("use RDCleanPathUrl and RDCleanPathToken for ActiveX RPC connections")
         );
 
         properties.remove("ironrdp_rdcleanpathurl");
-        properties.insert("ironrdp_rdcleanpathtoken", "test-token");
+        properties.insert("RDCleanPathUrl", 42i32);
         assert_eq!(
-            rdcleanpath_rpc_configuration_error(&properties),
-            Some("RDCleanPath URL is required when an RDCleanPath token is configured")
-        );
-
-        properties.insert("ironrdp_rdcleanpathurl", "wss://rdcleanpath.example.test/rdp");
-        assert_eq!(rdcleanpath_rpc_configuration_error(&properties), None);
-
-        properties.insert("ironrdp_rdcleanpathtoken", "");
-        assert_eq!(
-            rdcleanpath_rpc_configuration_error(&properties),
-            Some("RDCleanPath token must not be empty")
+            rdcleanpath_rpc_client_properties(&properties),
+            Err("RDCleanPathUrl must be a string")
         );
     }
 

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -6793,9 +6793,10 @@ impl Control {
         let work_dir = compatibility.secured_work_dir.clone();
         let transport = match self.rpc_transport.borrow_mut().take() {
             Some(transport) => transport,
-            None => self
-                .rdcleanpath_transport()?
-                .unwrap_or(active_x_transport(&settings, &compatibility)?),
+            None => match self.rdcleanpath_transport()? {
+                Some(transport) => transport,
+                None => active_x_transport(&settings, &compatibility)?,
+            },
         };
         let performance_flags = compatibility.performance_flags;
         let keyboard_layout = compatibility.keyboard_layout;

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -143,6 +143,8 @@ const ACTIVEX_CLIENT_DIRECTORY_PROPERTY: &str = "IronRdpClientDirectory";
 const ACTIVEX_IME_FILE_NAME_PROPERTY: &str = "IronRdpImeFileName";
 const ACTIVEX_DIGITAL_PRODUCT_ID_PROPERTY: &str = "IronRdpDigitalProductId";
 const ACTIVEX_FAKE_EVENTS_INTERVAL_PROPERTY: &str = "IronRdpFakeEventsIntervalMinutes";
+const ACTIVEX_RDCLEANPATH_URL_PROPERTY: &str = "RDCleanPathUrl";
+const ACTIVEX_RDCLEANPATH_TOKEN_PROPERTY: &str = "RDCleanPathToken";
 const MAX_ACTIVEX_EXTENDED_SETTING_STRING_BYTES: usize = 8 * 1024;
 const ACTIVEX_DVC_PLUGIN_OPT_IN: &str = "IRONRDP_ACTIVEX_ENABLE_DVC_PLUGINS";
 const MAX_ACTIVEX_DVC_PLUGINS: usize = 16;
@@ -1052,6 +1054,69 @@ fn active_x_connection_settings_mutable(state: ConnectionState, settings: &Compa
         return Err(Error::from_hresult(E_UNEXPECTED));
     }
     Ok(())
+}
+
+#[derive(Clone, Default)]
+struct RDCleanPathSettings {
+    url: Option<String>,
+    token: Option<String>,
+}
+
+impl RDCleanPathSettings {
+    fn set_url(&mut self, value: String) -> Result<()> {
+        let value = validate_activex_extended_string(value)?;
+        let url = value
+            .parse::<url::Url>()
+            .map_err(|_| Error::new(E_INVALIDARG, "invalid RDCleanPath URL"))?;
+        if !matches!(url.scheme(), "ws" | "wss") {
+            return Err(Error::new(
+                E_INVALIDARG,
+                "RDCleanPath URL must use the ws or wss scheme",
+            ));
+        }
+
+        self.url = Some(value);
+        Ok(())
+    }
+
+    fn set_token(&mut self, value: String) -> Result<()> {
+        let value = validate_activex_extended_string(value)?;
+        if value.is_empty() {
+            return Err(Error::new(E_INVALIDARG, "RDCleanPathToken must not be empty"));
+        }
+
+        self.token = Some(value);
+        Ok(())
+    }
+
+    fn transport(&self) -> Result<Option<ActiveXTransport>> {
+        match (&self.url, &self.token) {
+            (None, None) => Ok(None),
+            (Some(url), Some(token)) => {
+                let url = url
+                    .parse::<url::Url>()
+                    .map_err(|_| Error::new(E_INVALIDARG, "invalid RDCleanPath URL"))?;
+                Ok(Some(ActiveXTransport::RDCleanPath(RDCleanPathConfig {
+                    url,
+                    auth_token: token.clone(),
+                })))
+            }
+            _ => Err(Error::new(
+                E_INVALIDARG,
+                "RDCleanPathUrl and RDCleanPathToken must be configured together",
+            )),
+        }
+    }
+
+    fn apply_to_client_properties(&self, properties: &mut PropertySet) -> Result<()> {
+        if let (Some(url), Some(token)) = (&self.url, &self.token) {
+            properties.insert("ironrdp_rdcleanpathurl", url.clone());
+            properties.insert("ironrdp_rdcleanpathtoken", token.clone());
+        } else {
+            self.transport()?;
+        }
+        Ok(())
+    }
 }
 
 // The settings objects are consumed through their published dual-interface vtables by
@@ -2349,10 +2414,14 @@ fn rdcleanpath_rpc_client_properties(properties: &PropertySet) -> core::result::
         return Err("use RDCleanPathUrl and RDCleanPathToken for ActiveX RPC connections");
     }
 
-    let url = properties.get::<&str>("RDCleanPathUrl");
-    let token = properties.get::<&str>("RDCleanPathToken");
-    let has_url = properties.iter().any(|(key, _)| key.as_ref() == "RDCleanPathUrl");
-    let has_token = properties.iter().any(|(key, _)| key.as_ref() == "RDCleanPathToken");
+    let url = properties.get::<&str>(ACTIVEX_RDCLEANPATH_URL_PROPERTY);
+    let token = properties.get::<&str>(ACTIVEX_RDCLEANPATH_TOKEN_PROPERTY);
+    let has_url = properties
+        .iter()
+        .any(|(key, _)| key.as_ref() == ACTIVEX_RDCLEANPATH_URL_PROPERTY);
+    let has_token = properties
+        .iter()
+        .any(|(key, _)| key.as_ref() == ACTIVEX_RDCLEANPATH_TOKEN_PROPERTY);
 
     if has_url && url.is_none() {
         return Err("RDCleanPathUrl must be a string");
@@ -4297,6 +4366,7 @@ pub(crate) struct Control {
     traced_frame_layout_generation: Cell<u64>,
     traced_paint_layout_generation: Cell<u64>,
     rpc: Option<ActiveXRpc>,
+    rdcleanpath_settings: RefCell<RDCleanPathSettings>,
     rpc_properties: RefCell<Option<PropertySet>>,
     rpc_transport: RefCell<Option<ActiveXTransport>>,
     rpc_kerberos_config: RefCell<Option<ironrdp_connector::credssp::KerberosConfig>>,
@@ -4407,11 +4477,35 @@ impl Control {
             traced_frame_layout_generation: Cell::new(0),
             traced_paint_layout_generation: Cell::new(0),
             rpc: ActiveXRpc::from_environment(),
+            rdcleanpath_settings: RefCell::new(RDCleanPathSettings::default()),
             rpc_properties: RefCell::new(None),
             rpc_transport: RefCell::new(None),
             rpc_kerberos_config: RefCell::new(None),
             rpc_log_directive: RefCell::new(None),
         }
+    }
+
+    fn replace_rdcleanpath_settings(&self, url: String, token: String) -> Result<()> {
+        let mut settings = self.rdcleanpath_settings.borrow_mut();
+        let mut replacement = settings.clone();
+        replacement.set_url(url)?;
+        replacement.set_token(token)?;
+        *settings = replacement;
+        Ok(())
+    }
+
+    fn rdcleanpath_transport(&self) -> Result<Option<ActiveXTransport>> {
+        self.rdcleanpath_settings.borrow().transport()
+    }
+
+    fn apply_rdcleanpath_settings_to_client_properties(&self, properties: &mut PropertySet) -> Result<()> {
+        self.rdcleanpath_settings
+            .borrow()
+            .apply_to_client_properties(properties)
+    }
+
+    fn clear_rdcleanpath_token(&self) {
+        self.rdcleanpath_settings.borrow_mut().token = None;
     }
 
     fn remember_callback_owner(&self, owner: *const Control_Impl) {
@@ -6408,7 +6502,7 @@ impl Control {
                 "a session is already active; disconnect first",
             );
         }
-        let client_properties = match rdcleanpath_rpc_client_properties(&properties) {
+        let mut client_properties = match rdcleanpath_rpc_client_properties(&properties) {
             Ok(properties) => properties,
             Err(message) => {
                 return ironrdp_agent::ipc::Response::typed_error(
@@ -6417,6 +6511,16 @@ impl Control {
                 );
             }
         };
+        if let Some((url, token)) = client_properties
+            .get::<&str>("ironrdp_rdcleanpathurl")
+            .zip(client_properties.get::<&str>("ironrdp_rdcleanpathtoken"))
+        {
+            if let Err(error) = self.replace_rdcleanpath_settings(url.to_owned(), token.to_owned()) {
+                return rpc_control_error(error);
+            }
+        } else if let Err(error) = self.apply_rdcleanpath_settings_to_client_properties(&mut client_properties) {
+            return rpc_control_error(error);
+        }
         if ["ironrdp_dvcpipeproxy", "ironrdp_dvcplugin"]
             .into_iter()
             .any(|key| properties.get::<&str>(key).is_some())
@@ -6689,7 +6793,9 @@ impl Control {
         let work_dir = compatibility.secured_work_dir.clone();
         let transport = match self.rpc_transport.borrow_mut().take() {
             Some(transport) => transport,
-            None => active_x_transport(&settings, &compatibility)?,
+            None => self
+                .rdcleanpath_transport()?
+                .unwrap_or(active_x_transport(&settings, &compatibility)?),
         };
         let performance_flags = compatibility.performance_flags;
         let keyboard_layout = compatibility.keyboard_layout;
@@ -6880,6 +6986,7 @@ impl Control {
         } else {
             builder
         };
+        let using_rdcleanpath = matches!(&transport, ActiveXTransport::RDCleanPath(_));
         let builder = match transport {
             ActiveXTransport::Direct => builder,
             ActiveXTransport::Gateway {
@@ -6918,6 +7025,9 @@ impl Control {
         let config = builder
             .build()
             .map_err(|error| Error::new(E_INVALIDARG, format!("invalid RDP configuration: {error}")))?;
+        if using_rdcleanpath {
+            self.clear_rdcleanpath_token();
+        }
         let rpc_destination = config.destination().to_string();
         drop(settings);
         let (output_sender, mut output_receiver) = mpsc::channel(32);
@@ -9257,6 +9367,30 @@ impl IMsRdpExtendedSettings_Impl for Control_Impl {
                 return Ok(());
             }
         }
+        if name.eq_ignore_ascii_case(ACTIVEX_RDCLEANPATH_URL_PROPERTY) {
+            if value.is_null() {
+                return Err(Error::from_hresult(E_POINTER));
+            }
+            let url = variant_string(unsafe { &*value }, ptr::null_mut())?;
+            let compatibility = self.compatibility.borrow();
+            active_x_connection_settings_mutable(self.state.get(), &compatibility)?;
+            drop(compatibility);
+            self.rdcleanpath_settings.borrow_mut().set_url(url)?;
+            trace_host_call("IMsRdpExtendedSettings::put_RDCleanPathUrl");
+            return Ok(());
+        }
+        if name.eq_ignore_ascii_case(ACTIVEX_RDCLEANPATH_TOKEN_PROPERTY) {
+            if value.is_null() {
+                return Err(Error::from_hresult(E_POINTER));
+            }
+            let token = variant_string(unsafe { &*value }, ptr::null_mut())?;
+            let compatibility = self.compatibility.borrow();
+            active_x_connection_settings_mutable(self.state.get(), &compatibility)?;
+            drop(compatibility);
+            self.rdcleanpath_settings.borrow_mut().set_token(token)?;
+            trace_host_call("IMsRdpExtendedSettings::put_RDCleanPathToken");
+            return Ok(());
+        }
         if name.eq_ignore_ascii_case("ClientDeviceName") {
             if value.is_null() {
                 return Err(Error::from_hresult(E_POINTER));
@@ -9435,6 +9569,18 @@ impl IMsRdpExtendedSettings_Impl for Control_Impl {
         if name.eq_ignore_ascii_case("ZoomLevel") {
             trace_host_call("IMsRdpExtendedSettings::get_ZoomLevel");
             return write_out(value, variant_i32(self.compatibility.borrow().zoom_level));
+        }
+        if name.eq_ignore_ascii_case(ACTIVEX_RDCLEANPATH_URL_PROPERTY) {
+            let compatibility = self.compatibility.borrow();
+            active_x_connection_settings_mutable(self.state.get(), &compatibility)?;
+            drop(compatibility);
+            let url = self.rdcleanpath_settings.borrow().url.clone().unwrap_or_default();
+            trace_host_call("IMsRdpExtendedSettings::get_RDCleanPathUrl");
+            return write_out(value, variant_bstr(url));
+        }
+        if name.eq_ignore_ascii_case(ACTIVEX_RDCLEANPATH_TOKEN_PROPERTY) {
+            write_out(value, VARIANT::default())?;
+            return Err(Error::from_hresult(E_NOTIMPL));
         }
         if name.eq_ignore_ascii_case("ClientDeviceName") {
             let client_name = self
@@ -12208,6 +12354,99 @@ mod tests {
             rdcleanpath_rpc_client_properties(&properties),
             Err("RDCleanPathUrl must be a string")
         );
+    }
+
+    #[test]
+    fn extended_settings_expose_rdcleanpath_url_and_protect_token() {
+        let control: IMsRdpClient10 = Control::new().into();
+        let extended = control
+            .cast::<IMsRdpExtendedSettings>()
+            .expect("control supports IMsRdpExtendedSettings");
+
+        let mut invalid_url = variant_i32(42);
+        let error = unsafe {
+            extended
+                .put_Property(BSTR::from(ACTIVEX_RDCLEANPATH_URL_PROPERTY).as_ptr(), &mut invalid_url)
+                .expect_err("RDCleanPathUrl only accepts VT_BSTR")
+        };
+        assert_eq!(error.code(), DISP_E_TYPEMISMATCH);
+
+        let mut invalid_scheme = variant_bstr("https://rdcleanpath.example.test/rdp".to_owned());
+        let error = unsafe {
+            extended
+                .put_Property(
+                    BSTR::from(ACTIVEX_RDCLEANPATH_URL_PROPERTY).as_ptr(),
+                    &mut invalid_scheme,
+                )
+                .expect_err("RDCleanPathUrl only accepts ws and wss URLs")
+        };
+        free_owned_bstr_variant(&mut invalid_scheme);
+        assert_eq!(error.code(), E_INVALIDARG);
+
+        let mut url = variant_bstr("wss://rdcleanpath.example.test/rdp".to_owned());
+        unsafe {
+            extended
+                .put_Property(BSTR::from(ACTIVEX_RDCLEANPATH_URL_PROPERTY).as_ptr(), &mut url)
+                .expect("set RDCleanPath URL");
+        }
+        free_owned_bstr_variant(&mut url);
+
+        let mut returned_url = VARIANT::default();
+        unsafe {
+            extended
+                .get_Property(BSTR::from(ACTIVEX_RDCLEANPATH_URL_PROPERTY).as_ptr(), &mut returned_url)
+                .expect("get RDCleanPath URL");
+        }
+        assert_eq!(
+            variant_bstr_value(&returned_url).expect("RDCleanPath URL BSTR"),
+            "wss://rdcleanpath.example.test/rdp"
+        );
+        free_owned_bstr_variant(&mut returned_url);
+
+        let mut token = variant_bstr("test-token".to_owned());
+        unsafe {
+            extended
+                .put_Property(BSTR::from(ACTIVEX_RDCLEANPATH_TOKEN_PROPERTY).as_ptr(), &mut token)
+                .expect("set RDCleanPath token");
+        }
+        free_owned_bstr_variant(&mut token);
+
+        let mut returned_token = VARIANT::default();
+        let error = unsafe {
+            extended
+                .get_Property(
+                    BSTR::from(ACTIVEX_RDCLEANPATH_TOKEN_PROPERTY).as_ptr(),
+                    &mut returned_token,
+                )
+                .expect_err("RDCleanPathToken is write-only")
+        };
+        assert_eq!(error.code(), E_NOTIMPL);
+        assert_eq!(variant_header(&returned_token).vt, VT_EMPTY);
+    }
+
+    #[test]
+    fn rdcleanpath_settings_require_a_complete_pair_and_mutable_connection_settings() {
+        let mut settings = RDCleanPathSettings::default();
+        settings
+            .set_url("wss://rdcleanpath.example.test/rdp".to_owned())
+            .expect("RDCleanPath URL is valid");
+        let error = match settings.transport() {
+            Ok(_) => panic!("RDCleanPath token is required"),
+            Err(error) => error,
+        };
+        assert_eq!(error.code(), E_INVALIDARG);
+
+        let control = Control::new();
+        control.compatibility.borrow_mut().connection_settings_sealed = true;
+        let extended: IMsRdpExtendedSettings = control.into();
+        let mut url = variant_bstr("wss://rdcleanpath.example.test/rdp".to_owned());
+        let error = unsafe {
+            extended
+                .put_Property(BSTR::from(ACTIVEX_RDCLEANPATH_URL_PROPERTY).as_ptr(), &mut url)
+                .expect_err("RDCleanPath settings are immutable after connection settings are sealed")
+        };
+        free_owned_bstr_variant(&mut url);
+        assert_eq!(error.code(), E_UNEXPECTED);
     }
 
     #[implement(IDispatch)]

--- a/crates/ironrdp-activex/src/rpc.rs
+++ b/crates/ironrdp-activex/src/rpc.rs
@@ -193,6 +193,7 @@ impl ActiveXRpc {
     }
 
     pub(crate) fn session_started(&self, destination: String, mut properties: PropertySet, endpoint: Arc<NowEndpoint>) {
+        properties.remove("RDCleanPathToken");
         properties.remove("ironrdp_rdcleanpathtoken");
         self.shared.logs.clear();
         let mut live = lock(&self.shared.live);
@@ -786,8 +787,8 @@ mod tests {
     fn rdcleanpath_token_is_not_exposed_in_session_properties() {
         let rpc = rpc();
         let mut properties = PropertySet::new();
-        properties.insert("ironrdp_rdcleanpathurl", "wss://rdcleanpath.example.test/rdp");
-        properties.insert("ironrdp_rdcleanpathtoken", "test-token");
+        properties.insert("RDCleanPathUrl", "wss://rdcleanpath.example.test/rdp");
+        properties.insert("RDCleanPathToken", "test-token");
         let endpoint = Arc::new(NowEndpoint::new().expect("allocate NOW endpoint"));
 
         rpc.session_started("server.example:3389".to_owned(), properties, endpoint);
@@ -795,18 +796,8 @@ mod tests {
         let Response::Ok(Payload::Properties(properties)) = query_props(&rpc.shared, None) else {
             panic!("session properties must be available");
         };
-        assert!(
-            properties
-                .entries
-                .iter()
-                .any(|entry| entry.key == "ironrdp_rdcleanpathurl")
-        );
-        assert!(
-            !properties
-                .entries
-                .iter()
-                .any(|entry| entry.key == "ironrdp_rdcleanpathtoken")
-        );
+        assert!(properties.entries.iter().any(|entry| entry.key == "RDCleanPathUrl"));
+        assert!(!properties.entries.iter().any(|entry| entry.key == "RDCleanPathToken"));
     }
 
     #[test]

--- a/crates/ironrdp-activex/src/rpc.rs
+++ b/crates/ironrdp-activex/src/rpc.rs
@@ -192,7 +192,8 @@ impl ActiveXRpc {
         }
     }
 
-    pub(crate) fn session_started(&self, destination: String, properties: PropertySet, endpoint: Arc<NowEndpoint>) {
+    pub(crate) fn session_started(&self, destination: String, mut properties: PropertySet, endpoint: Arc<NowEndpoint>) {
+        properties.remove("ironrdp_rdcleanpathtoken");
         self.shared.logs.clear();
         let mut live = lock(&self.shared.live);
         live.state = ConnState::Connecting;
@@ -779,6 +780,33 @@ mod tests {
         };
         assert_eq!(stopped_status.state, ConnState::Disconnected);
         assert!(!screenshot(&rpc.shared).is_ok());
+    }
+
+    #[test]
+    fn rdcleanpath_token_is_not_exposed_in_session_properties() {
+        let rpc = rpc();
+        let mut properties = PropertySet::new();
+        properties.insert("ironrdp_rdcleanpathurl", "wss://rdcleanpath.example.test/rdp");
+        properties.insert("ironrdp_rdcleanpathtoken", "test-token");
+        let endpoint = Arc::new(NowEndpoint::new().expect("allocate NOW endpoint"));
+
+        rpc.session_started("server.example:3389".to_owned(), properties, endpoint);
+
+        let Response::Ok(Payload::Properties(properties)) = query_props(&rpc.shared, None) else {
+            panic!("session properties must be available");
+        };
+        assert!(
+            properties
+                .entries
+                .iter()
+                .any(|entry| entry.key == "ironrdp_rdcleanpathurl")
+        );
+        assert!(
+            !properties
+                .entries
+                .iter()
+                .any(|entry| entry.key == "ironrdp_rdcleanpathtoken")
+        );
     }
 
     #[test]

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -947,7 +947,7 @@ where
         let rdcleanpath_req =
             ironrdp_rdcleanpath::RDCleanPathPdu::new_request(x224_pdu, destination, proxy_auth_token, pcb)
                 .map_err(|e| ironrdp_connector::custom_err!("new RDCleanPath request", e))?;
-        debug!("Send RDCleanPath request");
+        debug!(message = ?rdcleanpath_req, "Send RDCleanPath request");
         let rdcleanpath_req = rdcleanpath_req
             .to_der()
             .map_err(|e| ironrdp_connector::custom_err!("RDCleanPath request encode", e))?;

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -947,7 +947,7 @@ where
         let rdcleanpath_req =
             ironrdp_rdcleanpath::RDCleanPathPdu::new_request(x224_pdu, destination, proxy_auth_token, pcb)
                 .map_err(|e| ironrdp_connector::custom_err!("new RDCleanPath request", e))?;
-        debug!(message = ?rdcleanpath_req, "Send RDCleanPath request");
+        debug!("Send RDCleanPath request");
         let rdcleanpath_req = rdcleanpath_req
             .to_der()
             .map_err(|e| ironrdp_connector::custom_err!("RDCleanPath request encode", e))?;


### PR DESCRIPTION
## Summary
- expose RDCleanPath through `IMsRdpExtendedSettings` using `RDCleanPathUrl` and write-only `RDCleanPathToken`
- preserve the matching local ActiveX RPC property names with deterministic COM/RPC precedence
- validate the required `ws`/`wss` URL and paired nonempty token while preventing token persistence, logging, or property retrieval

## Validation
- `cargo test -p ironrdp-activex`
- `cargo clippy -p ironrdp-activex --tests -- -D warnings`
- `cargo xtask check locks -v`