### PR TITLE
ci: add forced PR automation

### DIFF
--- a/.github/PR_AUTOMATION.md
+++ b/.github/PR_AUTOMATION.md
@@ -155,7 +155,8 @@ The `workflow_dispatch` route accepts a pull request number, a route selector, a
 The workflow ignores `force` on every other event.
 
 For classification, force mode bypasses completed-classification cache, fork quota, `size/XL`, terminal review count, draft status, and bot authorship.
-Forced classification does not enqueue a review; select the review route explicitly when one is required.
+Its SHA-bound check retains protocol state for a later forced review but cannot open an automatic review route.
+Select the review route explicitly when one is required.
 For review, it also bypasses classification, CI, duplicate, legitimacy, risk, contributor-history, and review-count eligibility.
 Forced review uses valid protocol state from the current-head classification when available.
 Without valid protocol state, it uses the trusted not-applicable handoff and runs the skeptical reviewer without protocol analysis.

--- a/.github/PR_AUTOMATION.md
+++ b/.github/PR_AUTOMATION.md
@@ -1,7 +1,7 @@
 # Pull request automation
 
-`.github/workflows/labeler.yml` classifies ready, open pull requests and runs at most two automated reviews.
-The workflow never runs an LLM for `ai-reviewed/2`; that label is terminal and requires human review.
+`.github/workflows/labeler.yml` automatically classifies ready, open pull requests and runs at most two automated reviews.
+Automatic routes never run an LLM for `ai-reviewed/2`; that label is terminal unless a maintainer uses force mode.
 
 ## Review pipeline
 
@@ -47,7 +47,7 @@ The protocol and skeptical review stages select Opus with `--model opus` and use
 | Protocol conformance | Opus | Default `high` | Performs the protocol analysis worth the higher cost. |
 | Skeptical review | Opus | Default `high` | Evaluates correctness and the validated protocol handoff. |
 
-The heavy stages run at most twice per pull request.
+Automatic heavy stages run at most twice per pull request.
 `haiku` is cheaper than Sonnet at `low` effort but supports no effort level, so the classifier does not use it.
 Model names are floating aliases, so each stage tracks the latest model in its tier.
 
@@ -55,12 +55,13 @@ Model names are floating aliases, so each stage tracks the latest model in its t
 
 ### Bot-authored pull requests
 
-Bot-authored pull requests, including Dependabot's and `devolutionsbot`'s release-plz pull requests, are excluded from this workflow.
-Dependabot is the sole owner of dependency and language labels, so this automation never adds, removes, or reconciles labels on bot pull requests.
+Bot-authored pull requests, including Dependabot's and `devolutionsbot`'s release-plz pull requests, are excluded from automatic routes.
+Dependabot is the sole owner of dependency and language labels, so automatic routes never add, remove, or reconcile labels on bot pull requests.
+A maintainer can explicitly override this exclusion with force mode.
 
 ### Oversized pull requests
 
-For a `size/XL` pull request with 800 or more changed source lines, the workflow skips classification and review before any model runs.
+For a `size/XL` pull request with 800 or more changed source lines, automatic routes skip classification and review before any model runs.
 Classification falls back to deterministic scope, size, first-time-contributor, and `cargo-semver-checks` results, while every classified pull request retains exactly one `size/*` label.
 
 The workflow comments once to explain the exclusion and point to [stacked pull requests](https://docs.github.com/en/pull-requests/get-started/about-stacked-prs) for splitting dependent work.
@@ -70,7 +71,7 @@ Duplicate and legitimacy verdicts are model-derived, so an oversized run leaves 
 
 ### Fork automation limits
 
-Fork-origin pull requests are subject to daily UTC automation limits.
+Fork-origin pull requests are subject to daily UTC limits on automatic runs.
 The first five pull requests from a fork author may use automation, while authors with at least 15 qualifying merged IronRDP pull requests may use ten.
 Across all forks, the workflow stops LLM automation after 30 fork-origin pull requests were opened that day.
 This GitHub-only global limit is best-effort under concurrent submissions.
@@ -138,15 +139,29 @@ It never deletes repository labels.
 
 ## Review routing
 
-Risk measures maintainer scrutiny, so it does not decide whether a protocol change is worth reviewing.
+On automatic routes, risk measures maintainer scrutiny, so it does not decide whether a protocol change is worth reviewing.
 A `protocol_related` classification is review-eligible at any risk level, subject to the remaining review gates.
 For every other change, `risk/low` without `breaking-change` skips the review.
-Duplicates, `size/XL`, a legitimacy stop, and the terminal review count stop every route.
+Duplicates, `size/XL`, a legitimacy stop, and the terminal review count stop every automatic route.
 
 ## Review prerequisites
 
-The first heavy review requires successful `CI` for the exact classified head and an author with at least three qualifying merged IronRDP pull requests; a second requires a later push and matching successful CI.
-Manual dispatch bypasses only the CI-success requirement, not draft status, duplicate or XL handling, contributor history, classification, risk, terminal state, or SHA validation.
+Automatic review requires successful `CI` for the exact classified head and an author with at least three qualifying merged IronRDP pull requests.
+A second automatic review requires a later push and matching successful CI.
+
+## Manual force mode
+
+The `workflow_dispatch` route accepts a pull request number, a route selector, and a `force` flag.
+The workflow ignores `force` on every other event.
+
+For classification, force mode bypasses completed-classification cache, fork quota, `size/XL`, terminal review count, draft status, and bot authorship.
+Forced classification does not enqueue a review; select the review route explicitly when one is required.
+For review, it also bypasses classification, CI, duplicate, legitimacy, risk, contributor-history, and review-count eligibility.
+Forced review uses valid protocol state from the current-head classification when available.
+Without valid protocol state, it uses the trusted not-applicable handoff and runs the skeptical reviewer without protocol analysis.
+
+Force mode cannot target a closed pull request or select an older head.
+It does not bypass evidence retrieval, hostile-output validation, protocol handoff validation, or the final stale-head check.
 
 ## Secrets and versioning
 

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -83,6 +83,7 @@ test("workflow force mode bypasses model policy gates without changing automatic
   const classificationGate = workflowJob(workflow, "classification-gate");
   assert.match(classificationGate, /if \(force\) \{/);
   assert.match(classificationGate, /setOutput\("required", true\)/);
+  assert.match(classificationGate, /state\?\.automaticReviewEligible === true/);
 
   const classifierJob = workflowJob(workflow, "classifier");
   assert.match(classifierJob, /if: >-\n\s+always\(\) && !cancelled\(\) &&/);
@@ -98,6 +99,7 @@ test("workflow force mode bypasses model policy gates without changing automatic
   const reviewGate = workflowJob(workflow, "review-gate");
   assert.match(reviewGate, /ok: true, force: true, head_sha: headSha/);
   assert.match(reviewGate, /labels: force \? resolvedLabels : \[\], protocolRelated: false/);
+  assert.match(reviewGate, /protocolState\.automaticReviewEligible === true/);
   for (const name of ["protocol-reviewer", "validate-protocol-review", "skeptical-reviewer"]) {
     assert.match(workflowJob(workflow, name), /needs\.resolve-pr\.outputs\.force == 'true' \|\|/);
   }
@@ -434,8 +436,20 @@ test("corpus reader indexes real headings and refuses traversal", () => {
 });
 
 test("classification check state survives a round trip and fails closed when absent", () => {
-  const encoded = `Validated AI classification is bound to this commit.\n\n${encodeCheckState({ protocolRelated: true })}`;
-  assert.deepEqual(parseCheckState(encoded), { protocolRelated: true });
+  const encoded = `Validated AI classification is bound to this commit.\n\n${encodeCheckState({
+    protocolRelated: true,
+    automaticReviewEligible: false,
+  })}`;
+  assert.deepEqual(parseCheckState(encoded), {
+    protocolRelated: true,
+    automaticReviewEligible: false,
+  });
+  assert.deepEqual(parseCheckState(
+    "ironrdp-pr-automation-state: {\"schema_version\":\"classifier-v2\",\"protocol_related\":true}",
+  ), {
+    protocolRelated: true,
+    automaticReviewEligible: true,
+  });
   assert.equal(parseCheckState("Validated AI classification is bound to this commit."), null);
   assert.equal(parseCheckState("ironrdp-pr-automation-state: {\"schema_version\":\"classifier-v1\",\"protocol_related\":true}"), null);
   assert.equal(parseCheckState("ironrdp-pr-automation-state: {\"schema_version\":\"classifier-v2\"}"), null);
@@ -813,11 +827,14 @@ test("forced classification bypasses policy, quota, and cache but still validate
   assert.equal(state.oversized, undefined);
   assert.equal(state.check.title, "Classification complete");
   assert.equal(state.dispatchReview, false);
-  assert.equal(state.comments.some((comment) => comment.kind === "xl"), true);
+  assert.equal(state.check.machineState.automaticReviewEligible, false);
+  assert.equal(state.comments.some((comment) => comment.kind === "xl"), false);
+  assert.equal(state.removeCommentMarkers.includes(XL_MARKER), true);
 
   const invalid = resolveClassificationState({ ...args, classifier: "" });
   assert.equal(invalid.failed, true);
   assert.equal(invalid.reason, "invalid classifier object");
+  assert.deepEqual(invalid.comments, []);
   const wrongHead = resolveClassificationState({
     ...args, classifier: classifier({ head_sha: "b".repeat(40) }),
   });
@@ -858,9 +875,11 @@ test("forced review bypasses eligibility while retaining trusted publication gat
   assert.equal(resolveReviewState({
     ...args, reviewer: review({ head_sha: "b".repeat(40) }),
   }).failed, true);
-  assert.equal(resolveReviewState({
+  const evidenceFailure = resolveReviewState({
     ...args, evidenceReason: "changed file retrieval unavailable",
-  }).reason, "changed file retrieval unavailable");
+  });
+  assert.equal(evidenceFailure.reason, "changed file retrieval unavailable");
+  assert.deepEqual(evidenceFailure.comments, []);
   assert.equal(resolveReviewState({
     ...args, reviewMarkerId: "",
   }).reason, "forced review marker unavailable");

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -43,6 +43,13 @@ const review = (changes = {}) => ({
   ...changes,
 });
 
+function workflowJob(workflow, name) {
+  const start = workflow.indexOf(`  ${name}:\n`);
+  assert.notEqual(start, -1, `${name} job is missing`);
+  const following = workflow.slice(start + 1).search(/\n  [a-z][a-z0-9-]+:\n/);
+  return workflow.slice(start, following === -1 ? undefined : start + following + 1);
+}
+
 test("workflow does not overwrite github-script result outputs", () => {
   const workflow = fs.readFileSync(path.join(__dirname, "..", "workflows", "labeler.yml"), "utf8");
   assert.doesNotMatch(workflow, /core\.setOutput\("result"/);
@@ -64,12 +71,48 @@ test("workflow does not overwrite github-script result outputs", () => {
 test("workflow does not resolve or write state after cancellation", () => {
   const workflow = fs.readFileSync(path.join(__dirname, "..", "workflows", "labeler.yml"), "utf8");
   for (const name of ["resolve-classification-state", "resolve-review-state", "write-state"]) {
-    const start = workflow.indexOf(`  ${name}:\n`);
-    assert.notEqual(start, -1, `${name} job is missing`);
-    const following = workflow.slice(start + 1).search(/\n  [a-z][a-z0-9-]+:\n/);
-    const job = workflow.slice(start, following === -1 ? undefined : start + following + 1);
-    assert.match(job, /^    if: always\(\) && !cancelled\(\) &&/m);
+    assert.match(workflowJob(workflow, name), /^    if: always\(\) && !cancelled\(\) &&/m);
   }
+});
+
+test("workflow force mode bypasses model policy gates without changing automatic branches", () => {
+  const workflow = fs.readFileSync(path.join(__dirname, "..", "workflows", "labeler.yml"), "utf8");
+  assert.match(workflow, /^\s{6}force:\n\s{8}description:/m);
+  assert.doesNotMatch(workflow, /bypass-ci|bypassCi|BYPASS_CI/);
+
+  const classificationGate = workflowJob(workflow, "classification-gate");
+  assert.match(classificationGate, /if \(force\) \{/);
+  assert.match(classificationGate, /setOutput\("required", true\)/);
+
+  const classifierJob = workflowJob(workflow, "classifier");
+  assert.match(classifierJob, /if: >-\n\s+always\(\) && !cancelled\(\) &&/);
+  for (const automaticGate of [
+    "classification-gate.outputs.available == 'true'",
+    "classification-gate.outputs.required == 'true'",
+    "deterministic-analysis.outputs.size-label != 'size/XL'",
+    "fork-rate-limit.outputs.allowed == 'true'",
+    "'ai-reviewed/2'",
+  ]) assert.equal(classifierJob.includes(automaticGate), true, automaticGate);
+  assert.match(classifierJob, /needs\.resolve-pr\.outputs\.force == 'true' \|\|/);
+
+  const reviewGate = workflowJob(workflow, "review-gate");
+  assert.match(reviewGate, /ok: true, force: true, head_sha: headSha/);
+  assert.match(reviewGate, /labels: force \? resolvedLabels : \[\], protocolRelated: false/);
+  for (const name of ["protocol-reviewer", "validate-protocol-review", "skeptical-reviewer"]) {
+    assert.match(workflowJob(workflow, name), /needs\.resolve-pr\.outputs\.force == 'true' \|\|/);
+  }
+  for (const name of ["semver", "protocol-reviewer", "skeptical-reviewer"]) {
+    assert.match(workflowJob(workflow, name), /if: >-\n\s+always\(\) && !cancelled\(\) &&/);
+  }
+  for (const name of ["protocol-reviewer", "validate-protocol-review", "skeptical-reviewer"]) {
+    assert.match(workflowJob(workflow, name), /needs\.resolve-pr\.outputs\.review-route == 'true'/);
+  }
+
+  const reviewState = workflowJob(workflow, "resolve-review-state");
+  assert.match(reviewState, /const force = process\.env\.FORCE === "true"/);
+  assert.match(reviewState, /parse\(process\.env\.GATE, force \? \{/);
+  assert.match(reviewState, /REVIEW_MARKER_ID: \$\{\{ github\.run_id \}\}/);
+  assert.match(reviewGate, /classificationCheck && ciGreen && secondReviewEligible && policyEligible/);
 });
 
 test("review skills own methodology while stage prompts own pipeline contracts", () => {
@@ -426,6 +469,49 @@ test("bot authors are excluded from automation", async () => {
   assert.equal(human.reviewRoute, true);
 });
 
+test("force is dispatch-only and bypasses draft and bot eligibility", async () => {
+  const pullRequest = (changes = {}) => ({
+    number: 7, draft: false, state: "open", labels: [],
+    user: { node_id: "U_1", login: "contributor", type: "User" },
+    head: { sha: SHA, repo: { full_name: "Devolutions/IronRDP" } }, base: { sha: "b".repeat(40) },
+    ...changes,
+  });
+  const resolve = async ({ eventName = "workflow_dispatch", inputs = {}, changes = {} }) => resolvePr({
+    github: { rest: { pulls: {
+      get: async () => ({ data: pullRequest(changes) }),
+      list: async () => ({ data: [pullRequest(changes)] }),
+    } } },
+    context: {
+      eventName, repo: { owner: "Devolutions", repo: "IronRDP" },
+      payload: eventName === "workflow_run"
+        ? { workflow_run: { name: "CI", head_sha: SHA, pull_requests: [{ number: 7 }] } }
+        : { inputs: { "pr-number": "7", force: inputs.force, review: inputs.review } },
+    },
+    inputs: { prNumber: 7, ...inputs },
+  });
+
+  const forcedDraft = await resolve({ inputs: { force: true }, changes: { draft: true } });
+  assert.equal(forcedDraft.ok, true);
+  assert.equal(forcedDraft.force, true);
+  assert.equal(forcedDraft.headSha, SHA);
+
+  const forcedBot = await resolve({
+    inputs: { force: "true", review: true },
+    changes: { user: { node_id: "U_2", login: "dependabot[bot]", type: "Bot" } },
+  });
+  assert.equal(forcedBot.ok, true);
+  assert.equal(forcedBot.force, true);
+  assert.equal(forcedBot.reviewRequested, true);
+
+  assert.equal((await resolve({ changes: { draft: true } })).reason, "pull request is draft");
+  const automaticBot = await resolve({
+    eventName: "workflow_run", inputs: { force: true },
+    changes: { user: { node_id: "U_2", login: "dependabot[bot]", type: "Bot" } },
+  });
+  assert.equal(automaticBot.ok, false);
+  assert.equal(automaticBot.reason, "bot-authored pull request");
+});
+
 test("deterministic semver outranks the model and a model-only break cannot stay low", () => {
   const deterministic = { ok: true, pathLabels: [], ownedPathLabels: [], sizeLabel: "size/S", sizeLabels: ["size/S"],
     firstTime: false };
@@ -707,6 +793,79 @@ test("quota decisions stop classification and review with a bounded human handof
   assert.equal(review.comments[0].kind, "global-quota");
 });
 
+test("forced classification bypasses policy, quota, and cache but still validates output", () => {
+  const deterministic = {
+    ok: true, pathLabels: [], ownedPathLabels: [], sizeLabel: "size/XL",
+    sizeLabels: ["size/L", "size/XL"], firstTime: false,
+  };
+  const args = {
+    expectedSha: SHA,
+    labels: ["ai-reviewed/2"],
+    deterministic,
+    classifier: classifier(),
+    classificationGate: { available: false, reason: "checks unavailable" },
+    rateLimit: { status: "limited", scope: "global", quota: 30, count: 31 },
+    semver: { head_sha: SHA, status: "not-suspected" },
+    force: true,
+  };
+  const state = resolveClassificationState(args);
+  assert.equal(state.failed, undefined);
+  assert.equal(state.oversized, undefined);
+  assert.equal(state.check.title, "Classification complete");
+  assert.equal(state.dispatchReview, false);
+  assert.equal(state.comments.some((comment) => comment.kind === "xl"), true);
+
+  const invalid = resolveClassificationState({ ...args, classifier: "" });
+  assert.equal(invalid.failed, true);
+  assert.equal(invalid.reason, "invalid classifier object");
+  const wrongHead = resolveClassificationState({
+    ...args, classifier: classifier({ head_sha: "b".repeat(40) }),
+  });
+  assert.equal(wrongHead.failed, true);
+});
+
+test("forced review bypasses eligibility while retaining trusted publication gates", () => {
+  const reviewer = {
+    head_sha: SHA, has_findings: false, summary: "none",
+    protocol_handoff: { received: false, disposition: "not_applicable", rationale: "" }, findings: [],
+  };
+  const args = {
+    expectedSha: SHA,
+    labels: ["ai-reviewed/2", "duplicate", "size/XL", "risk/low"],
+    reviewer,
+    gate: { ok: true, force: true, head_sha: SHA, protocolRelated: false },
+    contributor: { status: "ineligible" },
+    rateLimit: { status: "limited", scope: "global", quota: 30, count: 31 },
+    protocolStatus: "not_applicable",
+    force: true,
+    reviewMarkerId: "1234",
+  };
+  const state = resolveReviewState(args);
+  assert.equal(state.failed, undefined);
+  assert.deepEqual(state.labelSets[0].desired, ["ai-reviewed/2"]);
+  const findingState = resolveReviewState({
+    ...args, reviewer: review(), changedPaths: ["src/lib.rs"], changedLines: { "src/lib.rs": [4] },
+  });
+  assert.equal(findingState.comments[0].marker,
+    `<!-- ironrdp-pr-automation:review:${SHA}:force:1234 -->`);
+
+  assert.equal(resolveReviewState({
+    ...args, gate: { ...args.gate, head_sha: "b".repeat(40) },
+  }).reason, "forced review gate unavailable");
+  assert.equal(resolveReviewState({
+    ...args, protocolStatus: "unavailable", protocolReason: "protocol validation failed",
+  }).reason, "protocol validation failed");
+  assert.equal(resolveReviewState({
+    ...args, reviewer: review({ head_sha: "b".repeat(40) }),
+  }).failed, true);
+  assert.equal(resolveReviewState({
+    ...args, evidenceReason: "changed file retrieval unavailable",
+  }).reason, "changed file retrieval unavailable");
+  assert.equal(resolveReviewState({
+    ...args, reviewMarkerId: "",
+  }).reason, "forced review marker unavailable");
+});
+
 test("review transition is terminal-safe and preserves human triage on no findings", () => {
   const reviewer = {
     head_sha: SHA, has_findings: false, summary: "none",
@@ -878,6 +1037,71 @@ test("writer upgrades a neutral automated review check instead of creating a dup
   assert.equal(update.check_run_id, 7);
   assert.equal(update.conclusion, "success");
   assert.equal(update.output.title, "Automated review complete");
+});
+
+test("writer dispatches automatic but not forced completed classifications", async () => {
+  const writeClassification = async (dispatchReview) => {
+    let dispatches = 0;
+    const github = {
+      paginate: { iterator: async function* () { yield { data: [] }; } },
+      rest: {
+        checks: { listForRef: () => {}, create: async () => {} },
+        pulls: { get: async () => ({ data: { state: "open", head: { sha: SHA } } }) },
+        issues: { get: async () => ({ data: { labels: [] } }) },
+        repos: { createDispatchEvent: async () => { dispatches += 1; } },
+      },
+    };
+    await writeState({
+      github, owner: "Devolutions", repo: "IronRDP", prNumber: 1, botLogin: "github-actions[bot]",
+      state: {
+        ok: true, mode: "classification", expectedSha: SHA, labelSets: [], addLabels: [],
+        comments: [], removeCommentMarkers: [], dispatchReview,
+        check: {
+          name: "AI classification", externalId: `classifier-v2:${SHA}`,
+          title: "Classification complete", summary: "Validated classification.",
+          machineState: { protocolRelated: false },
+        },
+      },
+    });
+    return dispatches;
+  };
+
+  assert.equal(await writeClassification(true), 1);
+  assert.equal(await writeClassification(false), 0);
+});
+
+test("writer deduplicates one forced review invocation but publishes a later one", async () => {
+  const existingMarker = `<!-- ironrdp-pr-automation:review:${SHA}:force:1234 -->`;
+  const publish = async (marker) => {
+    let published = 0;
+    const listReviews = () => {};
+    const github = {
+      paginate: { iterator: async function* (method) {
+        yield { data: method === listReviews
+          ? [{ user: { login: "github-actions[bot]" }, body: existingMarker }]
+          : [] };
+      } },
+      rest: {
+        pulls: {
+          listReviews,
+          get: async () => ({ data: { state: "open", head: { sha: SHA } } }),
+          createReview: async () => { published += 1; },
+        },
+        issues: { get: async () => ({ data: { labels: [] } }) },
+      },
+    };
+    await writeState({
+      github, owner: "Devolutions", repo: "IronRDP", prNumber: 1, botLogin: "github-actions[bot]",
+      state: {
+        ok: true, mode: "review", expectedSha: SHA, labelSets: [], addLabels: [],
+        comments: [{ kind: "review", marker, review: review() }],
+      },
+    });
+    return published;
+  };
+
+  assert.equal(await publish(existingMarker), 0);
+  assert.equal(await publish(`<!-- ironrdp-pr-automation:review:${SHA}:force:5678 -->`), 1);
 });
 
 function paginated(pages) {

--- a/.github/pr-automation/resolve-pr.js
+++ b/.github/pr-automation/resolve-pr.js
@@ -52,6 +52,8 @@ async function workflowRunPullRequests(github, owner, repo, workflowRun) {
 async function resolvePr({ github, context, inputs = {} }) {
   const route = routeFor(context);
   const { owner, repo } = context.repo;
+  const force = route === "dispatch" && ["true", true].includes(
+    inputs.force ?? context.payload.inputs?.force);
   let pr;
   try {
     if (route === "classification") {
@@ -82,13 +84,13 @@ async function resolvePr({ github, context, inputs = {} }) {
     return noResult("GitHub API unavailable", route);
   }
   if (!pr) return noResult("pull request is closed or stale", route);
-  if (pr.draft) return noResult("pull request is draft", route);
+  if (pr.draft && !force) return noResult("pull request is draft", route);
   // Dependabot owns dependency and language labels, while devolutionsbot opens release-plz PRs.
   // This automation must not mutate either kind of automated pull request.
   const authorLogin = pr.user?.login || "";
   const authorIsBot = pr.user?.type === "Bot" || /\[bot\]$/i.test(authorLogin) ||
     authorLogin.toLowerCase() === "devolutionsbot";
-  if (authorIsBot) return noResult("bot-authored pull request", route);
+  if (authorIsBot && !force) return noResult("bot-authored pull request", route);
   return {
     ok: true, route, prNumber: pr.number, headSha: pr.head.sha, baseSha: pr.base.sha,
     labels: (pr.labels || []).map((label) => typeof label === "string" ? label : label.name).filter(Boolean),
@@ -96,8 +98,7 @@ async function resolvePr({ github, context, inputs = {} }) {
       nodeId: pr.user?.node_id || null, login: pr.user?.login || null, type: pr.user?.type || null,
       association: pr.author_association || null,
     },
-    bypassCi: route === "dispatch" && ["true", true].includes(
-      inputs.bypassCi ?? context.payload.inputs?.["bypass-ci"]),
+    force,
     reviewRequested: route === "dispatch" && ["true", true].includes(
       inputs.review ?? context.payload.inputs?.review),
     classificationRequested: route === "classification" ||

--- a/.github/pr-automation/resolve-state.js
+++ b/.github/pr-automation/resolve-state.js
@@ -109,9 +109,10 @@ function resolveClassificationState({
 } = {}) {
   const existing = labelsOf(labels);
   const forced = force === true;
+  const failureRateLimit = forced ? undefined : rateLimit;
   if (typeof expectedSha !== "string") return { ok: false, reason: "missing expected SHA" };
   if (!forced && existing.has("ai-reviewed/2")) {
-    return failedClassification(expectedSha, deterministic, "terminal AI review count", rateLimit);
+    return failedClassification(expectedSha, deterministic, "terminal AI review count", failureRateLimit);
   }
   const semverStatus = boundStatus(semver, expectedSha, ["suspected", "not-suspected"]);
   // Checked before the classifier is consulted: an oversized pull request never reaches a model, so
@@ -120,25 +121,26 @@ function resolveClassificationState({
     return xlClassification(expectedSha, deterministic, semverStatus);
   }
   if (!forced && rateLimit && rateLimit.status !== "allowed") {
-    return failedClassification(expectedSha, deterministic, "fork LLM quota unavailable", rateLimit, semverStatus);
+    return failedClassification(expectedSha, deterministic, "fork LLM quota unavailable", failureRateLimit, semverStatus);
   }
   if (!deterministic?.ok) {
     const reason = deterministic?.reason || "deterministic analysis unavailable";
-    return failedClassification(expectedSha, deterministic, reason, rateLimit, semverStatus);
+    return failedClassification(expectedSha, deterministic, reason, failureRateLimit, semverStatus);
   }
   if (!forced && classificationGate?.available === false) {
     const reason = classificationGate.reason || "classification gate unavailable";
-    return failedClassification(expectedSha, deterministic, reason, rateLimit, semverStatus);
+    return failedClassification(expectedSha, deterministic, reason, failureRateLimit, semverStatus);
   }
   const classifierResult = validateClassifier(classifier, {
     expectedSha, changedPaths, documentationOnlyPaths: deterministic.documentationOnlyPaths, prNumber,
   });
   if (!classifierResult?.ok || classifierResult.value?.head_sha !== expectedSha) {
     const reason = classifierResult?.reason || "classifier output unavailable";
-    return failedClassification(expectedSha, deterministic, reason, rateLimit, semverStatus);
+    return failedClassification(expectedSha, deterministic, reason, failureRateLimit, semverStatus);
   }
   if (semverStatus === "unavailable") {
-    return failedClassification(expectedSha, deterministic, "public API compatibility unavailable", rateLimit, semverStatus);
+    return failedClassification(
+      expectedSha, deterministic, "public API compatibility unavailable", failureRateLimit, semverStatus);
   }
   const model = classifierResult.value;
   const breaking = semverStatus === "suspected" || model.breaking_change_suspected;
@@ -170,7 +172,7 @@ function resolveClassificationState({
       kind: "duplicate", marker: DUPLICATE_MARKER,
       url: model.duplicate.similar_pr_url, rationale: model.duplicate.rationale,
     }] : []),
-    ...(isXl ? [{ kind: "xl", marker: XL_MARKER }] : []),
+    ...(isXl && !forced ? [{ kind: "xl", marker: XL_MARKER }] : []),
     ...(legitimacyStopped ? [{
       kind: "legitimacy", marker: LEGITIMACY_MARKER, reason: model.non_legitimate_reason,
     }] : []),
@@ -183,7 +185,7 @@ function resolveClassificationState({
       // A later push can make a previously reported duplicate or XL verdict wrong, and stale
       // guidance would then contradict the labels this run just wrote.
       ...(duplicate ? [] : [DUPLICATE_MARKER]),
-      ...(isXl ? [] : [XL_MARKER]),
+      ...(isXl && !forced ? [] : [XL_MARKER]),
     ],
     legitimacyStopped,
     check: {
@@ -193,7 +195,10 @@ function resolveClassificationState({
       summary: legitimacyStopped
         ? "Validated human-triage classification is bound to this commit."
         : "Validated AI classification is bound to this commit.",
-      machineState: { protocolRelated: model.protocol_related },
+      machineState: {
+        protocolRelated: model.protocol_related,
+        automaticReviewEligible: !forced,
+      },
     },
   };
 }
@@ -251,7 +256,7 @@ function resolveReviewState({
   const existing = labelsOf(labels);
   const forced = force === true;
   const fail = (reason, report = false) => {
-    const comment = quotaComment(rateLimit);
+    const comment = forced ? null : quotaComment(rateLimit);
     return {
       ok: true, mode: "review", expectedSha, failed: true, reason,
       labelSets: [], addLabels: ["maintainer-required"], comments: comment ? [comment] : [],

--- a/.github/pr-automation/resolve-state.js
+++ b/.github/pr-automation/resolve-state.js
@@ -105,27 +105,28 @@ function xlClassification(expectedSha, deterministic, semverStatus) {
 }
 
 function resolveClassificationState({
-  expectedSha, labels, deterministic, classifier, classificationGate, changedPaths, prNumber, semver, rateLimit,
+  expectedSha, labels, deterministic, classifier, classificationGate, changedPaths, prNumber, semver, rateLimit, force,
 } = {}) {
   const existing = labelsOf(labels);
+  const forced = force === true;
   if (typeof expectedSha !== "string") return { ok: false, reason: "missing expected SHA" };
-  if (existing.has("ai-reviewed/2")) {
+  if (!forced && existing.has("ai-reviewed/2")) {
     return failedClassification(expectedSha, deterministic, "terminal AI review count", rateLimit);
   }
   const semverStatus = boundStatus(semver, expectedSha, ["suspected", "not-suspected"]);
   // Checked before the classifier is consulted: an oversized pull request never reaches a model, so
   // there is no classifier output to validate and no quota to charge.
-  if (deterministic?.ok && deterministic.sizeLabel === "size/XL") {
+  if (!forced && deterministic?.ok && deterministic.sizeLabel === "size/XL") {
     return xlClassification(expectedSha, deterministic, semverStatus);
   }
-  if (rateLimit && rateLimit.status !== "allowed") {
+  if (!forced && rateLimit && rateLimit.status !== "allowed") {
     return failedClassification(expectedSha, deterministic, "fork LLM quota unavailable", rateLimit, semverStatus);
   }
   if (!deterministic?.ok) {
     const reason = deterministic?.reason || "deterministic analysis unavailable";
     return failedClassification(expectedSha, deterministic, reason, rateLimit, semverStatus);
   }
-  if (classificationGate?.available === false) {
+  if (!forced && classificationGate?.available === false) {
     const reason = classificationGate.reason || "classification gate unavailable";
     return failedClassification(expectedSha, deterministic, reason, rateLimit, semverStatus);
   }
@@ -176,6 +177,7 @@ function resolveClassificationState({
   ];
   return {
     ok: true, mode: "classification", expectedSha, labelSets, addLabels, comments,
+    dispatchReview: !forced,
     removeCommentMarkers: [
       ...(legitimacyStopped ? [] : [LEGITIMACY_MARKER]),
       // A later push can make a previously reported duplicate or XL verdict wrong, and stale
@@ -244,9 +246,10 @@ async function contributorEligibility({ github, owner, repo, author, currentPrNu
 
 function resolveReviewState({
   expectedSha, labels, reviewer, changedPaths, changedLines, gate, contributor,
-  rateLimit, protocolStatus, protocolReason, reviewerReason, evidenceReason,
+  rateLimit, protocolStatus, protocolReason, reviewerReason, evidenceReason, force, reviewMarkerId,
 } = {}) {
   const existing = labelsOf(labels);
+  const forced = force === true;
   const fail = (reason, report = false) => {
     const comment = quotaComment(rateLimit);
     return {
@@ -261,16 +264,25 @@ function resolveReviewState({
     };
   };
   if (typeof expectedSha !== "string") return { ok: false, reason: "missing expected SHA" };
-  if (existing.has("ai-reviewed/2")) return fail("terminal AI review count");
-  if (rateLimit && rateLimit.status !== "allowed") return fail("fork LLM quota unavailable");
-  if (!gate?.ok || gate.head_sha !== expectedSha || gate.classificationCheck !== true ||
-      (gate.ciGreen !== true && gate.bypassCi !== true) || contributor?.status !== "eligible") {
-    return fail("review gate unavailable");
+  if (forced) {
+    if (gate?.force !== true || gate.head_sha !== expectedSha) return fail("forced review gate unavailable");
+    if (typeof reviewMarkerId !== "string" || !/^[1-9]\d{0,19}$/.test(reviewMarkerId)) {
+      return fail("forced review marker unavailable");
+    }
+  } else {
+    if (existing.has("ai-reviewed/2")) return fail("terminal AI review count");
+    if (rateLimit && rateLimit.status !== "allowed") return fail("fork LLM quota unavailable");
+    if (!gate?.ok || gate.head_sha !== expectedSha || gate.classificationCheck !== true ||
+        gate.ciGreen !== true || contributor?.status !== "eligible") {
+      return fail("review gate unavailable");
+    }
+    if (existing.has("ai-reviewed/1") && gate.secondReviewEligible !== true) {
+      return fail("second review is not eligible");
+    }
+    if (!reviewPolicyEligible({
+      labels, legitimacyStopped: gate.legitimacyStopped, protocolRelated: gate.protocolRelated,
+    })) return fail("review is not eligible");
   }
-  if (existing.has("ai-reviewed/1") && gate.secondReviewEligible !== true) return fail("second review is not eligible");
-  if (!reviewPolicyEligible({
-    labels, legitimacyStopped: gate.legitimacyStopped, protocolRelated: gate.protocolRelated,
-  })) return fail("review is not eligible");
   if (evidenceReason) return fail(evidenceReason, true);
   // A protocol-related review is only publishable when the protocol stage produced a validated
   // handoff; anything else fails closed to humans.
@@ -283,13 +295,17 @@ function resolveReviewState({
   if (!reviewerResult?.ok || reviewerResult.value?.head_sha !== expectedSha) {
     return fail(reviewerReason || reviewerResult?.reason || "reviewer unavailable", true);
   }
-  const nextCount = existing.has("ai-reviewed/1") ? "ai-reviewed/2" : "ai-reviewed/1";
+  const nextCount = existing.has("ai-reviewed/2") ? "ai-reviewed/2"
+    : existing.has("ai-reviewed/1") ? "ai-reviewed/2"
+    : "ai-reviewed/1";
   const hasFindings = reviewerResult.value.has_findings;
+  const reviewMarker = `<!-- ironrdp-pr-automation:review:${expectedSha}` +
+    `${forced ? `:force:${reviewMarkerId}` : ""} -->`;
   return {
     ok: true, mode: "review", expectedSha, labelSets: [{ owned: AI_COUNTS, desired: [nextCount] }],
     addLabels: nextCount === "ai-reviewed/2" || !hasFindings ? ["maintainer-required"] : [],
     removeLabels: nextCount === "ai-reviewed/1" && hasFindings ? ["maintainer-required"] : [],
-    comments: hasFindings ? [{ kind: "review", marker: `<!-- ironrdp-pr-automation:review:${expectedSha} -->`,
+    comments: hasFindings ? [{ kind: "review", marker: reviewMarker,
       review: reviewerResult.value }] : [],
     check: { name: "AI automated review", externalId: `${REVIEWER_SCHEMA_VERSION}:${expectedSha}` },
     reviewerSchemaVersion: REVIEWER_SCHEMA_VERSION,

--- a/.github/pr-automation/validate-classifier.js
+++ b/.github/pr-automation/validate-classifier.js
@@ -102,9 +102,16 @@ function validateClassifier(raw, { expectedSha, changedPaths, documentationOnlyP
   return { ok: true, status: "valid", schemaVersion: SCHEMA_VERSION, value: normalized };
 }
 
-function encodeCheckState({ protocolRelated } = {}) {
+function encodeCheckState({ protocolRelated, automaticReviewEligible = true } = {}) {
   if (typeof protocolRelated !== "boolean") throw new Error("protocolRelated must be a boolean");
-  return `${CHECK_STATE_MARKER} ${JSON.stringify({ schema_version: SCHEMA_VERSION, protocol_related: protocolRelated })}`;
+  if (typeof automaticReviewEligible !== "boolean") {
+    throw new Error("automaticReviewEligible must be a boolean");
+  }
+  return `${CHECK_STATE_MARKER} ${JSON.stringify({
+    schema_version: SCHEMA_VERSION,
+    protocol_related: protocolRelated,
+    automatic_review_eligible: automaticReviewEligible,
+  })}`;
 }
 
 function parseCheckState(text) {
@@ -114,9 +121,16 @@ function parseCheckState(text) {
   if (!line) return null;
   let parsed;
   try { parsed = JSON.parse(line.slice(CHECK_STATE_MARKER.length)); } catch { return null; }
-  if (!exactKeys(parsed, ["schema_version", "protocol_related"]) ||
-      parsed.schema_version !== SCHEMA_VERSION || typeof parsed.protocol_related !== "boolean") return null;
-  return { protocolRelated: parsed.protocol_related };
+  const legacyKeys = ["schema_version", "protocol_related"];
+  const currentKeys = [...legacyKeys, "automatic_review_eligible"];
+  if ((!exactKeys(parsed, legacyKeys) && !exactKeys(parsed, currentKeys)) ||
+      parsed.schema_version !== SCHEMA_VERSION || typeof parsed.protocol_related !== "boolean" ||
+      (parsed.automatic_review_eligible !== undefined &&
+      typeof parsed.automatic_review_eligible !== "boolean")) return null;
+  return {
+    protocolRelated: parsed.protocol_related,
+    automaticReviewEligible: parsed.automatic_review_eligible ?? true,
+  };
 }
 
 module.exports = {

--- a/.github/pr-automation/write-state.js
+++ b/.github/pr-automation/write-state.js
@@ -235,7 +235,7 @@ async function writeState({ github, owner, repo, prNumber, state, botLogin }) {
     }
     if (state.check) {
       const created = await ensureClassificationCheck(github, owner, repo, prNumber, state.expectedSha, state.check);
-      if (created && state.check.title === "Classification complete") {
+      if (created && state.check.title === "Classification complete" && state.dispatchReview !== false) {
         await dispatchClassificationComplete(github, owner, repo, prNumber, state.expectedSha);
       }
     }

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -139,9 +139,11 @@ jobs:
               const externalId = `${SCHEMA_VERSION}:${process.env.HEAD_SHA}`;
               // A check without the current machine-readable state cannot satisfy the review gate,
               // so it must not suppress reclassification either.
-              const completed = data.check_runs.some((run) =>
-                run.external_id === externalId && run.conclusion === "success" &&
-                run.app?.slug === "github-actions" && parseCheckState(run.output?.summary) !== null);
+              const completed = data.check_runs.some((run) => {
+                const state = parseCheckState(run.output?.summary);
+                return run.external_id === externalId && run.conclusion === "success" &&
+                  run.app?.slug === "github-actions" && state?.automaticReviewEligible === true;
+              });
               core.setOutput("required", !completed);
               core.setOutput("available", true);
               core.setOutput("reason", "");
@@ -548,6 +550,7 @@ jobs:
               // and wait for a later classification event to rewrite it.
               const protocolState = trusted ? parseCheckState(classification.output?.summary) : null;
               const classificationCheck = trusted && protocolState !== null &&
+                protocolState.automaticReviewEligible === true &&
                 classification.output?.title === "Classification complete";
               const legitimacyStopped = trusted && classification.output?.title === "Automation stopped";
               const protocolRelated = protocolState?.protocolRelated === true;

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -19,8 +19,8 @@ on:
         required: true
         default: false
         type: boolean
-      bypass-ci:
-        description: Permit a manual review without a green CI run
+      force:
+        description: Bypass automation gates for this manual classifier or reviewer run
         required: true
         default: false
         type: boolean
@@ -52,7 +52,7 @@ jobs:
       base-sha: ${{ steps.resolve.outputs.base-sha }}
       labels: ${{ steps.resolve.outputs.labels }}
       author: ${{ steps.resolve.outputs.author }}
-      bypass-ci: ${{ steps.resolve.outputs.bypass-ci }}
+      force: ${{ steps.resolve.outputs.force }}
       review-requested: ${{ steps.resolve.outputs.review-requested }}
       classification-requested: ${{ steps.resolve.outputs.classification-requested }}
       review-route: ${{ steps.resolve.outputs.review-route }}
@@ -72,7 +72,7 @@ jobs:
               context,
               inputs: {
                 prNumber: context.payload.inputs?.["pr-number"],
-                bypassCi: context.payload.inputs?.["bypass-ci"],
+                force: context.payload.inputs?.force,
                 review: context.payload.inputs?.review,
               },
             });
@@ -83,7 +83,7 @@ jobs:
             core.setOutput("base-sha", result.baseSha ?? "");
             core.setOutput("labels", JSON.stringify(result.labels ?? []));
             core.setOutput("author", JSON.stringify(result.author ?? null));
-            core.setOutput("bypass-ci", result.bypassCi === true);
+            core.setOutput("force", result.force === true);
             core.setOutput("review-requested", result.reviewRequested === true);
             core.setOutput("classification-requested", result.classificationRequested === true);
             core.setOutput("review-route", result.reviewRoute === true);
@@ -96,7 +96,8 @@ jobs:
     if: >-
       needs.resolve-pr.outputs.ok == 'true' &&
       needs.resolve-pr.outputs.classification-requested == 'true' &&
-      !contains(fromJSON(needs.resolve-pr.outputs.labels), 'ai-reviewed/2')
+      (needs.resolve-pr.outputs.force == 'true' ||
+      !contains(fromJSON(needs.resolve-pr.outputs.labels), 'ai-reviewed/2'))
     runs-on: ubuntu-latest
     permissions:
       checks: read
@@ -115,9 +116,21 @@ jobs:
         uses: actions/github-script@v8
         env:
           HEAD_SHA: ${{ needs.resolve-pr.outputs.head-sha }}
+          FORCE: ${{ needs.resolve-pr.outputs.force }}
         with:
           script: |
             const { SCHEMA_VERSION, parseCheckState } = require("./.github/pr-automation/validate-classifier");
+            const force = process.env.FORCE === "true";
+            if (force) {
+              core.setOutput("required", true);
+              core.setOutput("available", true);
+              core.setOutput("reason", "");
+              core.info(JSON.stringify({
+                event: "pr-automation.classification-gate",
+                decision: { available: true, required: true, force: true },
+              }));
+              return;
+            }
             try {
               const { data } = await github.rest.checks.listForRef({
                 owner: context.repo.owner, repo: context.repo.repo, ref: process.env.HEAD_SHA,
@@ -245,11 +258,13 @@ jobs:
     name: Check public API compatibility
     needs: [resolve-pr, classification-gate]
     if: >-
+      always() && !cancelled() &&
       needs.resolve-pr.outputs.ok == 'true' &&
       needs.resolve-pr.outputs.classification-requested == 'true' &&
-      needs.classification-gate.outputs.available == 'true' &&
+      (needs.resolve-pr.outputs.force == 'true' ||
+      (needs.classification-gate.outputs.available == 'true' &&
       needs.classification-gate.outputs.required == 'true' &&
-      !contains(fromJSON(needs.resolve-pr.outputs.labels), 'ai-reviewed/2')
+      !contains(fromJSON(needs.resolve-pr.outputs.labels), 'ai-reviewed/2')))
     runs-on: ubuntu-latest
     permissions: {}
     outputs:
@@ -344,15 +359,17 @@ jobs:
     name: Classify pull request
     needs: [resolve-pr, classification-gate, deterministic-analysis, fork-rate-limit]
     if: >-
+      always() && !cancelled() &&
       needs.resolve-pr.outputs.ok == 'true' &&
-      needs.classification-gate.outputs.available == 'true' &&
-      needs.classification-gate.outputs.required == 'true' &&
       needs.deterministic-analysis.result == 'success' &&
       needs.deterministic-analysis.outputs.ok == 'true' &&
+      (needs.resolve-pr.outputs.force == 'true' ||
+      (needs.classification-gate.outputs.available == 'true' &&
+      needs.classification-gate.outputs.required == 'true' &&
       needs.deterministic-analysis.outputs.size-label != 'size/XL' &&
       needs.fork-rate-limit.result == 'success' &&
       needs.fork-rate-limit.outputs.allowed == 'true' &&
-      !contains(fromJSON(needs.resolve-pr.outputs.labels), 'ai-reviewed/2')
+      !contains(fromJSON(needs.resolve-pr.outputs.labels), 'ai-reviewed/2')))
     runs-on: ubuntu-latest
     permissions: {}
     environment: llm-providers
@@ -445,6 +462,7 @@ jobs:
           CLASSIFICATION_GATE_REASON: ${{ needs.classification-gate.outputs.reason }}
           FORK_RATE_LIMIT: ${{ needs.fork-rate-limit.outputs.quota }}
           SEMVER: ${{ needs.semver.outputs.compatibility }}
+          FORCE: ${{ needs.resolve-pr.outputs.force }}
         with:
           script: |
             const { resolveClassificationState } = require("./.github/pr-automation/resolve-state");
@@ -461,6 +479,7 @@ jobs:
               },
               rateLimit: parse(process.env.FORK_RATE_LIMIT, {}),
               semver: parse(process.env.SEMVER, {}),
+              force: process.env.FORCE === "true",
             });
             core.setOutput("state", JSON.stringify(state));
             core.info(JSON.stringify({ event: "pr-automation.classification-state", decision: state }));
@@ -494,7 +513,8 @@ jobs:
           PULL_REQUEST_NUMBER: ${{ needs.resolve-pr.outputs.pr-number }}
           HEAD_SHA: ${{ needs.resolve-pr.outputs.head-sha }}
           ROUTE: ${{ needs.resolve-pr.outputs.route }}
-          BYPASS_CI: ${{ needs.resolve-pr.outputs.bypass-ci }}
+          LABELS: ${{ needs.resolve-pr.outputs.labels }}
+          FORCE: ${{ needs.resolve-pr.outputs.force }}
         with:
           script: |
             const { SCHEMA_VERSION, parseCheckState } = require("./.github/pr-automation/validate-classifier");
@@ -502,18 +522,22 @@ jobs:
             const { reviewPolicyEligible } = require("./.github/pr-automation/resolve-state");
             const prNumber = Number(process.env.PULL_REQUEST_NUMBER);
             const headSha = process.env.HEAD_SHA;
+            const force = process.env.FORCE === "true";
+            let resolvedLabels = [];
+            try { resolvedLabels = JSON.parse(process.env.LABELS || "[]"); } catch {}
+            const publish = (gate, eligible = gate.ok) => {
+              core.setOutput("gate", JSON.stringify(gate));
+              core.setOutput("eligible", eligible);
+              core.setOutput("protocol-related", gate.protocolRelated === true);
+              core.info(JSON.stringify({
+                event: "pr-automation.review-gate",
+                decision: gate,
+              }));
+            };
             try {
-              const { data: issue } = await github.rest.issues.get({
-                owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber,
-              });
-              const labels = issue.labels.map((label) => typeof label === "string" ? label : label.name);
               const classificationRuns = await github.rest.checks.listForRef({
                 owner: context.repo.owner, repo: context.repo.repo, ref: headSha,
                 check_name: "AI classification", per_page: 100,
-              });
-              const reviewRuns = await github.rest.checks.listForRef({
-                owner: context.repo.owner, repo: context.repo.repo, ref: headSha,
-                check_name: "AI automated review", per_page: 100,
               });
               const completed = (runs, externalId) => runs.data.check_runs
                 .filter((run) => run.external_id === externalId)
@@ -526,44 +550,45 @@ jobs:
               const classificationCheck = trusted && protocolState !== null &&
                 classification.output?.title === "Classification complete";
               const legitimacyStopped = trusted && classification.output?.title === "Automation stopped";
+              const protocolRelated = protocolState?.protocolRelated === true;
+              if (force) {
+                publish({
+                  ok: true, force: true, head_sha: headSha, classificationCheck,
+                  legitimacyStopped, ciGreen: false, secondReviewEligible: true,
+                  policyEligible: true, labels: resolvedLabels, protocolRelated,
+                });
+                return;
+              }
+              const { data: issue } = await github.rest.issues.get({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: prNumber,
+              });
+              const labels = issue.labels.map((label) => typeof label === "string" ? label : label.name);
+              const reviewRuns = await github.rest.checks.listForRef({
+                owner: context.repo.owner, repo: context.repo.repo, ref: headSha,
+                check_name: "AI automated review", per_page: 100,
+              });
               const reviewAtHead = completed(reviewRuns, `${REVIEWER_SCHEMA_VERSION}:${headSha}`)?.conclusion === "success";
               const workflowRuns = process.env.ROUTE === "ci" ? [context.payload.workflow_run] :
                 (await github.rest.actions.listWorkflowRunsForRepo({
                   owner: context.repo.owner, repo: context.repo.repo, head_sha: headSha, per_page: 100,
                 })).data.workflow_runs;
               const ciGreen = workflowRuns.some((run) => run?.name === "CI" && run?.conclusion === "success");
-              const bypassCi = process.env.BYPASS_CI === "true";
               const secondReviewEligible = !labels.includes("ai-reviewed/1") || !reviewAtHead;
-              const protocolRelated = protocolState?.protocolRelated === true;
               const policyEligible = reviewPolicyEligible({ labels, legitimacyStopped, protocolRelated });
-              core.setOutput("gate", JSON.stringify({
-                ok: classificationCheck && (ciGreen || bypassCi) && secondReviewEligible && policyEligible,
-                head_sha: headSha, classificationCheck, legitimacyStopped, ciGreen, bypassCi, secondReviewEligible, policyEligible, labels,
+              publish({
+                ok: classificationCheck && ciGreen && secondReviewEligible && policyEligible,
+                force: false, head_sha: headSha, classificationCheck, legitimacyStopped,
+                ciGreen, secondReviewEligible, policyEligible, labels,
                 protocolRelated,
-              }));
-              core.setOutput("eligible", classificationCheck && (ciGreen || bypassCi) && secondReviewEligible && policyEligible);
-              core.setOutput("protocol-related", protocolRelated);
-              core.info(JSON.stringify({
-                event: "pr-automation.review-gate",
-                decision: {
-                  ok: classificationCheck && (ciGreen || bypassCi) && secondReviewEligible && policyEligible,
-                  headSha, classificationCheck, legitimacyStopped, ciGreen, bypassCi, secondReviewEligible,
-                  policyEligible, labels, protocolRelated,
-                },
-              }));
+              });
             } catch (error) {
               core.warning(`Review gate unavailable: ${error.message}`);
-              core.setOutput("gate", JSON.stringify({
-                ok: false, head_sha: headSha, classificationCheck: false, ciGreen: false,
-                legitimacyStopped: false, bypassCi: process.env.BYPASS_CI === "true", secondReviewEligible: false,
-                policyEligible: false, labels: [], protocolRelated: false,
-              }));
-              core.setOutput("eligible", false);
-              core.setOutput("protocol-related", false);
-              core.info(JSON.stringify({
-                event: "pr-automation.review-gate",
-                decision: { ok: false, headSha, reason: error.message },
-              }));
+              publish({
+                ok: force, force, head_sha: headSha, classificationCheck: false,
+                legitimacyStopped: false, ciGreen: false, secondReviewEligible: force,
+                policyEligible: force, labels: force ? resolvedLabels : [], protocolRelated: false,
+                reason: error.message,
+              }, force);
             }
 
   contributor-history:
@@ -589,9 +614,17 @@ jobs:
         env:
           AUTHOR: ${{ needs.resolve-pr.outputs.author }}
           PULL_REQUEST_NUMBER: ${{ needs.resolve-pr.outputs.pr-number }}
+          FORCE: ${{ needs.resolve-pr.outputs.force }}
         with:
           script: |
             const { contributorEligibility } = require("./.github/pr-automation/resolve-state");
+            if (process.env.FORCE === "true") {
+              const result = { status: "forced" };
+              core.setOutput("history", JSON.stringify(result));
+              core.setOutput("eligible", true);
+              core.info(JSON.stringify({ event: "pr-automation.contributor-history", decision: result }));
+              return;
+            }
             let author = null;
             try { author = JSON.parse(process.env.AUTHOR); } catch {}
             const result = await contributorEligibility({
@@ -606,12 +639,15 @@ jobs:
     name: Analyze protocol conformance
     needs: [resolve-pr, fork-rate-limit, review-gate, contributor-history]
     if: >-
+      always() && !cancelled() &&
       needs.resolve-pr.outputs.ok == 'true' &&
-      needs.fork-rate-limit.result == 'success' &&
+      needs.resolve-pr.outputs.review-route == 'true' &&
+      needs.review-gate.outputs.protocol-related == 'true' &&
+      (needs.resolve-pr.outputs.force == 'true' ||
+      (needs.fork-rate-limit.result == 'success' &&
       needs.fork-rate-limit.outputs.allowed == 'true' &&
       needs.review-gate.outputs.eligible == 'true' &&
-      needs.review-gate.outputs.protocol-related == 'true' &&
-      needs.contributor-history.outputs.eligible == 'true'
+      needs.contributor-history.outputs.eligible == 'true'))
     runs-on: ubuntu-latest
     permissions: {}
     environment: llm-providers
@@ -689,10 +725,12 @@ jobs:
   validate-protocol-review:
     name: Validate protocol handoff
     needs: [resolve-pr, fork-rate-limit, review-gate, contributor-history, protocol-reviewer]
-    if: always() && needs.resolve-pr.outputs.ok == 'true' &&
-      needs.review-gate.outputs.eligible == 'true' &&
+    if: always() && !cancelled() && needs.resolve-pr.outputs.ok == 'true' &&
+      needs.resolve-pr.outputs.review-route == 'true' &&
+      (needs.resolve-pr.outputs.force == 'true' ||
+      (needs.review-gate.outputs.eligible == 'true' &&
       needs.contributor-history.outputs.eligible == 'true' &&
-      needs.fork-rate-limit.outputs.allowed == 'true'
+      needs.fork-rate-limit.outputs.allowed == 'true'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -796,13 +834,16 @@ jobs:
     name: Review pull request
     needs: [resolve-pr, fork-rate-limit, review-gate, contributor-history, validate-protocol-review]
     if: >-
+      always() && !cancelled() &&
       needs.resolve-pr.outputs.ok == 'true' &&
-      needs.fork-rate-limit.result == 'success' &&
+      needs.resolve-pr.outputs.review-route == 'true' &&
+      (needs.validate-protocol-review.outputs.status == 'valid' ||
+      needs.validate-protocol-review.outputs.status == 'not_applicable') &&
+      (needs.resolve-pr.outputs.force == 'true' ||
+      (needs.fork-rate-limit.result == 'success' &&
       needs.fork-rate-limit.outputs.allowed == 'true' &&
       needs.review-gate.outputs.eligible == 'true' &&
-      needs.contributor-history.outputs.eligible == 'true' &&
-      (needs.validate-protocol-review.outputs.status == 'valid' ||
-      needs.validate-protocol-review.outputs.status == 'not_applicable')
+      needs.contributor-history.outputs.eligible == 'true'))
     runs-on: ubuntu-latest
     permissions: {}
     environment: llm-providers
@@ -899,12 +940,19 @@ jobs:
           RAW_OUTPUT: ${{ needs.skeptical-reviewer.outputs.output }}
           REVIEWER_REASON: ${{ needs.skeptical-reviewer.outputs.failure-reason }}
           PULL_REQUEST_NUMBER: ${{ needs.resolve-pr.outputs.pr-number }}
+          FORCE: ${{ needs.resolve-pr.outputs.force }}
+          LABELS: ${{ needs.resolve-pr.outputs.labels }}
+          REVIEW_MARKER_ID: ${{ github.run_id }}
         with:
           script: |
             const { addedLinesByPath, listPrFiles } = require("./.github/pr-automation/deterministic-analysis");
             const { resolveReviewState } = require("./.github/pr-automation/resolve-state");
             const parse = (value, fallback) => { try { return JSON.parse(value || ""); } catch { return fallback; } };
-            const gate = parse(process.env.GATE, {});
+            const force = process.env.FORCE === "true";
+            const gate = parse(process.env.GATE, force ? {
+              ok: true, force: true, head_sha: process.env.HEAD_SHA,
+              labels: parse(process.env.LABELS, []), protocolRelated: false,
+            } : {});
             let files = [];
             let evidenceReason;
             try {
@@ -928,6 +976,8 @@ jobs:
               evidenceReason,
               changedPaths: files.map((file) => file.filename),
               changedLines: addedLinesByPath(files),
+              force,
+              reviewMarkerId: process.env.REVIEW_MARKER_ID,
             });
             core.setOutput("state", JSON.stringify(state));
             core.info(JSON.stringify({ event: "pr-automation.review-state", decision: state }));


### PR DESCRIPTION
Replace the manual CI-only bypass with a workflow_dispatch force
mode. Forced classifier and reviewer runs bypass policy, quota, cache,
and eligibility gates while keeping head, output, protocol, and
stale-write validation intact.

Keep automatic routes unchanged. Forced classifications no longer start
reviews, and forced same-head reviews use run-specific publication
markers so distinct requests publish without duplicating reruns.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>