### PR TITLE
fix(rdpeusb): enforce terminal state after retraction

### DIFF
--- a/crates/ironrdp-rdpeusb/src/server.rs
+++ b/crates/ironrdp-rdpeusb/src/server.rs
@@ -220,16 +220,27 @@ pub trait UrbdrcDeviceServerBackend: Send {
         request_id: RequestId,
         completion: TransferOutCompletionResult,
     ) -> PduResult<()>;
+
+    /// Notifies the backend that the per-device dynamic channel has closed.
+    fn close(&mut self, _channel_id: u32) {}
 }
 
 pub struct UrbdrcDeviceServer {
     msg_alloc: IdAllocator,
     request_id_alloc: RequestIdAllocator,
+    state: DeviceState,
     udev_iface: Option<InterfaceId>,
     comp_iface: InterfaceId,
     no_ack_isoch_write_jitter_buf_size: Option<NoAckIsochWriteJitterBufSizeInMs>,
     pending_io: BTreeMap<RequestId, Pending>,
     backend: Box<dyn UrbdrcDeviceServerBackend>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum DeviceState {
+    AwaitingDevice,
+    Ready,
+    Retracted,
 }
 
 enum Pending {
@@ -292,6 +303,7 @@ impl UrbdrcDeviceServer {
         Ok(Self {
             msg_alloc: IdAllocator::new(),
             request_id_alloc: RequestIdAllocator::new(),
+            state: DeviceState::AwaitingDevice,
             udev_iface: None,
             comp_iface,
             no_ack_isoch_write_jitter_buf_size: None,
@@ -454,16 +466,20 @@ impl UrbdrcDeviceServer {
 
     pub fn retract_device(&mut self, reason: UsbRetractReason) -> PduResult<DvcMessage> {
         let udev_iface = self.usb_device_iface()?;
-        self.pending_io.clear();
-        self.no_ack_isoch_write_jitter_buf_size = None;
-        Ok(Box::new(RetractDevice {
+        let message = Box::new(RetractDevice {
             msg_id: self.msg_alloc.alloc(),
             udev_iface,
             reason,
-        }))
+        });
+        self.state = DeviceState::Retracted;
+        Ok(message)
     }
 
     fn usb_device_iface(&self) -> PduResult<InterfaceId> {
+        if self.state != DeviceState::Ready {
+            return Err(pdu_other_err!("USB device is not ready for I/O"));
+        }
+
         self.udev_iface
             .ok_or_else(|| pdu_other_err!("USB device uninitialized"))
     }
@@ -646,6 +662,14 @@ impl DvcProcessor for UrbdrcDeviceServer {
     }
 
     fn process(&mut self, channel_id: u32, payload: &[u8]) -> PduResult<Vec<DvcMessage>> {
+        // SPEC [3.1.5]: Messages received after RETRACT_DEVICE are out of sequence and
+        // MUST be ignored while the containing DVC is being closed.
+        //
+        // [3.1.5]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeusb/f31cc9ef-a8c3-4a4d-b64d-f027ed0752b0
+        if self.state == DeviceState::Retracted {
+            return Ok(Vec::new());
+        }
+
         let pdu = UrbdrcClientDevicePdu::decode(&mut ReadCursor::new(payload)).map_err(|e| decode_err!(e))?;
         let mut resp: Vec<DvcMessage> = Vec::new();
 
@@ -661,17 +685,18 @@ impl DvcProcessor for UrbdrcDeviceServer {
             AddDev(add_dev_pdu) => {
                 // In the case of the server receiving a duplicate interface ID, the server MUST
                 // ignore the ADD_DEVICE message.
-                if self.udev_iface.is_some() {
+                if self.state != DeviceState::AwaitingDevice {
                     return Ok(resp);
                 }
                 let udev_iface = add_dev_pdu.usb_device;
                 let no_ack_isoch_write_jitter_buf_size = add_dev_pdu.usb_device_caps.no_ack_isoch_write_jitter_buf_size;
-                self.udev_iface = Some(udev_iface);
 
                 let device = add_dev_pdu.try_into()?;
 
                 self.backend.add_device(device)?;
+                self.udev_iface = Some(udev_iface);
                 self.no_ack_isoch_write_jitter_buf_size = Some(no_ack_isoch_write_jitter_buf_size);
+                self.state = DeviceState::Ready;
                 resp.push(Box::new(InterfaceRelease {
                     msg_id: self.msg_alloc.alloc(),
                     iface_id: InterfaceId::DEVICE_SINK.with_mask(Mask::Proxy),
@@ -706,6 +731,10 @@ impl DvcProcessor for UrbdrcDeviceServer {
                 Ok(resp)
             }
         }
+    }
+
+    fn close(&mut self, channel_id: u32) {
+        self.backend.close(channel_id);
     }
 }
 

--- a/crates/ironrdp-testsuite-core/tests/rdpeusb/io/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeusb/io/mod.rs
@@ -57,6 +57,9 @@ enum ClientEvent {
 
 #[derive(Debug)]
 enum ServerEvent {
+    Closed {
+        channel_id: u32,
+    },
     DeviceText(DeviceText),
     IoControlCompleted {
         channel_id: u32,
@@ -263,6 +266,10 @@ impl UrbdrcDeviceServerBackend for ChannelDeviceServerBackend {
             completion,
         });
         Ok(())
+    }
+
+    fn close(&mut self, channel_id: u32) {
+        self.send(ServerEvent::Closed { channel_id });
     }
 }
 

--- a/crates/ironrdp-testsuite-core/tests/rdpeusb/io/requests.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeusb/io/requests.rs
@@ -1,4 +1,7 @@
-use ironrdp_rdpeusb::io::{InternalIoControlPacket, IoControlCompletionResult, IoControlPacket, IoctlInternalUsb};
+use ironrdp_dvc::DvcProcessor as _;
+use ironrdp_rdpeusb::io::{
+    InternalIoControlPacket, IoControlCompletionResult, IoControlPacket, IoctlInternalUsb, UsbRetractReason,
+};
 use rstest::rstest;
 
 use super::{
@@ -214,4 +217,51 @@ fn cancel_pending_request() {
     };
     assert_eq!(channel_id, CHANNEL_ID);
     assert_eq!(backend_request_id, request_id);
+}
+
+// Ref: [Processing a Retract Device Message][3.3.5.3.8].
+// [3.3.5.3.8]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeusb/8a86b746-b361-4e4a-8e47-53c90089893d
+#[test]
+fn retract_makes_device_terminal_until_channel_close() {
+    let mut device = ConnectedDevice::new();
+    let request = device
+        .server
+        .io_control(IoControlPacket {
+            ioctl_code: IoctlInternalUsb::GetPortStatus,
+            input_buffer: Vec::new(),
+            output_buffer_size: 4,
+        })
+        .expect("IO control should succeed");
+    let request_id = request.request_id;
+    assert!(device.send_to_client(request.message).is_empty());
+    assert!(matches!(device.next_client_event(), ClientEvent::IoControl { .. }));
+
+    let retract = device
+        .server
+        .retract_device(UsbRetractReason::BlockedByPolicy)
+        .expect("retract should succeed");
+    assert!(device.send_to_client(retract).is_empty());
+    assert!(!device.client.ready_for_io());
+
+    assert!(
+        device
+            .server
+            .io_control(IoControlPacket {
+                ioctl_code: IoctlInternalUsb::GetPortStatus,
+                input_buffer: Vec::new(),
+                output_buffer_size: 4,
+            })
+            .is_err(),
+        "new I/O should be rejected after retract"
+    );
+    assert!(
+        device.server.cancel_request(request_id).is_err(),
+        "cancel should not be sent after retract"
+    );
+
+    device.server.close(CHANNEL_ID);
+    let ServerEvent::Closed { channel_id } = device.next_server_event() else {
+        panic!("expected device close event");
+    };
+    assert_eq!(channel_id, CHANNEL_ID);
 }


### PR DESCRIPTION
## Summary

Make device retraction a terminal state for `UrbdrcDeviceServer` until the containing dynamic virtual channel is closed.

- Track the device lifecycle as awaiting device, ready, or retracted.
- Reject new I/O and cancellation requests after `RETRACT_DEVICE`.
- Ignore client device messages received after retraction.
- Preserve pending request metadata until channel teardown.
- Notify the device backend when the DVC closes.
- Add regression coverage for the retract and close lifecycle.

## Rationale

Previously, `retract_device` cleared the pending request state but left the device processor usable. New requests could still be constructed, while late client completions could be treated as mismatched requests.

According to [MS-RDPEUSB section 3.3.5.3.8](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeusb/8a86b746-b361-4e4a-8e47-53c90089893d), the client should terminate the dynamic virtual channel after receiving `RETRACT_DEVICE`. Messages received while the channel is closing are therefore ignored as out-of-sequence, following [section 3.1.5](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeusb/f31cc9ef-a8c3-4a4d-b64d-f027ed0752b0).

Closing the containing DVC remains the responsibility of the server or application layer.