### PR TITLE
ci: preserve labels on cancellation

### DIFF
--- a/.github/PR_AUTOMATION.md
+++ b/.github/PR_AUTOMATION.md
@@ -31,7 +31,8 @@ it.
 The trusted LLM validators normalize exact empty-string representation artifacts consistently.
 An invalid classifier result keeps the pull request `risk/unknown` and
 `maintainer-required`, and publishes a neutral `AI classification` check containing the local
-validation reason so the review remains blocked without hiding why.
+validation reason so the review remains blocked without hiding why. A cancelled workflow does not
+publish a fallback state or change labels; the succeeding workflow run recomputes the classification.
 
 Each analytical stage selects its model and effort through `--model` and `--effort` in the `claude-args` step
 that builds its `claude_args`. The classifier runs Sonnet at `low` effort: it runs on every push and

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -47,6 +47,17 @@ test("workflow does not overwrite github-script result outputs", () => {
   assert.doesNotMatch(workflow, /needs\.[\w-]+\.outputs\.result\b/);
 });
 
+test("workflow does not resolve or write state after cancellation", () => {
+  const workflow = fs.readFileSync(path.join(__dirname, "..", "workflows", "labeler.yml"), "utf8");
+  for (const name of ["resolve-classification-state", "resolve-review-state", "write-state"]) {
+    const start = workflow.indexOf(`  ${name}:\n`);
+    assert.notEqual(start, -1, `${name} job is missing`);
+    const following = workflow.slice(start + 1).search(/\n  [a-z][a-z0-9-]+:\n/);
+    const job = workflow.slice(start, following === -1 ? undefined : start + following + 1);
+    assert.match(job, /^    if: always\(\) && !cancelled\(\) &&/m);
+  }
+});
+
 test("review skills own methodology while stage prompts own pipeline contracts", () => {
   const githubDirectory = path.join(__dirname, "..");
   const repositoryRoot = path.join(githubDirectory, "..");

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -462,7 +462,7 @@ jobs:
   resolve-classification-state:
     name: Resolve classification state
     needs: [resolve-pr, classification-gate, deterministic-analysis, fork-rate-limit, semver, classifier]
-    if: always() && needs.resolve-pr.outputs.ok == 'true' &&
+    if: always() && !cancelled() && needs.resolve-pr.outputs.ok == 'true' &&
       needs.resolve-pr.outputs.classification-requested == 'true' &&
       (needs.classification-gate.outputs.required == 'true' ||
       needs.classification-gate.outputs.available != 'true')
@@ -938,7 +938,7 @@ jobs:
   resolve-review-state:
     name: Resolve review state
     needs: [resolve-pr, fork-rate-limit, review-gate, contributor-history, validate-protocol-review, skeptical-reviewer]
-    if: always() && needs.resolve-pr.outputs.ok == 'true' &&
+    if: always() && !cancelled() && needs.resolve-pr.outputs.ok == 'true' &&
       needs.resolve-pr.outputs.review-route == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -1007,7 +1007,7 @@ jobs:
     needs: [resolve-pr, classification-gate, deterministic-analysis, fork-rate-limit, semver,
       classifier, resolve-classification-state, review-gate, contributor-history, protocol-reviewer,
       validate-protocol-review, skeptical-reviewer, resolve-review-state]
-    if: always() && needs.resolve-pr.outputs.ok == 'true'
+    if: always() && !cancelled() && needs.resolve-pr.outputs.ok == 'true'
     runs-on: ubuntu-latest
     concurrency:
       group: pr-automation-write-${{ needs.resolve-pr.outputs.pr-number }}


### PR DESCRIPTION
Cancelled workflow runs have no classifier result, not an unknown risk assessment. Skip state resolution and writes after cancellation while preserving the fallback for completed classifier failures.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>