### PR TITLE
fix(ci): avoid duplicate review findings

### DIFF
--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -1198,6 +1198,50 @@ test("writer deduplicates one forced review invocation but publishes a later one
   assert.equal(await publish(`<!-- ironrdp-pr-automation:review:${SHA}:force:5678 -->`), 1);
 });
 
+test("writer publishes each finding either inline or in the review body", async () => {
+  let published;
+  const github = {
+    paginate: { iterator: async function* () { yield { data: [] }; } },
+    rest: {
+      pulls: {
+        listReviews: () => {},
+        get: async () => ({ data: { state: "open", head: { sha: SHA } } }),
+        createReview: async (payload) => { published = payload; },
+      },
+      issues: { get: async () => ({ data: { labels: [] } }) },
+    },
+  };
+  await writeState({
+    github, owner: "Devolutions", repo: "IronRDP", prNumber: 1, botLogin: "github-actions[bot]",
+    state: {
+      ok: true, mode: "review", expectedSha: SHA, labelSets: [], addLabels: [],
+      comments: [{
+        kind: "review",
+        marker: `<!-- ironrdp-pr-automation:review:${SHA} -->`,
+        review: review({
+          summary: "review summary",
+          protocol_handoff: { received: true, disposition: "accepted", rationale: "protocol rationale" },
+          findings: [
+            finding({ rationale: "inline-only rationale" }),
+            finding({
+              path: "src/other.rs", start_line: null, end_line: null,
+              rationale: "body-only rationale",
+            }),
+          ],
+        }),
+      }],
+    },
+  });
+
+  assert.equal(published.comments.length, 1);
+  assert.match(published.comments[0].body, /inline-only rationale/);
+  assert.doesNotMatch(published.comments[0].body, /body-only rationale/);
+  assert.match(published.body, /review summary/);
+  assert.match(published.body, /protocol rationale/);
+  assert.match(published.body, /body-only rationale/);
+  assert.doesNotMatch(published.body, /inline-only rationale/);
+});
+
 function paginated(pages) {
   return {
     paginate: { iterator: async function* (_method, options) {

--- a/.github/pr-automation/write-state.js
+++ b/.github/pr-automation/write-state.js
@@ -82,10 +82,8 @@ async function deleteMarkedComment(github, owner, repo, prNumber, expectedSha, b
 }
 
 function reviewBody(marker, review) {
-  const findings = review.findings.map((finding, index) => {
-    const location = finding.start_line === null ? escapeMarkdown(finding.path) :
-      `${escapeMarkdown(finding.path)}:${finding.start_line}-${finding.end_line}`;
-    return `${index + 1}. **${finding.classification}** / ${finding.severity} — ${location}\n   ${escapeMarkdown(finding.rationale)}`;
+  const findings = review.findings.filter((finding) => finding.start_line === null).map((finding, index) => {
+    return `${index + 1}. **${finding.classification}** / ${finding.severity} — ${escapeMarkdown(finding.path)}\n   ${escapeMarkdown(finding.rationale)}`;
   }).join("\n");
   const handoff = review.protocol_handoff.received
     ? `\n\nProtocol analysis: ${review.protocol_handoff.disposition} — ${escapeMarkdown(review.protocol_handoff.rationale)}`


### PR DESCRIPTION
Publish located findings only as inline comments, while retaining findings without a valid diff location in the top-level review body.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>