### PR TITLE
feat(agent): start Sandbox VMs over gRPC

### DIFF
--- a/crates/ironrdp-agent/README.md
+++ b/crates/ironrdp-agent/README.md
@@ -72,16 +72,12 @@ The ActiveX backend explicitly rejects this bulk input operation.
 
 ## Windows Sandbox
 
-On Windows with the Windows Sandbox feature enabled, the agent can attach to a sandbox that was
-created separately (preferred) and speak RDP over the product's default **named-pipe** transport
-(`\\.\pipe\{VMId}`), using standard RDP security with no encryption (`PROTOCOL_RDP` /
-`ENCRYPTION_LEVEL_NONE`).
+On Windows with the Windows Sandbox feature enabled, the agent can create and attach to a sandbox over the product's default **named-pipe** transport (`\\.\pipe\{VMId}`).
+The connection uses standard RDP security with no encryption (`PROTOCOL_RDP` / `ENCRYPTION_LEVEL_NONE`).
 
 ```bat
-:: create headless (prints Id only)
-wsb start
-
-:: inspect / list via WindowsSandboxServer gRPC
+:: create, inspect, and stop via WindowsSandboxServer gRPC
+ironrdp-agent sandbox start
 ironrdp-agent sandbox list
 ironrdp-agent sandbox config <sandbox-id>
 
@@ -91,9 +87,10 @@ ironrdp-agent connect --sandbox-id <sandbox-id>
 ironrdp-agent screenshot sandbox.png
 ```
 
-The agent speaks `sandboxserver.SandboxCore` in-process over the per-user named pipe
-(`\\.\pipe\wsandbox\<md5(user SID)>`) — no .NET helper is required. WindowsSandboxServer must
-already be running (starting a sandbox with `wsb start` / the Sandbox UI is enough).
+The agent speaks `sandboxserver.SandboxCore` in-process over the per-user named pipe (`\\.\pipe\wsandbox\<md5(user SID)>`) — no .NET helper is required.
+WindowsSandboxServer must already be running; opening the Sandbox UI or invoking `wsb` starts it.
+On retail builds that permit one active sandbox, stop that initial sandbox before using `sandbox start`; the agent reports server policy errors rather than bypassing them.
+`sandbox start` accepts `--id <GUID>` and `--config <FILE>`, reads the same configuration XML accepted by `wsb start --config`, and prints the created sandbox Id.
 
 Low-level escape hatch when you already have the pipe path and guest password:
 

--- a/crates/ironrdp-agent/README.md
+++ b/crates/ironrdp-agent/README.md
@@ -85,6 +85,9 @@ ironrdp-agent sandbox config <sandbox-id>
 ironrdp-agent daemon-start
 ironrdp-agent connect --sandbox-id <sandbox-id>
 ironrdp-agent screenshot sandbox.png
+
+:: shut down when finished
+ironrdp-agent sandbox stop <sandbox-id>
 ```
 
 The agent speaks `sandboxserver.SandboxCore` in-process over the per-user named pipe (`\\.\pipe\wsandbox\<md5(user SID)>`) — no .NET helper is required.

--- a/crates/ironrdp-agent/src/cli.rs
+++ b/crates/ironrdp-agent/src/cli.rs
@@ -193,7 +193,7 @@ enum Command {
     Now(NowArgs),
     /// Inspect and exercise the validated, headless RemoteApp/RAIL audit plane.
     Rail(RailArgs),
-    /// Windows Sandbox lifecycle helpers (list/config/stop via WindowsSandboxServer gRPC).
+    /// Windows Sandbox lifecycle helpers via WindowsSandboxServer gRPC.
     #[cfg(windows)]
     Sandbox(SandboxArgs),
 }
@@ -208,6 +208,15 @@ struct SandboxArgs {
 #[cfg(windows)]
 #[derive(Subcommand, Debug)]
 enum SandboxCommand {
+    /// Start a sandbox through the running WindowsSandboxServer.
+    Start {
+        /// Optional sandbox ID. The server generates one when omitted.
+        #[arg(long, value_name = "GUID")]
+        id: Option<String>,
+        /// Read Windows Sandbox configuration XML from this file.
+        #[arg(long, value_name = "FILE")]
+        config: Option<PathBuf>,
+    },
     /// List running sandbox ids (`EnumerateSandboxVMs`).
     List,
     /// Show RDP config for a sandbox (password redacted).
@@ -1069,6 +1078,16 @@ fn build_connect_request(args: ConnectArgs) -> anyhow::Result<Request> {
 #[cfg(windows)]
 fn run_sandbox_command(args: SandboxArgs) -> anyhow::Result<()> {
     match args.command {
+        SandboxCommand::Start { id, config } => {
+            let recipe = config
+                .as_deref()
+                .map(|path| std::fs::read_to_string(path).with_context(|| format!("read {}", path.display())))
+                .transpose()?;
+            let cfg =
+                crate::sandbox::start_sandbox(recipe.as_deref(), id.as_deref()).context("start Windows Sandbox")?;
+            println!("{}", cfg.sandbox_id);
+            Ok(())
+        }
         SandboxCommand::List => {
             let ids = crate::sandbox::list_sandbox_ids().context("list Windows sandboxes")?;
             if ids.is_empty() {
@@ -2033,6 +2052,8 @@ mod tests {
     use clap::{CommandFactory as _, Parser as _};
 
     use super::Command;
+    #[cfg(windows)]
+    use super::SandboxCommand;
     use super::{
         Backend, Cli, CommonExecutionArgs, MAX_UNICODE_TEXT_CHARS, NowExecutionKind, build_now_execution,
         endpoint_from_arg,
@@ -2087,6 +2108,30 @@ mod tests {
         for drive in ["C:\\", "=C:\\", "Data=", "too-long=C:\\", "Data/C:\\"] {
             assert!(Cli::try_parse_from(["ironrdp-agent", "daemon-start", "--rdpdr-drive", drive]).is_err());
         }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn sandbox_start_parses_optional_id_and_config_file() {
+        let cli = Cli::try_parse_from([
+            "ironrdp-agent",
+            "sandbox",
+            "start",
+            "--id",
+            "8825f947-7d05-46e5-9efb-317ca83500ec",
+            "--config",
+            "sandbox.wsb",
+        ])
+        .expect("valid sandbox start arguments");
+
+        let Some(Command::Sandbox(args)) = cli.command else {
+            panic!("expected sandbox command");
+        };
+        let SandboxCommand::Start { id, config } = args.command else {
+            panic!("expected sandbox start command");
+        };
+        assert_eq!(id.as_deref(), Some("8825f947-7d05-46e5-9efb-317ca83500ec"));
+        assert_eq!(config, Some(PathBuf::from("sandbox.wsb")));
     }
 
     #[test]

--- a/crates/ironrdp-agent/src/help.rs
+++ b/crates/ironrdp-agent/src/help.rs
@@ -181,10 +181,13 @@ capability, or mapping, even if a peer advertises it.
 
 ## Windows Sandbox (Windows only)
 
-Prefer create-then-connect: start the VM with official `wsb start` (prints the sandbox Id), then
-attach with the agent. The agent calls WindowsSandboxServer gRPC in-process over the per-user
-named pipe (no .NET helper).
+Start the Windows Sandbox UI or `wsb` once to bootstrap WindowsSandboxServer.
+The agent can then create, inspect, and stop sandboxes over its per-user named pipe without a .NET helper.
+On retail builds that permit one active sandbox, stop that initial sandbox before using `sandbox start`; the agent reports server policy errors rather than bypassing them.
 
+- `sandbox start [--id GUID] [--config FILE]`
+                                  Start a sandbox and print its Id.
+                                  The server uses its default configuration when `--config` is omitted.
 - `sandbox list`                 List running sandbox Ids via WindowsSandboxServer.
 - `sandbox config <ID>`          Print a redacted RdpClientConfig summary (password shown as set/empty).
 - `sandbox stop <ID>`            Shut down a running sandbox via gRPC.
@@ -193,8 +196,8 @@ named pipe (no .NET helper).
 - `connect --sandbox-pipe PATH -u USER -p PASS`
                                  Low-level NamedPipe connect when you already have the guest password.
 
-Default product transport is NamedPipe. Local (VMConnect :2179 + PCB) and guest TCP are not the
-primary path.
+Default product transport is NamedPipe.
+Local (VMConnect :2179 + PCB) and guest TCP are not the primary path.
 
 ## Errors
 

--- a/crates/ironrdp-agent/src/sandbox.rs
+++ b/crates/ironrdp-agent/src/sandbox.rs
@@ -50,6 +50,16 @@ pub(crate) fn list_sandbox_ids() -> anyhow::Result<Vec<String>> {
     sandbox_grpc::enumerate_sandbox_vms()
 }
 
+/// Start a sandbox through WindowsSandboxServer and return its RDP configuration.
+///
+/// `recipe` is the Windows Sandbox configuration XML.
+/// When it is absent, the server uses its default configuration.
+/// `sandbox_id` lets callers select a stable ID; otherwise the server assigns one.
+pub(crate) fn start_sandbox(recipe: Option<&str>, sandbox_id: Option<&str>) -> anyhow::Result<SandboxRdpConfig> {
+    let xml = sandbox_grpc::start_sandbox(recipe, sandbox_id).context("StartSandbox")?;
+    Ok(parse_config_xml(&xml, sandbox_id.unwrap_or_default()))
+}
+
 /// Fetch `RdpClientConfig` for a running sandbox.
 pub(crate) fn get_rdp_config(sandbox_id: &str) -> anyhow::Result<SandboxRdpConfig> {
     let xml = sandbox_grpc::get_rdp_client_config_xml(sandbox_id)

--- a/crates/ironrdp-agent/src/sandbox_grpc.rs
+++ b/crates/ironrdp-agent/src/sandbox_grpc.rs
@@ -60,6 +60,9 @@ pub(crate) fn start_sandbox(recipe: Option<&str>, sandbox_id: Option<&str>) -> a
     let request = encode_start_sandbox_request(recipe, sandbox_id);
     let payload = block_on(unary("StartSandbox", &request, START_SANDBOX_TIMEOUT))?;
     let (hr, _, cfg) = parse_reply(&payload, ParseMode::Config)?;
+    if hr == CO_E_APPSINGLEUSE {
+        bail!("multiple Windows Sandbox instances are not permitted by this Windows build or license");
+    }
     ensure_ok(hr, "StartSandbox")?;
     if cfg.is_empty() {
         bail!("empty RdpClientConfig from WindowsSandboxServer");
@@ -89,9 +92,6 @@ pub(crate) fn shutdown_sandbox(sandbox_id: &str) -> anyhow::Result<()> {
 }
 
 fn ensure_ok(hr: i32, method: &str) -> anyhow::Result<()> {
-    if hr == CO_E_APPSINGLEUSE {
-        bail!("multiple Windows Sandbox instances are not permitted by this Windows build or license");
-    }
     if hr != 0 {
         bail!("{method} failed with hresult=0x{hr:08X}");
     }
@@ -576,15 +576,6 @@ mod tests {
         assert_eq!(
             encode_start_sandbox_request(Some("<Configuration/>"), Some("sandbox-id")),
             b"\x0a\x10<Configuration/>\x12\nsandbox-id"
-        );
-    }
-
-    #[test]
-    fn single_instance_policy_error_is_actionable() {
-        let error = ensure_ok(CO_E_APPSINGLEUSE, "StartSandbox").expect_err("single-instance policy must fail");
-        assert_eq!(
-            error.to_string(),
-            "multiple Windows Sandbox instances are not permitted by this Windows build or license"
         );
     }
 }

--- a/crates/ironrdp-agent/src/sandbox_grpc.rs
+++ b/crates/ironrdp-agent/src/sandbox_grpc.rs
@@ -19,6 +19,7 @@ use windows::core::PWSTR;
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
 const PIPE_BUSY_RETRY: Duration = Duration::from_millis(50);
 const RPC_TIMEOUT: Duration = Duration::from_secs(15);
+const START_SANDBOX_TIMEOUT: Duration = Duration::from_secs(120);
 /// `ERROR_PIPE_BUSY` — another client still holds the pipe instance.
 const ERROR_PIPE_BUSY: i32 = 231;
 /// `CO_E_APPSINGLEUSE` — the Windows Sandbox policy permits only one active VM.
@@ -44,7 +45,7 @@ fn grpc_pipe_path_for_sid(sid: &str) -> String {
 
 /// `EnumerateSandboxVMs` → sandbox id list.
 pub(crate) fn enumerate_sandbox_vms() -> anyhow::Result<Vec<String>> {
-    let payload = block_on(unary("EnumerateSandboxVMs", &[]))?;
+    let payload = block_on(unary("EnumerateSandboxVMs", &[], RPC_TIMEOUT))?;
     let (hr, ids, _) = parse_reply(&payload, ParseMode::Ids)?;
     ensure_ok(hr, "EnumerateSandboxVMs")?;
     Ok(ids)
@@ -56,15 +57,8 @@ pub(crate) fn enumerate_sandbox_vms() -> anyhow::Result<Vec<String>> {
 /// When omitted, the server uses its default recipe.
 /// `sandbox_id` is optional; the server generates an ID when it is absent.
 pub(crate) fn start_sandbox(recipe: Option<&str>, sandbox_id: Option<&str>) -> anyhow::Result<String> {
-    let mut request = Vec::new();
-    if let Some(recipe) = recipe {
-        request.extend_from_slice(&encode_string_field(1, recipe));
-    }
-    if let Some(sandbox_id) = sandbox_id {
-        request.extend_from_slice(&encode_string_field(2, sandbox_id));
-    }
-
-    let payload = block_on(unary("StartSandbox", &request))?;
+    let request = encode_start_sandbox_request(recipe, sandbox_id);
+    let payload = block_on(unary("StartSandbox", &request, START_SANDBOX_TIMEOUT))?;
     let (hr, _, cfg) = parse_reply(&payload, ParseMode::Config)?;
     ensure_ok(hr, "StartSandbox")?;
     if cfg.is_empty() {
@@ -76,7 +70,7 @@ pub(crate) fn start_sandbox(recipe: Option<&str>, sandbox_id: Option<&str>) -> a
 /// `GetRdpClientConfig` → serialized RdpClientConfig XML.
 pub(crate) fn get_rdp_client_config_xml(sandbox_id: &str) -> anyhow::Result<String> {
     let req = encode_string_field(1, sandbox_id);
-    let payload = block_on(unary("GetRdpClientConfig", &req))?;
+    let payload = block_on(unary("GetRdpClientConfig", &req, RPC_TIMEOUT))?;
     let (hr, _, cfg) = parse_reply(&payload, ParseMode::Config)?;
     ensure_ok(hr, "GetRdpClientConfig")?;
     if cfg.is_empty() {
@@ -88,7 +82,7 @@ pub(crate) fn get_rdp_client_config_xml(sandbox_id: &str) -> anyhow::Result<Stri
 /// `ShutdownSandbox`.
 pub(crate) fn shutdown_sandbox(sandbox_id: &str) -> anyhow::Result<()> {
     let req = encode_string_field(1, sandbox_id);
-    let payload = block_on(unary("ShutdownSandbox", &req))?;
+    let payload = block_on(unary("ShutdownSandbox", &req, RPC_TIMEOUT))?;
     let (hr, _, _) = parse_reply(&payload, ParseMode::Config)?;
     ensure_ok(hr, "ShutdownSandbox")?;
     Ok(())
@@ -125,7 +119,7 @@ where
     }
 }
 
-async fn unary(method: &str, request_proto: &[u8]) -> anyhow::Result<Vec<u8>> {
+async fn unary(method: &str, request_proto: &[u8], timeout: Duration) -> anyhow::Result<Vec<u8>> {
     let path = grpc_pipe_path()?;
     let stream = open_pipe(&path).await?;
 
@@ -160,7 +154,7 @@ async fn unary(method: &str, request_proto: &[u8]) -> anyhow::Result<Vec<u8>> {
         .send_data(frame.freeze(), true)
         .context("send gRPC request body")?;
 
-    let response = tokio::time::timeout(RPC_TIMEOUT, response_future)
+    let response = tokio::time::timeout(timeout, response_future)
         .await
         .context("timeout waiting for gRPC response headers")?
         .context("await gRPC response headers")?;
@@ -171,7 +165,7 @@ async fn unary(method: &str, request_proto: &[u8]) -> anyhow::Result<Vec<u8>> {
     let mut body = response.into_body();
     let mut data = BytesMut::new();
     loop {
-        let next = tokio::time::timeout(RPC_TIMEOUT, body.data())
+        let next = tokio::time::timeout(timeout, body.data())
             .await
             .context("timeout reading gRPC response body")?;
         match next {
@@ -185,7 +179,7 @@ async fn unary(method: &str, request_proto: &[u8]) -> anyhow::Result<Vec<u8>> {
         }
     }
 
-    if let Some(trailers) = tokio::time::timeout(RPC_TIMEOUT, body.trailers())
+    if let Some(trailers) = tokio::time::timeout(timeout, body.trailers())
         .await
         .context("timeout reading gRPC trailers")?
         .context("read gRPC trailers")?
@@ -318,6 +312,17 @@ fn encode_string_field(field_number: u32, value: &str) -> Vec<u8> {
     write_varint(u64::try_from(value.len()).expect("usize fits u64"), &mut out);
     out.extend_from_slice(value.as_bytes());
     out
+}
+
+fn encode_start_sandbox_request(recipe: Option<&str>, sandbox_id: Option<&str>) -> Vec<u8> {
+    let mut request = Vec::new();
+    if let Some(recipe) = recipe {
+        request.extend_from_slice(&encode_string_field(1, recipe));
+    }
+    if let Some(sandbox_id) = sandbox_id {
+        request.extend_from_slice(&encode_string_field(2, sandbox_id));
+    }
+    request
 }
 
 fn write_varint(mut value: u64, out: &mut Vec<u8>) {
@@ -559,10 +564,19 @@ mod tests {
 
     #[test]
     fn start_request_encodes_optional_recipe_and_id() {
-        let mut request = encode_string_field(1, "<Configuration/>");
-        request.extend_from_slice(&encode_string_field(2, "sandbox-id"));
-
-        assert_eq!(request, b"\x0a\x10<Configuration/>\x12\nsandbox-id");
+        assert_eq!(encode_start_sandbox_request(None, None), b"");
+        assert_eq!(
+            encode_start_sandbox_request(Some("<Configuration/>"), None),
+            b"\x0a\x10<Configuration/>"
+        );
+        assert_eq!(
+            encode_start_sandbox_request(None, Some("sandbox-id")),
+            b"\x12\nsandbox-id"
+        );
+        assert_eq!(
+            encode_start_sandbox_request(Some("<Configuration/>"), Some("sandbox-id")),
+            b"\x0a\x10<Configuration/>\x12\nsandbox-id"
+        );
     }
 
     #[test]

--- a/crates/ironrdp-agent/src/sandbox_grpc.rs
+++ b/crates/ironrdp-agent/src/sandbox_grpc.rs
@@ -21,6 +21,8 @@ const PIPE_BUSY_RETRY: Duration = Duration::from_millis(50);
 const RPC_TIMEOUT: Duration = Duration::from_secs(15);
 /// `ERROR_PIPE_BUSY` — another client still holds the pipe instance.
 const ERROR_PIPE_BUSY: i32 = 231;
+/// `CO_E_APPSINGLEUSE` — the Windows Sandbox policy permits only one active VM.
+const CO_E_APPSINGLEUSE: i32 = -2_147_221_002;
 
 /// Resolve the per-user WindowsSandboxServer gRPC pipe path.
 pub(crate) fn grpc_pipe_path() -> anyhow::Result<String> {
@@ -48,6 +50,29 @@ pub(crate) fn enumerate_sandbox_vms() -> anyhow::Result<Vec<String>> {
     Ok(ids)
 }
 
+/// `StartSandbox` → serialized `RdpClientConfig` for the new sandbox.
+///
+/// `recipe` is the Windows Sandbox configuration XML.
+/// When omitted, the server uses its default recipe.
+/// `sandbox_id` is optional; the server generates an ID when it is absent.
+pub(crate) fn start_sandbox(recipe: Option<&str>, sandbox_id: Option<&str>) -> anyhow::Result<String> {
+    let mut request = Vec::new();
+    if let Some(recipe) = recipe {
+        request.extend_from_slice(&encode_string_field(1, recipe));
+    }
+    if let Some(sandbox_id) = sandbox_id {
+        request.extend_from_slice(&encode_string_field(2, sandbox_id));
+    }
+
+    let payload = block_on(unary("StartSandbox", &request))?;
+    let (hr, _, cfg) = parse_reply(&payload, ParseMode::Config)?;
+    ensure_ok(hr, "StartSandbox")?;
+    if cfg.is_empty() {
+        bail!("empty RdpClientConfig from WindowsSandboxServer");
+    }
+    Ok(cfg)
+}
+
 /// `GetRdpClientConfig` → serialized RdpClientConfig XML.
 pub(crate) fn get_rdp_client_config_xml(sandbox_id: &str) -> anyhow::Result<String> {
     let req = encode_string_field(1, sandbox_id);
@@ -70,6 +95,9 @@ pub(crate) fn shutdown_sandbox(sandbox_id: &str) -> anyhow::Result<()> {
 }
 
 fn ensure_ok(hr: i32, method: &str) -> anyhow::Result<()> {
+    if hr == CO_E_APPSINGLEUSE {
+        bail!("multiple Windows Sandbox instances are not permitted by this Windows build or license");
+    }
     if hr != 0 {
         bail!("{method} failed with hresult=0x{hr:08X}");
     }
@@ -527,5 +555,22 @@ mod tests {
         let (hr, _, cfg) = parse_reply(&msg, ParseMode::Config).unwrap();
         assert_eq!(hr, 0);
         assert_eq!(cfg, "hi");
+    }
+
+    #[test]
+    fn start_request_encodes_optional_recipe_and_id() {
+        let mut request = encode_string_field(1, "<Configuration/>");
+        request.extend_from_slice(&encode_string_field(2, "sandbox-id"));
+
+        assert_eq!(request, b"\x0a\x10<Configuration/>\x12\nsandbox-id");
+    }
+
+    #[test]
+    fn single_instance_policy_error_is_actionable() {
+        let error = ensure_ok(CO_E_APPSINGLEUSE, "StartSandbox").expect_err("single-instance policy must fail");
+        assert_eq!(
+            error.to_string(),
+            "multiple Windows Sandbox instances are not permitted by this Windows build or license"
+        );
     }
 }


### PR DESCRIPTION
Create Windows Sandbox instances through the SandboxCore named pipe.
Accept an optional GUID and configuration file.
Wait up to two minutes for provisioning before reporting failure.
Print the created ID and report single-instance policy failures.