### PR TITLE
feat(rdpdr): add advanced Windows filesystem semantics

### DIFF
--- a/crates/ironrdp-rdpdr-native/Cargo.toml
+++ b/crates/ironrdp-rdpdr-native/Cargo.toml
@@ -14,7 +14,6 @@ categories.workspace = true
 
 [lib]
 doctest = false
-test = false
 
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
 ironrdp-core = { path = "../ironrdp-core", version = "0.2" }
@@ -26,9 +25,9 @@ tracing = { version = "0.1", features = ["log"] }
 
 [target.'cfg(windows)'.dependencies]
 ironrdp-core = { path = "../ironrdp-core", version = "0.2" }
-ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9" }
-ironrdp-rdpdr = { path = "../ironrdp-rdpdr", version = "0.7" }
-ironrdp-svc = { path = "../ironrdp-svc", version = "0.8" }
+ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9" } # public
+ironrdp-rdpdr = { path = "../ironrdp-rdpdr", version = "0.7" } # public
+ironrdp-svc = { path = "../ironrdp-svc", version = "0.8" } # public
 tracing = { version = "0.1", features = ["log"] }
 windows = { version = "0.62", features = [
     "Wdk_Foundation",

--- a/crates/ironrdp-rdpdr-native/Cargo.toml
+++ b/crates/ironrdp-rdpdr-native/Cargo.toml
@@ -26,19 +26,21 @@ tracing = { version = "0.1", features = ["log"] }
 
 [target.'cfg(windows)'.dependencies]
 ironrdp-core = { path = "../ironrdp-core", version = "0.2" }
-ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9" } # public
-ironrdp-svc = { path = "../ironrdp-svc", version = "0.8" } # public
-ironrdp-rdpdr = { path = "../ironrdp-rdpdr", version = "0.7" } # public
+ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9" }
+ironrdp-rdpdr = { path = "../ironrdp-rdpdr", version = "0.7" }
+ironrdp-svc = { path = "../ironrdp-svc", version = "0.8" }
+tracing = { version = "0.1", features = ["log"] }
 windows = { version = "0.62", features = [
     "Wdk_Foundation",
     "Wdk_Storage_FileSystem",
     "Wdk_System_SystemServices",
     "Win32_Foundation",
     "Win32_Security",
+    "Win32_Security_Authorization",
     "Win32_Storage_FileSystem",
     "Win32_System_IO",
+    "Win32_System_Threading",
 ] }
 
-[target.'cfg(windows)'.dev-dependencies]
-ironrdp-rdpdr = { path = "../ironrdp-rdpdr", version = "0.7" }
-ironrdp-svc = { path = "../ironrdp-svc", version = "0.8" }
+[lints]
+workspace = true

--- a/crates/ironrdp-rdpdr-native/Cargo.toml
+++ b/crates/ironrdp-rdpdr-native/Cargo.toml
@@ -41,6 +41,3 @@ windows = { version = "0.62", features = [
     "Win32_System_IO",
     "Win32_System_Threading",
 ] }
-
-[lints]
-workspace = true

--- a/crates/ironrdp-rdpdr-native/README.md
+++ b/crates/ironrdp-rdpdr-native/README.md
@@ -1,14 +1,29 @@
 # IronRDP RDPDR native backends
 
-Native RDPDR backend implementations.
+Native backend building blocks for the IronRDP RDPDR static channel.
 
-On Windows, `WindowsRdpdrBackendFactory` configures one explicitly selected
-logical volume root for the portable `ironrdp-rdpdr` backend contract. The
-initial-drive name returned by `initial_drives` must be passed to
-`Rdpdr::with_drives`.
+- On macOS and Linux, the crate exports the existing `nix::backend` filesystem
+  backend.
+- On Windows, the crate contains the native, handle-relative filesystem
+  foundation used for drive redirection. It validates every protocol path
+  before resolving it below an opened volume root, and it rejects DOS device
+  aliases and reparse-point traversal. Its static filesystem support includes
+  create/open with initial allocation and validated delete-on-close, close,
+  flush, bounded synchronous offset I/O, basic file-information queries, actual
+  selected-volume information, basic metadata, EOF/allocation, delete-on-close
+  and confined rename changes, handle-bound security descriptor queries and
+  validated descriptor updates, alternate-data-stream information, plus
+  one-entry-at-a-time directory enumeration. Waiting byte-range locks and
+  directory-change notifications complete from bounded, cancellable worker
+  operations; close, reset, and device removal cancel outstanding work. Device
+  Control is deny-by-default: supported filesystem controls are the
+  handle-bound `FSCTL_CREATE_OR_GET_OBJECT_ID` with an empty input and fixed
+  64-byte output, plus the read-only `FSCTL_GET_COMPRESSION`,
+  `FSCTL_GET_INTEGRITY_INFORMATION`, and `FSCTL_QUERY_ALLOCATED_RANGES`, all
+  with validated, bounded buffers.
 
-The Windows implementation is deliberately narrow. It supports handle-relative
-create/open, close, synchronous bounded reads and writes, and basic file
-metadata queries and updates. It does not implement directory enumeration,
-notifications, locks, security descriptors, streams, control requests, or
-volume queries. Those requests receive `STATUS_NOT_SUPPORTED`.
+The Windows implementation is intentionally layered so protocol code remains
+platform independent in `ironrdp-rdpdr`.
+
+`WindowsRdpdrBackendFactory` configures one `RedirectedDrive`. Multi-drive
+registry management remains outside this native backend.

--- a/crates/ironrdp-rdpdr-native/src/nix/backend.rs
+++ b/crates/ironrdp-rdpdr-native/src/nix/backend.rs
@@ -47,6 +47,11 @@ impl RdpdrBackend for NixRdpdrBackend {
             ServerDriveIoRequest::ServerCreateDriveRequest(req_inner) => create_drive(self, req_inner),
             ServerDriveIoRequest::DeviceReadRequest(req_inner) => read_device(self, req_inner),
             ServerDriveIoRequest::DeviceCloseRequest(req_inner) => close_device(self, req_inner),
+            ServerDriveIoRequest::DeviceFlushBuffersRequest(req_inner) => Ok(vec![SvcMessage::from(
+                RdpdrPdu::DeviceFlushBuffersResponse(DeviceFlushBuffersResponse {
+                    device_io_response: DeviceIoResponse::new(req_inner.device_io_request, NtStatus::NOT_SUPPORTED),
+                }),
+            )]),
             ServerDriveIoRequest::ServerDriveNotifyChangeDirectoryRequest(_) => {
                 // TODO
                 Ok(Vec::new())
@@ -66,6 +71,19 @@ impl RdpdrBackend for NixRdpdrBackend {
             ServerDriveIoRequest::ServerDriveLockControlRequest(_) => {
                 // TODO
                 Ok(Vec::new())
+            }
+            ServerDriveIoRequest::ServerDriveQuerySecurityRequest(req_inner) => Ok(vec![SvcMessage::from(
+                RdpdrPdu::ClientDriveQuerySecurityResponse(ClientDriveQuerySecurityResponse {
+                    device_io_response: DeviceIoResponse::new(req_inner.device_io_request, NtStatus::NOT_SUPPORTED),
+                    security_descriptor: None,
+                }),
+            )]),
+            ServerDriveIoRequest::ServerDriveSetSecurityRequest(req_inner) => {
+                let response = ClientDriveSetSecurityResponse::new(&req_inner, NtStatus::NOT_SUPPORTED)
+                    .map_err(|error| encode_err!(error))?;
+                Ok(vec![SvcMessage::from(RdpdrPdu::ClientDriveSetSecurityResponse(
+                    response,
+                ))])
             }
         }
     }

--- a/crates/ironrdp-rdpdr-native/src/windows/backend.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/backend.rs
@@ -1,383 +1,154 @@
-//! Narrow Windows filesystem backend for the portable RDPDR contract.
-//!
-//! The IRPs implemented here correspond to [MS-RDPEFS] 2.2.3.3.1 through
-//! 2.2.3.3.4 and 2.2.3.3.8 through 2.2.3.3.9. Native information buffers use
-//! [MS-FSCC] 2.4.7, 2.4.14, and 2.4.47.
-//!
-//! [MS-RDPEFS]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs
-//! [MS-FSCC]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc
+use std::collections::HashMap;
 
 use ironrdp_core::impl_as_any;
-use ironrdp_pdu::{PduResult, encode_err, pdu_other_err};
+use ironrdp_pdu::{PduResult, pdu_other_err};
 use ironrdp_rdpdr::RdpdrBackend;
-use ironrdp_rdpdr::pdu::RdpdrPdu;
 use ironrdp_rdpdr::pdu::efs::{
-    AnyIoCtlCode, Boolean, ClientDriveLockControlResponse, ClientDriveNotifyChangeDirectoryResponse,
-    ClientDriveQueryDirectoryResponse, ClientDriveQueryInformationResponse, ClientDriveQueryVolumeInformationResponse,
-    ClientDriveSetInformationResponse, DecodedDeviceControlRequest, DeviceCloseRequest, DeviceCloseResponse,
-    DeviceControlRequest, DeviceControlResponse, DeviceCreateRequest, DeviceCreateResponse, DeviceIoResponse,
-    DeviceReadRequest, DeviceReadResponse, DeviceWriteRequest, DeviceWriteResponse, FileAttributeTagInformation,
-    FileAttributes, FileBasicInformation, FileInformationClass, FileInformationClassLevel, FileStandardInformation,
-    Information, NtStatus, ServerDeviceAnnounceResponse, ServerDriveIoRequest, ServerDriveQueryInformationRequest,
-    ServerDriveSetInformationRequest,
+    AnyIoCtlCode, DecodedDeviceControlRequest, DeviceControlRequest, ServerDeviceAnnounceResponse, ServerDriveIoRequest,
 };
 use ironrdp_rdpdr::pdu::esc::{ScardCall, ScardIoCtlCode};
 use ironrdp_svc::SvcMessage;
-use windows::Wdk::Storage::FileSystem::FILE_BASIC_INFORMATION as NativeFileBasicInformation;
 
+use super::control;
+use super::directory;
 use super::factory::RedirectedDrive;
+use super::file;
 use super::file_table::FileTable;
-use super::handles::{
-    FILE_CREATED_INFORMATION, FILE_OPENED_INFORMATION, FILE_OVERWRITTEN_INFORMATION, FILE_SUPERSEDED_INFORMATION,
-    FileHandle, FileOpenOptions, RootDirectory,
-};
+use super::handles::{FileHandle, RootDirectory};
+use super::locks;
 use super::path::RelativePath;
-use super::status::{from_ntstatus, from_path_policy};
+use super::pending::DeferredOperations;
+use super::security;
+use super::status::from_open_directory;
+use super::volume;
 
 const DEFAULT_MAX_OPEN_FILES: usize = 1_024;
-const MAX_STATIC_IO_SIZE: usize = 1_024 * 1_024;
-const SYNCHRONIZE: u32 = 0x0010_0000;
-const FILE_READ_ATTRIBUTES: u32 = 0x0000_0080;
-const FILE_WRITE_DATA: u32 = 0x0000_0002;
-const FILE_APPEND_DATA: u32 = 0x0000_0004;
-const FILE_WRITE_EA: u32 = 0x0000_0010;
-const FILE_WRITE_ATTRIBUTES: u32 = 0x0000_0100;
-const DELETE: u32 = 0x0001_0000;
-const GENERIC_ALL: u32 = 0x1000_0000;
-const GENERIC_WRITE: u32 = 0x4000_0000;
-const FILE_DIRECTORY_FILE: u32 = 0x0000_0001;
-const FILE_NON_DIRECTORY_FILE: u32 = 0x0000_0040;
-const FILE_WRITE_THROUGH: u32 = 0x0000_0002;
-const FILE_SEQUENTIAL_ONLY: u32 = 0x0000_0004;
-const FILE_SYNCHRONOUS_IO_NONALERT: u32 = 0x0000_0020;
-const FILE_RANDOM_ACCESS: u32 = 0x0000_0800;
-const FILE_DELETE_ON_CLOSE: u32 = 0x0000_1000;
-const FILE_OPEN_BY_FILE_ID: u32 = 0x0000_2000;
-const FILE_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
-const ALLOWED_CREATE_OPTIONS: u32 = FILE_DIRECTORY_FILE
-    | FILE_NON_DIRECTORY_FILE
-    | FILE_WRITE_THROUGH
-    | FILE_SEQUENTIAL_ONLY
-    | FILE_SYNCHRONOUS_IO_NONALERT
-    | FILE_RANDOM_ACCESS;
 
-/// Windows backend that safely opens files below explicitly configured roots.
+/// Windows RDPDR filesystem backend for a fixed per-connection drive snapshot.
+///
+/// The static filesystem operation matrix is implemented incrementally. Until an
+/// operation has a confined native implementation, the backend emits its typed
+/// `STATUS_NOT_SUPPORTED` response rather than leaving an IRP unanswered.
 #[derive(Debug)]
 pub struct WindowsRdpdrBackend {
     drive: RedirectedDrive,
-    root: Option<RedirectedRoot>,
-    open_files: FileTable<OpenFile>,
+    pub(super) roots: HashMap<u32, RedirectedRoot>,
+    pub(super) open_files: FileTable<OpenFile>,
+    deferred_operations: DeferredOperations,
 }
 
 impl WindowsRdpdrBackend {
     pub(crate) fn from_drive(drive: RedirectedDrive) -> Self {
         Self {
             drive,
-            root: None,
+            roots: HashMap::new(),
             open_files: FileTable::new(DEFAULT_MAX_OPEN_FILES),
+            deferred_operations: DeferredOperations::new(),
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_active_drive(drive: RedirectedDrive) -> Self {
+        let device_id = drive.device_id();
+        let mut backend = Self::from_drive(drive);
+        backend
+            .activate_drive(device_id)
+            .expect("test redirected drive must activate");
+        backend
     }
 
     fn activate_drive(&mut self, device_id: u32) -> PduResult<()> {
         if device_id != self.drive.device_id() {
             return Err(pdu_other_err!("windows RDPDR drive is not configured"));
         }
-        if self.root.is_some() {
+        if self.roots.contains_key(&device_id) {
             return Err(pdu_other_err!("windows RDPDR drive is already active"));
         }
+
         let root = RootDirectory::open(self.drive.root_path())
-            .map_err(|_status| pdu_other_err!("open configured Windows RDPDR volume root"))?;
-        self.root = Some(RedirectedRoot {
-            root,
-            read_only: self.drive.read_only(),
-        });
+            .map_err(|error| pdu_other_err!("open configured Windows RDPDR volume root").with_source(error))?;
+        let previous = self.roots.insert(
+            device_id,
+            RedirectedRoot {
+                root,
+                read_only: self.drive.read_only(),
+            },
+        );
+        debug_assert!(
+            previous.is_none(),
+            "an inactive RDPDR drive cannot retain a root handle"
+        );
         Ok(())
     }
 
-    fn create(&mut self, req: DeviceCreateRequest) -> PduResult<Vec<SvcMessage>> {
-        let response = match self.create_inner(&req) {
-            Ok((file_id, information)) => DeviceCreateResponse {
-                device_io_reply: DeviceIoResponse::new(req.device_io_request, NtStatus::SUCCESS),
-                file_id,
-                information,
-            },
-            Err(status) => DeviceCreateResponse {
-                device_io_reply: DeviceIoResponse::new(req.device_io_request, status),
-                file_id: 0,
-                information: Information::empty(),
-            },
-        };
-
-        Ok(vec![SvcMessage::from(RdpdrPdu::DeviceCreateResponse(response))])
-    }
-
-    fn create_inner(&mut self, req: &DeviceCreateRequest) -> Result<(u32, Information), NtStatus> {
-        let path = RelativePath::parse(&req.path).map_err(from_path_policy)?;
-        let is_root = path.components().next().is_none();
-        if req.device_io_request.device_id != self.drive.device_id() {
-            return Err(NtStatus::INVALID_PARAMETER);
-        }
-        let root = self.root.as_ref().ok_or(NtStatus::INVALID_PARAMETER)?;
-        validate_create_request(req, root.read_only, is_root)?;
-
-        if is_root {
-            let disposition = u32::from(req.create_disposition);
-            if !matches!(
-                disposition,
-                x if x == u32::from(ironrdp_rdpdr::pdu::efs::CreateDisposition::FILE_OPEN)
-                    || x == u32::from(ironrdp_rdpdr::pdu::efs::CreateDisposition::FILE_OPEN_IF)
-            ) {
-                return Err(NtStatus::OBJECT_NAME_COLLISION);
-            }
-            if req.create_options.bits() & FILE_NON_DIRECTORY_FILE != 0 {
-                return Err(NtStatus::FILE_IS_A_DIRECTORY);
-            }
-            if req.allocation_size != 0 {
-                return Err(NtStatus::INVALID_PARAMETER);
-            }
+    fn deactivate_drive(&mut self, device_id: u32) -> PduResult<Vec<SvcMessage>> {
+        if device_id != self.drive.device_id() || !self.roots.contains_key(&device_id) {
+            return Err(pdu_other_err!("windows RDPDR drive is not active"));
         }
 
-        let allocation_size = i64::try_from(req.allocation_size).map_err(|_| NtStatus::INVALID_PARAMETER)?;
-        let options = FileOpenOptions {
-            // Explorer often opens an object for enumeration and then asks for
-            // metadata without separately requesting FILE_READ_ATTRIBUTES.
-            desired_access: req.desired_access.bits() | SYNCHRONIZE | FILE_READ_ATTRIBUTES,
-            allocation_size: (req.allocation_size != 0).then_some(allocation_size),
-            file_attributes: req.file_attributes.bits(),
-            share_access: req.shared_access.bits(),
-            create_disposition: u32::from(req.create_disposition),
-            create_options: req.create_options.bits(),
-        };
-        let reservation = self.open_files.reserve_file_id().map_err(|error| match error {
-            super::file_table::FileTableError::CapacityExceeded
-            | super::file_table::FileTableError::IdSpaceExhausted => NtStatus::from(0xC000_009A),
-        })?;
-        let file_id = reservation.file_id();
-        let (handle, native_information) = match root.root.open_relative_file(&path, options) {
-            Ok(result) => result,
-            Err(status) => {
-                self.open_files.release_file_id(reservation);
-                return Err(from_ntstatus(status));
-            }
-        };
-        let information = match create_information(native_information) {
-            Ok(information) => information,
-            Err(status) => {
-                self.open_files.release_file_id(reservation);
-                return Err(status);
-            }
-        };
-        self.open_files.insert(
-            reservation,
-            OpenFile {
-                read_only: root.read_only,
-                handle,
-            },
-        );
-
-        Ok((file_id, information))
+        let cancelled = self.deferred_operations.cancel_drive(device_id);
+        self.open_files.retain(|file| file.device_id != device_id);
+        self.roots.remove(&device_id);
+        Ok(cancelled)
     }
 
-    fn close(&mut self, req: DeviceCloseRequest) -> PduResult<Vec<SvcMessage>> {
-        let status = match self.open_files.get(req.device_io_request.file_id) {
-            Some(_) if req.device_io_request.device_id == self.drive.device_id() => {
-                let _ = self.open_files.remove(req.device_io_request.file_id);
-                NtStatus::SUCCESS
-            }
-            _ => NtStatus::INVALID_HANDLE,
-        };
-        Ok(vec![SvcMessage::from(RdpdrPdu::DeviceCloseResponse(
-            DeviceCloseResponse {
-                device_io_response: DeviceIoResponse::new(req.device_io_request, status),
-            },
-        ))])
+    pub(super) fn schedule_waiting_lock(
+        &mut self,
+        request: ironrdp_rdpdr::pdu::efs::DeviceIoRequest,
+        ranges: Vec<(u64, u64)>,
+        exclusive: bool,
+    ) -> Result<(), ironrdp_rdpdr::pdu::efs::NtStatus> {
+        let handle = file::file_for_request(self, request.device_id, request.file_id)?
+            .handle
+            .try_clone()
+            .map_err(|_| ironrdp_rdpdr::pdu::efs::NtStatus::UNSUCCESSFUL)?;
+        self.deferred_operations
+            .schedule_waiting_lock(request, ranges, exclusive, handle)
     }
 
-    fn read(&self, req: DeviceReadRequest) -> PduResult<Vec<SvcMessage>> {
-        let (status, read_data) = self
-            .read_inner(&req)
-            .map_or_else(|status| (status, Vec::new()), |data| (NtStatus::SUCCESS, data));
-        Ok(vec![SvcMessage::from(RdpdrPdu::DeviceReadResponse(
-            DeviceReadResponse {
-                device_io_reply: DeviceIoResponse::new(req.device_io_request, status),
-                read_data,
-            },
-        ))])
+    pub(super) fn cancel_deferred_file_operations(&mut self, device_id: u32, file_id: u32) -> Vec<SvcMessage> {
+        self.deferred_operations.cancel_file(device_id, file_id)
     }
 
-    fn read_inner(&self, req: &DeviceReadRequest) -> Result<Vec<u8>, NtStatus> {
-        let length = usize::try_from(req.length).map_err(|_| NtStatus::INVALID_PARAMETER)?;
-        validate_io_length(length)?;
-        let offset = i64::try_from(req.offset).map_err(|_| NtStatus::INVALID_PARAMETER)?;
-        let file = self.file_for_request(req.device_io_request.device_id, req.device_io_request.file_id)?;
-        let mut data = vec![0; length];
-        let completion = file.handle.read_at(offset, &mut data).map_err(from_ntstatus)?;
-        if completion.status.0 < 0 {
-            return Err(from_ntstatus(completion.status));
-        }
-        data.truncate(completion.transferred);
-        Ok(data)
+    pub(super) fn schedule_directory_notification(
+        &mut self,
+        request: ironrdp_rdpdr::pdu::efs::ServerDriveNotifyChangeDirectoryRequest,
+    ) -> Result<(), ironrdp_rdpdr::pdu::efs::NtStatus> {
+        let handle = self
+            .open_directory_for_notification(request.device_io_request.device_id, request.device_io_request.file_id)?;
+        self.deferred_operations
+            .schedule_directory_notification(request, handle)
     }
 
-    fn write(&self, req: DeviceWriteRequest) -> PduResult<Vec<SvcMessage>> {
-        let (status, length) = self
-            .write_inner(&req)
-            .map_or_else(|status| (status, 0), |length| (NtStatus::SUCCESS, length));
-        Ok(vec![SvcMessage::from(RdpdrPdu::DeviceWriteResponse(
-            DeviceWriteResponse {
-                device_io_reply: DeviceIoResponse::new(req.device_io_request, status),
-                length,
-            },
-        ))])
-    }
-
-    fn write_inner(&self, req: &DeviceWriteRequest) -> Result<u32, NtStatus> {
-        validate_io_length(req.write_data.len())?;
-        let offset = if req.offset == u64::MAX {
-            -1 // FILE_WRITE_TO_END_OF_FILE
-        } else {
-            i64::try_from(req.offset).map_err(|_| NtStatus::INVALID_PARAMETER)?
-        };
-        let file = self.file_for_request(req.device_io_request.device_id, req.device_io_request.file_id)?;
-        if file.read_only {
-            return Err(NtStatus::MEDIA_WRITE_PROTECTED);
-        }
-
-        let completion = file.handle.write_at(offset, &req.write_data).map_err(from_ntstatus)?;
-        if completion.status.0 < 0 {
-            return Err(from_ntstatus(completion.status));
-        }
-        if completion.transferred != req.write_data.len() {
-            return Err(NtStatus::UNSUCCESSFUL);
-        }
-        u32::try_from(completion.transferred).map_err(|_| NtStatus::UNSUCCESSFUL)
-    }
-
-    fn query_information(&self, req: ServerDriveQueryInformationRequest) -> PduResult<Vec<SvcMessage>> {
-        let (status, buffer) = self
-            .query_information_inner(&req)
-            .map_or_else(|status| (status, None), |buffer| (NtStatus::SUCCESS, Some(buffer)));
-        Ok(vec![SvcMessage::from(RdpdrPdu::ClientDriveQueryInformationResponse(
-            ClientDriveQueryInformationResponse {
-                device_io_response: DeviceIoResponse::new(req.device_io_request, status),
-                buffer,
-            },
-        ))])
-    }
-
-    fn query_information_inner(
+    pub(super) fn open_directory_for_notification(
         &self,
-        req: &ServerDriveQueryInformationRequest,
-    ) -> Result<FileInformationClass, NtStatus> {
-        let file = self.file_for_request(req.device_io_request.device_id, req.device_io_request.file_id)?;
+        device_id: u32,
+        file_id: u32,
+    ) -> Result<FileHandle, ironrdp_rdpdr::pdu::efs::NtStatus> {
+        let path = file::file_for_request(self, device_id, file_id)?.path.clone();
 
-        match req.file_info_class_lvl {
-            FileInformationClassLevel::FILE_BASIC_INFORMATION => {
-                let information = file.handle.query_basic_information().map_err(from_ntstatus)?;
-                Ok(FileBasicInformation {
-                    creation_time: information.CreationTime,
-                    last_access_time: information.LastAccessTime,
-                    last_write_time: information.LastWriteTime,
-                    change_time: information.ChangeTime,
-                    file_attributes: FileAttributes::from_bits_retain(information.FileAttributes),
-                }
-                .into())
-            }
-            FileInformationClassLevel::FILE_STANDARD_INFORMATION => {
-                let information = file.handle.query_standard_information().map_err(from_ntstatus)?;
-                Ok(FileStandardInformation {
-                    allocation_size: information.AllocationSize,
-                    end_of_file: information.EndOfFile,
-                    number_of_links: information.NumberOfLinks,
-                    delete_pending: Boolean::from(u8::from(information.DeletePending)),
-                    directory: Boolean::from(u8::from(information.Directory)),
-                }
-                .into())
-            }
-            FileInformationClassLevel::FILE_ATTRIBUTE_TAG_INFORMATION => {
-                let information = file.handle.query_attribute_tag_information().map_err(from_ntstatus)?;
-                Ok(FileAttributeTagInformation {
-                    file_attributes: FileAttributes::from_bits_retain(information.FileAttributes),
-                    reparse_tag: information.ReparseTag,
-                }
-                .into())
-            }
-            _ => Err(NtStatus::NOT_SUPPORTED),
-        }
-    }
-
-    fn set_information(&self, req: ServerDriveSetInformationRequest) -> PduResult<Vec<SvcMessage>> {
-        let status = self
-            .set_information_inner(&req)
-            .map_or_else(|status| status, |_| NtStatus::SUCCESS);
-        let response = ClientDriveSetInformationResponse::new(&req, status).map_err(|error| encode_err!(error))?;
-        Ok(vec![SvcMessage::from(RdpdrPdu::ClientDriveSetInformationResponse(
-            response,
-        ))])
-    }
-
-    fn set_information_inner(&self, req: &ServerDriveSetInformationRequest) -> Result<(), NtStatus> {
-        let file = self.file_for_request(req.device_io_request.device_id, req.device_io_request.file_id)?;
-        if file.read_only {
-            return Err(NtStatus::MEDIA_WRITE_PROTECTED);
-        }
-
-        match &req.set_buffer {
-            FileInformationClass::EndOfFile(information) => {
-                if information.end_of_file < 0 {
-                    return Err(NtStatus::INVALID_PARAMETER);
-                }
-                file.handle
-                    .set_end_of_file(information.end_of_file)
-                    .map_err(from_ntstatus)
-            }
-            FileInformationClass::Basic(information) => {
-                if [
-                    information.creation_time,
-                    information.last_access_time,
-                    information.last_write_time,
-                    information.change_time,
-                ]
-                .into_iter()
-                .any(|time| time < -2)
-                {
-                    return Err(NtStatus::INVALID_PARAMETER);
-                }
-                file.handle
-                    .set_basic_information(NativeFileBasicInformation {
-                        CreationTime: information.creation_time,
-                        LastAccessTime: information.last_access_time,
-                        LastWriteTime: information.last_write_time,
-                        ChangeTime: information.change_time,
-                        FileAttributes: information.file_attributes.bits(),
-                    })
-                    .map_err(from_ntstatus)
-            }
-            _ => Err(NtStatus::NOT_SUPPORTED),
-        }
-    }
-
-    fn file_for_request(&self, device_id: u32, file_id: u32) -> Result<&OpenFile, NtStatus> {
-        if device_id != self.drive.device_id() {
-            return Err(NtStatus::INVALID_HANDLE);
-        }
-
-        self.open_files.get(file_id).ok_or(NtStatus::INVALID_HANDLE)
-    }
-
-    fn unsupported_control(req: DeviceControlRequest<AnyIoCtlCode>) -> PduResult<Vec<SvcMessage>> {
-        Ok(vec![SvcMessage::from(RdpdrPdu::DeviceControlResponse(
-            DeviceControlResponse::new(req, NtStatus::NOT_SUPPORTED, None),
-        ))])
+        self.roots
+            .get(&device_id)
+            .ok_or(ironrdp_rdpdr::pdu::efs::NtStatus::INVALID_PARAMETER)?
+            .root
+            .open_relative_directory_for_notification(&path)
+            .map_err(from_open_directory)?
+            .map(|directory| directory.into_file_handle())
+            .ok_or(ironrdp_rdpdr::pdu::efs::NtStatus::NOT_A_DIRECTORY)
     }
 }
 
 impl_as_any!(WindowsRdpdrBackend);
 
 impl RdpdrBackend for WindowsRdpdrBackend {
+    fn supports_drive_security(&self) -> bool {
+        true
+    }
+
     fn reset(&mut self) -> PduResult<()> {
+        self.deferred_operations.reset();
         self.open_files.clear();
-        self.root = None;
+        self.roots.clear();
         Ok(())
     }
 
@@ -393,40 +164,30 @@ impl RdpdrBackend for WindowsRdpdrBackend {
         Ok(())
     }
 
+    fn add_drive(&mut self, device_id: u32) -> PduResult<()> {
+        self.activate_drive(device_id)
+    }
+
+    fn remove_drive(&mut self, device_id: u32) -> PduResult<Vec<SvcMessage>> {
+        self.deactivate_drive(device_id)
+    }
+
     fn handle_drive_io_request(&mut self, req: ServerDriveIoRequest) -> PduResult<Vec<SvcMessage>> {
         match req {
-            ServerDriveIoRequest::ServerCreateDriveRequest(req) => self.create(req),
-            ServerDriveIoRequest::DeviceCloseRequest(req) => self.close(req),
-            ServerDriveIoRequest::DeviceReadRequest(req) => self.read(req),
-            ServerDriveIoRequest::DeviceWriteRequest(req) => self.write(req),
-            ServerDriveIoRequest::ServerDriveQueryInformationRequest(req) => self.query_information(req),
-            ServerDriveIoRequest::ServerDriveSetInformationRequest(req) => self.set_information(req),
-            ServerDriveIoRequest::ServerDriveQueryDirectoryRequest(req) => Ok(vec![SvcMessage::from(
-                RdpdrPdu::ClientDriveQueryDirectoryResponse(ClientDriveQueryDirectoryResponse {
-                    device_io_reply: DeviceIoResponse::new(req.device_io_request, NtStatus::NOT_SUPPORTED),
-                    buffer: None,
-                }),
-            )]),
-            ServerDriveIoRequest::ServerDriveNotifyChangeDirectoryRequest(req) => Ok(vec![SvcMessage::from(
-                RdpdrPdu::ClientDriveNotifyChangeDirectoryResponse(ClientDriveNotifyChangeDirectoryResponse::new(
-                    req.device_io_request,
-                    NtStatus::NOT_SUPPORTED,
-                    Vec::new(),
-                )),
-            )]),
-            ServerDriveIoRequest::ServerDriveQueryVolumeInformationRequest(req) => Ok(vec![SvcMessage::from(
-                RdpdrPdu::ClientDriveQueryVolumeInformationResponse(ClientDriveQueryVolumeInformationResponse::new(
-                    req.device_io_request,
-                    NtStatus::NOT_SUPPORTED,
-                    None,
-                )),
-            )]),
-            ServerDriveIoRequest::ServerDriveLockControlRequest(req) => {
-                Ok(vec![SvcMessage::from(RdpdrPdu::ClientDriveLockControlResponse(
-                    ClientDriveLockControlResponse::new(req.device_io_request, NtStatus::NOT_SUPPORTED),
-                ))])
-            }
-            ServerDriveIoRequest::DeviceControlRequest(req) => Self::unsupported_control(req),
+            ServerDriveIoRequest::ServerCreateDriveRequest(req) => file::create(self, req),
+            ServerDriveIoRequest::DeviceCloseRequest(req) => file::close(self, req),
+            ServerDriveIoRequest::DeviceReadRequest(req) => file::read(self, req),
+            ServerDriveIoRequest::DeviceWriteRequest(req) => file::write(self, req),
+            ServerDriveIoRequest::DeviceFlushBuffersRequest(req) => file::flush(self, req),
+            ServerDriveIoRequest::ServerDriveQueryInformationRequest(req) => file::query_information(self, req),
+            ServerDriveIoRequest::ServerDriveQuerySecurityRequest(req) => security::query(self, req),
+            ServerDriveIoRequest::ServerDriveQueryVolumeInformationRequest(req) => volume::query_information(self, req),
+            ServerDriveIoRequest::ServerDriveSetInformationRequest(req) => file::set_information(self, req),
+            ServerDriveIoRequest::ServerDriveSetSecurityRequest(req) => security::set(self, req),
+            ServerDriveIoRequest::ServerDriveQueryDirectoryRequest(req) => directory::query_information(self, req),
+            ServerDriveIoRequest::ServerDriveNotifyChangeDirectoryRequest(req) => directory::notify_change(self, req),
+            ServerDriveIoRequest::ServerDriveLockControlRequest(req) => locks::control(self, req),
+            ServerDriveIoRequest::DeviceControlRequest(req) => control::handle(self, req, &[]),
         }
     }
 
@@ -434,411 +195,31 @@ impl RdpdrBackend for WindowsRdpdrBackend {
         &mut self,
         req: DecodedDeviceControlRequest<AnyIoCtlCode>,
     ) -> PduResult<Vec<SvcMessage>> {
-        Self::unsupported_control(req.request)
+        control::handle(self, req.request, &req.input_buffer)
+    }
+
+    fn poll_deferred_messages(&mut self) -> PduResult<Vec<SvcMessage>> {
+        Ok(self.deferred_operations.poll())
     }
 }
 
 #[derive(Debug)]
-struct RedirectedRoot {
-    root: RootDirectory,
-    read_only: bool,
+pub(super) struct RedirectedRoot {
+    pub(super) root: RootDirectory,
+    pub(super) read_only: bool,
 }
 
+/// An opaque local handle bound to the RDPDR device that opened it.
 #[derive(Debug)]
-struct OpenFile {
-    read_only: bool,
-    handle: FileHandle,
-}
-
-fn validate_create_request(req: &DeviceCreateRequest, read_only: bool, is_root: bool) -> Result<(), NtStatus> {
-    let desired_access = req.desired_access.bits();
-    let options = req.create_options.bits();
-    let disposition = u32::from(req.create_disposition);
-
-    if i64::try_from(req.allocation_size).is_err() {
-        return Err(NtStatus::INVALID_PARAMETER);
-    }
-    if options & (FILE_OPEN_BY_FILE_ID | FILE_OPEN_REPARSE_POINT | FILE_DELETE_ON_CLOSE) != 0
-        || options & !ALLOWED_CREATE_OPTIONS != 0
-    {
-        return Err(NtStatus::NOT_SUPPORTED);
-    }
-    if options & FILE_DIRECTORY_FILE != 0 && options & FILE_NON_DIRECTORY_FILE != 0 {
-        return Err(NtStatus::INVALID_PARAMETER);
-    }
-    if !matches!(
-        disposition,
-        x if x == u32::from(ironrdp_rdpdr::pdu::efs::CreateDisposition::FILE_SUPERSEDE)
-            || x == u32::from(ironrdp_rdpdr::pdu::efs::CreateDisposition::FILE_OPEN)
-            || x == u32::from(ironrdp_rdpdr::pdu::efs::CreateDisposition::FILE_CREATE)
-            || x == u32::from(ironrdp_rdpdr::pdu::efs::CreateDisposition::FILE_OPEN_IF)
-            || x == u32::from(ironrdp_rdpdr::pdu::efs::CreateDisposition::FILE_OVERWRITE)
-            || x == u32::from(ironrdp_rdpdr::pdu::efs::CreateDisposition::FILE_OVERWRITE_IF)
-    ) {
-        return Err(NtStatus::INVALID_PARAMETER);
-    }
-
-    let mutating_disposition = matches!(
-        disposition,
-        x if x == u32::from(ironrdp_rdpdr::pdu::efs::CreateDisposition::FILE_SUPERSEDE)
-            || x == u32::from(ironrdp_rdpdr::pdu::efs::CreateDisposition::FILE_CREATE)
-            || (x == u32::from(ironrdp_rdpdr::pdu::efs::CreateDisposition::FILE_OPEN_IF) && !is_root)
-            || x == u32::from(ironrdp_rdpdr::pdu::efs::CreateDisposition::FILE_OVERWRITE)
-            || x == u32::from(ironrdp_rdpdr::pdu::efs::CreateDisposition::FILE_OVERWRITE_IF)
-    );
-    let mutating_access = FILE_WRITE_DATA
-        | FILE_APPEND_DATA
-        | FILE_WRITE_EA
-        | FILE_WRITE_ATTRIBUTES
-        | DELETE
-        | GENERIC_ALL
-        | GENERIC_WRITE;
-    if read_only && (desired_access & mutating_access != 0 || mutating_disposition) {
-        return Err(NtStatus::MEDIA_WRITE_PROTECTED);
-    }
-
-    Ok(())
-}
-
-fn validate_io_length(length: usize) -> Result<(), NtStatus> {
-    if length > MAX_STATIC_IO_SIZE {
-        return Err(NtStatus::INVALID_PARAMETER);
-    }
-    Ok(())
-}
-
-fn create_information(information: usize) -> Result<Information, NtStatus> {
-    match information {
-        FILE_SUPERSEDED_INFORMATION => Ok(Information::file_superseded()),
-        FILE_OPENED_INFORMATION => Ok(Information::file_opened()),
-        FILE_CREATED_INFORMATION => Ok(Information::file_created()),
-        FILE_OVERWRITTEN_INFORMATION => Ok(Information::file_overwritten()),
-        _ => Err(NtStatus::UNSUCCESSFUL),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::path::PathBuf;
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    use ironrdp_rdpdr::pdu::efs::{
-        CreateDisposition, CreateOptions, DesiredAccess, FileEndOfFileInformation, LockOperation, MajorFunction,
-        MinorFunction, ServerDriveLockControlRequest, ServerDriveNotifyChangeDirectoryRequest, SharedAccess,
-    };
-
-    use crate::windows::factory::WindowsRdpdrBackendFactory;
-
-    #[test]
-    fn regular_file_lifecycle_is_handle_relative_and_bounded() {
-        let fixture = Fixture::new();
-        let mut backend = fixture.backend();
-        activate(&mut backend);
-
-        let create = create_request(&fixture.relative(r"root\report.txt"), CreateDisposition::FILE_OPEN_IF);
-        let create_response = backend
-            .handle_drive_io_request(ServerDriveIoRequest::ServerCreateDriveRequest(create))
-            .expect("complete create");
-        assert_eq!(response_status(&create_response), NtStatus::SUCCESS);
-        let file_id = response_file_id(&create_response);
-
-        let write = DeviceWriteRequest {
-            device_io_request: request_header(file_id, MajorFunction::Write),
-            offset: 0,
-            write_data: b"hello".to_vec(),
-        };
-        let write_response = backend
-            .handle_drive_io_request(ServerDriveIoRequest::DeviceWriteRequest(write))
-            .expect("complete write");
-        assert_eq!(response_status(&write_response), NtStatus::SUCCESS);
-
-        let append_response = backend
-            .handle_drive_io_request(ServerDriveIoRequest::DeviceWriteRequest(DeviceWriteRequest {
-                device_io_request: request_header(file_id, MajorFunction::Write),
-                offset: u64::MAX,
-                write_data: b"!".to_vec(),
-            }))
-            .expect("complete append");
-        assert_eq!(response_status(&append_response), NtStatus::SUCCESS);
-
-        let read = DeviceReadRequest {
-            device_io_request: request_header(file_id, MajorFunction::Read),
-            length: 6,
-            offset: 0,
-        };
-        let read_response = backend
-            .handle_drive_io_request(ServerDriveIoRequest::DeviceReadRequest(read))
-            .expect("complete read");
-        assert_eq!(response_status(&read_response), NtStatus::SUCCESS);
-        let bytes = read_response[0].encode_unframed_pdu().expect("encode read response");
-        assert_eq!(&bytes[20..], b"hello!");
-
-        for file_info_class_lvl in [
-            FileInformationClassLevel::FILE_BASIC_INFORMATION,
-            FileInformationClassLevel::FILE_STANDARD_INFORMATION,
-            FileInformationClassLevel::FILE_ATTRIBUTE_TAG_INFORMATION,
-        ] {
-            let query_response = backend
-                .handle_drive_io_request(ServerDriveIoRequest::ServerDriveQueryInformationRequest(
-                    ServerDriveQueryInformationRequest {
-                        device_io_request: request_header(file_id, MajorFunction::QueryInformation),
-                        file_info_class_lvl,
-                    },
-                ))
-                .expect("complete metadata query");
-            assert_eq!(response_status(&query_response), NtStatus::SUCCESS);
-        }
-
-        let set = ServerDriveSetInformationRequest {
-            device_io_request: request_header(file_id, MajorFunction::SetInformation),
-            set_buffer: FileInformationClass::EndOfFile(FileEndOfFileInformation { end_of_file: 5 }),
-        };
-        let set_response = backend
-            .handle_drive_io_request(ServerDriveIoRequest::ServerDriveSetInformationRequest(set))
-            .expect("complete set information");
-        assert_eq!(response_status(&set_response), NtStatus::SUCCESS);
-        assert_eq!(
-            std::fs::read(fixture.root.join("root").join("report.txt")).expect("read test file"),
-            b"hello"
-        );
-
-        let close_response = backend
-            .handle_drive_io_request(ServerDriveIoRequest::DeviceCloseRequest(DeviceCloseRequest {
-                device_io_request: request_header(file_id, MajorFunction::Close),
-            }))
-            .expect("complete close");
-        assert_eq!(response_status(&close_response), NtStatus::SUCCESS);
-    }
-
-    #[test]
-    fn volume_root_requests_use_the_trusted_root_handle() {
-        let fixture = Fixture::new();
-        let mut backend = fixture.backend();
-        activate(&mut backend);
-
-        let mut create = create_request(r"\", CreateDisposition::FILE_OPEN);
-        create.desired_access = DesiredAccess::from_bits_retain(FILE_READ_ATTRIBUTES | SYNCHRONIZE);
-        let response = backend
-            .handle_drive_io_request(ServerDriveIoRequest::ServerCreateDriveRequest(create))
-            .expect("complete root create");
-        assert_eq!(response_status(&response), NtStatus::SUCCESS);
-
-        let close = backend
-            .handle_drive_io_request(ServerDriveIoRequest::DeviceCloseRequest(DeviceCloseRequest {
-                device_io_request: request_header(response_file_id(&response), MajorFunction::Close),
-            }))
-            .expect("complete root close");
-        assert_eq!(response_status(&close), NtStatus::SUCCESS);
-    }
-
-    #[test]
-    fn hostile_paths_never_open_outside_the_selected_volume() {
-        let fixture = Fixture::new();
-        let mut backend = fixture.backend();
-        activate(&mut backend);
-
-        for path in [
-            r"\..\outside.txt",
-            r"\??\C:\outside.txt",
-            r"\root\CON",
-            r"\root\file:stream",
-        ] {
-            let response = backend
-                .handle_drive_io_request(ServerDriveIoRequest::ServerCreateDriveRequest(create_request(
-                    path,
-                    CreateDisposition::FILE_OPEN_IF,
-                )))
-                .expect("complete hostile create");
-            assert_ne!(response_status(&response), NtStatus::SUCCESS);
-        }
-    }
-
-    #[test]
-    fn backup_intent_is_not_forwarded_to_windows() {
-        let fixture = Fixture::new();
-        let mut backend = fixture.backend();
-        activate(&mut backend);
-
-        let mut create = create_request(&fixture.relative(r"root\backup.txt"), CreateDisposition::FILE_OPEN_IF);
-        create.create_options = CreateOptions::from_bits_retain(0x0000_4000);
-        let response = backend
-            .handle_drive_io_request(ServerDriveIoRequest::ServerCreateDriveRequest(create))
-            .expect("complete backup intent create");
-
-        assert_eq!(response_status(&response), NtStatus::NOT_SUPPORTED);
-        assert!(!fixture.root.join("root").join("backup.txt").exists());
-    }
-
-    #[test]
-    fn reparse_points_cannot_escape_the_trusted_volume_root() {
-        let fixture = Fixture::new();
-        let outside = fixture.sandbox.join("outside");
-        std::fs::create_dir_all(&outside).expect("create outside directory");
-        std::fs::write(outside.join("sentinel.txt"), b"outside").expect("write sentinel");
-
-        let link = fixture.root.join("root").join("escape");
-        if let Err(error) = std::os::windows::fs::symlink_dir(&outside, &link) {
-            if error.raw_os_error() == Some(1314) {
-                return;
-            }
-            panic!("create test reparse point: {error}");
-        }
-
-        let mut backend = fixture.backend();
-        activate(&mut backend);
-        let response = backend
-            .handle_drive_io_request(ServerDriveIoRequest::ServerCreateDriveRequest(create_request(
-                &fixture.relative(r"root\escape\sentinel.txt"),
-                CreateDisposition::FILE_OPEN,
-            )))
-            .expect("complete reparse create");
-
-        assert_ne!(response_status(&response), NtStatus::SUCCESS);
-        assert_eq!(
-            std::fs::read(outside.join("sentinel.txt")).expect("read sentinel"),
-            b"outside"
-        );
-    }
-
-    #[test]
-    fn unsupported_device_control_receives_a_completion() {
-        let fixture = Fixture::new();
-        let mut backend = fixture.backend();
-        activate(&mut backend);
-        let request = DeviceControlRequest {
-            header: request_header(0, MajorFunction::DeviceControl),
-            output_buffer_length: 0,
-            input_buffer_length: 0,
-            io_control_code: AnyIoCtlCode(0),
-        };
-
-        let response = backend
-            .handle_drive_io_request(ServerDriveIoRequest::DeviceControlRequest(request))
-            .expect("complete unsupported control");
-        assert_eq!(response_status(&response), NtStatus::NOT_SUPPORTED);
-    }
-
-    #[test]
-    fn unsupported_directory_notifications_and_locks_receive_completions() {
-        let fixture = Fixture::new();
-        let mut backend = fixture.backend();
-        activate(&mut backend);
-
-        let notification = backend
-            .handle_drive_io_request(ServerDriveIoRequest::ServerDriveNotifyChangeDirectoryRequest(
-                ServerDriveNotifyChangeDirectoryRequest {
-                    device_io_request: request_header(0, MajorFunction::DirectoryControl),
-                    watch_tree: 0,
-                    completion_filter: 0,
-                },
-            ))
-            .expect("complete unsupported notification");
-        assert_eq!(response_status(&notification), NtStatus::NOT_SUPPORTED);
-
-        let lock = backend
-            .handle_drive_io_request(ServerDriveIoRequest::ServerDriveLockControlRequest(
-                ServerDriveLockControlRequest {
-                    device_io_request: request_header(0, MajorFunction::LockControl),
-                    operation: LockOperation::Exclusive,
-                    wait: false,
-                    locks: Vec::new(),
-                },
-            ))
-            .expect("complete unsupported lock");
-        assert_eq!(response_status(&lock), NtStatus::NOT_SUPPORTED);
-    }
-
-    fn activate(backend: &mut WindowsRdpdrBackend) {
-        RdpdrBackend::restore_drive(backend, 1).expect("activate test drive");
-    }
-
-    fn create_request(path: &str, disposition: CreateDisposition) -> DeviceCreateRequest {
-        DeviceCreateRequest {
-            device_io_request: request_header(0, MajorFunction::Create),
-            desired_access: DesiredAccess::from_bits_retain(0x0010_0083),
-            allocation_size: 0,
-            file_attributes: FileAttributes::FILE_ATTRIBUTE_NORMAL,
-            shared_access: SharedAccess::from_bits_retain(0x0000_0007),
-            create_disposition: disposition,
-            create_options: CreateOptions::empty(),
-            path: path.to_owned(),
-        }
-    }
-
-    fn request_header(file_id: u32, major_function: MajorFunction) -> ironrdp_rdpdr::pdu::efs::DeviceIoRequest {
-        ironrdp_rdpdr::pdu::efs::DeviceIoRequest {
-            device_id: 1,
-            file_id,
-            completion_id: 7,
-            major_function,
-            minor_function: MinorFunction::from(0),
-        }
-    }
-
-    fn response_status(messages: &[SvcMessage]) -> NtStatus {
-        let response = messages[0].encode_unframed_pdu().expect("encode RDPDR response");
-        NtStatus::from(u32::from_le_bytes(
-            response[12..16].try_into().expect("response status"),
-        ))
-    }
-
-    fn response_file_id(messages: &[SvcMessage]) -> u32 {
-        let response = messages[0].encode_unframed_pdu().expect("encode create response");
-        u32::from_le_bytes(response[16..20].try_into().expect("create file ID"))
-    }
-
-    struct Fixture {
-        sandbox: PathBuf,
-        root: PathBuf,
-        volume_root: PathBuf,
-    }
-
-    impl Fixture {
-        fn new() -> Self {
-            let workspace = std::env::current_dir().expect("current workspace directory");
-            let volume_root = workspace
-                .ancestors()
-                .last()
-                .expect("workspace has a volume root")
-                .to_owned();
-            let unique = format!(
-                "rdpdr-native-{}-{}",
-                std::process::id(),
-                SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .expect("system clock is after Unix epoch")
-                    .as_nanos()
-            );
-            let sandbox = workspace.join("target").join(unique);
-            let root = sandbox.join("root");
-            std::fs::create_dir_all(root.join("root")).expect("create fixture root");
-            Self {
-                sandbox,
-                root,
-                volume_root,
-            }
-        }
-
-        fn backend(&self) -> WindowsRdpdrBackend {
-            WindowsRdpdrBackendFactory::new(
-                RedirectedDrive::new(1, "Test", &self.volume_root, false).expect("valid test drive"),
-            )
-            .build()
-        }
-
-        fn relative(&self, suffix: &str) -> String {
-            let relative = self
-                .root
-                .strip_prefix(&self.volume_root)
-                .expect("fixture is beneath its volume root");
-            format!(r"\{}\{}", relative.display(), suffix).replace('/', r"\")
-        }
-    }
-
-    impl Drop for Fixture {
-        fn drop(&mut self) {
-            let _ = std::fs::remove_dir_all(&self.sandbox);
-        }
-    }
+pub(super) struct OpenFile {
+    pub(super) device_id: u32,
+    pub(super) read_only: bool,
+    /// Validated path used to reopen an independent directory watcher handle.
+    pub(super) path: RelativePath,
+    pub(super) handle: FileHandle,
+    /// The directory selected by the most recent initial query for this file ID.
+    ///
+    /// MS-RDPEFS requires continuation queries to ignore their `Path` field, so
+    /// this owns the native cursor selected by the preceding initial query.
+    pub(super) directory_query_handle: Option<FileHandle>,
 }

--- a/crates/ironrdp-rdpdr-native/src/windows/control.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/control.rs
@@ -1,0 +1,541 @@
+//! Constrained filesystem Device Control support for redirected Windows files.
+
+use ironrdp_core::{EncodeResult, WriteCursor, ensure_size};
+use ironrdp_pdu::PduResult;
+use ironrdp_rdpdr::pdu::RdpdrPdu;
+use ironrdp_rdpdr::pdu::efs::{AnyIoCtlCode, DeviceControlRequest, DeviceControlResponse, NtStatus};
+use ironrdp_rdpdr::pdu::esc::rpce;
+use ironrdp_svc::SvcMessage;
+
+use super::backend::WindowsRdpdrBackend;
+use super::file::file_for_request;
+use super::handles::FILE_OBJECTID_BUFFER_SIZE;
+use super::status::from_ntstatus;
+
+/// `FSCTL_CREATE_OR_GET_OBJECT_ID` obtains an existing handle-bound object ID
+/// or creates one when the local filesystem supports that operation.
+const FSCTL_CREATE_OR_GET_OBJECT_ID: u32 = 0x0009_00C0;
+/// `FSCTL_GET_COMPRESSION` is a handle-bound query with no input and a fixed
+/// two-byte `COMPRESSION_FORMAT` output.
+const FSCTL_GET_COMPRESSION: u32 = 0x0009_003C;
+/// `FSCTL_QUERY_ALLOCATED_RANGES` reads only allocation metadata for an
+/// already-open file. It never exposes volume-wide allocation state.
+const FSCTL_QUERY_ALLOCATED_RANGES: u32 = 0x0009_40CF;
+/// `FSCTL_GET_INTEGRITY_INFORMATION` reports integrity metadata associated
+/// with an already-open file or directory.
+const FSCTL_GET_INTEGRITY_INFORMATION: u32 = 0x0009_027C;
+const COMPRESSION_FORMAT_SIZE: usize = 2;
+const FILE_ALLOCATED_RANGE_BUFFER_SIZE: usize = 16;
+const INTEGRITY_INFORMATION_SIZE: usize = 16;
+const MAX_DEVICE_CONTROL_OUTPUT_SIZE: usize = 1024 * 1024;
+
+pub(crate) fn handle(
+    backend: &WindowsRdpdrBackend,
+    req: DeviceControlRequest<AnyIoCtlCode>,
+    input_buffer: &[u8],
+) -> PduResult<Vec<SvcMessage>> {
+    let (status, output_buffer): (NtStatus, Option<Box<dyn rpce::Encode>>) =
+        match handle_inner_with_input(backend, &req, input_buffer) {
+            Ok(completion) => (completion.status, Some(Box::new(completion.output))),
+            Err(status) => (status, None),
+        };
+    let response = DeviceControlResponse::new(req, status, output_buffer);
+
+    Ok(vec![SvcMessage::from(RdpdrPdu::DeviceControlResponse(response))])
+}
+
+fn handle_inner_with_input(
+    backend: &WindowsRdpdrBackend,
+    req: &DeviceControlRequest<AnyIoCtlCode>,
+    input_buffer: &[u8],
+) -> Result<DeviceControlCompletion, NtStatus> {
+    validate_declared_input_length(req, input_buffer)?;
+    let file = file_for_request(backend, req.header.device_id, req.header.file_id)?;
+
+    match req.io_control_code.0 {
+        FSCTL_CREATE_OR_GET_OBJECT_ID => {
+            validate_create_or_get_object_id_request(req, input_buffer)?;
+            if file.read_only {
+                return Err(NtStatus::MEDIA_WRITE_PROTECTED);
+            }
+            let object_id = file.handle.create_or_get_object_id().map_err(from_ntstatus)?;
+
+            Ok(DeviceControlCompletion::success(object_id.to_vec()))
+        }
+        FSCTL_GET_COMPRESSION => {
+            validate_get_compression_request(req, input_buffer)?;
+            let format = file.handle.query_compression_format().map_err(from_ntstatus)?;
+
+            Ok(DeviceControlCompletion::success(format.to_vec()))
+        }
+        FSCTL_QUERY_ALLOCATED_RANGES => {
+            let (range, output_buffer_length) = validate_query_allocated_ranges_request(req, input_buffer)?;
+            let completion = file.handle.query_allocated_ranges(&range, output_buffer_length);
+            let status = if completion.status.0 >= 0 {
+                NtStatus::SUCCESS
+            } else {
+                from_ntstatus(completion.status)
+            };
+            if status != NtStatus::SUCCESS && status != NtStatus::BUFFER_OVERFLOW {
+                return Err(status);
+            }
+            if completion.output.len() % FILE_ALLOCATED_RANGE_BUFFER_SIZE != 0 {
+                return Err(NtStatus::UNSUCCESSFUL);
+            }
+
+            Ok(DeviceControlCompletion {
+                status,
+                output: DeviceControlOutput(completion.output),
+            })
+        }
+        FSCTL_GET_INTEGRITY_INFORMATION => {
+            validate_get_integrity_information_request(req, input_buffer)?;
+            let information = file.handle.query_integrity_information().map_err(from_ntstatus)?;
+
+            Ok(DeviceControlCompletion::success(information.to_vec()))
+        }
+        _ => Err(NtStatus::NOT_SUPPORTED),
+    }
+}
+
+fn validate_declared_input_length(
+    req: &DeviceControlRequest<AnyIoCtlCode>,
+    input_buffer: &[u8],
+) -> Result<(), NtStatus> {
+    let input_buffer_length = usize::try_from(req.input_buffer_length).map_err(|_| NtStatus::INVALID_PARAMETER)?;
+    if input_buffer_length != input_buffer.len() {
+        return Err(NtStatus::INVALID_PARAMETER);
+    }
+
+    Ok(())
+}
+
+fn validate_create_or_get_object_id_request(
+    req: &DeviceControlRequest<AnyIoCtlCode>,
+    input_buffer: &[u8],
+) -> Result<(), NtStatus> {
+    if !input_buffer.is_empty() {
+        return Err(NtStatus::INVALID_PARAMETER);
+    }
+    let output_buffer_length = usize::try_from(req.output_buffer_length).map_err(|_| NtStatus::INVALID_PARAMETER)?;
+    if output_buffer_length < FILE_OBJECTID_BUFFER_SIZE {
+        return Err(NtStatus::INVALID_PARAMETER);
+    }
+
+    Ok(())
+}
+
+fn validate_get_compression_request(
+    req: &DeviceControlRequest<AnyIoCtlCode>,
+    input_buffer: &[u8],
+) -> Result<(), NtStatus> {
+    if !input_buffer.is_empty() {
+        return Err(NtStatus::INVALID_PARAMETER);
+    }
+    let output_buffer_length = usize::try_from(req.output_buffer_length).map_err(|_| NtStatus::INVALID_PARAMETER)?;
+    if output_buffer_length < COMPRESSION_FORMAT_SIZE {
+        return Err(NtStatus::INVALID_PARAMETER);
+    }
+
+    Ok(())
+}
+
+fn validate_get_integrity_information_request(
+    req: &DeviceControlRequest<AnyIoCtlCode>,
+    input_buffer: &[u8],
+) -> Result<(), NtStatus> {
+    if !input_buffer.is_empty() {
+        return Err(NtStatus::INVALID_PARAMETER);
+    }
+    let output_buffer_length = usize::try_from(req.output_buffer_length).map_err(|_| NtStatus::INVALID_PARAMETER)?;
+    if output_buffer_length < INTEGRITY_INFORMATION_SIZE {
+        return Err(NtStatus::INVALID_PARAMETER);
+    }
+
+    Ok(())
+}
+
+fn validate_query_allocated_ranges_request(
+    req: &DeviceControlRequest<AnyIoCtlCode>,
+    input_buffer: &[u8],
+) -> Result<([u8; FILE_ALLOCATED_RANGE_BUFFER_SIZE], usize), NtStatus> {
+    let range: [u8; FILE_ALLOCATED_RANGE_BUFFER_SIZE] =
+        input_buffer.try_into().map_err(|_| NtStatus::INVALID_PARAMETER)?;
+    let file_offset = i64::from_le_bytes(range[..8].try_into().expect("fixed range offset size"));
+    let length = i64::from_le_bytes(range[8..].try_into().expect("fixed range length size"));
+    if file_offset < 0 || length < 0 || file_offset.checked_add(length).is_none() {
+        return Err(NtStatus::INVALID_PARAMETER);
+    }
+
+    let output_buffer_length = usize::try_from(req.output_buffer_length).map_err(|_| NtStatus::INVALID_PARAMETER)?;
+    if output_buffer_length > MAX_DEVICE_CONTROL_OUTPUT_SIZE {
+        return Err(NtStatus::INVALID_PARAMETER);
+    }
+    if output_buffer_length < FILE_ALLOCATED_RANGE_BUFFER_SIZE {
+        return Err(NtStatus::BUFFER_TOO_SMALL);
+    }
+
+    Ok((range, output_buffer_length))
+}
+
+#[derive(Debug)]
+struct DeviceControlCompletion {
+    status: NtStatus,
+    output: DeviceControlOutput,
+}
+
+impl DeviceControlCompletion {
+    fn success(output: Vec<u8>) -> Self {
+        Self {
+            status: NtStatus::SUCCESS,
+            output: DeviceControlOutput(output),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct DeviceControlOutput(Vec<u8>);
+
+impl ironrdp_core::Encode for DeviceControlOutput {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_slice(&self.0);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "DeviceControlOutput"
+    }
+
+    fn size(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl rpce::Encode for DeviceControlOutput {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironrdp_rdpdr::pdu::efs::{
+        CreateDisposition, CreateOptions, DesiredAccess, DeviceCreateRequest, DeviceIoRequest, FileAttributes,
+        MajorFunction, MinorFunction, SharedAccess,
+    };
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use crate::windows::factory::RedirectedDrive;
+
+    fn get_compression_request(
+        input_buffer_length: u32,
+        output_buffer_length: u32,
+    ) -> DeviceControlRequest<AnyIoCtlCode> {
+        DeviceControlRequest {
+            header: DeviceIoRequest {
+                device_id: 1,
+                file_id: 1,
+                completion_id: 1,
+                major_function: MajorFunction::DeviceControl,
+                minor_function: MinorFunction::from(0),
+            },
+            output_buffer_length,
+            input_buffer_length,
+            io_control_code: AnyIoCtlCode(FSCTL_GET_COMPRESSION),
+        }
+    }
+
+    fn create_or_get_object_id_request(
+        input_buffer_length: u32,
+        output_buffer_length: u32,
+    ) -> DeviceControlRequest<AnyIoCtlCode> {
+        let mut req = get_compression_request(input_buffer_length, output_buffer_length);
+        req.io_control_code = AnyIoCtlCode(FSCTL_CREATE_OR_GET_OBJECT_ID);
+        req
+    }
+
+    fn query_allocated_ranges_request(
+        input_buffer_length: u32,
+        output_buffer_length: u32,
+    ) -> DeviceControlRequest<AnyIoCtlCode> {
+        let mut req = get_compression_request(input_buffer_length, output_buffer_length);
+        req.io_control_code = AnyIoCtlCode(FSCTL_QUERY_ALLOCATED_RANGES);
+        req
+    }
+
+    fn get_integrity_information_request(
+        input_buffer_length: u32,
+        output_buffer_length: u32,
+    ) -> DeviceControlRequest<AnyIoCtlCode> {
+        let mut req = get_compression_request(input_buffer_length, output_buffer_length);
+        req.io_control_code = AnyIoCtlCode(FSCTL_GET_INTEGRITY_INFORMATION);
+        req
+    }
+
+    fn allocated_range(file_offset: i64, length: i64) -> [u8; FILE_ALLOCATED_RANGE_BUFFER_SIZE] {
+        let mut range = [0; FILE_ALLOCATED_RANGE_BUFFER_SIZE];
+        range[..8].copy_from_slice(&file_offset.to_le_bytes());
+        range[8..].copy_from_slice(&length.to_le_bytes());
+        range
+    }
+
+    fn u32_size(value: usize) -> u32 {
+        u32::try_from(value).expect("fixed protocol size fits in u32")
+    }
+
+    #[test]
+    fn get_compression_requires_an_empty_input_buffer() {
+        let req = get_compression_request(1, u32_size(COMPRESSION_FORMAT_SIZE));
+
+        assert_eq!(
+            validate_get_compression_request(&req, &[1]),
+            Err(NtStatus::INVALID_PARAMETER)
+        );
+    }
+
+    #[test]
+    fn get_compression_requires_the_fixed_output_buffer() {
+        let req = get_compression_request(0, u32_size(COMPRESSION_FORMAT_SIZE) - 1);
+
+        assert_eq!(
+            validate_get_compression_request(&req, &[]),
+            Err(NtStatus::INVALID_PARAMETER)
+        );
+    }
+
+    #[test]
+    fn create_or_get_object_id_requires_an_empty_input_and_full_output_buffer() {
+        let input = [1];
+        let req = create_or_get_object_id_request(
+            u32::try_from(input.len()).expect("request size fits in u32"),
+            u32_size(FILE_OBJECTID_BUFFER_SIZE),
+        );
+
+        assert_eq!(
+            validate_create_or_get_object_id_request(&req, &input),
+            Err(NtStatus::INVALID_PARAMETER)
+        );
+        assert_eq!(
+            validate_create_or_get_object_id_request(
+                &create_or_get_object_id_request(0, u32_size(FILE_OBJECTID_BUFFER_SIZE) - 1),
+                &[]
+            ),
+            Err(NtStatus::INVALID_PARAMETER)
+        );
+    }
+
+    #[test]
+    fn get_integrity_information_requires_an_empty_input_and_fixed_output_buffer() {
+        let input = [1];
+        let req = get_integrity_information_request(
+            u32::try_from(input.len()).expect("request size fits in u32"),
+            u32::try_from(INTEGRITY_INFORMATION_SIZE - 1).expect("response size fits in u32"),
+        );
+
+        assert_eq!(
+            validate_get_integrity_information_request(&req, &input),
+            Err(NtStatus::INVALID_PARAMETER)
+        );
+        assert_eq!(
+            validate_get_integrity_information_request(
+                &get_integrity_information_request(0, u32_size(INTEGRITY_INFORMATION_SIZE) - 1),
+                &[]
+            ),
+            Err(NtStatus::INVALID_PARAMETER)
+        );
+    }
+
+    #[test]
+    fn device_control_rejects_declared_input_length_mismatch() {
+        let req = get_compression_request(1, u32_size(COMPRESSION_FORMAT_SIZE));
+
+        assert_eq!(
+            validate_declared_input_length(&req, &[]),
+            Err(NtStatus::INVALID_PARAMETER)
+        );
+    }
+
+    #[test]
+    fn query_allocated_ranges_requires_an_exact_input_buffer() {
+        let req = query_allocated_ranges_request(
+            u32::try_from(FILE_ALLOCATED_RANGE_BUFFER_SIZE - 1).expect("request size fits in u32"),
+            u32::try_from(FILE_ALLOCATED_RANGE_BUFFER_SIZE).expect("response size fits in u32"),
+        );
+
+        assert_eq!(
+            validate_query_allocated_ranges_request(&req, &[0; FILE_ALLOCATED_RANGE_BUFFER_SIZE - 1]),
+            Err(NtStatus::INVALID_PARAMETER)
+        );
+    }
+
+    #[test]
+    fn query_allocated_ranges_rejects_invalid_ranges() {
+        let req = query_allocated_ranges_request(
+            u32::try_from(FILE_ALLOCATED_RANGE_BUFFER_SIZE).expect("request size fits in u32"),
+            u32::try_from(FILE_ALLOCATED_RANGE_BUFFER_SIZE).expect("response size fits in u32"),
+        );
+
+        for range in [allocated_range(-1, 1), allocated_range(i64::MAX, 1)] {
+            assert_eq!(
+                validate_query_allocated_ranges_request(&req, &range),
+                Err(NtStatus::INVALID_PARAMETER)
+            );
+        }
+    }
+
+    #[test]
+    fn query_allocated_ranges_accepts_an_empty_range() {
+        let range = allocated_range(0, 0);
+        let req = query_allocated_ranges_request(
+            u32::try_from(range.len()).expect("request size fits in u32"),
+            u32::try_from(FILE_ALLOCATED_RANGE_BUFFER_SIZE).expect("response size fits in u32"),
+        );
+
+        assert!(validate_query_allocated_ranges_request(&req, &range).is_ok());
+    }
+
+    #[test]
+    fn query_allocated_ranges_bounds_output_without_requiring_alignment() {
+        let input = allocated_range(0, 1);
+        let too_small = query_allocated_ranges_request(
+            u32::try_from(input.len()).expect("request size fits in u32"),
+            u32::try_from(FILE_ALLOCATED_RANGE_BUFFER_SIZE - 1).expect("response size fits in u32"),
+        );
+        assert_eq!(
+            validate_query_allocated_ranges_request(&too_small, &input),
+            Err(NtStatus::BUFFER_TOO_SMALL)
+        );
+
+        let unaligned = query_allocated_ranges_request(
+            u32::try_from(input.len()).expect("request size fits in u32"),
+            u32::try_from(FILE_ALLOCATED_RANGE_BUFFER_SIZE + 1).expect("response size fits in u32"),
+        );
+        assert!(validate_query_allocated_ranges_request(&unaligned, &input).is_ok());
+
+        let too_large = query_allocated_ranges_request(
+            u32::try_from(input.len()).expect("request size fits in u32"),
+            u32::try_from(MAX_DEVICE_CONTROL_OUTPUT_SIZE + FILE_ALLOCATED_RANGE_BUFFER_SIZE)
+                .expect("bounded output size fits in u32"),
+        );
+        assert_eq!(
+            validate_query_allocated_ranges_request(&too_large, &input),
+            Err(NtStatus::INVALID_PARAMETER)
+        );
+    }
+
+    #[test]
+    fn filesystem_controls_query_the_opened_file_handle() {
+        let temporary_path = std::env::temp_dir().join(format!(
+            "ironrdp-rdpdr-native-{}-{}.tmp",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock is after Unix epoch")
+                .as_nanos()
+        ));
+        std::fs::write(&temporary_path, b"compression query").expect("create temporary file");
+        let root_path = temporary_path
+            .ancestors()
+            .last()
+            .expect("temporary file has a volume root")
+            .to_owned();
+        let relative_path = temporary_path
+            .strip_prefix(&root_path)
+            .expect("temporary file is beneath its volume root");
+
+        {
+            let drive = RedirectedDrive::new(1, "Test", root_path.clone(), false).expect("valid redirected drive");
+            let mut backend = WindowsRdpdrBackend::from_active_drive(drive);
+            let (file_id, _) = super::super::file::create_inner(
+                &mut backend,
+                &DeviceCreateRequest {
+                    device_io_request: DeviceIoRequest {
+                        device_id: 1,
+                        file_id: 0,
+                        completion_id: 1,
+                        major_function: MajorFunction::Create,
+                        minor_function: MinorFunction::from(0),
+                    },
+                    desired_access: DesiredAccess::FILE_READ_DATA_OR_FILE_LIST_DIRECTORY
+                        | DesiredAccess::FILE_WRITE_ATTRIBUTES,
+                    allocation_size: 0,
+                    file_attributes: FileAttributes::empty(),
+                    shared_access: SharedAccess::empty(),
+                    create_disposition: CreateDisposition::FILE_OPEN,
+                    create_options: CreateOptions::empty(),
+                    path: format!(r"\{}", relative_path.display()),
+                },
+            )
+            .expect("open temporary file");
+            let mut req = get_compression_request(0, u32_size(COMPRESSION_FORMAT_SIZE));
+            req.header.file_id = file_id;
+
+            let format = handle_inner_with_input(&backend, &req, &[])
+                .expect("query compression format")
+                .output;
+            let format = u16::from_le_bytes(format.0.try_into().expect("compression format has two bytes"));
+            assert!(matches!(format, 0..=4));
+
+            let mut req = create_or_get_object_id_request(0, u32_size(FILE_OBJECTID_BUFFER_SIZE));
+            req.header.file_id = file_id;
+            let object_id = handle_inner_with_input(&backend, &req, &[])
+                .expect("create or query object ID through opened file")
+                .output;
+            assert_eq!(object_id.0.len(), FILE_OBJECTID_BUFFER_SIZE);
+
+            let range = allocated_range(0, 4_096);
+            let mut req = query_allocated_ranges_request(
+                u32::try_from(range.len()).expect("allocated range request size fits in u32"),
+                u32::try_from(FILE_ALLOCATED_RANGE_BUFFER_SIZE).expect("allocated range response size fits in u32"),
+            );
+            req.header.file_id = file_id;
+
+            let completion =
+                handle_inner_with_input(&backend, &req, &range).expect("query allocated ranges through opened file");
+            assert_eq!(completion.status, NtStatus::SUCCESS);
+            assert!(completion.output.0.len() <= FILE_ALLOCATED_RANGE_BUFFER_SIZE);
+            assert_eq!(completion.output.0.len() % FILE_ALLOCATED_RANGE_BUFFER_SIZE, 0);
+
+            let mut req = get_integrity_information_request(0, u32_size(INTEGRITY_INFORMATION_SIZE));
+            req.header.file_id = file_id;
+            match handle_inner_with_input(&backend, &req, &[]) {
+                Ok(completion) => {
+                    assert_eq!(completion.status, NtStatus::SUCCESS);
+                    assert_eq!(completion.output.0.len(), INTEGRITY_INFORMATION_SIZE);
+                }
+                Err(status) => assert_eq!(status, NtStatus::INVALID_DEVICE_REQUEST),
+            }
+        }
+
+        {
+            let drive = RedirectedDrive::new(1, "Test", root_path, true).expect("valid read-only redirected drive");
+            let mut backend = WindowsRdpdrBackend::from_active_drive(drive);
+            let (file_id, _) = super::super::file::create_inner(
+                &mut backend,
+                &DeviceCreateRequest {
+                    device_io_request: DeviceIoRequest {
+                        device_id: 1,
+                        file_id: 0,
+                        completion_id: 1,
+                        major_function: MajorFunction::Create,
+                        minor_function: MinorFunction::from(0),
+                    },
+                    desired_access: DesiredAccess::FILE_READ_DATA_OR_FILE_LIST_DIRECTORY,
+                    allocation_size: 0,
+                    file_attributes: FileAttributes::empty(),
+                    shared_access: SharedAccess::empty(),
+                    create_disposition: CreateDisposition::FILE_OPEN,
+                    create_options: CreateOptions::empty(),
+                    path: format!(r"\{}", relative_path.display()),
+                },
+            )
+            .expect("open temporary file on read-only redirected drive");
+            let mut req = create_or_get_object_id_request(0, u32_size(FILE_OBJECTID_BUFFER_SIZE));
+            req.header.file_id = file_id;
+
+            let status = handle_inner_with_input(&backend, &req, &[])
+                .expect_err("read-only redirected drive rejects object-ID creation");
+            assert_eq!(status, NtStatus::MEDIA_WRITE_PROTECTED);
+        }
+
+        std::fs::remove_file(temporary_path).expect("remove temporary file");
+    }
+}

--- a/crates/ironrdp-rdpdr-native/src/windows/directory.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/directory.rs
@@ -1,0 +1,680 @@
+//! Windows RDPDR directory enumeration on already-confined directory handles.
+
+use ironrdp_pdu::PduResult;
+use ironrdp_rdpdr::pdu::RdpdrPdu;
+use ironrdp_rdpdr::pdu::efs::{
+    ClientDriveNotifyChangeDirectoryResponse, ClientDriveQueryDirectoryResponse, DeviceIoResponse,
+    FileBothDirectoryInformation, FileDirectoryInformation, FileFullDirectoryInformation, FileInformationClass,
+    FileInformationClassLevel, FileNamesInformation, NtStatus, ServerDriveNotifyChangeDirectoryRequest,
+    ServerDriveQueryDirectoryRequest,
+};
+use ironrdp_svc::SvcMessage;
+use windows::Wdk::Storage::FileSystem::{
+    FileBothDirectoryInformation as NativeFileBothDirectoryInformation,
+    FileDirectoryInformation as NativeFileDirectoryInformation,
+    FileFullDirectoryInformation as NativeFileFullDirectoryInformation,
+    FileNamesInformation as NativeFileNamesInformation,
+};
+
+use super::backend::WindowsRdpdrBackend;
+use super::file::{file_for_request, file_for_request_mut};
+use super::handles::{DirectoryHandle, FileHandle};
+use super::path::RelativePath;
+use super::status::{from_ntstatus, from_open_directory, from_path_policy};
+
+const FILE_DIRECTORY_INFORMATION_NAME_OFFSET: usize = 64;
+const FILE_FULL_DIRECTORY_INFORMATION_NAME_OFFSET: usize = 68;
+const FILE_BOTH_DIRECTORY_INFORMATION_SHORT_NAME_OFFSET: usize = 70;
+const FILE_BOTH_DIRECTORY_INFORMATION_NAME_OFFSET: usize = 94;
+const FILE_NAMES_INFORMATION_NAME_OFFSET: usize = 12;
+const SHORT_NAME_SIZE: usize = 24;
+const FILE_NOTIFY_VALID_FILTERS: u32 = 0x0000_0fff;
+
+pub(crate) fn query_information(
+    backend: &mut WindowsRdpdrBackend,
+    req: ServerDriveQueryDirectoryRequest,
+) -> PduResult<Vec<SvcMessage>> {
+    let initial_query = req.initial_query != 0;
+    let (status, buffer) = match query_information_inner(backend, &req) {
+        Ok(buffer) => (NtStatus::SUCCESS, Some(buffer)),
+        Err(NtStatus::NO_MORE_FILES) if initial_query => (NtStatus::NO_SUCH_FILE, None),
+        Err(status) => (status, None),
+    };
+
+    Ok(vec![SvcMessage::from(RdpdrPdu::ClientDriveQueryDirectoryResponse(
+        ClientDriveQueryDirectoryResponse {
+            device_io_reply: DeviceIoResponse::new(req.device_io_request, status),
+            buffer,
+        },
+    ))])
+}
+
+pub(crate) fn notify_change(
+    backend: &mut WindowsRdpdrBackend,
+    req: ServerDriveNotifyChangeDirectoryRequest,
+) -> PduResult<Vec<SvcMessage>> {
+    let status = if req.completion_filter == 0 || req.completion_filter & !FILE_NOTIFY_VALID_FILTERS != 0 {
+        Err(NtStatus::INVALID_PARAMETER)
+    } else {
+        backend.schedule_directory_notification(req.clone())
+    };
+
+    match status {
+        Ok(()) => Ok(Vec::new()),
+        Err(status) => Ok(vec![SvcMessage::from(
+            RdpdrPdu::ClientDriveNotifyChangeDirectoryResponse(ClientDriveNotifyChangeDirectoryResponse::new(
+                req.device_io_request,
+                status,
+                Vec::new(),
+            )),
+        )]),
+    }
+}
+
+pub(super) fn query_information_inner(
+    backend: &mut WindowsRdpdrBackend,
+    req: &ServerDriveQueryDirectoryRequest,
+) -> Result<FileInformationClass, NtStatus> {
+    let initial_query = req.initial_query != 0;
+    let native_information_class = native_information_class(req.file_info_class_lvl.clone())?;
+    let pattern = if initial_query {
+        let query_path = query_path(&req.path)?;
+        let device_id =
+            file_for_request(backend, req.device_io_request.device_id, req.device_io_request.file_id)?.device_id;
+        let directory_handle = open_query_directory(backend, device_id, &query_path.directory)?;
+        let file = file_for_request_mut(backend, req.device_io_request.device_id, req.device_io_request.file_id)?;
+        file.directory_query_handle = directory_handle;
+        Some(query_path.pattern)
+    } else {
+        file_for_request(backend, req.device_io_request.device_id, req.device_io_request.file_id)?;
+        None
+    };
+    let file = file_for_request(backend, req.device_io_request.device_id, req.device_io_request.file_id)?;
+    let directory_handle = file.directory_query_handle.as_ref().unwrap_or(&file.handle);
+    let native_buffer = directory_handle
+        .query_directory_information(native_information_class, pattern.as_deref(), initial_query)
+        .map_err(from_ntstatus)?;
+
+    parse_information(req.file_info_class_lvl.clone(), &native_buffer)
+}
+
+fn native_information_class(
+    information_class: FileInformationClassLevel,
+) -> Result<windows::Wdk::Storage::FileSystem::FILE_INFORMATION_CLASS, NtStatus> {
+    match information_class {
+        FileInformationClassLevel::FILE_DIRECTORY_INFORMATION => Ok(NativeFileDirectoryInformation),
+        FileInformationClassLevel::FILE_FULL_DIRECTORY_INFORMATION => Ok(NativeFileFullDirectoryInformation),
+        FileInformationClassLevel::FILE_BOTH_DIRECTORY_INFORMATION => Ok(NativeFileBothDirectoryInformation),
+        FileInformationClassLevel::FILE_NAMES_INFORMATION => Ok(NativeFileNamesInformation),
+        _ => Err(NtStatus::NOT_SUPPORTED),
+    }
+}
+
+fn parse_information(
+    information_class: FileInformationClassLevel,
+    buffer: &[u8],
+) -> Result<FileInformationClass, NtStatus> {
+    match information_class {
+        FileInformationClassLevel::FILE_DIRECTORY_INFORMATION => Ok(FileDirectoryInformation {
+            next_entry_offset: 0,
+            file_index: read_u32(buffer, 4)?,
+            creation_time: read_i64(buffer, 8)?,
+            last_access_time: read_i64(buffer, 16)?,
+            last_write_time: read_i64(buffer, 24)?,
+            change_time: read_i64(buffer, 32)?,
+            end_of_file: read_i64(buffer, 40)?,
+            allocation_size: read_i64(buffer, 48)?,
+            file_attributes: read_file_attributes(buffer, 56)?,
+            file_name: read_file_name(buffer, FILE_DIRECTORY_INFORMATION_NAME_OFFSET, 60)?,
+        }
+        .into()),
+        FileInformationClassLevel::FILE_FULL_DIRECTORY_INFORMATION => Ok(FileFullDirectoryInformation {
+            next_entry_offset: 0,
+            file_index: read_u32(buffer, 4)?,
+            creation_time: read_i64(buffer, 8)?,
+            last_access_time: read_i64(buffer, 16)?,
+            last_write_time: read_i64(buffer, 24)?,
+            change_time: read_i64(buffer, 32)?,
+            end_of_file: read_i64(buffer, 40)?,
+            allocation_size: read_i64(buffer, 48)?,
+            file_attributes: read_file_attributes(buffer, 56)?,
+            ea_size: read_u32(buffer, 64)?,
+            file_name: read_file_name(buffer, FILE_FULL_DIRECTORY_INFORMATION_NAME_OFFSET, 60)?,
+        }
+        .into()),
+        FileInformationClassLevel::FILE_BOTH_DIRECTORY_INFORMATION => {
+            let short_name_length = read_u8(buffer, 68)?;
+            if usize::from(short_name_length) > SHORT_NAME_SIZE {
+                return Err(NtStatus::UNSUCCESSFUL);
+            }
+            let mut short_name = [0; SHORT_NAME_SIZE];
+            short_name.copy_from_slice(read_bytes(
+                buffer,
+                FILE_BOTH_DIRECTORY_INFORMATION_SHORT_NAME_OFFSET,
+                SHORT_NAME_SIZE,
+            )?);
+
+            Ok(FileBothDirectoryInformation {
+                next_entry_offset: 0,
+                file_index: read_u32(buffer, 4)?,
+                creation_time: read_i64(buffer, 8)?,
+                last_access_time: read_i64(buffer, 16)?,
+                last_write_time: read_i64(buffer, 24)?,
+                change_time: read_i64(buffer, 32)?,
+                end_of_file: read_i64(buffer, 40)?,
+                allocation_size: read_i64(buffer, 48)?,
+                file_attributes: read_file_attributes(buffer, 56)?,
+                ea_size: read_u32(buffer, 64)?,
+                short_name_length: i8::try_from(short_name_length).map_err(|_| NtStatus::UNSUCCESSFUL)?,
+                short_name,
+                file_name: read_file_name(buffer, FILE_BOTH_DIRECTORY_INFORMATION_NAME_OFFSET, 60)?,
+            }
+            .into())
+        }
+        FileInformationClassLevel::FILE_NAMES_INFORMATION => Ok(FileNamesInformation {
+            next_entry_offset: 0,
+            file_index: read_u32(buffer, 4)?,
+            file_name: read_file_name(buffer, FILE_NAMES_INFORMATION_NAME_OFFSET, 8)?,
+        }
+        .into()),
+        _ => Err(NtStatus::NOT_SUPPORTED),
+    }
+}
+
+struct DirectoryQueryPath {
+    directory: RelativePath,
+    pattern: Vec<u16>,
+}
+
+fn query_path(path: &str) -> Result<DirectoryQueryPath, NtStatus> {
+    if path.starts_with('/') || path.starts_with(r"\\") {
+        return Err(NtStatus::OBJECT_NAME_INVALID);
+    }
+
+    let path = path.strip_prefix('\\').unwrap_or(path);
+    let (directory, pattern) = if path.is_empty() {
+        ("", "*")
+    } else {
+        path.rsplit_once('\\')
+            .map_or(("", path), |(directory, pattern)| (directory, pattern))
+    };
+    let directory = RelativePath::parse(directory).map_err(from_path_policy)?;
+    if pattern.is_empty()
+        || matches!(pattern, "." | "..")
+        || pattern
+            .chars()
+            .any(|character| character <= '\u{1F}' || matches!(character, ':' | '/' | '"' | '<' | '>' | '|'))
+    {
+        return Err(NtStatus::OBJECT_NAME_INVALID);
+    }
+
+    let pattern = pattern.encode_utf16().collect::<Vec<_>>();
+    if pattern.len() > 255 {
+        return Err(NtStatus::OBJECT_NAME_INVALID);
+    }
+
+    Ok(DirectoryQueryPath { directory, pattern })
+}
+
+fn open_query_directory(
+    backend: &WindowsRdpdrBackend,
+    device_id: u32,
+    directory: &RelativePath,
+) -> Result<Option<FileHandle>, NtStatus> {
+    let root = backend.roots.get(&device_id).ok_or(NtStatus::INVALID_PARAMETER)?;
+    root.root
+        .open_relative_directory(directory)
+        .map_err(from_open_directory)
+        .map(|directory| directory.map(DirectoryHandle::into_file_handle))
+}
+
+fn read_file_attributes(buffer: &[u8], offset: usize) -> Result<ironrdp_rdpdr::pdu::efs::FileAttributes, NtStatus> {
+    Ok(ironrdp_rdpdr::pdu::efs::FileAttributes::from_bits_retain(read_u32(
+        buffer, offset,
+    )?))
+}
+
+fn read_file_name(buffer: &[u8], offset: usize, length_offset: usize) -> Result<String, NtStatus> {
+    let length = usize::try_from(read_u32(buffer, length_offset)?).map_err(|_| NtStatus::UNSUCCESSFUL)?;
+    if length % size_of::<u16>() != 0 {
+        return Err(NtStatus::UNSUCCESSFUL);
+    }
+
+    let bytes = read_bytes(buffer, offset, length)?;
+    let units = bytes
+        .chunks_exact(size_of::<u16>())
+        .map(|unit| u16::from_le_bytes([unit[0], unit[1]]))
+        .collect::<Vec<_>>();
+
+    String::from_utf16(&units).map_err(|_| NtStatus::UNSUCCESSFUL)
+}
+
+fn read_i64(buffer: &[u8], offset: usize) -> Result<i64, NtStatus> {
+    Ok(i64::from_le_bytes(read_array(buffer, offset)?))
+}
+
+fn read_u32(buffer: &[u8], offset: usize) -> Result<u32, NtStatus> {
+    Ok(u32::from_le_bytes(read_array(buffer, offset)?))
+}
+
+fn read_u8(buffer: &[u8], offset: usize) -> Result<u8, NtStatus> {
+    buffer.get(offset).copied().ok_or(NtStatus::UNSUCCESSFUL)
+}
+
+fn read_array<const N: usize>(buffer: &[u8], offset: usize) -> Result<[u8; N], NtStatus> {
+    read_bytes(buffer, offset, N)?
+        .try_into()
+        .map_err(|_| NtStatus::UNSUCCESSFUL)
+}
+
+fn read_bytes(buffer: &[u8], offset: usize, length: usize) -> Result<&[u8], NtStatus> {
+    let end = offset.checked_add(length).ok_or(NtStatus::UNSUCCESSFUL)?;
+    buffer.get(offset..end).ok_or(NtStatus::UNSUCCESSFUL)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::time::Duration;
+
+    use ironrdp_rdpdr::RdpdrBackend;
+    use ironrdp_rdpdr::pdu::efs::{
+        CreateDisposition, CreateOptions, DesiredAccess, DeviceCreateRequest, DeviceIoRequest, FileAttributes,
+        MajorFunction, MinorFunction, ServerDriveIoRequest, SharedAccess,
+    };
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use crate::windows::factory::RedirectedDrive;
+    use crate::windows::file::create_inner;
+
+    #[test]
+    fn parses_all_directory_information_classes() {
+        let name = "file.txt";
+        let name_bytes = name.encode_utf16().flat_map(u16::to_le_bytes).collect::<Vec<_>>();
+
+        for (information_class, name_offset) in [
+            (
+                FileInformationClassLevel::FILE_DIRECTORY_INFORMATION,
+                FILE_DIRECTORY_INFORMATION_NAME_OFFSET,
+            ),
+            (
+                FileInformationClassLevel::FILE_FULL_DIRECTORY_INFORMATION,
+                FILE_FULL_DIRECTORY_INFORMATION_NAME_OFFSET,
+            ),
+            (
+                FileInformationClassLevel::FILE_BOTH_DIRECTORY_INFORMATION,
+                FILE_BOTH_DIRECTORY_INFORMATION_NAME_OFFSET,
+            ),
+            (
+                FileInformationClassLevel::FILE_NAMES_INFORMATION,
+                FILE_NAMES_INFORMATION_NAME_OFFSET,
+            ),
+        ] {
+            let mut buffer = vec![0; name_offset + name_bytes.len()];
+            buffer[4..8].copy_from_slice(&7u32.to_le_bytes());
+            buffer[8..12].copy_from_slice(&(u32::try_from(name_bytes.len()).expect("name length fits")).to_le_bytes());
+
+            if information_class != FileInformationClassLevel::FILE_NAMES_INFORMATION {
+                buffer[56..60].copy_from_slice(&FileAttributes::FILE_ATTRIBUTE_ARCHIVE.bits().to_le_bytes());
+                buffer[60..64]
+                    .copy_from_slice(&(u32::try_from(name_bytes.len()).expect("name length fits")).to_le_bytes());
+            }
+            if information_class == FileInformationClassLevel::FILE_FULL_DIRECTORY_INFORMATION
+                || information_class == FileInformationClassLevel::FILE_BOTH_DIRECTORY_INFORMATION
+            {
+                buffer[64..68].copy_from_slice(&5u32.to_le_bytes());
+            }
+            if information_class == FileInformationClassLevel::FILE_BOTH_DIRECTORY_INFORMATION {
+                buffer[68] = 0;
+            }
+            buffer[name_offset..].copy_from_slice(&name_bytes);
+
+            let information = parse_information(information_class, &buffer).expect("valid native directory response");
+            assert_eq!(file_name(&information), name);
+        }
+    }
+
+    #[test]
+    fn query_paths_select_a_confined_directory_and_pattern() {
+        let wildcard = "*".encode_utf16().collect::<Vec<_>>();
+        let query = query_path(r"\*").expect("valid wildcard");
+        assert!(query.directory.components().next().is_none());
+        assert_eq!(query.pattern, wildcard);
+
+        let query = query_path("").expect("empty pattern defaults to wildcard");
+        assert!(query.directory.components().next().is_none());
+        assert_eq!(query.pattern, "*".encode_utf16().collect::<Vec<_>>());
+
+        let query = query_path(r"\folder\*").expect("directory-qualified wildcard");
+        assert_eq!(query.directory.components().collect::<Vec<_>>(), ["folder"]);
+        assert_eq!(query.pattern, "*".encode_utf16().collect::<Vec<_>>());
+        assert!(matches!(query_path(r"\..\*"), Err(NtStatus::OBJECT_NAME_INVALID)));
+        assert!(matches!(
+            query_path("outside/anything"),
+            Err(NtStatus::OBJECT_NAME_INVALID)
+        ));
+    }
+
+    #[test]
+    fn malformed_native_directory_entries_are_rejected() {
+        assert_eq!(
+            parse_information(FileInformationClassLevel::FILE_NAMES_INFORMATION, &[]),
+            Err(NtStatus::UNSUCCESSFUL)
+        );
+    }
+
+    #[test]
+    fn enumerates_an_opened_directory_for_every_supported_information_class() {
+        let temporary_directory = TemporaryDirectory::create();
+        std::fs::write(temporary_directory.0.join("example.txt"), b"content").expect("create directory entry");
+        let root_path = temporary_directory
+            .0
+            .ancestors()
+            .last()
+            .expect("temporary directory has a volume root")
+            .to_owned();
+        let relative_path = temporary_directory
+            .0
+            .strip_prefix(&root_path)
+            .expect("temporary directory is beneath its volume root");
+        let drive = RedirectedDrive::new(1, "Test", root_path, false).expect("valid redirected drive");
+        let mut backend = WindowsRdpdrBackend::from_active_drive(drive);
+        let (root_file_id, _) =
+            create_inner(&mut backend, &directory_create_request(r"\")).expect("open redirected root");
+        query_information_inner(
+            &mut backend,
+            &query_request(root_file_id, FileInformationClassLevel::FILE_NAMES_INFORMATION),
+        )
+        .expect("enumerate redirected root through an independent synchronous handle");
+
+        let path = format!(r"\{}", relative_path.display());
+        let (file_id, _) = create_inner(&mut backend, &directory_create_request(&path)).expect("open test directory");
+
+        for information_class in [
+            FileInformationClassLevel::FILE_DIRECTORY_INFORMATION,
+            FileInformationClassLevel::FILE_FULL_DIRECTORY_INFORMATION,
+            FileInformationClassLevel::FILE_BOTH_DIRECTORY_INFORMATION,
+            FileInformationClassLevel::FILE_NAMES_INFORMATION,
+        ] {
+            let mut request = query_request(file_id, information_class);
+            request.path = format!(r"\{}\*", relative_path.display());
+            let information = query_information_inner(&mut backend, &request).expect("enumerate opened directory");
+            assert!(!file_name(&information).is_empty());
+        }
+
+        let mut continuation_request = query_request(file_id, FileInformationClassLevel::FILE_NAMES_INFORMATION);
+        continuation_request.path = format!(r"\{}\*", relative_path.display());
+        continuation_request.initial_query = 0;
+        continuation_request.path = r"\ignored\by-continuation".to_owned();
+        let mut returned_entries = 0;
+        loop {
+            match query_information_inner(&mut backend, &continuation_request) {
+                Ok(_) => returned_entries += 1,
+                Err(NtStatus::NO_MORE_FILES) => break,
+                Err(status) => panic!("unexpected continuation status: {status:?}"),
+            }
+            assert!(returned_entries < 16, "bounded directory must reach its end");
+        }
+        assert!(returned_entries > 0);
+    }
+
+    #[test]
+    fn initial_query_enumerates_the_directory_named_by_path() {
+        let temporary_directory = TemporaryDirectory::create();
+        let target_directory = temporary_directory.0.join("query-target");
+        let target_file_name = "only-in-query-target.txt";
+        std::fs::create_dir(&target_directory).expect("create query target directory");
+        std::fs::write(target_directory.join(target_file_name), b"content").expect("create query target entry");
+
+        let root_path = temporary_directory
+            .0
+            .ancestors()
+            .last()
+            .expect("temporary directory has a volume root")
+            .to_owned();
+        let relative_target = target_directory
+            .strip_prefix(&root_path)
+            .expect("query target is below the redirected root");
+        let drive = RedirectedDrive::new(1, "Test", root_path, false).expect("valid redirected drive");
+        let mut backend = WindowsRdpdrBackend::from_active_drive(drive);
+        let (root_file_id, _) =
+            create_inner(&mut backend, &directory_create_request(r"\")).expect("open redirected root");
+        let mut request = query_request(root_file_id, FileInformationClassLevel::FILE_NAMES_INFORMATION);
+        request.path = format!(r"\{}\*", relative_target.display());
+
+        let mut found_target_entry = false;
+        for _ in 0..16 {
+            match query_information_inner(&mut backend, &request) {
+                Ok(information) => {
+                    if file_name(&information) == target_file_name {
+                        found_target_entry = true;
+                        break;
+                    }
+                    request.initial_query = 0;
+                }
+                Err(NtStatus::NO_MORE_FILES) => break,
+                Err(status) => panic!("unexpected directory query status: {status:?}"),
+            }
+        }
+
+        assert!(
+            found_target_entry,
+            "the initial query must enumerate its requested directory"
+        );
+    }
+
+    #[test]
+    fn backend_delivers_directory_change_completion() {
+        let (temporary_directory, mut backend, file_id) = backend_with_open_temporary_directory();
+        let request = directory_notification_request(file_id);
+
+        assert!(
+            RdpdrBackend::handle_drive_io_request(
+                &mut backend,
+                ServerDriveIoRequest::ServerDriveNotifyChangeDirectoryRequest(request),
+            )
+            .expect("schedule directory notification")
+            .is_empty()
+        );
+
+        let mut completion = None;
+        for index in 0..20 {
+            std::fs::write(temporary_directory.0.join(format!("change-{index}")), b"change")
+                .expect("create watched file");
+            for _ in 0..4 {
+                std::thread::sleep(Duration::from_millis(25));
+                let mut messages =
+                    RdpdrBackend::poll_deferred_messages(&mut backend).expect("poll directory notification");
+                if let Some(message) = messages.pop() {
+                    assert!(messages.is_empty(), "one watch has one completion");
+                    completion = Some(message);
+                    break;
+                }
+            }
+            if completion.is_some() {
+                break;
+            }
+        }
+
+        let response = completion
+            .expect("receive deferred directory notification")
+            .encode_unframed_pdu()
+            .expect("directory notification is encodable");
+        assert_eq!(
+            u32::from_le_bytes(response[12..16].try_into().expect("response status is present")),
+            u32::from(NtStatus::SUCCESS)
+        );
+        assert!(
+            u32::from_le_bytes(response[16..20].try_into().expect("buffer length is present")) >= 12,
+            "a directory notification contains FILE_NOTIFY_INFORMATION"
+        );
+        assert_eq!(
+            u32::from_le_bytes(response[24..28].try_into().expect("action is present")),
+            1,
+            "the created file produces FILE_ACTION_ADDED"
+        );
+    }
+
+    #[test]
+    fn nonzero_watch_tree_values_enable_subtree_notifications() {
+        let (_temporary_directory, mut backend, file_id) = backend_with_open_temporary_directory();
+        let mut request = directory_notification_request(file_id);
+        request.watch_tree = 2;
+
+        assert!(
+            RdpdrBackend::handle_drive_io_request(
+                &mut backend,
+                ServerDriveIoRequest::ServerDriveNotifyChangeDirectoryRequest(request),
+            )
+            .expect("schedule subtree directory notification")
+            .is_empty()
+        );
+
+        let messages = RdpdrBackend::remove_drive(&mut backend, 1).expect("remove watched drive");
+        assert_eq!(messages.len(), 1);
+    }
+
+    #[test]
+    fn removing_dynamic_drive_cancels_directory_watch() {
+        let (_temporary_directory, mut backend, file_id) = backend_with_open_temporary_directory();
+        let request = directory_notification_request(file_id);
+
+        assert!(
+            RdpdrBackend::handle_drive_io_request(
+                &mut backend,
+                ServerDriveIoRequest::ServerDriveNotifyChangeDirectoryRequest(request),
+            )
+            .expect("schedule directory notification")
+            .is_empty()
+        );
+
+        let messages = RdpdrBackend::remove_drive(&mut backend, 1).expect("remove active dynamic drive");
+        assert_eq!(messages.len(), 1);
+        let response = messages
+            .into_iter()
+            .next()
+            .expect("removed drive returns a cancellation completion")
+            .encode_unframed_pdu()
+            .expect("directory cancellation is encodable");
+        assert_eq!(
+            u32::from_le_bytes(response[12..16].try_into().expect("response status is present")),
+            u32::from(NtStatus::CANCELLED)
+        );
+        assert_eq!(
+            u32::from_le_bytes(response[16..20].try_into().expect("buffer length is present")),
+            0
+        );
+        assert!(
+            RdpdrBackend::poll_deferred_messages(&mut backend)
+                .expect("poll removed drive")
+                .is_empty()
+        );
+    }
+
+    fn backend_with_open_temporary_directory() -> (TemporaryDirectory, WindowsRdpdrBackend, u32) {
+        let temporary_directory = TemporaryDirectory::create();
+        let root_path = temporary_directory
+            .0
+            .ancestors()
+            .last()
+            .expect("temporary directory has a volume root")
+            .to_owned();
+        let relative_path = temporary_directory
+            .0
+            .strip_prefix(&root_path)
+            .expect("temporary directory is beneath its volume root");
+        let drive = RedirectedDrive::new(1, "Test", root_path, false).expect("valid redirected drive");
+        let mut backend = WindowsRdpdrBackend::from_active_drive(drive);
+        let (file_id, _) = create_inner(
+            &mut backend,
+            &directory_create_request(&format!(r"\{}", relative_path.display())),
+        )
+        .expect("open test directory");
+        (temporary_directory, backend, file_id)
+    }
+
+    fn directory_notification_request(file_id: u32) -> ServerDriveNotifyChangeDirectoryRequest {
+        ServerDriveNotifyChangeDirectoryRequest {
+            device_io_request: DeviceIoRequest {
+                device_id: 1,
+                file_id,
+                completion_id: 3,
+                major_function: MajorFunction::DirectoryControl,
+                minor_function: MinorFunction::IRP_MN_NOTIFY_CHANGE_DIRECTORY,
+            },
+            watch_tree: 0,
+            completion_filter: 1,
+        }
+    }
+
+    fn file_name(information: &FileInformationClass) -> &str {
+        match information {
+            FileInformationClass::BothDirectory(information) => &information.file_name,
+            FileInformationClass::FullDirectory(information) => &information.file_name,
+            FileInformationClass::Names(information) => &information.file_name,
+            FileInformationClass::Directory(information) => &information.file_name,
+            _ => panic!("expected a directory information class"),
+        }
+    }
+
+    fn directory_create_request(path: &str) -> DeviceCreateRequest {
+        DeviceCreateRequest {
+            device_io_request: DeviceIoRequest {
+                device_id: 1,
+                file_id: 0,
+                completion_id: 1,
+                major_function: MajorFunction::Create,
+                minor_function: MinorFunction::from(0),
+            },
+            desired_access: DesiredAccess::from_bits_retain(0x0010_0001),
+            allocation_size: 0,
+            file_attributes: FileAttributes::empty(),
+            shared_access: SharedAccess::FILE_SHARE_READ
+                | SharedAccess::FILE_SHARE_WRITE
+                | SharedAccess::FILE_SHARE_DELETE,
+            create_disposition: CreateDisposition::FILE_OPEN,
+            create_options: CreateOptions::from_bits_retain(0x0000_0021),
+            path: path.to_owned(),
+        }
+    }
+
+    fn query_request(file_id: u32, file_info_class_lvl: FileInformationClassLevel) -> ServerDriveQueryDirectoryRequest {
+        ServerDriveQueryDirectoryRequest {
+            device_io_request: DeviceIoRequest {
+                device_id: 1,
+                file_id,
+                completion_id: 2,
+                major_function: MajorFunction::DirectoryControl,
+                minor_function: MinorFunction::IRP_MN_QUERY_DIRECTORY,
+            },
+            file_info_class_lvl,
+            initial_query: 1,
+            path: r"\*".to_owned(),
+        }
+    }
+
+    struct TemporaryDirectory(PathBuf);
+
+    impl TemporaryDirectory {
+        fn create() -> Self {
+            let unique_name = format!(
+                "ironrdp-rdpdr-native-{}-{}",
+                std::process::id(),
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .expect("system clock is after Unix epoch")
+                    .as_nanos()
+            );
+            let path = std::env::temp_dir().join(unique_name);
+            std::fs::create_dir(&path).expect("create temporary directory");
+            Self(path)
+        }
+    }
+
+    impl Drop for TemporaryDirectory {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+}

--- a/crates/ironrdp-rdpdr-native/src/windows/file.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/file.rs
@@ -192,10 +192,10 @@ pub(super) fn create_inner(
     backend: &mut WindowsRdpdrBackend,
     req: &DeviceCreateRequest,
 ) -> Result<(u32, Information), NtStatus> {
-    let (read_only, root) = backend
+    let read_only = backend
         .roots
         .get(&req.device_io_request.device_id)
-        .map(|root| (root.read_only, &root.root))
+        .map(|root| root.read_only)
         .ok_or(NtStatus::INVALID_PARAMETER)?;
     let path = RelativePath::parse(&req.path).map_err(from_path_policy)?;
     let is_root = path.components().len() == 0;
@@ -237,27 +237,48 @@ pub(super) fn create_inner(
         create_options: (req.create_options.bits() & !FILE_OPEN_FOR_BACKUP_INTENT) | FILE_SYNCHRONOUS_IO_NONALERT,
     };
     let _security_privilege = security::enable_for_access_system_security(req.desired_access.bits())?;
-    let (handle, information) = root.open_relative_file(&path, options).map_err(|error| {
-        let status = from_open_file(error);
-        debug!(
-            device_id = req.device_io_request.device_id,
-            completion_id = req.device_io_request.completion_id,
-            ?status,
-            "Native filesystem create failed"
-        );
-        status
-    })?;
-    let information = create_information(information)?;
-    let file_id = backend
+    let reservation = backend
         .open_files
-        .insert(OpenFile {
+        .reserve_file_id()
+        .map_err(|_| NtStatus::UNSUCCESSFUL)?;
+    let open_result = match backend.roots.get(&req.device_io_request.device_id) {
+        Some(root) => root.root.open_relative_file(&path, options),
+        None => {
+            backend.open_files.release_file_id(reservation);
+            return Err(NtStatus::INVALID_PARAMETER);
+        }
+    };
+    let (handle, information) = match open_result {
+        Ok(result) => result,
+        Err(error) => {
+            backend.open_files.release_file_id(reservation);
+            let status = from_open_file(error);
+            debug!(
+                device_id = req.device_io_request.device_id,
+                completion_id = req.device_io_request.completion_id,
+                ?status,
+                "Native filesystem create failed"
+            );
+            return Err(status);
+        }
+    };
+    let information = match create_information(information) {
+        Ok(information) => information,
+        Err(status) => {
+            backend.open_files.release_file_id(reservation);
+            return Err(status);
+        }
+    };
+    let file_id = backend.open_files.insert_reserved(
+        reservation,
+        OpenFile {
             device_id: req.device_io_request.device_id,
             read_only,
             path,
             handle,
             directory_query_handle: None,
-        })
-        .map_err(|_| NtStatus::UNSUCCESSFUL)?;
+        },
+    );
 
     Ok((file_id, information))
 }

--- a/crates/ironrdp-rdpdr-native/src/windows/file.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/file.rs
@@ -720,7 +720,7 @@ mod tests {
     }
 
     #[test]
-    fn root_open_rejects_unapplicable_mutation_options() {
+    fn root_open_rejects_inapplicable_mutation_options() {
         let system_drive = std::env::var("SystemDrive").expect("SystemDrive is set on Windows");
         let drive =
             RedirectedDrive::new(1, "Test", format!(r"{system_drive}\"), false).expect("valid redirected drive");

--- a/crates/ironrdp-rdpdr-native/src/windows/file.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/file.rs
@@ -1,0 +1,1686 @@
+use ironrdp_pdu::{PduResult, encode_err};
+use ironrdp_rdpdr::pdu::RdpdrPdu;
+use ironrdp_rdpdr::pdu::efs::{
+    Boolean, ClientDriveQueryInformationResponse, ClientDriveSetInformationResponse, CreateDisposition,
+    DeviceCloseRequest, DeviceCloseResponse, DeviceCreateRequest, DeviceCreateResponse, DeviceFlushBuffersRequest,
+    DeviceFlushBuffersResponse, DeviceIoResponse, DeviceReadRequest, DeviceReadResponse, DeviceWriteRequest,
+    DeviceWriteResponse, FileAttributeTagInformation, FileAttributes, FileBasicInformation, FileInformationClass,
+    FileInformationClassLevel, FileStandardInformation, FileStreamInformation, Information, NtStatus,
+    ServerDriveQueryInformationRequest, ServerDriveSetInformationRequest,
+};
+use ironrdp_svc::SvcMessage;
+use tracing::debug;
+use windows::Wdk::Storage::FileSystem::FILE_BASIC_INFORMATION as NativeFileBasicInformation;
+
+use super::backend::{OpenFile, WindowsRdpdrBackend};
+use super::handles::{
+    FILE_CREATED_INFORMATION, FILE_OPEN_REPARSE_POINT, FILE_OPENED_INFORMATION, FILE_OVERWRITTEN_INFORMATION,
+    FILE_SUPERSEDED_INFORMATION, FileOpenOptions, RENAME_DESTINATION_DIRECTORY_ACCESS,
+};
+use super::path::RelativePath;
+use super::security;
+use super::status::{from_ntstatus, from_open_directory, from_open_file, from_path_policy};
+
+const SYNCHRONIZE: u32 = 0x0010_0000;
+const FILE_DIRECTORY_FILE: u32 = 0x0000_0001;
+const FILE_WRITE_THROUGH: u32 = 0x0000_0002;
+const FILE_SEQUENTIAL_ONLY: u32 = 0x0000_0004;
+const FILE_SYNCHRONOUS_IO_NONALERT: u32 = 0x0000_0020;
+const FILE_NON_DIRECTORY_FILE: u32 = 0x0000_0040;
+const FILE_RANDOM_ACCESS: u32 = 0x0000_0800;
+const FILE_DELETE_ON_CLOSE: u32 = 0x0000_1000;
+const FILE_OPEN_BY_FILE_ID: u32 = 0x0000_2000;
+const FILE_OPEN_FOR_BACKUP_INTENT: u32 = 0x0000_4000;
+const FILE_OPEN_NO_RECALL: u32 = 0x0040_0000;
+const FILE_OPEN_FOR_FREE_SPACE_QUERY: u32 = 0x0080_0000;
+const ALLOWED_CREATE_OPTIONS: u32 = FILE_DIRECTORY_FILE
+    | FILE_WRITE_THROUGH
+    | FILE_SEQUENTIAL_ONLY
+    | FILE_SYNCHRONOUS_IO_NONALERT
+    | FILE_NON_DIRECTORY_FILE
+    | FILE_RANDOM_ACCESS
+    | FILE_DELETE_ON_CLOSE
+    | FILE_OPEN_FOR_BACKUP_INTENT
+    | FILE_OPEN_REPARSE_POINT
+    // These hints affect local caching and capacity-query behavior only; they
+    // neither widen the requested access nor change path resolution.
+    | FILE_OPEN_NO_RECALL
+    | FILE_OPEN_FOR_FREE_SPACE_QUERY;
+
+const FILE_WRITE_DATA: u32 = 0x0000_0002;
+const FILE_APPEND_DATA: u32 = 0x0000_0004;
+const FILE_WRITE_EA: u32 = 0x0000_0010;
+const FILE_READ_ATTRIBUTES: u32 = 0x0000_0080;
+const FILE_WRITE_ATTRIBUTES: u32 = 0x0000_0100;
+const DELETE: u32 = 0x0001_0000;
+const WRITE_DAC: u32 = 0x0004_0000;
+const WRITE_OWNER: u32 = 0x0008_0000;
+const MAXIMUM_ALLOWED: u32 = 0x0200_0000;
+const GENERIC_ALL: u32 = 0x1000_0000;
+const GENERIC_WRITE: u32 = 0x4000_0000;
+const SECURITY_MUTATION_ACCESS: u32 = WRITE_DAC | WRITE_OWNER | security::ACCESS_SYSTEM_SECURITY;
+const READ_ONLY_MUTATION_ACCESS: u32 = FILE_WRITE_DATA
+    | FILE_APPEND_DATA
+    | FILE_WRITE_EA
+    | FILE_WRITE_ATTRIBUTES
+    | DELETE
+    | SECURITY_MUTATION_ACCESS
+    | MAXIMUM_ALLOWED
+    | GENERIC_ALL
+    | GENERIC_WRITE;
+const MAX_STATIC_IO_SIZE: usize = 1024 * 1024;
+
+pub(crate) fn create(backend: &mut WindowsRdpdrBackend, req: DeviceCreateRequest) -> PduResult<Vec<SvcMessage>> {
+    let response = match create_inner(backend, &req) {
+        Ok((file_id, information)) => DeviceCreateResponse {
+            device_io_reply: DeviceIoResponse::new(req.device_io_request, NtStatus::SUCCESS),
+            file_id,
+            information,
+        },
+        Err(status) => DeviceCreateResponse {
+            device_io_reply: DeviceIoResponse::new(req.device_io_request, status),
+            file_id: 0,
+            information: Information::empty(),
+        },
+    };
+
+    Ok(vec![SvcMessage::from(RdpdrPdu::DeviceCreateResponse(response))])
+}
+
+pub(crate) fn close(backend: &mut WindowsRdpdrBackend, req: DeviceCloseRequest) -> PduResult<Vec<SvcMessage>> {
+    let mut messages = Vec::new();
+    let status = if matches!(
+        backend.open_files.get(req.device_io_request.file_id),
+        Some(file) if file.device_id == req.device_io_request.device_id
+    ) {
+        backend
+            .open_files
+            .remove(req.device_io_request.file_id)
+            .expect("a file ID checked in the file table is still present");
+        messages.extend(
+            backend.cancel_deferred_file_operations(req.device_io_request.device_id, req.device_io_request.file_id),
+        );
+        NtStatus::SUCCESS
+    } else {
+        NtStatus::INVALID_HANDLE
+    };
+
+    messages.push(SvcMessage::from(RdpdrPdu::DeviceCloseResponse(DeviceCloseResponse {
+        device_io_response: DeviceIoResponse::new(req.device_io_request, status),
+    })));
+    Ok(messages)
+}
+
+pub(crate) fn flush(backend: &WindowsRdpdrBackend, req: DeviceFlushBuffersRequest) -> PduResult<Vec<SvcMessage>> {
+    let status = flush_inner(backend, &req).map_or_else(|status| status, |_| NtStatus::SUCCESS);
+    Ok(vec![SvcMessage::from(RdpdrPdu::DeviceFlushBuffersResponse(
+        DeviceFlushBuffersResponse {
+            device_io_response: DeviceIoResponse::new(req.device_io_request, status),
+        },
+    ))])
+}
+
+pub(crate) fn read(backend: &mut WindowsRdpdrBackend, req: DeviceReadRequest) -> PduResult<Vec<SvcMessage>> {
+    let (status, read_data) = match read_inner(backend, &req) {
+        Ok(read_data) => (NtStatus::SUCCESS, read_data),
+        Err(status) => (status, Vec::new()),
+    };
+
+    Ok(vec![SvcMessage::from(RdpdrPdu::DeviceReadResponse(
+        DeviceReadResponse {
+            device_io_reply: DeviceIoResponse::new(req.device_io_request, status),
+            read_data,
+        },
+    ))])
+}
+
+pub(crate) fn write(backend: &mut WindowsRdpdrBackend, req: DeviceWriteRequest) -> PduResult<Vec<SvcMessage>> {
+    let (status, length) = match write_inner(backend, &req) {
+        Ok(completion) => match u32::try_from(completion.transferred) {
+            Ok(length) => (completion_status(completion.status), length),
+            Err(_) => (NtStatus::UNSUCCESSFUL, 0),
+        },
+        Err(status) => (status, 0),
+    };
+
+    Ok(vec![SvcMessage::from(RdpdrPdu::DeviceWriteResponse(
+        DeviceWriteResponse {
+            device_io_reply: DeviceIoResponse::new(req.device_io_request, status),
+            length,
+        },
+    ))])
+}
+
+pub(crate) fn query_information(
+    backend: &mut WindowsRdpdrBackend,
+    req: ServerDriveQueryInformationRequest,
+) -> PduResult<Vec<SvcMessage>> {
+    let information_class = u32::from(req.file_info_class_lvl.clone());
+    let (status, buffer) = match query_information_inner_with_status(backend, &req) {
+        Ok((status, buffer)) => (status, Some(buffer)),
+        Err(status) => (status, None),
+    };
+    let response_length = buffer.as_ref().map_or(0, FileInformationClass::size);
+    debug!(
+        information_class,
+        ?status,
+        response_length,
+        "Completed filesystem query-information IRP"
+    );
+
+    Ok(vec![SvcMessage::from(RdpdrPdu::ClientDriveQueryInformationResponse(
+        ClientDriveQueryInformationResponse {
+            device_io_response: DeviceIoResponse::new(req.device_io_request, status),
+            buffer,
+        },
+    ))])
+}
+
+pub(crate) fn set_information(
+    backend: &mut WindowsRdpdrBackend,
+    req: ServerDriveSetInformationRequest,
+) -> PduResult<Vec<SvcMessage>> {
+    let status = set_information_inner(backend, &req).map_or_else(|status| status, |_| NtStatus::SUCCESS);
+    let response = ClientDriveSetInformationResponse::new(&req, status).map_err(|error| encode_err!(error))?;
+
+    Ok(vec![SvcMessage::from(RdpdrPdu::ClientDriveSetInformationResponse(
+        response,
+    ))])
+}
+
+pub(super) fn create_inner(
+    backend: &mut WindowsRdpdrBackend,
+    req: &DeviceCreateRequest,
+) -> Result<(u32, Information), NtStatus> {
+    let (read_only, root) = backend
+        .roots
+        .get(&req.device_io_request.device_id)
+        .map(|root| (root.read_only, &root.root))
+        .ok_or(NtStatus::INVALID_PARAMETER)?;
+    let path = RelativePath::parse(&req.path).map_err(from_path_policy)?;
+    let is_root = path.components().len() == 0;
+    validate_create_request(req, read_only, is_root)?;
+    let allocation_size = i64::try_from(req.allocation_size).map_err(|_| NtStatus::INVALID_PARAMETER)?;
+
+    if is_root {
+        if req.create_options.bits() & FILE_NON_DIRECTORY_FILE != 0 {
+            return Err(NtStatus::FILE_IS_A_DIRECTORY);
+        }
+        if !matches!(
+            u32::from(req.create_disposition),
+            x if x == u32::from(CreateDisposition::FILE_OPEN)
+                || x == u32::from(CreateDisposition::FILE_OPEN_IF)
+        ) {
+            return Err(NtStatus::OBJECT_NAME_COLLISION);
+        }
+        if req.create_options.bits() & FILE_DELETE_ON_CLOSE != 0 {
+            return Err(NtStatus::ACCESS_DENIED);
+        }
+        if req.allocation_size != 0 {
+            return Err(NtStatus::INVALID_PARAMETER);
+        }
+    }
+
+    // Explorer queries metadata immediately after directory listings and file
+    // opens, even when its CREATE request omitted FILE_READ_ATTRIBUTES. Match
+    // MSTSC's compatibility access without granting data, write, or security
+    // permissions the server did not request.
+    let desired_access = req.desired_access.bits() | SYNCHRONIZE | FILE_READ_ATTRIBUTES;
+    let options = FileOpenOptions {
+        desired_access,
+        allocation_size: (req.allocation_size != 0).then_some(allocation_size),
+        file_attributes: req.file_attributes.bits(),
+        share_access: req.shared_access.bits(),
+        create_disposition: u32::from(req.create_disposition),
+        // A remote server must not be able to use this hint to exercise the
+        // local process's backup or restore privileges during ACL evaluation.
+        create_options: (req.create_options.bits() & !FILE_OPEN_FOR_BACKUP_INTENT) | FILE_SYNCHRONOUS_IO_NONALERT,
+    };
+    let _security_privilege = security::enable_for_access_system_security(req.desired_access.bits())?;
+    let (handle, information) = root.open_relative_file(&path, options).map_err(|error| {
+        let status = from_open_file(error);
+        debug!(
+            device_id = req.device_io_request.device_id,
+            completion_id = req.device_io_request.completion_id,
+            ?status,
+            "Native filesystem create failed"
+        );
+        status
+    })?;
+    let information = create_information(information)?;
+    let file_id = backend
+        .open_files
+        .insert(OpenFile {
+            device_id: req.device_io_request.device_id,
+            read_only,
+            path,
+            handle,
+            directory_query_handle: None,
+        })
+        .map_err(|_| NtStatus::UNSUCCESSFUL)?;
+
+    Ok((file_id, information))
+}
+
+fn read_inner(backend: &WindowsRdpdrBackend, req: &DeviceReadRequest) -> Result<Vec<u8>, NtStatus> {
+    let length = usize::try_from(req.length).map_err(|_| NtStatus::INVALID_PARAMETER)?;
+    validate_io_length(length)?;
+    let offset = read_offset(req.offset)?;
+    let file = file_for_request(backend, req.device_io_request.device_id, req.device_io_request.file_id)?;
+
+    if length == 0 {
+        return Ok(Vec::new());
+    }
+
+    let mut read_data = vec![0; length];
+    let completion = file
+        .handle
+        .read_at(offset, &mut read_data)
+        .map_err(|_| NtStatus::INVALID_PARAMETER)?;
+    if completion.status.0 < 0 {
+        return Err(from_ntstatus(completion.status));
+    }
+
+    read_data.truncate(completion.transferred);
+    Ok(read_data)
+}
+
+fn write_inner(
+    backend: &WindowsRdpdrBackend,
+    req: &DeviceWriteRequest,
+) -> Result<super::handles::NativeIoCompletion, NtStatus> {
+    validate_io_length(req.write_data.len())?;
+    let offset = write_offset(req.offset)?;
+    let file = file_for_request(backend, req.device_io_request.device_id, req.device_io_request.file_id)?;
+    if file.read_only {
+        return Err(NtStatus::MEDIA_WRITE_PROTECTED);
+    }
+
+    if req.write_data.is_empty() {
+        return Ok(super::handles::NativeIoCompletion {
+            status: windows::Win32::Foundation::NTSTATUS(0),
+            transferred: 0,
+        });
+    }
+
+    match offset {
+        WriteOffset::Explicit(offset) => file.handle.write_at(offset, &req.write_data),
+        WriteOffset::Append => file.handle.write_to_end(&req.write_data),
+    }
+    .map_err(|_| NtStatus::INVALID_PARAMETER)
+}
+
+fn flush_inner(backend: &WindowsRdpdrBackend, req: &DeviceFlushBuffersRequest) -> Result<(), NtStatus> {
+    file_for_request(backend, req.device_io_request.device_id, req.device_io_request.file_id)?
+        .handle
+        .flush()
+        .map_err(from_ntstatus)
+}
+
+#[cfg(test)]
+fn query_information_inner(
+    backend: &WindowsRdpdrBackend,
+    req: &ServerDriveQueryInformationRequest,
+) -> Result<FileInformationClass, NtStatus> {
+    query_information_inner_with_status(backend, req).map(|(_, information)| information)
+}
+
+fn query_information_inner_with_status(
+    backend: &WindowsRdpdrBackend,
+    req: &ServerDriveQueryInformationRequest,
+) -> Result<(NtStatus, FileInformationClass), NtStatus> {
+    let file = file_for_request(backend, req.device_io_request.device_id, req.device_io_request.file_id)?;
+
+    match req.file_info_class_lvl {
+        FileInformationClassLevel::FILE_BASIC_INFORMATION => {
+            let information = file.handle.query_basic_information().map_err(from_ntstatus)?;
+            Ok((
+                NtStatus::SUCCESS,
+                FileBasicInformation {
+                    creation_time: information.CreationTime,
+                    last_access_time: information.LastAccessTime,
+                    last_write_time: information.LastWriteTime,
+                    change_time: information.ChangeTime,
+                    file_attributes: FileAttributes::from_bits_retain(information.FileAttributes),
+                }
+                .into(),
+            ))
+        }
+        FileInformationClassLevel::FILE_STANDARD_INFORMATION => {
+            let information = file.handle.query_standard_information().map_err(from_ntstatus)?;
+            Ok((
+                NtStatus::SUCCESS,
+                FileStandardInformation {
+                    allocation_size: information.AllocationSize,
+                    end_of_file: information.EndOfFile,
+                    number_of_links: information.NumberOfLinks,
+                    delete_pending: Boolean::from(u8::from(information.DeletePending)),
+                    directory: Boolean::from(u8::from(information.Directory)),
+                }
+                .into(),
+            ))
+        }
+        FileInformationClassLevel::FILE_ATTRIBUTE_TAG_INFORMATION => {
+            let information = file.handle.query_attribute_tag_information().map_err(from_ntstatus)?;
+            Ok((
+                NtStatus::SUCCESS,
+                FileAttributeTagInformation {
+                    file_attributes: FileAttributes::from_bits_retain(information.FileAttributes),
+                    reparse_tag: information.ReparseTag,
+                }
+                .into(),
+            ))
+        }
+        FileInformationClassLevel::FILE_STREAM_INFORMATION => {
+            let completion = file.handle.query_stream_information().map_err(from_ntstatus)?;
+            Ok((
+                from_ntstatus(completion.status),
+                FileStreamInformation::from_buffer(completion.output).into(),
+            ))
+        }
+        _ => Err(NtStatus::NOT_SUPPORTED),
+    }
+}
+
+fn set_information_inner(
+    backend: &mut WindowsRdpdrBackend,
+    req: &ServerDriveSetInformationRequest,
+) -> Result<(), NtStatus> {
+    let file = file_for_request(backend, req.device_io_request.device_id, req.device_io_request.file_id)?;
+    if file.read_only {
+        return Err(NtStatus::MEDIA_WRITE_PROTECTED);
+    }
+
+    match &req.set_buffer {
+        FileInformationClass::EndOfFile(information) => {
+            if information.end_of_file < 0 {
+                return Err(NtStatus::INVALID_PARAMETER);
+            }
+            file.handle
+                .set_end_of_file(information.end_of_file)
+                .map_err(from_ntstatus)
+        }
+        FileInformationClass::Allocation(information) => {
+            if information.allocation_size < 0 {
+                return Err(NtStatus::INVALID_PARAMETER);
+            }
+            file.handle
+                .set_allocation_size(information.allocation_size)
+                .map_err(from_ntstatus)
+        }
+        FileInformationClass::Basic(information) => {
+            if [
+                information.creation_time,
+                information.last_access_time,
+                information.last_write_time,
+                information.change_time,
+            ]
+            .into_iter()
+            .any(|time| time < -2)
+            {
+                return Err(NtStatus::INVALID_PARAMETER);
+            }
+
+            file.handle
+                .set_basic_information(NativeFileBasicInformation {
+                    CreationTime: information.creation_time,
+                    LastAccessTime: information.last_access_time,
+                    LastWriteTime: information.last_write_time,
+                    ChangeTime: information.change_time,
+                    FileAttributes: information.file_attributes.bits(),
+                })
+                .map_err(from_ntstatus)
+        }
+        FileInformationClass::Disposition(information) => {
+            let delete_pending = match information.delete_pending {
+                0 => false,
+                1 => true,
+                _ => return Err(NtStatus::INVALID_PARAMETER),
+            };
+            file.handle.set_delete_pending(delete_pending).map_err(from_ntstatus)
+        }
+        FileInformationClass::Rename(information) => {
+            let destination_path = RelativePath::parse(&information.file_name).map_err(from_path_policy)?;
+            let file_name = destination_path
+                .components()
+                .next_back()
+                .ok_or(NtStatus::OBJECT_NAME_INVALID)?;
+            let root = backend.roots.get(&file.device_id).ok_or(NtStatus::INVALID_PARAMETER)?;
+            let parent_directory = root
+                .root
+                .open_relative_parent_directory(&destination_path, RENAME_DESTINATION_DIRECTORY_ACCESS)
+                .map_err(from_open_directory)?;
+
+            file.handle
+                .rename(
+                    parent_directory.as_raw(),
+                    file_name,
+                    information.replace_if_exists == Boolean::True,
+                )
+                .map_err(from_ntstatus)?;
+            file_for_request_mut(backend, req.device_io_request.device_id, req.device_io_request.file_id)?.path =
+                destination_path;
+            Ok(())
+        }
+        _ => Err(NtStatus::NOT_SUPPORTED),
+    }
+}
+
+fn validate_create_request(req: &DeviceCreateRequest, read_only: bool, is_root: bool) -> Result<(), NtStatus> {
+    let desired_access = req.desired_access.bits();
+    let create_options = req.create_options.bits();
+    let disposition = u32::from(req.create_disposition);
+    let delete_on_close = create_options & FILE_DELETE_ON_CLOSE != 0;
+
+    if i64::try_from(req.allocation_size).is_err() {
+        return Err(NtStatus::INVALID_PARAMETER);
+    }
+    if delete_on_close && desired_access & DELETE == 0 {
+        return Err(NtStatus::INVALID_PARAMETER);
+    }
+    if create_options & FILE_OPEN_BY_FILE_ID != 0 || create_options & !ALLOWED_CREATE_OPTIONS != 0 {
+        return Err(NtStatus::NOT_SUPPORTED);
+    }
+    if create_options & FILE_DIRECTORY_FILE != 0 && create_options & FILE_NON_DIRECTORY_FILE != 0 {
+        return Err(NtStatus::INVALID_PARAMETER);
+    }
+    if !matches!(
+        disposition,
+        x if x == u32::from(CreateDisposition::FILE_SUPERSEDE)
+            || x == u32::from(CreateDisposition::FILE_OPEN)
+            || x == u32::from(CreateDisposition::FILE_CREATE)
+            || x == u32::from(CreateDisposition::FILE_OPEN_IF)
+            || x == u32::from(CreateDisposition::FILE_OVERWRITE)
+            || x == u32::from(CreateDisposition::FILE_OVERWRITE_IF)
+    ) {
+        return Err(NtStatus::INVALID_PARAMETER);
+    }
+    if create_options & FILE_DIRECTORY_FILE != 0
+        && !matches!(
+            disposition,
+            x if x == u32::from(CreateDisposition::FILE_OPEN)
+                || x == u32::from(CreateDisposition::FILE_CREATE)
+                || x == u32::from(CreateDisposition::FILE_OPEN_IF)
+        )
+    {
+        return Err(NtStatus::INVALID_PARAMETER);
+    }
+
+    let mutating_disposition = matches!(
+        disposition,
+        x if x == u32::from(CreateDisposition::FILE_SUPERSEDE)
+            || x == u32::from(CreateDisposition::FILE_CREATE)
+            || (x == u32::from(CreateDisposition::FILE_OPEN_IF) && !is_root)
+            || x == u32::from(CreateDisposition::FILE_OVERWRITE)
+            || x == u32::from(CreateDisposition::FILE_OVERWRITE_IF)
+    );
+    if read_only && (desired_access & READ_ONLY_MUTATION_ACCESS != 0 || mutating_disposition || delete_on_close) {
+        return Err(NtStatus::MEDIA_WRITE_PROTECTED);
+    }
+
+    Ok(())
+}
+
+fn validate_io_length(length: usize) -> Result<(), NtStatus> {
+    if length > MAX_STATIC_IO_SIZE {
+        return Err(NtStatus::INVALID_PARAMETER);
+    }
+
+    Ok(())
+}
+
+fn read_offset(offset: u64) -> Result<i64, NtStatus> {
+    i64::try_from(offset).map_err(|_| NtStatus::INVALID_PARAMETER)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum WriteOffset {
+    Explicit(i64),
+    Append,
+}
+
+fn write_offset(offset: u64) -> Result<WriteOffset, NtStatus> {
+    // MS-RDPEFS 2.2.1.4.4 reserves the all-ones append sentinel for clients
+    // that announce minor version 0x000D or later.
+    if offset == u64::MAX {
+        return Ok(WriteOffset::Append);
+    }
+
+    i64::try_from(offset)
+        .map(WriteOffset::Explicit)
+        .map_err(|_| NtStatus::INVALID_PARAMETER)
+}
+
+pub(super) fn file_for_request(
+    backend: &WindowsRdpdrBackend,
+    device_id: u32,
+    file_id: u32,
+) -> Result<&OpenFile, NtStatus> {
+    match backend.open_files.get(file_id) {
+        Some(file) if file.device_id == device_id => Ok(file),
+        _ => Err(NtStatus::INVALID_HANDLE),
+    }
+}
+
+pub(super) fn file_for_request_mut(
+    backend: &mut WindowsRdpdrBackend,
+    device_id: u32,
+    file_id: u32,
+) -> Result<&mut OpenFile, NtStatus> {
+    match backend.open_files.get_mut(file_id) {
+        Some(file) if file.device_id == device_id => Ok(file),
+        _ => Err(NtStatus::INVALID_HANDLE),
+    }
+}
+
+fn completion_status(status: windows::Win32::Foundation::NTSTATUS) -> NtStatus {
+    if status.0 < 0 {
+        from_ntstatus(status)
+    } else {
+        NtStatus::SUCCESS
+    }
+}
+
+fn create_information(information: usize) -> Result<Information, NtStatus> {
+    match information {
+        FILE_SUPERSEDED_INFORMATION => Ok(Information::file_superseded()),
+        FILE_OPENED_INFORMATION => Ok(Information::file_opened()),
+        FILE_CREATED_INFORMATION => Ok(Information::file_created()),
+        FILE_OVERWRITTEN_INFORMATION => Ok(Information::file_overwritten()),
+        _ => Err(NtStatus::UNSUCCESSFUL),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironrdp_rdpdr::pdu::efs::{
+        CreateOptions, DesiredAccess, DeviceIoRequest, FileAllocationInformation, FileDispositionInformation,
+        FileEndOfFileInformation, FileRenameInformation, FileSystemInformationClass, FileSystemInformationClassLevel,
+        MajorFunction, MinorFunction, ServerDriveQueryVolumeInformationRequest, SharedAccess,
+    };
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use crate::windows::factory::RedirectedDrive;
+    use crate::windows::volume::query_information_inner as query_volume_information_inner;
+
+    #[test]
+    fn create_information_matches_nt_create_file_results() {
+        assert_eq!(
+            create_information(FILE_SUPERSEDED_INFORMATION),
+            Ok(Information::file_superseded())
+        );
+        assert_eq!(
+            create_information(FILE_OPENED_INFORMATION),
+            Ok(Information::file_opened())
+        );
+        assert_eq!(
+            create_information(FILE_CREATED_INFORMATION),
+            Ok(Information::file_created())
+        );
+        assert_eq!(
+            create_information(FILE_OVERWRITTEN_INFORMATION),
+            Ok(Information::file_overwritten())
+        );
+    }
+
+    #[test]
+    fn read_only_drives_reject_mutating_create_requests() {
+        let request = create_request(FILE_WRITE_DATA, CreateDisposition::FILE_OPEN, 0, r"\example.txt");
+
+        assert_eq!(
+            validate_create_request(&request, true, false),
+            Err(NtStatus::MEDIA_WRITE_PROTECTED)
+        );
+    }
+
+    #[test]
+    fn create_requests_allow_security_descriptor_access() {
+        let request = create_request(WRITE_DAC, CreateDisposition::FILE_OPEN, 0, r"\example.txt");
+
+        assert_eq!(validate_create_request(&request, false, false), Ok(()));
+    }
+
+    #[test]
+    fn create_requests_allow_backup_intent() {
+        let request = create_request(
+            FILE_WRITE_DATA,
+            CreateDisposition::FILE_OPEN_IF,
+            FILE_OPEN_FOR_BACKUP_INTENT,
+            r"\example.txt",
+        );
+
+        assert_eq!(validate_create_request(&request, false, false), Ok(()));
+    }
+
+    #[test]
+    fn create_requests_allow_non_mutating_cache_and_capacity_hints() {
+        for option in [FILE_OPEN_NO_RECALL, FILE_OPEN_FOR_FREE_SPACE_QUERY] {
+            let request = create_request(
+                FILE_READ_ATTRIBUTES,
+                CreateDisposition::FILE_OPEN,
+                option,
+                r"\example.txt",
+            );
+
+            assert_eq!(validate_create_request(&request, false, false), Ok(()));
+        }
+    }
+
+    #[test]
+    fn backup_intent_does_not_change_the_native_open_access_check() {
+        let temporary_directory = TemporaryDirectory::new();
+        let root_path = temporary_directory
+            .0
+            .ancestors()
+            .last()
+            .expect("temporary directory has a volume root")
+            .to_owned();
+        let relative_path = temporary_directory
+            .0
+            .strip_prefix(&root_path)
+            .expect("temporary directory is beneath its volume root");
+        let drive = RedirectedDrive::new(1, "Test", root_path, false).expect("valid redirected drive");
+        let mut backend = WindowsRdpdrBackend::from_active_drive(drive);
+        let request = create_request(
+            0x0010_0001,
+            CreateDisposition::FILE_OPEN,
+            FILE_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_NONALERT | FILE_OPEN_FOR_BACKUP_INTENT,
+            &format!(r"\{}", relative_path.display()),
+        );
+
+        assert!(create_inner(&mut backend, &request).is_ok());
+    }
+
+    #[test]
+    fn delete_on_close_requires_delete_access() {
+        let request = create_request(
+            FILE_WRITE_DATA,
+            CreateDisposition::FILE_OPEN,
+            FILE_DELETE_ON_CLOSE,
+            r"\example.txt",
+        );
+
+        assert_eq!(
+            validate_create_request(&request, false, false),
+            Err(NtStatus::INVALID_PARAMETER)
+        );
+        assert_eq!(
+            validate_create_request(&request, true, false),
+            Err(NtStatus::INVALID_PARAMETER)
+        );
+
+        let mut request = create_request(FILE_WRITE_DATA, CreateDisposition::FILE_OPEN, 0, r"\example.txt");
+        request.allocation_size = u64::MAX;
+        assert_eq!(
+            validate_create_request(&request, false, false),
+            Err(NtStatus::INVALID_PARAMETER)
+        );
+    }
+
+    #[test]
+    fn root_open_rejects_unapplicable_mutation_options() {
+        let system_drive = std::env::var("SystemDrive").expect("SystemDrive is set on Windows");
+        let drive =
+            RedirectedDrive::new(1, "Test", format!(r"{system_drive}\"), false).expect("valid redirected drive");
+        let mut backend = WindowsRdpdrBackend::from_active_drive(drive);
+
+        let delete_request = create_request(DELETE, CreateDisposition::FILE_OPEN, FILE_DELETE_ON_CLOSE, r"\");
+        assert_eq!(
+            create_inner(&mut backend, &delete_request),
+            Err(NtStatus::ACCESS_DENIED)
+        );
+
+        let mut allocation_request = create_request(0x0000_0001, CreateDisposition::FILE_OPEN, 0, r"\");
+        allocation_request.allocation_size = 1;
+        assert_eq!(
+            create_inner(&mut backend, &allocation_request),
+            Err(NtStatus::INVALID_PARAMETER)
+        );
+    }
+
+    #[test]
+    fn root_open_if_opens_the_existing_volume_root() {
+        let system_drive = std::env::var("SystemDrive").expect("SystemDrive is set on Windows");
+        let drive = RedirectedDrive::new(1, "Test", format!(r"{system_drive}\"), true).expect("valid redirected drive");
+        let mut backend = WindowsRdpdrBackend::from_active_drive(drive);
+        let request = create_request(
+            FILE_READ_ATTRIBUTES,
+            CreateDisposition::FILE_OPEN_IF,
+            FILE_DIRECTORY_FILE,
+            r"\",
+        );
+
+        assert_eq!(
+            create_inner(&mut backend, &request),
+            Ok((1, Information::file_opened()))
+        );
+    }
+
+    #[test]
+    fn directory_open_allows_metadata_queries_after_an_explorer_directory_list_request() {
+        let temporary_directory = TemporaryDirectory::new();
+        let root_path = temporary_directory
+            .0
+            .ancestors()
+            .last()
+            .expect("temporary directory has a volume root")
+            .to_owned();
+        let relative_path = temporary_directory
+            .0
+            .strip_prefix(&root_path)
+            .expect("temporary directory is beneath its volume root");
+        let drive = RedirectedDrive::new(1, "Test", root_path, false).expect("valid redirected drive");
+        let mut backend = WindowsRdpdrBackend::from_active_drive(drive);
+        let mut request = create_request(
+            0x0010_0001,
+            CreateDisposition::FILE_OPEN,
+            FILE_DIRECTORY_FILE,
+            &format!(r"\{}", relative_path.display()),
+        );
+        request.shared_access = SharedAccess::from_bits_retain(0x0000_0007);
+
+        let (file_id, _) = create_inner(&mut backend, &request).expect("open directory for listing");
+        let watcher_handle = backend
+            .open_directory_for_notification(1, file_id)
+            .expect("reopen an independent directory watcher handle");
+        let open_handle = backend
+            .open_files
+            .get(file_id)
+            .expect("open directory remains in the file table")
+            .handle
+            .as_raw();
+
+        assert_ne!(watcher_handle.as_raw(), open_handle);
+
+        query_information_inner(
+            &backend,
+            &query_request(file_id, FileInformationClassLevel::FILE_BASIC_INFORMATION),
+        )
+        .expect("query directory metadata without an explicit read-attributes request");
+    }
+
+    #[test]
+    fn file_open_allows_metadata_queries_after_an_explorer_file_open_request() {
+        let temporary_file = TemporaryFile::create();
+        let root_path = temporary_file
+            .0
+            .ancestors()
+            .last()
+            .expect("temporary file has a volume root")
+            .to_owned();
+        let relative_path = temporary_file
+            .0
+            .strip_prefix(&root_path)
+            .expect("temporary file is beneath its volume root");
+        let drive = RedirectedDrive::new(1, "Test", root_path, false).expect("valid redirected drive");
+        let mut backend = WindowsRdpdrBackend::from_active_drive(drive);
+        let request = create_request(
+            SYNCHRONIZE,
+            CreateDisposition::FILE_OPEN,
+            0,
+            &format!(r"\{}", relative_path.display()),
+        );
+
+        let (file_id, _) = create_inner(&mut backend, &request).expect("open file");
+
+        query_information_inner(
+            &backend,
+            &query_request(file_id, FileInformationClassLevel::FILE_BASIC_INFORMATION),
+        )
+        .expect("query file metadata without an explicit read-attributes request");
+    }
+
+    #[test]
+    fn file_open_with_reparse_point_option_allows_an_ordinary_file() {
+        let temporary_file = TemporaryFile::create();
+        let root_path = temporary_file
+            .0
+            .ancestors()
+            .last()
+            .expect("temporary file has a volume root")
+            .to_owned();
+        let relative_path = temporary_file
+            .0
+            .strip_prefix(&root_path)
+            .expect("temporary file is beneath its volume root");
+        let drive = RedirectedDrive::new(1, "Test", root_path, false).expect("valid redirected drive");
+        let mut backend = WindowsRdpdrBackend::from_active_drive(drive);
+
+        create_inner(
+            &mut backend,
+            &create_request(
+                FILE_READ_ATTRIBUTES,
+                CreateDisposition::FILE_OPEN,
+                FILE_OPEN_REPARSE_POINT,
+                &format!(r"\{}", relative_path.display()),
+            ),
+        )
+        .expect("open ordinary file with reparse-point option");
+    }
+
+    #[test]
+    fn read_response_preserves_requested_non_eof_length() {
+        let temporary_file = TemporaryFile::new();
+        let expected_data = vec![0x5A; MAX_STATIC_IO_SIZE];
+        std::fs::write(&temporary_file.0, &expected_data).expect("write temporary file");
+        let root_path = temporary_file
+            .0
+            .ancestors()
+            .last()
+            .expect("temporary file has a volume root")
+            .to_owned();
+        let relative_path = temporary_file
+            .0
+            .strip_prefix(&root_path)
+            .expect("temporary file is beneath its volume root");
+        let drive = RedirectedDrive::new(1, "Test", root_path, false).expect("valid redirected drive");
+        let mut backend = WindowsRdpdrBackend::from_active_drive(drive);
+        let (file_id, _) = create_inner(
+            &mut backend,
+            &create_request(
+                0x0010_0081,
+                CreateDisposition::FILE_OPEN,
+                0,
+                &format!(r"\{}", relative_path.display()),
+            ),
+        )
+        .expect("open temporary file");
+        let response = read(
+            &mut backend,
+            DeviceReadRequest {
+                device_io_request: DeviceIoRequest {
+                    device_id: 1,
+                    file_id,
+                    completion_id: 1,
+                    major_function: MajorFunction::Read,
+                    minor_function: MinorFunction::from(0),
+                },
+                length: u32::try_from(MAX_STATIC_IO_SIZE).expect("maximum I/O size fits in u32"),
+                offset: 0,
+            },
+        )
+        .expect("read temporary file")
+        .into_iter()
+        .next()
+        .expect("read produces one completion")
+        .encode_unframed_pdu()
+        .expect("read completion is encodable");
+
+        assert_eq!(response.len(), expected_data.len() + 20);
+        assert_eq!(&response[20..], expected_data);
+    }
+
+    #[test]
+    fn read_response_honors_large_offset() {
+        let temporary_file = TemporaryFile::new();
+        let mut file_data = vec![0; MAX_STATIC_IO_SIZE * 9];
+        for (block, data) in file_data.chunks_exact_mut(MAX_STATIC_IO_SIZE).enumerate() {
+            data.fill(u8::try_from(block).expect("test block fits in u8"));
+        }
+        std::fs::write(&temporary_file.0, file_data).expect("write temporary file");
+        let root_path = temporary_file
+            .0
+            .ancestors()
+            .last()
+            .expect("temporary file has a volume root")
+            .to_owned();
+        let relative_path = temporary_file
+            .0
+            .strip_prefix(&root_path)
+            .expect("temporary file is beneath its volume root");
+        let drive = RedirectedDrive::new(1, "Test", root_path, false).expect("valid redirected drive");
+        let mut backend = WindowsRdpdrBackend::from_active_drive(drive);
+        let (file_id, _) = create_inner(
+            &mut backend,
+            &create_request(
+                0x0010_0081,
+                CreateDisposition::FILE_OPEN,
+                0,
+                &format!(r"\{}", relative_path.display()),
+            ),
+        )
+        .expect("open temporary file");
+        let response = read(
+            &mut backend,
+            DeviceReadRequest {
+                device_io_request: DeviceIoRequest {
+                    device_id: 1,
+                    file_id,
+                    completion_id: 1,
+                    major_function: MajorFunction::Read,
+                    minor_function: MinorFunction::from(0),
+                },
+                length: u32::try_from(MAX_STATIC_IO_SIZE).expect("maximum I/O size fits in u32"),
+                offset: u64::try_from(MAX_STATIC_IO_SIZE * 7).expect("test offset fits in u64"),
+            },
+        )
+        .expect("read temporary file")
+        .into_iter()
+        .next()
+        .expect("read produces one completion")
+        .encode_unframed_pdu()
+        .expect("read completion is encodable");
+
+        assert_eq!(response.len(), MAX_STATIC_IO_SIZE + 20);
+        assert_eq!(&response[20..], vec![7; MAX_STATIC_IO_SIZE]);
+    }
+
+    #[test]
+    fn create_applies_allocation_size_and_deletes_on_close() {
+        let temporary_file = TemporaryFile::new();
+        let root_path = temporary_file
+            .0
+            .ancestors()
+            .last()
+            .expect("temporary file has a volume root")
+            .to_owned();
+        let relative_path = temporary_file
+            .0
+            .strip_prefix(&root_path)
+            .expect("temporary file is beneath its volume root");
+        let drive = RedirectedDrive::new(1, "Test", root_path, false).expect("valid redirected drive");
+        let mut backend = WindowsRdpdrBackend::from_active_drive(drive);
+        let mut request = create_request(
+            FILE_WRITE_DATA | FILE_READ_ATTRIBUTES | DELETE,
+            CreateDisposition::FILE_CREATE,
+            FILE_DELETE_ON_CLOSE,
+            &format!(r"\{}", relative_path.display()),
+        );
+        request.allocation_size = 4_096;
+
+        let (file_id, information) = create_inner(&mut backend, &request).expect("create temporary file");
+        assert_eq!(information, Information::file_created());
+        let FileInformationClass::Standard(standard_information) = query_information_inner(
+            &backend,
+            &query_request(file_id, FileInformationClassLevel::FILE_STANDARD_INFORMATION),
+        )
+        .expect("query created file information") else {
+            panic!("standard query must return FileStandardInformation");
+        };
+        assert!(standard_information.allocation_size >= 4_096);
+
+        close(
+            &mut backend,
+            DeviceCloseRequest {
+                device_io_request: DeviceIoRequest {
+                    device_id: 1,
+                    file_id,
+                    completion_id: 1,
+                    major_function: MajorFunction::Close,
+                    minor_function: MinorFunction::from(0),
+                },
+            },
+        )
+        .expect("close delete-on-close file");
+        assert!(!temporary_file.0.exists());
+    }
+
+    #[test]
+    fn static_file_operations_use_explicit_and_append_offsets_with_handle_bound_information_queries() {
+        let mut temporary_file = TemporaryFile::create();
+        let root_path = temporary_file
+            .0
+            .ancestors()
+            .last()
+            .expect("temporary file has a volume root")
+            .to_owned();
+        let relative_path = temporary_file
+            .0
+            .strip_prefix(&root_path)
+            .expect("temporary file is beneath its volume root");
+        let drive = RedirectedDrive::new(1, "Test", root_path.clone(), false).expect("valid redirected drive");
+        let mut backend = WindowsRdpdrBackend::from_active_drive(drive);
+        let path = format!(r"\{}", relative_path.display());
+        let request = create_request(0x0001_0183, CreateDisposition::FILE_OPEN, 0, &path);
+        let (file_id, _) = create_inner(&mut backend, &request).expect("open temporary file");
+        let write_request = DeviceWriteRequest {
+            device_io_request: DeviceIoRequest {
+                device_id: 1,
+                file_id,
+                completion_id: 2,
+                major_function: MajorFunction::Write,
+                minor_function: MinorFunction::from(0),
+            },
+            offset: 1,
+            write_data: b"X".to_vec(),
+        };
+
+        let write = write_inner(&backend, &write_request).expect("write through opaque handle");
+        assert_eq!(completion_status(write.status), NtStatus::SUCCESS);
+        assert_eq!(write.transferred, 1);
+
+        let append_request = DeviceWriteRequest {
+            device_io_request: DeviceIoRequest {
+                device_id: 1,
+                file_id,
+                completion_id: 3,
+                major_function: MajorFunction::Write,
+                minor_function: MinorFunction::from(0),
+            },
+            offset: u64::MAX,
+            write_data: b"!".to_vec(),
+        };
+        let append = write_inner(&backend, &append_request).expect("append through opaque handle");
+        assert_eq!(completion_status(append.status), NtStatus::SUCCESS);
+        assert_eq!(append.transferred, 1);
+
+        let flush_response = flush(
+            &backend,
+            DeviceFlushBuffersRequest {
+                device_io_request: DeviceIoRequest {
+                    device_id: 1,
+                    file_id,
+                    completion_id: 3,
+                    major_function: MajorFunction::FlushBuffers,
+                    minor_function: MinorFunction::from(0),
+                },
+            },
+        )
+        .expect("flush through opaque handle")
+        .into_iter()
+        .next()
+        .expect("flush produces one completion")
+        .encode_unframed_pdu()
+        .expect("flush completion is encodable");
+        assert_eq!(flush_response.len(), 16);
+        assert_eq!(
+            u32::from_le_bytes(flush_response[12..16].try_into().expect("response status is present")),
+            u32::from(NtStatus::SUCCESS)
+        );
+
+        let read_request = DeviceReadRequest {
+            device_io_request: DeviceIoRequest {
+                device_id: 1,
+                file_id,
+                completion_id: 4,
+                major_function: MajorFunction::Read,
+                minor_function: MinorFunction::from(0),
+            },
+            length: 6,
+            offset: 0,
+        };
+        assert_eq!(
+            read_inner(&backend, &read_request).expect("read through opaque handle"),
+            b"hXllo!"
+        );
+        assert!(matches!(
+            file_for_request(&backend, 2, file_id),
+            Err(NtStatus::INVALID_HANDLE)
+        ));
+
+        let basic_information = query_information_inner(
+            &backend,
+            &query_request(file_id, FileInformationClassLevel::FILE_BASIC_INFORMATION),
+        )
+        .expect("query basic information");
+        let FileInformationClass::Basic(basic_information) = basic_information else {
+            panic!("basic query must return FileBasicInformation");
+        };
+        assert!(
+            !basic_information
+                .file_attributes
+                .contains(FileAttributes::FILE_ATTRIBUTE_DIRECTORY)
+        );
+
+        let standard_information = query_information_inner(
+            &backend,
+            &query_request(file_id, FileInformationClassLevel::FILE_STANDARD_INFORMATION),
+        )
+        .expect("query standard information");
+        let FileInformationClass::Standard(standard_information) = standard_information else {
+            panic!("standard query must return FileStandardInformation");
+        };
+        assert_eq!(standard_information.end_of_file, 6);
+        assert!(standard_information.allocation_size >= standard_information.end_of_file);
+        assert_eq!(standard_information.directory, Boolean::False);
+
+        let attribute_tag_information = query_information_inner(
+            &backend,
+            &query_request(file_id, FileInformationClassLevel::FILE_ATTRIBUTE_TAG_INFORMATION),
+        )
+        .expect("query attribute tag information");
+        let FileInformationClass::AttributeTag(attribute_tag_information) = attribute_tag_information else {
+            panic!("attribute tag query must return FileAttributeTagInformation");
+        };
+        assert_eq!(attribute_tag_information.reparse_tag, 0);
+
+        let volume_information = query_volume_information_inner(
+            &backend,
+            &query_volume_request(file_id, FileSystemInformationClassLevel::FILE_FS_VOLUME_INFORMATION),
+        )
+        .expect("query volume information");
+        let FileSystemInformationClass::FileFsVolumeInformation(volume_information) = volume_information else {
+            panic!("volume query must return FileFsVolumeInformation");
+        };
+        assert!(!volume_information.volume_label.contains('\0'));
+
+        let size_information = query_volume_information_inner(
+            &backend,
+            &query_volume_request(file_id, FileSystemInformationClassLevel::FILE_FS_SIZE_INFORMATION),
+        )
+        .expect("query volume size information");
+        let FileSystemInformationClass::FileFsSizeInformation(size_information) = size_information else {
+            panic!("size query must return FileFsSizeInformation");
+        };
+        assert!(size_information.total_alloc_units >= size_information.available_alloc_units);
+        assert_ne!(size_information.sectors_per_alloc_unit, 0);
+        assert_ne!(size_information.bytes_per_sector, 0);
+
+        let attribute_information = query_volume_information_inner(
+            &backend,
+            &query_volume_request(file_id, FileSystemInformationClassLevel::FILE_FS_ATTRIBUTE_INFORMATION),
+        )
+        .expect("query volume attribute information");
+        let FileSystemInformationClass::FileFsAttributeInformation(attribute_information) = attribute_information
+        else {
+            panic!("attribute query must return FileFsAttributeInformation");
+        };
+        assert_ne!(attribute_information.max_component_name_len, 0);
+        assert!(!attribute_information.file_system_name.is_empty());
+
+        let full_size_information = query_volume_information_inner(
+            &backend,
+            &query_volume_request(file_id, FileSystemInformationClassLevel::FILE_FS_FULL_SIZE_INFORMATION),
+        )
+        .expect("query full volume size information");
+        let FileSystemInformationClass::FileFsFullSizeInformation(full_size_information) = full_size_information else {
+            panic!("full size query must return FileFsFullSizeInformation");
+        };
+        assert!(full_size_information.total_alloc_units >= full_size_information.caller_available_alloc_units);
+        assert_ne!(full_size_information.sectors_per_alloc_unit, 0);
+        assert_ne!(full_size_information.bytes_per_sector, 0);
+
+        let device_information = query_volume_information_inner(
+            &backend,
+            &query_volume_request(file_id, FileSystemInformationClassLevel::FILE_FS_DEVICE_INFORMATION),
+        );
+        assert_eq!(device_information, Err(NtStatus::INVALID_DEVICE_REQUEST));
+
+        set_information_inner(
+            &mut backend,
+            &set_request(
+                file_id,
+                FileInformationClass::EndOfFile(FileEndOfFileInformation { end_of_file: 1 }),
+            ),
+        )
+        .expect("set end of file");
+        let standard_information = query_information_inner(
+            &backend,
+            &query_request(file_id, FileInformationClassLevel::FILE_STANDARD_INFORMATION),
+        )
+        .expect("query standard information after truncation");
+        let FileInformationClass::Standard(standard_information) = standard_information else {
+            panic!("standard query must return FileStandardInformation");
+        };
+        assert_eq!(standard_information.end_of_file, 1);
+
+        set_information_inner(
+            &mut backend,
+            &set_request(
+                file_id,
+                FileInformationClass::Allocation(FileAllocationInformation { allocation_size: 4_096 }),
+            ),
+        )
+        .expect("set allocation size");
+        let standard_information = query_information_inner(
+            &backend,
+            &query_request(file_id, FileInformationClassLevel::FILE_STANDARD_INFORMATION),
+        )
+        .expect("query standard information after allocation");
+        let FileInformationClass::Standard(standard_information) = standard_information else {
+            panic!("standard query must return FileStandardInformation");
+        };
+        assert!(standard_information.allocation_size >= 4_096);
+
+        set_information_inner(
+            &mut backend,
+            &set_request(
+                file_id,
+                FileInformationClass::Basic(FileBasicInformation {
+                    creation_time: 0,
+                    last_access_time: 0,
+                    last_write_time: 0,
+                    change_time: 0,
+                    file_attributes: FileAttributes::FILE_ATTRIBUTE_HIDDEN,
+                }),
+            ),
+        )
+        .expect("set basic file information");
+        let basic_information = query_information_inner(
+            &backend,
+            &query_request(file_id, FileInformationClassLevel::FILE_BASIC_INFORMATION),
+        )
+        .expect("query basic information after attribute update");
+        let FileInformationClass::Basic(basic_information) = basic_information else {
+            panic!("basic query must return FileBasicInformation");
+        };
+        assert!(
+            basic_information
+                .file_attributes
+                .contains(FileAttributes::FILE_ATTRIBUTE_HIDDEN)
+        );
+
+        assert_eq!(
+            set_information_inner(
+                &mut backend,
+                &set_request(
+                    file_id,
+                    FileInformationClass::Basic(FileBasicInformation {
+                        creation_time: -3,
+                        last_access_time: 0,
+                        last_write_time: 0,
+                        change_time: 0,
+                        file_attributes: FileAttributes::empty(),
+                    }),
+                ),
+            ),
+            Err(NtStatus::INVALID_PARAMETER)
+        );
+
+        let renamed_path = temporary_file.0.with_file_name("z");
+        let renamed_relative_path = renamed_path
+            .strip_prefix(&root_path)
+            .expect("renamed temporary file is beneath its volume root");
+        set_information_inner(
+            &mut backend,
+            &set_request(
+                file_id,
+                FileInformationClass::Rename(FileRenameInformation {
+                    replace_if_exists: Boolean::False,
+                    file_name: format!(r"\{}", renamed_relative_path.display()),
+                }),
+            ),
+        )
+        .expect("rename through a reparse-safe destination parent");
+        assert!(!temporary_file.0.exists());
+        assert!(renamed_path.exists());
+        temporary_file.0 = renamed_path;
+
+        set_information_inner(
+            &mut backend,
+            &set_request(
+                file_id,
+                FileInformationClass::Disposition(FileDispositionInformation { delete_pending: 1 }),
+            ),
+        )
+        .expect("mark temporary file for deletion");
+        let standard_information = query_information_inner(
+            &backend,
+            &query_request(file_id, FileInformationClassLevel::FILE_STANDARD_INFORMATION),
+        )
+        .expect("query standard information after marking for deletion");
+        let FileInformationClass::Standard(standard_information) = standard_information else {
+            panic!("standard query must return FileStandardInformation");
+        };
+        assert_eq!(standard_information.delete_pending, Boolean::True);
+
+        let _ = close(
+            &mut backend,
+            DeviceCloseRequest {
+                device_io_request: DeviceIoRequest {
+                    device_id: 1,
+                    file_id,
+                    completion_id: 7,
+                    major_function: MajorFunction::Close,
+                    minor_function: MinorFunction::from(0),
+                },
+            },
+        )
+        .expect("close deleted temporary file");
+        assert!(!temporary_file.0.exists());
+    }
+
+    #[test]
+    fn static_file_operations_open_alternate_data_streams() {
+        let temporary_file = TemporaryFile::create();
+        let root_path = temporary_file
+            .0
+            .ancestors()
+            .last()
+            .expect("temporary file has a volume root")
+            .to_owned();
+        let relative_path = temporary_file
+            .0
+            .strip_prefix(&root_path)
+            .expect("temporary file is beneath its volume root");
+        let drive = RedirectedDrive::new(1, "Test", root_path, false).expect("valid redirected drive");
+        let mut backend = WindowsRdpdrBackend::from_active_drive(drive);
+        let stream_name = "ironrdp-rdpdr";
+        let request = create_request(
+            FILE_WRITE_DATA,
+            CreateDisposition::FILE_OPEN_IF,
+            0,
+            &format!(r"\{}:{}", relative_path.display(), stream_name),
+        );
+        let (file_id, _) = create_inner(&mut backend, &request).expect("open alternate data stream");
+
+        let write_request = DeviceWriteRequest {
+            device_io_request: DeviceIoRequest {
+                device_id: 1,
+                file_id,
+                completion_id: 2,
+                major_function: MajorFunction::Write,
+                minor_function: MinorFunction::from(0),
+            },
+            offset: 0,
+            write_data: b"stream".to_vec(),
+        };
+        assert_eq!(
+            write_inner(&backend, &write_request)
+                .expect("write alternate data stream")
+                .transferred,
+            6
+        );
+        close(
+            &mut backend,
+            DeviceCloseRequest {
+                device_io_request: DeviceIoRequest {
+                    device_id: 1,
+                    file_id,
+                    completion_id: 3,
+                    major_function: MajorFunction::Close,
+                    minor_function: MinorFunction::from(0),
+                },
+            },
+        )
+        .expect("close alternate data stream");
+
+        assert_eq!(
+            std::fs::read(format!("{}:{}", temporary_file.0.display(), stream_name))
+                .expect("read alternate data stream"),
+            b"stream"
+        );
+
+        let base_request = create_request(
+            FILE_READ_ATTRIBUTES,
+            CreateDisposition::FILE_OPEN,
+            0,
+            &format!(r"\{}", relative_path.display()),
+        );
+        let (base_file_id, _) = create_inner(&mut backend, &base_request).expect("open base file for stream query");
+        let FileInformationClass::Stream(stream_information) = query_information_inner(
+            &backend,
+            &query_request(base_file_id, FileInformationClassLevel::FILE_STREAM_INFORMATION),
+        )
+        .expect("query file streams") else {
+            panic!("stream query must return FileStreamInformation");
+        };
+        let mut encoded = vec![0; stream_information.size()];
+        stream_information
+            .encode(&mut ironrdp_core::WriteCursor::new(&mut encoded))
+            .expect("encode stream information");
+        let expected_stream_name = format!(":{stream_name}:$DATA")
+            .encode_utf16()
+            .flat_map(u16::to_le_bytes)
+            .collect::<Vec<_>>();
+        assert!(
+            encoded
+                .windows(expected_stream_name.len())
+                .any(|window| window == expected_stream_name),
+            "stream query must enumerate the named alternate data stream"
+        );
+    }
+
+    #[test]
+    fn rename_supports_directories_and_replace_if_exists() {
+        let temporary_directory = TemporaryDirectory::new();
+        let source_directory = temporary_directory.0.join("source-directory");
+        let renamed_directory = temporary_directory.0.join("renamed-directory");
+        std::fs::create_dir(&source_directory).expect("create source directory");
+
+        let root_path = temporary_directory
+            .0
+            .ancestors()
+            .last()
+            .expect("temporary directory has a volume root")
+            .to_owned();
+        let source_relative_path = source_directory
+            .strip_prefix(&root_path)
+            .expect("source directory is beneath its volume root");
+        let renamed_relative_path = renamed_directory
+            .strip_prefix(&root_path)
+            .expect("renamed directory is beneath its volume root");
+        let drive = RedirectedDrive::new(1, "Test", root_path.clone(), false).expect("valid redirected drive");
+        let mut backend = WindowsRdpdrBackend::from_active_drive(drive);
+        let request = create_request(
+            DELETE | FILE_READ_ATTRIBUTES,
+            CreateDisposition::FILE_OPEN,
+            FILE_DIRECTORY_FILE,
+            &format!(r"\{}", source_relative_path.display()),
+        );
+        let (directory_file_id, _) = create_inner(&mut backend, &request).expect("open source directory");
+
+        set_information_inner(
+            &mut backend,
+            &set_request(
+                directory_file_id,
+                FileInformationClass::Rename(FileRenameInformation {
+                    replace_if_exists: Boolean::False,
+                    file_name: format!(r"\{}", renamed_relative_path.display()),
+                }),
+            ),
+        )
+        .expect("rename directory through a reparse-safe destination parent");
+        assert!(!source_directory.exists());
+        assert!(renamed_directory.is_dir());
+        assert_eq!(
+            file_for_request(&backend, 1, directory_file_id)
+                .expect("renamed directory remains open")
+                .path,
+            RelativePath::parse(&format!(r"\{}", renamed_relative_path.display()))
+                .expect("renamed directory has a valid redirected path")
+        );
+        close(
+            &mut backend,
+            DeviceCloseRequest {
+                device_io_request: DeviceIoRequest {
+                    device_id: 1,
+                    file_id: directory_file_id,
+                    completion_id: 8,
+                    major_function: MajorFunction::Close,
+                    minor_function: MinorFunction::from(0),
+                },
+            },
+        )
+        .expect("close renamed directory");
+
+        let source_file = temporary_directory.0.join("source-file");
+        let destination_parent = temporary_directory.0.join("destination-parent");
+        let destination_file = destination_parent.join("destination-file");
+        std::fs::create_dir(&destination_parent).expect("create destination parent directory");
+        std::fs::write(&source_file, b"source").expect("create source file");
+        std::fs::write(&destination_file, b"destination").expect("create destination file");
+        let source_relative_path = source_file
+            .strip_prefix(&root_path)
+            .expect("source file is beneath its volume root");
+        let destination_relative_path = destination_file
+            .strip_prefix(&root_path)
+            .expect("destination file is beneath its volume root");
+        let request = create_request(
+            DELETE | FILE_READ_ATTRIBUTES,
+            CreateDisposition::FILE_OPEN,
+            0,
+            &format!(r"\{}", source_relative_path.display()),
+        );
+        let (file_id, _) = create_inner(&mut backend, &request).expect("open source file");
+
+        assert_eq!(
+            set_information_inner(
+                &mut backend,
+                &set_request(
+                    file_id,
+                    FileInformationClass::Rename(FileRenameInformation {
+                        replace_if_exists: Boolean::False,
+                        file_name: format!(r"\{}", destination_relative_path.display()),
+                    }),
+                ),
+            ),
+            Err(NtStatus::OBJECT_NAME_COLLISION)
+        );
+        assert!(source_file.is_file());
+        assert_eq!(
+            std::fs::read(&destination_file).expect("read destination file"),
+            b"destination"
+        );
+
+        set_information_inner(
+            &mut backend,
+            &set_request(
+                file_id,
+                FileInformationClass::Rename(FileRenameInformation {
+                    replace_if_exists: Boolean::True,
+                    file_name: format!(r"\{}", destination_relative_path.display()),
+                }),
+            ),
+        )
+        .expect("replace destination file during rename");
+        assert!(!source_file.exists());
+        close(
+            &mut backend,
+            DeviceCloseRequest {
+                device_io_request: DeviceIoRequest {
+                    device_id: 1,
+                    file_id,
+                    completion_id: 9,
+                    major_function: MajorFunction::Close,
+                    minor_function: MinorFunction::from(0),
+                },
+            },
+        )
+        .expect("close renamed file");
+        assert_eq!(
+            std::fs::read(&destination_file).expect("read replaced destination file"),
+            b"source"
+        );
+    }
+
+    #[test]
+    fn static_io_rejects_oversized_or_invalid_offsets() {
+        assert_eq!(
+            validate_io_length(MAX_STATIC_IO_SIZE + 1),
+            Err(NtStatus::INVALID_PARAMETER)
+        );
+        assert_eq!(read_offset(u64::MAX), Err(NtStatus::INVALID_PARAMETER));
+        assert!(matches!(write_offset(u64::MAX), Ok(WriteOffset::Append)));
+        assert_eq!(write_offset(1), Ok(WriteOffset::Explicit(1)));
+    }
+
+    fn create_request(
+        desired_access: u32,
+        create_disposition: CreateDisposition,
+        create_options: u32,
+        path: &str,
+    ) -> DeviceCreateRequest {
+        DeviceCreateRequest {
+            device_io_request: DeviceIoRequest {
+                device_id: 1,
+                file_id: 0,
+                completion_id: 1,
+                major_function: MajorFunction::Create,
+                minor_function: MinorFunction::from(0),
+            },
+            desired_access: DesiredAccess::from_bits_retain(desired_access),
+            allocation_size: 0,
+            file_attributes: FileAttributes::empty(),
+            shared_access: SharedAccess::empty(),
+            create_disposition,
+            create_options: CreateOptions::from_bits_retain(create_options),
+            path: path.to_owned(),
+        }
+    }
+
+    fn query_request(
+        file_id: u32,
+        file_info_class_lvl: FileInformationClassLevel,
+    ) -> ServerDriveQueryInformationRequest {
+        ServerDriveQueryInformationRequest {
+            device_io_request: DeviceIoRequest {
+                device_id: 1,
+                file_id,
+                completion_id: 4,
+                major_function: MajorFunction::QueryInformation,
+                minor_function: MinorFunction::from(0),
+            },
+            file_info_class_lvl,
+        }
+    }
+
+    fn query_volume_request(
+        file_id: u32,
+        fs_info_class_lvl: FileSystemInformationClassLevel,
+    ) -> ServerDriveQueryVolumeInformationRequest {
+        ServerDriveQueryVolumeInformationRequest {
+            device_io_request: DeviceIoRequest {
+                device_id: 1,
+                file_id,
+                completion_id: 5,
+                major_function: MajorFunction::QueryVolumeInformation,
+                minor_function: MinorFunction::from(0),
+            },
+            fs_info_class_lvl,
+        }
+    }
+
+    fn set_request(file_id: u32, set_buffer: FileInformationClass) -> ServerDriveSetInformationRequest {
+        ServerDriveSetInformationRequest {
+            device_io_request: DeviceIoRequest {
+                device_id: 1,
+                file_id,
+                completion_id: 6,
+                major_function: MajorFunction::SetInformation,
+                minor_function: MinorFunction::from(0),
+            },
+            set_buffer,
+        }
+    }
+
+    struct TemporaryFile(PathBuf);
+
+    impl TemporaryFile {
+        fn create() -> Self {
+            let path = Self::new_path();
+            std::fs::write(&path, b"hello").expect("create temporary file");
+            Self(path)
+        }
+
+        fn new() -> Self {
+            Self(Self::new_path())
+        }
+
+        fn new_path() -> PathBuf {
+            let unique_name = format!(
+                "ironrdp-rdpdr-native-{}-{}.tmp",
+                std::process::id(),
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .expect("system clock is after Unix epoch")
+                    .as_nanos()
+            );
+            std::env::temp_dir().join(unique_name)
+        }
+    }
+
+    impl Drop for TemporaryFile {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.0);
+        }
+    }
+
+    struct TemporaryDirectory(PathBuf);
+
+    impl TemporaryDirectory {
+        fn new() -> Self {
+            let path = TemporaryFile::new_path();
+            std::fs::create_dir(&path).expect("create temporary directory");
+            Self(path)
+        }
+    }
+
+    impl Drop for TemporaryDirectory {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+}

--- a/crates/ironrdp-rdpdr-native/src/windows/file_table.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/file_table.rs
@@ -9,17 +9,6 @@ pub(crate) struct FileTable<T> {
     available_ids: Vec<u32>,
     next_id: Option<u32>,
     max_entries: usize,
-    active_ids: usize,
-}
-
-/// An opaque file ID reserved before opening a native handle.
-#[derive(Debug)]
-pub(crate) struct FileIdReservation(u32);
-
-impl FileIdReservation {
-    pub(crate) fn file_id(&self) -> u32 {
-        self.0
-    }
 }
 
 impl<T> FileTable<T> {
@@ -29,12 +18,11 @@ impl<T> FileTable<T> {
             available_ids: Vec::new(),
             next_id: Some(1),
             max_entries,
-            active_ids: 0,
         }
     }
 
-    pub(crate) fn reserve_file_id(&mut self) -> Result<FileIdReservation, FileTableError> {
-        if self.active_ids == self.max_entries {
+    pub(crate) fn insert(&mut self, value: T) -> Result<u32, FileTableError> {
+        if self.entries.len() == self.max_entries {
             return Err(FileTableError::CapacityExceeded);
         }
 
@@ -45,39 +33,43 @@ impl<T> FileTable<T> {
             self.next_id = file_id.checked_add(1);
             file_id
         };
-        self.active_ids += 1;
-        Ok(FileIdReservation(file_id))
-    }
-
-    pub(crate) fn insert(&mut self, reservation: FileIdReservation, value: T) {
-        let file_id = reservation.0;
         let previous = self.entries.insert(file_id, value);
         debug_assert!(
             previous.is_none(),
-            "released RDPDR file IDs never collide with open files"
+            "available RDPDR file IDs never collide with open files"
         );
-    }
-
-    pub(crate) fn release_file_id(&mut self, reservation: FileIdReservation) {
-        self.available_ids.push(reservation.0);
-        self.active_ids -= 1;
+        Ok(file_id)
     }
 
     pub(crate) fn get(&self, file_id: u32) -> Option<&T> {
         self.entries.get(&file_id)
     }
 
+    pub(crate) fn get_mut(&mut self, file_id: u32) -> Option<&mut T> {
+        self.entries.get_mut(&file_id)
+    }
+
     pub(crate) fn remove(&mut self, file_id: u32) -> Option<T> {
         let value = self.entries.remove(&file_id)?;
         self.available_ids.push(file_id);
-        self.active_ids -= 1;
         Some(value)
     }
 
+    /// Releases all entries and makes their IDs available to subsequent opens.
     pub(crate) fn clear(&mut self) {
         self.available_ids
             .extend(self.entries.drain().map(|(file_id, _)| file_id));
-        self.active_ids = 0;
+    }
+
+    /// Retains entries that satisfy `predicate`, dropping all others.
+    pub(crate) fn retain(&mut self, mut predicate: impl FnMut(&T) -> bool) {
+        let removed_ids = self
+            .entries
+            .iter()
+            .filter_map(|(&file_id, value)| (!predicate(value)).then_some(file_id))
+            .collect::<Vec<_>>();
+        self.entries.retain(|_, value| predicate(value));
+        self.available_ids.extend(removed_ids);
     }
 }
 
@@ -95,24 +87,36 @@ mod tests {
     use super::*;
 
     #[test]
-    fn released_file_ids_are_reused() {
-        let mut table = FileTable::new(1);
-        let reservation = table.reserve_file_id().expect("first allocation");
-        let file_id = reservation.file_id();
-        table.insert(reservation, ());
-        assert!(table.remove(file_id).is_some());
-        assert_eq!(table.reserve_file_id().expect("reuse allocation").file_id(), file_id);
+    fn closed_file_ids_are_reused() {
+        let mut table = FileTable::new(2);
+        let first = table.insert("first").expect("first allocation");
+        assert_eq!(table.remove(first), Some("first"));
+
+        let second = table.insert("second").expect("second allocation");
+
+        assert_eq!(first, 1);
+        assert_eq!(second, first);
+        assert_eq!(table.remove(second), Some("second"));
     }
 
     #[test]
-    fn reservations_enforce_capacity_before_a_handle_is_inserted() {
-        let mut table = FileTable::<()>::new(1);
-        let reservation = table.reserve_file_id().expect("reserve file ID");
-        let file_id = reservation.file_id();
+    fn clearing_and_retaining_entries_releases_their_ids() {
+        let mut table = FileTable::new(3);
+        let first = table.insert("first").expect("first allocation");
+        let second = table.insert("second").expect("second allocation");
+        table.retain(|value| *value == "first");
+        assert_eq!(table.insert("third").expect("reuse retained entry ID"), second);
 
-        assert!(matches!(table.reserve_file_id(), Err(FileTableError::CapacityExceeded)));
+        table.clear();
+        let reused = table.insert("fourth").expect("reuse cleared entry ID");
+        assert!(reused == first || reused == second);
+    }
 
-        table.release_file_id(reservation);
-        assert_eq!(table.reserve_file_id().expect("reuse reservation").file_id(), file_id);
+    #[test]
+    fn allocation_is_bounded() {
+        let mut table = FileTable::new(1);
+        table.insert(()).expect("first allocation");
+
+        assert_eq!(table.insert(()), Err(FileTableError::CapacityExceeded));
     }
 }

--- a/crates/ironrdp-rdpdr-native/src/windows/file_table.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/file_table.rs
@@ -7,8 +7,15 @@ use std::collections::HashMap;
 pub(crate) struct FileTable<T> {
     entries: HashMap<u32, T>,
     available_ids: Vec<u32>,
+    reserved_ids: HashMap<u32, ()>,
     next_id: Option<u32>,
     max_entries: usize,
+}
+
+/// A file ID reserved before a filesystem operation that can mutate local state.
+#[derive(Debug)]
+pub(crate) struct FileIdReservation {
+    file_id: u32,
 }
 
 impl<T> FileTable<T> {
@@ -16,13 +23,21 @@ impl<T> FileTable<T> {
         Self {
             entries: HashMap::new(),
             available_ids: Vec::new(),
+            reserved_ids: HashMap::new(),
             next_id: Some(1),
             max_entries,
         }
     }
 
-    pub(crate) fn insert(&mut self, value: T) -> Result<u32, FileTableError> {
-        if self.entries.len() == self.max_entries {
+    #[cfg(test)]
+    fn insert(&mut self, value: T) -> Result<u32, FileTableError> {
+        let reservation = self.reserve_file_id()?;
+        Ok(self.insert_reserved(reservation, value))
+    }
+
+    /// Reserves an ID before an operation that can mutate the filesystem.
+    pub(crate) fn reserve_file_id(&mut self) -> Result<FileIdReservation, FileTableError> {
+        if self.entries.len() + self.reserved_ids.len() == self.max_entries {
             return Err(FileTableError::CapacityExceeded);
         }
 
@@ -33,12 +48,34 @@ impl<T> FileTable<T> {
             self.next_id = file_id.checked_add(1);
             file_id
         };
+        let previous = self.reserved_ids.insert(file_id, ());
+        debug_assert!(
+            previous.is_none(),
+            "reserved RDPDR file IDs never collide with open or reserved files"
+        );
+        Ok(FileIdReservation { file_id })
+    }
+
+    /// Records a successfully opened file under a previously reserved ID.
+    pub(crate) fn insert_reserved(&mut self, reservation: FileIdReservation, value: T) -> u32 {
+        let file_id = reservation.file_id;
+        let reserved = self.reserved_ids.remove(&file_id);
+        debug_assert!(reserved.is_some(), "file IDs are inserted only once after reservation");
         let previous = self.entries.insert(file_id, value);
         debug_assert!(
             previous.is_none(),
-            "available RDPDR file IDs never collide with open files"
+            "reserved RDPDR file IDs never collide with open files"
         );
-        Ok(file_id)
+        file_id
+    }
+
+    /// Releases an ID after the operation it guarded failed.
+    pub(crate) fn release_file_id(&mut self, reservation: FileIdReservation) {
+        let released = self.reserved_ids.remove(&reservation.file_id);
+        debug_assert!(released.is_some(), "file IDs are released only once after reservation");
+        if released.is_some() {
+            self.available_ids.push(reservation.file_id);
+        }
     }
 
     pub(crate) fn get(&self, file_id: u32) -> Option<&T> {
@@ -63,12 +100,14 @@ impl<T> FileTable<T> {
 
     /// Retains entries that satisfy `predicate`, dropping all others.
     pub(crate) fn retain(&mut self, mut predicate: impl FnMut(&T) -> bool) {
-        let removed_ids = self
-            .entries
-            .iter()
-            .filter_map(|(&file_id, value)| (!predicate(value)).then_some(file_id))
-            .collect::<Vec<_>>();
-        self.entries.retain(|_, value| predicate(value));
+        let mut removed_ids = Vec::new();
+        self.entries.retain(|file_id, value| {
+            let retain = predicate(value);
+            if !retain {
+                removed_ids.push(*file_id);
+            }
+            retain
+        });
         self.available_ids.extend(removed_ids);
     }
 }
@@ -118,5 +157,31 @@ mod tests {
         table.insert(()).expect("first allocation");
 
         assert_eq!(table.insert(()), Err(FileTableError::CapacityExceeded));
+    }
+
+    #[test]
+    fn reservations_prevent_mutating_operations_beyond_capacity() {
+        let mut table = FileTable::new(1);
+        let reservation = table.reserve_file_id().expect("first reservation");
+
+        assert!(matches!(table.reserve_file_id(), Err(FileTableError::CapacityExceeded)));
+
+        table.release_file_id(reservation);
+        assert_eq!(table.insert(()).expect("released reservation is reusable"), 1);
+    }
+
+    #[test]
+    fn retaining_entries_evaluates_each_predicate_once() {
+        let mut table = FileTable::new(2);
+        table.insert("first").expect("first allocation");
+        table.insert("second").expect("second allocation");
+        let mut evaluations = 0;
+
+        table.retain(|_| {
+            evaluations += 1;
+            evaluations == 1
+        });
+
+        assert_eq!(evaluations, 2);
     }
 }

--- a/crates/ironrdp-rdpdr-native/src/windows/handles.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/handles.rs
@@ -1,78 +1,202 @@
-//! Handle-relative Windows filesystem primitives for the narrow RDPDR backend.
+//! Owning Windows directory handles used as roots for RDPDR path resolution.
 
 use core::fmt;
+use core::mem::offset_of;
 use std::os::windows::ffi::OsStrExt as _;
 use std::path::Path;
 
 use windows::Wdk::Foundation::OBJECT_ATTRIBUTES;
 use windows::Wdk::Storage::FileSystem::{
-    FILE_BASIC_INFORMATION, FILE_INFORMATION_CLASS, FILE_OPEN, FILE_STANDARD_INFORMATION, FILE_SYNCHRONOUS_IO_NONALERT,
-    FileAttributeTagInformation, FileBasicInformation, FileEndOfFileInformation, FileStandardInformation,
-    NTCREATEFILE_CREATE_DISPOSITION, NTCREATEFILE_CREATE_OPTIONS, NtCreateFile, NtQueryInformationFile, NtReadFile,
-    NtSetInformationFile, NtWriteFile,
+    FILE_ALLOCATION_INFORMATION, FILE_BASIC_INFORMATION, FILE_DIRECTORY_FILE, FILE_DISPOSITION_INFORMATION,
+    FILE_INFORMATION_CLASS, FILE_OPEN, FILE_RENAME_INFORMATION, FILE_STANDARD_INFORMATION,
+    FILE_SYNCHRONOUS_IO_NONALERT, FS_INFORMATION_CLASS, FileAllocationInformation, FileAttributeTagInformation,
+    FileBasicInformation, FileDispositionInformation, FileEndOfFileInformation, FileRenameInformation,
+    FileStandardInformation, FileStreamInformation, NTCREATEFILE_CREATE_DISPOSITION, NTCREATEFILE_CREATE_OPTIONS,
+    NtCreateFile, NtFlushBuffersFile, NtFsControlFile, NtQueryDirectoryFile, NtQueryInformationFile,
+    NtQueryVolumeInformationFile, NtReadFile, NtSetInformationFile, NtWriteFile,
 };
 use windows::Wdk::System::SystemServices::FILE_END_OF_FILE_INFORMATION;
 use windows::Win32::Foundation::{
-    CloseHandle, HANDLE, NTSTATUS, OBJ_CASE_INSENSITIVE, OBJ_DONT_REPARSE, OBJECT_ATTRIBUTE_FLAGS, UNICODE_STRING,
+    CloseHandle, DUPLICATE_SAME_ACCESS, DuplicateHandle, ERROR_IO_PENDING, HANDLE, NTSTATUS, OBJ_CASE_INSENSITIVE,
+    OBJ_DONT_REPARSE, OBJECT_ATTRIBUTE_FLAGS, UNICODE_STRING,
 };
 use windows::Win32::Storage::FileSystem::{
-    FILE_ACCESS_RIGHTS, FILE_ATTRIBUTE_NORMAL, FILE_FLAGS_AND_ATTRIBUTES, FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE,
-    FILE_SHARE_MODE, FILE_SHARE_READ, FILE_SHARE_WRITE, FILE_TRAVERSE, SYNCHRONIZE,
+    FILE_ACCESS_RIGHTS, FILE_ADD_FILE, FILE_ADD_SUBDIRECTORY, FILE_ATTRIBUTE_NORMAL, FILE_ATTRIBUTE_TAG_INFO,
+    FILE_FLAGS_AND_ATTRIBUTES, FILE_NOTIFY_CHANGE, FILE_READ_ATTRIBUTES, FILE_READ_DATA, FILE_SHARE_DELETE,
+    FILE_SHARE_MODE, FILE_SHARE_READ, FILE_SHARE_WRITE, FILE_TRAVERSE, LOCKFILE_EXCLUSIVE_LOCK,
+    LOCKFILE_FAIL_IMMEDIATELY, LockFileEx, ReadDirectoryChangesW, SYNCHRONIZE, UnlockFileEx,
 };
-use windows::Win32::System::IO::IO_STATUS_BLOCK;
+use windows::Win32::System::IO::{
+    CancelIoEx, GetOverlappedResult, IO_STATUS_BLOCK, OVERLAPPED, OVERLAPPED_0, OVERLAPPED_0_0,
+};
+use windows::Win32::System::Threading::{CreateEventW, GetCurrentProcess};
+use windows::core::HRESULT;
 
-use super::path::RelativePath;
+use crate::windows::path::RelativePath;
 
-const STATUS_INVALID_PARAMETER: NTSTATUS = NTSTATUS(i32::from_ne_bytes(0xC000_000Du32.to_ne_bytes()));
-const STATUS_OBJECT_NAME_INVALID: NTSTATUS = NTSTATUS(i32::from_ne_bytes(0xC000_0033u32.to_ne_bytes()));
-const DIRECTORY_OPEN_OPTIONS: u32 = FILE_SYNCHRONOUS_IO_NONALERT.0 | 0x0000_0001;
+const MAX_VOLUME_QUERY_SIZE: usize = 64 * 1024;
+const MAX_STREAM_QUERY_SIZE: usize = 64 * 1024;
+const MAX_DIRECTORY_QUERY_SIZE: usize = 128 * 1024;
+const MAX_DIRECTORY_NOTIFY_SIZE: usize = 64 * 1024;
+const FILE_ALLOCATED_RANGE_BUFFER_SIZE: usize = 16;
+const SYNCHRONOUS_DIRECTORY_CREATE_OPTIONS: u32 = FILE_DIRECTORY_FILE.0 | FILE_SYNCHRONOUS_IO_NONALERT.0;
+const ASYNCHRONOUS_DIRECTORY_CREATE_OPTIONS: u32 = FILE_DIRECTORY_FILE.0;
+pub(crate) const FILE_OBJECTID_BUFFER_SIZE: usize = 64;
+pub(super) const FILE_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+pub(crate) const RENAME_DESTINATION_DIRECTORY_ACCESS: FILE_ACCESS_RIGHTS = FILE_ACCESS_RIGHTS(
+    FILE_TRAVERSE.0 | FILE_ADD_FILE.0 | FILE_ADD_SUBDIRECTORY.0 | FILE_READ_ATTRIBUTES.0 | SYNCHRONIZE.0,
+);
+const DIRECTORY_TRAVERSAL_ACCESS: FILE_ACCESS_RIGHTS =
+    FILE_ACCESS_RIGHTS(FILE_TRAVERSE.0 | FILE_READ_ATTRIBUTES.0 | SYNCHRONIZE.0);
 
-/// A validated native path for an explicitly configured logical-volume root.
+/// A validated native path for a logical-volume root.
 pub(crate) struct RootDirectory {
-    root_handle: DirectoryHandle,
+    nt_path: Vec<u16>,
 }
 
 impl RootDirectory {
-    /// Validates an absolute logical drive root such as `C:\`.
-    pub(crate) fn open(path: &Path) -> Result<Self, NTSTATUS> {
-        let mut nt_path = volume_root_nt_path(path).ok_or(STATUS_OBJECT_NAME_INVALID)?;
-        let root_handle = DirectoryHandle(open_directory(HANDLE::default(), &mut nt_path)?);
-
-        Ok(Self { root_handle })
+    /// Validates the native path of a logical-volume root.
+    pub(crate) fn open(path: &Path) -> Result<Self, OpenDirectoryError> {
+        Ok(Self {
+            nt_path: volume_root_nt_path(path).ok_or(OpenDirectoryError::InvalidVolumeRoot)?,
+        })
     }
 
-    /// Opens a file or directory without ever joining server input to a host path.
+    /// Opens a descendant directory relative to this redirected-volume root.
+    ///
+    /// Each native open is rooted at the preceding directory handle, so no
+    /// host path join can replace the configured root.
+    pub(crate) fn open_relative_directory(
+        &self,
+        path: &RelativePath,
+    ) -> Result<Option<DirectoryHandle>, OpenDirectoryError> {
+        self.open_relative_directory_with_final_options(path, SYNCHRONOUS_DIRECTORY_CREATE_OPTIONS)
+    }
+
+    /// Opens an independently-owned directory handle that can receive an
+    /// overlapped change-notification request.
+    pub(crate) fn open_relative_directory_for_notification(
+        &self,
+        path: &RelativePath,
+    ) -> Result<Option<DirectoryHandle>, OpenDirectoryError> {
+        if path.components().next().is_none() {
+            return self
+                .open_traversal_root_with_options(
+                    FILE_READ_DATA | DIRECTORY_TRAVERSAL_ACCESS | SYNCHRONIZE,
+                    ASYNCHRONOUS_DIRECTORY_CREATE_OPTIONS,
+                )
+                .map(Some);
+        }
+
+        self.open_relative_directory_with_final_options(path, ASYNCHRONOUS_DIRECTORY_CREATE_OPTIONS)
+    }
+
+    fn open_relative_directory_with_final_options(
+        &self,
+        path: &RelativePath,
+        final_create_options: u32,
+    ) -> Result<Option<DirectoryHandle>, OpenDirectoryError> {
+        let mut current_directory = self.open_traversal_root()?;
+        let final_component = path.components().count().saturating_sub(1);
+        for (index, component) in path.components().enumerate() {
+            let mut component = component.encode_utf16().collect::<Vec<_>>();
+            let create_options = if index == final_component {
+                final_create_options
+            } else {
+                SYNCHRONOUS_DIRECTORY_CREATE_OPTIONS
+            };
+            let child = DirectoryHandle(open_directory_with_access_and_options(
+                current_directory.as_raw(),
+                &mut component,
+                FILE_READ_DATA | DIRECTORY_TRAVERSAL_ACCESS | SYNCHRONIZE,
+                create_options,
+            )?);
+            current_directory = child;
+        }
+
+        Ok(Some(current_directory))
+    }
+
+    /// Opens a non-directory entry relative to this redirected-volume root.
     pub(crate) fn open_relative_file(
         &self,
         path: &RelativePath,
         options: FileOpenOptions,
-    ) -> Result<(FileHandle, usize), NTSTATUS> {
-        let mut components = path.components();
-        let Some(file_name) = components.next_back() else {
+    ) -> Result<(FileHandle, usize), OpenFileError> {
+        let Some(file_name) = path.components().next_back() else {
             return self.open_root_file(options);
         };
-
-        let mut parent = None;
-        for component in components {
-            let mut component = component.encode_utf16().collect::<Vec<_>>();
-            let root_directory = parent
-                .as_ref()
-                .map_or(self.root_handle.as_raw(), DirectoryHandle::as_raw);
-            parent = Some(DirectoryHandle(open_directory(root_directory, &mut component)?));
-        }
-
+        let parent_directory = self
+            .open_relative_parent_directory(path, DIRECTORY_TRAVERSAL_ACCESS)
+            .map_err(OpenFileError::Directory)?;
         let mut file_name = file_name.encode_utf16().collect::<Vec<_>>();
-        let root_directory = parent
-            .as_ref()
-            .map_or(self.root_handle.as_raw(), DirectoryHandle::as_raw);
-        open_file(root_directory, &mut file_name, options)
+        open_file(parent_directory.as_raw(), &mut file_name, options)
     }
 
-    fn open_root_file(&self, mut options: FileOpenOptions) -> Result<(FileHandle, usize), NTSTATUS> {
-        options.desired_access |= FILE_READ_ATTRIBUTES.0;
-        // An empty relative name opens the object identified by RootDirectory.
-        let mut name = [];
-        open_file(self.root_handle.as_raw(), &mut name, options)
+    /// Opens the parent directory of a validated path beneath this volume root.
+    pub(crate) fn open_relative_parent_directory(
+        &self,
+        path: &RelativePath,
+        final_access: FILE_ACCESS_RIGHTS,
+    ) -> Result<DirectoryHandle, OpenDirectoryError> {
+        let mut components = path.components().collect::<Vec<_>>();
+        let _ = components.pop();
+        if components.is_empty() {
+            return self.open_traversal_root_with_access(final_access);
+        }
+
+        let mut current_directory = self.open_traversal_root()?;
+        let final_component = components.len() - 1;
+        for (index, component) in components.into_iter().enumerate() {
+            let mut component = component.encode_utf16().collect::<Vec<_>>();
+            let desired_access = if index == final_component {
+                final_access
+            } else {
+                DIRECTORY_TRAVERSAL_ACCESS
+            };
+            let child = DirectoryHandle(open_directory_with_access(
+                current_directory.as_raw(),
+                &mut component,
+                desired_access,
+            )?);
+            current_directory = child;
+        }
+
+        Ok(current_directory)
+    }
+
+    fn open_traversal_root(&self) -> Result<DirectoryHandle, OpenDirectoryError> {
+        self.open_traversal_root_with_access(FILE_READ_DATA | DIRECTORY_TRAVERSAL_ACCESS)
+    }
+
+    fn open_traversal_root_with_access(
+        &self,
+        desired_access: FILE_ACCESS_RIGHTS,
+    ) -> Result<DirectoryHandle, OpenDirectoryError> {
+        self.open_traversal_root_with_options(desired_access, SYNCHRONOUS_DIRECTORY_CREATE_OPTIONS)
+    }
+
+    fn open_traversal_root_with_options(
+        &self,
+        desired_access: FILE_ACCESS_RIGHTS,
+        create_options: u32,
+    ) -> Result<DirectoryHandle, OpenDirectoryError> {
+        let mut nt_path = self.nt_path.clone();
+        open_directory_with_access_and_options(HANDLE::default(), &mut nt_path, desired_access, create_options)
+            .map(DirectoryHandle)
+    }
+
+    fn open_root_file(&self, options: FileOpenOptions) -> Result<(FileHandle, usize), OpenFileError> {
+        // Explorer opens a redirected volume for directory listing and then
+        // immediately queries its metadata. MSTSC's root file object carries
+        // this access even when the list request omits it; grant it only to
+        // independently opened volume roots, never to descendant files.
+        let options = FileOpenOptions {
+            desired_access: options.desired_access | FILE_READ_ATTRIBUTES.0,
+            ..options
+        };
+        let mut nt_path = self.nt_path.clone();
+        open_file(HANDLE::default(), &mut nt_path, options)
     }
 }
 
@@ -82,22 +206,31 @@ impl fmt::Debug for RootDirectory {
     }
 }
 
-struct DirectoryHandle(HANDLE);
+/// A non-cloneable directory handle opened below a redirected volume.
+pub(crate) struct DirectoryHandle(HANDLE);
 
-// SAFETY: The handle has unique ownership, is only used through backend-owned
-// state, and is closed exactly once by its Drop implementation.
+// SAFETY: Windows handles are process-wide kernel object references. This
+// wrapper has unique ownership and only closes its handle on drop, so moving it
+// between the client and RDP worker threads cannot create concurrent access.
 unsafe impl Send for DirectoryHandle {}
 
 impl DirectoryHandle {
-    fn as_raw(&self) -> HANDLE {
+    pub(crate) fn as_raw(&self) -> HANDLE {
         self.0
+    }
+
+    pub(crate) fn into_file_handle(self) -> FileHandle {
+        let directory = core::mem::ManuallyDrop::new(self);
+        FileHandle(directory.0)
     }
 }
 
 impl Drop for DirectoryHandle {
     fn drop(&mut self) {
-        // SAFETY: This guard owns the handle returned by NtCreateFile.
-        let _ = unsafe { CloseHandle(self.0) };
+        // SAFETY: `self.0` was returned by NtCreateFile and remains exclusively owned by this guard.
+        if let Err(error) = unsafe { CloseHandle(self.0) } {
+            tracing::warn!(error = %error, "Failed to close redirected-drive directory handle");
+        }
     }
 }
 
@@ -105,23 +238,343 @@ impl Drop for DirectoryHandle {
 #[derive(Debug)]
 pub(crate) struct FileHandle(HANDLE);
 
-// SAFETY: The handle has unique ownership, is only used through backend-owned
-// state, and is closed exactly once by its Drop implementation.
+// SAFETY: Windows handles are process-wide kernel object references. This
+// wrapper has unique ownership and only closes its handle on drop, so moving it
+// between the client and RDP worker threads cannot create concurrent access.
 unsafe impl Send for FileHandle {}
 
+/// Synchronous completion from a native offset-based file I/O request.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct NativeIoCompletion {
+    pub(crate) status: NTSTATUS,
+    pub(crate) transferred: usize,
+}
+
+/// Synchronous completion from a filesystem control request.
+#[derive(Debug)]
+pub(crate) struct NativeFsControlCompletion {
+    pub(crate) status: NTSTATUS,
+    pub(crate) output: Vec<u8>,
+}
+
+/// Synchronous completion from a variable-length file information query.
+#[derive(Debug)]
+pub(crate) struct NativeInformationCompletion {
+    pub(crate) status: NTSTATUS,
+    pub(crate) output: Vec<u8>,
+}
+
+/// The request buffer cannot be represented by the native API.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct NativeIoLengthError;
+
 impl FileHandle {
+    pub(crate) fn as_raw(&self) -> HANDLE {
+        self.0
+    }
+
+    /// Duplicates this process-local handle for a deferred worker.
+    ///
+    /// The worker owns the duplicate so a file-table mutation cannot close a
+    /// handle while native work is still using it.
+    pub(crate) fn try_clone(&self) -> Result<Self, windows::core::Error> {
+        // SAFETY: `GetCurrentProcess` takes no arguments and returns the
+        // pseudo-handle for the current process.
+        let process = unsafe { GetCurrentProcess() };
+        let mut handle = HANDLE::default();
+
+        // SAFETY: `self.0` is a valid handle owned by this process and `handle`
+        // is writable storage for the duplicated process-local handle.
+        unsafe {
+            DuplicateHandle(
+                process,
+                self.0,
+                process,
+                core::ptr::addr_of_mut!(handle),
+                0,
+                false,
+                DUPLICATE_SAME_ACCESS,
+            )
+        }?;
+
+        Ok(Self(handle))
+    }
+
+    /// Applies a byte-range lock without allowing the RDP event loop to block.
+    pub(crate) fn lock_range(&self, offset: u64, length: u64, exclusive: bool) -> Result<(), windows::core::Error> {
+        let mut overlapped = Self::overlapped_at(offset);
+        let (length_low, length_high) = split_u64(length);
+        let mut flags = LOCKFILE_FAIL_IMMEDIATELY;
+        if exclusive {
+            flags |= LOCKFILE_EXCLUSIVE_LOCK;
+        }
+
+        // SAFETY: `self.0` is exclusively owned, `overlapped` remains valid
+        // for the synchronous call, and the byte range is represented exactly
+        // by the split low/high length values.
+        unsafe {
+            LockFileEx(
+                self.0,
+                flags,
+                Some(0),
+                length_low,
+                length_high,
+                core::ptr::addr_of_mut!(overlapped),
+            )
+        }
+    }
+
+    /// Applies each byte-range lock, releasing earlier ranges if a later lock
+    /// cannot be acquired.
+    pub(crate) fn lock_ranges(&self, ranges: &[(u64, u64)], exclusive: bool) -> Result<(), windows::core::Error> {
+        let mut acquired = Vec::with_capacity(ranges.len());
+        for &(offset, length) in ranges {
+            if let Err(error) = self.lock_range(offset, length, exclusive) {
+                for &(locked_offset, locked_length) in acquired.iter().rev() {
+                    if let Err(rollback_error) = self.unlock_range(locked_offset, locked_length) {
+                        tracing::warn!(
+                            error = %rollback_error,
+                            "Failed to roll back a partially acquired RDPDR byte-range lock"
+                        );
+                    }
+                }
+                return Err(error);
+            }
+            acquired.push((offset, length));
+        }
+
+        Ok(())
+    }
+
+    /// Releases a byte-range lock previously applied through [`Self::lock_range`].
+    pub(crate) fn unlock_range(&self, offset: u64, length: u64) -> Result<(), windows::core::Error> {
+        let mut overlapped = Self::overlapped_at(offset);
+        let (length_low, length_high) = split_u64(length);
+
+        // SAFETY: `self.0` is exclusively owned, `overlapped` remains valid
+        // for the synchronous call, and the byte range is represented exactly
+        // by the split low/high length values.
+        unsafe {
+            UnlockFileEx(
+                self.0,
+                Some(0),
+                length_low,
+                length_high,
+                core::ptr::addr_of_mut!(overlapped),
+            )
+        }
+    }
+
+    /// Releases every requested byte-range lock, reporting the first native
+    /// failure after attempting the complete request.
+    pub(crate) fn unlock_ranges(&self, ranges: &[(u64, u64)]) -> Result<(), windows::core::Error> {
+        let mut first_error = None;
+        for &(offset, length) in ranges {
+            if let Err(error) = self.unlock_range(offset, length)
+                && first_error.is_none()
+            {
+                first_error = Some(error);
+            }
+        }
+
+        first_error.map_or(Ok(()), Err)
+    }
+
+    /// Waits synchronously for a directory change on a worker-owned handle.
+    ///
+    /// Cancellation is issued with `CancelSynchronousIo` against the worker
+    /// thread, so this must never run on the RDP static-channel thread.
+    #[cfg(test)]
+    pub(crate) fn read_directory_changes(
+        &self,
+        watch_tree: bool,
+        completion_filter: u32,
+    ) -> Result<Vec<u8>, windows::core::Error> {
+        let mut buffer = vec![0; MAX_DIRECTORY_NOTIFY_SIZE];
+        let mut bytes_returned = 0;
+
+        // SAFETY: `self.0` is a worker-owned duplicate, the buffer and byte
+        // count remain valid for this synchronous call, and the caller
+        // validates the completion filter before starting the worker.
+        unsafe {
+            ReadDirectoryChangesW(
+                self.0,
+                buffer.as_mut_ptr().cast(),
+                u32::try_from(buffer.len()).expect("bounded directory notification buffer fits in u32"),
+                watch_tree,
+                FILE_NOTIFY_CHANGE(completion_filter),
+                Some(core::ptr::addr_of_mut!(bytes_returned)),
+                None,
+                None,
+            )
+        }?;
+        buffer.truncate(usize::try_from(bytes_returned).expect("Win32 byte count fits in usize"));
+        Ok(buffer)
+    }
+
+    /// Registers an asynchronous directory-change request before returning.
+    ///
+    /// The returned operation owns the handle, buffer, and `OVERLAPPED` state
+    /// until the worker has observed either a change or cancellation.
+    pub(crate) fn begin_directory_changes(
+        self,
+        watch_tree: bool,
+        completion_filter: u32,
+    ) -> Result<Box<DirectoryChange>, windows::core::Error> {
+        // SAFETY: no security attributes or name are supplied, and the returned
+        // event is owned by `DirectoryChange` until the I/O operation ends.
+        let event = unsafe { CreateEventW(None, true, false, None) }?;
+        let mut operation = Box::new(DirectoryChange {
+            handle: self,
+            event,
+            buffer: vec![0; MAX_DIRECTORY_NOTIFY_SIZE],
+            overlapped: OVERLAPPED {
+                Internal: 0,
+                InternalHigh: 0,
+                Anonymous: OVERLAPPED_0 {
+                    Anonymous: OVERLAPPED_0_0 {
+                        Offset: 0,
+                        OffsetHigh: 0,
+                    },
+                },
+                hEvent: event,
+            },
+        });
+
+        // SAFETY: the asynchronous directory handle, its buffer, and its
+        // OVERLAPPED state all remain owned by `operation` until completion.
+        match unsafe {
+            ReadDirectoryChangesW(
+                operation.handle.as_raw(),
+                operation.buffer.as_mut_ptr().cast(),
+                u32::try_from(operation.buffer.len()).expect("bounded directory notification buffer fits in u32"),
+                watch_tree,
+                FILE_NOTIFY_CHANGE(completion_filter),
+                None,
+                Some(core::ptr::addr_of_mut!(operation.overlapped)),
+                None,
+            )
+        } {
+            Ok(()) => {
+                tracing::debug!(watch_tree, completion_filter, "Registered RDPDR directory notification");
+                Ok(operation)
+            }
+            Err(error) if error.code() == HRESULT::from_win32(ERROR_IO_PENDING.0) => {
+                tracing::debug!(
+                    watch_tree,
+                    completion_filter,
+                    "Registered pending RDPDR directory notification"
+                );
+                Ok(operation)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
     pub(crate) fn query_basic_information(&self) -> Result<FILE_BASIC_INFORMATION, NTSTATUS> {
         self.query_information(FileBasicInformation)
+    }
+
+    fn overlapped_at(offset: u64) -> OVERLAPPED {
+        let (offset_low, offset_high) = split_u64(offset);
+        OVERLAPPED {
+            Internal: 0,
+            InternalHigh: 0,
+            Anonymous: OVERLAPPED_0 {
+                Anonymous: OVERLAPPED_0_0 {
+                    Offset: offset_low,
+                    OffsetHigh: offset_high,
+                },
+            },
+            hEvent: HANDLE::default(),
+        }
     }
 
     pub(crate) fn query_standard_information(&self) -> Result<FILE_STANDARD_INFORMATION, NTSTATUS> {
         self.query_information(FileStandardInformation)
     }
 
-    pub(crate) fn query_attribute_tag_information(
-        &self,
-    ) -> Result<windows::Win32::Storage::FileSystem::FILE_ATTRIBUTE_TAG_INFO, NTSTATUS> {
+    pub(crate) fn query_attribute_tag_information(&self) -> Result<FILE_ATTRIBUTE_TAG_INFO, NTSTATUS> {
         self.query_information(FileAttributeTagInformation)
+    }
+
+    /// Returns the native FILE_STREAM_INFORMATION buffer for every data stream
+    /// attached to this file or directory.
+    pub(crate) fn query_stream_information(&self) -> Result<NativeInformationCompletion, NTSTATUS> {
+        self.query_information_buffer(FileStreamInformation, MAX_STREAM_QUERY_SIZE)
+    }
+
+    pub(crate) fn query_volume_information(
+        &self,
+        information_class: FS_INFORMATION_CLASS,
+    ) -> Result<NativeInformationCompletion, NTSTATUS> {
+        let mut information = vec![0; MAX_VOLUME_QUERY_SIZE];
+        let mut io_status = IO_STATUS_BLOCK::default();
+
+        // SAFETY:
+        // - `self.0` is exclusively owned by this guard and remains open for
+        //   the duration of the synchronous request.
+        // - `information` and `io_status` remain valid writable storage for
+        //   the duration of the call.
+        let status = unsafe {
+            NtQueryVolumeInformationFile(
+                self.0,
+                core::ptr::addr_of_mut!(io_status),
+                information.as_mut_ptr().cast(),
+                u32::try_from(information.len()).expect("bounded volume query buffer fits in u32"),
+                information_class,
+            )
+        };
+        const STATUS_BUFFER_OVERFLOW: i32 = i32::from_ne_bytes(0x8000_0005u32.to_ne_bytes());
+        if status.0 < 0 && status.0 != STATUS_BUFFER_OVERFLOW {
+            return Err(status);
+        }
+
+        information.truncate(io_status.Information.min(information.len()));
+        Ok(NativeInformationCompletion {
+            status,
+            output: information,
+        })
+    }
+
+    pub(crate) fn query_directory_information(
+        &self,
+        information_class: FILE_INFORMATION_CLASS,
+        pattern: Option<&[u16]>,
+        restart_scan: bool,
+    ) -> Result<Vec<u8>, NTSTATUS> {
+        let mut information = vec![0; MAX_DIRECTORY_QUERY_SIZE];
+        let mut io_status = IO_STATUS_BLOCK::default();
+        let unicode_pattern = pattern.map(unicode_string).transpose()?;
+
+        // SAFETY:
+        // - `self.0` is exclusively owned by this guard and remains open for
+        //   the duration of the synchronous request.
+        // - `information`, `io_status`, and `unicode_pattern` remain valid
+        //   for the duration of the native call.
+        // - `return_single_entry` limits the response to one RDPDR directory
+        //   entry, whose cursor the kernel keeps on the directory handle.
+        let status = unsafe {
+            NtQueryDirectoryFile(
+                self.0,
+                None,
+                None,
+                None,
+                core::ptr::addr_of_mut!(io_status),
+                information.as_mut_ptr().cast(),
+                u32::try_from(information.len()).expect("bounded directory query buffer fits in u32"),
+                information_class,
+                true,
+                unicode_pattern.as_ref().map(core::ptr::from_ref),
+                restart_scan,
+            )
+        };
+        if status.0 < 0 {
+            return Err(status);
+        }
+
+        information.truncate(io_status.Information.min(information.len()));
+        Ok(information)
     }
 
     pub(crate) fn set_end_of_file(&self, end_of_file: i64) -> Result<(), NTSTATUS> {
@@ -135,12 +588,74 @@ impl FileHandle {
         self.set_information(FileBasicInformation, &information)
     }
 
-    pub(crate) fn read_at(&self, offset: i64, buffer: &mut [u8]) -> Result<NativeIoCompletion, NTSTATUS> {
-        let length = u32::try_from(buffer.len()).map_err(|_| STATUS_INVALID_PARAMETER)?;
-        let mut io_status = IO_STATUS_BLOCK::default();
+    pub(crate) fn set_delete_pending(&self, delete_pending: bool) -> Result<(), NTSTATUS> {
+        self.set_information(
+            FileDispositionInformation,
+            &FILE_DISPOSITION_INFORMATION {
+                DeleteFile: delete_pending,
+            },
+        )
+    }
 
-        // SAFETY: The handle is live, the output buffer and IO status remain
-        // valid for the synchronous request, and the explicit offset is valid.
+    pub(crate) fn rename(
+        &self,
+        root_directory: HANDLE,
+        file_name: &str,
+        replace_if_exists: bool,
+    ) -> Result<(), NTSTATUS> {
+        let file_name = file_name.encode_utf16().collect::<Vec<_>>();
+        let file_name_length = file_name
+            .len()
+            .checked_mul(size_of::<u16>())
+            .and_then(|length| u32::try_from(length).ok())
+            .ok_or(NTSTATUS(i32::from_ne_bytes(0xC000_000Du32.to_ne_bytes())))?;
+        let header_length = offset_of!(FILE_RENAME_INFORMATION, FileName);
+        let buffer_length = header_length
+            .checked_add(usize::try_from(file_name_length).expect("u32 fits in usize"))
+            .map(|length| length.max(size_of::<FILE_RENAME_INFORMATION>()))
+            .ok_or(NTSTATUS(i32::from_ne_bytes(0xC000_000Du32.to_ne_bytes())))?;
+        let mut information = vec![0; buffer_length];
+        // The variable-length buffer has byte alignment, so encode its fixed
+        // native prefix by field offset instead of casting it to the typed struct.
+        information[offset_of!(FILE_RENAME_INFORMATION, Anonymous)] = u8::from(replace_if_exists);
+        let root_directory_offset = offset_of!(FILE_RENAME_INFORMATION, RootDirectory);
+        information[root_directory_offset..][..size_of::<HANDLE>()]
+            .copy_from_slice(&root_directory.0.addr().to_le_bytes());
+        let file_name_length_offset = offset_of!(FILE_RENAME_INFORMATION, FileNameLength);
+        information[file_name_length_offset..][..size_of::<u32>()].copy_from_slice(&file_name_length.to_le_bytes());
+        for (destination, code_unit) in information[header_length..]
+            .chunks_exact_mut(size_of::<u16>())
+            .zip(file_name)
+        {
+            destination.copy_from_slice(&code_unit.to_le_bytes());
+        }
+
+        self.set_information_buffer(
+            FileRenameInformation,
+            information.as_ptr().cast(),
+            u32::try_from(buffer_length).expect("bounded rename buffer fits in u32"),
+        )
+    }
+
+    pub(crate) fn set_allocation_size(&self, allocation_size: i64) -> Result<(), NTSTATUS> {
+        self.set_information(
+            FileAllocationInformation,
+            &FILE_ALLOCATION_INFORMATION {
+                AllocationSize: allocation_size,
+            },
+        )
+    }
+
+    pub(crate) fn read_at(&self, offset: i64, buffer: &mut [u8]) -> Result<NativeIoCompletion, NativeIoLengthError> {
+        let mut io_status = IO_STATUS_BLOCK::default();
+        let length = u32::try_from(buffer.len()).map_err(|_| NativeIoLengthError)?;
+
+        // SAFETY:
+        // - `self.0` is exclusively owned by this guard and remains open for
+        //   the duration of the synchronous request.
+        // - `io_status`, `offset`, and `buffer` are valid for the call.
+        // - an explicit `offset` prevents this request from changing or
+        //   consuming a shared file cursor.
         let status = unsafe {
             NtReadFile(
                 self.0,
@@ -161,12 +676,16 @@ impl FileHandle {
         })
     }
 
-    pub(crate) fn write_at(&self, offset: i64, buffer: &[u8]) -> Result<NativeIoCompletion, NTSTATUS> {
-        let length = u32::try_from(buffer.len()).map_err(|_| STATUS_INVALID_PARAMETER)?;
+    pub(crate) fn write_at(&self, offset: i64, buffer: &[u8]) -> Result<NativeIoCompletion, NativeIoLengthError> {
         let mut io_status = IO_STATUS_BLOCK::default();
+        let length = u32::try_from(buffer.len()).map_err(|_| NativeIoLengthError)?;
 
-        // SAFETY: The handle is live, the input buffer and IO status remain
-        // valid for the synchronous request, and the explicit offset is valid.
+        // SAFETY:
+        // - `self.0` is exclusively owned by this guard and remains open for
+        //   the duration of the synchronous request.
+        // - `io_status`, `offset`, and `buffer` are valid for the call.
+        // - an explicit `offset` prevents this request from changing or
+        //   consuming a shared file cursor.
         let status = unsafe {
             NtWriteFile(
                 self.0,
@@ -187,13 +706,130 @@ impl FileHandle {
         })
     }
 
+    /// Writes at the end of the file without resolving its path again.
+    pub(crate) fn write_to_end(&self, buffer: &[u8]) -> Result<NativeIoCompletion, NativeIoLengthError> {
+        // NtWriteFile interprets a byte offset of -1 as an append request.
+        self.write_at(-1, buffer)
+    }
+
+    pub(crate) fn flush(&self) -> Result<(), NTSTATUS> {
+        let mut io_status = IO_STATUS_BLOCK::default();
+
+        // SAFETY: `self.0` is exclusively owned by this guard and `io_status`
+        // remains valid writable storage for the synchronous request.
+        let status = unsafe { NtFlushBuffersFile(self.0, core::ptr::addr_of_mut!(io_status)) };
+        if status.0 < 0 {
+            return Err(status);
+        }
+
+        Ok(())
+    }
+
+    /// Queries the file's compression format through a fixed-size FSCTL response.
+    pub(crate) fn query_compression_format(&self) -> Result<[u8; 2], NTSTATUS> {
+        const FSCTL_GET_COMPRESSION: u32 = 0x0009_003C;
+        let mut compression_format = [0; 2];
+        self.query_fixed_size_fsctl(FSCTL_GET_COMPRESSION, &mut compression_format)?;
+        Ok(compression_format)
+    }
+
+    /// Queries the file's integrity metadata through its fixed-size FSCTL response.
+    pub(crate) fn query_integrity_information(&self) -> Result<[u8; 16], NTSTATUS> {
+        const FSCTL_GET_INTEGRITY_INFORMATION: u32 = 0x0009_027C;
+        let mut integrity_information = [0; 16];
+        self.query_fixed_size_fsctl(FSCTL_GET_INTEGRITY_INFORMATION, &mut integrity_information)?;
+        Ok(integrity_information)
+    }
+
+    /// Creates an object ID when absent, then returns the file's 64-byte object-ID buffer.
+    pub(crate) fn create_or_get_object_id(&self) -> Result<[u8; FILE_OBJECTID_BUFFER_SIZE], NTSTATUS> {
+        const FSCTL_CREATE_OR_GET_OBJECT_ID: u32 = 0x0009_00C0;
+        let mut object_id = [0; FILE_OBJECTID_BUFFER_SIZE];
+        self.query_fixed_size_fsctl(FSCTL_CREATE_OR_GET_OBJECT_ID, &mut object_id)?;
+        Ok(object_id)
+    }
+
+    /// Queries allocated byte ranges with a caller-validated range and output
+    /// bound. The raw result is retained only for the matching RDPDR response.
+    pub(crate) fn query_allocated_ranges(
+        &self,
+        range: &[u8; FILE_ALLOCATED_RANGE_BUFFER_SIZE],
+        output_buffer_length: usize,
+    ) -> NativeFsControlCompletion {
+        const FSCTL_QUERY_ALLOCATED_RANGES: u32 = 0x0009_40CF;
+        let mut output = vec![0; output_buffer_length];
+        let mut io_status = IO_STATUS_BLOCK::default();
+
+        // SAFETY:
+        // - `self.0` is exclusively owned by this guard and remains open for
+        //   the duration of the synchronous request.
+        // - `range` is the exact 16-byte FILE_ALLOCATED_RANGE_BUFFER supplied
+        //   by a validated RDPDR control request.
+        // - `output` is bounded by the caller and remains valid for the call.
+        // - `io_status` remains valid for the duration of the call.
+        let status = unsafe {
+            NtFsControlFile(
+                self.0,
+                None,
+                None,
+                None,
+                core::ptr::addr_of_mut!(io_status),
+                FSCTL_QUERY_ALLOCATED_RANGES,
+                Some(range.as_ptr().cast()),
+                u32::try_from(range.len()).expect("allocated range request size fits in u32"),
+                (!output.is_empty()).then_some(output.as_mut_ptr().cast()),
+                u32::try_from(output.len()).expect("bounded allocated range output fits in u32"),
+            )
+        };
+        output.truncate(io_status.Information.min(output.len()));
+
+        NativeFsControlCompletion { status, output }
+    }
+
+    fn query_fixed_size_fsctl(&self, control_code: u32, output: &mut [u8]) -> Result<(), NTSTATUS> {
+        let mut io_status = IO_STATUS_BLOCK::default();
+
+        // SAFETY:
+        // - `self.0` is exclusively owned by this guard and remains open for
+        //   the duration of the synchronous request.
+        // - each supported fixed-size FSCTL has no input and writes exactly
+        //   the required result into the caller-provided `output` buffer.
+        // - `io_status` and the output buffer remain valid for the call.
+        let status = unsafe {
+            NtFsControlFile(
+                self.0,
+                None,
+                None,
+                None,
+                core::ptr::addr_of_mut!(io_status),
+                control_code,
+                None,
+                0,
+                Some(output.as_mut_ptr().cast()),
+                u32::try_from(output.len()).expect("fixed FSCTL output size fits in u32"),
+            )
+        };
+        if status.0 < 0 {
+            return Err(status);
+        }
+        if io_status.Information != output.len() {
+            return Err(NTSTATUS(i32::from_ne_bytes(0xC000_0001u32.to_ne_bytes())));
+        }
+
+        Ok(())
+    }
+
     fn query_information<T: Default>(&self, information_class: FILE_INFORMATION_CLASS) -> Result<T, NTSTATUS> {
         let mut information = T::default();
         let mut io_status = IO_STATUS_BLOCK::default();
-        let length = u32::try_from(size_of::<T>()).map_err(|_| STATUS_INVALID_PARAMETER)?;
+        let length = u32::try_from(size_of::<T>()).expect("fixed native file information fits in u32");
 
-        // SAFETY: `information` and `io_status` are writable for the complete
-        // synchronous call, and `T` is the native structure for the class.
+        // SAFETY:
+        // - `self.0` is exclusively owned by this guard and remains open for
+        //   the duration of the synchronous request.
+        // - each caller chooses the native structure required by
+        //   `information_class`, and `information` is valid writable storage.
+        // - `io_status` remains valid for the duration of the call.
         let status = unsafe {
             NtQueryInformationFile(
                 self.0,
@@ -210,17 +846,67 @@ impl FileHandle {
         Ok(information)
     }
 
-    fn set_information<T>(&self, information_class: FILE_INFORMATION_CLASS, information: &T) -> Result<(), NTSTATUS> {
+    fn query_information_buffer(
+        &self,
+        information_class: FILE_INFORMATION_CLASS,
+        buffer_length: usize,
+    ) -> Result<NativeInformationCompletion, NTSTATUS> {
+        let mut information = vec![0; buffer_length];
         let mut io_status = IO_STATUS_BLOCK::default();
-        let length = u32::try_from(size_of::<T>()).map_err(|_| STATUS_INVALID_PARAMETER)?;
+        let length = u32::try_from(information.len()).expect("bounded native file information fits in u32");
 
-        // SAFETY: `information` is valid immutable native input and
-        // `io_status` remains writable for the synchronous call.
+        // SAFETY:
+        // - `self.0` is exclusively owned by this guard and remains open for
+        //   the duration of the synchronous request.
+        // - `information` is writable storage for the requested native
+        //   variable-length information class.
+        // - `io_status` remains valid for the duration of the call.
+        let status = unsafe {
+            NtQueryInformationFile(
+                self.0,
+                core::ptr::addr_of_mut!(io_status),
+                information.as_mut_ptr().cast(),
+                length,
+                information_class,
+            )
+        };
+        const STATUS_BUFFER_OVERFLOW: i32 = i32::from_ne_bytes(0x8000_0005u32.to_ne_bytes());
+        if status.0 < 0 && status.0 != STATUS_BUFFER_OVERFLOW {
+            return Err(status);
+        }
+
+        information.truncate(io_status.Information.min(information.len()));
+        Ok(NativeInformationCompletion {
+            status,
+            output: information,
+        })
+    }
+
+    fn set_information<T>(&self, information_class: FILE_INFORMATION_CLASS, information: &T) -> Result<(), NTSTATUS> {
+        let length = u32::try_from(size_of::<T>()).expect("fixed native file information fits in u32");
+
+        self.set_information_buffer(information_class, core::ptr::from_ref(information).cast(), length)
+    }
+
+    fn set_information_buffer(
+        &self,
+        information_class: FILE_INFORMATION_CLASS,
+        information: *const core::ffi::c_void,
+        length: u32,
+    ) -> Result<(), NTSTATUS> {
+        let mut io_status = IO_STATUS_BLOCK::default();
+
+        // SAFETY:
+        // - `self.0` is exclusively owned by this guard and remains open for
+        //   the duration of the synchronous request.
+        // - each caller chooses the native structure and buffer required by
+        //   `information_class`, and `information` is valid readable storage.
+        // - `io_status` remains valid for the duration of the call.
         let status = unsafe {
             NtSetInformationFile(
                 self.0,
                 core::ptr::addr_of_mut!(io_status),
-                core::ptr::from_ref(information).cast_mut().cast(),
+                information,
                 length,
                 information_class,
             )
@@ -233,20 +919,106 @@ impl FileHandle {
     }
 }
 
-impl Drop for FileHandle {
-    fn drop(&mut self) {
-        // SAFETY: This guard owns the handle returned by NtCreateFile.
-        let _ = unsafe { CloseHandle(self.0) };
+/// An asynchronous directory-change request registered on a dedicated handle.
+pub(crate) struct DirectoryChange {
+    handle: FileHandle,
+    event: HANDLE,
+    buffer: Vec<u8>,
+    overlapped: OVERLAPPED,
+}
+
+// SAFETY: the operation has exclusive ownership of its kernel handle, buffer,
+// and OVERLAPPED state while it runs on a deferred worker thread.
+unsafe impl Send for DirectoryChange {}
+
+impl DirectoryChange {
+    pub(crate) fn handle(&self) -> HANDLE {
+        self.handle.as_raw()
+    }
+
+    #[expect(
+        clippy::boxed_local,
+        reason = "the submitted OVERLAPPED points into this allocation, which must not move while the request is pending"
+    )]
+    pub(crate) fn wait(mut self: Box<Self>) -> Result<Vec<u8>, windows::core::Error> {
+        let mut bytes_returned = 0;
+
+        // SAFETY: `self` keeps the file handle, OVERLAPPED state, and output
+        // buffer alive until the registered operation has completed.
+        unsafe {
+            GetOverlappedResult(
+                self.handle.as_raw(),
+                core::ptr::addr_of_mut!(self.overlapped),
+                core::ptr::addr_of_mut!(bytes_returned),
+                true,
+            )
+        }?;
+        let bytes_returned = usize::try_from(bytes_returned).expect("Win32 byte count fits in usize");
+        let native_bytes_returned = self.overlapped.InternalHigh;
+        let notification_bytes = bytes_returned.max(native_bytes_returned);
+        self.buffer.truncate(notification_bytes);
+        let notification_action = self.buffer.get(4..8).map(|bytes| {
+            u32::from_le_bytes(
+                bytes
+                    .try_into()
+                    .expect("the notification action field is exactly four bytes"),
+            )
+        });
+        tracing::debug!(
+            notification_bytes,
+            ?notification_action,
+            "Completed RDPDR directory notification"
+        );
+        Ok(core::mem::take(&mut self.buffer))
     }
 }
 
-/// A synchronous native read or write completion.
-#[derive(Clone, Copy, Debug)]
-pub(crate) struct NativeIoCompletion {
-    pub(crate) status: NTSTATUS,
-    pub(crate) transferred: usize,
+impl Drop for DirectoryChange {
+    fn drop(&mut self) {
+        let mut bytes_returned = 0;
+
+        // SAFETY: the handle, OVERLAPPED state, and output buffer remain valid
+        // until GetOverlappedResult observes cancellation or normal completion.
+        // This also covers a worker-spawn failure after ReadDirectoryChangesW
+        // has registered asynchronous I/O.
+        let _ = unsafe { CancelIoEx(self.handle.as_raw(), Some(core::ptr::addr_of_mut!(self.overlapped))) };
+        // SAFETY: cancellation above guarantees this waits on the same still-live
+        // handle and OVERLAPPED storage before the operation is dropped.
+        let _ = unsafe {
+            GetOverlappedResult(
+                self.handle.as_raw(),
+                core::ptr::addr_of_mut!(self.overlapped),
+                core::ptr::addr_of_mut!(bytes_returned),
+                true,
+            )
+        };
+
+        // SAFETY: `self.event` is exclusively owned by this operation and no
+        // longer needed once completion has been observed.
+        if let Err(error) = unsafe { CloseHandle(self.event) } {
+            tracing::warn!(error = %error, "Failed to close redirected-drive directory notification event");
+        }
+    }
 }
 
+fn split_u64(value: u64) -> (u32, u32) {
+    let bytes = value.to_le_bytes();
+    (
+        u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
+        u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]),
+    )
+}
+
+impl Drop for FileHandle {
+    fn drop(&mut self) {
+        // SAFETY: `self.0` was returned by NtCreateFile and remains exclusively owned by this guard.
+        if let Err(error) = unsafe { CloseHandle(self.0) } {
+            tracing::warn!(error = %error, "Failed to close redirected-drive file handle");
+        }
+    }
+}
+
+/// Options for a synchronous, handle-relative native file open.
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct FileOpenOptions {
     pub(crate) desired_access: u32,
@@ -257,13 +1029,47 @@ pub(crate) struct FileOpenOptions {
     pub(crate) create_options: u32,
 }
 
+/// Result from a native file open.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum OpenFileError {
+    /// Opening a parent directory failed.
+    Directory(OpenDirectoryError),
+    /// The final native open failed.
+    NtStatus(NTSTATUS),
+}
+
 pub(crate) const FILE_SUPERSEDED_INFORMATION: usize = 0;
 pub(crate) const FILE_OPENED_INFORMATION: usize = 1;
 pub(crate) const FILE_CREATED_INFORMATION: usize = 2;
 pub(crate) const FILE_OVERWRITTEN_INFORMATION: usize = 3;
 
+/// Failure while opening a selected redirected-volume root.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum OpenDirectoryError {
+    /// The selection is not a logical Windows volume root (`C:\`).
+    InvalidVolumeRoot,
+    /// The native open failed without disclosing the host path.
+    NtStatus(NTSTATUS),
+}
+
+impl fmt::Display for OpenDirectoryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidVolumeRoot => f.write_str("redirected drive must be a logical volume root"),
+            Self::NtStatus(status) => write!(
+                f,
+                "opening redirected-drive root failed with NTSTATUS {:#010X}",
+                status.0
+            ),
+        }
+    }
+}
+
+impl core::error::Error for OpenDirectoryError {}
+
 fn volume_root_nt_path(path: &Path) -> Option<Vec<u16>> {
     let path = path.as_os_str().encode_wide().collect::<Vec<_>>();
+
     let is_logical_volume_root = path.len() == 3
         && matches!(path[0], 65..=90 | 97..=122)
         && path[1] == u16::from(b':')
@@ -277,16 +1083,64 @@ fn volume_root_nt_path(path: &Path) -> Option<Vec<u16>> {
     Some(nt_path)
 }
 
-fn open_directory(root_directory: HANDLE, name: &mut [u16]) -> Result<HANDLE, NTSTATUS> {
-    let name = unicode_string(name)?;
-    let object_attributes = object_attributes(root_directory, &name);
+fn unicode_string(value: &[u16]) -> Result<UNICODE_STRING, NTSTATUS> {
+    let byte_len = value
+        .len()
+        .checked_mul(size_of::<u16>())
+        .and_then(|length| u16::try_from(length).ok())
+        .ok_or(NTSTATUS(i32::from_ne_bytes(0xC000_000Du32.to_ne_bytes())))?;
+
+    Ok(UNICODE_STRING {
+        Length: byte_len,
+        MaximumLength: byte_len,
+        Buffer: windows::core::PWSTR::from_raw(value.as_ptr().cast_mut()),
+    })
+}
+
+fn open_directory_with_access(
+    root_directory: HANDLE,
+    name: &mut [u16],
+    desired_access: FILE_ACCESS_RIGHTS,
+) -> Result<HANDLE, OpenDirectoryError> {
+    open_directory_with_access_and_options(
+        root_directory,
+        name,
+        desired_access,
+        SYNCHRONOUS_DIRECTORY_CREATE_OPTIONS,
+    )
+}
+
+fn open_directory_with_access_and_options(
+    root_directory: HANDLE,
+    name: &mut [u16],
+    desired_access: FILE_ACCESS_RIGHTS,
+    create_options: u32,
+) -> Result<HANDLE, OpenDirectoryError> {
+    let name_byte_len = name
+        .len()
+        .checked_mul(size_of::<u16>())
+        .and_then(|length| u16::try_from(length).ok())
+        .ok_or(OpenDirectoryError::InvalidVolumeRoot)?;
+    let mut unicode_name = UNICODE_STRING {
+        Length: name_byte_len,
+        MaximumLength: name_byte_len,
+        Buffer: windows::core::PWSTR::from_raw(name.as_mut_ptr()),
+    };
+    let object_attributes = OBJECT_ATTRIBUTES {
+        Length: u32::try_from(size_of::<OBJECT_ATTRIBUTES>()).expect("OBJECT_ATTRIBUTES size fits in u32"),
+        RootDirectory: root_directory,
+        ObjectName: core::ptr::addr_of_mut!(unicode_name),
+        Attributes: OBJ_CASE_INSENSITIVE | OBJ_DONT_REPARSE,
+        SecurityDescriptor: core::ptr::null(),
+        SecurityQualityOfService: core::ptr::null(),
+    };
     let mut handle = HANDLE::default();
     let mut io_status = IO_STATUS_BLOCK::default();
-    let desired_access = FILE_ACCESS_RIGHTS(FILE_TRAVERSE.0 | SYNCHRONIZE.0);
 
-    // SAFETY: Name, object attributes, output handle, and IO status remain
-    // valid for this synchronous call. OBJ_DONT_REPARSE blocks every reparse
-    // point while walking from the trusted root.
+    // SAFETY:
+    // - `name` and `unicode_name` stay alive for the entire call.
+    // - `object_attributes`, `handle`, and `io_status` are valid writable pointers.
+    // - `OBJ_DONT_REPARSE` ensures object-manager resolution fails instead of traversing a reparse point.
     let status = unsafe {
         NtCreateFile(
             core::ptr::addr_of_mut!(handle),
@@ -297,13 +1151,13 @@ fn open_directory(root_directory: HANDLE, name: &mut [u16]) -> Result<HANDLE, NT
             FILE_ATTRIBUTE_NORMAL,
             FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
             FILE_OPEN,
-            NTCREATEFILE_CREATE_OPTIONS(DIRECTORY_OPEN_OPTIONS),
+            NTCREATEFILE_CREATE_OPTIONS(create_options),
             None,
             0,
         )
     };
     if status.0 < 0 {
-        return Err(status);
+        return Err(OpenDirectoryError::NtStatus(status));
     }
 
     Ok(handle)
@@ -313,15 +1167,35 @@ fn open_file(
     root_directory: HANDLE,
     name: &mut [u16],
     options: FileOpenOptions,
-) -> Result<(FileHandle, usize), NTSTATUS> {
-    let name = unicode_string(name)?;
-    let object_attributes = object_attributes(root_directory, &name);
+) -> Result<(FileHandle, usize), OpenFileError> {
+    let name_byte_len = name
+        .len()
+        .checked_mul(size_of::<u16>())
+        .and_then(|length| u16::try_from(length).ok())
+        .ok_or(OpenFileError::NtStatus(NTSTATUS(i32::from_ne_bytes(
+            0xC000_000Du32.to_ne_bytes(),
+        ))))?;
+    let mut unicode_name = UNICODE_STRING {
+        Length: name_byte_len,
+        MaximumLength: name_byte_len,
+        Buffer: windows::core::PWSTR::from_raw(name.as_mut_ptr()),
+    };
+    let object_attributes = OBJECT_ATTRIBUTES {
+        Length: u32::try_from(size_of::<OBJECT_ATTRIBUTES>()).expect("OBJECT_ATTRIBUTES size fits in u32"),
+        RootDirectory: root_directory,
+        ObjectName: core::ptr::addr_of_mut!(unicode_name),
+        Attributes: final_file_object_attributes(options.create_options),
+        SecurityDescriptor: core::ptr::null(),
+        SecurityQualityOfService: core::ptr::null(),
+    };
     let mut handle = HANDLE::default();
     let mut io_status = IO_STATUS_BLOCK::default();
 
-    // SAFETY: Name, object attributes, output handle, allocation size, and IO
-    // status remain valid for the call. OBJ_DONT_REPARSE prevents the final
-    // component from escaping the selected logical volume.
+    // SAFETY:
+    // - `name` and `unicode_name` stay alive for the entire call.
+    // - `object_attributes`, `handle`, and `io_status` are valid writable pointers.
+    // - `OBJ_DONT_REPARSE` prevents reparse-point traversal outside the volume
+    //   unless the caller explicitly opens the final reparse-point object.
     let status = unsafe {
         NtCreateFile(
             core::ptr::addr_of_mut!(handle),
@@ -332,57 +1206,433 @@ fn open_file(
             FILE_FLAGS_AND_ATTRIBUTES(options.file_attributes),
             FILE_SHARE_MODE(options.share_access),
             NTCREATEFILE_CREATE_DISPOSITION(options.create_disposition),
-            NTCREATEFILE_CREATE_OPTIONS(options.create_options | FILE_SYNCHRONOUS_IO_NONALERT.0),
+            NTCREATEFILE_CREATE_OPTIONS(options.create_options),
             None,
             0,
         )
     };
     if status.0 < 0 {
-        return Err(status);
+        return Err(OpenFileError::NtStatus(status));
     }
 
     Ok((FileHandle(handle), io_status.Information))
 }
 
-fn unicode_string(value: &mut [u16]) -> Result<UNICODE_STRING, NTSTATUS> {
-    let byte_len = value
-        .len()
-        .checked_mul(size_of::<u16>())
-        .and_then(|length| u16::try_from(length).ok())
-        .ok_or(STATUS_INVALID_PARAMETER)?;
-
-    Ok(UNICODE_STRING {
-        Length: byte_len,
-        MaximumLength: byte_len,
-        Buffer: windows::core::PWSTR::from_raw(value.as_mut_ptr()),
-    })
-}
-
-fn object_attributes(root_directory: HANDLE, name: &UNICODE_STRING) -> OBJECT_ATTRIBUTES {
-    OBJECT_ATTRIBUTES {
-        Length: u32::try_from(size_of::<OBJECT_ATTRIBUTES>()).expect("OBJECT_ATTRIBUTES size fits in u32"),
-        RootDirectory: root_directory,
-        ObjectName: core::ptr::from_ref(name).cast_mut(),
-        Attributes: OBJECT_ATTRIBUTE_FLAGS(OBJ_CASE_INSENSITIVE.0 | OBJ_DONT_REPARSE.0),
-        SecurityDescriptor: core::ptr::null(),
-        SecurityQualityOfService: core::ptr::null(),
+fn final_file_object_attributes(create_options: u32) -> OBJECT_ATTRIBUTE_FLAGS {
+    let mut attributes = OBJ_CASE_INSENSITIVE;
+    if create_options & FILE_OPEN_REPARSE_POINT == 0 {
+        attributes |= OBJ_DONT_REPARSE;
     }
+    attributes
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::time::Duration;
+    use std::os::windows::io::AsRawHandle as _;
+    use std::path::PathBuf;
+    use std::sync::mpsc;
+    use std::thread;
+
+    use windows::Wdk::Storage::FileSystem::FileDirectoryInformation;
+    use windows::Win32::System::IO::CancelSynchronousIo;
 
     #[test]
-    fn accepts_only_logical_volume_roots() {
-        assert!(RootDirectory::open(Path::new(r"C:\")).is_ok());
-        assert!(matches!(
-            RootDirectory::open(Path::new(r"C:\Windows")),
-            Err(STATUS_OBJECT_NAME_INVALID)
+    fn final_reparse_point_open_does_not_set_object_manager_reparse_blocking() {
+        assert_ne!((final_file_object_attributes(0) & OBJ_DONT_REPARSE).0, 0);
+        assert_eq!(
+            (final_file_object_attributes(FILE_OPEN_REPARSE_POINT) & OBJ_DONT_REPARSE).0,
+            0
+        );
+    }
+
+    #[test]
+    fn opens_the_system_volume_root() {
+        let system_drive = std::env::var("SystemDrive").expect("SystemDrive is set on Windows");
+        let root = format!(r"{system_drive}\");
+
+        let handle = RootDirectory::open(Path::new(&root)).expect("open system volume root");
+
+        assert!(
+            handle
+                .open_relative_directory(&RelativePath::parse(r"\Windows").expect("valid relative path"))
+                .expect("open child directory")
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn opens_a_child_directory_relative_to_the_system_volume() {
+        let system_drive = std::env::var("SystemDrive").expect("SystemDrive is set on Windows");
+        let root = format!(r"{system_drive}\");
+        let root = RootDirectory::open(Path::new(&root)).expect("open system volume root");
+        let windows_directory = RelativePath::parse(r"\Windows").expect("valid relative path");
+
+        let handle = root
+            .open_relative_directory(&windows_directory)
+            .expect("open child directory relative to root");
+
+        assert!(handle.is_some());
+    }
+
+    #[test]
+    fn opens_a_distinct_handle_for_the_volume_root_directory() {
+        let system_drive = std::env::var("SystemDrive").expect("SystemDrive is set on Windows");
+        let root = RootDirectory::open(Path::new(&format!(r"{system_drive}\"))).expect("open system volume root");
+
+        assert!(
+            root.open_relative_directory(&RelativePath::parse(r"\").expect("valid root path"))
+                .expect("open root directory relative to root")
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn opens_an_existing_file_relative_to_the_system_volume() {
+        let system_drive = std::env::var("SystemDrive").expect("SystemDrive is set on Windows");
+        let root = format!(r"{system_drive}\");
+        let root = RootDirectory::open(Path::new(&root)).expect("open system volume root");
+        let kernel32 = RelativePath::parse(r"\Windows\System32\kernel32.dll").expect("valid relative path");
+
+        let (_handle, information) = root
+            .open_relative_file(
+                &kernel32,
+                FileOpenOptions {
+                    desired_access: 0x0010_0081,
+                    allocation_size: None,
+                    file_attributes: FILE_ATTRIBUTE_NORMAL.0,
+                    share_access: (FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE).0,
+                    create_disposition: FILE_OPEN.0,
+                    create_options: 0x0000_0020,
+                },
+            )
+            .expect("open kernel32 relative to system root");
+
+        assert_eq!(information, FILE_OPENED_INFORMATION);
+    }
+
+    #[test]
+    fn root_open_allows_metadata_queries_after_an_explorer_directory_list_request() {
+        let system_drive = std::env::var("SystemDrive").expect("SystemDrive is set on Windows");
+        let root = RootDirectory::open(Path::new(&format!(r"{system_drive}\"))).expect("validate system volume root");
+        let options = FileOpenOptions {
+            desired_access: 0x0010_0001,
+            allocation_size: None,
+            file_attributes: FILE_ATTRIBUTE_NORMAL.0,
+            share_access: (FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE).0,
+            create_disposition: FILE_OPEN.0,
+            create_options: (FILE_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_NONALERT).0,
+        };
+
+        let (handle, _) = root.open_root_file(options).expect("open system volume root");
+
+        handle
+            .query_basic_information()
+            .expect("query root metadata without an explicit read-attributes request");
+    }
+
+    #[test]
+    fn independent_root_opens_do_not_block_directory_queries_behind_a_notification() {
+        let system_drive = std::env::var("SystemDrive").expect("SystemDrive is set on Windows");
+        let root = RootDirectory::open(Path::new(&format!(r"{system_drive}\"))).expect("validate system volume root");
+        let options = FileOpenOptions {
+            desired_access: 0x0010_0001,
+            allocation_size: None,
+            file_attributes: FILE_ATTRIBUTE_NORMAL.0,
+            share_access: (FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE).0,
+            create_disposition: FILE_OPEN.0,
+            create_options: (FILE_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_NONALERT).0,
+        };
+        let (watch_handle, _) = root.open_root_file(options).expect("open watched system volume root");
+        let (query_handle, _) = root.open_root_file(options).expect("open queried system volume root");
+        let (started_sender, started_receiver) = mpsc::channel();
+        let watcher = thread::spawn(move || {
+            started_sender
+                .send(())
+                .expect("directory notification starter remains available");
+            watch_handle.read_directory_changes(false, 1)
+        });
+        started_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("directory notification worker starts");
+        thread::sleep(Duration::from_millis(25));
+
+        let (query_sender, query_receiver) = mpsc::channel();
+        let query = thread::spawn(move || {
+            query_sender
+                .send(query_handle.query_directory_information(FileDirectoryInformation, None, true))
+                .expect("directory query receiver remains available");
+        });
+        let query_result = query_receiver.recv_timeout(Duration::from_secs(1));
+
+        while !watcher.is_finished() {
+            // SAFETY: `watcher` owns a live Windows thread handle until it is joined.
+            let _ = unsafe { CancelSynchronousIo(HANDLE(watcher.as_raw_handle())) };
+            thread::sleep(Duration::from_millis(1));
+        }
+        let _ = watcher.join().expect("directory notification worker does not panic");
+
+        match query_result {
+            Ok(result) => {
+                let _ = result.expect("independent root directory query succeeds");
+            }
+            Err(error) => {
+                query
+                    .join()
+                    .expect("blocked directory query exits after notification cancellation");
+                panic!("independent root directory query did not complete: {error}");
+            }
+        }
+        query.join().expect("directory query worker does not panic");
+    }
+
+    #[test]
+    fn asynchronous_directory_notification_observes_an_immediate_public_documents_change() {
+        let public_documents =
+            PathBuf::from(std::env::var("PUBLIC").expect("PUBLIC is set on Windows")).join("Documents");
+        let temporary_directory = public_documents.join(format!(
+            "ironrdp-rdpdr-async-notify-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time is after the Unix epoch")
+                .as_nanos()
         ));
-        assert!(matches!(
-            RootDirectory::open(Path::new(r"\\server\share\")),
-            Err(STATUS_OBJECT_NAME_INVALID)
+        std::fs::create_dir(&temporary_directory).expect("create temporary directory");
+        let volume_root = temporary_directory
+            .ancestors()
+            .last()
+            .expect("temporary directory has a volume root");
+        let relative_path = temporary_directory
+            .strip_prefix(volume_root)
+            .expect("temporary directory is beneath its volume root");
+        let relative_path = RelativePath::parse(&format!(r"\{}", relative_path.display()))
+            .expect("temporary directory has a valid path");
+
+        let root = RootDirectory::open(volume_root).expect("open temporary volume root");
+        let directory_handle = root
+            .open_relative_directory_for_notification(&relative_path)
+            .expect("open asynchronous directory notification handle")
+            .expect("existing temporary directory")
+            .into_file_handle();
+        let mode: windows::Wdk::Storage::FileSystem::FILE_MODE_INFORMATION = directory_handle
+            .query_information(windows::Wdk::Storage::FileSystem::FileModeInformation)
+            .expect("query asynchronous directory handle mode");
+        assert_eq!(mode.Mode & FILE_SYNCHRONOUS_IO_NONALERT.0, 0);
+        let directory_change = directory_handle
+            .begin_directory_changes(false, 1)
+            .expect("register asynchronous directory notification");
+        let notification_handle = directory_change.handle().0.expose_provenance();
+        let (result_sender, result_receiver) = mpsc::channel();
+        let watcher = thread::spawn(move || {
+            result_sender
+                .send(directory_change.wait())
+                .expect("directory notification result receiver remains available");
+        });
+
+        assert!(
+            matches!(result_receiver.try_recv(), Err(mpsc::TryRecvError::Empty)),
+            "directory notification completed before a change occurred"
+        );
+        std::fs::write(temporary_directory.join("created.txt"), b"created").expect("create watched file");
+        let result = match result_receiver.recv_timeout(Duration::from_secs(2)) {
+            Ok(result) => result,
+            Err(error) => {
+                // SAFETY: the worker owns the asynchronous directory handle
+                // until it reports completion. Cancelling here guarantees the
+                // test can join it before reporting the timeout.
+                let _ = unsafe {
+                    CancelIoEx(
+                        HANDLE(core::ptr::with_exposed_provenance_mut(notification_handle)),
+                        None,
+                    )
+                };
+                let _ = result_receiver
+                    .recv_timeout(Duration::from_secs(1))
+                    .expect("cancelled directory notification worker exits");
+                watcher.join().expect("directory notification worker does not panic");
+                panic!("directory change notification did not complete: {error}");
+            }
+        };
+        watcher.join().expect("directory notification worker does not panic");
+        let result = result.expect("directory notification succeeds");
+
+        assert!(!result.is_empty());
+        std::fs::remove_dir_all(&temporary_directory).expect("remove temporary directory");
+    }
+
+    #[test]
+    fn byte_range_locks_conflict_until_unlocked() {
+        let temporary_directory = std::env::temp_dir();
+        let volume_root = temporary_directory
+            .ancestors()
+            .last()
+            .expect("temporary directory has a volume root");
+        let file_path = temporary_directory.join(format!(
+            "ironrdp-rdpdr-lock-test-{}-{}.bin",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time is after the Unix epoch")
+                .as_nanos()
         ));
+        std::fs::write(&file_path, [0u8; 16]).expect("create temporary test file");
+
+        {
+            let root = RootDirectory::open(volume_root).expect("open temporary volume root");
+            let relative_path = file_path
+                .strip_prefix(volume_root)
+                .expect("temporary file is beneath its volume root");
+            let relative_path = RelativePath::parse(&format!(r"\{}", relative_path.display()))
+                .expect("temporary file has a valid relative path");
+            let options = FileOpenOptions {
+                desired_access: 0x0010_0083,
+                allocation_size: None,
+                file_attributes: FILE_ATTRIBUTE_NORMAL.0,
+                share_access: (FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE).0,
+                create_disposition: FILE_OPEN.0,
+                create_options: 0x0000_0020,
+            };
+            let (first, _) = root
+                .open_relative_file(&relative_path, options)
+                .expect("open first temporary file handle");
+            let (second, _) = root
+                .open_relative_file(&relative_path, options)
+                .expect("open second temporary file handle");
+
+            first.lock_range(0, 8, true).expect("acquire exclusive byte-range lock");
+            assert!(second.lock_range(0, 8, true).is_err());
+            first.unlock_range(0, 8).expect("release exclusive byte-range lock");
+            second.lock_range(0, 8, true).expect("acquire released byte-range lock");
+            second.unlock_range(0, 8).expect("release second byte-range lock");
+        }
+
+        std::fs::remove_file(&file_path).expect("remove temporary test file");
+    }
+
+    #[test]
+    fn multi_range_locks_rollback_on_conflict_and_unlock_all_ranges() {
+        let temporary_directory = std::env::temp_dir();
+        let volume_root = temporary_directory
+            .ancestors()
+            .last()
+            .expect("temporary directory has a volume root");
+        let file_path = temporary_directory.join(format!(
+            "ironrdp-rdpdr-multi-lock-test-{}-{}.bin",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time is after Unix epoch")
+                .as_nanos()
+        ));
+        std::fs::write(&file_path, [0u8; 16]).expect("create temporary test file");
+
+        {
+            let root = RootDirectory::open(volume_root).expect("open temporary volume root");
+            let relative_path = file_path
+                .strip_prefix(volume_root)
+                .expect("temporary file is beneath its volume root");
+            let relative_path = RelativePath::parse(&format!(r"\{}", relative_path.display()))
+                .expect("temporary file has a valid relative path");
+            let options = FileOpenOptions {
+                desired_access: 0x0010_0083,
+                allocation_size: None,
+                file_attributes: FILE_ATTRIBUTE_NORMAL.0,
+                share_access: (FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE).0,
+                create_disposition: FILE_OPEN.0,
+                create_options: 0x0000_0020,
+            };
+            let (first, _) = root
+                .open_relative_file(&relative_path, options)
+                .expect("open first temporary file handle");
+            let (second, _) = root
+                .open_relative_file(&relative_path, options)
+                .expect("open second temporary file handle");
+            let ranges = [(0, 4), (8, 4)];
+
+            first.lock_ranges(&ranges, true).expect("acquire all byte-range locks");
+            assert!(second.lock_range(0, 4, true).is_err());
+            assert!(second.lock_range(8, 4, true).is_err());
+            first.unlock_ranges(&ranges).expect("release all byte-range locks");
+            second
+                .lock_ranges(&ranges, true)
+                .expect("acquire released byte-range locks");
+            second.unlock_ranges(&ranges).expect("release second byte-range locks");
+        }
+
+        std::fs::remove_file(&file_path).expect("remove temporary test file");
+    }
+
+    #[test]
+    fn directory_change_notifications_return_file_notify_information() {
+        let temporary_directory = std::env::temp_dir().join(format!(
+            "ironrdp-rdpdr-notify-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time is after the Unix epoch")
+                .as_nanos()
+        ));
+        std::fs::create_dir(&temporary_directory).expect("create temporary test directory");
+        let volume_root = temporary_directory
+            .ancestors()
+            .last()
+            .expect("temporary directory has a volume root");
+
+        {
+            let root = RootDirectory::open(volume_root).expect("open temporary volume root");
+            let relative_path = temporary_directory
+                .strip_prefix(volume_root)
+                .expect("temporary directory is beneath its volume root");
+            let relative_path = RelativePath::parse(&format!(r"\{}", relative_path.display()))
+                .expect("temporary directory has a valid path");
+            let options = FileOpenOptions {
+                desired_access: 0x0010_0081,
+                allocation_size: None,
+                file_attributes: FILE_ATTRIBUTE_NORMAL.0,
+                share_access: (FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE).0,
+                create_disposition: FILE_OPEN.0,
+                create_options: 0x0000_0021,
+            };
+            let (directory_handle, _) = root
+                .open_relative_file(&relative_path, options)
+                .expect("open directory notification handle");
+            let worker_handle = directory_handle
+                .try_clone()
+                .expect("duplicate directory handle for notification worker");
+            let (sender, receiver) = mpsc::channel();
+            let worker = thread::spawn(move || {
+                sender
+                    .send(worker_handle.read_directory_changes(false, 1))
+                    .expect("directory notification receiver remains available");
+            });
+
+            let mut notification = None;
+            for index in 0..20 {
+                std::fs::write(temporary_directory.join(format!("change-{index}")), b"change")
+                    .expect("create watched file");
+                if let Ok(result) = receiver.recv_timeout(Duration::from_millis(25)) {
+                    notification = Some(result);
+                    break;
+                }
+            }
+
+            let buffer = notification
+                .expect("receive directory notification")
+                .expect("directory notification succeeds");
+            worker.join().expect("directory notification worker does not panic");
+            assert!(buffer.len() >= 12);
+            assert_eq!(
+                u32::from_le_bytes(buffer[4..8].try_into().expect("action is present")),
+                1
+            );
+            assert_ne!(
+                u32::from_le_bytes(buffer[8..12].try_into().expect("file name length is present")),
+                0
+            );
+        }
+
+        std::fs::remove_dir_all(&temporary_directory).expect("remove temporary test directory");
     }
 }

--- a/crates/ironrdp-rdpdr-native/src/windows/handles.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/handles.rs
@@ -242,6 +242,9 @@ pub(crate) struct FileHandle(HANDLE);
 // wrapper has unique ownership and only closes its handle on drop, so moving it
 // between the client and RDP worker threads cannot create concurrent access.
 unsafe impl Send for FileHandle {}
+// SAFETY: shared access only obtains the immutable native handle value. The
+// owning guard closes it once after every shared reference is released.
+unsafe impl Sync for FileHandle {}
 
 /// Synchronous completion from a native offset-based file I/O request.
 #[derive(Clone, Copy, Debug)]
@@ -425,7 +428,7 @@ impl FileHandle {
         // event is owned by `DirectoryChange` until the I/O operation ends.
         let event = unsafe { CreateEventW(None, true, false, None) }?;
         let mut operation = Box::new(DirectoryChange {
-            handle: self,
+            handle: std::sync::Arc::new(self),
             event,
             buffer: vec![0; MAX_DIRECTORY_NOTIFY_SIZE],
             overlapped: OVERLAPPED {
@@ -921,7 +924,7 @@ impl FileHandle {
 
 /// An asynchronous directory-change request registered on a dedicated handle.
 pub(crate) struct DirectoryChange {
-    handle: FileHandle,
+    handle: std::sync::Arc<FileHandle>,
     event: HANDLE,
     buffer: Vec<u8>,
     overlapped: OVERLAPPED,
@@ -932,8 +935,8 @@ pub(crate) struct DirectoryChange {
 unsafe impl Send for DirectoryChange {}
 
 impl DirectoryChange {
-    pub(crate) fn handle(&self) -> HANDLE {
-        self.handle.as_raw()
+    pub(crate) fn cancellation_handle(&self) -> std::sync::Arc<FileHandle> {
+        std::sync::Arc::clone(&self.handle)
     }
 
     #[expect(
@@ -1423,7 +1426,7 @@ mod tests {
         let directory_change = directory_handle
             .begin_directory_changes(false, 1)
             .expect("register asynchronous directory notification");
-        let notification_handle = directory_change.handle().0.expose_provenance();
+        let cancellation_handle = directory_change.cancellation_handle();
         let (result_sender, result_receiver) = mpsc::channel();
         let watcher = thread::spawn(move || {
             result_sender
@@ -1439,15 +1442,9 @@ mod tests {
         let result = match result_receiver.recv_timeout(Duration::from_secs(2)) {
             Ok(result) => result,
             Err(error) => {
-                // SAFETY: the worker owns the asynchronous directory handle
-                // until it reports completion. Cancelling here guarantees the
-                // test can join it before reporting the timeout.
-                let _ = unsafe {
-                    CancelIoEx(
-                        HANDLE(core::ptr::with_exposed_provenance_mut(notification_handle)),
-                        None,
-                    )
-                };
+                // SAFETY: the shared cancellation handle remains open until
+                // this test joins the worker.
+                let _ = unsafe { CancelIoEx(cancellation_handle.as_raw(), None) };
                 let _ = result_receiver
                     .recv_timeout(Duration::from_secs(1))
                     .expect("cancelled directory notification worker exits");

--- a/crates/ironrdp-rdpdr-native/src/windows/locks.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/locks.rs
@@ -1,0 +1,228 @@
+//! Non-blocking byte-range locking for redirected Windows files.
+
+use ironrdp_pdu::PduResult;
+use ironrdp_rdpdr::pdu::RdpdrPdu;
+use ironrdp_rdpdr::pdu::efs::{
+    ClientDriveLockControlResponse, DeviceIoResponse, LockOperation, NtStatus, RdpLockInfo,
+    ServerDriveLockControlRequest,
+};
+use ironrdp_svc::SvcMessage;
+
+use super::backend::WindowsRdpdrBackend;
+use super::file::file_for_request;
+
+pub(crate) fn control(
+    backend: &mut WindowsRdpdrBackend,
+    req: ServerDriveLockControlRequest,
+) -> PduResult<Vec<SvcMessage>> {
+    if req.wait && matches!(req.operation, LockOperation::Shared | LockOperation::Exclusive) {
+        return defer_waiting_lock(backend, req);
+    }
+
+    let status = control_inner(backend, &req).map_or_else(|status| status, |_| NtStatus::SUCCESS);
+    let response = ClientDriveLockControlResponse {
+        device_io_reply: DeviceIoResponse::new(req.device_io_request, status),
+    };
+
+    Ok(vec![SvcMessage::from(RdpdrPdu::ClientDriveLockControlResponse(
+        response,
+    ))])
+}
+
+fn control_inner(backend: &WindowsRdpdrBackend, req: &ServerDriveLockControlRequest) -> Result<(), NtStatus> {
+    if req.locks.is_empty() {
+        return Err(NtStatus::INVALID_PARAMETER);
+    }
+
+    let ranges = normalized_ranges(&req.locks)?;
+    let file = file_for_request(backend, req.device_io_request.device_id, req.device_io_request.file_id)?;
+
+    match req.operation {
+        LockOperation::Shared | LockOperation::Exclusive => file
+            .handle
+            .lock_ranges(&ranges, req.operation == LockOperation::Exclusive)
+            .map_err(|error| lock_error_status(&error)),
+        LockOperation::Unlock | LockOperation::UnlockMultiple => file
+            .handle
+            .unlock_ranges(&ranges)
+            .map_err(|error| lock_error_status(&error)),
+    }
+}
+
+fn defer_waiting_lock(
+    backend: &mut WindowsRdpdrBackend,
+    req: ServerDriveLockControlRequest,
+) -> PduResult<Vec<SvcMessage>> {
+    let ranges = match normalized_ranges(&req.locks) {
+        Ok(ranges) => ranges,
+        Err(status) => return immediate_response(req, status),
+    };
+    let exclusive = match req.operation {
+        LockOperation::Shared => false,
+        LockOperation::Exclusive => true,
+        LockOperation::Unlock | LockOperation::UnlockMultiple => unreachable!("only lock operations are deferred"),
+    };
+
+    match backend.schedule_waiting_lock(req.device_io_request.clone(), ranges, exclusive) {
+        Ok(()) => Ok(Vec::new()),
+        Err(status) => immediate_response(req, status),
+    }
+}
+
+fn immediate_response(req: ServerDriveLockControlRequest, status: NtStatus) -> PduResult<Vec<SvcMessage>> {
+    let response = ClientDriveLockControlResponse {
+        device_io_reply: DeviceIoResponse::new(req.device_io_request, status),
+    };
+    Ok(vec![SvcMessage::from(RdpdrPdu::ClientDriveLockControlResponse(
+        response,
+    ))])
+}
+
+fn normalized_ranges(locks: &[RdpLockInfo]) -> Result<Vec<(u64, u64)>, NtStatus> {
+    if locks.is_empty() {
+        return Err(NtStatus::INVALID_PARAMETER);
+    }
+
+    Ok(locks.iter().map(|lock| (lock.offset, lock.length)).collect())
+}
+
+pub(super) fn lock_error_status(error: &windows::core::Error) -> NtStatus {
+    match u32::from_ne_bytes(error.code().0.to_ne_bytes()) {
+        0x8007_0005 => NtStatus::ACCESS_DENIED,
+        0x8007_0006 => NtStatus::INVALID_HANDLE,
+        0x8007_0021 => NtStatus::LOCK_NOT_GRANTED,
+        0x8007_0057 => NtStatus::INVALID_PARAMETER,
+        _ => NtStatus::UNSUCCESSFUL,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironrdp_rdpdr::pdu::efs::{
+        CreateDisposition, CreateOptions, DesiredAccess, DeviceCreateRequest, DeviceIoRequest, FileAttributes,
+        MajorFunction, MinorFunction, SharedAccess,
+    };
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use crate::windows::factory::RedirectedDrive;
+
+    #[test]
+    fn lock_control_preserves_all_requested_ranges_including_zero_length_regions() {
+        assert_eq!(
+            normalized_ranges(&[
+                RdpLockInfo { offset: 0, length: 0 },
+                RdpLockInfo { offset: 8, length: 4 },
+            ]),
+            Ok(vec![(0, 0), (8, 4)])
+        );
+    }
+
+    #[test]
+    fn lock_control_handles_multiple_ranges_and_waiting_unlocks() {
+        let file_path = std::env::temp_dir().join(format!(
+            "ironrdp-rdpdr-lock-control-test-{}-{}.bin",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock is after Unix epoch")
+                .as_nanos()
+        ));
+        std::fs::write(&file_path, [0u8; 16]).expect("create temporary file");
+        let root_path = file_path
+            .ancestors()
+            .last()
+            .expect("temporary file has a volume root")
+            .to_owned();
+        let relative_path = file_path
+            .strip_prefix(&root_path)
+            .expect("temporary file is beneath its volume root");
+
+        {
+            let drive = RedirectedDrive::new(1, "Test", root_path.clone(), false).expect("valid redirected drive");
+            let mut backend = WindowsRdpdrBackend::from_active_drive(drive);
+            let (file_id, _) = super::super::file::create_inner(
+                &mut backend,
+                &DeviceCreateRequest {
+                    device_io_request: DeviceIoRequest {
+                        device_id: 1,
+                        file_id: 0,
+                        completion_id: 1,
+                        major_function: MajorFunction::Create,
+                        minor_function: MinorFunction::from(0),
+                    },
+                    desired_access: DesiredAccess::from_bits_retain(0x0010_0083),
+                    allocation_size: 0,
+                    file_attributes: FileAttributes::empty(),
+                    shared_access: SharedAccess::from_bits_retain(0x0000_0007),
+                    create_disposition: CreateDisposition::FILE_OPEN,
+                    create_options: CreateOptions::empty(),
+                    path: format!(r"\{}", relative_path.display()),
+                },
+            )
+            .expect("open temporary file");
+            let ranges = vec![
+                RdpLockInfo { offset: 0, length: 4 },
+                RdpLockInfo { offset: 8, length: 4 },
+            ];
+
+            let lock_response = control(
+                &mut backend,
+                ServerDriveLockControlRequest {
+                    device_io_request: DeviceIoRequest {
+                        device_id: 1,
+                        file_id,
+                        completion_id: 2,
+                        major_function: MajorFunction::LockControl,
+                        minor_function: MinorFunction::from(0),
+                    },
+                    operation: LockOperation::Exclusive,
+                    wait: false,
+                    locks: ranges.clone(),
+                },
+            )
+            .expect("lock control response");
+            assert_eq!(lock_response.len(), 1);
+            let lock_response = lock_response
+                .into_iter()
+                .next()
+                .expect("one lock response")
+                .encode_unframed_pdu()
+                .expect("lock response is encodable");
+            assert_eq!(
+                u32::from_le_bytes(lock_response[12..16].try_into().expect("response status is present")),
+                u32::from(NtStatus::SUCCESS)
+            );
+
+            let unlock_response = control(
+                &mut backend,
+                ServerDriveLockControlRequest {
+                    device_io_request: DeviceIoRequest {
+                        device_id: 1,
+                        file_id,
+                        completion_id: 3,
+                        major_function: MajorFunction::LockControl,
+                        minor_function: MinorFunction::from(0),
+                    },
+                    operation: LockOperation::Unlock,
+                    wait: true,
+                    locks: ranges,
+                },
+            )
+            .expect("unlock control response");
+            assert_eq!(unlock_response.len(), 1);
+            let unlock_response = unlock_response
+                .into_iter()
+                .next()
+                .expect("one unlock response")
+                .encode_unframed_pdu()
+                .expect("unlock response is encodable");
+            assert_eq!(
+                u32::from_le_bytes(unlock_response[12..16].try_into().expect("response status is present")),
+                u32::from(NtStatus::SUCCESS)
+            );
+        }
+
+        std::fs::remove_file(&file_path).expect("remove temporary file");
+    }
+}

--- a/crates/ironrdp-rdpdr-native/src/windows/mod.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/mod.rs
@@ -1,9 +1,16 @@
 mod backend;
+mod control;
+mod directory;
 mod factory;
+mod file;
 mod file_table;
 mod handles;
+mod locks;
 mod path;
+mod pending;
+mod security;
 mod status;
+mod volume;
 
 pub use backend::WindowsRdpdrBackend;
 pub use factory::{RedirectedDrive, RedirectedDriveError, WindowsRdpdrBackendFactory};

--- a/crates/ironrdp-rdpdr-native/src/windows/path.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/path.rs
@@ -1,10 +1,8 @@
 //! Validation for server-supplied RDPDR filesystem paths.
 //!
-//! [MS-RDPEFS] 2.2.3.3.1 identifies the drive through the device ID, so a
-//! server-supplied path must name only a descendant of the selected volume.
-//! This module validates that namespace before native handle-relative opens.
-//!
-//! [MS-RDPEFS]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs
+//! RDPDR carries Unicode path strings, but the local Windows namespace has
+//! additional aliases and rooted forms that must never be resolved outside an
+//! announced volume root.
 
 const MAX_PATH_CODE_UNITS: usize = 32_767;
 const MAX_COMPONENT_CODE_UNITS: usize = 255;
@@ -18,13 +16,14 @@ pub(crate) struct RelativePath {
 impl RelativePath {
     /// Parses an RDPDR path without resolving it in the host filesystem.
     ///
-    /// RDPDR represents the selected volume root by an empty path or one
-    /// leading backslash. The leading separator is protocol syntax only; it is
-    /// never passed to a Win32 path join operation.
+    /// A single leading backslash is the protocol's root-relative spelling and
+    /// is stripped before later handle-relative opens. It is not passed to a
+    /// Win32 path join operation.
     pub(crate) fn parse(path: &str) -> Result<Self, PathPolicyError> {
         if path.encode_utf16().count() > MAX_PATH_CODE_UNITS {
             return Err(PathPolicyError::TooLong);
         }
+
         if path.starts_with('/') || path.starts_with(r"\\") {
             return Err(PathPolicyError::Rooted);
         }
@@ -35,8 +34,12 @@ impl RelativePath {
         }
 
         let components = path.split('\\').collect::<Vec<_>>();
-        for component in &components {
-            validate_component(component)?;
+        for (index, component) in components.iter().enumerate() {
+            if index + 1 == components.len() {
+                validate_final_component(component)?;
+            } else {
+                validate_filename(component)?;
+            }
         }
 
         Ok(Self {
@@ -56,13 +59,39 @@ pub(crate) enum PathPolicyError {
     Rooted,
     /// A path component is empty, a traversal marker, or contains an invalid character.
     InvalidComponent,
-    /// A path component is a Windows DOS device alias.
+    /// A component is a Windows DOS device alias.
     ReservedDevice,
     /// The path or a component exceeds the bounded native namespace policy.
     TooLong,
 }
 
-fn validate_component(component: &str) -> Result<(), PathPolicyError> {
+fn validate_final_component(component: &str) -> Result<(), PathPolicyError> {
+    let mut components = component.split(':');
+    let file_name = components.next().expect("split always returns an initial component");
+    validate_filename(file_name)?;
+
+    let Some(stream_name) = components.next() else {
+        return Ok(());
+    };
+    let stream_type = components.next();
+    if components.next().is_some() {
+        return Err(PathPolicyError::InvalidComponent);
+    }
+    if stream_name.is_empty() && stream_type.is_none() {
+        return Err(PathPolicyError::InvalidComponent);
+    }
+    validate_stream_name(stream_name)?;
+    if let Some(stream_type) = stream_type {
+        if stream_type.is_empty() {
+            return Err(PathPolicyError::InvalidComponent);
+        }
+        validate_stream_type(stream_type)?;
+    }
+
+    Ok(())
+}
+
+fn validate_filename(component: &str) -> Result<(), PathPolicyError> {
     if component.is_empty() || matches!(component, "." | "..") {
         return Err(PathPolicyError::InvalidComponent);
     }
@@ -79,6 +108,31 @@ fn validate_component(component: &str) -> Result<(), PathPolicyError> {
     }
     if is_reserved_device_name(component) {
         return Err(PathPolicyError::ReservedDevice);
+    }
+
+    Ok(())
+}
+
+fn validate_stream_name(component: &str) -> Result<(), PathPolicyError> {
+    if component.encode_utf16().count() > MAX_COMPONENT_CODE_UNITS {
+        return Err(PathPolicyError::TooLong);
+    }
+    if component
+        .chars()
+        .any(|character| matches!(character, '\0' | '\\' | '/' | ':'))
+    {
+        return Err(PathPolicyError::InvalidComponent);
+    }
+
+    Ok(())
+}
+
+fn validate_stream_type(component: &str) -> Result<(), PathPolicyError> {
+    if component
+        .chars()
+        .any(|character| matches!(character, '\0' | '\\' | '/' | ':'))
+    {
+        return Err(PathPolicyError::InvalidComponent);
     }
 
     Ok(())
@@ -123,24 +177,19 @@ mod tests {
 
     #[test]
     fn accepts_the_redirected_volume_root() {
-        assert!(
-            RelativePath::parse(r"\")
-                .expect("redirected root")
-                .components()
-                .next()
-                .is_none()
-        );
+        let path = RelativePath::parse(r"\").expect("redirected root");
+
+        assert!(path.components().next().is_none());
     }
 
     #[test]
-    fn rejects_host_namespace_paths_traversal_and_streams() {
+    fn rejects_rooted_host_paths_and_traversal() {
         for path in [
             r"\\server\share",
             r"\??\C:\outside",
             r"C:\outside",
             r"..\outside",
             r"one\\two",
-            "file:stream",
         ] {
             assert!(matches!(
                 RelativePath::parse(path),
@@ -151,8 +200,46 @@ mod tests {
 
     #[test]
     fn rejects_dos_device_aliases_in_every_component() {
-        for path in ["CON", "con.txt", r"folder\LPT9", "COM\u{00B9}", "AUX", "clock$"] {
+        for path in [
+            "CON",
+            "con.txt",
+            "CON:stream",
+            r"folder\LPT9",
+            "COM\u{00B9}",
+            "AUX",
+            "clock$",
+        ] {
             assert_eq!(RelativePath::parse(path), Err(PathPolicyError::ReservedDevice));
         }
+    }
+
+    #[test]
+    fn rejects_aliasing_and_invalid_characters() {
+        for path in ["name. ", "name.", "file:", "file:stream:", "embedded\0nul", "one/two"] {
+            assert_eq!(RelativePath::parse(path), Err(PathPolicyError::InvalidComponent));
+        }
+    }
+
+    #[test]
+    fn accepts_alternate_data_streams_on_the_final_component_only() {
+        let path = RelativePath::parse(r"\folder\file:Zone.Identifier").expect("valid alternate data stream pathname");
+        assert_eq!(
+            path.components().collect::<Vec<_>>(),
+            ["folder", "file:Zone.Identifier"]
+        );
+        assert!(RelativePath::parse(r"\file::$DATA").is_ok());
+        assert_eq!(
+            RelativePath::parse(r"\folder:stream\file"),
+            Err(PathPolicyError::InvalidComponent)
+        );
+        assert_eq!(
+            RelativePath::parse(r"\file:stream:type:extra"),
+            Err(PathPolicyError::InvalidComponent)
+        );
+    }
+
+    #[test]
+    fn accepts_non_ascii_components_without_panicking() {
+        assert!(RelativePath::parse("CO\u{80}").is_ok());
     }
 }

--- a/crates/ironrdp-rdpdr-native/src/windows/pending.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/pending.rs
@@ -1,0 +1,742 @@
+//! Deferred Windows RDPDR IRP completion and cancellation bookkeeping.
+
+use core::sync::atomic::{AtomicBool, Ordering};
+use core::time::Duration;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use ironrdp_rdpdr::pdu::RdpdrPdu;
+use ironrdp_rdpdr::pdu::efs::{
+    ClientDriveLockControlResponse, ClientDriveNotifyChangeDirectoryResponse, DeviceIoRequest, NtStatus,
+    ServerDriveNotifyChangeDirectoryRequest,
+};
+use ironrdp_svc::SvcMessage;
+use windows::Win32::System::IO::CancelIoEx;
+
+use super::handles::{DirectoryChange, FileHandle};
+use super::locks::lock_error_status;
+
+const MAX_DEFERRED_OPERATIONS: usize = 128;
+const LOCK_RETRY_INTERVAL: Duration = Duration::from_millis(25);
+
+#[derive(Debug)]
+pub(super) struct DeferredOperations {
+    next_operation_id: u64,
+    epoch: u64,
+    operations: HashMap<u64, PendingLockOperation>,
+    notifications: HashMap<u64, PendingDirectoryNotification>,
+    completions: Arc<Mutex<Vec<DeferredCompletion>>>,
+}
+
+#[derive(Debug)]
+struct PendingLockOperation {
+    device_id: u32,
+    file_id: u32,
+    request: DeviceIoRequest,
+    ranges: Vec<(u64, u64)>,
+    handle: FileHandle,
+    cancellation: Arc<LockCancellation>,
+    worker: thread::JoinHandle<()>,
+}
+
+#[derive(Debug)]
+struct LockCancellation {
+    cancelled: AtomicBool,
+    acquired: AtomicBool,
+    released: AtomicBool,
+}
+
+#[derive(Debug)]
+struct PendingDirectoryNotification {
+    device_id: u32,
+    file_id: u32,
+    request: DeviceIoRequest,
+    handle: usize,
+    cancellation: Arc<DirectoryCancellation>,
+    worker: thread::JoinHandle<()>,
+}
+
+#[derive(Debug)]
+struct DirectoryCancellation {
+    cancelled: AtomicBool,
+    finished: AtomicBool,
+}
+
+struct DirectoryWorkerFinished<'a>(&'a DirectoryCancellation);
+
+impl Drop for DirectoryWorkerFinished<'_> {
+    fn drop(&mut self) {
+        self.0.finished.store(true, Ordering::Release);
+    }
+}
+
+#[derive(Debug)]
+struct DeferredCompletion {
+    operation_id: u64,
+    epoch: u64,
+    message: SvcMessage,
+}
+
+impl DeferredOperations {
+    pub(super) fn new() -> Self {
+        Self {
+            next_operation_id: 1,
+            epoch: 0,
+            operations: HashMap::new(),
+            notifications: HashMap::new(),
+            completions: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    pub(super) fn schedule_waiting_lock(
+        &mut self,
+        request: DeviceIoRequest,
+        ranges: Vec<(u64, u64)>,
+        exclusive: bool,
+        handle: FileHandle,
+    ) -> Result<(), NtStatus> {
+        if self.len() == MAX_DEFERRED_OPERATIONS {
+            return Err(NtStatus::UNSUCCESSFUL);
+        }
+
+        let operation_id = self.allocate_operation_id()?;
+        let cancellation = Arc::new(LockCancellation {
+            cancelled: AtomicBool::new(false),
+            acquired: AtomicBool::new(false),
+            released: AtomicBool::new(false),
+        });
+        let cancellation_handle = handle.try_clone().map_err(|_| NtStatus::UNSUCCESSFUL)?;
+        let completions = Arc::clone(&self.completions);
+        let epoch = self.epoch;
+        let worker_request = request.clone();
+        let worker_ranges = ranges.clone();
+        let worker_cancellation = Arc::clone(&cancellation);
+        let worker = thread::Builder::new()
+            .name("ironrdp-rdpdr-lock".to_owned())
+            .spawn(move || {
+                wait_for_lock(
+                    operation_id,
+                    epoch,
+                    worker_request,
+                    worker_ranges,
+                    exclusive,
+                    handle,
+                    worker_cancellation,
+                    completions,
+                )
+            })
+            .map_err(|_| NtStatus::UNSUCCESSFUL)?;
+        let previous = self.operations.insert(
+            operation_id,
+            PendingLockOperation {
+                device_id: request.device_id,
+                file_id: request.file_id,
+                request,
+                ranges,
+                handle: cancellation_handle,
+                cancellation,
+                worker,
+            },
+        );
+        debug_assert!(previous.is_none(), "deferred RDPDR operation IDs never collide");
+
+        Ok(())
+    }
+
+    pub(super) fn schedule_directory_notification(
+        &mut self,
+        request: ServerDriveNotifyChangeDirectoryRequest,
+        handle: FileHandle,
+    ) -> Result<(), NtStatus> {
+        if self.len() == MAX_DEFERRED_OPERATIONS {
+            return Err(NtStatus::UNSUCCESSFUL);
+        }
+
+        let operation_id = self.allocate_operation_id()?;
+        let cancellation = Arc::new(DirectoryCancellation {
+            cancelled: AtomicBool::new(false),
+            finished: AtomicBool::new(false),
+        });
+        let completions = Arc::clone(&self.completions);
+        let epoch = self.epoch;
+        let worker_request = request.device_io_request.clone();
+        let worker_cancellation = Arc::clone(&cancellation);
+        let watch_tree = request.watch_tree != 0;
+        let completion_filter = request.completion_filter;
+        let dispatch = tracing::dispatcher::get_default(Clone::clone);
+        let directory_change = handle
+            .begin_directory_changes(watch_tree, completion_filter)
+            .map_err(|error| lock_error_status(&error))?;
+        let notification_handle = directory_change.handle().0.expose_provenance();
+        let worker = thread::Builder::new()
+            .name("ironrdp-rdpdr-notify".to_owned())
+            .spawn(move || {
+                tracing::dispatcher::with_default(&dispatch, || {
+                    wait_for_directory_change(
+                        operation_id,
+                        epoch,
+                        worker_request,
+                        directory_change,
+                        worker_cancellation,
+                        completions,
+                    )
+                })
+            })
+            .map_err(|_| NtStatus::UNSUCCESSFUL)?;
+        let previous = self.notifications.insert(
+            operation_id,
+            PendingDirectoryNotification {
+                device_id: request.device_io_request.device_id,
+                file_id: request.device_io_request.file_id,
+                request: request.device_io_request,
+                handle: notification_handle,
+                cancellation,
+                worker,
+            },
+        );
+        debug_assert!(previous.is_none(), "deferred RDPDR operation IDs never collide");
+        Ok(())
+    }
+
+    pub(super) fn poll(&mut self) -> Vec<SvcMessage> {
+        let completions = {
+            let mut completions = self
+                .completions
+                .lock()
+                .expect("deferred RDPDR completion queue mutex must not be poisoned");
+            core::mem::take(&mut *completions)
+        };
+        if !completions.is_empty() {
+            tracing::debug!(
+                count = completions.len(),
+                "Draining completed RDPDR deferred operations"
+            );
+        }
+
+        completions
+            .into_iter()
+            .filter_map(|completion| {
+                let is_pending = if let Some(operation) = self.operations.remove(&completion.operation_id) {
+                    join_lock_worker(operation);
+                    true
+                } else if let Some(notification) = self.notifications.remove(&completion.operation_id) {
+                    join_directory_worker(notification);
+                    true
+                } else {
+                    false
+                };
+                (completion.epoch == self.epoch && is_pending).then_some(completion.message)
+            })
+            .collect()
+    }
+
+    pub(super) fn cancel_file(&mut self, device_id: u32, file_id: u32) -> Vec<SvcMessage> {
+        let operation_ids = self
+            .operations
+            .iter()
+            .filter_map(|(&operation_id, operation)| {
+                (operation.device_id == device_id && operation.file_id == file_id).then_some(operation_id)
+            })
+            .collect::<Vec<_>>();
+        let notification_ids = self
+            .notifications
+            .iter()
+            .filter_map(|(&operation_id, notification)| {
+                (notification.device_id == device_id && notification.file_id == file_id).then_some(operation_id)
+            })
+            .collect::<Vec<_>>();
+
+        let mut cancelled = Vec::with_capacity(operation_ids.len() + notification_ids.len());
+        for operation_id in &operation_ids {
+            let operation = self
+                .operations
+                .remove(operation_id)
+                .expect("operation ID was collected from the pending operation table");
+            let request = operation.request.clone();
+            cancel_lock_operation(operation);
+            cancelled.push(lock_completion(request, NtStatus::CANCELLED));
+        }
+        for operation_id in &notification_ids {
+            let notification = self
+                .notifications
+                .remove(operation_id)
+                .expect("operation ID was collected from the pending notification table");
+            let request = notification.request.clone();
+            cancel_directory_notification(notification);
+            cancelled.push(directory_completion(request, NtStatus::SUCCESS, Vec::new()));
+        }
+        self.discard_queued(&operation_ids);
+        self.discard_queued(&notification_ids);
+        cancelled
+    }
+
+    pub(super) fn cancel_drive(&mut self, device_id: u32) -> Vec<SvcMessage> {
+        let operation_ids = self
+            .operations
+            .iter()
+            .filter_map(|(&operation_id, operation)| (operation.device_id == device_id).then_some(operation_id))
+            .collect::<Vec<_>>();
+        let notification_ids = self
+            .notifications
+            .iter()
+            .filter_map(|(&operation_id, notification)| (notification.device_id == device_id).then_some(operation_id))
+            .collect::<Vec<_>>();
+
+        let mut cancelled = Vec::with_capacity(operation_ids.len() + notification_ids.len());
+        for operation_id in &operation_ids {
+            let operation = self
+                .operations
+                .remove(operation_id)
+                .expect("operation ID was collected from the pending operation table");
+            let request = operation.request.clone();
+            cancel_lock_operation(operation);
+            cancelled.push(lock_completion(request, NtStatus::CANCELLED));
+        }
+        for operation_id in &notification_ids {
+            let notification = self
+                .notifications
+                .remove(operation_id)
+                .expect("operation ID was collected from the pending notification table");
+            let request = notification.request.clone();
+            cancel_directory_notification(notification);
+            cancelled.push(directory_completion(request, NtStatus::CANCELLED, Vec::new()));
+        }
+        self.discard_queued(&operation_ids);
+        self.discard_queued(&notification_ids);
+        cancelled
+    }
+
+    pub(super) fn reset(&mut self) {
+        self.cancel_matching(|_| true);
+        self.cancel_notifications(|_| true);
+        self.epoch = self.epoch.wrapping_add(1);
+    }
+
+    fn cancel_matching(&mut self, predicate: impl Fn(&PendingLockOperation) -> bool) {
+        let operation_ids = self
+            .operations
+            .iter()
+            .filter_map(|(&operation_id, operation)| predicate(operation).then_some(operation_id))
+            .collect::<Vec<_>>();
+        for operation_id in &operation_ids {
+            let operation = self
+                .operations
+                .remove(operation_id)
+                .expect("operation ID was collected from the pending operation table");
+            cancel_lock_operation(operation);
+        }
+        self.discard_queued(&operation_ids);
+    }
+
+    fn cancel_notifications(&mut self, predicate: impl Fn(&PendingDirectoryNotification) -> bool) {
+        let operation_ids = self
+            .notifications
+            .iter()
+            .filter_map(|(&operation_id, notification)| predicate(notification).then_some(operation_id))
+            .collect::<Vec<_>>();
+        for operation_id in &operation_ids {
+            let notification = self
+                .notifications
+                .remove(operation_id)
+                .expect("operation ID was collected from the pending notification table");
+            cancel_directory_notification(notification);
+        }
+        self.discard_queued(&operation_ids);
+    }
+
+    fn allocate_operation_id(&mut self) -> Result<u64, NtStatus> {
+        let operation_id = self.next_operation_id;
+        self.next_operation_id = self.next_operation_id.checked_add(1).ok_or(NtStatus::UNSUCCESSFUL)?;
+        Ok(operation_id)
+    }
+
+    fn len(&self) -> usize {
+        self.operations.len() + self.notifications.len()
+    }
+
+    fn discard_queued(&self, operation_ids: &[u64]) {
+        if operation_ids.is_empty() {
+            return;
+        }
+
+        self.completions
+            .lock()
+            .expect("deferred RDPDR completion queue mutex must not be poisoned")
+            .retain(|completion| !operation_ids.contains(&completion.operation_id));
+    }
+}
+
+impl Drop for DeferredOperations {
+    fn drop(&mut self) {
+        self.cancel_matching(|_| true);
+        self.cancel_notifications(|_| true);
+    }
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the worker requires the full deferred-operation ownership and completion context"
+)]
+fn wait_for_lock(
+    operation_id: u64,
+    epoch: u64,
+    request: DeviceIoRequest,
+    ranges: Vec<(u64, u64)>,
+    exclusive: bool,
+    handle: FileHandle,
+    cancellation: Arc<LockCancellation>,
+    completions: Arc<Mutex<Vec<DeferredCompletion>>>,
+) {
+    loop {
+        if cancellation.cancelled.load(Ordering::Acquire) {
+            return;
+        }
+
+        match handle.lock_ranges(&ranges, exclusive) {
+            Ok(()) => {
+                cancellation.acquired.store(true, Ordering::Release);
+                if cancellation.cancelled.load(Ordering::Acquire) {
+                    release_cancelled_lock(&handle, &ranges, &cancellation, request.file_id);
+                    return;
+                }
+
+                queue_completion(
+                    &completions,
+                    DeferredCompletion {
+                        operation_id,
+                        epoch,
+                        message: lock_completion(request, NtStatus::SUCCESS),
+                    },
+                );
+                return;
+            }
+            Err(error) if lock_error_status(&error) == NtStatus::LOCK_NOT_GRANTED => {
+                thread::sleep(LOCK_RETRY_INTERVAL);
+            }
+            Err(error) => {
+                if !cancellation.cancelled.load(Ordering::Acquire) {
+                    queue_completion(
+                        &completions,
+                        DeferredCompletion {
+                            operation_id,
+                            epoch,
+                            message: lock_completion(request, lock_error_status(&error)),
+                        },
+                    );
+                }
+                return;
+            }
+        }
+    }
+}
+
+fn wait_for_directory_change(
+    operation_id: u64,
+    epoch: u64,
+    request: DeviceIoRequest,
+    directory_change: Box<DirectoryChange>,
+    cancellation: Arc<DirectoryCancellation>,
+    completions: Arc<Mutex<Vec<DeferredCompletion>>>,
+) {
+    let _finished = DirectoryWorkerFinished(&cancellation);
+    if cancellation.cancelled.load(Ordering::Acquire) {
+        tracing::debug!(operation_id, "Cancelled RDPDR directory notification before waiting");
+        return;
+    }
+
+    tracing::debug!(operation_id, "Waiting for RDPDR directory notification");
+    match directory_change.wait() {
+        Ok(buffer) if !cancellation.cancelled.load(Ordering::Acquire) => queue_completion(
+            &completions,
+            DeferredCompletion {
+                operation_id,
+                epoch,
+                message: directory_completion(request, NtStatus::SUCCESS, buffer),
+            },
+        ),
+        Ok(_) => tracing::debug!(operation_id, "Discarded cancelled RDPDR directory notification"),
+        Err(error) if !cancellation.cancelled.load(Ordering::Acquire) => {
+            tracing::debug!(error = %error, "RDPDR directory notification failed");
+            queue_completion(
+                &completions,
+                DeferredCompletion {
+                    operation_id,
+                    epoch,
+                    message: directory_completion(request, lock_error_status(&error), Vec::new()),
+                },
+            );
+        }
+        Err(_) => tracing::debug!(operation_id, "Discarded cancelled RDPDR directory notification failure"),
+    }
+}
+
+fn queue_completion(completions: &Mutex<Vec<DeferredCompletion>>, completion: DeferredCompletion) {
+    tracing::debug!(
+        operation_id = completion.operation_id,
+        "Queued completed RDPDR deferred operation"
+    );
+    completions
+        .lock()
+        .expect("deferred RDPDR completion queue mutex must not be poisoned")
+        .push(completion);
+}
+
+fn lock_completion(request: DeviceIoRequest, status: NtStatus) -> SvcMessage {
+    SvcMessage::from(RdpdrPdu::ClientDriveLockControlResponse(
+        ClientDriveLockControlResponse::new(request, status),
+    ))
+}
+
+fn directory_completion(request: DeviceIoRequest, status: NtStatus, buffer: Vec<u8>) -> SvcMessage {
+    SvcMessage::from(RdpdrPdu::ClientDriveNotifyChangeDirectoryResponse(
+        ClientDriveNotifyChangeDirectoryResponse::new(request, status, buffer),
+    ))
+}
+
+fn join_lock_worker(operation: PendingLockOperation) {
+    join_worker(operation.worker, operation.file_id, "lock");
+}
+
+fn cancel_lock_operation(operation: PendingLockOperation) {
+    operation.cancellation.cancelled.store(true, Ordering::Release);
+    let file_id = operation.file_id;
+    let ranges = &operation.ranges;
+    let cancellation = &operation.cancellation;
+    join_worker(operation.worker, file_id, "lock");
+    release_cancelled_lock(&operation.handle, ranges, cancellation, file_id);
+}
+
+fn release_cancelled_lock(handle: &FileHandle, ranges: &[(u64, u64)], cancellation: &LockCancellation, file_id: u32) {
+    if cancellation.acquired.load(Ordering::Acquire)
+        && cancellation
+            .released
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        && let Err(error) = handle.unlock_ranges(ranges)
+    {
+        tracing::warn!(error = %error, file_id, "Failed to release cancelled deferred RDPDR lock");
+    }
+}
+
+fn join_directory_worker(notification: PendingDirectoryNotification) {
+    join_worker(notification.worker, notification.file_id, "directory notification");
+}
+
+fn join_worker(worker: thread::JoinHandle<()>, file_id: u32, operation: &str) {
+    if worker.join().is_err() {
+        tracing::error!(file_id, operation, "Deferred RDPDR worker panicked");
+    }
+}
+
+fn cancel_directory_notification(notification: PendingDirectoryNotification) {
+    notification.cancellation.cancelled.store(true, Ordering::Release);
+
+    while !notification.cancellation.finished.load(Ordering::Acquire) {
+        // SAFETY: the worker owns the duplicated asynchronous directory handle
+        // until it marks itself finished. Repeating the cancellation closes the
+        // race where this thread requests cancellation before the I/O manager
+        // has observed the just-submitted notification request.
+        let _ = unsafe {
+            CancelIoEx(
+                windows::Win32::Foundation::HANDLE(core::ptr::with_exposed_provenance_mut(notification.handle)),
+                None,
+            )
+        };
+        thread::sleep(Duration::from_millis(1));
+    }
+    join_directory_worker(notification);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironrdp_rdpdr::pdu::efs::{MajorFunction, MinorFunction};
+    use windows::Wdk::Storage::FileSystem::FILE_OPEN;
+    use windows::Win32::Storage::FileSystem::{
+        FILE_ATTRIBUTE_NORMAL, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+    };
+
+    use crate::windows::handles::{FileOpenOptions, RootDirectory};
+    use crate::windows::path::RelativePath;
+
+    #[test]
+    fn cancelling_a_waiting_lock_completes_once_and_discards_a_late_worker_result() {
+        let temporary_directory = std::env::temp_dir();
+        let volume_root = temporary_directory
+            .ancestors()
+            .last()
+            .expect("temporary directory has a volume root");
+        let file_path = temporary_directory.join(format!(
+            "ironrdp-rdpdr-deferred-lock-test-{}-{}.bin",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time is after the Unix epoch")
+                .as_nanos()
+        ));
+        std::fs::write(&file_path, [0u8; 16]).expect("create temporary test file");
+
+        let root = RootDirectory::open(volume_root).expect("open temporary volume root");
+        let relative_path = file_path
+            .strip_prefix(volume_root)
+            .expect("temporary file is beneath its volume root");
+        let relative_path =
+            RelativePath::parse(&format!(r"\{}", relative_path.display())).expect("temporary file has a valid path");
+        let options = FileOpenOptions {
+            desired_access: 0x0010_0083,
+            allocation_size: None,
+            file_attributes: FILE_ATTRIBUTE_NORMAL.0,
+            share_access: (FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE).0,
+            create_disposition: FILE_OPEN.0,
+            create_options: 0x0000_0020,
+        };
+        let (locking_handle, _) = root
+            .open_relative_file(&relative_path, options)
+            .expect("open first temporary file handle");
+        let (waiting_handle, _) = root
+            .open_relative_file(&relative_path, options)
+            .expect("open second temporary file handle");
+        locking_handle
+            .lock_range(0, 8, true)
+            .expect("acquire exclusive byte-range lock");
+
+        let mut operations = DeferredOperations::new();
+        operations
+            .schedule_waiting_lock(
+                DeviceIoRequest {
+                    device_id: 1,
+                    file_id: 7,
+                    completion_id: 3,
+                    major_function: MajorFunction::LockControl,
+                    minor_function: MinorFunction::from(0),
+                },
+                vec![(0, 8)],
+                true,
+                waiting_handle,
+            )
+            .expect("schedule waiting lock");
+
+        let cancelled = operations.cancel_file(1, 7);
+        assert_eq!(cancelled.len(), 1);
+        let response = cancelled
+            .into_iter()
+            .next()
+            .expect("the cancelled lock has one completion")
+            .encode_unframed_pdu()
+            .expect("the cancellation completion is encodable");
+        assert_eq!(
+            u32::from_le_bytes(response[12..16].try_into().expect("response status is present")),
+            u32::from(NtStatus::CANCELLED)
+        );
+        assert!(operations.poll().is_empty());
+
+        let (drive_waiting_handle, _) = root
+            .open_relative_file(&relative_path, options)
+            .expect("open third temporary file handle");
+        operations
+            .schedule_waiting_lock(
+                DeviceIoRequest {
+                    device_id: 1,
+                    file_id: 8,
+                    completion_id: 4,
+                    major_function: MajorFunction::LockControl,
+                    minor_function: MinorFunction::from(0),
+                },
+                vec![(0, 8)],
+                true,
+                drive_waiting_handle,
+            )
+            .expect("schedule waiting drive lock");
+
+        let cancelled = operations.cancel_drive(1);
+        assert_eq!(cancelled.len(), 1);
+        let response = cancelled
+            .into_iter()
+            .next()
+            .expect("the removed drive has one cancellation completion")
+            .encode_unframed_pdu()
+            .expect("the cancellation completion is encodable");
+        assert_eq!(
+            u32::from_le_bytes(response[12..16].try_into().expect("response status is present")),
+            u32::from(NtStatus::CANCELLED)
+        );
+        assert!(operations.poll().is_empty());
+
+        locking_handle
+            .unlock_range(0, 8)
+            .expect("release exclusive byte-range lock");
+        std::fs::remove_file(&file_path).expect("remove temporary test file");
+    }
+
+    #[test]
+    fn closing_a_directory_watch_returns_a_successful_empty_completion() {
+        let temporary_directory = std::env::temp_dir().join(format!(
+            "ironrdp-rdpdr-deferred-notify-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time is after the Unix epoch")
+                .as_nanos()
+        ));
+        std::fs::create_dir(&temporary_directory).expect("create temporary test directory");
+        let volume_root = temporary_directory
+            .ancestors()
+            .last()
+            .expect("temporary directory has a volume root");
+
+        {
+            let root = RootDirectory::open(volume_root).expect("open temporary volume root");
+            let relative_path = temporary_directory
+                .strip_prefix(volume_root)
+                .expect("temporary directory is beneath its volume root");
+            let relative_path = RelativePath::parse(&format!(r"\{}", relative_path.display()))
+                .expect("temporary directory has a valid path");
+            let directory_handle = root
+                .open_relative_directory_for_notification(&relative_path)
+                .expect("open asynchronous directory notification handle")
+                .expect("existing temporary directory")
+                .into_file_handle();
+
+            let mut operations = DeferredOperations::new();
+            operations
+                .schedule_directory_notification(
+                    ServerDriveNotifyChangeDirectoryRequest {
+                        device_io_request: DeviceIoRequest {
+                            device_id: 1,
+                            file_id: 7,
+                            completion_id: 3,
+                            major_function: MajorFunction::DirectoryControl,
+                            minor_function: MinorFunction::IRP_MN_NOTIFY_CHANGE_DIRECTORY,
+                        },
+                        watch_tree: 0,
+                        completion_filter: 1,
+                    },
+                    directory_handle
+                        .try_clone()
+                        .expect("duplicate directory handle for notification worker"),
+                )
+                .expect("schedule directory notification");
+
+            let cancelled = operations.cancel_file(1, 7);
+            assert_eq!(cancelled.len(), 1);
+            let response = cancelled
+                .into_iter()
+                .next()
+                .expect("the cancelled notification has one completion")
+                .encode_unframed_pdu()
+                .expect("the cancellation completion is encodable");
+            assert_eq!(
+                u32::from_le_bytes(response[12..16].try_into().expect("response status is present")),
+                u32::from(NtStatus::SUCCESS)
+            );
+            assert_eq!(
+                u32::from_le_bytes(response[16..20].try_into().expect("response length is present")),
+                0
+            );
+            assert!(operations.poll().is_empty());
+        }
+
+        std::fs::remove_dir_all(&temporary_directory).expect("remove temporary test directory");
+    }
+}

--- a/crates/ironrdp-rdpdr-native/src/windows/pending.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/pending.rs
@@ -6,16 +6,14 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
+use super::handles::{DirectoryChange, FileHandle};
+use super::locks::lock_error_status;
 use ironrdp_rdpdr::pdu::RdpdrPdu;
 use ironrdp_rdpdr::pdu::efs::{
     ClientDriveLockControlResponse, ClientDriveNotifyChangeDirectoryResponse, DeviceIoRequest, NtStatus,
     ServerDriveNotifyChangeDirectoryRequest,
 };
 use ironrdp_svc::SvcMessage;
-use windows::Win32::System::IO::CancelIoEx;
-
-use super::handles::{DirectoryChange, FileHandle};
-use super::locks::lock_error_status;
 
 const MAX_DEFERRED_OPERATIONS: usize = 128;
 const LOCK_RETRY_INTERVAL: Duration = Duration::from_millis(25);
@@ -52,7 +50,7 @@ struct PendingDirectoryNotification {
     device_id: u32,
     file_id: u32,
     request: DeviceIoRequest,
-    handle: usize,
+    handle: Arc<FileHandle>,
     cancellation: Arc<DirectoryCancellation>,
     worker: thread::JoinHandle<()>,
 }
@@ -168,7 +166,7 @@ impl DeferredOperations {
         let directory_change = handle
             .begin_directory_changes(watch_tree, completion_filter)
             .map_err(|error| lock_error_status(&error))?;
-        let notification_handle = directory_change.handle().0.expose_provenance();
+        let notification_handle = directory_change.cancellation_handle();
         let worker = thread::Builder::new()
             .name("ironrdp-rdpdr-notify".to_owned())
             .spawn(move || {
@@ -537,12 +535,7 @@ fn cancel_directory_notification(notification: PendingDirectoryNotification) {
         // until it marks itself finished. Repeating the cancellation closes the
         // race where this thread requests cancellation before the I/O manager
         // has observed the just-submitted notification request.
-        let _ = unsafe {
-            CancelIoEx(
-                windows::Win32::Foundation::HANDLE(core::ptr::with_exposed_provenance_mut(notification.handle)),
-                None,
-            )
-        };
+        let _ = unsafe { windows::Win32::System::IO::CancelIoEx(notification.handle.as_raw(), None) };
         thread::sleep(Duration::from_millis(1));
     }
     join_directory_worker(notification);

--- a/crates/ironrdp-rdpdr-native/src/windows/security.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/security.rs
@@ -1,0 +1,809 @@
+use ironrdp_pdu::{PduResult, encode_err};
+use ironrdp_rdpdr::pdu::RdpdrPdu;
+use ironrdp_rdpdr::pdu::efs::{
+    ClientDriveQuerySecurityResponse, ClientDriveSetSecurityResponse, DeviceIoResponse, NtStatus, SecurityInformation,
+    ServerDriveQuerySecurityRequest, ServerDriveSetSecurityRequest,
+};
+use ironrdp_svc::SvcMessage;
+use windows::Win32::Foundation::{
+    CloseHandle, ERROR_ACCESS_DENIED, ERROR_INVALID_PARAMETER, ERROR_INVALID_SECURITY_DESCR, ERROR_NO_TOKEN,
+    ERROR_NOT_ALL_ASSIGNED, ERROR_PRIVILEGE_NOT_HELD, ERROR_SUCCESS, GetLastError, HANDLE, HLOCAL, LUID, LocalFree,
+    SetLastError, WIN32_ERROR,
+};
+use windows::Win32::Security::Authorization::{GetSecurityInfo, SE_FILE_OBJECT, SetSecurityInfo};
+use windows::Win32::Security::{
+    ACL, AdjustTokenPrivileges, GetSecurityDescriptorDacl, GetSecurityDescriptorGroup, GetSecurityDescriptorLength,
+    GetSecurityDescriptorOwner, GetSecurityDescriptorSacl, ImpersonateSelf, IsValidSecurityDescriptor,
+    LUID_AND_ATTRIBUTES, LookupPrivilegeValueW, OBJECT_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR, PSID, RevertToSelf,
+    SE_BACKUP_NAME, SE_PRIVILEGE_ENABLED, SE_RESTORE_NAME, SE_SECURITY_NAME, SE_SELF_RELATIVE, SecurityImpersonation,
+    TOKEN_ADJUST_PRIVILEGES, TOKEN_PRIVILEGES, TOKEN_QUERY,
+};
+use windows::Win32::System::Threading::{GetCurrentThread, OpenThreadToken};
+
+use super::backend::WindowsRdpdrBackend;
+use super::file::file_for_request;
+use super::handles::FileHandle;
+
+const MAX_SECURITY_DESCRIPTOR_SIZE: usize = 1024 * 1024;
+const SECURITY_DESCRIPTOR_RELATIVE_SIZE: usize = 20;
+const ACL_HEADER_SIZE: usize = 8;
+const ACE_HEADER_SIZE: usize = 4;
+const SID_HEADER_SIZE: usize = 8;
+pub(super) const ACCESS_SYSTEM_SECURITY: u32 = 0x0100_0000;
+
+pub(crate) fn query(backend: &WindowsRdpdrBackend, req: ServerDriveQuerySecurityRequest) -> PduResult<Vec<SvcMessage>> {
+    let (status, security_descriptor) = match query_inner(backend, &req) {
+        Ok(security_descriptor) => (NtStatus::SUCCESS, Some(security_descriptor)),
+        Err(status) => (status, None),
+    };
+
+    Ok(vec![SvcMessage::from(RdpdrPdu::ClientDriveQuerySecurityResponse(
+        ClientDriveQuerySecurityResponse {
+            device_io_response: DeviceIoResponse::new(req.device_io_request, status),
+            security_descriptor,
+        },
+    ))])
+}
+
+pub(crate) fn set(backend: &WindowsRdpdrBackend, req: ServerDriveSetSecurityRequest) -> PduResult<Vec<SvcMessage>> {
+    let status = set_inner(backend, &req).map_or_else(|status| status, |_| NtStatus::SUCCESS);
+    let response = ClientDriveSetSecurityResponse::new(&req, status).map_err(|error| encode_err!(error))?;
+
+    Ok(vec![SvcMessage::from(RdpdrPdu::ClientDriveSetSecurityResponse(
+        response,
+    ))])
+}
+
+fn query_inner(backend: &WindowsRdpdrBackend, req: &ServerDriveQuerySecurityRequest) -> Result<Vec<u8>, NtStatus> {
+    if req.security_information.is_empty() {
+        return Err(NtStatus::INVALID_PARAMETER);
+    }
+
+    let file = file_for_request(backend, req.device_io_request.device_id, req.device_io_request.file_id)?;
+    let mut descriptor = PSECURITY_DESCRIPTOR::default();
+    let required_privileges = query_required_privileges(req.security_information);
+    let _security_privilege = ScopedSecurityPrivilege::enable(&required_privileges)?;
+
+    // SAFETY: the file handle remains open for this synchronous query and
+    // `descriptor` is writable storage for the LocalAlloc-owned result.
+    let status = unsafe {
+        GetSecurityInfo(
+            file.handle.as_raw(),
+            SE_FILE_OBJECT,
+            object_security_information(req.security_information),
+            None,
+            None,
+            None,
+            None,
+            Some(core::ptr::addr_of_mut!(descriptor)),
+        )
+    };
+    if status != ERROR_SUCCESS {
+        return Err(from_win32_error(status));
+    }
+
+    let descriptor = LocalSecurityDescriptor(descriptor);
+    if descriptor.0.0.is_null() {
+        return Err(NtStatus::UNSUCCESSFUL);
+    }
+
+    // SAFETY: GetSecurityInfo returned a valid, self-relative security
+    // descriptor whose LocalAlloc ownership is retained by `descriptor`.
+    let length = unsafe { GetSecurityDescriptorLength(descriptor.0) };
+    let length = usize::try_from(length).map_err(|_| NtStatus::UNSUCCESSFUL)?;
+    if length == 0 || length > MAX_SECURITY_DESCRIPTOR_SIZE {
+        return Err(NtStatus::UNSUCCESSFUL);
+    }
+
+    // SAFETY: the API-reported descriptor length is bounded above and the
+    // LocalAlloc allocation remains live until `descriptor` is dropped.
+    Ok(unsafe { core::slice::from_raw_parts(descriptor.0.0.cast::<u8>(), length) }.to_vec())
+}
+
+fn set_inner(backend: &WindowsRdpdrBackend, req: &ServerDriveSetSecurityRequest) -> Result<(), NtStatus> {
+    if req.security_information.is_empty() {
+        return Err(NtStatus::INVALID_PARAMETER);
+    }
+
+    let file = file_for_request(backend, req.device_io_request.device_id, req.device_io_request.file_id)?;
+    if file.read_only {
+        return Err(NtStatus::MEDIA_WRITE_PROTECTED);
+    }
+
+    let descriptor = RelativeSecurityDescriptor::new(&req.security_descriptor)?;
+    let required_privileges = set_required_privileges(req.security_information);
+    let _security_privilege = ScopedSecurityPrivilege::enable(&required_privileges)?;
+    let status = descriptor.set_on(&file.handle, req.security_information)?;
+    if status != ERROR_SUCCESS {
+        return Err(from_win32_error(status));
+    }
+
+    Ok(())
+}
+
+fn object_security_information(security_information: SecurityInformation) -> OBJECT_SECURITY_INFORMATION {
+    OBJECT_SECURITY_INFORMATION(security_information.bits())
+}
+
+pub(super) fn enable_for_access_system_security(
+    desired_access: u32,
+) -> Result<Option<ScopedSecurityPrivilege>, NtStatus> {
+    let privileges = (desired_access & ACCESS_SYSTEM_SECURITY != 0)
+        .then_some(SecurityPrivilege::Security)
+        .into_iter()
+        .collect::<Vec<_>>();
+    ScopedSecurityPrivilege::enable(&privileges)
+}
+
+fn query_required_privileges(security_information: SecurityInformation) -> Vec<SecurityPrivilege> {
+    let mut privileges = Vec::new();
+    if contains_sacl_information(security_information) {
+        privileges.push(SecurityPrivilege::Security);
+    }
+    if security_information.contains(SecurityInformation::BACKUP) {
+        privileges.push(SecurityPrivilege::Backup);
+    }
+    privileges
+}
+
+fn set_required_privileges(security_information: SecurityInformation) -> Vec<SecurityPrivilege> {
+    let mut privileges = Vec::new();
+    if contains_sacl_information(security_information) {
+        privileges.push(SecurityPrivilege::Security);
+    }
+    if security_information.contains(SecurityInformation::BACKUP) {
+        privileges.push(SecurityPrivilege::Restore);
+    }
+    privileges
+}
+
+fn contains_sacl_information(security_information: SecurityInformation) -> bool {
+    security_information.intersects(
+        SecurityInformation::SACL
+            | SecurityInformation::LABEL
+            | SecurityInformation::ATTRIBUTE
+            | SecurityInformation::SCOPE
+            | SecurityInformation::PROCESS_TRUST_LABEL
+            | SecurityInformation::PROTECTED_SACL
+            | SecurityInformation::UNPROTECTED_SACL,
+    )
+}
+
+fn from_win32_error(error: WIN32_ERROR) -> NtStatus {
+    match error {
+        ERROR_ACCESS_DENIED => NtStatus::ACCESS_DENIED,
+        ERROR_INVALID_PARAMETER | ERROR_INVALID_SECURITY_DESCR => NtStatus::INVALID_PARAMETER,
+        ERROR_PRIVILEGE_NOT_HELD => NtStatus::PRIVILEGE_NOT_HELD,
+        _ => NtStatus::UNSUCCESSFUL,
+    }
+}
+
+struct LocalSecurityDescriptor(PSECURITY_DESCRIPTOR);
+
+impl Drop for LocalSecurityDescriptor {
+    fn drop(&mut self) {
+        if !self.0.0.is_null() {
+            // SAFETY: GetSecurityInfo allocated this descriptor with LocalAlloc
+            // and this guard owns its sole release.
+            let _ = unsafe { LocalFree(Some(HLOCAL(self.0.0))) };
+        }
+    }
+}
+
+struct OwnedTokenHandle(HANDLE);
+
+impl Drop for OwnedTokenHandle {
+    fn drop(&mut self) {
+        // SAFETY: this is a real token handle opened by OpenThreadToken and
+        // owned exclusively by this guard.
+        if let Err(error) = unsafe { CloseHandle(self.0) } {
+            tracing::warn!(%error, "Failed to close security privilege token");
+        }
+    }
+}
+
+pub(super) struct ScopedSecurityPrivilege {
+    token: OwnedTokenHandle,
+    previous: Vec<TOKEN_PRIVILEGES>,
+    impersonated_self: bool,
+}
+
+impl ScopedSecurityPrivilege {
+    fn enable(privileges: &[SecurityPrivilege]) -> Result<Option<Self>, NtStatus> {
+        if privileges.is_empty() {
+            return Ok(None);
+        }
+
+        let (token, impersonated_self) = open_current_thread_token()?;
+
+        let mut previous = Vec::with_capacity(privileges.len());
+        for privilege in privileges {
+            match enable_privilege(token.0, *privilege) {
+                Ok(previous_privilege) => previous.push(previous_privilege),
+                Err(status) => {
+                    restore_privileges(token.0, &previous);
+                    if impersonated_self {
+                        revert_to_self();
+                    }
+                    return Err(status);
+                }
+            }
+        }
+
+        Ok(Some(Self {
+            token,
+            previous,
+            impersonated_self,
+        }))
+    }
+}
+
+fn open_current_thread_token() -> Result<(OwnedTokenHandle, bool), NtStatus> {
+    // SAFETY: GetCurrentThread takes no arguments and returns a pseudo-handle
+    // that must not be closed.
+    let thread = unsafe { GetCurrentThread() };
+    let mut token = HANDLE::default();
+
+    // SAFETY: `thread` is valid and `token` is writable output storage.
+    match unsafe {
+        OpenThreadToken(
+            thread,
+            TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY,
+            false,
+            core::ptr::addr_of_mut!(token),
+        )
+    } {
+        Ok(()) => Ok((OwnedTokenHandle(token), false)),
+        Err(error) if error.code() == windows::core::HRESULT::from_win32(ERROR_NO_TOKEN.0) => {
+            // No impersonation token exists on this thread. Create one from
+            // the process token so privilege changes remain thread-local.
+            // SAFETY: SecurityImpersonation is a valid impersonation level.
+            unsafe { ImpersonateSelf(SecurityImpersonation) }.map_err(|_| NtStatus::PRIVILEGE_NOT_HELD)?;
+
+            // SAFETY: successful ImpersonateSelf installs a thread token and
+            // `token` remains writable output storage.
+            let opened = unsafe {
+                OpenThreadToken(
+                    thread,
+                    TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY,
+                    false,
+                    core::ptr::addr_of_mut!(token),
+                )
+            };
+            match opened {
+                Ok(()) => Ok((OwnedTokenHandle(token), true)),
+                Err(_) => {
+                    revert_to_self();
+                    Err(NtStatus::PRIVILEGE_NOT_HELD)
+                }
+            }
+        }
+        Err(_) => Err(NtStatus::PRIVILEGE_NOT_HELD),
+    }
+}
+
+fn revert_to_self() {
+    // SAFETY: this only removes a thread impersonation token previously
+    // installed by ImpersonateSelf in this module.
+    if let Err(error) = unsafe { RevertToSelf() } {
+        tracing::warn!(%error, "Failed to revert RDPDR thread impersonation");
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SecurityPrivilege {
+    Security,
+    Backup,
+    Restore,
+}
+
+impl SecurityPrivilege {
+    fn name(self) -> windows::core::PCWSTR {
+        match self {
+            Self::Security => SE_SECURITY_NAME,
+            Self::Backup => SE_BACKUP_NAME,
+            Self::Restore => SE_RESTORE_NAME,
+        }
+    }
+}
+
+fn enable_privilege(token: HANDLE, privilege: SecurityPrivilege) -> Result<TOKEN_PRIVILEGES, NtStatus> {
+    let mut luid = LUID::default();
+    // SAFETY: the local system name and standard privilege name are valid, and
+    // `luid` is writable output storage.
+    unsafe { LookupPrivilegeValueW(None, privilege.name(), core::ptr::addr_of_mut!(luid)) }
+        .map_err(|_| NtStatus::PRIVILEGE_NOT_HELD)?;
+    let requested = TOKEN_PRIVILEGES {
+        PrivilegeCount: 1,
+        Privileges: [LUID_AND_ATTRIBUTES {
+            Luid: luid,
+            Attributes: SE_PRIVILEGE_ENABLED,
+        }],
+    };
+    let mut previous = TOKEN_PRIVILEGES::default();
+    let mut previous_size = 0;
+    // AdjustTokenPrivileges leaves the last-error value unchanged on a full
+    // success, so clear it before checking for ERROR_NOT_ALL_ASSIGNED.
+    // SAFETY: SetLastError only updates the calling thread's error state.
+    unsafe { SetLastError(ERROR_SUCCESS) };
+    // SAFETY: the current thread token is valid; the fixed one-privilege
+    // states are exactly the sizes expected for this single adjustment.
+    unsafe {
+        AdjustTokenPrivileges(
+            token,
+            false,
+            Some(core::ptr::addr_of!(requested)),
+            u32::try_from(size_of::<TOKEN_PRIVILEGES>()).expect("token privilege state fits in u32"),
+            Some(core::ptr::addr_of_mut!(previous)),
+            Some(core::ptr::addr_of_mut!(previous_size)),
+        )
+    }
+    .map_err(|_| NtStatus::PRIVILEGE_NOT_HELD)?;
+    // AdjustTokenPrivileges reports a missing assigned privilege through
+    // GetLastError even when the function call itself succeeds.
+    // SAFETY: GetLastError only reads the calling thread's error state.
+    if unsafe { GetLastError() } == ERROR_NOT_ALL_ASSIGNED {
+        return Err(NtStatus::PRIVILEGE_NOT_HELD);
+    }
+
+    Ok(previous)
+}
+
+fn restore_privileges(token: HANDLE, privileges: &[TOKEN_PRIVILEGES]) {
+    for privilege in privileges.iter().rev() {
+        // SAFETY: `token` is valid and `privilege` is the one-privilege state
+        // returned by AdjustTokenPrivileges when the scope enabled the privilege.
+        let restore =
+            unsafe { AdjustTokenPrivileges(token, false, Some(core::ptr::addr_of!(*privilege)), 0, None, None) };
+        if let Err(error) = restore {
+            tracing::warn!(%error, "Failed to restore security privilege");
+        }
+    }
+}
+
+impl Drop for ScopedSecurityPrivilege {
+    fn drop(&mut self) {
+        restore_privileges(self.token.0, &self.previous);
+        if self.impersonated_self {
+            revert_to_self();
+        }
+    }
+}
+
+struct RelativeSecurityDescriptor<'a> {
+    bytes: &'a [u8],
+}
+
+impl<'a> RelativeSecurityDescriptor<'a> {
+    fn new(bytes: &'a [u8]) -> Result<Self, NtStatus> {
+        if bytes.len() < SECURITY_DESCRIPTOR_RELATIVE_SIZE || bytes.len() > MAX_SECURITY_DESCRIPTOR_SIZE {
+            return Err(NtStatus::INVALID_PARAMETER);
+        }
+        if bytes[0] != 1 {
+            return Err(NtStatus::INVALID_PARAMETER);
+        }
+
+        let control = read_u16(bytes, 2)?;
+        if control & SE_SELF_RELATIVE.0 == 0 {
+            return Err(NtStatus::INVALID_PARAMETER);
+        }
+
+        for offset in [4, 8] {
+            if let Some(offset) = relative_offset(bytes, offset)? {
+                validate_sid(bytes, offset)?;
+            }
+        }
+        for offset in [12, 16] {
+            if let Some(offset) = relative_offset(bytes, offset)? {
+                validate_acl(bytes, offset)?;
+            }
+        }
+
+        let descriptor = Self { bytes };
+        // SAFETY: all relative component offsets and their variable-length
+        // SID/ACL payloads have been bounded to `bytes` before validation.
+        if !unsafe { IsValidSecurityDescriptor(descriptor.as_raw()) }.as_bool() {
+            return Err(NtStatus::INVALID_PARAMETER);
+        }
+
+        Ok(descriptor)
+    }
+
+    fn set_on(&self, handle: &FileHandle, security_information: SecurityInformation) -> Result<WIN32_ERROR, NtStatus> {
+        let backup = security_information.contains(SecurityInformation::BACKUP);
+        let owner = (backup || security_information.contains(SecurityInformation::OWNER))
+            .then(|| self.owner())
+            .transpose()?;
+        let group = (backup || security_information.contains(SecurityInformation::GROUP))
+            .then(|| self.group())
+            .transpose()?;
+        let dacl = self.dacl_for(security_information)?;
+        let sacl = (backup || contains_sacl_information(security_information))
+            .then(|| self.sacl())
+            .transpose()?;
+
+        // SAFETY: `self` validates the self-relative descriptor and all
+        // extracted SID/ACL pointers remain valid for the duration of this
+        // synchronous handle-relative call.
+        Ok(unsafe {
+            SetSecurityInfo(
+                handle.as_raw(),
+                SE_FILE_OBJECT,
+                object_security_information(security_information),
+                owner,
+                group,
+                dacl,
+                sacl,
+            )
+        })
+    }
+
+    fn owner(&self) -> Result<PSID, NtStatus> {
+        let mut owner = PSID::default();
+        let mut defaulted = windows::core::BOOL::default();
+        // SAFETY: self-relative descriptor was structurally and semantically
+        // validated when this value was constructed.
+        unsafe { GetSecurityDescriptorOwner(self.as_raw(), core::ptr::addr_of_mut!(owner), &mut defaulted) }
+            .map_err(|_| NtStatus::INVALID_PARAMETER)?;
+        if owner.0.is_null() {
+            return Err(NtStatus::INVALID_PARAMETER);
+        }
+        Ok(owner)
+    }
+
+    fn group(&self) -> Result<PSID, NtStatus> {
+        let mut group = PSID::default();
+        let mut defaulted = windows::core::BOOL::default();
+        // SAFETY: self-relative descriptor was structurally and semantically
+        // validated when this value was constructed.
+        unsafe { GetSecurityDescriptorGroup(self.as_raw(), core::ptr::addr_of_mut!(group), &mut defaulted) }
+            .map_err(|_| NtStatus::INVALID_PARAMETER)?;
+        if group.0.is_null() {
+            return Err(NtStatus::INVALID_PARAMETER);
+        }
+        Ok(group)
+    }
+
+    fn dacl(&self) -> Result<*const ACL, NtStatus> {
+        let mut present = windows::core::BOOL::default();
+        let mut dacl = core::ptr::null_mut();
+        let mut defaulted = windows::core::BOOL::default();
+        // SAFETY: self-relative descriptor was structurally and semantically
+        // validated when this value was constructed.
+        unsafe {
+            GetSecurityDescriptorDacl(
+                self.as_raw(),
+                core::ptr::addr_of_mut!(present),
+                core::ptr::addr_of_mut!(dacl),
+                core::ptr::addr_of_mut!(defaulted),
+            )
+        }
+        .map_err(|_| NtStatus::INVALID_PARAMETER)?;
+        if !present.as_bool() || dacl.is_null() {
+            // SetSecurityInfo interprets a null DACL as "grant everyone full
+            // access", which must never be accepted from the remote server.
+            return Err(NtStatus::INVALID_PARAMETER);
+        }
+        Ok(dacl.cast_const())
+    }
+
+    fn dacl_for(&self, security_information: SecurityInformation) -> Result<Option<*const ACL>, NtStatus> {
+        (security_information.contains(SecurityInformation::BACKUP)
+            || security_information.contains(SecurityInformation::DACL))
+        .then(|| self.dacl())
+        .transpose()
+    }
+
+    fn sacl(&self) -> Result<*const ACL, NtStatus> {
+        let mut present = windows::core::BOOL::default();
+        let mut sacl = core::ptr::null_mut();
+        let mut defaulted = windows::core::BOOL::default();
+        // SAFETY: self-relative descriptor was structurally and semantically
+        // validated when this value was constructed.
+        unsafe {
+            GetSecurityDescriptorSacl(
+                self.as_raw(),
+                core::ptr::addr_of_mut!(present),
+                core::ptr::addr_of_mut!(sacl),
+                core::ptr::addr_of_mut!(defaulted),
+            )
+        }
+        .map_err(|_| NtStatus::INVALID_PARAMETER)?;
+        Ok(sacl.cast_const())
+    }
+
+    fn as_raw(&self) -> PSECURITY_DESCRIPTOR {
+        PSECURITY_DESCRIPTOR(self.bytes.as_ptr().cast_mut().cast())
+    }
+}
+
+fn relative_offset(bytes: &[u8], field_offset: usize) -> Result<Option<usize>, NtStatus> {
+    let offset = usize::try_from(read_u32(bytes, field_offset)?).map_err(|_| NtStatus::INVALID_PARAMETER)?;
+    if offset == 0 {
+        return Ok(None);
+    }
+    if offset < SECURITY_DESCRIPTOR_RELATIVE_SIZE || offset >= bytes.len() {
+        return Err(NtStatus::INVALID_PARAMETER);
+    }
+    Ok(Some(offset))
+}
+
+fn validate_sid(bytes: &[u8], offset: usize) -> Result<(), NtStatus> {
+    let header = bytes
+        .get(offset..offset + SID_HEADER_SIZE)
+        .ok_or(NtStatus::INVALID_PARAMETER)?;
+    if header[0] != 1 {
+        return Err(NtStatus::INVALID_PARAMETER);
+    }
+    let length = SID_HEADER_SIZE
+        .checked_add(
+            usize::from(header[1])
+                .checked_mul(size_of::<u32>())
+                .ok_or(NtStatus::INVALID_PARAMETER)?,
+        )
+        .ok_or(NtStatus::INVALID_PARAMETER)?;
+    bytes
+        .get(offset..offset.checked_add(length).ok_or(NtStatus::INVALID_PARAMETER)?)
+        .ok_or(NtStatus::INVALID_PARAMETER)?;
+    Ok(())
+}
+
+fn validate_acl(bytes: &[u8], offset: usize) -> Result<(), NtStatus> {
+    let header = bytes
+        .get(offset..offset + ACL_HEADER_SIZE)
+        .ok_or(NtStatus::INVALID_PARAMETER)?;
+    let length = usize::from(u16::from_le_bytes([header[2], header[3]]));
+    let ace_count = usize::from(u16::from_le_bytes([header[4], header[5]]));
+    if length < ACL_HEADER_SIZE {
+        return Err(NtStatus::INVALID_PARAMETER);
+    }
+    let end = offset.checked_add(length).ok_or(NtStatus::INVALID_PARAMETER)?;
+    bytes.get(offset..end).ok_or(NtStatus::INVALID_PARAMETER)?;
+
+    let mut ace_offset = offset + ACL_HEADER_SIZE;
+    for _ in 0..ace_count {
+        let ace = bytes
+            .get(ace_offset..ace_offset + ACE_HEADER_SIZE)
+            .ok_or(NtStatus::INVALID_PARAMETER)?;
+        let ace_length = usize::from(u16::from_le_bytes([ace[2], ace[3]]));
+        if ace_length < ACE_HEADER_SIZE {
+            return Err(NtStatus::INVALID_PARAMETER);
+        }
+        ace_offset = ace_offset.checked_add(ace_length).ok_or(NtStatus::INVALID_PARAMETER)?;
+        if ace_offset > end {
+            return Err(NtStatus::INVALID_PARAMETER);
+        }
+    }
+
+    Ok(())
+}
+
+fn read_u16(bytes: &[u8], offset: usize) -> Result<u16, NtStatus> {
+    let value = bytes
+        .get(offset..offset + size_of::<u16>())
+        .ok_or(NtStatus::INVALID_PARAMETER)?;
+    Ok(u16::from_le_bytes([value[0], value[1]]))
+}
+
+fn read_u32(bytes: &[u8], offset: usize) -> Result<u32, NtStatus> {
+    let value = bytes
+        .get(offset..offset + size_of::<u32>())
+        .ok_or(NtStatus::INVALID_PARAMETER)?;
+    Ok(u32::from_le_bytes([value[0], value[1], value[2], value[3]]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironrdp_rdpdr::pdu::efs::{
+        CreateDisposition, CreateOptions, DesiredAccess, DeviceCreateRequest, DeviceIoRequest, FileAttributes,
+        MajorFunction, MinorFunction, SharedAccess,
+    };
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use crate::windows::factory::RedirectedDrive;
+    use crate::windows::file::create_inner;
+
+    #[test]
+    fn query_and_set_dacl_use_the_opened_file_handle() {
+        let (_temporary_file, backend, file_id) = open_test_file(false, 0x0006_0080);
+        let query = ServerDriveQuerySecurityRequest {
+            device_io_request: DeviceIoRequest {
+                device_id: 1,
+                file_id,
+                completion_id: 2,
+                major_function: MajorFunction::QuerySecurity,
+                minor_function: MinorFunction::from(0),
+            },
+            security_information: SecurityInformation::OWNER | SecurityInformation::GROUP | SecurityInformation::DACL,
+        };
+
+        let descriptor = query_inner(&backend, &query).expect("query DACL through redirected handle");
+        RelativeSecurityDescriptor::new(&descriptor).expect("Windows returned a valid self-relative descriptor");
+        let set = ServerDriveSetSecurityRequest {
+            device_io_request: DeviceIoRequest {
+                major_function: MajorFunction::SetSecurity,
+                completion_id: 3,
+                ..query.device_io_request
+            },
+            security_information: SecurityInformation::DACL,
+            security_descriptor: descriptor.clone(),
+        };
+        set_inner(&backend, &set).expect("reapply DACL through redirected handle");
+
+        let protection_only_set = ServerDriveSetSecurityRequest {
+            security_information: SecurityInformation::PROTECTED_DACL,
+            security_descriptor: descriptor,
+            ..set
+        };
+        set_inner(&backend, &protection_only_set)
+            .expect("set DACL protection without supplying a DACL pointer to SetSecurityInfo");
+    }
+
+    #[test]
+    fn query_security_requires_read_control_on_the_opened_handle() {
+        let (_temporary_file, backend, file_id) = open_test_file(false, 0x0000_0080);
+        let query = ServerDriveQuerySecurityRequest {
+            device_io_request: DeviceIoRequest {
+                device_id: 1,
+                file_id,
+                completion_id: 2,
+                major_function: MajorFunction::QuerySecurity,
+                minor_function: MinorFunction::from(0),
+            },
+            security_information: SecurityInformation::OWNER,
+        };
+
+        assert_eq!(query_inner(&backend, &query), Err(NtStatus::ACCESS_DENIED));
+    }
+
+    #[test]
+    fn read_only_drive_rejects_security_mutation_before_parsing_the_descriptor() {
+        let (_temporary_file, backend, file_id) = open_test_file(true, 0x0002_0080);
+        let request = ServerDriveSetSecurityRequest {
+            device_io_request: DeviceIoRequest {
+                device_id: 1,
+                file_id,
+                completion_id: 2,
+                major_function: MajorFunction::SetSecurity,
+                minor_function: MinorFunction::from(0),
+            },
+            security_information: SecurityInformation::DACL,
+            security_descriptor: Vec::new(),
+        };
+
+        assert_eq!(set_inner(&backend, &request), Err(NtStatus::MEDIA_WRITE_PROTECTED));
+    }
+
+    #[test]
+    fn security_operations_request_their_required_privileges() {
+        assert_eq!(
+            query_required_privileges(SecurityInformation::SACL | SecurityInformation::BACKUP),
+            vec![SecurityPrivilege::Security, SecurityPrivilege::Backup]
+        );
+        assert_eq!(
+            set_required_privileges(SecurityInformation::SACL | SecurityInformation::BACKUP),
+            vec![SecurityPrivilege::Security, SecurityPrivilege::Restore]
+        );
+        assert_eq!(
+            query_required_privileges(
+                SecurityInformation::LABEL | SecurityInformation::ATTRIBUTE | SecurityInformation::PROCESS_TRUST_LABEL
+            ),
+            vec![SecurityPrivilege::Security]
+        );
+        assert_eq!(
+            set_required_privileges(
+                SecurityInformation::LABEL | SecurityInformation::ATTRIBUTE | SecurityInformation::PROCESS_TRUST_LABEL
+            ),
+            vec![SecurityPrivilege::Security]
+        );
+    }
+
+    #[test]
+    fn malformed_self_relative_descriptor_is_rejected_before_windows_parses_it() {
+        let mut descriptor = vec![0; SECURITY_DESCRIPTOR_RELATIVE_SIZE];
+        descriptor[0] = 1; // Revision
+        descriptor[2..4].copy_from_slice(&SE_SELF_RELATIVE.0.to_le_bytes());
+        descriptor[4..8].copy_from_slice(
+            &u32::try_from(SECURITY_DESCRIPTOR_RELATIVE_SIZE)
+                .expect("descriptor header size fits in u32")
+                .to_le_bytes(),
+        );
+
+        assert!(matches!(
+            RelativeSecurityDescriptor::new(&descriptor),
+            Err(NtStatus::INVALID_PARAMETER)
+        ));
+    }
+
+    #[test]
+    fn rejects_absent_or_null_dacls() {
+        for control in [
+            SE_SELF_RELATIVE.0,
+            SE_SELF_RELATIVE.0 | windows::Win32::Security::SE_DACL_PRESENT.0,
+        ] {
+            let mut descriptor = vec![0; SECURITY_DESCRIPTOR_RELATIVE_SIZE];
+            descriptor[0] = 1; // Revision
+            descriptor[2..4].copy_from_slice(&control.to_le_bytes());
+            let descriptor = RelativeSecurityDescriptor::new(&descriptor)
+                .expect("a descriptor without an owner, group, or DACL is structurally valid");
+
+            assert_eq!(descriptor.dacl(), Err(NtStatus::INVALID_PARAMETER));
+            assert_eq!(
+                descriptor
+                    .dacl_for(SecurityInformation::PROTECTED_DACL)
+                    .expect("DACL protection does not need a DACL payload"),
+                None
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_absent_owner_or_group_when_requested() {
+        let mut bytes = vec![0; SECURITY_DESCRIPTOR_RELATIVE_SIZE];
+        bytes[0] = 1; // Revision
+        bytes[2..4].copy_from_slice(&SE_SELF_RELATIVE.0.to_le_bytes());
+        let descriptor = RelativeSecurityDescriptor::new(&bytes).expect("structurally valid security descriptor");
+
+        assert_eq!(descriptor.owner(), Err(NtStatus::INVALID_PARAMETER));
+        assert_eq!(descriptor.group(), Err(NtStatus::INVALID_PARAMETER));
+    }
+
+    fn open_test_file(read_only: bool, desired_access: u32) -> (TemporaryFile, WindowsRdpdrBackend, u32) {
+        let temporary_file = TemporaryFile::create();
+        let root_path = temporary_file
+            .0
+            .ancestors()
+            .last()
+            .expect("temporary file has a volume root")
+            .to_owned();
+        let relative_path = temporary_file
+            .0
+            .strip_prefix(&root_path)
+            .expect("temporary file is beneath its volume root");
+        let drive = RedirectedDrive::new(1, "Test", root_path, read_only).expect("valid redirected drive");
+        let mut backend = WindowsRdpdrBackend::from_active_drive(drive);
+        let request = DeviceCreateRequest {
+            device_io_request: DeviceIoRequest {
+                device_id: 1,
+                file_id: 0,
+                completion_id: 1,
+                major_function: MajorFunction::Create,
+                minor_function: MinorFunction::from(0),
+            },
+            desired_access: DesiredAccess::from_bits_retain(desired_access),
+            allocation_size: 0,
+            file_attributes: FileAttributes::empty(),
+            shared_access: SharedAccess::empty(),
+            create_disposition: CreateDisposition::FILE_OPEN,
+            create_options: CreateOptions::empty(),
+            path: format!(r"\{}", relative_path.display()),
+        };
+        let (file_id, _) = create_inner(&mut backend, &request).expect("open temporary file");
+        (temporary_file, backend, file_id)
+    }
+
+    struct TemporaryFile(PathBuf);
+
+    impl TemporaryFile {
+        fn create() -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "ironrdp-rdpdr-security-{}-{}.tmp",
+                std::process::id(),
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .expect("system clock is after Unix epoch")
+                    .as_nanos()
+            ));
+            std::fs::write(&path, b"security").expect("create temporary file");
+            Self(path)
+        }
+    }
+
+    impl Drop for TemporaryFile {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.0);
+        }
+    }
+}

--- a/crates/ironrdp-rdpdr-native/src/windows/status.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/status.rs
@@ -4,6 +4,7 @@ use windows::Win32::Foundation::NTSTATUS;
 
 use ironrdp_rdpdr::pdu::efs::NtStatus;
 
+use super::handles::{OpenDirectoryError, OpenFileError};
 use super::path::PathPolicyError;
 
 pub(crate) fn from_path_policy(error: PathPolicyError) -> NtStatus {
@@ -15,18 +16,41 @@ pub(crate) fn from_path_policy(error: PathPolicyError) -> NtStatus {
     }
 }
 
-pub(crate) fn from_ntstatus(status: NTSTATUS) -> NtStatus {
-    NtStatus::from(u32::from_ne_bytes(status.0.to_ne_bytes()))
+pub(crate) fn from_open_file(error: OpenFileError) -> NtStatus {
+    match error {
+        OpenFileError::Directory(error) => from_open_directory(error),
+        OpenFileError::NtStatus(status) => from_ntstatus(status),
+    }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+pub(crate) fn from_open_directory(error: OpenDirectoryError) -> NtStatus {
+    match error {
+        OpenDirectoryError::InvalidVolumeRoot => NtStatus::OBJECT_NAME_INVALID,
+        OpenDirectoryError::NtStatus(status) => from_ntstatus(status),
+    }
+}
 
-    #[test]
-    fn preserves_native_status_values() {
-        let status = NTSTATUS(i32::from_ne_bytes(0xC000_0034u32.to_ne_bytes()));
-
-        assert_eq!(from_ntstatus(status), NtStatus::from(0xC000_0034));
+pub(crate) fn from_ntstatus(status: NTSTATUS) -> NtStatus {
+    match u32::from_ne_bytes(status.0.to_ne_bytes()) {
+        0xC000_0008 => NtStatus::INVALID_HANDLE,
+        0xC000_000D => NtStatus::INVALID_PARAMETER,
+        0xC000_000F | 0xC000_0034 => NtStatus::NO_SUCH_FILE,
+        0xC000_0010 => NtStatus::INVALID_DEVICE_REQUEST,
+        0xC000_0011 => NtStatus::END_OF_FILE,
+        0x8000_0005 => NtStatus::BUFFER_OVERFLOW,
+        0x8000_0006 => NtStatus::NO_MORE_FILES,
+        0xC000_0022 => NtStatus::ACCESS_DENIED,
+        0xC000_0023 => NtStatus::BUFFER_TOO_SMALL,
+        0xC000_0033 => NtStatus::OBJECT_NAME_INVALID,
+        0xC000_0035 => NtStatus::OBJECT_NAME_COLLISION,
+        0xC000_003A | 0xC000_003B => NtStatus::OBJECT_PATH_NOT_FOUND,
+        0xC000_0043 => NtStatus::SHARING_VIOLATION,
+        0xC000_007F => NtStatus::DISK_FULL,
+        0xC000_00BA => NtStatus::FILE_IS_A_DIRECTORY,
+        0xC000_0101 => NtStatus::DIRECTORY_NOT_EMPTY,
+        0xC000_0103 => NtStatus::NOT_A_DIRECTORY,
+        0xC000_0120 => NtStatus::CANCELLED,
+        0xC000_0279 | 0xC000_0280 | 0x8000_002D => NtStatus::ACCESS_DENIED,
+        _ => NtStatus::from(u32::from_ne_bytes(status.0.to_ne_bytes())),
     }
 }

--- a/crates/ironrdp-rdpdr-native/src/windows/volume.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/volume.rs
@@ -1,0 +1,260 @@
+//! Windows RDPDR volume-information queries bound to an opened redirected file.
+
+use core::mem::offset_of;
+
+use ironrdp_pdu::PduResult;
+use ironrdp_rdpdr::pdu::RdpdrPdu;
+use ironrdp_rdpdr::pdu::efs::{
+    Boolean, ClientDriveQueryVolumeInformationResponse, FileFsAttributeInformation, FileFsFullSizeInformation,
+    FileFsSizeInformation, FileFsVolumeInformation, FileSystemAttributes, FileSystemInformationClass,
+    FileSystemInformationClassLevel, NtStatus, ServerDriveQueryVolumeInformationRequest,
+};
+use ironrdp_svc::SvcMessage;
+use tracing::debug;
+use windows::Wdk::Storage::FileSystem::{
+    FILE_FS_ATTRIBUTE_INFORMATION, FileFsAttributeInformation as NativeFileFsAttributeInformation,
+    FileFsFullSizeInformation as NativeFileFsFullSizeInformation, FileFsSizeInformation as NativeFileFsSizeInformation,
+    FileFsVolumeInformation as NativeFileFsVolumeInformation,
+};
+use windows::Wdk::System::SystemServices::{
+    FILE_FS_FULL_SIZE_INFORMATION, FILE_FS_SIZE_INFORMATION, FILE_FS_VOLUME_INFORMATION,
+};
+
+use super::backend::WindowsRdpdrBackend;
+use super::file::file_for_request;
+use super::status::from_ntstatus;
+
+pub(crate) fn query_information(
+    backend: &mut WindowsRdpdrBackend,
+    req: ServerDriveQueryVolumeInformationRequest,
+) -> PduResult<Vec<SvcMessage>> {
+    let information_class = &req.fs_info_class_lvl;
+    let (status, buffer) = match query_information_inner(backend, &req) {
+        Ok(buffer) => (NtStatus::SUCCESS, Some(buffer)),
+        Err(status) => (status, None),
+    };
+    let named_streams = match buffer.as_ref() {
+        Some(FileSystemInformationClass::FileFsAttributeInformation(information)) => Some(
+            information
+                .file_system_attributes
+                .contains(FileSystemAttributes::FILE_NAMED_STREAMS),
+        ),
+        _ => None,
+    };
+    debug!(
+        ?information_class,
+        ?status,
+        ?named_streams,
+        "Completed filesystem query-volume-information IRP"
+    );
+
+    Ok(vec![SvcMessage::from(
+        RdpdrPdu::ClientDriveQueryVolumeInformationResponse(ClientDriveQueryVolumeInformationResponse::new(
+            req.device_io_request,
+            status,
+            buffer,
+        )),
+    )])
+}
+
+pub(super) fn query_information_inner(
+    backend: &WindowsRdpdrBackend,
+    req: &ServerDriveQueryVolumeInformationRequest,
+) -> Result<FileSystemInformationClass, NtStatus> {
+    let file = file_for_request(backend, req.device_io_request.device_id, req.device_io_request.file_id)?;
+
+    match req.fs_info_class_lvl {
+        FileSystemInformationClassLevel::FILE_FS_VOLUME_INFORMATION => {
+            let buffer = file
+                .handle
+                .query_volume_information(NativeFileFsVolumeInformation)
+                .map_err(from_ntstatus)?
+                .output;
+            volume_information(&buffer).map(Into::into)
+        }
+        FileSystemInformationClassLevel::FILE_FS_SIZE_INFORMATION => {
+            let buffer = file
+                .handle
+                .query_volume_information(NativeFileFsSizeInformation)
+                .map_err(from_ntstatus)?
+                .output;
+            let information = read_native::<FILE_FS_SIZE_INFORMATION>(&buffer)?;
+            Ok(FileFsSizeInformation {
+                total_alloc_units: information.TotalAllocationUnits,
+                available_alloc_units: information.AvailableAllocationUnits,
+                sectors_per_alloc_unit: information.SectorsPerAllocationUnit,
+                bytes_per_sector: information.BytesPerSector,
+            }
+            .into())
+        }
+        FileSystemInformationClassLevel::FILE_FS_ATTRIBUTE_INFORMATION => {
+            let buffer = file
+                .handle
+                .query_volume_information(NativeFileFsAttributeInformation)
+                .map_err(from_ntstatus)?
+                .output;
+            attribute_information(&buffer, file.read_only).map(Into::into)
+        }
+        FileSystemInformationClassLevel::FILE_FS_FULL_SIZE_INFORMATION => {
+            let buffer = file
+                .handle
+                .query_volume_information(NativeFileFsFullSizeInformation)
+                .map_err(from_ntstatus)?
+                .output;
+            let information = read_native::<FILE_FS_FULL_SIZE_INFORMATION>(&buffer)?;
+            Ok(FileFsFullSizeInformation {
+                total_alloc_units: information.TotalAllocationUnits,
+                caller_available_alloc_units: information.CallerAvailableAllocationUnits,
+                actual_available_alloc_units: information.ActualAvailableAllocationUnits,
+                sectors_per_alloc_unit: information.SectorsPerAllocationUnit,
+                bytes_per_sector: information.BytesPerSector,
+            }
+            .into())
+        }
+        // `mstscax.dll!W32Drive::MsgIrpQueryVolumeInfo` recognizes only
+        // FileFsVolumeInformation, FileFsSizeInformation, FileFsAttributeInformation,
+        // and FileFsFullSizeInformation. It maps ERROR_INVALID_FUNCTION for this
+        // otherwise valid MS-RDPEFS request to STATUS_INVALID_DEVICE_REQUEST.
+        FileSystemInformationClassLevel::FILE_FS_DEVICE_INFORMATION => Err(NtStatus::INVALID_DEVICE_REQUEST),
+        _ => Err(NtStatus::NOT_SUPPORTED),
+    }
+}
+
+fn volume_information(buffer: &[u8]) -> Result<FileFsVolumeInformation, NtStatus> {
+    let label_offset = offset_of!(FILE_FS_VOLUME_INFORMATION, VolumeLabel);
+    let creation_time = read_i64(buffer, 0)?;
+    let serial_number = read_u32(buffer, 8)?;
+    let label_length = read_u32(buffer, 12)?;
+    let supports_objects = read_u8(buffer, 16)?;
+
+    let volume_label = read_utf16(buffer, label_offset, label_length)?;
+    let volume_label = volume_label.strip_suffix('\0').unwrap_or(&volume_label);
+
+    Ok(FileFsVolumeInformation {
+        volume_creation_time: creation_time,
+        volume_serial_number: serial_number,
+        supports_objects: Boolean::from(supports_objects),
+        // MS-FSCC limits the redirected volume label to 32 characters even
+        // when the local file system reports a longer name.
+        volume_label: volume_label.chars().take(32).collect(),
+    })
+}
+
+fn attribute_information(buffer: &[u8], read_only: bool) -> Result<FileFsAttributeInformation, NtStatus> {
+    let file_system_name_offset = offset_of!(FILE_FS_ATTRIBUTE_INFORMATION, FileSystemName);
+    let file_system_attributes = read_u32(buffer, 0)?;
+    let maximum_component_name_length = u32::try_from(read_i32(buffer, 4)?).map_err(|_| NtStatus::UNSUCCESSFUL)?;
+    let file_system_name_length = read_u32(buffer, 8)?;
+    let mut file_system_attributes = FileSystemAttributes::from_bits_retain(file_system_attributes);
+    if read_only {
+        file_system_attributes.insert(FileSystemAttributes::FILE_READ_ONLY_VOLUME);
+    }
+
+    Ok(FileFsAttributeInformation {
+        file_system_attributes,
+        max_component_name_len: maximum_component_name_length,
+        file_system_name: read_utf16(buffer, file_system_name_offset, file_system_name_length)?,
+    })
+}
+
+fn read_native<T: Copy>(buffer: &[u8]) -> Result<T, NtStatus> {
+    let bytes = buffer.get(..size_of::<T>()).ok_or(NtStatus::UNSUCCESSFUL)?;
+
+    // SAFETY: `bytes` contains a complete native structure; unaligned access is
+    // required because the query buffer is stored as bytes.
+    Ok(unsafe { bytes.as_ptr().cast::<T>().read_unaligned() })
+}
+
+fn read_i64(buffer: &[u8], offset: usize) -> Result<i64, NtStatus> {
+    Ok(i64::from_le_bytes(read_array(buffer, offset)?))
+}
+
+fn read_i32(buffer: &[u8], offset: usize) -> Result<i32, NtStatus> {
+    Ok(i32::from_le_bytes(read_array(buffer, offset)?))
+}
+
+fn read_u32(buffer: &[u8], offset: usize) -> Result<u32, NtStatus> {
+    Ok(u32::from_le_bytes(read_array(buffer, offset)?))
+}
+
+fn read_u8(buffer: &[u8], offset: usize) -> Result<u8, NtStatus> {
+    buffer.get(offset).copied().ok_or(NtStatus::UNSUCCESSFUL)
+}
+
+fn read_array<const N: usize>(buffer: &[u8], offset: usize) -> Result<[u8; N], NtStatus> {
+    let end = offset.checked_add(N).ok_or(NtStatus::UNSUCCESSFUL)?;
+    buffer
+        .get(offset..end)
+        .ok_or(NtStatus::UNSUCCESSFUL)?
+        .try_into()
+        .map_err(|_| NtStatus::UNSUCCESSFUL)
+}
+
+fn read_utf16(buffer: &[u8], offset: usize, byte_length: u32) -> Result<String, NtStatus> {
+    let byte_length = usize::try_from(byte_length).map_err(|_| NtStatus::UNSUCCESSFUL)?;
+    if byte_length % size_of::<u16>() != 0 {
+        return Err(NtStatus::UNSUCCESSFUL);
+    }
+
+    let end = offset.checked_add(byte_length).ok_or(NtStatus::UNSUCCESSFUL)?;
+    let bytes = buffer.get(offset..end).ok_or(NtStatus::UNSUCCESSFUL)?;
+    let utf16 = bytes
+        .chunks_exact(size_of::<u16>())
+        .map(|code_unit| u16::from_le_bytes([code_unit[0], code_unit[1]]))
+        .collect::<Vec<_>>();
+    Ok(String::from_utf16_lossy(&utf16))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_only_volume_configuration_is_reported_to_the_server() {
+        let attributes = attribute_information(
+            &vec![0; offset_of!(FILE_FS_ATTRIBUTE_INFORMATION, FileSystemName)],
+            true,
+        )
+        .expect("valid empty native attribute response");
+        assert!(
+            attributes
+                .file_system_attributes
+                .contains(FileSystemAttributes::FILE_READ_ONLY_VOLUME)
+        );
+    }
+
+    #[test]
+    fn volume_names_reject_malformed_native_lengths() {
+        assert_eq!(read_utf16(&[], 0, 1), Err(NtStatus::UNSUCCESSFUL));
+        assert_eq!(read_utf16(&[], 0, 2), Err(NtStatus::UNSUCCESSFUL));
+    }
+
+    #[test]
+    fn long_volume_labels_are_truncated_to_the_protocol_limit() {
+        let label = "a".repeat(40);
+        let label_offset = offset_of!(FILE_FS_VOLUME_INFORMATION, VolumeLabel);
+        let mut buffer = vec![0; label_offset + label.len() * size_of::<u16>()];
+        buffer[12..16]
+            .copy_from_slice(&(u32::try_from(label.len() * size_of::<u16>()).expect("length fits")).to_le_bytes());
+        for (offset, code_unit) in label.encode_utf16().enumerate() {
+            let start = label_offset + offset * size_of::<u16>();
+            buffer[start..start + size_of::<u16>()].copy_from_slice(&code_unit.to_le_bytes());
+        }
+
+        let information = volume_information(&buffer).expect("valid native volume information");
+
+        assert_eq!(information.volume_label, "a".repeat(32));
+    }
+
+    #[test]
+    fn volume_label_terminator_is_not_retained_in_the_protocol_value() {
+        let label_offset = offset_of!(FILE_FS_VOLUME_INFORMATION, VolumeLabel);
+        let mut buffer = vec![0; label_offset + 4];
+        buffer[12..16].copy_from_slice(&4u32.to_le_bytes());
+        buffer[label_offset..label_offset + 4].copy_from_slice(&[b'C', 0, 0, 0]);
+
+        let information = volume_information(&buffer).expect("valid terminated native volume information");
+
+        assert_eq!(information.volume_label, "C");
+    }
+}

--- a/crates/ironrdp-rdpdr-native/tests/windows_backend.rs
+++ b/crates/ironrdp-rdpdr-native/tests/windows_backend.rs
@@ -7,13 +7,18 @@ use ironrdp_core as _;
 use ironrdp_pdu as _;
 use ironrdp_rdpdr::RdpdrBackend;
 use ironrdp_rdpdr::pdu::efs::{
-    CreateDisposition, CreateOptions, DesiredAccess, DeviceCloseRequest, DeviceCreateRequest, DeviceIoRequest,
-    DeviceReadRequest, DeviceWriteRequest, FileAttributes, FileEndOfFileInformation, FileInformationClass,
-    FileInformationClassLevel, MajorFunction, MinorFunction, NtStatus, ServerDriveIoRequest,
-    ServerDriveQueryInformationRequest, ServerDriveSetInformationRequest, SharedAccess,
+    AnyIoCtlCode, CreateDisposition, CreateOptions, DecodedDeviceControlRequest, DesiredAccess, DeviceCloseRequest,
+    DeviceControlRequest, DeviceCreateRequest, DeviceFlushBuffersRequest, DeviceIoRequest, DeviceReadRequest,
+    DeviceWriteRequest, FileAttributes, FileEndOfFileInformation, FileInformationClass, FileInformationClassLevel,
+    FileSystemInformationClassLevel, LockOperation, MajorFunction, MinorFunction, NtStatus, RdpLockInfo,
+    SecurityInformation, ServerDriveIoRequest, ServerDriveLockControlRequest, ServerDriveNotifyChangeDirectoryRequest,
+    ServerDriveQueryDirectoryRequest, ServerDriveQueryInformationRequest, ServerDriveQuerySecurityRequest,
+    ServerDriveQueryVolumeInformationRequest, ServerDriveSetInformationRequest, ServerDriveSetSecurityRequest,
+    SharedAccess,
 };
 use ironrdp_rdpdr_native::{RedirectedDrive, WindowsRdpdrBackend, WindowsRdpdrBackendFactory};
 use ironrdp_svc::SvcMessage;
+use tracing as _;
 use windows as _;
 
 const MAX_STATIC_IO_SIZE: usize = 1_024 * 1_024;
@@ -290,8 +295,210 @@ fn reparse_points_cannot_escape_the_trusted_volume_root() {
     );
 }
 
+#[test]
+fn advanced_filesystem_operations_are_handle_bound() {
+    let fixture = Fixture::new();
+    let mut backend = fixture.backend();
+    activate(&mut backend);
+
+    let file_response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::ServerCreateDriveRequest(create_request(
+            &fixture.relative(r"root\advanced.txt"),
+            CreateDisposition::FILE_OPEN_IF,
+        )))
+        .expect("complete advanced file create");
+    assert_eq!(response_status(&file_response), NtStatus::SUCCESS);
+    let file_id = response_file_id(&file_response);
+
+    let stream_response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::ServerDriveQueryInformationRequest(
+            ServerDriveQueryInformationRequest {
+                device_io_request: request_header(file_id, MajorFunction::QueryInformation),
+                file_info_class_lvl: FileInformationClassLevel::FILE_STREAM_INFORMATION,
+            },
+        ))
+        .expect("complete stream query");
+    assert_eq!(response_status(&stream_response), NtStatus::SUCCESS);
+
+    let flush_response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::DeviceFlushBuffersRequest(
+            DeviceFlushBuffersRequest {
+                device_io_request: request_header(file_id, MajorFunction::FlushBuffers),
+            },
+        ))
+        .expect("complete explicit flush");
+    assert_eq!(response_status(&flush_response), NtStatus::SUCCESS);
+
+    let lock_response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::ServerDriveLockControlRequest(
+            ServerDriveLockControlRequest {
+                device_io_request: request_header(file_id, MajorFunction::LockControl),
+                operation: LockOperation::Exclusive,
+                wait: false,
+                locks: vec![RdpLockInfo { length: 4, offset: 0 }],
+            },
+        ))
+        .expect("complete byte-range lock");
+    assert_eq!(response_status(&lock_response), NtStatus::SUCCESS);
+
+    let unlock_response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::ServerDriveLockControlRequest(
+            ServerDriveLockControlRequest {
+                device_io_request: request_header(file_id, MajorFunction::LockControl),
+                operation: LockOperation::Unlock,
+                wait: false,
+                locks: vec![RdpLockInfo { length: 4, offset: 0 }],
+            },
+        ))
+        .expect("complete byte-range unlock");
+    assert_eq!(response_status(&unlock_response), NtStatus::SUCCESS);
+
+    let control_response = backend
+        .handle_drive_device_control(DecodedDeviceControlRequest {
+            request: DeviceControlRequest {
+                header: request_header(file_id, MajorFunction::DeviceControl),
+                output_buffer_length: 2,
+                input_buffer_length: 0,
+                io_control_code: AnyIoCtlCode(0x0009_003c),
+            },
+            input_buffer: Vec::new(),
+        })
+        .expect("complete compression query");
+    assert_eq!(response_status(&control_response), NtStatus::SUCCESS);
+
+    let directory_response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::ServerCreateDriveRequest(
+            directory_create_request(&fixture.relative("root")),
+        ))
+        .expect("open directory");
+    assert_eq!(response_status(&directory_response), NtStatus::SUCCESS);
+    let directory_id = response_file_id(&directory_response);
+
+    let query_directory_response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::ServerDriveQueryDirectoryRequest(
+            ServerDriveQueryDirectoryRequest {
+                device_io_request: request_header(directory_id, MajorFunction::DirectoryControl),
+                file_info_class_lvl: FileInformationClassLevel::FILE_NAMES_INFORMATION,
+                initial_query: 1,
+                path: fixture.relative(r"root\*"),
+            },
+        ))
+        .expect("complete directory query");
+    assert_eq!(response_status(&query_directory_response), NtStatus::SUCCESS);
+
+    let volume_response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::ServerDriveQueryVolumeInformationRequest(
+            ServerDriveQueryVolumeInformationRequest {
+                device_io_request: request_header(directory_id, MajorFunction::QueryVolumeInformation),
+                fs_info_class_lvl: FileSystemInformationClassLevel::FILE_FS_VOLUME_INFORMATION,
+            },
+        ))
+        .expect("complete volume query");
+    assert_eq!(response_status(&volume_response), NtStatus::SUCCESS);
+}
+
+#[test]
+fn directory_notifications_are_cancelled_by_close() {
+    let fixture = Fixture::new();
+    let mut backend = fixture.backend();
+    activate(&mut backend);
+
+    let directory_response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::ServerCreateDriveRequest(
+            directory_create_request(&fixture.relative("root")),
+        ))
+        .expect("open watched directory");
+    assert_eq!(response_status(&directory_response), NtStatus::SUCCESS);
+    let directory_id = response_file_id(&directory_response);
+
+    let scheduled = backend
+        .handle_drive_io_request(ServerDriveIoRequest::ServerDriveNotifyChangeDirectoryRequest(
+            ServerDriveNotifyChangeDirectoryRequest {
+                device_io_request: request_header(directory_id, MajorFunction::DirectoryControl),
+                watch_tree: 0,
+                completion_filter: 1,
+            },
+        ))
+        .expect("schedule directory notification");
+    assert!(scheduled.is_empty());
+
+    let close_response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::DeviceCloseRequest(DeviceCloseRequest {
+            device_io_request: request_header(directory_id, MajorFunction::Close),
+        }))
+        .expect("close watched directory");
+    assert_eq!(close_response.len(), 2);
+    assert_eq!(response_status(&close_response[..1]), NtStatus::SUCCESS);
+    assert_eq!(response_status(&close_response[1..]), NtStatus::SUCCESS);
+    assert!(
+        RdpdrBackend::poll_deferred_messages(&mut backend)
+            .expect("poll cancelled notification")
+            .is_empty()
+    );
+}
+
+#[test]
+fn security_descriptor_query_and_set_use_the_opened_handle() {
+    let fixture = Fixture::new();
+    let mut backend = fixture.backend();
+    activate(&mut backend);
+
+    let mut create = create_request(&fixture.relative(r"root\security.txt"), CreateDisposition::FILE_OPEN_IF);
+    create.desired_access = DesiredAccess::from_bits_retain(0x0016_0083);
+    let create_response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::ServerCreateDriveRequest(create))
+        .expect("create security test file");
+    assert_eq!(response_status(&create_response), NtStatus::SUCCESS);
+    let file_id = response_file_id(&create_response);
+
+    let query_response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::ServerDriveQuerySecurityRequest(
+            ServerDriveQuerySecurityRequest {
+                device_io_request: request_header(file_id, MajorFunction::QuerySecurity),
+                security_information: SecurityInformation::OWNER
+                    | SecurityInformation::GROUP
+                    | SecurityInformation::DACL,
+            },
+        ))
+        .expect("query security descriptor");
+    assert_eq!(response_status(&query_response), NtStatus::SUCCESS);
+    let bytes = query_response[0]
+        .encode_unframed_pdu()
+        .expect("encode security response");
+    let descriptor_length = usize::try_from(u32::from_le_bytes(
+        bytes[16..20].try_into().expect("security descriptor length"),
+    ))
+    .expect("descriptor length fits in usize");
+    let descriptor = bytes[20..20 + descriptor_length].to_vec();
+    assert!(!descriptor.is_empty());
+
+    let set_response = backend
+        .handle_drive_io_request(ServerDriveIoRequest::ServerDriveSetSecurityRequest(
+            ServerDriveSetSecurityRequest {
+                device_io_request: request_header(file_id, MajorFunction::SetSecurity),
+                security_information: SecurityInformation::DACL,
+                security_descriptor: descriptor,
+            },
+        ))
+        .expect("set security descriptor");
+    assert_eq!(response_status(&set_response), NtStatus::SUCCESS);
+}
+
 fn activate(backend: &mut WindowsRdpdrBackend) {
     RdpdrBackend::restore_drive(backend, 1).expect("activate test drive");
+}
+
+fn directory_create_request(path: &str) -> DeviceCreateRequest {
+    DeviceCreateRequest {
+        device_io_request: request_header(0, MajorFunction::Create),
+        desired_access: DesiredAccess::from_bits_retain(0x0010_0001),
+        allocation_size: 0,
+        file_attributes: FileAttributes::empty(),
+        shared_access: SharedAccess::from_bits_retain(0x0000_0007),
+        create_disposition: CreateDisposition::FILE_OPEN,
+        create_options: CreateOptions::from_bits_retain(0x0000_0021),
+        path: path.to_owned(),
+    }
 }
 
 fn create_request(path: &str, disposition: CreateDisposition) -> DeviceCreateRequest {

--- a/crates/ironrdp-rdpdr/src/backend/mod.rs
+++ b/crates/ironrdp-rdpdr/src/backend/mod.rs
@@ -16,6 +16,14 @@ use crate::pdu::esc::{ScardCall, ScardIoCtlCode};
 
 /// Device redirection backend interface.
 pub trait RdpdrBackend: AsAny + fmt::Debug + Send {
+    /// Indicates whether the backend implements the RDPDR security IRPs.
+    ///
+    /// The channel advertises the corresponding optional capability bits only
+    /// when this returns `true`.
+    fn supports_drive_security(&self) -> bool {
+        false
+    }
+
     /// Releases state associated with the current RDPDR initialization sequence.
     ///
     /// A Server Announce Request starts a new sequence. Stateful

--- a/crates/ironrdp-rdpdr/src/lib.rs
+++ b/crates/ironrdp-rdpdr/src/lib.rs
@@ -409,6 +409,13 @@ impl Rdpdr {
     fn enable_drive_capability(&mut self) {
         if !self.drive_capability_configured {
             self.capabilities.add_drive();
+            if self
+                .backend
+                .as_ref()
+                .is_some_and(|backend| backend.supports_drive_security())
+            {
+                self.capabilities.add_drive_security();
+            }
             self.drive_capability_configured = true;
         }
     }
@@ -684,13 +691,16 @@ impl SvcProcessor for Rdpdr {
             | RdpdrPdu::DeviceControlResponse(_)
             | RdpdrPdu::DeviceCreateResponse(_)
             | RdpdrPdu::ClientDriveQueryInformationResponse(_)
+            | RdpdrPdu::ClientDriveQuerySecurityResponse(_)
             | RdpdrPdu::DeviceCloseResponse(_)
             | RdpdrPdu::ClientDriveQueryDirectoryResponse(_)
             | RdpdrPdu::ClientDriveNotifyChangeDirectoryResponse(_)
             | RdpdrPdu::ClientDriveQueryVolumeInformationResponse(_)
             | RdpdrPdu::DeviceReadResponse(_)
             | RdpdrPdu::DeviceWriteResponse(_)
+            | RdpdrPdu::DeviceFlushBuffersResponse(_)
             | RdpdrPdu::ClientDriveSetInformationResponse(_)
+            | RdpdrPdu::ClientDriveSetSecurityResponse(_)
             | RdpdrPdu::ClientDriveLockControlResponse(_)
             | RdpdrPdu::EmptyResponse => Err(pdu_other_err!("Rdpdr", "received unexpected packet")),
         }

--- a/crates/ironrdp-rdpdr/src/pdu/efs.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/efs.rs
@@ -1869,8 +1869,11 @@ pub enum ServerDriveIoRequest {
     DeviceControlRequest(DeviceControlRequest<AnyIoCtlCode>),
     DeviceReadRequest(DeviceReadRequest),
     DeviceWriteRequest(DeviceWriteRequest),
+    DeviceFlushBuffersRequest(DeviceFlushBuffersRequest),
     ServerDriveSetInformationRequest(ServerDriveSetInformationRequest),
     ServerDriveLockControlRequest(ServerDriveLockControlRequest),
+    ServerDriveQuerySecurityRequest(ServerDriveQuerySecurityRequest),
+    ServerDriveSetSecurityRequest(ServerDriveSetSecurityRequest),
 }
 
 impl ServerDriveIoRequest {
@@ -1880,6 +1883,7 @@ impl ServerDriveIoRequest {
             MajorFunction::Close => Ok(DeviceCloseRequest::decode(dev_io_req).into()),
             MajorFunction::Read => Ok(DeviceReadRequest::decode(dev_io_req, src)?.into()),
             MajorFunction::Write => Ok(DeviceWriteRequest::decode(dev_io_req, src)?.into()),
+            MajorFunction::FlushBuffers => Ok(DeviceFlushBuffersRequest::decode(dev_io_req).into()),
             MajorFunction::DeviceControl => Ok(DeviceControlRequest::<AnyIoCtlCode>::decode(dev_io_req, src)?.into()),
             MajorFunction::QueryVolumeInformation => {
                 Ok(ServerDriveQueryVolumeInformationRequest::decode(dev_io_req, src)?.into())
@@ -1901,10 +1905,9 @@ impl ServerDriveIoRequest {
                 )),
             },
             MajorFunction::LockControl => Ok(ServerDriveLockControlRequest::decode(dev_io_req, src)?.into()),
-            MajorFunction::FlushBuffers
-            | MajorFunction::SetVolumeInformation
-            | MajorFunction::QuerySecurity
-            | MajorFunction::SetSecurity => Err(unsupported_value_err!(
+            MajorFunction::QuerySecurity => Ok(ServerDriveQuerySecurityRequest::decode(dev_io_req, src)?.into()),
+            MajorFunction::SetSecurity => Ok(ServerDriveSetSecurityRequest::decode(dev_io_req, src)?.into()),
+            MajorFunction::SetVolumeInformation => Err(unsupported_value_err!(
                 "ServerDriveIoRequest::decode",
                 "MajorFunction",
                 "unsupported value".to_owned()
@@ -1967,6 +1970,12 @@ impl From<DeviceWriteRequest> for ServerDriveIoRequest {
     }
 }
 
+impl From<DeviceFlushBuffersRequest> for ServerDriveIoRequest {
+    fn from(req: DeviceFlushBuffersRequest) -> Self {
+        Self::DeviceFlushBuffersRequest(req)
+    }
+}
+
 impl From<ServerDriveSetInformationRequest> for ServerDriveIoRequest {
     fn from(req: ServerDriveSetInformationRequest) -> Self {
         Self::ServerDriveSetInformationRequest(req)
@@ -1976,6 +1985,18 @@ impl From<ServerDriveSetInformationRequest> for ServerDriveIoRequest {
 impl From<ServerDriveLockControlRequest> for ServerDriveIoRequest {
     fn from(req: ServerDriveLockControlRequest) -> Self {
         Self::ServerDriveLockControlRequest(req)
+    }
+}
+
+impl From<ServerDriveQuerySecurityRequest> for ServerDriveIoRequest {
+    fn from(req: ServerDriveQuerySecurityRequest) -> Self {
+        Self::ServerDriveQuerySecurityRequest(req)
+    }
+}
+
+impl From<ServerDriveSetSecurityRequest> for ServerDriveIoRequest {
+    fn from(req: ServerDriveSetSecurityRequest) -> Self {
+        Self::ServerDriveSetSecurityRequest(req)
     }
 }
 
@@ -4761,8 +4782,11 @@ mod tests {
         let mut query_payload = Vec::new();
         query_payload.extend_from_slice(&SecurityInformation::OWNER.bits().to_le_bytes());
 
-        let query = ServerDriveQuerySecurityRequest::decode(request.clone(), &mut ReadCursor::new(&query_payload))
+        let query = ServerDriveIoRequest::decode(request.clone(), &mut ReadCursor::new(&query_payload))
             .expect("valid query security request");
+        let ServerDriveIoRequest::ServerDriveQuerySecurityRequest(query) = query else {
+            panic!("decoded request must be query security");
+        };
         assert_eq!(query.security_information, SecurityInformation::OWNER);
 
         let descriptor = vec![1, 2, 3, 4];
@@ -4775,8 +4799,11 @@ mod tests {
             major_function: MajorFunction::SetSecurity,
             ..request
         };
-        let set = ServerDriveSetSecurityRequest::decode(set_request, &mut ReadCursor::new(&set_payload))
+        let set = ServerDriveIoRequest::decode(set_request, &mut ReadCursor::new(&set_payload))
             .expect("valid set security request");
+        let ServerDriveIoRequest::ServerDriveSetSecurityRequest(set) = set else {
+            panic!("decoded request must be set security");
+        };
         assert_eq!(set.security_descriptor, descriptor);
 
         let query_response = ClientDriveQuerySecurityResponse {
@@ -4900,13 +4927,14 @@ mod tests {
             minor_function: MinorFunction::from(0),
         };
 
-        let decoded = DeviceFlushBuffersRequest::decode(request.clone());
+        let decoded =
+            ServerDriveIoRequest::decode(request.clone(), &mut ReadCursor::new(&[])).expect("valid flush request");
 
         assert_eq!(
             decoded,
-            DeviceFlushBuffersRequest {
+            ServerDriveIoRequest::DeviceFlushBuffersRequest(DeviceFlushBuffersRequest {
                 device_io_request: request,
-            }
+            })
         );
     }
 
@@ -4937,23 +4965,16 @@ mod tests {
     }
 
     #[test]
-    fn filesystem_foundation_requests_remain_outside_drive_dispatch() {
-        for major_function in [
-            MajorFunction::FlushBuffers,
-            MajorFunction::SetVolumeInformation,
-            MajorFunction::QuerySecurity,
-            MajorFunction::SetSecurity,
-        ] {
-            let request = DeviceIoRequest {
-                device_id: 1,
-                file_id: 2,
-                completion_id: 3,
-                major_function,
-                minor_function: MinorFunction::from(0),
-            };
+    fn volume_updates_remain_outside_drive_dispatch() {
+        let request = DeviceIoRequest {
+            device_id: 1,
+            file_id: 2,
+            completion_id: 3,
+            major_function: MajorFunction::SetVolumeInformation,
+            minor_function: MinorFunction::from(0),
+        };
 
-            assert!(ServerDriveIoRequest::decode(request, &mut ReadCursor::new(&[])).is_err());
-        }
+        assert!(ServerDriveIoRequest::decode(request, &mut ReadCursor::new(&[])).is_err());
     }
 
     #[test]

--- a/crates/ironrdp-rdpdr/src/pdu/mod.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/mod.rs
@@ -9,9 +9,10 @@ use ironrdp_svc::SvcEncode;
 use self::efs::{
     ClientDeviceListAnnounce, ClientDeviceListRemove, ClientDriveLockControlResponse,
     ClientDriveNotifyChangeDirectoryResponse, ClientDriveQueryDirectoryResponse, ClientDriveQueryInformationResponse,
-    ClientDriveQueryVolumeInformationResponse, ClientDriveSetInformationResponse, ClientNameRequest, CoreCapability,
-    CoreCapabilityKind, DeviceCloseResponse, DeviceControlResponse, DeviceCreateResponse, DeviceIoRequest,
-    DeviceReadResponse, DeviceWriteResponse, ServerDeviceAnnounceResponse, VersionAndIdPdu, VersionAndIdPduKind,
+    ClientDriveQuerySecurityResponse, ClientDriveQueryVolumeInformationResponse, ClientDriveSetInformationResponse,
+    ClientDriveSetSecurityResponse, ClientNameRequest, CoreCapability, CoreCapabilityKind, DeviceCloseResponse,
+    DeviceControlResponse, DeviceCreateResponse, DeviceFlushBuffersResponse, DeviceIoRequest, DeviceReadResponse,
+    DeviceWriteResponse, ServerDeviceAnnounceResponse, VersionAndIdPdu, VersionAndIdPduKind,
 };
 
 pub mod efs;
@@ -29,13 +30,16 @@ pub enum RdpdrPdu {
     DeviceControlResponse(DeviceControlResponse),
     DeviceCreateResponse(DeviceCreateResponse),
     ClientDriveQueryInformationResponse(ClientDriveQueryInformationResponse),
+    ClientDriveQuerySecurityResponse(ClientDriveQuerySecurityResponse),
     DeviceCloseResponse(DeviceCloseResponse),
     ClientDriveQueryDirectoryResponse(ClientDriveQueryDirectoryResponse),
-    ClientDriveNotifyChangeDirectoryResponse(ClientDriveNotifyChangeDirectoryResponse),
     ClientDriveQueryVolumeInformationResponse(ClientDriveQueryVolumeInformationResponse),
     DeviceReadResponse(DeviceReadResponse),
     DeviceWriteResponse(DeviceWriteResponse),
+    DeviceFlushBuffersResponse(DeviceFlushBuffersResponse),
     ClientDriveSetInformationResponse(ClientDriveSetInformationResponse),
+    ClientDriveSetSecurityResponse(ClientDriveSetSecurityResponse),
+    ClientDriveNotifyChangeDirectoryResponse(ClientDriveNotifyChangeDirectoryResponse),
     ClientDriveLockControlResponse(ClientDriveLockControlResponse),
     UserLoggedon,
     EmptyResponse,
@@ -92,13 +96,16 @@ impl RdpdrPdu {
             RdpdrPdu::DeviceControlResponse(_)
             | RdpdrPdu::DeviceCreateResponse(_)
             | RdpdrPdu::ClientDriveQueryInformationResponse(_)
+            | RdpdrPdu::ClientDriveQuerySecurityResponse(_)
             | RdpdrPdu::DeviceCloseResponse(_)
             | RdpdrPdu::ClientDriveQueryDirectoryResponse(_)
-            | RdpdrPdu::ClientDriveNotifyChangeDirectoryResponse(_)
             | RdpdrPdu::ClientDriveQueryVolumeInformationResponse(_)
             | RdpdrPdu::DeviceReadResponse(_)
             | RdpdrPdu::DeviceWriteResponse(_)
+            | RdpdrPdu::DeviceFlushBuffersResponse(_)
             | RdpdrPdu::ClientDriveSetInformationResponse(_)
+            | RdpdrPdu::ClientDriveSetSecurityResponse(_)
+            | RdpdrPdu::ClientDriveNotifyChangeDirectoryResponse(_)
             | RdpdrPdu::ClientDriveLockControlResponse(_)
             | RdpdrPdu::EmptyResponse => SharedHeader {
                 component: Component::RdpdrCtypCore,
@@ -152,13 +159,16 @@ impl Encode for RdpdrPdu {
             RdpdrPdu::DeviceControlResponse(pdu) => pdu.encode(dst),
             RdpdrPdu::DeviceCreateResponse(pdu) => pdu.encode(dst),
             RdpdrPdu::ClientDriveQueryInformationResponse(pdu) => pdu.encode(dst),
+            RdpdrPdu::ClientDriveQuerySecurityResponse(pdu) => pdu.encode(dst),
             RdpdrPdu::DeviceCloseResponse(pdu) => pdu.encode(dst),
             RdpdrPdu::ClientDriveQueryDirectoryResponse(pdu) => pdu.encode(dst),
-            RdpdrPdu::ClientDriveNotifyChangeDirectoryResponse(pdu) => pdu.encode(dst),
             RdpdrPdu::ClientDriveQueryVolumeInformationResponse(pdu) => pdu.encode(dst),
             RdpdrPdu::DeviceReadResponse(pdu) => pdu.encode(dst),
             RdpdrPdu::DeviceWriteResponse(pdu) => pdu.encode(dst),
+            RdpdrPdu::DeviceFlushBuffersResponse(pdu) => pdu.encode(dst),
             RdpdrPdu::ClientDriveSetInformationResponse(pdu) => pdu.encode(dst),
+            RdpdrPdu::ClientDriveSetSecurityResponse(pdu) => pdu.encode(dst),
+            RdpdrPdu::ClientDriveNotifyChangeDirectoryResponse(pdu) => pdu.encode(dst),
             RdpdrPdu::ClientDriveLockControlResponse(pdu) => pdu.encode(dst),
             RdpdrPdu::UserLoggedon => Ok(()),
             RdpdrPdu::EmptyResponse => {
@@ -181,13 +191,16 @@ impl Encode for RdpdrPdu {
             RdpdrPdu::DeviceControlResponse(pdu) => pdu.name(),
             RdpdrPdu::DeviceCreateResponse(pdu) => pdu.name(),
             RdpdrPdu::ClientDriveQueryInformationResponse(pdu) => pdu.name(),
+            RdpdrPdu::ClientDriveQuerySecurityResponse(pdu) => pdu.name(),
             RdpdrPdu::DeviceCloseResponse(pdu) => pdu.name(),
             RdpdrPdu::ClientDriveQueryDirectoryResponse(pdu) => pdu.name(),
-            RdpdrPdu::ClientDriveNotifyChangeDirectoryResponse(pdu) => pdu.name(),
             RdpdrPdu::ClientDriveQueryVolumeInformationResponse(pdu) => pdu.name(),
             RdpdrPdu::DeviceReadResponse(pdu) => pdu.name(),
             RdpdrPdu::DeviceWriteResponse(pdu) => pdu.name(),
+            RdpdrPdu::DeviceFlushBuffersResponse(pdu) => pdu.name(),
             RdpdrPdu::ClientDriveSetInformationResponse(pdu) => pdu.name(),
+            RdpdrPdu::ClientDriveSetSecurityResponse(pdu) => pdu.name(),
+            RdpdrPdu::ClientDriveNotifyChangeDirectoryResponse(pdu) => pdu.name(),
             RdpdrPdu::ClientDriveLockControlResponse(pdu) => pdu.name(),
             RdpdrPdu::UserLoggedon => "UserLoggedon",
             RdpdrPdu::EmptyResponse => "EmptyResponse",
@@ -207,13 +220,16 @@ impl Encode for RdpdrPdu {
                 RdpdrPdu::DeviceControlResponse(pdu) => pdu.size(),
                 RdpdrPdu::DeviceCreateResponse(pdu) => pdu.size(),
                 RdpdrPdu::ClientDriveQueryInformationResponse(pdu) => pdu.size(),
+                RdpdrPdu::ClientDriveQuerySecurityResponse(pdu) => pdu.size(),
                 RdpdrPdu::DeviceCloseResponse(pdu) => pdu.size(),
                 RdpdrPdu::ClientDriveQueryDirectoryResponse(pdu) => pdu.size(),
-                RdpdrPdu::ClientDriveNotifyChangeDirectoryResponse(pdu) => pdu.size(),
                 RdpdrPdu::ClientDriveQueryVolumeInformationResponse(pdu) => pdu.size(),
                 RdpdrPdu::DeviceReadResponse(pdu) => pdu.size(),
                 RdpdrPdu::DeviceWriteResponse(pdu) => pdu.size(),
+                RdpdrPdu::DeviceFlushBuffersResponse(pdu) => pdu.size(),
                 RdpdrPdu::ClientDriveSetInformationResponse(pdu) => pdu.size(),
+                RdpdrPdu::ClientDriveSetSecurityResponse(pdu) => pdu.size(),
+                RdpdrPdu::ClientDriveNotifyChangeDirectoryResponse(pdu) => pdu.size(),
                 RdpdrPdu::ClientDriveLockControlResponse(pdu) => pdu.size(),
                 RdpdrPdu::UserLoggedon => 0,
                 RdpdrPdu::EmptyResponse => size_of::<u32>(),
@@ -256,13 +272,13 @@ impl fmt::Debug for RdpdrPdu {
             Self::ClientDriveQueryInformationResponse(it) => {
                 write!(f, "RdpdrPdu({it:?})")
             }
+            Self::ClientDriveQuerySecurityResponse(it) => {
+                write!(f, "RdpdrPdu({it:?})")
+            }
             Self::DeviceCloseResponse(it) => {
                 write!(f, "RdpdrPdu({it:?})")
             }
             Self::ClientDriveQueryDirectoryResponse(it) => {
-                write!(f, "RdpdrPdu({it:?})")
-            }
-            Self::ClientDriveNotifyChangeDirectoryResponse(it) => {
                 write!(f, "RdpdrPdu({it:?})")
             }
             Self::ClientDriveQueryVolumeInformationResponse(it) => {
@@ -274,7 +290,16 @@ impl fmt::Debug for RdpdrPdu {
             Self::DeviceWriteResponse(it) => {
                 write!(f, "RdpdrPdu({it:?})")
             }
+            Self::DeviceFlushBuffersResponse(it) => {
+                write!(f, "RdpdrPdu({it:?})")
+            }
             Self::ClientDriveSetInformationResponse(it) => {
+                write!(f, "RdpdrPdu({it:?})")
+            }
+            Self::ClientDriveSetSecurityResponse(it) => {
+                write!(f, "RdpdrPdu({it:?})")
+            }
+            Self::ClientDriveNotifyChangeDirectoryResponse(it) => {
                 write!(f, "RdpdrPdu({it:?})")
             }
             Self::ClientDriveLockControlResponse(it) => {
@@ -308,6 +333,12 @@ impl From<ClientDriveQueryInformationResponse> for RdpdrPdu {
     }
 }
 
+impl From<ClientDriveQuerySecurityResponse> for RdpdrPdu {
+    fn from(value: ClientDriveQuerySecurityResponse) -> Self {
+        Self::ClientDriveQuerySecurityResponse(value)
+    }
+}
+
 impl From<DeviceCloseResponse> for RdpdrPdu {
     fn from(value: DeviceCloseResponse) -> Self {
         Self::DeviceCloseResponse(value)
@@ -317,12 +348,6 @@ impl From<DeviceCloseResponse> for RdpdrPdu {
 impl From<ClientDriveQueryDirectoryResponse> for RdpdrPdu {
     fn from(value: ClientDriveQueryDirectoryResponse) -> Self {
         Self::ClientDriveQueryDirectoryResponse(value)
-    }
-}
-
-impl From<ClientDriveNotifyChangeDirectoryResponse> for RdpdrPdu {
-    fn from(value: ClientDriveNotifyChangeDirectoryResponse) -> Self {
-        Self::ClientDriveNotifyChangeDirectoryResponse(value)
     }
 }
 
@@ -344,9 +369,27 @@ impl From<DeviceWriteResponse> for RdpdrPdu {
     }
 }
 
+impl From<DeviceFlushBuffersResponse> for RdpdrPdu {
+    fn from(value: DeviceFlushBuffersResponse) -> Self {
+        Self::DeviceFlushBuffersResponse(value)
+    }
+}
+
 impl From<ClientDriveSetInformationResponse> for RdpdrPdu {
     fn from(value: ClientDriveSetInformationResponse) -> Self {
         Self::ClientDriveSetInformationResponse(value)
+    }
+}
+
+impl From<ClientDriveSetSecurityResponse> for RdpdrPdu {
+    fn from(value: ClientDriveSetSecurityResponse) -> Self {
+        Self::ClientDriveSetSecurityResponse(value)
+    }
+}
+
+impl From<ClientDriveNotifyChangeDirectoryResponse> for RdpdrPdu {
+    fn from(value: ClientDriveNotifyChangeDirectoryResponse) -> Self {
+        Self::ClientDriveNotifyChangeDirectoryResponse(value)
     }
 }
 


### PR DESCRIPTION
Extend the Windows-native RDPDR backend with confined directory,
notification, lock, security, stream, control, and volume support.
Decode only the portable IRPs and capability needed to dispatch these
native operations.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>