### PR TITLE
ci: recover failed Claude action output

### DIFF
--- a/.github/actions/resilient-review-output/action.yml
+++ b/.github/actions/resilient-review-output/action.yml
@@ -82,20 +82,31 @@ runs:
       with:
         script: |
           const {
-            validateModelOutput,
+            isSessionId, recoverExecutionOutput, validateModelOutput,
           } = require("./.github/actions/resilient-review-output/validate");
-          const output = process.env.STRUCTURED_OUTPUT || "";
+          const recovered = recoverExecutionOutput(process.env.RUNNER_TEMP);
+          const actionOutput = process.env.STRUCTURED_OUTPUT || "";
+          const output = actionOutput || (recovered.ok ? recovered.structuredOutput : "");
+          const source = actionOutput ? "initial" : output ? "initial-transcript" : "";
           const result = output === "" && process.env.OUTCOME === "failure"
-            ? { ok: false, reason: "initial model action failed without structured output" }
+            ? {
+              ok: false,
+              reason: recovered.ok
+                ? "initial model action failed without structured output"
+                : `initial model action failed without structured output; ${recovered.reason}`,
+            }
             : validateModelOutput(output, {
               stage: process.env.STAGE, expectedSha: process.env.EXPECTED_SHA,
               prNumber: Number(process.env.PR_NUMBER),
             });
           core.setOutput("valid", result.ok);
+          core.setOutput("output", result.ok ? output : "");
+          core.setOutput("source", result.ok ? source : "");
           core.setOutput("reason", result.ok ? "" : result.reason);
-          const sessionId = process.env.SESSION_ID;
-          if (!result.ok &&
-              /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(sessionId)) {
+          const sessionId = isSessionId(process.env.SESSION_ID)
+            ? process.env.SESSION_ID
+            : recovered.ok ? recovered.sessionId : "";
+          if (!result.ok && sessionId) {
             core.setOutput("retry-args", `${process.env.RETRY_ARGS} --resume ${sessionId}`);
           }
 
@@ -135,31 +146,43 @@ runs:
         EXPECTED_SHA: ${{ inputs.expected_sha }}
         PR_NUMBER: ${{ inputs.pr_number }}
         INITIAL_VALID: ${{ steps.validate-initial.outputs.valid }}
+        INITIAL_SOURCE: ${{ steps.validate-initial.outputs.source }}
         INITIAL_REASON: ${{ steps.validate-initial.outputs.reason }}
         INITIAL_OUTCOME: ${{ steps.initial.outcome }}
-        INITIAL_OUTPUT: ${{ steps.initial.outputs.structured_output }}
+        INITIAL_OUTPUT: ${{ steps.validate-initial.outputs.output }}
         RETRY_ATTEMPTED: ${{ steps.validate-initial.outputs.retry-args != '' }}
         RETRY_OUTCOME: ${{ steps.retry.outcome }}
         RETRY_OUTPUT: ${{ steps.retry.outputs.structured_output }}
       with:
         script: |
           const {
-            validateModelOutput,
+            recoverExecutionOutput, validateModelOutput,
           } = require("./.github/actions/resilient-review-output/validate");
           let output = process.env.INITIAL_OUTPUT || "";
-          let selected = process.env.INITIAL_VALID === "true" ? "initial" : null;
+          let selected = process.env.INITIAL_VALID === "true"
+            ? process.env.INITIAL_SOURCE || "initial"
+            : null;
           let reason = process.env.INITIAL_REASON;
+          let retryStructuredOutput = process.env.RETRY_OUTPUT || "";
           if (!selected && process.env.RETRY_ATTEMPTED === "true") {
-            const retryOutput = process.env.RETRY_OUTPUT || "";
+            const recovered = recoverExecutionOutput(process.env.RUNNER_TEMP);
+            const actionOutput = retryStructuredOutput;
+            const retryOutput = actionOutput || (recovered.ok ? recovered.structuredOutput : "");
+            retryStructuredOutput = retryOutput;
             const retry = retryOutput === "" && process.env.RETRY_OUTCOME === "failure"
-              ? { ok: false, reason: "resumed model action failed without structured output" }
+              ? {
+                ok: false,
+                reason: recovered.ok
+                  ? "resumed model action failed without structured output"
+                  : `resumed model action failed without structured output; ${recovered.reason}`,
+              }
               : validateModelOutput(retryOutput, {
                 stage: process.env.STAGE, expectedSha: process.env.EXPECTED_SHA,
                 prNumber: Number(process.env.PR_NUMBER),
               });
             if (retry.ok) {
               output = retryOutput;
-              selected = "resumed";
+              selected = actionOutput ? "resumed" : "resumed-transcript";
               reason = "";
             } else {
               reason = `initial: ${reason}; resumed: ${retry.reason}`;
@@ -173,7 +196,7 @@ runs:
             retryOutcome: process.env.RETRY_ATTEMPTED === "true" ? process.env.RETRY_OUTCOME : null,
             initialStructuredOutput: process.env.INITIAL_OUTPUT || null,
             retryStructuredOutput: process.env.RETRY_ATTEMPTED === "true"
-              ? process.env.RETRY_OUTPUT || null : null,
+              ? retryStructuredOutput || null : null,
             reason: selected ? null : reason,
           }));
           if (!selected) core.warning(`No valid ${process.env.STAGE} output: ${reason}`);

--- a/.github/actions/resilient-review-output/validate.js
+++ b/.github/actions/resilient-review-output/validate.js
@@ -5,7 +5,7 @@ const path = require("node:path");
 const { execFileSync } = require("node:child_process");
 
 const { MAX_FILES } = require("../../pr-automation/deterministic-analysis");
-const { invalid, REPO_PATH, SHA } = require("../../pr-automation/validation");
+const { invalid, isPlainObject, REPO_PATH, SHA } = require("../../pr-automation/validation");
 const {
   corpusFromDirectory, validateProtocolReview,
 } = require("../../pr-automation/validate-protocol-review");
@@ -13,6 +13,47 @@ const { validateClassifier } = require("../../pr-automation/validate-classifier"
 const { validateReviewer } = require("../../pr-automation/validate-reviewer");
 
 const MAX_PATH_BYTES = 500;
+const MAX_EXECUTION_BYTES = 64 * 1024 * 1024;
+const SESSION_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function isSessionId(value) {
+  return typeof value === "string" && SESSION_ID.test(value);
+}
+
+function recoverExecutionOutput(runnerTemp) {
+  if (typeof runnerTemp !== "string" || runnerTemp.length === 0) {
+    return invalid("execution transcript path unavailable");
+  }
+  const executionFile = path.join(runnerTemp, "claude-execution-output.json");
+  let messages;
+  try {
+    const size = fs.statSync(executionFile).size;
+    if (size === 0 || size > MAX_EXECUTION_BYTES) {
+      return invalid("execution transcript size is invalid");
+    }
+    messages = JSON.parse(fs.readFileSync(executionFile, "utf8"));
+  } catch {
+    return invalid("execution transcript unavailable");
+  }
+  if (!Array.isArray(messages)) return invalid("execution transcript is invalid");
+
+  let sessionId = "";
+  let structuredOutput = "";
+  for (const message of messages) {
+    if (!isPlainObject(message)) continue;
+    if (message.type === "system" && message.subtype === "init" &&
+        isSessionId(message.session_id)) {
+      sessionId = message.session_id;
+    }
+    if (message.type === "result" && message.subtype === "success" && message.is_error === false &&
+        Object.hasOwn(message, "structured_output") && message.structured_output !== null) {
+      structuredOutput = typeof message.structured_output === "string"
+        ? message.structured_output
+        : JSON.stringify(message.structured_output);
+    }
+  }
+  return { ok: true, sessionId, structuredOutput };
+}
 
 function parseChangedPaths(source) {
   if (!Buffer.isBuffer(source) || source.length === 0 ||
@@ -75,4 +116,6 @@ function validateModelOutput(raw, {
   });
 }
 
-module.exports = { changedPathsFromRepository, parseChangedPaths, validateModelOutput };
+module.exports = {
+  changedPathsFromRepository, isSessionId, parseChangedPaths, recoverExecutionOutput, validateModelOutput,
+};

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
 const assert = require("node:assert/strict");
@@ -16,7 +17,7 @@ const {
   corpusFromDirectory, notApplicableHandoff, validateProtocolReview,
 } = require("./validate-protocol-review");
 const {
-  parseChangedPaths, validateModelOutput,
+  isSessionId, parseChangedPaths, recoverExecutionOutput, validateModelOutput,
 } = require("../actions/resilient-review-output/validate");
 
 const SHA = "a".repeat(40);
@@ -58,14 +59,72 @@ test("workflow does not overwrite github-script result outputs", () => {
   assert.equal((workflow.match(/uses: \.\/\.github\/actions\/resilient-review-output/g) || []).length, 3);
   assert.match(workflow, /stage: classifier/);
   assert.match(workflow, /pr_number: \$\{\{ needs\.resolve-pr\.outputs\.pr-number \}\}/);
+  assert.match(workflow, /core\.setOutput\("value", `\$\{common\} --max-turns 10`\)/);
   assert.match(workflow, /core\.setOutput\("retry", `\$\{common\} --max-turns 3`\)/);
   const resilientAction = fs.readFileSync(
     path.join(__dirname, "..", "actions", "resilient-review-output", "action.yml"), "utf8");
   assert.match(resilientAction, /--resume \$\{sessionId\}/);
+  assert.match(resilientAction, /steps\.validate-initial\.outputs\.output/);
+  assert.equal((resilientAction.match(/recoverExecutionOutput\(process\.env\.RUNNER_TEMP\)/g) || []).length, 2);
   assert.equal(
     (resilientAction.match(/git ls-files --error-unmatch -- package\.json/g) || []).length,
     2,
   );
+});
+
+test("execution transcript recovers rejected successful output", () => {
+  const runnerTemp = fs.mkdtempSync(path.join(os.tmpdir(), "ironrdp-llm-output-"));
+  const sessionId = "4e9d7d9e-a05f-42bd-b731-8359f4ad5ce0";
+  const output = classifier();
+  try {
+    fs.writeFileSync(path.join(runnerTemp, "claude-execution-output.json"), JSON.stringify([
+      { type: "system", subtype: "init", session_id: sessionId },
+      {
+        type: "result", subtype: "success", is_error: false, num_turns: 9,
+        structured_output: output,
+      },
+    ]));
+    assert.deepEqual(recoverExecutionOutput(runnerTemp), {
+      ok: true, sessionId, structuredOutput: JSON.stringify(output),
+    });
+  } finally {
+    fs.rmSync(runnerTemp, { recursive: true, force: true });
+  }
+});
+
+test("execution transcript recovers a max-turn session for resume", () => {
+  const runnerTemp = fs.mkdtempSync(path.join(os.tmpdir(), "ironrdp-llm-session-"));
+  const sessionId = "6c793474-453b-42c3-aa68-826d1837109e";
+  try {
+    fs.writeFileSync(path.join(runnerTemp, "claude-execution-output.json"), JSON.stringify([
+      { type: "system", subtype: "init", session_id: sessionId },
+      { type: "result", subtype: "error_max_turns", is_error: true },
+    ]));
+    assert.deepEqual(recoverExecutionOutput(runnerTemp), {
+      ok: true, sessionId, structuredOutput: "",
+    });
+  } finally {
+    fs.rmSync(runnerTemp, { recursive: true, force: true });
+  }
+});
+
+test("execution transcript rejects malformed recovery data", () => {
+  const runnerTemp = fs.mkdtempSync(path.join(os.tmpdir(), "ironrdp-llm-invalid-"));
+  try {
+    fs.writeFileSync(path.join(runnerTemp, "claude-execution-output.json"), JSON.stringify([
+      { type: "system", subtype: "init", session_id: "--resume attacker-controlled" },
+      {
+        type: "result", subtype: "error_max_turns", is_error: true,
+        structured_output: classifier(),
+      },
+    ]));
+    assert.deepEqual(recoverExecutionOutput(runnerTemp), {
+      ok: true, sessionId: "", structuredOutput: "",
+    });
+    assert.equal(isSessionId("--resume attacker-controlled"), false);
+  } finally {
+    fs.rmSync(runnerTemp, { recursive: true, force: true });
+  }
 });
 
 test("workflow does not resolve or write state after cancellation", () => {

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -414,7 +414,7 @@ jobs:
             // Sonnet at its lowest effort: the heavy stages are where deep reasoning is worth
             // paying for. Haiku is cheaper still but supports no effort control at all.
             const common = `--model sonnet --effort low --add-dir pr-head --add-dir pr-evidence --allowedTools "Read,Glob,Grep" --disallowedTools "Bash,Edit,Write,WebFetch,Task" --json-schema '${schema}'`;
-            core.setOutput("value", `${common} --max-turns 8`);
+            core.setOutput("value", `${common} --max-turns 10`);
             core.setOutput("retry", `${common} --max-turns 3`);
 
       - id: claude


### PR DESCRIPTION
Claude action failures can suppress otherwise usable step outputs.

Recover validated results and resume IDs from its bounded transcript.
Failed steps no longer discard successful output or block retries.
Raise the classifier's initial budget from 8 to 10 turns.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>