### PR TITLE
feat(dvc)!: add Soft-Sync PDU support

### DIFF
--- a/crates/ironrdp-dvc/src/client.rs
+++ b/crates/ironrdp-dvc/src/client.rs
@@ -293,12 +293,15 @@ impl DrdynvcClient {
         Some(SvcMessage::from(DrdynvcClientPdu::Close(ClosePdu::new(channel_id))))
     }
 
-    /// Enables a multitransport tunnel for a future Soft-Sync request.
+    /// Marks a multitransport tunnel as ready for a future Soft-Sync request.
+    ///
+    /// Call this only after the tunnel's Initiate Multitransport Response has
+    /// been sent successfully.
     pub fn enable_soft_sync_tunnel(&mut self, tunnel_type: SoftSyncTunnelType) {
         self.available_tunnels.insert(tunnel_type);
     }
 
-    /// Returns whether a Soft-Sync response has been encoded but not yet sent on TCP.
+    /// Returns whether a Soft-Sync response has been queued but not yet sent on TCP.
     pub fn has_pending_soft_sync_response(&self) -> bool {
         self.pending_tunnel_channels.is_some()
     }
@@ -363,13 +366,22 @@ impl DrdynvcClient {
         let mut tunnels_to_switch = Vec::new();
         for list in request.channel_lists() {
             if !self.available_tunnels.contains(&list.tunnel_type()) {
-                continue;
+                return Err(pdu_other_err!("soft-sync request selected an unavailable tunnel"));
             }
+
+            let mut selected_channels = Vec::new();
             for channel_id in list.channel_ids() {
                 if self.dynamic_channels.get_by_channel_id(*channel_id).is_none() {
-                    return Err(pdu_other_err!("Soft-Sync request contains an unknown dynamic channel"));
+                    selected_channels.clear();
+                    break;
                 }
-                tunnel_channels.insert(*channel_id, list.tunnel_type());
+                selected_channels.push(*channel_id);
+            }
+            if selected_channels.is_empty() && !list.channel_ids().is_empty() {
+                continue;
+            }
+            for channel_id in selected_channels {
+                tunnel_channels.insert(channel_id, list.tunnel_type());
             }
             tunnels_to_switch.push(list.tunnel_type());
         }
@@ -619,5 +631,57 @@ mod tests {
         assert!(channels.has_listener_by_type_id(TypeId::of::<TestDvc>()));
         assert!(channels.try_create_channel(&"test".to_owned(), 1).is_some());
         assert!(!channels.has_listener_by_type_id(TypeId::of::<TestDvc>()));
+    }
+
+    fn add_active_channel(client: &mut DrdynvcClient, channel_id: DynamicChannelId) {
+        client
+            .dynamic_channels
+            .active_channels
+            .insert(channel_id, DynamicVirtualChannel::from_boxed(Box::new(TestDvc)));
+    }
+
+    #[test]
+    fn soft_sync_routes_a_selected_channel_after_response_is_sent() {
+        let mut client = DrdynvcClient::new();
+        add_active_channel(&mut client, 1);
+        client.enable_soft_sync_tunnel(SoftSyncTunnelType::RELIABLE_UDP);
+
+        let request = crate::pdu::SoftSyncRequestPdu::new(alloc::vec![crate::pdu::SoftSyncChannelList::new(
+            SoftSyncTunnelType::RELIABLE_UDP,
+            alloc::vec![1],
+        )]);
+        client.process_soft_sync_request(request).unwrap();
+
+        assert!(client.has_pending_soft_sync_response());
+        assert_eq!(client.tunnel_for_channel(1), None);
+
+        client.complete_soft_sync_response().unwrap();
+
+        assert!(client.soft_sync_complete());
+        assert_eq!(client.tunnel_for_channel(1), Some(SoftSyncTunnelType::RELIABLE_UDP));
+
+        let tcp_data = ironrdp_core::encode_vec(&DrdynvcServerPdu::Data(DrdynvcDataPdu::Data(
+            crate::pdu::DataPdu::new(1, Vec::new()),
+        )))
+        .unwrap();
+        assert!(client.process(&tcp_data).is_err());
+
+        client.close_channel(1).unwrap();
+        assert_eq!(client.tunnel_for_channel(1), None);
+    }
+
+    #[test]
+    fn soft_sync_rejects_an_unavailable_tunnel() {
+        let mut client = DrdynvcClient::new();
+        add_active_channel(&mut client, 1);
+
+        let request = crate::pdu::SoftSyncRequestPdu::new(alloc::vec![crate::pdu::SoftSyncChannelList::new(
+            SoftSyncTunnelType::RELIABLE_UDP,
+            alloc::vec![1],
+        )]);
+
+        assert!(client.process_soft_sync_request(request).is_err());
+        assert!(!client.has_pending_soft_sync_response());
+        assert!(!client.soft_sync_complete());
     }
 }

--- a/crates/ironrdp-dvc/src/client.rs
+++ b/crates/ironrdp-dvc/src/client.rs
@@ -129,7 +129,6 @@ pub struct DrdynvcClient {
     /// Indicates whether the capability request/response handshake has been completed.
     cap_handshake_done: bool,
     available_tunnels: BTreeSet<SoftSyncTunnelType>,
-    pending_tunnel_channels: Option<BTreeMap<DynamicChannelId, SoftSyncTunnelType>>,
     tunnel_channels: BTreeMap<DynamicChannelId, SoftSyncTunnelType>,
     soft_sync_complete: bool,
 }
@@ -157,7 +156,6 @@ impl DrdynvcClient {
             dynamic_channels: DynamicChannelSet::new(),
             cap_handshake_done: false,
             available_tunnels: BTreeSet::new(),
-            pending_tunnel_channels: None,
             tunnel_channels: BTreeMap::new(),
             soft_sync_complete: false,
         }
@@ -287,9 +285,6 @@ impl DrdynvcClient {
     pub fn close_channel(&mut self, channel_id: u32) -> Option<SvcMessage> {
         self.dynamic_channels.remove_by_channel_id(channel_id)?;
         self.tunnel_channels.remove(&channel_id);
-        if let Some(channels) = self.pending_tunnel_channels.as_mut() {
-            channels.remove(&channel_id);
-        }
         Some(SvcMessage::from(DrdynvcClientPdu::Close(ClosePdu::new(channel_id))))
     }
 
@@ -301,27 +296,8 @@ impl DrdynvcClient {
         self.available_tunnels.insert(tunnel_type);
     }
 
-    /// Returns whether a Soft-Sync response has been queued but not yet sent on TCP.
-    pub fn has_pending_soft_sync_response(&self) -> bool {
-        self.pending_tunnel_channels.is_some()
-    }
-
-    /// Activates the routing selected by the most recent Soft-Sync response.
-    ///
-    /// Call this only after the response has been successfully written over the
-    /// DRDYNVC static virtual channel.
-    pub fn complete_soft_sync_response(&mut self) -> PduResult<()> {
-        let pending = self
-            .pending_tunnel_channels
-            .take()
-            .ok_or_else(|| pdu_other_err!("no Soft-Sync response is pending"))?;
-        self.tunnel_channels = pending;
-        self.soft_sync_complete = true;
-        Ok(())
-    }
-
-    /// Returns whether the Soft-Sync response has been sent over TCP and
-    /// multitransport DVC data can be exchanged.
+    /// Returns whether the client has produced its Soft-Sync response and activated
+    /// its local routing state.
     pub const fn soft_sync_complete(&self) -> bool {
         self.soft_sync_complete
     }
@@ -358,7 +334,7 @@ impl DrdynvcClient {
     }
 
     fn process_soft_sync_request(&mut self, request: crate::pdu::SoftSyncRequestPdu) -> PduResult<SvcMessage> {
-        if self.pending_tunnel_channels.is_some() || self.soft_sync_complete {
+        if self.soft_sync_complete {
             return Err(pdu_other_err!("received duplicate Soft-Sync request"));
         }
 
@@ -386,10 +362,12 @@ impl DrdynvcClient {
             tunnels_to_switch.push(list.tunnel_type());
         }
 
-        self.pending_tunnel_channels = Some(tunnel_channels);
-        Ok(SvcMessage::from(DrdynvcClientPdu::SoftSyncResponse(
-            SoftSyncResponsePdu::new(tunnels_to_switch),
-        )))
+        let response = SvcMessage::from(DrdynvcClientPdu::SoftSyncResponse(SoftSyncResponsePdu::new(
+            tunnels_to_switch,
+        )));
+        self.tunnel_channels = tunnel_channels;
+        self.soft_sync_complete = true;
+        Ok(response)
     }
 }
 
@@ -641,10 +619,16 @@ mod tests {
     }
 
     #[test]
-    fn soft_sync_routes_a_selected_channel_after_response_is_sent() {
+    fn soft_sync_rejects_tunnel_data_until_a_response_is_generated() {
         let mut client = DrdynvcClient::new();
         add_active_channel(&mut client, 1);
         client.enable_soft_sync_tunnel(SoftSyncTunnelType::RELIABLE_UDP);
+
+        let tunnel_data = ironrdp_core::encode_vec(&DrdynvcServerPdu::Data(DrdynvcDataPdu::Data(
+            crate::pdu::DataPdu::new(1, Vec::new()),
+        )))
+        .unwrap();
+        assert!(client.process_tunnel(&tunnel_data).is_err());
 
         let request = crate::pdu::SoftSyncRequestPdu::new(alloc::vec![crate::pdu::SoftSyncChannelList::new(
             SoftSyncTunnelType::RELIABLE_UDP,
@@ -652,19 +636,11 @@ mod tests {
         )]);
         client.process_soft_sync_request(request).unwrap();
 
-        assert!(client.has_pending_soft_sync_response());
-        assert_eq!(client.tunnel_for_channel(1), None);
-
-        client.complete_soft_sync_response().unwrap();
-
         assert!(client.soft_sync_complete());
         assert_eq!(client.tunnel_for_channel(1), Some(SoftSyncTunnelType::RELIABLE_UDP));
+        assert!(client.process_tunnel(&tunnel_data).is_ok());
 
-        let tcp_data = ironrdp_core::encode_vec(&DrdynvcServerPdu::Data(DrdynvcDataPdu::Data(
-            crate::pdu::DataPdu::new(1, Vec::new()),
-        )))
-        .unwrap();
-        assert!(client.process(&tcp_data).is_err());
+        assert!(client.process(&tunnel_data).is_err());
 
         client.close_channel(1).unwrap();
         assert_eq!(client.tunnel_for_channel(1), None);
@@ -681,7 +657,6 @@ mod tests {
         )]);
 
         assert!(client.process_soft_sync_request(request).is_err());
-        assert!(!client.has_pending_soft_sync_response());
         assert!(!client.soft_sync_complete());
     }
 }

--- a/crates/ironrdp-dvc/src/client.rs
+++ b/crates/ironrdp-dvc/src/client.rs
@@ -1,4 +1,5 @@
 use alloc::boxed::Box;
+use alloc::collections::BTreeSet;
 use alloc::collections::btree_map::BTreeMap;
 use alloc::vec::Vec;
 use core::any::TypeId;
@@ -15,7 +16,7 @@ use tracing::debug;
 
 use crate::pdu::{
     CapabilitiesResponsePdu, CapsVersion, ClosePdu, CreateResponsePdu, CreationStatus, DrdynvcClientPdu,
-    DrdynvcDataPdu, DrdynvcServerPdu,
+    DrdynvcDataPdu, DrdynvcServerPdu, SoftSyncResponsePdu, SoftSyncTunnelType,
 };
 use crate::{
     DvcMessage, DvcProcessor, DynamicChannelId, DynamicChannelMut, DynamicChannelName, DynamicChannelRef,
@@ -127,6 +128,10 @@ pub struct DrdynvcClient {
     dynamic_channels: DynamicChannelSet,
     /// Indicates whether the capability request/response handshake has been completed.
     cap_handshake_done: bool,
+    available_tunnels: BTreeSet<SoftSyncTunnelType>,
+    pending_tunnel_channels: Option<BTreeMap<DynamicChannelId, SoftSyncTunnelType>>,
+    tunnel_channels: BTreeMap<DynamicChannelId, SoftSyncTunnelType>,
+    soft_sync_complete: bool,
 }
 
 impl fmt::Debug for DrdynvcClient {
@@ -151,6 +156,10 @@ impl DrdynvcClient {
         Self {
             dynamic_channels: DynamicChannelSet::new(),
             cap_handshake_done: false,
+            available_tunnels: BTreeSet::new(),
+            pending_tunnel_channels: None,
+            tunnel_channels: BTreeMap::new(),
+            soft_sync_complete: false,
         }
     }
 
@@ -277,7 +286,98 @@ impl DrdynvcClient {
 
     pub fn close_channel(&mut self, channel_id: u32) -> Option<SvcMessage> {
         self.dynamic_channels.remove_by_channel_id(channel_id)?;
+        self.tunnel_channels.remove(&channel_id);
+        if let Some(channels) = self.pending_tunnel_channels.as_mut() {
+            channels.remove(&channel_id);
+        }
         Some(SvcMessage::from(DrdynvcClientPdu::Close(ClosePdu::new(channel_id))))
+    }
+
+    /// Enables a multitransport tunnel for a future Soft-Sync request.
+    pub fn enable_soft_sync_tunnel(&mut self, tunnel_type: SoftSyncTunnelType) {
+        self.available_tunnels.insert(tunnel_type);
+    }
+
+    /// Returns whether a Soft-Sync response has been encoded but not yet sent on TCP.
+    pub fn has_pending_soft_sync_response(&self) -> bool {
+        self.pending_tunnel_channels.is_some()
+    }
+
+    /// Activates the routing selected by the most recent Soft-Sync response.
+    ///
+    /// Call this only after the response has been successfully written over the
+    /// DRDYNVC static virtual channel.
+    pub fn complete_soft_sync_response(&mut self) -> PduResult<()> {
+        let pending = self
+            .pending_tunnel_channels
+            .take()
+            .ok_or_else(|| pdu_other_err!("no Soft-Sync response is pending"))?;
+        self.tunnel_channels = pending;
+        self.soft_sync_complete = true;
+        Ok(())
+    }
+
+    /// Returns whether the Soft-Sync response has been sent over TCP and
+    /// multitransport DVC data can be exchanged.
+    pub const fn soft_sync_complete(&self) -> bool {
+        self.soft_sync_complete
+    }
+
+    /// Returns the tunnel selected for client-to-server messages on `channel_id`.
+    pub fn tunnel_for_channel(&self, channel_id: DynamicChannelId) -> Option<SoftSyncTunnelType> {
+        self.tunnel_channels.get(&channel_id).copied()
+    }
+
+    /// Processes raw DRDYNVC data received through an established multitransport tunnel.
+    pub fn process_tunnel(&mut self, payload: &[u8]) -> PduResult<Vec<SvcMessage>> {
+        let pdu = decode_dvc_message(payload).map_err(|e| decode_err!(e))?;
+        let DrdynvcServerPdu::Data(data) = pdu else {
+            return Err(pdu_other_err!("only DVC data is permitted on a multitransport tunnel"));
+        };
+        let channel_id = data.channel_id();
+        if !self.tunnel_channels.contains_key(&channel_id) {
+            return Err(pdu_other_err!(
+                "received tunneled data for a channel not selected by Soft-Sync"
+            ));
+        }
+        self.process_data(data)
+    }
+
+    fn process_data(&mut self, data: DrdynvcDataPdu) -> PduResult<Vec<SvcMessage>> {
+        let channel_id = data.channel_id();
+        let messages = self
+            .dynamic_channels
+            .get_by_channel_id_mut(channel_id)
+            .ok_or_else(|| pdu_other_err!("access to non existing DVC channel"))?
+            .process(data)?;
+
+        encode_dvc_messages(channel_id, messages, ChannelFlags::empty()).map_err(|e| encode_err!(e))
+    }
+
+    fn process_soft_sync_request(&mut self, request: crate::pdu::SoftSyncRequestPdu) -> PduResult<SvcMessage> {
+        if self.pending_tunnel_channels.is_some() || self.soft_sync_complete {
+            return Err(pdu_other_err!("received duplicate Soft-Sync request"));
+        }
+
+        let mut tunnel_channels = BTreeMap::new();
+        let mut tunnels_to_switch = Vec::new();
+        for list in request.channel_lists() {
+            if !self.available_tunnels.contains(&list.tunnel_type()) {
+                continue;
+            }
+            for channel_id in list.channel_ids() {
+                if self.dynamic_channels.get_by_channel_id(*channel_id).is_none() {
+                    return Err(pdu_other_err!("Soft-Sync request contains an unknown dynamic channel"));
+                }
+                tunnel_channels.insert(*channel_id, list.tunnel_type());
+            }
+            tunnels_to_switch.push(list.tunnel_type());
+        }
+
+        self.pending_tunnel_channels = Some(tunnel_channels);
+        Ok(SvcMessage::from(DrdynvcClientPdu::SoftSyncResponse(
+            SoftSyncResponsePdu::new(tunnels_to_switch),
+        )))
     }
 }
 
@@ -359,17 +459,14 @@ impl SvcProcessor for DrdynvcClient {
                 }
             }
             DrdynvcServerPdu::Data(data) => {
-                let channel_id = data.channel_id();
-
-                let messages = self
-                    .dynamic_channels
-                    .get_by_channel_id_mut(channel_id)
-                    .ok_or_else(|| pdu_other_err!("access to non existing DVC channel"))?
-                    .process(data)?;
-
-                responses.extend(
-                    encode_dvc_messages(channel_id, messages, ChannelFlags::empty()).map_err(|e| encode_err!(e))?,
-                );
+                if self.tunnel_channels.contains_key(&data.channel_id()) {
+                    return Err(pdu_other_err!("received TCP data for a channel selected by Soft-Sync"));
+                }
+                responses.extend(self.process_data(data)?);
+            }
+            DrdynvcServerPdu::SoftSyncRequest(request) => {
+                debug!("Got DVC Soft-Sync Request PDU: {request:?}");
+                responses.push(self.process_soft_sync_request(request)?);
             }
         }
 

--- a/crates/ironrdp-dvc/src/pdu.rs
+++ b/crates/ironrdp-dvc/src/pdu.rs
@@ -14,6 +14,7 @@ use ironrdp_svc::SvcEncode;
 use crate::{DynamicChannelId, String, Vec};
 
 /// Dynamic Virtual Channel PDU's that are sent by both client and server.
+#[non_exhaustive]
 #[derive(Debug, PartialEq)]
 pub enum DrdynvcDataPdu {
     DataFirst(DataFirstPdu),
@@ -56,6 +57,7 @@ impl Encode for DrdynvcDataPdu {
 }
 
 /// Dynamic Virtual Channel PDU's that are sent by the client.
+#[non_exhaustive]
 #[derive(Debug, PartialEq)]
 pub enum DrdynvcClientPdu {
     Capabilities(CapabilitiesResponsePdu),
@@ -115,6 +117,7 @@ impl Decode<'_> for DrdynvcClientPdu {
 }
 
 /// Dynamic Virtual Channel PDU's that are sent by the server.
+#[non_exhaustive]
 #[derive(Debug, PartialEq)]
 pub enum DrdynvcServerPdu {
     Capabilities(CapabilitiesRequestPdu),
@@ -185,33 +188,24 @@ impl SvcEncode for DrdynvcServerPdu {}
 /// [\[MS-RDPEDYC\] 2.2.5.1.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpedyc/20a29627-6966-4085-b5f1-00112a6114e3
 /// [\[MS-RDPEDYC\] 2.2.5.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpedyc/2f9c83aa-8c82-4d85-a7fe-b4c6301a9f90
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-#[repr(u32)]
-pub enum SoftSyncTunnelType {
+pub struct SoftSyncTunnelType(u32);
+
+impl SoftSyncTunnelType {
     /// Reliable RDP-UDP FEC tunnel.
-    ReliableUdp = 0x0000_0001,
+    pub const RELIABLE_UDP: Self = Self(0x0000_0001);
     /// Lossy RDP-UDP FEC tunnel.
-    LossyUdp = 0x0000_0003,
+    pub const LOSSY_UDP: Self = Self(0x0000_0003);
 }
 
-impl TryFrom<u32> for SoftSyncTunnelType {
-    type Error = DecodeError;
-
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
-        match value {
-            0x0000_0001 => Ok(Self::ReliableUdp),
-            0x0000_0003 => Ok(Self::LossyUdp),
-            _ => Err(invalid_field_err!("TunnelType", "unsupported tunnel type")),
-        }
+impl From<u32> for SoftSyncTunnelType {
+    fn from(value: u32) -> Self {
+        Self(value)
     }
 }
 
 impl From<SoftSyncTunnelType> for u32 {
-    #[expect(
-        clippy::as_conversions,
-        reason = "repr(u32) guarantees discriminant layout, and as is the only way to cast enum -> primitive"
-    )]
     fn from(value: SoftSyncTunnelType) -> Self {
-        value as u32
+        value.0
     }
 }
 
@@ -259,11 +253,8 @@ impl SoftSyncChannelList {
     fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
         ensure_size!(in: src, size: Self::FIXED_PART_SIZE);
 
-        let tunnel_type = SoftSyncTunnelType::try_from(src.read_u32())?;
+        let tunnel_type = SoftSyncTunnelType::from(src.read_u32());
         let number_of_dvcs = usize::from(src.read_u16());
-        if number_of_dvcs == 0 {
-            return Err(invalid_field_err!("NumberOfDVCs", "must be nonzero"));
-        }
         ensure_size!(in: src, size: number_of_dvcs * 4 /* ListOfDVCIds */);
 
         let mut channel_ids = Vec::with_capacity(number_of_dvcs);
@@ -295,7 +286,6 @@ pub struct SoftSyncRequestPdu {
 impl SoftSyncRequestPdu {
     const TCP_FLUSHED: u16 = 0x0001;
     const CHANNEL_LIST_PRESENT: u16 = 0x0002;
-    const FLAGS_MASK: u16 = Self::TCP_FLUSHED | Self::CHANNEL_LIST_PRESENT;
     const LENGTH_FIXED_PART_SIZE: usize = 4 /* Length */ + 2 /* Flags */ + 2 /* NumberOfTunnels */;
     const FIXED_PART_SIZE: usize = Header::FIXED_PART_SIZE + 1 /* Pad */ + Self::LENGTH_FIXED_PART_SIZE;
 
@@ -324,9 +314,6 @@ impl SoftSyncRequestPdu {
         let mut channel_ids = BTreeSet::new();
 
         for list in &self.channel_lists {
-            if list.channel_ids.is_empty() {
-                return Err(invalid_field_err!("NumberOfDVCs", "must be nonzero"));
-            }
             let _: u16 = cast_length!("NumberOfDVCs", list.channel_ids.len())?;
             if !tunnel_types.insert(list.tunnel_type) {
                 return Err(invalid_field_err!(
@@ -369,19 +356,15 @@ impl SoftSyncRequestPdu {
         }
 
         let flags = src.read_u16();
-        if flags & !Self::FLAGS_MASK != 0 {
-            return Err(invalid_field_err!("Flags", "contains unsupported flags"));
-        }
         if flags & Self::TCP_FLUSHED == 0 {
             return Err(invalid_field_err!("Flags", "SOFT_SYNC_TCP_FLUSHED must be set"));
         }
 
         let number_of_tunnels = usize::from(src.read_u16());
-        let channel_list_present = flags & Self::CHANNEL_LIST_PRESENT != 0;
-        if channel_list_present != (number_of_tunnels != 0) {
+        if number_of_tunnels > src.len() / SoftSyncChannelList::FIXED_PART_SIZE {
             return Err(invalid_field_err!(
-                "Flags",
-                "SOFT_SYNC_CHANNEL_LIST_PRESENT must agree with NumberOfTunnels"
+                "NumberOfTunnels",
+                "does not fit in the remaining bytes"
             ));
         }
 
@@ -491,12 +474,19 @@ impl SoftSyncResponsePdu {
         }
         let number_of_tunnels =
             usize::try_from(src.read_u32()).map_err(|_| invalid_field_err!("NumberOfTunnels", "is too large"))?;
-        ensure_size!(in: src, size: number_of_tunnels * 4 /* TunnelsToSwitch */);
+        if number_of_tunnels > src.len() / 4
+        /* TunnelsToSwitch */
+        {
+            return Err(invalid_field_err!(
+                "NumberOfTunnels",
+                "does not fit in the remaining bytes"
+            ));
+        }
 
         let mut tunnels_to_switch = Vec::with_capacity(number_of_tunnels);
         let mut tunnels = BTreeSet::new();
         for _ in 0..number_of_tunnels {
-            let tunnel = SoftSyncTunnelType::try_from(src.read_u32())?;
+            let tunnel = SoftSyncTunnelType::from(src.read_u32());
             if !tunnels.insert(tunnel) {
                 return Err(invalid_field_err!(
                     "TunnelsToSwitch",

--- a/crates/ironrdp-dvc/src/pdu.rs
+++ b/crates/ironrdp-dvc/src/pdu.rs
@@ -1,3 +1,4 @@
+use alloc::collections::BTreeSet;
 use alloc::format;
 use core::fmt;
 
@@ -61,6 +62,7 @@ pub enum DrdynvcClientPdu {
     Create(CreateResponsePdu),
     Close(ClosePdu),
     Data(DrdynvcDataPdu),
+    SoftSyncResponse(SoftSyncResponsePdu),
 }
 
 impl Encode for DrdynvcClientPdu {
@@ -70,6 +72,7 @@ impl Encode for DrdynvcClientPdu {
             DrdynvcClientPdu::Create(pdu) => pdu.encode(dst),
             DrdynvcClientPdu::Data(pdu) => pdu.encode(dst),
             DrdynvcClientPdu::Close(pdu) => pdu.encode(dst),
+            DrdynvcClientPdu::SoftSyncResponse(pdu) => pdu.encode(dst),
         }
     }
 
@@ -79,6 +82,7 @@ impl Encode for DrdynvcClientPdu {
             DrdynvcClientPdu::Create(_) => CreateResponsePdu::name(),
             DrdynvcClientPdu::Data(pdu) => pdu.name(),
             DrdynvcClientPdu::Close(_) => ClosePdu::name(),
+            DrdynvcClientPdu::SoftSyncResponse(_) => SoftSyncResponsePdu::name(),
         }
     }
 
@@ -88,6 +92,7 @@ impl Encode for DrdynvcClientPdu {
             DrdynvcClientPdu::Create(pdu) => pdu.size(),
             DrdynvcClientPdu::Data(pdu) => pdu.size(),
             DrdynvcClientPdu::Close(pdu) => pdu.size(),
+            DrdynvcClientPdu::SoftSyncResponse(pdu) => pdu.size(),
         }
     }
 }
@@ -103,6 +108,7 @@ impl Decode<'_> for DrdynvcClientPdu {
             Cmd::Data => Ok(Self::Data(DrdynvcDataPdu::Data(DataPdu::decode(header, src)?))),
             Cmd::Close => Ok(Self::Close(ClosePdu::decode(header, src)?)),
             Cmd::Capability => Ok(Self::Capabilities(CapabilitiesResponsePdu::decode(header, src)?)),
+            Cmd::SoftSyncResponse => Ok(Self::SoftSyncResponse(SoftSyncResponsePdu::decode(header, src)?)),
             _ => Err(unsupported_value_err!("Cmd", header.cmd.into())),
         }
     }
@@ -115,6 +121,7 @@ pub enum DrdynvcServerPdu {
     Create(CreateRequestPdu),
     Close(ClosePdu),
     Data(DrdynvcDataPdu),
+    SoftSyncRequest(SoftSyncRequestPdu),
 }
 
 impl Encode for DrdynvcServerPdu {
@@ -124,6 +131,7 @@ impl Encode for DrdynvcServerPdu {
             DrdynvcServerPdu::Capabilities(pdu) => pdu.encode(dst),
             DrdynvcServerPdu::Create(pdu) => pdu.encode(dst),
             DrdynvcServerPdu::Close(pdu) => pdu.encode(dst),
+            DrdynvcServerPdu::SoftSyncRequest(pdu) => pdu.encode(dst),
         }
     }
 
@@ -133,6 +141,7 @@ impl Encode for DrdynvcServerPdu {
             DrdynvcServerPdu::Capabilities(pdu) => pdu.name(),
             DrdynvcServerPdu::Create(_) => CreateRequestPdu::name(),
             DrdynvcServerPdu::Close(_) => ClosePdu::name(),
+            DrdynvcServerPdu::SoftSyncRequest(_) => SoftSyncRequestPdu::name(),
         }
     }
 
@@ -142,6 +151,7 @@ impl Encode for DrdynvcServerPdu {
             DrdynvcServerPdu::Capabilities(pdu) => pdu.size(),
             DrdynvcServerPdu::Create(pdu) => pdu.size(),
             DrdynvcServerPdu::Close(pdu) => pdu.size(),
+            DrdynvcServerPdu::SoftSyncRequest(pdu) => pdu.size(),
         }
     }
 }
@@ -157,6 +167,7 @@ impl Decode<'_> for DrdynvcServerPdu {
             Cmd::Data => Ok(Self::Data(DrdynvcDataPdu::Data(DataPdu::decode(header, src)?))),
             Cmd::Close => Ok(Self::Close(ClosePdu::decode(header, src)?)),
             Cmd::Capability => Ok(Self::Capabilities(CapabilitiesRequestPdu::decode(header, src)?)),
+            Cmd::SoftSyncRequest => Ok(Self::SoftSyncRequest(SoftSyncRequestPdu::decode(header, src)?)),
             _ => Err(unsupported_value_err!("Cmd", header.cmd.into())),
         }
     }
@@ -166,6 +177,366 @@ impl Decode<'_> for DrdynvcServerPdu {
 impl SvcEncode for DrdynvcDataPdu {}
 impl SvcEncode for DrdynvcClientPdu {}
 impl SvcEncode for DrdynvcServerPdu {}
+
+/// A multitransport tunnel used for Soft-Sync.
+///
+/// Defined in [\[MS-RDPEDYC\] 2.2.5.1.1] and [\[MS-RDPEDYC\] 2.2.5.2].
+///
+/// [\[MS-RDPEDYC\] 2.2.5.1.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpedyc/20a29627-6966-4085-b5f1-00112a6114e3
+/// [\[MS-RDPEDYC\] 2.2.5.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpedyc/2f9c83aa-8c82-4d85-a7fe-b4c6301a9f90
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum SoftSyncTunnelType {
+    /// Reliable RDP-UDP FEC tunnel.
+    ReliableUdp = 0x0000_0001,
+    /// Lossy RDP-UDP FEC tunnel.
+    LossyUdp = 0x0000_0003,
+}
+
+impl TryFrom<u32> for SoftSyncTunnelType {
+    type Error = DecodeError;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            0x0000_0001 => Ok(Self::ReliableUdp),
+            0x0000_0003 => Ok(Self::LossyUdp),
+            _ => Err(invalid_field_err!("TunnelType", "unsupported tunnel type")),
+        }
+    }
+}
+
+impl From<SoftSyncTunnelType> for u32 {
+    #[expect(
+        clippy::as_conversions,
+        reason = "repr(u32) guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
+    fn from(value: SoftSyncTunnelType) -> Self {
+        value as u32
+    }
+}
+
+/// A group of dynamic virtual channels sent over one Soft-Sync tunnel.
+///
+/// Defined in [\[MS-RDPEDYC\] 2.2.5.1.1].
+///
+/// [\[MS-RDPEDYC\] 2.2.5.1.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpedyc/20a29627-6966-4085-b5f1-00112a6114e3
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SoftSyncChannelList {
+    tunnel_type: SoftSyncTunnelType,
+    channel_ids: Vec<DynamicChannelId>,
+}
+
+impl SoftSyncChannelList {
+    const FIXED_PART_SIZE: usize = 4 /* TunnelType */ + 2 /* NumberOfDVCs */;
+
+    /// Creates a channel list for a multitransport tunnel.
+    pub fn new(tunnel_type: SoftSyncTunnelType, channel_ids: Vec<DynamicChannelId>) -> Self {
+        Self {
+            tunnel_type,
+            channel_ids,
+        }
+    }
+
+    /// Returns the tunnel selected for these channels.
+    pub fn tunnel_type(&self) -> SoftSyncTunnelType {
+        self.tunnel_type
+    }
+
+    /// Returns the dynamic virtual channels assigned to this tunnel.
+    pub fn channel_ids(&self) -> &[DynamicChannelId] {
+        &self.channel_ids
+    }
+
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        dst.write_u32(self.tunnel_type.into());
+        dst.write_u16(cast_length!("NumberOfDVCs", self.channel_ids.len())?);
+        for channel_id in &self.channel_ids {
+            dst.write_u32(*channel_id);
+        }
+        Ok(())
+    }
+
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: Self::FIXED_PART_SIZE);
+
+        let tunnel_type = SoftSyncTunnelType::try_from(src.read_u32())?;
+        let number_of_dvcs = usize::from(src.read_u16());
+        if number_of_dvcs == 0 {
+            return Err(invalid_field_err!("NumberOfDVCs", "must be nonzero"));
+        }
+        ensure_size!(in: src, size: number_of_dvcs * 4 /* ListOfDVCIds */);
+
+        let mut channel_ids = Vec::with_capacity(number_of_dvcs);
+        for _ in 0..number_of_dvcs {
+            channel_ids.push(src.read_u32());
+        }
+
+        Ok(Self {
+            tunnel_type,
+            channel_ids,
+        })
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.channel_ids.len() * 4 /* ListOfDVCIds */
+    }
+}
+
+/// Soft-Sync request sent by the DVC server manager.
+///
+/// Defined in [\[MS-RDPEDYC\] 2.2.5.1].
+///
+/// [\[MS-RDPEDYC\] 2.2.5.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpedyc/98c6b432-842d-4d43-b1fb-ae02f945feee
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SoftSyncRequestPdu {
+    channel_lists: Vec<SoftSyncChannelList>,
+}
+
+impl SoftSyncRequestPdu {
+    const TCP_FLUSHED: u16 = 0x0001;
+    const CHANNEL_LIST_PRESENT: u16 = 0x0002;
+    const FLAGS_MASK: u16 = Self::TCP_FLUSHED | Self::CHANNEL_LIST_PRESENT;
+    const LENGTH_FIXED_PART_SIZE: usize = 4 /* Length */ + 2 /* Flags */ + 2 /* NumberOfTunnels */;
+    const FIXED_PART_SIZE: usize = Header::FIXED_PART_SIZE + 1 /* Pad */ + Self::LENGTH_FIXED_PART_SIZE;
+
+    /// Creates a Soft-Sync request for the supplied tunnel/channel assignments.
+    pub fn new(channel_lists: Vec<SoftSyncChannelList>) -> Self {
+        Self { channel_lists }
+    }
+
+    /// Returns the tunnel/channel assignments announced by this request.
+    pub fn channel_lists(&self) -> &[SoftSyncChannelList] {
+        &self.channel_lists
+    }
+
+    fn flags(&self) -> u16 {
+        Self::TCP_FLUSHED
+            | if self.channel_lists.is_empty() {
+                0
+            } else {
+                Self::CHANNEL_LIST_PRESENT
+            }
+    }
+
+    fn validate(&self) -> EncodeResult<()> {
+        let _: u16 = cast_length!("NumberOfTunnels", self.channel_lists.len())?;
+        let mut tunnel_types = BTreeSet::new();
+        let mut channel_ids = BTreeSet::new();
+
+        for list in &self.channel_lists {
+            if list.channel_ids.is_empty() {
+                return Err(invalid_field_err!("NumberOfDVCs", "must be nonzero"));
+            }
+            let _: u16 = cast_length!("NumberOfDVCs", list.channel_ids.len())?;
+            if !tunnel_types.insert(list.tunnel_type) {
+                return Err(invalid_field_err!(
+                    "TunnelType",
+                    "appears in more than one channel list"
+                ));
+            }
+            for channel_id in &list.channel_ids {
+                if !channel_ids.insert(*channel_id) {
+                    return Err(invalid_field_err!(
+                        "ListOfDVCIds",
+                        "channel ID appears in more than one channel list"
+                    ));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn decode(header: Header, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        if header.cb_id != FieldType::U8 || header.sp != FieldType::U8 {
+            return Err(invalid_field_err!("Header", "cbId and Sp must be zero"));
+        }
+        ensure_size!(in: src, size: Self::FIXED_PART_SIZE - Header::FIXED_PART_SIZE);
+
+        let headerless_size = src.len();
+        let pad = src.read_u8();
+        if pad != 0 {
+            return Err(invalid_field_err!("Pad", "must be zero"));
+        }
+        let length = usize::try_from(src.read_u32()).map_err(|_| invalid_field_err!("Length", "is too large"))?;
+        if length != headerless_size - 1
+        /* Pad */
+        {
+            return Err(invalid_field_err!(
+                "Length",
+                "does not match the bytes following the pad field"
+            ));
+        }
+
+        let flags = src.read_u16();
+        if flags & !Self::FLAGS_MASK != 0 {
+            return Err(invalid_field_err!("Flags", "contains unsupported flags"));
+        }
+        if flags & Self::TCP_FLUSHED == 0 {
+            return Err(invalid_field_err!("Flags", "SOFT_SYNC_TCP_FLUSHED must be set"));
+        }
+
+        let number_of_tunnels = usize::from(src.read_u16());
+        let channel_list_present = flags & Self::CHANNEL_LIST_PRESENT != 0;
+        if channel_list_present != (number_of_tunnels != 0) {
+            return Err(invalid_field_err!(
+                "Flags",
+                "SOFT_SYNC_CHANNEL_LIST_PRESENT must agree with NumberOfTunnels"
+            ));
+        }
+
+        let mut channel_lists = Vec::with_capacity(number_of_tunnels);
+        let mut tunnel_types = BTreeSet::new();
+        let mut channel_ids = BTreeSet::new();
+        for _ in 0..number_of_tunnels {
+            let list = SoftSyncChannelList::decode(src)?;
+            if !tunnel_types.insert(list.tunnel_type) {
+                return Err(invalid_field_err!(
+                    "TunnelType",
+                    "appears in more than one channel list"
+                ));
+            }
+            for channel_id in &list.channel_ids {
+                if !channel_ids.insert(*channel_id) {
+                    return Err(invalid_field_err!(
+                        "ListOfDVCIds",
+                        "channel ID appears in more than one channel list"
+                    ));
+                }
+            }
+            channel_lists.push(list);
+        }
+        if !src.is_empty() {
+            return Err(invalid_field_err!("Length", "contains trailing bytes"));
+        }
+
+        Ok(Self { channel_lists })
+    }
+
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        self.validate()?;
+        ensure_size!(in: dst, size: self.size());
+
+        Header::new(0, 0, Cmd::SoftSyncRequest).encode(dst)?;
+        dst.write_u8(0);
+        dst.write_u32(cast_length!("Length", self.length())?);
+        dst.write_u16(self.flags());
+        dst.write_u16(cast_length!("NumberOfTunnels", self.channel_lists.len())?);
+        for list in &self.channel_lists {
+            list.encode(dst)?;
+        }
+
+        Ok(())
+    }
+
+    fn name() -> &'static str {
+        "DYNVC_SOFT_SYNC_REQUEST"
+    }
+
+    fn length(&self) -> usize {
+        Self::LENGTH_FIXED_PART_SIZE + self.channel_lists.iter().map(SoftSyncChannelList::size).sum::<usize>()
+    }
+
+    fn size(&self) -> usize {
+        Header::FIXED_PART_SIZE + 1 /* Pad */ + self.length()
+    }
+}
+
+/// Soft-Sync response sent by the DVC client manager.
+///
+/// Defined in [\[MS-RDPEDYC\] 2.2.5.2].
+///
+/// [\[MS-RDPEDYC\] 2.2.5.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpedyc/2f9c83aa-8c82-4d85-a7fe-b4c6301a9f90
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SoftSyncResponsePdu {
+    tunnels_to_switch: Vec<SoftSyncTunnelType>,
+}
+
+impl SoftSyncResponsePdu {
+    const FIXED_PART_SIZE: usize = Header::FIXED_PART_SIZE + 1 /* Pad */ + 4 /* NumberOfTunnels */;
+
+    /// Creates a Soft-Sync response for the tunnels on which the client will write DVC data.
+    pub fn new(tunnels_to_switch: Vec<SoftSyncTunnelType>) -> Self {
+        Self { tunnels_to_switch }
+    }
+
+    /// Returns the tunnels on which the client will write DVC data.
+    pub fn tunnels_to_switch(&self) -> &[SoftSyncTunnelType] {
+        &self.tunnels_to_switch
+    }
+
+    fn validate(&self) -> EncodeResult<()> {
+        let _: u32 = cast_length!("NumberOfTunnels", self.tunnels_to_switch.len())?;
+        let mut tunnels = BTreeSet::new();
+        for tunnel in &self.tunnels_to_switch {
+            if !tunnels.insert(*tunnel) {
+                return Err(invalid_field_err!(
+                    "TunnelsToSwitch",
+                    "contains a duplicate tunnel type"
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn decode(header: Header, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        if header.cb_id != FieldType::U8 || header.sp != FieldType::U8 {
+            return Err(invalid_field_err!("Header", "cbId and Sp must be zero"));
+        }
+        ensure_size!(in: src, size: Self::FIXED_PART_SIZE - Header::FIXED_PART_SIZE);
+
+        let pad = src.read_u8();
+        if pad != 0 {
+            return Err(invalid_field_err!("Pad", "must be zero"));
+        }
+        let number_of_tunnels =
+            usize::try_from(src.read_u32()).map_err(|_| invalid_field_err!("NumberOfTunnels", "is too large"))?;
+        ensure_size!(in: src, size: number_of_tunnels * 4 /* TunnelsToSwitch */);
+
+        let mut tunnels_to_switch = Vec::with_capacity(number_of_tunnels);
+        let mut tunnels = BTreeSet::new();
+        for _ in 0..number_of_tunnels {
+            let tunnel = SoftSyncTunnelType::try_from(src.read_u32())?;
+            if !tunnels.insert(tunnel) {
+                return Err(invalid_field_err!(
+                    "TunnelsToSwitch",
+                    "contains a duplicate tunnel type"
+                ));
+            }
+            tunnels_to_switch.push(tunnel);
+        }
+        if !src.is_empty() {
+            return Err(invalid_field_err!(
+                "NumberOfTunnels",
+                "does not match the remaining bytes"
+            ));
+        }
+
+        Ok(Self { tunnels_to_switch })
+    }
+
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        self.validate()?;
+        ensure_size!(in: dst, size: self.size());
+
+        Header::new(0, 0, Cmd::SoftSyncResponse).encode(dst)?;
+        dst.write_u8(0);
+        dst.write_u32(cast_length!("NumberOfTunnels", self.tunnels_to_switch.len())?);
+        for tunnel in &self.tunnels_to_switch {
+            dst.write_u32((*tunnel).into());
+        }
+
+        Ok(())
+    }
+
+    fn name() -> &'static str {
+        "DYNVC_SOFT_SYNC_RESPONSE"
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.tunnels_to_switch.len() * 4 /* TunnelsToSwitch */
+    }
+}
 
 /// [2.2] Message Syntax
 ///

--- a/crates/ironrdp-dvc/src/server.rs
+++ b/crates/ironrdp-dvc/src/server.rs
@@ -1,5 +1,5 @@
 use alloc::boxed::Box;
-use alloc::collections::BTreeMap;
+use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::vec::Vec;
 use core::any::TypeId;
 use core::fmt;
@@ -26,6 +26,18 @@ enum ChannelState {
     Creation,
     Opened,
     CreationFailed(u32),
+}
+
+enum SoftSyncState {
+    Idle,
+    RequestPending {
+        tunnel_channels: BTreeMap<u32, SoftSyncTunnelType>,
+        requested_tunnels: BTreeSet<SoftSyncTunnelType>,
+    },
+    Active {
+        requested_tunnels: BTreeSet<SoftSyncTunnelType>,
+        response_received: bool,
+    },
 }
 
 struct DynamicChannel {
@@ -124,10 +136,9 @@ impl DynamicChannel {
 pub struct DrdynvcServer {
     dynamic_channels: DynamicChannelAllocator,
     type_id_to_channel_id: BTreeMap<TypeId, u32>,
-    pending_tunnel_channels: Option<BTreeMap<u32, SoftSyncTunnelType>>,
+    soft_sync_state: SoftSyncState,
     outgoing_tunnel_channels: BTreeMap<u32, SoftSyncTunnelType>,
     incoming_tunnel_channels: BTreeMap<u32, SoftSyncTunnelType>,
-    soft_sync_response_received: bool,
 }
 
 impl fmt::Debug for DrdynvcServer {
@@ -152,10 +163,9 @@ impl DrdynvcServer {
         Self {
             dynamic_channels: DynamicChannelAllocator::new(),
             type_id_to_channel_id: BTreeMap::new(),
-            pending_tunnel_channels: None,
+            soft_sync_state: SoftSyncState::Idle,
             outgoing_tunnel_channels: BTreeMap::new(),
             incoming_tunnel_channels: BTreeMap::new(),
-            soft_sync_response_received: false,
         }
     }
 
@@ -252,9 +262,6 @@ impl DrdynvcServer {
 
     pub fn close_channel(&mut self, channel_id: u32) -> Option<SvcMessage> {
         self.remove_by_channel_id(channel_id)?;
-        if let Some(channels) = self.pending_tunnel_channels.as_mut() {
-            channels.remove(&channel_id);
-        }
         self.outgoing_tunnel_channels.remove(&channel_id);
         self.incoming_tunnel_channels.remove(&channel_id);
         Some(
@@ -269,10 +276,10 @@ impl DrdynvcServer {
     /// has been successfully written over TCP.
     pub fn request_reliable_udp(&mut self, channel_ids: Vec<u32>) -> PduResult<SvcMessage> {
         if channel_ids.is_empty() {
-            return Err(pdu_other_err!("Soft-Sync requires at least one dynamic channel"));
+            return Err(pdu_other_err!("soft-sync requires at least one dynamic channel"));
         }
-        if self.pending_tunnel_channels.is_some() || !self.outgoing_tunnel_channels.is_empty() {
-            return Err(pdu_other_err!("Soft-Sync has already been requested"));
+        if !matches!(self.soft_sync_state, SoftSyncState::Idle) {
+            return Err(pdu_other_err!("soft-sync has already been requested"));
         }
 
         let mut selected_channels = BTreeMap::new();
@@ -283,28 +290,40 @@ impl DrdynvcServer {
                 ));
             }
             if selected_channels
-                .insert(*channel_id, SoftSyncTunnelType::ReliableUdp)
+                .insert(*channel_id, SoftSyncTunnelType::RELIABLE_UDP)
                 .is_some()
             {
-                return Err(pdu_other_err!("Soft-Sync channel list contains a duplicate channel ID"));
+                return Err(pdu_other_err!("soft-sync channel list contains a duplicate channel ID"));
             }
         }
 
         let request = SoftSyncRequestPdu::new(alloc::vec![SoftSyncChannelList::new(
-            SoftSyncTunnelType::ReliableUdp,
+            SoftSyncTunnelType::RELIABLE_UDP,
             channel_ids,
         )]);
-        self.pending_tunnel_channels = Some(selected_channels);
+        self.soft_sync_state = SoftSyncState::RequestPending {
+            tunnel_channels: selected_channels,
+            requested_tunnels: BTreeSet::from([SoftSyncTunnelType::RELIABLE_UDP]),
+        };
         as_svc_msg_with_flag(DrdynvcServerPdu::SoftSyncRequest(request))
     }
 
     /// Begins server-to-client tunnel routing after a Soft-Sync request was sent over TCP.
     pub fn complete_soft_sync_request(&mut self) -> PduResult<()> {
-        let pending = self
-            .pending_tunnel_channels
-            .take()
-            .ok_or_else(|| pdu_other_err!("no Soft-Sync request is pending"))?;
-        self.outgoing_tunnel_channels = pending;
+        let state = core::mem::replace(&mut self.soft_sync_state, SoftSyncState::Idle);
+        let SoftSyncState::RequestPending {
+            tunnel_channels,
+            requested_tunnels,
+        } = state
+        else {
+            self.soft_sync_state = state;
+            return Err(pdu_other_err!("no Soft-Sync request is pending"));
+        };
+        self.outgoing_tunnel_channels = tunnel_channels;
+        self.soft_sync_state = SoftSyncState::Active {
+            requested_tunnels,
+            response_received: false,
+        };
         Ok(())
     }
 
@@ -315,7 +334,13 @@ impl DrdynvcServer {
 
     /// Returns whether the client has acknowledged the Soft-Sync request over TCP.
     pub const fn soft_sync_response_received(&self) -> bool {
-        self.soft_sync_response_received
+        matches!(
+            self.soft_sync_state,
+            SoftSyncState::Active {
+                response_received: true,
+                ..
+            }
+        )
     }
 
     /// Processes raw DRDYNVC data received through an established multitransport tunnel.
@@ -348,18 +373,19 @@ impl DrdynvcServer {
     }
 
     fn process_soft_sync_response(&mut self, response: crate::pdu::SoftSyncResponsePdu) -> PduResult<()> {
-        if self.outgoing_tunnel_channels.is_empty() || self.soft_sync_response_received {
+        let SoftSyncState::Active {
+            requested_tunnels,
+            response_received,
+        } = &mut self.soft_sync_state
+        else {
             return Err(pdu_other_err!("received unexpected Soft-Sync response"));
+        };
+        if *response_received {
+            return Err(pdu_other_err!("received duplicate Soft-Sync response"));
         }
-
-        let requested_tunnels: BTreeMap<_, _> = self
-            .outgoing_tunnel_channels
-            .iter()
-            .map(|(channel_id, tunnel_type)| (*channel_id, *tunnel_type))
-            .collect();
         for tunnel_type in response.tunnels_to_switch() {
-            if !requested_tunnels.values().any(|requested| requested == tunnel_type) {
-                return Err(pdu_other_err!("Soft-Sync response selected an unrequested tunnel"));
+            if !requested_tunnels.contains(tunnel_type) {
+                return Err(pdu_other_err!("soft-sync response selected an unrequested tunnel"));
             }
         }
         self.incoming_tunnel_channels = self
@@ -368,7 +394,7 @@ impl DrdynvcServer {
             .filter(|(_, tunnel_type)| response.tunnels_to_switch().contains(tunnel_type))
             .map(|(channel_id, tunnel_type)| (*channel_id, *tunnel_type))
             .collect();
-        self.soft_sync_response_received = true;
+        *response_received = true;
         Ok(())
     }
 }
@@ -457,4 +483,48 @@ fn decode_dvc_message(user_data: &[u8]) -> DecodeResult<DrdynvcClientPdu> {
 
 fn as_svc_msg_with_flag(pdu: DrdynvcServerPdu) -> PduResult<SvcMessage> {
     Ok(SvcMessage::from(pdu).with_flags(ChannelFlags::SHOW_PROTOCOL))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestDvc;
+
+    impl_as_any!(TestDvc);
+
+    impl DvcProcessor for TestDvc {
+        fn channel_name(&self) -> &str {
+            "test"
+        }
+
+        fn start(&mut self, _channel_id: u32) -> PduResult<Vec<crate::DvcMessage>> {
+            Ok(Vec::new())
+        }
+
+        fn process(&mut self, _channel_id: u32, _payload: &[u8]) -> PduResult<Vec<crate::DvcMessage>> {
+            Ok(Vec::new())
+        }
+    }
+
+    impl DvcServerProcessor for TestDvc {}
+
+    #[test]
+    fn soft_sync_accepts_a_response_after_the_selected_channel_closes() {
+        let mut server = DrdynvcServer::new();
+        let channel_id = server.dynamic_channels.insert_channel(TestDvc, ChannelState::Opened);
+
+        server.request_reliable_udp(alloc::vec![channel_id]).unwrap();
+        server.complete_soft_sync_request().unwrap();
+        server.close_channel(channel_id).unwrap();
+
+        server
+            .process_soft_sync_response(crate::pdu::SoftSyncResponsePdu::new(alloc::vec![
+                SoftSyncTunnelType::RELIABLE_UDP,
+            ]))
+            .unwrap();
+
+        assert!(server.soft_sync_response_received());
+        assert!(server.request_reliable_udp(alloc::vec![channel_id]).is_err());
+    }
 }

--- a/crates/ironrdp-dvc/src/server.rs
+++ b/crates/ironrdp-dvc/src/server.rs
@@ -30,10 +30,6 @@ enum ChannelState {
 
 enum SoftSyncState {
     Idle,
-    RequestPending {
-        tunnel_channels: BTreeMap<u32, SoftSyncTunnelType>,
-        requested_tunnels: BTreeSet<SoftSyncTunnelType>,
-    },
     Active {
         requested_tunnels: BTreeSet<SoftSyncTunnelType>,
         response_received: bool,
@@ -272,8 +268,9 @@ impl DrdynvcServer {
 
     /// Creates a Soft-Sync request that moves the supplied channels to reliable UDP.
     ///
-    /// Call [`Self::complete_soft_sync_request`] only after the returned message
-    /// has been successfully written over TCP.
+    /// This API emits exactly one `ReliableUdp` channel list and maps every supplied
+    /// channel to that list. A future multi-tunnel request API must establish an
+    /// explicit response-routing mapping before it is exposed.
     pub fn request_reliable_udp(&mut self, channel_ids: Vec<u32>) -> PduResult<SvcMessage> {
         if channel_ids.is_empty() {
             return Err(pdu_other_err!("soft-sync requires at least one dynamic channel"));
@@ -301,30 +298,13 @@ impl DrdynvcServer {
             SoftSyncTunnelType::RELIABLE_UDP,
             channel_ids,
         )]);
-        self.soft_sync_state = SoftSyncState::RequestPending {
-            tunnel_channels: selected_channels,
-            requested_tunnels: BTreeSet::from([SoftSyncTunnelType::RELIABLE_UDP]),
-        };
-        as_svc_msg_with_flag(DrdynvcServerPdu::SoftSyncRequest(request))
-    }
-
-    /// Begins server-to-client tunnel routing after a Soft-Sync request was sent over TCP.
-    pub fn complete_soft_sync_request(&mut self) -> PduResult<()> {
-        let state = core::mem::replace(&mut self.soft_sync_state, SoftSyncState::Idle);
-        let SoftSyncState::RequestPending {
-            tunnel_channels,
-            requested_tunnels,
-        } = state
-        else {
-            self.soft_sync_state = state;
-            return Err(pdu_other_err!("no Soft-Sync request is pending"));
-        };
-        self.outgoing_tunnel_channels = tunnel_channels;
+        let message = as_svc_msg_with_flag(DrdynvcServerPdu::SoftSyncRequest(request))?;
+        self.outgoing_tunnel_channels = selected_channels;
         self.soft_sync_state = SoftSyncState::Active {
-            requested_tunnels,
+            requested_tunnels: BTreeSet::from([SoftSyncTunnelType::RELIABLE_UDP]),
             response_received: false,
         };
-        Ok(())
+        Ok(message)
     }
 
     /// Returns whether server-to-client data for `channel_id` must be sent through a tunnel.
@@ -510,12 +490,41 @@ mod tests {
     impl DvcServerProcessor for TestDvc {}
 
     #[test]
+    fn soft_sync_rejects_tunnel_data_until_the_client_responds() {
+        let mut server = DrdynvcServer::new();
+        let channel_id = server.dynamic_channels.insert_channel(TestDvc, ChannelState::Opened);
+
+        server.request_reliable_udp(alloc::vec![channel_id]).unwrap();
+        assert_eq!(
+            server.tunnel_for_outgoing_channel(channel_id),
+            Some(SoftSyncTunnelType::RELIABLE_UDP)
+        );
+
+        let tunnel_data = ironrdp_core::encode_vec(&DrdynvcClientPdu::Data(crate::pdu::DrdynvcDataPdu::Data(
+            crate::pdu::DataPdu::new(channel_id, Vec::new()),
+        )))
+        .unwrap();
+        assert!(server.process_tunnel(&tunnel_data).is_err());
+
+        server
+            .process_soft_sync_response(crate::pdu::SoftSyncResponsePdu::new(alloc::vec![
+                SoftSyncTunnelType::RELIABLE_UDP,
+            ]))
+            .unwrap();
+
+        assert!(server.soft_sync_response_received());
+        assert!(server.process_tunnel(&tunnel_data).is_ok());
+
+        server.close_channel(channel_id).unwrap();
+        assert!(server.request_reliable_udp(alloc::vec![channel_id]).is_err());
+    }
+
+    #[test]
     fn soft_sync_accepts_a_response_after_the_selected_channel_closes() {
         let mut server = DrdynvcServer::new();
         let channel_id = server.dynamic_channels.insert_channel(TestDvc, ChannelState::Opened);
 
         server.request_reliable_udp(alloc::vec![channel_id]).unwrap();
-        server.complete_soft_sync_request().unwrap();
         server.close_channel(channel_id).unwrap();
 
         server

--- a/crates/ironrdp-dvc/src/server.rs
+++ b/crates/ironrdp-dvc/src/server.rs
@@ -12,7 +12,8 @@ use pdu::gcc::ChannelName;
 use tracing::debug;
 
 use crate::pdu::{
-    CapabilitiesRequestPdu, CapsVersion, ClosePdu, CreateRequestPdu, CreationStatus, DrdynvcClientPdu, DrdynvcServerPdu,
+    CapabilitiesRequestPdu, CapsVersion, ClosePdu, CreateRequestPdu, CreationStatus, DrdynvcClientPdu,
+    DrdynvcServerPdu, SoftSyncChannelList, SoftSyncRequestPdu, SoftSyncTunnelType,
 };
 use crate::{CompleteData, DvcProcessor, DynamicChannelMut, DynamicChannelRef, encode_dvc_messages};
 
@@ -123,6 +124,10 @@ impl DynamicChannel {
 pub struct DrdynvcServer {
     dynamic_channels: DynamicChannelAllocator,
     type_id_to_channel_id: BTreeMap<TypeId, u32>,
+    pending_tunnel_channels: Option<BTreeMap<u32, SoftSyncTunnelType>>,
+    outgoing_tunnel_channels: BTreeMap<u32, SoftSyncTunnelType>,
+    incoming_tunnel_channels: BTreeMap<u32, SoftSyncTunnelType>,
+    soft_sync_response_received: bool,
 }
 
 impl fmt::Debug for DrdynvcServer {
@@ -147,6 +152,10 @@ impl DrdynvcServer {
         Self {
             dynamic_channels: DynamicChannelAllocator::new(),
             type_id_to_channel_id: BTreeMap::new(),
+            pending_tunnel_channels: None,
+            outgoing_tunnel_channels: BTreeMap::new(),
+            incoming_tunnel_channels: BTreeMap::new(),
+            soft_sync_response_received: false,
         }
     }
 
@@ -243,10 +252,124 @@ impl DrdynvcServer {
 
     pub fn close_channel(&mut self, channel_id: u32) -> Option<SvcMessage> {
         self.remove_by_channel_id(channel_id)?;
+        if let Some(channels) = self.pending_tunnel_channels.as_mut() {
+            channels.remove(&channel_id);
+        }
+        self.outgoing_tunnel_channels.remove(&channel_id);
+        self.incoming_tunnel_channels.remove(&channel_id);
         Some(
             SvcMessage::from(DrdynvcServerPdu::Close(ClosePdu::new(channel_id)))
                 .with_flags(ChannelFlags::SHOW_PROTOCOL),
         )
+    }
+
+    /// Creates a Soft-Sync request that moves the supplied channels to reliable UDP.
+    ///
+    /// Call [`Self::complete_soft_sync_request`] only after the returned message
+    /// has been successfully written over TCP.
+    pub fn request_reliable_udp(&mut self, channel_ids: Vec<u32>) -> PduResult<SvcMessage> {
+        if channel_ids.is_empty() {
+            return Err(pdu_other_err!("Soft-Sync requires at least one dynamic channel"));
+        }
+        if self.pending_tunnel_channels.is_some() || !self.outgoing_tunnel_channels.is_empty() {
+            return Err(pdu_other_err!("Soft-Sync has already been requested"));
+        }
+
+        let mut selected_channels = BTreeMap::new();
+        for channel_id in &channel_ids {
+            if !self.is_channel_opened(*channel_id) {
+                return Err(pdu_other_err!(
+                    "Soft-Sync requested for a dynamic channel that is not open"
+                ));
+            }
+            if selected_channels
+                .insert(*channel_id, SoftSyncTunnelType::ReliableUdp)
+                .is_some()
+            {
+                return Err(pdu_other_err!("Soft-Sync channel list contains a duplicate channel ID"));
+            }
+        }
+
+        let request = SoftSyncRequestPdu::new(alloc::vec![SoftSyncChannelList::new(
+            SoftSyncTunnelType::ReliableUdp,
+            channel_ids,
+        )]);
+        self.pending_tunnel_channels = Some(selected_channels);
+        as_svc_msg_with_flag(DrdynvcServerPdu::SoftSyncRequest(request))
+    }
+
+    /// Begins server-to-client tunnel routing after a Soft-Sync request was sent over TCP.
+    pub fn complete_soft_sync_request(&mut self) -> PduResult<()> {
+        let pending = self
+            .pending_tunnel_channels
+            .take()
+            .ok_or_else(|| pdu_other_err!("no Soft-Sync request is pending"))?;
+        self.outgoing_tunnel_channels = pending;
+        Ok(())
+    }
+
+    /// Returns whether server-to-client data for `channel_id` must be sent through a tunnel.
+    pub fn tunnel_for_outgoing_channel(&self, channel_id: u32) -> Option<SoftSyncTunnelType> {
+        self.outgoing_tunnel_channels.get(&channel_id).copied()
+    }
+
+    /// Returns whether the client has acknowledged the Soft-Sync request over TCP.
+    pub const fn soft_sync_response_received(&self) -> bool {
+        self.soft_sync_response_received
+    }
+
+    /// Processes raw DRDYNVC data received through an established multitransport tunnel.
+    pub fn process_tunnel(&mut self, payload: &[u8]) -> PduResult<Vec<SvcMessage>> {
+        let pdu = decode_dvc_message(payload).map_err(|e| decode_err!(e))?;
+        let DrdynvcClientPdu::Data(data) = pdu else {
+            return Err(pdu_other_err!("only DVC data is permitted on a multitransport tunnel"));
+        };
+        if !self.incoming_tunnel_channels.contains_key(&data.channel_id()) {
+            return Err(pdu_other_err!(
+                "received tunneled data for a channel not selected by Soft-Sync"
+            ));
+        }
+        self.process_data(data)
+    }
+
+    fn process_data(&mut self, data: crate::pdu::DrdynvcDataPdu) -> PduResult<Vec<SvcMessage>> {
+        let channel_id = data.channel_id();
+        let c = self.channel_by_id(channel_id).map_err(|e| decode_err!(e))?;
+        if c.state != ChannelState::Opened {
+            debug!(?channel_id, ?c.state, "Invalid channel state");
+            return Err(pdu_other_err!("invalid channel state"));
+        }
+        let mut resp = Vec::new();
+        if let Some(complete) = c.complete_data.process_data(data).map_err(|e| decode_err!(e))? {
+            let msg = c.processor.process(channel_id, &complete)?;
+            resp.extend(encode_dvc_messages(channel_id, msg, ChannelFlags::SHOW_PROTOCOL).map_err(|e| encode_err!(e))?);
+        }
+        Ok(resp)
+    }
+
+    fn process_soft_sync_response(&mut self, response: crate::pdu::SoftSyncResponsePdu) -> PduResult<()> {
+        if self.outgoing_tunnel_channels.is_empty() || self.soft_sync_response_received {
+            return Err(pdu_other_err!("received unexpected Soft-Sync response"));
+        }
+
+        let requested_tunnels: BTreeMap<_, _> = self
+            .outgoing_tunnel_channels
+            .iter()
+            .map(|(channel_id, tunnel_type)| (*channel_id, *tunnel_type))
+            .collect();
+        for tunnel_type in response.tunnels_to_switch() {
+            if !requested_tunnels.values().any(|requested| requested == tunnel_type) {
+                return Err(pdu_other_err!("Soft-Sync response selected an unrequested tunnel"));
+            }
+        }
+        self.incoming_tunnel_channels = self
+            .outgoing_tunnel_channels
+            .iter()
+            .filter(|(_, tunnel_type)| response.tunnels_to_switch().contains(tunnel_type))
+            .map(|(channel_id, tunnel_type)| (*channel_id, *tunnel_type))
+            .collect();
+        self.soft_sync_response_received = true;
+        Ok(())
     }
 }
 
@@ -311,19 +434,14 @@ impl SvcProcessor for DrdynvcServer {
                 self.remove_by_channel_id(channel_id);
             }
             DrdynvcClientPdu::Data(data) => {
-                let channel_id = data.channel_id();
-                let c = self.channel_by_id(channel_id).map_err(|e| decode_err!(e))?;
-                if c.state != ChannelState::Opened {
-                    debug!(?channel_id, ?c.state, "Invalid channel state");
-                    return Err(pdu_other_err!("invalid channel state"));
+                if self.incoming_tunnel_channels.contains_key(&data.channel_id()) {
+                    return Err(pdu_other_err!("received TCP data for a channel selected by Soft-Sync"));
                 }
-                if let Some(complete) = c.complete_data.process_data(data).map_err(|e| decode_err!(e))? {
-                    let msg = c.processor.process(channel_id, &complete)?;
-                    resp.extend(
-                        encode_dvc_messages(channel_id, msg, ChannelFlags::SHOW_PROTOCOL)
-                            .map_err(|e| encode_err!(e))?,
-                    );
-                }
+                resp.extend(self.process_data(data)?);
+            }
+            DrdynvcClientPdu::SoftSyncResponse(response) => {
+                debug!("Got DVC Soft-Sync Response PDU: {response:?}");
+                self.process_soft_sync_response(response)?;
             }
         }
 

--- a/crates/ironrdp-testsuite-core/tests/dvc/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/dvc/mod.rs
@@ -4,6 +4,7 @@ use ironrdp_core::{Decode, Encode, ReadCursor, WriteCursor};
 use ironrdp_dvc::pdu::{
     CapabilitiesRequestPdu, CapabilitiesResponsePdu, CapsVersion, ClosePdu, CreateRequestPdu, CreateResponsePdu,
     CreationStatus, DataFirstPdu, DataPdu, DrdynvcClientPdu, DrdynvcDataPdu, DrdynvcServerPdu, FieldType,
+    SoftSyncChannelList, SoftSyncRequestPdu, SoftSyncResponsePdu, SoftSyncTunnelType,
 };
 
 // TODO: This likely generalizes to many tests and can thus be reused outside of this module.
@@ -25,3 +26,4 @@ mod close;
 mod create;
 mod data;
 mod data_first;
+mod soft_sync;

--- a/crates/ironrdp-testsuite-core/tests/dvc/soft_sync.rs
+++ b/crates/ironrdp-testsuite-core/tests/dvc/soft_sync.rs
@@ -29,6 +29,43 @@ fn decodes_soft_sync_request() {
 }
 
 #[test]
+fn decodes_soft_sync_request_with_unknown_tunnel_type() {
+    let mut request = REQUEST_ENCODED;
+    request[10] = 0x7F;
+
+    test_decodes(
+        &request,
+        &DrdynvcServerPdu::SoftSyncRequest(SoftSyncRequestPdu::new(vec![SoftSyncChannelList::new(
+            SoftSyncTunnelType::from(0x7F),
+            vec![CHANNEL_ID],
+        )])),
+    );
+}
+
+#[test]
+fn decodes_soft_sync_request_with_empty_channel_list() {
+    let request = [
+        0x80, 0x00, 0x0E, 0x00, 0x00, 0x00, 0x03, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ];
+
+    test_decodes(
+        &request,
+        &DrdynvcServerPdu::SoftSyncRequest(SoftSyncRequestPdu::new(vec![SoftSyncChannelList::new(
+            SoftSyncTunnelType::RELIABLE_UDP,
+            Vec::new(),
+        )])),
+    );
+}
+
+#[test]
+fn decodes_soft_sync_request_without_channel_list_flag() {
+    let mut encoded = REQUEST_ENCODED;
+    encoded[6] = 0x01;
+
+    test_decodes(&encoded, &DrdynvcServerPdu::SoftSyncRequest(request()));
+}
+
+#[test]
 fn encodes_soft_sync_response() {
     test_encodes(&DrdynvcClientPdu::SoftSyncResponse(response()), &RESPONSE_ENCODED);
 }

--- a/crates/ironrdp-testsuite-core/tests/dvc/soft_sync.rs
+++ b/crates/ironrdp-testsuite-core/tests/dvc/soft_sync.rs
@@ -9,13 +9,13 @@ const RESPONSE_ENCODED: [u8; 10] = [0x90, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x
 
 fn request() -> SoftSyncRequestPdu {
     SoftSyncRequestPdu::new(vec![SoftSyncChannelList::new(
-        SoftSyncTunnelType::ReliableUdp,
+        SoftSyncTunnelType::RELIABLE_UDP,
         vec![CHANNEL_ID],
     )])
 }
 
 fn response() -> SoftSyncResponsePdu {
-    SoftSyncResponsePdu::new(vec![SoftSyncTunnelType::ReliableUdp])
+    SoftSyncResponsePdu::new(vec![SoftSyncTunnelType::RELIABLE_UDP])
 }
 
 #[test]
@@ -66,4 +66,33 @@ fn rejects_soft_sync_response_with_duplicate_tunnel_type() {
 
     let mut src = ReadCursor::new(&response);
     assert!(DrdynvcClientPdu::decode(&mut src).is_err());
+}
+
+#[test]
+fn rejects_soft_sync_response_with_too_many_tunnels() {
+    let response = [0x90, 0x00, 0xFF, 0xFF, 0xFF, 0xFF];
+
+    let mut src = ReadCursor::new(&response);
+    assert!(DrdynvcClientPdu::decode(&mut src).is_err());
+}
+
+#[test]
+fn rejects_soft_sync_request_with_too_many_tunnels() {
+    let request = [0x80, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0xFF, 0xFF];
+
+    let mut src = ReadCursor::new(&request);
+    assert!(DrdynvcServerPdu::decode(&mut src).is_err());
+}
+
+#[test]
+fn decodes_unknown_soft_sync_tunnel_type() {
+    let response = [0x90, 0x00, 0x01, 0x00, 0x00, 0x00, 0x7F, 0x00, 0x00, 0x00];
+
+    let mut src = ReadCursor::new(&response);
+    let decoded = DrdynvcClientPdu::decode(&mut src).unwrap();
+    let DrdynvcClientPdu::SoftSyncResponse(response) = decoded else {
+        panic!("expected Soft-Sync response");
+    };
+
+    assert_eq!(response.tunnels_to_switch(), &[SoftSyncTunnelType::from(0x7F)]);
 }

--- a/crates/ironrdp-testsuite-core/tests/dvc/soft_sync.rs
+++ b/crates/ironrdp-testsuite-core/tests/dvc/soft_sync.rs
@@ -1,0 +1,69 @@
+use super::*;
+
+const CHANNEL_ID: u32 = 0x0303;
+const REQUEST_ENCODED: [u8; 20] = [
+    0x80, 0x00, 0x12, 0x00, 0x00, 0x00, 0x03, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x03, 0x03, 0x00,
+    0x00,
+];
+const RESPONSE_ENCODED: [u8; 10] = [0x90, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00];
+
+fn request() -> SoftSyncRequestPdu {
+    SoftSyncRequestPdu::new(vec![SoftSyncChannelList::new(
+        SoftSyncTunnelType::ReliableUdp,
+        vec![CHANNEL_ID],
+    )])
+}
+
+fn response() -> SoftSyncResponsePdu {
+    SoftSyncResponsePdu::new(vec![SoftSyncTunnelType::ReliableUdp])
+}
+
+#[test]
+fn encodes_soft_sync_request() {
+    test_encodes(&DrdynvcServerPdu::SoftSyncRequest(request()), &REQUEST_ENCODED);
+}
+
+#[test]
+fn decodes_soft_sync_request() {
+    test_decodes(&REQUEST_ENCODED, &DrdynvcServerPdu::SoftSyncRequest(request()));
+}
+
+#[test]
+fn encodes_soft_sync_response() {
+    test_encodes(&DrdynvcClientPdu::SoftSyncResponse(response()), &RESPONSE_ENCODED);
+}
+
+#[test]
+fn decodes_soft_sync_response() {
+    test_decodes(&RESPONSE_ENCODED, &DrdynvcClientPdu::SoftSyncResponse(response()));
+}
+
+#[test]
+fn rejects_soft_sync_request_with_mismatched_length() {
+    let mut request = REQUEST_ENCODED;
+    request[2] = 0x11;
+
+    let mut src = ReadCursor::new(&request);
+    assert!(DrdynvcServerPdu::decode(&mut src).is_err());
+}
+
+#[test]
+fn rejects_soft_sync_request_with_duplicate_channel_id() {
+    let request = [
+        0x80, 0x00, 0x1C, 0x00, 0x00, 0x00, 0x03, 0x00, 0x02, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x03, 0x03,
+        0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x01, 0x00, 0x03, 0x03, 0x00, 0x00,
+    ];
+
+    let mut src = ReadCursor::new(&request);
+    assert!(DrdynvcServerPdu::decode(&mut src).is_err());
+}
+
+#[test]
+fn rejects_soft_sync_response_with_duplicate_tunnel_type() {
+    let response = [
+        0x90, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+    ];
+
+    let mut src = ReadCursor::new(&response);
+    assert!(DrdynvcClientPdu::decode(&mut src).is_err());
+}


### PR DESCRIPTION
Add Soft-Sync codecs and DVC dispatch for tunnel assignments.

Keep decoding forward compatible and bound peer-controlled allocations. Reject exchanges before their required multitransport endpoint is ready.