### PR TITLE
fix: clarify LLM footer coverage

### DIFF
--- a/.agents/skills/llm-comment-footer/SKILL.md
+++ b/.agents/skills/llm-comment-footer/SKILL.md
@@ -5,7 +5,8 @@ description: Add required LLM attribution to GitHub issue bodies and issue or pu
 
 # LLM comment footer
 
-Append exactly one of these footers to the issue body or comment Markdown after a blank line:
+Include exactly one attribution.
+Append one of these footers to the issue body or comment Markdown after a blank line unless using a helper-managed byline:
 
 - `_LLM-assisted comment: auto-replied (no human feedback)._`
 - `_LLM-assisted comment: tuned by human._`
@@ -13,8 +14,7 @@ Append exactly one of these footers to the issue body or comment Markdown after 
 Use `auto-replied` only when the comment is posted without human review, edits, or feedback.
 Use `tuned by human` when a human reviews, edits, or provides feedback that shapes the final comment.
 
-For app-owned `agent-merge` and other helper-driven replies, treat the helper's app-managed byline as separate from the reply content.
-Include one allowed footer in the reply Markdown unless the helper's configured byline exactly matches an allowed footer.
-Never silently assume the helper will add the footer.
+For app-owned `agent-merge` and other helper-driven replies, use an allowed footer in the reply Markdown or the helper's configured app-managed byline.
+Ensure the chosen attribution is actually inserted; never assume the helper will add it or include both.
 
 Do not add the footer to pull request bodies because it conflicts with pull request guidelines.

--- a/.agents/skills/llm-comment-footer/SKILL.md
+++ b/.agents/skills/llm-comment-footer/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: llm-comment-footer
-description: Add required LLM attribution to GitHub issue and pull request comments. Use whenever drafting, creating, or replying to comments, including agent-merge review-thread replies and helper-driven GitHub comment replies. Do not use for issue bodies, pull request bodies, commit messages, or non-comment content.
+description: Add required LLM attribution to GitHub issue bodies and issue or pull request comments. Use whenever drafting, creating, or replying to this content, including agent-merge review-thread replies and helper-driven GitHub comment replies. Do not use for pull request bodies.
 ---
 
 # LLM comment footer
 
-Append exactly one of these footers to the comment Markdown after a blank line:
+Append exactly one of these footers to the issue body or comment Markdown after a blank line:
 
 - `_LLM-assisted comment: auto-replied (no human feedback)._`
 - `_LLM-assisted comment: tuned by human._`
@@ -17,4 +17,4 @@ For app-owned `agent-merge` and other helper-driven replies, treat the helper's 
 Include one allowed footer in the reply Markdown unless the helper's configured byline exactly matches an allowed footer.
 Never silently assume the helper will add the footer.
 
-Do not add the footer to issue bodies, pull request bodies, commit messages, or non-comment content.
+Do not add the footer to pull request bodies because it conflicts with pull request guidelines.

--- a/.agents/skills/llm-comment-footer/SKILL.md
+++ b/.agents/skills/llm-comment-footer/SKILL.md
@@ -8,11 +8,13 @@ description: Add required LLM attribution to GitHub issue bodies and issue or pu
 Include exactly one attribution.
 Append one of these footers to the issue body or comment Markdown after a blank line unless using a helper-managed byline:
 
-- `_LLM-assisted comment: auto-replied (no human feedback)._`
-- `_LLM-assisted comment: tuned by human._`
+- `> [!NOTE]`
+  `> LLM-assisted auto-reply (no human feedback).`
+- `> [!NOTE]`
+  `> Human-tuned, LLM-assisted reply.`
 
-Use `auto-replied` only when the comment is posted without human review, edits, or feedback.
-Use `tuned by human` when a human reviews, edits, or provides feedback that shapes the final comment.
+Use the auto-reply footer only when the comment is posted without human review, edits, or feedback.
+Use the human-tuned footer when a human reviews, edits, or provides feedback that shapes the final comment.
 
 For app-owned `agent-merge` and other helper-driven replies, use an allowed footer in the reply Markdown or the helper's configured app-managed byline.
 Ensure the chosen attribution is actually inserted; never assume the helper will add it or include both.

--- a/.agents/skills/llm-comment-footer/SKILL.md
+++ b/.agents/skills/llm-comment-footer/SKILL.md
@@ -1,15 +1,20 @@
 ---
 name: llm-comment-footer
-description: Add an LLM-usage footer to comments on GitHub issues and pull requests. Use whenever drafting, creating, or replying to an issue comment, pull request conversation comment, or pull request review comment. Do not use for issue bodies or pull request bodies.
+description: Add required LLM attribution to GitHub issue and pull request comments. Use whenever drafting, creating, or replying to comments, including agent-merge review-thread replies and helper-driven GitHub comment replies. Do not use for issue bodies, pull request bodies, commit messages, or non-comment content.
 ---
 
 # LLM comment footer
 
-Append exactly one of these footers after a blank line:
+Append exactly one of these footers to the comment Markdown after a blank line:
 
 - `_LLM-assisted comment: auto-replied (no human feedback)._`
 - `_LLM-assisted comment: tuned by human._`
 
 Use `auto-replied` only when the comment is posted without human review, edits, or feedback.
 Use `tuned by human` when a human reviews, edits, or provides feedback that shapes the final comment.
-Do not add the footer to issue bodies, pull request bodies, commit messages, or other content.
+
+For app-owned `agent-merge` and other helper-driven replies, treat the helper's app-managed byline as separate from the reply content.
+Include one allowed footer in the reply Markdown unless the helper's configured byline exactly matches an allowed footer.
+Never silently assume the helper will add the footer.
+
+Do not add the footer to issue bodies, pull request bodies, commit messages, or non-comment content.


### PR DESCRIPTION
Require repository LLM attribution in issue bodies and issue or pull request comments, including app-owned agent-merge and helper-driven review replies. Format the automated and human-tuned footer variants as GitHub note callouts. For helper replies, accept either an allowed Markdown footer or the configured app-managed byline while requiring exactly one attribution to be inserted. Keep pull request bodies excluded so their text follows pull request guidelines.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>