### PR TITLE
ci(pr-automation): bind evidence to PR base

### DIFF
--- a/.github/PR_AUTOMATION.md
+++ b/.github/PR_AUTOMATION.md
@@ -87,7 +87,7 @@ Each Claude action uses only an explicit file or skill invocation, which injects
 Trusted workflow code writes the target head SHA and handoff-receipt status to `pr-automation-context.json` instead of interpolating them into instructions.
 
 The evidence script writes `pr-evidence/changed-files.txt` and `pr-evidence/pull-request.diff`.
-Both files are computed against the merge base so unrelated commits landing on `master` are not attributed to the pull request.
+Both files are computed between the resolved base and head SHAs so they match GitHub's pull request file list even when branch history has diverged.
 The head tree remains available in `pr-head` for surrounding context.
 
 Before exposing that tree to filesystem-reading tools, the script removes every symlink so a pull request cannot redirect a read outside the checkout.

--- a/.github/PR_AUTOMATION.md
+++ b/.github/PR_AUTOMATION.md
@@ -87,7 +87,7 @@ Each Claude action uses only an explicit file or skill invocation, which injects
 Trusted workflow code writes the target head SHA and handoff-receipt status to `pr-automation-context.json` instead of interpolating them into instructions.
 
 The evidence script writes `pr-evidence/changed-files.txt` and `pr-evidence/pull-request.diff`.
-Both files are computed between the resolved base and head SHAs so they match GitHub's pull request file list even when branch history has diverged.
+Both files are computed from the merge base of the resolved base and head SHAs so they match GitHub's pull request file list without racing changes to `master`.
 The head tree remains available in `pr-head` for surrounding context.
 
 Before exposing that tree to filesystem-reading tools, the script removes every symlink so a pull request cannot redirect a read outside the checkout.

--- a/.github/actions/resilient-review-output/validate.js
+++ b/.github/actions/resilient-review-output/validate.js
@@ -72,7 +72,8 @@ function parseChangedPaths(source) {
 function changedPathsFromRepository(repository) {
   try {
     return parseChangedPaths(execFileSync("git", [
-      "-C", repository, "diff", "--find-renames", "--name-only", "-z", "origin/master...HEAD",
+      "-C", repository, "diff", "--find-renames", "--name-only", "-z",
+      "origin/pull-request-base", "HEAD",
     ], { encoding: "buffer", maxBuffer: MAX_FILES * (MAX_PATH_BYTES + 1) }));
   } catch {
     return invalid("changed path evidence unavailable");

--- a/.github/actions/resilient-review-output/validate.js
+++ b/.github/actions/resilient-review-output/validate.js
@@ -72,8 +72,7 @@ function parseChangedPaths(source) {
 function changedPathsFromRepository(repository) {
   try {
     return parseChangedPaths(execFileSync("git", [
-      "-C", repository, "diff", "--find-renames", "--name-only", "-z",
-      "origin/pull-request-base", "HEAD",
+      "-C", repository, "diff", "--find-renames", "--name-only", "-z", "origin/pull-request-base...HEAD",
     ], { encoding: "buffer", maxBuffer: MAX_FILES * (MAX_PATH_BYTES + 1) }));
   } catch {
     return invalid("changed path evidence unavailable");

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -3,6 +3,7 @@
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
+const { execFileSync } = require("node:child_process");
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const { SIZE_LABELS, addedLinesByPath, analyzeFiles, parseLabelerRules } = require("./deterministic-analysis");
@@ -17,7 +18,7 @@ const {
   corpusFromDirectory, notApplicableHandoff, validateProtocolReview,
 } = require("./validate-protocol-review");
 const {
-  isSessionId, parseChangedPaths, recoverExecutionOutput, validateModelOutput,
+  changedPathsFromRepository, isSessionId, parseChangedPaths, recoverExecutionOutput, validateModelOutput,
 } = require("../actions/resilient-review-output/validate");
 
 const SHA = "a".repeat(40);
@@ -232,6 +233,23 @@ test("review skills own methodology while stage prompts own pipeline contracts",
     assert.match(stagePrompt, /pr-evidence\/changed-files\.txt/);
     assert.match(stagePrompt, /Return only the required .*JSON/);
   }
+});
+
+test("LLM evidence is bound to the resolved pull request base", () => {
+  const githubDirectory = path.join(__dirname, "..");
+  const workflow = fs.readFileSync(path.join(githubDirectory, "workflows", "labeler.yml"), "utf8");
+  const evidenceScript = fs.readFileSync(path.join(__dirname, "fetch-pr-evidence.sh"), "utf8");
+  for (const name of ["classifier", "protocol-reviewer", "skeptical-reviewer"]) {
+    const job = workflowJob(workflow, name);
+    assert.match(job, /BASE_SHA: \$\{\{ needs\.resolve-pr\.outputs\.base-sha \}\}/);
+    assert.match(job, /fetch-pr-evidence\.sh "\$HEAD_SHA" "\$BASE_SHA"/);
+  }
+  assert.match(evidenceScript, /\+\$base_sha:refs\/remotes\/origin\/pull-request-base/);
+  assert.match(
+    evidenceScript,
+    /origin\/pull-request-base origin\/pull-request-head > pr-evidence\/changed-files\.txt/,
+  );
+  assert.doesNotMatch(evidenceScript, /merge-base|origin\/master/);
 });
 
 test("every deterministic label is declared and the repository rules classify tooling changes", () => {
@@ -504,6 +522,29 @@ test("heavy review output rejects malformed changed-path evidence", () => {
   });
   assert.equal(parseChangedPaths(Buffer.from("../outside\0")).ok, false);
   assert.equal(parseChangedPaths(Buffer.from("unterminated")).ok, false);
+});
+
+test("heavy review output validates paths against the resolved pull request base", () => {
+  const repository = fs.mkdtempSync(path.join(os.tmpdir(), "ironrdp-pr-base-"));
+  try {
+    execFileSync("git", ["init", "--quiet"], { cwd: repository });
+    execFileSync("git", ["config", "user.email", "automation@example.invalid"], { cwd: repository });
+    execFileSync("git", ["config", "user.name", "PR automation"], { cwd: repository });
+    fs.writeFileSync(path.join(repository, "base.txt"), "base\n");
+    execFileSync("git", ["add", "base.txt"], { cwd: repository });
+    execFileSync("git", ["commit", "--quiet", "-m", "base"], { cwd: repository });
+    const baseSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: repository, encoding: "utf8" }).trim();
+    execFileSync("git", ["update-ref", "refs/remotes/origin/pull-request-base", baseSha], { cwd: repository });
+    fs.writeFileSync(path.join(repository, "pull-request.txt"), "change\n");
+    execFileSync("git", ["add", "pull-request.txt"], { cwd: repository });
+    execFileSync("git", ["commit", "--quiet", "-m", "pull request"], { cwd: repository });
+
+    assert.deepEqual(changedPathsFromRepository(repository), {
+      ok: true, paths: ["pull-request.txt"],
+    });
+  } finally {
+    fs.rmSync(repository, { recursive: true, force: true });
+  }
 });
 
 test("corpus reader indexes real headings and refuses traversal", () => {

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -247,9 +247,9 @@ test("LLM evidence is bound to the resolved pull request base", () => {
   assert.match(evidenceScript, /\+\$base_sha:refs\/remotes\/origin\/pull-request-base/);
   assert.match(
     evidenceScript,
-    /origin\/pull-request-base origin\/pull-request-head > pr-evidence\/changed-files\.txt/,
+    /origin\/pull-request-base\.\.\.origin\/pull-request-head > pr-evidence\/changed-files\.txt/,
   );
-  assert.doesNotMatch(evidenceScript, /merge-base|origin\/master/);
+  assert.doesNotMatch(evidenceScript, /origin\/master/);
 });
 
 test("every deterministic label is declared and the repository rules classify tooling changes", () => {
@@ -533,11 +533,19 @@ test("heavy review output validates paths against the resolved pull request base
     fs.writeFileSync(path.join(repository, "base.txt"), "base\n");
     execFileSync("git", ["add", "base.txt"], { cwd: repository });
     execFileSync("git", ["commit", "--quiet", "-m", "base"], { cwd: repository });
-    const baseSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: repository, encoding: "utf8" }).trim();
-    execFileSync("git", ["update-ref", "refs/remotes/origin/pull-request-base", baseSha], { cwd: repository });
+    const commonSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: repository, encoding: "utf8" }).trim();
     fs.writeFileSync(path.join(repository, "pull-request.txt"), "change\n");
     execFileSync("git", ["add", "pull-request.txt"], { cwd: repository });
     execFileSync("git", ["commit", "--quiet", "-m", "pull request"], { cwd: repository });
+    const headSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd: repository, encoding: "utf8" }).trim();
+    execFileSync("git", ["checkout", "--quiet", "--detach", commonSha], { cwd: repository });
+    fs.writeFileSync(path.join(repository, "base-only.txt"), "base change\n");
+    execFileSync("git", ["add", "base-only.txt"], { cwd: repository });
+    execFileSync("git", ["commit", "--quiet", "-m", "advance base"], { cwd: repository });
+    execFileSync("git", [
+      "update-ref", "refs/remotes/origin/pull-request-base", "HEAD",
+    ], { cwd: repository });
+    execFileSync("git", ["checkout", "--quiet", "--detach", headSha], { cwd: repository });
 
     assert.deepEqual(changedPathsFromRepository(repository), {
       ok: true, paths: ["pull-request.txt"],

--- a/.github/pr-automation/fetch-pr-evidence.sh
+++ b/.github/pr-automation/fetch-pr-evidence.sh
@@ -11,12 +11,13 @@
 # below is a security boundary, and three hand-maintained copies of it would eventually drift.
 set -euo pipefail
 
-if [ "$#" -ne 1 ]; then
-  echo "usage: fetch-pr-evidence.sh <head-sha>" >&2
+if [ "$#" -ne 2 ]; then
+  echo "usage: fetch-pr-evidence.sh <head-sha> <base-sha>" >&2
   exit 1
 fi
 
 head_sha="$1"
+base_sha="$2"
 export GIT_CONFIG_NOSYSTEM=1
 export GIT_CONFIG_GLOBAL=/dev/null
 
@@ -24,7 +25,7 @@ git init pr-head
 git -C pr-head config --local core.hooksPath /dev/null
 git -C pr-head remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
 git -C pr-head fetch --no-tags origin "+$head_sha:refs/remotes/origin/pull-request-head"
-git -C pr-head fetch --no-tags origin +master:refs/remotes/origin/master
+git -C pr-head fetch --no-tags origin "+$base_sha:refs/remotes/origin/pull-request-base"
 git -C pr-head checkout --detach origin/pull-request-head
 
 # The head tree is contributor-controlled. Remove symlinks before granting filesystem-reading tools
@@ -40,14 +41,13 @@ find pr-head -depth \
   -exec rm -rf {} +
 rm -rf pr-head/.github/copilot-instructions.md pr-head/.github/instructions
 
-# Compared against the merge base rather than the base tip so that unrelated commits landing on
-# master while the pull request is open are not attributed to it.
-base_sha="$(git -C pr-head merge-base origin/master origin/pull-request-head)"
+# The resolved base is the same snapshot GitHub uses for the pull request file list. Using the current
+# master merge base can reintroduce changes already present in the resolved base after history diverges.
 mkdir -p pr-evidence
 git -C pr-head diff --no-color --find-renames --name-status \
-  "$base_sha" origin/pull-request-head > pr-evidence/changed-files.txt
+  origin/pull-request-base origin/pull-request-head > pr-evidence/changed-files.txt
 git -C pr-head diff --no-color --find-renames --unified=3 \
-  "$base_sha" origin/pull-request-head > pr-evidence/pull-request.diff
+  origin/pull-request-base origin/pull-request-head > pr-evidence/pull-request.diff
 
 # A single oversized file would otherwise crowd out the rest of the evidence. Oversized pull
 # requests are already excluded upstream, so this only guards against pathological single changes.

--- a/.github/pr-automation/fetch-pr-evidence.sh
+++ b/.github/pr-automation/fetch-pr-evidence.sh
@@ -41,13 +41,12 @@ find pr-head -depth \
   -exec rm -rf {} +
 rm -rf pr-head/.github/copilot-instructions.md pr-head/.github/instructions
 
-# The resolved base is the same snapshot GitHub uses for the pull request file list. Using the current
-# master merge base can reintroduce changes already present in the resolved base after history diverges.
+# Pinning the base avoids races with master while the merge-base comparison excludes base-only changes.
 mkdir -p pr-evidence
 git -C pr-head diff --no-color --find-renames --name-status \
-  origin/pull-request-base origin/pull-request-head > pr-evidence/changed-files.txt
+  origin/pull-request-base...origin/pull-request-head > pr-evidence/changed-files.txt
 git -C pr-head diff --no-color --find-renames --unified=3 \
-  origin/pull-request-base origin/pull-request-head > pr-evidence/pull-request.diff
+  origin/pull-request-base...origin/pull-request-head > pr-evidence/pull-request.diff
 
 # A single oversized file would otherwise crowd out the rest of the evidence. Oversized pull
 # requests are already excluded upstream, so this only guards against pathological single changes.

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -382,6 +382,7 @@ jobs:
         shell: bash
         env:
           HEAD_SHA: ${{ needs.resolve-pr.outputs.head-sha }}
+          BASE_SHA: ${{ needs.resolve-pr.outputs.base-sha }}
         run: |
           set -euo pipefail
           export GIT_CONFIG_NOSYSTEM=1
@@ -391,7 +392,7 @@ jobs:
           git remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
           git fetch --no-tags origin +master:refs/remotes/origin/master
           git checkout --detach origin/master
-          bash ./.github/pr-automation/fetch-pr-evidence.sh "$HEAD_SHA"
+          bash ./.github/pr-automation/fetch-pr-evidence.sh "$HEAD_SHA" "$BASE_SHA"
 
       - id: claude-args
         uses: actions/github-script@v8
@@ -664,6 +665,7 @@ jobs:
         shell: bash
         env:
           HEAD_SHA: ${{ needs.resolve-pr.outputs.head-sha }}
+          BASE_SHA: ${{ needs.resolve-pr.outputs.base-sha }}
         run: |
           set -euo pipefail
           export GIT_CONFIG_NOSYSTEM=1
@@ -673,7 +675,7 @@ jobs:
           git remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
           git fetch --no-tags origin +master:refs/remotes/origin/master
           git checkout --detach origin/master
-          bash ./.github/pr-automation/fetch-pr-evidence.sh "$HEAD_SHA"
+          bash ./.github/pr-automation/fetch-pr-evidence.sh "$HEAD_SHA" "$BASE_SHA"
           # Stage the skill from the corpus default branch. It is a Devolutions-maintained
           # repository, so tracking master keeps the specifications current. No npm, package
           # lifecycle script, or repository credential is involved. The resolved commit is exported
@@ -858,6 +860,7 @@ jobs:
         shell: bash
         env:
           HEAD_SHA: ${{ needs.resolve-pr.outputs.head-sha }}
+          BASE_SHA: ${{ needs.resolve-pr.outputs.base-sha }}
         run: |
           set -euo pipefail
           export GIT_CONFIG_NOSYSTEM=1
@@ -867,7 +870,7 @@ jobs:
           git remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
           git fetch --no-tags origin +master:refs/remotes/origin/master
           git checkout --detach origin/master
-          bash ./.github/pr-automation/fetch-pr-evidence.sh "$HEAD_SHA"
+          bash ./.github/pr-automation/fetch-pr-evidence.sh "$HEAD_SHA" "$BASE_SHA"
           mkdir -p .claude/skills
           cp -R .agents/skills/skeptical-reviewer .claude/skills/skeptical-reviewer
           test -f .claude/skills/skeptical-reviewer/SKILL.md


### PR DESCRIPTION
Build every LLM evidence bundle from the merge base of the resolved pull request base and head instead of the current `master` merge base. This keeps model-visible paths aligned with GitHub's trusted pull request file list when histories diverge without admitting base-only changes.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>