### PR TITLE
fix(agent): preserve RAIL audit correlation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2646,6 +2646,7 @@ dependencies = [
  "anyhow",
  "ironrdp-cfg",
  "ironrdp-client",
+ "ironrdp-connector",
  "ironrdp-input",
  "ironrdp-pdu",
  "ironrdp-propertyset",

--- a/crates/ironrdp-agent/src/cli.rs
+++ b/crates/ironrdp-agent/src/cli.rs
@@ -409,29 +409,17 @@ enum OutputFormat {
 const MAX_JSON_STREAM_EVENTS: usize = 8 * 1024;
 const MAX_JSON_STREAM_OUTPUT: usize = 2 * 1024 * 1024;
 
-/// A daemon-provided error that must be rendered according to the selected NOW output format.
+/// A daemon-provided error that must be rendered according to the selected output format.
 #[derive(Debug)]
-struct NowRequestError(AgentError);
+struct DaemonRequestError(AgentError);
 
-impl fmt::Display for NowRequestError {
+impl fmt::Display for DaemonRequestError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.0.message)
     }
 }
 
-impl core::error::Error for NowRequestError {}
-
-/// A daemon-provided RAIL error that must be rendered according to the selected output format.
-#[derive(Debug)]
-struct RailRequestError(AgentError);
-
-impl fmt::Display for RailRequestError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.0.message)
-    }
-}
-
-impl core::error::Error for RailRequestError {}
+impl core::error::Error for DaemonRequestError {}
 
 #[derive(Args, Debug)]
 struct DaemonArgs {
@@ -799,7 +787,7 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
             let exit_code = match run_now(&endpoint, args).await {
                 Ok(exit_code) => exit_code,
                 Err(error) => {
-                    if let Some(error) = error.downcast_ref::<NowRequestError>() {
+                    if let Some(error) = error.downcast_ref::<DaemonRequestError>() {
                         print_request_error(&error.0, format)?;
                         std::process::exit(1);
                     }
@@ -816,7 +804,7 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
         Command::Rail(args) => {
             let format = args.format;
             if let Err(error) = run_rail(&endpoint, args).await {
-                if let Some(error) = error.downcast_ref::<RailRequestError>() {
+                if let Some(error) = error.downcast_ref::<DaemonRequestError>() {
                     print_request_error(&error.0, format)?;
                     std::process::exit(1);
                 }
@@ -1132,7 +1120,7 @@ async fn run_rail(endpoint: &Endpoint, args: RailArgs) -> anyhow::Result<()> {
     let response = transport::send_request(endpoint, &request).await?;
     let payload = match response {
         Response::Ok(payload) => payload,
-        Response::Err(error) => return Err(RailRequestError(error).into()),
+        Response::Err(error) => return Err(DaemonRequestError(error).into()),
     };
     print_rail_payload(payload, format)
 }
@@ -1511,7 +1499,7 @@ async fn now_execution(
             let response = transport::send_request(endpoint, &Request::NowExecute(request)).await?;
             let payload = match response {
                 Response::Ok(payload) => payload,
-                Response::Err(error) => return Err(NowRequestError(error).into()),
+                Response::Err(error) => return Err(DaemonRequestError(error).into()),
             };
             let Payload::NowOperation(operation) = &payload else {
                 anyhow::bail!("unexpected response while writing operation ID");
@@ -1530,7 +1518,7 @@ async fn now_single(endpoint: &Endpoint, request: Request, format: OutputFormat)
     let response = transport::send_request(endpoint, &request).await?;
     let payload = match response {
         Response::Ok(payload) => payload,
-        Response::Err(error) => return Err(NowRequestError(error).into()),
+        Response::Err(error) => return Err(DaemonRequestError(error).into()),
     };
     print_now_payload(&payload, format)?;
     Ok(payload_remote_exit(&payload))
@@ -1547,7 +1535,7 @@ async fn now_stream(
     let first: Response = transport::read_message(&mut stream).await?;
     let first = match first {
         Response::Ok(payload) => payload,
-        Response::Err(error) => return Err(NowRequestError(error).into()),
+        Response::Err(error) => return Err(DaemonRequestError(error).into()),
     };
 
     let mut exit_code = payload_remote_exit(&first);
@@ -1587,7 +1575,7 @@ async fn now_stream(
         };
         let payload = match response {
             Response::Ok(payload) => payload,
-            Response::Err(error) => return Err(NowRequestError(error).into()),
+            Response::Err(error) => return Err(DaemonRequestError(error).into()),
         };
         if let Payload::NowEvent(event) = &payload {
             match &event.kind {
@@ -1634,7 +1622,7 @@ fn print_request_error(error: &AgentError, format: OutputFormat) -> anyhow::Resu
                     "category": error.category.as_str(),
                     "message": error.message,
                 }))
-                .context("serialize NOW error")?
+                .context("serialize daemon request error")?
             );
             Ok(())
         }

--- a/crates/ironrdp-agent/src/cli.rs
+++ b/crates/ironrdp-agent/src/cli.rs
@@ -800,7 +800,7 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
                 Ok(exit_code) => exit_code,
                 Err(error) => {
                     if let Some(error) = error.downcast_ref::<NowRequestError>() {
-                        print_now_error(&error.0, format)?;
+                        print_request_error(&error.0, format)?;
                         std::process::exit(1);
                     }
                     return Err(error);
@@ -813,7 +813,17 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
             }
             return Ok(());
         }
-        Command::Rail(args) => return run_rail(&endpoint, args).await,
+        Command::Rail(args) => {
+            let format = args.format;
+            if let Err(error) = run_rail(&endpoint, args).await {
+                if let Some(error) = error.downcast_ref::<RailRequestError>() {
+                    print_request_error(&error.0, format)?;
+                    std::process::exit(1);
+                }
+                return Err(error);
+            }
+            return Ok(());
+        }
         Command::Connect(args) => build_connect_request(args)?,
         #[cfg(windows)]
         Command::Sandbox(args) => {
@@ -1610,7 +1620,7 @@ async fn now_stream(
     Ok(exit_code)
 }
 
-fn print_now_error(error: &AgentError, format: OutputFormat) -> anyhow::Result<()> {
+fn print_request_error(error: &AgentError, format: OutputFormat) -> anyhow::Result<()> {
     match format {
         OutputFormat::Human => {
             eprintln!("{}", error.message);

--- a/crates/ironrdp-agent/src/cli.rs
+++ b/crates/ironrdp-agent/src/cli.rs
@@ -421,6 +421,18 @@ impl fmt::Display for NowRequestError {
 
 impl core::error::Error for NowRequestError {}
 
+/// A daemon-provided RAIL error that must be rendered according to the selected output format.
+#[derive(Debug)]
+struct RailRequestError(AgentError);
+
+impl fmt::Display for RailRequestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0.message)
+    }
+}
+
+impl core::error::Error for RailRequestError {}
+
 #[derive(Args, Debug)]
 struct DaemonArgs {
     /// Path to a .rdp file whose properties are preloaded as an overlay applied to every `connect`
@@ -1110,7 +1122,7 @@ async fn run_rail(endpoint: &Endpoint, args: RailArgs) -> anyhow::Result<()> {
     let response = transport::send_request(endpoint, &request).await?;
     let payload = match response {
         Response::Ok(payload) => payload,
-        Response::Err(error) => anyhow::bail!("{error}"),
+        Response::Err(error) => return Err(RailRequestError(error).into()),
     };
     print_rail_payload(payload, format)
 }

--- a/crates/ironrdp-daemon/Cargo.toml
+++ b/crates/ironrdp-daemon/Cargo.toml
@@ -31,6 +31,7 @@ whoami = "2.1"
 ironrdp-rail = { version = "0.1.0", path = "../ironrdp-rail" }
 
 [dev-dependencies]
+ironrdp-connector = { path = "../ironrdp-connector" }
 now-proto-pdu = { version = "0.4", features = ["std"] }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/ironrdp-daemon/src/daemon.rs
+++ b/crates/ironrdp-daemon/src/daemon.rs
@@ -1481,6 +1481,7 @@ async fn consume_output(
             RdpOutputEvent::ConnectionFailure(error) => {
                 guard.state = ConnState::Failed;
                 guard.error = Some(format!("{error}"));
+                guard.rail.clear_pending();
                 error!(%error, "Session connection failed");
                 false
             }
@@ -1517,8 +1518,8 @@ async fn consume_output(
         ConnState::Connecting | ConnState::Connected | ConnState::Disconnecting
     ) {
         guard.state = ConnState::Disconnected;
-        guard.rail.clear_pending();
     }
+    guard.rail.clear_pending();
     drop(guard);
     notify(&notification);
 }
@@ -2061,6 +2062,47 @@ mod tests {
 
         drop(output_tx);
         consumer.await.expect("consume output");
+    }
+
+    #[tokio::test]
+    async fn connection_failure_discards_pending_rail_launches() {
+        let (daemon, mut input_rx, live, rail_notify) = active_rail_session(true);
+        let (output_tx, output_rx) = mpsc::channel(1);
+        let consumer = tokio::spawn(consume_output(
+            output_rx,
+            Arc::clone(&live),
+            None,
+            rail_notify,
+            Arc::new(AtomicU64::new(2)),
+        ));
+
+        assert!(matches!(
+            daemon.rail_execute(RailExecuteRequest {
+                executable: "notepad.exe".to_owned(),
+                working_directory: String::new(),
+                arguments: String::new(),
+                flags: 0,
+            }),
+            Response::Ok(Payload::RailLaunch(RailLaunchInfo { launch_id: 1, .. }))
+        ));
+        assert!(matches!(input_rx.recv().await, Some(RdpInputEvent::RailExecute(_))));
+        output_tx
+            .send(ironrdp_client::rdp::RdpOutputEvent::ConnectionFailure(
+                ironrdp_connector::general_err!("test connection failure"),
+            ))
+            .await
+            .expect("send connection failure");
+        drop(output_tx);
+        consumer.await.expect("consume output");
+
+        assert_eq!(
+            live.lock().expect("session live state poisoned").state,
+            ConnState::Failed
+        );
+        assert!(matches!(
+            daemon.rail_status(),
+            Response::Ok(Payload::RailStatus(status)) if status.pending_launches.is_empty()
+        ));
     }
 
     #[test]

--- a/crates/ironrdp-daemon/src/daemon.rs
+++ b/crates/ironrdp-daemon/src/daemon.rs
@@ -35,10 +35,10 @@ use std::collections::BTreeSet;
 use ironrdp_rdpdr_native::{RedirectedDrive, WindowsRdpdrBackendFactory};
 
 use crate::ipc::{
-    ConnState, KeyFilter, MAX_UNICODE_TEXT_CHARS, NowDiagnostics, Payload, PenFrameRequest, PropValue, PropertyDump,
-    PropertyEntry, RailEvent, RailEventDump, RailEventKind, RailExecuteFailureReason, RailExecuteRequest,
-    RailLaunchInfo, RailStatusInfo, Request, Response, StatusInfo, TouchFrameRequest, pen_event_from_request,
-    touch_event_from_request,
+    ConnState, KeyFilter, MAX_RAIL_RETAINED_EVENTS, MAX_UNICODE_TEXT_CHARS, NowDiagnostics, Payload, PenFrameRequest,
+    PropValue, PropertyDump, PropertyEntry, RailEvent, RailEventDump, RailEventKind, RailExecuteFailureReason,
+    RailExecuteRequest, RailLaunchInfo, RailStatusInfo, Request, Response, StatusInfo, TouchFrameRequest,
+    pen_event_from_request, touch_event_from_request,
 };
 use crate::logbuf::{self, LogBuffer};
 use crate::now::NowEndpoint;
@@ -233,6 +233,8 @@ pub struct Daemon {
     /// Monotonically assigns RAIL ledger generations so observations from a former session cannot be
     /// mistaken for the active connection.
     next_rail_generation: Arc<AtomicU64>,
+    /// Assigns RAIL launch IDs across every session so they remain unambiguous with their generation.
+    next_rail_launch_id: AtomicU64,
     certificate_validation: CertificateValidation,
     #[cfg(windows)]
     rdpdr_backend_factory: Option<WindowsRdpdrBackendFactory>,
@@ -293,7 +295,6 @@ struct Live {
     rail: RailLedger,
 }
 
-const MAX_RAIL_EVENTS: usize = 256;
 const MAX_PENDING_RAIL_LAUNCHES: usize = 64;
 
 #[derive(Debug)]
@@ -342,7 +343,7 @@ impl RailLedger {
             kind,
         };
         self.next_sequence = self.next_sequence.saturating_add(1);
-        if self.events.len() == MAX_RAIL_EVENTS {
+        if self.events.len() == MAX_RAIL_RETAINED_EVENTS {
             let _ = self.events.pop_front();
         }
         self.events.push_back(event);
@@ -421,6 +422,10 @@ impl RailLedger {
             Some(PendingRailLaunch::Agent(launch)) => Some(launch.launch_id),
         }
     }
+
+    fn clear_pending(&mut self) {
+        self.pending_launches.clear();
+    }
 }
 
 /// A decoded frame retained for screenshots. `pixels` are `0x00RRGGBB` (`to_be_bytes()` yields
@@ -457,6 +462,7 @@ impl Daemon {
             overlay,
             credentials_loaded,
             next_rail_generation: Arc::new(AtomicU64::new(1)),
+            next_rail_launch_id: AtomicU64::new(1),
             certificate_validation,
             #[cfg(windows)]
             rdpdr_backend_factory,
@@ -959,7 +965,7 @@ impl Daemon {
         };
         let mut live = session.live.lock().expect("session live state poisoned");
         let launch = RailLaunchInfo {
-            launch_id: live.rail.next_sequence,
+            launch_id: self.next_rail_launch_id.fetch_add(1, Ordering::Relaxed),
             executable: execute.executable.clone(),
             flags: execute.flags,
         };
@@ -1481,12 +1487,14 @@ async fn consume_output(
             RdpOutputEvent::Terminated(Ok(reason)) => {
                 guard.state = ConnState::Disconnected;
                 guard.error = Some(format!("{reason:?}"));
+                guard.rail.clear_pending();
                 info!(?reason, "Session terminated");
                 false
             }
             RdpOutputEvent::Terminated(Err(error)) => {
                 guard.state = ConnState::Failed;
                 guard.error = Some(format!("{error}"));
+                guard.rail.clear_pending();
                 warn!(%error, "Session terminated with an error");
                 false
             }
@@ -1509,6 +1517,7 @@ async fn consume_output(
         ConnState::Connecting | ConnState::Connected | ConnState::Disconnecting
     ) {
         guard.state = ConnState::Disconnected;
+        guard.rail.clear_pending();
     }
     drop(guard);
     notify(&notification);
@@ -1674,9 +1683,9 @@ mod tests {
     use ironrdp_propertyset::PropertySet;
 
     use super::{
-        ConnState, Daemon, DaemonOptions, Live, MAX_PENDING_RAIL_LAUNCHES, MAX_RAIL_EVENTS, MAX_UNICODE_TEXT_CHARS,
-        NowEndpoint, OperationManager, RailLedger, RdpdrDriveConfig, ResizeError, Session, consume_output,
-        enqueue_unicode_text, notify,
+        ConnState, Daemon, DaemonOptions, Live, MAX_PENDING_RAIL_LAUNCHES, MAX_RAIL_RETAINED_EVENTS,
+        MAX_UNICODE_TEXT_CHARS, NowEndpoint, OperationManager, RailLedger, RdpdrDriveConfig, ResizeError, Session,
+        consume_output, enqueue_unicode_text, notify,
     };
     use crate::ipc::{Payload, Response};
     use ironrdp_rpc::ipc::{RailEventKind, RailExecuteRequest, RailLaunchInfo};
@@ -1705,7 +1714,7 @@ mod tests {
         ledger.queue_launch(launch).expect("room for launch");
         assert_eq!(ledger.take_launch(0, "notepad.exe"), Some(1));
 
-        for byte_count in 0..=MAX_RAIL_EVENTS {
+        for byte_count in 0..=MAX_RAIL_RETAINED_EVENTS {
             ledger.record(RailEventKind::WindowingOrders {
                 byte_count: u32::try_from(byte_count).expect("test count fits"),
             });
@@ -1717,7 +1726,7 @@ mod tests {
             dump.events.first(),
             Some(event) if matches!(event.kind, RailEventKind::Gap { .. })
         ));
-        assert_eq!(dump.events.len(), MAX_RAIL_EVENTS + 1);
+        assert_eq!(dump.events.len(), MAX_RAIL_RETAINED_EVENTS + 1);
     }
 
     #[test]

--- a/crates/ironrdp-daemon/src/daemon.rs
+++ b/crates/ironrdp-daemon/src/daemon.rs
@@ -423,8 +423,21 @@ impl RailLedger {
         }
     }
 
-    fn clear_pending(&mut self) {
-        self.pending_launches.clear();
+    fn fail_pending_launches(&mut self) -> bool {
+        let pending_launches = core::mem::take(&mut self.pending_launches);
+        let mut recorded_failure = false;
+        for launch in pending_launches {
+            if let PendingRailLaunch::Agent(launch) = launch {
+                self.record(RailEventKind::ExecuteFailed {
+                    launch_id: Some(launch.launch_id),
+                    executable: launch.executable,
+                    flags: launch.flags,
+                    reason: RailExecuteFailureReason::RailUnavailable,
+                });
+                recorded_failure = true;
+            }
+        }
+        recorded_failure
     }
 }
 
@@ -954,6 +967,13 @@ impl Daemon {
                 "RAIL is not enabled for this session",
             );
         }
+        let mut live = session.live.lock().expect("session live state poisoned");
+        if !matches!(live.state, ConnState::Connecting | ConnState::Connected) {
+            return Response::typed_error(
+                crate::ipc::AgentErrorCategory::Unavailable,
+                "RAIL session is not accepting launch requests",
+            );
+        }
         let permit = match session.input_tx.try_reserve() {
             Ok(permit) => permit,
             Err(_) => {
@@ -963,7 +983,6 @@ impl Daemon {
                 );
             }
         };
-        let mut live = session.live.lock().expect("session live state poisoned");
         let launch = RailLaunchInfo {
             launch_id: self.next_rail_launch_id.fetch_add(1, Ordering::Relaxed),
             executable: execute.executable.clone(),
@@ -1481,23 +1500,23 @@ async fn consume_output(
             RdpOutputEvent::ConnectionFailure(error) => {
                 guard.state = ConnState::Failed;
                 guard.error = Some(format!("{error}"));
-                guard.rail.clear_pending();
+                let rail_changed = guard.rail.fail_pending_launches();
                 error!(%error, "Session connection failed");
-                false
+                rail_changed
             }
             RdpOutputEvent::Terminated(Ok(reason)) => {
                 guard.state = ConnState::Disconnected;
                 guard.error = Some(format!("{reason:?}"));
-                guard.rail.clear_pending();
+                let rail_changed = guard.rail.fail_pending_launches();
                 info!(?reason, "Session terminated");
-                false
+                rail_changed
             }
             RdpOutputEvent::Terminated(Err(error)) => {
                 guard.state = ConnState::Failed;
                 guard.error = Some(format!("{error}"));
-                guard.rail.clear_pending();
+                let rail_changed = guard.rail.fail_pending_launches();
                 warn!(%error, "Session terminated with an error");
-                false
+                rail_changed
             }
             // With software pointer rendering the cursor is composited into the `Image` frames
             // above; the remaining pointer events (default/hidden) carry no live state we track.
@@ -1519,8 +1538,11 @@ async fn consume_output(
     ) {
         guard.state = ConnState::Disconnected;
     }
-    guard.rail.clear_pending();
+    let rail_changed = guard.rail.fail_pending_launches();
     drop(guard);
+    if rail_changed {
+        rail_notify.notify_waiters();
+    }
     notify(&notification);
 }
 
@@ -2086,15 +2108,32 @@ mod tests {
             Response::Ok(Payload::RailLaunch(RailLaunchInfo { launch_id: 1, .. }))
         ));
         assert!(matches!(input_rx.recv().await, Some(RdpInputEvent::RailExecute(_))));
+        let mut wait = Box::pin(daemon.rail_wait(Some(1), 1_000));
         output_tx
             .send(ironrdp_client::rdp::RdpOutputEvent::ConnectionFailure(
                 ironrdp_connector::general_err!("test connection failure"),
             ))
             .await
             .expect("send connection failure");
-        drop(output_tx);
-        consumer.await.expect("consume output");
 
+        let response = tokio::time::timeout(Duration::from_secs(1), wait.as_mut())
+            .await
+            .expect("connection failure wakes wait");
+        assert!(matches!(
+            response,
+            Response::Ok(Payload::RailEvents(events))
+                if matches!(
+                    events.events.as_slice(),
+                    [event] if matches!(
+                        event.kind,
+                        RailEventKind::ExecuteFailed {
+                            launch_id: Some(1),
+                            reason: ironrdp_rpc::ipc::RailExecuteFailureReason::RailUnavailable,
+                            ..
+                        }
+                    )
+                )
+        ));
         assert_eq!(
             live.lock().expect("session live state poisoned").state,
             ConnState::Failed
@@ -2103,6 +2142,55 @@ mod tests {
             daemon.rail_status(),
             Response::Ok(Payload::RailStatus(status)) if status.pending_launches.is_empty()
         ));
+
+        drop(output_tx);
+        consumer.await.expect("consume output");
+    }
+
+    #[test]
+    fn rail_launch_ids_do_not_repeat_after_a_session_reconnects() {
+        let (daemon, mut input_rx, live, _) = active_rail_session(true);
+
+        assert!(matches!(
+            daemon.rail_execute(RailExecuteRequest {
+                executable: "notepad.exe".to_owned(),
+                working_directory: String::new(),
+                arguments: String::new(),
+                flags: 0,
+            }),
+            Response::Ok(Payload::RailLaunch(RailLaunchInfo { launch_id: 1, .. }))
+        ));
+        assert!(matches!(input_rx.try_recv(), Ok(RdpInputEvent::RailExecute(_))));
+        live.lock().expect("session live state poisoned").rail = RailLedger::new(2, 1, None);
+
+        assert!(matches!(
+            daemon.rail_execute(RailExecuteRequest {
+                executable: "wordpad.exe".to_owned(),
+                working_directory: String::new(),
+                arguments: String::new(),
+                flags: 0,
+            }),
+            Response::Ok(Payload::RailLaunch(RailLaunchInfo { launch_id: 2, .. }))
+        ));
+    }
+
+    #[test]
+    fn rail_execute_rejects_terminal_sessions_without_queueing_input() {
+        let (daemon, mut input_rx, live, _) = active_rail_session(true);
+        live.lock().expect("session live state poisoned").state = ConnState::Failed;
+
+        let response = daemon.rail_execute(RailExecuteRequest {
+            executable: "notepad.exe".to_owned(),
+            working_directory: String::new(),
+            arguments: String::new(),
+            flags: 0,
+        });
+
+        assert!(matches!(
+            response,
+            Response::Err(error) if error.message == "RAIL session is not accepting launch requests"
+        ));
+        assert!(matches!(input_rx.try_recv(), Err(mpsc::error::TryRecvError::Empty)));
     }
 
     #[test]

--- a/crates/ironrdp-rpc/src/ipc.rs
+++ b/crates/ironrdp-rpc/src/ipc.rs
@@ -59,6 +59,11 @@ pub const MAX_PEN_ROTATION: u16 = 359;
 /// Maximum absolute MS-RDPEI pen tilt angle in degrees ([MS-RDPEI] 2.2.3.7.1.1).
 pub const MAX_PEN_TILT: i16 = 90;
 
+/// Maximum retained RAIL observations, excluding a possible history-gap marker.
+pub const MAX_RAIL_RETAINED_EVENTS: usize = 256;
+
+const MAX_RAIL_EVENT_DUMP_EVENTS: usize = MAX_RAIL_RETAINED_EVENTS + 1;
+
 /// One contact sample inside a [`TouchFrameRequest`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TouchContactRequest {
@@ -1862,6 +1867,9 @@ impl_pdu_pod!(RailEvent);
 
 impl Encode for RailEventDump {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        if self.events.len() > MAX_RAIL_EVENT_DUMP_EVENTS {
+            return Err(ironrdp_core::invalid_field_err!("RAIL events", "count exceeds limit"));
+        }
         ensure_size!(in: dst, size: self.size());
         dst.write_u64(self.generation);
         let count: u32 = cast_length!("RAIL event count", self.events.len())?;
@@ -1885,8 +1893,12 @@ impl Decode<'_> for RailEventDump {
     fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
         ensure_size!(in: src, size: 12);
         let generation = src.read_u64();
-        let count = src.read_u32();
-        let mut events = Vec::new();
+        let count = usize::try_from(src.read_u32())
+            .map_err(|_| ironrdp_core::other_err!("RAIL events", "count does not fit in usize"))?;
+        if count > MAX_RAIL_EVENT_DUMP_EVENTS {
+            return Err(ironrdp_core::invalid_field_err!("RAIL events", "count exceeds limit"));
+        }
+        let mut events = Vec::with_capacity(count);
         for _ in 0..count {
             events.push(RailEvent::decode(src)?);
         }
@@ -2863,7 +2875,9 @@ impl_pdu_pod!(OperationEvent);
 
 #[cfg(test)]
 mod tests {
-    use super::RailExecuteRequest;
+    use ironrdp_core::{decode, encode_vec};
+
+    use super::{MAX_RAIL_EVENT_DUMP_EVENTS, RailEvent, RailEventDump, RailEventKind, RailExecuteRequest};
 
     #[test]
     fn rail_execute_debug_redacts_command_fields() {
@@ -2879,6 +2893,24 @@ mod tests {
         assert!(!debug.contains("C:\\secret-directory"));
         assert!(!debug.contains("secret-token"));
         assert!(debug.contains("executable_len"));
+    }
+
+    #[test]
+    fn rail_event_dump_rejects_oversized_counts() {
+        let event = RailEvent {
+            sequence: 1,
+            kind: RailEventKind::Gap { lost_through: 1 },
+        };
+        let dump = RailEventDump {
+            generation: 1,
+            events: vec![event; MAX_RAIL_EVENT_DUMP_EVENTS + 1],
+        };
+        assert!(encode_vec(&dump).is_err());
+
+        let mut bytes = [0; 12];
+        bytes[8..]
+            .copy_from_slice(&(u32::try_from(MAX_RAIL_EVENT_DUMP_EVENTS + 1).expect("limit fits u32")).to_le_bytes());
+        assert!(decode::<RailEventDump>(&bytes).is_err());
     }
 }
 

--- a/crates/ironrdp-rpc/src/ipc.rs
+++ b/crates/ironrdp-rpc/src/ipc.rs
@@ -2906,7 +2906,10 @@ mod tests {
             events: vec![event.clone(); MAX_RAIL_EVENT_DUMP_EVENTS],
         };
         let encoded = encode_vec(&accepted).expect("encode the event limit");
-        assert_eq!(decode::<RailEventDump>(&encoded).expect("decode the event limit"), accepted);
+        assert_eq!(
+            decode::<RailEventDump>(&encoded).expect("decode the event limit"),
+            accepted
+        );
 
         let dump = RailEventDump {
             generation: 1,

--- a/crates/ironrdp-rpc/src/ipc.rs
+++ b/crates/ironrdp-rpc/src/ipc.rs
@@ -2901,6 +2901,13 @@ mod tests {
             sequence: 1,
             kind: RailEventKind::Gap { lost_through: 1 },
         };
+        let accepted = RailEventDump {
+            generation: 1,
+            events: vec![event.clone(); MAX_RAIL_EVENT_DUMP_EVENTS],
+        };
+        let encoded = encode_vec(&accepted).expect("encode the event limit");
+        assert_eq!(decode::<RailEventDump>(&encoded).expect("decode the event limit"), accepted);
+
         let dump = RailEventDump {
             generation: 1,
             events: vec![event; MAX_RAIL_EVENT_DUMP_EVENTS + 1],


### PR DESCRIPTION
Retain RAIL audit history after a session terminates while clearing Execute requests that can no longer receive a result, including connection failures.
Render daemon RAIL errors in the selected machine format and exit nonzero.
Keep bounded RAIL event encoding symmetric with decoding.