### PR TITLE
feat(rdpdr): complete MS-RDPESC PDUs and native handles

### DIFF
--- a/crates/ironrdp-rdpdr/src/pdu/esc/mod.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/esc/mod.rs
@@ -25,17 +25,28 @@ use crate::pdu::esc::ndr::{Decode as _, Encode as _};
 pub enum ScardCall {
     AccessStartedEventCall(ScardAccessStartedEventCall),
     EstablishContextCall(EstablishContextCall),
+    ListReaderGroupsCall(ListReaderGroupsCall),
     ListReadersCall(ListReadersCall),
     GetStatusChangeCall(GetStatusChangeCall),
+    LocateCardsCall(LocateCardsCall),
+    LocateCardsByAtrCall(LocateCardsByAtrCall),
     ConnectCall(ConnectCall),
+    ReconnectCall(ReconnectCall),
     HCardAndDispositionCall(HCardAndDispositionCall),
     TransmitCall(TransmitCall),
     StatusCall(StatusCall),
+    StateCall(StateCall),
+    ControlCall(ControlCall),
+    GetAttribCall(GetAttribCall),
+    SetAttribCall(SetAttribCall),
+    GetTransmitCountCall(GetTransmitCountCall),
     ContextCall(ContextCall),
     GetDeviceTypeIdCall(GetDeviceTypeIdCall),
     ReadCacheCall(ReadCacheCall),
     WriteCacheCall(WriteCacheCall),
     GetReaderIconCall(GetReaderIconCall),
+    ContextAndStringCall(ContextAndStringCall),
+    ContextAndTwoStringCall(ContextAndTwoStringCall),
     Unsupported,
 }
 
@@ -46,6 +57,9 @@ impl ScardCall {
                 ScardAccessStartedEventCall::decode(src)?,
             )),
             ScardIoCtlCode::EstablishContext => Ok(ScardCall::EstablishContextCall(EstablishContextCall::decode(src)?)),
+            ScardIoCtlCode::ListReaderGroupsW | ScardIoCtlCode::ListReaderGroupsA => {
+                Ok(ScardCall::ListReaderGroupsCall(ListReaderGroupsCall::decode(src)?))
+            }
             ScardIoCtlCode::ListReadersW => Ok(ScardCall::ListReadersCall(ListReadersCall::decode(
                 src,
                 Some(CharacterSet::Unicode),
@@ -62,6 +76,22 @@ impl ScardCall {
                 src,
                 Some(CharacterSet::Ansi),
             )?)),
+            ScardIoCtlCode::LocateCardsW => Ok(ScardCall::LocateCardsCall(LocateCardsCall::decode(
+                src,
+                Some(CharacterSet::Unicode),
+            )?)),
+            ScardIoCtlCode::LocateCardsA => Ok(ScardCall::LocateCardsCall(LocateCardsCall::decode(
+                src,
+                Some(CharacterSet::Ansi),
+            )?)),
+            ScardIoCtlCode::LocateCardsByAtrW => Ok(ScardCall::LocateCardsByAtrCall(LocateCardsByAtrCall::decode(
+                src,
+                Some(CharacterSet::Unicode),
+            )?)),
+            ScardIoCtlCode::LocateCardsByAtrA => Ok(ScardCall::LocateCardsByAtrCall(LocateCardsByAtrCall::decode(
+                src,
+                Some(CharacterSet::Ansi),
+            )?)),
             ScardIoCtlCode::ConnectW => Ok(ScardCall::ConnectCall(ConnectCall::decode(
                 src,
                 Some(CharacterSet::Unicode),
@@ -70,11 +100,17 @@ impl ScardCall {
                 src,
                 Some(CharacterSet::Ansi),
             )?)),
+            ScardIoCtlCode::Reconnect => Ok(ScardCall::ReconnectCall(ReconnectCall::decode(src)?)),
             ScardIoCtlCode::BeginTransaction => Ok(ScardCall::HCardAndDispositionCall(
                 HCardAndDispositionCall::decode(src)?,
             )),
             ScardIoCtlCode::Transmit => Ok(ScardCall::TransmitCall(TransmitCall::decode(src)?)),
             ScardIoCtlCode::StatusW | ScardIoCtlCode::StatusA => Ok(ScardCall::StatusCall(StatusCall::decode(src)?)),
+            ScardIoCtlCode::State => Ok(ScardCall::StateCall(StateCall::decode(src)?)),
+            ScardIoCtlCode::Control => Ok(ScardCall::ControlCall(ControlCall::decode(src)?)),
+            ScardIoCtlCode::GetAttrib => Ok(ScardCall::GetAttribCall(GetAttribCall::decode(src)?)),
+            ScardIoCtlCode::SetAttrib => Ok(ScardCall::SetAttribCall(SetAttribCall::decode(src)?)),
+            ScardIoCtlCode::GetTransmitCount => Ok(ScardCall::GetTransmitCountCall(GetTransmitCountCall::decode(src)?)),
             ScardIoCtlCode::ReleaseContext => Ok(ScardCall::ContextCall(ContextCall::decode(src)?)),
             ScardIoCtlCode::EndTransaction => Ok(ScardCall::HCardAndDispositionCall(HCardAndDispositionCall::decode(
                 src,
@@ -102,6 +138,28 @@ impl ScardCall {
                 Some(CharacterSet::Ansi),
             )?)),
             ScardIoCtlCode::GetReaderIcon => Ok(ScardCall::GetReaderIconCall(GetReaderIconCall::decode(src)?)),
+            ScardIoCtlCode::IntroduceReaderGroupW
+            | ScardIoCtlCode::ForgetReaderGroupW
+            | ScardIoCtlCode::ForgetReaderW => Ok(ScardCall::ContextAndStringCall(ContextAndStringCall::decode(
+                src,
+                Some(CharacterSet::Unicode),
+            )?)),
+            ScardIoCtlCode::IntroduceReaderGroupA
+            | ScardIoCtlCode::ForgetReaderGroupA
+            | ScardIoCtlCode::ForgetReaderA => Ok(ScardCall::ContextAndStringCall(ContextAndStringCall::decode(
+                src,
+                Some(CharacterSet::Ansi),
+            )?)),
+            ScardIoCtlCode::IntroduceReaderW
+            | ScardIoCtlCode::AddReaderToGroupW
+            | ScardIoCtlCode::RemoveReaderFromGroupW => Ok(ScardCall::ContextAndTwoStringCall(
+                ContextAndTwoStringCall::decode(src, Some(CharacterSet::Unicode))?,
+            )),
+            ScardIoCtlCode::IntroduceReaderA
+            | ScardIoCtlCode::AddReaderToGroupA
+            | ScardIoCtlCode::RemoveReaderFromGroupA => Ok(ScardCall::ContextAndTwoStringCall(
+                ContextAndTwoStringCall::decode(src, Some(CharacterSet::Ansi))?,
+            )),
             _ => {
                 warn!(?io_ctl_code, "Unsupported ScardIoCtlCode");
                 // TODO: maybe this should be an error
@@ -113,32 +171,97 @@ impl ScardCall {
 
 /// [2.2.1.1] REDIR_SCARDCONTEXT
 ///
+/// Opaque client-owned context bytes. MS-RDPESC allows `cbContext` in `0..=16`;
+/// Windows clients commonly emit 4 (x86) or 8 (x64) native `SCARDCONTEXT` bytes.
+///
 /// [2.2.1.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/060abee1-e520-4149-9ef7-ce79eb500a59
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
 pub struct ScardContext {
-    /// Shortcut: we always create 4-byte context values.
-    /// The spec allows this field to have variable length.
-    pub value: u32,
+    /// Number of significant bytes in [`Self::bytes`] (`0`, `4`, or `8`).
+    len: u8,
+    /// Little-endian opaque context; only the first `len` bytes are on the wire.
+    bytes: [u8; 8],
 }
 
 impl ScardContext {
-    /// See [`ScardContext::value`]
-    const VALUE_LENGTH: u32 = 4;
-
+    /// Creates a 4-byte context value (legacy synthetic-id encoding).
     pub fn new(value: u32) -> Self {
-        Self { value }
+        let mut bytes = [0u8; 8];
+        bytes[..4].copy_from_slice(&value.to_le_bytes());
+        Self { len: 4, bytes }
+    }
+
+    /// Creates a context from a native WinSCard `SCARDCONTEXT` (`usize` width).
+    pub fn from_native(native: usize) -> Self {
+        Self::from_native_len(native, size_of::<usize>() as u8)
+    }
+
+    fn from_native_len(native: usize, len: u8) -> Self {
+        debug_assert!(matches!(len, 0 | 4 | 8));
+        let mut bytes = [0u8; 8];
+        let le = (native as u64).to_le_bytes();
+        let n = usize::from(len);
+        bytes[..n].copy_from_slice(&le[..n]);
+        Self { len, bytes }
+    }
+
+    /// Wire length of `pbContext`.
+    pub fn len(self) -> u8 {
+        self.len
+    }
+
+    pub fn is_empty(self) -> bool {
+        self.len == 0
+    }
+
+    /// Significant opaque bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes[..usize::from(self.len)]
+    }
+
+    /// First four little-endian bytes as `u32` (0 when empty).
+    pub fn value(self) -> u32 {
+        if self.len == 0 {
+            return 0;
+        }
+        let mut tmp = [0u8; 4];
+        let n = usize::from(self.len).min(4);
+        tmp[..n].copy_from_slice(&self.bytes[..n]);
+        u32::from_le_bytes(tmp)
+    }
+
+    /// Native `SCARDCONTEXT`-sized integer (little-endian, zero-extended).
+    pub fn native(self) -> usize {
+        let mut tmp = [0u8; 8];
+        let n = usize::from(self.len);
+        tmp[..n].copy_from_slice(&self.bytes[..n]);
+        u64::from_le_bytes(tmp) as usize
+    }
+
+    fn supported_len(length: u32) -> bool {
+        matches!(length, 0 | 4 | 8)
     }
 }
 
 impl ndr::Encode for ScardContext {
     fn encode_ptr(&self, index: &mut u32, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
-        ndr::encode_ptr(Some(Self::VALUE_LENGTH), index, dst)
+        // Empty context: cbContext=0 and NULL pointer (8 zero bytes), matching FreeRDP/mstscax.
+        if self.len == 0 {
+            ensure_size!(in: dst, size: ndr::ptr_size(true));
+            dst.write_u32(0);
+            dst.write_u32(0);
+            return Ok(());
+        }
+        ndr::encode_ptr(Some(u32::from(self.len)), index, dst)
     }
 
     fn encode_value(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        if self.len == 0 {
+            return Ok(());
+        }
         ensure_size!(in: dst, size: self.size_value());
-        dst.write_u32(Self::VALUE_LENGTH);
-        dst.write_u32(self.value);
+        dst.write_u32(u32::from(self.len));
+        dst.write_slice(self.as_bytes());
         Ok(())
     }
 
@@ -147,7 +270,11 @@ impl ndr::Encode for ScardContext {
     }
 
     fn size_value(&self) -> usize {
-        4 /* cbContext */ + 4 /* pbContext */
+        if self.len == 0 {
+            0
+        } else {
+            4 /* length */ + usize::from(self.len) /* pbContext */
+        }
     }
 }
 
@@ -158,7 +285,7 @@ impl ndr::Decode for ScardContext {
     {
         ensure_size!(in: src, size: size_of::<u32>());
         let length = src.read_u32();
-        if length != Self::VALUE_LENGTH {
+        if !Self::supported_len(length) {
             error!(?length, "Unsupported value length in ScardContext");
             return Err(invalid_field_err!(
                 "decode_ptr",
@@ -166,22 +293,36 @@ impl ndr::Decode for ScardContext {
             ));
         }
 
-        let _ptr = ndr::decode_ptr(src, index)?;
-        Ok(Self { value: 0 })
+        let ptr = ndr::decode_ptr(src, index)?;
+        if (length == 0) != (ptr == 0) {
+            return Err(invalid_field_err!(
+                "decode_ptr",
+                "ScardContext cbContext/pbContext inconsistency"
+            ));
+        }
+        Ok(Self {
+            len: length as u8,
+            bytes: [0; 8],
+        })
     }
 
     fn decode_value(&mut self, src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<()> {
         expect_no_charset(charset)?;
-        ensure_size!(in: src, size: size_of::<u32>() * 2);
+        if self.len == 0 {
+            return Ok(());
+        }
+        ensure_size!(in: src, size: size_of::<u32>());
         let length = src.read_u32();
-        if length != Self::VALUE_LENGTH {
-            error!(?length, "Unsupported value length in ScardContext");
+        if length != u32::from(self.len) {
+            error!(?length, expected = self.len, "ScardContext length mismatch");
             return Err(invalid_field_err!(
                 "decode_value",
-                "unsupported value length in ScardContext"
+                "ScardContext length mismatch"
             ));
         }
-        self.value = src.read_u32();
+        let n = usize::from(self.len);
+        ensure_size!(in: src, size: n);
+        self.bytes[..n].copy_from_slice(src.read_slice(n));
         Ok(())
     }
 }
@@ -910,6 +1051,196 @@ bitflags! {
     }
 }
 
+/// [2.2.1.4] LocateCards_ATRMask
+///
+/// [2.2.1.4]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
+#[derive(Debug, PartialEq, Clone)]
+pub struct LocateCardsAtrMask {
+    pub atr_length: u32,
+    pub atr: [u8; 36],
+    pub mask: [u8; 36],
+}
+
+impl LocateCardsAtrMask {
+    const FIXED_PART_SIZE: usize = 4 /* cbAtr */ + 36 /* rgbAtr */ + 36 /* rgbMask */;
+
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(in: src, size: Self::FIXED_PART_SIZE);
+        let atr_length = src.read_u32();
+        let atr = src.read_array::<36>();
+        let mask = src.read_array::<36>();
+        Ok(Self { atr_length, atr, mask })
+    }
+}
+
+/// [2.2.2.9] LocateCardsA_Call / [2.2.2.10] LocateCardsW_Call
+///
+/// [2.2.2.9]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
+/// [2.2.2.10]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
+#[derive(Debug, PartialEq, Clone)]
+pub struct LocateCardsCall {
+    pub context: ScardContext,
+    pub cards_ptr_length: u32,
+    pub cards_ptr: u32,
+    pub cards_length: u32,
+    pub cards: Vec<String>,
+    pub states_ptr_length: u32,
+    pub states_ptr: u32,
+    pub states_length: u32,
+    pub states: Vec<ReaderState>,
+}
+
+impl LocateCardsCall {
+    pub fn decode(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
+        Ok(rpce::Pdu::<Self>::decode(src, charset)?.into_inner())
+    }
+}
+
+impl rpce::HeaderlessDecode for LocateCardsCall {
+    fn headerless_decode(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
+        let charset = expect_charset(charset)?;
+        let mut index = 0;
+        let mut context = ScardContext::decode_ptr(src, &mut index)?;
+
+        ensure_size!(in: src, size: size_of::<u32>());
+        let cards_ptr_length = src.read_u32();
+        let cards_ptr = ndr::decode_ptr(src, &mut index)?;
+
+        ensure_size!(in: src, size: size_of::<u32>());
+        let states_ptr_length = src.read_u32();
+        let states_ptr = ndr::decode_ptr(src, &mut index)?;
+
+        context.decode_value(src, None)?;
+
+        let (cards_length, cards) = if cards_ptr == 0 {
+            (0, Vec::new())
+        } else {
+            ensure_size!(in: src, size: size_of::<u32>());
+            let cards_length = src.read_u32();
+            if cards_length != cards_ptr_length {
+                return Err(invalid_field_err!(
+                    "decode",
+                    "mismatched cards length in NDR pointer and value"
+                ));
+            }
+            let cards = read_multistring_from_cursor(src, charset)?;
+            (cards_length, cards)
+        };
+
+        let (states_length, states) = if states_ptr == 0 {
+            (0, Vec::new())
+        } else {
+            ensure_size!(in: src, size: size_of::<u32>());
+            let states_length = src.read_u32();
+            let mut states = Vec::with_capacity(states_length as usize);
+            for _ in 0..states_length {
+                states.push(ReaderState::decode_ptr(src, &mut index)?);
+            }
+            for state in states.iter_mut() {
+                state.decode_value(src, Some(charset))?;
+            }
+            (states_length, states)
+        };
+
+        Ok(Self {
+            context,
+            cards_ptr_length,
+            cards_ptr,
+            cards_length,
+            cards,
+            states_ptr_length,
+            states_ptr,
+            states_length,
+            states,
+        })
+    }
+}
+
+/// [2.2.2.23] LocateCardsByATRA_Call / [2.2.2.24] LocateCardsByATRW_Call
+///
+/// [2.2.2.23]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
+/// [2.2.2.24]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
+#[derive(Debug, PartialEq, Clone)]
+pub struct LocateCardsByAtrCall {
+    pub context: ScardContext,
+    pub atr_masks_ptr_length: u32,
+    pub atr_masks_ptr: u32,
+    pub atr_masks_length: u32,
+    pub atr_masks: Vec<LocateCardsAtrMask>,
+    pub states_ptr_length: u32,
+    pub states_ptr: u32,
+    pub states_length: u32,
+    pub states: Vec<ReaderState>,
+}
+
+impl LocateCardsByAtrCall {
+    pub fn decode(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
+        Ok(rpce::Pdu::<Self>::decode(src, charset)?.into_inner())
+    }
+}
+
+impl rpce::HeaderlessDecode for LocateCardsByAtrCall {
+    fn headerless_decode(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
+        let mut index = 0;
+        let mut context = ScardContext::decode_ptr(src, &mut index)?;
+
+        ensure_size!(in: src, size: size_of::<u32>());
+        let atr_masks_ptr_length = src.read_u32();
+        let atr_masks_ptr = ndr::decode_ptr(src, &mut index)?;
+
+        ensure_size!(in: src, size: size_of::<u32>());
+        let states_ptr_length = src.read_u32();
+        let states_ptr = ndr::decode_ptr(src, &mut index)?;
+
+        context.decode_value(src, None)?;
+
+        let (atr_masks_length, atr_masks) = if atr_masks_ptr == 0 {
+            (0, Vec::new())
+        } else {
+            ensure_size!(in: src, size: size_of::<u32>());
+            let atr_masks_length = src.read_u32();
+            if atr_masks_length != atr_masks_ptr_length {
+                return Err(invalid_field_err!(
+                    "decode",
+                    "mismatched ATR mask length in NDR pointer and value"
+                ));
+            }
+            let mut atr_masks = Vec::with_capacity(atr_masks_length as usize);
+            for _ in 0..atr_masks_length {
+                atr_masks.push(LocateCardsAtrMask::decode(src)?);
+            }
+            (atr_masks_length, atr_masks)
+        };
+
+        let (states_length, states) = if states_ptr == 0 {
+            (0, Vec::new())
+        } else {
+            ensure_size!(in: src, size: size_of::<u32>());
+            let states_length = src.read_u32();
+            let mut states = Vec::with_capacity(states_length as usize);
+            for _ in 0..states_length {
+                states.push(ReaderState::decode_ptr(src, &mut index)?);
+            }
+            for state in states.iter_mut() {
+                state.decode_value(src, charset)?;
+            }
+            (states_length, states)
+        };
+
+        Ok(Self {
+            context,
+            atr_masks_ptr_length,
+            atr_masks_ptr,
+            atr_masks_length,
+            atr_masks,
+            states_ptr_length,
+            states_ptr,
+            states_length,
+            states,
+        })
+    }
+}
+
 /// [2.2.3.5] LocateCards_Return and GetStatusChange_Return
 ///
 /// [2.2.3.5]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/7b73e0c2-e0fc-46b1-9b03-50684ad2beba
@@ -1035,21 +1366,76 @@ bitflags! {
 
 /// [2.2.1.2] REDIR_SCARDHANDLE
 ///
+/// Reader handle associated with a [`ScardContext`]. Like the context, `cbHandle`
+/// is typically 4 or 8 bytes (native `SCARDHANDLE` width).
+///
 /// [2.2.1.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/b6276356-7c5f-4d3e-be92-a6c85e58d008
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub struct ScardHandle {
     pub context: ScardContext,
-    /// Shortcut: we always create 4-byte handle values.
-    /// The spec allows this field to have variable length.
-    pub value: u32,
+    /// Number of significant bytes in [`Self::bytes`] (`0`, `4`, or `8`).
+    len: u8,
+    /// Little-endian opaque handle; only the first `len` bytes are on the wire.
+    bytes: [u8; 8],
 }
 
 impl ScardHandle {
-    /// See [`ScardHandle::value`]
-    const VALUE_LENGTH: u32 = 4;
-
+    /// Creates a 4-byte handle value (legacy synthetic-id encoding).
     pub fn new(context: ScardContext, value: u32) -> Self {
-        Self { context, value }
+        let mut bytes = [0u8; 8];
+        bytes[..4].copy_from_slice(&value.to_le_bytes());
+        Self {
+            context,
+            len: 4,
+            bytes,
+        }
+    }
+
+    /// Creates a handle from a native WinSCard `SCARDHANDLE` (`usize` width).
+    pub fn from_native(context: ScardContext, native: usize) -> Self {
+        let mut bytes = [0u8; 8];
+        let le = (native as u64).to_le_bytes();
+        let len = size_of::<usize>() as u8;
+        let n = usize::from(len);
+        bytes[..n].copy_from_slice(&le[..n]);
+        Self { context, len, bytes }
+    }
+
+    /// Wire length of `pbHandle`.
+    pub fn len(self) -> u8 {
+        self.len
+    }
+
+    pub fn is_empty(self) -> bool {
+        self.len == 0
+    }
+
+    /// Significant opaque bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes[..usize::from(self.len)]
+    }
+
+    /// First four little-endian bytes as `u32` (0 when empty).
+    pub fn value(self) -> u32 {
+        if self.len == 0 {
+            return 0;
+        }
+        let mut tmp = [0u8; 4];
+        let n = usize::from(self.len).min(4);
+        tmp[..n].copy_from_slice(&self.bytes[..n]);
+        u32::from_le_bytes(tmp)
+    }
+
+    /// Native `SCARDHANDLE`-sized integer (little-endian, zero-extended).
+    pub fn native(self) -> usize {
+        let mut tmp = [0u8; 8];
+        let n = usize::from(self.len);
+        tmp[..n].copy_from_slice(&self.bytes[..n]);
+        u64::from_le_bytes(tmp) as usize
+    }
+
+    fn supported_len(length: u32) -> bool {
+        matches!(length, 0 | 4 | 8)
     }
 }
 
@@ -1061,31 +1447,45 @@ impl ndr::Decode for ScardHandle {
         let context = ScardContext::decode_ptr(src, index)?;
         ensure_size!(ctx: "ScardHandle::decode_ptr", in: src, size: size_of::<u32>());
         let length = src.read_u32();
-        if length != Self::VALUE_LENGTH {
+        if !Self::supported_len(length) {
             error!(?length, "Unsupported value length in ScardHandle");
             return Err(invalid_field_err!(
                 "decode_ptr",
                 "unsupported value length in ScardHandle"
             ));
         }
-        let _ptr = ndr::decode_ptr(src, index)?;
-        Ok(Self { context, value: 0 })
+        let ptr = ndr::decode_ptr(src, index)?;
+        if (length == 0) != (ptr == 0) {
+            return Err(invalid_field_err!(
+                "decode_ptr",
+                "ScardHandle cbHandle/pbHandle inconsistency"
+            ));
+        }
+        Ok(Self {
+            context,
+            len: length as u8,
+            bytes: [0; 8],
+        })
     }
 
     fn decode_value(&mut self, src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<()> {
         expect_no_charset(charset)?;
         self.context.decode_value(src, None)?;
-        ensure_size!(in: src, size: size_of::<u32>());
-        let length = src.read_u32();
-        if length != Self::VALUE_LENGTH {
-            error!(?length, "Unsupported value length in ScardHandle");
-            return Err(invalid_field_err!(
-                "decode_value",
-                "unsupported value length in ScardHandle"
-            ));
+        if self.len == 0 {
+            return Ok(());
         }
         ensure_size!(in: src, size: size_of::<u32>());
-        self.value = src.read_u32();
+        let length = src.read_u32();
+        if length != u32::from(self.len) {
+            error!(?length, expected = self.len, "ScardHandle length mismatch");
+            return Err(invalid_field_err!(
+                "decode_value",
+                "ScardHandle length mismatch"
+            ));
+        }
+        let n = usize::from(self.len);
+        ensure_size!(in: src, size: n);
+        self.bytes[..n].copy_from_slice(src.read_slice(n));
         Ok(())
     }
 }
@@ -1093,15 +1493,24 @@ impl ndr::Decode for ScardHandle {
 impl ndr::Encode for ScardHandle {
     fn encode_ptr(&self, index: &mut u32, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         self.context.encode_ptr(index, dst)?;
-        ndr::encode_ptr(Some(Self::VALUE_LENGTH), index, dst)?;
+        if self.len == 0 {
+            ensure_size!(in: dst, size: ndr::ptr_size(true));
+            dst.write_u32(0);
+            dst.write_u32(0);
+            return Ok(());
+        }
+        ndr::encode_ptr(Some(u32::from(self.len)), index, dst)?;
         Ok(())
     }
 
     fn encode_value(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         ensure_size!(in: dst, size: self.size_value());
         self.context.encode_value(dst)?;
-        dst.write_u32(Self::VALUE_LENGTH);
-        dst.write_u32(self.value);
+        if self.len == 0 {
+            return Ok(());
+        }
+        dst.write_u32(u32::from(self.len));
+        dst.write_slice(self.as_bytes());
         Ok(())
     }
 
@@ -1110,7 +1519,12 @@ impl ndr::Encode for ScardHandle {
     }
 
     fn size_value(&self) -> usize {
-        self.context.size_value() + 4 /* cbHandle */ + 4 /* pbHandle */
+        let handle_value = if self.len == 0 {
+            0
+        } else {
+            4 /* length */ + usize::from(self.len) /* pbHandle */
+        };
+        self.context.size_value() + handle_value
     }
 }
 
@@ -1779,6 +2193,69 @@ impl ndr::Decode for WriteCacheCommon {
     }
 }
 
+/// [2.2.2.5] ContextAndStringA_Call / [2.2.2.6] ContextAndStringW_Call
+///
+/// Used by IntroduceReaderGroup, ForgetReaderGroup, and ForgetReader.
+///
+/// [2.2.2.5]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/a130c3df-016c-4ca1-b85e-ad450fa4fe6d
+/// [2.2.2.6]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/a42d07cc-b37b-4fe4-9df9-2ba6320d72fa
+#[derive(Debug, PartialEq, Clone)]
+pub struct ContextAndStringCall {
+    pub context: ScardContext,
+    pub sz: String,
+}
+
+impl ContextAndStringCall {
+    pub fn decode(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
+        Ok(rpce::Pdu::<Self>::decode(src, charset)?.into_inner())
+    }
+}
+
+impl rpce::HeaderlessDecode for ContextAndStringCall {
+    fn headerless_decode(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
+        let charset = expect_charset(charset)?;
+        let mut index = 0;
+        let mut context = ScardContext::decode_ptr(src, &mut index)?;
+        let _sz_ptr = ndr::decode_ptr(src, &mut index)?;
+        context.decode_value(src, None)?;
+        let sz = ndr::read_string_from_cursor(src, charset)?;
+        Ok(Self { context, sz })
+    }
+}
+
+/// [2.2.2.7] ContextAndTwoStringA_Call / [2.2.2.8] ContextAndTwoStringW_Call
+///
+/// Used by IntroduceReader, AddReaderToGroup, and RemoveReaderFromGroup.
+///
+/// [2.2.2.7]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/9ce7270c-aad5-46f7-8a10-941cb94b57f5
+/// [2.2.2.8]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/34bec62b-b75c-4729-adb2-f6033484fe6b
+#[derive(Debug, PartialEq, Clone)]
+pub struct ContextAndTwoStringCall {
+    pub context: ScardContext,
+    pub sz1: String,
+    pub sz2: String,
+}
+
+impl ContextAndTwoStringCall {
+    pub fn decode(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
+        Ok(rpce::Pdu::<Self>::decode(src, charset)?.into_inner())
+    }
+}
+
+impl rpce::HeaderlessDecode for ContextAndTwoStringCall {
+    fn headerless_decode(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
+        let charset = expect_charset(charset)?;
+        let mut index = 0;
+        let mut context = ScardContext::decode_ptr(src, &mut index)?;
+        let _sz1_ptr = ndr::decode_ptr(src, &mut index)?;
+        let _sz2_ptr = ndr::decode_ptr(src, &mut index)?;
+        context.decode_value(src, None)?;
+        let sz1 = ndr::read_string_from_cursor(src, charset)?;
+        let sz2 = ndr::read_string_from_cursor(src, charset)?;
+        Ok(Self { context, sz1, sz2 })
+    }
+}
+
 /// [2.2.2.31] GetReaderIcon_Call
 ///
 /// [2.2.2.31]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/e6a68d90-697f-4b98-8ad6-f74853d27ccb
@@ -1849,6 +2326,464 @@ impl rpce::HeaderlessEncode for GetReaderIconReturn {
     }
 }
 
+/// [2.2.2.3] ListReaderGroups_Call
+///
+/// [2.2.2.3]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/2f3f1b0f-0d0c-4f4c-8f2e-5f4f0e0f0e0f
+#[derive(Debug, PartialEq, Clone)]
+pub struct ListReaderGroupsCall {
+    pub context: ScardContext,
+    pub groups_is_null: bool,
+    pub groups_size: u32,
+}
+
+impl ListReaderGroupsCall {
+    pub fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        Ok(rpce::Pdu::<Self>::decode(src, None)?.into_inner())
+    }
+}
+
+impl rpce::HeaderlessDecode for ListReaderGroupsCall {
+    fn headerless_decode(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
+        expect_no_charset(charset)?;
+        let mut index = 0;
+        let mut context = ScardContext::decode_ptr(src, &mut index)?;
+        ensure_size!(in: src, size: size_of::<u32>() * 2);
+        let groups_is_null = src.read_u32() == 0x0000_0001;
+        let groups_size = src.read_u32();
+        context.decode_value(src, None)?;
+        Ok(Self {
+            context,
+            groups_is_null,
+            groups_size,
+        })
+    }
+}
+
+/// [2.2.2.15] Reconnect_Call
+///
+/// [2.2.2.15]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/ad9fbc8e-0963-44ac-8d71-38021685790c
+#[derive(Debug, PartialEq, Clone)]
+pub struct ReconnectCall {
+    pub handle: ScardHandle,
+    pub share_mode: u32,
+    pub preferred_protocols: CardProtocol,
+    pub initialization: u32,
+}
+
+impl ReconnectCall {
+    pub fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        Ok(rpce::Pdu::<Self>::decode(src, None)?.into_inner())
+    }
+}
+
+impl rpce::HeaderlessDecode for ReconnectCall {
+    fn headerless_decode(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
+        expect_no_charset(charset)?;
+        let mut index = 0;
+        let mut handle = ScardHandle::decode_ptr(src, &mut index)?;
+        ensure_size!(in: src, size: size_of::<u32>() * 3);
+        let share_mode = src.read_u32();
+        let preferred_protocols = CardProtocol::from_bits_retain(src.read_u32());
+        let initialization = src.read_u32();
+        handle.decode_value(src, None)?;
+        Ok(Self {
+            handle,
+            share_mode,
+            preferred_protocols,
+            initialization,
+        })
+    }
+}
+
+/// [2.2.3.7] Reconnect_Return
+///
+/// [2.2.3.7]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
+#[derive(Debug, PartialEq, Clone)]
+pub struct ReconnectReturn {
+    pub return_code: ReturnCode,
+    pub active_protocol: CardProtocol,
+}
+
+impl ReconnectReturn {
+    const NAME: &'static str = "Reconnect_Return";
+
+    pub fn new(return_code: ReturnCode, active_protocol: CardProtocol) -> rpce::Pdu<Self> {
+        rpce::Pdu(Self {
+            return_code,
+            active_protocol,
+        })
+    }
+}
+
+impl rpce::HeaderlessEncode for ReconnectReturn {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u32(self.return_code.into());
+        dst.write_u32(self.active_protocol.bits());
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        self.return_code.size() + 4 /* dwActiveProtocol */
+    }
+}
+
+/// [2.2.2.17] State_Call
+///
+/// [2.2.2.17]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
+#[derive(Debug, PartialEq, Clone)]
+pub struct StateCall {
+    pub handle: ScardHandle,
+    pub atr_is_null: bool,
+    pub atr_length: u32,
+}
+
+impl StateCall {
+    pub fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        Ok(rpce::Pdu::<Self>::decode(src, None)?.into_inner())
+    }
+}
+
+impl rpce::HeaderlessDecode for StateCall {
+    fn headerless_decode(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
+        expect_no_charset(charset)?;
+        let mut index = 0;
+        let mut handle = ScardHandle::decode_ptr(src, &mut index)?;
+        ensure_size!(in: src, size: size_of::<u32>() * 2);
+        let atr_is_null = src.read_u32() == 0x0000_0001;
+        let atr_length = src.read_u32();
+        handle.decode_value(src, None)?;
+        Ok(Self {
+            handle,
+            atr_is_null,
+            atr_length,
+        })
+    }
+}
+
+/// [2.2.3.9] State_Return
+///
+/// [2.2.3.9]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
+#[derive(Debug, PartialEq, Clone)]
+pub struct StateReturn {
+    pub return_code: ReturnCode,
+    pub state: CardState,
+    pub protocol: CardProtocol,
+    pub atr: Vec<u8>,
+}
+
+impl StateReturn {
+    const NAME: &'static str = "State_Return";
+
+    pub fn new(return_code: ReturnCode, state: CardState, protocol: CardProtocol, atr: Vec<u8>) -> rpce::Pdu<Self> {
+        rpce::Pdu(Self {
+            return_code,
+            state,
+            protocol,
+            atr,
+        })
+    }
+}
+
+impl rpce::HeaderlessEncode for StateReturn {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u32(self.return_code.into());
+        dst.write_u32(self.state.into());
+        dst.write_u32(self.protocol.bits());
+        let atr_len: u32 = cast_length!("StateReturn", "atr_len", self.atr.len())?;
+        let mut index = 0;
+        ndr::encode_ptr(Some(atr_len), &mut index, dst)?;
+        dst.write_u32(atr_len);
+        dst.write_slice(&self.atr);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        self.return_code.size()
+            + 4 /* dwState */
+            + 4 /* dwProtocol */
+            + ndr::ptr_size(true)
+            + 4 /* cbAtrLen value */
+            + self.atr.len()
+    }
+}
+
+/// [2.2.2.20] Control_Call
+///
+/// [2.2.2.20]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
+#[derive(Debug, PartialEq, Clone)]
+pub struct ControlCall {
+    pub handle: ScardHandle,
+    pub control_code: u32,
+    pub in_buffer: Vec<u8>,
+    pub out_buffer_is_null: bool,
+    pub out_buffer_size: u32,
+}
+
+impl ControlCall {
+    pub fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        Ok(rpce::Pdu::<Self>::decode(src, None)?.into_inner())
+    }
+}
+
+impl rpce::HeaderlessDecode for ControlCall {
+    fn headerless_decode(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
+        expect_no_charset(charset)?;
+        let mut index = 0;
+        let mut handle = ScardHandle::decode_ptr(src, &mut index)?;
+        ensure_size!(in: src, size: size_of::<u32>() * 2);
+        let control_code = src.read_u32();
+        let _in_buffer_len = src.read_u32();
+        let in_buffer_ptr = ndr::decode_ptr(src, &mut index)?;
+        ensure_size!(in: src, size: size_of::<u32>() * 2);
+        let out_buffer_is_null = src.read_u32() == 0x0000_0001;
+        let out_buffer_size = src.read_u32();
+        handle.decode_value(src, None)?;
+
+        let in_buffer = if in_buffer_ptr != 0 {
+            ensure_size!(in: src, size: size_of::<u32>());
+            let in_len: usize = cast_length!("ControlCall", "in_buffer_len", src.read_u32())?;
+            ensure_size!(in: src, size: in_len);
+            src.read_slice(in_len).to_vec()
+        } else {
+            Vec::new()
+        };
+
+        Ok(Self {
+            handle,
+            control_code,
+            in_buffer,
+            out_buffer_is_null,
+            out_buffer_size,
+        })
+    }
+}
+
+/// [2.2.3.6] Control_Return
+///
+/// [2.2.3.6]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
+#[derive(Debug, PartialEq, Clone)]
+pub struct ControlReturn {
+    pub return_code: ReturnCode,
+    pub out_buffer: Vec<u8>,
+}
+
+impl ControlReturn {
+    const NAME: &'static str = "Control_Return";
+
+    pub fn new(return_code: ReturnCode, out_buffer: Vec<u8>) -> rpce::Pdu<Self> {
+        rpce::Pdu(Self {
+            return_code,
+            out_buffer,
+        })
+    }
+}
+
+impl rpce::HeaderlessEncode for ControlReturn {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u32(self.return_code.into());
+        let data_len: u32 = cast_length!("ControlReturn", "out_buffer_len", self.out_buffer.len())?;
+        let mut index = 0;
+        ndr::encode_ptr(Some(data_len), &mut index, dst)?;
+        dst.write_u32(data_len);
+        dst.write_slice(&self.out_buffer);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        self.return_code.size() + ndr::ptr_size(true) + 4 + self.out_buffer.len()
+    }
+}
+
+/// [2.2.2.21] GetAttrib_Call
+///
+/// [2.2.2.21]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
+#[derive(Debug, PartialEq, Clone)]
+pub struct GetAttribCall {
+    pub handle: ScardHandle,
+    pub attr_id: u32,
+    pub attr_is_null: bool,
+    pub attr_length: u32,
+}
+
+impl GetAttribCall {
+    pub fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        Ok(rpce::Pdu::<Self>::decode(src, None)?.into_inner())
+    }
+}
+
+impl rpce::HeaderlessDecode for GetAttribCall {
+    fn headerless_decode(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
+        expect_no_charset(charset)?;
+        let mut index = 0;
+        let mut handle = ScardHandle::decode_ptr(src, &mut index)?;
+        ensure_size!(in: src, size: size_of::<u32>() * 3);
+        let attr_id = src.read_u32();
+        let attr_is_null = src.read_u32() == 0x0000_0001;
+        let attr_length = src.read_u32();
+        handle.decode_value(src, None)?;
+        Ok(Self {
+            handle,
+            attr_id,
+            attr_is_null,
+            attr_length,
+        })
+    }
+}
+
+/// [2.2.3.12] GetAttrib_Return
+///
+/// [2.2.3.12]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
+#[derive(Debug, PartialEq, Clone)]
+pub struct GetAttribReturn {
+    pub return_code: ReturnCode,
+    pub attr: Vec<u8>,
+}
+
+impl GetAttribReturn {
+    const NAME: &'static str = "GetAttrib_Return";
+
+    pub fn new(return_code: ReturnCode, attr: Vec<u8>) -> rpce::Pdu<Self> {
+        rpce::Pdu(Self { return_code, attr })
+    }
+}
+
+impl rpce::HeaderlessEncode for GetAttribReturn {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u32(self.return_code.into());
+        let data_len: u32 = cast_length!("GetAttribReturn", "attr_len", self.attr.len())?;
+        let mut index = 0;
+        ndr::encode_ptr(Some(data_len), &mut index, dst)?;
+        dst.write_u32(data_len);
+        dst.write_slice(&self.attr);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        self.return_code.size() + ndr::ptr_size(true) + 4 + self.attr.len()
+    }
+}
+
+/// [2.2.2.22] SetAttrib_Call
+///
+/// [2.2.2.22]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
+#[derive(Debug, PartialEq, Clone)]
+pub struct SetAttribCall {
+    pub handle: ScardHandle,
+    pub attr_id: u32,
+    pub attr: Vec<u8>,
+}
+
+impl SetAttribCall {
+    pub fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        Ok(rpce::Pdu::<Self>::decode(src, None)?.into_inner())
+    }
+}
+
+impl rpce::HeaderlessDecode for SetAttribCall {
+    fn headerless_decode(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
+        expect_no_charset(charset)?;
+        let mut index = 0;
+        let mut handle = ScardHandle::decode_ptr(src, &mut index)?;
+        ensure_size!(in: src, size: size_of::<u32>() * 2);
+        let attr_id = src.read_u32();
+        let _attr_len = src.read_u32();
+        let attr_ptr = ndr::decode_ptr(src, &mut index)?;
+        handle.decode_value(src, None)?;
+
+        let attr = if attr_ptr != 0 {
+            ensure_size!(in: src, size: size_of::<u32>());
+            let attr_len: usize = cast_length!("SetAttribCall", "attr_len", src.read_u32())?;
+            ensure_size!(in: src, size: attr_len);
+            src.read_slice(attr_len).to_vec()
+        } else {
+            Vec::new()
+        };
+
+        Ok(Self { handle, attr_id, attr })
+    }
+}
+
+/// [2.2.2.29] GetTransmitCount_Call
+///
+/// [2.2.2.29]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
+#[derive(Debug, PartialEq, Clone)]
+pub struct GetTransmitCountCall {
+    pub handle: ScardHandle,
+}
+
+impl GetTransmitCountCall {
+    pub fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        Ok(rpce::Pdu::<Self>::decode(src, None)?.into_inner())
+    }
+}
+
+impl rpce::HeaderlessDecode for GetTransmitCountCall {
+    fn headerless_decode(src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<Self> {
+        expect_no_charset(charset)?;
+        let mut index = 0;
+        let mut handle = ScardHandle::decode_ptr(src, &mut index)?;
+        handle.decode_value(src, None)?;
+        Ok(Self { handle })
+    }
+}
+
+/// [2.2.3.13] GetTransmitCount_Return
+///
+/// [2.2.3.13]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
+#[derive(Debug, PartialEq, Clone)]
+pub struct GetTransmitCountReturn {
+    pub return_code: ReturnCode,
+    pub transmit_count: u32,
+}
+
+impl GetTransmitCountReturn {
+    const NAME: &'static str = "GetTransmitCount_Return";
+
+    pub fn new(return_code: ReturnCode, transmit_count: u32) -> rpce::Pdu<Self> {
+        rpce::Pdu(Self {
+            return_code,
+            transmit_count,
+        })
+    }
+}
+
+impl rpce::HeaderlessEncode for GetTransmitCountReturn {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u32(self.return_code.into());
+        dst.write_u32(self.transmit_count);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        self.return_code.size() + 4 /* cTransmitCount */
+    }
+}
+
 fn expect_charset(charset: Option<CharacterSet>) -> DecodeResult<CharacterSet> {
     charset.ok_or_else(|| other_err!("internal error: missing character set"))
 }
@@ -1860,4 +2795,91 @@ fn expect_no_charset(charset: Option<CharacterSet>) -> DecodeResult<()> {
         ));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pdu::esc::ndr::{Decode as NdrDecode, Encode as NdrEncode};
+    use crate::pdu::esc::rpce::HeaderlessEncode;
+
+    fn roundtrip_context(ctx: ScardContext) -> ScardContext {
+        let mut buf = vec![0u8; ctx.size()];
+        {
+            let mut dst = WriteCursor::new(&mut buf);
+            let mut index = 0;
+            ctx.encode_ptr(&mut index, &mut dst).unwrap();
+            ctx.encode_value(&mut dst).unwrap();
+            assert_eq!(dst.pos(), ctx.size());
+        }
+        let mut src = ReadCursor::new(&buf);
+        let mut index = 0;
+        let mut decoded = ScardContext::decode_ptr(&mut src, &mut index).unwrap();
+        decoded.decode_value(&mut src, None).unwrap();
+        assert_eq!(src.pos(), buf.len());
+        decoded
+    }
+
+    fn roundtrip_handle(handle: ScardHandle) -> ScardHandle {
+        let mut buf = vec![0u8; handle.size()];
+        {
+            let mut dst = WriteCursor::new(&mut buf);
+            let mut index = 0;
+            handle.encode_ptr(&mut index, &mut dst).unwrap();
+            handle.encode_value(&mut dst).unwrap();
+            assert_eq!(dst.pos(), handle.size());
+        }
+        let mut src = ReadCursor::new(&buf);
+        let mut index = 0;
+        let mut decoded = ScardHandle::decode_ptr(&mut src, &mut index).unwrap();
+        decoded.decode_value(&mut src, None).unwrap();
+        assert_eq!(src.pos(), buf.len());
+        decoded
+    }
+
+    #[test]
+    fn scard_context_roundtrip_4_and_8_byte() {
+        let c4 = ScardContext::new(0xA1B2_C3D4);
+        assert_eq!(c4.len(), 4);
+        assert_eq!(roundtrip_context(c4), c4);
+        assert_eq!(c4.value(), 0xA1B2_C3D4);
+        assert_eq!(c4.native() as u32, 0xA1B2_C3D4);
+
+        let native = 0x0123_4567_89AB_CDEFusize;
+        let c8 = ScardContext::from_native_len(native, 8);
+        assert_eq!(c8.len(), 8);
+        assert_eq!(roundtrip_context(c8), c8);
+        assert_eq!(c8.native(), native);
+        assert_eq!(c8.value(), 0x89AB_CDEFu32);
+
+        let empty = ScardContext::from_native_len(0, 0);
+        assert!(empty.is_empty());
+        assert_eq!(roundtrip_context(empty), empty);
+    }
+
+    #[test]
+    fn scard_handle_roundtrip_4_and_8_byte() {
+        let ctx = ScardContext::new(0x1111_2222);
+        let h4 = ScardHandle::new(ctx, 0x3333_4444);
+        assert_eq!(h4.len(), 4);
+        assert_eq!(roundtrip_handle(h4), h4);
+
+        let ctx8 = ScardContext::from_native_len(0xAAAA_BBBBusize, 8);
+        let h8 = ScardHandle::from_native(ctx8, 0xCCCC_DDDD_EEEE_FFFFusize);
+        assert_eq!(h8.len(), size_of::<usize>() as u8);
+        assert_eq!(roundtrip_handle(h8), h8);
+        assert_eq!(h8.native(), 0xCCCC_DDDD_EEEE_FFFFusize);
+    }
+
+    #[test]
+    fn establish_context_return_size_uses_native_width() {
+        let ctx = ScardContext::from_native(0x42);
+        assert_eq!(ctx.len() as usize, size_of::<usize>());
+        // Headerless body: ReturnCode(4) + cbContext(4) + ptr(4) + length(4) + bytes(native width).
+        let body = EstablishContextReturn {
+            return_code: ReturnCode::Success,
+            context: ctx,
+        };
+        assert_eq!(HeaderlessEncode::size(&body), 4 + 4 + 4 + 4 + size_of::<usize>());
+    }
 }

--- a/crates/ironrdp-rdpdr/src/pdu/esc/mod.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/esc/mod.rs
@@ -315,10 +315,7 @@ impl ndr::Decode for ScardContext {
         let length = src.read_u32();
         if length != u32::from(self.len) {
             error!(?length, expected = self.len, "ScardContext length mismatch");
-            return Err(invalid_field_err!(
-                "decode_value",
-                "ScardContext length mismatch"
-            ));
+            return Err(invalid_field_err!("decode_value", "ScardContext length mismatch"));
         }
         let n = usize::from(self.len);
         ensure_size!(in: src, size: n);
@@ -1384,11 +1381,7 @@ impl ScardHandle {
     pub fn new(context: ScardContext, value: u32) -> Self {
         let mut bytes = [0u8; 8];
         bytes[..4].copy_from_slice(&value.to_le_bytes());
-        Self {
-            context,
-            len: 4,
-            bytes,
-        }
+        Self { context, len: 4, bytes }
     }
 
     /// Creates a handle from a native WinSCard `SCARDHANDLE` (`usize` width).
@@ -1478,10 +1471,7 @@ impl ndr::Decode for ScardHandle {
         let length = src.read_u32();
         if length != u32::from(self.len) {
             error!(?length, expected = self.len, "ScardHandle length mismatch");
-            return Err(invalid_field_err!(
-                "decode_value",
-                "ScardHandle length mismatch"
-            ));
+            return Err(invalid_field_err!("decode_value", "ScardHandle length mismatch"));
         }
         let n = usize::from(self.len);
         ensure_size!(in: src, size: n);

--- a/crates/ironrdp-rdpdr/src/pdu/esc/mod.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/esc/mod.rs
@@ -169,6 +169,47 @@ impl ScardCall {
     }
 }
 
+/// Native WinSCard handle/context width on this target (`4` or `8`).
+#[cfg(target_pointer_width = "32")]
+const fn native_scard_len() -> u8 {
+    4
+}
+
+/// Native WinSCard handle/context width on this target (`4` or `8`).
+#[cfg(target_pointer_width = "64")]
+const fn native_scard_len() -> u8 {
+    8
+}
+
+fn scard_wire_len(length: u32) -> DecodeResult<u8> {
+    match length {
+        0 => Ok(0),
+        4 => Ok(4),
+        8 => Ok(8),
+        _ => Err(invalid_field_err!(
+            "decode_ptr",
+            "unsupported value length for SCARDCONTEXT/SCARDHANDLE"
+        )),
+    }
+}
+
+fn write_native_le_bytes(native: usize, len: u8, bytes: &mut [u8; 8]) {
+    debug_assert!(matches!(len, 0 | 4 | 8));
+    // Zero-extend native into 8 LE bytes, then keep the first `len` of them.
+    let mut le = [0u8; 8];
+    let native_bytes = native.to_le_bytes();
+    le[..native_bytes.len()].copy_from_slice(&native_bytes);
+    let n = usize::from(len);
+    bytes[..n].copy_from_slice(&le[..n]);
+}
+
+fn read_native_le_bytes(bytes: &[u8; 8], len: u8) -> usize {
+    let mut tmp = [0u8; size_of::<usize>()];
+    let n = usize::from(len).min(size_of::<usize>());
+    tmp[..n].copy_from_slice(&bytes[..n]);
+    usize::from_le_bytes(tmp)
+}
+
 /// [2.2.1.1] REDIR_SCARDCONTEXT
 ///
 /// Opaque client-owned context bytes. MS-RDPESC allows `cbContext` in `0..=16`;
@@ -193,15 +234,12 @@ impl ScardContext {
 
     /// Creates a context from a native WinSCard `SCARDCONTEXT` (`usize` width).
     pub fn from_native(native: usize) -> Self {
-        Self::from_native_len(native, size_of::<usize>() as u8)
+        Self::from_native_len(native, native_scard_len())
     }
 
     fn from_native_len(native: usize, len: u8) -> Self {
-        debug_assert!(matches!(len, 0 | 4 | 8));
         let mut bytes = [0u8; 8];
-        let le = (native as u64).to_le_bytes();
-        let n = usize::from(len);
-        bytes[..n].copy_from_slice(&le[..n]);
+        write_native_le_bytes(native, len, &mut bytes);
         Self { len, bytes }
     }
 
@@ -232,14 +270,7 @@ impl ScardContext {
 
     /// Native `SCARDCONTEXT`-sized integer (little-endian, zero-extended).
     pub fn native(self) -> usize {
-        let mut tmp = [0u8; 8];
-        let n = usize::from(self.len);
-        tmp[..n].copy_from_slice(&self.bytes[..n]);
-        u64::from_le_bytes(tmp) as usize
-    }
-
-    fn supported_len(length: u32) -> bool {
-        matches!(length, 0 | 4 | 8)
+        read_native_le_bytes(&self.bytes, self.len)
     }
 }
 
@@ -285,13 +316,13 @@ impl ndr::Decode for ScardContext {
     {
         ensure_size!(in: src, size: size_of::<u32>());
         let length = src.read_u32();
-        if !Self::supported_len(length) {
-            error!(?length, "Unsupported value length in ScardContext");
-            return Err(invalid_field_err!(
-                "decode_ptr",
-                "unsupported value length in ScardContext"
-            ));
-        }
+        let len = match scard_wire_len(length) {
+            Ok(len) => len,
+            Err(err) => {
+                error!(?length, "Unsupported value length in ScardContext");
+                return Err(err);
+            }
+        };
 
         let ptr = ndr::decode_ptr(src, index)?;
         if (length == 0) != (ptr == 0) {
@@ -301,7 +332,7 @@ impl ndr::Decode for ScardContext {
             ));
         }
         Ok(Self {
-            len: length as u8,
+            len,
             bytes: [0; 8],
         })
     }
@@ -1129,7 +1160,7 @@ impl rpce::HeaderlessDecode for LocateCardsCall {
         } else {
             ensure_size!(in: src, size: size_of::<u32>());
             let states_length = src.read_u32();
-            let mut states = Vec::with_capacity(states_length as usize);
+            let mut states = Vec::new();
             for _ in 0..states_length {
                 states.push(ReaderState::decode_ptr(src, &mut index)?);
             }
@@ -1202,7 +1233,7 @@ impl rpce::HeaderlessDecode for LocateCardsByAtrCall {
                     "mismatched ATR mask length in NDR pointer and value"
                 ));
             }
-            let mut atr_masks = Vec::with_capacity(atr_masks_length as usize);
+            let mut atr_masks = Vec::new();
             for _ in 0..atr_masks_length {
                 atr_masks.push(LocateCardsAtrMask::decode(src)?);
             }
@@ -1214,7 +1245,7 @@ impl rpce::HeaderlessDecode for LocateCardsByAtrCall {
         } else {
             ensure_size!(in: src, size: size_of::<u32>());
             let states_length = src.read_u32();
-            let mut states = Vec::with_capacity(states_length as usize);
+            let mut states = Vec::new();
             for _ in 0..states_length {
                 states.push(ReaderState::decode_ptr(src, &mut index)?);
             }
@@ -1369,7 +1400,7 @@ bitflags! {
 /// [2.2.1.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/b6276356-7c5f-4d3e-be92-a6c85e58d008
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub struct ScardHandle {
-    pub context: ScardContext,
+    context: ScardContext,
     /// Number of significant bytes in [`Self::bytes`] (`0`, `4`, or `8`).
     len: u8,
     /// Little-endian opaque handle; only the first `len` bytes are on the wire.
@@ -1387,11 +1418,14 @@ impl ScardHandle {
     /// Creates a handle from a native WinSCard `SCARDHANDLE` (`usize` width).
     pub fn from_native(context: ScardContext, native: usize) -> Self {
         let mut bytes = [0u8; 8];
-        let le = (native as u64).to_le_bytes();
-        let len = size_of::<usize>() as u8;
-        let n = usize::from(len);
-        bytes[..n].copy_from_slice(&le[..n]);
+        let len = native_scard_len();
+        write_native_le_bytes(native, len, &mut bytes);
         Self { context, len, bytes }
+    }
+
+    /// Context that owns this handle.
+    pub fn context(self) -> ScardContext {
+        self.context
     }
 
     /// Wire length of `pbHandle`.
@@ -1421,14 +1455,7 @@ impl ScardHandle {
 
     /// Native `SCARDHANDLE`-sized integer (little-endian, zero-extended).
     pub fn native(self) -> usize {
-        let mut tmp = [0u8; 8];
-        let n = usize::from(self.len);
-        tmp[..n].copy_from_slice(&self.bytes[..n]);
-        u64::from_le_bytes(tmp) as usize
-    }
-
-    fn supported_len(length: u32) -> bool {
-        matches!(length, 0 | 4 | 8)
+        read_native_le_bytes(&self.bytes, self.len)
     }
 }
 
@@ -1440,13 +1467,13 @@ impl ndr::Decode for ScardHandle {
         let context = ScardContext::decode_ptr(src, index)?;
         ensure_size!(ctx: "ScardHandle::decode_ptr", in: src, size: size_of::<u32>());
         let length = src.read_u32();
-        if !Self::supported_len(length) {
-            error!(?length, "Unsupported value length in ScardHandle");
-            return Err(invalid_field_err!(
-                "decode_ptr",
-                "unsupported value length in ScardHandle"
-            ));
-        }
+        let len = match scard_wire_len(length) {
+            Ok(len) => len,
+            Err(err) => {
+                error!(?length, "Unsupported value length in ScardHandle");
+                return Err(err);
+            }
+        };
         let ptr = ndr::decode_ptr(src, index)?;
         if (length == 0) != (ptr == 0) {
             return Err(invalid_field_err!(
@@ -1456,7 +1483,7 @@ impl ndr::Decode for ScardHandle {
         }
         Ok(Self {
             context,
-            len: length as u8,
+            len,
             bytes: [0; 8],
         })
     }
@@ -2790,7 +2817,6 @@ fn expect_no_charset(charset: Option<CharacterSet>) -> DecodeResult<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pdu::esc::ndr::{Decode as NdrDecode, Encode as NdrEncode};
     use crate::pdu::esc::rpce::HeaderlessEncode;
 
     fn roundtrip_context(ctx: ScardContext) -> ScardContext {
@@ -2833,7 +2859,7 @@ mod tests {
         assert_eq!(c4.len(), 4);
         assert_eq!(roundtrip_context(c4), c4);
         assert_eq!(c4.value(), 0xA1B2_C3D4);
-        assert_eq!(c4.native() as u32, 0xA1B2_C3D4);
+        assert_eq!(c4.native(), usize::try_from(0xA1B2_C3D4u32).unwrap());
 
         let native = 0x0123_4567_89AB_CDEFusize;
         let c8 = ScardContext::from_native_len(native, 8);
@@ -2852,11 +2878,12 @@ mod tests {
         let ctx = ScardContext::new(0x1111_2222);
         let h4 = ScardHandle::new(ctx, 0x3333_4444);
         assert_eq!(h4.len(), 4);
+        assert_eq!(h4.context(), ctx);
         assert_eq!(roundtrip_handle(h4), h4);
 
         let ctx8 = ScardContext::from_native_len(0xAAAA_BBBBusize, 8);
         let h8 = ScardHandle::from_native(ctx8, 0xCCCC_DDDD_EEEE_FFFFusize);
-        assert_eq!(h8.len(), size_of::<usize>() as u8);
+        assert_eq!(h8.len(), native_scard_len());
         assert_eq!(roundtrip_handle(h8), h8);
         assert_eq!(h8.native(), 0xCCCC_DDDD_EEEE_FFFFusize);
     }
@@ -2864,7 +2891,7 @@ mod tests {
     #[test]
     fn establish_context_return_size_uses_native_width() {
         let ctx = ScardContext::from_native(0x42);
-        assert_eq!(ctx.len() as usize, size_of::<usize>());
+        assert_eq!(usize::from(ctx.len()), size_of::<usize>());
         // Headerless body: ReturnCode(4) + cbContext(4) + ptr(4) + length(4) + bytes(native width).
         let body = EstablishContextReturn {
             return_code: ReturnCode::Success,

--- a/crates/ironrdp-rdpdr/src/pdu/esc/mod.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/esc/mod.rs
@@ -331,10 +331,7 @@ impl ndr::Decode for ScardContext {
                 "ScardContext cbContext/pbContext inconsistency"
             ));
         }
-        Ok(Self {
-            len,
-            bytes: [0; 8],
-        })
+        Ok(Self { len, bytes: [0; 8] })
     }
 
     fn decode_value(&mut self, src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<()> {

--- a/crates/ironrdp-rdpdr/src/pdu/esc/mod.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/esc/mod.rs
@@ -2970,12 +2970,27 @@ mod tests {
         let h16 = ScardHandle::from_opaque(ctx, &opaque).unwrap();
         assert_eq!(roundtrip_handle(h16).as_bytes(), &opaque);
         assert!(ScardHandle::from_opaque(ctx, &[0; 17]).is_err());
+    }
 
-        let body = EstablishContextReturn {
-            return_code: ReturnCode::Success,
-            context: ScardContext::from_native(0x42),
-        };
-        assert_eq!(HeaderlessEncode::size(&body), 4 + 4 + 4 + 4 + size_of::<usize>());
+    /// `::new` 4-byte EstablishContext/Connect returns stay byte-identical to master.
+    #[test]
+    fn legacy_four_byte_return_encode_matches_master() {
+        fn enc(body: &impl HeaderlessEncode) -> Vec<u8> {
+            let mut buf = vec![0u8; HeaderlessEncode::size(body)];
+            HeaderlessEncode::encode(body, &mut WriteCursor::new(&mut buf)).unwrap();
+            buf
+        }
+        let est = EstablishContextReturn::new(ReturnCode::Success, ScardContext::new(0xA1B2_C3D4)).into_inner();
+        assert_eq!(enc(&est), [0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 2, 0, 4, 0, 0, 0, 0xD4, 0xC3, 0xB2, 0xA1]);
+        let h = ScardHandle::new(ScardContext::new(0x1111_2222), 0x3333_4444);
+        let conn = ConnectReturn::new(ReturnCode::Success, h, CardProtocol::SCARD_PROTOCOL_T0).into_inner();
+        assert_eq!(
+            enc(&conn),
+            [
+                0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 2, 0, 4, 0, 0, 0, 4, 0, 2, 0, 1, 0, 0, 0, 4, 0, 0, 0, 0x22, 0x22, 0x11,
+                0x11, 4, 0, 0, 0, 0x44, 0x44, 0x33, 0x33,
+            ]
+        );
     }
 
     /// 6-byte Unicode mszCards needs 2-byte NDR pad before reader states.

--- a/crates/ironrdp-rdpdr/src/pdu/esc/mod.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/esc/mod.rs
@@ -181,29 +181,31 @@ const fn native_scard_len() -> u8 {
     8
 }
 
+/// MS-RDPESC `cbContext` / `cbHandle` maximum (`range(0,16)`).
+const SCARD_OPAQUE_MAX_LEN: u32 = 16;
+
 fn scard_wire_len(length: u32) -> DecodeResult<u8> {
-    match length {
-        0 => Ok(0),
-        4 => Ok(4),
-        8 => Ok(8),
-        _ => Err(invalid_field_err!(
+    if length > SCARD_OPAQUE_MAX_LEN {
+        return Err(invalid_field_err!(
             "decode_ptr",
-            "unsupported value length for SCARDCONTEXT/SCARDHANDLE"
-        )),
+            "cbContext/cbHandle exceeds MS-RDPESC range 0..=16"
+        ));
     }
+    // INVARIANT: length <= 16 fits in u8.
+    Ok(u8::try_from(length).expect("length <= 16 fits in u8"))
 }
 
-fn write_native_le_bytes(native: usize, len: u8, bytes: &mut [u8; 8]) {
+fn write_native_le_bytes(native: usize, len: u8, bytes: &mut [u8; 16]) {
     debug_assert!(matches!(len, 0 | 4 | 8));
-    // Zero-extend native into 8 LE bytes, then keep the first `len` of them.
-    let mut le = [0u8; 8];
+    // Zero-extend native into LE bytes, then keep the first `len` of them.
+    let mut le = [0u8; 16];
     let native_bytes = native.to_le_bytes();
     le[..native_bytes.len()].copy_from_slice(&native_bytes);
     let n = usize::from(len);
     bytes[..n].copy_from_slice(&le[..n]);
 }
 
-fn read_native_le_bytes(bytes: &[u8; 8], len: u8) -> usize {
+fn read_native_le_bytes(bytes: &[u8; 16], len: u8) -> usize {
     let mut tmp = [0u8; size_of::<usize>()];
     let n = usize::from(len).min(size_of::<usize>());
     tmp[..n].copy_from_slice(&bytes[..n]);
@@ -218,16 +220,16 @@ fn read_native_le_bytes(bytes: &[u8; 8], len: u8) -> usize {
 /// [2.2.1.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/060abee1-e520-4149-9ef7-ce79eb500a59
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
 pub struct ScardContext {
-    /// Number of significant bytes in [`Self::bytes`] (`0`, `4`, or `8`).
+    /// Number of significant bytes in [`Self::bytes`] (`0..=16`).
     len: u8,
-    /// Little-endian opaque context; only the first `len` bytes are on the wire.
-    bytes: [u8; 8],
+    /// Opaque context; only the first `len` bytes are on the wire.
+    bytes: [u8; 16],
 }
 
 impl ScardContext {
     /// Creates a 4-byte context value (legacy synthetic-id encoding).
     pub fn new(value: u32) -> Self {
-        let mut bytes = [0u8; 8];
+        let mut bytes = [0u8; 16];
         bytes[..4].copy_from_slice(&value.to_le_bytes());
         Self { len: 4, bytes }
     }
@@ -237,8 +239,16 @@ impl ScardContext {
         Self::from_native_len(native, native_scard_len())
     }
 
+    /// Creates a context from opaque wire bytes (`0..=16`).
+    pub fn from_opaque(opaque: &[u8]) -> DecodeResult<Self> {
+        let len = scard_wire_len(u32::try_from(opaque.len()).unwrap_or(u32::MAX))?;
+        let mut bytes = [0u8; 16];
+        bytes[..opaque.len()].copy_from_slice(opaque);
+        Ok(Self { len, bytes })
+    }
+
     fn from_native_len(native: usize, len: u8) -> Self {
-        let mut bytes = [0u8; 8];
+        let mut bytes = [0u8; 16];
         write_native_le_bytes(native, len, &mut bytes);
         Self { len, bytes }
     }
@@ -268,7 +278,9 @@ impl ScardContext {
         u32::from_le_bytes(tmp)
     }
 
-    /// Native `SCARDCONTEXT`-sized integer (little-endian, zero-extended).
+    /// Convenience view of the first `size_of::<usize>()` LE bytes as a native integer.
+    ///
+    /// Useful for 4- and 8-byte Windows `SCARDCONTEXT` values; longer opaque blobs are truncated.
     pub fn native(self) -> usize {
         read_native_le_bytes(&self.bytes, self.len)
     }
@@ -331,7 +343,7 @@ impl ndr::Decode for ScardContext {
                 "ScardContext cbContext/pbContext inconsistency"
             ));
         }
-        Ok(Self { len, bytes: [0; 8] })
+        Ok(Self { len, bytes: [0; 16] })
     }
 
     fn decode_value(&mut self, src: &mut ReadCursor<'_>, charset: Option<CharacterSet>) -> DecodeResult<()> {
@@ -1078,7 +1090,7 @@ bitflags! {
 
 /// [2.2.1.4] LocateCards_ATRMask
 ///
-/// [2.2.1.4]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
+/// [2.2.1.4]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/479fe1cf-eaf0-4d51-8964-d4195a61f573
 #[derive(Debug, PartialEq, Clone)]
 pub struct LocateCardsAtrMask {
     pub atr_length: u32,
@@ -1092,6 +1104,13 @@ impl LocateCardsAtrMask {
     fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
         ensure_size!(in: src, size: Self::FIXED_PART_SIZE);
         let atr_length = src.read_u32();
+        // MS-RDPESC: cbAtr range(0,36)
+        if atr_length > 36 {
+            return Err(invalid_field_err!(
+                "decode",
+                "LocateCards_ATRMask cbAtr exceeds range 0..=36"
+            ));
+        }
         let atr = src.read_array::<36>();
         let mask = src.read_array::<36>();
         Ok(Self { atr_length, atr, mask })
@@ -1100,8 +1119,8 @@ impl LocateCardsAtrMask {
 
 /// [2.2.2.9] LocateCardsA_Call / [2.2.2.10] LocateCardsW_Call
 ///
-/// [2.2.2.9]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
-/// [2.2.2.10]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
+/// [2.2.2.9]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/c6b49a98-99e6-43c0-af63-56e4918814f3
+/// [2.2.2.10]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/c40fb671-6a50-4ae1-b75d-f44b25612eb2
 #[derive(Debug, PartialEq, Clone)]
 pub struct LocateCardsCall {
     pub context: ScardContext,
@@ -1148,7 +1167,22 @@ impl rpce::HeaderlessDecode for LocateCardsCall {
                     "mismatched cards length in NDR pointer and value"
                 ));
             }
-            let cards = read_multistring_from_cursor(src, charset)?;
+            // MS-RDPESC: cBytes range(0, 65536)
+            if cards_length > 65_536 {
+                return Err(invalid_field_err!(
+                    "decode",
+                    "LocateCards cBytes exceeds range 0..=65536"
+                ));
+            }
+            let cards_len: usize = cast_length!("LocateCardsCall", "cards_length", cards_length)?;
+            ensure_size!(in: src, size: cards_len);
+            // Limit the multistring parser to the declared byte count so it cannot
+            // consume subsequent NDR fields (for example reader states).
+            let mut cards_src = ReadCursor::new(src.read_slice(cards_len));
+            let cards = read_multistring_from_cursor(&mut cards_src, charset)?;
+            // Conformant byte arrays are followed by padding to a 4-byte boundary
+            // before the next NDR field (FreeRDP smartcard_pack / MS-RPCE).
+            ndr::skip_pad(src)?;
             (cards_length, cards)
         };
 
@@ -1157,6 +1191,19 @@ impl rpce::HeaderlessDecode for LocateCardsCall {
         } else {
             ensure_size!(in: src, size: size_of::<u32>());
             let states_length = src.read_u32();
+            // MS-RDPESC: cReaders range(0,10)
+            if states_length > 10 {
+                return Err(invalid_field_err!(
+                    "decode",
+                    "LocateCards cReaders exceeds range 0..=10"
+                ));
+            }
+            if states_length != states_ptr_length {
+                return Err(invalid_field_err!(
+                    "decode",
+                    "mismatched states length in NDR pointer and value"
+                ));
+            }
             let mut states = Vec::new();
             for _ in 0..states_length {
                 states.push(ReaderState::decode_ptr(src, &mut index)?);
@@ -1183,8 +1230,8 @@ impl rpce::HeaderlessDecode for LocateCardsCall {
 
 /// [2.2.2.23] LocateCardsByATRA_Call / [2.2.2.24] LocateCardsByATRW_Call
 ///
-/// [2.2.2.23]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
-/// [2.2.2.24]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
+/// [2.2.2.23]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/100a5cc6-cb6a-4f90-b0e4-659b872c26d5
+/// [2.2.2.24]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/c934cc70-c1c9-4193-8b1b-038d8055c000
 #[derive(Debug, PartialEq, Clone)]
 pub struct LocateCardsByAtrCall {
     pub context: ScardContext,
@@ -1230,6 +1277,13 @@ impl rpce::HeaderlessDecode for LocateCardsByAtrCall {
                     "mismatched ATR mask length in NDR pointer and value"
                 ));
             }
+            // MS-RDPESC: cAtrs range(0,1000)
+            if atr_masks_length > 1000 {
+                return Err(invalid_field_err!(
+                    "decode",
+                    "LocateCardsByATR cAtrs exceeds range 0..=1000"
+                ));
+            }
             let mut atr_masks = Vec::new();
             for _ in 0..atr_masks_length {
                 atr_masks.push(LocateCardsAtrMask::decode(src)?);
@@ -1242,6 +1296,19 @@ impl rpce::HeaderlessDecode for LocateCardsByAtrCall {
         } else {
             ensure_size!(in: src, size: size_of::<u32>());
             let states_length = src.read_u32();
+            // MS-RDPESC: cReaders range(0,10)
+            if states_length > 10 {
+                return Err(invalid_field_err!(
+                    "decode",
+                    "LocateCardsByATR cReaders exceeds range 0..=10"
+                ));
+            }
+            if states_length != states_ptr_length {
+                return Err(invalid_field_err!(
+                    "decode",
+                    "mismatched states length in NDR pointer and value"
+                ));
+            }
             let mut states = Vec::new();
             for _ in 0..states_length {
                 states.push(ReaderState::decode_ptr(src, &mut index)?);
@@ -1391,33 +1458,41 @@ bitflags! {
 
 /// [2.2.1.2] REDIR_SCARDHANDLE
 ///
-/// Reader handle associated with a [`ScardContext`]. Like the context, `cbHandle`
-/// is typically 4 or 8 bytes (native `SCARDHANDLE` width).
+/// Reader handle associated with a [`ScardContext`]. MS-RDPESC allows `cbHandle`
+/// in `0..=16`; Windows clients commonly emit 4 or 8 native `SCARDHANDLE` bytes.
 ///
 /// [2.2.1.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/b6276356-7c5f-4d3e-be92-a6c85e58d008
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub struct ScardHandle {
     context: ScardContext,
-    /// Number of significant bytes in [`Self::bytes`] (`0`, `4`, or `8`).
+    /// Number of significant bytes in [`Self::bytes`] (`0..=16`).
     len: u8,
-    /// Little-endian opaque handle; only the first `len` bytes are on the wire.
-    bytes: [u8; 8],
+    /// Opaque handle; only the first `len` bytes are on the wire.
+    bytes: [u8; 16],
 }
 
 impl ScardHandle {
     /// Creates a 4-byte handle value (legacy synthetic-id encoding).
     pub fn new(context: ScardContext, value: u32) -> Self {
-        let mut bytes = [0u8; 8];
+        let mut bytes = [0u8; 16];
         bytes[..4].copy_from_slice(&value.to_le_bytes());
         Self { context, len: 4, bytes }
     }
 
     /// Creates a handle from a native WinSCard `SCARDHANDLE` (`usize` width).
     pub fn from_native(context: ScardContext, native: usize) -> Self {
-        let mut bytes = [0u8; 8];
+        let mut bytes = [0u8; 16];
         let len = native_scard_len();
         write_native_le_bytes(native, len, &mut bytes);
         Self { context, len, bytes }
+    }
+
+    /// Creates a handle from opaque wire bytes (`0..=16`).
+    pub fn from_opaque(context: ScardContext, opaque: &[u8]) -> DecodeResult<Self> {
+        let len = scard_wire_len(u32::try_from(opaque.len()).unwrap_or(u32::MAX))?;
+        let mut bytes = [0u8; 16];
+        bytes[..opaque.len()].copy_from_slice(opaque);
+        Ok(Self { context, len, bytes })
     }
 
     /// Context that owns this handle.
@@ -1450,7 +1525,9 @@ impl ScardHandle {
         u32::from_le_bytes(tmp)
     }
 
-    /// Native `SCARDHANDLE`-sized integer (little-endian, zero-extended).
+    /// Convenience view of the first `size_of::<usize>()` LE bytes as a native integer.
+    ///
+    /// Useful for 4- and 8-byte Windows `SCARDHANDLE` values; longer opaque blobs are truncated.
     pub fn native(self) -> usize {
         read_native_le_bytes(&self.bytes, self.len)
     }
@@ -1481,7 +1558,7 @@ impl ndr::Decode for ScardHandle {
         Ok(Self {
             context,
             len,
-            bytes: [0; 8],
+            bytes: [0; 16],
         })
     }
 
@@ -2342,7 +2419,7 @@ impl rpce::HeaderlessEncode for GetReaderIconReturn {
 
 /// [2.2.2.3] ListReaderGroups_Call
 ///
-/// [2.2.2.3]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/2f3f1b0f-0d0c-4f4c-8f2e-5f4f0e0f0e0f
+/// [2.2.2.3]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/dde8c811-c258-444f-8028-98311a9e0082
 #[derive(Debug, PartialEq, Clone)]
 pub struct ListReaderGroupsCall {
     pub context: ScardContext,
@@ -2375,7 +2452,7 @@ impl rpce::HeaderlessDecode for ListReaderGroupsCall {
 
 /// [2.2.2.15] Reconnect_Call
 ///
-/// [2.2.2.15]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/ad9fbc8e-0963-44ac-8d71-38021685790c
+/// [2.2.2.15]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/9c1eca52-3a99-403c-8ac8-6437f246a154
 #[derive(Debug, PartialEq, Clone)]
 pub struct ReconnectCall {
     pub handle: ScardHandle,
@@ -2411,7 +2488,7 @@ impl rpce::HeaderlessDecode for ReconnectCall {
 
 /// [2.2.3.7] Reconnect_Return
 ///
-/// [2.2.3.7]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
+/// [2.2.3.7]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/e25a583f-ab82-4ba3-bebf-af656c58e6d8
 #[derive(Debug, PartialEq, Clone)]
 pub struct ReconnectReturn {
     pub return_code: ReturnCode,
@@ -2448,7 +2525,7 @@ impl rpce::HeaderlessEncode for ReconnectReturn {
 
 /// [2.2.2.17] State_Call
 ///
-/// [2.2.2.17]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
+/// [2.2.2.17]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/ba3b9097-02fe-4f6b-951c-05439a7d9da7
 #[derive(Debug, PartialEq, Clone)]
 pub struct StateCall {
     pub handle: ScardHandle,
@@ -2481,7 +2558,7 @@ impl rpce::HeaderlessDecode for StateCall {
 
 /// [2.2.3.9] State_Return
 ///
-/// [2.2.3.9]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
+/// [2.2.3.9]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/574e5ec5-96ba-4b11-bfa9-52eb34307356
 #[derive(Debug, PartialEq, Clone)]
 pub struct StateReturn {
     pub return_code: ReturnCode,
@@ -2533,7 +2610,7 @@ impl rpce::HeaderlessEncode for StateReturn {
 
 /// [2.2.2.20] Control_Call
 ///
-/// [2.2.2.20]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
+/// [2.2.2.20]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/002fc3a3-2ca2-492e-8463-aba8f3923e48
 #[derive(Debug, PartialEq, Clone)]
 pub struct ControlCall {
     pub handle: ScardHandle,
@@ -2556,7 +2633,14 @@ impl rpce::HeaderlessDecode for ControlCall {
         let mut handle = ScardHandle::decode_ptr(src, &mut index)?;
         ensure_size!(in: src, size: size_of::<u32>() * 2);
         let control_code = src.read_u32();
-        let _in_buffer_len = src.read_u32();
+        // MS-RDPESC: cbInBufferSize range(0,66560)
+        let in_buffer_len = src.read_u32();
+        if in_buffer_len > 66_560 {
+            return Err(invalid_field_err!(
+                "decode",
+                "Control cbInBufferSize exceeds range 0..=66560"
+            ));
+        }
         let in_buffer_ptr = ndr::decode_ptr(src, &mut index)?;
         ensure_size!(in: src, size: size_of::<u32>() * 2);
         let out_buffer_is_null = src.read_u32() == 0x0000_0001;
@@ -2565,9 +2649,21 @@ impl rpce::HeaderlessDecode for ControlCall {
 
         let in_buffer = if in_buffer_ptr != 0 {
             ensure_size!(in: src, size: size_of::<u32>());
-            let in_len: usize = cast_length!("ControlCall", "in_buffer_len", src.read_u32())?;
+            let referent_len = src.read_u32();
+            if referent_len != in_buffer_len {
+                return Err(invalid_field_err!(
+                    "decode",
+                    "mismatched Control in-buffer length in NDR pointer and value"
+                ));
+            }
+            let in_len: usize = cast_length!("ControlCall", "in_buffer_len", referent_len)?;
             ensure_size!(in: src, size: in_len);
             src.read_slice(in_len).to_vec()
+        } else if in_buffer_len != 0 {
+            return Err(invalid_field_err!(
+                "decode",
+                "Control cbInBufferSize/pvInBuffer inconsistency"
+            ));
         } else {
             Vec::new()
         };
@@ -2584,7 +2680,7 @@ impl rpce::HeaderlessDecode for ControlCall {
 
 /// [2.2.3.6] Control_Return
 ///
-/// [2.2.3.6]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
+/// [2.2.3.6]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/e7e854f8-0c5a-4814-bfdd-b72cb8aefe3e
 #[derive(Debug, PartialEq, Clone)]
 pub struct ControlReturn {
     pub return_code: ReturnCode,
@@ -2619,13 +2715,16 @@ impl rpce::HeaderlessEncode for ControlReturn {
     }
 
     fn size(&self) -> usize {
-        self.return_code.size() + ndr::ptr_size(true) + 4 + self.out_buffer.len()
+        self.return_code.size()
+            + ndr::ptr_size(true)
+            + 4 /* cbOutBufferSize value */
+            + self.out_buffer.len() // pvOutBuffer
     }
 }
 
 /// [2.2.2.21] GetAttrib_Call
 ///
-/// [2.2.2.21]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
+/// [2.2.2.21]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/f4e36ff1-e7b3-4046-bddb-cd192a76c7ab
 #[derive(Debug, PartialEq, Clone)]
 pub struct GetAttribCall {
     pub handle: ScardHandle,
@@ -2661,7 +2760,7 @@ impl rpce::HeaderlessDecode for GetAttribCall {
 
 /// [2.2.3.12] GetAttrib_Return
 ///
-/// [2.2.3.12]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
+/// [2.2.3.12]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/ab3ac071-3fc5-44e6-9b94-c1eee1168266
 #[derive(Debug, PartialEq, Clone)]
 pub struct GetAttribReturn {
     pub return_code: ReturnCode,
@@ -2693,13 +2792,16 @@ impl rpce::HeaderlessEncode for GetAttribReturn {
     }
 
     fn size(&self) -> usize {
-        self.return_code.size() + ndr::ptr_size(true) + 4 + self.attr.len()
+        self.return_code.size()
+            + ndr::ptr_size(true)
+            + 4 /* cbAttrLen value */
+            + self.attr.len() // pbAttr
     }
 }
 
 /// [2.2.2.22] SetAttrib_Call
 ///
-/// [2.2.2.22]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
+/// [2.2.2.22]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/28f8dd60-35b7-45fb-ab75-15bbf81f5d11
 #[derive(Debug, PartialEq, Clone)]
 pub struct SetAttribCall {
     pub handle: ScardHandle,
@@ -2720,15 +2822,31 @@ impl rpce::HeaderlessDecode for SetAttribCall {
         let mut handle = ScardHandle::decode_ptr(src, &mut index)?;
         ensure_size!(in: src, size: size_of::<u32>() * 2);
         let attr_id = src.read_u32();
-        let _attr_len = src.read_u32();
+        // MS-RDPESC: cbAttrLen range(0,65536)
+        let attr_len = src.read_u32();
+        if attr_len > 65_536 {
+            return Err(invalid_field_err!(
+                "decode",
+                "SetAttrib cbAttrLen exceeds range 0..=65536"
+            ));
+        }
         let attr_ptr = ndr::decode_ptr(src, &mut index)?;
         handle.decode_value(src, None)?;
 
         let attr = if attr_ptr != 0 {
             ensure_size!(in: src, size: size_of::<u32>());
-            let attr_len: usize = cast_length!("SetAttribCall", "attr_len", src.read_u32())?;
+            let referent_len = src.read_u32();
+            if referent_len != attr_len {
+                return Err(invalid_field_err!(
+                    "decode",
+                    "mismatched SetAttrib attr length in NDR pointer and value"
+                ));
+            }
+            let attr_len: usize = cast_length!("SetAttribCall", "attr_len", referent_len)?;
             ensure_size!(in: src, size: attr_len);
             src.read_slice(attr_len).to_vec()
+        } else if attr_len != 0 {
+            return Err(invalid_field_err!("decode", "SetAttrib cbAttrLen/pbAttr inconsistency"));
         } else {
             Vec::new()
         };
@@ -2739,7 +2857,7 @@ impl rpce::HeaderlessDecode for SetAttribCall {
 
 /// [2.2.2.29] GetTransmitCount_Call
 ///
-/// [2.2.2.29]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
+/// [2.2.2.29]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/f453f1b4-1291-4c69-8e97-f781b2d8e66f
 #[derive(Debug, PartialEq, Clone)]
 pub struct GetTransmitCountCall {
     pub handle: ScardHandle,
@@ -2763,7 +2881,7 @@ impl rpce::HeaderlessDecode for GetTransmitCountCall {
 
 /// [2.2.3.13] GetTransmitCount_Return
 ///
-/// [2.2.3.13]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/
+/// [2.2.3.13]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpesc/32aea1d7-0edb-4807-bbd1-a6ee1fbb0087
 #[derive(Debug, PartialEq, Clone)]
 pub struct GetTransmitCountReturn {
     pub return_code: ReturnCode,
@@ -2871,6 +2989,18 @@ mod tests {
     }
 
     #[test]
+    fn scard_context_roundtrip_16_byte_opaque() {
+        let opaque = [
+            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF,
+        ];
+        let c16 = ScardContext::from_opaque(&opaque).unwrap();
+        assert_eq!(c16.len(), 16);
+        assert_eq!(c16.as_bytes(), &opaque);
+        assert_eq!(roundtrip_context(c16), c16);
+        assert!(ScardContext::from_opaque(&[0; 17]).is_err());
+    }
+
+    #[test]
     fn scard_handle_roundtrip_4_and_8_byte() {
         let ctx = ScardContext::new(0x1111_2222);
         let h4 = ScardHandle::new(ctx, 0x3333_4444);
@@ -2886,6 +3016,19 @@ mod tests {
     }
 
     #[test]
+    fn scard_handle_roundtrip_16_byte_opaque() {
+        let ctx = ScardContext::from_opaque(&[1, 2, 3, 4, 5, 6]).unwrap();
+        let opaque = [
+            0xF0, 0xE1, 0xD2, 0xC3, 0xB4, 0xA5, 0x96, 0x87, 0x78, 0x69, 0x5A, 0x4B, 0x3C, 0x2D, 0x1E, 0x0F,
+        ];
+        let h16 = ScardHandle::from_opaque(ctx, &opaque).unwrap();
+        assert_eq!(h16.len(), 16);
+        assert_eq!(h16.as_bytes(), &opaque);
+        assert_eq!(roundtrip_handle(h16), h16);
+        assert!(ScardHandle::from_opaque(ctx, &[0; 17]).is_err());
+    }
+
+    #[test]
     fn establish_context_return_size_uses_native_width() {
         let ctx = ScardContext::from_native(0x42);
         assert_eq!(usize::from(ctx.len()), size_of::<usize>());
@@ -2895,5 +3038,63 @@ mod tests {
             context: ctx,
         };
         assert_eq!(HeaderlessEncode::size(&body), 4 + 4 + 4 + 4 + size_of::<usize>());
+    }
+
+    /// LocateCardsW with a 6-byte Unicode mszCards (not 4-aligned) before states.
+    ///
+    /// Confirms the decoder consumes the declared card bytes, skips NDR pad to a
+    /// 4-byte boundary, then decodes reader states without desynchronizing.
+    #[test]
+    fn locate_cards_w_skips_msz_cards_ndr_pad() {
+        // Unicode multi-string "A\0\0" = 6 bytes; pad 2 bytes before states count.
+        let cards: &[u8] = &[
+            0x41, 0x00, // 'A'
+            0x00, 0x00, // string NUL
+            0x00, 0x00, // multi-string terminator
+        ];
+        assert_eq!(cards.len() % 4, 2);
+
+        let mut body = Vec::new();
+        // Empty REDIR_SCARDCONTEXT pointer pair (cbContext=0, pbContext=NULL).
+        body.extend_from_slice(&0u32.to_le_bytes());
+        body.extend_from_slice(&0u32.to_le_bytes());
+        // cBytes / mszCards pointer (index 0)
+        body.extend_from_slice(&u32::try_from(cards.len()).unwrap().to_le_bytes());
+        body.extend_from_slice(&0x0002_0000u32.to_le_bytes());
+        // cReaders / rgReaderStates pointer (index 1)
+        body.extend_from_slice(&1u32.to_le_bytes());
+        body.extend_from_slice(&0x0002_0004u32.to_le_bytes());
+        // mszCards value: conformant length + bytes + NDR pad
+        body.extend_from_slice(&u32::try_from(cards.len()).unwrap().to_le_bytes());
+        body.extend_from_slice(cards);
+        body.extend_from_slice(&[0u8, 0u8]); // pad to 4-byte boundary
+        // states conformant count
+        body.extend_from_slice(&1u32.to_le_bytes());
+        // ReaderState pointer: szReader (index 2) + ReaderState_Common_Call
+        body.extend_from_slice(&0x0002_0008u32.to_le_bytes());
+        body.extend_from_slice(&0u32.to_le_bytes()); // dwCurrentState
+        body.extend_from_slice(&0u32.to_le_bytes()); // dwEventState
+        body.extend_from_slice(&0u32.to_le_bytes()); // cbAtr
+        body.extend_from_slice(&[0u8; 36]); // rgbAtr
+        // szReader NDR string "R"
+        body.extend_from_slice(&2u32.to_le_bytes()); // max_count
+        body.extend_from_slice(&0u32.to_le_bytes()); // offset
+        body.extend_from_slice(&2u32.to_le_bytes()); // actual_count
+        body.extend_from_slice(&[0x52, 0x00, 0x00, 0x00]); // 'R' + NUL (already 4-aligned)
+
+        // RPCE headers (16 bytes, 4-aligned) so skip_pad vs full buffer matches body.
+        let mut pdu = vec![
+            0x01, 0x10, 0x08, 0x00, 0xCC, 0xCC, 0xCC, 0xCC, // StreamHeader LE
+        ];
+        pdu.extend_from_slice(&u32::try_from(body.len()).unwrap().to_le_bytes()); // TypeHeader length
+        pdu.extend_from_slice(&0u32.to_le_bytes()); // TypeHeader filler
+        pdu.extend_from_slice(&body);
+
+        let decoded = LocateCardsCall::decode(&mut ReadCursor::new(&pdu), Some(CharacterSet::Unicode)).unwrap();
+        assert_eq!(decoded.cards, vec!["A".to_owned()]);
+        assert_eq!(decoded.cards_length, u32::try_from(cards.len()).unwrap());
+        assert_eq!(decoded.states_length, 1);
+        assert_eq!(decoded.states.len(), 1);
+        assert_eq!(decoded.states[0].reader, "R");
     }
 }

--- a/crates/ironrdp-rdpdr/src/pdu/esc/mod.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/esc/mod.rs
@@ -1106,10 +1106,7 @@ impl LocateCardsAtrMask {
         let atr_length = src.read_u32();
         // MS-RDPESC: cbAtr range(0,36)
         if atr_length > 36 {
-            return Err(invalid_field_err!(
-                "decode",
-                "LocateCards_ATRMask cbAtr exceeds range 0..=36"
-            ));
+            return Err(invalid_field_err!("decode", "LocateCards_ATRMask cbAtr out of range"));
         }
         let atr = src.read_array::<36>();
         let mask = src.read_array::<36>();
@@ -1169,10 +1166,7 @@ impl rpce::HeaderlessDecode for LocateCardsCall {
             }
             // MS-RDPESC: cBytes range(0, 65536)
             if cards_length > 65_536 {
-                return Err(invalid_field_err!(
-                    "decode",
-                    "LocateCards cBytes exceeds range 0..=65536"
-                ));
+                return Err(invalid_field_err!("decode", "LocateCards cBytes out of range"));
             }
             let cards_len: usize = cast_length!("LocateCardsCall", "cards_length", cards_length)?;
             ensure_size!(in: src, size: cards_len);
@@ -1193,10 +1187,7 @@ impl rpce::HeaderlessDecode for LocateCardsCall {
             let states_length = src.read_u32();
             // MS-RDPESC: cReaders range(0,10)
             if states_length > 10 {
-                return Err(invalid_field_err!(
-                    "decode",
-                    "LocateCards cReaders exceeds range 0..=10"
-                ));
+                return Err(invalid_field_err!("decode", "LocateCards cReaders out of range"));
             }
             if states_length != states_ptr_length {
                 return Err(invalid_field_err!(
@@ -1279,10 +1270,7 @@ impl rpce::HeaderlessDecode for LocateCardsByAtrCall {
             }
             // MS-RDPESC: cAtrs range(0,1000)
             if atr_masks_length > 1000 {
-                return Err(invalid_field_err!(
-                    "decode",
-                    "LocateCardsByATR cAtrs exceeds range 0..=1000"
-                ));
+                return Err(invalid_field_err!("decode", "LocateCardsByATR cAtrs out of range"));
             }
             let mut atr_masks = Vec::new();
             for _ in 0..atr_masks_length {
@@ -1298,10 +1286,7 @@ impl rpce::HeaderlessDecode for LocateCardsByAtrCall {
             let states_length = src.read_u32();
             // MS-RDPESC: cReaders range(0,10)
             if states_length > 10 {
-                return Err(invalid_field_err!(
-                    "decode",
-                    "LocateCardsByATR cReaders exceeds range 0..=10"
-                ));
+                return Err(invalid_field_err!("decode", "LocateCardsByATR cReaders out of range"));
             }
             if states_length != states_ptr_length {
                 return Err(invalid_field_err!(
@@ -2636,10 +2621,7 @@ impl rpce::HeaderlessDecode for ControlCall {
         // MS-RDPESC: cbInBufferSize range(0,66560)
         let in_buffer_len = src.read_u32();
         if in_buffer_len > 66_560 {
-            return Err(invalid_field_err!(
-                "decode",
-                "Control cbInBufferSize exceeds range 0..=66560"
-            ));
+            return Err(invalid_field_err!("decode", "Control cbInBufferSize out of range"));
         }
         let in_buffer_ptr = ndr::decode_ptr(src, &mut index)?;
         ensure_size!(in: src, size: size_of::<u32>() * 2);
@@ -2825,10 +2807,7 @@ impl rpce::HeaderlessDecode for SetAttribCall {
         // MS-RDPESC: cbAttrLen range(0,65536)
         let attr_len = src.read_u32();
         if attr_len > 65_536 {
-            return Err(invalid_field_err!(
-                "decode",
-                "SetAttrib cbAttrLen exceeds range 0..=65536"
-            ));
+            return Err(invalid_field_err!("decode", "SetAttrib cbAttrLen out of range"));
         }
         let attr_ptr = ndr::decode_ptr(src, &mut index)?;
         handle.decode_value(src, None)?;
@@ -2936,165 +2915,97 @@ mod tests {
 
     fn roundtrip_context(ctx: ScardContext) -> ScardContext {
         let mut buf = vec![0u8; ctx.size()];
+        let mut index = 0;
         {
             let mut dst = WriteCursor::new(&mut buf);
-            let mut index = 0;
             ctx.encode_ptr(&mut index, &mut dst).unwrap();
             ctx.encode_value(&mut dst).unwrap();
-            assert_eq!(dst.pos(), ctx.size());
         }
+        index = 0;
         let mut src = ReadCursor::new(&buf);
-        let mut index = 0;
         let mut decoded = ScardContext::decode_ptr(&mut src, &mut index).unwrap();
         decoded.decode_value(&mut src, None).unwrap();
-        assert_eq!(src.pos(), buf.len());
         decoded
     }
 
     fn roundtrip_handle(handle: ScardHandle) -> ScardHandle {
         let mut buf = vec![0u8; handle.size()];
+        let mut index = 0;
         {
             let mut dst = WriteCursor::new(&mut buf);
-            let mut index = 0;
             handle.encode_ptr(&mut index, &mut dst).unwrap();
             handle.encode_value(&mut dst).unwrap();
-            assert_eq!(dst.pos(), handle.size());
         }
+        index = 0;
         let mut src = ReadCursor::new(&buf);
-        let mut index = 0;
         let mut decoded = ScardHandle::decode_ptr(&mut src, &mut index).unwrap();
         decoded.decode_value(&mut src, None).unwrap();
-        assert_eq!(src.pos(), buf.len());
         decoded
     }
 
     #[test]
-    fn scard_context_roundtrip_4_and_8_byte() {
+    fn scard_context_and_handle_roundtrip() {
         let c4 = ScardContext::new(0xA1B2_C3D4);
-        assert_eq!(c4.len(), 4);
         assert_eq!(roundtrip_context(c4), c4);
-        assert_eq!(c4.value(), 0xA1B2_C3D4);
         assert_eq!(c4.native(), usize::try_from(0xA1B2_C3D4u32).unwrap());
 
         let native = 0x0123_4567_89AB_CDEFusize;
         let c8 = ScardContext::from_native_len(native, 8);
-        assert_eq!(c8.len(), 8);
         assert_eq!(roundtrip_context(c8), c8);
         assert_eq!(c8.native(), native);
-        assert_eq!(c8.value(), 0x89AB_CDEFu32);
 
-        let empty = ScardContext::from_native_len(0, 0);
-        assert!(empty.is_empty());
-        assert_eq!(roundtrip_context(empty), empty);
-    }
-
-    #[test]
-    fn scard_context_roundtrip_16_byte_opaque() {
         let opaque = [
             0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF,
         ];
         let c16 = ScardContext::from_opaque(&opaque).unwrap();
-        assert_eq!(c16.len(), 16);
-        assert_eq!(c16.as_bytes(), &opaque);
-        assert_eq!(roundtrip_context(c16), c16);
+        assert_eq!(roundtrip_context(c16).as_bytes(), &opaque);
         assert!(ScardContext::from_opaque(&[0; 17]).is_err());
-    }
+        assert_eq!(roundtrip_context(ScardContext::from_native_len(0, 0)).len(), 0);
 
-    #[test]
-    fn scard_handle_roundtrip_4_and_8_byte() {
         let ctx = ScardContext::new(0x1111_2222);
         let h4 = ScardHandle::new(ctx, 0x3333_4444);
-        assert_eq!(h4.len(), 4);
-        assert_eq!(h4.context(), ctx);
         assert_eq!(roundtrip_handle(h4), h4);
-
-        let ctx8 = ScardContext::from_native_len(0xAAAA_BBBBusize, 8);
-        let h8 = ScardHandle::from_native(ctx8, 0xCCCC_DDDD_EEEE_FFFFusize);
-        assert_eq!(h8.len(), native_scard_len());
-        assert_eq!(roundtrip_handle(h8), h8);
-        assert_eq!(h8.native(), 0xCCCC_DDDD_EEEE_FFFFusize);
-    }
-
-    #[test]
-    fn scard_handle_roundtrip_16_byte_opaque() {
-        let ctx = ScardContext::from_opaque(&[1, 2, 3, 4, 5, 6]).unwrap();
-        let opaque = [
-            0xF0, 0xE1, 0xD2, 0xC3, 0xB4, 0xA5, 0x96, 0x87, 0x78, 0x69, 0x5A, 0x4B, 0x3C, 0x2D, 0x1E, 0x0F,
-        ];
+        let h8 = ScardHandle::from_native(ctx, 0xCCCC_DDDD_EEEE_FFFFusize);
+        assert_eq!(roundtrip_handle(h8).native(), 0xCCCC_DDDD_EEEE_FFFFusize);
         let h16 = ScardHandle::from_opaque(ctx, &opaque).unwrap();
-        assert_eq!(h16.len(), 16);
-        assert_eq!(h16.as_bytes(), &opaque);
-        assert_eq!(roundtrip_handle(h16), h16);
+        assert_eq!(roundtrip_handle(h16).as_bytes(), &opaque);
         assert!(ScardHandle::from_opaque(ctx, &[0; 17]).is_err());
-    }
 
-    #[test]
-    fn establish_context_return_size_uses_native_width() {
-        let ctx = ScardContext::from_native(0x42);
-        assert_eq!(usize::from(ctx.len()), size_of::<usize>());
-        // Headerless body: ReturnCode(4) + cbContext(4) + ptr(4) + length(4) + bytes(native width).
         let body = EstablishContextReturn {
             return_code: ReturnCode::Success,
-            context: ctx,
+            context: ScardContext::from_native(0x42),
         };
         assert_eq!(HeaderlessEncode::size(&body), 4 + 4 + 4 + 4 + size_of::<usize>());
     }
 
-    /// LocateCardsW with a 6-byte Unicode mszCards (not 4-aligned) before states.
-    ///
-    /// Confirms the decoder consumes the declared card bytes, skips NDR pad to a
-    /// 4-byte boundary, then decodes reader states without desynchronizing.
+    /// 6-byte Unicode mszCards needs 2-byte NDR pad before reader states.
     #[test]
     fn locate_cards_w_skips_msz_cards_ndr_pad() {
-        // Unicode multi-string "A\0\0" = 6 bytes; pad 2 bytes before states count.
-        let cards: &[u8] = &[
-            0x41, 0x00, // 'A'
-            0x00, 0x00, // string NUL
-            0x00, 0x00, // multi-string terminator
-        ];
-        assert_eq!(cards.len() % 4, 2);
-
+        let cards = [0x41u8, 0x00, 0x00, 0x00, 0x00, 0x00]; // "A\0\0"
         let mut body = Vec::new();
-        // Empty REDIR_SCARDCONTEXT pointer pair (cbContext=0, pbContext=NULL).
-        body.extend_from_slice(&0u32.to_le_bytes());
-        body.extend_from_slice(&0u32.to_le_bytes());
-        // cBytes / mszCards pointer (index 0)
-        body.extend_from_slice(&u32::try_from(cards.len()).unwrap().to_le_bytes());
+        body.extend_from_slice(&[0u8; 8]); // empty context ptr
+        body.extend_from_slice(&6u32.to_le_bytes());
         body.extend_from_slice(&0x0002_0000u32.to_le_bytes());
-        // cReaders / rgReaderStates pointer (index 1)
         body.extend_from_slice(&1u32.to_le_bytes());
         body.extend_from_slice(&0x0002_0004u32.to_le_bytes());
-        // mszCards value: conformant length + bytes + NDR pad
-        body.extend_from_slice(&u32::try_from(cards.len()).unwrap().to_le_bytes());
-        body.extend_from_slice(cards);
-        body.extend_from_slice(&[0u8, 0u8]); // pad to 4-byte boundary
-        // states conformant count
+        body.extend_from_slice(&6u32.to_le_bytes());
+        body.extend_from_slice(&cards);
+        body.extend_from_slice(&[0u8; 2]); // NDR pad
         body.extend_from_slice(&1u32.to_le_bytes());
-        // ReaderState pointer: szReader (index 2) + ReaderState_Common_Call
         body.extend_from_slice(&0x0002_0008u32.to_le_bytes());
-        body.extend_from_slice(&0u32.to_le_bytes()); // dwCurrentState
-        body.extend_from_slice(&0u32.to_le_bytes()); // dwEventState
-        body.extend_from_slice(&0u32.to_le_bytes()); // cbAtr
-        body.extend_from_slice(&[0u8; 36]); // rgbAtr
-        // szReader NDR string "R"
-        body.extend_from_slice(&2u32.to_le_bytes()); // max_count
-        body.extend_from_slice(&0u32.to_le_bytes()); // offset
-        body.extend_from_slice(&2u32.to_le_bytes()); // actual_count
-        body.extend_from_slice(&[0x52, 0x00, 0x00, 0x00]); // 'R' + NUL (already 4-aligned)
+        body.extend_from_slice(&[0u8; 12 + 36]); // ReaderState_Common_Call zeros
+        body.extend_from_slice(&2u32.to_le_bytes());
+        body.extend_from_slice(&0u32.to_le_bytes());
+        body.extend_from_slice(&2u32.to_le_bytes());
+        body.extend_from_slice(&[0x52, 0x00, 0x00, 0x00]); // "R"
 
-        // RPCE headers (16 bytes, 4-aligned) so skip_pad vs full buffer matches body.
-        let mut pdu = vec![
-            0x01, 0x10, 0x08, 0x00, 0xCC, 0xCC, 0xCC, 0xCC, // StreamHeader LE
-        ];
-        pdu.extend_from_slice(&u32::try_from(body.len()).unwrap().to_le_bytes()); // TypeHeader length
-        pdu.extend_from_slice(&0u32.to_le_bytes()); // TypeHeader filler
+        let mut pdu = vec![0x01, 0x10, 0x08, 0x00, 0xCC, 0xCC, 0xCC, 0xCC];
+        pdu.extend_from_slice(&u32::try_from(body.len()).unwrap().to_le_bytes());
+        pdu.extend_from_slice(&0u32.to_le_bytes());
         pdu.extend_from_slice(&body);
 
         let decoded = LocateCardsCall::decode(&mut ReadCursor::new(&pdu), Some(CharacterSet::Unicode)).unwrap();
         assert_eq!(decoded.cards, vec!["A".to_owned()]);
-        assert_eq!(decoded.cards_length, u32::try_from(cards.len()).unwrap());
-        assert_eq!(decoded.states_length, 1);
-        assert_eq!(decoded.states.len(), 1);
         assert_eq!(decoded.states[0].reader, "R");
     }
 }

--- a/crates/ironrdp-rdpdr/src/pdu/esc/mod.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/esc/mod.rs
@@ -169,18 +169,6 @@ impl ScardCall {
     }
 }
 
-/// Native WinSCard handle/context width on this target (`4` or `8`).
-#[cfg(target_pointer_width = "32")]
-const fn native_scard_len() -> u8 {
-    4
-}
-
-/// Native WinSCard handle/context width on this target (`4` or `8`).
-#[cfg(target_pointer_width = "64")]
-const fn native_scard_len() -> u8 {
-    8
-}
-
 /// MS-RDPESC `cbContext` / `cbHandle` maximum (`range(0,16)`).
 const SCARD_OPAQUE_MAX_LEN: u32 = 16;
 
@@ -193,23 +181,6 @@ fn scard_wire_len(length: u32) -> DecodeResult<u8> {
     }
     // INVARIANT: length <= 16 fits in u8.
     Ok(u8::try_from(length).expect("length <= 16 fits in u8"))
-}
-
-fn write_native_le_bytes(native: usize, len: u8, bytes: &mut [u8; 16]) {
-    debug_assert!(matches!(len, 0 | 4 | 8));
-    // Zero-extend native into LE bytes, then keep the first `len` of them.
-    let mut le = [0u8; 16];
-    let native_bytes = native.to_le_bytes();
-    le[..native_bytes.len()].copy_from_slice(&native_bytes);
-    let n = usize::from(len);
-    bytes[..n].copy_from_slice(&le[..n]);
-}
-
-fn read_native_le_bytes(bytes: &[u8; 16], len: u8) -> usize {
-    let mut tmp = [0u8; size_of::<usize>()];
-    let n = usize::from(len).min(size_of::<usize>());
-    tmp[..n].copy_from_slice(&bytes[..n]);
-    usize::from_le_bytes(tmp)
 }
 
 /// [2.2.1.1] REDIR_SCARDCONTEXT
@@ -234,23 +205,12 @@ impl ScardContext {
         Self { len: 4, bytes }
     }
 
-    /// Creates a context from a native WinSCard `SCARDCONTEXT` (`usize` width).
-    pub fn from_native(native: usize) -> Self {
-        Self::from_native_len(native, native_scard_len())
-    }
-
     /// Creates a context from opaque wire bytes (`0..=16`).
     pub fn from_opaque(opaque: &[u8]) -> DecodeResult<Self> {
         let len = scard_wire_len(u32::try_from(opaque.len()).unwrap_or(u32::MAX))?;
         let mut bytes = [0u8; 16];
         bytes[..opaque.len()].copy_from_slice(opaque);
         Ok(Self { len, bytes })
-    }
-
-    fn from_native_len(native: usize, len: u8) -> Self {
-        let mut bytes = [0u8; 16];
-        write_native_le_bytes(native, len, &mut bytes);
-        Self { len, bytes }
     }
 
     /// Wire length of `pbContext`.
@@ -276,13 +236,6 @@ impl ScardContext {
         let n = usize::from(self.len).min(4);
         tmp[..n].copy_from_slice(&self.bytes[..n]);
         u32::from_le_bytes(tmp)
-    }
-
-    /// Convenience view of the first `size_of::<usize>()` LE bytes as a native integer.
-    ///
-    /// Useful for 4- and 8-byte Windows `SCARDCONTEXT` values; longer opaque blobs are truncated.
-    pub fn native(self) -> usize {
-        read_native_le_bytes(&self.bytes, self.len)
     }
 }
 
@@ -1174,9 +1127,10 @@ impl rpce::HeaderlessDecode for LocateCardsCall {
             // consume subsequent NDR fields (for example reader states).
             let mut cards_src = ReadCursor::new(src.read_slice(cards_len));
             let cards = read_multistring_from_cursor(&mut cards_src, charset)?;
-            // Conformant byte arrays are followed by padding to a 4-byte boundary
-            // before the next NDR field (FreeRDP smartcard_pack / MS-RPCE).
-            ndr::skip_pad(src)?;
+            // Pad only when another NDR field follows; stub tail is RPCE packing.
+            if states_ptr != 0 {
+                ndr::skip_pad(src)?;
+            }
             (cards_length, cards)
         };
 
@@ -1464,14 +1418,6 @@ impl ScardHandle {
         Self { context, len: 4, bytes }
     }
 
-    /// Creates a handle from a native WinSCard `SCARDHANDLE` (`usize` width).
-    pub fn from_native(context: ScardContext, native: usize) -> Self {
-        let mut bytes = [0u8; 16];
-        let len = native_scard_len();
-        write_native_le_bytes(native, len, &mut bytes);
-        Self { context, len, bytes }
-    }
-
     /// Creates a handle from opaque wire bytes (`0..=16`).
     pub fn from_opaque(context: ScardContext, opaque: &[u8]) -> DecodeResult<Self> {
         let len = scard_wire_len(u32::try_from(opaque.len()).unwrap_or(u32::MAX))?;
@@ -1508,13 +1454,6 @@ impl ScardHandle {
         let n = usize::from(self.len).min(4);
         tmp[..n].copy_from_slice(&self.bytes[..n]);
         u32::from_le_bytes(tmp)
-    }
-
-    /// Convenience view of the first `size_of::<usize>()` LE bytes as a native integer.
-    ///
-    /// Useful for 4- and 8-byte Windows `SCARDHANDLE` values; longer opaque blobs are truncated.
-    pub fn native(self) -> usize {
-        read_native_le_bytes(&self.bytes, self.len)
     }
 }
 
@@ -2292,9 +2231,14 @@ impl rpce::HeaderlessDecode for ContextAndStringCall {
         let charset = expect_charset(charset)?;
         let mut index = 0;
         let mut context = ScardContext::decode_ptr(src, &mut index)?;
-        let _sz_ptr = ndr::decode_ptr(src, &mut index)?;
+        // IDL pointer_default(unique): NULL contributes no referent.
+        let sz_ptr = ndr::decode_ptr(src, &mut index)?;
         context.decode_value(src, None)?;
-        let sz = ndr::read_string_from_cursor(src, charset)?;
+        let sz = if sz_ptr == 0 {
+            String::new()
+        } else {
+            ndr::read_string_from_cursor(src, charset)?
+        };
         Ok(Self { context, sz })
     }
 }
@@ -2323,11 +2267,20 @@ impl rpce::HeaderlessDecode for ContextAndTwoStringCall {
         let charset = expect_charset(charset)?;
         let mut index = 0;
         let mut context = ScardContext::decode_ptr(src, &mut index)?;
-        let _sz1_ptr = ndr::decode_ptr(src, &mut index)?;
-        let _sz2_ptr = ndr::decode_ptr(src, &mut index)?;
+        // IDL pointer_default(unique): each [string] may be NULL independently.
+        let sz1_ptr = ndr::decode_ptr(src, &mut index)?;
+        let sz2_ptr = ndr::decode_ptr(src, &mut index)?;
         context.decode_value(src, None)?;
-        let sz1 = ndr::read_string_from_cursor(src, charset)?;
-        let sz2 = ndr::read_string_from_cursor(src, charset)?;
+        let sz1 = if sz1_ptr == 0 {
+            String::new()
+        } else {
+            ndr::read_string_from_cursor(src, charset)?
+        };
+        let sz2 = if sz2_ptr == 0 {
+            String::new()
+        } else {
+            ndr::read_string_from_cursor(src, charset)?
+        };
         Ok(Self { context, sz1, sz2 })
     }
 }
@@ -2571,6 +2524,10 @@ impl rpce::HeaderlessEncode for StateReturn {
         dst.write_u32(self.return_code.into());
         dst.write_u32(self.state.into());
         dst.write_u32(self.protocol.bits());
+        // MS-RDPESC: cbAtrLen range(0,36)
+        if self.atr.len() > 36 {
+            return Err(invalid_field_err!("encode", "StateReturn cbAtrLen out of range"));
+        }
         let atr_len: u32 = cast_length!("StateReturn", "atr_len", self.atr.len())?;
         let mut index = 0;
         ndr::encode_ptr(Some(atr_len), &mut index, dst)?;
@@ -2684,6 +2641,13 @@ impl rpce::HeaderlessEncode for ControlReturn {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         ensure_size!(in: dst, size: self.size());
         dst.write_u32(self.return_code.into());
+        // MS-RDPESC: cbOutBufferSize range(0,66560)
+        if self.out_buffer.len() > 66_560 {
+            return Err(invalid_field_err!(
+                "encode",
+                "ControlReturn cbOutBufferSize out of range"
+            ));
+        }
         let data_len: u32 = cast_length!("ControlReturn", "out_buffer_len", self.out_buffer.len())?;
         let mut index = 0;
         ndr::encode_ptr(Some(data_len), &mut index, dst)?;
@@ -2761,6 +2725,10 @@ impl rpce::HeaderlessEncode for GetAttribReturn {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         ensure_size!(in: dst, size: self.size());
         dst.write_u32(self.return_code.into());
+        // MS-RDPESC: cbAttrLen range(0,65536)
+        if self.attr.len() > 65_536 {
+            return Err(invalid_field_err!("encode", "GetAttribReturn cbAttrLen out of range"));
+        }
         let data_len: u32 = cast_length!("GetAttribReturn", "attr_len", self.attr.len())?;
         let mut index = 0;
         ndr::encode_ptr(Some(data_len), &mut index, dst)?;
@@ -2947,29 +2915,35 @@ mod tests {
     fn scard_context_and_handle_roundtrip() {
         let c4 = ScardContext::new(0xA1B2_C3D4);
         assert_eq!(roundtrip_context(c4), c4);
-        assert_eq!(c4.native(), usize::try_from(0xA1B2_C3D4u32).unwrap());
-
-        let native = 0x0123_4567_89AB_CDEFusize;
-        let c8 = ScardContext::from_native_len(native, 8);
-        assert_eq!(roundtrip_context(c8), c8);
-        assert_eq!(c8.native(), native);
-
+        assert_eq!(c4.value(), 0xA1B2_C3D4);
         let opaque = [
             0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF,
         ];
-        let c16 = ScardContext::from_opaque(&opaque).unwrap();
-        assert_eq!(roundtrip_context(c16).as_bytes(), &opaque);
+        assert_eq!(
+            roundtrip_context(ScardContext::from_opaque(&opaque).unwrap()).as_bytes(),
+            &opaque
+        );
         assert!(ScardContext::from_opaque(&[0; 17]).is_err());
-        assert_eq!(roundtrip_context(ScardContext::from_native_len(0, 0)).len(), 0);
-
+        assert_eq!(roundtrip_context(ScardContext::from_opaque(&[]).unwrap()).len(), 0);
         let ctx = ScardContext::new(0x1111_2222);
-        let h4 = ScardHandle::new(ctx, 0x3333_4444);
-        assert_eq!(roundtrip_handle(h4), h4);
-        let h8 = ScardHandle::from_native(ctx, 0xCCCC_DDDD_EEEE_FFFFusize);
-        assert_eq!(roundtrip_handle(h8).native(), 0xCCCC_DDDD_EEEE_FFFFusize);
-        let h16 = ScardHandle::from_opaque(ctx, &opaque).unwrap();
-        assert_eq!(roundtrip_handle(h16).as_bytes(), &opaque);
+        assert_eq!(
+            roundtrip_handle(ScardHandle::new(ctx, 0x3333_4444)),
+            ScardHandle::new(ctx, 0x3333_4444)
+        );
+        assert_eq!(
+            roundtrip_handle(ScardHandle::from_opaque(ctx, &opaque).unwrap()).as_bytes(),
+            &opaque
+        );
         assert!(ScardHandle::from_opaque(ctx, &[0; 17]).is_err());
+    }
+
+    #[test]
+    fn context_and_string_null_unique_ptr() {
+        // empty context + NULL sz unique pointer
+        let mut pdu = vec![0x01, 0x10, 0x08, 0x00, 0xCC, 0xCC, 0xCC, 0xCC, 12, 0, 0, 0, 0, 0, 0, 0];
+        pdu.extend_from_slice(&[0u8; 12]);
+        let d = ContextAndStringCall::decode(&mut ReadCursor::new(&pdu), Some(CharacterSet::Unicode)).unwrap();
+        assert!(d.sz.is_empty());
     }
 
     /// `::new` 4-byte EstablishContext/Connect returns stay byte-identical to master.
@@ -2981,7 +2955,10 @@ mod tests {
             buf
         }
         let est = EstablishContextReturn::new(ReturnCode::Success, ScardContext::new(0xA1B2_C3D4)).into_inner();
-        assert_eq!(enc(&est), [0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 2, 0, 4, 0, 0, 0, 0xD4, 0xC3, 0xB2, 0xA1]);
+        assert_eq!(
+            enc(&est),
+            [0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 2, 0, 4, 0, 0, 0, 0xD4, 0xC3, 0xB2, 0xA1]
+        );
         let h = ScardHandle::new(ScardContext::new(0x1111_2222), 0x3333_4444);
         let conn = ConnectReturn::new(ReturnCode::Success, h, CardProtocol::SCARD_PROTOCOL_T0).into_inner();
         assert_eq!(

--- a/crates/ironrdp-rdpdr/src/pdu/esc/ndr.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/esc/ndr.rs
@@ -76,11 +76,27 @@ pub fn ptr_size(with_length: bool) -> usize {
     }
 }
 
+const ALIGNMENT: usize = 4;
+
+/// Skip trailing padding so the next NDR field starts on a 4-byte boundary.
+///
+/// Alignment is relative to the start of the current cursor buffer, matching
+/// FreeRDP `smartcard_pack` and [`read_string_from_cursor`].
+pub fn skip_pad(cursor: &mut ReadCursor<'_>) -> DecodeResult<()> {
+    let mut pad = cursor.pos();
+    let size = (pad + ALIGNMENT - 1) & !(ALIGNMENT - 1);
+    pad = size - pad;
+    if pad > 0 {
+        ensure_size!(ctx: "ndr::skip_pad", in: cursor, size: pad);
+        cursor.advance(pad);
+    }
+    Ok(())
+}
+
 /// A special read_string_from_cursor which reads and ignores the additional length and
 /// offset fields prefixing the string, as well as any extra padding for a 4-byte aligned
 /// NULL-terminated string.
 pub fn read_string_from_cursor(cursor: &mut ReadCursor<'_>, charset: CharacterSet) -> DecodeResult<String> {
-    const ALIGNMENT: usize = 4;
     ensure_size!(ctx: "ndr::read_string_from_cursor", in: cursor, size: size_of::<u32>() * 3);
     let _length = cursor.read_u32();
     let _offset = cursor.read_u32();
@@ -89,13 +105,7 @@ pub fn read_string_from_cursor(cursor: &mut ReadCursor<'_>, charset: CharacterSe
     let string = utils::read_string_from_cursor(cursor, charset, true)?;
 
     // Skip padding for 4-byte aligned NULL-terminated string.
-    let mut pad = cursor.pos();
-    let size = (pad + ALIGNMENT - 1) & !(ALIGNMENT - 1);
-    pad = size - pad;
-    if pad > 0 {
-        ensure_size!(ctx: "ndr::read_string_from_cursor", in: cursor, size: pad);
-        cursor.advance(pad);
-    }
+    skip_pad(cursor)?;
 
     Ok(string)
 }


### PR DESCRIPTION
Fill out the remaining MS-RDPESC call/return PDUs and encode SCARDCONTEXT/SCARDHANDLE as variable-length native values so x86 (4-byte) and x64 (8-byte) WinSCard handles round-trip on the wire. Keep this change PDU-only; the WinSCard backend lands in stacked follow-ups.