### PR TITLE
ci: clean malformed action package manifest

### DIFF
--- a/.github/actions/resilient-review-output/action.yml
+++ b/.github/actions/resilient-review-output/action.yml
@@ -58,6 +58,16 @@ runs:
         settings: ${{ inputs.settings }}
         prompt: ${{ inputs.prompt }}
 
+    - id: clean-before-validation
+      if: always()
+      # claude-code-action can leave an untracked, malformed package manifest in the base checkout.
+      # The repository does not track one, and Node refuses every subsequent require until it is removed.
+      run: |
+        if ! git ls-files --error-unmatch -- package.json >/dev/null 2>&1; then
+          rm -f -- package.json
+        fi
+      shell: bash
+
     - id: validate-initial
       if: always()
       uses: actions/github-script@v8
@@ -107,6 +117,15 @@ runs:
         prompt: >-
           ${{ inputs.retry_prompt }}
           Trusted validation reason: ${{ steps.validate-initial.outputs.reason }}.
+
+    - id: clean-before-selection
+      if: always()
+      # See the cleanup before validate-initial. The resumed model invocation can recreate the file.
+      run: |
+        if ! git ls-files --error-unmatch -- package.json >/dev/null 2>&1; then
+          rm -f -- package.json
+        fi
+      shell: bash
 
     - id: select
       if: always()

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -55,6 +55,10 @@ test("workflow does not overwrite github-script result outputs", () => {
   const resilientAction = fs.readFileSync(
     path.join(__dirname, "..", "actions", "resilient-review-output", "action.yml"), "utf8");
   assert.match(resilientAction, /--resume \$\{sessionId\}/);
+  assert.equal(
+    (resilientAction.match(/git ls-files --error-unmatch -- package\.json/g) || []).length,
+    2,
+  );
 });
 
 test("workflow does not resolve or write state after cancellation", () => {


### PR DESCRIPTION
Prevent Claude Code Action artifacts from breaking the trusted Node validators that process model output.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>