### PR TITLE
feat(activex): add static drive redirection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2437,6 +2437,7 @@ dependencies = [
  "ironrdp-input",
  "ironrdp-pdu",
  "ironrdp-propertyset",
+ "ironrdp-rdpdr-native",
  "ironrdp-rpc",
  "ironrdp-session",
  "ironrdp-svc",

--- a/crates/ironrdp-activex/Cargo.toml
+++ b/crates/ironrdp-activex/Cargo.toml
@@ -20,7 +20,7 @@ doctest = false
 
 [target.'cfg(windows)'.dependencies]
 anyhow = "1"
-ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["clipboard", "dvc-com-plugin", "gateway", "rustls", "sound"] }
+ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["clipboard", "dvc-com-plugin", "gateway", "rdpdr", "rustls", "sound"] }
 ironrdp-cliprdr = { path = "../ironrdp-cliprdr", version = "0.7" }
 ironrdp-cliprdr-native = { path = "../ironrdp-cliprdr-native", version = "0.7" }
 ironrdp-cfg = { path = "../ironrdp-cfg", version = "0.1" }
@@ -30,6 +30,7 @@ ironrdp-daemon = { path = "../ironrdp-daemon", version = "0.1" }
 ironrdp-input = { path = "../ironrdp-input", version = "0.7" }
 ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9" }
 ironrdp-propertyset = { path = "../ironrdp-propertyset", version = "0.1" }
+ironrdp-rdpdr-native = { path = "../ironrdp-rdpdr-native", version = "0.7" }
 ironrdp-rpc = { path = "../ironrdp-rpc", version = "0.1" }
 ironrdp-session = { path = "../ironrdp-session", version = "0.11" }
 ironrdp-svc = { path = "../ironrdp-svc", version = "0.8" }
@@ -48,6 +49,7 @@ windows = { version = "0.62", features = [
     "Win32_System_Ole",
     "Win32_System_Registry",
     "Win32_System_Variant",
+    "Win32_Storage_FileSystem",
     "Win32_Security_Credentials",
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_UI_Controls",

--- a/crates/ironrdp-activex/README.md
+++ b/crates/ironrdp-activex/README.md
@@ -285,14 +285,11 @@ A source-level audit of RDM's Windows RDP host covers these ActiveX contracts:
 | WinForms `AxHost` lifecycle | Windowed OLE activation, focus, sizing, the inherited `IMsRdpClient` through `IMsRdpClient10` raw interfaces, and the RDM virtual channels `RDMJump`, `RDMLog`, and `RDMCmd` are supported. |
 | Connection configuration | Server, account, desktop, color, smart-sizing, keyboard, display update, gateway, audio, clipboard, CredSSP, client-device name, and backing `ConfigBuilder` settings are mapped where IronRDP provides the same behavior. |
 | Events | Connecting, connected, login-complete, disconnect, fatal-error, fullscreen-leave, virtual-channel, resize, and writable confirm-close events are delivered on the creating apartment. Warning and auto-reconnect events remain unfired until an IronRDP worker produces their real state. |
-| Optional RDM interfaces | Non-scriptable device, drive, camera, clipboard, monitor, and preferred-redirection interfaces expose only available backend capabilities. Empty collections and disabled capabilities never advertise RDPDR, RemoteApp, camera, or multimonitor support. |
+| Optional RDM interfaces | `IMsRdpDriveCollection` exposes Windows logical volumes for static filesystem redirection. Non-filesystem device, camera, monitor, and preferred-redirection capabilities remain unavailable. |
 
-The audit also identified RDM settings that have no IronRDP ActiveX backend: input throttling,
-automatic reconnect, authentication policy, device/printer/port/smart-card
-redirection, RemoteApp, audio capture, video policy, PCB, load balancing, and Microsoft workspace
-extensions. Their audited AdvancedSettings vtable slots use their exact published ABI signatures,
-initialize out parameters, and return `E_NOTIMPL`; the control does not report success for settings
-that cannot affect the connection.
+The audit also identified RDM settings with no IronRDP ActiveX backend: input throttling, automatic reconnect, authentication policy, printer/port/smart-card and non-filesystem device redirection, RemoteApp, audio capture, video policy, PCB, load balancing, and Microsoft workspace extensions.
+Their audited AdvancedSettings vtable slots use their exact published ABI signatures, initialize out parameters, and return `E_NOTIMPL`.
+The control does not report success for settings that cannot affect the connection.
 
 The control exposes a standard `IConnectionPointContainer` and an event connection point for the
 published `IMsTscAxEvents` IID `{336D5562-EFA8-482E-8CB3-C5C0FC7A7DB6}`. Lifecycle events are delivered
@@ -358,9 +355,7 @@ credential, certificate, or remote-error details. A genuine terminal connection 
 existing `OnFatalError` and `OnDisconnected` events first, then shows a bounded generic failure
 dialog with no remote error text.
 
-RDPDR-style redirection warning UI remains unsupported: `ShowRedirectionWarningDialog`,
-printer/device/drive redirection warnings, and DirectX redirection continue to return `E_NOTIMPL`
-because this ActiveX backend does not advertise the corresponding protocol capabilities.
+RDPDR-style redirection warning UI remains unsupported: `ShowRedirectionWarningDialog`, printer/device/drive redirection warnings, and DirectX redirection continue to return `E_NOTIMPL`.
 
 Every independently returned COM child object, including settings objects, empty capability
 collections, clipboard capabilities, connection points, and OLE or connection enumerators, keeps
@@ -486,9 +481,14 @@ logged-on-user, and system-default gateway-policy modes return `E_NOTIMPL` rathe
 changing authentication or routing behavior. Every remaining setting is an explicit
 `TODO(activex)` stub and returns `E_NOTIMPL`; it must not be treated as enabled.
 `EnableMouse` now gates renderer mouse movement, buttons, and wheel forwarding while retaining
-keyboard forwarding. `DisableRdpdr` reports disabled because this ActiveX host has no safe RDPDR
-device backend; attempting to enable RDPDR returns `E_NOTIMPL` instead of claiming unsupported
-drive, printer, port, smart-card, or PnP device redirection.
+keyboard forwarding.
+`IMsRdpDriveCollection` exposes Windows logical volumes with initially unselected `IMsRdpDrive::RedirectionState` values.
+`RescanDrives` preserves known selections and applies its Boolean argument only to newly discovered volumes.
+`RedirectDrives` selects or clears the current catalog before connecting.
+`DisableRdpdr` is a hard preconnect override, so it suppresses RDPDR even when drives are selected.
+The worker receives only a snapshot of selected drive names and roots through a `WindowsRdpdrBackendFactory`.
+Drive selection, catalog refresh, and `DisableRdpdr` are sealed after connection setup.
+`RedirectDynamicDrives` remains unsupported, so the collection does not modify an active session.
 `IMsRdpPreferredRedirectionInfo::UseRedirectionServerName` likewise reports disabled and rejects
 enabling it because IronRDP does not currently consume load-balancing redirection names. Remote
 actions also return `E_NOTIMPL` until an IronRDP session-operation mapping exists.
@@ -704,5 +704,5 @@ sink for the event interface IID before retaining its `IDispatch`.
 
 This is an Automation, lifecycle, hosting, framebuffer, basic input, persistence, static
 virtual-channel, and Unicode-text OLE clipboard-snapshot foundation.
-It does not yet implement RemoteApp, non-text or writable OLE clipboard exchange, monikers, RDPDR device redirection, or arbitrary persisted designer state.
+It does not yet implement RemoteApp, non-text or writable OLE clipboard exchange, monikers, non-filesystem RDPDR device redirection, or arbitrary persisted designer state.
 Those contracts must be added as exact ABI implementations before advertising their individual methods as supported.

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -6,7 +6,7 @@ use core::slice;
 use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::collections::{BTreeMap, BTreeSet};
 use std::panic::{AssertUnwindSafe, catch_unwind};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::{Arc, Mutex, mpsc as std_mpsc};
 use std::time::Duration;
@@ -45,6 +45,7 @@ use windows::Win32::Security::Credentials::{
     CREDUI_FLAGS_ALWAYS_SHOW_UI, CREDUI_FLAGS_DO_NOT_PERSIST, CREDUI_FLAGS_GENERIC_CREDENTIALS, CREDUI_INFOW,
     CredUIPromptForCredentialsW,
 };
+use windows::Win32::Storage::FileSystem::GetLogicalDrives;
 use windows::Win32::System::Com::{
     CONNECTDATA, CoTaskMemAlloc, DATADIR_GET, DATADIR_SET, DISPATCH_FLAGS, DISPATCH_METHOD, DISPATCH_PROPERTYGET,
     DISPATCH_PROPERTYPUT, DISPPARAMS, DVASPECT, DVASPECT_CONTENT, DVTARGETDEVICE, EXCEPINFO, FORMATETC, IAdviseSink,
@@ -115,9 +116,10 @@ use crate::mstsc::{
     IMsRdpClientNonScriptable5_Impl, IMsRdpClientNonScriptable6, IMsRdpClientNonScriptable6_Impl,
     IMsRdpClientNonScriptable7, IMsRdpClientNonScriptable7_Impl, IMsRdpClientNonScriptable8,
     IMsRdpClientNonScriptable8_Impl, IMsRdpClipboard, IMsRdpClipboard_Impl, IMsRdpDeviceCollection,
-    IMsRdpDeviceCollection_Impl, IMsRdpDriveCollection, IMsRdpDriveCollection_Impl, IMsRdpExtendedSettings,
-    IMsRdpExtendedSettings_Impl, IMsRdpPreferredRedirectionInfo, IMsRdpPreferredRedirectionInfo_Impl, IMsTscAx_Impl,
-    IMsTscAx_Redist_Impl, IMsTscNonScriptable, IMsTscNonScriptable_Impl, InterfaceOut,
+    IMsRdpDeviceCollection_Impl, IMsRdpDrive, IMsRdpDrive_Impl, IMsRdpDriveCollection, IMsRdpDriveCollection_Impl,
+    IMsRdpExtendedSettings, IMsRdpExtendedSettings_Impl, IMsRdpPreferredRedirectionInfo,
+    IMsRdpPreferredRedirectionInfo_Impl, IMsTscAx_Impl, IMsTscAx_Redist_Impl, IMsTscNonScriptable,
+    IMsTscNonScriptable_Impl, InterfaceOut,
 };
 use crate::rpc::{self, ActiveXRpc, Command as RpcCommand};
 use ironrdp_rpc as ironrdp_agent;
@@ -425,7 +427,7 @@ impl Drop for TestHostTracePath {
     }
 }
 
-fn append_host_trace(path: impl AsRef<std::path::Path>, name: &str) {
+fn append_host_trace(path: impl AsRef<Path>, name: &str) {
     // Host startup may carry credentials in Automation values, so log method names only.
     if let Ok(mut file) = std::fs::OpenOptions::new().create(true).append(true).open(path) {
         let _ = std::io::Write::write_all(&mut file, format!("{name}\n").as_bytes());
@@ -925,6 +927,9 @@ struct CompatibilitySettings {
     enable_mouse: bool,
     enable_windows_key: bool,
     redirect_clipboard: bool,
+    redirect_drives: bool,
+    disable_rdpdr: bool,
+    drive_catalog: Rc<RefCell<DriveCatalog>>,
     warn_about_sending_credentials: bool,
     warn_about_clipboard_redirection: bool,
     performance_flags: PerformanceFlags,
@@ -991,6 +996,9 @@ impl Default for CompatibilitySettings {
             enable_mouse: true,
             enable_windows_key: true,
             redirect_clipboard: true,
+            redirect_drives: false,
+            disable_rdpdr: false,
+            drive_catalog: Rc::new(RefCell::new(DriveCatalog::new())),
             warn_about_sending_credentials: false,
             warn_about_clipboard_redirection: false,
             performance_flags: PerformanceFlags::default(),
@@ -1764,7 +1772,6 @@ advanced_put_not_implemented!(
     (93, advanced_put_bitmap_persistence, i32),
     (95, advanced_put_minutes_to_idle_timeout, i32),
     (112, advanced_put_load_balance_info, Bstr),
-    (114, advanced_put_redirect_drives, i16),
     (116, advanced_put_redirect_printers, i16),
     (118, advanced_put_redirect_ports, i16),
     (120, advanced_put_redirect_smart_cards, i16),
@@ -1786,7 +1793,6 @@ advanced_get_not_implemented!(
     (92, advanced_get_connect_to_server_console, i16),
     (94, advanced_get_bitmap_persistence, i32),
     (96, advanced_get_minutes_to_idle_timeout, i32),
-    (115, advanced_get_redirect_drives, i16),
     (117, advanced_get_redirect_printers, i16),
     (119, advanced_get_redirect_ports, i16),
     (121, advanced_get_redirect_smart_cards, i16),
@@ -2288,18 +2294,53 @@ unsafe extern "system" fn advanced_get_keyboard_function_key(this: *mut c_void, 
     }
 }
 
-unsafe extern "system" fn advanced_put_disable_rdpdr(_this: *mut c_void, value: i32) -> HRESULT {
-    if value == 0 {
-        // The ActiveX connection owns no RDPDR host backend, so enabling the channel would falsely
-        // advertise drives, printers, ports, or devices that cannot be serviced.
-        E_NOTIMPL
-    } else {
-        S_OK
+unsafe extern "system" fn advanced_put_disable_rdpdr(this: *mut c_void, value: i32) -> HRESULT {
+    let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
+    let mut settings = object.settings.borrow_mut();
+    if settings.connection_settings_sealed {
+        return E_FAIL;
     }
+    settings.disable_rdpdr = value != 0;
+    mark_compatibility_persistence_dirty(&settings);
+    S_OK
 }
 
-unsafe extern "system" fn advanced_get_disable_rdpdr(_this: *mut c_void, value: *mut i32) -> HRESULT {
-    write_out(value, 1).map_or_else(|error| error.code(), |_| S_OK)
+unsafe extern "system" fn advanced_get_disable_rdpdr(this: *mut c_void, output: *mut i32) -> HRESULT {
+    let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
+    let value = i32::from(object.settings.borrow().disable_rdpdr);
+    write_out(output, value).map_or_else(|error| error.code(), |_| S_OK)
+}
+
+unsafe extern "system" fn advanced_put_redirect_drives(this: *mut c_void, value: i16) -> HRESULT {
+    let value = match normalize_variant_bool(value) {
+        Ok(value) => value == VARIANT_TRUE.0,
+        Err(error) => return error.code(),
+    };
+    let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
+    let catalog = {
+        let mut settings = object.settings.borrow_mut();
+        if settings.connection_settings_sealed {
+            return E_FAIL;
+        }
+        settings.redirect_drives = value;
+        mark_compatibility_persistence_dirty(&settings);
+        Rc::clone(&settings.drive_catalog)
+    };
+    catalog.borrow().set_redirection_state(value);
+    S_OK
+}
+
+unsafe extern "system" fn advanced_get_redirect_drives(this: *mut c_void, value: *mut i16) -> HRESULT {
+    let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
+    write_out(
+        value,
+        if object.settings.borrow().redirect_drives {
+            VARIANT_TRUE.0
+        } else {
+            VARIANT_FALSE.0
+        },
+    )
+    .map_or_else(|error| error.code(), |_| S_OK)
 }
 
 unsafe extern "system" fn advanced_put_enable_mouse(this: *mut c_void, value: i32) -> HRESULT {
@@ -3840,32 +3881,219 @@ impl IMsRdpDeviceCollection_Impl for EmptyDeviceCollection_Impl {
     }
 }
 
-#[implement(IMsRdpDriveCollection)]
-struct EmptyDriveCollection {
-    _lifetime: ServerObjectLifetime,
+struct DriveCatalogEntry {
+    device_id: u32,
+    name: String,
+    root_path: PathBuf,
+    redirection_state: Cell<bool>,
 }
 
-impl EmptyDriveCollection {
+struct DriveCatalog {
+    entries: Vec<Rc<DriveCatalogEntry>>,
+    known_entries: BTreeMap<PathBuf, Rc<DriveCatalogEntry>>,
+    next_device_id: u32,
+}
+
+impl DriveCatalog {
     fn new() -> Self {
+        Self::from_roots(logical_volume_roots(), false)
+    }
+
+    fn from_roots(roots: Vec<PathBuf>, redirect_new_drives: bool) -> Self {
+        let mut catalog = Self {
+            entries: Vec::new(),
+            known_entries: BTreeMap::new(),
+            next_device_id: 1,
+        };
+        catalog.rescan_from_roots(roots, redirect_new_drives);
+        catalog
+    }
+
+    fn rescan(&mut self, redirect_new_drives: bool) {
+        self.rescan_from_roots(logical_volume_roots(), redirect_new_drives);
+    }
+
+    fn rescan_from_roots(&mut self, roots: Vec<PathBuf>, redirect_new_drives: bool) {
+        self.entries = roots
+            .into_iter()
+            .map(|root_path| {
+                Rc::clone(self.known_entries.entry(root_path.clone()).or_insert_with(|| {
+                    let device_id = self.next_device_id;
+                    self.next_device_id = self
+                        .next_device_id
+                        .checked_add(1)
+                        .expect("logical-volume RDPDR device IDs must not exhaust u32");
+                    Rc::new(DriveCatalogEntry {
+                        device_id,
+                        name: logical_volume_name(&root_path),
+                        root_path,
+                        redirection_state: Cell::new(redirect_new_drives),
+                    })
+                }))
+            })
+            .collect();
+    }
+
+    fn set_redirection_state(&self, value: bool) {
+        for entry in &self.entries {
+            entry.redirection_state.set(value);
+        }
+    }
+
+    fn selected_drives(&self) -> Result<Vec<ironrdp_rdpdr_native::RedirectedDrive>> {
+        self.entries
+            .iter()
+            .filter(|entry| entry.redirection_state.get())
+            .map(|entry| {
+                ironrdp_rdpdr_native::RedirectedDrive::new(
+                    entry.device_id,
+                    entry.name.clone(),
+                    entry.root_path.clone(),
+                    false,
+                )
+                .map_err(|error| Error::new(E_FAIL, format!("invalid redirected drive: {error}")))
+            })
+            .collect()
+    }
+
+    #[cfg(test)]
+    fn selected_drive_names(&self) -> Vec<String> {
+        self.entries
+            .iter()
+            .filter(|entry| entry.redirection_state.get())
+            .map(|entry| entry.name.clone())
+            .collect()
+    }
+}
+
+fn logical_volume_roots() -> Vec<PathBuf> {
+    let mask = unsafe { GetLogicalDrives() };
+    if mask == 0 {
+        tracing::warn!("Unable to enumerate logical drives for ActiveX RDPDR redirection");
+    }
+
+    (0..26)
+        .filter(|index| mask & (1u32 << index) != 0)
+        .map(|index| PathBuf::from(format!("{}:\\", char::from(b'A' + index))))
+        .collect()
+}
+
+fn logical_volume_name(root_path: &Path) -> String {
+    root_path.to_string_lossy().trim_end_matches(['\\', '/']).to_owned()
+}
+
+#[implement(IMsRdpDrive)]
+struct Drive {
+    _lifetime: ServerObjectLifetime,
+    catalog: Rc<RefCell<DriveCatalog>>,
+    entry: Rc<DriveCatalogEntry>,
+    settings: Rc<RefCell<CompatibilitySettings>>,
+}
+
+impl Drive {
+    fn new(
+        catalog: Rc<RefCell<DriveCatalog>>,
+        entry: Rc<DriveCatalogEntry>,
+        settings: Rc<RefCell<CompatibilitySettings>>,
+    ) -> Self {
         Self {
             _lifetime: ServerObjectLifetime::new(),
+            catalog,
+            entry,
+            settings,
         }
     }
 }
 
-impl IMsRdpDriveCollection_Impl for EmptyDriveCollection_Impl {
-    unsafe fn RescanDrives(&self, _dynamic_redirection: i16) -> Result<()> {
-        // TODO(activex): enumerate drives after IronRDP RDPDR exposes a host-drive backend.
+impl IMsRdpDrive_Impl for Drive_Impl {
+    unsafe fn get_Name(&self, name: BstrOut) -> Result<()> {
+        // mstscax returns a volume-root name with an embedded terminal NUL in the BSTR payload.
+        write_bstr(name, &format!("{}\\\0", self.entry.name))
+    }
+
+    unsafe fn put_RedirectionState(&self, state: i16) -> Result<()> {
+        let state = normalize_variant_bool(state)? == VARIANT_TRUE.0;
+        if !self
+            .catalog
+            .borrow()
+            .entries
+            .iter()
+            .any(|entry| Rc::ptr_eq(entry, &self.entry))
+        {
+            return Err(Error::from_hresult(E_FAIL));
+        }
+
+        let settings = self.settings.borrow();
+        if settings.connection_settings_sealed {
+            return Err(Error::from_hresult(E_FAIL));
+        }
+        self.entry.redirection_state.set(state);
+        mark_compatibility_persistence_dirty(&settings);
         Ok(())
     }
 
-    unsafe fn get_DriveByIndex(&self, _index: u32, drive: InterfaceOut) -> Result<()> {
-        write_out(drive, ptr::null_mut())?;
-        Err(Error::from_hresult(E_INVALIDARG))
+    unsafe fn get_RedirectionState(&self, state: *mut i16) -> Result<()> {
+        write_out(
+            state,
+            if self.entry.redirection_state.get() {
+                VARIANT_TRUE.0
+            } else {
+                VARIANT_FALSE.0
+            },
+        )
+    }
+}
+
+#[implement(IMsRdpDriveCollection)]
+struct DriveCollection {
+    _lifetime: ServerObjectLifetime,
+    catalog: Rc<RefCell<DriveCatalog>>,
+    settings: Rc<RefCell<CompatibilitySettings>>,
+}
+
+impl DriveCollection {
+    fn new(catalog: Rc<RefCell<DriveCatalog>>, settings: Rc<RefCell<CompatibilitySettings>>) -> Self {
+        Self {
+            _lifetime: ServerObjectLifetime::new(),
+            catalog,
+            settings,
+        }
+    }
+}
+
+impl IMsRdpDriveCollection_Impl for DriveCollection_Impl {
+    unsafe fn RescanDrives(&self, redirect_new_drives: i16) -> Result<()> {
+        let redirect_new_drives = normalize_variant_bool(redirect_new_drives)? == VARIANT_TRUE.0;
+        if self.settings.borrow().connection_settings_sealed {
+            return Err(Error::from_hresult(E_FAIL));
+        }
+        self.catalog.borrow_mut().rescan(redirect_new_drives);
+        mark_compatibility_persistence_dirty(&self.settings.borrow());
+        Ok(())
+    }
+
+    unsafe fn get_DriveByIndex(&self, index: u32, output: InterfaceOut) -> Result<()> {
+        if output.is_null() {
+            return Err(Error::from_hresult(E_POINTER));
+        }
+        let entry = self
+            .catalog
+            .borrow()
+            .entries
+            .get(usize::try_from(index).map_err(|_| Error::from_hresult(E_INVALIDARG))?)
+            .cloned()
+            // mstscax returns E_UNEXPECTED and does not overwrite the output pointer for an
+            // out-of-range index.
+            .ok_or_else(|| Error::from_hresult(E_UNEXPECTED))?;
+        let drive: IMsRdpDrive = Drive::new(Rc::clone(&self.catalog), entry, Rc::clone(&self.settings)).into();
+        write_out(output, drive.into_raw().cast())
     }
 
     unsafe fn get_DriveCount(&self, count: *mut u32) -> Result<()> {
-        write_out(count, 0)
+        write_out(
+            count,
+            u32::try_from(self.catalog.borrow().entries.len()).map_err(|_| Error::from_hresult(E_FAIL))?,
+        )
     }
 }
 
@@ -4324,6 +4552,7 @@ pub(crate) struct Control {
     class_id: GUID,
     settings: RefCell<Settings>,
     compatibility: Rc<RefCell<CompatibilitySettings>>,
+    drive_collection: IMsRdpDriveCollection,
     state: Cell<ConnectionState>,
     last_disconnect: Cell<DisconnectInfo>,
     clipboard_state: Rc<ClipboardState>,
@@ -4428,10 +4657,14 @@ impl Control {
         let persistence_dirty = Rc::new(Cell::new(false));
         let compatibility = Rc::new(RefCell::new(CompatibilitySettings::default()));
         compatibility.borrow_mut().persistence_dirty = Some(Rc::clone(&persistence_dirty));
+        let drive_catalog = Rc::clone(&compatibility.borrow().drive_catalog);
+        let drive_collection: IMsRdpDriveCollection =
+            DriveCollection::new(drive_catalog, Rc::clone(&compatibility)).into();
         Self {
             class_id,
             settings: RefCell::new(Settings::default()),
             compatibility,
+            drive_collection,
             state: Cell::new(ConnectionState::Disconnected),
             last_disconnect: Cell::new(DisconnectInfo::no_info()),
             clipboard_state: Rc::new(ClipboardState {
@@ -6800,6 +7033,16 @@ impl Control {
         let clipboard = compatibility.redirect_clipboard;
         let warn_about_credentials = compatibility.warn_about_sending_credentials;
         let warn_about_clipboard = clipboard && compatibility.warn_about_clipboard_redirection;
+        let redirected_drives = if compatibility.disable_rdpdr {
+            Vec::new()
+        } else {
+            compatibility.drive_catalog.borrow().selected_drives()?
+        };
+        let rdpdr_factory = (!redirected_drives.is_empty())
+            .then(|| ironrdp_rdpdr_native::WindowsRdpdrBackendFactory::from_drives(redirected_drives))
+            .transpose()
+            .map_err(|error| Error::new(E_FAIL, format!("invalid redirected-drive configuration: {error}")))?;
+        let rdpdr_enabled = rdpdr_factory.is_some();
         let audio_redirection_mode = audio_mode_from_raw(compatibility.audio_redirection_mode)?;
         let keyboard_type = compatibility.keyboard_type;
         let keyboard_subtype = compatibility.keyboard_subtype;
@@ -6956,7 +7199,8 @@ impl Control {
                 ClipboardType::Enable
             } else {
                 ClipboardType::Disable
-            });
+            })
+            .with_rdpdr(rdpdr_enabled);
         let builder = if let Some(kerberos_config) = self.rpc_kerberos_config.borrow_mut().take() {
             builder.with_kerberos_config(kerberos_config)
         } else {
@@ -7054,6 +7298,11 @@ impl Control {
             client.with_cliprdr_backend_factory(factory)
         } else {
             self.stop_clipboard_redirection();
+            client
+        };
+        let client = if let Some(factory) = rdpdr_factory {
+            client.with_rdpdr_backend_factory(Box::new(factory))
+        } else {
             client
         };
         self.compatibility.borrow_mut().connection_settings_sealed = true;
@@ -9065,8 +9314,7 @@ impl IMsRdpClientNonScriptable3_Impl for Control_Impl {
         if output.is_null() {
             return Err(Error::from_hresult(E_POINTER));
         }
-        let collection: IMsRdpDriveCollection = EmptyDriveCollection::new().into();
-        write_out(output, collection.into_raw().cast())
+        write_out(output, self.drive_collection.clone().into_raw().cast())
     }
 
     unsafe fn put_WarnAboutSendingCredentials(&self, value: i16) -> Result<()> {
@@ -13137,9 +13385,19 @@ mod tests {
 
         let mut disable_rdpdr = 0;
         assert_eq!(unsafe { advanced_get_disable_rdpdr(this, &mut disable_rdpdr) }, S_OK);
-        assert_eq!(disable_rdpdr, 1);
-        assert_eq!(unsafe { advanced_put_disable_rdpdr(this, 0) }, E_NOTIMPL);
+        assert_eq!(disable_rdpdr, 0);
         assert_eq!(unsafe { advanced_put_disable_rdpdr(this, 1) }, S_OK);
+        assert_eq!(unsafe { advanced_get_disable_rdpdr(this, &mut disable_rdpdr) }, S_OK);
+        assert_eq!(disable_rdpdr, 1);
+        assert_eq!(unsafe { advanced_put_disable_rdpdr(this, 0) }, S_OK);
+
+        assert_eq!(unsafe { advanced_put_redirect_drives(this, VARIANT_TRUE.0) }, S_OK);
+        let mut redirect_drives = VARIANT_FALSE.0;
+        assert_eq!(
+            unsafe { advanced_get_redirect_drives(this, &mut redirect_drives) },
+            S_OK
+        );
+        assert_eq!(redirect_drives, VARIANT_TRUE.0);
 
         assert_eq!(unsafe { advanced_put_enable_mouse(this, 0) }, S_OK);
         let mut enable_mouse = -1;
@@ -13782,7 +14040,9 @@ mod tests {
     #[test]
     fn independently_returned_com_children_keep_the_server_loaded() {
         let _devices: IMsRdpDeviceCollection = EmptyDeviceCollection::new().into();
-        let _drives: IMsRdpDriveCollection = EmptyDriveCollection::new().into();
+        let settings = Rc::new(RefCell::new(CompatibilitySettings::default()));
+        let _drives: IMsRdpDriveCollection =
+            DriveCollection::new(Rc::clone(&settings.borrow().drive_catalog), Rc::clone(&settings)).into();
         let _cameras: IMsRdpCameraRedirConfigCollection = EmptyCameraRedirConfigCollection::new().into();
         let _clipboard: IMsRdpClipboard = ClipboardCapabilities::new(Rc::new(ClipboardState {
             enabled_for_session: Cell::new(false),
@@ -16543,5 +16803,103 @@ mod tests {
             seen.lock().expect("event sink state").as_ref(),
             Some(&("alpha".to_owned(), "\0\u{ff}".to_owned()))
         );
+    }
+
+    #[test]
+    fn drive_catalog_preserves_selection_and_defaults_only_new_volumes() {
+        let mut catalog = DriveCatalog::from_roots(vec![PathBuf::from(r"C:\"), PathBuf::from(r"D:\")], false);
+        catalog.entries[0].redirection_state.set(true);
+
+        catalog.rescan_from_roots(
+            vec![PathBuf::from(r"C:\"), PathBuf::from(r"D:\"), PathBuf::from(r"E:\")],
+            true,
+        );
+
+        assert_eq!(catalog.selected_drive_names(), vec!["C:".to_owned(), "E:".to_owned()]);
+        assert!(!catalog.entries[1].redirection_state.get());
+
+        catalog.rescan_from_roots(vec![PathBuf::from(r"D:\"), PathBuf::from(r"E:\")], false);
+        catalog.rescan_from_roots(
+            vec![PathBuf::from(r"C:\"), PathBuf::from(r"D:\"), PathBuf::from(r"E:\")],
+            false,
+        );
+        assert_eq!(catalog.selected_drive_names(), vec!["C:".to_owned(), "E:".to_owned()]);
+    }
+
+    #[test]
+    fn drive_collection_exposes_selected_volume_snapshots() {
+        let catalog = Rc::new(RefCell::new(DriveCatalog::from_roots(
+            vec![PathBuf::from(r"C:\"), PathBuf::from(r"D:\")],
+            false,
+        )));
+        let persistence_dirty = Rc::new(Cell::new(false));
+        let settings = Rc::new(RefCell::new(CompatibilitySettings {
+            drive_catalog: Rc::clone(&catalog),
+            persistence_dirty: Some(Rc::clone(&persistence_dirty)),
+            ..Default::default()
+        }));
+        let collection: IMsRdpDriveCollection = DriveCollection::new(Rc::clone(&catalog), Rc::clone(&settings)).into();
+
+        let mut count = 0;
+        unsafe { collection.get_DriveCount(&mut count) }.expect("get drive count");
+        assert_eq!(count, 2);
+
+        let mut drive = ptr::null_mut();
+        unsafe { collection.get_DriveByIndex(0, &mut drive) }.expect("get first drive");
+        let drive = unsafe { IMsRdpDrive::from_raw(drive) };
+
+        let mut name = ptr::null();
+        unsafe { drive.get_Name(&mut name) }.expect("get drive name");
+        let name = unsafe { BSTR::from_raw(name) };
+        assert_eq!(String::try_from(&name).expect("valid drive name"), "C:\\\0");
+
+        let mut state = VARIANT_TRUE.0;
+        unsafe { drive.get_RedirectionState(&mut state) }.expect("get initial redirection state");
+        assert_eq!(state, VARIANT_FALSE.0);
+        unsafe { drive.put_RedirectionState(VARIANT_TRUE.0) }.expect("select first drive");
+        assert_eq!(catalog.borrow().selected_drive_names(), vec!["C:".to_owned()]);
+
+        let snapshot = catalog.borrow().selected_drives().expect("snapshot selected drive");
+        let factory =
+            ironrdp_rdpdr_native::WindowsRdpdrBackendFactory::from_drives(snapshot).expect("create drive factory");
+        assert_eq!(factory.initial_drives(), vec![(1, "C:".to_owned())]);
+
+        settings.borrow_mut().connection_settings_sealed = true;
+        assert_eq!(
+            unsafe { drive.put_RedirectionState(VARIANT_FALSE.0) }
+                .expect_err("connection snapshots seal drive selection")
+                .code(),
+            E_FAIL
+        );
+
+        let mut missing: *mut c_void = ptr::dangling_mut();
+        assert_eq!(
+            unsafe { collection.get_DriveByIndex(2, &mut missing) }
+                .expect_err("out-of-range drive index is rejected")
+                .code(),
+            E_UNEXPECTED
+        );
+        assert_eq!(missing, ptr::dangling_mut());
+
+        settings.borrow_mut().connection_settings_sealed = false;
+        persistence_dirty.set(false);
+        unsafe { collection.RescanDrives(VARIANT_TRUE.0) }.expect("rescan drives");
+        assert!(persistence_dirty.get());
+    }
+
+    #[test]
+    fn control_retains_its_drive_collection() {
+        let control: IMsRdpClient10 = Control::new().into();
+        let non_scriptable = control
+            .cast::<IMsRdpClientNonScriptable3>()
+            .expect("control supports the drive collection contract");
+
+        let mut first = ptr::null_mut();
+        let mut second = ptr::null_mut();
+        unsafe { non_scriptable.get_DriveCollection(&mut first) }.expect("get first drive collection");
+        unsafe { non_scriptable.get_DriveCollection(&mut second) }.expect("get second drive collection");
+        assert_eq!(first, second);
+        drop(unsafe { IMsRdpDriveCollection::from_raw(first) });
+        drop(unsafe { IMsRdpDriveCollection::from_raw(second) });
     }
 }

--- a/crates/ironrdp-activex/src/mstsc.rs
+++ b/crates/ironrdp-activex/src/mstsc.rs
@@ -28,9 +28,16 @@ pub(crate) unsafe trait IMsRdpDeviceCollection: IUnknown {
 
 #[interface("7FF17599-DA2C-4677-AD35-F60C04FE1585")]
 pub(crate) unsafe trait IMsRdpDriveCollection: IUnknown {
-    fn RescanDrives(&self, dynamic_redirection: i16) -> Result<()>;
-    fn get_DriveByIndex(&self, index: u32, drive: InterfaceOut) -> Result<()>;
-    fn get_DriveCount(&self, count: *mut u32) -> Result<()>;
+    pub(crate) fn RescanDrives(&self, dynamic_redirection: i16) -> Result<()>;
+    pub(crate) fn get_DriveByIndex(&self, index: u32, drive: InterfaceOut) -> Result<()>;
+    pub(crate) fn get_DriveCount(&self, count: *mut u32) -> Result<()>;
+}
+
+#[interface("D28B5458-F694-47A8-8E61-40356A767E46")]
+pub(crate) unsafe trait IMsRdpDrive: IUnknown {
+    pub(crate) fn get_Name(&self, name: BstrOut) -> Result<()>;
+    pub(crate) fn put_RedirectionState(&self, state: i16) -> Result<()>;
+    pub(crate) fn get_RedirectionState(&self, state: *mut i16) -> Result<()>;
 }
 
 #[interface("AE45252B-AAAB-4504-B681-649D6073A37A")]
@@ -104,7 +111,7 @@ pub(crate) unsafe trait IMsRdpClientNonScriptable3: IMsRdpClientNonScriptable2 {
     fn put_RedirectDynamicDevices(&self, value: i16) -> Result<()>;
     fn get_RedirectDynamicDevices(&self, value: *mut i16) -> Result<()>;
     fn get_DeviceCollection(&self, collection: InterfaceOut) -> Result<()>;
-    fn get_DriveCollection(&self, collection: InterfaceOut) -> Result<()>;
+    pub(crate) fn get_DriveCollection(&self, collection: InterfaceOut) -> Result<()>;
     fn put_WarnAboutSendingCredentials(&self, value: i16) -> Result<()>;
     fn get_WarnAboutSendingCredentials(&self, value: *mut i16) -> Result<()>;
     fn put_WarnAboutClipboardRedirection(&self, value: i16) -> Result<()>;

--- a/crates/ironrdp-rdpdr-native/src/windows/backend.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/backend.rs
@@ -31,16 +31,21 @@ const DEFAULT_MAX_OPEN_FILES: usize = 1_024;
 /// `STATUS_NOT_SUPPORTED` response rather than leaving an IRP unanswered.
 #[derive(Debug)]
 pub struct WindowsRdpdrBackend {
-    drive: RedirectedDrive,
+    drives: HashMap<u32, RedirectedDrive>,
     pub(super) roots: HashMap<u32, RedirectedRoot>,
     pub(super) open_files: FileTable<OpenFile>,
     deferred_operations: DeferredOperations,
 }
 
 impl WindowsRdpdrBackend {
+    #[cfg(test)]
     pub(crate) fn from_drive(drive: RedirectedDrive) -> Self {
+        Self::from_drives(vec![drive])
+    }
+
+    pub(crate) fn from_drives(drives: Vec<RedirectedDrive>) -> Self {
         Self {
-            drive,
+            drives: drives.into_iter().map(|drive| (drive.device_id(), drive)).collect(),
             roots: HashMap::new(),
             open_files: FileTable::new(DEFAULT_MAX_OPEN_FILES),
             deferred_operations: DeferredOperations::new(),
@@ -58,20 +63,21 @@ impl WindowsRdpdrBackend {
     }
 
     fn activate_drive(&mut self, device_id: u32) -> PduResult<()> {
-        if device_id != self.drive.device_id() {
-            return Err(pdu_other_err!("windows RDPDR drive is not configured"));
-        }
+        let drive = self
+            .drives
+            .get(&device_id)
+            .ok_or_else(|| pdu_other_err!("windows RDPDR drive is not configured"))?;
         if self.roots.contains_key(&device_id) {
             return Err(pdu_other_err!("windows RDPDR drive is already active"));
         }
 
-        let root = RootDirectory::open(self.drive.root_path())
+        let root = RootDirectory::open(drive.root_path())
             .map_err(|error| pdu_other_err!("open configured Windows RDPDR volume root").with_source(error))?;
         let previous = self.roots.insert(
             device_id,
             RedirectedRoot {
                 root,
-                read_only: self.drive.read_only(),
+                read_only: drive.read_only(),
             },
         );
         debug_assert!(
@@ -82,8 +88,8 @@ impl WindowsRdpdrBackend {
     }
 
     fn deactivate_drive(&mut self, device_id: u32) -> PduResult<Vec<SvcMessage>> {
-        if device_id != self.drive.device_id() || !self.roots.contains_key(&device_id) {
-            return Err(pdu_other_err!("windows RDPDR drive is not active"));
+        if !self.drives.contains_key(&device_id) || !self.roots.contains_key(&device_id) {
+            return Err(pdu_other_err!("windows RDPDR drive is not configured"));
         }
 
         let cancelled = self.deferred_operations.cancel_drive(device_id);
@@ -222,4 +228,25 @@ pub(super) struct OpenFile {
     /// MS-RDPEFS requires continuation queries to ignore their `Path` field, so
     /// this owns the native cursor selected by the preceding initial query.
     pub(super) directory_query_handle: Option<FileHandle>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backend_restores_each_selected_drive() {
+        let system_drive = std::env::var("SystemDrive").expect("SystemDrive is set on Windows");
+        let root = format!(r"{system_drive}\");
+        let mut backend = WindowsRdpdrBackend::from_drives(vec![
+            RedirectedDrive::new(1, "System", &root, false).expect("valid system drive"),
+            RedirectedDrive::new(2, "System copy", root, false).expect("valid system drive copy"),
+        ]);
+
+        ironrdp_rdpdr::RdpdrBackend::restore_drive(&mut backend, 1).expect("restore first selected drive");
+        ironrdp_rdpdr::RdpdrBackend::restore_drive(&mut backend, 2).expect("restore second selected drive");
+
+        assert!(backend.roots.contains_key(&1));
+        assert!(backend.roots.contains_key(&2));
+    }
 }

--- a/crates/ironrdp-rdpdr-native/src/windows/factory.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/factory.rs
@@ -1,6 +1,7 @@
 //! Windows RDPDR backend configuration.
 
 use core::fmt;
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use super::backend::WindowsRdpdrBackend;
@@ -94,20 +95,35 @@ impl core::error::Error for RedirectedDriveError {}
 /// the portable RDPDR crate.
 #[derive(Clone, Debug)]
 pub struct WindowsRdpdrBackendFactory {
-    drive: RedirectedDrive,
+    drives: Vec<RedirectedDrive>,
 }
 
 impl WindowsRdpdrBackendFactory {
     /// Configures the single logical-volume root supported by this baseline.
     #[must_use]
     pub fn new(drive: RedirectedDrive) -> Self {
-        Self { drive }
+        Self { drives: vec![drive] }
+    }
+
+    /// Configures the logical-volume roots selected for one connection.
+    pub fn from_drives(drives: Vec<RedirectedDrive>) -> Result<Self, RedirectedDriveFactoryError> {
+        let mut device_ids = HashSet::with_capacity(drives.len());
+        for drive in &drives {
+            if !device_ids.insert(drive.device_id()) {
+                return Err(RedirectedDriveFactoryError::DuplicateDeviceId(drive.device_id()));
+            }
+        }
+
+        Ok(Self { drives })
     }
 
     /// Returns the initial `(device_id, name)` pair for `Rdpdr::with_drives`.
     #[must_use]
     pub fn initial_drives(&self) -> Vec<(u32, String)> {
-        vec![(self.drive.device_id, self.drive.display_name.clone())]
+        self.drives
+            .iter()
+            .map(|drive| (drive.device_id, drive.display_name.clone()))
+            .collect()
     }
 
     /// Builds a backend with no active root handles.
@@ -117,7 +133,7 @@ impl WindowsRdpdrBackendFactory {
     /// sequence.
     #[must_use]
     pub fn build(&self) -> WindowsRdpdrBackend {
-        WindowsRdpdrBackend::from_drive(self.drive.clone())
+        WindowsRdpdrBackend::from_drives(self.drives.clone())
     }
 }
 
@@ -132,6 +148,23 @@ impl RdpdrBackendFactory for WindowsRdpdrBackendFactory {
         ))
     }
 }
+
+/// Invalid selected-drive factory configuration.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RedirectedDriveFactoryError {
+    /// More than one selected drive used the same RDPDR device ID.
+    DuplicateDeviceId(u32),
+}
+
+impl fmt::Display for RedirectedDriveFactoryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DuplicateDeviceId(device_id) => write!(f, "duplicate RDPDR device ID {device_id}"),
+        }
+    }
+}
+
+impl core::error::Error for RedirectedDriveFactoryError {}
 
 #[cfg(test)]
 mod tests {
@@ -161,5 +194,29 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![(1, "System")]
         );
+    }
+
+    #[test]
+    fn factory_preserves_multiple_selected_drives() {
+        let factory = WindowsRdpdrBackendFactory::from_drives(vec![
+            RedirectedDrive::new(1, "System", r"C:\", false).expect("valid system drive"),
+            RedirectedDrive::new(2, "Data", r"D:\", false).expect("valid data drive"),
+        ])
+        .expect("unique device IDs");
+
+        assert_eq!(
+            factory.initial_drives(),
+            vec![(1, "System".to_owned()), (2, "Data".to_owned())]
+        );
+    }
+
+    #[test]
+    fn factory_rejects_duplicate_device_ids() {
+        let result = WindowsRdpdrBackendFactory::from_drives(vec![
+            RedirectedDrive::new(1, "System", r"C:\", false).expect("valid system drive"),
+            RedirectedDrive::new(1, "Data", r"D:\", false).expect("valid data drive"),
+        ]);
+
+        assert!(matches!(result, Err(RedirectedDriveFactoryError::DuplicateDeviceId(1))));
     }
 }


### PR DESCRIPTION
Expose Windows logical volumes through the ActiveX drive collection and configure a static RDPDR backend from the selected pre-connect snapshot.

DisableRdpdr remains a hard override.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>