### PR TITLE
ci: isolate PR automation concurrency

### DIFF
--- a/.github/actions/resilient-review-output/action.yml
+++ b/.github/actions/resilient-review-output/action.yml
@@ -85,8 +85,11 @@ runs:
             validateModelOutput,
           } = require("./.github/actions/resilient-review-output/validate");
           const output = process.env.STRUCTURED_OUTPUT || "";
-          const result = output === "" && process.env.OUTCOME === "failure"
-            ? { ok: false, reason: "initial model action failed without structured output" }
+          const result = output === "" && process.env.OUTCOME !== "success"
+            ? {
+                ok: false,
+                reason: `initial model action ${process.env.OUTCOME} before producing structured output`,
+              }
             : validateModelOutput(output, {
               stage: process.env.STAGE, expectedSha: process.env.EXPECTED_SHA,
               prNumber: Number(process.env.PR_NUMBER),
@@ -151,8 +154,11 @@ runs:
           let reason = process.env.INITIAL_REASON;
           if (!selected && process.env.RETRY_ATTEMPTED === "true") {
             const retryOutput = process.env.RETRY_OUTPUT || "";
-            const retry = retryOutput === "" && process.env.RETRY_OUTCOME === "failure"
-              ? { ok: false, reason: "resumed model action failed without structured output" }
+            const retry = retryOutput === "" && process.env.RETRY_OUTCOME !== "success"
+              ? {
+                  ok: false,
+                  reason: `resumed model action ${process.env.RETRY_OUTCOME} before producing structured output`,
+                }
               : validateModelOutput(retryOutput, {
                 stage: process.env.STAGE, expectedSha: process.env.EXPECTED_SHA,
                 prNumber: Number(process.env.PR_NUMBER),

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -75,6 +75,22 @@ test("workflow does not resolve or write state after cancellation", () => {
   }
 });
 
+test("workflow isolates CI completion concurrency by source commit", () => {
+  const workflow = fs.readFileSync(path.join(__dirname, "..", "workflows", "labeler.yml"), "utf8");
+  assert.match(workflow, /pr-automation-\$\{\{ github\.event_name }}-\$\{\{/);
+  assert.match(workflow, /github\.event\.workflow_run\.head_sha \|\|/);
+  assert.doesNotMatch(workflow, /github\.event\.workflow_run\.pull_requests\[0\]\.number/);
+});
+
+test("resilient model output reports interrupted attempts without validating empty output", () => {
+  const action = fs.readFileSync(
+    path.join(__dirname, "..", "actions", "resilient-review-output", "action.yml"), "utf8");
+  assert.match(action, /process\.env\.OUTCOME !== "success"/);
+  assert.match(action, /initial model action \$\{process\.env\.OUTCOME} before producing structured output/);
+  assert.match(action, /process\.env\.RETRY_OUTCOME !== "success"/);
+  assert.match(action, /resumed model action \$\{process\.env\.RETRY_OUTCOME} before producing structured output/);
+});
+
 test("workflow force mode bypasses model policy gates without changing automatic branches", () => {
   const workflow = fs.readFileSync(path.join(__dirname, "..", "workflows", "labeler.yml"), "utf8");
   assert.match(workflow, /^\s{6}force:\n\s{8}description:/m);

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -26,13 +26,13 @@ on:
         type: boolean
 
 concurrency:
-  # A fork pull request leaves workflow_run.pull_requests empty, so the head SHA keeps concurrent
-  # runs for the same commit grouped instead of degrading to a never-colliding run identifier.
+  # Keep event routes separate so a stale CI completion cannot cancel newer PR-head automation.
+  # Group CI completions by source commit because their associated PR may already have moved ahead.
   group: >-
-    pr-automation-${{ github.event.pull_request.number || inputs.pr-number ||
-    github.event.workflow_run.pull_requests[0].number ||
+    pr-automation-${{ github.event_name }}-${{ github.event.workflow_run.head_sha ||
+    github.event.pull_request.number || inputs.pr-number ||
     github.event.client_payload.pr_number ||
-    github.event.workflow_run.head_sha || github.run_id }}
+    github.run_id }}
   cancel-in-progress: true
 
 permissions: {}


### PR DESCRIPTION
Group CI completion runs by their source commit so stale results cannot cancel automation for a newer pull request head. Report interrupted model calls as cancelled instead of treating missing output as malformed.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>