### PR TITLE
chore(xtask): allow the rdpeudp and rdpemt title scopes

### DIFF
--- a/xtask/src/pr.rs
+++ b/xtask/src/pr.rs
@@ -31,6 +31,8 @@ const CANONICAL_SCOPES: &[&str] = &[
     "echo",
     "egfx",
     "rdpeusb",
+    "rdpeudp",
+    "rdpemt",
     "rdcleanpath",
     "tls",
     "mstsgu",


### PR DESCRIPTION
# chore(xtask): allow the rdpeudp and rdpemt title scopes

Two entries in `CANONICAL_SCOPES`, following #1615.

The RDP-UDP transport @mamoreau-devolutions asked for on #140 arrives as two
crates, `ironrdp-rdpeudp` and `ironrdp-rdpemt`. Neither name is in the list, so
`cargo xtask pr check-message` rejects the titles of the PRs that add them:
#1626 and #1627 are both red on `Check message` for exactly this, with
everything else green.

Placed next to `rdpeusb`, which keeps the protocol extension crates together.

## No scope for the tokio adapter

The transport also comes with `ironrdp-rdpeudp-tokio`, and I have deliberately
not added a scope for it. The list names subsystems rather than crates, which is
why there is no `tokio`, `async`, `blocking` or `-native` entry either, so
changes to that crate belong under `rdpeudp`. Say the word if you would rather
have one per crate and I will add it.

## Test plan

`cargo xtask check fmt/lints/tests/typos/locks`

Also checked directly against the titles this unblocks, by feeding each to
`cargo xtask pr check-message` with a synthetic event file: the two filed PRs
and the three still to come all validate, as does this PR's own title.
