### PR TITLE
ci(pr-automation): preserve legitimacy flags

### DIFF
--- a/.github/PR_AUTOMATION.md
+++ b/.github/PR_AUTOMATION.md
@@ -75,7 +75,7 @@ Fork-origin pull requests are subject to daily UTC limits on automatic runs.
 The first five pull requests from a fork author may use automation, while authors with at least 15 qualifying merged IronRDP pull requests may use ten.
 Across all forks, the workflow stops LLM automation after 30 fork-origin pull requests were opened that day.
 This GitHub-only global limit is best-effort under concurrent submissions.
-A high-confidence non-legitimate classifier result also stops automated review and hands the pull request to a human.
+A high-confidence non-legitimate classifier result adds `triage/legitimacy`, records the flagged commit in a permanent comment, and hands the pull request to a human.
 
 ## Trust boundaries
 
@@ -130,6 +130,12 @@ The classifier alone controls `scope/cross-cutting`, which requires a material b
 Multiple files, tests, generated companions, and manifest updates alone do not qualify.
 The classifier also controls `kind/technical-debt` and documentation-only labels.
 `origin/fuzzing` remains manual because paths cannot establish how a defect was discovered.
+
+### Legitimacy triage
+
+`triage/legitimacy` records that at least one commit received a high-confidence non-legitimate classification.
+The label remains until a maintainer removes it, and SHA-bound comments remain as an audit trail even when later classifications differ.
+Automated review remains blocked while the label is present.
 
 ### Label setup
 

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -8,7 +8,10 @@ const assert = require("node:assert/strict");
 const { SIZE_LABELS, addedLinesByPath, analyzeFiles, parseLabelerRules } = require("./deterministic-analysis");
 const { validateClassifier } = require("./validate-classifier");
 const { validateReviewer } = require("./validate-reviewer");
-const { resolveClassificationState, resolveReviewState, reviewPolicyEligible, DUPLICATE_MARKER, LEGITIMACY_MARKER, XL_MARKER } = require("./resolve-state");
+const {
+  resolveClassificationState, resolveReviewState, reviewPolicyEligible, DUPLICATE_MARKER,
+  LEGITIMACY_LABEL, LEGITIMACY_MARKER_PREFIX, XL_MARKER,
+} = require("./resolve-state");
 const { resolvePr } = require("./resolve-pr");
 const { StaleHeadError, applyLabels, escapeMarkdown, markerBody, writeState } = require("./write-state");
 const { forkRateLimit } = require("./fork-rate-limit");
@@ -21,6 +24,7 @@ const {
 } = require("../actions/resilient-review-output/validate");
 
 const SHA = "a".repeat(40);
+const OTHER_SHA = "b".repeat(40);
 const classifier = (changes = {}) => ({
   schema_version: "1", head_sha: SHA, risk: "low", technical_debt: false, documentation_only: false,
   cross_cutting: false,
@@ -240,7 +244,9 @@ test("every deterministic label is declared and the repository rules classify to
   const declaredLabels = new Set(JSON.parse(
     fs.readFileSync(path.join(__dirname, "labels.json"), "utf8"),
   ).map((label) => label.name));
-  for (const label of [...Object.keys(rules), ...SIZE_LABELS, "contributor/first-time", "kind/protocol"]) {
+  for (const label of [
+    ...Object.keys(rules), ...SIZE_LABELS, "contributor/first-time", "kind/protocol", LEGITIMACY_LABEL,
+  ]) {
     assert.equal(declaredLabels.has(label), true, `${label} is missing from labels.json`);
   }
   for (const [label, patterns] of Object.entries(rules)) {
@@ -734,7 +740,7 @@ test("protocol relevance overrides risk suppression but no other exclusion", () 
   assert.equal(reviewPolicyEligible({ labels: ["risk/low"], protocolRelated: false }), false);
   assert.equal(reviewPolicyEligible({ labels: ["risk/low", "breaking-change"] }), true);
   assert.equal(reviewPolicyEligible({ labels: ["risk/medium"] }), true);
-  for (const blocking of ["size/XL", "duplicate", "ai-reviewed/2"]) {
+  for (const blocking of ["size/XL", "duplicate", "ai-reviewed/2", LEGITIMACY_LABEL]) {
     assert.equal(reviewPolicyEligible({ labels: ["risk/high", blocking], protocolRelated: true }), false);
   }
   assert.equal(reviewPolicyEligible({
@@ -845,7 +851,7 @@ test("model text cannot smuggle active markup into a bot comment", () => {
   assert.equal(escapeMarkdown("<img src=x>"), "&lt;img src=x&gt;");
 });
 
-test("legitimacy stop is human-owned and clears only after a valid false result", () => {
+test("legitimacy flags leave SHA-bound audit records for maintainer triage", () => {
   const deterministic = { ok: true, pathLabels: [], ownedPathLabels: [], sizeLabel: "size/S", sizeLabels: ["size/S"],
     firstTime: false };
   const stopped = resolveClassificationState({
@@ -856,15 +862,34 @@ test("legitimacy stop is human-owned and clears only after a valid false result"
   });
   assert.equal(stopped.legitimacyStopped, true);
   assert.equal(stopped.check.title, "Automation stopped");
-  assert.equal(stopped.comments[0].kind, "legitimacy");
-  assert.equal(stopped.removeCommentMarkers.includes(LEGITIMACY_MARKER), false);
+  assert.deepEqual(stopped.comments, []);
+  assert.equal(stopped.auditComments[0].kind, "legitimacy");
+  assert.equal(stopped.auditComments[0].marker, `${LEGITIMACY_MARKER_PREFIX}${SHA} -->`);
+  assert.deepEqual(stopped.addLabels, ["maintainer-required", LEGITIMACY_LABEL]);
+  assert.match(markerBody(stopped.auditComments[0]), new RegExp(SHA));
+  assert.match(markerBody(stopped.auditComments[0]), /remains as an audit record/);
+
+  const laterStopped = resolveClassificationState({
+    expectedSha: OTHER_SHA, labels: [LEGITIMACY_LABEL], deterministic,
+    classifier: classifier({
+      head_sha: OTHER_SHA,
+      likely_non_legitimate: true,
+      non_legitimate_confidence: 0.95,
+      non_legitimate_reason: "different evidence",
+    }),
+    semver: { head_sha: OTHER_SHA, status: "not-suspected" },
+  });
+  assert.notEqual(laterStopped.auditComments[0].marker, stopped.auditComments[0].marker);
 
   const cleared = resolveClassificationState({
-    expectedSha: SHA, labels: [], deterministic, classifier: classifier(),
-    semver: { head_sha: SHA, status: "not-suspected" },
+    expectedSha: OTHER_SHA, labels: ["risk/high", LEGITIMACY_LABEL], deterministic,
+    classifier: classifier({ head_sha: OTHER_SHA }),
+    semver: { head_sha: OTHER_SHA, status: "not-suspected" },
   });
   assert.equal(cleared.check.title, "Classification complete");
-  assert.equal(cleared.removeCommentMarkers.includes(LEGITIMACY_MARKER), true);
+  assert.deepEqual(cleared.auditComments, []);
+  assert.equal(cleared.addLabels.includes(LEGITIMACY_LABEL), false);
+  assert.equal(cleared.labelSets.some((set) => set.owned.includes(LEGITIMACY_LABEL)), false);
 });
 
 test("quota decisions stop classification and review with a bounded human handoff", () => {
@@ -1080,6 +1105,34 @@ test("writer stops before mutations when the head is stale", async () => {
     state: { ok: true, mode: "classification", expectedSha: SHA, labelSets: [], addLabels: ["maintainer-required"] },
   }), StaleHeadError);
   assert.equal(writes, 0);
+});
+
+test("writer publishes classification audit comments", async () => {
+  let body = null;
+  const github = {
+    paginate: { iterator: async function* () { yield { data: [] }; } },
+    rest: {
+      pulls: { get: async () => ({ data: { state: "open", head: { sha: SHA } } }) },
+      issues: {
+        get: async () => ({ data: { labels: [] } }),
+        listComments: () => {},
+        createComment: async (payload) => { body = payload.body; },
+      },
+    },
+  };
+  await writeState({
+    github, owner: "Devolutions", repo: "IronRDP", prNumber: 1, botLogin: "github-actions[bot]",
+    state: {
+      ok: true, mode: "classification", expectedSha: SHA, labelSets: [], addLabels: [], comments: [],
+      auditComments: [{
+        kind: "legitimacy", marker: `${LEGITIMACY_MARKER_PREFIX}${SHA} -->`,
+        sha: SHA, reason: "suspicious evidence",
+      }],
+      removeCommentMarkers: [],
+    },
+  });
+  assert.match(body, new RegExp(SHA));
+  assert.match(body, /suspicious evidence/);
 });
 
 test("writer batches the label delta and tolerates an absent label removal", async () => {

--- a/.github/pr-automation/labels.json
+++ b/.github/pr-automation/labels.json
@@ -105,6 +105,11 @@
     "description": "Maintainer review or intervention is required"
   },
   {
+    "name": "triage/legitimacy",
+    "color": "fbca04",
+    "description": "A classifier flagged at least one commit for legitimacy triage"
+  },
+  {
     "name": "ai-reviewed/1",
     "color": "000000",
     "description": "One automated review completed"

--- a/.github/pr-automation/resolve-state.js
+++ b/.github/pr-automation/resolve-state.js
@@ -7,7 +7,8 @@ const { validateReviewer } = require("./validate-reviewer");
 
 const RISK = ["risk/low", "risk/medium", "risk/high", "risk/unknown"];
 const AI_COUNTS = ["ai-reviewed/1", "ai-reviewed/2"];
-const LEGITIMACY_MARKER = "<!-- ironrdp-pr-automation:legitimacy:v1 -->";
+const LEGITIMACY_LABEL = "triage/legitimacy";
+const LEGITIMACY_MARKER_PREFIX = "<!-- ironrdp-pr-automation:legitimacy:v2:";
 const DUPLICATE_MARKER = "<!-- ironrdp-pr-automation:duplicate -->";
 const XL_MARKER = "<!-- ironrdp-pr-automation:xl -->";
 const FORK_QUOTA_MARKER = "<!-- ironrdp-pr-automation:fork-llm-quota -->";
@@ -24,7 +25,7 @@ function labelsOf(labels) {
 function reviewPolicyEligible({ labels, legitimacyStopped, protocolRelated } = {}) {
   const present = labelsOf(labels);
   if (present.has("ai-reviewed/2") || present.has("duplicate") || present.has("size/XL") ||
-      legitimacyStopped === true) return false;
+      present.has(LEGITIMACY_LABEL) || legitimacyStopped === true) return false;
   // Risk gates the non-protocol route only. Risk measures how much human scrutiny a change needs,
   // not how much an automated review is worth, so a protocol-related change is always reviewed.
   if (protocolRelated === true) return true;
@@ -165,23 +166,28 @@ function resolveClassificationState({
     ...optional.map(([label, enabled]) => ({ owned: [label], desired: enabled ? [label] : [] })),
     { owned: ["breaking-change"], desired: breaking ? ["breaking-change"] : [] },
   ];
-  const addLabels = ["maintainer-required"];
   const legitimacyStopped = model.likely_non_legitimate;
+  const addLabels = [
+    "maintainer-required",
+    ...(legitimacyStopped ? [LEGITIMACY_LABEL] : []),
+  ];
   const comments = [
     ...(duplicate ? [{
       kind: "duplicate", marker: DUPLICATE_MARKER,
       url: model.duplicate.similar_pr_url, rationale: model.duplicate.rationale,
     }] : []),
     ...(isXl && !forced ? [{ kind: "xl", marker: XL_MARKER }] : []),
+  ];
+  const auditComments = [
     ...(legitimacyStopped ? [{
-      kind: "legitimacy", marker: LEGITIMACY_MARKER, reason: model.non_legitimate_reason,
+      kind: "legitimacy", marker: `${LEGITIMACY_MARKER_PREFIX}${expectedSha} -->`,
+      sha: expectedSha, reason: model.non_legitimate_reason,
     }] : []),
   ];
   return {
-    ok: true, mode: "classification", expectedSha, labelSets, addLabels, comments,
+    ok: true, mode: "classification", expectedSha, labelSets, addLabels, comments, auditComments,
     dispatchReview: !forced,
     removeCommentMarkers: [
-      ...(legitimacyStopped ? [] : [LEGITIMACY_MARKER]),
       // A later push can make a previously reported duplicate or XL verdict wrong, and stale
       // guidance would then contradict the labels this run just wrote.
       ...(duplicate ? [] : [DUPLICATE_MARKER]),
@@ -332,7 +338,7 @@ function resolveReviewState({
 }
 
 module.exports = {
-  AI_COUNTS, DUPLICATE_MARKER, FORK_QUOTA_MARKER, GLOBAL_QUOTA_MARKER, LEGITIMACY_MARKER, RISK,
-  XL_MARKER, ELIGIBLE_MERGED_PRS, contributorEligibility, isExcludedHistory, qualifyingMergedPrs,
-  resolveClassificationState, resolveReviewState, reviewPolicyEligible,
+  AI_COUNTS, DUPLICATE_MARKER, FORK_QUOTA_MARKER, GLOBAL_QUOTA_MARKER, LEGITIMACY_LABEL,
+  LEGITIMACY_MARKER_PREFIX, RISK, XL_MARKER, ELIGIBLE_MERGED_PRS, contributorEligibility, isExcludedHistory,
+  qualifyingMergedPrs, resolveClassificationState, resolveReviewState, reviewPolicyEligible,
 };

--- a/.github/pr-automation/write-state.js
+++ b/.github/pr-automation/write-state.js
@@ -44,7 +44,7 @@ function markerBody(comment, owner, repo) {
     return `${comment.marker}\n\nThis pull request is \`size/XL\`, so automated review is disabled for it: a change this large is hard to review well in one piece, whether by a human or a model.\n\nPlease split it into focused pull requests that can each be reviewed on their own. When the parts build on each other, [stacked pull requests](https://docs.github.com/en/pull-requests/get-started/about-stacked-prs) let you open each one on top of the last without waiting for the one below to merge. Stacks require every branch to live in this repository, so from a fork, please open separate pull requests instead.\n\nAutomated review resumes once the change is below the \`size/XL\` threshold.`;
   }
   if (comment.kind === "legitimacy") {
-    return `${comment.marker}\n\nAutomated review stopped because this pull request has strong indicators requiring maintainer triage.\n\n${escapeMarkdown(comment.reason)}\n\nMaintainer review is required.`;
+    return `${comment.marker}\n\nAutomated review stopped because commit \`${escapeMarkdown(comment.sha)}\` has strong indicators requiring maintainer triage.\n\n${escapeMarkdown(comment.reason)}\n\nThis comment remains as an audit record if later classifications differ. Maintainer review is required.`;
   }
   if (comment.kind === "fork-quota") {
     return `${comment.marker}\n\nAutomated classification and review capacity is unavailable because this fork account has reached its daily UTC quota of ${comment.quota} pull requests.\n\nSee the [automation policy](https://github.com/${owner}/${repo}/blob/master/.github/PR_AUTOMATION.md). Maintainer review is required.`;
@@ -227,6 +227,8 @@ async function writeState({ github, owner, repo, prNumber, state, botLogin }) {
     if (state.check) await ensureReviewCheck(github, owner, repo, prNumber, state.expectedSha, state.check);
   } else {
     for (const comment of state.comments || []) await upsertMarkedComment(
+      github, owner, repo, prNumber, state.expectedSha, botLogin, comment);
+    for (const comment of state.auditComments || []) await upsertMarkedComment(
       github, owner, repo, prNumber, state.expectedSha, botLogin, comment);
     for (const marker of new Set(state.removeCommentMarkers || [])) {
       await deleteMarkedComment(github, owner, repo, prNumber, state.expectedSha, botLogin, marker);


### PR DESCRIPTION
Legitimacy classifications are audit events, but later classifier runs could delete the explanatory comment and replace the risk state.

Publish SHA-bound records through a persistent audit-comment path, add a sticky triage label, and block automated review until a maintainer clears it. Keep duplicate and XL notices on the transient reconciliation path.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>