### PR TITLE
feat(rdpdr): plumb smartcard device into RDPDR backends

### DIFF
--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -2619,8 +2619,8 @@ mod tests {
     use ironrdp_rdpdr::pdu::RdpdrPdu;
     #[cfg(feature = "rdpdr")]
     use ironrdp_rdpdr::pdu::efs::{
-        DeviceControlRequest, ServerDeviceAnnounceResponse, ServerDriveIoRequest, VERSION_MINOR_12, VersionAndIdPdu,
-        VersionAndIdPduKind,
+        CapabilityMessage, CoreCapability, CoreCapabilityKind, DeviceControlRequest, DeviceType,
+        ServerDeviceAnnounceResponse, ServerDriveIoRequest, VERSION_MINOR_12, VersionAndIdPdu, VersionAndIdPduKind,
     };
     #[cfg(feature = "rdpdr")]
     use ironrdp_rdpdr::pdu::esc::{ScardCall, ScardIoCtlCode};
@@ -2890,7 +2890,7 @@ mod tests {
             smartcard: true,
         };
 
-        let rdpdr = build_rdpdr_channel(Some(&factory), &config)
+        let mut rdpdr = build_rdpdr_channel(Some(&factory), &config)
             .expect("smartcard-only RDPDR should not fail")
             .expect("smartcard-only product should build a channel");
 
@@ -2901,6 +2901,75 @@ mod tests {
                 .expect("test backend should be retained")
                 .instance
                 >= 1
+        );
+
+        let client_id = 0x1234_5678;
+        let server_announce = RdpdrPdu::VersionAndIdPdu(VersionAndIdPdu {
+            version_major: 1,
+            version_minor: VERSION_MINOR_12,
+            client_id,
+            kind: VersionAndIdPduKind::ServerAnnounceRequest,
+        });
+        assert_eq!(
+            rdpdr
+                .process(&encode_vec(&server_announce).expect("encode server announce"))
+                .expect("process server announce")
+                .len(),
+            2
+        );
+
+        let client_confirm = RdpdrPdu::VersionAndIdPdu(VersionAndIdPdu {
+            version_major: 1,
+            version_minor: VERSION_MINOR_12,
+            client_id,
+            kind: VersionAndIdPduKind::ServerClientIdConfirm,
+        });
+        let announcements = rdpdr
+            .process(&encode_vec(&client_confirm).expect("encode client ID confirm"))
+            .expect("process client ID confirm");
+        assert_eq!(announcements.len(), 1);
+        let wire = announcements[0]
+            .encode_unframed_pdu()
+            .expect("encode device announcement");
+        assert_eq!(
+            u16::from_le_bytes(wire[2..4].try_into().expect("device announcement packet ID")),
+            u16::from(ironrdp_rdpdr::pdu::PacketId::CoreDevicelistAnnounce)
+        );
+        assert_eq!(u32::from_le_bytes(wire[4..8].try_into().expect("device count")), 1);
+        assert_eq!(
+            u32::from_le_bytes(wire[8..12].try_into().expect("device type")),
+            u32::from(DeviceType::Smartcard)
+        );
+        assert_eq!(u32::from_le_bytes(wire[12..16].try_into().expect("device ID")), 0);
+
+        let server_capability = RdpdrPdu::CoreCapability(CoreCapability {
+            capabilities: vec![
+                CapabilityMessage::new_general(0),
+                CapabilityMessage::new_drive(),
+                CapabilityMessage::new_smartcard(),
+            ],
+            kind: CoreCapabilityKind::ServerCoreCapabilityRequest,
+        });
+        let capability_response = rdpdr
+            .process(&encode_vec(&server_capability).expect("encode server capability"))
+            .expect("process server capability");
+        assert_eq!(capability_response.len(), 1);
+        assert_eq!(
+            capability_response[0]
+                .encode_unframed_pdu()
+                .expect("encode client capability"),
+            encode_vec(&RdpdrPdu::CoreCapability(CoreCapability::new_response(vec![
+                CapabilityMessage::new_general(1),
+                CapabilityMessage::new_smartcard(),
+            ])))
+            .expect("encode expected client capability")
+        );
+
+        assert!(
+            rdpdr
+                .process(&encode_vec(&RdpdrPdu::UserLoggedon).expect("encode user logged on"))
+                .expect("process user logged on")
+                .is_empty()
         );
     }
 

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -787,7 +787,12 @@ fn build_rdpdr_channel(
         .into_iter()
         .map(RdpdrDrive::into_parts)
         .collect::<Vec<_>>();
-    let rdpdr_channel = ironrdp_rdpdr::Rdpdr::new(backend, "IronRDP".to_owned()).with_drives(Some(initial_drives));
+
+    // Do not advertise drive capability for smartcard-only products.
+    let mut rdpdr_channel = ironrdp_rdpdr::Rdpdr::new(backend, "IronRDP".to_owned());
+    if !initial_drives.is_empty() {
+        rdpdr_channel = rdpdr_channel.with_drives(Some(initial_drives));
+    }
 
     #[cfg(feature = "smartcard")]
     let rdpdr_channel = if smartcard {
@@ -2857,13 +2862,43 @@ mod tests {
     #[test]
     fn empty_rdpdr_product_omits_the_channel() {
         let factory = CountingRdpdrFactory::new(Vec::new());
+        // Default RdpdrConfig enables smartcard when the feature is on; disable it so
+        // this case still covers an empty drive product with no smartcard device.
+        let config = crate::config::RdpdrConfig {
+            enabled: true,
+            #[cfg(feature = "smartcard")]
+            smartcard: false,
+        };
 
         assert!(
-            build_rdpdr_channel(Some(&factory), &crate::config::RdpdrConfig::default())
+            build_rdpdr_channel(Some(&factory), &config)
                 .expect("empty RDPDR product should not fail")
                 .is_none()
         );
         assert_eq!(factory.builds.load(Ordering::SeqCst), 1);
+    }
+
+    #[cfg(all(feature = "rdpdr", feature = "smartcard"))]
+    #[test]
+    fn smartcard_only_rdpdr_builds_without_drives() {
+        let factory = CountingRdpdrFactory::new(Vec::new());
+        let config = crate::config::RdpdrConfig {
+            enabled: true,
+            smartcard: true,
+        };
+
+        let rdpdr = build_rdpdr_channel(Some(&factory), &config)
+            .expect("smartcard-only RDPDR should not fail")
+            .expect("smartcard-only product should build a channel");
+
+        assert_eq!(factory.builds.load(Ordering::SeqCst), 1);
+        assert!(
+            rdpdr
+                .downcast_backend::<TestRdpdrBackend>()
+                .expect("test backend should be retained")
+                .instance
+                >= 1
+        );
     }
 
     #[cfg(feature = "rdpdr")]

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -789,6 +789,9 @@ fn build_rdpdr_channel(
         .collect::<Vec<_>>();
 
     // Do not advertise drive capability for smartcard-only products.
+    // Skipping `with_drives` omits CAP_DRIVE_REDIRECT, so later
+    // `Rdpdr::add_dynamic_drive` hot-plug is unavailable on that session.
+    // Prefer attaching an empty drive list only when drive hot-plug is required.
     let mut rdpdr_channel = ironrdp_rdpdr::Rdpdr::new(backend, "IronRDP".to_owned());
     if !initial_drives.is_empty() {
         rdpdr_channel = rdpdr_channel.with_drives(Some(initial_drives));

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -773,7 +773,13 @@ fn build_rdpdr_channel(
         .build_rdpdr_backend()
         .map_err(|error| ironrdp_connector::custom_err!("build RDPDR backend", RdpdrBackendBuildError(error)))?
         .into_parts();
-    if initial_drives.is_empty() {
+
+    #[cfg(feature = "smartcard")]
+    let smartcard = config.smartcard;
+    #[cfg(not(feature = "smartcard"))]
+    let smartcard = false;
+
+    if initial_drives.is_empty() && !smartcard {
         return Ok(None);
     }
 
@@ -784,7 +790,7 @@ fn build_rdpdr_channel(
     let rdpdr_channel = ironrdp_rdpdr::Rdpdr::new(backend, "IronRDP".to_owned()).with_drives(Some(initial_drives));
 
     #[cfg(feature = "smartcard")]
-    let rdpdr_channel = if config.smartcard {
+    let rdpdr_channel = if smartcard {
         rdpdr_channel.with_smartcard(0)
     } else {
         rdpdr_channel
@@ -2653,8 +2659,8 @@ mod tests {
             &mut self,
             _req: DeviceControlRequest<ScardIoCtlCode>,
             _call: ScardCall,
-        ) -> ironrdp_pdu::PduResult<()> {
-            Ok(())
+        ) -> ironrdp_pdu::PduResult<Vec<SvcMessage>> {
+            Ok(Vec::new())
         }
 
         fn handle_drive_io_request(&mut self, _req: ServerDriveIoRequest) -> ironrdp_pdu::PduResult<Vec<SvcMessage>> {

--- a/crates/ironrdp-rdpdr-native/README.md
+++ b/crates/ironrdp-rdpdr-native/README.md
@@ -21,9 +21,15 @@ Native backend building blocks for the IronRDP RDPDR static channel.
   64-byte output, plus the read-only `FSCTL_GET_COMPRESSION`,
   `FSCTL_GET_INTEGRITY_INFORMATION`, and `FSCTL_QUERY_ALLOCATED_RANGES`, all
   with validated, bounded buffers.
+  - On Windows, optional smartcard redirection is pluggable via
+    `WindowsRdpdrBackendFactory::with_smartcard(true)`. Smartcard-only products
+    (no drives) are valid. The current backend is a compile-ready stub that
+    completes decoded MS-RDPESC calls with `SCARD_E_UNSUPPORTED_FEATURE`; a full
+    WinSCard implementation is a follow-up.
 
 The Windows implementation is intentionally layered so protocol code remains
 platform independent in `ironrdp-rdpdr`.
 
-`WindowsRdpdrBackendFactory` configures one `RedirectedDrive`. Multi-drive
-registry management remains outside this native backend.
+`WindowsRdpdrBackendFactory` configures zero or more `RedirectedDrive`s and an
+optional smartcard flag. Multi-drive registry management remains outside this
+native backend.

--- a/crates/ironrdp-rdpdr-native/README.md
+++ b/crates/ironrdp-rdpdr-native/README.md
@@ -21,15 +21,12 @@ Native backend building blocks for the IronRDP RDPDR static channel.
   64-byte output, plus the read-only `FSCTL_GET_COMPRESSION`,
   `FSCTL_GET_INTEGRITY_INFORMATION`, and `FSCTL_QUERY_ALLOCATED_RANGES`, all
   with validated, bounded buffers.
-  - On Windows, optional smartcard redirection is pluggable via
-    `WindowsRdpdrBackendFactory::with_smartcard(true)`. Smartcard-only products
-    (no drives) are valid. The current backend is a compile-ready stub that
-    completes decoded MS-RDPESC calls with `SCARD_E_UNSUPPORTED_FEATURE`; a full
-    WinSCard implementation is a follow-up.
+  - Smartcard-only products are valid when the channel is configured with `ironrdp_rdpdr::Rdpdr::with_smartcard(0)`.
+    The current Windows backend is a compile-ready stub that completes decoded MS-RDPESC calls with `SCARD_E_UNSUPPORTED_FEATURE`.
+    A full WinSCard implementation is a follow-up.
 
 The Windows implementation is intentionally layered so protocol code remains
 platform independent in `ironrdp-rdpdr`.
 
-`WindowsRdpdrBackendFactory` configures zero or more `RedirectedDrive`s and an
-optional smartcard flag. Multi-drive registry management remains outside this
-native backend.
+`WindowsRdpdrBackendFactory` configures zero or more `RedirectedDrive`s.
+Multi-drive registry management remains outside this native backend.

--- a/crates/ironrdp-rdpdr-native/src/nix/backend.rs
+++ b/crates/ironrdp-rdpdr-native/src/nix/backend.rs
@@ -37,8 +37,12 @@ impl RdpdrBackend for NixRdpdrBackend {
     fn handle_server_device_announce_response(&mut self, _pdu: ServerDeviceAnnounceResponse) -> PduResult<()> {
         Ok(())
     }
-    fn handle_scard_call(&mut self, _req: DeviceControlRequest<ScardIoCtlCode>, _call: ScardCall) -> PduResult<()> {
-        Ok(())
+    fn handle_scard_call(
+        &mut self,
+        _req: DeviceControlRequest<ScardIoCtlCode>,
+        _call: ScardCall,
+    ) -> PduResult<Vec<SvcMessage>> {
+        Ok(Vec::new())
     }
     fn handle_drive_io_request(&mut self, req: ServerDriveIoRequest) -> PduResult<Vec<SvcMessage>> {
         debug!("handle_drive_io_request:{:?}", req);

--- a/crates/ironrdp-rdpdr-native/src/windows/backend.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/backend.rs
@@ -31,22 +31,22 @@ pub struct WindowsRdpdrBackend {
     pub(super) roots: HashMap<u32, RedirectedRoot>,
     pub(super) open_files: FileTable<OpenFile>,
     deferred_operations: DeferredOperations,
-    scard: Option<ScardSession>,
+    scard: ScardSession,
 }
 
 impl WindowsRdpdrBackend {
     #[cfg(test)]
     pub(crate) fn from_drive(drive: RedirectedDrive) -> Self {
-        Self::from_drives(vec![drive], false)
+        Self::from_drives(vec![drive])
     }
 
-    pub(crate) fn from_drives(drives: Vec<RedirectedDrive>, smartcard: bool) -> Self {
+    pub(crate) fn from_drives(drives: Vec<RedirectedDrive>) -> Self {
         Self {
             drives: drives.into_iter().map(|drive| (drive.device_id(), drive)).collect(),
             roots: HashMap::new(),
             open_files: FileTable::new(DEFAULT_MAX_OPEN_FILES),
             deferred_operations: DeferredOperations::new(),
-            scard: smartcard.then(ScardSession::new),
+            scard: ScardSession::new(),
         }
     }
 
@@ -151,9 +151,7 @@ impl RdpdrBackend for WindowsRdpdrBackend {
 
     fn reset(&mut self) -> PduResult<()> {
         self.deferred_operations.reset();
-        if let Some(scard) = self.scard.as_mut() {
-            scard.reset();
-        }
+        self.scard.reset();
         self.open_files.clear();
         self.roots.clear();
         Ok(())
@@ -172,11 +170,7 @@ impl RdpdrBackend for WindowsRdpdrBackend {
         req: DeviceControlRequest<ScardIoCtlCode>,
         call: ScardCall,
     ) -> PduResult<Vec<SvcMessage>> {
-        // Always complete MS-RDPESC IRPs. The channel may announce device ID 0
-        // even when the factory left `with_smartcard(false)`, and dropping the
-        // IRP hangs the server. Lazy-create the stub session on first use so
-        // announce and backend cannot diverge.
-        self.scard.get_or_insert_with(ScardSession::new).handle_call(req, call)
+        self.scard.handle_call(req, call)
     }
 
     fn add_drive(&mut self, device_id: u32) -> PduResult<()> {
@@ -215,9 +209,7 @@ impl RdpdrBackend for WindowsRdpdrBackend {
 
     fn poll_deferred_messages(&mut self) -> PduResult<Vec<SvcMessage>> {
         let mut messages = self.deferred_operations.poll();
-        if let Some(scard) = self.scard.as_mut() {
-            messages.extend(scard.poll());
-        }
+        messages.extend(self.scard.poll());
         Ok(messages)
     }
 }
@@ -254,13 +246,10 @@ mod tests {
     fn backend_restores_each_selected_drive() {
         let system_drive = std::env::var("SystemDrive").expect("SystemDrive is set on Windows");
         let root = format!(r"{system_drive}\");
-        let mut backend = WindowsRdpdrBackend::from_drives(
-            vec![
-                RedirectedDrive::new(1, "System", &root, false).expect("valid system drive"),
-                RedirectedDrive::new(2, "System copy", root, false).expect("valid system drive copy"),
-            ],
-            false,
-        );
+        let mut backend = WindowsRdpdrBackend::from_drives(vec![
+            RedirectedDrive::new(1, "System", &root, false).expect("valid system drive"),
+            RedirectedDrive::new(2, "System copy", root, false).expect("valid system drive copy"),
+        ]);
 
         ironrdp_rdpdr::RdpdrBackend::restore_drive(&mut backend, 1).expect("restore first selected drive");
         ironrdp_rdpdr::RdpdrBackend::restore_drive(&mut backend, 2).expect("restore second selected drive");
@@ -270,10 +259,8 @@ mod tests {
     }
 
     #[test]
-    fn scard_irp_completes_when_factory_smartcard_flag_is_off() {
-        // Channel announce can enable device 0 without factory.with_smartcard(true).
-        let mut backend = WindowsRdpdrBackend::from_drives(Vec::new(), false);
-        assert!(backend.scard.is_none());
+    fn scard_irp_completes_without_redirected_drives() {
+        let mut backend = WindowsRdpdrBackend::from_drives(Vec::new());
 
         let req = DeviceControlRequest {
             header: DeviceIoRequest {
@@ -293,9 +280,8 @@ mod tests {
             req,
             ScardCall::EstablishContextCall(EstablishContextCall { scope: Scope::User }),
         )
-        .expect("lazy stub must complete the IRP");
+        .expect("stub must complete the IRP");
 
         assert_eq!(messages.len(), 1);
-        assert!(backend.scard.is_some());
     }
 }

--- a/crates/ironrdp-rdpdr-native/src/windows/backend.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/backend.rs
@@ -9,18 +9,14 @@ use ironrdp_rdpdr::pdu::efs::{
 use ironrdp_rdpdr::pdu::esc::{ScardCall, ScardIoCtlCode};
 use ironrdp_svc::SvcMessage;
 
-use super::control;
-use super::directory;
 use super::factory::RedirectedDrive;
-use super::file;
 use super::file_table::FileTable;
 use super::handles::{FileHandle, RootDirectory};
-use super::locks;
 use super::path::RelativePath;
 use super::pending::DeferredOperations;
-use super::security;
+use super::scard::ScardSession;
 use super::status::from_open_directory;
-use super::volume;
+use super::{control, directory, file, locks, security, volume};
 
 const DEFAULT_MAX_OPEN_FILES: usize = 1_024;
 
@@ -35,20 +31,22 @@ pub struct WindowsRdpdrBackend {
     pub(super) roots: HashMap<u32, RedirectedRoot>,
     pub(super) open_files: FileTable<OpenFile>,
     deferred_operations: DeferredOperations,
+    scard: Option<ScardSession>,
 }
 
 impl WindowsRdpdrBackend {
     #[cfg(test)]
     pub(crate) fn from_drive(drive: RedirectedDrive) -> Self {
-        Self::from_drives(vec![drive])
+        Self::from_drives(vec![drive], false)
     }
 
-    pub(crate) fn from_drives(drives: Vec<RedirectedDrive>) -> Self {
+    pub(crate) fn from_drives(drives: Vec<RedirectedDrive>, smartcard: bool) -> Self {
         Self {
             drives: drives.into_iter().map(|drive| (drive.device_id(), drive)).collect(),
             roots: HashMap::new(),
             open_files: FileTable::new(DEFAULT_MAX_OPEN_FILES),
             deferred_operations: DeferredOperations::new(),
+            scard: smartcard.then(ScardSession::new),
         }
     }
 
@@ -153,6 +151,9 @@ impl RdpdrBackend for WindowsRdpdrBackend {
 
     fn reset(&mut self) -> PduResult<()> {
         self.deferred_operations.reset();
+        if let Some(scard) = self.scard.as_mut() {
+            scard.reset();
+        }
         self.open_files.clear();
         self.roots.clear();
         Ok(())
@@ -166,8 +167,15 @@ impl RdpdrBackend for WindowsRdpdrBackend {
         Ok(())
     }
 
-    fn handle_scard_call(&mut self, _req: DeviceControlRequest<ScardIoCtlCode>, _call: ScardCall) -> PduResult<()> {
-        Ok(())
+    fn handle_scard_call(
+        &mut self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+        call: ScardCall,
+    ) -> PduResult<Vec<SvcMessage>> {
+        match self.scard.as_mut() {
+            Some(scard) => scard.handle_call(req, call),
+            None => Ok(Vec::new()),
+        }
     }
 
     fn add_drive(&mut self, device_id: u32) -> PduResult<()> {
@@ -205,7 +213,11 @@ impl RdpdrBackend for WindowsRdpdrBackend {
     }
 
     fn poll_deferred_messages(&mut self) -> PduResult<Vec<SvcMessage>> {
-        Ok(self.deferred_operations.poll())
+        let mut messages = self.deferred_operations.poll();
+        if let Some(scard) = self.scard.as_mut() {
+            messages.extend(scard.poll());
+        }
+        Ok(messages)
     }
 }
 
@@ -238,10 +250,13 @@ mod tests {
     fn backend_restores_each_selected_drive() {
         let system_drive = std::env::var("SystemDrive").expect("SystemDrive is set on Windows");
         let root = format!(r"{system_drive}\");
-        let mut backend = WindowsRdpdrBackend::from_drives(vec![
-            RedirectedDrive::new(1, "System", &root, false).expect("valid system drive"),
-            RedirectedDrive::new(2, "System copy", root, false).expect("valid system drive copy"),
-        ]);
+        let mut backend = WindowsRdpdrBackend::from_drives(
+            vec![
+                RedirectedDrive::new(1, "System", &root, false).expect("valid system drive"),
+                RedirectedDrive::new(2, "System copy", root, false).expect("valid system drive copy"),
+            ],
+            false,
+        );
 
         ironrdp_rdpdr::RdpdrBackend::restore_drive(&mut backend, 1).expect("restore first selected drive");
         ironrdp_rdpdr::RdpdrBackend::restore_drive(&mut backend, 2).expect("restore second selected drive");

--- a/crates/ironrdp-rdpdr-native/src/windows/backend.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/backend.rs
@@ -172,10 +172,11 @@ impl RdpdrBackend for WindowsRdpdrBackend {
         req: DeviceControlRequest<ScardIoCtlCode>,
         call: ScardCall,
     ) -> PduResult<Vec<SvcMessage>> {
-        match self.scard.as_mut() {
-            Some(scard) => scard.handle_call(req, call),
-            None => Ok(Vec::new()),
-        }
+        // Always complete MS-RDPESC IRPs. The channel may announce device ID 0
+        // even when the factory left `with_smartcard(false)`, and dropping the
+        // IRP hangs the server. Lazy-create the stub session on first use so
+        // announce and backend cannot diverge.
+        self.scard.get_or_insert_with(ScardSession::new).handle_call(req, call)
     }
 
     fn add_drive(&mut self, device_id: u32) -> PduResult<()> {
@@ -244,6 +245,9 @@ pub(super) struct OpenFile {
 
 #[cfg(test)]
 mod tests {
+    use ironrdp_rdpdr::pdu::efs::{DeviceIoRequest, MajorFunction, MinorFunction};
+    use ironrdp_rdpdr::pdu::esc::{EstablishContextCall, ScardIoCtlCode, Scope};
+
     use super::*;
 
     #[test]
@@ -263,5 +267,35 @@ mod tests {
 
         assert!(backend.roots.contains_key(&1));
         assert!(backend.roots.contains_key(&2));
+    }
+
+    #[test]
+    fn scard_irp_completes_when_factory_smartcard_flag_is_off() {
+        // Channel announce can enable device 0 without factory.with_smartcard(true).
+        let mut backend = WindowsRdpdrBackend::from_drives(Vec::new(), false);
+        assert!(backend.scard.is_none());
+
+        let req = DeviceControlRequest {
+            header: DeviceIoRequest {
+                device_id: 0,
+                file_id: 0,
+                completion_id: 11,
+                major_function: MajorFunction::DeviceControl,
+                minor_function: MinorFunction::from(0),
+            },
+            output_buffer_length: 2048,
+            input_buffer_length: 0,
+            io_control_code: ScardIoCtlCode::EstablishContext,
+        };
+
+        let messages = ironrdp_rdpdr::RdpdrBackend::handle_scard_call(
+            &mut backend,
+            req,
+            ScardCall::EstablishContextCall(EstablishContextCall { scope: Scope::User }),
+        )
+        .expect("lazy stub must complete the IRP");
+
+        assert_eq!(messages.len(), 1);
+        assert!(backend.scard.is_some());
     }
 }

--- a/crates/ironrdp-rdpdr-native/src/windows/factory.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/factory.rs
@@ -96,21 +96,17 @@ impl core::error::Error for RedirectedDriveError {}
 /// the portable RDPDR crate.
 ///
 /// Smartcard redirection is optional and independent of drives: an empty drive
-/// list with `smartcard` enabled is valid for smartcard-only sessions.
+/// list is valid for smartcard-only sessions.
 #[derive(Clone, Debug)]
 pub struct WindowsRdpdrBackendFactory {
     drives: Vec<RedirectedDrive>,
-    smartcard: bool,
 }
 
 impl WindowsRdpdrBackendFactory {
     /// Configures the single logical-volume root supported by this baseline.
     #[must_use]
     pub fn new(drive: RedirectedDrive) -> Self {
-        Self {
-            drives: vec![drive],
-            smartcard: false,
-        }
+        Self { drives: vec![drive] }
     }
 
     /// Configures the logical-volume roots selected for one connection.
@@ -122,23 +118,7 @@ impl WindowsRdpdrBackendFactory {
             }
         }
 
-        Ok(Self {
-            drives,
-            smartcard: false,
-        })
-    }
-
-    /// Enables or disables smartcard redirection on the built backend.
-    #[must_use]
-    pub fn with_smartcard(mut self, enabled: bool) -> Self {
-        self.smartcard = enabled;
-        self
-    }
-
-    /// Returns whether smartcard redirection is enabled for this factory.
-    #[must_use]
-    pub fn smartcard(&self) -> bool {
-        self.smartcard
+        Ok(Self { drives })
     }
 
     /// Returns the initial `(device_id, name)` pair for `Rdpdr::with_drives`.
@@ -157,7 +137,7 @@ impl WindowsRdpdrBackendFactory {
     /// sequence.
     #[must_use]
     pub fn build(&self) -> WindowsRdpdrBackend {
-        WindowsRdpdrBackend::from_drives(self.drives.clone(), self.smartcard)
+        WindowsRdpdrBackend::from_drives(self.drives.clone())
     }
 }
 
@@ -242,16 +222,5 @@ mod tests {
         ]);
 
         assert!(matches!(result, Err(RedirectedDriveFactoryError::DuplicateDeviceId(1))));
-    }
-
-    #[test]
-    fn factory_allows_smartcard_only_product() {
-        let factory = WindowsRdpdrBackendFactory::from_drives(Vec::new())
-            .expect("empty drive list is valid")
-            .with_smartcard(true);
-
-        assert!(factory.smartcard());
-        assert!(factory.initial_drives().is_empty());
-        let _backend = factory.build();
     }
 }

--- a/crates/ironrdp-rdpdr-native/src/windows/factory.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/factory.rs
@@ -4,8 +4,9 @@ use core::fmt;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
-use super::backend::WindowsRdpdrBackend;
 use ironrdp_rdpdr::{RdpdrBackendFactory, RdpdrBackendFactoryResult, RdpdrBackendProduct, RdpdrDrive};
+
+use super::backend::WindowsRdpdrBackend;
 
 /// Immutable logical-volume definition selected for Windows RDPDR redirection.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -93,16 +94,23 @@ impl core::error::Error for RedirectedDriveError {}
 /// The returned initial-drive list is intentionally shaped for
 /// [`ironrdp_rdpdr::Rdpdr::with_drives`], keeping platform configuration out of
 /// the portable RDPDR crate.
+///
+/// Smartcard redirection is optional and independent of drives: an empty drive
+/// list with `smartcard` enabled is valid for smartcard-only sessions.
 #[derive(Clone, Debug)]
 pub struct WindowsRdpdrBackendFactory {
     drives: Vec<RedirectedDrive>,
+    smartcard: bool,
 }
 
 impl WindowsRdpdrBackendFactory {
     /// Configures the single logical-volume root supported by this baseline.
     #[must_use]
     pub fn new(drive: RedirectedDrive) -> Self {
-        Self { drives: vec![drive] }
+        Self {
+            drives: vec![drive],
+            smartcard: false,
+        }
     }
 
     /// Configures the logical-volume roots selected for one connection.
@@ -114,7 +122,23 @@ impl WindowsRdpdrBackendFactory {
             }
         }
 
-        Ok(Self { drives })
+        Ok(Self {
+            drives,
+            smartcard: false,
+        })
+    }
+
+    /// Enables or disables smartcard redirection on the built backend.
+    #[must_use]
+    pub fn with_smartcard(mut self, enabled: bool) -> Self {
+        self.smartcard = enabled;
+        self
+    }
+
+    /// Returns whether smartcard redirection is enabled for this factory.
+    #[must_use]
+    pub fn smartcard(&self) -> bool {
+        self.smartcard
     }
 
     /// Returns the initial `(device_id, name)` pair for `Rdpdr::with_drives`.
@@ -133,7 +157,7 @@ impl WindowsRdpdrBackendFactory {
     /// sequence.
     #[must_use]
     pub fn build(&self) -> WindowsRdpdrBackend {
-        WindowsRdpdrBackend::from_drives(self.drives.clone())
+        WindowsRdpdrBackend::from_drives(self.drives.clone(), self.smartcard)
     }
 }
 
@@ -218,5 +242,16 @@ mod tests {
         ]);
 
         assert!(matches!(result, Err(RedirectedDriveFactoryError::DuplicateDeviceId(1))));
+    }
+
+    #[test]
+    fn factory_allows_smartcard_only_product() {
+        let factory = WindowsRdpdrBackendFactory::from_drives(Vec::new())
+            .expect("empty drive list is valid")
+            .with_smartcard(true);
+
+        assert!(factory.smartcard());
+        assert!(factory.initial_drives().is_empty());
+        let _backend = factory.build();
     }
 }

--- a/crates/ironrdp-rdpdr-native/src/windows/mod.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/mod.rs
@@ -8,6 +8,7 @@ mod handles;
 mod locks;
 mod path;
 mod pending;
+mod scard;
 mod security;
 mod status;
 mod volume;

--- a/crates/ironrdp-rdpdr-native/src/windows/scard/mod.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/scard/mod.rs
@@ -1,8 +1,8 @@
 //! Stub Windows smartcard session for RDPDR device ID 0.
 //!
 //! Completes every decoded MS-RDPESC call with the IOCTL-appropriate return
-//! PDU and `SCARD_E_UNSUPPORTED_FEATURE`, so peers never hang or mis-decode
-//! while the real WinSCard backend lands.
+//! PDU and `SCARD_E_UNSUPPORTED_FEATURE`, so peers never hang or decode the
+//! wrong structure while the real WinSCard backend lands.
 
 use ironrdp_pdu::PduResult;
 use ironrdp_pdu::utils::CharacterSet;

--- a/crates/ironrdp-rdpdr-native/src/windows/scard/mod.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/scard/mod.rs
@@ -1,0 +1,46 @@
+//! Stub Windows smartcard session for RDPDR device ID 0.
+//!
+//! Completes every decoded MS-RDPESC call with `SCARD_E_UNSUPPORTED_FEATURE`
+//! so Device Control IRPs never hang while the real WinSCard backend lands.
+
+use ironrdp_pdu::PduResult;
+use ironrdp_rdpdr::pdu::RdpdrPdu;
+use ironrdp_rdpdr::pdu::efs::{DeviceControlRequest, DeviceControlResponse, NtStatus};
+use ironrdp_rdpdr::pdu::esc::{LongReturn, ReturnCode, ScardCall, ScardIoCtlCode};
+use ironrdp_svc::SvcMessage;
+
+/// Per-connection smartcard state for RDPDR device ID 0.
+///
+/// This stub holds no native WinSCard resources. It only provides the backend
+/// hooks (`new` / `reset` / `poll` / `handle_call`) expected by
+/// [`super::backend::WindowsRdpdrBackend`].
+#[derive(Debug, Default)]
+pub(super) struct ScardSession;
+
+impl ScardSession {
+    pub(super) fn new() -> Self {
+        Self
+    }
+
+    pub(super) fn reset(&mut self) {}
+
+    pub(super) fn poll(&mut self) -> Vec<SvcMessage> {
+        Vec::new()
+    }
+
+    pub(super) fn handle_call(
+        &mut self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+        _call: ScardCall,
+    ) -> PduResult<Vec<SvcMessage>> {
+        Ok(vec![complete_long(req, ReturnCode::UnsupportedFeature)])
+    }
+}
+
+fn complete_long(req: DeviceControlRequest<ScardIoCtlCode>, code: ReturnCode) -> SvcMessage {
+    SvcMessage::from(RdpdrPdu::DeviceControlResponse(DeviceControlResponse::new(
+        req,
+        NtStatus::SUCCESS,
+        Some(Box::new(LongReturn::new(code))),
+    )))
+}

--- a/crates/ironrdp-rdpdr-native/src/windows/scard/mod.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/scard/mod.rs
@@ -20,7 +20,8 @@ use ironrdp_svc::SvcMessage;
 ///
 /// This stub holds no native WinSCard resources. It only provides the backend
 /// hooks (`new` / `reset` / `poll` / `handle_call`) expected by
-/// [`super::backend::WindowsRdpdrBackend`].
+/// [`super::backend::WindowsRdpdrBackend`]. `reset` and `poll` stay no-ops until
+/// the real WinSCard backend needs deferred completions.
 #[derive(Debug, Default)]
 pub(super) struct ScardSession;
 
@@ -40,59 +41,60 @@ impl ScardSession {
         req: DeviceControlRequest<ScardIoCtlCode>,
         call: ScardCall,
     ) -> PduResult<Vec<SvcMessage>> {
-        let code = ReturnCode::UnsupportedFeature;
-        let empty_context = ScardContext::new(0);
-        let empty_handle = ScardHandle::new(empty_context, 0);
-        let undefined = CardProtocol::SCARD_PROTOCOL_UNDEFINED;
+        let output = stub_output(req.io_control_code, call);
+        Ok(vec![complete_rpce(req, output)])
+    }
+}
 
-        let message = match call {
-            ScardCall::AccessStartedEventCall(_)
-            | ScardCall::HCardAndDispositionCall(_)
-            | ScardCall::SetAttribCall(_)
-            | ScardCall::ContextCall(_)
-            | ScardCall::WriteCacheCall(_)
-            | ScardCall::ContextAndStringCall(_)
-            | ScardCall::ContextAndTwoStringCall(_)
-            | ScardCall::Unsupported => complete_rpce(req, Box::new(LongReturn::new(code))),
-            ScardCall::EstablishContextCall(_) => {
-                complete_rpce(req, Box::new(EstablishContextReturn::new(code, empty_context)))
-            }
-            ScardCall::ListReaderGroupsCall(_) | ScardCall::ListReadersCall(_) => {
-                complete_rpce(req, Box::new(ListReadersReturn::new(code, Vec::new())))
-            }
-            ScardCall::GetStatusChangeCall(_) | ScardCall::LocateCardsCall(_) | ScardCall::LocateCardsByAtrCall(_) => {
-                complete_rpce(req, Box::new(GetStatusChangeReturn::new(code, Vec::new())))
-            }
-            ScardCall::ConnectCall(_) => {
-                complete_rpce(req, Box::new(ConnectReturn::new(code, empty_handle, undefined)))
-            }
-            ScardCall::ReconnectCall(_) => complete_rpce(req, Box::new(ReconnectReturn::new(code, undefined))),
-            ScardCall::TransmitCall(_) => complete_rpce(req, Box::new(TransmitReturn::new(code, None, Vec::new()))),
-            ScardCall::StatusCall(_) => complete_rpce(
-                req,
-                Box::new(StatusReturn::new(
-                    code,
-                    Vec::new(),
-                    CardState::Unknown,
-                    undefined,
-                    [0u8; 32],
-                    0,
-                    CharacterSet::Unicode,
-                )),
-            ),
-            ScardCall::StateCall(_) => complete_rpce(
-                req,
-                Box::new(StateReturn::new(code, CardState::Unknown, undefined, Vec::new())),
-            ),
-            ScardCall::ControlCall(_) => complete_rpce(req, Box::new(ControlReturn::new(code, Vec::new()))),
-            ScardCall::GetAttribCall(_) => complete_rpce(req, Box::new(GetAttribReturn::new(code, Vec::new()))),
-            ScardCall::GetTransmitCountCall(_) => complete_rpce(req, Box::new(GetTransmitCountReturn::new(code, 0))),
-            ScardCall::GetDeviceTypeIdCall(_) => complete_rpce(req, Box::new(GetDeviceTypeIdReturn::new(code, 0))),
-            ScardCall::ReadCacheCall(_) => complete_rpce(req, Box::new(ReadCacheReturn::new(code, Vec::new()))),
-            ScardCall::GetReaderIconCall(_) => complete_rpce(req, Box::new(GetReaderIconReturn::new(code, Vec::new()))),
-        };
+fn stub_output(io_control_code: ScardIoCtlCode, call: ScardCall) -> Box<dyn rpce::Encode> {
+    let code = ReturnCode::UnsupportedFeature;
+    let empty_context = ScardContext::new(0);
+    let empty_handle = ScardHandle::new(empty_context, 0);
+    let undefined = CardProtocol::SCARD_PROTOCOL_UNDEFINED;
+    // Status_Return.mszReaderNames encoding follows the A/W IOCTL form.
+    let status_charset = match io_control_code {
+        ScardIoCtlCode::StatusA => CharacterSet::Ansi,
+        _ => CharacterSet::Unicode,
+    };
 
-        Ok(vec![message])
+    match call {
+        ScardCall::AccessStartedEventCall(_)
+        | ScardCall::HCardAndDispositionCall(_)
+        | ScardCall::SetAttribCall(_)
+        | ScardCall::ContextCall(_)
+        | ScardCall::WriteCacheCall(_)
+        | ScardCall::ContextAndStringCall(_)
+        | ScardCall::ContextAndTwoStringCall(_) => Box::new(LongReturn::new(code)),
+        // MS-RDPESC 3.1.4.46 marks SCARD_IOCTL_RELEASETARTEDEVENT unused with
+        // no output packet. The server still issued an IRP, so retire it with
+        // Long_Return rather than leaving the IRP unanswered.
+        ScardCall::Unsupported => Box::new(LongReturn::new(code)),
+        ScardCall::EstablishContextCall(_) => Box::new(EstablishContextReturn::new(code, empty_context)),
+        ScardCall::ListReaderGroupsCall(_) | ScardCall::ListReadersCall(_) => {
+            Box::new(ListReadersReturn::new(code, Vec::new()))
+        }
+        ScardCall::GetStatusChangeCall(_) | ScardCall::LocateCardsCall(_) | ScardCall::LocateCardsByAtrCall(_) => {
+            Box::new(GetStatusChangeReturn::new(code, Vec::new()))
+        }
+        ScardCall::ConnectCall(_) => Box::new(ConnectReturn::new(code, empty_handle, undefined)),
+        ScardCall::ReconnectCall(_) => Box::new(ReconnectReturn::new(code, undefined)),
+        ScardCall::TransmitCall(_) => Box::new(TransmitReturn::new(code, None, Vec::new())),
+        ScardCall::StatusCall(_) => Box::new(StatusReturn::new(
+            code,
+            Vec::new(),
+            CardState::Unknown,
+            undefined,
+            [0u8; 32],
+            0,
+            status_charset,
+        )),
+        ScardCall::StateCall(_) => Box::new(StateReturn::new(code, CardState::Unknown, undefined, Vec::new())),
+        ScardCall::ControlCall(_) => Box::new(ControlReturn::new(code, Vec::new())),
+        ScardCall::GetAttribCall(_) => Box::new(GetAttribReturn::new(code, Vec::new())),
+        ScardCall::GetTransmitCountCall(_) => Box::new(GetTransmitCountReturn::new(code, 0)),
+        ScardCall::GetDeviceTypeIdCall(_) => Box::new(GetDeviceTypeIdReturn::new(code, 0)),
+        ScardCall::ReadCacheCall(_) => Box::new(ReadCacheReturn::new(code, Vec::new())),
+        ScardCall::GetReaderIconCall(_) => Box::new(GetReaderIconReturn::new(code, Vec::new())),
     }
 }
 
@@ -102,4 +104,150 @@ fn complete_rpce(req: DeviceControlRequest<ScardIoCtlCode>, output: Box<dyn rpce
         NtStatus::SUCCESS,
         Some(output),
     )))
+}
+
+#[cfg(test)]
+mod tests {
+    use ironrdp_rdpdr::pdu::efs::{DeviceIoRequest, MajorFunction, MinorFunction};
+    use ironrdp_rdpdr::pdu::esc::{EstablishContextCall, ScardAccessStartedEventCall, Scope};
+
+    use super::*;
+
+    fn establish_context_call() -> ScardCall {
+        ScardCall::EstablishContextCall(EstablishContextCall { scope: Scope::User })
+    }
+
+    fn control_req(code: ScardIoCtlCode, device_id: u32, completion_id: u32) -> DeviceControlRequest<ScardIoCtlCode> {
+        DeviceControlRequest {
+            header: DeviceIoRequest {
+                device_id,
+                file_id: 0,
+                completion_id,
+                major_function: MajorFunction::DeviceControl,
+                minor_function: MinorFunction::from(0),
+            },
+            output_buffer_length: 2048,
+            input_buffer_length: 0,
+            io_control_code: code,
+        }
+    }
+
+    #[test]
+    fn establish_context_maps_to_establish_context_return() {
+        let output = stub_output(ScardIoCtlCode::EstablishContext, establish_context_call());
+        assert_eq!(output.name(), "EstablishContext_Return");
+    }
+
+    #[test]
+    fn long_return_calls_map_to_long_return() {
+        let output = stub_output(
+            ScardIoCtlCode::AccessStartedEvent,
+            ScardCall::AccessStartedEventCall(ScardAccessStartedEventCall),
+        );
+        assert_eq!(output.name(), "Long_Return");
+    }
+
+    #[test]
+    fn unsupported_release_tarted_event_maps_to_long_return() {
+        let output = stub_output(ScardIoCtlCode::ReleaseTartedEvent, ScardCall::Unsupported);
+        assert_eq!(output.name(), "Long_Return");
+    }
+
+    #[test]
+    fn connect_and_list_readers_map_to_table_return_names() {
+        // Call payloads are unused by the stub mapping; only the enum arm matters.
+        let connect = stub_output(
+            ScardIoCtlCode::ConnectW,
+            ScardCall::ConnectCall(ironrdp_rdpdr::pdu::esc::ConnectCall {
+                reader: String::new(),
+                common: ironrdp_rdpdr::pdu::esc::ConnectCommon {
+                    context: ScardContext::new(0),
+                    share_mode: 0,
+                    preferred_protocols: CardProtocol::SCARD_PROTOCOL_UNDEFINED,
+                },
+            }),
+        );
+        assert_eq!(connect.name(), "Connect_Return");
+
+        let readers = stub_output(
+            ScardIoCtlCode::ListReadersW,
+            ScardCall::ListReadersCall(ironrdp_rdpdr::pdu::esc::ListReadersCall {
+                context: ScardContext::new(0),
+                groups_ptr_length: 0,
+                groups_length: 0,
+                groups_ptr: 0,
+                groups: Vec::new(),
+                readers_is_null: true,
+                readers_size: 0,
+            }),
+        );
+        assert_eq!(readers.name(), "ListReaders_Return");
+    }
+
+    #[test]
+    fn status_a_and_status_w_select_matching_charset_encoding() {
+        fn encode(output: &dyn rpce::Encode) -> Vec<u8> {
+            ironrdp_core::encode_vec(output).expect("encode Status_Return")
+        }
+
+        let status_call = ScardCall::StatusCall(ironrdp_rdpdr::pdu::esc::StatusCall {
+            handle: ScardHandle::new(ScardContext::new(0), 0),
+            reader_names_is_null: true,
+            reader_length: 0,
+            atr_length: 0,
+        });
+        let stub_a = stub_output(ScardIoCtlCode::StatusA, status_call.clone());
+        let stub_w = stub_output(ScardIoCtlCode::StatusW, status_call);
+        assert_eq!(stub_a.name(), "Status_Return");
+        assert_eq!(stub_w.name(), "Status_Return");
+
+        let expected_a = StatusReturn::new(
+            ReturnCode::UnsupportedFeature,
+            Vec::new(),
+            CardState::Unknown,
+            CardProtocol::SCARD_PROTOCOL_UNDEFINED,
+            [0u8; 32],
+            0,
+            CharacterSet::Ansi,
+        );
+        let expected_w = StatusReturn::new(
+            ReturnCode::UnsupportedFeature,
+            Vec::new(),
+            CardState::Unknown,
+            CardProtocol::SCARD_PROTOCOL_UNDEFINED,
+            [0u8; 32],
+            0,
+            CharacterSet::Unicode,
+        );
+
+        assert_eq!(encode(stub_a.as_ref()), encode(&expected_a), "StatusA -> Ansi");
+        assert_eq!(encode(stub_w.as_ref()), encode(&expected_w), "StatusW -> Unicode");
+        assert_ne!(
+            encode(&expected_a),
+            encode(&expected_w),
+            "A/W empty multistring encodings must differ"
+        );
+    }
+
+    #[test]
+    fn handle_call_echoes_device_and_completion_ids() {
+        let mut session = ScardSession::new();
+        let req = control_req(ScardIoCtlCode::EstablishContext, 0, 42);
+        let messages = session
+            .handle_call(req.clone(), establish_context_call())
+            .expect("stub must complete");
+        assert_eq!(messages.len(), 1);
+
+        // Rebuild the same response shape and compare encoded wire bytes.
+        let expected = complete_rpce(
+            req,
+            Box::new(EstablishContextReturn::new(
+                ReturnCode::UnsupportedFeature,
+                ScardContext::new(0),
+            )),
+        );
+        let actual = messages[0].encode_unframed_pdu().expect("encode actual");
+        let expected = expected.encode_unframed_pdu().expect("encode expected");
+        assert_eq!(actual, expected);
+    }
 }

--- a/crates/ironrdp-rdpdr-native/src/windows/scard/mod.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/scard/mod.rs
@@ -1,12 +1,19 @@
 //! Stub Windows smartcard session for RDPDR device ID 0.
 //!
-//! Completes every decoded MS-RDPESC call with `SCARD_E_UNSUPPORTED_FEATURE`
-//! so Device Control IRPs never hang while the real WinSCard backend lands.
+//! Completes every decoded MS-RDPESC call with the IOCTL-appropriate return
+//! PDU and `SCARD_E_UNSUPPORTED_FEATURE`, so peers never hang or mis-decode
+//! while the real WinSCard backend lands.
 
 use ironrdp_pdu::PduResult;
+use ironrdp_pdu::utils::CharacterSet;
 use ironrdp_rdpdr::pdu::RdpdrPdu;
 use ironrdp_rdpdr::pdu::efs::{DeviceControlRequest, DeviceControlResponse, NtStatus};
-use ironrdp_rdpdr::pdu::esc::{LongReturn, ReturnCode, ScardCall, ScardIoCtlCode};
+use ironrdp_rdpdr::pdu::esc::{
+    CardProtocol, CardState, ConnectReturn, ControlReturn, EstablishContextReturn, GetAttribReturn,
+    GetDeviceTypeIdReturn, GetReaderIconReturn, GetStatusChangeReturn, GetTransmitCountReturn, ListReadersReturn,
+    LongReturn, ReadCacheReturn, ReconnectReturn, ReturnCode, ScardCall, ScardContext, ScardHandle, ScardIoCtlCode,
+    StateReturn, StatusReturn, TransmitReturn, rpce,
+};
 use ironrdp_svc::SvcMessage;
 
 /// Per-connection smartcard state for RDPDR device ID 0.
@@ -31,16 +38,68 @@ impl ScardSession {
     pub(super) fn handle_call(
         &mut self,
         req: DeviceControlRequest<ScardIoCtlCode>,
-        _call: ScardCall,
+        call: ScardCall,
     ) -> PduResult<Vec<SvcMessage>> {
-        Ok(vec![complete_long(req, ReturnCode::UnsupportedFeature)])
+        let code = ReturnCode::UnsupportedFeature;
+        let empty_context = ScardContext::new(0);
+        let empty_handle = ScardHandle::new(empty_context, 0);
+        let undefined = CardProtocol::SCARD_PROTOCOL_UNDEFINED;
+
+        let message = match call {
+            ScardCall::AccessStartedEventCall(_)
+            | ScardCall::HCardAndDispositionCall(_)
+            | ScardCall::SetAttribCall(_)
+            | ScardCall::ContextCall(_)
+            | ScardCall::WriteCacheCall(_)
+            | ScardCall::ContextAndStringCall(_)
+            | ScardCall::ContextAndTwoStringCall(_)
+            | ScardCall::Unsupported => complete_rpce(req, Box::new(LongReturn::new(code))),
+            ScardCall::EstablishContextCall(_) => {
+                complete_rpce(req, Box::new(EstablishContextReturn::new(code, empty_context)))
+            }
+            ScardCall::ListReaderGroupsCall(_) | ScardCall::ListReadersCall(_) => {
+                complete_rpce(req, Box::new(ListReadersReturn::new(code, Vec::new())))
+            }
+            ScardCall::GetStatusChangeCall(_) | ScardCall::LocateCardsCall(_) | ScardCall::LocateCardsByAtrCall(_) => {
+                complete_rpce(req, Box::new(GetStatusChangeReturn::new(code, Vec::new())))
+            }
+            ScardCall::ConnectCall(_) => {
+                complete_rpce(req, Box::new(ConnectReturn::new(code, empty_handle, undefined)))
+            }
+            ScardCall::ReconnectCall(_) => complete_rpce(req, Box::new(ReconnectReturn::new(code, undefined))),
+            ScardCall::TransmitCall(_) => complete_rpce(req, Box::new(TransmitReturn::new(code, None, Vec::new()))),
+            ScardCall::StatusCall(_) => complete_rpce(
+                req,
+                Box::new(StatusReturn::new(
+                    code,
+                    Vec::new(),
+                    CardState::Unknown,
+                    undefined,
+                    [0u8; 32],
+                    0,
+                    CharacterSet::Unicode,
+                )),
+            ),
+            ScardCall::StateCall(_) => complete_rpce(
+                req,
+                Box::new(StateReturn::new(code, CardState::Unknown, undefined, Vec::new())),
+            ),
+            ScardCall::ControlCall(_) => complete_rpce(req, Box::new(ControlReturn::new(code, Vec::new()))),
+            ScardCall::GetAttribCall(_) => complete_rpce(req, Box::new(GetAttribReturn::new(code, Vec::new()))),
+            ScardCall::GetTransmitCountCall(_) => complete_rpce(req, Box::new(GetTransmitCountReturn::new(code, 0))),
+            ScardCall::GetDeviceTypeIdCall(_) => complete_rpce(req, Box::new(GetDeviceTypeIdReturn::new(code, 0))),
+            ScardCall::ReadCacheCall(_) => complete_rpce(req, Box::new(ReadCacheReturn::new(code, Vec::new()))),
+            ScardCall::GetReaderIconCall(_) => complete_rpce(req, Box::new(GetReaderIconReturn::new(code, Vec::new()))),
+        };
+
+        Ok(vec![message])
     }
 }
 
-fn complete_long(req: DeviceControlRequest<ScardIoCtlCode>, code: ReturnCode) -> SvcMessage {
+fn complete_rpce(req: DeviceControlRequest<ScardIoCtlCode>, output: Box<dyn rpce::Encode>) -> SvcMessage {
     SvcMessage::from(RdpdrPdu::DeviceControlResponse(DeviceControlResponse::new(
         req,
         NtStatus::SUCCESS,
-        Some(Box::new(LongReturn::new(code))),
+        Some(output),
     )))
 }

--- a/crates/ironrdp-rdpdr-native/src/windows/scard/mod.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/scard/mod.rs
@@ -18,22 +18,25 @@ use ironrdp_svc::SvcMessage;
 
 /// Per-connection smartcard state for RDPDR device ID 0.
 ///
-/// This stub holds no native WinSCard resources. It only provides the backend
-/// hooks (`new` / `reset` / `poll` / `handle_call`) expected by
-/// [`super::backend::WindowsRdpdrBackend`]. `reset` and `poll` stay no-ops until
-/// the real WinSCard backend needs deferred completions.
+/// This stub holds no native WinSCard resources.
+/// It provides the `new`, `reset`, `poll`, and `handle_call` hooks expected by [`super::backend::WindowsRdpdrBackend`].
+/// `reset` clears queued messages, and `poll` drains them for deferred completions.
 #[derive(Debug, Default)]
-pub(super) struct ScardSession;
+pub(super) struct ScardSession {
+    messages: Vec<SvcMessage>,
+}
 
 impl ScardSession {
     pub(super) fn new() -> Self {
-        Self
+        Self::default()
     }
 
-    pub(super) fn reset(&mut self) {}
+    pub(super) fn reset(&mut self) {
+        self.messages.clear();
+    }
 
     pub(super) fn poll(&mut self) -> Vec<SvcMessage> {
-        Vec::new()
+        std::mem::take(&mut self.messages)
     }
 
     pub(super) fn handle_call(
@@ -42,7 +45,8 @@ impl ScardSession {
         call: ScardCall,
     ) -> PduResult<Vec<SvcMessage>> {
         let output = stub_output(req.io_control_code, call);
-        Ok(vec![complete_rpce(req, output)])
+        self.messages.push(complete_rpce(req, output));
+        Ok(self.poll())
     }
 }
 
@@ -99,10 +103,16 @@ fn stub_output(io_control_code: ScardIoCtlCode, call: ScardCall) -> Box<dyn rpce
 }
 
 fn complete_rpce(req: DeviceControlRequest<ScardIoCtlCode>, output: Box<dyn rpce::Encode>) -> SvcMessage {
+    let (status, output_buffer) = if output.size() <= req.output_buffer_length as usize {
+        (NtStatus::SUCCESS, Some(output))
+    } else {
+        (NtStatus::BUFFER_TOO_SMALL, None)
+    };
+
     SvcMessage::from(RdpdrPdu::DeviceControlResponse(DeviceControlResponse::new(
         req,
-        NtStatus::SUCCESS,
-        Some(output),
+        status,
+        output_buffer,
     )))
 }
 
@@ -246,6 +256,30 @@ mod tests {
                 ScardContext::new(0),
             )),
         );
+        let actual = messages[0].encode_unframed_pdu().expect("encode actual");
+        let expected = expected.encode_unframed_pdu().expect("encode expected");
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn handle_call_respects_output_buffer_length() {
+        let mut session = ScardSession::new();
+        let req = control_req(ScardIoCtlCode::EstablishContext, 0, 42);
+        let messages = session
+            .handle_call(
+                DeviceControlRequest {
+                    output_buffer_length: 0,
+                    ..req.clone()
+                },
+                establish_context_call(),
+            )
+            .expect("stub must complete");
+
+        let expected = SvcMessage::from(RdpdrPdu::DeviceControlResponse(DeviceControlResponse::new(
+            req,
+            NtStatus::BUFFER_TOO_SMALL,
+            None,
+        )));
         let actual = messages[0].encode_unframed_pdu().expect("encode actual");
         let expected = expected.encode_unframed_pdu().expect("encode expected");
         assert_eq!(actual, expected);

--- a/crates/ironrdp-rdpdr/src/backend/mod.rs
+++ b/crates/ironrdp-rdpdr/src/backend/mod.rs
@@ -66,7 +66,17 @@ pub trait RdpdrBackend: AsAny + fmt::Debug + Send {
     ///
     /// A rejected filesystem device is never eligible for server I/O.
     fn handle_server_device_announce_response(&mut self, pdu: ServerDeviceAnnounceResponse) -> PduResult<()>;
-    fn handle_scard_call(&mut self, req: DeviceControlRequest<ScardIoCtlCode>, call: ScardCall) -> PduResult<()>;
+
+    /// Handles a decoded smart-card Device Control IRP.
+    ///
+    /// Return the RDPDR completions to send immediately. Long-running calls such
+    /// as status-change waits may return an empty vector and complete later via
+    /// [`Self::poll_deferred_messages`].
+    fn handle_scard_call(
+        &mut self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+        call: ScardCall,
+    ) -> PduResult<Vec<SvcMessage>>;
 
     /// Handles a decoded filesystem IRP.
     fn handle_drive_io_request(&mut self, req: ServerDriveIoRequest) -> PduResult<Vec<SvcMessage>>;

--- a/crates/ironrdp-rdpdr/src/backend/noop.rs
+++ b/crates/ironrdp-rdpdr/src/backend/noop.rs
@@ -15,8 +15,12 @@ impl RdpdrBackend for NoopRdpdrBackend {
     fn handle_server_device_announce_response(&mut self, _pdu: ServerDeviceAnnounceResponse) -> PduResult<()> {
         Ok(())
     }
-    fn handle_scard_call(&mut self, _req: DeviceControlRequest<ScardIoCtlCode>, _call: ScardCall) -> PduResult<()> {
-        Ok(())
+    fn handle_scard_call(
+        &mut self,
+        _req: DeviceControlRequest<ScardIoCtlCode>,
+        _call: ScardCall,
+    ) -> PduResult<Vec<SvcMessage>> {
+        Ok(Vec::new())
     }
     fn handle_drive_io_request(&mut self, _req: crate::pdu::efs::ServerDriveIoRequest) -> PduResult<Vec<SvcMessage>> {
         Err(pdu_other_err!(

--- a/crates/ironrdp-rdpdr/src/lib.rs
+++ b/crates/ironrdp-rdpdr/src/lib.rs
@@ -542,9 +542,7 @@ impl Rdpdr {
                 self.backend
                     .as_mut()
                     .ok_or_else(|| pdu_other_err!("missing rdpdr backend"))?
-                    .handle_scard_call(req, call)?;
-
-                Ok(Vec::new())
+                    .handle_scard_call(req, call)
             }
             DeviceType::Filesystem => {
                 if self.rejected_device_ids.contains(&dev_io_req.device_id) {
@@ -713,8 +711,9 @@ impl SvcClientProcessor for Rdpdr {}
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use ironrdp_core::encode_vec;
+
+    use super::*;
 
     #[derive(Debug, Default)]
     struct TrackingBackend {
@@ -756,8 +755,12 @@ mod tests {
             Ok(())
         }
 
-        fn handle_scard_call(&mut self, _req: DeviceControlRequest<ScardIoCtlCode>, _call: ScardCall) -> PduResult<()> {
-            Ok(())
+        fn handle_scard_call(
+            &mut self,
+            _req: DeviceControlRequest<ScardIoCtlCode>,
+            _call: ScardCall,
+        ) -> PduResult<Vec<SvcMessage>> {
+            Ok(Vec::new())
         }
 
         fn handle_drive_io_request(&mut self, req: ServerDriveIoRequest) -> PduResult<Vec<SvcMessage>> {

--- a/crates/ironrdp-testsuite-core/tests/rdpdr/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpdr/mod.rs
@@ -34,8 +34,12 @@ impl RdpdrBackend for ResetTrackingRdpdrBackend {
         Ok(())
     }
 
-    fn handle_scard_call(&mut self, _req: DeviceControlRequest<ScardIoCtlCode>, _call: ScardCall) -> PduResult<()> {
-        Ok(())
+    fn handle_scard_call(
+        &mut self,
+        _req: DeviceControlRequest<ScardIoCtlCode>,
+        _call: ScardCall,
+    ) -> PduResult<Vec<SvcMessage>> {
+        Ok(Vec::new())
     }
 
     fn handle_drive_io_request(&mut self, _req: ServerDriveIoRequest) -> PduResult<Vec<SvcMessage>> {

--- a/crates/ironrdp-testsuite-extra/tests/e2e.rs
+++ b/crates/ironrdp-testsuite-extra/tests/e2e.rs
@@ -692,8 +692,8 @@ impl RdpdrBackend for UnsupportedRdpdrBackend {
         &mut self,
         _: ironrdp_rdpdr::pdu::efs::DeviceControlRequest<ScardIoCtlCode>,
         _: ScardCall,
-    ) -> pdu::PduResult<()> {
-        Ok(())
+    ) -> pdu::PduResult<Vec<SvcMessage>> {
+        Ok(Vec::new())
     }
 
     fn handle_drive_io_request(&mut self, req: ServerDriveIoRequest) -> pdu::PduResult<Vec<SvcMessage>> {

--- a/crates/ironrdp-web/src/printer.rs
+++ b/crates/ironrdp-web/src/printer.rs
@@ -230,9 +230,13 @@ impl RdpdrBackend for WasmPrinterBackend {
         Ok(())
     }
 
-    fn handle_scard_call(&mut self, _req: DeviceControlRequest<ScardIoCtlCode>, _call: ScardCall) -> PduResult<()> {
+    fn handle_scard_call(
+        &mut self,
+        _req: DeviceControlRequest<ScardIoCtlCode>,
+        _call: ScardCall,
+    ) -> PduResult<Vec<SvcMessage>> {
         warn!("Smartcard IOCTL reached printer-only backend; ignoring");
-        Ok(())
+        Ok(Vec::new())
     }
 
     fn handle_drive_io_request(&mut self, _req: ServerDriveIoRequest) -> PduResult<Vec<SvcMessage>> {


### PR DESCRIPTION
Return immediate SvcMessage completions from handle_scard_call so backends can finish MS-RDPESC IRPs without blocking the channel path.

Wire WindowsRdpdrBackendFactory::with_smartcard and a minimal ScardSession stub that answers decoded calls with SCARD_E_UNSUPPORTED_FEATURE. Allow smartcard-only RDPDR products (no drives). Full WinSCard work and product CLI/ActiveX enablement remain follow-ups.

Depends on #1654.