### PR TITLE
feat(replay): export replay frame sequences

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -292,6 +292,10 @@ Contains all integration tests for code living in the extra tier, in a single bi
 
 Provides test case generators and oracles for use with fuzzing.
 
+#### [`crates/ironrdp-capture-replay`](./crates/ironrdp-capture-replay)
+
+Offline direct-TCP RDP capture analysis that routes recovered plaintext and exports payload-free replay diagnostics with rendered framebuffer snapshots.
+
 #### [`fuzz`](./fuzz)
 
 Fuzz targets for code in core tier.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2620,6 +2620,7 @@ dependencies = [
  "ironrdp-session",
  "ironrdp-svc",
  "pcap-parser",
+ "png",
  "sha2 0.10.9",
  "thiserror 2.0.19",
  "zeroize",

--- a/crates/ironrdp-capture-replay/Cargo.toml
+++ b/crates/ironrdp-capture-replay/Cargo.toml
@@ -22,6 +22,7 @@ ironrdp-pdu = { version = "0.9.0", path = "../ironrdp-pdu" } # public
 ironrdp-session = { version = "0.11.0", path = "../ironrdp-session" }
 ironrdp-svc = { version = "0.8.0", path = "../ironrdp-svc" }
 pcap-parser = "0.17"
+png = "0.18"
 sha2 = "0.10"
 thiserror = "2"
 zeroize = "1.8"

--- a/crates/ironrdp-capture-replay/README.md
+++ b/crates/ironrdp-capture-replay/README.md
@@ -12,7 +12,7 @@ cargo run -p ironrdp-capture-replay --bin ironrdp-capture-replay -- capture.pcap
 ```
 
 The command succeeds only when replay produces visual framebuffer updates.
-It writes `frame_0000.png`-style PNG files in replay order, along with payload-free `frame_meta.psv`, `events.tsv`, `gaps.tsv`, and `dynamic-channels.tsv` files.
+It writes PNG files zero-padded to at least six digits (`frame_000000.png`, `frame_000001.png`, ...) in replay order, along with payload-free `frame_meta.psv`, `events.tsv`, `gaps.tsv`, and `dynamic-channels.tsv` files.
 Each `frame_meta.psv` row maps a sequence filename to its source packet, dimensions, and full-frame update geometry.
 
 The output directory must be empty by default.

--- a/crates/ironrdp-capture-replay/README.md
+++ b/crates/ironrdp-capture-replay/README.md
@@ -12,7 +12,7 @@ cargo run -p ironrdp-capture-replay --bin ironrdp-capture-replay -- capture.pcap
 ```
 
 The command succeeds only when replay produces visual framebuffer updates.
-It writes `frame_000000000000.png`-style PNG files in replay order, along with payload-free `frame_meta.psv`, `events.tsv`, `gaps.tsv`, and `dynamic-channels.tsv` files.
+It writes `frame_0000.png`-style PNG files in replay order, along with payload-free `frame_meta.psv`, `events.tsv`, `gaps.tsv`, and `dynamic-channels.tsv` files.
 Each `frame_meta.psv` row maps a sequence filename to its source packet, dimensions, and full-frame update geometry.
 
 The output directory must be empty by default.

--- a/crates/ironrdp-capture-replay/README.md
+++ b/crates/ironrdp-capture-replay/README.md
@@ -12,8 +12,8 @@ cargo run -p ironrdp-capture-replay --bin ironrdp-capture-replay -- capture.pcap
 ```
 
 The command succeeds only when replay produces visual framebuffer updates.
-It writes `frame-000000-packet-000000000012.png`-style PNG files in replay order, along with payload-free `metadata.tsv`, `events.tsv`, `gaps.tsv`, and `dynamic-channels.tsv` files.
-The packet number in each filename and diagnostic row identifies its capture provenance.
+It writes `frame-000000000000-packet-000000000012.png`-style PNG files in replay order, along with payload-free `metadata.tsv`, `events.tsv`, `gaps.tsv`, and `dynamic-channels.tsv` files.
+Each frame filename and each event or gap row includes the source packet number.
 
 The output directory must be empty by default.
 Pass `--replace` to replace an existing directory after a complete export is staged successfully.

--- a/crates/ironrdp-capture-replay/README.md
+++ b/crates/ironrdp-capture-replay/README.md
@@ -1,0 +1,22 @@
+# ironrdp-capture-replay
+
+`ironrdp-capture-replay` replays supported direct-TCP RDP captures offline and exports framebuffer snapshots without writing TLS secrets, decrypted payloads, or raw capture data.
+It is an internal analysis tool built on the replay routing pipeline.
+
+## Exporting frames
+
+Run the CLI with a pcapng capture that contains the TLS key-log material required by the replay pipeline.
+
+```shell
+cargo run -p ironrdp-capture-replay --bin ironrdp-capture-replay -- capture.pcapng replay-output
+```
+
+The command succeeds only when replay produces visual framebuffer updates.
+It writes `frame-000000-packet-000000000012.png`-style PNG files in replay order, along with payload-free `metadata.tsv`, `events.tsv`, `gaps.tsv`, and `dynamic-channels.tsv` files.
+The packet number in each filename and diagnostic row identifies its capture provenance.
+
+The output directory must be empty by default.
+Pass `--replace` to replace an existing directory after a complete export is staged successfully.
+
+The current router exports snapshots only for graphics updates it can render.
+It does not synthesize frames for routing-only captures or implement unsupported graphics codecs and channels.

--- a/crates/ironrdp-capture-replay/README.md
+++ b/crates/ironrdp-capture-replay/README.md
@@ -12,8 +12,8 @@ cargo run -p ironrdp-capture-replay --bin ironrdp-capture-replay -- capture.pcap
 ```
 
 The command succeeds only when replay produces visual framebuffer updates.
-It writes `frame-000000000000-packet-000000000012.png`-style PNG files in replay order, along with payload-free `metadata.tsv`, `events.tsv`, `gaps.tsv`, and `dynamic-channels.tsv` files.
-Each frame filename and each event or gap row includes the source packet number.
+It writes `frame_000000000000.png`-style PNG files in replay order, along with payload-free `frame_meta.psv`, `events.tsv`, `gaps.tsv`, and `dynamic-channels.tsv` files.
+Each `frame_meta.psv` row maps a sequence filename to its source packet, dimensions, and full-frame update geometry.
 
 The output directory must be empty by default.
 Pass `--replace` to replace an existing directory after a complete export is staged successfully.

--- a/crates/ironrdp-capture-replay/src/bin/ironrdp-capture-replay.rs
+++ b/crates/ironrdp-capture-replay/src/bin/ironrdp-capture-replay.rs
@@ -1,0 +1,80 @@
+#![expect(
+    unused_crate_dependencies,
+    reason = "the binary delegates replay implementation to the library crate"
+)]
+#![expect(
+    clippy::print_stdout,
+    reason = "the command reports a completed export path to its interactive caller"
+)]
+#![expect(
+    clippy::print_stderr,
+    reason = "the command reports explicit failures to its interactive caller"
+)]
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use ironrdp_capture_replay::{ExportOptions, export_replay, read_capture, replay_capture};
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("replay export failed: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<(), String> {
+    let arguments = parse_arguments(std::env::args_os().skip(1))?;
+    let capture = read_capture(&arguments.capture).map_err(|error| error.to_string())?;
+    let report = replay_capture(&capture).map_err(|error| error.to_string())?;
+    let summary = export_replay(
+        &report,
+        &ExportOptions {
+            directory: arguments.output,
+            replace: arguments.replace,
+        },
+    )
+    .map_err(|error| error.to_string())?;
+
+    println!(
+        "exported {} replay frame(s) to {}",
+        summary.frame_count,
+        summary.directory.display()
+    );
+    Ok(())
+}
+
+struct Arguments {
+    capture: PathBuf,
+    output: PathBuf,
+    replace: bool,
+}
+
+fn parse_arguments(arguments: impl Iterator<Item = OsString>) -> Result<Arguments, String> {
+    let mut replace = false;
+    let mut paths = Vec::new();
+    for argument in arguments {
+        if argument == "--replace" {
+            replace = true;
+        } else if argument.to_string_lossy().starts_with('-') {
+            return Err(usage());
+        } else {
+            paths.push(argument);
+        }
+    }
+    let [capture, output]: [OsString; 2] = paths.try_into().map_err(|_| usage())?;
+
+    Ok(Arguments {
+        capture: PathBuf::from(capture),
+        output: PathBuf::from(output),
+        replace,
+    })
+}
+
+fn usage() -> String {
+    "usage: ironrdp-capture-replay [--replace] <capture.pcapng> <output-directory>".to_owned()
+}

--- a/crates/ironrdp-capture-replay/src/bin/ironrdp-capture-replay.rs
+++ b/crates/ironrdp-capture-replay/src/bin/ironrdp-capture-replay.rs
@@ -15,7 +15,7 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-use ironrdp_capture_replay::{ExportOptions, export_replay, read_capture, replay_capture};
+use ironrdp_capture_replay::{ExportOptions, export_capture, read_capture};
 
 fn main() -> ExitCode {
     match run() {
@@ -30,9 +30,8 @@ fn main() -> ExitCode {
 fn run() -> Result<(), String> {
     let arguments = parse_arguments(std::env::args_os().skip(1))?;
     let capture = read_capture(&arguments.capture).map_err(|error| error.to_string())?;
-    let report = replay_capture(&capture).map_err(|error| error.to_string())?;
-    let summary = export_replay(
-        &report,
+    let summary = export_capture(
+        &capture,
         &ExportOptions {
             directory: arguments.output,
             replace: arguments.replace,

--- a/crates/ironrdp-capture-replay/src/lib.rs
+++ b/crates/ironrdp-capture-replay/src/lib.rs
@@ -9,10 +9,10 @@ mod transport;
 
 pub use error::ReplayError;
 pub use negotiation::{NegotiatedState, StaticChannel, recover_negotiated_state};
-pub use output::{ExportError, ExportOptions, ExportSummary, export_replay};
+pub use output::{ExportError, ExportOptions, ExportSummary, export_capture};
 pub use routing::{
-    CapturedActivation, CapturedDynamicChannel, ReplayDirection, ReplayEvent, ReplayFrame, ReplayGap, ReplayGapKind,
-    ReplayReport, ReplayRoute, ReplayRouter, replay_capture,
+    CapturedActivation, CapturedDynamicChannel, ReplayDirection, ReplayEvent, ReplayGap, ReplayGapKind, ReplayReport,
+    ReplayRoute, ReplayRouter, replay_capture,
 };
 pub use tls::{Plaintext, decrypt_tls};
 pub use transport::{Capture, Endpoint, Flow, PacketStream, TlsKeyLog, read_capture};

--- a/crates/ironrdp-capture-replay/src/lib.rs
+++ b/crates/ironrdp-capture-replay/src/lib.rs
@@ -2,15 +2,17 @@
 
 mod error;
 mod negotiation;
+mod output;
 mod routing;
 mod tls;
 mod transport;
 
 pub use error::ReplayError;
 pub use negotiation::{NegotiatedState, StaticChannel, recover_negotiated_state};
+pub use output::{ExportError, ExportOptions, ExportSummary, export_replay};
 pub use routing::{
-    CapturedActivation, CapturedDynamicChannel, ReplayDirection, ReplayEvent, ReplayGap, ReplayGapKind, ReplayReport,
-    ReplayRoute, ReplayRouter, replay_capture,
+    CapturedActivation, CapturedDynamicChannel, ReplayDirection, ReplayEvent, ReplayFrame, ReplayGap, ReplayGapKind,
+    ReplayReport, ReplayRoute, ReplayRouter, replay_capture,
 };
 pub use tls::{Plaintext, decrypt_tls};
 pub use transport::{Capture, Endpoint, Flow, PacketStream, TlsKeyLog, read_capture};

--- a/crates/ironrdp-capture-replay/src/output.rs
+++ b/crates/ironrdp-capture-replay/src/output.rs
@@ -56,8 +56,12 @@ pub enum ExportError {
     #[error("failed to finalize replay output")]
     FinalizeOutput(#[source] io::Error),
     /// An incomplete staged export could not be removed.
-    #[error("failed to clean up incomplete replay output")]
-    CleanupOutput(#[source] io::Error),
+    #[error("{original_error}; additionally failed to clean up incomplete replay output: {cleanup_error}")]
+    CleanupOutput {
+        #[source]
+        original_error: Box<ExportError>,
+        cleanup_error: io::Error,
+    },
 }
 
 /// Replay a capture and write visual frames with payload-free diagnostics.
@@ -78,7 +82,12 @@ pub fn export_capture(capture: &Capture, options: &ExportOptions) -> Result<Expo
         Ok(summary) => Ok(summary),
         Err(error) => {
             if !output.finalization_started {
-                fs::remove_dir_all(&output.directory).map_err(ExportError::CleanupOutput)?;
+                if let Err(cleanup_error) = fs::remove_dir_all(&output.directory) {
+                    return Err(ExportError::CleanupOutput {
+                        original_error: Box::new(error),
+                        cleanup_error,
+                    });
+                }
             }
             Err(error)
         }
@@ -144,10 +153,7 @@ impl StagedOutput {
 }
 
 fn validate_output_directory(directory: &Path, replace: bool) -> Result<(), ExportError> {
-    let Some(name) = directory.file_name() else {
-        return Err(ExportError::OutputPathNotLeaf);
-    };
-    if name == "." || name == ".." {
+    if directory.file_name().is_none() {
         return Err(ExportError::OutputPathNotLeaf);
     }
 

--- a/crates/ironrdp-capture-replay/src/output.rs
+++ b/crates/ironrdp-capture-replay/src/output.rs
@@ -1,0 +1,448 @@
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+
+use crate::{ReplayDirection, ReplayEvent, ReplayFrame, ReplayGap, ReplayGapKind, ReplayReport, ReplayRoute};
+
+/// Options that control replay artifact export.
+#[derive(Clone, Debug)]
+pub struct ExportOptions {
+    /// Directory that receives the completed export.
+    pub directory: PathBuf,
+    /// Replace an existing non-empty output directory.
+    pub replace: bool,
+}
+
+/// Completed replay export metadata.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExportSummary {
+    /// Directory containing the completed export.
+    pub directory: PathBuf,
+    /// Number of framebuffer PNG files written.
+    pub frame_count: usize,
+}
+
+/// Errors that prevent a replay export from completing.
+#[derive(Debug, Error)]
+pub enum ExportError {
+    /// The routed capture had no visual updates to export.
+    #[error("replay did not produce any visual frames")]
+    NoVisualFrames,
+    /// The selected output path cannot contain the export.
+    #[error("replay output path is not a directory")]
+    OutputPathNotDirectory,
+    /// Replacing output was not explicitly approved.
+    #[error("replay output directory is not empty; use --replace to replace it")]
+    OutputDirectoryNotEmpty,
+    /// A routed frame is not a complete RGBA framebuffer.
+    #[error("replay frame {frame} has invalid RGBA pixel data")]
+    InvalidFrame {
+        /// Index of the invalid frame in replay order.
+        frame: usize,
+    },
+    /// Frame order would not preserve capture provenance.
+    #[error("replay frame {current} follows packet {previous} out of capture order")]
+    FrameOutOfOrder {
+        /// Packet number of the preceding frame.
+        previous: usize,
+        /// Packet number of the out-of-order frame.
+        current: usize,
+    },
+    /// A filesystem operation failed before output was completed.
+    #[error("failed to prepare replay output")]
+    PrepareOutput(#[source] io::Error),
+    /// A filesystem operation failed while producing staged output.
+    #[error("failed to write replay output")]
+    WriteOutput(#[source] io::Error),
+    /// PNG encoding failed.
+    #[error("failed to encode replay frame")]
+    EncodePng(#[source] png::EncodingError),
+    /// The fully staged output could not replace the destination.
+    #[error("failed to finalize replay output")]
+    FinalizeOutput(#[source] io::Error),
+    /// An incomplete staged export could not be removed.
+    #[error("failed to clean up incomplete replay output")]
+    CleanupOutput(#[source] io::Error),
+}
+
+/// Write visual replay frames and payload-free diagnostics into one output directory.
+///
+/// The destination receives nothing unless all PNGs and tabular files were written successfully.
+pub fn export_replay(report: &ReplayReport, options: &ExportOptions) -> Result<ExportSummary, ExportError> {
+    validate_frames(&report.frames)?;
+    validate_output_directory(&options.directory, options.replace)?;
+
+    let parent = output_parent(&options.directory);
+    fs::create_dir_all(parent).map_err(ExportError::PrepareOutput)?;
+    let staging = create_staging_directory(parent, &options.directory)?;
+
+    let result = write_export(&staging, report).and_then(|()| replace_output_directory(&staging, &options.directory));
+    if let Err(error) = result {
+        fs::remove_dir_all(&staging).map_err(ExportError::CleanupOutput)?;
+        return Err(error);
+    }
+
+    Ok(ExportSummary {
+        directory: options.directory.clone(),
+        frame_count: report.frames.len(),
+    })
+}
+
+fn validate_frames(frames: &[ReplayFrame]) -> Result<(), ExportError> {
+    if frames.is_empty() {
+        return Err(ExportError::NoVisualFrames);
+    }
+
+    let mut previous_packet = None;
+    for (index, frame) in frames.iter().enumerate() {
+        if let Some(previous) = previous_packet
+            && frame.packet < previous
+        {
+            return Err(ExportError::FrameOutOfOrder {
+                previous,
+                current: frame.packet,
+            });
+        }
+        previous_packet = Some(frame.packet);
+
+        let expected_len = usize::from(frame.width)
+            .checked_mul(usize::from(frame.height))
+            .and_then(|pixels| pixels.checked_mul(4 /* RGBA */));
+        if frame.width == 0 || frame.height == 0 || expected_len != Some(frame.pixels.len()) {
+            return Err(ExportError::InvalidFrame { frame: index + 1 });
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_output_directory(directory: &Path, replace: bool) -> Result<(), ExportError> {
+    match fs::symlink_metadata(directory) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            Err(ExportError::OutputPathNotDirectory)
+        }
+        Ok(_) => {
+            let is_empty = fs::read_dir(directory)
+                .map_err(ExportError::PrepareOutput)?
+                .next()
+                .transpose()
+                .map_err(ExportError::PrepareOutput)?
+                .is_none();
+            if is_empty || replace {
+                Ok(())
+            } else {
+                Err(ExportError::OutputDirectoryNotEmpty)
+            }
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(ExportError::PrepareOutput(error)),
+    }
+}
+
+fn output_parent(directory: &Path) -> &Path {
+    directory
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+}
+
+fn create_staging_directory(parent: &Path, directory: &Path) -> Result<PathBuf, ExportError> {
+    let stem = directory
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("replay-output");
+    for attempt in 0..1_000 {
+        let staging = parent.join(format!(".{stem}.staging-{}-{attempt}", std::process::id()));
+        match fs::create_dir(&staging) {
+            Ok(()) => return Ok(staging),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+            Err(error) => return Err(ExportError::PrepareOutput(error)),
+        }
+    }
+
+    Err(ExportError::PrepareOutput(io::Error::new(
+        io::ErrorKind::AlreadyExists,
+        "could not allocate replay output staging directory",
+    )))
+}
+
+fn write_export(directory: &Path, report: &ReplayReport) -> Result<(), ExportError> {
+    for (index, frame) in report.frames.iter().enumerate() {
+        let name = format!("frame-{index:06}-packet-{:012}.png", frame.packet);
+        let png = encode_png(frame)?;
+        fs::write(directory.join(name), png).map_err(ExportError::WriteOutput)?;
+    }
+
+    fs::write(directory.join("metadata.tsv"), metadata_tsv(report)).map_err(ExportError::WriteOutput)?;
+    fs::write(directory.join("events.tsv"), events_tsv(&report.events)).map_err(ExportError::WriteOutput)?;
+    fs::write(directory.join("gaps.tsv"), gaps_tsv(&report.gaps)).map_err(ExportError::WriteOutput)?;
+    fs::write(directory.join("dynamic-channels.tsv"), dynamic_channels_tsv(report))
+        .map_err(ExportError::WriteOutput)?;
+    Ok(())
+}
+
+fn replace_output_directory(staging: &Path, directory: &Path) -> Result<(), ExportError> {
+    match fs::symlink_metadata(directory) {
+        Ok(_) => fs::remove_dir_all(directory).map_err(ExportError::FinalizeOutput)?,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(ExportError::FinalizeOutput(error)),
+    }
+    fs::rename(staging, directory).map_err(ExportError::FinalizeOutput)
+}
+
+fn encode_png(frame: &ReplayFrame) -> Result<Vec<u8>, ExportError> {
+    let mut png = Vec::new();
+    let mut encoder = png::Encoder::new(&mut png, u32::from(frame.width), u32::from(frame.height));
+    encoder.set_color(png::ColorType::Rgba);
+    encoder.set_depth(png::BitDepth::Eight);
+    let mut writer = encoder.write_header().map_err(ExportError::EncodePng)?;
+    writer.write_image_data(&frame.pixels).map_err(ExportError::EncodePng)?;
+    writer.finish().map_err(ExportError::EncodePng)?;
+    Ok(png)
+}
+
+fn metadata_tsv(report: &ReplayReport) -> String {
+    format!(
+        "field\tvalue\nformat-version\t1\nframes\t{}\nevents\t{}\ngaps\t{}\ndynamic-channels\t{}\n",
+        report.frames.len(),
+        report.events.len(),
+        report.gaps.len(),
+        report.dynamic_channels.len(),
+    )
+}
+
+fn events_tsv(events: &[ReplayEvent]) -> String {
+    let mut output = String::from("order\tpacket\tdirection\taction\troute\n");
+    for (index, event) in events.iter().enumerate() {
+        output.push_str(&format!(
+            "{}\t{}\t{}\t{:?}\t{}\n",
+            index + 1,
+            event.packet,
+            direction_name(event.direction),
+            event.action,
+            route_name(event.route),
+        ));
+    }
+    output
+}
+
+fn gaps_tsv(gaps: &[ReplayGap]) -> String {
+    let mut output = String::from("packet\tdirection\tkind\tskipped-bytes\n");
+    for gap in gaps {
+        output.push_str(&format!(
+            "{}\t{}\t{}\t{}\n",
+            gap.packet,
+            direction_name(gap.direction),
+            gap_kind_name(gap.kind),
+            gap.skipped_bytes,
+        ));
+    }
+    output
+}
+
+fn dynamic_channels_tsv(report: &ReplayReport) -> String {
+    let mut output = String::from("id\n");
+    for channel in &report.dynamic_channels {
+        output.push_str(&format!("{}\n", channel.id));
+    }
+    output
+}
+
+fn direction_name(direction: ReplayDirection) -> &'static str {
+    match direction {
+        ReplayDirection::Client => "client",
+        ReplayDirection::Server => "server",
+    }
+}
+
+fn route_name(route: ReplayRoute) -> &'static str {
+    match route {
+        ReplayRoute::Connection => "connection",
+        ReplayRoute::ClientObservation => "client-observation",
+        ReplayRoute::FastPath => "fast-path",
+        ReplayRoute::IoChannel => "io-channel",
+        ReplayRoute::MessageChannel => "message-channel",
+        ReplayRoute::StaticChannel => "static-channel",
+        ReplayRoute::OtherServerMessage => "other-server-message",
+    }
+}
+
+fn gap_kind_name(kind: ReplayGapKind) -> &'static str {
+    match kind {
+        ReplayGapKind::Framing => "framing",
+        ReplayGapKind::TruncatedPdu => "truncated-pdu",
+        ReplayGapKind::StaticChannel => "static-channel",
+        ReplayGapKind::DynamicChannel => "dynamic-channel",
+        ReplayGapKind::Session => "session",
+        ReplayGapKind::IncompleteActivation => "incomplete-activation",
+        ReplayGapKind::Unsupported => "unsupported",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::sync::atomic::{AtomicUsize, Ordering};
+
+    use ironrdp_pdu::Action;
+
+    use super::*;
+    use crate::CapturedDynamicChannel;
+
+    static NEXT_DIRECTORY: AtomicUsize = AtomicUsize::new(0);
+
+    #[test]
+    fn writes_ordered_pngs_and_safe_diagnostics() {
+        let directory = temporary_directory("ordered");
+        let report = report_with_frames();
+
+        let summary = export_replay(
+            &report,
+            &ExportOptions {
+                directory: directory.clone(),
+                replace: false,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(summary.frame_count, 2);
+        let first = directory.join("frame-000000-packet-000000000012.png");
+        let second = directory.join("frame-000001-packet-000000000047.png");
+        assert!(first.is_file());
+        assert!(second.is_file());
+        assert_png_rgba(&first, [0x11, 0x22, 0x33, 0xff]);
+        assert_png_rgba(&second, [0x44, 0x55, 0x66, 0xff]);
+
+        let diagnostics = fs::read_to_string(directory.join("events.tsv")).unwrap();
+        let metadata = fs::read_to_string(directory.join("metadata.tsv")).unwrap();
+        let channels = fs::read_to_string(directory.join("dynamic-channels.tsv")).unwrap();
+        assert!(diagnostics.contains("1\t12\tserver\tFastPath\tfast-path"));
+        assert!(metadata.contains("frames\t2"));
+        assert_eq!(channels, "id\n7\n");
+        for text in [diagnostics, metadata, channels] {
+            assert!(!text.contains("CLIENT_RANDOM"));
+            assert!(!text.contains("decrypted payload"));
+        }
+
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn refuses_non_empty_output_without_replace() {
+        let directory = temporary_directory("refuse");
+        fs::create_dir(&directory).unwrap();
+        fs::write(directory.join("keep"), "existing").unwrap();
+
+        let error = export_replay(
+            &report_with_frames(),
+            &ExportOptions {
+                directory: directory.clone(),
+                replace: false,
+            },
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, ExportError::OutputDirectoryNotEmpty));
+        assert_eq!(fs::read_to_string(directory.join("keep")).unwrap(), "existing");
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn replacement_removes_existing_contents_after_staging() {
+        let directory = temporary_directory("replace");
+        fs::create_dir(&directory).unwrap();
+        fs::write(directory.join("stale"), "existing").unwrap();
+
+        export_replay(
+            &report_with_frames(),
+            &ExportOptions {
+                directory: directory.clone(),
+                replace: true,
+            },
+        )
+        .unwrap();
+
+        assert!(!directory.join("stale").exists());
+        assert!(directory.join("metadata.tsv").is_file());
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn refuses_reports_without_visual_frames() {
+        let directory = temporary_directory("no-frames");
+        let error = export_replay(
+            &ReplayReport::default(),
+            &ExportOptions {
+                directory: directory.clone(),
+                replace: false,
+            },
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, ExportError::NoVisualFrames));
+        assert!(!directory.exists());
+    }
+
+    fn report_with_frames() -> ReplayReport {
+        ReplayReport {
+            events: vec![
+                ReplayEvent {
+                    packet: 12,
+                    direction: ReplayDirection::Server,
+                    action: Action::FastPath,
+                    route: ReplayRoute::FastPath,
+                },
+                ReplayEvent {
+                    packet: 47,
+                    direction: ReplayDirection::Server,
+                    action: Action::X224,
+                    route: ReplayRoute::IoChannel,
+                },
+            ],
+            frames: vec![
+                ReplayFrame {
+                    packet: 12,
+                    width: 1,
+                    height: 1,
+                    pixels: vec![0x11, 0x22, 0x33, 0xff],
+                },
+                ReplayFrame {
+                    packet: 47,
+                    width: 1,
+                    height: 1,
+                    pixels: vec![0x44, 0x55, 0x66, 0xff],
+                },
+            ],
+            gaps: vec![ReplayGap {
+                packet: 20,
+                direction: ReplayDirection::Server,
+                kind: ReplayGapKind::Framing,
+                skipped_bytes: 3,
+            }],
+            dynamic_channels: vec![CapturedDynamicChannel {
+                id: 7,
+                name: "CLIENT_RANDOM decrypted payload".to_owned(),
+            }],
+        }
+    }
+
+    fn assert_png_rgba(path: &Path, expected: [u8; 4]) {
+        let input = fs::File::open(path).unwrap();
+        let decoder = png::Decoder::new(io::BufReader::new(input));
+        let mut reader = decoder.read_info().unwrap();
+        let mut pixels = vec![0; reader.output_buffer_size().unwrap()];
+        let info = reader.next_frame(&mut pixels).unwrap();
+
+        assert_eq!((info.width, info.height), (1, 1));
+        assert_eq!(&pixels[..info.buffer_size()], expected);
+    }
+
+    fn temporary_directory(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "ironrdp-capture-replay-{name}-{}-{}",
+            std::process::id(),
+            NEXT_DIRECTORY.fetch_add(1, Ordering::Relaxed),
+        ))
+    }
+}

--- a/crates/ironrdp-capture-replay/src/output.rs
+++ b/crates/ironrdp-capture-replay/src/output.rs
@@ -4,7 +4,8 @@ use std::path::{Path, PathBuf};
 
 use thiserror::Error;
 
-use crate::{ReplayDirection, ReplayEvent, ReplayFrame, ReplayGap, ReplayGapKind, ReplayReport, ReplayRoute};
+use crate::routing::{ReplayFrame, prepare_replay_capture};
+use crate::{Capture, ReplayDirection, ReplayError, ReplayEvent, ReplayGap, ReplayGapKind, ReplayReport, ReplayRoute};
 
 /// Options that control replay artifact export.
 #[derive(Clone, Debug)]
@@ -33,23 +34,15 @@ pub enum ExportError {
     /// The selected output path cannot contain the export.
     #[error("replay output path is not a directory")]
     OutputPathNotDirectory,
+    /// The selected output path does not name a replaceable directory.
+    #[error("replay output path must name a directory")]
+    OutputPathNotLeaf,
     /// Replacing output was not explicitly approved.
     #[error("replay output directory is not empty; use --replace to replace it")]
     OutputDirectoryNotEmpty,
-    /// A routed frame is not a complete RGBA framebuffer.
-    #[error("replay frame {frame} has invalid RGBA pixel data")]
-    InvalidFrame {
-        /// Index of the invalid frame in replay order.
-        frame: usize,
-    },
-    /// Frame order would not preserve capture provenance.
-    #[error("replay frame {current} follows packet {previous} out of capture order")]
-    FrameOutOfOrder {
-        /// Packet number of the preceding frame.
-        previous: usize,
-        /// Packet number of the out-of-order frame.
-        current: usize,
-    },
+    /// The captured replay could not be prepared.
+    #[error("failed to replay capture")]
+    Replay(#[source] ReplayError),
     /// A filesystem operation failed before output was completed.
     #[error("failed to prepare replay output")]
     PrepareOutput(#[source] io::Error),
@@ -67,92 +60,116 @@ pub enum ExportError {
     CleanupOutput(#[source] io::Error),
 }
 
-/// Write visual replay frames and payload-free diagnostics into one output directory.
+/// Replay a capture and write visual frames with payload-free diagnostics.
 ///
-/// The destination receives nothing unless all PNGs and tabular files were written successfully.
-pub fn export_replay(report: &ReplayReport, options: &ExportOptions) -> Result<ExportSummary, ExportError> {
-    validate_frames(&report.frames)?;
+/// The destination receives nothing unless every PNG and tabular file was written successfully.
+pub fn export_capture(capture: &Capture, options: &ExportOptions) -> Result<ExportSummary, ExportError> {
+    let (mut router, plaintext) = prepare_replay_capture(capture).map_err(ExportError::Replay)?;
     validate_output_directory(&options.directory, options.replace)?;
 
     let parent = output_parent(&options.directory);
     fs::create_dir_all(parent).map_err(ExportError::PrepareOutput)?;
     let staging = create_staging_directory(parent, &options.directory)?;
-
-    let result = write_export(&staging, report).and_then(|()| replace_output_directory(&staging, &options.directory));
-    if let Err(error) = result {
-        fs::remove_dir_all(&staging).map_err(ExportError::CleanupOutput)?;
-        return Err(error);
+    let mut output = StagedOutput::new(staging);
+    let result = router
+        .route_plaintext_with_frame_sink(&plaintext, &mut |frame| output.write_frame(frame))
+        .and_then(|report| finalize_staged_output(&output, &report, options));
+    match result {
+        Ok(summary) => Ok(summary),
+        Err(error) => {
+            fs::remove_dir_all(&output.directory).map_err(ExportError::CleanupOutput)?;
+            Err(error)
+        }
     }
+}
 
+fn finalize_staged_output(
+    output: &StagedOutput,
+    report: &ReplayReport,
+    options: &ExportOptions,
+) -> Result<ExportSummary, ExportError> {
+    if output.frame_count == 0 {
+        return Err(ExportError::NoVisualFrames);
+    }
+    output.write_diagnostics(report)?;
+    replace_output_directory(&output.directory, &options.directory, options.replace)?;
     Ok(ExportSummary {
         directory: options.directory.clone(),
-        frame_count: report.frames.len(),
+        frame_count: output.frame_count,
     })
 }
 
-fn validate_frames(frames: &[ReplayFrame]) -> Result<(), ExportError> {
-    if frames.is_empty() {
-        return Err(ExportError::NoVisualFrames);
-    }
+struct StagedOutput {
+    directory: PathBuf,
+    frame_count: usize,
+}
 
-    let mut previous_packet = None;
-    for (index, frame) in frames.iter().enumerate() {
-        if let Some(previous) = previous_packet
-            && frame.packet < previous
-        {
-            return Err(ExportError::FrameOutOfOrder {
-                previous,
-                current: frame.packet,
-            });
-        }
-        previous_packet = Some(frame.packet);
-
-        let expected_len = usize::from(frame.width)
-            .checked_mul(usize::from(frame.height))
-            .and_then(|pixels| pixels.checked_mul(4 /* RGBA */));
-        if frame.width == 0 || frame.height == 0 || expected_len != Some(frame.pixels.len()) {
-            return Err(ExportError::InvalidFrame { frame: index + 1 });
+impl StagedOutput {
+    fn new(directory: PathBuf) -> Self {
+        Self {
+            directory,
+            frame_count: 0,
         }
     }
 
-    Ok(())
+    fn write_frame(&mut self, frame: ReplayFrame) -> Result<(), ExportError> {
+        let name = format!("frame-{:012}-packet-{:012}.png", self.frame_count, frame.packet);
+        encode_png(&self.directory.join(name), &frame)?;
+        self.frame_count += 1;
+        Ok(())
+    }
+
+    fn write_diagnostics(&self, report: &ReplayReport) -> Result<(), ExportError> {
+        fs::write(
+            self.directory.join("metadata.tsv"),
+            metadata_tsv(report, self.frame_count),
+        )
+        .map_err(ExportError::WriteOutput)?;
+        fs::write(self.directory.join("events.tsv"), events_tsv(&report.events)).map_err(ExportError::WriteOutput)?;
+        fs::write(self.directory.join("gaps.tsv"), gaps_tsv(&report.gaps)).map_err(ExportError::WriteOutput)?;
+        fs::write(
+            self.directory.join("dynamic-channels.tsv"),
+            dynamic_channels_tsv(report),
+        )
+        .map_err(ExportError::WriteOutput)?;
+        Ok(())
+    }
 }
 
 fn validate_output_directory(directory: &Path, replace: bool) -> Result<(), ExportError> {
+    let Some(name) = directory.file_name() else {
+        return Err(ExportError::OutputPathNotLeaf);
+    };
+    if name == "." || name == ".." {
+        return Err(ExportError::OutputPathNotLeaf);
+    }
+
     match fs::symlink_metadata(directory) {
         Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
             Err(ExportError::OutputPathNotDirectory)
         }
-        Ok(_) => {
-            let is_empty = fs::read_dir(directory)
-                .map_err(ExportError::PrepareOutput)?
-                .next()
-                .transpose()
-                .map_err(ExportError::PrepareOutput)?
-                .is_none();
-            if is_empty || replace {
-                Ok(())
-            } else {
-                Err(ExportError::OutputDirectoryNotEmpty)
-            }
+        Ok(_) if !replace && !directory_is_empty(directory).map_err(ExportError::PrepareOutput)? => {
+            Err(ExportError::OutputDirectoryNotEmpty)
         }
+        Ok(_) => Ok(()),
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
         Err(error) => Err(ExportError::PrepareOutput(error)),
     }
 }
 
+fn directory_is_empty(directory: &Path) -> io::Result<bool> {
+    Ok(fs::read_dir(directory)?.next().transpose()?.is_none())
+}
+
 fn output_parent(directory: &Path) -> &Path {
-    directory
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-        .unwrap_or_else(|| Path::new("."))
+    directory.parent().unwrap_or_else(|| Path::new("."))
 }
 
 fn create_staging_directory(parent: &Path, directory: &Path) -> Result<PathBuf, ExportError> {
     let stem = directory
         .file_name()
         .and_then(|name| name.to_str())
-        .unwrap_or("replay-output");
+        .ok_or(ExportError::OutputPathNotLeaf)?;
     for attempt in 0..1_000 {
         let staging = parent.join(format!(".{stem}.staging-{}-{attempt}", std::process::id()));
         match fs::create_dir(&staging) {
@@ -168,45 +185,36 @@ fn create_staging_directory(parent: &Path, directory: &Path) -> Result<PathBuf, 
     )))
 }
 
-fn write_export(directory: &Path, report: &ReplayReport) -> Result<(), ExportError> {
-    for (index, frame) in report.frames.iter().enumerate() {
-        let name = format!("frame-{index:06}-packet-{:012}.png", frame.packet);
-        let png = encode_png(frame)?;
-        fs::write(directory.join(name), png).map_err(ExportError::WriteOutput)?;
-    }
-
-    fs::write(directory.join("metadata.tsv"), metadata_tsv(report)).map_err(ExportError::WriteOutput)?;
-    fs::write(directory.join("events.tsv"), events_tsv(&report.events)).map_err(ExportError::WriteOutput)?;
-    fs::write(directory.join("gaps.tsv"), gaps_tsv(&report.gaps)).map_err(ExportError::WriteOutput)?;
-    fs::write(directory.join("dynamic-channels.tsv"), dynamic_channels_tsv(report))
-        .map_err(ExportError::WriteOutput)?;
-    Ok(())
-}
-
-fn replace_output_directory(staging: &Path, directory: &Path) -> Result<(), ExportError> {
+fn replace_output_directory(staging: &Path, directory: &Path, replace: bool) -> Result<(), ExportError> {
     match fs::symlink_metadata(directory) {
-        Ok(_) => fs::remove_dir_all(directory).map_err(ExportError::FinalizeOutput)?,
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            return Err(ExportError::OutputPathNotDirectory);
+        }
+        Ok(_) if replace => fs::remove_dir_all(directory).map_err(ExportError::FinalizeOutput)?,
+        Ok(_) if directory_is_empty(directory).map_err(ExportError::FinalizeOutput)? => {
+            fs::remove_dir(directory).map_err(ExportError::FinalizeOutput)?;
+        }
+        Ok(_) => return Err(ExportError::OutputDirectoryNotEmpty),
         Err(error) if error.kind() == io::ErrorKind::NotFound => {}
         Err(error) => return Err(ExportError::FinalizeOutput(error)),
     }
     fs::rename(staging, directory).map_err(ExportError::FinalizeOutput)
 }
 
-fn encode_png(frame: &ReplayFrame) -> Result<Vec<u8>, ExportError> {
-    let mut png = Vec::new();
-    let mut encoder = png::Encoder::new(&mut png, u32::from(frame.width), u32::from(frame.height));
+fn encode_png(path: &Path, frame: &ReplayFrame) -> Result<(), ExportError> {
+    let file = fs::File::create(path).map_err(ExportError::WriteOutput)?;
+    let mut encoder = png::Encoder::new(file, u32::from(frame.width), u32::from(frame.height));
     encoder.set_color(png::ColorType::Rgba);
     encoder.set_depth(png::BitDepth::Eight);
     let mut writer = encoder.write_header().map_err(ExportError::EncodePng)?;
     writer.write_image_data(&frame.pixels).map_err(ExportError::EncodePng)?;
     writer.finish().map_err(ExportError::EncodePng)?;
-    Ok(png)
+    Ok(())
 }
 
-fn metadata_tsv(report: &ReplayReport) -> String {
+fn metadata_tsv(report: &ReplayReport, frame_count: usize) -> String {
     format!(
-        "field\tvalue\nformat-version\t1\nframes\t{}\nevents\t{}\ngaps\t{}\ndynamic-channels\t{}\n",
-        report.frames.len(),
+        "field\tvalue\nformat-version\t1\nframes\t{frame_count}\nevents\t{}\ngaps\t{}\ndynamic-channels\t{}\n",
         report.events.len(),
         report.gaps.len(),
         report.dynamic_channels.len(),
@@ -295,25 +303,22 @@ mod tests {
     #[test]
     fn writes_ordered_pngs_and_safe_diagnostics() {
         let directory = temporary_directory("ordered");
-        let report = report_with_frames();
+        let staging = create_staging_directory(directory.parent().unwrap(), &directory).unwrap();
+        let mut output = StagedOutput::new(staging.clone());
+        let report = report();
+        output.write_frame(frame(12, [0x11, 0x22, 0x33, 0xff])).unwrap();
+        output.write_frame(frame(47, [0x44, 0x55, 0x66, 0xff])).unwrap();
+        output.write_diagnostics(&report).unwrap();
+        replace_output_directory(&staging, &directory, false).unwrap();
 
-        let summary = export_replay(
-            &report,
-            &ExportOptions {
-                directory: directory.clone(),
-                replace: false,
-            },
-        )
-        .unwrap();
-
-        assert_eq!(summary.frame_count, 2);
-        let first = directory.join("frame-000000-packet-000000000012.png");
-        let second = directory.join("frame-000001-packet-000000000047.png");
-        assert!(first.is_file());
-        assert!(second.is_file());
-        assert_png_rgba(&first, [0x11, 0x22, 0x33, 0xff]);
-        assert_png_rgba(&second, [0x44, 0x55, 0x66, 0xff]);
-
+        assert_png_rgba(
+            &directory.join("frame-000000000000-packet-000000000012.png"),
+            [0x11, 0x22, 0x33, 0xff],
+        );
+        assert_png_rgba(
+            &directory.join("frame-000000000001-packet-000000000047.png"),
+            [0x44, 0x55, 0x66, 0xff],
+        );
         let diagnostics = fs::read_to_string(directory.join("events.tsv")).unwrap();
         let metadata = fs::read_to_string(directory.join("metadata.tsv")).unwrap();
         let channels = fs::read_to_string(directory.join("dynamic-channels.tsv")).unwrap();
@@ -334,14 +339,7 @@ mod tests {
         fs::create_dir(&directory).unwrap();
         fs::write(directory.join("keep"), "existing").unwrap();
 
-        let error = export_replay(
-            &report_with_frames(),
-            &ExportOptions {
-                directory: directory.clone(),
-                replace: false,
-            },
-        )
-        .unwrap_err();
+        let error = validate_output_directory(&directory, false).unwrap_err();
 
         assert!(matches!(error, ExportError::OutputDirectoryNotEmpty));
         assert_eq!(fs::read_to_string(directory.join("keep")).unwrap(), "existing");
@@ -349,13 +347,39 @@ mod tests {
     }
 
     #[test]
-    fn replacement_removes_existing_contents_after_staging() {
+    fn rejects_non_leaf_output_paths() {
+        let error = validate_output_directory(Path::new("."), false).unwrap_err();
+
+        assert!(matches!(error, ExportError::OutputPathNotLeaf));
+    }
+
+    #[test]
+    fn does_not_replace_new_contents_without_replace() {
+        let directory = temporary_directory("race");
+        fs::create_dir(&directory).unwrap();
+        let staging = create_staging_directory(directory.parent().unwrap(), &directory).unwrap();
+        fs::write(directory.join("keep"), "new").unwrap();
+
+        let error = replace_output_directory(&staging, &directory, false).unwrap_err();
+
+        assert!(matches!(error, ExportError::OutputDirectoryNotEmpty));
+        assert_eq!(fs::read_to_string(directory.join("keep")).unwrap(), "new");
+        fs::remove_dir_all(staging).unwrap();
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn replaces_non_empty_output_after_staging() {
         let directory = temporary_directory("replace");
         fs::create_dir(&directory).unwrap();
-        fs::write(directory.join("stale"), "existing").unwrap();
+        fs::write(directory.join("keep"), "old").unwrap();
+        let staging = create_staging_directory(directory.parent().unwrap(), &directory).unwrap();
+        let mut output = StagedOutput::new(staging);
+        output.write_frame(frame(12, [0x11, 0x22, 0x33, 0xff])).unwrap();
 
-        export_replay(
-            &report_with_frames(),
+        let summary = finalize_staged_output(
+            &output,
+            &report(),
             &ExportOptions {
                 directory: directory.clone(),
                 replace: true,
@@ -363,16 +387,21 @@ mod tests {
         )
         .unwrap();
 
-        assert!(!directory.join("stale").exists());
-        assert!(directory.join("metadata.tsv").is_file());
+        assert_eq!(summary.frame_count, 1);
+        assert!(!directory.join("keep").exists());
+        assert!(directory.join("frame-000000000000-packet-000000000012.png").exists());
         fs::remove_dir_all(directory).unwrap();
     }
 
     #[test]
-    fn refuses_reports_without_visual_frames() {
+    fn refuses_to_finalize_without_visual_frames() {
         let directory = temporary_directory("no-frames");
-        let error = export_replay(
-            &ReplayReport::default(),
+        let staging = create_staging_directory(directory.parent().unwrap(), &directory).unwrap();
+        let output = StagedOutput::new(staging.clone());
+
+        let error = finalize_staged_output(
+            &output,
+            &report(),
             &ExportOptions {
                 directory: directory.clone(),
                 replace: false,
@@ -382,38 +411,17 @@ mod tests {
 
         assert!(matches!(error, ExportError::NoVisualFrames));
         assert!(!directory.exists());
+        fs::remove_dir_all(staging).unwrap();
     }
 
-    fn report_with_frames() -> ReplayReport {
+    fn report() -> ReplayReport {
         ReplayReport {
-            events: vec![
-                ReplayEvent {
-                    packet: 12,
-                    direction: ReplayDirection::Server,
-                    action: Action::FastPath,
-                    route: ReplayRoute::FastPath,
-                },
-                ReplayEvent {
-                    packet: 47,
-                    direction: ReplayDirection::Server,
-                    action: Action::X224,
-                    route: ReplayRoute::IoChannel,
-                },
-            ],
-            frames: vec![
-                ReplayFrame {
-                    packet: 12,
-                    width: 1,
-                    height: 1,
-                    pixels: vec![0x11, 0x22, 0x33, 0xff],
-                },
-                ReplayFrame {
-                    packet: 47,
-                    width: 1,
-                    height: 1,
-                    pixels: vec![0x44, 0x55, 0x66, 0xff],
-                },
-            ],
+            events: vec![ReplayEvent {
+                packet: 12,
+                direction: ReplayDirection::Server,
+                action: Action::FastPath,
+                route: ReplayRoute::FastPath,
+            }],
             gaps: vec![ReplayGap {
                 packet: 20,
                 direction: ReplayDirection::Server,
@@ -424,6 +432,15 @@ mod tests {
                 id: 7,
                 name: "CLIENT_RANDOM decrypted payload".to_owned(),
             }],
+        }
+    }
+
+    fn frame(packet: usize, pixels: [u8; 4]) -> ReplayFrame {
+        ReplayFrame {
+            packet,
+            width: 1,
+            height: 1,
+            pixels: pixels.to_vec(),
         }
     }
 

--- a/crates/ironrdp-capture-replay/src/output.rs
+++ b/crates/ironrdp-capture-replay/src/output.rs
@@ -102,6 +102,7 @@ fn finalize_staged_output(
 struct StagedOutput {
     directory: PathBuf,
     frame_count: usize,
+    frame_metadata: String,
 }
 
 impl StagedOutput {
@@ -109,22 +110,23 @@ impl StagedOutput {
         Self {
             directory,
             frame_count: 0,
+            frame_metadata: String::from("FrameIndex|FramePacket|FrameSize|FrameFile|UpdatePos|UpdateSize\n"),
         }
     }
 
     fn write_frame(&mut self, frame: ReplayFrame) -> Result<(), ExportError> {
-        let name = format!("frame-{:012}-packet-{:012}.png", self.frame_count, frame.packet);
+        let name = format!("frame_{:012}.png", self.frame_count);
         encode_png(&self.directory.join(name), &frame)?;
+        self.frame_metadata.push_str(&format!(
+            "{}|{}|{}x{}|frame_{:012}.png|0x0|{}x{}\n",
+            self.frame_count, frame.packet, frame.width, frame.height, self.frame_count, frame.width, frame.height,
+        ));
         self.frame_count += 1;
         Ok(())
     }
 
     fn write_diagnostics(&self, report: &ReplayReport) -> Result<(), ExportError> {
-        fs::write(
-            self.directory.join("metadata.tsv"),
-            metadata_tsv(report, self.frame_count),
-        )
-        .map_err(ExportError::WriteOutput)?;
+        fs::write(self.directory.join("frame_meta.psv"), &self.frame_metadata).map_err(ExportError::WriteOutput)?;
         fs::write(self.directory.join("events.tsv"), events_tsv(&report.events)).map_err(ExportError::WriteOutput)?;
         fs::write(self.directory.join("gaps.tsv"), gaps_tsv(&report.gaps)).map_err(ExportError::WriteOutput)?;
         fs::write(
@@ -210,15 +212,6 @@ fn encode_png(path: &Path, frame: &ReplayFrame) -> Result<(), ExportError> {
     writer.write_image_data(&frame.pixels).map_err(ExportError::EncodePng)?;
     writer.finish().map_err(ExportError::EncodePng)?;
     Ok(())
-}
-
-fn metadata_tsv(report: &ReplayReport, frame_count: usize) -> String {
-    format!(
-        "field\tvalue\nformat-version\t1\nframes\t{frame_count}\nevents\t{}\ngaps\t{}\ndynamic-channels\t{}\n",
-        report.events.len(),
-        report.gaps.len(),
-        report.dynamic_channels.len(),
-    )
 }
 
 fn events_tsv(events: &[ReplayEvent]) -> String {
@@ -311,19 +304,18 @@ mod tests {
         output.write_diagnostics(&report).unwrap();
         replace_output_directory(&staging, &directory, false).unwrap();
 
-        assert_png_rgba(
-            &directory.join("frame-000000000000-packet-000000000012.png"),
-            [0x11, 0x22, 0x33, 0xff],
-        );
-        assert_png_rgba(
-            &directory.join("frame-000000000001-packet-000000000047.png"),
-            [0x44, 0x55, 0x66, 0xff],
-        );
+        assert_png_rgba(&directory.join("frame_000000000000.png"), [0x11, 0x22, 0x33, 0xff]);
+        assert_png_rgba(&directory.join("frame_000000000001.png"), [0x44, 0x55, 0x66, 0xff]);
         let diagnostics = fs::read_to_string(directory.join("events.tsv")).unwrap();
-        let metadata = fs::read_to_string(directory.join("metadata.tsv")).unwrap();
+        let metadata = fs::read_to_string(directory.join("frame_meta.psv")).unwrap();
         let channels = fs::read_to_string(directory.join("dynamic-channels.tsv")).unwrap();
         assert!(diagnostics.contains("1\t12\tserver\tFastPath\tfast-path"));
-        assert!(metadata.contains("frames\t2"));
+        assert_eq!(
+            metadata,
+            "FrameIndex|FramePacket|FrameSize|FrameFile|UpdatePos|UpdateSize\n\
+             0|12|1x1|frame_000000000000.png|0x0|1x1\n\
+             1|47|1x1|frame_000000000001.png|0x0|1x1\n"
+        );
         assert_eq!(channels, "id\n7\n");
         for text in [diagnostics, metadata, channels] {
             assert!(!text.contains("CLIENT_RANDOM"));
@@ -389,7 +381,7 @@ mod tests {
 
         assert_eq!(summary.frame_count, 1);
         assert!(!directory.join("keep").exists());
-        assert!(directory.join("frame-000000000000-packet-000000000012.png").exists());
+        assert!(directory.join("frame_000000000000.png").exists());
         fs::remove_dir_all(directory).unwrap();
     }
 

--- a/crates/ironrdp-capture-replay/src/output.rs
+++ b/crates/ironrdp-capture-replay/src/output.rs
@@ -73,18 +73,20 @@ pub fn export_capture(capture: &Capture, options: &ExportOptions) -> Result<Expo
     let mut output = StagedOutput::new(staging);
     let result = router
         .route_plaintext_with_frame_sink(&plaintext, &mut |frame| output.write_frame(frame))
-        .and_then(|report| finalize_staged_output(&output, &report, options));
+        .and_then(|report| finalize_staged_output(&mut output, &report, options));
     match result {
         Ok(summary) => Ok(summary),
         Err(error) => {
-            fs::remove_dir_all(&output.directory).map_err(ExportError::CleanupOutput)?;
+            if !output.finalization_started {
+                fs::remove_dir_all(&output.directory).map_err(ExportError::CleanupOutput)?;
+            }
             Err(error)
         }
     }
 }
 
 fn finalize_staged_output(
-    output: &StagedOutput,
+    output: &mut StagedOutput,
     report: &ReplayReport,
     options: &ExportOptions,
 ) -> Result<ExportSummary, ExportError> {
@@ -92,6 +94,7 @@ fn finalize_staged_output(
         return Err(ExportError::NoVisualFrames);
     }
     output.write_diagnostics(report)?;
+    output.finalization_started = true;
     replace_output_directory(&output.directory, &options.directory, options.replace)?;
     Ok(ExportSummary {
         directory: options.directory.clone(),
@@ -103,6 +106,7 @@ struct StagedOutput {
     directory: PathBuf,
     frame_count: usize,
     frame_metadata: String,
+    finalization_started: bool,
 }
 
 impl StagedOutput {
@@ -111,14 +115,15 @@ impl StagedOutput {
             directory,
             frame_count: 0,
             frame_metadata: String::from("FrameIndex|FramePacket|FrameSize|FrameFile|UpdatePos|UpdateSize\n"),
+            finalization_started: false,
         }
     }
 
     fn write_frame(&mut self, frame: ReplayFrame) -> Result<(), ExportError> {
-        let name = format!("frame_{:04}.png", self.frame_count);
+        let name = format!("frame_{:06}.png", self.frame_count);
         encode_png(&self.directory.join(name), &frame)?;
         self.frame_metadata.push_str(&format!(
-            "{}|{}|{}x{}|frame_{:04}.png|0x0|{}x{}\n",
+            "{}|{}|{}x{}|frame_{:06}.png|0x0|{}x{}\n",
             self.frame_count, frame.packet, frame.width, frame.height, self.frame_count, frame.width, frame.height,
         ));
         self.frame_count += 1;
@@ -192,7 +197,74 @@ fn replace_output_directory(staging: &Path, directory: &Path, replace: bool) -> 
         Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
             return Err(ExportError::OutputPathNotDirectory);
         }
-        Ok(_) if replace => fs::remove_dir_all(directory).map_err(ExportError::FinalizeOutput)?,
+        Ok(_) if replace => {
+            let stem = directory
+                .file_name()
+                .and_then(|name| name.to_str())
+                .ok_or(ExportError::OutputPathNotLeaf)?;
+            let mut previous = None;
+            for attempt in 0..1_000 {
+                let backup =
+                    output_parent(directory).join(format!(".{stem}.previous-{}-{attempt}", std::process::id()));
+                match fs::rename(directory, &backup) {
+                    Ok(()) => {
+                        previous = Some(backup);
+                        break;
+                    }
+                    Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+                    Err(error) => return Err(ExportError::FinalizeOutput(error)),
+                }
+            }
+            let previous = previous.ok_or_else(|| {
+                ExportError::FinalizeOutput(io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    "could not allocate replay output backup directory",
+                ))
+            })?;
+
+            if let Err(error) = fs::rename(staging, directory) {
+                if let Err(restore_error) = fs::rename(&previous, directory) {
+                    return Err(ExportError::FinalizeOutput(io::Error::new(
+                        error.kind(),
+                        format!(
+                            "could not publish replay output; previous output remains at {}: {restore_error}",
+                            previous.display()
+                        ),
+                    )));
+                }
+                return Err(ExportError::FinalizeOutput(io::Error::new(
+                    error.kind(),
+                    format!(
+                        "could not publish replay output; completed export remains staged at {}: {error}",
+                        staging.display()
+                    ),
+                )));
+            }
+
+            if let Err(error) = fs::remove_dir_all(&previous) {
+                if let Err(rollback_error) = fs::rename(directory, staging) {
+                    return Err(ExportError::FinalizeOutput(io::Error::new(
+                        error.kind(),
+                        format!(
+                            "could not remove previous replay output; replay output remains at {} and previous output remains at {}: {rollback_error}",
+                            directory.display(),
+                            previous.display()
+                        ),
+                    )));
+                }
+                if let Err(restore_error) = fs::rename(&previous, directory) {
+                    return Err(ExportError::FinalizeOutput(io::Error::new(
+                        error.kind(),
+                        format!(
+                            "could not remove previous replay output; previous output remains at {}: {restore_error}",
+                            previous.display()
+                        ),
+                    )));
+                }
+                return Err(ExportError::FinalizeOutput(error));
+            }
+            return Ok(());
+        }
         Ok(_) if directory_is_empty(directory).map_err(ExportError::FinalizeOutput)? => {
             fs::remove_dir(directory).map_err(ExportError::FinalizeOutput)?;
         }
@@ -304,8 +376,8 @@ mod tests {
         output.write_diagnostics(&report).unwrap();
         replace_output_directory(&staging, &directory, false).unwrap();
 
-        assert_png_rgba(&directory.join("frame_0000.png"), [0x11, 0x22, 0x33, 0xff]);
-        assert_png_rgba(&directory.join("frame_0001.png"), [0x44, 0x55, 0x66, 0xff]);
+        assert_png_rgba(&directory.join("frame_000000.png"), [0x11, 0x22, 0x33, 0xff]);
+        assert_png_rgba(&directory.join("frame_000001.png"), [0x44, 0x55, 0x66, 0xff]);
         let diagnostics = fs::read_to_string(directory.join("events.tsv")).unwrap();
         let metadata = fs::read_to_string(directory.join("frame_meta.psv")).unwrap();
         let channels = fs::read_to_string(directory.join("dynamic-channels.tsv")).unwrap();
@@ -313,8 +385,8 @@ mod tests {
         assert_eq!(
             metadata,
             "FrameIndex|FramePacket|FrameSize|FrameFile|UpdatePos|UpdateSize\n\
-             0|12|1x1|frame_0000.png|0x0|1x1\n\
-             1|47|1x1|frame_0001.png|0x0|1x1\n"
+             0|12|1x1|frame_000000.png|0x0|1x1\n\
+             1|47|1x1|frame_000001.png|0x0|1x1\n"
         );
         assert_eq!(channels, "id\n7\n");
         for text in [diagnostics, metadata, channels] {
@@ -370,7 +442,7 @@ mod tests {
         output.write_frame(frame(12, [0x11, 0x22, 0x33, 0xff])).unwrap();
 
         let summary = finalize_staged_output(
-            &output,
+            &mut output,
             &report(),
             &ExportOptions {
                 directory: directory.clone(),
@@ -381,7 +453,13 @@ mod tests {
 
         assert_eq!(summary.frame_count, 1);
         assert!(!directory.join("keep").exists());
-        assert!(directory.join("frame_0000.png").exists());
+        assert!(directory.join("frame_000000.png").exists());
+        let backup_prefix = format!(".{}.previous-", directory.file_name().unwrap().to_string_lossy());
+        assert!(
+            fs::read_dir(directory.parent().unwrap())
+                .unwrap()
+                .all(|entry| { !entry.unwrap().file_name().to_string_lossy().starts_with(&backup_prefix) })
+        );
         fs::remove_dir_all(directory).unwrap();
     }
 
@@ -389,10 +467,10 @@ mod tests {
     fn refuses_to_finalize_without_visual_frames() {
         let directory = temporary_directory("no-frames");
         let staging = create_staging_directory(directory.parent().unwrap(), &directory).unwrap();
-        let output = StagedOutput::new(staging.clone());
+        let mut output = StagedOutput::new(staging.clone());
 
         let error = finalize_staged_output(
-            &output,
+            &mut output,
             &report(),
             &ExportOptions {
                 directory: directory.clone(),

--- a/crates/ironrdp-capture-replay/src/output.rs
+++ b/crates/ironrdp-capture-replay/src/output.rs
@@ -115,10 +115,10 @@ impl StagedOutput {
     }
 
     fn write_frame(&mut self, frame: ReplayFrame) -> Result<(), ExportError> {
-        let name = format!("frame_{:012}.png", self.frame_count);
+        let name = format!("frame_{:04}.png", self.frame_count);
         encode_png(&self.directory.join(name), &frame)?;
         self.frame_metadata.push_str(&format!(
-            "{}|{}|{}x{}|frame_{:012}.png|0x0|{}x{}\n",
+            "{}|{}|{}x{}|frame_{:04}.png|0x0|{}x{}\n",
             self.frame_count, frame.packet, frame.width, frame.height, self.frame_count, frame.width, frame.height,
         ));
         self.frame_count += 1;
@@ -304,8 +304,8 @@ mod tests {
         output.write_diagnostics(&report).unwrap();
         replace_output_directory(&staging, &directory, false).unwrap();
 
-        assert_png_rgba(&directory.join("frame_000000000000.png"), [0x11, 0x22, 0x33, 0xff]);
-        assert_png_rgba(&directory.join("frame_000000000001.png"), [0x44, 0x55, 0x66, 0xff]);
+        assert_png_rgba(&directory.join("frame_0000.png"), [0x11, 0x22, 0x33, 0xff]);
+        assert_png_rgba(&directory.join("frame_0001.png"), [0x44, 0x55, 0x66, 0xff]);
         let diagnostics = fs::read_to_string(directory.join("events.tsv")).unwrap();
         let metadata = fs::read_to_string(directory.join("frame_meta.psv")).unwrap();
         let channels = fs::read_to_string(directory.join("dynamic-channels.tsv")).unwrap();
@@ -313,8 +313,8 @@ mod tests {
         assert_eq!(
             metadata,
             "FrameIndex|FramePacket|FrameSize|FrameFile|UpdatePos|UpdateSize\n\
-             0|12|1x1|frame_000000000000.png|0x0|1x1\n\
-             1|47|1x1|frame_000000000001.png|0x0|1x1\n"
+             0|12|1x1|frame_0000.png|0x0|1x1\n\
+             1|47|1x1|frame_0001.png|0x0|1x1\n"
         );
         assert_eq!(channels, "id\n7\n");
         for text in [diagnostics, metadata, channels] {
@@ -381,7 +381,7 @@ mod tests {
 
         assert_eq!(summary.frame_count, 1);
         assert!(!directory.join("keep").exists());
-        assert!(directory.join("frame_000000000000.png").exists());
+        assert!(directory.join("frame_0000.png").exists());
         fs::remove_dir_all(directory).unwrap();
     }
 

--- a/crates/ironrdp-capture-replay/src/routing.rs
+++ b/crates/ironrdp-capture-replay/src/routing.rs
@@ -1,4 +1,5 @@
 use core::any::TypeId;
+use core::convert::Infallible;
 use core::mem;
 use std::collections::BTreeSet;
 
@@ -77,16 +78,11 @@ pub struct ReplayEvent {
     pub route: ReplayRoute,
 }
 
-/// A framebuffer snapshot produced by a captured graphics update.
 #[derive(Clone, Eq, PartialEq)]
-pub struct ReplayFrame {
-    /// Packet number that produced this framebuffer state.
+pub(crate) struct ReplayFrame {
     pub packet: usize,
-    /// Framebuffer width in pixels.
     pub width: u16,
-    /// Framebuffer height in pixels.
     pub height: u16,
-    /// RGBA framebuffer pixels in row-major order.
     pub pixels: Vec<u8>,
 }
 
@@ -147,8 +143,6 @@ pub struct CapturedDynamicChannel {
 pub struct ReplayReport {
     /// Routed RDP PDUs in capture order.
     pub events: Vec<ReplayEvent>,
-    /// Framebuffer snapshots produced in capture order.
-    pub frames: Vec<ReplayFrame>,
     /// Messages that were not safely replayable.
     pub gaps: Vec<ReplayGap>,
     /// Dynamic channels attached from recorded DVC create requests.
@@ -258,6 +252,17 @@ impl ReplayRouter {
     ///
     /// Construct a new router for each capture so session and channel state cannot cross capture boundaries.
     pub fn route_plaintext(&mut self, plaintext: &Plaintext) -> ReplayReport {
+        match self.route_plaintext_with_frame_sink(plaintext, &mut |_| Ok::<_, Infallible>(())) {
+            Ok(report) => report,
+            Err(error) => match error {},
+        }
+    }
+
+    pub(crate) fn route_plaintext_with_frame_sink<E>(
+        &mut self,
+        plaintext: &Plaintext,
+        frame_sink: &mut impl FnMut(ReplayFrame) -> Result<(), E>,
+    ) -> Result<ReplayReport, E> {
         let mut report = ReplayReport::default();
         let mut messages = framed_stream(&plaintext.client, ReplayDirection::Client, &mut report.gaps);
         messages.extend(framed_stream(
@@ -288,7 +293,7 @@ impl ReplayRouter {
                 }
                 ReplayRoute::Connection
             } else {
-                let (route, deactivated) = self.route_server_message(&message, &mut report);
+                let (route, deactivated) = self.route_server_message(&message, &mut report, frame_sink)?;
                 if deactivated {
                     activated = false;
                     awaiting_finalization = false;
@@ -314,10 +319,15 @@ impl ReplayRouter {
             }
         }
         report.gaps.sort_by_key(|gap| gap.packet);
-        report
+        Ok(report)
     }
 
-    fn route_server_message(&mut self, message: &CapturedPdu, report: &mut ReplayReport) -> (ReplayRoute, bool) {
+    fn route_server_message<E>(
+        &mut self,
+        message: &CapturedPdu,
+        report: &mut ReplayReport,
+        frame_sink: &mut impl FnMut(ReplayFrame) -> Result<(), E>,
+    ) -> Result<(ReplayRoute, bool), E> {
         let route = match message.action {
             Action::FastPath => ReplayRoute::FastPath,
             Action::X224 => match mcs::decode_send_data_indication(&message.bytes) {
@@ -343,7 +353,7 @@ impl ReplayRouter {
             self.observe_dvc_lifecycle(message, report);
         }
         if route == ReplayRoute::OtherServerMessage {
-            return (route, false);
+            return Ok((route, false));
         }
         match self.stage.process(&mut self.image, message.action, &message.bytes) {
             Ok(outputs) => {
@@ -351,19 +361,19 @@ impl ReplayRouter {
                     .iter()
                     .any(|output| matches!(output, ActiveStageOutput::GraphicsUpdate(_)))
                 {
-                    report.frames.push(ReplayFrame {
+                    frame_sink(ReplayFrame {
                         packet: message.packet,
                         width: self.image.width(),
                         height: self.image.height(),
                         pixels: self.image.data().to_vec(),
-                    });
+                    })?;
                 }
-                (
+                Ok((
                     route,
                     outputs
                         .iter()
                         .any(|output| matches!(output, ActiveStageOutput::DeactivateAll)),
-                )
+                ))
             }
             Err(_) => {
                 report.gaps.push(ReplayGap {
@@ -376,7 +386,7 @@ impl ReplayRouter {
                     },
                     skipped_bytes: 0,
                 });
-                (route, false)
+                Ok((route, false))
             }
         }
     }
@@ -458,12 +468,17 @@ impl ReplayRouter {
 
 /// Decrypt, recover captured activation state, and route a direct TCP RDP capture.
 pub fn replay_capture(capture: &Capture) -> Result<ReplayReport, ReplayError> {
+    let (mut router, plaintext) = prepare_replay_capture(capture)?;
+    Ok(router.route_plaintext(&plaintext))
+}
+
+pub(crate) fn prepare_replay_capture(capture: &Capture) -> Result<(ReplayRouter, Plaintext), ReplayError> {
     let plaintext = decrypt_tls(capture)?;
-    let mut router = ReplayRouter::new(CapturedActivation {
+    let router = ReplayRouter::new(CapturedActivation {
         state: recover_negotiated_state(&plaintext)?,
         compression_type: captured_compression_type(&plaintext),
     })?;
-    Ok(router.route_plaintext(&plaintext))
+    Ok((router, plaintext))
 }
 
 fn captured_compression_type(plaintext: &Plaintext) -> Option<CompressionType> {
@@ -703,7 +718,10 @@ mod tests {
 
     use ironrdp_core::encode_vec;
     use ironrdp_dvc::pdu::{CreateRequestPdu, DataPdu, DrdynvcDataPdu};
+    use ironrdp_pdu::bitmap::{BitmapData, BitmapUpdateData, Compression};
+    use ironrdp_pdu::fast_path::{EncryptionFlags, FastPathHeader, FastPathUpdatePdu, Fragmentation, UpdateCode};
     use ironrdp_pdu::gcc::ChannelName;
+    use ironrdp_pdu::geometry::InclusiveRectangle;
     use ironrdp_pdu::mcs::{DisconnectProviderUltimatum, DisconnectReason, McsMessage};
     use ironrdp_pdu::rdp::capability_sets::{
         Bitmap, BitmapDrawingFlags, CapabilitySet, DemandActive, ServerDemandActive,
@@ -755,6 +773,38 @@ mod tests {
         assert_eq!(report.events[2].route, ReplayRoute::ClientObservation);
         assert_eq!(report.events[3].route, ReplayRoute::StaticChannel);
         assert!(report.gaps.is_empty());
+    }
+
+    #[test]
+    fn streams_graphics_updates_in_capture_order() {
+        let mut router = ReplayRouter::new(activation()).unwrap();
+        let mut frames = Vec::new();
+        let report = router
+            .route_plaintext_with_frame_sink(
+                &Plaintext {
+                    client: Vec::new(),
+                    server: vec![
+                        (1, demand_active()),
+                        (2, font_map()),
+                        (3, bitmap_fast_path([0x11, 0x22, 0x33, 0xff])),
+                        (4, bitmap_fast_path([0x44, 0x55, 0x66, 0xff])),
+                    ],
+                },
+                &mut |frame| {
+                    frames.push(frame);
+                    Ok::<_, ()>(())
+                },
+            )
+            .unwrap();
+
+        assert_eq!(
+            report.events.iter().map(|event| event.packet).collect::<Vec<_>>(),
+            vec![1, 2, 3, 4]
+        );
+        assert_eq!(frames.iter().map(|frame| frame.packet).collect::<Vec<_>>(), vec![3, 4]);
+        assert!(frames.iter().all(|frame| (frame.width, frame.height) == (32, 32)));
+        assert_eq!(&frames[0].pixels[..4], [0x33, 0x22, 0x11, 0xff]);
+        assert_eq!(&frames[1].pixels[..4], [0x66, 0x55, 0x44, 0xff]);
     }
 
     #[test]
@@ -1076,6 +1126,37 @@ mod tests {
             user_data: Cow::Owned(user_data),
         })))
         .unwrap()
+    }
+
+    fn bitmap_fast_path(pixel: [u8; 4]) -> Vec<u8> {
+        let bitmap = encode_vec(&BitmapUpdateData {
+            rectangles: vec![BitmapData {
+                rectangle: InclusiveRectangle {
+                    left: 0,
+                    top: 0,
+                    right: 0,
+                    bottom: 0,
+                },
+                width: 1,
+                height: 1,
+                bits_per_pixel: 32,
+                compression_flags: Compression::empty(),
+                compressed_data_header: None,
+                bitmap_data: &pixel,
+            }],
+        })
+        .unwrap();
+        let update = encode_vec(&FastPathUpdatePdu {
+            fragmentation: Fragmentation::Single,
+            update_code: UpdateCode::Bitmap,
+            compression_flags: None,
+            compression_type: None,
+            data: &bitmap,
+        })
+        .unwrap();
+        let mut frame = encode_vec(&FastPathHeader::new(EncryptionFlags::empty(), update.len())).unwrap();
+        frame.extend_from_slice(&update);
+        frame
     }
 
     fn create(id: u32, name: &str) -> DrdynvcServerPdu {

--- a/crates/ironrdp-capture-replay/src/routing.rs
+++ b/crates/ironrdp-capture-replay/src/routing.rs
@@ -77,6 +77,30 @@ pub struct ReplayEvent {
     pub route: ReplayRoute,
 }
 
+/// A framebuffer snapshot produced by a captured graphics update.
+#[derive(Clone, Eq, PartialEq)]
+pub struct ReplayFrame {
+    /// Packet number that produced this framebuffer state.
+    pub packet: usize,
+    /// Framebuffer width in pixels.
+    pub width: u16,
+    /// Framebuffer height in pixels.
+    pub height: u16,
+    /// RGBA framebuffer pixels in row-major order.
+    pub pixels: Vec<u8>,
+}
+
+impl core::fmt::Debug for ReplayFrame {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ReplayFrame")
+            .field("packet", &self.packet)
+            .field("width", &self.width)
+            .field("height", &self.height)
+            .field("pixels", &"<redacted>")
+            .finish()
+    }
+}
+
 /// Classifies an explicitly recorded replay gap.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ReplayGapKind {
@@ -123,6 +147,8 @@ pub struct CapturedDynamicChannel {
 pub struct ReplayReport {
     /// Routed RDP PDUs in capture order.
     pub events: Vec<ReplayEvent>,
+    /// Framebuffer snapshots produced in capture order.
+    pub frames: Vec<ReplayFrame>,
     /// Messages that were not safely replayable.
     pub gaps: Vec<ReplayGap>,
     /// Dynamic channels attached from recorded DVC create requests.
@@ -320,12 +346,25 @@ impl ReplayRouter {
             return (route, false);
         }
         match self.stage.process(&mut self.image, message.action, &message.bytes) {
-            Ok(outputs) => (
-                route,
-                outputs
+            Ok(outputs) => {
+                if outputs
                     .iter()
-                    .any(|output| matches!(output, ActiveStageOutput::DeactivateAll)),
-            ),
+                    .any(|output| matches!(output, ActiveStageOutput::GraphicsUpdate(_)))
+                {
+                    report.frames.push(ReplayFrame {
+                        packet: message.packet,
+                        width: self.image.width(),
+                        height: self.image.height(),
+                        pixels: self.image.data().to_vec(),
+                    });
+                }
+                (
+                    route,
+                    outputs
+                        .iter()
+                        .any(|output| matches!(output, ActiveStageOutput::DeactivateAll)),
+                )
+            }
             Err(_) => {
                 report.gaps.push(ReplayGap {
                     packet: message.packet,


### PR DESCRIPTION
Export replay framebuffer updates as ordered PNGs and stage all artifacts before replacing the selected directory.

Refuse empty visual output and omit TLS secrets, decrypted payloads, and raw captured data from tabular diagnostics.