### PR TITLE
feat(dvc): attach recorded dynamic channels

### DIFF
--- a/crates/ironrdp-dvc/src/client.rs
+++ b/crates/ironrdp-dvc/src/client.rs
@@ -191,6 +191,14 @@ impl DrdynvcClient {
         self.dynamic_channels.register_once(channel);
     }
 
+    pub fn attach_established_dynamic_channel<T>(&mut self, channel_id: DynamicChannelId, channel: T) -> PduResult<()>
+    where
+        T: DvcClientProcessor + 'static,
+    {
+        self.dynamic_channels
+            .attach_established_channel(channel_id, Box::new(channel))
+    }
+
     /// Bind a listener.
     ///
     /// # Note
@@ -506,6 +514,21 @@ impl DynamicChannelSet {
                 type_id: Some(TypeId::of::<T>()),
             },
         );
+    }
+
+    fn attach_established_channel(
+        &mut self,
+        channel_id: DynamicChannelId,
+        channel: Box<dyn DvcClientProcessor>,
+    ) -> PduResult<()> {
+        if self.active_channels.contains_key(&channel_id) {
+            return Err(pdu_other_err!("dynamic channel ID is already attached"));
+        }
+
+        let mut channel = DynamicVirtualChannel::from_boxed(channel);
+        let _messages = channel.start(channel_id)?;
+        self.active_channels.insert(channel_id, channel);
+        Ok(())
     }
 
     fn try_create_channel(

--- a/crates/ironrdp-testsuite-core/tests/dvc/client.rs
+++ b/crates/ironrdp-testsuite-core/tests/dvc/client.rs
@@ -1,0 +1,108 @@
+use ironrdp_core::{encode_vec, impl_as_any};
+use ironrdp_dvc::ironrdp_pdu::{PduResult, pdu_other_err};
+use ironrdp_dvc::pdu::{DataPdu, DrdynvcDataPdu, DrdynvcServerPdu};
+use ironrdp_dvc::{DrdynvcClient, DvcClientProcessor, DvcMessage, DvcProcessor};
+use ironrdp_svc::SvcProcessor as _;
+
+#[derive(Default)]
+struct RecordedDvc {
+    started_with: Option<u32>,
+    received: Vec<Vec<u8>>,
+}
+
+impl_as_any!(RecordedDvc);
+
+impl DvcProcessor for RecordedDvc {
+    fn channel_name(&self) -> &str {
+        "recorded"
+    }
+
+    fn start(&mut self, channel_id: u32) -> PduResult<Vec<DvcMessage>> {
+        self.started_with = Some(channel_id);
+        Ok(Vec::new())
+    }
+
+    fn process(&mut self, _channel_id: u32, payload: &[u8]) -> PduResult<Vec<DvcMessage>> {
+        self.received.push(payload.to_vec());
+        Ok(Vec::new())
+    }
+}
+
+impl DvcClientProcessor for RecordedDvc {}
+
+struct FailingDvc;
+
+impl_as_any!(FailingDvc);
+
+impl DvcProcessor for FailingDvc {
+    fn channel_name(&self) -> &str {
+        "failing"
+    }
+
+    fn start(&mut self, _channel_id: u32) -> PduResult<Vec<DvcMessage>> {
+        Err(pdu_other_err!("failed to restore dynamic channel"))
+    }
+
+    fn process(&mut self, _channel_id: u32, _payload: &[u8]) -> PduResult<Vec<DvcMessage>> {
+        Ok(Vec::new())
+    }
+}
+
+impl DvcClientProcessor for FailingDvc {}
+
+#[test]
+fn established_dynamic_channel_routes_recorded_data_without_negotiation() {
+    let mut client = DrdynvcClient::new();
+    client
+        .attach_established_dynamic_channel(7, RecordedDvc::default())
+        .expect("recorded channel should attach");
+
+    let payload = encode_vec(&DrdynvcServerPdu::Data(DrdynvcDataPdu::Data(DataPdu::new(
+        7,
+        b"recorded data".to_vec(),
+    ))))
+    .expect("recorded DVC data should encode");
+    assert!(
+        client
+            .process(&payload)
+            .expect("recorded DVC data should route")
+            .is_empty()
+    );
+
+    let channel = client
+        .get_dvc_by_channel_id::<RecordedDvc>(7)
+        .expect("recorded channel should remain attached");
+    assert_eq!(channel.processor().started_with, Some(7));
+    assert_eq!(channel.processor().received, vec![b"recorded data".to_vec()]);
+}
+
+#[test]
+fn established_dynamic_channel_rejects_repeated_ids() {
+    let mut client = DrdynvcClient::new();
+    client
+        .attach_established_dynamic_channel(7, RecordedDvc::default())
+        .expect("first attachment should succeed");
+
+    let error = client
+        .attach_established_dynamic_channel(7, RecordedDvc::default())
+        .expect_err("duplicate channel ID should fail");
+
+    assert!(error.to_string().contains("dynamic channel ID is already attached"));
+}
+
+#[test]
+fn failed_established_dynamic_channel_attachment_is_not_registered() {
+    let mut client = DrdynvcClient::new();
+
+    let error = client
+        .attach_established_dynamic_channel(7, FailingDvc)
+        .expect_err("failing channel should not attach");
+
+    assert!(error.to_string().contains("failed to restore dynamic channel"));
+    assert!(client.get_dvc_by_channel_id::<FailingDvc>(7).is_none());
+    assert!(
+        client
+            .attach_established_dynamic_channel(7, RecordedDvc::default())
+            .is_ok()
+    );
+}

--- a/crates/ironrdp-testsuite-core/tests/dvc/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/dvc/mod.rs
@@ -22,6 +22,7 @@ fn test_decodes<'a, T: Decode<'a> + PartialEq + core::fmt::Debug>(encoded: &'a [
 }
 
 mod capabilities;
+mod client;
 mod close;
 mod create;
 mod data;


### PR DESCRIPTION
Attach known channel IDs for offline replay.

Reject duplicate IDs and failed startup atomically.