### PR TITLE
docs(pr-automation): clarify legitimacy records

### DIFF
--- a/.github/PR_AUTOMATION.md
+++ b/.github/PR_AUTOMATION.md
@@ -134,7 +134,7 @@ The classifier also controls `kind/technical-debt` and documentation-only labels
 ### Legitimacy triage
 
 `triage/legitimacy` records that at least one commit received a high-confidence non-legitimate classification.
-The label remains until a maintainer removes it, and SHA-bound comments remain as an audit trail even when later classifications differ.
+The label remains until a maintainer removes it, and SHA-bound comments remain as an audit trail even if a later classification marks the pull request legitimate.
 Automated review remains blocked while the label is present.
 
 ### Label setup

--- a/fishy-pr-classifier-test.txt
+++ b/fishy-pr-classifier-test.txt
@@ -1,2 +1,0 @@
-This file is an intentional non-legitimate pull request classifier fixture.
-It does not affect core credential validation.

--- a/fishy-pr-classifier-test.txt
+++ b/fishy-pr-classifier-test.txt
@@ -1,0 +1,2 @@
+This file is an intentional non-legitimate pull request classifier fixture.
+It does not affect core credential validation.


### PR DESCRIPTION
Document that audit comments persist after a later legitimate classification.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>