### PR TITLE
feat(rdpei): add Input DVC and ActiveX touch

### DIFF
--- a/.agents/skills/commit-scope/SKILL.md
+++ b/.agents/skills/commit-scope/SKILL.md
@@ -11,7 +11,7 @@ Choose at most one optional scope for `<type>[optional scope][!]: <description>`
 
 ```text
 meta core error pdu str bulk graphics config input connector session driver
-svc dvc cliprdr rdpdr rdpsnd rdpeai displaycontrol echo egfx rdpeudp rdpeusb rdpemt rdcleanpath
+svc dvc cliprdr rdpdr rdpsnd rdpeai displaycontrol rdpei echo egfx rdpeudp rdpeusb rdpemt rdcleanpath
 tls mstsgu vmconnect
 
 client viewer agent daemon rpc activex server web ffi replay

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2395,6 +2395,7 @@ dependencies = [
  "ironrdp-mstsgu",
  "ironrdp-pdu",
  "ironrdp-rdpdr",
+ "ironrdp-rdpei",
  "ironrdp-rdpsnd",
  "ironrdp-server",
  "ironrdp-session",
@@ -2440,6 +2441,7 @@ dependencies = [
  "ironrdp-propertyset",
  "ironrdp-rail",
  "ironrdp-rdpdr-native",
+ "ironrdp-rdpei",
  "ironrdp-rpc",
  "ironrdp-session",
  "ironrdp-svc",
@@ -2555,6 +2557,7 @@ dependencies = [
  "ironrdp-rail",
  "ironrdp-rdcleanpath",
  "ironrdp-rdpdr",
+ "ironrdp-rdpei",
  "ironrdp-rdpsnd",
  "ironrdp-rdpsnd-native",
  "ironrdp-session",
@@ -2908,6 +2911,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ironrdp-rdpei"
+version = "0.1.0"
+dependencies = [
+ "bitflags 2.13.1",
+ "ironrdp-core 0.2.1",
+ "ironrdp-dvc",
+ "ironrdp-pdu",
+ "ironrdp-svc",
+ "tracing",
+]
+
+[[package]]
 name = "ironrdp-rdpeusb"
 version = "0.1.0"
 dependencies = [
@@ -3011,6 +3026,7 @@ dependencies = [
  "ironrdp-error 0.2.0",
  "ironrdp-graphics",
  "ironrdp-pdu",
+ "ironrdp-rdpei",
  "ironrdp-svc",
  "qoicoubeh",
  "tracing",
@@ -3067,6 +3083,7 @@ dependencies = [
  "ironrdp-rdcleanpath",
  "ironrdp-rdpdr",
  "ironrdp-rdpeai",
+ "ironrdp-rdpei",
  "ironrdp-rdpeusb",
  "ironrdp-rdpfile",
  "ironrdp-rdpsnd",

--- a/crates/ironrdp-activex/Cargo.toml
+++ b/crates/ironrdp-activex/Cargo.toml
@@ -29,6 +29,7 @@ ironrdp-core = { path = "../ironrdp-core", version = "0.2" }
 ironrdp-daemon = { path = "../ironrdp-daemon", version = "0.1" }
 ironrdp-input = { path = "../ironrdp-input", version = "0.7" }
 ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9" }
+ironrdp-rdpei = { path = "../ironrdp-rdpei", version = "0.1" }
 ironrdp-propertyset = { path = "../ironrdp-propertyset", version = "0.1" }
 ironrdp-rail = { path = "../ironrdp-rail", version = "0.1" }
 ironrdp-rdpdr-native = { path = "../ironrdp-rdpdr-native", version = "0.7" }
@@ -53,6 +54,7 @@ windows = { version = "0.62", features = [
     "Win32_Storage_FileSystem",
     "Win32_Security_Credentials",
     "Win32_UI_Input_KeyboardAndMouse",
+    "Win32_UI_Input_Pointer",
     "Win32_UI_Controls",
     "Win32_UI_HiDpi",
     "Win32_UI_Shell",

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -29,6 +29,7 @@ use ironrdp_pdu::rdp::{
 use ironrdp_pdu::window::try_decode_slow_path_windowing_orders;
 use ironrdp_propertyset::PropertySet;
 use ironrdp_rail::pdu::{ActivatePdu, ExecutePdu, RailPdu, SystemCommand, SystemCommandPdu};
+use ironrdp_rdpei::pdu::TouchEventPdu;
 use ironrdp_session::{GracefulDisconnectReason, SessionError, SessionErrorKind};
 use ironrdp_svc::{SvcClientProcessor, SvcMessage, SvcProcessor, impl_as_any};
 use ironrdp_tls::CertificateValidation;
@@ -90,20 +91,26 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
     EnableWindow, GetKeyState, IsWindowEnabled, ReleaseCapture, SetCapture, SetFocus, TME_LEAVE, TRACKMOUSEEVENT,
     TrackMouseEvent, VIRTUAL_KEY, VK_CANCEL, VK_CONTROL, VK_ESCAPE, VK_MENU, VK_PAUSE, VK_SHIFT, VK_TAB,
 };
+use windows::Win32::UI::Input::Pointer::{
+    GetPointerFrameTouchInfo, GetPointerInfo, POINTER_FLAG_CANCELED, POINTER_FLAG_INCONTACT, POINTER_FLAG_INRANGE,
+    POINTER_FLAG_UP, POINTER_INFO, POINTER_TOUCH_INFO, SkipPointerFrameMessages,
+};
 use windows::Win32::UI::Shell::{DefSubclassProc, SetWindowSubclass};
 use windows::Win32::UI::WindowsAndMessaging::{
     BS_PUSHBUTTON, CREATESTRUCTW, CreateWindowExW, DefWindowProcW, DestroyWindow, EnumWindows, GA_ROOT, GA_ROOTOWNER,
     GWL_EXSTYLE, GWL_STYLE, GWLP_HWNDPARENT, GWLP_USERDATA, GetAncestor, GetClassNameW, GetClientRect, GetCursorPos,
     GetDlgItem, GetForegroundWindow, GetParent, GetWindowLongPtrW, GetWindowRect, GetWindowTextW,
-    GetWindowThreadProcessId, HMENU, HWND_MESSAGE, IsIconic, IsWindow, IsWindowVisible, KillTimer, PostMessageW,
-    RegisterClassW, SC_MAXIMIZE, SC_MINIMIZE, SC_MOVE, SC_RESTORE, SC_SIZE, SIZE_MINIMIZED, SW_HIDE, SW_MAXIMIZE,
-    SW_MINIMIZE, SW_RESTORE, SW_SHOWNA, SWP_FRAMECHANGED, SWP_NOACTIVATE, SWP_NOCOPYBITS, SWP_NOZORDER, SendMessageW,
-    SetTimer, SetWindowLongPtrW, SetWindowPos, SetWindowTextW, ShowWindow, UnregisterClassW, WINDOW_EX_STYLE,
-    WINDOW_STYLE, WM_ACTIVATE, WM_APP, WM_CANCELMODE, WM_CAPTURECHANGED, WM_CLOSE, WM_COMMAND, WM_DPICHANGED,
-    WM_ENABLE, WM_KEYDOWN, WM_KEYUP, WM_KILLFOCUS, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP,
-    WM_MOUSEHWHEEL, WM_MOUSEMOVE, WM_MOUSEWHEEL, WM_MOVE, WM_NCCREATE, WM_NCDESTROY, WM_PAINT, WM_RBUTTONDOWN,
-    WM_RBUTTONUP, WM_SHOWWINDOW, WM_SIZE, WM_SYSCOMMAND, WM_SYSKEYDOWN, WM_SYSKEYUP, WM_TIMER, WM_XBUTTONDOWN,
-    WM_XBUTTONUP, WNDCLASSW, WS_CHILD, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW, WS_POPUP, WS_TABSTOP, WS_VISIBLE,
+    GetWindowThreadProcessId, HMENU, HWND_MESSAGE, IsIconic, IsWindow, IsWindowVisible, KillTimer, PT_TOUCH,
+    PostMessageW, RegisterClassW, SC_MAXIMIZE, SC_MINIMIZE, SC_MOVE, SC_RESTORE, SC_SIZE, SIZE_MINIMIZED, SW_HIDE,
+    SW_MAXIMIZE, SW_MINIMIZE, SW_RESTORE, SW_SHOWNA, SWP_FRAMECHANGED, SWP_NOACTIVATE, SWP_NOCOPYBITS, SWP_NOZORDER,
+    SendMessageW, SetTimer, SetWindowLongPtrW, SetWindowPos, SetWindowTextW, ShowWindow, TOUCH_MASK_CONTACTAREA,
+    TOUCH_MASK_ORIENTATION, TOUCH_MASK_PRESSURE, UnregisterClassW, WINDOW_EX_STYLE, WINDOW_STYLE, WM_ACTIVATE, WM_APP,
+    WM_CANCELMODE, WM_CAPTURECHANGED, WM_CLOSE, WM_COMMAND, WM_DPICHANGED, WM_ENABLE, WM_KEYDOWN, WM_KEYUP,
+    WM_KILLFOCUS, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP, WM_MOUSEHWHEEL, WM_MOUSEMOVE,
+    WM_MOUSEWHEEL, WM_MOVE, WM_NCCREATE, WM_NCDESTROY, WM_PAINT, WM_POINTERCAPTURECHANGED, WM_POINTERDOWN,
+    WM_POINTERLEAVE, WM_POINTERUP, WM_POINTERUPDATE, WM_RBUTTONDOWN, WM_RBUTTONUP, WM_SHOWWINDOW, WM_SIZE,
+    WM_SYSCOMMAND, WM_SYSKEYDOWN, WM_SYSKEYUP, WM_TIMER, WM_XBUTTONDOWN, WM_XBUTTONUP, WNDCLASSW, WS_CHILD,
+    WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW, WS_POPUP, WS_TABSTOP, WS_VISIBLE,
 };
 use windows::core::{s, w};
 use windows_core::{
@@ -129,6 +136,7 @@ use crate::mstsc::{
     IMsTscNonScriptable_Impl, InterfaceOut,
 };
 use crate::rpc::{self, ActiveXRpc, Command as RpcCommand};
+use crate::touch::{TouchContactTracker, TouchSample};
 use ironrdp_rpc as ironrdp_agent;
 
 /// The IronRDP-owned class identifier registered by this DLL.
@@ -5681,6 +5689,7 @@ pub(crate) struct Control {
     input_sender: RefCell<Option<RdpInputSender>>,
     static_channels: RefCell<BTreeMap<String, ActiveXStaticChannelSpec>>,
     input_database: Rc<RefCell<InputDatabase>>,
+    touch_tracker: RefCell<TouchContactTracker>,
     sinks: Rc<RefCell<BTreeMap<u32, EventSink>>>,
     next_cookie: Rc<Cell<u32>>,
     ole_advise_sinks: Rc<RefCell<BTreeMap<u32, IAdviseSink>>>,
@@ -5807,6 +5816,7 @@ impl Control {
             input_sender: RefCell::new(None),
             static_channels: RefCell::new(BTreeMap::new()),
             input_database,
+            touch_tracker: RefCell::new(TouchContactTracker::new()),
             sinks: Rc::new(RefCell::new(BTreeMap::new())),
             next_cookie: Rc::new(Cell::new(1)),
             ole_advise_sinks: Rc::new(RefCell::new(BTreeMap::new())),
@@ -8698,6 +8708,7 @@ impl Control {
         self.remote_size.set(None);
         self.clear_frame();
         self.input_database.borrow_mut().release_all();
+        *self.touch_tracker.borrow_mut() = TouchContactTracker::new();
         self.state.set(ConnectionState::Connecting);
         self.fire_event(DISPID_ON_CONNECTING, &[]);
         if self.state.get() == ConnectionState::Connecting {
@@ -9421,6 +9432,165 @@ impl Control {
         }
     }
 
+    /// Reserves input-queue capacity, then commits tracker transitions and sends.
+    ///
+    /// Capacity is reserved before mutating the tracker so a full queue cannot
+    /// desynchronize local contact state from the server.
+    fn send_touch_event_with<F>(&self, build: F)
+    where
+        F: FnOnce(&mut TouchContactTracker) -> Option<TouchEventPdu>,
+    {
+        let Some(sender) = self.input_sender.borrow().as_ref().cloned() else {
+            return;
+        };
+        let Ok(permit) = sender.try_reserve() else {
+            tracing::warn!("Unable to enqueue ActiveX RDPEI touch event for the RDP session");
+            return;
+        };
+        if let Some(event) = build(&mut self.touch_tracker.borrow_mut()) {
+            permit.send(RdpInputEvent::Touch(event));
+        }
+    }
+
+    fn release_touch_contacts(&self) {
+        self.send_touch_event_with(|tracker| tracker.release_all());
+    }
+
+    /// Maps client-area coordinates onto the remote desktop (signed RDPEI space).
+    fn desktop_position(&self, window: HWND, x: i32, y: i32) -> Option<(i32, i32)> {
+        let position = self.mouse_position(window, x, y)?;
+        Some((i32::from(position.x), i32::from(position.y)))
+    }
+
+    fn suppress_mouse_for_touch(&self) -> bool {
+        self.touch_tracker.borrow().has_active_contacts()
+    }
+
+    fn handle_pointer_message(&self, window: HWND, message: u32, wparam: WPARAM, _lparam: LPARAM) -> bool {
+        let pointer_id = (wparam.0 & 0xffff) as u32;
+
+        let mut info = POINTER_INFO::default();
+        if unsafe { GetPointerInfo(pointer_id, &mut info) }.is_err() {
+            return false;
+        }
+        if info.pointerType != PT_TOUCH {
+            // Pen and other pointer types are not remoted in this cut.
+            return false;
+        }
+
+        let mut pointer_count = 0u32;
+        if unsafe { GetPointerFrameTouchInfo(pointer_id, &mut pointer_count, None) }.is_err() || pointer_count == 0 {
+            return true;
+        }
+
+        let mut touch_infos = vec![POINTER_TOUCH_INFO::default(); pointer_count as usize];
+        if unsafe { GetPointerFrameTouchInfo(pointer_id, &mut pointer_count, Some(touch_infos.as_mut_ptr())) }.is_err()
+        {
+            return true;
+        }
+        touch_infos.truncate(pointer_count as usize);
+
+        let mut samples = Vec::with_capacity(touch_infos.len());
+        for touch in &touch_infos {
+            let ptr = touch.pointerInfo;
+            if ptr.pointerType != PT_TOUCH {
+                continue;
+            }
+
+            let mut client_point = ptr.ptPixelLocation;
+            if !unsafe { ScreenToClient(window, &mut client_point) }.as_bool() {
+                continue;
+            }
+            let mapped = self.desktop_position(window, client_point.x, client_point.y);
+            let canceled = (ptr.pointerFlags & POINTER_FLAG_CANCELED).0 != 0
+                || message == WM_POINTERCAPTURECHANGED
+                || (message == WM_POINTERLEAVE && (ptr.pointerFlags & POINTER_FLAG_INCONTACT).0 == 0);
+            let leaving = (ptr.pointerFlags & POINTER_FLAG_UP).0 != 0 || canceled;
+
+            let Some((x, y)) = mapped else {
+                // Outside the rendered desktop: still emit terminal transitions, keeping
+                // the last tracked coordinates rather than inventing (0, 0).
+                if leaving {
+                    samples.push(TouchSample {
+                        pointer_id: ptr.pointerId,
+                        x: 0,
+                        y: 0,
+                        preserve_position: true,
+                        in_range: false,
+                        in_contact: false,
+                        canceled,
+                        orientation: None,
+                        pressure: None,
+                        contact_rect: None,
+                    });
+                }
+                continue;
+            };
+
+            let contact_rect = if touch.touchMask & TOUCH_MASK_CONTACTAREA != 0 {
+                let mut tl = POINT {
+                    x: touch.rcContact.left,
+                    y: touch.rcContact.top,
+                };
+                let mut br = POINT {
+                    x: touch.rcContact.right,
+                    y: touch.rcContact.bottom,
+                };
+                if unsafe { ScreenToClient(window, &mut tl) }.as_bool()
+                    && unsafe { ScreenToClient(window, &mut br) }.as_bool()
+                {
+                    // Contact rect is exclusive bounds relative to the contact point.
+                    match (
+                        self.desktop_position(window, tl.x, tl.y),
+                        self.desktop_position(window, br.x, br.y),
+                    ) {
+                        (Some((l, t)), Some((r, b))) => {
+                            let left = i16::try_from(l.saturating_sub(x)).unwrap_or(i16::MIN);
+                            let top = i16::try_from(t.saturating_sub(y)).unwrap_or(i16::MIN);
+                            let right = i16::try_from(r.saturating_sub(x)).unwrap_or(i16::MAX);
+                            let bottom = i16::try_from(b.saturating_sub(y)).unwrap_or(i16::MAX);
+                            Some((left, top, right, bottom))
+                        }
+                        _ => None,
+                    }
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+
+            let orientation = if touch.touchMask & TOUCH_MASK_ORIENTATION != 0 {
+                Some(TouchContactTracker::win32_orientation_to_rdpei(touch.orientation))
+            } else {
+                None
+            };
+            let pressure = if touch.touchMask & TOUCH_MASK_PRESSURE != 0 {
+                Some(touch.pressure)
+            } else {
+                None
+            };
+
+            samples.push(TouchSample {
+                pointer_id: ptr.pointerId,
+                x,
+                y,
+                preserve_position: false,
+                in_range: (ptr.pointerFlags & POINTER_FLAG_INRANGE).0 != 0,
+                in_contact: (ptr.pointerFlags & POINTER_FLAG_INCONTACT).0 != 0,
+                canceled,
+                orientation,
+                pressure,
+                contact_rect,
+            });
+        }
+
+        self.send_touch_event_with(|tracker| tracker.process_samples(&samples));
+
+        let _ = unsafe { SkipPointerFrameMessages(pointer_id) };
+        true
+    }
+
     fn send_keys(&self, key_count: i32, key_up: *const i16, key_data: *const i32) -> Result<()> {
         let key_count = usize::try_from(key_count)
             .ok()
@@ -9505,6 +9675,7 @@ impl Control {
     }
 
     fn release_input(&self) {
+        self.release_touch_contacts();
         let fast_path = self.input_database.borrow_mut().release_all();
         if fast_path.is_empty() {
             return;
@@ -9668,11 +9839,14 @@ impl Control {
                 self.apply_input([operation]);
                 true
             }
+            WM_POINTERUPDATE | WM_POINTERDOWN | WM_POINTERUP | WM_POINTERLEAVE | WM_POINTERCAPTURECHANGED => {
+                self.handle_pointer_message(window, message, wparam, lparam)
+            }
             WM_MOUSEMOVE => {
                 if i32::from((lparam.0 >> 16) as i16) <= 4 {
                     self.expose_connection_bar();
                 }
-                if !self.compatibility.borrow().enable_mouse {
+                if !self.compatibility.borrow().enable_mouse || self.suppress_mouse_for_touch() {
                     return true;
                 }
                 let x = i32::from(lparam.0 as i32 as i16);
@@ -9683,7 +9857,7 @@ impl Control {
                 true
             }
             WM_LBUTTONDOWN | WM_RBUTTONDOWN | WM_MBUTTONDOWN | WM_XBUTTONDOWN => {
-                if !self.compatibility.borrow().enable_mouse {
+                if !self.compatibility.borrow().enable_mouse || self.suppress_mouse_for_touch() {
                     return true;
                 }
                 if let Err(error) = unsafe { SetFocus(Some(window)) } {
@@ -9703,6 +9877,9 @@ impl Control {
                 true
             }
             WM_LBUTTONUP | WM_RBUTTONUP | WM_MBUTTONUP | WM_XBUTTONUP => {
+                if self.suppress_mouse_for_touch() {
+                    return true;
+                }
                 let button = match message {
                     WM_LBUTTONUP => MouseButton::Left,
                     WM_RBUTTONUP => MouseButton::Right,
@@ -9715,7 +9892,7 @@ impl Control {
                 true
             }
             WM_MOUSEWHEEL | WM_MOUSEHWHEEL => {
-                if !self.compatibility.borrow().enable_mouse {
+                if !self.compatibility.borrow().enable_mouse || self.suppress_mouse_for_touch() {
                     return true;
                 }
                 let mut point = POINT {

--- a/crates/ironrdp-activex/src/lib.rs
+++ b/crates/ironrdp-activex/src/lib.rs
@@ -31,6 +31,8 @@ mod mstsc;
 mod registration;
 #[cfg(windows)]
 mod rpc;
+#[cfg(windows)]
+mod touch;
 
 #[cfg(windows)]
 pub use com::{

--- a/crates/ironrdp-activex/src/touch.rs
+++ b/crates/ironrdp-activex/src/touch.rs
@@ -1,0 +1,380 @@
+//! ActiveX touch → MS-RDPEI contact tracking.
+//!
+//! Maps Win32 `WM_POINTER*` touch samples onto the RDPEI contact state machine
+//! ([MS-RDPEI] 2.2.3.3.1.1 / 3.1.1.1).
+
+use std::collections::HashMap;
+use std::time::Instant;
+
+use ironrdp_rdpei::pdu::{TouchContact, TouchContactFlags, TouchEventPdu, TouchFrame};
+
+/// Lifetime phase of a tracked contact relative to the RDPEI FSM.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ContactPhase {
+    /// In range, not pressed.
+    Hovering,
+    /// Pressed (in contact).
+    Engaged,
+}
+
+#[derive(Debug, Clone)]
+struct TrackedContact {
+    contact_id: u8,
+    phase: ContactPhase,
+    x: i32,
+    y: i32,
+    started_at: Instant,
+}
+
+/// One Win32 pointer sample converted into desktop coordinates.
+#[derive(Debug, Clone)]
+pub(crate) struct TouchSample {
+    pub pointer_id: u32,
+    pub x: i32,
+    pub y: i32,
+    /// When true, coordinates are a placeholder and the last tracked position should be kept.
+    pub preserve_position: bool,
+    pub in_range: bool,
+    pub in_contact: bool,
+    pub canceled: bool,
+    /// RDPEI orientation degrees (0 = up, counter-clockwise), already converted from Win32.
+    pub orientation: Option<u32>,
+    pub pressure: Option<u32>,
+    /// Contact rect offsets relative to `(x, y)`, not absolute corners.
+    pub contact_rect: Option<(i16, i16, i16, i16)>,
+}
+
+/// Tracks active contacts and builds RDPEI touch frames.
+#[derive(Debug, Default)]
+pub(crate) struct TouchContactTracker {
+    by_pointer: HashMap<u32, TrackedContact>,
+    next_contact_id: u8,
+}
+
+impl TouchContactTracker {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    pub(crate) fn has_active_contacts(&self) -> bool {
+        !self.by_pointer.is_empty()
+    }
+
+    /// Converts Win32 pointer orientation (degrees clockwise from +X) to RDPEI
+    /// orientation (degrees counter-clockwise from +Y / up).
+    #[must_use]
+    pub(crate) fn win32_orientation_to_rdpei(win32_degrees: u32) -> u32 {
+        // RDPEI = (90 - win32) mod 360
+        (90 + 360 - (win32_degrees % 360)) % 360
+    }
+
+    /// Builds a touch event for the given samples, advancing the local FSM.
+    ///
+    /// Returns `None` when no legal contact transitions are produced (for example
+    /// an untracked cancel). Callers must reserve send capacity before invoking
+    /// this method so a full queue cannot drop a transition that already mutated
+    /// the tracker.
+    pub(crate) fn process_samples(&mut self, samples: &[TouchSample]) -> Option<TouchEventPdu> {
+        let mut contacts = Vec::with_capacity(samples.len());
+        let mut finished = Vec::new();
+
+        for sample in samples {
+            let prev = self.by_pointer.get(&sample.pointer_id).cloned();
+            let Some((next_phase, flags)) = map_contact_flags(prev.as_ref().map(|c| c.phase), sample) else {
+                continue;
+            };
+
+            let contact_id = match prev.as_ref() {
+                Some(c) => c.contact_id,
+                None => self.allocate_contact_id(),
+            };
+            let (x, y) = if sample.preserve_position {
+                prev.as_ref().map(|c| (c.x, c.y)).unwrap_or((sample.x, sample.y))
+            } else {
+                (sample.x, sample.y)
+            };
+            let started_at = prev.as_ref().map(|c| c.started_at).unwrap_or_else(Instant::now);
+
+            let mut contact = TouchContact::new(contact_id, x, y, flags);
+            if let Some(orientation) = sample.orientation {
+                contact = contact.with_orientation(orientation);
+            }
+            if let Some(pressure) = sample.pressure {
+                // RDPEI pressure is 0..=1024; Win32 touch pressure is 0..=1024 already.
+                contact = contact.with_pressure(pressure.min(1024));
+            }
+            if let Some((left, top, right, bottom)) = sample.contact_rect {
+                contact = contact.with_contact_rect(left, top, right, bottom);
+            }
+            contacts.push(contact);
+
+            match next_phase {
+                None => {
+                    finished.push(sample.pointer_id);
+                }
+                Some(phase) => {
+                    self.by_pointer.insert(
+                        sample.pointer_id,
+                        TrackedContact {
+                            contact_id,
+                            phase,
+                            x,
+                            y,
+                            started_at,
+                        },
+                    );
+                }
+            }
+        }
+
+        for pointer_id in finished {
+            self.by_pointer.remove(&pointer_id);
+        }
+
+        if contacts.is_empty() {
+            return None;
+        }
+
+        // Single-frame PDUs are encoded immediately; encodeTime is the generation→encode
+        // delay for the oldest frame, which is ~0 here (not transaction age).
+        Some(TouchEventPdu::new(0, vec![TouchFrame::new(0, contacts)]))
+    }
+
+    /// Forces every tracked contact out of range (focus loss / capture change).
+    pub(crate) fn release_all(&mut self) -> Option<TouchEventPdu> {
+        if self.by_pointer.is_empty() {
+            return None;
+        }
+
+        let mut contacts = Vec::with_capacity(self.by_pointer.len());
+        for (_, tracked) in self.by_pointer.drain() {
+            let flags = match tracked.phase {
+                // Hovering → out of range: UPDATE (no INRANGE).
+                ContactPhase::Hovering => TouchContactFlags::UPDATE,
+                // Engaged → out of range: UP (no INRANGE).
+                ContactPhase::Engaged => TouchContactFlags::UP,
+            };
+            contacts.push(TouchContact::new(tracked.contact_id, tracked.x, tracked.y, flags));
+        }
+
+        Some(TouchEventPdu::new(0, vec![TouchFrame::new(0, contacts)]))
+    }
+
+    fn allocate_contact_id(&mut self) -> u8 {
+        // Prefer unused IDs; wrap if needed. Contact IDs are 8-bit.
+        let used: std::collections::HashSet<u8> = self.by_pointer.values().map(|c| c.contact_id).collect();
+        for _ in 0..=u8::MAX {
+            let id = self.next_contact_id;
+            self.next_contact_id = self.next_contact_id.wrapping_add(1);
+            if !used.contains(&id) {
+                return id;
+            }
+        }
+        // All 256 IDs in use; reuse next.
+        let id = self.next_contact_id;
+        self.next_contact_id = self.next_contact_id.wrapping_add(1);
+        id
+    }
+}
+
+/// Maps previous phase + sample onto `(next_phase, flags)`.
+///
+/// `next_phase == None` means the contact leaves the tracker (out of range).
+fn map_contact_flags(
+    prev: Option<ContactPhase>,
+    sample: &TouchSample,
+) -> Option<(Option<ContactPhase>, TouchContactFlags)> {
+    if sample.canceled {
+        return match prev {
+            Some(ContactPhase::Hovering) => Some((None, TouchContactFlags::UPDATE | TouchContactFlags::CANCELED)),
+            Some(ContactPhase::Engaged) => Some((None, TouchContactFlags::UP | TouchContactFlags::CANCELED)),
+            // Ignore cancels for contacts we never advertised — avoids ID leaks.
+            None => None,
+        };
+    }
+
+    let in_range = sample.in_range;
+    let in_contact = sample.in_contact && in_range;
+
+    match (prev, in_range, in_contact) {
+        // → Engaged
+        (None | Some(ContactPhase::Hovering), true, true) => Some((
+            Some(ContactPhase::Engaged),
+            TouchContactFlags::DOWN | TouchContactFlags::INRANGE | TouchContactFlags::INCONTACT,
+        )),
+        (Some(ContactPhase::Engaged), true, true) => Some((
+            Some(ContactPhase::Engaged),
+            TouchContactFlags::UPDATE | TouchContactFlags::INRANGE | TouchContactFlags::INCONTACT,
+        )),
+        // Engaged lift → hover (still in range)
+        (Some(ContactPhase::Engaged), true, false) => Some((
+            Some(ContactPhase::Hovering),
+            TouchContactFlags::UP | TouchContactFlags::INRANGE,
+        )),
+        // Engaged lift → out of range
+        (Some(ContactPhase::Engaged), false, _) => Some((None, TouchContactFlags::UP)),
+        // → / stay Hovering
+        (None, true, false) => Some((
+            Some(ContactPhase::Hovering),
+            TouchContactFlags::UPDATE | TouchContactFlags::INRANGE,
+        )),
+        (Some(ContactPhase::Hovering), true, false) => Some((
+            Some(ContactPhase::Hovering),
+            TouchContactFlags::UPDATE | TouchContactFlags::INRANGE,
+        )),
+        // Hovering leave range → out of range (UPDATE without INRANGE)
+        (Some(ContactPhase::Hovering), false, _) => Some((None, TouchContactFlags::UPDATE)),
+        // Still out of range
+        (None, false, _) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(pointer_id: u32, x: i32, y: i32, in_range: bool, in_contact: bool) -> TouchSample {
+        TouchSample {
+            pointer_id,
+            x,
+            y,
+            preserve_position: false,
+            in_range,
+            in_contact,
+            canceled: false,
+            orientation: None,
+            pressure: None,
+            contact_rect: None,
+        }
+    }
+
+    #[test]
+    fn down_update_up_happy_path() {
+        let mut tracker = TouchContactTracker::new();
+        let down = tracker.process_samples(&[sample(7, 10, 20, true, true)]).expect("down");
+        assert_eq!(
+            down.frames[0].contacts[0].contact_flags,
+            TouchContactFlags::DOWN | TouchContactFlags::INRANGE | TouchContactFlags::INCONTACT
+        );
+        assert_eq!(down.encode_time, 0);
+
+        let mov = tracker.process_samples(&[sample(7, 11, 21, true, true)]).expect("move");
+        assert_eq!(
+            mov.frames[0].contacts[0].contact_flags,
+            TouchContactFlags::UPDATE | TouchContactFlags::INRANGE | TouchContactFlags::INCONTACT
+        );
+
+        let up = tracker.process_samples(&[sample(7, 11, 21, false, false)]).expect("up");
+        assert_eq!(up.frames[0].contacts[0].contact_flags, TouchContactFlags::UP);
+        assert!(!tracker.has_active_contacts());
+    }
+
+    #[test]
+    fn hover_then_leave_uses_update() {
+        let mut tracker = TouchContactTracker::new();
+        let hover = tracker.process_samples(&[sample(1, 5, 5, true, false)]).expect("hover");
+        assert_eq!(
+            hover.frames[0].contacts[0].contact_flags,
+            TouchContactFlags::UPDATE | TouchContactFlags::INRANGE
+        );
+
+        let leave = tracker
+            .process_samples(&[sample(1, 5, 5, false, false)])
+            .expect("leave");
+        assert_eq!(leave.frames[0].contacts[0].contact_flags, TouchContactFlags::UPDATE);
+    }
+
+    #[test]
+    fn engaged_lift_to_hover_uses_up_inrange() {
+        let mut tracker = TouchContactTracker::new();
+        tracker.process_samples(&[sample(1, 1, 1, true, true)]).expect("down");
+        let lift = tracker.process_samples(&[sample(1, 1, 1, true, false)]).expect("lift");
+        assert_eq!(
+            lift.frames[0].contacts[0].contact_flags,
+            TouchContactFlags::UP | TouchContactFlags::INRANGE
+        );
+    }
+
+    #[test]
+    fn cancel_engaged_uses_up_canceled() {
+        let mut tracker = TouchContactTracker::new();
+        tracker.process_samples(&[sample(3, 0, 0, true, true)]).expect("down");
+        let mut cancel = sample(3, 0, 0, false, false);
+        cancel.canceled = true;
+        let pdu = tracker.process_samples(&[cancel]).expect("cancel");
+        assert_eq!(
+            pdu.frames[0].contacts[0].contact_flags,
+            TouchContactFlags::UP | TouchContactFlags::CANCELED
+        );
+    }
+
+    #[test]
+    fn cancel_hovering_uses_update_canceled() {
+        let mut tracker = TouchContactTracker::new();
+        tracker.process_samples(&[sample(3, 0, 0, true, false)]).expect("hover");
+        let mut cancel = sample(3, 0, 0, false, false);
+        cancel.canceled = true;
+        let pdu = tracker.process_samples(&[cancel]).expect("cancel");
+        assert_eq!(
+            pdu.frames[0].contacts[0].contact_flags,
+            TouchContactFlags::UPDATE | TouchContactFlags::CANCELED
+        );
+    }
+
+    #[test]
+    fn untracked_cancel_is_ignored() {
+        let mut tracker = TouchContactTracker::new();
+        let mut cancel = sample(9, 0, 0, false, false);
+        cancel.canceled = true;
+        assert!(tracker.process_samples(&[cancel]).is_none());
+    }
+
+    #[test]
+    fn release_all_distinguishes_hover_and_engaged() {
+        let mut tracker = TouchContactTracker::new();
+        tracker.process_samples(&[sample(1, 1, 1, true, false)]).expect("hover");
+        tracker.process_samples(&[sample(2, 2, 2, true, true)]).expect("down");
+        let pdu = tracker.release_all().expect("release");
+        let flags: Vec<_> = pdu.frames[0].contacts.iter().map(|c| c.contact_flags).collect();
+        assert!(flags.contains(&TouchContactFlags::UPDATE));
+        assert!(flags.contains(&TouchContactFlags::UP));
+    }
+
+    #[test]
+    fn preserve_position_keeps_last_coords() {
+        let mut tracker = TouchContactTracker::new();
+        tracker.process_samples(&[sample(1, 42, 24, true, true)]).expect("down");
+        let mut outside = sample(1, 0, 0, false, false);
+        outside.preserve_position = true;
+        let up = tracker.process_samples(&[outside]).expect("up");
+        assert_eq!(up.frames[0].contacts[0].x, 42);
+        assert_eq!(up.frames[0].contacts[0].y, 24);
+    }
+
+    #[test]
+    fn orientation_conversion_win32_to_rdpei() {
+        assert_eq!(TouchContactTracker::win32_orientation_to_rdpei(0), 90);
+        assert_eq!(TouchContactTracker::win32_orientation_to_rdpei(90), 0);
+        assert_eq!(TouchContactTracker::win32_orientation_to_rdpei(180), 270);
+        assert_eq!(TouchContactTracker::win32_orientation_to_rdpei(270), 180);
+    }
+
+    #[test]
+    fn every_emitted_flag_set_is_legal() {
+        let cases = [
+            sample(1, 0, 0, true, true),
+            sample(1, 1, 1, true, true),
+            sample(1, 1, 1, true, false),
+            sample(1, 1, 1, false, false),
+        ];
+        let mut tracker = TouchContactTracker::new();
+        for s in cases {
+            if let Some(pdu) = tracker.process_samples(&[s]) {
+                for c in &pdu.frames[0].contacts {
+                    assert!(c.contact_flags.is_legal(), "{:?}", c.contact_flags);
+                }
+            }
+        }
+    }
+}

--- a/crates/ironrdp-client/Cargo.toml
+++ b/crates/ironrdp-client/Cargo.toml
@@ -63,6 +63,7 @@ ironrdp-session = { path = "../ironrdp-session", version = "0.11" } # public
 ironrdp-graphics = { path = "../ironrdp-graphics", version = "0.9" } # public
 ironrdp-displaycontrol = { path = "../ironrdp-displaycontrol", version = "0.8" }
 ironrdp-echo = { path = "../ironrdp-echo", version = "0.4" }
+ironrdp-rdpei = { path = "../ironrdp-rdpei", version = "0.1" }
 ironrdp-tls = { path = "../ironrdp-tls", version = "0.2" } # public
 ironrdp-tokio = { path = "../ironrdp-tokio", version = "0.10", features = ["reqwest"] }
 ironrdp-rdcleanpath = { path = "../ironrdp-rdcleanpath", version = "0.2" }

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -23,6 +23,8 @@ use ironrdp_pdu::input::mouse::PointerFlags;
 use ironrdp_pdu::pdu_other_err;
 #[cfg(feature = "rdpdr")]
 pub use ironrdp_rdpdr::backend::{RdpdrBackendFactory, RdpdrBackendFactoryResult, RdpdrBackendProduct, RdpdrDrive};
+use ironrdp_rdpei::RdpeiClient;
+use ironrdp_rdpei::pdu::TouchEventPdu;
 #[cfg(any(feature = "clipboard", feature = "rdpdr"))]
 use ironrdp_session::ActiveStage;
 use ironrdp_session::image::DecodedImage;
@@ -158,6 +160,12 @@ pub enum RdpInputEvent {
         physical_size: Option<(u32, u32)>,
     },
     FastPath(SmallVec<[FastPathInputEvent; 2]>),
+    /// Multitouch frames for MS-RDPEI (`Microsoft::Windows::RDS::Input`).
+    Touch(TouchEventPdu),
+    /// Dismiss a hovering touch contact over MS-RDPEI.
+    DismissHoveringTouchContact {
+        contact_id: u8,
+    },
     Close,
     #[cfg(feature = "clipboard")]
     Clipboard(ClipboardMessage),
@@ -816,7 +824,8 @@ fn build_connector(
 
     let mut drdynvc = ironrdp_dvc::DrdynvcClient::new()
         .with_dynamic_channel(DisplayControlClient::new(|_| Ok(Vec::new())))
-        .with_dynamic_channel(EchoClient::new());
+        .with_dynamic_channel(EchoClient::new())
+        .with_dynamic_channel(RdpeiClient::default());
 
     // Attach DVC pipe proxies.
     #[cfg(feature = "dvc-pipe-proxy")]
@@ -1776,9 +1785,35 @@ async fn active_session(
                         }
                         active_stage.process_fastpath_input(&mut image, &events)?
                     }
-                    RdpInputEvent::Close => {
-                        active_stage.graceful_shutdown()?
+                    RdpInputEvent::Touch(event) => {
+                        trace!(frames = event.frames.len(), "RDPEI touch event");
+                        match active_stage.encode_rdpei_touch(event) {
+                            Some(Ok(frame)) => vec![ActiveStageOutput::ResponseFrame(frame)],
+                            Some(Err(error)) => {
+                                // Surface encode failures so producers can resync contact state.
+                                warn!(%error, "Failed to encode RDPEI touch event");
+                                Vec::new()
+                            }
+                            None => {
+                                // Channel missing / not ready / suspended: warn rather than
+                                // silently dropping, which desynchronizes the contact FSM.
+                                warn!("Dropping RDPEI touch event: channel unavailable, not ready, or suspended");
+                                Vec::new()
+                            }
+                        }
                     }
+                    RdpInputEvent::DismissHoveringTouchContact { contact_id } => {
+                        trace!(contact_id, "RDPEI dismiss hovering touch contact");
+                        match active_stage.encode_rdpei_dismiss_hovering(contact_id) {
+                            Some(Ok(frame)) => vec![ActiveStageOutput::ResponseFrame(frame)],
+                            Some(Err(error)) => {
+                                warn!(%error, "Failed to encode RDPEI dismiss hovering");
+                                Vec::new()
+                            }
+                            None => Vec::new(),
+                        }
+                    }
+                    RdpInputEvent::Close => active_stage.graceful_shutdown()?,
                     #[cfg(feature = "clipboard")]
                     RdpInputEvent::Clipboard(event) => {
                         process_clipboard_message(&mut active_stage, event)?

--- a/crates/ironrdp-rdpei/CHANGELOG.md
+++ b/crates/ironrdp-rdpei/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [0.1.0] - YYYY-MM-DD
+
+### Added
+
+- Initial MS-RDPEI implementation: variable-length integers, all input PDUs, client and server DVC processors.

--- a/crates/ironrdp-rdpei/Cargo.toml
+++ b/crates/ironrdp-rdpei/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "ironrdp-rdpei"
+version = "0.1.0"
+readme = "README.md"
+description = "Input virtual channel extension (MS-RDPEI) implementation"
+edition.workspace = true
+rust-version = "1.94"
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lib]
+doctest = false
+
+[dependencies]
+bitflags = "2.11"
+ironrdp-core = { path = "../ironrdp-core", version = "0.2" } # public
+ironrdp-dvc = { path = "../ironrdp-dvc", version = "0.8" } # public
+ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9" } # public
+ironrdp-svc = { path = "../ironrdp-svc", version = "0.8" } # public
+tracing = { version = "0.1", features = ["log"] }
+
+[lints]
+workspace = true

--- a/crates/ironrdp-rdpei/README.md
+++ b/crates/ironrdp-rdpei/README.md
@@ -1,0 +1,11 @@
+# IronRDP RDPEI
+
+Implements the Remote Desktop Protocol: Input Virtual Channel Extension ([MS-RDPEI]).
+
+This is the dynamic channel `Microsoft::Windows::RDS::Input` used to remote multitouch and pen input
+from an RDP client to a server.
+
+This crate is part of the [IronRDP] project.
+
+[MS-RDPEI]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpei/deb1ca39-344a-467a-b9d4-dfe196b46c9d
+[IronRDP]: https://github.com/Devolutions/IronRDP

--- a/crates/ironrdp-rdpei/src/client.rs
+++ b/crates/ironrdp-rdpei/src/client.rs
@@ -1,0 +1,204 @@
+use ironrdp_core::{EncodeResult, decode, impl_as_any};
+use ironrdp_dvc::{DvcClientProcessor, DvcMessage, DvcProcessor, encode_dvc_messages};
+use ironrdp_pdu::{PduResult, decode_err, pdu_other_err};
+use ironrdp_svc::{ChannelFlags, SvcMessage};
+use tracing::debug;
+
+use crate::CHANNEL_NAME;
+use crate::pdu::{
+    CsReadyFlags, CsReadyPdu, DismissHoveringTouchContactPdu, PenEventPdu, RdpInputProtocolVersion, RdpeiPdu,
+    ScReadyFeatures, TouchEventPdu,
+};
+
+/// Client endpoint for the MS-RDPEI dynamic channel.
+#[derive(Debug)]
+pub struct RdpeiClient {
+    max_touch_contacts: u16,
+    cs_ready_flags: CsReadyFlags,
+    /// Protocol version the client will advertise in CS_READY.
+    advertise_version: RdpInputProtocolVersion,
+    ready: bool,
+    suspended: bool,
+    negotiated_version: Option<RdpInputProtocolVersion>,
+    server_features: Option<ScReadyFeatures>,
+}
+
+impl Default for RdpeiClient {
+    fn default() -> Self {
+        Self::new(10, CsReadyFlags::empty(), RdpInputProtocolVersion::V200)
+    }
+}
+
+impl RdpeiClient {
+    /// Creates a new client that will reply to `SC_READY` with the given capabilities.
+    pub fn new(
+        max_touch_contacts: u16,
+        cs_ready_flags: CsReadyFlags,
+        advertise_version: RdpInputProtocolVersion,
+    ) -> Self {
+        Self {
+            max_touch_contacts,
+            cs_ready_flags,
+            advertise_version,
+            ready: false,
+            suspended: false,
+            negotiated_version: None,
+            server_features: None,
+        }
+    }
+
+    /// True after a successful SC_READY / CS_READY exchange.
+    #[must_use]
+    pub fn ready(&self) -> bool {
+        self.ready
+    }
+
+    /// True while the server has suspended input injection.
+    #[must_use]
+    pub fn is_suspended(&self) -> bool {
+        self.suspended
+    }
+
+    /// Negotiated server protocol version, if known.
+    #[must_use]
+    pub fn negotiated_version(&self) -> Option<RdpInputProtocolVersion> {
+        self.negotiated_version
+    }
+
+    /// Whether pen frames may be sent given the negotiated version.
+    #[must_use]
+    pub fn pen_allowed(&self) -> bool {
+        self.negotiated_version
+            .is_some_and(RdpInputProtocolVersion::supports_pen)
+    }
+
+    /// Encodes a touch event when the channel is ready and not suspended.
+    pub fn encode_touch_event(&self, channel_id: u32, event: TouchEventPdu) -> EncodeResult<Vec<SvcMessage>> {
+        self.ensure_can_send_input()?;
+        encode_dvc_messages(
+            channel_id,
+            vec![Box::new(RdpeiPdu::Touch(event))],
+            ChannelFlags::empty(),
+        )
+    }
+
+    /// Encodes a pen event when the channel is ready, not suspended, and pen is allowed.
+    pub fn encode_pen_event(&self, channel_id: u32, event: PenEventPdu) -> EncodeResult<Vec<SvcMessage>> {
+        self.ensure_can_send_input()?;
+        if !self.pen_allowed() {
+            return Err(ironrdp_core::other_err!(
+                "RdpeiClient::encode_pen_event",
+                "pen frames not allowed for negotiated protocol version"
+            ));
+        }
+        encode_dvc_messages(channel_id, vec![Box::new(RdpeiPdu::Pen(event))], ChannelFlags::empty())
+    }
+
+    /// Encodes a dismiss-hovering-touch-contact PDU when the channel is ready.
+    pub fn encode_dismiss_hovering(&self, channel_id: u32, contact_id: u8) -> EncodeResult<Vec<SvcMessage>> {
+        if !self.ready {
+            return Err(ironrdp_core::other_err!(
+                "RdpeiClient::encode_dismiss_hovering",
+                "rdpei channel is not ready"
+            ));
+        }
+        encode_dvc_messages(
+            channel_id,
+            vec![Box::new(RdpeiPdu::DismissHoveringTouchContact(
+                DismissHoveringTouchContactPdu::new(contact_id),
+            ))],
+            ChannelFlags::empty(),
+        )
+    }
+
+    fn ensure_can_send_input(&self) -> EncodeResult<()> {
+        if !self.ready {
+            return Err(ironrdp_core::other_err!("RdpeiClient", "rdpei channel is not ready"));
+        }
+        if self.suspended {
+            return Err(ironrdp_core::other_err!("RdpeiClient", "rdpei input is suspended"));
+        }
+        Ok(())
+    }
+
+    fn build_cs_ready(&self, server_version: RdpInputProtocolVersion) -> CsReadyPdu {
+        // Advertise our preferred version; when the server only supports touch-only
+        // versions, match the server so negotiation stays valid.
+        let version = match server_version {
+            RdpInputProtocolVersion::V100 | RdpInputProtocolVersion::V101
+                if self.advertise_version > server_version =>
+            {
+                server_version
+            }
+            _ => self.advertise_version,
+        };
+
+        let mut flags = self.cs_ready_flags;
+        // Do not send DISABLE_TIMESTAMP_INJECTION to V100-only servers.
+        if server_version == RdpInputProtocolVersion::V100 {
+            flags.remove(CsReadyFlags::DISABLE_TIMESTAMP_INJECTION);
+        }
+
+        CsReadyPdu::new(flags, version, self.max_touch_contacts)
+    }
+}
+
+impl_as_any!(RdpeiClient);
+
+impl DvcProcessor for RdpeiClient {
+    fn channel_name(&self) -> &str {
+        CHANNEL_NAME
+    }
+
+    fn start(&mut self, _channel_id: u32) -> PduResult<Vec<DvcMessage>> {
+        // Server initiates with SC_READY (MS-RDPEI 3.2.3 / 3.3.3).
+        Ok(Vec::new())
+    }
+
+    fn process(&mut self, _channel_id: u32, payload: &[u8]) -> PduResult<Vec<DvcMessage>> {
+        let pdu: RdpeiPdu = decode(payload).map_err(|e| decode_err!(e))?;
+
+        match pdu {
+            RdpeiPdu::ScReady(sc) => {
+                debug!(
+                    version = ?sc.protocol_version,
+                    features = ?sc.supported_features,
+                    "Received RDPEI SC_READY"
+                );
+                self.server_features = sc.supported_features;
+                self.suspended = false;
+
+                let cs = self.build_cs_ready(sc.protocol_version);
+                // Effective version is the minimum of what both endpoints advertise.
+                self.negotiated_version = Some(core::cmp::min(sc.protocol_version, cs.protocol_version));
+                self.ready = true;
+                debug!(
+                    version = ?cs.protocol_version,
+                    negotiated = ?self.negotiated_version,
+                    max_touch_contacts = cs.max_touch_contacts,
+                    flags = ?cs.flags,
+                    "Sending RDPEI CS_READY"
+                );
+                Ok(vec![Box::new(RdpeiPdu::CsReady(cs))])
+            }
+            RdpeiPdu::SuspendInput => {
+                debug!("RDPEI input suspended by server");
+                self.suspended = true;
+                Ok(Vec::new())
+            }
+            RdpeiPdu::ResumeInput => {
+                debug!("RDPEI input resumed by server");
+                self.suspended = false;
+                Ok(Vec::new())
+            }
+            RdpeiPdu::CsReady(_) | RdpeiPdu::Touch(_) | RdpeiPdu::Pen(_) | RdpeiPdu::DismissHoveringTouchContact(_) => {
+                Err(pdu_other_err!(
+                    "RdpeiClient::process",
+                    "received unexpected client-to-server RDPEI PDU from server"
+                ))
+            }
+        }
+    }
+}
+
+impl DvcClientProcessor for RdpeiClient {}

--- a/crates/ironrdp-rdpei/src/lib.rs
+++ b/crates/ironrdp-rdpei/src/lib.rs
@@ -1,0 +1,16 @@
+#![cfg_attr(doc, doc = include_str!("../README.md"))]
+#![doc(html_logo_url = "https://cdnweb.devolutions.net/images/projects/devolutions/logos/devolutions-icon-shadow.svg")]
+
+//! MS-RDPEI Input Virtual Channel Extension.
+
+mod client;
+pub mod pdu;
+mod server;
+
+pub use client::RdpeiClient;
+pub use server::{RdpeiHandler, RdpeiServer};
+
+/// Dynamic channel name for MS-RDPEI ([MS-RDPEI] 2.1).
+///
+/// [MS-RDPEI]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpei/1aab43bf-cab8-4f0a-9eb3-b83b8365e237
+pub const CHANNEL_NAME: &str = "Microsoft::Windows::RDS::Input";

--- a/crates/ironrdp-rdpei/src/pdu/mod.rs
+++ b/crates/ironrdp-rdpei/src/pdu/mod.rs
@@ -1,0 +1,1299 @@
+//! MS-RDPEI PDU definitions.
+//!
+//! Structures follow [MS-RDPEI] sections 2.2.2 and 2.2.3.
+//!
+//! [MS-RDPEI]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpei/deb1ca39-344a-467a-b9d4-dfe196b46c9d
+
+// Wire codecs intentionally pack integers with truncating casts after range checks.
+#![allow(clippy::as_conversions)]
+#![allow(clippy::cast_possible_truncation)]
+
+mod varint;
+
+use bitflags::bitflags;
+use ironrdp_core::{
+    Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, cast_int, cast_length, ensure_fixed_part_size,
+    ensure_size, invalid_field_err,
+};
+use ironrdp_dvc::DvcEncode;
+
+pub use self::varint::{EightByteUnsigned, FourByteSigned, FourByteUnsigned, TwoByteSigned, TwoByteUnsigned};
+
+/// Fixed size of [`RdpInputHeader`].
+pub const RDP_INPUT_HEADER_SIZE: usize = 6;
+
+/// EVENTID values from [MS-RDPEI] 2.2.2.6.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u16)]
+pub enum RdpInputEventId {
+    ScReady = 0x0001,
+    CsReady = 0x0002,
+    Touch = 0x0003,
+    SuspendInput = 0x0004,
+    ResumeInput = 0x0005,
+    DismissHoveringTouchContact = 0x0006,
+    Pen = 0x0008,
+}
+
+impl RdpInputEventId {
+    pub fn from_u16(value: u16) -> DecodeResult<Self> {
+        match value {
+            0x0001 => Ok(Self::ScReady),
+            0x0002 => Ok(Self::CsReady),
+            0x0003 => Ok(Self::Touch),
+            0x0004 => Ok(Self::SuspendInput),
+            0x0005 => Ok(Self::ResumeInput),
+            0x0006 => Ok(Self::DismissHoveringTouchContact),
+            0x0008 => Ok(Self::Pen),
+            _ => Err(invalid_field_err!("eventId", "unknown RDPINPUT event id")),
+        }
+    }
+
+    pub fn as_u16(self) -> u16 {
+        match self {
+            Self::ScReady => 0x0001,
+            Self::CsReady => 0x0002,
+            Self::Touch => 0x0003,
+            Self::SuspendInput => 0x0004,
+            Self::ResumeInput => 0x0005,
+            Self::DismissHoveringTouchContact => 0x0006,
+            Self::Pen => 0x0008,
+        }
+    }
+}
+
+/// Protocol versions advertised in SC_READY / CS_READY.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(u32)]
+pub enum RdpInputProtocolVersion {
+    V100 = 0x0001_0000,
+    V101 = 0x0001_0001,
+    V200 = 0x0002_0000,
+    V300 = 0x0003_0000,
+}
+
+impl RdpInputProtocolVersion {
+    pub fn from_u32(value: u32) -> DecodeResult<Self> {
+        match value {
+            0x0001_0000 => Ok(Self::V100),
+            0x0001_0001 => Ok(Self::V101),
+            0x0002_0000 => Ok(Self::V200),
+            0x0003_0000 => Ok(Self::V300),
+            _ => Err(invalid_field_err!(
+                "protocolVersion",
+                "unknown RDPINPUT protocol version"
+            )),
+        }
+    }
+
+    pub fn as_u32(self) -> u32 {
+        self as u32
+    }
+
+    pub fn supports_pen(self) -> bool {
+        self >= Self::V200
+    }
+}
+
+bitflags! {
+    /// Optional features in SC_READY (V300).
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct ScReadyFeatures: u32 {
+        const MULTIPEN_INJECTION_SUPPORTED = 0x0000_0001;
+    }
+}
+
+bitflags! {
+    /// CS_READY flags ([MS-RDPEI] 2.2.3.2).
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct CsReadyFlags: u32 {
+        const SHOW_TOUCH_VISUALS = 0x0000_0001;
+        const DISABLE_TIMESTAMP_INJECTION = 0x0000_0002;
+        const ENABLE_MULTIPEN_INJECTION = 0x0000_0004;
+    }
+}
+
+bitflags! {
+    /// Touch contact flags ([MS-RDPEI] 2.2.3.3.1.1 `contactFlags`).
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct TouchContactFlags: u32 {
+        const DOWN = 0x0001;
+        const UPDATE = 0x0002;
+        const UP = 0x0004;
+        const INRANGE = 0x0008;
+        const INCONTACT = 0x0010;
+        const CANCELED = 0x0020;
+    }
+}
+
+impl TouchContactFlags {
+    /// Returns true when the flag combination is one of the eight legal sets from MS-RDPEI 2.2.3.3.1.1.
+    #[must_use]
+    pub fn is_legal(self) -> bool {
+        let legal = [
+            Self::UP.bits(),
+            (Self::UP | Self::CANCELED).bits(),
+            Self::UPDATE.bits(),
+            (Self::UPDATE | Self::CANCELED).bits(),
+            (Self::DOWN | Self::INRANGE | Self::INCONTACT).bits(),
+            (Self::UPDATE | Self::INRANGE | Self::INCONTACT).bits(),
+            (Self::UP | Self::INRANGE).bits(),
+            (Self::UPDATE | Self::INRANGE).bits(),
+        ];
+        legal.contains(&self.bits())
+    }
+}
+
+bitflags! {
+    /// Optional fields present in RDPINPUT_TOUCH_CONTACT ([MS-RDPEI] 2.2.3.3.1.1).
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct TouchContactDataFlags: u16 {
+        const CONTACTRECT_PRESENT = 0x0001;
+        const ORIENTATION_PRESENT = 0x0002;
+        const PRESSURE_PRESENT = 0x0004;
+    }
+}
+
+bitflags! {
+    /// Pen contact state flags ([MS-RDPEI] 2.2.3.7.1.1 `contactFlags`).
+    ///
+    /// Same legal combinations as [`TouchContactFlags`].
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct PenContactFlags: u32 {
+        const DOWN = 0x0001;
+        const UPDATE = 0x0002;
+        const UP = 0x0004;
+        const INRANGE = 0x0008;
+        const INCONTACT = 0x0010;
+        const CANCELED = 0x0020;
+    }
+}
+
+impl PenContactFlags {
+    /// Returns true when the flag combination is one of the eight legal sets from MS-RDPEI 2.2.3.7.1.1.
+    #[must_use]
+    pub fn is_legal(self) -> bool {
+        TouchContactFlags::from_bits_truncate(self.bits()).is_legal()
+    }
+}
+
+bitflags! {
+    /// Pen button / inversion flags ([MS-RDPEI] 2.2.3.7.1.1 `penFlags`).
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct PenFlags: u32 {
+        const BARREL_PRESSED = 0x0001;
+        const ERASER_PRESSED = 0x0002;
+        const INVERTED = 0x0004;
+    }
+}
+
+bitflags! {
+    /// Optional fields present in RDPINPUT_PEN_CONTACT ([MS-RDPEI] 2.2.3.7.1.1).
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct PenContactDataFlags: u16 {
+        const PENFLAGS_PRESENT = 0x0001;
+        const PRESSURE_PRESENT = 0x0002;
+        const ROTATION_PRESENT = 0x0004;
+        const TILTX_PRESENT = 0x0008;
+        const TILTY_PRESENT = 0x0010;
+    }
+}
+
+/// RDPINPUT_HEADER ([MS-RDPEI] 2.2.2.6).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RdpInputHeader {
+    pub event_id: RdpInputEventId,
+    /// Total PDU length in bytes, including this header.
+    pub pdu_length: u32,
+}
+
+impl RdpInputHeader {
+    const NAME: &'static str = "RDPINPUT_HEADER";
+    const FIXED_PART_SIZE: usize = RDP_INPUT_HEADER_SIZE;
+}
+
+impl Encode for RdpInputHeader {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_fixed_part_size!(in: dst);
+        dst.write_u16(self.event_id.as_u16());
+        dst.write_u32(self.pdu_length);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl<'de> Decode<'de> for RdpInputHeader {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+        let event_id = RdpInputEventId::from_u16(src.read_u16())?;
+        let pdu_length = src.read_u32();
+        if pdu_length < Self::FIXED_PART_SIZE as u32 {
+            return Err(invalid_field_err!("pduLength", "less than header size"));
+        }
+        Ok(Self { event_id, pdu_length })
+    }
+}
+
+/// RDPINPUT_SC_READY_PDU ([MS-RDPEI] 2.2.3.1).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScReadyPdu {
+    pub protocol_version: RdpInputProtocolVersion,
+    pub supported_features: Option<ScReadyFeatures>,
+}
+
+impl ScReadyPdu {
+    const NAME: &'static str = "RDPINPUT_SC_READY_PDU";
+
+    pub fn new(protocol_version: RdpInputProtocolVersion) -> Self {
+        Self {
+            protocol_version,
+            supported_features: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_features(mut self, features: ScReadyFeatures) -> Self {
+        self.supported_features = Some(features);
+        self
+    }
+
+    fn payload_size(&self) -> usize {
+        4 /* protocolVersion */ + if self.supported_features.is_some() { 4 } else { 0 }
+    }
+}
+
+impl Encode for ScReadyPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        let pdu_length = cast_int!("pduLength", RDP_INPUT_HEADER_SIZE + self.payload_size())?;
+        RdpInputHeader {
+            event_id: RdpInputEventId::ScReady,
+            pdu_length,
+        }
+        .encode(dst)?;
+        dst.write_u32(self.protocol_version.as_u32());
+        if let Some(features) = self.supported_features {
+            dst.write_u32(features.bits());
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        RDP_INPUT_HEADER_SIZE + self.payload_size()
+    }
+}
+
+impl<'de> Decode<'de> for ScReadyPdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        let header = RdpInputHeader::decode(src)?;
+        if header.event_id != RdpInputEventId::ScReady {
+            return Err(invalid_field_err!("eventId", "expected EVENTID_SC_READY"));
+        }
+        ensure_size!(in: src, size: 4);
+        let protocol_version = RdpInputProtocolVersion::from_u32(src.read_u32())?;
+        let remaining = header.pdu_length as usize - RDP_INPUT_HEADER_SIZE - 4;
+        let supported_features = if remaining >= 4 {
+            ensure_size!(in: src, size: 4);
+            Some(ScReadyFeatures::from_bits_truncate(src.read_u32()))
+        } else {
+            None
+        };
+        Ok(Self {
+            protocol_version,
+            supported_features,
+        })
+    }
+}
+
+/// RDPINPUT_CS_READY_PDU ([MS-RDPEI] 2.2.3.2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CsReadyPdu {
+    pub flags: CsReadyFlags,
+    pub protocol_version: RdpInputProtocolVersion,
+    pub max_touch_contacts: u16,
+}
+
+impl CsReadyPdu {
+    const NAME: &'static str = "RDPINPUT_CS_READY_PDU";
+    const PAYLOAD_SIZE: usize = 4 /* flags */ + 4 /* protocolVersion */ + 2 /* maxTouchContacts */;
+
+    pub fn new(flags: CsReadyFlags, protocol_version: RdpInputProtocolVersion, max_touch_contacts: u16) -> Self {
+        Self {
+            flags,
+            protocol_version,
+            max_touch_contacts,
+        }
+    }
+}
+
+impl Encode for CsReadyPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        let pdu_length = cast_int!("pduLength", RDP_INPUT_HEADER_SIZE + Self::PAYLOAD_SIZE)?;
+        RdpInputHeader {
+            event_id: RdpInputEventId::CsReady,
+            pdu_length,
+        }
+        .encode(dst)?;
+        dst.write_u32(self.flags.bits());
+        dst.write_u32(self.protocol_version.as_u32());
+        dst.write_u16(self.max_touch_contacts);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        RDP_INPUT_HEADER_SIZE + Self::PAYLOAD_SIZE
+    }
+}
+
+impl<'de> Decode<'de> for CsReadyPdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        let header = RdpInputHeader::decode(src)?;
+        if header.event_id != RdpInputEventId::CsReady {
+            return Err(invalid_field_err!("eventId", "expected EVENTID_CS_READY"));
+        }
+        ensure_size!(in: src, size: Self::PAYLOAD_SIZE);
+        let flags = CsReadyFlags::from_bits_truncate(src.read_u32());
+        let protocol_version = RdpInputProtocolVersion::from_u32(src.read_u32())?;
+        let max_touch_contacts = src.read_u16();
+        Ok(Self {
+            flags,
+            protocol_version,
+            max_touch_contacts,
+        })
+    }
+}
+
+/// Optional geometry/pressure fields for a touch contact.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct TouchContactFields {
+    pub contact_rect_left: Option<i16>,
+    pub contact_rect_top: Option<i16>,
+    pub contact_rect_right: Option<i16>,
+    pub contact_rect_bottom: Option<i16>,
+    pub orientation: Option<u32>,
+    pub pressure: Option<u32>,
+}
+
+/// RDPINPUT_CONTACT_DATA ([MS-RDPEI] 2.2.3.3.1.1).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TouchContact {
+    pub contact_id: u8,
+    pub fields_present: TouchContactDataFlags,
+    pub x: i32,
+    pub y: i32,
+    pub contact_flags: TouchContactFlags,
+    pub fields: TouchContactFields,
+}
+
+impl TouchContact {
+    const NAME: &'static str = "RDPINPUT_CONTACT_DATA";
+
+    #[must_use]
+    pub fn new(contact_id: u8, x: i32, y: i32, contact_flags: TouchContactFlags) -> Self {
+        Self {
+            contact_id,
+            fields_present: TouchContactDataFlags::empty(),
+            x,
+            y,
+            contact_flags,
+            fields: TouchContactFields::default(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_contact_rect(mut self, left: i16, top: i16, right: i16, bottom: i16) -> Self {
+        self.fields_present.insert(TouchContactDataFlags::CONTACTRECT_PRESENT);
+        self.fields.contact_rect_left = Some(left);
+        self.fields.contact_rect_top = Some(top);
+        self.fields.contact_rect_right = Some(right);
+        self.fields.contact_rect_bottom = Some(bottom);
+        self
+    }
+
+    #[must_use]
+    pub fn with_orientation(mut self, orientation: u32) -> Self {
+        self.fields_present.insert(TouchContactDataFlags::ORIENTATION_PRESENT);
+        self.fields.orientation = Some(orientation);
+        self
+    }
+
+    #[must_use]
+    pub fn with_pressure(mut self, pressure: u32) -> Self {
+        self.fields_present.insert(TouchContactDataFlags::PRESSURE_PRESENT);
+        self.fields.pressure = Some(pressure);
+        self
+    }
+
+    fn payload_size(&self) -> usize {
+        1 /* contactId */
+            + TwoByteUnsigned::encoded_size(self.fields_present.bits())
+            + FourByteSigned::encoded_size(self.x)
+            + FourByteSigned::encoded_size(self.y)
+            + FourByteUnsigned::encoded_size(self.contact_flags.bits())
+            + if self.fields_present.contains(TouchContactDataFlags::CONTACTRECT_PRESENT) {
+                TwoByteSigned::encoded_size(self.fields.contact_rect_left.unwrap_or(0))
+                    + TwoByteSigned::encoded_size(self.fields.contact_rect_top.unwrap_or(0))
+                    + TwoByteSigned::encoded_size(self.fields.contact_rect_right.unwrap_or(0))
+                    + TwoByteSigned::encoded_size(self.fields.contact_rect_bottom.unwrap_or(0))
+            } else {
+                0
+            }
+            + if self.fields_present.contains(TouchContactDataFlags::ORIENTATION_PRESENT) {
+                FourByteUnsigned::encoded_size(self.fields.orientation.unwrap_or(0))
+            } else {
+                0
+            }
+            + if self.fields_present.contains(TouchContactDataFlags::PRESSURE_PRESENT) {
+                FourByteUnsigned::encoded_size(self.fields.pressure.unwrap_or(0))
+            } else {
+                0
+            }
+    }
+}
+
+impl Encode for TouchContact {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u8(self.contact_id);
+        TwoByteUnsigned::new(self.fields_present.bits())
+            .map_err(|e| ironrdp_core::other_err!("fieldsPresent", source: e))?
+            .encode(dst)?;
+        FourByteSigned::new(self.x)
+            .map_err(|e| ironrdp_core::other_err!("x", source: e))?
+            .encode(dst)?;
+        FourByteSigned::new(self.y)
+            .map_err(|e| ironrdp_core::other_err!("y", source: e))?
+            .encode(dst)?;
+        FourByteUnsigned::new(self.contact_flags.bits())
+            .map_err(|e| ironrdp_core::other_err!("contactFlags", source: e))?
+            .encode(dst)?;
+
+        if self.fields_present.contains(TouchContactDataFlags::CONTACTRECT_PRESENT) {
+            let left = self
+                .fields
+                .contact_rect_left
+                .ok_or_else(|| invalid_field_err!("contactRectLeft", "missing"))?;
+            let top = self
+                .fields
+                .contact_rect_top
+                .ok_or_else(|| invalid_field_err!("contactRectTop", "missing"))?;
+            let right = self
+                .fields
+                .contact_rect_right
+                .ok_or_else(|| invalid_field_err!("contactRectRight", "missing"))?;
+            let bottom = self
+                .fields
+                .contact_rect_bottom
+                .ok_or_else(|| invalid_field_err!("contactRectBottom", "missing"))?;
+            TwoByteSigned::new(left)
+                .map_err(|e| ironrdp_core::other_err!("contactRectLeft", source: e))?
+                .encode(dst)?;
+            TwoByteSigned::new(top)
+                .map_err(|e| ironrdp_core::other_err!("contactRectTop", source: e))?
+                .encode(dst)?;
+            TwoByteSigned::new(right)
+                .map_err(|e| ironrdp_core::other_err!("contactRectRight", source: e))?
+                .encode(dst)?;
+            TwoByteSigned::new(bottom)
+                .map_err(|e| ironrdp_core::other_err!("contactRectBottom", source: e))?
+                .encode(dst)?;
+        }
+        if self.fields_present.contains(TouchContactDataFlags::ORIENTATION_PRESENT) {
+            let orientation = self
+                .fields
+                .orientation
+                .ok_or_else(|| invalid_field_err!("orientation", "missing"))?;
+            FourByteUnsigned::new(orientation)
+                .map_err(|e| ironrdp_core::other_err!("orientation", source: e))?
+                .encode(dst)?;
+        }
+        if self.fields_present.contains(TouchContactDataFlags::PRESSURE_PRESENT) {
+            let pressure = self
+                .fields
+                .pressure
+                .ok_or_else(|| invalid_field_err!("pressure", "missing"))?;
+            FourByteUnsigned::new(pressure)
+                .map_err(|e| ironrdp_core::other_err!("pressure", source: e))?
+                .encode(dst)?;
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        self.payload_size()
+    }
+}
+
+impl<'de> Decode<'de> for TouchContact {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 1);
+        let contact_id = src.read_u8();
+        let fields_present = TouchContactDataFlags::from_bits_truncate(TwoByteUnsigned::decode(src)?.get());
+        let x = FourByteSigned::decode(src)?.get();
+        let y = FourByteSigned::decode(src)?.get();
+        let contact_flags = TouchContactFlags::from_bits_truncate(FourByteUnsigned::decode(src)?.get());
+
+        let mut fields = TouchContactFields::default();
+        if fields_present.contains(TouchContactDataFlags::CONTACTRECT_PRESENT) {
+            fields.contact_rect_left = Some(TwoByteSigned::decode(src)?.get());
+            fields.contact_rect_top = Some(TwoByteSigned::decode(src)?.get());
+            fields.contact_rect_right = Some(TwoByteSigned::decode(src)?.get());
+            fields.contact_rect_bottom = Some(TwoByteSigned::decode(src)?.get());
+        }
+        if fields_present.contains(TouchContactDataFlags::ORIENTATION_PRESENT) {
+            fields.orientation = Some(FourByteUnsigned::decode(src)?.get());
+        }
+        if fields_present.contains(TouchContactDataFlags::PRESSURE_PRESENT) {
+            fields.pressure = Some(FourByteUnsigned::decode(src)?.get());
+        }
+
+        Ok(Self {
+            contact_id,
+            fields_present,
+            x,
+            y,
+            contact_flags,
+            fields,
+        })
+    }
+}
+
+/// RDPINPUT_TOUCH_FRAME ([MS-RDPEI] 2.2.3.3.1).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TouchFrame {
+    /// Microseconds since the previous frame (0 for the first frame of a transaction).
+    pub frame_offset: u64,
+    pub contacts: Vec<TouchContact>,
+}
+
+impl TouchFrame {
+    const NAME: &'static str = "RDPINPUT_TOUCH_FRAME";
+
+    pub fn new(frame_offset: u64, contacts: Vec<TouchContact>) -> Self {
+        Self { frame_offset, contacts }
+    }
+
+    fn payload_size(&self) -> usize {
+        let contact_count = self.contacts.len() as u16;
+        TwoByteUnsigned::encoded_size(contact_count)
+            + EightByteUnsigned::encoded_size(self.frame_offset)
+            + self.contacts.iter().map(Encode::size).sum::<usize>()
+    }
+}
+
+impl Encode for TouchFrame {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        let contact_count: u16 = cast_length!("contactCount", self.contacts.len())?;
+        TwoByteUnsigned::new(contact_count)
+            .map_err(|e| ironrdp_core::other_err!("contactCount", source: e))?
+            .encode(dst)?;
+        EightByteUnsigned::new(self.frame_offset)
+            .map_err(|e| ironrdp_core::other_err!("frameOffset", source: e))?
+            .encode(dst)?;
+        for contact in &self.contacts {
+            contact.encode(dst)?;
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        self.payload_size()
+    }
+}
+
+impl<'de> Decode<'de> for TouchFrame {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        let contact_count = TwoByteUnsigned::decode(src)?.get();
+        let frame_offset = EightByteUnsigned::decode(src)?.get();
+        let mut contacts = Vec::with_capacity(contact_count as usize);
+        for _ in 0..contact_count {
+            contacts.push(TouchContact::decode(src)?);
+        }
+        Ok(Self { frame_offset, contacts })
+    }
+}
+
+/// RDPINPUT_TOUCH_EVENT_PDU ([MS-RDPEI] 2.2.3.3).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TouchEventPdu {
+    /// Milliseconds elapsed for the oldest frame in this PDU.
+    pub encode_time: u32,
+    pub frames: Vec<TouchFrame>,
+}
+
+impl TouchEventPdu {
+    const NAME: &'static str = "RDPINPUT_TOUCH_EVENT_PDU";
+
+    pub fn new(encode_time: u32, frames: Vec<TouchFrame>) -> Self {
+        Self { encode_time, frames }
+    }
+
+    fn payload_size(&self) -> usize {
+        let frame_count = self.frames.len() as u16;
+        FourByteUnsigned::encoded_size(self.encode_time)
+            + TwoByteUnsigned::encoded_size(frame_count)
+            + self.frames.iter().map(Encode::size).sum::<usize>()
+    }
+}
+
+impl Encode for TouchEventPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        let pdu_length = cast_int!("pduLength", RDP_INPUT_HEADER_SIZE + self.payload_size())?;
+        RdpInputHeader {
+            event_id: RdpInputEventId::Touch,
+            pdu_length,
+        }
+        .encode(dst)?;
+        FourByteUnsigned::new(self.encode_time)
+            .map_err(|e| ironrdp_core::other_err!("encodeTime", source: e))?
+            .encode(dst)?;
+        let frame_count: u16 = cast_length!("frameCount", self.frames.len())?;
+        TwoByteUnsigned::new(frame_count)
+            .map_err(|e| ironrdp_core::other_err!("frameCount", source: e))?
+            .encode(dst)?;
+        for frame in &self.frames {
+            frame.encode(dst)?;
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        RDP_INPUT_HEADER_SIZE + self.payload_size()
+    }
+}
+
+impl<'de> Decode<'de> for TouchEventPdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        let header = RdpInputHeader::decode(src)?;
+        if header.event_id != RdpInputEventId::Touch {
+            return Err(invalid_field_err!("eventId", "expected EVENTID_TOUCH"));
+        }
+        let encode_time = FourByteUnsigned::decode(src)?.get();
+        let frame_count = TwoByteUnsigned::decode(src)?.get();
+        let mut frames = Vec::with_capacity(frame_count as usize);
+        for _ in 0..frame_count {
+            frames.push(TouchFrame::decode(src)?);
+        }
+        Ok(Self { encode_time, frames })
+    }
+}
+
+/// Header-only PDUs (SUSPEND / RESUME).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HeaderOnlyPdu {
+    pub event_id: RdpInputEventId,
+}
+
+impl HeaderOnlyPdu {
+    const NAME: &'static str = "RDPINPUT_HEADER_ONLY_PDU";
+
+    pub fn suspend() -> Self {
+        Self {
+            event_id: RdpInputEventId::SuspendInput,
+        }
+    }
+
+    pub fn resume() -> Self {
+        Self {
+            event_id: RdpInputEventId::ResumeInput,
+        }
+    }
+}
+
+impl Encode for HeaderOnlyPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        RdpInputHeader {
+            event_id: self.event_id,
+            pdu_length: RDP_INPUT_HEADER_SIZE as u32,
+        }
+        .encode(dst)
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        RDP_INPUT_HEADER_SIZE
+    }
+}
+
+impl<'de> Decode<'de> for HeaderOnlyPdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        let header = RdpInputHeader::decode(src)?;
+        match header.event_id {
+            RdpInputEventId::SuspendInput | RdpInputEventId::ResumeInput => Ok(Self {
+                event_id: header.event_id,
+            }),
+            _ => Err(invalid_field_err!(
+                "eventId",
+                "expected EVENTID_SUSPEND_INPUT or EVENTID_RESUME_INPUT"
+            )),
+        }
+    }
+}
+
+/// RDPINPUT_DISMISS_HOVERING_TOUCH_CONTACT_PDU ([MS-RDPEI] 2.2.3.6).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DismissHoveringTouchContactPdu {
+    pub contact_id: u8,
+}
+
+impl DismissHoveringTouchContactPdu {
+    const NAME: &'static str = "RDPINPUT_DISMISS_HOVERING_TOUCH_CONTACT_PDU";
+    const PAYLOAD_SIZE: usize = 1;
+
+    pub fn new(contact_id: u8) -> Self {
+        Self { contact_id }
+    }
+}
+
+impl Encode for DismissHoveringTouchContactPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        let pdu_length = cast_int!("pduLength", RDP_INPUT_HEADER_SIZE + Self::PAYLOAD_SIZE)?;
+        RdpInputHeader {
+            event_id: RdpInputEventId::DismissHoveringTouchContact,
+            pdu_length,
+        }
+        .encode(dst)?;
+        dst.write_u8(self.contact_id);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        RDP_INPUT_HEADER_SIZE + Self::PAYLOAD_SIZE
+    }
+}
+
+impl<'de> Decode<'de> for DismissHoveringTouchContactPdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        let header = RdpInputHeader::decode(src)?;
+        if header.event_id != RdpInputEventId::DismissHoveringTouchContact {
+            return Err(invalid_field_err!(
+                "eventId",
+                "expected EVENTID_DISMISS_HOVERING_TOUCH_CONTACT"
+            ));
+        }
+        ensure_size!(in: src, size: Self::PAYLOAD_SIZE);
+        Ok(Self {
+            contact_id: src.read_u8(),
+        })
+    }
+}
+
+/// Optional fields for a pen contact ([MS-RDPEI] 2.2.3.7.1.1).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PenContactFields {
+    pub pen_flags: Option<PenFlags>,
+    pub pressure: Option<u32>,
+    pub rotation: Option<u16>,
+    pub tilt_x: Option<i16>,
+    pub tilt_y: Option<i16>,
+}
+
+/// RDPINPUT_PEN_CONTACT ([MS-RDPEI] 2.2.3.7.1.1).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PenContact {
+    pub device_id: u8,
+    pub fields_present: PenContactDataFlags,
+    pub x: i32,
+    pub y: i32,
+    pub contact_flags: PenContactFlags,
+    pub fields: PenContactFields,
+}
+
+impl PenContact {
+    const NAME: &'static str = "RDPINPUT_PEN_CONTACT";
+
+    #[must_use]
+    pub fn new(device_id: u8, x: i32, y: i32, contact_flags: PenContactFlags) -> Self {
+        Self {
+            device_id,
+            fields_present: PenContactDataFlags::empty(),
+            x,
+            y,
+            contact_flags,
+            fields: PenContactFields::default(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_pen_flags(mut self, pen_flags: PenFlags) -> Self {
+        self.fields_present.insert(PenContactDataFlags::PENFLAGS_PRESENT);
+        self.fields.pen_flags = Some(pen_flags);
+        self
+    }
+
+    #[must_use]
+    pub fn with_pressure(mut self, pressure: u32) -> Self {
+        self.fields_present.insert(PenContactDataFlags::PRESSURE_PRESENT);
+        self.fields.pressure = Some(pressure);
+        self
+    }
+
+    #[must_use]
+    pub fn with_rotation(mut self, rotation: u16) -> Self {
+        self.fields_present.insert(PenContactDataFlags::ROTATION_PRESENT);
+        self.fields.rotation = Some(rotation);
+        self
+    }
+
+    #[must_use]
+    pub fn with_tilt(mut self, tilt_x: i16, tilt_y: i16) -> Self {
+        self.fields_present
+            .insert(PenContactDataFlags::TILTX_PRESENT | PenContactDataFlags::TILTY_PRESENT);
+        self.fields.tilt_x = Some(tilt_x);
+        self.fields.tilt_y = Some(tilt_y);
+        self
+    }
+
+    fn payload_size(&self) -> usize {
+        1 /* deviceId */
+            + TwoByteUnsigned::encoded_size(self.fields_present.bits())
+            + FourByteSigned::encoded_size(self.x)
+            + FourByteSigned::encoded_size(self.y)
+            + FourByteUnsigned::encoded_size(self.contact_flags.bits())
+            + if self.fields_present.contains(PenContactDataFlags::PENFLAGS_PRESENT) {
+                FourByteUnsigned::encoded_size(self.fields.pen_flags.unwrap_or(PenFlags::empty()).bits())
+            } else {
+                0
+            }
+            + if self.fields_present.contains(PenContactDataFlags::PRESSURE_PRESENT) {
+                FourByteUnsigned::encoded_size(self.fields.pressure.unwrap_or(0))
+            } else {
+                0
+            }
+            + if self.fields_present.contains(PenContactDataFlags::ROTATION_PRESENT) {
+                TwoByteUnsigned::encoded_size(self.fields.rotation.unwrap_or(0))
+            } else {
+                0
+            }
+            + if self.fields_present.contains(PenContactDataFlags::TILTX_PRESENT) {
+                TwoByteSigned::encoded_size(self.fields.tilt_x.unwrap_or(0))
+            } else {
+                0
+            }
+            + if self.fields_present.contains(PenContactDataFlags::TILTY_PRESENT) {
+                TwoByteSigned::encoded_size(self.fields.tilt_y.unwrap_or(0))
+            } else {
+                0
+            }
+    }
+}
+
+impl Encode for PenContact {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u8(self.device_id);
+        TwoByteUnsigned::new(self.fields_present.bits())
+            .map_err(|e| ironrdp_core::other_err!("fieldsPresent", source: e))?
+            .encode(dst)?;
+        FourByteSigned::new(self.x)
+            .map_err(|e| ironrdp_core::other_err!("x", source: e))?
+            .encode(dst)?;
+        FourByteSigned::new(self.y)
+            .map_err(|e| ironrdp_core::other_err!("y", source: e))?
+            .encode(dst)?;
+        FourByteUnsigned::new(self.contact_flags.bits())
+            .map_err(|e| ironrdp_core::other_err!("contactFlags", source: e))?
+            .encode(dst)?;
+
+        if self.fields_present.contains(PenContactDataFlags::PENFLAGS_PRESENT) {
+            let pen_flags = self
+                .fields
+                .pen_flags
+                .ok_or_else(|| invalid_field_err!("penFlags", "missing"))?;
+            FourByteUnsigned::new(pen_flags.bits())
+                .map_err(|e| ironrdp_core::other_err!("penFlags", source: e))?
+                .encode(dst)?;
+        }
+        if self.fields_present.contains(PenContactDataFlags::PRESSURE_PRESENT) {
+            let pressure = self
+                .fields
+                .pressure
+                .ok_or_else(|| invalid_field_err!("pressure", "missing"))?;
+            FourByteUnsigned::new(pressure)
+                .map_err(|e| ironrdp_core::other_err!("pressure", source: e))?
+                .encode(dst)?;
+        }
+        if self.fields_present.contains(PenContactDataFlags::ROTATION_PRESENT) {
+            let rotation = self
+                .fields
+                .rotation
+                .ok_or_else(|| invalid_field_err!("rotation", "missing"))?;
+            TwoByteUnsigned::new(rotation)
+                .map_err(|e| ironrdp_core::other_err!("rotation", source: e))?
+                .encode(dst)?;
+        }
+        if self.fields_present.contains(PenContactDataFlags::TILTX_PRESENT) {
+            let tilt_x = self
+                .fields
+                .tilt_x
+                .ok_or_else(|| invalid_field_err!("tiltX", "missing"))?;
+            TwoByteSigned::new(tilt_x)
+                .map_err(|e| ironrdp_core::other_err!("tiltX", source: e))?
+                .encode(dst)?;
+        }
+        if self.fields_present.contains(PenContactDataFlags::TILTY_PRESENT) {
+            let tilt_y = self
+                .fields
+                .tilt_y
+                .ok_or_else(|| invalid_field_err!("tiltY", "missing"))?;
+            TwoByteSigned::new(tilt_y)
+                .map_err(|e| ironrdp_core::other_err!("tiltY", source: e))?
+                .encode(dst)?;
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        self.payload_size()
+    }
+}
+
+impl<'de> Decode<'de> for PenContact {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 1);
+        let device_id = src.read_u8();
+        let fields_present = PenContactDataFlags::from_bits_truncate(TwoByteUnsigned::decode(src)?.get());
+        let x = FourByteSigned::decode(src)?.get();
+        let y = FourByteSigned::decode(src)?.get();
+        let contact_flags = PenContactFlags::from_bits_truncate(FourByteUnsigned::decode(src)?.get());
+
+        let mut fields = PenContactFields::default();
+        if fields_present.contains(PenContactDataFlags::PENFLAGS_PRESENT) {
+            fields.pen_flags = Some(PenFlags::from_bits_truncate(FourByteUnsigned::decode(src)?.get()));
+        }
+        if fields_present.contains(PenContactDataFlags::PRESSURE_PRESENT) {
+            fields.pressure = Some(FourByteUnsigned::decode(src)?.get());
+        }
+        if fields_present.contains(PenContactDataFlags::ROTATION_PRESENT) {
+            fields.rotation = Some(TwoByteUnsigned::decode(src)?.get());
+        }
+        if fields_present.contains(PenContactDataFlags::TILTX_PRESENT) {
+            fields.tilt_x = Some(TwoByteSigned::decode(src)?.get());
+        }
+        if fields_present.contains(PenContactDataFlags::TILTY_PRESENT) {
+            fields.tilt_y = Some(TwoByteSigned::decode(src)?.get());
+        }
+
+        Ok(Self {
+            device_id,
+            fields_present,
+            x,
+            y,
+            contact_flags,
+            fields,
+        })
+    }
+}
+
+/// RDPINPUT_PEN_FRAME ([MS-RDPEI] 2.2.3.7.1).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PenFrame {
+    pub frame_offset: u64,
+    pub contacts: Vec<PenContact>,
+}
+
+impl PenFrame {
+    const NAME: &'static str = "RDPINPUT_PEN_FRAME";
+
+    pub fn new(frame_offset: u64, contacts: Vec<PenContact>) -> Self {
+        Self { frame_offset, contacts }
+    }
+
+    fn payload_size(&self) -> usize {
+        let contact_count = self.contacts.len() as u16;
+        TwoByteUnsigned::encoded_size(contact_count)
+            + EightByteUnsigned::encoded_size(self.frame_offset)
+            + self.contacts.iter().map(Encode::size).sum::<usize>()
+    }
+}
+
+impl Encode for PenFrame {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        let contact_count: u16 = cast_length!("contactCount", self.contacts.len())?;
+        TwoByteUnsigned::new(contact_count)
+            .map_err(|e| ironrdp_core::other_err!("contactCount", source: e))?
+            .encode(dst)?;
+        EightByteUnsigned::new(self.frame_offset)
+            .map_err(|e| ironrdp_core::other_err!("frameOffset", source: e))?
+            .encode(dst)?;
+        for contact in &self.contacts {
+            contact.encode(dst)?;
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        self.payload_size()
+    }
+}
+
+impl<'de> Decode<'de> for PenFrame {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        let contact_count = TwoByteUnsigned::decode(src)?.get();
+        let frame_offset = EightByteUnsigned::decode(src)?.get();
+        let mut contacts = Vec::with_capacity(contact_count as usize);
+        for _ in 0..contact_count {
+            contacts.push(PenContact::decode(src)?);
+        }
+        Ok(Self { frame_offset, contacts })
+    }
+}
+
+/// RDPINPUT_PEN_EVENT_PDU ([MS-RDPEI] 2.2.3.7).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PenEventPdu {
+    pub encode_time: u32,
+    pub frames: Vec<PenFrame>,
+}
+
+impl PenEventPdu {
+    const NAME: &'static str = "RDPINPUT_PEN_EVENT_PDU";
+
+    pub fn new(encode_time: u32, frames: Vec<PenFrame>) -> Self {
+        Self { encode_time, frames }
+    }
+
+    fn payload_size(&self) -> usize {
+        let frame_count = self.frames.len() as u16;
+        FourByteUnsigned::encoded_size(self.encode_time)
+            + TwoByteUnsigned::encoded_size(frame_count)
+            + self.frames.iter().map(Encode::size).sum::<usize>()
+    }
+}
+
+impl Encode for PenEventPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        let pdu_length = cast_int!("pduLength", RDP_INPUT_HEADER_SIZE + self.payload_size())?;
+        RdpInputHeader {
+            event_id: RdpInputEventId::Pen,
+            pdu_length,
+        }
+        .encode(dst)?;
+        FourByteUnsigned::new(self.encode_time)
+            .map_err(|e| ironrdp_core::other_err!("encodeTime", source: e))?
+            .encode(dst)?;
+        let frame_count: u16 = cast_length!("frameCount", self.frames.len())?;
+        TwoByteUnsigned::new(frame_count)
+            .map_err(|e| ironrdp_core::other_err!("frameCount", source: e))?
+            .encode(dst)?;
+        for frame in &self.frames {
+            frame.encode(dst)?;
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        RDP_INPUT_HEADER_SIZE + self.payload_size()
+    }
+}
+
+impl<'de> Decode<'de> for PenEventPdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        let header = RdpInputHeader::decode(src)?;
+        if header.event_id != RdpInputEventId::Pen {
+            return Err(invalid_field_err!("eventId", "expected EVENTID_PEN"));
+        }
+        let encode_time = FourByteUnsigned::decode(src)?.get();
+        let frame_count = TwoByteUnsigned::decode(src)?.get();
+        let mut frames = Vec::with_capacity(frame_count as usize);
+        for _ in 0..frame_count {
+            frames.push(PenFrame::decode(src)?);
+        }
+        Ok(Self { encode_time, frames })
+    }
+}
+
+/// Top-level RDPEI PDU enum for channel process/encode.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RdpeiPdu {
+    ScReady(ScReadyPdu),
+    CsReady(CsReadyPdu),
+    Touch(TouchEventPdu),
+    SuspendInput,
+    ResumeInput,
+    DismissHoveringTouchContact(DismissHoveringTouchContactPdu),
+    Pen(PenEventPdu),
+}
+
+impl RdpeiPdu {
+    const NAME: &'static str = "RdpeiPdu";
+}
+
+impl Encode for RdpeiPdu {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        match self {
+            Self::ScReady(pdu) => pdu.encode(dst),
+            Self::CsReady(pdu) => pdu.encode(dst),
+            Self::Touch(pdu) => pdu.encode(dst),
+            Self::SuspendInput => HeaderOnlyPdu::suspend().encode(dst),
+            Self::ResumeInput => HeaderOnlyPdu::resume().encode(dst),
+            Self::DismissHoveringTouchContact(pdu) => pdu.encode(dst),
+            Self::Pen(pdu) => pdu.encode(dst),
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        match self {
+            Self::ScReady(pdu) => pdu.size(),
+            Self::CsReady(pdu) => pdu.size(),
+            Self::Touch(pdu) => pdu.size(),
+            Self::SuspendInput | Self::ResumeInput => RDP_INPUT_HEADER_SIZE,
+            Self::DismissHoveringTouchContact(pdu) => pdu.size(),
+            Self::Pen(pdu) => pdu.size(),
+        }
+    }
+}
+
+impl<'de> Decode<'de> for RdpeiPdu {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: RDP_INPUT_HEADER_SIZE);
+        let bytes = src.remaining();
+        let header_preview = {
+            let mut tmp = ReadCursor::new(bytes);
+            RdpInputHeader::decode(&mut tmp)?
+        };
+        let pdu_len: usize = cast_length!("pduLength", header_preview.pdu_length)?;
+        ensure_size!(in: src, size: pdu_len);
+        let pdu_bytes = src.read_slice(pdu_len);
+        let mut pdu_src = ReadCursor::new(pdu_bytes);
+
+        match header_preview.event_id {
+            RdpInputEventId::ScReady => Ok(Self::ScReady(ScReadyPdu::decode(&mut pdu_src)?)),
+            RdpInputEventId::CsReady => Ok(Self::CsReady(CsReadyPdu::decode(&mut pdu_src)?)),
+            RdpInputEventId::Touch => Ok(Self::Touch(TouchEventPdu::decode(&mut pdu_src)?)),
+            RdpInputEventId::SuspendInput => {
+                HeaderOnlyPdu::decode(&mut pdu_src)?;
+                Ok(Self::SuspendInput)
+            }
+            RdpInputEventId::ResumeInput => {
+                HeaderOnlyPdu::decode(&mut pdu_src)?;
+                Ok(Self::ResumeInput)
+            }
+            RdpInputEventId::DismissHoveringTouchContact => Ok(Self::DismissHoveringTouchContact(
+                DismissHoveringTouchContactPdu::decode(&mut pdu_src)?,
+            )),
+            RdpInputEventId::Pen => Ok(Self::Pen(PenEventPdu::decode(&mut pdu_src)?)),
+        }
+    }
+}
+
+impl DvcEncode for RdpeiPdu {}
+
+#[cfg(test)]
+mod tests {
+    use ironrdp_core::{decode, encode_vec};
+
+    use super::*;
+
+    #[test]
+    fn sc_ready_round_trip() {
+        let pdu = ScReadyPdu::new(RdpInputProtocolVersion::V200);
+        let encoded = encode_vec(&pdu).unwrap();
+        assert_eq!(decode::<ScReadyPdu>(&encoded).unwrap(), pdu);
+        assert_eq!(decode::<RdpeiPdu>(&encoded).unwrap(), RdpeiPdu::ScReady(pdu));
+    }
+
+    #[test]
+    fn cs_ready_round_trip() {
+        let pdu = CsReadyPdu::new(CsReadyFlags::SHOW_TOUCH_VISUALS, RdpInputProtocolVersion::V200, 10);
+        let encoded = encode_vec(&pdu).unwrap();
+        assert_eq!(decode::<CsReadyPdu>(&encoded).unwrap(), pdu);
+    }
+
+    #[test]
+    fn touch_event_round_trip() {
+        let contact = TouchContact::new(
+            1,
+            100,
+            200,
+            TouchContactFlags::DOWN | TouchContactFlags::INRANGE | TouchContactFlags::INCONTACT,
+        )
+        .with_pressure(512);
+        let frame = TouchFrame::new(0, vec![contact]);
+        let pdu = TouchEventPdu::new(16, vec![frame]);
+        let encoded = encode_vec(&pdu).unwrap();
+        assert_eq!(decode::<TouchEventPdu>(&encoded).unwrap(), pdu);
+        assert_eq!(decode::<RdpeiPdu>(&encoded).unwrap(), RdpeiPdu::Touch(pdu));
+    }
+
+    #[test]
+    fn pen_event_round_trip() {
+        let contact = PenContact::new(
+            0,
+            50,
+            -20,
+            PenContactFlags::UPDATE | PenContactFlags::INRANGE | PenContactFlags::INCONTACT,
+        )
+        .with_pressure(1024)
+        .with_tilt(10, -5);
+        let frame = PenFrame::new(1000, vec![contact]);
+        let pdu = PenEventPdu::new(32, vec![frame]);
+        let encoded = encode_vec(&pdu).unwrap();
+        assert_eq!(decode::<PenEventPdu>(&encoded).unwrap(), pdu);
+    }
+
+    #[test]
+    fn suspend_resume_dismiss_round_trip() {
+        let suspend = encode_vec(&HeaderOnlyPdu::suspend()).unwrap();
+        assert_eq!(decode::<RdpeiPdu>(&suspend).unwrap(), RdpeiPdu::SuspendInput);
+
+        let resume = encode_vec(&HeaderOnlyPdu::resume()).unwrap();
+        assert_eq!(decode::<RdpeiPdu>(&resume).unwrap(), RdpeiPdu::ResumeInput);
+
+        let dismiss = DismissHoveringTouchContactPdu::new(3);
+        let encoded = encode_vec(&dismiss).unwrap();
+        assert_eq!(
+            decode::<RdpeiPdu>(&encoded).unwrap(),
+            RdpeiPdu::DismissHoveringTouchContact(dismiss)
+        );
+    }
+}

--- a/crates/ironrdp-rdpei/src/pdu/varint.rs
+++ b/crates/ironrdp-rdpei/src/pdu/varint.rs
@@ -1,0 +1,523 @@
+//! Variable-length integer encodings from [MS-RDPEI] 2.2.2.
+//!
+//! [MS-RDPEI]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpei/1aab43bf-cab8-4f0a-9eb3-b83b8365e237
+
+// Varint packing is defined in terms of byte splits after explicit range checks.
+#![allow(clippy::as_conversions)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+
+use ironrdp_core::{
+    Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor, ensure_size, invalid_field_err,
+};
+
+const TWO_BYTE_UNSIGNED_MAX: u16 = 0x7FFF;
+const TWO_BYTE_SIGNED_MAX: i16 = 0x3FFF;
+const FOUR_BYTE_UNSIGNED_MAX: u32 = 0x3FFF_FFFF;
+const FOUR_BYTE_SIGNED_MAX: i32 = 0x1FFF_FFFF;
+const EIGHT_BYTE_UNSIGNED_MAX: u64 = 0x1FFF_FFFF_FFFF_FFFF;
+
+/// TWO_BYTE_UNSIGNED_INTEGER — range `0x0000`..=`0x7FFF`.
+///
+/// [2.2.2.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpei/c8d5dc69-e4d4-4d72-a1be-d3a062a3a7d0
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TwoByteUnsigned(u16);
+
+impl TwoByteUnsigned {
+    pub const MAX: u16 = TWO_BYTE_UNSIGNED_MAX;
+
+    pub fn new(value: u16) -> DecodeResult<Self> {
+        if value > Self::MAX {
+            return Err(invalid_field_err!("TWO_BYTE_UNSIGNED_INTEGER", "value out of range"));
+        }
+        Ok(Self(value))
+    }
+
+    pub fn get(self) -> u16 {
+        self.0
+    }
+
+    pub fn encoded_size(value: u16) -> usize {
+        if value <= 0x7F { 1 } else { 2 }
+    }
+}
+
+impl Encode for TwoByteUnsigned {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        let size = Self::encoded_size(self.0);
+        ensure_size!(in: dst, size: size);
+        if size == 1 {
+            dst.write_u8(self.0 as u8);
+        } else {
+            let val1 = ((self.0 >> 8) & 0x7F) as u8;
+            let val2 = (self.0 & 0xFF) as u8;
+            dst.write_u8(0x80 | val1);
+            dst.write_u8(val2);
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "TWO_BYTE_UNSIGNED_INTEGER"
+    }
+
+    fn size(&self) -> usize {
+        Self::encoded_size(self.0)
+    }
+}
+
+impl<'de> Decode<'de> for TwoByteUnsigned {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 1);
+        let first = src.read_u8();
+        if first & 0x80 == 0 {
+            Ok(Self(u16::from(first)))
+        } else {
+            ensure_size!(in: src, size: 1);
+            let second = src.read_u8();
+            let value = (u16::from(first & 0x7F) << 8) | u16::from(second);
+            Ok(Self(value))
+        }
+    }
+}
+
+/// TWO_BYTE_SIGNED_INTEGER — range `-0x3FFF`..=`0x3FFF`.
+///
+/// [2.2.2.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpei/1aab43bf-344a-467a-b9d4-dfe196b46c9d
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TwoByteSigned(i16);
+
+impl TwoByteSigned {
+    pub const MAX: i16 = TWO_BYTE_SIGNED_MAX;
+    pub const MIN: i16 = -TWO_BYTE_SIGNED_MAX;
+
+    pub fn new(value: i16) -> DecodeResult<Self> {
+        if !(-Self::MAX..=Self::MAX).contains(&value) {
+            return Err(invalid_field_err!("TWO_BYTE_SIGNED_INTEGER", "value out of range"));
+        }
+        Ok(Self(value))
+    }
+
+    pub fn get(self) -> i16 {
+        self.0
+    }
+
+    pub fn encoded_size(value: i16) -> usize {
+        let magnitude = value.unsigned_abs();
+        if magnitude <= 0x3F { 1 } else { 2 }
+    }
+}
+
+impl Encode for TwoByteSigned {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        let size = Self::encoded_size(self.0);
+        ensure_size!(in: dst, size: size);
+        let negative = self.0 < 0;
+        let magnitude = self.0.unsigned_abs();
+        if size == 1 {
+            let mut first = (magnitude & 0x3F) as u8;
+            if negative {
+                first |= 0x40;
+            }
+            dst.write_u8(first);
+        } else {
+            let mut first = 0x80 | (((magnitude >> 8) & 0x3F) as u8);
+            if negative {
+                first |= 0x40;
+            }
+            dst.write_u8(first);
+            dst.write_u8((magnitude & 0xFF) as u8);
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "TWO_BYTE_SIGNED_INTEGER"
+    }
+
+    fn size(&self) -> usize {
+        Self::encoded_size(self.0)
+    }
+}
+
+impl<'de> Decode<'de> for TwoByteSigned {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 1);
+        let first = src.read_u8();
+        let negative = first & 0x40 != 0;
+        let two_bytes = first & 0x80 != 0;
+        let magnitude = if two_bytes {
+            ensure_size!(in: src, size: 1);
+            let second = src.read_u8();
+            (u16::from(first & 0x3F) << 8) | u16::from(second)
+        } else {
+            u16::from(first & 0x3F)
+        };
+        if magnitude > TWO_BYTE_SIGNED_MAX as u16 {
+            return Err(invalid_field_err!("TWO_BYTE_SIGNED_INTEGER", "value out of range"));
+        }
+        let value = if negative {
+            -(magnitude as i16)
+        } else {
+            magnitude as i16
+        };
+        Ok(Self(value))
+    }
+}
+
+/// FOUR_BYTE_UNSIGNED_INTEGER — range `0x00000000`..=`0x3FFFFFFF`.
+///
+/// [2.2.2.3]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpei/c8d5dc69-e4d4-4d72-a1be-d3a062a3a7d0
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FourByteUnsigned(u32);
+
+impl FourByteUnsigned {
+    pub const MAX: u32 = FOUR_BYTE_UNSIGNED_MAX;
+
+    pub fn new(value: u32) -> DecodeResult<Self> {
+        if value > Self::MAX {
+            return Err(invalid_field_err!("FOUR_BYTE_UNSIGNED_INTEGER", "value out of range"));
+        }
+        Ok(Self(value))
+    }
+
+    pub fn get(self) -> u32 {
+        self.0
+    }
+
+    pub fn encoded_size(value: u32) -> usize {
+        if value <= 0x3F {
+            1
+        } else if value <= 0x3FFF {
+            2
+        } else if value <= 0x3F_FFFF {
+            3
+        } else {
+            4
+        }
+    }
+}
+
+impl Encode for FourByteUnsigned {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        let size = Self::encoded_size(self.0);
+        ensure_size!(in: dst, size: size);
+        let c = (size - 1) as u8;
+        match size {
+            1 => dst.write_u8(self.0 as u8),
+            2 => {
+                dst.write_u8((c << 6) | (((self.0 >> 8) & 0x3F) as u8));
+                dst.write_u8((self.0 & 0xFF) as u8);
+            }
+            3 => {
+                dst.write_u8((c << 6) | (((self.0 >> 16) & 0x3F) as u8));
+                dst.write_u8(((self.0 >> 8) & 0xFF) as u8);
+                dst.write_u8((self.0 & 0xFF) as u8);
+            }
+            _ => {
+                dst.write_u8((c << 6) | (((self.0 >> 24) & 0x3F) as u8));
+                dst.write_u8(((self.0 >> 16) & 0xFF) as u8);
+                dst.write_u8(((self.0 >> 8) & 0xFF) as u8);
+                dst.write_u8((self.0 & 0xFF) as u8);
+            }
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "FOUR_BYTE_UNSIGNED_INTEGER"
+    }
+
+    fn size(&self) -> usize {
+        Self::encoded_size(self.0)
+    }
+}
+
+impl<'de> Decode<'de> for FourByteUnsigned {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 1);
+        let first = src.read_u8();
+        let c = (first >> 6) as usize;
+        let val1 = u32::from(first & 0x3F);
+        let extra = c;
+        ensure_size!(in: src, size: extra);
+        let mut value = val1;
+        for _ in 0..extra {
+            value = (value << 8) | u32::from(src.read_u8());
+        }
+        Ok(Self(value))
+    }
+}
+
+/// FOUR_BYTE_SIGNED_INTEGER — range `-0x1FFFFFFF`..=`0x1FFFFFFF`.
+///
+/// [2.2.2.4]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpei/deb1ca39-344a-467a-b9d4-dfe196b46c9d
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FourByteSigned(i32);
+
+impl FourByteSigned {
+    pub const MAX: i32 = FOUR_BYTE_SIGNED_MAX;
+    pub const MIN: i32 = -FOUR_BYTE_SIGNED_MAX;
+
+    pub fn new(value: i32) -> DecodeResult<Self> {
+        if !(-Self::MAX..=Self::MAX).contains(&value) {
+            return Err(invalid_field_err!("FOUR_BYTE_SIGNED_INTEGER", "value out of range"));
+        }
+        Ok(Self(value))
+    }
+
+    pub fn get(self) -> i32 {
+        self.0
+    }
+
+    pub fn encoded_size(value: i32) -> usize {
+        let magnitude = value.unsigned_abs();
+        if magnitude <= 0x1F {
+            1
+        } else if magnitude <= 0x1FFF {
+            2
+        } else if magnitude <= 0x1F_FFFF {
+            3
+        } else {
+            4
+        }
+    }
+}
+
+impl Encode for FourByteSigned {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        let size = Self::encoded_size(self.0);
+        ensure_size!(in: dst, size: size);
+        let negative = self.0 < 0;
+        let magnitude = self.0.unsigned_abs();
+        let c = (size - 1) as u8;
+        let sign_bit: u8 = if negative { 0x20 } else { 0 };
+        match size {
+            1 => dst.write_u8(sign_bit | ((magnitude & 0x1F) as u8)),
+            2 => {
+                dst.write_u8((c << 6) | sign_bit | (((magnitude >> 8) & 0x1F) as u8));
+                dst.write_u8((magnitude & 0xFF) as u8);
+            }
+            3 => {
+                dst.write_u8((c << 6) | sign_bit | (((magnitude >> 16) & 0x1F) as u8));
+                dst.write_u8(((magnitude >> 8) & 0xFF) as u8);
+                dst.write_u8((magnitude & 0xFF) as u8);
+            }
+            _ => {
+                dst.write_u8((c << 6) | sign_bit | (((magnitude >> 24) & 0x1F) as u8));
+                dst.write_u8(((magnitude >> 16) & 0xFF) as u8);
+                dst.write_u8(((magnitude >> 8) & 0xFF) as u8);
+                dst.write_u8((magnitude & 0xFF) as u8);
+            }
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "FOUR_BYTE_SIGNED_INTEGER"
+    }
+
+    fn size(&self) -> usize {
+        Self::encoded_size(self.0)
+    }
+}
+
+impl<'de> Decode<'de> for FourByteSigned {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 1);
+        let first = src.read_u8();
+        let c = (first >> 6) as usize;
+        let negative = first & 0x20 != 0;
+        let val1 = u32::from(first & 0x1F);
+        let extra = c;
+        ensure_size!(in: src, size: extra);
+        let mut magnitude = val1;
+        for _ in 0..extra {
+            magnitude = (magnitude << 8) | u32::from(src.read_u8());
+        }
+        if magnitude > FOUR_BYTE_SIGNED_MAX as u32 {
+            return Err(invalid_field_err!("FOUR_BYTE_SIGNED_INTEGER", "value out of range"));
+        }
+        let value = if negative {
+            -(magnitude as i32)
+        } else {
+            magnitude as i32
+        };
+        Ok(Self(value))
+    }
+}
+
+/// EIGHT_BYTE_UNSIGNED_INTEGER — range `0`..=`0x1FFFFFFFFFFFFFFF`.
+///
+/// [2.2.2.5]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpei/1aab43bf-cab8-4f0a-9eb3-b83b8365e237
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EightByteUnsigned(u64);
+
+impl EightByteUnsigned {
+    pub const MAX: u64 = EIGHT_BYTE_UNSIGNED_MAX;
+
+    pub fn new(value: u64) -> DecodeResult<Self> {
+        if value > Self::MAX {
+            return Err(invalid_field_err!("EIGHT_BYTE_UNSIGNED_INTEGER", "value out of range"));
+        }
+        Ok(Self(value))
+    }
+
+    pub fn get(self) -> u64 {
+        self.0
+    }
+
+    pub fn encoded_size(value: u64) -> usize {
+        if value <= 0x1F {
+            1
+        } else if value <= 0x1FFF {
+            2
+        } else if value <= 0x1F_FFFF {
+            3
+        } else if value <= 0x1FFF_FFFF {
+            4
+        } else if value <= 0x1F_FFFF_FFFF {
+            5
+        } else if value <= 0x1FFF_FFFF_FFFF {
+            6
+        } else if value <= 0x1F_FFFF_FFFF_FFFF {
+            7
+        } else {
+            8
+        }
+    }
+}
+
+impl Encode for EightByteUnsigned {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        let size = Self::encoded_size(self.0);
+        ensure_size!(in: dst, size: size);
+        let c = (size - 1) as u8;
+        let shift = (size - 1) * 8;
+        let first_val = if shift == 0 {
+            self.0 & 0x1F
+        } else {
+            (self.0 >> shift) & 0x1F
+        };
+        dst.write_u8((c << 5) | (first_val as u8));
+        let mut remaining_shift = shift;
+        while remaining_shift > 0 {
+            remaining_shift -= 8;
+            dst.write_u8(((self.0 >> remaining_shift) & 0xFF) as u8);
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "EIGHT_BYTE_UNSIGNED_INTEGER"
+    }
+
+    fn size(&self) -> usize {
+        Self::encoded_size(self.0)
+    }
+}
+
+impl<'de> Decode<'de> for EightByteUnsigned {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 1);
+        let first = src.read_u8();
+        let c = (first >> 5) as usize;
+        let val1 = u64::from(first & 0x1F);
+        let extra = c;
+        ensure_size!(in: src, size: extra);
+        let mut value = val1;
+        for _ in 0..extra {
+            value = (value << 8) | u64::from(src.read_u8());
+        }
+        if value > Self::MAX {
+            return Err(invalid_field_err!("EIGHT_BYTE_UNSIGNED_INTEGER", "value out of range"));
+        }
+        Ok(Self(value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ironrdp_core::{decode, encode_vec};
+
+    use super::*;
+
+    #[test]
+    fn two_byte_unsigned_spec_example() {
+        let value = TwoByteUnsigned::new(0x1A1B).unwrap();
+        assert_eq!(encode_vec(&value).unwrap(), vec![0x9A, 0x1B]);
+        assert_eq!(decode::<TwoByteUnsigned>(&[0x9A, 0x1B]).unwrap().get(), 0x1A1B);
+    }
+
+    #[test]
+    fn two_byte_signed_spec_examples() {
+        let neg_large = TwoByteSigned::new(-0x1A1B).unwrap();
+        assert_eq!(encode_vec(&neg_large).unwrap(), vec![0xDA, 0x1B]);
+        assert_eq!(decode::<TwoByteSigned>(&[0xDA, 0x1B]).unwrap().get(), -0x1A1B);
+
+        let neg_small = TwoByteSigned::new(-2).unwrap();
+        assert_eq!(encode_vec(&neg_small).unwrap(), vec![0x42]);
+        assert_eq!(decode::<TwoByteSigned>(&[0x42]).unwrap().get(), -2);
+    }
+
+    #[test]
+    fn four_byte_unsigned_spec_example() {
+        let value = FourByteUnsigned::new(0x001A_1B1C).unwrap();
+        assert_eq!(encode_vec(&value).unwrap(), vec![0x9A, 0x1B, 0x1C]);
+        assert_eq!(
+            decode::<FourByteUnsigned>(&[0x9A, 0x1B, 0x1C]).unwrap().get(),
+            0x001A_1B1C
+        );
+    }
+
+    #[test]
+    fn four_byte_signed_spec_examples() {
+        let neg_large = FourByteSigned::new(-0x001A_1B1C).unwrap();
+        assert_eq!(encode_vec(&neg_large).unwrap(), vec![0xBA, 0x1B, 0x1C]);
+        assert_eq!(
+            decode::<FourByteSigned>(&[0xBA, 0x1B, 0x1C]).unwrap().get(),
+            -0x001A_1B1C
+        );
+
+        let neg_small = FourByteSigned::new(-2).unwrap();
+        assert_eq!(encode_vec(&neg_small).unwrap(), vec![0x22]);
+        assert_eq!(decode::<FourByteSigned>(&[0x22]).unwrap().get(), -2);
+    }
+
+    #[test]
+    fn eight_byte_unsigned_spec_example() {
+        let value = EightByteUnsigned::new(0x001A_1B1C_1D1E_1F2A).unwrap();
+        assert_eq!(
+            encode_vec(&value).unwrap(),
+            vec![0xDA, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x2A]
+        );
+        assert_eq!(
+            decode::<EightByteUnsigned>(&[0xDA, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x2A])
+                .unwrap()
+                .get(),
+            0x001A_1B1C_1D1E_1F2A
+        );
+    }
+
+    #[test]
+    fn round_trip_small_values() {
+        for v in [0u16, 1, 0x7F, 0x80, 0x7FFF] {
+            let encoded = encode_vec(&TwoByteUnsigned::new(v).unwrap()).unwrap();
+            assert_eq!(decode::<TwoByteUnsigned>(&encoded).unwrap().get(), v);
+        }
+        for v in [
+            0i32,
+            1,
+            -1,
+            0x1F,
+            -0x1F,
+            0x20,
+            -0x20,
+            FOUR_BYTE_SIGNED_MAX,
+            -FOUR_BYTE_SIGNED_MAX,
+        ] {
+            let encoded = encode_vec(&FourByteSigned::new(v).unwrap()).unwrap();
+            assert_eq!(decode::<FourByteSigned>(&encoded).unwrap().get(), v);
+        }
+    }
+}

--- a/crates/ironrdp-rdpei/src/server.rs
+++ b/crates/ironrdp-rdpei/src/server.rs
@@ -1,0 +1,94 @@
+use ironrdp_core::{decode, impl_as_any};
+use ironrdp_dvc::{DvcMessage, DvcProcessor, DvcServerProcessor};
+use ironrdp_pdu::{PduResult, decode_err, pdu_other_err};
+use tracing::debug;
+
+use crate::CHANNEL_NAME;
+use crate::pdu::{
+    CsReadyPdu, DismissHoveringTouchContactPdu, PenEventPdu, RdpInputProtocolVersion, RdpeiPdu, ScReadyFeatures,
+    ScReadyPdu, TouchEventPdu,
+};
+
+/// Handler callbacks for RDPEI server-side messages from the client.
+pub trait RdpeiHandler: Send {
+    fn cs_ready(&mut self, pdu: CsReadyPdu) {
+        debug!(?pdu, "RDPEI CS_READY");
+    }
+
+    fn touch(&mut self, pdu: TouchEventPdu) {
+        debug!(frames = pdu.frames.len(), "RDPEI touch event");
+    }
+
+    fn pen(&mut self, pdu: PenEventPdu) {
+        debug!(frames = pdu.frames.len(), "RDPEI pen event");
+    }
+
+    fn dismiss_hovering(&mut self, pdu: DismissHoveringTouchContactPdu) {
+        debug!(contact_id = pdu.contact_id, "RDPEI dismiss hovering");
+    }
+}
+
+/// Server endpoint for the MS-RDPEI dynamic channel.
+pub struct RdpeiServer {
+    handler: Box<dyn RdpeiHandler>,
+    protocol_version: RdpInputProtocolVersion,
+    supported_features: Option<ScReadyFeatures>,
+}
+
+impl RdpeiServer {
+    /// Create a server that advertises the given protocol version on channel start.
+    pub fn new(handler: Box<dyn RdpeiHandler>) -> Self {
+        Self {
+            handler,
+            protocol_version: RdpInputProtocolVersion::V200,
+            supported_features: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_protocol_version(mut self, version: RdpInputProtocolVersion) -> Self {
+        self.protocol_version = version;
+        self
+    }
+
+    #[must_use]
+    pub fn with_supported_features(mut self, features: ScReadyFeatures) -> Self {
+        self.supported_features = Some(features);
+        self
+    }
+}
+
+impl_as_any!(RdpeiServer);
+
+impl DvcProcessor for RdpeiServer {
+    fn channel_name(&self) -> &str {
+        CHANNEL_NAME
+    }
+
+    fn start(&mut self, _channel_id: u32) -> PduResult<Vec<DvcMessage>> {
+        let mut sc = ScReadyPdu::new(self.protocol_version);
+        if let Some(features) = self.supported_features {
+            sc = sc.with_features(features);
+        }
+        debug!(version = ?self.protocol_version, "Sending RDPEI SC_READY");
+        Ok(vec![Box::new(RdpeiPdu::ScReady(sc))])
+    }
+
+    fn process(&mut self, _channel_id: u32, payload: &[u8]) -> PduResult<Vec<DvcMessage>> {
+        match decode(payload).map_err(|e| decode_err!(e))? {
+            RdpeiPdu::CsReady(pdu) => self.handler.cs_ready(pdu),
+            RdpeiPdu::Touch(pdu) => self.handler.touch(pdu),
+            RdpeiPdu::Pen(pdu) => self.handler.pen(pdu),
+            RdpeiPdu::DismissHoveringTouchContact(pdu) => self.handler.dismiss_hovering(pdu),
+            RdpeiPdu::ScReady(_) | RdpeiPdu::SuspendInput | RdpeiPdu::ResumeInput => {
+                return Err(pdu_other_err!(
+                    "RdpeiServer::process",
+                    "received unexpected server-to-client RDPEI PDU from client"
+                ));
+            }
+        }
+        Ok(Vec::new())
+    }
+}
+
+impl DvcServerProcessor for RdpeiServer {}

--- a/crates/ironrdp-session/Cargo.toml
+++ b/crates/ironrdp-session/Cargo.toml
@@ -30,6 +30,7 @@ ironrdp-error = { path = "../ironrdp-error", version = "0.2" } # public
 ironrdp-graphics = { path = "../ironrdp-graphics", version = "0.9" } # public
 ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9", features = ["std"] } # public
 ironrdp-displaycontrol = { path = "../ironrdp-displaycontrol", version = "0.8" }
+ironrdp-rdpei = { path = "../ironrdp-rdpei", version = "0.1" }
 tracing = { version = "0.1", features = ["log"] }
 qoicoubeh = { version = "0.5", optional = true }
 zstd-safe = { version = "7.2", optional = true, features = ["std"] }

--- a/crates/ironrdp-session/src/active_stage.rs
+++ b/crates/ironrdp-session/src/active_stage.rs
@@ -21,6 +21,7 @@ use ironrdp_pdu::window::{
     WindowingOrdersUpdate, try_decode_fast_path_windowing_orders, try_decode_slow_path_windowing_orders,
 };
 use ironrdp_pdu::{Action, mcs};
+use ironrdp_rdpei::RdpeiClient;
 use ironrdp_svc::{StaticChannelSet, SvcMessage, SvcProcessor, SvcProcessorMessages};
 use tracing::debug;
 
@@ -503,6 +504,68 @@ impl ActiveStage {
             debug!("Could not encode a resize: Display Control Virtual Channel is not available");
         }
 
+        None
+    }
+
+    /// Returns whether the RDPEI channel is available and ready (SC_READY / CS_READY exchanged).
+    ///
+    /// `None` means no RDPEI client is configured. `Some(false)` means it is registered but not
+    /// yet ready (or currently suspended for touch/pen send purposes when checking readiness for
+    /// injection — use [`Self::rdpei_can_send_touch`] for the send gate).
+    pub fn rdpei_ready(&mut self) -> Option<bool> {
+        let Some(dvc) = self.get_dvc::<RdpeiClient>() else {
+            return self
+                .get_svc_processor::<DrdynvcClient>()
+                .and_then(|drdynvc| drdynvc.has_registered_dvc::<RdpeiClient>().then_some(false));
+        };
+        Some(dvc.processor().ready())
+    }
+
+    /// True when RDPEI is ready and the server has not suspended input.
+    pub fn rdpei_can_send_touch(&mut self) -> bool {
+        self.get_dvc::<RdpeiClient>()
+            .is_some_and(|dvc| dvc.processor().ready() && !dvc.processor().is_suspended())
+    }
+
+    /// Encodes a touch event for the RDPEI dynamic channel.
+    ///
+    /// Returns `None` when the channel is unavailable, not ready, or suspended.
+    pub fn encode_rdpei_touch(&mut self, event: ironrdp_rdpei::pdu::TouchEventPdu) -> Option<SessionResult<Vec<u8>>> {
+        if let Some(dvc) = self.get_dvc::<RdpeiClient>() {
+            let channel_id = dvc.channel_id();
+            let rdpei = dvc.processor();
+            if !rdpei.ready() {
+                return Some(Err(SessionError::general("RDPEI channel is not ready")));
+            }
+            if rdpei.is_suspended() {
+                return Some(Err(SessionError::general("RDPEI input is suspended")));
+            }
+            let svc_messages = match rdpei.encode_touch_event(channel_id, event) {
+                Ok(messages) => messages,
+                Err(e) => return Some(Err(SessionError::encode(e))),
+            };
+            return Some(self.process_svc_processor_messages(SvcProcessorMessages::<DrdynvcClient>::new(svc_messages)));
+        } else {
+            debug!("Could not encode RDPEI touch: Input Virtual Channel is not available");
+        }
+        None
+    }
+
+    /// Encodes a dismiss-hovering-touch-contact PDU on the RDPEI channel.
+    pub fn encode_rdpei_dismiss_hovering(&mut self, contact_id: u8) -> Option<SessionResult<Vec<u8>>> {
+        if let Some(dvc) = self.get_dvc::<RdpeiClient>() {
+            let channel_id = dvc.channel_id();
+            let rdpei = dvc.processor();
+            if !rdpei.ready() {
+                debug!("Could not encode RDPEI dismiss hovering: channel is not ready");
+                return None;
+            }
+            let svc_messages = match rdpei.encode_dismiss_hovering(channel_id, contact_id) {
+                Ok(messages) => messages,
+                Err(e) => return Some(Err(SessionError::encode(e))),
+            };
+            return Some(self.process_svc_processor_messages(SvcProcessorMessages::<DrdynvcClient>::new(svc_messages)));
+        }
         None
     }
 

--- a/crates/ironrdp-testsuite-core/Cargo.toml
+++ b/crates/ironrdp-testsuite-core/Cargo.toml
@@ -45,6 +45,7 @@ ironrdp-connector.path = "../ironrdp-connector"
 ironrdp-displaycontrol.path = "../ironrdp-displaycontrol"
 ironrdp-dvc.path = "../ironrdp-dvc"
 ironrdp-echo.path = "../ironrdp-echo"
+ironrdp-rdpei.path = "../ironrdp-rdpei"
 ironrdp-error = { path = "../ironrdp-error", features = ["std"] }
 ironrdp-fuzzing.path = "../ironrdp-fuzzing"
 ironrdp-graphics.path = "../ironrdp-graphics"

--- a/crates/ironrdp-testsuite-core/tests/main.rs
+++ b/crates/ironrdp-testsuite-core/tests/main.rs
@@ -29,6 +29,7 @@ mod propertyset;
 mod rdcleanpath;
 mod rdpdr;
 mod rdpeai;
+mod rdpei;
 mod rdpeusb;
 mod rdpsnd;
 mod server;

--- a/crates/ironrdp-testsuite-core/tests/rdpei/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpei/mod.rs
@@ -1,0 +1,84 @@
+use ironrdp_core::{decode, encode_vec};
+use ironrdp_rdpei::pdu::{
+    CsReadyFlags, CsReadyPdu, DismissHoveringTouchContactPdu, PenContact, PenContactFlags, PenEventPdu, PenFrame,
+    RdpInputProtocolVersion, RdpeiPdu, ScReadyPdu, TouchContact, TouchContactFlags, TouchEventPdu, TouchFrame,
+};
+use ironrdp_testsuite_core::assert_eq_hex;
+
+#[test]
+fn sc_ready_v200_round_trip() {
+    let pdu = RdpeiPdu::ScReady(ScReadyPdu::new(RdpInputProtocolVersion::V200));
+    let encoded = encode_vec(&pdu).expect("encode SC_READY");
+    assert_eq!(decode::<RdpeiPdu>(&encoded).expect("decode SC_READY"), pdu);
+    // EVENTID_SC_READY = 1, pduLength includes the 6-byte header, protocolVersion = 0x00020000.
+    assert_eq_hex!(
+        encoded,
+        [
+            0x01, 0x00, // eventId
+            0x0A, 0x00, 0x00, 0x00, // pduLength = 10
+            0x00, 0x00, 0x02, 0x00, // protocolVersion V200
+        ]
+    );
+}
+
+#[test]
+fn cs_ready_round_trip() {
+    let pdu = RdpeiPdu::CsReady(CsReadyPdu::new(
+        CsReadyFlags::SHOW_TOUCH_VISUALS,
+        RdpInputProtocolVersion::V200,
+        10,
+    ));
+    let encoded = encode_vec(&pdu).expect("encode CS_READY");
+    assert_eq!(decode::<RdpeiPdu>(&encoded).expect("decode CS_READY"), pdu);
+}
+
+#[test]
+fn touch_event_with_pressure_round_trip() {
+    let contact = TouchContact::new(
+        1,
+        100,
+        200,
+        TouchContactFlags::DOWN | TouchContactFlags::INRANGE | TouchContactFlags::INCONTACT,
+    )
+    .with_pressure(512);
+    let pdu = RdpeiPdu::Touch(TouchEventPdu::new(16, vec![TouchFrame::new(0, vec![contact])]));
+    let encoded = encode_vec(&pdu).expect("encode touch");
+    assert_eq!(decode::<RdpeiPdu>(&encoded).expect("decode touch"), pdu);
+}
+
+#[test]
+fn pen_event_round_trip() {
+    let contact = PenContact::new(
+        0,
+        50,
+        -20,
+        PenContactFlags::UPDATE | PenContactFlags::INRANGE | PenContactFlags::INCONTACT,
+    )
+    .with_pressure(1024)
+    .with_tilt(10, -5);
+    let pdu = RdpeiPdu::Pen(PenEventPdu::new(32, vec![PenFrame::new(1000, vec![contact])]));
+    let encoded = encode_vec(&pdu).expect("encode pen");
+    assert_eq!(decode::<RdpeiPdu>(&encoded).expect("decode pen"), pdu);
+}
+
+#[test]
+fn suspend_resume_dismiss_round_trip() {
+    let suspend = encode_vec(&RdpeiPdu::SuspendInput).expect("encode suspend");
+    assert_eq!(
+        decode::<RdpeiPdu>(&suspend).expect("decode suspend"),
+        RdpeiPdu::SuspendInput
+    );
+    assert_eq_hex!(suspend, [0x04, 0x00, 0x06, 0x00, 0x00, 0x00]);
+
+    let resume = encode_vec(&RdpeiPdu::ResumeInput).expect("encode resume");
+    assert_eq!(
+        decode::<RdpeiPdu>(&resume).expect("decode resume"),
+        RdpeiPdu::ResumeInput
+    );
+    assert_eq_hex!(resume, [0x05, 0x00, 0x06, 0x00, 0x00, 0x00]);
+
+    let dismiss = RdpeiPdu::DismissHoveringTouchContact(DismissHoveringTouchContactPdu::new(3));
+    let encoded = encode_vec(&dismiss).expect("encode dismiss");
+    assert_eq!(decode::<RdpeiPdu>(&encoded).expect("decode dismiss"), dismiss);
+    assert_eq_hex!(encoded, [0x06, 0x00, 0x07, 0x00, 0x00, 0x00, 0x03]);
+}

--- a/crates/ironrdp/Cargo.toml
+++ b/crates/ironrdp/Cargo.toml
@@ -32,6 +32,7 @@ dvc = ["dep:ironrdp-dvc"]
 rdpdr = ["dep:ironrdp-rdpdr"]
 rdpsnd = ["dep:ironrdp-rdpsnd"]
 displaycontrol = ["dep:ironrdp-displaycontrol"]
+rdpei = ["dep:ironrdp-rdpei"]
 echo = ["dep:ironrdp-echo"]
 mstsgu = ["dep:ironrdp-mstsgu"]
 client = ["dep:ironrdp-client"]
@@ -71,6 +72,7 @@ ironrdp-dvc = { path = "../ironrdp-dvc", version = "0.8", optional = true } # pu
 ironrdp-rdpdr = { path = "../ironrdp-rdpdr", version = "0.7", optional = true } # public
 ironrdp-rdpsnd = { path = "../ironrdp-rdpsnd", version = "0.9", optional = true } # public
 ironrdp-displaycontrol = { path = "../ironrdp-displaycontrol", version = "0.8", optional = true } # public
+ironrdp-rdpei = { path = "../ironrdp-rdpei", version = "0.1", optional = true } # public
 ironrdp-echo = { path = "../ironrdp-echo", version = "0.4", optional = true } # public
 ironrdp-mstsgu = { path = "../ironrdp-mstsgu", version = "0.0.1", optional = true } # public
 ironrdp-client = { path = "../ironrdp-client", version = "0.1", optional = true } # public

--- a/crates/ironrdp/src/lib.rs
+++ b/crates/ironrdp/src/lib.rs
@@ -32,6 +32,10 @@ pub use ironrdp_core as core;
 #[doc(inline)]
 pub use ironrdp_displaycontrol as displaycontrol;
 
+#[cfg(feature = "rdpei")]
+#[doc(inline)]
+pub use ironrdp_rdpei as rdpei;
+
 #[cfg(feature = "echo")]
 #[doc(inline)]
 pub use ironrdp_echo as echo;


### PR DESCRIPTION
Implement MS-RDPEI for multi-touch over the dynamic virtual channel
Microsoft::Windows::RDS::Input, and wire Windows pointer messages in
ActiveX through session encode helpers.

Introduce ironrdp-rdpei PDUs and processors, register the channel from
the client, encode touch frames from ActiveX WM_POINTER*, and cover the
protocol with unit and integration tests.