### PR TITLE
feat(replay): read direct TCP pcapng flows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,9 +271,9 @@ dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
- "rusticata-macros",
+ "rusticata-macros 4.1.0",
  "thiserror 2.0.19",
 ]
 
@@ -701,6 +701,12 @@ dependencies = [
  "crypto-common 0.2.2",
  "inout",
 ]
+
+[[package]]
+name = "circular"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fc239e0f6cb375d2402d48afb92f76f5404fd1df208a41930ec81eda078bea"
 
 [[package]]
 name = "clap"
@@ -1223,9 +1229,9 @@ checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs",
  "displaydoc",
- "nom",
+ "nom 7.1.3",
  "num-traits",
- "rusticata-macros",
+ "rusticata-macros 4.1.0",
 ]
 
 [[package]]
@@ -2528,6 +2534,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ironrdp-capture-replay"
+version = "0.0.0"
+dependencies = [
+ "pcap-parser",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "ironrdp-cfg"
 version = "0.1.0"
 dependencies = [
@@ -3691,6 +3705,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "now-client"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4351,6 +4374,17 @@ checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
  "digest 0.11.3",
  "hmac 0.13.0",
+]
+
+[[package]]
+name = "pcap-parser"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1099a3a64b376c536394622c9e5ea8ecfac3e3e44f88857b1e7da114135d3df4"
+dependencies = [
+ "circular",
+ "nom 8.0.0",
+ "rusticata-macros 5.0.0",
 ]
 
 [[package]]
@@ -5251,7 +5285,16 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom",
+ "nom 7.1.3",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40620447734539bcc6c64e9c66fed2410e17b46986733f1090c922d85f7105b"
+dependencies = [
+ "nom 8.0.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2539,6 +2539,7 @@ version = "0.0.0"
 dependencies = [
  "pcap-parser",
  "thiserror 2.0.19",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/ironrdp-capture-replay/Cargo.toml
+++ b/crates/ironrdp-capture-replay/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "ironrdp-capture-replay"
+version = "0.0.0"
+publish = false
+description = "Offline analysis of direct TCP RDP captures"
+edition.workspace = true
+rust-version = "1.94"
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+pcap-parser = "0.17"
+thiserror = "2"
+
+[lib]
+doctest = false
+
+[lints]
+workspace = true

--- a/crates/ironrdp-capture-replay/Cargo.toml
+++ b/crates/ironrdp-capture-replay/Cargo.toml
@@ -15,6 +15,7 @@ categories.workspace = true
 [dependencies]
 pcap-parser = "0.17"
 thiserror = "2"
+zeroize = "1.8"
 
 [lib]
 doctest = false

--- a/crates/ironrdp-capture-replay/src/error.rs
+++ b/crates/ironrdp-capture-replay/src/error.rs
@@ -1,0 +1,20 @@
+use std::io;
+
+use thiserror::Error;
+
+/// Errors that make an offline replay unreliable.
+#[derive(Debug, Error)]
+pub enum ReplayError {
+    /// The capture could not be read.
+    #[error("failed to read capture")]
+    Io(#[source] io::Error),
+    /// The capture could not be parsed.
+    #[error("invalid pcapng capture: {0}")]
+    Pcap(String),
+    /// The capture does not contain a supported direct TCP flow.
+    #[error("capture does not contain an Ethernet direct TCP flow")]
+    UnsupportedTransport,
+    /// The capture has incomplete or contradictory TCP data.
+    #[error("capture does not contain a complete client/server TCP flow")]
+    MissingTcpFlow,
+}

--- a/crates/ironrdp-capture-replay/src/lib.rs
+++ b/crates/ironrdp-capture-replay/src/lib.rs
@@ -1,0 +1,7 @@
+//! Offline analysis support for direct TCP RDP captures.
+
+mod error;
+mod transport;
+
+pub use error::ReplayError;
+pub use transport::{Capture, Endpoint, Flow, PacketStream, read_capture};

--- a/crates/ironrdp-capture-replay/src/lib.rs
+++ b/crates/ironrdp-capture-replay/src/lib.rs
@@ -4,4 +4,4 @@ mod error;
 mod transport;
 
 pub use error::ReplayError;
-pub use transport::{Capture, Endpoint, Flow, PacketStream, read_capture};
+pub use transport::{Capture, Endpoint, Flow, PacketStream, TlsKeyLog, read_capture};

--- a/crates/ironrdp-capture-replay/src/transport.rs
+++ b/crates/ironrdp-capture-replay/src/transport.rs
@@ -383,7 +383,7 @@ fn reassemble(segments: Vec<Segment>, origin: u32) -> Result<PacketStream, Repla
     Ok(stream)
 }
 
-fn flatten(stream: &PacketStream) -> Vec<u8> {
+pub(crate) fn flatten(stream: &PacketStream) -> Vec<u8> {
     stream.iter().flat_map(|(_, bytes)| bytes).copied().collect()
 }
 

--- a/crates/ironrdp-capture-replay/src/transport.rs
+++ b/crates/ironrdp-capture-replay/src/transport.rs
@@ -211,6 +211,8 @@ fn assemble_flow(mut segments: Vec<Segment>) -> Result<Flow, ReplayError> {
         let server = syn.destination.clone();
         let mut client_segments = Vec::new();
         let mut server_segments = Vec::new();
+        let mut client_closed = false;
+        let mut server_closed = false;
 
         for segment in segments.iter().skip(start) {
             if segment.syn
@@ -222,14 +224,19 @@ fn assemble_flow(mut segments: Vec<Segment>) -> Result<Flow, ReplayError> {
                 break;
             }
             if segment.source == client && segment.destination == server {
-                client_segments.push(segment.clone());
+                if !client_closed {
+                    client_segments.push(segment.clone());
+                    client_closed |= segment.fin;
+                }
             } else if segment.source == server && segment.destination == client {
-                server_segments.push(segment.clone());
+                if !server_closed {
+                    server_segments.push(segment.clone());
+                    server_closed |= segment.fin;
+                }
+            } else {
+                continue;
             }
-            if (segment.fin || segment.rst)
-                && ((segment.source == client && segment.destination == server)
-                    || (segment.source == server && segment.destination == client))
-            {
+            if segment.rst || (client_closed && server_closed) {
                 break;
             }
         }
@@ -286,54 +293,44 @@ fn reassemble(segments: Vec<Segment>, origin: u32) -> Result<PacketStream, Repla
         })
         .collect::<Vec<_>>();
     segments.sort_by_key(|(_, sequence, _)| *sequence);
-    let Some((packet, sequence, data)) = segments.first().cloned() else {
+    let mut segments = segments.into_iter();
+    let Some((packet, start_sequence, data)) = segments.next() else {
         return Ok(Vec::new());
     };
 
-    let mut ranges = vec![(packet, sequence, data)];
-    for (packet, sequence, mut data) in segments.into_iter().skip(1) {
-        let mut data_offset = 0;
-        for (_, range_sequence, range_data) in &ranges {
-            let range_len = u32::try_from(range_data.len()).map_err(|_| ReplayError::MissingTcpFlow)?;
-            let range_end = range_sequence
-                .checked_add(range_len)
-                .ok_or(ReplayError::MissingTcpFlow)?;
-            if sequence >= range_end {
-                continue;
-            }
-            let data_sequence = sequence
-                .checked_add(u32::try_from(data_offset).map_err(|_| ReplayError::MissingTcpFlow)?)
-                .ok_or(ReplayError::MissingTcpFlow)?;
-            if data_sequence < *range_sequence {
-                return Err(ReplayError::MissingTcpFlow);
-            }
-            let range_offset =
-                usize::try_from(data_sequence - range_sequence).map_err(|_| ReplayError::MissingTcpFlow)?;
-            let count = (range_data.len() - range_offset).min(data.len() - data_offset);
-            if range_data[range_offset..range_offset + count] != data[data_offset..data_offset + count] {
-                return Err(ReplayError::MissingTcpFlow);
-            }
-            data_offset += count;
-            if data_offset == data.len() {
-                break;
-            }
+    let mut bytes = data.clone();
+    let mut stream = vec![(packet, data)];
+    for (packet, sequence, data) in segments {
+        let data_end = sequence
+            .checked_add(u32::try_from(data.len()).map_err(|_| ReplayError::MissingTcpFlow)?)
+            .ok_or(ReplayError::MissingTcpFlow)?;
+        let stream_end = start_sequence
+            .checked_add(u32::try_from(bytes.len()).map_err(|_| ReplayError::MissingTcpFlow)?)
+            .ok_or(ReplayError::MissingTcpFlow)?;
+        if sequence > stream_end {
+            return Err(ReplayError::MissingTcpFlow);
         }
-        if data_offset < data.len() {
-            let data_sequence = sequence
-                .checked_add(u32::try_from(data_offset).map_err(|_| ReplayError::MissingTcpFlow)?)
-                .ok_or(ReplayError::MissingTcpFlow)?;
-            let (_, previous_sequence, previous_data) = ranges.last().ok_or(ReplayError::MissingTcpFlow)?;
-            let previous_end = previous_sequence
-                .checked_add(u32::try_from(previous_data.len()).map_err(|_| ReplayError::MissingTcpFlow)?)
-                .ok_or(ReplayError::MissingTcpFlow)?;
-            if data_sequence != previous_end {
-                return Err(ReplayError::MissingTcpFlow);
+        let offset = usize::try_from(sequence - start_sequence).map_err(|_| ReplayError::MissingTcpFlow)?;
+        let overlap = usize::try_from(stream_end - sequence)
+            .map_err(|_| ReplayError::MissingTcpFlow)?
+            .min(data.len());
+        if bytes[offset..offset + overlap] != data[..overlap] {
+            return Err(ReplayError::MissingTcpFlow);
+        }
+        if data_end > stream_end {
+            let data = data[overlap..].to_vec();
+            bytes.extend_from_slice(&data);
+            if let Some((previous_packet, previous_data)) = stream.last_mut()
+                && *previous_packet == packet
+            {
+                previous_data.extend(data);
+            } else {
+                stream.push((packet, data));
             }
-            ranges.push((packet, data_sequence, data.split_off(data_offset)));
         }
     }
 
-    Ok(ranges.into_iter().map(|(packet, _, data)| (packet, data)).collect())
+    Ok(stream)
 }
 
 fn flatten(stream: &PacketStream) -> Vec<u8> {
@@ -484,6 +481,35 @@ mod tests {
 
         assert_eq!(flow.client_stream[0].0, 5);
         assert_eq!(flow.server_stream[0].0, 6);
+    }
+
+    #[test]
+    fn preserves_peer_data_after_a_half_close() {
+        let client = endpoint(1);
+        let server = endpoint(2);
+        let mut client_fin = segment_between(client.clone(), server.clone(), 108, 3, false, true, &[]);
+        client_fin.fin = true;
+        let mut server_fin = segment_between(server.clone(), client.clone(), 311, 6, false, true, &[]);
+        server_fin.fin = true;
+        let flow = assemble_flow(vec![
+            segment_between(client.clone(), server.clone(), 100, 1, true, false, &[]),
+            segment_between(
+                client.clone(),
+                server.clone(),
+                101,
+                2,
+                false,
+                true,
+                &[3, 0, 0, 7, 2, 0xe0, 0],
+            ),
+            client_fin,
+            segment_between(server.clone(), client.clone(), 300, 4, false, true, b"first"),
+            segment_between(server, client, 305, 5, false, true, b"second"),
+            server_fin,
+        ])
+        .unwrap();
+
+        assert_eq!(flatten(&flow.server_stream), b"firstsecond");
     }
 
     #[test]

--- a/crates/ironrdp-capture-replay/src/transport.rs
+++ b/crates/ironrdp-capture-replay/src/transport.rs
@@ -59,6 +59,10 @@ impl core::fmt::Debug for Capture {
 pub struct TlsKeyLog(String);
 
 impl TlsKeyLog {
+    pub(crate) fn new(value: String) -> Self {
+        Self(value)
+    }
+
     /// Get the key log required to decrypt the recorded TLS stream.
     pub fn as_str(&self) -> &str {
         &self.0
@@ -150,7 +154,7 @@ pub fn read_capture(path: &Path) -> Result<Capture, ReplayError> {
 
     Ok(Capture {
         flow: assemble_flow(segments)?,
-        tls_key_log: TlsKeyLog(tls_key_log),
+        tls_key_log: TlsKeyLog::new(tls_key_log),
     })
 }
 

--- a/crates/ironrdp-capture-replay/src/transport.rs
+++ b/crates/ironrdp-capture-replay/src/transport.rs
@@ -312,22 +312,19 @@ fn assemble_flow(mut segments: Vec<Segment>) -> Result<Flow, ReplayError> {
 }
 
 fn has_x224_connection_initiation(client_stream: &PacketStream, server_stream: &PacketStream) -> bool {
-    has_x224_connection_tpdu(&flatten(client_stream), 0xe0) && has_x224_connection_tpdu(&flatten(server_stream), 0xd0)
+    x224_connection_tpdu_end(&flatten(client_stream), 0xe0).is_some()
+        && x224_connection_tpdu_end(&flatten(server_stream), 0xd0).is_some()
 }
 
-fn has_x224_connection_tpdu(bytes: &[u8], code: u8) -> bool {
-    let Some(header) = bytes.get(..4) else {
-        return false;
-    };
+pub(crate) fn x224_connection_tpdu_end(bytes: &[u8], code: u8) -> Option<usize> {
+    let header = bytes.get(..4)?;
     if header[0] != 3 || header[1] != 0 {
-        return false;
+        return None;
     }
     let length = usize::from(u16::from_be_bytes([header[2], header[3]]));
-    let Some(frame) = bytes.get(..length) else {
-        return false;
-    };
+    let frame = bytes.get(..length)?;
 
-    frame.len() >= 11 && frame[4] == 6 && frame[5] == code && frame[6..11] == [0; 5]
+    (frame.len() >= 11 && frame[4] == 6 && frame[5] == code && frame[6..11] == [0; 5]).then_some(length)
 }
 
 fn reassemble(segments: Vec<Segment>, origin: u32) -> Result<PacketStream, ReplayError> {

--- a/crates/ironrdp-capture-replay/src/transport.rs
+++ b/crates/ironrdp-capture-replay/src/transport.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::fs::File;
 use std::path::Path;
 
@@ -37,7 +36,7 @@ pub struct Flow {
 }
 
 /// Capture data used by later replay stages.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Capture {
     /// Direct TCP RDP flow selected from the pcapng input.
     pub flow: Flow,
@@ -45,6 +44,15 @@ pub struct Capture {
     ///
     /// The entries are retained only in memory and must not be logged or persisted.
     pub tls_key_log: String,
+}
+
+impl core::fmt::Debug for Capture {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Capture")
+            .field("flow", &self.flow)
+            .field("tls_key_log", &"<redacted>")
+            .finish()
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -55,6 +63,8 @@ struct Segment {
     sequence: u32,
     syn: bool,
     ack: bool,
+    fin: bool,
+    rst: bool,
     data: Vec<u8>,
 }
 
@@ -64,16 +74,20 @@ pub fn read_capture(path: &Path) -> Result<Capture, ReplayError> {
     let mut reader = PcapNGReader::new(1024 * 1024, file).map_err(|error| ReplayError::Pcap(error.to_string()))?;
     let mut packet = 0;
     let mut linktypes = Vec::new();
+    let mut has_ethernet = false;
     let mut segments = Vec::new();
     let mut tls_key_log = String::new();
 
     loop {
         match reader.next() {
             Ok((offset, block)) => {
-                packet += 1;
                 match block {
+                    PcapBlockOwned::NG(Block::SectionHeader(_)) => {
+                        linktypes.clear();
+                    }
                     PcapBlockOwned::NG(Block::InterfaceDescription(interface)) => {
                         linktypes.push(interface.linktype.0);
+                        has_ethernet |= interface.linktype.0 == ETHERNET_LINKTYPE;
                     }
                     PcapBlockOwned::NG(Block::DecryptionSecrets(secrets))
                         if secrets.secrets_type == SecretsType::TlsKeyLog =>
@@ -89,6 +103,7 @@ pub fn read_capture(path: &Path) -> Result<Capture, ReplayError> {
                         tls_key_log.push_str(text);
                     }
                     PcapBlockOwned::NG(Block::EnhancedPacket(packet_block)) => {
+                        packet += 1;
                         let interface = usize::try_from(packet_block.if_id)
                             .map_err(|_| ReplayError::Pcap("interface ID is too large".to_owned()))?;
                         if linktypes.get(interface) == Some(&ETHERNET_LINKTYPE) && !packet_block.truncated() {
@@ -109,7 +124,7 @@ pub fn read_capture(path: &Path) -> Result<Capture, ReplayError> {
         }
     }
 
-    if !linktypes.contains(&ETHERNET_LINKTYPE) {
+    if !has_ethernet {
         return Err(ReplayError::UnsupportedTransport);
     }
 
@@ -127,30 +142,39 @@ fn parse_tcp_packet(packet: usize, bytes: &[u8]) -> Option<Segment> {
         (14, ethernet_type)
     };
 
-    let (source, destination, tcp_offset) = match ethernet_type {
+    let (source, destination, tcp_offset, network_end) = match ethernet_type {
         0x0800 => {
             let header = bytes.get(network_offset..)?;
             let header_len = usize::from(header.first()? & 0x0f) * 4;
             if header_len < 20 || *header.get(9)? != 6 {
                 return None;
             }
+            let total_len = usize::from(u16::from_be_bytes(header.get(2..4)?.try_into().ok()?));
+            if total_len < header_len {
+                return None;
+            }
+            let network_end = network_offset.checked_add(total_len)?;
+            bytes.get(network_offset..network_end)?;
             let source = IpAddr::from(<[u8; 4]>::try_from(header.get(12..16)?).ok()?);
             let destination = IpAddr::from(<[u8; 4]>::try_from(header.get(16..20)?).ok()?);
-            (source, destination, network_offset + header_len)
+            (source, destination, network_offset + header_len, network_end)
         }
         0x86dd => {
             let header = bytes.get(network_offset..network_offset + 40)?;
             if header[6] != 6 {
                 return None;
             }
+            let payload_len = usize::from(u16::from_be_bytes(header.get(4..6)?.try_into().ok()?));
+            let network_end = network_offset.checked_add(40 + payload_len)?;
+            bytes.get(network_offset..network_end)?;
             let source = IpAddr::from(<[u8; 16]>::try_from(&header[8..24]).ok()?);
             let destination = IpAddr::from(<[u8; 16]>::try_from(&header[24..40]).ok()?);
-            (source, destination, network_offset + 40)
+            (source, destination, network_offset + 40, network_end)
         }
         _ => return None,
     };
 
-    let tcp = bytes.get(tcp_offset..)?;
+    let tcp = bytes.get(tcp_offset..network_end)?;
     let header_len = usize::from(tcp.get(12)? >> 4) * 4;
     if header_len < 20 || tcp.len() < header_len {
         return None;
@@ -170,28 +194,64 @@ fn parse_tcp_packet(packet: usize, bytes: &[u8]) -> Option<Segment> {
         sequence: u32::from_be_bytes(tcp.get(4..8)?.try_into().ok()?),
         syn: flags & 0x02 != 0,
         ack: flags & 0x10 != 0,
+        fin: flags & 0x01 != 0,
+        rst: flags & 0x04 != 0,
         data: tcp[header_len..].to_vec(),
     })
 }
 
 fn assemble_flow(mut segments: Vec<Segment>) -> Result<Flow, ReplayError> {
-    segments.retain(|segment| !segment.data.is_empty() || segment.syn);
-    for syn in segments.iter().filter(|segment| segment.syn && !segment.ack) {
+    segments.retain(|segment| !segment.data.is_empty() || segment.syn || segment.fin || segment.rst);
+    for (start, syn) in segments
+        .iter()
+        .enumerate()
+        .filter(|(_, segment)| segment.syn && !segment.ack)
+    {
         let client = syn.source.clone();
         let server = syn.destination.clone();
         let mut client_segments = Vec::new();
         let mut server_segments = Vec::new();
 
-        for segment in &segments {
+        for segment in segments.iter().skip(start) {
+            if segment.syn
+                && !segment.ack
+                && segment.packet != syn.packet
+                && segment.source == client
+                && segment.destination == server
+            {
+                break;
+            }
             if segment.source == client && segment.destination == server {
                 client_segments.push(segment.clone());
             } else if segment.source == server && segment.destination == client {
                 server_segments.push(segment.clone());
             }
+            if (segment.fin || segment.rst)
+                && ((segment.source == client && segment.destination == server)
+                    || (segment.source == server && segment.destination == client))
+            {
+                break;
+            }
         }
 
-        let client_stream = reassemble(client_segments)?;
-        let server_stream = reassemble(server_segments)?;
+        let client_origin = syn.sequence.wrapping_add(1);
+        let server_origin = server_segments
+            .iter()
+            .find(|segment| segment.syn)
+            .map(|segment| segment.sequence.wrapping_add(1))
+            .or_else(|| {
+                server_segments
+                    .iter()
+                    .find(|segment| !segment.data.is_empty())
+                    .map(|segment| segment.sequence)
+            })
+            .unwrap_or(0);
+        let Ok(client_stream) = reassemble(client_segments, client_origin) else {
+            continue;
+        };
+        let Ok(server_stream) = reassemble(server_segments, server_origin) else {
+            continue;
+        };
         if !client_stream.is_empty() && !server_stream.is_empty() && has_x224_connection_request(&client_stream) {
             return Ok(Flow {
                 client,
@@ -210,46 +270,70 @@ fn has_x224_connection_request(stream: &PacketStream) -> bool {
     tpkt_frames(&bytes).any(|frame| frame.get(5) == Some(&0xe0))
 }
 
-fn reassemble(segments: Vec<Segment>) -> Result<PacketStream, ReplayError> {
-    let mut bytes = BTreeMap::new();
-    for segment in segments {
-        for (offset, byte) in segment.data.into_iter().enumerate() {
-            let offset = u32::try_from(offset).map_err(|_| ReplayError::MissingTcpFlow)?;
-            let sequence = segment
-                .sequence
-                .checked_add(offset)
-                .ok_or(ReplayError::MissingTcpFlow)?;
-            match bytes.entry(sequence) {
-                std::collections::btree_map::Entry::Vacant(entry) => {
-                    entry.insert((segment.packet, byte));
-                }
-                std::collections::btree_map::Entry::Occupied(entry) if entry.get().1 == byte => {}
-                std::collections::btree_map::Entry::Occupied(_) => return Err(ReplayError::MissingTcpFlow),
-            }
-        }
-    }
-
-    let Some((&first, _)) = bytes.first_key_value() else {
+fn reassemble(segments: Vec<Segment>, origin: u32) -> Result<PacketStream, ReplayError> {
+    let mut segments = segments
+        .into_iter()
+        .filter(|segment| !segment.data.is_empty())
+        .map(|segment| {
+            (
+                segment.packet,
+                segment
+                    .sequence
+                    .wrapping_add(u32::from(segment.syn))
+                    .wrapping_sub(origin),
+                segment.data,
+            )
+        })
+        .collect::<Vec<_>>();
+    segments.sort_by_key(|(_, sequence, _)| *sequence);
+    let Some((packet, sequence, data)) = segments.first().cloned() else {
         return Ok(Vec::new());
     };
 
-    let mut sequence = first;
-    let mut stream = PacketStream::new();
-    while let Some((packet, byte)) = bytes.remove(&sequence) {
-        if let Some((previous_packet, chunk)) = stream.last_mut()
-            && *previous_packet == packet
-        {
-            chunk.push(byte);
-        } else {
-            stream.push((packet, vec![byte]));
+    let mut ranges = vec![(packet, sequence, data)];
+    for (packet, sequence, mut data) in segments.into_iter().skip(1) {
+        let mut data_offset = 0;
+        for (_, range_sequence, range_data) in &ranges {
+            let range_len = u32::try_from(range_data.len()).map_err(|_| ReplayError::MissingTcpFlow)?;
+            let range_end = range_sequence
+                .checked_add(range_len)
+                .ok_or(ReplayError::MissingTcpFlow)?;
+            if sequence >= range_end {
+                continue;
+            }
+            let data_sequence = sequence
+                .checked_add(u32::try_from(data_offset).map_err(|_| ReplayError::MissingTcpFlow)?)
+                .ok_or(ReplayError::MissingTcpFlow)?;
+            if data_sequence < *range_sequence {
+                return Err(ReplayError::MissingTcpFlow);
+            }
+            let range_offset =
+                usize::try_from(data_sequence - range_sequence).map_err(|_| ReplayError::MissingTcpFlow)?;
+            let count = (range_data.len() - range_offset).min(data.len() - data_offset);
+            if range_data[range_offset..range_offset + count] != data[data_offset..data_offset + count] {
+                return Err(ReplayError::MissingTcpFlow);
+            }
+            data_offset += count;
+            if data_offset == data.len() {
+                break;
+            }
         }
-        sequence = sequence.checked_add(1).ok_or(ReplayError::MissingTcpFlow)?;
-    }
-    if !bytes.is_empty() {
-        return Err(ReplayError::MissingTcpFlow);
+        if data_offset < data.len() {
+            let data_sequence = sequence
+                .checked_add(u32::try_from(data_offset).map_err(|_| ReplayError::MissingTcpFlow)?)
+                .ok_or(ReplayError::MissingTcpFlow)?;
+            let (_, previous_sequence, previous_data) = ranges.last().ok_or(ReplayError::MissingTcpFlow)?;
+            let previous_end = previous_sequence
+                .checked_add(u32::try_from(previous_data.len()).map_err(|_| ReplayError::MissingTcpFlow)?)
+                .ok_or(ReplayError::MissingTcpFlow)?;
+            if data_sequence != previous_end {
+                return Err(ReplayError::MissingTcpFlow);
+            }
+            ranges.push((packet, data_sequence, data.split_off(data_offset)));
+        }
     }
 
-    Ok(stream)
+    Ok(ranges.into_iter().map(|(packet, _, data)| (packet, data)).collect())
 }
 
 fn flatten(stream: &PacketStream) -> Vec<u8> {
@@ -289,24 +373,41 @@ mod tests {
     }
 
     fn segment(sequence: u32, packet: usize, data: &[u8]) -> Segment {
+        segment_between(endpoint(1), endpoint(2), sequence, packet, false, false, data)
+    }
+
+    fn segment_between(
+        source: Endpoint,
+        destination: Endpoint,
+        sequence: u32,
+        packet: usize,
+        syn: bool,
+        ack: bool,
+        data: &[u8],
+    ) -> Segment {
         Segment {
             packet,
-            source: endpoint(1),
-            destination: endpoint(2),
+            source,
+            destination,
             sequence,
-            syn: false,
-            ack: true,
+            syn,
+            ack,
+            fin: false,
+            rst: false,
             data: data.to_vec(),
         }
     }
 
     #[test]
     fn reassembly_deduplicates_retransmissions() {
-        let stream = reassemble(vec![
-            segment(12, 2, b"world"),
-            segment(7, 1, b"hello"),
-            segment(7, 3, b"hello"),
-        ])
+        let stream = reassemble(
+            vec![
+                segment(12, 2, b"world"),
+                segment(7, 1, b"hello"),
+                segment(7, 3, b"hello"),
+            ],
+            7,
+        )
         .unwrap();
 
         assert_eq!(flatten(&stream), b"helloworld");
@@ -315,9 +416,74 @@ mod tests {
 
     #[test]
     fn reassembly_rejects_conflicting_overlap() {
-        let error = reassemble(vec![segment(1, 1, b"hello"), segment(3, 2, b"XX")]).unwrap_err();
+        let error = reassemble(vec![segment(1, 1, b"hello"), segment(3, 2, b"XX")], 1).unwrap_err();
 
         assert!(matches!(error, ReplayError::MissingTcpFlow));
+    }
+
+    #[test]
+    fn reassembly_handles_wrapped_sequence_numbers() {
+        let stream = reassemble(
+            vec![segment(u32::MAX - 1, 1, b"abcd"), segment(2, 2, b"ef")],
+            u32::MAX - 1,
+        )
+        .unwrap();
+
+        assert_eq!(flatten(&stream), b"abcdef");
+    }
+
+    #[test]
+    fn skips_incomplete_flows_before_a_valid_rdp_connection() {
+        let first_client = endpoint(1);
+        let first_server = endpoint(2);
+        let second_client = endpoint(3);
+        let second_server = endpoint(4);
+        let flow = assemble_flow(vec![
+            segment_between(first_client.clone(), first_server.clone(), 100, 1, true, false, &[]),
+            segment_between(first_client.clone(), first_server.clone(), 101, 2, false, true, b"bad"),
+            segment_between(first_client, first_server, 101, 3, false, true, b"XX"),
+            segment_between(second_client.clone(), second_server.clone(), 200, 4, true, false, &[]),
+            segment_between(
+                second_client.clone(),
+                second_server.clone(),
+                201,
+                5,
+                false,
+                true,
+                &[3, 0, 0, 7, 2, 0xe0, 0],
+            ),
+            segment_between(second_server, second_client, 300, 6, false, true, &[0]),
+        ])
+        .unwrap();
+
+        assert_eq!(flow.client.port, 3);
+        assert_eq!(flow.server.port, 4);
+    }
+
+    #[test]
+    fn separates_connections_that_reuse_a_tcp_tuple() {
+        let client = endpoint(1);
+        let server = endpoint(2);
+        let flow = assemble_flow(vec![
+            segment_between(client.clone(), server.clone(), 100, 1, true, false, &[]),
+            segment_between(client.clone(), server.clone(), 101, 2, false, true, b"old"),
+            segment_between(server.clone(), client.clone(), 300, 3, false, true, b"old"),
+            segment_between(client.clone(), server.clone(), 500, 4, true, false, &[]),
+            segment_between(
+                client.clone(),
+                server.clone(),
+                501,
+                5,
+                false,
+                true,
+                &[3, 0, 0, 7, 2, 0xe0, 0],
+            ),
+            segment_between(server, client, 700, 6, false, true, &[0]),
+        ])
+        .unwrap();
+
+        assert_eq!(flow.client_stream[0].0, 5);
+        assert_eq!(flow.server_stream[0].0, 6);
     }
 
     #[test]
@@ -338,12 +504,52 @@ mod tests {
 
         assert_eq!(capture.flow.client.port, 1);
         assert_eq!(capture.flow.server.port, 2);
+        assert_eq!(capture.flow.client_stream[0].0, 2);
+        assert_eq!(capture.flow.server_stream[0].0, 3);
         assert_eq!(flatten(&capture.flow.client_stream), [3, 0, 0, 7, 2, 0xe0, 0]);
         assert_eq!(flatten(&capture.flow.server_stream), [0]);
         std::fs::remove_file(path).unwrap();
     }
 
+    #[test]
+    fn reads_unpadded_tls_key_log_entries() {
+        let path = std::env::temp_dir().join(format!("ironrdp-capture-replay-secrets-{}.pcapng", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        std::fs::write(
+            &path,
+            pcapng_with_key_log(
+                [
+                    ethernet_tcp(1, 2, 100, 0x02, &[]),
+                    ethernet_tcp(1, 2, 101, 0x10, &[3, 0, 0, 7, 2, 0xe0, 0]),
+                    ethernet_tcp(2, 1, 200, 0x10, &[0]),
+                ],
+                "CLIENT_RANDOM synthetic secret\n",
+            ),
+        )
+        .unwrap();
+
+        let capture = read_capture(&path).unwrap();
+
+        assert_eq!(capture.tls_key_log, "CLIENT_RANDOM synthetic secret\n");
+        assert!(!format!("{capture:?}").contains("synthetic secret"));
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn ignores_padding_after_the_ipv4_packet() {
+        let mut packet = ethernet_tcp(1, 2, 100, 0x10, b"payload");
+        packet.extend([0; 16]);
+
+        let segment = parse_tcp_packet(1, &packet).unwrap();
+
+        assert_eq!(segment.data, b"payload");
+    }
+
     fn pcapng(frames: impl IntoIterator<Item = Vec<u8>>) -> Vec<u8> {
+        pcapng_with_key_log(frames, "")
+    }
+
+    fn pcapng_with_key_log(frames: impl IntoIterator<Item = Vec<u8>>, tls_key_log: &str) -> Vec<u8> {
         let mut output = Vec::new();
         output.extend(block(0x0a0d0d0a, {
             let mut body = Vec::new();
@@ -360,6 +566,14 @@ mod tests {
             body.extend(u32::MAX.to_le_bytes());
             body
         }));
+        if !tls_key_log.is_empty() {
+            let mut body = Vec::new();
+            body.extend(0x544c534bu32.to_le_bytes());
+            body.extend(u32::try_from(tls_key_log.len()).unwrap().to_le_bytes());
+            body.extend(tls_key_log.as_bytes());
+            body.resize((body.len() + 3) & !3, 0);
+            output.extend(block(0x0a, body));
+        }
         for frame in frames {
             let mut body = Vec::new();
             body.extend(0u32.to_le_bytes());

--- a/crates/ironrdp-capture-replay/src/transport.rs
+++ b/crates/ironrdp-capture-replay/src/transport.rs
@@ -1,0 +1,408 @@
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::path::Path;
+
+use core::net::IpAddr;
+use pcap_parser::pcapng::{Block, SecretsType};
+use pcap_parser::traits::{PcapNGPacketBlock as _, PcapReaderIterator as _};
+use pcap_parser::{PcapBlockOwned, PcapError, PcapNGReader};
+
+use crate::ReplayError;
+
+const ETHERNET_LINKTYPE: i32 = 1;
+
+/// One endpoint of a captured TCP flow.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Endpoint {
+    /// IP address of the endpoint.
+    pub address: IpAddr,
+    /// TCP port of the endpoint.
+    pub port: u16,
+}
+
+/// Reassembled TCP bytes associated with their source packet number.
+pub type PacketStream = Vec<(usize, Vec<u8>)>;
+
+/// A direct TCP RDP flow reconstructed from a capture.
+#[derive(Clone, Debug)]
+pub struct Flow {
+    /// Client endpoint identified by the TCP handshake.
+    pub client: Endpoint,
+    /// Server endpoint identified by the TCP handshake.
+    pub server: Endpoint,
+    /// Reassembled client-to-server TCP stream.
+    pub client_stream: PacketStream,
+    /// Reassembled server-to-client TCP stream.
+    pub server_stream: PacketStream,
+}
+
+/// Capture data used by later replay stages.
+#[derive(Clone, Debug)]
+pub struct Capture {
+    /// Direct TCP RDP flow selected from the pcapng input.
+    pub flow: Flow,
+    /// NSS-compatible TLS key-log entries embedded in the capture.
+    ///
+    /// The entries are retained only in memory and must not be logged or persisted.
+    pub tls_key_log: String,
+}
+
+#[derive(Clone, Debug)]
+struct Segment {
+    packet: usize,
+    source: Endpoint,
+    destination: Endpoint,
+    sequence: u32,
+    syn: bool,
+    ack: bool,
+    data: Vec<u8>,
+}
+
+/// Read an Ethernet direct TCP RDP flow from a pcapng capture.
+pub fn read_capture(path: &Path) -> Result<Capture, ReplayError> {
+    let file = File::open(path).map_err(ReplayError::Io)?;
+    let mut reader = PcapNGReader::new(1024 * 1024, file).map_err(|error| ReplayError::Pcap(error.to_string()))?;
+    let mut packet = 0;
+    let mut linktypes = Vec::new();
+    let mut segments = Vec::new();
+    let mut tls_key_log = String::new();
+
+    loop {
+        match reader.next() {
+            Ok((offset, block)) => {
+                packet += 1;
+                match block {
+                    PcapBlockOwned::NG(Block::InterfaceDescription(interface)) => {
+                        linktypes.push(interface.linktype.0);
+                    }
+                    PcapBlockOwned::NG(Block::DecryptionSecrets(secrets))
+                        if secrets.secrets_type == SecretsType::TlsKeyLog =>
+                    {
+                        let length = usize::try_from(secrets.secrets_len)
+                            .map_err(|_| ReplayError::Pcap("TLS secret block is too large".to_owned()))?;
+                        let data = secrets
+                            .data
+                            .get(..length)
+                            .ok_or_else(|| ReplayError::Pcap("truncated TLS secret block".to_owned()))?;
+                        let text = core::str::from_utf8(data)
+                            .map_err(|_| ReplayError::Pcap("TLS secret block is not UTF-8".to_owned()))?;
+                        tls_key_log.push_str(text);
+                    }
+                    PcapBlockOwned::NG(Block::EnhancedPacket(packet_block)) => {
+                        let interface = usize::try_from(packet_block.if_id)
+                            .map_err(|_| ReplayError::Pcap("interface ID is too large".to_owned()))?;
+                        if linktypes.get(interface) == Some(&ETHERNET_LINKTYPE) && !packet_block.truncated() {
+                            if let Some(segment) = parse_tcp_packet(packet, packet_block.packet_data()) {
+                                segments.push(segment);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+                reader.consume(offset);
+            }
+            Err(PcapError::Eof) => break,
+            Err(PcapError::Incomplete(_)) => reader
+                .refill()
+                .map_err(|_| ReplayError::Pcap("truncated pcapng block".to_owned()))?,
+            Err(error) => return Err(ReplayError::Pcap(error.to_string())),
+        }
+    }
+
+    if !linktypes.contains(&ETHERNET_LINKTYPE) {
+        return Err(ReplayError::UnsupportedTransport);
+    }
+
+    Ok(Capture {
+        flow: assemble_flow(segments)?,
+        tls_key_log,
+    })
+}
+
+fn parse_tcp_packet(packet: usize, bytes: &[u8]) -> Option<Segment> {
+    let ethernet_type = u16::from_be_bytes(bytes.get(12..14)?.try_into().ok()?);
+    let (network_offset, ethernet_type) = if ethernet_type == 0x8100 {
+        (18, u16::from_be_bytes(bytes.get(16..18)?.try_into().ok()?))
+    } else {
+        (14, ethernet_type)
+    };
+
+    let (source, destination, tcp_offset) = match ethernet_type {
+        0x0800 => {
+            let header = bytes.get(network_offset..)?;
+            let header_len = usize::from(header.first()? & 0x0f) * 4;
+            if header_len < 20 || *header.get(9)? != 6 {
+                return None;
+            }
+            let source = IpAddr::from(<[u8; 4]>::try_from(header.get(12..16)?).ok()?);
+            let destination = IpAddr::from(<[u8; 4]>::try_from(header.get(16..20)?).ok()?);
+            (source, destination, network_offset + header_len)
+        }
+        0x86dd => {
+            let header = bytes.get(network_offset..network_offset + 40)?;
+            if header[6] != 6 {
+                return None;
+            }
+            let source = IpAddr::from(<[u8; 16]>::try_from(&header[8..24]).ok()?);
+            let destination = IpAddr::from(<[u8; 16]>::try_from(&header[24..40]).ok()?);
+            (source, destination, network_offset + 40)
+        }
+        _ => return None,
+    };
+
+    let tcp = bytes.get(tcp_offset..)?;
+    let header_len = usize::from(tcp.get(12)? >> 4) * 4;
+    if header_len < 20 || tcp.len() < header_len {
+        return None;
+    }
+    let flags = *tcp.get(13)?;
+
+    Some(Segment {
+        packet,
+        source: Endpoint {
+            address: source,
+            port: u16::from_be_bytes(tcp.get(0..2)?.try_into().ok()?),
+        },
+        destination: Endpoint {
+            address: destination,
+            port: u16::from_be_bytes(tcp.get(2..4)?.try_into().ok()?),
+        },
+        sequence: u32::from_be_bytes(tcp.get(4..8)?.try_into().ok()?),
+        syn: flags & 0x02 != 0,
+        ack: flags & 0x10 != 0,
+        data: tcp[header_len..].to_vec(),
+    })
+}
+
+fn assemble_flow(mut segments: Vec<Segment>) -> Result<Flow, ReplayError> {
+    segments.retain(|segment| !segment.data.is_empty() || segment.syn);
+    for syn in segments.iter().filter(|segment| segment.syn && !segment.ack) {
+        let client = syn.source.clone();
+        let server = syn.destination.clone();
+        let mut client_segments = Vec::new();
+        let mut server_segments = Vec::new();
+
+        for segment in &segments {
+            if segment.source == client && segment.destination == server {
+                client_segments.push(segment.clone());
+            } else if segment.source == server && segment.destination == client {
+                server_segments.push(segment.clone());
+            }
+        }
+
+        let client_stream = reassemble(client_segments)?;
+        let server_stream = reassemble(server_segments)?;
+        if !client_stream.is_empty() && !server_stream.is_empty() && has_x224_connection_request(&client_stream) {
+            return Ok(Flow {
+                client,
+                server,
+                client_stream,
+                server_stream,
+            });
+        }
+    }
+
+    Err(ReplayError::UnsupportedTransport)
+}
+
+fn has_x224_connection_request(stream: &PacketStream) -> bool {
+    let bytes = flatten(stream);
+    tpkt_frames(&bytes).any(|frame| frame.get(5) == Some(&0xe0))
+}
+
+fn reassemble(segments: Vec<Segment>) -> Result<PacketStream, ReplayError> {
+    let mut bytes = BTreeMap::new();
+    for segment in segments {
+        for (offset, byte) in segment.data.into_iter().enumerate() {
+            let offset = u32::try_from(offset).map_err(|_| ReplayError::MissingTcpFlow)?;
+            let sequence = segment
+                .sequence
+                .checked_add(offset)
+                .ok_or(ReplayError::MissingTcpFlow)?;
+            match bytes.entry(sequence) {
+                std::collections::btree_map::Entry::Vacant(entry) => {
+                    entry.insert((segment.packet, byte));
+                }
+                std::collections::btree_map::Entry::Occupied(entry) if entry.get().1 == byte => {}
+                std::collections::btree_map::Entry::Occupied(_) => return Err(ReplayError::MissingTcpFlow),
+            }
+        }
+    }
+
+    let Some((&first, _)) = bytes.first_key_value() else {
+        return Ok(Vec::new());
+    };
+
+    let mut sequence = first;
+    let mut stream = PacketStream::new();
+    while let Some((packet, byte)) = bytes.remove(&sequence) {
+        if let Some((previous_packet, chunk)) = stream.last_mut()
+            && *previous_packet == packet
+        {
+            chunk.push(byte);
+        } else {
+            stream.push((packet, vec![byte]));
+        }
+        sequence = sequence.checked_add(1).ok_or(ReplayError::MissingTcpFlow)?;
+    }
+    if !bytes.is_empty() {
+        return Err(ReplayError::MissingTcpFlow);
+    }
+
+    Ok(stream)
+}
+
+fn flatten(stream: &PacketStream) -> Vec<u8> {
+    stream.iter().flat_map(|(_, bytes)| bytes).copied().collect()
+}
+
+fn tpkt_frames(bytes: &[u8]) -> impl Iterator<Item = &[u8]> {
+    let mut offset = 0;
+    core::iter::from_fn(move || {
+        while offset + 4 <= bytes.len() {
+            if bytes[offset] == 3 && bytes[offset + 1] == 0 {
+                let length = usize::from(u16::from_be_bytes([bytes[offset + 2], bytes[offset + 3]]));
+                let end = offset.checked_add(length)?;
+                if length >= 7 && end <= bytes.len() {
+                    let frame = &bytes[offset..end];
+                    offset = end;
+                    return Some(frame);
+                }
+            }
+            offset += 1;
+        }
+        None
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use core::net::Ipv4Addr;
+
+    use super::*;
+
+    fn endpoint(port: u16) -> Endpoint {
+        Endpoint {
+            address: IpAddr::V4(Ipv4Addr::LOCALHOST),
+            port,
+        }
+    }
+
+    fn segment(sequence: u32, packet: usize, data: &[u8]) -> Segment {
+        Segment {
+            packet,
+            source: endpoint(1),
+            destination: endpoint(2),
+            sequence,
+            syn: false,
+            ack: true,
+            data: data.to_vec(),
+        }
+    }
+
+    #[test]
+    fn reassembly_deduplicates_retransmissions() {
+        let stream = reassemble(vec![
+            segment(12, 2, b"world"),
+            segment(7, 1, b"hello"),
+            segment(7, 3, b"hello"),
+        ])
+        .unwrap();
+
+        assert_eq!(flatten(&stream), b"helloworld");
+        assert_eq!(stream[0].0, 1);
+    }
+
+    #[test]
+    fn reassembly_rejects_conflicting_overlap() {
+        let error = reassemble(vec![segment(1, 1, b"hello"), segment(3, 2, b"XX")]).unwrap_err();
+
+        assert!(matches!(error, ReplayError::MissingTcpFlow));
+    }
+
+    #[test]
+    fn parses_direct_tcp_flow_from_pcapng() {
+        let path = std::env::temp_dir().join(format!("ironrdp-capture-replay-{}.pcapng", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        std::fs::write(
+            &path,
+            pcapng([
+                ethernet_tcp(1, 2, 100, 0x02, &[]),
+                ethernet_tcp(1, 2, 101, 0x10, &[3, 0, 0, 7, 2, 0xe0, 0]),
+                ethernet_tcp(2, 1, 200, 0x10, &[0]),
+            ]),
+        )
+        .unwrap();
+
+        let capture = read_capture(&path).unwrap();
+
+        assert_eq!(capture.flow.client.port, 1);
+        assert_eq!(capture.flow.server.port, 2);
+        assert_eq!(flatten(&capture.flow.client_stream), [3, 0, 0, 7, 2, 0xe0, 0]);
+        assert_eq!(flatten(&capture.flow.server_stream), [0]);
+        std::fs::remove_file(path).unwrap();
+    }
+
+    fn pcapng(frames: impl IntoIterator<Item = Vec<u8>>) -> Vec<u8> {
+        let mut output = Vec::new();
+        output.extend(block(0x0a0d0d0a, {
+            let mut body = Vec::new();
+            body.extend(0x1a2b3c4du32.to_le_bytes());
+            body.extend(1u16.to_le_bytes());
+            body.extend(0u16.to_le_bytes());
+            body.extend((-1i64).to_le_bytes());
+            body
+        }));
+        output.extend(block(1, {
+            let mut body = Vec::new();
+            body.extend(1u16.to_le_bytes());
+            body.extend(0u16.to_le_bytes());
+            body.extend(u32::MAX.to_le_bytes());
+            body
+        }));
+        for frame in frames {
+            let mut body = Vec::new();
+            body.extend(0u32.to_le_bytes());
+            body.extend(0u32.to_le_bytes());
+            body.extend(0u32.to_le_bytes());
+            body.extend(u32::try_from(frame.len()).unwrap().to_le_bytes());
+            body.extend(u32::try_from(frame.len()).unwrap().to_le_bytes());
+            body.extend(frame);
+            body.resize((body.len() + 3) & !3, 0);
+            output.extend(block(6, body));
+        }
+        output
+    }
+
+    fn block(kind: u32, body: Vec<u8>) -> Vec<u8> {
+        let length = u32::try_from(body.len() + 12).unwrap();
+        let mut output = Vec::new();
+        output.extend(kind.to_le_bytes());
+        output.extend(length.to_le_bytes());
+        output.extend(body);
+        output.extend(length.to_le_bytes());
+        output
+    }
+
+    fn ethernet_tcp(source_port: u16, destination_port: u16, sequence: u32, flags: u8, data: &[u8]) -> Vec<u8> {
+        let mut packet = vec![0; 14 + 20 + 20];
+        packet[12..14].copy_from_slice(&0x0800u16.to_be_bytes());
+        packet[14] = 0x45;
+        let length = u16::try_from(20 + 20 + data.len()).unwrap();
+        packet[16..18].copy_from_slice(&length.to_be_bytes());
+        packet[22] = 64;
+        packet[23] = 6;
+        let source_address = if source_port == 1 { 1 } else { 2 };
+        let destination_address = if destination_port == 1 { 1 } else { 2 };
+        packet[26..30].copy_from_slice(&[127, 0, 0, source_address]);
+        packet[30..34].copy_from_slice(&[127, 0, 0, destination_address]);
+        let tcp = &mut packet[34..];
+        tcp[0..2].copy_from_slice(&source_port.to_be_bytes());
+        tcp[2..4].copy_from_slice(&destination_port.to_be_bytes());
+        tcp[4..8].copy_from_slice(&sequence.to_be_bytes());
+        tcp[12] = 0x50;
+        tcp[13] = flags;
+        packet.extend(data);
+        packet
+    }
+}

--- a/crates/ironrdp-capture-replay/src/transport.rs
+++ b/crates/ironrdp-capture-replay/src/transport.rs
@@ -5,6 +5,7 @@ use core::net::IpAddr;
 use pcap_parser::pcapng::{Block, SecretsType};
 use pcap_parser::traits::{PcapNGPacketBlock as _, PcapReaderIterator as _};
 use pcap_parser::{PcapBlockOwned, PcapError, PcapNGReader};
+use zeroize::Zeroize as _;
 
 use crate::ReplayError;
 
@@ -41,9 +42,7 @@ pub struct Capture {
     /// Direct TCP RDP flow selected from the pcapng input.
     pub flow: Flow,
     /// NSS-compatible TLS key-log entries embedded in the capture.
-    ///
-    /// The entries are retained only in memory and must not be logged or persisted.
-    pub tls_key_log: String,
+    pub tls_key_log: TlsKeyLog,
 }
 
 impl core::fmt::Debug for Capture {
@@ -52,6 +51,29 @@ impl core::fmt::Debug for Capture {
             .field("flow", &self.flow)
             .field("tls_key_log", &"<redacted>")
             .finish()
+    }
+}
+
+/// TLS key-log material retained for decrypting a capture.
+#[derive(Clone)]
+pub struct TlsKeyLog(String);
+
+impl TlsKeyLog {
+    /// Get the key log required to decrypt the recorded TLS stream.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl core::fmt::Debug for TlsKeyLog {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("<redacted>")
+    }
+}
+
+impl Drop for TlsKeyLog {
+    fn drop(&mut self) {
+        self.0.zeroize();
     }
 }
 
@@ -117,9 +139,7 @@ pub fn read_capture(path: &Path) -> Result<Capture, ReplayError> {
                 reader.consume(offset);
             }
             Err(PcapError::Eof) => break,
-            Err(PcapError::Incomplete(_)) => reader
-                .refill()
-                .map_err(|_| ReplayError::Pcap("truncated pcapng block".to_owned()))?,
+            Err(PcapError::Incomplete(_)) => reader.refill().map_err(|error| ReplayError::Pcap(error.to_string()))?,
             Err(error) => return Err(ReplayError::Pcap(error.to_string())),
         }
     }
@@ -130,7 +150,7 @@ pub fn read_capture(path: &Path) -> Result<Capture, ReplayError> {
 
     Ok(Capture {
         flow: assemble_flow(segments)?,
-        tls_key_log,
+        tls_key_log: TlsKeyLog(tls_key_log),
     })
 }
 
@@ -161,15 +181,23 @@ fn parse_tcp_packet(packet: usize, bytes: &[u8]) -> Option<Segment> {
         }
         0x86dd => {
             let header = bytes.get(network_offset..network_offset + 40)?;
-            if header[6] != 6 {
-                return None;
-            }
             let payload_len = usize::from(u16::from_be_bytes(header.get(4..6)?.try_into().ok()?));
             let network_end = network_offset.checked_add(40 + payload_len)?;
             bytes.get(network_offset..network_end)?;
             let source = IpAddr::from(<[u8; 16]>::try_from(&header[8..24]).ok()?);
             let destination = IpAddr::from(<[u8; 16]>::try_from(&header[24..40]).ok()?);
-            (source, destination, network_offset + 40, network_end)
+            let mut next_header = header[6];
+            let mut tcp_offset = network_offset + 40;
+            while matches!(next_header, 0 | 43 | 60) {
+                let extension = bytes.get(tcp_offset..network_end)?;
+                let length = (usize::from(*extension.get(1)?) + 1) * 8;
+                next_header = *extension.first()?;
+                tcp_offset = tcp_offset.checked_add(length)?;
+            }
+            if next_header != 6 {
+                return None;
+            }
+            (source, destination, tcp_offset, network_end)
         }
         _ => return None,
     };
@@ -202,6 +230,7 @@ fn parse_tcp_packet(packet: usize, bytes: &[u8]) -> Option<Segment> {
 
 fn assemble_flow(mut segments: Vec<Segment>) -> Result<Flow, ReplayError> {
     segments.retain(|segment| !segment.data.is_empty() || segment.syn || segment.fin || segment.rst);
+    let mut missing_tcp_flow = false;
     for (start, syn) in segments
         .iter()
         .enumerate()
@@ -254,12 +283,14 @@ fn assemble_flow(mut segments: Vec<Segment>) -> Result<Flow, ReplayError> {
             })
             .unwrap_or(0);
         let Ok(client_stream) = reassemble(client_segments, client_origin) else {
+            missing_tcp_flow = true;
             continue;
         };
         let Ok(server_stream) = reassemble(server_segments, server_origin) else {
+            missing_tcp_flow = true;
             continue;
         };
-        if !client_stream.is_empty() && !server_stream.is_empty() && has_x224_connection_request(&client_stream) {
+        if has_x224_connection_initiation(&client_stream, &server_stream) {
             return Ok(Flow {
                 client,
                 server,
@@ -269,12 +300,30 @@ fn assemble_flow(mut segments: Vec<Segment>) -> Result<Flow, ReplayError> {
         }
     }
 
-    Err(ReplayError::UnsupportedTransport)
+    Err(if missing_tcp_flow {
+        ReplayError::MissingTcpFlow
+    } else {
+        ReplayError::UnsupportedTransport
+    })
 }
 
-fn has_x224_connection_request(stream: &PacketStream) -> bool {
-    let bytes = flatten(stream);
-    tpkt_frames(&bytes).any(|frame| frame.get(5) == Some(&0xe0))
+fn has_x224_connection_initiation(client_stream: &PacketStream, server_stream: &PacketStream) -> bool {
+    has_x224_connection_tpdu(&flatten(client_stream), 0xe0) && has_x224_connection_tpdu(&flatten(server_stream), 0xd0)
+}
+
+fn has_x224_connection_tpdu(bytes: &[u8], code: u8) -> bool {
+    let Some(header) = bytes.get(..4) else {
+        return false;
+    };
+    if header[0] != 3 || header[1] != 0 {
+        return false;
+    }
+    let length = usize::from(u16::from_be_bytes([header[2], header[3]]));
+    let Some(frame) = bytes.get(..length) else {
+        return false;
+    };
+
+    frame.len() >= 11 && frame[4] == 6 && frame[5] == code && frame[6..11] == [0; 5]
 }
 
 fn reassemble(segments: Vec<Segment>, origin: u32) -> Result<PacketStream, ReplayError> {
@@ -337,25 +386,6 @@ fn flatten(stream: &PacketStream) -> Vec<u8> {
     stream.iter().flat_map(|(_, bytes)| bytes).copied().collect()
 }
 
-fn tpkt_frames(bytes: &[u8]) -> impl Iterator<Item = &[u8]> {
-    let mut offset = 0;
-    core::iter::from_fn(move || {
-        while offset + 4 <= bytes.len() {
-            if bytes[offset] == 3 && bytes[offset + 1] == 0 {
-                let length = usize::from(u16::from_be_bytes([bytes[offset + 2], bytes[offset + 3]]));
-                let end = offset.checked_add(length)?;
-                if length >= 7 && end <= bytes.len() {
-                    let frame = &bytes[offset..end];
-                    offset = end;
-                    return Some(frame);
-                }
-            }
-            offset += 1;
-        }
-        None
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use core::net::Ipv4Addr;
@@ -395,6 +425,14 @@ mod tests {
         }
     }
 
+    fn connection_request() -> [u8; 19] {
+        [3, 0, 0, 19, 6, 0xe0, 0, 0, 0, 0, 0, 1, 0, 8, 0, 1, 0, 0, 0]
+    }
+
+    fn connection_confirm() -> [u8; 19] {
+        [3, 0, 0, 19, 6, 0xd0, 0, 0, 0, 0, 0, 2, 0, 8, 0, 1, 0, 0, 0]
+    }
+
     #[test]
     fn reassembly_deduplicates_retransmissions() {
         let stream = reassemble(
@@ -430,6 +468,28 @@ mod tests {
     }
 
     #[test]
+    fn rejects_invalid_x224_connection_initiation() {
+        let client = vec![3, 0, 0, 7, 2, 0xe0, 0];
+        let server = connection_confirm();
+
+        assert!(!has_x224_connection_initiation(
+            &vec![(1, client)],
+            &vec![(2, server.to_vec())]
+        ));
+    }
+
+    #[test]
+    fn rejects_x224_connection_request_after_leading_data() {
+        let client = [b"not-rdp".as_slice(), connection_request().as_slice()].concat();
+        let server = connection_confirm();
+
+        assert!(!has_x224_connection_initiation(
+            &vec![(1, client)],
+            &vec![(2, server.to_vec())]
+        ));
+    }
+
+    #[test]
     fn skips_incomplete_flows_before_a_valid_rdp_connection() {
         let first_client = endpoint(1);
         let first_server = endpoint(2);
@@ -447,14 +507,37 @@ mod tests {
                 5,
                 false,
                 true,
-                &[3, 0, 0, 7, 2, 0xe0, 0],
+                &connection_request(),
             ),
-            segment_between(second_server, second_client, 300, 6, false, true, &[0]),
+            segment_between(second_server, second_client, 300, 6, false, true, &connection_confirm()),
         ])
         .unwrap();
 
         assert_eq!(flow.client.port, 3);
         assert_eq!(flow.server.port, 4);
+    }
+
+    #[test]
+    fn reports_missing_tcp_flow_when_no_candidate_reassembles() {
+        let client = endpoint(1);
+        let server = endpoint(2);
+        let request = connection_request();
+        let error = assemble_flow(vec![
+            segment_between(client.clone(), server.clone(), 100, 1, true, false, &[]),
+            segment_between(client.clone(), server.clone(), 101, 2, false, true, &request[..8]),
+            segment_between(
+                client,
+                server,
+                101 + u32::try_from(request.len()).unwrap(),
+                3,
+                false,
+                true,
+                &request[8..],
+            ),
+        ])
+        .unwrap_err();
+
+        assert!(matches!(error, ReplayError::MissingTcpFlow));
     }
 
     #[test]
@@ -473,9 +556,9 @@ mod tests {
                 5,
                 false,
                 true,
-                &[3, 0, 0, 7, 2, 0xe0, 0],
+                &connection_request(),
             ),
-            segment_between(server, client, 700, 6, false, true, &[0]),
+            segment_between(server, client, 700, 6, false, true, &connection_confirm()),
         ])
         .unwrap();
 
@@ -487,29 +570,50 @@ mod tests {
     fn preserves_peer_data_after_a_half_close() {
         let client = endpoint(1);
         let server = endpoint(2);
-        let mut client_fin = segment_between(client.clone(), server.clone(), 108, 3, false, true, &[]);
+        let request = connection_request();
+        let confirm = connection_confirm();
+        let mut client_fin = segment_between(
+            client.clone(),
+            server.clone(),
+            101 + u32::try_from(request.len()).unwrap(),
+            3,
+            false,
+            true,
+            &[],
+        );
         client_fin.fin = true;
-        let mut server_fin = segment_between(server.clone(), client.clone(), 311, 6, false, true, &[]);
+        let mut server_fin = segment_between(
+            server.clone(),
+            client.clone(),
+            300 + u32::try_from(confirm.len() + 11).unwrap(),
+            6,
+            false,
+            true,
+            &[],
+        );
         server_fin.fin = true;
         let flow = assemble_flow(vec![
             segment_between(client.clone(), server.clone(), 100, 1, true, false, &[]),
+            segment_between(client.clone(), server.clone(), 101, 2, false, true, &request),
+            client_fin,
+            segment_between(server.clone(), client.clone(), 300, 4, false, true, &confirm),
             segment_between(
-                client.clone(),
-                server.clone(),
-                101,
-                2,
+                server,
+                client,
+                300 + u32::try_from(confirm.len()).unwrap(),
+                5,
                 false,
                 true,
-                &[3, 0, 0, 7, 2, 0xe0, 0],
+                b"firstsecond",
             ),
-            client_fin,
-            segment_between(server.clone(), client.clone(), 300, 4, false, true, b"first"),
-            segment_between(server, client, 305, 5, false, true, b"second"),
             server_fin,
         ])
         .unwrap();
 
-        assert_eq!(flatten(&flow.server_stream), b"firstsecond");
+        assert_eq!(
+            flatten(&flow.server_stream),
+            [confirm.as_slice(), b"firstsecond"].concat()
+        );
     }
 
     #[test]
@@ -520,8 +624,8 @@ mod tests {
             &path,
             pcapng([
                 ethernet_tcp(1, 2, 100, 0x02, &[]),
-                ethernet_tcp(1, 2, 101, 0x10, &[3, 0, 0, 7, 2, 0xe0, 0]),
-                ethernet_tcp(2, 1, 200, 0x10, &[0]),
+                ethernet_tcp(1, 2, 101, 0x10, &connection_request()),
+                ethernet_tcp(2, 1, 200, 0x10, &connection_confirm()),
             ]),
         )
         .unwrap();
@@ -532,8 +636,8 @@ mod tests {
         assert_eq!(capture.flow.server.port, 2);
         assert_eq!(capture.flow.client_stream[0].0, 2);
         assert_eq!(capture.flow.server_stream[0].0, 3);
-        assert_eq!(flatten(&capture.flow.client_stream), [3, 0, 0, 7, 2, 0xe0, 0]);
-        assert_eq!(flatten(&capture.flow.server_stream), [0]);
+        assert_eq!(flatten(&capture.flow.client_stream), connection_request());
+        assert_eq!(flatten(&capture.flow.server_stream), connection_confirm());
         std::fs::remove_file(path).unwrap();
     }
 
@@ -546,8 +650,8 @@ mod tests {
             pcapng_with_key_log(
                 [
                     ethernet_tcp(1, 2, 100, 0x02, &[]),
-                    ethernet_tcp(1, 2, 101, 0x10, &[3, 0, 0, 7, 2, 0xe0, 0]),
-                    ethernet_tcp(2, 1, 200, 0x10, &[0]),
+                    ethernet_tcp(1, 2, 101, 0x10, &connection_request()),
+                    ethernet_tcp(2, 1, 200, 0x10, &connection_confirm()),
                 ],
                 "CLIENT_RANDOM synthetic secret\n",
             ),
@@ -556,7 +660,7 @@ mod tests {
 
         let capture = read_capture(&path).unwrap();
 
-        assert_eq!(capture.tls_key_log, "CLIENT_RANDOM synthetic secret\n");
+        assert_eq!(capture.tls_key_log.as_str(), "CLIENT_RANDOM synthetic secret\n");
         assert!(!format!("{capture:?}").contains("synthetic secret"));
         std::fs::remove_file(path).unwrap();
     }
@@ -567,6 +671,13 @@ mod tests {
         packet.extend([0; 16]);
 
         let segment = parse_tcp_packet(1, &packet).unwrap();
+
+        assert_eq!(segment.data, b"payload");
+    }
+
+    #[test]
+    fn parses_tcp_after_an_ipv6_hop_by_hop_header() {
+        let segment = parse_tcp_packet(1, &ethernet_ipv6_tcp_with_hop_by_hop(1, 2, 100, b"payload")).unwrap();
 
         assert_eq!(segment.data, b"payload");
     }
@@ -642,6 +753,32 @@ mod tests {
         tcp[4..8].copy_from_slice(&sequence.to_be_bytes());
         tcp[12] = 0x50;
         tcp[13] = flags;
+        packet.extend(data);
+        packet
+    }
+
+    fn ethernet_ipv6_tcp_with_hop_by_hop(
+        source_port: u16,
+        destination_port: u16,
+        sequence: u32,
+        data: &[u8],
+    ) -> Vec<u8> {
+        let mut packet = vec![0; 14 + 40 + 8 + 20];
+        packet[12..14].copy_from_slice(&0x86ddu16.to_be_bytes());
+        packet[14] = 0x60;
+        let payload_length = u16::try_from(8 + 20 + data.len()).unwrap();
+        packet[18..20].copy_from_slice(&payload_length.to_be_bytes());
+        packet[20] = 0;
+        packet[21] = 64;
+        packet[29] = if source_port == 1 { 1 } else { 2 };
+        packet[45] = if destination_port == 1 { 1 } else { 2 };
+        packet[54] = 6;
+        let tcp = &mut packet[62..];
+        tcp[0..2].copy_from_slice(&source_port.to_be_bytes());
+        tcp[2..4].copy_from_slice(&destination_port.to_be_bytes());
+        tcp[4..8].copy_from_slice(&sequence.to_be_bytes());
+        tcp[12] = 0x50;
+        tcp[13] = 0x10;
         packet.extend(data);
         packet
     }


### PR DESCRIPTION
Read and reassemble Ethernet direct TCP RDP flows from PCAPNG captures.

Retain embedded TLS key-log entries only in memory for later decryption.