### PR TITLE
feat: forward negotiated windowing orders

### DIFF
--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -1847,7 +1847,7 @@ async fn active_session(
                             static_channel_chunk_size,
                             refresh_rect_support: reactivated_refresh_rect_support,
                             suppress_output_support: reactivated_suppress_output_support,
-                            window_support_level: _,
+                            window_support_level,
                         } = connection_activation.connection_activation_state()
                         {
                             debug!(?desktop_size, "Deactivation-Reactivation Sequence completed");
@@ -1863,6 +1863,7 @@ async fn active_session(
                             ) {
                                 return Err(ironrdp_session::general_err!("invalid static channel chunk size"));
                             }
+                            active_stage.set_window_support_level(window_support_level);
                             refresh_rect_support = reactivated_refresh_rect_support;
                             suppress_output_support = reactivated_suppress_output_support;
                             break 'activation_seq;

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -1736,6 +1736,9 @@ async fn active_session(
                         ));
                     }
                 }
+                ActiveStageOutput::WindowingOrders(_) => {
+                    // This desktop client does not provide a consumer for windowing orders.
+                }
                 ActiveStageOutput::SaveSessionInfo { logon_complete: true } => {
                     if !post_logon_redraw_requested {
                         post_logon_redraw_requested = true;
@@ -1844,6 +1847,7 @@ async fn active_session(
                             static_channel_chunk_size,
                             refresh_rect_support: reactivated_refresh_rect_support,
                             suppress_output_support: reactivated_suppress_output_support,
+                            window_support_level: _,
                         } = connection_activation.connection_activation_state()
                         {
                             debug!(?desktop_size, "Deactivation-Reactivation Sequence completed");

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -5,6 +5,7 @@ use std::borrow::Cow;
 use std::sync::Arc;
 
 use ironrdp_core::{Encode, WriteBuf, decode, encode_vec};
+use ironrdp_pdu::rdp::capability_sets::WindowSupportLevel;
 use ironrdp_pdu::rdp::session_info::ServerAutoReconnect;
 use ironrdp_pdu::x224::X224;
 use ironrdp_pdu::{PduHint, gcc, mcs, nego, rdp};
@@ -76,6 +77,11 @@ pub struct ConnectionResult {
     pub refresh_rect_support: bool,
     /// Whether the server permits Suppress Output PDUs for visual recovery.
     pub suppress_output_support: bool,
+    /// The Window List support level negotiated with the server.
+    ///
+    /// `None` means Window List was absent or disabled, so windowing orders
+    /// retain ordinary desktop-session handling.
+    pub window_support_level: Option<WindowSupportLevel>,
     /// Factory for producing connection activation sequences.
     ///
     /// Used to drive the [Deactivation-Reactivation Sequence] when a Server Deactivate All PDU is
@@ -1238,6 +1244,7 @@ impl Sequence for ClientConnector {
                             pointer_software_rendering,
                             refresh_rect_support,
                             suppress_output_support,
+                            window_support_level,
                         } => {
                             let mut static_channels = mem::take(&mut self.static_channels);
                             if !static_channels.set_maximum_chunk_size(static_channel_chunk_size) {
@@ -1257,6 +1264,7 @@ impl Sequence for ClientConnector {
                                     pointer_software_rendering,
                                     refresh_rect_support,
                                     suppress_output_support,
+                                    window_support_level,
                                     activation_factory: ConnectionActivationFactory::new(
                                         self.config.clone(),
                                         connection_activation.io_channel_id(),

--- a/crates/ironrdp-connector/src/connection_activation.rs
+++ b/crates/ironrdp-connector/src/connection_activation.rs
@@ -1,7 +1,7 @@
 use core::mem;
 
 use ironrdp_pdu::rdp;
-use ironrdp_pdu::rdp::capability_sets::{CapabilitySet, InputFlags};
+use ironrdp_pdu::rdp::capability_sets::{CapabilitySet, InputFlags, WindowList, WindowSupportLevel};
 use tracing::{debug, warn};
 
 use crate::{
@@ -202,6 +202,9 @@ impl Sequence for ConnectionActivationSequence {
                     ));
                 };
 
+                let window_list = server_window_list(&capability_sets);
+                let window_support_level = negotiated_window_support_level(window_list.as_ref());
+
                 let (refresh_rect_support, suppress_output_support) = capability_sets
                     .iter()
                     .find_map(|capability_set| {
@@ -267,7 +270,7 @@ impl Sequence for ConnectionActivationSequence {
                 let share_id = share_control_ctx.share_id;
 
                 let client_confirm_active = rdp::headers::ShareControlPdu::ClientConfirmActive(
-                    create_client_confirm_active(&self.config, capability_sets, desktop_size)?,
+                    create_client_confirm_active(&self.config, capability_sets, desktop_size, window_list)?,
                 );
 
                 debug!(message = ?client_confirm_active, "Send");
@@ -290,6 +293,7 @@ impl Sequence for ConnectionActivationSequence {
                         static_channel_chunk_size,
                         refresh_rect_support,
                         suppress_output_support,
+                        window_support_level,
                         connection_finalization: ConnectionFinalizationSequence::new(
                             self.io_channel_id,
                             self.user_channel_id,
@@ -305,6 +309,7 @@ impl Sequence for ConnectionActivationSequence {
                 static_channel_chunk_size,
                 refresh_rect_support,
                 suppress_output_support,
+                window_support_level,
                 mut connection_finalization,
             } => {
                 debug!("Connection Finalization");
@@ -319,6 +324,7 @@ impl Sequence for ConnectionActivationSequence {
                         static_channel_chunk_size,
                         refresh_rect_support,
                         suppress_output_support,
+                        window_support_level,
                         connection_finalization,
                     }
                 } else {
@@ -331,6 +337,7 @@ impl Sequence for ConnectionActivationSequence {
                         pointer_software_rendering: self.config.pointer_software_rendering,
                         refresh_rect_support,
                         suppress_output_support,
+                        window_support_level,
                     }
                 };
 
@@ -358,6 +365,8 @@ pub enum ConnectionActivationState {
         static_channel_chunk_size: usize,
         refresh_rect_support: bool,
         suppress_output_support: bool,
+        /// The server-negotiated Window List support level.
+        window_support_level: Option<WindowSupportLevel>,
         connection_finalization: ConnectionFinalizationSequence,
     },
     Finalized {
@@ -378,6 +387,8 @@ pub enum ConnectionActivationState {
         refresh_rect_support: bool,
         /// Whether the server permits Suppress Output PDUs for visual recovery.
         suppress_output_support: bool,
+        /// The server-negotiated Window List support level.
+        window_support_level: Option<WindowSupportLevel>,
     },
 }
 
@@ -402,10 +413,27 @@ impl State for ConnectionActivationState {
 
 const DEFAULT_POINTER_CACHE_SIZE: u16 = 32;
 
+fn server_window_list(capability_sets: &[CapabilitySet]) -> Option<WindowList> {
+    capability_sets.iter().find_map(|capability_set| {
+        if let CapabilitySet::WindowList(window_list) = capability_set {
+            Some(window_list.clone())
+        } else {
+            None
+        }
+    })
+}
+
+fn negotiated_window_support_level(window_list: Option<&WindowList>) -> Option<WindowSupportLevel> {
+    window_list.and_then(|window_list| {
+        (window_list.support_level != WindowSupportLevel::NotSupported).then_some(window_list.support_level)
+    })
+}
+
 fn create_client_confirm_active(
     config: &Config,
     mut server_capability_sets: Vec<CapabilitySet>,
     desktop_size: DesktopSize,
+    window_list: Option<WindowList>,
 ) -> ConnectorResult<rdp::capability_sets::ClientConfirmActive> {
     use ironrdp_pdu::rdp::capability_sets::{
         BITMAP_CACHE_ENTRIES_NUM, Bitmap, BitmapCache, BitmapDrawingFlags, Brush, CacheDefinition, CacheEntry,
@@ -528,6 +556,9 @@ fn create_client_confirm_active(
             max_request_size: 8 * 1024 * 1024, // 8 MB
         }));
     }
+    if let Some(window_list) = window_list {
+        server_capability_sets.push(CapabilitySet::WindowList(window_list));
+    }
 
     Ok(ClientConfirmActive {
         originator_id: SERVER_CHANNEL_ID,
@@ -560,7 +591,9 @@ fn requested_bitmap_color_depth(bitmap: Option<&crate::BitmapConfig>) -> Connect
 
 #[cfg(test)]
 mod tests {
-    use super::requested_bitmap_color_depth;
+    use ironrdp_pdu::rdp::capability_sets::{CapabilitySet, WindowList, WindowSupportLevel};
+
+    use super::{negotiated_window_support_level, requested_bitmap_color_depth, server_window_list};
     use crate::BitmapConfig;
 
     #[test]
@@ -578,5 +611,30 @@ mod tests {
                 expected_color_depth
             );
         }
+    }
+
+    #[test]
+    fn window_list_capability_preserves_supported_level() {
+        let window_list = WindowList {
+            support_level: WindowSupportLevel::SupportedEx,
+            num_icon_caches: 3,
+            num_icon_cache_entries: 12,
+        };
+        let capabilities = vec![CapabilitySet::WindowList(window_list.clone())];
+
+        assert_eq!(server_window_list(&capabilities), Some(window_list));
+        assert_eq!(
+            negotiated_window_support_level(server_window_list(&capabilities).as_ref()),
+            Some(WindowSupportLevel::SupportedEx)
+        );
+        assert_eq!(negotiated_window_support_level(None), None);
+        assert_eq!(
+            negotiated_window_support_level(Some(&WindowList {
+                support_level: WindowSupportLevel::NotSupported,
+                num_icon_caches: 0,
+                num_icon_cache_entries: 0,
+            })),
+            None
+        );
     }
 }

--- a/crates/ironrdp-pdu/src/basic_output/fast_path/mod.rs
+++ b/crates/ironrdp-pdu/src/basic_output/fast_path/mod.rs
@@ -225,6 +225,8 @@ impl<'de> Decode<'de> for FastPathUpdatePdu<'de> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum FastPathUpdate<'a> {
+    /// Raw Fast-Path Orders update data.
+    Orders(&'a [u8]),
     SurfaceCommands(Vec<SurfaceCommand<'a>>),
     Bitmap(BitmapUpdateData<'a>),
     Pointer(PointerUpdateData<'a>),
@@ -244,6 +246,11 @@ impl<'a> FastPathUpdate<'a> {
 
     pub fn decode_cursor_with_code(src: &mut ReadCursor<'a>, code: UpdateCode) -> DecodeResult<Self> {
         match code {
+            UpdateCode::Orders => {
+                let data = src.remaining();
+                src.advance(data.len());
+                Ok(Self::Orders(data))
+            }
             UpdateCode::SurfaceCommands => {
                 let mut commands = Vec::with_capacity(1);
                 while src.len() >= SURFACE_COMMAND_HEADER_SIZE {
@@ -274,6 +281,7 @@ impl<'a> FastPathUpdate<'a> {
 
     pub fn as_short_name(&self) -> &str {
         match self {
+            Self::Orders(_) => "Orders",
             Self::SurfaceCommands(_) => "Surface Commands",
             Self::Bitmap(_) => "Bitmap",
             Self::Pointer(_) => "Pointer",
@@ -287,6 +295,9 @@ impl Encode for FastPathUpdate<'_> {
         ensure_size!(in: dst, size: self.size());
 
         match self {
+            Self::Orders(data) => {
+                dst.write_slice(data);
+            }
             Self::SurfaceCommands(commands) => {
                 for command in commands {
                     command.encode(dst)?;
@@ -318,6 +329,7 @@ impl Encode for FastPathUpdate<'_> {
 
     fn size(&self) -> usize {
         match self {
+            Self::Orders(data) => data.len(),
             Self::SurfaceCommands(commands) => commands.iter().map(|c| c.size()).sum::<usize>(),
             Self::Bitmap(bitmap) => bitmap.size(),
             Self::Palette(data) => data.len(),
@@ -365,6 +377,7 @@ impl UpdateCode {
 impl From<&FastPathUpdate<'_>> for UpdateCode {
     fn from(update: &FastPathUpdate<'_>) -> Self {
         match update {
+            FastPathUpdate::Orders(_) => Self::Orders,
             FastPathUpdate::SurfaceCommands(_) => Self::SurfaceCommands,
             FastPathUpdate::Bitmap(_) => Self::Bitmap,
             FastPathUpdate::Palette(_) => Self::Palette,

--- a/crates/ironrdp-pdu/src/basic_output/mod.rs
+++ b/crates/ironrdp-pdu/src/basic_output/mod.rs
@@ -3,3 +3,4 @@ pub mod fast_path;
 pub mod pointer;
 pub mod slow_path;
 pub mod surface_commands;
+pub mod window;

--- a/crates/ironrdp-pdu/src/basic_output/window.rs
+++ b/crates/ironrdp-pdu/src/basic_output/window.rs
@@ -30,6 +30,34 @@ pub struct WindowingOrder<'a> {
     pub fields_present: u32,
 }
 
+macro_rules! skip_if {
+    ($src:ident, $flags:expr, $flag:expr, $size:expr) => {
+        if $flags & $flag != 0 {
+            ensure_size!(in: $src, size: $size);
+            $src.advance($size);
+        }
+    };
+}
+
+macro_rules! skip_unicode_if {
+    ($src:ident, $flags:expr, $flag:expr, $maximum_size:expr) => {
+        if $flags & $flag != 0 {
+            skip_unicode($src, $maximum_size)?;
+        }
+    };
+}
+
+macro_rules! skip_rectangles_if {
+    ($src:ident, $flags:expr, $flag:expr) => {
+        if $flags & $flag != 0 {
+            ensure_size!(in: $src, size: 2 /* Rectangle count */);
+            let count = usize::from($src.read_u16());
+            ensure_size!(in: $src, size: count * 8 /* TS_RECTANGLE_16 */);
+            $src.advance(count * 8);
+        }
+    };
+}
+
 impl<'de> WindowingOrder<'de> {
     fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
         ensure_size!(in: src, size: ALTERNATE_SECONDARY_HEADER_SIZE);
@@ -68,6 +96,10 @@ impl<'de> WindowingOrder<'de> {
                 "order is smaller than its typed header"
             ));
         }
+        validate_order_fields(fields_present, &mut order_data)?;
+        if !order_data.eof() {
+            return Err(invalid_field_err!("orderSize", "order contains trailing data"));
+        }
 
         Ok(Self {
             encoded: &encoded[..order_size],
@@ -83,19 +115,244 @@ impl<'de> WindowingOrder<'de> {
     }
 }
 
+fn validate_order_fields(fields_present: u32, src: &mut ReadCursor<'_>) -> DecodeResult<()> {
+    match fields_present & ORDER_TYPE_MASK {
+        WINDOW_TYPE => validate_window_fields(fields_present, src),
+        NOTIFY_ICON_TYPE => validate_notification_icon_fields(fields_present, src),
+        DESKTOP_TYPE => validate_desktop_fields(fields_present, src),
+        _ => unreachable!("the order type was validated by the caller"),
+    }
+}
+
+fn validate_window_fields(flags: u32, src: &mut ReadCursor<'_>) -> DecodeResult<()> {
+    const DELETED: u32 = 0x2000_0000;
+    const ICON: u32 = 0x4000_0000;
+    const CACHED_ICON: u32 = 0x8000_0000;
+    const ICON_FLAGS: u32 = 0x0010_0000 | 0x0000_2000;
+    const ALLOWED: u32 = WINDOW_TYPE
+        | 0x0000_0001 /* APPBAR_EDGE */
+        | 0x0000_0002 /* OWNER */
+        | 0x0000_0004 /* TITLE */
+        | 0x0000_0008 /* STYLE */
+        | 0x0000_0010 /* SHOW */
+        | 0x0000_0040 /* APPBAR_STATE */
+        | 0x0000_0080 /* RESIZE_MARGIN_X */
+        | 0x0000_0100 /* WNDRECTS */
+        | 0x0000_0200 /* VISIBILITY */
+        | 0x0000_0400 /* WNDSIZE */
+        | 0x0000_0800 /* WNDOFFSET */
+        | 0x0000_1000 /* VISOFFSET */
+        | 0x0000_2000 /* ICON_BIG */
+        | 0x0000_4000 /* CLIENTAREAOFFSET */
+        | 0x0000_8000 /* CLIENTDELTA */
+        | 0x0001_0000 /* CLIENTAREASIZE */
+        | 0x0002_0000 /* RPCONTENT */
+        | 0x0004_0000 /* ROOTPARENT */
+        | 0x0008_0000 /* ENFORCE_SERVER_ZORDER */
+        | 0x0010_0000 /* ICON_OVERLAY */
+        | 0x0020_0000 /* ICON_OVERLAY_NULL */
+        | 0x0040_0000 /* OVERLAY_DESCRIPTION */
+        | 0x0080_0000 /* TASKBAR_BUTTON */
+        | 0x0800_0000 /* RESIZE_MARGIN_Y */
+        | 0x1000_0000 /* STATE_NEW */
+        | DELETED
+        | ICON
+        | CACHED_ICON;
+
+    if flags & !ALLOWED != 0 {
+        return Err(invalid_field_err!("fieldsPresent", "unknown window order flag"));
+    }
+    ensure_size!(in: src, size: 4 /* WindowId */);
+    src.advance(4);
+    if flags & DELETED != 0 {
+        if flags != WINDOW_TYPE | DELETED {
+            return Err(invalid_field_err!("fieldsPresent", "deleted window order contains additional fields"));
+        }
+        return Ok(());
+    }
+    if flags & (ICON | CACHED_ICON) != 0 {
+        if flags & (ICON | CACHED_ICON) == ICON | CACHED_ICON {
+            return Err(invalid_field_err!("fieldsPresent", "window order contains both icon representations"));
+        }
+        if flags & !(WINDOW_TYPE | 0x1000_0000 | ICON | CACHED_ICON | ICON_FLAGS) != 0 {
+            return Err(invalid_field_err!("fieldsPresent", "invalid flags for a window icon order"));
+        }
+        return if flags & ICON != 0 {
+            validate_icon(src)
+        } else {
+            ensure_size!(in: src, size: 3 /* CacheEntry, CacheId */);
+            src.advance(3);
+            Ok(())
+        };
+    }
+
+    skip_if!(src, flags, 0x0000_0002, 4 /* OwnerWindowId */);
+    skip_if!(src, flags, 0x0000_0008, 8 /* Style, ExtendedStyle */);
+    if flags & 0x0000_0010 != 0 {
+        ensure_size!(in: src, size: 1 /* ShowState */);
+        if !matches!(src.read_u8(), 0 | 2 | 3 | 5) {
+            return Err(invalid_field_err!("ShowState", "invalid window show state"));
+        }
+    }
+    skip_unicode_if!(src, flags, 0x0000_0004, 520);
+    skip_if!(src, flags, 0x0000_4000, 8 /* ClientOffset */);
+    skip_if!(src, flags, 0x0001_0000, 8 /* ClientAreaSize */);
+    skip_if!(src, flags, 0x0000_0080, 8 /* HorizontalResizeMargins */);
+    skip_if!(src, flags, 0x0800_0000, 8 /* VerticalResizeMargins */);
+    if flags & 0x0002_0000 != 0 {
+        ensure_size!(in: src, size: 1 /* RPContent */);
+        if src.read_u8() > 1 {
+            return Err(invalid_field_err!("RPContent", "invalid render plugin content"));
+        }
+    }
+    skip_if!(src, flags, 0x0004_0000, 4 /* RootParentHandle */);
+    skip_if!(src, flags, 0x0000_0800, 8 /* WindowOffset */);
+    skip_if!(src, flags, 0x0000_8000, 8 /* ClientDelta */);
+    skip_if!(src, flags, 0x0000_0400, 8 /* WindowSize */);
+    skip_rectangles_if!(src, flags, 0x0000_0100);
+    skip_if!(src, flags, 0x0000_1000, 8 /* VisibleOffset */);
+    skip_rectangles_if!(src, flags, 0x0000_0200);
+    skip_unicode_if!(src, flags, 0x0040_0000, usize::from(u16::MAX));
+    skip_if!(src, flags, 0x0080_0000, 1 /* TaskbarButton */);
+    skip_if!(src, flags, 0x0008_0000, 1 /* EnforceServerZOrder */);
+    skip_if!(src, flags, 0x0000_0040, 1 /* AppBarState */);
+    skip_if!(src, flags, 0x0000_0001, 1 /* AppBarEdge */);
+    Ok(())
+}
+
+fn validate_notification_icon_fields(flags: u32, src: &mut ReadCursor<'_>) -> DecodeResult<()> {
+    const DELETED: u32 = 0x2000_0000;
+    const ICON: u32 = 0x4000_0000;
+    const CACHED_ICON: u32 = 0x8000_0000;
+    const ALLOWED: u32 = NOTIFY_ICON_TYPE | 0x0000_000F | 0x1000_0000 | DELETED | ICON | CACHED_ICON;
+    if flags & !ALLOWED != 0 {
+        return Err(invalid_field_err!("fieldsPresent", "unknown notification icon order flag"));
+    }
+    ensure_size!(in: src, size: 8 /* WindowId, NotifyIconId */);
+    src.advance(8);
+    if flags & DELETED != 0 {
+        if flags != NOTIFY_ICON_TYPE | DELETED {
+            return Err(invalid_field_err!("fieldsPresent", "deleted notification icon contains additional fields"));
+        }
+        return Ok(());
+    }
+    if flags & (ICON | CACHED_ICON) == ICON | CACHED_ICON {
+        return Err(invalid_field_err!("fieldsPresent", "notification icon contains both icon representations"));
+    }
+    if flags & 0x1000_0000 != 0 && flags & (ICON | CACHED_ICON) == 0 {
+        return Err(invalid_field_err!("fieldsPresent", "new notification icon has no icon representation"));
+    }
+    if flags & 0x0000_0008 != 0 {
+        ensure_size!(in: src, size: 4 /* Version */);
+        if !matches!(src.read_u32(), 0 | 3 | 4) {
+            return Err(invalid_field_err!("Version", "unsupported notification icon version"));
+        }
+    }
+    skip_unicode_if!(src, flags, 0x0000_0001, usize::from(u16::MAX));
+    if flags & 0x0000_0002 != 0 {
+        ensure_size!(in: src, size: 8 /* Timeout, InfoFlags */);
+        src.advance(4);
+        let info_flags = src.read_u32();
+        if info_flags & !0x33 != 0 || !matches!(info_flags & 0x0F, 0..=3) {
+            return Err(invalid_field_err!("InfoFlags", "invalid notification icon info tip flags"));
+        }
+        skip_unicode(src, 510)?;
+        skip_unicode(src, 126)?;
+    }
+    if flags & 0x0000_0004 != 0 {
+        ensure_size!(in: src, size: 4 /* State */);
+        if src.read_u32() & !1 != 0 {
+            return Err(invalid_field_err!("State", "unknown notification icon state"));
+        }
+    }
+    if flags & ICON != 0 {
+        validate_icon(src)?;
+    } else if flags & CACHED_ICON != 0 {
+        ensure_size!(in: src, size: 3 /* CacheEntry, CacheId */);
+        src.advance(3);
+    }
+    Ok(())
+}
+
+fn validate_desktop_fields(flags: u32, src: &mut ReadCursor<'_>) -> DecodeResult<()> {
+    const ALLOWED: u32 = DESKTOP_TYPE | 0x3F;
+    if flags & !ALLOWED != 0 {
+        return Err(invalid_field_err!("fieldsPresent", "unknown desktop order flag"));
+    }
+    if flags & 1 != 0 {
+        if flags != DESKTOP_TYPE | 1 {
+            return Err(invalid_field_err!("fieldsPresent", "non-monitored desktop contains additional fields"));
+        }
+        return Ok(());
+    }
+    if flags & 8 != 0 && flags & 2 == 0 {
+        return Err(invalid_field_err!("fieldsPresent", "desktop ARC began requires hooked"));
+    }
+    if flags & 4 != 0 && flags != DESKTOP_TYPE | 4 {
+        return Err(invalid_field_err!("fieldsPresent", "desktop ARC completed contains additional fields"));
+    }
+    skip_if!(src, flags, 0x20, 4 /* ActiveWindowId */);
+    if flags & 0x10 != 0 {
+        ensure_size!(in: src, size: 1 /* NumWindowIds */);
+        let count = usize::from(src.read_u8());
+        ensure_size!(in: src, size: count * 4 /* WindowIds */);
+        src.advance(count * 4);
+    }
+    Ok(())
+}
+
+fn validate_icon(src: &mut ReadCursor<'_>) -> DecodeResult<()> {
+    ensure_size!(in: src, size: 8 /* fixed icon fields */);
+    src.advance(3);
+    let bpp = src.read_u8();
+    if !matches!(bpp, 1 | 4 | 8 | 16 | 24 | 32) {
+        return Err(invalid_field_err!("Bpp", "unsupported icon color depth"));
+    }
+    src.advance(4);
+    let color_table_len = if matches!(bpp, 1 | 4 | 8) {
+        ensure_size!(in: src, size: 2 /* CbColorTable */);
+        usize::from(src.read_u16())
+    } else {
+        0
+    };
+    ensure_size!(in: src, size: 4 /* CbBitsMask, CbBitsColor */);
+    let mask_len = usize::from(src.read_u16());
+    let color_len = usize::from(src.read_u16());
+    ensure_size!(in: src, size: color_table_len + mask_len + color_len);
+    src.advance(color_table_len + mask_len + color_len);
+    Ok(())
+}
+
+fn skip_unicode(src: &mut ReadCursor<'_>, maximum_size: usize) -> DecodeResult<()> {
+    ensure_size!(in: src, size: 2 /* CbString */);
+    let size = usize::from(src.read_u16());
+    if size % 2 != 0 || size > maximum_size {
+        return Err(invalid_field_err!("CbString", "invalid UTF-16 string length"));
+    }
+    ensure_size!(in: src, size: size);
+    let bytes = src.read_slice(size);
+    let code_units = bytes.chunks_exact(2).map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]])).collect::<Vec<_>>();
+    String::from_utf16(&code_units).map_err(|_| invalid_field_err!("String", "invalid UTF-16 string"))?;
+    Ok(())
+}
+
 /// A validated collection of Windowing Alternate Secondary Drawing Orders.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WindowingOrdersUpdate<'a> {
     pub orders: Vec<WindowingOrder<'a>>,
+    /// Whether the source update also contains drawing orders outside the
+    /// Windowing Alternate Secondary subset.
+    ///
+    /// Their framing is stateful, so they remain in the encoded update for the
+    /// consumer instead of being discarded while scanning for window orders.
+    pub contains_non_window_orders: bool,
 }
 
 /// Parses a slow-path Orders update after its `updateType` field.
 ///
-/// Returns `None` when the update contains a non-window order. Malformed
-/// window orders return an error rather than forwarding a partial prefix.
 pub fn try_decode_slow_path_windowing_orders<'a>(
     src: &mut ReadCursor<'a>,
-) -> DecodeResult<Option<WindowingOrdersUpdate<'a>>> {
+) -> DecodeResult<WindowingOrdersUpdate<'a>> {
     ensure_size!(in: src, size: 2 /* pad2OctetsA */ + 2 /* numberOrders */ + 2 /* pad2OctetsB */);
     src.advance(2);
     let order_count = usize::from(src.read_u16());
@@ -105,21 +362,22 @@ pub fn try_decode_slow_path_windowing_orders<'a>(
 
 /// Parses a Fast-Path Orders update after its Fast-Path framing.
 ///
-/// Returns `None` when the update contains a non-window order. Malformed
-/// window orders return an error rather than forwarding a partial prefix.
 pub fn try_decode_fast_path_windowing_orders<'a>(
     src: &mut ReadCursor<'a>,
-) -> DecodeResult<Option<WindowingOrdersUpdate<'a>>> {
+) -> DecodeResult<WindowingOrdersUpdate<'a>> {
     ensure_size!(in: src, size: 2 /* numberOrders */);
     let order_count = usize::from(src.read_u16());
     decode_orders(src, order_count)
 }
 
-fn decode_orders<'a>(src: &mut ReadCursor<'a>, order_count: usize) -> DecodeResult<Option<WindowingOrdersUpdate<'a>>> {
+fn decode_orders<'a>(src: &mut ReadCursor<'a>, order_count: usize) -> DecodeResult<WindowingOrdersUpdate<'a>> {
     let mut orders = Vec::with_capacity(order_count);
     for _ in 0..order_count {
         if src.remaining().first().copied() != Some(WINDOWING_ORDER_CONTROL_FLAGS) {
-            return Ok(None);
+            return Ok(WindowingOrdersUpdate {
+                orders,
+                contains_non_window_orders: true,
+            });
         }
         orders.push(WindowingOrder::decode(src)?);
     }
@@ -127,7 +385,10 @@ fn decode_orders<'a>(src: &mut ReadCursor<'a>, order_count: usize) -> DecodeResu
         return Err(invalid_field_err!("orderData", "orders update contains trailing data"));
     }
 
-    Ok(Some(WindowingOrdersUpdate { orders }))
+    Ok(WindowingOrdersUpdate {
+        orders,
+        contains_non_window_orders: false,
+    })
 }
 
 #[cfg(test)]
@@ -145,7 +406,6 @@ mod tests {
         update.extend_from_slice(&order);
 
         let orders = try_decode_slow_path_windowing_orders(&mut ReadCursor::new(&update))
-            .unwrap()
             .unwrap();
         assert_eq!(orders.orders.len(), 1);
         assert_eq!(orders.orders[0].encoded, order.as_slice());
@@ -159,7 +419,6 @@ mod tests {
         update.extend_from_slice(&order);
 
         let orders = try_decode_fast_path_windowing_orders(&mut ReadCursor::new(&update))
-            .unwrap()
             .unwrap();
         assert_eq!(orders.orders[0].encoded, order.as_slice());
     }
@@ -175,14 +434,23 @@ mod tests {
     }
 
     #[test]
-    fn skips_non_window_orders_without_partial_forwarding() {
+    fn rejects_window_order_with_truncated_optional_field() {
+        let mut order = deleted_window_order();
+        order[3..7].copy_from_slice(&(WINDOW_TYPE | 0x0000_0004 /* TITLE */).to_le_bytes());
+        let mut update = vec![1, 0];
+        update.extend_from_slice(&order);
+
+        assert!(try_decode_fast_path_windowing_orders(&mut ReadCursor::new(&update)).is_err());
+    }
+
+    #[test]
+    fn preserves_mixed_order_updates_for_consumers() {
         let mut update = vec![2, 0];
         update.extend_from_slice(&deleted_window_order());
         update.push(0);
 
-        assert_eq!(
-            try_decode_fast_path_windowing_orders(&mut ReadCursor::new(&update)).unwrap(),
-            None
-        );
+        let orders = try_decode_fast_path_windowing_orders(&mut ReadCursor::new(&update)).unwrap();
+        assert_eq!(orders.orders.len(), 1);
+        assert!(orders.contains_non_window_orders);
     }
 }

--- a/crates/ironrdp-pdu/src/basic_output/window.rs
+++ b/crates/ironrdp-pdu/src/basic_output/window.rs
@@ -166,16 +166,25 @@ fn validate_window_fields(flags: u32, src: &mut ReadCursor<'_>) -> DecodeResult<
     src.advance(4);
     if flags & DELETED != 0 {
         if flags != WINDOW_TYPE | DELETED {
-            return Err(invalid_field_err!("fieldsPresent", "deleted window order contains additional fields"));
+            return Err(invalid_field_err!(
+                "fieldsPresent",
+                "deleted window order contains additional fields"
+            ));
         }
         return Ok(());
     }
     if flags & (ICON | CACHED_ICON) != 0 {
         if flags & (ICON | CACHED_ICON) == ICON | CACHED_ICON {
-            return Err(invalid_field_err!("fieldsPresent", "window order contains both icon representations"));
+            return Err(invalid_field_err!(
+                "fieldsPresent",
+                "window order contains both icon representations"
+            ));
         }
         if flags & !(WINDOW_TYPE | 0x1000_0000 | ICON | CACHED_ICON | ICON_FLAGS) != 0 {
-            return Err(invalid_field_err!("fieldsPresent", "invalid flags for a window icon order"));
+            return Err(invalid_field_err!(
+                "fieldsPresent",
+                "invalid flags for a window icon order"
+            ));
         }
         return if flags & ICON != 0 {
             validate_icon(src)
@@ -226,21 +235,33 @@ fn validate_notification_icon_fields(flags: u32, src: &mut ReadCursor<'_>) -> De
     const CACHED_ICON: u32 = 0x8000_0000;
     const ALLOWED: u32 = NOTIFY_ICON_TYPE | 0x0000_000F | 0x1000_0000 | DELETED | ICON | CACHED_ICON;
     if flags & !ALLOWED != 0 {
-        return Err(invalid_field_err!("fieldsPresent", "unknown notification icon order flag"));
+        return Err(invalid_field_err!(
+            "fieldsPresent",
+            "unknown notification icon order flag"
+        ));
     }
     ensure_size!(in: src, size: 8 /* WindowId, NotifyIconId */);
     src.advance(8);
     if flags & DELETED != 0 {
         if flags != NOTIFY_ICON_TYPE | DELETED {
-            return Err(invalid_field_err!("fieldsPresent", "deleted notification icon contains additional fields"));
+            return Err(invalid_field_err!(
+                "fieldsPresent",
+                "deleted notification icon contains additional fields"
+            ));
         }
         return Ok(());
     }
     if flags & (ICON | CACHED_ICON) == ICON | CACHED_ICON {
-        return Err(invalid_field_err!("fieldsPresent", "notification icon contains both icon representations"));
+        return Err(invalid_field_err!(
+            "fieldsPresent",
+            "notification icon contains both icon representations"
+        ));
     }
     if flags & 0x1000_0000 != 0 && flags & (ICON | CACHED_ICON) == 0 {
-        return Err(invalid_field_err!("fieldsPresent", "new notification icon has no icon representation"));
+        return Err(invalid_field_err!(
+            "fieldsPresent",
+            "new notification icon has no icon representation"
+        ));
     }
     if flags & 0x0000_0008 != 0 {
         ensure_size!(in: src, size: 4 /* Version */);
@@ -254,7 +275,10 @@ fn validate_notification_icon_fields(flags: u32, src: &mut ReadCursor<'_>) -> De
         src.advance(4);
         let info_flags = src.read_u32();
         if info_flags & !0x33 != 0 || !matches!(info_flags & 0x0F, 0..=3) {
-            return Err(invalid_field_err!("InfoFlags", "invalid notification icon info tip flags"));
+            return Err(invalid_field_err!(
+                "InfoFlags",
+                "invalid notification icon info tip flags"
+            ));
         }
         skip_unicode(src, 510)?;
         skip_unicode(src, 126)?;
@@ -281,7 +305,10 @@ fn validate_desktop_fields(flags: u32, src: &mut ReadCursor<'_>) -> DecodeResult
     }
     if flags & 1 != 0 {
         if flags != DESKTOP_TYPE | 1 {
-            return Err(invalid_field_err!("fieldsPresent", "non-monitored desktop contains additional fields"));
+            return Err(invalid_field_err!(
+                "fieldsPresent",
+                "non-monitored desktop contains additional fields"
+            ));
         }
         return Ok(());
     }
@@ -289,7 +316,10 @@ fn validate_desktop_fields(flags: u32, src: &mut ReadCursor<'_>) -> DecodeResult
         return Err(invalid_field_err!("fieldsPresent", "desktop ARC began requires hooked"));
     }
     if flags & 4 != 0 && flags != DESKTOP_TYPE | 4 {
-        return Err(invalid_field_err!("fieldsPresent", "desktop ARC completed contains additional fields"));
+        return Err(invalid_field_err!(
+            "fieldsPresent",
+            "desktop ARC completed contains additional fields"
+        ));
     }
     skip_if!(src, flags, 0x20, 4 /* ActiveWindowId */);
     if flags & 0x10 != 0 {
@@ -331,7 +361,10 @@ fn skip_unicode(src: &mut ReadCursor<'_>, maximum_size: usize) -> DecodeResult<(
     }
     ensure_size!(in: src, size: size);
     let bytes = src.read_slice(size);
-    let code_units = bytes.chunks_exact(2).map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]])).collect::<Vec<_>>();
+    let code_units = bytes
+        .chunks_exact(2)
+        .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+        .collect::<Vec<_>>();
     String::from_utf16(&code_units).map_err(|_| invalid_field_err!("String", "invalid UTF-16 string"))?;
     Ok(())
 }
@@ -350,9 +383,7 @@ pub struct WindowingOrdersUpdate<'a> {
 
 /// Parses a slow-path Orders update after its `updateType` field.
 ///
-pub fn try_decode_slow_path_windowing_orders<'a>(
-    src: &mut ReadCursor<'a>,
-) -> DecodeResult<WindowingOrdersUpdate<'a>> {
+pub fn try_decode_slow_path_windowing_orders<'a>(src: &mut ReadCursor<'a>) -> DecodeResult<WindowingOrdersUpdate<'a>> {
     ensure_size!(in: src, size: 2 /* pad2OctetsA */ + 2 /* numberOrders */ + 2 /* pad2OctetsB */);
     src.advance(2);
     let order_count = usize::from(src.read_u16());
@@ -362,9 +393,7 @@ pub fn try_decode_slow_path_windowing_orders<'a>(
 
 /// Parses a Fast-Path Orders update after its Fast-Path framing.
 ///
-pub fn try_decode_fast_path_windowing_orders<'a>(
-    src: &mut ReadCursor<'a>,
-) -> DecodeResult<WindowingOrdersUpdate<'a>> {
+pub fn try_decode_fast_path_windowing_orders<'a>(src: &mut ReadCursor<'a>) -> DecodeResult<WindowingOrdersUpdate<'a>> {
     ensure_size!(in: src, size: 2 /* numberOrders */);
     let order_count = usize::from(src.read_u16());
     decode_orders(src, order_count)
@@ -405,8 +434,7 @@ mod tests {
         let mut update = vec![0, 0, 1, 0, 0, 0];
         update.extend_from_slice(&order);
 
-        let orders = try_decode_slow_path_windowing_orders(&mut ReadCursor::new(&update))
-            .unwrap();
+        let orders = try_decode_slow_path_windowing_orders(&mut ReadCursor::new(&update)).unwrap();
         assert_eq!(orders.orders.len(), 1);
         assert_eq!(orders.orders[0].encoded, order.as_slice());
         assert!(!orders.orders[0].requires_extended_support());
@@ -418,8 +446,7 @@ mod tests {
         let mut update = vec![1, 0];
         update.extend_from_slice(&order);
 
-        let orders = try_decode_fast_path_windowing_orders(&mut ReadCursor::new(&update))
-            .unwrap();
+        let orders = try_decode_fast_path_windowing_orders(&mut ReadCursor::new(&update)).unwrap();
         assert_eq!(orders.orders[0].encoded, order.as_slice());
     }
 
@@ -436,7 +463,7 @@ mod tests {
     #[test]
     fn rejects_window_order_with_truncated_optional_field() {
         let mut order = deleted_window_order();
-        order[3..7].copy_from_slice(&(WINDOW_TYPE | 0x0000_0004 /* TITLE */).to_le_bytes());
+        order[3..7].copy_from_slice(&(WINDOW_TYPE | 0x0000_0004/* TITLE */).to_le_bytes());
         let mut update = vec![1, 0];
         update.extend_from_slice(&order);
 

--- a/crates/ironrdp-pdu/src/basic_output/window.rs
+++ b/crates/ironrdp-pdu/src/basic_output/window.rs
@@ -1,0 +1,188 @@
+//! Windowing Alternate Secondary Drawing Orders.
+//!
+//! These orders are carried by slow-path and Fast-Path Orders updates as defined
+//! in [MS-RDPERP] section 2.2.1.3.
+//!
+//! [MS-RDPERP]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdperp
+
+use ironrdp_core::{DecodeResult, ReadCursor, ensure_size, invalid_field_err};
+
+const WINDOWING_ORDER_CONTROL_FLAGS: u8 = 0x2e;
+const ALTERNATE_SECONDARY_HEADER_SIZE: usize = 1 /* controlFlags */ + 2 /* orderSize */;
+const ORDER_FLAGS_SIZE: usize = 4 /* fieldsPresent */;
+const WINDOW_HEADER_SIZE: usize = ALTERNATE_SECONDARY_HEADER_SIZE + ORDER_FLAGS_SIZE + 4 /* windowId */;
+const NOTIFY_ICON_HEADER_SIZE: usize =
+    ALTERNATE_SECONDARY_HEADER_SIZE + ORDER_FLAGS_SIZE + 4 /* windowId */ + 4 /* notifyIconId */;
+const DESKTOP_HEADER_SIZE: usize = ALTERNATE_SECONDARY_HEADER_SIZE + ORDER_FLAGS_SIZE;
+
+const WINDOW_TYPE: u32 = 0x0100_0000;
+const NOTIFY_ICON_TYPE: u32 = 0x0200_0000;
+const DESKTOP_TYPE: u32 = 0x0400_0000;
+const ORDER_TYPE_MASK: u32 = WINDOW_TYPE | NOTIFY_ICON_TYPE | DESKTOP_TYPE;
+
+/// A validated Windowing Alternate Secondary Drawing Order.
+///
+/// The encoded data remains opaque so protocol consumers can apply their own
+/// window-management policy without coupling this layer to a presentation API.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WindowingOrder<'a> {
+    pub encoded: &'a [u8],
+    pub fields_present: u32,
+}
+
+impl<'de> WindowingOrder<'de> {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: ALTERNATE_SECONDARY_HEADER_SIZE);
+
+        let encoded = src.remaining();
+        let control_flags = src.read_u8();
+        if control_flags != WINDOWING_ORDER_CONTROL_FLAGS {
+            return Err(invalid_field_err!(
+                "controlFlags",
+                "expected a windowing alternate secondary drawing order"
+            ));
+        }
+
+        let order_size = usize::from(src.read_u16());
+        if order_size < DESKTOP_HEADER_SIZE {
+            return Err(invalid_field_err!(
+                "orderSize",
+                "order is smaller than its common header"
+            ));
+        }
+
+        ensure_size!(in: src, size: order_size - ALTERNATE_SECONDARY_HEADER_SIZE);
+        let order_data = src.read_slice(order_size - ALTERNATE_SECONDARY_HEADER_SIZE);
+        let mut order_data = ReadCursor::new(order_data);
+        ensure_size!(in: order_data, size: ORDER_FLAGS_SIZE);
+        let fields_present = order_data.read_u32();
+        let header_size = match fields_present & ORDER_TYPE_MASK {
+            WINDOW_TYPE => WINDOW_HEADER_SIZE,
+            NOTIFY_ICON_TYPE => NOTIFY_ICON_HEADER_SIZE,
+            DESKTOP_TYPE => DESKTOP_HEADER_SIZE,
+            _ => return Err(invalid_field_err!("fieldsPresent", "invalid windowing order type")),
+        };
+        if order_size < header_size {
+            return Err(invalid_field_err!(
+                "orderSize",
+                "order is smaller than its typed header"
+            ));
+        }
+
+        Ok(Self {
+            encoded: &encoded[..order_size],
+            fields_present,
+        })
+    }
+
+    /// Returns whether this order requires extended Window List support.
+    pub const fn requires_extended_support(self) -> bool {
+        self.fields_present
+            & (0x0001_0000 /* CLIENTAREASIZE */ | 0x0002_0000 /* RPCONTENT */ | 0x0004_0000/* ROOTPARENT */)
+            != 0
+    }
+}
+
+/// A validated collection of Windowing Alternate Secondary Drawing Orders.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WindowingOrdersUpdate<'a> {
+    pub orders: Vec<WindowingOrder<'a>>,
+}
+
+/// Parses a slow-path Orders update after its `updateType` field.
+///
+/// Returns `None` when the update contains a non-window order. Malformed
+/// window orders return an error rather than forwarding a partial prefix.
+pub fn try_decode_slow_path_windowing_orders<'a>(
+    src: &mut ReadCursor<'a>,
+) -> DecodeResult<Option<WindowingOrdersUpdate<'a>>> {
+    ensure_size!(in: src, size: 2 /* pad2OctetsA */ + 2 /* numberOrders */ + 2 /* pad2OctetsB */);
+    src.advance(2);
+    let order_count = usize::from(src.read_u16());
+    src.advance(2);
+    decode_orders(src, order_count)
+}
+
+/// Parses a Fast-Path Orders update after its Fast-Path framing.
+///
+/// Returns `None` when the update contains a non-window order. Malformed
+/// window orders return an error rather than forwarding a partial prefix.
+pub fn try_decode_fast_path_windowing_orders<'a>(
+    src: &mut ReadCursor<'a>,
+) -> DecodeResult<Option<WindowingOrdersUpdate<'a>>> {
+    ensure_size!(in: src, size: 2 /* numberOrders */);
+    let order_count = usize::from(src.read_u16());
+    decode_orders(src, order_count)
+}
+
+fn decode_orders<'a>(src: &mut ReadCursor<'a>, order_count: usize) -> DecodeResult<Option<WindowingOrdersUpdate<'a>>> {
+    let mut orders = Vec::with_capacity(order_count);
+    for _ in 0..order_count {
+        if src.remaining().first().copied() != Some(WINDOWING_ORDER_CONTROL_FLAGS) {
+            return Ok(None);
+        }
+        orders.push(WindowingOrder::decode(src)?);
+    }
+    if !src.eof() {
+        return Err(invalid_field_err!("orderData", "orders update contains trailing data"));
+    }
+
+    Ok(Some(WindowingOrdersUpdate { orders }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn deleted_window_order() -> [u8; 11] {
+        [WINDOWING_ORDER_CONTROL_FLAGS, 11, 0, 0, 0, 0, 0x21, 7, 0, 0, 0]
+    }
+
+    #[test]
+    fn parses_slow_path_windowing_order() {
+        let order = deleted_window_order();
+        let mut update = vec![0, 0, 1, 0, 0, 0];
+        update.extend_from_slice(&order);
+
+        let orders = try_decode_slow_path_windowing_orders(&mut ReadCursor::new(&update))
+            .unwrap()
+            .unwrap();
+        assert_eq!(orders.orders.len(), 1);
+        assert_eq!(orders.orders[0].encoded, order.as_slice());
+        assert!(!orders.orders[0].requires_extended_support());
+    }
+
+    #[test]
+    fn parses_fast_path_windowing_order() {
+        let order = deleted_window_order();
+        let mut update = vec![1, 0];
+        update.extend_from_slice(&order);
+
+        let orders = try_decode_fast_path_windowing_orders(&mut ReadCursor::new(&update))
+            .unwrap()
+            .unwrap();
+        assert_eq!(orders.orders[0].encoded, order.as_slice());
+    }
+
+    #[test]
+    fn rejects_malformed_windowing_order() {
+        let mut malformed = deleted_window_order();
+        malformed[1] = 12;
+        let mut update = vec![1, 0];
+        update.extend_from_slice(&malformed);
+
+        assert!(try_decode_fast_path_windowing_orders(&mut ReadCursor::new(&update)).is_err());
+    }
+
+    #[test]
+    fn skips_non_window_orders_without_partial_forwarding() {
+        let mut update = vec![2, 0];
+        update.extend_from_slice(&deleted_window_order());
+        update.push(0);
+
+        assert_eq!(
+            try_decode_fast_path_windowing_orders(&mut ReadCursor::new(&update)).unwrap(),
+            None
+        );
+    }
+}

--- a/crates/ironrdp-pdu/src/lib.rs
+++ b/crates/ironrdp-pdu/src/lib.rs
@@ -29,7 +29,7 @@ pub(crate) mod ber;
 pub(crate) mod crypto;
 pub(crate) mod per;
 
-pub use crate::basic_output::{bitmap, fast_path, pointer, slow_path, surface_commands};
+pub use crate::basic_output::{bitmap, fast_path, pointer, slow_path, surface_commands, window};
 
 pub type PduResult<T> = Result<T, PduError>;
 

--- a/crates/ironrdp-pdu/src/rdp/capability_sets/mod.rs
+++ b/crates/ironrdp-pdu/src/rdp/capability_sets/mod.rs
@@ -23,6 +23,7 @@ mod pointer;
 mod sound;
 mod surface_commands;
 mod virtual_channel;
+mod window_list;
 
 pub use self::bitmap::{Bitmap, BitmapDrawingFlags};
 pub use self::bitmap_cache::{
@@ -46,6 +47,7 @@ pub use self::pointer::Pointer;
 pub use self::sound::{Sound, SoundFlags};
 pub use self::surface_commands::{CmdFlags, SurfaceCommands};
 pub use self::virtual_channel::{VirtualChannel, VirtualChannelFlags};
+pub use self::window_list::{WindowList, WindowSupportLevel};
 
 pub const SERVER_CHANNEL_ID: u16 = 0x03ea;
 
@@ -278,7 +280,7 @@ pub enum CapabilitySet {
     DrawNineGridCache(Vec<u8>),
     DrawGdiPlus(Vec<u8>),
     Rail(Vec<u8>),
-    WindowList(Vec<u8>),
+    WindowList(WindowList),
     BitmapCacheV3(Vec<u8>),
 }
 
@@ -429,6 +431,14 @@ impl Encode for CapabilitySet {
                 )?);
                 capset.encode(dst)?;
             }
+            CapabilitySet::WindowList(capset) => {
+                dst.write_u16(CapabilitySetType::WindowList.as_u16());
+                dst.write_u16(cast_length!(
+                    "len",
+                    capset.size() + CAPABILITY_SET_TYPE_FIELD_SIZE + CAPABILITY_SET_LENGTH_FIELD_SIZE
+                )?);
+                capset.encode(dst)?;
+            }
             _ => {
                 let (capability_set_type, capability_set_buffer) = match self {
                     CapabilitySet::Control(buffer) => (CapabilitySetType::Control, buffer),
@@ -443,7 +453,6 @@ impl Encode for CapabilitySet {
                     CapabilitySet::DrawNineGridCache(buffer) => (CapabilitySetType::DrawNineGridCache, buffer),
                     CapabilitySet::DrawGdiPlus(buffer) => (CapabilitySetType::DrawGdiPlus, buffer),
                     CapabilitySet::Rail(buffer) => (CapabilitySetType::Rail, buffer),
-                    CapabilitySet::WindowList(buffer) => (CapabilitySetType::WindowList, buffer),
                     CapabilitySet::BitmapCacheV3(buffer) => (CapabilitySetType::BitmapCacheV3CodecID, buffer),
                     // Structured variants are routed through the outer match's
                     // specific arms above this block and cannot reach this
@@ -470,7 +479,8 @@ impl Encode for CapabilitySet {
                     | CapabilitySet::LargePointer(_)
                     | CapabilitySet::SurfaceCommands(_)
                     | CapabilitySet::BitmapCodecs(_)
-                    | CapabilitySet::FrameAcknowledge(_) => {
+                    | CapabilitySet::FrameAcknowledge(_)
+                    | CapabilitySet::WindowList(_) => {
                         unreachable!("structured variant routed to raw-buffer encoder arm")
                     }
                 };
@@ -510,6 +520,7 @@ impl Encode for CapabilitySet {
                 CapabilitySet::MultiFragmentUpdate(capset) => capset.size(),
                 CapabilitySet::LargePointer(capset) => capset.size(),
                 CapabilitySet::FrameAcknowledge(capset) => capset.size(),
+                CapabilitySet::WindowList(capset) => capset.size(),
                 CapabilitySet::Control(buffer)
                 | CapabilitySet::WindowActivation(buffer)
                 | CapabilitySet::Share(buffer)
@@ -520,7 +531,6 @@ impl Encode for CapabilitySet {
                 | CapabilitySet::DrawNineGridCache(buffer)
                 | CapabilitySet::DrawGdiPlus(buffer)
                 | CapabilitySet::Rail(buffer)
-                | CapabilitySet::WindowList(buffer)
                 | CapabilitySet::BitmapCacheV3(buffer) => buffer.len(),
             }
     }
@@ -584,7 +594,13 @@ impl<'de> Decode<'de> for CapabilitySet {
             CapabilitySetType::DrawNineGridCache => Ok(CapabilitySet::DrawNineGridCache(capability_set_buffer.into())),
             CapabilitySetType::DrawGdiPlus => Ok(CapabilitySet::DrawGdiPlus(capability_set_buffer.into())),
             CapabilitySetType::Rail => Ok(CapabilitySet::Rail(capability_set_buffer.into())),
-            CapabilitySetType::WindowList => Ok(CapabilitySet::WindowList(capability_set_buffer.into())),
+            CapabilitySetType::WindowList => {
+                if buffer_length != WindowList::FIXED_PART_SIZE {
+                    return Err(invalid_field_err!("len", "invalid window list capability set length"));
+                }
+
+                Ok(CapabilitySet::WindowList(decode(capability_set_buffer)?))
+            }
             CapabilitySetType::FrameAcknowledge => Ok(CapabilitySet::FrameAcknowledge(decode(capability_set_buffer)?)),
             CapabilitySetType::BitmapCacheV3CodecID => Ok(CapabilitySet::BitmapCacheV3(capability_set_buffer.into())),
         }

--- a/crates/ironrdp-pdu/src/rdp/capability_sets/window_list.rs
+++ b/crates/ironrdp-pdu/src/rdp/capability_sets/window_list.rs
@@ -1,0 +1,117 @@
+use ironrdp_core::{
+    Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, ensure_fixed_part_size, invalid_field_err,
+};
+
+/// [2.2.1.1.2] Window List Capability Set.
+///
+/// [2.2.1.1.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdperp
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct WindowList {
+    pub support_level: WindowSupportLevel,
+    pub num_icon_caches: u8,
+    pub num_icon_cache_entries: u16,
+}
+
+impl WindowList {
+    const NAME: &'static str = "WindowList";
+
+    pub(crate) const FIXED_PART_SIZE: usize =
+        4 /* WndSupportLevel */ + 1 /* NumIconCaches */ + 2 /* NumIconCacheEntries */;
+}
+
+impl Encode for WindowList {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_fixed_part_size!(in: dst);
+
+        dst.write_u32(self.support_level.as_u32());
+        dst.write_u8(self.num_icon_caches);
+        dst.write_u16(self.num_icon_cache_entries);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl<'de> Decode<'de> for WindowList {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let support_level = WindowSupportLevel::from_u32(src.read_u32())
+            .ok_or_else(|| invalid_field_err!("wndSupportLevel", "invalid window support level"))?;
+        let num_icon_caches = src.read_u8();
+        let num_icon_cache_entries = src.read_u16();
+
+        Ok(Self {
+            support_level,
+            num_icon_caches,
+            num_icon_cache_entries,
+        })
+    }
+}
+
+#[repr(u32)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub enum WindowSupportLevel {
+    NotSupported = 0,
+    Supported = 1,
+    SupportedEx = 2,
+}
+
+impl WindowSupportLevel {
+    fn from_u32(value: u32) -> Option<Self> {
+        match value {
+            0 => Some(Self::NotSupported),
+            1 => Some(Self::Supported),
+            2 => Some(Self::SupportedEx),
+            _ => None,
+        }
+    }
+
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
+    fn as_u32(self) -> u32 {
+        self as u32
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ironrdp_core::{decode, encode_vec};
+
+    use super::super::CapabilitySet;
+    use super::*;
+
+    const WINDOW_LIST_BUFFER: [u8; 7] = [0x02, 0x00, 0x00, 0x00, 0x03, 0x0c, 0x00];
+    const WINDOW_LIST: WindowList = WindowList {
+        support_level: WindowSupportLevel::SupportedEx,
+        num_icon_caches: 3,
+        num_icon_cache_entries: 12,
+    };
+
+    #[test]
+    fn round_trips_window_list() {
+        assert_eq!(WINDOW_LIST, decode(WINDOW_LIST_BUFFER.as_ref()).unwrap());
+        assert_eq!(WINDOW_LIST_BUFFER, encode_vec(&WINDOW_LIST).unwrap().as_slice());
+    }
+
+    #[test]
+    fn rejects_invalid_window_support_level() {
+        assert!(decode::<WindowList>(&[3, 0, 0, 0, 0, 0, 0]).is_err());
+    }
+
+    #[test]
+    fn rejects_invalid_window_list_capability_set_length() {
+        assert!(decode::<CapabilitySet>(&[0x18, 0, 0x0c, 0, 0, 0, 0, 0, 0, 0, 0, 0]).is_err());
+    }
+}

--- a/crates/ironrdp-session/src/active_stage.rs
+++ b/crates/ironrdp-session/src/active_stage.rs
@@ -645,9 +645,7 @@ fn process_slow_path_graphics(
             let Some(window_support_level) = window_support_level else {
                 return Ok((Vec::new(), None));
             };
-            let Some(orders) = try_decode_slow_path_windowing_orders(&mut src).map_err(SessionError::decode)? else {
-                return Ok((Vec::new(), None));
-            };
+            let orders = try_decode_slow_path_windowing_orders(&mut src).map_err(SessionError::decode)?;
             validate_windowing_orders_support(&orders, window_support_level)?;
             Ok((Vec::new(), Some(data.to_vec())))
         }
@@ -673,9 +671,7 @@ fn process_fast_path_windowing_orders(
     };
 
     let mut src = ReadCursor::new(data);
-    let Some(orders) = try_decode_fast_path_windowing_orders(&mut src).map_err(SessionError::decode)? else {
-        return Ok(None);
-    };
+    let orders = try_decode_fast_path_windowing_orders(&mut src).map_err(SessionError::decode)?;
     validate_windowing_orders_support(&orders, window_support_level)?;
 
     let mut normalized = Vec::with_capacity(
@@ -791,9 +787,14 @@ mod tests {
     fn window_order(fields_present: u32) -> Vec<u8> {
         let mut order = Vec::new();
         order.push(0x2e);
-        order.extend_from_slice(&11u16.to_le_bytes());
+        let client_area_size = (fields_present & 0x0001_0000 != 0).then_some([0; 8]);
+        let order_size: u16 = if client_area_size.is_some() { 19 } else { 11 };
+        order.extend_from_slice(&order_size.to_le_bytes());
         order.extend_from_slice(&fields_present.to_le_bytes());
         order.extend_from_slice(&7u32.to_le_bytes());
+        if let Some(client_area_size) = client_area_size {
+            order.extend_from_slice(&client_area_size);
+        }
         order
     }
 
@@ -853,7 +854,7 @@ mod tests {
 
     #[test]
     fn extended_windowing_orders_require_extended_support() {
-        let update = slow_path_orders_update(&window_order(0x2101_0000));
+        let update = slow_path_orders_update(&window_order(0x0101_0000));
         let mut processor = fast_path::ProcessorBuilder {
             io_channel_id: 0,
             user_channel_id: 0,

--- a/crates/ironrdp-session/src/active_stage.rs
+++ b/crates/ironrdp-session/src/active_stage.rs
@@ -9,6 +9,7 @@ use ironrdp_pdu::gcc::ChannelName;
 use ironrdp_pdu::geometry::InclusiveRectangle;
 use ironrdp_pdu::input::fast_path::{FastPathInput, FastPathInputEvent};
 use ironrdp_pdu::rdp::autodetect::AutoDetectRequest;
+use ironrdp_pdu::rdp::capability_sets::WindowSupportLevel;
 use ironrdp_pdu::rdp::client_info::CompressionType;
 use ironrdp_pdu::rdp::headers::ShareDataPdu;
 use ironrdp_pdu::rdp::multitransport::MultitransportRequestPdu;
@@ -16,9 +17,12 @@ use ironrdp_pdu::rdp::refresh_rectangle::RefreshRectanglePdu;
 use ironrdp_pdu::rdp::session_info::ServerAutoReconnect;
 use ironrdp_pdu::rdp::suppress_output::SuppressOutputPdu;
 use ironrdp_pdu::slow_path::{self, GraphicsUpdateType};
+use ironrdp_pdu::window::{
+    WindowingOrdersUpdate, try_decode_fast_path_windowing_orders, try_decode_slow_path_windowing_orders,
+};
 use ironrdp_pdu::{Action, mcs};
 use ironrdp_svc::{StaticChannelSet, SvcMessage, SvcProcessor, SvcProcessorMessages};
-use tracing::{debug, warn};
+use tracing::debug;
 
 use crate::fast_path::UpdateKind;
 use crate::image::DecodedImage;
@@ -39,6 +43,7 @@ pub struct ActiveStage {
     /// Shared server-to-client compression history across all output transports.
     bulk_decompressor: Option<BulkCompressor>,
     enable_server_pointer: bool,
+    window_support_level: Option<WindowSupportLevel>,
 }
 
 /// Builder for [`ActiveStage`].
@@ -94,6 +99,7 @@ impl ActiveStageBuilder {
             fast_path_processor,
             bulk_decompressor: new_bulk_decompressor(compression_type),
             enable_server_pointer,
+            window_support_level: None,
         }
     }
 }
@@ -187,8 +193,16 @@ impl ActiveStage {
                 for output in x224_outputs {
                     match output {
                         x224::ProcessorOutput::GraphicsUpdate(data) => {
-                            let updates = process_slow_path_graphics(&mut self.fast_path_processor, image, &data)?;
+                            let (updates, windowing_orders) = process_slow_path_graphics(
+                                &mut self.fast_path_processor,
+                                image,
+                                self.window_support_level,
+                                &data,
+                            )?;
                             processor_updates.extend(updates);
+                            if let Some(windowing_orders) = windowing_orders {
+                                stage_outputs.push(ActiveStageOutput::WindowingOrders(windowing_orders));
+                            }
                         }
                         x224::ProcessorOutput::PointerUpdate(data) => {
                             let updates = process_slow_path_pointer(&mut self.fast_path_processor, image, &data)?;
@@ -207,6 +221,13 @@ impl ActiveStage {
         for update in processor_updates {
             match update {
                 UpdateKind::None => {}
+                UpdateKind::Orders(data) => {
+                    if let Some(windowing_orders) =
+                        process_fast_path_windowing_orders(self.window_support_level, &data)?
+                    {
+                        stage_outputs.push(ActiveStageOutput::WindowingOrders(windowing_orders));
+                    }
+                }
                 UpdateKind::Region(region) => {
                     stage_outputs.push(ActiveStageOutput::GraphicsUpdate(region));
                 }
@@ -256,6 +277,13 @@ impl ActiveStage {
 
     pub fn set_enable_server_pointer(&mut self, enable_server_pointer: bool) {
         self.enable_server_pointer = enable_server_pointer;
+    }
+
+    /// Sets Window List support for the current activation.
+    ///
+    /// `None` preserves desktop-session behavior by ignoring drawing orders.
+    pub fn set_window_support_level(&mut self, window_support_level: Option<WindowSupportLevel>) {
+        self.window_support_level = window_support_level;
     }
 
     /// Rebuilds the fast-path processor for a [Deactivation-Reactivation Sequence].
@@ -493,6 +521,11 @@ pub enum ActiveStageOutput {
         y: u16,
     },
     PointerBitmap(Arc<DecodedPointer>),
+    /// Validated Windowing Alternate Secondary Drawing Orders.
+    ///
+    /// The payload is a complete slow-path Orders graphics update. It remains
+    /// protocol data rather than a RAIL message.
+    WindowingOrders(Vec<u8>),
     Terminate(GracefulDisconnectReason),
     /// Server Save Session Info notification ([MS-RDPBCGR] 2.2.10.1).
     ///
@@ -595,31 +628,80 @@ impl core::fmt::Display for GracefulDisconnectReason {
 fn process_slow_path_graphics(
     fast_path_processor: &mut fast_path::Processor,
     image: &mut DecodedImage,
+    window_support_level: Option<WindowSupportLevel>,
     data: &[u8],
-) -> SessionResult<Vec<UpdateKind>> {
+) -> SessionResult<(Vec<UpdateKind>, Option<Vec<u8>>)> {
     let mut src = ReadCursor::new(data);
     let update_type = slow_path::read_graphics_update_type(&mut src).map_err(SessionError::decode)?;
 
     match update_type {
         GraphicsUpdateType::Bitmap => {
             let bitmap = slow_path::decode_slow_path_bitmap(&mut src).map_err(SessionError::decode)?;
-            fast_path_processor.process_bitmap_update(image, bitmap)
+            fast_path_processor
+                .process_bitmap_update(image, bitmap)
+                .map(|updates| (updates, None))
         }
         GraphicsUpdateType::Orders => {
-            warn!("Slow-path drawing orders not supported (MS-RDPEGDI)");
-            Ok(Vec::new())
+            let Some(window_support_level) = window_support_level else {
+                return Ok((Vec::new(), None));
+            };
+            let Some(orders) = try_decode_slow_path_windowing_orders(&mut src).map_err(SessionError::decode)? else {
+                return Ok((Vec::new(), None));
+            };
+            validate_windowing_orders_support(&orders, window_support_level)?;
+            Ok((Vec::new(), Some(data.to_vec())))
         }
         GraphicsUpdateType::Palette => {
             fast_path_processor.process_palette_update(data);
-            Ok(Vec::new())
+            Ok((Vec::new(), None))
         }
         // Synchronize is an artifact from the T.128 multipoint protocol
         // and carries no data. Safe to ignore.
         GraphicsUpdateType::Synchronize => {
             debug!("Ignoring slow-path synchronize update");
-            Ok(Vec::new())
+            Ok((Vec::new(), None))
         }
     }
+}
+
+fn process_fast_path_windowing_orders(
+    window_support_level: Option<WindowSupportLevel>,
+    data: &[u8],
+) -> SessionResult<Option<Vec<u8>>> {
+    let Some(window_support_level) = window_support_level else {
+        return Ok(None);
+    };
+
+    let mut src = ReadCursor::new(data);
+    let Some(orders) = try_decode_fast_path_windowing_orders(&mut src).map_err(SessionError::decode)? else {
+        return Ok(None);
+    };
+    validate_windowing_orders_support(&orders, window_support_level)?;
+
+    let mut normalized = Vec::with_capacity(
+        2 /* updateType */ + 2 /* pad2OctetsA */ + data.len() + 2, /* pad2OctetsB */
+    );
+    normalized.extend_from_slice(&0u16.to_le_bytes());
+    normalized.extend_from_slice(&0u16.to_le_bytes());
+    normalized.extend_from_slice(&data[..2]);
+    normalized.extend_from_slice(&0u16.to_le_bytes());
+    normalized.extend_from_slice(&data[2..]);
+    Ok(Some(normalized))
+}
+
+fn validate_windowing_orders_support(
+    orders: &WindowingOrdersUpdate<'_>,
+    window_support_level: WindowSupportLevel,
+) -> SessionResult<()> {
+    if window_support_level == WindowSupportLevel::SupportedEx
+        || !orders.orders.iter().any(|order| order.requires_extended_support())
+    {
+        return Ok(());
+    }
+
+    Err(SessionError::general(
+        "received extended window order fields without negotiated extended window support",
+    ))
 }
 
 /// Parse and process a slow-path pointer update through the shared pointer pipeline.
@@ -679,9 +761,11 @@ mod tests {
         .build();
         let mut image = DecodedImage::new(PixelFormat::RgbA32, 1, 1);
 
-        let palette_updates = process_slow_path_graphics(&mut processor, &mut image, &palette_data)
-            .expect("slow-path palette update should succeed");
+        let (palette_updates, windowing_orders) =
+            process_slow_path_graphics(&mut processor, &mut image, None, &palette_data)
+                .expect("slow-path palette update should succeed");
         assert!(palette_updates.is_empty());
+        assert!(windowing_orders.is_none());
 
         let pointer = PointerAttribute {
             xor_bpp: 8,
@@ -702,5 +786,96 @@ mod tests {
             panic!("expected an accelerated pointer bitmap");
         };
         assert_eq!(pointer.bitmap_data, [0x10, 0x20, 0x30, 0xff]);
+    }
+
+    fn window_order(fields_present: u32) -> Vec<u8> {
+        let mut order = Vec::new();
+        order.push(0x2e);
+        order.extend_from_slice(&11u16.to_le_bytes());
+        order.extend_from_slice(&fields_present.to_le_bytes());
+        order.extend_from_slice(&7u32.to_le_bytes());
+        order
+    }
+
+    fn slow_path_orders_update(order: &[u8]) -> Vec<u8> {
+        let mut update = Vec::new();
+        update.extend_from_slice(&0u16.to_le_bytes());
+        update.extend_from_slice(&0u16.to_le_bytes());
+        update.extend_from_slice(&1u16.to_le_bytes());
+        update.extend_from_slice(&0u16.to_le_bytes());
+        update.extend_from_slice(order);
+        update
+    }
+
+    #[test]
+    fn slow_path_windowing_orders_require_negotiated_support() {
+        let mut processor = fast_path::ProcessorBuilder {
+            io_channel_id: 0,
+            user_channel_id: 0,
+            share_id: 0,
+            enable_server_pointer: false,
+            pointer_software_rendering: false,
+        }
+        .build();
+        let mut image = DecodedImage::new(PixelFormat::RgbA32, 1, 1);
+        let update = slow_path_orders_update(&window_order(0x2100_0000));
+
+        let (_, orders) = process_slow_path_graphics(&mut processor, &mut image, None, &update).unwrap();
+        assert!(orders.is_none());
+
+        let (_, orders) =
+            process_slow_path_graphics(&mut processor, &mut image, Some(WindowSupportLevel::Supported), &update)
+                .unwrap();
+        assert_eq!(orders.as_deref(), Some(update.as_slice()));
+    }
+
+    #[test]
+    fn fast_path_windowing_orders_are_normalized_for_forwarding() {
+        let order = window_order(0x2100_0000);
+        let mut update = Vec::new();
+        update.extend_from_slice(&1u16.to_le_bytes());
+        update.extend_from_slice(&order);
+
+        let normalized = process_fast_path_windowing_orders(Some(WindowSupportLevel::Supported), &update)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            normalized,
+            [
+                0, 0, // updateType
+                0, 0, // pad2OctetsA
+                1, 0, // numberOrders
+                0, 0, // pad2OctetsB
+                0x2e, 11, 0, 0, 0, 0, 0x21, 7, 0, 0, 0,
+            ]
+        );
+    }
+
+    #[test]
+    fn extended_windowing_orders_require_extended_support() {
+        let update = slow_path_orders_update(&window_order(0x2101_0000));
+        let mut processor = fast_path::ProcessorBuilder {
+            io_channel_id: 0,
+            user_channel_id: 0,
+            share_id: 0,
+            enable_server_pointer: false,
+            pointer_software_rendering: false,
+        }
+        .build();
+        let mut image = DecodedImage::new(PixelFormat::RgbA32, 1, 1);
+
+        assert!(
+            process_slow_path_graphics(&mut processor, &mut image, Some(WindowSupportLevel::Supported), &update)
+                .is_err()
+        );
+        assert!(
+            process_slow_path_graphics(
+                &mut processor,
+                &mut image,
+                Some(WindowSupportLevel::SupportedEx),
+                &update
+            )
+            .is_ok()
+        );
     }
 }

--- a/crates/ironrdp-session/src/fast_path.rs
+++ b/crates/ironrdp-session/src/fast_path.rs
@@ -114,6 +114,7 @@ impl FastPathBulkDecompressionFailure {
 #[derive(Debug)]
 pub enum UpdateKind {
     None,
+    Orders(Vec<u8>),
     Region(InclusiveRectangle),
     PointerDefault,
     PointerHidden,
@@ -248,6 +249,10 @@ impl Processor {
         let update = FastPathUpdate::decode_with_code(data.as_slice(), attributes.update_code);
 
         match update {
+            Ok(FastPathUpdate::Orders(orders)) => {
+                trace!("Received Fast-Path Orders update");
+                processor_updates.push(UpdateKind::Orders(orders.to_vec()));
+            }
             Ok(FastPathUpdate::SurfaceCommands(surface_commands)) => {
                 trace!("Received Surface Commands: {} pieces", surface_commands.len());
                 let update_region = self.process_surface_commands(image, output, surface_commands)?;

--- a/crates/ironrdp-testsuite-core/src/capsets.rs
+++ b/crates/ironrdp-testsuite-core/src/capsets.rs
@@ -2,7 +2,8 @@ use std::sync::LazyLock;
 
 use ironrdp_core::decode;
 use ironrdp_pdu::rdp::capability_sets::{
-    CapabilitySet, ClientConfirmActive, DemandActive, SERVER_CHANNEL_ID, ServerDemandActive,
+    CapabilitySet, ClientConfirmActive, DemandActive, SERVER_CHANNEL_ID, ServerDemandActive, WindowList,
+    WindowSupportLevel,
 };
 
 pub const SERVER_DEMAND_ACTIVE_BUFFER: [u8; 357] = [
@@ -281,7 +282,11 @@ pub static SERVER_DEMAND_ACTIVE: LazyLock<ServerDemandActive> = LazyLock::new(||
             CapabilitySet::Pointer(decode(SERVER_POINTER_CAPABILITY_SET.as_ref()).unwrap()),
             CapabilitySet::Input(decode(SERVER_INPUT_CAPABILITY_SET.as_ref()).unwrap()),
             CapabilitySet::Rail(SERVER_RAIL_CAPABILITY_SET.to_vec()),
-            CapabilitySet::WindowList(SERVER_WINDOW_LIST_CAPABILITY_SET.to_vec()),
+            CapabilitySet::WindowList(WindowList {
+                support_level: WindowSupportLevel::NotSupported,
+                num_icon_caches: 0,
+                num_icon_cache_entries: 0,
+            }),
         ],
     },
 });
@@ -315,7 +320,11 @@ pub static CLIENT_DEMAND_ACTIVE_WITH_INCOMPLETE_CAPABILITY_SET: LazyLock<ClientC
                 CapabilitySet::MultiFragmentUpdate(
                     decode(CLIENT_MULTI_FRAGMENT_UPDATE_CAPABILITY_SET.as_ref()).unwrap(),
                 ),
-                CapabilitySet::WindowList(CLIENT_WINDOW_LIST_CAPABILITY_SET.to_vec()),
+                CapabilitySet::WindowList(WindowList {
+                    support_level: WindowSupportLevel::Supported,
+                    num_icon_caches: 3,
+                    num_icon_cache_entries: 12,
+                }),
             ],
         },
     });

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -1034,6 +1034,7 @@ impl iron_remote_desktop::Session for Session {
                                 enable_server_pointer,
                                 pointer_software_rendering,
                                 static_channel_chunk_size,
+                                window_support_level,
                                 ..
                             } = connection_activation.connection_activation_state()
                             {
@@ -1049,6 +1050,7 @@ impl iron_remote_desktop::Session for Session {
                                 ) {
                                     return Err(IronError::from(anyhow::anyhow!("invalid static channel chunk size")));
                                 }
+                                active_stage.set_window_support_level(window_support_level);
                                 break 'activation_seq;
                             }
                         }

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -1000,6 +1000,9 @@ impl iron_remote_desktop::Session for Session {
                             hotspot_y,
                         })?;
                     }
+                    ActiveStageOutput::WindowingOrders(_) => {
+                        // Windowing orders are not meaningful to the protocol-agnostic web component.
+                    }
                     ActiveStageOutput::DeactivateAll => {
                         // Execute the Deactivation-Reactivation Sequence:
                         // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/dfc234ce-481a-4674-9a5d-2a7bafb14432

--- a/ffi/dotnet/Devolutions.IronRdp.AvaloniaExample/MainWindow.axaml.cs
+++ b/ffi/dotnet/Devolutions.IronRdp.AvaloniaExample/MainWindow.axaml.cs
@@ -533,6 +533,7 @@ public partial class MainWindow : Window
                         var enableServerPointer = finalized.GetEnableServerPointer();
                         var pointerSoftwareRendering = finalized.GetPointerSoftwareRendering();
                         var staticChannelChunkSize = finalized.GetStaticChannelChunkSize();
+                        var windowSupportLevel = finalized.GetWindowSupportLevel();
 
                         _decodedImage = DecodedImage.New(PixelFormat.RgbA32, desktopSize.GetWidth(),
                             desktopSize.GetHeight());
@@ -543,7 +544,8 @@ public partial class MainWindow : Window
                             shareId,
                             enableServerPointer,
                             pointerSoftwareRendering,
-                            staticChannelChunkSize
+                            staticChannelChunkSize,
+                            windowSupportLevel
                         );
 
                         _activeStage.SetEnableServerPointer(enableServerPointer);

--- a/ffi/dotnet/Devolutions.IronRdp/Generated/ActiveStage.cs
+++ b/ffi/dotnet/Devolutions.IronRdp/Generated/ActiveStage.cs
@@ -337,7 +337,7 @@ public partial class ActiveStage: IDisposable
     /// and static channel chunk size.
     /// </remarks>
     /// <exception cref="IronRdpException"></exception>
-    public void Reactivate(ushort ioChannelId, ushort userChannelId, uint shareId, bool enableServerPointer, bool pointerSoftwareRendering, nuint staticChannelChunkSize)
+    public void Reactivate(ushort ioChannelId, ushort userChannelId, uint shareId, bool enableServerPointer, bool pointerSoftwareRendering, nuint staticChannelChunkSize, sbyte windowSupportLevel)
     {
         unsafe
         {
@@ -345,7 +345,7 @@ public partial class ActiveStage: IDisposable
             {
                 throw new ObjectDisposedException("ActiveStage");
             }
-            Raw.SessionFfiResultVoidBoxIronRdpError result = Raw.ActiveStage.Reactivate(_inner, ioChannelId, userChannelId, shareId, enableServerPointer, pointerSoftwareRendering, staticChannelChunkSize);
+            Raw.SessionFfiResultVoidBoxIronRdpError result = Raw.ActiveStage.Reactivate(_inner, ioChannelId, userChannelId, shareId, enableServerPointer, pointerSoftwareRendering, staticChannelChunkSize, windowSupportLevel);
             if (!result.isOk)
             {
                 throw new IronRdpException(new IronRdpError(result.Err));

--- a/ffi/dotnet/Devolutions.IronRdp/Generated/ActiveStageOutput.cs
+++ b/ffi/dotnet/Devolutions.IronRdp/Generated/ActiveStageOutput.cs
@@ -79,6 +79,14 @@ public partial class ActiveStageOutput: IDisposable
         }
     }
 
+    public BytesSlice WindowingOrders
+    {
+        get
+        {
+            return GetWindowingOrders();
+        }
+    }
+
     /// <summary>
     /// Creates a managed <c>ActiveStageOutput</c> from a raw handle.
     /// </summary>
@@ -194,6 +202,28 @@ public partial class ActiveStageOutput: IDisposable
             }
             Raw.DecodedPointer* retVal = result.Ok;
             return new DecodedPointer(retVal);
+        }
+    }
+
+    /// <exception cref="IronRdpException"></exception>
+    /// <returns>
+    /// A <c>BytesSlice</c> allocated on Rust side.
+    /// </returns>
+    public BytesSlice GetWindowingOrders()
+    {
+        unsafe
+        {
+            if (_inner == null)
+            {
+                throw new ObjectDisposedException("ActiveStageOutput");
+            }
+            Raw.SessionFfiResultBoxBytesSliceBoxIronRdpError result = Raw.ActiveStageOutput.GetWindowingOrders(_inner);
+            if (!result.isOk)
+            {
+                throw new IronRdpException(new IronRdpError(result.Err));
+            }
+            Raw.BytesSlice* retVal = result.Ok;
+            return new BytesSlice(retVal);
         }
     }
 

--- a/ffi/dotnet/Devolutions.IronRdp/Generated/ActiveStageOutputType.cs
+++ b/ffi/dotnet/Devolutions.IronRdp/Generated/ActiveStageOutputType.cs
@@ -28,4 +28,7 @@ public enum ActiveStageOutputType
     /// RTT and bandwidth values for connection quality monitoring.
     /// </summary>
     AutoDetect = 9,
+    SaveSessionInfo = 10,
+    AutoReconnectCookie = 11,
+    WindowingOrders = 12,
 }

--- a/ffi/dotnet/Devolutions.IronRdp/Generated/ConnectionActivationStateFinalized.cs
+++ b/ffi/dotnet/Devolutions.IronRdp/Generated/ConnectionActivationStateFinalized.cs
@@ -55,6 +55,14 @@ public partial class ConnectionActivationStateFinalized: IDisposable
         }
     }
 
+    public sbyte WindowSupportLevel
+    {
+        get
+        {
+            return GetWindowSupportLevel();
+        }
+    }
+
     /// <summary>
     /// Creates a managed <c>ConnectionActivationStateFinalized</c> from a raw handle.
     /// </summary>
@@ -133,6 +141,23 @@ public partial class ConnectionActivationStateFinalized: IDisposable
                 throw new ObjectDisposedException("ConnectionActivationStateFinalized");
             }
             nuint retVal = Raw.ConnectionActivationStateFinalized.GetStaticChannelChunkSize(_inner);
+            return retVal;
+        }
+    }
+
+    /// <summary>
+    /// Returns -1 when Window List support was not negotiated, otherwise
+    /// the negotiated Window List support level.
+    /// </summary>
+    public sbyte GetWindowSupportLevel()
+    {
+        unsafe
+        {
+            if (_inner == null)
+            {
+                throw new ObjectDisposedException("ConnectionActivationStateFinalized");
+            }
+            sbyte retVal = Raw.ConnectionActivationStateFinalized.GetWindowSupportLevel(_inner);
             return retVal;
         }
     }

--- a/ffi/dotnet/Devolutions.IronRdp/Generated/RawActiveStage.cs
+++ b/ffi/dotnet/Devolutions.IronRdp/Generated/RawActiveStage.cs
@@ -65,7 +65,7 @@ public partial struct ActiveStage
     /// and static channel chunk size.
     /// </remarks>
     [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ActiveStage_reactivate", ExactSpelling = true)]
-    public static unsafe extern SessionFfiResultVoidBoxIronRdpError Reactivate(ActiveStage* self, ushort ioChannelId, ushort userChannelId, uint shareId, [MarshalAs(UnmanagedType.U1)] bool enableServerPointer, [MarshalAs(UnmanagedType.U1)] bool pointerSoftwareRendering, nuint staticChannelChunkSize);
+    public static unsafe extern SessionFfiResultVoidBoxIronRdpError Reactivate(ActiveStage* self, ushort ioChannelId, ushort userChannelId, uint shareId, [MarshalAs(UnmanagedType.U1)] bool enableServerPointer, [MarshalAs(UnmanagedType.U1)] bool pointerSoftwareRendering, nuint staticChannelChunkSize, sbyte windowSupportLevel);
 
     [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ActiveStage_set_enable_server_pointer", ExactSpelling = true)]
     public static unsafe extern void SetEnableServerPointer(ActiveStage* self, [MarshalAs(UnmanagedType.U1)] bool enableServerPointer);

--- a/ffi/dotnet/Devolutions.IronRdp/Generated/RawActiveStageOutput.cs
+++ b/ffi/dotnet/Devolutions.IronRdp/Generated/RawActiveStageOutput.cs
@@ -31,6 +31,9 @@ public partial struct ActiveStageOutput
     [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ActiveStageOutput_get_pointer_bitmap", ExactSpelling = true)]
     public static unsafe extern SessionFfiResultBoxDecodedPointerBoxIronRdpError GetPointerBitmap(ActiveStageOutput* self);
 
+    [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ActiveStageOutput_get_windowing_orders", ExactSpelling = true)]
+    public static unsafe extern SessionFfiResultBoxBytesSliceBoxIronRdpError GetWindowingOrders(ActiveStageOutput* self);
+
     [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ActiveStageOutput_get_terminate", ExactSpelling = true)]
     public static unsafe extern SessionFfiResultBoxGracefulDisconnectReasonBoxIronRdpError GetTerminate(ActiveStageOutput* self);
 

--- a/ffi/dotnet/Devolutions.IronRdp/Generated/RawActiveStageOutputType.cs
+++ b/ffi/dotnet/Devolutions.IronRdp/Generated/RawActiveStageOutputType.cs
@@ -28,4 +28,7 @@ public enum ActiveStageOutputType
     /// RTT and bandwidth values for connection quality monitoring.
     /// </summary>
     AutoDetect = 9,
+    SaveSessionInfo = 10,
+    AutoReconnectCookie = 11,
+    WindowingOrders = 12,
 }

--- a/ffi/dotnet/Devolutions.IronRdp/Generated/RawConnectionActivationStateFinalized.cs
+++ b/ffi/dotnet/Devolutions.IronRdp/Generated/RawConnectionActivationStateFinalized.cs
@@ -33,6 +33,13 @@ public partial struct ConnectionActivationStateFinalized
     [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ConnectionActivationStateFinalized_get_static_channel_chunk_size", ExactSpelling = true)]
     public static unsafe extern nuint GetStaticChannelChunkSize(ConnectionActivationStateFinalized* self);
 
+    /// <summary>
+    /// Returns -1 when Window List support was not negotiated, otherwise
+    /// the negotiated Window List support level.
+    /// </summary>
+    [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ConnectionActivationStateFinalized_get_window_support_level", ExactSpelling = true)]
+    public static unsafe extern sbyte GetWindowSupportLevel(ConnectionActivationStateFinalized* self);
+
     [DllImport(NativeLib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "ConnectionActivationStateFinalized_destroy", ExactSpelling = true)]
     public static unsafe extern void Destroy(ConnectionActivationStateFinalized* self);
 }

--- a/ffi/src/connector/activation.rs
+++ b/ffi/src/connector/activation.rs
@@ -104,6 +104,7 @@ pub mod ffi {
                     enable_server_pointer,
                     pointer_software_rendering,
                     static_channel_chunk_size,
+                    window_support_level,
                     ..
                 } => Ok(Box::new(ConnectionActivationStateFinalized {
                     share_id: *share_id,
@@ -111,6 +112,7 @@ pub mod ffi {
                     enable_server_pointer: *enable_server_pointer,
                     pointer_software_rendering: *pointer_software_rendering,
                     static_channel_chunk_size: *static_channel_chunk_size,
+                    window_support_level: *window_support_level,
                 })),
                 _ => Err(IncorrectEnumTypeError::on_variant("Finalized")
                     .of_enum("ConnectionActivationState")
@@ -138,6 +140,7 @@ pub mod ffi {
         pub enable_server_pointer: bool,
         pub pointer_software_rendering: bool,
         pub static_channel_chunk_size: usize,
+        pub window_support_level: Option<ironrdp::pdu::rdp::capability_sets::WindowSupportLevel>,
     }
 
     impl ConnectionActivationStateFinalized {
@@ -159,6 +162,17 @@ pub mod ffi {
 
         pub fn get_static_channel_chunk_size(&self) -> usize {
             self.static_channel_chunk_size
+        }
+
+        /// Returns -1 when Window List support was not negotiated, otherwise
+        /// the negotiated Window List support level.
+        pub fn get_window_support_level(&self) -> i8 {
+            match self.window_support_level {
+                None => -1,
+                Some(ironrdp::pdu::rdp::capability_sets::WindowSupportLevel::Supported) => 1,
+                Some(ironrdp::pdu::rdp::capability_sets::WindowSupportLevel::SupportedEx) => 2,
+                Some(ironrdp::pdu::rdp::capability_sets::WindowSupportLevel::NotSupported) => 0,
+            }
         }
     }
 }

--- a/ffi/src/session/mod.rs
+++ b/ffi/src/session/mod.rs
@@ -211,6 +211,10 @@ pub mod ffi {
         ///
         /// This retains negotiated bulk compression and applies the refreshed server-pointer state
         /// and static channel chunk size.
+        #[expect(
+            clippy::too_many_arguments,
+            reason = "the C-compatible reactivation entry point exposes the negotiated activation fields"
+        )]
         pub fn reactivate(
             &mut self,
             io_channel_id: u16,
@@ -219,7 +223,14 @@ pub mod ffi {
             enable_server_pointer: bool,
             pointer_software_rendering: bool,
             static_channel_chunk_size: usize,
+            window_support_level: i8,
         ) -> Result<(), Box<IronRdpError>> {
+            let window_support_level = match window_support_level {
+                -1 => None,
+                1 => Some(ironrdp::pdu::rdp::capability_sets::WindowSupportLevel::Supported),
+                2 => Some(ironrdp::pdu::rdp::capability_sets::WindowSupportLevel::SupportedEx),
+                _ => return Err("invalid Window List support level".into()),
+            };
             if !self.0.reactivate(
                 io_channel_id,
                 user_channel_id,
@@ -230,6 +241,7 @@ pub mod ffi {
             ) {
                 return Err("invalid static channel chunk size".into());
             }
+            self.0.set_window_support_level(window_support_level);
 
             Ok(())
         }

--- a/ffi/src/session/mod.rs
+++ b/ffi/src/session/mod.rs
@@ -49,7 +49,8 @@ pub mod ffi {
             // Retain the factory to drive the Deactivation-Reactivation Sequence.
             let activation_factory = connection_result.activation_factory;
 
-            let stage = ironrdp::session::ActiveStageBuilder {
+            let window_support_level = connection_result.window_support_level;
+            let mut stage = ironrdp::session::ActiveStageBuilder {
                 static_channels: connection_result.static_channels,
                 user_channel_id: connection_result.user_channel_id,
                 io_channel_id: connection_result.io_channel_id,
@@ -60,6 +61,7 @@ pub mod ffi {
                 pointer_software_rendering: connection_result.pointer_software_rendering,
             }
             .build();
+            stage.set_window_support_level(window_support_level);
 
             Ok(Box::new(ActiveStage(stage, activation_factory)))
         }
@@ -238,21 +240,22 @@ pub mod ffi {
     }
 
     pub enum ActiveStageOutputType {
-        ResponseFrame,
-        GraphicsUpdate,
-        PointerDefault,
-        PointerHidden,
-        PointerPosition,
-        PointerBitmap,
-        Terminate,
-        DeactivateAll,
-        MultitransportRequest,
+        ResponseFrame = 0,
+        GraphicsUpdate = 1,
+        PointerDefault = 2,
+        PointerHidden = 3,
+        PointerPosition = 4,
+        PointerBitmap = 5,
+        Terminate = 6,
+        DeactivateAll = 7,
+        MultitransportRequest = 8,
         /// Auto-detect network characteristics from server.
         /// Use `get_autodetect_network_characteristics()` to retrieve
         /// RTT and bandwidth values for connection quality monitoring.
-        AutoDetect,
-        SaveSessionInfo,
-        AutoReconnectCookie,
+        AutoDetect = 9,
+        SaveSessionInfo = 10,
+        AutoReconnectCookie = 11,
+        WindowingOrders = 12,
     }
 
     impl ActiveStageOutput {
@@ -264,6 +267,7 @@ pub mod ffi {
                 ironrdp::session::ActiveStageOutput::PointerHidden => ActiveStageOutputType::PointerHidden,
                 ironrdp::session::ActiveStageOutput::PointerPosition { .. } => ActiveStageOutputType::PointerPosition,
                 ironrdp::session::ActiveStageOutput::PointerBitmap { .. } => ActiveStageOutputType::PointerBitmap,
+                ironrdp::session::ActiveStageOutput::WindowingOrders(_) => ActiveStageOutputType::WindowingOrders,
                 ironrdp::session::ActiveStageOutput::Terminate { .. } => ActiveStageOutputType::Terminate,
                 ironrdp::session::ActiveStageOutput::DeactivateAll => ActiveStageOutputType::DeactivateAll,
                 ironrdp::session::ActiveStageOutput::MultitransportRequest { .. } => {
@@ -316,6 +320,15 @@ pub mod ffi {
                     .into()),
             }
             .map(Box::new)
+        }
+
+        pub fn get_windowing_orders(&self) -> Result<Box<BytesSlice<'_>>, Box<IronRdpError>> {
+            match &self.0 {
+                ironrdp::session::ActiveStageOutput::WindowingOrders(orders) => Ok(Box::new(BytesSlice(orders))),
+                _ => Err(IncorrectEnumTypeError::on_variant("WindowingOrders")
+                    .of_enum("ActiveStageOutput")
+                    .into()),
+            }
         }
 
         pub fn get_terminate(&self) -> Result<Box<GracefulDisconnectReason>, Box<IronRdpError>> {


### PR DESCRIPTION
Preserve Window List support during activation.
Forward validated orders through ActiveStage and the raw FFI output.
Desktop and web consumers retain their existing behavior.