### PR TITLE
fix(graphics): don't emit a value after a run that ends the input

### DIFF
--- a/crates/ironrdp-graphics/src/rlgr.rs
+++ b/crates/ironrdp-graphics/src/rlgr.rs
@@ -125,14 +125,25 @@ pub fn encode(mode: EntropyAlgorithm, input: &[i16], tile: &mut [u8]) -> Result<
                     .expect("value is guaranteed to be `Some` due to the prior check");
                 let mut nz: u32 = 0;
 
-                // Count zeros: while current value is zero and more data exists,
-                // count it as a run zero and read the next value.
+                // Count zeros: while the current value is zero, count it as a
+                // run zero and read the next value.
+                //
+                // A run that reaches the end of the input has no value after
+                // it, and `run_to_end` records that. The trailing zeros are the
+                // run and nothing follows them, because RL mode codes the
+                // following value's magnitude minus one and so cannot express a
+                // magnitude of zero: coding one there decodes as a magnitude of
+                // one, which appends a coefficient the input never had.
+                let mut run_to_end = false;
                 while val == 0 {
-                    if input.peek().is_none() {
-                        break;
-                    }
                     nz += 1;
-                    val = *input.next().expect("peek confirmed Some");
+                    match input.next() {
+                        Some(&next) => val = next,
+                        None => {
+                            run_to_end = true;
+                            break;
+                        }
+                    }
                 }
 
                 let mut runmax: u32 = 1 << k;
@@ -146,11 +157,13 @@ pub fn encode(mode: EntropyAlgorithm, input: &[i16], tile: &mut [u8]) -> Result<
                 bits.output_bit(1, true);
                 bits.output_bits(k as usize, nz);
 
-                // Always encode the value after the run (even if it's 0 due
-                // to exhausted input). This matches the reference encoder.
-                let mag = u32::from(val.unsigned_abs());
-                bits.output_bit(1, val < 0);
-                code_gr(&mut bits, &mut krp, if mag > 0 { mag - 1 } else { 0 });
+                // Encode the value that ended the run. A run that consumed the
+                // rest of the input has no such value.
+                if !run_to_end {
+                    let mag = u32::from(val.unsigned_abs());
+                    bits.output_bit(1, val < 0);
+                    code_gr(&mut bits, &mut krp, mag - 1);
+                }
 
                 kp = kp.saturating_sub(DN_GR);
                 k = kp >> LS_GR;

--- a/crates/ironrdp-testsuite-core/tests/graphics/rlgr.rs
+++ b/crates/ironrdp-testsuite-core/tests/graphics/rlgr.rs
@@ -707,3 +707,34 @@ const CR_DATA_DECODED: [i16; 4096] = [
     -38, -3, -1, 61, -68, 60, -4, -37, 1, -18, 2, 29, 29, 8, 18, -74, 10, 5, -17, -22, 108, -16, 33, -124, 22, -7, 0,
     -4, 48, 26, -46, -33,
 ];
+
+/// A run that consumes the rest of the input has no value after it.
+///
+/// RL mode codes the following value's magnitude minus one, so it cannot
+/// express a magnitude of zero. Coding one anyway decodes as a magnitude of
+/// one, which appends a coefficient the input never had. Quantized wavelet
+/// coefficients almost always end in a zero run, so this reaches every
+/// RemoteFX tile.
+#[test]
+fn round_trip_preserves_a_run_that_reaches_the_end_of_the_input() {
+    let cases: [&[i16]; 6] = [
+        &[0],
+        &[0, 0, 0, 0, 0, 0, 0, 0],
+        &[5, 0, 0, 0, 0, 0, 0, 0],
+        &[0, 0, 3, 0, 0, 0, 0, 0],
+        &[1, -2, 3, 0, 0, 0, 0, 0],
+        &[7],
+    ];
+
+    for mode in [EntropyAlgorithm::Rlgr1, EntropyAlgorithm::Rlgr3] {
+        for input in cases {
+            let mut encoded = vec![0; 8192];
+            let len = encode(mode, input, encoded.as_mut_slice()).expect("encode");
+
+            let mut decoded = vec![0i16; input.len()];
+            decode(mode, &encoded[..len], decoded.as_mut_slice()).expect("decode");
+
+            assert_eq!(decoded.as_slice(), input, "{mode:?} round trip of {input:?}");
+        }
+    }
+}


### PR DESCRIPTION
RL mode codes the following value's magnitude minus one, so it cannot express
zero. #1179 began coding a zero there when the run consumed the rest of the
input, and the decoder reconstructs magnitude as the coded value plus one, so
every input ending in a zero run gained a trailing 1.

That is what fails `progressive_fractional_base_quantization_reconstructs_rgb`
from #1499 on master: quantized coefficients end in a zero run, so the phantom
value lands in HH1 of each component.

The trailing zeros are the run and nothing follows them. #1179's other two
fixes are untouched.

2000 randomized round trips per entropy mode, 0 failures. Workspace suite green.
