### PR TITLE
ci(pr-automation): allow oversized review opt-in

### DIFF
--- a/.github/PR_AUTOMATION.md
+++ b/.github/PR_AUTOMATION.md
@@ -72,13 +72,17 @@ Size uses the larger bucket from additions plus deletions in Rust, C#, JavaScrip
 | `size/XL` | 900-1299 | 21-49 |
 | `size/XXL` | 1300 or more | 50 or more |
 
-For a `size/XXL` pull request, automatic routes skip classification and review before any model runs.
-Classification falls back to deterministic scope, size, first-time-contributor, and `cargo-semver-checks` results, while every classified pull request retains exactly one `size/*` label.
+For a `size/XXL` pull request, automatic routes skip classification and review before any model runs unless a maintainer adds `ai-review/allow-oversized`.
+Without that label, classification falls back to deterministic scope, size, first-time-contributor, and `cargo-semver-checks` results, while every classified pull request retains exactly one `size/*` label.
 
 The workflow comments once to explain the exclusion and point to [stacked pull requests](https://docs.github.com/en/pull-requests/get-started/about-stacked-prs) for splitting dependent work.
 Because stacks require every branch to live in this repository, fork authors should open separate pull requests.
 The comment is removed automatically once a later push brings the change below the threshold.
 Duplicate and legitimacy verdicts are model-derived, so an oversized run leaves any earlier verdict untouched rather than silently clearing it.
+
+`ai-review/allow-oversized` remains on the pull request and treats `size/XXL` as eligible on the initial label event and later pushes.
+It permits the normal classifier and up to two automatic reviews, including protocol analysis when applicable.
+It only waives the size exclusion; CI, quota, duplicate, legitimacy, contributor-history, and review-count gates still apply.
 
 ### Fork automation limits
 
@@ -162,7 +166,7 @@ It never deletes repository labels.
 On automatic routes, risk measures maintainer scrutiny, so it does not decide whether a protocol change is worth reviewing.
 A `protocol_related` classification is review-eligible at any risk level, subject to the remaining review gates.
 For every other change, `risk/low` without `breaking-change` skips the review.
-Duplicates, `size/XXL`, a legitimacy stop, and the terminal review count stop every automatic route.
+Duplicates, `size/XXL` without `ai-review/allow-oversized`, a legitimacy stop, and the terminal review count stop every automatic route.
 
 ## Review prerequisites
 

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -147,6 +147,8 @@ test("workflow isolates CI completion concurrency by source commit", () => {
   const workflow = fs.readFileSync(path.join(__dirname, "..", "workflows", "labeler.yml"), "utf8");
   assert.match(workflow, /pr-automation-\$\{\{ github\.event_name }}-\$\{\{/);
   assert.match(workflow, /github\.event\.workflow_run\.head_sha \|\|/);
+  assert.match(workflow, /github\.event\.label\.name == 'ai-review\/allow-oversized'/);
+  assert.match(workflow, /format\('label-\{0\}', github\.event\.label\.name\)/);
   assert.doesNotMatch(workflow, /github\.event\.workflow_run\.pull_requests\[0\]\.number/);
 });
 
@@ -176,6 +178,7 @@ test("workflow force mode bypasses model policy gates without changing automatic
   assert.match(classificationGate, /if \(force\) \{/);
   assert.match(classificationGate, /setOutput\("required", true\)/);
   assert.match(classificationGate, /state\?\.automaticReviewEligible === true/);
+  assert.match(classificationGate, /run\.output\?\.title === "Classification complete"/);
 
   const classifierJob = workflowJob(workflow, "classifier");
   assert.match(classifierJob, /if: >-\n\s+always\(\) && !cancelled\(\) &&/);
@@ -1044,6 +1047,9 @@ test("an oversized change retains deterministic labels without a classifier", ()
   assert.deepEqual(state.comments.map((comment) => comment.kind), ["oversized"]);
   // The review gate only trusts a check announcing a completed classification.
   assert.notEqual(state.check.title, "Classification complete");
+  assert.equal(state.check.machineState.automaticReviewEligible, false);
+  assert.equal(parseCheckState(`${state.check.summary}\n\n${encodeCheckState(state.check.machineState)}`)
+    .automaticReviewEligible, false);
   // No model ran, so a duplicate or legitimacy verdict from an earlier head is neither confirmed
   // nor refuted and must be left in place.
   assert.deepEqual(state.removeCommentMarkers, [LEGACY_XL_MARKER]);

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -12,6 +12,7 @@ const { validateReviewer } = require("./validate-reviewer");
 const {
   resolveClassificationState, resolveReviewState, reviewPolicyEligible, DUPLICATE_MARKER,
   LEGACY_XL_MARKER, LEGITIMACY_LABEL, LEGITIMACY_MARKER_PREFIX, OVERSIZED_MARKER,
+  OVERSIZED_REVIEW_LABEL,
 } = require("./resolve-state");
 const { resolvePr } = require("./resolve-pr");
 const { StaleHeadError, applyLabels, escapeMarkdown, markerBody, writeState } = require("./write-state");
@@ -798,6 +799,35 @@ test("force is dispatch-only and bypasses draft and bot eligibility", async () =
   assert.equal(automaticBot.reason, "bot-authored pull request");
 });
 
+test("only the persistent oversized-review label starts automation from a label event", async () => {
+  const workflow = fs.readFileSync(path.join(__dirname, "..", "workflows", "labeler.yml"), "utf8");
+  assert.match(workflow, /types: \[opened, reopened, synchronize, ready_for_review, edited, labeled\]/);
+  assert.match(workflowJob(workflow, "classifier"),
+    /contains\(fromJSON\(needs\.resolve-pr\.outputs\.labels\), 'ai-review\/allow-oversized'\)/);
+
+  const pullRequest = (labels = []) => ({
+    number: 7, draft: false, state: "open", labels,
+    user: { node_id: "U_1", login: "contributor", type: "User" },
+    head: { sha: SHA, repo: { full_name: "Devolutions/IronRDP" } }, base: { sha: "b".repeat(40) },
+  });
+  const resolve = async (label) => resolvePr({
+    github: { rest: { pulls: {
+      get: async () => ({ data: pullRequest([OVERSIZED_REVIEW_LABEL]) }),
+      list: async () => ({ data: [pullRequest([OVERSIZED_REVIEW_LABEL])] }),
+    } } },
+    context: {
+      eventName: "pull_request_target", repo: { owner: "Devolutions", repo: "IronRDP" },
+      payload: { action: "labeled", label: { name: label }, pull_request: { number: 7 } },
+    },
+  });
+
+  const requested = await resolve(OVERSIZED_REVIEW_LABEL);
+  assert.equal(requested.ok, true);
+  assert.equal(requested.classificationRequested, true);
+  assert.equal(requested.force, false);
+  assert.equal((await resolve("size/XXL")).reason, "unrelated pull request label");
+});
+
 test("deterministic semver outranks the model and a model-only break cannot stay low", () => {
   const deterministic = { ok: true, pathLabels: [], ownedPathLabels: [], sizeLabel: "size/S", sizeLabels: ["size/S"],
     firstTime: false };
@@ -927,6 +957,9 @@ test("protocol relevance overrides risk suppression but no other exclusion", () 
     assert.equal(reviewPolicyEligible({ labels: ["risk/high", blocking], protocolRelated: true }), false);
   }
   assert.equal(reviewPolicyEligible({
+    labels: ["risk/high", "size/XXL", OVERSIZED_REVIEW_LABEL], protocolRelated: true,
+  }), true);
+  assert.equal(reviewPolicyEligible({
     labels: ["risk/high"], protocolRelated: true, legitimacyStopped: true,
   }), false);
 });
@@ -949,6 +982,26 @@ test("review publication applies the same policy the workflow spent its call on"
   assert.equal(resolveReviewState({
     ...args, labels: ["risk/low", "size/XXL"], gate: gate({ protocolRelated: true }),
   }).failed, true);
+  assert.equal(resolveReviewState({
+    ...args, labels: ["risk/low", "size/XXL", OVERSIZED_REVIEW_LABEL],
+    gate: gate({ protocolRelated: true }),
+  }).failed, undefined);
+});
+
+test("persistent oversized-review label runs normal classification and review", () => {
+  const deterministic = { ok: true, pathLabels: [], ownedPathLabels: [],
+    sizeLabel: "size/XXL", sizeLabels: ["size/XL", "size/XXL"], firstTime: false };
+  const state = resolveClassificationState({
+    expectedSha: SHA, labels: [OVERSIZED_REVIEW_LABEL], deterministic, classifier: classifier({
+      protocol_related: true,
+    }), semver: { head_sha: SHA, status: "not-suspected" },
+  });
+
+  assert.equal(state.oversized, undefined);
+  assert.equal(state.check.title, "Classification complete");
+  assert.equal(state.dispatchReview, true);
+  assert.deepEqual(state.comments, []);
+  assert.equal(state.removeCommentMarkers.includes(OVERSIZED_MARKER), true);
 });
 
 test("XXL guidance is posted once and withdrawn when the change shrinks", () => {

--- a/.github/pr-automation/labels.json
+++ b/.github/pr-automation/labels.json
@@ -123,5 +123,10 @@
     "name": "ai-reviewed/2",
     "color": "000000",
     "description": "Final automated review completed"
+  },
+  {
+    "name": "ai-review/allow-oversized",
+    "color": "fbca04",
+    "description": "Allows normal automated review of an oversized pull request"
   }
 ]

--- a/.github/pr-automation/resolve-pr.js
+++ b/.github/pr-automation/resolve-pr.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const { OVERSIZED_REVIEW_LABEL } = require("./resolve-state");
+
 const SHA = /^[0-9a-f]{40}$/;
 
 function noResult(reason, route = "unknown") {
@@ -57,6 +59,11 @@ async function resolvePr({ github, context, inputs = {} }) {
   let pr;
   try {
     if (route === "classification") {
+      // State writes also emit `labeled` events, so only the explicit maintainer opt-in may start
+      // automation through that event.
+      if (context.payload.action === "labeled" && context.payload.label?.name !== OVERSIZED_REVIEW_LABEL) {
+        return noResult("unrelated pull request label", route);
+      }
       const number = positiveNumber(context.payload.pull_request?.number);
       if (!number) return noResult("missing pull request number", route);
       pr = await getOpenAtHead(github, owner, repo, number);

--- a/.github/pr-automation/resolve-state.js
+++ b/.github/pr-automation/resolve-state.js
@@ -74,7 +74,7 @@ function failedClassification(expectedSha, deterministic, reason, rateLimit, sem
       externalId: `${CLASSIFIER_SCHEMA_VERSION}:${expectedSha}`,
       title: "Classification unavailable",
       summary: `Automated classification was unavailable: ${reason}. Maintainer review is required.`,
-      machineState: { protocolRelated: false },
+      machineState: { protocolRelated: false, automaticReviewEligible: false },
       conclusion: "neutral",
     },
   };
@@ -103,7 +103,7 @@ function oversizedClassification(expectedSha, deterministic, semverStatus) {
       externalId: `${CLASSIFIER_SCHEMA_VERSION}:${expectedSha}`,
       title: "Deterministic labelling only",
       summary: "This pull request is too large for automated review, so no model was invoked.",
-      machineState: { protocolRelated: false },
+      machineState: { protocolRelated: false, automaticReviewEligible: false },
     },
   };
 }

--- a/.github/pr-automation/resolve-state.js
+++ b/.github/pr-automation/resolve-state.js
@@ -8,6 +8,7 @@ const { validateReviewer } = require("./validate-reviewer");
 const RISK = ["risk/low", "risk/medium", "risk/high", "risk/unknown"];
 const AI_COUNTS = ["ai-reviewed/1", "ai-reviewed/2"];
 const LEGITIMACY_LABEL = "triage/legitimacy";
+const OVERSIZED_REVIEW_LABEL = "ai-review/allow-oversized";
 const LEGITIMACY_MARKER_PREFIX = "<!-- ironrdp-pr-automation:legitimacy:v2:";
 const DUPLICATE_MARKER = "<!-- ironrdp-pr-automation:duplicate -->";
 const OVERSIZED_MARKER = "<!-- ironrdp-pr-automation:oversized -->";
@@ -25,7 +26,8 @@ function labelsOf(labels) {
 // of being restated in the workflow where the two copies could drift apart.
 function reviewPolicyEligible({ labels, legitimacyStopped, protocolRelated } = {}) {
   const present = labelsOf(labels);
-  if (present.has("ai-reviewed/2") || present.has("duplicate") || present.has("size/XXL") ||
+  const oversized = present.has("size/XXL") && !present.has(OVERSIZED_REVIEW_LABEL);
+  if (present.has("ai-reviewed/2") || present.has("duplicate") || oversized ||
       present.has(LEGITIMACY_LABEL) || legitimacyStopped === true) return false;
   // Risk gates the non-protocol route only. Risk measures how much human scrutiny a change needs,
   // not how much an automated review is worth, so a protocol-related change is always reviewed.
@@ -117,9 +119,11 @@ function resolveClassificationState({
     return failedClassification(expectedSha, deterministic, "terminal AI review count", failureRateLimit);
   }
   const semverStatus = boundStatus(semver, expectedSha, ["suspected", "not-suspected"]);
-  // Checked before the classifier is consulted: an oversized pull request never reaches a model, so
-  // there is no classifier output to validate and no quota to charge.
-  if (!forced && deterministic?.ok && deterministic.sizeLabel === "size/XXL") {
+  // Checked before the classifier is consulted unless a maintainer has opted the pull request into
+  // normal oversized review, avoiding a model call and quota charge for the default exclusion.
+  const oversized = deterministic?.ok && deterministic.sizeLabel === "size/XXL" &&
+    !existing.has(OVERSIZED_REVIEW_LABEL);
+  if (!forced && oversized) {
     return oversizedClassification(expectedSha, deterministic, semverStatus);
   }
   if (!forced && rateLimit && rateLimit.status !== "allowed") {
@@ -153,7 +157,6 @@ function resolveClassificationState({
     : model.breaking_change_suspected && model.risk === "low" ? "medium"
     : model.risk;
   const duplicate = model.duplicate.detected && model.duplicate.confidence >= 0.85;
-  const isOversized = deterministic.sizeLabel === "size/XXL";
   const optional = [
     ["kind/technical-debt", model.technical_debt],
     ["kind/protocol", model.protocol_related],
@@ -177,7 +180,7 @@ function resolveClassificationState({
       kind: "duplicate", marker: DUPLICATE_MARKER,
       url: model.duplicate.similar_pr_url, rationale: model.duplicate.rationale,
     }] : []),
-    ...(isOversized && !forced ? [{ kind: "oversized", marker: OVERSIZED_MARKER }] : []),
+    ...(oversized && !forced ? [{ kind: "oversized", marker: OVERSIZED_MARKER }] : []),
   ];
   const auditComments = [
     ...(legitimacyStopped ? [{
@@ -192,7 +195,7 @@ function resolveClassificationState({
       // A later push can make a previously reported duplicate or oversized verdict wrong, and stale
       // guidance would then contradict the labels this run just wrote.
       ...(duplicate ? [] : [DUPLICATE_MARKER]),
-      ...(isOversized && !forced ? [LEGACY_XL_MARKER] : [OVERSIZED_MARKER, LEGACY_XL_MARKER]),
+      ...(oversized && !forced ? [LEGACY_XL_MARKER] : [OVERSIZED_MARKER, LEGACY_XL_MARKER]),
     ],
     legitimacyStopped,
     check: {
@@ -340,6 +343,7 @@ function resolveReviewState({
 
 module.exports = {
   AI_COUNTS, DUPLICATE_MARKER, FORK_QUOTA_MARKER, GLOBAL_QUOTA_MARKER, LEGACY_XL_MARKER, LEGITIMACY_LABEL,
-  LEGITIMACY_MARKER_PREFIX, RISK, OVERSIZED_MARKER, ELIGIBLE_MERGED_PRS, contributorEligibility, isExcludedHistory,
-  qualifyingMergedPrs, resolveClassificationState, resolveReviewState, reviewPolicyEligible,
+  LEGITIMACY_MARKER_PREFIX, OVERSIZED_REVIEW_LABEL, RISK, OVERSIZED_MARKER, ELIGIBLE_MERGED_PRS,
+  contributorEligibility, isExcludedHistory, qualifyingMergedPrs, resolveClassificationState,
+  resolveReviewState, reviewPolicyEligible,
 };

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,7 +2,7 @@ name: Pull request automation
 
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize, ready_for_review, edited]
+    types: [opened, reopened, synchronize, ready_for_review, edited, labeled]
   workflow_run:
     workflows: [CI]
     types: [completed]
@@ -368,7 +368,8 @@ jobs:
       (needs.resolve-pr.outputs.force == 'true' ||
       (needs.classification-gate.outputs.available == 'true' &&
       needs.classification-gate.outputs.required == 'true' &&
-      needs.deterministic-analysis.outputs.size-label != 'size/XXL' &&
+      (needs.deterministic-analysis.outputs.size-label != 'size/XXL' ||
+      contains(fromJSON(needs.resolve-pr.outputs.labels), 'ai-review/allow-oversized')) &&
       needs.fork-rate-limit.result == 'success' &&
       needs.fork-rate-limit.outputs.allowed == 'true' &&
       !contains(fromJSON(needs.resolve-pr.outputs.labels), 'ai-reviewed/2')))

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -28,11 +28,13 @@ on:
 concurrency:
   # Keep event routes separate so a stale CI completion cannot cancel newer PR-head automation.
   # Group CI completions by source commit because their associated PR may already have moved ahead.
+  # Non-request labels get their own group, so their no-op runs cannot cancel active automation.
   group: >-
     pr-automation-${{ github.event_name }}-${{ github.event.workflow_run.head_sha ||
     github.event.pull_request.number || inputs.pr-number ||
     github.event.client_payload.pr_number ||
-    github.run_id }}
+    github.run_id }}-${{ github.event.label.name == 'ai-review/allow-oversized' && 'pr' ||
+    github.event.label.name && format('label-{0}', github.event.label.name) || 'pr' }}
   cancel-in-progress: true
 
 permissions: {}
@@ -142,7 +144,8 @@ jobs:
               const completed = data.check_runs.some((run) => {
                 const state = parseCheckState(run.output?.summary);
                 return run.external_id === externalId && run.conclusion === "success" &&
-                  run.app?.slug === "github-actions" && state?.automaticReviewEligible === true;
+                  run.app?.slug === "github-actions" && state?.automaticReviewEligible === true &&
+                  run.output?.title === "Classification complete";
               });
               core.setOutput("required", !completed);
               core.setOutput("available", true);


### PR DESCRIPTION
Allow maintainers to retain an oversized-review opt-in without using broad force mode.

Keep every review gate except the size exclusion, and rerun normal classification and review on later pushes.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>