### PR TITLE
chore: add focused writing and review skills

### DIFF
--- a/.agents/skills/code-compressor/SKILL.md
+++ b/.agents/skills/code-compressor/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: code-compressor
+description: Aggressively review changed code for unnecessary complexity and propose smaller, clearer, behavior-preserving alternatives. Use for code reviews, refactor assessments, or any diff where simplification, deletion, reuse, flatter control flow, or fewer abstractions may improve the implementation.
+---
+
+# Code compressor
+
+Treat every added branch, state, abstraction, helper, conversion, and dependency as complexity that must earn its place.
+Look for duplicated logic, speculative generality, needless indirection, over-modeled state, tangled control flow, verbose data transformations, and code that existing APIs can replace.
+
+Be aggressive in searching, but evidence-driven in reporting.
+Recommend a simplification only when you can describe a concrete, smaller alternative and explain why it preserves required behavior.
+Account for error handling, ownership, lifetimes, performance, public API stability, and repository conventions.
+Do not trade explicit correctness or necessary protocol detail for fewer lines.
+
+Report each opportunity with its location, the complexity it removes, the proposed shape, and any meaningful tradeoff.
+Separate optional compression opportunities from correctness defects.
+Omit formatting, naming preferences, and vague rewrite requests.
+If the code is already close to the simplest correct form, return no findings.

--- a/.agents/skills/docs-compressor/SKILL.md
+++ b/.agents/skills/docs-compressor/SKILL.md
@@ -5,12 +5,9 @@ description: Review documentation changes for concise, human-readable prose with
 
 # Documentation compressor
 
-Make the shortest version that remains accurate and useful to its intended reader.
-Remove repetition, throat-clearing, redundant headings, inflated wording, unnecessary examples, and details already clear from nearby context.
-Prefer direct sentences, concrete verbs, familiar words, and a structure that presents the reader's goal before implementation detail.
-
-Preserve technical precision, prerequisites, warnings, terminology, links, examples that carry unique information, and distinctions that affect behavior.
-Do not compress prose into fragments, erase useful rationale, or replace established project vocabulary merely to shorten it.
+Invoke `docs-writer` and `prose-writer`, then use their rules as review criteria without following their generation workflows.
+Challenge every paragraph, heading, example, and aside that does not add information or help the reader act.
+Look for the same meaning expressed with less structure, repetition, or wording while preserving the writer rules.
 
 Report only material readability gains.
 For each finding, cite the location, explain what obstructs the reader, and provide a concise replacement or a precise deletion.

--- a/.agents/skills/docs-compressor/SKILL.md
+++ b/.agents/skills/docs-compressor/SKILL.md
@@ -8,6 +8,9 @@ description: Review documentation changes for concise, human-readable prose with
 Invoke `docs-writer` and `prose-writer`, then use their rules as review criteria without following their generation workflows.
 Challenge every paragraph, heading, example, and aside that does not add information or help the reader act.
 Look for the same meaning expressed with less structure, repetition, or wording while preserving the writer rules.
+For substantial rewrites, compare word counts before and after.
+Unless the task adds information, treat growth as a failed compression pass and revise until the result is no longer than the original.
+Require a concrete explanation for any unavoidable growth.
 
 Report only material readability gains.
 For each finding, cite the location, explain what obstructs the reader, and provide a concise replacement or a precise deletion.

--- a/.agents/skills/docs-compressor/SKILL.md
+++ b/.agents/skills/docs-compressor/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: docs-compressor
+description: Review documentation changes for concise, human-readable prose without losing technical meaning. Use whenever READMEs, guides, reference docs, rustdoc, explanatory comments, release notes, or other instructional prose is added or edited.
+---
+
+# Documentation compressor
+
+Make the shortest version that remains accurate and useful to its intended reader.
+Remove repetition, throat-clearing, redundant headings, inflated wording, unnecessary examples, and details already clear from nearby context.
+Prefer direct sentences, concrete verbs, familiar words, and a structure that presents the reader's goal before implementation detail.
+
+Preserve technical precision, prerequisites, warnings, terminology, links, examples that carry unique information, and distinctions that affect behavior.
+Do not compress prose into fragments, erase useful rationale, or replace established project vocabulary merely to shorten it.
+
+Report only material readability gains.
+For each finding, cite the location, explain what obstructs the reader, and provide a concise replacement or a precise deletion.
+Combine repeated edits into one finding when the same rewrite addresses them.

--- a/.agents/skills/docs-compressor/SKILL.md
+++ b/.agents/skills/docs-compressor/SKILL.md
@@ -9,8 +9,8 @@ Invoke `docs-writer` and `prose-writer`, then use their rules as review criteria
 Challenge every paragraph, heading, example, and aside that does not add information or help the reader act.
 Look for the same meaning expressed with less structure, repetition, or wording while preserving the writer rules.
 For substantial rewrites, compare word counts before and after.
-Unless the task adds information, treat growth as a failed compression pass and revise until the result is no longer than the original.
-Require a concrete explanation for any unavoidable growth.
+Prefer no net growth when the task adds no information.
+Accept small growth only when it materially improves clarity or navigation without duplicating information, and explain why.
 
 Report only material readability gains.
 For each finding, cite the location, explain what obstructs the reader, and provide a concise replacement or a precise deletion.

--- a/.agents/skills/docs-writer/SKILL.md
+++ b/.agents/skills/docs-writer/SKILL.md
@@ -16,5 +16,6 @@ Place warnings and constraints beside the step they affect.
 Preserve established terminology and verify technical claims against the implementation.
 
 Write the requested documentation directly.
-For rewrites that add no requested information, recover the cost of new headings, tables, and transitions by compressing the body.
+Prefer no net word-count growth when restructuring existing documentation without adding requested information.
+New structure should replace or consolidate prose; allow small justified growth when it materially improves navigation without duplication.
 Before finishing, remove repetition and confirm that a reader can find the next action without reconstructing it from implementation details.

--- a/.agents/skills/docs-writer/SKILL.md
+++ b/.agents/skills/docs-writer/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: docs-writer
+description: Write clear, concise technical documentation that helps readers complete a task or understand an interface. Use whenever creating or substantially rewriting READMEs, guides, tutorials, reference docs, rustdoc, explanatory comments, or release notes.
+---
+
+# Documentation writer
+
+Invoke `prose-writer` before drafting and apply its rules throughout.
+Identify the intended reader, their goal, and the prerequisites they need.
+Present the outcome or shortest successful path before internal mechanics and edge cases.
+Use only the headings needed to answer distinct reader questions.
+Explain one path completely before introducing alternatives, and link to existing material instead of repeating it.
+Keep examples minimal, realistic, and responsible for unique information.
+Place warnings and constraints beside the step they affect.
+Preserve established terminology and verify technical claims against the implementation.
+
+Write the requested documentation directly.
+Before finishing, remove repetition and confirm that a reader can find the next action without reconstructing it from implementation details.

--- a/.agents/skills/docs-writer/SKILL.md
+++ b/.agents/skills/docs-writer/SKILL.md
@@ -5,7 +5,8 @@ description: Write clear, concise technical documentation that helps readers com
 
 # Documentation writer
 
-Invoke `prose-writer` before drafting and apply its rules throughout.
+For Markdown, invoke `markdown-writer`; otherwise invoke `prose-writer`.
+Apply the selected writer's rules throughout.
 Identify the intended reader, their goal, and the prerequisites they need.
 Before restructuring existing documentation, inventory its unique facts so none are lost or restated.
 Present the outcome or shortest successful path before internal mechanics and edge cases.

--- a/.agents/skills/docs-writer/SKILL.md
+++ b/.agents/skills/docs-writer/SKILL.md
@@ -7,6 +7,7 @@ description: Write clear, concise technical documentation that helps readers com
 
 Invoke `prose-writer` before drafting and apply its rules throughout.
 Identify the intended reader, their goal, and the prerequisites they need.
+Before restructuring existing documentation, inventory its unique facts so none are lost or restated.
 Present the outcome or shortest successful path before internal mechanics and edge cases.
 Use only the headings needed to answer distinct reader questions.
 Explain one path completely before introducing alternatives, and link to existing material instead of repeating it.
@@ -15,4 +16,5 @@ Place warnings and constraints beside the step they affect.
 Preserve established terminology and verify technical claims against the implementation.
 
 Write the requested documentation directly.
+For rewrites that add no requested information, recover the cost of new headings, tables, and transitions by compressing the body.
 Before finishing, remove repetition and confirm that a reader can find the next action without reconstructing it from implementation details.

--- a/.agents/skills/markdown-writer/SKILL.md
+++ b/.agents/skills/markdown-writer/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: markdown-writer
+description: Write clean, readable Markdown with concise prose and maintainable source formatting. Use whenever creating or substantially rewriting Markdown files, including READMEs, guides, release notes, issue templates, and Markdown-based documentation.
+---
+
+# Markdown writer
+
+Invoke `prose-writer` before drafting and apply its rules throughout.
+Use the shallowest heading hierarchy that makes the document easy to scan.
+Prefer short paragraphs and lists only when items are easier to compare or follow separately.
+Use fenced code blocks with a language identifier and keep explanatory prose outside the fence.
+
+Prefer reference-style links so URLs do not interrupt the source text.
+Place link definitions near the end of the document and reuse them for repeated destinations.
+Keep inline links when the literal URL is meaningful, the surrounding format requires one, or the link appears in a badge, raw HTML, generated content, or a compact table.
+
+Preserve valid embedded HTML and repository-specific Markdown conventions.
+Before finishing, check heading order, code fences, link definitions, and one sentence per source line.

--- a/.agents/skills/prose-verifier/SKILL.md
+++ b/.agents/skills/prose-verifier/SKILL.md
@@ -5,13 +5,8 @@ description: Verify edited prose is concise, human-first, and written one senten
 
 # Prose verifier
 
-Apply one sentence per line to prose source: each sentence starts on its own line, and a sentence is not hard-wrapped across lines.
-This keeps source diffs local without changing normal rendered paragraphs.
-
-Also verify that the prose leads with the reader's need, uses direct language, removes filler, and keeps sentences as short as clarity allows.
-Preserve necessary nuance, technical terms, and the document's established voice.
-
-Ignore code blocks, tables, headings, link definitions, generated files, and formats where line breaks change rendering or are controlled by a formatter.
-Do not force sentence fragments such as list-item labels onto separate lines.
+Invoke `prose-writer` and use its rules as review criteria without following its generation workflow.
+Review only the touched prose and pay particular attention to concise, human-first phrasing and one sentence per source line.
 Report exact locations and replacement text for violations; group mechanical instances that share one fix.
+Prefer localized corrections over rewriting compliant surrounding prose.
 Return no findings when the touched prose already complies.

--- a/.agents/skills/prose-verifier/SKILL.md
+++ b/.agents/skills/prose-verifier/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: prose-verifier
+description: Verify edited prose is concise, human-first, and written one sentence per source line. Use whenever Markdown, AsciiDoc, plain-text documentation, release notes, or other hand-maintained prose is changed, especially when reviewing documentation style or line-oriented diffs.
+---
+
+# Prose verifier
+
+Apply one sentence per line to prose source: each sentence starts on its own line, and a sentence is not hard-wrapped across lines.
+This keeps source diffs local without changing normal rendered paragraphs.
+
+Also verify that the prose leads with the reader's need, uses direct language, removes filler, and keeps sentences as short as clarity allows.
+Preserve necessary nuance, technical terms, and the document's established voice.
+
+Ignore code blocks, tables, headings, link definitions, generated files, and formats where line breaks change rendering or are controlled by a formatter.
+Do not force sentence fragments such as list-item labels onto separate lines.
+Report exact locations and replacement text for violations; group mechanical instances that share one fix.
+Return no findings when the touched prose already complies.

--- a/.agents/skills/prose-writer/SKILL.md
+++ b/.agents/skills/prose-writer/SKILL.md
@@ -15,4 +15,6 @@ In source formats where newlines render as spaces, start each sentence on its ow
 Do not apply that convention to code blocks, tables, headings, link definitions, generated files, or formats where line breaks affect rendering.
 
 Write the requested prose directly instead of discussing these rules unless the user asks.
+When rewriting existing prose without adding requested information, preserve or reduce its word count.
+Treat source line breaks as formatting, not justification for growth.
 Before finishing, reread from the reader's perspective and remove anything that does not help them understand or act.

--- a/.agents/skills/prose-writer/SKILL.md
+++ b/.agents/skills/prose-writer/SKILL.md
@@ -15,6 +15,7 @@ In source formats where newlines render as spaces, start each sentence on its ow
 Do not apply that convention to code blocks, tables, headings, link definitions, generated files, or formats where line breaks affect rendering.
 
 Write the requested prose directly instead of discussing these rules unless the user asks.
-When rewriting existing prose without adding requested information, preserve or reduce its word count.
+Prefer no net word-count growth when rewriting existing prose without adding requested information.
+Accept small growth only when it materially improves clarity without duplicating information.
 Treat source line breaks as formatting, not justification for growth.
 Before finishing, reread from the reader's perspective and remove anything that does not help them understand or act.

--- a/.agents/skills/prose-writer/SKILL.md
+++ b/.agents/skills/prose-writer/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: prose-writer
+description: Write concise, human-first prose with one sentence per source line. Use whenever generating or substantially rewriting Markdown, AsciiDoc, plain-text documentation, release notes, user-facing explanations, or other hand-maintained prose.
+---
+
+# Prose writer
+
+Lead with what the reader needs to know or do.
+Use direct sentences, concrete verbs, familiar words, and the shortest phrasing that preserves meaning.
+Remove throat-clearing, repetition, inflated wording, and details already clear from context.
+Keep each paragraph focused on one idea and order ideas by reader need rather than implementation history.
+Preserve necessary nuance, technical terms, warnings, and the document's established voice.
+
+In source formats where newlines render as spaces, start each sentence on its own line and do not hard-wrap a sentence.
+Do not apply that convention to code blocks, tables, headings, link definitions, generated files, or formats where line breaks affect rendering.
+
+Write the requested prose directly instead of discussing these rules unless the user asks.
+Before finishing, reread from the reader's perspective and remove anything that does not help them understand or act.

--- a/.agents/skills/review-orchestrator/SKILL.md
+++ b/.agents/skills/review-orchestrator/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: review-orchestrator
+description: Run an efficient, multi-perspective IronRDP diff review and return one evidence-checked report. Use for comprehensive code reviews or whenever protocol correctness, code compression, documentation compression, prose style, and skeptical design review may need coordinated coverage.
+---
+
+# Review orchestrator
+
+Inspect the diff, its stated goal, and repository guidance before selecting reviewers:
+
+- Run `protocol-reviewer` only when the change may affect protocol behavior, wire data, negotiation, state transitions, security, codecs, virtual channels, or protocol-visible errors.
+- Run `code-compressor` for the changed code.
+- Run `docs-compressor` when documentation, rustdoc, explanatory comments, or instructional prose changes.
+- Run `prose-verifier` when hand-maintained prose changes in a format where source line breaks are stylistic.
+- Run `skeptical-reviewer` last for every diff.
+
+Prefer one `rubber-duck` sub-agent per applicable skill.
+Run the protocol, compression, and prose reviews in parallel.
+Give every agent the change goal, review scope, base and head references, relevant repository guidance, and an instruction to invoke its named skill, inspect the diff itself, make no edits, and return only evidence-backed findings.
+If sub-agents or skill invocation are unavailable, apply the same skills directly and keep the ordering.
+
+Before the skeptical pass, normalize the initial results.
+Drop claims that lack a concrete location or mechanism, merge findings with the same root cause, and retain disagreements instead of resolving them by vote.
+Give the skeptical reviewer the diff plus the retained findings and ask it to independently review the change, verify or reject each supplied concern, and identify material issues the focused passes missed.
+
+Evaluate the final evidence yourself.
+Report correctness and protocol findings first, ordered by severity, then optional compression suggestions.
+Each retained item needs a location, concrete impact, and actionable correction or simplification.
+Merge duplicates across reviewers and do not inflate a maintainability preference into a defect.
+Briefly name skipped reviewers and why; if nothing material remains, say that no findings were identified.

--- a/.github/PR_AUTOMATION.md
+++ b/.github/PR_AUTOMATION.md
@@ -1,134 +1,159 @@
 # Pull request automation
 
-`.github/workflows/labeler.yml` classifies ready, open pull requests and runs at most two
-automated reviews. The workflow never runs an LLM for `ai-reviewed/2`; that label is terminal and
-requires human review.
+`.github/workflows/labeler.yml` classifies ready, open pull requests and runs at most two automated reviews.
+The workflow never runs an LLM for `ai-reviewed/2`; that label is terminal and requires human review.
 
-A heavy review is split into two isolated LLM stages. The classifier reports whether the change is
-protocol-related, and that boolean is persisted in machine-readable form on the SHA-bound
-`AI classification` check because the review route runs in a later workflow run. Its workflow-only
-instructions live in `.github/pr-automation/prompts/classifier.md`. Each LLM stage similarly injects
-its pipeline-specific evidence and output contract from
-`.github/pr-automation/prompts/<stage>.md`; reusable review methodology remains in `.agents/skills`.
-When it is true, **Analyze protocol conformance** runs first: it stages the `awakecoding/openspecs` default branch into
-`.claude/skills/windows-protocols/` with a credentialless git fetch — no `npx`, package lifecycle
-script, or global install — together with the repository's `.agents/skills/protocol-reviewer` skill. The commit it
-resolved is handed to the validation job, so both stages read the same corpus even if the corpus moves
-in between. A trusted job then validates that handoff, including that every cited protocol ID and
-section heading exists in that corpus. **Review pull request** invokes the
-`.agents/skills/skeptical-reviewer` skill: it never sees the corpus, receives the validated handoff as
-a data file, and must record whether it accepted, partly accepted, or rejected the protocol findings.
-Only its output is published, and inline comments are placed only on lines this pull request actually
-adds; any other finding is published in the review body instead.
+## Review pipeline
 
-Protocol-related reviews normally consume two calls against `ANTHROPIC_API_KEY_REVIEWER`;
-non-protocol reviews normally consume one. Each heavy stage validates its structured output
-immediately. If the action reaches its turn limit or validation rejects the result, it resumes that
-exact Claude session once with a six-turn output-only budget, preserving the analysis already paid
-for instead of starting over. The separately isolated publication jobs still revalidate the selected
-result against GitHub's pull request data and the pinned protocol corpus. If both attempts fail, the
-AI review count is unchanged, the PR stays `maintainer-required`, and a neutral SHA-bound
-`AI automated review` check records the precise failure reason. A classification check that predates
-the machine-readable protocol state is treated as unavailable; the next classification event
-rewrites it.
+The heavy review path uses two isolated LLM stages.
+Workflow-only classifier instructions live in `.github/pr-automation/prompts/classifier.md`.
+Each LLM stage similarly injects its pipeline-specific evidence and output contract from `.github/pr-automation/prompts/<stage>.md`, while reusable review methodology remains in `.agents/skills`.
+
+1. The classifier reports whether the change is protocol-related.
+   This boolean is persisted in machine-readable form on the SHA-bound `AI classification` check because review runs in a later workflow.
+2. When the result is true, **Analyze protocol conformance** runs first.
+   It stages the `awakecoding/openspecs` default branch into `.claude/skills/windows-protocols/` with a credentialless git fetch, without `npx`, package lifecycle scripts, or a global install.
+   It also stages the repository's `.agents/skills/protocol-reviewer` skill.
+   The resolved corpus commit is handed to the validation job so both stages read the same corpus even if its default branch moves.
+3. A trusted job validates the handoff, including that every cited protocol ID and section heading exists in the pinned corpus.
+4. **Review pull request** invokes `.agents/skills/skeptical-reviewer`.
+   It never sees the corpus, receives the validated handoff as a data file, and records whether it accepted, partly accepted, or rejected the protocol findings.
+5. Only the skeptical review output is published.
+   Inline comments are placed only on lines the pull request adds; every other finding appears in the review body.
+
+## Validation and recovery
+
+Protocol-related reviews normally consume two calls against `ANTHROPIC_API_KEY_REVIEWER`, while non-protocol reviews normally consume one.
+Each heavy stage validates its structured output immediately.
+If an action reaches its turn limit or validation rejects the result, it resumes the same Claude session once with a six-turn output-only budget.
+This retry preserves the analysis already paid for instead of starting over.
+The separately isolated publication jobs still revalidate the selected result against GitHub's pull request data and the pinned protocol corpus.
+
+If both attempts fail, the AI review count is unchanged and the pull request stays `maintainer-required`.
+A neutral SHA-bound `AI automated review` check records the precise failure reason.
+A classification check that predates the machine-readable protocol state is treated as unavailable, and the next classification event rewrites it.
 
 The trusted LLM validators normalize exact empty-string representation artifacts consistently.
-An invalid classifier result keeps the pull request `risk/unknown` and
-`maintainer-required`, and publishes a neutral `AI classification` check containing the local
-validation reason so the review remains blocked without hiding why. A cancelled workflow does not
-publish a fallback state or change labels; the succeeding workflow run recomputes the classification.
+An invalid classifier result keeps the pull request `risk/unknown` and `maintainer-required`.
+It also publishes a neutral `AI classification` check containing the local validation reason so the review remains blocked without hiding why.
+A cancelled workflow does not publish a fallback state or change labels; the succeeding workflow run recomputes the classification.
 
-Each analytical stage selects its model and effort through `--model` and `--effort` in the `claude-args` step
-that builds its `claude_args`. The classifier runs Sonnet at `low` effort: it runs on every push and
-only has to fill a small, schema-bound triage record, so it buys Sonnet-class judgement at a
-fraction of the default token spend. Both heavy stages run Opus at its default `high` effort, since
-protocol conformance and skeptical judgement are the work worth paying for and they run at most
-twice per pull request. `haiku` is cheaper than Sonnet at `low` effort but supports no effort level
-at all, which is why the classifier does not use it. The model names are floating aliases, so each
-stage tracks the latest model of its tier.
+## Models and cost
 
-Bot-authored pull requests, including Dependabot's and `devolutionsbot`'s release-plz PRs, are
-excluded from this workflow. Dependabot is the sole owner of dependency and language labels, so
-this automation never adds, removes, or reconciles labels on bot pull requests.
+Each analytical stage selects its model and effort through `--model` and `--effort` in the `claude-args` step that builds `claude_args`.
 
-Every LLM stage is given the same evidence, prepared by `.github/pr-automation/fetch-pr-evidence.sh`
-running from the trusted base checkout. The action uses only an explicit file or skill invocation,
-which injects no pull request context of its own, and `Bash` is denied, so a model cannot derive a
-diff by itself. Trusted workflow code writes the target head SHA and handoff-receipt status to
-`pr-automation-context.json` rather than interpolating them into instructions. The script writes
-`pr-evidence/changed-files.txt` and `pr-evidence/pull-request.diff`, both computed against the merge
-base so that unrelated commits landing on `master` are not attributed to the pull request, and the
-head tree stays available in `pr-head` for surrounding context. Before exposing that tree to
-filesystem-reading tools, it removes all symlinks so a pull request cannot redirect a read outside the
-checkout. It also removes contributor-controlled agent instruction files — `CLAUDE.md`,
-`CLAUDE.local.md`, `AGENTS.md`, `.claude`, `.cursor`, `.cursorrules` — recursively rather than only
-at the checkout root, because Claude Code discovers them in every directory it reads and a nested copy
-would otherwise escape the evidence-only boundary. Those files still appear in the diff, where they
-are reviewable data rather than instructions.
+| Stage | Model | Effort | Reason |
+| --- | --- | --- | --- |
+| Classifier | Sonnet | `low` | Runs on every push and fills a small, schema-bound triage record. |
+| Protocol conformance | Opus | Default `high` | Performs the protocol analysis worth the higher cost. |
+| Skeptical review | Opus | Default `high` | Evaluates correctness and the validated protocol handoff. |
 
-Model output is likewise treated as hostile on the way out. Text published in a bot comment or
-review is escaped so that HTML, code spans, mentions, issue references, and the Markdown constructs
-that produce links, images, and emphasis all render as inert prose.
+The heavy stages run at most twice per pull request.
+`haiku` is cheaper than Sonnet at `low` effort but supports no effort level, so the classifier does not use it.
+Model names are floating aliases, so each stage tracks the latest model in its tier.
 
-Each workflow run writes a structured decision trace to its GitHub Actions logs. It records event
-resolution, all gate and deterministic-analysis results, normalized classification and review states,
-and the selected label additions, removals, comments, and check mutation. Jobs skipped by a gate are
-included in the final trace with their job outcome. After every LLM
-stage, the log also records the action outcome and its complete schema-bound structured output. These
-values are untrusted pull-request-derived evidence: they are emitted through `core.info`, never
-interpolated into a shell command or executed.
+## Exclusions and limits
 
-The `risk/*` label states how much maintainer scrutiny a change needs, not how much an automated
-review is worth. Every classified pull request has exactly one risk label. `risk/high` means the
-change substantially affects the public API surface of a core tier crate; `risk/medium` means a
-behavioural change that does not substantially alter a core public API; `risk/low` means a
-self-contained change with no cross-crate behavioural effect; and `risk/unknown` means the
-classifier could not produce a valid judgement. A `cargo-semver-checks` incompatibility always
-produces `risk/high`, even when the classifier is unavailable, because that check runs against the
-`ironrdp` facade and every incompatibility it reports is a core public API break. A breaking change
-that only the classifier suspects raises its own `low` verdict to `risk/medium` rather than lowering
-its `medium` or `high` judgement.
+### Bot-authored pull requests
 
-Because risk measures maintainer scrutiny, it does not decide whether a protocol change is worth
-reviewing: a `protocol_related` classification always earns an automated review, at any risk level.
-For everything else, `risk/low` without `breaking-change` skips the review. Duplicates, `size/XL`,
-a legitimacy stop, and the terminal review count still stop every route.
+Bot-authored pull requests, including Dependabot's and `devolutionsbot`'s release-plz pull requests, are excluded from this workflow.
+Dependabot is the sole owner of dependency and language labels, so this automation never adds, removes, or reconciles labels on bot pull requests.
 
-A `size/XL` pull request, meaning 800 or more changed source lines, is excluded from automated
-review deterministically, before any model runs. The classifier is skipped along with the
-reviewers, so no LLM call is spent on a change that cannot be reviewed well anyway; classification
-falls back to deterministic scope, size, first-time-contributor, and `cargo-semver-checks` results.
-Every classified pull request has exactly one `size/*` label. The workflow comments once to explain the
-exclusion and to point at [stacked pull requests](https://docs.github.com/en/pull-requests/get-started/about-stacked-prs)
-for splitting dependent work, noting that stacks require every branch to live in this repository so
-fork authors should open separate pull requests. The comment is removed automatically once a later
-push brings the change below the threshold. Duplicate and legitimacy verdicts are model-derived, so
-an oversized run leaves any earlier verdict untouched rather than silently clearing it.
+### Oversized pull requests
 
-Run **Bootstrap pull request automation labels** once before enabling the workflow. It creates any
-missing labels and synchronizes the descriptions and colors declared in
-`.github/pr-automation/labels.json`; it never deletes repository labels.
+A `size/XL` pull request has 800 or more changed source lines and is excluded from automated review before any model runs.
+The classifier is also skipped so no LLM call is spent on a change that cannot be reviewed well.
+Classification falls back to deterministic scope, size, first-time-contributor, and `cargo-semver-checks` results.
+Every classified pull request has exactly one `size/*` label.
 
-Trusted changed paths can independently add `scope/core`, `scope/web`, `scope/ffi`, and
-`scope/tooling`. The classifier alone controls `scope/cross-cutting`, which requires a material
-behavioral, interface, or ownership boundary; multiple files, tests, generated companions, and
-manifest updates alone do not qualify. The classifier also controls `kind/technical-debt` and
-documentation-only labels. `origin/fuzzing` remains manual because paths cannot establish how a
-defect was discovered.
+The workflow comments once to explain the exclusion and point to [stacked pull requests](https://docs.github.com/en/pull-requests/get-started/about-stacked-prs) for splitting dependent work.
+Because stacks require every branch to live in this repository, fork authors should open separate pull requests.
+The comment is removed automatically once a later push brings the change below the threshold.
+Duplicate and legitimacy verdicts are model-derived, so an oversized run leaves any earlier verdict untouched rather than silently clearing it.
 
-The first heavy review requires a successful `CI` run for the exact classified head. A second
-review requires a later push and its matching successful CI run. Manual dispatch can bypass only
-the CI-success requirement; it cannot bypass draft status, duplicate/XL handling, contributor
-history, classification, risk, terminal state, or SHA validation.
+### Fork automation limits
 
-Fork-origin PRs are subject to daily UTC automation limits. The first five PRs from a fork author
-may use automation; authors with at least 15 qualifying merged IronRDP PRs may use ten. Across all
-forks, the workflow stops LLM automation after 30 fork-origin PRs were opened that day. This
-GitHub-only global limit is best-effort under concurrent submissions. A high-confidence
-non-legitimate classifier result also stops automated review and hands the PR to a human.
+Fork-origin pull requests are subject to daily UTC automation limits.
+The first five pull requests from a fork author may use automation, while authors with at least 15 qualifying merged IronRDP pull requests may use ten.
+Across all forks, the workflow stops LLM automation after 30 fork-origin pull requests were opened that day.
+This GitHub-only global limit is best-effort under concurrent submissions.
+A high-confidence non-legitimate classifier result also stops automated review and hands the pull request to a human.
 
-`llm-providers` must allow deployments from `master` and contain only
-`ANTHROPIC_API_KEY_CLASSIFIER` and `ANTHROPIC_API_KEY_REVIEWER`. The workflow passes each secret
-only to its corresponding Claude action step. The GitHub and Anthropic actions track their major
-version tags, and the Open Specifications corpus tracks its default branch, so specification
-coverage improves without a pin bump.
+## Trust boundaries
+
+### Inputs
+
+Every LLM stage receives the same evidence from `.github/pr-automation/fetch-pr-evidence.sh`, which runs from the trusted base checkout.
+Each Claude action uses only an explicit file or skill invocation, which injects no pull request context of its own.
+`Bash` is denied, so a model cannot derive a diff by itself.
+Trusted workflow code writes the target head SHA and handoff-receipt status to `pr-automation-context.json` instead of interpolating them into instructions.
+
+The evidence script writes `pr-evidence/changed-files.txt` and `pr-evidence/pull-request.diff`.
+Both files are computed against the merge base so unrelated commits landing on `master` are not attributed to the pull request.
+The head tree remains available in `pr-head` for surrounding context.
+
+Before exposing that tree to filesystem-reading tools, the script removes every symlink so a pull request cannot redirect a read outside the checkout.
+It also recursively removes contributor-controlled agent instruction files: `CLAUDE.md`, `CLAUDE.local.md`, `AGENTS.md`, `.claude`, `.cursor`, and `.cursorrules`.
+Recursive removal is required because Claude Code discovers these files in every directory it reads, and a nested copy would escape the evidence-only boundary.
+The files still appear in the diff as reviewable data rather than instructions.
+
+### Outputs and logs
+
+Model output is also treated as hostile.
+Text published in a bot comment or review is escaped so HTML, code spans, mentions, issue references, links, images, emphasis, and related Markdown constructs render as inert prose.
+
+Each workflow run writes a structured decision trace to its GitHub Actions logs.
+The trace records event resolution, every gate and deterministic-analysis result, normalized classification and review states, and the selected label additions, removals, comments, and check mutation.
+Jobs skipped by a gate appear in the final trace with their job outcome.
+After every LLM stage, the log records the action outcome and its complete schema-bound structured output.
+These values are untrusted pull-request-derived evidence, so they are emitted through `core.info` and never interpolated into or executed as a shell command.
+
+## Labels
+
+### Risk labels
+
+The `risk/*` label states how much maintainer scrutiny a change needs, not how much an automated review is worth.
+Every classified pull request has exactly one risk label:
+
+- `risk/high` means the change substantially affects the public API surface of a core tier crate.
+- `risk/medium` means a behavioral change that does not substantially alter a core public API.
+- `risk/low` means a self-contained change with no cross-crate behavioral effect.
+- `risk/unknown` means the classifier could not produce a valid judgment.
+
+A `cargo-semver-checks` incompatibility always produces `risk/high`, even when the classifier is unavailable.
+That check runs against the `ironrdp` facade, so every incompatibility it reports is a core public API break.
+A breaking change suspected only by the classifier raises its own `low` verdict to `risk/medium` without lowering a `medium` or `high` judgment.
+
+### Scope and kind labels
+
+Trusted changed paths can independently add `scope/core`, `scope/web`, `scope/ffi`, and `scope/tooling`.
+The classifier alone controls `scope/cross-cutting`, which requires a material behavioral, interface, or ownership boundary.
+Multiple files, tests, generated companions, and manifest updates alone do not qualify.
+The classifier also controls `kind/technical-debt` and documentation-only labels.
+`origin/fuzzing` remains manual because paths cannot establish how a defect was discovered.
+
+### Label setup
+
+Run **Bootstrap pull request automation labels** once before enabling the workflow.
+It creates missing labels and synchronizes the descriptions and colors declared in `.github/pr-automation/labels.json`.
+It never deletes repository labels.
+
+## Review routing
+
+Risk measures maintainer scrutiny, so it does not decide whether a protocol change is worth reviewing.
+A `protocol_related` classification always earns an automated review at any risk level.
+For every other change, `risk/low` without `breaking-change` skips the review.
+Duplicates, `size/XL`, a legitimacy stop, and the terminal review count stop every route.
+
+## Review prerequisites
+
+The first heavy review requires a successful `CI` run for the exact classified head.
+A second review requires a later push and its matching successful CI run.
+Manual dispatch can bypass only the CI-success requirement.
+It cannot bypass draft status, duplicate or XL handling, contributor history, classification, risk, terminal state, or SHA validation.
+
+## Secrets and versioning
+
+The `llm-providers` environment must allow deployments from `master` and contain only `ANTHROPIC_API_KEY_CLASSIFIER` and `ANTHROPIC_API_KEY_REVIEWER`.
+The workflow passes each secret only to its corresponding Claude action step.
+The GitHub and Anthropic actions track their major version tags, while the Open Specifications corpus tracks its default branch so specification coverage improves without a pin bump.

--- a/.github/PR_AUTOMATION.md
+++ b/.github/PR_AUTOMATION.md
@@ -24,9 +24,7 @@ Each LLM stage similarly injects its pipeline-specific evidence and output contr
 ## Validation and recovery
 
 Protocol-related reviews normally consume two calls against `ANTHROPIC_API_KEY_REVIEWER`, while non-protocol reviews normally consume one.
-Each heavy stage validates its structured output immediately.
-If an action reaches its turn limit or validation rejects the result, it resumes the same Claude session once with a six-turn output-only budget.
-This retry preserves the analysis already paid for instead of starting over.
+After validating its structured output, a heavy stage that reaches its turn limit or fails validation resumes the same Claude session once with a six-turn output-only budget, preserving existing analysis.
 The separately isolated publication jobs still revalidate the selected result against GitHub's pull request data and the pinned protocol corpus.
 
 If both attempts fail, the AI review count is unchanged and the pull request stays `maintainer-required`.
@@ -61,10 +59,8 @@ Dependabot is the sole owner of dependency and language labels, so this automati
 
 ### Oversized pull requests
 
-A `size/XL` pull request has 800 or more changed source lines and is excluded from automated review before any model runs.
-The classifier is also skipped so no LLM call is spent on a change that cannot be reviewed well.
-Classification falls back to deterministic scope, size, first-time-contributor, and `cargo-semver-checks` results.
-Every classified pull request has exactly one `size/*` label.
+For a `size/XL` pull request with 800 or more changed source lines, the workflow skips classification and review before any model runs.
+Classification falls back to deterministic scope, size, first-time-contributor, and `cargo-semver-checks` results, while every classified pull request retains exactly one `size/*` label.
 
 The workflow comments once to explain the exclusion and point to [stacked pull requests](https://docs.github.com/en/pull-requests/get-started/about-stacked-prs) for splitting dependent work.
 Because stacks require every branch to live in this repository, fork authors should open separate pull requests.
@@ -120,9 +116,8 @@ Every classified pull request has exactly one risk label:
 - `risk/low` means a self-contained change with no cross-crate behavioral effect.
 - `risk/unknown` means the classifier could not produce a valid judgment.
 
-A `cargo-semver-checks` incompatibility always produces `risk/high`, even when the classifier is unavailable.
-That check runs against the `ironrdp` facade, so every incompatibility it reports is a core public API break.
-A breaking change suspected only by the classifier raises its own `low` verdict to `risk/medium` without lowering a `medium` or `high` judgment.
+A `cargo-semver-checks` incompatibility always produces `risk/high`, even without a classifier result, because the check runs against the `ironrdp` facade and reports core public API breaks.
+A breaking change suspected only by the classifier promotes its `low` verdict to `risk/medium` without lowering a `medium` or `high` judgment.
 
 ### Scope and kind labels
 
@@ -147,10 +142,8 @@ Duplicates, `size/XL`, a legitimacy stop, and the terminal review count stop eve
 
 ## Review prerequisites
 
-The first heavy review requires a successful `CI` run for the exact classified head.
-A second review requires a later push and its matching successful CI run.
-Manual dispatch can bypass only the CI-success requirement.
-It cannot bypass draft status, duplicate or XL handling, contributor history, classification, risk, terminal state, or SHA validation.
+The first heavy review requires successful `CI` for the exact classified head; a second requires a later push and matching successful CI.
+Manual dispatch bypasses only the CI-success requirement, not draft status, duplicate or XL handling, contributor history, classification, risk, terminal state, or SHA validation.
 
 ## Secrets and versioning
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </p>
 
 IronRDP is a modular Rust implementation of RDP, the protocol behind Windows Remote Desktop.
-Its crates provide PDU codecs, connection and session state machines, virtual channels, and image codecs for native, WebAssembly, and .NET clients, servers, and proxies.
+It is not a monolithic client: its composable crates provide PDU codecs, connection and session state machines, virtual channels, and image codecs for native, WebAssembly, and .NET clients, servers, and proxies.
 The continuously fuzzed, `no_std`-compatible core performs no I/O, so applications supply the transport and runtime.
 
 ## Highlights

--- a/README.md
+++ b/README.md
@@ -12,27 +12,17 @@
   <a href="https://matrix.to/#/#IronRDP:matrix.org"><img src="https://img.shields.io/badge/chat-matrix-brightgreen?logo=matrix" alt="Matrix"></a>
 </p>
 
-IronRDP is a modular suite of Rust crates implementing RDP, the protocol behind Windows Remote
-Desktop. It is not a single monolithic client: it is a set of composable building blocks — PDU
-encoding/decoding, connection and session state machines, virtual channels, image codecs — that you
-can assemble into a client, a server, or a proxy, on native platforms, in the browser via
-WebAssembly, or from .NET through FFI bindings.
-
-The core protocol crates do no I/O, are `no_std`-compatible, and are continuously fuzzed. You bring
-the transport and the runtime; IronRDP brings the protocol.
+IronRDP is a modular Rust implementation of RDP, the protocol behind Windows Remote Desktop.
+Its crates provide PDU codecs, connection and session state machines, virtual channels, and image codecs for native, WebAssembly, and .NET clients, servers, and proxies.
+The continuously fuzzed, `no_std`-compatible core performs no I/O, so applications supply the transport and runtime.
 
 ## Highlights
 
-- **Sans-I/O core.** Connection and session logic are state machines with no sockets, no threads, and
-  no runtime attached. Drive them with blocking I/O, `tokio`, `futures`, or your own event loop.
-- **Security first.** Parsing is treated as a hostile-input surface: every core crate is fuzzed,
-  `unsafe` is heavily linted, and the workspace enforces a strict correctness lint policy.
-- **Runs everywhere.** Native binaries, a WebAssembly module for browsers, and C#/.NET bindings all
-  build from the same protocol core.
-- **Client *and* server.** Use the connector to talk to a Windows host, or the acceptor and server
-  skeleton to expose your own desktop over RDP.
-- **Pick only what you need.** Every subsystem is a separate crate behind a feature flag, so a
-  headless screenshot tool does not pull in audio, clipboard, or a GUI stack.
+- **Sans-I/O core:** Drive connection and session state machines with blocking I/O, `tokio`, `futures`, or your own event loop.
+- **Security first:** Core crates are fuzzed, `unsafe` is heavily linted, and the workspace enforces strict correctness lints.
+- **Runs everywhere:** The same protocol core powers native binaries, WebAssembly modules, and C#/.NET bindings.
+- **Client and server:** Connect to Windows hosts or expose your own desktop through the acceptor and server skeleton.
+- **Modular:** Enable only the crates and features you need without pulling in unrelated subsystems.
 
 ## Features
 
@@ -47,12 +37,9 @@ the transport and the runtime; IronRDP brings the protocol.
 
 **Graphics**
 
-- Client-side decoding: uncompressed raw bitmaps, Interleaved RLE, RDP 6.0 bitmap compression, and
-  RemoteFX (RFX)
-- Server-side encoding: RDP 6.0 bitmap compression, RemoteFX, optional NSCodec, and optional
-  QOI / QOI+zstd
-- Additional codec primitives available as libraries: ClearCodec, RemoteFX Progressive, ZGFX, and
-  the graphics pipeline (EGFX) PDUs
+- Client-side decoding: uncompressed raw bitmaps, Interleaved RLE, RDP 6.0 bitmap compression, and RemoteFX (RFX)
+- Server-side encoding: RDP 6.0 bitmap compression, RemoteFX, optional NSCodec, and optional QOI / QOI+zstd
+- Additional codec primitives available as libraries: ClearCodec, RemoteFX Progressive, ZGFX, and the graphics pipeline (EGFX) PDUs
 - Bulk compression: MPPC, NCRUSH, and XCRUSH
 
 **Virtual channels**
@@ -72,13 +59,12 @@ the transport and the runtime; IronRDP brings the protocol.
 
 ### Prebuilt binaries
 
-Checksummed `.tar.gz` archives are attached to each GitHub Release, one per supported platform:
+Checksummed `.tar.gz` archives are attached to each GitHub release, one per supported platform:
 
-- [`ironrdp-viewer`](./crates/ironrdp-viewer) — a windowed RDP client (tags `ironrdp-viewer-v*`)
-- [`ironrdp-agent`](./crates/ironrdp-agent) — a daemon-backed CLI for automation (tags `ironrdp-agent-v*`)
+- [`ironrdp-viewer`][ironrdp-viewer] - a windowed RDP client (tags `ironrdp-viewer-v*`)
+- [`ironrdp-agent`][ironrdp-agent] - a daemon-backed CLI for automation (tags `ironrdp-agent-v*`)
 
-Download, checksum, and extraction instructions are included in each release's notes on the
-[Releases page](https://github.com/Devolutions/IronRDP/releases).
+Each [release][releases] includes download, checksum, and extraction instructions.
 
 ### Install with Cargo
 
@@ -87,32 +73,29 @@ cargo install ironrdp-viewer
 cargo install ironrdp-agent
 ```
 
-Both binaries link native audio, so Linux builds need the ALSA development headers
-(`libasound2-dev` on Debian/Ubuntu) and Windows builds need NASM.
+Both binaries link native audio, so Linux builds need the ALSA development headers (`libasound2-dev` on Debian/Ubuntu) and Windows builds need NASM.
 
 ### `ironrdp-viewer`
 
-`ironrdp-viewer` is a portable, windowed RDP client that uses asynchronous I/O and software
-rendering.
+`ironrdp-viewer` is a portable, windowed RDP client with asynchronous I/O and software rendering.
 
 ```shell
 ironrdp-viewer <HOSTNAME> --username <USERNAME> --password <PASSWORD>
 ```
 
-Omitted credentials are prompted for interactively. You can also load a `.rdp` file:
+Omitted credentials are prompted for interactively.
+You can also load a `.rdp` file:
 
 ```shell
 ironrdp-viewer --rdp-file ./my-server.rdp
 ```
 
-Set `IRONRDP_LOG` to adjust logging, e.g. `IRONRDP_LOG="info,ironrdp_connector=trace"`. See the
-[viewer README](./crates/ironrdp-viewer/README.md) for the supported `.rdp` properties, TLS key
-logging, and the full option list.
+Set `IRONRDP_LOG` to adjust logging, for example `IRONRDP_LOG="info,ironrdp_connector=trace"`.
+See the [viewer README] for supported `.rdp` properties, TLS key logging, and the full option list.
 
 ### `ironrdp-agent`
 
-`ironrdp-agent` combines a long-lived RDP daemon with short-lived CLI invocations, which makes it
-convenient for scripts and LLM-driven automation:
+`ironrdp-agent` combines a long-lived RDP daemon with short-lived CLI invocations for scripts and LLM-driven automation:
 
 ```shell
 ironrdp-agent daemon-start --overlay ./credentials.rdp        # in one terminal
@@ -120,13 +103,10 @@ ironrdp-agent connect --server <HOSTNAME> --username <USER>   # in another
 ironrdp-agent screenshot ./desktop.png
 ```
 
-`connect` fails with `missing required fields` unless credentials are available, so either preload
-them into the daemon with `daemon-start --overlay <FILE>` — which keeps secrets away from the IPC
-caller — or pass `--password` to `connect`.
-
-Run `ironrdp-agent --help-agent` for a machine-readable description of every operation, and see the
-[agent README](./crates/ironrdp-agent/README.md) for the IPC format, secret handling, and remote
-execution support.
+`connect` fails with `missing required fields` unless credentials are available.
+Preload credentials with `daemon-start --overlay <FILE>` to keep secrets away from the IPC caller, or pass `--password` to `connect`.
+Run `ironrdp-agent --help-agent` for a machine-readable description of every operation.
+See the [agent README] for the IPC format, secret handling, and remote execution support.
 
 ## Using IronRDP as a library
 
@@ -137,9 +117,8 @@ Add the meta crate and enable only the pieces you need:
 ironrdp = { version = "0.17", features = ["connector", "session", "graphics"] }
 ```
 
-Each feature maps to a standalone crate, so you can also depend on `ironrdp-pdu`,
-`ironrdp-connector`, `ironrdp-session`, and friends directly. API documentation lives on
-[docs.rs](https://docs.rs/ironrdp/).
+Each feature maps to a standalone crate, so you can depend on `ironrdp-pdu`, `ironrdp-connector`, `ironrdp-session`, and related crates directly.
+API documentation is available on [docs.rs].
 
 Two runnable examples ship with the meta crate:
 
@@ -163,9 +142,8 @@ Set-ItemProperty -Path 'HKLM:\Software\Policies\Microsoft\Windows NT\Terminal Se
 Set-ItemProperty -Path 'HKLM:\Software\Policies\Microsoft\Windows NT\Terminal Services' -Name 'fEnableVirtualizedGraphics' -Type DWORD -Value 1
 ```
 
-Alternatively, enable the following group policies with `gpedit.msc` and reboot. All of them live
-under _Computer Configuration → Administrative Templates → Windows Components → Remote Desktop
-Services → Remote Desktop Session Host → Remote Session Environment_:
+Alternatively, enable these group policies with `gpedit.msc` and reboot.
+They are under _Computer Configuration → Administrative Templates → Windows Components → Remote Desktop Services → Remote Desktop Session Host → Remote Session Environment_:
 
 1. _RemoteFX for Windows Server 2008 R2 → Configure RemoteFX_
 2. _Enable RemoteFX encoding for RemoteFX clients designed for Windows Server 2008 R2 SP1_
@@ -175,57 +153,67 @@ Services → Remote Desktop Session Host → Remote Session Environment_:
 
 ## Who uses IronRDP
 
-- [Devolutions Gateway](https://github.com/Devolutions/devolutions-gateway) for browser-based and
-  native RDP client access
-- [Cloudflare Access](https://blog.cloudflare.com/browser-based-rdp/) for browser-based RDP
-- [Teleport](https://goteleport.com/) for its remote desktop web access
-- [Lamco RDP Server](https://lamco.ai/products/lamco-rdp-server/), a Wayland-native RDP server for
-  Linux desktop sharing
-- [MacRDP](https://github.com/clintcan/macrdp), a native RDP server for macOS
-- [`qemu-rdp`](https://gitlab.com/marcandre.lureau/qemu-display), an RDP server for QEMU displays
-- A growing set of community projects building RDP servers and clients on top of the crate suite
+- [Devolutions Gateway] for browser-based and native RDP client access
+- [Cloudflare Access] for browser-based RDP
+- [Teleport] for remote desktop web access
+- [Lamco RDP Server], a Wayland-native RDP server for Linux desktop sharing
+- [MacRDP], a native RDP server for macOS
+- [`qemu-rdp`][qemu-rdp], an RDP server for QEMU displays
+- A growing set of community projects building RDP servers and clients on the crate suite
 
 ## Rust version (MSRV)
 
-IronRDP libraries follow a conservative Minimum Supported Rust Version policy. The MSRV is the oldest
-stable Rust release that is at least 6 months old, bounded by the Rust version available in
-[Debian stable-backports](https://packages.debian.org/search?suite=all&arch=any&searchon=names&keywords=rust)
-and [Fedora stable](https://packages.fedoraproject.org/pkgs/rust/rust/). The toolchain pinned in
-`rust-toolchain.toml` is both the project toolchain and the MSRV validated by CI. See
-[ARCHITECTURE.md](./ARCHITECTURE.md#msrv-policy) for the full policy.
+IronRDP's MSRV is the oldest stable Rust release at least six months old and available in [Debian stable-backports] and [Fedora stable].
+`rust-toolchain.toml` pins both the project toolchain and the MSRV validated by CI.
+See the [architecture policy] for details.
 
 ## Contributing
 
-Contributions are welcome. Start with [ARCHITECTURE.md](./ARCHITECTURE.md) and
-[STYLE.md](./STYLE.md), and keep changes scoped.
+Contributions are welcome; start with [ARCHITECTURE] and [STYLE], and keep changes scoped.
+Project automation uses [`xtask`][xtask] following the [`cargo xtask`][cargo xtask] convention.
+Run `cargo xtask --help` for the command list and `cargo xtask bootstrap` to install development requirements.
+Run `cargo xtask ci` before opening a pull request; it covers everything CI runs except FFI and .NET checks, which have separate `cargo xtask ffi` commands.
 
-Project automation lives in [`xtask`](./xtask), following the
-[`cargo xtask`](https://github.com/matklad/cargo-xtask) convention. Run `cargo xtask --help` for the
-full list, `cargo xtask bootstrap` to install the development requirements, and `cargo xtask ci`
-before opening a pull request — it runs everything CI does except the FFI and .NET checks, which
-have their own `cargo xtask ffi` commands.
-
-Building the workspace needs the ALSA development headers on Linux (`libasound2-dev` on
-Debian/Ubuntu) and NASM on Windows. The web client additionally needs Node.js >= 24 LTS, and the FFI
-bindings need the .NET SDK.
+Workspace builds use the native prerequisites listed under [Install with Cargo].
+The web client also needs Node.js >= 24 LTS, and the FFI bindings need the .NET SDK.
 
 ## AI-assisted development
 
-AI-assisted development is encouraged when used thoughtfully. Contributors remain responsible for
-understanding, reviewing, and validating every change produced with AI assistance.
-
-For RDP protocol work, install the Windows Protocols skill so AI agents can navigate the Microsoft
-Open Specifications corpus. It significantly improves the correctness of AI-assisted work involving
-RDP protocol details. See [awakecoding/openspecs](https://github.com/awakecoding/openspecs) for
-installation instructions.
+AI-assisted development is welcome, but contributors remain responsible for understanding, reviewing, and validating every change.
+For RDP protocol work, install the Windows Protocols skill from [awakecoding/openspecs] so agents can navigate the Microsoft Open Specifications corpus.
 
 ## Getting help
 
-- Report bugs in the [issue tracker](https://github.com/Devolutions/IronRDP/issues)
-- Discuss the project in the [Matrix room](https://matrix.to/#/#IronRDP:matrix.org)
+- Report bugs in the [issue tracker]
+- Discuss the project in the [Matrix room]
 
 ## License
 
-Licensed under either of [MIT](./LICENSE-MIT) or [Apache-2.0](./LICENSE-APACHE) at your option.
+Licensed under either [MIT] or [Apache-2.0] at your option.
 
+[ironrdp-viewer]: ./crates/ironrdp-viewer
+[ironrdp-agent]: ./crates/ironrdp-agent
+[releases]: https://github.com/Devolutions/IronRDP/releases
+[viewer README]: ./crates/ironrdp-viewer/README.md
+[agent README]: ./crates/ironrdp-agent/README.md
+[docs.rs]: https://docs.rs/ironrdp/
 [Diplomat]: https://github.com/rust-diplomat/diplomat
+[Devolutions Gateway]: https://github.com/Devolutions/devolutions-gateway
+[Cloudflare Access]: https://blog.cloudflare.com/browser-based-rdp/
+[Teleport]: https://goteleport.com/
+[Lamco RDP Server]: https://lamco.ai/products/lamco-rdp-server/
+[MacRDP]: https://github.com/clintcan/macrdp
+[qemu-rdp]: https://gitlab.com/marcandre.lureau/qemu-display
+[Debian stable-backports]: https://packages.debian.org/search?suite=all&arch=any&searchon=names&keywords=rust
+[Fedora stable]: https://packages.fedoraproject.org/pkgs/rust/rust/
+[architecture policy]: ./ARCHITECTURE.md#msrv-policy
+[ARCHITECTURE]: ./ARCHITECTURE.md
+[STYLE]: ./STYLE.md
+[xtask]: ./xtask
+[cargo xtask]: https://github.com/matklad/cargo-xtask
+[Install with Cargo]: #install-with-cargo
+[awakecoding/openspecs]: https://github.com/awakecoding/openspecs
+[issue tracker]: https://github.com/Devolutions/IronRDP/issues
+[Matrix room]: https://matrix.to/#/#IronRDP:matrix.org
+[MIT]: ./LICENSE-MIT
+[Apache-2.0]: ./LICENSE-APACHE


### PR DESCRIPTION
Add proactive prose, Markdown, and documentation writers alongside focused post-hoc reviewers.

Keep authoring rules canonical by composing format-neutral prose guidance with Markdown-specific structure, code-fence, and reference-link conventions. Have verification and compression skills consume the writer guidance, prefer non-growing rewrites, and allow small growth only for material clarity or navigation gains without duplication.

Compose reviews through an evidence-checking orchestrator that runs protocol analysis only when relevant and skepticism last. Apply the writing guidance to streamline the project README and restructure the pull request automation reference without changing their technical meaning or workflow behavior.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>