### PR TITLE
feat: enable Windows smartcard in product surfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3292,6 +3292,7 @@ dependencies = [
  "ironrdp-cfg",
  "ironrdp-daemon",
  "ironrdp-propertyset",
+ "ironrdp-rdpdr-native",
  "ironrdp-rdpfile",
  "ironrdp-rpc",
  "proc-exit",

--- a/crates/ironrdp-activex/Cargo.toml
+++ b/crates/ironrdp-activex/Cargo.toml
@@ -20,7 +20,7 @@ doctest = false
 
 [target.'cfg(windows)'.dependencies]
 anyhow = "1"
-ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["clipboard", "dvc-com-plugin", "gateway", "rdpdr", "rustls", "sound", "webauthn"] }
+ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["clipboard", "dvc-com-plugin", "gateway", "rdpdr", "rustls", "smartcard", "sound", "webauthn"] }
 ironrdp-cliprdr = { path = "../ironrdp-cliprdr", version = "0.7" }
 ironrdp-cliprdr-native = { path = "../ironrdp-cliprdr-native", version = "0.7" }
 ironrdp-cfg = { path = "../ironrdp-cfg", version = "0.1" }

--- a/crates/ironrdp-activex/README.md
+++ b/crates/ironrdp-activex/README.md
@@ -283,8 +283,9 @@ A source-level audit of RDM's Windows RDP host covers these ActiveX contracts:
 | Connection configuration | Server, account, desktop, color, smart-sizing, keyboard, display update, gateway, audio, clipboard, CredSSP, client-device name, RemoteApp, and backing `ConfigBuilder` settings are mapped where IronRDP provides the same behavior. |
 | Events | Connecting, connected, login-complete, disconnect, fatal-error, fullscreen-leave, virtual-channel, resize, writable confirm-close, and worker-backed warning and auto-reconnect events are delivered on the creating apartment. |
 | Optional RDM interfaces | `IMsRdpDriveCollection` exposes Windows logical volumes for static filesystem redirection. Non-filesystem device, camera, monitor, and preferred-redirection capabilities remain unavailable. |
+| Smartcard redirection | `IMsRdpClientAdvancedSettings::RedirectSmartCards` enables WinSCard RDPDR smartcard redirection (smartcard-only sessions are valid without redirected drives). |
 
-The audit also identified RDM settings that have no IronRDP ActiveX backend: input throttling, authentication policy, device/printer/port/smart-card redirection, audio capture, video policy, PCB, load balancing, and Microsoft workspace extensions.
+The audit also identified RDM settings that have no IronRDP ActiveX backend: input throttling, authentication policy, device/printer/port redirection, audio capture, video policy, PCB, load balancing, and Microsoft workspace extensions.
 Their audited AdvancedSettings vtable slots use their exact published ABI signatures, initialize out parameters, and return `E_NOTIMPL`; the control does not report success for settings that cannot affect the connection.
 
 The control exposes a standard `IConnectionPointContainer` and an event connection point for the

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -1009,6 +1009,7 @@ struct CompatibilitySettings {
     redirect_clipboard: bool,
     redirect_webauthn: bool,
     redirect_drives: bool,
+    redirect_smart_cards: bool,
     disable_rdpdr: bool,
     drive_catalog: Rc<RefCell<DriveCatalog>>,
     warn_about_sending_credentials: bool,
@@ -1083,6 +1084,7 @@ impl Default for CompatibilitySettings {
             redirect_clipboard: true,
             redirect_webauthn: true,
             redirect_drives: false,
+            redirect_smart_cards: false,
             disable_rdpdr: false,
             drive_catalog: Rc::new(RefCell::new(DriveCatalog::new())),
             warn_about_sending_credentials: false,
@@ -1863,7 +1865,6 @@ advanced_put_not_implemented!(
     (112, advanced_put_load_balance_info, Bstr),
     (116, advanced_put_redirect_printers, i16),
     (118, advanced_put_redirect_ports, i16),
-    (120, advanced_put_redirect_smart_cards, i16),
     (150, advanced_put_redirect_devices, i16),
     (161, advanced_put_pcb, Bstr),
     (169, advanced_put_connect_to_administer_server, i16),
@@ -1881,7 +1882,6 @@ advanced_get_not_implemented!(
     (96, advanced_get_minutes_to_idle_timeout, i32),
     (117, advanced_get_redirect_printers, i16),
     (119, advanced_get_redirect_ports, i16),
-    (121, advanced_get_redirect_smart_cards, i16),
     (151, advanced_get_redirect_devices, i16),
     (170, advanced_get_connect_to_administer_server, i16),
     (174, advanced_get_video_playback_mode, u32),
@@ -2418,6 +2418,34 @@ unsafe extern "system" fn advanced_get_redirect_drives(this: *mut c_void, value:
     write_out(
         value,
         if object.settings.borrow().redirect_drives {
+            VARIANT_TRUE.0
+        } else {
+            VARIANT_FALSE.0
+        },
+    )
+    .map_or_else(|error| error.code(), |_| S_OK)
+}
+
+unsafe extern "system" fn advanced_put_redirect_smart_cards(this: *mut c_void, value: i16) -> HRESULT {
+    let value = match normalize_variant_bool(value) {
+        Ok(value) => value == VARIANT_TRUE.0,
+        Err(error) => return error.code(),
+    };
+    let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
+    let mut settings = object.settings.borrow_mut();
+    if settings.connection_settings_sealed {
+        return E_FAIL;
+    }
+    settings.redirect_smart_cards = value;
+    mark_compatibility_persistence_dirty(&settings);
+    S_OK
+}
+
+unsafe extern "system" fn advanced_get_redirect_smart_cards(this: *mut c_void, value: *mut i16) -> HRESULT {
+    let object = unsafe { &*(this.cast::<AdvancedSettingsObject>()) };
+    write_out(
+        value,
+        if object.settings.borrow().redirect_smart_cards {
             VARIANT_TRUE.0
         } else {
             VARIANT_FALSE.0
@@ -5953,6 +5981,7 @@ fn active_x_property_snapshot(settings: &Settings, compatibility: &Compatibility
     }
     properties.insert("redirectclipboard", compatibility.redirect_clipboard);
     properties.insert("redirectwebauthn", compatibility.redirect_webauthn);
+    properties.insert("ironrdp_smartcard", compatibility.redirect_smart_cards);
     properties.insert("compression", compatibility.compression.unwrap_or(true));
     properties
 }
@@ -8593,10 +8622,16 @@ impl Control {
         } else {
             compatibility.drive_catalog.borrow().selected_drives()?
         };
-        let rdpdr_factory = (!redirected_drives.is_empty())
-            .then(|| ironrdp_rdpdr_native::WindowsRdpdrBackendFactory::from_drives(redirected_drives))
-            .transpose()
-            .map_err(|error| Error::new(E_FAIL, format!("invalid redirected-drive configuration: {error}")))?;
+        let redirect_smart_cards = !compatibility.disable_rdpdr && compatibility.redirect_smart_cards;
+        let rdpdr_factory = if redirected_drives.is_empty() && !redirect_smart_cards {
+            None
+        } else {
+            Some(
+                ironrdp_rdpdr_native::WindowsRdpdrBackendFactory::from_drives(redirected_drives)
+                    .map_err(|error| Error::new(E_FAIL, format!("invalid redirected-drive configuration: {error}")))?
+                    .with_smartcard(redirect_smart_cards),
+            )
+        };
         let rdpdr_enabled = rdpdr_factory.is_some();
         let audio_redirection_mode = audio_mode_from_raw(compatibility.audio_redirection_mode)?;
         let audio_capture_enabled = compatibility.audio_capture_redirection_mode != VARIANT_FALSE.0;
@@ -8788,7 +8823,8 @@ impl Control {
             })
             .with_webauthn(redirect_webauthn)
             .with_webauthn_parent_hwnd(hwnd.0 as isize)
-            .with_rdpdr(rdpdr_enabled);
+            .with_rdpdr(rdpdr_enabled)
+            .with_smartcard(redirect_smart_cards);
         let builder = if remote_program_mode {
             builder
                 .with_remote_application_mode(true)
@@ -15426,6 +15462,18 @@ mod tests {
             S_OK
         );
         assert_eq!(redirect_drives, VARIANT_TRUE.0);
+
+        assert_eq!(unsafe { advanced_put_redirect_smart_cards(this, VARIANT_TRUE.0) }, S_OK);
+        let mut redirect_smart_cards = VARIANT_FALSE.0;
+        assert_eq!(
+            unsafe { advanced_get_redirect_smart_cards(this, &mut redirect_smart_cards) },
+            S_OK
+        );
+        assert_eq!(redirect_smart_cards, VARIANT_TRUE.0);
+        assert_eq!(
+            unsafe { advanced_get_redirect_smart_cards(this, ptr::null_mut()) },
+            E_POINTER
+        );
 
         assert_eq!(unsafe { advanced_put_enable_mouse(this, 0) }, S_OK);
         let mut enable_mouse = -1;

--- a/crates/ironrdp-agent/README.md
+++ b/crates/ironrdp-agent/README.md
@@ -34,6 +34,12 @@ For example, `ironrdp-agent daemon-start --rdpdr-drive System=C:\ --rdpdr-drive 
 Each root must be a unique existing local volume root in the exact `C:\` form, and each protocol-visible name must be unique case-insensitively and contain at most seven ASCII letters, numbers, spaces, underscores, hyphens, periods, or a trailing colon.
 The configured drives are fixed for the daemon lifetime; hot-plug and rescan are not supported.
 
+## Windows smartcard redirection
+
+On Windows, enable WinSCard smartcard redirection with `daemon-start --smartcard`, overlay/connect property `ironrdp_smartcard:i:1`, or a sandbox config with `SmartCardRedirection` enabled.
+Smartcard can be enabled without redirected drives (smartcard-only RDPDR).
+Connect-time `ironrdp_smartcard:i:0` disables it for that session even when the daemon was started with `--smartcard`.
+
 ## TLS certificate validation
 
 The daemon performs strict certificate and hostname validation by default.

--- a/crates/ironrdp-agent/src/cli.rs
+++ b/crates/ironrdp-agent/src/cli.rs
@@ -448,6 +448,14 @@ struct DaemonArgs {
     #[cfg(windows)]
     #[arg(long = "rdpdr-drive", value_name = "NAME=VOLUME_ROOT", value_parser = parse_rdpdr_drive)]
     rdpdr_drives: Vec<ironrdp_daemon::daemon::RdpdrDriveConfig>,
+    /// Enable Windows WinSCard smartcard redirection for every connect (Windows only).
+    ///
+    /// Equivalent to preloading `ironrdp_smartcard:i:1`. Connect can still disable with
+    /// `--prop ironrdp_smartcard:i:0`, or enable without this flag via that property / sandbox
+    /// `SmartCardRedirection`.
+    #[cfg(windows)]
+    #[arg(long)]
+    smartcard: bool,
 }
 
 #[derive(Args, Debug)]
@@ -777,9 +785,14 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
             let rdpdr_drives = args.rdpdr_drives;
             #[cfg(not(windows))]
             let rdpdr_drives = Vec::new();
+            #[cfg(windows)]
+            let smartcard = args.smartcard;
+            #[cfg(not(windows))]
+            let smartcard = false;
             let options = ironrdp_daemon::daemon::DaemonOptions::default()
                 .with_certificate_check_skipped(args.skip_certificate_check)
-                .with_rdpdr_drives(rdpdr_drives);
+                .with_rdpdr_drives(rdpdr_drives)
+                .with_smartcard(smartcard);
             return ironrdp_daemon::daemon::run(endpoint, overlay, options).await;
         }
         Command::Now(args) => {
@@ -2098,6 +2111,18 @@ mod tests {
             panic!("expected daemon-start command");
         };
         assert!(args.skip_certificate_check);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn daemon_start_can_enable_smartcard() {
+        let cli = Cli::try_parse_from(["ironrdp-agent", "daemon-start", "--smartcard"])
+            .expect("valid smartcard configuration");
+
+        let Some(Command::DaemonStart(args)) = cli.command else {
+            panic!("expected daemon-start command");
+        };
+        assert!(args.smartcard);
     }
 
     #[test]

--- a/crates/ironrdp-agent/src/help.rs
+++ b/crates/ironrdp-agent/src/help.rs
@@ -29,7 +29,7 @@ Override with `--endpoint <PATH-OR-PIPE>` on any subcommand.
 
 ## Lifecycle
 
-- `daemon-start [--overlay FILE] [--prop KEY:TYPE:VALUE]... [--skip-certificate-check] [--rdpdr-drive NAME=VOLUME_ROOT]...`
+- `daemon-start [--overlay FILE] [--prop KEY:TYPE:VALUE]... [--skip-certificate-check] [--rdpdr-drive NAME=VOLUME_ROOT]... [--smartcard]`
                                  Start the daemon (foreground). Run this first. `--overlay`
                                  preloads a .rdp file as an overlay applied to every `connect`
                                  (overlay wins), letting an operator provision any setting out of
@@ -44,7 +44,10 @@ Override with `--endpoint <PATH-OR-PIPE>` on any subcommand.
                                  local volume root in the exact `C:\` form, and each one-to-seven-character
                                  ASCII drive name must be unique (case-insensitive). The configured
                                  set is fixed for the daemon lifetime; drive hot-plug and rescan are
-                                 not supported.
+                                 not supported. On Windows, `--smartcard` enables WinSCard smartcard
+                                 redirection (same as overlay/connect `ironrdp_smartcard:i:1`).
+                                 Sandbox connects with `SmartCardRedirection` also set that property
+                                 at connect time, which can enable smartcard without `--smartcard`.
                                  TLS certificate and hostname validation is strict by default.
                                  `--skip-certificate-check` disables both for this daemon only.
                                  Use it only for an explicitly authorized test endpoint because it accepts any certificate and is vulnerable to on-path attacks.

--- a/crates/ironrdp-agent/src/sandbox.rs
+++ b/crates/ironrdp-agent/src/sandbox.rs
@@ -165,7 +165,7 @@ pub(crate) fn properties_from_config(cfg: &SandboxRdpConfig) -> anyhow::Result<P
     }
 
     ps.set_redirect_clipboard(cfg.clipboard_redirection);
-    let _ = cfg.smartcard_redirection;
+    ps.set_enable_smartcard(cfg.smartcard_redirection);
 
     Ok(ps)
 }
@@ -244,6 +244,24 @@ mod tests {
         assert!(props.named_pipe().is_some());
         assert_eq!(props.enable_tls(), Some(false));
         assert_eq!(props.enable_credssp_support(), Some(false));
+        assert_eq!(props.enable_smartcard(), Some(false));
+    }
+
+    #[test]
+    fn properties_from_config_sets_smartcard_redirection() {
+        let cfg = SandboxRdpConfig {
+            sandbox_id: "id".into(),
+            vm_id: "vm".into(),
+            username: "u".into(),
+            password: "p".into(),
+            rdp_transport: "NamedPipe".into(),
+            ip_address: String::new(),
+            pipe_path: Some(r"\\.\pipe\vm".into()),
+            clipboard_redirection: true,
+            smartcard_redirection: true,
+        };
+        let props = properties_from_config(&cfg).expect("named pipe props");
+        assert_eq!(props.enable_smartcard(), Some(true));
     }
 
     #[test]

--- a/crates/ironrdp-daemon/Cargo.toml
+++ b/crates/ironrdp-daemon/Cargo.toml
@@ -13,7 +13,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["rustls", "dvc-pipe-proxy", "rdpdr"] } # public
+ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["rustls", "dvc-pipe-proxy", "rdpdr", "smartcard"] } # public
 ironrdp-cfg = { path = "../ironrdp-cfg", version = "0.1" }
 ironrdp-input = { path = "../ironrdp-input", version = "0.7" }
 ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9" }

--- a/crates/ironrdp-daemon/README.md
+++ b/crates/ironrdp-daemon/README.md
@@ -4,3 +4,16 @@ Reusable persistent RDP-session support for local RPC hosts. It owns the daemon 
 retained framebuffer, input and screenshot handling, session log buffer, NOW endpoint, and durable
 NOW operation manager. The local RPC schema and transport are provided directly by
 [`ironrdp-rpc`](../ironrdp-rpc).
+
+## Windows RDPDR options
+
+`DaemonOptions` can configure fixed redirected volumes (`with_rdpdr_drives`) and WinSCard smartcard
+redirection (`with_smartcard`).
+
+Smartcard is also honored from connect/overlay property `ironrdp_smartcard`:
+
+- startup `--smartcard` / `with_smartcard(true)` / overlay `ironrdp_smartcard:i:1` sets the default
+- connect-time `ironrdp_smartcard:i:1` can enable smartcard-only without a startup flag
+- connect-time `ironrdp_smartcard:i:0` disables smartcard for that session
+
+Smartcard-only sessions use an empty drive list with device ID `0` reserved for the smartcard device.

--- a/crates/ironrdp-daemon/src/daemon.rs
+++ b/crates/ironrdp-daemon/src/daemon.rs
@@ -1715,13 +1715,22 @@ fn rdpdr_backend_factory(
 
 /// Resolves the RDPDR factory for one connect: clone the startup factory (if any) and apply the
 /// effective smartcard flag. Smartcard-only sessions may create an empty-drive factory on demand.
+/// An empty-drive factory is dropped when smartcard is disabled so RDPDR is not attached without a
+/// device to announce.
 #[cfg(windows)]
 fn resolve_rdpdr_factory(
     base: Option<&WindowsRdpdrBackendFactory>,
     smartcard: bool,
 ) -> anyhow::Result<Option<WindowsRdpdrBackendFactory>> {
     match base {
-        Some(factory) => Ok(Some(factory.clone().with_smartcard(smartcard))),
+        Some(factory) => {
+            let factory = factory.clone().with_smartcard(smartcard);
+            if factory.initial_drives().is_empty() && !smartcard {
+                Ok(None)
+            } else {
+                Ok(Some(factory))
+            }
+        }
         None if smartcard => WindowsRdpdrBackendFactory::from_drives(Vec::new())
             .map(|factory| factory.with_smartcard(true))
             .map(Some)
@@ -2439,6 +2448,11 @@ mod tests {
         assert!(factory.smartcard());
         assert!(factory.initial_drives().is_empty());
         assert!(super::resolve_rdpdr_factory(None, false).expect("no factory").is_none());
+        assert!(
+            super::resolve_rdpdr_factory(Some(&factory), false)
+                .expect("disable smartcard-only")
+                .is_none()
+        );
     }
 
     #[cfg(windows)]

--- a/crates/ironrdp-daemon/src/daemon.rs
+++ b/crates/ironrdp-daemon/src/daemon.rs
@@ -191,6 +191,8 @@ impl RdpdrDriveConfig {
 pub struct DaemonOptions {
     skip_certificate_check: bool,
     rdpdr_drives: Vec<RdpdrDriveConfig>,
+    /// Enables Windows WinSCard smartcard redirection when the connect property is unset.
+    smartcard: bool,
 }
 
 impl DaemonOptions {
@@ -215,6 +217,17 @@ impl DaemonOptions {
         self.rdpdr_drives = rdpdr_drives;
         self
     }
+
+    /// Enables WinSCard smartcard redirection for this daemon (Windows only).
+    ///
+    /// When `true`, smartcard is used unless a connect/`--prop`/`overlay` value of
+    /// `ironrdp_smartcard:i:0` explicitly disables it. Connect-time `ironrdp_smartcard:i:1`
+    /// can also enable smartcard without this startup flag.
+    #[must_use]
+    pub fn with_smartcard(mut self, enabled: bool) -> Self {
+        self.smartcard = enabled;
+        self
+    }
 }
 
 /// The daemon's mutable state: the (single) current session, plus the shared log buffer.
@@ -236,6 +249,8 @@ pub struct Daemon {
     /// Assigns RAIL launch IDs across every session so they remain unambiguous with their generation.
     next_rail_launch_id: AtomicU64,
     certificate_validation: CertificateValidation,
+    /// Default smartcard enablement when `ironrdp_smartcard` is absent from connect properties.
+    smartcard_default: bool,
     #[cfg(windows)]
     rdpdr_backend_factory: Option<WindowsRdpdrBackendFactory>,
     /// Notifies an optional GUI frontend whenever retained live state changes.
@@ -460,12 +475,22 @@ impl Daemon {
         if certificate_validation == CertificateValidation::DangerouslyAcceptInvalidCertificate {
             warn!("TLS certificate and hostname validation are disabled by explicit daemon configuration");
         }
-        let DaemonOptions { rdpdr_drives, .. } = options;
+        let DaemonOptions {
+            rdpdr_drives,
+            smartcard,
+            ..
+        } = options;
+        // Overlay may pre-enable smartcard via `ironrdp_smartcard` without a dedicated CLI flag.
+        let smartcard_default = smartcard || overlay.enable_smartcard().unwrap_or(false);
         #[cfg(windows)]
-        let rdpdr_backend_factory = rdpdr_backend_factory(rdpdr_drives)?;
+        let rdpdr_backend_factory = rdpdr_backend_factory(rdpdr_drives, smartcard_default)?;
         #[cfg(not(windows))]
         if !rdpdr_drives.is_empty() {
             anyhow::bail!("rdpdr filesystem redirection is only available on Windows");
+        }
+        #[cfg(not(windows))]
+        if smartcard_default {
+            anyhow::bail!("smartcard redirection is only available on Windows");
         }
 
         Ok(Self {
@@ -477,6 +502,7 @@ impl Daemon {
             next_rail_generation: Arc::new(AtomicU64::new(1)),
             next_rail_launch_id: AtomicU64::new(1),
             certificate_validation,
+            smartcard_default,
             #[cfg(windows)]
             rdpdr_backend_factory,
             notification: None,
@@ -675,11 +701,35 @@ impl Daemon {
             // Headless: composite the remote cursor into the framebuffer so it appears in
             // screenshots (there is no separate overlay to draw it).
             .with_pointer_software_rendering(true);
+        // Prefer an explicit connect/overlay property; otherwise use the daemon startup default.
+        // Always set smartcard explicitly so the client feature default (`true`) cannot announce a
+        // smartcard device without a matching WinSCard backend.
+        let smartcard = properties.enable_smartcard().unwrap_or(self.smartcard_default);
         #[cfg(windows)]
-        let builder = if self.rdpdr_backend_factory.is_some() {
-            builder.with_rdpdr(true)
+        let rdpdr_factory = match resolve_rdpdr_factory(self.rdpdr_backend_factory.as_ref(), smartcard) {
+            Ok(factory) => factory,
+            Err(error) => {
+                return Response::typed_error(
+                    crate::ipc::AgentErrorCategory::Internal,
+                    format!("invalid rdpdr configuration: {error:#}"),
+                );
+            }
+        };
+        #[cfg(windows)]
+        let builder = if rdpdr_factory.is_some() {
+            builder.with_rdpdr(true).with_smartcard(smartcard)
         } else {
-            builder
+            builder.with_smartcard(false)
+        };
+        #[cfg(not(windows))]
+        let builder = if smartcard {
+            return Response::typed_error(
+                crate::ipc::AgentErrorCategory::InvalidRequest,
+                "smartcard redirection is only available on Windows",
+            );
+        } else {
+            // Client feature defaults smartcard on; never announce without a WinSCard backend.
+            builder.with_smartcard(false)
         };
 
         let missing = builder.missing();
@@ -721,8 +771,8 @@ impl Daemon {
         let (output_tx, output_rx) = mpsc::channel(16);
         let client = RdpClient::new(config, output_tx);
         #[cfg(windows)]
-        let client = match &self.rdpdr_backend_factory {
-            Some(factory) => client.with_rdpdr_backend_factory(Box::new(factory.clone())),
+        let client = match rdpdr_factory {
+            Some(factory) => client.with_rdpdr_backend_factory(Box::new(factory)),
             None => client,
         };
         let input_tx = client.input_sender();
@@ -1629,8 +1679,11 @@ fn current_platform() -> MajorPlatformType {
 }
 
 #[cfg(windows)]
-fn rdpdr_backend_factory(drives: Vec<RdpdrDriveConfig>) -> anyhow::Result<Option<WindowsRdpdrBackendFactory>> {
-    if drives.is_empty() {
+fn rdpdr_backend_factory(
+    drives: Vec<RdpdrDriveConfig>,
+    smartcard: bool,
+) -> anyhow::Result<Option<WindowsRdpdrBackendFactory>> {
+    if drives.is_empty() && !smartcard {
         return Ok(None);
     }
 
@@ -1655,8 +1708,26 @@ fn rdpdr_backend_factory(drives: Vec<RdpdrDriveConfig>) -> anyhow::Result<Option
         .collect::<anyhow::Result<Vec<_>>>()?;
 
     WindowsRdpdrBackendFactory::from_drives(drives)
+        .map(|factory| factory.with_smartcard(smartcard))
         .map(Some)
         .map_err(|error| anyhow::anyhow!("invalid rdpdr drive configuration: {error}"))
+}
+
+/// Resolves the RDPDR factory for one connect: clone the startup factory (if any) and apply the
+/// effective smartcard flag. Smartcard-only sessions may create an empty-drive factory on demand.
+#[cfg(windows)]
+fn resolve_rdpdr_factory(
+    base: Option<&WindowsRdpdrBackendFactory>,
+    smartcard: bool,
+) -> anyhow::Result<Option<WindowsRdpdrBackendFactory>> {
+    match base {
+        Some(factory) => Ok(Some(factory.clone().with_smartcard(smartcard))),
+        None if smartcard => WindowsRdpdrBackendFactory::from_drives(Vec::new())
+            .map(|factory| factory.with_smartcard(true))
+            .map(Some)
+            .map_err(|error| anyhow::anyhow!("invalid smartcard-only rdpdr configuration: {error}")),
+        None => Ok(None),
+    }
 }
 
 #[cfg(windows)]
@@ -2331,6 +2402,43 @@ mod tests {
         let daemon = Daemon::with_rdpdr_drives(PropertySet::new(), vec![drive]).expect("valid daemon options");
 
         assert!(daemon.rdpdr_backend_factory.is_some());
+        assert!(!daemon.rdpdr_backend_factory.as_ref().expect("factory").smartcard());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn smartcard_daemon_constructs_a_factory_without_drives() {
+        let daemon = Daemon::with_options(PropertySet::new(), DaemonOptions::default().with_smartcard(true))
+            .expect("valid daemon options");
+
+        assert!(daemon.smartcard_default);
+        let factory = daemon.rdpdr_backend_factory.as_ref().expect("smartcard factory");
+        assert!(factory.smartcard());
+        assert!(factory.initial_drives().is_empty());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn smartcard_overlay_enables_factory_at_startup() {
+        use ironrdp_cfg::PropertySetExt as _;
+
+        let mut overlay = PropertySet::new();
+        overlay.set_enable_smartcard(true);
+        let daemon = Daemon::with_options(overlay, DaemonOptions::default()).expect("valid daemon options");
+
+        assert!(daemon.smartcard_default);
+        assert!(daemon.rdpdr_backend_factory.as_ref().expect("factory").smartcard());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn resolve_rdpdr_factory_creates_smartcard_only_on_demand() {
+        let factory = super::resolve_rdpdr_factory(None, true)
+            .expect("smartcard-only factory")
+            .expect("factory present");
+        assert!(factory.smartcard());
+        assert!(factory.initial_drives().is_empty());
+        assert!(super::resolve_rdpdr_factory(None, false).expect("no factory").is_none());
     }
 
     #[cfg(windows)]

--- a/crates/ironrdp-rdpdr-native/src/windows/factory.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/factory.rs
@@ -100,13 +100,17 @@ impl core::error::Error for RedirectedDriveError {}
 #[derive(Clone, Debug)]
 pub struct WindowsRdpdrBackendFactory {
     drives: Vec<RedirectedDrive>,
+    smartcard: bool,
 }
 
 impl WindowsRdpdrBackendFactory {
     /// Configures the single logical-volume root supported by this baseline.
     #[must_use]
     pub fn new(drive: RedirectedDrive) -> Self {
-        Self { drives: vec![drive] }
+        Self {
+            drives: vec![drive],
+            smartcard: false,
+        }
     }
 
     /// Configures the logical-volume roots selected for one connection.
@@ -118,7 +122,27 @@ impl WindowsRdpdrBackendFactory {
             }
         }
 
-        Ok(Self { drives })
+        Ok(Self {
+            drives,
+            smartcard: false,
+        })
+    }
+
+    /// Enables or disables WinSCard smartcard redirection for products using this factory.
+    ///
+    /// The portable channel still announces the smartcard device through
+    /// [`ironrdp_rdpdr::Rdpdr::with_smartcard`] / the client builder. Keep both sides aligned:
+    /// never announce a smartcard device without attaching a factory built with `true`.
+    #[must_use]
+    pub fn with_smartcard(mut self, enabled: bool) -> Self {
+        self.smartcard = enabled;
+        self
+    }
+
+    /// Returns whether products requested WinSCard smartcard redirection on this factory.
+    #[must_use]
+    pub fn smartcard(&self) -> bool {
+        self.smartcard
     }
 
     /// Returns the initial `(device_id, name)` pair for `Rdpdr::with_drives`.
@@ -212,6 +236,16 @@ mod tests {
             factory.initial_drives(),
             vec![(1, "System".to_owned()), (2, "Data".to_owned())]
         );
+    }
+
+    #[test]
+    fn factory_tracks_smartcard_enablement() {
+        let factory = WindowsRdpdrBackendFactory::from_drives(Vec::new())
+            .expect("empty drive list is valid")
+            .with_smartcard(true);
+        assert!(factory.smartcard());
+        assert!(factory.initial_drives().is_empty());
+        assert!(!factory.with_smartcard(false).smartcard());
     }
 
     #[test]

--- a/crates/ironrdp-rdpdr-native/src/windows/factory.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/factory.rs
@@ -128,11 +128,14 @@ impl WindowsRdpdrBackendFactory {
         })
     }
 
-    /// Enables or disables WinSCard smartcard redirection for products using this factory.
+    /// Records whether products intend WinSCard smartcard redirection with this factory.
     ///
-    /// The portable channel still announces the smartcard device through
-    /// [`ironrdp_rdpdr::Rdpdr::with_smartcard`] / the client builder. Keep both sides aligned:
-    /// never announce a smartcard device without attaching a factory built with `true`.
+    /// This is product configuration state used when cloning or resolving factories (for example
+    /// smartcard-only sessions with an empty drive list). The Windows backend always includes a
+    /// `ScardSession`; MS-RDPESC IRPs only arrive after the portable channel announces the device
+    /// via [`ironrdp_rdpdr::Rdpdr::with_smartcard`] / the client builder. Products must keep that
+    /// announcement aligned with this flag and must not attach an empty-drive factory when the flag
+    /// is `false`.
     #[must_use]
     pub fn with_smartcard(mut self, enabled: bool) -> Self {
         self.smartcard = enabled;

--- a/crates/ironrdp-viewer/Cargo.toml
+++ b/crates/ironrdp-viewer/Cargo.toml
@@ -35,6 +35,9 @@ ironrdp-cfg = { path = "../ironrdp-cfg", version = "0.1" }
 ironrdp-propertyset = { path = "../ironrdp-propertyset", version = "0.1" }
 ironrdp-rdpfile = { path = "../ironrdp-rdpfile", version = "0.1" }
 
+[target.'cfg(windows)'.dependencies]
+ironrdp-rdpdr-native = { path = "../ironrdp-rdpdr-native", version = "0.7" }
+
 # Windowing and rendering
 winit = { version = "0.30", features = ["rwh_06"] }
 softbuffer = "0.4"

--- a/crates/ironrdp-viewer/Cargo.toml
+++ b/crates/ironrdp-viewer/Cargo.toml
@@ -35,9 +35,6 @@ ironrdp-cfg = { path = "../ironrdp-cfg", version = "0.1" }
 ironrdp-propertyset = { path = "../ironrdp-propertyset", version = "0.1" }
 ironrdp-rdpfile = { path = "../ironrdp-rdpfile", version = "0.1" }
 
-[target.'cfg(windows)'.dependencies]
-ironrdp-rdpdr-native = { path = "../ironrdp-rdpdr-native", version = "0.7" }
-
 # Windowing and rendering
 winit = { version = "0.30", features = ["rwh_06"] }
 softbuffer = "0.4"
@@ -62,6 +59,9 @@ tap = "1"
 semver = "1"
 raw-window-handle = "0.6"
 url = "2"
+
+[target.'cfg(windows)'.dependencies]
+ironrdp-rdpdr-native = { path = "../ironrdp-rdpdr-native", version = "0.7" }
 
 [lints]
 workspace = true

--- a/crates/ironrdp-viewer/README.md
+++ b/crates/ironrdp-viewer/README.md
@@ -24,6 +24,9 @@ You can provide the hostname and credentials through environment variables inste
 RDP_HOSTNAME=<HOSTNAME> RDP_USERNAME=<USERNAME> RDP_PASSWORD=<PASSWORD> ironrdp-viewer
 ```
 
+On Windows, pass `--smartcard` (or set `ironrdp_smartcard:i:1` in a `.rdp` file) to redirect local smart cards through WinSCard.
+RPC mode (`--rpc`) enables smartcard the same way via agent connect properties (`ironrdp_smartcard` / sandbox `SmartCardRedirection`).
+
 ## Agent RPC host
 
 The viewer can host the same local RPC protocol used by `ironrdp-agent`, while keeping its visible
@@ -62,6 +65,7 @@ Currently supported properties:
 - `alternate shell:s:<value>`
 - `shell working directory:s:<value>`
 - `redirectclipboard:i:<0|1>`
+- `ironrdp_smartcard:i:<0|1>` (Windows WinSCard smartcard redirection)
 - `audiomode:i:<0|1|2>`
 - `desktopwidth:i:<value>`
 - `desktopheight:i:<value>`

--- a/crates/ironrdp-viewer/src/cli.rs
+++ b/crates/ironrdp-viewer/src/cli.rs
@@ -244,6 +244,13 @@ struct Args {
     /// or passed back via `--rdp-file` on the next invocation.
     #[clap(long)]
     dump_rdp: Option<PathBuf>,
+
+    /// Enable Windows WinSCard smartcard redirection (sets `ironrdp_smartcard`).
+    ///
+    /// On Windows this attaches the native RDPDR backend so smartcard IRPs complete via WinSCard.
+    /// Ignored on other platforms except for the property value itself.
+    #[clap(long)]
+    smartcard: bool,
 }
 
 /// Result of parsing CLI args + loading the `.rdp` file: a configured [`ConfigBuilder`] plus the
@@ -310,9 +317,17 @@ impl ViewerConfig {
         // resolved against this when applied below.
         let redirect_clipboard = properties.redirect_clipboard().unwrap_or(true);
         let redirect_webauthn = properties.redirect_webauthn().unwrap_or(true);
+        // Opt-in only: the client feature default for smartcard is `true`, which must not silently
+        // attach a WinSCard backend. Require CLI `--smartcard` or an explicit property.
+        let enable_smartcard = args.smartcard || properties.enable_smartcard().unwrap_or(false);
 
         // CLI arguments take precedence: apply them on top of the `.rdp`-derived builder.
-        let builder = apply_cli_to_builder(builder, args, redirect_clipboard, redirect_webauthn);
+        let mut builder = apply_cli_to_builder(builder, args, redirect_clipboard, redirect_webauthn);
+        builder = if enable_smartcard {
+            builder.with_rdpdr(true).with_smartcard(true)
+        } else {
+            builder.with_smartcard(false)
+        };
 
         Ok(Self {
             builder,

--- a/crates/ironrdp-viewer/src/main.rs
+++ b/crates/ironrdp-viewer/src/main.rs
@@ -43,7 +43,11 @@ fn main() -> anyhow::Result<()> {
         u32::from(config.connector().desktop_size.height),
     );
 
+    #[cfg(windows)]
+    let enable_smartcard = config.channels().rdpdr.smartcard;
     let client = RdpClient::new(config, output_event_sender);
+    #[cfg(windows)]
+    let client = attach_windows_rdpdr_backend(client, enable_smartcard)?;
     let input_event_sender = client.input_sender();
 
     let mut app =
@@ -141,6 +145,22 @@ fn run_rpc(cli: ViewerConfig) -> anyhow::Result<()> {
     event_loop_result?;
     server_result?;
     Ok(())
+}
+
+/// Attaches the Windows RDPDR backend when smartcard redirection is enabled.
+///
+/// Drive redirection is not yet exposed on the viewer CLI; smartcard-only sessions use an
+/// empty drive list with WinSCard enabled.
+#[cfg(windows)]
+fn attach_windows_rdpdr_backend(client: RdpClient, enable_smartcard: bool) -> anyhow::Result<RdpClient> {
+    if !enable_smartcard {
+        return Ok(client);
+    }
+
+    let factory = ironrdp_rdpdr_native::WindowsRdpdrBackendFactory::from_drives(Vec::new())
+        .map_err(|error| anyhow::anyhow!("invalid smartcard-only rdpdr configuration: {error}"))?
+        .with_smartcard(true);
+    Ok(client.with_rdpdr_backend_factory(Box::new(factory)))
 }
 
 fn setup_logging(log_file: Option<&str>) -> anyhow::Result<()> {


### PR DESCRIPTION
Wire daemon, agent, viewer, and ActiveX to the WinSCard RDPDR backend so products can announce a smartcard device only with a matching factory.

Expose `WindowsRdpdrBackendFactory::with_smartcard`, daemon/agent `--smartcard` and `ironrdp_smartcard` connect overrides, viewer `--smartcard`, and ActiveX `RedirectSmartCards`. Smartcard-only RDPDR is valid on Windows; non-Windows paths refuse or hard-disable enablement.

Enablement:
- daemon/agent: `daemon-start --smartcard`, overlay/connect `ironrdp_smartcard:i:1`, or sandbox `SmartCardRedirection` (`i:0` disables per session)
- viewer: `--smartcard` or `.rdp` `ironrdp_smartcard:i:1` (attaches empty-drive WinSCard factory on Windows)
- ActiveX: `AdvancedSettings.RedirectSmartCards` (honors `DisableRdpdr`)

Size gate: counted add+del in `.rs`/`.toml` = 324 (size/M).