### PR TITLE
chore(skills): improve Copilot reviews

### DIFF
--- a/.agents/skills/protocol-reviewer/SKILL.md
+++ b/.agents/skills/protocol-reviewer/SKILL.md
@@ -6,8 +6,10 @@ description: Analyze IronRDP changes for RDP protocol conformance against Micros
 # Protocol reviewer
 
 Use the `windows-protocols` skill when it is available to consult the local Microsoft Open
-Specifications corpus. If it is unavailable, use another authoritative specification source provided
-in the task and state any resulting evidence gap.
+Specifications corpus. If it is unavailable, use the Microsoft Learn MCP server when configured:
+search with `microsoft_docs_search`, then retrieve relevant `learn.microsoft.com/openspecs` pages with
+`microsoft_docs_fetch`. If neither source is available, use another authoritative specification source
+provided in the task and state any resulting evidence gap.
 
 Keep the review focused on protocol conformance rather than general code quality. Identify changed
 wire formats, PDUs, fields, constants, state transitions, capability negotiation, security behavior,

--- a/.agents/skills/protocol-reviewer/SKILL.md
+++ b/.agents/skills/protocol-reviewer/SKILL.md
@@ -5,11 +5,9 @@ description: Analyze IronRDP changes for RDP protocol conformance against Micros
 
 # Protocol reviewer
 
-Use the `windows-protocols` skill when it is available to consult the local Microsoft Open
-Specifications corpus. If it is unavailable, use the Microsoft Learn MCP server when configured:
-search with `microsoft_docs_search`, then retrieve relevant `learn.microsoft.com/openspecs` pages with
-`microsoft_docs_fetch`. If neither source is available, use another authoritative specification source
-provided in the task and state any resulting evidence gap.
+Use the `windows-protocols` skill when it is available to consult the local Microsoft Open Specifications corpus.
+If it is unavailable, use the Microsoft Learn MCP server when configured: search with `microsoft_docs_search`, then retrieve relevant `learn.microsoft.com/openspecs` pages with `microsoft_docs_fetch`.
+If neither source is available, use another authoritative specification source provided in the task and state any resulting evidence gap.
 
 Keep the review focused on protocol conformance rather than general code quality. Identify changed
 wire formats, PDUs, fields, constants, state transitions, capability negotiation, security behavior,

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: review-orchestrator
-description: Run an efficient, multi-perspective IronRDP diff review and return one evidence-checked report. Use for comprehensive code reviews or whenever protocol correctness, code compression, documentation compression, prose style, and skeptical design review may need coordinated coverage.
+name: code-review
+description: Review IronRDP pull requests and diffs using focused protocol, compression, prose, and skeptical passes. Use whenever Copilot code review is requested or a proposed change needs review.
 ---
 
-# Review orchestrator
+# Code review
 
 Inspect the diff, its stated goal, and repository guidance before selecting reviewers:
 


### PR DESCRIPTION
Rename the review orchestrator to the code-review entrypoint so GitHub Copilot code review is more likely to load it automatically.

Use Microsoft Learn MCP as the protocol specification fallback when the local windows-protocols skill is unavailable.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>