### PR TITLE
feat(client): add RemoteApp channel support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2551,6 +2551,7 @@ dependencies = [
  "ironrdp-mstsgu",
  "ironrdp-pdu",
  "ironrdp-propertyset",
+ "ironrdp-rail",
  "ironrdp-rdcleanpath",
  "ironrdp-rdpdr",
  "ironrdp-rdpsnd",

--- a/crates/ironrdp-cfg/src/lib.rs
+++ b/crates/ironrdp-cfg/src/lib.rs
@@ -299,6 +299,13 @@ pub trait PropertySetExt {
     /// Removes the `alternate shell` property.
     fn clear_alternate_shell(&mut self);
 
+    /// Whether the `.rdp` file requests RemoteApp mode (`remoteapplicationmode`).
+    fn remote_application_mode(&self) -> Option<bool>;
+    /// Sets the `remoteapplicationmode` property.
+    fn set_remote_application_mode(&mut self, value: bool);
+    /// Removes the `remoteapplicationmode` property.
+    fn clear_remote_application_mode(&mut self);
+
     /// Audio output redirection mode (`audiomode`).
     fn audio_mode(&self) -> Result<Option<AudioMode>, UnknownAudioMode>;
     /// Sets the `audiomode` property.
@@ -617,6 +624,18 @@ impl PropertySetExt for PropertySet {
 
     fn clear_alternate_shell(&mut self) {
         self.remove("alternate shell");
+    }
+
+    fn remote_application_mode(&self) -> Option<bool> {
+        self.get::<bool>("remoteapplicationmode")
+    }
+
+    fn set_remote_application_mode(&mut self, value: bool) {
+        self.insert("remoteapplicationmode", value);
+    }
+
+    fn clear_remote_application_mode(&mut self) {
+        self.remove("remoteapplicationmode");
     }
 
     fn audio_mode(&self) -> Result<Option<AudioMode>, UnknownAudioMode> {

--- a/crates/ironrdp-client/Cargo.toml
+++ b/crates/ironrdp-client/Cargo.toml
@@ -69,6 +69,7 @@ ironrdp-rdcleanpath = { path = "../ironrdp-rdcleanpath", version = "0.2" }
 ironrdp-vmconnect = { path = "../ironrdp-vmconnect", version = "0.1", optional = true }
 ironrdp-cfg = { path = "../ironrdp-cfg", version = "0.1" }
 ironrdp-propertyset = { path = "../ironrdp-propertyset", version = "0.1" } # public
+ironrdp-rail = { path = "../ironrdp-rail", version = "0.1" }
 
 # Optional protocol crates (activated by features above)
 ironrdp-cliprdr = { path = "../ironrdp-cliprdr", version = "0.7", optional = true } # public

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -627,6 +627,8 @@ pub struct ConfigBuilder {
     compression_enabled: Option<bool>,
     alternate_shell: Option<String>,
     work_dir: Option<String>,
+    remote_application_mode: Option<bool>,
+    rail_support_level: Option<ironrdp_pdu::rdp::capability_sets::RailSupportLevel>,
 
     transport: TransportKind,
     #[cfg(feature = "vmconnect")]
@@ -877,6 +879,30 @@ impl ConfigBuilder {
             self.properties.set_shell_working_directory(work_dir.clone());
             self.work_dir = Some(work_dir);
         }
+        self
+    }
+
+    /// Enable or disable RemoteApp/RAIL connection mode.
+    ///
+    /// RemoteApp launch information is sent on the RAIL static virtual channel
+    /// rather than through the Client Info Alternate Shell field.
+    #[must_use]
+    pub fn with_remote_application_mode(mut self, enabled: bool) -> Self {
+        self.properties.set_remote_application_mode(enabled);
+        self.remote_application_mode = Some(enabled);
+        self
+    }
+
+    /// Declares the RAIL capabilities implemented by this client.
+    ///
+    /// RemoteApp mode requires
+    /// [`RailSupportLevel::SUPPORTED`](ironrdp_pdu::rdp::capability_sets::RailSupportLevel::SUPPORTED).
+    #[must_use]
+    pub fn with_rail_support_level(
+        mut self,
+        support_level: ironrdp_pdu::rdp::capability_sets::RailSupportLevel,
+    ) -> Self {
+        self.rail_support_level = Some(support_level);
         self
     }
 
@@ -1424,6 +1450,16 @@ impl ConfigBuilder {
             self.enable_credssp.unwrap_or(true)
         };
 
+        let remote_application_mode = self.remote_application_mode.unwrap_or(false);
+        let rail_support_level = self
+            .rail_support_level
+            .unwrap_or(ironrdp_pdu::rdp::capability_sets::RailSupportLevel::SUPPORTED);
+        if remote_application_mode
+            && !rail_support_level.contains(ironrdp_pdu::rdp::capability_sets::RailSupportLevel::SUPPORTED)
+        {
+            anyhow::bail!("RAIL support level must include remote programs support when RemoteApp mode is enabled");
+        }
+
         let connector = ironrdp_connector::Config {
             credentials: ironrdp_connector::Credentials::UsernamePassword {
                 username: self.username.unwrap_or_default(),
@@ -1467,6 +1503,8 @@ impl ConfigBuilder {
             timezone_info: TimezoneInfo::default(),
             alternate_shell: self.alternate_shell.unwrap_or_default(),
             work_dir: self.work_dir.unwrap_or_default(),
+            remote_application_mode,
+            rail_support_level,
         };
 
         // To avoid easily leaking secrets, strip any known secret property before returning the resulting Config.
@@ -1568,6 +1606,9 @@ impl ConfigBuilder {
         }
         if let Some(dir) = ps.shell_working_directory() {
             self.work_dir = Some(dir.to_owned());
+        }
+        if let Some(remote_application_mode) = ps.remote_application_mode() {
+            self.remote_application_mode = Some(remote_application_mode);
         }
         if let Some(minutes) = ps.fake_events_interval() {
             self.fake_events_interval = Some(Duration::from_secs(u64::from(minutes) * 60));
@@ -1776,4 +1817,45 @@ fn kerberos_config_from_properties(
             kdc_proxy_url: Some(url),
             hostname: client_name.to_owned(),
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use ironrdp_cfg::PropertySetExt as _;
+    use ironrdp_pdu::rdp::capability_sets::{MajorPlatformType, RailSupportLevel};
+
+    use super::{ConfigBuilder, Destination};
+
+    fn complete_builder() -> ConfigBuilder {
+        ConfigBuilder::new()
+            .with_destination(Destination::new("server.example:3389").unwrap())
+            .with_username("user")
+            .with_password("password")
+            .with_client_build(1)
+            .with_client_dir("C:\\")
+            .with_platform(MajorPlatformType::WINDOWS)
+            .with_client_name("client")
+    }
+
+    #[test]
+    fn remote_application_mode_requires_remote_programs_support() {
+        let error = complete_builder()
+            .with_remote_application_mode(true)
+            .with_rail_support_level(RailSupportLevel::empty())
+            .build()
+            .expect_err("RemoteApp must require remote programs support");
+
+        assert!(error.to_string().contains("RAIL support level"), "{error:?}");
+    }
+
+    #[test]
+    fn remote_application_mode_is_preserved_in_properties() {
+        let config = complete_builder()
+            .with_remote_application_mode(true)
+            .build()
+            .expect("valid RemoteApp configuration");
+
+        assert!(config.connector().remote_application_mode);
+        assert_eq!(config.properties().remote_application_mode(), Some(true));
+    }
 }

--- a/crates/ironrdp-client/src/lib.rs
+++ b/crates/ironrdp-client/src/lib.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::cast_sign_loss)]
 
 pub mod config;
+pub mod rail;
 pub mod rdp;
 
 #[cfg(all(windows, feature = "clipboard"))]

--- a/crates/ironrdp-client/src/rail.rs
+++ b/crates/ironrdp-client/src/rail.rs
@@ -190,6 +190,11 @@ impl RailClient {
             if self.queued_pdus.len() >= Self::MAX_QUEUED_PDUS {
                 return Err(Self::resource_limit_error("queued RAIL PDUs"));
             }
+            if matches!(&pdu, QueuedRailPdu::Execute(_))
+                && self.pending_executes.len() + self.queued_execute_count() >= Self::MAX_PENDING_EXECUTES
+            {
+                return Err(Self::resource_limit_error("RAIL execute requests"));
+            }
             self.queued_pdus.push_back(pdu);
             return Ok(Vec::new().into());
         }
@@ -244,13 +249,16 @@ impl RailClient {
         .collect()
     }
 
-    fn finish_handshake(&mut self, handshake_ex_flags: Option<u32>) -> PduResult<Vec<SvcMessage>> {
-        self.state = RailState::Established;
-        let queued_execute_count = self
-            .queued_pdus
+    fn queued_execute_count(&self) -> usize {
+        self.queued_pdus
             .iter()
             .filter(|pdu| matches!(pdu, QueuedRailPdu::Execute(_)))
-            .count();
+            .count()
+    }
+
+    fn finish_handshake(&mut self, handshake_ex_flags: Option<u32>) -> PduResult<Vec<SvcMessage>> {
+        self.state = RailState::Established;
+        let queued_execute_count = self.queued_execute_count();
         let mut messages = self.initialization_messages();
         self.push_event(RailEvent::Handshake {
             handshake_ex_flags,
@@ -561,6 +569,39 @@ mod tests {
                 }
             ]
         ));
+    }
+
+    #[test]
+    fn queued_executes_do_not_exceed_pending_limit() {
+        let mut client = RailClient::new(1, 1, 1);
+        for _ in 0..RailClient::MAX_PENDING_EXECUTES {
+            client
+                .queue_execute(ExecutePdu {
+                    flags: 0,
+                    executable: "app".to_owned(),
+                    working_directory: String::new(),
+                    arguments: String::new(),
+                })
+                .unwrap();
+        }
+
+        assert!(
+            client
+                .queue_execute(ExecutePdu {
+                    flags: 0,
+                    executable: "app".to_owned(),
+                    working_directory: String::new(),
+                    arguments: String::new(),
+                })
+                .is_err()
+        );
+
+        client
+            .process(&encode_vec(&RailPdu::Handshake(HandshakePdu { build_number: 1 })).unwrap())
+            .unwrap();
+        let messages: Vec<_> = client.complete_desktop_synchronization().unwrap().into();
+
+        assert_eq!(messages.len(), RailClient::MAX_PENDING_EXECUTES);
     }
 
     #[test]

--- a/crates/ironrdp-client/src/rail.rs
+++ b/crates/ironrdp-client/src/rail.rs
@@ -1,0 +1,596 @@
+use std::collections::VecDeque;
+
+use ironrdp_core::{AsAny, decode};
+use ironrdp_pdu::gcc::{ChannelName, ChannelOptions};
+use ironrdp_pdu::{PduError, PduErrorExt as _, PduErrorKind, PduResult, decode_err};
+use ironrdp_rail::pdu::{
+    ActivatePdu, ClientStatusPdu, ClientSystemParameter, ClientSystemParametersPdu, CloakPdu, CompartmentInfoPdu,
+    ExecutePdu, ExecuteResultPdu, GetApplicationIdRequestPdu, GetApplicationIdResponseExPdu,
+    GetApplicationIdResponsePdu, HandshakeExPdu, HandshakePdu, LanguageBarInfoPdu, NotifyEventPdu,
+    PowerDisplayRequestPdu, RailPdu, ServerSystemParametersPdu, SystemCommandPdu, SystemMenuPdu,
+    SystemParameterRectangle, ZOrderSyncPdu,
+};
+use ironrdp_svc::{ChannelFlags, SvcClientProcessor, SvcMessage, SvcProcessor, SvcProcessorMessages};
+
+/// Client-originated RAIL events used by the initial RemoteApp launch flow.
+///
+/// Other client-valid RAIL PDUs, including window move and IME controls, are
+/// not yet exposed through this host-neutral boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RailInputEvent {
+    Activate(ActivatePdu),
+    SystemMenu(SystemMenuPdu),
+    SystemCommand(SystemCommandPdu),
+    NotifyEvent(NotifyEventPdu),
+    GetApplicationId(GetApplicationIdRequestPdu),
+}
+
+impl From<RailInputEvent> for RailPdu {
+    fn from(event: RailInputEvent) -> Self {
+        match event {
+            RailInputEvent::Activate(pdu) => Self::Activate(pdu),
+            RailInputEvent::SystemMenu(pdu) => Self::SystemMenu(pdu),
+            RailInputEvent::SystemCommand(pdu) => Self::SystemCommand(pdu),
+            RailInputEvent::NotifyEvent(pdu) => Self::NotifyEvent(pdu),
+            RailInputEvent::GetApplicationId(pdu) => Self::GetApplicationIdRequest(pdu),
+        }
+    }
+}
+
+/// Portable server-originated RAIL controls.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RailControlEvent {
+    SystemParameters(ServerSystemParametersPdu),
+    LanguageBar(LanguageBarInfoPdu),
+    Compartment(CompartmentInfoPdu),
+    ZOrderSync(ZOrderSyncPdu),
+    Cloak(CloakPdu),
+    PowerDisplayRequest(PowerDisplayRequestPdu),
+}
+
+/// Events emitted by a client-side RAIL channel processor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RailEvent {
+    Handshake {
+        handshake_ex_flags: Option<u32>,
+        initialization_message_count: usize,
+        queued_execute_count: usize,
+    },
+    DesktopSynchronized {
+        released_execute_count: usize,
+    },
+    PostHandshakeQueueReleased {
+        released_execute_count: usize,
+    },
+    ExecuteResult(ExecuteResultPdu),
+    ApplicationId {
+        window_id: u32,
+        application_id: String,
+        process_id: Option<u32>,
+        process_image_name: Option<String>,
+    },
+    Control(RailControlEvent),
+}
+
+/// PDUs emitted by [`RailClient`].
+pub type RailSvcMessages = SvcProcessorMessages<RailClient>;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum RailState {
+    WaitingForHandshake,
+    Established,
+}
+
+#[derive(Debug)]
+enum QueuedRailPdu {
+    Execute(ExecutePdu),
+    Input(RailInputEvent),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct PendingExecute {
+    flags: u16,
+    executable: String,
+}
+
+/// Client-side processor for the RAIL static virtual channel.
+#[derive(Debug)]
+pub struct RailClient {
+    build_number: u32,
+    desktop_width: u16,
+    desktop_height: u16,
+    state: RailState,
+    desktop_synchronized: bool,
+    queued_pdus: VecDeque<QueuedRailPdu>,
+    pending_executes: VecDeque<PendingExecute>,
+    events: VecDeque<RailEvent>,
+}
+
+impl RailClient {
+    const CHANNEL_NAME: ChannelName = ChannelName::from_static(b"rail\0\0\0\0");
+    const MAX_QUEUED_PDUS: usize = 128;
+    const MAX_PENDING_EXECUTES: usize = 64;
+    const MAX_EVENTS: usize = 256;
+
+    /// Creates a RAIL static-channel processor for the client's build and desktop size.
+    pub fn new(build_number: u32, desktop_width: u16, desktop_height: u16) -> Self {
+        Self {
+            build_number,
+            desktop_width,
+            desktop_height,
+            state: RailState::WaitingForHandshake,
+            desktop_synchronized: false,
+            queued_pdus: VecDeque::new(),
+            pending_executes: VecDeque::new(),
+            events: VecDeque::new(),
+        }
+    }
+
+    /// Queues a RemoteApp launch until initialization and desktop synchronization complete.
+    pub fn queue_execute(&mut self, execute: ExecutePdu) -> PduResult<RailSvcMessages> {
+        self.queue_pdu(QueuedRailPdu::Execute(execute))
+    }
+
+    /// Queues a client-originated RAIL input event.
+    pub fn queue_input(&mut self, event: RailInputEvent) -> PduResult<RailSvcMessages> {
+        self.queue_pdu(QueuedRailPdu::Input(event))
+    }
+
+    /// Releases queued RAIL input after the server completes desktop synchronization.
+    pub fn complete_desktop_synchronization(&mut self) -> PduResult<RailSvcMessages> {
+        if self.desktop_synchronized {
+            return Ok(Vec::new().into());
+        }
+
+        self.desktop_synchronized = true;
+        if !self.is_established() {
+            return Ok(Vec::new().into());
+        }
+
+        let (messages, released_execute_count) = self.drain_queued_pdus()?;
+        self.push_event(RailEvent::DesktopSynchronized { released_execute_count })?;
+        Ok(messages.into())
+    }
+
+    /// Releases queued input after initialization when desktop synchronization is not observable.
+    pub fn release_queued_after_handshake(&mut self) -> PduResult<RailSvcMessages> {
+        if self.desktop_synchronized || !self.is_established() {
+            return Ok(Vec::new().into());
+        }
+
+        self.desktop_synchronized = true;
+        let (messages, released_execute_count) = self.drain_queued_pdus()?;
+        self.push_event(RailEvent::PostHandshakeQueueReleased { released_execute_count })?;
+        Ok(messages.into())
+    }
+
+    /// Updates the RAIL work area after the client desktop size changes.
+    pub fn update_desktop_size(&mut self, desktop_width: u16, desktop_height: u16) -> RailSvcMessages {
+        self.desktop_width = desktop_width;
+        self.desktop_height = desktop_height;
+        if !self.is_established() {
+            return Vec::new().into();
+        }
+
+        self.desktop_system_parameter_messages().into()
+    }
+
+    /// Returns and clears server events accumulated while processing channel PDUs.
+    pub fn take_events(&mut self) -> Vec<RailEvent> {
+        self.events.drain(..).collect()
+    }
+
+    const fn is_established(&self) -> bool {
+        matches!(self.state, RailState::Established)
+    }
+
+    fn queue_pdu(&mut self, pdu: QueuedRailPdu) -> PduResult<RailSvcMessages> {
+        Self::validate_queued_pdu(&pdu)?;
+        if !self.is_established() || !self.desktop_synchronized {
+            if self.queued_pdus.len() >= Self::MAX_QUEUED_PDUS {
+                return Err(Self::resource_limit_error("queued RAIL PDUs"));
+            }
+            self.queued_pdus.push_back(pdu);
+            return Ok(Vec::new().into());
+        }
+
+        Ok(self.send_pdu(pdu)?.into())
+    }
+
+    fn initialization_messages(&self) -> Vec<SvcMessage> {
+        let mut messages = vec![
+            Self::service_message(RailPdu::Handshake(HandshakePdu {
+                build_number: self.build_number,
+            })),
+            Self::service_message(RailPdu::ClientStatus(ClientStatusPdu {
+                flags: ClientStatusPdu::Z_ORDER_SYNC
+                    | ClientStatusPdu::POWER_DISPLAY_REQUEST
+                    | ClientStatusPdu::BIDIRECTIONAL_CLOAK,
+            })),
+        ];
+        messages.extend(self.desktop_system_parameter_messages());
+        messages.extend([
+            Self::service_message(RailPdu::ClientSystemParameters(ClientSystemParametersPdu {
+                parameter: ClientSystemParameter::FullWindowDrag(false),
+            })),
+            Self::service_message(RailPdu::ClientSystemParameters(ClientSystemParametersPdu {
+                parameter: ClientSystemParameter::KeyboardCues(false),
+            })),
+            Self::service_message(RailPdu::ClientSystemParameters(ClientSystemParametersPdu {
+                parameter: ClientSystemParameter::KeyboardPreference(false),
+            })),
+            Self::service_message(RailPdu::ClientSystemParameters(ClientSystemParametersPdu {
+                parameter: ClientSystemParameter::MouseButtonSwap(false),
+            })),
+        ]);
+        messages
+    }
+
+    fn desktop_system_parameter_messages(&self) -> Vec<SvcMessage> {
+        let screen = SystemParameterRectangle {
+            left: 0,
+            top: 0,
+            right: self.desktop_width,
+            bottom: self.desktop_height,
+        };
+        [
+            ClientSystemParameter::DisplayChange(screen),
+            ClientSystemParameter::WorkArea(screen),
+        ]
+        .into_iter()
+        .map(|parameter| {
+            Self::service_message(RailPdu::ClientSystemParameters(ClientSystemParametersPdu { parameter }))
+        })
+        .collect()
+    }
+
+    fn finish_handshake(&mut self, handshake_ex_flags: Option<u32>) -> PduResult<Vec<SvcMessage>> {
+        self.state = RailState::Established;
+        let queued_execute_count = self
+            .queued_pdus
+            .iter()
+            .filter(|pdu| matches!(pdu, QueuedRailPdu::Execute(_)))
+            .count();
+        let mut messages = self.initialization_messages();
+        self.push_event(RailEvent::Handshake {
+            handshake_ex_flags,
+            initialization_message_count: messages.len(),
+            queued_execute_count,
+        })?;
+        if self.desktop_synchronized {
+            let (queued_messages, released_execute_count) = self.drain_queued_pdus()?;
+            messages.extend(queued_messages);
+            self.push_event(RailEvent::DesktopSynchronized { released_execute_count })?;
+        }
+        Ok(messages)
+    }
+
+    fn send_pdu(&mut self, pdu: QueuedRailPdu) -> PduResult<Vec<SvcMessage>> {
+        match pdu {
+            QueuedRailPdu::Execute(execute) => {
+                if self.pending_executes.len() >= Self::MAX_PENDING_EXECUTES {
+                    return Err(Self::resource_limit_error("pending RAIL execute requests"));
+                }
+                self.pending_executes.push_back(PendingExecute {
+                    flags: execute.flags,
+                    executable: execute.executable.clone(),
+                });
+                Ok(vec![Self::service_message(RailPdu::Execute(execute))])
+            }
+            QueuedRailPdu::Input(event) => Ok(vec![Self::service_message(RailPdu::from(event))]),
+        }
+    }
+
+    fn drain_queued_pdus(&mut self) -> PduResult<(Vec<SvcMessage>, usize)> {
+        let mut messages = Vec::new();
+        let mut released_execute_count = 0;
+        while let Some(pdu) = self.queued_pdus.pop_front() {
+            if matches!(pdu, QueuedRailPdu::Execute(_)) {
+                released_execute_count += 1;
+            }
+            messages.extend(self.send_pdu(pdu)?);
+        }
+        Ok((messages, released_execute_count))
+    }
+
+    fn push_event(&mut self, event: RailEvent) -> PduResult<()> {
+        if self.events.len() >= Self::MAX_EVENTS {
+            return Err(Self::resource_limit_error("queued RAIL events"));
+        }
+        self.events.push_back(event);
+        Ok(())
+    }
+
+    fn validate_queued_pdu(pdu: &QueuedRailPdu) -> PduResult<()> {
+        let pdu = match pdu {
+            QueuedRailPdu::Execute(execute) => RailPdu::Execute(execute.clone()),
+            QueuedRailPdu::Input(event) => RailPdu::from(*event),
+        };
+        pdu.validate()
+            .map_err(|error| PduError::encode("RAIL client request", error))
+    }
+
+    fn service_message(pdu: RailPdu) -> SvcMessage {
+        SvcMessage::from(pdu).with_flags(ChannelFlags::SHOW_PROTOCOL)
+    }
+
+    fn resource_limit_error(description: &'static str) -> PduError {
+        PduError::new("RAIL", PduErrorKind::Other { description })
+    }
+}
+
+impl SvcClientProcessor for RailClient {}
+
+impl AsAny for RailClient {
+    fn as_any(&self) -> &dyn core::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn core::any::Any {
+        self
+    }
+}
+
+impl SvcProcessor for RailClient {
+    fn channel_name(&self) -> ChannelName {
+        Self::CHANNEL_NAME
+    }
+
+    fn channel_options(&self) -> ChannelOptions {
+        ChannelOptions::INITIALIZED | ChannelOptions::SHOW_PROTOCOL
+    }
+
+    fn process(&mut self, payload: &[u8]) -> PduResult<Vec<SvcMessage>> {
+        let pdu = decode::<RailPdu>(payload).map_err(|error| decode_err!(error))?;
+        if self.is_established() && !pdu.is_server_to_client() {
+            return Err(PduError::new(
+                "RAIL",
+                PduErrorKind::Other {
+                    description: "received client-originated RAIL PDU from server",
+                },
+            ));
+        }
+
+        match (self.state, pdu) {
+            (RailState::WaitingForHandshake, RailPdu::Handshake(HandshakePdu { .. })) => self.finish_handshake(None),
+            (RailState::WaitingForHandshake, RailPdu::HandshakeEx(HandshakeExPdu { flags, .. })) => {
+                self.finish_handshake(Some(flags))
+            }
+            (RailState::WaitingForHandshake, _) => Err(PduError::new(
+                "RAIL",
+                PduErrorKind::Other {
+                    description: "received RAIL PDU before server handshake",
+                },
+            )),
+            (RailState::Established, RailPdu::Handshake(_) | RailPdu::HandshakeEx(_)) => Err(PduError::new(
+                "RAIL",
+                PduErrorKind::Other {
+                    description: "received duplicate RAIL server handshake",
+                },
+            )),
+            (RailState::Established, RailPdu::ExecuteResult(result)) => {
+                let Some(index) = self
+                    .pending_executes
+                    .iter()
+                    .position(|request| request.flags == result.flags && request.executable == result.executable)
+                else {
+                    return Err(PduError::new(
+                        "RAIL",
+                        PduErrorKind::Other {
+                            description: "received unmatched RAIL execute result",
+                        },
+                    ));
+                };
+                self.pending_executes.remove(index);
+                self.push_event(RailEvent::ExecuteResult(result))?;
+                Ok(Vec::new())
+            }
+            (
+                RailState::Established,
+                RailPdu::GetApplicationIdResponse(GetApplicationIdResponsePdu {
+                    window_id,
+                    application_id,
+                }),
+            ) => {
+                self.push_event(RailEvent::ApplicationId {
+                    window_id,
+                    application_id,
+                    process_id: None,
+                    process_image_name: None,
+                })?;
+                Ok(Vec::new())
+            }
+            (
+                RailState::Established,
+                RailPdu::GetApplicationIdResponseEx(GetApplicationIdResponseExPdu {
+                    window_id,
+                    application_id,
+                    process_id,
+                    process_image_name,
+                }),
+            ) => {
+                self.push_event(RailEvent::ApplicationId {
+                    window_id,
+                    application_id,
+                    process_id: Some(process_id),
+                    process_image_name: Some(process_image_name),
+                })?;
+                Ok(Vec::new())
+            }
+            (RailState::Established, RailPdu::ServerSystemParameters(parameters)) => {
+                self.push_event(RailEvent::Control(RailControlEvent::SystemParameters(parameters)))?;
+                Ok(Vec::new())
+            }
+            (RailState::Established, RailPdu::LanguageBarInfo(info)) => {
+                self.push_event(RailEvent::Control(RailControlEvent::LanguageBar(info)))?;
+                Ok(Vec::new())
+            }
+            (RailState::Established, RailPdu::CompartmentInfo(info)) => {
+                self.push_event(RailEvent::Control(RailControlEvent::Compartment(info)))?;
+                Ok(Vec::new())
+            }
+            (RailState::Established, RailPdu::ZOrderSync(sync)) => {
+                self.push_event(RailEvent::Control(RailControlEvent::ZOrderSync(sync)))?;
+                Ok(Vec::new())
+            }
+            (RailState::Established, RailPdu::Cloak(cloak)) => {
+                self.push_event(RailEvent::Control(RailControlEvent::Cloak(cloak)))?;
+                Ok(Vec::new())
+            }
+            (RailState::Established, RailPdu::PowerDisplayRequest(request)) => {
+                self.push_event(RailEvent::Control(RailControlEvent::PowerDisplayRequest(request)))?;
+                Ok(Vec::new())
+            }
+            (RailState::Established, _) => Ok(Vec::new()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ironrdp_core::{decode, encode_vec};
+    use ironrdp_rail::pdu::{
+        ClientStatusPdu, ClientSystemParameter, ClientSystemParametersPdu, ExecutePdu, HandshakePdu, RailPdu,
+        SystemParameterRectangle,
+    };
+    use ironrdp_svc::SvcProcessor as _;
+
+    use super::{RailClient, RailEvent};
+
+    #[test]
+    fn queued_execute_is_released_after_handshake_fallback() {
+        let mut client = RailClient::new(1, 1024, 768);
+        client
+            .queue_execute(ExecutePdu {
+                flags: 0,
+                executable: "app".to_owned(),
+                working_directory: String::new(),
+                arguments: String::new(),
+            })
+            .unwrap();
+        client
+            .process(&encode_vec(&RailPdu::Handshake(HandshakePdu { build_number: 1 })).unwrap())
+            .unwrap();
+
+        let messages: Vec<_> = client.release_queued_after_handshake().unwrap().into();
+        assert_eq!(messages.len(), 1);
+        assert!(matches!(
+            decode::<RailPdu>(&messages[0].encode_unframed_pdu().unwrap()).unwrap(),
+            RailPdu::Execute(_)
+        ));
+        assert!(matches!(
+            client.take_events().as_slice(),
+            [
+                RailEvent::Handshake {
+                    queued_execute_count: 1,
+                    ..
+                },
+                RailEvent::PostHandshakeQueueReleased {
+                    released_execute_count: 1
+                }
+            ]
+        ));
+    }
+
+    #[test]
+    fn server_cannot_send_client_input() {
+        let mut client = RailClient::new(1, 1, 1);
+        client
+            .process(&encode_vec(&RailPdu::Handshake(HandshakePdu { build_number: 1 })).unwrap())
+            .unwrap();
+
+        assert!(
+            client
+                .process(
+                    &encode_vec(&RailPdu::Execute(ExecutePdu {
+                        flags: 0,
+                        executable: "app".to_owned(),
+                        working_directory: String::new(),
+                        arguments: String::new(),
+                    }))
+                    .unwrap()
+                )
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn handshake_advertises_supported_server_controls() {
+        let mut client = RailClient::new(1, 1, 1);
+        let messages = client
+            .process(&encode_vec(&RailPdu::Handshake(HandshakePdu { build_number: 1 })).unwrap())
+            .unwrap();
+
+        assert!(matches!(
+                decode::<RailPdu>(&messages[1].encode_unframed_pdu().unwrap()).unwrap(),
+                RailPdu::ClientStatus(ClientStatusPdu { flags })
+                    if flags
+                        == ClientStatusPdu::Z_ORDER_SYNC
+                            | ClientStatusPdu::POWER_DISPLAY_REQUEST
+                            | ClientStatusPdu::BIDIRECTIONAL_CLOAK
+        ));
+    }
+
+    #[test]
+    fn desktop_synchronization_releases_queued_execute() {
+        let mut client = RailClient::new(1, 1, 1);
+        client
+            .queue_execute(ExecutePdu {
+                flags: 0,
+                executable: "app".to_owned(),
+                working_directory: String::new(),
+                arguments: String::new(),
+            })
+            .unwrap();
+        client
+            .process(&encode_vec(&RailPdu::Handshake(HandshakePdu { build_number: 1 })).unwrap())
+            .unwrap();
+
+        let messages: Vec<_> = client.complete_desktop_synchronization().unwrap().into();
+
+        assert!(matches!(
+            decode::<RailPdu>(&messages[0].encode_unframed_pdu().unwrap()).unwrap(),
+            RailPdu::Execute(_)
+        ));
+        assert!(matches!(
+            client.take_events().as_slice(),
+            [
+                RailEvent::Handshake { .. },
+                RailEvent::DesktopSynchronized {
+                    released_execute_count: 1
+                }
+            ]
+        ));
+    }
+
+    #[test]
+    fn desktop_size_update_sends_display_change_and_work_area() {
+        let mut client = RailClient::new(1, 1, 1);
+        client
+            .process(&encode_vec(&RailPdu::Handshake(HandshakePdu { build_number: 1 })).unwrap())
+            .unwrap();
+
+        let messages: Vec<_> = client.update_desktop_size(1024, 768).into();
+
+        assert!(matches!(
+            decode::<RailPdu>(&messages[0].encode_unframed_pdu().unwrap()).unwrap(),
+            RailPdu::ClientSystemParameters(ClientSystemParametersPdu {
+                parameter: ClientSystemParameter::DisplayChange(SystemParameterRectangle {
+                    right: 1024,
+                    bottom: 768,
+                    ..
+                })
+            })
+        ));
+        assert!(matches!(
+            decode::<RailPdu>(&messages[1].encode_unframed_pdu().unwrap()).unwrap(),
+            RailPdu::ClientSystemParameters(ClientSystemParametersPdu {
+                parameter: ClientSystemParameter::WorkArea(SystemParameterRectangle {
+                    right: 1024,
+                    bottom: 768,
+                    ..
+                })
+            })
+        ));
+    }
+}

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -23,8 +23,10 @@ use ironrdp_pdu::input::mouse::PointerFlags;
 use ironrdp_pdu::pdu_other_err;
 #[cfg(feature = "rdpdr")]
 pub use ironrdp_rdpdr::backend::{RdpdrBackendFactory, RdpdrBackendFactoryResult, RdpdrBackendProduct, RdpdrDrive};
+#[cfg(any(feature = "clipboard", feature = "rdpdr"))]
+use ironrdp_session::ActiveStage;
 use ironrdp_session::image::DecodedImage;
-use ironrdp_session::{ActiveStage, ActiveStageBuilder, ActiveStageOutput, GracefulDisconnectReason, SessionResult};
+use ironrdp_session::{ActiveStageBuilder, ActiveStageOutput, GracefulDisconnectReason, SessionResult};
 use ironrdp_svc::SvcMessage;
 use ironrdp_tokio::reqwest::ReqwestNetworkClient;
 use ironrdp_tokio::{FramedWrite, single_sequence_step_read, split_tokio_framed};
@@ -48,6 +50,8 @@ use ironrdp_dvc_pipe_proxy::DvcNamedPipeProxy;
 use ironrdp_rdpsnd_native::cpal;
 
 use crate::config::{Config, RDCleanPathConfig, Transport};
+use crate::rail::{RailClient, RailControlEvent, RailEvent, RailInputEvent};
+use ironrdp_rail::pdu::{ExecutePdu, ExecuteResultPdu};
 
 // ── Public event types ────────────────────────────────────────────────────────
 
@@ -83,6 +87,31 @@ pub enum RdpOutputEvent {
         y: u16,
     },
     PointerBitmap(Arc<DecodedPointer>),
+    /// The server completed the RAIL static-channel handshake.
+    RailHandshake {
+        handshake_ex_flags: Option<u32>,
+        initialization_message_count: usize,
+        queued_execute_count: usize,
+    },
+    /// Queued RAIL input was released after server desktop synchronization.
+    RailDesktopSynchronized {
+        released_execute_count: usize,
+    },
+    /// Queued RAIL input was released after the post-handshake fallback delay.
+    RailPostHandshakeQueueReleased {
+        released_execute_count: usize,
+    },
+    /// The server completed a RemoteApp launch request.
+    RailExecuteResult(ExecuteResultPdu),
+    /// The server supplied an application identity for a remote window.
+    RailApplicationId {
+        window_id: u32,
+        application_id: String,
+        process_id: Option<u32>,
+        process_image_name: Option<String>,
+    },
+    /// A portable server-originated RAIL control for the embedding host.
+    RailControl(RailControlEvent),
     /// A full-desktop redraw was requested after the initial logon notification.
     PostLogonDisplayRedraw,
     /// A malformed bitmap update was discarded and a capability-gated full redraw was sent.
@@ -115,6 +144,10 @@ pub enum RdpInputEvent {
         channel_name: ChannelName,
         data: Vec<u8>,
     },
+    /// Requests a RemoteApp launch over the RAIL static channel.
+    RailExecute(ExecutePdu),
+    /// Queues a client-originated RAIL input event.
+    Rail(RailInputEvent),
 }
 
 /// Maximum number of ordinary input events retained while the session is unable to process them.
@@ -185,6 +218,16 @@ impl RdpInputSender {
     /// the input event is guaranteed to fit in the bounded queue.
     pub fn try_reserve(&self) -> Result<mpsc::Permit<'_, RdpInputEvent>, mpsc::error::TrySendError<()>> {
         self.input_sender.try_reserve()
+    }
+
+    /// Queues a RemoteApp launch without allowing the ordinary input queue to grow unbounded.
+    pub fn try_send_rail_execute(&self, execute: ExecutePdu) -> Result<(), mpsc::error::TrySendError<RdpInputEvent>> {
+        self.input_sender.try_send(RdpInputEvent::RailExecute(execute))
+    }
+
+    /// Queues a client-originated RAIL input event.
+    pub fn try_send_rail_input(&self, event: RailInputEvent) -> Result<(), mpsc::error::TrySendError<RdpInputEvent>> {
+        self.input_sender.try_send(RdpInputEvent::Rail(event))
     }
 
     /// Enqueues a clipboard protocol message independently of ordinary bounded input.
@@ -834,9 +877,20 @@ fn build_connector(
 
     #[cfg(any(feature = "sound", feature = "rdpdr"))]
     let audio_playback = connector_config.enable_audio_playback;
+    let rail_client = connector_config.remote_application_mode.then(|| {
+        RailClient::new(
+            connector_config.client_build,
+            connector_config.desktop_size.width,
+            connector_config.desktop_size.height,
+        )
+    });
 
     let mut connector =
         ironrdp_connector::ClientConnector::new(connector_config, client_addr).with_static_channel(drdynvc);
+
+    if let Some(rail_client) = rail_client {
+        connector = connector.with_static_channel(rail_client);
+    }
 
     #[cfg(feature = "rdpdr")]
     let rdpdr_channel = build_rdpdr_channel(rdpdr_factory, &config.channels.rdpdr)?;
@@ -1502,6 +1556,7 @@ async fn active_session(
     let desktop_size = connection_result.desktop_size;
     let mut refresh_rect_support = connection_result.refresh_rect_support;
     let mut suppress_output_support = connection_result.suppress_output_support;
+    let window_support_level = connection_result.window_support_level;
     let mut image = DecodedImage::new(PixelFormat::RgbA32, desktop_size.width, desktop_size.height);
 
     // We retain the factory to drive the Deactivation-Reactivation Sequence locally.
@@ -1518,6 +1573,7 @@ async fn active_session(
         pointer_software_rendering: connection_result.pointer_software_rendering,
     }
     .build();
+    active_stage.set_window_support_level(window_support_level);
 
     // Timer interval for driving clipboard lock timeouts.
     let mut cleanup_interval = tokio::time::interval(Duration::from_secs(5));
@@ -1533,6 +1589,7 @@ async fn active_session(
     let mut fake_events_interval =
         fake_events_interval.map(|interval| tokio::time::interval(core::cmp::max(interval, Duration::from_secs(1))));
     let mut resize_queue = ResizeQueue::default();
+    let mut rail_queue_release_deadline = None;
     let mut graceful_shutdown_sent = false;
     let mut post_logon_redraw_requested = false;
     let mut initial_outputs = if *graceful_close_receiver.borrow_and_update() {
@@ -1649,7 +1706,17 @@ async fn active_session(
                             request.physical_size,
                         ) {
                             resize_queue.mark_in_flight(request);
-                            vec![ActiveStageOutput::ResponseFrame(response_frame?)]
+                            let mut outputs = vec![ActiveStageOutput::ResponseFrame(response_frame?)];
+                            if let Some(messages) = active_stage
+                                .get_svc_processor_mut::<RailClient>()
+                                .map(|rail_client| rail_client.update_desktop_size(request.width, request.height))
+                            {
+                                let frame = active_stage.process_svc_processor_messages(messages)?;
+                                if !frame.is_empty() {
+                                    outputs.push(ActiveStageOutput::ResponseFrame(frame));
+                                }
+                            }
+                            outputs
                         } else {
                             // TODO(#271): use the "auto-reconnect cookie": https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/15b0d1c9-2891-4adb-a45e-deb4aeeeab7c
                             debug!("Reconnecting with new size");
@@ -1689,6 +1756,36 @@ async fn active_session(
                                 Vec::new()
                             }
                         }
+                    }
+                    RdpInputEvent::RailExecute(execute) => {
+                        let messages = {
+                            let rail_client = active_stage
+                                .get_svc_processor_mut::<RailClient>()
+                                .ok_or_else(|| ironrdp_session::general_err!("RAIL is not enabled for this session"))?;
+                            rail_client
+                                .queue_execute(execute)
+                                .map_err(|error| ironrdp_session::custom_err!("RAIL", error))?
+                        };
+                        let frame = active_stage.process_svc_processor_messages(messages)?;
+                        (!frame.is_empty())
+                            .then_some(ActiveStageOutput::ResponseFrame(frame))
+                            .into_iter()
+                            .collect()
+                    }
+                    RdpInputEvent::Rail(event) => {
+                        let messages = {
+                            let rail_client = active_stage
+                                .get_svc_processor_mut::<RailClient>()
+                                .ok_or_else(|| ironrdp_session::general_err!("RAIL is not enabled for this session"))?;
+                            rail_client
+                                .queue_input(event)
+                                .map_err(|error| ironrdp_session::custom_err!("RAIL", error))?
+                        };
+                        let frame = active_stage.process_svc_processor_messages(messages)?;
+                        (!frame.is_empty())
+                            .then_some(ActiveStageOutput::ResponseFrame(frame))
+                            .into_iter()
+                            .collect()
                     }
                     }
                 }
@@ -1740,6 +1837,29 @@ async fn active_session(
                     height: request.height,
                     reason,
                 });
+                }
+                _ = async {
+                    match rail_queue_release_deadline {
+                        Some(deadline) => tokio::time::sleep_until(deadline).await,
+                        None => core::future::pending().await,
+                    }
+                } => {
+                    rail_queue_release_deadline = None;
+                    let messages = active_stage
+                        .get_svc_processor_mut::<RailClient>()
+                        .map(RailClient::release_queued_after_handshake)
+                        .transpose()
+                        .map_err(|error| ironrdp_session::custom_err!("RAIL", error))?;
+                    match messages {
+                        Some(messages) => {
+                            let frame = active_stage.process_svc_processor_messages(messages)?;
+                            (!frame.is_empty())
+                                .then_some(ActiveStageOutput::ResponseFrame(frame))
+                                .into_iter()
+                                .collect()
+                        }
+                        None => Vec::new(),
+                    }
                 }
                 _ = async { match fake_events_interval.as_mut() {
                 Some(interval) => interval.tick().await,
@@ -1982,6 +2102,25 @@ async fn active_session(
                                 return Err(ironrdp_session::general_err!("invalid static channel chunk size"));
                             }
                             active_stage.set_window_support_level(window_support_level);
+                            if let Some(messages) =
+                                active_stage.get_svc_processor_mut::<RailClient>().map(|rail_client| {
+                                    rail_client.update_desktop_size(desktop_size.width, desktop_size.height)
+                                })
+                            {
+                                let frame = active_stage.process_svc_processor_messages(messages)?;
+                                if !frame.is_empty() {
+                                    let Some(result) =
+                                        cancelable_operation(writer.write_all(&frame), close_receiver).await
+                                    else {
+                                        return Ok(RdpControlFlow::TerminatedGracefully(
+                                            GracefulDisconnectReason::UserInitiated,
+                                        ));
+                                    };
+                                    result.map_err(|error| {
+                                        ironrdp_session::custom_err!("write RAIL desktop size update", error)
+                                    })?;
+                                }
+                            }
                             refresh_rect_support = reactivated_refresh_rect_support;
                             suppress_output_support = reactivated_suppress_output_support;
                             break 'activation_seq;
@@ -2013,6 +2152,51 @@ async fn active_session(
             return Ok(RdpControlFlow::TerminatedGracefully(
                 GracefulDisconnectReason::UserInitiated,
             ));
+        }
+
+        for event in active_stage
+            .get_svc_processor_mut::<RailClient>()
+            .map(RailClient::take_events)
+            .unwrap_or_default()
+        {
+            let output_event = match event {
+                RailEvent::Handshake {
+                    handshake_ex_flags,
+                    initialization_message_count,
+                    queued_execute_count,
+                } => {
+                    rail_queue_release_deadline = Some(tokio::time::Instant::now() + Duration::from_millis(250));
+                    RdpOutputEvent::RailHandshake {
+                        handshake_ex_flags,
+                        initialization_message_count,
+                        queued_execute_count,
+                    }
+                }
+                RailEvent::DesktopSynchronized { released_execute_count } => {
+                    RdpOutputEvent::RailDesktopSynchronized { released_execute_count }
+                }
+                RailEvent::PostHandshakeQueueReleased { released_execute_count } => {
+                    RdpOutputEvent::RailPostHandshakeQueueReleased { released_execute_count }
+                }
+                RailEvent::ExecuteResult(result) => RdpOutputEvent::RailExecuteResult(result),
+                RailEvent::ApplicationId {
+                    window_id,
+                    application_id,
+                    process_id,
+                    process_image_name,
+                } => RdpOutputEvent::RailApplicationId {
+                    window_id,
+                    application_id,
+                    process_id,
+                    process_image_name,
+                },
+                RailEvent::Control(control) => RdpOutputEvent::RailControl(control),
+            };
+            if !send_active_output_event(output_event_sender, output_event, close_receiver).await? {
+                return Ok(RdpControlFlow::TerminatedGracefully(
+                    GracefulDisconnectReason::UserInitiated,
+                ));
+            }
         }
 
         if resize_queue.in_flight.is_none()

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -1527,6 +1527,13 @@ fn create_client_info_pdu(
         CompressionType::K8 // ignored if ClientInfoFlags::COMPRESSION is not set
     };
 
+    // MS-RDPERP requires RemoteApp launch data on the RAIL channel.
+    let (alternate_shell, work_dir) = if config.remote_application_mode {
+        (String::new(), String::new())
+    } else {
+        (config.alternate_shell.clone(), config.work_dir.clone())
+    };
+
     let client_info = ClientInfo {
         credentials: Credentials {
             username: config.credentials.username().unwrap_or("").to_owned(),
@@ -1536,13 +1543,8 @@ fn create_client_info_pdu(
         code_page: 0, // ignored if the keyboardLayout field of the Client Core Data is set to zero
         flags,
         compression_type,
-        // MS-RDPERP requires RemoteApp launch data on the RAIL channel.
-        alternate_shell: if config.remote_application_mode {
-            String::new()
-        } else {
-            config.alternate_shell.clone()
-        },
-        work_dir: config.work_dir.clone(),
+        alternate_shell,
+        work_dir,
         extra_info: ExtendedClientInfo {
             address_family: match client_addr {
                 SocketAddr::V4(_) => AddressFamily::INET,
@@ -1572,5 +1574,67 @@ fn create_client_info_pdu(
     ClientInfoPdu {
         security_header,
         client_info,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ironrdp_pdu::gcc;
+    use ironrdp_pdu::rdp::capability_sets::{MajorPlatformType, RailSupportLevel};
+    use ironrdp_pdu::rdp::client_info::ClientInfoFlags;
+
+    use super::create_client_info_pdu;
+    use crate::{Config, Credentials, DesktopSize};
+
+    #[test]
+    fn remote_application_client_info_uses_rail_launch_data() {
+        let config = Config {
+            desktop_size: DesktopSize {
+                width: 1024,
+                height: 768,
+            },
+            desktop_scale_factor: 0,
+            enable_tls: true,
+            enable_credssp: false,
+            enable_standard_rdp_security: false,
+            credentials: Credentials::UsernamePassword {
+                username: "test".into(),
+                password: "test".into(),
+            },
+            domain: None,
+            client_build: 0,
+            client_name: "test".into(),
+            keyboard_type: gcc::KeyboardType::IbmEnhanced,
+            keyboard_subtype: 0,
+            keyboard_functional_keys_count: 12,
+            keyboard_layout: 0,
+            connection_type: gcc::ConnectionType::Lan,
+            ime_file_name: String::new(),
+            bitmap: None,
+            dig_product_id: String::new(),
+            client_dir: String::new(),
+            alternate_shell: "app.exe".into(),
+            work_dir: "C:\\apps".into(),
+            remote_application_mode: true,
+            rail_support_level: RailSupportLevel::SUPPORTED,
+            platform: MajorPlatformType::UNIX,
+            hardware_id: None,
+            request_data: None,
+            autologon: false,
+            enable_audio_playback: false,
+            performance_flags: Default::default(),
+            license_cache: None,
+            timezone_info: Default::default(),
+            compression_type: None,
+            enable_server_pointer: false,
+            pointer_software_rendering: false,
+            multitransport_flags: None,
+        };
+
+        let client_info = create_client_info_pdu(&config, &"127.0.0.1:3389".parse().unwrap(), None).client_info;
+
+        assert!(client_info.flags.contains(ClientInfoFlags::RAIL));
+        assert!(client_info.alternate_shell.is_empty());
+        assert!(client_info.work_dir.is_empty());
     }
 }

--- a/crates/ironrdp-connector/src/connection.rs
+++ b/crates/ironrdp-connector/src/connection.rs
@@ -1514,6 +1514,10 @@ fn create_client_info_pdu(
         flags |= ClientInfoFlags::NO_AUDIO_PLAYBACK;
     }
 
+    if config.remote_application_mode {
+        flags |= ClientInfoFlags::RAIL;
+    }
+
     // Advertise bulk compression support if configured
     let compression_type = if let Some(ct) = config.compression_type {
         flags |= ClientInfoFlags::COMPRESSION;
@@ -1532,7 +1536,12 @@ fn create_client_info_pdu(
         code_page: 0, // ignored if the keyboardLayout field of the Client Core Data is set to zero
         flags,
         compression_type,
-        alternate_shell: config.alternate_shell.clone(),
+        // MS-RDPERP requires RemoteApp launch data on the RAIL channel.
+        alternate_shell: if config.remote_application_mode {
+            String::new()
+        } else {
+            config.alternate_shell.clone()
+        },
         work_dir: config.work_dir.clone(),
         extra_info: ExtendedClientInfo {
             address_family: match client_addr {

--- a/crates/ironrdp-connector/src/connection_activation.rs
+++ b/crates/ironrdp-connector/src/connection_activation.rs
@@ -1,7 +1,9 @@
 use core::mem;
 
 use ironrdp_pdu::rdp;
-use ironrdp_pdu::rdp::capability_sets::{CapabilitySet, InputFlags, WindowList, WindowSupportLevel};
+use ironrdp_pdu::rdp::capability_sets::{
+    CapabilitySet, InputFlags, Rail, RailSupportLevel, WindowList, WindowSupportLevel,
+};
 use tracing::{debug, warn};
 
 use crate::{
@@ -429,6 +431,42 @@ fn negotiated_window_support_level(window_list: Option<&WindowList>) -> Option<W
     })
 }
 
+fn remote_app_rail_capability(
+    remote_application_mode: bool,
+    rail_support_level: RailSupportLevel,
+    server_capability_sets: &[CapabilitySet],
+    window_list: Option<&WindowList>,
+) -> ConnectorResult<Option<Rail>> {
+    if !remote_application_mode {
+        return Ok(None);
+    }
+    if !rail_support_level.contains(RailSupportLevel::SUPPORTED) {
+        return Err(reason_err!(
+            "Capabilities Exchange",
+            "client RemoteApp configuration does not support remote programs"
+        ));
+    }
+
+    let rail_supported = server_capability_sets.iter().any(|capability_set| {
+        matches!(
+            capability_set,
+            CapabilitySet::Rail(rail) if rail.support_level.contains(RailSupportLevel::SUPPORTED)
+        )
+    });
+    let window_list_supported =
+        window_list.is_some_and(|window_list| window_list.support_level != WindowSupportLevel::NotSupported);
+    if !rail_supported || !window_list_supported {
+        return Err(reason_err!(
+            "Capabilities Exchange",
+            "server does not support required RemoteApp capabilities"
+        ));
+    }
+
+    Ok(Some(Rail {
+        support_level: rail_support_level,
+    }))
+}
+
 fn create_client_confirm_active(
     config: &Config,
     mut server_capability_sets: Vec<CapabilitySet>,
@@ -442,6 +480,13 @@ fn create_client_confirm_active(
         OffscreenBitmapCache, Order, OrderFlags, OrderSupportExFlags, Pointer, SERVER_CHANNEL_ID, Sound, SoundFlags,
         SupportLevel, SurfaceCommands, VirtualChannel, VirtualChannelFlags, client_codecs_capabilities,
     };
+
+    let remote_app_rail_capability = remote_app_rail_capability(
+        config.remote_application_mode,
+        config.rail_support_level,
+        &server_capability_sets,
+        window_list.as_ref(),
+    )?;
 
     server_capability_sets.retain(|capability_set| matches!(capability_set, CapabilitySet::MultiFragmentUpdate(_)));
 
@@ -556,6 +601,9 @@ fn create_client_confirm_active(
             max_request_size: 8 * 1024 * 1024, // 8 MB
         }));
     }
+    if let Some(rail) = remote_app_rail_capability {
+        server_capability_sets.push(CapabilitySet::Rail(rail));
+    }
     if let Some(window_list) = window_list {
         server_capability_sets.push(CapabilitySet::WindowList(window_list));
     }
@@ -591,9 +639,11 @@ fn requested_bitmap_color_depth(bitmap: Option<&crate::BitmapConfig>) -> Connect
 
 #[cfg(test)]
 mod tests {
-    use ironrdp_pdu::rdp::capability_sets::{CapabilitySet, WindowList, WindowSupportLevel};
+    use ironrdp_pdu::rdp::capability_sets::{CapabilitySet, Rail, RailSupportLevel, WindowList, WindowSupportLevel};
 
-    use super::{negotiated_window_support_level, requested_bitmap_color_depth, server_window_list};
+    use super::{
+        negotiated_window_support_level, remote_app_rail_capability, requested_bitmap_color_depth, server_window_list,
+    };
     use crate::BitmapConfig;
 
     #[test]
@@ -635,6 +685,56 @@ mod tests {
                 num_icon_cache_entries: 0,
             })),
             None
+        );
+    }
+
+    #[test]
+    fn remote_app_capabilities_require_server_rail_and_window_list() {
+        let rail_support_level = RailSupportLevel::SUPPORTED;
+        let window_list = WindowList {
+            support_level: WindowSupportLevel::SupportedEx,
+            num_icon_caches: 3,
+            num_icon_cache_entries: 12,
+        };
+        let rail = CapabilitySet::Rail(Rail {
+            support_level: RailSupportLevel::SUPPORTED,
+        });
+
+        assert_eq!(
+            remote_app_rail_capability(
+                true,
+                rail_support_level,
+                core::slice::from_ref(&rail),
+                Some(&window_list)
+            )
+            .unwrap(),
+            Some(Rail {
+                support_level: rail_support_level,
+            })
+        );
+        assert!(remote_app_rail_capability(true, rail_support_level, &[], Some(&window_list)).is_err());
+        assert!(remote_app_rail_capability(true, rail_support_level, core::slice::from_ref(&rail), None).is_err());
+    }
+
+    #[test]
+    fn remote_app_capabilities_require_client_rail_support() {
+        let window_list = WindowList {
+            support_level: WindowSupportLevel::Supported,
+            num_icon_caches: 0,
+            num_icon_cache_entries: 0,
+        };
+        let rail = CapabilitySet::Rail(Rail {
+            support_level: RailSupportLevel::SUPPORTED,
+        });
+
+        assert!(
+            remote_app_rail_capability(
+                true,
+                RailSupportLevel::empty(),
+                core::slice::from_ref(&rail),
+                Some(&window_list)
+            )
+            .is_err()
         );
     }
 }

--- a/crates/ironrdp-connector/src/lib.rs
+++ b/crates/ironrdp-connector/src/lib.rs
@@ -228,6 +228,15 @@ pub struct Config {
     pub alternate_shell: String,
     /// Working directory for the alternate shell
     pub work_dir: String,
+    /// Whether the connection uses the RemoteApp/RAIL connection model.
+    ///
+    /// RemoteApp launch information travels over the `rail` static virtual channel.
+    pub remote_application_mode: bool,
+    /// RAIL extensions implemented by the client.
+    ///
+    /// This must include [`capability_sets::RailSupportLevel::SUPPORTED`] when
+    /// [`Self::remote_application_mode`] is enabled.
+    pub rail_support_level: capability_sets::RailSupportLevel,
     pub platform: capability_sets::MajorPlatformType,
     /// Unique identifier for the computer
     ///

--- a/crates/ironrdp-testsuite-core/tests/connector/autodetect.rs
+++ b/crates/ironrdp-testsuite-core/tests/connector/autodetect.rs
@@ -66,6 +66,8 @@ fn test_config() -> ironrdp_connector::Config {
         timezone_info: Default::default(),
         alternate_shell: String::new(),
         work_dir: String::new(),
+        remote_application_mode: false,
+        rail_support_level: ironrdp_pdu::rdp::capability_sets::RailSupportLevel::SUPPORTED,
     }
 }
 

--- a/crates/ironrdp-testsuite-core/tests/session/connection_activation.rs
+++ b/crates/ironrdp-testsuite-core/tests/session/connection_activation.rs
@@ -64,6 +64,8 @@ fn test_config() -> ironrdp_connector::Config {
         timezone_info: Default::default(),
         alternate_shell: String::new(),
         work_dir: String::new(),
+        remote_application_mode: false,
+        rail_support_level: ironrdp_pdu::rdp::capability_sets::RailSupportLevel::SUPPORTED,
     }
 }
 

--- a/crates/ironrdp-testsuite-extra/tests/e2e.rs
+++ b/crates/ironrdp-testsuite-extra/tests/e2e.rs
@@ -1075,5 +1075,7 @@ fn default_client_config() -> connector::Config {
         timezone_info: Default::default(),
         alternate_shell: String::new(),
         work_dir: String::new(),
+        remote_application_mode: false,
+        rail_support_level: pdu::rdp::capability_sets::RailSupportLevel::SUPPORTED,
     }
 }

--- a/crates/ironrdp-viewer/src/app.rs
+++ b/crates/ironrdp-viewer/src/app.rs
@@ -546,6 +546,48 @@ impl RpcApp {
                     "Reconnecting because dynamic display resize could not complete"
                 );
             }
+            RdpOutputEvent::RailHandshake {
+                handshake_ex_flags,
+                initialization_message_count,
+                queued_execute_count,
+            } => {
+                debug!(
+                    ?handshake_ex_flags,
+                    initialization_message_count, queued_execute_count, "RAIL static channel initialized"
+                );
+            }
+            RdpOutputEvent::RailDesktopSynchronized { released_execute_count } => {
+                debug!(
+                    released_execute_count,
+                    "RAIL queued input released after desktop synchronization"
+                );
+            }
+            RdpOutputEvent::RailPostHandshakeQueueReleased { released_execute_count } => {
+                debug!(
+                    released_execute_count,
+                    "RAIL queued input released after handshake fallback"
+                );
+            }
+            RdpOutputEvent::RailExecuteResult(result) => {
+                debug!(?result, "RAIL execute completed");
+            }
+            RdpOutputEvent::RailApplicationId {
+                window_id,
+                application_id,
+                process_id,
+                process_image_name,
+            } => {
+                debug!(
+                    window_id,
+                    %application_id,
+                    ?process_id,
+                    ?process_image_name,
+                    "RAIL application identity received"
+                );
+            }
+            RdpOutputEvent::RailControl(control) => {
+                debug!(?control, "RAIL control received");
+            }
         }
     }
 }

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -1482,6 +1482,8 @@ fn build_config(
         timezone_info: TimezoneInfo::default(),
         alternate_shell: String::new(),
         work_dir: String::new(),
+        remote_application_mode: false,
+        rail_support_level: ironrdp::pdu::rdp::capability_sets::RailSupportLevel::SUPPORTED,
     }
 }
 

--- a/crates/ironrdp/examples/screenshot.rs
+++ b/crates/ironrdp/examples/screenshot.rs
@@ -274,6 +274,8 @@ fn build_config(
         timezone_info: TimezoneInfo::default(),
         alternate_shell: String::new(),
         work_dir: String::new(),
+        remote_application_mode: false,
+        rail_support_level: ironrdp_pdu::rdp::capability_sets::RailSupportLevel::empty(),
     })
 }
 

--- a/ffi/src/connector/config.rs
+++ b/ffi/src/connector/config.rs
@@ -225,6 +225,8 @@ pub mod ffi {
                 timezone_info: self.timezone_info.clone().unwrap_or_default(),
                 alternate_shell: String::new(),
                 work_dir: String::new(),
+                remote_application_mode: false,
+                rail_support_level: ironrdp::pdu::rdp::capability_sets::RailSupportLevel::empty(),
             };
             let dvc_pipe_proxy = self.dvc_pipe_proxy.clone();
 


### PR DESCRIPTION
Configure and negotiate RAIL connections, then route its static channel through the portable client with bounded request queues and server control events.