### PR TITLE
chore(xtask): allow the fuzz title scope

### DIFF
--- a/xtask/src/pr.rs
+++ b/xtask/src/pr.rs
@@ -45,6 +45,7 @@ const CANONICAL_SCOPES: &[&str] = &[
     "web",
     "ffi",
     "replay",
+    "fuzz",
     "xtask",
     "release",
     "pr-automation",


### PR DESCRIPTION
## Summary

`cargo xtask pr check-message` rejects `feat(fuzz):` and its siblings with `unsupported title scope 'fuzz'`, because `CANONICAL_SCOPES` has no entry for it.

`fuzz/` is a top-level workspace directory in the same way `xtask/` is, and `xtask` is on the list. The scope also has history behind it: master carries 15 merged commits using it, from five authors.

```
5663ce20  ci(fuzz): discover fuzz targets dynamically (#1290)
a8a813a2  feat(fuzz): add bulk decompression fuzz targets (MPPC, NCRUSH, XCRUSH) (#1285)
610cfd07  test(fuzz): add pdu_round_trip oracle and target (#1291)
cafbef1c  feat(fuzz): add egfx_avc420_decode oracle and target (#1326)
d399a867  feat(fuzz): add egfx_multi_frame oracle and target (#1336)
```

That reads as an omission rather than a deprecation, so this adds `fuzz` alongside the other tooling scopes.

## Effect

Four open pull requests fail the new check on this alone: #1320, #1327, #1333 and #1337. I ran the validator against each of their titles and bodies locally, and all four pass with this change and fail without it.

## Test plan

`cargo xtask check fmt`, `lints`, `tests`, `typos` and `locks` all clean, each verified by exit code.
