### PR TITLE
feat(agent): expose MS-RDPEI pen and multi-touch

### DIFF
--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -29,7 +29,10 @@ use ironrdp_pdu::rdp::{
 use ironrdp_pdu::window::try_decode_slow_path_windowing_orders;
 use ironrdp_propertyset::PropertySet;
 use ironrdp_rail::pdu::{ActivatePdu, ExecutePdu, RailPdu, SystemCommand, SystemCommandPdu};
-use ironrdp_rdpei::pdu::TouchEventPdu;
+use ironrdp_rdpei::pdu::{
+    PenContact, PenContactDataFlags, PenContactFlags, PenEventPdu, PenFlags, PenFrame, TouchContact, TouchContactFlags,
+    TouchEventPdu, TouchFrame,
+};
 use ironrdp_session::{GracefulDisconnectReason, SessionError, SessionErrorKind};
 use ironrdp_svc::{SvcClientProcessor, SvcMessage, SvcProcessor, impl_as_any};
 use ironrdp_tls::CertificateValidation;
@@ -5758,6 +5761,88 @@ pub(crate) struct Control {
     rpc_log_directive: RefCell<Option<String>>,
 }
 
+fn build_rpc_touch_event(
+    encode_time: u32,
+    frames: Vec<ironrdp_agent::ipc::TouchFrameRequest>,
+) -> core::result::Result<TouchEventPdu, ironrdp_agent::ipc::Response> {
+    let mut built_frames = Vec::with_capacity(frames.len());
+    for frame in frames {
+        let mut contacts = Vec::with_capacity(frame.contacts.len());
+        for contact in frame.contacts {
+            let Some(flags) = TouchContactFlags::from_bits(u32::from(contact.flags)) else {
+                return Err(ironrdp_agent::ipc::Response::typed_error(
+                    ironrdp_agent::ipc::AgentErrorCategory::InvalidRequest,
+                    "touch contact flags contain unknown bits",
+                ));
+            };
+            if !flags.is_legal() {
+                return Err(ironrdp_agent::ipc::Response::typed_error(
+                    ironrdp_agent::ipc::AgentErrorCategory::InvalidRequest,
+                    "touch contact flags are not a legal MS-RDPEI combination",
+                ));
+            }
+            contacts.push(TouchContact::new(contact.contact_id, contact.x, contact.y, flags));
+        }
+        built_frames.push(TouchFrame::new(frame.frame_offset, contacts));
+    }
+    Ok(TouchEventPdu::new(encode_time, built_frames))
+}
+
+fn build_rpc_pen_event(
+    encode_time: u32,
+    frames: Vec<ironrdp_agent::ipc::PenFrameRequest>,
+) -> core::result::Result<PenEventPdu, ironrdp_agent::ipc::Response> {
+    let mut built_frames = Vec::with_capacity(frames.len());
+    for frame in frames {
+        let mut contacts = Vec::with_capacity(frame.contacts.len());
+        for contact in frame.contacts {
+            let Some(flags) = PenContactFlags::from_bits(u32::from(contact.flags)) else {
+                return Err(ironrdp_agent::ipc::Response::typed_error(
+                    ironrdp_agent::ipc::AgentErrorCategory::InvalidRequest,
+                    "pen contact flags contain unknown bits",
+                ));
+            };
+            if !flags.is_legal() {
+                return Err(ironrdp_agent::ipc::Response::typed_error(
+                    ironrdp_agent::ipc::AgentErrorCategory::InvalidRequest,
+                    "pen contact flags are not a legal MS-RDPEI combination",
+                ));
+            }
+            let mut pen = PenContact::new(contact.device_id, contact.x, contact.y, flags);
+            if let Some(pen_flags_bits) = contact.pen_flags {
+                let Some(pen_flags) = PenFlags::from_bits(pen_flags_bits) else {
+                    return Err(ironrdp_agent::ipc::Response::typed_error(
+                        ironrdp_agent::ipc::AgentErrorCategory::InvalidRequest,
+                        "pen flags contain unknown bits",
+                    ));
+                };
+                pen = pen.with_pen_flags(pen_flags);
+            }
+            if let Some(pressure) = contact.pressure {
+                pen = pen.with_pressure(pressure);
+            }
+            if let Some(rotation) = contact.rotation {
+                pen = pen.with_rotation(rotation);
+            }
+            match (contact.tilt_x, contact.tilt_y) {
+                (Some(tilt_x), Some(tilt_y)) => pen = pen.with_tilt(tilt_x, tilt_y),
+                (Some(tilt_x), None) => {
+                    pen.fields_present.insert(PenContactDataFlags::TILTX_PRESENT);
+                    pen.fields.tilt_x = Some(tilt_x);
+                }
+                (None, Some(tilt_y)) => {
+                    pen.fields_present.insert(PenContactDataFlags::TILTY_PRESENT);
+                    pen.fields.tilt_y = Some(tilt_y);
+                }
+                (None, None) => {}
+            }
+            contacts.push(pen);
+        }
+        built_frames.push(PenFrame::new(frame.frame_offset, contacts));
+    }
+    Ok(PenEventPdu::new(encode_time, built_frames))
+}
+
 fn rpc_control_error(error: Error) -> ironrdp_agent::ipc::Response {
     let category = if error.code() == E_INVALIDARG || error.code() == E_NOTIMPL {
         ironrdp_agent::ipc::AgentErrorCategory::InvalidRequest
@@ -7879,6 +7964,16 @@ impl Control {
             } => {
                 let _ = response.send(self.rpc_touch(encode_time, frames));
             }
+            RpcCommand::Pen {
+                encode_time,
+                frames,
+                response,
+            } => {
+                let _ = response.send(self.rpc_pen(encode_time, frames));
+            }
+            RpcCommand::DismissHoveringTouchContact { contact_id, response } => {
+                let _ = response.send(self.rpc_dismiss_hovering_touch_contact(contact_id));
+            }
             RpcCommand::Resize {
                 width,
                 height,
@@ -8157,7 +8252,7 @@ impl Control {
                 "session input channel is unavailable",
             );
         };
-        let event = match ironrdp_agent::ipc::touch_event_from_request(encode_time, frames) {
+        let event = match build_rpc_touch_event(encode_time, frames) {
             Ok(event) => event,
             Err(response) => return response,
         };
@@ -8173,6 +8268,63 @@ impl Control {
         }
     }
 
+    fn rpc_pen(
+        &self,
+        encode_time: u32,
+        frames: Vec<ironrdp_agent::ipc::PenFrameRequest>,
+    ) -> ironrdp_agent::ipc::Response {
+        if self.state.get() != ConnectionState::Connected {
+            return ironrdp_agent::ipc::Response::typed_error(
+                ironrdp_agent::ipc::AgentErrorCategory::Unavailable,
+                "no active RDP session",
+            );
+        }
+        let Some(sender) = self.input_sender.borrow().as_ref().cloned() else {
+            return ironrdp_agent::ipc::Response::typed_error(
+                ironrdp_agent::ipc::AgentErrorCategory::Unavailable,
+                "session input channel is unavailable",
+            );
+        };
+        let event = match build_rpc_pen_event(encode_time, frames) {
+            Ok(event) => event,
+            Err(response) => return response,
+        };
+        match sender.try_reserve() {
+            Ok(permit) => {
+                permit.send(RdpInputEvent::Pen(event));
+                ironrdp_agent::ipc::Response::ok()
+            }
+            Err(_) => ironrdp_agent::ipc::Response::typed_error(
+                ironrdp_agent::ipc::AgentErrorCategory::Unavailable,
+                "session input channel is unavailable",
+            ),
+        }
+    }
+
+    fn rpc_dismiss_hovering_touch_contact(&self, contact_id: u8) -> ironrdp_agent::ipc::Response {
+        if self.state.get() != ConnectionState::Connected {
+            return ironrdp_agent::ipc::Response::typed_error(
+                ironrdp_agent::ipc::AgentErrorCategory::Unavailable,
+                "no active RDP session",
+            );
+        }
+        let Some(sender) = self.input_sender.borrow().as_ref().cloned() else {
+            return ironrdp_agent::ipc::Response::typed_error(
+                ironrdp_agent::ipc::AgentErrorCategory::Unavailable,
+                "session input channel is unavailable",
+            );
+        };
+        match sender.try_reserve() {
+            Ok(permit) => {
+                permit.send(RdpInputEvent::DismissHoveringTouchContact { contact_id });
+                ironrdp_agent::ipc::Response::ok()
+            }
+            Err(_) => ironrdp_agent::ipc::Response::typed_error(
+                ironrdp_agent::ipc::AgentErrorCategory::Unavailable,
+                "session input channel is unavailable",
+            ),
+        }
+    }
     fn rpc_input(&self, operation: Operation) -> ironrdp_agent::ipc::Response {
         if self.state.get() != ConnectionState::Connected {
             return ironrdp_agent::ipc::Response::typed_error(

--- a/crates/ironrdp-activex/src/rpc.rs
+++ b/crates/ironrdp-activex/src/rpc.rs
@@ -12,8 +12,8 @@ use std::thread::JoinHandle;
 
 use anyhow::Context as _;
 use ironrdp_agent::ipc::{
-    AgentErrorCategory, ConnState, KeyFilter, NowDiagnostics, Payload, PropValue, PropertyDump, PropertyEntry, Request,
-    Response, StatusInfo, TouchFrameRequest, touch_event_from_request,
+    AgentErrorCategory, ConnState, KeyFilter, NowDiagnostics, Payload, PenFrameRequest, PropValue, PropertyDump,
+    PropertyEntry, Request, Response, StatusInfo, TouchFrameRequest, pen_event_from_request, touch_event_from_request,
 };
 use ironrdp_daemon::logbuf::{self, LogBuffer};
 use ironrdp_daemon::now::NowEndpoint;
@@ -82,6 +82,15 @@ pub(crate) enum Command {
     Touch {
         encode_time: u32,
         frames: Vec<TouchFrameRequest>,
+        response: oneshot::Sender<Response>,
+    },
+    Pen {
+        encode_time: u32,
+        frames: Vec<PenFrameRequest>,
+        response: oneshot::Sender<Response>,
+    },
+    DismissHoveringTouchContact {
+        contact_id: u8,
         response: oneshot::Sender<Response>,
     },
     Resize {
@@ -410,6 +419,24 @@ async fn handle_request(shared: &Arc<Shared>, dispatcher: isize, request: Reques
             })
             .await
         }
+        Request::Pen { encode_time, frames } => {
+            if let Err(response) = pen_event_from_request(encode_time, frames.clone()) {
+                return ConnectionResponse::Single(response);
+            }
+            queue_command(shared, dispatcher, |response| Command::Pen {
+                encode_time,
+                frames,
+                response,
+            })
+            .await
+        }
+        Request::DismissHoveringTouchContact { contact_id } => {
+            queue_command(shared, dispatcher, |response| Command::DismissHoveringTouchContact {
+                contact_id,
+                response,
+            })
+            .await
+        }
         Request::RailStatus | Request::RailEvents { .. } | Request::RailWait { .. } | Request::RailExecute(_) => {
             Response::typed_error(
                 AgentErrorCategory::Unavailable,
@@ -715,6 +742,8 @@ fn respond(command: Command, response: Response) {
         | Command::Disconnect { response }
         | Command::Input { response, .. }
         | Command::Touch { response, .. }
+        | Command::Pen { response, .. }
+        | Command::DismissHoveringTouchContact { response, .. }
         | Command::Resize { response, .. } => response,
     };
     let _ = sender.send(response);
@@ -749,7 +778,6 @@ fn lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ironrdp_agent::ipc::TouchContactRequest;
 
     fn rpc() -> ActiveXRpc {
         ActiveXRpc {

--- a/crates/ironrdp-activex/src/rpc.rs
+++ b/crates/ironrdp-activex/src/rpc.rs
@@ -11,6 +11,8 @@ use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 
 use anyhow::Context as _;
+#[cfg(test)]
+use ironrdp_agent::ipc::TouchContactRequest;
 use ironrdp_agent::ipc::{
     AgentErrorCategory, ConnState, KeyFilter, NowDiagnostics, Payload, PenFrameRequest, PropValue, PropertyDump,
     PropertyEntry, Request, Response, StatusInfo, TouchFrameRequest, pen_event_from_request, touch_event_from_request,

--- a/crates/ironrdp-agent/src/cli.rs
+++ b/crates/ironrdp-agent/src/cli.rs
@@ -1,12 +1,12 @@
 //! The short-lived CLI: parse arguments, build a request (merging a `.rdp` file with overrides for
 //! `connect`), send it to the daemon, and print the response.
 //!
-//! The CLI operates purely at the [`PropertySet`] level for connection config â€” it never calls
+//! The CLI operates purely at the [`PropertySet`] level for connection config — it never calls
 //! typed `ConfigBuilder` setters.
 //!
-//! For `connect`, property precedence from low to high is: `.rdp` file â†’ `--prop` overrides â†’
-//! named flags (`--server`/`--username`/â€¦). The daemon's own overlay (`daemon-start --overlay`,
-//! itself built from a `.rdp` file with `--prop` overrides layered on top) wins over all of that â€”
+//! For `connect`, property precedence from low to high is: `.rdp` file → `--prop` overrides →
+//! named flags (`--server`/`--username`/…). The daemon's own overlay (`daemon-start --overlay`,
+//! itself built from a `.rdp` file with `--prop` overrides layered on top) wins over all of that —
 //! see `Daemon::connect` in `daemon.rs`.
 
 #![allow(clippy::print_stdout, clippy::print_stderr)]
@@ -664,34 +664,12 @@ impl CliPenAction {
     }
 }
 
-fn pen_request(
-    encode_time: u32,
-    frame_offset: u64,
-    device_id: u8,
-    x: i32,
-    y: i32,
-    flags: u16,
-    pressure: Option<u32>,
-    rotation: Option<u16>,
-    tilt_x: Option<i16>,
-    tilt_y: Option<i16>,
-    pen_flags: Option<u32>,
-) -> Request {
+fn pen_request(encode_time: u32, frame_offset: u64, contact: PenContactRequest) -> Request {
     Request::Pen {
         encode_time,
         frames: vec![PenFrameRequest {
             frame_offset,
-            contacts: vec![PenContactRequest {
-                device_id,
-                x,
-                y,
-                flags,
-                pressure,
-                rotation,
-                tilt_x,
-                tilt_y,
-                pen_flags,
-            }],
+            contacts: vec![contact],
         }],
     }
 }
@@ -928,15 +906,17 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
         } => pen_request(
             encode_time,
             frame_offset,
-            device_id,
-            x,
-            y,
-            action.flags(),
-            pressure,
-            rotation,
-            tilt_x,
-            tilt_y,
-            CliPenAction::pen_flags(eraser, inverted),
+            PenContactRequest {
+                device_id,
+                x,
+                y,
+                flags: action.flags(),
+                pressure,
+                rotation,
+                tilt_x,
+                tilt_y,
+                pen_flags: CliPenAction::pen_flags(eraser, inverted),
+            },
         ),
         Command::PenTap {
             device_id,

--- a/crates/ironrdp-agent/src/cli.rs
+++ b/crates/ironrdp-agent/src/cli.rs
@@ -1,12 +1,12 @@
 //! The short-lived CLI: parse arguments, build a request (merging a `.rdp` file with overrides for
 //! `connect`), send it to the daemon, and print the response.
 //!
-//! The CLI operates purely at the [`PropertySet`] level for connection config — it never calls
+//! The CLI operates purely at the [`PropertySet`] level for connection config â€” it never calls
 //! typed `ConfigBuilder` setters.
 //!
-//! For `connect`, property precedence from low to high is: `.rdp` file → `--prop` overrides →
-//! named flags (`--server`/`--username`/…). The daemon's own overlay (`daemon-start --overlay`,
-//! itself built from a `.rdp` file with `--prop` overrides layered on top) wins over all of that —
+//! For `connect`, property precedence from low to high is: `.rdp` file â†’ `--prop` overrides â†’
+//! named flags (`--server`/`--username`/â€¦). The daemon's own overlay (`daemon-start --overlay`,
+//! itself built from a `.rdp` file with `--prop` overrides layered on top) wins over all of that â€”
 //! see `Daemon::connect` in `daemon.rs`.
 
 #![allow(clippy::print_stdout, clippy::print_stderr)]
@@ -24,8 +24,8 @@ use ironrdp_propertyset::{PropertySet, Value};
 
 use ironrdp_rpc::ipc::{
     AgentError, KeyFilter, MAX_UNICODE_TEXT_CHARS, NowExecutionKind, NowExecutionRequest, NowStream, OperationEvent,
-    OperationEventKind, OperationInfo, OperationState, Payload, PropValue, RailEvent, RailEventKind,
-    RailExecuteRequest, Request, Response, TouchContactRequest, TouchFrameRequest,
+    OperationEventKind, OperationInfo, OperationState, Payload, PenContactRequest, PenFrameRequest, PropValue,
+    RailEvent, RailEventKind, RailExecuteRequest, Request, Response, TouchContactRequest, TouchFrameRequest,
 };
 use ironrdp_rpc::transport::{self, Endpoint};
 
@@ -128,6 +128,59 @@ enum Command {
         x: i32,
         #[arg(long, allow_hyphen_values = true)]
         y: i32,
+    },
+    /// Send one multi-contact MS-RDPEI touch frame (`id:x:y:action` entries).
+    TouchFrame {
+        /// Contacts as `id:x:y:action` (action uses the same names as `touch --action`).
+        #[arg(long = "contact", required = true, num_args = 1..)]
+        contacts: Vec<String>,
+        #[arg(long, default_value_t = 0)]
+        encode_time: u32,
+        #[arg(long, default_value_t = 0)]
+        frame_offset: u64,
+    },
+    /// Send one MS-RDPEI pen contact sample (legal flag sets only).
+    Pen {
+        #[arg(long, default_value_t = 0)]
+        device_id: u8,
+        #[arg(long, allow_hyphen_values = true)]
+        x: i32,
+        #[arg(long, allow_hyphen_values = true)]
+        y: i32,
+        #[arg(long, value_enum)]
+        action: CliPenAction,
+        #[arg(long, default_value_t = 0)]
+        encode_time: u32,
+        #[arg(long, default_value_t = 0)]
+        frame_offset: u64,
+        #[arg(long)]
+        pressure: Option<u32>,
+        #[arg(long)]
+        rotation: Option<u16>,
+        #[arg(long, allow_hyphen_values = true)]
+        tilt_x: Option<i16>,
+        #[arg(long, allow_hyphen_values = true)]
+        tilt_y: Option<i16>,
+        #[arg(long, default_value_t = false)]
+        eraser: bool,
+        #[arg(long, default_value_t = false)]
+        inverted: bool,
+    },
+    /// Tap once via MS-RDPEI pen (one pen PDU: DOWN then out-of-range UP).
+    PenTap {
+        #[arg(long, default_value_t = 0)]
+        device_id: u8,
+        #[arg(long, allow_hyphen_values = true)]
+        x: i32,
+        #[arg(long, allow_hyphen_values = true)]
+        y: i32,
+        #[arg(long)]
+        pressure: Option<u32>,
+    },
+    /// Dismiss a hovering MS-RDPEI touch contact.
+    DismissHovering {
+        #[arg(long, default_value_t = 0)]
+        contact_id: u8,
     },
     /// Resize the remote desktop.
     Resize {
@@ -562,6 +615,100 @@ fn parse_rdpdr_drive(input: &str) -> Result<ironrdp_daemon::daemon::RdpdrDriveCo
         .map_err(|error| error.to_string())
 }
 
+/// Legal MS-RDPEI pen contact transitions for agent testing.
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum CliPenAction {
+    /// DOWN | INRANGE | INCONTACT
+    Down,
+    /// UPDATE | INRANGE | INCONTACT
+    Move,
+    /// UP | INRANGE
+    Up,
+    /// UP
+    OutOfRange,
+    /// UPDATE | CANCELED
+    Cancel,
+    /// UPDATE | INRANGE
+    Hover,
+}
+
+impl CliPenAction {
+    fn flags(self) -> u16 {
+        const DOWN: u16 = 0x0001;
+        const UPDATE: u16 = 0x0002;
+        const UP: u16 = 0x0004;
+        const INRANGE: u16 = 0x0008;
+        const INCONTACT: u16 = 0x0010;
+        const CANCELED: u16 = 0x0020;
+
+        match self {
+            Self::Down => DOWN | INRANGE | INCONTACT,
+            Self::Move => UPDATE | INRANGE | INCONTACT,
+            Self::Up => UP | INRANGE,
+            Self::OutOfRange => UP,
+            Self::Cancel => UPDATE | CANCELED,
+            Self::Hover => UPDATE | INRANGE,
+        }
+    }
+
+    fn pen_flags(eraser: bool, inverted: bool) -> Option<u32> {
+        // MS-RDPEI penFlags: ERASER_PRESSED=0x2, INVERTED=0x4
+        let mut flags = 0u32;
+        if eraser {
+            flags |= 0x0002;
+        }
+        if inverted {
+            flags |= 0x0004;
+        }
+        if flags == 0 { None } else { Some(flags) }
+    }
+}
+
+fn pen_request(
+    encode_time: u32,
+    frame_offset: u64,
+    device_id: u8,
+    x: i32,
+    y: i32,
+    flags: u16,
+    pressure: Option<u32>,
+    rotation: Option<u16>,
+    tilt_x: Option<i16>,
+    tilt_y: Option<i16>,
+    pen_flags: Option<u32>,
+) -> Request {
+    Request::Pen {
+        encode_time,
+        frames: vec![PenFrameRequest {
+            frame_offset,
+            contacts: vec![PenContactRequest {
+                device_id,
+                x,
+                y,
+                flags,
+                pressure,
+                rotation,
+                tilt_x,
+                tilt_y,
+                pen_flags,
+            }],
+        }],
+    }
+}
+
+fn parse_touch_contact_spec(spec: &str) -> anyhow::Result<TouchContactRequest> {
+    let mut parts = spec.splitn(4, ':');
+    let (Some(id), Some(x), Some(y), Some(action)) = (parts.next(), parts.next(), parts.next(), parts.next()) else {
+        anyhow::bail!("malformed contact '{spec}', expected id:x:y:action");
+    };
+    Ok(TouchContactRequest {
+        contact_id: id.parse().with_context(|| format!("contact id in '{spec}'"))?,
+        x: x.parse().with_context(|| format!("contact x in '{spec}'"))?,
+        y: y.parse().with_context(|| format!("contact y in '{spec}'"))?,
+        flags: action.parse::<CliTouchAction>().map_err(anyhow::Error::msg)?.flags(),
+    })
+}
+
 /// Legal MS-RDPEI touch contact transitions for agent testing.
 #[derive(Clone, Copy, Debug, ValueEnum)]
 enum CliTouchAction {
@@ -597,6 +744,14 @@ impl CliTouchAction {
             Self::Cancel => UPDATE | CANCELED,
             Self::Hover => UPDATE | INRANGE,
         }
+    }
+}
+
+impl FromStr for CliTouchAction {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        ValueEnum::from_str(s, true)
     }
 }
 
@@ -740,6 +895,89 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
                 },
             ],
         },
+        Command::TouchFrame {
+            contacts,
+            encode_time,
+            frame_offset,
+        } => {
+            let mut parsed = Vec::with_capacity(contacts.len());
+            for spec in contacts {
+                parsed.push(parse_touch_contact_spec(&spec)?);
+            }
+            Request::Touch {
+                encode_time,
+                frames: vec![TouchFrameRequest {
+                    frame_offset,
+                    contacts: parsed,
+                }],
+            }
+        }
+        Command::Pen {
+            device_id,
+            x,
+            y,
+            action,
+            encode_time,
+            frame_offset,
+            pressure,
+            rotation,
+            tilt_x,
+            tilt_y,
+            eraser,
+            inverted,
+        } => pen_request(
+            encode_time,
+            frame_offset,
+            device_id,
+            x,
+            y,
+            action.flags(),
+            pressure,
+            rotation,
+            tilt_x,
+            tilt_y,
+            CliPenAction::pen_flags(eraser, inverted),
+        ),
+        Command::PenTap {
+            device_id,
+            x,
+            y,
+            pressure,
+        } => Request::Pen {
+            encode_time: 0,
+            frames: vec![
+                PenFrameRequest {
+                    frame_offset: 0,
+                    contacts: vec![PenContactRequest {
+                        device_id,
+                        x,
+                        y,
+                        flags: CliPenAction::Down.flags(),
+                        pressure,
+                        rotation: None,
+                        tilt_x: None,
+                        tilt_y: None,
+                        pen_flags: None,
+                    }],
+                },
+                PenFrameRequest {
+                    // 16 ms between engage and release, matching a short physical tap.
+                    frame_offset: 16_000,
+                    contacts: vec![PenContactRequest {
+                        device_id,
+                        x,
+                        y,
+                        flags: CliPenAction::OutOfRange.flags(),
+                        pressure,
+                        rotation: None,
+                        tilt_x: None,
+                        tilt_y: None,
+                        pen_flags: None,
+                    }],
+                },
+            ],
+        },
+        Command::DismissHovering { contact_id } => Request::DismissHoveringTouchContact { contact_id },
         Command::Resize { width, height } => Request::Resize { width, height },
     };
 

--- a/crates/ironrdp-agent/src/help.rs
+++ b/crates/ironrdp-agent/src/help.rs
@@ -123,7 +123,15 @@ Override with `--endpoint <PATH-OR-PIPE>` on any subcommand.
 - `touch --x X --y Y --action <down|move|up|out-of-range|cancel|hover>
     [--contact-id N] [--encode-time MS] [--frame-offset US]`
                                                  Send one MS-RDPEI touch contact sample.
-- `touch-tap --x X --y Y [--contact-id N]`       One RDPEI touch PDU: DOWN then out-of-range UP.
+- `touch-tap --x X --y Y [--contact-id N]`       DOWN then UP at the same point via RDPEI.
+- `touch-frame --contact id:x:y:action [...]`    One multi-contact MS-RDPEI touch frame.
+- `pen --x X --y Y --action <down|move|up|out-of-range|cancel|hover>
+    [--device-id N] [--pressure N] [--rotation N] [--tilt-x N] [--tilt-y N]
+    [--eraser] [--inverted] [--encode-time MS] [--frame-offset US]`
+                                                 Send one MS-RDPEI pen contact sample.
+- `pen-tap --x X --y Y [--device-id N] [--pressure N]`
+                                                 DOWN then UP pen tap via RDPEI.
+- `dismiss-hovering [--contact-id N]`            Dismiss a hovering touch contact.
 - `resize --width W --height H`                  Resize the remote desktop.
 
 ## NOW remote execution (requires an active, connected RDP session)

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -171,6 +171,8 @@ pub enum RdpInputEvent {
     FastPath(SmallVec<[FastPathInputEvent; 2]>),
     /// Multitouch frames for MS-RDPEI (`Microsoft::Windows::RDS::Input`).
     Touch(TouchEventPdu),
+    /// Pen frames for MS-RDPEI (`RDPINPUT_PEN_EVENT_PDU`).
+    Pen(ironrdp_rdpei::pdu::PenEventPdu),
     /// Dismiss a hovering touch contact over MS-RDPEI.
     DismissHoveringTouchContact {
         contact_id: u8,
@@ -1928,6 +1930,22 @@ async fn active_session(
                                 // Channel missing / not ready / suspended: warn rather than
                                 // silently dropping, which desynchronizes the contact FSM.
                                 warn!("Dropping RDPEI touch event: channel unavailable, not ready, or suspended");
+                                Vec::new()
+                            }
+                        }
+                    }
+                    RdpInputEvent::Pen(event) => {
+                        trace!(frames = event.frames.len(), "RDPEI pen event");
+                        match active_stage.encode_rdpei_pen(event) {
+                            Some(Ok(frame)) => vec![ActiveStageOutput::ResponseFrame(frame)],
+                            Some(Err(error)) => {
+                                warn!(%error, "Failed to encode RDPEI pen event");
+                                Vec::new()
+                            }
+                            None => {
+                                debug!(
+                                    "Dropping RDPEI pen event: channel not ready, suspended, or pen disallowed"
+                                );
                                 Vec::new()
                             }
                         }

--- a/crates/ironrdp-daemon/src/daemon.rs
+++ b/crates/ironrdp-daemon/src/daemon.rs
@@ -1679,7 +1679,7 @@ mod tests {
         enqueue_unicode_text, notify,
     };
     use crate::ipc::{Payload, Response};
-    use ironrdp_rpc::ipc::{PenContactRequest, PenFrameRequest, RailEventKind, RailExecuteRequest, RailLaunchInfo};
+    use ironrdp_rpc::ipc::{RailEventKind, RailExecuteRequest, RailLaunchInfo};
     use ironrdp_tls::CertificateValidation;
 
     #[test]

--- a/crates/ironrdp-daemon/src/daemon.rs
+++ b/crates/ironrdp-daemon/src/daemon.rs
@@ -35,9 +35,10 @@ use std::collections::BTreeSet;
 use ironrdp_rdpdr_native::{RedirectedDrive, WindowsRdpdrBackendFactory};
 
 use crate::ipc::{
-    ConnState, KeyFilter, MAX_UNICODE_TEXT_CHARS, NowDiagnostics, Payload, PropValue, PropertyDump, PropertyEntry,
-    RailEvent, RailEventDump, RailEventKind, RailExecuteFailureReason, RailExecuteRequest, RailLaunchInfo,
-    RailStatusInfo, Request, Response, StatusInfo, TouchFrameRequest, touch_event_from_request,
+    ConnState, KeyFilter, MAX_UNICODE_TEXT_CHARS, NowDiagnostics, Payload, PenFrameRequest, PropValue, PropertyDump,
+    PropertyEntry, RailEvent, RailEventDump, RailEventKind, RailExecuteFailureReason, RailExecuteRequest,
+    RailLaunchInfo, RailStatusInfo, Request, Response, StatusInfo, TouchFrameRequest, pen_event_from_request,
+    touch_event_from_request,
 };
 use crate::logbuf::{self, LogBuffer};
 use crate::now::NowEndpoint;
@@ -569,6 +570,10 @@ impl Daemon {
             } => DaemonResponse::Single(self.now_stdin(operation_id, data, last).await),
             Request::NowDiagnostics => DaemonResponse::Single(self.now_diagnostics().await),
             Request::Touch { encode_time, frames } => DaemonResponse::Single(self.touch(encode_time, frames)),
+            Request::Pen { encode_time, frames } => DaemonResponse::Single(self.pen(encode_time, frames)),
+            Request::DismissHoveringTouchContact { contact_id } => {
+                DaemonResponse::Single(self.dismiss_hovering_touch_contact(contact_id))
+            }
             Request::RailStatus => DaemonResponse::Single(self.rail_status()),
             Request::RailEvents { after_sequence } => DaemonResponse::Single(self.rail_events(after_sequence)),
             Request::RailWait {
@@ -1066,10 +1071,7 @@ impl Daemon {
         self.input_operations([operation])
     }
 
-    /// Queues one MS-RDPEI touch event on the active RDP session input path.
-    ///
-    /// Success means the validated event was accepted into the local input queue. The session loop
-    /// still drops the event when the Input DVC is absent, not ready, or suspended.
+    /// Sends one MS-RDPEI touch event to the active RDP session.
     ///
     /// # Panics
     ///
@@ -1094,6 +1096,57 @@ impl Daemon {
             }
         };
         permit.send(RdpInputEvent::Touch(event));
+        Response::ok()
+    }
+
+    /// Sends one MS-RDPEI pen event to the active RDP session.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the daemon state mutex is poisoned.
+    fn pen(&self, encode_time: u32, frames: Vec<PenFrameRequest>) -> Response {
+        let event = match pen_event_from_request(encode_time, frames) {
+            Ok(event) => event,
+            Err(response) => return response,
+        };
+
+        let mut guard = self.state.lock().expect("daemon state poisoned");
+        let Some(session) = guard.as_mut() else {
+            return Response::typed_error(crate::ipc::AgentErrorCategory::Unavailable, "no active session");
+        };
+        let permit = match session.input_tx.try_reserve() {
+            Ok(permit) => permit,
+            Err(_) => {
+                return Response::typed_error(
+                    crate::ipc::AgentErrorCategory::Unavailable,
+                    "session input channel is unavailable",
+                );
+            }
+        };
+        permit.send(RdpInputEvent::Pen(event));
+        Response::ok()
+    }
+
+    /// Dismisses a hovering MS-RDPEI touch contact on the active RDP session.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the daemon state mutex is poisoned.
+    fn dismiss_hovering_touch_contact(&self, contact_id: u8) -> Response {
+        let mut guard = self.state.lock().expect("daemon state poisoned");
+        let Some(session) = guard.as_mut() else {
+            return Response::typed_error(crate::ipc::AgentErrorCategory::Unavailable, "no active session");
+        };
+        let permit = match session.input_tx.try_reserve() {
+            Ok(permit) => permit,
+            Err(_) => {
+                return Response::typed_error(
+                    crate::ipc::AgentErrorCategory::Unavailable,
+                    "session input channel is unavailable",
+                );
+            }
+        };
+        permit.send(RdpInputEvent::DismissHoveringTouchContact { contact_id });
         Response::ok()
     }
 
@@ -1626,7 +1679,7 @@ mod tests {
         enqueue_unicode_text, notify,
     };
     use crate::ipc::{Payload, Response};
-    use ironrdp_rpc::ipc::{RailEventKind, RailExecuteRequest, RailLaunchInfo};
+    use ironrdp_rpc::ipc::{PenContactRequest, PenFrameRequest, RailEventKind, RailExecuteRequest, RailLaunchInfo};
     use ironrdp_tls::CertificateValidation;
 
     #[test]

--- a/crates/ironrdp-rpc/src/ipc.rs
+++ b/crates/ironrdp-rpc/src/ipc.rs
@@ -41,10 +41,23 @@ pub const MAX_TOUCH_CONTACTS: usize = 10;
 pub const MAX_TOUCH_FRAMES: usize = 64;
 
 /// Maximum contacts in one MS-RDPEI pen frame accepted over RPC.
-pub const MAX_PEN_CONTACTS: usize = 4;
+///
+/// Clients currently construct [`ironrdp_rdpei::RdpeiClient::default`], which advertises V200 with
+/// empty `CS_READY` feature flags. Until multi-pen negotiation is plumbed through, only a single
+/// pen contact with `deviceId == 0` is accepted ([MS-RDPEI] 3.1.1.1).
+pub const MAX_PEN_CONTACTS: usize = 1;
 
 /// Maximum pen frames in one [`Request::Pen`] PDU accepted over RPC.
 pub const MAX_PEN_FRAMES: usize = 64;
+
+/// Maximum MS-RDPEI pen pressure value ([MS-RDPEI] 2.2.3.7.1.1).
+pub const MAX_PEN_PRESSURE: u32 = 1024;
+
+/// Maximum MS-RDPEI pen rotation value in degrees ([MS-RDPEI] 2.2.3.7.1.1).
+pub const MAX_PEN_ROTATION: u16 = 359;
+
+/// Maximum absolute MS-RDPEI pen tilt angle in degrees ([MS-RDPEI] 2.2.3.7.1.1).
+pub const MAX_PEN_TILT: i16 = 90;
 
 /// One contact sample inside a [`TouchFrameRequest`].
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -167,8 +180,9 @@ fn touch_contact_from_request(contact: TouchContactRequest) -> Result<TouchConta
 
 /// Validates and converts an RPC pen request into an MS-RDPEI pen event PDU.
 ///
-/// Rejects empty frames/contacts, count limits, unknown or illegal flag combinations, and
-/// values outside the MS-RDPEI varint ranges used on the wire.
+/// Rejects empty frames/contacts, count limits, nonzero device IDs, a nonzero first-frame offset,
+/// unknown or illegal flag combinations, optional-field semantic ranges, and values outside the
+/// MS-RDPEI varint ranges used on the wire.
 pub fn pen_event_from_request(encode_time: u32, frames: Vec<PenFrameRequest>) -> Result<PenEventPdu, Response> {
     if frames.is_empty() {
         return Err(Response::typed_error(
@@ -186,6 +200,12 @@ pub fn pen_event_from_request(encode_time: u32, frames: Vec<PenFrameRequest>) ->
         return Err(Response::typed_error(
             AgentErrorCategory::InvalidRequest,
             "pen encode_time is out of MS-RDPEI range",
+        ));
+    }
+    if frames[0].frame_offset != 0 {
+        return Err(Response::typed_error(
+            AgentErrorCategory::InvalidRequest,
+            "pen first frame_offset must be zero",
         ));
     }
 
@@ -221,6 +241,12 @@ pub fn pen_event_from_request(encode_time: u32, frames: Vec<PenFrameRequest>) ->
 }
 
 fn pen_contact_from_request(contact: PenContactRequest) -> Result<PenContact, Response> {
+    if contact.device_id != 0 {
+        return Err(Response::typed_error(
+            AgentErrorCategory::InvalidRequest,
+            "pen device_id must be zero until multi-pen is negotiated",
+        ));
+    }
     if FourByteSigned::new(contact.x).is_err() || FourByteSigned::new(contact.y).is_err() {
         return Err(Response::typed_error(
             AgentErrorCategory::InvalidRequest,
@@ -248,16 +274,38 @@ fn pen_contact_from_request(contact: PenContactRequest) -> Result<PenContact, Re
         pen = pen.with_pen_flags(pen_flags);
     }
     if let Some(pressure) = contact.pressure {
-        if FourByteUnsigned::new(pressure).is_err() {
+        if pressure > MAX_PEN_PRESSURE {
             return Err(Response::typed_error(
                 AgentErrorCategory::InvalidRequest,
-                "pen pressure is out of MS-RDPEI range",
+                format!("pen pressure must be in 0..={MAX_PEN_PRESSURE}"),
             ));
         }
         pen = pen.with_pressure(pressure);
     }
     if let Some(rotation) = contact.rotation {
+        if rotation > MAX_PEN_ROTATION {
+            return Err(Response::typed_error(
+                AgentErrorCategory::InvalidRequest,
+                format!("pen rotation must be in 0..={MAX_PEN_ROTATION}"),
+            ));
+        }
         pen = pen.with_rotation(rotation);
+    }
+    if let Some(tilt_x) = contact.tilt_x {
+        if !(-MAX_PEN_TILT..=MAX_PEN_TILT).contains(&tilt_x) {
+            return Err(Response::typed_error(
+                AgentErrorCategory::InvalidRequest,
+                format!("pen tilt_x must be in -{MAX_PEN_TILT}..={MAX_PEN_TILT}"),
+            ));
+        }
+    }
+    if let Some(tilt_y) = contact.tilt_y {
+        if !(-MAX_PEN_TILT..=MAX_PEN_TILT).contains(&tilt_y) {
+            return Err(Response::typed_error(
+                AgentErrorCategory::InvalidRequest,
+                format!("pen tilt_y must be in -{MAX_PEN_TILT}..={MAX_PEN_TILT}"),
+            ));
+        }
     }
     match (contact.tilt_x, contact.tilt_y) {
         (Some(tilt_x), Some(tilt_y)) => {
@@ -351,19 +399,23 @@ pub enum Request {
     },
     /// Inspect the local NOW endpoint without exposing protocol internals.
     NowDiagnostics,
-    /// Send one MS-RDPEI touch event PDU (`RDPINPUT_TOUCH_EVENT_PDU`).
+    /// Queue one MS-RDPEI touch event PDU (`RDPINPUT_TOUCH_EVENT_PDU`) for the session input loop.
     ///
-    /// Requires the Input DVC to be ready and not suspended. Contacts must use legal flag sets from
-    /// [MS-RDPEI] 3.1.1.1. At most [`MAX_TOUCH_FRAMES`] frames and [`MAX_TOUCH_CONTACTS`] contacts
-    /// per frame are accepted.
+    /// `Ok` means the request was validated and reserved on the local input queue, not that the
+    /// Input DVC delivered it to the host. The session loop may still drop the event when RDPEI is
+    /// absent, unready, or suspended. Contacts must use legal flag sets from [MS-RDPEI] 3.1.1.1. At
+    /// most [`MAX_TOUCH_FRAMES`] frames and [`MAX_TOUCH_CONTACTS`] contacts per frame are accepted.
     Touch {
         /// Milliseconds elapsed for the oldest frame in this PDU.
         encode_time: u32,
         frames: Vec<TouchFrameRequest>,
     },
-    /// Send one MS-RDPEI pen event PDU (`RDPINPUT_PEN_EVENT_PDU`).
+    /// Queue one MS-RDPEI pen event PDU (`RDPINPUT_PEN_EVENT_PDU`) for the session input loop.
     ///
-    /// Requires RDPEI ready, not suspended, and a negotiated version that allows pen (V200+).
+    /// `Ok` means the request was validated and reserved on the local input queue, not that the
+    /// Input DVC delivered it to the host. The session loop may still drop the event when RDPEI is
+    /// absent, unready, suspended, or below the negotiated version that allows pen (V200+). Until
+    /// multi-pen is negotiated, only one contact with `deviceId == 0` is accepted.
     Pen {
         encode_time: u32,
         frames: Vec<PenFrameRequest>,
@@ -2939,9 +2991,11 @@ impl_pdu_pod!(NowDiagnostics);
 #[cfg(test)]
 mod rdpei_request_tests {
     use super::{
-        MAX_TOUCH_CONTACTS, MAX_TOUCH_FRAMES, TouchContactRequest, TouchFrameRequest, touch_event_from_request,
+        MAX_PEN_CONTACTS, MAX_PEN_FRAMES, MAX_PEN_PRESSURE, MAX_PEN_ROTATION, MAX_PEN_TILT, MAX_TOUCH_CONTACTS,
+        MAX_TOUCH_FRAMES, PenContactRequest, PenFrameRequest, TouchContactRequest, TouchFrameRequest,
+        pen_event_from_request, touch_event_from_request,
     };
-    use ironrdp_rdpei::pdu::{EightByteUnsigned, FourByteSigned, FourByteUnsigned, TouchContactFlags};
+    use ironrdp_rdpei::pdu::{EightByteUnsigned, FourByteSigned, FourByteUnsigned, PenContactFlags, TouchContactFlags};
 
     fn contact(flags: u16) -> TouchContactRequest {
         TouchContactRequest {
@@ -2954,6 +3008,24 @@ mod rdpei_request_tests {
 
     fn contact_flags(flags: TouchContactFlags) -> u16 {
         u16::try_from(flags.bits()).expect("touch contact flags fit in u16")
+    }
+
+    fn pen_contact(flags: u16) -> PenContactRequest {
+        PenContactRequest {
+            device_id: 0,
+            x: 10,
+            y: 20,
+            flags,
+            pressure: None,
+            rotation: None,
+            tilt_x: None,
+            tilt_y: None,
+            pen_flags: None,
+        }
+    }
+
+    fn pen_contact_flags(flags: PenContactFlags) -> u16 {
+        u16::try_from(flags.bits()).expect("pen contact flags fit in u16")
     }
 
     #[test]
@@ -3088,6 +3160,221 @@ mod rdpei_request_tests {
                         x: FourByteSigned::MAX + 1,
                         y: 0,
                         flags: legal,
+                    }],
+                }],
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn pen_event_accepts_legal_down_and_up() {
+        let down = pen_contact_flags(PenContactFlags::DOWN | PenContactFlags::INRANGE | PenContactFlags::INCONTACT);
+        let up = pen_contact_flags(PenContactFlags::UP);
+        let mut down_contact = pen_contact(down);
+        down_contact.pressure = Some(MAX_PEN_PRESSURE);
+        down_contact.rotation = Some(MAX_PEN_ROTATION);
+        down_contact.tilt_x = Some(-MAX_PEN_TILT);
+        down_contact.tilt_y = Some(MAX_PEN_TILT);
+        let event = pen_event_from_request(
+            0,
+            vec![
+                PenFrameRequest {
+                    frame_offset: 0,
+                    contacts: vec![down_contact],
+                },
+                PenFrameRequest {
+                    frame_offset: 16_000,
+                    contacts: vec![pen_contact(up)],
+                },
+            ],
+        )
+        .expect("legal pen tap frames");
+        assert_eq!(event.frames.len(), 2);
+        assert_eq!(event.frames[0].frame_offset, 0);
+        assert_eq!(event.frames[1].frame_offset, 16_000);
+    }
+
+    #[test]
+    fn pen_event_rejects_empty_frames_and_contacts() {
+        assert!(pen_event_from_request(0, Vec::new()).is_err());
+        assert!(
+            pen_event_from_request(
+                0,
+                vec![PenFrameRequest {
+                    frame_offset: 0,
+                    contacts: Vec::new(),
+                }],
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn pen_event_rejects_illegal_unknown_flags_and_device_id() {
+        assert!(
+            pen_event_from_request(
+                0,
+                vec![PenFrameRequest {
+                    frame_offset: 0,
+                    contacts: vec![pen_contact(0x0008)], // INRANGE alone
+                }],
+            )
+            .is_err()
+        );
+        assert!(
+            pen_event_from_request(
+                0,
+                vec![PenFrameRequest {
+                    frame_offset: 0,
+                    contacts: vec![pen_contact(0x0040)], // unknown bit
+                }],
+            )
+            .is_err()
+        );
+        let mut nonzero_device = pen_contact(pen_contact_flags(
+            PenContactFlags::DOWN | PenContactFlags::INRANGE | PenContactFlags::INCONTACT,
+        ));
+        nonzero_device.device_id = 1;
+        assert!(
+            pen_event_from_request(
+                0,
+                vec![PenFrameRequest {
+                    frame_offset: 0,
+                    contacts: vec![nonzero_device],
+                }],
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn pen_event_rejects_count_offset_and_field_ranges() {
+        let legal = pen_contact_flags(PenContactFlags::DOWN | PenContactFlags::INRANGE | PenContactFlags::INCONTACT);
+        assert_eq!(MAX_PEN_CONTACTS, 1);
+        assert!(
+            pen_event_from_request(
+                0,
+                vec![PenFrameRequest {
+                    frame_offset: 0,
+                    contacts: vec![pen_contact(legal), pen_contact(legal)],
+                }],
+            )
+            .is_err()
+        );
+
+        let too_many_frames = core::iter::repeat_with(|| PenFrameRequest {
+            frame_offset: 0,
+            contacts: vec![pen_contact(legal)],
+        })
+        .take(MAX_PEN_FRAMES + 1)
+        .collect::<Vec<_>>();
+        assert!(pen_event_from_request(0, too_many_frames).is_err());
+
+        assert!(
+            pen_event_from_request(
+                0,
+                vec![PenFrameRequest {
+                    frame_offset: 1,
+                    contacts: vec![pen_contact(legal)],
+                }],
+            )
+            .is_err()
+        );
+
+        let mut pressure = pen_contact(legal);
+        pressure.pressure = Some(MAX_PEN_PRESSURE + 1);
+        assert!(
+            pen_event_from_request(
+                0,
+                vec![PenFrameRequest {
+                    frame_offset: 0,
+                    contacts: vec![pressure],
+                }],
+            )
+            .is_err()
+        );
+
+        let mut rotation = pen_contact(legal);
+        rotation.rotation = Some(MAX_PEN_ROTATION + 1);
+        assert!(
+            pen_event_from_request(
+                0,
+                vec![PenFrameRequest {
+                    frame_offset: 0,
+                    contacts: vec![rotation],
+                }],
+            )
+            .is_err()
+        );
+
+        let mut tilt_x = pen_contact(legal);
+        tilt_x.tilt_x = Some(MAX_PEN_TILT + 1);
+        assert!(
+            pen_event_from_request(
+                0,
+                vec![PenFrameRequest {
+                    frame_offset: 0,
+                    contacts: vec![tilt_x],
+                }],
+            )
+            .is_err()
+        );
+
+        let mut tilt_y = pen_contact(legal);
+        tilt_y.tilt_y = Some(-MAX_PEN_TILT - 1);
+        assert!(
+            pen_event_from_request(
+                0,
+                vec![PenFrameRequest {
+                    frame_offset: 0,
+                    contacts: vec![tilt_y],
+                }],
+            )
+            .is_err()
+        );
+
+        assert!(
+            pen_event_from_request(
+                FourByteUnsigned::MAX + 1,
+                vec![PenFrameRequest {
+                    frame_offset: 0,
+                    contacts: vec![pen_contact(legal)],
+                }],
+            )
+            .is_err()
+        );
+        assert!(
+            pen_event_from_request(
+                0,
+                vec![
+                    PenFrameRequest {
+                        frame_offset: 0,
+                        contacts: vec![pen_contact(legal)],
+                    },
+                    PenFrameRequest {
+                        frame_offset: EightByteUnsigned::MAX + 1,
+                        contacts: vec![pen_contact(legal)],
+                    },
+                ],
+            )
+            .is_err()
+        );
+        assert!(
+            pen_event_from_request(
+                0,
+                vec![PenFrameRequest {
+                    frame_offset: 0,
+                    contacts: vec![PenContactRequest {
+                        device_id: 0,
+                        x: FourByteSigned::MAX + 1,
+                        y: 0,
+                        flags: legal,
+                        pressure: None,
+                        rotation: None,
+                        tilt_x: None,
+                        tilt_y: None,
+                        pen_flags: None,
                     }],
                 }],
             )

--- a/crates/ironrdp-rpc/src/ipc.rs
+++ b/crates/ironrdp-rpc/src/ipc.rs
@@ -19,7 +19,8 @@ use ironrdp_input::MouseButton;
 use ironrdp_pdu::impl_pdu_pod;
 use ironrdp_propertyset::PropertySet;
 use ironrdp_rdpei::pdu::{
-    EightByteUnsigned, FourByteSigned, FourByteUnsigned, TouchContact, TouchContactFlags, TouchEventPdu, TouchFrame,
+    EightByteUnsigned, FourByteSigned, FourByteUnsigned, PenContact, PenContactDataFlags, PenContactFlags, PenEventPdu,
+    PenFlags, PenFrame, TouchContact, TouchContactFlags, TouchEventPdu, TouchFrame,
 };
 
 use crate::wire::{
@@ -34,14 +35,16 @@ use crate::wire::{
 pub const MAX_UNICODE_TEXT_CHARS: usize = 96;
 
 /// Maximum contacts in one MS-RDPEI touch frame accepted over RPC.
-///
-/// Matches the default `maxTouchContacts` advertised by
-/// [`ironrdp_rdpei::RdpeiClient::default`] (`10`). Sessions that advertise a different
-/// capability must keep this RPC cap in sync or reject oversized frames at the session edge.
 pub const MAX_TOUCH_CONTACTS: usize = 10;
 
 /// Maximum touch frames in one [`Request::Touch`] PDU accepted over RPC.
 pub const MAX_TOUCH_FRAMES: usize = 64;
+
+/// Maximum contacts in one MS-RDPEI pen frame accepted over RPC.
+pub const MAX_PEN_CONTACTS: usize = 4;
+
+/// Maximum pen frames in one [`Request::Pen`] PDU accepted over RPC.
+pub const MAX_PEN_FRAMES: usize = 64;
 
 /// One contact sample inside a [`TouchFrameRequest`].
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -59,6 +62,30 @@ pub struct TouchFrameRequest {
     /// Microseconds since the previous frame (`0` for the first frame of a transaction).
     pub frame_offset: u64,
     pub contacts: Vec<TouchContactRequest>,
+}
+
+/// One pen contact sample inside a [`PenFrameRequest`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PenContactRequest {
+    pub device_id: u8,
+    pub x: i32,
+    pub y: i32,
+    /// Raw MS-RDPEI pen `contactFlags` bits ([MS-RDPEI] 2.2.3.7.1.1).
+    pub flags: u16,
+    pub pressure: Option<u32>,
+    pub rotation: Option<u16>,
+    pub tilt_x: Option<i16>,
+    pub tilt_y: Option<i16>,
+    /// Optional MS-RDPEI `penFlags` bits ([MS-RDPEI] 2.2.3.7.1.1).
+    pub pen_flags: Option<u32>,
+}
+
+/// One frame inside a [`Request::Pen`] event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PenFrameRequest {
+    /// Microseconds since the previous frame (`0` for the first frame of a transaction).
+    pub frame_offset: u64,
+    pub contacts: Vec<PenContactRequest>,
 }
 
 /// Validates and converts an RPC touch request into an MS-RDPEI touch event PDU.
@@ -138,6 +165,117 @@ fn touch_contact_from_request(contact: TouchContactRequest) -> Result<TouchConta
     Ok(TouchContact::new(contact.contact_id, contact.x, contact.y, flags))
 }
 
+/// Validates and converts an RPC pen request into an MS-RDPEI pen event PDU.
+///
+/// Rejects empty frames/contacts, count limits, unknown or illegal flag combinations, and
+/// values outside the MS-RDPEI varint ranges used on the wire.
+pub fn pen_event_from_request(encode_time: u32, frames: Vec<PenFrameRequest>) -> Result<PenEventPdu, Response> {
+    if frames.is_empty() {
+        return Err(Response::typed_error(
+            AgentErrorCategory::InvalidRequest,
+            "pen event requires at least one frame",
+        ));
+    }
+    if frames.len() > MAX_PEN_FRAMES {
+        return Err(Response::typed_error(
+            AgentErrorCategory::InvalidRequest,
+            format!("pen event exceeds the {MAX_PEN_FRAMES}-frame limit"),
+        ));
+    }
+    if FourByteUnsigned::new(encode_time).is_err() {
+        return Err(Response::typed_error(
+            AgentErrorCategory::InvalidRequest,
+            "pen encode_time is out of MS-RDPEI range",
+        ));
+    }
+
+    let mut built_frames = Vec::with_capacity(frames.len());
+    for frame in frames {
+        if frame.contacts.is_empty() {
+            return Err(Response::typed_error(
+                AgentErrorCategory::InvalidRequest,
+                "pen frame requires at least one contact",
+            ));
+        }
+        if frame.contacts.len() > MAX_PEN_CONTACTS {
+            return Err(Response::typed_error(
+                AgentErrorCategory::InvalidRequest,
+                format!("pen frame exceeds the {MAX_PEN_CONTACTS}-contact limit"),
+            ));
+        }
+        if EightByteUnsigned::new(frame.frame_offset).is_err() {
+            return Err(Response::typed_error(
+                AgentErrorCategory::InvalidRequest,
+                "pen frame_offset is out of MS-RDPEI range",
+            ));
+        }
+
+        let mut contacts = Vec::with_capacity(frame.contacts.len());
+        for contact in frame.contacts {
+            contacts.push(pen_contact_from_request(contact)?);
+        }
+        built_frames.push(PenFrame::new(frame.frame_offset, contacts));
+    }
+
+    Ok(PenEventPdu::new(encode_time, built_frames))
+}
+
+fn pen_contact_from_request(contact: PenContactRequest) -> Result<PenContact, Response> {
+    if FourByteSigned::new(contact.x).is_err() || FourByteSigned::new(contact.y).is_err() {
+        return Err(Response::typed_error(
+            AgentErrorCategory::InvalidRequest,
+            "pen contact coordinates are out of MS-RDPEI range",
+        ));
+    }
+    let flags = PenContactFlags::from_bits(u32::from(contact.flags)).ok_or_else(|| {
+        Response::typed_error(
+            AgentErrorCategory::InvalidRequest,
+            "pen contact flags contain unknown bits",
+        )
+    })?;
+    if !flags.is_legal() {
+        return Err(Response::typed_error(
+            AgentErrorCategory::InvalidRequest,
+            "pen contact flags are not a legal MS-RDPEI combination",
+        ));
+    }
+
+    let mut pen = PenContact::new(contact.device_id, contact.x, contact.y, flags);
+    if let Some(pen_flags_bits) = contact.pen_flags {
+        let pen_flags = PenFlags::from_bits(pen_flags_bits).ok_or_else(|| {
+            Response::typed_error(AgentErrorCategory::InvalidRequest, "pen flags contain unknown bits")
+        })?;
+        pen = pen.with_pen_flags(pen_flags);
+    }
+    if let Some(pressure) = contact.pressure {
+        if FourByteUnsigned::new(pressure).is_err() {
+            return Err(Response::typed_error(
+                AgentErrorCategory::InvalidRequest,
+                "pen pressure is out of MS-RDPEI range",
+            ));
+        }
+        pen = pen.with_pressure(pressure);
+    }
+    if let Some(rotation) = contact.rotation {
+        pen = pen.with_rotation(rotation);
+    }
+    match (contact.tilt_x, contact.tilt_y) {
+        (Some(tilt_x), Some(tilt_y)) => {
+            pen = pen.with_tilt(tilt_x, tilt_y);
+        }
+        (Some(tilt_x), None) => {
+            pen.fields_present.insert(PenContactDataFlags::TILTX_PRESENT);
+            pen.fields.tilt_x = Some(tilt_x);
+        }
+        (None, Some(tilt_y)) => {
+            pen.fields_present.insert(PenContactDataFlags::TILTY_PRESENT);
+            pen.fields.tilt_y = Some(tilt_y);
+        }
+        (None, None) => {}
+    }
+    Ok(pen)
+}
+
 /// A request sent by the CLI to the daemon.
 ///
 /// `Connect` carries a binary-encoded [`PropertySet`] — never `argv` or CLI strings. Runtime
@@ -213,19 +351,25 @@ pub enum Request {
     },
     /// Inspect the local NOW endpoint without exposing protocol internals.
     NowDiagnostics,
-    /// Queue one MS-RDPEI touch event PDU (`RDPINPUT_TOUCH_EVENT_PDU`) on the session input path.
+    /// Send one MS-RDPEI touch event PDU (`RDPINPUT_TOUCH_EVENT_PDU`).
     ///
-    /// Success means the event was accepted into the local input queue after request validation.
-    /// The session loop still drops the event when the Input DVC is absent, not ready, or
-    /// suspended, matching mouse and keyboard RPC requests. Contacts must use legal flag sets
-    /// from [MS-RDPEI] 3.1.1.1. At most [`MAX_TOUCH_FRAMES`] frames and [`MAX_TOUCH_CONTACTS`]
-    /// contacts per frame are accepted. Injected contact IDs share the server contact-id space
-    /// with native digitizer input; avoid concurrent native touch with the same IDs.
+    /// Requires the Input DVC to be ready and not suspended. Contacts must use legal flag sets from
+    /// [MS-RDPEI] 3.1.1.1. At most [`MAX_TOUCH_FRAMES`] frames and [`MAX_TOUCH_CONTACTS`] contacts
+    /// per frame are accepted.
     Touch {
         /// Milliseconds elapsed for the oldest frame in this PDU.
         encode_time: u32,
         frames: Vec<TouchFrameRequest>,
     },
+    /// Send one MS-RDPEI pen event PDU (`RDPINPUT_PEN_EVENT_PDU`).
+    ///
+    /// Requires RDPEI ready, not suspended, and a negotiated version that allows pen (V200+).
+    Pen {
+        encode_time: u32,
+        frames: Vec<PenFrameRequest>,
+    },
+    /// Dismiss a hovering touch contact (`RDPINPUT_DISMISS_HOVERING_TOUCH_CONTACT_PDU`).
+    DismissHoveringTouchContact { contact_id: u8 },
     /// Inspect the bounded, session-local RAIL observation ledger.
     RailStatus,
     /// Return RAIL observations after a sequence number.
@@ -330,6 +474,15 @@ impl fmt::Debug for Request {
                 .debug_struct("Touch")
                 .field("encode_time", encode_time)
                 .field("frames", frames)
+                .finish(),
+            Self::Pen { encode_time, frames } => f
+                .debug_struct("Pen")
+                .field("encode_time", encode_time)
+                .field("frames", frames)
+                .finish(),
+            Self::DismissHoveringTouchContact { contact_id } => f
+                .debug_struct("DismissHoveringTouchContact")
+                .field("contact_id", contact_id)
                 .finish(),
             Self::RailStatus => f.write_str("RailStatus"),
             Self::RailEvents { after_sequence } => f
@@ -957,6 +1110,113 @@ impl KeyFilter {
 }
 
 // ── KeyFilter codec ─────────────────────────────────────────────────────────
+
+// ── Pen contact RPC helpers ─────────────────────────────────────────────────
+
+const PEN_CONTACT_PRESSURE: u8 = 0x01;
+const PEN_CONTACT_ROTATION: u8 = 0x02;
+const PEN_CONTACT_TILT_X: u8 = 0x04;
+const PEN_CONTACT_TILT_Y: u8 = 0x08;
+const PEN_CONTACT_PEN_FLAGS: u8 = 0x10;
+
+fn pen_contact_size(contact: &PenContactRequest) -> usize {
+    1 /* device_id */ + 4 /* x */ + 4 /* y */ + 2 /* flags */ + 1 /* presence */
+        + contact.pressure.map_or(0, |_| 4)
+        + contact.rotation.map_or(0, |_| 2)
+        + contact.tilt_x.map_or(0, |_| 2)
+        + contact.tilt_y.map_or(0, |_| 2)
+        + contact.pen_flags.map_or(0, |_| 4)
+}
+
+fn write_pen_contact(dst: &mut WriteCursor<'_>, contact: &PenContactRequest) -> EncodeResult<()> {
+    dst.write_u8(contact.device_id);
+    dst.write_i32(contact.x);
+    dst.write_i32(contact.y);
+    dst.write_u16(contact.flags);
+    let mut presence = 0u8;
+    if contact.pressure.is_some() {
+        presence |= PEN_CONTACT_PRESSURE;
+    }
+    if contact.rotation.is_some() {
+        presence |= PEN_CONTACT_ROTATION;
+    }
+    if contact.tilt_x.is_some() {
+        presence |= PEN_CONTACT_TILT_X;
+    }
+    if contact.tilt_y.is_some() {
+        presence |= PEN_CONTACT_TILT_Y;
+    }
+    if contact.pen_flags.is_some() {
+        presence |= PEN_CONTACT_PEN_FLAGS;
+    }
+    dst.write_u8(presence);
+    if let Some(pressure) = contact.pressure {
+        dst.write_u32(pressure);
+    }
+    if let Some(rotation) = contact.rotation {
+        dst.write_u16(rotation);
+    }
+    if let Some(tilt_x) = contact.tilt_x {
+        dst.write_i16(tilt_x);
+    }
+    if let Some(tilt_y) = contact.tilt_y {
+        dst.write_i16(tilt_y);
+    }
+    if let Some(pen_flags) = contact.pen_flags {
+        dst.write_u32(pen_flags);
+    }
+    Ok(())
+}
+
+fn read_pen_contact(src: &mut ReadCursor<'_>) -> DecodeResult<PenContactRequest> {
+    ensure_size!(in: src, size: 12);
+    let device_id = src.read_u8();
+    let x = src.read_i32();
+    let y = src.read_i32();
+    let flags = src.read_u16();
+    let presence = src.read_u8();
+    let pressure = if presence & PEN_CONTACT_PRESSURE != 0 {
+        ensure_size!(in: src, size: 4);
+        Some(src.read_u32())
+    } else {
+        None
+    };
+    let rotation = if presence & PEN_CONTACT_ROTATION != 0 {
+        ensure_size!(in: src, size: 2);
+        Some(src.read_u16())
+    } else {
+        None
+    };
+    let tilt_x = if presence & PEN_CONTACT_TILT_X != 0 {
+        ensure_size!(in: src, size: 2);
+        Some(src.read_i16())
+    } else {
+        None
+    };
+    let tilt_y = if presence & PEN_CONTACT_TILT_Y != 0 {
+        ensure_size!(in: src, size: 2);
+        Some(src.read_i16())
+    } else {
+        None
+    };
+    let pen_flags = if presence & PEN_CONTACT_PEN_FLAGS != 0 {
+        ensure_size!(in: src, size: 4);
+        Some(src.read_u32())
+    } else {
+        None
+    };
+    Ok(PenContactRequest {
+        device_id,
+        x,
+        y,
+        flags,
+        pressure,
+        rotation,
+        tilt_x,
+        tilt_y,
+        pen_flags,
+    })
+}
 
 impl Encode for KeyFilter {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
@@ -1911,6 +2171,26 @@ impl Encode for Request {
                 write_opt_u64(dst, *after_sequence)?;
                 dst.write_u32(*timeout_ms);
             }
+            Self::Pen { encode_time, frames } => {
+                // Tag 27: after Touch (26) and RAIL (22-25).
+                dst.write_u8(27);
+                dst.write_u32(*encode_time);
+                let frame_count: u16 = cast_length!("pen frame count", frames.len())?;
+                dst.write_u16(frame_count);
+                for frame in frames {
+                    dst.write_u64(frame.frame_offset);
+                    let contact_count: u16 = cast_length!("pen contact count", frame.contacts.len())?;
+                    dst.write_u16(contact_count);
+                    for contact in &frame.contacts {
+                        write_pen_contact(dst, contact)?;
+                    }
+                }
+            }
+            Self::DismissHoveringTouchContact { contact_id } => {
+                // Tag 28: dismiss hovering touch contact.
+                dst.write_u8(28);
+                dst.write_u8(*contact_id);
+            }
         }
         Ok(())
     }
@@ -1959,6 +2239,17 @@ impl Encode for Request {
                 Self::RailEvents { after_sequence } => opt_u64_size(*after_sequence),
                 Self::RailExecute(request) => request.size(),
                 Self::RailWait { after_sequence, .. } => opt_u64_size(*after_sequence) + 4 /* timeout_ms */,
+                Self::Pen { frames, .. } => {
+                    4 /* encode_time */ + 2 /* frame_count */
+                        + frames
+                            .iter()
+                            .map(|frame| {
+                                8 /* frame_offset */ + 2 /* contact_count */
+                                    + frame.contacts.iter().map(pen_contact_size).sum::<usize>()
+                            })
+                            .sum::<usize>()
+                }
+                Self::DismissHoveringTouchContact { .. } => 1 /* contact_id */,
             }
     }
 }
@@ -2106,6 +2397,35 @@ impl Decode<'_> for Request {
                     frames.push(TouchFrameRequest { frame_offset, contacts });
                 }
                 Ok(Self::Touch { encode_time, frames })
+            }
+            27 => {
+                ensure_size!(in: src, size: 6);
+                let encode_time = src.read_u32();
+                let frame_count = usize::from(src.read_u16());
+                if frame_count > MAX_PEN_FRAMES {
+                    return Err(ironrdp_core::invalid_field_err!("pen frames", "too many frames"));
+                }
+                let mut frames = Vec::with_capacity(frame_count);
+                for _ in 0..frame_count {
+                    ensure_size!(in: src, size: 10);
+                    let frame_offset = src.read_u64();
+                    let contact_count = usize::from(src.read_u16());
+                    if contact_count > MAX_PEN_CONTACTS {
+                        return Err(ironrdp_core::invalid_field_err!("pen contacts", "too many contacts"));
+                    }
+                    let mut contacts = Vec::with_capacity(contact_count);
+                    for _ in 0..contact_count {
+                        contacts.push(read_pen_contact(src)?);
+                    }
+                    frames.push(PenFrameRequest { frame_offset, contacts });
+                }
+                Ok(Self::Pen { encode_time, frames })
+            }
+            28 => {
+                ensure_size!(in: src, size: 1);
+                Ok(Self::DismissHoveringTouchContact {
+                    contact_id: src.read_u8(),
+                })
             }
             22 => Ok(Self::RailStatus),
             23 => Ok(Self::RailEvents {
@@ -2491,11 +2811,7 @@ impl_pdu_pod!(OperationEvent);
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        MAX_TOUCH_CONTACTS, MAX_TOUCH_FRAMES, RailExecuteRequest, TouchContactRequest, TouchFrameRequest,
-        touch_event_from_request,
-    };
-    use ironrdp_rdpei::pdu::{EightByteUnsigned, FourByteSigned, FourByteUnsigned, TouchContactFlags};
+    use super::RailExecuteRequest;
 
     #[test]
     fn rail_execute_debug_redacts_command_fields() {
@@ -2512,6 +2828,120 @@ mod tests {
         assert!(!debug.contains("secret-token"));
         assert!(debug.contains("executable_len"));
     }
+}
+
+impl Encode for NowCapabilities {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u16(self.version_major);
+        dst.write_u16(self.version_minor);
+        write_opt_u64(dst, self.heartbeat_ms)?;
+        for value in [
+            self.run,
+            self.process,
+            self.batch,
+            self.powershell,
+            self.pwsh,
+            self.io_redirection,
+            self.unicode_console,
+        ] {
+            write_bool(dst, value)?;
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_rpc::ipc::NowCapabilities"
+    }
+
+    fn size(&self) -> usize {
+        2 /* version major */
+            + 2 /* version minor */
+            + opt_u64_size(self.heartbeat_ms)
+            + 7 /* feature flags */
+    }
+}
+
+impl Decode<'_> for NowCapabilities {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: 4);
+        let version_major = src.read_u16();
+        let version_minor = src.read_u16();
+        Ok(Self {
+            version_major,
+            version_minor,
+            heartbeat_ms: read_opt_u64(src)?,
+            run: read_bool(src)?,
+            process: read_bool(src)?,
+            batch: read_bool(src)?,
+            powershell: read_bool(src)?,
+            pwsh: read_bool(src)?,
+            io_redirection: read_bool(src)?,
+            unicode_console: read_bool(src)?,
+        })
+    }
+}
+
+impl_pdu_pod!(NowCapabilities);
+
+impl Encode for NowDiagnostics {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        write_bool(dst, self.endpoint_allocated)?;
+        write_bool(dst, self.connected)?;
+        match &self.capabilities {
+            Some(capabilities) => {
+                dst.write_u8(1);
+                capabilities.encode(dst)?;
+            }
+            None => dst.write_u8(0),
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "ironrdp_rpc::ipc::NowDiagnostics"
+    }
+
+    fn size(&self) -> usize {
+        1 /* endpoint_allocated */
+            + 1 /* connected */
+            + 1 /* capabilities presence */
+            + self.capabilities.as_ref().map_or(0, Encode::size)
+    }
+}
+
+impl Decode<'_> for NowDiagnostics {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        let endpoint_allocated = read_bool(src)?;
+        let connected = read_bool(src)?;
+        ensure_size!(in: src, size: 1);
+        let capabilities = match src.read_u8() {
+            0 => None,
+            1 => Some(NowCapabilities::decode(src)?),
+            _ => {
+                return Err(ironrdp_core::invalid_field_err!(
+                    "NOW capabilities",
+                    "invalid presence flag"
+                ));
+            }
+        };
+        Ok(Self {
+            endpoint_allocated,
+            connected,
+            capabilities,
+        })
+    }
+}
+
+impl_pdu_pod!(NowDiagnostics);
+
+#[cfg(test)]
+mod rdpei_request_tests {
+    use super::{
+        MAX_TOUCH_CONTACTS, MAX_TOUCH_FRAMES, TouchContactRequest, TouchFrameRequest, touch_event_from_request,
+    };
+    use ironrdp_rdpei::pdu::{EightByteUnsigned, FourByteSigned, FourByteUnsigned, TouchContactFlags};
 
     fn contact(flags: u16) -> TouchContactRequest {
         TouchContactRequest {
@@ -2665,109 +3095,3 @@ mod tests {
         );
     }
 }
-
-impl Encode for NowCapabilities {
-    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        ensure_size!(in: dst, size: self.size());
-        dst.write_u16(self.version_major);
-        dst.write_u16(self.version_minor);
-        write_opt_u64(dst, self.heartbeat_ms)?;
-        for value in [
-            self.run,
-            self.process,
-            self.batch,
-            self.powershell,
-            self.pwsh,
-            self.io_redirection,
-            self.unicode_console,
-        ] {
-            write_bool(dst, value)?;
-        }
-        Ok(())
-    }
-
-    fn name(&self) -> &'static str {
-        "ironrdp_rpc::ipc::NowCapabilities"
-    }
-
-    fn size(&self) -> usize {
-        2 /* version major */
-            + 2 /* version minor */
-            + opt_u64_size(self.heartbeat_ms)
-            + 7 /* feature flags */
-    }
-}
-
-impl Decode<'_> for NowCapabilities {
-    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
-        ensure_size!(in: src, size: 4);
-        let version_major = src.read_u16();
-        let version_minor = src.read_u16();
-        Ok(Self {
-            version_major,
-            version_minor,
-            heartbeat_ms: read_opt_u64(src)?,
-            run: read_bool(src)?,
-            process: read_bool(src)?,
-            batch: read_bool(src)?,
-            powershell: read_bool(src)?,
-            pwsh: read_bool(src)?,
-            io_redirection: read_bool(src)?,
-            unicode_console: read_bool(src)?,
-        })
-    }
-}
-
-impl_pdu_pod!(NowCapabilities);
-
-impl Encode for NowDiagnostics {
-    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        ensure_size!(in: dst, size: self.size());
-        write_bool(dst, self.endpoint_allocated)?;
-        write_bool(dst, self.connected)?;
-        match &self.capabilities {
-            Some(capabilities) => {
-                dst.write_u8(1);
-                capabilities.encode(dst)?;
-            }
-            None => dst.write_u8(0),
-        }
-        Ok(())
-    }
-
-    fn name(&self) -> &'static str {
-        "ironrdp_rpc::ipc::NowDiagnostics"
-    }
-
-    fn size(&self) -> usize {
-        1 /* endpoint_allocated */
-            + 1 /* connected */
-            + 1 /* capabilities presence */
-            + self.capabilities.as_ref().map_or(0, Encode::size)
-    }
-}
-
-impl Decode<'_> for NowDiagnostics {
-    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
-        let endpoint_allocated = read_bool(src)?;
-        let connected = read_bool(src)?;
-        ensure_size!(in: src, size: 1);
-        let capabilities = match src.read_u8() {
-            0 => None,
-            1 => Some(NowCapabilities::decode(src)?),
-            _ => {
-                return Err(ironrdp_core::invalid_field_err!(
-                    "NOW capabilities",
-                    "invalid presence flag"
-                ));
-            }
-        };
-        Ok(Self {
-            endpoint_allocated,
-            connected,
-            capabilities,
-        })
-    }
-}
-
-impl_pdu_pod!(NowDiagnostics);

--- a/crates/ironrdp-session/src/active_stage.rs
+++ b/crates/ironrdp-session/src/active_stage.rs
@@ -569,6 +569,36 @@ impl ActiveStage {
         None
     }
 
+    /// Encodes a pen event for the RDPEI dynamic channel.
+    ///
+    /// Returns `None` when the channel is unavailable, not ready, suspended, or pen is not allowed.
+    pub fn encode_rdpei_pen(&mut self, event: ironrdp_rdpei::pdu::PenEventPdu) -> Option<SessionResult<Vec<u8>>> {
+        if let Some(dvc) = self.get_dvc::<RdpeiClient>() {
+            let channel_id = dvc.channel_id();
+            let rdpei = dvc.processor();
+            if !rdpei.ready() {
+                debug!("Could not encode RDPEI pen: channel is not ready");
+                return None;
+            }
+            if rdpei.is_suspended() {
+                debug!("Could not encode RDPEI pen: input is suspended");
+                return None;
+            }
+            if !rdpei.pen_allowed() {
+                debug!("Could not encode RDPEI pen: pen not allowed for negotiated version");
+                return None;
+            }
+            let svc_messages = match rdpei.encode_pen_event(channel_id, event) {
+                Ok(messages) => messages,
+                Err(e) => return Some(Err(SessionError::encode(e))),
+            };
+            return Some(self.process_svc_processor_messages(SvcProcessorMessages::<DrdynvcClient>::new(svc_messages)));
+        } else {
+            debug!("Could not encode RDPEI pen: Input Virtual Channel is not available");
+        }
+        None
+    }
+
     pub fn encode_dvc_messages(&mut self, messages: Vec<SvcMessage>) -> SessionResult<Vec<u8>> {
         self.process_svc_processor_messages(SvcProcessorMessages::<DrdynvcClient>::new(messages))
     }

--- a/crates/ironrdp-testsuite-extra/tests/agent.rs
+++ b/crates/ironrdp-testsuite-extra/tests/agent.rs
@@ -105,7 +105,7 @@ fn request_variants_round_trip() {
             frames: vec![ironrdp_rpc::ipc::PenFrameRequest {
                 frame_offset: 0,
                 contacts: vec![ironrdp_rpc::ipc::PenContactRequest {
-                    device_id: 2,
+                    device_id: 0,
                     x: 300,
                     y: 400,
                     flags: 0x0019, // DOWN | INRANGE | INCONTACT

--- a/crates/ironrdp-testsuite-extra/tests/agent.rs
+++ b/crates/ironrdp-testsuite-extra/tests/agent.rs
@@ -100,6 +100,24 @@ fn request_variants_round_trip() {
                 }],
             }],
         },
+        Request::Pen {
+            encode_time: 24,
+            frames: vec![ironrdp_rpc::ipc::PenFrameRequest {
+                frame_offset: 0,
+                contacts: vec![ironrdp_rpc::ipc::PenContactRequest {
+                    device_id: 2,
+                    x: 300,
+                    y: 400,
+                    flags: 0x0019, // DOWN | INRANGE | INCONTACT
+                    pressure: Some(512),
+                    rotation: Some(45),
+                    tilt_x: Some(10),
+                    tilt_y: Some(-5),
+                    pen_flags: None,
+                }],
+            }],
+        },
+        Request::DismissHoveringTouchContact { contact_id: 3 },
         Request::NowCapabilities,
         Request::NowRun {
             command: "echo secret".to_owned(),


### PR DESCRIPTION
Extend the agent RPC path beyond single-contact touch so multi-contact frames, pen frames, and dismiss-hovering can be driven end-to-end against a real host.

Wire Pen/Dismiss through rpc, daemon, CLI, ActiveX control RPC, client input loop, and session encode helpers. Add pen contact flag legality checks and round-trip coverage.