### PR TITLE
feat(pdu): add RDP-UDP protocol codecs

### DIFF
--- a/crates/ironrdp-pdu/src/rdp/mod.rs
+++ b/crates/ironrdp-pdu/src/rdp/mod.rs
@@ -16,6 +16,7 @@ pub mod server_error_info;
 pub mod server_license;
 pub mod session_info;
 pub mod suppress_output;
+pub mod udp;
 pub mod vc;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/ironrdp-pdu/src/rdp/multitransport.rs
+++ b/crates/ironrdp-pdu/src/rdp/multitransport.rs
@@ -1,9 +1,13 @@
-//! Initiate Multitransport Request and Response PDU types.
+//! RDP multitransport bootstrapping and tunnel PDU types.
 //!
-//! Defined in [\[MS-RDPBCGR\] 2.2.15.1] and [\[MS-RDPBCGR\] 2.2.15.2].
+//! The bootstrapping PDUs are defined in [\[MS-RDPBCGR\] 2.2.15.1] and
+//! [\[MS-RDPBCGR\] 2.2.15.2]. Tunnel PDUs are defined in [\[MS-RDPEMT\] 2.2.1]
+//! and [\[MS-RDPEMT\] 2.2.2].
 //!
 //! [\[MS-RDPBCGR\] 2.2.15.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/de783158-8b01-4818-8fb0-62523a5b3490
 //! [\[MS-RDPBCGR\] 2.2.15.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/44044233-e498-46f8-8e16-1ffa595a8e8b
+//! [\[MS-RDPEMT\] 2.2.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpemt/d22b606c-32c4-4647-b356-86f75e23a22c
+//! [\[MS-RDPEMT\] 2.2.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpemt/d22b606c-32c4-4647-b356-86f75e23a22c
 
 use ironrdp_core::{
     Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, cast_length, ensure_fixed_part_size,
@@ -19,7 +23,7 @@ const SECURITY_COOKIE_LEN: usize = 16;
 ///
 /// Defined in [\[MS-RDPEMT\] 2.2.1.1.1].
 ///
-/// [\[MS-RDPEMT\] 2.2.1.1.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpemt/5d6ce64a-ec26-4ee2-8375-28040bc7f3f9
+/// [\[MS-RDPEMT\] 2.2.1.1.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpemt/d22b606c-32c4-4647-b356-86f75e23a22c
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TunnelSubheader {
@@ -38,9 +42,6 @@ impl TunnelSubheader {
 
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         let length: u8 = cast_length!("subHeaderLength", self.size())?;
-        if usize::from(length) < Self::FIXED_PART_SIZE {
-            return Err(invalid_field_err!("subHeaderLength", "must be at least two bytes"));
-        }
 
         dst.write_u8(length);
         dst.write_u8(self.ty);
@@ -69,7 +70,7 @@ impl TunnelSubheader {
 ///
 /// Defined in [\[MS-RDPEMT\] 2.2.1.1].
 ///
-/// [\[MS-RDPEMT\] 2.2.1.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpemt/80d0849e-91a0-4fe7-83ad-ea9eaa7d15e9
+/// [\[MS-RDPEMT\] 2.2.1.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpemt/d22b606c-32c4-4647-b356-86f75e23a22c
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[repr(u8)]
@@ -110,18 +111,24 @@ struct TunnelHeader {
 impl TunnelHeader {
     const FIXED_PART_SIZE: usize = 1 /* action and flags */ + 2 /* payloadLength */ + 1 /* headerLength */;
 
-    fn size(&self) -> usize {
-        Self::FIXED_PART_SIZE + self.subheaders.iter().map(TunnelSubheader::size).sum::<usize>()
+    fn encoded_size(subheaders: &[TunnelSubheader]) -> usize {
+        Self::FIXED_PART_SIZE + subheaders.iter().map(TunnelSubheader::size).sum::<usize>()
     }
 
-    fn encode(&self, payload_length: usize, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+    fn encode(
+        action: TunnelAction,
+        subheaders: &[TunnelSubheader],
+        payload_length: usize,
+        dst: &mut WriteCursor<'_>,
+    ) -> EncodeResult<()> {
         let payload_length: u16 = cast_length!("payloadLength", payload_length)?;
-        let header_length: u8 = cast_length!("headerLength", self.size())?;
+        let header_length: u8 = cast_length!("headerLength", Self::encoded_size(subheaders))?;
+        ensure_size!(in: dst, size: usize::from(header_length) + usize::from(payload_length));
 
-        dst.write_u8(self.action.as_u8());
+        dst.write_u8(action.as_u8());
         dst.write_u16(payload_length);
         dst.write_u8(header_length);
-        self.subheaders.iter().try_for_each(|subheader| subheader.encode(dst))
+        subheaders.iter().try_for_each(|subheader| subheader.encode(dst))
     }
 
     fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<(Self, usize)> {
@@ -149,12 +156,7 @@ impl TunnelHeader {
             subheaders.push(TunnelSubheader::decode(&mut subheaders_cursor)?);
         }
 
-        if src.len() != payload_length {
-            return Err(invalid_field_err!(
-                "payloadLength",
-                "does not match the bytes following the tunnel header"
-            ));
-        }
+        ensure_size!(in: src, size: payload_length);
 
         Ok((Self { action, subheaders }, payload_length))
     }
@@ -164,7 +166,7 @@ impl TunnelHeader {
 ///
 /// Defined in [\[MS-RDPEMT\] 2.2.2.1].
 ///
-/// [\[MS-RDPEMT\] 2.2.2.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpemt/4cee15bd-2f65-4624-95d2-a3aa6c08d588
+/// [\[MS-RDPEMT\] 2.2.2.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpemt/d22b606c-32c4-4647-b356-86f75e23a22c
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TunnelCreateRequestPdu {
@@ -189,11 +191,7 @@ impl TunnelCreateRequestPdu {
 
 impl Encode for TunnelCreateRequestPdu {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        TunnelHeader {
-            action: TunnelAction::CreateRequest,
-            subheaders: Vec::new(),
-        }
-        .encode(Self::PAYLOAD_SIZE, dst)?;
+        TunnelHeader::encode(TunnelAction::CreateRequest, &[], Self::PAYLOAD_SIZE, dst)?;
         dst.write_u32(self.request_id);
         dst.write_u32(0);
         dst.write_slice(&self.security_cookie);
@@ -206,12 +204,7 @@ impl Encode for TunnelCreateRequestPdu {
     }
 
     fn size(&self) -> usize {
-        TunnelHeader {
-            action: TunnelAction::CreateRequest,
-            subheaders: Vec::new(),
-        }
-        .size()
-            + Self::PAYLOAD_SIZE
+        TunnelHeader::encoded_size(&[]) + Self::PAYLOAD_SIZE
     }
 }
 
@@ -252,7 +245,7 @@ impl<'de> Decode<'de> for TunnelCreateRequestPdu {
 ///
 /// Defined in [\[MS-RDPEMT\] 2.2.2.2].
 ///
-/// [\[MS-RDPEMT\] 2.2.2.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpemt/8676e0f6-b5f3-45fb-8c3e-18a9414ea98f
+/// [\[MS-RDPEMT\] 2.2.2.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpemt/d22b606c-32c4-4647-b356-86f75e23a22c
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TunnelCreateResponsePdu {
@@ -264,7 +257,7 @@ impl TunnelCreateResponsePdu {
     const PAYLOAD_SIZE: usize = 4 /* hrResponse */;
     const NAME: &'static str = "TunnelCreateResponsePdu";
 
-    /// `S_OK`.
+    /// Exact `S_OK` response value.
     pub const S_OK: u32 = 0;
 
     /// Whether the server accepted the tunnel.
@@ -275,11 +268,7 @@ impl TunnelCreateResponsePdu {
 
 impl Encode for TunnelCreateResponsePdu {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        TunnelHeader {
-            action: TunnelAction::CreateResponse,
-            subheaders: Vec::new(),
-        }
-        .encode(Self::PAYLOAD_SIZE, dst)?;
+        TunnelHeader::encode(TunnelAction::CreateResponse, &[], Self::PAYLOAD_SIZE, dst)?;
         dst.write_u32(self.hr_response);
 
         Ok(())
@@ -290,12 +279,7 @@ impl Encode for TunnelCreateResponsePdu {
     }
 
     fn size(&self) -> usize {
-        TunnelHeader {
-            action: TunnelAction::CreateResponse,
-            subheaders: Vec::new(),
-        }
-        .size()
-            + Self::PAYLOAD_SIZE
+        TunnelHeader::encoded_size(&[]) + Self::PAYLOAD_SIZE
     }
 }
 
@@ -328,7 +312,7 @@ impl<'de> Decode<'de> for TunnelCreateResponsePdu {
 ///
 /// Defined in [\[MS-RDPEMT\] 2.2.2.3].
 ///
-/// [\[MS-RDPEMT\] 2.2.2.3]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpemt/0c9108e9-fa9f-4d44-a030-810e2902a2c6
+/// [\[MS-RDPEMT\] 2.2.2.3]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpemt/d22b606c-32c4-4647-b356-86f75e23a22c
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TunnelDataPdu {
@@ -352,11 +336,7 @@ impl TunnelDataPdu {
 
 impl Encode for TunnelDataPdu {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        TunnelHeader {
-            action: TunnelAction::Data,
-            subheaders: self.subheaders.clone(),
-        }
-        .encode(self.data.len(), dst)?;
+        TunnelHeader::encode(TunnelAction::Data, &self.subheaders, self.data.len(), dst)?;
         dst.write_slice(&self.data);
 
         Ok(())
@@ -367,12 +347,7 @@ impl Encode for TunnelDataPdu {
     }
 
     fn size(&self) -> usize {
-        TunnelHeader {
-            action: TunnelAction::Data,
-            subheaders: self.subheaders.clone(),
-        }
-        .size()
-            + self.data.len()
+        TunnelHeader::encoded_size(&self.subheaders) + self.data.len()
     }
 }
 
@@ -394,7 +369,7 @@ impl<'de> Decode<'de> for TunnelDataPdu {
 ///
 /// Defined in [\[MS-RDPEMT\] 2.2.2].
 ///
-/// [\[MS-RDPEMT\] 2.2.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpemt/9f9aefd5-c7dc-47d7-8767-1224a92f4e9f
+/// [\[MS-RDPEMT\] 2.2.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpemt/d22b606c-32c4-4647-b356-86f75e23a22c
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum TunnelPdu {
@@ -958,6 +933,55 @@ mod tests {
         );
         let decoded = ironrdp_core::decode::<TunnelPdu>(&encoded).unwrap();
         assert_eq!(decoded, pdu);
+    }
+
+    #[test]
+    fn tunnel_decoder_leaves_the_next_pdu_in_the_cursor() {
+        let first = ironrdp_core::encode_vec(&TunnelCreateResponsePdu {
+            hr_response: TunnelCreateResponsePdu::S_OK,
+        })
+        .unwrap();
+        let second = ironrdp_core::encode_vec(&TunnelCreateResponsePdu {
+            hr_response: 0x8000_4004,
+        })
+        .unwrap();
+        let mut wire = first;
+        wire.extend_from_slice(&second);
+
+        let mut cursor = ReadCursor::new(&wire);
+        assert_eq!(
+            TunnelCreateResponsePdu::decode(&mut cursor).unwrap().hr_response,
+            TunnelCreateResponsePdu::S_OK
+        );
+        assert_eq!(
+            TunnelCreateResponsePdu::decode(&mut cursor).unwrap().hr_response,
+            0x8000_4004
+        );
+        assert!(cursor.is_empty());
+    }
+
+    #[test]
+    fn tunnel_decoder_rejects_truncated_payloads() {
+        let wire = [
+            0x01, // action = create response, flags = 0
+            0x04, 0x00, // payloadLength = 4
+            0x04, // headerLength = 4
+            0x00, 0x00, 0x00, // incomplete hrResponse
+        ];
+        assert!(ironrdp_core::decode::<TunnelCreateResponsePdu>(&wire).is_err());
+    }
+
+    #[test]
+    fn tunnel_encoders_return_errors_for_small_buffers() {
+        let request = TunnelCreateRequestPdu::new(7, [0xAB; SECURITY_COOKIE_LEN]);
+        let response = TunnelCreateResponsePdu {
+            hr_response: TunnelCreateResponsePdu::S_OK,
+        };
+        let data = TunnelDataPdu::new(vec![1]);
+
+        assert!(ironrdp_core::encode(&request, &mut [0; 1]).is_err());
+        assert!(ironrdp_core::encode(&response, &mut [0; 1]).is_err());
+        assert!(ironrdp_core::encode(&data, &mut [0; 1]).is_err());
     }
 
     #[test]

--- a/crates/ironrdp-pdu/src/rdp/multitransport.rs
+++ b/crates/ironrdp-pdu/src/rdp/multitransport.rs
@@ -6,14 +6,445 @@
 //! [\[MS-RDPBCGR\] 2.2.15.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/44044233-e498-46f8-8e16-1ffa595a8e8b
 
 use ironrdp_core::{
-    Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, ensure_fixed_part_size, invalid_field_err,
-    read_padding, write_padding,
+    Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, cast_length, ensure_fixed_part_size,
+    ensure_size, invalid_field_err, read_padding, write_padding,
 };
 
 use crate::rdp::headers::{BasicSecurityHeader, BasicSecurityHeaderFlags};
 
 /// Length of the security cookie used for transport binding validation.
 const SECURITY_COOKIE_LEN: usize = 16;
+
+/// An RDPEMT tunnel subheader.
+///
+/// Defined in [\[MS-RDPEMT\] 2.2.1.1.1].
+///
+/// [\[MS-RDPEMT\] 2.2.1.1.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpemt/5d6ce64a-ec26-4ee2-8375-28040bc7f3f9
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct TunnelSubheader {
+    /// Type of the encapsulated subheader.
+    pub ty: u8,
+    /// Type-specific bytes following the length and type fields.
+    pub data: Vec<u8>,
+}
+
+impl TunnelSubheader {
+    const FIXED_PART_SIZE: usize = 1 /* subHeaderLength */ + 1 /* subHeaderType */;
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.data.len()
+    }
+
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        let length: u8 = cast_length!("subHeaderLength", self.size())?;
+        if usize::from(length) < Self::FIXED_PART_SIZE {
+            return Err(invalid_field_err!("subHeaderLength", "must be at least two bytes"));
+        }
+
+        dst.write_u8(length);
+        dst.write_u8(self.ty);
+        dst.write_slice(&self.data);
+
+        Ok(())
+    }
+
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: Self::FIXED_PART_SIZE);
+
+        let length = usize::from(src.read_u8());
+        if length < Self::FIXED_PART_SIZE {
+            return Err(invalid_field_err!("subHeaderLength", "must be at least two bytes"));
+        }
+
+        ensure_size!(in: src, size: length - 1 /* subHeaderLength */);
+        let ty = src.read_u8();
+        let data = src.read_slice(length - Self::FIXED_PART_SIZE).to_vec();
+
+        Ok(Self { ty, data })
+    }
+}
+
+/// Action carried in an RDPEMT tunnel PDU header.
+///
+/// Defined in [\[MS-RDPEMT\] 2.2.1.1].
+///
+/// [\[MS-RDPEMT\] 2.2.1.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpemt/80d0849e-91a0-4fe7-83ad-ea9eaa7d15e9
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[repr(u8)]
+pub enum TunnelAction {
+    /// `RDP_TUNNEL_CREATEREQUEST`.
+    CreateRequest = 0x0,
+    /// `RDP_TUNNEL_CREATERESPONSE`.
+    CreateResponse = 0x1,
+    /// `RDP_TUNNEL_DATA`.
+    Data = 0x2,
+}
+
+impl TunnelAction {
+    fn from_u8(value: u8) -> Option<Self> {
+        match value {
+            0x0 => Some(Self::CreateRequest),
+            0x1 => Some(Self::CreateResponse),
+            0x2 => Some(Self::Data),
+            _ => None,
+        }
+    }
+
+    #[expect(
+        clippy::as_conversions,
+        reason = "repr(u8) guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
+    fn as_u8(self) -> u8 {
+        self as u8
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TunnelHeader {
+    action: TunnelAction,
+    subheaders: Vec<TunnelSubheader>,
+}
+
+impl TunnelHeader {
+    const FIXED_PART_SIZE: usize = 1 /* action and flags */ + 2 /* payloadLength */ + 1 /* headerLength */;
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.subheaders.iter().map(TunnelSubheader::size).sum::<usize>()
+    }
+
+    fn encode(&self, payload_length: usize, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        let payload_length: u16 = cast_length!("payloadLength", payload_length)?;
+        let header_length: u8 = cast_length!("headerLength", self.size())?;
+
+        dst.write_u8(self.action.as_u8());
+        dst.write_u16(payload_length);
+        dst.write_u8(header_length);
+        self.subheaders.iter().try_for_each(|subheader| subheader.encode(dst))
+    }
+
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<(Self, usize)> {
+        ensure_size!(in: src, size: Self::FIXED_PART_SIZE);
+
+        let action_and_flags = src.read_u8();
+        let flags = action_and_flags >> 4;
+        if flags != 0 {
+            return Err(invalid_field_err!("flags", "must be zero"));
+        }
+
+        let action = TunnelAction::from_u8(action_and_flags & 0x0F)
+            .ok_or_else(|| invalid_field_err!("action", "unknown tunnel action"))?;
+        let payload_length = usize::from(src.read_u16());
+        let header_length = usize::from(src.read_u8());
+        if header_length < Self::FIXED_PART_SIZE {
+            return Err(invalid_field_err!("headerLength", "must be at least four bytes"));
+        }
+
+        let subheader_length = header_length - Self::FIXED_PART_SIZE;
+        ensure_size!(in: src, size: subheader_length);
+        let mut subheaders_cursor = ReadCursor::new(src.read_slice(subheader_length));
+        let mut subheaders = Vec::new();
+        while !subheaders_cursor.is_empty() {
+            subheaders.push(TunnelSubheader::decode(&mut subheaders_cursor)?);
+        }
+
+        if src.len() != payload_length {
+            return Err(invalid_field_err!(
+                "payloadLength",
+                "does not match the bytes following the tunnel header"
+            ));
+        }
+
+        Ok((Self { action, subheaders }, payload_length))
+    }
+}
+
+/// Client request that binds an RDPEMT tunnel to the main RDP connection.
+///
+/// Defined in [\[MS-RDPEMT\] 2.2.2.1].
+///
+/// [\[MS-RDPEMT\] 2.2.2.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpemt/4cee15bd-2f65-4624-95d2-a3aa6c08d588
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct TunnelCreateRequestPdu {
+    /// Request ID from the Initiate Multitransport Request PDU.
+    pub request_id: u32,
+    /// Security cookie from the Initiate Multitransport Request PDU.
+    pub security_cookie: [u8; SECURITY_COOKIE_LEN],
+}
+
+impl TunnelCreateRequestPdu {
+    const PAYLOAD_SIZE: usize = 4 /* requestId */ + 4 /* reserved */ + SECURITY_COOKIE_LEN /* securityCookie */;
+    const NAME: &'static str = "TunnelCreateRequestPdu";
+
+    /// Builds a tunnel-create request.
+    pub fn new(request_id: u32, security_cookie: [u8; SECURITY_COOKIE_LEN]) -> Self {
+        Self {
+            request_id,
+            security_cookie,
+        }
+    }
+}
+
+impl Encode for TunnelCreateRequestPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        TunnelHeader {
+            action: TunnelAction::CreateRequest,
+            subheaders: Vec::new(),
+        }
+        .encode(Self::PAYLOAD_SIZE, dst)?;
+        dst.write_u32(self.request_id);
+        dst.write_u32(0);
+        dst.write_slice(&self.security_cookie);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        TunnelHeader {
+            action: TunnelAction::CreateRequest,
+            subheaders: Vec::new(),
+        }
+        .size()
+            + Self::PAYLOAD_SIZE
+    }
+}
+
+impl<'de> Decode<'de> for TunnelCreateRequestPdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        let (header, payload_length) = TunnelHeader::decode(src)?;
+        if header.action != TunnelAction::CreateRequest {
+            return Err(invalid_field_err!("action", "expected tunnel create request"));
+        }
+        if !header.subheaders.is_empty() {
+            return Err(invalid_field_err!(
+                "headerLength",
+                "must be four bytes for a tunnel create request"
+            ));
+        }
+        if payload_length != Self::PAYLOAD_SIZE {
+            return Err(invalid_field_err!(
+                "payloadLength",
+                "must be 24 bytes for a tunnel create request"
+            ));
+        }
+
+        let request_id = src.read_u32();
+        let reserved = src.read_u32();
+        if reserved != 0 {
+            return Err(invalid_field_err!("reserved", "must be zero"));
+        }
+        let security_cookie = src.read_array();
+
+        Ok(Self {
+            request_id,
+            security_cookie,
+        })
+    }
+}
+
+/// Server response to an RDPEMT tunnel-create request.
+///
+/// Defined in [\[MS-RDPEMT\] 2.2.2.2].
+///
+/// [\[MS-RDPEMT\] 2.2.2.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpemt/8676e0f6-b5f3-45fb-8c3e-18a9414ea98f
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct TunnelCreateResponsePdu {
+    /// HRESULT returned by the server.
+    pub hr_response: u32,
+}
+
+impl TunnelCreateResponsePdu {
+    const PAYLOAD_SIZE: usize = 4 /* hrResponse */;
+    const NAME: &'static str = "TunnelCreateResponsePdu";
+
+    /// `S_OK`.
+    pub const S_OK: u32 = 0;
+
+    /// Whether the server accepted the tunnel.
+    pub fn is_success(&self) -> bool {
+        self.hr_response == Self::S_OK
+    }
+}
+
+impl Encode for TunnelCreateResponsePdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        TunnelHeader {
+            action: TunnelAction::CreateResponse,
+            subheaders: Vec::new(),
+        }
+        .encode(Self::PAYLOAD_SIZE, dst)?;
+        dst.write_u32(self.hr_response);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        TunnelHeader {
+            action: TunnelAction::CreateResponse,
+            subheaders: Vec::new(),
+        }
+        .size()
+            + Self::PAYLOAD_SIZE
+    }
+}
+
+impl<'de> Decode<'de> for TunnelCreateResponsePdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        let (header, payload_length) = TunnelHeader::decode(src)?;
+        if header.action != TunnelAction::CreateResponse {
+            return Err(invalid_field_err!("action", "expected tunnel create response"));
+        }
+        if !header.subheaders.is_empty() {
+            return Err(invalid_field_err!(
+                "headerLength",
+                "must be four bytes for a tunnel create response"
+            ));
+        }
+        if payload_length != Self::PAYLOAD_SIZE {
+            return Err(invalid_field_err!(
+                "payloadLength",
+                "must be four bytes for a tunnel create response"
+            ));
+        }
+
+        Ok(Self {
+            hr_response: src.read_u32(),
+        })
+    }
+}
+
+/// Higher-layer data transported by an established RDPEMT tunnel.
+///
+/// Defined in [\[MS-RDPEMT\] 2.2.2.3].
+///
+/// [\[MS-RDPEMT\] 2.2.2.3]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpemt/0c9108e9-fa9f-4d44-a030-810e2902a2c6
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct TunnelDataPdu {
+    /// Optional autodetect subheaders.
+    pub subheaders: Vec<TunnelSubheader>,
+    /// Complete higher-layer message.
+    pub data: Vec<u8>,
+}
+
+impl TunnelDataPdu {
+    const NAME: &'static str = "TunnelDataPdu";
+
+    /// Builds a tunnel data PDU without optional subheaders.
+    pub fn new(data: Vec<u8>) -> Self {
+        Self {
+            subheaders: Vec::new(),
+            data,
+        }
+    }
+}
+
+impl Encode for TunnelDataPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        TunnelHeader {
+            action: TunnelAction::Data,
+            subheaders: self.subheaders.clone(),
+        }
+        .encode(self.data.len(), dst)?;
+        dst.write_slice(&self.data);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        TunnelHeader {
+            action: TunnelAction::Data,
+            subheaders: self.subheaders.clone(),
+        }
+        .size()
+            + self.data.len()
+    }
+}
+
+impl<'de> Decode<'de> for TunnelDataPdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        let (header, payload_length) = TunnelHeader::decode(src)?;
+        if header.action != TunnelAction::Data {
+            return Err(invalid_field_err!("action", "expected tunnel data"));
+        }
+
+        Ok(Self {
+            subheaders: header.subheaders,
+            data: src.read_slice(payload_length).to_vec(),
+        })
+    }
+}
+
+/// Any complete RDPEMT tunnel PDU.
+///
+/// Defined in [\[MS-RDPEMT\] 2.2.2].
+///
+/// [\[MS-RDPEMT\] 2.2.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpemt/9f9aefd5-c7dc-47d7-8767-1224a92f4e9f
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub enum TunnelPdu {
+    /// Client tunnel-create request.
+    CreateRequest(TunnelCreateRequestPdu),
+    /// Server tunnel-create response.
+    CreateResponse(TunnelCreateResponsePdu),
+    /// Higher-layer data.
+    Data(TunnelDataPdu),
+}
+
+impl Encode for TunnelPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        match self {
+            Self::CreateRequest(pdu) => pdu.encode(dst),
+            Self::CreateResponse(pdu) => pdu.encode(dst),
+            Self::Data(pdu) => pdu.encode(dst),
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        match self {
+            Self::CreateRequest(pdu) => pdu.name(),
+            Self::CreateResponse(pdu) => pdu.name(),
+            Self::Data(pdu) => pdu.name(),
+        }
+    }
+
+    fn size(&self) -> usize {
+        match self {
+            Self::CreateRequest(pdu) => pdu.size(),
+            Self::CreateResponse(pdu) => pdu.size(),
+            Self::Data(pdu) => pdu.size(),
+        }
+    }
+}
+
+impl<'de> Decode<'de> for TunnelPdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: TunnelHeader::FIXED_PART_SIZE);
+        let action = TunnelAction::from_u8(src.remaining()[0] & 0x0F)
+            .ok_or_else(|| invalid_field_err!("action", "unknown tunnel action"))?;
+
+        match action {
+            TunnelAction::CreateRequest => TunnelCreateRequestPdu::decode(src).map(Self::CreateRequest),
+            TunnelAction::CreateResponse => TunnelCreateResponsePdu::decode(src).map(Self::CreateResponse),
+            TunnelAction::Data => TunnelDataPdu::decode(src).map(Self::Data),
+        }
+    }
+}
 
 /// Requested transport protocol for multitransport bootstrapping.
 ///
@@ -459,5 +890,85 @@ mod tests {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         ];
         assert!(ironrdp_core::decode::<MultitransportRequestPdu>(bad_wire).is_err());
+    }
+
+    #[test]
+    fn tunnel_create_request_round_trip() {
+        let pdu = TunnelCreateRequestPdu::new(7, [0xAB; SECURITY_COOKIE_LEN]);
+        let encoded = ironrdp_core::encode_vec(&pdu).unwrap();
+        assert_eq!(
+            encoded.as_slice(),
+            &[
+                0x00, // action = create request, flags = 0
+                0x18, 0x00, // payloadLength = 24
+                0x04, // headerLength = 4
+                0x07, 0x00, 0x00, 0x00, // requestId
+                0x00, 0x00, 0x00, 0x00, // reserved
+                0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, // securityCookie
+                0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB,
+            ]
+        );
+        let decoded = ironrdp_core::decode::<TunnelCreateRequestPdu>(&encoded).unwrap();
+        assert_eq!(decoded, pdu);
+    }
+
+    #[test]
+    fn tunnel_create_pdus_reject_subheaders() {
+        let request = [
+            0x00, // action = create request, flags = 0
+            0x18, 0x00, // payloadLength = 24
+            0x06, // headerLength = 6
+            0x02, 0x01, // subheader
+            0x07, 0x00, 0x00, 0x00, // requestId
+            0x00, 0x00, 0x00, 0x00, // reserved
+            0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, // securityCookie
+            0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB,
+        ];
+        assert!(ironrdp_core::decode::<TunnelCreateRequestPdu>(&request).is_err());
+
+        let response = [
+            0x01, // action = create response, flags = 0
+            0x04, 0x00, // payloadLength = 4
+            0x06, // headerLength = 6
+            0x02, 0x01, // subheader
+            0x00, 0x00, 0x00, 0x00, // hrResponse
+        ];
+        assert!(ironrdp_core::decode::<TunnelCreateResponsePdu>(&response).is_err());
+    }
+
+    #[test]
+    fn tunnel_pdu_preserves_subheaders_and_data() {
+        let pdu = TunnelPdu::Data(TunnelDataPdu {
+            subheaders: vec![TunnelSubheader {
+                ty: 1,
+                data: vec![0xAA, 0xBB],
+            }],
+            data: vec![1, 2, 3],
+        });
+        let encoded = ironrdp_core::encode_vec(&pdu).unwrap();
+        assert_eq!(
+            encoded.as_slice(),
+            &[
+                0x02, // action = data, flags = 0
+                0x03, 0x00, // payloadLength = 3
+                0x08, // headerLength = 8
+                0x04, 0x01, 0xAA, 0xBB, // subheader
+                0x01, 0x02, 0x03, // higher-layer data
+            ]
+        );
+        let decoded = ironrdp_core::decode::<TunnelPdu>(&encoded).unwrap();
+        assert_eq!(decoded, pdu);
+    }
+
+    #[test]
+    fn tunnel_header_rejects_invalid_lengths_and_flags() {
+        let invalid_header_length = [0x02, 0x00, 0x00, 0x03];
+        assert!(ironrdp_core::decode::<TunnelDataPdu>(&invalid_header_length).is_err());
+
+        let invalid_flags = [0x12, 0x00, 0x00, 0x04];
+        assert!(ironrdp_core::decode::<TunnelDataPdu>(&invalid_flags).is_err());
+
+        let invalid_payload_length = [0x02, 0x01, 0x00, 0x04];
+        assert!(ironrdp_core::decode::<TunnelDataPdu>(&invalid_payload_length).is_err());
     }
 }

--- a/crates/ironrdp-pdu/src/rdp/udp.rs
+++ b/crates/ironrdp-pdu/src/rdp/udp.rs
@@ -4,14 +4,14 @@
 //! common header, connection-initialization, acknowledgement, and source-data
 //! structures used by reliable RDP-UDP versions 1 and 2.
 //!
-//! Defined in [\[MS-RDPEUDP\] 2.2.2.1, 2.2.2.4-2.2.2.7].
+//! Defined in [\[MS-RDPEUDP\] 2.2.2.1, 2.2.2.4, 2.2.2.5, and 2.2.2.7].
 //!
-//! [\[MS-RDPEUDP\] 2.2.2.1, 2.2.2.4-2.2.2.7]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/2b8a6f10-cf3a-49f6-b989-51de4d2f99e6
+//! [\[MS-RDPEUDP\] 2.2.2.1, 2.2.2.4, 2.2.2.5, and 2.2.2.7]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/2744a3ee-04fb-407b-a9e3-b3b2ded422b1
 
 use bitflags::bitflags;
 use ironrdp_core::{
     Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, cast_length, ensure_fixed_part_size,
-    ensure_size, invalid_field_err,
+    ensure_size, invalid_field_err, read_padding,
 };
 
 /// Minimum MTU accepted during reliable RDP-UDP negotiation.
@@ -26,7 +26,7 @@ bitflags! {
     ///
     /// Defined in [\[MS-RDPEUDP\] 2.2.2.1].
     ///
-    /// [\[MS-RDPEUDP\] 2.2.2.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/2b8a6f10-cf3a-49f6-b989-51de4d2f99e6
+    /// [\[MS-RDPEUDP\] 2.2.2.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/2744a3ee-04fb-407b-a9e3-b3b2ded422b1
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
     pub struct RdpUdpFlags: u16 {
@@ -44,6 +44,8 @@ bitflags! {
         const CN = 0x0020;
         /// Congestion-window reset.
         const CWR = 0x0040;
+        /// Selective ACK option; currently unused by the protocol.
+        const SACK_OPTION = 0x0080;
         /// ACK-of-ACK vector follows the ACK vector.
         const ACK_OF_ACKS = 0x0100;
         /// Requests lossy transport; this is unsupported by the reliable-only engine.
@@ -63,7 +65,7 @@ bitflags! {
 ///
 /// Defined in [\[MS-RDPEUDP\] 2.2.2.1].
 ///
-/// [\[MS-RDPEUDP\] 2.2.2.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/2b8a6f10-cf3a-49f6-b989-51de4d2f99e6
+/// [\[MS-RDPEUDP\] 2.2.2.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/2744a3ee-04fb-407b-a9e3-b3b2ded422b1
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct RdpUdpFecHeader {
@@ -103,8 +105,7 @@ impl<'de> Decode<'de> for RdpUdpFecHeader {
         ensure_fixed_part_size!(in: src);
         let source_ack = src.read_u32_be();
         let receive_window_size = src.read_u16_be();
-        let flags = RdpUdpFlags::from_bits(src.read_u16_be())
-            .ok_or_else(|| invalid_field_err!("uFlags", "contains reserved bits"))?;
+        let flags = RdpUdpFlags::from_bits_truncate(src.read_u16_be());
 
         Ok(Self {
             source_ack,
@@ -118,7 +119,7 @@ impl<'de> Decode<'de> for RdpUdpFecHeader {
 ///
 /// Defined in [\[MS-RDPEUDP\] 2.2.2.5].
 ///
-/// [\[MS-RDPEUDP\] 2.2.2.5]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/da754206-a6d0-4a5b-9ef7-4a8e5352701f
+/// [\[MS-RDPEUDP\] 2.2.2.5]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/2744a3ee-04fb-407b-a9e3-b3b2ded422b1
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct RdpUdpSynData {
@@ -196,49 +197,11 @@ impl<'de> Decode<'de> for RdpUdpSynData {
     }
 }
 
-/// RDP-UDP protocol version advertised in extended SYN data.
-///
-/// Defined in [\[MS-RDPEUDP\] 2.2.2.9].
-///
-/// [\[MS-RDPEUDP\] 2.2.2.9]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/2399ce13-049d-4c02-bd3c-9226b38d14f2
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[repr(u16)]
-pub enum RdpUdpProtocolVersion {
-    /// Legacy reliable RDP-UDP with 500 ms minimum retransmission timeout.
-    V1 = 0x0001,
-    /// Legacy reliable RDP-UDP with 300 ms minimum retransmission timeout.
-    V2 = 0x0002,
-    /// RDP-UDP2 transfer after RDP-UDP initialization.
-    V3 = 0x0101,
-}
-
-impl RdpUdpProtocolVersion {
-    /// Converts a protocol-version integer received on the wire.
-    pub fn from_u16(value: u16) -> Option<Self> {
-        match value {
-            0x0001 => Some(Self::V1),
-            0x0002 => Some(Self::V2),
-            0x0101 => Some(Self::V3),
-            _ => None,
-        }
-    }
-
-    #[expect(
-        clippy::as_conversions,
-        reason = "repr(u16) guarantees discriminant layout, and as is the only way to cast enum -> primitive"
-    )]
-    /// Converts this version to its wire representation.
-    pub fn as_u16(self) -> u16 {
-        self as u16
-    }
-}
-
 /// RDP-UDP ACK vector with DWORD alignment padding.
 ///
 /// Defined in [\[MS-RDPEUDP\] 2.2.2.7].
 ///
-/// [\[MS-RDPEUDP\] 2.2.2.7]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/16ff7b1e-f60b-4369-b5de-d49eff260f05
+/// [\[MS-RDPEUDP\] 2.2.2.7]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/2744a3ee-04fb-407b-a9e3-b3b2ded422b1
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct RdpUdpAckVector {
@@ -289,9 +252,7 @@ impl<'de> Decode<'de> for RdpUdpAckVector {
         let padding_size = Self::padding_size(encoded_len);
         ensure_size!(in: src, size: encoded_len + padding_size);
         let encoded = src.read_slice(encoded_len).to_vec();
-        if src.read_slice(padding_size).iter().any(|&byte| byte != 0) {
-            return Err(invalid_field_err!("padding", "must be zero"));
-        }
+        read_padding(src, padding_size);
 
         Ok(Self { encoded })
     }
@@ -301,7 +262,7 @@ impl<'de> Decode<'de> for RdpUdpAckVector {
 ///
 /// Defined in [\[MS-RDPEUDP\] 2.2.2.4].
 ///
-/// [\[MS-RDPEUDP\] 2.2.2.4]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/916af634-f96b-4dcc-bfdf-5646d5dc7f7d
+/// [\[MS-RDPEUDP\] 2.2.2.4]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/2744a3ee-04fb-407b-a9e3-b3b2ded422b1
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct RdpUdpSourcePayload {
@@ -368,11 +329,51 @@ mod tests {
     }
 
     #[test]
+    fn accepts_documented_and_unknown_flags() {
+        let encoded = [
+            0xFF, 0xFF, 0xFF, 0xFF, // snSourceAck
+            0x04, 0x00, // uReceiveWindowSize
+            0x80, 0x84, // ACK | SACK_OPTION | unknown flag
+        ];
+        let header = ironrdp_core::decode::<RdpUdpFecHeader>(&encoded).unwrap();
+        assert_eq!(header.flags, RdpUdpFlags::ACK | RdpUdpFlags::SACK_OPTION);
+    }
+
+    #[test]
     fn ack_vector_round_trip_and_padding() {
-        let vector = RdpUdpAckVector { encoded: vec![0x04] };
-        let encoded = ironrdp_core::encode_vec(&vector).unwrap();
-        assert_eq!(encoded.as_slice(), &[0x00, 0x01, 0x04, 0x00]);
-        assert_eq!(ironrdp_core::decode::<RdpUdpAckVector>(&encoded).unwrap(), vector);
+        for encoded in [
+            vec![],
+            vec![0x04],
+            vec![0x04, 0x05],
+            vec![0x04, 0x05, 0x06],
+            vec![0x04; 2048],
+        ] {
+            let vector = RdpUdpAckVector { encoded };
+            let encoded = ironrdp_core::encode_vec(&vector).unwrap();
+            assert_eq!(ironrdp_core::decode::<RdpUdpAckVector>(&encoded).unwrap(), vector);
+        }
+    }
+
+    #[test]
+    fn ack_vector_ignores_non_zero_padding() {
+        let encoded = [0x00, 0x01, 0x04, 0xFF];
+        assert_eq!(
+            ironrdp_core::decode::<RdpUdpAckVector>(&encoded).unwrap(),
+            RdpUdpAckVector { encoded: vec![0x04] }
+        );
+    }
+
+    #[test]
+    fn accepts_mtu_boundaries() {
+        for mtu in [MIN_MTU, MAX_MTU] {
+            let syn = RdpUdpSynData {
+                initial_sequence_number: 1,
+                upstream_mtu: mtu,
+                downstream_mtu: mtu,
+            };
+            let encoded = ironrdp_core::encode_vec(&syn).unwrap();
+            assert_eq!(ironrdp_core::decode::<RdpUdpSynData>(&encoded).unwrap(), syn);
+        }
     }
 
     #[test]

--- a/crates/ironrdp-pdu/src/rdp/udp.rs
+++ b/crates/ironrdp-pdu/src/rdp/udp.rs
@@ -1,12 +1,12 @@
 //! RDP-UDP reliable transport wire structures.
 //!
 //! The transport state machine lives outside this crate. These types encode the
-//! common header, connection-initialization, acknowledgement, and source-data
-//! structures used by reliable RDP-UDP versions 1 and 2.
+//! common header, connection-initialization, acknowledgement, and data payload
+//! headers used by reliable RDP-UDP.
 //!
-//! Defined in [\[MS-RDPEUDP\] 2.2.2.1, 2.2.2.4, 2.2.2.5, and 2.2.2.7].
+//! Defined in [\[MS-RDPEUDP\] 2.2.2.1 through 2.2.2.9].
 //!
-//! [\[MS-RDPEUDP\] 2.2.2.1, 2.2.2.4, 2.2.2.5, and 2.2.2.7]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/2744a3ee-04fb-407b-a9e3-b3b2ded422b1
+//! [\[MS-RDPEUDP\] 2.2.2.1 through 2.2.2.9]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/2744a3ee-04fb-407b-a9e3-b3b2ded422b1
 
 use bitflags::bitflags;
 use ironrdp_core::{
@@ -38,7 +38,7 @@ bitflags! {
         const ACK = 0x0004;
         /// A data payload follows the ACK structures.
         const DATA = 0x0008;
-        /// The data payload is FEC encoded and follows an FEC payload header.
+        /// An FEC payload header follows the common header.
         const FEC = 0x0010;
         /// Congestion notification.
         const CN = 0x0020;
@@ -46,13 +46,13 @@ bitflags! {
         const CWR = 0x0040;
         /// Selective ACK option; currently unused by the protocol.
         const SACK_OPTION = 0x0080;
-        /// ACK-of-ACK vector follows the ACK vector.
+        /// An ACK-of-ACK vector header follows the ACK vector.
         const ACK_OF_ACKS = 0x0100;
-        /// Requests lossy transport; this is unsupported by the reliable-only engine.
+        /// Requests lossy transport.
         const SYN_LOSSY = 0x0200;
         /// Indicates delayed acknowledgement.
         const ACK_DELAYED = 0x0400;
-        /// A correlation ID follows SYN data.
+        /// A correlation ID payload follows SYN data.
         const CORRELATION_ID = 0x0800;
         /// Extended SYN data follows SYN data.
         const SYN_EX = 0x1000;
@@ -111,6 +111,110 @@ impl<'de> Decode<'de> for RdpUdpFecHeader {
             source_ack,
             receive_window_size,
             flags,
+        })
+    }
+}
+
+/// FEC payload metadata.
+///
+/// Defined in [\[MS-RDPEUDP\] 2.2.2.2].
+///
+/// [\[MS-RDPEUDP\] 2.2.2.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/2744a3ee-04fb-407b-a9e3-b3b2ded422b1
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RdpUdpFecPayloadHeader {
+    /// Sequence number of this coded packet.
+    pub coded_sequence_number: u32,
+    /// First source sequence number contained in the FEC payload.
+    pub source_sequence_number: u32,
+    /// Source-packet range covered by the FEC payload.
+    pub range: u8,
+    /// FEC engine index.
+    pub fec_index: u8,
+    /// Padding bytes supplied by the FEC engine.
+    pub padding: [u8; 2],
+}
+
+impl RdpUdpFecPayloadHeader {
+    const FIXED_PART_SIZE: usize = 4 /* snCoded */
+        + 4 /* snSourceStart */
+        + 1 /* uRange */
+        + 1 /* uFecIndex */
+        + 2 /* uPadding */;
+    const NAME: &'static str = "RdpUdpFecPayloadHeader";
+}
+
+impl Encode for RdpUdpFecPayloadHeader {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_fixed_part_size!(in: dst);
+        dst.write_u32_be(self.coded_sequence_number);
+        dst.write_u32_be(self.source_sequence_number);
+        dst.write_u8(self.range);
+        dst.write_u8(self.fec_index);
+        dst.write_array(self.padding);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl<'de> Decode<'de> for RdpUdpFecPayloadHeader {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+        Ok(Self {
+            coded_sequence_number: src.read_u32_be(),
+            source_sequence_number: src.read_u32_be(),
+            range: src.read_u8(),
+            fec_index: src.read_u8(),
+            padding: src.read_array(),
+        })
+    }
+}
+
+/// Length prefix for a recovered FEC payload.
+///
+/// Defined in [\[MS-RDPEUDP\] 2.2.2.3].
+///
+/// [\[MS-RDPEUDP\] 2.2.2.3]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/2744a3ee-04fb-407b-a9e3-b3b2ded422b1
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RdpUdpPayloadPrefix {
+    /// Length of the recovered payload.
+    pub payload_size: u16,
+}
+
+impl RdpUdpPayloadPrefix {
+    const FIXED_PART_SIZE: usize = 2 /* cbPayloadSize */;
+    const NAME: &'static str = "RdpUdpPayloadPrefix";
+}
+
+impl Encode for RdpUdpPayloadPrefix {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_fixed_part_size!(in: dst);
+        dst.write_u16_be(self.payload_size);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl<'de> Decode<'de> for RdpUdpPayloadPrefix {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+        Ok(Self {
+            payload_size: src.read_u16_be(),
         })
     }
 }
@@ -197,6 +301,48 @@ impl<'de> Decode<'de> for RdpUdpSynData {
     }
 }
 
+/// ACK-vector reset metadata.
+///
+/// Defined in [\[MS-RDPEUDP\] 2.2.2.6].
+///
+/// [\[MS-RDPEUDP\] 2.2.2.6]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/2744a3ee-04fb-407b-a9e3-b3b2ded422b1
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RdpUdpAckOfAckVectorHeader {
+    /// Sequence number that resets ACK-vector encoding state.
+    pub reset_sequence_number: u32,
+}
+
+impl RdpUdpAckOfAckVectorHeader {
+    const FIXED_PART_SIZE: usize = 4 /* snResetSeqNum */;
+    const NAME: &'static str = "RdpUdpAckOfAckVectorHeader";
+}
+
+impl Encode for RdpUdpAckOfAckVectorHeader {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_fixed_part_size!(in: dst);
+        dst.write_u32_be(self.reset_sequence_number);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl<'de> Decode<'de> for RdpUdpAckOfAckVectorHeader {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+        Ok(Self {
+            reset_sequence_number: src.read_u32_be(),
+        })
+    }
+}
+
 /// RDP-UDP ACK vector with DWORD alignment padding.
 ///
 /// Defined in [\[MS-RDPEUDP\] 2.2.2.7].
@@ -258,7 +404,7 @@ impl<'de> Decode<'de> for RdpUdpAckVector {
     }
 }
 
-/// Header and bytes of a reliable RDP-UDP source payload.
+/// Header of a reliable RDP-UDP source payload.
 ///
 /// Defined in [\[MS-RDPEUDP\] 2.2.2.4].
 ///
@@ -270,8 +416,6 @@ pub struct RdpUdpSourcePayload {
     pub coded_sequence_number: u32,
     /// Sequence number of the encapsulated source payload.
     pub source_sequence_number: u32,
-    /// Bytes delivered to the upper transport layer.
-    pub data: Vec<u8>,
 }
 
 impl RdpUdpSourcePayload {
@@ -281,10 +425,9 @@ impl RdpUdpSourcePayload {
 
 impl Encode for RdpUdpSourcePayload {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        ensure_size!(in: dst, size: self.size());
+        ensure_fixed_part_size!(in: dst);
         dst.write_u32_be(self.coded_sequence_number);
         dst.write_u32_be(self.source_sequence_number);
-        dst.write_slice(&self.data);
         Ok(())
     }
 
@@ -293,7 +436,7 @@ impl Encode for RdpUdpSourcePayload {
     }
 
     fn size(&self) -> usize {
-        Self::FIXED_PART_SIZE + self.data.len()
+        Self::FIXED_PART_SIZE
     }
 }
 
@@ -302,12 +445,148 @@ impl<'de> Decode<'de> for RdpUdpSourcePayload {
         ensure_fixed_part_size!(in: src);
         let coded_sequence_number = src.read_u32_be();
         let source_sequence_number = src.read_u32_be();
-        let data = src.read_remaining().to_vec();
 
         Ok(Self {
             coded_sequence_number,
             source_sequence_number,
-            data,
+        })
+    }
+}
+
+/// Correlation ID negotiated by the RDP-UDP endpoint.
+///
+/// Defined in [\[MS-RDPEUDP\] 2.2.2.8].
+///
+/// [\[MS-RDPEUDP\] 2.2.2.8]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/2744a3ee-04fb-407b-a9e3-b3b2ded422b1
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RdpUdpCorrelationId {
+    /// Connection correlation identifier in wire byte order.
+    pub correlation_id: [u8; 16],
+}
+
+impl RdpUdpCorrelationId {
+    const FIXED_PART_SIZE: usize = 16 /* uCorrelationId */ + 16 /* uReserved */;
+    const NAME: &'static str = "RdpUdpCorrelationId";
+}
+
+impl Encode for RdpUdpCorrelationId {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_fixed_part_size!(in: dst);
+        dst.write_array(self.correlation_id);
+        dst.write_array([0; 16]);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl<'de> Decode<'de> for RdpUdpCorrelationId {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+        let correlation_id = src.read_array();
+        let reserved = src.read_array::<16>();
+        if reserved != [0; 16] {
+            return Err(invalid_field_err!("uReserved", "must be all zeroes"));
+        }
+
+        Ok(Self { correlation_id })
+    }
+}
+
+bitflags! {
+    /// Extended SYN-data flags.
+    ///
+    /// Defined in [\[MS-RDPEUDP\] 2.2.2.9].
+    ///
+    /// [\[MS-RDPEUDP\] 2.2.2.9]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/2744a3ee-04fb-407b-a9e3-b3b2ded422b1
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+    pub struct RdpUdpSynDataExFlags: u16 {
+        /// The protocol version field is valid.
+        const VERSION_INFO_VALID = 0x0001;
+    }
+}
+
+/// RDP-UDP protocol version 3.
+///
+/// Version 3 uses the data transfer messages defined by MS-RDPEUDP2.
+pub const RDPUDP_PROTOCOL_VERSION_3: u16 = 0x0101;
+
+/// Extended RDP-UDP SYN parameters.
+///
+/// Defined in [\[MS-RDPEUDP\] 2.2.2.9].
+///
+/// [\[MS-RDPEUDP\] 2.2.2.9]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/2744a3ee-04fb-407b-a9e3-b3b2ded422b1
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RdpUdpSynDataEx {
+    /// Extended SYN options.
+    pub flags: RdpUdpSynDataExFlags,
+    /// Highest supported RDP-UDP protocol version.
+    pub protocol_version: u16,
+    /// Required cookie hash for protocol version 3, absent for all other versions.
+    pub cookie_hash: Option<[u8; 32]>,
+}
+
+impl RdpUdpSynDataEx {
+    const FIXED_PART_SIZE: usize = 2 /* uSynExFlags */ + 2 /* uUdpVer */;
+    const NAME: &'static str = "RdpUdpSynDataEx";
+
+    fn has_valid_cookie_hash(&self) -> bool {
+        (self.protocol_version == RDPUDP_PROTOCOL_VERSION_3) == self.cookie_hash.is_some()
+    }
+}
+
+impl Encode for RdpUdpSynDataEx {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        if !self.has_valid_cookie_hash() {
+            return Err(invalid_field_err!(
+                "cookieHash",
+                "must be present only for RDPUDP_PROTOCOL_VERSION_3"
+            ));
+        }
+
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u16_be(self.flags.bits());
+        dst.write_u16_be(self.protocol_version);
+        if let Some(cookie_hash) = self.cookie_hash {
+            dst.write_array(cookie_hash);
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.cookie_hash.map_or(0, |hash| hash.len())
+    }
+}
+
+impl<'de> Decode<'de> for RdpUdpSynDataEx {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+        let flags = RdpUdpSynDataExFlags::from_bits_truncate(src.read_u16_be());
+        let protocol_version = src.read_u16_be();
+        let cookie_hash = if protocol_version == RDPUDP_PROTOCOL_VERSION_3 {
+            ensure_size!(in: src, size: 32);
+            Some(src.read_array())
+        } else {
+            None
+        };
+
+        Ok(Self {
+            flags,
+            protocol_version,
+            cookie_hash,
         })
     }
 }
@@ -383,5 +662,86 @@ mod tests {
 
         let invalid_ack_size = [0x08, 0x01];
         assert!(ironrdp_core::decode::<RdpUdpAckVector>(&invalid_ack_size).is_err());
+    }
+
+    #[test]
+    fn supports_optional_udp_header_codecs() {
+        let fec = RdpUdpFecPayloadHeader {
+            coded_sequence_number: 1,
+            source_sequence_number: 2,
+            range: 3,
+            fec_index: 4,
+            padding: [5, 6],
+        };
+        let prefix = RdpUdpPayloadPrefix { payload_size: 1232 };
+        let ack_of_acks = RdpUdpAckOfAckVectorHeader {
+            reset_sequence_number: 7,
+        };
+        let correlation = RdpUdpCorrelationId {
+            correlation_id: [8; 16],
+        };
+        let syn_ex_v2 = RdpUdpSynDataEx {
+            flags: RdpUdpSynDataExFlags::VERSION_INFO_VALID,
+            protocol_version: 2,
+            cookie_hash: None,
+        };
+        let syn_ex_v3 = RdpUdpSynDataEx {
+            flags: RdpUdpSynDataExFlags::VERSION_INFO_VALID,
+            protocol_version: RDPUDP_PROTOCOL_VERSION_3,
+            cookie_hash: Some([9; 32]),
+        };
+
+        let encoded = ironrdp_core::encode_vec(&fec).unwrap();
+        assert_eq!(ironrdp_core::decode::<RdpUdpFecPayloadHeader>(&encoded).unwrap(), fec);
+        let encoded = ironrdp_core::encode_vec(&prefix).unwrap();
+        assert_eq!(ironrdp_core::decode::<RdpUdpPayloadPrefix>(&encoded).unwrap(), prefix);
+        let encoded = ironrdp_core::encode_vec(&ack_of_acks).unwrap();
+        assert_eq!(
+            ironrdp_core::decode::<RdpUdpAckOfAckVectorHeader>(&encoded).unwrap(),
+            ack_of_acks
+        );
+        let encoded = ironrdp_core::encode_vec(&correlation).unwrap();
+        assert_eq!(
+            ironrdp_core::decode::<RdpUdpCorrelationId>(&encoded).unwrap(),
+            correlation
+        );
+        let encoded = ironrdp_core::encode_vec(&syn_ex_v2).unwrap();
+        assert_eq!(ironrdp_core::decode::<RdpUdpSynDataEx>(&encoded).unwrap(), syn_ex_v2);
+        let encoded = ironrdp_core::encode_vec(&syn_ex_v3).unwrap();
+        assert_eq!(ironrdp_core::decode::<RdpUdpSynDataEx>(&encoded).unwrap(), syn_ex_v3);
+    }
+
+    #[test]
+    fn source_payload_header_preserves_following_payload() {
+        let encoded = [
+            0, 0, 0, 1, // snCoded
+            0, 0, 0, 2, // snSourceStart
+            3, 4, 5, // source payload
+        ];
+        let mut cursor = ReadCursor::new(&encoded);
+        assert_eq!(
+            RdpUdpSourcePayload::decode(&mut cursor).unwrap(),
+            RdpUdpSourcePayload {
+                coded_sequence_number: 1,
+                source_sequence_number: 2,
+            }
+        );
+        assert_eq!(cursor.remaining(), &[3, 4, 5]);
+    }
+
+    #[test]
+    fn rejects_invalid_optional_udp_header_fields() {
+        let correlation = [0; 32];
+        let mut invalid_correlation = correlation;
+        invalid_correlation[16] = 1;
+        assert!(ironrdp_core::decode::<RdpUdpCorrelationId>(&invalid_correlation).is_err());
+
+        let syn_ex = RdpUdpSynDataEx {
+            flags: RdpUdpSynDataExFlags::VERSION_INFO_VALID,
+            protocol_version: RDPUDP_PROTOCOL_VERSION_3,
+            cookie_hash: None,
+        };
+        assert!(ironrdp_core::encode_vec(&syn_ex).is_err());
+        assert!(ironrdp_core::decode::<RdpUdpSynDataEx>(&[0, 1, 1, 1]).is_err());
     }
 }

--- a/crates/ironrdp-pdu/src/rdp/udp.rs
+++ b/crates/ironrdp-pdu/src/rdp/udp.rs
@@ -1,0 +1,386 @@
+//! RDP-UDP reliable transport wire structures.
+//!
+//! The transport state machine lives outside this crate. These types encode the
+//! common header, connection-initialization, acknowledgement, and source-data
+//! structures used by reliable RDP-UDP versions 1 and 2.
+//!
+//! Defined in [\[MS-RDPEUDP\] 2.2.2.1, 2.2.2.4-2.2.2.7].
+//!
+//! [\[MS-RDPEUDP\] 2.2.2.1, 2.2.2.4-2.2.2.7]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/2b8a6f10-cf3a-49f6-b989-51de4d2f99e6
+
+use bitflags::bitflags;
+use ironrdp_core::{
+    Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, cast_length, ensure_fixed_part_size,
+    ensure_size, invalid_field_err,
+};
+
+/// Minimum MTU accepted during reliable RDP-UDP negotiation.
+pub const MIN_MTU: u16 = 1132;
+/// Maximum MTU accepted during reliable RDP-UDP negotiation.
+pub const MAX_MTU: u16 = 1232;
+/// Maximum encoded ACK vector size.
+pub const MAX_ACK_VECTOR_SIZE: usize = 2048;
+
+bitflags! {
+    /// Flags in an [`RdpUdpFecHeader`].
+    ///
+    /// Defined in [\[MS-RDPEUDP\] 2.2.2.1].
+    ///
+    /// [\[MS-RDPEUDP\] 2.2.2.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/2b8a6f10-cf3a-49f6-b989-51de4d2f99e6
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+    pub struct RdpUdpFlags: u16 {
+        /// Connection initialization.
+        const SYN = 0x0001;
+        /// Connection termination; currently unused by the protocol.
+        const FIN = 0x0002;
+        /// An ACK vector follows the common header.
+        const ACK = 0x0004;
+        /// A data payload follows the ACK structures.
+        const DATA = 0x0008;
+        /// The data payload is FEC encoded and follows an FEC payload header.
+        const FEC = 0x0010;
+        /// Congestion notification.
+        const CN = 0x0020;
+        /// Congestion-window reset.
+        const CWR = 0x0040;
+        /// ACK-of-ACK vector follows the ACK vector.
+        const ACK_OF_ACKS = 0x0100;
+        /// Requests lossy transport; this is unsupported by the reliable-only engine.
+        const SYN_LOSSY = 0x0200;
+        /// Indicates delayed acknowledgement.
+        const ACK_DELAYED = 0x0400;
+        /// A correlation ID follows SYN data.
+        const CORRELATION_ID = 0x0800;
+        /// Extended SYN data follows SYN data.
+        const SYN_EX = 0x1000;
+    }
+}
+
+/// Common RDP-UDP datagram header.
+///
+/// All fields are transmitted in network byte order.
+///
+/// Defined in [\[MS-RDPEUDP\] 2.2.2.1].
+///
+/// [\[MS-RDPEUDP\] 2.2.2.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/2b8a6f10-cf3a-49f6-b989-51de4d2f99e6
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RdpUdpFecHeader {
+    /// Highest source sequence number observed from the peer.
+    pub source_ack: u32,
+    /// Peer-facing receive window in datagrams.
+    pub receive_window_size: u16,
+    /// Present optional structures and connection flags.
+    pub flags: RdpUdpFlags,
+}
+
+impl RdpUdpFecHeader {
+    const FIXED_PART_SIZE: usize = 4 /* snSourceAck */ + 2 /* uReceiveWindowSize */ + 2 /* uFlags */;
+    const NAME: &'static str = "RdpUdpFecHeader";
+}
+
+impl Encode for RdpUdpFecHeader {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_fixed_part_size!(in: dst);
+        dst.write_u32_be(self.source_ack);
+        dst.write_u16_be(self.receive_window_size);
+        dst.write_u16_be(self.flags.bits());
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl<'de> Decode<'de> for RdpUdpFecHeader {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+        let source_ack = src.read_u32_be();
+        let receive_window_size = src.read_u16_be();
+        let flags = RdpUdpFlags::from_bits(src.read_u16_be())
+            .ok_or_else(|| invalid_field_err!("uFlags", "contains reserved bits"))?;
+
+        Ok(Self {
+            source_ack,
+            receive_window_size,
+            flags,
+        })
+    }
+}
+
+/// Parameters exchanged during the RDP-UDP SYN handshake.
+///
+/// Defined in [\[MS-RDPEUDP\] 2.2.2.5].
+///
+/// [\[MS-RDPEUDP\] 2.2.2.5]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/da754206-a6d0-4a5b-9ef7-4a8e5352701f
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RdpUdpSynData {
+    /// First coded and source sequence number used by the sender.
+    pub initial_sequence_number: u32,
+    /// Largest source payload the sender can transmit.
+    pub upstream_mtu: u16,
+    /// Largest source payload the sender can receive.
+    pub downstream_mtu: u16,
+}
+
+impl RdpUdpSynData {
+    const FIXED_PART_SIZE: usize = 4 /* snInitialSequenceNumber */ + 2 /* uUpStreamMtu */ + 2 /* uDownStreamMtu */;
+    const NAME: &'static str = "RdpUdpSynData";
+
+    fn has_valid_mtu(mtu: u16) -> bool {
+        (MIN_MTU..=MAX_MTU).contains(&mtu)
+    }
+}
+
+impl Encode for RdpUdpSynData {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        if !Self::has_valid_mtu(self.upstream_mtu) {
+            return Err(invalid_field_err!(
+                "uUpStreamMtu",
+                "must be between 1132 and 1232 bytes"
+            ));
+        }
+        if !Self::has_valid_mtu(self.downstream_mtu) {
+            return Err(invalid_field_err!(
+                "uDownStreamMtu",
+                "must be between 1132 and 1232 bytes"
+            ));
+        }
+        ensure_fixed_part_size!(in: dst);
+        dst.write_u32_be(self.initial_sequence_number);
+        dst.write_u16_be(self.upstream_mtu);
+        dst.write_u16_be(self.downstream_mtu);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl<'de> Decode<'de> for RdpUdpSynData {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+        let initial_sequence_number = src.read_u32_be();
+        let upstream_mtu = src.read_u16_be();
+        let downstream_mtu = src.read_u16_be();
+        if !Self::has_valid_mtu(upstream_mtu) {
+            return Err(invalid_field_err!(
+                "uUpStreamMtu",
+                "must be between 1132 and 1232 bytes"
+            ));
+        }
+        if !Self::has_valid_mtu(downstream_mtu) {
+            return Err(invalid_field_err!(
+                "uDownStreamMtu",
+                "must be between 1132 and 1232 bytes"
+            ));
+        }
+
+        Ok(Self {
+            initial_sequence_number,
+            upstream_mtu,
+            downstream_mtu,
+        })
+    }
+}
+
+/// RDP-UDP protocol version advertised in extended SYN data.
+///
+/// Defined in [\[MS-RDPEUDP\] 2.2.2.9].
+///
+/// [\[MS-RDPEUDP\] 2.2.2.9]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/2399ce13-049d-4c02-bd3c-9226b38d14f2
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[repr(u16)]
+pub enum RdpUdpProtocolVersion {
+    /// Legacy reliable RDP-UDP with 500 ms minimum retransmission timeout.
+    V1 = 0x0001,
+    /// Legacy reliable RDP-UDP with 300 ms minimum retransmission timeout.
+    V2 = 0x0002,
+    /// RDP-UDP2 transfer after RDP-UDP initialization.
+    V3 = 0x0101,
+}
+
+impl RdpUdpProtocolVersion {
+    /// Converts a protocol-version integer received on the wire.
+    pub fn from_u16(value: u16) -> Option<Self> {
+        match value {
+            0x0001 => Some(Self::V1),
+            0x0002 => Some(Self::V2),
+            0x0101 => Some(Self::V3),
+            _ => None,
+        }
+    }
+
+    #[expect(
+        clippy::as_conversions,
+        reason = "repr(u16) guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
+    /// Converts this version to its wire representation.
+    pub fn as_u16(self) -> u16 {
+        self as u16
+    }
+}
+
+/// RDP-UDP ACK vector with DWORD alignment padding.
+///
+/// Defined in [\[MS-RDPEUDP\] 2.2.2.7].
+///
+/// [\[MS-RDPEUDP\] 2.2.2.7]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/16ff7b1e-f60b-4369-b5de-d49eff260f05
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RdpUdpAckVector {
+    /// Run-length encoded ACK-vector elements.
+    pub encoded: Vec<u8>,
+}
+
+impl RdpUdpAckVector {
+    const FIXED_PART_SIZE: usize = 2 /* uAckVectorSize */;
+    const NAME: &'static str = "RdpUdpAckVector";
+
+    fn padding_size(encoded_len: usize) -> usize {
+        (4 - ((Self::FIXED_PART_SIZE + encoded_len) % 4)) % 4
+    }
+}
+
+impl Encode for RdpUdpAckVector {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        if self.encoded.len() > MAX_ACK_VECTOR_SIZE {
+            return Err(invalid_field_err!("uAckVectorSize", "must not exceed 2048 bytes"));
+        }
+
+        let encoded_len: u16 = cast_length!("uAckVectorSize", self.encoded.len())?;
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u16_be(encoded_len);
+        dst.write_slice(&self.encoded);
+        dst.write_slice(&[0; 3][..Self::padding_size(self.encoded.len())]);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.encoded.len() + Self::padding_size(self.encoded.len())
+    }
+}
+
+impl<'de> Decode<'de> for RdpUdpAckVector {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: Self::FIXED_PART_SIZE);
+        let encoded_len = usize::from(src.read_u16_be());
+        if encoded_len > MAX_ACK_VECTOR_SIZE {
+            return Err(invalid_field_err!("uAckVectorSize", "must not exceed 2048 bytes"));
+        }
+
+        let padding_size = Self::padding_size(encoded_len);
+        ensure_size!(in: src, size: encoded_len + padding_size);
+        let encoded = src.read_slice(encoded_len).to_vec();
+        if src.read_slice(padding_size).iter().any(|&byte| byte != 0) {
+            return Err(invalid_field_err!("padding", "must be zero"));
+        }
+
+        Ok(Self { encoded })
+    }
+}
+
+/// Header and bytes of a reliable RDP-UDP source payload.
+///
+/// Defined in [\[MS-RDPEUDP\] 2.2.2.4].
+///
+/// [\[MS-RDPEUDP\] 2.2.2.4]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeudp/916af634-f96b-4dcc-bfdf-5646d5dc7f7d
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RdpUdpSourcePayload {
+    /// Sequence number of this transmitted datagram.
+    pub coded_sequence_number: u32,
+    /// Sequence number of the encapsulated source payload.
+    pub source_sequence_number: u32,
+    /// Bytes delivered to the upper transport layer.
+    pub data: Vec<u8>,
+}
+
+impl RdpUdpSourcePayload {
+    const FIXED_PART_SIZE: usize = 4 /* snCoded */ + 4 /* snSourceStart */;
+    const NAME: &'static str = "RdpUdpSourcePayload";
+}
+
+impl Encode for RdpUdpSourcePayload {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u32_be(self.coded_sequence_number);
+        dst.write_u32_be(self.source_sequence_number);
+        dst.write_slice(&self.data);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.data.len()
+    }
+}
+
+impl<'de> Decode<'de> for RdpUdpSourcePayload {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+        let coded_sequence_number = src.read_u32_be();
+        let source_sequence_number = src.read_u32_be();
+        let data = src.read_remaining().to_vec();
+
+        Ok(Self {
+            coded_sequence_number,
+            source_sequence_number,
+            data,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn syn_packet_fields_use_network_byte_order() {
+        let header = RdpUdpFecHeader {
+            source_ack: 0xFFFF_FFFF,
+            receive_window_size: 1024,
+            flags: RdpUdpFlags::SYN | RdpUdpFlags::SYN_EX,
+        };
+        let encoded = ironrdp_core::encode_vec(&header).unwrap();
+        assert_eq!(encoded.as_slice(), &[0xFF, 0xFF, 0xFF, 0xFF, 0x04, 0x00, 0x10, 0x01]);
+        assert_eq!(ironrdp_core::decode::<RdpUdpFecHeader>(&encoded).unwrap(), header);
+    }
+
+    #[test]
+    fn ack_vector_round_trip_and_padding() {
+        let vector = RdpUdpAckVector { encoded: vec![0x04] };
+        let encoded = ironrdp_core::encode_vec(&vector).unwrap();
+        assert_eq!(encoded.as_slice(), &[0x00, 0x01, 0x04, 0x00]);
+        assert_eq!(ironrdp_core::decode::<RdpUdpAckVector>(&encoded).unwrap(), vector);
+    }
+
+    #[test]
+    fn rejects_invalid_mtu_and_ack_vector_size() {
+        let invalid_mtu = [0, 0, 0, 1, 0x04, 0x6B, 0x04, 0xD0];
+        assert!(ironrdp_core::decode::<RdpUdpSynData>(&invalid_mtu).is_err());
+
+        let invalid_ack_size = [0x08, 0x01];
+        assert!(ironrdp_core::decode::<RdpUdpAckVector>(&invalid_ack_size).is_err());
+    }
+}


### PR DESCRIPTION
Add RDP-UDP and RDPEMT wire codecs for the transport foundation.

Support FEC, ACK-of-ACK, correlation ID, and extended SYN headers while preserving source-payload framing boundaries and rejecting invalid RDPEMT create-PDU subheaders.