### PR TITLE
feat(replay): recover recorded RDP negotiation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2613,6 +2613,8 @@ version = "0.0.0"
 dependencies = [
  "aes-gcm 0.10.3",
  "hmac 0.12.1",
+ "ironrdp-core 0.2.1",
+ "ironrdp-pdu",
  "pcap-parser",
  "sha2 0.10.9",
  "thiserror 2.0.19",

--- a/crates/ironrdp-capture-replay/Cargo.toml
+++ b/crates/ironrdp-capture-replay/Cargo.toml
@@ -15,6 +15,8 @@ categories.workspace = true
 [dependencies]
 aes-gcm = "0.10"
 hmac = "0.12"
+ironrdp-core = { version = "0.2.1", path = "../ironrdp-core" }
+ironrdp-pdu = { version = "0.9.0", path = "../ironrdp-pdu" } # public
 pcap-parser = "0.17"
 sha2 = "0.10"
 thiserror = "2"

--- a/crates/ironrdp-capture-replay/src/error.rs
+++ b/crates/ironrdp-capture-replay/src/error.rs
@@ -32,4 +32,19 @@ pub enum ReplayError {
     /// The capture requires unsupported TLS 1.3 key rotation.
     #[error("capture uses unsupported TLS 1.3 key rotation")]
     TlsKeyUpdate,
+    /// The capture does not contain a complete RDP connection sequence.
+    #[error("capture does not contain enough negotiated RDP state")]
+    MissingRdpState,
+    /// The recorded desktop dimensions are unsuitable for recovery.
+    #[error("capture desktop dimensions are unsupported")]
+    UnsupportedDesktopSize,
+    /// The server did not assign all requested static channels.
+    #[error("capture does not contain server-assigned static channel IDs")]
+    MissingChannelMap,
+    /// The MCS user channel could not be recovered.
+    #[error("capture does not contain the client MCS user channel")]
+    MissingUserChannel,
+    /// The active RDP share identifier could not be recovered.
+    #[error("capture does not contain an activated RDP share ID")]
+    MissingShareId,
 }

--- a/crates/ironrdp-capture-replay/src/error.rs
+++ b/crates/ironrdp-capture-replay/src/error.rs
@@ -35,9 +35,6 @@ pub enum ReplayError {
     /// The capture does not contain a complete RDP connection sequence.
     #[error("capture does not contain enough negotiated RDP state")]
     MissingRdpState,
-    /// The recorded desktop dimensions are unsuitable for recovery.
-    #[error("capture desktop dimensions are unsupported")]
-    UnsupportedDesktopSize,
     /// The server did not assign all requested static channels.
     #[error("capture does not contain server-assigned static channel IDs")]
     MissingChannelMap,

--- a/crates/ironrdp-capture-replay/src/lib.rs
+++ b/crates/ironrdp-capture-replay/src/lib.rs
@@ -1,9 +1,11 @@
 //! Offline analysis support for direct TCP RDP captures.
 
 mod error;
+mod negotiation;
 mod tls;
 mod transport;
 
 pub use error::ReplayError;
+pub use negotiation::{NegotiatedState, StaticChannel, recover_negotiated_state};
 pub use tls::{Plaintext, decrypt_tls};
 pub use transport::{Capture, Endpoint, Flow, PacketStream, TlsKeyLog, read_capture};

--- a/crates/ironrdp-capture-replay/src/negotiation.rs
+++ b/crates/ironrdp-capture-replay/src/negotiation.rs
@@ -137,8 +137,10 @@ fn tpkt_frames(bytes: &[u8]) -> impl Iterator<Item = &[u8]> {
                 let end = offset.checked_add(length)?;
                 if length >= 7 && end <= bytes.len() {
                     let frame = &bytes[offset..end];
-                    offset = end;
-                    return Some(frame);
+                    if frame[4..7] == [2, 0xf0, 0x80] {
+                        offset = end;
+                        return Some(frame);
+                    }
                 }
             }
             offset += 1;

--- a/crates/ironrdp-capture-replay/src/negotiation.rs
+++ b/crates/ironrdp-capture-replay/src/negotiation.rs
@@ -1,12 +1,12 @@
 use ironrdp_core::decode;
 use ironrdp_pdu::gcc::ChannelName;
 use ironrdp_pdu::mcs::{self, McsMessage};
+use ironrdp_pdu::rdp::capability_sets::CapabilitySet;
+use ironrdp_pdu::rdp::headers::{self, ShareControlPdu};
 use ironrdp_pdu::x224::{X224, X224Data};
 
-use crate::{PacketStream, Plaintext, ReplayError};
-
-const MAX_DESKTOP_DIMENSION: u16 = 16_384;
-const MAX_FRAMEBUFFER_BYTES: usize = 256 * 1024 * 1024;
+use crate::transport::flatten;
+use crate::{Plaintext, ReplayError};
 
 /// A captured RDP static virtual channel.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -44,34 +44,18 @@ pub fn recover_negotiated_state(plaintext: &Plaintext) -> Result<NegotiatedState
     let server_connect = connect_response(&server_bytes).ok_or(ReplayError::MissingRdpState)?;
     let client_gcc = client_connect.conference_create_request.gcc_blocks();
     let server_gcc = server_connect.conference_create_response.gcc_blocks();
-    let width = client_gcc.core.desktop_width;
-    let height = client_gcc.core.desktop_height;
-    if width > MAX_DESKTOP_DIMENSION
-        || height > MAX_DESKTOP_DIMENSION
-        || usize::from(width)
-            .checked_mul(usize::from(height))
-            .and_then(|pixels| pixels.checked_mul(4))
-            .is_none_or(|size| size > MAX_FRAMEBUFFER_BYTES)
-    {
-        return Err(ReplayError::UnsupportedDesktopSize);
-    }
     let io_channel_id = server_gcc.network.io_channel;
     let channel_ids = &server_gcc.network.channel_ids;
-    if channel_ids.is_empty() && client_gcc.network.is_some() {
-        return Err(ReplayError::MissingChannelMap);
-    }
     let names = client_gcc.network.as_ref().map_or_else(Vec::new, |network| {
         network.channels.iter().map(|channel| channel.name.clone()).collect()
     });
-    let static_channels = names
-        .into_iter()
-        .zip(channel_ids.iter().copied())
-        .map(|(name, id)| StaticChannel { name, id })
-        .collect();
+    let static_channels = static_channels(names, channel_ids)?;
     let user_channel_id = first_user_channel(&client_bytes)
         .or_else(|| first_user_channel(&server_bytes))
         .ok_or(ReplayError::MissingUserChannel)?;
-    let share_id = first_share_id(&server_bytes).ok_or(ReplayError::MissingShareId)?;
+    let (share_id, desktop_size) =
+        first_demand_active(&server_bytes, io_channel_id).ok_or(ReplayError::MissingShareId)?;
+    let (width, height) = desktop_size.unwrap_or((client_gcc.core.desktop_width, client_gcc.core.desktop_height));
 
     Ok(NegotiatedState {
         user_channel_id,
@@ -87,8 +71,16 @@ pub fn recover_negotiated_state(plaintext: &Plaintext) -> Result<NegotiatedState
     })
 }
 
-fn flatten(records: &PacketStream) -> Vec<u8> {
-    records.iter().flat_map(|(_, bytes)| bytes).copied().collect()
+fn static_channels(names: Vec<ChannelName>, channel_ids: &[u16]) -> Result<Vec<StaticChannel>, ReplayError> {
+    if names.len() != channel_ids.len() {
+        return Err(ReplayError::MissingChannelMap);
+    }
+
+    Ok(names
+        .into_iter()
+        .zip(channel_ids.iter().copied())
+        .map(|(name, id)| StaticChannel { name, id })
+        .collect())
 }
 
 fn connect_initial(bytes: &[u8]) -> Option<mcs::ConnectInitial> {
@@ -114,14 +106,25 @@ fn first_user_channel(bytes: &[u8]) -> Option<u16> {
     })
 }
 
-fn first_share_id(bytes: &[u8]) -> Option<u32> {
+fn first_demand_active(bytes: &[u8], io_channel_id: u16) -> Option<(u32, Option<(u16, u16)>)> {
     tpkt_frames(bytes).find_map(|frame| {
-        let context = mcs::decode_send_data_indication(frame).ok()?;
-        let data = context.user_data;
-        if data.len() < 10 || u16::from_le_bytes(data.get(2..4)?.try_into().ok()?) & 0x0f != 1 {
+        let share_control = headers::decode_share_control(mcs::decode_send_data_indication(frame).ok()?).ok()?;
+        if share_control.channel_id != io_channel_id {
             return None;
         }
-        Some(u32::from_le_bytes(data.get(6..10)?.try_into().ok()?))
+        let ShareControlPdu::ServerDemandActive(demand_active) = share_control.pdu else {
+            return None;
+        };
+        let desktop_size = demand_active
+            .pdu
+            .capability_sets
+            .iter()
+            .find_map(|capability_set| match capability_set {
+                CapabilitySet::Bitmap(bitmap) => Some((bitmap.desktop_width, bitmap.desktop_height)),
+                _ => None,
+            });
+
+        Some((share_control.share_id, desktop_size))
     })
 }
 
@@ -170,5 +173,13 @@ mod tests {
         .unwrap_err();
 
         assert!(matches!(error, ReplayError::MissingRdpState));
+    }
+
+    #[test]
+    fn rejects_mismatched_static_channel_maps() {
+        assert!(matches!(
+            static_channels(Vec::new(), &[1]),
+            Err(ReplayError::MissingChannelMap)
+        ));
     }
 }

--- a/crates/ironrdp-capture-replay/src/negotiation.rs
+++ b/crates/ironrdp-capture-replay/src/negotiation.rs
@@ -149,7 +149,10 @@ fn tpkt_frames(bytes: &[u8]) -> impl Iterator<Item = &[u8]> {
 
 #[cfg(test)]
 mod tests {
+    use std::borrow::Cow;
+
     use ironrdp_core::encode_vec;
+    use ironrdp_pdu::rdp::capability_sets::{Bitmap, BitmapDrawingFlags, DemandActive, ServerDemandActive};
 
     use super::*;
 
@@ -181,5 +184,38 @@ mod tests {
             static_channels(Vec::new(), &[1]),
             Err(ReplayError::MissingChannelMap)
         ));
+    }
+
+    #[test]
+    fn recovers_demand_active_on_the_io_channel() {
+        let share_control = headers::ShareControlHeader {
+            pdu_source: 1_001,
+            share_id: 0x1122_3344,
+            share_control_pdu: ShareControlPdu::ServerDemandActive(ServerDemandActive {
+                pdu: DemandActive {
+                    source_descriptor: "test".to_owned(),
+                    capability_sets: vec![CapabilitySet::Bitmap(Bitmap {
+                        pref_bits_per_pix: 32,
+                        desktop_width: 1_920,
+                        desktop_height: 1_080,
+                        desktop_resize_flag: true,
+                        drawing_flags: BitmapDrawingFlags::empty(),
+                    })],
+                },
+            }),
+        };
+        let user_data = encode_vec(&share_control).unwrap();
+        let frame = encode_vec(&X224(McsMessage::SendDataIndication(mcs::SendDataIndication {
+            initiator_id: 1_001,
+            channel_id: 1_003,
+            user_data: Cow::Owned(user_data),
+        })))
+        .unwrap();
+
+        assert_eq!(
+            first_demand_active(&frame, 1_003),
+            Some((0x1122_3344, Some((1_920, 1_080))))
+        );
+        assert_eq!(first_demand_active(&frame, 1_004), None);
     }
 }

--- a/crates/ironrdp-capture-replay/src/negotiation.rs
+++ b/crates/ironrdp-capture-replay/src/negotiation.rs
@@ -1,0 +1,174 @@
+use ironrdp_core::decode;
+use ironrdp_pdu::gcc::ChannelName;
+use ironrdp_pdu::mcs::{self, McsMessage};
+use ironrdp_pdu::x224::{X224, X224Data};
+
+use crate::{PacketStream, Plaintext, ReplayError};
+
+const MAX_DESKTOP_DIMENSION: u16 = 16_384;
+const MAX_FRAMEBUFFER_BYTES: usize = 256 * 1024 * 1024;
+
+/// A captured RDP static virtual channel.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StaticChannel {
+    /// Channel name supplied by the client.
+    pub name: ChannelName,
+    /// Channel ID assigned by the server.
+    pub id: u16,
+}
+
+/// RDP state reconstructed from the recorded connection sequence.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NegotiatedState {
+    /// Client MCS user channel.
+    pub user_channel_id: u16,
+    /// Server I/O channel.
+    pub io_channel_id: u16,
+    /// Optional MCS message channel.
+    pub message_channel_id: Option<u16>,
+    /// RDP share ID.
+    pub share_id: u32,
+    /// Recorded desktop width.
+    pub width: u16,
+    /// Recorded desktop height.
+    pub height: u16,
+    /// Static channels paired with their captured IDs.
+    pub static_channels: Vec<StaticChannel>,
+}
+
+/// Recover the RDP connection state required to interpret recorded streams.
+pub fn recover_negotiated_state(plaintext: &Plaintext) -> Result<NegotiatedState, ReplayError> {
+    let client_bytes = flatten(&plaintext.client);
+    let server_bytes = flatten(&plaintext.server);
+    let client_connect = connect_initial(&client_bytes).ok_or(ReplayError::MissingRdpState)?;
+    let server_connect = connect_response(&server_bytes).ok_or(ReplayError::MissingRdpState)?;
+    let client_gcc = client_connect.conference_create_request.gcc_blocks();
+    let server_gcc = server_connect.conference_create_response.gcc_blocks();
+    let width = client_gcc.core.desktop_width;
+    let height = client_gcc.core.desktop_height;
+    if width > MAX_DESKTOP_DIMENSION
+        || height > MAX_DESKTOP_DIMENSION
+        || usize::from(width)
+            .checked_mul(usize::from(height))
+            .and_then(|pixels| pixels.checked_mul(4))
+            .is_none_or(|size| size > MAX_FRAMEBUFFER_BYTES)
+    {
+        return Err(ReplayError::UnsupportedDesktopSize);
+    }
+    let io_channel_id = server_gcc.network.io_channel;
+    let channel_ids = &server_gcc.network.channel_ids;
+    if channel_ids.is_empty() && client_gcc.network.is_some() {
+        return Err(ReplayError::MissingChannelMap);
+    }
+    let names = client_gcc.network.as_ref().map_or_else(Vec::new, |network| {
+        network.channels.iter().map(|channel| channel.name.clone()).collect()
+    });
+    let static_channels = names
+        .into_iter()
+        .zip(channel_ids.iter().copied())
+        .map(|(name, id)| StaticChannel { name, id })
+        .collect();
+    let user_channel_id = first_user_channel(&client_bytes)
+        .or_else(|| first_user_channel(&server_bytes))
+        .ok_or(ReplayError::MissingUserChannel)?;
+    let share_id = first_share_id(&server_bytes).ok_or(ReplayError::MissingShareId)?;
+
+    Ok(NegotiatedState {
+        user_channel_id,
+        io_channel_id,
+        message_channel_id: server_gcc
+            .message_channel
+            .as_ref()
+            .map(|channel| channel.mcs_message_channel_id),
+        share_id,
+        width,
+        height,
+        static_channels,
+    })
+}
+
+fn flatten(records: &PacketStream) -> Vec<u8> {
+    records.iter().flat_map(|(_, bytes)| bytes).copied().collect()
+}
+
+fn connect_initial(bytes: &[u8]) -> Option<mcs::ConnectInitial> {
+    tpkt_frames(bytes).find_map(|frame| {
+        let payload = decode::<X224<X224Data<'_>>>(frame).ok()?.0;
+        decode::<mcs::ConnectInitial>(payload.data.as_ref()).ok()
+    })
+}
+
+fn connect_response(bytes: &[u8]) -> Option<mcs::ConnectResponse> {
+    tpkt_frames(bytes).find_map(|frame| {
+        let payload = decode::<X224<X224Data<'_>>>(frame).ok()?.0;
+        decode::<mcs::ConnectResponse>(payload.data.as_ref()).ok()
+    })
+}
+
+fn first_user_channel(bytes: &[u8]) -> Option<u16> {
+    tpkt_frames(bytes).find_map(|frame| match decode::<X224<McsMessage<'_>>>(frame).ok()?.0 {
+        McsMessage::AttachUserConfirm(message) => Some(message.initiator_id),
+        McsMessage::ChannelJoinRequest(message) => Some(message.initiator_id),
+        McsMessage::SendDataRequest(message) => Some(message.initiator_id),
+        _ => None,
+    })
+}
+
+fn first_share_id(bytes: &[u8]) -> Option<u32> {
+    tpkt_frames(bytes).find_map(|frame| {
+        let context = mcs::decode_send_data_indication(frame).ok()?;
+        let data = context.user_data;
+        if data.len() < 10 || u16::from_le_bytes(data.get(2..4)?.try_into().ok()?) & 0x0f != 1 {
+            return None;
+        }
+        Some(u32::from_le_bytes(data.get(6..10)?.try_into().ok()?))
+    })
+}
+
+fn tpkt_frames(bytes: &[u8]) -> impl Iterator<Item = &[u8]> {
+    let mut offset = 0;
+    core::iter::from_fn(move || {
+        while offset + 4 <= bytes.len() {
+            if bytes[offset] == 3 && bytes[offset + 1] == 0 {
+                let length = usize::from(u16::from_be_bytes([bytes[offset + 2], bytes[offset + 3]]));
+                let end = offset.checked_add(length)?;
+                if length >= 7 && end <= bytes.len() {
+                    let frame = &bytes[offset..end];
+                    offset = end;
+                    return Some(frame);
+                }
+            }
+            offset += 1;
+        }
+        None
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use ironrdp_core::encode_vec;
+
+    use super::*;
+
+    #[test]
+    fn finds_the_mcs_user_channel() {
+        let frame = encode_vec(&X224(mcs::AttachUserConfirm {
+            result: 0,
+            initiator_id: 1_005,
+        }))
+        .unwrap();
+
+        assert_eq!(first_user_channel(&frame), Some(1_005));
+    }
+
+    #[test]
+    fn rejects_streams_without_connect_sequence() {
+        let error = recover_negotiated_state(&Plaintext {
+            client: vec![(1, vec![3, 0, 0, 7, 2, 0xe0, 0])],
+            server: Vec::new(),
+        })
+        .unwrap_err();
+
+        assert!(matches!(error, ReplayError::MissingRdpState));
+    }
+}


### PR DESCRIPTION
Recover desktop, channel, MCS, and share state from decrypted RDP streams.

Validate captured dimensions before exposing the recovered state.