### PR TITLE
feat(agent): add RAIL audit commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2643,6 +2643,7 @@ dependencies = [
  "ironrdp-input",
  "ironrdp-pdu",
  "ironrdp-propertyset",
+ "ironrdp-rail",
  "ironrdp-rdpdr-native",
  "ironrdp-rpc",
  "ironrdp-tls",

--- a/crates/ironrdp-activex/src/rpc.rs
+++ b/crates/ironrdp-activex/src/rpc.rs
@@ -394,6 +394,12 @@ async fn handle_request(shared: &Arc<Shared>, dispatcher: isize, request: Reques
             AgentErrorCategory::InvalidRequest,
             "bulk Unicode text input is unsupported by ActiveX",
         ),
+        Request::RailStatus | Request::RailEvents { .. } | Request::RailWait { .. } | Request::RailExecute(_) => {
+            Response::typed_error(
+                AgentErrorCategory::Unavailable,
+                "RAIL audit endpoints are unavailable through ActiveX",
+            )
+        }
         Request::Resize { width, height } => {
             queue_command(shared, dispatcher, |response| Command::Resize {
                 width,
@@ -771,6 +777,19 @@ mod tests {
         };
         assert_eq!(error.category, AgentErrorCategory::InvalidRequest);
         assert_eq!(error.message, "bulk Unicode text input is unsupported by ActiveX");
+    }
+
+    #[tokio::test]
+    async fn rail_audit_is_explicitly_unavailable() {
+        let rpc = rpc();
+
+        let ConnectionResponse::Single(Response::Err(error)) =
+            handle_request(&rpc.shared, 0, Request::RailStatus).await
+        else {
+            panic!("RAIL audit endpoints must be unavailable through ActiveX");
+        };
+        assert_eq!(error.category, AgentErrorCategory::Unavailable);
+        assert_eq!(error.message, "RAIL audit endpoints are unavailable through ActiveX");
     }
 
     #[test]

--- a/crates/ironrdp-agent/README.md
+++ b/crates/ironrdp-agent/README.md
@@ -20,6 +20,7 @@ On Windows, an ActiveX host can expose its session through the same local RPC pr
 host with `IRONRDP_ACTIVEX_RPC=1`, then use `--backend active-x` for agent operations. The agent
 uses the per-user `ironrdp-activex` endpoint by default and never attempts to start an ActiveX host.
 Use `--endpoint` when the host selected `IRONRDP_ACTIVEX_RPC_ENDPOINT`.
+The RAIL audit commands require the daemon backend.
 
 `connect` accepts `RDP_HOSTNAME`, `RDP_USERNAME`, and `RDP_PASSWORD` as defaults for its named
 connection flags. Explicit flags override those process-local values. The native MSTSC bridge uses
@@ -38,6 +39,28 @@ The configured drives are fixed for the daemon lifetime; hot-plug and rescan are
 The daemon performs strict certificate and hostname validation by default.
 For an explicitly authorized test endpoint, start the daemon with `--skip-certificate-check`.
 This startup-only flag accepts any certificate and server name, so it is vulnerable to on-path attacks and is unavailable through `connect`.
+
+## Headless RemoteApp validation
+
+The daemon-backend `rail` commands expose client-validated RAIL handshake, launch, and window-order evidence without rendering a RemoteApp UI or accepting raw protocol PDUs.
+Connect in RemoteApp mode with `remoteapplicationmode:i:1` and a canonical `remoteapplicationprogram:s:<program>` property.
+The client queues that program as the initial RAIL Execute request after the server handshake and keeps Client Info Alternate Shell and Working Directory empty.
+An `alternate shell` value is only used as a compatibility fallback when `remoteapplicationprogram` is absent.
+Start `ironrdp-agent daemon-start` in another terminal before connecting.
+The target must publish and allow the requested RemoteApp.
+
+```powershell
+ironrdp-agent connect --server rdp.example.test --prop remoteapplicationmode:i:1 --prop remoteapplicationprogram:s:notepad.exe
+ironrdp-agent rail status
+ironrdp-agent rail --format ndjson events
+ironrdp-agent rail execute notepad.exe --arguments C:\Temp\audit.txt
+```
+
+`rail events` retains 256 observations per connection generation.
+When a caller resumes too far behind, the returned stream contains a `gap` event reporting the last sequence number no longer retained.
+Set `N` to the latest sequence observed; `rail wait --after-sequence N --timeout-ms 30000` returns retained later observations immediately or waits up to 30 seconds without polling.
+Use `rail --format json` for one deterministic document or `rail --format ndjson` for one event per line.
+The agent advertises no local RAIL shell-integration flags because it does not implement move/size, taskbar, cloak, z-order, or display-power behavior.
 
 ## Bounded Unicode input
 
@@ -205,6 +228,10 @@ The ignored live test uses `IRONRDP_AGENT_E2E_HOST`, `IRONRDP_AGENT_E2E_USERNAME
 $env:IRONRDP_AGENT_E2E = '1'
 cargo test -p ironrdp-agent --test live_e2e -- --ignored
 ```
+
+The RemoteApp variant uses `IRONRDP_AGENT_RAIL_E2E=1` plus the corresponding
+`IRONRDP_AGENT_RAIL_E2E_HOST`, `IRONRDP_AGENT_RAIL_E2E_USERNAME`, `IRONRDP_AGENT_RAIL_E2E_PASSWORD`, and optional `IRONRDP_AGENT_RAIL_E2E_DOMAIN` variables.
+It starts an isolated daemon with `--skip-certificate-check`, so run it only against an explicitly authorized test endpoint.
 
 [`ironrdp-client`]: ../ironrdp-client
 [`ironrdp-core`]: ../ironrdp-core

--- a/crates/ironrdp-agent/README.md
+++ b/crates/ironrdp-agent/README.md
@@ -57,8 +57,10 @@ ironrdp-agent rail execute notepad.exe --arguments C:\Temp\audit.txt
 ```
 
 `rail events` retains 256 observations per connection generation.
+Sequences remain monotonic across resize reconnects even though each new generation starts with fresh history.
 When a caller resumes too far behind, the returned stream contains a `gap` event reporting the last sequence number no longer retained.
 Set `N` to the latest sequence observed; `rail wait --after-sequence N --timeout-ms 30000` returns retained later observations immediately or waits up to 30 seconds without polling.
+If an accepted local launch fails before it is sent, the event stream reports `execute_failed` with a stable reason and no working-directory or argument data.
 Use `rail --format json` for one deterministic document or `rail --format ndjson` for one event per line.
 The agent advertises no local RAIL shell-integration flags because it does not implement move/size, taskbar, cloak, z-order, or display-power behavior.
 

--- a/crates/ironrdp-agent/src/cli.rs
+++ b/crates/ironrdp-agent/src/cli.rs
@@ -910,6 +910,16 @@ fn print_rail_event(event: &RailEvent) {
             "{}: execute result launch={launch_id:?} executable={executable} flags=0x{flags:04x} result=0x{result:04x} raw=0x{raw_result:08x}",
             event.sequence
         ),
+        RailEventKind::ExecuteFailed {
+            launch_id,
+            executable,
+            flags,
+            reason,
+        } => println!(
+            "{}: execute failed launch={launch_id:?} executable={executable} flags=0x{flags:04x} reason={}",
+            event.sequence,
+            reason.as_str()
+        ),
         RailEventKind::ApplicationId {
             window_id,
             application_id,
@@ -971,6 +981,18 @@ fn rail_event_json(event: &RailEvent) -> serde_json::Value {
             "flags": flags,
             "result": result,
             "raw_result": raw_result,
+        }),
+        RailEventKind::ExecuteFailed {
+            launch_id,
+            executable,
+            flags,
+            reason,
+        } => json!({
+            "kind": "execute_failed",
+            "launch_id": launch_id,
+            "executable": executable,
+            "flags": flags,
+            "reason": reason.as_str(),
         }),
         RailEventKind::ApplicationId {
             window_id,

--- a/crates/ironrdp-agent/src/cli.rs
+++ b/crates/ironrdp-agent/src/cli.rs
@@ -24,7 +24,8 @@ use ironrdp_propertyset::{PropertySet, Value};
 
 use ironrdp_rpc::ipc::{
     AgentError, KeyFilter, MAX_UNICODE_TEXT_CHARS, NowExecutionKind, NowExecutionRequest, NowStream, OperationEvent,
-    OperationEventKind, OperationInfo, OperationState, Payload, PropValue, Request, Response,
+    OperationEventKind, OperationInfo, OperationState, Payload, PropValue, RailEvent, RailEventKind,
+    RailExecuteRequest, Request, Response,
 };
 use ironrdp_rpc::transport::{self, Endpoint};
 
@@ -113,6 +114,8 @@ enum Command {
     },
     /// Execute commands over the session's NOW DVC endpoint.
     Now(NowArgs),
+    /// Inspect and exercise the validated, headless RemoteApp/RAIL audit plane.
+    Rail(RailArgs),
     /// Windows Sandbox lifecycle helpers (list/config/stop via WindowsSandboxServer gRPC).
     #[cfg(windows)]
     Sandbox(SandboxArgs),
@@ -183,6 +186,50 @@ enum NowCommand {
     Stdin(NowStdinArgs),
     /// Display the local NOW endpoint state without making a new connection.
     Diagnostics,
+}
+
+#[derive(Args, Debug)]
+struct RailArgs {
+    /// Output format for RAIL evidence.
+    #[arg(long, value_enum, default_value_t = OutputFormat::Human)]
+    format: OutputFormat,
+    #[command(subcommand)]
+    command: RailCommand,
+}
+
+#[derive(Subcommand, Debug)]
+enum RailCommand {
+    /// Display the current RAIL handshake and pending-launch state.
+    Status,
+    /// Display validated RAIL events retained by the daemon.
+    Events {
+        /// Only show events with a sequence greater than this value.
+        #[arg(long)]
+        after_sequence: Option<u64>,
+    },
+    /// Wait for the next validated RAIL event without polling.
+    Wait {
+        /// Only return events with a sequence greater than this value.
+        #[arg(long)]
+        after_sequence: Option<u64>,
+        /// Maximum wait time in milliseconds, capped at 60,000.
+        #[arg(long, default_value_t = 30_000)]
+        timeout_ms: u32,
+    },
+    /// Queue a RemoteApp launch without exposing raw protocol injection.
+    Execute {
+        /// Remote executable path or alias.
+        executable: String,
+        /// Initial remote working directory.
+        #[arg(long)]
+        working_directory: Option<String>,
+        /// Command-line arguments for the executable.
+        #[arg(long)]
+        arguments: Option<String>,
+        /// RAIL Execute flags.
+        #[arg(long, default_value_t = 0)]
+        flags: u16,
+    },
 }
 
 #[derive(Args, Debug)]
@@ -544,6 +591,7 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
             }
             return Ok(());
         }
+        Command::Rail(args) => return run_rail(&endpoint, args).await,
         Command::Connect(args) => build_connect_request(args)?,
         #[cfg(windows)]
         Command::Sandbox(args) => {
@@ -705,6 +753,245 @@ fn run_sandbox_command(args: SandboxArgs) -> anyhow::Result<()> {
             Ok(())
         }
     }
+}
+
+async fn run_rail(endpoint: &Endpoint, args: RailArgs) -> anyhow::Result<()> {
+    let RailArgs { format, command } = args;
+    let request = match command {
+        RailCommand::Status => Request::RailStatus,
+        RailCommand::Events { after_sequence } => Request::RailEvents { after_sequence },
+        RailCommand::Wait {
+            after_sequence,
+            timeout_ms,
+        } => Request::RailWait {
+            after_sequence,
+            timeout_ms,
+        },
+        RailCommand::Execute {
+            executable,
+            working_directory,
+            arguments,
+            flags,
+        } => Request::RailExecute(RailExecuteRequest {
+            executable,
+            working_directory: working_directory.unwrap_or_default(),
+            arguments: arguments.unwrap_or_default(),
+            flags,
+        }),
+    };
+    let response = transport::send_request(endpoint, &request).await?;
+    let payload = match response {
+        Response::Ok(payload) => payload,
+        Response::Err(error) => anyhow::bail!("{error}"),
+    };
+    print_rail_payload(payload, format)
+}
+
+fn print_rail_payload(payload: Payload, format: OutputFormat) -> anyhow::Result<()> {
+    use serde_json::json;
+
+    match format {
+        OutputFormat::Human => match payload {
+            Payload::RailStatus(status) => {
+                println!("generation: {}", status.generation);
+                println!("next sequence: {}", status.next_sequence);
+                println!("handshake complete: {}", status.handshake_complete);
+                println!("desktop synchronized: {}", status.desktop_synchronized);
+                for launch in status.pending_launches {
+                    println!(
+                        "pending launch {}: {} (flags 0x{:04x})",
+                        launch.launch_id, launch.executable, launch.flags
+                    );
+                }
+            }
+            Payload::RailEvents(events) => {
+                println!("generation: {}", events.generation);
+                for event in events.events {
+                    print_rail_event(&event);
+                }
+            }
+            Payload::RailLaunch(launch) => {
+                println!(
+                    "queued launch {}: {} (flags 0x{:04x})",
+                    launch.launch_id, launch.executable, launch.flags
+                );
+            }
+            _ => anyhow::bail!("unexpected response to RAIL request"),
+        },
+        OutputFormat::Json => {
+            let value = match payload {
+                Payload::RailStatus(status) => json!({
+                    "type": "rail_status",
+                    "generation": status.generation,
+                    "next_sequence": status.next_sequence,
+                    "handshake_complete": status.handshake_complete,
+                    "desktop_synchronized": status.desktop_synchronized,
+                    "pending_launches": status.pending_launches.iter().map(rail_launch_json).collect::<Vec<_>>(),
+                }),
+                Payload::RailEvents(events) => json!({
+                    "type": "rail_events",
+                    "generation": events.generation,
+                    "events": events.events.iter().map(rail_event_json).collect::<Vec<_>>(),
+                }),
+                Payload::RailLaunch(launch) => json!({
+                    "type": "rail_launch",
+                    "launch": rail_launch_json(&launch),
+                }),
+                _ => anyhow::bail!("unexpected response to RAIL request"),
+            };
+            println!("{}", serde_json::to_string(&value)?);
+        }
+        OutputFormat::Ndjson => match payload {
+            Payload::RailEvents(events) => {
+                for event in events.events {
+                    println!(
+                        "{}",
+                        serde_json::to_string(&json!({
+                            "type": "rail_event",
+                            "generation": events.generation,
+                            "event": rail_event_json(&event),
+                        }))?
+                    );
+                }
+            }
+            Payload::RailStatus(status) => println!(
+                "{}",
+                serde_json::to_string(&json!({
+                    "type": "rail_status",
+                    "generation": status.generation,
+                    "next_sequence": status.next_sequence,
+                    "handshake_complete": status.handshake_complete,
+                    "desktop_synchronized": status.desktop_synchronized,
+                    "pending_launches": status.pending_launches.iter().map(rail_launch_json).collect::<Vec<_>>(),
+                }))?
+            ),
+            Payload::RailLaunch(launch) => println!(
+                "{}",
+                serde_json::to_string(&json!({
+                    "type": "rail_launch",
+                    "launch": rail_launch_json(&launch),
+                }))?
+            ),
+            _ => anyhow::bail!("unexpected response to RAIL request"),
+        },
+    }
+    Ok(())
+}
+
+fn print_rail_event(event: &RailEvent) {
+    match &event.kind {
+        RailEventKind::Handshake {
+            handshake_ex_flags,
+            initialization_message_count,
+            queued_execute_count,
+        } => println!(
+            "{}: handshake flags={handshake_ex_flags:?} initialization_messages={initialization_message_count} queued_executes={queued_execute_count}",
+            event.sequence
+        ),
+        RailEventKind::DesktopSynchronized { released_execute_count } => println!(
+            "{}: desktop synchronized released_executes={released_execute_count}",
+            event.sequence
+        ),
+        RailEventKind::PostHandshakeQueueReleased { released_execute_count } => println!(
+            "{}: post-handshake queue released executes={released_execute_count}",
+            event.sequence
+        ),
+        RailEventKind::ExecuteQueued(launch) => println!(
+            "{}: queued launch {} {} flags=0x{:04x}",
+            event.sequence, launch.launch_id, launch.executable, launch.flags
+        ),
+        RailEventKind::ExecuteResult {
+            launch_id,
+            executable,
+            flags,
+            result,
+            raw_result,
+        } => println!(
+            "{}: execute result launch={launch_id:?} executable={executable} flags=0x{flags:04x} result=0x{result:04x} raw=0x{raw_result:08x}",
+            event.sequence
+        ),
+        RailEventKind::ApplicationId {
+            window_id,
+            application_id,
+            process_id,
+            process_image_name,
+        } => println!(
+            "{}: application ID window=0x{window_id:08x} application={application_id} process={process_id:?} image={process_image_name:?}",
+            event.sequence
+        ),
+        RailEventKind::Control { kind } => println!("{}: control {kind}", event.sequence),
+        RailEventKind::WindowingOrders { byte_count } => {
+            println!("{}: validated windowing orders ({byte_count} bytes)", event.sequence)
+        }
+        RailEventKind::Gap { lost_through } => {
+            println!("{}: history gap through sequence {lost_through}", event.sequence)
+        }
+    }
+}
+
+fn rail_launch_json(launch: &ironrdp_rpc::ipc::RailLaunchInfo) -> serde_json::Value {
+    serde_json::json!({
+        "launch_id": launch.launch_id,
+        "executable": launch.executable,
+        "flags": launch.flags,
+    })
+}
+
+fn rail_event_json(event: &RailEvent) -> serde_json::Value {
+    use serde_json::json;
+
+    let kind = match &event.kind {
+        RailEventKind::Handshake {
+            handshake_ex_flags,
+            initialization_message_count,
+            queued_execute_count,
+        } => json!({
+            "kind": "handshake",
+            "handshake_ex_flags": handshake_ex_flags,
+            "initialization_message_count": initialization_message_count,
+            "queued_execute_count": queued_execute_count,
+        }),
+        RailEventKind::DesktopSynchronized { released_execute_count } => {
+            json!({"kind": "desktop_synchronized", "released_execute_count": released_execute_count})
+        }
+        RailEventKind::PostHandshakeQueueReleased { released_execute_count } => {
+            json!({"kind": "post_handshake_queue_released", "released_execute_count": released_execute_count})
+        }
+        RailEventKind::ExecuteQueued(launch) => json!({"kind": "execute_queued", "launch": rail_launch_json(launch)}),
+        RailEventKind::ExecuteResult {
+            launch_id,
+            executable,
+            flags,
+            result,
+            raw_result,
+        } => json!({
+            "kind": "execute_result",
+            "launch_id": launch_id,
+            "executable": executable,
+            "flags": flags,
+            "result": result,
+            "raw_result": raw_result,
+        }),
+        RailEventKind::ApplicationId {
+            window_id,
+            application_id,
+            process_id,
+            process_image_name,
+        } => json!({
+            "kind": "application_id",
+            "window_id": window_id,
+            "application_id": application_id,
+            "process_id": process_id,
+            "process_image_name": process_image_name,
+        }),
+        RailEventKind::Control { kind } => json!({"kind": "control", "control": kind}),
+        RailEventKind::WindowingOrders { byte_count } => json!({"kind": "windowing_orders", "byte_count": byte_count}),
+        RailEventKind::Gap { lost_through } => json!({"kind": "gap", "lost_through": lost_through}),
+    };
+    json!({
+        "sequence": event.sequence,
+        "event": kind,
+    })
 }
 
 async fn run_now(endpoint: &Endpoint, args: NowArgs) -> anyhow::Result<Option<u32>> {
@@ -1272,6 +1559,19 @@ fn print_payload(payload: Payload) {
         Payload::NowDiagnostics(diagnostics) => {
             println!("NOW endpoint allocated: {}", diagnostics.endpoint_allocated);
             println!("NOW connected: {}", diagnostics.connected);
+        }
+        Payload::RailStatus(status) => {
+            println!("RAIL generation: {}", status.generation);
+            println!("RAIL handshake complete: {}", status.handshake_complete);
+        }
+        Payload::RailEvents(events) => {
+            println!("RAIL generation: {}", events.generation);
+            for event in &events.events {
+                print_rail_event(event);
+            }
+        }
+        Payload::RailLaunch(launch) => {
+            println!("queued RAIL launch {}: {}", launch.launch_id, launch.executable);
         }
     }
 }

--- a/crates/ironrdp-agent/src/help.rs
+++ b/crates/ironrdp-agent/src/help.rs
@@ -25,6 +25,7 @@ Override with `--endpoint <PATH-OR-PIPE>` on any subcommand.
   `ironrdp-activex` endpoint. The host must set `IRONRDP_ACTIVEX_RPC=1` before creating the
   control; the agent never starts an ActiveX host. Use `--endpoint` when the host uses
   `IRONRDP_ACTIVEX_RPC_ENDPOINT`.
+  RAIL audit commands require the daemon backend.
 
 ## Lifecycle
 
@@ -76,6 +77,23 @@ Override with `--endpoint <PATH-OR-PIPE>` on any subcommand.
 
 ## Inspection
 
+  RAIL commands require the daemon backend.
+  Connect with `--prop remoteapplicationmode:i:1`; add
+  `--prop remoteapplicationprogram:s:<program>` to queue an initial launch.
+
+- `rail status`                     Show RAIL handshake and synchronization state plus agent-queued
+                                   launches.
+- `rail events [--after-sequence N]`
+                                   Show validated RAIL observations retained by the daemon.
+- `rail wait [--after-sequence N] [--timeout-ms MS]`
+                                   Return retained RAIL events newer than `--after-sequence`, waiting
+                                   up to the timeout only when none are available.
+- `rail execute EXECUTABLE [--working-directory DIR] [--arguments ARGS] [--flags FLAGS]`
+                                   Queue a bounded, validated RemoteApp launch.
+  All `rail` subcommands accept `--format human|json|ndjson` before the subcommand.
+  `json` prints one JSON document; `ndjson` prints one JSON object per returned event or response.
+  RAIL event history is bounded to 256 records per connection generation and returns an explicit
+  `gap` event after eviction.
 - `query-props [--filter SUBSTR] [--prefix PREFIX]`
                                  Print the live session property bag, one `key = value` per line.
                                  Secrets are stripped from the configuration before a session

--- a/crates/ironrdp-agent/tests/live_e2e.rs
+++ b/crates/ironrdp-agent/tests/live_e2e.rs
@@ -19,11 +19,13 @@ fn test_endpoint(name: &str) -> String {
     }
 }
 
-fn spawn_daemon(endpoint: &str) -> Child {
-    Command::new(env!("CARGO_BIN_EXE_ironrdp-agent"))
-        .arg("--endpoint")
-        .arg(endpoint)
-        .arg("daemon-start")
+fn spawn_daemon(endpoint: &str, skip_certificate_check: bool) -> Child {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_ironrdp-agent"));
+    command.arg("--endpoint").arg(endpoint).arg("daemon-start");
+    if skip_certificate_check {
+        command.arg("--skip-certificate-check");
+    }
+    command
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -110,7 +112,7 @@ fn connect_launch_browser_and_capture_screenshot() {
     let password = env("IRONRDP_AGENT_E2E_PASSWORD").expect("IRONRDP_AGENT_E2E_PASSWORD");
 
     let endpoint = test_endpoint("live");
-    let mut daemon = spawn_daemon(&endpoint);
+    let mut daemon = spawn_daemon(&endpoint, false);
     let screenshot = std::env::temp_dir().join(format!("ironrdp-agent-live-{}.png", std::process::id()));
 
     let result = std::panic::catch_unwind(|| {
@@ -187,6 +189,79 @@ fn connect_launch_browser_and_capture_screenshot() {
     let _ = daemon.kill();
     let _ = daemon.wait();
     let _ = std::fs::remove_file(&screenshot);
+
+    if let Err(error) = result {
+        std::panic::resume_unwind(error);
+    }
+}
+
+#[test]
+#[ignore = "requires an authorized RAIL endpoint and IRONRDP_AGENT_RAIL_E2E_* environment variables"]
+fn remoteapp_records_validated_rail_evidence() {
+    if env("IRONRDP_AGENT_RAIL_E2E").as_deref() != Some("1") {
+        return;
+    }
+
+    let host = env("IRONRDP_AGENT_RAIL_E2E_HOST").expect("IRONRDP_AGENT_RAIL_E2E_HOST");
+    let username = env("IRONRDP_AGENT_RAIL_E2E_USERNAME").expect("IRONRDP_AGENT_RAIL_E2E_USERNAME");
+    let domain = env("IRONRDP_AGENT_RAIL_E2E_DOMAIN");
+    let password = env("IRONRDP_AGENT_RAIL_E2E_PASSWORD").expect("IRONRDP_AGENT_RAIL_E2E_PASSWORD");
+
+    let endpoint = test_endpoint("rail-live");
+    let mut daemon = spawn_daemon(&endpoint, true);
+    let result = std::panic::catch_unwind(|| {
+        wait_for_daemon(&endpoint);
+
+        let mut connect_args = vec![
+            "connect",
+            "--server",
+            host.as_str(),
+            "--username",
+            username.as_str(),
+            "--password",
+            password.as_str(),
+            "--prop",
+            "remoteapplicationmode:i:1",
+            "--prop",
+            "remoteapplicationprogram:s:notepad.exe",
+            "--prop",
+            "ironrdp_autologon:i:1",
+        ];
+        if let Some(domain) = domain.as_deref() {
+            connect_args.push("--domain");
+            connect_args.push(domain);
+        }
+        assert_success(&agent(&endpoint, &connect_args));
+
+        let deadline = Instant::now() + Duration::from_secs(60);
+        let mut events = String::new();
+        while Instant::now() < deadline {
+            let status = agent(&endpoint, &["rail", "status"]);
+            assert_success(&status);
+            let output = agent(&endpoint, &["rail", "events"]);
+            assert_success(&output);
+            events = String::from_utf8_lossy(&output.stdout).into_owned();
+            if String::from_utf8_lossy(&status.stdout).contains("handshake complete: true")
+                && events.contains("execute result")
+            {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(250));
+        }
+
+        assert!(
+            events.contains("handshake"),
+            "missing RAIL handshake evidence: {events}"
+        );
+        assert!(
+            events.contains("execute result"),
+            "missing RAIL Execute Result evidence: {events}"
+        );
+        assert_success(&agent(&endpoint, &["disconnect"]));
+    });
+
+    let _ = daemon.kill();
+    let _ = daemon.wait();
 
     if let Err(error) = result {
         std::panic::resume_unwind(error);

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use anyhow::Context as _;
 use ironrdp_cfg::PropertySetExt as _;
 use ironrdp_propertyset::PropertySet;
+use ironrdp_rail::pdu::ExecutePdu;
 use url::Url;
 
 #[cfg(feature = "vmconnect")]
@@ -73,6 +74,8 @@ pub struct Config {
     pub(crate) fake_events_interval: Option<Duration>,
     pub(crate) channels: ChannelConfig,
     pub(crate) rail_client_status_flags: Option<u32>,
+    /// Initial RemoteApp launch queued after the RAIL handshake.
+    pub(crate) rail_initial_execute: Option<ExecutePdu>,
 
     /// DVC channel ↔ named-pipe proxy configuration.
     ///
@@ -630,6 +633,7 @@ pub struct ConfigBuilder {
     alternate_shell: Option<String>,
     work_dir: Option<String>,
     remote_application_mode: Option<bool>,
+    remote_application_program: Option<String>,
     rail_support_level: Option<ironrdp_pdu::rdp::capability_sets::RailSupportLevel>,
     rail_client_status_flags: Option<u32>,
 
@@ -1470,6 +1474,21 @@ impl ConfigBuilder {
             anyhow::bail!("RAIL support level must include remote programs support when RemoteApp mode is enabled");
         }
 
+        let rail_initial_execute = if remote_application_mode {
+            self.remote_application_program
+                .as_deref()
+                .filter(|program| !program.is_empty())
+                .or_else(|| self.alternate_shell.as_deref().filter(|shell| !shell.is_empty()))
+                .map(|executable| ExecutePdu {
+                    flags: 0,
+                    executable: executable.to_owned(),
+                    working_directory: self.work_dir.clone().unwrap_or_default(),
+                    arguments: String::new(),
+                })
+        } else {
+            None
+        };
+
         let connector = ironrdp_connector::Config {
             credentials: ironrdp_connector::Credentials::UsernamePassword {
                 username: self.username.unwrap_or_default(),
@@ -1511,8 +1530,16 @@ impl ConfigBuilder {
             compression_type,
             performance_flags: self.performance_flags.unwrap_or_default(),
             timezone_info: TimezoneInfo::default(),
-            alternate_shell: self.alternate_shell.unwrap_or_default(),
-            work_dir: self.work_dir.unwrap_or_default(),
+            alternate_shell: if remote_application_mode {
+                String::new()
+            } else {
+                self.alternate_shell.unwrap_or_default()
+            },
+            work_dir: if remote_application_mode {
+                String::new()
+            } else {
+                self.work_dir.unwrap_or_default()
+            },
             remote_application_mode,
             rail_support_level,
         };
@@ -1542,6 +1569,7 @@ impl ConfigBuilder {
             fake_events_interval: self.fake_events_interval,
             channels: self.channels,
             rail_client_status_flags: self.rail_client_status_flags,
+            rail_initial_execute,
             #[cfg(feature = "dvc-pipe-proxy")]
             dvc_pipe_proxies: self.dvc_pipe_proxies,
             #[cfg(all(windows, feature = "dvc-com-plugin"))]
@@ -1620,6 +1648,9 @@ impl ConfigBuilder {
         }
         if let Some(remote_application_mode) = ps.remote_application_mode() {
             self.remote_application_mode = Some(remote_application_mode);
+        }
+        if let Some(program) = ps.remote_application_program() {
+            self.remote_application_program = Some(program.to_owned());
         }
         if let Some(minutes) = ps.fake_events_interval() {
             self.fake_events_interval = Some(Duration::from_secs(u64::from(minutes) * 60));
@@ -1868,5 +1899,26 @@ mod tests {
 
         assert!(config.connector().remote_application_mode);
         assert_eq!(config.properties().remote_application_mode(), Some(true));
+    }
+
+    #[test]
+    fn remote_application_program_queues_rail_execute_and_clears_client_info_shell() {
+        let mut properties = ironrdp_propertyset::PropertySet::new();
+        properties.set_remote_application_mode(true);
+        properties.set_remote_application_program("notepad.exe");
+        properties.set_alternate_shell("fallback.exe");
+        properties.set_shell_working_directory("C:\\Temp");
+
+        let config = complete_builder()
+            .with_property_set(&properties)
+            .expect("valid properties")
+            .build()
+            .expect("valid RemoteApp configuration");
+
+        assert!(config.connector().alternate_shell.is_empty());
+        assert!(config.connector().work_dir.is_empty());
+        let execute = config.rail_initial_execute.expect("initial Execute PDU");
+        assert_eq!(execute.executable, "notepad.exe");
+        assert_eq!(execute.working_directory, "C:\\Temp");
     }
 }

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -599,6 +599,7 @@ impl RdpClient {
             match active_session(
                 framed,
                 connection_result,
+                self.config.rail_initial_execute.clone(),
                 &self.output_event_sender,
                 &mut self.input_event_receiver,
                 &mut self.clipboard_event_receiver,
@@ -1555,6 +1556,7 @@ fn poll_deferred_rdpdr_output(active_stage: &mut ActiveStage) -> SessionResult<O
 async fn active_session(
     framed: UpgradedFramed,
     connection_result: ConnectionResult,
+    initial_rail_execute: Option<ExecutePdu>,
     output_event_sender: &mpsc::Sender<RdpOutputEvent>,
     input_event_receiver: &mut mpsc::Receiver<RdpInputEvent>,
     clipboard_event_receiver: &mut mpsc::UnboundedReceiver<RdpInputEvent>,
@@ -1584,6 +1586,14 @@ async fn active_session(
     }
     .build();
     active_stage.set_window_support_level(window_support_level);
+    if let Some(execute) = initial_rail_execute {
+        let rail_client = active_stage
+            .get_svc_processor_mut::<RailClient>()
+            .ok_or_else(|| ironrdp_session::general_err!("RemoteApp launch requested without a RAIL static channel"))?;
+        rail_client
+            .queue_execute(execute)
+            .map_err(|error| ironrdp_session::custom_err!("queue initial RemoteApp launch", error))?;
+    }
 
     // Timer interval for driving clipboard lock timeouts.
     let mut cleanup_interval = tokio::time::interval(Duration::from_secs(5));
@@ -1768,34 +1778,60 @@ async fn active_session(
                         }
                     }
                     RdpInputEvent::RailExecute(execute) => {
-                        let messages = {
-                            let rail_client = active_stage
-                                .get_svc_processor_mut::<RailClient>()
-                                .ok_or_else(|| ironrdp_session::general_err!("RAIL is not enabled for this session"))?;
-                            rail_client
-                                .queue_execute(execute)
-                                .map_err(|error| ironrdp_session::custom_err!("RAIL", error))?
+                        let messages = match active_stage.get_svc_processor_mut::<RailClient>() {
+                            Some(rail_client) => match rail_client.queue_execute(execute) {
+                                Ok(messages) => Some(messages),
+                                Err(error) => {
+                                    warn!(%error, "Unable to queue RAIL Execute request");
+                                    None
+                                }
+                            },
+                            None => {
+                                warn!("Unable to queue RAIL Execute request because RAIL is disabled");
+                                None
+                            }
                         };
-                        let frame = active_stage.process_svc_processor_messages(messages)?;
-                        (!frame.is_empty())
-                            .then_some(ActiveStageOutput::ResponseFrame(frame))
-                            .into_iter()
-                            .collect()
+                        match messages {
+                            Some(messages) => match active_stage.process_svc_processor_messages(messages) {
+                                Ok(frame) => (!frame.is_empty())
+                                    .then_some(ActiveStageOutput::ResponseFrame(frame))
+                                    .into_iter()
+                                    .collect(),
+                                Err(error) => {
+                                    warn!(%error, "Unable to process RAIL Execute request");
+                                    Vec::new()
+                                }
+                            },
+                            None => Vec::new(),
+                        }
                     }
                     RdpInputEvent::Rail(event) => {
-                        let messages = {
-                            let rail_client = active_stage
-                                .get_svc_processor_mut::<RailClient>()
-                                .ok_or_else(|| ironrdp_session::general_err!("RAIL is not enabled for this session"))?;
-                            rail_client
-                                .queue_input(event)
-                                .map_err(|error| ironrdp_session::custom_err!("RAIL", error))?
+                        let messages = match active_stage.get_svc_processor_mut::<RailClient>() {
+                            Some(rail_client) => match rail_client.queue_input(event) {
+                                Ok(messages) => Some(messages),
+                                Err(error) => {
+                                    warn!(%error, "Unable to queue RAIL input");
+                                    None
+                                }
+                            },
+                            None => {
+                                warn!("Unable to queue RAIL input because RAIL is disabled");
+                                None
+                            }
                         };
-                        let frame = active_stage.process_svc_processor_messages(messages)?;
-                        (!frame.is_empty())
-                            .then_some(ActiveStageOutput::ResponseFrame(frame))
-                            .into_iter()
-                            .collect()
+                        match messages {
+                            Some(messages) => match active_stage.process_svc_processor_messages(messages) {
+                                Ok(frame) => (!frame.is_empty())
+                                    .then_some(ActiveStageOutput::ResponseFrame(frame))
+                                    .into_iter()
+                                    .collect(),
+                                Err(error) => {
+                                    warn!(%error, "Unable to process RAIL input");
+                                    Vec::new()
+                                }
+                            },
+                            None => Vec::new(),
+                        }
                     }
                     }
                 }

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -66,6 +66,17 @@ pub enum DisplayResizeFallbackReason {
     ReactivationTimedOut,
 }
 
+/// Explains why a locally accepted RemoteApp launch could not be processed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RailExecuteFailureReason {
+    /// The active session has no RAIL static-channel processor.
+    RailUnavailable,
+    /// The RAIL client rejected the Execute request before it could be sent.
+    QueueRejected,
+    /// The active stage could not encode the queued RAIL messages.
+    MessageProcessingFailed,
+}
+
 #[derive(Debug)]
 pub enum RdpOutputEvent {
     /// Connection negotiation and activation have completed.
@@ -108,6 +119,15 @@ pub enum RdpOutputEvent {
     },
     /// The server completed a RemoteApp launch request.
     RailExecuteResult(ExecuteResultPdu),
+    /// A locally accepted RemoteApp launch could not be processed.
+    ///
+    /// The event carries only the launch correlation fields, never its working directory or
+    /// arguments.
+    RailExecuteFailed {
+        executable: String,
+        flags: u16,
+        reason: RailExecuteFailureReason,
+    },
     /// The server supplied an application identity for a remote window.
     RailApplicationId {
         window_id: u32,
@@ -1778,17 +1798,19 @@ async fn active_session(
                         }
                     }
                     RdpInputEvent::RailExecute(execute) => {
-                        let messages = match active_stage.get_svc_processor_mut::<RailClient>() {
+                        let executable = execute.executable.clone();
+                        let flags = execute.flags;
+                        let (messages, failure_reason) = match active_stage.get_svc_processor_mut::<RailClient>() {
                             Some(rail_client) => match rail_client.queue_execute(execute) {
-                                Ok(messages) => Some(messages),
+                                Ok(messages) => (Some(messages), None),
                                 Err(error) => {
                                     warn!(%error, "Unable to queue RAIL Execute request");
-                                    None
+                                    (None, Some(RailExecuteFailureReason::QueueRejected))
                                 }
                             },
                             None => {
                                 warn!("Unable to queue RAIL Execute request because RAIL is disabled");
-                                None
+                                (None, Some(RailExecuteFailureReason::RailUnavailable))
                             }
                         };
                         match messages {
@@ -1799,10 +1821,43 @@ async fn active_session(
                                     .collect(),
                                 Err(error) => {
                                     warn!(%error, "Unable to process RAIL Execute request");
+                                    if !send_active_output_event(
+                                        output_event_sender,
+                                        RdpOutputEvent::RailExecuteFailed {
+                                            executable,
+                                            flags,
+                                            reason: RailExecuteFailureReason::MessageProcessingFailed,
+                                        },
+                                        close_receiver,
+                                    )
+                                    .await?
+                                    {
+                                        return Ok(RdpControlFlow::TerminatedGracefully(
+                                            GracefulDisconnectReason::UserInitiated,
+                                        ));
+                                    }
                                     Vec::new()
                                 }
                             },
-                            None => Vec::new(),
+                            None => {
+                                let reason = failure_reason.expect("RAIL Execute failure reason must be recorded");
+                                if !send_active_output_event(
+                                    output_event_sender,
+                                    RdpOutputEvent::RailExecuteFailed {
+                                        executable,
+                                        flags,
+                                        reason,
+                                    },
+                                    close_receiver,
+                                )
+                                .await?
+                                {
+                                    return Ok(RdpControlFlow::TerminatedGracefully(
+                                        GracefulDisconnectReason::UserInitiated,
+                                    ));
+                                }
+                                Vec::new()
+                            }
                         }
                     }
                     RdpInputEvent::Rail(event) => {
@@ -2836,6 +2891,34 @@ mod tests {
         assert!(matches!(
             output_receiver.recv().await,
             Some(RdpOutputEvent::WindowingOrders(data)) if data == [0, 0, 1, 2, 3]
+        ));
+    }
+
+    #[tokio::test]
+    async fn local_rail_execute_failure_is_delivered_without_terminating_the_session() {
+        let (output_sender, mut output_receiver) = mpsc::channel(1);
+        let (_close_sender, mut close_receiver) = watch::channel(false);
+
+        assert!(
+            send_active_output_event(
+                &output_sender,
+                RdpOutputEvent::RailExecuteFailed {
+                    executable: "notepad.exe".to_owned(),
+                    flags: 0,
+                    reason: RailExecuteFailureReason::QueueRejected,
+                },
+                &mut close_receiver,
+            )
+            .await
+            .expect("deliver local RAIL Execute failure")
+        );
+        assert!(matches!(
+            output_receiver.recv().await,
+            Some(RdpOutputEvent::RailExecuteFailed {
+                executable,
+                flags: 0,
+                reason: RailExecuteFailureReason::QueueRejected,
+            }) if executable == "notepad.exe"
         ));
     }
 

--- a/crates/ironrdp-daemon/Cargo.toml
+++ b/crates/ironrdp-daemon/Cargo.toml
@@ -28,6 +28,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"] }
 whoami = "2.1"
+ironrdp-rail = { version = "0.1.0", path = "../ironrdp-rail" }
 
 [dev-dependencies]
 now-proto-pdu = { version = "0.4", features = ["std"] }

--- a/crates/ironrdp-daemon/src/daemon.rs
+++ b/crates/ironrdp-daemon/src/daemon.rs
@@ -15,7 +15,10 @@ use anyhow::Context as _;
 use ironrdp_cfg::PropertySetExt as _;
 use ironrdp_client::config::{ConfigBuilder, MissingField};
 use ironrdp_client::rail::RailControlEvent;
-use ironrdp_client::rdp::{RdpClient, RdpInputEvent, RdpInputSender, RdpOutputEvent};
+use ironrdp_client::rdp::{
+    RailExecuteFailureReason as ClientRailExecuteFailureReason, RdpClient, RdpInputEvent, RdpInputSender,
+    RdpOutputEvent,
+};
 use ironrdp_input::{Database, MousePosition, Operation, Scancode, WheelRotations};
 use ironrdp_pdu::rdp::capability_sets::MajorPlatformType;
 use ironrdp_propertyset::{PropertySet, Value};
@@ -33,8 +36,8 @@ use ironrdp_rdpdr_native::{RedirectedDrive, WindowsRdpdrBackendFactory};
 
 use crate::ipc::{
     ConnState, KeyFilter, MAX_UNICODE_TEXT_CHARS, NowDiagnostics, Payload, PropValue, PropertyDump, PropertyEntry,
-    RailEvent, RailEventDump, RailEventKind, RailExecuteRequest, RailLaunchInfo, RailStatusInfo, Request, Response,
-    StatusInfo,
+    RailEvent, RailEventDump, RailEventKind, RailExecuteFailureReason, RailExecuteRequest, RailLaunchInfo,
+    RailStatusInfo, Request, Response, StatusInfo,
 };
 use crate::logbuf::{self, LogBuffer};
 use crate::now::NowEndpoint;
@@ -318,10 +321,10 @@ enum PendingRailLaunch {
 }
 
 impl RailLedger {
-    fn new(generation: u64, initial_execute: Option<(u16, String)>) -> Self {
+    fn new(generation: u64, next_sequence: u64, initial_execute: Option<(u16, String)>) -> Self {
         Self {
             generation,
-            next_sequence: 1,
+            next_sequence,
             handshake_complete: false,
             desktop_synchronized: false,
             events: VecDeque::new(),
@@ -708,6 +711,7 @@ impl Daemon {
             rail_initial_execute: initial_rail_execute.clone(),
             rail: RailLedger::new(
                 self.next_rail_generation.fetch_add(1, Ordering::Relaxed),
+                1,
                 initial_rail_execute,
             ),
         }));
@@ -968,7 +972,9 @@ impl Daemon {
                 );
             }
         }
+        drop(live);
         permit.send(RdpInputEvent::RailExecute(execute));
+        session.rail_notify.notify_waiters();
         Response::Ok(Payload::RailLaunch(launch))
     }
 
@@ -1308,6 +1314,27 @@ async fn consume_output(
                 });
                 true
             }
+            RdpOutputEvent::RailExecuteFailed {
+                executable,
+                flags,
+                reason,
+            } => {
+                let launch_id = guard.rail.take_launch(flags, &executable);
+                let reason = match reason {
+                    ClientRailExecuteFailureReason::RailUnavailable => RailExecuteFailureReason::RailUnavailable,
+                    ClientRailExecuteFailureReason::QueueRejected => RailExecuteFailureReason::QueueRejected,
+                    ClientRailExecuteFailureReason::MessageProcessingFailed => {
+                        RailExecuteFailureReason::MessageProcessingFailed
+                    }
+                };
+                guard.rail.record(RailEventKind::ExecuteFailed {
+                    launch_id,
+                    executable,
+                    flags,
+                    reason,
+                });
+                true
+            }
             RdpOutputEvent::RailApplicationId {
                 window_id,
                 application_id,
@@ -1335,8 +1362,10 @@ async fn consume_output(
                 true
             }
             RdpOutputEvent::DisplayResizeFallback(_) => {
+                let next_sequence = guard.rail.next_sequence;
                 guard.rail = RailLedger::new(
                     next_rail_generation.fetch_add(1, Ordering::Relaxed),
+                    next_sequence,
                     guard.rail_initial_execute.clone(),
                 );
                 true
@@ -1582,7 +1611,7 @@ mod tests {
 
     #[test]
     fn rail_ledger_reports_history_gaps_and_correlates_launches() {
-        let mut ledger = RailLedger::new(7, None);
+        let mut ledger = RailLedger::new(7, 1, None);
         let launch = RailLaunchInfo {
             launch_id: 1,
             executable: "notepad.exe".to_owned(),
@@ -1608,7 +1637,7 @@ mod tests {
 
     #[test]
     fn rail_ledger_reserves_capacity_for_the_initial_launch() {
-        let mut ledger = RailLedger::new(7, Some((0, "notepad.exe".to_owned())));
+        let mut ledger = RailLedger::new(7, 1, Some((0, "notepad.exe".to_owned())));
         let max_launches = u64::try_from(MAX_PENDING_RAIL_LAUNCHES).expect("launch limit fits");
 
         for launch_id in 1..max_launches {
@@ -1645,7 +1674,7 @@ mod tests {
 
     #[test]
     fn rail_ledger_rejects_indistinguishable_pending_launches() {
-        let mut ledger = RailLedger::new(7, Some((0, "notepad.exe".to_owned())));
+        let mut ledger = RailLedger::new(7, 1, Some((0, "notepad.exe".to_owned())));
 
         assert!(
             ledger
@@ -1675,7 +1704,7 @@ mod tests {
             error: None,
             frame: None,
             rail_initial_execute: Some((0, "notepad.exe".to_owned())),
-            rail: RailLedger::new(1, Some((0, "notepad.exe".to_owned()))),
+            rail: RailLedger::new(1, 1, Some((0, "notepad.exe".to_owned()))),
         }));
         {
             let mut guard = live.lock().expect("session live state poisoned");
@@ -1714,13 +1743,20 @@ mod tests {
         assert!(!guard.rail.handshake_complete);
         assert!(!guard.rail.desktop_synchronized);
         assert!(guard.rail.status().pending_launches.is_empty());
+        assert_eq!(guard.rail.status().next_sequence, 2);
         assert_eq!(guard.rail.take_launch(0, "notepad.exe"), None);
     }
 
-    #[tokio::test]
-    async fn rail_wait_ignores_non_rail_output_until_evidence_arrives() {
+    fn active_rail_session(
+        rail_enabled: bool,
+    ) -> (
+        Daemon,
+        mpsc::Receiver<RdpInputEvent>,
+        Arc<Mutex<Live>>,
+        Arc<tokio::sync::Notify>,
+    ) {
         let daemon = Daemon::with_overlay(PropertySet::new());
-        let (input_tx, _) = RdpInputSender::channel(1);
+        let (input_tx, input_rx) = RdpInputSender::channel(1);
         let now_endpoint = Arc::new(NowEndpoint::new().expect("create NOW endpoint"));
         let live = Arc::new(Mutex::new(Live {
             properties: PropertySet::new(),
@@ -1728,19 +1764,25 @@ mod tests {
             error: None,
             frame: None,
             rail_initial_execute: None,
-            rail: RailLedger::new(1, None),
+            rail: RailLedger::new(1, 1, None),
         }));
         let rail_notify = Arc::new(tokio::sync::Notify::new());
         *daemon.state.lock().expect("daemon state poisoned") = Some(Session {
             input_tx,
             input_db: Database::new(),
             destination: "server.example".to_owned(),
-            rail_enabled: true,
+            rail_enabled,
             live: Arc::clone(&live),
             rail_notify: Arc::clone(&rail_notify),
             operations: OperationManager::new(Arc::clone(&now_endpoint)),
             now_endpoint,
         });
+        (daemon, input_rx, live, rail_notify)
+    }
+
+    #[tokio::test]
+    async fn rail_wait_ignores_non_rail_output_until_evidence_arrives() {
+        let (daemon, _, live, rail_notify) = active_rail_session(true);
 
         let (output_tx, output_rx) = mpsc::channel(1);
         let consumer = tokio::spawn(consume_output(
@@ -1783,29 +1825,153 @@ mod tests {
         consumer.await.expect("consume output");
     }
 
+    #[tokio::test]
+    async fn rail_execute_wakes_waiters_after_queueing_evidence() {
+        let (daemon, mut input_rx, _, _) = active_rail_session(true);
+        let mut wait = Box::pin(daemon.rail_wait(Some(0), 1_000));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), wait.as_mut())
+                .await
+                .is_err()
+        );
+
+        let response = daemon.rail_execute(RailExecuteRequest {
+            executable: "notepad.exe".to_owned(),
+            working_directory: String::new(),
+            arguments: String::new(),
+            flags: 0,
+        });
+        assert!(matches!(
+            response,
+            Response::Ok(Payload::RailLaunch(RailLaunchInfo { launch_id: 1, .. }))
+        ));
+        assert!(matches!(
+            input_rx.recv().await,
+            Some(RdpInputEvent::RailExecute(execute)) if execute.executable == "notepad.exe"
+        ));
+
+        let response = tokio::time::timeout(Duration::from_secs(1), wait.as_mut())
+            .await
+            .expect("queued launch wakes wait");
+        assert!(matches!(
+            response,
+            Response::Ok(Payload::RailEvents(events))
+                if matches!(
+                    events.events.as_slice(),
+                    [event] if matches!(event.kind, RailEventKind::ExecuteQueued(_))
+                )
+        ));
+    }
+
+    #[tokio::test]
+    async fn rail_cursors_resume_after_resize_generation_resets() {
+        let (daemon, _, live, _) = active_rail_session(true);
+        let after_sequence = {
+            let mut live = live.lock().expect("session live state poisoned");
+            live.rail.record(RailEventKind::WindowingOrders { byte_count: 1 });
+            let after_sequence = live.rail.next_sequence.saturating_sub(1);
+            let next_sequence = live.rail.next_sequence;
+            live.rail = RailLedger::new(2, next_sequence, None);
+            live.rail.record(RailEventKind::WindowingOrders { byte_count: 2 });
+            after_sequence
+        };
+
+        let events = daemon.rail_events(Some(after_sequence));
+        assert!(matches!(
+            events,
+            Response::Ok(Payload::RailEvents(events))
+                if events.generation == 2
+                    && matches!(
+                        events.events.as_slice(),
+                        [event] if event.sequence > after_sequence
+                            && matches!(event.kind, RailEventKind::WindowingOrders { byte_count: 2 })
+                    )
+        ));
+        let events = daemon.rail_wait(Some(after_sequence), 0).await;
+        assert!(matches!(
+            events,
+            Response::Ok(Payload::RailEvents(events))
+                if events.generation == 2
+                    && matches!(
+                        events.events.as_slice(),
+                        [event] if event.sequence > after_sequence
+                            && matches!(event.kind, RailEventKind::WindowingOrders { byte_count: 2 })
+                    )
+        ));
+    }
+
+    #[tokio::test]
+    async fn local_rail_execute_failure_resolves_pending_launch_without_terminating() {
+        let (daemon, mut input_rx, live, rail_notify) = active_rail_session(true);
+        let (output_tx, output_rx) = mpsc::channel(1);
+        let consumer = tokio::spawn(consume_output(
+            output_rx,
+            Arc::clone(&live),
+            None,
+            rail_notify,
+            Arc::new(AtomicU64::new(2)),
+        ));
+
+        assert!(matches!(
+            daemon.rail_execute(RailExecuteRequest {
+                executable: "notepad.exe".to_owned(),
+                working_directory: String::new(),
+                arguments: "--token secret-token".to_owned(),
+                flags: 0,
+            }),
+            Response::Ok(Payload::RailLaunch(RailLaunchInfo { launch_id: 1, .. }))
+        ));
+        assert!(matches!(input_rx.recv().await, Some(RdpInputEvent::RailExecute(_))));
+
+        let mut wait = Box::pin(daemon.rail_wait(Some(1), 1_000));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), wait.as_mut())
+                .await
+                .is_err()
+        );
+        output_tx
+            .send(ironrdp_client::rdp::RdpOutputEvent::RailExecuteFailed {
+                executable: "notepad.exe".to_owned(),
+                flags: 0,
+                reason: ironrdp_client::rdp::RailExecuteFailureReason::RailUnavailable,
+            })
+            .await
+            .expect("send local failure");
+
+        let response = tokio::time::timeout(Duration::from_secs(1), wait.as_mut())
+            .await
+            .expect("local failure wakes wait");
+        assert!(matches!(
+            response,
+            Response::Ok(Payload::RailEvents(events))
+                if matches!(
+                    events.events.as_slice(),
+                    [event] if matches!(
+                        event.kind,
+                        RailEventKind::ExecuteFailed {
+                            launch_id: Some(1),
+                            reason: ironrdp_rpc::ipc::RailExecuteFailureReason::RailUnavailable,
+                            ..
+                        }
+                    )
+                )
+        ));
+        assert!(matches!(
+            daemon.rail_status(),
+            Response::Ok(Payload::RailStatus(status)) if status.pending_launches.is_empty()
+        ));
+        assert_eq!(
+            live.lock().expect("session live state poisoned").state,
+            ConnState::Connected
+        );
+
+        drop(output_tx);
+        consumer.await.expect("consume output");
+    }
+
     #[test]
     fn rail_execute_rejects_desktop_sessions_without_queueing_input() {
-        let daemon = Daemon::with_overlay(PropertySet::new());
-        let (input_tx, mut input_rx) = RdpInputSender::channel(1);
-        let now_endpoint = Arc::new(NowEndpoint::new().expect("create NOW endpoint"));
-        let live = Arc::new(Mutex::new(Live {
-            properties: PropertySet::new(),
-            state: ConnState::Connected,
-            error: None,
-            frame: None,
-            rail_initial_execute: None,
-            rail: RailLedger::new(1, None),
-        }));
-        *daemon.state.lock().expect("daemon state poisoned") = Some(Session {
-            input_tx,
-            input_db: Database::new(),
-            destination: "server.example".to_owned(),
-            rail_enabled: false,
-            live,
-            rail_notify: Arc::new(tokio::sync::Notify::new()),
-            operations: OperationManager::new(Arc::clone(&now_endpoint)),
-            now_endpoint,
-        });
+        let (daemon, mut input_rx, _, _) = active_rail_session(false);
 
         let response = daemon.rail_execute(RailExecuteRequest {
             executable: "notepad.exe".to_owned(),

--- a/crates/ironrdp-daemon/src/daemon.rs
+++ b/crates/ironrdp-daemon/src/daemon.rs
@@ -5,15 +5,21 @@
 //! explicitly with `daemon-start` and runs in the foreground; the caller is expected to background
 //! it. On a clean shutdown the Unix socket file is removed (see [`crate::transport`]).
 
+use core::sync::atomic::{AtomicU64, Ordering};
+use core::time::Duration;
+use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use anyhow::Context as _;
+use ironrdp_cfg::PropertySetExt as _;
 use ironrdp_client::config::{ConfigBuilder, MissingField};
+use ironrdp_client::rail::RailControlEvent;
 use ironrdp_client::rdp::{RdpClient, RdpInputEvent, RdpInputSender, RdpOutputEvent};
 use ironrdp_input::{Database, MousePosition, Operation, Scancode, WheelRotations};
 use ironrdp_pdu::rdp::capability_sets::MajorPlatformType;
 use ironrdp_propertyset::{PropertySet, Value};
+use ironrdp_rail::pdu::{ExecutePdu, RailPdu};
 use ironrdp_tls::CertificateValidation;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::mpsc;
@@ -27,7 +33,8 @@ use ironrdp_rdpdr_native::{RedirectedDrive, WindowsRdpdrBackendFactory};
 
 use crate::ipc::{
     ConnState, KeyFilter, MAX_UNICODE_TEXT_CHARS, NowDiagnostics, Payload, PropValue, PropertyDump, PropertyEntry,
-    Request, Response, StatusInfo,
+    RailEvent, RailEventDump, RailEventKind, RailExecuteRequest, RailLaunchInfo, RailStatusInfo, Request, Response,
+    StatusInfo,
 };
 use crate::logbuf::{self, LogBuffer};
 use crate::now::NowEndpoint;
@@ -219,6 +226,9 @@ pub struct Daemon {
     /// Whether [`Self::overlay`] contributes any secret (password/token) value, i.e. whether the
     /// caller can omit credentials of its own.
     credentials_loaded: bool,
+    /// Monotonically assigns RAIL ledger generations so observations from a former session cannot be
+    /// mistaken for the active connection.
+    next_rail_generation: Arc<AtomicU64>,
     certificate_validation: CertificateValidation,
     #[cfg(windows)]
     rdpdr_backend_factory: Option<WindowsRdpdrBackendFactory>,
@@ -232,7 +242,9 @@ struct Session {
     input_tx: RdpInputSender,
     input_db: Database,
     destination: String,
+    rail_enabled: bool,
     live: Arc<Mutex<Live>>,
+    rail_notify: Arc<tokio::sync::Notify>,
     now_endpoint: Arc<NowEndpoint>,
     operations: OperationManager,
 }
@@ -273,6 +285,138 @@ struct Live {
     /// Most recent frame (with the cursor already composited in by the session). Replaced on every
     /// graphics update; `None` until the first frame arrives.
     frame: Option<Frame>,
+    rail_initial_execute: Option<(u16, String)>,
+    rail: RailLedger,
+}
+
+const MAX_RAIL_EVENTS: usize = 256;
+const MAX_PENDING_RAIL_LAUNCHES: usize = 64;
+
+#[derive(Debug)]
+enum RailLaunchQueueError {
+    LimitReached,
+    DuplicateResponse,
+}
+
+/// Session-local RAIL evidence. The daemon records only client-validated outputs; it never reparses
+/// static-channel payloads or drawing orders.
+struct RailLedger {
+    generation: u64,
+    next_sequence: u64,
+    handshake_complete: bool,
+    desktop_synchronized: bool,
+    events: VecDeque<RailEvent>,
+    pending_launches: VecDeque<PendingRailLaunch>,
+}
+
+/// A client Execute request awaiting its server result.
+enum PendingRailLaunch {
+    /// The Execute request configured before the RDP session becomes active.
+    Initial { flags: u16, executable: String },
+    /// An Execute request explicitly submitted through the agent IPC API.
+    Agent(RailLaunchInfo),
+}
+
+impl RailLedger {
+    fn new(generation: u64, initial_execute: Option<(u16, String)>) -> Self {
+        Self {
+            generation,
+            next_sequence: 1,
+            handshake_complete: false,
+            desktop_synchronized: false,
+            events: VecDeque::new(),
+            pending_launches: initial_execute
+                .into_iter()
+                .map(|(flags, executable)| PendingRailLaunch::Initial { flags, executable })
+                .collect(),
+        }
+    }
+
+    fn record(&mut self, kind: RailEventKind) {
+        let event = RailEvent {
+            sequence: self.next_sequence,
+            kind,
+        };
+        self.next_sequence = self.next_sequence.saturating_add(1);
+        if self.events.len() == MAX_RAIL_EVENTS {
+            let _ = self.events.pop_front();
+        }
+        self.events.push_back(event);
+    }
+
+    fn status(&self) -> RailStatusInfo {
+        RailStatusInfo {
+            generation: self.generation,
+            next_sequence: self.next_sequence,
+            handshake_complete: self.handshake_complete,
+            desktop_synchronized: self.desktop_synchronized,
+            pending_launches: self
+                .pending_launches
+                .iter()
+                .filter_map(|launch| match launch {
+                    PendingRailLaunch::Initial { .. } => None,
+                    PendingRailLaunch::Agent(launch) => Some(launch.clone()),
+                })
+                .collect(),
+        }
+    }
+
+    fn events_after(&self, after_sequence: Option<u64>) -> RailEventDump {
+        let after_sequence = after_sequence.unwrap_or(0);
+        let mut events = Vec::new();
+        if let Some(first) = self.events.front() {
+            let lost_through = first.sequence.saturating_sub(1);
+            if after_sequence < lost_through {
+                events.push(RailEvent {
+                    sequence: lost_through,
+                    kind: RailEventKind::Gap { lost_through },
+                });
+            }
+        }
+        events.extend(
+            self.events
+                .iter()
+                .filter(|event| event.sequence > after_sequence)
+                .cloned(),
+        );
+        RailEventDump {
+            generation: self.generation,
+            events,
+        }
+    }
+
+    fn queue_launch(&mut self, launch: RailLaunchInfo) -> Result<(), RailLaunchQueueError> {
+        if self.pending_launches.len() >= MAX_PENDING_RAIL_LAUNCHES {
+            return Err(RailLaunchQueueError::LimitReached);
+        }
+        if self.pending_launches.iter().any(|pending| match pending {
+            PendingRailLaunch::Initial { flags, executable } => {
+                *flags == launch.flags && executable == &launch.executable
+            }
+            PendingRailLaunch::Agent(pending) => {
+                pending.flags == launch.flags && pending.executable == launch.executable
+            }
+        }) {
+            return Err(RailLaunchQueueError::DuplicateResponse);
+        }
+        self.record(RailEventKind::ExecuteQueued(launch.clone()));
+        self.pending_launches.push_back(PendingRailLaunch::Agent(launch));
+        Ok(())
+    }
+
+    fn take_launch(&mut self, flags: u16, executable: &str) -> Option<u64> {
+        let index = self.pending_launches.iter().position(|launch| match launch {
+            PendingRailLaunch::Initial {
+                flags: initial_flags,
+                executable: initial_executable,
+            } => *initial_flags == flags && initial_executable == executable,
+            PendingRailLaunch::Agent(launch) => launch.flags == flags && launch.executable == executable,
+        })?;
+        match self.pending_launches.remove(index) {
+            Some(PendingRailLaunch::Initial { .. }) | None => None,
+            Some(PendingRailLaunch::Agent(launch)) => Some(launch.launch_id),
+        }
+    }
 }
 
 /// A decoded frame retained for screenshots. `pixels` are `0x00RRGGBB` (`to_be_bytes()` yields
@@ -308,6 +452,7 @@ impl Daemon {
             logs,
             overlay,
             credentials_loaded,
+            next_rail_generation: Arc::new(AtomicU64::new(1)),
             certificate_validation,
             #[cfg(windows)]
             rdpdr_backend_factory,
@@ -420,6 +565,13 @@ impl Daemon {
                 last,
             } => DaemonResponse::Single(self.now_stdin(operation_id, data, last).await),
             Request::NowDiagnostics => DaemonResponse::Single(self.now_diagnostics().await),
+            Request::RailStatus => DaemonResponse::Single(self.rail_status()),
+            Request::RailEvents { after_sequence } => DaemonResponse::Single(self.rail_events(after_sequence)),
+            Request::RailWait {
+                after_sequence,
+                timeout_ms,
+            } => DaemonResponse::Single(self.rail_wait(after_sequence, timeout_ms).await),
+            Request::RailExecute(request) => DaemonResponse::Single(self.rail_execute(request)),
         }
     }
 
@@ -489,6 +641,9 @@ impl Daemon {
             .with_client_name(client_name())
             .with_dvc_pipe_proxy(now_endpoint.dvc_proxy_info())
             .with_certificate_validation(certificate_validation)
+            // The headless agent observes validated RAIL state but does not implement local
+            // move/size, taskbar, cloak, z-order, or display-power behavior.
+            .with_rail_client_status_flags(0)
             // Headless: composite the remote cursor into the framebuffer so it appears in
             // screenshots (there is no separate overlay to draw it).
             .with_pointer_software_rendering(true);
@@ -524,6 +679,16 @@ impl Daemon {
         // `ConfigBuilder::build` strips every secret property, so the live bag carries no secrets.
         let live_seed = config.properties().clone();
         let destination = config.destination().to_string();
+        let rail_enabled = live_seed.remote_application_mode().unwrap_or(false);
+        let initial_rail_execute = if rail_enabled {
+            live_seed
+                .remote_application_program()
+                .filter(|program| !program.is_empty())
+                .or_else(|| live_seed.alternate_shell().filter(|shell| !shell.is_empty()))
+                .map(|executable| (0, executable.to_owned()))
+        } else {
+            None
+        };
 
         let (output_tx, output_rx) = mpsc::channel(16);
         let client = RdpClient::new(config, output_tx);
@@ -534,11 +699,17 @@ impl Daemon {
         };
         let input_tx = client.input_sender();
 
+        let rail_notify = Arc::new(tokio::sync::Notify::new());
         let live = Arc::new(Mutex::new(Live {
             properties: live_seed,
             state: ConnState::Connecting,
             error: None,
             frame: None,
+            rail_initial_execute: initial_rail_execute.clone(),
+            rail: RailLedger::new(
+                self.next_rail_generation.fetch_add(1, Ordering::Relaxed),
+                initial_rail_execute,
+            ),
         }));
 
         // Capture this session's logs into the ring buffer (queryable via `Request::QueryLogs`)
@@ -565,7 +736,13 @@ impl Daemon {
             );
         }
 
-        tokio::spawn(consume_output(output_rx, Arc::clone(&live), self.notification.clone()));
+        tokio::spawn(consume_output(
+            output_rx,
+            Arc::clone(&live),
+            self.notification.clone(),
+            Arc::clone(&rail_notify),
+            Arc::clone(&self.next_rail_generation),
+        ));
 
         info!(%destination, "Started RDP session");
 
@@ -573,7 +750,9 @@ impl Daemon {
             input_tx,
             input_db: Database::new(),
             destination,
+            rail_enabled,
             live,
+            rail_notify,
             operations: OperationManager::new(Arc::clone(&now_endpoint)),
             now_endpoint,
         });
@@ -680,6 +859,117 @@ impl Daemon {
             }
         }
         Response::Ok(Payload::Logs(lines))
+    }
+
+    fn rail_status(&self) -> Response {
+        let guard = self.state.lock().expect("daemon state poisoned");
+        let Some(session) = guard.as_ref() else {
+            return Response::typed_error(crate::ipc::AgentErrorCategory::Unavailable, "no active session");
+        };
+        let live = session.live.lock().expect("session live state poisoned");
+        Response::Ok(Payload::RailStatus(live.rail.status()))
+    }
+
+    fn rail_events(&self, after_sequence: Option<u64>) -> Response {
+        let guard = self.state.lock().expect("daemon state poisoned");
+        let Some(session) = guard.as_ref() else {
+            return Response::typed_error(crate::ipc::AgentErrorCategory::Unavailable, "no active session");
+        };
+        let live = session.live.lock().expect("session live state poisoned");
+        Response::Ok(Payload::RailEvents(live.rail.events_after(after_sequence)))
+    }
+
+    async fn rail_wait(&self, after_sequence: Option<u64>, timeout_ms: u32) -> Response {
+        const MAX_RAIL_WAIT_MS: u32 = 60_000;
+        if timeout_ms > MAX_RAIL_WAIT_MS {
+            return Response::typed_error(
+                crate::ipc::AgentErrorCategory::InvalidRequest,
+                format!("RAIL wait timeout exceeds {MAX_RAIL_WAIT_MS} ms"),
+            );
+        }
+        let (live, rail_notify) = {
+            let guard = self.state.lock().expect("daemon state poisoned");
+            let Some(session) = guard.as_ref() else {
+                return Response::typed_error(crate::ipc::AgentErrorCategory::Unavailable, "no active session");
+            };
+            (Arc::clone(&session.live), Arc::clone(&session.rail_notify))
+        };
+        let deadline = tokio::time::Instant::now() + Duration::from_millis(u64::from(timeout_ms));
+        loop {
+            let notified = rail_notify.notified();
+            tokio::pin!(notified);
+            let _ = notified.as_mut().enable();
+            let events = {
+                let live = live.lock().expect("session live state poisoned");
+                live.rail.events_after(after_sequence)
+            };
+            if !events.events.is_empty() || timeout_ms == 0 {
+                return Response::Ok(Payload::RailEvents(events));
+            }
+
+            if tokio::time::timeout_at(deadline, &mut notified).await.is_err() {
+                let live = live.lock().expect("session live state poisoned");
+                return Response::Ok(Payload::RailEvents(live.rail.events_after(after_sequence)));
+            }
+        }
+    }
+
+    fn rail_execute(&self, request: RailExecuteRequest) -> Response {
+        let execute = ExecutePdu {
+            executable: request.executable,
+            working_directory: request.working_directory,
+            arguments: request.arguments,
+            flags: request.flags,
+        };
+        if let Err(error) = RailPdu::Execute(execute.clone()).validate() {
+            return Response::typed_error(
+                crate::ipc::AgentErrorCategory::InvalidRequest,
+                format!("invalid RAIL Execute request: {error}"),
+            );
+        }
+
+        let guard = self.state.lock().expect("daemon state poisoned");
+        let Some(session) = guard.as_ref() else {
+            return Response::typed_error(crate::ipc::AgentErrorCategory::Unavailable, "no active session");
+        };
+        if !session.rail_enabled {
+            return Response::typed_error(
+                crate::ipc::AgentErrorCategory::Unavailable,
+                "RAIL is not enabled for this session",
+            );
+        }
+        let permit = match session.input_tx.try_reserve() {
+            Ok(permit) => permit,
+            Err(_) => {
+                return Response::typed_error(
+                    crate::ipc::AgentErrorCategory::Unavailable,
+                    "session input channel is unavailable",
+                );
+            }
+        };
+        let mut live = session.live.lock().expect("session live state poisoned");
+        let launch = RailLaunchInfo {
+            launch_id: live.rail.next_sequence,
+            executable: execute.executable.clone(),
+            flags: execute.flags,
+        };
+        match live.rail.queue_launch(launch.clone()) {
+            Ok(()) => {}
+            Err(RailLaunchQueueError::LimitReached) => {
+                return Response::typed_error(
+                    crate::ipc::AgentErrorCategory::Unavailable,
+                    "too many pending RAIL launch requests",
+                );
+            }
+            Err(RailLaunchQueueError::DuplicateResponse) => {
+                return Response::typed_error(
+                    crate::ipc::AgentErrorCategory::Conflict,
+                    "an indistinguishable RAIL launch request is already pending",
+                );
+            }
+        }
+        permit.send(RdpInputEvent::RailExecute(execute));
+        Response::Ok(Payload::RailLaunch(launch))
     }
 
     fn screenshot(&self) -> Response {
@@ -959,19 +1249,98 @@ async fn consume_output(
     mut output_rx: mpsc::Receiver<RdpOutputEvent>,
     live: Arc<Mutex<Live>>,
     notification: Option<mpsc::Sender<()>>,
+    rail_notify: Arc<tokio::sync::Notify>,
+    next_rail_generation: Arc<AtomicU64>,
 ) {
     while let Some(event) = output_rx.recv().await {
         let mut guard = live.lock().expect("session live state poisoned");
         let previous = guard.state;
-        match event {
+        let rail_changed = match event {
             RdpOutputEvent::Connected => {
                 guard.state = ConnState::Connected;
                 guard.error = None;
                 if previous != ConnState::Connected {
                     info!("Session connected");
                 }
+                false
             }
-            RdpOutputEvent::LoginComplete => {}
+            RdpOutputEvent::LoginComplete => false,
+            RdpOutputEvent::WindowingOrders(orders) => {
+                guard.rail.record(RailEventKind::WindowingOrders {
+                    byte_count: u32::try_from(orders.len()).unwrap_or(u32::MAX),
+                });
+                true
+            }
+            RdpOutputEvent::RailHandshake {
+                handshake_ex_flags,
+                initialization_message_count,
+                queued_execute_count,
+            } => {
+                guard.rail.handshake_complete = true;
+                guard.rail.record(RailEventKind::Handshake {
+                    handshake_ex_flags,
+                    initialization_message_count: u16::try_from(initialization_message_count).unwrap_or(u16::MAX),
+                    queued_execute_count: u16::try_from(queued_execute_count).unwrap_or(u16::MAX),
+                });
+                true
+            }
+            RdpOutputEvent::RailDesktopSynchronized { released_execute_count } => {
+                guard.rail.desktop_synchronized = true;
+                guard.rail.record(RailEventKind::DesktopSynchronized {
+                    released_execute_count: u16::try_from(released_execute_count).unwrap_or(u16::MAX),
+                });
+                true
+            }
+            RdpOutputEvent::RailPostHandshakeQueueReleased { released_execute_count } => {
+                guard.rail.record(RailEventKind::PostHandshakeQueueReleased {
+                    released_execute_count: u16::try_from(released_execute_count).unwrap_or(u16::MAX),
+                });
+                true
+            }
+            RdpOutputEvent::RailExecuteResult(result) => {
+                let launch_id = guard.rail.take_launch(result.flags, &result.executable);
+                guard.rail.record(RailEventKind::ExecuteResult {
+                    launch_id,
+                    executable: result.executable,
+                    flags: result.flags,
+                    result: u16::from(result.result),
+                    raw_result: result.raw_result,
+                });
+                true
+            }
+            RdpOutputEvent::RailApplicationId {
+                window_id,
+                application_id,
+                process_id,
+                process_image_name,
+            } => {
+                guard.rail.record(RailEventKind::ApplicationId {
+                    window_id,
+                    application_id,
+                    process_id,
+                    process_image_name,
+                });
+                true
+            }
+            RdpOutputEvent::RailControl(control) => {
+                let kind = match control {
+                    RailControlEvent::SystemParameters(_) => "system-parameters",
+                    RailControlEvent::LanguageBar(_) => "language-bar",
+                    RailControlEvent::Compartment(_) => "compartment",
+                    RailControlEvent::ZOrderSync(_) => "z-order-sync",
+                    RailControlEvent::Cloak(_) => "cloak",
+                    RailControlEvent::PowerDisplayRequest(_) => "power-display-request",
+                };
+                guard.rail.record(RailEventKind::Control { kind: kind.to_owned() });
+                true
+            }
+            RdpOutputEvent::DisplayResizeFallback(_) => {
+                guard.rail = RailLedger::new(
+                    next_rail_generation.fetch_add(1, Ordering::Relaxed),
+                    guard.rail_initial_execute.clone(),
+                );
+                true
+            }
             RdpOutputEvent::Image { buffer, width, height } => {
                 let width = width.get();
                 let height = height.get();
@@ -987,27 +1356,34 @@ async fn consume_output(
                 if previous != ConnState::Connected {
                     info!(width, height, "Session connected");
                 }
+                false
             }
             RdpOutputEvent::ConnectionFailure(error) => {
                 guard.state = ConnState::Failed;
                 guard.error = Some(format!("{error}"));
                 error!(%error, "Session connection failed");
+                false
             }
             RdpOutputEvent::Terminated(Ok(reason)) => {
                 guard.state = ConnState::Disconnected;
                 guard.error = Some(format!("{reason:?}"));
                 info!(?reason, "Session terminated");
+                false
             }
             RdpOutputEvent::Terminated(Err(error)) => {
                 guard.state = ConnState::Failed;
                 guard.error = Some(format!("{error}"));
                 warn!(%error, "Session terminated with an error");
+                false
             }
             // With software pointer rendering the cursor is composited into the `Image` frames
             // above; the remaining pointer events (default/hidden) carry no live state we track.
-            _ => {}
-        }
+            _ => false,
+        };
         drop(guard);
+        if rail_changed {
+            rail_notify.notify_waiters();
+        }
         notify(&notification);
     }
 
@@ -1171,7 +1547,10 @@ fn validate_rdpdr_volume_root(root_path: &Path) -> anyhow::Result<String> {
 
 #[cfg(test)]
 mod tests {
+    use core::sync::atomic::AtomicU64;
+    use core::time::Duration;
     use std::path::PathBuf;
+    use std::sync::{Arc, Mutex};
 
     use tokio::sync::mpsc;
 
@@ -1181,9 +1560,12 @@ mod tests {
     use ironrdp_propertyset::PropertySet;
 
     use super::{
-        Daemon, DaemonOptions, MAX_UNICODE_TEXT_CHARS, RdpdrDriveConfig, ResizeError, enqueue_unicode_text, notify,
+        ConnState, Daemon, DaemonOptions, Live, MAX_PENDING_RAIL_LAUNCHES, MAX_RAIL_EVENTS, MAX_UNICODE_TEXT_CHARS,
+        NowEndpoint, OperationManager, RailLedger, RdpdrDriveConfig, ResizeError, Session, consume_output,
+        enqueue_unicode_text, notify,
     };
-    use crate::ipc::Response;
+    use crate::ipc::{Payload, Response};
+    use ironrdp_rpc::ipc::{RailEventKind, RailExecuteRequest, RailLaunchInfo};
     use ironrdp_tls::CertificateValidation;
 
     #[test]
@@ -1196,6 +1578,244 @@ mod tests {
 
         assert_eq!(receiver.try_recv(), Ok(()));
         assert!(matches!(receiver.try_recv(), Err(mpsc::error::TryRecvError::Empty)));
+    }
+
+    #[test]
+    fn rail_ledger_reports_history_gaps_and_correlates_launches() {
+        let mut ledger = RailLedger::new(7, None);
+        let launch = RailLaunchInfo {
+            launch_id: 1,
+            executable: "notepad.exe".to_owned(),
+            flags: 0,
+        };
+        ledger.queue_launch(launch).expect("room for launch");
+        assert_eq!(ledger.take_launch(0, "notepad.exe"), Some(1));
+
+        for byte_count in 0..=MAX_RAIL_EVENTS {
+            ledger.record(RailEventKind::WindowingOrders {
+                byte_count: u32::try_from(byte_count).expect("test count fits"),
+            });
+        }
+
+        let dump = ledger.events_after(Some(0));
+        assert_eq!(dump.generation, 7);
+        assert!(matches!(
+            dump.events.first(),
+            Some(event) if matches!(event.kind, RailEventKind::Gap { .. })
+        ));
+        assert_eq!(dump.events.len(), MAX_RAIL_EVENTS + 1);
+    }
+
+    #[test]
+    fn rail_ledger_reserves_capacity_for_the_initial_launch() {
+        let mut ledger = RailLedger::new(7, Some((0, "notepad.exe".to_owned())));
+        let max_launches = u64::try_from(MAX_PENDING_RAIL_LAUNCHES).expect("launch limit fits");
+
+        for launch_id in 1..max_launches {
+            ledger
+                .queue_launch(RailLaunchInfo {
+                    launch_id,
+                    executable: format!("application-{launch_id}.exe"),
+                    flags: 0,
+                })
+                .expect("room for dynamic launch");
+        }
+        assert_eq!(ledger.status().pending_launches.len(), MAX_PENDING_RAIL_LAUNCHES - 1);
+        assert!(
+            ledger
+                .queue_launch(RailLaunchInfo {
+                    launch_id: max_launches,
+                    executable: "application-final.exe".to_owned(),
+                    flags: 0,
+                })
+                .is_err()
+        );
+
+        assert_eq!(ledger.take_launch(0, "notepad.exe"), None);
+        assert!(
+            ledger
+                .queue_launch(RailLaunchInfo {
+                    launch_id: max_launches,
+                    executable: "application-final.exe".to_owned(),
+                    flags: 0,
+                })
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn rail_ledger_rejects_indistinguishable_pending_launches() {
+        let mut ledger = RailLedger::new(7, Some((0, "notepad.exe".to_owned())));
+
+        assert!(
+            ledger
+                .queue_launch(RailLaunchInfo {
+                    launch_id: 1,
+                    executable: "notepad.exe".to_owned(),
+                    flags: 0,
+                })
+                .is_err()
+        );
+        assert!(
+            ledger
+                .queue_launch(RailLaunchInfo {
+                    launch_id: 2,
+                    executable: "notepad.exe".to_owned(),
+                    flags: 1,
+                })
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn resize_fallback_starts_a_new_rail_generation() {
+        let live = Arc::new(Mutex::new(Live {
+            properties: PropertySet::new(),
+            state: ConnState::Connected,
+            error: None,
+            frame: None,
+            rail_initial_execute: Some((0, "notepad.exe".to_owned())),
+            rail: RailLedger::new(1, Some((0, "notepad.exe".to_owned()))),
+        }));
+        {
+            let mut guard = live.lock().expect("session live state poisoned");
+            guard.rail.handshake_complete = true;
+            guard.rail.desktop_synchronized = true;
+            guard
+                .rail
+                .queue_launch(RailLaunchInfo {
+                    launch_id: 1,
+                    executable: "wordpad.exe".to_owned(),
+                    flags: 0,
+                })
+                .expect("queue a dynamic launch");
+        }
+
+        let (output_tx, output_rx) = mpsc::channel(1);
+        let rail_notify = Arc::new(tokio::sync::Notify::new());
+        let consumer = tokio::spawn(consume_output(
+            output_rx,
+            Arc::clone(&live),
+            None,
+            Arc::clone(&rail_notify),
+            Arc::new(AtomicU64::new(2)),
+        ));
+        output_tx
+            .send(ironrdp_client::rdp::RdpOutputEvent::DisplayResizeFallback(
+                ironrdp_client::rdp::DisplayResizeFallbackReason::CapabilitiesTimedOut,
+            ))
+            .await
+            .expect("send resize fallback");
+        drop(output_tx);
+        consumer.await.expect("consume output");
+
+        let mut guard = live.lock().expect("session live state poisoned");
+        assert_eq!(guard.rail.generation, 2);
+        assert!(!guard.rail.handshake_complete);
+        assert!(!guard.rail.desktop_synchronized);
+        assert!(guard.rail.status().pending_launches.is_empty());
+        assert_eq!(guard.rail.take_launch(0, "notepad.exe"), None);
+    }
+
+    #[tokio::test]
+    async fn rail_wait_ignores_non_rail_output_until_evidence_arrives() {
+        let daemon = Daemon::with_overlay(PropertySet::new());
+        let (input_tx, _) = RdpInputSender::channel(1);
+        let now_endpoint = Arc::new(NowEndpoint::new().expect("create NOW endpoint"));
+        let live = Arc::new(Mutex::new(Live {
+            properties: PropertySet::new(),
+            state: ConnState::Connected,
+            error: None,
+            frame: None,
+            rail_initial_execute: None,
+            rail: RailLedger::new(1, None),
+        }));
+        let rail_notify = Arc::new(tokio::sync::Notify::new());
+        *daemon.state.lock().expect("daemon state poisoned") = Some(Session {
+            input_tx,
+            input_db: Database::new(),
+            destination: "server.example".to_owned(),
+            rail_enabled: true,
+            live: Arc::clone(&live),
+            rail_notify: Arc::clone(&rail_notify),
+            operations: OperationManager::new(Arc::clone(&now_endpoint)),
+            now_endpoint,
+        });
+
+        let (output_tx, output_rx) = mpsc::channel(1);
+        let consumer = tokio::spawn(consume_output(
+            output_rx,
+            live,
+            None,
+            rail_notify,
+            Arc::new(AtomicU64::new(2)),
+        ));
+        output_tx
+            .send(ironrdp_client::rdp::RdpOutputEvent::LoginComplete)
+            .await
+            .expect("send ignored output");
+
+        let mut wait = Box::pin(daemon.rail_wait(None, 1_000));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), wait.as_mut())
+                .await
+                .is_err()
+        );
+
+        output_tx
+            .send(ironrdp_client::rdp::RdpOutputEvent::RailHandshake {
+                handshake_ex_flags: None,
+                initialization_message_count: 0,
+                queued_execute_count: 0,
+            })
+            .await
+            .expect("send RAIL evidence");
+        let response = tokio::time::timeout(Duration::from_secs(1), wait.as_mut())
+            .await
+            .expect("RAIL event wakes wait");
+        assert!(matches!(
+            response,
+            Response::Ok(Payload::RailEvents(events))
+                if matches!(events.events.as_slice(), [event] if matches!(event.kind, RailEventKind::Handshake { .. }))
+        ));
+
+        drop(output_tx);
+        consumer.await.expect("consume output");
+    }
+
+    #[test]
+    fn rail_execute_rejects_desktop_sessions_without_queueing_input() {
+        let daemon = Daemon::with_overlay(PropertySet::new());
+        let (input_tx, mut input_rx) = RdpInputSender::channel(1);
+        let now_endpoint = Arc::new(NowEndpoint::new().expect("create NOW endpoint"));
+        let live = Arc::new(Mutex::new(Live {
+            properties: PropertySet::new(),
+            state: ConnState::Connected,
+            error: None,
+            frame: None,
+            rail_initial_execute: None,
+            rail: RailLedger::new(1, None),
+        }));
+        *daemon.state.lock().expect("daemon state poisoned") = Some(Session {
+            input_tx,
+            input_db: Database::new(),
+            destination: "server.example".to_owned(),
+            rail_enabled: false,
+            live,
+            rail_notify: Arc::new(tokio::sync::Notify::new()),
+            operations: OperationManager::new(Arc::clone(&now_endpoint)),
+            now_endpoint,
+        });
+
+        let response = daemon.rail_execute(RailExecuteRequest {
+            executable: "notepad.exe".to_owned(),
+            working_directory: String::new(),
+            arguments: String::new(),
+            flags: 0,
+        });
+
+        assert!(matches!(response, Response::Err(error) if error.message == "RAIL is not enabled for this session"));
+        assert!(matches!(input_rx.try_recv(), Err(mpsc::error::TryRecvError::Empty)));
     }
 
     #[test]

--- a/crates/ironrdp-rpc/src/ipc.rs
+++ b/crates/ironrdp-rpc/src/ipc.rs
@@ -399,6 +399,13 @@ pub enum RailEventKind {
         result: u16,
         raw_result: u32,
     },
+    /// A locally accepted Execute request could not be processed.
+    ExecuteFailed {
+        launch_id: Option<u64>,
+        executable: String,
+        flags: u16,
+        reason: RailExecuteFailureReason,
+    },
     ApplicationId {
         window_id: u32,
         application_id: String,
@@ -415,6 +422,48 @@ pub enum RailEventKind {
     Gap {
         lost_through: u64,
     },
+}
+
+/// Stable, command-free diagnostic for a locally failed RAIL Execute request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RailExecuteFailureReason {
+    /// The active session did not retain a RAIL static-channel processor.
+    RailUnavailable,
+    /// The RAIL client rejected the Execute request before sending it.
+    QueueRejected,
+    /// The active stage could not encode the queued RAIL messages.
+    MessageProcessingFailed,
+}
+
+impl RailExecuteFailureReason {
+    /// Stable lowercase diagnostic text for structured CLI output.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::RailUnavailable => "rail_unavailable",
+            Self::QueueRejected => "queue_rejected",
+            Self::MessageProcessingFailed => "message_processing_failed",
+        }
+    }
+
+    const fn tag(self) -> u8 {
+        match self {
+            Self::RailUnavailable => 0,
+            Self::QueueRejected => 1,
+            Self::MessageProcessingFailed => 2,
+        }
+    }
+
+    fn from_tag(tag: u8) -> DecodeResult<Self> {
+        match tag {
+            0 => Ok(Self::RailUnavailable),
+            1 => Ok(Self::QueueRejected),
+            2 => Ok(Self::MessageProcessingFailed),
+            _ => Err(ironrdp_core::invalid_field_err!(
+                "RAIL Execute failure",
+                "unknown reason"
+            )),
+        }
+    }
 }
 
 /// Machine-readable error category. The message is safe for display but must not include request
@@ -1153,6 +1202,18 @@ impl Encode for RailEventKind {
                 dst.write_u16(*result);
                 dst.write_u32(*raw_result);
             }
+            Self::ExecuteFailed {
+                launch_id,
+                executable,
+                flags,
+                reason,
+            } => {
+                dst.write_u8(9);
+                write_opt_u64(dst, *launch_id)?;
+                write_string(dst, executable)?;
+                dst.write_u16(*flags);
+                dst.write_u8(reason.tag());
+            }
             Self::ApplicationId {
                 window_id,
                 application_id,
@@ -1205,6 +1266,11 @@ impl Encode for RailEventKind {
                     executable,
                     ..
                 } => opt_u64_size(*launch_id) + string_size(executable) + 2 + 2 + 4,
+                Self::ExecuteFailed {
+                    launch_id,
+                    executable,
+                    ..
+                } => opt_u64_size(*launch_id) + string_size(executable) + 2 + 1,
                 Self::ApplicationId {
                     application_id,
                     process_id,
@@ -1267,6 +1333,17 @@ impl Decode<'_> for RailEventKind {
                     flags: src.read_u16(),
                     result: src.read_u16(),
                     raw_result: src.read_u32(),
+                })
+            }
+            9 => {
+                let launch_id = read_opt_u64(src)?;
+                let executable = read_string(src)?;
+                ensure_size!(in: src, size: 3);
+                Ok(Self::ExecuteFailed {
+                    launch_id,
+                    executable,
+                    flags: src.read_u16(),
+                    reason: RailExecuteFailureReason::from_tag(src.read_u8())?,
                 })
             }
             5 => {

--- a/crates/ironrdp-rpc/src/ipc.rs
+++ b/crates/ironrdp-rpc/src/ipc.rs
@@ -105,6 +105,17 @@ pub enum Request {
     },
     /// Inspect the local NOW endpoint without exposing protocol internals.
     NowDiagnostics,
+    /// Inspect the bounded, session-local RAIL observation ledger.
+    RailStatus,
+    /// Return RAIL observations after a sequence number.
+    RailEvents { after_sequence: Option<u64> },
+    /// Wait for a RAIL observation after a sequence number.
+    RailWait {
+        after_sequence: Option<u64>,
+        timeout_ms: u32,
+    },
+    /// Queue a validated RAIL Execute request.
+    RailExecute(RailExecuteRequest),
     // TODO: add clipboard support (CLIPRDR), e.g. requests to read the remote clipboard text and to
     // set it, so an LLM can copy/paste to and from the session.
 }
@@ -194,6 +205,20 @@ impl fmt::Debug for Request {
                 .field("last", last)
                 .finish(),
             Self::NowDiagnostics => f.write_str("NowDiagnostics"),
+            Self::RailStatus => f.write_str("RailStatus"),
+            Self::RailEvents { after_sequence } => f
+                .debug_struct("RailEvents")
+                .field("after_sequence", after_sequence)
+                .finish(),
+            Self::RailWait {
+                after_sequence,
+                timeout_ms,
+            } => f
+                .debug_struct("RailWait")
+                .field("after_sequence", after_sequence)
+                .field("timeout_ms", timeout_ms)
+                .finish(),
+            Self::RailExecute(request) => f.debug_tuple("RailExecute").field(request).finish(),
         }
     }
 }
@@ -264,6 +289,12 @@ pub enum Payload {
     NowEvent(OperationEvent),
     /// Local NOW endpoint diagnostic state.
     NowDiagnostics(NowDiagnostics),
+    /// Session-local RAIL state.
+    RailStatus(RailStatusInfo),
+    /// Sequenced RAIL observations.
+    RailEvents(RailEventDump),
+    /// A locally assigned RAIL launch identifier.
+    RailLaunch(RailLaunchInfo),
 }
 
 impl fmt::Debug for Payload {
@@ -285,8 +316,105 @@ impl fmt::Debug for Payload {
             Self::NowOperations(operations) => f.debug_tuple("NowOperations").field(operations).finish(),
             Self::NowEvent(event) => f.debug_tuple("NowEvent").field(event).finish(),
             Self::NowDiagnostics(diagnostics) => f.debug_tuple("NowDiagnostics").field(diagnostics).finish(),
+            Self::RailStatus(status) => f.debug_tuple("RailStatus").field(status).finish(),
+            Self::RailEvents(events) => f.debug_tuple("RailEvents").field(events).finish(),
+            Self::RailLaunch(launch) => f.debug_tuple("RailLaunch").field(launch).finish(),
         }
     }
+}
+
+/// One locally initiated RAIL launch.
+///
+/// `launch_id` is assigned by the daemon for audit correlation. It is not a protocol identifier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RailLaunchInfo {
+    pub launch_id: u64,
+    pub executable: String,
+    pub flags: u16,
+}
+
+/// A validated RAIL Execute request.
+#[derive(Clone, PartialEq, Eq)]
+pub struct RailExecuteRequest {
+    pub executable: String,
+    pub working_directory: String,
+    pub arguments: String,
+    pub flags: u16,
+}
+
+impl fmt::Debug for RailExecuteRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RailExecuteRequest")
+            .field("executable_len", &self.executable.len())
+            .field("working_directory_len", &self.working_directory.len())
+            .field("arguments_len", &self.arguments.len())
+            .field("flags", &self.flags)
+            .finish()
+    }
+}
+
+/// Summary of the current RAIL observation generation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RailStatusInfo {
+    pub generation: u64,
+    pub next_sequence: u64,
+    pub handshake_complete: bool,
+    pub desktop_synchronized: bool,
+    pub pending_launches: Vec<RailLaunchInfo>,
+}
+
+/// Bounded RAIL observation history.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RailEventDump {
+    pub generation: u64,
+    pub events: Vec<RailEvent>,
+}
+
+/// A sequence-numbered RAIL observation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RailEvent {
+    pub sequence: u64,
+    pub kind: RailEventKind,
+}
+
+/// One client-validated RAIL observation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RailEventKind {
+    Handshake {
+        handshake_ex_flags: Option<u32>,
+        initialization_message_count: u16,
+        queued_execute_count: u16,
+    },
+    DesktopSynchronized {
+        released_execute_count: u16,
+    },
+    PostHandshakeQueueReleased {
+        released_execute_count: u16,
+    },
+    ExecuteQueued(RailLaunchInfo),
+    ExecuteResult {
+        launch_id: Option<u64>,
+        executable: String,
+        flags: u16,
+        result: u16,
+        raw_result: u32,
+    },
+    ApplicationId {
+        window_id: u32,
+        application_id: String,
+        process_id: Option<u32>,
+        process_image_name: Option<String>,
+    },
+    Control {
+        kind: String,
+    },
+    WindowingOrders {
+        byte_count: u32,
+    },
+    /// History before this sequence was evicted from the bounded ledger.
+    Gap {
+        lost_through: u64,
+    },
 }
 
 /// Machine-readable error category. The message is safe for display but must not include request
@@ -851,6 +979,408 @@ impl Decode<'_> for StatusInfo {
 
 impl_pdu_pod!(StatusInfo);
 
+// ── RAIL audit codec ─────────────────────────────────────────────────────────
+
+impl Encode for RailLaunchInfo {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u64(self.launch_id);
+        write_string(dst, &self.executable)?;
+        dst.write_u16(self.flags);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_rpc::ipc::RailLaunchInfo"
+    }
+
+    fn size(&self) -> usize {
+        8 /* launch_id */ + string_size(&self.executable) + 2 /* flags */
+    }
+}
+
+impl Decode<'_> for RailLaunchInfo {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 8);
+        let launch_id = src.read_u64();
+        let executable = read_string(src)?;
+        ensure_size!(in: src, size: 2);
+        let flags = src.read_u16();
+        Ok(Self {
+            launch_id,
+            executable,
+            flags,
+        })
+    }
+}
+
+impl_pdu_pod!(RailLaunchInfo);
+
+impl Encode for RailExecuteRequest {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        write_string(dst, &self.executable)?;
+        write_string(dst, &self.working_directory)?;
+        write_string(dst, &self.arguments)?;
+        dst.write_u16(self.flags);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_rpc::ipc::RailExecuteRequest"
+    }
+
+    fn size(&self) -> usize {
+        string_size(&self.executable) + string_size(&self.working_directory) + string_size(&self.arguments) + 2 /* flags */
+    }
+}
+
+impl Decode<'_> for RailExecuteRequest {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        let executable = read_string(src)?;
+        let working_directory = read_string(src)?;
+        let arguments = read_string(src)?;
+        ensure_size!(in: src, size: 2);
+        let flags = src.read_u16();
+        Ok(Self {
+            executable,
+            working_directory,
+            arguments,
+            flags,
+        })
+    }
+}
+
+impl_pdu_pod!(RailExecuteRequest);
+
+impl Encode for RailStatusInfo {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u64(self.generation);
+        dst.write_u64(self.next_sequence);
+        write_bool(dst, self.handshake_complete)?;
+        write_bool(dst, self.desktop_synchronized)?;
+        let count: u32 = cast_length!("pending RAIL launch count", self.pending_launches.len())?;
+        dst.write_u32(count);
+        for launch in &self.pending_launches {
+            launch.encode(dst)?;
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_rpc::ipc::RailStatusInfo"
+    }
+
+    fn size(&self) -> usize {
+        8 /* generation */
+            + 8 /* next_sequence */
+            + 1 /* handshake_complete */
+            + 1 /* desktop_synchronized */
+            + 4 /* pending launch count */
+            + self.pending_launches.iter().map(Encode::size).sum::<usize>()
+    }
+}
+
+impl Decode<'_> for RailStatusInfo {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 16);
+        let generation = src.read_u64();
+        let next_sequence = src.read_u64();
+        let handshake_complete = read_bool(src)?;
+        let desktop_synchronized = read_bool(src)?;
+        ensure_size!(in: src, size: 4);
+        let count = src.read_u32();
+        let mut pending_launches = Vec::new();
+        for _ in 0..count {
+            pending_launches.push(RailLaunchInfo::decode(src)?);
+        }
+        Ok(Self {
+            generation,
+            next_sequence,
+            handshake_complete,
+            desktop_synchronized,
+            pending_launches,
+        })
+    }
+}
+
+impl_pdu_pod!(RailStatusInfo);
+
+impl Encode for RailEventKind {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        match self {
+            Self::Handshake {
+                handshake_ex_flags,
+                initialization_message_count,
+                queued_execute_count,
+            } => {
+                dst.write_u8(0);
+                match handshake_ex_flags {
+                    Some(flags) => {
+                        dst.write_u8(1);
+                        dst.write_u32(*flags);
+                    }
+                    None => dst.write_u8(0),
+                }
+                dst.write_u16(*initialization_message_count);
+                dst.write_u16(*queued_execute_count);
+            }
+            Self::DesktopSynchronized { released_execute_count } => {
+                dst.write_u8(1);
+                dst.write_u16(*released_execute_count);
+            }
+            Self::PostHandshakeQueueReleased { released_execute_count } => {
+                dst.write_u8(2);
+                dst.write_u16(*released_execute_count);
+            }
+            Self::ExecuteQueued(launch) => {
+                dst.write_u8(3);
+                launch.encode(dst)?;
+            }
+            Self::ExecuteResult {
+                launch_id,
+                executable,
+                flags,
+                result,
+                raw_result,
+            } => {
+                dst.write_u8(4);
+                write_opt_u64(dst, *launch_id)?;
+                write_string(dst, executable)?;
+                dst.write_u16(*flags);
+                dst.write_u16(*result);
+                dst.write_u32(*raw_result);
+            }
+            Self::ApplicationId {
+                window_id,
+                application_id,
+                process_id,
+                process_image_name,
+            } => {
+                dst.write_u8(5);
+                dst.write_u32(*window_id);
+                write_string(dst, application_id)?;
+                match process_id {
+                    Some(process_id) => {
+                        dst.write_u8(1);
+                        dst.write_u32(*process_id);
+                    }
+                    None => dst.write_u8(0),
+                }
+                write_opt_string(dst, process_image_name.as_deref())?;
+            }
+            Self::Control { kind } => {
+                dst.write_u8(6);
+                write_string(dst, kind)?;
+            }
+            Self::WindowingOrders { byte_count } => {
+                dst.write_u8(7);
+                dst.write_u32(*byte_count);
+            }
+            Self::Gap { lost_through } => {
+                dst.write_u8(8);
+                dst.write_u64(*lost_through);
+            }
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_rpc::ipc::RailEventKind"
+    }
+
+    fn size(&self) -> usize {
+        1 /* tag */
+            + match self {
+                Self::Handshake {
+                    handshake_ex_flags,
+                    ..
+                } => 1 /* flags presence */ + handshake_ex_flags.map_or(0, |_| 4) + 2 + 2,
+                Self::DesktopSynchronized { .. } | Self::PostHandshakeQueueReleased { .. } => 2,
+                Self::ExecuteQueued(launch) => launch.size(),
+                Self::ExecuteResult {
+                    launch_id,
+                    executable,
+                    ..
+                } => opt_u64_size(*launch_id) + string_size(executable) + 2 + 2 + 4,
+                Self::ApplicationId {
+                    application_id,
+                    process_id,
+                    process_image_name,
+                    ..
+                } => 4 + string_size(application_id) + 1 + process_id.map_or(0, |_| 4) + opt_string_size(process_image_name.as_deref()),
+                Self::Control { kind } => string_size(kind),
+                Self::WindowingOrders { .. } => 4,
+                Self::Gap { .. } => 8,
+            }
+    }
+}
+
+impl Decode<'_> for RailEventKind {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 1);
+        match src.read_u8() {
+            0 => {
+                ensure_size!(in: src, size: 1);
+                let handshake_ex_flags = match src.read_u8() {
+                    0 => None,
+                    1 => {
+                        ensure_size!(in: src, size: 4);
+                        Some(src.read_u32())
+                    }
+                    _ => {
+                        return Err(ironrdp_core::invalid_field_err!(
+                            "RAIL handshake",
+                            "invalid flags presence"
+                        ));
+                    }
+                };
+                ensure_size!(in: src, size: 4);
+                Ok(Self::Handshake {
+                    handshake_ex_flags,
+                    initialization_message_count: src.read_u16(),
+                    queued_execute_count: src.read_u16(),
+                })
+            }
+            1 => {
+                ensure_size!(in: src, size: 2);
+                Ok(Self::DesktopSynchronized {
+                    released_execute_count: src.read_u16(),
+                })
+            }
+            2 => {
+                ensure_size!(in: src, size: 2);
+                Ok(Self::PostHandshakeQueueReleased {
+                    released_execute_count: src.read_u16(),
+                })
+            }
+            3 => Ok(Self::ExecuteQueued(RailLaunchInfo::decode(src)?)),
+            4 => {
+                let launch_id = read_opt_u64(src)?;
+                let executable = read_string(src)?;
+                ensure_size!(in: src, size: 8);
+                Ok(Self::ExecuteResult {
+                    launch_id,
+                    executable,
+                    flags: src.read_u16(),
+                    result: src.read_u16(),
+                    raw_result: src.read_u32(),
+                })
+            }
+            5 => {
+                ensure_size!(in: src, size: 4);
+                let window_id = src.read_u32();
+                let application_id = read_string(src)?;
+                ensure_size!(in: src, size: 1);
+                let process_id = match src.read_u8() {
+                    0 => None,
+                    1 => {
+                        ensure_size!(in: src, size: 4);
+                        Some(src.read_u32())
+                    }
+                    _ => {
+                        return Err(ironrdp_core::invalid_field_err!(
+                            "RAIL application ID",
+                            "invalid process ID presence"
+                        ));
+                    }
+                };
+                let process_image_name = read_opt_string(src)?;
+                Ok(Self::ApplicationId {
+                    window_id,
+                    application_id,
+                    process_id,
+                    process_image_name,
+                })
+            }
+            6 => Ok(Self::Control {
+                kind: read_string(src)?,
+            }),
+            7 => {
+                ensure_size!(in: src, size: 4);
+                Ok(Self::WindowingOrders {
+                    byte_count: src.read_u32(),
+                })
+            }
+            8 => {
+                ensure_size!(in: src, size: 8);
+                Ok(Self::Gap {
+                    lost_through: src.read_u64(),
+                })
+            }
+            _ => Err(ironrdp_core::invalid_field_err!("RAIL event", "unknown tag")),
+        }
+    }
+}
+
+impl_pdu_pod!(RailEventKind);
+
+impl Encode for RailEvent {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u64(self.sequence);
+        self.kind.encode(dst)
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_rpc::ipc::RailEvent"
+    }
+
+    fn size(&self) -> usize {
+        8 /* sequence */ + self.kind.size()
+    }
+}
+
+impl Decode<'_> for RailEvent {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 8);
+        Ok(Self {
+            sequence: src.read_u64(),
+            kind: RailEventKind::decode(src)?,
+        })
+    }
+}
+
+impl_pdu_pod!(RailEvent);
+
+impl Encode for RailEventDump {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u64(self.generation);
+        let count: u32 = cast_length!("RAIL event count", self.events.len())?;
+        dst.write_u32(count);
+        for event in &self.events {
+            event.encode(dst)?;
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_rpc::ipc::RailEventDump"
+    }
+
+    fn size(&self) -> usize {
+        8 /* generation */ + 4 /* event count */ + self.events.iter().map(Encode::size).sum::<usize>()
+    }
+}
+
+impl Decode<'_> for RailEventDump {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 12);
+        let generation = src.read_u64();
+        let count = src.read_u32();
+        let mut events = Vec::new();
+        for _ in 0..count {
+            events.push(RailEvent::decode(src)?);
+        }
+        Ok(Self { generation, events })
+    }
+}
+
+impl_pdu_pod!(RailEventDump);
+
 // ── Payload codec ───────────────────────────────────────────────────────────
 
 impl Encode for Payload {
@@ -904,6 +1434,18 @@ impl Encode for Payload {
                 dst.write_u8(9);
                 diagnostics.encode(dst)?;
             }
+            Self::RailStatus(status) => {
+                dst.write_u8(10);
+                status.encode(dst)?;
+            }
+            Self::RailEvents(events) => {
+                dst.write_u8(11);
+                events.encode(dst)?;
+            }
+            Self::RailLaunch(launch) => {
+                dst.write_u8(12);
+                launch.encode(dst)?;
+            }
         }
         Ok(())
     }
@@ -925,6 +1467,9 @@ impl Encode for Payload {
                 Self::NowOperations(operations) => 4 + operations.iter().map(Encode::size).sum::<usize>(),
                 Self::NowEvent(event) => event.size(),
                 Self::NowDiagnostics(diagnostics) => diagnostics.size(),
+                Self::RailStatus(status) => status.size(),
+                Self::RailEvents(events) => events.size(),
+                Self::RailLaunch(launch) => launch.size(),
             }
     }
 }
@@ -965,6 +1510,9 @@ impl Decode<'_> for Payload {
             }
             8 => Ok(Self::NowEvent(OperationEvent::decode(src)?)),
             9 => Ok(Self::NowDiagnostics(NowDiagnostics::decode(src)?)),
+            10 => Ok(Self::RailStatus(RailStatusInfo::decode(src)?)),
+            11 => Ok(Self::RailEvents(RailEventDump::decode(src)?)),
+            12 => Ok(Self::RailLaunch(RailLaunchInfo::decode(src)?)),
             _ => Err(ironrdp_core::invalid_field_err!("payload", "unknown tag")),
         }
     }
@@ -1125,6 +1673,23 @@ impl Encode for Request {
                 write_bool(dst, *last)?;
             }
             Self::NowDiagnostics => dst.write_u8(20),
+            Self::RailStatus => dst.write_u8(22),
+            Self::RailEvents { after_sequence } => {
+                dst.write_u8(23);
+                write_opt_u64(dst, *after_sequence)?;
+            }
+            Self::RailExecute(request) => {
+                dst.write_u8(24);
+                request.encode(dst)?;
+            }
+            Self::RailWait {
+                after_sequence,
+                timeout_ms,
+            } => {
+                dst.write_u8(25);
+                write_opt_u64(dst, *after_sequence)?;
+                dst.write_u32(*timeout_ms);
+            }
         }
         Ok(())
     }
@@ -1144,7 +1709,8 @@ impl Encode for Request {
                 | Self::Screenshot
                 | Self::NowCapabilities
                 | Self::NowList
-                | Self::NowDiagnostics => 0,
+                | Self::NowDiagnostics
+                | Self::RailStatus => 0,
                 Self::QueryProps { filter } => 1 /* presence */ + filter.as_ref().map_or(0, Encode::size),
                 Self::QueryLogs { substring, last } => {
                     opt_string_size(substring.as_deref()) + 1 /* presence */ + last.map_or(0, |_| 4)
@@ -1161,6 +1727,9 @@ impl Encode for Request {
                 Self::NowCancel { .. } | Self::NowStatus { .. } => 8,
                 Self::NowAttach { after_sequence, .. } => 8 /* operation_id */ + opt_u64_size(*after_sequence),
                 Self::NowStdin { data, .. } => 8 /* operation_id */ + bytes_size(data) + 1 /* last */,
+                Self::RailEvents { after_sequence } => opt_u64_size(*after_sequence),
+                Self::RailExecute(request) => request.size(),
+                Self::RailWait { after_sequence, .. } => opt_u64_size(*after_sequence) + 4 /* timeout_ms */,
             }
     }
 }
@@ -1280,6 +1849,19 @@ impl Decode<'_> for Request {
                 })
             }
             20 => Ok(Self::NowDiagnostics),
+            22 => Ok(Self::RailStatus),
+            23 => Ok(Self::RailEvents {
+                after_sequence: read_opt_u64(src)?,
+            }),
+            24 => Ok(Self::RailExecute(RailExecuteRequest::decode(src)?)),
+            25 => {
+                let after_sequence = read_opt_u64(src)?;
+                ensure_size!(in: src, size: 4);
+                Ok(Self::RailWait {
+                    after_sequence,
+                    timeout_ms: src.read_u32(),
+                })
+            }
             _ => Err(ironrdp_core::invalid_field_err!("request", "unknown tag")),
         }
     }
@@ -1648,6 +2230,27 @@ impl Decode<'_> for OperationEvent {
 }
 
 impl_pdu_pod!(OperationEvent);
+
+#[cfg(test)]
+mod tests {
+    use super::RailExecuteRequest;
+
+    #[test]
+    fn rail_execute_debug_redacts_command_fields() {
+        let request = RailExecuteRequest {
+            executable: "secret-program.exe".to_owned(),
+            working_directory: "C:\\secret-directory".to_owned(),
+            arguments: "--token secret-token".to_owned(),
+            flags: 0,
+        };
+
+        let debug = format!("{request:?}");
+        assert!(!debug.contains("secret-program.exe"));
+        assert!(!debug.contains("C:\\secret-directory"));
+        assert!(!debug.contains("secret-token"));
+        assert!(debug.contains("executable_len"));
+    }
+}
 
 impl Encode for NowCapabilities {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {

--- a/crates/ironrdp-testsuite-extra/tests/agent.rs
+++ b/crates/ironrdp-testsuite-extra/tests/agent.rs
@@ -13,8 +13,8 @@ use ironrdp_propertyset::PropertySet;
 use ironrdp_rpc::ipc::{
     AgentError, AgentErrorCategory, ConnState, KeyFilter, NowCapabilities, NowDiagnostics, NowExecutionKind,
     NowExecutionRequest, NowStream, OperationEvent, OperationEventKind, OperationInfo, OperationState, Payload,
-    PropValue, PropertyDump, PropertyEntry, RailEvent, RailEventDump, RailEventKind, RailExecuteRequest,
-    RailLaunchInfo, RailStatusInfo, Request, Response, StatusInfo,
+    PropValue, PropertyDump, PropertyEntry, RailEvent, RailEventDump, RailEventKind, RailExecuteFailureReason,
+    RailExecuteRequest, RailLaunchInfo, RailStatusInfo, Request, Response, StatusInfo,
 };
 use ironrdp_rpc::wire;
 
@@ -257,6 +257,15 @@ fn response_variants_round_trip() {
                         flags: 0,
                         result: 0,
                         raw_result: 0,
+                    },
+                },
+                RailEvent {
+                    sequence: 6,
+                    kind: RailEventKind::ExecuteFailed {
+                        launch_id: Some(3),
+                        executable: "notepad.exe".to_owned(),
+                        flags: 0,
+                        reason: RailExecuteFailureReason::QueueRejected,
                     },
                 },
             ],

--- a/crates/ironrdp-testsuite-extra/tests/agent.rs
+++ b/crates/ironrdp-testsuite-extra/tests/agent.rs
@@ -13,7 +13,8 @@ use ironrdp_propertyset::PropertySet;
 use ironrdp_rpc::ipc::{
     AgentError, AgentErrorCategory, ConnState, KeyFilter, NowCapabilities, NowDiagnostics, NowExecutionKind,
     NowExecutionRequest, NowStream, OperationEvent, OperationEventKind, OperationInfo, OperationState, Payload,
-    PropValue, PropertyDump, PropertyEntry, Request, Response, StatusInfo,
+    PropValue, PropertyDump, PropertyEntry, RailEvent, RailEventDump, RailEventKind, RailExecuteRequest,
+    RailLaunchInfo, RailStatusInfo, Request, Response, StatusInfo,
 };
 use ironrdp_rpc::wire;
 
@@ -116,6 +117,20 @@ fn request_variants_round_trip() {
             last: true,
         },
         Request::NowDiagnostics,
+        Request::RailStatus,
+        Request::RailEvents {
+            after_sequence: Some(7),
+        },
+        Request::RailWait {
+            after_sequence: Some(7),
+            timeout_ms: 1_000,
+        },
+        Request::RailExecute(RailExecuteRequest {
+            executable: "notepad.exe".to_owned(),
+            working_directory: "C:\\Temp".to_owned(),
+            arguments: "audit.txt".to_owned(),
+            flags: 0,
+        }),
     ];
 
     for request in &requests {
@@ -215,6 +230,41 @@ fn response_variants_round_trip() {
             endpoint_allocated: true,
             connected: false,
             capabilities: None,
+        })),
+        Response::Ok(Payload::RailStatus(RailStatusInfo {
+            generation: 9,
+            next_sequence: 4,
+            handshake_complete: true,
+            desktop_synchronized: false,
+            pending_launches: vec![RailLaunchInfo {
+                launch_id: 3,
+                executable: "notepad.exe".to_owned(),
+                flags: 0,
+            }],
+        })),
+        Response::Ok(Payload::RailEvents(RailEventDump {
+            generation: 9,
+            events: vec![
+                RailEvent {
+                    sequence: 1,
+                    kind: RailEventKind::Gap { lost_through: 4 },
+                },
+                RailEvent {
+                    sequence: 5,
+                    kind: RailEventKind::ExecuteResult {
+                        launch_id: Some(3),
+                        executable: "notepad.exe".to_owned(),
+                        flags: 0,
+                        result: 0,
+                        raw_result: 0,
+                    },
+                },
+            ],
+        })),
+        Response::Ok(Payload::RailLaunch(RailLaunchInfo {
+            launch_id: 3,
+            executable: "notepad.exe".to_owned(),
+            flags: 0,
         })),
     ];
 

--- a/crates/ironrdp-viewer/src/app.rs
+++ b/crates/ironrdp-viewer/src/app.rs
@@ -571,6 +571,9 @@ impl RpcApp {
             RdpOutputEvent::RailExecuteResult(result) => {
                 debug!(?result, "RAIL execute completed");
             }
+            RdpOutputEvent::RailExecuteFailed { flags, reason, .. } => {
+                warn!(flags, ?reason, "RAIL execute could not be processed");
+            }
             RdpOutputEvent::RailApplicationId {
                 window_id,
                 application_id,


### PR DESCRIPTION
Expose bounded client-validated RAIL events and RemoteApp launch requests through the daemon IPC so headless agents can verify sessions.

Preserve cursors across resize reconnects, wake waiting readers for locally queued launches, and redact launch data in logs.

Report terminal local Execute failures without disrupting an otherwise valid RDP session.