### PR TITLE
feat(agents): add crate creation skills

### DIFF
--- a/.agents/skills/crate-readme-writer/SKILL.md
+++ b/.agents/skills/crate-readme-writer/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: crate-readme-writer
+description: Write or substantially revise a Rust crate's README.md as a concise, user-facing design document. Use whenever creating a crate README, documenting a planned crate, or defining a crate's purpose and public interface before implementation.
+---
+
+# Crate README writer
+
+Invoke `docs-writer` and apply its rules throughout.
+
+For a new crate, write the README before implementing behavior.
+Use it as a lightweight specification: changing prose and examples is cheaper than changing code, and a written proposal gives collaborators a concrete design to review.
+For an existing crate, inspect its manifest and implementation first so the README describes current behavior rather than an imagined interface.
+
+1. Identify the intended reader, the problem the crate solves, and why it belongs in the repository.
+2. Lead with the crate name and a one- or two-sentence description of its purpose.
+3. Describe the smallest useful public contract: principal capability, expected integration point, and important platform or architectural constraints.
+4. Add a minimal usage example only when it clarifies the intended API better than prose.
+5. Revise the proposed interface in the README until it is coherent before committing to implementation details.
+6. Treat a long or complicated README as design feedback: narrow or split the crate instead of writing an exhaustive specification.
+7. Link to existing project or protocol documentation rather than duplicating it.
+8. After implementation, verify every claim and example against the code while preserving the README's concise introductory role.
+
+Write `README.md` directly.
+Keep it short enough to expose unclear scope and unnecessary complexity.
+
+This workflow follows [Readme Driven Development](https://tom.preston-werner.com/2010/08/23/readme-driven-development).

--- a/.agents/skills/crate-readme-writer/SKILL.md
+++ b/.agents/skills/crate-readme-writer/SKILL.md
@@ -11,14 +11,14 @@ For a new crate, write the README before implementing behavior.
 Use it as a lightweight specification: changing prose and examples is cheaper than changing code, and a written proposal gives collaborators a concrete design to review.
 For an existing crate, inspect its manifest and implementation first so the README describes current behavior rather than an imagined interface.
 
-1. Identify the intended reader, the problem the crate solves, and why it belongs in the repository.
-2. Lead with the crate name and a one- or two-sentence description of its purpose.
-3. Describe the smallest useful contract: principal capability, expected integration point, and important platform or architectural constraints.
-4. Add a minimal usage example only when it clarifies the intended API better than prose.
-5. Revise the proposed interface in the README until it is coherent before committing to implementation details.
-6. Treat a long or complicated README as design feedback: narrow or split the crate instead of writing an exhaustive specification.
-7. Link to existing project or protocol documentation rather than duplicating it.
-8. After implementation, verify every claim and example against the code while preserving the README's concise introductory role.
+- Identify the intended reader, the problem the crate solves, and why it belongs in the repository.
+- Lead with the crate name and a one- or two-sentence description of its purpose.
+- Describe the smallest useful contract: principal capability, expected integration point, and important platform or architectural constraints.
+- Add a minimal usage example only when it clarifies the intended API better than prose.
+- Revise the proposed interface until it is coherent before committing to implementation details.
+- Treat a long or complicated README as design feedback: narrow or split the crate instead of writing an exhaustive specification.
+- Link to existing project or protocol documentation rather than duplicating it.
+- After implementation, verify every claim and example against the code while preserving the README's concise introductory role.
 
 Write `README.md` directly.
 Keep it short enough to expose unclear scope and unnecessary complexity.

--- a/.agents/skills/crate-readme-writer/SKILL.md
+++ b/.agents/skills/crate-readme-writer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: crate-readme-writer
-description: Write or substantially revise a Rust crate's README.md as a concise, user-facing design document. Use whenever creating a crate README, documenting a planned crate, or defining a crate's purpose and public interface before implementation.
+description: Write or substantially revise a Rust crate's README.md as a concise, user-facing design document. Use whenever creating a crate README, documenting a planned crate, or defining a crate's purpose, role, or interface before implementation.
 ---
 
 # Crate README writer
@@ -13,7 +13,7 @@ For an existing crate, inspect its manifest and implementation first so the READ
 
 1. Identify the intended reader, the problem the crate solves, and why it belongs in the repository.
 2. Lead with the crate name and a one- or two-sentence description of its purpose.
-3. Describe the smallest useful public contract: principal capability, expected integration point, and important platform or architectural constraints.
+3. Describe the smallest useful contract: principal capability, expected integration point, and important platform or architectural constraints.
 4. Add a minimal usage example only when it clarifies the intended API better than prose.
 5. Revise the proposed interface in the README until it is coherent before committing to implementation details.
 6. Treat a long or complicated README as design feedback: narrow or split the crate instead of writing an exhaustive specification.

--- a/.agents/skills/new-crate/SKILL.md
+++ b/.agents/skills/new-crate/SKILL.md
@@ -31,11 +31,3 @@ Determine the crate's name, purpose, architectural tier, API-boundary status, an
    Do not reorder or rewrite unrelated entries.
 7. Add dependencies and implementation only after the README and architecture entry establish the crate's role.
 8. Format the generated files and run the narrowest workspace checks that cover the new crate.
-
-Confirm that Cargo recognizes the package and that the final manifest retains:
-
-```toml
-[lib]
-doctest = false
-test = false
-```

--- a/.agents/skills/new-crate/SKILL.md
+++ b/.agents/skills/new-crate/SKILL.md
@@ -10,9 +10,9 @@ Determine the crate's name, purpose, architectural tier, API-boundary status, an
 
 1. Run `cargo new --lib --vcs none crates/<crate-name>` from the repository root.
    Do not hand-create the directory or initial `Cargo.toml`.
-   Treat the generated manifest as a starting point because `cargo new` does not add all repository metadata.
+   Preserve the workspace inheritance entries generated from `[workspace.package]`.
 2. Align `[package]` with a nearby same-tier crate.
-   Set `readme`, `description`, the repository's current `rust-version`, and workspace inheritance for `edition`, `license`, `homepage`, `repository`, `authors`, `keywords`, and `categories`.
+   Add `readme`, `description`, and the repository's current `rust-version`.
    Add `[lints] workspace = true`.
 3. Add these target settings:
 

--- a/.agents/skills/new-crate/SKILL.md
+++ b/.agents/skills/new-crate/SKILL.md
@@ -30,4 +30,3 @@ Determine the crate's name, purpose, architectural tier, API-boundary status, an
    State API-boundary or architectural invariants only when they materially apply.
    Do not reorder or rewrite unrelated entries.
 7. Add dependencies and implementation only after the README and architecture entry establish the crate's role.
-8. Format the generated files and run the narrowest workspace checks that cover the new crate.

--- a/.agents/skills/new-crate/SKILL.md
+++ b/.agents/skills/new-crate/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: new-crate
+description: Create and integrate a new Rust crate in the IronRDP workspace. Use whenever adding, scaffolding, or initializing a crate under crates/, including requests that mention cargo new, a new library package, or registering a crate in the architecture.
+---
+
+# New crate
+
+Inspect the root `Cargo.toml`, nearby same-tier crates, and `ARCHITECTURE.md` before creating files.
+Determine the crate's name, purpose, architectural tier, API-boundary status, and platform or `no_std` constraints from the request and repository rules.
+
+1. Run `cargo new --lib --vcs none crates/<crate-name>` from the repository root.
+   Do not hand-create the directory or initial `Cargo.toml`; `cargo new` connects generated package metadata to the workspace configuration.
+2. Preserve the generated workspace metadata inheritance and align any additional package fields with nearby crates.
+3. Add these target settings:
+
+   ```toml
+   [lib]
+   doctest = false
+   test = false
+   ```
+
+4. Remove Cargo's sample function and test before adding the crate's real implementation.
+5. Invoke `crate-readme-writer` and write a short `README.md` before implementing crate behavior.
+   Set `readme = "README.md"` and a concise `description` in `[package]` when `cargo new` did not add them.
+6. Add the crate to the appropriate tier in `ARCHITECTURE.md`.
+   Follow the existing `#### [`crates/<crate-name>`](./crates/<crate-name>)` heading and concise-description pattern.
+   State API-boundary or architectural invariants only when they materially apply.
+   Do not reorder or rewrite unrelated entries.
+7. Add dependencies and implementation only after the README and architecture entry establish the crate's role.
+8. Format the generated files and run the narrowest workspace checks that cover the new crate.
+
+Confirm that Cargo recognizes the package and that the final manifest retains:
+
+```toml
+[lib]
+doctest = false
+test = false
+```

--- a/.agents/skills/new-crate/SKILL.md
+++ b/.agents/skills/new-crate/SKILL.md
@@ -5,28 +5,22 @@ description: Create and integrate a new Rust crate in the IronRDP workspace. Use
 
 # New crate
 
-Inspect the root `Cargo.toml`, nearby same-tier crates, and `ARCHITECTURE.md` before creating files.
-Determine the crate's name, purpose, architectural tier, API-boundary status, and platform or `no_std` constraints from the request and repository rules.
+Run `cargo new --lib --vcs none crates/<crate-name>` from the repository root.
+Do not hand-create the directory or initial `Cargo.toml`.
 
-1. Run `cargo new --lib --vcs none crates/<crate-name>` from the repository root.
-   Do not hand-create the directory or initial `Cargo.toml`.
-   Preserve the workspace inheritance entries generated from `[workspace.package]`.
-2. Align `[package]` with a nearby same-tier crate.
-   Add `readme`, `description`, and the repository's current `rust-version`.
-   Add `[lints] workspace = true`.
-3. Add these target settings:
+In the generated manifest:
 
-   ```toml
-   [lib]
-   doctest = false
-   test = false
-   ```
+- Preserve the workspace inheritance entries.
+- Set `version = "0.0.0"` and `publish = false`.
+- Add `readme`, `description`, the repository's current `rust-version`, and `[lints] workspace = true`.
+- Add:
 
-4. Remove Cargo's sample function and test before adding the crate's real implementation.
-5. Invoke `crate-readme-writer` and write a short `README.md` before implementing crate behavior.
-6. Add the crate to the appropriate tier in `ARCHITECTURE.md`.
-   Follow the existing `#### [`crates/<crate-name>`](./crates/<crate-name>)` heading and concise-description pattern.
-   For a Community Tier crate, append the responsible maintainer suffix used by neighboring entries.
-   State API-boundary or architectural invariants only when they materially apply.
-   Do not reorder or rewrite unrelated entries.
-7. Add dependencies and implementation only after the README and architecture entry establish the crate's role.
+  ```toml
+  [lib]
+  doctest = false
+  test = false
+  ```
+
+Invoke `crate-readme-writer` to write a short `README.md`.
+Add the crate to the appropriate `ARCHITECTURE.md` tier by following its existing entry pattern.
+Invoke `public-dependency` whenever adding a dependency.

--- a/.agents/skills/new-crate/SKILL.md
+++ b/.agents/skills/new-crate/SKILL.md
@@ -9,8 +9,11 @@ Inspect the root `Cargo.toml`, nearby same-tier crates, and `ARCHITECTURE.md` be
 Determine the crate's name, purpose, architectural tier, API-boundary status, and platform or `no_std` constraints from the request and repository rules.
 
 1. Run `cargo new --lib --vcs none crates/<crate-name>` from the repository root.
-   Do not hand-create the directory or initial `Cargo.toml`; `cargo new` connects generated package metadata to the workspace configuration.
-2. Preserve the generated workspace metadata inheritance and align any additional package fields with nearby crates.
+   Do not hand-create the directory or initial `Cargo.toml`.
+   Treat the generated manifest as a starting point because `cargo new` does not add all repository metadata.
+2. Align `[package]` with a nearby same-tier crate.
+   Set `readme`, `description`, the repository's current `rust-version`, and workspace inheritance for `edition`, `license`, `homepage`, `repository`, `authors`, `keywords`, and `categories`.
+   Add `[lints] workspace = true`.
 3. Add these target settings:
 
    ```toml
@@ -21,9 +24,9 @@ Determine the crate's name, purpose, architectural tier, API-boundary status, an
 
 4. Remove Cargo's sample function and test before adding the crate's real implementation.
 5. Invoke `crate-readme-writer` and write a short `README.md` before implementing crate behavior.
-   Set `readme = "README.md"` and a concise `description` in `[package]` when `cargo new` did not add them.
 6. Add the crate to the appropriate tier in `ARCHITECTURE.md`.
    Follow the existing `#### [`crates/<crate-name>`](./crates/<crate-name>)` heading and concise-description pattern.
+   For a Community Tier crate, append the responsible maintainer suffix used by neighboring entries.
    State API-boundary or architectural invariants only when they materially apply.
    Do not reorder or rewrite unrelated entries.
 7. Add dependencies and implementation only after the README and architecture entry establish the crate's role.

--- a/.agents/skills/public-dependency/SKILL.md
+++ b/.agents/skills/public-dependency/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: public-dependency
+description: Add or change Rust crate dependencies while preserving IronRDP's public-dependency markers. Use whenever adding, updating, renaming, removing, or changing features of a Cargo dependency, or when a public API starts or stops exposing dependency-owned types or traits.
+---
+
+# Public dependency
+
+Use `cargo add --package <crate> <dependency>` and its flags, then append `# public` on the same manifest line when the dependency is exposed by the crate's public API:
+
+```toml
+dependency = "1" # public
+```
+
+Exposure includes dependency-owned types or traits in re-exports, signatures, public fields, aliases, implementations or bounds, and associated types.
+Whether the dependency is direct, optional, or workspace-internal is irrelevant.
+Do not mark implementation-only, test, or example dependencies.
+
+The marker records that a breaking dependency change can require a breaking crate release.
+Add or remove it as API exposure changes, and preserve a short condition or type note when it clarifies non-obvious exposure.


### PR DESCRIPTION
Capture README-driven design and crate scaffolding workflows as focused, reusable agent instructions.

Add one skill for concise crate READMEs and another that uses `cargo new`, configures library targets, delegates README writing, and updates architecture documentation.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>