### PR TITLE
feat(rdpeudp)!: add the connection state machine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3042,6 +3042,7 @@ dependencies = [
  "arbitrary",
  "bitflags 2.13.1",
  "ironrdp-core 0.2.1",
+ "ironrdp-error 0.2.0",
 ]
 
 [[package]]

--- a/crates/ironrdp-rdpeudp/Cargo.toml
+++ b/crates/ironrdp-rdpeudp/Cargo.toml
@@ -22,7 +22,7 @@ doctest = false
 # payloads this protocol carries are heap-allocated, so there is no useful build
 # without it and no `alloc` feature is offered.
 default = []
-std = ["ironrdp-core/std"]
+std = ["ironrdp-core/std", "ironrdp-error/std"]
 # Structure-aware fuzzing support, mirroring `ironrdp-pdu`.
 # `arbitrary` needs the standard library, so structure-aware fuzzing implies `std`.
 arbitrary = ["dep:arbitrary", "std", "bitflags/arbitrary"]
@@ -30,6 +30,7 @@ arbitrary = ["dep:arbitrary", "std", "bitflags/arbitrary"]
 [dependencies]
 arbitrary = { version = "1", features = ["derive"], optional = true }
 ironrdp-core = { path = "../ironrdp-core", version = "0.2", features = ["alloc"] } # public
+ironrdp-error = { path = "../ironrdp-error", version = "0.2", features = ["alloc"] } # public
 bitflags = "2.11" # public
 
 [lints]

--- a/crates/ironrdp-rdpeudp/README.md
+++ b/crates/ironrdp-rdpeudp/README.md
@@ -1,12 +1,17 @@
 # IronRDP RDP-UDP
 
-Wire types for the [MS-RDPEUDP] version 1 handshake: the FEC header, SYN and SYN+ACK payloads, ACK vectors, and the correlation ID payload.
+Reliable UDP transport implemented as described in [MS-RDPEUDP] and
+[MS-RDPEUDP2].
 
-[MS-RDPEUDP] and [MS-RDPEUDP2] use opposite byte orders and number the bits in their diagrams in opposite directions.
-Code and tests that touch both documents need to keep that straight.
+The two documents divide the work. [MS-RDPEUDP] defines the handshake that
+opens a connection and negotiates a protocol version; from version 3 onward
+that handshake leads into the data transfer defined by [MS-RDPEUDP2], which is
+the one this crate implements. Note that the documents take opposite byte
+orders, and number the bits in their diagrams in opposite directions.
 
-This crate does not yet implement a connection state machine or the [MS-RDPEUDP2] data transfer that a negotiated version 3 connection uses.
-Those land in a later crate.
+Sans-I/O: the state machine is driven by datagrams and by a caller-supplied
+instant, and returns the datagrams it wants sent. It performs no I/O and reads
+no clock, so it can be driven by any runtime.
 
 This crate is part of the [IronRDP] project.
 

--- a/crates/ironrdp-rdpeudp/src/congestion.rs
+++ b/crates/ironrdp-rdpeudp/src/congestion.rs
@@ -1,0 +1,302 @@
+//! NewReno congestion control for RDPEUDP2.
+//!
+//! MS-RDPEUDP Section 3.1.1 and MS-RDPEUDP2 Section 3.1.1.2.
+//!
+//! Implements a standard NewReno-style congestion controller with slow
+//! start and congestion avoidance phases.
+//!
+//! Loss is the only congestion signal. MS-RDPEUDP2 has no explicit one:
+//! 3.1.1.2.2 names a Congestion Controller as a higher-layer concept for
+//! "inferring the runtime network conditions" and its packet header
+//! (2.2.1.1) carries nothing but payload-presence flags. The CN and CWR
+//! flags belong to MS-RDPEUDP, whose RDPUDP_FEC_HEADER defines them, and
+//! this crate speaks the v2 data transfer.
+//!
+//! At most one reaction per recovery epoch; see `on_loss`.
+
+/// Initial congestion window size in bytes.
+///
+/// MS-RDPEUDP2 doesn't specify an initial window. Quinn uses 14720
+/// bytes (10 * 1200 + spare). We use 10 * 1232 = 12320, aligned to
+/// the RDPEUDP2 MTU of 1232 bytes.
+const INITIAL_WINDOW: u64 = 10 * 1232;
+
+/// Minimum congestion window: 2 × MTU.
+///
+/// The window never drops below this, even after loss events.
+const MIN_WINDOW: u64 = 2 * 1232;
+
+/// NewReno congestion controller.
+///
+/// Manages the congestion window (cwnd), slow start threshold (ssthresh),
+/// and loss epoch tracking via the CWR sequence number.
+#[derive(Debug, Clone)]
+pub(crate) struct CongestionControl {
+    /// Congestion window in bytes.
+    window: u64,
+
+    /// Slow start threshold in bytes.
+    /// Set to u64::MAX initially (all traffic starts in slow start).
+    ssthresh: u64,
+
+    /// Bytes acknowledged since the last window increase.
+    /// Used for congestion avoidance: increase by 1 MTU per cwnd bytes ACKed.
+    bytes_acked: u64,
+
+    /// Highest DataSeqNum in flight when the window was last reduced by a
+    /// locally detected loss.
+    ///
+    /// Everything at or below it was already on the wire when the reduction
+    /// happened, so losing it is part of the same event and must not reduce
+    /// the window again.
+    recovery_seq: Option<u64>,
+}
+
+impl CongestionControl {
+    /// Create a new controller with the default initial window.
+    pub(crate) fn new() -> Self {
+        Self::with_initial_window(INITIAL_WINDOW)
+    }
+
+    /// Create a controller with a specified initial window size.
+    pub(crate) fn with_initial_window(initial_window: u64) -> Self {
+        Self {
+            window: initial_window,
+            ssthresh: u64::MAX,
+            bytes_acked: 0,
+            recovery_seq: None,
+        }
+    }
+
+    /// Current congestion window in bytes.
+    ///
+    /// The caller should ensure `bytes_in_flight <= window()` before
+    /// transmitting new data.
+    pub(crate) fn window(&self) -> u64 {
+        self.window
+    }
+
+    /// Whether the controller is in slow start phase.
+    pub(crate) fn in_slow_start(&self) -> bool {
+        self.window < self.ssthresh
+    }
+
+    /// Current slow start threshold.
+    #[cfg(test)]
+    pub(crate) fn ssthresh(&self) -> u64 {
+        self.ssthresh
+    }
+
+    /// Called when an ACK acknowledges new data.
+    ///
+    /// In slow start: window increases by `newly_acked_bytes` (doubles
+    /// roughly every RTT).
+    /// In congestion avoidance: window increases by approximately
+    /// 1 MTU per cwnd bytes ACKed (linear increase).
+    pub(crate) fn on_ack(&mut self, newly_acked_bytes: u64) {
+        if self.in_slow_start() {
+            // Slow start: exponential growth
+            self.window += newly_acked_bytes;
+
+            // Don't overshoot ssthresh
+            if self.window >= self.ssthresh {
+                self.bytes_acked = 0;
+            }
+        } else {
+            // Congestion avoidance: linear growth
+            // Increase by 1 MTU per cwnd bytes acknowledged
+            self.bytes_acked += newly_acked_bytes;
+
+            if self.bytes_acked >= self.window {
+                self.bytes_acked -= self.window;
+                self.window += 1232; // 1 MTU increase
+            }
+        }
+    }
+
+    /// Called when a packet is declared lost.
+    ///
+    /// `loss_seq` is the DataSeqNum of the lost packet and `largest_sent`
+    /// the highest DataSeqNum handed to the network so far.
+    ///
+    /// The window is reduced once per recovery epoch, not once per lost
+    /// packet. A burst of loss is one congestion event: everything already
+    /// in flight when the reduction happened belongs to it, so only losing
+    /// something sent afterwards starts a new epoch. Halving per packet
+    /// instead puts the window on its floor after a single burst, and the
+    /// floor is two MTUs.
+    ///
+    /// Returns `true` if the window was actually reduced.
+    pub(crate) fn on_loss(&mut self, loss_seq: u64, largest_sent: u64) -> bool {
+        if let Some(recovery) = self.recovery_seq {
+            if loss_seq <= recovery {
+                // Same congestion event: already reacted.
+                return false;
+            }
+        }
+
+        self.recovery_seq = Some(largest_sent);
+        self.halve_window();
+        true
+    }
+
+    /// Halve the window and set the slow-start threshold to match.
+    fn halve_window(&mut self) {
+        self.ssthresh = (self.window / 2).max(MIN_WINDOW);
+        self.window = self.ssthresh;
+        self.bytes_acked = 0;
+    }
+}
+
+impl Default for CongestionControl {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initial_state() {
+        let cc = CongestionControl::new();
+        assert_eq!(cc.window(), INITIAL_WINDOW);
+        assert!(cc.in_slow_start()); // ssthresh = MAX
+    }
+
+    #[test]
+    fn slow_start_doubles_per_rtt() {
+        let mut cc = CongestionControl::new();
+        let initial = cc.window();
+
+        // ACK the entire window → window should roughly double
+        cc.on_ack(initial);
+
+        assert_eq!(cc.window(), initial * 2);
+        assert!(cc.in_slow_start());
+    }
+
+    #[test]
+    fn slow_start_growth() {
+        let mut cc = CongestionControl::new();
+
+        cc.on_ack(1232); // 1 MTU acked
+        assert_eq!(cc.window(), INITIAL_WINDOW + 1232);
+    }
+
+    #[test]
+    fn transition_to_congestion_avoidance_on_loss() {
+        let mut cc = CongestionControl::new();
+        let initial = cc.window();
+
+        // Loss event
+        cc.on_loss(1, 1);
+        assert!(!cc.in_slow_start()); // ssthresh = window/2 = initial/2, window = ssthresh
+        assert_eq!(cc.window(), initial / 2);
+        assert_eq!(cc.ssthresh(), initial / 2);
+    }
+
+    #[test]
+    fn congestion_avoidance_linear_growth() {
+        let mut cc = CongestionControl::with_initial_window(12320);
+
+        // Force into congestion avoidance
+        cc.on_loss(1, 1);
+        let window_after_loss = cc.window(); // 6160
+
+        // In congestion avoidance, need to ACK ~cwnd bytes to gain 1 MTU
+        cc.on_ack(window_after_loss);
+
+        // Window should increase by 1 MTU
+        assert_eq!(cc.window(), window_after_loss + 1232);
+    }
+
+    #[test]
+    fn window_floor_on_loss() {
+        let mut cc = CongestionControl::with_initial_window(MIN_WINDOW);
+
+        cc.on_loss(1, 1);
+        // Window should not drop below MIN_WINDOW
+        assert_eq!(cc.window(), MIN_WINDOW);
+    }
+
+    #[test]
+    fn on_loss_once_per_epoch() {
+        let mut cc = CongestionControl::new();
+        let initial = cc.window();
+
+        // First loss, with sequence numbers up to 10 already in flight.
+        assert!(cc.on_loss(5, 10));
+        let after_first = cc.window();
+        assert_eq!(after_first, initial / 2);
+
+        // Another packet from that same flight: same event, no reaction.
+        assert!(!cc.on_loss(7, 14));
+        assert_eq!(cc.window(), after_first);
+
+        // Something sent after the reduction: a new event.
+        assert!(cc.on_loss(12, 20));
+        assert_eq!(cc.window(), after_first / 2);
+    }
+
+    /// Losing a burst is one congestion event, not one per packet. Reducing
+    /// per packet puts the window on its floor from a single burst.
+    #[test]
+    fn a_burst_of_loss_reduces_the_window_once() {
+        let mut cc = CongestionControl::new();
+        let initial = cc.window();
+
+        // Ten packets, sequence numbers 1 to 10, all declared lost together.
+        for loss_seq in 1..=10 {
+            cc.on_loss(loss_seq, 10);
+        }
+
+        assert_eq!(cc.window(), initial / 2);
+        assert!(cc.window() > MIN_WINDOW, "the window collapsed to its floor");
+    }
+
+    #[test]
+    fn repeated_loss_converges_to_floor() {
+        let mut cc = CongestionControl::new();
+
+        // Each loss is of a packet sent after the previous reduction, so
+        // each one is its own congestion event.
+        for seq in 0..50 {
+            cc.on_loss(seq, seq);
+        }
+
+        assert_eq!(cc.window(), MIN_WINDOW);
+    }
+
+    #[test]
+    fn default_matches_new() {
+        let from_new = CongestionControl::new();
+        let from_default = CongestionControl::default();
+        assert_eq!(from_new.window(), from_default.window());
+        assert_eq!(from_new.ssthresh(), from_default.ssthresh());
+    }
+
+    #[test]
+    fn custom_initial_window() {
+        let cc = CongestionControl::with_initial_window(5000);
+        assert_eq!(cc.window(), 5000);
+    }
+
+    #[test]
+    fn slow_start_to_avoidance_boundary() {
+        let mut cc = CongestionControl::new();
+        let initial = cc.window();
+
+        // Trigger loss to set ssthresh
+        cc.on_loss(1, 1);
+        let ssthresh = cc.ssthresh();
+        assert_eq!(ssthresh, initial / 2);
+
+        // Window is at ssthresh, so we're in congestion avoidance
+        assert!(!cc.in_slow_start());
+
+        // If window somehow goes below ssthresh, we'd be in slow start
+        // (this doesn't happen normally, but tests the boundary)
+    }
+}

--- a/crates/ironrdp-rdpeudp/src/connection.rs
+++ b/crates/ironrdp-rdpeudp/src/connection.rs
@@ -1,0 +1,2088 @@
+//! RDPEUDP2 connection state machine.
+//!
+//! Sans-I/O design: the state machine never touches the network or system
+//! clock. All `MonotonicInstant` values are passed in by the caller, and outgoing
+//! packets are returned as `Transmit` values. This mirrors Quinn's
+//! `Connection` architecture (ADR-0001).
+//!
+//! # Lifecycle
+//!
+//! ```text
+//! Client: connect() → SynSent ──(recv SYN+ACK)──→ Established
+//! Server: accept()  → SynReceived ──(recv ACK)──→ Established
+//! Either: close()   → Closed
+//! Either: idle timeout ──→ Closed
+//! ```
+//!
+//! # V1/V2 packet discrimination
+//!
+//! The v1 wire format is used for the three-way handshake (SYN/SYN+ACK/ACK).
+//! Once established, all packets use the v2 format with the PacketPrefixByte
+//! framing from MS-RDPEUDP2 Section 2.2.1.3.
+
+use crate::time::MonotonicInstant;
+use alloc::collections::VecDeque;
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
+use core::time::Duration;
+
+use ironrdp_core::{decode, encode_vec};
+
+use crate::congestion::CongestionControl;
+use crate::error::{RdpeudpError, RdpeudpErrorExt as _};
+use crate::loss::LossDetector;
+use crate::pdu::prefix::{decode_with_prefix, encode_with_prefix};
+use crate::pdu::v1_ack::{V1AckVectorElement, V1AckVectorHeader, VectorElementState};
+use crate::pdu::v1_flags::V1Flags;
+use crate::pdu::v1_header::FecHeader;
+use crate::pdu::v1_syn::{SynDataExPayload, SynDataPayload, SynExFlags, UdpVersion};
+use crate::pdu::v2_ack::{ACK_VECTOR_MAX_ENTRIES, AckPayload, AckVectorEntry, AckVectorPayload};
+use crate::pdu::v2_control::AckOfAcksPayload;
+use crate::pdu::v2_data::{DataBody, DataHeader};
+use crate::pdu::v2_flags::V2Flags;
+use crate::pdu::v2_header::{LOG_WINDOW_SIZE_MAX, V2Header};
+use crate::pdu::{V1Datagram, V2Packet};
+use crate::recv_window::RecvWindow;
+use crate::reliability::ReliabilityController;
+use crate::rtt::RttEstimator;
+use crate::send_window::SendWindow;
+use crate::seq;
+use crate::timer::{Timer, TimerTable};
+
+// ════════════════════════════════════════════════════════════════════
+// Public types
+// ════════════════════════════════════════════════════════════════════
+
+/// Which side of the connection this endpoint represents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Side {
+    /// Initiated the connection (sent the initial SYN).
+    Client,
+    /// Accepted the connection (responded with SYN+ACK).
+    Server,
+}
+
+/// Events produced by the state machine for the application layer.
+///
+/// Retrieved by calling `poll_event()` after any state mutation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Event {
+    /// The handshake completed and the connection is established.
+    Connected,
+
+    /// Application data has been received and reassembled in order.
+    DataReceived(Vec<u8>),
+
+    /// The connection has been closed (locally or by timeout).
+    ConnectionClosed,
+}
+
+/// An outgoing packet to be sent on the wire.
+///
+/// Retrieved by calling `poll_transmit()` after any state mutation.
+#[derive(Debug, Clone)]
+pub struct Transmit {
+    /// The raw wire bytes to send (including PacketPrefixByte for v2 packets).
+    pub contents: Vec<u8>,
+}
+
+/// Configuration for a new RDPEUDP2 connection.
+#[derive(Debug, Clone)]
+pub struct ConnectionConfig {
+    /// Initial sequence number from the SYN exchange.
+    pub initial_sequence_number: u32,
+
+    /// log2 of the receive window size (0..=15).
+    /// Actual window = `1 << log_window_size`.
+    pub log_window_size: u8,
+
+    /// Upstream MTU (client → server), negotiated during handshake.
+    pub upstream_mtu: u16,
+
+    /// Downstream MTU (server → client), negotiated during handshake.
+    pub downstream_mtu: u16,
+
+    /// Idle timeout: connection closes if no packets received within this duration.
+    ///
+    /// Default: 65 seconds, the interval [MS-RDPEUDP] 3.1.1.9 gives for
+    /// deciding the peer has gone. Shortening it below that closes
+    /// connections a conforming peer still considers live.
+    pub idle_timeout: Duration,
+
+    /// Keep-alive interval: send a probe if no data has been sent for this long.
+    /// Should be shorter than the remote's idle timeout.
+    ///
+    /// Default: 8 seconds. The spec asks only that endpoints acknowledge
+    /// "periodically" (3.1.1.9), the point being to hold the NAT binding
+    /// open, so the interval is ours to pick.
+    pub keep_alive_interval: Duration,
+
+    /// SHA-256 of the `securityCookie` from the Initiate Multitransport
+    /// Request PDU ([MS-RDPBCGR] 2.2.15.1).
+    ///
+    /// Required, despite being an `Option`: this crate implements the
+    /// MS-RDPEUDP2 data transfer, which [MS-RDPEUDP] 1.3.2.2 reaches only at
+    /// protocol version 3, and 2.2.2.9 requires the hash in a version 3 SYN.
+    /// A connection without it cannot be built, so [`RdpeudpConnection::connect`]
+    /// and [`RdpeudpConnection::accept`] both refuse one.
+    ///
+    /// The default is `None` because there is no meaningful value to invent.
+    /// Callers get the cookie from the multitransport request and hash it;
+    /// `ironrdp-rdpeudp-tokio` does this for them.
+    ///
+    /// The server holds the same value and compares it against the client's
+    /// SYN, which is the check 3.1.5.1.1 asks of it.
+    pub cookie_hash: Option<[u8; 32]>,
+}
+
+impl Default for ConnectionConfig {
+    fn default() -> Self {
+        Self {
+            initial_sequence_number: 0,
+            log_window_size: 6,
+            upstream_mtu: 1232,
+            downstream_mtu: 1232,
+            idle_timeout: Duration::from_secs(65),
+            keep_alive_interval: Duration::from_secs(8),
+            cookie_hash: None,
+        }
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Internal state
+// ════════════════════════════════════════════════════════════════════
+
+/// The RDP-UDP2 MTU.
+///
+/// [MS-RDPEUDP2] 1.5 fixes it: "The maximum transmission unit (MTU) size in
+/// RDP-UDP2 transport layer is set to 1232 bytes." The v1 handshake still
+/// negotiates `uUpStreamMtu` and `uDownStreamMtu` in the range 1132 to 1232,
+/// so the effective limit is whichever of the two is smaller.
+const RDPEUDP2_MTU: usize = 1232;
+
+/// What a data packet spends on framing before any payload: the
+/// PacketPrefixByte (1), the RDP-UDP2 header (2), the DataHeader (2) and the
+/// DataBody's ChannelSeqNum (2).
+const DATA_PACKET_OVERHEAD: usize = 7;
+
+/// Room held back on every data packet for an acknowledgment riding along.
+///
+/// The largest is an ACK vector: three bytes fixed, four for the timestamp
+/// block, and up to 127 entries, that being the limit of its 7-bit size field.
+/// The cumulative form reaches 22 and cannot appear beside it, since 2.2.1.1
+/// makes the two flags mutually exclusive. An AckOfAcks adds two more.
+///
+/// Reserving the worst case costs about a tenth of each packet on a link with
+/// nothing to report. Measuring instead, and dropping the acknowledgment when
+/// it would not fit, would buy that back at the cost of a second way for a
+/// packet to be built; not worth it until something shows the throughput
+/// matters. `a_full_data_packet_fits_the_mtu` checks this figure against the
+/// encoders rather than leaving it as arithmetic in a comment.
+const PIGGYBACK_RESERVE: usize = 134 + 2;
+
+/// How many unanswered retransmits of a handshake datagram we tolerate
+/// before closing.
+///
+/// [MS-RDPEUDP] 3.1.5.4.1 puts the cutoff at "at least three and no more
+/// than five", so an endpoint may not give up earlier than three and must
+/// have given up by five. Five is the friendliest conforming choice on a
+/// link that is losing packets.
+const HANDSHAKE_RETRANSMIT_LIMIT: u8 = 5;
+
+/// How many multiples of the send window's own capacity `send()` lets the
+/// send buffer hold ahead of it before returning `SendBufferFull`.
+///
+/// Generous enough that writing well ahead of a slow or lossy link is not
+/// mistaken for the unbounded growth this bound exists to catch: this
+/// crate's own tests queue up to 4x a window's worth in one burst before
+/// any of it drains.
+const SEND_BUFFER_WINDOW_MULTIPLE: usize = 8;
+
+/// Connection state in the handshake / lifecycle FSM.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum State {
+    /// Client has sent SYN, waiting for SYN+ACK.
+    SynSent,
+    /// Server has received SYN and sent SYN+ACK, waiting for final ACK.
+    SynReceived,
+    /// Handshake complete, data transfer active.
+    Established,
+    /// Connection terminated.
+    Closed,
+}
+
+/// An acknowledgment ready to go onto an outgoing packet.
+///
+/// The cumulative and vector forms are mutually exclusive: [MS-RDPEUDP2]
+/// 2.2.1.1 says the ACKVEC flag "MUST NOT be set if the ACK flag is set".
+struct Acknowledgement {
+    flag: V2Flags,
+    ack: Option<AckPayload>,
+    ack_vector: Option<AckVectorPayload>,
+}
+
+/// Negotiated parameters from the handshake.
+#[derive(Debug, Clone)]
+struct NegotiatedParams {
+    /// Our ISN (from our SYN).
+    local_isn: u32,
+    /// Remote ISN (from their SYN).
+    remote_isn: u32,
+    /// Negotiated MTU: min(upstream, downstream, remote_upstream, remote_downstream).
+    mtu: u16,
+    /// log2 of the window size.
+    log_window_size: u8,
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Connection
+// ════════════════════════════════════════════════════════════════════
+
+/// RDPEUDP2 connection state machine.
+///
+/// Wires together all protocol components (send/receive windows,
+/// congestion control, loss detection, RTT estimation, timers,
+/// reliability controller) behind a sans-I/O polling API.
+///
+/// # Usage pattern
+///
+/// ```ignore
+/// // Create
+/// let mut conn = RdpeudpConnection::connect(config, now);
+///
+/// // Main loop:
+/// // 1. Send the initial SYN
+/// while let Some(transmit) = conn.poll_transmit() {
+///     socket.send(&transmit.contents);
+/// }
+///
+/// // 2. Receive packets
+/// conn.handle_datagram(&mut incoming_bytes, now)?;
+///
+/// // 3. Check for events
+/// while let Some(event) = conn.poll_event() {
+///     match event {
+///         Event::Connected => { /* handshake done */ }
+///         Event::DataReceived(data) => { /* process data */ }
+///         Event::ConnectionClosed => { break; }
+///     }
+/// }
+///
+/// // 4. Handle timeouts
+/// if let Some(deadline) = conn.poll_timeout() {
+///     // schedule wakeup at `deadline`
+/// }
+/// conn.handle_timeout(now);
+/// ```
+pub struct RdpeudpConnection {
+    /// Which side we are.
+    side: Side,
+
+    /// Current lifecycle state.
+    state: State,
+
+    /// Configuration (immutable after construction).
+    config: ConnectionConfig,
+
+    /// Negotiated handshake parameters (populated during/after handshake).
+    params: Option<NegotiatedParams>,
+
+    // ── Data transfer components (initialized on Established) ──
+    send_window: Option<SendWindow>,
+    recv_window: Option<RecvWindow>,
+    congestion: CongestionControl,
+    loss_detector: LossDetector,
+    reliability: ReliabilityController,
+    rtt: RttEstimator,
+    timers: TimerTable,
+
+    /// Queued outgoing wire-format packets.
+    pending_transmits: VecDeque<Transmit>,
+
+    /// Queued events for the application.
+    pending_events: VecDeque<Event>,
+
+    /// Application data waiting to be packaged into packets.
+    send_buffer: VecDeque<Vec<u8>>,
+
+    /// Whether we need to send a standalone ACK (no data piggybacked).
+    ack_pending: bool,
+
+    /// The DataSeqNum we are waiting to see acknowledged, when the peer still
+    /// needs telling.
+    ///
+    /// [MS-RDPEUDP2] 2.2.1.2.4 defines AckOfAcksSeqNum as "the sequence number
+    /// the Sender is waiting to receive acknowledgment of", and 3.1.5.3 has
+    /// the sender advertise it after declaring a loss, "so that the Receiver
+    /// can stop waiting for any packets with lower sequence numbers to
+    /// arrive".
+    ///
+    /// This is the only thing that can move a receiver past a packet we gave
+    /// up on. The retransmission carries a fresh DataSeqNum, so the lost one
+    /// is never filled, and 3.1.1.2.2 lets a receiver advance its lower bound
+    /// only over received packets or on this payload. Without it the peer's
+    /// window sits on the hole until it fills, and the connection stops
+    /// carrying data one window later.
+    ///
+    /// Held as the full 64-bit value and truncated on the wire, so it can be
+    /// compared against what the peer reports.
+    pending_ack_of_acks: Option<u64>,
+
+    /// The last handshake datagram we put on the wire, kept so it can go
+    /// out again. [MS-RDPEUDP] 1.3.1 delivers the SYN, the SYN+ACK and the
+    /// ACK by persistent retransmits whatever mode the transport is in.
+    ///
+    /// The client holds on to its final ACK after establishing, because a
+    /// repeated SYN+ACK is the server saying it never arrived.
+    handshake_datagram: Option<Vec<u8>>,
+
+    /// How many times `handshake_datagram` has been retransmitted by the
+    /// timer. Peer-prompted resends do not count: those got an answer.
+    handshake_retransmits: u8,
+
+    /// When the last handshake datagram (`handshake_datagram`) was first
+    /// sent, for sampling the handshake round trip as the connection's
+    /// first RTT estimate. `None` until the first SYN or SYN+ACK goes out.
+    handshake_sent_at: Option<MonotonicInstant>,
+
+    /// When the earliest currently-unacknowledged data arrived, `None` when
+    /// nothing is owed an acknowledgment.
+    ///
+    /// Set the first time [`process_data`]/[`process_dummy_data`] has
+    /// something new to acknowledge and [`Timer::AckDelay`] is not already
+    /// armed, matching that timer's own arm condition. Read by
+    /// [`build_ack_payload`]/[`build_ack_vector_payload`] to report the real
+    /// `received_ts` and the real gap between receipt and acknowledgment,
+    /// and cleared by [`commit_acknowledgement`] once that acknowledgment has
+    /// actually gone out.
+    ///
+    /// [`process_data`]: RdpeudpConnection::process_data
+    /// [`process_dummy_data`]: RdpeudpConnection::process_dummy_data
+    /// [`build_ack_payload`]: RdpeudpConnection::build_ack_payload
+    /// [`build_ack_vector_payload`]: RdpeudpConnection::build_ack_vector_payload
+    /// [`commit_acknowledgement`]: RdpeudpConnection::commit_acknowledgement
+    ack_delay_started_at: Option<MonotonicInstant>,
+
+    /// Remote timestamp reference for reconstruction.
+    remote_timestamp_ref: u64,
+
+    /// Reusable wire encoding buffer.
+    wire_buf: Vec<u8>,
+}
+
+impl RdpeudpConnection {
+    // ════════════════════════════════════════════════════════════════
+    // Constructors
+    // ════════════════════════════════════════════════════════════════
+
+    /// Create a client-side connection and enqueue the initial SYN.
+    ///
+    /// After calling this, use `poll_transmit()` to retrieve the SYN
+    /// datagram to send on the wire.
+    ///
+    /// Returns an error if `config.cookie_hash` is absent. The SYN advertises
+    /// protocol version 3, which is what selects the MS-RDPEUDP2 data
+    /// transfer this crate implements, and [MS-RDPEUDP] 2.2.2.9 requires the
+    /// hash to accompany that version.
+    pub fn connect(config: ConnectionConfig, now: MonotonicInstant) -> Result<Self, RdpeudpError> {
+        if config.log_window_size > LOG_WINDOW_SIZE_MAX {
+            return Err(RdpeudpError::invalid_state(
+                "ConnectionConfig::log_window_size must be 0..=15",
+            ));
+        }
+
+        if config.cookie_hash.is_none() {
+            return Err(RdpeudpError::invalid_state(
+                "connect without ConnectionConfig::cookie_hash, which a version 3 SYN must carry",
+            ));
+        }
+
+        let mut conn = Self::new(Side::Client, config);
+        conn.enqueue_syn(now);
+        Ok(conn)
+    }
+
+    /// Create a server-side connection from a received SYN datagram.
+    ///
+    /// The caller has already decoded the V1 datagram and determined
+    /// it's a SYN. This constructs the server state machine and
+    /// enqueues the SYN+ACK response.
+    ///
+    /// Returns an error if the SYN datagram is malformed (missing
+    /// SYN data or version negotiation).
+    pub fn accept(
+        config: ConnectionConfig,
+        syn_datagram: &V1Datagram,
+        now: MonotonicInstant,
+    ) -> Result<Self, RdpeudpError> {
+        if config.log_window_size > LOG_WINDOW_SIZE_MAX {
+            return Err(RdpeudpError::invalid_state(
+                "ConnectionConfig::log_window_size must be 0..=15",
+            ));
+        }
+
+        let syn_data = syn_datagram
+            .syn_data
+            .as_ref()
+            .ok_or_else(|| RdpeudpError::invalid_packet("accept", "SYN datagram missing SynData payload"))?;
+
+        let syn_data_ex = syn_datagram
+            .syn_data_ex
+            .as_ref()
+            .ok_or_else(|| RdpeudpError::invalid_packet("accept", "SYN datagram missing SynDataEx payload"))?;
+
+        let expected_hash = config.cookie_hash.ok_or_else(|| {
+            RdpeudpError::invalid_state(
+                "accept without ConnectionConfig::cookie_hash, needed to check the client's SYN",
+            )
+        })?;
+
+        // Only version 3 selects the MS-RDPEUDP2 data transfer (1.3.2.2), and
+        // that is the only data transfer this crate implements, so a client
+        // offering version 1 or 2 (asking for the MS-RDPEUDP one) cannot be
+        // served. A client offering something above version 3 can: MS-RDPEUDP
+        // 1.7's negotiate-down MUST clause requires settling on our own
+        // highest supported version rather than refusing the connection, and
+        // `enqueue_syn_ack` below always answers with version 3 regardless of
+        // what was offered, which is exactly that settlement.
+        if syn_data_ex.udp_ver.0 < UdpVersion::V3.0 {
+            return Err(RdpeudpError::invalid_packet(
+                "accept",
+                "remote offered a protocol version below 3, whose data transfer is MS-RDPEUDP rather than MS-RDPEUDP2",
+            ));
+        }
+
+        // 3.1.5.1.1 asks the server to confirm the hash, and says an invalid
+        // one MUST drop the connection back to version 2. That version means
+        // the MS-RDPEUDP data transfer, which this crate does not implement,
+        // so the only honest outcome is to refuse the connection.
+        let offered_hash = syn_data_ex
+            .cookie_hash
+            .ok_or_else(|| RdpeudpError::invalid_packet("accept", "version 3 SYN carries no cookieHash"))?;
+
+        if offered_hash != expected_hash {
+            return Err(RdpeudpError::invalid_packet(
+                "accept",
+                "cookieHash does not match the security cookie for this multitransport request",
+            ));
+        }
+
+        let mut conn = Self::new(Side::Server, config);
+        conn.state = State::SynReceived;
+
+        let remote_isn = syn_data.initial_sequence_number;
+        let local_isn = conn.config.initial_sequence_number;
+
+        // Negotiate MTU: minimum of all advertised values
+        let mtu = conn
+            .config
+            .upstream_mtu
+            .min(conn.config.downstream_mtu)
+            .min(syn_data.upstream_mtu)
+            .min(syn_data.downstream_mtu);
+
+        conn.params = Some(NegotiatedParams {
+            local_isn,
+            remote_isn,
+            mtu,
+            log_window_size: conn.config.log_window_size,
+        });
+
+        conn.enqueue_syn_ack(remote_isn, now);
+        conn.timers.set(Timer::Idle, now + conn.config.idle_timeout);
+
+        Ok(conn)
+    }
+
+    fn new(side: Side, config: ConnectionConfig) -> Self {
+        Self {
+            side,
+            state: State::SynSent,
+            config,
+            params: None,
+            send_window: None,
+            recv_window: None,
+            congestion: CongestionControl::new(),
+            loss_detector: LossDetector::new(),
+            reliability: ReliabilityController::new(),
+            rtt: RttEstimator::new(),
+            timers: TimerTable::new(),
+            pending_transmits: VecDeque::new(),
+            pending_events: VecDeque::new(),
+            send_buffer: VecDeque::new(),
+            ack_pending: false,
+            pending_ack_of_acks: None,
+            handshake_datagram: None,
+            handshake_retransmits: 0,
+            handshake_sent_at: None,
+            ack_delay_started_at: None,
+            remote_timestamp_ref: 0,
+            wire_buf: Vec::with_capacity(1400),
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    // Public API
+    // ════════════════════════════════════════════════════════════════
+
+    /// Enqueue application data for transmission.
+    ///
+    /// The data will be sent in the next `poll_transmit()` call,
+    /// subject to congestion window availability.
+    ///
+    /// Returns an error if the connection is not established or
+    /// the send buffer is full.
+    pub fn send(&mut self, data: Vec<u8>) -> Result<(), RdpeudpError> {
+        match self.state {
+            State::Established => {}
+            State::Closed => return Err(RdpeudpError::connection_closed("send")),
+            _ => return Err(RdpeudpError::invalid_state("send")),
+        }
+
+        let max_payload = self.max_payload();
+
+        // Bounded at the send window's own capacity: past that, nothing
+        // queued here can drain any faster than the window already allows,
+        // so holding more only grows memory under sustained congestion or an
+        // unresponsive peer. Checked whole against every chunk this call
+        // would add before pushing any of them, since pushing part of a
+        // split chunk set and rejecting the rest would corrupt the byte
+        // stream the receiving end reassembles.
+        let max_entries = SEND_BUFFER_WINDOW_MULTIPLE * (1usize << usize::from(self.config.log_window_size));
+        let chunks_needed = data.len().div_ceil(max_payload).max(1);
+        if self.send_buffer.len() + chunks_needed > max_entries {
+            return Err(RdpeudpError::send_buffer_full("send"));
+        }
+
+        if data.len() <= max_payload {
+            self.send_buffer.push_back(data);
+            return Ok(());
+        }
+
+        // Split rather than reject. The caller here is a TLS session writing a
+        // byte stream: it has no message boundaries to preserve and no notion
+        // of what fits in a datagram, and the receiving end concatenates
+        // whatever arrives before handing it back to TLS.
+        for chunk in data.chunks(max_payload) {
+            self.send_buffer.push_back(chunk.to_vec());
+        }
+
+        Ok(())
+    }
+
+    /// The largest payload this connection will put in one packet.
+    ///
+    /// [MS-RDPEUDP2] has no segmentation. 3.1.1.2.4.2 has the receiver strip
+    /// the ChannelSeqNum and forward "the rest of the data payload to the
+    /// upper layer immediately", and the format carries no first or last
+    /// marker to reassemble by, so a packet's payload arrives whole or not at
+    /// all. Anything longer has to be split before it becomes packets, which
+    /// is what [`send`] does.
+    ///
+    /// [`send`]: Self::send
+    pub fn max_payload(&self) -> usize {
+        let mtu = self
+            .params
+            .as_ref()
+            .map_or(RDPEUDP2_MTU, |params| usize::from(params.mtu).min(RDPEUDP2_MTU));
+
+        mtu.saturating_sub(DATA_PACKET_OVERHEAD + PIGGYBACK_RESERVE).max(1)
+    }
+
+    /// Process a received wire-format datagram.
+    ///
+    /// For v1 (handshake) datagrams, pass the raw UDP payload bytes.
+    /// For v2 (data) packets, pass the raw UDP payload including the
+    /// PacketPrefixByte framing.
+    ///
+    /// The `wire` slice must be mutable because `decode_with_prefix`
+    /// performs an in-place byte swap.
+    pub fn handle_datagram(&mut self, wire: &mut [u8], now: MonotonicInstant) -> Result<(), RdpeudpError> {
+        if self.state == State::Closed {
+            return Err(RdpeudpError::connection_closed("handle datagram"));
+        }
+
+        // Reset idle timer on any received packet
+        self.timers.set(Timer::Idle, now + self.config.idle_timeout);
+
+        match self.state {
+            State::SynSent => self.handle_syn_ack(wire, now),
+            State::SynReceived => self.handle_final_ack(wire, now),
+            State::Established => {
+                // A server that missed our final ACK repeats its SYN+ACK, in
+                // the v1 format, long after we have moved on to v2.
+                if self.is_repeated_syn_ack(wire) {
+                    self.resend_handshake_datagram();
+                    return Ok(());
+                }
+
+                self.handle_v2_packet(wire, now)
+            }
+            State::Closed => Err(RdpeudpError::connection_closed("handle datagram")),
+        }
+    }
+
+    /// Whether `wire` is the server repeating the SYN+ACK we already
+    /// answered.
+    ///
+    /// v1 and v2 datagrams share no framing and no discriminator, so this
+    /// leans on the initial sequence number: a v2 data packet would have to
+    /// carry the exact 32-bit value the server opened with, at the offset
+    /// SYNDATA occupies, to be mistaken for one.
+    fn is_repeated_syn_ack(&self, wire: &[u8]) -> bool {
+        if self.side != Side::Client {
+            return false;
+        }
+
+        let Some(params) = self.params.as_ref() else {
+            return false;
+        };
+
+        // Read the fixed header on its own first. This runs for every
+        // datagram the connection receives once established, and a full v1
+        // parse of arbitrary bytes can allocate an ACK vector of up to 65535
+        // elements before deciding they were never a SYN+ACK.
+        let Ok(header) = decode::<FecHeader>(wire) else {
+            return false;
+        };
+
+        if !header.flags.contains(V1Flags::SYN | V1Flags::ACK) {
+            return false;
+        }
+
+        let Ok(datagram) = decode::<V1Datagram>(wire) else {
+            return false;
+        };
+
+        datagram
+            .syn_data
+            .is_some_and(|syn_data| syn_data.initial_sequence_number == params.remote_isn)
+    }
+
+    /// Retrieve the next outgoing packet to send on the wire.
+    ///
+    /// Returns `None` when there are no more packets to send.
+    /// The caller should call this in a loop until it returns `None`.
+    ///
+    /// This method also generates new data packets from the send
+    /// buffer when congestion window budget is available, processes
+    /// retransmissions, and sends standalone ACKs.
+    pub fn poll_transmit(&mut self, now: MonotonicInstant) -> Option<Transmit> {
+        // A closed connection has nothing left to say. Returning early also
+        // keeps the handshake branch below from arming the keep-alive timer
+        // after `close` cleared it: `handle_timeout` returns early once closed,
+        // so a timer armed here would stay due forever and a caller polling
+        // the deadline without checking `is_closed` would spin.
+        if self.state == State::Closed {
+            return None;
+        }
+
+        // First, drain any pre-built transmits (handshake packets)
+        if let Some(t) = self.pending_transmits.pop_front() {
+            self.timers.set(Timer::KeepAlive, now + self.config.keep_alive_interval);
+            return Some(t);
+        }
+
+        if self.state != State::Established {
+            return None;
+        }
+
+        // Priority order:
+        // 1. Retransmissions (reliability queue)
+        // 2. New data from send buffer
+        // 3. Standalone ACK (if needed)
+        // 4. Keep-alive probe
+
+        // Try retransmissions
+        if let Some(transmit) = self.try_retransmit(now) {
+            self.timers.set(Timer::KeepAlive, now + self.config.keep_alive_interval);
+            return Some(transmit);
+        }
+
+        // Try new data
+        if let Some(transmit) = self.try_send_new_data(now) {
+            self.timers.set(Timer::KeepAlive, now + self.config.keep_alive_interval);
+            return Some(transmit);
+        }
+
+        // Standalone ACK
+        if self.ack_pending {
+            if let Some(transmit) = self.build_standalone_ack(now) {
+                self.ack_pending = false;
+                self.timers.clear(Timer::AckDelay);
+                self.timers.set(Timer::KeepAlive, now + self.config.keep_alive_interval);
+                return Some(transmit);
+            }
+        }
+
+        None
+    }
+
+    /// The next time the caller should invoke `handle_timeout()`.
+    ///
+    /// Returns `None` if no timers are active.
+    pub fn poll_timeout(&self) -> Option<MonotonicInstant> {
+        self.timers.next_deadline()
+    }
+
+    /// Process expired timers at the current time.
+    ///
+    /// The caller should invoke this when `now >= poll_timeout()`.
+    pub fn handle_timeout(&mut self, now: MonotonicInstant) {
+        if self.state == State::Closed {
+            return;
+        }
+
+        let expired: Vec<Timer> = self.timers.expired(now).collect();
+
+        for timer in expired {
+            // The idle timer closes the connection, and `close` clears every
+            // timer. Handlers later in this list would otherwise still run and
+            // re-arm their own timer on a connection that is already gone,
+            // leaving a deadline `handle_timeout` will never service because
+            // it returns early once closed. A caller that polls the deadline
+            // without checking `is_closed` first would then spin.
+            if self.state == State::Closed {
+                break;
+            }
+
+            match timer {
+                Timer::Retransmit => self.handle_retransmit_timeout(now),
+                Timer::AckDelay => self.handle_ack_delay_timeout(now),
+                Timer::Idle => self.handle_idle_timeout(),
+                Timer::KeepAlive => self.handle_keep_alive_timeout(now),
+            }
+        }
+    }
+
+    /// Retrieve the next event for the application layer.
+    ///
+    /// Returns `None` when there are no more events.
+    pub fn poll_event(&mut self) -> Option<Event> {
+        self.pending_events.pop_front()
+    }
+
+    /// Initiate a graceful close of the connection.
+    pub fn close(&mut self) {
+        if self.state != State::Closed {
+            self.state = State::Closed;
+            self.timers.clear(Timer::Retransmit);
+            self.timers.clear(Timer::AckDelay);
+            self.timers.clear(Timer::Idle);
+            self.timers.clear(Timer::KeepAlive);
+            self.pending_events.push_back(Event::ConnectionClosed);
+        }
+    }
+
+    /// Whether the connection is fully established and ready for data.
+    pub fn is_established(&self) -> bool {
+        self.state == State::Established
+    }
+
+    /// Whether the connection has been closed.
+    pub fn is_closed(&self) -> bool {
+        self.state == State::Closed
+    }
+
+    /// Current smoothed RTT estimate, if available.
+    pub fn srtt(&self) -> Option<Duration> {
+        self.rtt.srtt()
+    }
+
+    /// Current retransmission timeout.
+    pub fn rto(&self) -> Duration {
+        self.rtt.rto()
+    }
+
+    /// Negotiated MTU (maximum payload per packet), if handshake is complete.
+    pub fn mtu(&self) -> Option<u16> {
+        self.params.as_ref().map(|p| p.mtu)
+    }
+
+    /// The ACK delay timeout to use right now.
+    ///
+    /// [MS-RDPEUDP2] 3.1.5.2 gives the receiver's assumed default as "half
+    /// the round trip time", with no floor or ceiling of its own for the
+    /// RDP-UDP2 wire format. [MS-RDPEUDP] 3.1.6.3 gives the VERSION_2 analog
+    /// for the v1 wire format a concrete shape, "50 ms or half the RTT,
+    /// whichever is longer, up to a maximum of 200 ms"; that formula is used
+    /// here as the closest available spec anchor for what RDPEUDP2's own
+    /// silence on the floor and ceiling should mean, not as a v2-spec
+    /// requirement in its own right.
+    ///
+    /// Falls back to the floor when no RTT sample exists yet. In practice
+    /// this is only reachable when the handshake's own sample was skipped by
+    /// Karn's algorithm (`sample_handshake_rtt`) because the handshake
+    /// datagram was retransmitted.
+    fn ack_delay_timeout(&self) -> Duration {
+        const FLOOR: Duration = Duration::from_millis(50);
+        const CEILING: Duration = Duration::from_millis(200);
+
+        match self.rtt.srtt() {
+            Some(srtt) => (srtt / 2).clamp(FLOOR, CEILING),
+            None => FLOOR,
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    // Handshake: SYN generation
+    // ════════════════════════════════════════════════════════════════
+
+    /// Build and enqueue the client SYN datagram.
+    fn enqueue_syn(&mut self, now: MonotonicInstant) {
+        let datagram = V1Datagram {
+            header: FecHeader {
+                sn_source_ack: 0xFFFF_FFFF, // No prior packet to ACK
+                receive_window_size: 1u16 << u16::from(self.config.log_window_size),
+                flags: V1Flags::SYN | V1Flags::SYNEX,
+            },
+            ack_vector: None,
+            ack_of_acks: None,
+            syn_data: Some(SynDataPayload {
+                initial_sequence_number: self.config.initial_sequence_number,
+                upstream_mtu: self.config.upstream_mtu,
+                downstream_mtu: self.config.downstream_mtu,
+            }),
+            correlation_id: None,
+            syn_data_ex: Some(SynDataExPayload {
+                syn_ex_flags: SynExFlags::VERSION_INFO_VALID,
+                // Version 3 is what selects the MS-RDPEUDP2 data transfer
+                // (1.3.2.2). Version 2 is the same v1 data transfer with
+                // shorter timers, so advertising it and then speaking v2
+                // framing leaves the peer unable to parse anything.
+                udp_ver: UdpVersion::V3,
+                // 2.2.2.9: mandatory with version 3 in a client SYN.
+                // `connect` refuses to build a connection without it.
+                cookie_hash: self.config.cookie_hash,
+            }),
+        };
+
+        if !self.enqueue_handshake(&datagram) {
+            return;
+        }
+        self.handshake_sent_at = Some(now);
+
+        self.timers.set(Timer::Retransmit, now + self.rtt.rto());
+        self.timers.set(Timer::Idle, now + self.config.idle_timeout);
+    }
+
+    /// Build and enqueue the server SYN+ACK datagram.
+    fn enqueue_syn_ack(&mut self, remote_isn: u32, now: MonotonicInstant) {
+        let datagram = V1Datagram {
+            header: FecHeader {
+                sn_source_ack: remote_isn,
+                receive_window_size: 1u16 << u16::from(self.config.log_window_size),
+                flags: V1Flags::SYN | V1Flags::ACK | V1Flags::SYNEX,
+            },
+            // A SYN+ACK acknowledges the client's SYN through snSourceAck
+            // alone (3.1.5.1.3); no ACK vector goes on the wire.
+            ack_vector: None,
+            ack_of_acks: None,
+            syn_data: Some(SynDataPayload {
+                initial_sequence_number: self.config.initial_sequence_number,
+                upstream_mtu: self.config.upstream_mtu,
+                downstream_mtu: self.config.downstream_mtu,
+            }),
+            correlation_id: None,
+            syn_data_ex: Some(SynDataExPayload {
+                syn_ex_flags: SynExFlags::VERSION_INFO_VALID,
+                udp_ver: UdpVersion::V3,
+                // 2.2.2.9 puts the hash in the client's SYN and nowhere else:
+                // "It MUST NOT be present in any other case."
+                cookie_hash: None,
+            }),
+        };
+
+        if !self.enqueue_handshake(&datagram) {
+            return;
+        }
+        self.handshake_sent_at = Some(now);
+
+        self.timers.set(Timer::Retransmit, now + self.rtt.rto());
+    }
+
+    /// Queue a handshake datagram and keep a copy for retransmission.
+    ///
+    /// These datagrams have a fixed shape, so the encode cannot fail in
+    /// practice. If it somehow does there is no handshake to be had, and
+    /// silently dropping the packet would leave the caller waiting on a
+    /// connection that will never answer.
+    ///
+    /// Returns whether the datagram was queued. Callers must not arm timers
+    /// when it was not: `close` has just cleared them, and re-arming leaves
+    /// a deadline that `handle_timeout` returns early from without ever
+    /// clearing.
+    #[must_use]
+    fn enqueue_handshake(&mut self, datagram: &V1Datagram) -> bool {
+        let Ok(bytes) = encode_vec(datagram) else {
+            self.close();
+            return false;
+        };
+
+        self.pending_transmits.push_back(Transmit {
+            contents: bytes.clone(),
+        });
+        self.handshake_datagram = Some(bytes);
+        self.handshake_retransmits = 0;
+
+        true
+    }
+
+    /// Put the last handshake datagram back on the wire because the peer
+    /// repeated the one before it, so ours went missing.
+    ///
+    /// Not counted against `HANDSHAKE_RETRANSMIT_LIMIT`: that limit counts
+    /// datagrams sent "without a response" (3.1.5.4.1), and this one is a
+    /// response.
+    fn resend_handshake_datagram(&mut self) {
+        if let Some(datagram) = self.handshake_datagram.as_ref() {
+            self.pending_transmits.push_back(Transmit {
+                contents: datagram.clone(),
+            });
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    // Handshake: receiving
+    // ════════════════════════════════════════════════════════════════
+
+    /// Client receives SYN+ACK from server.
+    fn handle_syn_ack(&mut self, wire: &[u8], now: MonotonicInstant) -> Result<(), RdpeudpError> {
+        let datagram: V1Datagram = decode(wire).map_err(RdpeudpError::decode)?;
+
+        // Must have SYN + ACK flags
+        if !datagram.header.flags.contains(V1Flags::SYN | V1Flags::ACK) {
+            return Err(RdpeudpError::invalid_packet(
+                "handle SYN+ACK",
+                "expected SYN+ACK during handshake",
+            ));
+        }
+
+        let syn_data = datagram
+            .syn_data
+            .as_ref()
+            .ok_or_else(|| RdpeudpError::invalid_packet("handle SYN+ACK", "SYN+ACK missing SynData"))?;
+
+        let syn_data_ex = datagram
+            .syn_data_ex
+            .as_ref()
+            .ok_or_else(|| RdpeudpError::invalid_packet("handle SYN+ACK", "SYN+ACK missing SynDataEx"))?;
+
+        // 3.1.5.1.1: the version in the SYN+ACK is "the highest version
+        // supported by both endpoints", and per 3.1.5.1.3 that is the version
+        // both MUST then use. Anything below 3 means the server settled on the
+        // MS-RDPEUDP data transfer, which this crate does not speak.
+        if !syn_data_ex.udp_ver.uses_v2_wire_format() {
+            return Err(RdpeudpError::invalid_packet(
+                "handle SYN+ACK",
+                "server settled on a protocol version below 3, whose data transfer is MS-RDPEUDP rather than MS-RDPEUDP2",
+            ));
+        }
+
+        let local_isn = self.config.initial_sequence_number;
+        let remote_isn = syn_data.initial_sequence_number;
+
+        let mtu = self
+            .config
+            .upstream_mtu
+            .min(self.config.downstream_mtu)
+            .min(syn_data.upstream_mtu)
+            .min(syn_data.downstream_mtu);
+
+        self.params = Some(NegotiatedParams {
+            local_isn,
+            remote_isn,
+            mtu,
+            log_window_size: self.config.log_window_size,
+        });
+
+        // Sample before enqueuing the final ACK. `enqueue_final_ack` calls
+        // `enqueue_handshake`, which resets `handshake_retransmits` to 0 for
+        // the new datagram; doing that first would erase whether the SYN
+        // this SYN+ACK answers was itself retransmitted, defeating the
+        // Karn's-algorithm check `sample_handshake_rtt` relies on.
+        self.sample_handshake_rtt(now);
+
+        // Send final ACK to complete handshake
+        self.enqueue_final_ack(remote_isn);
+
+        // Transition to established
+        self.transition_to_established(now);
+
+        Ok(())
+    }
+
+    /// Server receives the client's final ACK.
+    fn handle_final_ack(&mut self, wire: &[u8], now: MonotonicInstant) -> Result<(), RdpeudpError> {
+        let datagram: V1Datagram = decode(wire).map_err(RdpeudpError::decode)?;
+
+        // The client repeats its SYN when our SYN+ACK goes missing. Answer it
+        // again rather than reading it as a protocol violation.
+        if datagram.header.flags.contains(V1Flags::SYN) {
+            self.resend_handshake_datagram();
+            return Ok(());
+        }
+
+        if !datagram.header.flags.contains(V1Flags::ACK) {
+            return Err(RdpeudpError::invalid_packet(
+                "handle final ACK",
+                "expected ACK during handshake",
+            ));
+        }
+
+        self.sample_handshake_rtt(now);
+
+        self.transition_to_established(now);
+        Ok(())
+    }
+
+    /// Build and enqueue the client's final ACK.
+    fn enqueue_final_ack(&mut self, remote_isn: u32) {
+        let datagram = V1Datagram {
+            header: FecHeader {
+                sn_source_ack: remote_isn,
+                receive_window_size: 1u16 << u16::from(self.config.log_window_size),
+                flags: V1Flags::ACK,
+            },
+            ack_vector: Some(V1AckVectorHeader {
+                elements: vec![V1AckVectorElement {
+                    state: VectorElementState::DatagramReceived,
+                    length: 1,
+                }],
+            }),
+            ack_of_acks: None,
+            syn_data: None,
+            correlation_id: None,
+            syn_data_ex: None,
+        };
+
+        let _queued = self.enqueue_handshake(&datagram);
+    }
+
+    /// Sample the handshake round trip as the connection's first RTT
+    /// estimate, from whichever handshake datagram we last sent and are
+    /// now getting the answer to.
+    ///
+    /// Skipped if that datagram was retransmitted: Karn's algorithm (RFC
+    /// 6298 Section 3) forbids RTT samples from retransmitted segments,
+    /// since it is ambiguous which transmission this answer corresponds to.
+    fn sample_handshake_rtt(&mut self, now: MonotonicInstant) {
+        if self.handshake_retransmits != 0 {
+            return;
+        }
+        if let Some(sent_at) = self.handshake_sent_at {
+            self.rtt.update(now.duration_since(sent_at));
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    // State transitions
+    // ════════════════════════════════════════════════════════════════
+
+    /// Transition from handshake to established state.
+    ///
+    /// Initializes all data transfer components (windows, timers).
+    fn transition_to_established(&mut self, now: MonotonicInstant) {
+        self.state = State::Established;
+        self.timers.clear(Timer::Retransmit);
+
+        // The client keeps its final ACK: nothing acknowledges that ACK, so
+        // the only sign it was lost is the server repeating its SYN+ACK. The
+        // server, having just received that ACK, has nothing left to repeat.
+        if self.side == Side::Server {
+            self.handshake_datagram = None;
+        }
+
+        let params = self
+            .params
+            .as_ref()
+            .expect("params must be set before transitioning to established");
+
+        // Data sequence numbers start at ISN + 1
+        let local_initial_data_seq = u64::from(params.local_isn) + 1;
+        let remote_initial_data_seq = u64::from(params.remote_isn) + 1;
+
+        // Channel sequence numbers start at 1
+        let initial_channel_seq = 1u64;
+
+        self.send_window = Some(SendWindow::new(
+            local_initial_data_seq,
+            initial_channel_seq,
+            params.log_window_size,
+        ));
+
+        self.recv_window = Some(RecvWindow::new(
+            remote_initial_data_seq,
+            initial_channel_seq,
+            params.log_window_size,
+        ));
+
+        self.timers.set(Timer::Idle, now + self.config.idle_timeout);
+        self.timers.set(Timer::KeepAlive, now + self.config.keep_alive_interval);
+
+        self.pending_events.push_back(Event::Connected);
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    // V2 packet handling (established state)
+    // ════════════════════════════════════════════════════════════════
+
+    /// Process a v2 wire-format packet (with prefix byte framing).
+    fn handle_v2_packet(&mut self, wire: &mut [u8], now: MonotonicInstant) -> Result<(), RdpeudpError> {
+        let (prefix, packet_bytes) = decode_with_prefix(wire).map_err(RdpeudpError::prefix)?;
+
+        let packet: V2Packet = decode(packet_bytes).map_err(RdpeudpError::decode)?;
+
+        // Process ACK payload (cumulative acknowledgment)
+        if let Some(ref ack) = packet.ack {
+            self.process_ack(ack, &packet.header, now);
+        }
+
+        // Process AckVector (selective acknowledgment with gaps)
+        if let Some(ref ack_vector) = packet.ack_vector {
+            self.process_ack_vector(ack_vector, &packet.header, now);
+        }
+
+        // Process AckOfAcks (advance recv window base)
+        if let Some(ref aoa) = packet.ack_of_acks {
+            self.process_ack_of_acks(aoa);
+        }
+
+        // Process data payload
+        if let (Some(dh), Some(db)) = (&packet.data_header, &packet.data_body) {
+            if prefix.is_dummy() {
+                // [MS-RDPEUDP2] 3.1.1.1.5: a dummy packet "is treated as a
+                // normal RDP-UDP2 packet by the UDP transport", so it still
+                // occupies its sequence number and gets acknowledged, but
+                // "the contents MUST be ignored by higher layers using the
+                // UDP transport".
+                self.process_dummy_data(dh, now);
+            } else {
+                self.process_data(dh, db, now);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Process a cumulative ACK payload.
+    fn process_ack(&mut self, ack: &AckPayload, _header: &V2Header, now: MonotonicInstant) {
+        let send_window = match self.send_window.as_mut() {
+            Some(sw) => sw,
+            None => return,
+        };
+
+        // Update remote timestamp reference from the received timestamp
+        self.remote_timestamp_ref = seq::reconstruct_timestamp(ack.received_ts, self.remote_timestamp_ref);
+
+        // Reconstruct the full 64-bit DataSeqNum from the 16-bit wire value
+        let reference = send_window.next_data_seq().saturating_sub(1);
+        let acked_seq = seq::reconstruct_seq(ack.seq_num, reference);
+
+        // A peer cannot legitimately acknowledge a DataSeqNum that was never
+        // assigned. Accepting one anyway would let `mark_received_through`
+        // drain every currently outstanding entry as if it had been
+        // delivered, discarding real in-flight application data on a single
+        // malformed or hostile ACK.
+        if acked_seq >= send_window.next_data_seq() {
+            return;
+        }
+
+        // Time the acknowledged packet before acknowledging it. Resolving an
+        // entry drains it off the front of the window, so looking it up
+        // afterwards finds nothing and no RTT sample is ever taken: the
+        // estimator stays empty and the RTO sits at its initial value for
+        // the life of the connection.
+        //
+        // Karn's algorithm: only packets that went out once can be timed.
+        let elapsed = send_window
+            .get_by_data_seq(acked_seq)
+            .filter(|entry| entry.transmit_count == 1)
+            .map(|entry| now.duration_since(entry.sent_at));
+
+        // The ACK seq_num is the highest sequentially received DataSeqNum, so
+        // everything at or below it is acknowledged.
+        let newly_acked_bytes = send_window.mark_received_through(acked_seq);
+
+        if let Some(elapsed) = elapsed {
+            let ack_gap = Duration::from_millis(u64::from(ack.send_ack_time_gap));
+            if let Some(rtt_sample) = elapsed.checked_sub(ack_gap) {
+                self.rtt.update(rtt_sample);
+            }
+        }
+
+        // Congestion window growth
+        if newly_acked_bytes > 0 {
+            self.congestion.on_ack(newly_acked_bytes);
+        }
+
+        // Run loss detection after processing the ACK
+        self.run_loss_detection(now);
+
+        // New data acknowledged retires the packet the timer's deadline was
+        // set for, so a still-outstanding later packet would otherwise be
+        // measured against a deadline meant for something else and can be
+        // declared lost within milliseconds instead of a full RTO. Clearing
+        // only on real progress, never on a duplicate ACK, is what keeps a
+        // peer from postponing loss detection indefinitely by repeating one.
+        if newly_acked_bytes > 0 {
+            self.timers.clear(Timer::Retransmit);
+        }
+        self.update_retransmit_timer(now);
+
+        // 3.1.5.3: stop advertising once the peer acknowledges past it.
+        self.retire_ack_of_acks(acked_seq);
+    }
+
+    /// Process a selective ACK vector.
+    fn process_ack_vector(&mut self, ack_vector: &AckVectorPayload, _header: &V2Header, now: MonotonicInstant) {
+        let send_window = match self.send_window.as_mut() {
+            Some(sw) => sw,
+            None => return,
+        };
+
+        let reference = send_window.next_data_seq().saturating_sub(1);
+        let base = seq::reconstruct_seq(ack_vector.base_seq_num, reference);
+
+        // Walk the ack vector entries and mark packets received/not-received
+        let mut current_seq = base;
+        let mut newly_acked_bytes: u64 = 0;
+
+        // Timing for the highest packet this vector acknowledges, taken as we
+        // go because resolving an entry drains it out of the window. Karn's
+        // algorithm: only packets that went out once can be timed.
+        let mut elapsed = None;
+
+        for entry in &ack_vector.entries {
+            match entry {
+                AckVectorEntry::RunLength { received, length } => {
+                    for _ in 0..u64::from(*length) {
+                        if *received {
+                            if let Some(sample) = send_window
+                                .get_by_data_seq(current_seq)
+                                .filter(|entry| entry.transmit_count == 1)
+                                .map(|entry| now.duration_since(entry.sent_at))
+                            {
+                                elapsed = Some(sample);
+                            }
+
+                            if let Some(size) = send_window.mark_received(current_seq) {
+                                newly_acked_bytes += u64::try_from(size).expect("packet size fits in u64");
+                            }
+                        }
+                        current_seq += 1;
+                    }
+                }
+                AckVectorEntry::StateMap { bitmap } => {
+                    // [MS-RDPEUDP2] 2.2.1.2.6 state-map mode: the most
+                    // significant bit is the mode marker and the remaining
+                    // seven carry one sequence number each, so a state-map byte
+                    // covers seven, not eight. Advancing by eight desynchronised
+                    // the cursor from the peer's vector for every entry after
+                    // the first state map.
+                    for bit_pos in 0..7u32 {
+                        let received = (bitmap >> bit_pos) & 1 == 1;
+                        if received {
+                            if let Some(sample) = send_window
+                                .get_by_data_seq(current_seq)
+                                .filter(|entry| entry.transmit_count == 1)
+                                .map(|entry| now.duration_since(entry.sent_at))
+                            {
+                                elapsed = Some(sample);
+                            }
+
+                            if let Some(size) = send_window.mark_received(current_seq) {
+                                newly_acked_bytes += u64::try_from(size).expect("packet size fits in u64");
+                            }
+                        }
+                        current_seq += 1;
+                    }
+                }
+            }
+        }
+
+        // RTT estimation from ACKVEC timing
+        if let (Some(elapsed), Some(gap_ms)) = (elapsed, ack_vector.send_ack_time_gap_ms) {
+            let ack_gap = Duration::from_millis(u64::from(gap_ms));
+            if let Some(rtt_sample) = elapsed.checked_sub(ack_gap) {
+                self.rtt.update(rtt_sample);
+            }
+        }
+
+        if newly_acked_bytes > 0 {
+            self.congestion.on_ack(newly_acked_bytes);
+        }
+
+        self.run_loss_detection(now);
+
+        // See the matching comment in `process_ack`: restart on real
+        // progress only, so a duplicate ACK cannot postpone the deadline.
+        if newly_acked_bytes > 0 {
+            self.timers.clear(Timer::Retransmit);
+        }
+        self.update_retransmit_timer(now);
+
+        // 3.1.5.3 also retires it on "an acknowledgment vector with its lowest
+        // sequence number still missing that is higher than the AckOfAck
+        // sequence number", which is this vector's base.
+        self.retire_ack_of_acks(base);
+    }
+
+    /// Process an AckOfAcks payload: advance our recv window base.
+    fn process_ack_of_acks(&mut self, aoa: &AckOfAcksPayload) {
+        let recv_window = match self.recv_window.as_mut() {
+            Some(rw) => rw,
+            None => return,
+        };
+
+        let reference = recv_window.highest_seq();
+        let new_base = seq::reconstruct_seq(aoa.ack_of_acks_seq_num, reference);
+        recv_window.advance_base(new_base);
+    }
+
+    /// Account for a dummy packet without handing anything to the
+    /// application.
+    ///
+    /// [MS-RDPEUDP2] 3.1.1.1.5 keeps the transport's view of a dummy packet
+    /// ordinary: it fills its slot in the receive window and is acknowledged,
+    /// which is what lets the sender see it arrive. Only the contents are
+    /// off limits.
+    fn process_dummy_data(&mut self, dh: &DataHeader, now: MonotonicInstant) {
+        let Some(recv_window) = self.recv_window.as_mut() else {
+            return;
+        };
+
+        let reference = recv_window.highest_seq();
+        let data_seq = seq::reconstruct_seq(dh.data_seq_num, reference);
+
+        if !recv_window.receive_without_payload(data_seq) {
+            return;
+        }
+
+        self.ack_pending = true;
+        if !self.timers.is_set(Timer::AckDelay) {
+            self.timers.set(Timer::AckDelay, now + self.ack_delay_timeout());
+            self.ack_delay_started_at = Some(now);
+        }
+    }
+
+    fn process_data(&mut self, dh: &DataHeader, db: &DataBody, now: MonotonicInstant) {
+        let recv_window = match self.recv_window.as_mut() {
+            Some(rw) => rw,
+            None => return,
+        };
+
+        // Reconstruct full sequence numbers from 16-bit wire values
+        let reference_data = recv_window.highest_seq();
+        let data_seq = seq::reconstruct_seq(dh.data_seq_num, reference_data);
+
+        let reference_channel = recv_window.next_channel_seq();
+        let channel_seq = seq::reconstruct_seq(db.channel_seq_num, reference_channel);
+
+        // Record the packet in the receive window
+        let is_new = recv_window.receive(data_seq, channel_seq, db.data.clone());
+
+        if is_new {
+            // Drain ordered data for application delivery
+            let delivered = recv_window.drain_ordered();
+            for chunk in delivered {
+                self.pending_events.push_back(Event::DataReceived(chunk));
+            }
+
+            // Schedule ACK (either piggybacked on next data or standalone)
+            self.ack_pending = true;
+            if !self.timers.is_set(Timer::AckDelay) {
+                self.timers.set(Timer::AckDelay, now + self.ack_delay_timeout());
+                self.ack_delay_started_at = Some(now);
+            }
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    // Loss detection and retransmission
+    // ════════════════════════════════════════════════════════════════
+
+    /// Run the loss detector on the current send window state.
+    fn run_loss_detection(&mut self, now: MonotonicInstant) {
+        let send_window = match self.send_window.as_mut() {
+            Some(sw) => sw,
+            None => return,
+        };
+
+        let highest_acked = send_window.highest_acked_data_seq();
+        let rto = self.rtt.rto();
+
+        let lost_seqs = self.loss_detector.detect(send_window, highest_acked, rto, now);
+
+        for data_seq in lost_seqs {
+            self.declare_lost(data_seq);
+        }
+    }
+
+    /// Move one packet out of the send window and onto the retransmit queue.
+    fn declare_lost(&mut self, data_seq: u64) {
+        let Some(send_window) = self.send_window.as_mut() else {
+            return;
+        };
+
+        // Read before `mark_lost` drops the entry: this bounds the recovery
+        // epoch, so everything already in flight counts as one loss event.
+        let largest_sent = send_window.next_data_seq().saturating_sub(1);
+
+        let Some(info) = send_window.mark_lost(data_seq) else {
+            return;
+        };
+
+        // Losing the packet moved the front of the window past it, and the
+        // retransmission will carry a new DataSeqNum, so this one is never
+        // going to be acknowledged. Tell the peer where we have got to, or its
+        // receive window will sit on the hole forever (3.1.5.3).
+        let lowest_unacknowledged = send_window.lowest_unacknowledged();
+
+        self.congestion.on_loss(data_seq, largest_sent);
+        self.reliability.enqueue(info.channel_seq, info.data);
+        self.pending_ack_of_acks = Some(lowest_unacknowledged);
+    }
+
+    /// Stop advertising the AckOfAcks once the peer has moved past it.
+    ///
+    /// [MS-RDPEUDP2] 3.1.5.3: the sender "should stop sending this payload
+    /// when either it receives an acknowledgment that has a sequence number
+    /// that is higher than the AckOfAck sequence number, or it receives an
+    /// acknowledgment vector with its lowest sequence number still missing
+    /// that is higher than the AckOfAck sequence number".
+    fn retire_ack_of_acks(&mut self, peer_reported_seq: u64) {
+        if self
+            .pending_ack_of_acks
+            .is_some_and(|advertised| peer_reported_seq > advertised)
+        {
+            self.pending_ack_of_acks = None;
+        }
+    }
+
+    /// Declare the oldest unacknowledged packet lost because the retransmit
+    /// timer expired on it.
+    ///
+    /// The timer firing is itself the loss signal: [MS-RDPEUDP] 3.1.6.1 arms
+    /// it for a datagram that has gone unacknowledged for an RTO, and 3.1.1.5
+    /// leaves the choice of retransmit scheme to the implementation. Without
+    /// this, a packet lost with fewer than `DEFAULT_REORDER_THRESHOLD` later
+    /// packets behind it is never retransmitted at all, because the time
+    /// threshold in `LossDetector` is computed from an RTO that
+    /// `RttEstimator::on_timeout` has already doubled and so always sits
+    /// ahead of the elapsed time.
+    fn declare_oldest_pending_lost(&mut self) {
+        let Some(send_window) = self.send_window.as_ref() else {
+            return;
+        };
+
+        let Some(oldest) = send_window.pending_entries().map(|entry| entry.data_seq).min() else {
+            return;
+        };
+
+        self.declare_lost(oldest);
+    }
+
+    /// Update the retransmit timer based on send window state.
+    fn update_retransmit_timer(&mut self, now: MonotonicInstant) {
+        let has_pending = match self.send_window.as_ref() {
+            Some(send_window) => send_window.pending_entries().next().is_some(),
+            None => return,
+        };
+
+        // The retransmit queue counts too. A packet declared lost leaves the
+        // send window immediately but may sit in the queue while the
+        // congestion window is full, and with no timer armed nothing would
+        // come back to it if the peer had also gone quiet.
+        if has_pending || self.reliability.has_pending() {
+            // Keep the timer running
+            if !self.timers.is_set(Timer::Retransmit) {
+                self.timers.set(Timer::Retransmit, now + self.rtt.rto());
+            }
+        } else {
+            // Nothing outstanding: clear the timer
+            self.timers.clear(Timer::Retransmit);
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    // Transmit generation
+    // ════════════════════════════════════════════════════════════════
+
+    /// Try to build and send a retransmission from the reliability queue.
+    fn try_retransmit(&mut self, now: MonotonicInstant) -> Option<Transmit> {
+        if !self.reliability.has_pending() {
+            return None;
+        }
+
+        let send_window = self.send_window.as_mut()?;
+
+        // Check congestion window allows sending
+        if send_window.bytes_in_flight() >= self.congestion.window() {
+            return None;
+        }
+
+        if !send_window.has_capacity() {
+            return None;
+        }
+
+        let entry = self.reliability.dequeue()?;
+
+        // Create a new DataSeqNum for the retransmit but preserve ChannelSeqNum
+        let new_data_seq = send_window.push_retransmit(entry.channel_seq, entry.data.clone(), now)?;
+
+        let transmit = self.build_data_packet(new_data_seq, entry.channel_seq, entry.data, now);
+
+        if transmit.is_some() {
+            // Reset retransmit timer
+            self.timers.set(Timer::Retransmit, now + self.rtt.rto());
+        }
+
+        transmit
+    }
+
+    /// Try to build and send new data from the send buffer.
+    fn try_send_new_data(&mut self, now: MonotonicInstant) -> Option<Transmit> {
+        if self.send_buffer.is_empty() {
+            return None;
+        }
+
+        let send_window = self.send_window.as_mut()?;
+
+        // Check congestion window
+        if send_window.bytes_in_flight() >= self.congestion.window() {
+            return None;
+        }
+
+        if !send_window.has_capacity() {
+            return None;
+        }
+
+        let data = self.send_buffer.pop_front()?;
+
+        // Push into send window (assigns DataSeqNum and ChannelSeqNum)
+        let (data_seq, channel_seq) = send_window.push(data.clone(), now)?;
+
+        let transmit = self.build_data_packet(data_seq, channel_seq, data, now);
+
+        if transmit.is_some() {
+            // Set retransmit timer if not already running
+            if !self.timers.is_set(Timer::Retransmit) {
+                self.timers.set(Timer::Retransmit, now + self.rtt.rto());
+            }
+        }
+
+        transmit
+    }
+
+    /// Build a V2 data packet with optional ACK piggybacking.
+    fn build_data_packet(
+        &mut self,
+        data_seq: u64,
+        channel_seq: u64,
+        data: Vec<u8>,
+        now: MonotonicInstant,
+    ) -> Option<Transmit> {
+        let log_window_size = self.params.as_ref()?.log_window_size;
+
+        let mut flags = V2Flags::DATA;
+
+        // Piggyback an acknowledgment if one is pending
+        let mut acknowledged = false;
+        let (ack, ack_vector) = if self.ack_pending {
+            match self.build_acknowledgement(now) {
+                Some(acknowledgement) => {
+                    acknowledged = true;
+                    flags |= acknowledgement.flag;
+                    (acknowledgement.ack, acknowledgement.ack_vector)
+                }
+                None => (None, None),
+            }
+        } else {
+            (None, None)
+        };
+
+        // AckOfAcks if pending
+        let ack_of_acks = self.pending_ack_of_acks.map(|seq| AckOfAcksPayload {
+            ack_of_acks_seq_num: seq::truncate_seq(seq),
+        });
+        if ack_of_acks.is_some() {
+            flags |= V2Flags::AOA;
+        }
+
+        let packet = V2Packet {
+            header: V2Header { flags, log_window_size },
+            ack,
+            overhead_size: None,
+            delay_ack_info: None,
+            ack_of_acks,
+            data_header: Some(DataHeader {
+                data_seq_num: seq::truncate_seq(data_seq),
+            }),
+            ack_vector,
+            data_body: Some(DataBody {
+                channel_seq_num: seq::truncate_seq(channel_seq),
+                data,
+            }),
+        };
+
+        let transmit = self.encode_v2_packet(&packet)?;
+
+        // Retire what the packet carried only now that it exists. Clearing
+        // any of this before the encode drops an acknowledgment that was
+        // never sent, and the peer has no way to learn it was owed one.
+        if acknowledged {
+            self.ack_pending = false;
+            self.timers.clear(Timer::AckDelay);
+            self.commit_acknowledgement();
+        }
+
+        Some(transmit)
+    }
+
+    /// Build a standalone ACK (no data).
+    fn build_standalone_ack(&mut self, now: MonotonicInstant) -> Option<Transmit> {
+        let log_window_size = self.params.as_ref()?.log_window_size;
+
+        let acknowledgement = self.build_acknowledgement(now)?;
+        let mut flags = acknowledgement.flag;
+        let (ack, ack_vector) = (acknowledgement.ack, acknowledgement.ack_vector);
+
+        let ack_of_acks = self.pending_ack_of_acks.map(|seq| AckOfAcksPayload {
+            ack_of_acks_seq_num: seq::truncate_seq(seq),
+        });
+        if ack_of_acks.is_some() {
+            flags |= V2Flags::AOA;
+        }
+
+        let packet = V2Packet {
+            header: V2Header { flags, log_window_size },
+            ack,
+            overhead_size: None,
+            delay_ack_info: None,
+            ack_of_acks,
+            data_header: None,
+            ack_vector,
+            data_body: None,
+        };
+
+        let transmit = self.encode_v2_packet(&packet)?;
+
+        // Same ordering as the data path: the window only moves past packets
+        // whose acknowledgment actually made it into a packet.
+        self.commit_acknowledgement();
+
+        Some(transmit)
+    }
+
+    /// Build the cumulative ACK payload from the recv window state.
+    /// Build the acknowledgment to attach to an outgoing packet.
+    ///
+    /// A cumulative ACK claims every packet through its sequence number, so
+    /// it is only true when the window has no holes. [MS-RDPEUDP2] 3.1.1.2.2
+    /// keeps the vector form for the other case. Sending the cumulative form
+    /// over a hole tells the sender to stop retransmitting a packet that
+    /// never arrived, and the receiver never asks for it again.
+    fn build_acknowledgement(&self, now: MonotonicInstant) -> Option<Acknowledgement> {
+        let recv_window = self.recv_window.as_ref()?;
+
+        let acknowledgement = if recv_window.has_gaps() {
+            Acknowledgement {
+                flag: V2Flags::ACKVEC,
+                ack: None,
+                ack_vector: Some(self.build_ack_vector_payload(recv_window, now)),
+            }
+        } else {
+            Acknowledgement {
+                flag: V2Flags::ACK,
+                ack: Some(self.build_ack_payload(recv_window, now)),
+                ack_vector: None,
+            }
+        };
+
+        Some(acknowledgement)
+    }
+
+    /// Retire the receive-window slots covered by an acknowledgment that is
+    /// now encoded and on its way out.
+    ///
+    /// Separate from building it so a failed encode cannot advance the
+    /// window past packets whose acknowledgment never reached the wire.
+    fn commit_acknowledgement(&mut self) {
+        if let Some(recv_window) = self.recv_window.as_mut() {
+            recv_window.release_acknowledged();
+        }
+        self.ack_delay_started_at = None;
+    }
+
+    /// Convert an instant to the wire timestamp's 4us units.
+    ///
+    /// `MonotonicInstant` is millisecond resolution, an exact multiple of
+    /// the 4us unit, so this loses no precision the crate's time model has
+    /// in the first place.
+    fn timestamp_units(instant: MonotonicInstant) -> u64 {
+        seq::us_to_timestamp_units(instant.as_millis() * 1_000)
+    }
+
+    fn build_ack_payload(&self, recv_window: &RecvWindow, now: MonotonicInstant) -> AckPayload {
+        // seq_num = highest sequentially received DataSeqNum
+        // For cumulative ACK, this is base_seq + count of contiguous received - 1,
+        // but recv_window.highest_seq() gives us the overall highest.
+        // For a true cumulative ACK without gaps, highest_seq is correct.
+        // When gaps exist, we use ACKVEC instead.
+        let cumulative_seq = recv_window.highest_seq();
+        let received_at = self.ack_delay_started_at.unwrap_or(now);
+
+        AckPayload {
+            seq_num: seq::truncate_seq(cumulative_seq),
+            received_ts: seq::truncate_timestamp(Self::timestamp_units(received_at)),
+            // MS-RDPEUDP2 2.2.1.2.1 gives this field the full 0..=255 range,
+            // unlike the vector payload's equivalent below.
+            send_ack_time_gap: u8::try_from(now.duration_since(received_at).as_millis()).unwrap_or(u8::MAX),
+            delay_ack_time_scale: 0,
+            delay_ack_time_additions: Vec::new(),
+        }
+    }
+
+    /// Build the selective ACK vector payload from recv window state.
+    ///
+    /// `codedAckVecSize` is a 7-bit wire field, so at most
+    /// [`ACK_VECTOR_MAX_ENTRIES`] entries fit. An alternating received /
+    /// not-received pattern needs one entry per slot, which a configured
+    /// window above that many slots can produce. Describing only a prefix of
+    /// the window here, rather than failing the whole encode once the limit
+    /// is hit, is what keeps that case making progress: a truncated vector is
+    /// still an accurate description of everything up to where it stops, and
+    /// the next acknowledgment picks up wherever the window has moved by
+    /// then.
+    fn build_ack_vector_payload(&self, recv_window: &RecvWindow, now: MonotonicInstant) -> AckVectorPayload {
+        let received_at = self.ack_delay_started_at.unwrap_or(now);
+        let ack_vec = recv_window.ack_vector();
+        let mut entries: Vec<AckVectorEntry> = Vec::new();
+
+        // RunLength entries have a 6-bit length field (max 63).
+        // Split longer runs into multiple entries.
+        'runs: for (received, count) in ack_vec {
+            let mut remaining = count;
+            while remaining > 0 {
+                if entries.len() >= ACK_VECTOR_MAX_ENTRIES {
+                    break 'runs;
+                }
+                let chunk = u8::try_from(remaining.min(63)).expect("clamped to 6-bit range");
+                entries.push(AckVectorEntry::RunLength {
+                    received,
+                    length: chunk,
+                });
+                remaining -= u64::from(chunk);
+            }
+        }
+
+        AckVectorPayload {
+            base_seq_num: seq::truncate_seq(recv_window.base_seq()),
+            timestamp: Some(seq::truncate_timestamp(Self::timestamp_units(received_at))),
+            // MS-RDPEUDP2 2.2.1.2.6 reserves 255 to mean "invalid, MUST NOT
+            // be used", unlike the cumulative payload's equivalent above.
+            send_ack_time_gap_ms: Some(
+                u8::try_from(now.duration_since(received_at).as_millis())
+                    .unwrap_or(254)
+                    .min(254),
+            ),
+            entries,
+        }
+    }
+
+    /// Encode a V2 packet with the PacketPrefixByte framing.
+    fn encode_v2_packet(&mut self, packet: &V2Packet) -> Option<Transmit> {
+        let packet_bytes = encode_vec(packet).ok()?;
+        // We never originate dummy packets. They exist for a sender that wants
+        // to probe or pad without giving the higher layer anything to read,
+        // and this transport has no use for that.
+        let is_dummy = false;
+
+        self.wire_buf.clear();
+        encode_with_prefix(&packet_bytes, is_dummy, &mut self.wire_buf).ok()?;
+
+        Some(Transmit {
+            contents: self.wire_buf.clone(),
+        })
+    }
+
+    // ════════════════════════════════════════════════════════════════
+    // Timer handlers
+    // ════════════════════════════════════════════════════════════════
+
+    /// Handle retransmit timer expiry.
+    fn handle_retransmit_timeout(&mut self, now: MonotonicInstant) {
+        self.timers.clear(Timer::Retransmit);
+
+        if self.state != State::Established {
+            self.rtt.on_timeout();
+            self.retransmit_handshake(now);
+            return;
+        }
+
+        // Before the backoff, which moves the threshold this would be
+        // measured against out of reach. See `declare_oldest_pending_lost`.
+        self.declare_oldest_pending_lost();
+
+        // Apply exponential backoff
+        self.rtt.on_timeout();
+
+        // Reset the timer if there is still unfinished business
+        self.update_retransmit_timer(now);
+    }
+
+    /// Resend the handshake datagram the peer has not answered, or close
+    /// once it has had enough chances (3.1.5.4.1).
+    fn retransmit_handshake(&mut self, now: MonotonicInstant) {
+        if self.handshake_datagram.is_none() {
+            return;
+        }
+
+        if self.handshake_retransmits >= HANDSHAKE_RETRANSMIT_LIMIT {
+            self.close();
+            return;
+        }
+
+        self.handshake_retransmits += 1;
+        self.resend_handshake_datagram();
+
+        // 3.1.6.1 wants the timer to keep firing at no less than the same
+        // interval; `on_timeout` above has already backed the RTO off.
+        self.timers.set(Timer::Retransmit, now + self.rtt.rto());
+    }
+
+    /// Handle ACK delay timer expiry: send a standalone ACK.
+    fn handle_ack_delay_timeout(&mut self, _now: MonotonicInstant) {
+        self.timers.clear(Timer::AckDelay);
+        self.ack_pending = true;
+    }
+
+    /// Handle idle timeout: close the connection.
+    fn handle_idle_timeout(&mut self) {
+        self.close();
+    }
+
+    /// Handle keep-alive timer: enqueue a keep-alive probe.
+    fn handle_keep_alive_timeout(&mut self, now: MonotonicInstant) {
+        self.timers.clear(Timer::KeepAlive);
+
+        // Send a standalone ACK as a keep-alive probe
+        self.ack_pending = true;
+
+        self.timers.set(Timer::KeepAlive, now + self.config.keep_alive_interval);
+    }
+}
+
+impl core::fmt::Debug for RdpeudpConnection {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RdpeudpConnection")
+            .field("side", &self.side)
+            .field("state", &self.state)
+            .field("rto", &self.rtt.rto())
+            .field("srtt", &self.rtt.srtt())
+            .field("pending_transmits", &self.pending_transmits.len())
+            .field("pending_events", &self.pending_events.len())
+            .field("send_buffer", &self.send_buffer.len())
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The worst data packet this connection can build still fits the MTU.
+    ///
+    /// `PIGGYBACK_RESERVE` is arithmetic over payload sizes that live in
+    /// another module, so measure it rather than trust it. If any of those
+    /// payloads grows, this fails instead of a peer silently receiving an
+    /// over-length datagram.
+    #[test]
+    fn a_full_data_packet_fits_the_mtu() {
+        let max_payload = RDPEUDP2_MTU - DATA_PACKET_OVERHEAD - PIGGYBACK_RESERVE;
+
+        let packet = V2Packet {
+            header: V2Header {
+                flags: V2Flags::DATA | V2Flags::ACKVEC | V2Flags::AOA,
+                log_window_size: 6,
+            },
+            ack: None,
+            overhead_size: None,
+            delay_ack_info: None,
+            ack_of_acks: Some(AckOfAcksPayload {
+                ack_of_acks_seq_num: 0xFFFF,
+            }),
+            data_header: Some(DataHeader { data_seq_num: 0xFFFF }),
+            // The biggest vector the 7-bit size field can describe, with the
+            // optional timestamp block present.
+            ack_vector: Some(AckVectorPayload {
+                base_seq_num: 0xFFFF,
+                timestamp: Some(0x00FF_FFFF),
+                send_ack_time_gap_ms: Some(0xFF),
+                entries: vec![
+                    AckVectorEntry::RunLength {
+                        received: true,
+                        length: 63,
+                    };
+                    127
+                ],
+            }),
+            data_body: Some(DataBody {
+                channel_seq_num: 0xFFFF,
+                data: vec![0xAB; max_payload],
+            }),
+        };
+
+        let encoded = encode_vec(&packet).expect("encode");
+
+        let mut wire = Vec::new();
+        encode_with_prefix(&encoded, false, &mut wire).expect("prefix");
+
+        assert!(
+            wire.len() <= RDPEUDP2_MTU,
+            "a full data packet is {} bytes, over the {RDPEUDP2_MTU} byte MTU",
+            wire.len()
+        );
+    }
+
+    /// The reserve should not be wildly larger than it needs to be either.
+    #[test]
+    fn the_piggyback_reserve_is_not_wasteful() {
+        let max_payload = RDPEUDP2_MTU - DATA_PACKET_OVERHEAD - PIGGYBACK_RESERVE;
+
+        assert!(
+            max_payload >= 1000,
+            "only {max_payload} bytes of every packet are usable"
+        );
+    }
+
+    /// An alternating received/not-received pattern needs one run-length
+    /// entry per slot, which a window above 127 slots can produce more of
+    /// than the 7-bit wire field allows. The vector must still respect the
+    /// limit and still encode, rather than describing the whole window and
+    /// failing the encode outright.
+    #[test]
+    fn build_ack_vector_payload_truncates_to_the_wire_limit() {
+        let conn = RdpeudpConnection::new(Side::Client, test_config());
+
+        let mut recv_window = RecvWindow::new(1, 1, 8); // 256 slots
+        for seq in 1..256u64 {
+            if seq % 2 == 1 {
+                recv_window.receive_without_payload(seq);
+            }
+        }
+
+        let payload = conn.build_ack_vector_payload(&recv_window, MonotonicInstant::from_millis(0));
+
+        assert!(
+            payload.entries.len() <= ACK_VECTOR_MAX_ENTRIES,
+            "got {} entries, over the wire limit of {ACK_VECTOR_MAX_ENTRIES}",
+            payload.entries.len()
+        );
+        encode_vec(&payload).expect("a truncated vector must still encode");
+    }
+
+    /// Both ACK builders must report the real receive-to-send gap, not a
+    /// hardcoded zero: an always-zero gap makes the peer fold the entire
+    /// delayed-ACK hold time into its RTT sample instead of only the network
+    /// transit time.
+    #[test]
+    fn ack_builders_report_the_real_delay_gap_and_timestamp() {
+        let mut conn = RdpeudpConnection::new(Side::Client, test_config());
+        conn.ack_delay_started_at = Some(MonotonicInstant::from_millis(100));
+        let now = MonotonicInstant::from_millis(140);
+
+        let mut recv_window = RecvWindow::new(1, 1, 6);
+        recv_window.receive_without_payload(1);
+
+        let expected_ts =
+            seq::truncate_timestamp(RdpeudpConnection::timestamp_units(MonotonicInstant::from_millis(100)));
+
+        let ack = conn.build_ack_payload(&recv_window, now);
+        assert_eq!(ack.send_ack_time_gap, 40);
+        assert_eq!(ack.received_ts, expected_ts);
+
+        let vector = conn.build_ack_vector_payload(&recv_window, now);
+        assert_eq!(vector.send_ack_time_gap_ms, Some(40));
+        assert_eq!(vector.timestamp, Some(expected_ts));
+    }
+
+    /// With nothing outstanding, `ack_delay_started_at` is `None` and the
+    /// gap must read as zero rather than panicking or reporting stale state.
+    #[test]
+    fn ack_builders_report_a_zero_gap_with_nothing_pending() {
+        let conn = RdpeudpConnection::new(Side::Client, test_config());
+        let now = MonotonicInstant::from_millis(140);
+
+        let mut recv_window = RecvWindow::new(1, 1, 6);
+        recv_window.receive_without_payload(1);
+
+        let ack = conn.build_ack_payload(&recv_window, now);
+        assert_eq!(ack.send_ack_time_gap, 0);
+
+        let vector = conn.build_ack_vector_payload(&recv_window, now);
+        assert_eq!(vector.send_ack_time_gap_ms, Some(0));
+    }
+
+    fn test_config() -> ConnectionConfig {
+        ConnectionConfig {
+            cookie_hash: Some([0x5A; 32]),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn ack_delay_timeout_floors_when_no_rtt_sample() {
+        let conn = RdpeudpConnection::new(Side::Client, test_config());
+        assert_eq!(conn.ack_delay_timeout(), Duration::from_millis(50));
+    }
+
+    #[test]
+    fn ack_delay_timeout_floors_below_the_50ms_minimum() {
+        let mut conn = RdpeudpConnection::new(Side::Client, test_config());
+        conn.rtt.update(Duration::from_millis(60)); // half = 30ms, below the floor
+        assert_eq!(conn.ack_delay_timeout(), Duration::from_millis(50));
+    }
+
+    #[test]
+    fn ack_delay_timeout_tracks_half_the_srtt_between_the_bounds() {
+        let mut conn = RdpeudpConnection::new(Side::Client, test_config());
+        conn.rtt.update(Duration::from_millis(300)); // half = 150ms, within bounds
+        assert_eq!(conn.ack_delay_timeout(), Duration::from_millis(150));
+    }
+
+    #[test]
+    fn ack_delay_timeout_caps_above_the_200ms_maximum() {
+        let mut conn = RdpeudpConnection::new(Side::Client, test_config());
+        conn.rtt.update(Duration::from_secs(1)); // half = 500ms, above the cap
+        assert_eq!(conn.ack_delay_timeout(), Duration::from_millis(200));
+    }
+
+    #[test]
+    fn sample_handshake_rtt_updates_the_estimator() {
+        let mut conn = RdpeudpConnection::new(Side::Client, test_config());
+        let sent_at = MonotonicInstant::from_millis(1_000);
+        conn.handshake_sent_at = Some(sent_at);
+
+        conn.sample_handshake_rtt(sent_at + Duration::from_millis(40));
+
+        assert_eq!(conn.rtt.srtt(), Some(Duration::from_millis(40)));
+    }
+
+    /// Karn's algorithm (RFC 6298 Section 3): a retransmitted handshake
+    /// datagram makes it ambiguous which transmission an answer is for, so
+    /// no sample should be taken.
+    #[test]
+    fn sample_handshake_rtt_skips_after_a_retransmit() {
+        let mut conn = RdpeudpConnection::new(Side::Client, test_config());
+        let sent_at = MonotonicInstant::from_millis(1_000);
+        conn.handshake_sent_at = Some(sent_at);
+        conn.handshake_retransmits = 1;
+
+        conn.sample_handshake_rtt(sent_at + Duration::from_millis(40));
+
+        assert_eq!(conn.rtt.srtt(), None);
+    }
+}

--- a/crates/ironrdp-rdpeudp/src/error.rs
+++ b/crates/ironrdp-rdpeudp/src/error.rs
@@ -1,0 +1,123 @@
+//! Error types for the RDP-UDP connection state machine.
+//!
+//! These surface at the public API boundary of [`RdpeudpConnection`], and carry
+//! both wire-level decode and encode failures from `ironrdp-core` and
+//! protocol-level failures from the state machine itself.
+//!
+//! [`RdpeudpConnection`]: crate::RdpeudpConnection
+
+use core::fmt;
+
+use ironrdp_core::{DecodeError, EncodeError};
+
+use crate::pdu::PrefixError;
+
+pub type RdpeudpResult<T> = Result<T, RdpeudpError>;
+
+pub type RdpeudpError = ironrdp_error::Error<RdpeudpErrorKind>;
+
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum RdpeudpErrorKind {
+    /// A datagram could not be decoded.
+    Decode(DecodeError),
+
+    /// A datagram could not be encoded.
+    Encode(EncodeError),
+
+    /// The RDP-UDP2 packet prefix could not be applied or removed.
+    Prefix(PrefixError),
+
+    /// The connection is not in a state where this operation is meaningful.
+    ///
+    /// Sending before the handshake completes, or handling a datagram after the
+    /// connection is closed, both land here.
+    InvalidState,
+
+    /// The send window is full.
+    ///
+    /// The caller should drain [`poll_transmit`] and wait for acknowledgements
+    /// to open the window before retrying.
+    ///
+    /// [`poll_transmit`]: crate::RdpeudpConnection::poll_transmit
+    SendBufferFull,
+
+    /// The connection has been closed, locally or by the idle timeout.
+    ConnectionClosed,
+
+    /// A datagram decoded cleanly but is not valid for the current state.
+    InvalidPacket { reason: &'static str },
+}
+
+impl fmt::Display for RdpeudpErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Decode(_) => write!(f, "decode error"),
+            Self::Encode(_) => write!(f, "encode error"),
+            Self::Prefix(_) => write!(f, "packet prefix error"),
+            Self::InvalidState => write!(f, "connection is in the wrong state for this operation"),
+            Self::SendBufferFull => write!(f, "send buffer is full"),
+            Self::ConnectionClosed => write!(f, "connection is closed"),
+            Self::InvalidPacket { reason } => write!(f, "invalid packet: {reason}"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl core::error::Error for RdpeudpErrorKind {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::Decode(error) => Some(error),
+            Self::Encode(error) => Some(error),
+            Self::Prefix(error) => Some(error),
+            Self::InvalidState | Self::SendBufferFull | Self::ConnectionClosed | Self::InvalidPacket { .. } => None,
+        }
+    }
+}
+
+pub trait RdpeudpErrorExt {
+    fn decode(error: DecodeError) -> Self;
+    fn encode(error: EncodeError) -> Self;
+    fn prefix(error: PrefixError) -> Self;
+    fn invalid_state(context: &'static str) -> Self;
+    fn send_buffer_full(context: &'static str) -> Self;
+    fn connection_closed(context: &'static str) -> Self;
+    fn invalid_packet(context: &'static str, reason: &'static str) -> Self;
+}
+
+impl RdpeudpErrorExt for RdpeudpError {
+    #[track_caller]
+    fn decode(error: DecodeError) -> Self {
+        Self::new("decode error", RdpeudpErrorKind::Decode(error))
+    }
+
+    #[track_caller]
+    fn encode(error: EncodeError) -> Self {
+        Self::new("encode error", RdpeudpErrorKind::Encode(error))
+    }
+
+    #[track_caller]
+    fn prefix(error: PrefixError) -> Self {
+        Self::new("packet prefix error", RdpeudpErrorKind::Prefix(error))
+    }
+
+    #[track_caller]
+    fn invalid_state(context: &'static str) -> Self {
+        Self::new(context, RdpeudpErrorKind::InvalidState)
+    }
+
+    #[track_caller]
+    fn send_buffer_full(context: &'static str) -> Self {
+        Self::new(context, RdpeudpErrorKind::SendBufferFull)
+    }
+
+    #[track_caller]
+    fn connection_closed(context: &'static str) -> Self {
+        Self::new(context, RdpeudpErrorKind::ConnectionClosed)
+    }
+
+    #[track_caller]
+    fn invalid_packet(context: &'static str, reason: &'static str) -> Self {
+        Self::new(context, RdpeudpErrorKind::InvalidPacket { reason })
+    }
+}

--- a/crates/ironrdp-rdpeudp/src/lib.rs
+++ b/crates/ironrdp-rdpeudp/src/lib.rs
@@ -4,4 +4,20 @@
 
 extern crate alloc;
 
+pub mod connection;
+pub mod error;
 pub mod pdu;
+pub mod seq;
+pub mod time;
+
+pub(crate) mod congestion;
+pub(crate) mod loss;
+pub(crate) mod recv_window;
+pub(crate) mod reliability;
+pub(crate) mod rtt;
+pub(crate) mod send_window;
+pub(crate) mod timer;
+
+pub use self::connection::{ConnectionConfig, Event, RdpeudpConnection, Side, Transmit};
+pub use self::error::{RdpeudpError, RdpeudpErrorExt, RdpeudpErrorKind, RdpeudpResult};
+pub use self::time::MonotonicInstant;

--- a/crates/ironrdp-rdpeudp/src/loss.rs
+++ b/crates/ironrdp-rdpeudp/src/loss.rs
@@ -1,0 +1,311 @@
+//! Loss detection for in-flight packets.
+//!
+//! MS-RDPEUDP2 Section 3.1.1.2.3.
+//!
+//! Two independent detection mechanisms:
+//!
+//! 1. **Reordering-based**: A packet is declared lost if a packet with a
+//!    higher DataSeqNum has been acknowledged and the gap exceeds the
+//!    reordering threshold.
+//!
+//! 2. **Time-based**: A packet is declared lost if it has been in flight
+//!    longer than the time threshold (typically 1.25 × RTO).
+//!
+//! When a packet is declared lost, all pending packets with lower
+//! DataSeqNum are also declared lost (per spec requirement, since loss is
+//! monotonic from the sender's perspective).
+
+use crate::time::MonotonicInstant;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+use core::time::Duration;
+
+use crate::send_window::SendWindow;
+
+/// Default reordering threshold: a packet is lost if at least this many
+/// higher-numbered packets have been acknowledged.
+///
+/// This matches TCP's RACK default and QUIC's kPacketThreshold.
+const DEFAULT_REORDER_THRESHOLD: u64 = 3;
+
+/// Time-based loss detection multiplier applied to the RTO.
+///
+/// A packet is lost if `now - sent_at > time_threshold`.
+/// time_threshold = TIME_THRESHOLD_MULTIPLIER × rto.
+///
+/// 9/8 (1.125) is standard for QUIC; we use 1.25 for slightly more
+/// tolerance given RDPEUDP2's higher minimum RTO of 300ms.
+const TIME_THRESHOLD_NUMERATOR: u32 = 5;
+const TIME_THRESHOLD_DENOMINATOR: u32 = 4;
+
+/// Loss detection state.
+#[derive(Debug, Clone)]
+pub(crate) struct LossDetector {
+    /// Reordering threshold (in packets).
+    reorder_threshold: u64,
+}
+
+impl LossDetector {
+    /// Create a new loss detector with default parameters.
+    pub(crate) fn new() -> Self {
+        Self {
+            reorder_threshold: DEFAULT_REORDER_THRESHOLD,
+        }
+    }
+
+    /// Compute the time-based loss threshold from the current RTO.
+    fn time_threshold(rto: Duration) -> Duration {
+        rto * TIME_THRESHOLD_NUMERATOR / TIME_THRESHOLD_DENOMINATOR
+    }
+
+    /// Detect newly lost packets in the send window.
+    ///
+    /// Examines all Pending entries and declares them lost if:
+    /// - A higher-numbered packet was ACKed and the gap exceeds
+    ///   the reordering threshold, OR
+    /// - The packet has been in flight longer than `time_threshold(rto)`.
+    ///
+    /// Additionally, when a packet is declared lost, all pending packets
+    /// with lower DataSeqNum are also declared lost.
+    ///
+    /// Returns the DataSeqNums of newly detected lost packets.
+    pub(crate) fn detect(
+        &self,
+        send_window: &SendWindow,
+        highest_acked: Option<u64>,
+        rto: Duration,
+        now: MonotonicInstant,
+    ) -> Vec<u64> {
+        let time_thresh = Self::time_threshold(rto);
+        let mut lost_seqs = Vec::new();
+
+        // Collect pending entries that meet loss criteria.
+        for entry in send_window.pending_entries() {
+            let reorder_lost =
+                highest_acked.is_some_and(|ha| ha >= entry.data_seq && (ha - entry.data_seq) >= self.reorder_threshold);
+
+            let time_lost = now.duration_since(entry.sent_at) > time_thresh;
+
+            if reorder_lost || time_lost {
+                lost_seqs.push(entry.data_seq);
+            }
+        }
+
+        if lost_seqs.is_empty() {
+            return lost_seqs;
+        }
+
+        // Per spec: all pending packets with lower seq than the highest
+        // declared-lost packet are also lost.
+        let highest_lost = *lost_seqs.iter().max().expect("lost_seqs is non-empty");
+
+        for entry in send_window.pending_entries() {
+            if entry.data_seq < highest_lost && !lost_seqs.contains(&entry.data_seq) {
+                lost_seqs.push(entry.data_seq);
+            }
+        }
+
+        // Sort for deterministic ordering.
+        lost_seqs.sort_unstable();
+        lost_seqs
+    }
+}
+
+impl Default for LossDetector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn now() -> MonotonicInstant {
+        MonotonicInstant::from_millis(0)
+    }
+
+    fn later(base: MonotonicInstant, ms: u64) -> MonotonicInstant {
+        base + Duration::from_millis(ms)
+    }
+
+    #[test]
+    fn no_loss_when_nothing_pending() {
+        let ld = LossDetector::new();
+        let w = SendWindow::new(1, 1, 6);
+        let rto = Duration::from_millis(300);
+
+        let lost = ld.detect(&w, None, rto, now());
+        assert!(lost.is_empty());
+    }
+
+    #[test]
+    fn no_loss_when_no_acks_and_time_not_expired() {
+        let t = now();
+        let ld = LossDetector::new();
+        let mut w = SendWindow::new(1, 1, 6);
+        let rto = Duration::from_millis(300);
+
+        w.push(vec![0; 10], t);
+        w.push(vec![0; 10], t);
+
+        // No ACKs yet, and time hasn't exceeded threshold
+        let lost = ld.detect(&w, None, rto, t);
+        assert!(lost.is_empty());
+    }
+
+    #[test]
+    fn reorder_based_loss() {
+        let t = now();
+        let ld = LossDetector::new();
+        let mut w = SendWindow::new(1, 1, 6);
+        let rto = Duration::from_millis(300);
+
+        // Send 5 packets
+        for _ in 0..5 {
+            w.push(vec![0; 10], t);
+        }
+
+        // ACK packets 4 and 5 (gap = 3 from packet 1)
+        w.mark_received(4);
+        w.mark_received(5);
+
+        // Packet 1 should be lost: highest_acked=5, 5-1=4 >= threshold=3
+        // Packet 2 should be lost: 5-2=3 >= threshold=3
+        let lost = ld.detect(&w, Some(5), rto, t);
+        assert!(lost.contains(&1));
+        assert!(lost.contains(&2));
+        // Packet 3: 5-3=2 < threshold=3, NOT lost by reorder
+        assert!(!lost.contains(&3));
+    }
+
+    #[test]
+    fn time_based_loss() {
+        let t = now();
+        let ld = LossDetector::new();
+        let mut w = SendWindow::new(1, 1, 6);
+        let rto = Duration::from_millis(300);
+
+        w.push(vec![0; 10], t);
+
+        // Time threshold = 300 * 5/4 = 375ms
+        // At t+400ms, packet 1 should be lost
+        let lost = ld.detect(&w, None, rto, later(t, 400));
+        assert_eq!(lost, vec![1]);
+    }
+
+    #[test]
+    fn time_based_loss_not_triggered_early() {
+        let t = now();
+        let ld = LossDetector::new();
+        let mut w = SendWindow::new(1, 1, 6);
+        let rto = Duration::from_millis(300);
+
+        w.push(vec![0; 10], t);
+
+        // Time threshold = 375ms, at t+370ms should NOT be lost
+        let lost = ld.detect(&w, None, rto, later(t, 370));
+        assert!(lost.is_empty());
+    }
+
+    #[test]
+    fn lower_packets_implied_lost() {
+        let t = now();
+        let ld = LossDetector::new();
+        let mut w = SendWindow::new(1, 1, 6);
+        let rto = Duration::from_millis(300);
+
+        // Send 6 packets
+        for _ in 0..6 {
+            w.push(vec![0; 10], t);
+        }
+
+        // ACK packet 6 only
+        w.mark_received(6);
+
+        // Packet 3: 6-3=3 >= threshold → lost
+        // Packets 1, 2 have lower seq than 3 → also lost
+        let lost = ld.detect(&w, Some(6), rto, t);
+        assert!(lost.contains(&1));
+        assert!(lost.contains(&2));
+        assert!(lost.contains(&3));
+        // Packets 4, 5: 6-4=2, 6-5=1, below threshold
+        assert!(!lost.contains(&4));
+        assert!(!lost.contains(&5));
+    }
+
+    #[test]
+    fn combined_reorder_and_time_loss() {
+        let t = now();
+        let ld = LossDetector::new();
+        let mut w = SendWindow::new(1, 1, 6);
+        let rto = Duration::from_millis(300);
+
+        // Packet 1 sent at t
+        w.push(vec![0; 10], t);
+
+        // Packet 2 sent at t+200ms
+        w.push(vec![0; 10], later(t, 200));
+
+        // Packet 3, 4, 5 sent at t+350ms
+        let t3 = later(t, 350);
+        w.push(vec![0; 10], t3);
+        w.push(vec![0; 10], t3);
+        w.push(vec![0; 10], t3);
+
+        // ACK packet 5
+        w.mark_received(5);
+
+        // At t+380ms: time threshold = 375ms
+        // Packet 1: sent at t, age = 380ms > 375ms → time-lost
+        // Packet 2: sent at t+200, age = 180ms, 5-2=3 >= threshold → reorder-lost
+        // Packet 1 also qualifies by reorder: 5-1=4 >= 3
+        let lost = ld.detect(&w, Some(5), rto, later(t, 380));
+        assert!(lost.contains(&1));
+        assert!(lost.contains(&2));
+    }
+
+    #[test]
+    fn already_lost_packets_not_re_detected() {
+        let t = now();
+        let ld = LossDetector::new();
+        let mut w = SendWindow::new(1, 1, 6);
+        let rto = Duration::from_millis(300);
+
+        for _ in 0..5 {
+            w.push(vec![0; 10], t);
+        }
+        w.mark_received(5);
+
+        // First detection
+        let lost = ld.detect(&w, Some(5), rto, t);
+        assert!(lost.contains(&1));
+
+        // Mark them lost in the window
+        for &seq in &lost {
+            w.mark_lost(seq);
+        }
+
+        // Second detection should find nothing new
+        let lost2 = ld.detect(&w, Some(5), rto, t);
+        assert!(lost2.is_empty());
+    }
+
+    #[test]
+    fn time_threshold_computation() {
+        let rto = Duration::from_millis(300);
+        let thresh = LossDetector::time_threshold(rto);
+        assert_eq!(thresh, Duration::from_millis(375));
+
+        let rto = Duration::from_millis(1000);
+        let thresh = LossDetector::time_threshold(rto);
+        assert_eq!(thresh, Duration::from_millis(1250));
+    }
+
+    #[test]
+    fn default_matches_new() {
+        let from_new = LossDetector::new();
+        let from_default = LossDetector::default();
+        assert_eq!(from_new.reorder_threshold, from_default.reorder_threshold);
+    }
+}

--- a/crates/ironrdp-rdpeudp/src/pdu/v1_syn.rs
+++ b/crates/ironrdp-rdpeudp/src/pdu/v1_syn.rs
@@ -130,40 +130,25 @@ bitflags! {
 /// RDPEUDP protocol version negotiated via SYNDATAEX.
 ///
 /// MS-RDPEUDP Section 2.2.2.9.
+///
+/// Carries the raw wire value instead of a closed set of variants. MS-RDPEUDP
+/// 1.7 and 3.1.5.1.3 require a responder to negotiate down to a version it
+/// supports when the peer advertises one it does not recognize; a decode that
+/// hard-fails on an unrecognized value makes that MUST clause unsatisfiable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[repr(u16)]
-pub enum UdpVersion {
+pub struct UdpVersion(pub u16);
+
+impl UdpVersion {
     /// v1: min retransmit 500ms, min ACK delay 200ms.
     /// Data transfer uses the MS-RDPEUDP wire format.
-    V1 = 0x0001,
+    pub const V1: Self = Self(0x0001);
     /// v2: min retransmit 300ms, min ACK delay 50ms.
     /// Data transfer still uses the MS-RDPEUDP wire format.
-    V2 = 0x0002,
+    pub const V2: Self = Self(0x0002);
     /// v3: data transfer uses the MS-RDPEUDP2 wire format.
     /// The client's SYN carries a cookieHash binding it to the
     /// multitransport request.
-    V3 = 0x0101,
-}
-
-impl UdpVersion {
-    /// Try to parse a version from its wire representation.
-    pub fn from_u16(value: u16) -> Option<Self> {
-        match value {
-            0x0001 => Some(Self::V1),
-            0x0002 => Some(Self::V2),
-            0x0101 => Some(Self::V3),
-            _ => None,
-        }
-    }
-
-    /// Returns the wire representation.
-    pub fn as_u16(self) -> u16 {
-        match self {
-            Self::V1 => 0x0001,
-            Self::V2 => 0x0002,
-            Self::V3 => 0x0101,
-        }
-    }
+    pub const V3: Self = Self(0x0101);
 
     /// Whether this version selects the MS-RDPEUDP2 wire format for data
     /// transfer.
@@ -174,9 +159,10 @@ impl UdpVersion {
     /// [MS-RDPEUDP2]. 1.3.2.2 states it from the other direction, that the
     /// MS-RDPEUDP data transfer messages "MUST be used only when the version
     /// negotiated in the UDP connection initialization phase is version 1 or
-    /// version 2".
+    /// version 2". An unrecognized version is neither, so this correctly
+    /// returns `false` for it as well.
     pub fn uses_v2_wire_format(self) -> bool {
-        matches!(self, Self::V3)
+        self == Self::V3
     }
 }
 
@@ -225,10 +211,7 @@ impl SynDataExPayload {
         let syn_ex_flags_raw = src.read_u16_be();
         let syn_ex_flags = SynExFlags::from_bits_truncate(syn_ex_flags_raw);
 
-        let udp_ver_raw = src.read_u16_be();
-        let udp_ver = UdpVersion::from_u16(udp_ver_raw).ok_or_else(|| {
-            ironrdp_core::invalid_field_err!("RDPUDP_SYNDATAEX_PAYLOAD", "uUdpVer", "unknown protocol version")
-        })?;
+        let udp_ver = UdpVersion(src.read_u16_be());
 
         Ok((syn_ex_flags, udp_ver))
     }
@@ -276,7 +259,7 @@ impl Encode for SynDataExPayload {
         ironrdp_core::ensure_size!(in: dst, size: self.encoded_size());
 
         dst.write_u16_be(self.syn_ex_flags.bits());
-        dst.write_u16_be(self.udp_ver.as_u16());
+        dst.write_u16_be(self.udp_ver.0);
 
         if let Some(hash) = &self.cookie_hash {
             dst.write_slice(hash);

--- a/crates/ironrdp-rdpeudp/src/pdu/v2_ack.rs
+++ b/crates/ironrdp-rdpeudp/src/pdu/v2_ack.rs
@@ -7,6 +7,11 @@
 use alloc::vec::Vec;
 use ironrdp_core::{Decode, DecodeResult, Encode, EncodeResult, ReadCursor, WriteCursor};
 
+/// Maximum number of entries an [`AckVectorPayload`] can carry.
+///
+/// `codedAckVecSize` (MS-RDPEUDP2 Section 2.2.1.2.6) is a 7-bit field.
+pub const ACK_VECTOR_MAX_ENTRIES: usize = 127;
+
 // ── Acknowledgement Payload (ACK flag) ──
 
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
@@ -208,6 +213,8 @@ impl AckVectorEntry {
 /// - `BaseSeqNum(2)` + packed byte (`codedAckVecSize(7 bits) : TimeStampPresent(1 bit)`) = 3 bytes.
 /// - If `TimeStampPresent`: `TimeStamp(3)` + `SendAckTimeGapInMs(1)` = 4 bytes.
 /// - `codedAckVector(codedAckVecSize bytes)`.
+///
+/// `codedAckVecSize` is 7 bits, so at most [`ACK_VECTOR_MAX_ENTRIES`] entries fit.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AckVectorPayload {
     /// Lower 16 bits of the base sequence number for this vector.
@@ -273,7 +280,7 @@ impl Encode for AckVectorPayload {
         dst.write_u16(self.base_seq_num);
 
         let vec_size: u8 = ironrdp_core::cast_length!("AckVectorPayload", "codedAckVecSize", self.entries.len())?;
-        if vec_size > 0x7F {
+        if usize::from(vec_size) > ACK_VECTOR_MAX_ENTRIES {
             return Err(ironrdp_core::invalid_field_err!(
                 "AckVectorPayload",
                 "codedAckVecSize",

--- a/crates/ironrdp-rdpeudp/src/recv_window.rs
+++ b/crates/ironrdp-rdpeudp/src/recv_window.rs
@@ -1,0 +1,606 @@
+//! Receiver window buffer for packet reordering and reassembly.
+//!
+//! MS-RDPEUDP2 Section 3.1.1.2.2.
+//!
+//! The receive window tracks expected and received packets, handles
+//! out-of-order delivery, and reassembles data in ChannelSeqNum order
+//! for delivery to the application layer.
+//!
+//! The window tracks packet state using DataSeqNum for ACK generation,
+//! and uses ChannelSeqNum for data reassembly ordering.
+
+use alloc::collections::BTreeMap;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+/// State of a slot in the receive window.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RecvEntryState {
+    /// Expected but not yet received.
+    Pending,
+    /// Packet received.
+    Received,
+}
+
+/// Entry in the receive window, tracking a single DataSeqNum slot.
+#[derive(Debug, Clone)]
+struct RecvEntry {
+    state: RecvEntryState,
+    /// ChannelSeqNum associated with this data, if received.
+    channel_seq: Option<u64>,
+}
+
+/// Receive window tracking incoming packets.
+///
+/// Uses DataSeqNum to track which packets have been received (for ACK
+/// vector generation), and ChannelSeqNum for reassembly ordering.
+///
+/// Data is delivered to the application in ChannelSeqNum order:
+/// contiguous data starting from `next_channel_seq` is drained
+/// from the reorder buffer.
+#[derive(Debug)]
+pub(crate) struct RecvWindow {
+    /// Per-slot state indexed by (data_seq - base_seq).
+    entries: Vec<RecvEntry>,
+
+    /// DataSeqNum of the first slot in `entries`.
+    base_seq: u64,
+
+    /// Highest DataSeqNum received so far.
+    highest_seq: u64,
+
+    /// Next ChannelSeqNum expected for in-order delivery.
+    next_channel_seq: u64,
+
+    /// Out-of-order data buffered by ChannelSeqNum, waiting for gaps to fill.
+    reorder_buf: BTreeMap<u64, Vec<u8>>,
+
+    /// Maximum window size (1 << log_window_size).
+    max_entries: usize,
+}
+
+impl RecvWindow {
+    /// Create a new receive window.
+    ///
+    /// `initial_data_seq` is the first DataSeqNum expected.
+    /// `initial_channel_seq` is the first ChannelSeqNum expected.
+    /// `log_window_size` determines the maximum window.
+    pub(crate) fn new(initial_data_seq: u64, initial_channel_seq: u64, log_window_size: u8) -> Self {
+        let max_entries = 1usize << usize::from(log_window_size);
+        Self {
+            entries: Vec::with_capacity(max_entries),
+            base_seq: initial_data_seq,
+            highest_seq: initial_data_seq.saturating_sub(1),
+            next_channel_seq: initial_channel_seq,
+            reorder_buf: BTreeMap::new(),
+            max_entries,
+        }
+    }
+
+    /// Process a received data packet.
+    ///
+    /// Records the DataSeqNum as received and buffers the data for
+    /// ChannelSeqNum-ordered reassembly. Returns `true` if this is a
+    /// new packet (not a duplicate).
+    pub(crate) fn receive(&mut self, data_seq: u64, channel_seq: u64, data: Vec<u8>) -> bool {
+        // A ChannelSeqNum below the delivery cursor belongs to data the
+        // application has already seen, so this is a retransmission of
+        // something we no longer need. Acknowledge it, so the sender stops
+        // resending, but keep it out of the reorder buffer: `drain_ordered`
+        // only ever removes at `next_channel_seq`, so an entry below that
+        // would occupy a slot for the rest of the connection.
+        let already_delivered = channel_seq < self.next_channel_seq;
+
+        // The reorder buffer holds at most one entry per window slot. It
+        // drains only at `next_channel_seq`, so a peer that keeps sending
+        // fresh numbers while withholding that one would otherwise grow it by
+        // an entry per datagram, without bound. Refuse such a packet outright
+        // rather than storing it and acknowledging it.
+        //
+        // Never refuse the packet at `next_channel_seq` itself. It is the one
+        // that empties the buffer, and it is by definition not in it, so a
+        // plain "full, and not already present" test rejects precisely the
+        // packet that would resolve the situation and reassembly stops for
+        // good.
+        if !already_delivered
+            && channel_seq != self.next_channel_seq
+            && self.reorder_buf.len() >= self.max_entries
+            && !self.reorder_buf.contains_key(&channel_seq)
+        {
+            return false;
+        }
+
+        if !self.occupy_slot(data_seq, Some(channel_seq)) {
+            return false;
+        }
+
+        // Buffer data for reassembly by ChannelSeqNum.
+        if !already_delivered {
+            self.reorder_buf.insert(channel_seq, data);
+        }
+
+        true
+    }
+
+    /// Record a DataSeqNum as received while taking nothing from the packet.
+    ///
+    /// This is a dummy packet. [MS-RDPEUDP2] 3.1.1.1.5 has the transport treat
+    /// one "as a normal RDP-UDP2 packet", so it occupies its sequence number
+    /// and is acknowledged like any other, but "the contents MUST be ignored
+    /// by higher layers", which includes the ChannelSeqNum it carries: that
+    /// number belongs to no real datum and reassembling around it would leave
+    /// the delivery cursor waiting on data no one will ever send.
+    pub(crate) fn receive_without_payload(&mut self, data_seq: u64) -> bool {
+        self.occupy_slot(data_seq, None)
+    }
+
+    /// Mark a slot received, returning whether this is new rather than a
+    /// duplicate or a packet outside the window.
+    fn occupy_slot(&mut self, data_seq: u64, channel_seq: Option<u64>) -> bool {
+        // Ignore packets below the window base (already processed).
+        if data_seq < self.base_seq {
+            return false;
+        }
+
+        let index = data_seq - self.base_seq;
+
+        // Ignore packets beyond the window limit.
+        if index >= u64::try_from(self.max_entries).expect("max_entries fits in u64") {
+            return false;
+        }
+
+        let idx = usize::try_from(index).expect("index within window fits in usize");
+
+        // Extend the entries vector if needed.
+        while self.entries.len() <= idx {
+            self.entries.push(RecvEntry {
+                state: RecvEntryState::Pending,
+                channel_seq: None,
+            });
+        }
+
+        // Check for duplicate.
+        if self.entries[idx].state == RecvEntryState::Received {
+            return false;
+        }
+
+        // Mark as received.
+        self.entries[idx].state = RecvEntryState::Received;
+        self.entries[idx].channel_seq = channel_seq;
+
+        if data_seq > self.highest_seq {
+            self.highest_seq = data_seq;
+        }
+
+        true
+    }
+
+    /// Drain contiguous in-order data starting from `next_channel_seq`.
+    ///
+    /// Returns data chunks in ChannelSeqNum order. The caller should
+    /// call this after each `receive()` to deliver data to the
+    /// application layer.
+    pub(crate) fn drain_ordered(&mut self) -> Vec<Vec<u8>> {
+        let mut delivered = Vec::new();
+
+        while let Some(data) = self.reorder_buf.remove(&self.next_channel_seq) {
+            delivered.push(data);
+            self.next_channel_seq += 1;
+        }
+
+        delivered
+    }
+
+    /// Advance the lower bound past the received packets at the bottom of
+    /// the window, which is what sending an acknowledgment that names them
+    /// permits.
+    ///
+    /// [MS-RDPEUDP2] 3.1.1.2.2 gives two events that move the lower bound:
+    /// this one and an AckOfAcks from the sender (`advance_base`). Only
+    /// implementing the second stalls a connection that is not losing
+    /// anything, because a sender with nothing to report sends no ACK
+    /// vector, so no AckOfAcks comes back, so the bound never moves and
+    /// `receive` starts rejecting everything one window past the last
+    /// AckOfAcks.
+    ///
+    /// The spec's caveat for the vector case ("the lower bound can advance
+    /// only if the first sequence number ... is in the Received state")
+    /// falls out of taking the leading run: a hole at the bottom is a run
+    /// of length zero.
+    ///
+    /// Returns the number of slots released.
+    pub(crate) fn release_acknowledged(&mut self) -> usize {
+        let received = self
+            .entries
+            .iter()
+            .take_while(|entry| entry.state == RecvEntryState::Received)
+            .count();
+
+        if received > 0 {
+            self.entries.drain(..received);
+            self.base_seq += u64::try_from(received).expect("run length fits in u64");
+        }
+
+        received
+    }
+
+    /// Advance the window base up to `new_base`.
+    ///
+    /// Called when an AckOfAcks is received, telling us the sender
+    /// knows we've received everything up to this point. Entries below
+    /// `new_base` are no longer needed for ACK vector generation.
+    pub(crate) fn advance_base(&mut self, new_base: u64) {
+        if new_base <= self.base_seq {
+            return;
+        }
+
+        let advance_by = new_base - self.base_seq;
+        let drain_count =
+            usize::try_from(advance_by.min(u64::try_from(self.entries.len()).expect("entries len fits in u64")))
+                .expect("drain count fits in usize");
+
+        self.entries.drain(..drain_count);
+        self.base_seq = new_base;
+    }
+
+    /// Build an ACK vector representing the reception state of packets
+    /// from `base_seq` to `highest_seq`.
+    ///
+    /// Returns a list of `(state, count)` pairs suitable for encoding
+    /// into the RDPEUDP2 AckVector format. The receiver generates this
+    /// to tell the sender which packets it has and hasn't received.
+    ///
+    /// `true` means received, `false` means not received.
+    pub(crate) fn ack_vector(&self) -> Vec<(bool, u64)> {
+        if self.entries.is_empty() {
+            return Vec::new();
+        }
+
+        let mut runs = Vec::new();
+        let mut current_state = self.entries[0].state == RecvEntryState::Received;
+        let mut current_count: u64 = 1;
+
+        for entry in self.entries.iter().skip(1) {
+            let received = entry.state == RecvEntryState::Received;
+            if received == current_state {
+                current_count += 1;
+            } else {
+                runs.push((current_state, current_count));
+                current_state = received;
+                current_count = 1;
+            }
+        }
+        runs.push((current_state, current_count));
+
+        runs
+    }
+
+    /// The current base DataSeqNum (lowest unresolved).
+    pub(crate) fn base_seq(&self) -> u64 {
+        self.base_seq
+    }
+
+    /// The highest DataSeqNum received.
+    pub(crate) fn highest_seq(&self) -> u64 {
+        self.highest_seq
+    }
+
+    /// The next ChannelSeqNum expected for in-order delivery.
+    pub(crate) fn next_channel_seq(&self) -> u64 {
+        self.next_channel_seq
+    }
+
+    /// Whether there are gaps in the received data (some pending slots
+    /// exist between base and highest).
+    pub(crate) fn has_gaps(&self) -> bool {
+        self.entries.iter().any(|e| e.state == RecvEntryState::Pending)
+    }
+
+    /// Number of entries in the reorder buffer waiting to be delivered.
+    #[cfg(test)]
+    pub(crate) fn reorder_buf_len(&self) -> usize {
+        self.reorder_buf.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_window_state() {
+        let w = RecvWindow::new(1, 100, 6);
+        assert_eq!(w.base_seq(), 1);
+        assert_eq!(w.next_channel_seq(), 100);
+        assert!(!w.has_gaps());
+        assert_eq!(w.reorder_buf_len(), 0);
+    }
+
+    #[test]
+    fn receive_in_order() {
+        let mut w = RecvWindow::new(1, 100, 6);
+
+        assert!(w.receive(1, 100, vec![0xAA]));
+        assert!(w.receive(2, 101, vec![0xBB]));
+        assert!(w.receive(3, 102, vec![0xCC]));
+
+        let delivered = w.drain_ordered();
+        assert_eq!(delivered.len(), 3);
+        assert_eq!(delivered[0], vec![0xAA]);
+        assert_eq!(delivered[1], vec![0xBB]);
+        assert_eq!(delivered[2], vec![0xCC]);
+        assert_eq!(w.next_channel_seq(), 103);
+    }
+
+    #[test]
+    fn receive_out_of_order() {
+        let mut w = RecvWindow::new(1, 100, 6);
+
+        // Receive seq 3 first (out of order)
+        assert!(w.receive(3, 102, vec![0xCC]));
+        let delivered = w.drain_ordered();
+        assert!(delivered.is_empty()); // can't deliver until 100 arrives
+
+        // Receive seq 1
+        assert!(w.receive(1, 100, vec![0xAA]));
+        let delivered = w.drain_ordered();
+        assert_eq!(delivered.len(), 1);
+        assert_eq!(delivered[0], vec![0xAA]);
+
+        // Receive seq 2 → now 101 and 102 are contiguous
+        assert!(w.receive(2, 101, vec![0xBB]));
+        let delivered = w.drain_ordered();
+        assert_eq!(delivered.len(), 2);
+        assert_eq!(delivered[0], vec![0xBB]);
+        assert_eq!(delivered[1], vec![0xCC]);
+    }
+
+    #[test]
+    fn reject_duplicate() {
+        let mut w = RecvWindow::new(1, 100, 6);
+
+        assert!(w.receive(1, 100, vec![0xAA]));
+        // Duplicate
+        assert!(!w.receive(1, 100, vec![0xAA]));
+    }
+
+    #[test]
+    fn reject_below_base() {
+        let mut w = RecvWindow::new(5, 100, 6);
+
+        // data_seq 3 is below base_seq 5
+        assert!(!w.receive(3, 98, vec![0x00]));
+    }
+
+    #[test]
+    fn reject_beyond_window() {
+        let mut w = RecvWindow::new(1, 100, 2); // window = 4
+
+        // data_seq 5 is at index 4 (>= max_entries=4)
+        assert!(!w.receive(5, 104, vec![0x00]));
+
+        // data_seq 4 is at index 3 (last valid slot)
+        assert!(w.receive(4, 103, vec![0x00]));
+    }
+
+    #[test]
+    fn has_gaps_detection() {
+        let mut w = RecvWindow::new(1, 100, 6);
+
+        w.receive(1, 100, vec![0x00]);
+        w.receive(3, 102, vec![0x00]); // gap at seq 2
+
+        assert!(w.has_gaps());
+    }
+
+    #[test]
+    fn ack_vector_contiguous() {
+        let mut w = RecvWindow::new(1, 100, 6);
+
+        w.receive(1, 100, vec![0x00]);
+        w.receive(2, 101, vec![0x00]);
+        w.receive(3, 102, vec![0x00]);
+
+        let ack_vec = w.ack_vector();
+        assert_eq!(ack_vec, vec![(true, 3)]);
+    }
+
+    #[test]
+    fn ack_vector_with_gap() {
+        let mut w = RecvWindow::new(1, 100, 6);
+
+        w.receive(1, 100, vec![0x00]);
+        w.receive(3, 102, vec![0x00]); // gap at index 1 (data_seq 2)
+
+        let ack_vec = w.ack_vector();
+        // entries[0] = Received, entries[1] = Pending, entries[2] = Received
+        assert_eq!(ack_vec, vec![(true, 1), (false, 1), (true, 1)]);
+    }
+
+    #[test]
+    fn ack_vector_empty() {
+        let w = RecvWindow::new(1, 100, 6);
+        assert!(w.ack_vector().is_empty());
+    }
+
+    /// The buffer is bounded, but the packet that empties it is exempt.
+    ///
+    /// A cap of "full, and not already buffered" rejects precisely the
+    /// ChannelSeqNum the buffer is waiting on, because that one is by
+    /// definition not in it. Reassembly then never restarts.
+    #[test]
+    fn the_packet_that_drains_the_buffer_is_never_refused() {
+        let window = 1usize << 4;
+        let mut w = RecvWindow::new(1, 1, 4);
+        let mut data_seq = 1u64;
+
+        // ChannelSeqNum 1 goes missing. Everything after it arrives, and each
+        // acknowledgment slides the window on, so the buffer fills to its cap.
+        for channel_seq in 2..=u64::try_from(window * 2).expect("window fits in u64") {
+            w.receive(data_seq, channel_seq, vec![0xAB]);
+            w.release_acknowledged();
+            data_seq += 1;
+        }
+
+        assert_eq!(w.reorder_buf_len(), window, "the buffer should be at its cap");
+        assert!(w.drain_ordered().is_empty(), "nothing is deliverable yet");
+
+        // The sender retransmits the missing datum. [MS-RDPEUDP2] gives the
+        // retransmission a fresh DataSeqNum and keeps the ChannelSeqNum.
+        assert!(
+            w.receive(w.base_seq(), 1, vec![0x01]),
+            "the packet that drains the buffer was refused"
+        );
+
+        assert_eq!(
+            w.drain_ordered().len(),
+            window + 1,
+            "the missing datum should release everything behind it"
+        );
+    }
+
+    /// Data the application has already seen must not take a buffer slot.
+    ///
+    /// `drain_ordered` only removes at `next_channel_seq`, so an entry below
+    /// it is never collected and holds its slot for the rest of the
+    /// connection.
+    #[test]
+    fn a_redelivered_channel_seq_is_acknowledged_but_not_buffered() {
+        let mut w = RecvWindow::new(1, 1, 4);
+
+        assert!(w.receive(1, 1, vec![0xAA]));
+        assert_eq!(w.drain_ordered(), vec![vec![0xAA]]);
+        assert_eq!(w.reorder_buf_len(), 0);
+
+        // The sender did not see our acknowledgment and resent the datum under
+        // a new DataSeqNum.
+        assert!(
+            w.receive(2, 1, vec![0xAA]),
+            "the duplicate should still be acknowledged"
+        );
+        assert_eq!(w.reorder_buf_len(), 0, "and it should not occupy a slot");
+        assert!(w.drain_ordered().is_empty());
+    }
+
+    /// The reorder buffer is bounded by the window. A peer sending packets
+    /// whose ChannelSeqNum never lets the buffer drain would otherwise add one
+    /// entry per datagram for as long as it cared to keep sending.
+    #[test]
+    fn reorder_buffer_is_bounded_by_the_window() {
+        let window = 1usize << 4;
+        let mut w = RecvWindow::new(1, 1, 4);
+
+        // Every packet arrives except the one the buffer is waiting on, so
+        // nothing can ever be delivered and nothing drains.
+        for offset in 0..window * 4 {
+            let seq = 2 + u64::try_from(offset).expect("offset fits in u64");
+            w.advance_base(seq);
+            w.receive(seq, seq, vec![0xAB]);
+        }
+
+        assert!(w.reorder_buf_len() <= window, "the reorder buffer grew past the window");
+    }
+
+    #[test]
+    fn advance_base() {
+        let mut w = RecvWindow::new(1, 100, 6);
+
+        w.receive(1, 100, vec![0x00]);
+        w.receive(2, 101, vec![0x00]);
+        w.receive(3, 102, vec![0x00]);
+        w.receive(5, 104, vec![0x00]);
+
+        // Advance base to 3 → entries for data_seq 1 and 2 are removed
+        w.advance_base(3);
+        assert_eq!(w.base_seq(), 3);
+
+        // The ack vector should now start from data_seq 3
+        let ack_vec = w.ack_vector();
+        // entries[0] = seq3 (Received), entries[1] = seq4 (Pending), entries[2] = seq5 (Received)
+        assert_eq!(ack_vec, vec![(true, 1), (false, 1), (true, 1)]);
+    }
+
+    #[test]
+    fn advance_base_no_effect_if_not_advancing() {
+        let mut w = RecvWindow::new(5, 100, 6);
+        w.advance_base(3); // 3 < base_seq=5, no effect
+        assert_eq!(w.base_seq(), 5);
+    }
+
+    #[test]
+    fn highest_seq_tracking() {
+        let mut w = RecvWindow::new(1, 100, 6);
+
+        w.receive(3, 102, vec![0x00]);
+        assert_eq!(w.highest_seq(), 3);
+
+        w.receive(1, 100, vec![0x00]);
+        assert_eq!(w.highest_seq(), 3); // still 3
+
+        w.receive(5, 104, vec![0x00]);
+        assert_eq!(w.highest_seq(), 5);
+    }
+
+    #[test]
+    fn retransmit_different_data_seq_same_channel_seq() {
+        let mut w = RecvWindow::new(1, 100, 6);
+
+        // Original: data_seq=1, channel_seq=100
+        w.receive(1, 100, vec![0xAA]);
+        let delivered = w.drain_ordered();
+        assert_eq!(delivered, vec![vec![0xAA]]);
+
+        // Retransmit arrives: data_seq=5, channel_seq=100 (same)
+        // Should be rejected as duplicate channel_seq (data already delivered)
+        // Actually, data_seq=5 is a new DataSeqNum slot, but channel_seq=100
+        // is already past next_channel_seq. The receive window records it
+        // by data_seq, and the reorder buf records by channel_seq.
+        // Since channel_seq 100 was already drained, this won't double-deliver.
+        assert!(w.receive(5, 100, vec![0xBB]));
+
+        // drain_ordered won't return anything because next_channel_seq is 101
+        // and channel_seq 100 was re-inserted but is behind
+        let delivered = w.drain_ordered();
+        assert!(delivered.is_empty());
+    }
+
+    #[test]
+    fn reorder_buf_len() {
+        let mut w = RecvWindow::new(1, 100, 6);
+
+        w.receive(3, 102, vec![0x00]); // buffered
+        w.receive(5, 104, vec![0x00]); // buffered
+        assert_eq!(w.reorder_buf_len(), 2);
+
+        w.receive(1, 100, vec![0x00]);
+        w.drain_ordered(); // delivers 100
+        assert_eq!(w.reorder_buf_len(), 2); // 102 and 104 still buffered
+    }
+
+    #[test]
+    fn large_gap_then_fill() {
+        let mut w = RecvWindow::new(1, 100, 6);
+
+        // Receive packets 1, 5, 10 (with gaps)
+        w.receive(1, 100, vec![0x01]);
+        w.receive(5, 104, vec![0x05]);
+        w.receive(10, 109, vec![0x0A]);
+
+        let delivered = w.drain_ordered();
+        assert_eq!(delivered.len(), 1); // only 100
+
+        // Fill the gaps progressively
+        for i in 2..=4 {
+            w.receive(i, 99 + i, vec![u8::try_from(i).expect("fits")]);
+        }
+        let delivered = w.drain_ordered();
+        assert_eq!(delivered.len(), 4); // 101, 102, 103, 104
+
+        // Fill 105-108
+        for i in 6..=9 {
+            w.receive(i, 99 + i, vec![u8::try_from(i).expect("fits")]);
+        }
+        let delivered = w.drain_ordered();
+        assert_eq!(delivered.len(), 5); // 105, 106, 107, 108, 109
+    }
+}

--- a/crates/ironrdp-rdpeudp/src/reliability.rs
+++ b/crates/ironrdp-rdpeudp/src/reliability.rs
@@ -1,0 +1,217 @@
+//! Reliability controller for retransmission management.
+//!
+//! MS-RDPEUDP2 Section 3.1.1.2.4.
+//!
+//! Manages the retransmit queue: when packets are declared lost,
+//! their ChannelSeqNum is enqueued for retransmission. The retransmit
+//! queue is drained by `poll_transmit()` in the connection state machine.
+//!
+//! Key invariant: ChannelSeqNum is preserved across retransmissions
+//! so the receiver can match a retransmit to the original gap.
+//! DataSeqNum changes on each transmission (assigned by SendWindow).
+
+use alloc::collections::VecDeque;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+/// Entry in the retransmit queue.
+#[derive(Debug, Clone)]
+pub(crate) struct RetransmitEntry {
+    /// The ChannelSeqNum identifying this data across retransmissions.
+    pub channel_seq: u64,
+
+    /// The payload data to retransmit.
+    pub data: Vec<u8>,
+}
+
+/// Retransmission queue manager.
+///
+/// When the loss detector declares packets lost, their data is enqueued
+/// here by ChannelSeqNum. The connection state machine dequeues entries
+/// when it has congestion window budget to retransmit them.
+#[derive(Debug)]
+pub(crate) struct ReliabilityController {
+    /// Queue of packets awaiting retransmission.
+    queue: VecDeque<RetransmitEntry>,
+}
+
+impl ReliabilityController {
+    /// Create an empty controller.
+    pub(crate) fn new() -> Self {
+        Self { queue: VecDeque::new() }
+    }
+
+    /// Enqueue data for retransmission.
+    ///
+    /// If the same `channel_seq` is already queued, the existing entry
+    /// is replaced (avoids duplicate retransmits).
+    pub(crate) fn enqueue(&mut self, channel_seq: u64, data: Vec<u8>) {
+        // Avoid duplicate entries for the same channel_seq.
+        if self.queue.iter().any(|e| e.channel_seq == channel_seq) {
+            return;
+        }
+        self.queue.push_back(RetransmitEntry { channel_seq, data });
+    }
+
+    /// Dequeue the next entry for retransmission.
+    ///
+    /// Returns `None` if the queue is empty.
+    pub(crate) fn dequeue(&mut self) -> Option<RetransmitEntry> {
+        self.queue.pop_front()
+    }
+
+    /// Peek at the next entry without removing it.
+    #[cfg(test)]
+    pub(crate) fn peek(&self) -> Option<&RetransmitEntry> {
+        self.queue.front()
+    }
+
+    /// Whether the queue has entries.
+    pub(crate) fn has_pending(&self) -> bool {
+        !self.queue.is_empty()
+    }
+
+    /// Number of entries in the queue.
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.queue.len()
+    }
+
+    /// Remove an entry by channel_seq if it's no longer needed
+    /// (e.g., the receiver has since acknowledged it).
+    #[cfg(test)]
+    pub(crate) fn cancel(&mut self, channel_seq: u64) {
+        self.queue.retain(|e| e.channel_seq != channel_seq);
+    }
+
+    /// Clear the entire queue.
+    #[cfg(test)]
+    pub(crate) fn clear(&mut self) {
+        self.queue.clear();
+    }
+}
+
+impl Default for ReliabilityController {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_is_empty() {
+        let rc = ReliabilityController::new();
+        assert!(!rc.has_pending());
+        assert_eq!(rc.len(), 0);
+    }
+
+    #[test]
+    fn enqueue_and_dequeue() {
+        let mut rc = ReliabilityController::new();
+
+        rc.enqueue(100, vec![0xAA]);
+        rc.enqueue(101, vec![0xBB]);
+
+        assert!(rc.has_pending());
+        assert_eq!(rc.len(), 2);
+
+        let entry = rc.dequeue().expect("should have entry");
+        assert_eq!(entry.channel_seq, 100);
+        assert_eq!(entry.data, vec![0xAA]);
+
+        let entry = rc.dequeue().expect("should have entry");
+        assert_eq!(entry.channel_seq, 101);
+        assert_eq!(entry.data, vec![0xBB]);
+
+        assert!(!rc.has_pending());
+    }
+
+    #[test]
+    fn dequeue_fifo_order() {
+        let mut rc = ReliabilityController::new();
+
+        for i in 0..5 {
+            rc.enqueue(i, vec![u8::try_from(i).expect("fits")]);
+        }
+
+        for i in 0..5 {
+            let entry = rc.dequeue().expect("should have entry");
+            assert_eq!(entry.channel_seq, i);
+        }
+    }
+
+    #[test]
+    fn duplicate_enqueue_ignored() {
+        let mut rc = ReliabilityController::new();
+
+        rc.enqueue(100, vec![0xAA]);
+        rc.enqueue(100, vec![0xBB]); // duplicate, ignored
+
+        assert_eq!(rc.len(), 1);
+
+        let entry = rc.dequeue().expect("should have entry");
+        assert_eq!(entry.data, vec![0xAA]); // original data preserved
+    }
+
+    #[test]
+    fn peek() {
+        let mut rc = ReliabilityController::new();
+
+        assert!(rc.peek().is_none());
+
+        rc.enqueue(100, vec![0xAA]);
+        let peeked = rc.peek().expect("should have entry");
+        assert_eq!(peeked.channel_seq, 100);
+
+        // Peek doesn't remove
+        assert_eq!(rc.len(), 1);
+    }
+
+    #[test]
+    fn cancel() {
+        let mut rc = ReliabilityController::new();
+
+        rc.enqueue(100, vec![0xAA]);
+        rc.enqueue(101, vec![0xBB]);
+        rc.enqueue(102, vec![0xCC]);
+
+        rc.cancel(101);
+
+        assert_eq!(rc.len(), 2);
+        let entry = rc.dequeue().expect("entry");
+        assert_eq!(entry.channel_seq, 100);
+        let entry = rc.dequeue().expect("entry");
+        assert_eq!(entry.channel_seq, 102);
+    }
+
+    #[test]
+    fn cancel_nonexistent() {
+        let mut rc = ReliabilityController::new();
+        rc.enqueue(100, vec![0xAA]);
+
+        rc.cancel(999); // no-op
+        assert_eq!(rc.len(), 1);
+    }
+
+    #[test]
+    fn clear() {
+        let mut rc = ReliabilityController::new();
+
+        rc.enqueue(100, vec![0xAA]);
+        rc.enqueue(101, vec![0xBB]);
+
+        rc.clear();
+        assert!(!rc.has_pending());
+        assert_eq!(rc.len(), 0);
+    }
+
+    #[test]
+    fn default_matches_new() {
+        let from_new = ReliabilityController::new();
+        let from_default = ReliabilityController::default();
+        assert_eq!(from_new.len(), from_default.len());
+    }
+}

--- a/crates/ironrdp-rdpeudp/src/rtt.rs
+++ b/crates/ironrdp-rdpeudp/src/rtt.rs
@@ -1,0 +1,416 @@
+//! RTT estimation and RTO calculation.
+//!
+//! Implements RFC 6298 ("Computing TCP's Retransmission Timer") adapted
+//! for RDPEUDP2. The key difference from standard TCP: the minimum RTO
+//! is 300ms, not TCP's 1 second. MS-RDPEUDP2 Section 3.1.1.2.3 itself only
+//! says the loss-detection timeout is "dynamically variable, depending on
+//! the current network conditions", with no fixed floor of its own; the
+//! 300ms figure is [MS-RDPEUDP] (the v1 document) Section 3.1.6.1's
+//! VERSION_2 minimum retransmit timeout, used here as the closest available
+//! spec anchor.
+//!
+//! RTT samples are derived from the ACK payload's `receivedTS` and
+//! `sendAckTimeGap` fields. Samples from delayed ACKs (ACKDELAYED flag)
+//! must be excluded by the caller, as they would inflate the estimate.
+
+use core::time::Duration;
+
+/// Minimum RTO for RDPEUDP2 connections.
+///
+/// [MS-RDPEUDP] Section 3.1.6.1's VERSION_2 minimum retransmit timeout
+/// (see the module doc comment for why that document rather than
+/// MS-RDPEUDP2 itself). This is lower than TCP's 1s minimum (RFC 6298
+/// Section 2.4) because the protocol operates over a typically low-latency
+/// network path (RDP sessions).
+const MIN_RTO: Duration = Duration::from_millis(300);
+
+/// Maximum RTO cap to prevent unbounded backoff.
+///
+/// RFC 6298 Section 2.5 recommends at least 60 seconds.
+/// Quinn uses 16 seconds. We use 16 seconds to match Quinn's behavior,
+/// which is reasonable for interactive RDP sessions where longer
+/// timeouts would degrade user experience beyond recovery.
+const MAX_RTO: Duration = Duration::from_secs(16);
+
+/// Initial RTO before any RTT measurement is available.
+///
+/// RFC 6298 Section 2.1 recommends 1 second as the initial value.
+/// RDPEUDP2 doesn't specify an override, so we use the RFC default.
+const INITIAL_RTO: Duration = Duration::from_secs(1);
+
+/// RFC 6298 smoothing factor alpha = 1/8.
+const SRTT_ALPHA: u32 = 8;
+
+/// RFC 6298 deviation factor beta = 1/4.
+const RTTVAR_BETA: u32 = 4;
+
+/// RTT estimator with smoothed RTT, RTT variance, and RTO calculation.
+///
+/// Follows RFC 6298 Section 2 with the RDPEUDP2 minimum RTO of 300ms.
+///
+/// # Usage
+///
+/// The caller provides RTT samples from ACK processing. Each sample
+/// is the measured round-trip time for a specific packet. The estimator
+/// maintains a smoothed RTT (SRTT) and variance (RTTVAR) to compute
+/// the retransmission timeout (RTO).
+///
+/// ```ignore
+/// let mut rtt = RttEstimator::new();
+/// // First sample initializes SRTT and RTTVAR
+/// rtt.update(Duration::from_millis(50));
+/// assert!(rtt.rto() >= Duration::from_millis(300)); // min RTO enforced
+///
+/// // Subsequent samples refine the estimate
+/// rtt.update(Duration::from_millis(48));
+/// rtt.update(Duration::from_millis(52));
+/// ```
+#[derive(Debug, Clone)]
+pub(crate) struct RttEstimator {
+    /// Smoothed RTT. `None` until the first sample is processed.
+    srtt: Option<Duration>,
+
+    /// RTT variance (mean deviation).
+    /// Initialized to half the first RTT sample per RFC 6298 Section 2.2.
+    rttvar: Duration,
+
+    /// Current retransmission timeout, always clamped to [MIN_RTO, MAX_RTO].
+    rto: Duration,
+}
+
+impl RttEstimator {
+    /// Create a new estimator with no RTT samples.
+    ///
+    /// The initial RTO is 1 second per RFC 6298 Section 2.1.
+    pub(crate) fn new() -> Self {
+        Self {
+            srtt: None,
+            rttvar: Duration::ZERO,
+            rto: INITIAL_RTO,
+        }
+    }
+
+    /// Update the estimate with a new RTT sample.
+    ///
+    /// Implements RFC 6298 Section 2.2 (first sample) and Section 2.3
+    /// (subsequent samples).
+    ///
+    /// The caller must not pass samples from delayed ACKs (those with
+    /// the ACKDELAYED flag set), as they would inflate the estimate.
+    /// The caller must also not pass samples from retransmitted packets,
+    /// per Karn's algorithm (RFC 6298 Section 3).
+    pub(crate) fn update(&mut self, rtt: Duration) {
+        match self.srtt {
+            None => {
+                // RFC 6298 Section 2.2: First measurement
+                // SRTT = R
+                // RTTVAR = R/2
+                // RTO = SRTT + max(G, K*RTTVAR) where K=4, G=clock granularity
+                // We treat G as negligible (sub-microsecond system clocks).
+                self.srtt = Some(rtt);
+                self.rttvar = rtt / 2;
+            }
+            Some(srtt) => {
+                // RFC 6298 Section 2.3: Subsequent measurements
+                // RTTVAR = (1 - beta) * RTTVAR + beta * |SRTT - R|
+                //        = 3/4 * RTTVAR + 1/4 * |SRTT - R|
+                // SRTT = (1 - alpha) * SRTT + alpha * R
+                //      = 7/8 * SRTT + 1/8 * R
+
+                let abs_diff = srtt.abs_diff(rtt);
+
+                // RTTVAR update must happen BEFORE SRTT update (RFC 6298 Section 2.3)
+                self.rttvar = self.rttvar.mul_f64(1.0 - 1.0 / f64::from(RTTVAR_BETA)) + abs_diff / RTTVAR_BETA;
+
+                self.srtt = Some(srtt.mul_f64(1.0 - 1.0 / f64::from(SRTT_ALPHA)) + rtt / SRTT_ALPHA);
+            }
+        }
+
+        self.recompute_rto();
+    }
+
+    /// Current retransmission timeout.
+    ///
+    /// Always in the range [300ms, 16s] for RDPEUDP2.
+    pub(crate) fn rto(&self) -> Duration {
+        self.rto
+    }
+
+    /// Current smoothed RTT, if any samples have been collected.
+    pub(crate) fn srtt(&self) -> Option<Duration> {
+        self.srtt
+    }
+
+    /// Current RTT variance.
+    #[cfg(test)]
+    pub(crate) fn rttvar(&self) -> Duration {
+        self.rttvar
+    }
+
+    /// Apply exponential backoff to the RTO after a retransmission timeout.
+    ///
+    /// RFC 6298 Section 5.5: double the RTO on each successive timeout
+    /// for the same segment, capped at MAX_RTO.
+    pub(crate) fn on_timeout(&mut self) {
+        self.rto = (self.rto * 2).min(MAX_RTO);
+    }
+
+    /// Recompute RTO from SRTT and RTTVAR, applying floor and ceiling.
+    fn recompute_rto(&mut self) {
+        if let Some(srtt) = self.srtt {
+            // RFC 6298: RTO = SRTT + max(G, K*RTTVAR) where K=4
+            // G (clock granularity) treated as negligible
+            let k_rttvar = self.rttvar * 4;
+
+            // Ensure RTO is at least SRTT + some variance
+            // When RTTVAR is very small, use a 1ms floor for the variance component
+            let variance_floor = Duration::from_millis(1);
+            let rto = srtt + k_rttvar.max(variance_floor);
+
+            self.rto = rto.clamp(MIN_RTO, MAX_RTO);
+        }
+        // If no SRTT yet, keep the initial RTO
+    }
+}
+
+impl Default for RttEstimator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initial_state() {
+        let rtt = RttEstimator::new();
+        assert_eq!(rtt.srtt(), None);
+        assert_eq!(rtt.rttvar(), Duration::ZERO);
+        assert_eq!(rtt.rto(), INITIAL_RTO);
+    }
+
+    #[test]
+    fn first_sample_initializes() {
+        let mut rtt = RttEstimator::new();
+        let sample = Duration::from_millis(100);
+
+        rtt.update(sample);
+
+        // RFC 6298 Section 2.2: SRTT = R, RTTVAR = R/2
+        assert_eq!(rtt.srtt(), Some(sample));
+        assert_eq!(rtt.rttvar(), sample / 2);
+    }
+
+    #[test]
+    fn first_sample_rto_floor() {
+        let mut rtt = RttEstimator::new();
+        // Very small RTT → RTO should be clamped to 300ms minimum
+        rtt.update(Duration::from_millis(10));
+
+        assert_eq!(rtt.srtt(), Some(Duration::from_millis(10)));
+        assert_eq!(rtt.rto(), MIN_RTO);
+    }
+
+    #[test]
+    fn first_sample_rto_computation() {
+        let mut rtt = RttEstimator::new();
+        // R = 200ms → SRTT = 200ms, RTTVAR = 100ms
+        // RTO = SRTT + 4*RTTVAR = 200 + 400 = 600ms
+        rtt.update(Duration::from_millis(200));
+
+        assert_eq!(rtt.srtt(), Some(Duration::from_millis(200)));
+        assert_eq!(rtt.rttvar(), Duration::from_millis(100));
+        assert_eq!(rtt.rto(), Duration::from_millis(600));
+    }
+
+    #[test]
+    fn subsequent_sample_stable() {
+        let mut rtt = RttEstimator::new();
+        // Initialize with 100ms
+        rtt.update(Duration::from_millis(100));
+
+        // Second sample identical → estimate should converge
+        rtt.update(Duration::from_millis(100));
+
+        // RTTVAR = 3/4 * 50 + 1/4 * |100 - 100| = 37.5ms
+        // SRTT = 7/8 * 100 + 1/8 * 100 = 100ms
+        // RTO = 100 + 4 * 37.5 = 250ms → clamped to 300ms
+        assert_eq!(rtt.srtt(), Some(Duration::from_millis(100)));
+        assert_eq!(rtt.rto(), MIN_RTO);
+    }
+
+    #[test]
+    fn subsequent_sample_increase() {
+        let mut rtt = RttEstimator::new();
+        rtt.update(Duration::from_millis(100));
+        rtt.update(Duration::from_millis(200));
+
+        // RTTVAR = 3/4 * 50 + 1/4 * |100 - 200| = 37.5 + 25 = 62.5ms
+        // SRTT = 7/8 * 100 + 1/8 * 200 = 87.5 + 25 = 112.5ms
+        // RTO = 112.5 + 4 * 62.5 = 362.5ms
+        let srtt = rtt.srtt().expect("should have SRTT");
+        assert!(srtt > Duration::from_millis(110) && srtt < Duration::from_millis(115));
+
+        let rto = rtt.rto();
+        assert!(rto > Duration::from_millis(360) && rto < Duration::from_millis(365));
+    }
+
+    #[test]
+    fn convergence_with_stable_rtt() {
+        let mut est = RttEstimator::new();
+        // Feed 20 identical samples of 80ms
+        for _ in 0..20 {
+            est.update(Duration::from_millis(80));
+        }
+
+        // SRTT should be very close to 80ms
+        let srtt = est.srtt().expect("should have SRTT");
+        let srtt_ms = srtt.as_micros();
+        assert!(
+            (79_500..=80_500).contains(&srtt_ms),
+            "expected SRTT near 80ms, got {srtt_ms}μs"
+        );
+
+        // RTTVAR should be very small (near zero variance)
+        let rttvar_us = est.rttvar().as_micros();
+        assert!(rttvar_us < 5_000, "expected small RTTVAR, got {rttvar_us}μs");
+    }
+
+    #[test]
+    fn rto_min_floor_enforced() {
+        let mut est = RttEstimator::new();
+        // Extremely fast connection → RTO should still be >= 300ms
+        est.update(Duration::from_micros(500));
+        assert!(
+            est.rto() >= MIN_RTO,
+            "RTO {} < min {}",
+            est.rto().as_millis(),
+            MIN_RTO.as_millis()
+        );
+
+        est.update(Duration::from_micros(500));
+        assert!(est.rto() >= MIN_RTO);
+    }
+
+    #[test]
+    fn rto_max_ceiling_enforced() {
+        let mut est = RttEstimator::new();
+        // Very high RTT → RTO should be capped
+        est.update(Duration::from_secs(10));
+
+        // SRTT=10s, RTTVAR=5s → RTO = 10 + 4*5 = 30s → capped at 16s
+        assert_eq!(est.rto(), MAX_RTO);
+    }
+
+    #[test]
+    fn timeout_backoff() {
+        let mut est = RttEstimator::new();
+        est.update(Duration::from_millis(200));
+
+        let rto_before = est.rto();
+        est.on_timeout();
+        let rto_after = est.rto();
+
+        // RTO should double
+        assert_eq!(rto_after, rto_before * 2);
+    }
+
+    #[test]
+    fn timeout_backoff_respects_max() {
+        let mut est = RttEstimator::new();
+        est.update(Duration::from_millis(200));
+
+        // Double repeatedly until we hit the ceiling
+        for _ in 0..20 {
+            est.on_timeout();
+        }
+
+        assert_eq!(est.rto(), MAX_RTO);
+    }
+
+    #[test]
+    fn timeout_backoff_then_sample_resets() {
+        let mut est = RttEstimator::new();
+        est.update(Duration::from_millis(100));
+
+        // Back off several times
+        est.on_timeout();
+        est.on_timeout();
+        let backed_off_rto = est.rto();
+        assert!(backed_off_rto > Duration::from_secs(1));
+
+        // A new RTT sample recalculates RTO from SRTT/RTTVAR,
+        // effectively resetting from the backoff
+        est.update(Duration::from_millis(100));
+        assert!(est.rto() < backed_off_rto);
+    }
+
+    #[test]
+    fn default_matches_new() {
+        let from_new = RttEstimator::new();
+        let from_default = RttEstimator::default();
+        assert_eq!(from_new.rto(), from_default.rto());
+        assert_eq!(from_new.srtt(), from_default.srtt());
+        assert_eq!(from_new.rttvar(), from_default.rttvar());
+    }
+
+    #[test]
+    fn jittery_samples() {
+        let mut est = RttEstimator::new();
+        // Simulate a jittery connection: RTT oscillates between 40ms and 120ms
+        let samples = [40, 120, 45, 115, 42, 118, 48, 112, 40, 120];
+        for &ms in &samples {
+            est.update(Duration::from_millis(ms));
+        }
+
+        // SRTT should be near the mean (~80ms)
+        let srtt = est.srtt().expect("should have SRTT");
+        let srtt_ms = srtt.as_millis();
+        assert!(
+            (60..=100).contains(&srtt_ms),
+            "expected SRTT near 80ms, got {srtt_ms}ms"
+        );
+
+        // RTTVAR should be non-trivial due to jitter
+        let rttvar_ms = est.rttvar().as_millis();
+        assert!(rttvar_ms > 5, "expected non-trivial RTTVAR, got {rttvar_ms}ms");
+    }
+
+    #[test]
+    fn decreasing_rtt_adjusts_downward() {
+        let mut est = RttEstimator::new();
+        // Start high, then decrease
+        est.update(Duration::from_millis(500));
+        let initial_rto = est.rto();
+
+        for _ in 0..10 {
+            est.update(Duration::from_millis(50));
+        }
+
+        // RTO should have decreased substantially
+        assert!(est.rto() < initial_rto);
+    }
+
+    #[test]
+    fn rttvar_ordering_in_update() {
+        // Verify that RTTVAR is updated before SRTT per RFC 6298 Section 2.3.
+        // The order matters because RTTVAR uses the current (old) SRTT,
+        // not the newly computed one.
+        let mut est = RttEstimator::new();
+        est.update(Duration::from_millis(100));
+
+        // Large spike
+        est.update(Duration::from_millis(500));
+
+        // RTTVAR should reflect |old_SRTT(100) - R(500)| = 400,
+        // contributing 1/4 * 400 = 100ms to the new RTTVAR.
+        // Previous RTTVAR was 50ms, so new = 3/4 * 50 + 1/4 * 400 = 37.5 + 100 = 137.5ms
+        let rttvar_ms = est.rttvar().as_millis();
+        assert!(
+            (135..=140).contains(&rttvar_ms),
+            "expected RTTVAR ~137.5ms, got {rttvar_ms}ms"
+        );
+    }
+}

--- a/crates/ironrdp-rdpeudp/src/send_window.rs
+++ b/crates/ironrdp-rdpeudp/src/send_window.rs
@@ -1,0 +1,672 @@
+//! Sender window buffer for tracking in-flight packets.
+//!
+//! MS-RDPEUDP2 Section 3.1.1.2.1.
+//!
+//! The send window tracks packets that have been transmitted but not yet
+//! acknowledged. Each entry holds the packet data (for retransmission),
+//! both sequence numbers (DataSeqNum and ChannelSeqNum), timing info,
+//! and current state (Pending/Received/Lost).
+//!
+//! The window size is bounded by `1 << log_window_size` (max 32768).
+//! The lower bound advances when consecutive entries at the front
+//! transition to Received or Lost.
+//!
+//! When a packet is declared lost, its data is returned to the caller
+//! for the ReliabilityController. The entry is drained from the window
+//! (if at the front). Retransmission creates a fresh entry with a new
+//! DataSeqNum but the same ChannelSeqNum, following the QUIC model.
+
+use crate::time::MonotonicInstant;
+use alloc::collections::VecDeque;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+/// State of a packet in the send window.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SendEntryState {
+    /// Sent, waiting for acknowledgment.
+    Pending,
+    /// Acknowledged by the receiver.
+    Received,
+}
+
+/// Metadata for a sent packet.
+#[derive(Debug, Clone)]
+pub(crate) struct SendEntry {
+    /// DataSeqNum assigned when this packet was (re)transmitted.
+    pub data_seq: u64,
+
+    /// ChannelSeqNum: the logical sequence number for this data.
+    /// Preserved across retransmissions so the receiver can match
+    /// retransmits to the original gap.
+    pub channel_seq: u64,
+
+    /// When this packet was most recently sent.
+    pub sent_at: MonotonicInstant,
+
+    /// Payload size in bytes (used for congestion window accounting).
+    pub size: usize,
+
+    /// Current state: Pending or Received.
+    pub state: SendEntryState,
+
+    /// Number of times this packet has been transmitted.
+    pub transmit_count: u32,
+}
+
+/// Information returned when a packet is declared lost.
+#[derive(Debug, Clone)]
+pub(crate) struct LostPacketInfo {
+    /// ChannelSeqNum for matching with the retransmit queue.
+    pub channel_seq: u64,
+    /// The payload data for retransmission.
+    pub data: Vec<u8>,
+    /// Payload size in bytes (used for diagnostics and accounting in tests).
+    #[cfg_attr(not(test), expect(dead_code, reason = "diagnostic field used in tests"))]
+    pub size: usize,
+}
+
+/// Send window tracking all in-flight packets.
+///
+/// Internally a `VecDeque` where the front entry corresponds to the
+/// lowest unresolved DataSeqNum. Entries at the front that have been
+/// resolved (Received) are drained to advance the window.
+#[derive(Debug)]
+pub(crate) struct SendWindow {
+    /// In-flight entries. Front = lowest DataSeqNum.
+    entries: VecDeque<SendEntry>,
+
+    /// Packet data indexed by DataSeqNum, held for retransmission.
+    /// Removed when entry is Received or returned via mark_lost.
+    data_store: VecDeque<(u64, Vec<u8>)>,
+
+    /// Next DataSeqNum to assign to a new transmission.
+    next_data_seq: u64,
+
+    /// Next ChannelSeqNum to assign to new (non-retransmit) data.
+    next_channel_seq: u64,
+
+    /// Total bytes currently in flight (state == Pending).
+    bytes_in_flight: u64,
+
+    /// Maximum number of entries (1 << log_window_size).
+    max_entries: usize,
+}
+
+impl SendWindow {
+    /// Create a new send window.
+    ///
+    /// `initial_data_seq` and `initial_channel_seq` are the starting
+    /// sequence numbers (typically derived from the handshake ISN).
+    /// `log_window_size` determines the maximum window: `1 << log_window_size`.
+    pub(crate) fn new(initial_data_seq: u64, initial_channel_seq: u64, log_window_size: u8) -> Self {
+        let max_entries = 1usize << usize::from(log_window_size);
+        Self {
+            entries: VecDeque::with_capacity(max_entries),
+            data_store: VecDeque::with_capacity(max_entries),
+            next_data_seq: initial_data_seq,
+            next_channel_seq: initial_channel_seq,
+            bytes_in_flight: 0,
+            max_entries,
+        }
+    }
+
+    /// Whether the window has room for another packet.
+    pub(crate) fn has_capacity(&self) -> bool {
+        self.entries.len() < self.max_entries
+    }
+
+    /// Number of entries currently in the window.
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the window is empty.
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Total bytes in flight (entries in Pending state).
+    pub(crate) fn bytes_in_flight(&self) -> u64 {
+        self.bytes_in_flight
+    }
+
+    /// The next DataSeqNum that will be assigned.
+    pub(crate) fn next_data_seq(&self) -> u64 {
+        self.next_data_seq
+    }
+
+    /// The next ChannelSeqNum that will be assigned to new data.
+    #[cfg(test)]
+    pub(crate) fn next_channel_seq(&self) -> u64 {
+        self.next_channel_seq
+    }
+
+    /// Record a newly sent packet and return its assigned sequence numbers.
+    ///
+    /// The caller provides the payload data and the send timestamp.
+    /// A new ChannelSeqNum is assigned (this is a first transmission,
+    /// not a retransmit).
+    ///
+    /// Returns `None` if the window is full.
+    pub(crate) fn push(&mut self, data: Vec<u8>, now: MonotonicInstant) -> Option<(u64, u64)> {
+        if !self.has_capacity() {
+            return None;
+        }
+
+        let data_seq = self.next_data_seq;
+        let channel_seq = self.next_channel_seq;
+        let size = data.len();
+
+        self.entries.push_back(SendEntry {
+            data_seq,
+            channel_seq,
+            sent_at: now,
+            size,
+            state: SendEntryState::Pending,
+            transmit_count: 1,
+        });
+        self.data_store.push_back((data_seq, data));
+
+        self.next_data_seq += 1;
+        self.next_channel_seq += 1;
+        self.bytes_in_flight += u64::try_from(size).expect("packet size fits in u64");
+
+        Some((data_seq, channel_seq))
+    }
+
+    /// Record a retransmission with a preserved ChannelSeqNum.
+    ///
+    /// A new DataSeqNum is assigned (per RDPEUDP2: DataSeqNum changes
+    /// on retransmit, ChannelSeqNum does not). A fresh Pending entry
+    /// is added to the window.
+    ///
+    /// Returns `None` if the window is full.
+    pub(crate) fn push_retransmit(&mut self, channel_seq: u64, data: Vec<u8>, now: MonotonicInstant) -> Option<u64> {
+        if !self.has_capacity() {
+            return None;
+        }
+
+        let data_seq = self.next_data_seq;
+        let size = data.len();
+
+        self.entries.push_back(SendEntry {
+            data_seq,
+            channel_seq,
+            sent_at: now,
+            size,
+            state: SendEntryState::Pending,
+            transmit_count: 2, // at least the second transmission
+        });
+        self.data_store.push_back((data_seq, data));
+
+        self.next_data_seq += 1;
+        self.bytes_in_flight += u64::try_from(size).expect("packet size fits in u64");
+
+        Some(data_seq)
+    }
+
+    /// Mark a packet as received (acknowledged) by its DataSeqNum.
+    ///
+    /// Returns the size of the acknowledged packet (for congestion
+    /// window accounting), or `None` if the seq was not found or
+    /// was already received.
+    pub(crate) fn mark_received(&mut self, data_seq: u64) -> Option<usize> {
+        let entry = self.entries.iter_mut().find(|e| e.data_seq == data_seq)?;
+
+        if entry.state != SendEntryState::Pending {
+            return None;
+        }
+
+        entry.state = SendEntryState::Received;
+        let size = entry.size;
+        self.bytes_in_flight -= u64::try_from(size).expect("packet size fits in u64");
+
+        // Remove data: no longer needed for retransmission.
+        self.data_store.retain(|(seq, _)| *seq != data_seq);
+
+        self.advance_window();
+
+        Some(size)
+    }
+
+    /// Mark every pending packet up to and including `data_seq` as
+    /// received, returning the total bytes that changed state.
+    ///
+    /// Walking the window rather than the sequence range keeps the cost
+    /// tied to how many packets are in flight. Counting from the initial
+    /// sequence number instead costs one iteration per sequence number
+    /// ever sent, on every acknowledgment, and a peer naming a sequence
+    /// number far ahead of the window pays for the whole gap.
+    pub(crate) fn mark_received_through(&mut self, data_seq: u64) -> u64 {
+        let mut bytes = 0;
+
+        // Entries are ordered by DataSeqNum and `mark_received` drains the
+        // resolved ones off the front, so this walks each acknowledged
+        // packet once.
+        while let Some(front) = self.entries.front() {
+            if front.data_seq > data_seq {
+                break;
+            }
+
+            let front_seq = front.data_seq;
+            let Some(size) = self.mark_received(front_seq) else {
+                break;
+            };
+
+            bytes += u64::try_from(size).expect("packet size fits in u64");
+        }
+
+        bytes
+    }
+
+    /// Mark a packet as lost by its DataSeqNum.
+    ///
+    /// Removes the entry from the window and returns its info
+    /// (ChannelSeqNum + data) for the ReliabilityController to
+    /// enqueue for retransmission.
+    ///
+    /// Returns `None` if not found or not Pending.
+    pub(crate) fn mark_lost(&mut self, data_seq: u64) -> Option<LostPacketInfo> {
+        let entry_idx = self.entries.iter().position(|e| e.data_seq == data_seq)?;
+
+        if self.entries[entry_idx].state != SendEntryState::Pending {
+            return None;
+        }
+
+        // Extract the entry.
+        let entry = self.entries.remove(entry_idx).expect("index is valid");
+        self.bytes_in_flight -= u64::try_from(entry.size).expect("packet size fits in u64");
+
+        // Extract the data.
+        let data = self
+            .data_store
+            .iter()
+            .position(|(seq, _)| *seq == data_seq)
+            .map(|i| self.data_store.remove(i).expect("index is valid").1)
+            .unwrap_or_default();
+
+        // Try to advance the window (front entries may now be resolved).
+        self.advance_window();
+
+        Some(LostPacketInfo {
+            channel_seq: entry.channel_seq,
+            data,
+            size: entry.size,
+        })
+    }
+
+    /// Get an entry by DataSeqNum (for loss detection timing checks).
+    pub(crate) fn get_by_data_seq(&self, data_seq: u64) -> Option<&SendEntry> {
+        self.entries.iter().find(|e| e.data_seq == data_seq)
+    }
+
+    /// Iterate over all Pending entries (for loss detection scans).
+    pub(crate) fn pending_entries(&self) -> impl Iterator<Item = &SendEntry> {
+        self.entries.iter().filter(|e| e.state == SendEntryState::Pending)
+    }
+
+    /// The lowest DataSeqNum still waiting to be acknowledged.
+    ///
+    /// This is what [MS-RDPEUDP2] 2.2.1.2.4 calls "the sequence number the
+    /// Sender is waiting to receive acknowledgment of". Resolved entries are
+    /// drained off the front, so the front is it; with nothing outstanding it
+    /// is the next number that will be assigned.
+    pub(crate) fn lowest_unacknowledged(&self) -> u64 {
+        self.entries.front().map_or(self.next_data_seq, |entry| entry.data_seq)
+    }
+
+    /// The highest DataSeqNum that has been acknowledged.
+    ///
+    /// Returns `None` if no packets have been acknowledged yet.
+    pub(crate) fn highest_acked_data_seq(&self) -> Option<u64> {
+        self.entries
+            .iter()
+            .filter(|e| e.state == SendEntryState::Received)
+            .map(|e| e.data_seq)
+            .max()
+    }
+
+    /// Advance the window by draining front entries that are Received.
+    fn advance_window(&mut self) {
+        while let Some(front) = self.entries.front() {
+            if front.state == SendEntryState::Pending {
+                break;
+            }
+            let removed = self.entries.pop_front().expect("checked non-empty");
+            // Clean up data store (should already be removed for Received entries,
+            // but belt-and-suspenders).
+            self.data_store.retain(|(seq, _)| *seq != removed.data_seq);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::time::Duration;
+
+    use super::*;
+
+    fn now() -> MonotonicInstant {
+        MonotonicInstant::from_millis(0)
+    }
+
+    fn later(base: MonotonicInstant, ms: u64) -> MonotonicInstant {
+        base + Duration::from_millis(ms)
+    }
+
+    #[test]
+    fn new_window_is_empty() {
+        let w = SendWindow::new(1, 1, 6); // window = 64
+        assert!(w.is_empty());
+        assert_eq!(w.len(), 0);
+        assert!(w.has_capacity());
+        assert_eq!(w.bytes_in_flight(), 0);
+        assert_eq!(w.next_data_seq(), 1);
+        assert_eq!(w.next_channel_seq(), 1);
+    }
+
+    #[test]
+    fn push_assigns_sequences() {
+        let t = now();
+        let mut w = SendWindow::new(10, 100, 6);
+
+        let (dsn, csn) = w.push(vec![0xAA; 50], t).expect("has capacity");
+        assert_eq!(dsn, 10);
+        assert_eq!(csn, 100);
+        assert_eq!(w.next_data_seq(), 11);
+        assert_eq!(w.next_channel_seq(), 101);
+        assert_eq!(w.len(), 1);
+        assert_eq!(w.bytes_in_flight(), 50);
+    }
+
+    #[test]
+    fn push_multiple() {
+        let t = now();
+        let mut w = SendWindow::new(1, 1, 6);
+
+        for i in 0..5 {
+            let (dsn, csn) = w.push(vec![0; 100], t).expect("has capacity");
+            assert_eq!(dsn, 1 + i);
+            assert_eq!(csn, 1 + i);
+        }
+
+        assert_eq!(w.len(), 5);
+        assert_eq!(w.bytes_in_flight(), 500);
+    }
+
+    #[test]
+    fn push_rejects_when_full() {
+        let t = now();
+        let mut w = SendWindow::new(1, 1, 2); // window = 4
+
+        for _ in 0..4 {
+            assert!(w.push(vec![0; 10], t).is_some());
+        }
+
+        assert!(!w.has_capacity());
+        assert!(w.push(vec![0; 10], t).is_none());
+    }
+
+    #[test]
+    fn mark_received_returns_size() {
+        let t = now();
+        let mut w = SendWindow::new(1, 1, 6);
+        w.push(vec![0; 200], t);
+
+        let size = w.mark_received(1).expect("should find entry");
+        assert_eq!(size, 200);
+        assert_eq!(w.bytes_in_flight(), 0);
+    }
+
+    #[test]
+    fn mark_received_unknown_seq_returns_none() {
+        let t = now();
+        let mut w = SendWindow::new(1, 1, 6);
+        w.push(vec![0; 100], t);
+
+        assert!(w.mark_received(999).is_none());
+    }
+
+    #[test]
+    fn mark_received_already_received_returns_none() {
+        let t = now();
+        let mut w = SendWindow::new(1, 1, 6);
+        w.push(vec![0; 100], t);
+
+        w.mark_received(1);
+        assert!(w.mark_received(1).is_none());
+    }
+
+    #[test]
+    fn mark_lost_returns_info() {
+        let t = now();
+        let mut w = SendWindow::new(1, 100, 6);
+        w.push(vec![0xBB; 50], t);
+
+        let info = w.mark_lost(1).expect("should find entry");
+        assert_eq!(info.channel_seq, 100);
+        assert_eq!(info.data, vec![0xBB; 50]);
+        assert_eq!(info.size, 50);
+        assert_eq!(w.bytes_in_flight(), 0);
+        // Entry was removed from the window.
+        assert!(w.is_empty());
+    }
+
+    #[test]
+    fn window_advances_on_front_resolved() {
+        let t = now();
+        let mut w = SendWindow::new(1, 1, 6);
+
+        w.push(vec![0; 10], t);
+        w.push(vec![0; 10], t);
+        w.push(vec![0; 10], t);
+
+        assert_eq!(w.len(), 3);
+
+        // ACK seq 1 → front drains
+        w.mark_received(1);
+        assert_eq!(w.len(), 2);
+
+        // ACK seq 2 → front drains again
+        w.mark_received(2);
+        assert_eq!(w.len(), 1);
+    }
+
+    #[test]
+    fn window_does_not_advance_past_pending() {
+        let t = now();
+        let mut w = SendWindow::new(1, 1, 6);
+
+        w.push(vec![0; 10], t);
+        w.push(vec![0; 10], t);
+        w.push(vec![0; 10], t);
+
+        // ACK seq 3 (out of order): front is still seq 1 (Pending)
+        w.mark_received(3);
+        assert_eq!(w.len(), 3); // nothing drained
+
+        // ACK seq 1 → front (seq 1, Received) drains.
+        // Seq 2 (Pending) becomes the new front and blocks further drain.
+        // Seq 3 (Received) remains behind seq 2.
+        w.mark_received(1);
+        assert_eq!(w.len(), 2); // seq 2 (Pending) and seq 3 (Received) remain
+    }
+
+    #[test]
+    fn retransmit_via_push_retransmit() {
+        let t = now();
+        let t2 = later(t, 500);
+        let mut w = SendWindow::new(1, 100, 6);
+
+        w.push(vec![0xBB; 30], t);
+
+        // Mark as lost: get the data back
+        let info = w.mark_lost(1).expect("should find entry");
+        assert_eq!(info.channel_seq, 100);
+        assert_eq!(info.data, vec![0xBB; 30]);
+        assert!(w.is_empty());
+
+        // Retransmit with the same ChannelSeqNum but new DataSeqNum
+        let new_dsn = w.push_retransmit(100, info.data, t2).expect("has capacity");
+        assert_eq!(new_dsn, 2); // next_data_seq was 2
+        assert_eq!(w.next_data_seq(), 3);
+        assert_eq!(w.bytes_in_flight(), 30);
+        assert_eq!(w.len(), 1);
+
+        let entry = w.get_by_data_seq(2).expect("should find");
+        assert_eq!(entry.channel_seq, 100);
+        assert_eq!(entry.state, SendEntryState::Pending);
+        assert_eq!(entry.transmit_count, 2);
+        assert_eq!(entry.sent_at, t2);
+    }
+
+    #[test]
+    fn pending_entries_iterator() {
+        let t = now();
+        let mut w = SendWindow::new(1, 1, 6);
+
+        w.push(vec![0; 10], t);
+        w.push(vec![0; 10], t);
+        w.push(vec![0; 10], t);
+
+        w.mark_received(2);
+
+        let pending: Vec<u64> = w.pending_entries().map(|e| e.data_seq).collect();
+        assert_eq!(pending, vec![1, 3]);
+    }
+
+    #[test]
+    fn highest_acked_data_seq() {
+        let t = now();
+        let mut w = SendWindow::new(1, 1, 6);
+
+        w.push(vec![0; 10], t);
+        w.push(vec![0; 10], t);
+        w.push(vec![0; 10], t);
+
+        assert_eq!(w.highest_acked_data_seq(), None);
+
+        w.mark_received(3);
+        assert_eq!(w.highest_acked_data_seq(), Some(3));
+
+        w.mark_received(1);
+        assert_eq!(w.highest_acked_data_seq(), Some(3));
+    }
+
+    #[test]
+    fn bytes_in_flight_tracking() {
+        let t = now();
+        let mut w = SendWindow::new(1, 1, 6);
+
+        w.push(vec![0; 100], t);
+        w.push(vec![0; 200], t);
+        w.push(vec![0; 300], t);
+        assert_eq!(w.bytes_in_flight(), 600);
+
+        w.mark_received(1);
+        assert_eq!(w.bytes_in_flight(), 500);
+
+        // Mark seq 2 lost: bytes leave in-flight
+        let info = w.mark_lost(2).expect("should find");
+        assert_eq!(w.bytes_in_flight(), 300);
+
+        // Retransmit: bytes return to in-flight
+        w.push_retransmit(info.channel_seq, info.data, t);
+        assert_eq!(w.bytes_in_flight(), 500);
+    }
+
+    #[test]
+    fn capacity_frees_after_advance() {
+        let t = now();
+        let mut w = SendWindow::new(1, 1, 2); // window = 4
+
+        for _ in 0..4 {
+            w.push(vec![0; 10], t);
+        }
+        assert!(!w.has_capacity());
+
+        // ACK front entry → window advances → capacity freed
+        w.mark_received(1);
+        assert!(w.has_capacity());
+        assert!(w.push(vec![0; 10], t).is_some());
+    }
+
+    #[test]
+    fn get_by_data_seq() {
+        let t = now();
+        let mut w = SendWindow::new(1, 100, 6);
+        w.push(vec![0xAA; 10], t);
+
+        let entry = w.get_by_data_seq(1).expect("should find");
+        assert_eq!(entry.data_seq, 1);
+        assert_eq!(entry.channel_seq, 100);
+
+        assert!(w.get_by_data_seq(999).is_none());
+    }
+
+    #[test]
+    fn mark_lost_removes_entry_from_window() {
+        let t = now();
+        let mut w = SendWindow::new(1, 1, 6);
+
+        w.push(vec![0; 10], t);
+        w.push(vec![0; 10], t);
+        w.push(vec![0; 10], t);
+
+        // Mark middle packet as lost
+        w.mark_lost(2);
+        assert_eq!(w.len(), 2);
+
+        // Remaining entries are seq 1 and seq 3
+        let pending: Vec<u64> = w.pending_entries().map(|e| e.data_seq).collect();
+        assert_eq!(pending, vec![1, 3]);
+    }
+
+    #[test]
+    fn mark_lost_multiple() {
+        let t = now();
+        let mut w = SendWindow::new(1, 1, 6);
+
+        w.push(vec![0; 10], t);
+        w.push(vec![0; 10], t);
+        w.push(vec![0; 10], t);
+
+        let info1 = w.mark_lost(1).expect("should find");
+        assert_eq!(info1.channel_seq, 1);
+
+        let info3 = w.mark_lost(3).expect("should find");
+        assert_eq!(info3.channel_seq, 3);
+
+        // Only seq 2 remains
+        assert_eq!(w.len(), 1);
+        let entry = w.get_by_data_seq(2).expect("should find");
+        assert_eq!(entry.channel_seq, 2);
+    }
+
+    #[test]
+    fn retransmit_then_ack() {
+        let t = now();
+        let mut w = SendWindow::new(1, 100, 6);
+
+        w.push(vec![0xAA; 50], t);
+        w.push(vec![0xBB; 60], t);
+
+        // Lose packet 1
+        let info = w.mark_lost(1).expect("lost");
+        assert_eq!(info.channel_seq, 100);
+
+        // Retransmit it
+        let new_dsn = w.push_retransmit(100, info.data, later(t, 500)).expect("has cap");
+        assert_eq!(new_dsn, 3); // next_data_seq was 3
+
+        // ACK both the original seq 2 and retransmitted seq 3
+        w.mark_received(2);
+        w.mark_received(3);
+
+        assert!(w.is_empty());
+        assert_eq!(w.bytes_in_flight(), 0);
+    }
+}

--- a/crates/ironrdp-rdpeudp/src/seq.rs
+++ b/crates/ironrdp-rdpeudp/src/seq.rs
@@ -1,0 +1,302 @@
+//! Sequence number and timestamp reconstruction.
+//!
+//! MS-RDPEUDP2 Section 3.1.1.1.3 (sequence numbers) and
+//! Section 3.1.1.1.4 (timestamps).
+//!
+//! All wire-format sequence numbers are 16-bit. Full resolution
+//! is 64-bit, reconstructed from a nearby reference value.
+//! The active window is limited to `(1 << log_window_size) - 1`
+//! which is at most 32767, so 16 bits are sufficient when a
+//! reference is available.
+//!
+//! Timestamps use 24 bits on the wire in units of 4 microseconds,
+//! giving a wrap range of ~67 seconds. Reconstruction uses the
+//! same principle as sequence numbers but with 24-bit values.
+
+/// Reconstruct a full 64-bit sequence number from a 16-bit wire value
+/// and a nearby reference sequence number.
+///
+/// MS-RDPEUDP2 Section 3.1.1.1.3.
+///
+/// The algorithm finds the full 64-bit value closest to `reference`
+/// whose lower 16 bits match `wire_seq`. This works because the
+/// active window is at most 32767 packets, well within 16-bit range.
+pub fn reconstruct_seq(wire_seq: u16, reference: u64) -> u64 {
+    let wire = u64::from(wire_seq);
+    let high = reference & !0xFFFF;
+    let candidate = high | wire;
+
+    // Find the candidate closest to the reference.
+    // At most three candidates: candidate, candidate-0x10000, candidate+0x10000.
+    // The correct one is the one closest to reference.
+    if candidate > reference {
+        let diff = candidate - reference;
+        if diff > 0x8000 && candidate >= 0x10000 {
+            candidate - 0x10000
+        } else {
+            candidate
+        }
+    } else {
+        let diff = reference - candidate;
+        if diff > 0x8000 { candidate + 0x10000 } else { candidate }
+    }
+}
+
+/// Truncate a full 64-bit sequence number to its 16-bit wire representation.
+///
+/// # Panics
+///
+/// Infallible: the 0xFFFF mask guarantees the result fits in `u16`.
+pub fn truncate_seq(full: u64) -> u16 {
+    u16::try_from(full & 0xFFFF).expect("masked to 16 bits fits in u16")
+}
+
+/// Reconstruct a full 64-bit timestamp (in 4μs units) from a 24-bit wire value
+/// and a nearby reference timestamp.
+///
+/// MS-RDPEUDP2 Section 3.1.1.1.4.
+///
+/// Wire timestamps are the lower 24 bits, in units of 4 microseconds.
+/// The 24-bit field wraps every `2^24 * 4μs = 67,108,864μs ≈ 67.1 seconds`.
+/// A timestamp is considered stale (and should be discarded) if it differs
+/// from the current time by more than 32 seconds.
+pub fn reconstruct_timestamp(wire_ts: u32, reference: u64) -> u64 {
+    let wire = u64::from(wire_ts & TIMESTAMP_24BIT_MASK);
+    let high = reference & !u64::from(TIMESTAMP_24BIT_MASK);
+    let candidate = high | wire;
+
+    if candidate > reference {
+        let diff = candidate - reference;
+        if diff > TIMESTAMP_HALF_RANGE && candidate >= TIMESTAMP_WRAP {
+            candidate - TIMESTAMP_WRAP
+        } else {
+            candidate
+        }
+    } else {
+        let diff = reference - candidate;
+        if diff > TIMESTAMP_HALF_RANGE {
+            candidate + TIMESTAMP_WRAP
+        } else {
+            candidate
+        }
+    }
+}
+
+/// Truncate a full 64-bit timestamp to its 24-bit wire representation.
+///
+/// # Panics
+///
+/// Infallible: the 24-bit mask guarantees the result fits in `u32`.
+pub fn truncate_timestamp(full: u64) -> u32 {
+    u32::try_from(full & u64::from(TIMESTAMP_24BIT_MASK)).expect("masked to 24 bits fits in u32")
+}
+
+/// Convert microseconds to timestamp units (4μs per unit).
+pub fn us_to_timestamp_units(us: u64) -> u64 {
+    us / TIMESTAMP_UNIT_US
+}
+
+/// Convert timestamp units back to microseconds.
+pub fn timestamp_units_to_us(units: u64) -> u64 {
+    units * TIMESTAMP_UNIT_US
+}
+
+/// Mask for 24-bit timestamp values.
+const TIMESTAMP_24BIT_MASK: u32 = 0x00FF_FFFF;
+
+/// One timestamp unit = 4 microseconds.
+const TIMESTAMP_UNIT_US: u64 = 4;
+
+/// Full wrap range of the 24-bit timestamp field.
+const TIMESTAMP_WRAP: u64 = 1 << 24; // 16,777,216 units = 67,108,864μs
+
+/// Half the wrap range, used for closest-value selection.
+const TIMESTAMP_HALF_RANGE: u64 = TIMESTAMP_WRAP / 2;
+
+/// Maximum timestamp age before it's considered stale (32 seconds in 4μs units).
+/// Per MS-RDPEUDP2 Section 3.1.1.1.4.
+pub const TIMESTAMP_STALENESS_LIMIT: u64 = 32_000_000 / TIMESTAMP_UNIT_US; // 8,000,000 units
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Sequence number reconstruction ──
+
+    #[test]
+    fn reconstruct_seq_same_epoch() {
+        // Wire 100, reference 50 → should reconstruct to 100
+        assert_eq!(reconstruct_seq(100, 50), 100);
+    }
+
+    #[test]
+    fn reconstruct_seq_nearby() {
+        // Wire 0x0005, reference 0x10003 → should reconstruct to 0x10005
+        assert_eq!(reconstruct_seq(0x0005, 0x1_0003), 0x1_0005);
+    }
+
+    #[test]
+    fn reconstruct_seq_wrap_forward() {
+        // Reference near the top of a 16-bit epoch, wire is in the next epoch.
+        // Reference = 0x1FFFE, wire = 0x0002 → should reconstruct to 0x20002
+        assert_eq!(reconstruct_seq(0x0002, 0x1_FFFE), 0x2_0002);
+    }
+
+    #[test]
+    fn reconstruct_seq_wrap_backward() {
+        // Reference in a new epoch, wire is from the previous epoch.
+        // Reference = 0x20002, wire = 0xFFFE → should reconstruct to 0x1FFFE
+        assert_eq!(reconstruct_seq(0xFFFE, 0x2_0002), 0x1_FFFE);
+    }
+
+    #[test]
+    fn reconstruct_seq_exact_match() {
+        // Wire matches reference exactly
+        assert_eq!(reconstruct_seq(0x1234, 0x5_1234), 0x5_1234);
+    }
+
+    #[test]
+    fn reconstruct_seq_half_range_forward() {
+        // Exactly at the boundary of half range (0x8000)
+        assert_eq!(reconstruct_seq(0x8000, 0), 0x8000);
+    }
+
+    #[test]
+    fn reconstruct_seq_just_past_half_range() {
+        // Wire is 0x8001 ahead → should wrap backward
+        // Reference = 0, wire = 0x8001
+        // candidate = 0x8001, diff = 0x8001 > 0x8000 → wrap back
+        // But candidate < 0x10000, so we can't subtract. Edge case.
+        // At reference=0, the reconstruction should still handle this.
+        let result = reconstruct_seq(0x8001, 0);
+        // candidate = 0x8001, diff > 0x8000, candidate >= 0x10000? No.
+        // So result = 0x8001.
+        assert_eq!(result, 0x8001);
+    }
+
+    #[test]
+    fn reconstruct_seq_large_reference() {
+        // Large reference values
+        assert_eq!(reconstruct_seq(0x0042, 0xFFFF_FFFF_0000_0040), 0xFFFF_FFFF_0000_0042);
+    }
+
+    #[test]
+    fn truncate_seq_basic() {
+        assert_eq!(truncate_seq(0x1234_5678), 0x5678);
+    }
+
+    #[test]
+    fn truncate_seq_max() {
+        assert_eq!(truncate_seq(0xFFFF_FFFF_FFFF_FFFF), 0xFFFF);
+    }
+
+    #[test]
+    fn seq_roundtrip() {
+        let original = 0x1_0042u64;
+        let wire = truncate_seq(original);
+        let reference = 0x1_0040;
+        let reconstructed = reconstruct_seq(wire, reference);
+        assert_eq!(reconstructed, original);
+    }
+
+    #[test]
+    fn seq_roundtrip_across_wrap() {
+        let original = 0x2_0005u64;
+        let wire = truncate_seq(original); // 0x0005
+        let reference = 0x1_FFFA;
+        let reconstructed = reconstruct_seq(wire, reference);
+        assert_eq!(reconstructed, original);
+    }
+
+    // ── Timestamp reconstruction ──
+
+    #[test]
+    fn reconstruct_ts_same_epoch() {
+        assert_eq!(reconstruct_timestamp(1000, 500), 1000);
+    }
+
+    #[test]
+    fn reconstruct_ts_nearby() {
+        let reference = 0x100_0500u64; // well above 24-bit range
+        let wire = 0x00_0510u32;
+        assert_eq!(reconstruct_timestamp(wire, reference), 0x100_0510);
+    }
+
+    #[test]
+    fn reconstruct_ts_wrap_forward() {
+        // Reference near the end of a 24-bit epoch, wire wraps to next
+        let reference = 0x00FF_FFFEu64;
+        let wire = 0x00_0002u32;
+        assert_eq!(
+            reconstruct_timestamp(wire, reference),
+            0x0100_0002 // next epoch
+        );
+    }
+
+    #[test]
+    fn reconstruct_ts_wrap_backward() {
+        // Reference in new epoch, wire from previous
+        let reference = 0x0100_0002u64;
+        let wire = 0x00FF_FFFEu32;
+        assert_eq!(
+            reconstruct_timestamp(wire, reference),
+            0x00FF_FFFE // previous epoch
+        );
+    }
+
+    #[test]
+    fn reconstruct_ts_exact_match() {
+        assert_eq!(reconstruct_timestamp(0x00_ABCD, 0x500_ABCD), 0x500_ABCD);
+    }
+
+    #[test]
+    fn truncate_ts_basic() {
+        assert_eq!(truncate_timestamp(0xABCD_1234), 0x00CD_1234);
+    }
+
+    #[test]
+    fn truncate_ts_max_24bit() {
+        assert_eq!(truncate_timestamp(0x00FF_FFFF), 0x00FF_FFFF);
+    }
+
+    #[test]
+    fn ts_roundtrip() {
+        let original = 0x100_5000u64;
+        let wire = truncate_timestamp(original);
+        let reference = 0x100_4FFF;
+        let reconstructed = reconstruct_timestamp(wire, reference);
+        assert_eq!(reconstructed, original);
+    }
+
+    #[test]
+    fn ts_roundtrip_across_wrap() {
+        let original = 0x200_0010u64;
+        let wire = truncate_timestamp(original); // 0x00_0010
+        let reference = 0x1FF_FFF0;
+        let reconstructed = reconstruct_timestamp(wire, reference);
+        assert_eq!(reconstructed, original);
+    }
+
+    // ── Timestamp unit conversions ──
+
+    #[test]
+    fn us_to_units() {
+        assert_eq!(us_to_timestamp_units(0), 0);
+        assert_eq!(us_to_timestamp_units(4), 1);
+        assert_eq!(us_to_timestamp_units(1_000_000), 250_000); // 1 second
+        assert_eq!(us_to_timestamp_units(67_108_864), TIMESTAMP_WRAP); // full 24-bit range
+    }
+
+    #[test]
+    fn units_to_us() {
+        assert_eq!(timestamp_units_to_us(0), 0);
+        assert_eq!(timestamp_units_to_us(1), 4);
+        assert_eq!(timestamp_units_to_us(250_000), 1_000_000); // 1 second
+    }
+
+    #[test]
+    fn staleness_limit() {
+        // 32 seconds = 32,000,000μs / 4μs = 8,000,000 units
+        assert_eq!(TIMESTAMP_STALENESS_LIMIT, 8_000_000);
+    }
+}

--- a/crates/ironrdp-rdpeudp/src/time.rs
+++ b/crates/ironrdp-rdpeudp/src/time.rs
@@ -1,0 +1,64 @@
+//! Monotonic time readings supplied by the caller.
+//!
+//! The connection state machine never reads a clock. It receives the current
+//! instant on every call that can advance time, and reports when it next wants
+//! to be woken through [`RdpeudpConnection::poll_timeout`].
+//!
+//! `std::time::Instant` is deliberately not used here. `Instant::now` panics
+//! on `wasm32-unknown-unknown`, which this crate compiles for, and a state
+//! machine that read a clock itself would measure how quickly it drained an
+//! already-filled buffer rather than when the datagram actually arrived.
+//!
+//! [`RdpeudpConnection::poll_timeout`]: crate::RdpeudpConnection::poll_timeout
+
+use core::ops::Add;
+use core::time::Duration;
+
+/// A monotonic instant, in milliseconds, from an epoch chosen by the caller.
+///
+/// The epoch is arbitrary and carries no meaning; only differences between two
+/// instants do. Millisecond resolution is well below the shortest interval the
+/// protocol asks us to measure, the delayed-ACK timer of [MS-RDPEUDP2] 3.1.1.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MonotonicInstant(u64);
+
+impl MonotonicInstant {
+    /// Builds an instant from a monotonic millisecond reading.
+    #[must_use]
+    pub fn from_millis(milliseconds: u64) -> Self {
+        Self(milliseconds)
+    }
+
+    /// The reading this instant was built from.
+    #[must_use]
+    pub fn as_millis(self) -> u64 {
+        self.0
+    }
+
+    /// The time elapsed since `earlier`, saturating at zero if the clock went
+    /// backwards or the arguments were transposed.
+    #[must_use]
+    pub fn duration_since(self, earlier: Self) -> Duration {
+        Duration::from_millis(self.0.saturating_sub(earlier.0))
+    }
+
+    /// This instant advanced by `duration`, saturating at the end of the
+    /// representable range.
+    ///
+    /// Saturating is the right behavior for the only caller: a deadline that
+    /// cannot be represented is one that never fires, which is what a timer set
+    /// beyond the end of time should do.
+    #[must_use]
+    pub fn saturating_add(self, duration: Duration) -> Self {
+        let milliseconds = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX);
+        Self(self.0.saturating_add(milliseconds))
+    }
+}
+
+impl Add<Duration> for MonotonicInstant {
+    type Output = Self;
+
+    fn add(self, rhs: Duration) -> Self {
+        self.saturating_add(rhs)
+    }
+}

--- a/crates/ironrdp-rdpeudp/src/timer.rs
+++ b/crates/ironrdp-rdpeudp/src/timer.rs
@@ -1,0 +1,319 @@
+//! Timer management for the sans-I/O state machine.
+//!
+//! Per ADR-0001, the connection state machine never calls system clocks.
+//! Instead, `MonotonicInstant` values are passed in by the caller and the state
+//! machine reports when the next timeout fires via `poll_timeout()`.
+//!
+//! The `TimerTable` holds a fixed-size array of `Option<MonotonicInstant>` deadlines,
+//! one per logical timer. This mirrors Quinn's timer management pattern.
+
+use crate::time::MonotonicInstant;
+
+/// Logical timers used by the RDPEUDP2 connection.
+///
+/// Each timer has specific semantics described in the variant docs.
+/// The numeric values are used as array indices into `TimerTable`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub(crate) enum Timer {
+    /// Retransmission timer. Fires when an in-flight packet has not
+    /// been acknowledged within the RTO interval.
+    ///
+    /// Minimum interval: 300ms for RDPEUDP2.
+    /// When fired: trigger loss detection and congestion response.
+    /// Set when: a packet is sent with no outstanding retransmit timer.
+    /// Cleared when: all outstanding packets are acknowledged.
+    Retransmit = 0,
+
+    /// ACK delay coalescing timer. Fires when received data packets
+    /// have not yet been acknowledged.
+    ///
+    /// Interval: half the current smoothed RTT, clamped to [50ms, 200ms]
+    /// (`RdpeudpConnection::ack_delay_timeout`). [MS-RDPEUDP2] 3.1.5.2 gives
+    /// the "half the round trip time" default but no floor or ceiling of
+    /// its own; the clamp is [MS-RDPEUDP]'s VERSION_2 analog (3.1.6.3).
+    /// When fired: send a standalone ACK.
+    /// Set when: a data packet is received and no ACK delay timer is running.
+    /// Cleared when: an ACK is sent (piggybacked on data or standalone).
+    AckDelay = 1,
+
+    /// Idle timeout. Fires when no packets have been received for the
+    /// configured idle timeout duration, indicating the connection is dead.
+    ///
+    /// Default: 16 seconds (configurable).
+    /// When fired: transition to Closed state.
+    /// Set when: any packet is received (resets the deadline).
+    /// Cleared when: never, only fires or is reset.
+    Idle = 2,
+
+    /// Keep-alive timer. Fires when no data has been sent for a while,
+    /// triggering a probe packet to prevent the remote's idle timeout
+    /// from expiring and to keep NAT mappings alive.
+    ///
+    /// Default: 8 seconds (should be less than idle timeout).
+    /// When fired: send a keep-alive probe (empty data or ACK).
+    /// Set when: any packet is sent (resets the deadline).
+    /// Cleared when: never, only fires or is reset by sending.
+    KeepAlive = 3,
+}
+
+impl Timer {
+    /// All timer variants, for iteration.
+    const ALL: [Self; TIMER_COUNT] = [Self::Retransmit, Self::AckDelay, Self::Idle, Self::KeepAlive];
+
+    /// Array index for this timer variant.
+    #[expect(clippy::as_conversions, reason = "repr(u8) enum to usize is safe")]
+    const fn index(self) -> usize {
+        self as usize
+    }
+}
+
+/// Number of distinct timer types.
+const TIMER_COUNT: usize = 4;
+
+/// Fixed-size table of timer deadlines.
+///
+/// Each slot is `Option<MonotonicInstant>`: `None` means the timer is inactive,
+/// `Some(deadline)` means the timer fires at that instant.
+///
+/// This design avoids allocation and provides O(1) access to any timer
+/// and O(n) scan for the next deadline (where n=4, so effectively O(1)).
+#[derive(Debug, Clone)]
+pub(crate) struct TimerTable {
+    deadlines: [Option<MonotonicInstant>; TIMER_COUNT],
+}
+
+impl TimerTable {
+    /// Create a new table with all timers inactive.
+    pub(crate) fn new() -> Self {
+        Self {
+            deadlines: [None; TIMER_COUNT],
+        }
+    }
+
+    /// Set a timer to fire at `deadline`.
+    ///
+    /// Overwrites any existing deadline for this timer.
+    pub(crate) fn set(&mut self, timer: Timer, deadline: MonotonicInstant) {
+        self.deadlines[timer.index()] = Some(deadline);
+    }
+
+    /// Clear a timer, making it inactive.
+    pub(crate) fn clear(&mut self, timer: Timer) {
+        self.deadlines[timer.index()] = None;
+    }
+
+    /// Get the current deadline for a specific timer, if active.
+    #[cfg(test)]
+    pub(crate) fn get(&self, timer: Timer) -> Option<MonotonicInstant> {
+        self.deadlines[timer.index()]
+    }
+
+    /// Whether a specific timer is currently active.
+    pub(crate) fn is_set(&self, timer: Timer) -> bool {
+        self.deadlines[timer.index()].is_some()
+    }
+
+    /// Get the earliest deadline across all active timers.
+    ///
+    /// Returns `None` if no timers are active.
+    /// This is the value the caller should use for `poll_timeout()`.
+    pub(crate) fn next_deadline(&self) -> Option<MonotonicInstant> {
+        self.deadlines.iter().filter_map(|d| *d).min()
+    }
+
+    /// Iterate over timers that have expired as of `now`.
+    ///
+    /// A timer is expired if its deadline is <= `now`.
+    /// Returns an iterator of `Timer` values in enum-order.
+    /// The caller should process each expired timer and clear or
+    /// reset it as appropriate.
+    pub(crate) fn expired(&self, now: MonotonicInstant) -> impl Iterator<Item = Timer> + '_ {
+        Timer::ALL
+            .iter()
+            .copied()
+            .filter(move |timer| self.deadlines[timer.index()].is_some_and(|deadline| deadline <= now))
+    }
+}
+
+impl Default for TimerTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn instant_at(ms: u64) -> MonotonicInstant {
+        MonotonicInstant::from_millis(ms)
+    }
+
+    #[test]
+    fn new_table_all_inactive() {
+        let table = TimerTable::new();
+        assert!(!table.is_set(Timer::Retransmit));
+        assert!(!table.is_set(Timer::AckDelay));
+        assert!(!table.is_set(Timer::Idle));
+        assert!(!table.is_set(Timer::KeepAlive));
+        assert_eq!(table.next_deadline(), None);
+    }
+
+    #[test]
+    fn set_and_get() {
+        let mut table = TimerTable::new();
+        let deadline = instant_at(1000);
+
+        table.set(Timer::Retransmit, deadline);
+        assert!(table.is_set(Timer::Retransmit));
+        assert_eq!(table.get(Timer::Retransmit), Some(deadline));
+    }
+
+    #[test]
+    fn clear_timer() {
+        let mut table = TimerTable::new();
+        table.set(Timer::AckDelay, instant_at(500));
+        assert!(table.is_set(Timer::AckDelay));
+
+        table.clear(Timer::AckDelay);
+        assert!(!table.is_set(Timer::AckDelay));
+        assert_eq!(table.get(Timer::AckDelay), None);
+    }
+
+    #[test]
+    fn next_deadline_single_timer() {
+        let mut table = TimerTable::new();
+        let deadline = instant_at(1000);
+        table.set(Timer::Idle, deadline);
+        assert_eq!(table.next_deadline(), Some(deadline));
+    }
+
+    #[test]
+    fn next_deadline_returns_earliest() {
+        let mut table = TimerTable::new();
+        table.set(Timer::Retransmit, instant_at(300));
+        table.set(Timer::AckDelay, instant_at(100));
+        table.set(Timer::Idle, instant_at(16000));
+        table.set(Timer::KeepAlive, instant_at(8000));
+
+        // AckDelay at 100ms is the earliest
+        assert_eq!(table.next_deadline(), Some(instant_at(100)));
+    }
+
+    #[test]
+    fn next_deadline_updates_after_clear() {
+        let mut table = TimerTable::new();
+        table.set(Timer::AckDelay, instant_at(100));
+        table.set(Timer::Retransmit, instant_at(300));
+
+        assert_eq!(table.next_deadline(), Some(instant_at(100)));
+
+        table.clear(Timer::AckDelay);
+        assert_eq!(table.next_deadline(), Some(instant_at(300)));
+    }
+
+    #[test]
+    fn overwrite_deadline() {
+        let mut table = TimerTable::new();
+        table.set(Timer::Retransmit, instant_at(300));
+        assert_eq!(table.get(Timer::Retransmit), Some(instant_at(300)));
+
+        // Overwrite with an earlier deadline
+        table.set(Timer::Retransmit, instant_at(150));
+        assert_eq!(table.get(Timer::Retransmit), Some(instant_at(150)));
+    }
+
+    #[test]
+    fn expired_none_when_all_inactive() {
+        let table = TimerTable::new();
+        let expired: Vec<Timer> = table.expired(instant_at(10000)).collect();
+        assert!(expired.is_empty());
+    }
+
+    #[test]
+    fn expired_none_when_all_in_future() {
+        let mut table = TimerTable::new();
+        table.set(Timer::Retransmit, instant_at(500));
+        table.set(Timer::AckDelay, instant_at(200));
+
+        // Check at t=100, both timers are in the future
+        let expired: Vec<Timer> = table.expired(instant_at(100)).collect();
+        assert!(expired.is_empty());
+    }
+
+    #[test]
+    fn expired_returns_past_timers() {
+        let mut table = TimerTable::new();
+        table.set(Timer::Retransmit, instant_at(300));
+        table.set(Timer::AckDelay, instant_at(100));
+        table.set(Timer::Idle, instant_at(16000));
+        table.set(Timer::KeepAlive, instant_at(8000));
+
+        // At t=500, Retransmit (300) and AckDelay (100) have expired
+        let expired: Vec<Timer> = table.expired(instant_at(500)).collect();
+        assert_eq!(expired.len(), 2);
+        assert!(expired.contains(&Timer::Retransmit));
+        assert!(expired.contains(&Timer::AckDelay));
+    }
+
+    #[test]
+    fn expired_includes_exact_deadline() {
+        let mut table = TimerTable::new();
+        table.set(Timer::AckDelay, instant_at(100));
+
+        // At exactly the deadline, the timer should be expired
+        let expired: Vec<Timer> = table.expired(instant_at(100)).collect();
+        assert_eq!(expired, vec![Timer::AckDelay]);
+    }
+
+    #[test]
+    fn expired_all_timers() {
+        let mut table = TimerTable::new();
+        table.set(Timer::Retransmit, instant_at(100));
+        table.set(Timer::AckDelay, instant_at(200));
+        table.set(Timer::Idle, instant_at(300));
+        table.set(Timer::KeepAlive, instant_at(400));
+
+        let expired: Vec<Timer> = table.expired(instant_at(500)).collect();
+        assert_eq!(expired.len(), 4);
+    }
+
+    #[test]
+    fn timer_independence() {
+        // Setting/clearing one timer doesn't affect others
+        let mut table = TimerTable::new();
+        table.set(Timer::Retransmit, instant_at(300));
+        table.set(Timer::AckDelay, instant_at(100));
+
+        table.clear(Timer::AckDelay);
+        assert!(table.is_set(Timer::Retransmit));
+        assert_eq!(table.get(Timer::Retransmit), Some(instant_at(300)));
+    }
+
+    #[test]
+    fn default_matches_new() {
+        let from_new = TimerTable::new();
+        let from_default = TimerTable::default();
+        assert_eq!(from_new.next_deadline(), from_default.next_deadline());
+        for timer in Timer::ALL {
+            assert_eq!(from_new.get(timer), from_default.get(timer));
+        }
+    }
+
+    #[test]
+    fn expired_preserves_enum_order() {
+        let mut table = TimerTable::new();
+        // Set all with same deadline
+        for timer in Timer::ALL {
+            table.set(timer, instant_at(100));
+        }
+
+        let expired: Vec<Timer> = table.expired(instant_at(200)).collect();
+        // Should come in enum order: Retransmit, AckDelay, Idle, KeepAlive
+        assert_eq!(
+            expired,
+            vec![Timer::Retransmit, Timer::AckDelay, Timer::Idle, Timer::KeepAlive]
+        );
+    }
+}

--- a/crates/ironrdp-testsuite-core/tests/rdpeudp/connection.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeudp/connection.rs
@@ -1,0 +1,1447 @@
+use core::time::Duration;
+use ironrdp_core::{decode, encode_vec};
+use ironrdp_rdpeudp::pdu::*;
+use ironrdp_rdpeudp::*;
+fn now() -> MonotonicInstant {
+    MonotonicInstant::from_millis(0)
+}
+
+fn later(base: MonotonicInstant, ms: u64) -> MonotonicInstant {
+    base + Duration::from_millis(ms)
+}
+
+/// Stand-in for the SHA-256 of a security cookie. Both ends of a test use the
+/// same one, which is what a real client and server would also have.
+const TEST_COOKIE_HASH: [u8; 32] = [0x5A; 32];
+
+fn default_config(isn: u32) -> ConnectionConfig {
+    ConnectionConfig {
+        initial_sequence_number: isn,
+        log_window_size: 6,
+        upstream_mtu: 1232,
+        downstream_mtu: 1232,
+        idle_timeout: Duration::from_secs(65),
+        keep_alive_interval: Duration::from_secs(8),
+        cookie_hash: Some(TEST_COOKIE_HASH),
+    }
+}
+
+/// A client SYN as `connect` builds it, for tests that drive the server side
+/// by hand.
+fn test_syn_data_ex() -> SynDataExPayload {
+    SynDataExPayload {
+        syn_ex_flags: SynExFlags::VERSION_INFO_VALID,
+        udp_ver: UdpVersion::V3,
+        cookie_hash: Some(TEST_COOKIE_HASH),
+    }
+}
+
+// ── Handshake tests ──
+
+#[test]
+fn client_connect_produces_syn() {
+    let t = now();
+    let mut conn = RdpeudpConnection::connect(default_config(100), t).expect("connect");
+
+    let transmit = conn.poll_transmit(t).expect("should have SYN");
+    assert!(!transmit.contents.is_empty());
+
+    // Decode the SYN
+    let datagram: V1Datagram = decode(&transmit.contents).expect("valid SYN");
+    assert!(datagram.header.flags.contains(V1Flags::SYN));
+    assert!(datagram.header.flags.contains(V1Flags::SYNEX));
+    assert_eq!(
+        datagram
+            .syn_data
+            .as_ref()
+            .expect("has syn_data")
+            .initial_sequence_number,
+        100
+    );
+
+    // No more transmits
+    assert!(conn.poll_transmit(t).is_none());
+
+    // Should be in SynSent state
+    assert!(!conn.is_established());
+    assert!(!conn.is_closed());
+}
+
+#[test]
+fn server_accept_produces_syn_ack() {
+    let t = now();
+
+    // Build a client SYN
+    let client_syn = V1Datagram {
+        header: FecHeader {
+            sn_source_ack: 0xFFFF_FFFF,
+            receive_window_size: 64,
+            flags: V1Flags::SYN | V1Flags::SYNEX,
+        },
+        ack_vector: None,
+        ack_of_acks: None,
+        syn_data: Some(SynDataPayload {
+            initial_sequence_number: 100,
+            upstream_mtu: 1232,
+            downstream_mtu: 1232,
+        }),
+        correlation_id: None,
+        syn_data_ex: Some(test_syn_data_ex()),
+    };
+
+    let mut conn = RdpeudpConnection::accept(default_config(200), &client_syn, t).expect("accept");
+
+    let transmit = conn.poll_transmit(t).expect("should have SYN+ACK");
+
+    // Decode the SYN+ACK
+    let datagram: V1Datagram = decode(&transmit.contents).expect("valid SYN+ACK");
+    assert!(datagram.header.flags.contains(V1Flags::SYN));
+    assert!(datagram.header.flags.contains(V1Flags::ACK));
+    assert!(datagram.header.flags.contains(V1Flags::SYNEX));
+    assert_eq!(
+        datagram
+            .syn_data
+            .as_ref()
+            .expect("has syn_data")
+            .initial_sequence_number,
+        200
+    );
+}
+
+#[test]
+fn full_handshake_client_server() {
+    let t = now();
+
+    // Step 1: Client sends SYN
+    let mut client = RdpeudpConnection::connect(default_config(100), t).expect("connect");
+    let syn_transmit = client.poll_transmit(t).expect("client SYN");
+
+    // Step 2: Server receives SYN and creates connection with SYN+ACK
+    let syn_datagram: V1Datagram = decode(&syn_transmit.contents).expect("decode SYN");
+    let mut server = RdpeudpConnection::accept(default_config(200), &syn_datagram, t).expect("accept");
+    let syn_ack_transmit = server.poll_transmit(t).expect("server SYN+ACK");
+
+    // Step 3: Client receives SYN+ACK → transitions to Established
+    let mut syn_ack_bytes = syn_ack_transmit.contents;
+    client
+        .handle_datagram(&mut syn_ack_bytes, later(t, 50))
+        .expect("handle SYN+ACK");
+
+    assert!(client.is_established());
+
+    // Client should emit Connected event
+    let event = client.poll_event().expect("should have event");
+    assert_eq!(event, Event::Connected);
+
+    // Client sends final ACK
+    let ack_transmit = client.poll_transmit(later(t, 50)).expect("client final ACK");
+
+    // Step 4: Server receives final ACK → transitions to Established
+    let mut ack_bytes = ack_transmit.contents;
+    server
+        .handle_datagram(&mut ack_bytes, later(t, 100))
+        .expect("handle final ACK");
+
+    assert!(server.is_established());
+
+    let event = server.poll_event().expect("should have event");
+    assert_eq!(event, Event::Connected);
+}
+
+#[test]
+fn server_rejects_non_v2_syn() {
+    let t = now();
+
+    let syn = V1Datagram {
+        header: FecHeader {
+            sn_source_ack: 0xFFFF_FFFF,
+            receive_window_size: 64,
+            flags: V1Flags::SYN | V1Flags::SYNEX,
+        },
+        ack_vector: None,
+        ack_of_acks: None,
+        syn_data: Some(SynDataPayload {
+            initial_sequence_number: 100,
+            upstream_mtu: 1232,
+            downstream_mtu: 1232,
+        }),
+        correlation_id: None,
+        syn_data_ex: Some(SynDataExPayload {
+            syn_ex_flags: SynExFlags::VERSION_INFO_VALID,
+            udp_ver: UdpVersion::V1,
+            cookie_hash: None,
+        }),
+    };
+
+    let result = RdpeudpConnection::accept(default_config(200), &syn, t);
+    assert!(result.is_err());
+}
+
+/// MS-RDPEUDP 1.7's negotiate-down MUST clause: a client offering a version
+/// above 3, which this crate does not recognize, must still get a V3
+/// SYN+ACK rather than a refused connection, since 3 is our own highest (and
+/// only) supported version, at or below anything higher that was offered.
+#[test]
+fn server_accepts_and_settles_on_v3_for_an_unrecognized_higher_version() {
+    let t = now();
+
+    let syn = V1Datagram {
+        header: FecHeader {
+            sn_source_ack: 0xFFFF_FFFF,
+            receive_window_size: 64,
+            flags: V1Flags::SYN | V1Flags::SYNEX,
+        },
+        ack_vector: None,
+        ack_of_acks: None,
+        syn_data: Some(SynDataPayload {
+            initial_sequence_number: 100,
+            upstream_mtu: 1232,
+            downstream_mtu: 1232,
+        }),
+        correlation_id: None,
+        syn_data_ex: Some(SynDataExPayload {
+            syn_ex_flags: SynExFlags::VERSION_INFO_VALID,
+            udp_ver: UdpVersion(0x0102),
+            cookie_hash: Some(TEST_COOKIE_HASH),
+        }),
+    };
+
+    let mut conn = RdpeudpConnection::accept(default_config(200), &syn, t).expect("accept");
+    let transmit = conn.poll_transmit(t).expect("SYN+ACK");
+
+    let datagram: V1Datagram = decode(&transmit.contents).expect("decode SYN+ACK");
+    let settled = datagram.syn_data_ex.expect("has syn_data_ex").udp_ver;
+    assert_eq!(settled, UdpVersion::V3);
+}
+
+#[test]
+fn send_before_established_returns_error() {
+    let t = now();
+    let mut conn = RdpeudpConnection::connect(default_config(100), t).expect("connect");
+
+    let result = conn.send(vec![0xAA; 100]);
+    assert!(matches!(result.unwrap_err().kind(), RdpeudpErrorKind::InvalidState));
+}
+
+/// `send` must eventually refuse more data rather than growing the buffer
+/// without limit when nothing is draining it, under sustained congestion or
+/// an unresponsive peer.
+#[test]
+fn send_returns_send_buffer_full_once_the_bound_is_reached() {
+    let (mut client, _server, _t) = establish_pair();
+
+    // default_config's log_window_size is 6 (64 slots); the bound is 8x that.
+    for _ in 0..512 {
+        client.send(vec![0xAA; 4]).expect("send");
+    }
+
+    let result = client.send(vec![0xAA; 4]);
+    assert!(matches!(result.unwrap_err().kind(), RdpeudpErrorKind::SendBufferFull));
+}
+
+/// `log_window_size` shifts a `u16` and a `usize` elsewhere in the state
+/// machine, so an unvalidated out-of-range value panics on the first
+/// handshake datagram rather than surfacing as this constructor's `Result`.
+#[test]
+fn connect_rejects_an_out_of_range_log_window_size() {
+    let t = now();
+    let mut config = default_config(100);
+    config.log_window_size = 16;
+
+    let result = RdpeudpConnection::connect(config, t);
+    assert!(matches!(result.unwrap_err().kind(), RdpeudpErrorKind::InvalidState));
+}
+
+#[test]
+fn accept_rejects_an_out_of_range_log_window_size() {
+    let t = now();
+    let mut config = default_config(200);
+    config.log_window_size = 16;
+
+    let syn = V1Datagram {
+        header: FecHeader {
+            sn_source_ack: 0xFFFF_FFFF,
+            receive_window_size: 64,
+            flags: V1Flags::SYN | V1Flags::SYNEX,
+        },
+        ack_vector: None,
+        ack_of_acks: None,
+        syn_data: Some(SynDataPayload {
+            initial_sequence_number: 100,
+            upstream_mtu: 1232,
+            downstream_mtu: 1232,
+        }),
+        correlation_id: None,
+        syn_data_ex: Some(test_syn_data_ex()),
+    };
+
+    let result = RdpeudpConnection::accept(config, &syn, t);
+    assert!(matches!(result.unwrap_err().kind(), RdpeudpErrorKind::InvalidState));
+}
+
+// ── Data transfer tests ──
+
+/// Helper: perform a full handshake and return (client, server, time).
+fn establish_pair() -> (RdpeudpConnection, RdpeudpConnection, MonotonicInstant) {
+    let t = now();
+
+    let mut client = RdpeudpConnection::connect(default_config(100), t).expect("connect");
+    let syn = client.poll_transmit(t).expect("SYN");
+
+    let syn_dg: V1Datagram = decode(&syn.contents).expect("decode SYN");
+    let mut server = RdpeudpConnection::accept(default_config(200), &syn_dg, t).expect("accept");
+    let syn_ack = server.poll_transmit(t).expect("SYN+ACK");
+
+    let mut syn_ack_bytes = syn_ack.contents;
+    client
+        .handle_datagram(&mut syn_ack_bytes, later(t, 50))
+        .expect("handle SYN+ACK");
+
+    // Drain client events and final ACK
+    while client.poll_event().is_some() {}
+    let final_ack = client.poll_transmit(later(t, 50)).expect("final ACK");
+
+    let mut ack_bytes = final_ack.contents;
+    server
+        .handle_datagram(&mut ack_bytes, later(t, 100))
+        .expect("handle ACK");
+    while server.poll_event().is_some() {}
+
+    (client, server, t)
+}
+
+/// Each side's handshake round trip seeds its RTT estimate, rather than
+/// leaving it unset until the first data-phase ACK.
+#[test]
+fn handshake_seeds_rtt_estimate() {
+    let (client, server, _t) = establish_pair();
+
+    // Client: SYN sent at t=0, SYN+ACK handled at t=50.
+    assert_eq!(client.srtt(), Some(Duration::from_millis(50)));
+
+    // Server: SYN+ACK sent at t=0 (inside `accept`), final ACK handled at t=100.
+    assert_eq!(server.srtt(), Some(Duration::from_millis(100)));
+}
+
+/// Karn's algorithm (RFC 6298 Section 3): once the client's SYN has been
+/// retransmitted, a SYN+ACK that arrives afterward cannot be tied to a single
+/// transmission, so it must not seed an RTT sample.
+#[test]
+fn a_retransmitted_syn_skips_the_handshake_rtt_sample() {
+    let t = now();
+    let mut client = RdpeudpConnection::connect(default_config(100), t).expect("connect");
+    let first_syn = client.poll_transmit(t).expect("SYN");
+
+    let _retransmitted_syn = advance_to_retransmit(&mut client).expect("SYN retransmit");
+    let deadline = client.poll_timeout().expect("retransmit timer still armed");
+
+    let syn_dg: V1Datagram = decode(&first_syn.contents).expect("decode SYN");
+    let mut server = RdpeudpConnection::accept(default_config(200), &syn_dg, deadline).expect("accept");
+    let syn_ack = server.poll_transmit(deadline).expect("SYN+ACK");
+
+    let mut syn_ack_bytes = syn_ack.contents;
+    client
+        .handle_datagram(&mut syn_ack_bytes, later(deadline, 10))
+        .expect("handle SYN+ACK");
+
+    assert_eq!(client.srtt(), None, "an ambiguous answer must not seed a sample");
+}
+
+#[test]
+fn send_data_after_established() {
+    let (mut client, _server, t) = establish_pair();
+
+    // Send data
+    client.send(vec![0xDE, 0xAD, 0xBE, 0xEF]).expect("send");
+
+    // Should produce a data transmit
+    let transmit = client.poll_transmit(later(t, 200)).expect("data packet");
+    assert!(!transmit.contents.is_empty());
+}
+
+#[test]
+fn data_delivery_roundtrip() {
+    let (mut client, mut server, t) = establish_pair();
+
+    // Client sends data
+    let payload = vec![0xDE, 0xAD, 0xBE, 0xEF];
+    client.send(payload.clone()).expect("send");
+    let data_pkt = client.poll_transmit(later(t, 200)).expect("data packet");
+
+    // Server receives data
+    let mut data_bytes = data_pkt.contents;
+    server
+        .handle_datagram(&mut data_bytes, later(t, 250))
+        .expect("handle data");
+
+    // Server should emit DataReceived event
+    let event = server.poll_event().expect("should have event");
+    assert_eq!(event, Event::DataReceived(payload));
+}
+
+#[test]
+fn bidirectional_data() {
+    let (mut client, mut server, t) = establish_pair();
+
+    // Client → Server
+    let c2s = vec![0x01, 0x02, 0x03];
+    client.send(c2s.clone()).expect("send c2s");
+    let pkt = client.poll_transmit(later(t, 200)).expect("c2s packet");
+    let mut pkt_bytes = pkt.contents;
+    server
+        .handle_datagram(&mut pkt_bytes, later(t, 250))
+        .expect("handle c2s");
+
+    let event = server.poll_event().expect("c2s event");
+    assert_eq!(event, Event::DataReceived(c2s));
+
+    // Server → Client
+    let s2c = vec![0x04, 0x05, 0x06];
+    server.send(s2c.clone()).expect("send s2c");
+    let pkt = server.poll_transmit(later(t, 300)).expect("s2c packet");
+    let mut pkt_bytes = pkt.contents;
+    client
+        .handle_datagram(&mut pkt_bytes, later(t, 350))
+        .expect("handle s2c");
+
+    let event = client.poll_event().expect("s2c event");
+    assert_eq!(event, Event::DataReceived(s2c));
+}
+
+// ── Close and timeout tests ──
+
+#[test]
+fn close_produces_event() {
+    let (mut client, _server, _t) = establish_pair();
+    client.close();
+
+    assert!(client.is_closed());
+    let event = client.poll_event().expect("close event");
+    assert_eq!(event, Event::ConnectionClosed);
+}
+
+#[test]
+fn send_after_close_returns_error() {
+    let (mut client, _server, _t) = establish_pair();
+    client.close();
+
+    let result = client.send(vec![0x42]);
+    assert!(matches!(result.unwrap_err().kind(), RdpeudpErrorKind::ConnectionClosed));
+}
+
+#[test]
+fn idle_timeout_closes_connection() {
+    let (mut client, _server, t) = establish_pair();
+
+    // Advance time past idle timeout
+    let idle_time = later(t, 66_000); // 66 seconds > the 65 second timeout
+    client.handle_timeout(idle_time);
+
+    assert!(client.is_closed());
+    let event = client.poll_event().expect("idle close event");
+    assert_eq!(event, Event::ConnectionClosed);
+}
+
+#[test]
+fn keep_alive_fires() {
+    let (mut client, _server, t) = establish_pair();
+
+    // Advance time past keep-alive interval
+    let ka_time = later(t, 8_500); // 8.5 seconds > 8 second interval
+    client.handle_timeout(ka_time);
+
+    // The keep-alive leaves an acknowledgement pending, which the next
+    // poll_transmit turns into a probe on the wire.
+    assert!(client.poll_transmit(ka_time).is_some());
+}
+
+#[test]
+fn poll_timeout_returns_earliest() {
+    let (client, _server, _t) = establish_pair();
+
+    let timeout = client.poll_timeout();
+    assert!(timeout.is_some());
+}
+
+// ── Congestion backpressure test ──
+
+#[test]
+fn congestion_backpressure() {
+    let (mut client, _server, t) = establish_pair();
+
+    // One packet's worth per write, so the count below stays a packet count.
+    // A larger write would be split and the arithmetic would not follow.
+    let mtu_data = vec![0xAA; client.max_payload()];
+    let mut sent_count = 0u32;
+
+    for _ in 0..100 {
+        if client.send(mtu_data.clone()).is_ok() {
+            sent_count += 1;
+        }
+    }
+    assert!(sent_count > 0);
+
+    // Drain transmits until congestion window is full
+    let mut transmit_count = 0u32;
+    let t2 = later(t, 200);
+    while client.poll_transmit(t2).is_some() {
+        transmit_count += 1;
+        if transmit_count > 200 {
+            break; // safety valve
+        }
+    }
+
+    // Should have been limited by the congestion window.
+    // The initial window is 12320 bytes and each packet carries one full
+    // payload, so a dozen or so go out before it closes.
+    assert!(transmit_count > 0);
+    assert!(transmit_count <= 15); // reasonable upper bound with overhead
+}
+
+#[test]
+fn multiple_data_chunks_delivered_in_order() {
+    let (mut client, mut server, t) = establish_pair();
+
+    // Send multiple data chunks
+    for i in 0u8..5 {
+        client.send(vec![i; 100]).expect("send");
+    }
+
+    // Transmit and deliver each
+    for i in 0u8..5 {
+        let pkt = client.poll_transmit(later(t, 200 + u64::from(i) * 50));
+        if let Some(pkt) = pkt {
+            let mut pkt_bytes = pkt.contents;
+            server
+                .handle_datagram(&mut pkt_bytes, later(t, 225 + u64::from(i) * 50))
+                .expect("handle data");
+        }
+    }
+
+    // Verify all events arrived in order
+    let mut received = Vec::new();
+    while let Some(event) = server.poll_event() {
+        if let Event::DataReceived(data) = event {
+            received.push(data[0]); // first byte identifies the chunk
+        }
+    }
+
+    assert_eq!(received, vec![0, 1, 2, 3, 4]);
+}
+
+#[test]
+fn handle_datagram_after_close_returns_error() {
+    let (mut client, _server, t) = establish_pair();
+    client.close();
+
+    let mut wire = vec![0u8; 16];
+    let result = client.handle_datagram(&mut wire, later(t, 100));
+    assert!(matches!(result.unwrap_err().kind(), RdpeudpErrorKind::ConnectionClosed));
+}
+
+#[test]
+fn config_default() {
+    let config = ConnectionConfig::default();
+    assert_eq!(config.log_window_size, 6);
+    assert_eq!(config.upstream_mtu, 1232);
+    assert_eq!(config.downstream_mtu, 1232);
+    assert_eq!(config.idle_timeout, Duration::from_secs(65));
+    assert_eq!(config.keep_alive_interval, Duration::from_secs(8));
+}
+
+#[test]
+fn debug_impl() {
+    let t = now();
+    let conn = RdpeudpConnection::connect(default_config(1), t);
+    let debug = format!("{conn:?}");
+    assert!(debug.contains("RdpeudpConnection"));
+    assert!(debug.contains("Client"));
+}
+
+/// Regression: the idle timeout must not leave a re-armed timer behind.
+///
+/// `handle_timeout` collects the expired timers, then handles them in order.
+/// The idle timer closes the connection and `close` clears every timer, but a
+/// handler later in the same list used to run anyway and re-arm its own timer
+/// on a connection that had already gone. `handle_timeout` returns early once
+/// closed, so that deadline was never serviced: a driver polling it without
+/// checking `is_closed` first would wake immediately, do nothing, and spin.
+///
+/// Found by the `rdpeudp_connection` fuzz oracle.
+#[test]
+fn idle_close_leaves_no_timer_armed() {
+    let mut now = MonotonicInstant::from_millis(0);
+    let mut conn = RdpeudpConnection::connect(default_config(100), now).expect("connect");
+    while conn.poll_transmit(now).is_some() {}
+
+    // Walk past the keep-alive interval so that timer is armed and due in the
+    // same pass as the idle timer, which is the ordering that used to break.
+    for step in [1_000u64, 8_000, 65_000] {
+        now = now + Duration::from_millis(step);
+        conn.handle_timeout(now);
+        while conn.poll_transmit(now).is_some() {}
+    }
+
+    assert!(conn.is_closed(), "the idle timeout should have closed the connection");
+    assert_eq!(
+        conn.poll_timeout(),
+        None,
+        "a closed connection must not report a deadline"
+    );
+
+    // Advancing again must not resurrect one.
+    now = now + Duration::from_secs(60);
+    conn.handle_timeout(now);
+    assert_eq!(conn.poll_timeout(), None, "a closed connection re-armed a timer");
+}
+
+/// Regression: a closed connection must not emit packets or arm timers.
+///
+/// `poll_transmit` drained queued handshake packets before checking the state,
+/// and armed the keep-alive timer on the way past. `close` had already cleared
+/// the timers and `handle_timeout` returns early once closed, so that deadline
+/// stayed due forever and a caller polling it without checking `is_closed`
+/// would wake immediately, do nothing, and spin.
+///
+/// Found by the `rdpeudp_connection` fuzz oracle.
+#[test]
+fn closed_connection_transmits_nothing_and_arms_nothing() {
+    let now = MonotonicInstant::from_millis(0);
+
+    // Close while the SYN is still queued, which is the state the oracle found.
+    let mut conn = RdpeudpConnection::connect(default_config(100), now).expect("connect");
+    conn.close();
+
+    assert!(
+        conn.poll_transmit(now).is_none(),
+        "a closed connection emitted a packet"
+    );
+    assert_eq!(conn.poll_timeout(), None, "a closed connection armed a timer");
+
+    // And it stays that way once the clock moves on.
+    let later = now + Duration::from_secs(30);
+    conn.handle_timeout(later);
+    assert!(conn.poll_transmit(later).is_none());
+    assert_eq!(conn.poll_timeout(), None);
+}
+
+// ── Handshake retransmission ──
+//
+// [MS-RDPEUDP] 1.3.1: the SYN, SYN+ACK and ACK are delivered by persistent
+// retransmits whatever mode the transport is running in. 3.1.5.4.1 stops
+// after somewhere between three and five unanswered tries.
+
+/// Drive the connection to its next retransmit deadline and collect whatever
+/// it decides to send.
+fn advance_to_retransmit(conn: &mut RdpeudpConnection) -> Option<Vec<u8>> {
+    let deadline = conn.poll_timeout()?;
+    conn.handle_timeout(deadline);
+    conn.poll_transmit(deadline).map(|transmit| transmit.contents)
+}
+
+#[test]
+fn unanswered_syn_is_retransmitted() {
+    let t = now();
+    let mut client = RdpeudpConnection::connect(default_config(100), t).expect("connect");
+
+    let first = client.poll_transmit(t).expect("SYN");
+    let again = advance_to_retransmit(&mut client).expect("SYN again");
+
+    assert_eq!(first.contents, again, "the retransmitted SYN differs from the original");
+    assert!(!client.is_closed());
+}
+
+#[test]
+fn unanswered_syn_ack_is_retransmitted() {
+    let t = now();
+
+    let mut client = RdpeudpConnection::connect(default_config(100), t).expect("connect");
+    let syn = client.poll_transmit(t).expect("SYN");
+    let syn_dg: V1Datagram = decode(&syn.contents).expect("decode SYN");
+
+    let mut server = RdpeudpConnection::accept(default_config(200), &syn_dg, t).expect("accept");
+    let first = server.poll_transmit(t).expect("SYN+ACK");
+    let again = advance_to_retransmit(&mut server).expect("SYN+ACK again");
+
+    assert_eq!(first.contents, again);
+    assert!(!server.is_closed());
+}
+
+#[test]
+fn a_syn_that_is_never_answered_closes_the_connection() {
+    let t = now();
+    let mut client = RdpeudpConnection::connect(default_config(100), t).expect("connect");
+    client.poll_transmit(t).expect("SYN");
+
+    // The retransmit timer keeps firing until the limit is reached. The idle
+    // timer would also close this connection eventually, so the assertion
+    // below is that we gave up on the retransmit count first.
+    let mut retransmits = 0;
+    while !client.is_closed() {
+        let deadline = client.poll_timeout().expect("a timer is armed");
+        assert!(
+            deadline < t + client_idle_timeout(),
+            "gave up on the idle timeout rather than the retransmit limit"
+        );
+
+        client.handle_timeout(deadline);
+        if client.poll_transmit(deadline).is_some() {
+            retransmits += 1;
+        }
+    }
+
+    assert_eq!(retransmits, 5, "[MS-RDPEUDP] 3.1.5.4.1 allows between three and five");
+    assert_eq!(client.poll_event(), Some(Event::ConnectionClosed));
+}
+
+fn client_idle_timeout() -> Duration {
+    default_config(0).idle_timeout
+}
+
+#[test]
+fn a_repeated_syn_draws_another_syn_ack() {
+    let t = now();
+
+    let mut client = RdpeudpConnection::connect(default_config(100), t).expect("connect");
+    let syn = client.poll_transmit(t).expect("SYN");
+    let syn_dg: V1Datagram = decode(&syn.contents).expect("decode SYN");
+
+    let mut server = RdpeudpConnection::accept(default_config(200), &syn_dg, t).expect("accept");
+    let syn_ack = server.poll_transmit(t).expect("SYN+ACK");
+
+    // The client did not see that SYN+ACK, so it repeats its SYN.
+    let mut repeated = syn.contents;
+    server
+        .handle_datagram(&mut repeated, later(t, 500))
+        .expect("a repeated SYN is not a protocol violation");
+
+    let answer = server.poll_transmit(later(t, 500)).expect("another SYN+ACK");
+    assert_eq!(answer.contents, syn_ack.contents);
+    assert!(!server.is_established());
+}
+
+#[test]
+fn a_repeated_syn_ack_draws_another_final_ack() {
+    let t = now();
+
+    let mut client = RdpeudpConnection::connect(default_config(100), t).expect("connect");
+    let syn = client.poll_transmit(t).expect("SYN");
+    let syn_dg: V1Datagram = decode(&syn.contents).expect("decode SYN");
+
+    let mut server = RdpeudpConnection::accept(default_config(200), &syn_dg, t).expect("accept");
+    let syn_ack = server.poll_transmit(t).expect("SYN+ACK");
+
+    let mut syn_ack_bytes = syn_ack.contents.clone();
+    client
+        .handle_datagram(&mut syn_ack_bytes, later(t, 50))
+        .expect("handle SYN+ACK");
+    while client.poll_event().is_some() {}
+
+    let final_ack = client.poll_transmit(later(t, 50)).expect("final ACK");
+    assert!(client.is_established());
+
+    // That ACK was lost, so the server repeats its SYN+ACK. The client is on
+    // v2 by now and must still recognise it.
+    let mut repeated = syn_ack.contents;
+    client
+        .handle_datagram(&mut repeated, later(t, 600))
+        .expect("a repeated SYN+ACK is not a protocol violation");
+
+    let answer = client.poll_transmit(later(t, 600)).expect("the final ACK again");
+    assert_eq!(answer.contents, final_ack.contents);
+    assert!(client.is_established(), "the connection did not fall back a state");
+}
+
+#[test]
+fn data_is_not_mistaken_for_a_repeated_syn_ack() {
+    let (mut client, mut server, t) = establish_pair();
+
+    server.send(vec![0x11; 32]).expect("send");
+    let mut data = server.poll_transmit(later(t, 200)).expect("data").contents;
+
+    client.handle_datagram(&mut data, later(t, 250)).expect("handle data");
+
+    assert_eq!(client.poll_event(), Some(Event::DataReceived(vec![0x11; 32])));
+}
+
+// ── Receive window lifecycle ──
+
+/// Shuttle packets between the two endpoints until neither has more to say.
+fn pump(client: &mut RdpeudpConnection, server: &mut RdpeudpConnection, at: MonotonicInstant) {
+    for _ in 0..10_000 {
+        let mut moved = false;
+
+        while let Some(transmit) = client.poll_transmit(at) {
+            let mut bytes = transmit.contents;
+            server.handle_datagram(&mut bytes, at).expect("server handles");
+            moved = true;
+        }
+
+        while let Some(transmit) = server.poll_transmit(at) {
+            let mut bytes = transmit.contents;
+            client.handle_datagram(&mut bytes, at).expect("client handles");
+            moved = true;
+        }
+
+        if !moved {
+            return;
+        }
+    }
+
+    panic!("the endpoints never went quiet");
+}
+
+fn drain_received(conn: &mut RdpeudpConnection) -> Vec<Vec<u8>> {
+    let mut received = Vec::new();
+    while let Some(event) = conn.poll_event() {
+        if let Event::DataReceived(chunk) = event {
+            received.push(chunk);
+        }
+    }
+    received
+}
+
+/// [MS-RDPEUDP2] 3.1.1.2.2 moves the receive window's lower bound when an
+/// acknowledgment naming those packets is sent, as well as when an AckOfAcks
+/// arrives. Nothing is lost in this exchange, so the receiver never sends an
+/// ACK vector and the sender never sends an AckOfAcks: the bound has to move
+/// on the first of those two events or the window fills and stays full.
+#[test]
+fn a_clean_transfer_outlasts_the_receive_window() {
+    let (mut client, mut server, t) = establish_pair();
+
+    // Four times the 64-slot window implied by log_window_size 6.
+    let chunk_count = 256usize;
+    for i in 0..chunk_count {
+        let byte = u8::try_from(i % 256).expect("modulo 256 fits in u8");
+        client.send(vec![byte; 4]).expect("send");
+    }
+
+    pump(&mut client, &mut server, later(t, 200));
+
+    let received = drain_received(&mut server);
+    assert_eq!(received.len(), chunk_count, "the receive window stalled");
+
+    for (i, chunk) in received.iter().enumerate() {
+        let byte = u8::try_from(i % 256).expect("modulo 256 fits in u8");
+        assert_eq!(chunk, &vec![byte; 4], "chunk {i} arrived out of order");
+    }
+}
+
+/// Run both endpoints forward through their own timers up to `until`,
+/// delivering everything they emit along the way.
+fn advance(client: &mut RdpeudpConnection, server: &mut RdpeudpConnection, until: MonotonicInstant) {
+    for _ in 0..1_000 {
+        let next = [client.poll_timeout(), server.poll_timeout()]
+            .into_iter()
+            .flatten()
+            .min();
+
+        let Some(at) = next.filter(|at| *at <= until) else {
+            return;
+        };
+
+        client.handle_timeout(at);
+        server.handle_timeout(at);
+        pump(client, server, at);
+    }
+
+    panic!("the endpoints never stopped scheduling work");
+}
+
+/// New data acknowledged retires whichever packet the retransmit timer's
+/// deadline was set for. A later, still-outstanding packet must not then be
+/// measured against a deadline meant for a different packet, or it can be
+/// declared lost within a few milliseconds instead of a full RTO.
+#[test]
+fn an_ack_restarts_the_retransmit_timer_for_the_still_outstanding_packet() {
+    let (mut client, mut server, t) = establish_pair();
+
+    client.send(vec![0xA1; 8]).expect("send");
+    let a = client.poll_transmit(later(t, 500)).expect("packet A");
+    let a_deadline = client.poll_timeout().expect("retransmit timer armed for A");
+
+    client.send(vec![0xB1; 8]).expect("send");
+    let _b = client.poll_transmit(later(t, 600)).expect("packet B");
+    // Sending B does not touch an already-armed timer.
+    assert_eq!(client.poll_timeout(), Some(a_deadline));
+
+    let mut a_bytes = a.contents;
+    server.handle_datagram(&mut a_bytes, later(t, 520)).expect("handle A");
+    let ack_deadline = server.poll_timeout().expect("delayed-ACK timer armed");
+    server.handle_timeout(ack_deadline);
+    let ack = server.poll_transmit(ack_deadline).expect("acknowledgment");
+
+    // Delivered 5ms before A's stale deadline: barely any protection left
+    // for B under the bug, comfortably inside a fresh RTO under the fix.
+    let mut ack_bytes = ack.contents;
+    client
+        .handle_datagram(&mut ack_bytes, later(t, 795))
+        .expect("handle ack");
+
+    let new_deadline = client.poll_timeout().expect("retransmit timer still armed for B");
+    assert!(
+        new_deadline > a_deadline,
+        "the timer must restart from B's own outstanding state, not stay at A's stale deadline"
+    );
+    assert!(
+        new_deadline.duration_since(later(t, 795)) >= Duration::from_millis(200),
+        "the restarted deadline should reflect close to a full RTO, not a few leftover milliseconds"
+    );
+}
+
+/// A packet lost on its own, with too few behind it to trip the reordering
+/// threshold, has only the retransmit timer to recover it. That timer used to
+/// hand the decision to a time threshold derived from an RTO it had just
+/// doubled, so the threshold always sat ahead of the elapsed time and the
+/// packet was never retransmitted at all.
+#[test]
+fn a_lone_lost_packet_is_recovered() {
+    let (mut client, mut server, t) = establish_pair();
+
+    client.send(vec![0xA1; 8]).expect("send");
+    client.send(vec![0xA2; 8]).expect("send");
+
+    // The first packet never reaches the server.
+    let _dropped = client.poll_transmit(later(t, 100)).expect("first data packet");
+    let delivered = client.poll_transmit(later(t, 100)).expect("second data packet");
+
+    let mut bytes = delivered.contents;
+    server.handle_datagram(&mut bytes, later(t, 150)).expect("handle data");
+
+    // Nothing has been delivered to the application: the second chunk is
+    // waiting behind the hole.
+    assert!(drain_received(&mut server).is_empty());
+
+    advance(&mut client, &mut server, later(t, 10_000));
+
+    assert_eq!(
+        drain_received(&mut server),
+        vec![vec![0xA1; 8], vec![0xA2; 8]],
+        "the lost packet was never retransmitted"
+    );
+}
+
+/// A cumulative ACK claims every packet through its sequence number, so it
+/// cannot describe a window with a hole in it. The piggybacked path sent one
+/// regardless, which tells the sender its lost packet arrived.
+#[test]
+fn a_hole_is_never_reported_as_a_cumulative_ack() {
+    let (mut client, mut server, t) = establish_pair();
+
+    client.send(vec![0xA1; 8]).expect("send");
+    client.send(vec![0xA2; 8]).expect("send");
+
+    let _dropped = client.poll_transmit(later(t, 100)).expect("first data packet");
+    let delivered = client.poll_transmit(later(t, 100)).expect("second data packet");
+
+    let mut bytes = delivered.contents;
+    server.handle_datagram(&mut bytes, later(t, 150)).expect("handle data");
+
+    // Give the server data of its own, so its acknowledgment rides along on a
+    // data packet rather than going out standalone.
+    server.send(vec![0xB1; 8]).expect("send");
+    let reply = server.poll_transmit(later(t, 200)).expect("server data packet");
+
+    let mut reply_bytes = reply.contents;
+    let (_, packet_bytes) = decode_with_prefix(&mut reply_bytes).expect("prefix");
+    let packet: V2Packet = decode(packet_bytes).expect("decode");
+
+    assert!(packet.data_body.is_some(), "the acknowledgment should be piggybacked");
+    assert!(packet.ack.is_none(), "a cumulative ACK cannot describe a hole");
+    assert!(packet.ack_vector.is_some(), "the hole needs a vector to describe it");
+    assert!(packet.header.flags.contains(V2Flags::ACKVEC));
+    assert!(!packet.header.flags.contains(V2Flags::ACK));
+}
+
+/// A cumulative ACK claiming a sequence number the sender never assigned is
+/// malformed or hostile. Accepting it would drain every outstanding entry in
+/// the send window as if delivered, discarding real in-flight data on a
+/// single bad datagram.
+#[test]
+fn an_out_of_range_cumulative_ack_does_not_discard_outstanding_data() {
+    let (mut client, _server, t) = establish_pair();
+
+    client.send(vec![0xE1; 8]).expect("send");
+    let _sent = client.poll_transmit(later(t, 100)).expect("data packet");
+
+    // A cumulative ACK claiming far more than the client has ever sent.
+    let bogus_ack = V2Packet {
+        header: V2Header {
+            flags: V2Flags::empty(),
+            log_window_size: 6,
+        },
+        ack: Some(AckPayload {
+            seq_num: 0xFFFF,
+            received_ts: 0,
+            send_ack_time_gap: 0,
+            delay_ack_time_scale: 0,
+            delay_ack_time_additions: Vec::new(),
+        }),
+        overhead_size: None,
+        delay_ack_info: None,
+        ack_of_acks: None,
+        data_header: None,
+        ack_vector: None,
+        data_body: None,
+    };
+    let encoded = encode_vec(&bogus_ack).expect("encode");
+    let mut wire = Vec::new();
+    encode_with_prefix(&encoded, false, &mut wire).expect("prefix");
+    client
+        .handle_datagram(&mut wire, later(t, 160))
+        .expect("handle bogus ack");
+
+    // The data is still tracked as outstanding and gets retransmitted, which
+    // proves the bogus ACK did not drain it from the send window. Compared by
+    // decoded payload, not raw bytes: a retransmission piggybacks whatever
+    // header and ACK state is current, so the framing legitimately differs
+    // from the original send.
+    let mut retransmitted = advance_to_retransmit(&mut client).expect("data packet retransmitted");
+    let (_, packet_bytes) = decode_with_prefix(&mut retransmitted).expect("prefix");
+    let packet: V2Packet = decode(packet_bytes).expect("decode");
+    assert_eq!(
+        packet.data_body.expect("retransmission carries the data").data,
+        vec![0xE1; 8],
+        "the outstanding packet must survive an out-of-range ACK"
+    );
+}
+
+/// Acknowledging a packet resolves it and drains it off the front of the send
+/// window, so the timing has to be read before that happens. Reading it after
+/// finds nothing and no sample reaches the estimator from this exchange.
+///
+/// The handshake round trip already seeded the estimator (see
+/// `handshake_seeds_rtt_estimate`), so this data-phase acknowledgment is the
+/// *second* sample: it refines the existing estimate rather than setting it
+/// from nothing.
+#[test]
+fn an_acknowledgement_produces_an_rtt_sample() {
+    let (mut client, mut server, t) = establish_pair();
+
+    // Handshake sample: SYN at t=0, SYN+ACK handled at t=50.
+    assert_eq!(client.srtt(), Some(Duration::from_millis(50)));
+
+    client.send(vec![0xC1; 16]).expect("send");
+    let data = client.poll_transmit(later(t, 100)).expect("data packet");
+
+    let mut bytes = data.contents;
+    server.handle_datagram(&mut bytes, later(t, 140)).expect("handle data");
+
+    // The delayed-ACK timer arms when the data arrives (t=140) and the
+    // server's handshake-seeded 100ms srtt gives a 50ms delay, so it fires
+    // at t=190: a real 50ms gap between receipt and send, encoded on the
+    // wire rather than reported as zero.
+    server.handle_timeout(later(t, 190));
+    let ack = server.poll_transmit(later(t, 190)).expect("acknowledgment");
+
+    // The ACK reaches the client 60ms after the server sent it, at t=250:
+    // after t=190, not before it.
+    let mut ack_bytes = ack.contents;
+    client
+        .handle_datagram(&mut ack_bytes, later(t, 250))
+        .expect("handle ack");
+
+    // Client-side elapsed since the data went out is 250 - 100 = 150ms.
+    // Subtracting the real 50ms processing gap gives a 100ms sample; folding
+    // the whole gap in unsubtracted, as an always-zero gap would, gives a
+    // wrong 150ms sample instead. RFC 6298 Section 2.3 blends the correct
+    // 100ms sample with the existing 50ms estimate:
+    // srtt = 7/8 * 50ms + 1/8 * 100ms = 56.25ms.
+    let srtt = client.srtt().expect("an RTT sample");
+    assert_eq!(srtt, Duration::from_micros(56_250));
+}
+
+// ── Protocol version negotiation ──
+//
+// [MS-RDPEUDP] 1.3.2.2: the MS-RDPEUDP data transfer messages "MUST be used
+// only when the version negotiated in the UDP connection initialization phase
+// is version 1 or version 2". Only version 3 reaches MS-RDPEUDP2, which is the
+// data transfer this crate implements, so version 3 is the only value it can
+// honestly advertise or accept.
+
+fn syn_data_ex_of(transmit: &Transmit) -> SynDataExPayload {
+    let datagram: V1Datagram = decode(&transmit.contents).expect("decode");
+    datagram.syn_data_ex.expect("SYNDATAEX")
+}
+
+#[test]
+fn the_syn_advertises_version_3_with_the_cookie_hash() {
+    let t = now();
+    let mut client = RdpeudpConnection::connect(default_config(100), t).expect("connect");
+
+    let syn = client.poll_transmit(t).expect("SYN");
+    let syn_data_ex = syn_data_ex_of(&syn);
+
+    assert_eq!(syn_data_ex.udp_ver, UdpVersion::V3);
+    assert_eq!(
+        syn_data_ex.cookie_hash,
+        Some(TEST_COOKIE_HASH),
+        "[MS-RDPEUDP] 2.2.2.9 requires the hash alongside version 3"
+    );
+}
+
+#[test]
+fn the_syn_ack_advertises_version_3_without_a_cookie_hash() {
+    let t = now();
+
+    let mut client = RdpeudpConnection::connect(default_config(100), t).expect("connect");
+    let syn = client.poll_transmit(t).expect("SYN");
+    let syn_dg: V1Datagram = decode(&syn.contents).expect("decode SYN");
+
+    let mut server = RdpeudpConnection::accept(default_config(200), &syn_dg, t).expect("accept");
+    let syn_ack = server.poll_transmit(t).expect("SYN+ACK");
+    let syn_data_ex = syn_data_ex_of(&syn_ack);
+
+    assert_eq!(syn_data_ex.udp_ver, UdpVersion::V3);
+    assert_eq!(
+        syn_data_ex.cookie_hash, None,
+        "2.2.2.9: the hash belongs in the client's SYN and \"MUST NOT be present in any other case\""
+    );
+}
+
+#[test]
+fn connect_refuses_to_build_a_version_3_syn_without_a_cookie_hash() {
+    let config = ConnectionConfig {
+        cookie_hash: None,
+        ..default_config(100)
+    };
+
+    RdpeudpConnection::connect(config, now()).expect_err("a version 3 SYN must carry the hash");
+}
+
+#[test]
+fn a_server_rejects_a_syn_offering_a_version_below_3() {
+    let t = now();
+
+    let syn = V1Datagram {
+        header: FecHeader {
+            sn_source_ack: 0xFFFF_FFFF,
+            receive_window_size: 64,
+            flags: V1Flags::SYN | V1Flags::SYNEX,
+        },
+        ack_vector: None,
+        ack_of_acks: None,
+        syn_data: Some(SynDataPayload {
+            initial_sequence_number: 100,
+            upstream_mtu: 1232,
+            downstream_mtu: 1232,
+        }),
+        correlation_id: None,
+        syn_data_ex: Some(SynDataExPayload {
+            syn_ex_flags: SynExFlags::VERSION_INFO_VALID,
+            // 0x0002 means the MS-RDPEUDP data transfer, not MS-RDPEUDP2.
+            udp_ver: UdpVersion::V2,
+            cookie_hash: None,
+        }),
+    };
+
+    RdpeudpConnection::accept(default_config(200), &syn, t).expect_err("version 2 is not RDPEUDP2");
+}
+
+#[test]
+fn a_server_rejects_a_syn_whose_cookie_hash_does_not_match() {
+    let t = now();
+
+    let syn = V1Datagram {
+        header: FecHeader {
+            sn_source_ack: 0xFFFF_FFFF,
+            receive_window_size: 64,
+            flags: V1Flags::SYN | V1Flags::SYNEX,
+        },
+        ack_vector: None,
+        ack_of_acks: None,
+        syn_data: Some(SynDataPayload {
+            initial_sequence_number: 100,
+            upstream_mtu: 1232,
+            downstream_mtu: 1232,
+        }),
+        correlation_id: None,
+        syn_data_ex: Some(SynDataExPayload {
+            syn_ex_flags: SynExFlags::VERSION_INFO_VALID,
+            udp_ver: UdpVersion::V3,
+            cookie_hash: Some([0xFF; 32]),
+        }),
+    };
+
+    RdpeudpConnection::accept(default_config(200), &syn, t).expect_err("the hash is for a different cookie");
+}
+
+#[test]
+fn a_client_rejects_a_syn_ack_that_settles_below_version_3() {
+    let t = now();
+    let mut client = RdpeudpConnection::connect(default_config(100), t).expect("connect");
+    client.poll_transmit(t).expect("SYN");
+
+    let syn_ack = V1Datagram {
+        header: FecHeader {
+            sn_source_ack: 100,
+            receive_window_size: 64,
+            flags: V1Flags::SYN | V1Flags::ACK | V1Flags::SYNEX,
+        },
+        ack_vector: None,
+        ack_of_acks: None,
+        syn_data: Some(SynDataPayload {
+            initial_sequence_number: 200,
+            upstream_mtu: 1232,
+            downstream_mtu: 1232,
+        }),
+        correlation_id: None,
+        syn_data_ex: Some(SynDataExPayload {
+            syn_ex_flags: SynExFlags::VERSION_INFO_VALID,
+            udp_ver: UdpVersion::V2,
+            cookie_hash: None,
+        }),
+    };
+
+    let mut bytes = encode_vec(&syn_ack).expect("encode");
+    client
+        .handle_datagram(&mut bytes, later(t, 50))
+        .expect_err("the server settled on the MS-RDPEUDP data transfer");
+    assert!(!client.is_established());
+}
+
+/// A transfer longer than the window survives a loss partway through.
+///
+/// A retransmission carries a fresh DataSeqNum, so the lost one is never
+/// filled and [MS-RDPEUDP2] 3.1.1.2.2 will not let the receiver's lower bound
+/// advance over it. The AckOfAcks payload is the only way past, and 3.1.5.3
+/// has the sender advertise it on exactly this event: "the Sender declares the
+/// packet loss and updates its own next sequence number to wait on. It then
+/// sends the AckOfAcks payload ... so that the Receiver can stop waiting for
+/// any packets with lower sequence numbers to arrive."
+///
+/// Sending the peer's own numbers back instead leaves its window pinned on the
+/// hole, and the transfer stops one window later.
+#[test]
+fn a_transfer_survives_a_loss_in_the_middle() {
+    let (mut client, mut server, t) = establish_pair();
+
+    // Well past the 64-slot window implied by log_window_size 6.
+    let chunk_count = 200usize;
+    for i in 0..chunk_count {
+        let byte = u8::try_from(i % 256).expect("modulo 256 fits in u8");
+        client.send(vec![byte; 4]).expect("send");
+    }
+
+    // The first packet never reaches the server.
+    let _lost = client.poll_transmit(later(t, 100)).expect("first data packet");
+
+    advance(&mut client, &mut server, later(t, 30_000));
+
+    let received = drain_received(&mut server);
+    assert_eq!(
+        received.len(),
+        chunk_count,
+        "the transfer stalled: the receiver's window never moved past the hole"
+    );
+
+    for (i, chunk) in received.iter().enumerate() {
+        let byte = u8::try_from(i % 256).expect("modulo 256 fits in u8");
+        assert_eq!(chunk, &vec![byte; 4], "chunk {i} arrived out of order");
+    }
+}
+
+// ── Dummy packets ──
+//
+// [MS-RDPEUDP2] 3.1.1.1.5: "If Packet_Type_Index is set to 8, then a dummy
+// packet follows the PacketPrefixByte. A dummy packet is treated as a normal
+// RDP-UDP2 packet by the UDP transport. However, loss of this packet MUST not
+// generate a retransmit. In addition, the contents MUST be ignored by higher
+// layers using the UDP transport."
+
+/// Re-frame a v2 packet as a dummy, which is a property of the prefix byte
+/// rather than anything in the header.
+fn as_dummy(transmit: Transmit) -> Vec<u8> {
+    let mut bytes = transmit.contents;
+    let (_, packet) = decode_with_prefix(&mut bytes).expect("prefix");
+    let packet = packet.to_vec();
+
+    let mut wire = Vec::new();
+    encode_with_prefix(&packet, true, &mut wire).expect("re-frame as dummy");
+    wire
+}
+
+#[test]
+fn a_dummy_packets_contents_never_reach_the_application() {
+    let (mut client, mut server, t) = establish_pair();
+
+    client.send(vec![0xD0; 16]).expect("send");
+    let data = client.poll_transmit(later(t, 100)).expect("data packet");
+
+    let mut dummy = as_dummy(data);
+    server.handle_datagram(&mut dummy, later(t, 150)).expect("handle dummy");
+
+    assert!(
+        drain_received(&mut server).is_empty(),
+        "the contents of a dummy packet must be ignored by higher layers"
+    );
+}
+
+/// The transport still accounts for a dummy, because 3.1.1.1.5 has it
+/// "treated as a normal RDP-UDP2 packet by the UDP transport". Its sequence
+/// number is filled and acknowledged like any other, so the sender is not left
+/// retransmitting it forever.
+#[test]
+fn a_dummy_packet_is_still_acknowledged() {
+    let (mut client, mut server, t) = establish_pair();
+
+    client.send(vec![0xD0; 16]).expect("send");
+    let data = client.poll_transmit(later(t, 100)).expect("data packet");
+
+    let mut dummy = as_dummy(data);
+    server.handle_datagram(&mut dummy, later(t, 150)).expect("handle dummy");
+
+    // The delayed-ACK timer is the sign the transport took it as a real packet.
+    let deadline = server.poll_timeout().expect("a timer is armed");
+    server.handle_timeout(deadline);
+    let ack = server.poll_transmit(deadline).expect("an acknowledgment");
+
+    let mut ack_bytes = ack.contents;
+    let (_, packet_bytes) = decode_with_prefix(&mut ack_bytes).expect("prefix");
+    let packet: V2Packet = decode(packet_bytes).expect("decode");
+
+    assert!(
+        packet.ack.is_some() || packet.ack_vector.is_some(),
+        "a dummy packet should still be acknowledged"
+    );
+}
+
+/// A dummy carries a ChannelSeqNum that belongs to no real datum, so taking it
+/// into reassembly would leave the delivery cursor waiting on data nobody will
+/// ever send. Real data on either side of it must still flow.
+#[test]
+fn a_dummy_does_not_disturb_the_channel_sequence() {
+    let (mut client, mut server, t) = establish_pair();
+
+    client.send(vec![0xA1; 8]).expect("send");
+    let mut first = client.poll_transmit(later(t, 100)).expect("first data packet").contents;
+    server.handle_datagram(&mut first, later(t, 110)).expect("handle data");
+    assert_eq!(drain_received(&mut server), vec![vec![0xA1; 8]]);
+
+    // A synthetic dummy, which is what a real sender emits: it takes a
+    // DataSeqNum of its own and its ChannelSeqNum names nothing.
+    let dummy = V2Packet {
+        header: V2Header {
+            flags: V2Flags::DATA,
+            log_window_size: 6,
+        },
+        ack: None,
+        overhead_size: None,
+        delay_ack_info: None,
+        ack_of_acks: None,
+        data_header: Some(DataHeader { data_seq_num: 150 }),
+        ack_vector: None,
+        data_body: Some(DataBody {
+            channel_seq_num: 900,
+            data: vec![0xFF; 8],
+        }),
+    };
+
+    let encoded = encode_vec(&dummy).expect("encode");
+    let mut wire = Vec::new();
+    encode_with_prefix(&encoded, true, &mut wire).expect("prefix as dummy");
+    server.handle_datagram(&mut wire, later(t, 120)).expect("handle dummy");
+
+    assert!(
+        drain_received(&mut server).is_empty(),
+        "the contents of a dummy packet must be ignored"
+    );
+
+    // Real data keeps flowing behind it.
+    client.send(vec![0xA2; 8]).expect("send");
+    let mut second = client
+        .poll_transmit(later(t, 130))
+        .expect("second data packet")
+        .contents;
+    server.handle_datagram(&mut second, later(t, 140)).expect("handle data");
+
+    assert_eq!(
+        drain_received(&mut server),
+        vec![vec![0xA2; 8]],
+        "a dummy must not disturb the channel sequence"
+    );
+}
+
+// ── Segmentation ──
+//
+// [MS-RDPEUDP2] does not segment. 3.1.1.2.4.2 has the receiver strip the
+// ChannelSeqNum and forward "the rest of the data payload to the upper layer
+// immediately", and nothing in the format marks a first or last fragment, so a
+// packet's payload arrives whole or not at all. Anything longer than one
+// packet has to be split before it becomes packets.
+
+/// Every datagram the connection emits fits the MTU, however much the caller
+/// writes at once.
+///
+/// The caller above is a TLS session, which emits records up to about 16 KiB
+/// and knows nothing about datagrams. Passing one of those through as a single
+/// packet produces an IP-fragmented datagram thirteen times the MTU, where one
+/// lost fragment destroys the whole thing and no retransmission can recover a
+/// fragment.
+#[test]
+fn a_write_larger_than_a_packet_is_split_to_fit() {
+    let (mut client, mut server, t) = establish_pair();
+
+    let payload: Vec<u8> = (0..16_384u32)
+        .map(|i| u8::try_from(i % 256).expect("modulo 256 fits in u8"))
+        .collect();
+    client.send(payload.clone()).expect("send");
+
+    let mut packets = 0usize;
+    let mut at = later(t, 100);
+    for _ in 0..2_000 {
+        let mut moved = false;
+
+        while let Some(transmit) = client.poll_transmit(at) {
+            assert!(
+                transmit.contents.len() <= 1232,
+                "a {} byte datagram exceeds the 1232 byte MTU",
+                transmit.contents.len()
+            );
+            packets += 1;
+
+            let mut bytes = transmit.contents;
+            server.handle_datagram(&mut bytes, at).expect("server handles");
+            moved = true;
+        }
+
+        while let Some(transmit) = server.poll_transmit(at) {
+            let mut bytes = transmit.contents;
+            client.handle_datagram(&mut bytes, at).expect("client handles");
+            moved = true;
+        }
+
+        if !moved {
+            let Some(next) = [client.poll_timeout(), server.poll_timeout()]
+                .into_iter()
+                .flatten()
+                .min()
+            else {
+                break;
+            };
+
+            at = next;
+            client.handle_timeout(at);
+            server.handle_timeout(at);
+        }
+    }
+
+    assert!(packets > 1, "16 KiB should not have gone out as one packet");
+
+    let received: Vec<u8> = drain_received(&mut server).concat();
+    assert_eq!(received, payload, "the split payload did not reassemble");
+}
+
+/// The split is sized from the negotiated MTU, not from a fixed guess.
+#[test]
+fn the_payload_limit_follows_the_negotiated_mtu() {
+    let (client, _server, _t) = establish_pair();
+
+    let max_payload = client.max_payload();
+    assert!(max_payload > 0);
+    assert!(
+        max_payload + 7 + 136 <= 1232,
+        "the payload limit leaves no room for framing"
+    );
+}

--- a/crates/ironrdp-testsuite-core/tests/rdpeudp/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeudp/mod.rs
@@ -1,3 +1,4 @@
+mod connection;
 mod pdu_prefix;
 mod pdu_v1_datagram;
 mod pdu_v1_header;
@@ -6,3 +7,4 @@ mod pdu_v2_ack;
 mod pdu_v2_control;
 mod pdu_v2_data;
 mod pdu_v2_packet;
+mod time;

--- a/crates/ironrdp-testsuite-core/tests/rdpeudp/pdu_v1_syn.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeudp/pdu_v1_syn.rs
@@ -192,14 +192,19 @@ fn syndataex_roundtrip_v3_with_cookie() {
     assert_eq!(original, decoded);
 }
 
+/// MS-RDPEUDP 1.7 and 3.1.5.1.3 require a responder to negotiate down to a
+/// version it supports when the peer advertises one it does not recognize.
+/// Decoding an unrecognized `uUdpVer` must therefore succeed and hand back
+/// the raw value, not fail the datagram outright.
 #[test]
-fn syndataex_unknown_version() {
+fn syndataex_unknown_version_decodes_to_the_raw_value() {
     let bytes = [
         0x01, 0x00, // VERSION_INFO_VALID
         0xFF, 0xFF, // unknown version
     ];
-    let result: DecodeResult<SynDataExPayload> = decode(&bytes);
-    assert!(result.is_err());
+    let decoded: SynDataExPayload = decode(&bytes).expect("decode");
+    assert_eq!(decoded.udp_ver, UdpVersion(0xFFFF));
+    assert!(!decoded.udp_ver.uses_v2_wire_format());
 }
 
 #[test]
@@ -213,9 +218,21 @@ fn syndataex_insufficient_bytes() {
 
 #[test]
 fn version_wire_values() {
-    assert_eq!(UdpVersion::V1.as_u16(), 0x0001);
-    assert_eq!(UdpVersion::V2.as_u16(), 0x0002);
-    assert_eq!(UdpVersion::V3.as_u16(), 0x0101);
+    assert_eq!(UdpVersion::V1.0, 0x0001);
+    assert_eq!(UdpVersion::V2.0, 0x0002);
+    assert_eq!(UdpVersion::V3.0, 0x0101);
+}
+
+/// The enum this replaced derived `Hash`; downstream `HashMap`/`HashSet` use
+/// keyed on `UdpVersion` must keep working across the representation change.
+#[test]
+fn version_is_still_usable_as_a_hash_key() {
+    let mut supported = std::collections::HashSet::new();
+    supported.insert(UdpVersion::V1);
+    supported.insert(UdpVersion::V3);
+
+    assert!(supported.contains(&UdpVersion::V1));
+    assert!(!supported.contains(&UdpVersion::V2));
 }
 
 /// Only version 3 selects the MS-RDPEUDP2 data transfer.

--- a/crates/ironrdp-testsuite-core/tests/rdpeudp/time.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeudp/time.rs
@@ -1,0 +1,43 @@
+use core::time::Duration;
+use ironrdp_rdpeudp::*;
+#[test]
+fn duration_since_measures_forward_difference() {
+    let earlier = MonotonicInstant::from_millis(1_000);
+    let later = MonotonicInstant::from_millis(1_750);
+
+    assert_eq!(later.duration_since(earlier), Duration::from_millis(750));
+}
+
+#[test]
+fn duration_since_saturates_when_transposed() {
+    let earlier = MonotonicInstant::from_millis(1_000);
+    let later = MonotonicInstant::from_millis(1_750);
+
+    assert_eq!(earlier.duration_since(later), Duration::ZERO);
+}
+
+#[test]
+fn add_advances_by_the_duration() {
+    let base = MonotonicInstant::from_millis(500);
+
+    assert_eq!(base + Duration::from_millis(250), MonotonicInstant::from_millis(750));
+}
+
+#[test]
+fn add_saturates_at_the_end_of_the_range() {
+    let base = MonotonicInstant::from_millis(u64::MAX - 1);
+
+    assert_eq!(base + Duration::from_secs(60), MonotonicInstant::from_millis(u64::MAX));
+}
+
+#[test]
+fn add_saturates_when_the_duration_itself_overflows() {
+    let base = MonotonicInstant::from_millis(0);
+
+    assert_eq!(base + Duration::MAX, MonotonicInstant::from_millis(u64::MAX));
+}
+
+#[test]
+fn instants_order_by_reading() {
+    assert!(MonotonicInstant::from_millis(1) < MonotonicInstant::from_millis(2));
+}

--- a/typos.toml
+++ b/typos.toml
@@ -23,6 +23,9 @@ extend-exclude = ["*.bin", "*.bmp", "package-lock.json"]
 [default.extend-words]
 # "look-alikes" is a legitimate hyphenated word
 alikes = "alikes"
+# Retransmission timeout, the RFC 6298 term used by the RDP-UDP state machine.
+rto = "rto"
+RTO = "RTO"
 # Windows PostScript printer driver name.
 Imagesetter = "Imagesetter"
 # Windows Plug and Play field names use this abbreviation.
@@ -36,6 +39,8 @@ cose = "cose"
 [default.extend-identifiers]
 # COM FORMATETC target-device field.
 ptd = "ptd"
+# Retransmission timeout, the RFC 6298 term used by the RDP-UDP state machine.
+rto = "rto"
 # Windows TRACKMOUSEEVENT flag.
 TME_LEAVE = "TME_LEAVE"
 # WebAuthn COSE algorithm parameter identifiers / locals.


### PR DESCRIPTION
Fourth of six. Filed against master directly; #1626, #1627 and #1679 have
all merged.

Adds the sans-I/O `RdpeudpConnection` and the machinery it drives: send and
receive windows, loss detection, NewReno congestion control, an RFC 6298 RTT
estimator, the timer table, the reliability controller that matches
retransmissions to the packets they replace, and sequence-number reconstruction
from 16-bit wire values.

This is the largest PR in the stack. I looked at splitting the state machine
from the reliability primitives, but `connection.rs` drives all of them and the
tests span both, so the seam would have been artificial.

## Sans-I/O

No clock, no socket. Time arrives as a `MonotonicInstant` argument and outgoing
packets leave as `Transmit` values. That keeps it testable without a network,
and avoids `std::time::Instant`, whose `now` panics on
`wasm32-unknown-unknown`.

**`MonotonicInstant` is defined here, and #1530 adds one to `ironrdp-connector`
for the same reason.** Two copies of one abstraction is a wart. `ironrdp-core`
looks like the right home to me, and I raised it on #140; happy to move it
wherever you prefer, in this PR or a follow-up.

## Behaviour that is required rather than chosen

**Version 3 in the SYN.** That is the version [MS-RDPEUDP] 1.3.2.2 and the
2.2.2.9 table tie to the MS-RDPEUDP2 data transfer. Version 2 selects the
MS-RDPEUDP one, which this crate does not implement. Version 3 requires the
SHA-256 of the `securityCookie` in the client's SYN (2.2.2.9), so
`ConnectionConfig` carries it, `connect` refuses without it, and the server
performs the check 3.1.5.1.1 asks for.

**The handshake retransmits.** 1.3.1 delivers the SYN, SYN+ACK and ACK by
persistent retransmits whatever mode the transport runs in; 3.1.5.4.1 gives up
after between three and five unanswered tries. A repeated datagram from the peer
draws a repeat of ours rather than an error, including a SYN+ACK arriving after
we have moved on to v2, which is how a client learns its final ACK was lost.

**The delayed-ACK timer tracks the RTT instead of a fixed duration.**
MS-RDPEUDP2 3.1.5.2 gives half the round trip time as the receiver's default.
The handshake round trip seeds the existing RFC 6298 estimator (skipped when
the handshake datagram was retransmitted, per Karn's algorithm), and the
computed timeout is clamped to the 50-200ms band [MS-RDPEUDP] 3.1.6.3 gives a
version-2 connection, since MS-RDPEUDP2 itself states no floor or cap of its
own.

**`UdpVersion` widens from a closed enum to a newtype carrying the raw wire
value.** This is a breaking change to the public API #1627 shipped. MS-RDPEUDP
1.7 and 3.1.5.1.3 require a responder to negotiate down to a version it
supports when the peer advertises one it does not recognize; hard-failing
decode on an unrecognized value made that MUST clause unsatisfiable. Every
call site already used the named constants, so this is the only consequential
part of the change.

**`error.rs` and its `Cargo.toml`/README wiring are back.** #1627 correctly
dropped them at its own narrower, PDU-only scope; this PR's state machine is
what actually needs them.

**The receive window advances on both events in 3.1.1.2.2**, not only on
AckOfAcks. The first one is what fires on a connection that is losing nothing;
without it the window fills one window in and stops accepting.

**AckOfAcks carries our own lowest unacknowledged sequence number** (2.2.1.2.4,
3.1.5.3). It is the only thing that can move a receiver past a packet the sender
gave up on, since the retransmission carries a fresh `DataSeqNum` and the
original is never filled.

**Writes are split to the MTU.** MS-RDPEUDP2 does not segment: 3.1.1.2.4.2
forwards each packet's payload straight up and nothing marks a first or last
fragment. `ChannelSeqNum` looks like it would serve but 3.1.5.5 gives it a
different job, matching a retransmission to the packet it replaces. So anything
longer than one packet is split before it becomes packets.

**Dummy packets** are accounted for by the transport and their contents dropped,
per 3.1.1.1.5.

## Test plan

`cargo xtask check fmt/lints/tests/typos/locks`

179 rdpeudp tests in `ironrdp-testsuite-core` with this PR applied, plus 179
inline unit tests across the crate's components. The connection tests cover a
clean transfer longer than the window, a loss in the middle of one, handshake
retransmission to the give-up limit, the version and cookie negotiation paths,
decoding an unrecognized `uUdpVer`, the ack-delay timeout's RTT-tracking and
clamping behaviour, and the review round's findings: an out-of-range ACK no
longer discards outstanding data, the ACK vector respects its 127-entry wire
limit, `log_window_size` is validated, the ACK builders encode real
timestamps and gaps, the handshake's Karn's-algorithm check is ordered
correctly, the retransmit timer restarts on real progress, `accept` completes
the negotiate-down behaviour, and `send` enforces a buffer bound.
