### PR TITLE
feat(activex): support automatic reconnect

### DIFF
--- a/crates/ironrdp-activex/README.md
+++ b/crates/ironrdp-activex/README.md
@@ -311,8 +311,9 @@ cookie and an active session actually fails, `AdvancedSettings.EnableAutoReconne
 enabled) and `MaxReconnectAttempts` (default `20`) bound retry attempts. Each real attempt raises
 `OnAutoReconnecting` (`0x11`) and `OnAutoReconnecting2` (`0x22`); a completed retry raises
 `OnAutoReconnected()` (`0x21`) without a second `OnConnected`. The continuation pointer exposed
-by `OnAutoReconnecting` is currently advisory: hosts can cancel by calling `Disconnect`, but its
-automatic (`0`), stop (`1`), and manual (`2`) value does not otherwise alter the active retry.
+by `OnAutoReconnecting` controls the pending retry: automatic (`0`) continues, while stop (`1`)
+and manual (`2`) suppress further automatic reconnect attempts. Calling `Disconnect` also stops
+a pending retry.
 
 Worker-to-apartment events are bounded to 64 pending entries. Frame updates coalesce to the latest
 frame, while lifecycle and terminal state evict only frames or static-channel data. A full queue

--- a/crates/ironrdp-activex/README.md
+++ b/crates/ironrdp-activex/README.md
@@ -309,12 +309,16 @@ transitions and preserves their ordering: it is shown after `OnConnecting` (`0x0
 after `OnConnected` (`0x02`) or `OnDisconnected(long)` (`0x04`). When the server supplied a
 cookie and an active session actually fails, `AdvancedSettings.EnableAutoReconnect` (default
 enabled) and `MaxReconnectAttempts` (default `20`) bound retry attempts. Each real attempt raises
-`OnAutoReconnecting` (`0x11`); `OnAutoReconnecting2` (`0x22`) follows only when the original event
-permits continuation. A completed retry raises `OnAutoReconnected()` (`0x21`) without a second
-`OnConnected`. The continuation pointer exposed
-by `OnAutoReconnecting` controls the pending retry: automatic (`0`) continues, while stop (`1`)
-and manual (`2`) suppress further automatic reconnect attempts. Calling `Disconnect` also stops
-a pending retry.
+`OnAutoReconnecting(disconnectReason, attemptCount, AutoReconnectContinueState*)` (`0x11`);
+`OnAutoReconnecting2(disconnectReason, networkAvailable, attemptCount, maximumAttempts)` (`0x22`)
+follows only when the original event permits continuation. IronRDP uses `disconnectReason == 0`
+and `networkAvailable == false` when the transport disappears without a server-provided reason.
+The continuation pointer exposed by `OnAutoReconnecting` controls the pending retry: automatic
+(`0`) continues, while stop (`1`) and manual (`2`) suppress further automatic reconnect attempts.
+A completed retry raises `OnAutoReconnected()` (`0x21`) only after post-reconnect active-session
+traffic confirms the session is usable; a server ARC-status rejection clears the cookie and does
+not raise that success event. Display-size fallback reconnects deliberately start a new session
+without reusing the session-bound ARC cookie. Calling `Disconnect` also stops a pending retry.
 
 Worker-to-apartment events are bounded to 64 pending entries. Frame updates coalesce to the latest
 frame, while lifecycle and terminal state evict only frames or static-channel data. A full queue

--- a/crates/ironrdp-activex/README.md
+++ b/crates/ironrdp-activex/README.md
@@ -281,7 +281,7 @@ A source-level audit of RDM's Windows RDP host covers these ActiveX contracts:
 | Legacy RDP 6.1 through 11 host selection | The six published `MsRdpClient*NotSafeForScripting` class identifiers are accepted by `DllGetClassObject` and preserve their requested `IPersist` class identity. They are explicit backend aliases, not global COM registrations. |
 | WinForms `AxHost` lifecycle | Windowed OLE activation, focus, sizing, the inherited `IMsRdpClient` through `IMsRdpClient10` raw interfaces, and the RDM virtual channels `RDMJump`, `RDMLog`, and `RDMCmd` are supported. |
 | Connection configuration | Server, account, desktop, color, smart-sizing, keyboard, display update, gateway, audio, clipboard, CredSSP, client-device name, RemoteApp, and backing `ConfigBuilder` settings are mapped where IronRDP provides the same behavior. |
-| Events | Connecting, connected, login-complete, disconnect, fatal-error, fullscreen-leave, virtual-channel, resize, and writable confirm-close events are delivered on the creating apartment. Warning and auto-reconnect events remain unfired until an IronRDP worker produces their real state. |
+| Events | Connecting, connected, login-complete, disconnect, fatal-error, fullscreen-leave, virtual-channel, resize, writable confirm-close, and worker-backed warning and auto-reconnect events are delivered on the creating apartment. |
 | Optional RDM interfaces | `IMsRdpDriveCollection` exposes Windows logical volumes for static filesystem redirection. Non-filesystem device, camera, monitor, and preferred-redirection capabilities remain unavailable. |
 
 The audit also identified RDM settings that have no IronRDP ActiveX backend: input throttling,
@@ -309,8 +309,9 @@ transitions and preserves their ordering: it is shown after `OnConnecting` (`0x0
 after `OnConnected` (`0x02`) or `OnDisconnected(long)` (`0x04`). When the server supplied a
 cookie and an active session actually fails, `AdvancedSettings.EnableAutoReconnect` (default
 enabled) and `MaxReconnectAttempts` (default `20`) bound retry attempts. Each real attempt raises
-`OnAutoReconnecting` (`0x11`) and `OnAutoReconnecting2` (`0x22`); a completed retry raises
-`OnAutoReconnected()` (`0x21`) without a second `OnConnected`. The continuation pointer exposed
+`OnAutoReconnecting` (`0x11`); `OnAutoReconnecting2` (`0x22`) follows only when the original event
+permits continuation. A completed retry raises `OnAutoReconnected()` (`0x21`) without a second
+`OnConnected`. The continuation pointer exposed
 by `OnAutoReconnecting` controls the pending retry: automatic (`0`) continues, while stop (`1`)
 and manual (`2`) suppress further automatic reconnect attempts. Calling `Disconnect` also stops
 a pending retry.

--- a/crates/ironrdp-activex/README.md
+++ b/crates/ironrdp-activex/README.md
@@ -183,16 +183,13 @@ The public OLE `EnableModeless` notification enables or disables only the bar's 
 commands while a container-owned modal dialog is active; it neither hides the bar nor changes the
 RDP session. The setting is retained for a subsequently created bar.
 
-While an IronRDP connection is genuinely starting, the control also presents an IronRDP-owned,
+While an IronRDP connection is genuinely starting or retrying after an eligible transport loss, the control presents an IronRDP-owned,
 modeless, non-activating connection-health popup owned by the renderer. It is centered over the
 renderer, scales from that child window's DPI, and polls only its own owner-relative geometry; it
-does not subclass or otherwise modify an embedding host window. The generic worker currently has
-no truthful reconnect-progress transition, so the popup shows only **Connecting...** and is removed
-after actual connection, final disconnect/error, OLE close/deactivation, or renderer destruction.
-An internal hook accepts future worker retry progress only when both a positive attempt and its
-maximum are known; only then may it display **Reconnecting...** and `Attempt N of M`. It has no
-Cancel action, never includes endpoints, credentials, certificates, or error detail, and never
-raises a COM event.
+does not subclass or otherwise modify an embedding host window. During a real automatic reconnect it
+shows **Reconnecting...** and `Attempt N of M`; it is removed only after a successful reconnect, final
+disconnect/error, OLE close/deactivation, or renderer destruction. It has no Cancel action and never
+includes endpoints, credentials, certificates, cookie values, or error detail.
 
 When an actual Display Control update cannot complete in-session, IronRDP's worker reports that it
 is reconnecting with the requested display size. The same popup then shows **Updating remote
@@ -287,9 +284,12 @@ A source-level audit of RDM's Windows RDP host covers these ActiveX contracts:
 | Events | Connecting, connected, login-complete, disconnect, fatal-error, fullscreen-leave, virtual-channel, resize, and writable confirm-close events are delivered on the creating apartment. Warning and auto-reconnect events remain unfired until an IronRDP worker produces their real state. |
 | Optional RDM interfaces | `IMsRdpDriveCollection` exposes Windows logical volumes for static filesystem redirection. Non-filesystem device, camera, monitor, and preferred-redirection capabilities remain unavailable. |
 
-The audit also identified RDM settings with no IronRDP ActiveX backend: input throttling, automatic reconnect, authentication policy, printer/port/smart-card and non-filesystem device redirection, audio capture, video policy, PCB, load balancing, and Microsoft workspace extensions.
-Their audited AdvancedSettings vtable slots use their exact published ABI signatures, initialize out parameters, and return `E_NOTIMPL`.
-The control does not report success for settings that cannot affect the connection.
+The audit also identified RDM settings that have no IronRDP ActiveX backend: input throttling,
+authentication policy, device/printer/port/smart-card
+redirection, RemoteApp, audio capture, video policy, PCB, load balancing, and Microsoft workspace
+extensions. Their audited AdvancedSettings vtable slots use their exact published ABI signatures,
+initialize out parameters, and return `E_NOTIMPL`; the control does not report success for settings
+that cannot affect the connection.
 
 The control exposes a standard `IConnectionPointContainer` and an event connection point for the
 published `IMsTscAxEvents` IID `{336D5562-EFA8-482E-8CB3-C5C0FC7A7DB6}`. Lifecycle events are delivered
@@ -298,19 +298,21 @@ COM sink from its background thread. Implemented event DISPIDs are `OnConnecting
 `OnLoginComplete`, `OnDisconnected`, `OnEnterFullScreenMode`, `OnLeaveFullScreenMode`, `OnRequestGoFullScreen`,
 `OnRequestLeaveFullScreen`, `OnFatalError`, `OnAuthenticationWarningDisplayed`,
 `OnAuthenticationWarningDismissed`,
-`OnRemoteDesktopSizeChange`, `OnConnectionBarPullDown`, and `OnConfirmClose`. `IMsRdpClient::RequestClose` raises
+`OnRemoteDesktopSizeChange`, `OnConnectionBarPullDown`, `OnConfirmClose`,
+`OnAutoReconnecting`, `OnAutoReconnecting2`, and `OnAutoReconnected`. `IMsRdpClient::RequestClose` raises
 `OnConfirmClose` synchronously on the creating apartment with its documented `VT_BOOL | VT_BYREF`
 argument. A sink can veto closing; the control then returns `controlCloseWaitForEvents` instead of
 `controlCloseCanProceed`. `OnConnected` follows completed IronRDP connection activation, and
 `OnLoginComplete` follows the server's value-free Save Session Info notification rather than the
 first decoded framebuffer. The connection-health popup follows only those actual lifecycle
 transitions and preserves their ordering: it is shown after `OnConnecting` (`0x01`) and removed
-after `OnConnected` (`0x02`) or `OnDisconnected(long)` (`0x04`). It does not synthesize
-`OnAutoReconnecting(long,long,AutoReconnectContinueState*)` (`0x11`),
-`OnAutoReconnected()` (`0x21`), or
-`OnAutoReconnecting2(long,VARIANT_BOOL,long,long)` (`0x22`). Those events and their public
-automatic (`0`), stop (`1`), and manual (`2`) continuation values remain unavailable until an
-IronRDP worker produces the corresponding real state.
+after `OnConnected` (`0x02`) or `OnDisconnected(long)` (`0x04`). When the server supplied a
+cookie and an active session actually fails, `AdvancedSettings.EnableAutoReconnect` (default
+enabled) and `MaxReconnectAttempts` (default `20`) bound retry attempts. Each real attempt raises
+`OnAutoReconnecting` (`0x11`) and `OnAutoReconnecting2` (`0x22`); a completed retry raises
+`OnAutoReconnected()` (`0x21`) without a second `OnConnected`. The continuation pointer exposed
+by `OnAutoReconnecting` is currently advisory: hosts can cancel by calling `Disconnect`, but its
+automatic (`0`), stop (`1`), and manual (`2`) value does not otherwise alter the active retry.
 
 Worker-to-apartment events are bounded to 64 pending entries. Frame updates coalesce to the latest
 frame, while lifecycle and terminal state evict only frames or static-channel data. A full queue

--- a/crates/ironrdp-activex/README.md
+++ b/crates/ironrdp-activex/README.md
@@ -284,12 +284,8 @@ A source-level audit of RDM's Windows RDP host covers these ActiveX contracts:
 | Events | Connecting, connected, login-complete, disconnect, fatal-error, fullscreen-leave, virtual-channel, resize, writable confirm-close, and worker-backed warning and auto-reconnect events are delivered on the creating apartment. |
 | Optional RDM interfaces | `IMsRdpDriveCollection` exposes Windows logical volumes for static filesystem redirection. Non-filesystem device, camera, monitor, and preferred-redirection capabilities remain unavailable. |
 
-The audit also identified RDM settings that have no IronRDP ActiveX backend: input throttling,
-authentication policy, device/printer/port/smart-card
-redirection, RemoteApp, audio capture, video policy, PCB, load balancing, and Microsoft workspace
-extensions. Their audited AdvancedSettings vtable slots use their exact published ABI signatures,
-initialize out parameters, and return `E_NOTIMPL`; the control does not report success for settings
-that cannot affect the connection.
+The audit also identified RDM settings that have no IronRDP ActiveX backend: input throttling, authentication policy, device/printer/port/smart-card redirection, audio capture, video policy, PCB, load balancing, and Microsoft workspace extensions.
+Their audited AdvancedSettings vtable slots use their exact published ABI signatures, initialize out parameters, and return `E_NOTIMPL`; the control does not report success for settings that cannot affect the connection.
 
 The control exposes a standard `IConnectionPointContainer` and an event connection point for the
 published `IMsTscAxEvents` IID `{336D5562-EFA8-482E-8CB3-C5C0FC7A7DB6}`. Lifecycle events are delivered

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -399,8 +399,11 @@ const DISPID_ON_REQUEST_LEAVE_FULL_SCREEN: i32 = 9;
 const DISPID_ON_FATAL_ERROR: i32 = 10;
 const DISPID_ON_REMOTE_DESKTOP_SIZE_CHANGE: i32 = 12;
 const DISPID_ON_CONFIRM_CLOSE: i32 = 15;
+const DISPID_ON_AUTO_RECONNECTING: i32 = 17;
 const DISPID_ON_AUTHENTICATION_WARNING_DISPLAYED: i32 = 18;
 const DISPID_ON_AUTHENTICATION_WARNING_DISMISSED: i32 = 19;
+const DISPID_ON_AUTO_RECONNECTED: i32 = 33;
+const DISPID_ON_AUTO_RECONNECTING2: i32 = 34;
 
 const WM_DISPATCH_EVENTS: u32 = WM_APP + 0x52;
 const WM_DESTROY_CONTROL_WINDOW: u32 = WM_APP + 0x53;
@@ -1049,6 +1052,8 @@ struct CompatibilitySettings {
     authentication_level: u32,
     authentication_level_set: bool,
     public_mode: bool,
+    enable_auto_reconnect: bool,
+    max_reconnect_attempts: u32,
     connection_settings_sealed: bool,
     persistence_dirty: Option<Rc<Cell<bool>>>,
 }
@@ -1120,6 +1125,8 @@ impl Default for CompatibilitySettings {
             authentication_level: 0,
             authentication_level_set: false,
             public_mode: false,
+            enable_auto_reconnect: true,
+            max_reconnect_attempts: 20,
             connection_settings_sealed: false,
             persistence_dirty: None,
         }
@@ -1857,8 +1864,6 @@ advanced_put_not_implemented!(
     (116, advanced_put_redirect_printers, i16),
     (118, advanced_put_redirect_ports, i16),
     (120, advanced_put_redirect_smart_cards, i16),
-    (132, advanced_put_enable_auto_reconnect, i16),
-    (134, advanced_put_max_reconnect_attempts, i32),
     (150, advanced_put_redirect_devices, i16),
     (161, advanced_put_pcb, Bstr),
     (169, advanced_put_connect_to_administer_server, i16),
@@ -1877,8 +1882,6 @@ advanced_get_not_implemented!(
     (117, advanced_get_redirect_printers, i16),
     (119, advanced_get_redirect_ports, i16),
     (121, advanced_get_redirect_smart_cards, i16),
-    (133, advanced_get_enable_auto_reconnect, i16),
-    (135, advanced_get_max_reconnect_attempts, i32),
     (151, advanced_get_redirect_devices, i16),
     (170, advanced_get_connect_to_administer_server, i16),
     (174, advanced_get_video_playback_mode, u32),
@@ -2468,6 +2471,47 @@ unsafe extern "system" fn advanced_put_redirect_clipboard(this: *mut c_void, val
     let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
     object.settings.borrow_mut().redirect_clipboard = value != VARIANT_FALSE.0;
     S_OK
+}
+
+unsafe extern "system" fn advanced_put_enable_auto_reconnect(this: *mut c_void, value: i16) -> HRESULT {
+    let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
+    object.settings.borrow_mut().enable_auto_reconnect = value != VARIANT_FALSE.0;
+    S_OK
+}
+
+unsafe extern "system" fn advanced_get_enable_auto_reconnect(this: *mut c_void, value: *mut i16) -> HRESULT {
+    let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
+    match write_out(
+        value,
+        if object.settings.borrow().enable_auto_reconnect {
+            VARIANT_TRUE.0
+        } else {
+            VARIANT_FALSE.0
+        },
+    ) {
+        Ok(()) => S_OK,
+        Err(error) => error.code(),
+    }
+}
+
+unsafe extern "system" fn advanced_put_max_reconnect_attempts(this: *mut c_void, value: i32) -> HRESULT {
+    let Ok(value) = u32::try_from(value) else {
+        return E_INVALIDARG;
+    };
+    let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
+    object.settings.borrow_mut().max_reconnect_attempts = value;
+    S_OK
+}
+
+unsafe extern "system" fn advanced_get_max_reconnect_attempts(this: *mut c_void, value: *mut i32) -> HRESULT {
+    let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
+    let result = i32::try_from(object.settings.borrow().max_reconnect_attempts)
+        .map_err(|_| Error::from_hresult(E_FAIL))
+        .and_then(|configured| write_out(value, configured));
+    match result {
+        Ok(()) => S_OK,
+        Err(error) => error.code(),
+    }
 }
 
 fn set_audio_redirection_mode(settings: &mut CompatibilitySettings, value: u32) -> Result<()> {
@@ -3453,6 +3497,14 @@ enum WorkerEvent {
         generation: u64,
         data: Vec<u8>,
     },
+    AutoReconnecting {
+        generation: u64,
+        attempt: u32,
+        maximum_attempts: u32,
+    },
+    AutoReconnected {
+        generation: u64,
+    },
     FatalError {
         generation: u64,
         disconnect: DisconnectInfo,
@@ -3480,6 +3532,8 @@ impl WorkerEvent {
             | Self::Image { generation, .. }
             | Self::DisplayResizeFallback { generation }
             | Self::RailWindowingOrders { generation, .. }
+            | Self::AutoReconnecting { generation, .. }
+            | Self::AutoReconnected { generation }
             | Self::FatalError { generation, .. }
             | Self::Disconnected { generation, .. }
             | Self::StaticChannelData { generation, .. }
@@ -6744,12 +6798,6 @@ impl Control {
         self.update_connection_health_window();
     }
 
-    // This is intentionally an internal-only hook. The current IronRDP worker does not expose
-    // retry progress, so public reconnect calls and generic failures must never call it.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "the current worker has no reconnect-progress event")
-    )]
     fn report_reconnect_worker_progress(&self, attempt: u32, maximum: u32) {
         let Some(status) = ConnectionHealthStatus::reconnecting(attempt, maximum) else {
             tracing::warn!(attempt, maximum, "Ignoring invalid reconnect worker progress");
@@ -7392,6 +7440,94 @@ impl Control {
         }
     }
 
+    fn fire_auto_reconnecting_event(&self, attempt: i32, maximum_attempts: i32) {
+        if self.events_are_frozen() {
+            return;
+        }
+
+        let mut continuation = 0;
+        let mut variants = [
+            variant_i32_byref(&mut continuation),
+            variant_i32(maximum_attempts),
+            variant_i32(attempt),
+        ];
+        let params = DISPPARAMS {
+            rgvarg: variants.as_mut_ptr(),
+            rgdispidNamedArgs: ptr::null_mut(),
+            cArgs: variants.len() as u32,
+            cNamedArgs: 0,
+        };
+        let iid_null = GUID::zeroed();
+        let sinks = self
+            .sinks
+            .borrow()
+            .values()
+            .map(|sink| sink.dispatch.clone())
+            .collect::<Vec<_>>();
+
+        for sink in sinks {
+            let result = unsafe {
+                sink.Invoke(
+                    DISPID_ON_AUTO_RECONNECTING,
+                    &iid_null,
+                    0,
+                    DISPATCH_METHOD,
+                    &params,
+                    None,
+                    None,
+                    None,
+                )
+            };
+            if let Err(error) = result {
+                tracing::debug!(?error, "ActiveX event sink rejected automatic reconnect notification");
+            }
+        }
+    }
+
+    fn fire_auto_reconnecting2_event(&self, attempt: i32, maximum_attempts: i32) {
+        if self.events_are_frozen() {
+            return;
+        }
+
+        let mut variants = [
+            variant_i32(maximum_attempts),
+            variant_i32(attempt),
+            variant_bool_value(false),
+            variant_i32(0),
+        ];
+        let params = DISPPARAMS {
+            rgvarg: variants.as_mut_ptr(),
+            rgdispidNamedArgs: ptr::null_mut(),
+            cArgs: variants.len() as u32,
+            cNamedArgs: 0,
+        };
+        let iid_null = GUID::zeroed();
+        let sinks = self
+            .sinks
+            .borrow()
+            .values()
+            .map(|sink| sink.dispatch.clone())
+            .collect::<Vec<_>>();
+
+        for sink in sinks {
+            let result = unsafe {
+                sink.Invoke(
+                    DISPID_ON_AUTO_RECONNECTING2,
+                    &iid_null,
+                    0,
+                    DISPATCH_METHOD,
+                    &params,
+                    None,
+                    None,
+                    None,
+                )
+            };
+            if let Err(error) = result {
+                tracing::debug!(?error, "ActiveX event sink rejected automatic reconnect notification");
+            }
+        }
+    }
+
     fn certificate_warning_parent(&self) -> HWND {
         let renderer = self.activex_window.get();
         if !renderer.0.is_null() && unsafe { IsWindow(Some(renderer)) }.as_bool() {
@@ -7859,6 +7995,23 @@ impl Control {
                 WorkerEvent::RailWindowingOrders { data, .. } => {
                     if self.rail_windows.borrow().is_enabled() {
                         self.rail_windows.borrow_mut().consume(&data);
+                    }
+                }
+                WorkerEvent::AutoReconnecting {
+                    attempt,
+                    maximum_attempts,
+                    ..
+                } => {
+                    self.report_reconnect_worker_progress(attempt, maximum_attempts);
+                    let attempt = i32::try_from(attempt).unwrap_or(i32::MAX);
+                    let maximum_attempts = i32::try_from(maximum_attempts).unwrap_or(i32::MAX);
+                    self.fire_auto_reconnecting_event(attempt, maximum_attempts);
+                    self.fire_auto_reconnecting2_event(attempt, maximum_attempts);
+                }
+                WorkerEvent::AutoReconnected { .. } => {
+                    if self.state.get() == ConnectionState::Connected {
+                        self.clear_connection_health_window();
+                        self.fire_event(DISPID_ON_AUTO_RECONNECTED, &[]);
                     }
                 }
                 WorkerEvent::FatalError { disconnect, .. } => {
@@ -8462,6 +8615,9 @@ impl Control {
         let authentication_level = compatibility.authentication_level;
         let authentication_level_set = compatibility.authentication_level_set;
         let public_mode = compatibility.public_mode;
+        let auto_reconnect_maximum_attempts = compatibility
+            .enable_auto_reconnect
+            .then_some(compatibility.max_reconnect_attempts);
         let direct_rpc_properties = active_x_property_snapshot(&settings, &compatibility);
         drop(compatibility);
         let remote_application = self.remote_application.borrow();
@@ -8696,6 +8852,11 @@ impl Control {
         drop(settings);
         let (output_sender, mut output_receiver) = mpsc::channel(32);
         let client = RdpClient::new(config, output_sender);
+        let client = if let Some(maximum_attempts) = auto_reconnect_maximum_attempts {
+            client.with_auto_reconnect(maximum_attempts)
+        } else {
+            client
+        };
         let input_sender = client.input_sender();
         if let Some(execute) = remote_application_execute {
             input_sender
@@ -8838,6 +8999,29 @@ impl Control {
                                                     &worker_event_posted,
                                                     hwnd,
                                                     WorkerEvent::DisplayResizeFallback { generation },
+                                                );
+                                            }
+                                            RdpOutputEvent::AutoReconnecting {
+                                                attempt,
+                                                maximum_attempts,
+                                            } => {
+                                                queue_worker_event(
+                                                    &worker_events,
+                                                    &worker_event_posted,
+                                                    hwnd,
+                                                    WorkerEvent::AutoReconnecting {
+                                                        generation,
+                                                        attempt,
+                                                        maximum_attempts,
+                                                    },
+                                                );
+                                            }
+                                            RdpOutputEvent::AutoReconnected => {
+                                                queue_worker_event(
+                                                    &worker_events,
+                                                    &worker_event_posted,
+                                                    hwnd,
+                                                    WorkerEvent::AutoReconnected { generation },
                                                 );
                                             }
                                             RdpOutputEvent::Terminated(result) => {
@@ -13171,7 +13355,11 @@ fn queue_worker_event(
                 false
             }
         }
-        WorkerEvent::Connected { .. } | WorkerEvent::LoginComplete { .. } | WorkerEvent::DisplayResizeFallback { .. } => {
+        WorkerEvent::Connected { .. }
+        | WorkerEvent::LoginComplete { .. }
+        | WorkerEvent::DisplayResizeFallback { .. }
+        | WorkerEvent::AutoReconnecting { .. }
+        | WorkerEvent::AutoReconnected { .. } => {
             if queue.iter().any(|pending| {
                 pending.generation() == event.generation()
                     && core::mem::discriminant(pending) == core::mem::discriminant(&event)
@@ -14031,6 +14219,22 @@ fn variant_bool_byref(value: &mut VARIANT_BOOL) -> VARIANT {
                 wReserved3: 0,
                 Anonymous: VARIANT_0_0_0 {
                     pboolVal: value as *mut VARIANT_BOOL,
+                },
+            }),
+        },
+    }
+}
+
+fn variant_i32_byref(value: &mut i32) -> VARIANT {
+    VARIANT {
+        Anonymous: VARIANT_0 {
+            Anonymous: ManuallyDrop::new(VARIANT_0_0 {
+                vt: VT_I4 | VT_BYREF,
+                wReserved1: 0,
+                wReserved2: 0,
+                wReserved3: 0,
+                Anonymous: VARIANT_0_0_0 {
+                    plVal: value as *mut i32,
                 },
             }),
         },
@@ -14982,6 +15186,28 @@ mod tests {
         };
         let this = (&mut object as *mut AdvancedSettingsObject).cast::<c_void>();
 
+        let mut auto_reconnect = VARIANT_FALSE.0;
+        assert_eq!(
+            unsafe { advanced_get_enable_auto_reconnect(this, &mut auto_reconnect) },
+            S_OK
+        );
+        assert_eq!(auto_reconnect, VARIANT_TRUE.0);
+        assert_eq!(
+            unsafe { advanced_put_enable_auto_reconnect(this, VARIANT_FALSE.0) },
+            S_OK
+        );
+        assert!(!settings.borrow().enable_auto_reconnect);
+
+        let mut max_reconnect_attempts = 0;
+        assert_eq!(
+            unsafe { advanced_get_max_reconnect_attempts(this, &mut max_reconnect_attempts) },
+            S_OK
+        );
+        assert_eq!(max_reconnect_attempts, 20);
+        assert_eq!(unsafe { advanced_put_max_reconnect_attempts(this, 3) }, S_OK);
+        assert_eq!(settings.borrow().max_reconnect_attempts, 3);
+        assert_eq!(unsafe { advanced_put_max_reconnect_attempts(this, -1) }, E_INVALIDARG);
+
         assert_eq!(unsafe { advanced_put_compress(this, 0) }, S_OK);
         let mut compression = -1;
         assert_eq!(unsafe { advanced_get_compress(this, &mut compression) }, S_OK);
@@ -15288,6 +15514,22 @@ mod tests {
         assert_eq!(vtable.slots[28], advanced_put_rdp_port as *const () as usize);
         assert_eq!(vtable.slots[30], advanced_put_enable_mouse as *const () as usize);
         assert_eq!(vtable.slots[34], advanced_put_enable_windows_key as *const () as usize);
+        assert_eq!(
+            vtable.slots[132],
+            advanced_put_enable_auto_reconnect as *const () as usize
+        );
+        assert_eq!(
+            vtable.slots[133],
+            advanced_get_enable_auto_reconnect as *const () as usize
+        );
+        assert_eq!(
+            vtable.slots[134],
+            advanced_put_max_reconnect_attempts as *const () as usize
+        );
+        assert_eq!(
+            vtable.slots[135],
+            advanced_get_max_reconnect_attempts as *const () as usize
+        );
         assert_eq!(vtable.slots[83], advanced_put_keyboard_type as *const () as usize);
         assert_eq!(vtable.slots[85], advanced_put_keyboard_subtype as *const () as usize);
         assert_eq!(

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -442,6 +442,7 @@ const CONTROL_RECONNECT_BLOCKED: i32 = 1;
 const CONTROL_CLOSE_CAN_PROCEED: i32 = 0;
 const CONTROL_CLOSE_WAIT_FOR_EVENTS: i32 = 1;
 const MAX_ACTIVEX_STATIC_CHANNELS: usize = 28;
+const MAX_RECONNECT_ATTEMPTS: u32 = 200;
 const MAX_PENDING_WORKER_EVENTS: usize = 64;
 const CERTIFICATE_WARNING_CONTINUE_BUTTON: i32 = 100;
 const SECURITY_WARNING_CONTINUE_BUTTON: i32 = 101;
@@ -2477,7 +2478,11 @@ unsafe extern "system" fn advanced_put_redirect_clipboard(this: *mut c_void, val
 
 unsafe extern "system" fn advanced_put_enable_auto_reconnect(this: *mut c_void, value: i16) -> HRESULT {
     let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
-    object.settings.borrow_mut().enable_auto_reconnect = value != VARIANT_FALSE.0;
+    let mut settings = object.settings.borrow_mut();
+    if settings.connection_settings_sealed {
+        return E_FAIL;
+    }
+    settings.enable_auto_reconnect = value != VARIANT_FALSE.0;
     S_OK
 }
 
@@ -2500,8 +2505,15 @@ unsafe extern "system" fn advanced_put_max_reconnect_attempts(this: *mut c_void,
     let Ok(value) = u32::try_from(value) else {
         return E_INVALIDARG;
     };
+    if value > MAX_RECONNECT_ATTEMPTS {
+        return E_INVALIDARG;
+    }
     let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
-    object.settings.borrow_mut().max_reconnect_attempts = value;
+    let mut settings = object.settings.borrow_mut();
+    if settings.connection_settings_sealed {
+        return E_FAIL;
+    }
+    settings.max_reconnect_attempts = value;
     S_OK
 }
 
@@ -13345,6 +13357,12 @@ fn queue_worker_event(
     hwnd: HWND,
     event: WorkerEvent,
 ) -> bool {
+    let auto_reconnect_key = match &event {
+        WorkerEvent::AutoReconnecting {
+            generation, attempt, ..
+        } => Some((*generation, *attempt)),
+        _ => None,
+    };
     if events.closed.load(Ordering::Acquire) {
         return false;
     }
@@ -13445,7 +13463,6 @@ fn queue_worker_event(
             true
         }
     };
-    drop(queue);
     if !queued {
         return false;
     }
@@ -13455,7 +13472,24 @@ fn queue_worker_event(
     {
         event_posted.store(false, Ordering::Release);
         tracing::debug!(?error, "Unable to post ActiveX event dispatch message");
+        if let Some((generation, attempt)) = auto_reconnect_key {
+            if let Some(index) = queue.iter().rposition(|pending| {
+                matches!(
+                    pending,
+                    WorkerEvent::AutoReconnecting {
+                        generation: pending_generation,
+                        attempt: pending_attempt,
+                        ..
+                    } if *pending_generation == generation && *pending_attempt == attempt
+                )
+            }) {
+                queue.remove(index);
+                events.space_available.notify_all();
+            }
+            return false;
+        }
     }
+    drop(queue);
     true
 }
 
@@ -15255,6 +15289,24 @@ mod tests {
         assert_eq!(unsafe { advanced_put_max_reconnect_attempts(this, 3) }, S_OK);
         assert_eq!(settings.borrow().max_reconnect_attempts, 3);
         assert_eq!(unsafe { advanced_put_max_reconnect_attempts(this, -1) }, E_INVALIDARG);
+        assert_eq!(
+            unsafe {
+                advanced_put_max_reconnect_attempts(
+                    this,
+                    i32::try_from(MAX_RECONNECT_ATTEMPTS + 1).expect("limit fits in i32"),
+                )
+            },
+            E_INVALIDARG
+        );
+        settings.borrow_mut().connection_settings_sealed = true;
+        assert_eq!(
+            unsafe { advanced_put_enable_auto_reconnect(this, VARIANT_TRUE.0) },
+            E_FAIL
+        );
+        assert_eq!(unsafe { advanced_put_max_reconnect_attempts(this, 4) }, E_FAIL);
+        assert!(!settings.borrow().enable_auto_reconnect);
+        assert_eq!(settings.borrow().max_reconnect_attempts, 3);
+        settings.borrow_mut().connection_settings_sealed = false;
 
         assert_eq!(unsafe { advanced_put_compress(this, 0) }, S_OK);
         let mut compression = -1;
@@ -19233,6 +19285,29 @@ mod tests {
                 .iter()
                 .any(|event| matches!(event, WorkerEvent::AutoReconnecting { .. }))
         );
+    }
+
+    #[test]
+    fn worker_event_queue_rejects_auto_reconnect_when_dispatch_fails() {
+        let events = Arc::new(WorkerEventQueue::new());
+        let event_posted = Arc::new(AtomicBool::new(false));
+        let (sender, mut receiver) = oneshot::channel();
+
+        assert!(!queue_worker_event(
+            &events,
+            &event_posted,
+            HWND(ptr::dangling_mut()),
+            WorkerEvent::AutoReconnecting {
+                generation: 7,
+                disconnect_reason: 0,
+                attempt: 1,
+                maximum_attempts: 1,
+                response: sender,
+            },
+        ));
+        assert!(matches!(receiver.try_recv(), Err(oneshot::error::TryRecvError::Closed)));
+        assert!(events.events.lock().expect("event queue is available").is_empty());
+        assert!(!event_posted.load(Ordering::Acquire));
     }
 
     #[test]

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -14,7 +14,9 @@ use std::time::Duration;
 use ironrdp_cfg::{AudioMode, GatewayCredentialsSource, GatewayUsageMethod};
 use ironrdp_client::config::{ClipboardType, ConfigBuilder, Destination, RDCleanPathConfig, Transport, TransportKind};
 use ironrdp_client::rail::RailInputEvent;
-use ironrdp_client::rdp::{CliprdrBackendFactory, RdpClient, RdpInputEvent, RdpInputSender, RdpOutputEvent};
+use ironrdp_client::rdp::{
+    AutoReconnectDecision, CliprdrBackendFactory, RdpClient, RdpInputEvent, RdpInputSender, RdpOutputEvent,
+};
 use ironrdp_cliprdr::backend::{ClipboardMessage, ClipboardMessageProxy};
 use ironrdp_cliprdr_native::WinClipboard;
 use ironrdp_connector::{ConnectorError, ConnectorErrorKind, Credentials};
@@ -37,7 +39,7 @@ use ironrdp_session::{GracefulDisconnectReason, SessionError, SessionErrorKind};
 use ironrdp_svc::{SvcClientProcessor, SvcMessage, SvcProcessor, impl_as_any};
 use ironrdp_tls::CertificateValidation;
 use sha2::{Digest as _, Sha256};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use windows::Win32::Foundation::{
     DATA_S_SAMEFORMATETC, DISP_E_BADPARAMCOUNT, DISP_E_MEMBERNOTFOUND, DISP_E_TYPEMISMATCH, DISP_E_UNKNOWNNAME,
     DV_E_DVASPECT, DV_E_DVTARGETDEVICE, DV_E_FORMATETC, DV_E_LINDEX, DV_E_TYMED, E_FAIL, E_INVALIDARG, E_NOTIMPL,
@@ -3501,6 +3503,7 @@ enum WorkerEvent {
         generation: u64,
         attempt: u32,
         maximum_attempts: u32,
+        response: oneshot::Sender<AutoReconnectDecision>,
     },
     AutoReconnected {
         generation: u64,
@@ -3542,8 +3545,14 @@ impl WorkerEvent {
     }
 
     fn reject_certificate_warning(self) {
-        if let Self::CertificateWarning { response, .. } = self {
-            let _ = response.send(CertificateDecision::Reject);
+        match self {
+            Self::CertificateWarning { response, .. } => {
+                let _ = response.send(CertificateDecision::Reject);
+            }
+            Self::AutoReconnecting { response, .. } => {
+                let _ = response.send(AutoReconnectDecision::Stop);
+            }
+            _ => {}
         }
     }
 }
@@ -7440,9 +7449,9 @@ impl Control {
         }
     }
 
-    fn fire_auto_reconnecting_event(&self, attempt: i32, maximum_attempts: i32) {
+    fn fire_auto_reconnecting_event(&self, attempt: i32, maximum_attempts: i32) -> i32 {
         if self.events_are_frozen() {
-            return;
+            return 0;
         }
 
         let mut continuation = 0;
@@ -7482,6 +7491,8 @@ impl Control {
                 tracing::debug!(?error, "ActiveX event sink rejected automatic reconnect notification");
             }
         }
+
+        continuation
     }
 
     fn fire_auto_reconnecting2_event(&self, attempt: i32, maximum_attempts: i32) {
@@ -8000,13 +8011,20 @@ impl Control {
                 WorkerEvent::AutoReconnecting {
                     attempt,
                     maximum_attempts,
+                    response,
                     ..
                 } => {
                     self.report_reconnect_worker_progress(attempt, maximum_attempts);
                     let attempt = i32::try_from(attempt).unwrap_or(i32::MAX);
                     let maximum_attempts = i32::try_from(maximum_attempts).unwrap_or(i32::MAX);
-                    self.fire_auto_reconnecting_event(attempt, maximum_attempts);
-                    self.fire_auto_reconnecting2_event(attempt, maximum_attempts);
+                    let decision = match self.fire_auto_reconnecting_event(attempt, maximum_attempts) {
+                        0 => {
+                            self.fire_auto_reconnecting2_event(attempt, maximum_attempts);
+                            AutoReconnectDecision::Continue
+                        }
+                        _ => AutoReconnectDecision::Stop,
+                    };
+                    let _ = response.send(decision);
                 }
                 WorkerEvent::AutoReconnected { .. } => {
                     if self.state.get() == ConnectionState::Connected {
@@ -9004,8 +9022,9 @@ impl Control {
                                             RdpOutputEvent::AutoReconnecting {
                                                 attempt,
                                                 maximum_attempts,
+                                                response,
                                             } => {
-                                                queue_worker_event(
+                                                if !queue_worker_event(
                                                     &worker_events,
                                                     &worker_event_posted,
                                                     hwnd,
@@ -9013,8 +9032,13 @@ impl Control {
                                                         generation,
                                                         attempt,
                                                         maximum_attempts,
+                                                        response,
                                                     },
-                                                );
+                                                ) {
+                                                    // The host cannot make a decision if its dispatcher is gone.
+                                                    // Fail closed rather than starting an unobservable retry.
+                                                    // `response` has been moved into the rejected queue request.
+                                                }
                                             }
                                             RdpOutputEvent::AutoReconnected => {
                                                 queue_worker_event(

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -19225,12 +19225,14 @@ mod tests {
             },
         ));
         assert!(receiver.try_recv().is_err());
-        assert!(events
-            .events
-            .lock()
-            .expect("event queue is available")
-            .iter()
-            .any(|event| matches!(event, WorkerEvent::AutoReconnecting { .. })));
+        assert!(
+            events
+                .events
+                .lock()
+                .expect("event queue is available")
+                .iter()
+                .any(|event| matches!(event, WorkerEvent::AutoReconnecting { .. }))
+        );
     }
 
     #[test]

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -3501,6 +3501,7 @@ enum WorkerEvent {
     },
     AutoReconnecting {
         generation: u64,
+        disconnect_reason: u32,
         attempt: u32,
         maximum_attempts: u32,
         response: oneshot::Sender<AutoReconnectDecision>,
@@ -7449,7 +7450,7 @@ impl Control {
         }
     }
 
-    fn fire_auto_reconnecting_event(&self, attempt: i32, maximum_attempts: i32) -> i32 {
+    fn fire_auto_reconnecting_event(&self, disconnect_reason: i32, attempt: i32) -> i32 {
         if self.events_are_frozen() {
             return 0;
         }
@@ -7457,8 +7458,8 @@ impl Control {
         let mut continuation = 0;
         let mut variants = [
             variant_i32_byref(&mut continuation),
-            variant_i32(maximum_attempts),
             variant_i32(attempt),
+            variant_i32(disconnect_reason),
         ];
         let params = DISPPARAMS {
             rgvarg: variants.as_mut_ptr(),
@@ -7495,7 +7496,13 @@ impl Control {
         continuation
     }
 
-    fn fire_auto_reconnecting2_event(&self, attempt: i32, maximum_attempts: i32) {
+    fn fire_auto_reconnecting2_event(
+        &self,
+        disconnect_reason: i32,
+        network_available: bool,
+        attempt: i32,
+        maximum_attempts: i32,
+    ) {
         if self.events_are_frozen() {
             return;
         }
@@ -7503,8 +7510,8 @@ impl Control {
         let mut variants = [
             variant_i32(maximum_attempts),
             variant_i32(attempt),
-            variant_bool_value(false),
-            variant_i32(0),
+            variant_bool_value(network_available),
+            variant_i32(disconnect_reason),
         ];
         let params = DISPPARAMS {
             rgvarg: variants.as_mut_ptr(),
@@ -8009,17 +8016,19 @@ impl Control {
                     }
                 }
                 WorkerEvent::AutoReconnecting {
+                    disconnect_reason,
                     attempt,
                     maximum_attempts,
                     response,
                     ..
                 } => {
                     self.report_reconnect_worker_progress(attempt, maximum_attempts);
+                    let disconnect_reason = i32::try_from(disconnect_reason).unwrap_or(i32::MAX);
                     let attempt = i32::try_from(attempt).unwrap_or(i32::MAX);
                     let maximum_attempts = i32::try_from(maximum_attempts).unwrap_or(i32::MAX);
-                    let decision = match self.fire_auto_reconnecting_event(attempt, maximum_attempts) {
+                    let decision = match self.fire_auto_reconnecting_event(disconnect_reason, attempt) {
                         0 => {
-                            self.fire_auto_reconnecting2_event(attempt, maximum_attempts);
+                            self.fire_auto_reconnecting2_event(disconnect_reason, false, attempt, maximum_attempts);
                             AutoReconnectDecision::Continue
                         }
                         _ => AutoReconnectDecision::Stop,
@@ -9020,6 +9029,7 @@ impl Control {
                                                 );
                                             }
                                             RdpOutputEvent::AutoReconnecting {
+                                                disconnect_reason,
                                                 attempt,
                                                 maximum_attempts,
                                                 response,
@@ -9030,6 +9040,7 @@ impl Control {
                                                     hwnd,
                                                     WorkerEvent::AutoReconnecting {
                                                         generation,
+                                                        disconnect_reason,
                                                         attempt,
                                                         maximum_attempts,
                                                         response,
@@ -13379,10 +13390,23 @@ fn queue_worker_event(
                 false
             }
         }
+        WorkerEvent::AutoReconnecting { .. } => {
+            while queue.len() >= MAX_PENDING_WORKER_EVENTS {
+                if let Some(index) = queue
+                    .iter()
+                    .position(|pending| matches!(pending, WorkerEvent::Image { .. } | WorkerEvent::StaticChannelData { .. }))
+                {
+                    queue.remove(index);
+                } else {
+                    return false;
+                }
+            }
+            queue.push(event);
+            true
+        }
         WorkerEvent::Connected { .. }
         | WorkerEvent::LoginComplete { .. }
         | WorkerEvent::DisplayResizeFallback { .. }
-        | WorkerEvent::AutoReconnecting { .. }
         | WorkerEvent::AutoReconnected { .. } => {
             if queue.iter().any(|pending| {
                 pending.generation() == event.generation()
@@ -19137,6 +19161,76 @@ mod tests {
                 .iter()
                 .all(|event| matches!(event, WorkerEvent::StaticChannelData { .. }))
         );
+    }
+
+    #[test]
+    fn worker_event_queue_preserves_auto_reconnect_decisions() {
+        let events = Arc::new(WorkerEventQueue::new());
+        let event_posted = Arc::new(AtomicBool::new(true));
+        let dispatcher = HWND(ptr::null_mut());
+        let (first_sender, mut first_receiver) = oneshot::channel();
+        let (second_sender, mut second_receiver) = oneshot::channel();
+
+        for (attempt, response) in [(1, first_sender), (2, second_sender)] {
+            assert!(queue_worker_event(
+                &events,
+                &event_posted,
+                dispatcher,
+                WorkerEvent::AutoReconnecting {
+                    generation: 7,
+                    disconnect_reason: 0,
+                    attempt,
+                    maximum_attempts: 2,
+                    response,
+                },
+            ));
+        }
+        assert_eq!(
+            events
+                .events
+                .lock()
+                .expect("event queue is available")
+                .iter()
+                .filter(|event| matches!(event, WorkerEvent::AutoReconnecting { .. }))
+                .count(),
+            2
+        );
+        assert!(first_receiver.try_recv().is_err());
+        assert!(second_receiver.try_recv().is_err());
+
+        events.events.lock().expect("event queue is available").clear();
+        for index in 0..MAX_PENDING_WORKER_EVENTS {
+            assert!(queue_worker_event(
+                &events,
+                &event_posted,
+                dispatcher,
+                WorkerEvent::StaticChannelData {
+                    generation: 7,
+                    channel_name: "alpha".to_owned(),
+                    data: vec![u8::try_from(index).expect("queue capacity fits in u8")],
+                },
+            ));
+        }
+        let (sender, mut receiver) = oneshot::channel();
+        assert!(queue_worker_event(
+            &events,
+            &event_posted,
+            dispatcher,
+            WorkerEvent::AutoReconnecting {
+                generation: 7,
+                disconnect_reason: 0,
+                attempt: 1,
+                maximum_attempts: 1,
+                response: sender,
+            },
+        ));
+        assert!(receiver.try_recv().is_err());
+        assert!(events
+            .events
+            .lock()
+            .expect("event queue is available")
+            .iter()
+            .any(|event| matches!(event, WorkerEvent::AutoReconnecting { .. })));
     }
 
     #[test]

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -2502,16 +2502,16 @@ unsafe extern "system" fn advanced_get_enable_auto_reconnect(this: *mut c_void, 
 }
 
 unsafe extern "system" fn advanced_put_max_reconnect_attempts(this: *mut c_void, value: i32) -> HRESULT {
+    let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
+    let mut settings = object.settings.borrow_mut();
+    if settings.connection_settings_sealed {
+        return E_FAIL;
+    }
     let Ok(value) = u32::try_from(value) else {
         return E_INVALIDARG;
     };
     if value > MAX_RECONNECT_ATTEMPTS {
         return E_INVALIDARG;
-    }
-    let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
-    let mut settings = object.settings.borrow_mut();
-    if settings.connection_settings_sealed {
-        return E_FAIL;
     }
     settings.max_reconnect_attempts = value;
     S_OK
@@ -15304,6 +15304,7 @@ mod tests {
             E_FAIL
         );
         assert_eq!(unsafe { advanced_put_max_reconnect_attempts(this, 4) }, E_FAIL);
+        assert_eq!(unsafe { advanced_put_max_reconnect_attempts(this, -1) }, E_FAIL);
         assert!(!settings.borrow().enable_auto_reconnect);
         assert_eq!(settings.borrow().max_reconnect_attempts, 3);
         settings.borrow_mut().connection_settings_sealed = false;

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -32,6 +32,7 @@ use ironrdp_rdpei::RdpeiClient;
 use ironrdp_rdpei::pdu::TouchEventPdu;
 #[cfg(any(feature = "clipboard", feature = "rdpdr"))]
 use ironrdp_session::ActiveStage;
+use ironrdp_pdu::rdp::session_info::ServerAutoReconnect;
 use ironrdp_session::image::DecodedImage;
 use ironrdp_session::{ActiveStageBuilder, ActiveStageOutput, GracefulDisconnectReason, SessionResult};
 use ironrdp_svc::SvcMessage;
@@ -156,6 +157,15 @@ pub enum RdpOutputEvent {
     ///
     /// The next connection attempt uses the requested desktop size.
     DisplayResizeFallback(DisplayResizeFallbackReason),
+    /// An active session was interrupted and a cookie-based reconnect is about to start.
+    ///
+    /// `attempt` is one-based and never exceeds `maximum_attempts`.
+    AutoReconnecting {
+        attempt: u32,
+        maximum_attempts: u32,
+    },
+    /// A cookie-based reconnect has completed successfully.
+    AutoReconnected,
     Terminated(SessionResult<GracefulDisconnectReason>),
 }
 
@@ -376,6 +386,7 @@ pub struct RdpClient {
     clipboard_event_receiver: mpsc::UnboundedReceiver<RdpInputEvent>,
     close_receiver: watch::Receiver<bool>,
     graceful_close_receiver: watch::Receiver<bool>,
+    auto_reconnect_maximum_attempts: Option<u32>,
     #[cfg(feature = "clipboard")]
     cliprdr_backend_factory: Option<Box<dyn CliprdrBackendFactory + Send>>,
     #[cfg(feature = "rdpdr")]
@@ -399,6 +410,7 @@ impl RdpClient {
             clipboard_event_receiver,
             close_receiver,
             graceful_close_receiver,
+            auto_reconnect_maximum_attempts: None,
             #[cfg(feature = "clipboard")]
             cliprdr_backend_factory: None,
             #[cfg(feature = "rdpdr")]
@@ -429,6 +441,16 @@ impl RdpClient {
     /// events from the GUI thread.
     pub fn input_sender(&self) -> RdpInputSender {
         self.input_event_sender.clone()
+    }
+
+    /// Enables automatic reconnection after an active-session interruption.
+    ///
+    /// A reconnect is attempted only when the server has supplied an auto-reconnect cookie.
+    /// A value of zero disables retries.
+    #[must_use]
+    pub fn with_auto_reconnect(mut self, maximum_attempts: u32) -> Self {
+        self.auto_reconnect_maximum_attempts = Some(maximum_attempts);
+        self
     }
 
     pub async fn run(mut self) {
@@ -526,6 +548,10 @@ impl RdpClient {
         let rdpdr_factory: RdpdrFactoryRef<'_> = core::marker::PhantomData;
 
         // ── Connection + session loop ─────────────────────────────────────────
+        let auto_reconnect_policy = self.auto_reconnect_maximum_attempts.map(AutoReconnectPolicy::new);
+        let mut auto_reconnect_cookie = None;
+        let mut reconnect_attempt = 0;
+
         loop {
             if *self.close_receiver.borrow_and_update() {
                 self.emit_user_initiated_termination();
@@ -534,13 +560,35 @@ impl RdpClient {
 
             let (connection_result, framed) = match &self.config.transport {
                 Transport::Direct => match Box::pin(cancelable_operation(
-                    connect_direct(&self.config, &self.input_event_sender, cliprdr_factory, rdpdr_factory),
+                    connect_direct(
+                        &self.config,
+                        &self.input_event_sender,
+                        cliprdr_factory,
+                        rdpdr_factory,
+                        auto_reconnect_cookie.as_ref(),
+                    ),
                     &mut self.close_receiver,
                 ))
                 .await
                 {
                     Some(Ok(result)) => result,
                     Some(Err(error)) => {
+                        if let Some(attempt) = next_auto_reconnect_attempt(
+                            auto_reconnect_policy,
+                            reconnect_attempt,
+                            auto_reconnect_cookie.as_ref(),
+                        ) {
+                            reconnect_attempt = attempt;
+                            if self
+                                .send_output_event(RdpOutputEvent::AutoReconnecting {
+                                    attempt,
+                                    maximum_attempts: auto_reconnect_policy.map_or(0, |policy| policy.maximum_attempts),
+                                })
+                                .await
+                            {
+                                continue;
+                            }
+                        }
                         if !self.send_output_event(RdpOutputEvent::ConnectionFailure(error)).await {
                             self.emit_user_initiated_termination();
                         }
@@ -560,6 +608,7 @@ impl RdpClient {
                         &self.input_event_sender,
                         cliprdr_factory,
                         rdpdr_factory,
+                        auto_reconnect_cookie.as_ref(),
                     ),
                     &mut self.close_receiver,
                 ))
@@ -567,6 +616,22 @@ impl RdpClient {
                 {
                     Some(Ok(result)) => result,
                     Some(Err(error)) => {
+                        if let Some(attempt) = next_auto_reconnect_attempt(
+                            auto_reconnect_policy,
+                            reconnect_attempt,
+                            auto_reconnect_cookie.as_ref(),
+                        ) {
+                            reconnect_attempt = attempt;
+                            if self
+                                .send_output_event(RdpOutputEvent::AutoReconnecting {
+                                    attempt,
+                                    maximum_attempts: auto_reconnect_policy.map_or(0, |policy| policy.maximum_attempts),
+                                })
+                                .await
+                            {
+                                continue;
+                            }
+                        }
                         if !self.send_output_event(RdpOutputEvent::ConnectionFailure(error)).await {
                             self.emit_user_initiated_termination();
                         }
@@ -585,6 +650,7 @@ impl RdpClient {
                         &self.input_event_sender,
                         cliprdr_factory,
                         rdpdr_factory,
+                        auto_reconnect_cookie.as_ref(),
                     ),
                     &mut self.close_receiver,
                 ))
@@ -592,6 +658,22 @@ impl RdpClient {
                 {
                     Some(Ok(result)) => result,
                     Some(Err(error)) => {
+                        if let Some(attempt) = next_auto_reconnect_attempt(
+                            auto_reconnect_policy,
+                            reconnect_attempt,
+                            auto_reconnect_cookie.as_ref(),
+                        ) {
+                            reconnect_attempt = attempt;
+                            if self
+                                .send_output_event(RdpOutputEvent::AutoReconnecting {
+                                    attempt,
+                                    maximum_attempts: auto_reconnect_policy.map_or(0, |policy| policy.maximum_attempts),
+                                })
+                                .await
+                            {
+                                continue;
+                            }
+                        }
                         if !self.send_output_event(RdpOutputEvent::ConnectionFailure(error)).await {
                             self.emit_user_initiated_termination();
                         }
@@ -611,6 +693,7 @@ impl RdpClient {
                         &self.input_event_sender,
                         cliprdr_factory,
                         rdpdr_factory,
+                        auto_reconnect_cookie.as_ref(),
                     ),
                     &mut self.close_receiver,
                 ))
@@ -618,6 +701,22 @@ impl RdpClient {
                 {
                     Some(Ok(result)) => result,
                     Some(Err(error)) => {
+                        if let Some(attempt) = next_auto_reconnect_attempt(
+                            auto_reconnect_policy,
+                            reconnect_attempt,
+                            auto_reconnect_cookie.as_ref(),
+                        ) {
+                            reconnect_attempt = attempt;
+                            if self
+                                .send_output_event(RdpOutputEvent::AutoReconnecting {
+                                    attempt,
+                                    maximum_attempts: auto_reconnect_policy.map_or(0, |policy| policy.maximum_attempts),
+                                })
+                                .await
+                            {
+                                continue;
+                            }
+                        }
                         if !self.send_output_event(RdpOutputEvent::ConnectionFailure(error)).await {
                             self.emit_user_initiated_termination();
                         }
@@ -630,10 +729,17 @@ impl RdpClient {
                 },
             };
 
-            if !self.send_output_event(RdpOutputEvent::Connected).await {
+            let reconnected = reconnect_attempt != 0;
+            let connected_event = if !reconnected {
+                RdpOutputEvent::Connected
+            } else {
+                RdpOutputEvent::AutoReconnected
+            };
+            if !self.send_output_event(connected_event).await {
                 self.emit_user_initiated_termination();
                 break;
             }
+            reconnect_attempt = 0;
 
             match active_session(
                 framed,
@@ -645,6 +751,7 @@ impl RdpClient {
                 &mut self.close_receiver,
                 &mut self.graceful_close_receiver,
                 self.config.fake_events_interval,
+                &mut auto_reconnect_cookie,
             )
             .await
             {
@@ -666,9 +773,26 @@ impl RdpClient {
                     break;
                 }
                 Err(e) => {
+                    if let Some(attempt) = next_auto_reconnect_attempt(
+                        auto_reconnect_policy,
+                        reconnect_attempt,
+                        auto_reconnect_cookie.as_ref(),
+                    ) {
+                        reconnect_attempt = attempt;
+                        if self
+                            .send_output_event(RdpOutputEvent::AutoReconnecting {
+                                attempt,
+                                maximum_attempts: auto_reconnect_policy.map_or(0, |policy| policy.maximum_attempts),
+                            })
+                            .await
+                        {
+                            continue;
+                        }
+                    }
                     if !self.send_output_event(RdpOutputEvent::Terminated(Err(e))).await {
                         self.emit_user_initiated_termination();
                     }
+
                     break;
                 }
             }
@@ -686,6 +810,33 @@ impl RdpClient {
             .output_event_sender
             .try_send(RdpOutputEvent::Terminated(Ok(GracefulDisconnectReason::UserInitiated)));
     }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct AutoReconnectPolicy {
+    maximum_attempts: u32,
+}
+
+impl AutoReconnectPolicy {
+    const fn new(maximum_attempts: u32) -> Self {
+        Self { maximum_attempts }
+    }
+
+    const fn next_attempt(self, previous_attempt: u32, has_cookie: bool) -> Option<u32> {
+        if has_cookie && previous_attempt < self.maximum_attempts {
+            Some(previous_attempt + 1)
+        } else {
+            None
+        }
+    }
+}
+
+fn next_auto_reconnect_attempt(
+    policy: Option<AutoReconnectPolicy>,
+    previous_attempt: u32,
+    cookie: Option<&ServerAutoReconnect>,
+) -> Option<u32> {
+    policy.and_then(|policy| policy.next_attempt(previous_attempt, cookie.is_some()))
 }
 
 async fn cancelable_operation<T>(
@@ -837,6 +988,7 @@ fn build_connector(
     input_sender: &RdpInputSender,
     cliprdr_factory: CliprdrFactoryRef<'_>,
     rdpdr_factory: RdpdrFactoryRef<'_>,
+    auto_reconnect_cookie: Option<&ServerAutoReconnect>,
 ) -> ConnectorResult<ironrdp_connector::ClientConnector> {
     // `input_sender` is only consumed by the optional DVC wirings below, and `cliprdr_factory`
     // only by the optional CLIPRDR attachment; discard them explicitly when those are compiled out.
@@ -1124,6 +1276,10 @@ fn build_connector(
         attach_sc(&mut connector, &config.properties);
     }
 
+    if let Some(cookie) = auto_reconnect_cookie {
+        connector = connector.with_auto_reconnect_cookie(cookie.clone());
+    }
+
     Ok(connector)
 }
 
@@ -1139,6 +1295,7 @@ async fn connect_direct(
     input_sender: &RdpInputSender,
     cliprdr_factory: CliprdrFactoryRef<'_>,
     rdpdr_factory: RdpdrFactoryRef<'_>,
+    auto_reconnect_cookie: Option<&ServerAutoReconnect>,
 ) -> ConnectorResult<(ConnectionResult, UpgradedFramed)> {
     let dest = config.destination.to_string();
     let stream = TcpStream::connect(&dest)
@@ -1151,7 +1308,14 @@ async fn connect_direct(
         .map_err(|e| ironrdp_connector::custom_err!("get socket local address", e))?;
     let framed = ironrdp_tokio::TokioFramed::new(stream);
 
-    let connector = build_connector(config, client_addr, input_sender, cliprdr_factory, rdpdr_factory)?;
+    let connector = build_connector(
+        config,
+        client_addr,
+        input_sender,
+        cliprdr_factory,
+        rdpdr_factory,
+        auto_reconnect_cookie,
+    )?;
     #[cfg(feature = "vmconnect")]
     if config.vm_id().is_some() {
         return vmconnect_handshake_and_finalize(framed, connector, config, pcb_deadline).await;
@@ -1170,6 +1334,7 @@ async fn connect_named_pipe(
     input_sender: &RdpInputSender,
     cliprdr_factory: CliprdrFactoryRef<'_>,
     rdpdr_factory: RdpdrFactoryRef<'_>,
+    auto_reconnect_cookie: Option<&ServerAutoReconnect>,
 ) -> ConnectorResult<(ConnectionResult, UpgradedFramed)> {
     use tokio::net::windows::named_pipe::ClientOptions;
 
@@ -1190,7 +1355,14 @@ async fn connect_named_pipe(
     // Named pipes have no socket address; use a dummy loopback address for Client Info.
     let client_addr = SocketAddr::from(([127, 0, 0, 1], 0));
     let framed = ironrdp_tokio::TokioFramed::new(stream);
-    let connector = build_connector(config, client_addr, input_sender, cliprdr_factory, rdpdr_factory)?;
+    let connector = build_connector(
+        config,
+        client_addr,
+        input_sender,
+        cliprdr_factory,
+        rdpdr_factory,
+        auto_reconnect_cookie,
+    )?;
 
     security_upgrade_and_finalize(framed, connector, config).await
 }
@@ -1203,6 +1375,7 @@ async fn connect_gateway(
     input_sender: &RdpInputSender,
     cliprdr_factory: CliprdrFactoryRef<'_>,
     rdpdr_factory: RdpdrFactoryRef<'_>,
+    auto_reconnect_cookie: Option<&ServerAutoReconnect>,
 ) -> ConnectorResult<(ConnectionResult, UpgradedFramed)> {
     use ironrdp_mstsgu::GwConnectTarget;
 
@@ -1229,7 +1402,14 @@ async fn connect_gateway(
 
     let framed = ironrdp_tokio::TokioFramed::new(gw_stream);
 
-    let connector = build_connector(config, client_addr, input_sender, cliprdr_factory, rdpdr_factory)?;
+    let connector = build_connector(
+        config,
+        client_addr,
+        input_sender,
+        cliprdr_factory,
+        rdpdr_factory,
+        auto_reconnect_cookie,
+    )?;
     security_upgrade_and_finalize(framed, connector, config).await
 }
 
@@ -1240,6 +1420,7 @@ async fn connect_rdcleanpath_transport(
     input_sender: &RdpInputSender,
     cliprdr_factory: CliprdrFactoryRef<'_>,
     rdpdr_factory: RdpdrFactoryRef<'_>,
+    auto_reconnect_cookie: Option<&ServerAutoReconnect>,
 ) -> ConnectorResult<(ConnectionResult, UpgradedFramed)> {
     let hostname = rdcp
         .url
@@ -1263,7 +1444,14 @@ async fn connect_rdcleanpath_transport(
     let ws = crate::ws::websocket_compat(ws);
     let mut framed = ironrdp_tokio::TokioFramed::new(ws);
 
-    let mut connector = build_connector(config, client_addr, input_sender, cliprdr_factory, rdpdr_factory)?;
+    let mut connector = build_connector(
+        config,
+        client_addr,
+        input_sender,
+        cliprdr_factory,
+        rdpdr_factory,
+        auto_reconnect_cookie,
+    )?;
 
     let destination = config.destination.to_string();
     let mut network_client = ReqwestNetworkClient::new();
@@ -1738,6 +1926,7 @@ async fn active_session(
     close_receiver: &mut watch::Receiver<bool>,
     graceful_close_receiver: &mut watch::Receiver<bool>,
     fake_events_interval: Option<Duration>,
+    auto_reconnect_cookie: &mut Option<ServerAutoReconnect>,
 ) -> SessionResult<RdpControlFlow> {
     let (mut reader, mut writer) = split_tokio_framed(framed);
     let desktop_size = connection_result.desktop_size;
@@ -2184,11 +2373,8 @@ async fn active_session(
 
         for out in outputs {
             match out {
-                ActiveStageOutput::AutoReconnectCookie(_cookie) => {
-                    // The connector can now return this to the server via
-                    // `with_auto_reconnect_cookie`. Holding it across a dropped
-                    // connection and reconnecting with it is the remaining part of
-                    // #271; see the TODO at the reconnect site.
+                ActiveStageOutput::AutoReconnectCookie(cookie) => {
+                    *auto_reconnect_cookie = Some(cookie);
                     debug!("Received a Server Auto-Reconnect Cookie");
                 }
                 ActiveStageOutput::ResponseFrame(frame) => {
@@ -2772,6 +2958,21 @@ mod tests {
             queue.timed_out_request(deadline),
             Some((request, DisplayResizeFallbackReason::CapabilitiesTimedOut))
         );
+    }
+
+    #[test]
+    fn auto_reconnect_policy_requires_a_cookie_and_respects_its_limit() {
+        let policy = AutoReconnectPolicy::new(2);
+
+        assert_eq!(policy.next_attempt(0, false), None);
+        assert_eq!(policy.next_attempt(0, true), Some(1));
+        assert_eq!(policy.next_attempt(1, true), Some(2));
+        assert_eq!(policy.next_attempt(2, true), None);
+    }
+
+    #[test]
+    fn zero_auto_reconnect_limit_disables_retries() {
+        assert_eq!(AutoReconnectPolicy::new(0).next_attempt(0, true), None);
     }
 
     #[test]

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -1,3 +1,4 @@
+use core::error::Error as _;
 use core::net::SocketAddr;
 use core::num::NonZeroU16;
 use core::time::Duration;
@@ -894,6 +895,17 @@ fn is_transport_read_error(error: &io::Error) -> bool {
     !error
         .get_ref()
         .is_some_and(|source| source.is::<ironrdp_core::DecodeError>())
+}
+
+fn is_transport_session_error(error: &(dyn core::error::Error + 'static)) -> bool {
+    let mut source = Some(error);
+    while let Some(error) = source {
+        if let Some(error) = error.downcast_ref::<io::Error>() {
+            return is_transport_read_error(error);
+        }
+        source = error.source();
+    }
+    false
 }
 
 async fn cancelable_operation<T>(
@@ -2665,8 +2677,22 @@ async fn active_session(
                                 ));
                             };
                             result
-                        }
-                        .map_err(|e| ironrdp_session::custom_err!("read deactivation-reactivation sequence step", e))?;
+                        };
+                        let written = match written {
+                            Ok(written) => written,
+                            Err(error) if is_transport_session_error(&error) => {
+                                return Ok(RdpControlFlow::TransportFailure(ironrdp_session::custom_err!(
+                                    "read deactivation-reactivation sequence step",
+                                    error
+                                )));
+                            }
+                            Err(error) => {
+                                return Err(ironrdp_session::custom_err!(
+                                    "read deactivation-reactivation sequence step",
+                                    error
+                                ));
+                            }
+                        };
                         if written.size().is_some() {
                             let Some(result) =
                                 cancelable_operation(writer.write_all(buf.filled()), close_receiver).await
@@ -2722,9 +2748,12 @@ async fn active_session(
                                             GracefulDisconnectReason::UserInitiated,
                                         ));
                                     };
-                                    result.map_err(|error| {
-                                        ironrdp_session::custom_err!("write RAIL desktop size update", error)
-                                    })?;
+                                    if let Err(error) = result {
+                                        return Ok(RdpControlFlow::TransportFailure(ironrdp_session::custom_err!(
+                                            "write RAIL desktop size update",
+                                            error
+                                        )));
+                                    }
                                 }
                             }
                             refresh_rect_support = reactivated_refresh_rect_support;
@@ -3101,6 +3130,18 @@ mod tests {
         assert!(is_transport_read_error(&io::Error::from(
             io::ErrorKind::ConnectionReset
         )));
+
+        let transport_error = ironrdp_session::custom_err!(
+            "read activation",
+            ironrdp_connector::custom_err!("read frame", io::Error::from(io::ErrorKind::ConnectionReset))
+        );
+        assert!(is_transport_session_error(&transport_error));
+
+        let protocol_error = ironrdp_session::custom_err!(
+            "read activation",
+            ironrdp_connector::custom_err!("read frame", protocol_error)
+        );
+        assert!(!is_transport_session_error(&protocol_error));
     }
 
     #[test]

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -574,6 +574,7 @@ impl RdpClient {
             let reconnect_cookie = (reconnect_attempt != 0)
                 .then_some(auto_reconnect_cookie.as_ref())
                 .flatten();
+            let used_auto_reconnect_cookie = reconnect_cookie.is_some();
             let (connection_result, framed) = match &self.config.transport {
                 Transport::Direct => match Box::pin(cancelable_operation(
                     connect_direct(
@@ -589,21 +590,15 @@ impl RdpClient {
                 {
                     Some(Ok(result)) => result,
                     Some(Err(error)) => {
-                        if let Some(attempt) = next_auto_reconnect_attempt(
-                            auto_reconnect_policy,
-                            reconnect_attempt,
-                            auto_reconnect_cookie.as_ref(),
-                        ) {
-                            reconnect_attempt = attempt;
-                            if self
-                                .confirm_auto_reconnect(
-                                    attempt,
-                                    auto_reconnect_policy.map_or(0, |policy| policy.maximum_attempts),
-                                )
-                                .await
-                            {
-                                continue;
-                            }
+                        if self
+                            .try_auto_reconnect(
+                                auto_reconnect_policy,
+                                &mut reconnect_attempt,
+                                auto_reconnect_cookie.as_ref(),
+                            )
+                            .await
+                        {
+                            continue;
                         }
                         if !self.send_output_event(RdpOutputEvent::ConnectionFailure(error)).await {
                             self.emit_user_initiated_termination();
@@ -632,21 +627,15 @@ impl RdpClient {
                 {
                     Some(Ok(result)) => result,
                     Some(Err(error)) => {
-                        if let Some(attempt) = next_auto_reconnect_attempt(
-                            auto_reconnect_policy,
-                            reconnect_attempt,
-                            auto_reconnect_cookie.as_ref(),
-                        ) {
-                            reconnect_attempt = attempt;
-                            if self
-                                .confirm_auto_reconnect(
-                                    attempt,
-                                    auto_reconnect_policy.map_or(0, |policy| policy.maximum_attempts),
-                                )
-                                .await
-                            {
-                                continue;
-                            }
+                        if self
+                            .try_auto_reconnect(
+                                auto_reconnect_policy,
+                                &mut reconnect_attempt,
+                                auto_reconnect_cookie.as_ref(),
+                            )
+                            .await
+                        {
+                            continue;
                         }
                         if !self.send_output_event(RdpOutputEvent::ConnectionFailure(error)).await {
                             self.emit_user_initiated_termination();
@@ -674,21 +663,15 @@ impl RdpClient {
                 {
                     Some(Ok(result)) => result,
                     Some(Err(error)) => {
-                        if let Some(attempt) = next_auto_reconnect_attempt(
-                            auto_reconnect_policy,
-                            reconnect_attempt,
-                            auto_reconnect_cookie.as_ref(),
-                        ) {
-                            reconnect_attempt = attempt;
-                            if self
-                                .confirm_auto_reconnect(
-                                    attempt,
-                                    auto_reconnect_policy.map_or(0, |policy| policy.maximum_attempts),
-                                )
-                                .await
-                            {
-                                continue;
-                            }
+                        if self
+                            .try_auto_reconnect(
+                                auto_reconnect_policy,
+                                &mut reconnect_attempt,
+                                auto_reconnect_cookie.as_ref(),
+                            )
+                            .await
+                        {
+                            continue;
                         }
                         if !self.send_output_event(RdpOutputEvent::ConnectionFailure(error)).await {
                             self.emit_user_initiated_termination();
@@ -717,21 +700,15 @@ impl RdpClient {
                 {
                     Some(Ok(result)) => result,
                     Some(Err(error)) => {
-                        if let Some(attempt) = next_auto_reconnect_attempt(
-                            auto_reconnect_policy,
-                            reconnect_attempt,
-                            auto_reconnect_cookie.as_ref(),
-                        ) {
-                            reconnect_attempt = attempt;
-                            if self
-                                .confirm_auto_reconnect(
-                                    attempt,
-                                    auto_reconnect_policy.map_or(0, |policy| policy.maximum_attempts),
-                                )
-                                .await
-                            {
-                                continue;
-                            }
+                        if self
+                            .try_auto_reconnect(
+                                auto_reconnect_policy,
+                                &mut reconnect_attempt,
+                                auto_reconnect_cookie.as_ref(),
+                            )
+                            .await
+                        {
+                            continue;
                         }
                         if !self.send_output_event(RdpOutputEvent::ConnectionFailure(error)).await {
                             self.emit_user_initiated_termination();
@@ -744,6 +721,12 @@ impl RdpClient {
                     }
                 },
             };
+
+            // A successful ARC connection consumes the session-bound cookie.
+            // Only a subsequent Save Session Info PDU may provide a replacement.
+            if used_auto_reconnect_cookie {
+                auto_reconnect_cookie = None;
+            }
 
             if reconnect_attempt == 0 && !self.send_output_event(RdpOutputEvent::Connected).await {
                 self.emit_user_initiated_termination();
@@ -787,21 +770,15 @@ impl RdpClient {
                     break;
                 }
                 Ok(RdpControlFlow::TransportFailure(error)) => {
-                    if let Some(attempt) = next_auto_reconnect_attempt(
-                        auto_reconnect_policy,
-                        reconnect_attempt,
-                        auto_reconnect_cookie.as_ref(),
-                    ) {
-                        reconnect_attempt = attempt;
-                        if self
-                            .confirm_auto_reconnect(
-                                attempt,
-                                auto_reconnect_policy.map_or(0, |policy| policy.maximum_attempts),
-                            )
-                            .await
-                        {
-                            continue;
-                        }
+                    if self
+                        .try_auto_reconnect(
+                            auto_reconnect_policy,
+                            &mut reconnect_attempt,
+                            auto_reconnect_cookie.as_ref(),
+                        )
+                        .await
+                    {
+                        continue;
                     }
                     if !self.send_output_event(RdpOutputEvent::Terminated(Err(error))).await {
                         self.emit_user_initiated_termination();
@@ -825,6 +802,23 @@ impl RdpClient {
             .unwrap_or(false)
     }
 
+    async fn try_auto_reconnect(
+        &mut self,
+        policy: Option<AutoReconnectPolicy>,
+        reconnect_attempt: &mut u32,
+        cookie: Option<&ServerAutoReconnect>,
+    ) -> bool {
+        let Some(policy) = policy else {
+            return false;
+        };
+        let Some(attempt) = policy.next_attempt(*reconnect_attempt, cookie.is_some()) else {
+            return false;
+        };
+
+        *reconnect_attempt = attempt;
+        self.confirm_auto_reconnect(attempt, policy.maximum_attempts).await
+    }
+
     async fn confirm_auto_reconnect(&mut self, attempt: u32, maximum_attempts: u32) -> bool {
         let (response, receiver) = oneshot::channel();
         if !self
@@ -839,10 +833,12 @@ impl RdpClient {
             return false;
         }
 
-        if !matches!(
-            tokio::time::timeout(Duration::from_secs(30), receiver).await,
-            Ok(Ok(AutoReconnectDecision::Continue))
-        ) {
+        let decision = cancelable_operation(
+            tokio::time::timeout(Duration::from_secs(30), receiver),
+            &mut self.close_receiver,
+        )
+        .await;
+        if !matches!(decision, Some(Ok(Ok(AutoReconnectDecision::Continue)))) {
             return false;
         }
 
@@ -878,14 +874,6 @@ impl AutoReconnectPolicy {
             None
         }
     }
-}
-
-fn next_auto_reconnect_attempt(
-    policy: Option<AutoReconnectPolicy>,
-    previous_attempt: u32,
-    cookie: Option<&ServerAutoReconnect>,
-) -> Option<u32> {
-    policy.and_then(|policy| policy.next_attempt(previous_attempt, cookie.is_some()))
 }
 
 fn is_transport_read_error(error: &io::Error) -> bool {
@@ -2113,7 +2101,20 @@ async fn active_session(
                         *auto_reconnect_cookie = None;
                         // The server rejected the cookie but may complete this
                         // connection with the configured credentials instead.
-                        *reconnect_attempt = 0;
+                        if *reconnect_attempt != 0 {
+                            if !send_active_output_event(
+                                output_event_sender,
+                                RdpOutputEvent::Connected,
+                                close_receiver,
+                            )
+                            .await?
+                            {
+                                return Ok(RdpControlFlow::TerminatedGracefully(
+                                    GracefulDisconnectReason::UserInitiated,
+                                ));
+                            }
+                            *reconnect_attempt = 0;
+                        }
                     }
                     if *reconnect_attempt != 0
                         && outputs.iter().any(|output| {

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -27,13 +27,13 @@ use ironrdp_pdu::input::mouse::PointerFlags;
     all(windows, feature = "webauthn")
 ))]
 use ironrdp_pdu::pdu_other_err;
+use ironrdp_pdu::rdp::session_info::ServerAutoReconnect;
 #[cfg(feature = "rdpdr")]
 pub use ironrdp_rdpdr::backend::{RdpdrBackendFactory, RdpdrBackendFactoryResult, RdpdrBackendProduct, RdpdrDrive};
 use ironrdp_rdpei::RdpeiClient;
 use ironrdp_rdpei::pdu::TouchEventPdu;
 #[cfg(any(feature = "clipboard", feature = "rdpdr"))]
 use ironrdp_session::ActiveStage;
-use ironrdp_pdu::rdp::session_info::ServerAutoReconnect;
 use ironrdp_session::image::DecodedImage;
 use ironrdp_session::{ActiveStageBuilder, ActiveStageOutput, GracefulDisconnectReason, SessionResult};
 use ironrdp_svc::SvcMessage;

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -1,4 +1,3 @@
-use core::error::Error as _;
 use core::net::SocketAddr;
 use core::num::NonZeroU16;
 use core::time::Duration;

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -3456,6 +3456,7 @@ mod tests {
             &input_sender,
             no_cliprdr_factory(),
             Some(&factory),
+            None,
         )
         .expect("RDPDR connector should build");
 
@@ -3528,7 +3529,7 @@ mod tests {
             .expect("the first event fits");
 
         sender
-            .send_clipboard(ClipboardMessage::Error(Box::new(std::io::Error::other(
+            .send_clipboard(ClipboardMessage::Error(Box::new(io::Error::other(
                 "test clipboard message",
             ))))
             .expect("clipboard messages use a dedicated queue");

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -780,7 +780,7 @@ impl RdpClient {
                     }
                     break;
                 }
-                Err(e) => {
+                Ok(RdpControlFlow::TransportFailure(error)) => {
                     if let Some(attempt) = next_auto_reconnect_attempt(
                         auto_reconnect_policy,
                         reconnect_attempt,
@@ -797,6 +797,12 @@ impl RdpClient {
                             continue;
                         }
                     }
+                    if !self.send_output_event(RdpOutputEvent::Terminated(Err(error))).await {
+                        self.emit_user_initiated_termination();
+                    }
+                    break;
+                }
+                Err(e) => {
                     if !self.send_output_event(RdpOutputEvent::Terminated(Err(e))).await {
                         self.emit_user_initiated_termination();
                     }
@@ -1919,6 +1925,7 @@ enum RdpControlFlow {
         height: u16,
         reason: DisplayResizeFallbackReason,
     },
+    TransportFailure(ironrdp_session::SessionError),
     TerminatedGracefully(GracefulDisconnectReason),
 }
 
@@ -2053,7 +2060,14 @@ async fn active_session(
                     }
                 }
                 frame = reader.read_pdu() => {
-                    let (action, payload) = frame.map_err(|e| ironrdp_session::custom_err!("read frame", e))?;
+                    let (action, payload) = match frame {
+                        Ok(frame) => frame,
+                        Err(error) => {
+                            return Ok(RdpControlFlow::TransportFailure(
+                                ironrdp_session::custom_err!("read frame", error),
+                            ));
+                        }
+                    };
                     trace!(?action, frame_length = payload.len(), "Frame received");
                     let mut outputs = active_stage.process(&mut image, action, &payload)?;
                     #[cfg(feature = "rdpdr")]
@@ -2410,7 +2424,12 @@ async fn active_session(
                             GracefulDisconnectReason::UserInitiated,
                         ));
                     };
-                    result.map_err(|e| ironrdp_session::custom_err!("write response", e))?;
+                    if let Err(error) = result {
+                        return Ok(RdpControlFlow::TransportFailure(ironrdp_session::custom_err!(
+                            "write response",
+                            error
+                        )));
+                    }
                 }
                 ActiveStageOutput::GraphicsUpdate(_region) => {
                     let buffer: Vec<u32> = image

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -808,17 +808,6 @@ impl RdpClient {
                     }
                     break;
                 }
-                Ok(RdpControlFlow::AutoReconnectRejected) => {
-                    if !self
-                        .send_output_event(RdpOutputEvent::Terminated(Err(ironrdp_session::general_err!(
-                            "auto reconnect rejected by server"
-                        ))))
-                        .await
-                    {
-                        self.emit_user_initiated_termination();
-                    }
-                    break;
-                }
                 Err(e) => {
                     if !self.send_output_event(RdpOutputEvent::Terminated(Err(e))).await {
                         self.emit_user_initiated_termination();
@@ -850,10 +839,19 @@ impl RdpClient {
             return false;
         }
 
-        matches!(
+        if !matches!(
             tokio::time::timeout(Duration::from_secs(30), receiver).await,
-            Ok(Ok(AutoReconnectDecision::Continue)) | Err(_)
-        )
+            Ok(Ok(AutoReconnectDecision::Continue))
+        ) {
+            return false;
+        }
+
+        // Keep bounded retries from exhausting their budget before a transient
+        // network failure has had time to clear. A close during the wait is
+        // handled by the connection loop before another connection attempt starts.
+        cancelable_operation(tokio::time::sleep(Duration::from_secs(1)), &mut self.close_receiver)
+            .await
+            .is_some()
     }
 
     fn emit_user_initiated_termination(&self) {
@@ -1961,7 +1959,6 @@ enum RdpControlFlow {
         reason: DisplayResizeFallbackReason,
     },
     TransportFailure(ironrdp_session::SessionError),
-    AutoReconnectRejected,
     TerminatedGracefully(GracefulDisconnectReason),
 }
 
@@ -2114,7 +2111,9 @@ async fn active_session(
                     }
                     if outputs.iter().any(|output| matches!(output, ActiveStageOutput::AutoReconnectFailed)) {
                         *auto_reconnect_cookie = None;
-                        return Ok(RdpControlFlow::AutoReconnectRejected);
+                        // The server rejected the cookie but may complete this
+                        // connection with the configured credentials instead.
+                        *reconnect_attempt = 0;
                     }
                     if *reconnect_attempt != 0
                         && outputs.iter().any(|output| {
@@ -2486,9 +2485,9 @@ async fn active_session(
                     *auto_reconnect_cookie = Some(cookie);
                     debug!("Received a Server Auto-Reconnect Cookie");
                 }
-                ActiveStageOutput::AutoReconnectFailed => {
-                    return Ok(RdpControlFlow::AutoReconnectRejected);
-                }
+                // The status pre-scan above discarded the reconnect state before
+                // success can be reported; this output has no host-facing event.
+                ActiveStageOutput::AutoReconnectFailed => {}
                 ActiveStageOutput::ResponseFrame(frame) => {
                     let Some(result) = cancelable_operation(writer.write_all(&frame), close_receiver).await else {
                         return Ok(RdpControlFlow::TerminatedGracefully(

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -1,6 +1,7 @@
 use core::net::SocketAddr;
 use core::num::NonZeroU16;
 use core::time::Duration;
+use std::io;
 use std::sync::Arc;
 
 #[cfg(feature = "clipboard")]
@@ -161,6 +162,8 @@ pub enum RdpOutputEvent {
     ///
     /// `attempt` is one-based and never exceeds `maximum_attempts`.
     AutoReconnecting {
+        /// The server did not provide a protocol-level disconnect code for the transport loss.
+        disconnect_reason: u32,
         attempt: u32,
         maximum_attempts: u32,
         response: oneshot::Sender<AutoReconnectDecision>,
@@ -566,6 +569,11 @@ impl RdpClient {
                 break;
             }
 
+            // Only a transport-loss retry may attach the session-bound ARC cookie. Display
+            // fallback reconnects establish a new desktop session and must not reuse it.
+            let reconnect_cookie = (reconnect_attempt != 0)
+                .then_some(auto_reconnect_cookie.as_ref())
+                .flatten();
             let (connection_result, framed) = match &self.config.transport {
                 Transport::Direct => match Box::pin(cancelable_operation(
                     connect_direct(
@@ -573,7 +581,7 @@ impl RdpClient {
                         &self.input_event_sender,
                         cliprdr_factory,
                         rdpdr_factory,
-                        auto_reconnect_cookie.as_ref(),
+                        reconnect_cookie,
                     ),
                     &mut self.close_receiver,
                 ))
@@ -616,7 +624,7 @@ impl RdpClient {
                         &self.input_event_sender,
                         cliprdr_factory,
                         rdpdr_factory,
-                        auto_reconnect_cookie.as_ref(),
+                        reconnect_cookie,
                     ),
                     &mut self.close_receiver,
                 ))
@@ -658,7 +666,7 @@ impl RdpClient {
                         &self.input_event_sender,
                         cliprdr_factory,
                         rdpdr_factory,
-                        auto_reconnect_cookie.as_ref(),
+                        reconnect_cookie,
                     ),
                     &mut self.close_receiver,
                 ))
@@ -673,10 +681,10 @@ impl RdpClient {
                         ) {
                             reconnect_attempt = attempt;
                             if self
-                                .send_output_event(RdpOutputEvent::AutoReconnecting {
+                                .confirm_auto_reconnect(
                                     attempt,
-                                    maximum_attempts: auto_reconnect_policy.map_or(0, |policy| policy.maximum_attempts),
-                                })
+                                    auto_reconnect_policy.map_or(0, |policy| policy.maximum_attempts),
+                                )
                                 .await
                             {
                                 continue;
@@ -701,7 +709,7 @@ impl RdpClient {
                         &self.input_event_sender,
                         cliprdr_factory,
                         rdpdr_factory,
-                        auto_reconnect_cookie.as_ref(),
+                        reconnect_cookie,
                     ),
                     &mut self.close_receiver,
                 ))
@@ -737,17 +745,10 @@ impl RdpClient {
                 },
             };
 
-            let reconnected = reconnect_attempt != 0;
-            let connected_event = if !reconnected {
-                RdpOutputEvent::Connected
-            } else {
-                RdpOutputEvent::AutoReconnected
-            };
-            if !self.send_output_event(connected_event).await {
+            if reconnect_attempt == 0 && !self.send_output_event(RdpOutputEvent::Connected).await {
                 self.emit_user_initiated_termination();
                 break;
             }
-            reconnect_attempt = 0;
 
             match active_session(
                 framed,
@@ -760,6 +761,7 @@ impl RdpClient {
                 &mut self.graceful_close_receiver,
                 self.config.fake_events_interval,
                 &mut auto_reconnect_cookie,
+                &mut reconnect_attempt,
             )
             .await
             {
@@ -771,6 +773,10 @@ impl RdpClient {
                         self.emit_user_initiated_termination();
                         break;
                     }
+                    // A resize fallback intentionally establishes a new session, not an
+                    // automatic reconnection to the old one.
+                    auto_reconnect_cookie = None;
+                    reconnect_attempt = 0;
                     self.config.connector.desktop_size.width = width;
                     self.config.connector.desktop_size.height = height;
                 }
@@ -802,6 +808,17 @@ impl RdpClient {
                     }
                     break;
                 }
+                Ok(RdpControlFlow::AutoReconnectRejected) => {
+                    if !self
+                        .send_output_event(RdpOutputEvent::Terminated(Err(ironrdp_session::general_err!(
+                            "auto reconnect rejected by server"
+                        ))))
+                        .await
+                    {
+                        self.emit_user_initiated_termination();
+                    }
+                    break;
+                }
                 Err(e) => {
                     if !self.send_output_event(RdpOutputEvent::Terminated(Err(e))).await {
                         self.emit_user_initiated_termination();
@@ -823,6 +840,7 @@ impl RdpClient {
         let (response, receiver) = oneshot::channel();
         if !self
             .send_output_event(RdpOutputEvent::AutoReconnecting {
+                disconnect_reason: 0,
                 attempt,
                 maximum_attempts,
                 response,
@@ -870,6 +888,12 @@ fn next_auto_reconnect_attempt(
     cookie: Option<&ServerAutoReconnect>,
 ) -> Option<u32> {
     policy.and_then(|policy| policy.next_attempt(previous_attempt, cookie.is_some()))
+}
+
+fn is_transport_read_error(error: &io::Error) -> bool {
+    !error
+        .get_ref()
+        .is_some_and(|source| source.is::<ironrdp_core::DecodeError>())
 }
 
 async fn cancelable_operation<T>(
@@ -1926,6 +1950,7 @@ enum RdpControlFlow {
         reason: DisplayResizeFallbackReason,
     },
     TransportFailure(ironrdp_session::SessionError),
+    AutoReconnectRejected,
     TerminatedGracefully(GracefulDisconnectReason),
 }
 
@@ -1961,6 +1986,7 @@ async fn active_session(
     graceful_close_receiver: &mut watch::Receiver<bool>,
     fake_events_interval: Option<Duration>,
     auto_reconnect_cookie: &mut Option<ServerAutoReconnect>,
+    reconnect_attempt: &mut u32,
 ) -> SessionResult<RdpControlFlow> {
     let (mut reader, mut writer) = split_tokio_framed(framed);
     let desktop_size = connection_result.desktop_size;
@@ -2062,17 +2088,48 @@ async fn active_session(
                 frame = reader.read_pdu() => {
                     let (action, payload) = match frame {
                         Ok(frame) => frame,
-                        Err(error) => {
+                        Err(error) if is_transport_read_error(&error) => {
                             return Ok(RdpControlFlow::TransportFailure(
                                 ironrdp_session::custom_err!("read frame", error),
                             ));
                         }
+                        Err(error) => return Err(ironrdp_session::custom_err!("read frame", error)),
                     };
                     trace!(?action, frame_length = payload.len(), "Frame received");
                     let mut outputs = active_stage.process(&mut image, action, &payload)?;
                     #[cfg(feature = "rdpdr")]
                     if let Some(output) = poll_deferred_rdpdr_output(&mut active_stage)? {
                         outputs.push(output);
+                    }
+                    if outputs.iter().any(|output| matches!(output, ActiveStageOutput::AutoReconnectFailed)) {
+                        *auto_reconnect_cookie = None;
+                        return Ok(RdpControlFlow::AutoReconnectRejected);
+                    }
+                    if *reconnect_attempt != 0
+                        && outputs.iter().any(|output| {
+                            matches!(
+                                output,
+                                ActiveStageOutput::SaveSessionInfo { .. }
+                                    | ActiveStageOutput::GraphicsUpdate(_)
+                                    | ActiveStageOutput::PointerDefault
+                                    | ActiveStageOutput::PointerHidden
+                                    | ActiveStageOutput::PointerPosition { .. }
+                                    | ActiveStageOutput::PointerBitmap(_)
+                            )
+                        })
+                    {
+                        if !send_active_output_event(
+                            output_event_sender,
+                            RdpOutputEvent::AutoReconnected,
+                            close_receiver,
+                        )
+                        .await?
+                        {
+                            return Ok(RdpControlFlow::TerminatedGracefully(
+                                GracefulDisconnectReason::UserInitiated,
+                            ));
+                        }
+                        *reconnect_attempt = 0;
                     }
                     if active_stage.take_bitmap_recovery_request() {
                         let redraw_frames = active_stage.request_full_redraw(
@@ -2418,6 +2475,9 @@ async fn active_session(
                     *auto_reconnect_cookie = Some(cookie);
                     debug!("Received a Server Auto-Reconnect Cookie");
                 }
+                ActiveStageOutput::AutoReconnectFailed => {
+                    return Ok(RdpControlFlow::AutoReconnectRejected);
+                }
                 ActiveStageOutput::ResponseFrame(frame) => {
                     let Some(result) = cancelable_operation(writer.write_all(&frame), close_receiver).await else {
                         return Ok(RdpControlFlow::TerminatedGracefully(
@@ -2535,9 +2595,12 @@ async fn active_session(
                                     GracefulDisconnectReason::UserInitiated,
                                 ));
                             };
-                            result.map_err(|error| {
-                                ironrdp_session::custom_err!("write post-logon redraw request", error)
-                            })?;
+                            if let Err(error) = result {
+                                return Ok(RdpControlFlow::TransportFailure(ironrdp_session::custom_err!(
+                                    "write post-logon redraw request",
+                                    error
+                                )));
+                            }
                         }
 
                         if redraw_requested
@@ -2612,9 +2675,12 @@ async fn active_session(
                                     GracefulDisconnectReason::UserInitiated,
                                 ));
                             };
-                            result.map_err(|e| {
-                                ironrdp_session::custom_err!("write deactivation-reactivation sequence step", e)
-                            })?;
+                            if let Err(error) = result {
+                                return Ok(RdpControlFlow::TransportFailure(ironrdp_session::custom_err!(
+                                    "write deactivation-reactivation sequence step",
+                                    error
+                                )));
+                            }
                         }
                         if let ConnectionActivationState::Finalized {
                             desktop_size,
@@ -2761,7 +2827,12 @@ async fn active_session(
                             GracefulDisconnectReason::UserInitiated,
                         ));
                     };
-                    result.map_err(|e| ironrdp_session::custom_err!("write pending resize", e))?;
+                    if let Err(error) = result {
+                        return Ok(RdpControlFlow::TransportFailure(ironrdp_session::custom_err!(
+                            "write pending resize",
+                            error
+                        )));
+                    }
                 }
                 None => {
                     debug!("Reconnecting because Display Control is unavailable");
@@ -3019,6 +3090,17 @@ mod tests {
     #[test]
     fn zero_auto_reconnect_limit_disables_retries() {
         assert_eq!(AutoReconnectPolicy::new(0).next_attempt(0, true), None);
+    }
+
+    #[test]
+    fn protocol_decode_errors_do_not_trigger_auto_reconnect() {
+        let decode_error = ironrdp_pdu::find_size(&[0x01]).expect_err("invalid fast-path action must fail");
+        let protocol_error = io::Error::other(decode_error);
+
+        assert!(!is_transport_read_error(&protocol_error));
+        assert!(is_transport_read_error(&io::Error::from(
+            io::ErrorKind::ConnectionReset
+        )));
     }
 
     #[test]

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -41,7 +41,7 @@ use ironrdp_tokio::{FramedWrite, single_sequence_step_read, split_tokio_framed};
 use smallvec::SmallVec;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::TcpStream;
-use tokio::sync::{mpsc, watch};
+use tokio::sync::{mpsc, oneshot, watch};
 #[cfg(any(feature = "clipboard", all(windows, feature = "dvc-com-plugin")))]
 use tracing::error;
 use tracing::{debug, info, trace, warn};
@@ -163,10 +163,18 @@ pub enum RdpOutputEvent {
     AutoReconnecting {
         attempt: u32,
         maximum_attempts: u32,
+        response: oneshot::Sender<AutoReconnectDecision>,
     },
     /// A cookie-based reconnect has completed successfully.
     AutoReconnected,
     Terminated(SessionResult<GracefulDisconnectReason>),
+}
+
+/// Controls whether a pending automatic reconnect may proceed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AutoReconnectDecision {
+    Continue,
+    Stop,
 }
 
 #[derive(Debug)]
@@ -580,10 +588,10 @@ impl RdpClient {
                         ) {
                             reconnect_attempt = attempt;
                             if self
-                                .send_output_event(RdpOutputEvent::AutoReconnecting {
+                                .confirm_auto_reconnect(
                                     attempt,
-                                    maximum_attempts: auto_reconnect_policy.map_or(0, |policy| policy.maximum_attempts),
-                                })
+                                    auto_reconnect_policy.map_or(0, |policy| policy.maximum_attempts),
+                                )
                                 .await
                             {
                                 continue;
@@ -623,10 +631,10 @@ impl RdpClient {
                         ) {
                             reconnect_attempt = attempt;
                             if self
-                                .send_output_event(RdpOutputEvent::AutoReconnecting {
+                                .confirm_auto_reconnect(
                                     attempt,
-                                    maximum_attempts: auto_reconnect_policy.map_or(0, |policy| policy.maximum_attempts),
-                                })
+                                    auto_reconnect_policy.map_or(0, |policy| policy.maximum_attempts),
+                                )
                                 .await
                             {
                                 continue;
@@ -708,10 +716,10 @@ impl RdpClient {
                         ) {
                             reconnect_attempt = attempt;
                             if self
-                                .send_output_event(RdpOutputEvent::AutoReconnecting {
+                                .confirm_auto_reconnect(
                                     attempt,
-                                    maximum_attempts: auto_reconnect_policy.map_or(0, |policy| policy.maximum_attempts),
-                                })
+                                    auto_reconnect_policy.map_or(0, |policy| policy.maximum_attempts),
+                                )
                                 .await
                             {
                                 continue;
@@ -780,10 +788,10 @@ impl RdpClient {
                     ) {
                         reconnect_attempt = attempt;
                         if self
-                            .send_output_event(RdpOutputEvent::AutoReconnecting {
+                            .confirm_auto_reconnect(
                                 attempt,
-                                maximum_attempts: auto_reconnect_policy.map_or(0, |policy| policy.maximum_attempts),
-                            })
+                                auto_reconnect_policy.map_or(0, |policy| policy.maximum_attempts),
+                            )
                             .await
                         {
                             continue;
@@ -803,6 +811,25 @@ impl RdpClient {
         send_cancellable_output_event(&self.output_event_sender, event, &mut self.close_receiver)
             .await
             .unwrap_or(false)
+    }
+
+    async fn confirm_auto_reconnect(&mut self, attempt: u32, maximum_attempts: u32) -> bool {
+        let (response, receiver) = oneshot::channel();
+        if !self
+            .send_output_event(RdpOutputEvent::AutoReconnecting {
+                attempt,
+                maximum_attempts,
+                response,
+            })
+            .await
+        {
+            return false;
+        }
+
+        matches!(
+            tokio::time::timeout(Duration::from_secs(30), receiver).await,
+            Ok(Ok(AutoReconnectDecision::Continue)) | Err(_)
+        )
     }
 
     fn emit_user_initiated_termination(&self) {

--- a/crates/ironrdp-session/src/active_stage.rs
+++ b/crates/ironrdp-session/src/active_stage.rs
@@ -659,6 +659,8 @@ pub enum ActiveStageOutput {
     ///
     /// [\[MS-RDPBCGR\] 2.2.4.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/18f4f605-0ee3-4175-8a62-cf8775252547
     AutoReconnectCookie(ServerAutoReconnect),
+    /// Server rejected the automatic reconnection attempt.
+    AutoReconnectFailed,
 }
 
 impl TryFrom<x224::ProcessorOutput> for ActiveStageOutput {
@@ -684,6 +686,7 @@ impl TryFrom<x224::ProcessorOutput> for ActiveStageOutput {
             x224::ProcessorOutput::MultitransportRequest(pdu) => Ok(Self::MultitransportRequest(pdu)),
             x224::ProcessorOutput::AutoDetect(request) => Ok(Self::AutoDetect(request)),
             x224::ProcessorOutput::AutoReconnectCookie(cookie) => Ok(Self::AutoReconnectCookie(cookie)),
+            x224::ProcessorOutput::AutoReconnectFailed => Ok(Self::AutoReconnectFailed),
             // GraphicsUpdate and PointerUpdate are consumed in ActiveStage::process()
             // before reaching this conversion.
             x224::ProcessorOutput::GraphicsUpdate(_) | x224::ProcessorOutput::PointerUpdate(_) => Err(

--- a/crates/ironrdp-session/src/x224/mod.rs
+++ b/crates/ironrdp-session/src/x224/mod.rs
@@ -60,9 +60,11 @@ pub enum ProcessorOutput {
     /// [\[MS-RDPBCGR\] 2.2.4.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/18f4f605-0ee3-4175-8a62-cf8775252547
     /// [\[MS-RDPBCGR\] 1.3.1.5]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/15b0d1c9-2891-4adb-a45e-deb4aeeeab7c
     AutoReconnectCookie(ServerAutoReconnect),
-    /// Server rejected a Client Auto-Reconnect Packet ([MS-RDPBCGR] 2.2.4.1).
+    /// Server rejected a Client Auto-Reconnect Packet ([\[MS-RDPBCGR\] 2.2.4.1]).
     ///
     /// The client must discard its cookie and not report the reconnect as successful.
+    ///
+    /// [\[MS-RDPBCGR\] 2.2.4.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/5073f4ed-1e93-45e1-b039-6e30c385867c
     AutoReconnectFailed,
     /// Auto-detect network characteristics from server ([\[MS-RDPBCGR\] 2.2.14]).
     ///

--- a/crates/ironrdp-session/src/x224/mod.rs
+++ b/crates/ironrdp-session/src/x224/mod.rs
@@ -60,6 +60,10 @@ pub enum ProcessorOutput {
     /// [\[MS-RDPBCGR\] 2.2.4.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/18f4f605-0ee3-4175-8a62-cf8775252547
     /// [\[MS-RDPBCGR\] 1.3.1.5]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/15b0d1c9-2891-4adb-a45e-deb4aeeeab7c
     AutoReconnectCookie(ServerAutoReconnect),
+    /// Server rejected a Client Auto-Reconnect Packet ([MS-RDPBCGR] 2.2.4.1).
+    ///
+    /// The client must discard its cookie and not report the reconnect as successful.
+    AutoReconnectFailed,
     /// Auto-detect network characteristics from server ([\[MS-RDPBCGR\] 2.2.14]).
     ///
     /// Currently only surfaces [`AutoDetectRequest::NetworkCharacteristicsResult`].
@@ -275,6 +279,13 @@ impl Processor {
                 }
 
                 Ok(outputs)
+            }
+            ShareDataPdu::ArcStatusPdu(status) => {
+                if status != [0; 4] {
+                    return Err(reason_err!("IO channel", "invalid auto-reconnect status PDU"));
+                }
+
+                Ok(vec![ProcessorOutput::AutoReconnectFailed])
             }
             // FIXME: workaround fix to not terminate the session on "unhandled PDU: Set Keyboard Indicators PDU"
             ShareDataPdu::SetKeyboardIndicators(data) => {
@@ -537,5 +548,46 @@ mod tests {
         };
 
         assert!(is_logon_complete(&session_info));
+    }
+
+    #[test]
+    fn processor_surfaces_valid_auto_reconnect_status() {
+        let mut bulk_decompressor = None;
+        let outputs = Processor::process_share_data(
+            ShareDataCtx {
+                initiator_id: 0,
+                channel_id: 0,
+                share_id: 0,
+                pdu_source: 0,
+                compression_flags: CompressionFlags::empty(),
+                compression_type: CompressionType::K64,
+                pdu: ShareDataPdu::ArcStatusPdu(vec![0; 4]),
+            },
+            &mut bulk_decompressor,
+        )
+        .expect("valid auto-reconnect status PDU should be processed");
+
+        assert!(matches!(outputs.as_slice(), [ProcessorOutput::AutoReconnectFailed]));
+    }
+
+    #[test]
+    fn processor_rejects_invalid_auto_reconnect_status() {
+        let mut bulk_decompressor = None;
+
+        assert!(
+            Processor::process_share_data(
+                ShareDataCtx {
+                    initiator_id: 0,
+                    channel_id: 0,
+                    share_id: 0,
+                    pdu_source: 0,
+                    compression_flags: CompressionFlags::empty(),
+                    compression_type: CompressionType::K64,
+                    pdu: ShareDataPdu::ArcStatusPdu(vec![0, 0, 0]),
+                },
+                &mut bulk_decompressor,
+            )
+            .is_err()
+        );
     }
 }

--- a/crates/ironrdp-viewer/src/app.rs
+++ b/crates/ironrdp-viewer/src/app.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::Context as _;
-use ironrdp::client::rdp::{RdpInputEvent, RdpInputSender, RdpOutputEvent};
+use ironrdp::client::rdp::{AutoReconnectDecision, RdpInputEvent, RdpInputSender, RdpOutputEvent};
 use ironrdp_daemon::daemon::{Daemon, ResizeError};
 use raw_window_handle::{DisplayHandle, HasDisplayHandle as _};
 use smallvec::SmallVec;
@@ -545,6 +545,22 @@ impl RpcApp {
                     ?reason,
                     "Reconnecting because dynamic display resize could not complete"
                 );
+            }
+            RdpOutputEvent::AutoReconnecting {
+                attempt,
+                maximum_attempts,
+                response,
+                ..
+            } => {
+                warn!(
+                    attempt,
+                    maximum_attempts,
+                    "Stopping unsupported automatic reconnect"
+                );
+                let _ = response.send(AutoReconnectDecision::Stop);
+            }
+            RdpOutputEvent::AutoReconnected => {
+                info!("RDP session automatically reconnected");
             }
             RdpOutputEvent::RailHandshake {
                 handshake_ex_flags,

--- a/crates/ironrdp-viewer/src/app.rs
+++ b/crates/ironrdp-viewer/src/app.rs
@@ -552,11 +552,7 @@ impl RpcApp {
                 response,
                 ..
             } => {
-                warn!(
-                    attempt,
-                    maximum_attempts,
-                    "Stopping unsupported automatic reconnect"
-                );
+                warn!(attempt, maximum_attempts, "Stopping unsupported automatic reconnect");
                 let _ = response.send(AutoReconnectDecision::Stop);
             }
             RdpOutputEvent::AutoReconnected => {

--- a/crates/ironrdp-web/src/session.rs
+++ b/crates/ironrdp-web/src/session.rs
@@ -1078,6 +1078,9 @@ impl iron_remote_desktop::Session for Session {
                     ActiveStageOutput::AutoReconnectCookie(_) => {
                         debug!("Server Auto-Reconnect Cookie received (automatic reconnection not implemented)");
                     }
+                    ActiveStageOutput::AutoReconnectFailed => {
+                        return Err(anyhow::Error::msg("automatic reconnect rejected by server").into());
+                    }
                     ActiveStageOutput::SaveSessionInfo { logon_complete: true } => {
                         debug!("RDP login complete");
                     }

--- a/ffi/dotnet/Devolutions.IronRdp/Generated/ActiveStageOutputType.cs
+++ b/ffi/dotnet/Devolutions.IronRdp/Generated/ActiveStageOutputType.cs
@@ -31,4 +31,5 @@ public enum ActiveStageOutputType
     SaveSessionInfo = 10,
     AutoReconnectCookie = 11,
     WindowingOrders = 12,
+    AutoReconnectFailed = 13,
 }

--- a/ffi/dotnet/Devolutions.IronRdp/Generated/RawActiveStageOutputType.cs
+++ b/ffi/dotnet/Devolutions.IronRdp/Generated/RawActiveStageOutputType.cs
@@ -31,4 +31,5 @@ public enum ActiveStageOutputType
     SaveSessionInfo = 10,
     AutoReconnectCookie = 11,
     WindowingOrders = 12,
+    AutoReconnectFailed = 13,
 }

--- a/ffi/src/session/mod.rs
+++ b/ffi/src/session/mod.rs
@@ -293,9 +293,7 @@ pub mod ffi {
                 ironrdp::session::ActiveStageOutput::AutoReconnectCookie { .. } => {
                     ActiveStageOutputType::AutoReconnectCookie
                 }
-                ironrdp::session::ActiveStageOutput::AutoReconnectFailed => {
-                    ActiveStageOutputType::AutoReconnectFailed
-                }
+                ironrdp::session::ActiveStageOutput::AutoReconnectFailed => ActiveStageOutputType::AutoReconnectFailed,
             }
         }
 

--- a/ffi/src/session/mod.rs
+++ b/ffi/src/session/mod.rs
@@ -270,6 +270,7 @@ pub mod ffi {
         SaveSessionInfo = 10,
         AutoReconnectCookie = 11,
         WindowingOrders = 12,
+        AutoReconnectFailed = 13,
     }
 
     impl ActiveStageOutput {
@@ -291,6 +292,9 @@ pub mod ffi {
                 ironrdp::session::ActiveStageOutput::SaveSessionInfo { .. } => ActiveStageOutputType::SaveSessionInfo,
                 ironrdp::session::ActiveStageOutput::AutoReconnectCookie { .. } => {
                     ActiveStageOutputType::AutoReconnectCookie
+                }
+                ironrdp::session::ActiveStageOutput::AutoReconnectFailed => {
+                    ActiveStageOutputType::AutoReconnectFailed
                 }
             }
         }


### PR DESCRIPTION
Support automatic reconnect through the ActiveX control with bounded host-approved retries after transport loss.

Reuse ARC cookies only for resumed sessions, reject server ARC status failures, and report success after active-session traffic.