### PR TITLE
feat(agent): configure static RDPDR drives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2640,6 +2640,7 @@ dependencies = [
  "ironrdp-input",
  "ironrdp-pdu",
  "ironrdp-propertyset",
+ "ironrdp-rdpdr-native",
  "ironrdp-rpc",
  "ironrdp-tls",
  "libc",

--- a/crates/ironrdp-agent/README.md
+++ b/crates/ironrdp-agent/README.md
@@ -30,7 +30,7 @@ these only when it is explicitly enabled; `RDP_AUTOLOGON` is active only when it
 
 On Windows, start the daemon with one or more `--rdpdr-drive NAME=VOLUME_ROOT` options to opt in to static filesystem redirection.
 For example, `ironrdp-agent daemon-start --rdpdr-drive System=C:\ --rdpdr-drive Data=D:\` exposes two local volumes to every session created by that daemon.
-Each root must be a unique existing local volume root, and each protocol-visible name must be unique case-insensitively and contain at most seven ASCII letters, numbers, spaces, underscores, hyphens, periods, or a trailing colon.
+Each root must be a unique existing local volume root in the exact `C:\` form, and each protocol-visible name must be unique case-insensitively and contain at most seven ASCII letters, numbers, spaces, underscores, hyphens, periods, or a trailing colon.
 The configured drives are fixed for the daemon lifetime; hot-plug and rescan are not supported.
 
 ## Windows Sandbox

--- a/crates/ironrdp-agent/README.md
+++ b/crates/ironrdp-agent/README.md
@@ -26,6 +26,13 @@ connection flags. Explicit flags override those process-local values. The native
 these only when it is explicitly enabled; `RDP_AUTOLOGON` is active only when its value is exactly
 `1`, and requires nonempty username and password values.
 
+## Windows filesystem redirection
+
+On Windows, start the daemon with one or more `--rdpdr-drive NAME=VOLUME_ROOT` options to opt in to static filesystem redirection.
+For example, `ironrdp-agent daemon-start --rdpdr-drive System=C:\ --rdpdr-drive Data=D:\` exposes two local volumes to every session created by that daemon.
+Each root must be a unique existing local volume root, and each protocol-visible name must be unique case-insensitively and contain at most seven ASCII letters, numbers, spaces, underscores, hyphens, periods, or a trailing colon.
+The configured drives are fixed for the daemon lifetime; hot-plug and rescan are not supported.
+
 ## Windows Sandbox
 
 On Windows with the Windows Sandbox feature enabled, the agent can attach to a sandbox that was

--- a/crates/ironrdp-agent/src/cli.rs
+++ b/crates/ironrdp-agent/src/cli.rs
@@ -1346,7 +1346,9 @@ mod tests {
 
     use clap::{CommandFactory as _, Parser as _};
 
-    use super::{Backend, Cli, Command, CommonExecutionArgs, NowExecutionKind, build_now_execution, endpoint_from_arg};
+    #[cfg(windows)]
+    use super::Command;
+    use super::{Backend, Cli, CommonExecutionArgs, NowExecutionKind, build_now_execution, endpoint_from_arg};
 
     #[test]
     fn backend_endpoint_selection_is_distinct_and_overridable() {

--- a/crates/ironrdp-agent/src/cli.rs
+++ b/crates/ironrdp-agent/src/cli.rs
@@ -306,6 +306,13 @@ struct DaemonArgs {
     /// property without a dedicated flag existing for it.
     #[arg(long = "prop", value_name = "KEY:TYPE:VALUE")]
     prop: Vec<PropOverride>,
+    /// Named local Windows volume exposed as an RDPDR filesystem drive.
+    ///
+    /// Repeat this flag to redirect multiple volumes. `NAME` is protocol-visible
+    /// and must be unique.
+    #[cfg(windows)]
+    #[arg(long = "rdpdr-drive", value_name = "NAME=VOLUME_ROOT", value_parser = parse_rdpdr_drive)]
+    rdpdr_drives: Vec<ironrdp_daemon::daemon::RdpdrDriveConfig>,
 }
 
 #[derive(Args, Debug)]
@@ -451,6 +458,15 @@ fn parse_scancode(input: &str) -> Result<u16, core::num::ParseIntError> {
     }
 }
 
+#[cfg(windows)]
+fn parse_rdpdr_drive(input: &str) -> Result<ironrdp_daemon::daemon::RdpdrDriveConfig, String> {
+    let (display_name, root_path) = input
+        .split_once('=')
+        .ok_or_else(|| "rdpdr drive must use NAME=VOLUME_ROOT syntax".to_owned())?;
+    ironrdp_daemon::daemon::RdpdrDriveConfig::new(PathBuf::from(root_path), display_name.to_owned())
+        .map_err(|error| error.to_string())
+}
+
 /// Entry point shared by the binary: dispatches the parsed [`Cli`].
 pub async fn run(cli: Cli) -> anyhow::Result<()> {
     if cli.help_agent {
@@ -476,7 +492,11 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
                 anyhow::bail!("daemon-start requires --backend daemon");
             }
             let overlay = load_overlay(args.overlay.as_deref(), args.prop)?;
-            return ironrdp_daemon::daemon::run(endpoint, overlay).await;
+            #[cfg(windows)]
+            let rdpdr_drives = args.rdpdr_drives;
+            #[cfg(not(windows))]
+            let rdpdr_drives = Vec::new();
+            return ironrdp_daemon::daemon::run(endpoint, overlay, rdpdr_drives).await;
         }
         Command::Now(args) => {
             let format = args.format;
@@ -1321,9 +1341,12 @@ fn property_description(key: &str) -> Option<&'static str> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(windows)]
+    use std::path::PathBuf;
+
     use clap::{CommandFactory as _, Parser as _};
 
-    use super::{Backend, Cli, CommonExecutionArgs, NowExecutionKind, build_now_execution, endpoint_from_arg};
+    use super::{Backend, Cli, Command, CommonExecutionArgs, NowExecutionKind, build_now_execution, endpoint_from_arg};
 
     #[test]
     fn backend_endpoint_selection_is_distinct_and_overridable() {
@@ -1343,6 +1366,37 @@ mod tests {
             endpoint_from_arg(Some("custom-rpc-endpoint".to_owned()), Backend::ActiveX).to_string(),
             "custom-rpc-endpoint"
         );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn daemon_rdpdr_drive_flags_parse_multiple_static_volumes() {
+        let cli = Cli::try_parse_from([
+            "ironrdp-agent",
+            "daemon-start",
+            "--rdpdr-drive",
+            r"System=C:\",
+            "--rdpdr-drive",
+            r"Data=D:\",
+        ])
+        .expect("valid multiple-drive configuration");
+
+        let Some(Command::DaemonStart(args)) = cli.command else {
+            panic!("expected daemon-start command");
+        };
+        assert_eq!(args.rdpdr_drives.len(), 2);
+        assert_eq!(args.rdpdr_drives[0].display_name(), "System");
+        assert_eq!(args.rdpdr_drives[0].root_path(), PathBuf::from(r"C:\"));
+        assert_eq!(args.rdpdr_drives[1].display_name(), "Data");
+        assert_eq!(args.rdpdr_drives[1].root_path(), PathBuf::from(r"D:\"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn daemon_rdpdr_drive_flags_reject_invalid_definitions() {
+        for drive in ["C:\\", "=C:\\", "Data=", "too-long=C:\\", "Data/C:\\"] {
+            assert!(Cli::try_parse_from(["ironrdp-agent", "daemon-start", "--rdpdr-drive", drive]).is_err());
+        }
     }
 
     #[test]

--- a/crates/ironrdp-agent/src/help.rs
+++ b/crates/ironrdp-agent/src/help.rs
@@ -28,7 +28,7 @@ Override with `--endpoint <PATH-OR-PIPE>` on any subcommand.
 
 ## Lifecycle
 
-- `daemon-start [--overlay FILE] [--prop KEY:TYPE:VALUE]...`
+- `daemon-start [--overlay FILE] [--prop KEY:TYPE:VALUE]... [--rdpdr-drive NAME=VOLUME_ROOT]...`
                                  Start the daemon (foreground). Run this first. `--overlay`
                                  preloads a .rdp file as an overlay applied to every `connect`
                                  (overlay wins), letting an operator provision any setting out of
@@ -38,6 +38,12 @@ Override with `--endpoint <PATH-OR-PIPE>` on any subcommand.
                                  file line (TYPE is `i` for integer or `s` for string), e.g.
                                  `--prop ironrdp_autologon:i:1`. Check `status` to see whether
                                  credentials are already loaded before supplying any yourself.
+                                 On Windows, repeat `--rdpdr-drive NAME=VOLUME_ROOT` to opt in to
+                                 static filesystem redirection. Each root must be a unique existing
+                                 local volume root such as `C:\`, and each one-to-seven-character
+                                 ASCII drive name must be unique (case-insensitive). The configured
+                                 set is fixed for the daemon lifetime; drive hot-plug and rescan are
+                                 not supported.
 - `connect [--rdp-file F] [--prop KEY:TYPE:VALUE]... [--server H[:PORT]] [-u USER] [-p PASS] [-d DOMAIN] [--sandbox-id ID] [--sandbox-pipe PATH] [--log-directive D]`
                                  Merge an optional .rdp file with CLI overrides into one config and
                                  open a session. Precedence (low to high): .rdp file -> `--prop`

--- a/crates/ironrdp-agent/src/help.rs
+++ b/crates/ironrdp-agent/src/help.rs
@@ -40,7 +40,7 @@ Override with `--endpoint <PATH-OR-PIPE>` on any subcommand.
                                  credentials are already loaded before supplying any yourself.
                                  On Windows, repeat `--rdpdr-drive NAME=VOLUME_ROOT` to opt in to
                                  static filesystem redirection. Each root must be a unique existing
-                                 local volume root such as `C:\`, and each one-to-seven-character
+                                 local volume root in the exact `C:\` form, and each one-to-seven-character
                                  ASCII drive name must be unique (case-insensitive). The configured
                                  set is fixed for the daemon lifetime; drive hot-plug and rescan are
                                  not supported.

--- a/crates/ironrdp-daemon/Cargo.toml
+++ b/crates/ironrdp-daemon/Cargo.toml
@@ -13,7 +13,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["rustls", "dvc-pipe-proxy"] } # public
+ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["rustls", "dvc-pipe-proxy", "rdpdr"] } # public
 ironrdp-cfg = { path = "../ironrdp-cfg", version = "0.1" }
 ironrdp-input = { path = "../ironrdp-input", version = "0.7" }
 ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9" }
@@ -34,6 +34,9 @@ now-proto-pdu = { version = "0.4", features = ["std"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+ironrdp-rdpdr-native = { path = "../ironrdp-rdpdr-native", version = "0.7" }
 
 [lints]
 workspace = true

--- a/crates/ironrdp-daemon/src/daemon.rs
+++ b/crates/ironrdp-daemon/src/daemon.rs
@@ -5,6 +5,7 @@
 //! explicitly with `daemon-start` and runs in the foreground; the caller is expected to background
 //! it. On a clean shutdown the Unix socket file is removed (see [`crate::transport`]).
 
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use anyhow::Context as _;
@@ -17,6 +18,14 @@ use ironrdp_tls::CertificateValidation;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, trace, warn};
+
+#[cfg(windows)]
+use std::collections::BTreeSet;
+#[cfg(windows)]
+use std::path::{Component, Prefix};
+
+#[cfg(windows)]
+use ironrdp_rdpdr_native::{RedirectedDrive, WindowsRdpdrBackendFactory};
 
 use crate::ipc::{
     ConnState, KeyFilter, NowDiagnostics, Payload, PropValue, PropertyDump, PropertyEntry, Request, Response,
@@ -31,10 +40,11 @@ use crate::transport::{Endpoint, Listener, read_message, write_message};
 ///
 /// `overlay` is an operator-provided [`PropertySet`] layered on top of every `Connect` request
 /// (overlay wins), so any setting — credentials in particular — can be preconfigured without the
-/// caller ever supplying it. Pass an empty set when no overlay is desired.
-pub async fn run(endpoint: Endpoint, overlay: PropertySet) -> anyhow::Result<()> {
+/// caller ever supplying it. `rdpdr_drives` is a fixed set of Windows filesystem volumes exposed
+/// through every connection that this daemon creates.
+pub async fn run(endpoint: Endpoint, overlay: PropertySet, rdpdr_drives: Vec<RdpdrDriveConfig>) -> anyhow::Result<()> {
     init_daemon_logging();
-    let daemon = Arc::new(Daemon::with_overlay(overlay));
+    let daemon = Arc::new(Daemon::with_rdpdr_drives(overlay, rdpdr_drives)?);
     serve(endpoint, daemon).await
 }
 
@@ -122,6 +132,52 @@ pub enum ResizeError {
     Closed,
 }
 
+/// Windows volume definition exposed as one static RDPDR filesystem drive.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RdpdrDriveConfig {
+    root_path: PathBuf,
+    display_name: String,
+}
+
+impl RdpdrDriveConfig {
+    /// Creates a filesystem-drive definition.
+    pub fn new(root_path: PathBuf, display_name: String) -> anyhow::Result<Self> {
+        if root_path.as_os_str().is_empty() {
+            anyhow::bail!("rdpdr volume root must not be empty");
+        }
+        if display_name.is_empty() {
+            anyhow::bail!("rdpdr drive name must not be empty");
+        }
+        if display_name.len() > 7 || !display_name.is_ascii() {
+            anyhow::bail!("rdpdr drive name must contain at most seven ASCII characters");
+        }
+        if !display_name.chars().enumerate().all(|(index, character)| {
+            character.is_ascii_alphanumeric()
+                || matches!(character, ' ' | '_' | '-' | '.')
+                || (character == ':' && index + 1 == display_name.len())
+        }) {
+            anyhow::bail!("rdpdr drive name contains an invalid DOS device-name character");
+        }
+
+        Ok(Self {
+            root_path,
+            display_name,
+        })
+    }
+
+    /// Returns the volume root selected for redirection.
+    #[must_use]
+    pub fn root_path(&self) -> &Path {
+        &self.root_path
+    }
+
+    /// Returns the protocol-visible drive name.
+    #[must_use]
+    pub fn display_name(&self) -> &str {
+        &self.display_name
+    }
+}
+
 /// The daemon's mutable state: the (single) current session, plus the shared log buffer.
 pub struct Daemon {
     state: Mutex<Option<Session>>,
@@ -135,6 +191,8 @@ pub struct Daemon {
     /// Whether [`Self::overlay`] contributes any secret (password/token) value, i.e. whether the
     /// caller can omit credentials of its own.
     credentials_loaded: bool,
+    #[cfg(windows)]
+    rdpdr_backend_factory: Option<WindowsRdpdrBackendFactory>,
     /// Notifies an optional GUI frontend whenever retained live state changes.
     notification: Option<mpsc::Sender<()>>,
     shutdown: tokio::sync::watch::Sender<()>,
@@ -171,25 +229,43 @@ pub struct Frame {
 }
 
 impl Daemon {
-    fn new(logs: Arc<LogBuffer>, overlay: PropertySet) -> Self {
+    fn new(logs: Arc<LogBuffer>, overlay: PropertySet, rdpdr_drives: Vec<RdpdrDriveConfig>) -> anyhow::Result<Self> {
         // Credentials are considered "loaded" when the overlay provides at least one secret value,
         // which is what frees the caller from supplying a password.
         let credentials_loaded = overlay.iter().any(|(key, _)| ironrdp_cfg::is_secret_key(key));
         let (shutdown, _) = tokio::sync::watch::channel(());
-        Self {
+        #[cfg(windows)]
+        let rdpdr_backend_factory = rdpdr_backend_factory(rdpdr_drives)?;
+        #[cfg(not(windows))]
+        if !rdpdr_drives.is_empty() {
+            anyhow::bail!("rdpdr filesystem redirection is only available on Windows");
+        }
+
+        Ok(Self {
             state: Mutex::new(None),
             connect_lock: Mutex::new(()),
             logs,
             overlay,
             credentials_loaded,
+            #[cfg(windows)]
+            rdpdr_backend_factory,
             notification: None,
             shutdown,
-        }
+        })
     }
 
     /// Creates a daemon with no preconfigured connection properties.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the default daemon configuration becomes invalid.
     pub fn with_overlay(overlay: PropertySet) -> Self {
-        Self::new(LogBuffer::new(), overlay)
+        Self::with_rdpdr_drives(overlay, Vec::new()).expect("default daemon configuration is valid")
+    }
+
+    /// Creates a daemon with fixed Windows filesystem drives for every connection.
+    pub fn with_rdpdr_drives(overlay: PropertySet, rdpdr_drives: Vec<RdpdrDriveConfig>) -> anyhow::Result<Self> {
+        Self::new(LogBuffer::new(), overlay, rdpdr_drives)
     }
 
     /// Adds a capacity-one notification channel for frontends that render retained live state.
@@ -353,6 +429,12 @@ impl Daemon {
             // Headless: composite the remote cursor into the framebuffer so it appears in
             // screenshots (there is no separate overlay to draw it).
             .with_pointer_software_rendering(true);
+        #[cfg(windows)]
+        let builder = if self.rdpdr_backend_factory.is_some() {
+            builder.with_rdpdr(true)
+        } else {
+            builder
+        };
 
         let missing = builder.missing();
         if !missing.is_empty() {
@@ -382,6 +464,11 @@ impl Daemon {
 
         let (output_tx, output_rx) = mpsc::channel(16);
         let client = RdpClient::new(config, output_tx);
+        #[cfg(windows)]
+        let client = match &self.rdpdr_backend_factory {
+            Some(factory) => client.with_rdpdr_backend_factory(Box::new(factory.clone())),
+            None => client,
+        };
         let input_tx = client.input_sender();
 
         let live = Arc::new(Mutex::new(Live {
@@ -939,13 +1026,73 @@ fn current_platform() -> MajorPlatformType {
     }
 }
 
+#[cfg(windows)]
+fn rdpdr_backend_factory(drives: Vec<RdpdrDriveConfig>) -> anyhow::Result<Option<WindowsRdpdrBackendFactory>> {
+    if drives.is_empty() {
+        return Ok(None);
+    }
+
+    let mut names = BTreeSet::new();
+    let mut roots = BTreeSet::new();
+    let drives = drives
+        .iter()
+        .enumerate()
+        .map(|(index, drive)| {
+            if !names.insert(drive.display_name.to_ascii_uppercase()) {
+                anyhow::bail!("rdpdr drive names must be unique");
+            }
+            if !roots.insert(validate_rdpdr_volume_root(&drive.root_path)?) {
+                anyhow::bail!("rdpdr volume roots must be unique");
+            }
+
+            let device_id =
+                u32::try_from(index + 1).map_err(|_| anyhow::anyhow!("too many rdpdr drive configurations"))?;
+            RedirectedDrive::new(device_id, &drive.display_name, &drive.root_path, false)
+                .map_err(|error| anyhow::anyhow!("invalid rdpdr drive configuration: {error}"))
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    WindowsRdpdrBackendFactory::from_drives(drives)
+        .map(Some)
+        .map_err(|error| anyhow::anyhow!("invalid rdpdr drive configuration: {error}"))
+}
+
+#[cfg(windows)]
+fn validate_rdpdr_volume_root(root_path: &Path) -> anyhow::Result<String> {
+    let mut components = root_path.components();
+    let is_disk_root = matches!(
+        (components.next(), components.next(), components.next()),
+        (
+            Some(Component::Prefix(prefix)),
+            Some(Component::RootDir),
+            None
+        ) if matches!(prefix.kind(), Prefix::Disk(_) | Prefix::VerbatimDisk(_))
+    );
+    if !is_disk_root {
+        anyhow::bail!("rdpdr volume root must be a full local Windows volume root");
+    }
+
+    let metadata =
+        std::fs::metadata(root_path).with_context(|| format!("inspect rdpdr volume root {}", root_path.display()))?;
+    if !metadata.is_dir() {
+        anyhow::bail!("rdpdr volume root must be a directory");
+    }
+
+    Ok(std::fs::canonicalize(root_path)
+        .with_context(|| format!("canonicalize rdpdr volume root {}", root_path.display()))?
+        .to_string_lossy()
+        .to_ascii_uppercase())
+}
+
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use tokio::sync::mpsc;
 
     use ironrdp_propertyset::PropertySet;
 
-    use super::{Daemon, ResizeError, notify};
+    use super::{Daemon, RdpdrDriveConfig, ResizeError, notify};
     use crate::ipc::Response;
 
     #[test]
@@ -976,5 +1123,66 @@ mod tests {
         daemon.shutdown();
 
         assert!(shutdown.has_changed().expect("shutdown sender is live"));
+    }
+
+    #[test]
+    fn rdpdr_drive_configuration_rejects_invalid_names_and_roots() {
+        assert!(RdpdrDriveConfig::new(PathBuf::new(), "Data".to_owned()).is_err());
+        assert!(RdpdrDriveConfig::new(PathBuf::from(r"C:\"), String::new()).is_err());
+        assert!(RdpdrDriveConfig::new(PathBuf::from(r"C:\"), "too-long".to_owned()).is_err());
+        assert!(RdpdrDriveConfig::new(PathBuf::from(r"C:\"), "data/".to_owned()).is_err());
+        assert!(RdpdrDriveConfig::new(PathBuf::from(r"C:\"), "Data".to_owned()).is_ok());
+    }
+
+    #[cfg(windows)]
+    fn system_volume_root() -> PathBuf {
+        let system_drive = std::env::var("SystemDrive").expect("SystemDrive is set on Windows");
+        PathBuf::from(format!(r"{system_drive}\"))
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn rdpdr_daemon_constructs_a_factory_for_a_volume_root() {
+        let drive = RdpdrDriveConfig::new(system_volume_root(), "System".to_owned()).expect("valid drive");
+        let daemon = Daemon::with_rdpdr_drives(PropertySet::new(), vec![drive]).expect("valid daemon options");
+
+        assert!(daemon.rdpdr_backend_factory.is_some());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn rdpdr_daemon_rejects_duplicate_names_and_roots() {
+        let root = system_volume_root();
+        let duplicate_name = Daemon::with_rdpdr_drives(
+            PropertySet::new(),
+            vec![
+                RdpdrDriveConfig::new(root.clone(), "System".to_owned()).expect("valid drive"),
+                RdpdrDriveConfig::new(root.clone(), "system".to_owned()).expect("valid drive"),
+            ],
+        );
+        assert!(matches!(duplicate_name, Err(error) if error.to_string() == "rdpdr drive names must be unique"));
+
+        let duplicate_root = Daemon::with_rdpdr_drives(
+            PropertySet::new(),
+            vec![
+                RdpdrDriveConfig::new(root.clone(), "System".to_owned()).expect("valid drive"),
+                RdpdrDriveConfig::new(root, "Data".to_owned()).expect("valid drive"),
+            ],
+        );
+        assert!(matches!(duplicate_root, Err(error) if error.to_string() == "rdpdr volume roots must be unique"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn rdpdr_daemon_rejects_non_root_directories() {
+        let drive = RdpdrDriveConfig::new(std::env::current_dir().expect("current directory"), "Data".to_owned())
+            .expect("non-empty drive config");
+
+        let result = Daemon::with_rdpdr_drives(PropertySet::new(), vec![drive]);
+
+        assert!(matches!(
+            result,
+            Err(error) if error.to_string() == "rdpdr volume root must be a full local Windows volume root"
+        ));
     }
 }

--- a/crates/ironrdp-daemon/src/daemon.rs
+++ b/crates/ironrdp-daemon/src/daemon.rs
@@ -21,8 +21,6 @@ use tracing::{debug, error, info, trace, warn};
 
 #[cfg(windows)]
 use std::collections::BTreeSet;
-#[cfg(windows)]
-use std::path::{Component, Prefix};
 
 #[cfg(windows)]
 use ironrdp_rdpdr_native::{RedirectedDrive, WindowsRdpdrBackendFactory};
@@ -1059,17 +1057,22 @@ fn rdpdr_backend_factory(drives: Vec<RdpdrDriveConfig>) -> anyhow::Result<Option
 
 #[cfg(windows)]
 fn validate_rdpdr_volume_root(root_path: &Path) -> anyhow::Result<String> {
-    let mut components = root_path.components();
+    use std::os::windows::ffi::OsStrExt as _;
+
+    let mut path = root_path.as_os_str().encode_wide();
     let is_disk_root = matches!(
-        (components.next(), components.next(), components.next()),
+        (path.next(), path.next(), path.next(), path.next()),
         (
-            Some(Component::Prefix(prefix)),
-            Some(Component::RootDir),
+            Some(drive_letter),
+            Some(colon),
+            Some(separator),
             None
-        ) if matches!(prefix.kind(), Prefix::Disk(_) | Prefix::VerbatimDisk(_))
+        ) if matches!(drive_letter, 65..=90 | 97..=122)
+            && colon == u16::from(b':')
+            && separator == u16::from(b'\\')
     );
     if !is_disk_root {
-        anyhow::bail!("rdpdr volume root must be a full local Windows volume root");
+        anyhow::bail!("rdpdr volume root must use the X:\\ form");
     }
 
     let metadata =
@@ -1180,9 +1183,21 @@ mod tests {
 
         let result = Daemon::with_rdpdr_drives(PropertySet::new(), vec![drive]);
 
-        assert!(matches!(
-            result,
-            Err(error) if error.to_string() == "rdpdr volume root must be a full local Windows volume root"
-        ));
+        assert!(matches!(result, Err(error) if error.to_string() == "rdpdr volume root must use the X:\\ form"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn rdpdr_daemon_rejects_noncanonical_volume_root_spellings() {
+        for root in ["C:/", r"C:\.", r"\\?\C:\"] {
+            let drive = RdpdrDriveConfig::new(PathBuf::from(root), "Data".to_owned()).expect("non-empty drive config");
+
+            let result = Daemon::with_rdpdr_drives(PropertySet::new(), vec![drive]);
+
+            assert!(matches!(
+                result,
+                Err(error) if error.to_string() == "rdpdr volume root must use the X:\\ form"
+            ));
+        }
     }
 }


### PR DESCRIPTION
Allow an agent daemon to opt in to fixed Windows filesystem drives.

Validate names, roots, and duplicate definitions before listening, then attach the native RDPDR backend factory to each client.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
