### PR TITLE
chore(xtask): allow the rdpei title scope

### DIFF
--- a/xtask/src/pr.rs
+++ b/xtask/src/pr.rs
@@ -29,6 +29,7 @@ const CANONICAL_SCOPES: &[&str] = &[
     "rdpsnd",
     "rdpeai",
     "displaycontrol",
+    "rdpei",
     "echo",
     "egfx",
     "rdpeusb",


### PR DESCRIPTION
Add `rdpei` to the canonical PR title scopes so MS-RDPEI work can use `feat(rdpei):` titles.

Needed before https://github.com/Devolutions/IronRDP/pull/1647 can pass pull-request conventions (that workflow validates titles against the base branch).