### PR TITLE
feat: add native MS-RDPEWA WebAuthn redirection

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -106,6 +106,11 @@ RDPSND static channel for audio output implemented as described in MS-RDPEA.
 
 AUDIO_INPUT dynamic channel for client microphone capture implemented as described in MS-RDPEAI.
 
+#### [`crates/ironrdp-rdpewa`](./crates/ironrdp-rdpewa)
+
+RDPEWA dynamic virtual channel for WebAuthn redirection as described in MS-RDPEWA.
+The Windows backend lives in [`crates/ironrdp-rdpewa-native`](./crates/ironrdp-rdpewa-native).
+
 #### [`crates/ironrdp-connector`](./crates/ironrdp-connector)
 
 State machines to drive an RDP connection sequence.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2950,7 +2950,6 @@ dependencies = [
 name = "ironrdp-rdpewa-native"
 version = "0.1.0"
 dependencies = [
- "ironrdp-dvc-com-plugin",
  "ironrdp-rdpewa",
  "tracing",
  "windows",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2557,8 +2557,11 @@ dependencies = [
  "ironrdp-rail",
  "ironrdp-rdcleanpath",
  "ironrdp-rdpdr",
- "ironrdp-rdpeai",
+"ironrdp-rdpeai",
  "ironrdp-rdpei",
+ "ironrdp-rdpewa",
+ "ironrdp-rdpewa-native",
+
  "ironrdp-rdpsnd",
  "ironrdp-rdpsnd-native",
  "ironrdp-session",
@@ -2931,6 +2934,26 @@ dependencies = [
  "ironrdp-dvc",
  "ironrdp-pdu",
  "ironrdp-str",
+]
+
+[[package]]
+name = "ironrdp-rdpewa"
+version = "0.1.0"
+dependencies = [
+ "ironrdp-core 0.2.1",
+ "ironrdp-dvc",
+ "ironrdp-pdu",
+ "ironrdp-svc",
+ "tracing",
+]
+
+[[package]]
+name = "ironrdp-rdpewa-native"
+version = "0.1.0"
+dependencies = [
+ "ironrdp-rdpewa",
+ "tracing",
+ "windows",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2557,11 +2557,10 @@ dependencies = [
  "ironrdp-rail",
  "ironrdp-rdcleanpath",
  "ironrdp-rdpdr",
-"ironrdp-rdpeai",
+ "ironrdp-rdpeai",
  "ironrdp-rdpei",
  "ironrdp-rdpewa",
  "ironrdp-rdpewa-native",
-
  "ironrdp-rdpsnd",
  "ironrdp-rdpsnd-native",
  "ironrdp-session",
@@ -2951,6 +2950,7 @@ dependencies = [
 name = "ironrdp-rdpewa-native"
 version = "0.1.0"
 dependencies = [
+ "ironrdp-dvc-com-plugin",
  "ironrdp-rdpewa",
  "tracing",
  "windows",

--- a/crates/ironrdp-activex/Cargo.toml
+++ b/crates/ironrdp-activex/Cargo.toml
@@ -20,7 +20,7 @@ doctest = false
 
 [target.'cfg(windows)'.dependencies]
 anyhow = "1"
-ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["clipboard", "dvc-com-plugin", "gateway", "rdpdr", "rustls", "sound"] }
+ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["clipboard", "dvc-com-plugin", "gateway", "rdpdr", "rustls", "sound", "webauthn"] }
 ironrdp-cliprdr = { path = "../ironrdp-cliprdr", version = "0.7" }
 ironrdp-cliprdr-native = { path = "../ironrdp-cliprdr-native", version = "0.7" }
 ironrdp-cfg = { path = "../ironrdp-cfg", version = "0.1" }

--- a/crates/ironrdp-activex/README.md
+++ b/crates/ironrdp-activex/README.md
@@ -480,6 +480,10 @@ Native MS-RDPEWA WebAuthn redirection is controlled through the extended setting
 (default enabled) and the RDP property key `redirectwebauthn`.
 When enabled, the control registers IronRDP's native `WebAuthN_Channel` client with the ActiveX HWND
 as the WebAuthn parent window.
+There is no public MSTSC `IMsRdpClientAdvancedSettings` slot for `RedirectWebAuthn`, so hosts should
+use ExtendedSettings or the RDP property rather than a raw AdvancedSettings vtable index.
+Like other redirect toggles, `RedirectWebAuthn` is not part of `IPersistStreamInit` persistence;
+hosts that need a durable value should store it themselves or in an `.rdp` file.
 When a host also lists `webauthn.dll` under `IronRdpDvcPluginPaths`, that COM plugin is skipped so the
 native channel remains the sole claimant.
 `EnableCredSspSupport` is

--- a/crates/ironrdp-activex/README.md
+++ b/crates/ironrdp-activex/README.md
@@ -476,20 +476,15 @@ Invalid audio modes and keyboard types return `E_INVALIDARG`.
 redirection creates its Windows CLIPRDR listener on the ActiveX creating apartment, where its hidden
 window is serviced by the host message loop; the RDP worker receives only the thread-safe backend
 factory. Disabling it omits the channel.
-Native MS-RDPEWA WebAuthn redirection is controlled through the extended setting `RedirectWebAuthn`
+MS-RDPEWA WebAuthn redirection is controlled through the extended setting `RedirectWebAuthn`
 (default enabled) and the RDP property key `redirectwebauthn`.
-When enabled, IronRDP prefers the Windows system `webauthn.dll` DVC COM plugin (MSTSC path), which
-handles hash-only hosts that omit `clientDataJSON`.
-If that plugin cannot be loaded, the control falls back to IronRDP's pure-Rust `WebAuthN_Channel`
-client and parents Windows Security UI to the ActiveX HWND (or the foreground window when no HWND is
-available).
-Set `IRONRDP_WEBAUTHN_FORCE_NATIVE=1` to skip the COM path for debugging.
+When enabled, the control first registers System32 `webauthn.dll`'s `WebAuthN_Channel` COM listener, which follows the MSTSC path and owns its own UI integration.
+If that listener cannot load, IronRDP registers its native fallback with the ActiveX HWND as the WebAuthn parent window.
 There is no public MSTSC `IMsRdpClientAdvancedSettings` slot for `RedirectWebAuthn`, so hosts should
 use ExtendedSettings or the RDP property rather than a raw AdvancedSettings vtable index.
 Like other redirect toggles, `RedirectWebAuthn` is not part of `IPersistStreamInit` persistence;
 hosts that need a durable value should store it themselves or in an `.rdp` file.
-When a host also lists `webauthn.dll` under `IronRdpDvcPluginPaths`, that explicit entry is skipped
-so the built-in WebAuthn path remains the sole `WebAuthN_Channel` claimant.
+When a host also lists a file named `webauthn.dll` under `IronRdpDvcPluginPaths`, that duplicate COM plugin is skipped because the WebAuthn setting already registered it.
 `EnableCredSspSupport` is
 applied to the next connection when explicitly set; otherwise the control preserves IronRDP's
 default CredSSP-enabled security negotiation. Smart sizing fits the remote framebuffer to the

--- a/crates/ironrdp-activex/README.md
+++ b/crates/ironrdp-activex/README.md
@@ -478,14 +478,18 @@ window is serviced by the host message loop; the RDP worker receives only the th
 factory. Disabling it omits the channel.
 Native MS-RDPEWA WebAuthn redirection is controlled through the extended setting `RedirectWebAuthn`
 (default enabled) and the RDP property key `redirectwebauthn`.
-When enabled, the control registers IronRDP's native `WebAuthN_Channel` client with the ActiveX HWND
-as the WebAuthn parent window.
+When enabled, IronRDP prefers the Windows system `webauthn.dll` DVC COM plugin (MSTSC path), which
+handles hash-only hosts that omit `clientDataJSON`.
+If that plugin cannot be loaded, the control falls back to IronRDP's pure-Rust `WebAuthN_Channel`
+client and parents Windows Security UI to the ActiveX HWND (or the foreground window when no HWND is
+available).
+Set `IRONRDP_WEBAUTHN_FORCE_NATIVE=1` to skip the COM path for debugging.
 There is no public MSTSC `IMsRdpClientAdvancedSettings` slot for `RedirectWebAuthn`, so hosts should
 use ExtendedSettings or the RDP property rather than a raw AdvancedSettings vtable index.
 Like other redirect toggles, `RedirectWebAuthn` is not part of `IPersistStreamInit` persistence;
 hosts that need a durable value should store it themselves or in an `.rdp` file.
-When a host also lists `webauthn.dll` under `IronRdpDvcPluginPaths`, that COM plugin is skipped so the
-native channel remains the sole claimant.
+When a host also lists `webauthn.dll` under `IronRdpDvcPluginPaths`, that explicit entry is skipped
+so the built-in WebAuthn path remains the sole `WebAuthN_Channel` claimant.
 `EnableCredSspSupport` is
 applied to the next connection when explicitly set; otherwise the control preserves IronRDP's
 default CredSSP-enabled security negotiation. Smart sizing fits the remote framebuffer to the

--- a/crates/ironrdp-activex/README.md
+++ b/crates/ironrdp-activex/README.md
@@ -475,7 +475,14 @@ Invalid audio modes and keyboard types return `E_INVALIDARG`.
 `Compress`, `RDPPort`, and `RedirectClipboard` configure the next IronRDP connection. Clipboard
 redirection creates its Windows CLIPRDR listener on the ActiveX creating apartment, where its hidden
 window is serviced by the host message loop; the RDP worker receives only the thread-safe backend
-factory. Disabling it omits the channel. `EnableCredSspSupport` is
+factory. Disabling it omits the channel.
+Native MS-RDPEWA WebAuthn redirection is controlled through the extended setting `RedirectWebAuthn`
+(default enabled) and the RDP property key `redirectwebauthn`.
+When enabled, the control registers IronRDP's native `WebAuthN_Channel` client with the ActiveX HWND
+as the WebAuthn parent window.
+When a host also lists `webauthn.dll` under `IronRdpDvcPluginPaths`, that COM plugin is skipped so the
+native channel remains the sole claimant.
+`EnableCredSspSupport` is
 applied to the next connection when explicitly set; otherwise the control preserves IronRDP's
 default CredSSP-enabled security negotiation. Smart sizing fits the remote framebuffer to the
 ActiveX bounds while preserving its aspect ratio; when disabled, the renderer retains the
@@ -534,7 +541,9 @@ viewport.
 ### DVC COM plugins
 
 The IronRDP-specific `IMsRdpExtendedSettings::Property` named `IronRdpDvcPluginPaths` configures
-one or more native Windows Dynamic Virtual Channel plugin DLLs, such as a WebAuthn client plugin.
+one or more native Windows Dynamic Virtual Channel plugin DLLs as an advanced escape hatch.
+Prefer native `RedirectWebAuthn` for WebAuthn redirection; keep `webauthn.dll` only when you intentionally
+disable the native channel.
 Set `IRONRDP_ACTIVEX_ENABLE_DVC_PLUGINS=1` in the process environment before creating the control;
 without that explicit opt-in, the property returns `E_NOTIMPL`. The BSTR value is a semicolon-delimited
 list of at most 16 local absolute paths. Each path is canonicalized, must name a distinct existing
@@ -545,6 +554,8 @@ The DVC loader owns each plugin's COM objects on dedicated worker threads and br
 through IronRDP's `drdynvc` implementation. It does not grant remote code execution: the embedding
 host explicitly selects the local DLLs it is prepared to load. A selected plugin that cannot load or
 initialize makes connection setup fail rather than quietly connecting without its requested channel.
+When native WebAuthn redirection is enabled, `webauthn.dll` is filtered out of the plugin list with a
+warning so `WebAuthN_Channel` is not double-registered.
 
 The following IronRDP-specific extended settings configure the next connection and reject writes after
 connection setup begins: `IronRdpEnableTls`, `IronRdpAutoLogon`, `IronRdpDesktopScaleFactor`,

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -1001,6 +1001,7 @@ struct CompatibilitySettings {
     enable_mouse: bool,
     enable_windows_key: bool,
     redirect_clipboard: bool,
+    redirect_webauthn: bool,
     redirect_drives: bool,
     disable_rdpdr: bool,
     drive_catalog: Rc<RefCell<DriveCatalog>>,
@@ -1072,6 +1073,7 @@ impl Default for CompatibilitySettings {
             enable_mouse: true,
             enable_windows_key: true,
             redirect_clipboard: true,
+            redirect_webauthn: true,
             redirect_drives: false,
             disable_rdpdr: false,
             drive_catalog: Rc::new(RefCell::new(DriveCatalog::new())),
@@ -5792,6 +5794,7 @@ fn active_x_property_snapshot(settings: &Settings, compatibility: &Compatibility
         properties.insert("desktopscalefactor", value);
     }
     properties.insert("redirectclipboard", compatibility.redirect_clipboard);
+    properties.insert("redirectwebauthn", compatibility.redirect_webauthn);
     properties.insert("compression", compatibility.compression.unwrap_or(true));
     properties
 }
@@ -8048,6 +8051,7 @@ impl Control {
                 ironrdp_pdu::rdp::client_info::CompressionType::Rdp61 => 3,
             });
             compatibility.redirect_clipboard = matches!(config.channels().clipboard, ClipboardType::Enable);
+            compatibility.redirect_webauthn = config.channels().webauthn;
             compatibility.performance_flags = connector.performance_flags;
             compatibility.keyboard_type = connector.keyboard_type;
             compatibility.keyboard_subtype = connector.keyboard_subtype;
@@ -8200,6 +8204,7 @@ impl Control {
         let enable_credssp = compatibility.enable_credssp;
         let compression = compatibility.compression;
         let clipboard = compatibility.redirect_clipboard;
+        let redirect_webauthn = compatibility.redirect_webauthn;
         let warn_about_credentials = compatibility.warn_about_sending_credentials;
         let warn_about_clipboard = clipboard && compatibility.warn_about_clipboard_redirection;
         let redirected_drives = if compatibility.disable_rdpdr {
@@ -8233,7 +8238,26 @@ impl Control {
             .client_name
             .clone()
             .unwrap_or_else(|| "IronRDP ActiveX".to_owned());
-        let dvc_plugin_paths = compatibility.dvc_plugin_paths.clone();
+        let dvc_plugin_paths = if redirect_webauthn {
+            let mut filtered = Vec::new();
+            for path in &compatibility.dvc_plugin_paths {
+                let is_webauthn_plugin = path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.eq_ignore_ascii_case("webauthn.dll"));
+                if is_webauthn_plugin {
+                    tracing::warn!(
+                        dll = %path.display(),
+                        "Skipping webauthn.dll COM DVC plugin because native RedirectWebAuthn is enabled"
+                    );
+                } else {
+                    filtered.push(path.clone());
+                }
+            }
+            filtered
+        } else {
+            compatibility.dvc_plugin_paths.clone()
+        };
         let enable_tls = compatibility.enable_tls;
         let autologon = compatibility.autologon;
         let desktop_scale_factor = compatibility.desktop_scale_factor;
@@ -8378,6 +8402,8 @@ impl Control {
             } else {
                 ClipboardType::Disable
             })
+            .with_webauthn(redirect_webauthn)
+            .with_webauthn_parent_hwnd(hwnd.0 as isize)
             .with_rdpdr(rdpdr_enabled);
         let builder = if remote_program_mode {
             builder
@@ -11232,6 +11258,18 @@ impl IMsRdpExtendedSettings_Impl for Control_Impl {
             trace_host_call("IMsRdpExtendedSettings::put_IronRdpDvcPluginPaths");
             return Ok(());
         }
+        if name.eq_ignore_ascii_case("RedirectWebAuthn") {
+            if value.is_null() {
+                return Err(Error::from_hresult(E_POINTER));
+            }
+            let redirect_webauthn = variant_bool(unsafe { &*value }, ptr::null_mut())?;
+            let mut compatibility = self.compatibility.borrow_mut();
+            active_x_connection_settings_mutable(self.state.get(), &compatibility)?;
+            compatibility.redirect_webauthn = redirect_webauthn;
+            mark_compatibility_persistence_dirty(&compatibility);
+            trace_host_call("IMsRdpExtendedSettings::put_RedirectWebAuthn");
+            return Ok(());
+        }
 
         Err(Error::from_hresult(E_NOTIMPL))
     }
@@ -11365,6 +11403,10 @@ impl IMsRdpExtendedSettings_Impl for Control_Impl {
                 .join(";");
             trace_host_call("IMsRdpExtendedSettings::get_IronRdpDvcPluginPaths");
             return write_out(value, variant_bstr(paths));
+        }
+        if name.eq_ignore_ascii_case("RedirectWebAuthn") {
+            trace_host_call("IMsRdpExtendedSettings::get_RedirectWebAuthn");
+            return write_out(value, variant_bool_value(self.compatibility.borrow().redirect_webauthn));
         }
         write_out(value, VARIANT::default())?;
         Err(Error::from_hresult(E_NOTIMPL))
@@ -14132,6 +14174,53 @@ mod tests {
         };
         assert_eq!(error.code(), E_NOTIMPL);
         assert_eq!(variant_header(&returned_token).vt, VT_EMPTY);
+    }
+
+    #[test]
+    fn extended_settings_redirect_webauthn_round_trip() {
+        let control: IMsRdpClient10 = Control::new().into();
+        let extended = control
+            .cast::<IMsRdpExtendedSettings>()
+            .expect("control supports IMsRdpExtendedSettings");
+
+        let mut default_value = VARIANT::default();
+        unsafe {
+            extended
+                .get_Property(BSTR::from("RedirectWebAuthn").as_ptr(), &mut default_value)
+                .expect("get default RedirectWebAuthn");
+        }
+        assert!(
+            variant_bool(&default_value, ptr::null_mut()).expect("RedirectWebAuthn boolean"),
+            "RedirectWebAuthn defaults to true"
+        );
+
+        let mut disabled = variant_bool_value(false);
+        unsafe {
+            extended
+                .put_Property(BSTR::from("RedirectWebAuthn").as_ptr(), &mut disabled)
+                .expect("disable RedirectWebAuthn");
+        }
+        let mut returned = VARIANT::default();
+        unsafe {
+            extended
+                .get_Property(BSTR::from("RedirectWebAuthn").as_ptr(), &mut returned)
+                .expect("get RedirectWebAuthn after disable");
+        }
+        assert!(!variant_bool(&returned, ptr::null_mut()).expect("RedirectWebAuthn boolean"));
+
+        let mut enabled = variant_bool_value(true);
+        unsafe {
+            extended
+                .put_Property(BSTR::from("RedirectWebAuthn").as_ptr(), &mut enabled)
+                .expect("enable RedirectWebAuthn");
+        }
+        let mut returned = VARIANT::default();
+        unsafe {
+            extended
+                .get_Property(BSTR::from("RedirectWebAuthn").as_ptr(), &mut returned)
+                .expect("get RedirectWebAuthn after enable");
+        }
+        assert!(variant_bool(&returned, ptr::null_mut()).expect("RedirectWebAuthn boolean"));
     }
 
     #[test]

--- a/crates/ironrdp-cfg/src/lib.rs
+++ b/crates/ironrdp-cfg/src/lib.rs
@@ -485,6 +485,13 @@ pub trait PropertySetExt {
     /// Removes the `redirectclipboard` property.
     fn clear_redirect_clipboard(&mut self);
 
+    /// Whether WebAuthn redirection is requested (`redirectwebauthn`).
+    fn redirect_webauthn(&self) -> Option<bool>;
+    /// Sets the `redirectwebauthn` property.
+    fn set_redirect_webauthn(&mut self, value: bool);
+    /// Removes the `redirectwebauthn` property.
+    fn clear_redirect_webauthn(&mut self);
+
     /// RemoteApp application name (`remoteapplicationname`).
     fn remote_application_name(&self) -> Option<&str>;
     /// Sets the `remoteapplicationname` property.
@@ -924,6 +931,18 @@ impl PropertySetExt for PropertySet {
 
     fn clear_redirect_clipboard(&mut self) {
         self.remove("redirectclipboard");
+    }
+
+    fn redirect_webauthn(&self) -> Option<bool> {
+        self.get::<bool>("redirectwebauthn")
+    }
+
+    fn set_redirect_webauthn(&mut self, value: bool) {
+        self.insert("redirectwebauthn", value);
+    }
+
+    fn clear_redirect_webauthn(&mut self) {
+        self.remove("redirectwebauthn");
     }
 
     fn remote_application_name(&self) -> Option<&str> {

--- a/crates/ironrdp-client/Cargo.toml
+++ b/crates/ironrdp-client/Cargo.toml
@@ -44,6 +44,7 @@ qoi = ["ironrdp-connector/qoi", "ironrdp-session/qoi"]
 qoiz = ["ironrdp-connector/qoiz", "ironrdp-session/qoiz"]
 dvc-pipe-proxy = ["dep:ironrdp-dvc-pipe-proxy"]
 dvc-com-plugin = ["dep:ironrdp-dvc-com-plugin"]
+webauthn = ["dep:ironrdp-rdpewa", "dep:ironrdp-rdpewa-native"]
 vmconnect = ["dep:ironrdp-vmconnect"]
 
 all = [
@@ -54,6 +55,7 @@ all = [
     "gateway",
     "dvc-pipe-proxy",
     "dvc-com-plugin",
+    "webauthn",
     "vmconnect",
 ]
 
@@ -88,6 +90,8 @@ ironrdp-rdpsnd-native = { path = "../ironrdp-rdpsnd-native", version = "0.7", op
 ironrdp-cliprdr-native = { path = "../ironrdp-cliprdr-native", version = "0.7", optional = true }
 ironrdp-mstsgu = { path = "../ironrdp-mstsgu", version = "0.0.1", optional = true }
 ironrdp-dvc-pipe-proxy = { path = "../ironrdp-dvc-pipe-proxy", version = "0.5", optional = true }
+ironrdp-rdpewa = { path = "../ironrdp-rdpewa", version = "0.1", optional = true }
+ironrdp-rdpewa-native = { path = "../ironrdp-rdpewa-native", version = "0.1", optional = true }
 
 # Logging
 tracing = { version = "0.1", features = ["log"] }

--- a/crates/ironrdp-client/Cargo.toml
+++ b/crates/ironrdp-client/Cargo.toml
@@ -44,7 +44,9 @@ qoi = ["ironrdp-connector/qoi", "ironrdp-session/qoi"]
 qoiz = ["ironrdp-connector/qoiz", "ironrdp-session/qoiz"]
 dvc-pipe-proxy = ["dep:ironrdp-dvc-pipe-proxy"]
 dvc-com-plugin = ["dep:ironrdp-dvc-com-plugin"]
-webauthn = ["dep:ironrdp-rdpewa", "dep:ironrdp-rdpewa-native"]
+# Prefer System32\webauthn.dll via the DVC COM plugin host (MSTSC parity / hash-only hosts).
+# Keep the pure-Rust RDPEWA path as a fallback when the COM plugin is unavailable.
+webauthn = ["dep:ironrdp-rdpewa", "dep:ironrdp-rdpewa-native", "dvc-com-plugin"]
 vmconnect = ["dep:ironrdp-vmconnect"]
 
 all = [

--- a/crates/ironrdp-client/Cargo.toml
+++ b/crates/ironrdp-client/Cargo.toml
@@ -92,8 +92,6 @@ ironrdp-rdpsnd-native = { path = "../ironrdp-rdpsnd-native", version = "0.7", op
 ironrdp-cliprdr-native = { path = "../ironrdp-cliprdr-native", version = "0.7", optional = true }
 ironrdp-mstsgu = { path = "../ironrdp-mstsgu", version = "0.0.1", optional = true }
 ironrdp-dvc-pipe-proxy = { path = "../ironrdp-dvc-pipe-proxy", version = "0.5", optional = true }
-ironrdp-rdpewa = { path = "../ironrdp-rdpewa", version = "0.1", optional = true }
-ironrdp-rdpewa-native = { path = "../ironrdp-rdpewa-native", version = "0.1", optional = true }
 
 # Logging
 tracing = { version = "0.1", features = ["log"] }
@@ -111,6 +109,8 @@ x509-cert = { version = "0.3", default-features = false, features = ["std"] }
 
 [target.'cfg(windows)'.dependencies]
 ironrdp-dvc-com-plugin = { path = "../ironrdp-dvc-com-plugin", version = "0.1", optional = true }
+ironrdp-rdpewa = { path = "../ironrdp-rdpewa", version = "0.1", optional = true }
+ironrdp-rdpewa-native = { path = "../ironrdp-rdpewa-native", version = "0.1", optional = true }
 
 [lints]
 workspace = true

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -2115,39 +2115,32 @@ mod tests {
 
     #[cfg(feature = "webauthn")]
     #[test]
-    fn with_webauthn_false_clears_channel_and_property() {
-        let config = complete_builder()
-            .with_webauthn(false)
-            .build()
-            .expect("valid configuration");
+    fn with_webauthn_updates_the_channel_and_property() {
+        let builder = ConfigBuilder::new().with_webauthn(false);
 
-        assert!(!config.channels().webauthn);
-        assert_eq!(config.properties().redirect_webauthn(), Some(false));
+        assert!(!builder.channels.webauthn);
+        assert!(!builder.properties.redirect_webauthn().unwrap());
     }
 
     #[cfg(feature = "webauthn")]
     #[test]
-    fn from_property_set_honors_redirectwebauthn() {
-        let mut enabled = ironrdp_propertyset::PropertySet::new();
-        enabled.set_redirect_webauthn(true);
-        let config_on = complete_builder()
-            .with_webauthn(false)
-            .with_property_set(&enabled)
-            .expect("valid properties")
-            .build()
-            .expect("valid configuration");
-        assert!(config_on.channels().webauthn);
-        assert_eq!(config_on.properties().redirect_webauthn(), Some(true));
+    fn property_set_enables_webauthn_redirection() {
+        let mut properties = ironrdp_propertyset::PropertySet::new();
+        properties.set_redirect_webauthn(true);
 
-        let mut disabled = ironrdp_propertyset::PropertySet::new();
-        disabled.set_redirect_webauthn(false);
-        let config_off = complete_builder()
-            .with_webauthn(true)
-            .with_property_set(&disabled)
-            .expect("valid properties")
-            .build()
-            .expect("valid configuration");
-        assert!(!config_off.channels().webauthn);
-        assert_eq!(config_off.properties().redirect_webauthn(), Some(false));
+        let builder = ConfigBuilder::from_property_set(&properties).expect("valid WebAuthn property");
+        assert!(builder.channels.webauthn);
+        assert!(builder.properties.redirect_webauthn().unwrap());
+    }
+
+    #[cfg(feature = "webauthn")]
+    #[test]
+    fn property_set_disables_webauthn_redirection() {
+        let mut properties = ironrdp_propertyset::PropertySet::new();
+        properties.set_redirect_webauthn(false);
+
+        let builder = ConfigBuilder::from_property_set(&properties).expect("valid WebAuthn property");
+        assert!(!builder.channels.webauthn);
+        assert!(!builder.properties.redirect_webauthn().unwrap());
     }
 }

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -91,6 +91,10 @@ pub struct Config {
     #[cfg(all(windows, feature = "dvc-com-plugin"))]
     pub(crate) dvc_plugins: Vec<PathBuf>,
 
+    /// Parent HWND for WebAuthn UI prompts (Windows only).
+    #[cfg(all(windows, feature = "webauthn"))]
+    pub(crate) webauthn_parent_hwnd: Option<isize>,
+
     /// The merged PropertySet that produced this config, shared (read-only) with channel factories.
     ///
     /// Well-known secret properties are stripped when calling [`ConfigBuilder::build`].
@@ -164,6 +168,12 @@ impl Config {
         &self.dvc_plugins
     }
 
+    /// Parent HWND for native WebAuthn redirection prompts (Windows only).
+    #[cfg(all(windows, feature = "webauthn"))]
+    pub fn webauthn_parent_hwnd(&self) -> Option<isize> {
+        self.webauthn_parent_hwnd
+    }
+
     /// Merged `.rdp` PropertySet that produced this config.
     pub fn properties(&self) -> &PropertySet {
         &self.properties
@@ -194,6 +204,8 @@ impl fmt::Debug for Config {
         s.field("dvc_pipe_proxies", &self.dvc_pipe_proxies);
         #[cfg(all(windows, feature = "dvc-com-plugin"))]
         s.field("dvc_plugins", &self.dvc_plugins);
+        #[cfg(all(windows, feature = "webauthn"))]
+        s.field("webauthn_parent_hwnd", &self.webauthn_parent_hwnd);
         s.field("extensions", &self.extensions);
         s.finish()
     }
@@ -254,10 +266,20 @@ pub struct ChannelConfig {
     /// Enable QOIZ (QOI with zlib) bitmap codec.
     #[cfg(feature = "qoiz")]
     pub qoiz: bool,
+
+    /// Enable native MS-RDPEWA WebAuthn redirection.
+    #[cfg(feature = "webauthn")]
+    pub webauthn: bool,
 }
 
 #[cfg_attr(
-    not(any(feature = "sound", feature = "clipboard", feature = "qoi", feature = "qoiz")),
+    not(any(
+        feature = "sound",
+        feature = "clipboard",
+        feature = "qoi",
+        feature = "qoiz",
+        feature = "webauthn"
+    )),
     expect(
         clippy::derivable_impls,
         reason = "fields setting non-default values are feature-gated; the impl is only trivially derivable in some feature combinations"
@@ -278,6 +300,8 @@ impl Default for ChannelConfig {
             qoi: true,
             #[cfg(feature = "qoiz")]
             qoiz: true,
+            #[cfg(feature = "webauthn")]
+            webauthn: true,
         }
     }
 }
@@ -657,6 +681,8 @@ pub struct ConfigBuilder {
     dvc_pipe_proxies: Vec<DvcProxyInfo>,
     #[cfg(all(windows, feature = "dvc-com-plugin"))]
     dvc_plugins: Vec<PathBuf>,
+    #[cfg(all(windows, feature = "webauthn"))]
+    webauthn_parent_hwnd: Option<isize>,
     properties: PropertySet,
     extensions: ExtensionRegistry,
 }
@@ -1220,6 +1246,23 @@ impl ConfigBuilder {
         self
     }
 
+    /// Enable or disable native MS-RDPEWA WebAuthn redirection.
+    #[cfg(feature = "webauthn")]
+    #[must_use]
+    pub fn with_webauthn(mut self, enabled: bool) -> Self {
+        self.channels.webauthn = enabled;
+        self.properties.set_redirect_webauthn(enabled);
+        self
+    }
+
+    /// Parent HWND used for WebAuthn UI prompts (Windows only).
+    #[cfg(all(windows, feature = "webauthn"))]
+    #[must_use]
+    pub fn with_webauthn_parent_hwnd(mut self, hwnd: isize) -> Self {
+        self.webauthn_parent_hwnd = Some(hwnd);
+        self
+    }
+
     // TODO: It can be useful to have a method for enabling or disabling all the extra channels at once.
     // Example: in tests, disable all + enable only the required channel.
 
@@ -1600,6 +1643,8 @@ impl ConfigBuilder {
             dvc_pipe_proxies: self.dvc_pipe_proxies,
             #[cfg(all(windows, feature = "dvc-com-plugin"))]
             dvc_plugins: self.dvc_plugins,
+            #[cfg(all(windows, feature = "webauthn"))]
+            webauthn_parent_hwnd: self.webauthn_parent_hwnd,
             properties,
             extensions: self.extensions,
         })
@@ -1827,6 +1872,14 @@ impl ConfigBuilder {
             }
             let _ = redirect;
         }
+if let Some(redirect) = ps.redirect_webauthn() {
+            #[cfg(feature = "webauthn")]
+            {
+                self.channels.webauthn = redirect;
+            }
+            let _ = redirect;
+        }
+
         #[cfg(feature = "rdpdr")]
         if let Some(enabled) = ps.enable_rdpdr() {
             self.channels.rdpdr.enabled = enabled;

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -1872,7 +1872,7 @@ impl ConfigBuilder {
             }
             let _ = redirect;
         }
-if let Some(redirect) = ps.redirect_webauthn() {
+        if let Some(redirect) = ps.redirect_webauthn() {
             #[cfg(feature = "webauthn")]
             {
                 self.channels.webauthn = redirect;

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -2112,4 +2112,42 @@ mod tests {
             Some(AudioCaptureMode::Disabled)
         );
     }
+
+    #[cfg(feature = "webauthn")]
+    #[test]
+    fn with_webauthn_false_clears_channel_and_property() {
+        let config = complete_builder()
+            .with_webauthn(false)
+            .build()
+            .expect("valid configuration");
+
+        assert!(!config.channels().webauthn);
+        assert_eq!(config.properties().redirect_webauthn(), Some(false));
+    }
+
+    #[cfg(feature = "webauthn")]
+    #[test]
+    fn from_property_set_honors_redirectwebauthn() {
+        let mut enabled = ironrdp_propertyset::PropertySet::new();
+        enabled.set_redirect_webauthn(true);
+        let config_on = complete_builder()
+            .with_webauthn(false)
+            .with_property_set(&enabled)
+            .expect("valid properties")
+            .build()
+            .expect("valid configuration");
+        assert!(config_on.channels().webauthn);
+        assert_eq!(config_on.properties().redirect_webauthn(), Some(true));
+
+        let mut disabled = ironrdp_propertyset::PropertySet::new();
+        disabled.set_redirect_webauthn(false);
+        let config_off = complete_builder()
+            .with_webauthn(true)
+            .with_property_set(&disabled)
+            .expect("valid properties")
+            .build()
+            .expect("valid configuration");
+        assert!(!config_off.channels().webauthn);
+        assert_eq!(config_off.properties().redirect_webauthn(), Some(false));
+    }
 }

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -864,41 +864,50 @@ fn build_connector(
     // Prefer System32\webauthn.dll via the DVC COM plugin host — that is the MSTSC path and the only
     // way to handle hash-only MS-RDPEWA hosts that omit clientDataJSON. Fall back to the pure-Rust
     // WebAuthN* backend when the plugin cannot be loaded.
+    // IRONRDP_WEBAUTHN_FORCE_NATIVE=1 skips COM and always uses WindowsRdpewaBackend (smoke/debug).
     #[cfg(all(windows, feature = "webauthn"))]
     let mut webauthn_com_loaded = false;
     #[cfg(all(windows, feature = "webauthn"))]
     if config.channels.webauthn {
-        let webauthn_dll = std::path::PathBuf::from(r"C:\Windows\System32\webauthn.dll");
-        let sender_clone = input_sender.clone();
-        match load_dvc_plugin_listeners(&webauthn_dll, move || {
-            let sender = sender_clone.clone();
-            Box::new(move |channel_id, messages| {
-                sender
-                    .try_send(RdpInputEvent::SendDvcMessages { channel_id, messages })
-                    .map_err(|_| pdu_other_err!("send webauthn.dll DVC messages to the event loop"))?;
-                Ok(())
-            })
-        }) {
-            Ok(listeners) => {
-                for listener in listeners {
-                    info!(
-                        channel_name = %listener.channel_name(),
-                        "Registering webauthn.dll COM DVC channel listener"
-                    );
-                    if listener.channel_name() == ironrdp_rdpewa::CHANNEL_NAME {
-                        webauthn_com_loaded = true;
+        let force_native = std::env::var_os("IRONRDP_WEBAUTHN_FORCE_NATIVE").is_some_and(|v| {
+            let v = v.to_string_lossy();
+            !(v.is_empty() || v == "0" || v.eq_ignore_ascii_case("false"))
+        });
+        if force_native {
+            info!("IRONRDP_WEBAUTHN_FORCE_NATIVE set; skipping webauthn.dll COM path");
+        } else {
+            let webauthn_dll = std::path::PathBuf::from(r"C:\Windows\System32\webauthn.dll");
+            let sender_clone = input_sender.clone();
+            match load_dvc_plugin_listeners(&webauthn_dll, move || {
+                let sender = sender_clone.clone();
+                Box::new(move |channel_id, messages| {
+                    sender
+                        .try_send(RdpInputEvent::SendDvcMessages { channel_id, messages })
+                        .map_err(|_| pdu_other_err!("send webauthn.dll DVC messages to the event loop"))?;
+                    Ok(())
+                })
+            }) {
+                Ok(listeners) => {
+                    for listener in listeners {
+                        info!(
+                            channel_name = %listener.channel_name(),
+                            "Registering webauthn.dll COM DVC channel listener"
+                        );
+                        if listener.channel_name() == ironrdp_rdpewa::CHANNEL_NAME {
+                            webauthn_com_loaded = true;
+                        }
+                        drdynvc = drdynvc.with_listener(listener);
                     }
-                    drdynvc = drdynvc.with_listener(listener);
+                    if !webauthn_com_loaded {
+                        warn!("webauthn.dll loaded but did not register WebAuthN_Channel");
+                    }
                 }
-                if !webauthn_com_loaded {
-                    warn!("webauthn.dll loaded but did not register WebAuthN_Channel");
+                Err(e) => {
+                    warn!(
+                        error = %e,
+                        "Failed to load webauthn.dll COM plugin; falling back to native RDPEWA backend"
+                    );
                 }
-            }
-            Err(e) => {
-                warn!(
-                    error = %e,
-                    "Failed to load webauthn.dll COM plugin; falling back to native RDPEWA backend"
-                );
             }
         }
 

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -51,12 +51,14 @@ use crate::config::ClipboardType;
 use ironrdp_cliprdr::backend::ClipboardMessage;
 #[cfg(all(windows, feature = "dvc-com-plugin"))]
 use ironrdp_dvc_com_plugin::load_dvc_plugin_listeners;
+#[cfg(all(windows, feature = "webauthn"))]
+use ironrdp_dvc_com_plugin::system_webauthn_dll_path;
 #[cfg(feature = "dvc-pipe-proxy")]
 use ironrdp_dvc_pipe_proxy::DvcNamedPipeProxy;
 #[cfg(all(windows, feature = "webauthn"))]
 use ironrdp_rdpewa::{RdpewaClient, RdpewaClientListener};
 #[cfg(all(windows, feature = "webauthn"))]
-use ironrdp_rdpewa_native::WindowsRdpewaBackend;
+use ironrdp_rdpewa_native::WindowsRdpewaSession;
 #[cfg(feature = "sound")]
 use ironrdp_rdpsnd_native::{RdpeaiCaptureBackend, cpal};
 
@@ -875,8 +877,7 @@ fn build_connector(
         });
         if force_native {
             info!("IRONRDP_WEBAUTHN_FORCE_NATIVE set; skipping webauthn.dll COM path");
-        } else {
-            let webauthn_dll = std::path::PathBuf::from(r"C:\Windows\System32\webauthn.dll");
+        } else if let Some(webauthn_dll) = system_webauthn_dll_path() {
             let sender_clone = input_sender.clone();
             match load_dvc_plugin_listeners(&webauthn_dll, move || {
                 let sender = sender_clone.clone();
@@ -891,6 +892,7 @@ fn build_connector(
                     for listener in listeners {
                         info!(
                             channel_name = %listener.channel_name(),
+                            dll = %webauthn_dll.display(),
                             "Registering webauthn.dll COM DVC channel listener"
                         );
                         if listener.channel_name() == ironrdp_rdpewa::CHANNEL_NAME {
@@ -909,6 +911,8 @@ fn build_connector(
                     );
                 }
             }
+        } else {
+            warn!("Failed to resolve System32\\webauthn.dll; falling back to native RDPEWA backend");
         }
 
         if !webauthn_com_loaded {
@@ -921,9 +925,12 @@ fn build_connector(
                     .map_err(|_| pdu_other_err!("send RDPEWA DVC messages to the event loop"))?;
                 Ok(())
             });
+            // One session object is shared across channel recreates for cancel + in-flight state.
+            let session = WindowsRdpewaSession::new();
             drdynvc = drdynvc.with_listener(RdpewaClientListener::new(move || {
                 let write_callback = Arc::clone(&write_callback);
-                RdpewaClient::new(Box::new(WindowsRdpewaBackend::new(parent_hwnd)))
+                let session = session.clone();
+                RdpewaClient::new(Box::new(session.backend(parent_hwnd)))
                     .with_write_callback(move |channel_id, messages| write_callback(channel_id, messages))
             }));
         }

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -51,14 +51,12 @@ use crate::config::ClipboardType;
 use ironrdp_cliprdr::backend::ClipboardMessage;
 #[cfg(all(windows, feature = "dvc-com-plugin"))]
 use ironrdp_dvc_com_plugin::load_dvc_plugin_listeners;
-#[cfg(all(windows, feature = "webauthn"))]
-use ironrdp_dvc_com_plugin::system_webauthn_dll_path;
 #[cfg(feature = "dvc-pipe-proxy")]
 use ironrdp_dvc_pipe_proxy::DvcNamedPipeProxy;
 #[cfg(all(windows, feature = "webauthn"))]
 use ironrdp_rdpewa::{RdpewaClient, RdpewaClientListener};
 #[cfg(all(windows, feature = "webauthn"))]
-use ironrdp_rdpewa_native::WindowsRdpewaSession;
+use ironrdp_rdpewa_native::{WindowsRdpewaBackend, WindowsRdpewaSessionState};
 #[cfg(feature = "sound")]
 use ironrdp_rdpsnd_native::{RdpeaiCaptureBackend, cpal};
 
@@ -877,42 +875,49 @@ fn build_connector(
         });
         if force_native {
             info!("IRONRDP_WEBAUTHN_FORCE_NATIVE set; skipping webauthn.dll COM path");
-        } else if let Some(webauthn_dll) = system_webauthn_dll_path() {
-            let sender_clone = input_sender.clone();
-            match load_dvc_plugin_listeners(&webauthn_dll, move || {
-                let sender = sender_clone.clone();
-                Box::new(move |channel_id, messages| {
-                    sender
-                        .try_send(RdpInputEvent::SendDvcMessages { channel_id, messages })
-                        .map_err(|_| pdu_other_err!("send webauthn.dll DVC messages to the event loop"))?;
-                    Ok(())
-                })
-            }) {
-                Ok(listeners) => {
-                    for listener in listeners {
-                        info!(
-                            channel_name = %listener.channel_name(),
-                            dll = %webauthn_dll.display(),
-                            "Registering webauthn.dll COM DVC channel listener"
-                        );
-                        if listener.channel_name() == ironrdp_rdpewa::CHANNEL_NAME {
-                            webauthn_com_loaded = true;
+        } else {
+            match ironrdp_dvc_com_plugin::webauthn_dll_path() {
+                Ok(webauthn_dll) => {
+                    let sender_clone = input_sender.clone();
+                    match load_dvc_plugin_listeners(&webauthn_dll, move || {
+                        let sender = sender_clone.clone();
+                        Box::new(move |channel_id, messages| {
+                            sender
+                                .try_send(RdpInputEvent::SendDvcMessages { channel_id, messages })
+                                .map_err(|_| pdu_other_err!("send webauthn.dll DVC messages to the event loop"))?;
+                            Ok(())
+                        })
+                    }) {
+                        Ok(listeners) => {
+                            for listener in listeners {
+                                info!(
+                                    channel_name = %listener.channel_name(),
+                                    "Registering webauthn.dll COM DVC channel listener"
+                                );
+                                if listener.channel_name() == ironrdp_rdpewa::CHANNEL_NAME {
+                                    webauthn_com_loaded = true;
+                                }
+                                drdynvc = drdynvc.with_listener(listener);
+                            }
+                            if !webauthn_com_loaded {
+                                warn!("webauthn.dll loaded but did not register WebAuthN_Channel");
+                            }
                         }
-                        drdynvc = drdynvc.with_listener(listener);
-                    }
-                    if !webauthn_com_loaded {
-                        warn!("webauthn.dll loaded but did not register WebAuthN_Channel");
+                        Err(e) => {
+                            warn!(
+                                error = %e,
+                                "Failed to load webauthn.dll COM plugin; falling back to native RDPEWA backend"
+                            );
+                        }
                     }
                 }
                 Err(e) => {
                     warn!(
                         error = %e,
-                        "Failed to load webauthn.dll COM plugin; falling back to native RDPEWA backend"
+                        "Failed to resolve webauthn.dll; falling back to native RDPEWA backend"
                     );
                 }
             }
-        } else {
-            warn!("Failed to resolve System32\\webauthn.dll; falling back to native RDPEWA backend");
         }
 
         if !webauthn_com_loaded {
@@ -925,13 +930,15 @@ fn build_connector(
                     .map_err(|_| pdu_other_err!("send RDPEWA DVC messages to the event loop"))?;
                 Ok(())
             });
-            // One session object is shared across channel recreates for cancel + in-flight state.
-            let session = WindowsRdpewaSession::new();
+            let session_state = Arc::new(WindowsRdpewaSessionState::default());
             drdynvc = drdynvc.with_listener(RdpewaClientListener::new(move || {
                 let write_callback = Arc::clone(&write_callback);
-                let session = session.clone();
-                RdpewaClient::new(Box::new(session.backend(parent_hwnd)))
-                    .with_write_callback(move |channel_id, messages| write_callback(channel_id, messages))
+                let session_state = Arc::clone(&session_state);
+                RdpewaClient::new(Box::new(WindowsRdpewaBackend::new_with_session_state(
+                    parent_hwnd,
+                    session_state,
+                )))
+                .with_write_callback(move |channel_id, messages| write_callback(channel_id, messages))
             }));
         }
     }
@@ -941,15 +948,16 @@ fn build_connector(
     {
         for plugin_path in &config.dvc_plugins {
             #[cfg(all(windows, feature = "webauthn"))]
-            if config.channels.webauthn {
-                let canonical = plugin_path.to_string_lossy().to_ascii_lowercase();
-                if canonical.ends_with("webauthn.dll") {
-                    debug!(
-                        dll = %plugin_path.display(),
-                        "Skipping explicit webauthn.dll plugin; already handled by webauthn feature"
-                    );
-                    continue;
-                }
+            if config.channels.webauthn
+                && plugin_path
+                    .file_name()
+                    .is_some_and(|file_name| file_name.to_string_lossy().eq_ignore_ascii_case("webauthn.dll"))
+            {
+                debug!(
+                    dll = %plugin_path.display(),
+                    "Skipping explicit webauthn.dll plugin; already handled by webauthn feature"
+                );
+                continue;
             }
 
             info!(dll = %plugin_path.display(), "Loading DVC COM plugin");

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -22,7 +22,8 @@ use ironrdp_pdu::input::mouse::PointerFlags;
 #[cfg(any(
     feature = "dvc-pipe-proxy",
     all(windows, feature = "dvc-com-plugin"),
-    feature = "sound"
+    feature = "sound",
+    all(windows, feature = "webauthn")
 ))]
 use ironrdp_pdu::pdu_other_err;
 #[cfg(feature = "rdpdr")]
@@ -52,6 +53,10 @@ use ironrdp_cliprdr::backend::ClipboardMessage;
 use ironrdp_dvc_com_plugin::load_dvc_plugin;
 #[cfg(feature = "dvc-pipe-proxy")]
 use ironrdp_dvc_pipe_proxy::DvcNamedPipeProxy;
+#[cfg(all(windows, feature = "webauthn"))]
+use ironrdp_rdpewa::RdpewaClient;
+#[cfg(all(windows, feature = "webauthn"))]
+use ironrdp_rdpewa_native::WindowsRdpewaBackend;
 #[cfg(feature = "sound")]
 use ironrdp_rdpsnd_native::{RdpeaiCaptureBackend, cpal};
 
@@ -820,11 +825,12 @@ fn build_connector(
     // `input_sender` is only consumed by the optional DVC wirings below, and `cliprdr_factory`
     // only by the optional CLIPRDR attachment; discard them explicitly when those are compiled out.
     #[cfg(not(any(
-        feature = "dvc-pipe-proxy",
-        all(windows, feature = "dvc-com-plugin"),
-        feature = "sound"
-    )))]
-    let _ = input_sender;
+            feature = "dvc-pipe-proxy",
+            all(windows, feature = "dvc-com-plugin"),
+            feature = "sound",
+            all(windows, feature = "webauthn")
+        )))]
+        let _ = input_sender;
     #[cfg(not(feature = "clipboard"))]
     let _ = cliprdr_factory;
     #[cfg(not(feature = "rdpdr"))]
@@ -854,6 +860,24 @@ fn build_connector(
         ));
     }
 
+    // Native MS-RDPEWA WebAuthn redirection (Windows + webauthn feature).
+    #[cfg(all(windows, feature = "webauthn"))]
+    if config.channels.webauthn {
+        let sender = input_sender.clone();
+        let parent_hwnd = config.webauthn_parent_hwnd.unwrap_or(0);
+        info!(parent_hwnd, "Registering native RDPEWA WebAuthn channel");
+        drdynvc = drdynvc.with_dynamic_channel(
+            RdpewaClient::new(Box::new(WindowsRdpewaBackend::new(parent_hwnd))).with_write_callback(
+                move |channel_id, messages| {
+                    sender
+                        .try_send(RdpInputEvent::SendDvcMessages { channel_id, messages })
+                        .map_err(|_| pdu_other_err!("send RDPEWA DVC messages to the event loop"))?;
+                    Ok(())
+                },
+            ),
+        );
+    }
+
     // Load DVC COM plugins (Windows + dvc-com-plugin feature).
     #[cfg(all(windows, feature = "dvc-com-plugin"))]
     {
@@ -871,6 +895,15 @@ fn build_connector(
             }) {
                 Ok(channels) => {
                     for channel in channels {
+                        #[cfg(all(windows, feature = "webauthn"))]
+                        if config.channels.webauthn && channel.channel_name() == ironrdp_rdpewa::CHANNEL_NAME {
+                            warn!(
+                                dll = %plugin_path.display(),
+                                channel = ironrdp_rdpewa::CHANNEL_NAME,
+                                "Skipping COM DVC channel that conflicts with native RDPEWA WebAuthn"
+                            );
+                            continue;
+                        }
                         info!(channel_name = %channel.channel_name(), "Registered COM DVC channel");
                         drdynvc = drdynvc.with_dynamic_channel(channel);
                     }

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -11,7 +11,7 @@ use ironrdp_core::WriteBuf;
 use ironrdp_displaycontrol::client::DisplayControlClient;
 use ironrdp_displaycontrol::pdu::MonitorLayoutEntry;
 #[cfg(all(windows, feature = "dvc-com-plugin"))]
-use ironrdp_dvc::DvcProcessor as _;
+use ironrdp_dvc::DvcChannelListener as _;
 use ironrdp_echo::client::EchoClient;
 use ironrdp_graphics::image_processing::PixelFormat;
 use ironrdp_graphics::pointer::DecodedPointer;
@@ -50,11 +50,11 @@ use crate::config::ClipboardType;
 #[cfg(feature = "clipboard")]
 use ironrdp_cliprdr::backend::ClipboardMessage;
 #[cfg(all(windows, feature = "dvc-com-plugin"))]
-use ironrdp_dvc_com_plugin::load_dvc_plugin;
+use ironrdp_dvc_com_plugin::load_dvc_plugin_listeners;
 #[cfg(feature = "dvc-pipe-proxy")]
 use ironrdp_dvc_pipe_proxy::DvcNamedPipeProxy;
 #[cfg(all(windows, feature = "webauthn"))]
-use ironrdp_rdpewa::RdpewaClient;
+use ironrdp_rdpewa::{RdpewaClient, RdpewaClientListener};
 #[cfg(all(windows, feature = "webauthn"))]
 use ironrdp_rdpewa_native::WindowsRdpewaBackend;
 #[cfg(feature = "sound")]
@@ -860,31 +860,86 @@ fn build_connector(
         ));
     }
 
-    // Native MS-RDPEWA WebAuthn redirection (Windows + webauthn feature).
+    // WebAuthn redirection (Windows + webauthn feature).
+    // Prefer System32\webauthn.dll via the DVC COM plugin host — that is the MSTSC path and the only
+    // way to handle hash-only MS-RDPEWA hosts that omit clientDataJSON. Fall back to the pure-Rust
+    // WebAuthN* backend when the plugin cannot be loaded.
+    #[cfg(all(windows, feature = "webauthn"))]
+    let mut webauthn_com_loaded = false;
     #[cfg(all(windows, feature = "webauthn"))]
     if config.channels.webauthn {
-        let sender = input_sender.clone();
-        let parent_hwnd = config.webauthn_parent_hwnd.unwrap_or(0);
-        info!(parent_hwnd, "Registering native RDPEWA WebAuthn channel");
-        drdynvc = drdynvc.with_dynamic_channel(
-            RdpewaClient::new(Box::new(WindowsRdpewaBackend::new(parent_hwnd))).with_write_callback(
-                move |channel_id, messages| {
-                    sender
-                        .try_send(RdpInputEvent::SendDvcMessages { channel_id, messages })
-                        .map_err(|_| pdu_other_err!("send RDPEWA DVC messages to the event loop"))?;
-                    Ok(())
-                },
-            ),
-        );
+        let webauthn_dll = std::path::PathBuf::from(r"C:\Windows\System32\webauthn.dll");
+        let sender_clone = input_sender.clone();
+        match load_dvc_plugin_listeners(&webauthn_dll, move || {
+            let sender = sender_clone.clone();
+            Box::new(move |channel_id, messages| {
+                sender
+                    .try_send(RdpInputEvent::SendDvcMessages { channel_id, messages })
+                    .map_err(|_| pdu_other_err!("send webauthn.dll DVC messages to the event loop"))?;
+                Ok(())
+            })
+        }) {
+            Ok(listeners) => {
+                for listener in listeners {
+                    info!(
+                        channel_name = %listener.channel_name(),
+                        "Registering webauthn.dll COM DVC channel listener"
+                    );
+                    if listener.channel_name() == ironrdp_rdpewa::CHANNEL_NAME {
+                        webauthn_com_loaded = true;
+                    }
+                    drdynvc = drdynvc.with_listener(listener);
+                }
+                if !webauthn_com_loaded {
+                    warn!("webauthn.dll loaded but did not register WebAuthN_Channel");
+                }
+            }
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    "Failed to load webauthn.dll COM plugin; falling back to native RDPEWA backend"
+                );
+            }
+        }
+
+        if !webauthn_com_loaded {
+            let sender = input_sender.clone();
+            let parent_hwnd = config.webauthn_parent_hwnd.unwrap_or(0);
+            info!(parent_hwnd, "Registering native RDPEWA WebAuthn channel listener");
+            let write_callback = Arc::new(move |channel_id, messages| {
+                sender
+                    .try_send(RdpInputEvent::SendDvcMessages { channel_id, messages })
+                    .map_err(|_| pdu_other_err!("send RDPEWA DVC messages to the event loop"))?;
+                Ok(())
+            });
+            drdynvc = drdynvc.with_listener(RdpewaClientListener::new(move || {
+                let write_callback = Arc::clone(&write_callback);
+                RdpewaClient::new(Box::new(WindowsRdpewaBackend::new(parent_hwnd))).with_write_callback(
+                    move |channel_id, messages| write_callback(channel_id, messages),
+                )
+            }));
+        }
     }
 
-    // Load DVC COM plugins (Windows + dvc-com-plugin feature).
+    // Load additional DVC COM plugins (Windows + dvc-com-plugin feature).
     #[cfg(all(windows, feature = "dvc-com-plugin"))]
     {
         for plugin_path in &config.dvc_plugins {
+            #[cfg(all(windows, feature = "webauthn"))]
+            if config.channels.webauthn {
+                let canonical = plugin_path.to_string_lossy().to_ascii_lowercase();
+                if canonical.ends_with("webauthn.dll") {
+                    debug!(
+                        dll = %plugin_path.display(),
+                        "Skipping explicit webauthn.dll plugin; already handled by webauthn feature"
+                    );
+                    continue;
+                }
+            }
+
             info!(dll = %plugin_path.display(), "Loading DVC COM plugin");
             let sender_clone = input_sender.clone();
-            match load_dvc_plugin(plugin_path, move || {
+            match load_dvc_plugin_listeners(plugin_path, move || {
                 let sender = sender_clone.clone();
                 Box::new(move |channel_id, messages| {
                     sender
@@ -893,19 +948,10 @@ fn build_connector(
                     Ok(())
                 })
             }) {
-                Ok(channels) => {
-                    for channel in channels {
-                        #[cfg(all(windows, feature = "webauthn"))]
-                        if config.channels.webauthn && channel.channel_name() == ironrdp_rdpewa::CHANNEL_NAME {
-                            warn!(
-                                dll = %plugin_path.display(),
-                                channel = ironrdp_rdpewa::CHANNEL_NAME,
-                                "Skipping COM DVC channel that conflicts with native RDPEWA WebAuthn"
-                            );
-                            continue;
-                        }
-                        info!(channel_name = %channel.channel_name(), "Registered COM DVC channel");
-                        drdynvc = drdynvc.with_dynamic_channel(channel);
+                Ok(listeners) => {
+                    for listener in listeners {
+                        info!(channel_name = %listener.channel_name(), "Registered COM DVC channel listener");
+                        drdynvc = drdynvc.with_listener(listener);
                     }
                 }
                 Err(e) => {

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -825,12 +825,12 @@ fn build_connector(
     // `input_sender` is only consumed by the optional DVC wirings below, and `cliprdr_factory`
     // only by the optional CLIPRDR attachment; discard them explicitly when those are compiled out.
     #[cfg(not(any(
-            feature = "dvc-pipe-proxy",
-            all(windows, feature = "dvc-com-plugin"),
-            feature = "sound",
-            all(windows, feature = "webauthn")
-        )))]
-        let _ = input_sender;
+        feature = "dvc-pipe-proxy",
+        all(windows, feature = "dvc-com-plugin"),
+        feature = "sound",
+        all(windows, feature = "webauthn")
+    )))]
+    let _ = input_sender;
     #[cfg(not(feature = "clipboard"))]
     let _ = cliprdr_factory;
     #[cfg(not(feature = "rdpdr"))]
@@ -923,9 +923,8 @@ fn build_connector(
             });
             drdynvc = drdynvc.with_listener(RdpewaClientListener::new(move || {
                 let write_callback = Arc::clone(&write_callback);
-                RdpewaClient::new(Box::new(WindowsRdpewaBackend::new(parent_hwnd))).with_write_callback(
-                    move |channel_id, messages| write_callback(channel_id, messages),
-                )
+                RdpewaClient::new(Box::new(WindowsRdpewaBackend::new(parent_hwnd)))
+                    .with_write_callback(move |channel_id, messages| write_callback(channel_id, messages))
             }));
         }
     }

--- a/crates/ironrdp-daemon/Cargo.toml
+++ b/crates/ironrdp-daemon/Cargo.toml
@@ -13,7 +13,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["rustls", "dvc-pipe-proxy", "rdpdr", "webauthn"] } # public
+ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["rustls", "dvc-pipe-proxy", "rdpdr"] } # public
 ironrdp-cfg = { path = "../ironrdp-cfg", version = "0.1" }
 ironrdp-input = { path = "../ironrdp-input", version = "0.7" }
 ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9" }
@@ -37,7 +37,10 @@ now-proto-pdu = { version = "0.4", features = ["std"] }
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
+# WebAuthn redirection is Windows-only (webauthn.dll / WebAuthN* APIs).
+ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["webauthn"] }
 ironrdp-rdpdr-native = { path = "../ironrdp-rdpdr-native", version = "0.7" }
 
 [lints]
 workspace = true
+

--- a/crates/ironrdp-daemon/Cargo.toml
+++ b/crates/ironrdp-daemon/Cargo.toml
@@ -13,7 +13,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["rustls", "dvc-pipe-proxy", "rdpdr"] } # public
+ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["rustls", "dvc-pipe-proxy", "rdpdr", "webauthn"] } # public
 ironrdp-cfg = { path = "../ironrdp-cfg", version = "0.1" }
 ironrdp-input = { path = "../ironrdp-input", version = "0.7" }
 ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9" }

--- a/crates/ironrdp-dvc-com-plugin/Cargo.toml
+++ b/crates/ironrdp-dvc-com-plugin/Cargo.toml
@@ -26,11 +26,10 @@ ironrdp-svc = { path = "../ironrdp-svc", version = "0.8" }
 tracing = { version = "0.1", features = ["log"] }
 windows = { version = "0.62", features = [
     "Win32_Foundation",
-    "Win32_Networking_WindowsWebServices",
-    "Win32_System_RemoteDesktop",
     "Win32_System_Com",
     "Win32_System_Com_StructuredStorage",
     "Win32_System_LibraryLoader",
+    "Win32_System_RemoteDesktop",
     "Win32_System_SystemInformation",
 ] }
 windows-core = "0.62"

--- a/crates/ironrdp-dvc-com-plugin/Cargo.toml
+++ b/crates/ironrdp-dvc-com-plugin/Cargo.toml
@@ -26,10 +26,12 @@ ironrdp-svc = { path = "../ironrdp-svc", version = "0.8" }
 tracing = { version = "0.1", features = ["log"] }
 windows = { version = "0.62", features = [
     "Win32_Foundation",
+    "Win32_Networking_WindowsWebServices",
     "Win32_System_RemoteDesktop",
     "Win32_System_Com",
     "Win32_System_Com_StructuredStorage",
     "Win32_System_LibraryLoader",
+    "Win32_System_SystemInformation",
 ] }
 windows-core = "0.62"
 

--- a/crates/ironrdp-dvc-com-plugin/src/channel.rs
+++ b/crates/ironrdp-dvc-com-plugin/src/channel.rs
@@ -1,11 +1,10 @@
 //! [`DvcComChannel`] — the `DvcProcessor` implementation that bridges IronRDP ↔ COM plugin.
 //!
-//! Also contains the public [`load_dvc_plugin`] function which loads a plugin DLL,
-//! initializes its COM objects, and returns a set of `DvcComChannel`s to register
-//! with IronRDP's `DrdynvcClient`.
+//! Also contains the public [`load_dvc_plugin`] / [`load_dvc_plugin_listeners`] helpers which load a
+//! plugin DLL, initialize its COM objects, and return processors or recreatable listeners.
 
-use core::cell::Cell;
 use core::ffi::c_void;
+use core::sync::atomic::{AtomicBool, Ordering};
 use std::collections::HashMap;
 use std::os::windows::ffi::OsStrExt as _;
 use std::path::Path;
@@ -13,7 +12,7 @@ use std::sync::{Arc, mpsc as std_mpsc};
 use std::thread;
 
 use ironrdp_core::impl_as_any;
-use ironrdp_dvc::{DvcClientProcessor, DvcMessage, DvcProcessor};
+use ironrdp_dvc::{DvcChannelListener, DvcClientProcessor, DvcMessage, DvcProcessor, DynamicChannelId};
 use ironrdp_pdu::{PduResult, pdu_other_err};
 use ironrdp_svc::SvcMessage;
 use tracing::{debug, error, trace, warn};
@@ -37,21 +36,32 @@ use crate::worker::{ComCommand, run_com_worker};
 type VirtualChannelGetInstanceFn =
     unsafe extern "system" fn(refiid: *const GUID, pnumobjs: *mut u32, ppobjarray: *mut *mut c_void) -> HRESULT;
 
-/// A DVC channel backed by a native COM plugin DLL.
+/// Shared COM worker + plugin state.
 ///
-/// Each instance represents one listener (channel name) registered by the plugin
-/// during `IWTSPlugin::Initialize`. It implements [`DvcProcessor`] + [`DvcClientProcessor`]
-/// so it can be registered with IronRDP's `DrdynvcClient`.
-///
-/// Communication with the COM worker thread happens via `std::sync::mpsc` channels.
-pub struct DvcComChannel {
-    channel_name: String,
+/// Lifetime is independent of individual DVC open/close cycles. Shutdown is sent only when the last
+/// [`Arc`] clone is dropped (session teardown).
+struct ComPluginShared {
     command_tx: std_mpsc::Sender<ComCommand>,
     on_write_dvc_tx: std_mpsc::Sender<OnWriteDvc>,
     on_write_dvc_factory: Arc<dyn Fn() -> OnWriteDvcMessage + Send + Sync>,
-    /// Set to false after the first `start()` call sends `Connected`
-    needs_connected: bool,
+    connected_sent: AtomicBool,
     _worker_handle: Option<thread::JoinHandle<()>>,
+}
+
+impl Drop for ComPluginShared {
+    fn drop(&mut self) {
+        let _ = self.command_tx.send(ComCommand::Shutdown);
+    }
+}
+
+/// A DVC channel backed by a native COM plugin DLL.
+///
+/// Each instance represents one open of a listener (channel name) registered by the plugin during
+/// `IWTSPlugin::Initialize`. Multiple instances may share the same plugin worker so hosts that
+/// open and close the channel around individual RPCs (e.g. `WebAuthN_Channel`) keep working.
+pub struct DvcComChannel {
+    channel_name: String,
+    shared: Arc<ComPluginShared>,
 }
 
 impl_as_any!(DvcComChannel);
@@ -68,19 +78,19 @@ impl DvcProcessor for DvcComChannel {
             "DVC COM channel start"
         );
 
-        // Notify the plugin that the RDP connection is established (only once per plugin)
-        if self.needs_connected {
-            self.needs_connected = false;
-            let _ = self.command_tx.send(ComCommand::Connected);
+        // Notify the plugin that the RDP connection is established (only once per plugin).
+        if !self.shared.connected_sent.swap(true, Ordering::SeqCst) {
+            let _ = self.shared.command_tx.send(ComCommand::Connected);
         }
 
-        // Create a fresh write callback for this channel opening
-        let write_cb = (self.on_write_dvc_factory)();
-        let _ = self.on_write_dvc_tx.send(write_cb);
+        // Fresh write callback for this channel open.
+        let write_cb = (self.shared.on_write_dvc_factory)();
+        let _ = self.shared.on_write_dvc_tx.send(write_cb);
 
         let (accept_tx, accept_rx) = std_mpsc::sync_channel(1);
 
-        self.command_tx
+        self.shared
+            .command_tx
             .send(ComCommand::ChannelOpened {
                 channel_name: self.channel_name.clone(),
                 channel_id,
@@ -88,7 +98,6 @@ impl DvcProcessor for DvcComChannel {
             })
             .map_err(|_| pdu_other_err!("COM worker thread is gone"))?;
 
-        // Block until the COM thread processes the channel open
         let accepted = accept_rx.recv().unwrap_or(false);
 
         if accepted {
@@ -109,7 +118,8 @@ impl DvcProcessor for DvcComChannel {
     }
 
     fn process(&mut self, channel_id: u32, payload: &[u8]) -> PduResult<Vec<DvcMessage>> {
-        self.command_tx
+        self.shared
+            .command_tx
             .send(ComCommand::DataReceived {
                 channel_id,
                 data: payload.to_vec(),
@@ -126,36 +136,46 @@ impl DvcProcessor for DvcComChannel {
             "DVC COM channel close"
         );
 
-        let _ = self.command_tx.send(ComCommand::ChannelClosed { channel_id });
+        let _ = self.shared.command_tx.send(ComCommand::ChannelClosed { channel_id });
     }
 }
 
 impl DvcClientProcessor for DvcComChannel {}
 
-impl Drop for DvcComChannel {
-    fn drop(&mut self) {
-        // Send shutdown to the COM worker thread
-        let _ = self.command_tx.send(ComCommand::Shutdown);
-        // Don't join — the worker will clean up asynchronously
+/// Recreatable listener for a single COM plugin channel name.
+///
+/// Prefer this over a one-shot [`DvcComChannel`] when the host opens and closes the DVC around each
+/// RPC (as Windows does for `WebAuthN_Channel`).
+pub struct DvcComChannelListener {
+    channel_name: String,
+    shared: Arc<ComPluginShared>,
+}
+
+impl DvcComChannelListener {
+    fn new(channel_name: String, shared: Arc<ComPluginShared>) -> Self {
+        Self { channel_name, shared }
+    }
+}
+
+impl DvcChannelListener for DvcComChannelListener {
+    fn channel_name(&self) -> &str {
+        &self.channel_name
+    }
+
+    fn create(&mut self, _channel_id: DynamicChannelId) -> Option<Box<dyn DvcClientProcessor>> {
+        Some(Box::new(DvcComChannel {
+            channel_name: self.channel_name.clone(),
+            shared: Arc::clone(&self.shared),
+        }))
     }
 }
 
 /// Callback type matching the pipe proxy pattern: called when the plugin writes outbound DVC data.
 pub(crate) type OnWriteDvcMessage = Box<dyn Fn(u32, Vec<SvcMessage>) -> PduResult<()> + Send + 'static>;
 
-/// Load a DVC client plugin DLL and return channels for each listener the plugin registers.
+/// Load a DVC client plugin DLL and return one-shot channels for each listener the plugin registers.
 ///
-/// # Arguments
-///
-/// * `dll_path` — Path to the DVC plugin DLL (e.g. `C:\Windows\System32\webauthn.dll`)
-/// * `on_write_dvc` — Factory function that creates a write callback for each channel.
-///   The callback is invoked when the plugin calls `IWTSVirtualChannel::Write()`,
-///   sending the encoded DVC messages back into IronRDP's session event loop.
-///
-/// # Returns
-///
-/// A `Vec<DvcComChannel>`, one per listener the plugin registered during `Initialize`.
-/// These should be added to a `DrdynvcClient` via `with_dynamic_channel()`.
+/// Prefer [`load_dvc_plugin_listeners`] when the host re-creates channels (WebAuthn).
 ///
 /// # Panics
 ///
@@ -164,46 +184,64 @@ pub fn load_dvc_plugin<F>(dll_path: &Path, on_write_dvc_factory: F) -> PduResult
 where
     F: Fn() -> OnWriteDvcMessage + Send + Sync + 'static,
 {
+    let (shared, channel_names) = load_plugin_shared(dll_path, on_write_dvc_factory)?;
+    Ok(channel_names
+        .into_iter()
+        .map(|name| DvcComChannel {
+            channel_name: name,
+            shared: Arc::clone(&shared),
+        })
+        .collect())
+}
+
+/// Load a DVC client plugin DLL and return recreatable listeners for each registered channel name.
+///
+/// # Panics
+///
+/// Panics if the COM worker thread cannot be spawned.
+pub fn load_dvc_plugin_listeners<F>(dll_path: &Path, on_write_dvc_factory: F) -> PduResult<Vec<DvcComChannelListener>>
+where
+    F: Fn() -> OnWriteDvcMessage + Send + Sync + 'static,
+{
+    let (shared, channel_names) = load_plugin_shared(dll_path, on_write_dvc_factory)?;
+    Ok(channel_names
+        .into_iter()
+        .map(|name| DvcComChannelListener::new(name, Arc::clone(&shared)))
+        .collect())
+}
+
+fn load_plugin_shared<F>(dll_path: &Path, on_write_dvc_factory: F) -> PduResult<(Arc<ComPluginShared>, Vec<String>)>
+where
+    F: Fn() -> OnWriteDvcMessage + Send + Sync + 'static,
+{
     debug!(dll = %dll_path.display(), "Loading DVC COM plugin");
 
-    // Channel for sending commands to the COM worker thread
     let (command_tx, command_rx) = std_mpsc::channel();
-
-    // Channel for sending write callbacks to the COM worker thread
     let (on_write_dvc_tx, on_write_dvc_rx) = std_mpsc::channel();
-
-    // Channel for receiving the list of registered listeners back from the COM thread
     let (init_tx, init_rx) = std_mpsc::sync_channel::<Result<Vec<String>, String>>(1);
 
     let dll_path_owned = dll_path.to_path_buf();
-    let _on_write_dvc_tx_clone = on_write_dvc_tx.clone();
 
-    let _worker_handle = thread::Builder::new()
+    let worker_handle = thread::Builder::new()
         .name("dvc-com-worker".into())
-        .spawn(move || {
-            // Load and initialize on the COM thread
-            match initialize_plugin_on_thread(&dll_path_owned) {
-                Ok((plugin, manager, listeners)) => {
-                    let channel_names: Vec<String> = listeners.keys().cloned().collect();
-                    debug!(
-                        channels = ?channel_names,
-                        "Plugin initialized, registered {} listener(s)",
-                        channel_names.len()
-                    );
-                    let _ = init_tx.send(Ok(channel_names));
-
-                    // Enter the command loop
-                    run_com_worker(plugin, manager, listeners, command_rx, on_write_dvc_rx);
-                }
-                Err(e) => {
-                    error!(error = %e, "Failed to initialize DVC COM plugin");
-                    let _ = init_tx.send(Err(e));
-                }
+        .spawn(move || match initialize_plugin_on_thread(&dll_path_owned) {
+            Ok((plugin, manager, listeners)) => {
+                let channel_names: Vec<String> = listeners.keys().cloned().collect();
+                debug!(
+                    channels = ?channel_names,
+                    "Plugin initialized, registered {} listener(s)",
+                    channel_names.len()
+                );
+                let _ = init_tx.send(Ok(channel_names));
+                run_com_worker(plugin, manager, listeners, command_rx, on_write_dvc_rx);
+            }
+            Err(e) => {
+                error!(error = %e, "Failed to initialize DVC COM plugin");
+                let _ = init_tx.send(Err(e));
             }
         })
         .expect("spawn COM worker thread");
 
-    // Wait for initialization to complete
     let channel_names = init_rx
         .recv()
         .map_err(|_| pdu_other_err!("COM worker thread died during initialization"))?
@@ -213,43 +251,21 @@ where
         warn!(dll = %dll_path.display(), "Plugin registered no listeners");
     }
 
-    // Create a DvcComChannel for each registered listener
-    let mut channels = Vec::with_capacity(channel_names.len());
-    let is_first = Cell::new(true);
-    let factory: Arc<dyn Fn() -> OnWriteDvcMessage + Send + Sync> = Arc::new(on_write_dvc_factory);
+    let shared = Arc::new(ComPluginShared {
+        command_tx,
+        on_write_dvc_tx,
+        on_write_dvc_factory: Arc::new(on_write_dvc_factory),
+        connected_sent: AtomicBool::new(false),
+        _worker_handle: Some(worker_handle),
+    });
 
-    for name in channel_names {
-        debug!(channel_name = %name, "Creating DvcComChannel");
-
-        channels.push(DvcComChannel {
-            channel_name: name,
-            command_tx: command_tx.clone(),
-            on_write_dvc_tx: on_write_dvc_tx.clone(),
-            on_write_dvc_factory: Arc::clone(&factory),
-            needs_connected: is_first.get(),
-            _worker_handle: None,
-        });
-        is_first.set(false);
-    }
-
-    Ok(channels)
+    Ok((shared, channel_names))
 }
 
 /// Load the plugin DLL and call VirtualChannelGetInstance + Initialize on the COM thread.
-///
-/// Returns the plugin COM object, the channel manager interface, and
-/// the map of listener names → callbacks.
 fn initialize_plugin_on_thread(
     dll_path: &Path,
-) -> Result<
-    (
-        IWTSPlugin,
-        IWTSVirtualChannelManager,
-        HashMap<String, IWTSListenerCallback>,
-    ),
-    String,
-> {
-    // Load the DLL
+) -> Result<(IWTSPlugin, IWTSVirtualChannelManager, HashMap<String, IWTSListenerCallback>), String> {
     let dll_path_wide: Vec<u16> = dll_path.as_os_str().encode_wide().chain(core::iter::once(0)).collect();
     let dll_path_pcwstr = PCWSTR(dll_path_wide.as_ptr());
 
@@ -258,19 +274,17 @@ fn initialize_plugin_on_thread(
 
     trace!(dll = %dll_path.display(), "DLL loaded successfully");
 
-    // Get the VirtualChannelGetInstance export
     let proc_name = PCSTR::from_raw(c"VirtualChannelGetInstance".as_ptr().cast::<u8>());
 
     // SAFETY: hmodule is valid, proc_name is a null-terminated ASCII string
     let proc_addr = unsafe { GetProcAddress(hmodule, proc_name) }
         .ok_or_else(|| "VirtualChannelGetInstance export not found in DLL".to_owned())?;
 
-    // SAFETY: transmuting the function pointer; we trust the DLL follows the documented API
+    // SAFETY: the export matches the documented VirtualChannelGetInstance signature
     let get_instance: VirtualChannelGetInstanceFn = unsafe { core::mem::transmute(proc_addr) };
 
     trace!("VirtualChannelGetInstance export found");
 
-    // Phase 1: query the number of plugin objects
     let iid = IWTSPlugin::IID;
     let mut num_objs: u32 = 0;
 
@@ -289,7 +303,6 @@ fn initialize_plugin_on_thread(
         return Err("plugin returned 0 objects".to_owned());
     }
 
-    // Phase 2: get the actual plugin objects
     let mut obj_array: Vec<*mut c_void> =
         vec![core::ptr::null_mut(); usize::try_from(num_objs).expect("u32 fits in usize")];
 
@@ -302,7 +315,6 @@ fn initialize_plugin_on_thread(
         ));
     }
 
-    // Use the first plugin object
     let plugin_ptr = obj_array[0];
     if plugin_ptr.is_null() {
         return Err("VirtualChannelGetInstance returned null plugin pointer".to_owned());
@@ -313,8 +325,6 @@ fn initialize_plugin_on_thread(
 
     trace!("Got IWTSPlugin COM object");
 
-    // Create shared state for listeners: we keep an Rc clone so we can read the
-    // map after Initialize() without needing an unsafe cast from the COM pointer.
     let listeners_rc = std::rc::Rc::new(core::cell::RefCell::new(HashMap::new()));
     let channel_manager_impl = ChannelManager::new(std::rc::Rc::clone(&listeners_rc));
     let manager: IWTSVirtualChannelManager = channel_manager_impl.into();
@@ -324,7 +334,6 @@ fn initialize_plugin_on_thread(
 
     trace!("IWTSPlugin::Initialize succeeded");
 
-    // Read the listener map that the plugin populated during Initialize.
     let listeners: HashMap<String, IWTSListenerCallback> = listeners_rc.borrow().clone();
 
     Ok((plugin, manager, listeners))

--- a/crates/ironrdp-dvc-com-plugin/src/channel.rs
+++ b/crates/ironrdp-dvc-com-plugin/src/channel.rs
@@ -263,9 +263,16 @@ where
 }
 
 /// Load the plugin DLL and call VirtualChannelGetInstance + Initialize on the COM thread.
-fn initialize_plugin_on_thread(
+pub(crate) fn initialize_plugin_on_thread(
     dll_path: &Path,
-) -> Result<(IWTSPlugin, IWTSVirtualChannelManager, HashMap<String, IWTSListenerCallback>), String> {
+) -> Result<
+    (
+        IWTSPlugin,
+        IWTSVirtualChannelManager,
+        HashMap<String, IWTSListenerCallback>,
+    ),
+    String,
+> {
     let dll_path_wide: Vec<u16> = dll_path.as_os_str().encode_wide().chain(core::iter::once(0)).collect();
     let dll_path_pcwstr = PCWSTR(dll_path_wide.as_ptr());
 

--- a/crates/ironrdp-dvc-com-plugin/src/lib.rs
+++ b/crates/ironrdp-dvc-com-plugin/src/lib.rs
@@ -33,6 +33,8 @@
 
 mod channel;
 mod com;
+mod oneshot;
 mod worker;
 
 pub use channel::{DvcComChannel, DvcComChannelListener, load_dvc_plugin, load_dvc_plugin_listeners};
+pub use oneshot::{process_plugin_request, process_webauthn_dll_request};

--- a/crates/ironrdp-dvc-com-plugin/src/lib.rs
+++ b/crates/ironrdp-dvc-com-plugin/src/lib.rs
@@ -35,4 +35,4 @@ mod channel;
 mod com;
 mod worker;
 
-pub use channel::{DvcComChannel, load_dvc_plugin};
+pub use channel::{DvcComChannel, DvcComChannelListener, load_dvc_plugin, load_dvc_plugin_listeners};

--- a/crates/ironrdp-dvc-com-plugin/src/lib.rs
+++ b/crates/ironrdp-dvc-com-plugin/src/lib.rs
@@ -37,4 +37,4 @@ mod oneshot;
 mod worker;
 
 pub use channel::{DvcComChannel, DvcComChannelListener, load_dvc_plugin, load_dvc_plugin_listeners};
-pub use oneshot::{process_plugin_request, process_webauthn_dll_request};
+pub use oneshot::{PluginRequestError, process_plugin_request, process_webauthn_dll_request, system_webauthn_dll_path};

--- a/crates/ironrdp-dvc-com-plugin/src/lib.rs
+++ b/crates/ironrdp-dvc-com-plugin/src/lib.rs
@@ -37,4 +37,4 @@ mod oneshot;
 mod worker;
 
 pub use channel::{DvcComChannel, DvcComChannelListener, load_dvc_plugin, load_dvc_plugin_listeners};
-pub use oneshot::{PluginRequestError, process_plugin_request, process_webauthn_dll_request, system_webauthn_dll_path};
+pub use oneshot::{process_plugin_request, process_webauthn_dll_request, webauthn_dll_path};

--- a/crates/ironrdp-dvc-com-plugin/src/oneshot.rs
+++ b/crates/ironrdp-dvc-com-plugin/src/oneshot.rs
@@ -5,65 +5,162 @@
 
 use core::cell::RefCell;
 use core::time::Duration;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::mpsc as std_mpsc;
 use std::thread;
 
 use tracing::{debug, info, warn};
-use windows::Win32::Foundation::{E_FAIL, E_INVALIDARG};
+use windows::Win32::Foundation::{E_FAIL, E_INVALIDARG, MAX_PATH};
+use windows::Win32::Networking::WindowsWebServices::WebAuthNCancelCurrentOperation;
 use windows::Win32::System::Com::{COINIT_APARTMENTTHREADED, CoInitializeEx, CoUninitialize};
 use windows::Win32::System::RemoteDesktop::{IWTSVirtualChannel, IWTSVirtualChannel_Impl, IWTSVirtualChannelCallback};
-use windows::core::{BSTR, Error, IUnknown, Ref, Result as WinResult};
+use windows::Win32::System::SystemInformation::GetSystemDirectoryW;
+use windows::core::{BSTR, Error, GUID, IUnknown, Ref, Result as WinResult};
 use windows_core::{BOOL, implement};
 
 use crate::channel::initialize_plugin_on_thread;
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(120);
 
+/// Structured oneshot failure so callers can avoid unsafe public-API fallback after timeout/cancel.
+#[derive(Debug, Clone)]
+pub struct PluginRequestError {
+    pub hresult: u32,
+    pub message: &'static str,
+    /// `true` only when the plugin never started a ceremony (load/init failures).
+    pub allow_public_fallback: bool,
+}
+
+impl core::fmt::Display for PluginRequestError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{} (HRESULT 0x{:08X})", self.message, self.hresult)
+    }
+}
+
+impl core::error::Error for PluginRequestError {}
+
+impl PluginRequestError {
+    fn load(message: &'static str) -> Self {
+        Self {
+            hresult: hresult_to_u32(E_FAIL),
+            message,
+            allow_public_fallback: true,
+        }
+    }
+
+    fn fail(hresult: u32, message: &'static str) -> Self {
+        Self {
+            hresult,
+            message,
+            allow_public_fallback: false,
+        }
+    }
+
+    fn from_dynamic(message: String, allow_public_fallback: bool) -> Self {
+        // Keep a static message for the wire/handler path; full detail goes to logs.
+        warn!(%message, allow_public_fallback, "DVC COM oneshot error");
+        Self {
+            hresult: hresult_to_u32(E_FAIL),
+            message: if allow_public_fallback {
+                "COM plugin request failed before ceremony"
+            } else {
+                "COM plugin request failed"
+            },
+            allow_public_fallback,
+        }
+    }
+}
+
 /// Run a single request through a DVC COM plugin channel and return the plugin's `Write` payload.
 ///
 /// This mirrors MSTSC's `webauthn.dll` path: open the named channel, deliver `request` via
 /// `OnDataReceived`, and capture the bytes the plugin writes back on `IWTSVirtualChannel::Write`.
 ///
+/// On timeout, best-effort cancels the in-flight WebAuthn operation using `cancellation_id` (16-byte
+/// Windows GUID layout) before returning so callers do not start a second prompt.
+///
 /// # Errors
 ///
-/// Returns a human-readable error when the plugin cannot be loaded, rejects the channel, fails the
+/// Returns a structured error when the plugin cannot be loaded, rejects the channel, fails the
 /// request, or does not produce a response before `timeout`.
 pub fn process_plugin_request(
     dll_path: &Path,
     channel_name: &str,
     request: &[u8],
+    cancellation_id: &[u8],
     timeout: Duration,
-) -> Result<Vec<u8>, String> {
+) -> Result<Vec<u8>, PluginRequestError> {
     let dll_path = dll_path.to_path_buf();
     let channel_name = channel_name.to_owned();
     let request = request.to_vec();
+    let cancel_guid = guid_from_bytes(cancellation_id);
 
     let (tx, rx) = std_mpsc::sync_channel(1);
-    thread::Builder::new()
+    let handle = thread::Builder::new()
         .name("dvc-com-oneshot".into())
         .spawn(move || {
             let result = run_oneshot_on_com_thread(&dll_path, &channel_name, &request);
             let _ = tx.send(result);
         })
-        .map_err(|e| format!("failed to spawn COM oneshot thread: {e}"))?;
+        .map_err(|e| {
+            warn!(error = %e, "failed to spawn COM oneshot thread");
+            PluginRequestError::load("failed to spawn COM oneshot thread")
+        })?;
 
-    rx.recv_timeout(timeout)
-        .map_err(|_| format!("COM plugin request timed out after {timeout:?}"))?
+    match rx.recv_timeout(timeout) {
+        Ok(Ok(bytes)) => {
+            let _ = handle.join();
+            Ok(bytes)
+        }
+        Ok(Err(err)) => {
+            let _ = handle.join();
+            Err(err)
+        }
+        Err(_) => {
+            warn!(?timeout, "COM plugin request timed out; cancelling in-flight operation");
+            if let Some(guid) = cancel_guid {
+                // SAFETY: cancel GUID is a plain value; WebAuthNCancelCurrentOperation is process-wide.
+                let _ = unsafe { WebAuthNCancelCurrentOperation(&guid) };
+            }
+            // Do not join indefinitely: OnDataReceived may still be inside modal UI until cancel
+            // lands. Detach the worker and refuse public-API fallback.
+            drop(handle);
+            Err(PluginRequestError::fail(
+                0x8000_4004, /* E_ABORT */
+                "COM plugin request timed out",
+            ))
+        }
+    }
 }
 
 /// Convenience wrapper for System32 `webauthn.dll` / `WebAuthN_Channel`.
-pub fn process_webauthn_dll_request(request: &[u8]) -> Result<Vec<u8>, String> {
-    process_plugin_request(
-        Path::new(r"C:\Windows\System32\webauthn.dll"),
-        "WebAuthN_Channel",
-        request,
-        DEFAULT_TIMEOUT,
-    )
+pub fn process_webauthn_dll_request(request: &[u8], cancellation_id: &[u8]) -> Result<Vec<u8>, PluginRequestError> {
+    let dll = system_webauthn_dll_path().ok_or_else(|| PluginRequestError::load("failed to resolve System32 path"))?;
+    process_plugin_request(&dll, "WebAuthN_Channel", request, cancellation_id, DEFAULT_TIMEOUT)
 }
 
-fn run_oneshot_on_com_thread(dll_path: &Path, channel_name: &str, request: &[u8]) -> Result<Vec<u8>, String> {
+/// Resolve `%SystemRoot%\System32\webauthn.dll` via `GetSystemDirectoryW`.
+pub fn system_webauthn_dll_path() -> Option<PathBuf> {
+    let capacity = usize::try_from(MAX_PATH).ok()?;
+    let mut buf = vec![0u16; capacity];
+    // SAFETY: buffer length is in wide chars; API writes a NUL-terminated path.
+    let len = unsafe { GetSystemDirectoryW(Some(&mut buf)) };
+    let len = usize::try_from(len).ok()?;
+    if len == 0 || len >= buf.len() {
+        return None;
+    }
+    buf.truncate(len);
+    let mut path = PathBuf::from(String::from_utf16_lossy(&buf));
+    path.push("webauthn.dll");
+    Some(path)
+}
+
+fn run_oneshot_on_com_thread(
+    dll_path: &Path,
+    channel_name: &str,
+    request: &[u8],
+) -> Result<Vec<u8>, PluginRequestError> {
     // SAFETY: initialize a STA apartment for the duration of this oneshot thread.
     let should_uninit = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) }.is_ok();
 
@@ -76,15 +173,18 @@ fn run_oneshot_on_com_thread(dll_path: &Path, channel_name: &str, request: &[u8]
     result
 }
 
-fn run_oneshot_body(dll_path: &Path, channel_name: &str, request: &[u8]) -> Result<Vec<u8>, String> {
-    let (plugin, _manager, listeners) = initialize_plugin_on_thread(dll_path)?;
+fn run_oneshot_body(dll_path: &Path, channel_name: &str, request: &[u8]) -> Result<Vec<u8>, PluginRequestError> {
+    let (plugin, _manager, listeners) = initialize_plugin_on_thread(dll_path).map_err(|e| {
+        warn!(error = %e, "initialize_plugin_on_thread failed");
+        PluginRequestError::from_dynamic(e, true)
+    })?;
 
     // SAFETY: COM objects live on this thread for the duration of the oneshot.
     let _ = unsafe { plugin.Connected() };
 
     let listener = listeners
         .get(channel_name)
-        .ok_or_else(|| format!("plugin did not register listener for {channel_name}"))?
+        .ok_or_else(|| PluginRequestError::load("plugin did not register expected channel listener"))?
         .clone();
 
     let capture = Rc::new(RefCell::new(Vec::<u8>::new()));
@@ -101,14 +201,18 @@ fn run_oneshot_body(dll_path: &Path, channel_name: &str, request: &[u8]) -> Resu
     unsafe {
         listener
             .OnNewChannelConnection(&virtual_channel, &BSTR::default(), &mut accept, &mut channel_callback)
-            .map_err(|e| format!("OnNewChannelConnection failed: {e}"))?;
+            .map_err(|e| {
+                warn!(error = %e, "OnNewChannelConnection failed");
+                PluginRequestError::from_dynamic(format!("OnNewChannelConnection failed: {e}"), true)
+            })?;
     }
 
     if !accept.as_bool() {
-        return Err("plugin rejected oneshot channel".to_owned());
+        return Err(PluginRequestError::load("plugin rejected oneshot channel"));
     }
 
-    let callback = channel_callback.ok_or_else(|| "plugin accepted channel without callback".to_owned())?;
+    let callback =
+        channel_callback.ok_or_else(|| PluginRequestError::load("plugin accepted channel without callback"))?;
 
     debug!(
         channel_name,
@@ -119,9 +223,10 @@ fn run_oneshot_body(dll_path: &Path, channel_name: &str, request: &[u8]) -> Resu
     // SAFETY: buffer lives for the duration of OnDataReceived; webauthn.dll processes
     // WebAuthn ceremonies synchronously and calls Write before returning.
     unsafe {
-        callback
-            .OnDataReceived(request)
-            .map_err(|e| format!("OnDataReceived failed: {e}"))?;
+        callback.OnDataReceived(request).map_err(|e| {
+            warn!(error = %e, "OnDataReceived failed");
+            PluginRequestError::from_dynamic(format!("OnDataReceived failed: {e}"), false)
+        })?;
     }
 
     let response = capture.borrow().clone();
@@ -131,7 +236,10 @@ fn run_oneshot_body(dll_path: &Path, channel_name: &str, request: &[u8]) -> Resu
         let _ = unsafe { callback.OnClose() };
         let _ = unsafe { plugin.Disconnected(0) };
         let _ = unsafe { plugin.Terminated() };
-        return Err("COM plugin produced empty response".to_owned());
+        return Err(PluginRequestError::fail(
+            hresult_to_u32(E_FAIL),
+            "COM plugin produced empty response",
+        ));
     }
 
     let hresult = response
@@ -152,6 +260,22 @@ fn run_oneshot_body(dll_path: &Path, channel_name: &str, request: &[u8]) -> Resu
     let _ = unsafe { plugin.Terminated() };
 
     Ok(response)
+}
+
+fn hresult_to_u32(hr: windows::core::HRESULT) -> u32 {
+    u32::from_ne_bytes(hr.0.to_ne_bytes())
+}
+
+fn guid_from_bytes(bytes: &[u8]) -> Option<GUID> {
+    if bytes.len() != 16 {
+        return None;
+    }
+    Some(GUID {
+        data1: u32::from_le_bytes(bytes[0..4].try_into().ok()?),
+        data2: u16::from_le_bytes(bytes[4..6].try_into().ok()?),
+        data3: u16::from_le_bytes(bytes[6..8].try_into().ok()?),
+        data4: bytes[8..16].try_into().ok()?,
+    })
 }
 
 /// `IWTSVirtualChannel` that captures raw `Write` bytes instead of framing DVC PDUs.

--- a/crates/ironrdp-dvc-com-plugin/src/oneshot.rs
+++ b/crates/ironrdp-dvc-com-plugin/src/oneshot.rs
@@ -1,0 +1,191 @@
+//! One-shot DVC COM plugin request helper.
+//!
+//! Used by the pure-Rust RDPEWA backend when a host omits `clientDataJSON` (hash-only MS-RDPEWA).
+//! Public WebAuthN* APIs cannot complete those ceremonies; `webauthn.dll`'s IWTS plugin path can.
+
+use core::cell::RefCell;
+use std::path::Path;
+use std::rc::Rc;
+use std::sync::mpsc as std_mpsc;
+use std::thread;
+use std::time::Duration;
+
+use tracing::{debug, info, warn};
+use windows::Win32::Foundation::{E_FAIL, E_INVALIDARG};
+use windows::Win32::System::Com::{COINIT_APARTMENTTHREADED, CoInitializeEx, CoUninitialize};
+use windows::Win32::System::RemoteDesktop::{IWTSVirtualChannel, IWTSVirtualChannel_Impl, IWTSVirtualChannelCallback};
+use windows::core::{BSTR, Error, IUnknown, Ref, Result as WinResult};
+use windows_core::{BOOL, implement};
+
+use crate::channel::initialize_plugin_on_thread;
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Run a single request through a DVC COM plugin channel and return the plugin's `Write` payload.
+///
+/// This mirrors MSTSC's `webauthn.dll` path: open the named channel, deliver `request` via
+/// `OnDataReceived`, and capture the bytes the plugin writes back on `IWTSVirtualChannel::Write`.
+///
+/// # Errors
+///
+/// Returns a human-readable error when the plugin cannot be loaded, rejects the channel, fails the
+/// request, or does not produce a response before `timeout`.
+pub fn process_plugin_request(
+    dll_path: &Path,
+    channel_name: &str,
+    request: &[u8],
+    timeout: Duration,
+) -> Result<Vec<u8>, String> {
+    let dll_path = dll_path.to_path_buf();
+    let channel_name = channel_name.to_owned();
+    let request = request.to_vec();
+
+    let (tx, rx) = std_mpsc::sync_channel(1);
+    thread::Builder::new()
+        .name("dvc-com-oneshot".into())
+        .spawn(move || {
+            let result = run_oneshot_on_com_thread(&dll_path, &channel_name, &request);
+            let _ = tx.send(result);
+        })
+        .map_err(|e| format!("failed to spawn COM oneshot thread: {e}"))?;
+
+    rx.recv_timeout(timeout)
+        .map_err(|_| format!("COM plugin request timed out after {timeout:?}"))?
+}
+
+/// Convenience wrapper for System32 `webauthn.dll` / `WebAuthN_Channel`.
+pub fn process_webauthn_dll_request(request: &[u8]) -> Result<Vec<u8>, String> {
+    process_plugin_request(
+        Path::new(r"C:\Windows\System32\webauthn.dll"),
+        "WebAuthN_Channel",
+        request,
+        DEFAULT_TIMEOUT,
+    )
+}
+
+fn run_oneshot_on_com_thread(dll_path: &Path, channel_name: &str, request: &[u8]) -> Result<Vec<u8>, String> {
+    // SAFETY: initialize a STA apartment for the duration of this oneshot thread.
+    let should_uninit = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) }.is_ok();
+
+    let result = run_oneshot_body(dll_path, channel_name, request);
+
+    // SAFETY: balance a successful CoInitializeEx.
+    if should_uninit {
+        unsafe { CoUninitialize() };
+    }
+    result
+}
+
+fn run_oneshot_body(dll_path: &Path, channel_name: &str, request: &[u8]) -> Result<Vec<u8>, String> {
+    let (plugin, _manager, listeners) = initialize_plugin_on_thread(dll_path)?;
+
+    // SAFETY: COM objects live on this thread for the duration of the oneshot.
+    let _ = unsafe { plugin.Connected() };
+
+    let listener = listeners
+        .get(channel_name)
+        .ok_or_else(|| format!("plugin did not register listener for {channel_name}"))?
+        .clone();
+
+    let capture = Rc::new(RefCell::new(Vec::<u8>::new()));
+    let virtual_channel: IWTSVirtualChannel = CaptureVirtualChannel {
+        capture: Rc::clone(&capture),
+        closed: RefCell::new(false),
+    }
+    .into();
+
+    let mut accept = BOOL::default();
+    let mut channel_callback: Option<IWTSVirtualChannelCallback> = None;
+
+    // SAFETY: COM call on the owning thread; out-params are stack locals valid for the call.
+    unsafe {
+        listener
+            .OnNewChannelConnection(&virtual_channel, &BSTR::default(), &mut accept, &mut channel_callback)
+            .map_err(|e| format!("OnNewChannelConnection failed: {e}"))?;
+    }
+
+    if !accept.as_bool() {
+        return Err("plugin rejected oneshot channel".to_owned());
+    }
+
+    let callback = channel_callback.ok_or_else(|| "plugin accepted channel without callback".to_owned())?;
+
+    debug!(
+        channel_name,
+        request_len = request.len(),
+        "Delivering oneshot request to COM plugin"
+    );
+
+    // SAFETY: buffer lives for the duration of OnDataReceived; webauthn.dll processes
+    // WebAuthn ceremonies synchronously and calls Write before returning.
+    unsafe {
+        callback
+            .OnDataReceived(request)
+            .map_err(|e| format!("OnDataReceived failed: {e}"))?;
+    }
+
+    let response = capture.borrow().clone();
+    if response.is_empty() {
+        warn!(channel_name, "COM plugin produced empty Write payload");
+        // SAFETY: channel teardown on owning thread.
+        let _ = unsafe { callback.OnClose() };
+        let _ = unsafe { plugin.Disconnected(0) };
+        let _ = unsafe { plugin.Terminated() };
+        return Err("COM plugin produced empty response".to_owned());
+    }
+
+    let hresult = response
+        .get(..4)
+        .and_then(|b| b.try_into().ok())
+        .map(u32::from_le_bytes)
+        .unwrap_or(0);
+    info!(
+        channel_name,
+        hresult = format!("0x{hresult:08X}"),
+        response_len = response.len(),
+        "COM oneshot Write captured"
+    );
+
+    // SAFETY: channel teardown on owning thread.
+    let _ = unsafe { callback.OnClose() };
+    let _ = unsafe { plugin.Disconnected(0) };
+    let _ = unsafe { plugin.Terminated() };
+
+    Ok(response)
+}
+
+/// `IWTSVirtualChannel` that captures raw `Write` bytes instead of framing DVC PDUs.
+#[implement(IWTSVirtualChannel)]
+struct CaptureVirtualChannel {
+    capture: Rc<RefCell<Vec<u8>>>,
+    closed: RefCell<bool>,
+}
+
+impl IWTSVirtualChannel_Impl for CaptureVirtualChannel_Impl {
+    fn Write(&self, cbsize: u32, pbuffer: *const u8, _preserved: Ref<'_, IUnknown>) -> WinResult<()> {
+        if *self.closed.borrow() {
+            return Err(Error::new(E_FAIL, "channel is closed"));
+        }
+
+        let size = usize::try_from(cbsize).expect("u32 fits in usize");
+        if pbuffer.is_null() && size > 0 {
+            return Err(Error::new(E_INVALIDARG, "null buffer"));
+        }
+
+        // SAFETY: plugin guarantees buffer validity for the Write call.
+        let data = if size > 0 {
+            unsafe { core::slice::from_raw_parts(pbuffer, size) }.to_vec()
+        } else {
+            Vec::new()
+        };
+
+        debug!(size = data.len(), "CaptureVirtualChannel::Write");
+        *self.capture.borrow_mut() = data;
+        Ok(())
+    }
+
+    fn Close(&self) -> WinResult<()> {
+        *self.closed.borrow_mut() = true;
+        Ok(())
+    }
+}

--- a/crates/ironrdp-dvc-com-plugin/src/oneshot.rs
+++ b/crates/ironrdp-dvc-com-plugin/src/oneshot.rs
@@ -4,11 +4,11 @@
 //! Public WebAuthN* APIs cannot complete those ceremonies; `webauthn.dll`'s IWTS plugin path can.
 
 use core::cell::RefCell;
+use core::time::Duration;
 use std::path::Path;
 use std::rc::Rc;
 use std::sync::mpsc as std_mpsc;
 use std::thread;
-use std::time::Duration;
 
 use tracing::{debug, info, warn};
 use windows::Win32::Foundation::{E_FAIL, E_INVALIDARG};

--- a/crates/ironrdp-dvc-com-plugin/src/oneshot.rs
+++ b/crates/ironrdp-dvc-com-plugin/src/oneshot.rs
@@ -4,163 +4,77 @@
 //! Public WebAuthN* APIs cannot complete those ceremonies; `webauthn.dll`'s IWTS plugin path can.
 
 use core::cell::RefCell;
-use core::time::Duration;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::mpsc as std_mpsc;
 use std::thread;
 
 use tracing::{debug, info, warn};
-use windows::Win32::Foundation::{E_FAIL, E_INVALIDARG, MAX_PATH};
-use windows::Win32::Networking::WindowsWebServices::WebAuthNCancelCurrentOperation;
+use windows::Win32::Foundation::{E_FAIL, E_INVALIDARG};
 use windows::Win32::System::Com::{COINIT_APARTMENTTHREADED, CoInitializeEx, CoUninitialize};
 use windows::Win32::System::RemoteDesktop::{IWTSVirtualChannel, IWTSVirtualChannel_Impl, IWTSVirtualChannelCallback};
 use windows::Win32::System::SystemInformation::GetSystemDirectoryW;
-use windows::core::{BSTR, Error, GUID, IUnknown, Ref, Result as WinResult};
+use windows::core::{BSTR, Error, IUnknown, Ref, Result as WinResult};
 use windows_core::{BOOL, implement};
 
 use crate::channel::initialize_plugin_on_thread;
 
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(120);
-
-/// Structured oneshot failure so callers can avoid unsafe public-API fallback after timeout/cancel.
-#[derive(Debug, Clone)]
-pub struct PluginRequestError {
-    pub hresult: u32,
-    pub message: &'static str,
-    /// `true` only when the plugin never started a ceremony (load/init failures).
-    pub allow_public_fallback: bool,
-}
-
-impl core::fmt::Display for PluginRequestError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{} (HRESULT 0x{:08X})", self.message, self.hresult)
-    }
-}
-
-impl core::error::Error for PluginRequestError {}
-
-impl PluginRequestError {
-    fn load(message: &'static str) -> Self {
-        Self {
-            hresult: hresult_to_u32(E_FAIL),
-            message,
-            allow_public_fallback: true,
-        }
-    }
-
-    fn fail(hresult: u32, message: &'static str) -> Self {
-        Self {
-            hresult,
-            message,
-            allow_public_fallback: false,
-        }
-    }
-
-    fn from_dynamic(message: String, allow_public_fallback: bool) -> Self {
-        // Keep a static message for the wire/handler path; full detail goes to logs.
-        warn!(%message, allow_public_fallback, "DVC COM oneshot error");
-        Self {
-            hresult: hresult_to_u32(E_FAIL),
-            message: if allow_public_fallback {
-                "COM plugin request failed before ceremony"
-            } else {
-                "COM plugin request failed"
-            },
-            allow_public_fallback,
-        }
-    }
-}
-
 /// Run a single request through a DVC COM plugin channel and return the plugin's `Write` payload.
 ///
-/// This mirrors MSTSC's `webauthn.dll` path: open the named channel, deliver `request` via
-/// `OnDataReceived`, and capture the bytes the plugin writes back on `IWTSVirtualChannel::Write`.
-///
-/// On timeout, best-effort cancels the in-flight WebAuthn operation using `cancellation_id` (16-byte
-/// Windows GUID layout) before returning so callers do not start a second prompt.
+/// This mirrors MSTSC's `webauthn.dll` path: open the named channel, deliver `request` via `OnDataReceived`, and capture the bytes the plugin writes back on `IWTSVirtualChannel::Write`.
 ///
 /// # Errors
 ///
-/// Returns a structured error when the plugin cannot be loaded, rejects the channel, fails the
-/// request, or does not produce a response before `timeout`.
-pub fn process_plugin_request(
-    dll_path: &Path,
-    channel_name: &str,
-    request: &[u8],
-    cancellation_id: &[u8],
-    timeout: Duration,
-) -> Result<Vec<u8>, PluginRequestError> {
+/// Returns a human-readable error when the plugin cannot be loaded, rejects the channel, or fails the request.
+///
+/// This waits for the COM call to complete so the plugin is torn down on its owning apartment before the caller can try another WebAuthn implementation.
+pub fn process_plugin_request(dll_path: &Path, channel_name: &str, request: &[u8]) -> Result<Vec<u8>, String> {
     let dll_path = dll_path.to_path_buf();
     let channel_name = channel_name.to_owned();
     let request = request.to_vec();
-    let cancel_guid = guid_from_bytes(cancellation_id);
 
     let (tx, rx) = std_mpsc::sync_channel(1);
-    let handle = thread::Builder::new()
+    thread::Builder::new()
         .name("dvc-com-oneshot".into())
         .spawn(move || {
             let result = run_oneshot_on_com_thread(&dll_path, &channel_name, &request);
             let _ = tx.send(result);
         })
-        .map_err(|e| {
-            warn!(error = %e, "failed to spawn COM oneshot thread");
-            PluginRequestError::load("failed to spawn COM oneshot thread")
-        })?;
+        .map_err(|e| format!("failed to spawn COM oneshot thread: {e}"))?;
 
-    match rx.recv_timeout(timeout) {
-        Ok(Ok(bytes)) => {
-            let _ = handle.join();
-            Ok(bytes)
-        }
-        Ok(Err(err)) => {
-            let _ = handle.join();
-            Err(err)
-        }
-        Err(_) => {
-            warn!(?timeout, "COM plugin request timed out; cancelling in-flight operation");
-            if let Some(guid) = cancel_guid {
-                // SAFETY: cancel GUID is a plain value; WebAuthNCancelCurrentOperation is process-wide.
-                let _ = unsafe { WebAuthNCancelCurrentOperation(&guid) };
-            }
-            // Do not join indefinitely: OnDataReceived may still be inside modal UI until cancel
-            // lands. Detach the worker and refuse public-API fallback.
-            drop(handle);
-            Err(PluginRequestError::fail(
-                0x8000_4004, /* E_ABORT */
-                "COM plugin request timed out",
-            ))
-        }
-    }
+    rx.recv()
+        .map_err(|_| "COM plugin thread terminated before producing a response".to_owned())?
 }
 
 /// Convenience wrapper for System32 `webauthn.dll` / `WebAuthN_Channel`.
-pub fn process_webauthn_dll_request(request: &[u8], cancellation_id: &[u8]) -> Result<Vec<u8>, PluginRequestError> {
-    let dll = system_webauthn_dll_path().ok_or_else(|| PluginRequestError::load("failed to resolve System32 path"))?;
-    process_plugin_request(&dll, "WebAuthN_Channel", request, cancellation_id, DEFAULT_TIMEOUT)
+pub fn process_webauthn_dll_request(request: &[u8]) -> Result<Vec<u8>, String> {
+    process_plugin_request(&webauthn_dll_path()?, "WebAuthN_Channel", request)
 }
 
-/// Resolve `%SystemRoot%\System32\webauthn.dll` via `GetSystemDirectoryW`.
-pub fn system_webauthn_dll_path() -> Option<PathBuf> {
-    let capacity = usize::try_from(MAX_PATH).ok()?;
-    let mut buf = vec![0u16; capacity];
-    // SAFETY: buffer length is in wide chars; API writes a NUL-terminated path.
-    let len = unsafe { GetSystemDirectoryW(Some(&mut buf)) };
-    let len = usize::try_from(len).ok()?;
-    if len == 0 || len >= buf.len() {
-        return None;
+/// Resolve the native `webauthn.dll` from the active Windows system directory.
+pub fn webauthn_dll_path() -> Result<PathBuf, String> {
+    let mut buffer = vec![0u16; 260];
+
+    loop {
+        // SAFETY: buffer is writable UTF-16 storage passed directly to the Windows API.
+        let len = unsafe { GetSystemDirectoryW(Some(&mut buffer)) };
+        if len == 0 {
+            return Err(format!("GetSystemDirectoryW failed: {}", Error::from_thread()));
+        }
+
+        let len = usize::try_from(len).map_err(|_| "system directory path is too long".to_owned())?;
+        if len < buffer.len() {
+            let directory = String::from_utf16(&buffer[..len])
+                .map_err(|_| "GetSystemDirectoryW returned invalid UTF-16".to_owned())?;
+            return Ok(PathBuf::from(directory).join("webauthn.dll"));
+        }
+
+        buffer.resize(len + 1, 0);
     }
-    buf.truncate(len);
-    let mut path = PathBuf::from(String::from_utf16_lossy(&buf));
-    path.push("webauthn.dll");
-    Some(path)
 }
 
-fn run_oneshot_on_com_thread(
-    dll_path: &Path,
-    channel_name: &str,
-    request: &[u8],
-) -> Result<Vec<u8>, PluginRequestError> {
+fn run_oneshot_on_com_thread(dll_path: &Path, channel_name: &str, request: &[u8]) -> Result<Vec<u8>, String> {
     // SAFETY: initialize a STA apartment for the duration of this oneshot thread.
     let should_uninit = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) }.is_ok();
 
@@ -173,18 +87,15 @@ fn run_oneshot_on_com_thread(
     result
 }
 
-fn run_oneshot_body(dll_path: &Path, channel_name: &str, request: &[u8]) -> Result<Vec<u8>, PluginRequestError> {
-    let (plugin, _manager, listeners) = initialize_plugin_on_thread(dll_path).map_err(|e| {
-        warn!(error = %e, "initialize_plugin_on_thread failed");
-        PluginRequestError::from_dynamic(e, true)
-    })?;
+fn run_oneshot_body(dll_path: &Path, channel_name: &str, request: &[u8]) -> Result<Vec<u8>, String> {
+    let (plugin, _manager, listeners) = initialize_plugin_on_thread(dll_path)?;
 
     // SAFETY: COM objects live on this thread for the duration of the oneshot.
     let _ = unsafe { plugin.Connected() };
 
     let listener = listeners
         .get(channel_name)
-        .ok_or_else(|| PluginRequestError::load("plugin did not register expected channel listener"))?
+        .ok_or_else(|| format!("plugin did not register listener for {channel_name}"))?
         .clone();
 
     let capture = Rc::new(RefCell::new(Vec::<u8>::new()));
@@ -201,18 +112,14 @@ fn run_oneshot_body(dll_path: &Path, channel_name: &str, request: &[u8]) -> Resu
     unsafe {
         listener
             .OnNewChannelConnection(&virtual_channel, &BSTR::default(), &mut accept, &mut channel_callback)
-            .map_err(|e| {
-                warn!(error = %e, "OnNewChannelConnection failed");
-                PluginRequestError::from_dynamic(format!("OnNewChannelConnection failed: {e}"), true)
-            })?;
+            .map_err(|e| format!("OnNewChannelConnection failed: {e}"))?;
     }
 
     if !accept.as_bool() {
-        return Err(PluginRequestError::load("plugin rejected oneshot channel"));
+        return Err("plugin rejected oneshot channel".to_owned());
     }
 
-    let callback =
-        channel_callback.ok_or_else(|| PluginRequestError::load("plugin accepted channel without callback"))?;
+    let callback = channel_callback.ok_or_else(|| "plugin accepted channel without callback".to_owned())?;
 
     debug!(
         channel_name,
@@ -222,60 +129,39 @@ fn run_oneshot_body(dll_path: &Path, channel_name: &str, request: &[u8]) -> Resu
 
     // SAFETY: buffer lives for the duration of OnDataReceived; webauthn.dll processes
     // WebAuthn ceremonies synchronously and calls Write before returning.
-    unsafe {
-        callback.OnDataReceived(request).map_err(|e| {
-            warn!(error = %e, "OnDataReceived failed");
-            PluginRequestError::from_dynamic(format!("OnDataReceived failed: {e}"), false)
-        })?;
+    let result = unsafe {
+        callback
+            .OnDataReceived(request)
+            .map_err(|e| format!("OnDataReceived failed: {e}"))
     }
+    .and_then(|()| {
+        let response = capture.borrow().clone();
+        if response.is_empty() {
+            warn!(channel_name, "COM plugin produced empty Write payload");
+            return Err("COM plugin produced empty response".to_owned());
+        }
 
-    let response = capture.borrow().clone();
-    if response.is_empty() {
-        warn!(channel_name, "COM plugin produced empty Write payload");
-        // SAFETY: channel teardown on owning thread.
-        let _ = unsafe { callback.OnClose() };
-        let _ = unsafe { plugin.Disconnected(0) };
-        let _ = unsafe { plugin.Terminated() };
-        return Err(PluginRequestError::fail(
-            hresult_to_u32(E_FAIL),
-            "COM plugin produced empty response",
-        ));
-    }
+        let hresult = response
+            .get(..4)
+            .and_then(|b| b.try_into().ok())
+            .map(u32::from_le_bytes)
+            .unwrap_or(0);
+        info!(
+            channel_name,
+            hresult = format!("0x{hresult:08X}"),
+            response_len = response.len(),
+            "COM oneshot Write captured"
+        );
 
-    let hresult = response
-        .get(..4)
-        .and_then(|b| b.try_into().ok())
-        .map(u32::from_le_bytes)
-        .unwrap_or(0);
-    info!(
-        channel_name,
-        hresult = format!("0x{hresult:08X}"),
-        response_len = response.len(),
-        "COM oneshot Write captured"
-    );
+        Ok(response)
+    });
 
     // SAFETY: channel teardown on owning thread.
     let _ = unsafe { callback.OnClose() };
     let _ = unsafe { plugin.Disconnected(0) };
     let _ = unsafe { plugin.Terminated() };
 
-    Ok(response)
-}
-
-fn hresult_to_u32(hr: windows::core::HRESULT) -> u32 {
-    u32::from_ne_bytes(hr.0.to_ne_bytes())
-}
-
-fn guid_from_bytes(bytes: &[u8]) -> Option<GUID> {
-    if bytes.len() != 16 {
-        return None;
-    }
-    Some(GUID {
-        data1: u32::from_le_bytes(bytes[0..4].try_into().ok()?),
-        data2: u16::from_le_bytes(bytes[4..6].try_into().ok()?),
-        data3: u16::from_le_bytes(bytes[6..8].try_into().ok()?),
-        data4: bytes[8..16].try_into().ok()?,
-    })
+    result
 }
 
 /// `IWTSVirtualChannel` that captures raw `Write` bytes instead of framing DVC PDUs.

--- a/crates/ironrdp-rdpewa-native/CHANGELOG.md
+++ b/crates/ironrdp-rdpewa-native/CHANGELOG.md
@@ -2,11 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
-## [[Unreleased]]
+## Unreleased
 
 ### Added
 
 - Initial Windows WebAuthn backend for MS-RDPEWA ([MS-RDPEWA]).
 
-[Unreleased]: https://github.com/Devolutions/IronRDP/compare/placeholder...HEAD
 [MS-RDPEWA]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpewa/

--- a/crates/ironrdp-rdpewa-native/CHANGELOG.md
+++ b/crates/ironrdp-rdpewa-native/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [[Unreleased]]
+
+### Added
+
+- Initial Windows WebAuthn backend for MS-RDPEWA ([MS-RDPEWA]).
+
+[Unreleased]: https://github.com/Devolutions/IronRDP/compare/placeholder...HEAD
+[MS-RDPEWA]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpewa/

--- a/crates/ironrdp-rdpewa-native/Cargo.toml
+++ b/crates/ironrdp-rdpewa-native/Cargo.toml
@@ -22,6 +22,7 @@ windows = { version = "0.62", features = [
     "Win32_Foundation",
     "Win32_Networking_WindowsWebServices",
     "Win32_System_Com",
+    "Win32_UI_WindowsAndMessaging",
 ] }
 
 [lints]

--- a/crates/ironrdp-rdpewa-native/Cargo.toml
+++ b/crates/ironrdp-rdpewa-native/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "ironrdp-rdpewa-native"
+version = "0.1.0"
+readme = "README.md"
+description = "Windows WebAuthn backend for IronRDP MS-RDPEWA client"
+edition.workspace = true
+rust-version = "1.94"
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lib]
+doctest = false
+test = false
+
+[target.'cfg(windows)'.dependencies]
+ironrdp-rdpewa = { path = "../ironrdp-rdpewa", version = "0.1" } # public
+tracing = { version = "0.1", features = ["log"] }
+windows = { version = "0.62", features = [
+    "Win32_Foundation",
+    "Win32_Networking_WindowsWebServices",
+    "Win32_System_Com",
+] }
+
+[lints]
+workspace = true

--- a/crates/ironrdp-rdpewa-native/Cargo.toml
+++ b/crates/ironrdp-rdpewa-native/Cargo.toml
@@ -17,6 +17,8 @@ doctest = false
 
 [target.'cfg(windows)'.dependencies]
 ironrdp-rdpewa = { path = "../ironrdp-rdpewa", version = "0.1" } # public
+# Hash-only MS-RDPEWA hosts need webauthn.dll's IWTS remote-RPC path (same as MSTSC).
+ironrdp-dvc-com-plugin = { path = "../ironrdp-dvc-com-plugin", version = "0.1" }
 tracing = { version = "0.1", features = ["log"] }
 windows = { version = "0.62", features = [
     "Win32_Foundation",

--- a/crates/ironrdp-rdpewa-native/Cargo.toml
+++ b/crates/ironrdp-rdpewa-native/Cargo.toml
@@ -14,7 +14,6 @@ categories.workspace = true
 
 [lib]
 doctest = false
-test = false
 
 [target.'cfg(windows)'.dependencies]
 ironrdp-rdpewa = { path = "../ironrdp-rdpewa", version = "0.1" } # public

--- a/crates/ironrdp-rdpewa-native/Cargo.toml
+++ b/crates/ironrdp-rdpewa-native/Cargo.toml
@@ -17,8 +17,6 @@ doctest = false
 
 [target.'cfg(windows)'.dependencies]
 ironrdp-rdpewa = { path = "../ironrdp-rdpewa", version = "0.1" } # public
-# Hash-only MS-RDPEWA hosts need webauthn.dll's IWTS remote-RPC path (same as MSTSC).
-ironrdp-dvc-com-plugin = { path = "../ironrdp-dvc-com-plugin", version = "0.1" }
 tracing = { version = "0.1", features = ["log"] }
 windows = { version = "0.62", features = [
     "Win32_Foundation",

--- a/crates/ironrdp-rdpewa-native/README.md
+++ b/crates/ironrdp-rdpewa-native/README.md
@@ -1,8 +1,20 @@
 # ironrdp-rdpewa-native
 
-Windows WebAuthn API backend for the IronRDP [MS-RDPEWA] client.
+Windows backend for the IronRDP [MS-RDPEWA] client.
 
-Implements `RdpewaClientHandler` using `webauthn.dll` exports
-(`WebAuthNAuthenticatorMakeCredential`, `WebAuthNAuthenticatorGetAssertion`, …).
+## Paths
+
+1. **webauthn.dll oneshot (preferred for ceremonies)**
+   Forwards the original RDPEWA CBOR through `webauthn.dll`'s IWTS remote-RPC path
+   (same private stack MSTSC uses). Required for **hash-only** hosts that omit
+   `clientDataJSON` — public `WebAuthN*` APIs cannot complete those ceremonies.
+
+2. **Public WebAuthN* APIs (fallback)**
+   Used when oneshot is unavailable and the host supplied full `clientDataJSON`.
+
+Session channel registration may still prefer hosting `webauthn.dll` as a DVC COM
+listener (`ironrdp-dvc-com-plugin`) for full MSTSC parity. Set
+`IRONRDP_WEBAUTHN_FORCE_NATIVE=1` to exercise this backend via `RdpewaClientListener`
+instead.
 
 [MS-RDPEWA]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpewa/

--- a/crates/ironrdp-rdpewa-native/README.md
+++ b/crates/ironrdp-rdpewa-native/README.md
@@ -1,0 +1,8 @@
+# ironrdp-rdpewa-native
+
+Windows WebAuthn API backend for the IronRDP [MS-RDPEWA] client.
+
+Implements `RdpewaClientHandler` using `webauthn.dll` exports
+(`WebAuthNAuthenticatorMakeCredential`, `WebAuthNAuthenticatorGetAssertion`, …).
+
+[MS-RDPEWA]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpewa/

--- a/crates/ironrdp-rdpewa-native/src/backend.rs
+++ b/crates/ironrdp-rdpewa-native/src/backend.rs
@@ -40,7 +40,7 @@ use crate::ctap::{
 /// ceremony started by an earlier channel instance.
 fn shared_cancel_guid() -> Arc<Mutex<Option<GUID>>> {
     static SLOT: OnceLock<Arc<Mutex<Option<GUID>>>> = OnceLock::new();
-    SLOT.get_or_init(|| Arc::new(Mutex::new(None))).clone()
+    Arc::clone(SLOT.get_or_init(|| Arc::new(Mutex::new(None))))
 }
 
 /// Windows Hello / security-key backend for [`ironrdp_rdpewa::RdpewaClient`].
@@ -127,7 +127,7 @@ impl RdpewaClientHandler for WindowsRdpewaBackend {
                 let hwnd = resolve_parent_hwnd(parent_hwnd);
                 info!(
                     parent_hwnd,
-                    resolved_hwnd = hwnd.0 as usize,
+                                    resolved_hwnd = hwnd.0.addr(),
                     client_data_json_len = request.client_data_json.len(),
                     raw_request_len = request.raw_request.len(),
                     ?request.subcommand,
@@ -215,7 +215,8 @@ fn run_via_webauthn_dll_oneshot(request: &WebAuthnOperationRequest) -> RdpewaRes
 /// sessions without an ActiveX HWND can still parent Windows Security UI.
 fn resolve_parent_hwnd(parent_hwnd: isize) -> HWND {
     if parent_hwnd != 0 {
-        return HWND(parent_hwnd as *mut core::ffi::c_void);
+        // Reconstitute an opaque HWND value provided by the host UI layer.
+        return HWND(core::ptr::with_exposed_provenance_mut(parent_hwnd.cast_unsigned()));
     }
     // SAFETY: GetForegroundWindow is a simple system query with no pointer lifetime.
     unsafe { GetForegroundWindow() }
@@ -289,7 +290,7 @@ fn run_make_credential(
         pwszHashAlgId: WEBAUTHN_HASH_ALGORITHM_SHA_256,
     };
 
-    let mut exclude_ids = ctap.exclude_credential_ids.clone();
+    let mut exclude_ids = ctap.exclude_credential_ids;
     let mut exclude_storage = CredentialListStorage::from_ids(&mut exclude_ids)?;
 
     let mut cancel_id = resolve_cancel_id(request, cancel_guid)?;
@@ -357,7 +358,7 @@ fn run_get_assertion(
         pwszHashAlgId: WEBAUTHN_HASH_ALGORITHM_SHA_256,
     };
 
-    let mut allow_ids = ctap.allow_credential_ids.clone();
+    let mut allow_ids = ctap.allow_credential_ids;
     let mut allow_storage = CredentialListStorage::from_ids(&mut allow_ids)?;
 
     let mut cancel_id = resolve_cancel_id(request, cancel_guid)?;
@@ -454,7 +455,7 @@ impl CredentialListStorage {
                 dwTransports: 0,
             })
             .collect();
-        let mut ptrs: Vec<*mut WEBAUTHN_CREDENTIAL_EX> = creds.iter_mut().map(|c| c as *mut _).collect();
+        let mut ptrs: Vec<*mut WEBAUTHN_CREDENTIAL_EX> = creds.iter_mut().map(core::ptr::from_mut).collect();
         let list = WEBAUTHN_CREDENTIAL_LIST {
             cCredentials: u32_len_items(ptrs.len())?,
             ppCredentials: ptrs.as_mut_ptr(),
@@ -517,7 +518,8 @@ unsafe fn slice_from_parts<'a>(ptr: *mut u8, len: u32) -> &'a [u8] {
     if ptr.is_null() || len == 0 {
         &[]
     } else {
-        unsafe { core::slice::from_raw_parts(ptr, len as usize) }
+        // SAFETY: caller guarantees `ptr` points to at least `len` readable bytes for `'a`.
+        unsafe { core::slice::from_raw_parts(ptr, usize::try_from(len).unwrap_or(0)) }
     }
 }
 
@@ -525,16 +527,21 @@ unsafe fn pcwstr_to_string(p: PCWSTR) -> Option<String> {
     if p.is_null() {
         None
     } else {
+        // SAFETY: caller guarantees `p` is a valid NUL-terminated wide string or null.
         unsafe { p.to_string().ok() }
     }
 }
 
+fn hresult_to_u32(hr: HRESULT) -> u32 {
+    u32::from_ne_bytes(hr.0.to_ne_bytes())
+}
+
 fn hresult_err(hr: HRESULT, message: &'static str) -> RdpewaHandlerError {
-    RdpewaHandlerError::new(hr.0 as u32, message)
+    RdpewaHandlerError::new(hresult_to_u32(hr), message)
 }
 
 fn map_webauthn_error(hr: HRESULT) -> RdpewaHandlerError {
-    let code = hr.0 as u32;
+    let code = hresult_to_u32(hr);
     // ERROR_CANCELLED / NTE_USER_CANCELLED-ish paths map to E_ABORT.
     if code == 0x8007_04C7 || code == 0x8009_0036 || code == E_ABORT {
         RdpewaHandlerError::new(E_ABORT, "WebAuthn operation cancelled")

--- a/crates/ironrdp-rdpewa-native/src/backend.rs
+++ b/crates/ironrdp-rdpewa-native/src/backend.rs
@@ -1,6 +1,6 @@
 //! Windows WebAuthn API backend for MS-RDPEWA.
 
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 
 use ironrdp_rdpewa::{
@@ -36,6 +36,13 @@ use crate::ctap::{
     parse_make_credential,
 };
 
+/// Process-wide cancel slot so CancelCurOp on a recreated `WebAuthN_Channel` can abort an in-flight
+/// ceremony started by an earlier channel instance.
+fn shared_cancel_guid() -> Arc<Mutex<Option<GUID>>> {
+    static SLOT: OnceLock<Arc<Mutex<Option<GUID>>>> = OnceLock::new();
+    SLOT.get_or_init(|| Arc::new(Mutex::new(None))).clone()
+}
+
 /// Windows Hello / security-key backend for [`ironrdp_rdpewa::RdpewaClient`].
 pub struct WindowsRdpewaBackend {
     /// Parent window handle stored as integer so the backend is `Send`.
@@ -51,7 +58,7 @@ impl WindowsRdpewaBackend {
     pub fn new(parent_hwnd: isize) -> Self {
         Self {
             parent_hwnd,
-            cancel_guid: Arc::new(Mutex::new(None)),
+            cancel_guid: shared_cancel_guid(),
         }
     }
 
@@ -109,6 +116,11 @@ impl RdpewaClientHandler for WindowsRdpewaBackend {
         let parent_hwnd = self.parent_hwnd;
         let cancel_guid = Arc::clone(&self.cancel_guid);
 
+        // Remember host-supplied cancel id so CancelCurOp on a later channel recreate can abort.
+        if let Some(id) = request.para.cancellation_id.as_deref().and_then(guid_from_bytes) {
+            *cancel_guid.lock().unwrap_or_else(|e| e.into_inner()) = Some(id);
+        }
+
         thread::Builder::new()
             .name("ironrdp-rdpewa-webauthn".into())
             .spawn(move || {
@@ -117,9 +129,51 @@ impl RdpewaClientHandler for WindowsRdpewaBackend {
                     parent_hwnd,
                     resolved_hwnd = hwnd.0 as usize,
                     client_data_json_len = request.client_data_json.len(),
+                    raw_request_len = request.raw_request.len(),
                     ?request.subcommand,
                     "Starting native WebAuthn operation"
                 );
+
+                // Prefer webauthn.dll oneshot (MSTSC remote-RPC path). It handles hash-only hosts
+                // that omit clientDataJSON; public WebAuthN* cannot.
+                if !request.raw_request.is_empty() {
+                    match run_via_webauthn_dll_oneshot(&request) {
+                        Ok(response_pdu) => {
+                            let hresult = response_pdu
+                                .get(..4)
+                                .and_then(|b| b.try_into().ok())
+                                .map(u32::from_le_bytes)
+                                .unwrap_or(E_FAIL);
+                            info!(
+                                hresult = format!("0x{hresult:08X}"),
+                                response_len = response_pdu.len(),
+                                "WebAuthn completed via webauthn.dll oneshot"
+                            );
+                            reply.send_raw(response_pdu);
+                            *cancel_guid.lock().unwrap_or_else(|e| e.into_inner()) = None;
+                            return;
+                        }
+                        Err(err) => {
+                            // Fall through to public WebAuthN* only when the host supplied JSON.
+                            if request.client_data_json.is_empty() {
+                                warn!(error = %err, "webauthn.dll oneshot failed (hash-only; no public API fallback)");
+                                reply.send(RdpewaResponse::from_hresult(err.hresult));
+                                *cancel_guid.lock().unwrap_or_else(|e| e.into_inner()) = None;
+                                return;
+                            }
+                            warn!(
+                                error = %err,
+                                "webauthn.dll oneshot failed; falling back to public WebAuthN API"
+                            );
+                        }
+                    }
+                } else if request.client_data_json.is_empty() {
+                    warn!("missing clientDataJSON and raw RDPEWA request");
+                    reply.send(RdpewaResponse::from_hresult(E_INVALIDARG));
+                    *cancel_guid.lock().unwrap_or_else(|e| e.into_inner()) = None;
+                    return;
+                }
+
                 let outcome = run_webauthn_operation(hwnd, &request, &cancel_guid);
                 *cancel_guid.lock().unwrap_or_else(|e| e.into_inner()) = None;
                 match outcome {
@@ -141,6 +195,20 @@ impl RdpewaClientHandler for WindowsRdpewaBackend {
 
         Ok(WebAuthnDispatch::Async)
     }
+}
+
+fn run_via_webauthn_dll_oneshot(request: &WebAuthnOperationRequest) -> RdpewaResult<Vec<u8>> {
+    info!(
+        request_len = request.raw_request.len(),
+        client_data_json_len = request.client_data_json.len(),
+        ?request.subcommand,
+        "Forwarding RDPEWA request through webauthn.dll oneshot"
+    );
+
+    ironrdp_dvc_com_plugin::process_webauthn_dll_request(&request.raw_request).map_err(|message| {
+        warn!(%message, "webauthn.dll oneshot failed");
+        RdpewaHandlerError::new(E_FAIL, "webauthn.dll oneshot failed")
+    })
 }
 
 /// Prefer the configured parent HWND; if unset, fall back to the foreground window so agent/daemon
@@ -179,8 +247,8 @@ fn run_make_credential(
 
     let mut user_id = ctap.user_id.clone();
     let mut client_data_json = request.client_data_json.clone();
+    // Hash-only hosts are handled before this path via webauthn.dll oneshot.
     if client_data_json.is_empty() {
-        warn!(%rp_id, "native MakeCredential rejected: host omitted clientDataJSON (hash-only RDPEWA)");
         return Err(RdpewaHandlerError::new(E_INVALIDARG, "missing clientDataJSON"));
     }
 
@@ -277,8 +345,8 @@ fn run_get_assertion(
     let rp_id_w = wide(&rp_id);
 
     let mut client_data_json = request.client_data_json.clone();
+    // Hash-only hosts are handled before this path via webauthn.dll oneshot.
     if client_data_json.is_empty() {
-        warn!(%rp_id, "native GetAssertion rejected: host omitted clientDataJSON (hash-only RDPEWA)");
         return Err(RdpewaHandlerError::new(E_INVALIDARG, "missing clientDataJSON"));
     }
 

--- a/crates/ironrdp-rdpewa-native/src/backend.rs
+++ b/crates/ironrdp-rdpewa-native/src/backend.rs
@@ -1,11 +1,12 @@
 //! Windows WebAuthn API backend for MS-RDPEWA.
 
-use std::sync::{Arc, Mutex, OnceLock};
+use core::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::thread;
 
 use ironrdp_rdpewa::{
-    Attachment, Attestation, DeviceInfo, E_ABORT, E_FAIL, E_INVALIDARG, RdpewaClientHandler, RdpewaHandlerError,
-    RdpewaResponse, RdpewaResponseSender, RdpewaResult, S_OK, UserVerification, WebAuthnDispatch,
+    Attachment, Attestation, DeviceInfo, E_ABORT, E_BUSY, E_FAIL, E_INVALIDARG, RdpewaClientHandler,
+    RdpewaHandlerError, RdpewaResponse, RdpewaResponseSender, RdpewaResult, S_OK, UserVerification, WebAuthnDispatch,
     WebAuthnOperationRequest, WebAuthnOperationResponse, WebAuthnResponsePayload, WebAuthnSubcommand,
 };
 use tracing::{debug, info, warn};
@@ -36,11 +37,31 @@ use crate::ctap::{
     parse_make_credential,
 };
 
-/// Process-wide cancel slot so CancelCurOp on a recreated `WebAuthN_Channel` can abort an in-flight
-/// ceremony started by an earlier channel instance.
-fn shared_cancel_guid() -> Arc<Mutex<Option<GUID>>> {
-    static SLOT: OnceLock<Arc<Mutex<Option<GUID>>>> = OnceLock::new();
-    Arc::clone(SLOT.get_or_init(|| Arc::new(Mutex::new(None))))
+/// Session-scoped state shared by every recreated `WebAuthN_Channel` backend for one connection.
+///
+/// Cancel IDs and the in-flight ceremony guard must not be process-wide: concurrent IronRDP sessions
+/// in the same process would otherwise overwrite each other's cancellation slots.
+#[derive(Clone, Default)]
+pub struct WindowsRdpewaSession {
+    cancel_guid: Arc<Mutex<Option<GUID>>>,
+    in_flight: Arc<AtomicBool>,
+}
+
+impl WindowsRdpewaSession {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build a backend that shares this session's cancel slot and in-flight guard.
+    #[must_use]
+    pub fn backend(&self, parent_hwnd: isize) -> WindowsRdpewaBackend {
+        WindowsRdpewaBackend {
+            parent_hwnd,
+            cancel_guid: Arc::clone(&self.cancel_guid),
+            in_flight: Arc::clone(&self.in_flight),
+        }
+    }
 }
 
 /// Windows Hello / security-key backend for [`ironrdp_rdpewa::RdpewaClient`].
@@ -48,18 +69,18 @@ pub struct WindowsRdpewaBackend {
     /// Parent window handle stored as integer so the backend is `Send`.
     parent_hwnd: isize,
     cancel_guid: Arc<Mutex<Option<GUID>>>,
+    in_flight: Arc<AtomicBool>,
 }
 
 impl WindowsRdpewaBackend {
     /// Create a backend that parents WebAuthn UI to `parent_hwnd`.
     ///
     /// Pass the ActiveX control HWND (or another top-level window handle).
+    /// Prefer [`WindowsRdpewaSession::backend`] when channel instances are recreated so cancel and
+    /// in-flight state stay scoped to one session.
     #[must_use]
     pub fn new(parent_hwnd: isize) -> Self {
-        Self {
-            parent_hwnd,
-            cancel_guid: shared_cancel_guid(),
-        }
+        WindowsRdpewaSession::new().backend(parent_hwnd)
     }
 
     fn platform_device_info(transports: u32, resident_key: Option<bool>) -> DeviceInfo {
@@ -82,8 +103,12 @@ impl WindowsRdpewaBackend {
 
 impl Drop for WindowsRdpewaBackend {
     fn drop(&mut self) {
-        // Best-effort: dismiss an open WebAuthn prompt when the session tears down.
-        let _ = cancel_guid_slot(&self.cancel_guid, None);
+        // Best-effort: dismiss an open WebAuthn prompt when the last backend for this session drops
+        // while a ceremony is still marked in-flight.
+        if self.in_flight.load(Ordering::Acquire) {
+            let _ = cancel_guid_slot(&self.cancel_guid, None);
+            self.in_flight.store(false, Ordering::Release);
+        }
     }
 }
 
@@ -113,26 +138,46 @@ impl RdpewaClientHandler for WindowsRdpewaBackend {
         request: WebAuthnOperationRequest,
         mut reply: RdpewaResponseSender,
     ) -> RdpewaResult<WebAuthnDispatch> {
+        if self
+            .in_flight
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return Err(RdpewaHandlerError::new(
+                E_BUSY,
+                "WebAuthn operation already in progress for this session",
+            ));
+        }
+
         let parent_hwnd = self.parent_hwnd;
         let cancel_guid = Arc::clone(&self.cancel_guid);
+        let in_flight = Arc::clone(&self.in_flight);
 
         // Remember host-supplied cancel id so CancelCurOp on a later channel recreate can abort.
         if let Some(id) = request.para.cancellation_id.as_deref().and_then(guid_from_bytes) {
             *cancel_guid.lock().unwrap_or_else(|e| e.into_inner()) = Some(id);
         }
 
-        thread::Builder::new()
+        let spawn_result = thread::Builder::new()
             .name("ironrdp-rdpewa-webauthn".into())
             .spawn(move || {
+                let finish =
+                    |cancel_guid: &Arc<Mutex<Option<GUID>>>, in_flight: &AtomicBool, completed: Option<GUID>| {
+                        clear_cancel_if_matches(cancel_guid, completed);
+                        in_flight.store(false, Ordering::Release);
+                    };
+
                 let hwnd = resolve_parent_hwnd(parent_hwnd);
                 info!(
                     parent_hwnd,
-                                    resolved_hwnd = hwnd.0.addr(),
+                    resolved_hwnd = hwnd.0.addr(),
                     client_data_json_len = request.client_data_json.len(),
                     raw_request_len = request.raw_request.len(),
                     ?request.subcommand,
                     "Starting native WebAuthn operation"
                 );
+
+                let host_cancel = request.para.cancellation_id.as_deref().and_then(guid_from_bytes);
 
                 // Prefer webauthn.dll oneshot (MSTSC remote-RPC path). It handles hash-only hosts
                 // that omit clientDataJSON; public WebAuthN* cannot.
@@ -150,15 +195,19 @@ impl RdpewaClientHandler for WindowsRdpewaBackend {
                                 "WebAuthn completed via webauthn.dll oneshot"
                             );
                             reply.send_raw(response_pdu);
-                            *cancel_guid.lock().unwrap_or_else(|e| e.into_inner()) = None;
+                            finish(&cancel_guid, &in_flight, host_cancel);
                             return;
                         }
                         Err(err) => {
-                            // Fall through to public WebAuthN* only when the host supplied JSON.
-                            if request.client_data_json.is_empty() {
-                                warn!(error = %err, "webauthn.dll oneshot failed (hash-only; no public API fallback)");
+                            // Never fall back after a oneshot timeout/cancel: the COM thread may
+                            // still own a modal Windows Security prompt.
+                            if err.hresult == E_ABORT
+                                || request.client_data_json.is_empty()
+                                || !err.allow_public_fallback
+                            {
+                                warn!(error = %err, "webauthn.dll oneshot failed without public API fallback");
                                 reply.send(RdpewaResponse::from_hresult(err.hresult));
-                                *cancel_guid.lock().unwrap_or_else(|e| e.into_inner()) = None;
+                                finish(&cancel_guid, &in_flight, host_cancel);
                                 return;
                             }
                             warn!(
@@ -170,12 +219,12 @@ impl RdpewaClientHandler for WindowsRdpewaBackend {
                 } else if request.client_data_json.is_empty() {
                     warn!("missing clientDataJSON and raw RDPEWA request");
                     reply.send(RdpewaResponse::from_hresult(E_INVALIDARG));
-                    *cancel_guid.lock().unwrap_or_else(|e| e.into_inner()) = None;
+                    finish(&cancel_guid, &in_flight, host_cancel);
                     return;
                 }
 
                 let outcome = run_webauthn_operation(hwnd, &request, &cancel_guid);
-                *cancel_guid.lock().unwrap_or_else(|e| e.into_inner()) = None;
+                let completed = host_cancel.or_else(|| *cancel_guid.lock().unwrap_or_else(|e| e.into_inner()));
                 match outcome {
                     Ok(result) => {
                         let payload = WebAuthnResponsePayload {
@@ -190,14 +239,33 @@ impl RdpewaClientHandler for WindowsRdpewaBackend {
                         reply.send(RdpewaResponse::from_hresult(err.hresult));
                     }
                 }
-            })
-            .map_err(|_| RdpewaHandlerError::fail("failed to spawn WebAuthn worker thread"))?;
+                finish(&cancel_guid, &in_flight, completed);
+            });
 
-        Ok(WebAuthnDispatch::Async)
+        match spawn_result {
+            Ok(_) => Ok(WebAuthnDispatch::Async),
+            Err(_) => {
+                self.in_flight.store(false, Ordering::Release);
+                Err(RdpewaHandlerError::fail("failed to spawn WebAuthn worker thread"))
+            }
+        }
     }
 }
 
-fn run_via_webauthn_dll_oneshot(request: &WebAuthnOperationRequest) -> RdpewaResult<Vec<u8>> {
+/// Oneshot outcome used by the native backend to decide whether public WebAuthN* fallback is safe.
+struct OneshotError {
+    hresult: u32,
+    message: &'static str,
+    allow_public_fallback: bool,
+}
+
+impl core::fmt::Display for OneshotError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{} (HRESULT 0x{:08X})", self.message, self.hresult)
+    }
+}
+
+fn run_via_webauthn_dll_oneshot(request: &WebAuthnOperationRequest) -> Result<Vec<u8>, OneshotError> {
     info!(
         request_len = request.raw_request.len(),
         client_data_json_len = request.client_data_json.len(),
@@ -205,10 +273,18 @@ fn run_via_webauthn_dll_oneshot(request: &WebAuthnOperationRequest) -> RdpewaRes
         "Forwarding RDPEWA request through webauthn.dll oneshot"
     );
 
-    ironrdp_dvc_com_plugin::process_webauthn_dll_request(&request.raw_request).map_err(|message| {
-        warn!(%message, "webauthn.dll oneshot failed");
-        RdpewaHandlerError::new(E_FAIL, "webauthn.dll oneshot failed")
-    })
+    let cancellation_id = request.para.cancellation_id.as_deref().unwrap_or(&[]);
+    match ironrdp_dvc_com_plugin::process_webauthn_dll_request(&request.raw_request, cancellation_id) {
+        Ok(bytes) => Ok(bytes),
+        Err(err) => {
+            warn!(error = %err, "webauthn.dll oneshot failed");
+            Err(OneshotError {
+                hresult: err.hresult,
+                message: err.message,
+                allow_public_fallback: err.allow_public_fallback,
+            })
+        }
+    }
 }
 
 /// Prefer the configured parent HWND; if unset, fall back to the foreground window so agent/daemon
@@ -570,14 +646,15 @@ fn resolve_cancel_id(request: &WebAuthnOperationRequest, cancel_guid: &Arc<Mutex
 
 fn cancel_guid_slot(slot: &Arc<Mutex<Option<GUID>>>, preferred: Option<GUID>) -> RdpewaResult<()> {
     let mut guard = slot.lock().unwrap_or_else(|e| e.into_inner());
-    let guid = preferred.or_else(|| guard.take());
-    if preferred.is_some() {
-        // Clear the slot when it matches the cancelled operation.
-        if let (Some(preferred), Some(current)) = (preferred, *guard)
-            && preferred == current
-        {
+    let guid = preferred.or(*guard);
+    if let Some(preferred) = preferred {
+        // Clear the slot only when it still tracks the cancelled operation.
+        if *guard == Some(preferred) {
             *guard = None;
         }
+    } else {
+        // Drop path / best-effort cancel of whatever this session owns.
+        let _ = guard.take();
     }
     drop(guard);
 
@@ -589,6 +666,17 @@ fn cancel_guid_slot(slot: &Arc<Mutex<Option<GUID>>>, preferred: Option<GUID>) ->
         debug!("No in-flight WebAuthn operation to cancel");
     }
     Ok(())
+}
+
+fn clear_cancel_if_matches(slot: &Arc<Mutex<Option<GUID>>>, completed: Option<GUID>) {
+    let Some(completed) = completed else {
+        return;
+    };
+    let mut guard = slot.lock().unwrap_or_else(|e| e.into_inner());
+    // Clear only when the slot still tracks this completed ceremony.
+    if *guard == Some(completed) {
+        *guard = None;
+    }
 }
 
 fn guid_from_bytes(bytes: &[u8]) -> Option<GUID> {

--- a/crates/ironrdp-rdpewa-native/src/backend.rs
+++ b/crates/ironrdp-rdpewa-native/src/backend.rs
@@ -1,12 +1,11 @@
 //! Windows WebAuthn API backend for MS-RDPEWA.
 
-use core::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
 use ironrdp_rdpewa::{
-    Attachment, Attestation, DeviceInfo, E_ABORT, E_BUSY, E_FAIL, E_INVALIDARG, RdpewaClientHandler,
-    RdpewaHandlerError, RdpewaResponse, RdpewaResponseSender, RdpewaResult, S_OK, UserVerification, WebAuthnDispatch,
+    Attachment, Attestation, DeviceInfo, E_ABORT, E_FAIL, E_INVALIDARG, RdpewaClientHandler, RdpewaHandlerError,
+    RdpewaResponse, RdpewaResponseSender, RdpewaResult, S_OK, UserVerification, WebAuthnDispatch,
     WebAuthnOperationRequest, WebAuthnOperationResponse, WebAuthnResponsePayload, WebAuthnSubcommand,
 };
 use tracing::{debug, info, warn};
@@ -37,30 +36,46 @@ use crate::ctap::{
     parse_make_credential,
 };
 
-/// Session-scoped state shared by every recreated `WebAuthN_Channel` backend for one connection.
-///
-/// Cancel IDs and the in-flight ceremony guard must not be process-wide: concurrent IronRDP sessions
-/// in the same process would otherwise overwrite each other's cancellation slots.
-#[derive(Clone, Default)]
-pub struct WindowsRdpewaSession {
-    cancel_guid: Arc<Mutex<Option<GUID>>>,
-    in_flight: Arc<AtomicBool>,
+/// Per-session state shared by all recreated `WebAuthN_Channel` backends.
+#[derive(Debug, Default)]
+pub struct WindowsRdpewaSessionState {
+    cancellation_id: Mutex<Option<GUID>>,
 }
 
-impl WindowsRdpewaSession {
-    #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+impl WindowsRdpewaSessionState {
+    fn begin(&self, cancellation_id: GUID) -> RdpewaResult<()> {
+        let mut active = self.cancellation_id.lock().unwrap_or_else(|e| e.into_inner());
+        if active.is_some() {
+            return Err(RdpewaHandlerError::new(
+                E_FAIL,
+                "a WebAuthn operation is already in progress",
+            ));
+        }
+        *active = Some(cancellation_id);
+        Ok(())
     }
 
-    /// Build a backend that shares this session's cancel slot and in-flight guard.
-    #[must_use]
-    pub fn backend(&self, parent_hwnd: isize) -> WindowsRdpewaBackend {
-        WindowsRdpewaBackend {
-            parent_hwnd,
-            cancel_guid: Arc::clone(&self.cancel_guid),
-            in_flight: Arc::clone(&self.in_flight),
+    fn finish(&self, cancellation_id: GUID) {
+        let mut active = self.cancellation_id.lock().unwrap_or_else(|e| e.into_inner());
+        if *active == Some(cancellation_id) {
+            *active = None;
         }
+    }
+
+    fn cancel(&self, cancellation_id: &[u8]) -> RdpewaResult<()> {
+        let requested = guid_from_bytes(cancellation_id)
+            .ok_or_else(|| RdpewaHandlerError::new(E_INVALIDARG, "invalid WebAuthn cancellation ID"))?;
+        let active = *self.cancellation_id.lock().unwrap_or_else(|e| e.into_inner());
+        if active != Some(requested) {
+            debug!("No matching in-flight WebAuthn operation to cancel");
+            return Ok(());
+        }
+
+        info!("Cancelling in-flight WebAuthn operation");
+        unsafe { WebAuthNCancelCurrentOperation(&requested) }
+            .map_err(|e| hresult_err(e.code(), "WebAuthNCancelCurrentOperation failed"))?;
+        self.finish(requested);
+        Ok(())
     }
 }
 
@@ -68,19 +83,25 @@ impl WindowsRdpewaSession {
 pub struct WindowsRdpewaBackend {
     /// Parent window handle stored as integer so the backend is `Send`.
     parent_hwnd: isize,
-    cancel_guid: Arc<Mutex<Option<GUID>>>,
-    in_flight: Arc<AtomicBool>,
+    session_state: Arc<WindowsRdpewaSessionState>,
 }
 
 impl WindowsRdpewaBackend {
     /// Create a backend that parents WebAuthn UI to `parent_hwnd`.
     ///
     /// Pass the ActiveX control HWND (or another top-level window handle).
-    /// Prefer [`WindowsRdpewaSession::backend`] when channel instances are recreated so cancel and
-    /// in-flight state stay scoped to one session.
     #[must_use]
     pub fn new(parent_hwnd: isize) -> Self {
-        WindowsRdpewaSession::new().backend(parent_hwnd)
+        Self::new_with_session_state(parent_hwnd, Arc::new(WindowsRdpewaSessionState::default()))
+    }
+
+    /// Create a backend sharing session state with other recreated channel instances.
+    #[must_use]
+    pub fn new_with_session_state(parent_hwnd: isize, session_state: Arc<WindowsRdpewaSessionState>) -> Self {
+        Self {
+            parent_hwnd,
+            session_state,
+        }
     }
 
     fn platform_device_info(transports: u32, resident_key: Option<bool>) -> DeviceInfo {
@@ -97,17 +118,6 @@ impl WindowsRdpewaBackend {
             uv_retries: 0,
             transports,
             resident_key,
-        }
-    }
-}
-
-impl Drop for WindowsRdpewaBackend {
-    fn drop(&mut self) {
-        // Best-effort: dismiss an open WebAuthn prompt when the last backend for this session drops
-        // while a ceremony is still marked in-flight.
-        if self.in_flight.load(Ordering::Acquire) {
-            let _ = cancel_guid_slot(&self.cancel_guid, None);
-            self.in_flight.store(false, Ordering::Release);
         }
     }
 }
@@ -130,7 +140,7 @@ impl RdpewaClientHandler for WindowsRdpewaBackend {
     }
 
     fn cancel_current_operation(&mut self, cancellation_id: &[u8]) -> RdpewaResult<()> {
-        cancel_guid_slot(&self.cancel_guid, guid_from_bytes(cancellation_id))
+        self.session_state.cancel(cancellation_id)
     }
 
     fn begin_webauthn(
@@ -138,93 +148,33 @@ impl RdpewaClientHandler for WindowsRdpewaBackend {
         request: WebAuthnOperationRequest,
         mut reply: RdpewaResponseSender,
     ) -> RdpewaResult<WebAuthnDispatch> {
-        if self
-            .in_flight
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_err()
-        {
-            return Err(RdpewaHandlerError::new(
-                E_BUSY,
-                "WebAuthn operation already in progress for this session",
-            ));
-        }
-
         let parent_hwnd = self.parent_hwnd;
-        let cancel_guid = Arc::clone(&self.cancel_guid);
-        let in_flight = Arc::clone(&self.in_flight);
+        let session_state = Arc::clone(&self.session_state);
+        let cancellation_id = cancellation_id_for_request(&request)?;
+        session_state.begin(cancellation_id)?;
 
-        // Remember host-supplied cancel id so CancelCurOp on a later channel recreate can abort.
-        if let Some(id) = request.para.cancellation_id.as_deref().and_then(guid_from_bytes) {
-            *cancel_guid.lock().unwrap_or_else(|e| e.into_inner()) = Some(id);
-        }
-
-        let spawn_result = thread::Builder::new()
+        match thread::Builder::new()
             .name("ironrdp-rdpewa-webauthn".into())
             .spawn(move || {
-                let finish =
-                    |cancel_guid: &Arc<Mutex<Option<GUID>>>, in_flight: &AtomicBool, completed: Option<GUID>| {
-                        clear_cancel_if_matches(cancel_guid, completed);
-                        in_flight.store(false, Ordering::Release);
-                    };
-
                 let hwnd = resolve_parent_hwnd(parent_hwnd);
                 info!(
                     parent_hwnd,
-                    resolved_hwnd = hwnd.0.addr(),
+                                    resolved_hwnd = hwnd.0.addr(),
                     client_data_json_len = request.client_data_json.len(),
                     raw_request_len = request.raw_request.len(),
                     ?request.subcommand,
                     "Starting native WebAuthn operation"
                 );
 
-                let host_cancel = request.para.cancellation_id.as_deref().and_then(guid_from_bytes);
-
-                // Prefer webauthn.dll oneshot (MSTSC remote-RPC path). It handles hash-only hosts
-                // that omit clientDataJSON; public WebAuthN* cannot.
-                if !request.raw_request.is_empty() {
-                    match run_via_webauthn_dll_oneshot(&request) {
-                        Ok(response_pdu) => {
-                            let hresult = response_pdu
-                                .get(..4)
-                                .and_then(|b| b.try_into().ok())
-                                .map(u32::from_le_bytes)
-                                .unwrap_or(E_FAIL);
-                            info!(
-                                hresult = format!("0x{hresult:08X}"),
-                                response_len = response_pdu.len(),
-                                "WebAuthn completed via webauthn.dll oneshot"
-                            );
-                            reply.send_raw(response_pdu);
-                            finish(&cancel_guid, &in_flight, host_cancel);
-                            return;
-                        }
-                        Err(err) => {
-                            // Never fall back after a oneshot timeout/cancel: the COM thread may
-                            // still own a modal Windows Security prompt.
-                            if err.hresult == E_ABORT
-                                || request.client_data_json.is_empty()
-                                || !err.allow_public_fallback
-                            {
-                                warn!(error = %err, "webauthn.dll oneshot failed without public API fallback");
-                                reply.send(RdpewaResponse::from_hresult(err.hresult));
-                                finish(&cancel_guid, &in_flight, host_cancel);
-                                return;
-                            }
-                            warn!(
-                                error = %err,
-                                "webauthn.dll oneshot failed; falling back to public WebAuthN API"
-                            );
-                        }
-                    }
-                } else if request.client_data_json.is_empty() {
-                    warn!("missing clientDataJSON and raw RDPEWA request");
+                if request.client_data_json.is_empty() {
+                    warn!("missing clientDataJSON for native WebAuthn operation");
                     reply.send(RdpewaResponse::from_hresult(E_INVALIDARG));
-                    finish(&cancel_guid, &in_flight, host_cancel);
+                    session_state.finish(cancellation_id);
                     return;
                 }
 
-                let outcome = run_webauthn_operation(hwnd, &request, &cancel_guid);
-                let completed = host_cancel.or_else(|| *cancel_guid.lock().unwrap_or_else(|e| e.into_inner()));
+                let outcome = run_webauthn_operation(hwnd, &request, cancellation_id);
+                session_state.finish(cancellation_id);
                 match outcome {
                     Ok(result) => {
                         let payload = WebAuthnResponsePayload {
@@ -239,50 +189,12 @@ impl RdpewaClientHandler for WindowsRdpewaBackend {
                         reply.send(RdpewaResponse::from_hresult(err.hresult));
                     }
                 }
-                finish(&cancel_guid, &in_flight, completed);
-            });
-
-        match spawn_result {
+            }) {
             Ok(_) => Ok(WebAuthnDispatch::Async),
             Err(_) => {
-                self.in_flight.store(false, Ordering::Release);
+                self.session_state.finish(cancellation_id);
                 Err(RdpewaHandlerError::fail("failed to spawn WebAuthn worker thread"))
             }
-        }
-    }
-}
-
-/// Oneshot outcome used by the native backend to decide whether public WebAuthN* fallback is safe.
-struct OneshotError {
-    hresult: u32,
-    message: &'static str,
-    allow_public_fallback: bool,
-}
-
-impl core::fmt::Display for OneshotError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{} (HRESULT 0x{:08X})", self.message, self.hresult)
-    }
-}
-
-fn run_via_webauthn_dll_oneshot(request: &WebAuthnOperationRequest) -> Result<Vec<u8>, OneshotError> {
-    info!(
-        request_len = request.raw_request.len(),
-        client_data_json_len = request.client_data_json.len(),
-        ?request.subcommand,
-        "Forwarding RDPEWA request through webauthn.dll oneshot"
-    );
-
-    let cancellation_id = request.para.cancellation_id.as_deref().unwrap_or(&[]);
-    match ironrdp_dvc_com_plugin::process_webauthn_dll_request(&request.raw_request, cancellation_id) {
-        Ok(bytes) => Ok(bytes),
-        Err(err) => {
-            warn!(error = %err, "webauthn.dll oneshot failed");
-            Err(OneshotError {
-                hresult: err.hresult,
-                message: err.message,
-                allow_public_fallback: err.allow_public_fallback,
-            })
         }
     }
 }
@@ -301,18 +213,18 @@ fn resolve_parent_hwnd(parent_hwnd: isize) -> HWND {
 fn run_webauthn_operation(
     hwnd: HWND,
     request: &WebAuthnOperationRequest,
-    cancel_guid: &Arc<Mutex<Option<GUID>>>,
+    cancellation_id: GUID,
 ) -> RdpewaResult<WebAuthnOperationResponse> {
     match request.subcommand {
-        WebAuthnSubcommand::MakeCredential => run_make_credential(hwnd, request, cancel_guid),
-        WebAuthnSubcommand::GetAssertion => run_get_assertion(hwnd, request, cancel_guid),
+        WebAuthnSubcommand::MakeCredential => run_make_credential(hwnd, request, cancellation_id),
+        WebAuthnSubcommand::GetAssertion => run_get_assertion(hwnd, request, cancellation_id),
     }
 }
 
 fn run_make_credential(
     hwnd: HWND,
     request: &WebAuthnOperationRequest,
-    cancel_guid: &Arc<Mutex<Option<GUID>>>,
+    mut cancellation_id: GUID,
 ) -> RdpewaResult<WebAuthnOperationResponse> {
     let ctap = parse_make_credential(&request.ctap_cbor).map_err(|m| RdpewaHandlerError::new(E_INVALIDARG, m))?;
 
@@ -369,8 +281,6 @@ fn run_make_credential(
     let mut exclude_ids = ctap.exclude_credential_ids;
     let mut exclude_storage = CredentialListStorage::from_ids(&mut exclude_ids)?;
 
-    let mut cancel_id = resolve_cancel_id(request, cancel_guid)?;
-
     let mut options = WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS {
         dwVersion: WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_CURRENT_VERSION,
         dwTimeoutMilliseconds: if request.timeout_ms == 0 {
@@ -382,7 +292,7 @@ fn run_make_credential(
         bRequireResidentKey: (ctap.resident_key || request.para.require_resident_key).into(),
         dwUserVerificationRequirement: uv_to_win(request.para.user_verification),
         dwAttestationConveyancePreference: attestation_to_win(request.para.attestation),
-        pCancellationId: &raw mut cancel_id,
+        pCancellationId: &raw mut cancellation_id,
         pExcludeCredentialList: exclude_storage.list_ptr(),
         ..Default::default()
     };
@@ -406,7 +316,7 @@ fn run_make_credential(
 
     let result = unsafe { read_make_credential_result(attestation) };
     unsafe { WebAuthNFreeCredentialAttestation(Some(attestation)) };
-    // Keep options/cancel_id alive until after the API returns.
+    // Keep options/cancellation_id alive until after the API returns.
     let _ = &mut options;
     result
 }
@@ -414,7 +324,7 @@ fn run_make_credential(
 fn run_get_assertion(
     hwnd: HWND,
     request: &WebAuthnOperationRequest,
-    cancel_guid: &Arc<Mutex<Option<GUID>>>,
+    mut cancellation_id: GUID,
 ) -> RdpewaResult<WebAuthnOperationResponse> {
     let ctap = parse_get_assertion(&request.ctap_cbor).map_err(|m| RdpewaHandlerError::new(E_INVALIDARG, m))?;
 
@@ -437,8 +347,6 @@ fn run_get_assertion(
     let mut allow_ids = ctap.allow_credential_ids;
     let mut allow_storage = CredentialListStorage::from_ids(&mut allow_ids)?;
 
-    let mut cancel_id = resolve_cancel_id(request, cancel_guid)?;
-
     let mut options = WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS {
         dwVersion: WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_CURRENT_VERSION,
         dwTimeoutMilliseconds: if request.timeout_ms == 0 {
@@ -448,7 +356,7 @@ fn run_get_assertion(
         },
         dwAuthenticatorAttachment: attachment_to_win(request.para.attachment),
         dwUserVerificationRequirement: uv_to_win(request.para.user_verification),
-        pCancellationId: &raw mut cancel_id,
+        pCancellationId: &raw mut cancellation_id,
         pAllowCredentialList: allow_storage.list_ptr(),
         ..Default::default()
     };
@@ -629,53 +537,12 @@ fn map_webauthn_error(hr: HRESULT) -> RdpewaHandlerError {
 }
 
 /// Prefer a server-supplied 16-byte GUID; otherwise allocate one via the WebAuthn API.
-fn resolve_cancel_id(request: &WebAuthnOperationRequest, cancel_guid: &Arc<Mutex<Option<GUID>>>) -> RdpewaResult<GUID> {
-    let cancel_id = request
-        .para
-        .cancellation_id
-        .as_deref()
-        .and_then(guid_from_bytes)
-        .map(Ok)
-        .unwrap_or_else(|| {
-            unsafe { WebAuthNGetCancellationId() }
-                .map_err(|e| hresult_err(e.code(), "WebAuthNGetCancellationId failed"))
-        })?;
-    *cancel_guid.lock().unwrap_or_else(|e| e.into_inner()) = Some(cancel_id);
-    Ok(cancel_id)
-}
-
-fn cancel_guid_slot(slot: &Arc<Mutex<Option<GUID>>>, preferred: Option<GUID>) -> RdpewaResult<()> {
-    let mut guard = slot.lock().unwrap_or_else(|e| e.into_inner());
-    let guid = preferred.or(*guard);
-    if let Some(preferred) = preferred {
-        // Clear the slot only when it still tracks the cancelled operation.
-        if *guard == Some(preferred) {
-            *guard = None;
-        }
-    } else {
-        // Drop path / best-effort cancel of whatever this session owns.
-        let _ = guard.take();
-    }
-    drop(guard);
-
-    if let Some(guid) = guid {
-        info!("Cancelling in-flight WebAuthn operation");
-        unsafe { WebAuthNCancelCurrentOperation(&guid) }
-            .map_err(|e| hresult_err(e.code(), "WebAuthNCancelCurrentOperation failed"))?;
-    } else {
-        debug!("No in-flight WebAuthn operation to cancel");
-    }
-    Ok(())
-}
-
-fn clear_cancel_if_matches(slot: &Arc<Mutex<Option<GUID>>>, completed: Option<GUID>) {
-    let Some(completed) = completed else {
-        return;
-    };
-    let mut guard = slot.lock().unwrap_or_else(|e| e.into_inner());
-    // Clear only when the slot still tracks this completed ceremony.
-    if *guard == Some(completed) {
-        *guard = None;
+fn cancellation_id_for_request(request: &WebAuthnOperationRequest) -> RdpewaResult<GUID> {
+    match request.para.cancellation_id.as_deref() {
+        Some(cancellation_id) => guid_from_bytes(cancellation_id)
+            .ok_or_else(|| RdpewaHandlerError::new(E_INVALIDARG, "invalid WebAuthn cancellation ID")),
+        None => unsafe { WebAuthNGetCancellationId() }
+            .map_err(|e| hresult_err(e.code(), "WebAuthNGetCancellationId failed")),
     }
 }
 
@@ -713,5 +580,19 @@ mod tests {
         assert_eq!(guid.data2, 0x0506);
         assert_eq!(guid.data3, 0x0708);
         assert_eq!(guid.data4, [0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10]);
+    }
+
+    #[test]
+    fn session_state_allows_only_one_operation() {
+        let state = WindowsRdpewaSessionState::default();
+        let first = GUID::from_u128(1);
+        let second = GUID::from_u128(2);
+
+        state.begin(first).expect("first operation");
+        assert!(state.begin(second).is_err());
+        state.finish(second);
+        assert!(state.begin(second).is_err());
+        state.finish(first);
+        state.begin(second).expect("operation after completion");
     }
 }

--- a/crates/ironrdp-rdpewa-native/src/backend.rs
+++ b/crates/ironrdp-rdpewa-native/src/backend.rs
@@ -458,10 +458,7 @@ fn map_webauthn_error(hr: HRESULT) -> RdpewaHandlerError {
 }
 
 /// Prefer a server-supplied 16-byte GUID; otherwise allocate one via the WebAuthn API.
-fn resolve_cancel_id(
-    request: &WebAuthnOperationRequest,
-    cancel_guid: &Arc<Mutex<Option<GUID>>>,
-) -> RdpewaResult<GUID> {
+fn resolve_cancel_id(request: &WebAuthnOperationRequest, cancel_guid: &Arc<Mutex<Option<GUID>>>) -> RdpewaResult<GUID> {
     let cancel_id = request
         .para
         .cancellation_id
@@ -509,4 +506,29 @@ fn guid_from_bytes(bytes: &[u8]) -> Option<GUID> {
         data3: u16::from_le_bytes(bytes[6..8].try_into().ok()?),
         data4: bytes[8..16].try_into().ok()?,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn guid_from_bytes_rejects_wrong_length() {
+        assert!(guid_from_bytes(&[]).is_none());
+        assert!(guid_from_bytes(&[0; 15]).is_none());
+        assert!(guid_from_bytes(&[0; 17]).is_none());
+    }
+
+    #[test]
+    fn guid_from_bytes_parses_windows_layout() {
+        // {01020304-0506-0708-090A-0B0C0D0E0F10}
+        let bytes = [
+            0x04, 0x03, 0x02, 0x01, 0x06, 0x05, 0x08, 0x07, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+        ];
+        let guid = guid_from_bytes(&bytes).expect("valid GUID bytes");
+        assert_eq!(guid.data1, 0x0102_0304);
+        assert_eq!(guid.data2, 0x0506);
+        assert_eq!(guid.data3, 0x0708);
+        assert_eq!(guid.data4, [0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10]);
+    }
 }

--- a/crates/ironrdp-rdpewa-native/src/backend.rs
+++ b/crates/ironrdp-rdpewa-native/src/backend.rs
@@ -28,6 +28,7 @@ use windows::Win32::Networking::WindowsWebServices::{
     WebAuthNFreeAssertion, WebAuthNFreeCredentialAttestation, WebAuthNGetApiVersionNumber, WebAuthNGetCancellationId,
     WebAuthNIsUserVerifyingPlatformAuthenticatorAvailable,
 };
+use windows::Win32::UI::WindowsAndMessaging::GetForegroundWindow;
 use windows::core::{GUID, HRESULT, PCWSTR};
 
 use crate::ctap::{
@@ -111,7 +112,14 @@ impl RdpewaClientHandler for WindowsRdpewaBackend {
         thread::Builder::new()
             .name("ironrdp-rdpewa-webauthn".into())
             .spawn(move || {
-                let hwnd = HWND(parent_hwnd as *mut core::ffi::c_void);
+                let hwnd = resolve_parent_hwnd(parent_hwnd);
+                info!(
+                    parent_hwnd,
+                    resolved_hwnd = hwnd.0 as usize,
+                    client_data_json_len = request.client_data_json.len(),
+                    ?request.subcommand,
+                    "Starting native WebAuthn operation"
+                );
                 let outcome = run_webauthn_operation(hwnd, &request, &cancel_guid);
                 *cancel_guid.lock().unwrap_or_else(|e| e.into_inner()) = None;
                 match outcome {
@@ -133,6 +141,16 @@ impl RdpewaClientHandler for WindowsRdpewaBackend {
 
         Ok(WebAuthnDispatch::Async)
     }
+}
+
+/// Prefer the configured parent HWND; if unset, fall back to the foreground window so agent/daemon
+/// sessions without an ActiveX HWND can still parent Windows Security UI.
+fn resolve_parent_hwnd(parent_hwnd: isize) -> HWND {
+    if parent_hwnd != 0 {
+        return HWND(parent_hwnd as *mut core::ffi::c_void);
+    }
+    // SAFETY: GetForegroundWindow is a simple system query with no pointer lifetime.
+    unsafe { GetForegroundWindow() }
 }
 
 fn run_webauthn_operation(
@@ -162,6 +180,7 @@ fn run_make_credential(
     let mut user_id = ctap.user_id.clone();
     let mut client_data_json = request.client_data_json.clone();
     if client_data_json.is_empty() {
+        warn!(%rp_id, "native MakeCredential rejected: host omitted clientDataJSON (hash-only RDPEWA)");
         return Err(RdpewaHandlerError::new(E_INVALIDARG, "missing clientDataJSON"));
     }
 
@@ -259,6 +278,7 @@ fn run_get_assertion(
 
     let mut client_data_json = request.client_data_json.clone();
     if client_data_json.is_empty() {
+        warn!(%rp_id, "native GetAssertion rejected: host omitted clientDataJSON (hash-only RDPEWA)");
         return Err(RdpewaHandlerError::new(E_INVALIDARG, "missing clientDataJSON"));
     }
 

--- a/crates/ironrdp-rdpewa-native/src/backend.rs
+++ b/crates/ironrdp-rdpewa-native/src/backend.rs
@@ -1,0 +1,512 @@
+//! Windows WebAuthn API backend for MS-RDPEWA.
+
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use ironrdp_rdpewa::{
+    Attachment, Attestation, DeviceInfo, E_ABORT, E_FAIL, E_INVALIDARG, RdpewaClientHandler, RdpewaHandlerError,
+    RdpewaResponse, RdpewaResponseSender, RdpewaResult, S_OK, UserVerification, WebAuthnDispatch,
+    WebAuthnOperationRequest, WebAuthnOperationResponse, WebAuthnResponsePayload, WebAuthnSubcommand,
+};
+use tracing::{debug, info, warn};
+use windows::Win32::Foundation::HWND;
+use windows::Win32::Networking::WindowsWebServices::{
+    WEBAUTHN_ASSERTION, WEBAUTHN_ATTESTATION_CONVEYANCE_PREFERENCE_ANY,
+    WEBAUTHN_ATTESTATION_CONVEYANCE_PREFERENCE_DIRECT, WEBAUTHN_ATTESTATION_CONVEYANCE_PREFERENCE_INDIRECT,
+    WEBAUTHN_ATTESTATION_CONVEYANCE_PREFERENCE_NONE, WEBAUTHN_AUTHENTICATOR_ATTACHMENT_ANY,
+    WEBAUTHN_AUTHENTICATOR_ATTACHMENT_CROSS_PLATFORM, WEBAUTHN_AUTHENTICATOR_ATTACHMENT_PLATFORM,
+    WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS, WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_CURRENT_VERSION,
+    WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS, WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_CURRENT_VERSION,
+    WEBAUTHN_CLIENT_DATA, WEBAUTHN_CLIENT_DATA_CURRENT_VERSION, WEBAUTHN_COSE_CREDENTIAL_PARAMETER,
+    WEBAUTHN_COSE_CREDENTIAL_PARAMETER_CURRENT_VERSION, WEBAUTHN_COSE_CREDENTIAL_PARAMETERS, WEBAUTHN_CREDENTIAL_EX,
+    WEBAUTHN_CREDENTIAL_EX_CURRENT_VERSION, WEBAUTHN_CREDENTIAL_LIST, WEBAUTHN_CREDENTIAL_TYPE_PUBLIC_KEY,
+    WEBAUTHN_HASH_ALGORITHM_SHA_256, WEBAUTHN_RP_ENTITY_INFORMATION, WEBAUTHN_RP_ENTITY_INFORMATION_CURRENT_VERSION,
+    WEBAUTHN_USER_ENTITY_INFORMATION, WEBAUTHN_USER_ENTITY_INFORMATION_CURRENT_VERSION,
+    WEBAUTHN_USER_VERIFICATION_REQUIREMENT_ANY, WEBAUTHN_USER_VERIFICATION_REQUIREMENT_DISCOURAGED,
+    WEBAUTHN_USER_VERIFICATION_REQUIREMENT_PREFERRED, WEBAUTHN_USER_VERIFICATION_REQUIREMENT_REQUIRED,
+    WebAuthNAuthenticatorGetAssertion, WebAuthNAuthenticatorMakeCredential, WebAuthNCancelCurrentOperation,
+    WebAuthNFreeAssertion, WebAuthNFreeCredentialAttestation, WebAuthNGetApiVersionNumber, WebAuthNGetCancellationId,
+    WebAuthNIsUserVerifyingPlatformAuthenticatorAvailable,
+};
+use windows::core::{GUID, HRESULT, PCWSTR};
+
+use crate::ctap::{
+    encode_get_assertion_response, encode_make_credential_response, pack_ctap_response, parse_get_assertion,
+    parse_make_credential,
+};
+
+/// Windows Hello / security-key backend for [`ironrdp_rdpewa::RdpewaClient`].
+pub struct WindowsRdpewaBackend {
+    /// Parent window handle stored as integer so the backend is `Send`.
+    parent_hwnd: isize,
+    cancel_guid: Arc<Mutex<Option<GUID>>>,
+}
+
+impl WindowsRdpewaBackend {
+    /// Create a backend that parents WebAuthn UI to `parent_hwnd`.
+    ///
+    /// Pass the ActiveX control HWND (or another top-level window handle).
+    #[must_use]
+    pub fn new(parent_hwnd: isize) -> Self {
+        Self {
+            parent_hwnd,
+            cancel_guid: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    fn platform_device_info(transports: u32, resident_key: Option<bool>) -> DeviceInfo {
+        DeviceInfo {
+            max_msg_size: 2048,
+            max_serialized_large_blob_array: 1024,
+            provider_type: String::from("Platform"),
+            provider_name: String::from("IronRDPWebAuthnProvider"),
+            device_path: String::new(),
+            manufacturer: String::from("Microsoft"),
+            product: String::from("Windows WebAuthn"),
+            aa_guid: [0; 16],
+            uv_status: WEBAUTHN_USER_VERIFICATION_REQUIREMENT_ANY,
+            uv_retries: 0,
+            transports,
+            resident_key,
+        }
+    }
+}
+
+impl Drop for WindowsRdpewaBackend {
+    fn drop(&mut self) {
+        // Best-effort: dismiss an open WebAuthn prompt when the session tears down.
+        let _ = cancel_guid_slot(&self.cancel_guid, None);
+    }
+}
+
+impl RdpewaClientHandler for WindowsRdpewaBackend {
+    fn api_version(&mut self) -> RdpewaResult<u32> {
+        let version = unsafe { WebAuthNGetApiVersionNumber() };
+        debug!(version, "WebAuthNGetApiVersionNumber");
+        if version == 0 {
+            Err(RdpewaHandlerError::fail("WebAuthn API unavailable"))
+        } else {
+            Ok(version)
+        }
+    }
+
+    fn is_uvpaa(&mut self) -> RdpewaResult<bool> {
+        let available = unsafe { WebAuthNIsUserVerifyingPlatformAuthenticatorAvailable() }
+            .map_err(|e| hresult_err(e.code(), "IsUserVerifyingPlatformAuthenticatorAvailable failed"))?;
+        Ok(available.as_bool())
+    }
+
+    fn cancel_current_operation(&mut self, cancellation_id: &[u8]) -> RdpewaResult<()> {
+        cancel_guid_slot(&self.cancel_guid, guid_from_bytes(cancellation_id))
+    }
+
+    fn begin_webauthn(
+        &mut self,
+        request: WebAuthnOperationRequest,
+        mut reply: RdpewaResponseSender,
+    ) -> RdpewaResult<WebAuthnDispatch> {
+        let parent_hwnd = self.parent_hwnd;
+        let cancel_guid = Arc::clone(&self.cancel_guid);
+
+        thread::Builder::new()
+            .name("ironrdp-rdpewa-webauthn".into())
+            .spawn(move || {
+                let hwnd = HWND(parent_hwnd as *mut core::ffi::c_void);
+                let outcome = run_webauthn_operation(hwnd, &request, &cancel_guid);
+                *cancel_guid.lock().unwrap_or_else(|e| e.into_inner()) = None;
+                match outcome {
+                    Ok(result) => {
+                        let payload = WebAuthnResponsePayload {
+                            device_info: result.device_info,
+                            status: result.status,
+                            response: result.response,
+                        };
+                        reply.send_webauthn(S_OK, &payload);
+                    }
+                    Err(err) => {
+                        warn!(error = %err, "WebAuthn operation failed");
+                        reply.send(RdpewaResponse::from_hresult(err.hresult));
+                    }
+                }
+            })
+            .map_err(|_| RdpewaHandlerError::fail("failed to spawn WebAuthn worker thread"))?;
+
+        Ok(WebAuthnDispatch::Async)
+    }
+}
+
+fn run_webauthn_operation(
+    hwnd: HWND,
+    request: &WebAuthnOperationRequest,
+    cancel_guid: &Arc<Mutex<Option<GUID>>>,
+) -> RdpewaResult<WebAuthnOperationResponse> {
+    match request.subcommand {
+        WebAuthnSubcommand::MakeCredential => run_make_credential(hwnd, request, cancel_guid),
+        WebAuthnSubcommand::GetAssertion => run_get_assertion(hwnd, request, cancel_guid),
+    }
+}
+
+fn run_make_credential(
+    hwnd: HWND,
+    request: &WebAuthnOperationRequest,
+    cancel_guid: &Arc<Mutex<Option<GUID>>>,
+) -> RdpewaResult<WebAuthnOperationResponse> {
+    let ctap = parse_make_credential(&request.ctap_cbor).map_err(|m| RdpewaHandlerError::new(E_INVALIDARG, m))?;
+
+    let rp_id = request.rp_id.clone().unwrap_or_else(|| ctap.rp_id.clone());
+    let rp_id_w = wide(&rp_id);
+    let rp_name_w = wide(ctap.rp_name.as_deref().unwrap_or(rp_id.as_str()));
+    let user_name_w = wide(ctap.user_name.as_deref().unwrap_or(""));
+    let user_display_w = wide(ctap.user_display_name.as_deref().unwrap_or(""));
+
+    let mut user_id = ctap.user_id.clone();
+    let mut client_data_json = request.client_data_json.clone();
+    if client_data_json.is_empty() {
+        return Err(RdpewaHandlerError::new(E_INVALIDARG, "missing clientDataJSON"));
+    }
+
+    let rp_info = WEBAUTHN_RP_ENTITY_INFORMATION {
+        dwVersion: WEBAUTHN_RP_ENTITY_INFORMATION_CURRENT_VERSION,
+        pwszId: PCWSTR(rp_id_w.as_ptr()),
+        pwszName: PCWSTR(rp_name_w.as_ptr()),
+        pwszIcon: PCWSTR::null(),
+    };
+
+    let user_info = WEBAUTHN_USER_ENTITY_INFORMATION {
+        dwVersion: WEBAUTHN_USER_ENTITY_INFORMATION_CURRENT_VERSION,
+        cbId: u32_len(&user_id)?,
+        pbId: user_id.as_mut_ptr(),
+        pwszName: PCWSTR(user_name_w.as_ptr()),
+        pwszIcon: PCWSTR::null(),
+        pwszDisplayName: PCWSTR(user_display_w.as_ptr()),
+    };
+
+    let mut cose_params: Vec<WEBAUTHN_COSE_CREDENTIAL_PARAMETER> = ctap
+        .algorithms
+        .iter()
+        .map(|alg| WEBAUTHN_COSE_CREDENTIAL_PARAMETER {
+            dwVersion: WEBAUTHN_COSE_CREDENTIAL_PARAMETER_CURRENT_VERSION,
+            pwszCredentialType: WEBAUTHN_CREDENTIAL_TYPE_PUBLIC_KEY,
+            lAlg: *alg,
+        })
+        .collect();
+    let cose = WEBAUTHN_COSE_CREDENTIAL_PARAMETERS {
+        cCredentialParameters: u32_len_items(cose_params.len())?,
+        pCredentialParameters: cose_params.as_mut_ptr(),
+    };
+
+    let client_data = WEBAUTHN_CLIENT_DATA {
+        dwVersion: WEBAUTHN_CLIENT_DATA_CURRENT_VERSION,
+        cbClientDataJSON: u32_len(&client_data_json)?,
+        pbClientDataJSON: client_data_json.as_mut_ptr(),
+        pwszHashAlgId: WEBAUTHN_HASH_ALGORITHM_SHA_256,
+    };
+
+    let mut exclude_ids = ctap.exclude_credential_ids.clone();
+    let mut exclude_storage = CredentialListStorage::from_ids(&mut exclude_ids)?;
+
+    let mut cancel_id = resolve_cancel_id(request, cancel_guid)?;
+
+    let mut options = WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS {
+        dwVersion: WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS_CURRENT_VERSION,
+        dwTimeoutMilliseconds: if request.timeout_ms == 0 {
+            60_000
+        } else {
+            request.timeout_ms
+        },
+        dwAuthenticatorAttachment: attachment_to_win(request.para.attachment),
+        bRequireResidentKey: (ctap.resident_key || request.para.require_resident_key).into(),
+        dwUserVerificationRequirement: uv_to_win(request.para.user_verification),
+        dwAttestationConveyancePreference: attestation_to_win(request.para.attestation),
+        pCancellationId: &raw mut cancel_id,
+        pExcludeCredentialList: exclude_storage.list_ptr(),
+        ..Default::default()
+    };
+
+    info!(%rp_id, "WebAuthNAuthenticatorMakeCredential");
+    let attestation = unsafe {
+        WebAuthNAuthenticatorMakeCredential(
+            hwnd,
+            &rp_info,
+            &user_info,
+            &cose,
+            &client_data,
+            Some(&raw const options),
+        )
+    }
+    .map_err(|e| map_webauthn_error(e.code()))?;
+
+    if attestation.is_null() {
+        return Err(RdpewaHandlerError::fail("MakeCredential returned null attestation"));
+    }
+
+    let result = unsafe { read_make_credential_result(attestation) };
+    unsafe { WebAuthNFreeCredentialAttestation(Some(attestation)) };
+    // Keep options/cancel_id alive until after the API returns.
+    let _ = &mut options;
+    result
+}
+
+fn run_get_assertion(
+    hwnd: HWND,
+    request: &WebAuthnOperationRequest,
+    cancel_guid: &Arc<Mutex<Option<GUID>>>,
+) -> RdpewaResult<WebAuthnOperationResponse> {
+    let ctap = parse_get_assertion(&request.ctap_cbor).map_err(|m| RdpewaHandlerError::new(E_INVALIDARG, m))?;
+
+    let rp_id = request.rp_id.clone().unwrap_or_else(|| ctap.rp_id.clone());
+    let rp_id_w = wide(&rp_id);
+
+    let mut client_data_json = request.client_data_json.clone();
+    if client_data_json.is_empty() {
+        return Err(RdpewaHandlerError::new(E_INVALIDARG, "missing clientDataJSON"));
+    }
+
+    let client_data = WEBAUTHN_CLIENT_DATA {
+        dwVersion: WEBAUTHN_CLIENT_DATA_CURRENT_VERSION,
+        cbClientDataJSON: u32_len(&client_data_json)?,
+        pbClientDataJSON: client_data_json.as_mut_ptr(),
+        pwszHashAlgId: WEBAUTHN_HASH_ALGORITHM_SHA_256,
+    };
+
+    let mut allow_ids = ctap.allow_credential_ids.clone();
+    let mut allow_storage = CredentialListStorage::from_ids(&mut allow_ids)?;
+
+    let mut cancel_id = resolve_cancel_id(request, cancel_guid)?;
+
+    let mut options = WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS {
+        dwVersion: WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_CURRENT_VERSION,
+        dwTimeoutMilliseconds: if request.timeout_ms == 0 {
+            60_000
+        } else {
+            request.timeout_ms
+        },
+        dwAuthenticatorAttachment: attachment_to_win(request.para.attachment),
+        dwUserVerificationRequirement: uv_to_win(request.para.user_verification),
+        pCancellationId: &raw mut cancel_id,
+        pAllowCredentialList: allow_storage.list_ptr(),
+        ..Default::default()
+    };
+
+    info!(%rp_id, "WebAuthNAuthenticatorGetAssertion");
+    let assertion = unsafe {
+        WebAuthNAuthenticatorGetAssertion(hwnd, PCWSTR(rp_id_w.as_ptr()), &client_data, Some(&raw const options))
+    }
+    .map_err(|e| map_webauthn_error(e.code()))?;
+
+    if assertion.is_null() {
+        return Err(RdpewaHandlerError::fail("GetAssertion returned null assertion"));
+    }
+
+    let result = unsafe { read_get_assertion_result(assertion) };
+    unsafe { WebAuthNFreeAssertion(assertion) };
+    let _ = &mut options;
+    result
+}
+
+unsafe fn read_make_credential_result(
+    attestation: *mut windows::Win32::Networking::WindowsWebServices::WEBAUTHN_CREDENTIAL_ATTESTATION,
+) -> RdpewaResult<WebAuthnOperationResponse> {
+    let att = unsafe { &*attestation };
+    let fmt = unsafe { pcwstr_to_string(att.pwszFormatType) }.unwrap_or_else(|| String::from("none"));
+    let auth_data = unsafe { slice_from_parts(att.pbAuthenticatorData, att.cbAuthenticatorData) };
+    let att_stmt = unsafe { slice_from_parts(att.pbAttestation, att.cbAttestation) };
+
+    let body = encode_make_credential_response(&fmt, auth_data, Some(att_stmt)).map_err(RdpewaHandlerError::fail)?;
+    let transports = att.dwUsedTransport;
+    let resident_key = Some(att.bResidentKey.as_bool());
+
+    Ok(WebAuthnOperationResponse {
+        device_info: WindowsRdpewaBackend::platform_device_info(transports, resident_key),
+        status: 0,
+        response: pack_ctap_response(0x00, &body),
+    })
+}
+
+unsafe fn read_get_assertion_result(assertion: *mut WEBAUTHN_ASSERTION) -> RdpewaResult<WebAuthnOperationResponse> {
+    let a = unsafe { &*assertion };
+    let auth_data = unsafe { slice_from_parts(a.pbAuthenticatorData, a.cbAuthenticatorData) };
+    let signature = unsafe { slice_from_parts(a.pbSignature, a.cbSignature) };
+    let cred_id = unsafe { slice_from_parts(a.Credential.pbId, a.Credential.cbId) };
+    let user_id = unsafe { slice_from_parts(a.pbUserId, a.cbUserId) };
+    let user = if user_id.is_empty() { None } else { Some(user_id) };
+
+    let body = encode_get_assertion_response(cred_id, auth_data, signature, user).map_err(RdpewaHandlerError::fail)?;
+
+    Ok(WebAuthnOperationResponse {
+        device_info: WindowsRdpewaBackend::platform_device_info(a.dwUsedTransport, None),
+        status: 0,
+        response: pack_ctap_response(0x00, &body),
+    })
+}
+
+struct CredentialListStorage {
+    _creds: Vec<WEBAUTHN_CREDENTIAL_EX>,
+    _ptrs: Vec<*mut WEBAUTHN_CREDENTIAL_EX>,
+    list: WEBAUTHN_CREDENTIAL_LIST,
+}
+
+impl CredentialListStorage {
+    fn from_ids(ids: &mut [Vec<u8>]) -> RdpewaResult<Self> {
+        if ids.is_empty() {
+            return Ok(Self {
+                _creds: Vec::new(),
+                _ptrs: Vec::new(),
+                list: WEBAUTHN_CREDENTIAL_LIST::default(),
+            });
+        }
+
+        let mut creds: Vec<WEBAUTHN_CREDENTIAL_EX> = ids
+            .iter_mut()
+            .map(|id| WEBAUTHN_CREDENTIAL_EX {
+                dwVersion: WEBAUTHN_CREDENTIAL_EX_CURRENT_VERSION,
+                cbId: u32_len(id).unwrap_or(0),
+                pbId: id.as_mut_ptr(),
+                pwszCredentialType: WEBAUTHN_CREDENTIAL_TYPE_PUBLIC_KEY,
+                dwTransports: 0,
+            })
+            .collect();
+        let mut ptrs: Vec<*mut WEBAUTHN_CREDENTIAL_EX> = creds.iter_mut().map(|c| c as *mut _).collect();
+        let list = WEBAUTHN_CREDENTIAL_LIST {
+            cCredentials: u32_len_items(ptrs.len())?,
+            ppCredentials: ptrs.as_mut_ptr(),
+        };
+        Ok(Self {
+            _creds: creds,
+            _ptrs: ptrs,
+            list,
+        })
+    }
+
+    fn list_ptr(&mut self) -> *mut WEBAUTHN_CREDENTIAL_LIST {
+        if self._creds.is_empty() {
+            core::ptr::null_mut()
+        } else {
+            &raw mut self.list
+        }
+    }
+}
+
+fn attachment_to_win(v: Attachment) -> u32 {
+    match v {
+        Attachment::Platform => WEBAUTHN_AUTHENTICATOR_ATTACHMENT_PLATFORM,
+        Attachment::CrossPlatform => WEBAUTHN_AUTHENTICATOR_ATTACHMENT_CROSS_PLATFORM,
+        Attachment::Any => WEBAUTHN_AUTHENTICATOR_ATTACHMENT_ANY,
+    }
+}
+
+fn uv_to_win(v: UserVerification) -> u32 {
+    match v {
+        UserVerification::Required => WEBAUTHN_USER_VERIFICATION_REQUIREMENT_REQUIRED,
+        UserVerification::Preferred => WEBAUTHN_USER_VERIFICATION_REQUIREMENT_PREFERRED,
+        UserVerification::Discouraged => WEBAUTHN_USER_VERIFICATION_REQUIREMENT_DISCOURAGED,
+        UserVerification::Any => WEBAUTHN_USER_VERIFICATION_REQUIREMENT_ANY,
+    }
+}
+
+fn attestation_to_win(v: Attestation) -> u32 {
+    match v {
+        Attestation::None => WEBAUTHN_ATTESTATION_CONVEYANCE_PREFERENCE_NONE,
+        Attestation::Indirect => WEBAUTHN_ATTESTATION_CONVEYANCE_PREFERENCE_INDIRECT,
+        Attestation::Direct => WEBAUTHN_ATTESTATION_CONVEYANCE_PREFERENCE_DIRECT,
+        Attestation::Any => WEBAUTHN_ATTESTATION_CONVEYANCE_PREFERENCE_ANY,
+    }
+}
+
+fn wide(s: &str) -> Vec<u16> {
+    s.encode_utf16().chain(core::iter::once(0)).collect()
+}
+
+fn u32_len(bytes: &[u8]) -> RdpewaResult<u32> {
+    u32::try_from(bytes.len()).map_err(|_| RdpewaHandlerError::new(E_INVALIDARG, "buffer too large"))
+}
+
+fn u32_len_items(n: usize) -> RdpewaResult<u32> {
+    u32::try_from(n).map_err(|_| RdpewaHandlerError::new(E_INVALIDARG, "too many items"))
+}
+
+unsafe fn slice_from_parts<'a>(ptr: *mut u8, len: u32) -> &'a [u8] {
+    if ptr.is_null() || len == 0 {
+        &[]
+    } else {
+        unsafe { core::slice::from_raw_parts(ptr, len as usize) }
+    }
+}
+
+unsafe fn pcwstr_to_string(p: PCWSTR) -> Option<String> {
+    if p.is_null() {
+        None
+    } else {
+        unsafe { p.to_string().ok() }
+    }
+}
+
+fn hresult_err(hr: HRESULT, message: &'static str) -> RdpewaHandlerError {
+    RdpewaHandlerError::new(hr.0 as u32, message)
+}
+
+fn map_webauthn_error(hr: HRESULT) -> RdpewaHandlerError {
+    let code = hr.0 as u32;
+    // ERROR_CANCELLED / NTE_USER_CANCELLED-ish paths map to E_ABORT.
+    if code == 0x8007_04C7 || code == 0x8009_0036 || code == E_ABORT {
+        RdpewaHandlerError::new(E_ABORT, "WebAuthn operation cancelled")
+    } else if code == 0 {
+        RdpewaHandlerError::new(E_FAIL, "WebAuthn operation failed")
+    } else {
+        RdpewaHandlerError::new(code, "WebAuthn operation failed")
+    }
+}
+
+/// Prefer a server-supplied 16-byte GUID; otherwise allocate one via the WebAuthn API.
+fn resolve_cancel_id(
+    request: &WebAuthnOperationRequest,
+    cancel_guid: &Arc<Mutex<Option<GUID>>>,
+) -> RdpewaResult<GUID> {
+    let cancel_id = request
+        .para
+        .cancellation_id
+        .as_deref()
+        .and_then(guid_from_bytes)
+        .map(Ok)
+        .unwrap_or_else(|| {
+            unsafe { WebAuthNGetCancellationId() }
+                .map_err(|e| hresult_err(e.code(), "WebAuthNGetCancellationId failed"))
+        })?;
+    *cancel_guid.lock().unwrap_or_else(|e| e.into_inner()) = Some(cancel_id);
+    Ok(cancel_id)
+}
+
+fn cancel_guid_slot(slot: &Arc<Mutex<Option<GUID>>>, preferred: Option<GUID>) -> RdpewaResult<()> {
+    let mut guard = slot.lock().unwrap_or_else(|e| e.into_inner());
+    let guid = preferred.or_else(|| guard.take());
+    if preferred.is_some() {
+        // Clear the slot when it matches the cancelled operation.
+        if let (Some(preferred), Some(current)) = (preferred, *guard)
+            && preferred == current
+        {
+            *guard = None;
+        }
+    }
+    drop(guard);
+
+    if let Some(guid) = guid {
+        info!("Cancelling in-flight WebAuthn operation");
+        unsafe { WebAuthNCancelCurrentOperation(&guid) }
+            .map_err(|e| hresult_err(e.code(), "WebAuthNCancelCurrentOperation failed"))?;
+    } else {
+        debug!("No in-flight WebAuthn operation to cancel");
+    }
+    Ok(())
+}
+
+fn guid_from_bytes(bytes: &[u8]) -> Option<GUID> {
+    if bytes.len() != 16 {
+        return None;
+    }
+    Some(GUID {
+        data1: u32::from_le_bytes(bytes[0..4].try_into().ok()?),
+        data2: u16::from_le_bytes(bytes[4..6].try_into().ok()?),
+        data3: u16::from_le_bytes(bytes[6..8].try_into().ok()?),
+        data4: bytes[8..16].try_into().ok()?,
+    })
+}

--- a/crates/ironrdp-rdpewa-native/src/cbor_map.rs
+++ b/crates/ironrdp-rdpewa-native/src/cbor_map.rs
@@ -2,7 +2,7 @@
 
 use ironrdp_rdpewa::pdu::{CborKey, CborValue};
 
-pub(crate) fn map_get<'a>(map: &'a std::collections::BTreeMap<CborKey, CborValue>, key: i64) -> Option<&'a CborValue> {
+pub(crate) fn map_get(map: &std::collections::BTreeMap<CborKey, CborValue>, key: i64) -> Option<&CborValue> {
     map.get(&CborKey::Int(key))
 }
 

--- a/crates/ironrdp-rdpewa-native/src/cbor_map.rs
+++ b/crates/ironrdp-rdpewa-native/src/cbor_map.rs
@@ -1,0 +1,24 @@
+//! Helpers for reading CTAP integer-keyed CBOR maps.
+
+use ironrdp_rdpewa::pdu::{CborKey, CborValue};
+
+pub(crate) fn map_get<'a>(map: &'a std::collections::BTreeMap<CborKey, CborValue>, key: i64) -> Option<&'a CborValue> {
+    map.get(&CborKey::Int(key))
+}
+
+pub(crate) fn map_get_text<'a>(
+    map: &'a std::collections::BTreeMap<CborKey, CborValue>,
+    key: &str,
+) -> Option<&'a CborValue> {
+    map.get(&CborKey::Text(key.to_owned()))
+}
+
+pub(crate) fn text_field(map: &std::collections::BTreeMap<CborKey, CborValue>, key: &str) -> Option<String> {
+    map_get_text(map, key).and_then(|v| v.as_text().ok()).map(str::to_owned)
+}
+
+pub(crate) fn bytes_field(map: &std::collections::BTreeMap<CborKey, CborValue>, key: &str) -> Option<Vec<u8>> {
+    map_get_text(map, key)
+        .and_then(|v| v.as_bytes().ok())
+        .map(|b| b.to_vec())
+}

--- a/crates/ironrdp-rdpewa-native/src/ctap.rs
+++ b/crates/ironrdp-rdpewa-native/src/ctap.rs
@@ -69,19 +69,15 @@ pub(crate) fn parse_make_credential(ctap_cbor: &[u8]) -> Result<MakeCredentialCt
         algorithms.push(-7);
     }
 
-    let mut exclude_credential_ids = Vec::new();
-    if let Some(list) = map_get(map, MAKECRED_EXCLUDE_LIST) {
-        exclude_credential_ids = credential_ids_from_list(list)?;
-    }
+    let exclude_credential_ids = map_get(map, MAKECRED_EXCLUDE_LIST)
+        .map(credential_ids_from_list)
+        .transpose()?
+        .unwrap_or_default();
 
-    let mut resident_key = false;
-    if let Some(options) = map_get(map, MAKECRED_OPTIONS) {
-        if let Ok(opt_map) = options.as_map() {
-            if let Some(rk) = map_get_text_bool(opt_map, "rk") {
-                resident_key = rk;
-            }
-        }
-    }
+    let resident_key = map_get(map, MAKECRED_OPTIONS)
+        .and_then(|options| options.as_map().ok())
+        .and_then(|opt_map| map_get_text_bool(opt_map, "rk"))
+        .unwrap_or(false);
 
     Ok(MakeCredentialCtap {
         rp_id,
@@ -105,10 +101,10 @@ pub(crate) fn parse_get_assertion(ctap_cbor: &[u8]) -> Result<GetAssertionCtap, 
         .map_err(|_| "rpId is not text")?
         .to_owned();
 
-    let mut allow_credential_ids = Vec::new();
-    if let Some(list) = map_get(map, GETASSERT_ALLOW_LIST) {
-        allow_credential_ids = credential_ids_from_list(list)?;
-    }
+    let allow_credential_ids = map_get(map, GETASSERT_ALLOW_LIST)
+        .map(credential_ids_from_list)
+        .transpose()?
+        .unwrap_or_default();
 
     let _ = map_get(map, GETASSERT_OPTIONS);
 

--- a/crates/ironrdp-rdpewa-native/src/ctap.rs
+++ b/crates/ironrdp-rdpewa-native/src/ctap.rs
@@ -1,0 +1,192 @@
+//! CTAP request parsing and response encoding for MS-RDPEWA WEB_AUTHN bodies.
+
+use std::collections::BTreeMap;
+
+use ironrdp_rdpewa::pdu::{CborKey, CborValue, decode_all, encode_to_vec};
+
+use crate::cbor_map::{bytes_field, map_get, text_field};
+
+const MAKECRED_RP: i64 = 2;
+const MAKECRED_USER: i64 = 3;
+const MAKECRED_PUB_KEY_CRED_PARAMS: i64 = 4;
+const MAKECRED_EXCLUDE_LIST: i64 = 5;
+const MAKECRED_OPTIONS: i64 = 7;
+
+const GETASSERT_RP_ID: i64 = 1;
+const GETASSERT_ALLOW_LIST: i64 = 3;
+const GETASSERT_OPTIONS: i64 = 5;
+
+#[derive(Debug, Clone)]
+pub(crate) struct MakeCredentialCtap {
+    pub rp_id: String,
+    pub rp_name: Option<String>,
+    pub user_id: Vec<u8>,
+    pub user_name: Option<String>,
+    pub user_display_name: Option<String>,
+    pub algorithms: Vec<i32>,
+    pub exclude_credential_ids: Vec<Vec<u8>>,
+    pub resident_key: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct GetAssertionCtap {
+    pub rp_id: String,
+    pub allow_credential_ids: Vec<Vec<u8>>,
+}
+
+pub(crate) fn parse_make_credential(ctap_cbor: &[u8]) -> Result<MakeCredentialCtap, &'static str> {
+    let value = decode_all(ctap_cbor).map_err(|_| "invalid makeCredential CTAP CBOR")?;
+    let map = value.as_map().map_err(|_| "makeCredential CTAP body is not a map")?;
+
+    let rp_map = map_get(map, MAKECRED_RP)
+        .ok_or("missing rp")?
+        .as_map()
+        .map_err(|_| "rp is not a map")?;
+    let rp_id = text_field(rp_map, "id").ok_or("missing rp.id")?;
+    let rp_name = text_field(rp_map, "name");
+
+    let user_map = map_get(map, MAKECRED_USER)
+        .ok_or("missing user")?
+        .as_map()
+        .map_err(|_| "user is not a map")?;
+    let user_id = bytes_field(user_map, "id").ok_or("missing user.id")?;
+    let user_name = text_field(user_map, "name");
+    let user_display_name = text_field(user_map, "displayName");
+
+    let mut algorithms = Vec::new();
+    if let Some(params) = map_get(map, MAKECRED_PUB_KEY_CRED_PARAMS) {
+        let arr = params.as_array().map_err(|_| "pubKeyCredParams is not an array")?;
+        for item in arr {
+            if let Ok(param_map) = item.as_map() {
+                if let Some(alg) = map_get_text_i32(param_map, "alg") {
+                    algorithms.push(alg);
+                }
+            }
+        }
+    }
+    if algorithms.is_empty() {
+        // ES256 is the common default for Windows Hello / security keys.
+        algorithms.push(-7);
+    }
+
+    let mut exclude_credential_ids = Vec::new();
+    if let Some(list) = map_get(map, MAKECRED_EXCLUDE_LIST) {
+        exclude_credential_ids = credential_ids_from_list(list)?;
+    }
+
+    let mut resident_key = false;
+    if let Some(options) = map_get(map, MAKECRED_OPTIONS) {
+        if let Ok(opt_map) = options.as_map() {
+            if let Some(rk) = map_get_text_bool(opt_map, "rk") {
+                resident_key = rk;
+            }
+        }
+    }
+
+    Ok(MakeCredentialCtap {
+        rp_id,
+        rp_name,
+        user_id,
+        user_name,
+        user_display_name,
+        algorithms,
+        exclude_credential_ids,
+        resident_key,
+    })
+}
+
+pub(crate) fn parse_get_assertion(ctap_cbor: &[u8]) -> Result<GetAssertionCtap, &'static str> {
+    let value = decode_all(ctap_cbor).map_err(|_| "invalid getAssertion CTAP CBOR")?;
+    let map = value.as_map().map_err(|_| "getAssertion CTAP body is not a map")?;
+
+    let rp_id = map_get(map, GETASSERT_RP_ID)
+        .ok_or("missing rpId")?
+        .as_text()
+        .map_err(|_| "rpId is not text")?
+        .to_owned();
+
+    let mut allow_credential_ids = Vec::new();
+    if let Some(list) = map_get(map, GETASSERT_ALLOW_LIST) {
+        allow_credential_ids = credential_ids_from_list(list)?;
+    }
+
+    let _ = map_get(map, GETASSERT_OPTIONS);
+
+    Ok(GetAssertionCtap {
+        rp_id,
+        allow_credential_ids,
+    })
+}
+
+/// Build CTAP makeCredential response map: `{1:fmt, 2:authData, 3:attStmt}`.
+pub(crate) fn encode_make_credential_response(
+    fmt: &str,
+    auth_data: &[u8],
+    att_stmt_cbor: Option<&[u8]>,
+) -> Result<Vec<u8>, &'static str> {
+    let mut map = BTreeMap::new();
+    map.insert(CborKey::Int(1), CborValue::Text(fmt.to_owned()));
+    map.insert(CborKey::Int(2), CborValue::Bytes(auth_data.to_vec()));
+    let att_stmt = match att_stmt_cbor {
+        Some(raw) if !raw.is_empty() => decode_all(raw).unwrap_or_else(|_| CborValue::Map(BTreeMap::new())),
+        _ => CborValue::Map(BTreeMap::new()),
+    };
+    map.insert(CborKey::Int(3), att_stmt);
+    encode_to_vec(&CborValue::Map(map)).map_err(|_| "failed to encode makeCredential response")
+}
+
+/// Build CTAP getAssertion response map: `{1:cred, 2:authData, 3:sig, 4?:user}`.
+pub(crate) fn encode_get_assertion_response(
+    credential_id: &[u8],
+    auth_data: &[u8],
+    signature: &[u8],
+    user_id: Option<&[u8]>,
+) -> Result<Vec<u8>, &'static str> {
+    let mut cred = BTreeMap::new();
+    cred.insert(CborKey::Text("id".into()), CborValue::Bytes(credential_id.to_vec()));
+    cred.insert(CborKey::Text("type".into()), CborValue::Text("public-key".into()));
+
+    let mut map = BTreeMap::new();
+    map.insert(CborKey::Int(1), CborValue::Map(cred));
+    map.insert(CborKey::Int(2), CborValue::Bytes(auth_data.to_vec()));
+    map.insert(CborKey::Int(3), CborValue::Bytes(signature.to_vec()));
+    if let Some(uid) = user_id {
+        if !uid.is_empty() {
+            let mut user = BTreeMap::new();
+            user.insert(CborKey::Text("id".into()), CborValue::Bytes(uid.to_vec()));
+            map.insert(CborKey::Int(4), CborValue::Map(user));
+        }
+    }
+    encode_to_vec(&CborValue::Map(map)).map_err(|_| "failed to encode getAssertion response")
+}
+
+/// CTAP status byte + response CBOR body.
+pub(crate) fn pack_ctap_response(status: u8, body: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(1 + body.len());
+    out.push(status);
+    out.extend_from_slice(body);
+    out
+}
+
+fn credential_ids_from_list(list: &CborValue) -> Result<Vec<Vec<u8>>, &'static str> {
+    let arr = list.as_array().map_err(|_| "credential list is not an array")?;
+    let mut ids = Vec::new();
+    for item in arr {
+        if let Ok(map) = item.as_map() {
+            if let Some(id) = bytes_field(map, "id") {
+                ids.push(id);
+            }
+        }
+    }
+    Ok(ids)
+}
+
+fn map_get_text_i32(map: &BTreeMap<CborKey, CborValue>, key: &str) -> Option<i32> {
+    map.get(&CborKey::Text(key.to_owned()))
+        .and_then(|v| v.as_i64().ok())
+        .and_then(|n| i32::try_from(n).ok())
+}
+
+fn map_get_text_bool(map: &BTreeMap<CborKey, CborValue>, key: &str) -> Option<bool> {
+    map.get(&CborKey::Text(key.to_owned())).and_then(|v| v.as_bool().ok())
+}

--- a/crates/ironrdp-rdpewa-native/src/ctap.rs
+++ b/crates/ironrdp-rdpewa-native/src/ctap.rs
@@ -61,8 +61,8 @@ pub(crate) fn parse_make_credential(ctap_cbor: &[u8]) -> Result<MakeCredentialCt
     let mut algorithms = Vec::with_capacity(arr.len());
     for item in arr {
         let param_map = item.as_map().map_err(|_| "pubKeyCredParams entry is not a map")?;
-        let alg = map_get_text_i32(param_map, "alg").ok_or("pubKeyCredParams entry missing alg")?;
-        algorithms.push(alg);
+        let algorithm = map_get_text_i32(param_map, "alg").ok_or("missing or invalid pubKeyCredParams alg")?;
+        algorithms.push(algorithm);
     }
 
     let exclude_credential_ids = map_get(map, MAKECRED_EXCLUDE_LIST)
@@ -181,4 +181,47 @@ fn map_get_text_i32(map: &BTreeMap<CborKey, CborValue>, key: &str) -> Option<i32
 
 fn map_get_text_bool(map: &BTreeMap<CborKey, CborValue>, key: &str) -> Option<bool> {
     map.get(&CborKey::Text(key.to_owned())).and_then(|v| v.as_bool().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_credential_request(params: Option<CborValue>) -> Vec<u8> {
+        let mut rp = BTreeMap::new();
+        rp.insert(
+            CborKey::Text("id".to_owned()),
+            CborValue::Text("example.com".to_owned()),
+        );
+
+        let mut user = BTreeMap::new();
+        user.insert(CborKey::Text("id".to_owned()), CborValue::Bytes(vec![1]));
+
+        let mut request = BTreeMap::new();
+        request.insert(CborKey::Int(MAKECRED_RP), CborValue::Map(rp));
+        request.insert(CborKey::Int(MAKECRED_USER), CborValue::Map(user));
+        if let Some(params) = params {
+            request.insert(CborKey::Int(MAKECRED_PUB_KEY_CRED_PARAMS), params);
+        }
+
+        encode_to_vec(&CborValue::Map(request)).expect("valid CBOR")
+    }
+
+    #[test]
+    fn make_credential_requires_valid_credential_parameters() {
+        let cases = [
+            make_credential_request(None),
+            make_credential_request(Some(CborValue::Map(BTreeMap::new()))),
+            make_credential_request(Some(CborValue::Array(Vec::new()))),
+            make_credential_request(Some(CborValue::Array(vec![CborValue::Null]))),
+            make_credential_request(Some(CborValue::Array(vec![CborValue::Map(BTreeMap::new())]))),
+        ];
+
+        for request in cases {
+            assert!(
+                parse_make_credential(&request).is_err(),
+                "invalid pubKeyCredParams must be rejected"
+            );
+        }
+    }
 }

--- a/crates/ironrdp-rdpewa-native/src/ctap.rs
+++ b/crates/ironrdp-rdpewa-native/src/ctap.rs
@@ -53,20 +53,16 @@ pub(crate) fn parse_make_credential(ctap_cbor: &[u8]) -> Result<MakeCredentialCt
     let user_name = text_field(user_map, "name");
     let user_display_name = text_field(user_map, "displayName");
 
-    let mut algorithms = Vec::new();
-    if let Some(params) = map_get(map, MAKECRED_PUB_KEY_CRED_PARAMS) {
-        let arr = params.as_array().map_err(|_| "pubKeyCredParams is not an array")?;
-        for item in arr {
-            if let Ok(param_map) = item.as_map() {
-                if let Some(alg) = map_get_text_i32(param_map, "alg") {
-                    algorithms.push(alg);
-                }
-            }
-        }
+    let params = map_get(map, MAKECRED_PUB_KEY_CRED_PARAMS).ok_or("missing pubKeyCredParams")?;
+    let arr = params.as_array().map_err(|_| "pubKeyCredParams is not an array")?;
+    if arr.is_empty() {
+        return Err("pubKeyCredParams is empty");
     }
-    if algorithms.is_empty() {
-        // ES256 is the common default for Windows Hello / security keys.
-        algorithms.push(-7);
+    let mut algorithms = Vec::with_capacity(arr.len());
+    for item in arr {
+        let param_map = item.as_map().map_err(|_| "pubKeyCredParams entry is not a map")?;
+        let alg = map_get_text_i32(param_map, "alg").ok_or("pubKeyCredParams entry missing alg")?;
+        algorithms.push(alg);
     }
 
     let exclude_credential_ids = map_get(map, MAKECRED_EXCLUDE_LIST)

--- a/crates/ironrdp-rdpewa-native/src/lib.rs
+++ b/crates/ironrdp-rdpewa-native/src/lib.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(doc, doc = include_str!("../README.md"))]
 #![doc(html_logo_url = "https://cdnweb.devolutions.net/images/projects/devolutions/logos/devolutions-icon-shadow.svg")]
+// Windows WebAuthn FFI call sites are dense; safety is documented at helper boundaries.
+#![cfg_attr(windows, allow(clippy::undocumented_unsafe_blocks))]
 
 //! Windows WebAuthn backend for [`ironrdp_rdpewa`].
 

--- a/crates/ironrdp-rdpewa-native/src/lib.rs
+++ b/crates/ironrdp-rdpewa-native/src/lib.rs
@@ -1,0 +1,14 @@
+#![cfg_attr(doc, doc = include_str!("../README.md"))]
+#![doc(html_logo_url = "https://cdnweb.devolutions.net/images/projects/devolutions/logos/devolutions-icon-shadow.svg")]
+
+//! Windows WebAuthn backend for [`ironrdp_rdpewa`].
+
+#[cfg(windows)]
+mod backend;
+#[cfg(windows)]
+mod cbor_map;
+#[cfg(windows)]
+mod ctap;
+
+#[cfg(windows)]
+pub use backend::WindowsRdpewaBackend;

--- a/crates/ironrdp-rdpewa-native/src/lib.rs
+++ b/crates/ironrdp-rdpewa-native/src/lib.rs
@@ -13,4 +13,4 @@ mod cbor_map;
 mod ctap;
 
 #[cfg(windows)]
-pub use backend::{WindowsRdpewaBackend, WindowsRdpewaSession};
+pub use backend::{WindowsRdpewaBackend, WindowsRdpewaSessionState};

--- a/crates/ironrdp-rdpewa-native/src/lib.rs
+++ b/crates/ironrdp-rdpewa-native/src/lib.rs
@@ -13,4 +13,4 @@ mod cbor_map;
 mod ctap;
 
 #[cfg(windows)]
-pub use backend::WindowsRdpewaBackend;
+pub use backend::{WindowsRdpewaBackend, WindowsRdpewaSession};

--- a/crates/ironrdp-rdpewa/CHANGELOG.md
+++ b/crates/ironrdp-rdpewa/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+
+- Initial MS-RDPEWA protocol crate with CBOR PDU codec, client processor, and server skeleton.

--- a/crates/ironrdp-rdpewa/Cargo.toml
+++ b/crates/ironrdp-rdpewa/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "ironrdp-rdpewa"
+version = "0.1.0"
+readme = "README.md"
+description = "MS-RDPEWA WebAuthn dynamic virtual channel protocol"
+edition.workspace = true
+rust-version = "1.94"
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lib]
+doctest = false
+
+[dependencies]
+ironrdp-core = { path = "../ironrdp-core", version = "0.2", features = ["alloc"] } # public
+ironrdp-dvc = { path = "../ironrdp-dvc", version = "0.8" } # public
+ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9" } # public
+ironrdp-svc = { path = "../ironrdp-svc", version = "0.8" } # public
+tracing = { version = "0.1", features = ["log"] }
+
+[lints]
+workspace = true

--- a/crates/ironrdp-rdpewa/README.md
+++ b/crates/ironrdp-rdpewa/README.md
@@ -10,7 +10,7 @@ MS-RDPEWA (WebAuthn Virtual Channel) protocol types and DVC processors for IronR
 ## Layout
 
 - `pdu` — CBOR request/response codec and MVP command types
-- `client` — `RdpewaClient` + `RdpewaClientHandler`
+- `client` — `RdpewaClient`, recreatable `RdpewaClientListener`, and `RdpewaClientHandler`
 - `server` — minimal `RdpewaServer` skeleton for tests
 
 Platform backends (Windows WebAuthn APIs) live in `ironrdp-rdpewa-native`.

--- a/crates/ironrdp-rdpewa/README.md
+++ b/crates/ironrdp-rdpewa/README.md
@@ -1,0 +1,16 @@
+# ironrdp-rdpewa
+
+MS-RDPEWA (WebAuthn Virtual Channel) protocol types and DVC processors for IronRDP.
+
+## Channel
+
+- DVC name: `WebAuthN_Channel`
+- Spec: [MS-RDPEWA](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpewa/)
+
+## Layout
+
+- `pdu` — CBOR request/response codec and MVP command types
+- `client` — `RdpewaClient` + `RdpewaClientHandler`
+- `server` — minimal `RdpewaServer` skeleton for tests
+
+Platform backends (Windows WebAuthn APIs) live in `ironrdp-rdpewa-native`.

--- a/crates/ironrdp-rdpewa/src/client.rs
+++ b/crates/ironrdp-rdpewa/src/client.rs
@@ -1,0 +1,446 @@
+//! MS-RDPEWA client DVC processor.
+
+use std::sync::Arc;
+
+use ironrdp_core::{Encode, EncodeResult, WriteCursor, ensure_size, impl_as_any};
+use ironrdp_dvc::{DvcClientProcessor, DvcEncode, DvcMessage, DvcProcessor, encode_dvc_messages};
+use ironrdp_pdu::{PduResult, decode_err};
+use ironrdp_svc::{ChannelFlags, SvcMessage};
+use tracing::{debug, warn};
+
+use crate::CHANNEL_NAME;
+use crate::pdu::{
+    DeviceInfo, E_FAIL, E_NOTIMPL, RdpewaRequest, RdpewaResponse, RpcCommand, S_OK, WebAuthnPara,
+    WebAuthnResponsePayload, WebAuthnSubcommand,
+};
+
+/// Result type for platform handler operations.
+pub type RdpewaResult<T> = Result<T, RdpewaHandlerError>;
+
+/// Handler-level error mapped to an HRESULT for the wire response.
+#[derive(Debug)]
+pub struct RdpewaHandlerError {
+    pub hresult: u32,
+    pub message: &'static str,
+}
+
+impl RdpewaHandlerError {
+    pub fn new(hresult: u32, message: &'static str) -> Self {
+        Self { hresult, message }
+    }
+
+    pub fn not_impl(message: &'static str) -> Self {
+        Self::new(E_NOTIMPL, message)
+    }
+
+    pub fn fail(message: &'static str) -> Self {
+        Self::new(E_FAIL, message)
+    }
+}
+
+impl core::fmt::Display for RdpewaHandlerError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{} (HRESULT 0x{:08X})", self.message, self.hresult)
+    }
+}
+
+impl core::error::Error for RdpewaHandlerError {}
+
+/// Inputs for MakeCredential / GetAssertion.
+#[derive(Debug, Clone)]
+pub struct WebAuthnOperationRequest {
+    pub subcommand: WebAuthnSubcommand,
+    pub rp_id: Option<String>,
+    pub timeout_ms: u32,
+    pub transaction_id: Vec<u8>,
+    pub client_data_json: Vec<u8>,
+    pub para: WebAuthnPara,
+    /// CTAP CBOR map (without subcommand byte).
+    pub ctap_cbor: Vec<u8>,
+}
+
+/// Successful WebAuthn operation result from the platform backend.
+#[derive(Debug, Clone)]
+pub struct WebAuthnOperationResponse {
+    pub device_info: DeviceInfo,
+    pub status: u32,
+    /// CTAP status byte + CBOR body.
+    pub response: Vec<u8>,
+}
+
+/// Platform abstraction for MS-RDPEWA client work.
+///
+/// Long-running WebAuthn UI operations should complete asynchronously via
+/// [`RdpewaClientHandler::begin_webauthn`] / [`RdpewaResponseSender`].
+pub trait RdpewaClientHandler: Send {
+    /// Windows WebAuthn API version number.
+    fn api_version(&mut self) -> RdpewaResult<u32>;
+
+    /// `WebAuthNIsUserVerifyingPlatformAuthenticatorAvailable`.
+    fn is_uvpaa(&mut self) -> RdpewaResult<bool>;
+
+    /// Cancel an in-flight operation identified by `cancellation_id`.
+    fn cancel_current_operation(&mut self, cancellation_id: &[u8]) -> RdpewaResult<()>;
+
+    /// Begin MakeCredential or GetAssertion.
+    ///
+    /// Return [`WebAuthnDispatch::Sync`] when the result is immediately available
+    /// (tests / non-UI paths). Return [`WebAuthnDispatch::Async`] when the backend
+    /// will later deliver a response through the provided sender.
+    fn begin_webauthn(
+        &mut self,
+        request: WebAuthnOperationRequest,
+        reply: RdpewaResponseSender,
+    ) -> RdpewaResult<WebAuthnDispatch>;
+}
+
+/// How the handler handles a WEB_AUTHN request.
+#[derive(Debug)]
+pub enum WebAuthnDispatch {
+    /// Immediate result (encoded as WEB_AUTHN payload).
+    Sync(WebAuthnOperationResponse),
+    /// Completion will be delivered later via [`RdpewaResponseSender`].
+    Async,
+}
+
+/// Callback used to inject completed DVC messages into the active session loop.
+pub type RdpewaWriteCallback = Arc<dyn Fn(u32, Vec<SvcMessage>) -> PduResult<()> + Send + Sync>;
+
+/// Sends a completed RDPEWA response PDU back into the session.
+///
+/// Production wiring encodes the response as DVC SVC messages and posts them through
+/// the session input channel (`SendDvcMessages`).
+pub struct RdpewaResponseSender {
+    inner: Box<dyn FnMut(Vec<u8>) + Send>,
+}
+
+impl core::fmt::Debug for RdpewaResponseSender {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("RdpewaResponseSender")
+    }
+}
+
+impl RdpewaResponseSender {
+    pub fn new<F>(f: F) -> Self
+    where
+        F: FnMut(Vec<u8>) + Send + 'static,
+    {
+        Self { inner: Box::new(f) }
+    }
+
+    /// No-op sender used when async completion is not wired.
+    pub fn sink() -> Self {
+        Self::new(|_| {})
+    }
+
+    pub fn send_raw(&mut self, response_pdu: Vec<u8>) {
+        (self.inner)(response_pdu);
+    }
+
+    pub fn send(&mut self, response: RdpewaResponse) {
+        self.send_raw(response.to_bytes());
+    }
+
+    pub fn send_webauthn(&mut self, hresult: u32, payload: &WebAuthnResponsePayload) {
+        match payload.encode() {
+            Ok(bytes) => self.send(RdpewaResponse::with_payload(hresult, bytes)),
+            Err(_) => self.send(RdpewaResponse::from_hresult(E_FAIL)),
+        }
+    }
+}
+
+/// Factory invoked for each async WEB_AUTHN request to obtain a response sender.
+///
+/// Prefer [`RdpewaClient::with_write_callback`] for production wiring. Keep this factory
+/// for unit tests that assert on raw response bytes without DVC framing.
+pub type RdpewaResponseSenderFactory = Box<dyn FnMut() -> RdpewaResponseSender + Send>;
+
+/// Client-side MS-RDPEWA DVC processor.
+pub struct RdpewaClient {
+    handler: Box<dyn RdpewaClientHandler>,
+    write_callback: Option<RdpewaWriteCallback>,
+    sender_factory: Option<RdpewaResponseSenderFactory>,
+    channel_id: Option<u32>,
+}
+
+impl RdpewaClient {
+    pub fn new(handler: Box<dyn RdpewaClientHandler>) -> Self {
+        Self {
+            handler,
+            write_callback: None,
+            sender_factory: None,
+            channel_id: None,
+        }
+    }
+
+    /// Wire async WEB_AUTHN completions into the active session via `SendDvcMessages`.
+    ///
+    /// The callback receives the DVC channel id and fully framed DRDYNVC SVC messages.
+    #[must_use]
+    pub fn with_write_callback<F>(mut self, callback: F) -> Self
+    where
+        F: Fn(u32, Vec<SvcMessage>) -> PduResult<()> + Send + Sync + 'static,
+    {
+        self.write_callback = Some(Arc::new(callback));
+        self
+    }
+
+    /// Override the response-sender factory (primarily for tests).
+    ///
+    /// When set, this takes precedence over [`Self::with_write_callback`].
+    #[must_use]
+    pub fn with_response_sender_factory<F>(mut self, factory: F) -> Self
+    where
+        F: FnMut() -> RdpewaResponseSender + Send + 'static,
+    {
+        self.sender_factory = Some(Box::new(factory));
+        self
+    }
+
+    fn make_reply_sender(&mut self) -> RdpewaResponseSender {
+        if let Some(factory) = self.sender_factory.as_mut() {
+            return factory();
+        }
+
+        let Some(callback) = self.write_callback.clone() else {
+            return RdpewaResponseSender::sink();
+        };
+
+        let channel_id = self.channel_id.unwrap_or(0);
+        RdpewaResponseSender::new(move |response_pdu| {
+            let messages = match encode_dvc_messages(
+                channel_id,
+                vec![Box::new(RawDataDvcMessage(response_pdu))],
+                ChannelFlags::SHOW_PROTOCOL,
+            ) {
+                Ok(messages) => messages,
+                Err(error) => {
+                    warn!(%error, channel_id, "Failed to encode async RDPEWA DVC response");
+                    return;
+                }
+            };
+
+            if let Err(error) = callback(channel_id, messages) {
+                warn!(%error, channel_id, "Failed to submit async RDPEWA DVC response");
+            }
+        })
+    }
+
+    fn handle_request(&mut self, request: RdpewaRequest) -> PduResult<Option<RdpewaResponse>> {
+        match request.command {
+            RpcCommand::ApiVersion => {
+                let version = self.handler.api_version().unwrap_or_else(|e| {
+                    warn!(error = %e, "api_version failed");
+                    0
+                });
+                let hresult = if version == 0 { E_FAIL } else { S_OK };
+                if hresult == S_OK {
+                    Ok(Some(RdpewaResponse::with_u32(S_OK, version)))
+                } else {
+                    Ok(Some(RdpewaResponse::from_hresult(hresult)))
+                }
+            }
+            RpcCommand::Iuvpaa => match self.handler.is_uvpaa() {
+                Ok(available) => Ok(Some(RdpewaResponse::with_u32(S_OK, u32::from(available)))),
+                Err(e) => {
+                    warn!(error = %e, "is_uvpaa failed");
+                    Ok(Some(RdpewaResponse::from_hresult(e.hresult)))
+                }
+            },
+            RpcCommand::CancelCurOp => {
+                let cancellation_id = request
+                    .webauthn_para
+                    .as_ref()
+                    .and_then(|p| p.cancellation_id.as_deref())
+                    .unwrap_or(&[]);
+                match self.handler.cancel_current_operation(cancellation_id) {
+                    Ok(()) => Ok(Some(RdpewaResponse::ok_empty())),
+                    Err(e) => {
+                        warn!(error = %e, "cancel_current_operation failed");
+                        Ok(Some(RdpewaResponse::from_hresult(e.hresult)))
+                    }
+                }
+            }
+            RpcCommand::WebAuthn => self.handle_webauthn(request),
+            RpcCommand::GetCredentials | RpcCommand::GetAuthenticatorList => {
+                Ok(Some(RdpewaResponse::from_hresult(E_NOTIMPL)))
+            }
+        }
+    }
+
+    fn handle_webauthn(&mut self, request: RdpewaRequest) -> PduResult<Option<RdpewaResponse>> {
+        let body = match request.webauthn_body() {
+            Ok(b) => b,
+            Err(e) => {
+                warn!(error = %e, "invalid WEB_AUTHN request body");
+                return Ok(Some(RdpewaResponse::from_hresult(crate::pdu::E_INVALIDARG)));
+            }
+        };
+
+        let client_data_json = request.client_data_json.clone().unwrap_or_default();
+        let para = request.webauthn_para.clone().unwrap_or_default();
+        let op = WebAuthnOperationRequest {
+            subcommand: body.subcommand,
+            rp_id: request.rp_id.clone(),
+            timeout_ms: request.timeout_ms,
+            transaction_id: request.transaction_id.clone(),
+            client_data_json,
+            para,
+            ctap_cbor: body.ctap_cbor,
+        };
+
+        let reply = self.make_reply_sender();
+        match self.handler.begin_webauthn(op, reply) {
+            Ok(WebAuthnDispatch::Sync(result)) => {
+                let payload = WebAuthnResponsePayload {
+                    device_info: result.device_info,
+                    status: result.status,
+                    response: result.response,
+                };
+                match payload.encode() {
+                    Ok(bytes) => Ok(Some(RdpewaResponse::with_payload(S_OK, bytes))),
+                    Err(e) => {
+                        warn!(error = %e, "failed to encode WEB_AUTHN response");
+                        Ok(Some(RdpewaResponse::from_hresult(E_FAIL)))
+                    }
+                }
+            }
+            Ok(WebAuthnDispatch::Async) => {
+                debug!("WEB_AUTHN operation dispatched asynchronously");
+                Ok(None)
+            }
+            Err(e) => {
+                warn!(error = %e, "begin_webauthn failed");
+                Ok(Some(RdpewaResponse::from_hresult(e.hresult)))
+            }
+        }
+    }
+}
+
+impl_as_any!(RdpewaClient);
+
+impl DvcProcessor for RdpewaClient {
+    fn channel_name(&self) -> &str {
+        CHANNEL_NAME
+    }
+
+    fn start(&mut self, channel_id: u32) -> PduResult<Vec<DvcMessage>> {
+        self.channel_id = Some(channel_id);
+        debug!(channel_id, "RDPEWA channel started");
+        Ok(Vec::new())
+    }
+
+    fn process(&mut self, _channel_id: u32, payload: &[u8]) -> PduResult<Vec<DvcMessage>> {
+        let request = RdpewaRequest::decode(payload).map_err(|e| decode_err!(e))?;
+        debug!(?request.command, "Received RDPEWA request");
+
+        match self.handle_request(request)? {
+            Some(response) => Ok(vec![Box::new(response)]),
+            None => Ok(Vec::new()),
+        }
+    }
+}
+
+impl DvcClientProcessor for RdpewaClient {}
+
+struct RawDataDvcMessage(Vec<u8>);
+
+impl Encode for RawDataDvcMessage {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_slice(&self.0);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "RdpewaRawDataDvcMessage"
+    }
+
+    fn size(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl DvcEncode for RawDataDvcMessage {}
+
+/// Simple in-process handler for unit tests.
+#[derive(Debug, Default)]
+pub struct StubRdpewaHandler {
+    pub api_version: u32,
+    pub uvpaa: bool,
+}
+
+impl RdpewaClientHandler for StubRdpewaHandler {
+    fn api_version(&mut self) -> RdpewaResult<u32> {
+        Ok(self.api_version)
+    }
+
+    fn is_uvpaa(&mut self) -> RdpewaResult<bool> {
+        Ok(self.uvpaa)
+    }
+
+    fn cancel_current_operation(&mut self, _cancellation_id: &[u8]) -> RdpewaResult<()> {
+        Ok(())
+    }
+
+    fn begin_webauthn(
+        &mut self,
+        _request: WebAuthnOperationRequest,
+        _reply: RdpewaResponseSender,
+    ) -> RdpewaResult<WebAuthnDispatch> {
+        Err(RdpewaHandlerError::not_impl("stub webauthn"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn api_version_sync_response() {
+        let handler = StubRdpewaHandler {
+            api_version: 4,
+            uvpaa: true,
+        };
+        let mut client = RdpewaClient::new(Box::new(handler));
+        let req = RdpewaRequest {
+            command: RpcCommand::ApiVersion,
+            flags: 0,
+            rp_id: None,
+            timeout_ms: 0,
+            transaction_id: vec![0; 16],
+            client_data_json: None,
+            webauthn_para: None,
+            request_body: Vec::new(),
+            raw: Default::default(),
+        };
+        let encoded = req.encode().unwrap();
+        let _ = client.start(7).unwrap();
+        let messages = client.process(7, &encoded).unwrap();
+        assert_eq!(messages.len(), 1);
+    }
+
+    #[test]
+    fn async_sender_encodes_dvc_messages() {
+        use std::sync::Mutex;
+
+        let captured = Arc::new(Mutex::new(None));
+        let captured_cb = Arc::clone(&captured);
+        let mut client = RdpewaClient::new(Box::new(StubRdpewaHandler {
+            api_version: 1,
+            uvpaa: false,
+        }))
+        .with_write_callback(move |channel_id, messages| {
+            *captured_cb.lock().unwrap() = Some((channel_id, messages.len()));
+            Ok(())
+        });
+
+        let _ = client.start(42).unwrap();
+        let mut sender = client.make_reply_sender();
+        sender.send(RdpewaResponse::with_u32(S_OK, 1));
+
+        let (channel_id, message_count) = captured.lock().unwrap().take().expect("callback invoked");
+        assert_eq!(channel_id, 42);
+        assert!(message_count >= 1);
+    }
+}

--- a/crates/ironrdp-rdpewa/src/client.rs
+++ b/crates/ironrdp-rdpewa/src/client.rs
@@ -239,8 +239,8 @@ impl RdpewaClient {
     fn handle_request(&mut self, request: RdpewaRequest, raw_payload: &[u8]) -> PduResult<Option<RdpewaResponse>> {
         match request.command {
             RpcCommand::ApiVersion => match self.handler.api_version() {
-                Ok(0) => Ok(Some(RdpewaResponse::from_hresult(E_FAIL))),
-                Ok(version) => Ok(Some(RdpewaResponse::with_u32(S_OK, version))),
+                Ok(version) if version != 0 => Ok(Some(RdpewaResponse::with_u32(S_OK, version))),
+                Ok(_) => Ok(Some(RdpewaResponse::from_hresult(E_FAIL))),
                 Err(e) => {
                     warn!(error = %e, "api_version failed");
                     Ok(Some(RdpewaResponse::from_hresult(e.hresult)))
@@ -459,6 +459,54 @@ mod tests {
         let _ = client.start(7).unwrap();
         let messages = client.process(7, &encoded).unwrap();
         assert_eq!(messages.len(), 1);
+    }
+
+    #[test]
+    fn api_version_preserves_handler_hresult() {
+        struct FailingApiHandler;
+
+        impl RdpewaClientHandler for FailingApiHandler {
+            fn api_version(&mut self) -> RdpewaResult<u32> {
+                Err(RdpewaHandlerError::new(0x8123_4567, "custom API version failure"))
+            }
+
+            fn is_uvpaa(&mut self) -> RdpewaResult<bool> {
+                Ok(false)
+            }
+
+            fn cancel_current_operation(&mut self, _cancellation_id: &[u8]) -> RdpewaResult<()> {
+                Ok(())
+            }
+
+            fn begin_webauthn(
+                &mut self,
+                _request: WebAuthnOperationRequest,
+                _reply: RdpewaResponseSender,
+            ) -> RdpewaResult<WebAuthnDispatch> {
+                Err(RdpewaHandlerError::not_impl("not used"))
+            }
+        }
+
+        let mut client = RdpewaClient::new(Box::new(FailingApiHandler));
+        let response = client
+            .handle_request(
+                RdpewaRequest {
+                    command: RpcCommand::ApiVersion,
+                    flags: 0,
+                    rp_id: None,
+                    timeout_ms: 0,
+                    transaction_id: vec![0; 16],
+                    client_data_json: None,
+                    webauthn_para: None,
+                    request_body: Vec::new(),
+                    raw: Default::default(),
+                },
+                &[],
+            )
+            .expect("valid handler dispatch")
+            .expect("synchronous response");
+
+        assert_eq!(response.hresult, 0x8123_4567);
     }
 
     #[test]

--- a/crates/ironrdp-rdpewa/src/client.rs
+++ b/crates/ironrdp-rdpewa/src/client.rs
@@ -238,18 +238,14 @@ impl RdpewaClient {
 
     fn handle_request(&mut self, request: RdpewaRequest, raw_payload: &[u8]) -> PduResult<Option<RdpewaResponse>> {
         match request.command {
-            RpcCommand::ApiVersion => {
-                let version = self.handler.api_version().unwrap_or_else(|e| {
+            RpcCommand::ApiVersion => match self.handler.api_version() {
+                Ok(0) => Ok(Some(RdpewaResponse::from_hresult(E_FAIL))),
+                Ok(version) => Ok(Some(RdpewaResponse::with_u32(S_OK, version))),
+                Err(e) => {
                     warn!(error = %e, "api_version failed");
-                    0
-                });
-                let hresult = if version == 0 { E_FAIL } else { S_OK };
-                if hresult == S_OK {
-                    Ok(Some(RdpewaResponse::with_u32(S_OK, version)))
-                } else {
-                    Ok(Some(RdpewaResponse::from_hresult(hresult)))
+                    Ok(Some(RdpewaResponse::from_hresult(e.hresult)))
                 }
-            }
+            },
             RpcCommand::Iuvpaa => match self.handler.is_uvpaa() {
                 Ok(available) => Ok(Some(RdpewaResponse::with_u32(S_OK, u32::from(available)))),
                 Err(e) => {

--- a/crates/ironrdp-rdpewa/src/client.rs
+++ b/crates/ironrdp-rdpewa/src/client.rs
@@ -293,7 +293,7 @@ impl RdpewaClient {
             subcommand: body.subcommand,
             rp_id: request.rp_id.clone(),
             timeout_ms: request.timeout_ms,
-            transaction_id: request.transaction_id.clone(),
+            transaction_id: request.transaction_id,
             client_data_json,
             para,
             ctap_cbor: body.ctap_cbor,

--- a/crates/ironrdp-rdpewa/src/client.rs
+++ b/crates/ironrdp-rdpewa/src/client.rs
@@ -59,6 +59,11 @@ pub struct WebAuthnOperationRequest {
     pub para: WebAuthnPara,
     /// CTAP CBOR map (without subcommand byte).
     pub ctap_cbor: Vec<u8>,
+    /// Original RDPEWA request CBOR (full map).
+    ///
+    /// Required for hash-only hosts that omit `clientDataJSON`: the Windows backend can forward
+    /// these bytes through `webauthn.dll`'s private remote-RPC path.
+    pub raw_request: Vec<u8>,
 }
 
 /// Successful WebAuthn operation result from the platform backend.
@@ -213,7 +218,8 @@ impl RdpewaClient {
             let messages = match encode_dvc_messages(
                 channel_id,
                 vec![Box::new(RawDataDvcMessage(response_pdu))],
-                ChannelFlags::SHOW_PROTOCOL,
+                // Match ironrdp-dvc-com-plugin / MSTSC Write framing.
+                ChannelFlags::empty(),
             ) {
                 Ok(messages) => messages,
                 Err(error) => {
@@ -224,11 +230,13 @@ impl RdpewaClient {
 
             if let Err(error) = callback(channel_id, messages) {
                 warn!(%error, channel_id, "Failed to submit async RDPEWA DVC response");
+            } else {
+                debug!(channel_id, "Submitted async RDPEWA DVC response");
             }
         })
     }
 
-    fn handle_request(&mut self, request: RdpewaRequest) -> PduResult<Option<RdpewaResponse>> {
+    fn handle_request(&mut self, request: RdpewaRequest, raw_payload: &[u8]) -> PduResult<Option<RdpewaResponse>> {
         match request.command {
             RpcCommand::ApiVersion => {
                 let version = self.handler.api_version().unwrap_or_else(|e| {
@@ -263,14 +271,14 @@ impl RdpewaClient {
                     }
                 }
             }
-            RpcCommand::WebAuthn => self.handle_webauthn(request),
+            RpcCommand::WebAuthn => self.handle_webauthn(request, raw_payload),
             RpcCommand::GetCredentials | RpcCommand::GetAuthenticatorList => {
                 Ok(Some(RdpewaResponse::from_hresult(E_NOTIMPL)))
             }
         }
     }
 
-    fn handle_webauthn(&mut self, request: RdpewaRequest) -> PduResult<Option<RdpewaResponse>> {
+    fn handle_webauthn(&mut self, request: RdpewaRequest, raw_payload: &[u8]) -> PduResult<Option<RdpewaResponse>> {
         let body = match request.webauthn_body() {
             Ok(b) => b,
             Err(e) => {
@@ -289,6 +297,7 @@ impl RdpewaClient {
             client_data_json,
             para,
             ctap_cbor: body.ctap_cbor,
+            raw_request: raw_payload.to_vec(),
         };
 
         let reply = self.make_reply_sender();
@@ -336,7 +345,7 @@ impl DvcProcessor for RdpewaClient {
         let request = RdpewaRequest::decode(payload).map_err(|e| decode_err!(e))?;
         debug!(?request.command, "Received RDPEWA request");
 
-        match self.handle_request(request)? {
+        match self.handle_request(request, payload)? {
             Some(response) => Ok(vec![Box::new(response)]),
             None => Ok(Vec::new()),
         }

--- a/crates/ironrdp-rdpewa/src/client.rs
+++ b/crates/ironrdp-rdpewa/src/client.rs
@@ -3,7 +3,9 @@
 use std::sync::Arc;
 
 use ironrdp_core::{Encode, EncodeResult, WriteCursor, ensure_size, impl_as_any};
-use ironrdp_dvc::{DvcClientProcessor, DvcEncode, DvcMessage, DvcProcessor, encode_dvc_messages};
+use ironrdp_dvc::{
+    DvcChannelListener, DvcClientProcessor, DvcEncode, DvcMessage, DvcProcessor, DynamicChannelId, encode_dvc_messages,
+};
 use ironrdp_pdu::{PduResult, decode_err};
 use ironrdp_svc::{ChannelFlags, SvcMessage};
 use tracing::{debug, warn};
@@ -343,6 +345,40 @@ impl DvcProcessor for RdpewaClient {
 
 impl DvcClientProcessor for RdpewaClient {}
 
+/// Builds a fresh [`RdpewaClient`] for each DVC create of [`CHANNEL_NAME`].
+///
+/// Windows opens and closes `WebAuthN_Channel` around individual WebAuthn RPCs.
+/// Register this listener with [`ironrdp_dvc::DrdynvcClient::with_listener`] instead of a
+/// one-shot [`RdpewaClient`] so later creates are not rejected with `NO_LISTENER`.
+pub struct RdpewaClientListener<F>
+where
+    F: FnMut() -> RdpewaClient + Send,
+{
+    factory: F,
+}
+
+impl<F> RdpewaClientListener<F>
+where
+    F: FnMut() -> RdpewaClient + Send,
+{
+    pub fn new(factory: F) -> Self {
+        Self { factory }
+    }
+}
+
+impl<F> DvcChannelListener for RdpewaClientListener<F>
+where
+    F: FnMut() -> RdpewaClient + Send + 'static,
+{
+    fn channel_name(&self) -> &str {
+        CHANNEL_NAME
+    }
+
+    fn create(&mut self, _channel_id: DynamicChannelId) -> Option<Box<dyn DvcClientProcessor>> {
+        Some(Box::new((self.factory)()))
+    }
+}
+
 struct RawDataDvcMessage(Vec<u8>);
 
 impl Encode for RawDataDvcMessage {
@@ -442,5 +478,23 @@ mod tests {
         let (channel_id, message_count) = captured.lock().unwrap().take().expect("callback invoked");
         assert_eq!(channel_id, 42);
         assert!(message_count >= 1);
+    }
+
+    #[test]
+    fn listener_creates_independent_clients() {
+        let mut listener = RdpewaClientListener::new(|| {
+            RdpewaClient::new(Box::new(StubRdpewaHandler {
+                api_version: 7,
+                uvpaa: true,
+            }))
+        });
+
+        let mut first = listener.create(10).expect("first create");
+        let mut second = listener.create(11).expect("second create");
+        assert_eq!(first.channel_name(), CHANNEL_NAME);
+        assert_eq!(second.channel_name(), CHANNEL_NAME);
+
+        let _ = first.start(10).unwrap();
+        let _ = second.start(11).unwrap();
     }
 }

--- a/crates/ironrdp-rdpewa/src/lib.rs
+++ b/crates/ironrdp-rdpewa/src/lib.rs
@@ -1,0 +1,23 @@
+#![cfg_attr(doc, doc = include_str!("../README.md"))]
+#![doc(html_logo_url = "https://cdnweb.devolutions.net/images/projects/devolutions/logos/devolutions-icon-shadow.svg")]
+
+//! MS-RDPEWA WebAuthn dynamic virtual channel.
+
+/// DVC channel name per [MS-RDPEWA].
+///
+/// [MS-RDPEWA]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpewa/
+pub const CHANNEL_NAME: &str = "WebAuthN_Channel";
+
+pub mod client;
+pub mod pdu;
+pub mod server;
+
+pub use client::{
+    RdpewaClient, RdpewaClientHandler, RdpewaHandlerError, RdpewaResponseSender, RdpewaResult, StubRdpewaHandler,
+    WebAuthnDispatch, WebAuthnOperationRequest, WebAuthnOperationResponse,
+};
+pub use pdu::{
+    Attachment, Attestation, DeviceInfo, E_ABORT, E_FAIL, E_INVALIDARG, E_NOTIMPL, RdpewaRequest, RdpewaResponse,
+    RpcCommand, S_OK, UserVerification, WebAuthnPara, WebAuthnRequestBody, WebAuthnResponsePayload, WebAuthnSubcommand,
+};
+pub use server::RdpewaServer;

--- a/crates/ironrdp-rdpewa/src/lib.rs
+++ b/crates/ironrdp-rdpewa/src/lib.rs
@@ -13,8 +13,8 @@ pub mod pdu;
 pub mod server;
 
 pub use client::{
-    RdpewaClient, RdpewaClientHandler, RdpewaHandlerError, RdpewaResponseSender, RdpewaResult, StubRdpewaHandler,
-    WebAuthnDispatch, WebAuthnOperationRequest, WebAuthnOperationResponse,
+    RdpewaClient, RdpewaClientHandler, RdpewaClientListener, RdpewaHandlerError, RdpewaResponseSender, RdpewaResult,
+    StubRdpewaHandler, WebAuthnDispatch, WebAuthnOperationRequest, WebAuthnOperationResponse,
 };
 pub use pdu::{
     Attachment, Attestation, DeviceInfo, E_ABORT, E_FAIL, E_INVALIDARG, E_NOTIMPL, RdpewaRequest, RdpewaResponse,

--- a/crates/ironrdp-rdpewa/src/lib.rs
+++ b/crates/ironrdp-rdpewa/src/lib.rs
@@ -17,7 +17,8 @@ pub use client::{
     StubRdpewaHandler, WebAuthnDispatch, WebAuthnOperationRequest, WebAuthnOperationResponse,
 };
 pub use pdu::{
-    Attachment, Attestation, DeviceInfo, E_ABORT, E_FAIL, E_INVALIDARG, E_NOTIMPL, RdpewaRequest, RdpewaResponse,
-    RpcCommand, S_OK, UserVerification, WebAuthnPara, WebAuthnRequestBody, WebAuthnResponsePayload, WebAuthnSubcommand,
+    Attachment, Attestation, DeviceInfo, E_ABORT, E_BUSY, E_FAIL, E_INVALIDARG, E_NOTIMPL, RdpewaRequest,
+    RdpewaResponse, RpcCommand, S_OK, UserVerification, WebAuthnPara, WebAuthnRequestBody, WebAuthnResponsePayload,
+    WebAuthnSubcommand,
 };
 pub use server::RdpewaServer;

--- a/crates/ironrdp-rdpewa/src/pdu/cbor.rs
+++ b/crates/ironrdp-rdpewa/src/pdu/cbor.rs
@@ -35,7 +35,19 @@ impl CborKey {
     }
 }
 
+/// Maximum nesting depth for recursive CBOR arrays/maps.
+///
+/// Hostile DVC payloads can otherwise force deep recursion and exhaust the stack.
+const MAX_CBOR_DEPTH: u32 = 32;
+
 pub fn decode_value(src: &mut ReadCursor<'_>) -> DecodeResult<CborValue> {
+    decode_value_at_depth(src, 0)
+}
+
+fn decode_value_at_depth(src: &mut ReadCursor<'_>, depth: u32) -> DecodeResult<CborValue> {
+    if depth > MAX_CBOR_DEPTH {
+        return Err(invalid_field_err!("cbor", "depth", "maximum nesting depth exceeded"));
+    }
     if src.is_empty() {
         return Err(invalid_field_err!("cbor", "input", "unexpected end of input"));
     }
@@ -70,7 +82,7 @@ pub fn decode_value(src: &mut ReadCursor<'_>) -> DecodeResult<CborValue> {
             let len = usize_from_u64(read_uint(src, additional)?)?;
             let mut items = Vec::with_capacity(len.min(64));
             for _ in 0..len {
-                items.push(decode_value(src)?);
+                items.push(decode_value_at_depth(src, depth + 1)?);
             }
             Ok(CborValue::Array(items))
         }
@@ -78,8 +90,8 @@ pub fn decode_value(src: &mut ReadCursor<'_>) -> DecodeResult<CborValue> {
             let len = usize_from_u64(read_uint(src, additional)?)?;
             let mut map = BTreeMap::new();
             for _ in 0..len {
-                let key = decode_key(src)?;
-                let value = decode_value(src)?;
+                let key = decode_key(src, depth + 1)?;
+                let value = decode_value_at_depth(src, depth + 1)?;
                 map.insert(key, value);
             }
             Ok(CborValue::Map(map))
@@ -114,8 +126,8 @@ pub fn decode_value(src: &mut ReadCursor<'_>) -> DecodeResult<CborValue> {
     }
 }
 
-fn decode_key(src: &mut ReadCursor<'_>) -> DecodeResult<CborKey> {
-    match decode_value(src)? {
+fn decode_key(src: &mut ReadCursor<'_>, depth: u32) -> DecodeResult<CborKey> {
+    match decode_value_at_depth(src, depth)? {
         CborValue::Text(s) => Ok(CborKey::Text(s)),
         CborValue::Unsigned(n) => {
             let v = i64::try_from(n).map_err(|_| invalid_field_err!("cbor", "key", "int out of range"))?;
@@ -461,5 +473,14 @@ mod tests {
         let decoded = decode_all(&encoded).unwrap();
         let m = decoded.as_map().unwrap();
         assert_eq!(m.get(&CborKey::text("command")).unwrap().as_u32().unwrap(), 8);
+    }
+
+    #[test]
+    fn decode_rejects_excessive_nesting() {
+        // Nested arrays: 0x81 repeats = one-element array wrappers.
+        let depth = usize::try_from(MAX_CBOR_DEPTH + 2).expect("depth fits usize");
+        let mut payload = vec![0x81u8; depth];
+        payload.push(0x00); // unsigned 0 leaf
+        assert!(decode_all(&payload).is_err());
     }
 }

--- a/crates/ironrdp-rdpewa/src/pdu/cbor.rs
+++ b/crates/ironrdp-rdpewa/src/pdu/cbor.rs
@@ -1,0 +1,442 @@
+//! Minimal CBOR subset for MS-RDPEWA request/response maps.
+//!
+//! Multi-byte CBOR integers use network byte order (big-endian).
+
+use ironrdp_core::{DecodeResult, EncodeResult, ReadCursor, WriteCursor, invalid_field_err, other_err};
+use std::collections::BTreeMap;
+
+/// CBOR values needed by MS-RDPEWA.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CborValue {
+    Unsigned(u64),
+    Negative(i64),
+    Bytes(Vec<u8>),
+    Text(String),
+    Array(Vec<CborValue>),
+    Map(BTreeMap<CborKey, CborValue>),
+    Bool(bool),
+    Null,
+    Simple(u8),
+    Float(f64),
+    /// Opaque nested CBOR kept as raw bytes.
+    Raw(Vec<u8>),
+}
+
+/// Map keys used by MS-RDPEWA (text or integer).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum CborKey {
+    Text(String),
+    Int(i64),
+}
+
+impl CborKey {
+    pub fn text(s: impl Into<String>) -> Self {
+        Self::Text(s.into())
+    }
+}
+
+pub fn decode_value(src: &mut ReadCursor<'_>) -> DecodeResult<CborValue> {
+    if src.is_empty() {
+        return Err(invalid_field_err!("cbor", "input", "unexpected end of input"));
+    }
+    let initial = src.read_u8();
+    let major = initial >> 5;
+    let additional = initial & 0x1f;
+    match major {
+        0 => Ok(CborValue::Unsigned(read_uint(src, additional)?)),
+        1 => {
+            let n = read_uint(src, additional)?;
+            let n_i64 = i64::try_from(n).map_err(|_| invalid_field_err!("cbor", "negative", "out of range"))?;
+            let v = (-1i64)
+                .checked_sub(n_i64)
+                .ok_or_else(|| invalid_field_err!("cbor", "negative", "overflow"))?;
+            Ok(CborValue::Negative(v))
+        }
+        2 => {
+            let len = usize_from_u64(read_uint(src, additional)?)?;
+            ensure_remaining(src, len)?;
+            Ok(CborValue::Bytes(src.read_slice(len).to_vec()))
+        }
+        3 => {
+            let len = usize_from_u64(read_uint(src, additional)?)?;
+            ensure_remaining(src, len)?;
+            let bytes = src.read_slice(len);
+            let text = core::str::from_utf8(bytes)
+                .map_err(|_| invalid_field_err!("cbor", "text", "not utf-8"))?
+                .to_owned();
+            Ok(CborValue::Text(text))
+        }
+        4 => {
+            let len = usize_from_u64(read_uint(src, additional)?)?;
+            let mut items = Vec::with_capacity(len.min(64));
+            for _ in 0..len {
+                items.push(decode_value(src)?);
+            }
+            Ok(CborValue::Array(items))
+        }
+        5 => {
+            let len = usize_from_u64(read_uint(src, additional)?)?;
+            let mut map = BTreeMap::new();
+            for _ in 0..len {
+                let key = decode_key(src)?;
+                let value = decode_value(src)?;
+                map.insert(key, value);
+            }
+            Ok(CborValue::Map(map))
+        }
+        7 => match additional {
+            20 => Ok(CborValue::Bool(false)),
+            21 => Ok(CborValue::Bool(true)),
+            22 => Ok(CborValue::Null),
+            25 => {
+                ensure_remaining(src, 2)?;
+                let bits = src.read_u16_be();
+                Ok(CborValue::Float(f64::from(half_to_f32(bits))))
+            }
+            26 => {
+                ensure_remaining(src, 4)?;
+                let bits = src.read_u32_be();
+                Ok(CborValue::Float(f64::from(f32::from_bits(bits))))
+            }
+            27 => {
+                ensure_remaining(src, 8)?;
+                let bits = src.read_u64_be();
+                Ok(CborValue::Float(f64::from_bits(bits)))
+            }
+            24 => {
+                ensure_remaining(src, 1)?;
+                Ok(CborValue::Simple(src.read_u8()))
+            }
+            n if n < 24 => Ok(CborValue::Simple(n)),
+            _ => Err(invalid_field_err!("cbor", "simple", "unsupported simple/float value")),
+        },
+        _ => Err(invalid_field_err!("cbor", "major", "unsupported major type")),
+    }
+}
+
+fn decode_key(src: &mut ReadCursor<'_>) -> DecodeResult<CborKey> {
+    match decode_value(src)? {
+        CborValue::Text(s) => Ok(CborKey::Text(s)),
+        CborValue::Unsigned(n) => {
+            let v = i64::try_from(n).map_err(|_| invalid_field_err!("cbor", "key", "int out of range"))?;
+            Ok(CborKey::Int(v))
+        }
+        CborValue::Negative(n) => Ok(CborKey::Int(n)),
+        _ => Err(invalid_field_err!("cbor", "key", "unsupported map key type")),
+    }
+}
+
+pub fn encode_value(dst: &mut WriteCursor<'_>, value: &CborValue) -> EncodeResult<()> {
+    match value {
+        CborValue::Unsigned(n) => write_type_uint(dst, 0, *n),
+        CborValue::Negative(n) => {
+            let stored = (-1i64)
+                .checked_sub(*n)
+                .ok_or_else(|| other_err!("cbor", "negative encode overflow"))?;
+            let stored = u64::try_from(stored).map_err(|_| other_err!("cbor", "negative encode range"))?;
+            write_type_uint(dst, 1, stored)
+        }
+        CborValue::Bytes(b) => {
+            write_type_uint(dst, 2, b.len() as u64)?;
+            dst.write_slice(b);
+            Ok(())
+        }
+        CborValue::Text(s) => {
+            write_type_uint(dst, 3, s.len() as u64)?;
+            dst.write_slice(s.as_bytes());
+            Ok(())
+        }
+        CborValue::Array(items) => {
+            write_type_uint(dst, 4, items.len() as u64)?;
+            for item in items {
+                encode_value(dst, item)?;
+            }
+            Ok(())
+        }
+        CborValue::Map(map) => {
+            write_type_uint(dst, 5, map.len() as u64)?;
+            for (key, val) in map {
+                encode_key(dst, key)?;
+                encode_value(dst, val)?;
+            }
+            Ok(())
+        }
+        CborValue::Bool(false) => {
+            dst.write_u8(0xf4);
+            Ok(())
+        }
+        CborValue::Bool(true) => {
+            dst.write_u8(0xf5);
+            Ok(())
+        }
+        CborValue::Null => {
+            dst.write_u8(0xf6);
+            Ok(())
+        }
+        CborValue::Simple(n) => {
+            if *n < 24 {
+                dst.write_u8(0xe0 | n);
+            } else {
+                dst.write_u8(0xf8);
+                dst.write_u8(*n);
+            }
+            Ok(())
+        }
+        CborValue::Float(f) => {
+            dst.write_u8(0xfb);
+            dst.write_u64_be(f.to_bits());
+            Ok(())
+        }
+        CborValue::Raw(bytes) => {
+            dst.write_slice(bytes);
+            Ok(())
+        }
+    }
+}
+
+fn encode_key(dst: &mut WriteCursor<'_>, key: &CborKey) -> EncodeResult<()> {
+    match key {
+        CborKey::Text(s) => encode_value(dst, &CborValue::Text(s.clone())),
+        CborKey::Int(n) if *n >= 0 => encode_value(dst, &CborValue::Unsigned(*n as u64)),
+        CborKey::Int(n) => encode_value(dst, &CborValue::Negative(*n)),
+    }
+}
+
+pub fn encoded_size(value: &CborValue) -> usize {
+    match value {
+        CborValue::Unsigned(n) => 1 + uint_extra_len(*n),
+        CborValue::Negative(v) => {
+            let n = (-1i64 - v) as u64;
+            1 + uint_extra_len(n)
+        }
+        CborValue::Bytes(b) => 1 + uint_extra_len(b.len() as u64) + b.len(),
+        CborValue::Text(s) => 1 + uint_extra_len(s.len() as u64) + s.len(),
+        CborValue::Array(items) => {
+            1 + uint_extra_len(items.len() as u64) + items.iter().map(encoded_size).sum::<usize>()
+        }
+        CborValue::Map(map) => {
+            1 + uint_extra_len(map.len() as u64) + map.iter().map(|(k, v)| key_size(k) + encoded_size(v)).sum::<usize>()
+        }
+        CborValue::Bool(_) | CborValue::Null => 1,
+        CborValue::Simple(n) if *n < 24 => 1,
+        CborValue::Simple(_) => 2,
+        CborValue::Float(_) => 9,
+        CborValue::Raw(b) => b.len(),
+    }
+}
+
+fn key_size(key: &CborKey) -> usize {
+    match key {
+        CborKey::Text(s) => encoded_size(&CborValue::Text(s.clone())),
+        CborKey::Int(n) if *n >= 0 => encoded_size(&CborValue::Unsigned(*n as u64)),
+        CborKey::Int(n) => encoded_size(&CborValue::Negative(*n)),
+    }
+}
+
+fn uint_extra_len(n: u64) -> usize {
+    if n < 24 {
+        0
+    } else if n <= u64::from(u8::MAX) {
+        1
+    } else if n <= u64::from(u16::MAX) {
+        2
+    } else if n <= u64::from(u32::MAX) {
+        4
+    } else {
+        8
+    }
+}
+
+fn write_type_uint(dst: &mut WriteCursor<'_>, major: u8, n: u64) -> EncodeResult<()> {
+    let major_shift = major << 5;
+    if n < 24 {
+        dst.write_u8(major_shift | (n as u8));
+    } else if n <= u64::from(u8::MAX) {
+        dst.write_u8(major_shift | 24);
+        dst.write_u8(n as u8);
+    } else if n <= u64::from(u16::MAX) {
+        dst.write_u8(major_shift | 25);
+        dst.write_u16_be(n as u16);
+    } else if n <= u64::from(u32::MAX) {
+        dst.write_u8(major_shift | 26);
+        dst.write_u32_be(n as u32);
+    } else {
+        dst.write_u8(major_shift | 27);
+        dst.write_u64_be(n);
+    }
+    Ok(())
+}
+
+fn read_uint(src: &mut ReadCursor<'_>, additional: u8) -> DecodeResult<u64> {
+    match additional {
+        n if n < 24 => Ok(u64::from(n)),
+        24 => {
+            ensure_remaining(src, 1)?;
+            Ok(u64::from(src.read_u8()))
+        }
+        25 => {
+            ensure_remaining(src, 2)?;
+            Ok(u64::from(src.read_u16_be()))
+        }
+        26 => {
+            ensure_remaining(src, 4)?;
+            Ok(u64::from(src.read_u32_be()))
+        }
+        27 => {
+            ensure_remaining(src, 8)?;
+            Ok(src.read_u64_be())
+        }
+        _ => Err(invalid_field_err!(
+            "cbor",
+            "uint",
+            "unsupported integer additional info"
+        )),
+    }
+}
+
+fn usize_from_u64(n: u64) -> DecodeResult<usize> {
+    usize::try_from(n).map_err(|_| invalid_field_err!("cbor", "length", "does not fit in usize"))
+}
+
+fn ensure_remaining(src: &ReadCursor<'_>, n: usize) -> DecodeResult<()> {
+    if src.len() < n {
+        Err(invalid_field_err!("cbor", "input", "not enough bytes"))
+    } else {
+        Ok(())
+    }
+}
+
+fn half_to_f32(bits: u16) -> f32 {
+    let sign = (bits >> 15) & 1;
+    let exp = (bits >> 10) & 0x1f;
+    let frac = bits & 0x3ff;
+    let sign_f = if sign == 0 { 1.0f32 } else { -1.0f32 };
+    if exp == 0 {
+        if frac == 0 {
+            return 0.0 * sign_f;
+        }
+        return sign_f * f32::from(frac) * 2f32.powi(-24);
+    }
+    if exp == 31 {
+        if frac == 0 {
+            return sign_f * f32::INFINITY;
+        }
+        return f32::NAN;
+    }
+    sign_f * (1.0 + f32::from(frac) / 1024.0) * 2f32.powi(i32::from(exp) - 15)
+}
+
+pub fn encode_to_vec(value: &CborValue) -> EncodeResult<Vec<u8>> {
+    let mut buf = vec![0u8; encoded_size(value)];
+    let mut cursor = WriteCursor::new(&mut buf);
+    encode_value(&mut cursor, value)?;
+    Ok(buf)
+}
+
+pub fn decode_all(data: &[u8]) -> DecodeResult<CborValue> {
+    let mut cursor = ReadCursor::new(data);
+    let value = decode_value(&mut cursor)?;
+    if !cursor.is_empty() {
+        return Err(invalid_field_err!("cbor", "input", "trailing bytes after value"));
+    }
+    Ok(value)
+}
+
+impl CborValue {
+    pub fn as_u32(&self) -> DecodeResult<u32> {
+        match self {
+            CborValue::Unsigned(n) => {
+                u32::try_from(*n).map_err(|_| invalid_field_err!("cbor", "uint", "u32 out of range"))
+            }
+            _ => Err(invalid_field_err!("cbor", "uint", "expected unsigned integer")),
+        }
+    }
+
+    pub fn as_i64(&self) -> DecodeResult<i64> {
+        match self {
+            CborValue::Unsigned(n) => {
+                i64::try_from(*n).map_err(|_| invalid_field_err!("cbor", "int", "i64 out of range"))
+            }
+            CborValue::Negative(n) => Ok(*n),
+            _ => Err(invalid_field_err!("cbor", "int", "expected integer")),
+        }
+    }
+
+    pub fn as_u64(&self) -> DecodeResult<u64> {
+        match self {
+            CborValue::Unsigned(n) => Ok(*n),
+            _ => Err(invalid_field_err!("cbor", "uint", "expected unsigned integer")),
+        }
+    }
+
+    pub fn as_bool(&self) -> DecodeResult<bool> {
+        match self {
+            CborValue::Bool(b) => Ok(*b),
+            _ => Err(invalid_field_err!("cbor", "bool", "expected boolean")),
+        }
+    }
+
+    pub fn as_bytes(&self) -> DecodeResult<&[u8]> {
+        match self {
+            CborValue::Bytes(b) => Ok(b),
+            _ => Err(invalid_field_err!("cbor", "bytes", "expected byte string")),
+        }
+    }
+
+    pub fn as_text(&self) -> DecodeResult<&str> {
+        match self {
+            CborValue::Text(s) => Ok(s),
+            _ => Err(invalid_field_err!("cbor", "text", "expected text string")),
+        }
+    }
+
+    pub fn as_map(&self) -> DecodeResult<&BTreeMap<CborKey, CborValue>> {
+        match self {
+            CborValue::Map(m) => Ok(m),
+            _ => Err(invalid_field_err!("cbor", "map", "expected map")),
+        }
+    }
+
+    pub fn into_map(self) -> DecodeResult<BTreeMap<CborKey, CborValue>> {
+        match self {
+            CborValue::Map(m) => Ok(m),
+            _ => Err(invalid_field_err!("cbor", "map", "expected map")),
+        }
+    }
+
+    pub fn as_array(&self) -> DecodeResult<&[CborValue]> {
+        match self {
+            CborValue::Array(a) => Ok(a),
+            _ => Err(invalid_field_err!("cbor", "array", "expected array")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_simple_map() {
+        let mut map = BTreeMap::new();
+        map.insert(CborKey::text("command"), CborValue::Unsigned(8));
+        map.insert(CborKey::text("flags"), CborValue::Unsigned(0));
+        let value = CborValue::Map(map);
+        let encoded = encode_to_vec(&value).unwrap();
+        let decoded = decode_all(&encoded).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn decode_api_version_request() {
+        let mut map = BTreeMap::new();
+        map.insert(CborKey::text("command"), CborValue::Unsigned(8));
+        map.insert(CborKey::text("flags"), CborValue::Unsigned(0));
+        map.insert(CborKey::text("timeout"), CborValue::Unsigned(0));
+        map.insert(CborKey::text("transactionId"), CborValue::Bytes(vec![0; 16]));
+        let encoded = encode_to_vec(&CborValue::Map(map)).unwrap();
+        let decoded = decode_all(&encoded).unwrap();
+        let m = decoded.as_map().unwrap();
+        assert_eq!(m.get(&CborKey::text("command")).unwrap().as_u32().unwrap(), 8);
+    }
+}

--- a/crates/ironrdp-rdpewa/src/pdu/cbor.rs
+++ b/crates/ironrdp-rdpewa/src/pdu/cbor.rs
@@ -5,6 +5,8 @@
 use ironrdp_core::{DecodeResult, EncodeResult, ReadCursor, WriteCursor, invalid_field_err, other_err};
 use std::collections::BTreeMap;
 
+const MAX_NESTING_DEPTH: usize = 32;
+
 /// CBOR values needed by MS-RDPEWA.
 #[derive(Debug, Clone, PartialEq)]
 pub enum CborValue {
@@ -35,19 +37,11 @@ impl CborKey {
     }
 }
 
-/// Maximum nesting depth for recursive CBOR arrays/maps.
-///
-/// Hostile DVC payloads can otherwise force deep recursion and exhaust the stack.
-const MAX_CBOR_DEPTH: u32 = 32;
-
 pub fn decode_value(src: &mut ReadCursor<'_>) -> DecodeResult<CborValue> {
-    decode_value_at_depth(src, 0)
+    decode_value_with_depth(src, 0)
 }
 
-fn decode_value_at_depth(src: &mut ReadCursor<'_>, depth: u32) -> DecodeResult<CborValue> {
-    if depth > MAX_CBOR_DEPTH {
-        return Err(invalid_field_err!("cbor", "depth", "maximum nesting depth exceeded"));
-    }
+fn decode_value_with_depth(src: &mut ReadCursor<'_>, depth: usize) -> DecodeResult<CborValue> {
     if src.is_empty() {
         return Err(invalid_field_err!("cbor", "input", "unexpected end of input"));
     }
@@ -79,19 +73,21 @@ fn decode_value_at_depth(src: &mut ReadCursor<'_>, depth: u32) -> DecodeResult<C
             Ok(CborValue::Text(text))
         }
         4 => {
+            ensure_nesting_depth(depth)?;
             let len = usize_from_u64(read_uint(src, additional)?)?;
             let mut items = Vec::with_capacity(len.min(64));
             for _ in 0..len {
-                items.push(decode_value_at_depth(src, depth + 1)?);
+                items.push(decode_value_with_depth(src, depth + 1)?);
             }
             Ok(CborValue::Array(items))
         }
         5 => {
+            ensure_nesting_depth(depth)?;
             let len = usize_from_u64(read_uint(src, additional)?)?;
             let mut map = BTreeMap::new();
             for _ in 0..len {
                 let key = decode_key(src, depth + 1)?;
-                let value = decode_value_at_depth(src, depth + 1)?;
+                let value = decode_value_with_depth(src, depth + 1)?;
                 map.insert(key, value);
             }
             Ok(CborValue::Map(map))
@@ -126,8 +122,16 @@ fn decode_value_at_depth(src: &mut ReadCursor<'_>, depth: u32) -> DecodeResult<C
     }
 }
 
-fn decode_key(src: &mut ReadCursor<'_>, depth: u32) -> DecodeResult<CborKey> {
-    match decode_value_at_depth(src, depth)? {
+fn ensure_nesting_depth(depth: usize) -> DecodeResult<()> {
+    if depth >= MAX_NESTING_DEPTH {
+        Err(invalid_field_err!("cbor", "input", "maximum nesting depth exceeded"))
+    } else {
+        Ok(())
+    }
+}
+
+fn decode_key(src: &mut ReadCursor<'_>, depth: usize) -> DecodeResult<CborKey> {
+    match decode_value_with_depth(src, depth)? {
         CborValue::Text(s) => Ok(CborKey::Text(s)),
         CborValue::Unsigned(n) => {
             let v = i64::try_from(n).map_err(|_| invalid_field_err!("cbor", "key", "int out of range"))?;
@@ -476,11 +480,11 @@ mod tests {
     }
 
     #[test]
-    fn decode_rejects_excessive_nesting() {
-        // Nested arrays: 0x81 repeats = one-element array wrappers.
-        let depth = usize::try_from(MAX_CBOR_DEPTH + 2).expect("depth fits usize");
-        let mut payload = vec![0x81u8; depth];
-        payload.push(0x00); // unsigned 0 leaf
-        assert!(decode_all(&payload).is_err());
+    fn rejects_excessively_nested_values() {
+        let mut encoded = vec![0x81; MAX_NESTING_DEPTH + 1];
+        encoded.push(0xf6);
+
+        let error = decode_all(&encoded).expect_err("nested CBOR must be rejected");
+        assert!(error.to_string().contains("maximum nesting depth"), "{error}");
     }
 }

--- a/crates/ironrdp-rdpewa/src/pdu/cbor.rs
+++ b/crates/ironrdp-rdpewa/src/pdu/cbor.rs
@@ -137,24 +137,24 @@ pub fn encode_value(dst: &mut WriteCursor<'_>, value: &CborValue) -> EncodeResul
             write_type_uint(dst, 1, stored)
         }
         CborValue::Bytes(b) => {
-            write_type_uint(dst, 2, b.len() as u64)?;
+            write_type_uint(dst, 2, u64_from_usize(b.len())?)?;
             dst.write_slice(b);
             Ok(())
         }
         CborValue::Text(s) => {
-            write_type_uint(dst, 3, s.len() as u64)?;
+            write_type_uint(dst, 3, u64_from_usize(s.len())?)?;
             dst.write_slice(s.as_bytes());
             Ok(())
         }
         CborValue::Array(items) => {
-            write_type_uint(dst, 4, items.len() as u64)?;
+            write_type_uint(dst, 4, u64_from_usize(items.len())?)?;
             for item in items {
                 encode_value(dst, item)?;
             }
             Ok(())
         }
         CborValue::Map(map) => {
-            write_type_uint(dst, 5, map.len() as u64)?;
+            write_type_uint(dst, 5, u64_from_usize(map.len())?)?;
             for (key, val) in map {
                 encode_key(dst, key)?;
                 encode_value(dst, val)?;
@@ -197,7 +197,10 @@ pub fn encode_value(dst: &mut WriteCursor<'_>, value: &CborValue) -> EncodeResul
 fn encode_key(dst: &mut WriteCursor<'_>, key: &CborKey) -> EncodeResult<()> {
     match key {
         CborKey::Text(s) => encode_value(dst, &CborValue::Text(s.clone())),
-        CborKey::Int(n) if *n >= 0 => encode_value(dst, &CborValue::Unsigned(*n as u64)),
+        CborKey::Int(n) if *n >= 0 => {
+            let unsigned = u64::try_from(*n).map_err(|_| other_err!("cbor", "key int out of range"))?;
+            encode_value(dst, &CborValue::Unsigned(unsigned))
+        }
         CborKey::Int(n) => encode_value(dst, &CborValue::Negative(*n)),
     }
 }
@@ -206,16 +209,17 @@ pub fn encoded_size(value: &CborValue) -> usize {
     match value {
         CborValue::Unsigned(n) => 1 + uint_extra_len(*n),
         CborValue::Negative(v) => {
-            let n = (-1i64 - v) as u64;
+            let n = negative_to_stored_uint(*v).unwrap_or(u64::MAX);
             1 + uint_extra_len(n)
         }
-        CborValue::Bytes(b) => 1 + uint_extra_len(b.len() as u64) + b.len(),
-        CborValue::Text(s) => 1 + uint_extra_len(s.len() as u64) + s.len(),
+        CborValue::Bytes(b) => 1 + uint_extra_len(u64_from_usize_lossy(b.len())) + b.len(),
+        CborValue::Text(s) => 1 + uint_extra_len(u64_from_usize_lossy(s.len())) + s.len(),
         CborValue::Array(items) => {
-            1 + uint_extra_len(items.len() as u64) + items.iter().map(encoded_size).sum::<usize>()
+            1 + uint_extra_len(u64_from_usize_lossy(items.len())) + items.iter().map(encoded_size).sum::<usize>()
         }
         CborValue::Map(map) => {
-            1 + uint_extra_len(map.len() as u64) + map.iter().map(|(k, v)| key_size(k) + encoded_size(v)).sum::<usize>()
+            1 + uint_extra_len(u64_from_usize_lossy(map.len()))
+                + map.iter().map(|(k, v)| key_size(k) + encoded_size(v)).sum::<usize>()
         }
         CborValue::Bool(_) | CborValue::Null => 1,
         CborValue::Simple(n) if *n < 24 => 1,
@@ -228,7 +232,10 @@ pub fn encoded_size(value: &CborValue) -> usize {
 fn key_size(key: &CborKey) -> usize {
     match key {
         CborKey::Text(s) => encoded_size(&CborValue::Text(s.clone())),
-        CborKey::Int(n) if *n >= 0 => encoded_size(&CborValue::Unsigned(*n as u64)),
+        CborKey::Int(n) if *n >= 0 => {
+            let unsigned = u64::try_from(*n).unwrap_or(u64::MAX);
+            encoded_size(&CborValue::Unsigned(unsigned))
+        }
         CborKey::Int(n) => encoded_size(&CborValue::Negative(*n)),
     }
 }
@@ -236,11 +243,11 @@ fn key_size(key: &CborKey) -> usize {
 fn uint_extra_len(n: u64) -> usize {
     if n < 24 {
         0
-    } else if n <= u64::from(u8::MAX) {
+    } else if u8::try_from(n).is_ok() {
         1
-    } else if n <= u64::from(u16::MAX) {
+    } else if u16::try_from(n).is_ok() {
         2
-    } else if n <= u64::from(u32::MAX) {
+    } else if u32::try_from(n).is_ok() {
         4
     } else {
         8
@@ -250,21 +257,37 @@ fn uint_extra_len(n: u64) -> usize {
 fn write_type_uint(dst: &mut WriteCursor<'_>, major: u8, n: u64) -> EncodeResult<()> {
     let major_shift = major << 5;
     if n < 24 {
-        dst.write_u8(major_shift | (n as u8));
-    } else if n <= u64::from(u8::MAX) {
+        let n_u8 = u8::try_from(n).map_err(|_| other_err!("cbor", "uint additional info out of range"))?;
+        dst.write_u8(major_shift | n_u8);
+    } else if let Ok(n_u8) = u8::try_from(n) {
         dst.write_u8(major_shift | 24);
-        dst.write_u8(n as u8);
-    } else if n <= u64::from(u16::MAX) {
+        dst.write_u8(n_u8);
+    } else if let Ok(n_u16) = u16::try_from(n) {
         dst.write_u8(major_shift | 25);
-        dst.write_u16_be(n as u16);
-    } else if n <= u64::from(u32::MAX) {
+        dst.write_u16_be(n_u16);
+    } else if let Ok(n_u32) = u32::try_from(n) {
         dst.write_u8(major_shift | 26);
-        dst.write_u32_be(n as u32);
+        dst.write_u32_be(n_u32);
     } else {
         dst.write_u8(major_shift | 27);
         dst.write_u64_be(n);
     }
     Ok(())
+}
+
+fn u64_from_usize(n: usize) -> EncodeResult<u64> {
+    u64::try_from(n).map_err(|_| other_err!("cbor", "length does not fit in u64"))
+}
+
+fn u64_from_usize_lossy(n: usize) -> u64 {
+    u64::try_from(n).unwrap_or(u64::MAX)
+}
+
+fn negative_to_stored_uint(v: i64) -> EncodeResult<u64> {
+    let stored = (-1i64)
+        .checked_sub(v)
+        .ok_or_else(|| other_err!("cbor", "negative encode overflow"))?;
+    u64::try_from(stored).map_err(|_| other_err!("cbor", "negative encode range"))
 }
 
 fn read_uint(src: &mut ReadCursor<'_>, additional: u8) -> DecodeResult<u64> {

--- a/crates/ironrdp-rdpewa/src/pdu/mod.rs
+++ b/crates/ironrdp-rdpewa/src/pdu/mod.rs
@@ -1,0 +1,707 @@
+//! MS-RDPEWA PDUs: CBOR request maps and HRESULT-prefixed responses.
+
+mod cbor;
+
+pub use cbor::{CborKey, CborValue, decode_all, decode_value, encode_to_vec, encode_value, encoded_size};
+
+use ironrdp_core::{
+    DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, ensure_size, invalid_field_err, other_err,
+};
+use ironrdp_dvc::DvcEncode;
+use std::collections::BTreeMap;
+
+/// HRESULT success.
+pub const S_OK: u32 = 0;
+/// HRESULT `E_NOTIMPL`.
+pub const E_NOTIMPL: u32 = 0x8000_4001;
+/// HRESULT `E_FAIL`.
+pub const E_FAIL: u32 = 0x8000_4005;
+/// HRESULT `E_INVALIDARG`.
+pub const E_INVALIDARG: u32 = 0x8007_0057;
+/// HRESULT `E_ABORT` (operation cancelled).
+pub const E_ABORT: u32 = 0x8000_4004;
+
+/// MS-RDPEWA RPC command identifiers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum RpcCommand {
+    WebAuthn = 5,
+    Iuvpaa = 6,
+    CancelCurOp = 7,
+    ApiVersion = 8,
+    GetCredentials = 9,
+    GetAuthenticatorList = 12,
+}
+
+impl RpcCommand {
+    pub fn from_u32(v: u32) -> Option<Self> {
+        match v {
+            5 => Some(Self::WebAuthn),
+            6 => Some(Self::Iuvpaa),
+            7 => Some(Self::CancelCurOp),
+            8 => Some(Self::ApiVersion),
+            9 => Some(Self::GetCredentials),
+            12 => Some(Self::GetAuthenticatorList),
+            _ => None,
+        }
+    }
+
+    pub fn as_u32(self) -> u32 {
+        self as u32
+    }
+}
+
+/// WEB_AUTHN subcommand byte.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum WebAuthnSubcommand {
+    MakeCredential = 0x01,
+    GetAssertion = 0x02,
+}
+
+impl WebAuthnSubcommand {
+    pub fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            0x01 => Some(Self::MakeCredential),
+            0x02 => Some(Self::GetAssertion),
+            _ => None,
+        }
+    }
+}
+
+/// Authenticator attachment preference from `webAuthNPara`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[repr(u32)]
+pub enum Attachment {
+    #[default]
+    Any = 0,
+    Platform = 1,
+    CrossPlatform = 2,
+}
+
+impl Attachment {
+    pub fn from_u32(v: u32) -> Self {
+        match v {
+            1 => Self::Platform,
+            2 => Self::CrossPlatform,
+            _ => Self::Any,
+        }
+    }
+}
+
+/// User verification requirement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[repr(u32)]
+pub enum UserVerification {
+    #[default]
+    Any = 0,
+    Required = 1,
+    Preferred = 2,
+    Discouraged = 3,
+}
+
+impl UserVerification {
+    pub fn from_u32(v: u32) -> Self {
+        match v {
+            1 => Self::Required,
+            2 => Self::Preferred,
+            3 => Self::Discouraged,
+            _ => Self::Any,
+        }
+    }
+}
+
+/// Attestation conveyance preference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[repr(u32)]
+pub enum Attestation {
+    #[default]
+    Any = 0,
+    None = 1,
+    Indirect = 2,
+    Direct = 3,
+}
+
+impl Attestation {
+    pub fn from_u32(v: u32) -> Self {
+        match v {
+            1 => Self::None,
+            2 => Self::Indirect,
+            3 => Self::Direct,
+            _ => Self::Any,
+        }
+    }
+}
+
+/// Optional WebAuthn parameters carried beside the CTAP request.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct WebAuthnPara {
+    pub attachment: Attachment,
+    pub require_resident_key: bool,
+    pub user_verification: UserVerification,
+    pub attestation: Attestation,
+    pub cancellation_id: Option<Vec<u8>>,
+    pub ui_origin: Option<String>,
+    /// Remaining unknown/optional CBOR map entries.
+    pub extra: BTreeMap<CborKey, CborValue>,
+}
+
+impl WebAuthnPara {
+    pub fn decode(value: &CborValue) -> DecodeResult<Self> {
+        let map = value.as_map()?;
+        let mut para = Self::default();
+        for (key, val) in map {
+            match key {
+                CborKey::Text(name) => match name.as_str() {
+                    "attachment" => para.attachment = Attachment::from_u32(val.as_u32()?),
+                    "requireResidentKey" => para.require_resident_key = val.as_bool()?,
+                    "userVerification" => para.user_verification = UserVerification::from_u32(val.as_u32()?),
+                    "attestation" => para.attestation = Attestation::from_u32(val.as_u32()?),
+                    "cancellationId" => para.cancellation_id = Some(val.as_bytes()?.to_vec()),
+                    "uiOrigin" => para.ui_origin = Some(val.as_text()?.to_owned()),
+                    _ => {
+                        para.extra.insert(key.clone(), val.clone());
+                    }
+                },
+                other => {
+                    para.extra.insert(other.clone(), val.clone());
+                }
+            }
+        }
+        Ok(para)
+    }
+
+    pub fn encode(&self) -> CborValue {
+        let mut map = BTreeMap::new();
+        map.insert(CborKey::text("attachment"), CborValue::Unsigned(self.attachment as u64));
+        map.insert(
+            CborKey::text("requireResidentKey"),
+            CborValue::Bool(self.require_resident_key),
+        );
+        map.insert(
+            CborKey::text("userVerification"),
+            CborValue::Unsigned(self.user_verification as u64),
+        );
+        map.insert(
+            CborKey::text("attestation"),
+            CborValue::Unsigned(self.attestation as u64),
+        );
+        if let Some(id) = &self.cancellation_id {
+            map.insert(CborKey::text("cancellationId"), CborValue::Bytes(id.clone()));
+        }
+        if let Some(origin) = &self.ui_origin {
+            map.insert(CborKey::text("uiOrigin"), CborValue::Text(origin.clone()));
+        }
+        for (k, v) in &self.extra {
+            map.insert(k.clone(), v.clone());
+        }
+        CborValue::Map(map)
+    }
+}
+
+/// WEB_AUTHN request body: subcommand + CTAP CBOR payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WebAuthnRequestBody {
+    pub subcommand: WebAuthnSubcommand,
+    /// Raw CTAP CBOR map bytes (without the leading subcommand byte).
+    pub ctap_cbor: Vec<u8>,
+}
+
+impl WebAuthnRequestBody {
+    pub fn decode(bytes: &[u8]) -> DecodeResult<Self> {
+        if bytes.is_empty() {
+            return Err(invalid_field_err!("request", "body", "empty WEB_AUTHN request"));
+        }
+        let subcommand = WebAuthnSubcommand::from_u8(bytes[0])
+            .ok_or_else(|| invalid_field_err!("request", "subcommand", "unknown WEB_AUTHN subcommand"))?;
+        Ok(Self {
+            subcommand,
+            ctap_cbor: bytes[1..].to_vec(),
+        })
+    }
+
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(1 + self.ctap_cbor.len());
+        out.push(self.subcommand as u8);
+        out.extend_from_slice(&self.ctap_cbor);
+        out
+    }
+}
+
+/// Decoded MS-RDPEWA request.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RdpewaRequest {
+    pub command: RpcCommand,
+    pub flags: u32,
+    pub rp_id: Option<String>,
+    pub timeout_ms: u32,
+    pub transaction_id: Vec<u8>,
+    pub client_data_json: Option<Vec<u8>>,
+    pub webauthn_para: Option<WebAuthnPara>,
+    /// For WEB_AUTHN: subcommand + CTAP body. For other commands often empty.
+    pub request_body: Vec<u8>,
+    /// Full original map for forward-compat.
+    pub raw: BTreeMap<CborKey, CborValue>,
+}
+
+impl RdpewaRequest {
+    pub fn decode(data: &[u8]) -> DecodeResult<Self> {
+        let value = decode_all(data)?;
+        let map = value.into_map()?;
+        let command_u32 = map
+            .get(&CborKey::text("command"))
+            .ok_or_else(|| invalid_field_err!("request", "command", "missing"))?
+            .as_u32()?;
+        let command = RpcCommand::from_u32(command_u32)
+            .ok_or_else(|| invalid_field_err!("request", "command", "unsupported RPC command"))?;
+
+        let flags = map
+            .get(&CborKey::text("flags"))
+            .map(CborValue::as_u32)
+            .transpose()?
+            .unwrap_or(0);
+        let rp_id = map
+            .get(&CborKey::text("rpId"))
+            .map(CborValue::as_text)
+            .transpose()?
+            .map(str::to_owned);
+        let timeout_ms = map
+            .get(&CborKey::text("timeout"))
+            .map(CborValue::as_u32)
+            .transpose()?
+            .unwrap_or(0);
+        let transaction_id = map
+            .get(&CborKey::text("transactionId"))
+            .map(CborValue::as_bytes)
+            .transpose()?
+            .map(|b| b.to_vec())
+            .unwrap_or_default();
+        let client_data_json = map
+            .get(&CborKey::text("clientDataJSON"))
+            .map(CborValue::as_bytes)
+            .transpose()?
+            .map(|b| b.to_vec());
+        let webauthn_para = map
+            .get(&CborKey::text("webAuthNPara"))
+            .map(WebAuthnPara::decode)
+            .transpose()?;
+        let request_body = map
+            .get(&CborKey::text("request"))
+            .map(CborValue::as_bytes)
+            .transpose()?
+            .map(|b| b.to_vec())
+            .unwrap_or_default();
+
+        Ok(Self {
+            command,
+            flags,
+            rp_id,
+            timeout_ms,
+            transaction_id,
+            client_data_json,
+            webauthn_para,
+            request_body,
+            raw: map,
+        })
+    }
+
+    pub fn encode(&self) -> EncodeResult<Vec<u8>> {
+        let mut map = BTreeMap::new();
+        map.insert(
+            CborKey::text("command"),
+            CborValue::Unsigned(u64::from(self.command.as_u32())),
+        );
+        map.insert(CborKey::text("flags"), CborValue::Unsigned(u64::from(self.flags)));
+        if let Some(rp_id) = &self.rp_id {
+            map.insert(CborKey::text("rpId"), CborValue::Text(rp_id.clone()));
+        }
+        map.insert(
+            CborKey::text("timeout"),
+            CborValue::Unsigned(u64::from(self.timeout_ms)),
+        );
+        if !self.transaction_id.is_empty() {
+            map.insert(
+                CborKey::text("transactionId"),
+                CborValue::Bytes(self.transaction_id.clone()),
+            );
+        }
+        if !self.request_body.is_empty() {
+            map.insert(CborKey::text("request"), CborValue::Bytes(self.request_body.clone()));
+        }
+        if let Some(cdj) = &self.client_data_json {
+            map.insert(CborKey::text("clientDataJSON"), CborValue::Bytes(cdj.clone()));
+        }
+        if let Some(para) = &self.webauthn_para {
+            map.insert(CborKey::text("webAuthNPara"), para.encode());
+        }
+        encode_to_vec(&CborValue::Map(map))
+    }
+
+    pub fn webauthn_body(&self) -> DecodeResult<WebAuthnRequestBody> {
+        WebAuthnRequestBody::decode(&self.request_body)
+    }
+}
+
+/// MS-RDPEWA response: little-endian HRESULT + optional payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RdpewaResponse {
+    pub hresult: u32,
+    pub payload: Vec<u8>,
+}
+
+impl RdpewaResponse {
+    pub fn ok_empty() -> Self {
+        Self {
+            hresult: S_OK,
+            payload: Vec::new(),
+        }
+    }
+
+    pub fn from_hresult(hresult: u32) -> Self {
+        Self {
+            hresult,
+            payload: Vec::new(),
+        }
+    }
+
+    pub fn with_u32(hresult: u32, value: u32) -> Self {
+        Self {
+            hresult,
+            payload: value.to_le_bytes().to_vec(),
+        }
+    }
+
+    pub fn with_payload(hresult: u32, payload: Vec<u8>) -> Self {
+        Self { hresult, payload }
+    }
+
+    pub fn decode(data: &[u8]) -> DecodeResult<Self> {
+        if data.len() < 4 {
+            return Err(invalid_field_err!("response", "hresult", "not enough bytes"));
+        }
+        let mut cursor = ReadCursor::new(data);
+        let hresult = cursor.read_u32();
+        Ok(Self {
+            hresult,
+            payload: cursor.read_remaining().to_vec(),
+        })
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(4 + self.payload.len());
+        out.extend_from_slice(&self.hresult.to_le_bytes());
+        out.extend_from_slice(&self.payload);
+        out
+    }
+
+    pub fn encode_into(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        if dst.len() < 4 + self.payload.len() {
+            return Err(other_err!("response", "not enough space"));
+        }
+        dst.write_u32(self.hresult);
+        dst.write_slice(&self.payload);
+        Ok(())
+    }
+
+    pub fn size(&self) -> usize {
+        4 + self.payload.len()
+    }
+
+    pub fn payload_u32(&self) -> DecodeResult<u32> {
+        if self.payload.len() < 4 {
+            return Err(invalid_field_err!("response", "payload", "expected u32"));
+        }
+        Ok(u32::from_le_bytes(self.payload[..4].try_into().unwrap()))
+    }
+}
+
+/// Authenticator device metadata in a WEB_AUTHN response (`deviceInfo` map).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeviceInfo {
+    pub max_msg_size: u32,
+    pub max_serialized_large_blob_array: u32,
+    pub provider_type: String,
+    pub provider_name: String,
+    pub device_path: String,
+    pub manufacturer: String,
+    pub product: String,
+    pub aa_guid: [u8; 16],
+    pub uv_status: u32,
+    pub uv_retries: u32,
+    pub transports: u32,
+    pub resident_key: Option<bool>,
+}
+
+impl Default for DeviceInfo {
+    fn default() -> Self {
+        Self {
+            max_msg_size: 1200,
+            max_serialized_large_blob_array: 1024,
+            provider_type: String::from("Platform"),
+            provider_name: String::from("IronRDPWebAuthnProvider"),
+            device_path: String::new(),
+            manufacturer: String::new(),
+            product: String::new(),
+            aa_guid: [0; 16],
+            uv_status: 0,
+            uv_retries: 0,
+            transports: 0,
+            resident_key: None,
+        }
+    }
+}
+
+impl DeviceInfo {
+    pub fn encode(&self) -> CborValue {
+        let mut map = BTreeMap::new();
+        map.insert(
+            CborKey::text("maxMsgSize"),
+            CborValue::Unsigned(u64::from(self.max_msg_size)),
+        );
+        map.insert(
+            CborKey::text("maxSerializedLargeBlobArray"),
+            CborValue::Unsigned(u64::from(self.max_serialized_large_blob_array)),
+        );
+        map.insert(
+            CborKey::text("providerType"),
+            CborValue::Text(self.provider_type.clone()),
+        );
+        map.insert(
+            CborKey::text("providerName"),
+            CborValue::Text(self.provider_name.clone()),
+        );
+        map.insert(CborKey::text("devicePath"), CborValue::Text(self.device_path.clone()));
+        map.insert(
+            CborKey::text("Manufacturer"),
+            CborValue::Text(self.manufacturer.clone()),
+        );
+        map.insert(CborKey::text("Product"), CborValue::Text(self.product.clone()));
+        map.insert(CborKey::text("aaGuid"), CborValue::Bytes(self.aa_guid.to_vec()));
+        map.insert(
+            CborKey::text("uvStatus"),
+            CborValue::Unsigned(u64::from(self.uv_status)),
+        );
+        map.insert(
+            CborKey::text("uvRetries"),
+            CborValue::Unsigned(u64::from(self.uv_retries)),
+        );
+        map.insert(
+            CborKey::text("transports"),
+            CborValue::Unsigned(u64::from(self.transports)),
+        );
+        if let Some(rk) = self.resident_key {
+            map.insert(CborKey::text("residentKey"), CborValue::Bool(rk));
+        }
+        CborValue::Map(map)
+    }
+
+    pub fn decode(value: &CborValue) -> DecodeResult<Self> {
+        let map = value.as_map()?;
+        let mut info = Self::default();
+        if let Some(v) = map.get(&CborKey::text("maxMsgSize")) {
+            info.max_msg_size = v.as_u32()?;
+        }
+        if let Some(v) = map.get(&CborKey::text("maxSerializedLargeBlobArray")) {
+            info.max_serialized_large_blob_array = v.as_u32()?;
+        }
+        if let Some(v) = map.get(&CborKey::text("providerType")) {
+            info.provider_type = v.as_text()?.to_owned();
+        }
+        if let Some(v) = map.get(&CborKey::text("providerName")) {
+            info.provider_name = v.as_text()?.to_owned();
+        }
+        if let Some(v) = map.get(&CborKey::text("devicePath")) {
+            info.device_path = v.as_text()?.to_owned();
+        }
+        if let Some(v) = map.get(&CborKey::text("Manufacturer")) {
+            info.manufacturer = v.as_text()?.to_owned();
+        }
+        if let Some(v) = map.get(&CborKey::text("Product")) {
+            info.product = v.as_text()?.to_owned();
+        }
+        if let Some(v) = map.get(&CborKey::text("aaGuid")) {
+            let b = v.as_bytes()?;
+            if b.len() == 16 {
+                info.aa_guid.copy_from_slice(b);
+            }
+        }
+        if let Some(v) = map.get(&CborKey::text("uvStatus")) {
+            info.uv_status = v.as_u32()?;
+        }
+        if let Some(v) = map.get(&CborKey::text("uvRetries")) {
+            info.uv_retries = v.as_u32()?;
+        }
+        if let Some(v) = map.get(&CborKey::text("transports")) {
+            info.transports = v.as_u32()?;
+        }
+        if let Some(v) = map.get(&CborKey::text("residentKey")) {
+            info.resident_key = Some(v.as_bool()?);
+        }
+        Ok(info)
+    }
+}
+
+/// WEB_AUTHN success payload CBOR map fields.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WebAuthnResponsePayload {
+    pub device_info: DeviceInfo,
+    pub status: u32,
+    /// CTAP status byte + CTAP CBOR response body.
+    pub response: Vec<u8>,
+}
+
+impl WebAuthnResponsePayload {
+    pub fn encode(&self) -> EncodeResult<Vec<u8>> {
+        let mut map = BTreeMap::new();
+        map.insert(CborKey::text("deviceInfo"), self.device_info.encode());
+        map.insert(CborKey::text("status"), CborValue::Unsigned(u64::from(self.status)));
+        map.insert(CborKey::text("response"), CborValue::Bytes(self.response.clone()));
+        encode_to_vec(&CborValue::Map(map))
+    }
+
+    pub fn decode(data: &[u8]) -> DecodeResult<Self> {
+        let value = decode_all(data)?;
+        let map = value.as_map()?;
+        let device_info = map
+            .get(&CborKey::text("deviceInfo"))
+            .map(DeviceInfo::decode)
+            .transpose()?
+            .unwrap_or_default();
+        let status = map
+            .get(&CborKey::text("status"))
+            .or_else(|| map.get(&CborKey::text("Status")))
+            .map(CborValue::as_u32)
+            .transpose()?
+            .unwrap_or(0);
+        let response = map
+            .get(&CborKey::text("response"))
+            .or_else(|| map.get(&CborKey::text("Response")))
+            .map(CborValue::as_bytes)
+            .transpose()?
+            .map(|b| b.to_vec())
+            .unwrap_or_default();
+        Ok(Self {
+            device_info,
+            status,
+            response,
+        })
+    }
+}
+
+/// Build a CTAP-style response body: status byte + CBOR map.
+pub fn encode_ctap_response(status: u8, body: &CborValue) -> EncodeResult<Vec<u8>> {
+    let body_bytes = encode_to_vec(body)?;
+    let mut out = Vec::with_capacity(1 + body_bytes.len());
+    out.push(status);
+    out.extend_from_slice(&body_bytes);
+    Ok(out)
+}
+
+impl Encode for RdpewaResponse {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        self.encode_into(dst)
+    }
+
+    fn name(&self) -> &'static str {
+        "RDPEWA_RESPONSE"
+    }
+
+    fn size(&self) -> usize {
+        RdpewaResponse::size(self)
+    }
+}
+
+impl DvcEncode for RdpewaResponse {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_tx() -> Vec<u8> {
+        (0u8..16).collect()
+    }
+
+    #[test]
+    fn api_version_request_roundtrip() {
+        let req = RdpewaRequest {
+            command: RpcCommand::ApiVersion,
+            flags: 0,
+            rp_id: None,
+            timeout_ms: 0,
+            transaction_id: sample_tx(),
+            client_data_json: None,
+            webauthn_para: None,
+            request_body: Vec::new(),
+            raw: BTreeMap::new(),
+        };
+        let encoded = req.encode().unwrap();
+        let decoded = RdpewaRequest::decode(&encoded).unwrap();
+        assert_eq!(decoded.command, RpcCommand::ApiVersion);
+        assert_eq!(decoded.transaction_id, sample_tx());
+    }
+
+    #[test]
+    fn response_u32_payload() {
+        let resp = RdpewaResponse::with_u32(S_OK, 4);
+        let bytes = resp.to_bytes();
+        assert_eq!(bytes.len(), 8);
+        let decoded = RdpewaResponse::decode(&bytes).unwrap();
+        assert_eq!(decoded.hresult, S_OK);
+        assert_eq!(decoded.payload_u32().unwrap(), 4);
+    }
+
+    #[test]
+    fn cancel_response_hresult_only() {
+        let resp = RdpewaResponse::from_hresult(S_OK);
+        let bytes = resp.to_bytes();
+        assert_eq!(bytes, [0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn webauthn_body_parse() {
+        let body = WebAuthnRequestBody {
+            subcommand: WebAuthnSubcommand::MakeCredential,
+            ctap_cbor: vec![0xa1, 0x01, 0x60],
+        };
+        let encoded = body.encode();
+        let decoded = WebAuthnRequestBody::decode(&encoded).unwrap();
+        assert_eq!(decoded.subcommand, WebAuthnSubcommand::MakeCredential);
+        assert_eq!(decoded.ctap_cbor, vec![0xa1, 0x01, 0x60]);
+    }
+
+    #[test]
+    fn iuvpaa_request_decode() {
+        let req = RdpewaRequest {
+            command: RpcCommand::Iuvpaa,
+            flags: 0,
+            rp_id: None,
+            timeout_ms: 60_000,
+            transaction_id: sample_tx(),
+            client_data_json: None,
+            webauthn_para: None,
+            request_body: Vec::new(),
+            raw: BTreeMap::new(),
+        };
+        let encoded = req.encode().unwrap();
+        let decoded = RdpewaRequest::decode(&encoded).unwrap();
+        assert_eq!(decoded.command, RpcCommand::Iuvpaa);
+        assert_eq!(decoded.timeout_ms, 60_000);
+    }
+
+    #[test]
+    fn webauthn_response_payload_roundtrip() {
+        let payload = WebAuthnResponsePayload {
+            device_info: DeviceInfo {
+                provider_type: String::from("Platform"),
+                provider_name: String::from("test"),
+                ..DeviceInfo::default()
+            },
+            status: 0,
+            response: vec![0x00, 0xa0],
+        };
+        let encoded = payload.encode().unwrap();
+        let decoded = WebAuthnResponsePayload::decode(&encoded).unwrap();
+        assert_eq!(decoded, payload);
+    }
+}

--- a/crates/ironrdp-rdpewa/src/pdu/mod.rs
+++ b/crates/ironrdp-rdpewa/src/pdu/mod.rs
@@ -20,6 +20,8 @@ pub const E_FAIL: u32 = 0x8000_4005;
 pub const E_INVALIDARG: u32 = 0x8007_0057;
 /// HRESULT `E_ABORT` (operation cancelled).
 pub const E_ABORT: u32 = 0x8000_4004;
+/// HRESULT `HRESULT_FROM_WIN32(ERROR_BUSY)` — ceremony already in progress.
+pub const E_BUSY: u32 = 0x8007_00AA;
 
 /// MS-RDPEWA RPC command identifiers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/ironrdp-rdpewa/src/pdu/mod.rs
+++ b/crates/ironrdp-rdpewa/src/pdu/mod.rs
@@ -47,7 +47,14 @@ impl RpcCommand {
     }
 
     pub fn as_u32(self) -> u32 {
-        self as u32
+        match self {
+            Self::WebAuthn => 5,
+            Self::Iuvpaa => 6,
+            Self::CancelCurOp => 7,
+            Self::ApiVersion => 8,
+            Self::GetCredentials => 9,
+            Self::GetAuthenticatorList => 12,
+        }
     }
 }
 
@@ -65,6 +72,13 @@ impl WebAuthnSubcommand {
             0x01 => Some(Self::MakeCredential),
             0x02 => Some(Self::GetAssertion),
             _ => None,
+        }
+    }
+
+    pub fn as_u8(self) -> u8 {
+        match self {
+            Self::MakeCredential => 0x01,
+            Self::GetAssertion => 0x02,
         }
     }
 }
@@ -85,6 +99,14 @@ impl Attachment {
             1 => Self::Platform,
             2 => Self::CrossPlatform,
             _ => Self::Any,
+        }
+    }
+
+    pub fn as_u32(self) -> u32 {
+        match self {
+            Self::Any => 0,
+            Self::Platform => 1,
+            Self::CrossPlatform => 2,
         }
     }
 }
@@ -109,6 +131,15 @@ impl UserVerification {
             _ => Self::Any,
         }
     }
+
+    pub fn as_u32(self) -> u32 {
+        match self {
+            Self::Any => 0,
+            Self::Required => 1,
+            Self::Preferred => 2,
+            Self::Discouraged => 3,
+        }
+    }
 }
 
 /// Attestation conveyance preference.
@@ -129,6 +160,15 @@ impl Attestation {
             2 => Self::Indirect,
             3 => Self::Direct,
             _ => Self::Any,
+        }
+    }
+
+    pub fn as_u32(self) -> u32 {
+        match self {
+            Self::Any => 0,
+            Self::None => 1,
+            Self::Indirect => 2,
+            Self::Direct => 3,
         }
     }
 }
@@ -173,18 +213,21 @@ impl WebAuthnPara {
 
     pub fn encode(&self) -> CborValue {
         let mut map = BTreeMap::new();
-        map.insert(CborKey::text("attachment"), CborValue::Unsigned(self.attachment as u64));
+        map.insert(
+            CborKey::text("attachment"),
+            CborValue::Unsigned(u64::from(self.attachment.as_u32())),
+        );
         map.insert(
             CborKey::text("requireResidentKey"),
             CborValue::Bool(self.require_resident_key),
         );
         map.insert(
             CborKey::text("userVerification"),
-            CborValue::Unsigned(self.user_verification as u64),
+            CborValue::Unsigned(u64::from(self.user_verification.as_u32())),
         );
         map.insert(
             CborKey::text("attestation"),
-            CborValue::Unsigned(self.attestation as u64),
+            CborValue::Unsigned(u64::from(self.attestation.as_u32())),
         );
         if let Some(id) = &self.cancellation_id {
             map.insert(CborKey::text("cancellationId"), CborValue::Bytes(id.clone()));
@@ -222,7 +265,7 @@ impl WebAuthnRequestBody {
 
     pub fn encode(&self) -> Vec<u8> {
         let mut out = Vec::with_capacity(1 + self.ctap_cbor.len());
-        out.push(self.subcommand as u8);
+        out.push(self.subcommand.as_u8());
         out.extend_from_slice(&self.ctap_cbor);
         out
     }
@@ -388,14 +431,14 @@ impl RdpewaResponse {
     }
 
     pub fn to_bytes(&self) -> Vec<u8> {
-        let mut out = Vec::with_capacity(4 + self.payload.len());
+        let mut out = Vec::with_capacity(self.wire_len());
         out.extend_from_slice(&self.hresult.to_le_bytes());
         out.extend_from_slice(&self.payload);
         out
     }
 
     pub fn encode_into(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        if dst.len() < 4 + self.payload.len() {
+        if dst.len() < self.wire_len() {
             return Err(other_err!("response", "not enough space"));
         }
         dst.write_u32(self.hresult);
@@ -403,15 +446,17 @@ impl RdpewaResponse {
         Ok(())
     }
 
-    pub fn size(&self) -> usize {
+    pub fn wire_len(&self) -> usize {
         4 + self.payload.len()
     }
 
     pub fn payload_u32(&self) -> DecodeResult<u32> {
-        if self.payload.len() < 4 {
-            return Err(invalid_field_err!("response", "payload", "expected u32"));
-        }
-        Ok(u32::from_le_bytes(self.payload[..4].try_into().unwrap()))
+        let bytes: [u8; 4] = self
+            .payload
+            .get(..4)
+            .and_then(|slice| slice.try_into().ok())
+            .ok_or_else(|| invalid_field_err!("response", "payload", "expected u32"))?;
+        Ok(u32::from_le_bytes(bytes))
     }
 }
 
@@ -599,7 +644,7 @@ pub fn encode_ctap_response(status: u8, body: &CborValue) -> EncodeResult<Vec<u8
 
 impl Encode for RdpewaResponse {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        ensure_size!(in: dst, size: self.size());
+        ensure_size!(in: dst, size: self.wire_len());
         self.encode_into(dst)
     }
 
@@ -608,7 +653,7 @@ impl Encode for RdpewaResponse {
     }
 
     fn size(&self) -> usize {
-        RdpewaResponse::size(self)
+        self.wire_len()
     }
 }
 

--- a/crates/ironrdp-rdpewa/src/server.rs
+++ b/crates/ironrdp-rdpewa/src/server.rs
@@ -63,3 +63,13 @@ impl DvcProcessor for RdpewaServer {
 }
 
 impl DvcServerProcessor for RdpewaServer {}
+
+#[cfg(test)]
+mod tests {
+    use super::RdpewaServer;
+
+    #[test]
+    fn default_uses_the_current_api_version() {
+        assert_eq!(RdpewaServer::default().api_version, 1);
+    }
+}

--- a/crates/ironrdp-rdpewa/src/server.rs
+++ b/crates/ironrdp-rdpewa/src/server.rs
@@ -11,9 +11,15 @@ use crate::pdu::{E_NOTIMPL, RdpewaRequest, RdpewaResponse, RpcCommand, S_OK};
 /// Server-side skeleton that accepts the channel and answers simple RPCs.
 ///
 /// This is not a full host authenticator service. WEB_AUTHN returns `E_NOTIMPL`.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct RdpewaServer {
     api_version: u32,
+}
+
+impl Default for RdpewaServer {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl RdpewaServer {

--- a/crates/ironrdp-rdpewa/src/server.rs
+++ b/crates/ironrdp-rdpewa/src/server.rs
@@ -1,0 +1,59 @@
+//! Minimal MS-RDPEWA server DVC processor skeleton.
+
+use ironrdp_core::impl_as_any;
+use ironrdp_dvc::{DvcMessage, DvcProcessor, DvcServerProcessor};
+use ironrdp_pdu::{PduResult, decode_err};
+use tracing::debug;
+
+use crate::CHANNEL_NAME;
+use crate::pdu::{E_NOTIMPL, RdpewaRequest, RdpewaResponse, RpcCommand, S_OK};
+
+/// Server-side skeleton that accepts the channel and answers simple RPCs.
+///
+/// This is not a full host authenticator service. WEB_AUTHN returns `E_NOTIMPL`.
+#[derive(Debug, Default)]
+pub struct RdpewaServer {
+    api_version: u32,
+}
+
+impl RdpewaServer {
+    pub fn new() -> Self {
+        Self { api_version: 1 }
+    }
+
+    #[must_use]
+    pub fn with_api_version(mut self, version: u32) -> Self {
+        self.api_version = version;
+        self
+    }
+}
+
+impl_as_any!(RdpewaServer);
+
+impl DvcProcessor for RdpewaServer {
+    fn channel_name(&self) -> &str {
+        CHANNEL_NAME
+    }
+
+    fn start(&mut self, _channel_id: u32) -> PduResult<Vec<DvcMessage>> {
+        Ok(Vec::new())
+    }
+
+    fn process(&mut self, _channel_id: u32, payload: &[u8]) -> PduResult<Vec<DvcMessage>> {
+        let request = RdpewaRequest::decode(payload).map_err(|e| decode_err!(e))?;
+        debug!(?request.command, "Server received RDPEWA request");
+
+        let response = match request.command {
+            RpcCommand::ApiVersion => RdpewaResponse::with_u32(S_OK, self.api_version),
+            RpcCommand::Iuvpaa => RdpewaResponse::with_u32(S_OK, 0),
+            RpcCommand::CancelCurOp => RdpewaResponse::ok_empty(),
+            RpcCommand::WebAuthn | RpcCommand::GetCredentials | RpcCommand::GetAuthenticatorList => {
+                RdpewaResponse::from_hresult(E_NOTIMPL)
+            }
+        };
+
+        Ok(vec![Box::new(response)])
+    }
+}
+
+impl DvcServerProcessor for RdpewaServer {}

--- a/crates/ironrdp-viewer/src/cli.rs
+++ b/crates/ironrdp-viewer/src/cli.rs
@@ -184,6 +184,17 @@ struct Args {
     #[clap(long, value_enum, default_value_t = ClipboardType::Enable)]
     clipboard_type: ClipboardType,
 
+    /// Enable native MS-RDPEWA WebAuthn redirection (Windows Hello / security keys).
+    ///
+    /// Defaults to the `.rdp` `redirectwebauthn` value when present, otherwise enabled on
+    /// Windows builds that include the client `webauthn` feature.
+    #[clap(long, action = clap::ArgAction::SetTrue, overrides_with = "no_webauthn")]
+    webauthn: bool,
+
+    /// Disable native MS-RDPEWA WebAuthn redirection.
+    #[clap(long = "no-webauthn", action = clap::ArgAction::SetTrue, overrides_with = "webauthn")]
+    no_webauthn: bool,
+
     /// The bitmap codecs to use (remotefx:on, ...)
     #[clap(long, num_args = 1.., value_delimiter = ',')]
     codecs: Vec<String>,
@@ -298,9 +309,10 @@ impl ViewerConfig {
         // Whether the `.rdp` file requested clipboard redirection; the CLI `--clipboard-type` is
         // resolved against this when applied below.
         let redirect_clipboard = properties.redirect_clipboard().unwrap_or(true);
+        let redirect_webauthn = properties.redirect_webauthn().unwrap_or(true);
 
         // CLI arguments take precedence: apply them on top of the `.rdp`-derived builder.
-        let builder = apply_cli_to_builder(builder, args, redirect_clipboard);
+        let builder = apply_cli_to_builder(builder, args, redirect_clipboard, redirect_webauthn);
 
         Ok(Self {
             builder,
@@ -342,7 +354,12 @@ impl ViewerConfig {
 
 /// Apply CLI overrides on top of a builder that already reflects the `.rdp` file. Every flag that is
 /// present overwrites the corresponding builder (and mirrored property) value.
-fn apply_cli_to_builder(mut builder: ConfigBuilder, args: Args, redirect_clipboard: bool) -> ConfigBuilder {
+fn apply_cli_to_builder(
+    mut builder: ConfigBuilder,
+    args: Args,
+    redirect_clipboard: bool,
+    redirect_webauthn: bool,
+) -> ConfigBuilder {
     // Validate the codecs early to surface help text before connecting.
     {
         let codecs: Vec<_> = args.codecs.iter().map(String::as_str).collect();
@@ -426,6 +443,16 @@ fn apply_cli_to_builder(mut builder: ConfigBuilder, args: Args, redirect_clipboa
     }
 
     builder = builder.with_clipboard(resolve_clipboard_type(args.clipboard_type, redirect_clipboard));
+
+    // Viewer enables ironrdp-client `webauthn` through `client-all`.
+    let webauthn = if args.webauthn {
+        true
+    } else if args.no_webauthn {
+        false
+    } else {
+        redirect_webauthn
+    };
+    builder = builder.with_webauthn(webauthn);
 
     // CLI-only knobs that are not representable as `.rdp` properties.
     // TODO/FIXME: Some of these, we may want to add support for storing in .rdp files (e.g.: IME file name can be reasonably seen as a connection option)

--- a/typos.toml
+++ b/typos.toml
@@ -29,12 +29,20 @@ Imagesetter = "Imagesetter"
 Pn = "Pn"
 # "writeable" is an accepted alternate spelling of "writable".
 writeable = "writeable"
+# CBOR Object Signing and Encryption (WebAuthn COSE algorithms / Windows APIs).
+COSE = "COSE"
+cose = "cose"
 
 [default.extend-identifiers]
 # COM FORMATETC target-device field.
 ptd = "ptd"
 # Windows TRACKMOUSEEVENT flag.
 TME_LEAVE = "TME_LEAVE"
+# WebAuthn COSE algorithm parameter identifiers / locals.
+cose_params = "cose_params"
+WEBAUTHN_COSE_CREDENTIAL_PARAMETER = "WEBAUTHN_COSE_CREDENTIAL_PARAMETER"
+WEBAUTHN_COSE_CREDENTIAL_PARAMETER_CURRENT_VERSION = "WEBAUTHN_COSE_CREDENTIAL_PARAMETER_CURRENT_VERSION"
+WEBAUTHN_COSE_CREDENTIAL_PARAMETERS = "WEBAUTHN_COSE_CREDENTIAL_PARAMETERS"
 
 [default]
 extend-ignore-re = [


### PR DESCRIPTION
Implement the RDPEWA dynamic channel with a Windows WebAuthn backend and wire RedirectWebAuthn for ActiveX, the optional client feature, and the viewer CLI.

Prefer System32\webauthn.dll via the DVC COM plugin for MSTSC parity. The pure-Rust backend forwards ceremonies through a webauthn.dll IWTS oneshot so hash-only hosts that omit clientDataJSON still work; public WebAuthN* remains a fallback when JSON is present. Recreate WebAuthN_Channel opens through shared COM/listener factories because Windows opens and closes the channel around each RPC.

Side effects:
- New crates ironrdp-rdpewa and ironrdp-rdpewa-native
- Config key redirectwebauthn; ActiveX ExtendedSettings property
- ironrdp-daemon webauthn feature for ironrdp-agent
- IRONRDP_WEBAUTHN_FORCE_NATIVE debug switch
- Viewer --webauthn/--no-webauthn flags; .rdp redirectwebauthn default
- ActiveX docs note no AdvancedSettings slot and no IPersist persistence