### PR TITLE
feat(graphics): decode RFX Progressive tiles

### DIFF
--- a/crates/ironrdp-egfx/src/client.rs
+++ b/crates/ironrdp-egfx/src/client.rs
@@ -58,6 +58,7 @@ use std::collections::BTreeMap;
 use ironrdp_core::{Decode as _, ReadCursor, impl_as_any};
 use ironrdp_dvc::{DvcClientProcessor, DvcMessage, DvcProcessor};
 use ironrdp_graphics::clearcodec::ClearCodecDecoder;
+use ironrdp_graphics::progressive::ProgressiveDecoder;
 use ironrdp_graphics::rdp6::BitmapStreamDecoder;
 use ironrdp_graphics::zgfx;
 use ironrdp_pdu::geometry::ExclusiveRectangle;
@@ -185,7 +186,7 @@ impl CodecCapabilities {
 /// Decoded bitmap data for a surface region
 ///
 /// Delivered to [`GraphicsPipelineHandler::on_bitmap_updated`] when
-/// a `WireToSurface1` PDU is processed with decoded pixel data.
+/// a `WireToSurface1` or `WireToSurface2` PDU is processed with decoded pixel data.
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct BitmapUpdate {
@@ -193,7 +194,9 @@ pub struct BitmapUpdate {
     pub surface_id: u16,
     /// Destination rectangle within the surface (exclusive `right`/`bottom`)
     pub destination_rectangle: ExclusiveRectangle,
-    /// Codec that produced this update
+    /// Codec associated with this update
+    ///
+    /// RFX Progressive tiles use [`Codec1Type::Uncompressed`] after decoding to RGBA.
     pub codec_id: Codec1Type,
     /// RGBA pixel data (4 bytes per pixel), row-major
     ///
@@ -338,11 +341,13 @@ pub trait GraphicsPipelineHandler: Send {
     /// [MS-RDPEGFX 2.2.2.23]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpegfx/22fc0ec7-38ce-4d9d-ad6d-93a0e9f3c38c
     fn on_map_surface_to_scaled_window(&mut self, _pdu: &MapSurfaceToScaledWindowPdu) {}
 
-    /// Called for progressive codec (RFX Progressive) bitmap data
+    /// Called when the server sends an RFX Progressive bitmap PDU
     ///
-    /// Per [MS-RDPEGFX 3.3.5.3].
+    /// Implement [`GraphicsPipelineHandler::on_bitmap_updated`] to render its decoded tiles.
     ///
-    /// [MS-RDPEGFX 3.3.5.3]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpegfx/e6dbb3a7-3de0-44a5-a1ee-9de90f75e7e0
+    /// Per [MS-RDPEGFX 3.3.5.2].
+    ///
+    /// [MS-RDPEGFX 3.3.5.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpegfx/9791fc34-7644-4279-844f-7728ae9959c2
     fn on_wire_to_surface2(&mut self, _pdu: &WireToSurface2Pdu) {}
 
     /// Called when the server deletes a progressive encoding context
@@ -387,7 +392,7 @@ enum ClientState {
 /// Client for the Graphics Pipeline Virtual Channel (EGFX)
 ///
 /// This client handles capability negotiation, surface tracking,
-/// H.264 AVC420 decode, and frame acknowledgment per [MS-RDPEGFX].
+/// H.264 AVC420 and RFX Progressive decode, and frame acknowledgment per [MS-RDPEGFX].
 ///
 /// [MS-RDPEGFX]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpegfx/da5c75f9-cd99-450c-98c4-014a496942b0
 pub struct GraphicsPipelineClient {
@@ -395,6 +400,7 @@ pub struct GraphicsPipelineClient {
     h264_decoder: Option<Box<dyn H264Decoder>>,
     clearcodec_decoder: ClearCodecDecoder,
     planar_decoder: BitmapStreamDecoder,
+    progressive_decoder: ProgressiveDecoder,
 
     decompressor: zgfx::Decompressor,
     decompressed_buffer: Vec<u8>,
@@ -421,6 +427,7 @@ impl GraphicsPipelineClient {
             h264_decoder,
             clearcodec_decoder: ClearCodecDecoder::new(),
             planar_decoder: BitmapStreamDecoder::default(),
+            progressive_decoder: ProgressiveDecoder::new(),
             decompressor: zgfx::Decompressor::new(),
             decompressed_buffer: Vec::new(),
             state: ClientState::WaitingForConfirm,
@@ -519,6 +526,7 @@ impl GraphicsPipelineClient {
             GfxPdu::WireToSurface2(pdu) => {
                 trace!("WireToSurface2 (progressive codec)");
                 self.handler.on_wire_to_surface2(&pdu);
+                self.handle_wire_to_surface2(pdu)?;
                 Ok(vec![])
             }
             GfxPdu::EndFrame(end) => self.handle_end_frame(end.frame_id),
@@ -610,6 +618,8 @@ impl GraphicsPipelineClient {
                     codec_context_id = pdu.codec_context_id,
                     "DeleteEncodingContext"
                 );
+                self.progressive_decoder
+                    .delete_context(pdu.surface_id, pdu.codec_context_id);
                 self.handler.on_delete_encoding_context(&pdu);
                 Ok(vec![])
             }
@@ -675,6 +685,7 @@ impl GraphicsPipelineClient {
         if let Some(ref mut decoder) = self.h264_decoder {
             decoder.reset();
         }
+        self.progressive_decoder.reset();
         // The ClearCodec decoder is deliberately NOT reset here. MS-RDPEGFX 3.3.5.14 only
         // resizes the Graphics Output Buffer; cache lifetime is driven by the stream instead,
         // through CLEARCODEC_FLAG_CACHE_RESET (2.2.4.1), which ClearCodecDecoder::decode
@@ -709,6 +720,7 @@ impl GraphicsPipelineClient {
     }
 
     fn handle_delete_surface(&mut self, surface_id: u16) {
+        self.progressive_decoder.delete_surface(surface_id);
         if self.surfaces.remove(&surface_id).is_some() {
             self.compositor.delete_surface(surface_id);
             debug!(surface_id, "Surface deleted");
@@ -785,6 +797,65 @@ impl GraphicsPipelineClient {
                 trace!(codec_id = ?pdu.codec_id, "Forwarding unsupported codec to handler");
                 self.handler.on_unhandled_pdu(&GfxPdu::WireToSurface1(pdu));
             }
+        }
+
+        Ok(())
+    }
+
+    /// Decode RemoteFX Progressive bitmap data, applying each decoded tile to the
+    /// persistent surface before delivering the same RGBA update to the handler.
+    fn handle_wire_to_surface2(&mut self, pdu: WireToSurface2Pdu) -> PduResult<()> {
+        let surface = self
+            .surfaces
+            .get(&pdu.surface_id)
+            .ok_or_else(|| pdu_other_err!("unknown surface in WireToSurface2"))?;
+        let (surface_width, surface_height) = (surface.width, surface.height);
+
+        let tiles = self
+            .progressive_decoder
+            .decode_bitmap(
+                pdu.surface_id,
+                pdu.codec_context_id,
+                surface_width,
+                surface_height,
+                &pdu.bitmap_data,
+            )
+            .map_err(|error| {
+                warn!(?error, "rfx progressive decode failed");
+                pdu_other_err!("rfx progressive decode failed")
+            })?;
+
+        for tile in tiles {
+            let left = tile.x_idx.saturating_mul(64);
+            let top = tile.y_idx.saturating_mul(64);
+            let width = surface_width.saturating_sub(left).min(64);
+            let height = surface_height.saturating_sub(top).min(64);
+            if width == 0 || height == 0 {
+                continue;
+            }
+
+            let data = if width == 64 && height == 64 {
+                tile.pixels
+            } else {
+                crop_decoded_frame(&tile.pixels, 64, 64, width, height)
+            };
+            let update = BitmapUpdate {
+                surface_id: pdu.surface_id,
+                destination_rectangle: ExclusiveRectangle {
+                    left,
+                    top,
+                    right: left + width,
+                    bottom: top + height,
+                },
+                codec_id: Codec1Type::Uncompressed,
+                data,
+                width,
+                height,
+            };
+
+            self.compositor
+                .apply_bitmap(update.surface_id, &update.destination_rectangle, &update.data);
+            self.handler.on_bitmap_updated(&update);
         }
 
         Ok(())
@@ -1407,5 +1478,278 @@ mod tests {
                 .any(|cap| CodecCapabilities::from_capability_set(cap).avc420),
             "no advertised set enables AVC420"
         );
+    }
+
+    fn progressive_client() -> GraphicsPipelineClient {
+        let mut client = GraphicsPipelineClient::new(Box::new(TestHandler), None);
+        client
+            .handle_pdu(GfxPdu::ResetGraphics(crate::pdu::ResetGraphicsPdu {
+                width: 64,
+                height: 64,
+                monitors: vec![],
+            }))
+            .unwrap();
+        client
+            .handle_pdu(GfxPdu::CreateSurface(crate::pdu::CreateSurfacePdu {
+                surface_id: 1,
+                width: 64,
+                height: 64,
+                pixel_format: PixelFormat::XRgb,
+            }))
+            .unwrap();
+        client
+    }
+
+    fn wire_progressive(client: &mut GraphicsPipelineClient, bitmap_data: Vec<u8>) -> PduResult<Vec<DvcMessage>> {
+        client.handle_pdu(GfxPdu::WireToSurface2(WireToSurface2Pdu {
+            surface_id: 1,
+            codec_id: crate::pdu::Codec2Type::RemoteFxProgressive,
+            codec_context_id: 7,
+            pixel_format: PixelFormat::XRgb,
+            bitmap_data,
+        }))
+    }
+
+    fn progressive_context_stream(with_context: bool) -> Vec<u8> {
+        use ironrdp_pdu::codecs::rfx::RfxRectangle;
+        use ironrdp_pdu::codecs::rfx::progressive::{
+            ProgressiveBlock, ProgressiveContextPdu, ProgressiveFrameBeginPdu, ProgressiveFrameEndPdu,
+            ProgressiveRegion, ProgressiveSyncPdu, encode_progressive_stream,
+        };
+
+        let mut blocks = Vec::new();
+        if with_context {
+            blocks.push(ProgressiveBlock::Sync(ProgressiveSyncPdu));
+            blocks.push(ProgressiveBlock::Context(ProgressiveContextPdu {
+                context_id: 0,
+                tile_size: 0x0040,
+                flags: 0,
+            }));
+        }
+        blocks.push(ProgressiveBlock::FrameBegin(ProgressiveFrameBeginPdu {
+            frame_index: 0,
+            region_count: 1,
+        }));
+        blocks.push(ProgressiveBlock::Region(ProgressiveRegion {
+            tile_size: 0x40,
+            rects: vec![RfxRectangle {
+                x: 0,
+                y: 0,
+                width: 64,
+                height: 64,
+            }],
+            quant_vals: vec![],
+            quant_prog_vals: vec![],
+            flags: 0,
+            tiles: vec![],
+        }));
+        blocks.push(ProgressiveBlock::FrameEnd(ProgressiveFrameEndPdu));
+
+        encode_progressive_stream(&blocks).unwrap()
+    }
+
+    fn progressive_tile_stream(tile_x: u16, tile_y: u16, rect_width: u16, rect_height: u16) -> Vec<u8> {
+        use ironrdp_graphics::progressive::{COEFFICIENTS_PER_COMPONENT, encode_first_pass};
+        use ironrdp_pdu::codecs::rfx::RfxRectangle;
+        use ironrdp_pdu::codecs::rfx::progressive::{
+            ComponentCodecQuant, ProgressiveBlock, ProgressiveContextPdu, ProgressiveFrameBeginPdu,
+            ProgressiveFrameEndPdu, ProgressiveRegion, ProgressiveSyncPdu, ProgressiveTile, TileSimple,
+            encode_progressive_stream,
+        };
+
+        let base_quant = ComponentCodecQuant::LOSSLESS;
+        let mut component = [0i16; COEFFICIENTS_PER_COMPONENT];
+        let mut component_data = [0u8; 8192];
+        let component_len = encode_first_pass(
+            &mut component,
+            &mut component_data,
+            &base_quant,
+            &ComponentCodecQuant::LOSSLESS,
+            false,
+        )
+        .unwrap();
+        let component_data = &component_data[..component_len];
+
+        encode_progressive_stream(&[
+            ProgressiveBlock::Sync(ProgressiveSyncPdu),
+            ProgressiveBlock::Context(ProgressiveContextPdu {
+                context_id: 0,
+                tile_size: 0x0040,
+                flags: 0,
+            }),
+            ProgressiveBlock::FrameBegin(ProgressiveFrameBeginPdu {
+                frame_index: 0,
+                region_count: 1,
+            }),
+            ProgressiveBlock::Region(ProgressiveRegion {
+                tile_size: 0x40,
+                rects: vec![RfxRectangle {
+                    x: tile_x.saturating_mul(64),
+                    y: tile_y.saturating_mul(64),
+                    width: rect_width,
+                    height: rect_height,
+                }],
+                quant_vals: vec![base_quant],
+                quant_prog_vals: vec![],
+                flags: 0,
+                tiles: vec![ProgressiveTile::Simple(TileSimple {
+                    quant_idx_y: 0,
+                    quant_idx_cb: 0,
+                    quant_idx_cr: 0,
+                    x_idx: tile_x,
+                    y_idx: tile_y,
+                    flags: 0,
+                    y_data: component_data,
+                    cb_data: component_data,
+                    cr_data: component_data,
+                    tail_data: &[],
+                })],
+            }),
+            ProgressiveBlock::FrameEnd(ProgressiveFrameEndPdu),
+        ])
+        .unwrap()
+    }
+
+    #[test]
+    fn wire_to_surface2_renders_and_crops_progressive_edge_tile() {
+        let updates = Arc::new(Mutex::new(Vec::new()));
+        let unhandled = Arc::new(Mutex::new(0));
+        let mut client = GraphicsPipelineClient::new(
+            Box::new(CapturingHandler {
+                updates: Arc::clone(&updates),
+                unhandled,
+            }),
+            None,
+        );
+        client
+            .handle_pdu(GfxPdu::ResetGraphics(crate::pdu::ResetGraphicsPdu {
+                width: 100,
+                height: 100,
+                monitors: vec![],
+            }))
+            .unwrap();
+        client
+            .handle_pdu(GfxPdu::CreateSurface(crate::pdu::CreateSurfacePdu {
+                surface_id: 1,
+                width: 100,
+                height: 100,
+                pixel_format: PixelFormat::XRgb,
+            }))
+            .unwrap();
+        client
+            .handle_pdu(GfxPdu::MapSurfaceToOutput(crate::pdu::MapSurfaceToOutputPdu {
+                surface_id: 1,
+                output_origin_x: 0,
+                output_origin_y: 0,
+            }))
+            .unwrap();
+        client
+            .handle_pdu(GfxPdu::StartFrame(crate::pdu::StartFramePdu {
+                timestamp: crate::pdu::Timestamp {
+                    milliseconds: 0,
+                    seconds: 0,
+                    minutes: 0,
+                    hours: 0,
+                },
+                frame_id: 1,
+            }))
+            .unwrap();
+        client
+            .handle_pdu(GfxPdu::EndFrame(crate::pdu::EndFramePdu { frame_id: 1 }))
+            .unwrap();
+        let _ = client.drain_output();
+        client
+            .handle_pdu(GfxPdu::StartFrame(crate::pdu::StartFramePdu {
+                timestamp: crate::pdu::Timestamp {
+                    milliseconds: 0,
+                    seconds: 0,
+                    minutes: 0,
+                    hours: 0,
+                },
+                frame_id: 2,
+            }))
+            .unwrap();
+        wire_progressive(&mut client, progressive_tile_stream(1, 1, 36, 36)).unwrap();
+        client
+            .handle_pdu(GfxPdu::EndFrame(crate::pdu::EndFramePdu { frame_id: 2 }))
+            .unwrap();
+
+        let updates = updates.lock().expect("updates lock");
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0].0, Codec1Type::Uncompressed);
+        assert_eq!(updates[0].1, 36);
+        assert_eq!(updates[0].2, 36);
+        assert_eq!(updates[0].3.len(), 36 * 36 * 4);
+        assert!(updates[0].3.iter().any(|&pixel| pixel != 0));
+
+        let output = client.drain_output();
+        assert_eq!(output.len(), 1);
+        assert_eq!(
+            output[0].region,
+            ExclusiveRectangle {
+                left: 64,
+                top: 64,
+                right: 100,
+                bottom: 100,
+            }
+        );
+        assert_eq!(output[0].data.len(), 36 * 36 * 4);
+    }
+
+    fn assert_progressive_context_is_deleted(clear: impl FnOnce(&mut GraphicsPipelineClient)) {
+        let mut client = progressive_client();
+        wire_progressive(&mut client, progressive_context_stream(true)).unwrap();
+        clear(&mut client);
+        assert!(wire_progressive(&mut client, progressive_context_stream(false)).is_err());
+    }
+
+    #[test]
+    fn progressive_context_is_reset_with_graphics() {
+        assert_progressive_context_is_deleted(|client| {
+            client
+                .handle_pdu(GfxPdu::ResetGraphics(crate::pdu::ResetGraphicsPdu {
+                    width: 64,
+                    height: 64,
+                    monitors: vec![],
+                }))
+                .unwrap();
+            client
+                .handle_pdu(GfxPdu::CreateSurface(crate::pdu::CreateSurfacePdu {
+                    surface_id: 1,
+                    width: 64,
+                    height: 64,
+                    pixel_format: PixelFormat::XRgb,
+                }))
+                .unwrap();
+        });
+    }
+
+    #[test]
+    fn progressive_context_is_deleted_with_encoding_context() {
+        assert_progressive_context_is_deleted(|client| {
+            client
+                .handle_pdu(GfxPdu::DeleteEncodingContext(DeleteEncodingContextPdu {
+                    surface_id: 1,
+                    codec_context_id: 7,
+                }))
+                .unwrap();
+        });
+    }
+
+    #[test]
+    fn progressive_context_is_deleted_with_surface() {
+        assert_progressive_context_is_deleted(|client| {
+            client
+                .handle_pdu(GfxPdu::DeleteSurface(crate::pdu::DeleteSurfacePdu { surface_id: 1 }))
+                .unwrap();
+            client
+                .handle_pdu(GfxPdu::CreateSurface(crate::pdu::CreateSurfacePdu {
+                    surface_id: 1,
+                    width: 64,
+                    height: 64,
+                    pixel_format: PixelFormat::XRgb,
+                }))
+                .unwrap();
+        });
     }
 }

--- a/crates/ironrdp-egfx/src/compositor.rs
+++ b/crates/ironrdp-egfx/src/compositor.rs
@@ -3,7 +3,7 @@
 //! MS-RDPEGFX surfaces are persistent pixel canvases: the server creates them,
 //! writes decoded bitmaps into sub-rectangles, fills and scrolls regions, caches
 //! tiles, and maps surfaces onto the graphics output. A client that only decodes
-//! `WireToSurface1` bitmaps and forwards the remaining surface commands renders
+//! `WireToSurface1` or `WireToSurface2` bitmaps and forwards the remaining surface commands renders
 //! incorrectly against any server that uses them (GNOME Remote Desktop and
 //! Windows both do).
 //!
@@ -245,7 +245,7 @@ impl Compositor {
     }
 
     /// Write a decoded RGBA8888 bitmap into a surface sub-rectangle (the output of
-    /// a `WireToSurface1` decode) and record the resulting output delta.
+    /// a `WireToSurface1` or `WireToSurface2` decode) and record the resulting output delta.
     ///
     /// `rgba` is expected to be `dest.width() * dest.height() * 4` bytes; short or
     /// long buffers are handled defensively by the row-wise blit.

--- a/crates/ironrdp-graphics/src/progressive.rs
+++ b/crates/ironrdp-graphics/src/progressive.rs
@@ -1102,16 +1102,19 @@ impl From<RlgrError> for ProgressiveDecodeError {
     }
 }
 
-/// Per-context progressive state, identified by codec_context_id.
+/// Per-context progressive state, identified by `(surface_id, codec_context_id)`.
 struct ProgressiveContext {
     surface: SurfaceTiles,
 }
 
 /// High-level progressive bitmap decoder for EGFX WireToSurface2 processing.
 ///
-/// Maintains per-context tile state across frames, keyed by `codec_context_id`.
-/// Feed it progressive bitmap data from `WireToSurface2Pdu.bitmap_data` and
-/// get back decoded RGBA tiles for compositing.
+/// Maintains per-context tile state across frames, keyed by
+/// `(surface_id, codec_context_id)`.
+/// MS-RDPEGFX section 3.3.5.3 associates each codec context with a surface, so
+/// two surfaces can reuse a codec context ID without sharing tile state.
+/// Feed it progressive bitmap data from `WireToSurface2Pdu.bitmap_data` and get
+/// back decoded RGBA tiles for compositing.
 ///
 /// # Usage
 ///
@@ -1120,6 +1123,7 @@ struct ProgressiveContext {
 ///
 /// // On receiving WireToSurface2Pdu:
 /// let tiles = decoder.decode_bitmap(
+///     pdu.surface_id,
 ///     pdu.codec_context_id,
 ///     surface_width, surface_height,
 ///     &pdu.bitmap_data,
@@ -1130,7 +1134,7 @@ struct ProgressiveContext {
 /// }
 /// ```
 pub struct ProgressiveDecoder {
-    contexts: BTreeMap<u32, ProgressiveContext>,
+    contexts: BTreeMap<(u16, u32), ProgressiveContext>,
 }
 
 impl ProgressiveDecoder {
@@ -1147,12 +1151,14 @@ impl ProgressiveDecoder {
     /// returns RGBA pixel data for each tile that was updated.
     ///
     /// # Arguments
+    /// - `surface_id`: surface ID from the WireToSurface2Pdu
     /// - `codec_context_id`: context ID from the WireToSurface2Pdu
     /// - `surface_width`: surface width in pixels (for tile grid sizing)
     /// - `surface_height`: surface height in pixels
     /// - `bitmap_data`: raw progressive block stream from the PDU
     pub fn decode_bitmap(
         &mut self,
+        surface_id: u16,
         codec_context_id: u32,
         surface_width: u16,
         surface_height: u16,
@@ -1182,13 +1188,13 @@ impl ProgressiveDecoder {
             Some(v) => v,
             None => self
                 .contexts
-                .get(&codec_context_id)
+                .get(&(surface_id, codec_context_id))
                 .map(|c| c.surface.use_reduce_extrapolate)
                 .ok_or(ProgressiveDecodeError::MissingBlock("CONTEXT"))?,
         };
 
-        // Get or create the context for this codec_context_id
-        let context = match self.contexts.entry(codec_context_id) {
+        // Get or create the context for this (surface_id, codec_context_id).
+        let context = match self.contexts.entry((surface_id, codec_context_id)) {
             Entry::Occupied(e) => e.into_mut(),
             Entry::Vacant(e) => {
                 let surface = SurfaceTiles::new(surface_width, surface_height, use_reduce_extrapolate)?;
@@ -1233,9 +1239,19 @@ impl ProgressiveDecoder {
 
     /// Delete a codec context, freeing its tile state.
     ///
-    /// Called when the server sends RDPGFX_DELETE_ENCODING_CONTEXT.
-    pub fn delete_context(&mut self, codec_context_id: u32) {
-        self.contexts.remove(&codec_context_id);
+    /// Called when the server sends RDPGFX_DELETE_ENCODING_CONTEXT, which
+    /// identifies both the surface and codec context.
+    pub fn delete_context(&mut self, surface_id: u16, codec_context_id: u32) {
+        self.contexts.remove(&(surface_id, codec_context_id));
+    }
+
+    /// Delete every codec context associated with a surface.
+    ///
+    /// Call this when discarding a surface so a subsequent surface with the
+    /// same ID cannot inherit stale Progressive tile state.
+    pub fn delete_surface(&mut self, surface_id: u16) {
+        self.contexts
+            .retain(|(context_surface_id, _), _| *context_surface_id != surface_id);
     }
 
     /// Reset all contexts (e.g., on EGFX channel reset).
@@ -1389,6 +1405,44 @@ impl Default for ProgressiveDecoder {
 #[expect(clippy::as_conversions, clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 mod tests {
     use super::*;
+
+    fn minimal_progressive_stream() -> Vec<u8> {
+        use ironrdp_pdu::codecs::rfx::RfxRectangle;
+        use ironrdp_pdu::codecs::rfx::progressive::{
+            ProgressiveBlock, ProgressiveContextPdu, ProgressiveFrameBeginPdu, ProgressiveFrameEndPdu,
+            ProgressiveRegion, ProgressiveSyncPdu, encode_progressive_stream,
+        };
+
+        let region = ProgressiveRegion {
+            tile_size: 0x40,
+            rects: vec![RfxRectangle {
+                x: 0,
+                y: 0,
+                width: 64,
+                height: 64,
+            }],
+            quant_vals: vec![],
+            quant_prog_vals: vec![],
+            flags: 0,
+            tiles: vec![],
+        };
+        let blocks = [
+            ProgressiveBlock::Sync(ProgressiveSyncPdu),
+            ProgressiveBlock::Context(ProgressiveContextPdu {
+                context_id: 0,
+                tile_size: 0x0040,
+                flags: 0,
+            }),
+            ProgressiveBlock::FrameBegin(ProgressiveFrameBeginPdu {
+                frame_index: 0,
+                region_count: 1,
+            }),
+            ProgressiveBlock::Region(region),
+            ProgressiveBlock::FrameEnd(ProgressiveFrameEndPdu),
+        ];
+
+        encode_progressive_stream(&blocks).unwrap()
+    }
 
     #[test]
     fn surface_tiles_rejects_over_cap_dimensions() {
@@ -1685,56 +1739,41 @@ mod tests {
     fn decoder_delete_nonexistent_context() {
         let mut decoder = ProgressiveDecoder::new();
         // Should not panic on non-existent context
-        decoder.delete_context(42);
+        decoder.delete_context(1, 42);
     }
 
     #[test]
     fn decoder_reset_clears_contexts() {
         let mut decoder = ProgressiveDecoder::new();
 
-        // Decode a minimal valid stream to create a context
-        use ironrdp_pdu::codecs::rfx::RfxRectangle;
-        use ironrdp_pdu::codecs::rfx::progressive::{
-            ProgressiveBlock, ProgressiveContextPdu, ProgressiveFrameBeginPdu, ProgressiveFrameEndPdu,
-            ProgressiveRegion, ProgressiveSyncPdu, encode_progressive_stream,
-        };
-
-        let region = ProgressiveRegion {
-            tile_size: 0x40,
-            rects: vec![RfxRectangle {
-                x: 0,
-                y: 0,
-                width: 64,
-                height: 64,
-            }],
-            quant_vals: vec![],
-            quant_prog_vals: vec![],
-            flags: 0,
-            tiles: vec![],
-        };
-
-        let blocks = vec![
-            ProgressiveBlock::Sync(ProgressiveSyncPdu),
-            ProgressiveBlock::Context(ProgressiveContextPdu {
-                context_id: 0,
-                tile_size: 0x0040,
-                flags: 0,
-            }),
-            ProgressiveBlock::FrameBegin(ProgressiveFrameBeginPdu {
-                frame_index: 0,
-                region_count: 1,
-            }),
-            ProgressiveBlock::Region(region),
-            ProgressiveBlock::FrameEnd(ProgressiveFrameEndPdu),
-        ];
-
-        let encoded = encode_progressive_stream(&blocks).unwrap();
-        let result = decoder.decode_bitmap(1, 640, 480, &encoded);
+        let result = decoder.decode_bitmap(1, 1, 640, 480, &minimal_progressive_stream());
         assert!(result.is_ok());
         assert_eq!(decoder.contexts.len(), 1);
 
         decoder.reset();
         assert!(decoder.contexts.is_empty());
+    }
+
+    #[test]
+    fn decoder_contexts_are_scoped_by_surface() {
+        let mut decoder = ProgressiveDecoder::new();
+
+        let stream = minimal_progressive_stream();
+        assert!(decoder.decode_bitmap(1, 0, 640, 480, &stream).is_ok());
+        assert!(decoder.decode_bitmap(2, 0, 800, 600, &stream).is_ok());
+        assert_eq!(decoder.contexts.len(), 2);
+
+        decoder.delete_context(1, 0);
+        assert_eq!(decoder.contexts.len(), 1);
+        assert!(decoder.contexts.contains_key(&(2, 0)));
+
+        assert!(decoder.decode_bitmap(1, 0, 640, 480, &stream).is_ok());
+        assert!(decoder.decode_bitmap(1, 1, 640, 480, &stream).is_ok());
+        assert_eq!(decoder.contexts.len(), 3);
+
+        decoder.delete_surface(1);
+        assert_eq!(decoder.contexts.len(), 1);
+        assert!(decoder.contexts.contains_key(&(2, 0)));
     }
 
     #[test]

--- a/crates/ironrdp-graphics/src/progressive.rs
+++ b/crates/ironrdp-graphics/src/progressive.rs
@@ -1111,7 +1111,7 @@ struct ProgressiveContext {
 ///
 /// Maintains per-context tile state across frames, keyed by
 /// `(surface_id, codec_context_id)`.
-/// MS-RDPEGFX section 3.3.5.3 associates each codec context with a surface, so
+/// MS-RDPEGFX section 3.3.1.1 associates each codec context with a surface, so
 /// two surfaces can reuse a codec context ID without sharing tile state.
 /// Feed it progressive bitmap data from `WireToSurface2Pdu.bitmap_data` and get
 /// back decoded RGBA tiles for compositing.
@@ -1170,7 +1170,8 @@ impl ProgressiveDecoder {
 
         // Extract the band-layout flag from the CONTEXT block when present.
         // Per MS-RDPEGFX 2.2.4.2 the SYNC + CONTEXT blocks establish a codec
-        // context once (keyed by `codec_context_id`) and are not required to be
+        // context once (keyed by `(surface_id, codec_context_id)`) and are not
+        // required to be
         // repeated on subsequent frames that reference the same context.
         // Real-world servers (xrdp, GNOME Remote Desktop) omit the CONTEXT
         // block on every frame after the first one that established the
@@ -1406,7 +1407,7 @@ impl Default for ProgressiveDecoder {
 mod tests {
     use super::*;
 
-    fn minimal_progressive_stream() -> Vec<u8> {
+    fn minimal_progressive_stream(include_context: bool) -> Vec<u8> {
         use ironrdp_pdu::codecs::rfx::RfxRectangle;
         use ironrdp_pdu::codecs::rfx::progressive::{
             ProgressiveBlock, ProgressiveContextPdu, ProgressiveFrameBeginPdu, ProgressiveFrameEndPdu,
@@ -1426,20 +1427,22 @@ mod tests {
             flags: 0,
             tiles: vec![],
         };
-        let blocks = [
-            ProgressiveBlock::Sync(ProgressiveSyncPdu),
-            ProgressiveBlock::Context(ProgressiveContextPdu {
+        let mut blocks = vec![ProgressiveBlock::Sync(ProgressiveSyncPdu)];
+        if include_context {
+            blocks.push(ProgressiveBlock::Context(ProgressiveContextPdu {
                 context_id: 0,
                 tile_size: 0x0040,
                 flags: 0,
-            }),
+            }));
+        }
+        blocks.extend([
             ProgressiveBlock::FrameBegin(ProgressiveFrameBeginPdu {
                 frame_index: 0,
                 region_count: 1,
             }),
             ProgressiveBlock::Region(region),
             ProgressiveBlock::FrameEnd(ProgressiveFrameEndPdu),
-        ];
+        ]);
 
         encode_progressive_stream(&blocks).unwrap()
     }
@@ -1746,7 +1749,7 @@ mod tests {
     fn decoder_reset_clears_contexts() {
         let mut decoder = ProgressiveDecoder::new();
 
-        let result = decoder.decode_bitmap(1, 1, 640, 480, &minimal_progressive_stream());
+        let result = decoder.decode_bitmap(1, 1, 640, 480, &minimal_progressive_stream(true));
         assert!(result.is_ok());
         assert_eq!(decoder.contexts.len(), 1);
 
@@ -1758,7 +1761,7 @@ mod tests {
     fn decoder_contexts_are_scoped_by_surface() {
         let mut decoder = ProgressiveDecoder::new();
 
-        let stream = minimal_progressive_stream();
+        let stream = minimal_progressive_stream(true);
         assert!(decoder.decode_bitmap(1, 0, 640, 480, &stream).is_ok());
         assert!(decoder.decode_bitmap(2, 0, 800, 600, &stream).is_ok());
         assert_eq!(decoder.contexts.len(), 2);
@@ -1774,6 +1777,22 @@ mod tests {
         decoder.delete_surface(1);
         assert_eq!(decoder.contexts.len(), 1);
         assert!(decoder.contexts.contains_key(&(2, 0)));
+    }
+
+    #[test]
+    fn decoder_context_fallback_is_scoped_by_surface() {
+        let mut decoder = ProgressiveDecoder::new();
+        let stream_with_context = minimal_progressive_stream(true);
+        let stream_without_context = minimal_progressive_stream(false);
+
+        assert!(decoder.decode_bitmap(1, 0, 640, 480, &stream_with_context).is_ok());
+        assert!(matches!(
+            decoder.decode_bitmap(2, 0, 640, 480, &stream_without_context),
+            Err(ProgressiveDecodeError::MissingBlock("CONTEXT"))
+        ));
+
+        assert!(decoder.decode_bitmap(2, 0, 640, 480, &stream_with_context).is_ok());
+        assert!(decoder.decode_bitmap(2, 0, 640, 480, &stream_without_context).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Keep Progressive tile state scoped to its surface and codec context.

Reject context-less updates that have no state for their surface, and expose targeted context and surface cleanup for consumers.