### PR TITLE
ci(pr-automation): revise size label thresholds

### DIFF
--- a/.github/PR_AUTOMATION.md
+++ b/.github/PR_AUTOMATION.md
@@ -61,7 +61,18 @@ A maintainer can explicitly override this exclusion with force mode.
 
 ### Oversized pull requests
 
-For a `size/XL` pull request with 800 or more changed source lines, automatic routes skip classification and review before any model runs.
+Size uses the larger bucket from additions plus deletions in Rust, C#, JavaScript, TypeScript, Svelte, YAML, and TOML files, or from the total number of touched files.
+
+| Label | Counted changed lines | Touched files |
+| --- | ---: | ---: |
+| `size/XS` | 0-49 | 1-2 |
+| `size/S` | 50-199 | 3-5 |
+| `size/M` | 200-449 | 6-10 |
+| `size/L` | 450-899 | 11-20 |
+| `size/XL` | 900-1299 | 21-49 |
+| `size/XXL` | 1300 or more | 50 or more |
+
+For a `size/XXL` pull request, automatic routes skip classification and review before any model runs.
 Classification falls back to deterministic scope, size, first-time-contributor, and `cargo-semver-checks` results, while every classified pull request retains exactly one `size/*` label.
 
 The workflow comments once to explain the exclusion and point to [stacked pull requests](https://docs.github.com/en/pull-requests/get-started/about-stacked-prs) for splitting dependent work.
@@ -148,7 +159,7 @@ It never deletes repository labels.
 On automatic routes, risk measures maintainer scrutiny, so it does not decide whether a protocol change is worth reviewing.
 A `protocol_related` classification is review-eligible at any risk level, subject to the remaining review gates.
 For every other change, `risk/low` without `breaking-change` skips the review.
-Duplicates, `size/XL`, a legitimacy stop, and the terminal review count stop every automatic route.
+Duplicates, `size/XXL`, a legitimacy stop, and the terminal review count stop every automatic route.
 
 ## Review prerequisites
 
@@ -160,7 +171,7 @@ A second automatic review requires a later push and matching successful CI.
 The `workflow_dispatch` route accepts a pull request number, a route selector, and a `force` flag.
 The workflow ignores `force` on every other event.
 
-For classification, force mode bypasses completed-classification cache, fork quota, `size/XL`, terminal review count, draft status, and bot authorship.
+For classification, force mode bypasses completed-classification cache, fork quota, `size/XXL`, terminal review count, draft status, and bot authorship.
 Its SHA-bound check retains protocol state for a later forced review but cannot open an automatic review route.
 Select the review route explicitly when one is required.
 For review, it also bypasses classification, CI, duplicate, legitimacy, risk, contributor-history, and review-count eligibility.

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -11,7 +11,7 @@ const { validateClassifier } = require("./validate-classifier");
 const { validateReviewer } = require("./validate-reviewer");
 const {
   resolveClassificationState, resolveReviewState, reviewPolicyEligible, DUPLICATE_MARKER,
-  LEGITIMACY_LABEL, LEGITIMACY_MARKER_PREFIX, XL_MARKER,
+  LEGITIMACY_LABEL, LEGITIMACY_MARKER_PREFIX, OVERSIZED_MARKER,
 } = require("./resolve-state");
 const { resolvePr } = require("./resolve-pr");
 const { StaleHeadError, applyLabels, escapeMarkdown, markerBody, writeState } = require("./write-state");
@@ -178,7 +178,7 @@ test("workflow force mode bypasses model policy gates without changing automatic
   for (const automaticGate of [
     "classification-gate.outputs.available == 'true'",
     "classification-gate.outputs.required == 'true'",
-    "deterministic-analysis.outputs.size-label != 'size/XL'",
+    "deterministic-analysis.outputs.size-label != 'size/XXL'",
     "fork-rate-limit.outputs.allowed == 'true'",
     "'ai-reviewed/2'",
   ]) assert.equal(classifierJob.includes(automaticGate), true, automaticGate);
@@ -285,6 +285,36 @@ test("deterministic analysis applies trusted scopes and source size", () => {
   assert.equal(analyzeFiles([{ filename: "crates/ironrdp-core/src/lib.rs", additions: 29, deletions: 0 }],
     { labelerRules: rules }).pathLabels[0], "scope/core");
   assert.equal(result.sizeLabel, "size/XS");
+});
+
+test("deterministic size uses the larger changed-line or touched-file bucket", () => {
+  const rules = {};
+  const analyze = (changedLines, touchedFiles) => analyzeFiles(Array.from({ length: touchedFiles }, (_, index) => ({
+    filename: `src/file-${index}.rs`,
+    additions: index === 0 ? changedLines : 0,
+    deletions: 0,
+  })), { labelerRules: rules });
+  for (const [changedLines, expected] of [
+    [0, "size/XS"], [49, "size/XS"], [50, "size/S"], [199, "size/S"],
+    [200, "size/M"], [449, "size/M"], [450, "size/L"], [899, "size/L"],
+    [900, "size/XL"], [1299, "size/XL"], [1300, "size/XXL"],
+  ]) {
+    assert.equal(analyze(changedLines, 1).sizeLabel, expected, `${changedLines} changed lines`);
+  }
+  for (const [touchedFiles, expected] of [
+    [1, "size/XS"], [2, "size/XS"], [3, "size/S"], [5, "size/S"],
+    [6, "size/M"], [10, "size/M"], [11, "size/L"], [20, "size/L"],
+    [21, "size/XL"], [49, "size/XL"], [50, "size/XXL"],
+  ]) {
+    const result = analyze(0, touchedFiles);
+    assert.equal(result.sizeLabel, expected, `${touchedFiles} touched files`);
+    assert.equal(result.touchedFiles, touchedFiles);
+  }
+  assert.equal(analyze(10, 6).sizeLabel, "size/M");
+  assert.equal(analyze(1300, 1).sizeLabel, "size/XXL");
+  assert.equal(analyzeFiles([
+    { filename: "README.md", additions: 1300, deletions: 0 },
+  ], { labelerRules: rules }).sizeLabel, "size/XS");
 });
 
 test("classifier rejects malformed duplicate and executable documentation claims", () => {
@@ -743,7 +773,7 @@ test("model-owned labels coexist with path scopes and are withdrawn when no long
     pathLabels: ["scope/core", "scope/web"],
     ownedPathLabels: ["scope/core", "scope/web", "scope/ffi", "scope/tooling"],
     sizeLabel: "size/S",
-    sizeLabels: ["size/XS", "size/S", "size/M", "size/L", "size/XL"],
+    sizeLabels: SIZE_LABELS,
     firstTime: false,
   };
   const classified = resolveClassificationState({
@@ -775,7 +805,7 @@ test("successful classification preserves the first-time contributor label", () 
     pathLabels: [],
     ownedPathLabels: ["scope/core"],
     sizeLabel: "size/XS",
-    sizeLabels: ["size/XS", "size/S", "size/M", "size/L", "size/XL"],
+    sizeLabels: SIZE_LABELS,
     firstTime: true,
   };
   const state = resolveClassificationState({
@@ -796,7 +826,7 @@ test("protocol relevance overrides risk suppression but no other exclusion", () 
   assert.equal(reviewPolicyEligible({ labels: ["risk/low"], protocolRelated: false }), false);
   assert.equal(reviewPolicyEligible({ labels: ["risk/low", "breaking-change"] }), true);
   assert.equal(reviewPolicyEligible({ labels: ["risk/medium"] }), true);
-  for (const blocking of ["size/XL", "duplicate", "ai-reviewed/2", LEGITIMACY_LABEL]) {
+  for (const blocking of ["size/XXL", "duplicate", "ai-reviewed/2", LEGITIMACY_LABEL]) {
     assert.equal(reviewPolicyEligible({ labels: ["risk/high", blocking], protocolRelated: true }), false);
   }
   assert.equal(reviewPolicyEligible({
@@ -820,35 +850,35 @@ test("review publication applies the same policy the workflow spent its call on"
     ...args, labels: ["risk/low"], gate: gate({ protocolRelated: false }),
   }).failed, true);
   assert.equal(resolveReviewState({
-    ...args, labels: ["risk/low", "size/XL"], gate: gate({ protocolRelated: true }),
+    ...args, labels: ["risk/low", "size/XXL"], gate: gate({ protocolRelated: true }),
   }).failed, true);
 });
 
-test("XL guidance is posted once and withdrawn when the change shrinks", () => {
+test("XXL guidance is posted once and withdrawn when the change shrinks", () => {
   const deterministic = (sizeLabel) => ({ ok: true, pathLabels: [], ownedPathLabels: [],
-    sizeLabel, sizeLabels: ["size/L", "size/XL"], firstTime: false });
+    sizeLabel, sizeLabels: ["size/XL", "size/XXL"], firstTime: false });
   const state = (sizeLabel) => resolveClassificationState({
     expectedSha: SHA, labels: [], deterministic: deterministic(sizeLabel), classifier: classifier(),
     semver: { head_sha: SHA, status: "not-suspected" },
   });
-  const xl = state("size/XL");
-  assert.deepEqual(xl.comments.map((comment) => comment.kind), ["xl"]);
-  assert.equal(xl.removeCommentMarkers.includes(XL_MARKER), false);
-  const body = markerBody(xl.comments[0], "Devolutions", "IronRDP");
+  const oversized = state("size/XXL");
+  assert.deepEqual(oversized.comments.map((comment) => comment.kind), ["oversized"]);
+  assert.equal(oversized.removeCommentMarkers.includes(OVERSIZED_MARKER), false);
+  const body = markerBody(oversized.comments[0], "Devolutions", "IronRDP");
   assert.match(body, /stacked-prs/);
-  assert.match(body, /size\/XL/);
+  assert.match(body, /size\/XXL/);
   // A later push can drop the change below the threshold, and the guidance must not outlive it.
-  const shrunk = state("size/L");
+  const shrunk = state("size/XL");
   assert.deepEqual(shrunk.comments, []);
-  assert.equal(shrunk.removeCommentMarkers.includes(XL_MARKER), true);
+  assert.equal(shrunk.removeCommentMarkers.includes(OVERSIZED_MARKER), true);
 });
 
 test("an oversized change retains deterministic labels without a classifier", () => {
-  // The workflow skips the classifier job for size/XL, so no model output exists to validate here.
+  // The workflow skips the classifier job for size/XXL, so no model output exists to validate here.
   // Resolution must still succeed on deterministic evidence rather than degrading to a failure.
   const deterministic = { ok: true, pathLabels: ["scope/core", "scope/web"],
     ownedPathLabels: ["scope/core", "scope/web", "scope/ffi"],
-    sizeLabel: "size/XL", sizeLabels: ["size/L", "size/XL"], firstTime: true };
+    sizeLabel: "size/XXL", sizeLabels: ["size/XL", "size/XXL"], firstTime: true };
   const state = resolveClassificationState({
     expectedSha: SHA, labels: [], deterministic, classifier: undefined,
     semver: { head_sha: SHA, status: "suspected" },
@@ -857,9 +887,9 @@ test("an oversized change retains deterministic labels without a classifier", ()
   assert.equal(state.oversized, true);
   const desired = state.labelSets.flatMap((set) => set.desired);
   assert.deepEqual(desired.sort(), ["breaking-change", "contributor/first-time", "risk/high",
-    "scope/core", "scope/web", "size/XL"]);
+    "scope/core", "scope/web", "size/XXL"]);
   assert.deepEqual(state.addLabels, ["maintainer-required"]);
-  assert.deepEqual(state.comments.map((comment) => comment.kind), ["xl"]);
+  assert.deepEqual(state.comments.map((comment) => comment.kind), ["oversized"]);
   // The review gate only trusts a check announcing a completed classification.
   assert.notEqual(state.check.title, "Classification complete");
   // No model ran, so a duplicate or legitimacy verdict from an earlier head is neither confirmed
@@ -973,8 +1003,8 @@ test("quota decisions stop classification and review with a bounded human handof
 
 test("forced classification bypasses policy, quota, and cache but still validates output", () => {
   const deterministic = {
-    ok: true, pathLabels: [], ownedPathLabels: [], sizeLabel: "size/XL",
-    sizeLabels: ["size/L", "size/XL"], firstTime: false,
+    ok: true, pathLabels: [], ownedPathLabels: [], sizeLabel: "size/XXL",
+    sizeLabels: ["size/XL", "size/XXL"], firstTime: false,
   };
   const args = {
     expectedSha: SHA,
@@ -992,8 +1022,8 @@ test("forced classification bypasses policy, quota, and cache but still validate
   assert.equal(state.check.title, "Classification complete");
   assert.equal(state.dispatchReview, false);
   assert.equal(state.check.machineState.automaticReviewEligible, false);
-  assert.equal(state.comments.some((comment) => comment.kind === "xl"), false);
-  assert.equal(state.removeCommentMarkers.includes(XL_MARKER), true);
+  assert.equal(state.comments.some((comment) => comment.kind === "oversized"), false);
+  assert.equal(state.removeCommentMarkers.includes(OVERSIZED_MARKER), true);
 
   const invalid = resolveClassificationState({ ...args, classifier: "" });
   assert.equal(invalid.failed, true);
@@ -1012,7 +1042,7 @@ test("forced review bypasses eligibility while retaining trusted publication gat
   };
   const args = {
     expectedSha: SHA,
-    labels: ["ai-reviewed/2", "duplicate", "size/XL", "risk/low"],
+    labels: ["ai-reviewed/2", "duplicate", "size/XXL", "risk/low"],
     reviewer,
     gate: { ok: true, force: true, head_sha: SHA, protocolRelated: false },
     contributor: { status: "ineligible" },

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -11,7 +11,7 @@ const { validateClassifier } = require("./validate-classifier");
 const { validateReviewer } = require("./validate-reviewer");
 const {
   resolveClassificationState, resolveReviewState, reviewPolicyEligible, DUPLICATE_MARKER,
-  LEGITIMACY_LABEL, LEGITIMACY_MARKER_PREFIX, OVERSIZED_MARKER,
+  LEGACY_XL_MARKER, LEGITIMACY_LABEL, LEGITIMACY_MARKER_PREFIX, OVERSIZED_MARKER,
 } = require("./resolve-state");
 const { resolvePr } = require("./resolve-pr");
 const { StaleHeadError, applyLabels, escapeMarkdown, markerBody, writeState } = require("./write-state");
@@ -864,6 +864,7 @@ test("XXL guidance is posted once and withdrawn when the change shrinks", () => 
   const oversized = state("size/XXL");
   assert.deepEqual(oversized.comments.map((comment) => comment.kind), ["oversized"]);
   assert.equal(oversized.removeCommentMarkers.includes(OVERSIZED_MARKER), false);
+  assert.equal(oversized.removeCommentMarkers.includes(LEGACY_XL_MARKER), true);
   const body = markerBody(oversized.comments[0], "Devolutions", "IronRDP");
   assert.match(body, /stacked-prs/);
   assert.match(body, /size\/XXL/);
@@ -871,6 +872,7 @@ test("XXL guidance is posted once and withdrawn when the change shrinks", () => 
   const shrunk = state("size/XL");
   assert.deepEqual(shrunk.comments, []);
   assert.equal(shrunk.removeCommentMarkers.includes(OVERSIZED_MARKER), true);
+  assert.equal(shrunk.removeCommentMarkers.includes(LEGACY_XL_MARKER), true);
 });
 
 test("an oversized change retains deterministic labels without a classifier", () => {
@@ -894,7 +896,7 @@ test("an oversized change retains deterministic labels without a classifier", ()
   assert.notEqual(state.check.title, "Classification complete");
   // No model ran, so a duplicate or legitimacy verdict from an earlier head is neither confirmed
   // nor refuted and must be left in place.
-  assert.deepEqual(state.removeCommentMarkers, []);
+  assert.deepEqual(state.removeCommentMarkers, [LEGACY_XL_MARKER]);
 
   const unavailable = resolveClassificationState({
     expectedSha: SHA, labels: [], deterministic, classifier: undefined,

--- a/.github/pr-automation/deterministic-analysis.js
+++ b/.github/pr-automation/deterministic-analysis.js
@@ -5,7 +5,7 @@ const { isDocumentationPath } = require("./validate-classifier");
 
 const MAX_FILES = 3000;
 const MAX_FILENAME = 500;
-const SIZE_LABELS = ["size/XS", "size/S", "size/M", "size/L", "size/XL"];
+const SIZE_LABELS = ["size/XS", "size/S", "size/M", "size/L", "size/XL", "size/XXL"];
 const SOURCE_FILE = /\.(?:rs|cs|[cm]?js|jsx|[cm]?ts|tsx|svelte|ya?ml|toml)$/i;
 
 function globToRegExp(pattern) {
@@ -46,8 +46,15 @@ function parseLabelerRules(source) {
 function sourceSizeLabel(files) {
   const lines = files.reduce((total, file) => SOURCE_FILE.test(file.filename) ?
     total + file.additions + file.deletions : total, 0);
-  return { changedLines: lines, label: lines < 30 ? "size/XS" : lines < 150 ? "size/S" :
-    lines < 400 ? "size/M" : lines < 800 ? "size/L" : "size/XL" };
+  const lineSize = lines < 50 ? 0 : lines < 200 ? 1 : lines < 450 ? 2 :
+    lines < 900 ? 3 : lines < 1300 ? 4 : 5;
+  const fileSize = files.length < 3 ? 0 : files.length < 6 ? 1 : files.length < 11 ? 2 :
+    files.length < 21 ? 3 : files.length < 50 ? 4 : 5;
+  return {
+    changedLines: lines,
+    touchedFiles: files.length,
+    label: SIZE_LABELS[Math.max(lineSize, fileSize)],
+  };
 }
 
 function analyzeFiles(files, { labelerRules, authorAssociation } = {}) {
@@ -64,7 +71,7 @@ function analyzeFiles(files, { labelerRules, authorAssociation } = {}) {
   const size = sourceSizeLabel(files);
   return {
     ok: true, pathLabels, ownedPathLabels: Object.keys(labelerRules), sizeLabel: size.label,
-    sizeLabels: SIZE_LABELS, changedLines: size.changedLines,
+    sizeLabels: SIZE_LABELS, changedLines: size.changedLines, touchedFiles: size.touchedFiles,
     firstTime: ["FIRST_TIME_CONTRIBUTOR", "FIRST_TIMER"].includes(authorAssociation),
     documentationOnlyPaths: files.every((file) => isDocumentationPath(file.filename)),
   };

--- a/.github/pr-automation/labels.json
+++ b/.github/pr-automation/labels.json
@@ -47,27 +47,32 @@
   {
     "name": "size/XS",
     "color": "f9d0c4",
-    "description": "Size: Under 30 lines of code"
+    "description": "Size: 0-49 lines of code or 1-2 files"
   },
   {
     "name": "size/S",
     "color": "f9d0c4",
-    "description": "Size: 30-149 lines of code"
+    "description": "Size: 50-199 lines of code or 3-5 files"
   },
   {
     "name": "size/M",
     "color": "f9d0c4",
-    "description": "Size: 150-399 lines of code"
+    "description": "Size: 200-449 lines of code or 6-10 files"
   },
   {
     "name": "size/L",
     "color": "f9d0c4",
-    "description": "Size: 400-799 lines of code"
+    "description": "Size: 450-899 lines of code or 11-20 files"
   },
   {
     "name": "size/XL",
     "color": "f9d0c4",
-    "description": "Size: 800 or more lines of code"
+    "description": "Size: 900-1299 lines of code or 21-49 files"
+  },
+  {
+    "name": "size/XXL",
+    "color": "f9d0c4",
+    "description": "Size: 1300 or more lines of code or 50 or more files"
   },
   {
     "name": "risk/low",

--- a/.github/pr-automation/labels.json
+++ b/.github/pr-automation/labels.json
@@ -47,32 +47,32 @@
   {
     "name": "size/XS",
     "color": "f9d0c4",
-    "description": "Size: 0-49 lines of code or 1-2 files"
+    "description": "Size: up to 49 counted lines and 2 files"
   },
   {
     "name": "size/S",
     "color": "f9d0c4",
-    "description": "Size: 50-199 lines of code or 3-5 files"
+    "description": "Size: up to 199 counted lines and 5 files; exceeds XS in either measure"
   },
   {
     "name": "size/M",
     "color": "f9d0c4",
-    "description": "Size: 200-449 lines of code or 6-10 files"
+    "description": "Size: up to 449 counted lines and 10 files; exceeds S in either measure"
   },
   {
     "name": "size/L",
     "color": "f9d0c4",
-    "description": "Size: 450-899 lines of code or 11-20 files"
+    "description": "Size: up to 899 counted lines and 20 files; exceeds M in either measure"
   },
   {
     "name": "size/XL",
     "color": "f9d0c4",
-    "description": "Size: 900-1299 lines of code or 21-49 files"
+    "description": "Size: up to 1299 counted lines and 49 files; exceeds L in either measure"
   },
   {
     "name": "size/XXL",
     "color": "f9d0c4",
-    "description": "Size: 1300 or more lines of code or 50 or more files"
+    "description": "Size: 1300 or more counted lines or 50 or more files"
   },
   {
     "name": "risk/low",

--- a/.github/pr-automation/resolve-state.js
+++ b/.github/pr-automation/resolve-state.js
@@ -10,7 +10,7 @@ const AI_COUNTS = ["ai-reviewed/1", "ai-reviewed/2"];
 const LEGITIMACY_LABEL = "triage/legitimacy";
 const LEGITIMACY_MARKER_PREFIX = "<!-- ironrdp-pr-automation:legitimacy:v2:";
 const DUPLICATE_MARKER = "<!-- ironrdp-pr-automation:duplicate -->";
-const XL_MARKER = "<!-- ironrdp-pr-automation:xl -->";
+const OVERSIZED_MARKER = "<!-- ironrdp-pr-automation:oversized -->";
 const FORK_QUOTA_MARKER = "<!-- ironrdp-pr-automation:fork-llm-quota -->";
 const GLOBAL_QUOTA_MARKER = "<!-- ironrdp-pr-automation:fork-llm-global-budget -->";
 const ELIGIBLE_MERGED_PRS = 3;
@@ -24,7 +24,7 @@ function labelsOf(labels) {
 // of being restated in the workflow where the two copies could drift apart.
 function reviewPolicyEligible({ labels, legitimacyStopped, protocolRelated } = {}) {
   const present = labelsOf(labels);
-  if (present.has("ai-reviewed/2") || present.has("duplicate") || present.has("size/XL") ||
+  if (present.has("ai-reviewed/2") || present.has("duplicate") || present.has("size/XXL") ||
       present.has(LEGITIMACY_LABEL) || legitimacyStopped === true) return false;
   // Risk gates the non-protocol route only. Risk measures how much human scrutiny a change needs,
   // not how much an automated review is worth, so a protocol-related change is always reviewed.
@@ -77,11 +77,11 @@ function failedClassification(expectedSha, deterministic, reason, rateLimit, sem
   };
 }
 
-// A size/XL pull request is excluded from automated review before any model runs, so the classifier
+// A size/XXL pull request is excluded from automated review before any model runs, so the classifier
 // is never invoked and no model-derived label can be produced. The deterministic signals are still
 // published together with the split guidance, and the check title is deliberately not
 // "Classification complete" so the review gate refuses to open the review route.
-function xlClassification(expectedSha, deterministic, semverStatus) {
+function oversizedClassification(expectedSha, deterministic, semverStatus) {
   return {
     ok: true, mode: "classification", expectedSha, oversized: true,
     labelSets: [
@@ -91,7 +91,7 @@ function xlClassification(expectedSha, deterministic, semverStatus) {
       { owned: RISK, desired: [semverStatus === "suspected" ? "risk/high" : "risk/unknown"] },
     ],
     addLabels: ["maintainer-required"],
-    comments: [{ kind: "xl", marker: XL_MARKER }],
+    comments: [{ kind: "oversized", marker: OVERSIZED_MARKER }],
     // Duplicate and legitimacy verdicts are model-derived. No model ran, so a previously posted
     // verdict is neither confirmed nor refuted here and is left untouched.
     removeCommentMarkers: [],
@@ -118,8 +118,8 @@ function resolveClassificationState({
   const semverStatus = boundStatus(semver, expectedSha, ["suspected", "not-suspected"]);
   // Checked before the classifier is consulted: an oversized pull request never reaches a model, so
   // there is no classifier output to validate and no quota to charge.
-  if (!forced && deterministic?.ok && deterministic.sizeLabel === "size/XL") {
-    return xlClassification(expectedSha, deterministic, semverStatus);
+  if (!forced && deterministic?.ok && deterministic.sizeLabel === "size/XXL") {
+    return oversizedClassification(expectedSha, deterministic, semverStatus);
   }
   if (!forced && rateLimit && rateLimit.status !== "allowed") {
     return failedClassification(expectedSha, deterministic, "fork LLM quota unavailable", failureRateLimit, semverStatus);
@@ -152,7 +152,7 @@ function resolveClassificationState({
     : model.breaking_change_suspected && model.risk === "low" ? "medium"
     : model.risk;
   const duplicate = model.duplicate.detected && model.duplicate.confidence >= 0.85;
-  const isXl = deterministic.sizeLabel === "size/XL";
+  const isOversized = deterministic.sizeLabel === "size/XXL";
   const optional = [
     ["kind/technical-debt", model.technical_debt],
     ["kind/protocol", model.protocol_related],
@@ -176,7 +176,7 @@ function resolveClassificationState({
       kind: "duplicate", marker: DUPLICATE_MARKER,
       url: model.duplicate.similar_pr_url, rationale: model.duplicate.rationale,
     }] : []),
-    ...(isXl && !forced ? [{ kind: "xl", marker: XL_MARKER }] : []),
+    ...(isOversized && !forced ? [{ kind: "oversized", marker: OVERSIZED_MARKER }] : []),
   ];
   const auditComments = [
     ...(legitimacyStopped ? [{
@@ -188,10 +188,10 @@ function resolveClassificationState({
     ok: true, mode: "classification", expectedSha, labelSets, addLabels, comments, auditComments,
     dispatchReview: !forced,
     removeCommentMarkers: [
-      // A later push can make a previously reported duplicate or XL verdict wrong, and stale
+      // A later push can make a previously reported duplicate or oversized verdict wrong, and stale
       // guidance would then contradict the labels this run just wrote.
       ...(duplicate ? [] : [DUPLICATE_MARKER]),
-      ...(isXl && !forced ? [] : [XL_MARKER]),
+      ...(isOversized && !forced ? [] : [OVERSIZED_MARKER]),
     ],
     legitimacyStopped,
     check: {
@@ -339,6 +339,6 @@ function resolveReviewState({
 
 module.exports = {
   AI_COUNTS, DUPLICATE_MARKER, FORK_QUOTA_MARKER, GLOBAL_QUOTA_MARKER, LEGITIMACY_LABEL,
-  LEGITIMACY_MARKER_PREFIX, RISK, XL_MARKER, ELIGIBLE_MERGED_PRS, contributorEligibility, isExcludedHistory,
+  LEGITIMACY_MARKER_PREFIX, RISK, OVERSIZED_MARKER, ELIGIBLE_MERGED_PRS, contributorEligibility, isExcludedHistory,
   qualifyingMergedPrs, resolveClassificationState, resolveReviewState, reviewPolicyEligible,
 };

--- a/.github/pr-automation/resolve-state.js
+++ b/.github/pr-automation/resolve-state.js
@@ -11,6 +11,7 @@ const LEGITIMACY_LABEL = "triage/legitimacy";
 const LEGITIMACY_MARKER_PREFIX = "<!-- ironrdp-pr-automation:legitimacy:v2:";
 const DUPLICATE_MARKER = "<!-- ironrdp-pr-automation:duplicate -->";
 const OVERSIZED_MARKER = "<!-- ironrdp-pr-automation:oversized -->";
+const LEGACY_XL_MARKER = "<!-- ironrdp-pr-automation:xl -->";
 const FORK_QUOTA_MARKER = "<!-- ironrdp-pr-automation:fork-llm-quota -->";
 const GLOBAL_QUOTA_MARKER = "<!-- ironrdp-pr-automation:fork-llm-global-budget -->";
 const ELIGIBLE_MERGED_PRS = 3;
@@ -94,7 +95,7 @@ function oversizedClassification(expectedSha, deterministic, semverStatus) {
     comments: [{ kind: "oversized", marker: OVERSIZED_MARKER }],
     // Duplicate and legitimacy verdicts are model-derived. No model ran, so a previously posted
     // verdict is neither confirmed nor refuted here and is left untouched.
-    removeCommentMarkers: [],
+    removeCommentMarkers: [LEGACY_XL_MARKER],
     check: {
       name: "AI classification",
       externalId: `${CLASSIFIER_SCHEMA_VERSION}:${expectedSha}`,
@@ -191,7 +192,7 @@ function resolveClassificationState({
       // A later push can make a previously reported duplicate or oversized verdict wrong, and stale
       // guidance would then contradict the labels this run just wrote.
       ...(duplicate ? [] : [DUPLICATE_MARKER]),
-      ...(isOversized && !forced ? [] : [OVERSIZED_MARKER]),
+      ...(isOversized && !forced ? [LEGACY_XL_MARKER] : [OVERSIZED_MARKER, LEGACY_XL_MARKER]),
     ],
     legitimacyStopped,
     check: {
@@ -338,7 +339,7 @@ function resolveReviewState({
 }
 
 module.exports = {
-  AI_COUNTS, DUPLICATE_MARKER, FORK_QUOTA_MARKER, GLOBAL_QUOTA_MARKER, LEGITIMACY_LABEL,
+  AI_COUNTS, DUPLICATE_MARKER, FORK_QUOTA_MARKER, GLOBAL_QUOTA_MARKER, LEGACY_XL_MARKER, LEGITIMACY_LABEL,
   LEGITIMACY_MARKER_PREFIX, RISK, OVERSIZED_MARKER, ELIGIBLE_MERGED_PRS, contributorEligibility, isExcludedHistory,
   qualifyingMergedPrs, resolveClassificationState, resolveReviewState, reviewPolicyEligible,
 };

--- a/.github/pr-automation/write-state.js
+++ b/.github/pr-automation/write-state.js
@@ -40,8 +40,8 @@ function markerBody(comment, owner, repo) {
   if (comment.kind === "duplicate") {
     return `${comment.marker}\n\nPotential duplicate detected: ${escapeMarkdown(comment.url)}.\n\n${escapeMarkdown(comment.rationale)}\n\nMaintainer review is required.`;
   }
-  if (comment.kind === "xl") {
-    return `${comment.marker}\n\nThis pull request is \`size/XL\`, so automated review is disabled for it: a change this large is hard to review well in one piece, whether by a human or a model.\n\nPlease split it into focused pull requests that can each be reviewed on their own. When the parts build on each other, [stacked pull requests](https://docs.github.com/en/pull-requests/get-started/about-stacked-prs) let you open each one on top of the last without waiting for the one below to merge. Stacks require every branch to live in this repository, so from a fork, please open separate pull requests instead.\n\nAutomated review resumes once the change is below the \`size/XL\` threshold.`;
+  if (comment.kind === "oversized") {
+    return `${comment.marker}\n\nThis pull request is \`size/XXL\`, so automated review is disabled for it: a change this large is hard to review well in one piece, whether by a human or a model.\n\nPlease split it into focused pull requests that can each be reviewed on their own. When the parts build on each other, [stacked pull requests](https://docs.github.com/en/pull-requests/get-started/about-stacked-prs) let you open each one on top of the last without waiting for the one below to merge. Stacks require every branch to live in this repository, so from a fork, please open separate pull requests instead.\n\nAutomated review resumes once the change is below the \`size/XXL\` threshold.`;
   }
   if (comment.kind === "legitimacy") {
     return `${comment.marker}\n\nAutomated review stopped because commit \`${escapeMarkdown(comment.sha)}\` has strong indicators requiring maintainer triage.\n\n${escapeMarkdown(comment.reason)}\n\nThis comment remains as an audit record if later classifications differ. Maintainer review is required.`;

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -368,7 +368,7 @@ jobs:
       (needs.resolve-pr.outputs.force == 'true' ||
       (needs.classification-gate.outputs.available == 'true' &&
       needs.classification-gate.outputs.required == 'true' &&
-      needs.deterministic-analysis.outputs.size-label != 'size/XL' &&
+      needs.deterministic-analysis.outputs.size-label != 'size/XXL' &&
       needs.fork-rate-limit.result == 'success' &&
       needs.fork-rate-limit.outputs.allowed == 'true' &&
       !contains(fromJSON(needs.resolve-pr.outputs.labels), 'ai-reviewed/2')))


### PR DESCRIPTION
Classify pull requests by the larger changed-line or touched-file bucket. Add `size/XXL` and reserve split guidance and review exclusion for it.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>