### PR TITLE
ci(agents): source common skills from Gateway

### DIFF
--- a/.github/skills-sync.yml
+++ b/.github/skills-sync.yml
@@ -2,5 +2,12 @@ repositories:
   - repository: Devolutions/devolutions-gateway
     source_path: .agents/skills
     skills:
+      - code-compressor
       - commit-and-pr-conventions
+      - docs-compressor
+      - docs-writer
+      - llm-comment-footer
+      - markdown-writer
+      - prose-verifier
+      - prose-writer
       - tessl-skill-linting


### PR DESCRIPTION
Mirror all nine common agent skills from Devolutions Gateway.

Gateway is their canonical source. IronRDP-only skills remain local.

Synchronization depends on Gateway PR #1922 landing first:
https://github.com/Devolutions/devolutions-gateway/pull/1922

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>