### PR TITLE
ffi: pin diplomat for RustVec Result/Option (WIP catch-up)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,6 +206,9 @@ opt-level = 3
 opt-level = 3
 
 [patch.crates-io]
-# FIXME: We need to catch up with Diplomat upstream again, but this is a significant amount of work.
-# In the meantime, we use this forked version which fixes an undefined behavior in the code expanded by the bridge macro.
-diplomat = { git = "https://github.com/CBenoit/diplomat", rev = "6dc806e80162b6b39509a04a2835744236cd2396" }
+# WIP: pin to Result/Option owned-byte-slice work (rust-diplomat/diplomat#1250).
+# IronRDP is still on diplomat 0.7-era APIs — this alone does not finish the
+# 0.16 catch-up. After #1250 merges, cut a Devolutions diplomat tag and finish
+# the migration (then drop this comment).
+diplomat = { git = "https://github.com/irvingoujAtDevolution/diplomat.git", rev = "ab68f7a4bf1b910729d0e6ece4cb7da31e616306" }
+diplomat-runtime = { git = "https://github.com/irvingoujAtDevolution/diplomat.git", rev = "ab68f7a4bf1b910729d0e6ece4cb7da31e616306" }

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -12,8 +12,9 @@ test = false
 doctest = false
 
 [dependencies]
-diplomat = "0.7"
-diplomat-runtime = "0.7"
+# Same temporary pin as workspace [patch]; see Cargo.toml.
+diplomat = { git = "https://github.com/irvingoujAtDevolution/diplomat.git", rev = "ab68f7a4bf1b910729d0e6ece4cb7da31e616306" }
+diplomat-runtime = { git = "https://github.com/irvingoujAtDevolution/diplomat.git", rev = "ab68f7a4bf1b910729d0e6ece4cb7da31e616306" }
 ironrdp = { path = "../crates/ironrdp", features = ["session", "connector", "dvc", "svc", "rdpdr", "rdpsnd", "graphics", "input", "cliprdr", "displaycontrol"] }
 ironrdp-cliprdr-native.path = "../crates/ironrdp-cliprdr-native"
 ironrdp-dvc-pipe-proxy.path = "../crates/ironrdp-dvc-pipe-proxy"

--- a/ffi/README.md
+++ b/ffi/README.md
@@ -2,6 +2,16 @@
 
 [Diplomat]-based FFI for IronRDP.
 
+## Diplomat pin (temporary)
+
+Pinned to `irvingoujAtDevolution/diplomat@ab68f7a4` for
+[rust-diplomat/diplomat#1250](https://github.com/rust-diplomat/diplomat/pull/1250)
+(`Result`/`Option` of `Box<[u8]>` → .NET `RustVec`).
+
+IronRDP still needs a full diplomat **0.7 → 0.16** catch-up before this pin
+builds cleanly. After #1250 merges, publish a Devolutions diplomat tag and
+finish the migration (same pattern as IronVNC).
+
 Currently, only the .NET target is officially supported.
 
 ## How to build

--- a/xtask/src/bin_version.rs
+++ b/xtask/src/bin_version.rs
@@ -7,7 +7,11 @@ pub const CARGO_FUZZ: CargoPackage = CargoPackage::new("cargo-fuzz", "0.13.2");
 pub const CARGO_HACK: CargoPackage = CargoPackage::new("cargo-hack", "0.6.45");
 pub const WASM_PACK: CargoPackage = CargoPackage::new("wasm-pack", "0.15.0");
 pub const TYPOS_CLI: CargoPackage = CargoPackage::new("typos-cli", "1.48.0").with_binary_name("typos");
-pub const DIPLOMAT_TOOL: CargoPackage = CargoPackage::new("diplomat-tool", "0.7.1");
+// WIP pin matching ffi/Cargo.toml / workspace patch (diplomat#1250 branch).
+// Install: cargo install --git https://github.com/irvingoujAtDevolution/diplomat.git \
+//   --rev ab68f7a4bf1b910729d0e6ece4cb7da31e616306 diplomat-tool
+// crates.io 0.7.1 cannot generate against this pin.
+pub const DIPLOMAT_TOOL: CargoPackage = CargoPackage::new("diplomat-tool", "0.16.0");
 
 pub const WABT_VERSION: &str = "1.0.41";
 pub const NIGHTLY_TOOLCHAIN: &str = "nightly-2026-03-05";


### PR DESCRIPTION
WIP pin for [rust-diplomat/diplomat#1250](https://github.com/rust-diplomat/diplomat/pull/1250) (`Result`/`Option` of `Box<[u8]>` -> .NET `RustVec`).

### this PR
- workspace `[patch]` + `ffi` deps -> `irvingoujAtDevolution/diplomat@ab68f7a4`
- bump documented `diplomat-tool` to 0.16.0 (install from that git rev)

### not done here
IronRDP is still on diplomat **0.7** (CBenoit fork). Jumping the pin alone will not compile until the full 0.16 catch-up. Pattern once unblocked: IronVNC https://github.com/Devolutions/IronVNC/pull/1424

### after #1250 merges
Devolutions diplomat tag, then finish migration + move opaque `VecU8` byte returns to `Box<[u8]>` / `RustVec` where it matters.