### PR TITLE
chore(agents): align protocol commit scopes

### DIFF
--- a/.agents/skills/commit-scope/SKILL.md
+++ b/.agents/skills/commit-scope/SKILL.md
@@ -11,7 +11,7 @@ Choose at most one optional scope for `<type>[optional scope][!]: <description>`
 
 ```text
 meta core error pdu str bulk graphics config input connector session driver
-svc dvc cliprdr rdpdr rdpsnd displaycontrol echo egfx rdpeudp rdpeusb rdcleanpath
+svc dvc cliprdr rdpdr rdpsnd displaycontrol echo egfx rdpeudp rdpeusb rdpemt rdcleanpath
 tls mstsgu vmconnect
 
 client viewer agent daemon rpc activex server web ffi replay

--- a/.agents/skills/commit-scope/SKILL.md
+++ b/.agents/skills/commit-scope/SKILL.md
@@ -11,7 +11,7 @@ Choose at most one optional scope for `<type>[optional scope][!]: <description>`
 
 ```text
 meta core error pdu str bulk graphics config input connector session driver
-svc dvc cliprdr rdpdr rdpsnd displaycontrol echo egfx rdpeusb rdcleanpath
+svc dvc cliprdr rdpdr rdpsnd displaycontrol echo egfx rdpeudp rdpeusb rdcleanpath
 tls mstsgu vmconnect
 
 client viewer agent daemon rpc activex server web ffi replay


### PR DESCRIPTION
Keep the commit-scope skill aligned with the PR convention checker by documenting its existing `rdpeudp` and `rdpemt` scopes.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>