### PR TITLE
ci: resume incomplete automated reviews

### DIFF
--- a/.github/PR_AUTOMATION.md
+++ b/.github/PR_AUTOMATION.md
@@ -21,12 +21,16 @@ a data file, and must record whether it accepted, partly accepted, or rejected t
 Only its output is published, and inline comments are placed only on lines this pull request actually
 adds; any other finding is published in the review body instead.
 
-Protocol-related reviews therefore consume two calls against `ANTHROPIC_API_KEY_REVIEWER`;
-non-protocol reviews consume one. If the protocol stage fails, is cancelled, is malformed, or cites
-a specification section that does not exist, the skeptical stage does not run, the AI review count
-is unchanged, and the PR stays `maintainer-required`. A classification check that predates the
-machine-readable protocol state is treated as unavailable; the next classification event rewrites
-it.
+Protocol-related reviews normally consume two calls against `ANTHROPIC_API_KEY_REVIEWER`;
+non-protocol reviews normally consume one. Each heavy stage validates its structured output
+immediately. If the action reaches its turn limit or validation rejects the result, it resumes that
+exact Claude session once with a six-turn output-only budget, preserving the analysis already paid
+for instead of starting over. The separately isolated publication jobs still revalidate the selected
+result against GitHub's pull request data and the pinned protocol corpus. If both attempts fail, the
+AI review count is unchanged, the PR stays `maintainer-required`, and a neutral SHA-bound
+`AI automated review` check records the precise failure reason. A classification check that predates
+the machine-readable protocol state is treated as unavailable; the next classification event
+rewrites it.
 
 The trusted LLM validators normalize exact empty-string representation artifacts consistently.
 An invalid classifier result keeps the pull request `risk/unknown` and

--- a/.github/actions/resilient-review-output/action.yml
+++ b/.github/actions/resilient-review-output/action.yml
@@ -1,0 +1,152 @@
+name: Resilient review output
+description: Validate a review result and resume its Claude session once when necessary
+
+inputs:
+  stage:
+    description: Trusted validator to apply
+    required: true
+  expected_sha:
+    description: Pull request head SHA the output must bind to
+    required: true
+  anthropic_api_key:
+    description: Anthropic API key for the review stage
+    required: true
+  claude_args:
+    description: Claude CLI arguments for the initial analysis
+    required: true
+  retry_claude_args:
+    description: Claude CLI arguments for the bounded resume
+    required: true
+  settings:
+    description: Claude Code settings
+    required: true
+  prompt:
+    description: Initial analysis prompt
+    required: true
+  retry_prompt:
+    description: Prompt asking the existing session to finish its structured output
+    required: true
+
+outputs:
+  structured_output:
+    description: First validator-accepted structured output
+    value: ${{ steps.select.outputs.output }}
+  failure_reason:
+    description: Trusted validation reason when neither attempt produced usable output
+    value: ${{ steps.select.outputs.reason }}
+
+runs:
+  using: composite
+  steps:
+    - id: initial
+      continue-on-error: true
+      uses: anthropics/claude-code-action@v1
+      with:
+        anthropic_api_key: ${{ inputs.anthropic_api_key }}
+        github_token: ${{ github.token }}
+        allowed_non_write_users: "*"
+        include_comments_by_actor: "__pr_automation_no_comments__"
+        track_progress: false
+        use_sticky_comment: false
+        display_report: false
+        show_full_output: false
+        claude_args: ${{ inputs.claude_args }}
+        settings: ${{ inputs.settings }}
+        prompt: ${{ inputs.prompt }}
+
+    - id: validate-initial
+      if: always()
+      uses: actions/github-script@v8
+      env:
+        STAGE: ${{ inputs.stage }}
+        EXPECTED_SHA: ${{ inputs.expected_sha }}
+        OUTCOME: ${{ steps.initial.outcome }}
+        STRUCTURED_OUTPUT: ${{ steps.initial.outputs.structured_output }}
+        SESSION_ID: ${{ steps.initial.outputs.session_id }}
+        RETRY_ARGS: ${{ inputs.retry_claude_args }}
+      with:
+        script: |
+          const {
+            validateModelOutput,
+          } = require("./.github/actions/resilient-review-output/validate");
+          const output = process.env.STRUCTURED_OUTPUT || "";
+          const result = output === "" && process.env.OUTCOME === "failure"
+            ? { ok: false, reason: "initial model action failed without structured output" }
+            : validateModelOutput(output, {
+              stage: process.env.STAGE, expectedSha: process.env.EXPECTED_SHA,
+            });
+          core.setOutput("valid", result.ok);
+          core.setOutput("reason", result.ok ? "" : result.reason);
+          const sessionId = process.env.SESSION_ID;
+          if (!result.ok &&
+              /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(sessionId)) {
+            core.setOutput("retry-args", `${process.env.RETRY_ARGS} --resume ${sessionId}`);
+          }
+
+    - id: retry
+      if: steps.validate-initial.outputs.retry-args != ''
+      continue-on-error: true
+      uses: anthropics/claude-code-action@v1
+      with:
+        anthropic_api_key: ${{ inputs.anthropic_api_key }}
+        github_token: ${{ github.token }}
+        allowed_non_write_users: "*"
+        include_comments_by_actor: "__pr_automation_no_comments__"
+        track_progress: false
+        use_sticky_comment: false
+        display_report: false
+        show_full_output: false
+        claude_args: ${{ steps.validate-initial.outputs.retry-args }}
+        settings: ${{ inputs.settings }}
+        prompt: >-
+          ${{ inputs.retry_prompt }}
+          Trusted validation reason: ${{ steps.validate-initial.outputs.reason }}.
+
+    - id: select
+      if: always()
+      uses: actions/github-script@v8
+      env:
+        STAGE: ${{ inputs.stage }}
+        EXPECTED_SHA: ${{ inputs.expected_sha }}
+        INITIAL_VALID: ${{ steps.validate-initial.outputs.valid }}
+        INITIAL_REASON: ${{ steps.validate-initial.outputs.reason }}
+        INITIAL_OUTCOME: ${{ steps.initial.outcome }}
+        INITIAL_OUTPUT: ${{ steps.initial.outputs.structured_output }}
+        RETRY_ATTEMPTED: ${{ steps.validate-initial.outputs.retry-args != '' }}
+        RETRY_OUTCOME: ${{ steps.retry.outcome }}
+        RETRY_OUTPUT: ${{ steps.retry.outputs.structured_output }}
+      with:
+        script: |
+          const {
+            validateModelOutput,
+          } = require("./.github/actions/resilient-review-output/validate");
+          let output = process.env.INITIAL_OUTPUT || "";
+          let selected = process.env.INITIAL_VALID === "true" ? "initial" : null;
+          let reason = process.env.INITIAL_REASON;
+          if (!selected && process.env.RETRY_ATTEMPTED === "true") {
+            const retryOutput = process.env.RETRY_OUTPUT || "";
+            const retry = retryOutput === "" && process.env.RETRY_OUTCOME === "failure"
+              ? { ok: false, reason: "resumed model action failed without structured output" }
+              : validateModelOutput(retryOutput, {
+                stage: process.env.STAGE, expectedSha: process.env.EXPECTED_SHA,
+              });
+            if (retry.ok) {
+              output = retryOutput;
+              selected = "resumed";
+              reason = "";
+            } else {
+              reason = `initial: ${reason}; resumed: ${retry.reason}`;
+            }
+          }
+          core.setOutput("output", selected ? output : "");
+          core.setOutput("reason", selected ? "" : reason);
+          core.info(JSON.stringify({
+            event: "pr-automation.llm-output", stage: process.env.STAGE, selected,
+            initialOutcome: process.env.INITIAL_OUTCOME,
+            retryOutcome: process.env.RETRY_ATTEMPTED === "true" ? process.env.RETRY_OUTCOME : null,
+            initialStructuredOutput: process.env.INITIAL_OUTPUT || null,
+            retryStructuredOutput: process.env.RETRY_ATTEMPTED === "true"
+              ? process.env.RETRY_OUTPUT || null : null,
+            reason: selected ? null : reason,
+          }));
+          if (!selected) core.warning(`No valid ${process.env.STAGE} output: ${reason}`);

--- a/.github/actions/resilient-review-output/validate.js
+++ b/.github/actions/resilient-review-output/validate.js
@@ -1,0 +1,69 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { execFileSync } = require("node:child_process");
+
+const { MAX_FILES } = require("../../pr-automation/deterministic-analysis");
+const { invalid, REPO_PATH, SHA } = require("../../pr-automation/validation");
+const {
+  corpusFromDirectory, validateProtocolReview,
+} = require("../../pr-automation/validate-protocol-review");
+const { validateReviewer } = require("../../pr-automation/validate-reviewer");
+
+const MAX_PATH_BYTES = 500;
+
+function parseChangedPaths(source) {
+  if (!Buffer.isBuffer(source) || source.length === 0 ||
+      source.length > MAX_FILES * (MAX_PATH_BYTES + 1) || source.at(-1) !== 0) {
+    return invalid("invalid changed path evidence");
+  }
+  const paths = source.toString("utf8").slice(0, -1).split("\0");
+  if (paths.length === 0 || paths.length > MAX_FILES || new Set(paths).size !== paths.length ||
+      paths.some((entry) => !REPO_PATH.test(entry) || Buffer.byteLength(entry, "utf8") > MAX_PATH_BYTES ||
+        /[\u0000-\u001F\u007F]/.test(entry))) {
+    return invalid("invalid changed path evidence");
+  }
+  return { ok: true, paths };
+}
+
+function changedPathsFromRepository(repository) {
+  try {
+    return parseChangedPaths(execFileSync("git", [
+      "-C", repository, "diff", "--find-renames", "--name-only", "-z", "origin/master...HEAD",
+    ], { encoding: "buffer", maxBuffer: MAX_FILES * (MAX_PATH_BYTES + 1) }));
+  } catch {
+    return invalid("changed path evidence unavailable");
+  }
+}
+
+function validateModelOutput(raw, {
+  stage, expectedSha, workspace = process.cwd(), changedPaths, corpus, protocolReceived,
+} = {}) {
+  if (!["protocol-analysis", "skeptical-review"].includes(stage) || !SHA.test(expectedSha || "")) {
+    return invalid("invalid model validation context");
+  }
+  const paths = changedPaths === undefined
+    ? changedPathsFromRepository(path.join(workspace, "pr-head"))
+    : { ok: true, paths: changedPaths };
+  if (!paths.ok) return paths;
+  if (stage === "protocol-analysis") {
+    return validateProtocolReview(raw, {
+      expectedSha,
+      changedPaths: paths.paths,
+      corpus: corpus ?? corpusFromDirectory(path.join(workspace, ".claude", "skills", "windows-protocols")),
+    });
+  }
+  if (protocolReceived === undefined) {
+    try {
+      protocolReceived = JSON.parse(fs.readFileSync(path.join(workspace, "protocol-handoff.json"), "utf8")) !== null;
+    } catch {
+      return invalid("protocol handoff evidence unavailable");
+    }
+  }
+  return validateReviewer(raw, {
+    expectedSha, changedPaths: paths.paths, changedLines: {}, protocolReceived,
+  });
+}
+
+module.exports = { changedPathsFromRepository, parseChangedPaths, validateModelOutput };

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -716,6 +716,22 @@ test("an unavailable protocol handoff blocks the review count", () => {
   assert.equal(reviewerFailure.check.conclusion, "neutral");
 });
 
+test("evidence failures are reported only for an eligible review", () => {
+  const args = {
+    expectedSha: SHA, labels: ["risk/high"], reviewer: "",
+    gate: { ok: true, head_sha: SHA, classificationCheck: true, ciGreen: true },
+    contributor: { status: "eligible" }, protocolStatus: "not_applicable",
+    evidenceReason: "changed file retrieval unavailable",
+  };
+  const active = resolveReviewState(args);
+  assert.equal(active.reason, "changed file retrieval unavailable");
+  assert.equal(active.check.conclusion, "neutral");
+
+  const terminal = resolveReviewState({ ...args, labels: ["ai-reviewed/2", "risk/high"] });
+  assert.equal(terminal.reason, "terminal AI review count");
+  assert.equal(terminal.check, undefined);
+});
+
 test("writer stops before mutations when the head is stale", async () => {
   let writes = 0;
   const github = { rest: {

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -15,6 +15,9 @@ const { encodeCheckState, parseCheckState } = require("./validate-classifier");
 const {
   corpusFromDirectory, notApplicableHandoff, validateProtocolReview,
 } = require("./validate-protocol-review");
+const {
+  parseChangedPaths, validateModelOutput,
+} = require("../actions/resilient-review-output/validate");
 
 const SHA = "a".repeat(40);
 const classifier = (changes = {}) => ({
@@ -45,6 +48,10 @@ test("workflow does not overwrite github-script result outputs", () => {
   assert.doesNotMatch(workflow, /core\.setOutput\("result"/);
   assert.doesNotMatch(workflow, /^\s{6}result:\s+\$\{\{\s*steps\./m);
   assert.doesNotMatch(workflow, /needs\.[\w-]+\.outputs\.result\b/);
+  assert.equal((workflow.match(/uses: \.\/\.github\/actions\/resilient-review-output/g) || []).length, 2);
+  const resilientAction = fs.readFileSync(
+    path.join(__dirname, "..", "actions", "resilient-review-output", "action.yml"), "utf8");
+  assert.match(resilientAction, /--resume \$\{sessionId\}/);
 });
 
 test("review skills own methodology while stage prompts own pipeline contracts", () => {
@@ -307,6 +314,25 @@ test("protocol handoff treats quoted empty required prose as empty", () => {
   assert.equal(validateProtocolReview(protocolReview({
     relevance_reason: '""',
   }), { expectedSha: SHA, changedPaths: ["src/lib.rs"], corpus }).ok, false);
+});
+
+test("heavy review output validation accepts a schema-bound reviewer result", () => {
+  const valid = JSON.stringify(review({
+    has_findings: false, summary: "no findings",
+    protocol_handoff: { received: false, disposition: "not_applicable", rationale: "" },
+    findings: [],
+  }));
+  assert.equal(validateModelOutput(valid, {
+    stage: "skeptical-review", expectedSha: SHA, changedPaths: ["src/lib.rs"], protocolReceived: false,
+  }).ok, true);
+});
+
+test("heavy review output rejects malformed changed-path evidence", () => {
+  assert.deepEqual(parseChangedPaths(Buffer.from("src/lib.rs\0")), {
+    ok: true, paths: ["src/lib.rs"],
+  });
+  assert.equal(parseChangedPaths(Buffer.from("../outside\0")).ok, false);
+  assert.equal(parseChangedPaths(Buffer.from("unterminated")).ok, false);
 });
 
 test("corpus reader indexes real headings and refuses traversal", () => {
@@ -671,12 +697,23 @@ test("an unavailable protocol handoff blocks the review count", () => {
     expectedSha: SHA, labels: ["risk/high"], reviewer,
     gate: { ok: true, head_sha: SHA, classificationCheck: true, ciGreen: true }, contributor: { status: "eligible" },
   };
-  const failed = resolveReviewState({ ...args, protocolStatus: "unavailable" });
+  const failed = resolveReviewState({
+    ...args, protocolStatus: "unavailable", protocolReason: "resumed model action failed without structured output",
+  });
   assert.equal(failed.failed, true);
+  assert.equal(failed.reason, "resumed model action failed without structured output");
   assert.deepEqual(failed.addLabels, ["maintainer-required"]);
   assert.deepEqual(failed.labelSets, []);
+  assert.equal(failed.check.conclusion, "neutral");
+  assert.match(failed.check.summary, /resumed model action failed/);
   assert.equal(resolveReviewState(args).failed, true);
   assert.deepEqual(resolveReviewState({ ...args, protocolStatus: "valid" }).labelSets[0].desired, ["ai-reviewed/1"]);
+  const reviewerFailure = resolveReviewState({
+    ...args, protocolStatus: "valid", reviewer: "",
+    reviewerReason: "resumed model action failed without structured output",
+  });
+  assert.equal(reviewerFailure.reason, "resumed model action failed without structured output");
+  assert.equal(reviewerFailure.check.conclusion, "neutral");
 });
 
 test("writer stops before mutations when the head is stale", async () => {
@@ -756,6 +793,39 @@ test("writer reads normalized check-run pages and updates the newest matching ru
   });
   assert.equal(updatedCheckRun, 3);
   assert.equal(updatedConclusion, "neutral");
+});
+
+test("writer upgrades a neutral automated review check instead of creating a duplicate", async () => {
+  let created = 0;
+  let update = null;
+  const github = {
+    paginate: { iterator: async function* () {
+      yield { data: [{
+        id: 7, external_id: `reviewer-v1:${SHA}`, conclusion: "neutral",
+        output: { title: "Automated review unavailable", summary: "Model timed out." },
+      }] };
+    } },
+    rest: {
+      checks: {
+        listForRef: () => {},
+        create: async () => { created += 1; },
+        update: async (payload) => { update = payload; },
+      },
+      pulls: { get: async () => ({ data: { state: "open", head: { sha: SHA } } }) },
+      issues: { get: async () => ({ data: { labels: [] } }) },
+    },
+  };
+  await writeState({
+    github, owner: "Devolutions", repo: "IronRDP", prNumber: 1, botLogin: "github-actions[bot]",
+    state: {
+      ok: true, mode: "review", expectedSha: SHA, labelSets: [], addLabels: [], comments: [],
+      check: { name: "AI automated review", externalId: `reviewer-v1:${SHA}` },
+    },
+  });
+  assert.equal(created, 0);
+  assert.equal(update.check_run_id, 7);
+  assert.equal(update.conclusion, "success");
+  assert.equal(update.output.title, "Automated review complete");
 });
 
 function paginated(pages) {

--- a/.github/pr-automation/resolve-state.js
+++ b/.github/pr-automation/resolve-state.js
@@ -261,7 +261,6 @@ function resolveReviewState({
     };
   };
   if (typeof expectedSha !== "string") return { ok: false, reason: "missing expected SHA" };
-  if (evidenceReason) return fail(evidenceReason, true);
   if (existing.has("ai-reviewed/2")) return fail("terminal AI review count");
   if (rateLimit && rateLimit.status !== "allowed") return fail("fork LLM quota unavailable");
   if (!gate?.ok || gate.head_sha !== expectedSha || gate.classificationCheck !== true ||
@@ -272,6 +271,7 @@ function resolveReviewState({
   if (!reviewPolicyEligible({
     labels, legitimacyStopped: gate.legitimacyStopped, protocolRelated: gate.protocolRelated,
   })) return fail("review is not eligible");
+  if (evidenceReason) return fail(evidenceReason, true);
   // A protocol-related review is only publishable when the protocol stage produced a validated
   // handoff; anything else fails closed to humans.
   if (!["valid", "not_applicable"].includes(protocolStatus)) {

--- a/.github/pr-automation/resolve-state.js
+++ b/.github/pr-automation/resolve-state.js
@@ -244,17 +244,24 @@ async function contributorEligibility({ github, owner, repo, author, currentPrNu
 
 function resolveReviewState({
   expectedSha, labels, reviewer, changedPaths, changedLines, gate, contributor,
-  rateLimit, protocolStatus,
+  rateLimit, protocolStatus, protocolReason, reviewerReason, evidenceReason,
 } = {}) {
   const existing = labelsOf(labels);
-  const fail = (reason) => {
+  const fail = (reason, report = false) => {
     const comment = quotaComment(rateLimit);
     return {
       ok: true, mode: "review", expectedSha, failed: true, reason,
       labelSets: [], addLabels: ["maintainer-required"], comments: comment ? [comment] : [],
+      ...(report ? { check: {
+        name: "AI automated review", externalId: `${REVIEWER_SCHEMA_VERSION}:${expectedSha}`,
+        title: "Automated review unavailable",
+        summary: `Automated review was unavailable: ${reason}. Maintainer review is required.`,
+        conclusion: "neutral",
+      } } : {}),
     };
   };
   if (typeof expectedSha !== "string") return { ok: false, reason: "missing expected SHA" };
+  if (evidenceReason) return fail(evidenceReason, true);
   if (existing.has("ai-reviewed/2")) return fail("terminal AI review count");
   if (rateLimit && rateLimit.status !== "allowed") return fail("fork LLM quota unavailable");
   if (!gate?.ok || gate.head_sha !== expectedSha || gate.classificationCheck !== true ||
@@ -267,11 +274,15 @@ function resolveReviewState({
   })) return fail("review is not eligible");
   // A protocol-related review is only publishable when the protocol stage produced a validated
   // handoff; anything else fails closed to humans.
-  if (!["valid", "not_applicable"].includes(protocolStatus)) return fail("protocol handoff unavailable");
+  if (!["valid", "not_applicable"].includes(protocolStatus)) {
+    return fail(protocolReason || "protocol handoff unavailable", true);
+  }
   const reviewerResult = validateReviewer(reviewer, {
     expectedSha, changedPaths, changedLines, protocolReceived: protocolStatus === "valid",
   });
-  if (!reviewerResult?.ok || reviewerResult.value?.head_sha !== expectedSha) return fail("reviewer unavailable");
+  if (!reviewerResult?.ok || reviewerResult.value?.head_sha !== expectedSha) {
+    return fail(reviewerReason || reviewerResult?.reason || "reviewer unavailable", true);
+  }
   const nextCount = existing.has("ai-reviewed/1") ? "ai-reviewed/2" : "ai-reviewed/1";
   const hasFindings = reviewerResult.value.has_findings;
   return {

--- a/.github/pr-automation/write-state.js
+++ b/.github/pr-automation/write-state.js
@@ -152,14 +152,23 @@ async function ensureClassificationCheck(github, owner, repo, prNumber, expected
 }
 
 async function ensureReviewCheck(github, owner, repo, prNumber, expectedSha, check) {
-  if ((await findCheck(github, owner, repo, expectedSha, check))?.conclusion === "success") return false;
+  const conclusion = check.conclusion ?? "success";
+  const title = check.title ?? "Automated review complete";
+  const summary = check.summary ?? "Validated automated review is bound to this commit.";
+  const existing = await findCheck(github, owner, repo, expectedSha, check);
+  if (existing?.conclusion === conclusion && existing.output?.title === title &&
+      existing.output?.summary === summary) return false;
   await issueLabels(github, owner, repo, prNumber);
   await assertCurrentHead(github, owner, repo, prNumber, expectedSha);
-  await github.rest.checks.create({
+  const payload = {
     owner, repo, name: check.name, head_sha: expectedSha, external_id: check.externalId,
-    status: "completed", conclusion: "success",
-    output: { title: "Automated review complete", summary: "Validated automated review is bound to this commit." },
-  });
+    status: "completed", conclusion, output: { title, summary },
+  };
+  if (existing) {
+    await github.rest.checks.update({ ...payload, check_run_id: existing.id });
+  } else {
+    await github.rest.checks.create(payload);
+  }
   return true;
 }
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -661,6 +661,7 @@ jobs:
     environment: llm-providers
     outputs:
       output: ${{ steps.claude.outputs.structured_output }}
+      failure-reason: ${{ steps.claude.outputs.failure_reason }}
       openspecs-sha: ${{ steps.sources.outputs.openspecs-sha }}
     steps:
       - name: Fetch trusted base, PR head, and protocol skills
@@ -700,6 +701,7 @@ jobs:
           HEAD_SHA: ${{ needs.resolve-pr.outputs.head-sha }}
         with:
           script: |
+           const schema = JSON.stringify(require("./.github/pr-automation/schemas/protocol-reviewer.json"));
            require("node:fs").writeFileSync(
              "pr-automation-context.json",
              JSON.stringify({ head_sha: process.env.HEAD_SHA }, null, 2),
@@ -708,40 +710,25 @@ jobs:
              ".github/pr-automation/prompts/protocol-reviewer.md",
              "utf8",
            ));
-           const schema = JSON.stringify(require("./.github/pr-automation/schemas/protocol-reviewer.json"));
-           core.setOutput("value", `--model opus --max-turns 30 --add-dir pr-head --add-dir pr-evidence --allowedTools "Read,Glob,Grep,Skill" --disallowedTools "Bash,Edit,Write,WebFetch,Task" --json-schema '${schema}'`);
+           const common = `--model opus --add-dir pr-head --add-dir pr-evidence --allowedTools "Read,Glob,Grep,Skill" --disallowedTools "Bash,Edit,Write,WebFetch,Task" --json-schema '${schema}'`;
+           core.setOutput("value", `${common} --max-turns 30`);
+           core.setOutput("retry", `${common} --max-turns 6`);
 
       - id: claude
-        continue-on-error: true
-        uses: anthropics/claude-code-action@v1
+        uses: ./.github/actions/resilient-review-output
         with:
+          stage: protocol-analysis
+          expected_sha: ${{ needs.resolve-pr.outputs.head-sha }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_REVIEWER }}
-          github_token: ${{ github.token }}
-          allowed_non_write_users: "*"
-          include_comments_by_actor: "__pr_automation_no_comments__"
-          track_progress: false
-          use_sticky_comment: false
-          display_report: false
-          show_full_output: false
           claude_args: ${{ steps.claude-args.outputs.value }}
+          retry_claude_args: ${{ steps.claude-args.outputs.retry }}
           settings: >-
             {"permissions":{"allow":["Read","Glob","Grep","Skill"],"deny":["Bash","Edit","Write","WebFetch","Task"]}}
           prompt: ${{ steps.claude-args.outputs.prompt }}
-
-      - name: Log protocol-analysis LLM output
-        if: always()
-        uses: actions/github-script@v8
-        env:
-          OUTCOME: ${{ steps.claude.outcome }}
-          STRUCTURED_OUTPUT: ${{ steps.claude.outputs.structured_output }}
-        with:
-          script: |
-            core.info(JSON.stringify({
-              event: "pr-automation.llm-output",
-              stage: "protocol-analysis",
-              outcome: process.env.OUTCOME,
-              structuredOutput: process.env.STRUCTURED_OUTPUT || null,
-            }));
+          retry_prompt: >-
+            Finish the protocol handoff now using the analysis already completed in this session.
+            Do not investigate further. Correct the reported validation problem and return only the
+            required schema-bound JSON for head ${{ needs.resolve-pr.outputs.head-sha }}.
 
   validate-protocol-review:
     name: Validate protocol handoff
@@ -757,6 +744,7 @@ jobs:
     outputs:
       status: ${{ steps.validate.outputs.status }}
       handoff: ${{ steps.validate.outputs.handoff }}
+      reason: ${{ steps.validate.outputs.reason }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -764,7 +752,7 @@ jobs:
           persist-credentials: false
 
       - id: cited
-        if: needs.review-gate.outputs.protocol-related == 'true' && needs.protocol-reviewer.result == 'success'
+        if: needs.review-gate.outputs.protocol-related == 'true' && needs.protocol-reviewer.outputs.output != ''
         uses: actions/github-script@v8
         env:
           RAW_OUTPUT: ${{ needs.protocol-reviewer.outputs.output }}
@@ -778,7 +766,7 @@ jobs:
             core.setOutput("paths", ids.map((id) => `/skills/windows-protocols/${id}/`).join("\n"));
 
       - name: Fetch cited specifications from the reviewed corpus
-        if: needs.review-gate.outputs.protocol-related == 'true' && needs.protocol-reviewer.result == 'success'
+        if: needs.review-gate.outputs.protocol-related == 'true' && needs.protocol-reviewer.outputs.output != ''
         shell: bash
         env:
           OPENSPECS_SHA: ${{ needs.protocol-reviewer.outputs.openspecs-sha }}
@@ -808,8 +796,8 @@ jobs:
           HEAD_SHA: ${{ needs.resolve-pr.outputs.head-sha }}
           PULL_REQUEST_NUMBER: ${{ needs.resolve-pr.outputs.pr-number }}
           PROTOCOL_RELATED: ${{ needs.review-gate.outputs.protocol-related }}
-          PROTOCOL_RESULT: ${{ needs.protocol-reviewer.result }}
           RAW_OUTPUT: ${{ needs.protocol-reviewer.outputs.output }}
+          MODEL_REASON: ${{ needs.protocol-reviewer.outputs.failure-reason }}
         with:
           script: |
             const { listPrFiles } = require("./.github/pr-automation/deterministic-analysis");
@@ -819,6 +807,7 @@ jobs:
             const publish = (result) => {
               core.setOutput("status", result.ok ? result.status : "unavailable");
               core.setOutput("handoff", result.ok ? JSON.stringify(result) : "");
+              core.setOutput("reason", result.ok ? "" : result.reason);
               core.info(JSON.stringify({
                 event: "pr-automation.protocol-handoff",
                 decision: result,
@@ -826,8 +815,11 @@ jobs:
               if (!result.ok) core.warning(`Protocol handoff unavailable: ${result.reason}`);
             };
             if (process.env.PROTOCOL_RELATED !== "true") return publish(notApplicableHandoff());
-            if (process.env.PROTOCOL_RESULT !== "success") {
-              return publish({ ok: false, reason: "protocol analysis did not complete" });
+            if (!process.env.RAW_OUTPUT) {
+              return publish({
+                ok: false,
+                reason: process.env.MODEL_REASON || "protocol analysis did not produce structured output",
+              });
             }
             let changedPaths;
             try {
@@ -860,6 +852,7 @@ jobs:
     environment: llm-providers
     outputs:
       output: ${{ steps.claude.outputs.structured_output }}
+      failure-reason: ${{ steps.claude.outputs.failure_reason }}
     steps:
       - name: Fetch trusted base and untrusted PR head without credentials
         shell: bash
@@ -901,39 +894,25 @@ jobs:
              "utf8",
            ));
            const schema = JSON.stringify(require("./.github/pr-automation/schemas/reviewer.json"));
-           core.setOutput("value", `--model opus --max-turns 20 --add-dir pr-head --add-dir pr-evidence --allowedTools "Read,Glob,Grep,Skill" --disallowedTools "Bash,Edit,Write,WebFetch,Task" --json-schema '${schema}'`);
+           const common = `--model opus --add-dir pr-head --add-dir pr-evidence --allowedTools "Read,Glob,Grep,Skill" --disallowedTools "Bash,Edit,Write,WebFetch,Task" --json-schema '${schema}'`;
+           core.setOutput("value", `${common} --max-turns 20`);
+           core.setOutput("retry", `${common} --max-turns 6`);
 
       - id: claude
-        continue-on-error: true
-        uses: anthropics/claude-code-action@v1
+        uses: ./.github/actions/resilient-review-output
         with:
+          stage: skeptical-review
+          expected_sha: ${{ needs.resolve-pr.outputs.head-sha }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_REVIEWER }}
-          github_token: ${{ github.token }}
-          allowed_non_write_users: "*"
-          include_comments_by_actor: "__pr_automation_no_comments__"
-          track_progress: false
-          use_sticky_comment: false
-          display_report: false
-          show_full_output: false
           claude_args: ${{ steps.claude-args.outputs.value }}
+          retry_claude_args: ${{ steps.claude-args.outputs.retry }}
           settings: >-
             {"permissions":{"allow":["Read","Glob","Grep","Skill"],"deny":["Bash","Edit","Write","WebFetch","Task"]}}
           prompt: ${{ steps.claude-args.outputs.prompt }}
-
-      - name: Log skeptical-review LLM output
-        if: always()
-        uses: actions/github-script@v8
-        env:
-          OUTCOME: ${{ steps.claude.outcome }}
-          STRUCTURED_OUTPUT: ${{ steps.claude.outputs.structured_output }}
-        with:
-          script: |
-            core.info(JSON.stringify({
-              event: "pr-automation.llm-output",
-              stage: "skeptical-review",
-              outcome: process.env.OUTCOME,
-              structuredOutput: process.env.STRUCTURED_OUTPUT || null,
-            }));
+          retry_prompt: >-
+            Finish the skeptical review now using the analysis already completed in this session.
+            Do not investigate further. Correct the reported validation problem and return only the
+            required schema-bound JSON for head ${{ needs.resolve-pr.outputs.head-sha }}.
 
   resolve-review-state:
     name: Resolve review state
@@ -960,7 +939,9 @@ jobs:
           CONTRIBUTOR: ${{ needs.contributor-history.outputs.history }}
           FORK_RATE_LIMIT: ${{ needs.fork-rate-limit.outputs.quota }}
           PROTOCOL_STATUS: ${{ needs.validate-protocol-review.outputs.status }}
+          PROTOCOL_REASON: ${{ needs.validate-protocol-review.outputs.reason }}
           RAW_OUTPUT: ${{ needs.skeptical-reviewer.outputs.output }}
+          REVIEWER_REASON: ${{ needs.skeptical-reviewer.outputs.failure-reason }}
           PULL_REQUEST_NUMBER: ${{ needs.resolve-pr.outputs.pr-number }}
         with:
           script: |
@@ -968,25 +949,15 @@ jobs:
             const { resolveReviewState } = require("./.github/pr-automation/resolve-state");
             const parse = (value, fallback) => { try { return JSON.parse(value || ""); } catch { return fallback; } };
             const gate = parse(process.env.GATE, {});
-            let files;
+            let files = [];
+            let evidenceReason;
             try {
               files = await listPrFiles(github, {
                 owner: context.repo.owner, repo: context.repo.repo,
                 prNumber: Number(process.env.PULL_REQUEST_NUMBER),
               });
             } catch {
-              core.setOutput("state", JSON.stringify({
-                ok: true, mode: "review", expectedSha: process.env.HEAD_SHA, failed: true,
-                reason: "changed file retrieval unavailable", labelSets: [],
-                addLabels: ["maintainer-required"], comments: [],
-              }));
-              core.info(JSON.stringify({
-                event: "pr-automation.review-state",
-                decision: { ok: true, mode: "review", expectedSha: process.env.HEAD_SHA, failed: true,
-                  reason: "changed file retrieval unavailable", labelSets: [],
-                  addLabels: ["maintainer-required"], comments: [] },
-              }));
-              return;
+              evidenceReason = "changed file retrieval unavailable";
             }
             const state = resolveReviewState({
               expectedSha: process.env.HEAD_SHA,
@@ -995,7 +966,10 @@ jobs:
               contributor: parse(process.env.CONTRIBUTOR, {}),
               rateLimit: parse(process.env.FORK_RATE_LIMIT, {}),
               protocolStatus: process.env.PROTOCOL_STATUS,
+              protocolReason: process.env.PROTOCOL_REASON,
               reviewer: process.env.RAW_OUTPUT || "",
+              reviewerReason: process.env.REVIEWER_REASON,
+              evidenceReason,
               changedPaths: files.map((file) => file.filename),
               changedLines: addedLinesByPath(files),
             });


### PR DESCRIPTION
Resume each heavy review session once when its output is missing or invalid. Validate selected output again before publication.

Report exhausted attempts with a neutral SHA-bound check without advancing the AI review count. Preserve completed checks when an ineligible review-route event cannot retrieve PR evidence.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>