### PR TITLE
feat(pdu): support connection correlation info

### DIFF
--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -344,6 +344,7 @@ impl ClientConnector {
             }),
             flags: nego::RequestFlags::empty(),
             protocol: security_protocol,
+            correlation_info: None,
         };
 
         debug!(message = ?connection_request, "Send");

--- a/crates/ironrdp-pdu/src/nego.rs
+++ b/crates/ironrdp-pdu/src/nego.rs
@@ -266,12 +266,76 @@ pub struct ConnectionRequest {
     pub nego_data: Option<NegoRequestData>,
     pub flags: RequestFlags,
     pub protocol: SecurityProtocol,
+    /// Optional X.224 connection correlation information.
+    pub correlation_info: Option<CorrelationInfo>,
 }
 
 impl_x224_pdu_pod!(ConnectionRequest);
 
 impl ConnectionRequest {
     const RDP_NEG_REQ_SIZE: u16 = 8;
+}
+
+/// Connection correlation information carried after an RDP negotiation request.
+///
+/// Defined in [\[MS-RDPBCGR\] 2.2.1.1.2].
+///
+/// [\[MS-RDPBCGR\] 2.2.1.1.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/981b2aa8-2aa3-4bfb-8ac8-fc8efad2c0cd
+#[derive(Clone, PartialEq, Eq)]
+pub struct CorrelationInfo {
+    /// The client-selected connection correlation identifier.
+    pub correlation_id: [u8; 16],
+}
+
+impl fmt::Debug for CorrelationInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CorrelationInfo")
+            .field("correlation_id", &"<redacted>")
+            .finish()
+    }
+}
+
+impl CorrelationInfo {
+    const TYPE: u8 = 0x06;
+    const FLAGS: u8 = 0;
+    const SIZE: u16 = 36;
+    const RESERVED_SIZE: usize = 16;
+
+    fn write(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: usize::from(Self::SIZE));
+        dst.write_u8(Self::TYPE);
+        dst.write_u8(Self::FLAGS);
+        dst.write_u16(Self::SIZE);
+        dst.write_slice(&self.correlation_id);
+        dst.write_slice(&[0; Self::RESERVED_SIZE]);
+        Ok(())
+    }
+
+    fn read(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: usize::from(Self::SIZE));
+        let message_type = src.read_u8();
+        let flags = src.read_u8();
+        let length = src.read_u16();
+        if message_type != Self::TYPE || flags != Self::FLAGS || length != Self::SIZE {
+            return Err(invalid_field_err!(
+                "RDP_NEG_CORRELATION_INFO",
+                "header",
+                "contains invalid type, flags, or length"
+            ));
+        }
+
+        let mut correlation_id = [0; 16];
+        correlation_id.copy_from_slice(src.read_slice(16));
+        if src.read_slice(Self::RESERVED_SIZE).iter().any(|&byte| byte != 0) {
+            return Err(invalid_field_err!(
+                "RDP_NEG_CORRELATION_INFO",
+                "reserved",
+                "must be zero"
+            ));
+        }
+
+        Ok(Self { correlation_id })
+    }
 }
 
 impl<'de> X224Pdu<'de> for ConnectionRequest {
@@ -291,13 +355,26 @@ impl<'de> X224Pdu<'de> for ConnectionRequest {
         dst.write_u16(Self::RDP_NEG_REQ_SIZE);
         dst.write_u32(self.protocol.bits());
 
-        if self.flags.contains(RequestFlags::CORRELATION_INFO_PRESENT) {
-            // TODO(#111): support for RDP_NEG_CORRELATION_INFO
-            return Err(invalid_field_err(
-                Self::NAME,
-                "flags",
-                "CORRECTION_INFO_PRESENT flag is set, but not supported by IronRDP",
-            ));
+        match (
+            self.flags.contains(RequestFlags::CORRELATION_INFO_PRESENT),
+            self.correlation_info.as_ref(),
+        ) {
+            (true, Some(correlation_info)) => correlation_info.write(dst)?,
+            (true, None) => {
+                return Err(invalid_field_err!(
+                    Self::NAME,
+                    "flags",
+                    "CORRELATION_INFO_PRESENT requires correlation information"
+                ));
+            }
+            (false, Some(_)) => {
+                return Err(invalid_field_err!(
+                    Self::NAME,
+                    "correlation_info",
+                    "requires CORRELATION_INFO_PRESENT"
+                ));
+            }
+            (false, None) => {}
         }
 
         Ok(())
@@ -328,37 +405,56 @@ impl<'de> X224Pdu<'de> for ConnectionRequest {
             }
 
             let flags = RequestFlags::from_bits_retain(src.read_u8());
-
-            if flags.contains(RequestFlags::CORRELATION_INFO_PRESENT) {
-                // TODO(#111): support for RDP_NEG_CORRELATION_INFO
-                return Err(invalid_field_err(
-                    Self::NAME,
-                    "flags",
-                    "CORRECTION_INFO_PRESENT flag is set, but not supported by IronRDP",
-                ));
+            let length = src.read_u16();
+            if length != Self::RDP_NEG_REQ_SIZE {
+                return Err(invalid_field_err!(Self::NAME, "length", "must be eight bytes"));
             }
 
-            let _length = src.read_u16();
-
             let protocol = SecurityProtocol::from_bits_retain(src.read_u32());
+            let correlation_info = if flags.contains(RequestFlags::CORRELATION_INFO_PRESENT) {
+                if variable_part_rest_size != usize::from(Self::RDP_NEG_REQ_SIZE + CorrelationInfo::SIZE) {
+                    return Err(invalid_field_err!(
+                        Self::NAME,
+                        "TPDU header variable part",
+                        "has invalid correlation information length"
+                    ));
+                }
+                Some(CorrelationInfo::read(src)?)
+            } else {
+                if variable_part_rest_size != usize::from(Self::RDP_NEG_REQ_SIZE) {
+                    return Err(invalid_field_err!(
+                        Self::NAME,
+                        "TPDU header variable part",
+                        "has unexpected trailing data"
+                    ));
+                }
+                None
+            };
 
             Ok(Self {
                 nego_data,
                 flags,
                 protocol,
+                correlation_info,
             })
         } else {
             Ok(Self {
                 nego_data,
                 flags: RequestFlags::empty(),
                 protocol: SecurityProtocol::empty(),
+                correlation_info: None,
             })
         }
     }
 
     fn tpdu_header_variable_part_size(&self) -> usize {
         let optional_nego_data_size = self.nego_data.as_ref().map(|data| data.size()).unwrap_or(0);
-        optional_nego_data_size + usize::from(Self::RDP_NEG_REQ_SIZE)
+        optional_nego_data_size
+            + usize::from(Self::RDP_NEG_REQ_SIZE)
+            + self
+                .correlation_info
+                .as_ref()
+                .map_or(0, |_| usize::from(CorrelationInfo::SIZE))
     }
 
     fn tpdu_user_data_size(&self) -> usize {

--- a/crates/ironrdp-pdu/src/nego.rs
+++ b/crates/ironrdp-pdu/src/nego.rs
@@ -281,18 +281,13 @@ impl ConnectionRequest {
 /// Defined in [\[MS-RDPBCGR\] 2.2.1.1.2].
 ///
 /// [\[MS-RDPBCGR\] 2.2.1.1.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/981b2aa8-2aa3-4bfb-8ac8-fc8efad2c0cd
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CorrelationInfo {
     /// The client-selected connection correlation identifier.
+    ///
+    /// The first byte should not be `0x00` or `0xF4`, and no byte should
+    /// be `0x0D`.
     pub correlation_id: [u8; 16],
-}
-
-impl fmt::Debug for CorrelationInfo {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("CorrelationInfo")
-            .field("correlation_id", &"<redacted>")
-            .finish()
-    }
 }
 
 impl CorrelationInfo {
@@ -351,30 +346,14 @@ impl<'de> X224Pdu<'de> for ConnectionRequest {
         // [MS-RDPBCGR] mentions the following payload as optional, but it appears that on recent
         // versions of Windows, the server always expect to find this payload.
         dst.write_u8(u8::from(NegoMsgType::REQUEST));
-        dst.write_u8(self.flags.bits());
+        let mut flags = self.flags;
+        flags.set(RequestFlags::CORRELATION_INFO_PRESENT, self.correlation_info.is_some());
+        dst.write_u8(flags.bits());
         dst.write_u16(Self::RDP_NEG_REQ_SIZE);
         dst.write_u32(self.protocol.bits());
 
-        match (
-            self.flags.contains(RequestFlags::CORRELATION_INFO_PRESENT),
-            self.correlation_info.as_ref(),
-        ) {
-            (true, Some(correlation_info)) => correlation_info.write(dst)?,
-            (true, None) => {
-                return Err(invalid_field_err!(
-                    Self::NAME,
-                    "flags",
-                    "CORRELATION_INFO_PRESENT requires correlation information"
-                ));
-            }
-            (false, Some(_)) => {
-                return Err(invalid_field_err!(
-                    Self::NAME,
-                    "correlation_info",
-                    "requires CORRELATION_INFO_PRESENT"
-                ));
-            }
-            (false, None) => {}
+        if let Some(correlation_info) = &self.correlation_info {
+            correlation_info.write(dst)?;
         }
 
         Ok(())

--- a/crates/ironrdp-pdu/src/nego.rs
+++ b/crates/ironrdp-pdu/src/nego.rs
@@ -397,6 +397,14 @@ impl<'de> X224Pdu<'de> for ConnectionRequest {
             ));
         };
 
+        if variable_part_rest_size > 0 && variable_part_rest_size < usize::from(Self::RDP_NEG_REQ_SIZE) {
+            return Err(invalid_field_err!(
+                Self::NAME,
+                "TPDU header variable part",
+                "has a truncated negotiation request"
+            ));
+        }
+
         if variable_part_rest_size >= usize::from(Self::RDP_NEG_REQ_SIZE) {
             let msg_type = NegoMsgType::from(src.read_u8());
 

--- a/crates/ironrdp-testsuite-core/tests/pdu/x224.rs
+++ b/crates/ironrdp-testsuite-core/tests/pdu/x224.rs
@@ -1,8 +1,8 @@
 use expect_test::expect;
 use ironrdp_core::{ReadCursor, WriteCursor};
 use ironrdp_pdu::nego::{
-    ConnectionConfirm, ConnectionRequest, Cookie, FailureCode, NegoRequestData, RequestFlags, ResponseFlags,
-    RoutingToken, SecurityProtocol,
+    ConnectionConfirm, ConnectionRequest, Cookie, CorrelationInfo, FailureCode, NegoRequestData, RequestFlags,
+    ResponseFlags, RoutingToken, SecurityProtocol,
 };
 use ironrdp_pdu::tpdu::{TpduCode, TpduHeader};
 use ironrdp_pdu::tpkt::TpktHeader;
@@ -79,6 +79,7 @@ encode_decode_test! {
             nego_data: None,
             flags: RequestFlags::empty(),
             protocol: SecurityProtocol::empty(),
+            correlation_info: None,
         }),
         [
             // tpkt header
@@ -100,6 +101,7 @@ encode_decode_test! {
             nego_data: Some(NegoRequestData::Cookie(Cookie("User".to_owned()))),
             flags: RequestFlags::empty(),
             protocol: SecurityProtocol::empty(),
+            correlation_info: None,
         }),
         [
             // tpkt header
@@ -123,6 +125,7 @@ encode_decode_test! {
             nego_data: Some(NegoRequestData::Cookie(Cookie("User".to_owned()))),
             flags: RequestFlags::empty(),
             protocol: SecurityProtocol::HYBRID | SecurityProtocol::SSL,
+            correlation_info: None,
         }),
         [
             // tpkt header
@@ -146,6 +149,7 @@ encode_decode_test! {
             nego_data: Some(NegoRequestData::Cookie(Cookie("User".to_owned()))),
             flags: RequestFlags::RESTRICTED_ADMIN_MODE_REQUIRED | RequestFlags::REDIRECTED_AUTHENTICATION_MODE_REQUIRED,
             protocol: SecurityProtocol::HYBRID | SecurityProtocol::SSL,
+            correlation_info: None,
         }),
         [
             // tpkt header
@@ -166,6 +170,30 @@ encode_decode_test! {
             0x03, // flags
             0x08, 0x00, // length
             0x03, 0x00, 0x00, 0x00, // request message
+        ];
+
+    nego_connection_request_with_correlation_info:
+        X224(ConnectionRequest {
+            nego_data: None,
+            flags: RequestFlags::CORRELATION_INFO_PRESENT,
+            protocol: SecurityProtocol::SSL,
+            correlation_info: Some(CorrelationInfo {
+                correlation_id: [0x01; 16],
+            }),
+        }),
+        [
+            // tpkt header
+            0x03, 0x00, 0x00, 0x37,
+            // tpdu header
+            0x32, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00,
+            // RDP_NEG_REQ
+            0x01, 0x08, 0x08, 0x00, 0x01, 0x00, 0x00, 0x00,
+            // RDP_NEG_CORRELATION_INFO
+            0x06, 0x00, 0x24, 0x00,
+            0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+            0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ];
 
     nego_confirm_response:
@@ -212,6 +240,39 @@ encode_decode_test! {
             0x08, 0x00, // length
             0x06, 0x00, 0x00, 0x00, // failure code
         ];
+}
+
+#[test]
+fn nego_connection_request_rejects_invalid_correlation_info() {
+    let valid = ironrdp_core::encode_vec(&X224(ConnectionRequest {
+        nego_data: None,
+        flags: RequestFlags::CORRELATION_INFO_PRESENT,
+        protocol: SecurityProtocol::SSL,
+        correlation_info: Some(CorrelationInfo {
+            correlation_id: [0x01; 16],
+        }),
+    }))
+    .unwrap();
+
+    // TPKT (4 bytes) + X.224 connection request header (7 bytes) +
+    // RDP_NEG_REQ (8 bytes).
+    const CORRELATION_INFO_OFFSET: usize = 19;
+
+    let mut invalid_type = valid.clone();
+    invalid_type[CORRELATION_INFO_OFFSET] = 0x05;
+    assert!(ironrdp_core::decode::<X224<ConnectionRequest>>(&invalid_type).is_err());
+
+    let mut invalid_flags = valid.clone();
+    invalid_flags[CORRELATION_INFO_OFFSET + 1] = 0x01;
+    assert!(ironrdp_core::decode::<X224<ConnectionRequest>>(&invalid_flags).is_err());
+
+    let mut invalid_length = valid.clone();
+    invalid_length[CORRELATION_INFO_OFFSET + 2] = 0x23;
+    assert!(ironrdp_core::decode::<X224<ConnectionRequest>>(&invalid_length).is_err());
+
+    let mut invalid_reserved = valid;
+    invalid_reserved[CORRELATION_INFO_OFFSET + 20] = 0x01;
+    assert!(ironrdp_core::decode::<X224<ConnectionRequest>>(&invalid_reserved).is_err());
 }
 
 #[test]

--- a/crates/ironrdp-testsuite-core/tests/pdu/x224.rs
+++ b/crates/ironrdp-testsuite-core/tests/pdu/x224.rs
@@ -276,6 +276,32 @@ fn nego_connection_request_rejects_invalid_correlation_info() {
 }
 
 #[test]
+fn nego_connection_request_rejects_truncated_negotiation_request() {
+    const RDP_NEG_REQ_PREFIX: [u8; 7] = [0x01, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00];
+
+    for truncated_size in 1..=RDP_NEG_REQ_PREFIX.len() {
+        let mut payload = vec![
+            // tpkt header
+            0x03,
+            0x00,
+            0x00,
+            u8::try_from(11 + truncated_size).expect("TPKT size fits in u8"),
+            // tpdu header
+            u8::try_from(6 + truncated_size).expect("TPDU size fits in u8"),
+            0xE0,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+        ];
+        payload.extend_from_slice(&RDP_NEG_REQ_PREFIX[..truncated_size]);
+
+        assert!(ironrdp_core::decode::<X224<ConnectionRequest>>(&payload).is_err());
+    }
+}
+
+#[test]
 fn nego_request_unexpected_rdp_msg_type() {
     let payload = [
         // tpkt header

--- a/crates/ironrdp-testsuite-core/tests/pdu/x224.rs
+++ b/crates/ironrdp-testsuite-core/tests/pdu/x224.rs
@@ -196,6 +196,33 @@ encode_decode_test! {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ];
 
+    nego_connection_request_with_cookie_and_correlation_info:
+        X224(ConnectionRequest {
+            nego_data: Some(NegoRequestData::Cookie(Cookie("User".to_owned()))),
+            flags: RequestFlags::CORRELATION_INFO_PRESENT,
+            protocol: SecurityProtocol::SSL,
+            correlation_info: Some(CorrelationInfo {
+                correlation_id: [0x01; 16],
+            }),
+        }),
+        [
+            // tpkt header
+            0x03, 0x00, 0x00, 0x4E,
+            // tpdu header
+            0x49, 0xE0, 0x00, 0x00, 0x00, 0x00, 0x00,
+            // cookie
+            0x43, 0x6F, 0x6F, 0x6B, 0x69, 0x65, 0x3A, 0x20, 0x6D, 0x73, 0x74, 0x73, 0x68, 0x61, 0x73, 0x68, 0x3D, 0x55,
+            0x73, 0x65, 0x72, 0x0D, 0x0A,
+            // RDP_NEG_REQ
+            0x01, 0x08, 0x08, 0x00, 0x01, 0x00, 0x00, 0x00,
+            // RDP_NEG_CORRELATION_INFO
+            0x06, 0x00, 0x24, 0x00,
+            0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+            0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+
     nego_confirm_response:
         X224(ConnectionConfirm::Response {
             flags: ResponseFlags::from_bits_retain(0x1F),
@@ -273,6 +300,61 @@ fn nego_connection_request_rejects_invalid_correlation_info() {
     let mut invalid_reserved = valid;
     invalid_reserved[CORRELATION_INFO_OFFSET + 20] = 0x01;
     assert!(ironrdp_core::decode::<X224<ConnectionRequest>>(&invalid_reserved).is_err());
+
+    let mut oversized = ironrdp_core::encode_vec(&X224(ConnectionRequest {
+        nego_data: None,
+        flags: RequestFlags::CORRELATION_INFO_PRESENT,
+        protocol: SecurityProtocol::SSL,
+        correlation_info: Some(CorrelationInfo {
+            correlation_id: [0x01; 16],
+        }),
+    }))
+    .unwrap();
+    oversized[3] += 1; // TPKT length
+    oversized[4] += 1; // X.224 length indicator
+    oversized.push(0);
+    assert!(ironrdp_core::decode::<X224<ConnectionRequest>>(&oversized).is_err());
+}
+
+#[test]
+fn nego_connection_request_derives_correlation_info_flag() {
+    let correlation_info = CorrelationInfo {
+        correlation_id: [0x01; 16],
+    };
+
+    let request_with_correlation_info = ConnectionRequest {
+        nego_data: None,
+        flags: RequestFlags::empty(),
+        protocol: SecurityProtocol::SSL,
+        correlation_info: Some(correlation_info),
+    };
+    let encoded = ironrdp_core::encode_vec(&X224(request_with_correlation_info)).unwrap();
+    assert_eq!(encoded[12], RequestFlags::CORRELATION_INFO_PRESENT.bits());
+
+    let request_without_correlation_info = ConnectionRequest {
+        nego_data: None,
+        flags: RequestFlags::CORRELATION_INFO_PRESENT | RequestFlags::RESTRICTED_ADMIN_MODE_REQUIRED,
+        protocol: SecurityProtocol::SSL,
+        correlation_info: None,
+    };
+    let encoded = ironrdp_core::encode_vec(&X224(request_without_correlation_info)).unwrap();
+    assert_eq!(encoded[12], RequestFlags::RESTRICTED_ADMIN_MODE_REQUIRED.bits());
+}
+
+#[test]
+fn nego_connection_request_rejects_unexpected_trailing_data() {
+    let request = ConnectionRequest {
+        nego_data: None,
+        flags: RequestFlags::empty(),
+        protocol: SecurityProtocol::SSL,
+        correlation_info: None,
+    };
+    let mut encoded = ironrdp_core::encode_vec(&X224(request)).unwrap();
+    encoded[3] += 1; // TPKT length
+    encoded[4] += 1; // X.224 length indicator
+    encoded.push(0);
+
+    assert!(ironrdp_core::decode::<X224<ConnectionRequest>>(&encoded).is_err());
 }
 
 #[test]

--- a/crates/ironrdp-testsuite-core/tests/server/acceptor.rs
+++ b/crates/ironrdp-testsuite-core/tests/server/acceptor.rs
@@ -13,6 +13,7 @@ fn encode_connection_request(protocol: SecurityProtocol) -> Vec<u8> {
         nego_data: None,
         flags: nego::RequestFlags::empty(),
         protocol,
+        correlation_info: None,
     };
     let mut buf = WriteBuf::new();
     ironrdp_core::encode_buf(&X224(request), &mut buf).unwrap();


### PR DESCRIPTION
Encode the optional 36-byte X.224 RDP_NEG_CORRELATION_INFO block and reject malformed negotiation records.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>