### PR TITLE
feat(rdpeudp): add the RDP-UDP2 data transfer PDUs and packet framing

### DIFF
--- a/crates/ironrdp-rdpeudp/src/pdu/mod.rs
+++ b/crates/ironrdp-rdpeudp/src/pdu/mod.rs
@@ -1,16 +1,17 @@
 //! RDPEUDP PDU definitions.
 //!
-//! V1 handshake format, MS-RDPEUDP section 2.2.
+//! V1 handshake format (MS-RDPEUDP Section 2.2) and
+//! V2 data transfer format (MS-RDPEUDP2 Section 2.2).
 //!
-//! These structures carry the three-way handshake (SYN, SYN+ACK, ACK) that
-//! opens an RDP-UDP connection. They are used whatever protocol version the
-//! endpoints settle on, because the version is what the handshake negotiates.
+//! The v1 format is used for the three-way handshake (SYN/SYN+ACK/ACK)
+//! even when both sides negotiate v2+ for data transfer. Once the
+//! handshake completes, all subsequent packets use the v2 wire format
+//! from MS-RDPEUDP2.
 //!
-//! Everything here is big-endian: section 2.2 says "all of the messages
-//! written to the network or read from the network MUST be in network byte
-//! order", and the field diagrams number bits most significant first. The
-//! MS-RDPEUDP2 data transfer that a version 3 handshake leads to takes the
-//! opposite convention on both counts.
+//! Types are organized by protocol version:
+//! - `v1_*` modules: MS-RDPEUDP handshake structures.
+//! - `v2_*` modules: MS-RDPEUDP2 data transfer structures.
+//! - `prefix`: PacketPrefixByte wire-level framing for v2 packets.
 
 use ironrdp_core::{Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor};
 
@@ -21,12 +22,32 @@ pub mod v1_flags;
 pub mod v1_header;
 pub mod v1_syn;
 
+// ── V2 Data Transfer modules ──
+
+pub mod v2_ack;
+pub mod v2_control;
+pub mod v2_data;
+pub mod v2_flags;
+pub mod v2_header;
+
+// ── Wire-level framing ──
+
+pub mod prefix;
+
 // ── V1 re-exports ──
 
+// ── Prefix re-exports ──
+pub use prefix::{PacketPrefixByte, PrefixError, decode_with_prefix, encode_with_prefix};
 pub use v1_ack::{CorrelationIdPayload, V1AckOfAcksHeader, V1AckVectorElement, V1AckVectorHeader, VectorElementState};
 pub use v1_flags::V1Flags;
 pub use v1_header::FecHeader;
 pub use v1_syn::{MTU_MAX, MTU_MIN, SynDataExPayload, SynDataPayload, SynExFlags, UdpVersion};
+// ── V2 re-exports ──
+pub use v2_ack::{AckPayload, AckVectorEntry, AckVectorPayload};
+pub use v2_control::{AckOfAcksPayload, DelayAckInfoPayload, OverheadSizePayload};
+pub use v2_data::{DataBody, DataHeader};
+pub use v2_flags::V2Flags;
+pub use v2_header::{LOG_WINDOW_SIZE_MAX, V2Header};
 
 // ════════════════════════════════════════════════════════════════════
 // Composite V1 Datagram
@@ -270,6 +291,244 @@ impl Decode<'_> for V1Datagram {
             syn_data,
             correlation_id,
             syn_data_ex,
+        })
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Composite V2 Packet
+// ════════════════════════════════════════════════════════════════════
+
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+/// A complete RDP-UDP2 packet (after prefix byte extraction).
+///
+/// MS-RDPEUDP2 Section 2.2.1.
+/// The V2Header's flags field determines which optional payloads
+/// are present. On encode, payload-gating flags are auto-derived;
+/// there are no standalone flags to preserve.
+///
+/// Wire payload ordering (per MS-RDPEUDP2 Section 2.2.1):
+/// 1. V2Header (mandatory, 2 bytes)
+/// 2. AckPayload (if ACK flag)
+/// 3. OverheadSizePayload (if OVERHEADSIZE flag)
+/// 4. DelayAckInfoPayload (if DELAYACKINFO flag)
+/// 5. AckOfAcksPayload (if AOA flag)
+/// 6. DataHeader (if DATA flag)
+/// 7. AckVectorPayload (if ACKVEC flag)
+/// 8. DataBody (if DATA flag), always last, extending to the end of the packet
+///
+/// Invariants:
+/// - `ack` and `ack_vector` are mutually exclusive.
+/// - `data_header` and `data_body` must be both present or both absent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct V2Packet {
+    /// Mandatory header. Only `log_window_size` is taken from this field
+    /// as given; the flags are always derived from which payloads are
+    /// present and overwrite whatever `header.flags` was set to.
+    pub header: V2Header,
+
+    /// ACK payload. Gated by `V2Flags::ACK`.
+    /// Mutually exclusive with `ack_vector`.
+    pub ack: Option<AckPayload>,
+
+    /// OverheadSize payload. Gated by `V2Flags::OVERHEADSIZE`.
+    pub overhead_size: Option<OverheadSizePayload>,
+
+    /// DelayAckInfo payload. Gated by `V2Flags::DELAYACKINFO`.
+    pub delay_ack_info: Option<DelayAckInfoPayload>,
+
+    /// AckOfAcks payload. Gated by `V2Flags::AOA`.
+    pub ack_of_acks: Option<AckOfAcksPayload>,
+
+    /// DataHeader payload. Gated by `V2Flags::DATA`.
+    /// Must be paired with `data_body`.
+    pub data_header: Option<DataHeader>,
+
+    /// AckVector payload. Gated by `V2Flags::ACKVEC`.
+    /// Mutually exclusive with `ack`.
+    pub ack_vector: Option<AckVectorPayload>,
+
+    /// DataBody payload. Gated by `V2Flags::DATA`.
+    /// Must be paired with `data_header`.
+    /// Always last in wire layout (consumes remaining bytes on decode).
+    pub data_body: Option<DataBody>,
+}
+
+impl V2Packet {
+    const NAME: &'static str = "RDP-UDP2 Packet";
+
+    /// Compute flags from populated fields.
+    ///
+    /// Every flag [MS-RDPEUDP2] 2.2.1.1 defines announces a payload, so there
+    /// is nothing to carry over from the caller's header: what is present
+    /// determines the field completely.
+    fn compute_flags(&self) -> V2Flags {
+        let mut flags = V2Flags::empty();
+
+        if self.ack.is_some() {
+            flags |= V2Flags::ACK;
+        }
+        if self.overhead_size.is_some() {
+            flags |= V2Flags::OVERHEADSIZE;
+        }
+        if self.delay_ack_info.is_some() {
+            flags |= V2Flags::DELAYACKINFO;
+        }
+        if self.ack_of_acks.is_some() {
+            flags |= V2Flags::AOA;
+        }
+        if self.data_header.is_some() {
+            flags |= V2Flags::DATA;
+        }
+        if self.ack_vector.is_some() {
+            flags |= V2Flags::ACKVEC;
+        }
+
+        flags
+    }
+}
+
+impl Encode for V2Packet {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        // Validate invariants before writing anything
+        if self.data_header.is_some() != self.data_body.is_some() {
+            return Err(ironrdp_core::invalid_field_err!(
+                "V2Packet",
+                "DATA",
+                "data_header and data_body must be both present or both absent"
+            ));
+        }
+        if self.ack.is_some() && self.ack_vector.is_some() {
+            return Err(ironrdp_core::invalid_field_err!(
+                "V2Packet",
+                "ACK/ACKVEC",
+                "ACK and ACKVEC are mutually exclusive"
+            ));
+        }
+
+        ironrdp_core::ensure_size!(in: dst, size: self.size());
+
+        // Write header with auto-computed flags
+        let header = V2Header {
+            flags: self.compute_flags(),
+            ..self.header
+        };
+        header.encode(dst)?;
+
+        // Write payloads in spec-mandated order (MS-RDPEUDP2 Section 2.2.1)
+        if let Some(ref ack) = self.ack {
+            ack.encode(dst)?;
+        }
+        if let Some(ref overhead) = self.overhead_size {
+            overhead.encode(dst)?;
+        }
+        if let Some(ref dai) = self.delay_ack_info {
+            dai.encode(dst)?;
+        }
+        if let Some(ref aoa) = self.ack_of_acks {
+            aoa.encode(dst)?;
+        }
+        if let Some(ref dh) = self.data_header {
+            dh.encode(dst)?;
+        }
+        if let Some(ref av) = self.ack_vector {
+            av.encode(dst)?;
+        }
+        if let Some(ref db) = self.data_body {
+            db.encode(dst)?;
+        }
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        let mut total = self.header.size();
+        if let Some(ref a) = self.ack {
+            total += a.size();
+        }
+        if let Some(ref os) = self.overhead_size {
+            total += os.size();
+        }
+        if let Some(ref dai) = self.delay_ack_info {
+            total += dai.size();
+        }
+        if let Some(ref aoa) = self.ack_of_acks {
+            total += aoa.size();
+        }
+        if let Some(ref dh) = self.data_header {
+            total += dh.size();
+        }
+        if let Some(ref av) = self.ack_vector {
+            total += av.size();
+        }
+        if let Some(ref db) = self.data_body {
+            total += db.size();
+        }
+        total
+    }
+}
+
+impl Decode<'_> for V2Packet {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        // V2Header::decode validates ACK/ACKVEC mutual exclusion
+        let header = V2Header::decode(src)?;
+
+        let ack = if header.flags.contains(V2Flags::ACK) {
+            Some(AckPayload::decode(src)?)
+        } else {
+            None
+        };
+
+        let overhead_size = if header.flags.contains(V2Flags::OVERHEADSIZE) {
+            Some(OverheadSizePayload::decode(src)?)
+        } else {
+            None
+        };
+
+        let delay_ack_info = if header.flags.contains(V2Flags::DELAYACKINFO) {
+            Some(DelayAckInfoPayload::decode(src)?)
+        } else {
+            None
+        };
+
+        let ack_of_acks = if header.flags.contains(V2Flags::AOA) {
+            Some(AckOfAcksPayload::decode(src)?)
+        } else {
+            None
+        };
+
+        let data_header = if header.flags.contains(V2Flags::DATA) {
+            Some(DataHeader::decode(src)?)
+        } else {
+            None
+        };
+
+        let ack_vector = if header.flags.contains(V2Flags::ACKVEC) {
+            Some(AckVectorPayload::decode(src)?)
+        } else {
+            None
+        };
+
+        // DataBody is always last: it consumes all remaining bytes
+        let data_body = if header.flags.contains(V2Flags::DATA) {
+            Some(DataBody::decode(src)?)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            header,
+            ack,
+            overhead_size,
+            delay_ack_info,
+            ack_of_acks,
+            data_header,
+            ack_vector,
+            data_body,
         })
     }
 }

--- a/crates/ironrdp-rdpeudp/src/pdu/prefix.rs
+++ b/crates/ironrdp-rdpeudp/src/pdu/prefix.rs
@@ -1,0 +1,320 @@
+//! PacketPrefixByte and the wire-level byte-swap transform.
+//!
+//! MS-RDPEUDP2 Section 2.2.1.3 and Section 3.1.1.1.5.
+//!
+//! Every RDP-UDP2 packet on the wire is preceded by a PacketPrefixByte
+//! that is byte-swapped with the 8th byte of the payload for obfuscation.
+//! The send and receive transforms must be applied at the network boundary.
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+/// Position of the PacketPrefixByte after the swap (0-indexed).
+const PREFIX_SWAP_INDEX: usize = 7;
+
+/// Minimum wire payload size. Packets shorter than this are padded.
+const MIN_WIRE_SIZE: usize = 8; // 1 byte prefix + 7 bytes minimum
+
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+/// PacketPrefixByte structure.
+///
+/// MS-RDPEUDP2 Section 2.2.1.3.
+/// Wire layout (1 byte, bits numbered least significant first):
+/// - bit 0: Reserved (must be 0).
+/// - bits 1-4: Packet_Type_Index (0 = normal, 8 = dummy).
+/// - bits 5-7: Short_Packet_Length (size of following packet if < 7, else 7).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PacketPrefixByte {
+    /// Packet type. Must be 0 (normal) or 8 (dummy).
+    /// Dummy packets are treated normally by the transport layer
+    /// but their loss does not trigger retransmit, and their
+    /// contents are ignored by higher layers.
+    pub packet_type_index: u8,
+
+    /// Length of the following RDP-UDP2 packet if < 7 bytes.
+    /// Set to 7 if the packet is >= 7 bytes.
+    pub short_packet_length: u8,
+}
+
+impl PacketPrefixByte {
+    /// Create a prefix byte for a normal packet.
+    pub fn normal(packet_size: usize) -> Self {
+        Self {
+            packet_type_index: 0,
+            short_packet_length: Self::compute_short_length(packet_size),
+        }
+    }
+
+    /// Create a prefix byte for a dummy packet.
+    pub fn dummy(packet_size: usize) -> Self {
+        Self {
+            packet_type_index: 8,
+            short_packet_length: Self::compute_short_length(packet_size),
+        }
+    }
+
+    /// Whether this is a dummy packet.
+    pub fn is_dummy(self) -> bool {
+        self.packet_type_index == 8
+    }
+
+    fn compute_short_length(packet_size: usize) -> u8 {
+        if packet_size < 7 {
+            // The guard ensures packet_size fits in u8.
+            u8::try_from(packet_size).expect("packet_size < 7 fits in u8")
+        } else {
+            7
+        }
+    }
+
+    /// Encode to a single byte.
+    ///
+    /// [MS-RDPEUDP2] 2.2.1.3 numbers the bits least-significant first, as its
+    /// little-endian byte order implies: bit 0 is Reserved, bits 1 to 4 are
+    /// Packet_Type_Index, bits 5 to 7 are Short_Packet_Length. The worked
+    /// example in 3.1.1.1.5.1 pins it down: a prefix byte of 0x10 is
+    /// Packet_Type_Index 8, which is the dummy-packet value, and is only
+    /// reachable under this numbering.
+    fn to_byte(self) -> u8 {
+        ((self.short_packet_length & 0x07) << 5) | ((self.packet_type_index & 0x0F) << 1)
+    }
+
+    /// Decode from a single byte.
+    fn from_byte(byte: u8) -> Self {
+        Self {
+            packet_type_index: (byte >> 1) & 0x0F,
+            short_packet_length: (byte >> 5) & 0x07,
+        }
+    }
+}
+
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+/// Error returned by prefix encoding/decoding operations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PrefixError {
+    /// Wire payload is too short for the swap operation.
+    PayloadTooShort { len: usize },
+    /// The packet_type_index is not 0 or 8.
+    InvalidPacketType { got: u8 },
+}
+
+impl core::fmt::Display for PrefixError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::PayloadTooShort { len } => {
+                write!(f, "wire payload too short for prefix swap: {len} bytes")
+            }
+            Self::InvalidPacketType { got } => {
+                write!(f, "invalid packet_type_index: {got}, expected 0 or 8")
+            }
+        }
+    }
+}
+
+impl core::error::Error for PrefixError {}
+
+/// Apply the send transform: prepend `PacketPrefixByte` and swap byte[0] with byte[7].
+///
+/// MS-RDPEUDP2 Section 3.1.1.1.5.1.
+///
+/// Takes the raw RDP-UDP2 packet bytes and writes the wire-format payload
+/// (with prefix byte-swapped into position 7) into `wire_buf`.
+///
+/// Returns the number of bytes written to `wire_buf`.
+///
+/// # Procedure
+///
+/// 1. Generate PacketPrefixByte based on packet type and size.
+/// 2. If the RDP-UDP2 packet is shorter than 7 bytes, pad to 7.
+/// 3. Prepend the PacketPrefixByte (now at position 0).
+/// 4. Swap byte[0] with byte[7].
+pub fn encode_with_prefix(packet: &[u8], is_dummy: bool, wire_buf: &mut Vec<u8>) -> Result<usize, PrefixError> {
+    let prefix = if is_dummy {
+        PacketPrefixByte::dummy(packet.len())
+    } else {
+        PacketPrefixByte::normal(packet.len())
+    };
+
+    // Step 1-2: Determine padded size
+    let padded_size = core::cmp::max(packet.len(), 7);
+
+    // Step 3: Build [prefix_byte, packet_bytes..., padding...]
+    wire_buf.clear();
+    wire_buf.reserve(1 + padded_size);
+    wire_buf.push(prefix.to_byte());
+    wire_buf.extend_from_slice(packet);
+
+    // Pad if necessary
+    while wire_buf.len() < 1 + padded_size {
+        wire_buf.push(0);
+    }
+
+    // Step 4: Swap byte[0] with byte[7]
+    // After prepending prefix, wire_buf is [prefix, pkt[0], pkt[1], ..., pkt[6], ...]
+    // wire_buf[0] = prefix_byte, wire_buf[7] = pkt[6] (or padding)
+    if wire_buf.len() < MIN_WIRE_SIZE {
+        return Err(PrefixError::PayloadTooShort { len: wire_buf.len() });
+    }
+    wire_buf.swap(0, PREFIX_SWAP_INDEX);
+
+    Ok(wire_buf.len())
+}
+
+/// Apply the receive transform: swap byte[0] with byte[7], extract prefix, strip padding.
+///
+/// MS-RDPEUDP2 Section 3.1.1.1.5.2.
+///
+/// Takes the raw wire payload and returns `(prefix, packet_bytes)`.
+///
+/// # Procedure
+///
+/// 1. Swap byte[0] with byte[7].
+/// 2. Remove byte[0]: this is the PacketPrefixByte.
+/// 3. If Short_Packet_Length != 0 and < 7, truncate to that length.
+/// 4. Remaining bytes are the RDP-UDP2 packet.
+pub fn decode_with_prefix(wire: &mut [u8]) -> Result<(PacketPrefixByte, &[u8]), PrefixError> {
+    if wire.len() < MIN_WIRE_SIZE {
+        return Err(PrefixError::PayloadTooShort { len: wire.len() });
+    }
+
+    // Step 1: Swap byte[0] with byte[7]
+    wire.swap(0, PREFIX_SWAP_INDEX);
+
+    // Step 2: Extract the prefix byte (now at position 0)
+    let prefix = PacketPrefixByte::from_byte(wire[0]);
+
+    // Validate packet_type_index
+    if prefix.packet_type_index != 0 && prefix.packet_type_index != 8 {
+        return Err(PrefixError::InvalidPacketType {
+            got: prefix.packet_type_index,
+        });
+    }
+
+    // Step 3: The packet data starts at wire[1..]
+    let packet_data = &wire[1..];
+
+    // Step 4: If Short_Packet_Length is non-zero and less than 7,
+    // the actual packet is only that many bytes (rest is padding).
+    let actual_len = if prefix.short_packet_length > 0 && prefix.short_packet_length < 7 {
+        usize::from(prefix.short_packet_length)
+    } else {
+        packet_data.len()
+    };
+
+    if actual_len > packet_data.len() {
+        return Err(PrefixError::PayloadTooShort { len: packet_data.len() });
+    }
+
+    Ok((prefix, &packet_data[..actual_len]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefix_byte_encode_decode() {
+        let prefix = PacketPrefixByte {
+            packet_type_index: 0,
+            short_packet_length: 7,
+        };
+        let byte = prefix.to_byte();
+        let decoded = PacketPrefixByte::from_byte(byte);
+        assert_eq!(prefix, decoded);
+    }
+
+    #[test]
+    fn prefix_byte_dummy_encode_decode() {
+        let prefix = PacketPrefixByte {
+            packet_type_index: 8,
+            short_packet_length: 4,
+        };
+        let byte = prefix.to_byte();
+        // Short_Packet_Length 4 in bits 5-7 and Packet_Type_Index 8 in bits 1-4:
+        // 0b100_1000_0 = 0x90.
+        assert_eq!(byte, 0x90);
+        let decoded = PacketPrefixByte::from_byte(byte);
+        assert_eq!(prefix, decoded);
+    }
+
+    /// MS-RDPEUDP2 Section 3.1.1.1.5.1 worked example.
+    ///
+    /// Input: 10 bytes [0x30, 0x35, 0x56, 0x78, 0xa2, 0x36, 0x73, 0xee, 0x68, 0xf2]
+    /// PacketPrefixByte = 0x10, which is Packet_Type_Index 8 (a dummy packet) and
+    /// Short_Packet_Length 0. This example is what fixes the bit numbering: 8 is
+    /// a legal type and 2 is not, and only least-significant-first numbering
+    /// reads 0x10 as 8.
+    ///
+    /// After prepend: [0x10, 0x30, 0x35, 0x56, 0x78, 0xa2, 0x36, 0x73, 0xee, 0x68, 0xf2]
+    /// After swap[0]↔[7]: [0x73, 0x30, 0x35, 0x56, 0x78, 0xa2, 0x36, 0x10, 0xee, 0x68, 0xf2]
+    #[test]
+    fn spec_example_send_transform() {
+        let packet = [0x30, 0x35, 0x56, 0x78, 0xa2, 0x36, 0x73, 0xee, 0x68, 0xf2];
+
+        // Manually construct the prefix byte 0x10 for this example.
+        // 0x10 = 0b0001_0000 → packet_type_index = (0x10 >> 1) & 0x0F = 8,
+        //                      short_packet_length = (0x10 >> 5) & 0x07 = 0.
+        // The spec uses this value in its example; we replicate it.
+        let prefix_byte: u8 = 0x10;
+        let prefix = PacketPrefixByte::from_byte(prefix_byte);
+        assert_eq!(prefix.to_byte(), 0x10);
+
+        // Build wire payload manually following the spec procedure
+        let mut wire_buf = Vec::new();
+        wire_buf.push(prefix_byte);
+        wire_buf.extend_from_slice(&packet);
+        // Length = 11, no padding needed (packet >= 7)
+
+        // Swap byte[0] with byte[7]
+        wire_buf.swap(0, 7);
+
+        assert_eq!(
+            wire_buf,
+            vec![0x73, 0x30, 0x35, 0x56, 0x78, 0xa2, 0x36, 0x10, 0xee, 0x68, 0xf2]
+        );
+    }
+
+    /// Verify the receive transform reverses the send transform.
+    ///
+    /// Exercises the swap mechanics directly, rather than through
+    /// `decode_with_prefix`, so the assertion is about the prefix byte
+    /// itself rather than the length/padding handling that function also
+    /// does.
+    #[test]
+    fn spec_example_receive_transform() {
+        let mut wire = vec![0x73, 0x30, 0x35, 0x56, 0x78, 0xa2, 0x36, 0x10, 0xee, 0x68, 0xf2];
+
+        // Step 1: Swap byte[0] with byte[7]
+        wire.swap(0, 7);
+
+        // After swap: prefix byte is now at position 0
+        let prefix = PacketPrefixByte::from_byte(wire[0]);
+        assert_eq!(prefix.to_byte(), 0x10);
+        assert_eq!(prefix.packet_type_index, 8, "0x10 is the dummy-packet type");
+        assert_eq!(prefix.short_packet_length, 0);
+
+        // Step 2: The original packet is everything after the prefix byte
+        let packet = &wire[1..];
+        assert_eq!(packet, &[0x30, 0x35, 0x56, 0x78, 0xa2, 0x36, 0x73, 0xee, 0x68, 0xf2]);
+    }
+
+    /// Only Packet_Type_Index 0 and 8 are legal, and the encoding must place
+    /// them where a peer looks for them.
+    ///
+    /// [MS-RDPEUDP2] 3.1.1.1.5 fixes the two values, so any layout that cannot
+    /// represent both without touching the reserved bit is wrong.
+    #[test]
+    fn prefix_byte_layout_matches_the_legal_type_values() {
+        for length in 0..=7u8 {
+            for packet_type_index in [0u8, 8] {
+                let prefix = PacketPrefixByte {
+                    packet_type_index,
+                    short_packet_length: length,
+                };
+                let byte = prefix.to_byte();
+
+                assert_eq!(byte & 0x01, 0, "the reserved bit must stay clear");
+                assert_eq!(PacketPrefixByte::from_byte(byte), prefix);
+            }
+        }
+    }
+}

--- a/crates/ironrdp-rdpeudp/src/pdu/v2_ack.rs
+++ b/crates/ironrdp-rdpeudp/src/pdu/v2_ack.rs
@@ -1,0 +1,364 @@
+//! V2 acknowledgment payloads.
+//!
+//! `Acknowledgement Payload` (MS-RDPEUDP2 Section 2.2.1.2.1) and
+//! `Acknowledgement Vector Payload` (MS-RDPEUDP2 Section 2.2.1.2.6).
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+use ironrdp_core::{Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor};
+
+// ── Acknowledgement Payload (ACK flag) ──
+
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+/// Acknowledges one or more consecutively received packets.
+///
+/// MS-RDPEUDP2 Section 2.2.1.2.1.
+/// Present when the ACK flag (0x001) is set in the header.
+///
+/// Wire layout:
+/// - `SeqNum(2)` + `receivedTS(3)` + `sendAckTimeGap(1)` +
+///   `numDelayedAcks(4 bits) : delayAckTimeScale(4 bits)` = 7 bytes fixed.
+/// - `delayAckTimeAdditions(numDelayedAcks bytes)` = variable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AckPayload {
+    /// Lower 16 bits of the acknowledged data packet's sequence number.
+    pub seq_num: u16,
+
+    /// Lower 24 bits of the timestamp when the packet was received.
+    /// Units of 4 microseconds.
+    pub received_ts: u32,
+
+    /// Time in milliseconds between packet receipt and ACK send.
+    pub send_ack_time_gap: u8,
+
+    /// Scale for delay time additions (0..=15).
+    /// Each addition is in units of `(1 << delay_ack_time_scale)` microseconds.
+    pub delay_ack_time_scale: u8,
+
+    /// Per-ACK time deltas in reverse chronological order.
+    ///
+    /// The wire format carries the count in the low nibble of the packed
+    /// byte, so it is derived from this vector on encode rather than stored.
+    /// At most 15 entries fit; `encode` rejects more.
+    /// Each byte times `(1 << delay_ack_time_scale)` microseconds gives the
+    /// time between adjacent acknowledgments.
+    pub delay_ack_time_additions: Vec<u8>,
+}
+
+impl AckPayload {
+    /// Fixed part size: SeqNum(2) + receivedTS(3) + sendAckTimeGap(1) + packed_nibbles(1) = 7.
+    const FIXED_PART_SIZE: usize = 7;
+    const NAME: &'static str = "RDP-UDP2 Acknowledgement Payload";
+
+    /// Mask for the lower 24 bits of a timestamp.
+    pub const TIMESTAMP_MASK: u32 = 0x00FF_FFFF;
+}
+
+impl Encode for AckPayload {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ironrdp_core::ensure_size!(in: dst, size: self.size());
+
+        dst.write_u16(self.seq_num);
+
+        // receivedTS: 3 bytes little-endian (lower 24 bits)
+        let ts_bytes = (self.received_ts & Self::TIMESTAMP_MASK).to_le_bytes();
+        dst.write_u8(ts_bytes[0]);
+        dst.write_u8(ts_bytes[1]);
+        dst.write_u8(ts_bytes[2]);
+
+        dst.write_u8(self.send_ack_time_gap);
+
+        // Pack numDelayedAcks(high nibble) and delayAckTimeScale(low nibble).
+        // The count comes from the vector, never from a separate field: the
+        // two can disagree, and a truncated count leaves the decoder reading
+        // entries that were never written.
+        let num_delayed_acks = u8::try_from(self.delay_ack_time_additions.len())
+            .ok()
+            .filter(|count| *count <= 0x0F)
+            .ok_or_else(|| {
+                ironrdp_core::invalid_field_err!("AckPayload", "numDelayedAcks", "exceeds 4-bit maximum (15)")
+            })?;
+        // [MS-RDPEUDP2] 2.2.1.2.1: numDelayedAcks occupies bits 48 to 51 and
+        // delayAckTimeScale bits 52 to 55. Bits are numbered
+        // least-significant first, so the count is the low nibble.
+        let packed = ((self.delay_ack_time_scale & 0x0F) << 4) | num_delayed_acks;
+        dst.write_u8(packed);
+
+        dst.write_slice(&self.delay_ack_time_additions);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.delay_ack_time_additions.len()
+    }
+}
+
+impl Decode<'_> for AckPayload {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ironrdp_core::ensure_fixed_part_size!(in: src);
+
+        let seq_num = src.read_u16();
+
+        // receivedTS: 3 bytes little-endian
+        let ts_b0 = u32::from(src.read_u8());
+        let ts_b1 = u32::from(src.read_u8());
+        let ts_b2 = u32::from(src.read_u8());
+        let received_ts = ts_b0 | (ts_b1 << 8) | (ts_b2 << 16);
+
+        let send_ack_time_gap = src.read_u8();
+
+        let packed = src.read_u8();
+        let num_delayed_acks = packed & 0x0F;
+        let delay_ack_time_scale = (packed >> 4) & 0x0F;
+
+        let additions_len = usize::from(num_delayed_acks);
+        ironrdp_core::ensure_size!(in: src, size: additions_len);
+        let delay_ack_time_additions = src.read_slice(additions_len).to_vec();
+
+        Ok(Self {
+            seq_num,
+            received_ts,
+            send_ack_time_gap,
+            delay_ack_time_scale,
+            delay_ack_time_additions,
+        })
+    }
+}
+
+// ── Acknowledgement Vector Payload (ACKVEC flag) ──
+
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+/// Per-packet acknowledgment state encoding mode.
+///
+/// MS-RDPEUDP2 Section 2.2.1.2.6.
+/// Each byte in the coded ACK vector is independently encoded as either
+/// a state-map (MSB = 0) or a run-length (MSB = 1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AckVectorEntry {
+    /// State-map mode (MSB = 0).
+    /// Remaining 7 bits are a bitmap: each bit represents one sequence number
+    /// (1 = received, 0 = not received), from lowest to highest bit.
+    StateMap {
+        /// 7-bit bitmap of received/not-received states.
+        bitmap: u8,
+    },
+
+    /// Run-length mode (MSB = 1).
+    /// Bit 6 = state (1 = received, 0 = not received).
+    /// Bits 0-5 = run length (number of consecutive packets in this state).
+    RunLength {
+        /// Whether the packets in this run were received.
+        received: bool,
+        /// Number of consecutive packets in this state (0..=63).
+        length: u8,
+    },
+}
+
+impl AckVectorEntry {
+    /// Encode to a single byte.
+    pub fn to_byte(self) -> u8 {
+        match self {
+            Self::StateMap { bitmap } => bitmap & 0x7F, // MSB = 0
+            Self::RunLength { received, length } => {
+                let mut byte = 0x80; // MSB = 1
+                if received {
+                    byte |= 0x40; // bit 6 = state
+                }
+                byte | (length & 0x3F)
+            }
+        }
+    }
+
+    /// Decode from a single byte.
+    pub fn from_byte(byte: u8) -> Self {
+        if (byte & 0x80) == 0 {
+            // State-map mode
+            Self::StateMap { bitmap: byte & 0x7F }
+        } else {
+            // Run-length mode
+            Self::RunLength {
+                received: (byte & 0x40) != 0,
+                length: byte & 0x3F,
+            }
+        }
+    }
+
+    /// Number of sequence numbers covered by this entry.
+    pub fn coverage(self) -> u16 {
+        match self {
+            Self::StateMap { .. } => 7,
+            Self::RunLength { length, .. } => u16::from(length),
+        }
+    }
+}
+
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+/// Vector of per-packet acknowledgment states within the receiver window.
+///
+/// MS-RDPEUDP2 Section 2.2.1.2.6.
+/// Present when the ACKVEC flag (0x008) is set in the header.
+/// Mutually exclusive with the ACK payload.
+///
+/// Wire layout:
+/// - `BaseSeqNum(2)` + packed byte (`codedAckVecSize(7 bits) : TimeStampPresent(1 bit)`) = 3 bytes.
+/// - If `TimeStampPresent`: `TimeStamp(3)` + `SendAckTimeGapInMs(1)` = 4 bytes.
+/// - `codedAckVector(codedAckVecSize bytes)`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AckVectorPayload {
+    /// Lower 16 bits of the base sequence number for this vector.
+    pub base_seq_num: u16,
+
+    /// Lower 24 bits of timestamp for the highest unacked sequence number received.
+    /// Units of 4 microseconds. Present only when `timestamp_present`.
+    pub timestamp: Option<u32>,
+
+    /// Time in ms between ACK send and last data packet receipt.
+    /// 255 = invalid/unused. Present only when `timestamp_present`.
+    pub send_ack_time_gap_ms: Option<u8>,
+
+    /// Encoded ACK vector entries.
+    pub entries: Vec<AckVectorEntry>,
+}
+
+impl AckVectorPayload {
+    const NAME: &'static str = "RDP-UDP2 Acknowledgement Vector Payload";
+
+    /// Minimum fixed part: BaseSeqNum(2) + packed_byte(1) = 3 bytes.
+    const MIN_FIXED_SIZE: usize = 3;
+
+    /// Optional timestamp block: TimeStamp(3) + SendAckTimeGapInMs(1) = 4 bytes.
+    const TIMESTAMP_BLOCK_SIZE: usize = 4;
+}
+
+impl Encode for AckVectorPayload {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ironrdp_core::ensure_size!(in: dst, size: self.size());
+
+        for entry in &self.entries {
+            match *entry {
+                AckVectorEntry::StateMap { bitmap } if bitmap > 0x7F => {
+                    return Err(ironrdp_core::invalid_field_err!(
+                        "AckVectorPayload",
+                        "entries",
+                        "StateMap bitmap exceeds 7-bit maximum (0x7F)"
+                    ));
+                }
+                AckVectorEntry::RunLength { length, .. } if length > 0x3F => {
+                    return Err(ironrdp_core::invalid_field_err!(
+                        "AckVectorPayload",
+                        "entries",
+                        "RunLength length exceeds 6-bit maximum (0x3F)"
+                    ));
+                }
+                _ => {}
+            }
+        }
+
+        // The timestamp block is one unit on the wire (see below): a value
+        // carrying only one half has nowhere valid to go. Silently dropping
+        // it would discard data the caller explicitly set.
+        if self.timestamp.is_some() != self.send_ack_time_gap_ms.is_some() {
+            return Err(ironrdp_core::invalid_field_err!(
+                "AckVectorPayload",
+                "timestamp",
+                "timestamp and send_ack_time_gap_ms must be both present or both absent"
+            ));
+        }
+
+        dst.write_u16(self.base_seq_num);
+
+        let vec_size: u8 = ironrdp_core::cast_length!("AckVectorPayload", "codedAckVecSize", self.entries.len())?;
+        if vec_size > 0x7F {
+            return Err(ironrdp_core::invalid_field_err!(
+                "AckVectorPayload",
+                "codedAckVecSize",
+                "exceeds 7-bit maximum (127)"
+            ));
+        }
+
+        // The timestamp block is one unit on the wire: the gap byte and the
+        // three timestamp bytes are written together and read together. It is
+        // therefore present only when both fields are, and the flag bit, the
+        // write below and `size` must all agree on that. They did not: the flag
+        // was set from `timestamp` alone, so a value carrying a timestamp
+        // without a gap advertised a block it never wrote, and a peer would
+        // have read the first four ACK entries as the timestamp.
+        let timestamp_present = self.timestamp.is_some() && self.send_ack_time_gap_ms.is_some();
+        let packed = (vec_size & 0x7F) | if timestamp_present { 0x80 } else { 0x00 };
+        dst.write_u8(packed);
+
+        if let (Some(ts), Some(gap)) = (self.timestamp, self.send_ack_time_gap_ms) {
+            // [MS-RDPEUDP2] 2.2.1.2.6 places TimeStamp (bits 24 to 47) before
+            // SendAckTimeGapInMs (bits 48 to 55).
+            let ts_bytes = (ts & AckPayload::TIMESTAMP_MASK).to_le_bytes();
+            dst.write_u8(ts_bytes[0]);
+            dst.write_u8(ts_bytes[1]);
+            dst.write_u8(ts_bytes[2]);
+            dst.write_u8(gap);
+        }
+
+        for entry in &self.entries {
+            dst.write_u8(entry.to_byte());
+        }
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        let mut total = Self::MIN_FIXED_SIZE;
+        // Same condition as `encode`: the block goes out only when both halves
+        // are present.
+        if self.timestamp.is_some() && self.send_ack_time_gap_ms.is_some() {
+            total += Self::TIMESTAMP_BLOCK_SIZE;
+        }
+        total += self.entries.len();
+        total
+    }
+}
+
+impl Decode<'_> for AckVectorPayload {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ironrdp_core::ensure_size!(in: src, size: Self::MIN_FIXED_SIZE);
+
+        let base_seq_num = src.read_u16();
+
+        let packed = src.read_u8();
+        let coded_ack_vec_size = packed & 0x7F;
+        let timestamp_present = (packed & 0x80) != 0;
+
+        let (timestamp, send_ack_time_gap_ms) = if timestamp_present {
+            ironrdp_core::ensure_size!(in: src, size: Self::TIMESTAMP_BLOCK_SIZE);
+            let ts_b0 = u32::from(src.read_u8());
+            let ts_b1 = u32::from(src.read_u8());
+            let ts_b2 = u32::from(src.read_u8());
+            let ts = ts_b0 | (ts_b1 << 8) | (ts_b2 << 16);
+            let gap = src.read_u8();
+            (Some(ts), Some(gap))
+        } else {
+            (None, None)
+        };
+
+        let entries_len = usize::from(coded_ack_vec_size);
+        ironrdp_core::ensure_size!(in: src, size: entries_len);
+        let mut entries = Vec::with_capacity(entries_len);
+        for _ in 0..entries_len {
+            entries.push(AckVectorEntry::from_byte(src.read_u8()));
+        }
+
+        Ok(Self {
+            base_seq_num,
+            timestamp,
+            send_ack_time_gap_ms,
+            entries,
+        })
+    }
+}

--- a/crates/ironrdp-rdpeudp/src/pdu/v2_control.rs
+++ b/crates/ironrdp-rdpeudp/src/pdu/v2_control.rs
@@ -1,0 +1,176 @@
+//! V2 control payloads: OverheadSize, DelayAckInfo, AckOfAcks.
+//!
+//! These are small fixed-size payloads used for flow control and
+//! protocol tuning during data transfer.
+
+use ironrdp_core::{Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor};
+
+// ── OverheadSize Payload ──
+
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+/// Average extra header bytes from the RDP-UDP2 layer to the raw UDP layer.
+///
+/// MS-RDPEUDP2 Section 2.2.1.2.2.
+/// Present when the OVERHEADSIZE flag (0x040) is set.
+/// Sent by the Receiver to help the Sender's congestion control
+/// accurately estimate available bandwidth.
+///
+/// Wire layout: `OverheadSize(1)` = 1 byte.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OverheadSizePayload {
+    /// Average header overhead in bytes.
+    pub overhead_size: u8,
+}
+
+impl OverheadSizePayload {
+    const FIXED_PART_SIZE: usize = 1;
+    const NAME: &'static str = "RDP-UDP2 OverheadSize Payload";
+}
+
+impl Encode for OverheadSizePayload {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ironrdp_core::ensure_fixed_part_size!(in: dst);
+        dst.write_u8(self.overhead_size);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl Decode<'_> for OverheadSizePayload {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ironrdp_core::ensure_fixed_part_size!(in: src);
+        let overhead_size = src.read_u8();
+        Ok(Self { overhead_size })
+    }
+}
+
+// ── DelayAckInfo Payload ──
+
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+/// Parameters controlling the Receiver's ACK batching behavior.
+///
+/// MS-RDPEUDP2 Section 2.2.1.2.3.
+/// Present when the DELAYACKINFO flag (0x100) is set.
+/// Sent by the Sender to configure how the Receiver batches ACKs.
+///
+/// Wire layout (3 bytes):
+/// - `MaxDelayedAcks(8 bits)` = 1 byte.
+/// - `DelayedAckTimeoutInMs(16 bits)` = 2 bytes.
+///
+/// Default values (assumed after initialization):
+/// - `MaxDelayedAcks = 8`
+/// - `DelayedAckTimeoutInMs = RTT / 2`
+///
+/// The Sender can adjust these at any time during the connection.
+/// If the Receiver delays beyond these parameters, the packet is
+/// considered lost and must be retransmitted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DelayAckInfoPayload {
+    /// Maximum number of ACKs the Receiver may batch before
+    /// sending a standalone acknowledgment. Range 0..=255.
+    pub max_delayed_acks: u8,
+
+    /// Timeout in milliseconds. If the Receiver has unacknowledged
+    /// packets older than this, it must send an ACK immediately.
+    pub delayed_ack_timeout_ms: u16,
+}
+
+impl DelayAckInfoPayload {
+    const FIXED_PART_SIZE: usize = 3;
+    const NAME: &'static str = "RDP-UDP2 DelayAckInfo Payload";
+
+    /// Default max delayed ACKs per MS-RDPEUDP2 Section 3.1.5.2.
+    pub const DEFAULT_MAX_DELAYED_ACKS: u8 = 8;
+}
+
+impl Encode for DelayAckInfoPayload {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ironrdp_core::ensure_fixed_part_size!(in: dst);
+
+        // [MS-RDPEUDP2] 2.2.1.2.3 gives MaxDelayedAcks a whole byte, not a
+        // nibble, so the full range 0..=255 goes out.
+        dst.write_u8(self.max_delayed_acks);
+        dst.write_u16(self.delayed_ack_timeout_ms);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl Decode<'_> for DelayAckInfoPayload {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ironrdp_core::ensure_fixed_part_size!(in: src);
+
+        let max_delayed_acks = src.read_u8();
+        let delayed_ack_timeout_ms = src.read_u16();
+
+        Ok(Self {
+            max_delayed_acks,
+            delayed_ack_timeout_ms,
+        })
+    }
+}
+
+// ── AckOfAcks Payload ──
+
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+/// Tells the Receiver the lowest sequence number the Sender still cares about.
+///
+/// MS-RDPEUDP2 Section 2.2.1.2.4.
+/// Present when the AOA flag (0x010) is set.
+/// Sent by the Sender to allow the Receiver to shrink its window buffer.
+///
+/// Wire layout: `AckOfAcksSeqNum(2)` = 2 bytes.
+///
+/// The Sender sends this after detecting packet loss to inform the Receiver
+/// that packets with lower sequence numbers need not be tracked anymore.
+/// The Sender should stop sending this once it receives an ACK or ACK vector
+/// confirming a higher sequence number.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AckOfAcksPayload {
+    /// Lower 16 bits of the AckOfAcks sequence number.
+    pub ack_of_acks_seq_num: u16,
+}
+
+impl AckOfAcksPayload {
+    const FIXED_PART_SIZE: usize = 2;
+    const NAME: &'static str = "RDP-UDP2 AckOfAcks Payload";
+}
+
+impl Encode for AckOfAcksPayload {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ironrdp_core::ensure_fixed_part_size!(in: dst);
+        dst.write_u16(self.ack_of_acks_seq_num);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl Decode<'_> for AckOfAcksPayload {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ironrdp_core::ensure_fixed_part_size!(in: src);
+        let ack_of_acks_seq_num = src.read_u16();
+        Ok(Self { ack_of_acks_seq_num })
+    }
+}

--- a/crates/ironrdp-rdpeudp/src/pdu/v2_data.rs
+++ b/crates/ironrdp-rdpeudp/src/pdu/v2_data.rs
@@ -1,0 +1,114 @@
+//! V2 data payloads.
+//!
+//! `DataHeader Payload` (MS-RDPEUDP2 Section 2.2.1.2.5) and
+//! `DataBody Payload` (MS-RDPEUDP2 Section 2.2.1.2.7).
+//!
+//! Both are present when the DATA flag (0x004) is set.
+//! DataHeader always precedes DataBody in the packet layout.
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+use ironrdp_core::{Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor};
+
+// ── DataHeader Payload ──
+
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+/// Header portion of a data payload, carrying the data sequence number.
+///
+/// MS-RDPEUDP2 Section 2.2.1.2.5.
+/// Wire layout: `DataSeqNum(2)` = 2 bytes.
+///
+/// `DataSeqNum` is the lower 16 bits of the coded sequence number.
+/// This value changes on retransmit: a retransmitted packet gets
+/// a new DataSeqNum but preserves its ChannelSeqNum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DataHeader {
+    /// Lower 16 bits of the data sequence number.
+    pub data_seq_num: u16,
+}
+
+impl DataHeader {
+    const FIXED_PART_SIZE: usize = 2;
+    const NAME: &'static str = "RDP-UDP2 DataHeader Payload";
+}
+
+impl Encode for DataHeader {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ironrdp_core::ensure_fixed_part_size!(in: dst);
+        dst.write_u16(self.data_seq_num);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl Decode<'_> for DataHeader {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ironrdp_core::ensure_fixed_part_size!(in: src);
+        let data_seq_num = src.read_u16();
+        Ok(Self { data_seq_num })
+    }
+}
+
+// ── DataBody Payload ──
+
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+/// Application data payload, containing the channel sequence number
+/// and the actual RDP data from higher layers.
+///
+/// MS-RDPEUDP2 Section 2.2.1.2.7.
+/// Wire layout: `ChannelSeqNum(2)` + `Data(variable)`.
+///
+/// `ChannelSeqNum` is preserved across retransmits: the reliability
+/// controller uses it to match a retransmitted packet to the original.
+/// This is the sequence number that higher layers care about for
+/// ordering and reassembly. See MS-RDPEUDP2 Section 3.1.1.2.4.
+///
+/// The `Data` field contains the RDP protocol data from upper layers
+/// and extends to the end of the packet.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataBody {
+    /// Lower 16 bits of the channel sequence number.
+    /// Stable across retransmits.
+    pub channel_seq_num: u16,
+
+    /// Application data from higher RDP layers.
+    pub data: Vec<u8>,
+}
+
+impl DataBody {
+    const FIXED_PART_SIZE: usize = 2; // ChannelSeqNum
+    const NAME: &'static str = "RDP-UDP2 DataBody Payload";
+}
+
+impl Encode for DataBody {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ironrdp_core::ensure_size!(in: dst, size: self.size());
+        dst.write_u16(self.channel_seq_num);
+        dst.write_slice(&self.data);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.data.len()
+    }
+}
+
+impl<'de> Decode<'de> for DataBody {
+    fn decode(src: &mut ReadCursor<'de>) -> DecodeResult<Self> {
+        ironrdp_core::ensure_fixed_part_size!(in: src);
+        let channel_seq_num = src.read_u16();
+        let data = src.read_remaining().to_vec();
+        Ok(Self { channel_seq_num, data })
+    }
+}

--- a/crates/ironrdp-rdpeudp/src/pdu/v2_flags.rs
+++ b/crates/ironrdp-rdpeudp/src/pdu/v2_flags.rs
@@ -1,0 +1,112 @@
+//! V2 header flags per MS-RDPEUDP2 Section 2.2.1.1.
+//!
+//! The `Flags` field in the RDP-UDP2 Packet Header is a 12-bit bitmap
+//! stored in the lower 12 bits of the 16-bit header word.
+
+use bitflags::bitflags;
+
+bitflags! {
+    /// Flags in the RDP-UDP2 Packet Header.
+    ///
+    /// MS-RDPEUDP2 Section 2.2.1.1.
+    /// Stored in the lower 12 bits of the 16-bit header word.
+    /// The upper 4 bits are `LogWindowSize`.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+    pub struct V2Flags: u16 {
+        /// ACK payload (Section 2.2.1.2.1) is present.
+        /// Mutually exclusive with ACKVEC.
+        const ACK = 0x001;
+
+        /// DataHeader + DataBody payloads (Section 2.2.1.2.5, 2.2.1.2.7) are present.
+        const DATA = 0x004;
+
+        /// Acknowledgement Vector payload (Section 2.2.1.2.6) is present.
+        /// Mutually exclusive with ACK.
+        const ACKVEC = 0x008;
+
+        /// AckOfAcks payload (Section 2.2.1.2.4) is present.
+        const AOA = 0x010;
+
+        /// OverheadSize payload (Section 2.2.1.2.2) is present.
+        const OVERHEADSIZE = 0x040;
+
+        /// DelayAckInfo payload (Section 2.2.1.2.3) is present.
+        const DELAYACKINFO = 0x100;
+    }
+}
+
+// This is the whole table. [MS-RDPEUDP2] 2.2.1.1 defines six flags and no
+// others, so a bit outside this set is one no peer will read and none of them
+// carries a meaning beyond "this payload is present".
+//
+// Two absences are deliberate, because both were once defined here:
+//
+// - There is no DUMMY flag. A dummy packet is marked by Packet_Type_Index 8
+//   in the PacketPrefixByte, one layer down (3.1.1.1.5, `crate::pdu::prefix`).
+// - There are no CN or CWR flags. Those belong to MS-RDPEUDP, whose
+//   RDPUDP_FEC_HEADER carries RDPUDP_FLAG_CN 0x0020 and RDPUDP_FLAG_CWR
+//   0x0040 (see `crate::pdu::v1_flags`). MS-RDPEUDP2 has no explicit
+//   congestion signalling at all: it names a Congestion Controller in
+//   3.1.1.2.2 as a higher-layer concept and leaves it to infer conditions
+//   from what it observes.
+
+impl V2Flags {
+    /// Mask for the 12-bit flags field within the 16-bit header word.
+    pub const MASK: u16 = 0x0FFF;
+
+    /// Validate that ACK and ACKVEC are not both set.
+    /// Returns `true` if the flags are valid.
+    pub fn ack_flags_valid(self) -> bool {
+        !self.contains(Self::ACK | Self::ACKVEC)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flag_values_match_spec() {
+        assert_eq!(V2Flags::ACK.bits(), 0x001);
+        assert_eq!(V2Flags::DATA.bits(), 0x004);
+        assert_eq!(V2Flags::ACKVEC.bits(), 0x008);
+        assert_eq!(V2Flags::AOA.bits(), 0x010);
+        assert_eq!(V2Flags::OVERHEADSIZE.bits(), 0x040);
+        assert_eq!(V2Flags::DELAYACKINFO.bits(), 0x100);
+    }
+
+    #[test]
+    fn all_flags_fit_in_12_bits() {
+        let all = V2Flags::all();
+        assert_eq!(all.bits() & !V2Flags::MASK, 0, "flags must fit in 12 bits");
+    }
+
+    #[test]
+    fn ack_and_ackvec_mutual_exclusion() {
+        let ack_only = V2Flags::ACK;
+        assert!(ack_only.ack_flags_valid());
+
+        let ackvec_only = V2Flags::ACKVEC;
+        assert!(ackvec_only.ack_flags_valid());
+
+        let both = V2Flags::ACK | V2Flags::ACKVEC;
+        assert!(!both.ack_flags_valid());
+    }
+
+    #[test]
+    fn data_packet_flags() {
+        let flags = V2Flags::ACK | V2Flags::DATA;
+        assert!(flags.contains(V2Flags::ACK));
+        assert!(flags.contains(V2Flags::DATA));
+        assert!(flags.ack_flags_valid());
+    }
+
+    #[test]
+    fn roundtrip_from_bits() {
+        let original = V2Flags::DATA | V2Flags::ACKVEC | V2Flags::DELAYACKINFO;
+        let bits = original.bits();
+        let restored = V2Flags::from_bits_truncate(bits);
+        assert_eq!(original, restored);
+    }
+}

--- a/crates/ironrdp-rdpeudp/src/pdu/v2_header.rs
+++ b/crates/ironrdp-rdpeudp/src/pdu/v2_header.rs
@@ -1,0 +1,246 @@
+//! RDP-UDP2 Packet Header: the mandatory 2-byte header for all v2 packets.
+//!
+//! MS-RDPEUDP2 Section 2.2.1.1.
+//! Wire layout: 16 bits = lower 12 bits Flags + upper 4 bits LogWindowSize.
+
+use ironrdp_core::{Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor};
+
+use super::v2_flags::V2Flags;
+
+/// Maximum value for LogWindowSize (4-bit field).
+pub const LOG_WINDOW_SIZE_MAX: u8 = 15;
+
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+/// Mandatory header for every RDP-UDP2 packet.
+///
+/// MS-RDPEUDP2 Section 2.2.1.1.
+/// The 16-bit word is packed as: `flags(12 bits) | log_window_size(4 bits)`.
+/// - `flags`: bitmap of `V2Flags` indicating optional payloads.
+/// - `log_window_size`: log2 of the receiving window size (0..=15).
+///   Actual window size = `1 << log_window_size`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct V2Header {
+    /// Which optional payloads are present.
+    pub flags: V2Flags,
+
+    /// log2 of the receiving window size announced by this endpoint.
+    /// Must be in 0..=15.
+    pub log_window_size: u8,
+}
+
+impl V2Header {
+    const FIXED_PART_SIZE: usize = 2;
+    const NAME: &'static str = "RDP-UDP2 Packet Header";
+
+    /// Pack flags and LogWindowSize into a single 16-bit wire value.
+    fn to_wire(self) -> u16 {
+        let flags_bits = self.flags.bits() & V2Flags::MASK;
+        let window_bits = u16::from(self.log_window_size & 0x0F) << 12;
+        flags_bits | window_bits
+    }
+
+    /// Unpack from the 16-bit wire value.
+    fn from_wire(wire: u16) -> DecodeResult<Self> {
+        let flags = V2Flags::from_bits_truncate(wire & V2Flags::MASK);
+        // The 4-bit field always fits in u8; the mask guarantees 0..=15.
+        let log_window_size = u8::try_from((wire >> 12) & 0x0F).expect("4-bit field fits in u8");
+
+        if !flags.ack_flags_valid() {
+            return Err(ironrdp_core::invalid_field_err!(
+                "RDP-UDP2 Packet Header",
+                "flags",
+                "ACK and ACKVEC are mutually exclusive"
+            ));
+        }
+
+        Ok(Self { flags, log_window_size })
+    }
+
+    /// Actual window size (in packets): `1 << log_window_size`.
+    pub fn window_size(self) -> u32 {
+        1u32 << u32::from(self.log_window_size)
+    }
+}
+
+impl Encode for V2Header {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ironrdp_core::ensure_fixed_part_size!(in: dst);
+
+        if self.log_window_size > LOG_WINDOW_SIZE_MAX {
+            return Err(ironrdp_core::invalid_field_err!(
+                Self::NAME,
+                "log_window_size",
+                "exceeds 4-bit maximum (15)"
+            ));
+        }
+
+        if !self.flags.ack_flags_valid() {
+            return Err(ironrdp_core::invalid_field_err!(
+                Self::NAME,
+                "flags",
+                "ACK and ACKVEC are mutually exclusive"
+            ));
+        }
+
+        dst.write_u16(self.to_wire());
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl Decode<'_> for V2Header {
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ironrdp_core::ensure_fixed_part_size!(in: src);
+        let wire = src.read_u16();
+        Self::from_wire(wire)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ironrdp_core::{decode, encode_vec};
+
+    use super::*;
+
+    #[test]
+    fn encode_data_ack_header() {
+        let header = V2Header {
+            flags: V2Flags::ACK | V2Flags::DATA,
+            log_window_size: 6, // window = 64
+        };
+        let encoded = encode_vec(&header).expect("encode");
+        // flags = ACK(0x001) | DATA(0x004) = 0x005
+        // log_window_size = 6 → shifted = 0x6000
+        // wire = 0x6005
+        assert_eq!(encoded.as_slice(), &[0x05, 0x60]);
+    }
+
+    #[test]
+    fn decode_data_ack_header() {
+        let bytes = [0x05, 0x60]; // 0x6005
+        let decoded: V2Header = decode(&bytes).expect("decode");
+        assert_eq!(decoded.flags, V2Flags::ACK | V2Flags::DATA);
+        assert_eq!(decoded.log_window_size, 6);
+    }
+
+    #[test]
+    fn roundtrip() {
+        let original = V2Header {
+            flags: V2Flags::ACKVEC | V2Flags::AOA | V2Flags::OVERHEADSIZE,
+            log_window_size: 10,
+        };
+        let encoded = encode_vec(&original).expect("encode");
+        let decoded: V2Header = decode(&encoded).expect("decode");
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn window_size_calculation() {
+        let header = V2Header {
+            flags: V2Flags::empty(),
+            log_window_size: 0,
+        };
+        assert_eq!(header.window_size(), 1);
+
+        let header = V2Header {
+            flags: V2Flags::empty(),
+            log_window_size: 6,
+        };
+        assert_eq!(header.window_size(), 64);
+
+        let header = V2Header {
+            flags: V2Flags::empty(),
+            log_window_size: LOG_WINDOW_SIZE_MAX,
+        };
+        assert_eq!(header.window_size(), 32768);
+    }
+
+    #[test]
+    fn max_log_window_size() {
+        let header = V2Header {
+            flags: V2Flags::DATA,
+            log_window_size: LOG_WINDOW_SIZE_MAX,
+        };
+        let encoded = encode_vec(&header).expect("encode");
+        let decoded: V2Header = decode(&encoded).expect("decode");
+        assert_eq!(decoded.log_window_size, LOG_WINDOW_SIZE_MAX);
+    }
+
+    #[test]
+    fn reject_ack_and_ackvec_both_set() {
+        // Manually construct wire value with both ACK and ACKVEC
+        let flags_bits = V2Flags::ACK.bits() | V2Flags::ACKVEC.bits(); // 0x009
+        let wire = flags_bits | (6u16 << 12);
+        let bytes = wire.to_le_bytes();
+        let result: DecodeResult<V2Header> = decode(&bytes);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn encode_rejects_log_window_size_above_max() {
+        let header = V2Header {
+            flags: V2Flags::DATA,
+            log_window_size: LOG_WINDOW_SIZE_MAX + 1,
+        };
+        assert!(encode_vec(&header).is_err());
+    }
+
+    #[test]
+    fn encode_rejects_ack_and_ackvec_both_set() {
+        let header = V2Header {
+            flags: V2Flags::ACK | V2Flags::ACKVEC,
+            log_window_size: 6,
+        };
+        assert!(encode_vec(&header).is_err());
+    }
+
+    #[test]
+    fn size_is_correct() {
+        let header = V2Header {
+            flags: V2Flags::DATA,
+            log_window_size: 8,
+        };
+        assert_eq!(header.size(), 2);
+    }
+
+    #[test]
+    fn insufficient_bytes() {
+        let bytes = [0x05]; // only 1 byte, need 2
+        let result: DecodeResult<V2Header> = decode(&bytes);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn flags_only_lower_12_bits() {
+        // The six flags [MS-RDPEUDP2] 2.2.1.1 defines and no others:
+        // 0x001, 0x004, 0x008, 0x010, 0x040, 0x100 = 0x15D.
+        // from_bits_truncate drops undefined bit positions.
+        let all_defined = V2Flags::all();
+        assert_eq!(all_defined.bits(), 0x15D);
+
+        let header = V2Header {
+            flags: all_defined,
+            log_window_size: 0xF,
+        };
+        let wire = header.to_wire();
+        assert_eq!(wire, 0xF15D); // 0x15D | (0xF << 12)
+
+        // Can't decode all_defined because ACK and ACKVEC are both set.
+        // Test with valid flags to verify the bit separation.
+        let header = V2Header {
+            flags: V2Flags::DATA | V2Flags::ACKVEC | V2Flags::DELAYACKINFO,
+            log_window_size: 12,
+        };
+        let encoded = encode_vec(&header).expect("encode");
+        let decoded: V2Header = decode(&encoded).expect("decode");
+        assert_eq!(decoded.flags, header.flags);
+        assert_eq!(decoded.log_window_size, 12);
+    }
+}

--- a/crates/ironrdp-testsuite-core/tests/rdpeudp/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeudp/mod.rs
@@ -1,3 +1,8 @@
+mod pdu_prefix;
 mod pdu_v1_datagram;
 mod pdu_v1_header;
 mod pdu_v1_syn;
+mod pdu_v2_ack;
+mod pdu_v2_control;
+mod pdu_v2_data;
+mod pdu_v2_packet;

--- a/crates/ironrdp-testsuite-core/tests/rdpeudp/pdu_prefix.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeudp/pdu_prefix.rs
@@ -1,0 +1,95 @@
+use ironrdp_rdpeudp::pdu::{PacketPrefixByte, PrefixError, decode_with_prefix, encode_with_prefix};
+
+#[test]
+fn prefix_byte_normal() {
+    let prefix = PacketPrefixByte::normal(10);
+    assert_eq!(prefix.packet_type_index, 0);
+    assert_eq!(prefix.short_packet_length, 7);
+    assert!(!prefix.is_dummy());
+}
+
+#[test]
+fn prefix_byte_dummy() {
+    let prefix = PacketPrefixByte::dummy(10);
+    assert_eq!(prefix.packet_type_index, 8);
+    assert_eq!(prefix.short_packet_length, 7);
+    assert!(prefix.is_dummy());
+}
+
+#[test]
+fn prefix_byte_short_packet() {
+    let prefix = PacketPrefixByte::normal(3);
+    assert_eq!(prefix.short_packet_length, 3);
+}
+
+#[test]
+fn roundtrip_normal_packet() {
+    let packet = vec![0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x11, 0x22, 0x33];
+    let mut wire_buf = Vec::new();
+    let wire_len = encode_with_prefix(&packet, false, &mut wire_buf).expect("encode");
+    assert_eq!(wire_buf.len(), wire_len);
+
+    let (prefix, decoded_packet) = decode_with_prefix(&mut wire_buf).expect("decode");
+    assert!(!prefix.is_dummy());
+    assert_eq!(decoded_packet, &*packet);
+}
+
+#[test]
+fn roundtrip_dummy_packet() {
+    let packet = vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+    let mut wire_buf = Vec::new();
+    encode_with_prefix(&packet, true, &mut wire_buf).expect("encode");
+
+    let (prefix, decoded_packet) = decode_with_prefix(&mut wire_buf).expect("decode");
+    assert!(prefix.is_dummy());
+    assert_eq!(decoded_packet, &*packet);
+}
+
+#[test]
+fn roundtrip_short_packet() {
+    // Packet shorter than 7 bytes gets padded, then unpadded on receive.
+    let packet = vec![0xAA, 0xBB, 0xCC]; // 3 bytes
+    let mut wire_buf = Vec::new();
+    encode_with_prefix(&packet, false, &mut wire_buf).expect("encode");
+
+    // Wire should be 8 bytes: 1 prefix + 7 (padded from 3).
+    assert_eq!(wire_buf.len(), 8);
+
+    let (prefix, decoded_packet) = decode_with_prefix(&mut wire_buf).expect("decode");
+    assert_eq!(prefix.short_packet_length, 3);
+    assert_eq!(decoded_packet, &*packet);
+}
+
+#[test]
+fn roundtrip_minimum_packet() {
+    // Minimum: 2 bytes (the v2 header alone).
+    let packet = vec![0x05, 0x60];
+    let mut wire_buf = Vec::new();
+    encode_with_prefix(&packet, false, &mut wire_buf).expect("encode");
+
+    let (prefix, decoded_packet) = decode_with_prefix(&mut wire_buf).expect("decode");
+    assert_eq!(prefix.short_packet_length, 2);
+    assert_eq!(decoded_packet, &*packet);
+}
+
+#[test]
+fn roundtrip_large_packet() {
+    // Near-MTU packet.
+    let packet: Vec<u8> = (0..1200u32)
+        .map(|i| u8::try_from(i % 256).expect("modulo 256 fits in u8"))
+        .collect();
+    let mut wire_buf = Vec::new();
+    encode_with_prefix(&packet, false, &mut wire_buf).expect("encode");
+
+    let (prefix, decoded_packet) = decode_with_prefix(&mut wire_buf).expect("decode");
+    assert!(!prefix.is_dummy());
+    assert_eq!(prefix.short_packet_length, 7);
+    assert_eq!(decoded_packet, &*packet);
+}
+
+#[test]
+fn decode_payload_too_short() {
+    let mut wire = vec![0x00, 0x01, 0x02]; // only 3 bytes, need 8
+    let result = decode_with_prefix(&mut wire);
+    assert!(matches!(result, Err(PrefixError::PayloadTooShort { .. })));
+}

--- a/crates/ironrdp-testsuite-core/tests/rdpeudp/pdu_v2_ack.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeudp/pdu_v2_ack.rs
@@ -1,0 +1,378 @@
+use ironrdp_core::{DecodeResult, Encode as _, decode, encode_vec};
+use ironrdp_rdpeudp::pdu::*;
+// ── AckPayload tests ──
+
+#[test]
+fn ack_payload_no_delayed() {
+    let ack = AckPayload {
+        seq_num: 0x1234,
+        received_ts: 0x00AB_CDEF,
+        send_ack_time_gap: 5,
+        delay_ack_time_scale: 0,
+        delay_ack_time_additions: Vec::new(),
+    };
+    let encoded = encode_vec(&ack).expect("encode");
+    assert_eq!(ack.size(), 7);
+    assert_eq!(encoded.len(), 7);
+
+    let decoded: AckPayload = decode(&encoded).expect("decode");
+    assert_eq!(decoded, ack);
+}
+
+#[test]
+fn ack_payload_with_delayed() {
+    let ack = AckPayload {
+        seq_num: 0x0042,
+        received_ts: 0x00_123456,
+        send_ack_time_gap: 10,
+        delay_ack_time_scale: 2,
+        delay_ack_time_additions: vec![15, 20, 25],
+    };
+    let encoded = encode_vec(&ack).expect("encode");
+    assert_eq!(ack.size(), 10); // 7 + 3
+    assert_eq!(encoded.len(), 10);
+
+    let decoded: AckPayload = decode(&encoded).expect("decode");
+    assert_eq!(decoded, ack);
+}
+
+#[test]
+fn ack_payload_timestamp_24bit() {
+    let ack = AckPayload {
+        seq_num: 0,
+        received_ts: 0x00FF_FFFF, // max 24-bit value
+        send_ack_time_gap: 0,
+        delay_ack_time_scale: 0,
+        delay_ack_time_additions: Vec::new(),
+    };
+    let encoded = encode_vec(&ack).expect("encode");
+    let decoded: AckPayload = decode(&encoded).expect("decode");
+    assert_eq!(decoded.received_ts, 0x00FF_FFFF);
+}
+
+#[test]
+fn ack_payload_timestamp_masked() {
+    // Setting bits above 24 should be masked on encode
+    let ack = AckPayload {
+        seq_num: 0,
+        received_ts: 0xFFFF_FFFF, // bits above 24 set
+        send_ack_time_gap: 0,
+        delay_ack_time_scale: 0,
+        delay_ack_time_additions: Vec::new(),
+    };
+    let encoded = encode_vec(&ack).expect("encode");
+    let decoded: AckPayload = decode(&encoded).expect("decode");
+    assert_eq!(decoded.received_ts, 0x00FF_FFFF);
+}
+
+#[test]
+fn ack_payload_nibble_packing() {
+    // [MS-RDPEUDP2] 2.2.1.2.1: numDelayedAcks is the low nibble and
+    // delayAckTimeScale the high nibble of byte 6.
+    let ack = AckPayload {
+        seq_num: 0,
+        received_ts: 0,
+        send_ack_time_gap: 0,
+        delay_ack_time_scale: 8, // arbitrary 4-bit value
+        delay_ack_time_additions: vec![0; 15],
+    };
+    let encoded = encode_vec(&ack).expect("encode");
+    // (scale 8 << 4) | count 15 = 0x8F
+    assert_eq!(encoded[6], 0x8F);
+
+    let decoded: AckPayload = decode(&encoded).expect("decode");
+    assert_eq!(decoded.delay_ack_time_additions.len(), 15);
+    assert_eq!(decoded.delay_ack_time_scale, 8);
+}
+
+#[test]
+fn ack_payload_insufficient_bytes() {
+    let bytes = [0x00, 0x00, 0x00]; // only 3 bytes, need 7
+    let result: DecodeResult<AckPayload> = decode(&bytes);
+    assert!(result.is_err());
+}
+
+#[test]
+fn ack_payload_insufficient_additions() {
+    // Claims 5 delayed acks but no addition bytes follow
+    let bytes = [
+        0x00, 0x00, // seq_num
+        0x00, 0x00, 0x00, // received_ts
+        0x00, // send_ack_time_gap
+        0x05, // numDelayedAcks=5 in the low nibble, scale=0 in the high
+              // missing 5 addition bytes
+    ];
+    let result: DecodeResult<AckPayload> = decode(&bytes);
+    assert!(result.is_err());
+}
+
+// ── AckVectorEntry tests ──
+
+#[test]
+fn state_map_entry() {
+    let entry = AckVectorEntry::StateMap { bitmap: 0b0110_1010 };
+    let byte = entry.to_byte();
+    assert_eq!(byte & 0x80, 0, "MSB should be 0 for state-map");
+    assert_eq!(byte, 0b0110_1010);
+    let decoded = AckVectorEntry::from_byte(byte);
+    assert_eq!(decoded, entry);
+}
+
+#[test]
+fn run_length_received() {
+    let entry = AckVectorEntry::RunLength {
+        received: true,
+        length: 42,
+    };
+    let byte = entry.to_byte();
+    assert_eq!(byte, 0x80 | 0x40 | 42); // MSB=1, state=1, length=42
+    let decoded = AckVectorEntry::from_byte(byte);
+    assert_eq!(decoded, entry);
+}
+
+#[test]
+fn run_length_not_received() {
+    let entry = AckVectorEntry::RunLength {
+        received: false,
+        length: 7,
+    };
+    let byte = entry.to_byte();
+    assert_eq!(byte, 0x80 | 7); // MSB=1, state=0, length=7
+    let decoded = AckVectorEntry::from_byte(byte);
+    assert_eq!(decoded, entry);
+}
+
+#[test]
+fn run_length_max() {
+    let entry = AckVectorEntry::RunLength {
+        received: true,
+        length: 63, // 6-bit max
+    };
+    let byte = entry.to_byte();
+    assert_eq!(byte, 0xFF); // 0x80 | 0x40 | 0x3F
+    let decoded = AckVectorEntry::from_byte(byte);
+    assert_eq!(decoded, entry);
+}
+
+#[test]
+fn entry_coverage() {
+    let map = AckVectorEntry::StateMap { bitmap: 0x7F };
+    assert_eq!(map.coverage(), 7);
+
+    let run = AckVectorEntry::RunLength {
+        received: true,
+        length: 30,
+    };
+    assert_eq!(run.coverage(), 30);
+}
+
+// ── AckVectorPayload tests ──
+
+#[test]
+fn ack_vector_no_timestamp() {
+    let payload = AckVectorPayload {
+        base_seq_num: 0x0100,
+        timestamp: None,
+        send_ack_time_gap_ms: None,
+        entries: vec![
+            AckVectorEntry::RunLength {
+                received: true,
+                length: 10,
+            },
+            AckVectorEntry::StateMap { bitmap: 0b010_1010 },
+        ],
+    };
+    let encoded = encode_vec(&payload).expect("encode");
+    assert_eq!(payload.size(), 3 + 2); // 3 fixed + 2 entries
+    assert_eq!(encoded.len(), 5);
+
+    let decoded: AckVectorPayload = decode(&encoded).expect("decode");
+    assert_eq!(decoded, payload);
+}
+
+#[test]
+fn ack_vector_with_timestamp() {
+    let payload = AckVectorPayload {
+        base_seq_num: 0x0042,
+        timestamp: Some(0x00AB_CDEF),
+        send_ack_time_gap_ms: Some(25),
+        entries: vec![AckVectorEntry::RunLength {
+            received: true,
+            length: 20,
+        }],
+    };
+    let encoded = encode_vec(&payload).expect("encode");
+    assert_eq!(payload.size(), 3 + 4 + 1); // 3 fixed + 4 timestamp block + 1 entry
+    assert_eq!(encoded.len(), 8);
+    // Exact bytes, not just length: a round trip alone would not catch the
+    // timestamp and gap fields being swapped symmetrically in both encode
+    // and decode. base_seq_num=0x0042, packed=0x81 (1 entry, timestamp
+    // present), timestamp 0x00ABCDEF little-endian is EF CD AB, gap=25=0x19,
+    // entry RunLength{received:true, length:20} is 0xD4.
+    assert_eq!(encoded.as_slice(), &[0x42, 0x00, 0x81, 0xEF, 0xCD, 0xAB, 0x19, 0xD4]);
+
+    let decoded: AckVectorPayload = decode(&encoded).expect("decode");
+    assert_eq!(decoded, payload);
+}
+
+#[test]
+fn ack_vector_empty_entries() {
+    let payload = AckVectorPayload {
+        base_seq_num: 0,
+        timestamp: None,
+        send_ack_time_gap_ms: None,
+        entries: Vec::new(),
+    };
+    let encoded = encode_vec(&payload).expect("encode");
+    assert_eq!(payload.size(), 3);
+
+    let decoded: AckVectorPayload = decode(&encoded).expect("decode");
+    assert_eq!(decoded, payload);
+}
+
+#[test]
+fn ack_vector_roundtrip_mixed_entries() {
+    let payload = AckVectorPayload {
+        base_seq_num: 500,
+        timestamp: Some(0x00_AABBCC),
+        send_ack_time_gap_ms: Some(100),
+        entries: vec![
+            AckVectorEntry::RunLength {
+                received: true,
+                length: 63,
+            },
+            AckVectorEntry::StateMap { bitmap: 0b0111_1111 },
+            AckVectorEntry::RunLength {
+                received: false,
+                length: 1,
+            },
+            AckVectorEntry::RunLength {
+                received: true,
+                length: 5,
+            },
+        ],
+    };
+    let encoded = encode_vec(&payload).expect("encode");
+    let decoded: AckVectorPayload = decode(&encoded).expect("decode");
+    assert_eq!(decoded, payload);
+}
+
+#[test]
+fn ack_vector_rejects_a_state_map_bitmap_above_the_7_bit_maximum() {
+    let payload = AckVectorPayload {
+        base_seq_num: 0,
+        timestamp: None,
+        send_ack_time_gap_ms: None,
+        entries: vec![AckVectorEntry::StateMap { bitmap: 0x80 }],
+    };
+    assert!(encode_vec(&payload).is_err());
+}
+
+#[test]
+fn ack_vector_rejects_a_run_length_above_the_6_bit_maximum() {
+    let payload = AckVectorPayload {
+        base_seq_num: 0,
+        timestamp: None,
+        send_ack_time_gap_ms: None,
+        entries: vec![AckVectorEntry::RunLength {
+            received: true,
+            length: 64,
+        }],
+    };
+    assert!(encode_vec(&payload).is_err());
+}
+
+#[test]
+fn ack_vector_rejects_a_timestamp_without_a_gap() {
+    let payload = AckVectorPayload {
+        base_seq_num: 0,
+        timestamp: Some(0x00_AABBCC),
+        send_ack_time_gap_ms: None,
+        entries: vec![],
+    };
+    assert!(encode_vec(&payload).is_err());
+}
+
+#[test]
+fn ack_vector_rejects_a_gap_without_a_timestamp() {
+    let payload = AckVectorPayload {
+        base_seq_num: 0,
+        timestamp: None,
+        send_ack_time_gap_ms: Some(100),
+        entries: vec![],
+    };
+    assert!(encode_vec(&payload).is_err());
+}
+
+#[test]
+fn ack_vector_insufficient_bytes() {
+    let bytes = [0x00, 0x00]; // only 2 bytes, need 3
+    let result: DecodeResult<AckVectorPayload> = decode(&bytes);
+    assert!(result.is_err());
+}
+
+#[test]
+fn ack_vector_insufficient_entries() {
+    // Claims 10 entries but provides none
+    let bytes = [
+        0x00, 0x00, // base_seq_num
+        10,   // codedAckVecSize=10, TimeStampPresent=0
+    ];
+    let result: DecodeResult<AckVectorPayload> = decode(&bytes);
+    assert!(result.is_err());
+}
+
+#[test]
+fn ack_vector_insufficient_timestamp_block() {
+    // TimeStampPresent=1 but not enough bytes for the timestamp block
+    let bytes = [
+        0x00, 0x00, // base_seq_num
+        0x80, // codedAckVecSize=0, TimeStampPresent=1
+        0x05, // only 1 byte of the 4-byte timestamp block
+    ];
+    let result: DecodeResult<AckVectorPayload> = decode(&bytes);
+    assert!(result.is_err());
+}
+
+/// The delayed-ACK count is carried in a 4-bit nibble, so a vector that cannot
+/// be expressed must be rejected rather than truncated.
+///
+/// Truncating produced a packet whose header promised delayed ACKs the encoder
+/// never wrote, which a peer would then read out of the following payload.
+/// Found by the `rdpeudp_pdu_round_trip` fuzz oracle.
+#[test]
+fn ack_payload_rejects_more_delayed_acks_than_the_nibble_holds() {
+    let ack = AckPayload {
+        seq_num: 0,
+        received_ts: 0,
+        send_ack_time_gap: 0,
+        delay_ack_time_scale: 0,
+        delay_ack_time_additions: vec![0; 16],
+    };
+
+    encode_vec(&ack).expect_err("16 delayed ACKs do not fit in a 4-bit count");
+}
+
+/// The count on the wire always matches the vector that was encoded.
+#[test]
+fn ack_payload_count_follows_the_vector() {
+    for len in [0usize, 1, 7, 15] {
+        let ack = AckPayload {
+            seq_num: 1,
+            received_ts: 2,
+            send_ack_time_gap: 3,
+            delay_ack_time_scale: 4,
+            delay_ack_time_additions: vec![0xAA; len],
+        };
+
+        let encoded = encode_vec(&ack).expect("encode");
+        assert_eq!(
+            usize::from(encoded[6] & 0x0F),
+            len,
+            "packed count disagrees with the vector"
+        );
+
+        let decoded: AckPayload = decode(&encoded).expect("decode");
+        assert_eq!(decoded, ack, "round-trip changed the value");
+    }
+}

--- a/crates/ironrdp-testsuite-core/tests/rdpeudp/pdu_v2_control.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeudp/pdu_v2_control.rs
@@ -1,0 +1,149 @@
+use ironrdp_core::{DecodeResult, Encode as _, decode, encode_vec};
+use ironrdp_rdpeudp::pdu::*;
+// ── OverheadSize tests ──
+
+#[test]
+fn overhead_size_roundtrip() {
+    let original = OverheadSizePayload { overhead_size: 42 };
+    let encoded = encode_vec(&original).expect("encode");
+    assert_eq!(encoded.as_slice(), &[42]);
+    assert_eq!(original.size(), 1);
+
+    let decoded: OverheadSizePayload = decode(&encoded).expect("decode");
+    assert_eq!(original, decoded);
+}
+
+#[test]
+fn overhead_size_zero() {
+    let original = OverheadSizePayload { overhead_size: 0 };
+    let encoded = encode_vec(&original).expect("encode");
+    let decoded: OverheadSizePayload = decode(&encoded).expect("decode");
+    assert_eq!(original, decoded);
+}
+
+#[test]
+fn overhead_size_max() {
+    let original = OverheadSizePayload { overhead_size: 0xFF };
+    let encoded = encode_vec(&original).expect("encode");
+    let decoded: OverheadSizePayload = decode(&encoded).expect("decode");
+    assert_eq!(original, decoded);
+}
+
+#[test]
+fn overhead_size_insufficient_bytes() {
+    let bytes: [u8; 0] = [];
+    let result: DecodeResult<OverheadSizePayload> = decode(&bytes);
+    assert!(result.is_err());
+}
+
+// ── DelayAckInfo tests ──
+
+#[test]
+fn delay_ack_info_encode() {
+    let payload = DelayAckInfoPayload {
+        max_delayed_acks: 8,
+        delayed_ack_timeout_ms: 150,
+    };
+    let encoded = encode_vec(&payload).expect("encode");
+    assert_eq!(
+        encoded.as_slice(),
+        &[
+            0x08, // MaxDelayedAcks is a whole byte per 2.2.1.2.3
+            0x96, 0x00, // DelayedAckTimeoutInMs = 150, little-endian
+        ]
+    );
+    assert_eq!(payload.size(), 3);
+}
+
+#[test]
+fn delay_ack_info_decode() {
+    let bytes = [0x08, 0x96, 0x00];
+    let decoded: DelayAckInfoPayload = decode(&bytes).expect("decode");
+    assert_eq!(decoded.max_delayed_acks, 8);
+    assert_eq!(decoded.delayed_ack_timeout_ms, 150);
+}
+
+#[test]
+fn delay_ack_info_roundtrip() {
+    let original = DelayAckInfoPayload {
+        max_delayed_acks: 15,
+        delayed_ack_timeout_ms: 1000,
+    };
+    let encoded = encode_vec(&original).expect("encode");
+    let decoded: DelayAckInfoPayload = decode(&encoded).expect("decode");
+    assert_eq!(original, decoded);
+}
+
+#[test]
+fn delay_ack_info_default_values() {
+    let payload = DelayAckInfoPayload {
+        max_delayed_acks: DelayAckInfoPayload::DEFAULT_MAX_DELAYED_ACKS,
+        delayed_ack_timeout_ms: 50,
+    };
+    assert_eq!(payload.max_delayed_acks, 8);
+}
+
+#[test]
+fn delay_ack_info_insufficient_bytes() {
+    let bytes = [0x80, 0x96]; // only 2 bytes, need 3
+    let result: DecodeResult<DelayAckInfoPayload> = decode(&bytes);
+    assert!(result.is_err());
+}
+
+// ── AckOfAcks tests ──
+
+#[test]
+fn ack_of_acks_roundtrip() {
+    let original = AckOfAcksPayload {
+        ack_of_acks_seq_num: 0x1234,
+    };
+    let encoded = encode_vec(&original).expect("encode");
+    assert_eq!(encoded.as_slice(), &[0x34, 0x12]); // little-endian
+    assert_eq!(original.size(), 2);
+
+    let decoded: AckOfAcksPayload = decode(&encoded).expect("decode");
+    assert_eq!(original, decoded);
+}
+
+#[test]
+fn ack_of_acks_zero() {
+    let original = AckOfAcksPayload { ack_of_acks_seq_num: 0 };
+    let encoded = encode_vec(&original).expect("encode");
+    let decoded: AckOfAcksPayload = decode(&encoded).expect("decode");
+    assert_eq!(original, decoded);
+}
+
+#[test]
+fn ack_of_acks_max() {
+    let original = AckOfAcksPayload {
+        ack_of_acks_seq_num: 0xFFFF,
+    };
+    let encoded = encode_vec(&original).expect("encode");
+    let decoded: AckOfAcksPayload = decode(&encoded).expect("decode");
+    assert_eq!(original, decoded);
+}
+
+#[test]
+fn ack_of_acks_insufficient_bytes() {
+    let bytes = [0x34]; // only 1 byte, need 2
+    let result: DecodeResult<AckOfAcksPayload> = decode(&bytes);
+    assert!(result.is_err());
+}
+
+/// MaxDelayedAcks is a full byte, so values above 15 survive the round trip.
+///
+/// It was previously packed into a nibble, which silently truncated anything
+/// larger and made the sender's advertised limit unrepresentable.
+#[test]
+fn delay_ack_info_carries_a_full_byte_of_max_delayed_acks() {
+    for max_delayed_acks in [0u8, 15, 16, 200, 255] {
+        let payload = DelayAckInfoPayload {
+            max_delayed_acks,
+            delayed_ack_timeout_ms: 42,
+        };
+
+        let encoded = encode_vec(&payload).expect("encode");
+        assert_eq!(encoded[0], max_delayed_acks);
+        assert_eq!(decode::<DelayAckInfoPayload>(&encoded).expect("decode"), payload);
+    }
+}

--- a/crates/ironrdp-testsuite-core/tests/rdpeudp/pdu_v2_data.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeudp/pdu_v2_data.rs
@@ -1,0 +1,123 @@
+use ironrdp_core::{Decode as _, DecodeResult, Encode as _, ReadCursor, WriteCursor, decode, encode_vec};
+use ironrdp_rdpeudp::pdu::*;
+// ── DataHeader tests ──
+
+#[test]
+fn data_header_encode() {
+    let header = DataHeader { data_seq_num: 0x1234 };
+    let encoded = encode_vec(&header).expect("encode");
+    assert_eq!(encoded.as_slice(), &[0x34, 0x12]); // little-endian
+}
+
+#[test]
+fn data_header_decode() {
+    let bytes = [0x34, 0x12];
+    let decoded: DataHeader = decode(&bytes).expect("decode");
+    assert_eq!(decoded.data_seq_num, 0x1234);
+}
+
+#[test]
+fn data_header_roundtrip() {
+    let original = DataHeader { data_seq_num: 0xFFFF };
+    let encoded = encode_vec(&original).expect("encode");
+    let decoded: DataHeader = decode(&encoded).expect("decode");
+    assert_eq!(original, decoded);
+}
+
+#[test]
+fn data_header_size() {
+    let header = DataHeader { data_seq_num: 0 };
+    assert_eq!(header.size(), 2);
+}
+
+#[test]
+fn data_header_insufficient_bytes() {
+    let bytes = [0x34]; // only 1 byte, need 2
+    let result: DecodeResult<DataHeader> = decode(&bytes);
+    assert!(result.is_err());
+}
+
+// ── DataBody tests ──
+
+#[test]
+fn data_body_with_payload() {
+    let body = DataBody {
+        channel_seq_num: 0x0042,
+        data: vec![0x01, 0x02, 0x03, 0x04],
+    };
+    let encoded = encode_vec(&body).expect("encode");
+    assert_eq!(
+        encoded.as_slice(),
+        &[
+            0x42, 0x00, // channel_seq_num = 0x0042
+            0x01, 0x02, 0x03, 0x04, // data
+        ]
+    );
+    assert_eq!(body.size(), 6);
+}
+
+#[test]
+fn data_body_empty_data() {
+    let body = DataBody {
+        channel_seq_num: 0,
+        data: Vec::new(),
+    };
+    let encoded = encode_vec(&body).expect("encode");
+    assert_eq!(encoded.as_slice(), &[0x00, 0x00]);
+    assert_eq!(body.size(), 2);
+}
+
+#[test]
+fn data_body_roundtrip() {
+    let original = DataBody {
+        channel_seq_num: 0xABCD,
+        data: vec![0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE],
+    };
+    let encoded = encode_vec(&original).expect("encode");
+    let decoded: DataBody = decode(&encoded).expect("decode");
+    assert_eq!(original, decoded);
+}
+
+#[test]
+fn data_body_large_payload() {
+    // Simulate a near-MTU payload
+    let original = DataBody {
+        channel_seq_num: 1,
+        data: vec![0xAA; 1200],
+    };
+    let encoded = encode_vec(&original).expect("encode");
+    let decoded: DataBody = decode(&encoded).expect("decode");
+    assert_eq!(original.data.len(), decoded.data.len());
+    assert_eq!(original, decoded);
+}
+
+#[test]
+fn data_body_insufficient_bytes() {
+    let bytes = [0x42]; // only 1 byte, need 2 for ChannelSeqNum
+    let result: DecodeResult<DataBody> = decode(&bytes);
+    assert!(result.is_err());
+}
+
+// ── Combined DataHeader + DataBody test ──
+
+#[test]
+fn data_header_then_body_sequential() {
+    // Simulate reading a DATA payload: DataHeader then DataBody
+    let header = DataHeader { data_seq_num: 100 };
+    let body = DataBody {
+        channel_seq_num: 50,
+        data: vec![0x11, 0x22, 0x33],
+    };
+
+    let mut buf = vec![0u8; header.size() + body.size()];
+    let mut cursor = WriteCursor::new(&mut buf);
+    header.encode(&mut cursor).expect("encode header");
+    body.encode(&mut cursor).expect("encode body");
+
+    let mut read_cursor = ReadCursor::new(&buf);
+    let decoded_header = DataHeader::decode(&mut read_cursor).expect("decode header");
+    let decoded_body = DataBody::decode(&mut read_cursor).expect("decode body");
+
+    assert_eq!(decoded_header, header);
+    assert_eq!(decoded_body, body);
+}

--- a/crates/ironrdp-testsuite-core/tests/rdpeudp/pdu_v2_packet.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeudp/pdu_v2_packet.rs
@@ -1,0 +1,493 @@
+use ironrdp_core::{DecodeResult, Encode as _, decode, encode_vec};
+use ironrdp_rdpeudp::pdu::*;
+// ════════════════════════════════════════════════════════════════
+// V2Packet tests
+// ════════════════════════════════════════════════════════════════
+
+/// ACK-only packet.
+#[test]
+fn v2_ack_only_roundtrip() {
+    let packet = V2Packet {
+        header: V2Header {
+            flags: V2Flags::ACK,
+            log_window_size: 6,
+        },
+        ack: Some(AckPayload {
+            seq_num: 0x0042,
+            received_ts: 0x00_123456,
+            send_ack_time_gap: 5,
+            delay_ack_time_scale: 0,
+            delay_ack_time_additions: Vec::new(),
+        }),
+        overhead_size: None,
+        delay_ack_info: None,
+        ack_of_acks: None,
+        data_header: None,
+        ack_vector: None,
+        data_body: None,
+    };
+
+    // header(2) + ack(7) = 9
+    assert_eq!(packet.size(), 9);
+
+    let encoded = encode_vec(&packet).expect("encode");
+    let decoded: V2Packet = decode(&encoded).expect("decode");
+    assert_eq!(decoded, packet);
+}
+
+/// DATA-only packet.
+#[test]
+fn v2_data_only_roundtrip() {
+    let packet = V2Packet {
+        header: V2Header {
+            flags: V2Flags::DATA,
+            log_window_size: 8,
+        },
+        ack: None,
+        overhead_size: None,
+        delay_ack_info: None,
+        ack_of_acks: None,
+        data_header: Some(DataHeader { data_seq_num: 0x0100 }),
+        ack_vector: None,
+        data_body: Some(DataBody {
+            channel_seq_num: 0x0001,
+            data: vec![0xDE, 0xAD, 0xBE, 0xEF],
+        }),
+    };
+
+    // header(2) + data_header(2) + data_body(2+4=6) = 10
+    assert_eq!(packet.size(), 10);
+
+    let encoded = encode_vec(&packet).expect("encode");
+    let decoded: V2Packet = decode(&encoded).expect("decode");
+    assert_eq!(decoded, packet);
+}
+
+/// ACK + DATA combined.
+#[test]
+fn v2_ack_with_data_roundtrip() {
+    let packet = V2Packet {
+        header: V2Header {
+            flags: V2Flags::ACK | V2Flags::DATA,
+            log_window_size: 6,
+        },
+        ack: Some(AckPayload {
+            seq_num: 50,
+            received_ts: 0x00_AABBCC,
+            send_ack_time_gap: 10,
+            delay_ack_time_scale: 3,
+            delay_ack_time_additions: vec![15, 20],
+        }),
+        overhead_size: None,
+        delay_ack_info: None,
+        ack_of_acks: None,
+        data_header: Some(DataHeader { data_seq_num: 0x1234 }),
+        ack_vector: None,
+        data_body: Some(DataBody {
+            channel_seq_num: 100,
+            data: vec![0x01, 0x02, 0x03],
+        }),
+    };
+
+    let encoded = encode_vec(&packet).expect("encode");
+    let decoded: V2Packet = decode(&encoded).expect("decode");
+    assert_eq!(decoded, packet);
+}
+
+/// ACKVEC packet (mutually exclusive with ACK).
+#[test]
+fn v2_ackvec_roundtrip() {
+    let packet = V2Packet {
+        header: V2Header {
+            flags: V2Flags::ACKVEC,
+            log_window_size: 10,
+        },
+        ack: None,
+        overhead_size: None,
+        delay_ack_info: None,
+        ack_of_acks: None,
+        data_header: None,
+        ack_vector: Some(AckVectorPayload {
+            base_seq_num: 0x0100,
+            timestamp: Some(0x00_AABBCC),
+            send_ack_time_gap_ms: Some(25),
+            entries: vec![
+                AckVectorEntry::RunLength {
+                    received: true,
+                    length: 20,
+                },
+                AckVectorEntry::StateMap { bitmap: 0b0110_1010 },
+            ],
+        }),
+        data_body: None,
+    };
+
+    let encoded = encode_vec(&packet).expect("encode");
+    let decoded: V2Packet = decode(&encoded).expect("decode");
+    assert_eq!(decoded, packet);
+}
+
+/// All control payloads at once: OverheadSize + DelayAckInfo + AOA.
+#[test]
+fn v2_all_control_payloads_roundtrip() {
+    let packet = V2Packet {
+        header: V2Header {
+            flags: V2Flags::ACK | V2Flags::OVERHEADSIZE | V2Flags::DELAYACKINFO | V2Flags::AOA,
+            log_window_size: 6,
+        },
+        ack: Some(AckPayload {
+            seq_num: 10,
+            received_ts: 500_000,
+            send_ack_time_gap: 3,
+            delay_ack_time_scale: 0,
+            delay_ack_time_additions: Vec::new(),
+        }),
+        overhead_size: Some(OverheadSizePayload { overhead_size: 28 }),
+        delay_ack_info: Some(DelayAckInfoPayload {
+            max_delayed_acks: 8,
+            delayed_ack_timeout_ms: 150,
+        }),
+        ack_of_acks: Some(AckOfAcksPayload { ack_of_acks_seq_num: 5 }),
+        data_header: None,
+        ack_vector: None,
+        data_body: None,
+    };
+
+    // header(2) + ack(7) + overhead(1) + delay_ack_info(3) + aoa(2) = 15
+    assert_eq!(packet.size(), 15);
+
+    let encoded = encode_vec(&packet).expect("encode");
+    let decoded: V2Packet = decode(&encoded).expect("decode");
+    assert_eq!(decoded, packet);
+}
+
+/// Full packet with ACK + OverheadSize + DelayAckInfo + AOA + DATA.
+#[test]
+fn v2_full_packet_roundtrip() {
+    let packet = V2Packet {
+        header: V2Header {
+            flags: V2Flags::ACK | V2Flags::OVERHEADSIZE | V2Flags::DELAYACKINFO | V2Flags::AOA | V2Flags::DATA,
+            log_window_size: 8,
+        },
+        ack: Some(AckPayload {
+            seq_num: 0x1000,
+            received_ts: 0x00_FFFFFF,
+            send_ack_time_gap: 50,
+            delay_ack_time_scale: 2,
+            delay_ack_time_additions: vec![10, 20, 30],
+        }),
+        overhead_size: Some(OverheadSizePayload { overhead_size: 40 }),
+        delay_ack_info: Some(DelayAckInfoPayload {
+            max_delayed_acks: 15,
+            delayed_ack_timeout_ms: 500,
+        }),
+        ack_of_acks: Some(AckOfAcksPayload {
+            ack_of_acks_seq_num: 0x0FF0,
+        }),
+        data_header: Some(DataHeader { data_seq_num: 0x2000 }),
+        ack_vector: None,
+        data_body: Some(DataBody {
+            channel_seq_num: 0x1000,
+            data: vec![0x55; 100],
+        }),
+    };
+
+    let encoded = encode_vec(&packet).expect("encode");
+    let decoded: V2Packet = decode(&encoded).expect("decode");
+    assert_eq!(decoded, packet);
+}
+
+/// Verify flags are auto-computed from populated fields.
+#[test]
+fn v2_flags_auto_computed_on_encode() {
+    let packet = V2Packet {
+        header: V2Header {
+            // Caller only set DATA, but ack is also populated
+            flags: V2Flags::DATA,
+            log_window_size: 6,
+        },
+        ack: Some(AckPayload {
+            seq_num: 1,
+            received_ts: 0,
+            send_ack_time_gap: 0,
+            delay_ack_time_scale: 0,
+            delay_ack_time_additions: Vec::new(),
+        }),
+        overhead_size: None,
+        delay_ack_info: None,
+        ack_of_acks: None,
+        data_header: Some(DataHeader { data_seq_num: 1 }),
+        ack_vector: None,
+        data_body: Some(DataBody {
+            channel_seq_num: 1,
+            data: vec![0x42],
+        }),
+    };
+
+    let encoded = encode_vec(&packet).expect("encode");
+    let decoded: V2Packet = decode(&encoded).expect("decode");
+
+    // ACK should be auto-added
+    assert!(decoded.header.flags.contains(V2Flags::ACK));
+    // DATA should be present
+    assert!(decoded.header.flags.contains(V2Flags::DATA));
+    // ACKVEC should NOT be set
+    assert!(!decoded.header.flags.contains(V2Flags::ACKVEC));
+}
+
+/// The v2 header has no standalone flags, so a bit the caller sets without the
+/// payload it announces does not survive the round trip.
+///
+/// Every flag [MS-RDPEUDP2] 2.2.1.1 defines announces a payload. There is
+/// nothing like the v1 header's CN, CWR or SYNLOSSY, which stand on their own
+/// and have to be carried across.
+#[test]
+fn v2_has_no_standalone_flags() {
+    let packet = V2Packet {
+        header: V2Header {
+            // ACKVEC announces a payload this packet does not carry.
+            flags: V2Flags::ACK | V2Flags::ACKVEC,
+            log_window_size: 6,
+        },
+        ack: Some(AckPayload {
+            seq_num: 1,
+            received_ts: 0,
+            send_ack_time_gap: 0,
+            delay_ack_time_scale: 0,
+            delay_ack_time_additions: Vec::new(),
+        }),
+        overhead_size: None,
+        delay_ack_info: None,
+        ack_of_acks: None,
+        data_header: None,
+        ack_vector: None,
+        data_body: None,
+    };
+
+    let encoded = encode_vec(&packet).expect("encode");
+    let decoded: V2Packet = decode(&encoded).expect("decode");
+
+    assert_eq!(
+        decoded.header.flags,
+        V2Flags::ACK,
+        "flags should describe exactly the payloads present"
+    );
+}
+
+/// Encode rejects ACK + ACKVEC both set.
+#[test]
+fn v2_ack_and_ackvec_mutual_exclusion_encode() {
+    let packet = V2Packet {
+        header: V2Header {
+            flags: V2Flags::empty(),
+            log_window_size: 6,
+        },
+        ack: Some(AckPayload {
+            seq_num: 1,
+            received_ts: 0,
+            send_ack_time_gap: 0,
+            delay_ack_time_scale: 0,
+            delay_ack_time_additions: Vec::new(),
+        }),
+        overhead_size: None,
+        delay_ack_info: None,
+        ack_of_acks: None,
+        data_header: None,
+        ack_vector: Some(AckVectorPayload {
+            base_seq_num: 0,
+            timestamp: None,
+            send_ack_time_gap_ms: None,
+            entries: Vec::new(),
+        }),
+        data_body: None,
+    };
+
+    let result = encode_vec(&packet);
+    assert!(result.is_err());
+}
+
+/// Encode rejects data_header without data_body.
+#[test]
+fn v2_data_header_without_body_rejected() {
+    let packet = V2Packet {
+        header: V2Header {
+            flags: V2Flags::DATA,
+            log_window_size: 6,
+        },
+        ack: None,
+        overhead_size: None,
+        delay_ack_info: None,
+        ack_of_acks: None,
+        data_header: Some(DataHeader { data_seq_num: 1 }),
+        ack_vector: None,
+        data_body: None, // Missing!
+    };
+
+    let result = encode_vec(&packet);
+    assert!(result.is_err());
+}
+
+/// Encode rejects data_body without data_header.
+#[test]
+fn v2_data_body_without_header_rejected() {
+    let packet = V2Packet {
+        header: V2Header {
+            flags: V2Flags::DATA,
+            log_window_size: 6,
+        },
+        ack: None,
+        overhead_size: None,
+        delay_ack_info: None,
+        ack_of_acks: None,
+        data_header: None, // Missing!
+        ack_vector: None,
+        data_body: Some(DataBody {
+            channel_seq_num: 1,
+            data: vec![0x01],
+        }),
+    };
+
+    let result = encode_vec(&packet);
+    assert!(result.is_err());
+}
+
+/// Empty packet: just header, no payloads.
+#[test]
+fn v2_empty_packet_roundtrip() {
+    let packet = V2Packet {
+        header: V2Header {
+            flags: V2Flags::empty(),
+            log_window_size: 6,
+        },
+        ack: None,
+        overhead_size: None,
+        delay_ack_info: None,
+        ack_of_acks: None,
+        data_header: None,
+        ack_vector: None,
+        data_body: None,
+    };
+
+    assert_eq!(packet.size(), 2); // header only
+
+    let encoded = encode_vec(&packet).expect("encode");
+    let decoded: V2Packet = decode(&encoded).expect("decode");
+    assert_eq!(decoded, packet);
+}
+
+/// Insufficient bytes for V2 header.
+#[test]
+fn v2_insufficient_bytes() {
+    let bytes = [0x00]; // need 2 for header
+    let result: DecodeResult<V2Packet> = decode(&bytes);
+    assert!(result.is_err());
+}
+
+/// DataBody correctly consumes all remaining bytes.
+#[test]
+fn v2_data_body_consumes_remaining() {
+    // Build a packet with ACK + DATA, then verify data_body gets all remaining
+    let payload_data = vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+    let packet = V2Packet {
+        header: V2Header {
+            flags: V2Flags::ACK | V2Flags::DATA,
+            log_window_size: 6,
+        },
+        ack: Some(AckPayload {
+            seq_num: 1,
+            received_ts: 100,
+            send_ack_time_gap: 0,
+            delay_ack_time_scale: 0,
+            delay_ack_time_additions: Vec::new(),
+        }),
+        overhead_size: None,
+        delay_ack_info: None,
+        ack_of_acks: None,
+        data_header: Some(DataHeader { data_seq_num: 1 }),
+        ack_vector: None,
+        data_body: Some(DataBody {
+            channel_seq_num: 1,
+            data: payload_data.clone(),
+        }),
+    };
+
+    let encoded = encode_vec(&packet).expect("encode");
+    let decoded: V2Packet = decode(&encoded).expect("decode");
+
+    let body = decoded.data_body.expect("data_body should be present");
+    assert_eq!(body.data, payload_data);
+}
+
+/// ACKVEC + DATA combined (no ACK).
+#[test]
+fn v2_ackvec_with_data_roundtrip() {
+    let packet = V2Packet {
+        header: V2Header {
+            flags: V2Flags::ACKVEC | V2Flags::DATA,
+            log_window_size: 6,
+        },
+        ack: None,
+        overhead_size: None,
+        delay_ack_info: None,
+        ack_of_acks: None,
+        data_header: Some(DataHeader { data_seq_num: 0x0042 }),
+        ack_vector: Some(AckVectorPayload {
+            base_seq_num: 0x0100,
+            timestamp: None,
+            send_ack_time_gap_ms: None,
+            entries: vec![AckVectorEntry::RunLength {
+                received: true,
+                length: 10,
+            }],
+        }),
+        data_body: Some(DataBody {
+            channel_seq_num: 0x0042,
+            data: vec![0xAA, 0xBB, 0xCC],
+        }),
+    };
+
+    let encoded = encode_vec(&packet).expect("encode");
+    let decoded: V2Packet = decode(&encoded).expect("decode");
+    assert_eq!(decoded, packet);
+}
+
+/// The v2 header defines exactly six flags.
+///
+/// [MS-RDPEUDP2] 2.2.1.1 lists ACK, DATA, ACKVEC, AOA, OVERHEADSIZE and
+/// DELAYACKINFO, and nothing else. In particular there is no DUMMY flag: a
+/// dummy packet is marked by Packet_Type_Index 8 in the PacketPrefixByte
+/// (3.1.1.1.5), one layer down.
+#[test]
+fn v2_header_flags_match_the_spec_table() {
+    assert_eq!(V2Flags::ACK.bits(), 0x001);
+    assert_eq!(V2Flags::DATA.bits(), 0x004);
+    assert_eq!(V2Flags::ACKVEC.bits(), 0x008);
+    assert_eq!(V2Flags::AOA.bits(), 0x010);
+    assert_eq!(V2Flags::OVERHEADSIZE.bits(), 0x040);
+    assert_eq!(V2Flags::DELAYACKINFO.bits(), 0x100);
+}
+
+/// Near-MTU data packet.
+#[test]
+fn v2_large_data_packet_roundtrip() {
+    let packet = V2Packet {
+        header: V2Header {
+            flags: V2Flags::DATA,
+            log_window_size: 10,
+        },
+        ack: None,
+        overhead_size: None,
+        delay_ack_info: None,
+        ack_of_acks: None,
+        data_header: Some(DataHeader { data_seq_num: 1000 }),
+        ack_vector: None,
+        data_body: Some(DataBody {
+            channel_seq_num: 500,
+            data: vec![0xCC; 1200],
+        }),
+    };
+
+    let encoded = encode_vec(&packet).expect("encode");
+    let decoded: V2Packet = decode(&encoded).expect("decode");
+    assert_eq!(decoded, packet);
+}


### PR DESCRIPTION
# feat(rdpeudp): add the RDP-UDP2 data transfer PDUs and packet framing

Third of six. Builds on the RDPEMT tunnel crate (#1626) and the v1 handshake
PDUs (#1627), both merged, adding files to the crate the second one creates.

Adds the structures [MS-RDPEUDP2] section 2.2.1 defines for data transfer, which
is where a connection goes once the handshake settles on protocol version 3: the
packet header and flags, the ACK and acknowledgment vector payloads, the
OverheadSize, DelayAckInfo and AckOfAcks control payloads, DataHeader and
DataBody, the composite packet, and the PacketPrefixByte framing from 2.2.1.3.

## Why this is a separate PR from the v1 PDUs

The two documents take **opposite conventions**. MS-RDPEUDP is big-endian and
numbers diagram bits most significant first; MS-RDPEUDP2 is little-endian and
numbers them least significant first. Reading a v2 diagram with v1 habits
produces a plausible and wrong layout for several fields, so I would rather each
be reviewed against one document at a time.

Four fields where that difference bites, all settled against worked examples
rather than against the diagrams:

**The prefix byte.** `Packet_Type_Index` occupies bits 1 to 4 and
`Short_Packet_Length` bits 5 to 7. The worked example in 3.1.1.1.5.1 gives
`PacketPrefixByte = 0x10` for a 10-byte packet, which is `Packet_Type_Index = 8`
(dummy) only under least-significant-first numbering. Read the other way round
the same byte says something else entirely.

**The ACK payload nibbles.** 2.2.1.2.1 puts `numDelayedAcks` at bits 48-51 and
`delayAckTimeScale` at 52-55, so the count is the low nibble.

**The acknowledgment vector field order.** 2.2.1.2.6 places `TimeStamp` (bits
24-47) before `SendAckTimeGapInMs` (48-55).

**DelayAckInfo.** `MaxDelayedAcks` is a whole byte, not a nibble.

## On the flag set

The header carries exactly the six flags 2.2.1.1 lists, every one of them
announcing a payload. There is deliberately no `CN`, `CWR` or `DUMMY` here: the
first two belong to MS-RDPEUDP's own `RDPUDP_FEC_HEADER`, and a dummy packet is
marked by `Packet_Type_Index` 8 in the prefix byte, one layer down. With no
standalone flags the field is derived entirely from which payloads are present,
so a caller cannot set a bit that describes nothing.

## What is not here

No connection state machine. That is the next PR.

## Test plan

`cargo xtask check fmt/lints/tests/typos/locks`

122 rdpeudp tests in `ironrdp-testsuite-core` with this PR applied, plus 44
inline `#[cfg(test)]` tests in the crate itself covering packet-prefix framing
and header/flags internals, including the 3.1.1.1.5.1 worked example.
