### PR TITLE
feat(replay): decrypt recorded TLS streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,12 +37,33 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
+name = "aead"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
  "crypto-common 0.2.2",
- "inout",
+ "inout 0.2.2",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -51,9 +72,23 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
- "cipher",
+ "cipher 0.5.2",
  "cpubits",
  "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead 0.5.2",
+ "aes 0.8.4",
+ "cipher 0.4.4",
+ "ctr 0.9.2",
+ "ghash 0.5.1",
+ "subtle",
 ]
 
 [[package]]
@@ -62,11 +97,11 @@ version = "0.11.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da8c919c118108f144adecad74b425b804ad075580d605d9b33c2d6d1c62a2f8"
 dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
+ "aead 0.6.1",
+ "aes 0.9.1",
+ "cipher 0.5.2",
+ "ctr 0.10.1",
+ "ghash 0.6.0",
  "subtle",
 ]
 
@@ -76,7 +111,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41ac571010bd60765c56085a4f1d412012a9be2663b1a2f2b19b49318653fd0d"
 dependencies = [
- "aes",
+ "aes 0.9.1",
  "const-oid 0.10.2",
 ]
 
@@ -607,7 +642,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
 dependencies = [
- "cipher",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -693,13 +728,23 @@ dependencies = [
 
 [[package]]
 name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
  "block-buffer 0.12.1",
  "crypto-common 0.2.2",
- "inout",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -1069,6 +1114,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1136,11 +1182,20 @@ dependencies = [
 
 [[package]]
 name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "ctr"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
 dependencies = [
- "cipher",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -1290,7 +1345,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "916a94e407b54f9034d71dd748234cd1e516ced6284009906ae246f177eafe5a"
 dependencies = [
- "cipher",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -1889,11 +1944,21 @@ dependencies = [
 
 [[package]]
 name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval 0.6.2",
+]
+
+[[package]]
+name = "ghash"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
 dependencies = [
- "polyval",
+ "polyval 0.7.1",
 ]
 
 [[package]]
@@ -2339,6 +2404,15 @@ dependencies = [
 
 [[package]]
 name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "inout"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
@@ -2537,7 +2611,10 @@ dependencies = [
 name = "ironrdp-capture-replay"
 version = "0.0.0"
 dependencies = [
+ "aes-gcm 0.10.3",
+ "hmac 0.12.1",
  "pcap-parser",
+ "sha2 0.10.9",
  "thiserror 2.0.19",
  "zeroize",
 ]
@@ -4195,6 +4272,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openh264"
 version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4410,14 +4493,14 @@ version = "7.0.0-rc.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ae9cd78eb1d61be4790713d28368cf71c844218fcd91542768805423f02666"
 dependencies = [
- "aes",
- "aes-gcm",
+ "aes 0.9.1",
+ "aes-gcm 0.11.0-rc.4",
  "aes-kw",
  "base64",
  "cbc",
  "crypto-bigint",
  "crypto-common 0.2.2",
- "ctr",
+ "ctr 0.10.1",
  "curve25519-dalek",
  "des",
  "digest 0.11.3",
@@ -4426,7 +4509,7 @@ dependencies = [
  "hex",
  "hmac 0.13.0",
  "http",
- "inout",
+ "inout 0.2.2",
  "md-5 0.11.0",
  "p256",
  "p384",
@@ -4500,15 +4583,15 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d188f3192356068dbdba54bddbca6fd0f7a09565d3861eeb8efe1ab77ae8e97"
 dependencies = [
- "aes",
+ "aes 0.9.1",
  "block-padding",
  "byteorder",
  "cbc",
- "cipher",
+ "cipher 0.5.2",
  "crypto-bigint",
  "des",
  "hmac 0.13.0",
- "inout",
+ "inout 0.2.2",
  "oid",
  "pbkdf2",
  "picky-asn1",
@@ -4670,13 +4753,25 @@ dependencies = [
 
 [[package]]
 name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "polyval"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
 dependencies = [
  "cpubits",
  "cpufeatures 0.3.0",
- "universal-hash",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -5030,7 +5125,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceda21af1ae61033b63175653a1af86cae399d79cd03ca80ba347eb3a6c4a7fe"
 dependencies = [
- "cipher",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -6546,6 +6641,16 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
 
 [[package]]
 name = "universal-hash"

--- a/crates/ironrdp-capture-replay/Cargo.toml
+++ b/crates/ironrdp-capture-replay/Cargo.toml
@@ -13,7 +13,10 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+aes-gcm = "0.10"
+hmac = "0.12"
 pcap-parser = "0.17"
+sha2 = "0.10"
 thiserror = "2"
 zeroize = "1.8"
 

--- a/crates/ironrdp-capture-replay/src/error.rs
+++ b/crates/ironrdp-capture-replay/src/error.rs
@@ -17,4 +17,16 @@ pub enum ReplayError {
     /// The capture has incomplete or contradictory TCP data.
     #[error("capture does not contain a complete client/server TCP flow")]
     MissingTcpFlow,
+    /// The capture uses Standard RDP Security instead of TLS.
+    #[error("capture uses Standard RDP Security without decryptable session keys")]
+    StandardSecurity,
+    /// The TLS protocol version or cipher suite is unsupported.
+    #[error("capture TLS version or cipher suite is unsupported")]
+    UnsupportedTls,
+    /// The capture lacks the key-log entry required to decrypt its TLS session.
+    #[error("capture does not include an NSS TLS secret for the negotiated session")]
+    MissingTlsSecret,
+    /// TLS record authentication failed.
+    #[error("capture TLS authentication failed")]
+    TlsAuthentication,
 }

--- a/crates/ironrdp-capture-replay/src/error.rs
+++ b/crates/ironrdp-capture-replay/src/error.rs
@@ -29,4 +29,7 @@ pub enum ReplayError {
     /// TLS record authentication failed.
     #[error("capture TLS authentication failed")]
     TlsAuthentication,
+    /// The capture requires unsupported TLS 1.3 key rotation.
+    #[error("capture uses unsupported TLS 1.3 key rotation")]
+    TlsKeyUpdate,
 }

--- a/crates/ironrdp-capture-replay/src/lib.rs
+++ b/crates/ironrdp-capture-replay/src/lib.rs
@@ -1,7 +1,9 @@
 //! Offline analysis support for direct TCP RDP captures.
 
 mod error;
+mod tls;
 mod transport;
 
 pub use error::ReplayError;
+pub use tls::{Plaintext, decrypt_tls};
 pub use transport::{Capture, Endpoint, Flow, PacketStream, TlsKeyLog, read_capture};

--- a/crates/ironrdp-capture-replay/src/tls.rs
+++ b/crates/ironrdp-capture-replay/src/tls.rs
@@ -5,6 +5,9 @@ use sha2::{Sha256, Sha384};
 
 use crate::{Capture, PacketStream, ReplayError};
 
+#[cfg(test)]
+use crate::TlsKeyLog;
+
 const TLS_CONTENT_CHANGE_CIPHER_SPEC: u8 = 20;
 const TLS_CONTENT_HANDSHAKE: u8 = 22;
 const TLS_CONTENT_APPLICATION_DATA: u8 = 23;
@@ -29,7 +32,7 @@ pub fn decrypt_tls(capture: &Capture) -> Result<Plaintext, ReplayError> {
     if client_records.is_empty() && server_records.is_empty() {
         return Err(ReplayError::StandardSecurity);
     }
-    let tls = Tls::from_records(&client_records, &server_records, &capture.tls_key_log)?;
+    let tls = Tls::from_records(&client_records, &server_records, capture.tls_key_log.as_str())?;
 
     Ok(Plaintext {
         client: tls.decrypt(Direction::Client, &client_records)?,
@@ -599,7 +602,7 @@ mod tests {
                 client_stream: vec![(1, client_records.into_iter().flat_map(|(_, record)| record).collect())],
                 server_stream: vec![(4, server_records.into_iter().flat_map(|(_, record)| record).collect())],
             },
-            tls_key_log: key_log,
+            tls_key_log: TlsKeyLog::new(key_log),
         };
 
         let plaintext = decrypt_tls(&capture).unwrap();

--- a/crates/ironrdp-capture-replay/src/tls.rs
+++ b/crates/ironrdp-capture-replay/src/tls.rs
@@ -3,6 +3,7 @@ use aes_gcm::{Aes128Gcm, Aes256Gcm, Nonce, Tag};
 use hmac::{Hmac, Mac};
 use sha2::{Sha256, Sha384};
 
+use crate::transport::x224_connection_tpdu_end;
 use crate::{Capture, PacketStream, ReplayError};
 
 #[cfg(test)]
@@ -12,8 +13,11 @@ const TLS_CONTENT_CHANGE_CIPHER_SPEC: u8 = 20;
 const TLS_CONTENT_HANDSHAKE: u8 = 22;
 const TLS_CONTENT_APPLICATION_DATA: u8 = 23;
 const TLS_VERSION_1_2: u16 = 0x0303;
+const TLS_MAX_RECORD_LENGTH: usize = 16_384 + 256;
 
-/// Decrypted TLS application-data streams with their packet provenance.
+/// Decrypted TLS application data with packet provenance.
+///
+/// Callers must identify the negotiated security protocol before treating either stream as RDP framing.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Plaintext {
     /// Client-to-server application data.
@@ -27,8 +31,13 @@ pub struct Plaintext {
 /// TLS key-log entries are used only in memory and are not retained by the
 /// returned streams.
 pub fn decrypt_tls(capture: &Capture) -> Result<Plaintext, ReplayError> {
-    let client_records = collect_tls_records(&capture.flow.client_stream)?;
-    let server_records = collect_tls_records(&capture.flow.server_stream)?;
+    let client_records = collect_tls_records(&capture.flow.client_stream, 0xe0)?;
+    let server_records = collect_tls_records(&capture.flow.server_stream, 0xd0)?;
+    let (client_records, server_records) = match (client_records, server_records) {
+        (Some(client_records), Some(server_records)) => (client_records, server_records),
+        (None, None) => return Err(ReplayError::StandardSecurity),
+        _ => return Err(ReplayError::UnsupportedTls),
+    };
     if client_records.is_empty() && server_records.is_empty() {
         return Err(ReplayError::StandardSecurity);
     }
@@ -93,8 +102,8 @@ impl Tls12 {
         let client_random = &client_hello[2..34];
         let server_random = &server_hello[2..34];
         let cipher = match suite {
-            0x009c | 0xc02f => Cipher::Aes128GcmSha256,
-            0x009d | 0xc030 => Cipher::Aes256GcmSha384,
+            0x009c | 0xc02b | 0xc02f => Cipher::Aes128GcmSha256,
+            0x009d | 0xc02c | 0xc030 => Cipher::Aes256GcmSha384,
             _ => return Err(ReplayError::UnsupportedTls),
         };
         let master = parse_master_secret(key_log, client_random).ok_or(ReplayError::MissingTlsSecret)?;
@@ -268,6 +277,9 @@ impl Tls13 {
                     handshake_phase = false;
                 }
             }
+            if inner_type == TLS_CONTENT_HANDSHAKE && !handshake_phase && tls13_handshake_contains_key_update(content) {
+                return Err(ReplayError::TlsKeyUpdate);
+            }
             if inner_type == TLS_CONTENT_APPLICATION_DATA {
                 output.push((*packet, content.to_vec()));
             }
@@ -276,30 +288,43 @@ impl Tls13 {
     }
 }
 
-fn collect_tls_records(stream: &PacketStream) -> Result<PacketStream, ReplayError> {
+fn collect_tls_records(stream: &PacketStream, x224_code: u8) -> Result<Option<PacketStream>, ReplayError> {
     let mut bytes = Vec::new();
+    let mut packet_offsets = Vec::with_capacity(stream.len());
     for (packet, chunk) in stream {
-        bytes.extend(chunk.iter().copied().map(|byte| (*packet, byte)));
+        packet_offsets.push((bytes.len(), *packet));
+        bytes.extend_from_slice(chunk);
     }
-    let start = bytes
-        .windows(3)
-        .position(|window| window[0].1 == TLS_CONTENT_HANDSHAKE && window[1].1 == 3 && window[2].1 >= 1)
-        .ok_or(ReplayError::UnsupportedTransport)?;
-    let mut offset = start;
+    let tpkt_end = x224_connection_tpdu_end(&bytes, x224_code);
+    let start = if let Some(start) = tpkt_end {
+        bytes
+            .get(start..start + 3)
+            .is_some_and(|header| header[0] == TLS_CONTENT_HANDSHAKE && header[1] == 3 && header[2] >= 1)
+            .then_some(start)
+    } else {
+        bytes
+            .windows(3)
+            .position(|window| window[0] == TLS_CONTENT_HANDSHAKE && window[1] == 3 && window[2] >= 1)
+    };
+    let Some(mut offset) = start else {
+        return Ok(None);
+    };
+
     let mut records = Vec::new();
     while offset + 5 <= bytes.len() {
-        let length = usize::from(u16::from_be_bytes([bytes[offset + 3].1, bytes[offset + 4].1]));
-        let end = offset.checked_add(5 + length).ok_or(ReplayError::UnsupportedTls)?;
-        if end > bytes.len() {
+        let length = usize::from(u16::from_be_bytes([bytes[offset + 3], bytes[offset + 4]]));
+        if length > TLS_MAX_RECORD_LENGTH {
             return Err(ReplayError::UnsupportedTls);
         }
-        records.push((
-            bytes[offset].0,
-            bytes[offset..end].iter().map(|(_, byte)| *byte).collect(),
-        ));
+        let end = offset.checked_add(5 + length).ok_or(ReplayError::UnsupportedTls)?;
+        if end > bytes.len() {
+            break;
+        }
+        let packet_index = packet_offsets.partition_point(|(chunk_offset, _)| *chunk_offset <= offset) - 1;
+        records.push((packet_offsets[packet_index].1, bytes[offset..end].to_vec()));
         offset = end;
     }
-    Ok(records)
+    Ok(Some(records))
 }
 
 fn parse_tls_record(record: &[u8]) -> Option<(u8, u16, &[u8])> {
@@ -558,7 +583,26 @@ fn tls13_handshake_contains_finished(data: &[u8]) -> bool {
         if end > data.len() {
             return false;
         }
+
         if header[0] == 20 {
+            return true;
+        }
+        offset = end;
+    }
+    false
+}
+
+fn tls13_handshake_contains_key_update(data: &[u8]) -> bool {
+    let mut offset = 0;
+    while let Some(header) = data.get(offset..offset + 4) {
+        let length = (usize::from(header[1]) << 16) | (usize::from(header[2]) << 8) | usize::from(header[3]);
+        let Some(end) = offset.checked_add(4 + length) else {
+            return false;
+        };
+        if end > data.len() {
+            return false;
+        }
+        if header[0] == 24 {
             return true;
         }
         offset = end;
@@ -625,6 +669,98 @@ mod tests {
         assert!(matches!(result, Err(ReplayError::MissingTlsSecret)));
     }
 
+    #[test]
+    fn reports_standard_security_without_tls_records() {
+        let capture = Capture {
+            flow: Flow {
+                client: endpoint(1),
+                server: endpoint(2),
+                client_stream: vec![(1, x224_connection(0xe0))],
+                server_stream: vec![(2, x224_connection(0xd0))],
+            },
+            tls_key_log: TlsKeyLog::new(String::new()),
+        };
+
+        assert!(matches!(decrypt_tls(&capture), Err(ReplayError::StandardSecurity)));
+    }
+
+    #[test]
+    fn ignores_a_truncated_trailing_tls_record() {
+        let mut stream = x224_connection(0xe0);
+        stream.extend([TLS_CONTENT_HANDSHAKE, 3, 3, 0, 1]);
+
+        assert_eq!(collect_tls_records(&vec![(1, stream)], 0xe0).unwrap(), Some(Vec::new()));
+    }
+
+    #[test]
+    fn decrypts_tls13_handshake_and_application_records() {
+        let client_random = [1; 32];
+        let key_log = [
+            ("CLIENT_HANDSHAKE_TRAFFIC_SECRET", [2; 32]),
+            ("SERVER_HANDSHAKE_TRAFFIC_SECRET", [3; 32]),
+            ("CLIENT_TRAFFIC_SECRET_0", [4; 32]),
+            ("SERVER_TRAFFIC_SECRET_0", [5; 32]),
+        ]
+        .into_iter()
+        .map(|(label, secret)| format!("{label} {} {}", hex(&client_random), hex(&secret)))
+        .collect::<Vec<_>>()
+        .join("\n");
+        let tls = Tls13::from_hello(&hello(1, client_random, None), 0x1301, &key_log).unwrap();
+        let finished = [20, 0, 0, 0];
+        let client = vec![
+            (
+                1,
+                encrypt_tls13_record(tls.cipher, &tls.client_handshake, 0, &finished, TLS_CONTENT_HANDSHAKE),
+            ),
+            (
+                2,
+                encrypt_tls13_record(
+                    tls.cipher,
+                    &tls.client_application,
+                    0,
+                    b"client",
+                    TLS_CONTENT_APPLICATION_DATA,
+                ),
+            ),
+        ];
+        let server = vec![
+            (
+                3,
+                encrypt_tls13_record(tls.cipher, &tls.server_handshake, 0, &finished, TLS_CONTENT_HANDSHAKE),
+            ),
+            (
+                4,
+                encrypt_tls13_record(
+                    tls.cipher,
+                    &tls.server_application,
+                    0,
+                    b"server",
+                    TLS_CONTENT_APPLICATION_DATA,
+                ),
+            ),
+        ];
+
+        assert_eq!(
+            tls.decrypt(Direction::Client, &client).unwrap(),
+            vec![(2, b"client".to_vec())]
+        );
+        assert_eq!(
+            tls.decrypt(Direction::Server, &server).unwrap(),
+            vec![(4, b"server".to_vec())]
+        );
+    }
+
+    fn endpoint(port: u16) -> Endpoint {
+        Endpoint {
+            address: core::net::IpAddr::V4(core::net::Ipv4Addr::LOCALHOST),
+            port,
+        }
+    }
+
+    fn x224_connection(code: u8) -> Vec<u8> {
+        vec![3, 0, 0, 11, 6, code, 0, 0, 0, 0, 0]
+    }
+
     fn hello(kind: u8, random: [u8; 32], suite: Option<u16>) -> Vec<u8> {
         let mut body = Vec::new();
         body.extend(TLS_VERSION_1_2.to_be_bytes());
@@ -673,6 +809,37 @@ mod tests {
         body.extend(encrypted);
         body.extend(tag);
         tls_record(TLS_CONTENT_APPLICATION_DATA, &body)
+    }
+
+    fn encrypt_tls13_record(
+        cipher: Cipher,
+        key: &TrafficKey,
+        sequence: u64,
+        content: &[u8],
+        inner_type: u8,
+    ) -> Vec<u8> {
+        let mut plaintext = content.to_vec();
+        plaintext.push(inner_type);
+        let mut nonce = key.iv;
+        for (byte, sequence_byte) in nonce[4..].iter_mut().zip(sequence.to_be_bytes()) {
+            *byte ^= sequence_byte;
+        }
+        let ciphertext_len = plaintext.len() + 16;
+        let mut additional_data = vec![TLS_CONTENT_APPLICATION_DATA];
+        additional_data.extend(TLS_VERSION_1_2.to_be_bytes());
+        additional_data.extend(u16::try_from(ciphertext_len).unwrap().to_be_bytes());
+        let tag = match cipher {
+            Cipher::Aes128GcmSha256 => Aes128Gcm::new_from_slice(&key.key)
+                .unwrap()
+                .encrypt_in_place_detached(Nonce::from_slice(&nonce), &additional_data, &mut plaintext)
+                .unwrap(),
+            Cipher::Aes256GcmSha384 => Aes256Gcm::new_from_slice(&key.key)
+                .unwrap()
+                .encrypt_in_place_detached(Nonce::from_slice(&nonce), &additional_data, &mut plaintext)
+                .unwrap(),
+        };
+        plaintext.extend(tag);
+        tls_record(TLS_CONTENT_APPLICATION_DATA, &plaintext)
     }
 
     fn tls_record(content_type: u8, body: &[u8]) -> Vec<u8> {

--- a/crates/ironrdp-capture-replay/src/tls.rs
+++ b/crates/ironrdp-capture-replay/src/tls.rs
@@ -1,0 +1,683 @@
+use aes_gcm::aead::{AeadInPlace as _, KeyInit as _};
+use aes_gcm::{Aes128Gcm, Aes256Gcm, Nonce, Tag};
+use hmac::{Hmac, Mac};
+use sha2::{Sha256, Sha384};
+
+use crate::{Capture, PacketStream, ReplayError};
+
+const TLS_CONTENT_CHANGE_CIPHER_SPEC: u8 = 20;
+const TLS_CONTENT_HANDSHAKE: u8 = 22;
+const TLS_CONTENT_APPLICATION_DATA: u8 = 23;
+const TLS_VERSION_1_2: u16 = 0x0303;
+
+/// Decrypted TLS application-data streams with their packet provenance.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Plaintext {
+    /// Client-to-server application data.
+    pub client: PacketStream,
+    /// Server-to-client application data.
+    pub server: PacketStream,
+}
+
+/// Decrypt TLS application data from a direct TCP capture.
+///
+/// TLS key-log entries are used only in memory and are not retained by the
+/// returned streams.
+pub fn decrypt_tls(capture: &Capture) -> Result<Plaintext, ReplayError> {
+    let client_records = collect_tls_records(&capture.flow.client_stream)?;
+    let server_records = collect_tls_records(&capture.flow.server_stream)?;
+    if client_records.is_empty() && server_records.is_empty() {
+        return Err(ReplayError::StandardSecurity);
+    }
+    let tls = Tls::from_records(&client_records, &server_records, &capture.tls_key_log)?;
+
+    Ok(Plaintext {
+        client: tls.decrypt(Direction::Client, &client_records)?,
+        server: tls.decrypt(Direction::Server, &server_records)?,
+    })
+}
+
+#[derive(Clone, Copy)]
+enum Direction {
+    Client,
+    Server,
+}
+
+#[derive(Clone, Copy)]
+enum Cipher {
+    Aes128GcmSha256,
+    Aes256GcmSha384,
+}
+
+enum Tls {
+    V12(Tls12),
+    V13(Tls13),
+}
+
+impl Tls {
+    fn from_records(client: &PacketStream, server: &PacketStream, key_log: &str) -> Result<Self, ReplayError> {
+        let client_hello = first_handshake(client, 1).ok_or(ReplayError::UnsupportedTls)?;
+        let server_hello = first_handshake(server, 2).ok_or(ReplayError::UnsupportedTls)?;
+        let suite = tls_cipher_suite(&server_hello)?;
+
+        match suite {
+            0x1301 | 0x1302 => Tls13::from_hello(&client_hello, suite, key_log).map(Self::V13),
+            _ => Tls12::from_hello(&client_hello, &server_hello, suite, key_log).map(Self::V12),
+        }
+    }
+
+    fn decrypt(&self, direction: Direction, records: &PacketStream) -> Result<PacketStream, ReplayError> {
+        match self {
+            Self::V12(tls) => tls.decrypt(direction, records),
+            Self::V13(tls) => tls.decrypt(direction, records),
+        }
+    }
+}
+
+struct Tls12 {
+    cipher: Cipher,
+    client_key: Vec<u8>,
+    server_key: Vec<u8>,
+    client_iv: [u8; 4],
+    server_iv: [u8; 4],
+}
+
+impl Tls12 {
+    fn from_hello(client_hello: &[u8], server_hello: &[u8], suite: u16, key_log: &str) -> Result<Self, ReplayError> {
+        if client_hello.len() < 34 || server_hello.len() < 38 {
+            return Err(ReplayError::UnsupportedTls);
+        }
+        let client_random = &client_hello[2..34];
+        let server_random = &server_hello[2..34];
+        let cipher = match suite {
+            0x009c | 0xc02f => Cipher::Aes128GcmSha256,
+            0x009d | 0xc030 => Cipher::Aes256GcmSha384,
+            _ => return Err(ReplayError::UnsupportedTls),
+        };
+        let master = parse_master_secret(key_log, client_random).ok_or(ReplayError::MissingTlsSecret)?;
+        let mut seed = Vec::with_capacity(64);
+        seed.extend_from_slice(server_random);
+        seed.extend_from_slice(client_random);
+        let key_len = match cipher {
+            Cipher::Aes128GcmSha256 => 16,
+            Cipher::Aes256GcmSha384 => 32,
+        };
+        let key_block_len = 2 * key_len + 8;
+        let key_block = match cipher {
+            Cipher::Aes128GcmSha256 => tls_prf_sha256(&master, b"key expansion", &seed, key_block_len)?,
+            Cipher::Aes256GcmSha384 => tls_prf_sha384(&master, b"key expansion", &seed, key_block_len)?,
+        };
+        let (client_key, rest) = key_block.split_at(key_len);
+        let (server_key, rest) = rest.split_at(key_len);
+        let (client_iv, server_iv) = rest.split_at(4);
+
+        Ok(Self {
+            cipher,
+            client_key: client_key.to_vec(),
+            server_key: server_key.to_vec(),
+            client_iv: client_iv.try_into().map_err(|_| ReplayError::UnsupportedTls)?,
+            server_iv: server_iv.try_into().map_err(|_| ReplayError::UnsupportedTls)?,
+        })
+    }
+
+    fn decrypt(&self, direction: Direction, records: &PacketStream) -> Result<PacketStream, ReplayError> {
+        let mut encrypted = false;
+        let mut sequence = 0u64;
+        let mut output = Vec::new();
+        for (packet, record) in records {
+            let (content_type, version, body) = parse_tls_record(record).ok_or(ReplayError::UnsupportedTls)?;
+            if content_type == TLS_CONTENT_CHANGE_CIPHER_SPEC {
+                encrypted = true;
+                sequence = 0;
+                continue;
+            }
+            if !encrypted {
+                continue;
+            }
+            let plaintext = self.decrypt_record(direction, sequence, content_type, version, body)?;
+            sequence = sequence.checked_add(1).ok_or(ReplayError::UnsupportedTls)?;
+            if content_type == TLS_CONTENT_APPLICATION_DATA {
+                output.push((*packet, plaintext));
+            }
+        }
+        Ok(output)
+    }
+
+    fn decrypt_record(
+        &self,
+        direction: Direction,
+        sequence: u64,
+        content_type: u8,
+        version: u16,
+        body: &[u8],
+    ) -> Result<Vec<u8>, ReplayError> {
+        if version != TLS_VERSION_1_2 || body.len() < 8 + 16 {
+            return Err(ReplayError::UnsupportedTls);
+        }
+        let (explicit, ciphertext_and_tag) = body.split_at(8);
+        let (ciphertext, tag_bytes) = ciphertext_and_tag.split_at(ciphertext_and_tag.len() - 16);
+        let plaintext_len = u16::try_from(ciphertext.len()).map_err(|_| ReplayError::UnsupportedTls)?;
+        let mut additional_data = Vec::with_capacity(13);
+        additional_data.extend_from_slice(&sequence.to_be_bytes());
+        additional_data.push(content_type);
+        additional_data.extend_from_slice(&version.to_be_bytes());
+        additional_data.extend_from_slice(&plaintext_len.to_be_bytes());
+        let (key, fixed_iv) = match direction {
+            Direction::Client => (&self.client_key, self.client_iv),
+            Direction::Server => (&self.server_key, self.server_iv),
+        };
+        let mut nonce = [0u8; 12];
+        nonce[..4].copy_from_slice(&fixed_iv);
+        nonce[4..].copy_from_slice(explicit);
+        let tag = Tag::from_slice(tag_bytes);
+        let mut plaintext = ciphertext.to_vec();
+        let result = match self.cipher {
+            Cipher::Aes128GcmSha256 => Aes128Gcm::new_from_slice(key)
+                .map_err(|_| ReplayError::UnsupportedTls)?
+                .decrypt_in_place_detached(Nonce::from_slice(&nonce), &additional_data, &mut plaintext, tag),
+            Cipher::Aes256GcmSha384 => Aes256Gcm::new_from_slice(key)
+                .map_err(|_| ReplayError::UnsupportedTls)?
+                .decrypt_in_place_detached(Nonce::from_slice(&nonce), &additional_data, &mut plaintext, tag),
+        };
+        result.map_err(|_| ReplayError::TlsAuthentication)?;
+        Ok(plaintext)
+    }
+}
+
+struct Tls13 {
+    cipher: Cipher,
+    client_handshake: TrafficKey,
+    server_handshake: TrafficKey,
+    client_application: TrafficKey,
+    server_application: TrafficKey,
+}
+
+struct TrafficKey {
+    key: Vec<u8>,
+    iv: [u8; 12],
+}
+
+impl Tls13 {
+    fn from_hello(client_hello: &[u8], suite: u16, key_log: &str) -> Result<Self, ReplayError> {
+        let client_random = client_hello.get(2..34).ok_or(ReplayError::UnsupportedTls)?;
+        let cipher = match suite {
+            0x1301 => Cipher::Aes128GcmSha256,
+            0x1302 => Cipher::Aes256GcmSha384,
+            _ => return Err(ReplayError::UnsupportedTls),
+        };
+        let key_len = match cipher {
+            Cipher::Aes128GcmSha256 => 16,
+            Cipher::Aes256GcmSha384 => 32,
+        };
+        let client_handshake = tls13_traffic_key(
+            cipher,
+            parse_tls13_secret(key_log, "CLIENT_HANDSHAKE_TRAFFIC_SECRET", client_random)?,
+            key_len,
+        )?;
+        let server_handshake = tls13_traffic_key(
+            cipher,
+            parse_tls13_secret(key_log, "SERVER_HANDSHAKE_TRAFFIC_SECRET", client_random)?,
+            key_len,
+        )?;
+        let client_application = tls13_traffic_key(
+            cipher,
+            parse_tls13_secret(key_log, "CLIENT_TRAFFIC_SECRET_0", client_random)?,
+            key_len,
+        )?;
+        let server_application = tls13_traffic_key(
+            cipher,
+            parse_tls13_secret(key_log, "SERVER_TRAFFIC_SECRET_0", client_random)?,
+            key_len,
+        )?;
+
+        Ok(Self {
+            cipher,
+            client_handshake,
+            server_handshake,
+            client_application,
+            server_application,
+        })
+    }
+
+    fn decrypt(&self, direction: Direction, records: &PacketStream) -> Result<PacketStream, ReplayError> {
+        let (handshake, application) = match direction {
+            Direction::Client => (&self.client_handshake, &self.client_application),
+            Direction::Server => (&self.server_handshake, &self.server_application),
+        };
+        let mut key = handshake;
+        let mut sequence = 0u64;
+        let mut output = Vec::new();
+        let mut handshake_data = Vec::new();
+        let mut handshake_phase = true;
+        for (packet, record) in records {
+            let (content_type, version, body) = parse_tls_record(record).ok_or(ReplayError::UnsupportedTls)?;
+            if content_type != TLS_CONTENT_APPLICATION_DATA {
+                continue;
+            }
+            let plaintext = decrypt_tls13_record(self.cipher, key, sequence, content_type, version, body)?;
+            sequence = sequence.checked_add(1).ok_or(ReplayError::UnsupportedTls)?;
+            let (content, inner_type) = tls13_inner_plaintext(&plaintext).ok_or(ReplayError::UnsupportedTls)?;
+            if inner_type == TLS_CONTENT_HANDSHAKE && handshake_phase {
+                handshake_data.extend_from_slice(content);
+                if tls13_handshake_contains_finished(&handshake_data) {
+                    key = application;
+                    sequence = 0;
+                    handshake_phase = false;
+                }
+            }
+            if inner_type == TLS_CONTENT_APPLICATION_DATA {
+                output.push((*packet, content.to_vec()));
+            }
+        }
+        Ok(output)
+    }
+}
+
+fn collect_tls_records(stream: &PacketStream) -> Result<PacketStream, ReplayError> {
+    let mut bytes = Vec::new();
+    for (packet, chunk) in stream {
+        bytes.extend(chunk.iter().copied().map(|byte| (*packet, byte)));
+    }
+    let start = bytes
+        .windows(3)
+        .position(|window| window[0].1 == TLS_CONTENT_HANDSHAKE && window[1].1 == 3 && window[2].1 >= 1)
+        .ok_or(ReplayError::UnsupportedTransport)?;
+    let mut offset = start;
+    let mut records = Vec::new();
+    while offset + 5 <= bytes.len() {
+        let length = usize::from(u16::from_be_bytes([bytes[offset + 3].1, bytes[offset + 4].1]));
+        let end = offset.checked_add(5 + length).ok_or(ReplayError::UnsupportedTls)?;
+        if end > bytes.len() {
+            return Err(ReplayError::UnsupportedTls);
+        }
+        records.push((
+            bytes[offset].0,
+            bytes[offset..end].iter().map(|(_, byte)| *byte).collect(),
+        ));
+        offset = end;
+    }
+    Ok(records)
+}
+
+fn parse_tls_record(record: &[u8]) -> Option<(u8, u16, &[u8])> {
+    let header = record.get(..5)?;
+    let length = usize::from(u16::from_be_bytes([header[3], header[4]]));
+    let body = record.get(5..)?;
+    (body.len() == length).then_some((header[0], u16::from_be_bytes([header[1], header[2]]), body))
+}
+
+fn first_handshake(records: &PacketStream, wanted_type: u8) -> Option<Vec<u8>> {
+    let mut data = Vec::new();
+    for (_, record) in records {
+        let (content_type, _, body) = parse_tls_record(record)?;
+        if content_type == TLS_CONTENT_HANDSHAKE {
+            data.extend_from_slice(body);
+        }
+    }
+    let mut offset = 0;
+    while offset + 4 <= data.len() {
+        let length = (usize::from(data[offset + 1]) << 16)
+            | (usize::from(data[offset + 2]) << 8)
+            | usize::from(data[offset + 3]);
+        let end = offset.checked_add(4 + length)?;
+        let body = data.get(offset + 4..end)?;
+        if data[offset] == wanted_type {
+            return Some(body.to_vec());
+        }
+        offset = end;
+    }
+    None
+}
+
+fn tls_cipher_suite(server_hello: &[u8]) -> Result<u16, ReplayError> {
+    let session_len = usize::from(*server_hello.get(34).ok_or(ReplayError::UnsupportedTls)?);
+    let suite_offset = 35usize.checked_add(session_len).ok_or(ReplayError::UnsupportedTls)?;
+    server_hello
+        .get(suite_offset..suite_offset + 2)
+        .ok_or(ReplayError::UnsupportedTls)?
+        .try_into()
+        .map(u16::from_be_bytes)
+        .map_err(|_| ReplayError::UnsupportedTls)
+}
+
+fn parse_master_secret(key_log: &str, client_random: &[u8]) -> Option<Vec<u8>> {
+    let client_random = hex(client_random);
+    key_log.lines().find_map(|line| {
+        let mut fields = line.split_ascii_whitespace();
+        (fields.next()? == "CLIENT_RANDOM" && fields.next()? == client_random)
+            .then(|| decode_hex(fields.next()?))
+            .flatten()
+            .filter(|secret| secret.len() == 48)
+    })
+}
+
+fn parse_tls13_secret(key_log: &str, label: &str, client_random: &[u8]) -> Result<Vec<u8>, ReplayError> {
+    let client_random = hex(client_random);
+    key_log
+        .lines()
+        .find_map(|line| {
+            let mut fields = line.split_ascii_whitespace();
+            (fields.next()? == label && fields.next()? == client_random).then(|| decode_hex(fields.next()?))
+        })
+        .flatten()
+        .ok_or(ReplayError::MissingTlsSecret)
+}
+
+fn hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(char::from(HEX[usize::from(byte >> 4)]));
+        output.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    output
+}
+
+fn decode_hex(input: &str) -> Option<Vec<u8>> {
+    input.len().is_multiple_of(2).then_some(())?;
+    input
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|pair| {
+            let high = char::from(pair[0]).to_digit(16)?;
+            let low = char::from(pair[1]).to_digit(16)?;
+            u8::try_from((high << 4) | low).ok()
+        })
+        .collect()
+}
+
+fn tls_prf_sha256(secret: &[u8], label: &[u8], seed: &[u8], length: usize) -> Result<Vec<u8>, ReplayError> {
+    let mut label_seed = Vec::with_capacity(label.len() + seed.len());
+    label_seed.extend_from_slice(label);
+    label_seed.extend_from_slice(seed);
+    let mut a = <Hmac<Sha256> as Mac>::new_from_slice(secret)
+        .map_err(|_| ReplayError::UnsupportedTls)?
+        .chain_update(&label_seed)
+        .finalize()
+        .into_bytes()
+        .to_vec();
+    let mut output = Vec::with_capacity(length);
+    while output.len() < length {
+        let mut hmac = <Hmac<Sha256> as Mac>::new_from_slice(secret).map_err(|_| ReplayError::UnsupportedTls)?;
+        hmac.update(&a);
+        hmac.update(&label_seed);
+        output.extend_from_slice(&hmac.finalize().into_bytes());
+        a = <Hmac<Sha256> as Mac>::new_from_slice(secret)
+            .map_err(|_| ReplayError::UnsupportedTls)?
+            .chain_update(&a)
+            .finalize()
+            .into_bytes()
+            .to_vec();
+    }
+    output.truncate(length);
+    Ok(output)
+}
+
+fn tls_prf_sha384(secret: &[u8], label: &[u8], seed: &[u8], length: usize) -> Result<Vec<u8>, ReplayError> {
+    let mut label_seed = Vec::with_capacity(label.len() + seed.len());
+    label_seed.extend_from_slice(label);
+    label_seed.extend_from_slice(seed);
+    let mut a = <Hmac<Sha384> as Mac>::new_from_slice(secret)
+        .map_err(|_| ReplayError::UnsupportedTls)?
+        .chain_update(&label_seed)
+        .finalize()
+        .into_bytes()
+        .to_vec();
+    let mut output = Vec::with_capacity(length);
+    while output.len() < length {
+        let mut hmac = <Hmac<Sha384> as Mac>::new_from_slice(secret).map_err(|_| ReplayError::UnsupportedTls)?;
+        hmac.update(&a);
+        hmac.update(&label_seed);
+        output.extend_from_slice(&hmac.finalize().into_bytes());
+        a = <Hmac<Sha384> as Mac>::new_from_slice(secret)
+            .map_err(|_| ReplayError::UnsupportedTls)?
+            .chain_update(&a)
+            .finalize()
+            .into_bytes()
+            .to_vec();
+    }
+    output.truncate(length);
+    Ok(output)
+}
+
+fn tls13_traffic_key(cipher: Cipher, secret: Vec<u8>, key_len: usize) -> Result<TrafficKey, ReplayError> {
+    let key = tls13_expand_label(cipher, &secret, b"key", key_len)?;
+    let iv = tls13_expand_label(cipher, &secret, b"iv", 12)?
+        .try_into()
+        .map_err(|_| ReplayError::UnsupportedTls)?;
+    Ok(TrafficKey { key, iv })
+}
+
+fn tls13_expand_label(cipher: Cipher, secret: &[u8], label: &[u8], length: usize) -> Result<Vec<u8>, ReplayError> {
+    let mut info = Vec::with_capacity(2 + 1 + 6 + label.len() + 1);
+    info.extend_from_slice(
+        &u16::try_from(length)
+            .map_err(|_| ReplayError::UnsupportedTls)?
+            .to_be_bytes(),
+    );
+    let label_len = 6usize.checked_add(label.len()).ok_or(ReplayError::UnsupportedTls)?;
+    info.push(u8::try_from(label_len).map_err(|_| ReplayError::UnsupportedTls)?);
+    info.extend_from_slice(b"tls13 ");
+    info.extend_from_slice(label);
+    info.push(0);
+    match cipher {
+        Cipher::Aes128GcmSha256 => hkdf_expand_sha256(secret, &info, length),
+        Cipher::Aes256GcmSha384 => hkdf_expand_sha384(secret, &info, length),
+    }
+}
+
+fn hkdf_expand_sha256(secret: &[u8], info: &[u8], length: usize) -> Result<Vec<u8>, ReplayError> {
+    let mut previous = Vec::new();
+    let mut output = Vec::with_capacity(length);
+    for counter in 1..=u8::MAX {
+        let mut hmac = <Hmac<Sha256> as Mac>::new_from_slice(secret).map_err(|_| ReplayError::UnsupportedTls)?;
+        hmac.update(&previous);
+        hmac.update(info);
+        hmac.update(&[counter]);
+        previous = hmac.finalize().into_bytes().to_vec();
+        let remaining = length.saturating_sub(output.len());
+        output.extend_from_slice(&previous[..remaining.min(previous.len())]);
+        if output.len() == length {
+            return Ok(output);
+        }
+    }
+    Err(ReplayError::UnsupportedTls)
+}
+
+fn hkdf_expand_sha384(secret: &[u8], info: &[u8], length: usize) -> Result<Vec<u8>, ReplayError> {
+    let mut previous = Vec::new();
+    let mut output = Vec::with_capacity(length);
+    for counter in 1..=u8::MAX {
+        let mut hmac = <Hmac<Sha384> as Mac>::new_from_slice(secret).map_err(|_| ReplayError::UnsupportedTls)?;
+        hmac.update(&previous);
+        hmac.update(info);
+        hmac.update(&[counter]);
+        previous = hmac.finalize().into_bytes().to_vec();
+        let remaining = length.saturating_sub(output.len());
+        output.extend_from_slice(&previous[..remaining.min(previous.len())]);
+        if output.len() == length {
+            return Ok(output);
+        }
+    }
+    Err(ReplayError::UnsupportedTls)
+}
+
+fn decrypt_tls13_record(
+    cipher: Cipher,
+    key: &TrafficKey,
+    sequence: u64,
+    content_type: u8,
+    version: u16,
+    body: &[u8],
+) -> Result<Vec<u8>, ReplayError> {
+    if version != TLS_VERSION_1_2 || body.len() < 16 {
+        return Err(ReplayError::UnsupportedTls);
+    }
+    let (ciphertext, tag_bytes) = body.split_at(body.len() - 16);
+    let mut nonce = key.iv;
+    for (byte, sequence_byte) in nonce[4..].iter_mut().zip(sequence.to_be_bytes()) {
+        *byte ^= sequence_byte;
+    }
+    let mut additional_data = Vec::with_capacity(5);
+    additional_data.push(content_type);
+    additional_data.extend_from_slice(&version.to_be_bytes());
+    additional_data.extend_from_slice(
+        &u16::try_from(body.len())
+            .map_err(|_| ReplayError::UnsupportedTls)?
+            .to_be_bytes(),
+    );
+    let tag = Tag::from_slice(tag_bytes);
+    let mut plaintext = ciphertext.to_vec();
+    let result = match cipher {
+        Cipher::Aes128GcmSha256 => Aes128Gcm::new_from_slice(&key.key)
+            .map_err(|_| ReplayError::UnsupportedTls)?
+            .decrypt_in_place_detached(Nonce::from_slice(&nonce), &additional_data, &mut plaintext, tag),
+        Cipher::Aes256GcmSha384 => Aes256Gcm::new_from_slice(&key.key)
+            .map_err(|_| ReplayError::UnsupportedTls)?
+            .decrypt_in_place_detached(Nonce::from_slice(&nonce), &additional_data, &mut plaintext, tag),
+    };
+    result.map_err(|_| ReplayError::TlsAuthentication)?;
+    Ok(plaintext)
+}
+
+fn tls13_inner_plaintext(plaintext: &[u8]) -> Option<(&[u8], u8)> {
+    let content_end = plaintext.iter().rposition(|byte| *byte != 0)?;
+    Some((&plaintext[..content_end], plaintext[content_end]))
+}
+
+fn tls13_handshake_contains_finished(data: &[u8]) -> bool {
+    let mut offset = 0;
+    while let Some(header) = data.get(offset..offset + 4) {
+        let length = (usize::from(header[1]) << 16) | (usize::from(header[2]) << 8) | usize::from(header[3]);
+        let Some(end) = offset.checked_add(4 + length) else {
+            return false;
+        };
+        if end > data.len() {
+            return false;
+        }
+        if header[0] == 20 {
+            return true;
+        }
+        offset = end;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Endpoint, Flow};
+
+    #[test]
+    fn decrypts_tls12_application_data() {
+        let client_random = [1; 32];
+        let master = [2; 48];
+        let key_log = format!("CLIENT_RANDOM {} {}", hex(&client_random), hex(&master));
+        let client_hello = hello(1, client_random, None);
+        let server_hello = hello(2, [3; 32], Some(0x009c));
+        let tls = Tls12::from_hello(&client_hello, &server_hello, 0x009c, &key_log).unwrap();
+        let client_records = vec![
+            (1, handshake_record(1, &client_hello)),
+            (2, change_cipher_spec()),
+            (3, encrypt_tls12_record(&tls, Direction::Client, 0, b"client")),
+        ];
+        let server_records = vec![
+            (4, handshake_record(2, &server_hello)),
+            (5, change_cipher_spec()),
+            (6, encrypt_tls12_record(&tls, Direction::Server, 0, b"server")),
+        ];
+        let capture = Capture {
+            flow: Flow {
+                client: Endpoint {
+                    address: core::net::IpAddr::V4(core::net::Ipv4Addr::LOCALHOST),
+                    port: 1,
+                },
+                server: Endpoint {
+                    address: core::net::IpAddr::V4(core::net::Ipv4Addr::LOCALHOST),
+                    port: 2,
+                },
+                client_stream: vec![(1, client_records.into_iter().flat_map(|(_, record)| record).collect())],
+                server_stream: vec![(4, server_records.into_iter().flat_map(|(_, record)| record).collect())],
+            },
+            tls_key_log: key_log,
+        };
+
+        let plaintext = decrypt_tls(&capture).unwrap();
+
+        assert_eq!(plaintext.client, vec![(1, b"client".to_vec())]);
+        assert_eq!(plaintext.server, vec![(4, b"server".to_vec())]);
+    }
+
+    #[test]
+    fn rejects_tls_without_matching_key_log_entry() {
+        let client_hello = hello(1, [1; 32], None);
+        let server_hello = hello(2, [3; 32], Some(0x009c));
+
+        let result = Tls::from_records(
+            &vec![(1, handshake_record(1, &client_hello))],
+            &vec![(2, handshake_record(2, &server_hello))],
+            "",
+        );
+
+        assert!(matches!(result, Err(ReplayError::MissingTlsSecret)));
+    }
+
+    fn hello(kind: u8, random: [u8; 32], suite: Option<u16>) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend(TLS_VERSION_1_2.to_be_bytes());
+        body.extend(random);
+        if kind == 2 {
+            body.push(0);
+            body.extend(suite.unwrap().to_be_bytes());
+            body.push(0);
+        }
+        body
+    }
+
+    fn handshake_record(kind: u8, body: &[u8]) -> Vec<u8> {
+        let length = u32::try_from(body.len()).unwrap();
+        let mut handshake = vec![kind, 0, 0, 0];
+        handshake[1..4].copy_from_slice(&length.to_be_bytes()[1..]);
+        handshake.extend(body);
+        tls_record(TLS_CONTENT_HANDSHAKE, &handshake)
+    }
+
+    fn change_cipher_spec() -> Vec<u8> {
+        tls_record(TLS_CONTENT_CHANGE_CIPHER_SPEC, &[1])
+    }
+
+    fn encrypt_tls12_record(tls: &Tls12, direction: Direction, sequence: u64, plaintext: &[u8]) -> Vec<u8> {
+        let (key, fixed_iv) = match direction {
+            Direction::Client => (&tls.client_key, tls.client_iv),
+            Direction::Server => (&tls.server_key, tls.server_iv),
+        };
+        let explicit = [7; 8];
+        let mut nonce = [0; 12];
+        nonce[..4].copy_from_slice(&fixed_iv);
+        nonce[4..].copy_from_slice(&explicit);
+        let length = u16::try_from(plaintext.len()).unwrap();
+        let mut additional_data = Vec::new();
+        additional_data.extend(sequence.to_be_bytes());
+        additional_data.push(TLS_CONTENT_APPLICATION_DATA);
+        additional_data.extend(TLS_VERSION_1_2.to_be_bytes());
+        additional_data.extend(length.to_be_bytes());
+        let mut encrypted = plaintext.to_vec();
+        let tag = Aes128Gcm::new_from_slice(key)
+            .unwrap()
+            .encrypt_in_place_detached(Nonce::from_slice(&nonce), &additional_data, &mut encrypted)
+            .unwrap();
+        let mut body = explicit.to_vec();
+        body.extend(encrypted);
+        body.extend(tag);
+        tls_record(TLS_CONTENT_APPLICATION_DATA, &body)
+    }
+
+    fn tls_record(content_type: u8, body: &[u8]) -> Vec<u8> {
+        let length = u16::try_from(body.len()).unwrap();
+        let mut record = vec![content_type];
+        record.extend(TLS_VERSION_1_2.to_be_bytes());
+        record.extend(length.to_be_bytes());
+        record.extend(body);
+        record
+    }
+}


### PR DESCRIPTION
Derive TLS 1.2 and TLS 1.3 traffic keys from embedded key logs.

Decrypt application streams in memory without persisting secrets or payloads.