### PR TITLE
feat(rdpdr): add Windows filesystem backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2872,6 +2872,7 @@ dependencies = [
  "ironrdp-svc",
  "nix",
  "tracing",
+ "windows",
 ]
 
 [[package]]

--- a/crates/ironrdp-rdpdr-native/Cargo.toml
+++ b/crates/ironrdp-rdpdr-native/Cargo.toml
@@ -14,6 +14,7 @@ categories.workspace = true
 
 [lib]
 doctest = false
+test = false
 
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
 ironrdp-core = { path = "../ironrdp-core", version = "0.2" }
@@ -37,6 +38,10 @@ windows = { version = "0.62", features = [
     "Win32_Storage_FileSystem",
     "Win32_System_IO",
 ] }
+
+[dev-dependencies]
+ironrdp-rdpdr = { path = "../ironrdp-rdpdr", version = "0.7" }
+ironrdp-svc = { path = "../ironrdp-svc", version = "0.8" }
 
 [lints]
 workspace = true

--- a/crates/ironrdp-rdpdr-native/Cargo.toml
+++ b/crates/ironrdp-rdpdr-native/Cargo.toml
@@ -39,9 +39,6 @@ windows = { version = "0.62", features = [
     "Win32_System_IO",
 ] }
 
-[dev-dependencies]
+[target.'cfg(windows)'.dev-dependencies]
 ironrdp-rdpdr = { path = "../ironrdp-rdpdr", version = "0.7" }
 ironrdp-svc = { path = "../ironrdp-svc", version = "0.8" }
-
-[lints]
-workspace = true

--- a/crates/ironrdp-rdpdr-native/Cargo.toml
+++ b/crates/ironrdp-rdpdr-native/Cargo.toml
@@ -14,7 +14,6 @@ categories.workspace = true
 
 [lib]
 doctest = false
-test = false
 
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
 ironrdp-core = { path = "../ironrdp-core", version = "0.2" }
@@ -23,3 +22,21 @@ ironrdp-svc = { path = "../ironrdp-svc", version = "0.8" } # public
 ironrdp-rdpdr = { path = "../ironrdp-rdpdr", version = "0.7" } # public
 nix = { version = "0.31", features = ["fs", "dir"] }
 tracing = { version = "0.1", features = ["log"] }
+
+[target.'cfg(windows)'.dependencies]
+ironrdp-core = { path = "../ironrdp-core", version = "0.2" }
+ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9" } # public
+ironrdp-svc = { path = "../ironrdp-svc", version = "0.8" } # public
+ironrdp-rdpdr = { path = "../ironrdp-rdpdr", version = "0.7" } # public
+windows = { version = "0.62", features = [
+    "Wdk_Foundation",
+    "Wdk_Storage_FileSystem",
+    "Wdk_System_SystemServices",
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
+    "Win32_System_IO",
+] }
+
+[lints]
+workspace = true

--- a/crates/ironrdp-rdpdr-native/README.md
+++ b/crates/ironrdp-rdpdr-native/README.md
@@ -1,3 +1,14 @@
 # IronRDP RDPDR native backends
 
-Native RDPDR backend implementations. Currently only *nix systems are supported.
+Native RDPDR backend implementations.
+
+On Windows, `WindowsRdpdrBackendFactory` configures one explicitly selected
+logical volume root for the portable `ironrdp-rdpdr` backend contract. The
+initial-drive name returned by `initial_drives` must be passed to
+`Rdpdr::with_drives`.
+
+The Windows implementation is deliberately narrow. It supports handle-relative
+create/open, close, synchronous bounded reads and writes, and basic file
+metadata queries and updates. It does not implement directory enumeration,
+notifications, locks, security descriptors, streams, control requests, or
+volume queries. Those requests receive `STATUS_NOT_SUPPORTED`.

--- a/crates/ironrdp-rdpdr-native/src/lib.rs
+++ b/crates/ironrdp-rdpdr-native/src/lib.rs
@@ -13,3 +13,8 @@
 mod nix;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 pub use nix::backend;
+
+#[cfg(windows)]
+mod windows;
+#[cfg(windows)]
+pub use windows::{RedirectedDrive, RedirectedDriveError, WindowsRdpdrBackend, WindowsRdpdrBackendFactory};

--- a/crates/ironrdp-rdpdr-native/src/windows/backend.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/backend.rs
@@ -588,7 +588,7 @@ mod tests {
 
         let set = ServerDriveSetInformationRequest {
             device_io_request: request_header(file_id, MajorFunction::SetInformation),
-            set_buffer: FileInformationClass::EndOfFile(FileEndOfFileInformation { end_of_file: 3 }),
+            set_buffer: FileInformationClass::EndOfFile(FileEndOfFileInformation { end_of_file: 5 }),
         };
         let set_response = backend
             .handle_drive_io_request(ServerDriveIoRequest::ServerDriveSetInformationRequest(set))
@@ -596,7 +596,7 @@ mod tests {
         assert_eq!(response_status(&set_response), NtStatus::SUCCESS);
         assert_eq!(
             std::fs::read(fixture.root.join("root").join("report.txt")).expect("read test file"),
-            b"hel"
+            b"hello"
         );
 
         let close_response = backend

--- a/crates/ironrdp-rdpdr-native/src/windows/backend.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/backend.rs
@@ -49,12 +49,17 @@ const FILE_DIRECTORY_FILE: u32 = 0x0000_0001;
 const FILE_NON_DIRECTORY_FILE: u32 = 0x0000_0040;
 const FILE_WRITE_THROUGH: u32 = 0x0000_0002;
 const FILE_SEQUENTIAL_ONLY: u32 = 0x0000_0004;
+const FILE_SYNCHRONOUS_IO_NONALERT: u32 = 0x0000_0020;
 const FILE_RANDOM_ACCESS: u32 = 0x0000_0800;
 const FILE_DELETE_ON_CLOSE: u32 = 0x0000_1000;
 const FILE_OPEN_BY_FILE_ID: u32 = 0x0000_2000;
 const FILE_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
-const ALLOWED_CREATE_OPTIONS: u32 =
-    FILE_DIRECTORY_FILE | FILE_NON_DIRECTORY_FILE | FILE_WRITE_THROUGH | FILE_SEQUENTIAL_ONLY | FILE_RANDOM_ACCESS;
+const ALLOWED_CREATE_OPTIONS: u32 = FILE_DIRECTORY_FILE
+    | FILE_NON_DIRECTORY_FILE
+    | FILE_WRITE_THROUGH
+    | FILE_SEQUENTIAL_ONLY
+    | FILE_SYNCHRONOUS_IO_NONALERT
+    | FILE_RANDOM_ACCESS;
 
 /// Windows backend that safely opens files below explicitly configured roots.
 #[derive(Debug)]
@@ -75,10 +80,10 @@ impl WindowsRdpdrBackend {
 
     fn activate_drive(&mut self, device_id: u32) -> PduResult<()> {
         if device_id != self.drive.device_id() {
-            return Err(pdu_other_err!("Windows RDPDR drive is not configured"));
+            return Err(pdu_other_err!("windows RDPDR drive is not configured"));
         }
         if self.root.is_some() {
-            return Err(pdu_other_err!("Windows RDPDR drive is already active"));
+            return Err(pdu_other_err!("windows RDPDR drive is already active"));
         }
         let root = RootDirectory::open(self.drive.root_path())
             .map_err(|_status| pdu_other_err!("open configured Windows RDPDR volume root"))?;
@@ -245,7 +250,6 @@ impl WindowsRdpdrBackend {
         if completion.transferred != req.write_data.len() {
             return Err(NtStatus::UNSUCCESSFUL);
         }
-        file.handle.flush().map_err(from_ntstatus)?;
         u32::try_from(completion.transferred).map_err(|_| NtStatus::UNSUCCESSFUL)
     }
 

--- a/crates/ironrdp-rdpdr-native/src/windows/backend.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/backend.rs
@@ -1,0 +1,840 @@
+//! Narrow Windows filesystem backend for the portable RDPDR contract.
+//!
+//! The IRPs implemented here correspond to [MS-RDPEFS] 2.2.3.3.1 through
+//! 2.2.3.3.4 and 2.2.3.3.8 through 2.2.3.3.9. Native information buffers use
+//! [MS-FSCC] 2.4.7, 2.4.14, and 2.4.47.
+//!
+//! [MS-RDPEFS]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs
+//! [MS-FSCC]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc
+
+use ironrdp_core::impl_as_any;
+use ironrdp_pdu::{PduResult, encode_err, pdu_other_err};
+use ironrdp_rdpdr::RdpdrBackend;
+use ironrdp_rdpdr::pdu::RdpdrPdu;
+use ironrdp_rdpdr::pdu::efs::{
+    AnyIoCtlCode, Boolean, ClientDriveLockControlResponse, ClientDriveNotifyChangeDirectoryResponse,
+    ClientDriveQueryDirectoryResponse, ClientDriveQueryInformationResponse, ClientDriveQueryVolumeInformationResponse,
+    ClientDriveSetInformationResponse, DecodedDeviceControlRequest, DeviceCloseRequest, DeviceCloseResponse,
+    DeviceControlRequest, DeviceControlResponse, DeviceCreateRequest, DeviceCreateResponse, DeviceIoResponse,
+    DeviceReadRequest, DeviceReadResponse, DeviceWriteRequest, DeviceWriteResponse, FileAttributeTagInformation,
+    FileAttributes, FileBasicInformation, FileInformationClass, FileInformationClassLevel, FileStandardInformation,
+    Information, NtStatus, ServerDeviceAnnounceResponse, ServerDriveIoRequest, ServerDriveQueryInformationRequest,
+    ServerDriveSetInformationRequest,
+};
+use ironrdp_rdpdr::pdu::esc::{ScardCall, ScardIoCtlCode};
+use ironrdp_svc::SvcMessage;
+use windows::Wdk::Storage::FileSystem::FILE_BASIC_INFORMATION as NativeFileBasicInformation;
+
+use super::factory::RedirectedDrive;
+use super::file_table::FileTable;
+use super::handles::{
+    FILE_CREATED_INFORMATION, FILE_OPENED_INFORMATION, FILE_OVERWRITTEN_INFORMATION, FILE_SUPERSEDED_INFORMATION,
+    FileHandle, FileOpenOptions, RootDirectory,
+};
+use super::path::RelativePath;
+use super::status::{from_ntstatus, from_path_policy};
+
+const DEFAULT_MAX_OPEN_FILES: usize = 1_024;
+const MAX_STATIC_IO_SIZE: usize = 1_024 * 1_024;
+const SYNCHRONIZE: u32 = 0x0010_0000;
+const FILE_READ_ATTRIBUTES: u32 = 0x0000_0080;
+const FILE_WRITE_DATA: u32 = 0x0000_0002;
+const FILE_APPEND_DATA: u32 = 0x0000_0004;
+const FILE_WRITE_EA: u32 = 0x0000_0010;
+const FILE_WRITE_ATTRIBUTES: u32 = 0x0000_0100;
+const DELETE: u32 = 0x0001_0000;
+const GENERIC_ALL: u32 = 0x1000_0000;
+const GENERIC_WRITE: u32 = 0x4000_0000;
+const FILE_DIRECTORY_FILE: u32 = 0x0000_0001;
+const FILE_NON_DIRECTORY_FILE: u32 = 0x0000_0040;
+const FILE_WRITE_THROUGH: u32 = 0x0000_0002;
+const FILE_SEQUENTIAL_ONLY: u32 = 0x0000_0004;
+const FILE_RANDOM_ACCESS: u32 = 0x0000_0800;
+const FILE_DELETE_ON_CLOSE: u32 = 0x0000_1000;
+const FILE_OPEN_BY_FILE_ID: u32 = 0x0000_2000;
+const FILE_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+const ALLOWED_CREATE_OPTIONS: u32 =
+    FILE_DIRECTORY_FILE | FILE_NON_DIRECTORY_FILE | FILE_WRITE_THROUGH | FILE_SEQUENTIAL_ONLY | FILE_RANDOM_ACCESS;
+
+/// Windows backend that safely opens files below explicitly configured roots.
+#[derive(Debug)]
+pub struct WindowsRdpdrBackend {
+    drive: RedirectedDrive,
+    root: Option<RedirectedRoot>,
+    open_files: FileTable<OpenFile>,
+}
+
+impl WindowsRdpdrBackend {
+    pub(crate) fn from_drive(drive: RedirectedDrive) -> Self {
+        Self {
+            drive,
+            root: None,
+            open_files: FileTable::new(DEFAULT_MAX_OPEN_FILES),
+        }
+    }
+
+    fn activate_drive(&mut self, device_id: u32) -> PduResult<()> {
+        if device_id != self.drive.device_id() {
+            return Err(pdu_other_err!("Windows RDPDR drive is not configured"));
+        }
+        if self.root.is_some() {
+            return Err(pdu_other_err!("Windows RDPDR drive is already active"));
+        }
+        let root = RootDirectory::open(self.drive.root_path())
+            .map_err(|_status| pdu_other_err!("open configured Windows RDPDR volume root"))?;
+        self.root = Some(RedirectedRoot {
+            root,
+            read_only: self.drive.read_only(),
+        });
+        Ok(())
+    }
+
+    fn create(&mut self, req: DeviceCreateRequest) -> PduResult<Vec<SvcMessage>> {
+        let response = match self.create_inner(&req) {
+            Ok((file_id, information)) => DeviceCreateResponse {
+                device_io_reply: DeviceIoResponse::new(req.device_io_request, NtStatus::SUCCESS),
+                file_id,
+                information,
+            },
+            Err(status) => DeviceCreateResponse {
+                device_io_reply: DeviceIoResponse::new(req.device_io_request, status),
+                file_id: 0,
+                information: Information::empty(),
+            },
+        };
+
+        Ok(vec![SvcMessage::from(RdpdrPdu::DeviceCreateResponse(response))])
+    }
+
+    fn create_inner(&mut self, req: &DeviceCreateRequest) -> Result<(u32, Information), NtStatus> {
+        let path = RelativePath::parse(&req.path).map_err(from_path_policy)?;
+        let is_root = path.components().next().is_none();
+        if req.device_io_request.device_id != self.drive.device_id() {
+            return Err(NtStatus::INVALID_PARAMETER);
+        }
+        let root = self.root.as_ref().ok_or(NtStatus::INVALID_PARAMETER)?;
+        validate_create_request(req, root.read_only, is_root)?;
+
+        if is_root {
+            let disposition = u32::from(req.create_disposition);
+            if !matches!(
+                disposition,
+                x if x == u32::from(ironrdp_rdpdr::pdu::efs::CreateDisposition::FILE_OPEN)
+                    || x == u32::from(ironrdp_rdpdr::pdu::efs::CreateDisposition::FILE_OPEN_IF)
+            ) {
+                return Err(NtStatus::OBJECT_NAME_COLLISION);
+            }
+            if req.create_options.bits() & FILE_NON_DIRECTORY_FILE != 0 {
+                return Err(NtStatus::FILE_IS_A_DIRECTORY);
+            }
+            if req.allocation_size != 0 {
+                return Err(NtStatus::INVALID_PARAMETER);
+            }
+        }
+
+        let allocation_size = i64::try_from(req.allocation_size).map_err(|_| NtStatus::INVALID_PARAMETER)?;
+        let options = FileOpenOptions {
+            // Explorer often opens an object for enumeration and then asks for
+            // metadata without separately requesting FILE_READ_ATTRIBUTES.
+            desired_access: req.desired_access.bits() | SYNCHRONIZE | FILE_READ_ATTRIBUTES,
+            allocation_size: (req.allocation_size != 0).then_some(allocation_size),
+            file_attributes: req.file_attributes.bits(),
+            share_access: req.shared_access.bits(),
+            create_disposition: u32::from(req.create_disposition),
+            create_options: req.create_options.bits(),
+        };
+        let reservation = self.open_files.reserve_file_id().map_err(|error| match error {
+            super::file_table::FileTableError::CapacityExceeded
+            | super::file_table::FileTableError::IdSpaceExhausted => NtStatus::from(0xC000_009A),
+        })?;
+        let file_id = reservation.file_id();
+        let (handle, native_information) = match root.root.open_relative_file(&path, options) {
+            Ok(result) => result,
+            Err(status) => {
+                self.open_files.release_file_id(reservation);
+                return Err(from_ntstatus(status));
+            }
+        };
+        let information = match create_information(native_information) {
+            Ok(information) => information,
+            Err(status) => {
+                self.open_files.release_file_id(reservation);
+                return Err(status);
+            }
+        };
+        self.open_files.insert(
+            reservation,
+            OpenFile {
+                read_only: root.read_only,
+                handle,
+            },
+        );
+
+        Ok((file_id, information))
+    }
+
+    fn close(&mut self, req: DeviceCloseRequest) -> PduResult<Vec<SvcMessage>> {
+        let status = match self.open_files.get(req.device_io_request.file_id) {
+            Some(_) if req.device_io_request.device_id == self.drive.device_id() => {
+                let _ = self.open_files.remove(req.device_io_request.file_id);
+                NtStatus::SUCCESS
+            }
+            _ => NtStatus::INVALID_HANDLE,
+        };
+        Ok(vec![SvcMessage::from(RdpdrPdu::DeviceCloseResponse(
+            DeviceCloseResponse {
+                device_io_response: DeviceIoResponse::new(req.device_io_request, status),
+            },
+        ))])
+    }
+
+    fn read(&self, req: DeviceReadRequest) -> PduResult<Vec<SvcMessage>> {
+        let (status, read_data) = self
+            .read_inner(&req)
+            .map_or_else(|status| (status, Vec::new()), |data| (NtStatus::SUCCESS, data));
+        Ok(vec![SvcMessage::from(RdpdrPdu::DeviceReadResponse(
+            DeviceReadResponse {
+                device_io_reply: DeviceIoResponse::new(req.device_io_request, status),
+                read_data,
+            },
+        ))])
+    }
+
+    fn read_inner(&self, req: &DeviceReadRequest) -> Result<Vec<u8>, NtStatus> {
+        let length = usize::try_from(req.length).map_err(|_| NtStatus::INVALID_PARAMETER)?;
+        validate_io_length(length)?;
+        let offset = i64::try_from(req.offset).map_err(|_| NtStatus::INVALID_PARAMETER)?;
+        let file = self.file_for_request(req.device_io_request.device_id, req.device_io_request.file_id)?;
+        let mut data = vec![0; length];
+        let completion = file.handle.read_at(offset, &mut data).map_err(from_ntstatus)?;
+        if completion.status.0 < 0 {
+            return Err(from_ntstatus(completion.status));
+        }
+        data.truncate(completion.transferred);
+        Ok(data)
+    }
+
+    fn write(&self, req: DeviceWriteRequest) -> PduResult<Vec<SvcMessage>> {
+        let (status, length) = self
+            .write_inner(&req)
+            .map_or_else(|status| (status, 0), |length| (NtStatus::SUCCESS, length));
+        Ok(vec![SvcMessage::from(RdpdrPdu::DeviceWriteResponse(
+            DeviceWriteResponse {
+                device_io_reply: DeviceIoResponse::new(req.device_io_request, status),
+                length,
+            },
+        ))])
+    }
+
+    fn write_inner(&self, req: &DeviceWriteRequest) -> Result<u32, NtStatus> {
+        validate_io_length(req.write_data.len())?;
+        let offset = if req.offset == u64::MAX {
+            -1 // FILE_WRITE_TO_END_OF_FILE
+        } else {
+            i64::try_from(req.offset).map_err(|_| NtStatus::INVALID_PARAMETER)?
+        };
+        let file = self.file_for_request(req.device_io_request.device_id, req.device_io_request.file_id)?;
+        if file.read_only {
+            return Err(NtStatus::MEDIA_WRITE_PROTECTED);
+        }
+
+        let completion = file.handle.write_at(offset, &req.write_data).map_err(from_ntstatus)?;
+        if completion.status.0 < 0 {
+            return Err(from_ntstatus(completion.status));
+        }
+        if completion.transferred != req.write_data.len() {
+            return Err(NtStatus::UNSUCCESSFUL);
+        }
+        file.handle.flush().map_err(from_ntstatus)?;
+        u32::try_from(completion.transferred).map_err(|_| NtStatus::UNSUCCESSFUL)
+    }
+
+    fn query_information(&self, req: ServerDriveQueryInformationRequest) -> PduResult<Vec<SvcMessage>> {
+        let (status, buffer) = self
+            .query_information_inner(&req)
+            .map_or_else(|status| (status, None), |buffer| (NtStatus::SUCCESS, Some(buffer)));
+        Ok(vec![SvcMessage::from(RdpdrPdu::ClientDriveQueryInformationResponse(
+            ClientDriveQueryInformationResponse {
+                device_io_response: DeviceIoResponse::new(req.device_io_request, status),
+                buffer,
+            },
+        ))])
+    }
+
+    fn query_information_inner(
+        &self,
+        req: &ServerDriveQueryInformationRequest,
+    ) -> Result<FileInformationClass, NtStatus> {
+        let file = self.file_for_request(req.device_io_request.device_id, req.device_io_request.file_id)?;
+
+        match req.file_info_class_lvl {
+            FileInformationClassLevel::FILE_BASIC_INFORMATION => {
+                let information = file.handle.query_basic_information().map_err(from_ntstatus)?;
+                Ok(FileBasicInformation {
+                    creation_time: information.CreationTime,
+                    last_access_time: information.LastAccessTime,
+                    last_write_time: information.LastWriteTime,
+                    change_time: information.ChangeTime,
+                    file_attributes: FileAttributes::from_bits_retain(information.FileAttributes),
+                }
+                .into())
+            }
+            FileInformationClassLevel::FILE_STANDARD_INFORMATION => {
+                let information = file.handle.query_standard_information().map_err(from_ntstatus)?;
+                Ok(FileStandardInformation {
+                    allocation_size: information.AllocationSize,
+                    end_of_file: information.EndOfFile,
+                    number_of_links: information.NumberOfLinks,
+                    delete_pending: Boolean::from(u8::from(information.DeletePending)),
+                    directory: Boolean::from(u8::from(information.Directory)),
+                }
+                .into())
+            }
+            FileInformationClassLevel::FILE_ATTRIBUTE_TAG_INFORMATION => {
+                let information = file.handle.query_attribute_tag_information().map_err(from_ntstatus)?;
+                Ok(FileAttributeTagInformation {
+                    file_attributes: FileAttributes::from_bits_retain(information.FileAttributes),
+                    reparse_tag: information.ReparseTag,
+                }
+                .into())
+            }
+            _ => Err(NtStatus::NOT_SUPPORTED),
+        }
+    }
+
+    fn set_information(&self, req: ServerDriveSetInformationRequest) -> PduResult<Vec<SvcMessage>> {
+        let status = self
+            .set_information_inner(&req)
+            .map_or_else(|status| status, |_| NtStatus::SUCCESS);
+        let response = ClientDriveSetInformationResponse::new(&req, status).map_err(|error| encode_err!(error))?;
+        Ok(vec![SvcMessage::from(RdpdrPdu::ClientDriveSetInformationResponse(
+            response,
+        ))])
+    }
+
+    fn set_information_inner(&self, req: &ServerDriveSetInformationRequest) -> Result<(), NtStatus> {
+        let file = self.file_for_request(req.device_io_request.device_id, req.device_io_request.file_id)?;
+        if file.read_only {
+            return Err(NtStatus::MEDIA_WRITE_PROTECTED);
+        }
+
+        match &req.set_buffer {
+            FileInformationClass::EndOfFile(information) => {
+                if information.end_of_file < 0 {
+                    return Err(NtStatus::INVALID_PARAMETER);
+                }
+                file.handle
+                    .set_end_of_file(information.end_of_file)
+                    .map_err(from_ntstatus)
+            }
+            FileInformationClass::Basic(information) => {
+                if [
+                    information.creation_time,
+                    information.last_access_time,
+                    information.last_write_time,
+                    information.change_time,
+                ]
+                .into_iter()
+                .any(|time| time < -2)
+                {
+                    return Err(NtStatus::INVALID_PARAMETER);
+                }
+                file.handle
+                    .set_basic_information(NativeFileBasicInformation {
+                        CreationTime: information.creation_time,
+                        LastAccessTime: information.last_access_time,
+                        LastWriteTime: information.last_write_time,
+                        ChangeTime: information.change_time,
+                        FileAttributes: information.file_attributes.bits(),
+                    })
+                    .map_err(from_ntstatus)
+            }
+            _ => Err(NtStatus::NOT_SUPPORTED),
+        }
+    }
+
+    fn file_for_request(&self, device_id: u32, file_id: u32) -> Result<&OpenFile, NtStatus> {
+        if device_id != self.drive.device_id() {
+            return Err(NtStatus::INVALID_HANDLE);
+        }
+
+        self.open_files.get(file_id).ok_or(NtStatus::INVALID_HANDLE)
+    }
+
+    fn unsupported_control(req: DeviceControlRequest<AnyIoCtlCode>) -> PduResult<Vec<SvcMessage>> {
+        Ok(vec![SvcMessage::from(RdpdrPdu::DeviceControlResponse(
+            DeviceControlResponse::new(req, NtStatus::NOT_SUPPORTED, None),
+        ))])
+    }
+}
+
+impl_as_any!(WindowsRdpdrBackend);
+
+impl RdpdrBackend for WindowsRdpdrBackend {
+    fn reset(&mut self) -> PduResult<()> {
+        self.open_files.clear();
+        self.root = None;
+        Ok(())
+    }
+
+    fn restore_drive(&mut self, device_id: u32) -> PduResult<()> {
+        self.activate_drive(device_id)
+    }
+
+    fn handle_server_device_announce_response(&mut self, _pdu: ServerDeviceAnnounceResponse) -> PduResult<()> {
+        Ok(())
+    }
+
+    fn handle_scard_call(&mut self, _req: DeviceControlRequest<ScardIoCtlCode>, _call: ScardCall) -> PduResult<()> {
+        Ok(())
+    }
+
+    fn handle_drive_io_request(&mut self, req: ServerDriveIoRequest) -> PduResult<Vec<SvcMessage>> {
+        match req {
+            ServerDriveIoRequest::ServerCreateDriveRequest(req) => self.create(req),
+            ServerDriveIoRequest::DeviceCloseRequest(req) => self.close(req),
+            ServerDriveIoRequest::DeviceReadRequest(req) => self.read(req),
+            ServerDriveIoRequest::DeviceWriteRequest(req) => self.write(req),
+            ServerDriveIoRequest::ServerDriveQueryInformationRequest(req) => self.query_information(req),
+            ServerDriveIoRequest::ServerDriveSetInformationRequest(req) => self.set_information(req),
+            ServerDriveIoRequest::ServerDriveQueryDirectoryRequest(req) => Ok(vec![SvcMessage::from(
+                RdpdrPdu::ClientDriveQueryDirectoryResponse(ClientDriveQueryDirectoryResponse {
+                    device_io_reply: DeviceIoResponse::new(req.device_io_request, NtStatus::NOT_SUPPORTED),
+                    buffer: None,
+                }),
+            )]),
+            ServerDriveIoRequest::ServerDriveNotifyChangeDirectoryRequest(req) => Ok(vec![SvcMessage::from(
+                RdpdrPdu::ClientDriveNotifyChangeDirectoryResponse(ClientDriveNotifyChangeDirectoryResponse::new(
+                    req.device_io_request,
+                    NtStatus::NOT_SUPPORTED,
+                    Vec::new(),
+                )),
+            )]),
+            ServerDriveIoRequest::ServerDriveQueryVolumeInformationRequest(req) => Ok(vec![SvcMessage::from(
+                RdpdrPdu::ClientDriveQueryVolumeInformationResponse(ClientDriveQueryVolumeInformationResponse::new(
+                    req.device_io_request,
+                    NtStatus::NOT_SUPPORTED,
+                    None,
+                )),
+            )]),
+            ServerDriveIoRequest::ServerDriveLockControlRequest(req) => {
+                Ok(vec![SvcMessage::from(RdpdrPdu::ClientDriveLockControlResponse(
+                    ClientDriveLockControlResponse::new(req.device_io_request, NtStatus::NOT_SUPPORTED),
+                ))])
+            }
+            ServerDriveIoRequest::DeviceControlRequest(req) => Self::unsupported_control(req),
+        }
+    }
+
+    fn handle_drive_device_control(
+        &mut self,
+        req: DecodedDeviceControlRequest<AnyIoCtlCode>,
+    ) -> PduResult<Vec<SvcMessage>> {
+        Self::unsupported_control(req.request)
+    }
+}
+
+#[derive(Debug)]
+struct RedirectedRoot {
+    root: RootDirectory,
+    read_only: bool,
+}
+
+#[derive(Debug)]
+struct OpenFile {
+    read_only: bool,
+    handle: FileHandle,
+}
+
+fn validate_create_request(req: &DeviceCreateRequest, read_only: bool, is_root: bool) -> Result<(), NtStatus> {
+    let desired_access = req.desired_access.bits();
+    let options = req.create_options.bits();
+    let disposition = u32::from(req.create_disposition);
+
+    if i64::try_from(req.allocation_size).is_err() {
+        return Err(NtStatus::INVALID_PARAMETER);
+    }
+    if options & (FILE_OPEN_BY_FILE_ID | FILE_OPEN_REPARSE_POINT | FILE_DELETE_ON_CLOSE) != 0
+        || options & !ALLOWED_CREATE_OPTIONS != 0
+    {
+        return Err(NtStatus::NOT_SUPPORTED);
+    }
+    if options & FILE_DIRECTORY_FILE != 0 && options & FILE_NON_DIRECTORY_FILE != 0 {
+        return Err(NtStatus::INVALID_PARAMETER);
+    }
+    if !matches!(
+        disposition,
+        x if x == u32::from(ironrdp_rdpdr::pdu::efs::CreateDisposition::FILE_SUPERSEDE)
+            || x == u32::from(ironrdp_rdpdr::pdu::efs::CreateDisposition::FILE_OPEN)
+            || x == u32::from(ironrdp_rdpdr::pdu::efs::CreateDisposition::FILE_CREATE)
+            || x == u32::from(ironrdp_rdpdr::pdu::efs::CreateDisposition::FILE_OPEN_IF)
+            || x == u32::from(ironrdp_rdpdr::pdu::efs::CreateDisposition::FILE_OVERWRITE)
+            || x == u32::from(ironrdp_rdpdr::pdu::efs::CreateDisposition::FILE_OVERWRITE_IF)
+    ) {
+        return Err(NtStatus::INVALID_PARAMETER);
+    }
+
+    let mutating_disposition = matches!(
+        disposition,
+        x if x == u32::from(ironrdp_rdpdr::pdu::efs::CreateDisposition::FILE_SUPERSEDE)
+            || x == u32::from(ironrdp_rdpdr::pdu::efs::CreateDisposition::FILE_CREATE)
+            || (x == u32::from(ironrdp_rdpdr::pdu::efs::CreateDisposition::FILE_OPEN_IF) && !is_root)
+            || x == u32::from(ironrdp_rdpdr::pdu::efs::CreateDisposition::FILE_OVERWRITE)
+            || x == u32::from(ironrdp_rdpdr::pdu::efs::CreateDisposition::FILE_OVERWRITE_IF)
+    );
+    let mutating_access = FILE_WRITE_DATA
+        | FILE_APPEND_DATA
+        | FILE_WRITE_EA
+        | FILE_WRITE_ATTRIBUTES
+        | DELETE
+        | GENERIC_ALL
+        | GENERIC_WRITE;
+    if read_only && (desired_access & mutating_access != 0 || mutating_disposition) {
+        return Err(NtStatus::MEDIA_WRITE_PROTECTED);
+    }
+
+    Ok(())
+}
+
+fn validate_io_length(length: usize) -> Result<(), NtStatus> {
+    if length > MAX_STATIC_IO_SIZE {
+        return Err(NtStatus::INVALID_PARAMETER);
+    }
+    Ok(())
+}
+
+fn create_information(information: usize) -> Result<Information, NtStatus> {
+    match information {
+        FILE_SUPERSEDED_INFORMATION => Ok(Information::file_superseded()),
+        FILE_OPENED_INFORMATION => Ok(Information::file_opened()),
+        FILE_CREATED_INFORMATION => Ok(Information::file_created()),
+        FILE_OVERWRITTEN_INFORMATION => Ok(Information::file_overwritten()),
+        _ => Err(NtStatus::UNSUCCESSFUL),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use ironrdp_rdpdr::pdu::efs::{
+        CreateDisposition, CreateOptions, DesiredAccess, FileEndOfFileInformation, LockOperation, MajorFunction,
+        MinorFunction, ServerDriveLockControlRequest, ServerDriveNotifyChangeDirectoryRequest, SharedAccess,
+    };
+
+    use crate::windows::factory::WindowsRdpdrBackendFactory;
+
+    #[test]
+    fn regular_file_lifecycle_is_handle_relative_and_bounded() {
+        let fixture = Fixture::new();
+        let mut backend = fixture.backend();
+        activate(&mut backend);
+
+        let create = create_request(&fixture.relative(r"root\report.txt"), CreateDisposition::FILE_OPEN_IF);
+        let create_response = backend
+            .handle_drive_io_request(ServerDriveIoRequest::ServerCreateDriveRequest(create))
+            .expect("complete create");
+        assert_eq!(response_status(&create_response), NtStatus::SUCCESS);
+        let file_id = response_file_id(&create_response);
+
+        let write = DeviceWriteRequest {
+            device_io_request: request_header(file_id, MajorFunction::Write),
+            offset: 0,
+            write_data: b"hello".to_vec(),
+        };
+        let write_response = backend
+            .handle_drive_io_request(ServerDriveIoRequest::DeviceWriteRequest(write))
+            .expect("complete write");
+        assert_eq!(response_status(&write_response), NtStatus::SUCCESS);
+
+        let append_response = backend
+            .handle_drive_io_request(ServerDriveIoRequest::DeviceWriteRequest(DeviceWriteRequest {
+                device_io_request: request_header(file_id, MajorFunction::Write),
+                offset: u64::MAX,
+                write_data: b"!".to_vec(),
+            }))
+            .expect("complete append");
+        assert_eq!(response_status(&append_response), NtStatus::SUCCESS);
+
+        let read = DeviceReadRequest {
+            device_io_request: request_header(file_id, MajorFunction::Read),
+            length: 6,
+            offset: 0,
+        };
+        let read_response = backend
+            .handle_drive_io_request(ServerDriveIoRequest::DeviceReadRequest(read))
+            .expect("complete read");
+        assert_eq!(response_status(&read_response), NtStatus::SUCCESS);
+        let bytes = read_response[0].encode_unframed_pdu().expect("encode read response");
+        assert_eq!(&bytes[20..], b"hello!");
+
+        for file_info_class_lvl in [
+            FileInformationClassLevel::FILE_BASIC_INFORMATION,
+            FileInformationClassLevel::FILE_STANDARD_INFORMATION,
+            FileInformationClassLevel::FILE_ATTRIBUTE_TAG_INFORMATION,
+        ] {
+            let query_response = backend
+                .handle_drive_io_request(ServerDriveIoRequest::ServerDriveQueryInformationRequest(
+                    ServerDriveQueryInformationRequest {
+                        device_io_request: request_header(file_id, MajorFunction::QueryInformation),
+                        file_info_class_lvl,
+                    },
+                ))
+                .expect("complete metadata query");
+            assert_eq!(response_status(&query_response), NtStatus::SUCCESS);
+        }
+
+        let set = ServerDriveSetInformationRequest {
+            device_io_request: request_header(file_id, MajorFunction::SetInformation),
+            set_buffer: FileInformationClass::EndOfFile(FileEndOfFileInformation { end_of_file: 3 }),
+        };
+        let set_response = backend
+            .handle_drive_io_request(ServerDriveIoRequest::ServerDriveSetInformationRequest(set))
+            .expect("complete set information");
+        assert_eq!(response_status(&set_response), NtStatus::SUCCESS);
+        assert_eq!(
+            std::fs::read(fixture.root.join("root").join("report.txt")).expect("read test file"),
+            b"hel"
+        );
+
+        let close_response = backend
+            .handle_drive_io_request(ServerDriveIoRequest::DeviceCloseRequest(DeviceCloseRequest {
+                device_io_request: request_header(file_id, MajorFunction::Close),
+            }))
+            .expect("complete close");
+        assert_eq!(response_status(&close_response), NtStatus::SUCCESS);
+    }
+
+    #[test]
+    fn volume_root_requests_use_the_trusted_root_handle() {
+        let fixture = Fixture::new();
+        let mut backend = fixture.backend();
+        activate(&mut backend);
+
+        let mut create = create_request(r"\", CreateDisposition::FILE_OPEN);
+        create.desired_access = DesiredAccess::from_bits_retain(FILE_READ_ATTRIBUTES | SYNCHRONIZE);
+        let response = backend
+            .handle_drive_io_request(ServerDriveIoRequest::ServerCreateDriveRequest(create))
+            .expect("complete root create");
+        assert_eq!(response_status(&response), NtStatus::SUCCESS);
+
+        let close = backend
+            .handle_drive_io_request(ServerDriveIoRequest::DeviceCloseRequest(DeviceCloseRequest {
+                device_io_request: request_header(response_file_id(&response), MajorFunction::Close),
+            }))
+            .expect("complete root close");
+        assert_eq!(response_status(&close), NtStatus::SUCCESS);
+    }
+
+    #[test]
+    fn hostile_paths_never_open_outside_the_selected_volume() {
+        let fixture = Fixture::new();
+        let mut backend = fixture.backend();
+        activate(&mut backend);
+
+        for path in [
+            r"\..\outside.txt",
+            r"\??\C:\outside.txt",
+            r"\root\CON",
+            r"\root\file:stream",
+        ] {
+            let response = backend
+                .handle_drive_io_request(ServerDriveIoRequest::ServerCreateDriveRequest(create_request(
+                    path,
+                    CreateDisposition::FILE_OPEN_IF,
+                )))
+                .expect("complete hostile create");
+            assert_ne!(response_status(&response), NtStatus::SUCCESS);
+        }
+    }
+
+    #[test]
+    fn backup_intent_is_not_forwarded_to_windows() {
+        let fixture = Fixture::new();
+        let mut backend = fixture.backend();
+        activate(&mut backend);
+
+        let mut create = create_request(&fixture.relative(r"root\backup.txt"), CreateDisposition::FILE_OPEN_IF);
+        create.create_options = CreateOptions::from_bits_retain(0x0000_4000);
+        let response = backend
+            .handle_drive_io_request(ServerDriveIoRequest::ServerCreateDriveRequest(create))
+            .expect("complete backup intent create");
+
+        assert_eq!(response_status(&response), NtStatus::NOT_SUPPORTED);
+        assert!(!fixture.root.join("root").join("backup.txt").exists());
+    }
+
+    #[test]
+    fn reparse_points_cannot_escape_the_trusted_volume_root() {
+        let fixture = Fixture::new();
+        let outside = fixture.sandbox.join("outside");
+        std::fs::create_dir_all(&outside).expect("create outside directory");
+        std::fs::write(outside.join("sentinel.txt"), b"outside").expect("write sentinel");
+
+        let link = fixture.root.join("root").join("escape");
+        if let Err(error) = std::os::windows::fs::symlink_dir(&outside, &link) {
+            if error.raw_os_error() == Some(1314) {
+                return;
+            }
+            panic!("create test reparse point: {error}");
+        }
+
+        let mut backend = fixture.backend();
+        activate(&mut backend);
+        let response = backend
+            .handle_drive_io_request(ServerDriveIoRequest::ServerCreateDriveRequest(create_request(
+                &fixture.relative(r"root\escape\sentinel.txt"),
+                CreateDisposition::FILE_OPEN,
+            )))
+            .expect("complete reparse create");
+
+        assert_ne!(response_status(&response), NtStatus::SUCCESS);
+        assert_eq!(
+            std::fs::read(outside.join("sentinel.txt")).expect("read sentinel"),
+            b"outside"
+        );
+    }
+
+    #[test]
+    fn unsupported_device_control_receives_a_completion() {
+        let fixture = Fixture::new();
+        let mut backend = fixture.backend();
+        activate(&mut backend);
+        let request = DeviceControlRequest {
+            header: request_header(0, MajorFunction::DeviceControl),
+            output_buffer_length: 0,
+            input_buffer_length: 0,
+            io_control_code: AnyIoCtlCode(0),
+        };
+
+        let response = backend
+            .handle_drive_io_request(ServerDriveIoRequest::DeviceControlRequest(request))
+            .expect("complete unsupported control");
+        assert_eq!(response_status(&response), NtStatus::NOT_SUPPORTED);
+    }
+
+    #[test]
+    fn unsupported_directory_notifications_and_locks_receive_completions() {
+        let fixture = Fixture::new();
+        let mut backend = fixture.backend();
+        activate(&mut backend);
+
+        let notification = backend
+            .handle_drive_io_request(ServerDriveIoRequest::ServerDriveNotifyChangeDirectoryRequest(
+                ServerDriveNotifyChangeDirectoryRequest {
+                    device_io_request: request_header(0, MajorFunction::DirectoryControl),
+                    watch_tree: 0,
+                    completion_filter: 0,
+                },
+            ))
+            .expect("complete unsupported notification");
+        assert_eq!(response_status(&notification), NtStatus::NOT_SUPPORTED);
+
+        let lock = backend
+            .handle_drive_io_request(ServerDriveIoRequest::ServerDriveLockControlRequest(
+                ServerDriveLockControlRequest {
+                    device_io_request: request_header(0, MajorFunction::LockControl),
+                    operation: LockOperation::Exclusive,
+                    wait: false,
+                    locks: Vec::new(),
+                },
+            ))
+            .expect("complete unsupported lock");
+        assert_eq!(response_status(&lock), NtStatus::NOT_SUPPORTED);
+    }
+
+    fn activate(backend: &mut WindowsRdpdrBackend) {
+        RdpdrBackend::restore_drive(backend, 1).expect("activate test drive");
+    }
+
+    fn create_request(path: &str, disposition: CreateDisposition) -> DeviceCreateRequest {
+        DeviceCreateRequest {
+            device_io_request: request_header(0, MajorFunction::Create),
+            desired_access: DesiredAccess::from_bits_retain(0x0010_0083),
+            allocation_size: 0,
+            file_attributes: FileAttributes::FILE_ATTRIBUTE_NORMAL,
+            shared_access: SharedAccess::from_bits_retain(0x0000_0007),
+            create_disposition: disposition,
+            create_options: CreateOptions::empty(),
+            path: path.to_owned(),
+        }
+    }
+
+    fn request_header(file_id: u32, major_function: MajorFunction) -> ironrdp_rdpdr::pdu::efs::DeviceIoRequest {
+        ironrdp_rdpdr::pdu::efs::DeviceIoRequest {
+            device_id: 1,
+            file_id,
+            completion_id: 7,
+            major_function,
+            minor_function: MinorFunction::from(0),
+        }
+    }
+
+    fn response_status(messages: &[SvcMessage]) -> NtStatus {
+        let response = messages[0].encode_unframed_pdu().expect("encode RDPDR response");
+        NtStatus::from(u32::from_le_bytes(
+            response[12..16].try_into().expect("response status"),
+        ))
+    }
+
+    fn response_file_id(messages: &[SvcMessage]) -> u32 {
+        let response = messages[0].encode_unframed_pdu().expect("encode create response");
+        u32::from_le_bytes(response[16..20].try_into().expect("create file ID"))
+    }
+
+    struct Fixture {
+        sandbox: PathBuf,
+        root: PathBuf,
+        volume_root: PathBuf,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            let workspace = std::env::current_dir().expect("current workspace directory");
+            let volume_root = workspace
+                .ancestors()
+                .last()
+                .expect("workspace has a volume root")
+                .to_owned();
+            let unique = format!(
+                "rdpdr-native-{}-{}",
+                std::process::id(),
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .expect("system clock is after Unix epoch")
+                    .as_nanos()
+            );
+            let sandbox = workspace.join("target").join(unique);
+            let root = sandbox.join("root");
+            std::fs::create_dir_all(root.join("root")).expect("create fixture root");
+            Self {
+                sandbox,
+                root,
+                volume_root,
+            }
+        }
+
+        fn backend(&self) -> WindowsRdpdrBackend {
+            WindowsRdpdrBackendFactory::new(
+                RedirectedDrive::new(1, "Test", &self.volume_root, false).expect("valid test drive"),
+            )
+            .build()
+        }
+
+        fn relative(&self, suffix: &str) -> String {
+            let relative = self
+                .root
+                .strip_prefix(&self.volume_root)
+                .expect("fixture is beneath its volume root");
+            format!(r"\{}\{}", relative.display(), suffix).replace('/', r"\")
+        }
+    }
+
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.sandbox);
+        }
+    }
+}

--- a/crates/ironrdp-rdpdr-native/src/windows/factory.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/factory.rs
@@ -1,0 +1,135 @@
+//! Windows RDPDR backend configuration.
+
+use core::fmt;
+use std::path::{Path, PathBuf};
+
+use super::backend::WindowsRdpdrBackend;
+
+/// Immutable logical-volume definition selected for Windows RDPDR redirection.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RedirectedDrive {
+    device_id: u32,
+    display_name: String,
+    root_path: PathBuf,
+    read_only: bool,
+}
+
+impl RedirectedDrive {
+    /// Creates a drive definition for one full logical Windows volume.
+    pub fn new(
+        device_id: u32,
+        display_name: impl Into<String>,
+        root_path: impl Into<PathBuf>,
+        read_only: bool,
+    ) -> Result<Self, RedirectedDriveError> {
+        if device_id == 0 {
+            return Err(RedirectedDriveError::ReservedDeviceId);
+        }
+
+        let display_name = display_name.into();
+        if display_name.is_empty() {
+            return Err(RedirectedDriveError::EmptyDisplayName);
+        }
+        if display_name.contains('\0') {
+            return Err(RedirectedDriveError::EmbeddedNul);
+        }
+
+        Ok(Self {
+            device_id,
+            display_name,
+            root_path: root_path.into(),
+            read_only,
+        })
+    }
+
+    /// Returns the RDPDR filesystem device ID.
+    #[must_use]
+    pub fn device_id(&self) -> u32 {
+        self.device_id
+    }
+
+    /// Returns the drive name announced through the portable RDPDR channel.
+    #[must_use]
+    pub fn display_name(&self) -> &str {
+        &self.display_name
+    }
+
+    pub(crate) fn root_path(&self) -> &Path {
+        &self.root_path
+    }
+
+    pub(crate) fn read_only(&self) -> bool {
+        self.read_only
+    }
+}
+
+/// Invalid selected-drive configuration.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RedirectedDriveError {
+    /// Device ID zero is reserved for the smartcard channel.
+    ReservedDeviceId,
+    /// RDPDR requires a nonempty user-visible drive name.
+    EmptyDisplayName,
+    /// An embedded NUL would truncate the RDPDR Unicode device name.
+    EmbeddedNul,
+}
+
+impl fmt::Display for RedirectedDriveError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ReservedDeviceId => f.write_str("RDPDR device ID zero is reserved"),
+            Self::EmptyDisplayName => f.write_str("redirected drive display name must not be empty"),
+            Self::EmbeddedNul => f.write_str("redirected drive display name must not contain NUL"),
+        }
+    }
+}
+
+impl core::error::Error for RedirectedDriveError {}
+
+/// Creates one isolated backend from a fixed logical-volume definition.
+///
+/// The returned initial-drive list is intentionally shaped for
+/// [`ironrdp_rdpdr::Rdpdr::with_drives`], keeping platform configuration out of
+/// the portable RDPDR crate.
+#[derive(Clone, Debug)]
+pub struct WindowsRdpdrBackendFactory {
+    drive: RedirectedDrive,
+}
+
+impl WindowsRdpdrBackendFactory {
+    /// Configures the single logical-volume root supported by this baseline.
+    #[must_use]
+    pub fn new(drive: RedirectedDrive) -> Self {
+        Self { drive }
+    }
+
+    /// Returns the initial `(device_id, name)` pair for `Rdpdr::with_drives`.
+    #[must_use]
+    pub fn initial_drives(&self) -> Vec<(u32, String)> {
+        vec![(self.drive.device_id, self.drive.display_name.clone())]
+    }
+
+    /// Builds a backend with no active root handles.
+    ///
+    /// The portable channel activates initial drives with
+    /// `RdpdrBackend::restore_drive` at the start of each server-announcement
+    /// sequence.
+    #[must_use]
+    pub fn build(&self) -> WindowsRdpdrBackend {
+        WindowsRdpdrBackend::from_drive(self.drive.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn factory_preserves_portable_initial_drive_names() {
+        let factory = WindowsRdpdrBackendFactory::new(
+            RedirectedDrive::new(1, "System", r"C:\", false).expect("valid system drive"),
+        );
+
+        assert_eq!(factory.initial_drives(), vec![(1, "System".to_owned())]);
+    }
+}

--- a/crates/ironrdp-rdpdr-native/src/windows/factory.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/factory.rs
@@ -77,7 +77,7 @@ pub enum RedirectedDriveError {
 impl fmt::Display for RedirectedDriveError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::ReservedDeviceId => f.write_str("RDPDR device ID zero is reserved"),
+            Self::ReservedDeviceId => f.write_str("device ID zero is reserved for RDPDR"),
             Self::EmptyDisplayName => f.write_str("redirected drive display name must not be empty"),
             Self::EmbeddedNul => f.write_str("redirected drive display name must not contain NUL"),
         }

--- a/crates/ironrdp-rdpdr-native/src/windows/file_table.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/file_table.rs
@@ -1,0 +1,118 @@
+//! Bounded RDPDR file identifier allocation.
+
+use std::collections::HashMap;
+
+/// A table that keeps opaque local handles behind RDPDR file identifiers.
+#[derive(Debug)]
+pub(crate) struct FileTable<T> {
+    entries: HashMap<u32, T>,
+    available_ids: Vec<u32>,
+    next_id: Option<u32>,
+    max_entries: usize,
+    active_ids: usize,
+}
+
+/// An opaque file ID reserved before opening a native handle.
+#[derive(Debug)]
+pub(crate) struct FileIdReservation(u32);
+
+impl FileIdReservation {
+    pub(crate) fn file_id(&self) -> u32 {
+        self.0
+    }
+}
+
+impl<T> FileTable<T> {
+    pub(crate) fn new(max_entries: usize) -> Self {
+        Self {
+            entries: HashMap::new(),
+            available_ids: Vec::new(),
+            next_id: Some(1),
+            max_entries,
+            active_ids: 0,
+        }
+    }
+
+    pub(crate) fn reserve_file_id(&mut self) -> Result<FileIdReservation, FileTableError> {
+        if self.active_ids == self.max_entries {
+            return Err(FileTableError::CapacityExceeded);
+        }
+
+        let file_id = if let Some(file_id) = self.available_ids.pop() {
+            file_id
+        } else {
+            let file_id = self.next_id.ok_or(FileTableError::IdSpaceExhausted)?;
+            self.next_id = file_id.checked_add(1);
+            file_id
+        };
+        self.active_ids += 1;
+        Ok(FileIdReservation(file_id))
+    }
+
+    pub(crate) fn insert(&mut self, reservation: FileIdReservation, value: T) {
+        let file_id = reservation.0;
+        let previous = self.entries.insert(file_id, value);
+        debug_assert!(
+            previous.is_none(),
+            "released RDPDR file IDs never collide with open files"
+        );
+    }
+
+    pub(crate) fn release_file_id(&mut self, reservation: FileIdReservation) {
+        self.available_ids.push(reservation.0);
+        self.active_ids -= 1;
+    }
+
+    pub(crate) fn get(&self, file_id: u32) -> Option<&T> {
+        self.entries.get(&file_id)
+    }
+
+    pub(crate) fn remove(&mut self, file_id: u32) -> Option<T> {
+        let value = self.entries.remove(&file_id)?;
+        self.available_ids.push(file_id);
+        self.active_ids -= 1;
+        Some(value)
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.available_ids
+            .extend(self.entries.drain().map(|(file_id, _)| file_id));
+        self.active_ids = 0;
+    }
+}
+
+/// File-table allocation failure.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum FileTableError {
+    /// The backend reached its configured local handle limit.
+    CapacityExceeded,
+    /// The backend exhausted nonzero `u32` file identifiers.
+    IdSpaceExhausted,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn released_file_ids_are_reused() {
+        let mut table = FileTable::new(1);
+        let reservation = table.reserve_file_id().expect("first allocation");
+        let file_id = reservation.file_id();
+        table.insert(reservation, ());
+        assert!(table.remove(file_id).is_some());
+        assert_eq!(table.reserve_file_id().expect("reuse allocation").file_id(), file_id);
+    }
+
+    #[test]
+    fn reservations_enforce_capacity_before_a_handle_is_inserted() {
+        let mut table = FileTable::<()>::new(1);
+        let reservation = table.reserve_file_id().expect("reserve file ID");
+        let file_id = reservation.file_id();
+
+        assert!(matches!(table.reserve_file_id(), Err(FileTableError::CapacityExceeded)));
+
+        table.release_file_id(reservation);
+        assert_eq!(table.reserve_file_id().expect("reuse reservation").file_id(), file_id);
+    }
+}

--- a/crates/ironrdp-rdpdr-native/src/windows/handles.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/handles.rs
@@ -1,0 +1,400 @@
+//! Handle-relative Windows filesystem primitives for the narrow RDPDR backend.
+
+use core::fmt;
+use std::os::windows::ffi::OsStrExt as _;
+use std::path::Path;
+
+use windows::Wdk::Foundation::OBJECT_ATTRIBUTES;
+use windows::Wdk::Storage::FileSystem::{
+    FILE_BASIC_INFORMATION, FILE_INFORMATION_CLASS, FILE_OPEN, FILE_STANDARD_INFORMATION, FILE_SYNCHRONOUS_IO_NONALERT,
+    FileAttributeTagInformation, FileBasicInformation, FileEndOfFileInformation, FileStandardInformation,
+    NTCREATEFILE_CREATE_DISPOSITION, NTCREATEFILE_CREATE_OPTIONS, NtCreateFile, NtFlushBuffersFile,
+    NtQueryInformationFile, NtReadFile, NtSetInformationFile, NtWriteFile,
+};
+use windows::Wdk::System::SystemServices::FILE_END_OF_FILE_INFORMATION;
+use windows::Win32::Foundation::{
+    CloseHandle, HANDLE, NTSTATUS, OBJ_CASE_INSENSITIVE, OBJ_DONT_REPARSE, OBJECT_ATTRIBUTE_FLAGS, UNICODE_STRING,
+};
+use windows::Win32::Storage::FileSystem::{
+    FILE_ACCESS_RIGHTS, FILE_ATTRIBUTE_NORMAL, FILE_FLAGS_AND_ATTRIBUTES, FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE,
+    FILE_SHARE_MODE, FILE_SHARE_READ, FILE_SHARE_WRITE, FILE_TRAVERSE, SYNCHRONIZE,
+};
+use windows::Win32::System::IO::IO_STATUS_BLOCK;
+
+use super::path::RelativePath;
+
+const STATUS_INVALID_PARAMETER: NTSTATUS = NTSTATUS(i32::from_ne_bytes(0xC000_000Du32.to_ne_bytes()));
+const STATUS_OBJECT_NAME_INVALID: NTSTATUS = NTSTATUS(i32::from_ne_bytes(0xC000_0033u32.to_ne_bytes()));
+const DIRECTORY_OPEN_OPTIONS: u32 = FILE_SYNCHRONOUS_IO_NONALERT.0 | 0x0000_0001;
+
+/// A validated native path for an explicitly configured logical-volume root.
+pub(crate) struct RootDirectory {
+    root_handle: DirectoryHandle,
+}
+
+impl RootDirectory {
+    /// Validates an absolute logical drive root such as `C:\`.
+    pub(crate) fn open(path: &Path) -> Result<Self, NTSTATUS> {
+        let mut nt_path = volume_root_nt_path(path).ok_or(STATUS_OBJECT_NAME_INVALID)?;
+        let root_handle = DirectoryHandle(open_directory(HANDLE::default(), &mut nt_path)?);
+
+        Ok(Self { root_handle })
+    }
+
+    /// Opens a file or directory without ever joining server input to a host path.
+    pub(crate) fn open_relative_file(
+        &self,
+        path: &RelativePath,
+        options: FileOpenOptions,
+    ) -> Result<(FileHandle, usize), NTSTATUS> {
+        let mut components = path.components();
+        let Some(file_name) = components.next_back() else {
+            return self.open_root_file(options);
+        };
+
+        let mut parent = None;
+        for component in components {
+            let mut component = component.encode_utf16().collect::<Vec<_>>();
+            let root_directory = parent
+                .as_ref()
+                .map_or(self.root_handle.as_raw(), DirectoryHandle::as_raw);
+            parent = Some(DirectoryHandle(open_directory(root_directory, &mut component)?));
+        }
+
+        let mut file_name = file_name.encode_utf16().collect::<Vec<_>>();
+        let root_directory = parent
+            .as_ref()
+            .map_or(self.root_handle.as_raw(), DirectoryHandle::as_raw);
+        open_file(root_directory, &mut file_name, options)
+    }
+
+    fn open_root_file(&self, mut options: FileOpenOptions) -> Result<(FileHandle, usize), NTSTATUS> {
+        options.desired_access |= FILE_READ_ATTRIBUTES.0;
+        // An empty relative name opens the object identified by RootDirectory.
+        let mut name = [];
+        open_file(self.root_handle.as_raw(), &mut name, options)
+    }
+}
+
+impl fmt::Debug for RootDirectory {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("RootDirectory").field(&"<owned>").finish()
+    }
+}
+
+struct DirectoryHandle(HANDLE);
+
+// SAFETY: The handle has unique ownership, is only used through backend-owned
+// state, and is closed exactly once by its Drop implementation.
+unsafe impl Send for DirectoryHandle {}
+
+impl DirectoryHandle {
+    fn as_raw(&self) -> HANDLE {
+        self.0
+    }
+}
+
+impl Drop for DirectoryHandle {
+    fn drop(&mut self) {
+        // SAFETY: This guard owns the handle returned by NtCreateFile.
+        let _ = unsafe { CloseHandle(self.0) };
+    }
+}
+
+/// A non-cloneable local filesystem handle.
+#[derive(Debug)]
+pub(crate) struct FileHandle(HANDLE);
+
+// SAFETY: The handle has unique ownership, is only used through backend-owned
+// state, and is closed exactly once by its Drop implementation.
+unsafe impl Send for FileHandle {}
+
+impl FileHandle {
+    pub(crate) fn query_basic_information(&self) -> Result<FILE_BASIC_INFORMATION, NTSTATUS> {
+        self.query_information(FileBasicInformation)
+    }
+
+    pub(crate) fn query_standard_information(&self) -> Result<FILE_STANDARD_INFORMATION, NTSTATUS> {
+        self.query_information(FileStandardInformation)
+    }
+
+    pub(crate) fn query_attribute_tag_information(
+        &self,
+    ) -> Result<windows::Win32::Storage::FileSystem::FILE_ATTRIBUTE_TAG_INFO, NTSTATUS> {
+        self.query_information(FileAttributeTagInformation)
+    }
+
+    pub(crate) fn set_end_of_file(&self, end_of_file: i64) -> Result<(), NTSTATUS> {
+        self.set_information(
+            FileEndOfFileInformation,
+            &FILE_END_OF_FILE_INFORMATION { EndOfFile: end_of_file },
+        )
+    }
+
+    pub(crate) fn set_basic_information(&self, information: FILE_BASIC_INFORMATION) -> Result<(), NTSTATUS> {
+        self.set_information(FileBasicInformation, &information)
+    }
+
+    pub(crate) fn read_at(&self, offset: i64, buffer: &mut [u8]) -> Result<NativeIoCompletion, NTSTATUS> {
+        let length = u32::try_from(buffer.len()).map_err(|_| STATUS_INVALID_PARAMETER)?;
+        let mut io_status = IO_STATUS_BLOCK::default();
+
+        // SAFETY: The handle is live, the output buffer and IO status remain
+        // valid for the synchronous request, and the explicit offset is valid.
+        let status = unsafe {
+            NtReadFile(
+                self.0,
+                None,
+                None,
+                None,
+                core::ptr::addr_of_mut!(io_status),
+                buffer.as_mut_ptr().cast(),
+                length,
+                Some(core::ptr::addr_of!(offset)),
+                None,
+            )
+        };
+
+        Ok(NativeIoCompletion {
+            status,
+            transferred: io_status.Information.min(buffer.len()),
+        })
+    }
+
+    pub(crate) fn write_at(&self, offset: i64, buffer: &[u8]) -> Result<NativeIoCompletion, NTSTATUS> {
+        let length = u32::try_from(buffer.len()).map_err(|_| STATUS_INVALID_PARAMETER)?;
+        let mut io_status = IO_STATUS_BLOCK::default();
+
+        // SAFETY: The handle is live, the input buffer and IO status remain
+        // valid for the synchronous request, and the explicit offset is valid.
+        let status = unsafe {
+            NtWriteFile(
+                self.0,
+                None,
+                None,
+                None,
+                core::ptr::addr_of_mut!(io_status),
+                buffer.as_ptr().cast(),
+                length,
+                Some(core::ptr::addr_of!(offset)),
+                None,
+            )
+        };
+
+        Ok(NativeIoCompletion {
+            status,
+            transferred: io_status.Information.min(buffer.len()),
+        })
+    }
+
+    pub(crate) fn flush(&self) -> Result<(), NTSTATUS> {
+        let mut io_status = IO_STATUS_BLOCK::default();
+
+        // SAFETY: The handle and IO status remain valid for the synchronous call.
+        let status = unsafe { NtFlushBuffersFile(self.0, core::ptr::addr_of_mut!(io_status)) };
+        if status.0 < 0 {
+            return Err(status);
+        }
+
+        Ok(())
+    }
+
+    fn query_information<T: Default>(&self, information_class: FILE_INFORMATION_CLASS) -> Result<T, NTSTATUS> {
+        let mut information = T::default();
+        let mut io_status = IO_STATUS_BLOCK::default();
+        let length = u32::try_from(size_of::<T>()).map_err(|_| STATUS_INVALID_PARAMETER)?;
+
+        // SAFETY: `information` and `io_status` are writable for the complete
+        // synchronous call, and `T` is the native structure for the class.
+        let status = unsafe {
+            NtQueryInformationFile(
+                self.0,
+                core::ptr::addr_of_mut!(io_status),
+                core::ptr::addr_of_mut!(information).cast(),
+                length,
+                information_class,
+            )
+        };
+        if status.0 < 0 {
+            return Err(status);
+        }
+
+        Ok(information)
+    }
+
+    fn set_information<T>(&self, information_class: FILE_INFORMATION_CLASS, information: &T) -> Result<(), NTSTATUS> {
+        let mut io_status = IO_STATUS_BLOCK::default();
+        let length = u32::try_from(size_of::<T>()).map_err(|_| STATUS_INVALID_PARAMETER)?;
+
+        // SAFETY: `information` is valid immutable native input and
+        // `io_status` remains writable for the synchronous call.
+        let status = unsafe {
+            NtSetInformationFile(
+                self.0,
+                core::ptr::addr_of_mut!(io_status),
+                core::ptr::from_ref(information).cast_mut().cast(),
+                length,
+                information_class,
+            )
+        };
+        if status.0 < 0 {
+            return Err(status);
+        }
+
+        Ok(())
+    }
+}
+
+impl Drop for FileHandle {
+    fn drop(&mut self) {
+        // SAFETY: This guard owns the handle returned by NtCreateFile.
+        let _ = unsafe { CloseHandle(self.0) };
+    }
+}
+
+/// A synchronous native read or write completion.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct NativeIoCompletion {
+    pub(crate) status: NTSTATUS,
+    pub(crate) transferred: usize,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct FileOpenOptions {
+    pub(crate) desired_access: u32,
+    pub(crate) allocation_size: Option<i64>,
+    pub(crate) file_attributes: u32,
+    pub(crate) share_access: u32,
+    pub(crate) create_disposition: u32,
+    pub(crate) create_options: u32,
+}
+
+pub(crate) const FILE_SUPERSEDED_INFORMATION: usize = 0;
+pub(crate) const FILE_OPENED_INFORMATION: usize = 1;
+pub(crate) const FILE_CREATED_INFORMATION: usize = 2;
+pub(crate) const FILE_OVERWRITTEN_INFORMATION: usize = 3;
+
+fn volume_root_nt_path(path: &Path) -> Option<Vec<u16>> {
+    let path = path.as_os_str().encode_wide().collect::<Vec<_>>();
+    let is_logical_volume_root = path.len() == 3
+        && matches!(path[0], 65..=90 | 97..=122)
+        && path[1] == u16::from(b':')
+        && path[2] == u16::from(b'\\');
+    if !is_logical_volume_root {
+        return None;
+    }
+
+    let mut nt_path = r"\??\".encode_utf16().collect::<Vec<_>>();
+    nt_path.extend(path);
+    Some(nt_path)
+}
+
+fn open_directory(root_directory: HANDLE, name: &mut [u16]) -> Result<HANDLE, NTSTATUS> {
+    let name = unicode_string(name)?;
+    let object_attributes = object_attributes(root_directory, &name);
+    let mut handle = HANDLE::default();
+    let mut io_status = IO_STATUS_BLOCK::default();
+    let desired_access = FILE_ACCESS_RIGHTS(FILE_TRAVERSE.0 | SYNCHRONIZE.0);
+
+    // SAFETY: Name, object attributes, output handle, and IO status remain
+    // valid for this synchronous call. OBJ_DONT_REPARSE blocks every reparse
+    // point while walking from the trusted root.
+    let status = unsafe {
+        NtCreateFile(
+            core::ptr::addr_of_mut!(handle),
+            desired_access,
+            core::ptr::addr_of!(object_attributes),
+            core::ptr::addr_of_mut!(io_status),
+            None,
+            FILE_ATTRIBUTE_NORMAL,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            FILE_OPEN,
+            NTCREATEFILE_CREATE_OPTIONS(DIRECTORY_OPEN_OPTIONS),
+            None,
+            0,
+        )
+    };
+    if status.0 < 0 {
+        return Err(status);
+    }
+
+    Ok(handle)
+}
+
+fn open_file(
+    root_directory: HANDLE,
+    name: &mut [u16],
+    options: FileOpenOptions,
+) -> Result<(FileHandle, usize), NTSTATUS> {
+    let name = unicode_string(name)?;
+    let object_attributes = object_attributes(root_directory, &name);
+    let mut handle = HANDLE::default();
+    let mut io_status = IO_STATUS_BLOCK::default();
+
+    // SAFETY: Name, object attributes, output handle, allocation size, and IO
+    // status remain valid for the call. OBJ_DONT_REPARSE prevents the final
+    // component from escaping the selected logical volume.
+    let status = unsafe {
+        NtCreateFile(
+            core::ptr::addr_of_mut!(handle),
+            FILE_ACCESS_RIGHTS(options.desired_access),
+            core::ptr::addr_of!(object_attributes),
+            core::ptr::addr_of_mut!(io_status),
+            options.allocation_size.as_ref().map(core::ptr::from_ref),
+            FILE_FLAGS_AND_ATTRIBUTES(options.file_attributes),
+            FILE_SHARE_MODE(options.share_access),
+            NTCREATEFILE_CREATE_DISPOSITION(options.create_disposition),
+            NTCREATEFILE_CREATE_OPTIONS(options.create_options | FILE_SYNCHRONOUS_IO_NONALERT.0),
+            None,
+            0,
+        )
+    };
+    if status.0 < 0 {
+        return Err(status);
+    }
+
+    Ok((FileHandle(handle), io_status.Information))
+}
+
+fn unicode_string(value: &mut [u16]) -> Result<UNICODE_STRING, NTSTATUS> {
+    let byte_len = value
+        .len()
+        .checked_mul(size_of::<u16>())
+        .and_then(|length| u16::try_from(length).ok())
+        .ok_or(STATUS_INVALID_PARAMETER)?;
+
+    Ok(UNICODE_STRING {
+        Length: byte_len,
+        MaximumLength: byte_len,
+        Buffer: windows::core::PWSTR::from_raw(value.as_mut_ptr()),
+    })
+}
+
+fn object_attributes(root_directory: HANDLE, name: &UNICODE_STRING) -> OBJECT_ATTRIBUTES {
+    OBJECT_ATTRIBUTES {
+        Length: u32::try_from(size_of::<OBJECT_ATTRIBUTES>()).expect("OBJECT_ATTRIBUTES size fits in u32"),
+        RootDirectory: root_directory,
+        ObjectName: core::ptr::from_ref(name).cast_mut(),
+        Attributes: OBJECT_ATTRIBUTE_FLAGS(OBJ_CASE_INSENSITIVE.0 | OBJ_DONT_REPARSE.0),
+        SecurityDescriptor: core::ptr::null(),
+        SecurityQualityOfService: core::ptr::null(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_only_logical_volume_roots() {
+        assert!(RootDirectory::open(Path::new(r"C:\")).is_ok());
+        assert!(matches!(
+            RootDirectory::open(Path::new(r"C:\Windows")),
+            Err(STATUS_OBJECT_NAME_INVALID)
+        ));
+        assert!(matches!(
+            RootDirectory::open(Path::new(r"\\server\share\")),
+            Err(STATUS_OBJECT_NAME_INVALID)
+        ));
+    }
+}

--- a/crates/ironrdp-rdpdr-native/src/windows/handles.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/handles.rs
@@ -8,8 +8,8 @@ use windows::Wdk::Foundation::OBJECT_ATTRIBUTES;
 use windows::Wdk::Storage::FileSystem::{
     FILE_BASIC_INFORMATION, FILE_INFORMATION_CLASS, FILE_OPEN, FILE_STANDARD_INFORMATION, FILE_SYNCHRONOUS_IO_NONALERT,
     FileAttributeTagInformation, FileBasicInformation, FileEndOfFileInformation, FileStandardInformation,
-    NTCREATEFILE_CREATE_DISPOSITION, NTCREATEFILE_CREATE_OPTIONS, NtCreateFile, NtFlushBuffersFile,
-    NtQueryInformationFile, NtReadFile, NtSetInformationFile, NtWriteFile,
+    NTCREATEFILE_CREATE_DISPOSITION, NTCREATEFILE_CREATE_OPTIONS, NtCreateFile, NtQueryInformationFile, NtReadFile,
+    NtSetInformationFile, NtWriteFile,
 };
 use windows::Wdk::System::SystemServices::FILE_END_OF_FILE_INFORMATION;
 use windows::Win32::Foundation::{
@@ -185,18 +185,6 @@ impl FileHandle {
             status,
             transferred: io_status.Information.min(buffer.len()),
         })
-    }
-
-    pub(crate) fn flush(&self) -> Result<(), NTSTATUS> {
-        let mut io_status = IO_STATUS_BLOCK::default();
-
-        // SAFETY: The handle and IO status remain valid for the synchronous call.
-        let status = unsafe { NtFlushBuffersFile(self.0, core::ptr::addr_of_mut!(io_status)) };
-        if status.0 < 0 {
-            return Err(status);
-        }
-
-        Ok(())
     }
 
     fn query_information<T: Default>(&self, information_class: FILE_INFORMATION_CLASS) -> Result<T, NTSTATUS> {

--- a/crates/ironrdp-rdpdr-native/src/windows/mod.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/mod.rs
@@ -1,0 +1,9 @@
+mod backend;
+mod factory;
+mod file_table;
+mod handles;
+mod path;
+mod status;
+
+pub use backend::WindowsRdpdrBackend;
+pub use factory::{RedirectedDrive, RedirectedDriveError, WindowsRdpdrBackendFactory};

--- a/crates/ironrdp-rdpdr-native/src/windows/path.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/path.rs
@@ -1,0 +1,158 @@
+//! Validation for server-supplied RDPDR filesystem paths.
+//!
+//! [MS-RDPEFS] 2.2.3.3.1 identifies the drive through the device ID, so a
+//! server-supplied path must name only a descendant of the selected volume.
+//! This module validates that namespace before native handle-relative opens.
+//!
+//! [MS-RDPEFS]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs
+
+const MAX_PATH_CODE_UNITS: usize = 32_767;
+const MAX_COMPONENT_CODE_UNITS: usize = 255;
+
+/// A validated path relative to a redirected volume root.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct RelativePath {
+    components: Vec<String>,
+}
+
+impl RelativePath {
+    /// Parses an RDPDR path without resolving it in the host filesystem.
+    ///
+    /// RDPDR represents the selected volume root by an empty path or one
+    /// leading backslash. The leading separator is protocol syntax only; it is
+    /// never passed to a Win32 path join operation.
+    pub(crate) fn parse(path: &str) -> Result<Self, PathPolicyError> {
+        if path.encode_utf16().count() > MAX_PATH_CODE_UNITS {
+            return Err(PathPolicyError::TooLong);
+        }
+        if path.starts_with('/') || path.starts_with(r"\\") {
+            return Err(PathPolicyError::Rooted);
+        }
+
+        let path = path.strip_prefix('\\').unwrap_or(path);
+        if path.is_empty() {
+            return Ok(Self { components: Vec::new() });
+        }
+
+        let components = path.split('\\').collect::<Vec<_>>();
+        for component in &components {
+            validate_component(component)?;
+        }
+
+        Ok(Self {
+            components: components.into_iter().map(str::to_owned).collect(),
+        })
+    }
+
+    pub(crate) fn components(&self) -> impl DoubleEndedIterator<Item = &str> + ExactSizeIterator {
+        self.components.iter().map(String::as_str)
+    }
+}
+
+/// A rejected RDPDR path category.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PathPolicyError {
+    /// The path uses a rooted or namespace form rather than a volume-relative path.
+    Rooted,
+    /// A path component is empty, a traversal marker, or contains an invalid character.
+    InvalidComponent,
+    /// A path component is a Windows DOS device alias.
+    ReservedDevice,
+    /// The path or a component exceeds the bounded native namespace policy.
+    TooLong,
+}
+
+fn validate_component(component: &str) -> Result<(), PathPolicyError> {
+    if component.is_empty() || matches!(component, "." | "..") {
+        return Err(PathPolicyError::InvalidComponent);
+    }
+    if component.encode_utf16().count() > MAX_COMPONENT_CODE_UNITS {
+        return Err(PathPolicyError::TooLong);
+    }
+    if component.ends_with([' ', '.']) {
+        return Err(PathPolicyError::InvalidComponent);
+    }
+    if component.chars().any(|character| {
+        character <= '\u{1f}' || matches!(character, '<' | '>' | ':' | '"' | '/' | '\\' | '|' | '?' | '*')
+    }) {
+        return Err(PathPolicyError::InvalidComponent);
+    }
+    if is_reserved_device_name(component) {
+        return Err(PathPolicyError::ReservedDevice);
+    }
+
+    Ok(())
+}
+
+fn is_reserved_device_name(component: &str) -> bool {
+    let base_name = component.split('.').next().unwrap_or_default();
+
+    base_name.eq_ignore_ascii_case("CON")
+        || base_name.eq_ignore_ascii_case("NUL")
+        || base_name.eq_ignore_ascii_case("AUX")
+        || base_name.eq_ignore_ascii_case("PRN")
+        || base_name.eq_ignore_ascii_case("CLOCK$")
+        || is_numbered_device(base_name, "COM")
+        || is_numbered_device(base_name, "LPT")
+}
+
+fn is_numbered_device(component: &str, prefix: &str) -> bool {
+    let mut component = component.chars();
+
+    if !prefix.chars().all(|expected| {
+        component
+            .next()
+            .is_some_and(|actual| actual.eq_ignore_ascii_case(&expected))
+    }) {
+        return false;
+    }
+
+    matches!(component.next(), Some('1'..='9' | '\u{00B9}' | '\u{00B2}' | '\u{00B3}')) && component.next().is_none()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_protocol_root_relative_paths() {
+        let path = RelativePath::parse(r"\Documents\report.txt").expect("valid RDPDR path");
+
+        assert_eq!(path.components().collect::<Vec<_>>(), ["Documents", "report.txt"]);
+    }
+
+    #[test]
+    fn accepts_the_redirected_volume_root() {
+        assert!(
+            RelativePath::parse(r"\")
+                .expect("redirected root")
+                .components()
+                .next()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn rejects_host_namespace_paths_traversal_and_streams() {
+        for path in [
+            r"\\server\share",
+            r"\??\C:\outside",
+            r"C:\outside",
+            r"..\outside",
+            r"one\\two",
+            "file:stream",
+        ] {
+            assert!(matches!(
+                RelativePath::parse(path),
+                Err(PathPolicyError::Rooted | PathPolicyError::InvalidComponent)
+            ));
+        }
+    }
+
+    #[test]
+    fn rejects_dos_device_aliases_in_every_component() {
+        for path in ["CON", "con.txt", r"folder\LPT9", "COM\u{00B9}", "AUX", "clock$"] {
+            assert_eq!(RelativePath::parse(path), Err(PathPolicyError::ReservedDevice));
+        }
+    }
+}

--- a/crates/ironrdp-rdpdr-native/src/windows/status.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/status.rs
@@ -1,0 +1,32 @@
+//! Narrow status mapping for Windows RDPDR filesystem operations.
+
+use windows::Win32::Foundation::NTSTATUS;
+
+use ironrdp_rdpdr::pdu::efs::NtStatus;
+
+use super::path::PathPolicyError;
+
+pub(crate) fn from_path_policy(error: PathPolicyError) -> NtStatus {
+    match error {
+        PathPolicyError::ReservedDevice => NtStatus::ACCESS_DENIED,
+        PathPolicyError::Rooted | PathPolicyError::InvalidComponent | PathPolicyError::TooLong => {
+            NtStatus::OBJECT_NAME_INVALID
+        }
+    }
+}
+
+pub(crate) fn from_ntstatus(status: NTSTATUS) -> NtStatus {
+    NtStatus::from(u32::from_ne_bytes(status.0.to_ne_bytes()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preserves_native_status_values() {
+        let status = NTSTATUS(i32::from_ne_bytes(0xC000_0034u32.to_ne_bytes()));
+
+        assert_eq!(from_ntstatus(status), NtStatus::from(0xC000_0034));
+    }
+}

--- a/crates/ironrdp-rdpdr-native/tests/windows_backend.rs
+++ b/crates/ironrdp-rdpdr-native/tests/windows_backend.rs
@@ -16,6 +16,8 @@ use ironrdp_rdpdr_native::{RedirectedDrive, WindowsRdpdrBackend, WindowsRdpdrBac
 use ironrdp_svc::SvcMessage;
 use windows as _;
 
+const MAX_STATIC_IO_SIZE: usize = 1_024 * 1_024;
+
 #[test]
 fn filesystem_lifecycle_is_handle_relative_and_bounded() {
     let fixture = Fixture::new();
@@ -95,6 +97,144 @@ fn filesystem_lifecycle_is_handle_relative_and_bounded() {
         }))
         .expect("complete close");
     assert_eq!(response_status(&close_response), NtStatus::SUCCESS);
+}
+
+#[test]
+fn synchronous_nonalert_create_option_is_accepted() {
+    let fixture = Fixture::new();
+    let mut backend = fixture.backend();
+    activate(&mut backend);
+
+    let mut create = create_request(
+        &fixture.relative(r"root\synchronous.txt"),
+        CreateDisposition::FILE_OPEN_IF,
+    );
+    create.create_options = CreateOptions::FILE_SYNCHRONOUS_IO_NONALERT;
+    let response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::ServerCreateDriveRequest(create))
+        .expect("complete synchronous create");
+
+    assert_eq!(response_status(&response), NtStatus::SUCCESS);
+}
+
+#[test]
+fn read_only_drives_allow_reads_and_reject_mutations() {
+    let fixture = Fixture::new();
+    let file_path = fixture.root.join("root").join("read-only.txt");
+    std::fs::write(&file_path, b"safe").expect("write read-only fixture");
+
+    let mut backend = fixture.read_only_backend();
+    activate(&mut backend);
+
+    let mut open = create_request(&fixture.relative(r"root\read-only.txt"), CreateDisposition::FILE_OPEN);
+    open.desired_access = DesiredAccess::from_bits_retain(0x0010_0081);
+    let open_response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::ServerCreateDriveRequest(open))
+        .expect("complete read-only open");
+    assert_eq!(response_status(&open_response), NtStatus::SUCCESS);
+    let file_id = response_file_id(&open_response);
+
+    let read_response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::DeviceReadRequest(DeviceReadRequest {
+            device_io_request: request_header(file_id, MajorFunction::Read),
+            length: 4,
+            offset: 0,
+        }))
+        .expect("complete read-only read");
+    assert_eq!(response_status(&read_response), NtStatus::SUCCESS);
+    let bytes = read_response[0].encode_unframed_pdu().expect("encode read response");
+    assert_eq!(&bytes[20..], b"safe");
+
+    let access_response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::ServerCreateDriveRequest(create_request(
+            &fixture.relative(r"root\read-only.txt"),
+            CreateDisposition::FILE_OPEN,
+        )))
+        .expect("complete write-access open");
+    assert_eq!(response_status(&access_response), NtStatus::MEDIA_WRITE_PROTECTED);
+
+    let mut create = create_request(&fixture.relative(r"root\new.txt"), CreateDisposition::FILE_OPEN_IF);
+    create.desired_access = DesiredAccess::from_bits_retain(0x0010_0081);
+    let create_response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::ServerCreateDriveRequest(create))
+        .expect("complete create on read-only drive");
+    assert_eq!(response_status(&create_response), NtStatus::MEDIA_WRITE_PROTECTED);
+    assert!(!fixture.root.join("root").join("new.txt").exists());
+
+    let write_response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::DeviceWriteRequest(DeviceWriteRequest {
+            device_io_request: request_header(file_id, MajorFunction::Write),
+            offset: 0,
+            write_data: b"overwrite".to_vec(),
+        }))
+        .expect("complete write on read-only drive");
+    assert_eq!(response_status(&write_response), NtStatus::MEDIA_WRITE_PROTECTED);
+
+    let set_response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::ServerDriveSetInformationRequest(
+            ServerDriveSetInformationRequest {
+                device_io_request: request_header(file_id, MajorFunction::SetInformation),
+                set_buffer: FileInformationClass::EndOfFile(FileEndOfFileInformation { end_of_file: 0 }),
+            },
+        ))
+        .expect("complete metadata update on read-only drive");
+    assert_eq!(response_status(&set_response), NtStatus::MEDIA_WRITE_PROTECTED);
+    assert_eq!(
+        std::fs::read(file_path).expect("read fixture after rejected mutations"),
+        b"safe"
+    );
+}
+
+#[test]
+fn static_io_limit_is_inclusive() {
+    let fixture = Fixture::new();
+    let mut backend = fixture.backend();
+    activate(&mut backend);
+
+    let create_response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::ServerCreateDriveRequest(create_request(
+            &fixture.relative(r"root\bounded.bin"),
+            CreateDisposition::FILE_OPEN_IF,
+        )))
+        .expect("complete bounded create");
+    assert_eq!(response_status(&create_response), NtStatus::SUCCESS);
+    let file_id = response_file_id(&create_response);
+
+    let write_response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::DeviceWriteRequest(DeviceWriteRequest {
+            device_io_request: request_header(file_id, MajorFunction::Write),
+            offset: 0,
+            write_data: vec![0xA5; MAX_STATIC_IO_SIZE],
+        }))
+        .expect("complete maximum write");
+    assert_eq!(response_status(&write_response), NtStatus::SUCCESS);
+
+    let read_response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::DeviceReadRequest(DeviceReadRequest {
+            device_io_request: request_header(file_id, MajorFunction::Read),
+            length: u32::try_from(MAX_STATIC_IO_SIZE).expect("static I/O size fits in u32"),
+            offset: 0,
+        }))
+        .expect("complete maximum read");
+    assert_eq!(response_status(&read_response), NtStatus::SUCCESS);
+
+    let oversized_write = backend
+        .handle_drive_io_request(ServerDriveIoRequest::DeviceWriteRequest(DeviceWriteRequest {
+            device_io_request: request_header(file_id, MajorFunction::Write),
+            offset: 0,
+            write_data: vec![0; MAX_STATIC_IO_SIZE + 1],
+        }))
+        .expect("complete oversized write");
+    assert_eq!(response_status(&oversized_write), NtStatus::INVALID_PARAMETER);
+
+    let oversized_read = backend
+        .handle_drive_io_request(ServerDriveIoRequest::DeviceReadRequest(DeviceReadRequest {
+            device_io_request: request_header(file_id, MajorFunction::Read),
+            length: u32::try_from(MAX_STATIC_IO_SIZE + 1).expect("oversized I/O size fits in u32"),
+            offset: 0,
+        }))
+        .expect("complete oversized read");
+    assert_eq!(response_status(&oversized_read), NtStatus::INVALID_PARAMETER);
 }
 
 #[test]
@@ -222,8 +362,16 @@ impl Fixture {
     }
 
     fn backend(&self) -> WindowsRdpdrBackend {
+        self.backend_with_read_only(false)
+    }
+
+    fn read_only_backend(&self) -> WindowsRdpdrBackend {
+        self.backend_with_read_only(true)
+    }
+
+    fn backend_with_read_only(&self, read_only: bool) -> WindowsRdpdrBackend {
         WindowsRdpdrBackendFactory::new(
-            RedirectedDrive::new(1, "Test", &self.volume_root, false).expect("valid test drive"),
+            RedirectedDrive::new(1, "Test", &self.volume_root, read_only).expect("valid test drive"),
         )
         .build()
     }

--- a/crates/ironrdp-rdpdr-native/tests/windows_backend.rs
+++ b/crates/ironrdp-rdpdr-native/tests/windows_backend.rs
@@ -1,0 +1,244 @@
+#![cfg(windows)]
+
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use ironrdp_core as _;
+use ironrdp_pdu as _;
+use ironrdp_rdpdr::RdpdrBackend;
+use ironrdp_rdpdr::pdu::efs::{
+    CreateDisposition, CreateOptions, DesiredAccess, DeviceCloseRequest, DeviceCreateRequest, DeviceIoRequest,
+    DeviceReadRequest, DeviceWriteRequest, FileAttributes, FileEndOfFileInformation, FileInformationClass,
+    FileInformationClassLevel, MajorFunction, MinorFunction, NtStatus, ServerDriveIoRequest,
+    ServerDriveQueryInformationRequest, ServerDriveSetInformationRequest, SharedAccess,
+};
+use ironrdp_rdpdr_native::{RedirectedDrive, WindowsRdpdrBackend, WindowsRdpdrBackendFactory};
+use ironrdp_svc::SvcMessage;
+use windows as _;
+
+#[test]
+fn filesystem_lifecycle_is_handle_relative_and_bounded() {
+    let fixture = Fixture::new();
+    let mut backend = fixture.backend();
+    activate(&mut backend);
+
+    let create = create_request(&fixture.relative(r"root\report.txt"), CreateDisposition::FILE_OPEN_IF);
+    let create_response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::ServerCreateDriveRequest(create))
+        .expect("complete create");
+    assert_eq!(response_status(&create_response), NtStatus::SUCCESS);
+    let file_id = response_file_id(&create_response);
+
+    let write = DeviceWriteRequest {
+        device_io_request: request_header(file_id, MajorFunction::Write),
+        offset: 0,
+        write_data: b"hello".to_vec(),
+    };
+    let write_response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::DeviceWriteRequest(write))
+        .expect("complete write");
+    assert_eq!(response_status(&write_response), NtStatus::SUCCESS);
+
+    let append_response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::DeviceWriteRequest(DeviceWriteRequest {
+            device_io_request: request_header(file_id, MajorFunction::Write),
+            offset: u64::MAX,
+            write_data: b"!".to_vec(),
+        }))
+        .expect("complete append");
+    assert_eq!(response_status(&append_response), NtStatus::SUCCESS);
+
+    let read_response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::DeviceReadRequest(DeviceReadRequest {
+            device_io_request: request_header(file_id, MajorFunction::Read),
+            length: 6,
+            offset: 0,
+        }))
+        .expect("complete read");
+    assert_eq!(response_status(&read_response), NtStatus::SUCCESS);
+    let bytes = read_response[0].encode_unframed_pdu().expect("encode read response");
+    assert_eq!(&bytes[20..], b"hello!");
+
+    for file_info_class_lvl in [
+        FileInformationClassLevel::FILE_BASIC_INFORMATION,
+        FileInformationClassLevel::FILE_STANDARD_INFORMATION,
+        FileInformationClassLevel::FILE_ATTRIBUTE_TAG_INFORMATION,
+    ] {
+        let query_response = backend
+            .handle_drive_io_request(ServerDriveIoRequest::ServerDriveQueryInformationRequest(
+                ServerDriveQueryInformationRequest {
+                    device_io_request: request_header(file_id, MajorFunction::QueryInformation),
+                    file_info_class_lvl,
+                },
+            ))
+            .expect("complete metadata query");
+        assert_eq!(response_status(&query_response), NtStatus::SUCCESS);
+    }
+
+    let set_response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::ServerDriveSetInformationRequest(
+            ServerDriveSetInformationRequest {
+                device_io_request: request_header(file_id, MajorFunction::SetInformation),
+                set_buffer: FileInformationClass::EndOfFile(FileEndOfFileInformation { end_of_file: 5 }),
+            },
+        ))
+        .expect("complete set information");
+    assert_eq!(response_status(&set_response), NtStatus::SUCCESS);
+    assert_eq!(
+        std::fs::read(fixture.root.join("root").join("report.txt")).expect("read test file"),
+        b"hello"
+    );
+
+    let close_response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::DeviceCloseRequest(DeviceCloseRequest {
+            device_io_request: request_header(file_id, MajorFunction::Close),
+        }))
+        .expect("complete close");
+    assert_eq!(response_status(&close_response), NtStatus::SUCCESS);
+}
+
+#[test]
+fn hostile_paths_never_open_outside_the_selected_volume() {
+    let fixture = Fixture::new();
+    let mut backend = fixture.backend();
+    activate(&mut backend);
+
+    for path in [
+        r"\..\outside.txt",
+        r"\??\C:\outside.txt",
+        r"\root\CON",
+        r"\root\file:stream",
+    ] {
+        let response = backend
+            .handle_drive_io_request(ServerDriveIoRequest::ServerCreateDriveRequest(create_request(
+                path,
+                CreateDisposition::FILE_OPEN_IF,
+            )))
+            .expect("complete hostile create");
+        assert_ne!(response_status(&response), NtStatus::SUCCESS);
+    }
+}
+
+#[test]
+fn reparse_points_cannot_escape_the_trusted_volume_root() {
+    let fixture = Fixture::new();
+    let outside = fixture.sandbox.join("outside");
+    std::fs::create_dir_all(&outside).expect("create outside directory");
+    std::fs::write(outside.join("sentinel.txt"), b"outside").expect("write sentinel");
+
+    let link = fixture.root.join("root").join("escape");
+    if let Err(error) = std::os::windows::fs::symlink_dir(&outside, &link) {
+        if error.raw_os_error() == Some(1314) {
+            return;
+        }
+        panic!("create test reparse point: {error}");
+    }
+
+    let mut backend = fixture.backend();
+    activate(&mut backend);
+    let response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::ServerCreateDriveRequest(create_request(
+            &fixture.relative(r"root\escape\sentinel.txt"),
+            CreateDisposition::FILE_OPEN,
+        )))
+        .expect("complete reparse create");
+
+    assert_ne!(response_status(&response), NtStatus::SUCCESS);
+    assert_eq!(
+        std::fs::read(outside.join("sentinel.txt")).expect("read sentinel"),
+        b"outside"
+    );
+}
+
+fn activate(backend: &mut WindowsRdpdrBackend) {
+    RdpdrBackend::restore_drive(backend, 1).expect("activate test drive");
+}
+
+fn create_request(path: &str, disposition: CreateDisposition) -> DeviceCreateRequest {
+    DeviceCreateRequest {
+        device_io_request: request_header(0, MajorFunction::Create),
+        desired_access: DesiredAccess::from_bits_retain(0x0010_0083),
+        allocation_size: 0,
+        file_attributes: FileAttributes::FILE_ATTRIBUTE_NORMAL,
+        shared_access: SharedAccess::from_bits_retain(0x0000_0007),
+        create_disposition: disposition,
+        create_options: CreateOptions::empty(),
+        path: path.to_owned(),
+    }
+}
+
+fn request_header(file_id: u32, major_function: MajorFunction) -> DeviceIoRequest {
+    DeviceIoRequest {
+        device_id: 1,
+        file_id,
+        completion_id: 7,
+        major_function,
+        minor_function: MinorFunction::from(0),
+    }
+}
+
+fn response_status(messages: &[SvcMessage]) -> NtStatus {
+    let response = messages[0].encode_unframed_pdu().expect("encode RDPDR response");
+    NtStatus::from(u32::from_le_bytes(
+        response[12..16].try_into().expect("response status"),
+    ))
+}
+
+fn response_file_id(messages: &[SvcMessage]) -> u32 {
+    let response = messages[0].encode_unframed_pdu().expect("encode create response");
+    u32::from_le_bytes(response[16..20].try_into().expect("create file ID"))
+}
+
+struct Fixture {
+    sandbox: PathBuf,
+    root: PathBuf,
+    volume_root: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let workspace = std::env::current_dir().expect("current workspace directory");
+        let volume_root = workspace
+            .ancestors()
+            .last()
+            .expect("workspace has a volume root")
+            .to_owned();
+        let unique = format!(
+            "rdpdr-native-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock is after Unix epoch")
+                .as_nanos()
+        );
+        let sandbox = workspace.join("target").join(unique);
+        let root = sandbox.join("root");
+        std::fs::create_dir_all(root.join("root")).expect("create fixture root");
+        Self {
+            sandbox,
+            root,
+            volume_root,
+        }
+    }
+
+    fn backend(&self) -> WindowsRdpdrBackend {
+        WindowsRdpdrBackendFactory::new(
+            RedirectedDrive::new(1, "Test", &self.volume_root, false).expect("valid test drive"),
+        )
+        .build()
+    }
+
+    fn relative(&self, suffix: &str) -> String {
+        let relative = self
+            .root
+            .strip_prefix(&self.volume_root)
+            .expect("fixture is beneath its volume root");
+        format!(r"\{}\{}", relative.display(), suffix).replace('/', r"\")
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.sandbox);
+    }
+}

--- a/crates/ironrdp-rdpdr/src/lib.rs
+++ b/crates/ironrdp-rdpdr/src/lib.rs
@@ -686,10 +686,12 @@ impl SvcProcessor for Rdpdr {
             | RdpdrPdu::ClientDriveQueryInformationResponse(_)
             | RdpdrPdu::DeviceCloseResponse(_)
             | RdpdrPdu::ClientDriveQueryDirectoryResponse(_)
+            | RdpdrPdu::ClientDriveNotifyChangeDirectoryResponse(_)
             | RdpdrPdu::ClientDriveQueryVolumeInformationResponse(_)
             | RdpdrPdu::DeviceReadResponse(_)
             | RdpdrPdu::DeviceWriteResponse(_)
             | RdpdrPdu::ClientDriveSetInformationResponse(_)
+            | RdpdrPdu::ClientDriveLockControlResponse(_)
             | RdpdrPdu::EmptyResponse => Err(pdu_other_err!("Rdpdr", "received unexpected packet")),
         }
     }

--- a/crates/ironrdp-rdpdr/src/pdu/mod.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/mod.rs
@@ -7,11 +7,11 @@ use ironrdp_core::{
 use ironrdp_svc::SvcEncode;
 
 use self::efs::{
-    ClientDeviceListAnnounce, ClientDeviceListRemove, ClientDriveQueryDirectoryResponse,
-    ClientDriveQueryInformationResponse, ClientDriveQueryVolumeInformationResponse, ClientDriveSetInformationResponse,
-    ClientNameRequest, CoreCapability, CoreCapabilityKind, DeviceCloseResponse, DeviceControlResponse,
-    DeviceCreateResponse, DeviceIoRequest, DeviceReadResponse, DeviceWriteResponse, ServerDeviceAnnounceResponse,
-    VersionAndIdPdu, VersionAndIdPduKind,
+    ClientDeviceListAnnounce, ClientDeviceListRemove, ClientDriveLockControlResponse,
+    ClientDriveNotifyChangeDirectoryResponse, ClientDriveQueryDirectoryResponse, ClientDriveQueryInformationResponse,
+    ClientDriveQueryVolumeInformationResponse, ClientDriveSetInformationResponse, ClientNameRequest, CoreCapability,
+    CoreCapabilityKind, DeviceCloseResponse, DeviceControlResponse, DeviceCreateResponse, DeviceIoRequest,
+    DeviceReadResponse, DeviceWriteResponse, ServerDeviceAnnounceResponse, VersionAndIdPdu, VersionAndIdPduKind,
 };
 
 pub mod efs;
@@ -31,10 +31,12 @@ pub enum RdpdrPdu {
     ClientDriveQueryInformationResponse(ClientDriveQueryInformationResponse),
     DeviceCloseResponse(DeviceCloseResponse),
     ClientDriveQueryDirectoryResponse(ClientDriveQueryDirectoryResponse),
+    ClientDriveNotifyChangeDirectoryResponse(ClientDriveNotifyChangeDirectoryResponse),
     ClientDriveQueryVolumeInformationResponse(ClientDriveQueryVolumeInformationResponse),
     DeviceReadResponse(DeviceReadResponse),
     DeviceWriteResponse(DeviceWriteResponse),
     ClientDriveSetInformationResponse(ClientDriveSetInformationResponse),
+    ClientDriveLockControlResponse(ClientDriveLockControlResponse),
     UserLoggedon,
     EmptyResponse,
 }
@@ -92,10 +94,12 @@ impl RdpdrPdu {
             | RdpdrPdu::ClientDriveQueryInformationResponse(_)
             | RdpdrPdu::DeviceCloseResponse(_)
             | RdpdrPdu::ClientDriveQueryDirectoryResponse(_)
+            | RdpdrPdu::ClientDriveNotifyChangeDirectoryResponse(_)
             | RdpdrPdu::ClientDriveQueryVolumeInformationResponse(_)
             | RdpdrPdu::DeviceReadResponse(_)
             | RdpdrPdu::DeviceWriteResponse(_)
             | RdpdrPdu::ClientDriveSetInformationResponse(_)
+            | RdpdrPdu::ClientDriveLockControlResponse(_)
             | RdpdrPdu::EmptyResponse => SharedHeader {
                 component: Component::RdpdrCtypCore,
                 packet_id: PacketId::CoreDeviceIoCompletion,
@@ -150,10 +154,12 @@ impl Encode for RdpdrPdu {
             RdpdrPdu::ClientDriveQueryInformationResponse(pdu) => pdu.encode(dst),
             RdpdrPdu::DeviceCloseResponse(pdu) => pdu.encode(dst),
             RdpdrPdu::ClientDriveQueryDirectoryResponse(pdu) => pdu.encode(dst),
+            RdpdrPdu::ClientDriveNotifyChangeDirectoryResponse(pdu) => pdu.encode(dst),
             RdpdrPdu::ClientDriveQueryVolumeInformationResponse(pdu) => pdu.encode(dst),
             RdpdrPdu::DeviceReadResponse(pdu) => pdu.encode(dst),
             RdpdrPdu::DeviceWriteResponse(pdu) => pdu.encode(dst),
             RdpdrPdu::ClientDriveSetInformationResponse(pdu) => pdu.encode(dst),
+            RdpdrPdu::ClientDriveLockControlResponse(pdu) => pdu.encode(dst),
             RdpdrPdu::UserLoggedon => Ok(()),
             RdpdrPdu::EmptyResponse => {
                 // https://github.com/FreeRDP/FreeRDP/blob/dfa231c0a55b005af775b833f92f6bcd30363d77/channels/drive/client/drive_main.c#L601
@@ -177,10 +183,12 @@ impl Encode for RdpdrPdu {
             RdpdrPdu::ClientDriveQueryInformationResponse(pdu) => pdu.name(),
             RdpdrPdu::DeviceCloseResponse(pdu) => pdu.name(),
             RdpdrPdu::ClientDriveQueryDirectoryResponse(pdu) => pdu.name(),
+            RdpdrPdu::ClientDriveNotifyChangeDirectoryResponse(pdu) => pdu.name(),
             RdpdrPdu::ClientDriveQueryVolumeInformationResponse(pdu) => pdu.name(),
             RdpdrPdu::DeviceReadResponse(pdu) => pdu.name(),
             RdpdrPdu::DeviceWriteResponse(pdu) => pdu.name(),
             RdpdrPdu::ClientDriveSetInformationResponse(pdu) => pdu.name(),
+            RdpdrPdu::ClientDriveLockControlResponse(pdu) => pdu.name(),
             RdpdrPdu::UserLoggedon => "UserLoggedon",
             RdpdrPdu::EmptyResponse => "EmptyResponse",
         }
@@ -201,10 +209,12 @@ impl Encode for RdpdrPdu {
                 RdpdrPdu::ClientDriveQueryInformationResponse(pdu) => pdu.size(),
                 RdpdrPdu::DeviceCloseResponse(pdu) => pdu.size(),
                 RdpdrPdu::ClientDriveQueryDirectoryResponse(pdu) => pdu.size(),
+                RdpdrPdu::ClientDriveNotifyChangeDirectoryResponse(pdu) => pdu.size(),
                 RdpdrPdu::ClientDriveQueryVolumeInformationResponse(pdu) => pdu.size(),
                 RdpdrPdu::DeviceReadResponse(pdu) => pdu.size(),
                 RdpdrPdu::DeviceWriteResponse(pdu) => pdu.size(),
                 RdpdrPdu::ClientDriveSetInformationResponse(pdu) => pdu.size(),
+                RdpdrPdu::ClientDriveLockControlResponse(pdu) => pdu.size(),
                 RdpdrPdu::UserLoggedon => 0,
                 RdpdrPdu::EmptyResponse => size_of::<u32>(),
             }
@@ -252,6 +262,9 @@ impl fmt::Debug for RdpdrPdu {
             Self::ClientDriveQueryDirectoryResponse(it) => {
                 write!(f, "RdpdrPdu({it:?})")
             }
+            Self::ClientDriveNotifyChangeDirectoryResponse(it) => {
+                write!(f, "RdpdrPdu({it:?})")
+            }
             Self::ClientDriveQueryVolumeInformationResponse(it) => {
                 write!(f, "RdpdrPdu({it:?})")
             }
@@ -262,6 +275,9 @@ impl fmt::Debug for RdpdrPdu {
                 write!(f, "RdpdrPdu({it:?})")
             }
             Self::ClientDriveSetInformationResponse(it) => {
+                write!(f, "RdpdrPdu({it:?})")
+            }
+            Self::ClientDriveLockControlResponse(it) => {
                 write!(f, "RdpdrPdu({it:?})")
             }
             Self::UserLoggedon => {
@@ -304,6 +320,12 @@ impl From<ClientDriveQueryDirectoryResponse> for RdpdrPdu {
     }
 }
 
+impl From<ClientDriveNotifyChangeDirectoryResponse> for RdpdrPdu {
+    fn from(value: ClientDriveNotifyChangeDirectoryResponse) -> Self {
+        Self::ClientDriveNotifyChangeDirectoryResponse(value)
+    }
+}
+
 impl From<ClientDriveQueryVolumeInformationResponse> for RdpdrPdu {
     fn from(value: ClientDriveQueryVolumeInformationResponse) -> Self {
         Self::ClientDriveQueryVolumeInformationResponse(value)
@@ -325,6 +347,12 @@ impl From<DeviceWriteResponse> for RdpdrPdu {
 impl From<ClientDriveSetInformationResponse> for RdpdrPdu {
     fn from(value: ClientDriveSetInformationResponse) -> Self {
         Self::ClientDriveSetInformationResponse(value)
+    }
+}
+
+impl From<ClientDriveLockControlResponse> for RdpdrPdu {
+    fn from(value: ClientDriveLockControlResponse) -> Self {
+        Self::ClientDriveLockControlResponse(value)
     }
 }
 


### PR DESCRIPTION
Add a handle-relative Windows RDPDR backend for one selected volume.
It confines protocol paths below an opened root and supports bounded file I/O
and basic metadata.

Unsupported advanced filesystem operations return STATUS_NOT_SUPPORTED; later
stack layers will add advanced Windows semantics and host integration.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
