### PR TITLE
feat(rdpdr): Windows WinSCard core smartcard backend

### DIFF
--- a/crates/ironrdp-rdpdr-native/Cargo.toml
+++ b/crates/ironrdp-rdpdr-native/Cargo.toml
@@ -36,6 +36,7 @@ windows = { version = "0.62", features = [
     "Win32_Foundation",
     "Win32_Security",
     "Win32_Security_Authorization",
+    "Win32_Security_Credentials",
     "Win32_Storage_FileSystem",
     "Win32_System_IO",
     "Win32_System_Threading",

--- a/crates/ironrdp-rdpdr-native/README.md
+++ b/crates/ironrdp-rdpdr-native/README.md
@@ -22,8 +22,10 @@ Native backend building blocks for the IronRDP RDPDR static channel.
   `FSCTL_GET_INTEGRITY_INFORMATION`, and `FSCTL_QUERY_ALLOCATED_RANGES`, all
   with validated, bounded buffers.
   - Smartcard-only products are valid when the channel is configured with `ironrdp_rdpdr::Rdpdr::with_smartcard(0)`.
-    The current Windows backend is a compile-ready stub that completes decoded MS-RDPESC calls with `SCARD_E_UNSUPPORTED_FEATURE`.
-    A full WinSCard implementation is a follow-up.
+      The Windows backend implements a WinSCard core path for logon-critical MS-RDPESC IOCTLs
+      (context, readers, status-change, connect/transmit/status/state, and related card ops).
+      ANSI IOCTLs are upgraded to UTF-16 and executed through WinSCard `*W` APIs; StatusA replies keep ANSI charset on the wire.
+      Extended calls (LocateCards, Control, attrib/cache/icon, reader-group admin) still return typed `SCARD_E_UNSUPPORTED_FEATURE`.
 
 The Windows implementation is intentionally layered so protocol code remains
 platform independent in `ironrdp-rdpdr`.

--- a/crates/ironrdp-rdpdr-native/src/windows/scard/mod.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/scard/mod.rs
@@ -574,13 +574,20 @@ impl ScardSession {
                 let code = map_status(status);
                 let out_pci = recv_pci.as_ref().map(PciBuf::unpack);
                 if code != ReturnCode::Success {
-                    return Outcome::Message(xmit_ret(req, code, None, None, 0));
+                    // WinSCard writes the required size into pcbRecvLength on
+                    // SCARD_E_INSUFFICIENT_BUFFER; surface it as a NULL pbRecvBuffer probe.
+                    let need = if code == ReturnCode::InsufficientBuffer {
+                        len.min(MAX_RECV)
+                    } else {
+                        0
+                    };
+                    return Outcome::Message(xmit_ret(req, code, out_pci, None, need));
                 }
                 if call.recv_buffer_is_null {
-                    Outcome::Message(xmit_ret(req, code, out_pci, None, len))
+                    Outcome::Message(xmit_ret(req, code, out_pci, None, len.min(MAX_RECV)))
                 } else {
-                    buf.truncate(len as usize);
-                    Outcome::Message(xmit_ret(req, code, out_pci, Some(buf), len))
+                    buf.truncate((len as usize).min(buf.len()));
+                    Outcome::Message(xmit_ret(req, code, out_pci, Some(buf), len.min(MAX_RECV)))
                 }
             },
             |req, c| xmit_ret(req, c, None, None, 0),

--- a/crates/ironrdp-rdpdr-native/src/windows/scard/mod.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/scard/mod.rs
@@ -504,20 +504,26 @@ impl ScardSession {
             name,
             req,
             move |req, _| match ioctl {
-                // SAFETY: session-owned card handle.
                 ScardIoCtlCode::BeginTransaction => {
+                    // SAFETY: session-owned card handle.
                     Outcome::Message(complete_long(req, map_status(unsafe { SCardBeginTransaction(handle) })))
                 }
-                ScardIoCtlCode::EndTransaction => Outcome::Message(complete_long(
-                    req,
-                    map_status(unsafe { SCardEndTransaction(handle, disp) }),
-                )),
-                ScardIoCtlCode::Disconnect => Outcome::Disconnect {
-                    req,
-                    card: handle,
+                ScardIoCtlCode::EndTransaction => {
                     // SAFETY: session-owned card handle.
-                    code: map_status(unsafe { SCardDisconnect(handle, disp) }),
-                },
+                    Outcome::Message(complete_long(
+                        req,
+                        map_status(unsafe { SCardEndTransaction(handle, disp) }),
+                    ))
+                }
+                ScardIoCtlCode::Disconnect => {
+                    // SAFETY: session-owned card handle.
+                    let code = map_status(unsafe { SCardDisconnect(handle, disp) });
+                    Outcome::Disconnect {
+                        req,
+                        card: handle,
+                        code,
+                    }
+                }
                 _ => Outcome::Message(complete_long(req, ReturnCode::UnsupportedFeature)),
             },
             complete_long,
@@ -538,8 +544,8 @@ impl ScardSession {
             "ironrdp-scard-xmit",
             req,
             move |req, _| {
-                let send_pci = pack_pci(&call.send_pci);
-                let mut recv_pci = call.recv_pci.as_ref().map(pack_pci);
+                let send_pci = PciBuf::pack(&call.send_pci);
+                let mut recv_pci = call.recv_pci.as_ref().map(PciBuf::pack);
                 let mut len = if call.recv_buffer_is_null {
                     0
                 } else {
@@ -550,13 +556,13 @@ impl ScardSession {
                 } else {
                     vec![0u8; len as usize]
                 };
-                // SAFETY: card handle session-owned; PCI/recv buffers owned above.
+                // SAFETY: session card; PCI blobs are 4-byte aligned owners; recv buffer owned above.
                 let status = unsafe {
                     SCardTransmit(
                         handle,
-                        send_pci.as_ptr().cast::<SCARD_IO_REQUEST>(),
+                        send_pci.ptr(),
                         &call.send_buffer,
-                        recv_pci.as_mut().map(|b| b.as_mut_ptr().cast::<SCARD_IO_REQUEST>()),
+                        recv_pci.as_mut().map(PciBuf::ptr_mut),
                         if call.recv_buffer_is_null {
                             core::ptr::null_mut()
                         } else {
@@ -566,7 +572,7 @@ impl ScardSession {
                     )
                 };
                 let code = map_status(status);
-                let out_pci = recv_pci.as_deref().map(unpack_pci);
+                let out_pci = recv_pci.as_ref().map(PciBuf::unpack);
                 if code != ReturnCode::Success {
                     return Outcome::Message(xmit_ret(req, code, None, None, 0));
                 }
@@ -624,7 +630,7 @@ impl ScardSession {
                 }
                 Err(c) => Outcome::Message(state_err(req, c)),
             },
-            |req, c| state_err(req, c),
+            state_err,
         )
     }
 
@@ -735,15 +741,17 @@ fn push(completions: Arc<Mutex<Vec<DeferredCompletion>>>, id: u64, epoch: u64, o
 }
 
 fn list_groups_w(context: usize) -> Result<Vec<String>, ReturnCode> {
-    list_multi(context, |ctx, buf, len| unsafe {
-        SCardListReaderGroupsW(ctx, buf, len)
+    list_multi(context, |ctx, buf, len| {
+        // SAFETY: session context; optional out buffer sized by len.
+        unsafe { SCardListReaderGroupsW(ctx, buf, len) }
     })
 }
 
 fn list_readers_w(context: usize, groups: &[String]) -> Result<Vec<String>, ReturnCode> {
     let groups_w = multi_wide(groups);
-    list_multi(context, |ctx, buf, len| unsafe {
-        SCardListReadersW(ctx, PCWSTR(groups_w.as_ptr()), buf, len)
+    list_multi(context, |ctx, buf, len| {
+        // SAFETY: session context; groups_w lives for the call.
+        unsafe { SCardListReadersW(ctx, PCWSTR(groups_w.as_ptr()), buf, len) }
     })
 }
 
@@ -772,7 +780,9 @@ where
     Ok(parse_multi_wide(&buf[..actual as usize]))
 }
 
-fn card_status_w(handle: usize) -> Result<(Vec<String>, CardState, CardProtocol, [u8; MAX_ATR], u32), ReturnCode> {
+type CardStatus = (Vec<String>, CardState, CardProtocol, [u8; MAX_ATR], u32);
+
+fn card_status_w(handle: usize) -> Result<CardStatus, ReturnCode> {
     let mut name_len = 0u32;
     let mut state = 0u32;
     let mut protocol = 0u32;
@@ -1051,39 +1061,62 @@ fn multi_chars(v: &[String], cs: CharacterSet) -> u32 {
     }
 }
 
-fn pack_pci(pci: &SCardIORequest) -> Vec<u8> {
-    let hdr = core::mem::size_of::<SCARD_IO_REQUEST>();
-    let mut buf = vec![0u8; hdr + pci.extra_bytes.len()];
-    let req = SCARD_IO_REQUEST {
-        dwProtocol: pci.protocol.bits(),
-        cbPciLength: u32::try_from(buf.len()).unwrap_or(u32::MAX),
-    };
-    // SAFETY: write unaligned header into owned byte buffer.
-    unsafe {
-        core::ptr::write_unaligned(buf.as_mut_ptr().cast::<SCARD_IO_REQUEST>(), req);
-    }
-    if !pci.extra_bytes.is_empty() {
-        buf[hdr..].copy_from_slice(&pci.extra_bytes);
-    }
-    buf
+/// Aligned owner for a WinSCard `SCARD_IO_REQUEST` plus optional extra bytes.
+struct PciBuf {
+    /// Little-endian words keep the buffer 4-byte aligned for `SCARD_IO_REQUEST`.
+    words: Vec<u32>,
+    byte_len: usize,
 }
 
-fn unpack_pci(raw: &[u8]) -> SCardIORequest {
-    let hdr = core::mem::size_of::<SCARD_IO_REQUEST>();
-    if raw.len() < hdr {
-        return SCardIORequest {
-            protocol: CardProtocol::SCARD_PROTOCOL_UNDEFINED,
-            extra_bytes_length: 0,
-            extra_bytes: Vec::new(),
+impl PciBuf {
+    fn pack(pci: &SCardIORequest) -> Self {
+        let hdr = core::mem::size_of::<SCARD_IO_REQUEST>();
+        let byte_len = hdr + pci.extra_bytes.len();
+        let nwords = byte_len.div_ceil(4);
+        let mut words = vec![0u32; nwords];
+        let req = SCARD_IO_REQUEST {
+            dwProtocol: pci.protocol.bits(),
+            cbPciLength: u32::try_from(byte_len).unwrap_or(u32::MAX),
         };
+        // SAFETY: `words` is 4-byte aligned and large enough for the header.
+        unsafe {
+            core::ptr::write(words.as_mut_ptr().cast::<SCARD_IO_REQUEST>(), req);
+        }
+        if !pci.extra_bytes.is_empty() {
+            // SAFETY: view the packed words as the byte_len prefix we own.
+            let bytes = unsafe { core::slice::from_raw_parts_mut(words.as_mut_ptr().cast::<u8>(), byte_len) };
+            bytes[hdr..].copy_from_slice(&pci.extra_bytes);
+        }
+        Self { words, byte_len }
     }
-    // SAFETY: buffer holds at least one SCARD_IO_REQUEST header.
-    let req = unsafe { core::ptr::read_unaligned(raw.as_ptr().cast::<SCARD_IO_REQUEST>()) };
-    let extra = raw[hdr..].to_vec();
-    SCardIORequest {
-        protocol: CardProtocol::from_bits_retain(req.dwProtocol),
-        extra_bytes_length: extra.len(),
-        extra_bytes: extra,
+
+    fn ptr(&self) -> *const SCARD_IO_REQUEST {
+        self.words.as_ptr().cast()
+    }
+
+    fn ptr_mut(&mut self) -> *mut SCARD_IO_REQUEST {
+        self.words.as_mut_ptr().cast()
+    }
+
+    fn unpack(&self) -> SCardIORequest {
+        let hdr = core::mem::size_of::<SCARD_IO_REQUEST>();
+        if self.byte_len < hdr {
+            return SCardIORequest {
+                protocol: CardProtocol::SCARD_PROTOCOL_UNDEFINED,
+                extra_bytes_length: 0,
+                extra_bytes: Vec::new(),
+            };
+        }
+        // SAFETY: pack() wrote a full header into aligned storage.
+        let req = unsafe { core::ptr::read(self.words.as_ptr().cast::<SCARD_IO_REQUEST>()) };
+        // SAFETY: byte_len bytes were initialized by pack().
+        let bytes = unsafe { core::slice::from_raw_parts(self.words.as_ptr().cast::<u8>(), self.byte_len) };
+        let extra = bytes[hdr..].to_vec();
+        SCardIORequest {
+            protocol: CardProtocol::from_bits_retain(req.dwProtocol),
+            extra_bytes_length: extra.len(),
+            extra_bytes: extra,
+        }
     }
 }
 
@@ -1212,7 +1245,7 @@ mod tests {
             extra_bytes_length: 1,
             extra_bytes: vec![9],
         };
-        assert_eq!(unpack_pci(&pack_pci(&pci)).extra_bytes, vec![9]);
+        assert_eq!(PciBuf::pack(&pci).unpack().extra_bytes, vec![9]);
         let mut s = ScardSession::new();
         s.contexts.insert(1, ());
         s.cards.insert(2, 1);

--- a/crates/ironrdp-rdpdr-native/src/windows/scard/mod.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/scard/mod.rs
@@ -1,16 +1,16 @@
 //! Windows WinSCard core backend for MS-RDPESC Device Control IRPs.
 //!
-//! ANSI (`*A`) IOCTLs are decoded to `String`, upgraded to UTF-16, and run through
-//! WinSCard `*W` APIs. StatusA replies keep ANSI charset on the wire.
-//! Extended IOCTLs stay typed `SCARD_E_UNSUPPORTED_FEATURE` (follow-up PR).
+//! ANSI (`*A`) IOCTLs upgrade to UTF-16 and call WinSCard `*W` APIs.
+//! List/Status `*A` replies keep ANSI on the wire. Extended IOCTLs remain unsupported.
 
 use core::sync::atomic::{AtomicBool, Ordering};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
+use ironrdp_core::Encode as _;
 use ironrdp_pdu::PduResult;
-use ironrdp_pdu::utils::CharacterSet;
+use ironrdp_pdu::utils::{CharacterSet, encoded_multistring_len};
 use ironrdp_rdpdr::pdu::RdpdrPdu;
 use ironrdp_rdpdr::pdu::efs::{DeviceControlRequest, DeviceControlResponse, NtStatus};
 use ironrdp_rdpdr::pdu::esc::{
@@ -35,16 +35,15 @@ use windows::core::{PCWSTR, PWSTR};
 
 const MAX_DEFERRED: usize = 32;
 const MAX_ATR: usize = 32;
+const MAX_RECV: u32 = 64 * 1024;
 const SCARD_SCOPE_TERMINAL: SCARD_SCOPE = SCARD_SCOPE(1);
 
 /// Per-connection WinSCard state for RDPDR smartcard device ID 0.
-/// Wire handles carry native bytes (4/8) matching mstscax.
 #[derive(Debug)]
 pub(super) struct ScardSession {
     contexts: HashMap<usize, ()>,
     cards: HashMap<usize, usize>,
     deferred: DeferredOps,
-    /// Process-wide started-event; never CloseHandle — pair with SCardReleaseStartedEvent.
     access_event: Option<isize>,
     access_refs: u32,
 }
@@ -102,17 +101,17 @@ impl ScardSession {
     pub(super) fn reset(&mut self) {
         self.deferred.reset();
         for h in self.cards.keys().copied() {
-            // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+            // SAFETY: WinSCard.
             let _ = unsafe { SCardDisconnect(h, 0) };
         }
         self.cards.clear();
         for c in self.contexts.keys().copied() {
-            // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+            // SAFETY: WinSCard.
             let _ = unsafe { SCardReleaseContext(c) };
         }
         self.contexts.clear();
         while self.access_refs > 0 {
-            // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+            // SAFETY: WinSCard.
             unsafe { SCardReleaseStartedEvent() };
             self.access_refs -= 1;
         }
@@ -138,7 +137,7 @@ impl ScardSession {
                 }
                 let ctx = context.native();
                 if !self.contexts.contains_key(&ctx) {
-                    // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+                    // SAFETY: WinSCard.
                     let _ = unsafe { SCardDisconnect(native_handle, 0) };
                     return complete_connect(
                         req,
@@ -147,13 +146,15 @@ impl ScardSession {
                         CardProtocol::SCARD_PROTOCOL_UNDEFINED,
                     );
                 }
+                let handle = ScardHandle::from_native(context, native_handle);
+                let out = ConnectReturn::new(ReturnCode::Success, handle, active_protocol);
+                if out.size() > req.output_buffer_length as usize {
+                    // SAFETY: WinSCard.
+                    let _ = unsafe { SCardDisconnect(native_handle, 0) };
+                    return buffer_too_small(req);
+                }
                 self.cards.insert(native_handle, ctx);
-                complete_connect(
-                    req,
-                    ReturnCode::Success,
-                    ScardHandle::from_native(context, native_handle),
-                    active_protocol,
-                )
+                complete_rpce(req, Box::new(out))
             }
             Outcome::Disconnect { req, card, code } => {
                 if code == ReturnCode::Success {
@@ -208,15 +209,14 @@ impl ScardSession {
         call: ScardCall,
     ) -> PduResult<Vec<SvcMessage>> {
         let ioctl = req.io_control_code;
-        // MS-RDPESC 3.1.4.46: unused; Success so servers never hang.
         if ioctl == ScardIoCtlCode::ReleaseTartedEvent {
             return Ok(vec![complete_long(req, ReturnCode::Success)]);
         }
         match call {
             ScardCall::AccessStartedEventCall(_) => self.access_started(req),
             ScardCall::EstablishContextCall(c) => Ok(vec![self.establish_context(req, c)]),
-            ScardCall::ListReaderGroupsCall(c) => Ok(vec![self.list_groups(req, c)]),
-            ScardCall::ListReadersCall(c) => Ok(vec![self.list_readers(req, c)]),
+            ScardCall::ListReaderGroupsCall(c) => Ok(vec![self.list_groups(req, ioctl, c)]),
+            ScardCall::ListReadersCall(c) => Ok(vec![self.list_readers(req, ioctl, c)]),
             ScardCall::GetStatusChangeCall(c) => self.get_status_change(req, c),
             ScardCall::ConnectCall(c) => self.connect(req, c),
             ScardCall::ReconnectCall(c) => self.reconnect(req, c),
@@ -225,7 +225,6 @@ impl ScardSession {
             ScardCall::StatusCall(c) => self.status(req, ioctl, c),
             ScardCall::StateCall(c) => self.state(req, c),
             ScardCall::ContextCall(c) => Ok(vec![self.context_call(req, ioctl, c)]),
-            // PR4 leftovers: typed empty returns.
             other => Ok(vec![complete_rpce(req, unsupported(ioctl, other))]),
         }
     }
@@ -250,7 +249,7 @@ impl ScardSession {
     fn access_started(&mut self, req: DeviceControlRequest<ScardIoCtlCode>) -> PduResult<Vec<SvcMessage>> {
         let raw = match self.access_event {
             Some(r) => r,
-            // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+            // SAFETY: WinSCard.
             None => match unsafe { SCardAccessStartedEvent() } {
                 Ok(h) if !h.is_invalid() => {
                     let r = h.0 as isize;
@@ -261,7 +260,7 @@ impl ScardSession {
                 _ => return Ok(vec![complete_long(req, ReturnCode::Success)]),
             },
         };
-        // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+        // SAFETY: WinSCard.
         if unsafe { WaitForSingleObject(HANDLE(raw as *mut _), 0) } == WAIT_OBJECT_0 {
             return Ok(vec![complete_long(req, ReturnCode::Success)]);
         }
@@ -274,7 +273,7 @@ impl ScardSession {
                     if cancel.load(Ordering::Acquire) {
                         break ReturnCode::Cancelled;
                     }
-                    // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+                    // SAFETY: WinSCard.
                     let w = unsafe { WaitForSingleObject(HANDLE(raw as *mut _), 100) };
                     if w == WAIT_OBJECT_0 || w != WAIT_TIMEOUT {
                         break ReturnCode::Success;
@@ -291,13 +290,17 @@ impl ScardSession {
         req: DeviceControlRequest<ScardIoCtlCode>,
         call: EstablishContextCall,
     ) -> SvcMessage {
+        let preview = EstablishContextReturn::new(ReturnCode::Success, ScardContext::from_native(usize::MAX));
+        if preview.size() > req.output_buffer_length as usize {
+            return buffer_too_small(req);
+        }
         let scope = match call.scope {
             Scope::User => SCARD_SCOPE_USER,
             Scope::Terminal => SCARD_SCOPE_TERMINAL,
             Scope::System => SCARD_SCOPE_SYSTEM,
         };
         let mut native = 0usize;
-        // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+        // SAFETY: WinSCard.
         let code = map_status(unsafe { SCardEstablishContext(scope, None, None, &mut native) });
         if code != ReturnCode::Success {
             return complete_establish(req, code, ScardContext::from_native(0));
@@ -306,17 +309,29 @@ impl ScardSession {
         complete_establish(req, ReturnCode::Success, ScardContext::from_native(native))
     }
 
-    fn list_groups(&self, req: DeviceControlRequest<ScardIoCtlCode>, call: ListReaderGroupsCall) -> SvcMessage {
+    fn list_groups(
+        &self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+        ioctl: ScardIoCtlCode,
+        call: ListReaderGroupsCall,
+    ) -> SvcMessage {
+        let cs = list_cs(ioctl);
         match self.ctx(call.context).and_then(list_groups_w) {
-            Ok(v) => complete_list(req, ReturnCode::Success, v),
-            Err(c) => complete_list(req, c, Vec::new()),
+            Ok(v) => complete_list_fit(req, v, call.groups_is_null, call.groups_size, cs),
+            Err(c) => complete_list(req, c, Vec::new(), cs),
         }
     }
 
-    fn list_readers(&self, req: DeviceControlRequest<ScardIoCtlCode>, call: ListReadersCall) -> SvcMessage {
+    fn list_readers(
+        &self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+        ioctl: ScardIoCtlCode,
+        call: ListReadersCall,
+    ) -> SvcMessage {
+        let cs = list_cs(ioctl);
         match self.ctx(call.context).and_then(|n| list_readers_w(n, &call.groups)) {
-            Ok(v) => complete_list(req, ReturnCode::Success, v),
-            Err(c) => complete_list(req, c, Vec::new()),
+            Ok(v) => complete_list_fit(req, v, call.readers_is_null, call.readers_size, cs),
+            Err(c) => complete_list(req, c, Vec::new(), cs),
         }
     }
 
@@ -345,8 +360,8 @@ impl ScardSession {
                     .zip(bufs.iter())
                     .map(|(s, r)| reader_state_w(s, r))
                     .collect();
+                // SAFETY: WinSCard.
                 let status =
-                    // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
                     unsafe { SCardGetStatusChangeW(native, call.timeout, states.as_mut_ptr(), states.len() as u32) };
                 let code = if cancel.load(Ordering::Acquire) {
                     ReturnCode::Cancelled
@@ -376,6 +391,14 @@ impl ScardSession {
                 )]);
             }
         };
+        let preview = ConnectReturn::new(
+            ReturnCode::Success,
+            ScardHandle::from_native(call.common.context, usize::MAX),
+            CardProtocol::SCARD_PROTOCOL_T0,
+        );
+        if preview.size() > req.output_buffer_length as usize {
+            return Ok(vec![buffer_too_small(req)]);
+        }
         let context = call.common.context;
         self.defer(
             context.native(),
@@ -385,7 +408,7 @@ impl ScardSession {
                 let reader = wide(&call.reader);
                 let mut card = 0usize;
                 let mut active = 0u32;
-                // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+                // SAFETY: WinSCard.
                 let status = unsafe {
                     SCardConnectW(
                         native_ctx,
@@ -430,7 +453,7 @@ impl ScardSession {
             req,
             move |req, _| {
                 let mut active = 0u32;
-                // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+                // SAFETY: WinSCard.
                 let status = unsafe {
                     SCardReconnect(
                         handle,
@@ -472,19 +495,17 @@ impl ScardSession {
             name,
             req,
             move |req, _| match ioctl {
+                // SAFETY: WinSCard.
                 ScardIoCtlCode::BeginTransaction => {
-                    // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
                     Outcome::Message(complete_long(req, map_status(unsafe { SCardBeginTransaction(handle) })))
                 }
                 ScardIoCtlCode::EndTransaction => Outcome::Message(complete_long(
                     req,
-                    // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
                     map_status(unsafe { SCardEndTransaction(handle, disp) }),
                 )),
                 ScardIoCtlCode::Disconnect => Outcome::Disconnect {
                     req,
                     card: handle,
-                    // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
                     code: map_status(unsafe { SCardDisconnect(handle, disp) }),
                 },
                 _ => Outcome::Message(complete_long(req, ReturnCode::UnsupportedFeature)),
@@ -506,45 +527,7 @@ impl ScardSession {
             ctx_id,
             "ironrdp-scard-xmit",
             req,
-            move |req, _| {
-                let send_pci = SCARD_IO_REQUEST {
-                    dwProtocol: call.send_pci.protocol.bits(),
-                    cbPciLength: core::mem::size_of::<SCARD_IO_REQUEST>() as u32,
-                };
-                let mut recv_pci = call.recv_pci.as_ref().map(|p| SCARD_IO_REQUEST {
-                    dwProtocol: p.protocol.bits(),
-                    cbPciLength: core::mem::size_of::<SCARD_IO_REQUEST>() as u32,
-                });
-                let recv_len = if call.recv_buffer_is_null {
-                    0
-                } else {
-                    call.recv_length.max(2)
-                };
-                let mut buf = vec![0u8; recv_len as usize];
-                let mut len = recv_len;
-                // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
-                let status = unsafe {
-                    SCardTransmit(
-                        handle,
-                        &send_pci,
-                        &call.send_buffer,
-                        recv_pci.as_mut().map(|p| p as *mut SCARD_IO_REQUEST),
-                        buf.as_mut_ptr(),
-                        &mut len,
-                    )
-                };
-                let code = map_status(status);
-                if code != ReturnCode::Success {
-                    return Outcome::Message(complete_transmit(req, code, None, Vec::new()));
-                }
-                buf.truncate(len as usize);
-                let out_pci = recv_pci.map(|p| SCardIORequest {
-                    protocol: CardProtocol::from_bits_retain(p.dwProtocol),
-                    extra_bytes_length: 0,
-                    extra_bytes: Vec::new(),
-                });
-                Outcome::Message(complete_transmit(req, ReturnCode::Success, out_pci, buf))
-            },
+            move |req, _| run_transmit(req, handle, call),
             |req, c| complete_transmit(req, c, None, Vec::new()),
         )
     }
@@ -564,16 +547,14 @@ impl ScardSession {
             "ironrdp-scard-status",
             req,
             move |req, _| match card_status_w(handle) {
-                Ok((names, state, proto, atr, atr_len)) => Outcome::Message(complete_status(
-                    req,
-                    ReturnCode::Success,
-                    names,
-                    state,
-                    proto,
-                    atr,
-                    atr_len,
-                    status_cs(ioctl),
-                )),
+                Ok((names, state, proto, atr, atr_len)) => {
+                    let cs = status_cs(ioctl);
+                    let (code, names_opt, c_bytes) =
+                        fit_multi(names, call.reader_names_is_null, call.reader_length, cs);
+                    Outcome::Message(complete_status_fit(
+                        req, code, names_opt, c_bytes, state, proto, atr, atr_len, cs,
+                    ))
+                }
                 Err(c) => Outcome::Message(complete_status_err(req, c, ioctl)),
             },
             move |req, c| complete_status_err(req, c, ioctl),
@@ -598,14 +579,15 @@ impl ScardSession {
             "ironrdp-scard-state",
             req,
             move |req, _| match card_status_w(handle) {
-                Ok((_n, state, proto, atr, atr_len)) => {
-                    let atr = if call.atr_is_null {
-                        Vec::new()
-                    } else {
-                        atr[..atr_len as usize].to_vec()
-                    };
-                    Outcome::Message(complete_state(req, ReturnCode::Success, state, proto, atr))
-                }
+                Ok((_n, state, proto, atr, atr_len)) => Outcome::Message(complete_state_fit(
+                    req,
+                    ReturnCode::Success,
+                    state,
+                    proto,
+                    atr,
+                    atr_len,
+                    call,
+                )),
                 Err(c) => Outcome::Message(complete_state(
                     req,
                     c,
@@ -635,7 +617,7 @@ impl ScardSession {
         match ioctl {
             ScardIoCtlCode::ReleaseContext => self.release_context(req, call),
             ScardIoCtlCode::IsValidContext => match self.ctx(call.context) {
-                // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+                // SAFETY: WinSCard.
                 Ok(n) => complete_long(req, map_status(unsafe { SCardIsValidContext(n) })),
                 Err(c) => complete_long(req, c),
             },
@@ -646,7 +628,7 @@ impl ScardSession {
                             op.cancel.store(true, Ordering::Release);
                         }
                     }
-                    // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+                    // SAFETY: WinSCard.
                     complete_long(req, map_status(unsafe { SCardCancel(n) }))
                 }
                 Err(c) => complete_long(req, c),
@@ -660,20 +642,11 @@ impl ScardSession {
             Ok(n) => n,
             Err(c) => return complete_long(req, c),
         };
-        let cards: Vec<usize> = self
-            .cards
-            .iter()
-            .filter_map(|(h, c)| (*c == native).then_some(*h))
-            .collect();
-        for h in cards {
-            if self.cards.remove(&h).is_some() {
-                // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
-                let _ = unsafe { SCardDisconnect(h, 0) };
-            }
-        }
-        // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+        // ReleaseContext frees context-owned cards; update maps only after success.
+        // SAFETY: WinSCard.
         let code = map_status(unsafe { SCardReleaseContext(native) });
         if code == ReturnCode::Success {
+            self.cards.retain(|_, c| *c != native);
             self.contexts.remove(&native);
         }
         complete_long(req, code)
@@ -721,15 +694,8 @@ impl DeferredOps {
 
     fn reset(&mut self) {
         self.epoch = self.epoch.wrapping_add(1);
-        let ops = core::mem::take(&mut self.ops);
-        for op in ops.values() {
+        for (_, op) in self.ops.drain() {
             op.cancel.store(true, Ordering::Release);
-            if op.context_id != 0 {
-                // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
-                let _ = unsafe { SCardCancel(op.context_id) };
-            }
-        }
-        for op in ops.into_values() {
             let _ = op.worker.join();
         }
         if let Ok(mut g) = self.completions.lock() {
@@ -739,66 +705,75 @@ impl DeferredOps {
 }
 
 fn push(completions: Arc<Mutex<Vec<DeferredCompletion>>>, id: u64, epoch: u64, outcome: Outcome) {
-    let c = DeferredCompletion { id, epoch, outcome };
+    let item = DeferredCompletion { id, epoch, outcome };
     match completions.lock() {
-        Ok(mut g) => g.push(c),
-        Err(p) => p.into_inner().push(c),
+        Ok(mut g) => g.push(item),
+        Err(p) => p.into_inner().push(item),
     }
 }
 
 fn list_groups_w(context: usize) -> Result<Vec<String>, ReturnCode> {
-    // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
-    list_multi_w(context, |ctx, ptr, len| unsafe {
-        SCardListReaderGroupsW(ctx, ptr, len)
-    })
-}
-
-fn list_readers_w(context: usize, groups: &[String]) -> Result<Vec<String>, ReturnCode> {
-    let groups_buf = (!groups.is_empty()).then(|| multi_wide(groups));
-    let groups_ptr = groups_buf
-        .as_ref()
-        .map(|b| PCWSTR(b.as_ptr()))
-        .unwrap_or(PCWSTR::null());
-    // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
-    list_multi_w(context, |ctx, ptr, len| unsafe {
-        SCardListReadersW(ctx, groups_ptr, ptr, len)
-    })
-}
-
-fn list_multi_w<F>(context: usize, mut f: F) -> Result<Vec<String>, ReturnCode>
-where
-    F: FnMut(usize, Option<PWSTR>, &mut u32) -> i32,
-{
     let mut needed = 0u32;
-    let probe = map_status(f(context, None, &mut needed));
-    if probe == ReturnCode::NoReadersAvailable || needed == 0 {
+    // SAFETY: WinSCard.
+    let probe = unsafe { SCardListReaderGroupsW(context, None, &mut needed) };
+    let probe_code = map_status(probe);
+    if probe_code == ReturnCode::NoReadersAvailable {
         return Ok(Vec::new());
     }
-    if probe != ReturnCode::Success && probe != ReturnCode::InsufficientBuffer {
-        return Err(probe);
+    if probe_code != ReturnCode::Success && probe_code != ReturnCode::InsufficientBuffer {
+        return Err(probe_code);
+    }
+    if needed == 0 {
+        return Ok(Vec::new());
     }
     let mut buf = vec![0u16; needed as usize];
-    let mut actual = needed;
-    let code = map_status(f(context, Some(PWSTR(buf.as_mut_ptr())), &mut actual));
-    if code == ReturnCode::NoReadersAvailable {
-        return Ok(Vec::new());
-    }
+    let mut len = needed;
+    // SAFETY: WinSCard.
+    let code = map_status(unsafe { SCardListReaderGroupsW(context, Some(PWSTR(buf.as_mut_ptr())), &mut len) });
     if code != ReturnCode::Success {
         return Err(code);
     }
-    Ok(parse_multi_wide(&buf[..actual as usize]))
+    Ok(parse_multi_wide(&buf[..len as usize]))
 }
 
-type CardStatusW = (Vec<String>, CardState, CardProtocol, [u8; MAX_ATR], u32);
+fn list_readers_w(context: usize, groups: &[String]) -> Result<Vec<String>, ReturnCode> {
+    let groups_w = if groups.is_empty() {
+        None
+    } else {
+        Some(multi_wide(groups))
+    };
+    let groups_ptr = groups_w.as_ref().map(|g| PCWSTR(g.as_ptr())).unwrap_or(PCWSTR::null());
+    let mut needed = 0u32;
+    // SAFETY: WinSCard.
+    let probe = unsafe { SCardListReadersW(context, groups_ptr, None, &mut needed) };
+    let probe_code = map_status(probe);
+    if probe_code == ReturnCode::NoReadersAvailable {
+        return Ok(Vec::new());
+    }
+    if probe_code != ReturnCode::Success && probe_code != ReturnCode::InsufficientBuffer {
+        return Err(probe_code);
+    }
+    if needed == 0 {
+        return Ok(Vec::new());
+    }
+    let mut buf = vec![0u16; needed as usize];
+    let mut len = needed;
+    // SAFETY: WinSCard.
+    let code = map_status(unsafe { SCardListReadersW(context, groups_ptr, Some(PWSTR(buf.as_mut_ptr())), &mut len) });
+    if code != ReturnCode::Success {
+        return Err(code);
+    }
+    Ok(parse_multi_wide(&buf[..len as usize]))
+}
 
-fn card_status_w(handle: usize) -> Result<CardStatusW, ReturnCode> {
+fn card_status_w(handle: usize) -> Result<(Vec<String>, CardState, CardProtocol, [u8; MAX_ATR], u32), ReturnCode> {
     let mut name_len = 0u32;
     let mut state = 0u32;
     let mut protocol = 0u32;
     let mut atr = [0u8; MAX_ATR];
-    let mut atr_len = atr.len() as u32;
-    // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
-    let probe = map_status(unsafe {
+    let mut atr_len = MAX_ATR as u32;
+    // SAFETY: WinSCard.
+    let probe = unsafe {
         SCardStatusW(
             handle,
             None,
@@ -808,30 +783,32 @@ fn card_status_w(handle: usize) -> Result<CardStatusW, ReturnCode> {
             Some(atr.as_mut_ptr()),
             Some(&mut atr_len),
         )
-    });
-    if probe != ReturnCode::Success && probe != ReturnCode::InsufficientBuffer {
-        return Err(probe);
-    }
+    };
+    let probe_code = map_status(probe);
     let mut names = Vec::new();
-    if name_len > 0 {
-        let mut name_buf = vec![0u16; name_len as usize];
-        atr_len = atr.len() as u32;
-        // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
-        let code = map_status(unsafe {
-            SCardStatusW(
-                handle,
-                Some(PWSTR(name_buf.as_mut_ptr())),
-                Some(&mut name_len),
-                Some(&mut state),
-                Some(&mut protocol),
-                Some(atr.as_mut_ptr()),
-                Some(&mut atr_len),
-            )
-        });
-        if code != ReturnCode::Success {
-            return Err(code);
+    if probe_code == ReturnCode::Success || probe_code == ReturnCode::InsufficientBuffer {
+        if name_len > 0 {
+            let mut name_buf = vec![0u16; name_len as usize];
+            atr_len = MAX_ATR as u32;
+            // SAFETY: WinSCard.
+            let code = map_status(unsafe {
+                SCardStatusW(
+                    handle,
+                    Some(PWSTR(name_buf.as_mut_ptr())),
+                    Some(&mut name_len),
+                    Some(&mut state),
+                    Some(&mut protocol),
+                    Some(atr.as_mut_ptr()),
+                    Some(&mut atr_len),
+                )
+            });
+            if code != ReturnCode::Success {
+                return Err(code);
+            }
+            names = parse_multi_wide(&name_buf[..name_len as usize]);
         }
-        names = parse_multi_wide(&name_buf[..name_len as usize]);
+    } else {
+        return Err(probe_code);
     }
     let mut wire = [0u8; MAX_ATR];
     let n = (atr_len as usize).min(MAX_ATR);
@@ -854,6 +831,135 @@ fn card_status_w(handle: usize) -> Result<CardStatusW, ReturnCode> {
     ))
 }
 
+fn run_transmit(req: DeviceControlRequest<ScardIoCtlCode>, handle: usize, call: TransmitCall) -> Outcome {
+    let send_raw = pack_pci(&call.send_pci);
+    // SAFETY: WinSCard.
+    let send_pci = unsafe { &*(send_raw.as_ptr() as *const SCARD_IO_REQUEST) };
+    let mut recv_raw = call.recv_pci.as_ref().map(|p| {
+        let mut v = pack_pci(p);
+        if v.len() < core::mem::size_of::<SCARD_IO_REQUEST>() {
+            v.resize(core::mem::size_of::<SCARD_IO_REQUEST>(), 0);
+        }
+        v
+    });
+    let recv_pci_ptr = recv_raw.as_mut().map(|b| b.as_mut_ptr() as *mut SCARD_IO_REQUEST);
+
+    if call.recv_buffer_is_null {
+        let mut len = 0u32;
+        // SAFETY: WinSCard.
+        let status = unsafe {
+            SCardTransmit(
+                handle,
+                send_pci,
+                &call.send_buffer,
+                recv_pci_ptr,
+                core::ptr::null_mut(),
+                &mut len,
+            )
+        };
+        let code = map_status(status);
+        let out_pci = recv_raw.as_ref().map(|b| unpack_pci(b));
+        return Outcome::Message(complete_rpce(
+            req,
+            Box::new(TransmitReturn::recv_probe(code, out_pci, len)),
+        ));
+    }
+
+    let recv_len = call.recv_length.min(MAX_RECV);
+    let mut buf = vec![0u8; recv_len as usize];
+    let mut len = recv_len;
+    // SAFETY: WinSCard.
+    let status = unsafe {
+        SCardTransmit(
+            handle,
+            send_pci,
+            &call.send_buffer,
+            recv_pci_ptr,
+            if recv_len == 0 {
+                core::ptr::null_mut()
+            } else {
+                buf.as_mut_ptr()
+            },
+            &mut len,
+        )
+    };
+    let code = map_status(status);
+    if code != ReturnCode::Success {
+        return Outcome::Message(complete_transmit(req, code, None, Vec::new()));
+    }
+    buf.truncate(len as usize);
+    let out_pci = recv_raw.as_ref().map(|b| unpack_pci(b));
+    Outcome::Message(complete_transmit(req, ReturnCode::Success, out_pci, buf))
+}
+
+fn pack_pci(pci: &SCardIORequest) -> Vec<u8> {
+    let total = core::mem::size_of::<SCARD_IO_REQUEST>() + pci.extra_bytes.len();
+    let mut buf = vec![0u8; total];
+    let header = SCARD_IO_REQUEST {
+        dwProtocol: pci.protocol.bits(),
+        cbPciLength: total as u32,
+    };
+    // SAFETY: WinSCard.
+    unsafe {
+        core::ptr::write_unaligned(buf.as_mut_ptr() as *mut SCARD_IO_REQUEST, header);
+    }
+    if !pci.extra_bytes.is_empty() {
+        buf[core::mem::size_of::<SCARD_IO_REQUEST>()..].copy_from_slice(&pci.extra_bytes);
+    }
+    buf
+}
+
+fn unpack_pci(buf: &[u8]) -> SCardIORequest {
+    if buf.len() < core::mem::size_of::<SCARD_IO_REQUEST>() {
+        return SCardIORequest {
+            protocol: CardProtocol::SCARD_PROTOCOL_UNDEFINED,
+            extra_bytes_length: 0,
+            extra_bytes: Vec::new(),
+        };
+    }
+    // SAFETY: WinSCard.
+    let header = unsafe { core::ptr::read_unaligned(buf.as_ptr() as *const SCARD_IO_REQUEST) };
+    let declared = (header.cbPciLength as usize).min(buf.len());
+    let extra = if declared > core::mem::size_of::<SCARD_IO_REQUEST>() {
+        buf[core::mem::size_of::<SCARD_IO_REQUEST>()..declared].to_vec()
+    } else {
+        Vec::new()
+    };
+    SCardIORequest {
+        protocol: CardProtocol::from_bits_retain(header.dwProtocol),
+        extra_bytes_length: extra.len(),
+        extra_bytes: extra,
+    }
+}
+
+fn fit_multi(
+    values: Vec<String>,
+    is_null: bool,
+    capacity_chars: u32,
+    cs: CharacterSet,
+) -> (ReturnCode, Option<Vec<String>>, u32) {
+    let c_bytes = encoded_multistring_len(&values, cs) as u32;
+    let needed_chars = match cs {
+        CharacterSet::Unicode => c_bytes / 2,
+        CharacterSet::Ansi => c_bytes,
+    };
+    if is_null {
+        return (ReturnCode::Success, None, c_bytes);
+    }
+    if capacity_chars < needed_chars {
+        return (ReturnCode::InsufficientBuffer, None, c_bytes);
+    }
+    (ReturnCode::Success, Some(values), c_bytes)
+}
+
+fn buffer_too_small(req: DeviceControlRequest<ScardIoCtlCode>) -> SvcMessage {
+    SvcMessage::from(RdpdrPdu::DeviceControlResponse(DeviceControlResponse::new(
+        req,
+        NtStatus::BUFFER_TOO_SMALL,
+        None,
+    )))
+}
+
 fn complete_rpce(req: DeviceControlRequest<ScardIoCtlCode>, output: Box<dyn rpce::Encode>) -> SvcMessage {
     let (status, buf) = if output.size() <= req.output_buffer_length as usize {
         (NtStatus::SUCCESS, Some(output))
@@ -871,8 +977,26 @@ fn complete_long(req: DeviceControlRequest<ScardIoCtlCode>, code: ReturnCode) ->
 fn complete_establish(req: DeviceControlRequest<ScardIoCtlCode>, code: ReturnCode, ctx: ScardContext) -> SvcMessage {
     complete_rpce(req, Box::new(EstablishContextReturn::new(code, ctx)))
 }
-fn complete_list(req: DeviceControlRequest<ScardIoCtlCode>, code: ReturnCode, v: Vec<String>) -> SvcMessage {
-    complete_rpce(req, Box::new(ListReadersReturn::new(code, v)))
+fn complete_list(
+    req: DeviceControlRequest<ScardIoCtlCode>,
+    code: ReturnCode,
+    v: Vec<String>,
+    cs: CharacterSet,
+) -> SvcMessage {
+    complete_rpce(req, Box::new(ListReadersReturn::new(code, v, cs)))
+}
+fn complete_list_fit(
+    req: DeviceControlRequest<ScardIoCtlCode>,
+    v: Vec<String>,
+    is_null: bool,
+    capacity_chars: u32,
+    cs: CharacterSet,
+) -> SvcMessage {
+    let (code, names, c_bytes) = fit_multi(v, is_null, capacity_chars, cs);
+    match names {
+        Some(n) => complete_list(req, code, n, cs),
+        None => complete_rpce(req, Box::new(ListReadersReturn::probe(code, c_bytes, cs))),
+    }
 }
 fn complete_gsc(
     req: DeviceControlRequest<ScardIoCtlCode>,
@@ -897,36 +1021,46 @@ fn complete_transmit(
 ) -> SvcMessage {
     complete_rpce(req, Box::new(TransmitReturn::new(code, pci, data)))
 }
+
 #[allow(clippy::too_many_arguments)]
-fn complete_status(
+fn complete_status_fit(
     req: DeviceControlRequest<ScardIoCtlCode>,
     code: ReturnCode,
-    names: Vec<String>,
+    names: Option<Vec<String>>,
+    c_bytes: u32,
     state: CardState,
     proto: CardProtocol,
     atr: [u8; MAX_ATR],
     atr_len: u32,
     cs: CharacterSet,
 ) -> SvcMessage {
-    complete_rpce(
-        req,
-        Box::new(StatusReturn::new(code, names, state, proto, atr, atr_len, cs)),
-    )
+    match names {
+        Some(n) => complete_rpce(
+            req,
+            Box::new(StatusReturn::new(code, n, state, proto, atr, atr_len, cs)),
+        ),
+        None => complete_rpce(
+            req,
+            Box::new(StatusReturn::names_probe(code, c_bytes, state, proto, atr, atr_len, cs)),
+        ),
+    }
 }
 fn complete_status_err(
     req: DeviceControlRequest<ScardIoCtlCode>,
     code: ReturnCode,
     ioctl: ScardIoCtlCode,
 ) -> SvcMessage {
-    complete_status(
+    complete_rpce(
         req,
-        code,
-        Vec::new(),
-        CardState::Unknown,
-        CardProtocol::SCARD_PROTOCOL_UNDEFINED,
-        [0; MAX_ATR],
-        0,
-        status_cs(ioctl),
+        Box::new(StatusReturn::new(
+            code,
+            Vec::new(),
+            CardState::Unknown,
+            CardProtocol::SCARD_PROTOCOL_UNDEFINED,
+            [0; MAX_ATR],
+            0,
+            status_cs(ioctl),
+        )),
     )
 }
 fn complete_reconnect(req: DeviceControlRequest<ScardIoCtlCode>, code: ReturnCode, proto: CardProtocol) -> SvcMessage {
@@ -941,7 +1075,39 @@ fn complete_state(
 ) -> SvcMessage {
     complete_rpce(req, Box::new(StateReturn::new(code, state, proto, atr)))
 }
+fn complete_state_fit(
+    req: DeviceControlRequest<ScardIoCtlCode>,
+    code: ReturnCode,
+    state: CardState,
+    proto: CardProtocol,
+    atr: [u8; MAX_ATR],
+    atr_len: u32,
+    call: StateCall,
+) -> SvcMessage {
+    let full_len = atr_len.min(36);
+    if call.atr_is_null || call.atr_length == 0 {
+        return complete_rpce(req, Box::new(StateReturn::atr_probe(code, state, proto, full_len)));
+    }
+    if call.atr_length < atr_len {
+        return complete_rpce(
+            req,
+            Box::new(StateReturn::atr_probe(
+                ReturnCode::InsufficientBuffer,
+                state,
+                proto,
+                full_len,
+            )),
+        );
+    }
+    complete_state(req, code, state, proto, atr[..atr_len as usize].to_vec())
+}
 
+fn list_cs(ioctl: ScardIoCtlCode) -> CharacterSet {
+    match ioctl {
+        ScardIoCtlCode::ListReadersA | ScardIoCtlCode::ListReaderGroupsA => CharacterSet::Ansi,
+        _ => CharacterSet::Unicode,
+    }
+}
 fn status_cs(ioctl: ScardIoCtlCode) -> CharacterSet {
     match ioctl {
         ScardIoCtlCode::StatusA => CharacterSet::Ansi,
@@ -953,7 +1119,7 @@ fn map_status(status: i32) -> ReturnCode {
     let code = status as u32;
     match code {
         0 => ReturnCode::Success,
-        // SAFETY: ReturnCode is #[repr(u32)]; every value in these ranges is a defined variant.
+        // SAFETY: WinSCard.
         0x8010_0001..=0x8010_0034 | 0x8010_0065..=0x8010_0072 => unsafe {
             core::mem::transmute::<u32, ReturnCode>(code)
         },
@@ -969,7 +1135,6 @@ fn wide(value: &str) -> Vec<u16> {
     w.push(0);
     w
 }
-
 fn multi_wide(values: &[String]) -> Vec<u16> {
     let mut out = Vec::new();
     for v in values {
@@ -979,7 +1144,6 @@ fn multi_wide(values: &[String]) -> Vec<u16> {
     out.push(0);
     out
 }
-
 fn parse_multi_wide(buffer: &[u16]) -> Vec<String> {
     let mut out = Vec::new();
     let mut start = 0usize;
@@ -997,7 +1161,6 @@ fn parse_multi_wide(buffer: &[u16]) -> Vec<String> {
     }
     out
 }
-
 fn reader_state_w(state: &ReaderState, reader: &[u16]) -> SCARD_READERSTATEW {
     SCARD_READERSTATEW {
         szReader: PCWSTR(reader.as_ptr()),
@@ -1008,7 +1171,6 @@ fn reader_state_w(state: &ReaderState, reader: &[u16]) -> SCARD_READERSTATEW {
         rgbAtr: state.common.atr,
     }
 }
-
 fn reader_states_from_native(states: Vec<SCARD_READERSTATEW>) -> Vec<ReaderStateCommonCall> {
     states
         .into_iter()
@@ -1036,7 +1198,7 @@ fn unsupported(ioctl: ScardIoCtlCode, call: ScardCall) -> Box<dyn rpce::Encode> 
         ScardCall::GetReaderIconCall(_) => Box::new(GetReaderIconReturn::new(code, Vec::new())),
         ScardCall::EstablishContextCall(_) => Box::new(EstablishContextReturn::new(code, ScardContext::from_native(0))),
         ScardCall::ListReaderGroupsCall(_) | ScardCall::ListReadersCall(_) => {
-            Box::new(ListReadersReturn::new(code, Vec::new()))
+            Box::new(ListReadersReturn::new(code, Vec::new(), list_cs(ioctl)))
         }
         ScardCall::GetStatusChangeCall(_) => Box::new(GetStatusChangeReturn::new(code, Vec::new())),
         ScardCall::ConnectCall(_) => Box::new(ConnectReturn::new(
@@ -1057,40 +1219,5 @@ fn unsupported(ioctl: ScardIoCtlCode, call: ScardCall) -> Box<dyn rpce::Encode> 
         )),
         ScardCall::StateCall(_) => Box::new(StateReturn::new(code, CardState::Unknown, undef, Vec::new())),
         _ => Box::new(LongReturn::new(code)),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn map_success_and_no_readers() {
-        assert_eq!(map_status(0), ReturnCode::Success);
-        assert_eq!(map_status(0x8010_002E_u32 as i32), ReturnCode::NoReadersAvailable);
-    }
-
-    #[test]
-    fn multi_wide_roundtrip() {
-        let enc = multi_wide(&["A".into(), "B".into()]);
-        assert_eq!(parse_multi_wide(&enc), vec!["A".to_owned(), "B".to_owned()]);
-    }
-
-    #[test]
-    fn native_lookup() {
-        let mut s = ScardSession::new();
-        let ctx = 0x1111usize;
-        let card = 0x2222usize;
-        s.contexts.insert(ctx, ());
-        s.cards.insert(card, ctx);
-        assert_eq!(s.ctx(ScardContext::from_native(ctx)).unwrap(), ctx);
-        let h = ScardHandle::from_native(ScardContext::from_native(ctx), card);
-        assert_eq!(s.card(&h).unwrap(), (ctx, card));
-    }
-
-    #[test]
-    fn status_a_ansi() {
-        assert_eq!(status_cs(ScardIoCtlCode::StatusA), CharacterSet::Ansi);
-        assert_eq!(status_cs(ScardIoCtlCode::StatusW), CharacterSet::Unicode);
     }
 }

--- a/crates/ironrdp-rdpdr-native/src/windows/scard/mod.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/scard/mod.rs
@@ -1,42 +1,205 @@
-//! Stub Windows smartcard session for RDPDR device ID 0.
+//! Windows WinSCard core backend for MS-RDPESC Device Control IRPs.
 //!
-//! Completes every decoded MS-RDPESC call with the IOCTL-appropriate return
-//! PDU and `SCARD_E_UNSUPPORTED_FEATURE`, so peers never hang or decode the
-//! wrong structure while the real WinSCard backend lands.
+//! ANSI (`*A`) IOCTLs are decoded to `String`, upgraded to UTF-16, and run through
+//! WinSCard `*W` APIs. StatusA replies keep ANSI charset on the wire.
+//! Extended IOCTLs stay typed `SCARD_E_UNSUPPORTED_FEATURE` (follow-up PR).
+
+use core::sync::atomic::{AtomicBool, Ordering};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::thread;
 
 use ironrdp_pdu::PduResult;
 use ironrdp_pdu::utils::CharacterSet;
 use ironrdp_rdpdr::pdu::RdpdrPdu;
 use ironrdp_rdpdr::pdu::efs::{DeviceControlRequest, DeviceControlResponse, NtStatus};
 use ironrdp_rdpdr::pdu::esc::{
-    CardProtocol, CardState, ConnectReturn, ControlReturn, EstablishContextReturn, GetAttribReturn,
-    GetDeviceTypeIdReturn, GetReaderIconReturn, GetStatusChangeReturn, GetTransmitCountReturn, ListReadersReturn,
-    LongReturn, ReadCacheReturn, ReconnectReturn, ReturnCode, ScardCall, ScardContext, ScardHandle, ScardIoCtlCode,
-    StateReturn, StatusReturn, TransmitReturn, rpce,
+    CardProtocol, CardState, CardStateFlags, ConnectCall, ConnectReturn, ContextCall, ControlReturn,
+    EstablishContextCall, EstablishContextReturn, GetAttribReturn, GetDeviceTypeIdReturn, GetReaderIconReturn,
+    GetStatusChangeCall, GetStatusChangeReturn, GetTransmitCountReturn, HCardAndDispositionCall, ListReaderGroupsCall,
+    ListReadersCall, ListReadersReturn, LongReturn, ReadCacheReturn, ReaderState, ReaderStateCommonCall, ReconnectCall,
+    ReconnectReturn, ReturnCode, SCardIORequest, ScardCall, ScardContext, ScardHandle, ScardIoCtlCode, Scope,
+    StateCall, StateReturn, StatusCall, StatusReturn, TransmitCall, TransmitReturn, rpce,
 };
 use ironrdp_svc::SvcMessage;
+use tracing::warn;
+use windows::Win32::Foundation::{HANDLE, WAIT_OBJECT_0, WAIT_TIMEOUT};
+use windows::Win32::Security::Credentials::{
+    SCARD_IO_REQUEST, SCARD_READERSTATEW, SCARD_SCOPE, SCARD_SCOPE_SYSTEM, SCARD_SCOPE_USER, SCARD_STATE,
+    SCardAccessStartedEvent, SCardBeginTransaction, SCardCancel, SCardConnectW, SCardDisconnect, SCardEndTransaction,
+    SCardEstablishContext, SCardGetStatusChangeW, SCardIsValidContext, SCardListReaderGroupsW, SCardListReadersW,
+    SCardReconnect, SCardReleaseContext, SCardReleaseStartedEvent, SCardStatusW, SCardTransmit,
+};
+use windows::Win32::System::Threading::WaitForSingleObject;
+use windows::core::{PCWSTR, PWSTR};
 
-/// Per-connection smartcard state for RDPDR device ID 0.
-///
-/// This stub holds no native WinSCard resources.
-/// It provides the `new`, `reset`, `poll`, and `handle_call` hooks expected by [`super::backend::WindowsRdpdrBackend`].
-/// `reset` clears queued messages, and `poll` drains them for deferred completions.
-#[derive(Debug, Default)]
+const MAX_DEFERRED: usize = 32;
+const MAX_ATR: usize = 32;
+const SCARD_SCOPE_TERMINAL: SCARD_SCOPE = SCARD_SCOPE(1);
+
+/// Per-connection WinSCard state for RDPDR smartcard device ID 0.
+/// Wire handles carry native bytes (4/8) matching mstscax.
+#[derive(Debug)]
 pub(super) struct ScardSession {
-    messages: Vec<SvcMessage>,
+    contexts: HashMap<usize, ()>,
+    cards: HashMap<usize, usize>,
+    deferred: DeferredOps,
+    /// Process-wide started-event; never CloseHandle — pair with SCardReleaseStartedEvent.
+    access_event: Option<isize>,
+    access_refs: u32,
+}
+
+#[derive(Debug)]
+struct DeferredOps {
+    next_id: u64,
+    epoch: u64,
+    ops: HashMap<u64, PendingOp>,
+    completions: Arc<Mutex<Vec<DeferredCompletion>>>,
+}
+
+#[derive(Debug)]
+struct PendingOp {
+    context_id: usize,
+    cancel: Arc<AtomicBool>,
+    worker: thread::JoinHandle<()>,
+}
+
+#[derive(Debug)]
+struct DeferredCompletion {
+    id: u64,
+    epoch: u64,
+    outcome: Outcome,
+}
+
+#[derive(Debug)]
+enum Outcome {
+    Message(SvcMessage),
+    Connect {
+        req: DeviceControlRequest<ScardIoCtlCode>,
+        context: ScardContext,
+        code: ReturnCode,
+        native_handle: usize,
+        active_protocol: CardProtocol,
+    },
+    Disconnect {
+        req: DeviceControlRequest<ScardIoCtlCode>,
+        card: usize,
+        code: ReturnCode,
+    },
 }
 
 impl ScardSession {
     pub(super) fn new() -> Self {
-        Self::default()
+        Self {
+            contexts: HashMap::new(),
+            cards: HashMap::new(),
+            deferred: DeferredOps::new(),
+            access_event: None,
+            access_refs: 0,
+        }
     }
 
     pub(super) fn reset(&mut self) {
-        self.messages.clear();
+        self.deferred.reset();
+        for h in self.cards.keys().copied() {
+            // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+            let _ = unsafe { SCardDisconnect(h, 0) };
+        }
+        self.cards.clear();
+        for c in self.contexts.keys().copied() {
+            // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+            let _ = unsafe { SCardReleaseContext(c) };
+        }
+        self.contexts.clear();
+        while self.access_refs > 0 {
+            // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+            unsafe { SCardReleaseStartedEvent() };
+            self.access_refs -= 1;
+        }
+        self.access_event = None;
     }
 
     pub(super) fn poll(&mut self) -> Vec<SvcMessage> {
-        std::mem::take(&mut self.messages)
+        self.deferred.poll().into_iter().map(|o| self.apply(o)).collect()
+    }
+
+    fn apply(&mut self, outcome: Outcome) -> SvcMessage {
+        match outcome {
+            Outcome::Message(m) => m,
+            Outcome::Connect {
+                req,
+                context,
+                code,
+                native_handle,
+                active_protocol,
+            } => {
+                if code != ReturnCode::Success {
+                    return complete_connect(req, code, ScardHandle::from_native(context, 0), active_protocol);
+                }
+                let ctx = context.native();
+                if !self.contexts.contains_key(&ctx) {
+                    // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+                    let _ = unsafe { SCardDisconnect(native_handle, 0) };
+                    return complete_connect(
+                        req,
+                        ReturnCode::InvalidHandle,
+                        ScardHandle::from_native(context, 0),
+                        CardProtocol::SCARD_PROTOCOL_UNDEFINED,
+                    );
+                }
+                self.cards.insert(native_handle, ctx);
+                complete_connect(
+                    req,
+                    ReturnCode::Success,
+                    ScardHandle::from_native(context, native_handle),
+                    active_protocol,
+                )
+            }
+            Outcome::Disconnect { req, card, code } => {
+                if code == ReturnCode::Success {
+                    self.cards.remove(&card);
+                }
+                complete_long(req, code)
+            }
+        }
+    }
+
+    fn defer<F, E>(
+        &mut self,
+        context_id: usize,
+        name: &str,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+        work: F,
+        on_err: E,
+    ) -> PduResult<Vec<SvcMessage>>
+    where
+        F: FnOnce(DeviceControlRequest<ScardIoCtlCode>, Arc<AtomicBool>) -> Outcome + Send + 'static,
+        E: FnOnce(DeviceControlRequest<ScardIoCtlCode>, ReturnCode) -> SvcMessage,
+    {
+        if self.deferred.ops.len() >= MAX_DEFERRED {
+            return Ok(vec![on_err(req, ReturnCode::NoMemory)]);
+        }
+        let id = self.deferred.alloc_id();
+        let cancel = Arc::new(AtomicBool::new(false));
+        let completions = Arc::clone(&self.deferred.completions);
+        let epoch = self.deferred.epoch;
+        let worker_cancel = Arc::clone(&cancel);
+        let req_err = req.clone();
+        let worker = match thread::Builder::new().name(name.into()).spawn(move || {
+            push(completions, id, epoch, work(req, worker_cancel));
+        }) {
+            Ok(h) => h,
+            Err(_) => return Ok(vec![on_err(req_err, ReturnCode::InternalError)]),
+        };
+        self.deferred.ops.insert(
+            id,
+            PendingOp {
+                context_id,
+                cancel,
+                worker,
+            },
+        );
+        Ok(Vec::new())
     }
 
     pub(super) fn handle_call(
@@ -44,244 +207,890 @@ impl ScardSession {
         req: DeviceControlRequest<ScardIoCtlCode>,
         call: ScardCall,
     ) -> PduResult<Vec<SvcMessage>> {
-        let output = stub_output(req.io_control_code, call);
-        self.messages.push(complete_rpce(req, output));
-        Ok(self.poll())
+        let ioctl = req.io_control_code;
+        // MS-RDPESC 3.1.4.46: unused; Success so servers never hang.
+        if ioctl == ScardIoCtlCode::ReleaseTartedEvent {
+            return Ok(vec![complete_long(req, ReturnCode::Success)]);
+        }
+        match call {
+            ScardCall::AccessStartedEventCall(_) => self.access_started(req),
+            ScardCall::EstablishContextCall(c) => Ok(vec![self.establish_context(req, c)]),
+            ScardCall::ListReaderGroupsCall(c) => Ok(vec![self.list_groups(req, c)]),
+            ScardCall::ListReadersCall(c) => Ok(vec![self.list_readers(req, c)]),
+            ScardCall::GetStatusChangeCall(c) => self.get_status_change(req, c),
+            ScardCall::ConnectCall(c) => self.connect(req, c),
+            ScardCall::ReconnectCall(c) => self.reconnect(req, c),
+            ScardCall::HCardAndDispositionCall(c) => self.hcard(req, ioctl, c),
+            ScardCall::TransmitCall(c) => self.transmit(req, c),
+            ScardCall::StatusCall(c) => self.status(req, ioctl, c),
+            ScardCall::StateCall(c) => self.state(req, c),
+            ScardCall::ContextCall(c) => Ok(vec![self.context_call(req, ioctl, c)]),
+            // PR4 leftovers: typed empty returns.
+            other => Ok(vec![complete_rpce(req, unsupported(ioctl, other))]),
+        }
+    }
+
+    fn ctx(&self, c: ScardContext) -> Result<usize, ReturnCode> {
+        let n = c.native();
+        self.contexts
+            .contains_key(&n)
+            .then_some(n)
+            .ok_or(ReturnCode::InvalidHandle)
+    }
+
+    fn card(&self, h: &ScardHandle) -> Result<(usize, usize), ReturnCode> {
+        let card = h.native();
+        let ctx = *self.cards.get(&card).ok_or(ReturnCode::InvalidHandle)?;
+        if ctx != h.context().native() {
+            return Err(ReturnCode::InvalidHandle);
+        }
+        Ok((ctx, card))
+    }
+
+    fn access_started(&mut self, req: DeviceControlRequest<ScardIoCtlCode>) -> PduResult<Vec<SvcMessage>> {
+        let raw = match self.access_event {
+            Some(r) => r,
+            // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+            None => match unsafe { SCardAccessStartedEvent() } {
+                Ok(h) if !h.is_invalid() => {
+                    let r = h.0 as isize;
+                    self.access_event = Some(r);
+                    self.access_refs = 1;
+                    r
+                }
+                _ => return Ok(vec![complete_long(req, ReturnCode::Success)]),
+            },
+        };
+        // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+        if unsafe { WaitForSingleObject(HANDLE(raw as *mut _), 0) } == WAIT_OBJECT_0 {
+            return Ok(vec![complete_long(req, ReturnCode::Success)]);
+        }
+        self.defer(
+            0,
+            "ironrdp-scard-access",
+            req,
+            move |req, cancel| {
+                let code = loop {
+                    if cancel.load(Ordering::Acquire) {
+                        break ReturnCode::Cancelled;
+                    }
+                    // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+                    let w = unsafe { WaitForSingleObject(HANDLE(raw as *mut _), 100) };
+                    if w == WAIT_OBJECT_0 || w != WAIT_TIMEOUT {
+                        break ReturnCode::Success;
+                    }
+                };
+                Outcome::Message(complete_long(req, code))
+            },
+            complete_long,
+        )
+    }
+
+    fn establish_context(
+        &mut self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+        call: EstablishContextCall,
+    ) -> SvcMessage {
+        let scope = match call.scope {
+            Scope::User => SCARD_SCOPE_USER,
+            Scope::Terminal => SCARD_SCOPE_TERMINAL,
+            Scope::System => SCARD_SCOPE_SYSTEM,
+        };
+        let mut native = 0usize;
+        // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+        let code = map_status(unsafe { SCardEstablishContext(scope, None, None, &mut native) });
+        if code != ReturnCode::Success {
+            return complete_establish(req, code, ScardContext::from_native(0));
+        }
+        self.contexts.insert(native, ());
+        complete_establish(req, ReturnCode::Success, ScardContext::from_native(native))
+    }
+
+    fn list_groups(&self, req: DeviceControlRequest<ScardIoCtlCode>, call: ListReaderGroupsCall) -> SvcMessage {
+        match self.ctx(call.context).and_then(list_groups_w) {
+            Ok(v) => complete_list(req, ReturnCode::Success, v),
+            Err(c) => complete_list(req, c, Vec::new()),
+        }
+    }
+
+    fn list_readers(&self, req: DeviceControlRequest<ScardIoCtlCode>, call: ListReadersCall) -> SvcMessage {
+        match self.ctx(call.context).and_then(|n| list_readers_w(n, &call.groups)) {
+            Ok(v) => complete_list(req, ReturnCode::Success, v),
+            Err(c) => complete_list(req, c, Vec::new()),
+        }
+    }
+
+    fn get_status_change(
+        &mut self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+        call: GetStatusChangeCall,
+    ) -> PduResult<Vec<SvcMessage>> {
+        let native = match self.ctx(call.context) {
+            Ok(n) => n,
+            Err(c) => return Ok(vec![complete_gsc(req, c, Vec::new())]),
+        };
+        let ctx_id = call.context.native();
+        self.defer(
+            ctx_id,
+            "ironrdp-scard-gsc",
+            req,
+            move |req, cancel| {
+                if cancel.load(Ordering::Acquire) {
+                    return Outcome::Message(complete_gsc(req, ReturnCode::Cancelled, Vec::new()));
+                }
+                let bufs: Vec<Vec<u16>> = call.states.iter().map(|s| wide(&s.reader)).collect();
+                let mut states: Vec<SCARD_READERSTATEW> = call
+                    .states
+                    .iter()
+                    .zip(bufs.iter())
+                    .map(|(s, r)| reader_state_w(s, r))
+                    .collect();
+                let status =
+                    // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+                    unsafe { SCardGetStatusChangeW(native, call.timeout, states.as_mut_ptr(), states.len() as u32) };
+                let code = if cancel.load(Ordering::Acquire) {
+                    ReturnCode::Cancelled
+                } else {
+                    map_status(status)
+                };
+                let out = if matches!(code, ReturnCode::Success | ReturnCode::Timeout) {
+                    reader_states_from_native(states)
+                } else {
+                    Vec::new()
+                };
+                Outcome::Message(complete_gsc(req, code, out))
+            },
+            |req, c| complete_gsc(req, c, Vec::new()),
+        )
+    }
+
+    fn connect(&mut self, req: DeviceControlRequest<ScardIoCtlCode>, call: ConnectCall) -> PduResult<Vec<SvcMessage>> {
+        let native_ctx = match self.ctx(call.common.context) {
+            Ok(n) => n,
+            Err(c) => {
+                return Ok(vec![complete_connect(
+                    req,
+                    c,
+                    ScardHandle::from_native(call.common.context, 0),
+                    CardProtocol::SCARD_PROTOCOL_UNDEFINED,
+                )]);
+            }
+        };
+        let context = call.common.context;
+        self.defer(
+            context.native(),
+            "ironrdp-scard-connect",
+            req,
+            move |req, _| {
+                let reader = wide(&call.reader);
+                let mut card = 0usize;
+                let mut active = 0u32;
+                // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+                let status = unsafe {
+                    SCardConnectW(
+                        native_ctx,
+                        PCWSTR(reader.as_ptr()),
+                        call.common.share_mode,
+                        call.common.preferred_protocols.bits(),
+                        &mut card,
+                        &mut active,
+                    )
+                };
+                Outcome::Connect {
+                    req,
+                    context: call.common.context,
+                    code: map_status(status),
+                    native_handle: card,
+                    active_protocol: CardProtocol::from_bits_retain(active),
+                }
+            },
+            move |req, c| {
+                complete_connect(
+                    req,
+                    c,
+                    ScardHandle::from_native(context, 0),
+                    CardProtocol::SCARD_PROTOCOL_UNDEFINED,
+                )
+            },
+        )
+    }
+
+    fn reconnect(
+        &mut self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+        call: ReconnectCall,
+    ) -> PduResult<Vec<SvcMessage>> {
+        let (ctx_id, handle) = match self.card(&call.handle) {
+            Ok(v) => v,
+            Err(c) => return Ok(vec![complete_reconnect(req, c, CardProtocol::SCARD_PROTOCOL_UNDEFINED)]),
+        };
+        self.defer(
+            ctx_id,
+            "ironrdp-scard-reconnect",
+            req,
+            move |req, _| {
+                let mut active = 0u32;
+                // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+                let status = unsafe {
+                    SCardReconnect(
+                        handle,
+                        call.share_mode,
+                        call.preferred_protocols.bits(),
+                        call.initialization,
+                        Some(&mut active),
+                    )
+                };
+                Outcome::Message(complete_reconnect(
+                    req,
+                    map_status(status),
+                    CardProtocol::from_bits_retain(active),
+                ))
+            },
+            |req, c| complete_reconnect(req, c, CardProtocol::SCARD_PROTOCOL_UNDEFINED),
+        )
+    }
+
+    fn hcard(
+        &mut self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+        ioctl: ScardIoCtlCode,
+        call: HCardAndDispositionCall,
+    ) -> PduResult<Vec<SvcMessage>> {
+        let (ctx_id, handle) = match self.card(&call.handle) {
+            Ok(v) => v,
+            Err(c) => return Ok(vec![complete_long(req, c)]),
+        };
+        let name = match ioctl {
+            ScardIoCtlCode::BeginTransaction => "ironrdp-scard-begin",
+            ScardIoCtlCode::EndTransaction => "ironrdp-scard-end",
+            ScardIoCtlCode::Disconnect => "ironrdp-scard-disc",
+            _ => return Ok(vec![complete_long(req, ReturnCode::UnsupportedFeature)]),
+        };
+        let disp = call.disposition;
+        self.defer(
+            ctx_id,
+            name,
+            req,
+            move |req, _| match ioctl {
+                ScardIoCtlCode::BeginTransaction => {
+                    // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+                    Outcome::Message(complete_long(req, map_status(unsafe { SCardBeginTransaction(handle) })))
+                }
+                ScardIoCtlCode::EndTransaction => Outcome::Message(complete_long(
+                    req,
+                    // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+                    map_status(unsafe { SCardEndTransaction(handle, disp) }),
+                )),
+                ScardIoCtlCode::Disconnect => Outcome::Disconnect {
+                    req,
+                    card: handle,
+                    // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+                    code: map_status(unsafe { SCardDisconnect(handle, disp) }),
+                },
+                _ => Outcome::Message(complete_long(req, ReturnCode::UnsupportedFeature)),
+            },
+            complete_long,
+        )
+    }
+
+    fn transmit(
+        &mut self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+        call: TransmitCall,
+    ) -> PduResult<Vec<SvcMessage>> {
+        let (ctx_id, handle) = match self.card(&call.handle) {
+            Ok(v) => v,
+            Err(c) => return Ok(vec![complete_transmit(req, c, None, Vec::new())]),
+        };
+        self.defer(
+            ctx_id,
+            "ironrdp-scard-xmit",
+            req,
+            move |req, _| {
+                let send_pci = SCARD_IO_REQUEST {
+                    dwProtocol: call.send_pci.protocol.bits(),
+                    cbPciLength: core::mem::size_of::<SCARD_IO_REQUEST>() as u32,
+                };
+                let mut recv_pci = call.recv_pci.as_ref().map(|p| SCARD_IO_REQUEST {
+                    dwProtocol: p.protocol.bits(),
+                    cbPciLength: core::mem::size_of::<SCARD_IO_REQUEST>() as u32,
+                });
+                let recv_len = if call.recv_buffer_is_null {
+                    0
+                } else {
+                    call.recv_length.max(2)
+                };
+                let mut buf = vec![0u8; recv_len as usize];
+                let mut len = recv_len;
+                // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+                let status = unsafe {
+                    SCardTransmit(
+                        handle,
+                        &send_pci,
+                        &call.send_buffer,
+                        recv_pci.as_mut().map(|p| p as *mut SCARD_IO_REQUEST),
+                        buf.as_mut_ptr(),
+                        &mut len,
+                    )
+                };
+                let code = map_status(status);
+                if code != ReturnCode::Success {
+                    return Outcome::Message(complete_transmit(req, code, None, Vec::new()));
+                }
+                buf.truncate(len as usize);
+                let out_pci = recv_pci.map(|p| SCardIORequest {
+                    protocol: CardProtocol::from_bits_retain(p.dwProtocol),
+                    extra_bytes_length: 0,
+                    extra_bytes: Vec::new(),
+                });
+                Outcome::Message(complete_transmit(req, ReturnCode::Success, out_pci, buf))
+            },
+            |req, c| complete_transmit(req, c, None, Vec::new()),
+        )
+    }
+
+    fn status(
+        &mut self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+        ioctl: ScardIoCtlCode,
+        call: StatusCall,
+    ) -> PduResult<Vec<SvcMessage>> {
+        let (ctx_id, handle) = match self.card(&call.handle) {
+            Ok(v) => v,
+            Err(c) => return Ok(vec![complete_status_err(req, c, ioctl)]),
+        };
+        self.defer(
+            ctx_id,
+            "ironrdp-scard-status",
+            req,
+            move |req, _| match card_status_w(handle) {
+                Ok((names, state, proto, atr, atr_len)) => Outcome::Message(complete_status(
+                    req,
+                    ReturnCode::Success,
+                    names,
+                    state,
+                    proto,
+                    atr,
+                    atr_len,
+                    status_cs(ioctl),
+                )),
+                Err(c) => Outcome::Message(complete_status_err(req, c, ioctl)),
+            },
+            move |req, c| complete_status_err(req, c, ioctl),
+        )
+    }
+
+    fn state(&mut self, req: DeviceControlRequest<ScardIoCtlCode>, call: StateCall) -> PduResult<Vec<SvcMessage>> {
+        let (ctx_id, handle) = match self.card(&call.handle) {
+            Ok(v) => v,
+            Err(c) => {
+                return Ok(vec![complete_state(
+                    req,
+                    c,
+                    CardState::Unknown,
+                    CardProtocol::SCARD_PROTOCOL_UNDEFINED,
+                    Vec::new(),
+                )]);
+            }
+        };
+        self.defer(
+            ctx_id,
+            "ironrdp-scard-state",
+            req,
+            move |req, _| match card_status_w(handle) {
+                Ok((_n, state, proto, atr, atr_len)) => {
+                    let atr = if call.atr_is_null {
+                        Vec::new()
+                    } else {
+                        atr[..atr_len as usize].to_vec()
+                    };
+                    Outcome::Message(complete_state(req, ReturnCode::Success, state, proto, atr))
+                }
+                Err(c) => Outcome::Message(complete_state(
+                    req,
+                    c,
+                    CardState::Unknown,
+                    CardProtocol::SCARD_PROTOCOL_UNDEFINED,
+                    Vec::new(),
+                )),
+            },
+            |req, c| {
+                complete_state(
+                    req,
+                    c,
+                    CardState::Unknown,
+                    CardProtocol::SCARD_PROTOCOL_UNDEFINED,
+                    Vec::new(),
+                )
+            },
+        )
+    }
+
+    fn context_call(
+        &mut self,
+        req: DeviceControlRequest<ScardIoCtlCode>,
+        ioctl: ScardIoCtlCode,
+        call: ContextCall,
+    ) -> SvcMessage {
+        match ioctl {
+            ScardIoCtlCode::ReleaseContext => self.release_context(req, call),
+            ScardIoCtlCode::IsValidContext => match self.ctx(call.context) {
+                // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+                Ok(n) => complete_long(req, map_status(unsafe { SCardIsValidContext(n) })),
+                Err(c) => complete_long(req, c),
+            },
+            ScardIoCtlCode::Cancel => match self.ctx(call.context) {
+                Ok(n) => {
+                    for op in self.deferred.ops.values() {
+                        if op.context_id == n {
+                            op.cancel.store(true, Ordering::Release);
+                        }
+                    }
+                    // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+                    complete_long(req, map_status(unsafe { SCardCancel(n) }))
+                }
+                Err(c) => complete_long(req, c),
+            },
+            _ => complete_long(req, ReturnCode::UnsupportedFeature),
+        }
+    }
+
+    fn release_context(&mut self, req: DeviceControlRequest<ScardIoCtlCode>, call: ContextCall) -> SvcMessage {
+        let native = match self.ctx(call.context) {
+            Ok(n) => n,
+            Err(c) => return complete_long(req, c),
+        };
+        let cards: Vec<usize> = self
+            .cards
+            .iter()
+            .filter_map(|(h, c)| (*c == native).then_some(*h))
+            .collect();
+        for h in cards {
+            if self.cards.remove(&h).is_some() {
+                // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+                let _ = unsafe { SCardDisconnect(h, 0) };
+            }
+        }
+        // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+        let code = map_status(unsafe { SCardReleaseContext(native) });
+        if code == ReturnCode::Success {
+            self.contexts.remove(&native);
+        }
+        complete_long(req, code)
     }
 }
 
-fn stub_output(io_control_code: ScardIoCtlCode, call: ScardCall) -> Box<dyn rpce::Encode> {
-    let code = ReturnCode::UnsupportedFeature;
-    let empty_context = ScardContext::new(0);
-    let empty_handle = ScardHandle::new(empty_context, 0);
-    let undefined = CardProtocol::SCARD_PROTOCOL_UNDEFINED;
-    // Status_Return.mszReaderNames encoding follows the A/W IOCTL form.
-    let status_charset = match io_control_code {
+impl Drop for ScardSession {
+    fn drop(&mut self) {
+        self.reset();
+    }
+}
+
+impl DeferredOps {
+    fn new() -> Self {
+        Self {
+            next_id: 1,
+            epoch: 0,
+            ops: HashMap::new(),
+            completions: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn alloc_id(&mut self) -> u64 {
+        let id = self.next_id;
+        self.next_id = self.next_id.wrapping_add(1).max(1);
+        id
+    }
+
+    fn poll(&mut self) -> Vec<Outcome> {
+        let mut ready = match self.completions.lock() {
+            Ok(mut g) => core::mem::take(&mut *g),
+            Err(p) => core::mem::take(&mut *p.into_inner()),
+        };
+        ready.retain(|c| c.epoch == self.epoch);
+        let mut out = Vec::with_capacity(ready.len());
+        for c in ready {
+            if let Some(op) = self.ops.remove(&c.id) {
+                let _ = op.worker.join();
+            }
+            out.push(c.outcome);
+        }
+        self.ops.retain(|_, op| !op.worker.is_finished());
+        out
+    }
+
+    fn reset(&mut self) {
+        self.epoch = self.epoch.wrapping_add(1);
+        let ops = core::mem::take(&mut self.ops);
+        for op in ops.values() {
+            op.cancel.store(true, Ordering::Release);
+            if op.context_id != 0 {
+                // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+                let _ = unsafe { SCardCancel(op.context_id) };
+            }
+        }
+        for op in ops.into_values() {
+            let _ = op.worker.join();
+        }
+        if let Ok(mut g) = self.completions.lock() {
+            g.clear();
+        }
+    }
+}
+
+fn push(completions: Arc<Mutex<Vec<DeferredCompletion>>>, id: u64, epoch: u64, outcome: Outcome) {
+    let c = DeferredCompletion { id, epoch, outcome };
+    match completions.lock() {
+        Ok(mut g) => g.push(c),
+        Err(p) => p.into_inner().push(c),
+    }
+}
+
+fn list_groups_w(context: usize) -> Result<Vec<String>, ReturnCode> {
+    // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+    list_multi_w(context, |ctx, ptr, len| unsafe {
+        SCardListReaderGroupsW(ctx, ptr, len)
+    })
+}
+
+fn list_readers_w(context: usize, groups: &[String]) -> Result<Vec<String>, ReturnCode> {
+    let groups_buf = (!groups.is_empty()).then(|| multi_wide(groups));
+    let groups_ptr = groups_buf
+        .as_ref()
+        .map(|b| PCWSTR(b.as_ptr()))
+        .unwrap_or(PCWSTR::null());
+    // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+    list_multi_w(context, |ctx, ptr, len| unsafe {
+        SCardListReadersW(ctx, groups_ptr, ptr, len)
+    })
+}
+
+fn list_multi_w<F>(context: usize, mut f: F) -> Result<Vec<String>, ReturnCode>
+where
+    F: FnMut(usize, Option<PWSTR>, &mut u32) -> i32,
+{
+    let mut needed = 0u32;
+    let probe = map_status(f(context, None, &mut needed));
+    if probe == ReturnCode::NoReadersAvailable || needed == 0 {
+        return Ok(Vec::new());
+    }
+    if probe != ReturnCode::Success && probe != ReturnCode::InsufficientBuffer {
+        return Err(probe);
+    }
+    let mut buf = vec![0u16; needed as usize];
+    let mut actual = needed;
+    let code = map_status(f(context, Some(PWSTR(buf.as_mut_ptr())), &mut actual));
+    if code == ReturnCode::NoReadersAvailable {
+        return Ok(Vec::new());
+    }
+    if code != ReturnCode::Success {
+        return Err(code);
+    }
+    Ok(parse_multi_wide(&buf[..actual as usize]))
+}
+
+type CardStatusW = (Vec<String>, CardState, CardProtocol, [u8; MAX_ATR], u32);
+
+fn card_status_w(handle: usize) -> Result<CardStatusW, ReturnCode> {
+    let mut name_len = 0u32;
+    let mut state = 0u32;
+    let mut protocol = 0u32;
+    let mut atr = [0u8; MAX_ATR];
+    let mut atr_len = atr.len() as u32;
+    // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+    let probe = map_status(unsafe {
+        SCardStatusW(
+            handle,
+            None,
+            Some(&mut name_len),
+            Some(&mut state),
+            Some(&mut protocol),
+            Some(atr.as_mut_ptr()),
+            Some(&mut atr_len),
+        )
+    });
+    if probe != ReturnCode::Success && probe != ReturnCode::InsufficientBuffer {
+        return Err(probe);
+    }
+    let mut names = Vec::new();
+    if name_len > 0 {
+        let mut name_buf = vec![0u16; name_len as usize];
+        atr_len = atr.len() as u32;
+        // SAFETY: WinSCard/kernel call; handles and buffers come from this session or prior successful WinSCard returns.
+        let code = map_status(unsafe {
+            SCardStatusW(
+                handle,
+                Some(PWSTR(name_buf.as_mut_ptr())),
+                Some(&mut name_len),
+                Some(&mut state),
+                Some(&mut protocol),
+                Some(atr.as_mut_ptr()),
+                Some(&mut atr_len),
+            )
+        });
+        if code != ReturnCode::Success {
+            return Err(code);
+        }
+        names = parse_multi_wide(&name_buf[..name_len as usize]);
+    }
+    let mut wire = [0u8; MAX_ATR];
+    let n = (atr_len as usize).min(MAX_ATR);
+    wire[..n].copy_from_slice(&atr[..n]);
+    let card_state = match state {
+        1 => CardState::Absent,
+        2 => CardState::Present,
+        3 => CardState::Swallowed,
+        4 => CardState::Powered,
+        5 => CardState::Negotiable,
+        6 => CardState::SpecificMode,
+        _ => CardState::Unknown,
+    };
+    Ok((
+        names,
+        card_state,
+        CardProtocol::from_bits_retain(protocol),
+        wire,
+        atr_len.min(MAX_ATR as u32),
+    ))
+}
+
+fn complete_rpce(req: DeviceControlRequest<ScardIoCtlCode>, output: Box<dyn rpce::Encode>) -> SvcMessage {
+    let (status, buf) = if output.size() <= req.output_buffer_length as usize {
+        (NtStatus::SUCCESS, Some(output))
+    } else {
+        (NtStatus::BUFFER_TOO_SMALL, None)
+    };
+    SvcMessage::from(RdpdrPdu::DeviceControlResponse(DeviceControlResponse::new(
+        req, status, buf,
+    )))
+}
+
+fn complete_long(req: DeviceControlRequest<ScardIoCtlCode>, code: ReturnCode) -> SvcMessage {
+    complete_rpce(req, Box::new(LongReturn::new(code)))
+}
+fn complete_establish(req: DeviceControlRequest<ScardIoCtlCode>, code: ReturnCode, ctx: ScardContext) -> SvcMessage {
+    complete_rpce(req, Box::new(EstablishContextReturn::new(code, ctx)))
+}
+fn complete_list(req: DeviceControlRequest<ScardIoCtlCode>, code: ReturnCode, v: Vec<String>) -> SvcMessage {
+    complete_rpce(req, Box::new(ListReadersReturn::new(code, v)))
+}
+fn complete_gsc(
+    req: DeviceControlRequest<ScardIoCtlCode>,
+    code: ReturnCode,
+    states: Vec<ReaderStateCommonCall>,
+) -> SvcMessage {
+    complete_rpce(req, Box::new(GetStatusChangeReturn::new(code, states)))
+}
+fn complete_connect(
+    req: DeviceControlRequest<ScardIoCtlCode>,
+    code: ReturnCode,
+    handle: ScardHandle,
+    proto: CardProtocol,
+) -> SvcMessage {
+    complete_rpce(req, Box::new(ConnectReturn::new(code, handle, proto)))
+}
+fn complete_transmit(
+    req: DeviceControlRequest<ScardIoCtlCode>,
+    code: ReturnCode,
+    pci: Option<SCardIORequest>,
+    data: Vec<u8>,
+) -> SvcMessage {
+    complete_rpce(req, Box::new(TransmitReturn::new(code, pci, data)))
+}
+#[allow(clippy::too_many_arguments)]
+fn complete_status(
+    req: DeviceControlRequest<ScardIoCtlCode>,
+    code: ReturnCode,
+    names: Vec<String>,
+    state: CardState,
+    proto: CardProtocol,
+    atr: [u8; MAX_ATR],
+    atr_len: u32,
+    cs: CharacterSet,
+) -> SvcMessage {
+    complete_rpce(
+        req,
+        Box::new(StatusReturn::new(code, names, state, proto, atr, atr_len, cs)),
+    )
+}
+fn complete_status_err(
+    req: DeviceControlRequest<ScardIoCtlCode>,
+    code: ReturnCode,
+    ioctl: ScardIoCtlCode,
+) -> SvcMessage {
+    complete_status(
+        req,
+        code,
+        Vec::new(),
+        CardState::Unknown,
+        CardProtocol::SCARD_PROTOCOL_UNDEFINED,
+        [0; MAX_ATR],
+        0,
+        status_cs(ioctl),
+    )
+}
+fn complete_reconnect(req: DeviceControlRequest<ScardIoCtlCode>, code: ReturnCode, proto: CardProtocol) -> SvcMessage {
+    complete_rpce(req, Box::new(ReconnectReturn::new(code, proto)))
+}
+fn complete_state(
+    req: DeviceControlRequest<ScardIoCtlCode>,
+    code: ReturnCode,
+    state: CardState,
+    proto: CardProtocol,
+    atr: Vec<u8>,
+) -> SvcMessage {
+    complete_rpce(req, Box::new(StateReturn::new(code, state, proto, atr)))
+}
+
+fn status_cs(ioctl: ScardIoCtlCode) -> CharacterSet {
+    match ioctl {
         ScardIoCtlCode::StatusA => CharacterSet::Ansi,
         _ => CharacterSet::Unicode,
-    };
+    }
+}
 
-    match call {
-        ScardCall::AccessStartedEventCall(_)
-        | ScardCall::HCardAndDispositionCall(_)
-        | ScardCall::SetAttribCall(_)
-        | ScardCall::ContextCall(_)
-        | ScardCall::WriteCacheCall(_)
-        | ScardCall::ContextAndStringCall(_)
-        | ScardCall::ContextAndTwoStringCall(_) => Box::new(LongReturn::new(code)),
-        // MS-RDPESC 3.1.4.46 marks SCARD_IOCTL_RELEASETARTEDEVENT unused with
-        // no output packet. The server still issued an IRP, so retire it with
-        // Long_Return rather than leaving the IRP unanswered.
-        ScardCall::Unsupported => Box::new(LongReturn::new(code)),
-        ScardCall::EstablishContextCall(_) => Box::new(EstablishContextReturn::new(code, empty_context)),
-        ScardCall::ListReaderGroupsCall(_) | ScardCall::ListReadersCall(_) => {
-            Box::new(ListReadersReturn::new(code, Vec::new()))
+fn map_status(status: i32) -> ReturnCode {
+    let code = status as u32;
+    match code {
+        0 => ReturnCode::Success,
+        // SAFETY: ReturnCode is #[repr(u32)]; every value in these ranges is a defined variant.
+        0x8010_0001..=0x8010_0034 | 0x8010_0065..=0x8010_0072 => unsafe {
+            core::mem::transmute::<u32, ReturnCode>(code)
+        },
+        other => {
+            warn!(status = other, "Unmapped WinSCard status; treating as unknown error");
+            ReturnCode::UnknownError
         }
-        ScardCall::GetStatusChangeCall(_) | ScardCall::LocateCardsCall(_) | ScardCall::LocateCardsByAtrCall(_) => {
+    }
+}
+
+fn wide(value: &str) -> Vec<u16> {
+    let mut w: Vec<u16> = value.encode_utf16().collect();
+    w.push(0);
+    w
+}
+
+fn multi_wide(values: &[String]) -> Vec<u16> {
+    let mut out = Vec::new();
+    for v in values {
+        out.extend(v.encode_utf16());
+        out.push(0);
+    }
+    out.push(0);
+    out
+}
+
+fn parse_multi_wide(buffer: &[u16]) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut start = 0usize;
+    while start < buffer.len() {
+        if buffer[start] == 0 {
+            break;
+        }
+        let end = buffer[start..]
+            .iter()
+            .position(|&c| c == 0)
+            .map(|r| start + r)
+            .unwrap_or(buffer.len());
+        out.push(String::from_utf16_lossy(&buffer[start..end]));
+        start = end + 1;
+    }
+    out
+}
+
+fn reader_state_w(state: &ReaderState, reader: &[u16]) -> SCARD_READERSTATEW {
+    SCARD_READERSTATEW {
+        szReader: PCWSTR(reader.as_ptr()),
+        pvUserData: core::ptr::null_mut(),
+        dwCurrentState: SCARD_STATE(state.common.current_state.bits()),
+        dwEventState: SCARD_STATE(state.common.event_state.bits()),
+        cbAtr: state.common.atr_length.min(36),
+        rgbAtr: state.common.atr,
+    }
+}
+
+fn reader_states_from_native(states: Vec<SCARD_READERSTATEW>) -> Vec<ReaderStateCommonCall> {
+    states
+        .into_iter()
+        .map(|s| ReaderStateCommonCall {
+            current_state: CardStateFlags::from_bits_retain(s.dwCurrentState.0),
+            event_state: CardStateFlags::from_bits_retain(s.dwEventState.0),
+            atr_length: s.cbAtr.min(36),
+            atr: s.rgbAtr,
+        })
+        .collect()
+}
+
+fn unsupported(ioctl: ScardIoCtlCode, call: ScardCall) -> Box<dyn rpce::Encode> {
+    let code = ReturnCode::UnsupportedFeature;
+    let undef = CardProtocol::SCARD_PROTOCOL_UNDEFINED;
+    match call {
+        ScardCall::LocateCardsCall(_) | ScardCall::LocateCardsByAtrCall(_) => {
             Box::new(GetStatusChangeReturn::new(code, Vec::new()))
         }
-        ScardCall::ConnectCall(_) => Box::new(ConnectReturn::new(code, empty_handle, undefined)),
-        ScardCall::ReconnectCall(_) => Box::new(ReconnectReturn::new(code, undefined)),
-        ScardCall::TransmitCall(_) => Box::new(TransmitReturn::new(code, None, Vec::new())),
-        ScardCall::StatusCall(_) => Box::new(StatusReturn::new(
-            code,
-            Vec::new(),
-            CardState::Unknown,
-            undefined,
-            [0u8; 32],
-            0,
-            status_charset,
-        )),
-        ScardCall::StateCall(_) => Box::new(StateReturn::new(code, CardState::Unknown, undefined, Vec::new())),
         ScardCall::ControlCall(_) => Box::new(ControlReturn::new(code, Vec::new())),
         ScardCall::GetAttribCall(_) => Box::new(GetAttribReturn::new(code, Vec::new())),
         ScardCall::GetTransmitCountCall(_) => Box::new(GetTransmitCountReturn::new(code, 0)),
         ScardCall::GetDeviceTypeIdCall(_) => Box::new(GetDeviceTypeIdReturn::new(code, 0)),
         ScardCall::ReadCacheCall(_) => Box::new(ReadCacheReturn::new(code, Vec::new())),
         ScardCall::GetReaderIconCall(_) => Box::new(GetReaderIconReturn::new(code, Vec::new())),
+        ScardCall::EstablishContextCall(_) => Box::new(EstablishContextReturn::new(code, ScardContext::from_native(0))),
+        ScardCall::ListReaderGroupsCall(_) | ScardCall::ListReadersCall(_) => {
+            Box::new(ListReadersReturn::new(code, Vec::new()))
+        }
+        ScardCall::GetStatusChangeCall(_) => Box::new(GetStatusChangeReturn::new(code, Vec::new())),
+        ScardCall::ConnectCall(_) => Box::new(ConnectReturn::new(
+            code,
+            ScardHandle::from_native(ScardContext::from_native(0), 0),
+            undef,
+        )),
+        ScardCall::ReconnectCall(_) => Box::new(ReconnectReturn::new(code, undef)),
+        ScardCall::TransmitCall(_) => Box::new(TransmitReturn::new(code, None, Vec::new())),
+        ScardCall::StatusCall(_) => Box::new(StatusReturn::new(
+            code,
+            Vec::new(),
+            CardState::Unknown,
+            undef,
+            [0u8; 32],
+            0,
+            status_cs(ioctl),
+        )),
+        ScardCall::StateCall(_) => Box::new(StateReturn::new(code, CardState::Unknown, undef, Vec::new())),
+        _ => Box::new(LongReturn::new(code)),
     }
-}
-
-fn complete_rpce(req: DeviceControlRequest<ScardIoCtlCode>, output: Box<dyn rpce::Encode>) -> SvcMessage {
-    let (status, output_buffer) = if output.size() <= req.output_buffer_length as usize {
-        (NtStatus::SUCCESS, Some(output))
-    } else {
-        (NtStatus::BUFFER_TOO_SMALL, None)
-    };
-
-    SvcMessage::from(RdpdrPdu::DeviceControlResponse(DeviceControlResponse::new(
-        req,
-        status,
-        output_buffer,
-    )))
 }
 
 #[cfg(test)]
 mod tests {
-    use ironrdp_rdpdr::pdu::efs::{DeviceIoRequest, MajorFunction, MinorFunction};
-    use ironrdp_rdpdr::pdu::esc::{EstablishContextCall, ScardAccessStartedEventCall, Scope};
-
     use super::*;
 
-    fn establish_context_call() -> ScardCall {
-        ScardCall::EstablishContextCall(EstablishContextCall { scope: Scope::User })
-    }
-
-    fn control_req(code: ScardIoCtlCode, device_id: u32, completion_id: u32) -> DeviceControlRequest<ScardIoCtlCode> {
-        DeviceControlRequest {
-            header: DeviceIoRequest {
-                device_id,
-                file_id: 0,
-                completion_id,
-                major_function: MajorFunction::DeviceControl,
-                minor_function: MinorFunction::from(0),
-            },
-            output_buffer_length: 2048,
-            input_buffer_length: 0,
-            io_control_code: code,
-        }
+    #[test]
+    fn map_success_and_no_readers() {
+        assert_eq!(map_status(0), ReturnCode::Success);
+        assert_eq!(map_status(0x8010_002E_u32 as i32), ReturnCode::NoReadersAvailable);
     }
 
     #[test]
-    fn establish_context_maps_to_establish_context_return() {
-        let output = stub_output(ScardIoCtlCode::EstablishContext, establish_context_call());
-        assert_eq!(output.name(), "EstablishContext_Return");
+    fn multi_wide_roundtrip() {
+        let enc = multi_wide(&["A".into(), "B".into()]);
+        assert_eq!(parse_multi_wide(&enc), vec!["A".to_owned(), "B".to_owned()]);
     }
 
     #[test]
-    fn long_return_calls_map_to_long_return() {
-        let output = stub_output(
-            ScardIoCtlCode::AccessStartedEvent,
-            ScardCall::AccessStartedEventCall(ScardAccessStartedEventCall),
-        );
-        assert_eq!(output.name(), "Long_Return");
+    fn native_lookup() {
+        let mut s = ScardSession::new();
+        let ctx = 0x1111usize;
+        let card = 0x2222usize;
+        s.contexts.insert(ctx, ());
+        s.cards.insert(card, ctx);
+        assert_eq!(s.ctx(ScardContext::from_native(ctx)).unwrap(), ctx);
+        let h = ScardHandle::from_native(ScardContext::from_native(ctx), card);
+        assert_eq!(s.card(&h).unwrap(), (ctx, card));
     }
 
     #[test]
-    fn unsupported_release_tarted_event_maps_to_long_return() {
-        let output = stub_output(ScardIoCtlCode::ReleaseTartedEvent, ScardCall::Unsupported);
-        assert_eq!(output.name(), "Long_Return");
-    }
-
-    #[test]
-    fn connect_and_list_readers_map_to_table_return_names() {
-        // Call payloads are unused by the stub mapping; only the enum arm matters.
-        let connect = stub_output(
-            ScardIoCtlCode::ConnectW,
-            ScardCall::ConnectCall(ironrdp_rdpdr::pdu::esc::ConnectCall {
-                reader: String::new(),
-                common: ironrdp_rdpdr::pdu::esc::ConnectCommon {
-                    context: ScardContext::new(0),
-                    share_mode: 0,
-                    preferred_protocols: CardProtocol::SCARD_PROTOCOL_UNDEFINED,
-                },
-            }),
-        );
-        assert_eq!(connect.name(), "Connect_Return");
-
-        let readers = stub_output(
-            ScardIoCtlCode::ListReadersW,
-            ScardCall::ListReadersCall(ironrdp_rdpdr::pdu::esc::ListReadersCall {
-                context: ScardContext::new(0),
-                groups_ptr_length: 0,
-                groups_length: 0,
-                groups_ptr: 0,
-                groups: Vec::new(),
-                readers_is_null: true,
-                readers_size: 0,
-            }),
-        );
-        assert_eq!(readers.name(), "ListReaders_Return");
-    }
-
-    #[test]
-    fn status_a_and_status_w_select_matching_charset_encoding() {
-        fn encode(output: &dyn rpce::Encode) -> Vec<u8> {
-            ironrdp_core::encode_vec(output).expect("encode Status_Return")
-        }
-
-        let status_call = ScardCall::StatusCall(ironrdp_rdpdr::pdu::esc::StatusCall {
-            handle: ScardHandle::new(ScardContext::new(0), 0),
-            reader_names_is_null: true,
-            reader_length: 0,
-            atr_length: 0,
-        });
-        let stub_a = stub_output(ScardIoCtlCode::StatusA, status_call.clone());
-        let stub_w = stub_output(ScardIoCtlCode::StatusW, status_call);
-        assert_eq!(stub_a.name(), "Status_Return");
-        assert_eq!(stub_w.name(), "Status_Return");
-
-        let expected_a = StatusReturn::new(
-            ReturnCode::UnsupportedFeature,
-            Vec::new(),
-            CardState::Unknown,
-            CardProtocol::SCARD_PROTOCOL_UNDEFINED,
-            [0u8; 32],
-            0,
-            CharacterSet::Ansi,
-        );
-        let expected_w = StatusReturn::new(
-            ReturnCode::UnsupportedFeature,
-            Vec::new(),
-            CardState::Unknown,
-            CardProtocol::SCARD_PROTOCOL_UNDEFINED,
-            [0u8; 32],
-            0,
-            CharacterSet::Unicode,
-        );
-
-        assert_eq!(encode(stub_a.as_ref()), encode(&expected_a), "StatusA -> Ansi");
-        assert_eq!(encode(stub_w.as_ref()), encode(&expected_w), "StatusW -> Unicode");
-        assert_ne!(
-            encode(&expected_a),
-            encode(&expected_w),
-            "A/W empty multistring encodings must differ"
-        );
-    }
-
-    #[test]
-    fn handle_call_echoes_device_and_completion_ids() {
-        let mut session = ScardSession::new();
-        let req = control_req(ScardIoCtlCode::EstablishContext, 0, 42);
-        let messages = session
-            .handle_call(req.clone(), establish_context_call())
-            .expect("stub must complete");
-        assert_eq!(messages.len(), 1);
-
-        // Rebuild the same response shape and compare encoded wire bytes.
-        let expected = complete_rpce(
-            req,
-            Box::new(EstablishContextReturn::new(
-                ReturnCode::UnsupportedFeature,
-                ScardContext::new(0),
-            )),
-        );
-        let actual = messages[0].encode_unframed_pdu().expect("encode actual");
-        let expected = expected.encode_unframed_pdu().expect("encode expected");
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn handle_call_respects_output_buffer_length() {
-        let mut session = ScardSession::new();
-        let req = control_req(ScardIoCtlCode::EstablishContext, 0, 42);
-        let messages = session
-            .handle_call(
-                DeviceControlRequest {
-                    output_buffer_length: 0,
-                    ..req.clone()
-                },
-                establish_context_call(),
-            )
-            .expect("stub must complete");
-
-        let expected = SvcMessage::from(RdpdrPdu::DeviceControlResponse(DeviceControlResponse::new(
-            req,
-            NtStatus::BUFFER_TOO_SMALL,
-            None,
-        )));
-        let actual = messages[0].encode_unframed_pdu().expect("encode actual");
-        let expected = expected.encode_unframed_pdu().expect("encode expected");
-        assert_eq!(actual, expected);
+    fn status_a_ansi() {
+        assert_eq!(status_cs(ScardIoCtlCode::StatusA), CharacterSet::Ansi);
+        assert_eq!(status_cs(ScardIoCtlCode::StatusW), CharacterSet::Unicode);
     }
 }

--- a/crates/ironrdp-rdpdr-native/src/windows/scard/mod.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/scard/mod.rs
@@ -1,14 +1,11 @@
-//! Windows WinSCard core backend for MS-RDPESC Device Control IRPs.
-//!
-//! ANSI (`*A`) IOCTLs upgrade to UTF-16 and call WinSCard `*W` APIs.
-//! List/Status `*A` replies keep ANSI on the wire. Extended IOCTLs remain unsupported.
+//! Windows WinSCard core backend for MS-RDPESC (A IOCTLs call *W; A replies stay ANSI).
+//! Extended IOCTLs: typed `SCARD_E_UNSUPPORTED_FEATURE` (follow-up PR).
 
 use core::sync::atomic::{AtomicBool, Ordering};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-use ironrdp_core::Encode as _;
 use ironrdp_pdu::PduResult;
 use ironrdp_pdu::utils::{CharacterSet, encoded_multistring_len};
 use ironrdp_rdpdr::pdu::RdpdrPdu;
@@ -35,15 +32,17 @@ use windows::core::{PCWSTR, PWSTR};
 
 const MAX_DEFERRED: usize = 32;
 const MAX_ATR: usize = 32;
-const MAX_RECV: u32 = 64 * 1024;
+const MAX_RECV: u32 = 66_560; // MS-RDPESC Transmit_Return cbRecvLength max
+const SCARD_AUTOALLOCATE: u32 = 0xFFFF_FFFF;
 const SCARD_SCOPE_TERMINAL: SCARD_SCOPE = SCARD_SCOPE(1);
 
-/// Per-connection WinSCard state for RDPDR smartcard device ID 0.
+/// Per-connection WinSCard state (wire handles are native 4/8-byte values).
 #[derive(Debug)]
 pub(super) struct ScardSession {
     contexts: HashMap<usize, ()>,
     cards: HashMap<usize, usize>,
     deferred: DeferredOps,
+    /// Process-wide started-event (pair with SCardReleaseStartedEvent).
     access_event: Option<isize>,
     access_refs: u32,
 }
@@ -101,17 +100,17 @@ impl ScardSession {
     pub(super) fn reset(&mut self) {
         self.deferred.reset();
         for h in self.cards.keys().copied() {
-            // SAFETY: WinSCard.
+            // SAFETY: session-owned card handle.
             let _ = unsafe { SCardDisconnect(h, 0) };
         }
         self.cards.clear();
         for c in self.contexts.keys().copied() {
-            // SAFETY: WinSCard.
+            // SAFETY: session-owned context.
             let _ = unsafe { SCardReleaseContext(c) };
         }
         self.contexts.clear();
         while self.access_refs > 0 {
-            // SAFETY: WinSCard.
+            // SAFETY: pairs SCardAccessStartedEvent.
             unsafe { SCardReleaseStartedEvent() };
             self.access_refs -= 1;
         }
@@ -137,7 +136,7 @@ impl ScardSession {
                 }
                 let ctx = context.native();
                 if !self.contexts.contains_key(&ctx) {
-                    // SAFETY: WinSCard.
+                    // SAFETY: orphan card after context vanished.
                     let _ = unsafe { SCardDisconnect(native_handle, 0) };
                     return complete_connect(
                         req,
@@ -146,15 +145,13 @@ impl ScardSession {
                         CardProtocol::SCARD_PROTOCOL_UNDEFINED,
                     );
                 }
-                let handle = ScardHandle::from_native(context, native_handle);
-                let out = ConnectReturn::new(ReturnCode::Success, handle, active_protocol);
-                if out.size() > req.output_buffer_length as usize {
-                    // SAFETY: WinSCard.
-                    let _ = unsafe { SCardDisconnect(native_handle, 0) };
-                    return buffer_too_small(req);
-                }
                 self.cards.insert(native_handle, ctx);
-                complete_rpce(req, Box::new(out))
+                complete_connect(
+                    req,
+                    ReturnCode::Success,
+                    ScardHandle::from_native(context, native_handle),
+                    active_protocol,
+                )
             }
             Outcome::Disconnect { req, card, code } => {
                 if code == ReturnCode::Success {
@@ -209,6 +206,7 @@ impl ScardSession {
         call: ScardCall,
     ) -> PduResult<Vec<SvcMessage>> {
         let ioctl = req.io_control_code;
+        // MS-RDPESC: ReleaseTartedEvent is a no-op Success.
         if ioctl == ScardIoCtlCode::ReleaseTartedEvent {
             return Ok(vec![complete_long(req, ReturnCode::Success)]);
         }
@@ -249,7 +247,7 @@ impl ScardSession {
     fn access_started(&mut self, req: DeviceControlRequest<ScardIoCtlCode>) -> PduResult<Vec<SvcMessage>> {
         let raw = match self.access_event {
             Some(r) => r,
-            // SAFETY: WinSCard.
+            // SAFETY: WinSCard started-event handle.
             None => match unsafe { SCardAccessStartedEvent() } {
                 Ok(h) if !h.is_invalid() => {
                     let r = h.0 as isize;
@@ -260,7 +258,7 @@ impl ScardSession {
                 _ => return Ok(vec![complete_long(req, ReturnCode::Success)]),
             },
         };
-        // SAFETY: WinSCard.
+        // SAFETY: process-wide started-event handle.
         if unsafe { WaitForSingleObject(HANDLE(raw as *mut _), 0) } == WAIT_OBJECT_0 {
             return Ok(vec![complete_long(req, ReturnCode::Success)]);
         }
@@ -273,7 +271,7 @@ impl ScardSession {
                     if cancel.load(Ordering::Acquire) {
                         break ReturnCode::Cancelled;
                     }
-                    // SAFETY: WinSCard.
+                    // SAFETY: same started-event handle.
                     let w = unsafe { WaitForSingleObject(HANDLE(raw as *mut _), 100) };
                     if w == WAIT_OBJECT_0 || w != WAIT_TIMEOUT {
                         break ReturnCode::Success;
@@ -290,8 +288,11 @@ impl ScardSession {
         req: DeviceControlRequest<ScardIoCtlCode>,
         call: EstablishContextCall,
     ) -> SvcMessage {
-        let preview = EstablishContextReturn::new(ReturnCode::Success, ScardContext::from_native(usize::MAX));
-        if preview.size() > req.output_buffer_length as usize {
+        // Preflight fixed-size reply before native allocate.
+        if !out_fits(
+            &req,
+            &EstablishContextReturn::new(ReturnCode::Success, ScardContext::from_native(0)),
+        ) {
             return buffer_too_small(req);
         }
         let scope = match call.scope {
@@ -300,7 +301,7 @@ impl ScardSession {
             Scope::System => SCARD_SCOPE_SYSTEM,
         };
         let mut native = 0usize;
-        // SAFETY: WinSCard.
+        // SAFETY: WinSCard context allocation.
         let code = map_status(unsafe { SCardEstablishContext(scope, None, None, &mut native) });
         if code != ReturnCode::Success {
             return complete_establish(req, code, ScardContext::from_native(0));
@@ -317,8 +318,8 @@ impl ScardSession {
     ) -> SvcMessage {
         let cs = list_cs(ioctl);
         match self.ctx(call.context).and_then(list_groups_w) {
-            Ok(v) => complete_list_fit(req, v, call.groups_is_null, call.groups_size, cs),
-            Err(c) => complete_list(req, c, Vec::new(), cs),
+            Ok(v) => finish_list(req, call.groups_is_null, call.groups_size, v, cs),
+            Err(c) => complete_rpce(req, Box::new(ListReadersReturn::probe(c, 0, cs))),
         }
     }
 
@@ -330,8 +331,8 @@ impl ScardSession {
     ) -> SvcMessage {
         let cs = list_cs(ioctl);
         match self.ctx(call.context).and_then(|n| list_readers_w(n, &call.groups)) {
-            Ok(v) => complete_list_fit(req, v, call.readers_is_null, call.readers_size, cs),
-            Err(c) => complete_list(req, c, Vec::new(), cs),
+            Ok(v) => finish_list(req, call.readers_is_null, call.readers_size, v, cs),
+            Err(c) => complete_rpce(req, Box::new(ListReadersReturn::probe(c, 0, cs))),
         }
     }
 
@@ -344,9 +345,8 @@ impl ScardSession {
             Ok(n) => n,
             Err(c) => return Ok(vec![complete_gsc(req, c, Vec::new())]),
         };
-        let ctx_id = call.context.native();
         self.defer(
-            ctx_id,
+            call.context.native(),
             "ironrdp-scard-gsc",
             req,
             move |req, cancel| {
@@ -360,7 +360,7 @@ impl ScardSession {
                     .zip(bufs.iter())
                     .map(|(s, r)| reader_state_w(s, r))
                     .collect();
-                // SAFETY: WinSCard.
+                // SAFETY: context + reader-state buffers owned for this call.
                 let status =
                     unsafe { SCardGetStatusChangeW(native, call.timeout, states.as_mut_ptr(), states.len() as u32) };
                 let code = if cancel.load(Ordering::Acquire) {
@@ -380,6 +380,17 @@ impl ScardSession {
     }
 
     fn connect(&mut self, req: DeviceControlRequest<ScardIoCtlCode>, call: ConnectCall) -> PduResult<Vec<SvcMessage>> {
+        // Preflight Connect_Return so success cannot leak a card handle.
+        if !out_fits(
+            &req,
+            &ConnectReturn::new(
+                ReturnCode::Success,
+                ScardHandle::from_native(call.common.context, 0),
+                CardProtocol::SCARD_PROTOCOL_UNDEFINED,
+            ),
+        ) {
+            return Ok(vec![buffer_too_small(req)]);
+        }
         let native_ctx = match self.ctx(call.common.context) {
             Ok(n) => n,
             Err(c) => {
@@ -391,14 +402,6 @@ impl ScardSession {
                 )]);
             }
         };
-        let preview = ConnectReturn::new(
-            ReturnCode::Success,
-            ScardHandle::from_native(call.common.context, usize::MAX),
-            CardProtocol::SCARD_PROTOCOL_T0,
-        );
-        if preview.size() > req.output_buffer_length as usize {
-            return Ok(vec![buffer_too_small(req)]);
-        }
         let context = call.common.context;
         self.defer(
             context.native(),
@@ -408,7 +411,7 @@ impl ScardSession {
                 let reader = wide(&call.reader);
                 let mut card = 0usize;
                 let mut active = 0u32;
-                // SAFETY: WinSCard.
+                // SAFETY: context owned by session; reader buffer local.
                 let status = unsafe {
                     SCardConnectW(
                         native_ctx,
@@ -453,7 +456,7 @@ impl ScardSession {
             req,
             move |req, _| {
                 let mut active = 0u32;
-                // SAFETY: WinSCard.
+                // SAFETY: session-owned card handle.
                 let status = unsafe {
                     SCardReconnect(
                         handle,
@@ -495,7 +498,7 @@ impl ScardSession {
             name,
             req,
             move |req, _| match ioctl {
-                // SAFETY: WinSCard.
+                // SAFETY: session-owned card handle.
                 ScardIoCtlCode::BeginTransaction => {
                     Outcome::Message(complete_long(req, map_status(unsafe { SCardBeginTransaction(handle) })))
                 }
@@ -506,6 +509,7 @@ impl ScardSession {
                 ScardIoCtlCode::Disconnect => Outcome::Disconnect {
                     req,
                     card: handle,
+                    // SAFETY: session-owned card handle.
                     code: map_status(unsafe { SCardDisconnect(handle, disp) }),
                 },
                 _ => Outcome::Message(complete_long(req, ReturnCode::UnsupportedFeature)),
@@ -521,14 +525,53 @@ impl ScardSession {
     ) -> PduResult<Vec<SvcMessage>> {
         let (ctx_id, handle) = match self.card(&call.handle) {
             Ok(v) => v,
-            Err(c) => return Ok(vec![complete_transmit(req, c, None, Vec::new())]),
+            Err(c) => return Ok(vec![xmit_ret(req, c, None, None, 0)]),
         };
         self.defer(
             ctx_id,
             "ironrdp-scard-xmit",
             req,
-            move |req, _| run_transmit(req, handle, call),
-            |req, c| complete_transmit(req, c, None, Vec::new()),
+            move |req, _| {
+                let send_pci = pack_pci(&call.send_pci);
+                let mut recv_pci = call.recv_pci.as_ref().map(pack_pci);
+                let mut len = if call.recv_buffer_is_null {
+                    0
+                } else {
+                    call.recv_length.min(MAX_RECV)
+                };
+                let mut buf = if call.recv_buffer_is_null {
+                    Vec::new()
+                } else {
+                    vec![0u8; len as usize]
+                };
+                // SAFETY: card handle session-owned; PCI/recv buffers owned above.
+                let status = unsafe {
+                    SCardTransmit(
+                        handle,
+                        send_pci.as_ptr().cast::<SCARD_IO_REQUEST>(),
+                        &call.send_buffer,
+                        recv_pci.as_mut().map(|b| b.as_mut_ptr().cast::<SCARD_IO_REQUEST>()),
+                        if call.recv_buffer_is_null {
+                            core::ptr::null_mut()
+                        } else {
+                            buf.as_mut_ptr()
+                        },
+                        &mut len,
+                    )
+                };
+                let code = map_status(status);
+                let out_pci = recv_pci.as_deref().map(unpack_pci);
+                if code != ReturnCode::Success {
+                    return Outcome::Message(xmit_ret(req, code, None, None, 0));
+                }
+                if call.recv_buffer_is_null {
+                    Outcome::Message(xmit_ret(req, code, out_pci, None, len))
+                } else {
+                    buf.truncate(len as usize);
+                    Outcome::Message(xmit_ret(req, code, out_pci, Some(buf), len))
+                }
+            },
+            |req, c| xmit_ret(req, c, None, None, 0),
         )
     }
 
@@ -540,71 +583,42 @@ impl ScardSession {
     ) -> PduResult<Vec<SvcMessage>> {
         let (ctx_id, handle) = match self.card(&call.handle) {
             Ok(v) => v,
-            Err(c) => return Ok(vec![complete_status_err(req, c, ioctl)]),
+            Err(c) => return Ok(vec![status_err(req, c, ioctl)]),
         };
+        let names_null = call.reader_names_is_null;
+        let names_cap = call.reader_length;
         self.defer(
             ctx_id,
             "ironrdp-scard-status",
             req,
             move |req, _| match card_status_w(handle) {
-                Ok((names, state, proto, atr, atr_len)) => {
-                    let cs = status_cs(ioctl);
-                    let (code, names_opt, c_bytes) =
-                        fit_multi(names, call.reader_names_is_null, call.reader_length, cs);
-                    Outcome::Message(complete_status_fit(
-                        req, code, names_opt, c_bytes, state, proto, atr, atr_len, cs,
-                    ))
-                }
-                Err(c) => Outcome::Message(complete_status_err(req, c, ioctl)),
+                Ok((names, state, proto, atr, atr_len)) => Outcome::Message(finish_status(
+                    req, names, names_null, names_cap, state, proto, atr, atr_len, ioctl,
+                )),
+                Err(c) => Outcome::Message(status_err(req, c, ioctl)),
             },
-            move |req, c| complete_status_err(req, c, ioctl),
+            move |req, c| status_err(req, c, ioctl),
         )
     }
 
     fn state(&mut self, req: DeviceControlRequest<ScardIoCtlCode>, call: StateCall) -> PduResult<Vec<SvcMessage>> {
         let (ctx_id, handle) = match self.card(&call.handle) {
             Ok(v) => v,
-            Err(c) => {
-                return Ok(vec![complete_state(
-                    req,
-                    c,
-                    CardState::Unknown,
-                    CardProtocol::SCARD_PROTOCOL_UNDEFINED,
-                    Vec::new(),
-                )]);
-            }
+            Err(c) => return Ok(vec![state_err(req, c)]),
         };
+        let atr_null = call.atr_is_null;
+        let atr_cap = call.atr_length;
         self.defer(
             ctx_id,
             "ironrdp-scard-state",
             req,
             move |req, _| match card_status_w(handle) {
-                Ok((_n, state, proto, atr, atr_len)) => Outcome::Message(complete_state_fit(
-                    req,
-                    ReturnCode::Success,
-                    state,
-                    proto,
-                    atr,
-                    atr_len,
-                    call,
-                )),
-                Err(c) => Outcome::Message(complete_state(
-                    req,
-                    c,
-                    CardState::Unknown,
-                    CardProtocol::SCARD_PROTOCOL_UNDEFINED,
-                    Vec::new(),
-                )),
+                Ok((_n, state, proto, atr, atr_len)) => {
+                    Outcome::Message(finish_state(req, state, proto, atr, atr_len, atr_null, atr_cap))
+                }
+                Err(c) => Outcome::Message(state_err(req, c)),
             },
-            |req, c| {
-                complete_state(
-                    req,
-                    c,
-                    CardState::Unknown,
-                    CardProtocol::SCARD_PROTOCOL_UNDEFINED,
-                    Vec::new(),
-                )
-            },
+            |req, c| state_err(req, c),
         )
     }
 
@@ -617,7 +631,7 @@ impl ScardSession {
         match ioctl {
             ScardIoCtlCode::ReleaseContext => self.release_context(req, call),
             ScardIoCtlCode::IsValidContext => match self.ctx(call.context) {
-                // SAFETY: WinSCard.
+                // SAFETY: session-owned context.
                 Ok(n) => complete_long(req, map_status(unsafe { SCardIsValidContext(n) })),
                 Err(c) => complete_long(req, c),
             },
@@ -628,7 +642,7 @@ impl ScardSession {
                             op.cancel.store(true, Ordering::Release);
                         }
                     }
-                    // SAFETY: WinSCard.
+                    // SAFETY: session-owned context.
                     complete_long(req, map_status(unsafe { SCardCancel(n) }))
                 }
                 Err(c) => complete_long(req, c),
@@ -642,8 +656,8 @@ impl ScardSession {
             Ok(n) => n,
             Err(c) => return complete_long(req, c),
         };
-        // ReleaseContext frees context-owned cards; update maps only after success.
-        // SAFETY: WinSCard.
+        // Maps update only after successful release (context owns cards).
+        // SAFETY: session-owned context.
         let code = map_status(unsafe { SCardReleaseContext(native) });
         if code == ReturnCode::Success {
             self.cards.retain(|_, c| *c != native);
@@ -694,8 +708,10 @@ impl DeferredOps {
 
     fn reset(&mut self) {
         self.epoch = self.epoch.wrapping_add(1);
-        for (_, op) in self.ops.drain() {
+        for op in self.ops.values() {
             op.cancel.store(true, Ordering::Release);
+        }
+        for (_, op) in core::mem::take(&mut self.ops) {
             let _ = op.worker.join();
         }
         if let Ok(mut g) = self.completions.lock() {
@@ -713,67 +729,51 @@ fn push(completions: Arc<Mutex<Vec<DeferredCompletion>>>, id: u64, epoch: u64, o
 }
 
 fn list_groups_w(context: usize) -> Result<Vec<String>, ReturnCode> {
-    let mut needed = 0u32;
-    // SAFETY: WinSCard.
-    let probe = unsafe { SCardListReaderGroupsW(context, None, &mut needed) };
-    let probe_code = map_status(probe);
-    if probe_code == ReturnCode::NoReadersAvailable {
-        return Ok(Vec::new());
-    }
-    if probe_code != ReturnCode::Success && probe_code != ReturnCode::InsufficientBuffer {
-        return Err(probe_code);
-    }
-    if needed == 0 {
-        return Ok(Vec::new());
-    }
-    let mut buf = vec![0u16; needed as usize];
-    let mut len = needed;
-    // SAFETY: WinSCard.
-    let code = map_status(unsafe { SCardListReaderGroupsW(context, Some(PWSTR(buf.as_mut_ptr())), &mut len) });
-    if code != ReturnCode::Success {
-        return Err(code);
-    }
-    Ok(parse_multi_wide(&buf[..len as usize]))
+    list_multi(context, |ctx, buf, len| unsafe {
+        SCardListReaderGroupsW(ctx, buf, len)
+    })
 }
 
 fn list_readers_w(context: usize, groups: &[String]) -> Result<Vec<String>, ReturnCode> {
-    let groups_w = if groups.is_empty() {
-        None
-    } else {
-        Some(multi_wide(groups))
-    };
-    let groups_ptr = groups_w.as_ref().map(|g| PCWSTR(g.as_ptr())).unwrap_or(PCWSTR::null());
+    let groups_w = multi_wide(groups);
+    list_multi(context, |ctx, buf, len| unsafe {
+        SCardListReadersW(ctx, PCWSTR(groups_w.as_ptr()), buf, len)
+    })
+}
+
+fn list_multi<F>(context: usize, f: F) -> Result<Vec<String>, ReturnCode>
+where
+    F: Fn(usize, Option<PWSTR>, &mut u32) -> i32,
+{
     let mut needed = 0u32;
-    // SAFETY: WinSCard.
-    let probe = unsafe { SCardListReadersW(context, groups_ptr, None, &mut needed) };
-    let probe_code = map_status(probe);
-    if probe_code == ReturnCode::NoReadersAvailable {
+    // SAFETY: length probe; buffers null/owned by caller contract of f.
+    let probe = map_status(f(context, None, &mut needed));
+    if probe == ReturnCode::NoReadersAvailable || needed == 0 {
         return Ok(Vec::new());
     }
-    if probe_code != ReturnCode::Success && probe_code != ReturnCode::InsufficientBuffer {
-        return Err(probe_code);
-    }
-    if needed == 0 {
-        return Ok(Vec::new());
+    if probe != ReturnCode::Success && probe != ReturnCode::InsufficientBuffer {
+        return Err(probe);
     }
     let mut buf = vec![0u16; needed as usize];
-    let mut len = needed;
-    // SAFETY: WinSCard.
-    let code = map_status(unsafe { SCardListReadersW(context, groups_ptr, Some(PWSTR(buf.as_mut_ptr())), &mut len) });
+    let mut actual = needed;
+    let code = map_status(f(context, Some(PWSTR(buf.as_mut_ptr())), &mut actual));
+    if code == ReturnCode::NoReadersAvailable {
+        return Ok(Vec::new());
+    }
     if code != ReturnCode::Success {
         return Err(code);
     }
-    Ok(parse_multi_wide(&buf[..len as usize]))
+    Ok(parse_multi_wide(&buf[..actual as usize]))
 }
 
 fn card_status_w(handle: usize) -> Result<(Vec<String>, CardState, CardProtocol, [u8; MAX_ATR], u32), ReturnCode> {
     let mut name_len = 0u32;
     let mut state = 0u32;
     let mut protocol = 0u32;
-    let mut atr = [0u8; MAX_ATR];
-    let mut atr_len = MAX_ATR as u32;
-    // SAFETY: WinSCard.
-    let probe = unsafe {
+    let mut atr = [0u8; 36];
+    let mut atr_len = atr.len() as u32;
+    // SAFETY: length probe with null name buffer.
+    let probe = map_status(unsafe {
         SCardStatusW(
             handle,
             None,
@@ -783,32 +783,30 @@ fn card_status_w(handle: usize) -> Result<(Vec<String>, CardState, CardProtocol,
             Some(atr.as_mut_ptr()),
             Some(&mut atr_len),
         )
-    };
-    let probe_code = map_status(probe);
+    });
+    if probe != ReturnCode::Success && probe != ReturnCode::InsufficientBuffer {
+        return Err(probe);
+    }
     let mut names = Vec::new();
-    if probe_code == ReturnCode::Success || probe_code == ReturnCode::InsufficientBuffer {
-        if name_len > 0 {
-            let mut name_buf = vec![0u16; name_len as usize];
-            atr_len = MAX_ATR as u32;
-            // SAFETY: WinSCard.
-            let code = map_status(unsafe {
-                SCardStatusW(
-                    handle,
-                    Some(PWSTR(name_buf.as_mut_ptr())),
-                    Some(&mut name_len),
-                    Some(&mut state),
-                    Some(&mut protocol),
-                    Some(atr.as_mut_ptr()),
-                    Some(&mut atr_len),
-                )
-            });
-            if code != ReturnCode::Success {
-                return Err(code);
-            }
-            names = parse_multi_wide(&name_buf[..name_len as usize]);
+    if name_len > 0 {
+        let mut name_buf = vec![0u16; name_len as usize];
+        atr_len = atr.len() as u32;
+        // SAFETY: handle session-owned; buffers sized for WinSCard.
+        let code = map_status(unsafe {
+            SCardStatusW(
+                handle,
+                Some(PWSTR(name_buf.as_mut_ptr())),
+                Some(&mut name_len),
+                Some(&mut state),
+                Some(&mut protocol),
+                Some(atr.as_mut_ptr()),
+                Some(&mut atr_len),
+            )
+        });
+        if code != ReturnCode::Success {
+            return Err(code);
         }
-    } else {
-        return Err(probe_code);
+        names = parse_multi_wide(&name_buf[..name_len as usize]);
     }
     let mut wire = [0u8; MAX_ATR];
     let n = (atr_len as usize).min(MAX_ATR);
@@ -831,125 +829,8 @@ fn card_status_w(handle: usize) -> Result<(Vec<String>, CardState, CardProtocol,
     ))
 }
 
-fn run_transmit(req: DeviceControlRequest<ScardIoCtlCode>, handle: usize, call: TransmitCall) -> Outcome {
-    let send_raw = pack_pci(&call.send_pci);
-    // SAFETY: WinSCard.
-    let send_pci = unsafe { &*(send_raw.as_ptr() as *const SCARD_IO_REQUEST) };
-    let mut recv_raw = call.recv_pci.as_ref().map(|p| {
-        let mut v = pack_pci(p);
-        if v.len() < core::mem::size_of::<SCARD_IO_REQUEST>() {
-            v.resize(core::mem::size_of::<SCARD_IO_REQUEST>(), 0);
-        }
-        v
-    });
-    let recv_pci_ptr = recv_raw.as_mut().map(|b| b.as_mut_ptr() as *mut SCARD_IO_REQUEST);
-
-    if call.recv_buffer_is_null {
-        let mut len = 0u32;
-        // SAFETY: WinSCard.
-        let status = unsafe {
-            SCardTransmit(
-                handle,
-                send_pci,
-                &call.send_buffer,
-                recv_pci_ptr,
-                core::ptr::null_mut(),
-                &mut len,
-            )
-        };
-        let code = map_status(status);
-        let out_pci = recv_raw.as_ref().map(|b| unpack_pci(b));
-        return Outcome::Message(complete_rpce(
-            req,
-            Box::new(TransmitReturn::recv_probe(code, out_pci, len)),
-        ));
-    }
-
-    let recv_len = call.recv_length.min(MAX_RECV);
-    let mut buf = vec![0u8; recv_len as usize];
-    let mut len = recv_len;
-    // SAFETY: WinSCard.
-    let status = unsafe {
-        SCardTransmit(
-            handle,
-            send_pci,
-            &call.send_buffer,
-            recv_pci_ptr,
-            if recv_len == 0 {
-                core::ptr::null_mut()
-            } else {
-                buf.as_mut_ptr()
-            },
-            &mut len,
-        )
-    };
-    let code = map_status(status);
-    if code != ReturnCode::Success {
-        return Outcome::Message(complete_transmit(req, code, None, Vec::new()));
-    }
-    buf.truncate(len as usize);
-    let out_pci = recv_raw.as_ref().map(|b| unpack_pci(b));
-    Outcome::Message(complete_transmit(req, ReturnCode::Success, out_pci, buf))
-}
-
-fn pack_pci(pci: &SCardIORequest) -> Vec<u8> {
-    let total = core::mem::size_of::<SCARD_IO_REQUEST>() + pci.extra_bytes.len();
-    let mut buf = vec![0u8; total];
-    let header = SCARD_IO_REQUEST {
-        dwProtocol: pci.protocol.bits(),
-        cbPciLength: total as u32,
-    };
-    // SAFETY: WinSCard.
-    unsafe {
-        core::ptr::write_unaligned(buf.as_mut_ptr() as *mut SCARD_IO_REQUEST, header);
-    }
-    if !pci.extra_bytes.is_empty() {
-        buf[core::mem::size_of::<SCARD_IO_REQUEST>()..].copy_from_slice(&pci.extra_bytes);
-    }
-    buf
-}
-
-fn unpack_pci(buf: &[u8]) -> SCardIORequest {
-    if buf.len() < core::mem::size_of::<SCARD_IO_REQUEST>() {
-        return SCardIORequest {
-            protocol: CardProtocol::SCARD_PROTOCOL_UNDEFINED,
-            extra_bytes_length: 0,
-            extra_bytes: Vec::new(),
-        };
-    }
-    // SAFETY: WinSCard.
-    let header = unsafe { core::ptr::read_unaligned(buf.as_ptr() as *const SCARD_IO_REQUEST) };
-    let declared = (header.cbPciLength as usize).min(buf.len());
-    let extra = if declared > core::mem::size_of::<SCARD_IO_REQUEST>() {
-        buf[core::mem::size_of::<SCARD_IO_REQUEST>()..declared].to_vec()
-    } else {
-        Vec::new()
-    };
-    SCardIORequest {
-        protocol: CardProtocol::from_bits_retain(header.dwProtocol),
-        extra_bytes_length: extra.len(),
-        extra_bytes: extra,
-    }
-}
-
-fn fit_multi(
-    values: Vec<String>,
-    is_null: bool,
-    capacity_chars: u32,
-    cs: CharacterSet,
-) -> (ReturnCode, Option<Vec<String>>, u32) {
-    let c_bytes = encoded_multistring_len(&values, cs) as u32;
-    let needed_chars = match cs {
-        CharacterSet::Unicode => c_bytes / 2,
-        CharacterSet::Ansi => c_bytes,
-    };
-    if is_null {
-        return (ReturnCode::Success, None, c_bytes);
-    }
-    if capacity_chars < needed_chars {
-        return (ReturnCode::InsufficientBuffer, None, c_bytes);
-    }
-    (ReturnCode::Success, Some(values), c_bytes)
+fn out_fits(req: &DeviceControlRequest<ScardIoCtlCode>, output: &dyn rpce::Encode) -> bool {
+    output.size() <= req.output_buffer_length as usize
 }
 
 fn buffer_too_small(req: DeviceControlRequest<ScardIoCtlCode>) -> SvcMessage {
@@ -977,27 +858,6 @@ fn complete_long(req: DeviceControlRequest<ScardIoCtlCode>, code: ReturnCode) ->
 fn complete_establish(req: DeviceControlRequest<ScardIoCtlCode>, code: ReturnCode, ctx: ScardContext) -> SvcMessage {
     complete_rpce(req, Box::new(EstablishContextReturn::new(code, ctx)))
 }
-fn complete_list(
-    req: DeviceControlRequest<ScardIoCtlCode>,
-    code: ReturnCode,
-    v: Vec<String>,
-    cs: CharacterSet,
-) -> SvcMessage {
-    complete_rpce(req, Box::new(ListReadersReturn::new(code, v, cs)))
-}
-fn complete_list_fit(
-    req: DeviceControlRequest<ScardIoCtlCode>,
-    v: Vec<String>,
-    is_null: bool,
-    capacity_chars: u32,
-    cs: CharacterSet,
-) -> SvcMessage {
-    let (code, names, c_bytes) = fit_multi(v, is_null, capacity_chars, cs);
-    match names {
-        Some(n) => complete_list(req, code, n, cs),
-        None => complete_rpce(req, Box::new(ListReadersReturn::probe(code, c_bytes, cs))),
-    }
-}
 fn complete_gsc(
     req: DeviceControlRequest<ScardIoCtlCode>,
     code: ReturnCode,
@@ -1013,48 +873,134 @@ fn complete_connect(
 ) -> SvcMessage {
     complete_rpce(req, Box::new(ConnectReturn::new(code, handle, proto)))
 }
-fn complete_transmit(
+fn complete_reconnect(req: DeviceControlRequest<ScardIoCtlCode>, code: ReturnCode, proto: CardProtocol) -> SvcMessage {
+    complete_rpce(req, Box::new(ReconnectReturn::new(code, proto)))
+}
+
+fn xmit_ret(
     req: DeviceControlRequest<ScardIoCtlCode>,
     code: ReturnCode,
     pci: Option<SCardIORequest>,
-    data: Vec<u8>,
+    data: Option<Vec<u8>>,
+    recv_len: u32,
 ) -> SvcMessage {
-    complete_rpce(req, Box::new(TransmitReturn::new(code, pci, data)))
+    let pdu = match data {
+        Some(buf) => TransmitReturn::new(code, pci, buf),
+        None => TransmitReturn::recv_probe(code, pci, recv_len),
+    };
+    complete_rpce(req, Box::new(pdu))
+}
+
+fn finish_list(
+    req: DeviceControlRequest<ScardIoCtlCode>,
+    is_null: bool,
+    size_chars: u32,
+    v: Vec<String>,
+    cs: CharacterSet,
+) -> SvcMessage {
+    let need_chars = multi_chars(&v, cs);
+    let need_bytes = encoded_multistring_len(&v, cs) as u32;
+    if is_null || size_chars == 0 {
+        return complete_rpce(
+            req,
+            Box::new(ListReadersReturn::probe(ReturnCode::Success, need_bytes, cs)),
+        );
+    }
+    if size_chars != SCARD_AUTOALLOCATE && size_chars < need_chars {
+        return complete_rpce(
+            req,
+            Box::new(ListReadersReturn::probe(ReturnCode::InsufficientBuffer, need_bytes, cs)),
+        );
+    }
+    complete_rpce(req, Box::new(ListReadersReturn::new(ReturnCode::Success, v, cs)))
 }
 
 #[allow(clippy::too_many_arguments)]
-fn complete_status_fit(
+fn finish_status(
     req: DeviceControlRequest<ScardIoCtlCode>,
-    code: ReturnCode,
-    names: Option<Vec<String>>,
-    c_bytes: u32,
+    names: Vec<String>,
+    names_null: bool,
+    names_cap: u32,
     state: CardState,
     proto: CardProtocol,
     atr: [u8; MAX_ATR],
     atr_len: u32,
-    cs: CharacterSet,
-) -> SvcMessage {
-    match names {
-        Some(n) => complete_rpce(
-            req,
-            Box::new(StatusReturn::new(code, n, state, proto, atr, atr_len, cs)),
-        ),
-        None => complete_rpce(
-            req,
-            Box::new(StatusReturn::names_probe(code, c_bytes, state, proto, atr, atr_len, cs)),
-        ),
-    }
-}
-fn complete_status_err(
-    req: DeviceControlRequest<ScardIoCtlCode>,
-    code: ReturnCode,
     ioctl: ScardIoCtlCode,
 ) -> SvcMessage {
+    let cs = status_cs(ioctl);
+    let need_chars = multi_chars(&names, cs);
+    let need_bytes = encoded_multistring_len(&names, cs) as u32;
+    if names_null || names_cap == 0 || (names_cap != SCARD_AUTOALLOCATE && names_cap < need_chars) {
+        let code = if names_null || names_cap == 0 {
+            ReturnCode::Success
+        } else {
+            ReturnCode::InsufficientBuffer
+        };
+        return complete_rpce(
+            req,
+            Box::new(StatusReturn::names_probe(
+                code, need_bytes, state, proto, atr, atr_len, cs,
+            )),
+        );
+    }
     complete_rpce(
         req,
         Box::new(StatusReturn::new(
+            ReturnCode::Success,
+            names,
+            state,
+            proto,
+            atr,
+            atr_len,
+            cs,
+        )),
+    )
+}
+
+fn finish_state(
+    req: DeviceControlRequest<ScardIoCtlCode>,
+    state: CardState,
+    proto: CardProtocol,
+    atr: [u8; MAX_ATR],
+    atr_len: u32,
+    atr_null: bool,
+    atr_cap: u32,
+) -> SvcMessage {
+    let need = atr_len.min(36);
+    if atr_null || atr_cap == 0 {
+        return complete_rpce(
+            req,
+            Box::new(StateReturn::atr_probe(ReturnCode::Success, state, proto, need)),
+        );
+    }
+    if atr_cap < need {
+        return complete_rpce(
+            req,
+            Box::new(StateReturn::atr_probe(
+                ReturnCode::InsufficientBuffer,
+                state,
+                proto,
+                need,
+            )),
+        );
+    }
+    complete_rpce(
+        req,
+        Box::new(StateReturn::new(
+            ReturnCode::Success,
+            state,
+            proto,
+            atr[..need as usize].to_vec(),
+        )),
+    )
+}
+
+fn status_err(req: DeviceControlRequest<ScardIoCtlCode>, code: ReturnCode, ioctl: ScardIoCtlCode) -> SvcMessage {
+    complete_rpce(
+        req,
+        Box::new(StatusReturn::names_probe(
             code,
-            Vec::new(),
+            0,
             CardState::Unknown,
             CardProtocol::SCARD_PROTOCOL_UNDEFINED,
             [0; MAX_ATR],
@@ -1063,43 +1009,24 @@ fn complete_status_err(
         )),
     )
 }
-fn complete_reconnect(req: DeviceControlRequest<ScardIoCtlCode>, code: ReturnCode, proto: CardProtocol) -> SvcMessage {
-    complete_rpce(req, Box::new(ReconnectReturn::new(code, proto)))
+
+fn state_err(req: DeviceControlRequest<ScardIoCtlCode>, code: ReturnCode) -> SvcMessage {
+    complete_rpce(
+        req,
+        Box::new(StateReturn::atr_probe(
+            code,
+            CardState::Unknown,
+            CardProtocol::SCARD_PROTOCOL_UNDEFINED,
+            0,
+        )),
+    )
 }
-fn complete_state(
-    req: DeviceControlRequest<ScardIoCtlCode>,
-    code: ReturnCode,
-    state: CardState,
-    proto: CardProtocol,
-    atr: Vec<u8>,
-) -> SvcMessage {
-    complete_rpce(req, Box::new(StateReturn::new(code, state, proto, atr)))
-}
-fn complete_state_fit(
-    req: DeviceControlRequest<ScardIoCtlCode>,
-    code: ReturnCode,
-    state: CardState,
-    proto: CardProtocol,
-    atr: [u8; MAX_ATR],
-    atr_len: u32,
-    call: StateCall,
-) -> SvcMessage {
-    let full_len = atr_len.min(36);
-    if call.atr_is_null || call.atr_length == 0 {
-        return complete_rpce(req, Box::new(StateReturn::atr_probe(code, state, proto, full_len)));
+
+fn status_cs(ioctl: ScardIoCtlCode) -> CharacterSet {
+    match ioctl {
+        ScardIoCtlCode::StatusA => CharacterSet::Ansi,
+        _ => CharacterSet::Unicode,
     }
-    if call.atr_length < atr_len {
-        return complete_rpce(
-            req,
-            Box::new(StateReturn::atr_probe(
-                ReturnCode::InsufficientBuffer,
-                state,
-                proto,
-                full_len,
-            )),
-        );
-    }
-    complete_state(req, code, state, proto, atr[..atr_len as usize].to_vec())
 }
 
 fn list_cs(ioctl: ScardIoCtlCode) -> CharacterSet {
@@ -1108,10 +1035,49 @@ fn list_cs(ioctl: ScardIoCtlCode) -> CharacterSet {
         _ => CharacterSet::Unicode,
     }
 }
-fn status_cs(ioctl: ScardIoCtlCode) -> CharacterSet {
-    match ioctl {
-        ScardIoCtlCode::StatusA => CharacterSet::Ansi,
-        _ => CharacterSet::Unicode,
+
+fn multi_chars(v: &[String], cs: CharacterSet) -> u32 {
+    let bytes = encoded_multistring_len(v, cs) as u32;
+    if matches!(cs, CharacterSet::Unicode) {
+        bytes / 2
+    } else {
+        bytes
+    }
+}
+
+fn pack_pci(pci: &SCardIORequest) -> Vec<u8> {
+    let hdr = core::mem::size_of::<SCARD_IO_REQUEST>();
+    let mut buf = vec![0u8; hdr + pci.extra_bytes.len()];
+    let req = SCARD_IO_REQUEST {
+        dwProtocol: pci.protocol.bits(),
+        cbPciLength: buf.len() as u32,
+    };
+    // SAFETY: write unaligned header into owned byte buffer.
+    unsafe {
+        core::ptr::write_unaligned(buf.as_mut_ptr().cast::<SCARD_IO_REQUEST>(), req);
+    }
+    if !pci.extra_bytes.is_empty() {
+        buf[hdr..].copy_from_slice(&pci.extra_bytes);
+    }
+    buf
+}
+
+fn unpack_pci(raw: &[u8]) -> SCardIORequest {
+    let hdr = core::mem::size_of::<SCARD_IO_REQUEST>();
+    if raw.len() < hdr {
+        return SCardIORequest {
+            protocol: CardProtocol::SCARD_PROTOCOL_UNDEFINED,
+            extra_bytes_length: 0,
+            extra_bytes: Vec::new(),
+        };
+    }
+    // SAFETY: buffer holds at least one SCARD_IO_REQUEST header.
+    let req = unsafe { core::ptr::read_unaligned(raw.as_ptr().cast::<SCARD_IO_REQUEST>()) };
+    let extra = raw[hdr..].to_vec();
+    SCardIORequest {
+        protocol: CardProtocol::from_bits_retain(req.dwProtocol),
+        extra_bytes_length: extra.len(),
+        extra_bytes: extra,
     }
 }
 
@@ -1119,7 +1085,7 @@ fn map_status(status: i32) -> ReturnCode {
     let code = status as u32;
     match code {
         0 => ReturnCode::Success,
-        // SAFETY: WinSCard.
+        // SAFETY: ReturnCode is #[repr(u32)]; ranges are defined variants.
         0x8010_0001..=0x8010_0034 | 0x8010_0065..=0x8010_0072 => unsafe {
             core::mem::transmute::<u32, ReturnCode>(code)
         },
@@ -1135,6 +1101,7 @@ fn wide(value: &str) -> Vec<u16> {
     w.push(0);
     w
 }
+
 fn multi_wide(values: &[String]) -> Vec<u16> {
     let mut out = Vec::new();
     for v in values {
@@ -1144,6 +1111,7 @@ fn multi_wide(values: &[String]) -> Vec<u16> {
     out.push(0);
     out
 }
+
 fn parse_multi_wide(buffer: &[u16]) -> Vec<String> {
     let mut out = Vec::new();
     let mut start = 0usize;
@@ -1161,6 +1129,7 @@ fn parse_multi_wide(buffer: &[u16]) -> Vec<String> {
     }
     out
 }
+
 fn reader_state_w(state: &ReaderState, reader: &[u16]) -> SCARD_READERSTATEW {
     SCARD_READERSTATEW {
         szReader: PCWSTR(reader.as_ptr()),
@@ -1171,6 +1140,7 @@ fn reader_state_w(state: &ReaderState, reader: &[u16]) -> SCARD_READERSTATEW {
         rgbAtr: state.common.atr,
     }
 }
+
 fn reader_states_from_native(states: Vec<SCARD_READERSTATEW>) -> Vec<ReaderStateCommonCall> {
     states
         .into_iter()
@@ -1198,7 +1168,7 @@ fn unsupported(ioctl: ScardIoCtlCode, call: ScardCall) -> Box<dyn rpce::Encode> 
         ScardCall::GetReaderIconCall(_) => Box::new(GetReaderIconReturn::new(code, Vec::new())),
         ScardCall::EstablishContextCall(_) => Box::new(EstablishContextReturn::new(code, ScardContext::from_native(0))),
         ScardCall::ListReaderGroupsCall(_) | ScardCall::ListReadersCall(_) => {
-            Box::new(ListReadersReturn::new(code, Vec::new(), list_cs(ioctl)))
+            Box::new(ListReadersReturn::probe(code, 0, list_cs(ioctl)))
         }
         ScardCall::GetStatusChangeCall(_) => Box::new(GetStatusChangeReturn::new(code, Vec::new())),
         ScardCall::ConnectCall(_) => Box::new(ConnectReturn::new(
@@ -1208,16 +1178,42 @@ fn unsupported(ioctl: ScardIoCtlCode, call: ScardCall) -> Box<dyn rpce::Encode> 
         )),
         ScardCall::ReconnectCall(_) => Box::new(ReconnectReturn::new(code, undef)),
         ScardCall::TransmitCall(_) => Box::new(TransmitReturn::new(code, None, Vec::new())),
-        ScardCall::StatusCall(_) => Box::new(StatusReturn::new(
+        ScardCall::StatusCall(_) => Box::new(StatusReturn::names_probe(
             code,
-            Vec::new(),
+            0,
             CardState::Unknown,
             undef,
             [0u8; 32],
             0,
             status_cs(ioctl),
         )),
-        ScardCall::StateCall(_) => Box::new(StateReturn::new(code, CardState::Unknown, undef, Vec::new())),
+        ScardCall::StateCall(_) => Box::new(StateReturn::atr_probe(code, CardState::Unknown, undef, 0)),
         _ => Box::new(LongReturn::new(code)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn map_charset_pci_lookup() {
+        assert_eq!(map_status(0), ReturnCode::Success);
+        assert_eq!(list_cs(ScardIoCtlCode::ListReadersA), CharacterSet::Ansi);
+        assert_eq!(multi_chars(&["A".into()], CharacterSet::Unicode), 3);
+        let pci = SCardIORequest {
+            protocol: CardProtocol::SCARD_PROTOCOL_T0,
+            extra_bytes_length: 1,
+            extra_bytes: vec![9],
+        };
+        assert_eq!(unpack_pci(&pack_pci(&pci)).extra_bytes, vec![9]);
+        let mut s = ScardSession::new();
+        s.contexts.insert(1, ());
+        s.cards.insert(2, 1);
+        assert_eq!(
+            s.card(&ScardHandle::from_native(ScardContext::from_native(1), 2))
+                .unwrap(),
+            (1, 2)
+        );
     }
 }

--- a/crates/ironrdp-rdpdr-native/src/windows/scard/mod.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/scard/mod.rs
@@ -361,8 +361,14 @@ impl ScardSession {
                     .map(|(s, r)| reader_state_w(s, r))
                     .collect();
                 // SAFETY: context + reader-state buffers owned for this call.
-                let status =
-                    unsafe { SCardGetStatusChangeW(native, call.timeout, states.as_mut_ptr(), states.len() as u32) };
+                let status = unsafe {
+                    SCardGetStatusChangeW(
+                        native,
+                        call.timeout,
+                        states.as_mut_ptr(),
+                        u32::try_from(states.len()).unwrap_or(u32::MAX),
+                    )
+                };
                 let code = if cancel.load(Ordering::Acquire) {
                     ReturnCode::Cancelled
                 } else {
@@ -771,7 +777,7 @@ fn card_status_w(handle: usize) -> Result<(Vec<String>, CardState, CardProtocol,
     let mut state = 0u32;
     let mut protocol = 0u32;
     let mut atr = [0u8; 36];
-    let mut atr_len = atr.len() as u32;
+    let mut atr_len = u32::try_from(atr.len()).unwrap_or(u32::MAX);
     // SAFETY: length probe with null name buffer.
     let probe = map_status(unsafe {
         SCardStatusW(
@@ -790,7 +796,7 @@ fn card_status_w(handle: usize) -> Result<(Vec<String>, CardState, CardProtocol,
     let mut names = Vec::new();
     if name_len > 0 {
         let mut name_buf = vec![0u16; name_len as usize];
-        atr_len = atr.len() as u32;
+        atr_len = u32::try_from(atr.len()).unwrap_or(u32::MAX);
         // SAFETY: handle session-owned; buffers sized for WinSCard.
         let code = map_status(unsafe {
             SCardStatusW(
@@ -825,7 +831,7 @@ fn card_status_w(handle: usize) -> Result<(Vec<String>, CardState, CardProtocol,
         card_state,
         CardProtocol::from_bits_retain(protocol),
         wire,
-        atr_len.min(MAX_ATR as u32),
+        atr_len.min(u32::try_from(MAX_ATR).unwrap_or(u32::MAX)),
     ))
 }
 
@@ -899,7 +905,7 @@ fn finish_list(
     cs: CharacterSet,
 ) -> SvcMessage {
     let need_chars = multi_chars(&v, cs);
-    let need_bytes = encoded_multistring_len(&v, cs) as u32;
+    let need_bytes = u32::try_from(encoded_multistring_len(&v, cs)).unwrap_or(u32::MAX);
     if is_null || size_chars == 0 {
         return complete_rpce(
             req,
@@ -929,7 +935,7 @@ fn finish_status(
 ) -> SvcMessage {
     let cs = status_cs(ioctl);
     let need_chars = multi_chars(&names, cs);
-    let need_bytes = encoded_multistring_len(&names, cs) as u32;
+    let need_bytes = u32::try_from(encoded_multistring_len(&names, cs)).unwrap_or(u32::MAX);
     if names_null || names_cap == 0 || (names_cap != SCARD_AUTOALLOCATE && names_cap < need_chars) {
         let code = if names_null || names_cap == 0 {
             ReturnCode::Success
@@ -1037,7 +1043,7 @@ fn list_cs(ioctl: ScardIoCtlCode) -> CharacterSet {
 }
 
 fn multi_chars(v: &[String], cs: CharacterSet) -> u32 {
-    let bytes = encoded_multistring_len(v, cs) as u32;
+    let bytes = u32::try_from(encoded_multistring_len(v, cs)).unwrap_or(u32::MAX);
     if matches!(cs, CharacterSet::Unicode) {
         bytes / 2
     } else {
@@ -1050,7 +1056,7 @@ fn pack_pci(pci: &SCardIORequest) -> Vec<u8> {
     let mut buf = vec![0u8; hdr + pci.extra_bytes.len()];
     let req = SCARD_IO_REQUEST {
         dwProtocol: pci.protocol.bits(),
-        cbPciLength: buf.len() as u32,
+        cbPciLength: u32::try_from(buf.len()).unwrap_or(u32::MAX),
     };
     // SAFETY: write unaligned header into owned byte buffer.
     unsafe {
@@ -1082,7 +1088,7 @@ fn unpack_pci(raw: &[u8]) -> SCardIORequest {
 }
 
 fn map_status(status: i32) -> ReturnCode {
-    let code = status as u32;
+    let code = u32::from_ne_bytes(i32::to_ne_bytes(status));
     match code {
         0 => ReturnCode::Success,
         // SAFETY: ReturnCode is #[repr(u32)]; ranges are defined variants.

--- a/crates/ironrdp-rdpdr/src/pdu/esc/mod.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/esc/mod.rs
@@ -237,6 +237,30 @@ impl ScardContext {
         tmp[..n].copy_from_slice(&self.bytes[..n]);
         u32::from_le_bytes(tmp)
     }
+
+    /// Creates a context from a native WinSCard `SCARDCONTEXT` (4 bytes on x86, 8 on x64).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `size_of::<usize>()` does not fit in `u8` (never on supported targets).
+    pub fn from_native(native: usize) -> Self {
+        let le = native.to_le_bytes();
+        let mut bytes = [0u8; 16];
+        bytes[..le.len()].copy_from_slice(&le);
+        Self {
+            // INVARIANT: `size_of::<usize>()` is 4 or 8, both fit in `u8`.
+            len: u8::try_from(le.len()).expect("usize byte length fits in u8"),
+            bytes,
+        }
+    }
+
+    /// Native WinSCard `SCARDCONTEXT` value (0 when empty).
+    pub fn native(self) -> usize {
+        let mut tmp = [0u8; size_of::<usize>()];
+        let n = usize::from(self.len).min(size_of::<usize>());
+        tmp[..n].copy_from_slice(&self.bytes[..n]);
+        usize::from_le_bytes(tmp)
+    }
 }
 
 impl ndr::Encode for ScardContext {
@@ -1454,6 +1478,31 @@ impl ScardHandle {
         let n = usize::from(self.len).min(4);
         tmp[..n].copy_from_slice(&self.bytes[..n]);
         u32::from_le_bytes(tmp)
+    }
+
+    /// Creates a handle from a native WinSCard `SCARDHANDLE` (4 bytes on x86, 8 on x64).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `size_of::<usize>()` does not fit in `u8` (never on supported targets).
+    pub fn from_native(context: ScardContext, native: usize) -> Self {
+        let le = native.to_le_bytes();
+        let mut bytes = [0u8; 16];
+        bytes[..le.len()].copy_from_slice(&le);
+        Self {
+            context,
+            // INVARIANT: `size_of::<usize>()` is 4 or 8, both fit in `u8`.
+            len: u8::try_from(le.len()).expect("usize byte length fits in u8"),
+            bytes,
+        }
+    }
+
+    /// Native WinSCard `SCARDHANDLE` value (0 when empty).
+    pub fn native(self) -> usize {
+        let mut tmp = [0u8; size_of::<usize>()];
+        let n = usize::from(self.len).min(size_of::<usize>());
+        tmp[..n].copy_from_slice(&self.bytes[..n]);
+        usize::from_le_bytes(tmp)
     }
 }
 

--- a/crates/ironrdp-rdpdr/src/pdu/esc/mod.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/esc/mod.rs
@@ -945,9 +945,14 @@ impl rpce::HeaderlessEncode for ListReadersReturn {
         dst.write_u32(self.return_code.into());
         match &self.readers {
             Some(readers) => {
+                let c_bytes: u32 = cast_length!(
+                    "ListReadersReturn",
+                    "readers",
+                    encoded_multistring_len(readers, self.encoding)
+                )?;
                 let mut index = 0;
-                ndr::encode_ptr(Some(self.c_bytes), &mut index, dst)?;
-                dst.write_u32(self.c_bytes);
+                ndr::encode_ptr(Some(c_bytes), &mut index, dst)?;
+                dst.write_u32(c_bytes);
                 write_multistring_to_cursor(dst, readers, self.encoding)?;
             }
             None => {
@@ -1987,13 +1992,18 @@ impl rpce::HeaderlessEncode for StatusReturn {
         dst.write_u32(self.return_code.into());
         match &self.reader_names {
             Some(names) => {
+                let c_bytes: u32 = cast_length!(
+                    "StatusReturn",
+                    "reader_names",
+                    encoded_multistring_len(names, self.encoding)
+                )?;
                 let mut index = 0;
-                ndr::encode_ptr(Some(self.reader_c_bytes), &mut index, dst)?;
+                ndr::encode_ptr(Some(c_bytes), &mut index, dst)?;
                 dst.write_u32(self.state.into());
                 dst.write_u32(self.protocol.bits());
                 dst.write_slice(&self.atr);
                 dst.write_u32(self.atr_length);
-                dst.write_u32(self.reader_c_bytes);
+                dst.write_u32(c_bytes);
                 write_multistring_to_cursor(dst, names, self.encoding)?;
             }
             None => {
@@ -3137,6 +3147,17 @@ mod tests {
         let list_probe = ListReadersReturn::probe(ReturnCode::InsufficientBuffer, 12, CharacterSet::Ansi).into_inner();
         assert_eq!(enc_headerless(&list_full).len(), HeaderlessEncode::size(&list_full));
         assert_eq!(enc_headerless(&list_probe).len(), HeaderlessEncode::size(&list_probe));
+        let list_with_stale_length = ListReadersReturn {
+            return_code: ReturnCode::Success,
+            encoding: CharacterSet::Unicode,
+            c_bytes: 0,
+            readers: Some(vec!["RDR".into()]),
+        };
+        assert_eq!(
+            enc_headerless(&list_with_stale_length),
+            enc_headerless(&list_full),
+            "full replies derive cBytes from their live multistring"
+        );
 
         let xmit_full = TransmitReturn::new(ReturnCode::Success, None, vec![0x90, 0x00]).into_inner();
         let xmit_probe = TransmitReturn::recv_probe(ReturnCode::Success, None, 256).into_inner();
@@ -3171,6 +3192,21 @@ mod tests {
         assert_eq!(
             enc_headerless(&status_probe).len(),
             HeaderlessEncode::size(&status_probe)
+        );
+        let status_with_stale_length = StatusReturn {
+            return_code: ReturnCode::Success,
+            reader_names: Some(vec!["RDR".into()]),
+            reader_c_bytes: 0,
+            state: CardState::Present,
+            protocol: CardProtocol::SCARD_PROTOCOL_T0,
+            atr,
+            atr_length: 5,
+            encoding: CharacterSet::Unicode,
+        };
+        assert_eq!(
+            enc_headerless(&status_with_stale_length),
+            enc_headerless(&status_full),
+            "full replies derive cBytes from their live multistring"
         );
 
         let state_full = StateReturn::new(

--- a/crates/ironrdp-rdpdr/src/pdu/esc/mod.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/esc/mod.rs
@@ -909,14 +909,33 @@ impl rpce::HeaderlessDecode for ListReadersCall {
 #[derive(Debug, PartialEq, Clone)]
 pub struct ListReadersReturn {
     pub return_code: ReturnCode,
-    pub readers: Vec<String>,
+    pub encoding: CharacterSet,
+    /// Wire `cBytes` (byte length of multistring when present).
+    pub c_bytes: u32,
+    /// `None` => NULL `msz` (length-only / insufficient-buffer probe).
+    pub readers: Option<Vec<String>>,
 }
 
 impl ListReadersReturn {
     const NAME: &'static str = "ListReaders_Return";
 
-    pub fn new(return_code: ReturnCode, readers: Vec<String>) -> rpce::Pdu<Self> {
-        rpce::Pdu(Self { return_code, readers })
+    pub fn new(return_code: ReturnCode, readers: Vec<String>, encoding: CharacterSet) -> rpce::Pdu<Self> {
+        let c_bytes = encoded_multistring_len(&readers, encoding) as u32;
+        rpce::Pdu(Self {
+            return_code,
+            encoding,
+            c_bytes,
+            readers: Some(readers),
+        })
+    }
+
+    pub fn probe(return_code: ReturnCode, c_bytes: u32, encoding: CharacterSet) -> rpce::Pdu<Self> {
+        rpce::Pdu(Self {
+            return_code,
+            encoding,
+            c_bytes,
+            readers: None,
+        })
     }
 }
 
@@ -924,15 +943,18 @@ impl rpce::HeaderlessEncode for ListReadersReturn {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         ensure_size!(in: dst, size: self.size());
         dst.write_u32(self.return_code.into());
-        let readers_length: u32 = cast_length!(
-            "ListReadersReturn",
-            "readers",
-            encoded_multistring_len(&self.readers, CharacterSet::Unicode)
-        )?;
-        let mut index = 0;
-        ndr::encode_ptr(Some(readers_length), &mut index, dst)?;
-        dst.write_u32(readers_length);
-        write_multistring_to_cursor(dst, &self.readers, CharacterSet::Unicode)?;
+        match &self.readers {
+            Some(readers) => {
+                let mut index = 0;
+                ndr::encode_ptr(Some(self.c_bytes), &mut index, dst)?;
+                dst.write_u32(self.c_bytes);
+                write_multistring_to_cursor(dst, readers, self.encoding)?;
+            }
+            None => {
+                dst.write_u32(self.c_bytes);
+                dst.write_u32(0);
+            }
+        }
         Ok(())
     }
 
@@ -941,10 +963,11 @@ impl rpce::HeaderlessEncode for ListReadersReturn {
     }
 
     fn size(&self) -> usize {
-        self.return_code.size() // dst.write_u32(self.return_code.into());
-        + ndr::ptr_size(true) // ndr::encode_ptr(...);
-        + 4 // dst.write_u32(readers_length);
-        + encoded_multistring_len(&self.readers, CharacterSet::Unicode) // write_multistring_to_cursor(...);
+        self.return_code.size()
+            + match &self.readers {
+                Some(readers) => ndr::ptr_size(true) + 4 + encoded_multistring_len(readers, self.encoding),
+                None => 8,
+            }
     }
 }
 
@@ -1791,17 +1814,30 @@ impl ndr::Encode for SCardIORequest {
 pub struct TransmitReturn {
     pub return_code: ReturnCode,
     pub recv_pci: Option<SCardIORequest>,
-    pub recv_buffer: Vec<u8>,
+    /// `None` => NULL `pbRecvBuffer`; `recv_len` supplies `cbRecvLength`.
+    pub recv_buffer: Option<Vec<u8>>,
+    pub recv_len: u32,
 }
 
 impl TransmitReturn {
     const NAME: &'static str = "Transmit_Return";
 
     pub fn new(return_code: ReturnCode, recv_pci: Option<SCardIORequest>, recv_buffer: Vec<u8>) -> rpce::Pdu<Self> {
+        let recv_len = recv_buffer.len() as u32;
         rpce::Pdu(Self {
             return_code,
             recv_pci,
-            recv_buffer,
+            recv_buffer: Some(recv_buffer),
+            recv_len,
+        })
+    }
+
+    pub fn recv_probe(return_code: ReturnCode, recv_pci: Option<SCardIORequest>, recv_len: u32) -> rpce::Pdu<Self> {
+        rpce::Pdu(Self {
+            return_code,
+            recv_pci,
+            recv_buffer: None,
+            recv_len,
         })
     }
 }
@@ -1810,20 +1846,25 @@ impl rpce::HeaderlessEncode for TransmitReturn {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         ensure_size!(in: dst, size: self.size());
         dst.write_u32(self.return_code.into());
-
         let mut index = 0;
         if let Some(recv_pci) = &self.recv_pci {
             recv_pci.encode_ptr(&mut index, dst)?;
             recv_pci.encode_value(dst)?;
         } else {
-            dst.write_u32(0); // null value
+            dst.write_u32(0);
         }
-
-        let recv_buffer_len: u32 = cast_length!("TransmitReturn", "recv_buffer_len", self.recv_buffer.len())?;
-        ndr::encode_ptr(Some(recv_buffer_len), &mut index, dst)?;
-        dst.write_u32(recv_buffer_len);
-        dst.write_slice(&self.recv_buffer);
-
+        match &self.recv_buffer {
+            Some(buf) => {
+                let n: u32 = cast_length!("TransmitReturn", "recv_buffer_len", buf.len())?;
+                ndr::encode_ptr(Some(n), &mut index, dst)?;
+                dst.write_u32(n);
+                dst.write_slice(buf);
+            }
+            None => {
+                dst.write_u32(self.recv_len);
+                dst.write_u32(0);
+            }
+        }
         Ok(())
     }
 
@@ -1832,15 +1873,12 @@ impl rpce::HeaderlessEncode for TransmitReturn {
     }
 
     fn size(&self) -> usize {
-        self.return_code.size() // dst.write_u32(self.return_code.into());
-        + if let Some(recv_pci) = &self.recv_pci {
-            recv_pci.size()
-        } else {
-            4 // null value
-        }
-        + ndr::ptr_size(true) // ndr::encode_ptr(Some(recv_buffer_len), &mut index, dst)?;
-        + 4 // dst.write_u32(recv_buffer_len);
-        + self.recv_buffer.len() // dst.write_slice(&self.recv_buffer);
+        self.return_code.size()
+            + self.recv_pci.as_ref().map_or(4, SCardIORequest::size)
+            + match &self.recv_buffer {
+                Some(buf) => ndr::ptr_size(true) + 4 + buf.len(),
+                None => 8,
+            }
     }
 }
 
@@ -1886,12 +1924,13 @@ impl rpce::HeaderlessDecode for StatusCall {
 #[derive(Debug, PartialEq, Clone)]
 pub struct StatusReturn {
     pub return_code: ReturnCode,
-    pub reader_names: Vec<String>,
+    /// `None` => NULL reader-name multistring (probe / insufficient buffer).
+    pub reader_names: Option<Vec<String>>,
+    pub reader_c_bytes: u32,
     pub state: CardState,
     pub protocol: CardProtocol,
     pub atr: [u8; 32],
     pub atr_length: u32,
-
     pub encoding: CharacterSet,
 }
 
@@ -1907,9 +1946,32 @@ impl StatusReturn {
         atr_length: u32,
         encoding: CharacterSet,
     ) -> rpce::Pdu<Self> {
+        let reader_c_bytes = encoded_multistring_len(&reader_names, encoding) as u32;
         rpce::Pdu(Self {
             return_code,
-            reader_names,
+            reader_names: Some(reader_names),
+            reader_c_bytes,
+            state,
+            protocol,
+            atr,
+            atr_length,
+            encoding,
+        })
+    }
+
+    pub fn names_probe(
+        return_code: ReturnCode,
+        reader_c_bytes: u32,
+        state: CardState,
+        protocol: CardProtocol,
+        atr: [u8; 32],
+        atr_length: u32,
+        encoding: CharacterSet,
+    ) -> rpce::Pdu<Self> {
+        rpce::Pdu(Self {
+            return_code,
+            reader_names: None,
+            reader_c_bytes,
             state,
             protocol,
             atr,
@@ -1923,19 +1985,26 @@ impl rpce::HeaderlessEncode for StatusReturn {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         ensure_size!(in: dst, size: self.size());
         dst.write_u32(self.return_code.into());
-        let mut index = 0;
-        let reader_names_length: u32 = cast_length!(
-            "StatusReturn",
-            "reader_names_length",
-            encoded_multistring_len(&self.reader_names, self.encoding)
-        )?;
-        ndr::encode_ptr(Some(reader_names_length), &mut index, dst)?;
-        dst.write_u32(self.state.into());
-        dst.write_u32(self.protocol.bits());
-        dst.write_slice(&self.atr);
-        dst.write_u32(self.atr_length);
-        dst.write_u32(reader_names_length);
-        write_multistring_to_cursor(dst, &self.reader_names, self.encoding)?;
+        match &self.reader_names {
+            Some(names) => {
+                let mut index = 0;
+                ndr::encode_ptr(Some(self.reader_c_bytes), &mut index, dst)?;
+                dst.write_u32(self.state.into());
+                dst.write_u32(self.protocol.bits());
+                dst.write_slice(&self.atr);
+                dst.write_u32(self.atr_length);
+                dst.write_u32(self.reader_c_bytes);
+                write_multistring_to_cursor(dst, names, self.encoding)?;
+            }
+            None => {
+                dst.write_u32(self.reader_c_bytes);
+                dst.write_u32(0);
+                dst.write_u32(self.state.into());
+                dst.write_u32(self.protocol.bits());
+                dst.write_slice(&self.atr);
+                dst.write_u32(self.atr_length);
+            }
+        }
         Ok(())
     }
 
@@ -1944,10 +2013,16 @@ impl rpce::HeaderlessEncode for StatusReturn {
     }
 
     fn size(&self) -> usize {
-        size_of::<u32>() * 5 // dst.write_u32(self.return_code.into()); dst.write_u32(self.state.into()); dst.write_u32(self.protocol.bits()); dst.write_slice(&self.atr); dst.write_u32(self.atr_length);
-        + ndr::ptr_size(true) // ndr::encode_ptr(Some(reader_names_length), &mut index, dst)?;
-        + self.atr.len() // dst.write_slice(&self.atr);
-        + encoded_multistring_len(&self.reader_names, self.encoding) // write_multistring_to_cursor(dst, &self.reader_names, self.encoding)?;
+        // return + (names ptr/len) + state + protocol + atr[32] + atr_len [+ names bytes]
+        4 + 8
+            + 4
+            + 4
+            + 32
+            + 4
+            + self
+                .reader_names
+                .as_ref()
+                .map_or(0, |n| encoded_multistring_len(n, self.encoding))
     }
 }
 
@@ -2551,18 +2626,37 @@ pub struct StateReturn {
     pub return_code: ReturnCode,
     pub state: CardState,
     pub protocol: CardProtocol,
-    pub atr: Vec<u8>,
+    /// `None` => NULL `rgAtr`; `atr_len` supplies `cbAtrLen`.
+    pub atr: Option<Vec<u8>>,
+    pub atr_len: u32,
 }
 
 impl StateReturn {
     const NAME: &'static str = "State_Return";
 
     pub fn new(return_code: ReturnCode, state: CardState, protocol: CardProtocol, atr: Vec<u8>) -> rpce::Pdu<Self> {
+        let atr_len = atr.len() as u32;
         rpce::Pdu(Self {
             return_code,
             state,
             protocol,
-            atr,
+            atr: Some(atr),
+            atr_len,
+        })
+    }
+
+    pub fn atr_probe(
+        return_code: ReturnCode,
+        state: CardState,
+        protocol: CardProtocol,
+        atr_len: u32,
+    ) -> rpce::Pdu<Self> {
+        rpce::Pdu(Self {
+            return_code,
+            state,
+            protocol,
+            atr: None,
+            atr_len,
         })
     }
 }
@@ -2573,15 +2667,25 @@ impl rpce::HeaderlessEncode for StateReturn {
         dst.write_u32(self.return_code.into());
         dst.write_u32(self.state.into());
         dst.write_u32(self.protocol.bits());
-        // MS-RDPESC: cbAtrLen range(0,36)
-        if self.atr.len() > 36 {
-            return Err(invalid_field_err!("encode", "StateReturn cbAtrLen out of range"));
+        match &self.atr {
+            Some(atr) => {
+                if atr.len() > 36 {
+                    return Err(invalid_field_err!("encode", "StateReturn cbAtrLen out of range"));
+                }
+                let atr_len: u32 = cast_length!("StateReturn", "atr_len", atr.len())?;
+                let mut index = 0;
+                ndr::encode_ptr(Some(atr_len), &mut index, dst)?;
+                dst.write_u32(atr_len);
+                dst.write_slice(atr);
+            }
+            None => {
+                if self.atr_len > 36 {
+                    return Err(invalid_field_err!("encode", "StateReturn cbAtrLen out of range"));
+                }
+                dst.write_u32(self.atr_len);
+                dst.write_u32(0);
+            }
         }
-        let atr_len: u32 = cast_length!("StateReturn", "atr_len", self.atr.len())?;
-        let mut index = 0;
-        ndr::encode_ptr(Some(atr_len), &mut index, dst)?;
-        dst.write_u32(atr_len);
-        dst.write_slice(&self.atr);
         Ok(())
     }
 
@@ -2590,12 +2694,10 @@ impl rpce::HeaderlessEncode for StateReturn {
     }
 
     fn size(&self) -> usize {
-        self.return_code.size()
-            + 4 /* dwState */
-            + 4 /* dwProtocol */
-            + ndr::ptr_size(true)
-            + 4 /* cbAtrLen value */
-            + self.atr.len()
+        12 + match &self.atr {
+            Some(atr) => ndr::ptr_size(true) + 4 + atr.len(),
+            None => 8,
+        }
     }
 }
 

--- a/crates/ironrdp-rdpdr/src/pdu/esc/mod.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/esc/mod.rs
@@ -2013,16 +2013,16 @@ impl rpce::HeaderlessEncode for StatusReturn {
     }
 
     fn size(&self) -> usize {
-        // return + (names ptr/len) + state + protocol + atr[32] + atr_len [+ names bytes]
+        // return + cBytes + msz ptr + state + protocol + atr[32] + atr_len
+        // + deferred [cBytes + msz bytes] when names are present
         4 + 8
             + 4
             + 4
             + 32
             + 4
-            + self
-                .reader_names
-                .as_ref()
-                .map_or(0, |n| encoded_multistring_len(n, self.encoding))
+            + self.reader_names.as_ref().map_or(0, |n| {
+                4 /* deferred cBytes */ + encoded_multistring_len(n, self.encoding)
+            })
     }
 }
 
@@ -3119,6 +3119,76 @@ mod tests {
                 0x11, 4, 0, 0, 0, 0x44, 0x44, 0x33, 0x33,
             ]
         );
+    }
+
+    fn enc_headerless(body: &impl HeaderlessEncode) -> Vec<u8> {
+        let mut buf = vec![0u8; HeaderlessEncode::size(body)];
+        HeaderlessEncode::encode(body, &mut WriteCursor::new(&mut buf)).unwrap();
+        buf
+    }
+
+    /// size() must match bytes written for full and probe variants (Status undercount was a live bug).
+    #[test]
+    fn esc_return_size_matches_encode_full_and_probe() {
+        let names = vec!["RDR".into()];
+        let atr = [0x3Bu8; 32];
+
+        let list_full = ListReadersReturn::new(ReturnCode::Success, names.clone(), CharacterSet::Unicode).into_inner();
+        let list_probe = ListReadersReturn::probe(ReturnCode::InsufficientBuffer, 12, CharacterSet::Ansi).into_inner();
+        assert_eq!(enc_headerless(&list_full).len(), HeaderlessEncode::size(&list_full));
+        assert_eq!(enc_headerless(&list_probe).len(), HeaderlessEncode::size(&list_probe));
+
+        let xmit_full = TransmitReturn::new(ReturnCode::Success, None, vec![0x90, 0x00]).into_inner();
+        let xmit_probe = TransmitReturn::recv_probe(ReturnCode::Success, None, 256).into_inner();
+        assert_eq!(enc_headerless(&xmit_full).len(), HeaderlessEncode::size(&xmit_full));
+        assert_eq!(enc_headerless(&xmit_probe).len(), HeaderlessEncode::size(&xmit_probe));
+
+        let status_full = StatusReturn::new(
+            ReturnCode::Success,
+            names,
+            CardState::Present,
+            CardProtocol::SCARD_PROTOCOL_T0,
+            atr,
+            5,
+            CharacterSet::Unicode,
+        )
+        .into_inner();
+        let status_probe = StatusReturn::names_probe(
+            ReturnCode::InsufficientBuffer,
+            20,
+            CardState::Present,
+            CardProtocol::SCARD_PROTOCOL_T0,
+            atr,
+            5,
+            CharacterSet::Unicode,
+        )
+        .into_inner();
+        assert_eq!(
+            HeaderlessEncode::size(&status_full),
+            4 * 5 + 8 + 32 + encoded_multistring_len(status_full.reader_names.as_ref().unwrap(), CharacterSet::Unicode)
+        );
+        assert_eq!(enc_headerless(&status_full).len(), HeaderlessEncode::size(&status_full));
+        assert_eq!(
+            enc_headerless(&status_probe).len(),
+            HeaderlessEncode::size(&status_probe)
+        );
+
+        let state_full = StateReturn::new(
+            ReturnCode::Success,
+            CardState::Present,
+            CardProtocol::SCARD_PROTOCOL_T1,
+            vec![1, 2, 3],
+        )
+        .into_inner();
+        let state_probe = StateReturn::atr_probe(
+            ReturnCode::InsufficientBuffer,
+            CardState::Present,
+            CardProtocol::SCARD_PROTOCOL_T1,
+            3,
+        )
+        .into_inner();
+        assert_eq!(enc_headerless(&state_full).len(), HeaderlessEncode::size(&state_full));
+        assert_eq!(enc_headerless(&state_probe).len(), HeaderlessEncode::size(&state_probe));
     }
 
     /// 6-byte Unicode mszCards needs 2-byte NDR pad before reader states.

--- a/crates/ironrdp-rdpdr/src/pdu/esc/mod.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/esc/mod.rs
@@ -920,7 +920,7 @@ impl ListReadersReturn {
     const NAME: &'static str = "ListReaders_Return";
 
     pub fn new(return_code: ReturnCode, readers: Vec<String>, encoding: CharacterSet) -> rpce::Pdu<Self> {
-        let c_bytes = encoded_multistring_len(&readers, encoding) as u32;
+        let c_bytes = u32::try_from(encoded_multistring_len(&readers, encoding)).unwrap_or(u32::MAX);
         rpce::Pdu(Self {
             return_code,
             encoding,
@@ -1823,7 +1823,7 @@ impl TransmitReturn {
     const NAME: &'static str = "Transmit_Return";
 
     pub fn new(return_code: ReturnCode, recv_pci: Option<SCardIORequest>, recv_buffer: Vec<u8>) -> rpce::Pdu<Self> {
-        let recv_len = recv_buffer.len() as u32;
+        let recv_len = u32::try_from(recv_buffer.len()).unwrap_or(u32::MAX);
         rpce::Pdu(Self {
             return_code,
             recv_pci,
@@ -1946,7 +1946,7 @@ impl StatusReturn {
         atr_length: u32,
         encoding: CharacterSet,
     ) -> rpce::Pdu<Self> {
-        let reader_c_bytes = encoded_multistring_len(&reader_names, encoding) as u32;
+        let reader_c_bytes = u32::try_from(encoded_multistring_len(&reader_names, encoding)).unwrap_or(u32::MAX);
         rpce::Pdu(Self {
             return_code,
             reader_names: Some(reader_names),
@@ -2635,7 +2635,7 @@ impl StateReturn {
     const NAME: &'static str = "State_Return";
 
     pub fn new(return_code: ReturnCode, state: CardState, protocol: CardProtocol, atr: Vec<u8>) -> rpce::Pdu<Self> {
-        let atr_len = atr.len() as u32;
+        let atr_len = u32::try_from(atr.len()).unwrap_or(u32::MAX);
         rpce::Pdu(Self {
             return_code,
             state,


### PR DESCRIPTION
Replace the PR2 Windows smartcard stub with a trimmed WinSCard core so logon-critical MS-RDPESC IOCTLs complete against the host resource manager.

Implemented: AccessStartedEvent, ReleaseTartedEvent (Success no-op), EstablishContext/ReleaseContext, ListReaders/ListReaderGroups, GetStatusChange (deferred worker + cancel), Connect/Disconnect, BeginTransaction/EndTransaction/Cancel, Transmit, Status, State, Reconnect. Session keeps native context/handle maps, deferred pool, and PR2 new/reset/poll/handle_call shapes.

ANSI IOCTLs are upgraded to UTF-16 and executed via WinSCard *W APIs; StatusA still reports ANSI charset on the wire. Adds ScardContext/ScardHandle from_native/native helpers for 4/8-byte native handles.

Deferred to PR4 as typed UnsupportedFeature: LocateCards*, Control, Get/SetAttrib, GetTransmitCount, cache/icon/device-type, and reader-group admin string calls. Product wiring remains PR5.

Size gate: counted add+del in .rs/.toml = 1285 (under XXL 1300).