### PR TITLE
fix(ci): make maintainer-required outcome-driven

### DIFF
--- a/.github/PR_AUTOMATION.md
+++ b/.github/PR_AUTOMATION.md
@@ -112,6 +112,13 @@ review requires a later push and its matching successful CI run. Manual dispatch
 the CI-success requirement; it cannot bypass draft status, duplicate/XL handling, contributor
 history, classification, risk, terminal state, or SHA validation.
 
+`maintainer-required` records an actionable automation outcome, not a pull request that is merely
+waiting. Successful classification removes a stale copy of the label while CI and review are
+pending. A completed review adds it when no findings remain or when the second review makes
+automated review terminal; findings from the first review remove it. Automation failures and
+human-only stops such as duplicate, legitimacy, and `size/XL` classification also add it. A red or
+unfinished CI run does not.
+
 Fork-origin PRs are subject to daily UTC automation limits. The first five PRs from a fork author
 may use automation; authors with at least 15 qualifying merged IronRDP PRs may use ten. Across all
 forks, the workflow stops LLM automation after 30 fork-origin PRs were opened that day. This

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -416,6 +416,8 @@ test("model-owned labels coexist with path scopes and are withdrawn when no long
   assert.deepEqual(desired.sort(), [
     "kind/protocol", "kind/technical-debt", "risk/low", "scope/core", "scope/cross-cutting", "scope/web", "size/S",
   ]);
+  assert.deepEqual(classified.addLabels, []);
+  assert.deepEqual(classified.removeLabels, ["maintainer-required"]);
 
   const narrow = resolveClassificationState({
     expectedSha: SHA,
@@ -471,16 +473,75 @@ test("review publication applies the same policy the workflow spent its call on"
   const args = {
     expectedSha: SHA, reviewer, protocolStatus: "not_applicable", contributor: { status: "eligible" },
   };
-  const gate = (changes) => ({ ok: true, head_sha: SHA, classificationCheck: true, ciGreen: true, ...changes });
+  const gate = (changes) => ({
+    ok: true, available: true, head_sha: SHA, classificationCheck: true, ciGreen: true, ...changes,
+  });
   assert.equal(resolveReviewState({
     ...args, labels: ["risk/low"], gate: gate({ protocolRelated: true }),
   }).failed, undefined);
   assert.equal(resolveReviewState({
     ...args, labels: ["risk/low"], gate: gate({ protocolRelated: false }),
-  }).failed, true);
+  }).pending, true);
   assert.equal(resolveReviewState({
     ...args, labels: ["risk/low", "size/XL"], gate: gate({ protocolRelated: true }),
-  }).failed, true);
+  }).pending, true);
+});
+
+test("review waits for green CI without requesting maintainer intervention", () => {
+  const state = resolveReviewState({
+    expectedSha: SHA,
+    labels: ["risk/medium", "maintainer-required"],
+    gate: {
+      ok: false, available: true, head_sha: SHA, classificationCheck: true,
+      ciGreen: false, bypassCi: false, secondReviewEligible: true, policyEligible: true,
+    },
+    contributor: { status: "eligible" },
+  });
+  assert.equal(state.pending, true);
+  assert.equal(state.failed, undefined);
+  assert.deepEqual(state.addLabels, []);
+  assert.deepEqual(state.removeLabels, ["maintainer-required"]);
+});
+
+test("review waiting preserves actionable classification and completed review outcomes", () => {
+  const classificationFailure = resolveReviewState({
+    expectedSha: SHA,
+    labels: ["risk/unknown", "maintainer-required"],
+    gate: {
+      ok: false, available: true, head_sha: SHA, classificationCheck: false,
+      classificationFailed: true, ciGreen: false,
+    },
+    contributor: { status: "eligible" },
+  });
+  assert.equal(classificationFailure.pending, true);
+  assert.deepEqual(classificationFailure.addLabels, ["maintainer-required"]);
+  assert.deepEqual(classificationFailure.removeLabels, []);
+
+  const reviewedAtHead = resolveReviewState({
+    expectedSha: SHA,
+    labels: ["risk/medium", "ai-reviewed/1", "maintainer-required"],
+    gate: {
+      ok: false, available: true, head_sha: SHA, classificationCheck: true,
+      ciGreen: false, secondReviewEligible: false,
+    },
+    contributor: { status: "eligible" },
+  });
+  assert.equal(reviewedAtHead.pending, true);
+  assert.deepEqual(reviewedAtHead.addLabels, []);
+  assert.deepEqual(reviewedAtHead.removeLabels, []);
+
+  const reviewFailure = resolveReviewState({
+    expectedSha: SHA,
+    labels: ["risk/medium", "maintainer-required"],
+    gate: {
+      ok: false, available: true, head_sha: SHA, classificationCheck: true,
+      reviewFailed: true, ciGreen: false, secondReviewEligible: true,
+    },
+    contributor: { status: "eligible" },
+  });
+  assert.equal(reviewFailure.pending, true);
+  assert.deepEqual(reviewFailure.addLabels, ["maintainer-required"]);
+  assert.deepEqual(reviewFailure.removeLabels, []);
 });
 
 test("XL guidance is posted once and withdrawn when the change shrinks", () => {
@@ -603,7 +664,7 @@ test("quota decisions stop classification and review with a bounded human handof
 
   const review = resolveReviewState({
     expectedSha: SHA, labels: ["risk/high"],
-    gate: { ok: true, head_sha: SHA, classificationCheck: true, ciGreen: true },
+    gate: { ok: true, available: true, head_sha: SHA, classificationCheck: true, ciGreen: true },
     contributor: { status: "eligible" }, protocolStatus: "not_applicable",
     rateLimit: { status: "limited", scope: "global", quota: 30, count: 31 },
   });
@@ -618,14 +679,19 @@ test("review transition is terminal-safe and preserves human triage on no findin
   };
   const state = resolveReviewState({
     expectedSha: SHA, labels: ["risk/high"], reviewer, protocolStatus: "not_applicable",
-    gate: { ok: true, head_sha: SHA, classificationCheck: true, ciGreen: true }, contributor: { status: "eligible" },
+    gate: { ok: true, available: true, head_sha: SHA, classificationCheck: true, ciGreen: true },
+    contributor: { status: "eligible" },
   });
   assert.deepEqual(state.labelSets[0].desired, ["ai-reviewed/1"]);
   assert.deepEqual(state.addLabels, ["maintainer-required"]);
-  assert.equal(resolveReviewState({
+  const terminal = resolveReviewState({
     expectedSha: SHA, labels: ["ai-reviewed/2"], reviewer, protocolStatus: "not_applicable",
-    gate: { ok: true, head_sha: SHA, classificationCheck: true, ciGreen: true }, contributor: { status: "eligible" },
-  }).failed, true);
+    gate: { ok: true, available: true, head_sha: SHA, classificationCheck: true, ciGreen: true },
+    contributor: { status: "eligible" },
+  });
+  assert.equal(terminal.terminal, true);
+  assert.equal(terminal.failed, undefined);
+  assert.deepEqual(terminal.addLabels, ["maintainer-required"]);
 });
 
 test("an unavailable protocol handoff blocks the review count", () => {
@@ -635,12 +701,14 @@ test("an unavailable protocol handoff blocks the review count", () => {
   };
   const args = {
     expectedSha: SHA, labels: ["risk/high"], reviewer,
-    gate: { ok: true, head_sha: SHA, classificationCheck: true, ciGreen: true }, contributor: { status: "eligible" },
+    gate: { ok: true, available: true, head_sha: SHA, classificationCheck: true, ciGreen: true },
+    contributor: { status: "eligible" },
   };
   const failed = resolveReviewState({ ...args, protocolStatus: "unavailable" });
   assert.equal(failed.failed, true);
   assert.deepEqual(failed.addLabels, ["maintainer-required"]);
   assert.deepEqual(failed.labelSets, []);
+  assert.equal(failed.check.conclusion, "neutral");
   assert.equal(resolveReviewState(args).failed, true);
   assert.deepEqual(resolveReviewState({ ...args, protocolStatus: "valid" }).labelSets[0].desired, ["ai-reviewed/1"]);
 });
@@ -680,6 +748,71 @@ test("writer batches the label delta and tolerates an absent label removal", asy
   assert.equal(await applyLabels(github, "Devolutions", "IronRDP", 1, {
     expectedSha: SHA, labelSets: [], addLabels: ["risk/low"],
   }), false);
+});
+
+test("writer revalidates failures before clearing maintainer triage", async () => {
+  let removals = 0;
+  const github = {
+    paginate: { iterator: async function* (_method, options) {
+      if (options.check_name === "AI classification") {
+        yield { data: [{
+          id: 1,
+          external_id: `classifier-v2:${SHA}`,
+          conclusion: "neutral",
+          app: { slug: "github-actions" },
+          output: { title: "Classification unavailable" },
+        }] };
+      }
+    } },
+    rest: {
+      checks: { listForRef: () => {} },
+      pulls: { get: async () => ({ data: { state: "open", head: { sha: SHA } } }) },
+      issues: {
+        get: async () => ({ data: { labels: ["maintainer-required"] } }),
+        removeLabel: async () => { removals += 1; },
+      },
+    },
+  };
+  await writeState({
+    github, owner: "Devolutions", repo: "IronRDP", prNumber: 1, botLogin: "github-actions[bot]",
+    state: {
+      ok: true, mode: "review", expectedSha: SHA, pending: true, labelSets: [],
+      addLabels: [], removeLabels: ["maintainer-required"], comments: [],
+    },
+  });
+  assert.equal(removals, 0);
+});
+
+test("writer restores maintainer triage when outcome publication fails", async () => {
+  const labels = new Set(["maintainer-required"]);
+  const github = {
+    paginate: { iterator: async function* () {} },
+    rest: {
+      checks: {
+        listForRef: () => {},
+        create: async () => { throw new Error("checks API unavailable"); },
+      },
+      pulls: { get: async () => ({ data: { state: "open", head: { sha: SHA } } }) },
+      issues: {
+        get: async () => ({ data: { labels: [...labels] } }),
+        addLabels: async ({ labels: added }) => { for (const label of added) labels.add(label); },
+        removeLabel: async ({ name }) => { labels.delete(name); },
+      },
+    },
+  };
+  await assert.rejects(writeState({
+    github, owner: "Devolutions", repo: "IronRDP", prNumber: 1, botLogin: "github-actions[bot]",
+    state: {
+      ok: true, mode: "classification", expectedSha: SHA, labelSets: [],
+      addLabels: [], removeLabels: ["maintainer-required"], comments: [], removeCommentMarkers: [],
+      check: {
+        name: "AI classification", externalId: `classifier-v2:${SHA}`,
+        title: "Classification complete", summary: "Validated classification.",
+        machineState: { protocolRelated: false },
+      },
+    },
+  }), /checks API unavailable/);
+  assert.equal(labels.has("maintainer-required"), true);
 });
 
 test("writer reads normalized check-run pages and updates the newest matching run", async () => {

--- a/.github/pr-automation/labels.json
+++ b/.github/pr-automation/labels.json
@@ -102,7 +102,7 @@
   {
     "name": "maintainer-required",
     "color": "c2e0c6",
-    "description": "Maintainer review or intervention is required"
+    "description": "Automation completed with human-only triage or failed and needs maintainer intervention"
   },
   {
     "name": "ai-reviewed/1",

--- a/.github/pr-automation/resolve-state.js
+++ b/.github/pr-automation/resolve-state.js
@@ -162,8 +162,8 @@ function resolveClassificationState({
     ...optional.map(([label, enabled]) => ({ owned: [label], desired: enabled ? [label] : [] })),
     { owned: ["breaking-change"], desired: breaking ? ["breaking-change"] : [] },
   ];
-  const addLabels = ["maintainer-required"];
   const legitimacyStopped = model.likely_non_legitimate;
+  const requiresMaintainer = duplicate || legitimacyStopped;
   const comments = [
     ...(duplicate ? [{
       kind: "duplicate", marker: DUPLICATE_MARKER,
@@ -175,7 +175,10 @@ function resolveClassificationState({
     }] : []),
   ];
   return {
-    ok: true, mode: "classification", expectedSha, labelSets, addLabels, comments,
+    ok: true, mode: "classification", expectedSha, labelSets,
+    addLabels: requiresMaintainer ? ["maintainer-required"] : [],
+    removeLabels: requiresMaintainer ? [] : ["maintainer-required"],
+    comments,
     removeCommentMarkers: [
       ...(legitimacyStopped ? [] : [LEGITIMACY_MARKER]),
       // A later push can make a previously reported duplicate or XL verdict wrong, and stale
@@ -247,24 +250,49 @@ function resolveReviewState({
   rateLimit, protocolStatus,
 } = {}) {
   const existing = labelsOf(labels);
+  const needsHumanOnlyReview = existing.has("size/XL") || existing.has("duplicate") ||
+    gate?.legitimacyStopped === true || gate?.classificationFailed === true ||
+    gate?.reviewFailed === true;
   const fail = (reason) => {
     const comment = quotaComment(rateLimit);
     return {
       ok: true, mode: "review", expectedSha, failed: true, reason,
       labelSets: [], addLabels: ["maintainer-required"], comments: comment ? [comment] : [],
+      check: {
+        name: "AI automated review",
+        externalId: `${REVIEWER_SCHEMA_VERSION}:${expectedSha}`,
+        title: "Automated review unavailable",
+        summary: `Automated review was unavailable: ${reason}. Maintainer review is required.`,
+        conclusion: "neutral",
+      },
     };
   };
+  const wait = (reason, preserveMaintainer = false) => ({
+    ok: true, mode: "review", expectedSha, pending: true, reason, labelSets: [],
+    addLabels: needsHumanOnlyReview ? ["maintainer-required"] : [],
+    removeLabels: needsHumanOnlyReview || preserveMaintainer ? [] : ["maintainer-required"],
+    comments: [],
+  });
   if (typeof expectedSha !== "string") return { ok: false, reason: "missing expected SHA" };
-  if (existing.has("ai-reviewed/2")) return fail("terminal AI review count");
-  if (rateLimit && rateLimit.status !== "allowed") return fail("fork LLM quota unavailable");
-  if (!gate?.ok || gate.head_sha !== expectedSha || gate.classificationCheck !== true ||
-      (gate.ciGreen !== true && gate.bypassCi !== true) || contributor?.status !== "eligible") {
-    return fail("review gate unavailable");
+  if (existing.has("ai-reviewed/2")) {
+    return {
+      ok: true, mode: "review", expectedSha, terminal: true,
+      labelSets: [], addLabels: ["maintainer-required"], comments: [],
+    };
   }
-  if (existing.has("ai-reviewed/1") && gate.secondReviewEligible !== true) return fail("second review is not eligible");
+  if (rateLimit && rateLimit.status !== "allowed") return fail("fork LLM quota unavailable");
+  if (gate?.available === false || gate?.head_sha !== expectedSha) return fail("review gate unavailable");
+  if (contributor?.status === "unavailable") return fail("contributor history unavailable");
+  if (gate.classificationCheck !== true) return wait("classification is not ready");
+  if (existing.has("ai-reviewed/1") && gate.secondReviewEligible !== true) {
+    return wait("second review is not eligible", true);
+  }
+  if (gate.ciGreen !== true && gate.bypassCi !== true) return wait("CI is not green");
+  if (contributor?.status !== "eligible") return wait("contributor is not eligible");
   if (!reviewPolicyEligible({
     labels, legitimacyStopped: gate.legitimacyStopped, protocolRelated: gate.protocolRelated,
-  })) return fail("review is not eligible");
+  })) return wait("review is not eligible");
+  if (gate.ok !== true) return fail("review gate unavailable");
   // A protocol-related review is only publishable when the protocol stage produced a validated
   // handoff; anything else fails closed to humans.
   if (!["valid", "not_applicable"].includes(protocolStatus)) return fail("protocol handoff unavailable");

--- a/.github/pr-automation/write-state.js
+++ b/.github/pr-automation/write-state.js
@@ -1,6 +1,7 @@
 "use strict";
 
-const { encodeCheckState } = require("./validate-classifier");
+const { SCHEMA_VERSION: CLASSIFIER_SCHEMA_VERSION, encodeCheckState } = require("./validate-classifier");
+const { SCHEMA_VERSION: REVIEWER_SCHEMA_VERSION } = require("./validate-reviewer");
 
 class StaleHeadError extends Error {
   constructor() { super("pull request head is no longer current"); this.name = "StaleHeadError"; }
@@ -152,14 +153,23 @@ async function ensureClassificationCheck(github, owner, repo, prNumber, expected
 }
 
 async function ensureReviewCheck(github, owner, repo, prNumber, expectedSha, check) {
-  if ((await findCheck(github, owner, repo, expectedSha, check))?.conclusion === "success") return false;
+  const conclusion = check.conclusion ?? "success";
+  const title = check.title ?? "Automated review complete";
+  const summary = check.summary ?? "Validated automated review is bound to this commit.";
+  const existing = await findCheck(github, owner, repo, expectedSha, check);
+  if (existing?.conclusion === conclusion && existing.output?.title === title &&
+      existing.output?.summary === summary) return false;
   await issueLabels(github, owner, repo, prNumber);
   await assertCurrentHead(github, owner, repo, prNumber, expectedSha);
-  await github.rest.checks.create({
+  const payload = {
     owner, repo, name: check.name, head_sha: expectedSha, external_id: check.externalId,
-    status: "completed", conclusion: "success",
-    output: { title: "Automated review complete", summary: "Validated automated review is bound to this commit." },
-  });
+    status: "completed", conclusion, output: { title, summary },
+  };
+  if (existing) {
+    await github.rest.checks.update({ ...payload, check_run_id: existing.id });
+  } else {
+    await github.rest.checks.create(payload);
+  }
   return true;
 }
 
@@ -200,36 +210,88 @@ async function applyLabels(github, owner, repo, prNumber, state) {
   return true;
 }
 
+async function hasAutomationFailureAtHead(github, owner, repo, expectedSha) {
+  const checks = [
+    {
+      name: "AI classification",
+      externalId: `${CLASSIFIER_SCHEMA_VERSION}:${expectedSha}`,
+      title: "Classification unavailable",
+    },
+    {
+      name: "AI automated review",
+      externalId: `${REVIEWER_SCHEMA_VERSION}:${expectedSha}`,
+      title: "Automated review unavailable",
+    },
+  ];
+  for (const check of checks) {
+    const found = await findCheck(github, owner, repo, expectedSha, check);
+    if (found?.app?.slug === "github-actions" && found.conclusion === "neutral" &&
+        found.output?.title === check.title) return true;
+  }
+  return false;
+}
+
 async function writeState({ github, owner, repo, prNumber, state, botLogin }) {
   if (!state?.ok || !["classification", "review"].includes(state.mode) ||
       typeof state.expectedSha !== "string" || !Number.isSafeInteger(prNumber) || prNumber <= 0) {
     throw new Error("invalid normalized state");
   }
   await assertCurrentHead(github, owner, repo, prNumber, state.expectedSha);
+  let effectiveState = state;
+  let revalidationError;
+  if (state.pending === true && state.removeLabels?.includes("maintainer-required")) {
+    let preserveMaintainer = false;
+    try {
+      preserveMaintainer = await hasAutomationFailureAtHead(github, owner, repo, state.expectedSha);
+    } catch (error) {
+      preserveMaintainer = true;
+      revalidationError = error;
+    }
+    if (preserveMaintainer) {
+      effectiveState = {
+        ...state,
+        addLabels: [...new Set([...(state.addLabels || []), "maintainer-required"])],
+        removeLabels: state.removeLabels.filter((label) => label !== "maintainer-required"),
+      };
+    }
+  }
   // Labels come first in both modes: they are the durable record of the outcome, and a later
-  // comment or review failure must not leave the pull request without its maintainer-required triage.
-  await applyLabels(github, owner, repo, prNumber, state);
-  if (state.mode === "review") {
-    for (const comment of state.comments || []) {
-      if (comment.kind === "review") {
-        await publishReview(github, owner, repo, prNumber, state.expectedSha, botLogin, comment);
-      } else {
-        await upsertMarkedComment(github, owner, repo, prNumber, state.expectedSha, botLogin, comment);
+  // publication failure must not leave the pull request with stale triage.
+  await applyLabels(github, owner, repo, prNumber, effectiveState);
+  try {
+    if (revalidationError) throw revalidationError;
+    if (state.mode === "review") {
+      for (const comment of state.comments || []) {
+        if (comment.kind === "review") {
+          await publishReview(github, owner, repo, prNumber, state.expectedSha, botLogin, comment);
+        } else {
+          await upsertMarkedComment(github, owner, repo, prNumber, state.expectedSha, botLogin, comment);
+        }
+      }
+      if (state.check) await ensureReviewCheck(github, owner, repo, prNumber, state.expectedSha, state.check);
+    } else {
+      for (const comment of state.comments || []) await upsertMarkedComment(
+        github, owner, repo, prNumber, state.expectedSha, botLogin, comment);
+      for (const marker of new Set(state.removeCommentMarkers || [])) {
+        await deleteMarkedComment(github, owner, repo, prNumber, state.expectedSha, botLogin, marker);
+      }
+      if (state.check) {
+        const created = await ensureClassificationCheck(github, owner, repo, prNumber, state.expectedSha, state.check);
+        if (created && state.check.title === "Classification complete") {
+          await dispatchClassificationComplete(github, owner, repo, prNumber, state.expectedSha);
+        }
       }
     }
-    if (state.check) await ensureReviewCheck(github, owner, repo, prNumber, state.expectedSha, state.check);
-  } else {
-    for (const comment of state.comments || []) await upsertMarkedComment(
-      github, owner, repo, prNumber, state.expectedSha, botLogin, comment);
-    for (const marker of new Set(state.removeCommentMarkers || [])) {
-      await deleteMarkedComment(github, owner, repo, prNumber, state.expectedSha, botLogin, marker);
+  } catch (error) {
+    if (error instanceof StaleHeadError) throw error;
+    try {
+      await applyLabels(github, owner, repo, prNumber, {
+        expectedSha: state.expectedSha, labelSets: [], addLabels: ["maintainer-required"],
+      });
+    } catch (triageError) {
+      throw new AggregateError([error, triageError], "state publication and maintainer triage failed");
     }
-    if (state.check) {
-      const created = await ensureClassificationCheck(github, owner, repo, prNumber, state.expectedSha, state.check);
-      if (created && state.check.title === "Classification complete") {
-        await dispatchClassificationComplete(github, owner, repo, prNumber, state.expectedSha);
-      }
-    }
+    throw error;
   }
   return { ok: true };
 }

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -582,14 +582,22 @@ jobs:
                 .filter((run) => run.external_id === externalId)
                 .sort((left, right) => right.id - left.id)[0];
               const classification = completed(classificationRuns, `${SCHEMA_VERSION}:${headSha}`);
-              const trusted = classification?.conclusion === "success" && classification.app?.slug === "github-actions";
+              const classificationFromActions = classification?.app?.slug === "github-actions";
+              const trusted = classification?.conclusion === "success" && classificationFromActions;
               // A check without the current machine-readable state predates this contract: fail closed
               // and wait for a later classification event to rewrite it.
               const protocolState = trusted ? parseCheckState(classification.output?.summary) : null;
               const classificationCheck = trusted && protocolState !== null &&
                 classification.output?.title === "Classification complete";
+              const classificationFailed = classificationFromActions &&
+                classification?.conclusion === "neutral" &&
+                classification.output?.title === "Classification unavailable";
               const legitimacyStopped = trusted && classification.output?.title === "Automation stopped";
               const reviewAtHead = completed(reviewRuns, `${REVIEWER_SCHEMA_VERSION}:${headSha}`)?.conclusion === "success";
+              const reviewFailure = completed(reviewRuns, `${REVIEWER_SCHEMA_VERSION}:${headSha}`);
+              const reviewFailed = reviewFailure?.app?.slug === "github-actions" &&
+                reviewFailure.conclusion === "neutral" &&
+                reviewFailure.output?.title === "Automated review unavailable";
               const workflowRuns = process.env.ROUTE === "ci" ? [context.payload.workflow_run] :
                 (await github.rest.actions.listWorkflowRunsForRepo({
                   owner: context.repo.owner, repo: context.repo.repo, head_sha: headSha, per_page: 100,
@@ -601,7 +609,9 @@ jobs:
               const policyEligible = reviewPolicyEligible({ labels, legitimacyStopped, protocolRelated });
               core.setOutput("gate", JSON.stringify({
                 ok: classificationCheck && (ciGreen || bypassCi) && secondReviewEligible && policyEligible,
-                head_sha: headSha, classificationCheck, legitimacyStopped, ciGreen, bypassCi, secondReviewEligible, policyEligible, labels,
+                available: true,
+                head_sha: headSha, classificationCheck, classificationFailed, reviewFailed, legitimacyStopped,
+                ciGreen, bypassCi, secondReviewEligible, policyEligible, labels,
                 protocolRelated,
               }));
               core.setOutput("eligible", classificationCheck && (ciGreen || bypassCi) && secondReviewEligible && policyEligible);
@@ -610,16 +620,19 @@ jobs:
                 event: "pr-automation.review-gate",
                 decision: {
                   ok: classificationCheck && (ciGreen || bypassCi) && secondReviewEligible && policyEligible,
-                  headSha, classificationCheck, legitimacyStopped, ciGreen, bypassCi, secondReviewEligible,
+                  available: true,
+                  headSha, classificationCheck, classificationFailed, reviewFailed, legitimacyStopped,
+                  ciGreen, bypassCi, secondReviewEligible,
                   policyEligible, labels, protocolRelated,
                 },
               }));
             } catch (error) {
               core.warning(`Review gate unavailable: ${error.message}`);
               core.setOutput("gate", JSON.stringify({
-                ok: false, head_sha: headSha, classificationCheck: false, ciGreen: false,
+                ok: false, available: false, head_sha: headSha, classificationCheck: false,
+                classificationFailed: false, reviewFailed: false, ciGreen: false,
                 legitimacyStopped: false, bypassCi: process.env.BYPASS_CI === "true", secondReviewEligible: false,
-                policyEligible: false, labels: [], protocolRelated: false,
+                policyEligible: false, labels: [], protocolRelated: false, reason: error.message,
               }));
               core.setOutput("eligible", false);
               core.setOutput("protocol-related", false);
@@ -1031,6 +1044,7 @@ jobs:
           script: |
             const { addedLinesByPath, listPrFiles } = require("./.github/pr-automation/deterministic-analysis");
             const { resolveReviewState } = require("./.github/pr-automation/resolve-state");
+            const { SCHEMA_VERSION: REVIEWER_SCHEMA_VERSION } = require("./.github/pr-automation/validate-reviewer");
             const parse = (value, fallback) => { try { return JSON.parse(value || ""); } catch { return fallback; } };
             const gate = parse(process.env.GATE, {});
             let files;
@@ -1040,16 +1054,22 @@ jobs:
                 prNumber: Number(process.env.PULL_REQUEST_NUMBER),
               });
             } catch {
-              core.setOutput("state", JSON.stringify({
+              const state = {
                 ok: true, mode: "review", expectedSha: process.env.HEAD_SHA, failed: true,
                 reason: "changed file retrieval unavailable", labelSets: [],
                 addLabels: ["maintainer-required"], comments: [],
-              }));
+                check: {
+                  name: "AI automated review",
+                  externalId: `${REVIEWER_SCHEMA_VERSION}:${process.env.HEAD_SHA}`,
+                  title: "Automated review unavailable",
+                  summary: "Automated review was unavailable: changed file retrieval unavailable. Maintainer review is required.",
+                  conclusion: "neutral",
+                },
+              };
+              core.setOutput("state", JSON.stringify(state));
               core.info(JSON.stringify({
                 event: "pr-automation.review-state",
-                decision: { ok: true, mode: "review", expectedSha: process.env.HEAD_SHA, failed: true,
-                  reason: "changed file retrieval unavailable", labelSets: [],
-                  addLabels: ["maintainer-required"], comments: [] },
+                decision: state,
               }));
               return;
             }


### PR DESCRIPTION
## Summary
- stop applying `maintainer-required` while a normal pull request is only waiting for green CI or automated review
- retain the label for no-finding and terminal review outcomes, explicit human-only stops, and actual automation failures
- persist and revalidate SHA-bound failure outcomes so concurrent or repeated workflow runs cannot erase required triage
- restore maintainer triage when state publication fails and document the label lifecycle

## Validation
- `node --test .github/pr-automation/automation.test.js`
- `git diff --check`

`cargo xtask check typos -v` could not run because `typos-cli` is not installed in the local xtask tool directory.