### PR TITLE
fix(session): batch Fast-Path input events

### DIFF
--- a/crates/ironrdp-pdu/src/input/fast_path.rs
+++ b/crates/ironrdp-pdu/src/input/fast_path.rs
@@ -259,7 +259,7 @@ bitflags! {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FastPathInput(
-    /// INVARIANT: (1..=255).contains(len()) = at least one, and at most 255 elements.
+    /// INVARIANT: the input event count is within `1..=FastPathInput::MAX_EVENTS`.
     Vec<FastPathInputEvent>,
 );
 
@@ -269,7 +269,7 @@ pub struct FastPathInput(
 #[cfg(feature = "arbitrary")]
 impl<'a> arbitrary::Arbitrary<'a> for FastPathInput {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let len = u.int_in_range::<usize>(1..=255)?;
+        let len = u.int_in_range::<usize>(1..=Self::MAX_EVENTS)?;
         let mut events = Vec::with_capacity(len);
         for _ in 0..len {
             events.push(FastPathInputEvent::arbitrary(u)?);
@@ -281,9 +281,11 @@ impl<'a> arbitrary::Arbitrary<'a> for FastPathInput {
 impl FastPathInput {
     const NAME: &'static str = "FastPathInput";
 
+    pub const MAX_EVENTS: usize = 255;
+
     pub fn new(input_events: Vec<FastPathInputEvent>) -> DecodeResult<Self> {
         // Ensure the invariant on `input_events.len()` is respected.
-        if !(1..=255usize).contains(&input_events.len()) {
+        if !(1..=Self::MAX_EVENTS).contains(&input_events.len()) {
             return Err(invalid_field_err!("nEvents", "invalid number of input events"));
         }
 
@@ -310,7 +312,8 @@ impl Encode for FastPathInput {
 
         let data_length = self.0.iter().map(Encode::size).sum::<usize>();
         let header = FastPathInputHeader {
-            num_events: u8::try_from(self.0.len()).expect("per invariant (1..=255).contains(num_events.len())"),
+            num_events: u8::try_from(self.0.len())
+                .expect("per invariant (1..=FastPathInput::MAX_EVENTS).contains(num_events.len())"),
             flags: EncryptionFlags::empty(),
             data_length,
         };
@@ -331,7 +334,7 @@ impl Encode for FastPathInput {
         let data_length = self.0.iter().map(Encode::size).sum::<usize>();
         let header = FastPathInputHeader {
             num_events: u8::try_from(self.0.len())
-                .expect("INVARIANT: num_events is within the range of 1 to 255, inclusive"),
+                .expect("INVARIANT: num_events is within 1..=FastPathInput::MAX_EVENTS"),
             flags: EncryptionFlags::empty(),
             data_length,
         };

--- a/crates/ironrdp-session/src/active_stage.rs
+++ b/crates/ironrdp-session/src/active_stage.rs
@@ -126,14 +126,15 @@ impl ActiveStage {
         }
 
         // Mouse move events are prevalent, so we can preallocate space for
-        // response frame + graphics update
-        let mut output = Vec::with_capacity(2);
+        // response frames + graphics update.
+        let mut output = Vec::with_capacity(events.len().div_ceil(FastPathInput::MAX_EVENTS) + 1);
 
-        // Encoding fastpath response frame
-        // PERF: unnecessary copy
-        let fastpath_input = FastPathInput::new(events.to_vec()).map_err(SessionError::decode)?;
-        let frame = ironrdp_core::encode_vec(&fastpath_input).map_err(SessionError::encode)?;
-        output.push(ActiveStageOutput::ResponseFrame(frame));
+        for event_chunk in events.chunks(FastPathInput::MAX_EVENTS) {
+            // PERF: unnecessary copy
+            let fastpath_input = FastPathInput::new(event_chunk.to_vec()).map_err(SessionError::decode)?;
+            let frame = ironrdp_core::encode_vec(&fastpath_input).map_err(SessionError::encode)?;
+            output.push(ActiveStageOutput::ResponseFrame(frame));
+        }
 
         // If pointer rendering is disabled - we can skip the rest
         if !self.enable_server_pointer {
@@ -635,7 +636,9 @@ fn process_slow_path_pointer(
 
 #[cfg(test)]
 mod tests {
+    use ironrdp_core::Decode as _;
     use ironrdp_graphics::image_processing::PixelFormat;
+    use ironrdp_pdu::input::fast_path::KeyboardFlags;
     use ironrdp_pdu::pointer::{ColorPointerAttribute, Point16, PointerAttribute, PointerUpdateData};
 
     use super::*;
@@ -660,6 +663,51 @@ mod tests {
 
         assert_eq!(stage.request_full_redraw(1024, 768, true, false).unwrap().len(), 1);
         assert!(stage.request_full_redraw(1024, 768, false, false).unwrap().is_empty());
+    }
+
+    #[test]
+    fn fastpath_input_splits_at_event_limit() {
+        let mut stage = ActiveStageBuilder {
+            static_channels: StaticChannelSet::new(),
+            user_channel_id: 1001,
+            io_channel_id: 1003,
+            message_channel_id: None,
+            share_id: 1,
+            compression_type: None,
+            enable_server_pointer: false,
+            pointer_software_rendering: false,
+        }
+        .build();
+        let mut image = DecodedImage::new(PixelFormat::RgbA32, 1, 1);
+        let events = (0..=u8::MAX)
+            .map(|code| FastPathInputEvent::UnicodeKeyboardEvent(KeyboardFlags::empty(), u16::from(code)))
+            .collect::<Vec<_>>();
+
+        let output = stage.process_fastpath_input(&mut image, &events).unwrap();
+        let input_frames = output
+            .into_iter()
+            .map(|output| {
+                let ActiveStageOutput::ResponseFrame(frame) = output else {
+                    panic!("expected a fast-path input frame");
+                };
+                FastPathInput::decode(&mut ReadCursor::new(&frame)).unwrap()
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            input_frames
+                .iter()
+                .map(|input| input.input_events().len())
+                .collect::<Vec<_>>(),
+            [FastPathInput::MAX_EVENTS, 1]
+        );
+        assert_eq!(
+            input_frames
+                .iter()
+                .flat_map(FastPathInput::input_events)
+                .collect::<Vec<_>>(),
+            events.iter().collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/ffi/src/session/mod.rs
+++ b/ffi/src/session/mod.rs
@@ -2,6 +2,8 @@ pub mod image;
 
 #[diplomat::bridge]
 pub mod ffi {
+    use std::collections::VecDeque;
+
     use super::image::ffi::DecodedImage;
     use crate::clipboard::message::ffi::{ClipboardFormatId, ClipboardFormatIterator, FormatDataResponse};
     use crate::connector::activation::ffi::ConnectionActivationSequence;
@@ -23,7 +25,7 @@ pub mod ffi {
     pub struct ActiveStageOutput(pub ironrdp::session::ActiveStageOutput);
 
     #[diplomat::opaque]
-    pub struct ActiveStageOutputIterator(pub Vec<ironrdp::session::ActiveStageOutput>);
+    pub struct ActiveStageOutputIterator(pub VecDeque<ironrdp::session::ActiveStageOutput>);
 
     impl ActiveStageOutputIterator {
         pub fn len(&self) -> usize {
@@ -35,7 +37,7 @@ pub mod ffi {
         }
 
         pub fn next(&mut self) -> Option<Box<ActiveStageOutput>> {
-            self.0.pop().map(ActiveStageOutput).map(Box::new)
+            self.0.pop_front().map(ActiveStageOutput).map(Box::new)
         }
     }
 
@@ -80,7 +82,7 @@ pub mod ffi {
             payload: &[u8],
         ) -> Result<Box<ActiveStageOutputIterator>, Box<IronRdpError>> {
             let outputs = self.0.process(&mut image.0, action.0, payload)?;
-            Ok(Box::new(ActiveStageOutputIterator(outputs)))
+            Ok(Box::new(ActiveStageOutputIterator(outputs.into())))
         }
 
         pub fn process_fastpath_input(
@@ -91,7 +93,7 @@ pub mod ffi {
             Ok(self
                 .0
                 .process_fastpath_input(&mut image.0, &fastpath_input.0)
-                .map(|outputs| Box::new(ActiveStageOutputIterator(outputs)))?)
+                .map(|outputs| Box::new(ActiveStageOutputIterator(outputs.into())))?)
         }
 
         pub fn initiate_clipboard_copy(
@@ -164,7 +166,7 @@ pub mod ffi {
 
         pub fn graceful_shutdown(&mut self) -> Result<Box<ActiveStageOutputIterator>, Box<IronRdpError>> {
             let outputs = self.0.graceful_shutdown()?;
-            Ok(Box::new(ActiveStageOutputIterator(outputs)))
+            Ok(Box::new(ActiveStageOutputIterator(outputs.into())))
         }
 
         pub fn encoded_resize(
@@ -178,9 +180,9 @@ pub mod ffi {
                 .encode_resize(width, height, None, Some((width, height)))
                 .map(|outputs| {
                     outputs.map(|outputs| {
-                        Box::new(ActiveStageOutputIterator(vec![
-                            ironrdp::session::ActiveStageOutput::ResponseFrame(outputs),
-                        ]))
+                        Box::new(ActiveStageOutputIterator(
+                            vec![ironrdp::session::ActiveStageOutput::ResponseFrame(outputs)].into(),
+                        ))
                     })
                 })
                 .transpose()?)
@@ -396,4 +398,33 @@ pub mod ffi {
 
     #[diplomat::opaque]
     pub struct GracefulDisconnectReason(pub ironrdp::session::GracefulDisconnectReason);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+
+    use super::ffi::ActiveStageOutputIterator;
+
+    #[test]
+    fn active_stage_output_iterator_preserves_response_frame_order() {
+        let mut iterator = ActiveStageOutputIterator(VecDeque::from([
+            ironrdp::session::ActiveStageOutput::ResponseFrame(vec![1]),
+            ironrdp::session::ActiveStageOutput::ResponseFrame(vec![2]),
+        ]));
+
+        let first = iterator.next().unwrap();
+        let ironrdp::session::ActiveStageOutput::ResponseFrame(first) = &first.0 else {
+            panic!("expected a response frame");
+        };
+        assert_eq!(first, &[1]);
+
+        let second = iterator.next().unwrap();
+        let ironrdp::session::ActiveStageOutput::ResponseFrame(second) = &second.0 else {
+            panic!("expected a response frame");
+        };
+        assert_eq!(second, &[2]);
+
+        assert!(iterator.next().is_none());
+    }
 }


### PR DESCRIPTION
Keep outgoing Fast-Path input frames within the 255-event protocol limit and preserve their order across FFI.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>