### PR TITLE
feat(daemon): retain more session log lines

### DIFF
--- a/crates/ironrdp-daemon/src/logbuf.rs
+++ b/crates/ironrdp-daemon/src/logbuf.rs
@@ -20,7 +20,7 @@ use tracing_subscriber::Layer;
 use tracing_subscriber::layer::Context;
 
 /// Default ring-buffer capacity, in lines.
-const DEFAULT_CAPACITY: usize = 100;
+const DEFAULT_CAPACITY: usize = 4_096;
 
 /// A bounded ring buffer of formatted log lines.
 pub struct LogBuffer {


### PR DESCRIPTION
Increase the session formatted-log ring buffer from 100 to 4,096 lines so longer troubleshooting sessions remain queryable.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>