### PR TITLE
ci: remove transient package manifest

### DIFF
--- a/.github/actions/resilient-review-output/action.yml
+++ b/.github/actions/resilient-review-output/action.yml
@@ -58,6 +58,15 @@ runs:
         settings: ${{ inputs.settings }}
         prompt: ${{ inputs.prompt }}
 
+    - name: Remove untracked workspace package manifest
+      if: always()
+      shell: bash
+      run: |
+        if git ls-files --error-unmatch -- package.json >/dev/null 2>&1; then
+          exit 0
+        fi
+        rm -f -- package.json
+
     - id: validate-initial
       if: always()
       uses: actions/github-script@v8
@@ -107,6 +116,15 @@ runs:
         prompt: >-
           ${{ inputs.retry_prompt }}
           Trusted validation reason: ${{ steps.validate-initial.outputs.reason }}.
+
+    - name: Remove untracked workspace package manifest
+      if: always()
+      shell: bash
+      run: |
+        if git ls-files --error-unmatch -- package.json >/dev/null 2>&1; then
+          exit 0
+        fi
+        rm -f -- package.json
 
     - id: select
       if: always()

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -55,6 +55,12 @@ test("workflow does not overwrite github-script result outputs", () => {
   const resilientAction = fs.readFileSync(
     path.join(__dirname, "..", "actions", "resilient-review-output", "action.yml"), "utf8");
   assert.match(resilientAction, /--resume \$\{sessionId\}/);
+  assert.equal(
+    (resilientAction.match(/name: Remove untracked workspace package manifest/g) || []).length,
+    2,
+  );
+  assert.match(resilientAction, /if git ls-files --error-unmatch -- package\.json >\/dev\/null 2>&1; then/);
+  assert.match(resilientAction, /rm -f -- package\.json/);
 });
 
 test("workflow does not resolve or write state after cancellation", () => {


### PR DESCRIPTION
Remove an untracked root package.json after each Claude invocation before github-script loads trusted validators.

The Claude action can leave an invalid manifest that Node rejects while resolving validator modules. Tracked manifests remain untouched.