### PR TITLE
feat(rdpudp): add protocol codec foundation

### DIFF
--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -332,6 +332,7 @@ impl ClientConnector {
             }),
             flags: nego::RequestFlags::empty(),
             protocol: security_protocol,
+            correlation_info: None,
         };
 
         debug!(message = ?connection_request, "Send");

--- a/crates/ironrdp-dvc/src/client.rs
+++ b/crates/ironrdp-dvc/src/client.rs
@@ -1,4 +1,5 @@
 use alloc::boxed::Box;
+use alloc::collections::BTreeSet;
 use alloc::collections::btree_map::BTreeMap;
 use alloc::vec::Vec;
 use core::any::TypeId;
@@ -15,7 +16,7 @@ use tracing::debug;
 
 use crate::pdu::{
     CapabilitiesResponsePdu, CapsVersion, ClosePdu, CreateResponsePdu, CreationStatus, DrdynvcClientPdu,
-    DrdynvcDataPdu, DrdynvcServerPdu,
+    DrdynvcDataPdu, DrdynvcServerPdu, SoftSyncResponsePdu, SoftSyncTunnelType,
 };
 use crate::{
     DvcMessage, DvcProcessor, DynamicChannelId, DynamicChannelMut, DynamicChannelName, DynamicChannelRef,
@@ -127,6 +128,10 @@ pub struct DrdynvcClient {
     dynamic_channels: DynamicChannelSet,
     /// Indicates whether the capability request/response handshake has been completed.
     cap_handshake_done: bool,
+    available_tunnels: BTreeSet<SoftSyncTunnelType>,
+    pending_tunnel_channels: Option<BTreeMap<DynamicChannelId, SoftSyncTunnelType>>,
+    tunnel_channels: BTreeMap<DynamicChannelId, SoftSyncTunnelType>,
+    soft_sync_complete: bool,
 }
 
 impl fmt::Debug for DrdynvcClient {
@@ -151,6 +156,10 @@ impl DrdynvcClient {
         Self {
             dynamic_channels: DynamicChannelSet::new(),
             cap_handshake_done: false,
+            available_tunnels: BTreeSet::new(),
+            pending_tunnel_channels: None,
+            tunnel_channels: BTreeMap::new(),
+            soft_sync_complete: false,
         }
     }
 
@@ -277,7 +286,98 @@ impl DrdynvcClient {
 
     pub fn close_channel(&mut self, channel_id: u32) -> Option<SvcMessage> {
         self.dynamic_channels.remove_by_channel_id(channel_id)?;
+        self.tunnel_channels.remove(&channel_id);
+        if let Some(channels) = self.pending_tunnel_channels.as_mut() {
+            channels.remove(&channel_id);
+        }
         Some(SvcMessage::from(DrdynvcClientPdu::Close(ClosePdu::new(channel_id))))
+    }
+
+    /// Enables a multitransport tunnel for a future Soft-Sync request.
+    pub fn enable_soft_sync_tunnel(&mut self, tunnel_type: SoftSyncTunnelType) {
+        self.available_tunnels.insert(tunnel_type);
+    }
+
+    /// Returns whether a Soft-Sync response has been encoded but not yet sent on TCP.
+    pub fn has_pending_soft_sync_response(&self) -> bool {
+        self.pending_tunnel_channels.is_some()
+    }
+
+    /// Activates the routing selected by the most recent Soft-Sync response.
+    ///
+    /// Call this only after the response has been successfully written over the
+    /// DRDYNVC static virtual channel.
+    pub fn complete_soft_sync_response(&mut self) -> PduResult<()> {
+        let pending = self
+            .pending_tunnel_channels
+            .take()
+            .ok_or_else(|| pdu_other_err!("no Soft-Sync response is pending"))?;
+        self.tunnel_channels = pending;
+        self.soft_sync_complete = true;
+        Ok(())
+    }
+
+    /// Returns whether the Soft-Sync response has been sent over TCP and
+    /// multitransport DVC data can be exchanged.
+    pub const fn soft_sync_complete(&self) -> bool {
+        self.soft_sync_complete
+    }
+
+    /// Returns the tunnel selected for client-to-server messages on `channel_id`.
+    pub fn tunnel_for_channel(&self, channel_id: DynamicChannelId) -> Option<SoftSyncTunnelType> {
+        self.tunnel_channels.get(&channel_id).copied()
+    }
+
+    /// Processes raw DRDYNVC data received through an established multitransport tunnel.
+    pub fn process_tunnel(&mut self, payload: &[u8]) -> PduResult<Vec<SvcMessage>> {
+        let pdu = decode_dvc_message(payload).map_err(|e| decode_err!(e))?;
+        let DrdynvcServerPdu::Data(data) = pdu else {
+            return Err(pdu_other_err!("only DVC data is permitted on a multitransport tunnel"));
+        };
+        let channel_id = data.channel_id();
+        if !self.tunnel_channels.contains_key(&channel_id) {
+            return Err(pdu_other_err!(
+                "received tunneled data for a channel not selected by Soft-Sync"
+            ));
+        }
+        self.process_data(data)
+    }
+
+    fn process_data(&mut self, data: DrdynvcDataPdu) -> PduResult<Vec<SvcMessage>> {
+        let channel_id = data.channel_id();
+        let messages = self
+            .dynamic_channels
+            .get_by_channel_id_mut(channel_id)
+            .ok_or_else(|| pdu_other_err!("access to non existing DVC channel"))?
+            .process(data)?;
+
+        encode_dvc_messages(channel_id, messages, ChannelFlags::empty()).map_err(|e| encode_err!(e))
+    }
+
+    fn process_soft_sync_request(&mut self, request: crate::pdu::SoftSyncRequestPdu) -> PduResult<SvcMessage> {
+        if self.pending_tunnel_channels.is_some() || self.soft_sync_complete {
+            return Err(pdu_other_err!("received duplicate Soft-Sync request"));
+        }
+
+        let mut tunnel_channels = BTreeMap::new();
+        let mut tunnels_to_switch = Vec::new();
+        for list in request.channel_lists() {
+            if !self.available_tunnels.contains(&list.tunnel_type()) {
+                continue;
+            }
+            for channel_id in list.channel_ids() {
+                if self.dynamic_channels.get_by_channel_id(*channel_id).is_none() {
+                    return Err(pdu_other_err!("Soft-Sync request contains an unknown dynamic channel"));
+                }
+                tunnel_channels.insert(*channel_id, list.tunnel_type());
+            }
+            tunnels_to_switch.push(list.tunnel_type());
+        }
+
+        self.pending_tunnel_channels = Some(tunnel_channels);
+        Ok(SvcMessage::from(DrdynvcClientPdu::SoftSyncResponse(
+            SoftSyncResponsePdu::new(tunnels_to_switch),
+        )))
     }
 }
 
@@ -359,17 +459,14 @@ impl SvcProcessor for DrdynvcClient {
                 }
             }
             DrdynvcServerPdu::Data(data) => {
-                let channel_id = data.channel_id();
-
-                let messages = self
-                    .dynamic_channels
-                    .get_by_channel_id_mut(channel_id)
-                    .ok_or_else(|| pdu_other_err!("access to non existing DVC channel"))?
-                    .process(data)?;
-
-                responses.extend(
-                    encode_dvc_messages(channel_id, messages, ChannelFlags::empty()).map_err(|e| encode_err!(e))?,
-                );
+                if self.tunnel_channels.contains_key(&data.channel_id()) {
+                    return Err(pdu_other_err!("received TCP data for a channel selected by Soft-Sync"));
+                }
+                responses.extend(self.process_data(data)?);
+            }
+            DrdynvcServerPdu::SoftSyncRequest(request) => {
+                debug!("Got DVC Soft-Sync Request PDU: {request:?}");
+                responses.push(self.process_soft_sync_request(request)?);
             }
         }
 

--- a/crates/ironrdp-dvc/src/pdu.rs
+++ b/crates/ironrdp-dvc/src/pdu.rs
@@ -1,3 +1,4 @@
+use alloc::collections::BTreeSet;
 use alloc::format;
 use core::fmt;
 
@@ -61,6 +62,7 @@ pub enum DrdynvcClientPdu {
     Create(CreateResponsePdu),
     Close(ClosePdu),
     Data(DrdynvcDataPdu),
+    SoftSyncResponse(SoftSyncResponsePdu),
 }
 
 impl Encode for DrdynvcClientPdu {
@@ -70,6 +72,7 @@ impl Encode for DrdynvcClientPdu {
             DrdynvcClientPdu::Create(pdu) => pdu.encode(dst),
             DrdynvcClientPdu::Data(pdu) => pdu.encode(dst),
             DrdynvcClientPdu::Close(pdu) => pdu.encode(dst),
+            DrdynvcClientPdu::SoftSyncResponse(pdu) => pdu.encode(dst),
         }
     }
 
@@ -79,6 +82,7 @@ impl Encode for DrdynvcClientPdu {
             DrdynvcClientPdu::Create(_) => CreateResponsePdu::name(),
             DrdynvcClientPdu::Data(pdu) => pdu.name(),
             DrdynvcClientPdu::Close(_) => ClosePdu::name(),
+            DrdynvcClientPdu::SoftSyncResponse(_) => SoftSyncResponsePdu::name(),
         }
     }
 
@@ -88,6 +92,7 @@ impl Encode for DrdynvcClientPdu {
             DrdynvcClientPdu::Create(pdu) => pdu.size(),
             DrdynvcClientPdu::Data(pdu) => pdu.size(),
             DrdynvcClientPdu::Close(pdu) => pdu.size(),
+            DrdynvcClientPdu::SoftSyncResponse(pdu) => pdu.size(),
         }
     }
 }
@@ -103,6 +108,7 @@ impl Decode<'_> for DrdynvcClientPdu {
             Cmd::Data => Ok(Self::Data(DrdynvcDataPdu::Data(DataPdu::decode(header, src)?))),
             Cmd::Close => Ok(Self::Close(ClosePdu::decode(header, src)?)),
             Cmd::Capability => Ok(Self::Capabilities(CapabilitiesResponsePdu::decode(header, src)?)),
+            Cmd::SoftSyncResponse => Ok(Self::SoftSyncResponse(SoftSyncResponsePdu::decode(header, src)?)),
             _ => Err(unsupported_value_err!("Cmd", header.cmd.into())),
         }
     }
@@ -115,6 +121,7 @@ pub enum DrdynvcServerPdu {
     Create(CreateRequestPdu),
     Close(ClosePdu),
     Data(DrdynvcDataPdu),
+    SoftSyncRequest(SoftSyncRequestPdu),
 }
 
 impl Encode for DrdynvcServerPdu {
@@ -124,6 +131,7 @@ impl Encode for DrdynvcServerPdu {
             DrdynvcServerPdu::Capabilities(pdu) => pdu.encode(dst),
             DrdynvcServerPdu::Create(pdu) => pdu.encode(dst),
             DrdynvcServerPdu::Close(pdu) => pdu.encode(dst),
+            DrdynvcServerPdu::SoftSyncRequest(pdu) => pdu.encode(dst),
         }
     }
 
@@ -133,6 +141,7 @@ impl Encode for DrdynvcServerPdu {
             DrdynvcServerPdu::Capabilities(pdu) => pdu.name(),
             DrdynvcServerPdu::Create(_) => CreateRequestPdu::name(),
             DrdynvcServerPdu::Close(_) => ClosePdu::name(),
+            DrdynvcServerPdu::SoftSyncRequest(_) => SoftSyncRequestPdu::name(),
         }
     }
 
@@ -142,6 +151,7 @@ impl Encode for DrdynvcServerPdu {
             DrdynvcServerPdu::Capabilities(pdu) => pdu.size(),
             DrdynvcServerPdu::Create(pdu) => pdu.size(),
             DrdynvcServerPdu::Close(pdu) => pdu.size(),
+            DrdynvcServerPdu::SoftSyncRequest(pdu) => pdu.size(),
         }
     }
 }
@@ -157,6 +167,7 @@ impl Decode<'_> for DrdynvcServerPdu {
             Cmd::Data => Ok(Self::Data(DrdynvcDataPdu::Data(DataPdu::decode(header, src)?))),
             Cmd::Close => Ok(Self::Close(ClosePdu::decode(header, src)?)),
             Cmd::Capability => Ok(Self::Capabilities(CapabilitiesRequestPdu::decode(header, src)?)),
+            Cmd::SoftSyncRequest => Ok(Self::SoftSyncRequest(SoftSyncRequestPdu::decode(header, src)?)),
             _ => Err(unsupported_value_err!("Cmd", header.cmd.into())),
         }
     }
@@ -166,6 +177,366 @@ impl Decode<'_> for DrdynvcServerPdu {
 impl SvcEncode for DrdynvcDataPdu {}
 impl SvcEncode for DrdynvcClientPdu {}
 impl SvcEncode for DrdynvcServerPdu {}
+
+/// A multitransport tunnel used for Soft-Sync.
+///
+/// Defined in [\[MS-RDPEDYC\] 2.2.5.1.1] and [\[MS-RDPEDYC\] 2.2.5.2].
+///
+/// [\[MS-RDPEDYC\] 2.2.5.1.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpedyc/20a29627-6966-4085-b5f1-00112a6114e3
+/// [\[MS-RDPEDYC\] 2.2.5.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpedyc/2f9c83aa-8c82-4d85-a7fe-b4c6301a9f90
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum SoftSyncTunnelType {
+    /// Reliable RDP-UDP FEC tunnel.
+    ReliableUdp = 0x0000_0001,
+    /// Lossy RDP-UDP FEC tunnel.
+    LossyUdp = 0x0000_0003,
+}
+
+impl TryFrom<u32> for SoftSyncTunnelType {
+    type Error = DecodeError;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            0x0000_0001 => Ok(Self::ReliableUdp),
+            0x0000_0003 => Ok(Self::LossyUdp),
+            _ => Err(invalid_field_err!("TunnelType", "unsupported tunnel type")),
+        }
+    }
+}
+
+impl From<SoftSyncTunnelType> for u32 {
+    #[expect(
+        clippy::as_conversions,
+        reason = "repr(u32) guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
+    fn from(value: SoftSyncTunnelType) -> Self {
+        value as u32
+    }
+}
+
+/// A group of dynamic virtual channels sent over one Soft-Sync tunnel.
+///
+/// Defined in [\[MS-RDPEDYC\] 2.2.5.1.1].
+///
+/// [\[MS-RDPEDYC\] 2.2.5.1.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpedyc/20a29627-6966-4085-b5f1-00112a6114e3
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SoftSyncChannelList {
+    tunnel_type: SoftSyncTunnelType,
+    channel_ids: Vec<DynamicChannelId>,
+}
+
+impl SoftSyncChannelList {
+    const FIXED_PART_SIZE: usize = 4 /* TunnelType */ + 2 /* NumberOfDVCs */;
+
+    /// Creates a channel list for a multitransport tunnel.
+    pub fn new(tunnel_type: SoftSyncTunnelType, channel_ids: Vec<DynamicChannelId>) -> Self {
+        Self {
+            tunnel_type,
+            channel_ids,
+        }
+    }
+
+    /// Returns the tunnel selected for these channels.
+    pub fn tunnel_type(&self) -> SoftSyncTunnelType {
+        self.tunnel_type
+    }
+
+    /// Returns the dynamic virtual channels assigned to this tunnel.
+    pub fn channel_ids(&self) -> &[DynamicChannelId] {
+        &self.channel_ids
+    }
+
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        dst.write_u32(self.tunnel_type.into());
+        dst.write_u16(cast_length!("NumberOfDVCs", self.channel_ids.len())?);
+        for channel_id in &self.channel_ids {
+            dst.write_u32(*channel_id);
+        }
+        Ok(())
+    }
+
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: Self::FIXED_PART_SIZE);
+
+        let tunnel_type = SoftSyncTunnelType::try_from(src.read_u32())?;
+        let number_of_dvcs = usize::from(src.read_u16());
+        if number_of_dvcs == 0 {
+            return Err(invalid_field_err!("NumberOfDVCs", "must be nonzero"));
+        }
+        ensure_size!(in: src, size: number_of_dvcs * 4 /* ListOfDVCIds */);
+
+        let mut channel_ids = Vec::with_capacity(number_of_dvcs);
+        for _ in 0..number_of_dvcs {
+            channel_ids.push(src.read_u32());
+        }
+
+        Ok(Self {
+            tunnel_type,
+            channel_ids,
+        })
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.channel_ids.len() * 4 /* ListOfDVCIds */
+    }
+}
+
+/// Soft-Sync request sent by the DVC server manager.
+///
+/// Defined in [\[MS-RDPEDYC\] 2.2.5.1].
+///
+/// [\[MS-RDPEDYC\] 2.2.5.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpedyc/98c6b432-842d-4d43-b1fb-ae02f945feee
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SoftSyncRequestPdu {
+    channel_lists: Vec<SoftSyncChannelList>,
+}
+
+impl SoftSyncRequestPdu {
+    const TCP_FLUSHED: u16 = 0x0001;
+    const CHANNEL_LIST_PRESENT: u16 = 0x0002;
+    const FLAGS_MASK: u16 = Self::TCP_FLUSHED | Self::CHANNEL_LIST_PRESENT;
+    const LENGTH_FIXED_PART_SIZE: usize = 4 /* Length */ + 2 /* Flags */ + 2 /* NumberOfTunnels */;
+    const FIXED_PART_SIZE: usize = Header::FIXED_PART_SIZE + 1 /* Pad */ + Self::LENGTH_FIXED_PART_SIZE;
+
+    /// Creates a Soft-Sync request for the supplied tunnel/channel assignments.
+    pub fn new(channel_lists: Vec<SoftSyncChannelList>) -> Self {
+        Self { channel_lists }
+    }
+
+    /// Returns the tunnel/channel assignments announced by this request.
+    pub fn channel_lists(&self) -> &[SoftSyncChannelList] {
+        &self.channel_lists
+    }
+
+    fn flags(&self) -> u16 {
+        Self::TCP_FLUSHED
+            | if self.channel_lists.is_empty() {
+                0
+            } else {
+                Self::CHANNEL_LIST_PRESENT
+            }
+    }
+
+    fn validate(&self) -> EncodeResult<()> {
+        let _: u16 = cast_length!("NumberOfTunnels", self.channel_lists.len())?;
+        let mut tunnel_types = BTreeSet::new();
+        let mut channel_ids = BTreeSet::new();
+
+        for list in &self.channel_lists {
+            if list.channel_ids.is_empty() {
+                return Err(invalid_field_err!("NumberOfDVCs", "must be nonzero"));
+            }
+            let _: u16 = cast_length!("NumberOfDVCs", list.channel_ids.len())?;
+            if !tunnel_types.insert(list.tunnel_type) {
+                return Err(invalid_field_err!(
+                    "TunnelType",
+                    "appears in more than one channel list"
+                ));
+            }
+            for channel_id in &list.channel_ids {
+                if !channel_ids.insert(*channel_id) {
+                    return Err(invalid_field_err!(
+                        "ListOfDVCIds",
+                        "channel ID appears in more than one channel list"
+                    ));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn decode(header: Header, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        if header.cb_id != FieldType::U8 || header.sp != FieldType::U8 {
+            return Err(invalid_field_err!("Header", "cbId and Sp must be zero"));
+        }
+        ensure_size!(in: src, size: Self::FIXED_PART_SIZE - Header::FIXED_PART_SIZE);
+
+        let headerless_size = src.len();
+        let pad = src.read_u8();
+        if pad != 0 {
+            return Err(invalid_field_err!("Pad", "must be zero"));
+        }
+        let length = usize::try_from(src.read_u32()).map_err(|_| invalid_field_err!("Length", "is too large"))?;
+        if length != headerless_size - 1
+        /* Pad */
+        {
+            return Err(invalid_field_err!(
+                "Length",
+                "does not match the bytes following the pad field"
+            ));
+        }
+
+        let flags = src.read_u16();
+        if flags & !Self::FLAGS_MASK != 0 {
+            return Err(invalid_field_err!("Flags", "contains unsupported flags"));
+        }
+        if flags & Self::TCP_FLUSHED == 0 {
+            return Err(invalid_field_err!("Flags", "SOFT_SYNC_TCP_FLUSHED must be set"));
+        }
+
+        let number_of_tunnels = usize::from(src.read_u16());
+        let channel_list_present = flags & Self::CHANNEL_LIST_PRESENT != 0;
+        if channel_list_present != (number_of_tunnels != 0) {
+            return Err(invalid_field_err!(
+                "Flags",
+                "SOFT_SYNC_CHANNEL_LIST_PRESENT must agree with NumberOfTunnels"
+            ));
+        }
+
+        let mut channel_lists = Vec::with_capacity(number_of_tunnels);
+        let mut tunnel_types = BTreeSet::new();
+        let mut channel_ids = BTreeSet::new();
+        for _ in 0..number_of_tunnels {
+            let list = SoftSyncChannelList::decode(src)?;
+            if !tunnel_types.insert(list.tunnel_type) {
+                return Err(invalid_field_err!(
+                    "TunnelType",
+                    "appears in more than one channel list"
+                ));
+            }
+            for channel_id in &list.channel_ids {
+                if !channel_ids.insert(*channel_id) {
+                    return Err(invalid_field_err!(
+                        "ListOfDVCIds",
+                        "channel ID appears in more than one channel list"
+                    ));
+                }
+            }
+            channel_lists.push(list);
+        }
+        if !src.is_empty() {
+            return Err(invalid_field_err!("Length", "contains trailing bytes"));
+        }
+
+        Ok(Self { channel_lists })
+    }
+
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        self.validate()?;
+        ensure_size!(in: dst, size: self.size());
+
+        Header::new(0, 0, Cmd::SoftSyncRequest).encode(dst)?;
+        dst.write_u8(0);
+        dst.write_u32(cast_length!("Length", self.length())?);
+        dst.write_u16(self.flags());
+        dst.write_u16(cast_length!("NumberOfTunnels", self.channel_lists.len())?);
+        for list in &self.channel_lists {
+            list.encode(dst)?;
+        }
+
+        Ok(())
+    }
+
+    fn name() -> &'static str {
+        "DYNVC_SOFT_SYNC_REQUEST"
+    }
+
+    fn length(&self) -> usize {
+        Self::LENGTH_FIXED_PART_SIZE + self.channel_lists.iter().map(SoftSyncChannelList::size).sum::<usize>()
+    }
+
+    fn size(&self) -> usize {
+        Header::FIXED_PART_SIZE + 1 /* Pad */ + self.length()
+    }
+}
+
+/// Soft-Sync response sent by the DVC client manager.
+///
+/// Defined in [\[MS-RDPEDYC\] 2.2.5.2].
+///
+/// [\[MS-RDPEDYC\] 2.2.5.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpedyc/2f9c83aa-8c82-4d85-a7fe-b4c6301a9f90
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SoftSyncResponsePdu {
+    tunnels_to_switch: Vec<SoftSyncTunnelType>,
+}
+
+impl SoftSyncResponsePdu {
+    const FIXED_PART_SIZE: usize = Header::FIXED_PART_SIZE + 1 /* Pad */ + 4 /* NumberOfTunnels */;
+
+    /// Creates a Soft-Sync response for the tunnels on which the client will write DVC data.
+    pub fn new(tunnels_to_switch: Vec<SoftSyncTunnelType>) -> Self {
+        Self { tunnels_to_switch }
+    }
+
+    /// Returns the tunnels on which the client will write DVC data.
+    pub fn tunnels_to_switch(&self) -> &[SoftSyncTunnelType] {
+        &self.tunnels_to_switch
+    }
+
+    fn validate(&self) -> EncodeResult<()> {
+        let _: u32 = cast_length!("NumberOfTunnels", self.tunnels_to_switch.len())?;
+        let mut tunnels = BTreeSet::new();
+        for tunnel in &self.tunnels_to_switch {
+            if !tunnels.insert(*tunnel) {
+                return Err(invalid_field_err!(
+                    "TunnelsToSwitch",
+                    "contains a duplicate tunnel type"
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn decode(header: Header, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        if header.cb_id != FieldType::U8 || header.sp != FieldType::U8 {
+            return Err(invalid_field_err!("Header", "cbId and Sp must be zero"));
+        }
+        ensure_size!(in: src, size: Self::FIXED_PART_SIZE - Header::FIXED_PART_SIZE);
+
+        let pad = src.read_u8();
+        if pad != 0 {
+            return Err(invalid_field_err!("Pad", "must be zero"));
+        }
+        let number_of_tunnels =
+            usize::try_from(src.read_u32()).map_err(|_| invalid_field_err!("NumberOfTunnels", "is too large"))?;
+        ensure_size!(in: src, size: number_of_tunnels * 4 /* TunnelsToSwitch */);
+
+        let mut tunnels_to_switch = Vec::with_capacity(number_of_tunnels);
+        let mut tunnels = BTreeSet::new();
+        for _ in 0..number_of_tunnels {
+            let tunnel = SoftSyncTunnelType::try_from(src.read_u32())?;
+            if !tunnels.insert(tunnel) {
+                return Err(invalid_field_err!(
+                    "TunnelsToSwitch",
+                    "contains a duplicate tunnel type"
+                ));
+            }
+            tunnels_to_switch.push(tunnel);
+        }
+        if !src.is_empty() {
+            return Err(invalid_field_err!(
+                "NumberOfTunnels",
+                "does not match the remaining bytes"
+            ));
+        }
+
+        Ok(Self { tunnels_to_switch })
+    }
+
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        self.validate()?;
+        ensure_size!(in: dst, size: self.size());
+
+        Header::new(0, 0, Cmd::SoftSyncResponse).encode(dst)?;
+        dst.write_u8(0);
+        dst.write_u32(cast_length!("NumberOfTunnels", self.tunnels_to_switch.len())?);
+        for tunnel in &self.tunnels_to_switch {
+            dst.write_u32((*tunnel).into());
+        }
+
+        Ok(())
+    }
+
+    fn name() -> &'static str {
+        "DYNVC_SOFT_SYNC_RESPONSE"
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.tunnels_to_switch.len() * 4 /* TunnelsToSwitch */
+    }
+}
 
 /// [2.2] Message Syntax
 ///

--- a/crates/ironrdp-dvc/src/server.rs
+++ b/crates/ironrdp-dvc/src/server.rs
@@ -12,7 +12,8 @@ use pdu::gcc::ChannelName;
 use tracing::debug;
 
 use crate::pdu::{
-    CapabilitiesRequestPdu, CapsVersion, ClosePdu, CreateRequestPdu, CreationStatus, DrdynvcClientPdu, DrdynvcServerPdu,
+    CapabilitiesRequestPdu, CapsVersion, ClosePdu, CreateRequestPdu, CreationStatus, DrdynvcClientPdu,
+    DrdynvcServerPdu, SoftSyncChannelList, SoftSyncRequestPdu, SoftSyncTunnelType,
 };
 use crate::{CompleteData, DvcProcessor, DynamicChannelMut, DynamicChannelRef, encode_dvc_messages};
 
@@ -123,6 +124,10 @@ impl DynamicChannel {
 pub struct DrdynvcServer {
     dynamic_channels: DynamicChannelAllocator,
     type_id_to_channel_id: BTreeMap<TypeId, u32>,
+    pending_tunnel_channels: Option<BTreeMap<u32, SoftSyncTunnelType>>,
+    outgoing_tunnel_channels: BTreeMap<u32, SoftSyncTunnelType>,
+    incoming_tunnel_channels: BTreeMap<u32, SoftSyncTunnelType>,
+    soft_sync_response_received: bool,
 }
 
 impl fmt::Debug for DrdynvcServer {
@@ -147,6 +152,10 @@ impl DrdynvcServer {
         Self {
             dynamic_channels: DynamicChannelAllocator::new(),
             type_id_to_channel_id: BTreeMap::new(),
+            pending_tunnel_channels: None,
+            outgoing_tunnel_channels: BTreeMap::new(),
+            incoming_tunnel_channels: BTreeMap::new(),
+            soft_sync_response_received: false,
         }
     }
 
@@ -243,10 +252,124 @@ impl DrdynvcServer {
 
     pub fn close_channel(&mut self, channel_id: u32) -> Option<SvcMessage> {
         self.remove_by_channel_id(channel_id)?;
+        if let Some(channels) = self.pending_tunnel_channels.as_mut() {
+            channels.remove(&channel_id);
+        }
+        self.outgoing_tunnel_channels.remove(&channel_id);
+        self.incoming_tunnel_channels.remove(&channel_id);
         Some(
             SvcMessage::from(DrdynvcServerPdu::Close(ClosePdu::new(channel_id)))
                 .with_flags(ChannelFlags::SHOW_PROTOCOL),
         )
+    }
+
+    /// Creates a Soft-Sync request that moves the supplied channels to reliable UDP.
+    ///
+    /// Call [`Self::complete_soft_sync_request`] only after the returned message
+    /// has been successfully written over TCP.
+    pub fn request_reliable_udp(&mut self, channel_ids: Vec<u32>) -> PduResult<SvcMessage> {
+        if channel_ids.is_empty() {
+            return Err(pdu_other_err!("Soft-Sync requires at least one dynamic channel"));
+        }
+        if self.pending_tunnel_channels.is_some() || !self.outgoing_tunnel_channels.is_empty() {
+            return Err(pdu_other_err!("Soft-Sync has already been requested"));
+        }
+
+        let mut selected_channels = BTreeMap::new();
+        for channel_id in &channel_ids {
+            if !self.is_channel_opened(*channel_id) {
+                return Err(pdu_other_err!(
+                    "Soft-Sync requested for a dynamic channel that is not open"
+                ));
+            }
+            if selected_channels
+                .insert(*channel_id, SoftSyncTunnelType::ReliableUdp)
+                .is_some()
+            {
+                return Err(pdu_other_err!("Soft-Sync channel list contains a duplicate channel ID"));
+            }
+        }
+
+        let request = SoftSyncRequestPdu::new(alloc::vec![SoftSyncChannelList::new(
+            SoftSyncTunnelType::ReliableUdp,
+            channel_ids,
+        )]);
+        self.pending_tunnel_channels = Some(selected_channels);
+        as_svc_msg_with_flag(DrdynvcServerPdu::SoftSyncRequest(request))
+    }
+
+    /// Begins server-to-client tunnel routing after a Soft-Sync request was sent over TCP.
+    pub fn complete_soft_sync_request(&mut self) -> PduResult<()> {
+        let pending = self
+            .pending_tunnel_channels
+            .take()
+            .ok_or_else(|| pdu_other_err!("no Soft-Sync request is pending"))?;
+        self.outgoing_tunnel_channels = pending;
+        Ok(())
+    }
+
+    /// Returns whether server-to-client data for `channel_id` must be sent through a tunnel.
+    pub fn tunnel_for_outgoing_channel(&self, channel_id: u32) -> Option<SoftSyncTunnelType> {
+        self.outgoing_tunnel_channels.get(&channel_id).copied()
+    }
+
+    /// Returns whether the client has acknowledged the Soft-Sync request over TCP.
+    pub const fn soft_sync_response_received(&self) -> bool {
+        self.soft_sync_response_received
+    }
+
+    /// Processes raw DRDYNVC data received through an established multitransport tunnel.
+    pub fn process_tunnel(&mut self, payload: &[u8]) -> PduResult<Vec<SvcMessage>> {
+        let pdu = decode_dvc_message(payload).map_err(|e| decode_err!(e))?;
+        let DrdynvcClientPdu::Data(data) = pdu else {
+            return Err(pdu_other_err!("only DVC data is permitted on a multitransport tunnel"));
+        };
+        if !self.incoming_tunnel_channels.contains_key(&data.channel_id()) {
+            return Err(pdu_other_err!(
+                "received tunneled data for a channel not selected by Soft-Sync"
+            ));
+        }
+        self.process_data(data)
+    }
+
+    fn process_data(&mut self, data: crate::pdu::DrdynvcDataPdu) -> PduResult<Vec<SvcMessage>> {
+        let channel_id = data.channel_id();
+        let c = self.channel_by_id(channel_id).map_err(|e| decode_err!(e))?;
+        if c.state != ChannelState::Opened {
+            debug!(?channel_id, ?c.state, "Invalid channel state");
+            return Err(pdu_other_err!("invalid channel state"));
+        }
+        let mut resp = Vec::new();
+        if let Some(complete) = c.complete_data.process_data(data).map_err(|e| decode_err!(e))? {
+            let msg = c.processor.process(channel_id, &complete)?;
+            resp.extend(encode_dvc_messages(channel_id, msg, ChannelFlags::SHOW_PROTOCOL).map_err(|e| encode_err!(e))?);
+        }
+        Ok(resp)
+    }
+
+    fn process_soft_sync_response(&mut self, response: crate::pdu::SoftSyncResponsePdu) -> PduResult<()> {
+        if self.outgoing_tunnel_channels.is_empty() || self.soft_sync_response_received {
+            return Err(pdu_other_err!("received unexpected Soft-Sync response"));
+        }
+
+        let requested_tunnels: BTreeMap<_, _> = self
+            .outgoing_tunnel_channels
+            .iter()
+            .map(|(channel_id, tunnel_type)| (*channel_id, *tunnel_type))
+            .collect();
+        for tunnel_type in response.tunnels_to_switch() {
+            if !requested_tunnels.values().any(|requested| requested == tunnel_type) {
+                return Err(pdu_other_err!("Soft-Sync response selected an unrequested tunnel"));
+            }
+        }
+        self.incoming_tunnel_channels = self
+            .outgoing_tunnel_channels
+            .iter()
+            .filter(|(_, tunnel_type)| response.tunnels_to_switch().contains(tunnel_type))
+            .map(|(channel_id, tunnel_type)| (*channel_id, *tunnel_type))
+            .collect();
+        self.soft_sync_response_received = true;
+        Ok(())
     }
 }
 
@@ -311,19 +434,14 @@ impl SvcProcessor for DrdynvcServer {
                 self.remove_by_channel_id(channel_id);
             }
             DrdynvcClientPdu::Data(data) => {
-                let channel_id = data.channel_id();
-                let c = self.channel_by_id(channel_id).map_err(|e| decode_err!(e))?;
-                if c.state != ChannelState::Opened {
-                    debug!(?channel_id, ?c.state, "Invalid channel state");
-                    return Err(pdu_other_err!("invalid channel state"));
+                if self.incoming_tunnel_channels.contains_key(&data.channel_id()) {
+                    return Err(pdu_other_err!("received TCP data for a channel selected by Soft-Sync"));
                 }
-                if let Some(complete) = c.complete_data.process_data(data).map_err(|e| decode_err!(e))? {
-                    let msg = c.processor.process(channel_id, &complete)?;
-                    resp.extend(
-                        encode_dvc_messages(channel_id, msg, ChannelFlags::SHOW_PROTOCOL)
-                            .map_err(|e| encode_err!(e))?,
-                    );
-                }
+                resp.extend(self.process_data(data)?);
+            }
+            DrdynvcClientPdu::SoftSyncResponse(response) => {
+                debug!("Got DVC Soft-Sync Response PDU: {response:?}");
+                self.process_soft_sync_response(response)?;
             }
         }
 

--- a/crates/ironrdp-pdu/src/nego.rs
+++ b/crates/ironrdp-pdu/src/nego.rs
@@ -266,12 +266,76 @@ pub struct ConnectionRequest {
     pub nego_data: Option<NegoRequestData>,
     pub flags: RequestFlags,
     pub protocol: SecurityProtocol,
+    /// Optional X.224 connection correlation information.
+    pub correlation_info: Option<CorrelationInfo>,
 }
 
 impl_x224_pdu_pod!(ConnectionRequest);
 
 impl ConnectionRequest {
     const RDP_NEG_REQ_SIZE: u16 = 8;
+}
+
+/// Connection correlation information carried after an RDP negotiation request.
+///
+/// Defined in [\[MS-RDPBCGR\] 2.2.1.1.2].
+///
+/// [\[MS-RDPBCGR\] 2.2.1.1.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/981b2aa8-2aa3-4bfb-8ac8-fc8efad2c0cd
+#[derive(Clone, PartialEq, Eq)]
+pub struct CorrelationInfo {
+    /// The client-selected connection correlation identifier.
+    pub correlation_id: [u8; 16],
+}
+
+impl fmt::Debug for CorrelationInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CorrelationInfo")
+            .field("correlation_id", &"<redacted>")
+            .finish()
+    }
+}
+
+impl CorrelationInfo {
+    const TYPE: u8 = 0x06;
+    const FLAGS: u8 = 0;
+    const SIZE: u16 = 36;
+    const RESERVED_SIZE: usize = 16;
+
+    fn write(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: usize::from(Self::SIZE));
+        dst.write_u8(Self::TYPE);
+        dst.write_u8(Self::FLAGS);
+        dst.write_u16(Self::SIZE);
+        dst.write_slice(&self.correlation_id);
+        dst.write_slice(&[0; Self::RESERVED_SIZE]);
+        Ok(())
+    }
+
+    fn read(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: usize::from(Self::SIZE));
+        let message_type = src.read_u8();
+        let flags = src.read_u8();
+        let length = src.read_u16();
+        if message_type != Self::TYPE || flags != Self::FLAGS || length != Self::SIZE {
+            return Err(invalid_field_err!(
+                "RDP_NEG_CORRELATION_INFO",
+                "header",
+                "contains invalid type, flags, or length"
+            ));
+        }
+
+        let mut correlation_id = [0; 16];
+        correlation_id.copy_from_slice(src.read_slice(16));
+        if src.read_slice(Self::RESERVED_SIZE).iter().any(|&byte| byte != 0) {
+            return Err(invalid_field_err!(
+                "RDP_NEG_CORRELATION_INFO",
+                "reserved",
+                "must be zero"
+            ));
+        }
+
+        Ok(Self { correlation_id })
+    }
 }
 
 impl<'de> X224Pdu<'de> for ConnectionRequest {
@@ -291,13 +355,26 @@ impl<'de> X224Pdu<'de> for ConnectionRequest {
         dst.write_u16(Self::RDP_NEG_REQ_SIZE);
         dst.write_u32(self.protocol.bits());
 
-        if self.flags.contains(RequestFlags::CORRELATION_INFO_PRESENT) {
-            // TODO(#111): support for RDP_NEG_CORRELATION_INFO
-            return Err(invalid_field_err(
-                Self::NAME,
-                "flags",
-                "CORRECTION_INFO_PRESENT flag is set, but not supported by IronRDP",
-            ));
+        match (
+            self.flags.contains(RequestFlags::CORRELATION_INFO_PRESENT),
+            self.correlation_info.as_ref(),
+        ) {
+            (true, Some(correlation_info)) => correlation_info.write(dst)?,
+            (true, None) => {
+                return Err(invalid_field_err!(
+                    Self::NAME,
+                    "flags",
+                    "CORRELATION_INFO_PRESENT requires correlation information"
+                ));
+            }
+            (false, Some(_)) => {
+                return Err(invalid_field_err!(
+                    Self::NAME,
+                    "correlation_info",
+                    "requires CORRELATION_INFO_PRESENT"
+                ));
+            }
+            (false, None) => {}
         }
 
         Ok(())
@@ -328,37 +405,56 @@ impl<'de> X224Pdu<'de> for ConnectionRequest {
             }
 
             let flags = RequestFlags::from_bits_retain(src.read_u8());
-
-            if flags.contains(RequestFlags::CORRELATION_INFO_PRESENT) {
-                // TODO(#111): support for RDP_NEG_CORRELATION_INFO
-                return Err(invalid_field_err(
-                    Self::NAME,
-                    "flags",
-                    "CORRECTION_INFO_PRESENT flag is set, but not supported by IronRDP",
-                ));
+            let length = src.read_u16();
+            if length != Self::RDP_NEG_REQ_SIZE {
+                return Err(invalid_field_err!(Self::NAME, "length", "must be eight bytes"));
             }
 
-            let _length = src.read_u16();
-
             let protocol = SecurityProtocol::from_bits_retain(src.read_u32());
+            let correlation_info = if flags.contains(RequestFlags::CORRELATION_INFO_PRESENT) {
+                if variable_part_rest_size != usize::from(Self::RDP_NEG_REQ_SIZE + CorrelationInfo::SIZE) {
+                    return Err(invalid_field_err!(
+                        Self::NAME,
+                        "TPDU header variable part",
+                        "has invalid correlation information length"
+                    ));
+                }
+                Some(CorrelationInfo::read(src)?)
+            } else {
+                if variable_part_rest_size != usize::from(Self::RDP_NEG_REQ_SIZE) {
+                    return Err(invalid_field_err!(
+                        Self::NAME,
+                        "TPDU header variable part",
+                        "has unexpected trailing data"
+                    ));
+                }
+                None
+            };
 
             Ok(Self {
                 nego_data,
                 flags,
                 protocol,
+                correlation_info,
             })
         } else {
             Ok(Self {
                 nego_data,
                 flags: RequestFlags::empty(),
                 protocol: SecurityProtocol::empty(),
+                correlation_info: None,
             })
         }
     }
 
     fn tpdu_header_variable_part_size(&self) -> usize {
         let optional_nego_data_size = self.nego_data.as_ref().map(|data| data.size()).unwrap_or(0);
-        optional_nego_data_size + usize::from(Self::RDP_NEG_REQ_SIZE)
+        optional_nego_data_size
+            + usize::from(Self::RDP_NEG_REQ_SIZE)
+            + self
+                .correlation_info
+                .as_ref()
+                .map_or(0, |_| usize::from(CorrelationInfo::SIZE))
     }
 
     fn tpdu_user_data_size(&self) -> usize {

--- a/crates/ironrdp-pdu/src/rdp/mod.rs
+++ b/crates/ironrdp-pdu/src/rdp/mod.rs
@@ -16,6 +16,7 @@ pub mod server_error_info;
 pub mod server_license;
 pub mod session_info;
 pub mod suppress_output;
+pub mod udp;
 pub mod vc;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/ironrdp-pdu/src/rdp/multitransport.rs
+++ b/crates/ironrdp-pdu/src/rdp/multitransport.rs
@@ -6,14 +6,445 @@
 //! [\[MS-RDPBCGR\] 2.2.15.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/44044233-e498-46f8-8e16-1ffa595a8e8b
 
 use ironrdp_core::{
-    Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, ensure_fixed_part_size, invalid_field_err,
-    read_padding, write_padding,
+    Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, cast_length, ensure_fixed_part_size,
+    ensure_size, invalid_field_err, read_padding, write_padding,
 };
 
 use crate::rdp::headers::{BasicSecurityHeader, BasicSecurityHeaderFlags};
 
 /// Length of the security cookie used for transport binding validation.
 const SECURITY_COOKIE_LEN: usize = 16;
+
+/// An RDPEMT tunnel subheader.
+///
+/// Defined in [\[MS-RDPEMT\] 2.2.1.1.1].
+///
+/// [\[MS-RDPEMT\] 2.2.1.1.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpemt/5d6ce64a-ec26-4ee2-8375-28040bc7f3f9
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct TunnelSubheader {
+    /// Type of the encapsulated subheader.
+    pub ty: u8,
+    /// Type-specific bytes following the length and type fields.
+    pub data: Vec<u8>,
+}
+
+impl TunnelSubheader {
+    const FIXED_PART_SIZE: usize = 1 /* subHeaderLength */ + 1 /* subHeaderType */;
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.data.len()
+    }
+
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        let length: u8 = cast_length!("subHeaderLength", self.size())?;
+        if usize::from(length) < Self::FIXED_PART_SIZE {
+            return Err(invalid_field_err!("subHeaderLength", "must be at least two bytes"));
+        }
+
+        dst.write_u8(length);
+        dst.write_u8(self.ty);
+        dst.write_slice(&self.data);
+
+        Ok(())
+    }
+
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: Self::FIXED_PART_SIZE);
+
+        let length = usize::from(src.read_u8());
+        if length < Self::FIXED_PART_SIZE {
+            return Err(invalid_field_err!("subHeaderLength", "must be at least two bytes"));
+        }
+
+        ensure_size!(in: src, size: length - 1 /* subHeaderLength */);
+        let ty = src.read_u8();
+        let data = src.read_slice(length - Self::FIXED_PART_SIZE).to_vec();
+
+        Ok(Self { ty, data })
+    }
+}
+
+/// Action carried in an RDPEMT tunnel PDU header.
+///
+/// Defined in [\[MS-RDPEMT\] 2.2.1.1].
+///
+/// [\[MS-RDPEMT\] 2.2.1.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpemt/80d0849e-91a0-4fe7-83ad-ea9eaa7d15e9
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[repr(u8)]
+pub enum TunnelAction {
+    /// `RDP_TUNNEL_CREATEREQUEST`.
+    CreateRequest = 0x0,
+    /// `RDP_TUNNEL_CREATERESPONSE`.
+    CreateResponse = 0x1,
+    /// `RDP_TUNNEL_DATA`.
+    Data = 0x2,
+}
+
+impl TunnelAction {
+    fn from_u8(value: u8) -> Option<Self> {
+        match value {
+            0x0 => Some(Self::CreateRequest),
+            0x1 => Some(Self::CreateResponse),
+            0x2 => Some(Self::Data),
+            _ => None,
+        }
+    }
+
+    #[expect(
+        clippy::as_conversions,
+        reason = "repr(u8) guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
+    fn as_u8(self) -> u8 {
+        self as u8
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TunnelHeader {
+    action: TunnelAction,
+    subheaders: Vec<TunnelSubheader>,
+}
+
+impl TunnelHeader {
+    const FIXED_PART_SIZE: usize = 1 /* action and flags */ + 2 /* payloadLength */ + 1 /* headerLength */;
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.subheaders.iter().map(TunnelSubheader::size).sum::<usize>()
+    }
+
+    fn encode(&self, payload_length: usize, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        let payload_length: u16 = cast_length!("payloadLength", payload_length)?;
+        let header_length: u8 = cast_length!("headerLength", self.size())?;
+
+        dst.write_u8(self.action.as_u8());
+        dst.write_u16(payload_length);
+        dst.write_u8(header_length);
+        self.subheaders.iter().try_for_each(|subheader| subheader.encode(dst))
+    }
+
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<(Self, usize)> {
+        ensure_size!(in: src, size: Self::FIXED_PART_SIZE);
+
+        let action_and_flags = src.read_u8();
+        let flags = action_and_flags >> 4;
+        if flags != 0 {
+            return Err(invalid_field_err!("flags", "must be zero"));
+        }
+
+        let action = TunnelAction::from_u8(action_and_flags & 0x0F)
+            .ok_or_else(|| invalid_field_err!("action", "unknown tunnel action"))?;
+        let payload_length = usize::from(src.read_u16());
+        let header_length = usize::from(src.read_u8());
+        if header_length < Self::FIXED_PART_SIZE {
+            return Err(invalid_field_err!("headerLength", "must be at least four bytes"));
+        }
+
+        let subheader_length = header_length - Self::FIXED_PART_SIZE;
+        ensure_size!(in: src, size: subheader_length);
+        let mut subheaders_cursor = ReadCursor::new(src.read_slice(subheader_length));
+        let mut subheaders = Vec::new();
+        while !subheaders_cursor.is_empty() {
+            subheaders.push(TunnelSubheader::decode(&mut subheaders_cursor)?);
+        }
+
+        if src.len() != payload_length {
+            return Err(invalid_field_err!(
+                "payloadLength",
+                "does not match the bytes following the tunnel header"
+            ));
+        }
+
+        Ok((Self { action, subheaders }, payload_length))
+    }
+}
+
+/// Client request that binds an RDPEMT tunnel to the main RDP connection.
+///
+/// Defined in [\[MS-RDPEMT\] 2.2.2.1].
+///
+/// [\[MS-RDPEMT\] 2.2.2.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpemt/4cee15bd-2f65-4624-95d2-a3aa6c08d588
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct TunnelCreateRequestPdu {
+    /// Request ID from the Initiate Multitransport Request PDU.
+    pub request_id: u32,
+    /// Security cookie from the Initiate Multitransport Request PDU.
+    pub security_cookie: [u8; SECURITY_COOKIE_LEN],
+}
+
+impl TunnelCreateRequestPdu {
+    const PAYLOAD_SIZE: usize = 4 /* requestId */ + 4 /* reserved */ + SECURITY_COOKIE_LEN /* securityCookie */;
+    const NAME: &'static str = "TunnelCreateRequestPdu";
+
+    /// Builds a tunnel-create request.
+    pub fn new(request_id: u32, security_cookie: [u8; SECURITY_COOKIE_LEN]) -> Self {
+        Self {
+            request_id,
+            security_cookie,
+        }
+    }
+}
+
+impl Encode for TunnelCreateRequestPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        TunnelHeader {
+            action: TunnelAction::CreateRequest,
+            subheaders: Vec::new(),
+        }
+        .encode(Self::PAYLOAD_SIZE, dst)?;
+        dst.write_u32(self.request_id);
+        dst.write_u32(0);
+        dst.write_slice(&self.security_cookie);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        TunnelHeader {
+            action: TunnelAction::CreateRequest,
+            subheaders: Vec::new(),
+        }
+        .size()
+            + Self::PAYLOAD_SIZE
+    }
+}
+
+impl<'de> Decode<'de> for TunnelCreateRequestPdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        let (header, payload_length) = TunnelHeader::decode(src)?;
+        if header.action != TunnelAction::CreateRequest {
+            return Err(invalid_field_err!("action", "expected tunnel create request"));
+        }
+        if !header.subheaders.is_empty() {
+            return Err(invalid_field_err!(
+                "headerLength",
+                "must be four bytes for a tunnel create request"
+            ));
+        }
+        if payload_length != Self::PAYLOAD_SIZE {
+            return Err(invalid_field_err!(
+                "payloadLength",
+                "must be 24 bytes for a tunnel create request"
+            ));
+        }
+
+        let request_id = src.read_u32();
+        let reserved = src.read_u32();
+        if reserved != 0 {
+            return Err(invalid_field_err!("reserved", "must be zero"));
+        }
+        let security_cookie = src.read_array();
+
+        Ok(Self {
+            request_id,
+            security_cookie,
+        })
+    }
+}
+
+/// Server response to an RDPEMT tunnel-create request.
+///
+/// Defined in [\[MS-RDPEMT\] 2.2.2.2].
+///
+/// [\[MS-RDPEMT\] 2.2.2.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpemt/8676e0f6-b5f3-45fb-8c3e-18a9414ea98f
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct TunnelCreateResponsePdu {
+    /// HRESULT returned by the server.
+    pub hr_response: u32,
+}
+
+impl TunnelCreateResponsePdu {
+    const PAYLOAD_SIZE: usize = 4 /* hrResponse */;
+    const NAME: &'static str = "TunnelCreateResponsePdu";
+
+    /// `S_OK`.
+    pub const S_OK: u32 = 0;
+
+    /// Whether the server accepted the tunnel.
+    pub fn is_success(&self) -> bool {
+        self.hr_response == Self::S_OK
+    }
+}
+
+impl Encode for TunnelCreateResponsePdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        TunnelHeader {
+            action: TunnelAction::CreateResponse,
+            subheaders: Vec::new(),
+        }
+        .encode(Self::PAYLOAD_SIZE, dst)?;
+        dst.write_u32(self.hr_response);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        TunnelHeader {
+            action: TunnelAction::CreateResponse,
+            subheaders: Vec::new(),
+        }
+        .size()
+            + Self::PAYLOAD_SIZE
+    }
+}
+
+impl<'de> Decode<'de> for TunnelCreateResponsePdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        let (header, payload_length) = TunnelHeader::decode(src)?;
+        if header.action != TunnelAction::CreateResponse {
+            return Err(invalid_field_err!("action", "expected tunnel create response"));
+        }
+        if !header.subheaders.is_empty() {
+            return Err(invalid_field_err!(
+                "headerLength",
+                "must be four bytes for a tunnel create response"
+            ));
+        }
+        if payload_length != Self::PAYLOAD_SIZE {
+            return Err(invalid_field_err!(
+                "payloadLength",
+                "must be four bytes for a tunnel create response"
+            ));
+        }
+
+        Ok(Self {
+            hr_response: src.read_u32(),
+        })
+    }
+}
+
+/// Higher-layer data transported by an established RDPEMT tunnel.
+///
+/// Defined in [\[MS-RDPEMT\] 2.2.2.3].
+///
+/// [\[MS-RDPEMT\] 2.2.2.3]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpemt/0c9108e9-fa9f-4d44-a030-810e2902a2c6
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct TunnelDataPdu {
+    /// Optional autodetect subheaders.
+    pub subheaders: Vec<TunnelSubheader>,
+    /// Complete higher-layer message.
+    pub data: Vec<u8>,
+}
+
+impl TunnelDataPdu {
+    const NAME: &'static str = "TunnelDataPdu";
+
+    /// Builds a tunnel data PDU without optional subheaders.
+    pub fn new(data: Vec<u8>) -> Self {
+        Self {
+            subheaders: Vec::new(),
+            data,
+        }
+    }
+}
+
+impl Encode for TunnelDataPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        TunnelHeader {
+            action: TunnelAction::Data,
+            subheaders: self.subheaders.clone(),
+        }
+        .encode(self.data.len(), dst)?;
+        dst.write_slice(&self.data);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        TunnelHeader {
+            action: TunnelAction::Data,
+            subheaders: self.subheaders.clone(),
+        }
+        .size()
+            + self.data.len()
+    }
+}
+
+impl<'de> Decode<'de> for TunnelDataPdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        let (header, payload_length) = TunnelHeader::decode(src)?;
+        if header.action != TunnelAction::Data {
+            return Err(invalid_field_err!("action", "expected tunnel data"));
+        }
+
+        Ok(Self {
+            subheaders: header.subheaders,
+            data: src.read_slice(payload_length).to_vec(),
+        })
+    }
+}
+
+/// Any complete RDPEMT tunnel PDU.
+///
+/// Defined in [\[MS-RDPEMT\] 2.2.2].
+///
+/// [\[MS-RDPEMT\] 2.2.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpemt/9f9aefd5-c7dc-47d7-8767-1224a92f4e9f
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub enum TunnelPdu {
+    /// Client tunnel-create request.
+    CreateRequest(TunnelCreateRequestPdu),
+    /// Server tunnel-create response.
+    CreateResponse(TunnelCreateResponsePdu),
+    /// Higher-layer data.
+    Data(TunnelDataPdu),
+}
+
+impl Encode for TunnelPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        match self {
+            Self::CreateRequest(pdu) => pdu.encode(dst),
+            Self::CreateResponse(pdu) => pdu.encode(dst),
+            Self::Data(pdu) => pdu.encode(dst),
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        match self {
+            Self::CreateRequest(pdu) => pdu.name(),
+            Self::CreateResponse(pdu) => pdu.name(),
+            Self::Data(pdu) => pdu.name(),
+        }
+    }
+
+    fn size(&self) -> usize {
+        match self {
+            Self::CreateRequest(pdu) => pdu.size(),
+            Self::CreateResponse(pdu) => pdu.size(),
+            Self::Data(pdu) => pdu.size(),
+        }
+    }
+}
+
+impl<'de> Decode<'de> for TunnelPdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: TunnelHeader::FIXED_PART_SIZE);
+        let action = TunnelAction::from_u8(src.remaining()[0] & 0x0F)
+            .ok_or_else(|| invalid_field_err!("action", "unknown tunnel action"))?;
+
+        match action {
+            TunnelAction::CreateRequest => TunnelCreateRequestPdu::decode(src).map(Self::CreateRequest),
+            TunnelAction::CreateResponse => TunnelCreateResponsePdu::decode(src).map(Self::CreateResponse),
+            TunnelAction::Data => TunnelDataPdu::decode(src).map(Self::Data),
+        }
+    }
+}
 
 /// Requested transport protocol for multitransport bootstrapping.
 ///
@@ -459,5 +890,85 @@ mod tests {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ];
         assert!(ironrdp_core::decode::<MultitransportRequestPdu>(bad_wire).is_err());
+    }
+
+    #[test]
+    fn tunnel_create_request_round_trip() {
+        let pdu = TunnelCreateRequestPdu::new(7, [0xAB; SECURITY_COOKIE_LEN]);
+        let encoded = ironrdp_core::encode_vec(&pdu).unwrap();
+        assert_eq!(
+            encoded.as_slice(),
+            &[
+                0x00, // action = create request, flags = 0
+                0x18, 0x00, // payloadLength = 24
+                0x04, // headerLength = 4
+                0x07, 0x00, 0x00, 0x00, // requestId
+                0x00, 0x00, 0x00, 0x00, // reserved
+                0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, // securityCookie
+                0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB,
+            ]
+        );
+        let decoded = ironrdp_core::decode::<TunnelCreateRequestPdu>(&encoded).unwrap();
+        assert_eq!(decoded, pdu);
+    }
+
+    #[test]
+    fn tunnel_create_pdus_reject_subheaders() {
+        let request = [
+            0x00, // action = create request, flags = 0
+            0x18, 0x00, // payloadLength = 24
+            0x06, // headerLength = 6
+            0x02, 0x01, // subheader
+            0x07, 0x00, 0x00, 0x00, // requestId
+            0x00, 0x00, 0x00, 0x00, // reserved
+            0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, // securityCookie
+            0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB,
+        ];
+        assert!(ironrdp_core::decode::<TunnelCreateRequestPdu>(&request).is_err());
+
+        let response = [
+            0x01, // action = create response, flags = 0
+            0x04, 0x00, // payloadLength = 4
+            0x06, // headerLength = 6
+            0x02, 0x01, // subheader
+            0x00, 0x00, 0x00, 0x00, // hrResponse
+        ];
+        assert!(ironrdp_core::decode::<TunnelCreateResponsePdu>(&response).is_err());
+    }
+
+    #[test]
+    fn tunnel_pdu_preserves_subheaders_and_data() {
+        let pdu = TunnelPdu::Data(TunnelDataPdu {
+            subheaders: vec![TunnelSubheader {
+                ty: 1,
+                data: vec![0xAA, 0xBB],
+            }],
+            data: vec![1, 2, 3],
+        });
+        let encoded = ironrdp_core::encode_vec(&pdu).unwrap();
+        assert_eq!(
+            encoded.as_slice(),
+            &[
+                0x02, // action = data, flags = 0
+                0x03, 0x00, // payloadLength = 3
+                0x08, // headerLength = 8
+                0x04, 0x01, 0xAA, 0xBB, // subheader
+                0x01, 0x02, 0x03, // higher-layer data
+            ]
+        );
+        let decoded = ironrdp_core::decode::<TunnelPdu>(&encoded).unwrap();
+        assert_eq!(decoded, pdu);
+    }
+
+    #[test]
+    fn tunnel_header_rejects_invalid_lengths_and_flags() {
+        let invalid_header_length = [0x02, 0x00, 0x00, 0x03];
+        assert!(ironrdp_core::decode::<TunnelDataPdu>(&invalid_header_length).is_err());
+
+        let invalid_flags = [0x12, 0x00, 0x00, 0x04];
+        assert!(ironrdp_core::decode::<TunnelDataPdu>(&invalid_flags).is_err());
+
+        let invalid_payload_length = [0x02, 0x01, 0x00, 0x04];
+        assert!(ironrdp_core::decode::<TunnelDataPdu>(&invalid_payload_length).is_err());
     }
 }

--- a/crates/ironrdp-pdu/src/rdp/udp.rs
+++ b/crates/ironrdp-pdu/src/rdp/udp.rs
@@ -1,0 +1,386 @@
+//! RDP-UDP reliable transport wire structures.
+//!
+//! The transport state machine lives outside this crate. These types encode the
+//! common header, connection-initialization, acknowledgement, and source-data
+//! structures used by reliable RDP-UDP versions 1 and 2.
+//!
+//! Defined in [\[MS-RDPEUDP\] 2.2.2.1, 2.2.2.4-2.2.2.7].
+//!
+//! [\[MS-RDPEUDP\] 2.2.2.1, 2.2.2.4-2.2.2.7]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/2b8a6f10-cf3a-49f6-b989-51de4d2f99e6
+
+use bitflags::bitflags;
+use ironrdp_core::{
+    Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, cast_length, ensure_fixed_part_size,
+    ensure_size, invalid_field_err,
+};
+
+/// Minimum MTU accepted during reliable RDP-UDP negotiation.
+pub const MIN_MTU: u16 = 1132;
+/// Maximum MTU accepted during reliable RDP-UDP negotiation.
+pub const MAX_MTU: u16 = 1232;
+/// Maximum encoded ACK vector size.
+pub const MAX_ACK_VECTOR_SIZE: usize = 2048;
+
+bitflags! {
+    /// Flags in an [`RdpUdpFecHeader`].
+    ///
+    /// Defined in [\[MS-RDPEUDP\] 2.2.2.1].
+    ///
+    /// [\[MS-RDPEUDP\] 2.2.2.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/2b8a6f10-cf3a-49f6-b989-51de4d2f99e6
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+    pub struct RdpUdpFlags: u16 {
+        /// Connection initialization.
+        const SYN = 0x0001;
+        /// Connection termination; currently unused by the protocol.
+        const FIN = 0x0002;
+        /// An ACK vector follows the common header.
+        const ACK = 0x0004;
+        /// A data payload follows the ACK structures.
+        const DATA = 0x0008;
+        /// The data payload is FEC encoded and follows an FEC payload header.
+        const FEC = 0x0010;
+        /// Congestion notification.
+        const CN = 0x0020;
+        /// Congestion-window reset.
+        const CWR = 0x0040;
+        /// ACK-of-ACK vector follows the ACK vector.
+        const ACK_OF_ACKS = 0x0100;
+        /// Requests lossy transport; this is unsupported by the reliable-only engine.
+        const SYN_LOSSY = 0x0200;
+        /// Indicates delayed acknowledgement.
+        const ACK_DELAYED = 0x0400;
+        /// A correlation ID follows SYN data.
+        const CORRELATION_ID = 0x0800;
+        /// Extended SYN data follows SYN data.
+        const SYN_EX = 0x1000;
+    }
+}
+
+/// Common RDP-UDP datagram header.
+///
+/// All fields are transmitted in network byte order.
+///
+/// Defined in [\[MS-RDPEUDP\] 2.2.2.1].
+///
+/// [\[MS-RDPEUDP\] 2.2.2.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/2b8a6f10-cf3a-49f6-b989-51de4d2f99e6
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RdpUdpFecHeader {
+    /// Highest source sequence number observed from the peer.
+    pub source_ack: u32,
+    /// Peer-facing receive window in datagrams.
+    pub receive_window_size: u16,
+    /// Present optional structures and connection flags.
+    pub flags: RdpUdpFlags,
+}
+
+impl RdpUdpFecHeader {
+    const FIXED_PART_SIZE: usize = 4 /* snSourceAck */ + 2 /* uReceiveWindowSize */ + 2 /* uFlags */;
+    const NAME: &'static str = "RdpUdpFecHeader";
+}
+
+impl Encode for RdpUdpFecHeader {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_fixed_part_size!(in: dst);
+        dst.write_u32_be(self.source_ack);
+        dst.write_u16_be(self.receive_window_size);
+        dst.write_u16_be(self.flags.bits());
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl<'de> Decode<'de> for RdpUdpFecHeader {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+        let source_ack = src.read_u32_be();
+        let receive_window_size = src.read_u16_be();
+        let flags = RdpUdpFlags::from_bits(src.read_u16_be())
+            .ok_or_else(|| invalid_field_err!("uFlags", "contains reserved bits"))?;
+
+        Ok(Self {
+            source_ack,
+            receive_window_size,
+            flags,
+        })
+    }
+}
+
+/// Parameters exchanged during the RDP-UDP SYN handshake.
+///
+/// Defined in [\[MS-RDPEUDP\] 2.2.2.5].
+///
+/// [\[MS-RDPEUDP\] 2.2.2.5]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/da754206-a6d0-4a5b-9ef7-4a8e5352701f
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RdpUdpSynData {
+    /// First coded and source sequence number used by the sender.
+    pub initial_sequence_number: u32,
+    /// Largest source payload the sender can transmit.
+    pub upstream_mtu: u16,
+    /// Largest source payload the sender can receive.
+    pub downstream_mtu: u16,
+}
+
+impl RdpUdpSynData {
+    const FIXED_PART_SIZE: usize = 4 /* snInitialSequenceNumber */ + 2 /* uUpStreamMtu */ + 2 /* uDownStreamMtu */;
+    const NAME: &'static str = "RdpUdpSynData";
+
+    fn has_valid_mtu(mtu: u16) -> bool {
+        (MIN_MTU..=MAX_MTU).contains(&mtu)
+    }
+}
+
+impl Encode for RdpUdpSynData {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        if !Self::has_valid_mtu(self.upstream_mtu) {
+            return Err(invalid_field_err!(
+                "uUpStreamMtu",
+                "must be between 1132 and 1232 bytes"
+            ));
+        }
+        if !Self::has_valid_mtu(self.downstream_mtu) {
+            return Err(invalid_field_err!(
+                "uDownStreamMtu",
+                "must be between 1132 and 1232 bytes"
+            ));
+        }
+        ensure_fixed_part_size!(in: dst);
+        dst.write_u32_be(self.initial_sequence_number);
+        dst.write_u16_be(self.upstream_mtu);
+        dst.write_u16_be(self.downstream_mtu);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl<'de> Decode<'de> for RdpUdpSynData {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+        let initial_sequence_number = src.read_u32_be();
+        let upstream_mtu = src.read_u16_be();
+        let downstream_mtu = src.read_u16_be();
+        if !Self::has_valid_mtu(upstream_mtu) {
+            return Err(invalid_field_err!(
+                "uUpStreamMtu",
+                "must be between 1132 and 1232 bytes"
+            ));
+        }
+        if !Self::has_valid_mtu(downstream_mtu) {
+            return Err(invalid_field_err!(
+                "uDownStreamMtu",
+                "must be between 1132 and 1232 bytes"
+            ));
+        }
+
+        Ok(Self {
+            initial_sequence_number,
+            upstream_mtu,
+            downstream_mtu,
+        })
+    }
+}
+
+/// RDP-UDP protocol version advertised in extended SYN data.
+///
+/// Defined in [\[MS-RDPEUDP\] 2.2.2.9].
+///
+/// [\[MS-RDPEUDP\] 2.2.2.9]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/2399ce13-049d-4c02-bd3c-9226b38d14f2
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[repr(u16)]
+pub enum RdpUdpProtocolVersion {
+    /// Legacy reliable RDP-UDP with 500 ms minimum retransmission timeout.
+    V1 = 0x0001,
+    /// Legacy reliable RDP-UDP with 300 ms minimum retransmission timeout.
+    V2 = 0x0002,
+    /// RDP-UDP2 transfer after RDP-UDP initialization.
+    V3 = 0x0101,
+}
+
+impl RdpUdpProtocolVersion {
+    /// Converts a protocol-version integer received on the wire.
+    pub fn from_u16(value: u16) -> Option<Self> {
+        match value {
+            0x0001 => Some(Self::V1),
+            0x0002 => Some(Self::V2),
+            0x0101 => Some(Self::V3),
+            _ => None,
+        }
+    }
+
+    #[expect(
+        clippy::as_conversions,
+        reason = "repr(u16) guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
+    /// Converts this version to its wire representation.
+    pub fn as_u16(self) -> u16 {
+        self as u16
+    }
+}
+
+/// RDP-UDP ACK vector with DWORD alignment padding.
+///
+/// Defined in [\[MS-RDPEUDP\] 2.2.2.7].
+///
+/// [\[MS-RDPEUDP\] 2.2.2.7]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/16ff7b1e-f60b-4369-b5de-d49eff260f05
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RdpUdpAckVector {
+    /// Run-length encoded ACK-vector elements.
+    pub encoded: Vec<u8>,
+}
+
+impl RdpUdpAckVector {
+    const FIXED_PART_SIZE: usize = 2 /* uAckVectorSize */;
+    const NAME: &'static str = "RdpUdpAckVector";
+
+    fn padding_size(encoded_len: usize) -> usize {
+        (4 - ((Self::FIXED_PART_SIZE + encoded_len) % 4)) % 4
+    }
+}
+
+impl Encode for RdpUdpAckVector {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        if self.encoded.len() > MAX_ACK_VECTOR_SIZE {
+            return Err(invalid_field_err!("uAckVectorSize", "must not exceed 2048 bytes"));
+        }
+
+        let encoded_len: u16 = cast_length!("uAckVectorSize", self.encoded.len())?;
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u16_be(encoded_len);
+        dst.write_slice(&self.encoded);
+        dst.write_slice(&[0; 3][..Self::padding_size(self.encoded.len())]);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.encoded.len() + Self::padding_size(self.encoded.len())
+    }
+}
+
+impl<'de> Decode<'de> for RdpUdpAckVector {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: Self::FIXED_PART_SIZE);
+        let encoded_len = usize::from(src.read_u16_be());
+        if encoded_len > MAX_ACK_VECTOR_SIZE {
+            return Err(invalid_field_err!("uAckVectorSize", "must not exceed 2048 bytes"));
+        }
+
+        let padding_size = Self::padding_size(encoded_len);
+        ensure_size!(in: src, size: encoded_len + padding_size);
+        let encoded = src.read_slice(encoded_len).to_vec();
+        if src.read_slice(padding_size).iter().any(|&byte| byte != 0) {
+            return Err(invalid_field_err!("padding", "must be zero"));
+        }
+
+        Ok(Self { encoded })
+    }
+}
+
+/// Header and bytes of a reliable RDP-UDP source payload.
+///
+/// Defined in [\[MS-RDPEUDP\] 2.2.2.4].
+///
+/// [\[MS-RDPEUDP\] 2.2.2.4]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/916af634-f96b-4dcc-bfdf-5646d5dc7f7d
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RdpUdpSourcePayload {
+    /// Sequence number of this transmitted datagram.
+    pub coded_sequence_number: u32,
+    /// Sequence number of the encapsulated source payload.
+    pub source_sequence_number: u32,
+    /// Bytes delivered to the upper transport layer.
+    pub data: Vec<u8>,
+}
+
+impl RdpUdpSourcePayload {
+    const FIXED_PART_SIZE: usize = 4 /* snCoded */ + 4 /* snSourceStart */;
+    const NAME: &'static str = "RdpUdpSourcePayload";
+}
+
+impl Encode for RdpUdpSourcePayload {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u32_be(self.coded_sequence_number);
+        dst.write_u32_be(self.source_sequence_number);
+        dst.write_slice(&self.data);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.data.len()
+    }
+}
+
+impl<'de> Decode<'de> for RdpUdpSourcePayload {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+        let coded_sequence_number = src.read_u32_be();
+        let source_sequence_number = src.read_u32_be();
+        let data = src.read_remaining().to_vec();
+
+        Ok(Self {
+            coded_sequence_number,
+            source_sequence_number,
+            data,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn syn_packet_fields_use_network_byte_order() {
+        let header = RdpUdpFecHeader {
+            source_ack: 0xFFFF_FFFF,
+            receive_window_size: 1024,
+            flags: RdpUdpFlags::SYN | RdpUdpFlags::SYN_EX,
+        };
+        let encoded = ironrdp_core::encode_vec(&header).unwrap();
+        assert_eq!(encoded.as_slice(), &[0xFF, 0xFF, 0xFF, 0xFF, 0x04, 0x00, 0x10, 0x01]);
+        assert_eq!(ironrdp_core::decode::<RdpUdpFecHeader>(&encoded).unwrap(), header);
+    }
+
+    #[test]
+    fn ack_vector_round_trip_and_padding() {
+        let vector = RdpUdpAckVector { encoded: vec![0x04] };
+        let encoded = ironrdp_core::encode_vec(&vector).unwrap();
+        assert_eq!(encoded.as_slice(), &[0x00, 0x01, 0x04, 0x00]);
+        assert_eq!(ironrdp_core::decode::<RdpUdpAckVector>(&encoded).unwrap(), vector);
+    }
+
+    #[test]
+    fn rejects_invalid_mtu_and_ack_vector_size() {
+        let invalid_mtu = [0, 0, 0, 1, 0x04, 0x6B, 0x04, 0xD0];
+        assert!(ironrdp_core::decode::<RdpUdpSynData>(&invalid_mtu).is_err());
+
+        let invalid_ack_size = [0x08, 0x01];
+        assert!(ironrdp_core::decode::<RdpUdpAckVector>(&invalid_ack_size).is_err());
+    }
+}

--- a/crates/ironrdp-testsuite-core/tests/dvc/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/dvc/mod.rs
@@ -4,6 +4,7 @@ use ironrdp_core::{Decode, Encode, ReadCursor, WriteCursor};
 use ironrdp_dvc::pdu::{
     CapabilitiesRequestPdu, CapabilitiesResponsePdu, CapsVersion, ClosePdu, CreateRequestPdu, CreateResponsePdu,
     CreationStatus, DataFirstPdu, DataPdu, DrdynvcClientPdu, DrdynvcDataPdu, DrdynvcServerPdu, FieldType,
+    SoftSyncChannelList, SoftSyncRequestPdu, SoftSyncResponsePdu, SoftSyncTunnelType,
 };
 
 // TODO: This likely generalizes to many tests and can thus be reused outside of this module.
@@ -25,3 +26,4 @@ mod close;
 mod create;
 mod data;
 mod data_first;
+mod soft_sync;

--- a/crates/ironrdp-testsuite-core/tests/dvc/soft_sync.rs
+++ b/crates/ironrdp-testsuite-core/tests/dvc/soft_sync.rs
@@ -1,0 +1,69 @@
+use super::*;
+
+const CHANNEL_ID: u32 = 0x0303;
+const REQUEST_ENCODED: [u8; 20] = [
+    0x80, 0x00, 0x12, 0x00, 0x00, 0x00, 0x03, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x03, 0x03, 0x00,
+    0x00,
+];
+const RESPONSE_ENCODED: [u8; 10] = [0x90, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00];
+
+fn request() -> SoftSyncRequestPdu {
+    SoftSyncRequestPdu::new(vec![SoftSyncChannelList::new(
+        SoftSyncTunnelType::ReliableUdp,
+        vec![CHANNEL_ID],
+    )])
+}
+
+fn response() -> SoftSyncResponsePdu {
+    SoftSyncResponsePdu::new(vec![SoftSyncTunnelType::ReliableUdp])
+}
+
+#[test]
+fn encodes_soft_sync_request() {
+    test_encodes(&DrdynvcServerPdu::SoftSyncRequest(request()), &REQUEST_ENCODED);
+}
+
+#[test]
+fn decodes_soft_sync_request() {
+    test_decodes(&REQUEST_ENCODED, &DrdynvcServerPdu::SoftSyncRequest(request()));
+}
+
+#[test]
+fn encodes_soft_sync_response() {
+    test_encodes(&DrdynvcClientPdu::SoftSyncResponse(response()), &RESPONSE_ENCODED);
+}
+
+#[test]
+fn decodes_soft_sync_response() {
+    test_decodes(&RESPONSE_ENCODED, &DrdynvcClientPdu::SoftSyncResponse(response()));
+}
+
+#[test]
+fn rejects_soft_sync_request_with_mismatched_length() {
+    let mut request = REQUEST_ENCODED;
+    request[2] = 0x11;
+
+    let mut src = ReadCursor::new(&request);
+    assert!(DrdynvcServerPdu::decode(&mut src).is_err());
+}
+
+#[test]
+fn rejects_soft_sync_request_with_duplicate_channel_id() {
+    let request = [
+        0x80, 0x00, 0x1C, 0x00, 0x00, 0x00, 0x03, 0x00, 0x02, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x03, 0x03,
+        0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x01, 0x00, 0x03, 0x03, 0x00, 0x00,
+    ];
+
+    let mut src = ReadCursor::new(&request);
+    assert!(DrdynvcServerPdu::decode(&mut src).is_err());
+}
+
+#[test]
+fn rejects_soft_sync_response_with_duplicate_tunnel_type() {
+    let response = [
+        0x90, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+    ];
+
+    let mut src = ReadCursor::new(&response);
+    assert!(DrdynvcClientPdu::decode(&mut src).is_err());
+}

--- a/crates/ironrdp-testsuite-core/tests/pdu/x224.rs
+++ b/crates/ironrdp-testsuite-core/tests/pdu/x224.rs
@@ -1,8 +1,8 @@
 use expect_test::expect;
 use ironrdp_core::{ReadCursor, WriteCursor};
 use ironrdp_pdu::nego::{
-    ConnectionConfirm, ConnectionRequest, Cookie, FailureCode, NegoRequestData, RequestFlags, ResponseFlags,
-    RoutingToken, SecurityProtocol,
+    ConnectionConfirm, ConnectionRequest, Cookie, CorrelationInfo, FailureCode, NegoRequestData, RequestFlags,
+    ResponseFlags, RoutingToken, SecurityProtocol,
 };
 use ironrdp_pdu::tpdu::{TpduCode, TpduHeader};
 use ironrdp_pdu::tpkt::TpktHeader;
@@ -79,6 +79,7 @@ encode_decode_test! {
             nego_data: None,
             flags: RequestFlags::empty(),
             protocol: SecurityProtocol::empty(),
+            correlation_info: None,
         }),
         [
             // tpkt header
@@ -100,6 +101,7 @@ encode_decode_test! {
             nego_data: Some(NegoRequestData::Cookie(Cookie("User".to_owned()))),
             flags: RequestFlags::empty(),
             protocol: SecurityProtocol::empty(),
+            correlation_info: None,
         }),
         [
             // tpkt header
@@ -123,6 +125,7 @@ encode_decode_test! {
             nego_data: Some(NegoRequestData::Cookie(Cookie("User".to_owned()))),
             flags: RequestFlags::empty(),
             protocol: SecurityProtocol::HYBRID | SecurityProtocol::SSL,
+            correlation_info: None,
         }),
         [
             // tpkt header
@@ -146,6 +149,7 @@ encode_decode_test! {
             nego_data: Some(NegoRequestData::Cookie(Cookie("User".to_owned()))),
             flags: RequestFlags::RESTRICTED_ADMIN_MODE_REQUIRED | RequestFlags::REDIRECTED_AUTHENTICATION_MODE_REQUIRED,
             protocol: SecurityProtocol::HYBRID | SecurityProtocol::SSL,
+            correlation_info: None,
         }),
         [
             // tpkt header
@@ -166,6 +170,30 @@ encode_decode_test! {
             0x03, // flags
             0x08, 0x00, // length
             0x03, 0x00, 0x00, 0x00, // request message
+        ];
+
+    nego_connection_request_with_correlation_info:
+        X224(ConnectionRequest {
+            nego_data: None,
+            flags: RequestFlags::CORRELATION_INFO_PRESENT,
+            protocol: SecurityProtocol::SSL,
+            correlation_info: Some(CorrelationInfo {
+                correlation_id: [0x01; 16],
+            }),
+        }),
+        [
+            // tpkt header
+            0x03, 0x00, 0x00, 0x37,
+            // tpdu header
+            0x32, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00,
+            // RDP_NEG_REQ
+            0x01, 0x08, 0x08, 0x00, 0x01, 0x00, 0x00, 0x00,
+            // RDP_NEG_CORRELATION_INFO
+            0x06, 0x00, 0x24, 0x00,
+            0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+            0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ];
 
     nego_confirm_response:
@@ -212,6 +240,39 @@ encode_decode_test! {
             0x08, 0x00, // length
             0x06, 0x00, 0x00, 0x00, // failure code
         ];
+}
+
+#[test]
+fn nego_connection_request_rejects_invalid_correlation_info() {
+    let valid = ironrdp_core::encode_vec(&X224(ConnectionRequest {
+        nego_data: None,
+        flags: RequestFlags::CORRELATION_INFO_PRESENT,
+        protocol: SecurityProtocol::SSL,
+        correlation_info: Some(CorrelationInfo {
+            correlation_id: [0x01; 16],
+        }),
+    }))
+    .unwrap();
+
+    // TPKT (4 bytes) + X.224 connection request header (7 bytes) +
+    // RDP_NEG_REQ (8 bytes).
+    const CORRELATION_INFO_OFFSET: usize = 19;
+
+    let mut invalid_type = valid.clone();
+    invalid_type[CORRELATION_INFO_OFFSET] = 0x05;
+    assert!(ironrdp_core::decode::<X224<ConnectionRequest>>(&invalid_type).is_err());
+
+    let mut invalid_flags = valid.clone();
+    invalid_flags[CORRELATION_INFO_OFFSET + 1] = 0x01;
+    assert!(ironrdp_core::decode::<X224<ConnectionRequest>>(&invalid_flags).is_err());
+
+    let mut invalid_length = valid.clone();
+    invalid_length[CORRELATION_INFO_OFFSET + 2] = 0x23;
+    assert!(ironrdp_core::decode::<X224<ConnectionRequest>>(&invalid_length).is_err());
+
+    let mut invalid_reserved = valid;
+    invalid_reserved[CORRELATION_INFO_OFFSET + 20] = 0x01;
+    assert!(ironrdp_core::decode::<X224<ConnectionRequest>>(&invalid_reserved).is_err());
 }
 
 #[test]

--- a/crates/ironrdp-testsuite-core/tests/server/acceptor.rs
+++ b/crates/ironrdp-testsuite-core/tests/server/acceptor.rs
@@ -13,6 +13,7 @@ fn encode_connection_request(protocol: SecurityProtocol) -> Vec<u8> {
         nego_data: None,
         flags: nego::RequestFlags::empty(),
         protocol,
+        correlation_info: None,
     };
     let mut buf = WriteBuf::new();
     ironrdp_core::encode_buf(&X224(request), &mut buf).unwrap();


### PR DESCRIPTION
Add RDP-UDP and RDPEMT wire codecs, strict X.224 correlation-info handling, and DVC Soft-Sync dispatch.

Keep runtime transport and connection bootstrap out of this foundation.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>