### PR TITLE
ci(pr-automation): clarify review outcomes

### DIFF
--- a/.github/PR_AUTOMATION.md
+++ b/.github/PR_AUTOMATION.md
@@ -105,8 +105,8 @@ Each resolved, non-cancelled workflow run that reaches the final writer records 
 The trace records event resolution, every gate and deterministic-analysis result, normalized classification and review states, and the selected label additions, removals, comments, and check mutation.
 Jobs skipped by a gate appear in the final trace with their job outcome.
 Cancelled runs and runs without a successfully resolved pull request retain only the earlier job logs and do not emit this final trace.
-After every LLM stage, the log records the action outcome and its complete schema-bound structured output.
-These values are untrusted pull-request-derived evidence, so they are emitted through `core.info` and never interpolated into or executed as a shell command.
+After every LLM stage, the log records the action outcome, selected source, failure reason, and whether structured output was present with its UTF-8 byte size.
+This bounded metadata is emitted through `core.info`; the untrusted pull-request-derived output itself is validated but not logged.
 
 ## Labels
 

--- a/.github/actions/resilient-review-output/action.yml
+++ b/.github/actions/resilient-review-output/action.yml
@@ -192,13 +192,26 @@ runs:
           }
           core.setOutput("output", selected ? output : "");
           core.setOutput("reason", selected ? "" : reason);
+          const transcriptOutcome = selected === "initial-transcript"
+            ? process.env.INITIAL_OUTCOME
+            : selected === "resumed-transcript" ? process.env.RETRY_OUTCOME : null;
+          if (transcriptOutcome && transcriptOutcome !== "success") {
+            core.notice(
+              `Recovered valid ${process.env.STAGE} output from the execution transcript after ` +
+              `the model step reported ${transcriptOutcome}`,
+            );
+          }
+          const outputMetadata = (value) => ({
+            present: value !== "",
+            bytes: Buffer.byteLength(value, "utf8"),
+          });
           core.info(JSON.stringify({
             event: "pr-automation.llm-output", stage: process.env.STAGE, selected,
             initialOutcome: process.env.INITIAL_OUTCOME,
             retryOutcome: process.env.RETRY_ATTEMPTED === "true" ? process.env.RETRY_OUTCOME : null,
-            initialStructuredOutput: process.env.INITIAL_OUTPUT || null,
+            initialStructuredOutput: outputMetadata(process.env.INITIAL_OUTPUT || ""),
             retryStructuredOutput: process.env.RETRY_ATTEMPTED === "true"
-              ? retryStructuredOutput || null : null,
+              ? outputMetadata(retryStructuredOutput) : null,
             reason: selected ? null : reason,
           }));
           if (!selected) core.warning(`No valid ${process.env.STAGE} output: ${reason}`);

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -148,6 +148,14 @@ test("resilient model output reports interrupted attempts without validating emp
   assert.match(action, /initial model action \$\{process\.env\.OUTCOME} before producing structured output/);
   assert.match(action, /process\.env\.RETRY_OUTCOME !== "success"/);
   assert.match(action, /resumed model action \$\{process\.env\.RETRY_OUTCOME} before producing structured output/);
+  assert.match(action, /transcriptOutcome && transcriptOutcome !== "success"/);
+  assert.match(action, /core\.notice\(/);
+  assert.match(action, /Recovered valid \$\{process\.env\.STAGE} output from the execution transcript/);
+  assert.match(action, /Buffer\.byteLength\(value, "utf8"\)/);
+  assert.match(action, /initialStructuredOutput: outputMetadata\(process\.env\.INITIAL_OUTPUT \|\| ""\)/);
+  assert.match(action, /retryStructuredOutput: process\.env\.RETRY_ATTEMPTED === "true"\s+\? outputMetadata\(retryStructuredOutput\) : null/);
+  assert.doesNotMatch(action, /initialStructuredOutput: process\.env\.INITIAL_OUTPUT \|\| null/);
+  assert.doesNotMatch(action, /\? retryStructuredOutput \|\| null : null/);
 });
 
 test("workflow force mode bypasses model policy gates without changing automatic branches", () => {
@@ -975,6 +983,34 @@ test("review transition is terminal-safe and preserves human triage on no findin
     expectedSha: SHA, labels: ["ai-reviewed/2"], reviewer, protocolStatus: "not_applicable",
     gate: { ok: true, head_sha: SHA, classificationCheck: true, ciGreen: true }, contributor: { status: "eligible" },
   }).failed, true);
+});
+
+test("review blockers distinguish gate and contributor history failures", () => {
+  const args = {
+    expectedSha: SHA, labels: ["risk/high"], reviewer: review(), protocolStatus: "not_applicable",
+    gate: { ok: true, head_sha: SHA, classificationCheck: true, ciGreen: true },
+    contributor: { status: "eligible" },
+  };
+  const invalidGate = resolveReviewState({
+    ...args, gate: { ...args.gate, ok: false, reason: "checks unavailable" },
+  });
+  assert.equal(invalidGate.ok, true);
+  assert.equal(invalidGate.failed, true);
+  assert.equal(invalidGate.reason, "review gate unavailable: checks unavailable");
+
+  const ineligible = resolveReviewState({
+    ...args, contributor: { status: "ineligible", merged: 1 },
+  });
+  assert.equal(ineligible.ok, true);
+  assert.equal(ineligible.failed, true);
+  assert.equal(ineligible.reason, "contributor history ineligible (merged: 1, required: 3)");
+
+  const unavailable = resolveReviewState({
+    ...args, contributor: { status: "unavailable", reason: "GitHub API unavailable" },
+  });
+  assert.equal(unavailable.ok, true);
+  assert.equal(unavailable.failed, true);
+  assert.equal(unavailable.reason, "contributor history unavailable: GitHub API unavailable");
 });
 
 test("an unavailable protocol handoff blocks the review count", () => {

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -1011,6 +1011,18 @@ test("review blockers distinguish gate and contributor history failures", () => 
   assert.equal(unavailable.ok, true);
   assert.equal(unavailable.failed, true);
   assert.equal(unavailable.reason, "contributor history unavailable: GitHub API unavailable");
+
+  const secondReview = resolveReviewState({
+    ...args, labels: ["ai-reviewed/1", "risk/high"],
+    gate: { ...args.gate, ok: false, secondReviewEligible: false },
+  });
+  assert.equal(secondReview.reason, "second review is not eligible");
+
+  const policy = resolveReviewState({
+    ...args, labels: ["risk/low"],
+    gate: { ...args.gate, ok: false, policyEligible: false, protocolRelated: false },
+  });
+  assert.equal(policy.reason, "review is not eligible");
 });
 
 test("an unavailable protocol handoff blocks the review count", () => {

--- a/.github/pr-automation/resolve-state.js
+++ b/.github/pr-automation/resolve-state.js
@@ -278,8 +278,21 @@ function resolveReviewState({
     if (existing.has("ai-reviewed/2")) return fail("terminal AI review count");
     if (rateLimit && rateLimit.status !== "allowed") return fail("fork LLM quota unavailable");
     if (!gate?.ok || gate.head_sha !== expectedSha || gate.classificationCheck !== true ||
-        gate.ciGreen !== true || contributor?.status !== "eligible") {
-      return fail("review gate unavailable");
+        gate.ciGreen !== true) {
+      const reason = gate?.reason ? `review gate unavailable: ${gate.reason}` : "review gate unavailable";
+      return fail(reason);
+    }
+    if (contributor?.status === "ineligible") {
+      const reason = Number.isSafeInteger(contributor.merged)
+        ? `contributor history ineligible (merged: ${contributor.merged}, required: ${ELIGIBLE_MERGED_PRS})`
+        : `contributor history ineligible${contributor.reason ? `: ${contributor.reason}` : ""}`;
+      return fail(reason);
+    }
+    if (contributor?.status !== "eligible") {
+      const reason = contributor?.reason
+        ? `contributor history unavailable: ${contributor.reason}`
+        : "contributor history unavailable";
+      return fail(reason);
     }
     if (existing.has("ai-reviewed/1") && gate.secondReviewEligible !== true) {
       return fail("second review is not eligible");

--- a/.github/pr-automation/resolve-state.js
+++ b/.github/pr-automation/resolve-state.js
@@ -277,11 +277,11 @@ function resolveReviewState({
   } else {
     if (existing.has("ai-reviewed/2")) return fail("terminal AI review count");
     if (rateLimit && rateLimit.status !== "allowed") return fail("fork LLM quota unavailable");
-    if (!gate?.ok || gate.head_sha !== expectedSha || gate.classificationCheck !== true ||
-        gate.ciGreen !== true) {
+    if (!gate || gate.head_sha !== expectedSha || typeof gate.ok !== "boolean" || gate.reason) {
       const reason = gate?.reason ? `review gate unavailable: ${gate.reason}` : "review gate unavailable";
       return fail(reason);
     }
+    if (gate.classificationCheck !== true || gate.ciGreen !== true) return fail("review gate unavailable");
     if (contributor?.status === "ineligible") {
       const reason = Number.isSafeInteger(contributor.merged)
         ? `contributor history ineligible (merged: ${contributor.merged}, required: ${ELIGIBLE_MERGED_PRS})`
@@ -300,6 +300,7 @@ function resolveReviewState({
     if (!reviewPolicyEligible({
       labels, legitimacyStopped: gate.legitimacyStopped, protocolRelated: gate.protocolRelated,
     })) return fail("review is not eligible");
+    if (!gate.ok) return fail("review gate unavailable");
   }
   if (evidenceReason) return fail(evidenceReason, true);
   // A protocol-related review is only publishable when the protocol stage produced a validated


### PR DESCRIPTION
Attribute skipped reviews to the gate or contributor history so policy decisions remain successful without hiding their blocker.

Notice transcript recovery after failed model steps and log bounded output metadata instead of complete structured payloads.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>