### PR TITLE
fix(ci): use bot token for skill sync PRs

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -16,6 +16,9 @@ concurrency:
 jobs:
   sync:
     name: Sync shared skills
+    # TODO: Rename this environment or move the bot write token to a dedicated
+    # environment; trusted publishing no longer requires it for crates.io tokens.
+    environment: cratesio-publish
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -38,7 +38,7 @@ jobs:
         shell: bash
         env:
           BASE_BRANCH: ${{ github.event.repository.default_branch }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.DEVOLUTIONSBOT_WRITE_TOKEN }}
           PULL_REQUEST_BODY: |
             Synchronizes configured shared skills from their upstream repositories.
           PULL_REQUEST_TITLE: 'chore(skills): sync shared skills'


### PR DESCRIPTION
## Summary

- Run shared-skills synchronization in the existing `cratesio-publish` environment so it can access `DEVOLUTIONSBOT_WRITE_TOKEN`.
- Use that bot credential to create or update the synchronization pull request.
- Add a TODO to move the token to a dedicated environment or rename the existing environment, since crates.io uses trusted publishing.

## Verification

- `git diff --check`

The environment allows protected branches only, so the workflow must be run from `master` after this PR merges.
