### PR TITLE
Use zrip for zstd compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,6 +1590,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fearless_simd"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f5f895dac0865bc235f1364793899569a7db538137f1024dccea56bf41c78d"
+
+[[package]]
 name = "ff"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2960,6 +2966,7 @@ dependencies = [
  "tracing",
  "visibility",
  "x509-cert",
+ "zrip",
  "zstd-safe",
 ]
 
@@ -2977,6 +2984,7 @@ dependencies = [
  "ironrdp-svc",
  "qoicoubeh",
  "tracing",
+ "zrip",
  "zstd-safe",
 ]
 
@@ -3044,6 +3052,8 @@ dependencies = [
  "rstest",
  "tokio",
  "visibility",
+ "zrip",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -7465,6 +7475,42 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zrip"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6514da35b51d81bfc515782396980ac909fe46925fd19701b36329ddec46e8"
+dependencies = [
+ "zrip-core",
+ "zrip-decode",
+ "zrip-encode",
+]
+
+[[package]]
+name = "zrip-core"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9335acd94c1f09f729178fc339f9d49790254c1e98ba076f88df3a3f534c4e7d"
+
+[[package]]
+name = "zrip-decode"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16c26a2ea54a97d013b6f2a430b659fb77e0d5feb0aa3f80cb8c141d6827beba"
+dependencies = [
+ "fearless_simd",
+ "zrip-core",
+]
+
+[[package]]
+name = "zrip-encode"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e7e22b665b947f0240b44805713e87a15c34e86d0891cbe2856c575c5cda1d"
+dependencies = [
+ "zrip-core",
+]
 
 [[package]]
 name = "zstd-safe"

--- a/crates/ironrdp-client/Cargo.toml
+++ b/crates/ironrdp-client/Cargo.toml
@@ -37,6 +37,7 @@ smartcard = ["rdpdr"]
 gateway = ["dep:ironrdp-mstsgu"]
 qoi = ["ironrdp-connector/qoi", "ironrdp-session/qoi"]
 qoiz = ["ironrdp-connector/qoiz", "ironrdp-session/qoiz"]
+qoiz-zstd = ["ironrdp-session/qoiz-zstd", "qoiz"]
 dvc-pipe-proxy = ["dep:ironrdp-dvc-pipe-proxy"]
 dvc-com-plugin = ["dep:ironrdp-dvc-com-plugin"]
 

--- a/crates/ironrdp-server/Cargo.toml
+++ b/crates/ironrdp-server/Cargo.toml
@@ -21,7 +21,9 @@ default = ["rayon", "qoi", "qoiz"]
 helper = ["dep:x509-cert", "dep:rustls-pemfile"]
 rayon = ["dep:rayon"]
 qoi = ["dep:qoicoubeh", "ironrdp-pdu/qoi"]
-qoiz = ["dep:zstd-safe", "qoi", "ironrdp-pdu/qoiz"]
+qoiz = ["dep:zrip", "qoi", "ironrdp-pdu/qoiz"]
+# Compress QOIZ with the reference C zstd implementation instead of the pure Rust one.
+qoiz-zstd = ["dep:zstd-safe", "qoiz"]
 egfx = ["dep:ironrdp-egfx"]
 # Opt-in NSCodec encoder. Off by default so consumers that don't need a legacy
 # bitmap codec fallback (e.g., RemoteFX-only or H.264-capable clients) don't
@@ -60,6 +62,7 @@ rayon = { version = "1.12", optional = true }
 bytes = "1"
 visibility = { version = "0.1", optional = true }
 qoicoubeh = { version = "0.5", optional = true }
+zrip = { version = "0.8", optional = true, default-features = false, features = ["std", "frame", "ldm"] }
 zstd-safe = { version = "7.2", optional = true }
 
 [dev-dependencies]

--- a/crates/ironrdp-server/README.md
+++ b/crates/ironrdp-server/README.md
@@ -63,4 +63,17 @@ local
 
 `send_request` queues a probe via the server event loop. If no client has opened the ECHO channel yet, the request is dropped.
 
+## QOI codecs (features `qoi`, `qoiz`)
+
+`qoiz` compresses the QOI stream with zstd, using [`zrip`], a pure Rust zstd implementation.
+
+Enable `qoiz-zstd` to compress with [`zstd-safe`] (bindings to the reference C implementation)
+instead. It performs slightly better for non-WASM targets, but requires a C compiler to build.
+
+Both options emit the same wire format, so a server using either backend interoperates with a
+client using either one.
+
+[`zrip`]: https://crates.io/crates/zrip
+[`zstd-safe`]: https://crates.io/crates/zstd-safe
+
 [IronRDP]: https://github.com/Devolutions/IronRDP

--- a/crates/ironrdp-server/src/encoder/mod.rs
+++ b/crates/ironrdp-server/src/encoder/mod.rs
@@ -22,6 +22,8 @@ use crate::{ColorPointer, DisplayUpdate, Framebuffer, RGBAPointer};
 
 mod bitmap;
 mod fast_path;
+#[cfg(feature = "qoiz")]
+mod qoiz;
 pub(crate) mod rfx;
 
 pub(crate) use fast_path::*;
@@ -608,41 +610,19 @@ impl BitmapUpdateHandler for QoiHandler {
 }
 
 #[cfg(feature = "qoiz")]
+#[derive(Debug)]
 struct QoizHandler {
     codec_id: u8,
-    zctxt: zstd_safe::CCtx<'static>,
-}
-
-#[cfg(feature = "qoiz")]
-impl fmt::Debug for QoizHandler {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("QoizHandler").field("codec_id", &self.codec_id).finish()
-    }
+    compressor: qoiz::Compressor,
 }
 
 #[cfg(feature = "qoiz")]
 impl QoizHandler {
     fn new(codec_id: u8) -> Result<Self> {
-        let mut zctxt = zstd_safe::CCtx::default();
-
-        zctxt
-            .set_parameter(zstd_safe::CParameter::CompressionLevel(3))
-            .map_err(|code| {
-                anyhow!(
-                    "failed to set zstd compression level: {}",
-                    zstd_safe::get_error_name(code)
-                )
-            })?;
-        zctxt
-            .set_parameter(zstd_safe::CParameter::EnableLongDistanceMatching(true))
-            .map_err(|code| {
-                anyhow!(
-                    "failed to set zstd enable long distance matching: {}",
-                    zstd_safe::get_error_name(code)
-                )
-            })?;
-
-        Ok(Self { codec_id, zctxt })
+        Ok(Self {
+            codec_id,
+            compressor: qoiz::Compressor::new()?,
+        })
     }
 }
 
@@ -650,29 +630,9 @@ impl QoizHandler {
 impl BitmapUpdateHandler for QoizHandler {
     fn handle(&mut self, bitmap: &BitmapUpdate) -> Result<UpdateFragmenter> {
         let qoi = qoi_encode(bitmap)?;
-        let mut inb = zstd_safe::InBuffer::around(&qoi);
-        let mut data = vec![0; qoi.len()];
-        let mut outb;
-        let mut pos = 0;
+        let data = self.compressor.compress(&qoi)?;
 
-        loop {
-            outb = zstd_safe::OutBuffer::around_pos(data.as_mut_slice(), pos);
-            let res = self
-                .zctxt
-                .compress_stream2(
-                    &mut outb,
-                    &mut inb,
-                    zstd_safe::zstd_sys::ZSTD_EndDirective::ZSTD_e_flush,
-                )
-                .map_err(|code| anyhow!("failed to Zstd compress: {}", zstd_safe::get_error_name(code)))?;
-            if res == 0 {
-                break;
-            }
-            pos = outb.pos();
-            data.resize(data.len() + res, 0);
-        }
-
-        set_surface(bitmap, self.codec_id, outb.as_slice())
+        set_surface(bitmap, self.codec_id, &data)
     }
 }
 

--- a/crates/ironrdp-server/src/encoder/qoiz.rs
+++ b/crates/ironrdp-server/src/encoder/qoiz.rs
@@ -1,0 +1,218 @@
+//! Zstd compression for the QOIZ bitmap codec.
+//!
+//! Two backends are available:
+//!
+//! - `zrip`, a pure Rust zstd implementation, used by default.
+//! - `zstd-safe`, bindings to the reference C implementation, used when the
+//!   `qoiz-zstd` feature is enabled.
+//!
+//! Both emit standard zstd frames, so the choice of backend is invisible on the
+//! wire and either side of a connection may use either one.
+
+use anyhow::Result;
+
+/// Streaming compressor for the QOIZ codec.
+pub(crate) struct Compressor(Box<imp::Compressor>);
+
+impl Compressor {
+    pub(crate) fn new() -> Result<Self> {
+        imp::Compressor::new().map(|imp| Self(Box::new(imp)))
+    }
+
+    /// Compresses `input` and returns the bytes produced for this update.
+    pub(crate) fn compress(&mut self, input: &[u8]) -> Result<Vec<u8>> {
+        self.0.compress(input)
+    }
+}
+
+impl core::fmt::Debug for Compressor {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Compressor").field("backend", &imp::NAME).finish()
+    }
+}
+
+#[cfg(not(feature = "qoiz-zstd"))]
+mod imp {
+    use std::io::Write as _;
+    use std::sync::{Arc, Mutex};
+
+    use anyhow::{Context as _, Result, anyhow};
+
+    pub(super) const NAME: &str = "zrip";
+
+    /// Compression level, on zrip's `-8..=4` scale.
+    const COMPRESSION_LEVEL: i32 = 1;
+
+    /// Sink handing the encoder's output back to the caller.
+    ///
+    /// [`zrip::FrameEncoder`] owns its writer and exposes no accessor for it, so
+    /// the buffer is shared rather than borrowed back.
+    #[derive(Clone, Debug, Default)]
+    struct SharedSink(Arc<Mutex<Vec<u8>>>);
+
+    impl std::io::Write for SharedSink {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            let mut sink = self.0.lock().map_err(|_| std::io::Error::other("poisoned sink"))?;
+            sink.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    pub(super) struct Compressor {
+        encoder: zrip::FrameEncoder<SharedSink>,
+        sink: SharedSink,
+    }
+
+    impl Compressor {
+        pub(super) fn new() -> Result<Self> {
+            // Long distance matching is what lets an update match against
+            // earlier ones. Without it, repeated content is re-emitted in full.
+            let options = zrip::Options::default().ldm(true);
+            let sink = SharedSink::default();
+            let encoder = zrip::FrameEncoder::with_options(sink.clone(), COMPRESSION_LEVEL, &options)
+                .map_err(|e| anyhow!("failed to create zstd encoder: {e}"))?;
+
+            Ok(Self { encoder, sink })
+        }
+
+        pub(super) fn compress(&mut self, input: &[u8]) -> Result<Vec<u8>> {
+            self.encoder.write_all(input).context("failed to zstd compress")?;
+            self.encoder.flush().context("failed to zstd compress")?;
+
+            let mut sink = self
+                .sink
+                .0
+                .lock()
+                .map_err(|_| anyhow!("failed to zstd compress: poisoned sink"))?;
+
+            Ok(core::mem::take(&mut *sink))
+        }
+    }
+}
+
+#[cfg(feature = "qoiz-zstd")]
+mod imp {
+    // Cargo features are additive, so `qoiz` keeps pulling zrip in even when
+    // this backend is the one selected. Nothing links it in that case.
+    use zrip as _;
+
+    use anyhow::{Result, anyhow};
+
+    pub(super) const NAME: &str = "zstd-safe";
+
+    const COMPRESSION_LEVEL: i32 = 3;
+
+    pub(super) struct Compressor {
+        zctxt: zstd_safe::CCtx<'static>,
+    }
+
+    impl Compressor {
+        pub(super) fn new() -> Result<Self> {
+            let mut zctxt = zstd_safe::CCtx::default();
+
+            zctxt
+                .set_parameter(zstd_safe::CParameter::CompressionLevel(COMPRESSION_LEVEL))
+                .map_err(|code| {
+                    anyhow!(
+                        "failed to set zstd compression level: {}",
+                        zstd_safe::get_error_name(code)
+                    )
+                })?;
+            zctxt
+                .set_parameter(zstd_safe::CParameter::EnableLongDistanceMatching(true))
+                .map_err(|code| {
+                    anyhow!(
+                        "failed to set zstd enable long distance matching: {}",
+                        zstd_safe::get_error_name(code)
+                    )
+                })?;
+
+            Ok(Self { zctxt })
+        }
+
+        pub(super) fn compress(&mut self, input: &[u8]) -> Result<Vec<u8>> {
+            let mut inb = zstd_safe::InBuffer::around(input);
+            let mut data = vec![0; input.len()];
+            let mut outb;
+            let mut pos = 0;
+
+            loop {
+                outb = zstd_safe::OutBuffer::around_pos(data.as_mut_slice(), pos);
+                let res = self
+                    .zctxt
+                    .compress_stream2(
+                        &mut outb,
+                        &mut inb,
+                        zstd_safe::zstd_sys::ZSTD_EndDirective::ZSTD_e_flush,
+                    )
+                    .map_err(|code| anyhow!("failed to Zstd compress: {}", zstd_safe::get_error_name(code)))?;
+                if res == 0 {
+                    break;
+                }
+                pos = outb.pos();
+                data.resize(data.len() + res, 0);
+            }
+
+            let len = outb.pos();
+            data.truncate(len);
+
+            Ok(data)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Magic bytes every zstd frame starts with.
+    const ZSTD_MAGIC: [u8; 4] = [0x28, 0xb5, 0x2f, 0xfd];
+
+    fn payload(i: u8) -> Vec<u8> {
+        // `j / 17` stays under 121, so the conversion never truncates.
+        (0..2048u32)
+            .map(|j| u8::try_from(j / 17).expect("fits in u8").wrapping_add(i))
+            .collect()
+    }
+
+    #[test]
+    fn produces_a_zstd_frame() {
+        let mut compressor = Compressor::new().unwrap();
+
+        let compressed = compressor.compress(&payload(0)).unwrap();
+
+        assert_eq!(compressed.get(..4), Some(ZSTD_MAGIC.as_slice()));
+    }
+
+    /// Locks in long-distance-matching (LDM) behavior.
+    #[test]
+    fn reuses_history_across_updates() {
+        let mut compressor = Compressor::new().unwrap();
+
+        let first = compressor.compress(&payload(0)).unwrap();
+        compressor.compress(&payload(1)).unwrap();
+        let repeat = compressor.compress(&payload(0)).unwrap();
+
+        assert!(
+            repeat.len() * 4 < first.len(),
+            "repeated update did not match against history: {} bytes vs {} bytes",
+            repeat.len(),
+            first.len()
+        );
+    }
+
+    #[test]
+    fn flushes_every_update() {
+        let mut compressor = Compressor::new().unwrap();
+
+        for i in 0..8 {
+            let compressed = compressor.compress(&payload(i)).unwrap();
+
+            assert!(!compressed.is_empty(), "update {i} produced no output");
+        }
+    }
+}

--- a/crates/ironrdp-session/Cargo.toml
+++ b/crates/ironrdp-session/Cargo.toml
@@ -19,7 +19,10 @@ test = false
 [features]
 default = []
 qoi = ["dep:qoicoubeh", "ironrdp-pdu/qoi"]
-qoiz = ["dep:zstd-safe", "qoi"]
+qoiz = ["dep:zrip", "qoi"]
+# Decompress QOIZ with the reference C zstd implementation
+# instead of the pure Rust one.
+qoiz-zstd = ["dep:zstd-safe", "qoiz"]
 
 [dependencies]
 ironrdp-bulk = { path = "../ironrdp-bulk", version = "0.1" } # public
@@ -32,6 +35,7 @@ ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9", features = ["std"] } #
 ironrdp-displaycontrol = { path = "../ironrdp-displaycontrol", version = "0.8" }
 tracing = { version = "0.1", features = ["log"] }
 qoicoubeh = { version = "0.5", optional = true }
+zrip = { version = "0.8", optional = true, default-features = false, features = ["std", "frame", "simd"] }
 zstd-safe = { version = "7.2", optional = true, features = ["std"] }
 
 [lints]

--- a/crates/ironrdp-session/README.md
+++ b/crates/ironrdp-session/README.md
@@ -2,6 +2,19 @@
 
 Abstract state machine to drive an RDP session.
 
+## QOI codecs (features `qoi`, `qoiz`)
+
+`qoiz` compresses the QOI stream with zstd, using [`zrip`], a pure Rust zstd implementation.
+
+Enable `qoiz-zstd` to compress with [`zstd-safe`] (bindings to the reference C implementation)
+instead. It performs slightly better for non-WASM targets, but requires a C compiler to build.
+
+Both options emit the same wire format, so a server using either backend interoperates with a
+client using either one.
+
 This crate is part of the [IronRDP] project.
+
+[`zrip`]: https://crates.io/crates/zrip
+[`zstd-safe`]: https://crates.io/crates/zstd-safe
 
 [IronRDP]: https://github.com/Devolutions/IronRDP

--- a/crates/ironrdp-session/src/fast_path.rs
+++ b/crates/ironrdp-session/src/fast_path.rs
@@ -140,7 +140,7 @@ pub struct Processor {
     bitmap_recovery_requested: bool,
     bitmap_recovery_pending: bool,
     #[cfg(feature = "qoiz")]
-    zdctx: zstd_safe::DCtx<'static>,
+    qoiz_decompressor: crate::qoiz::Decompressor,
 }
 
 impl Processor {
@@ -790,23 +790,10 @@ impl Processor {
                         }
                         #[cfg(feature = "qoiz")]
                         ironrdp_pdu::rdp::capability_sets::CODEC_ID_QOIZ => {
-                            let compressed = &bits.extended_bitmap_data.data;
-                            let mut input = zstd_safe::InBuffer::around(compressed);
-                            let mut data = vec![0; compressed.len() * 4];
-                            let mut pos = 0;
-                            loop {
-                                let mut output = zstd_safe::OutBuffer::around_pos(data.as_mut_slice(), pos);
-                                self.zdctx
-                                    .decompress_stream(&mut output, &mut input)
-                                    .map_err(zstd_safe::get_error_name)
-                                    .map_err(|e| reason_err!("zstd", "{}", e))?;
-                                pos = output.pos();
-                                if pos == output.capacity() {
-                                    data.resize(data.capacity() * 2, 0);
-                                } else {
-                                    break;
-                                }
-                            }
+                            let data = self
+                                .qoiz_decompressor
+                                .decompress(bits.extended_bitmap_data.data)
+                                .map_err(|e| reason_err!("zstd", "{}", e))?;
 
                             qoi_apply(image, destination, &data, &mut update_rectangle)?;
                         }
@@ -902,7 +889,7 @@ impl ProcessorBuilder {
             bitmap_recovery_requested: false,
             bitmap_recovery_pending: false,
             #[cfg(feature = "qoiz")]
-            zdctx: zstd_safe::DCtx::default(),
+            qoiz_decompressor: crate::qoiz::Decompressor::new(),
         }
     }
 }

--- a/crates/ironrdp-session/src/lib.rs
+++ b/crates/ironrdp-session/src/lib.rs
@@ -12,6 +12,8 @@ pub mod x224;
 
 mod active_stage;
 mod palette;
+#[cfg(feature = "qoiz")]
+mod qoiz;
 
 use core::fmt;
 

--- a/crates/ironrdp-session/src/qoiz.rs
+++ b/crates/ironrdp-session/src/qoiz.rs
@@ -1,0 +1,248 @@
+//! Zstd decompression backend for the QOIZ bitmap codec.
+//!
+//! Two backends are available:
+//!
+//! - [`zrip`], a pure Rust zstd implementation, used by default.
+//! - `zstd-safe`, bindings to the reference C implementation, used when the
+//!   `qoiz-zstd` feature is enabled.
+//!
+//! Both consume standard zstd frames, so the choice of backend is invisible on
+//! the wire and either side of a connection may use either one.
+
+/// Streaming decompressor for the QOIZ codec.
+///
+/// Must be fed every update of a session, in order: an update is decoded
+/// against the history of the ones before it.
+pub(crate) struct Decompressor(Box<imp::Decompressor>);
+
+impl Decompressor {
+    pub(crate) fn new() -> Self {
+        Self(Box::new(imp::Decompressor::new()))
+    }
+
+    /// Decompresses the payload of a single surface command.
+    pub(crate) fn decompress(&mut self, input: &[u8]) -> std::io::Result<Vec<u8>> {
+        self.0.decompress(input)
+    }
+}
+
+impl core::fmt::Debug for Decompressor {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Decompressor").field("backend", &imp::NAME).finish()
+    }
+}
+
+#[cfg(not(feature = "qoiz-zstd"))]
+mod imp {
+    use std::io::Read as _;
+    use std::sync::{Arc, Mutex};
+
+    pub(super) const NAME: &str = "zrip";
+
+    /// Size of the chunks pulled out of the decoder at a time.
+    const READ_CHUNK: usize = 16 * 1024;
+
+    /// Source feeding one update at a time to the decoder.
+    #[derive(Clone, Debug, Default)]
+    struct SharedSource(Arc<Mutex<Vec<u8>>>);
+
+    impl std::io::Read for SharedSource {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            let mut source = self.0.lock().map_err(|_| std::io::Error::other("poisoned source"))?;
+            let len = buf.len().min(source.len());
+            buf[..len].copy_from_slice(&source[..len]);
+            source.drain(..len);
+            Ok(len)
+        }
+    }
+
+    pub(super) struct Decompressor {
+        decoder: zrip::FrameDecoder<SharedSource>,
+        source: SharedSource,
+    }
+
+    impl Decompressor {
+        pub(super) fn new() -> Self {
+            let source = SharedSource::default();
+
+            Self {
+                decoder: zrip::FrameDecoder::new(source.clone()),
+                source,
+            }
+        }
+
+        pub(super) fn decompress(&mut self, input: &[u8]) -> std::io::Result<Vec<u8>> {
+            {
+                let mut source = self
+                    .source
+                    .0
+                    .lock()
+                    .map_err(|_| std::io::Error::other("poisoned source"))?;
+                source.extend_from_slice(input);
+            }
+
+            let mut data = Vec::new();
+            let mut buf = [0; READ_CHUNK];
+
+            loop {
+                match self.decoder.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(len) => data.extend_from_slice(&buf[..len]),
+                    // The server flushes after every update, so an update always
+                    // ends on a block boundary. EOF means that this update is fully
+                    // decoded, and the decoder picks the stream back up when the next one arrives.
+                    Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
+                    Err(e) => return Err(e),
+                }
+            }
+
+            Ok(data)
+        }
+    }
+}
+
+#[cfg(feature = "qoiz-zstd")]
+mod imp {
+    // Cargo features are additive, so `qoiz` keeps pulling zrip in even when
+    // this backend is the one selected. Nothing links it in that case.
+    use zrip as _;
+
+    pub(super) const NAME: &str = "zstd-safe";
+
+    pub(super) struct Decompressor {
+        zdctx: zstd_safe::DCtx<'static>,
+    }
+
+    impl Decompressor {
+        pub(super) fn new() -> Self {
+            Self {
+                zdctx: zstd_safe::DCtx::default(),
+            }
+        }
+
+        pub(super) fn decompress(&mut self, input: &[u8]) -> std::io::Result<Vec<u8>> {
+            let mut source = zstd_safe::InBuffer::around(input);
+            let mut data = vec![0; input.len() * 4];
+            let mut pos = 0;
+
+            loop {
+                let mut output = zstd_safe::OutBuffer::around_pos(data.as_mut_slice(), pos);
+                self.zdctx
+                    .decompress_stream(&mut output, &mut source)
+                    .map_err(zstd_safe::get_error_name)
+                    .map_err(std::io::Error::other)?;
+                pos = output.pos();
+                if pos == output.capacity() {
+                    data.resize(data.capacity() * 2, 0);
+                } else {
+                    break;
+                }
+            }
+
+            data.truncate(pos);
+
+            Ok(data)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Payload of the update at index `i` in the streams below.
+    fn payload(i: u8) -> Vec<u8> {
+        // `j / 17` stays under 121, so the conversion never truncates.
+        (0..2048u32)
+            .map(|j| u8::try_from(j / 17).expect("fits in u8").wrapping_add(i))
+            .collect()
+    }
+
+    /// The updates encoded by both streams below. The third repeats the first,
+    /// so decoding it correctly requires the history of the earlier updates.
+    fn payloads() -> Vec<Vec<u8>> {
+        vec![payload(0), payload(1), payload(0), payload(2)]
+    }
+
+    // The two streams below contain four updates of a single zstd stream
+    // as produced by each of the two backends.
+    //
+    // Decoding both of them here proves that each backend can decode streams
+    // produced by the other.
+
+    const ZSTD_SAFE_STREAM: &[&[u8]] = &[
+        &[
+            0x28, 0xb5, 0x2f, 0xfd, 0x00, 0x88, 0x44, 0x04, 0x00, 0x12, 0x88, 0x1d, 0x07, 0x10, 0x10, 0xdf, 0x30, 0xb3,
+            0x7f, 0x0a, 0xff, 0xff, 0xff, 0xff, 0x01, 0x00, 0x75, 0xfa, 0x5c, 0x1e, 0x87, 0xbf, 0xdd, 0x6d, 0xf6, 0x5a,
+            0x9d, 0x46, 0x9f, 0xcd, 0x65, 0xf2, 0x58, 0x1c, 0x06, 0x7f, 0xbd, 0x5d, 0xee, 0x56, 0x9b, 0xc5, 0x5e, 0xad,
+            0x55, 0xea, 0x54, 0x1a, 0x85, 0x3e, 0x9d, 0x4d, 0xe6, 0x52, 0x99, 0x44, 0x1e, 0x8d, 0x45, 0xe2, 0x50, 0x18,
+            0x04, 0xfe, 0x7c, 0x3d, 0xde, 0x4e, 0x97, 0xc3, 0xdd, 0x6c, 0x35, 0xda, 0x4c, 0x16, 0x83, 0xbd, 0x5c, 0x2d,
+            0xd6, 0x4a, 0x95, 0x42, 0x9d, 0x4c, 0x25, 0xd2, 0x48, 0x14, 0x02, 0x7d, 0x3c, 0x1d, 0xce, 0x46, 0x93, 0xc1,
+            0x5c, 0x2c, 0x15, 0xca, 0x44, 0x12, 0x81, 0x3c, 0x1c, 0x0d, 0xc6, 0x42, 0x91, 0x40, 0x1c, 0x0c, 0x05, 0xc2,
+            0x40, 0x10, 0xd8, 0xf7, 0x78, 0x98, 0x10, 0xf0, 0x07, 0x00, 0x10, 0x7e, 0xc5, 0x0f, 0xd5, 0xda, 0x38, 0x48,
+            0x01,
+        ],
+        &[
+            0x94, 0x00, 0x00, 0x40, 0x79, 0x79, 0x79, 0x79, 0x79, 0x79, 0x79, 0x79, 0x02, 0x00, 0xb8, 0x02, 0xd8, 0x97,
+            0xff, 0xcf, 0x40,
+        ],
+        &[0x44, 0x00, 0x00, 0x00, 0x01, 0x00, 0xfd, 0x0f, 0xc0, 0x7f, 0x80],
+        &[
+            0x94, 0x00, 0x00, 0x40, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x02, 0x00, 0xb8, 0x02, 0xd8, 0x97,
+            0xff, 0x0f, 0x81,
+        ],
+    ];
+
+    const ZRIP_STREAM: &[&[u8]] = &[
+        &[
+            0x28, 0xb5, 0x2f, 0xfd, 0x04, 0x48, 0x44, 0x04, 0x00, 0x04, 0x08, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+            0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+            0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a,
+            0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c,
+            0x3d, 0x3e, 0x3f, 0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e,
+            0x4f, 0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5a, 0x5b, 0x5c, 0x5d, 0x5e, 0x5f, 0x60,
+            0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x6b, 0x6c, 0x6d, 0x6e, 0x6f, 0x70, 0x71, 0x72,
+            0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x78, 0x54, 0x01, 0x00, 0x0d,
+            0x01,
+        ],
+        &[
+            0x9c, 0x00, 0x00, 0x48, 0x78, 0x79, 0x79, 0x79, 0x79, 0x79, 0x79, 0x79, 0x79, 0x02, 0x00, 0x2e, 0x21, 0xec,
+            0xcb, 0xff, 0x67, 0x20,
+        ],
+        &[0x44, 0x00, 0x00, 0x00, 0x01, 0x00, 0xfd, 0x0f, 0xc0, 0x7f, 0x80],
+        &[
+            0x9c, 0x00, 0x00, 0x48, 0x79, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x7a, 0x02, 0x00, 0x2f, 0x21, 0xec,
+            0xcb, 0xff, 0x87, 0x40,
+        ],
+    ];
+
+    fn assert_decodes(stream: &[&[u8]]) {
+        let mut decompressor = Decompressor::new();
+
+        for (update, expected) in stream.iter().zip(payloads()) {
+            let decompressed = decompressor.decompress(update).unwrap();
+            assert_eq!(decompressed, expected);
+        }
+    }
+
+    #[test]
+    fn decompresses_stream_produced_by_zstd_safe() {
+        assert_decodes(ZSTD_SAFE_STREAM);
+    }
+
+    #[test]
+    fn decompresses_stream_produced_by_zrip() {
+        assert_decodes(ZRIP_STREAM);
+    }
+
+    /// An update is only decodable because the ones before it were fed in
+    /// order: starting mid-stream must not silently produce garbage.
+    #[test]
+    fn rejects_stream_joined_late() {
+        let mut decompressor = Decompressor::new();
+
+        let result = decompressor.decompress(ZRIP_STREAM[1]);
+
+        assert!(result.is_err(), "expected an error, got {result:?}");
+    }
+}

--- a/crates/ironrdp-testsuite-core/Cargo.toml
+++ b/crates/ironrdp-testsuite-core/Cargo.toml
@@ -16,6 +16,7 @@ test = false
 # Added here because it includes/link to some files from other crates
 __bench = ["dep:visibility"]
 openh264-bundled = ["ironrdp-egfx/openh264-bundled", "dep:openh264"]
+qoiz-zstd = ["ironrdp-session/qoiz-zstd", "ironrdp-server/qoiz-zstd", "dep:zstd-safe"]
 
 [[test]]
 name = "integration_tests_core"
@@ -31,6 +32,8 @@ ironrdp-pdu.path = "../ironrdp-pdu"
 paste = "1"
 openh264 = { version = "0.9", optional = true, default-features = false, features = ["source"] }
 visibility = { version = "0.1", optional = true }
+zrip = { version = "0.8", default-features = false, features = ["std", "frame", "ldm"] }
+zstd-safe = { version = "7.2", optional = true, features = ["std"] }
 
 [dev-dependencies]
 anyhow = "1"
@@ -55,8 +58,8 @@ ironrdp-rdcleanpath.path = "../ironrdp-rdcleanpath"
 ironrdp-rdpdr.path = "../ironrdp-rdpdr"
 ironrdp-rdpeusb.path = "../ironrdp-rdpeusb"
 ironrdp-rdpsnd = { path = "../ironrdp-rdpsnd", features = ["__test"] }
-ironrdp-server.path = "../ironrdp-server"
-ironrdp-session = { path = "../ironrdp-session", features = ["qoi"] }
+ironrdp-server = { path = "../ironrdp-server", features = ["qoiz"] }
+ironrdp-session = { path = "../ironrdp-session", features = ["qoi", "qoiz"] }
 ironrdp-cfg.path = "../ironrdp-cfg"
 ironrdp-propertyset.path = "../ironrdp-propertyset"
 ironrdp-rdpfile.path = "../ironrdp-rdpfile"

--- a/crates/ironrdp-testsuite-core/tests/server/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/server/mod.rs
@@ -2,3 +2,8 @@ mod acceptor;
 mod autodetect;
 mod credential_validator;
 mod fast_path;
+
+// Pulled in from the crate itself: `ironrdp-server` sets `test = false`, so its
+// inline unit tests only run when compiled as part of this test suite.
+#[path = "../../../ironrdp-server/src/encoder/qoiz.rs"]
+mod qoiz;

--- a/crates/ironrdp-testsuite-core/tests/session/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/session/mod.rs
@@ -1,6 +1,11 @@
 mod autodetect;
 mod connection_activation;
 mod fast_path;
+
+// Pulled in from the crate itself: `ironrdp-session` sets `test = false`, so its
+// inline unit tests only run when compiled as part of this test suite.
+#[path = "../../../ironrdp-session/src/qoiz.rs"]
+mod qoiz;
 mod rfx;
 mod save_session_info;
 

--- a/crates/ironrdp-web/Cargo.toml
+++ b/crates/ironrdp-web/Cargo.toml
@@ -22,6 +22,7 @@ default = ["panic_hook"]
 panic_hook = ["iron-remote-desktop/panic_hook"]
 qoi = ["ironrdp/qoi"]
 qoiz = ["ironrdp/qoiz"]
+qoiz-zstd = ["ironrdp/qoiz-zstd", "qoiz"]
 
 [dependencies]
 # Protocols

--- a/crates/ironrdp/Cargo.toml
+++ b/crates/ironrdp/Cargo.toml
@@ -49,6 +49,7 @@ client-dvc-com-plugin = ["ironrdp-client?/dvc-com-plugin"]
 client-all = ["ironrdp-client?/all"]
 qoi = ["ironrdp-server?/qoi", "ironrdp-pdu?/qoi", "ironrdp-connector?/qoi", "ironrdp-session?/qoi", "ironrdp-client?/qoi"]
 qoiz = ["ironrdp-server?/qoiz", "ironrdp-pdu?/qoiz", "ironrdp-connector?/qoiz", "ironrdp-session?/qoiz", "ironrdp-client?/qoiz"]
+qoiz-zstd = ["ironrdp-server?/qoiz-zstd", "ironrdp-session?/qoiz-zstd", "ironrdp-client?/qoiz-zstd", "qoiz"]
 
 # Internal (PRIVATE!) features used to aid testing.
 # Don't rely on these whatsoever. They may disappear at any time.


### PR DESCRIPTION
The qoiz feature currently requires the zstd-safe crate, which is implemented as Rust bindings to a C library.

This complicates the build process for clients targeting WASM, because you need not only a WASM target for cargo, but a C-compiler capable of targeting WASM.

Update the qoiz feature to instead use zrip (a pure Rust implementation) such that a separate C compiler is not necessary. zrip looks to perform slightly better when targeting WASM, but zstd-safe still wins server-side. For this reason, I added a qoiz-zstd feature that will opt-in to the original zstd-safe library.