### PR TITLE
feat(rdpeusb): add the usb translation module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3053,6 +3053,7 @@ dependencies = [
  "ironrdp-dvc",
  "ironrdp-pdu",
  "ironrdp-str",
+ "ironrdp-usb",
 ]
 
 [[package]]

--- a/crates/ironrdp-rdpeusb/Cargo.toml
+++ b/crates/ironrdp-rdpeusb/Cargo.toml
@@ -24,6 +24,7 @@ std = []
 ironrdp-core = { path = "../ironrdp-core", version = "0.2", features = ["alloc"] } # public
 ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9", features = ["alloc"] } # public
 ironrdp-dvc = { path = "../ironrdp-dvc", version = "0.8" } # public
+ironrdp-usb = { path = "../ironrdp-usb", version = "0.1" } # public
 ironrdp-str = { path = "../ironrdp-str", version = "0.1" }
 
 [lints]

--- a/crates/ironrdp-rdpeusb/README.md
+++ b/crates/ironrdp-rdpeusb/README.md
@@ -3,6 +3,11 @@
 Implements [Remote Desktop Protocol: USB Devices Virtual Channel Extension][spec]
 used to redirect USB devices from a terminal client to a terminal server.
 
+The `usb` module translates protocol-independent operations and descriptor
+semantics from `ironrdp-usb` into complete backend-facing RDPEUSB transfer
+requests. It is sans-I/O and does not allocate request IDs or manage pending
+request lifetimes.
+
 [spec]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeusb/a1004d0e-99e9-4968-894b-0b924ef2f125
 
 This crate is part of the [IronRDP] project.

--- a/crates/ironrdp-rdpeusb/src/io/device.rs
+++ b/crates/ironrdp-rdpeusb/src/io/device.rs
@@ -34,6 +34,7 @@ use alloc::{format, string::String, vec, vec::Vec};
 use ironrdp_pdu::{PduResult, pdu_other_err};
 use ironrdp_str::multi_sz::MultiSzString;
 use ironrdp_str::prefixed::Cch32String;
+use ironrdp_usb::BcdVersion;
 
 use crate::pdu::header::{InterfaceId, MessageId};
 use crate::pdu::sink::{
@@ -129,7 +130,7 @@ pub struct UsbDeviceDescriptorInfo {
     pub vendor_id: u16,
     pub product_id: u16,
     pub device_version: u16,
-    pub usb_version: UsbBcdVersion,
+    pub usb_version: BcdVersion,
     pub class_codes: UsbClassCodes,
     pub num_configurations: u8,
 }
@@ -160,33 +161,6 @@ impl UsbClassCodes {
         sub_class_code: 0x00,
         protocol_code: 0x00,
     };
-}
-
-/// Raw `bcdUSB` value from the USB device descriptor.
-///
-/// The value is preserved without BCD validation. RDPEUSB supports only
-/// USB 1.0, 1.1, and 2.0, so newer values are advertised as USB 2.0.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct UsbBcdVersion(u16);
-impl UsbBcdVersion {
-    /// Wraps a raw `bcdUSB` value without validating its BCD digits.
-    pub const fn from_bcd(value: u16) -> Self {
-        Self(value)
-    }
-
-    fn to_supported_usb_version(self) -> SupportedUsbVer {
-        if self.0 >= 0x0200 {
-            SupportedUsbVer::USB_20
-        } else if self.0 >= 0x0110 {
-            SupportedUsbVer::USB_11
-        } else {
-            SupportedUsbVer::USB_10
-        }
-    }
-
-    fn is_at_least_usb20(self) -> bool {
-        self.0 >= 0x0200
-    }
 }
 
 /// Connection speed reported by the USB backend.
@@ -293,13 +267,30 @@ fn usb_device_caps(info: &DeviceInfo) -> PduResult<UsbDeviceCaps> {
     Ok(UsbDeviceCaps {
         usb_bus_iface_ver: UsbBusIfaceVer::V2,
         usbdi_ver: UsbdiVer::V0X600,
-        supported_usb_ver: info.descriptor.usb_version.to_supported_usb_version(),
+        supported_usb_ver: supported_usb_version(info.descriptor.usb_version),
         device_speed: device_speed(info)?,
         no_ack_isoch_write_jitter_buf_size: NoAckIsochWriteJitterBufSizeInMs::try_from(
             DEFAULT_NO_ACK_ISOCH_WRITE_JITTER_MS,
         )
         .map_err(|_| pdu_other_err!("default isochronous jitter buffer size is invalid"))?,
     })
+}
+
+/// Map `bcdUSB` onto the RDPEUSB capability field.
+///
+/// The PDU enum models only USB 1.0, 1.1, and 2.0, so newer versions are advertised as USB 2.0.
+fn supported_usb_version(usb_version: BcdVersion) -> SupportedUsbVer {
+    if is_at_least_usb20(usb_version) {
+        SupportedUsbVer::USB_20
+    } else if usb_version.raw() >= 0x0110 {
+        SupportedUsbVer::USB_11
+    } else {
+        SupportedUsbVer::USB_10
+    }
+}
+
+fn is_at_least_usb20(usb_version: BcdVersion) -> bool {
+    usb_version.raw() >= 0x0200
 }
 
 fn device_speed(info: &DeviceInfo) -> PduResult<DeviceSpeed> {
@@ -309,7 +300,7 @@ fn device_speed(info: &DeviceInfo) -> PduResult<DeviceSpeed> {
             Ok(DeviceSpeed::HIGH_SPEED)
         }
         UsbConnectionSpeed::Unknown => {
-            if info.descriptor.usb_version.is_at_least_usb20() {
+            if is_at_least_usb20(info.descriptor.usb_version) {
                 Ok(DeviceSpeed::HIGH_SPEED)
             } else {
                 Ok(DeviceSpeed::FULL_SPEED)

--- a/crates/ironrdp-rdpeusb/src/io/mod.rs
+++ b/crates/ironrdp-rdpeusb/src/io/mod.rs
@@ -57,6 +57,15 @@ pub struct DeviceText {
     pub description: String,
 }
 
+/// Wrapper for the completion of RDPEUSB request.
+#[derive(Debug)]
+pub enum CompletionData {
+    IoControl(IoControlCompletionResult),
+    InternalIoControl(IoControlCompletionResult),
+    TransferIn(TransferInCompletionResult),
+    TransferOut(TransferOutCompletionResult),
+}
+
 /// Completion of an I/O control request.
 ///
 /// This completes either an [`IoControlPacket`] or an [`InternalIoControlPacket`]. The request ID

--- a/crates/ironrdp-rdpeusb/src/lib.rs
+++ b/crates/ironrdp-rdpeusb/src/lib.rs
@@ -9,6 +9,7 @@ pub mod client;
 pub mod io;
 pub mod pdu;
 pub mod server;
+pub mod usb;
 
 /// Error returned when a per-device USB interface ID conflicts with an RDPEUSB default interface.
 ///

--- a/crates/ironrdp-rdpeusb/src/usb.rs
+++ b/crates/ironrdp-rdpeusb/src/usb.rs
@@ -1,0 +1,1201 @@
+//! Translation from protocol-independent USB semantics to RDPEUSB requests.
+//!
+//! This module is deliberately sans-I/O. It does not know about usbredir
+//! packets, RDPEUSB request IDs, device state, completion routing, or async
+//! execution. Each function returns a complete backend-facing RDPEUSB transfer
+//! packet so that the TS_URB payload, URB function, transfer envelope, flags,
+//! and buffer shape cannot disagree.
+//!
+//! The adapter belongs to RDPEUSB because it selects TS_URB forms and
+//! Windows USBD conventions; the input types remain protocol-independent.
+
+use alloc::vec::Vec;
+use core::fmt;
+
+use crate::{
+    io::{
+        CompletionData, IoControlPacket, TransferInCompletionResult, TransferInPacket, TransferOutPacket, TsUrbInKind,
+        TsUrbInPacket, TsUrbOutKind, TsUrbOutPacket, UrbFunction,
+    },
+    pdu::{
+        completion::ts_urb_result::{TsUrbResultPayload, TsUrbSelectConfigResult, TsUrbSelectInterfaceResult},
+        usb_dev::IoctlInternalUsb,
+        usb_dev::ts_urb::{
+            TsUrbBulkOrInterruptTransfer, TsUrbControlDescRequest, TsUrbControlFeatRequest,
+            TsUrbControlGetConfigRequest, TsUrbControlGetInterfaceRequest, TsUrbControlGetStatusRequest,
+            TsUrbControlTransfer, TsUrbControlVendorClassRequest, TsUrbGetCurrFrameNum, TsUrbIsochTransfer,
+            TsUrbPipeRequest, TsUrbSelectConfig, TsUrbSelectInterface,
+            utils::{SetupPacket as RdpeusbSetupPacket, TsUsbdInterfaceInfo, TsUsbdPipeInfo, UsbConfigDesc},
+        },
+        utils::{ConfigHandle, PipeHandle, UsbdIsoPacketDesc},
+    },
+};
+use ironrdp_usb::{
+    Direction, InterfaceSelection, TransferType, UsbSpeed,
+    control::{GetDescriptorRequest, Recipient, RequestKind, SetupPacket, standard_request},
+    descriptor::{ConfigurationDescriptorSet, InterfaceDescriptor, ValidConfigurationDescriptorSet},
+    transfer::{
+        DataTransferRequest, FrameNumber, IsoCompletion, IsochronousPacketCompletion, IsochronousTransferOutput,
+        IsochronousTransferRequest, TransferCompletion, UsbError, UsbResult,
+    },
+};
+
+// WDK USBD transfer flags. RDPEUSB carries these values unchanged in TS_URB.
+const USBD_TRANSFER_DIRECTION_IN: u32 = 0x0000_0001;
+const USBD_SHORT_TRANSFER_OK: u32 = 0x0000_0002;
+const USBD_DEFAULT_PIPE_TRANSFER: u32 = 0x0000_0008;
+const USBD_START_ISO_TRANSFER_ASAP: u32 = 0x0000_0004;
+
+// Windows USBD status values carried unchanged in TS_URB_RESULT_HEADER.
+const USBD_STATUS_SUCCESS: u32 = 0x0000_0000;
+const USBD_STATUS_STALL_PID: u32 = 0xc000_0004;
+const USBD_STATUS_BABBLE_DETECTED: u32 = 0xc000_0012;
+const USBD_STATUS_CANCELED: u32 = 0xc001_0000;
+const USBD_STATUS_TIMEOUT: u32 = 0xc000_6000;
+const USBD_STATUS_DEVICE_GONE: u32 = 0xc000_7000;
+
+// MS-ERREF 2.1 defines bit 31 as the HRESULT severity bit.
+const HRESULT_FAILURE_BIT: u32 = 0x8000_0000;
+
+// A Windows URB addresses the default control endpoint with a null pipe
+// handle and USBD_DEFAULT_PIPE_TRANSFER. This is a Windows URB convention,
+// rather than an RDPEUSB-assigned pipe handle.
+const DEFAULT_CONTROL_PIPE_HANDLE: PipeHandle = 0;
+
+/// A complete RDPEUSB transfer request, before request-ID allocation and I/O.
+#[derive(Debug, Clone)]
+pub enum TransferRequest {
+    /// An RDPEUSB `TRANSFER_IN_REQUEST` envelope.
+    In(TransferInPacket),
+    /// An RDPEUSB `TRANSFER_OUT_REQUEST` envelope.
+    Out(TransferOutPacket),
+}
+
+/// A USB operation that cannot be represented by the requested RDPEUSB form.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ConversionError {
+    InTransferHasData { actual: usize },
+    OutTransferLengthMismatch { expected: usize, actual: usize },
+    TransferLengthNotRepresentable { length: u32 },
+    UnsupportedDescriptorRecipient { recipient: Recipient },
+    StatefulStandardRequest { request: u8 },
+    InvalidConfigurationHeaderLength { actual: u8 },
+    DuplicateInterface { interface: u8 },
+    InterfaceNotFound { selection: InterfaceSelection },
+    MissingInterfaceSelection { interface: u8 },
+    InvalidMaximumPacketSize { selection: InterfaceSelection, raw: u16 },
+    EmptyIsochronousTransfer,
+    IsochronousTransferLengthOverflow { packet: usize },
+    NoAckIsochronousIn,
+}
+
+impl fmt::Display for ConversionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InTransferHasData { actual } => {
+                write!(f, "USB IN transfer carries {actual} bytes of output data")
+            }
+            Self::OutTransferLengthMismatch { expected, actual } => write!(
+                f,
+                "USB OUT transfer declares {expected} bytes but carries {actual} bytes"
+            ),
+            Self::TransferLengthNotRepresentable { length } => {
+                write!(f, "USB transfer length {length} does not fit in usize")
+            }
+            Self::UnsupportedDescriptorRecipient { recipient } => write!(
+                f,
+                "RDPEUSB has no typed descriptor request for USB recipient {}",
+                recipient.raw()
+            ),
+            Self::StatefulStandardRequest { request } => write!(
+                f,
+                "USB standard request {:#04x} requires host-controller state and cannot use a generic RDPEUSB control transfer",
+                request
+            ),
+            Self::InvalidConfigurationHeaderLength { actual } => write!(
+                f,
+                "RDPEUSB requires a 9-byte USB configuration header, got {actual} bytes"
+            ),
+            Self::DuplicateInterface { interface } => {
+                write!(f, "USB interface {interface} is selected more than once")
+            }
+            Self::InterfaceNotFound { selection } => write!(
+                f,
+                "USB interface {} alternate setting {} is absent from the configuration",
+                selection.interface, selection.alternate_setting
+            ),
+            Self::MissingInterfaceSelection { interface } => write!(
+                f,
+                "USB configuration has no selected alternate setting for interface {}",
+                interface
+            ),
+            Self::InvalidMaximumPacketSize { selection, raw } => write!(
+                f,
+                "USB interface {} alternate setting {} has invalid wMaxPacketSize {raw:#06x}",
+                selection.interface, selection.alternate_setting
+            ),
+            Self::EmptyIsochronousTransfer => f.write_str("USB isochronous transfer contains no packets"),
+            Self::IsochronousTransferLengthOverflow { packet } => {
+                write!(f, "USB isochronous transfer length overflows u32 at packet {packet}")
+            }
+            Self::NoAckIsochronousIn => f.write_str("RDPEUSB NoAck is not valid for an isochronous IN transfer"),
+        }
+    }
+}
+
+impl core::error::Error for ConversionError {}
+
+/// An RDPEUSB completion that does not match the submitted USB operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CompletionError {
+    ExpectedTransferIn,
+    ExpectedTransfer,
+    ExpectedIoControl,
+    UnexpectedUrbResultPayload,
+    MissingSelectConfigurationResult,
+    MissingSelectInterfaceResult,
+    MissingCurrentFrameNumberResult,
+    MissingIsochronousResult,
+    UnexpectedOutputData { actual: usize },
+    ExpectedOneByteOutput { actual: usize },
+    OutputLengthTooLarge { actual: usize },
+    IsochronousPacketCountMismatch { expected: usize, actual: usize },
+    IsochronousPacketLengthExceeded { packet: usize, requested: u32, actual: u32 },
+    IsochronousTransferLengthOverflow,
+    IsochronousDataLengthMismatch { expected: u32, actual: u32 },
+}
+
+impl fmt::Display for CompletionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ExpectedTransferIn => f.write_str("expected an RDPEUSB transfer-in completion"),
+            Self::ExpectedTransfer => f.write_str("expected an RDPEUSB transfer completion"),
+            Self::ExpectedIoControl => f.write_str("expected an RDPEUSB IO-control completion"),
+            Self::UnexpectedUrbResultPayload => {
+                f.write_str("RDPEUSB completion contains an unexpected TS_URB result payload")
+            }
+            Self::MissingSelectConfigurationResult => {
+                f.write_str("RDPEUSB completion does not contain a select-configuration result")
+            }
+            Self::MissingSelectInterfaceResult => {
+                f.write_str("RDPEUSB completion does not contain a select-interface result")
+            }
+            Self::MissingCurrentFrameNumberResult => {
+                f.write_str("RDPEUSB completion does not contain a current-frame-number result")
+            }
+            Self::MissingIsochronousResult => {
+                f.write_str("RDPEUSB completion does not contain an isochronous-transfer result")
+            }
+            Self::UnexpectedOutputData { actual } => {
+                write!(f, "RDPEUSB completion unexpectedly contains {actual} output bytes")
+            }
+            Self::ExpectedOneByteOutput { actual } => {
+                write!(f, "RDPEUSB completion contains {actual} output bytes instead of one")
+            }
+            Self::OutputLengthTooLarge { actual } => {
+                write!(f, "RDPEUSB completion output length {actual} does not fit in u32")
+            }
+            Self::IsochronousPacketCountMismatch { expected, actual } => write!(
+                f,
+                "RDPEUSB isochronous completion contains {actual} packets instead of {expected}"
+            ),
+            Self::IsochronousPacketLengthExceeded {
+                packet,
+                requested,
+                actual,
+            } => write!(
+                f,
+                "RDPEUSB isochronous packet {packet} returned {actual} bytes for a {requested}-byte request"
+            ),
+            Self::IsochronousTransferLengthOverflow => {
+                f.write_str("RDPEUSB isochronous completion length overflows u32")
+            }
+            Self::IsochronousDataLengthMismatch { expected, actual } => write!(
+                f,
+                "RDPEUSB isochronous completion carries {actual} bytes instead of {expected}"
+            ),
+        }
+    }
+}
+
+impl core::error::Error for CompletionError {}
+
+/// Build a typed RDPEUSB GET_DESCRIPTOR request.
+///
+/// RDPEUSB only defines typed descriptor URBs for device, interface, and
+/// endpoint recipients. [`control_transfer`] falls back to a generic control
+/// URB for other recipients, while this explicitly typed helper returns an
+/// error.
+pub fn get_descriptor(request: GetDescriptorRequest) -> Result<TransferInPacket, ConversionError> {
+    let func = descriptor_function(request.recipient, DescriptorOperation::Get).ok_or(
+        ConversionError::UnsupportedDescriptorRecipient {
+            recipient: request.recipient,
+        },
+    )?;
+    let urb = TsUrbControlDescRequest {
+        index: request.descriptor_index,
+        desc_type: request.descriptor_type,
+        lang_id: request.index,
+    };
+
+    Ok(transfer_in(
+        TsUrbInKind::CtlDescReq(urb),
+        func,
+        u32::from(request.requested_length),
+    ))
+}
+
+/// Translate an RDPEUSB `GET_DESCRIPTOR` completion into general USB semantics.
+///
+/// A USB operation failure is returned as the [`UsbResult`] error. This
+/// function returns [`CompletionError`] only when the completion envelope does
+/// not match the submitted operation.
+///
+/// [MS-RDPEUSB 2.2.9.9] requires descriptor reads to use
+/// `TRANSFER_IN_REQUEST`; the corresponding result has only
+/// `TS_URB_RESULT_HEADER` plus the optional data buffer carried by
+/// [`URB_COMPLETION`][MS-RDPEUSB 2.2.7.2].
+///
+/// [MS-RDPEUSB 2.2.9.9]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeusb/a1004d0e-99e9-4968-894b-0b924ef2f125
+/// [MS-RDPEUSB 2.2.7.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeusb/5bfa9c84-a74b-4942-9d09-e770b21081eb
+pub fn get_descriptor_completion(completion: CompletionData) -> Result<UsbResult<Vec<u8>>, CompletionError> {
+    let completion = header_only_transfer_in(completion)?;
+
+    let status = completion_status(completion.hresult, completion.ts_urb_result.header.usbd_status);
+    Ok(status.map(|()| completion.output_buffer))
+}
+
+/// Translate a header-only RDPEUSB transfer completion into general USB data
+/// transfer semantics.
+///
+/// This covers control, bulk, and interrupt transfers. The completion
+/// envelope determines the direction: transfer-in data is returned verbatim,
+/// while transfer-out reports its completed byte count and an empty data
+/// buffer.
+pub fn transfer_completion(completion: CompletionData) -> Result<TransferCompletion<Vec<u8>>, CompletionError> {
+    match completion {
+        CompletionData::TransferIn(completion) => {
+            if completion.ts_urb_result.payload.is_some() {
+                return Err(CompletionError::UnexpectedUrbResultPayload);
+            }
+            let actual_length =
+                u32::try_from(completion.output_buffer.len()).map_err(|_| CompletionError::OutputLengthTooLarge {
+                    actual: completion.output_buffer.len(),
+                })?;
+
+            Ok(TransferCompletion {
+                status: completion_status(completion.hresult, completion.ts_urb_result.header.usbd_status),
+                actual_length,
+                data: completion.output_buffer,
+            })
+        }
+        CompletionData::TransferOut(completion) => {
+            if completion.ts_urb_result.payload.is_some() {
+                return Err(CompletionError::UnexpectedUrbResultPayload);
+            }
+
+            Ok(TransferCompletion {
+                status: completion_status(completion.hresult, completion.ts_urb_result.header.usbd_status),
+                actual_length: completion.output_buffer_size,
+                data: Vec::new(),
+            })
+        }
+        CompletionData::IoControl(_) | CompletionData::InternalIoControl(_) => Err(CompletionError::ExpectedTransfer),
+    }
+}
+
+/// Build an RDPEUSB `GET_CONFIGURATION` request.
+#[must_use]
+pub fn get_configuration() -> TransferInPacket {
+    transfer_in(
+        TsUrbInKind::CtlGetConfig(TsUrbControlGetConfigRequest),
+        UrbFunction::URB_FUNCTION_GET_CONFIGURATION,
+        1,
+    )
+}
+
+/// Translate an RDPEUSB `GET_CONFIGURATION` completion.
+pub fn get_configuration_completion(completion: CompletionData) -> Result<UsbResult<u8>, CompletionError> {
+    byte_transfer_in_completion(completion)
+}
+
+/// Build an RDPEUSB `GET_INTERFACE` request.
+#[must_use]
+pub fn get_interface(interface: u8) -> TransferInPacket {
+    transfer_in(
+        TsUrbInKind::CtlGetIface(TsUrbControlGetInterfaceRequest {
+            interface: u16::from(interface),
+        }),
+        UrbFunction::URB_FUNCTION_GET_INTERFACE,
+        1,
+    )
+}
+
+/// Translate an RDPEUSB `GET_INTERFACE` completion.
+pub fn get_interface_completion(completion: CompletionData) -> Result<UsbResult<u8>, CompletionError> {
+    byte_transfer_in_completion(completion)
+}
+
+/// Translate a default-control-pipe USB request into an RDPEUSB transfer.
+///
+/// Canonical standard, class, and vendor requests use the operation-specific
+/// TS_URB forms from MS-RDPEUSB sections 2.2.9.9 through 2.2.9.14. Other setup
+/// packets are preserved losslessly in `TS_URB_CONTROL_TRANSFER`. Requests
+/// whose execution changes host-controller state must be handled by the
+/// owning state layer instead of this function.
+pub fn control_transfer(setup: SetupPacket, data: Vec<u8>) -> Result<TransferRequest, ConversionError> {
+    validate_control_data(setup, &data)?;
+    if let Some(request) = setup.standard_request() {
+        if matches!(
+            request,
+            standard_request::SET_ADDRESS | standard_request::SET_CONFIGURATION | standard_request::SET_INTERFACE
+        ) {
+            return Err(ConversionError::StatefulStandardRequest { request });
+        }
+    }
+
+    let data = if setup.request_type.kind() == RequestKind::STANDARD {
+        match standard_control_transfer(setup, data) {
+            Ok(request) => return Ok(request),
+            Err(data) => data,
+        }
+    } else if matches!(setup.request_type.kind(), RequestKind::CLASS | RequestKind::VENDOR) {
+        if let Some(func) = vendor_or_class_function(setup.request_type.kind(), setup.request_type.recipient()) {
+            let urb = TsUrbControlVendorClassRequest {
+                transfer_flags: in_transfer_flags(setup.request_type.direction()),
+                request: setup.request,
+                value: setup.value,
+                index: setup.index,
+            };
+            return Ok(match setup.request_type.direction() {
+                Direction::In => TransferRequest::In(transfer_in(
+                    TsUrbInKind::VendorClassReq(urb),
+                    func,
+                    u32::from(setup.length),
+                )),
+                Direction::Out => TransferRequest::Out(transfer_out(TsUrbOutKind::VendorClassReq(urb), func, data)),
+            });
+        }
+        data
+    } else {
+        data
+    };
+
+    Ok(generic_control_transfer(setup, data))
+}
+
+/// Build an RDPEUSB bulk or interrupt IN transfer.
+#[must_use]
+fn bulk_or_interrupt_in(pipe_handle: PipeHandle, requested_length: u32) -> TransferInPacket {
+    transfer_in(
+        TsUrbInKind::BulkInterruptTransfer(TsUrbBulkOrInterruptTransfer {
+            pipe_handle,
+            transfer_flags: USBD_TRANSFER_DIRECTION_IN | USBD_SHORT_TRANSFER_OK,
+        }),
+        UrbFunction::URB_FUNCTION_BULK_OR_INTERRUPT_TRANSFER,
+        requested_length,
+    )
+}
+
+/// Build an RDPEUSB bulk or interrupt OUT transfer.
+#[must_use]
+fn bulk_or_interrupt_out(pipe_handle: PipeHandle, data: Vec<u8>) -> TransferOutPacket {
+    transfer_out(
+        TsUrbOutKind::BulkInterruptTransfer(TsUrbBulkOrInterruptTransfer {
+            pipe_handle,
+            transfer_flags: 0,
+        }),
+        UrbFunction::URB_FUNCTION_BULK_OR_INTERRUPT_TRANSFER,
+        data,
+    )
+}
+
+/// Build an RDPEUSB bulk or interrupt transfer from general USB semantics.
+pub fn bulk_or_interrupt(
+    pipe_handle: PipeHandle,
+    request: DataTransferRequest<Vec<u8>>,
+) -> Result<TransferRequest, ConversionError> {
+    match request.endpoint.direction() {
+        Direction::In => {
+            if !request.data.is_empty() {
+                return Err(ConversionError::InTransferHasData {
+                    actual: request.data.len(),
+                });
+            }
+
+            Ok(TransferRequest::In(bulk_or_interrupt_in(pipe_handle, request.length)))
+        }
+        Direction::Out => {
+            let expected = usize::try_from(request.length)
+                .map_err(|_| ConversionError::TransferLengthNotRepresentable { length: request.length })?;
+            if request.data.len() != expected {
+                return Err(ConversionError::OutTransferLengthMismatch {
+                    expected,
+                    actual: request.data.len(),
+                });
+            }
+
+            Ok(TransferRequest::Out(bulk_or_interrupt_out(pipe_handle, request.data)))
+        }
+    }
+}
+
+/// Build an RDPEUSB isochronous transfer.
+///
+/// Packet lengths are translated into the prefix offsets required by
+/// `USBD_ISO_PACKET_DESCRIPTOR`. Its request-side `Length` and `Status` fields
+/// are output-only and are therefore set to zero.
+pub fn isochronous(
+    pipe_handle: PipeHandle,
+    request: IsochronousTransferRequest<Vec<u8>, Vec<u32>>,
+    no_ack: bool,
+) -> Result<TransferRequest, ConversionError> {
+    let IsochronousTransferRequest {
+        endpoint,
+        start_frame,
+        data,
+        packets,
+    } = request;
+    if packets.is_empty() {
+        return Err(ConversionError::EmptyIsochronousTransfer);
+    }
+
+    let mut total_length = 0u32;
+    let mut iso_packet = Vec::with_capacity(packets.len());
+    for (packet, length) in packets.into_iter().enumerate() {
+        iso_packet.push(UsbdIsoPacketDesc {
+            offset: total_length,
+            length: 0,
+            status: 0,
+        });
+        total_length = total_length
+            .checked_add(length)
+            .ok_or(ConversionError::IsochronousTransferLengthOverflow { packet })?;
+    }
+
+    let direction = endpoint.direction();
+    if no_ack && direction == Direction::In {
+        return Err(ConversionError::NoAckIsochronousIn);
+    }
+    match direction {
+        Direction::In if !data.is_empty() => {
+            return Err(ConversionError::InTransferHasData { actual: data.len() });
+        }
+        Direction::Out => {
+            let expected = usize::try_from(total_length)
+                .map_err(|_| ConversionError::TransferLengthNotRepresentable { length: total_length })?;
+            if data.len() != expected {
+                return Err(ConversionError::OutTransferLengthMismatch {
+                    expected,
+                    actual: data.len(),
+                });
+            }
+        }
+        Direction::In => {}
+    }
+
+    let transfer_flags = match direction {
+        Direction::In => USBD_TRANSFER_DIRECTION_IN,
+        Direction::Out => 0,
+    } | if start_frame.is_none() {
+        USBD_START_ISO_TRANSFER_ASAP
+    } else {
+        0
+    };
+    let urb = TsUrbIsochTransfer {
+        pipe_handle,
+        transfer_flags,
+        start_frame: start_frame.unwrap_or(0),
+        error_count: 0,
+        iso_packet,
+    };
+
+    Ok(match direction {
+        Direction::In => TransferRequest::In(transfer_in(
+            TsUrbInKind::IsochTransfer(urb),
+            UrbFunction::URB_FUNCTION_ISOCH_TRANSFER,
+            total_length,
+        )),
+        Direction::Out => {
+            let mut packet = transfer_out(
+                TsUrbOutKind::IsochTransfer(urb),
+                UrbFunction::URB_FUNCTION_ISOCH_TRANSFER,
+                data,
+            );
+            packet.ts_urb.no_ack = no_ack;
+            TransferRequest::Out(packet)
+        }
+    })
+}
+
+/// Build an RDPEUSB unconfigure request selecting configuration zero.
+#[must_use]
+pub fn unconfigure() -> TransferInPacket {
+    transfer_in(
+        TsUrbInKind::SelectConfig(TsUrbSelectConfig {
+            usbd_ifaces: Vec::new(),
+            desc: None,
+        }),
+        UrbFunction::URB_FUNCTION_SELECT_CONFIGURATION,
+        0,
+    )
+}
+
+/// Build an RDPEUSB select-configuration request.
+///
+/// The complete descriptor set is included, and `active_interfaces` determines
+/// the alternate setting requested for every interface number. The interface
+/// array preserves caller order. Configuration zero is selected by
+/// [`unconfigure`] instead.
+///
+/// `TS_URB_SELECT_CONFIGURATION` carries the descriptor's declared counts
+/// verbatim next to a pipe array derived from the descriptors actually
+/// present, so a validated set is required to keep the two consistent.
+pub fn select_configuration(
+    descriptor: ValidConfigurationDescriptorSet<'_>,
+    active_interfaces: &[InterfaceSelection],
+    speed: UsbSpeed,
+) -> Result<TransferInPacket, ConversionError> {
+    let descriptor = descriptor.as_set();
+
+    let mut usbd_ifaces = Vec::with_capacity(active_interfaces.len());
+    for (index, selection) in active_interfaces.iter().copied().enumerate() {
+        if active_interfaces[..index]
+            .iter()
+            .any(|previous| previous.interface == selection.interface)
+        {
+            return Err(ConversionError::DuplicateInterface {
+                interface: selection.interface,
+            });
+        }
+        let interface = descriptor
+            .interface(selection.interface, selection.alternate_setting)
+            .ok_or(ConversionError::InterfaceNotFound { selection })?;
+        usbd_ifaces.push(interface_information(interface, speed)?);
+    }
+    for interface in descriptor.interfaces() {
+        if !active_interfaces
+            .iter()
+            .any(|selection| selection.interface == interface.number())
+        {
+            return Err(ConversionError::MissingInterfaceSelection {
+                interface: interface.number(),
+            });
+        }
+    }
+    Ok(transfer_in(
+        TsUrbInKind::SelectConfig(TsUrbSelectConfig {
+            usbd_ifaces,
+            desc: Some(configuration_descriptor(descriptor)?),
+        }),
+        UrbFunction::URB_FUNCTION_SELECT_CONFIGURATION,
+        0,
+    ))
+}
+
+/// Build an RDPEUSB select-interface request.
+///
+/// `descriptor` must describe the configuration `config_handle` refers to, and
+/// `selection` names the interface number and the alternate setting to
+/// activate. The request carries no descriptor bytes: the client matches the
+/// pipe array against the descriptor it retained from the earlier
+/// select-configuration, which is why a validated set is required here too.
+pub fn select_interface(
+    config_handle: ConfigHandle,
+    descriptor: ValidConfigurationDescriptorSet<'_>,
+    selection: InterfaceSelection,
+    speed: UsbSpeed,
+) -> Result<TransferInPacket, ConversionError> {
+    let interface = descriptor
+        .as_set()
+        .interface(selection.interface, selection.alternate_setting)
+        .ok_or(ConversionError::InterfaceNotFound { selection })?;
+    let urb = TsUrbSelectInterface {
+        config_handle,
+        usbd_iface: interface_information(interface, speed)?,
+    };
+    Ok(transfer_in(
+        TsUrbInKind::SelectIface(urb),
+        UrbFunction::URB_FUNCTION_SELECT_INTERFACE,
+        0,
+    ))
+}
+
+/// Translate an RDPEUSB select-configuration completion.
+///
+/// The returned configuration and pipe handles are RDPEUSB-private opaque
+/// values. A server facade is expected to validate and retain them, then
+/// expose only the general USB success or failure to its caller.
+pub fn select_configuration_completion(
+    completion: CompletionData,
+) -> Result<UsbResult<TsUrbSelectConfigResult>, CompletionError> {
+    let CompletionData::TransferIn(completion) = completion else {
+        return Err(CompletionError::ExpectedTransferIn);
+    };
+    ensure_empty_output(&completion)?;
+    let Some(TsUrbResultPayload::SelectConfig(result)) = completion.ts_urb_result.payload else {
+        return Err(CompletionError::MissingSelectConfigurationResult);
+    };
+
+    let status = completion_status(completion.hresult, completion.ts_urb_result.header.usbd_status);
+    Ok(status.map(|()| result))
+}
+
+/// Translate an RDPEUSB select-interface completion.
+pub fn select_interface_completion(
+    completion: CompletionData,
+) -> Result<UsbResult<TsUrbSelectInterfaceResult>, CompletionError> {
+    let CompletionData::TransferIn(completion) = completion else {
+        return Err(CompletionError::ExpectedTransferIn);
+    };
+    ensure_empty_output(&completion)?;
+    let Some(TsUrbResultPayload::SelectIface(result)) = completion.ts_urb_result.payload else {
+        return Err(CompletionError::MissingSelectInterfaceResult);
+    };
+
+    let status = completion_status(completion.hresult, completion.ts_urb_result.header.usbd_status);
+    Ok(status.map(|()| result))
+}
+
+/// Build a pipe reset that also clears the endpoint stall state.
+///
+/// [MS-RDPEUSB 2.2.9.4] carries `URB_PIPE_REQUEST` in a transfer-in request
+/// with an empty output buffer.
+///
+/// [MS-RDPEUSB 2.2.9.4]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeusb/dcba564e-de14-4d60-82ac-a0fe7a52b312
+#[must_use]
+pub fn reset_pipe_and_clear_stall(pipe_handle: PipeHandle) -> TransferInPacket {
+    transfer_in(
+        TsUrbInKind::PipeReq(TsUrbPipeRequest { pipe_handle }),
+        UrbFunction::URB_FUNCTION_SYNC_RESET_PIPE_AND_CLEAR_STALL,
+        0,
+    )
+}
+
+/// Translate a header-only RDPEUSB pipe-request completion.
+pub fn pipe_request_completion(completion: CompletionData) -> Result<UsbResult<()>, CompletionError> {
+    unit_transfer_in_completion(completion)
+}
+
+/// Build an RDPEUSB current-frame-number request.
+///
+/// [MS-RDPEUSB 2.2.9.5] carries this URB in a transfer-in request whose output
+/// buffer size is zero; the frame number is part of the TS_URB result.
+///
+/// [MS-RDPEUSB 2.2.9.5]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeusb/4985b1dc-5bd9-4988-97a6-063969dc26b4
+#[must_use]
+pub fn current_frame_number() -> TransferInPacket {
+    transfer_in(
+        TsUrbInKind::GetCurFrameNum(TsUrbGetCurrFrameNum),
+        UrbFunction::URB_FUNCTION_GET_CURRENT_FRAME_NUMBER,
+        0,
+    )
+}
+
+/// Translate an RDPEUSB current-frame-number completion.
+pub fn current_frame_number_completion(completion: CompletionData) -> Result<UsbResult<FrameNumber>, CompletionError> {
+    let CompletionData::TransferIn(completion) = completion else {
+        return Err(CompletionError::ExpectedTransferIn);
+    };
+    ensure_empty_output(&completion)?;
+    let Some(TsUrbResultPayload::FrameNum(result)) = completion.ts_urb_result.payload else {
+        return Err(CompletionError::MissingCurrentFrameNumberResult);
+    };
+
+    let status = completion_status(completion.hresult, completion.ts_urb_result.header.usbd_status);
+    Ok(status.map(|()| result.frame_number))
+}
+
+/// Build an RDPEUSB upstream-port reset request.
+///
+/// [MS-RDPEUSB 2.2.12.1] requires an `IO_CONTROL` request with empty input and
+/// output buffers.
+///
+/// [MS-RDPEUSB 2.2.12.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeusb/8f13c014-2ece-481d-a843-9ae9b03d45fe
+#[must_use]
+pub fn reset_device() -> IoControlPacket {
+    IoControlPacket {
+        ioctl_code: IoctlInternalUsb::ResetPort,
+        input_buffer: Vec::new(),
+        output_buffer_size: 0,
+    }
+}
+
+/// Translate an RDPEUSB upstream-port reset completion.
+pub fn reset_device_completion(completion: CompletionData) -> Result<UsbResult<()>, CompletionError> {
+    let CompletionData::IoControl(completion) = completion else {
+        return Err(CompletionError::ExpectedIoControl);
+    };
+    if !completion.output_buffer.is_empty() {
+        return Err(CompletionError::UnexpectedOutputData {
+            actual: completion.output_buffer.len(),
+        });
+    }
+
+    if hresult_succeeded(completion.hresult) {
+        Ok(Ok(()))
+    } else {
+        Ok(Err(UsbError::Error))
+    }
+}
+
+/// Translate an acknowledged RDPEUSB isochronous completion.
+///
+/// For transfer-in, [MS-RDPEUSB 2.2.10.5] packs only successful packet data
+/// into the output buffer. Packet offsets continue to describe the original
+/// transfer buffer and therefore are not used to slice that packed data.
+///
+/// [MS-RDPEUSB 2.2.10.5]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeusb/6f072673-52b8-4750-ac91-9d2313f13b17
+pub fn isochronous_completion(
+    completion: CompletionData,
+    requested_packet_lengths: &[u32],
+) -> Result<IsoCompletion<Vec<u8>, Vec<IsochronousPacketCompletion>>, CompletionError> {
+    let (ts_urb_result, hresult, output_buffer, envelope_actual_length, transfer_in) = match completion {
+        CompletionData::TransferIn(completion) => {
+            let actual_length =
+                u32::try_from(completion.output_buffer.len()).map_err(|_| CompletionError::OutputLengthTooLarge {
+                    actual: completion.output_buffer.len(),
+                })?;
+            (
+                completion.ts_urb_result,
+                completion.hresult,
+                completion.output_buffer,
+                actual_length,
+                true,
+            )
+        }
+        CompletionData::TransferOut(completion) => (
+            completion.ts_urb_result,
+            completion.hresult,
+            Vec::new(),
+            completion.output_buffer_size,
+            false,
+        ),
+        CompletionData::IoControl(_) | CompletionData::InternalIoControl(_) => {
+            return Err(CompletionError::ExpectedTransfer);
+        }
+    };
+    let Some(TsUrbResultPayload::Isoch(result)) = ts_urb_result.payload else {
+        return Err(CompletionError::MissingIsochronousResult);
+    };
+
+    // Clients such as FreeRDP return an empty packet list when the overall
+    // transfer failed. Packet details are meaningful only for a successful
+    // URB, so preserve the USB failure instead of upgrading it to a shape
+    // error.
+    let status = completion_status(hresult, ts_urb_result.header.usbd_status);
+    if let Err(error) = status {
+        return Ok(Err(error));
+    }
+
+    if result.iso_packet.len() != requested_packet_lengths.len() {
+        return Err(CompletionError::IsochronousPacketCountMismatch {
+            expected: requested_packet_lengths.len(),
+            actual: result.iso_packet.len(),
+        });
+    }
+
+    let mut successful_length = 0u32;
+    let mut packets = Vec::with_capacity(result.iso_packet.len());
+    for (packet, (result, requested)) in result
+        .iso_packet
+        .into_iter()
+        .zip(requested_packet_lengths.iter().copied())
+        .enumerate()
+    {
+        if result.length > requested {
+            return Err(CompletionError::IsochronousPacketLengthExceeded {
+                packet,
+                requested,
+                actual: result.length,
+            });
+        }
+
+        let packet_status = usb_status(packet_status_raw(result.status));
+        if packet_status.is_ok() {
+            successful_length = successful_length
+                .checked_add(result.length)
+                .ok_or(CompletionError::IsochronousTransferLengthOverflow)?;
+        }
+        packets.push(IsochronousPacketCompletion {
+            status: packet_status,
+            actual_length: result.length,
+        });
+    }
+
+    // Only transfer-in completions contain the packed successful-packet data
+    // described by MS-RDPEUSB 2.2.10.5. For transfer-out, OutputBufferSize is
+    // the number of bytes sent and is not required to equal that packet sum.
+    if transfer_in && envelope_actual_length != successful_length {
+        return Err(CompletionError::IsochronousDataLengthMismatch {
+            expected: successful_length,
+            actual: envelope_actual_length,
+        });
+    }
+    Ok(Ok(IsochronousTransferOutput {
+        start_frame: result.start_frame,
+        actual_length: envelope_actual_length,
+        data: output_buffer,
+        packets,
+    }))
+}
+
+fn standard_control_transfer(setup: SetupPacket, data: Vec<u8>) -> Result<TransferRequest, Vec<u8>> {
+    let Some(standard_request) = setup.standard_request() else {
+        return Err(data);
+    };
+    let recipient = setup.request_type.recipient();
+    let direction = setup.request_type.direction();
+
+    match standard_request {
+        standard_request::GET_DESCRIPTOR => {
+            // The setup packet and the recipient are already checked by the
+            // typed request; an unsupported one falls back to a generic
+            // control URB with the caller's buffer intact.
+            let Ok(request) = GetDescriptorRequest::try_from(setup) else {
+                return Err(data);
+            };
+            let Ok(packet) = get_descriptor(request) else {
+                return Err(data);
+            };
+            Ok(TransferRequest::In(packet))
+        }
+        standard_request::SET_DESCRIPTOR if setup.length == 0 || direction == Direction::Out => {
+            let Some(func) = descriptor_function(recipient, DescriptorOperation::Set) else {
+                return Err(data);
+            };
+            let [index, desc_type] = setup.value.to_le_bytes();
+            Ok(TransferRequest::Out(transfer_out(
+                TsUrbOutKind::CtlDescReq(TsUrbControlDescRequest {
+                    index,
+                    desc_type,
+                    lang_id: setup.index,
+                }),
+                func,
+                data,
+            )))
+        }
+        standard_request::GET_STATUS if direction == Direction::In && setup.value == 0 && setup.length == 2 => {
+            let Some(func) = get_status_function(recipient) else {
+                return Err(data);
+            };
+            Ok(TransferRequest::In(transfer_in(
+                TsUrbInKind::CtlGetStatus(TsUrbControlGetStatusRequest { index: setup.index }),
+                func,
+                2,
+            )))
+        }
+        standard_request::CLEAR_FEATURE | standard_request::SET_FEATURE
+            if direction == Direction::Out && setup.length == 0 =>
+        {
+            let Some(func) = feature_function(standard_request, recipient) else {
+                return Err(data);
+            };
+            // MS-RDPEUSB 2.2.9.10 requires this USB host-to-device operation
+            // in TRANSFER_IN_REQUEST with an empty output buffer.
+            Ok(TransferRequest::In(transfer_in(
+                TsUrbInKind::CtlFeatReq(TsUrbControlFeatRequest {
+                    feat_selector: setup.value,
+                    index: setup.index,
+                }),
+                func,
+                0,
+            )))
+        }
+        standard_request::GET_CONFIGURATION
+            if direction == Direction::In
+                && recipient == Recipient::DEVICE
+                && setup.value == 0
+                && setup.index == 0
+                && setup.length == 1 =>
+        {
+            Ok(TransferRequest::In(transfer_in(
+                TsUrbInKind::CtlGetConfig(TsUrbControlGetConfigRequest),
+                UrbFunction::URB_FUNCTION_GET_CONFIGURATION,
+                1,
+            )))
+        }
+        standard_request::GET_INTERFACE
+            if direction == Direction::In
+                && recipient == Recipient::INTERFACE
+                && setup.value == 0
+                && setup.length == 1 =>
+        {
+            Ok(TransferRequest::In(transfer_in(
+                TsUrbInKind::CtlGetIface(TsUrbControlGetInterfaceRequest { interface: setup.index }),
+                UrbFunction::URB_FUNCTION_GET_INTERFACE,
+                1,
+            )))
+        }
+        _ => Err(data),
+    }
+}
+
+fn generic_control_transfer(setup: SetupPacket, data: Vec<u8>) -> TransferRequest {
+    let direction = setup.request_type.direction();
+    let urb = TsUrbControlTransfer {
+        pipe: DEFAULT_CONTROL_PIPE_HANDLE,
+        transfer_flags: in_transfer_flags(direction) | USBD_DEFAULT_PIPE_TRANSFER,
+        setup_packet: rdpeusb_setup_packet(setup),
+    };
+
+    match direction {
+        Direction::In => TransferRequest::In(transfer_in(
+            TsUrbInKind::CtlTransfer(urb),
+            UrbFunction::URB_FUNCTION_CONTROL_TRANSFER,
+            u32::from(setup.length),
+        )),
+        Direction::Out => TransferRequest::Out(transfer_out(
+            TsUrbOutKind::CtlTransfer(urb),
+            UrbFunction::URB_FUNCTION_CONTROL_TRANSFER,
+            data,
+        )),
+    }
+}
+
+fn validate_control_data(setup: SetupPacket, data: &[u8]) -> Result<(), ConversionError> {
+    match setup.request_type.direction() {
+        Direction::In if !data.is_empty() => Err(ConversionError::InTransferHasData { actual: data.len() }),
+        Direction::Out if data.len() != usize::from(setup.length) => Err(ConversionError::OutTransferLengthMismatch {
+            expected: usize::from(setup.length),
+            actual: data.len(),
+        }),
+        Direction::In | Direction::Out => Ok(()),
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum DescriptorOperation {
+    Get,
+    Set,
+}
+
+fn descriptor_function(recipient: Recipient, operation: DescriptorOperation) -> Option<UrbFunction> {
+    match (operation, recipient) {
+        (DescriptorOperation::Get, Recipient::DEVICE) => Some(UrbFunction::URB_FUNCTION_GET_DESCRIPTOR_FROM_DEVICE),
+        (DescriptorOperation::Get, Recipient::INTERFACE) => {
+            Some(UrbFunction::URB_FUNCTION_GET_DESCRIPTOR_FROM_INTERFACE)
+        }
+        (DescriptorOperation::Get, Recipient::ENDPOINT) => Some(UrbFunction::URB_FUNCTION_GET_DESCRIPTOR_FROM_ENDPOINT),
+        (DescriptorOperation::Set, Recipient::DEVICE) => Some(UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_DEVICE),
+        (DescriptorOperation::Set, Recipient::INTERFACE) => Some(UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_INTERFACE),
+        (DescriptorOperation::Set, Recipient::ENDPOINT) => Some(UrbFunction::URB_FUNCTION_SET_DESCRIPTOR_TO_ENDPOINT),
+        _ => None,
+    }
+}
+
+fn feature_function(request: u8, recipient: Recipient) -> Option<UrbFunction> {
+    match (request, recipient) {
+        (standard_request::CLEAR_FEATURE, Recipient::DEVICE) => Some(UrbFunction::URB_FUNCTION_CLEAR_FEATURE_TO_DEVICE),
+        (standard_request::CLEAR_FEATURE, Recipient::INTERFACE) => {
+            Some(UrbFunction::URB_FUNCTION_CLEAR_FEATURE_TO_INTERFACE)
+        }
+        (standard_request::CLEAR_FEATURE, Recipient::ENDPOINT) => {
+            Some(UrbFunction::URB_FUNCTION_CLEAR_FEATURE_TO_ENDPOINT)
+        }
+        (standard_request::CLEAR_FEATURE, Recipient::OTHER) => Some(UrbFunction::URB_FUNCTION_CLEAR_FEATURE_TO_OTHER),
+        (standard_request::SET_FEATURE, Recipient::DEVICE) => Some(UrbFunction::URB_FUNCTION_SET_FEATURE_TO_DEVICE),
+        (standard_request::SET_FEATURE, Recipient::INTERFACE) => {
+            Some(UrbFunction::URB_FUNCTION_SET_FEATURE_TO_INTERFACE)
+        }
+        (standard_request::SET_FEATURE, Recipient::ENDPOINT) => Some(UrbFunction::URB_FUNCTION_SET_FEATURE_TO_ENDPOINT),
+        (standard_request::SET_FEATURE, Recipient::OTHER) => Some(UrbFunction::URB_FUNCTION_SET_FEATURE_TO_OTHER),
+        _ => None,
+    }
+}
+
+fn get_status_function(recipient: Recipient) -> Option<UrbFunction> {
+    match recipient {
+        Recipient::DEVICE => Some(UrbFunction::URB_FUNCTION_GET_STATUS_FROM_DEVICE),
+        Recipient::INTERFACE => Some(UrbFunction::URB_FUNCTION_GET_STATUS_FROM_INTERFACE),
+        Recipient::ENDPOINT => Some(UrbFunction::URB_FUNCTION_GET_STATUS_FROM_ENDPOINT),
+        Recipient::OTHER => Some(UrbFunction::URB_FUNCTION_GET_STATUS_FROM_OTHER),
+        _ => None,
+    }
+}
+
+fn vendor_or_class_function(kind: RequestKind, recipient: Recipient) -> Option<UrbFunction> {
+    match (kind, recipient) {
+        (RequestKind::VENDOR, Recipient::DEVICE) => Some(UrbFunction::URB_FUNCTION_VENDOR_DEVICE),
+        (RequestKind::VENDOR, Recipient::INTERFACE) => Some(UrbFunction::URB_FUNCTION_VENDOR_INTERFACE),
+        (RequestKind::VENDOR, Recipient::ENDPOINT) => Some(UrbFunction::URB_FUNCTION_VENDOR_ENDPOINT),
+        (RequestKind::VENDOR, Recipient::OTHER) => Some(UrbFunction::URB_FUNCTION_VENDOR_OTHER),
+        (RequestKind::CLASS, Recipient::DEVICE) => Some(UrbFunction::URB_FUNCTION_CLASS_DEVICE),
+        (RequestKind::CLASS, Recipient::INTERFACE) => Some(UrbFunction::URB_FUNCTION_CLASS_INTERFACE),
+        (RequestKind::CLASS, Recipient::ENDPOINT) => Some(UrbFunction::URB_FUNCTION_CLASS_ENDPOINT),
+        (RequestKind::CLASS, Recipient::OTHER) => Some(UrbFunction::URB_FUNCTION_CLASS_OTHER),
+        _ => None,
+    }
+}
+
+fn configuration_descriptor(descriptor: ConfigurationDescriptorSet<'_>) -> Result<UsbConfigDesc, ConversionError> {
+    let configuration = descriptor.configuration();
+    if usize::from(configuration.length()) != UsbConfigDesc::FIXED_PART_SIZE {
+        return Err(ConversionError::InvalidConfigurationHeaderLength {
+            actual: configuration.length(),
+        });
+    }
+
+    Ok(UsbConfigDesc {
+        length: configuration.length(),
+        descriptor_type: configuration.raw_descriptor().descriptor_type(),
+        total_length: configuration.total_length(),
+        num_interfaces: configuration.num_interfaces(),
+        configuration_value: configuration.configuration_value(),
+        configuration: configuration.configuration_string(),
+        attributes: configuration.attributes().raw(),
+        max_power: configuration.max_power_raw(),
+        trailing: descriptor.as_bytes()[UsbConfigDesc::FIXED_PART_SIZE..].to_vec(),
+    })
+}
+
+fn interface_information(
+    interface: InterfaceDescriptor<'_>,
+    speed: UsbSpeed,
+) -> Result<TsUsbdInterfaceInfo, ConversionError> {
+    let selection = InterfaceSelection {
+        interface: interface.number(),
+        alternate_setting: interface.alternate_setting(),
+    };
+    let mut pipes = Vec::with_capacity(interface.endpoints().count());
+    for endpoint in interface.endpoints() {
+        let raw_max_packet_size = endpoint.max_packet_size().raw();
+        if interface.alternate_setting() == 0
+            && endpoint.transfer_type() == TransferType::Isochronous
+            && raw_max_packet_size != 0
+        {
+            return Err(ConversionError::InvalidMaximumPacketSize {
+                selection,
+                raw: raw_max_packet_size,
+            });
+        }
+        let max_packet_size = endpoint
+            .max_packet_size()
+            .usb2_max_payload(speed, endpoint.transfer_type())
+            .ok_or(ConversionError::InvalidMaximumPacketSize {
+                selection,
+                raw: raw_max_packet_size,
+            })?;
+        pipes.push(TsUsbdPipeInfo {
+            max_packet_size,
+            // MS-RDPEUSB 2.2.9.1.3 notes that the client ignores this
+            // obsolete USBD field. Zero requests the client default.
+            max_transfer_size: 0,
+            // No general USB semantic requests a Windows pipe override.
+            pipe_flags: 0,
+        });
+    }
+
+    Ok(TsUsbdInterfaceInfo {
+        interface_number: selection.interface,
+        alternate_setting: selection.alternate_setting,
+        ts_usbd_pipe_info: pipes,
+    })
+}
+
+fn in_transfer_flags(direction: Direction) -> u32 {
+    match direction {
+        Direction::In => USBD_TRANSFER_DIRECTION_IN | USBD_SHORT_TRANSFER_OK,
+        Direction::Out => 0,
+    }
+}
+
+fn completion_status(hresult: u32, usbd_status: u32) -> UsbResult<()> {
+    if !hresult_succeeded(hresult) {
+        return Err(UsbError::Error);
+    }
+
+    usb_status(usbd_status)
+}
+
+fn hresult_succeeded(hresult: u32) -> bool {
+    hresult & HRESULT_FAILURE_BIT == 0
+}
+
+fn usb_status(usbd_status: u32) -> UsbResult<()> {
+    match usbd_status {
+        USBD_STATUS_SUCCESS => Ok(()),
+        USBD_STATUS_CANCELED => Err(UsbError::Cancelled),
+        USBD_STATUS_STALL_PID => Err(UsbError::Stall),
+        USBD_STATUS_TIMEOUT => Err(UsbError::Timeout),
+        USBD_STATUS_BABBLE_DETECTED => Err(UsbError::Overflow),
+        USBD_STATUS_DEVICE_GONE => Err(UsbError::NoDevice),
+        _ => Err(UsbError::Error),
+    }
+}
+
+fn packet_status_raw(status: i32) -> u32 {
+    u32::from_ne_bytes(status.to_ne_bytes())
+}
+
+fn header_only_transfer_in(completion: CompletionData) -> Result<TransferInCompletionResult, CompletionError> {
+    let CompletionData::TransferIn(completion) = completion else {
+        return Err(CompletionError::ExpectedTransferIn);
+    };
+    if completion.ts_urb_result.payload.is_some() {
+        return Err(CompletionError::UnexpectedUrbResultPayload);
+    }
+    Ok(completion)
+}
+
+fn ensure_empty_output(completion: &TransferInCompletionResult) -> Result<(), CompletionError> {
+    if completion.output_buffer.is_empty() {
+        Ok(())
+    } else {
+        Err(CompletionError::UnexpectedOutputData {
+            actual: completion.output_buffer.len(),
+        })
+    }
+}
+
+fn byte_transfer_in_completion(completion: CompletionData) -> Result<UsbResult<u8>, CompletionError> {
+    let completion = header_only_transfer_in(completion)?;
+    let status = completion_status(completion.hresult, completion.ts_urb_result.header.usbd_status);
+    if let Err(error) = status {
+        return Ok(Err(error));
+    }
+    if completion.output_buffer.len() != 1 {
+        return Err(CompletionError::ExpectedOneByteOutput {
+            actual: completion.output_buffer.len(),
+        });
+    }
+
+    Ok(Ok(completion.output_buffer[0]))
+}
+
+fn unit_transfer_in_completion(completion: CompletionData) -> Result<UsbResult<()>, CompletionError> {
+    let completion = header_only_transfer_in(completion)?;
+    ensure_empty_output(&completion)?;
+    let status = completion_status(completion.hresult, completion.ts_urb_result.header.usbd_status);
+    Ok(status)
+}
+
+fn rdpeusb_setup_packet(setup: SetupPacket) -> RdpeusbSetupPacket {
+    RdpeusbSetupPacket {
+        request_type: setup.request_type.raw(),
+        request: setup.request,
+        value: setup.value,
+        index: setup.index,
+        length: setup.length,
+    }
+}
+
+fn transfer_in(kind: TsUrbInKind, func: UrbFunction, output_buffer_size: u32) -> TransferInPacket {
+    TransferInPacket {
+        ts_urb: TsUrbInPacket { kind, func },
+        output_buffer_size,
+    }
+}
+
+fn transfer_out(kind: TsUrbOutKind, func: UrbFunction, output_buffer: Vec<u8>) -> TransferOutPacket {
+    TransferOutPacket {
+        ts_urb: TsUrbOutPacket {
+            kind,
+            no_ack: false,
+            func,
+        },
+        output_buffer,
+    }
+}

--- a/crates/ironrdp-testsuite-core/tests/rdpeusb/device.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeusb/device.rs
@@ -1,11 +1,12 @@
 use ironrdp_core::{DecodeResult, decode, encode_vec};
 use ironrdp_rdpeusb::io::device::{
-    DeviceInfo, UsbBcdVersion, UsbClassCodes, UsbConfigInfo, UsbConnectionSpeed, UsbDeviceDescriptorInfo,
-    UsbDeviceLocation, UsbInterfaceInfo, add_device_from_info,
+    DeviceInfo, UsbClassCodes, UsbConfigInfo, UsbConnectionSpeed, UsbDeviceDescriptorInfo, UsbDeviceLocation,
+    UsbInterfaceInfo, add_device_from_info,
 };
 use ironrdp_rdpeusb::pdu::UrbdrcClientDevicePdu;
 use ironrdp_rdpeusb::pdu::completion::ts_urb_result::Raw;
 use ironrdp_rdpeusb::pdu::header::InterfaceId;
+use ironrdp_usb::BcdVersion;
 use rstest::rstest;
 
 use super::simple_device_info;
@@ -70,7 +71,7 @@ fn no_port_numbers_device_info() -> DeviceInfo {
     }
 }
 
-fn usb_version_device_info(usb_version: UsbBcdVersion) -> DeviceInfo {
+fn usb_version_device_info(usb_version: BcdVersion) -> DeviceInfo {
     DeviceInfo {
         descriptor: UsbDeviceDescriptorInfo {
             usb_version,
@@ -93,9 +94,9 @@ fn speed_device_info(speed: UsbConnectionSpeed) -> DeviceInfo {
 #[case::composite_iad(iad_composite_device_info())]
 #[case::no_active_config(no_active_config_device_info())]
 #[case::no_port_numbers(no_port_numbers_device_info())]
-#[case::usb10(usb_version_device_info(UsbBcdVersion::from_bcd(0x0100)))]
-#[case::usb11(usb_version_device_info(UsbBcdVersion::from_bcd(0x0110)))]
-#[case::usb20(usb_version_device_info(UsbBcdVersion::from_bcd(0x0200)))]
+#[case::usb10(usb_version_device_info(BcdVersion::from_raw(0x0100)))]
+#[case::usb11(usb_version_device_info(BcdVersion::from_raw(0x0110)))]
+#[case::usb20(usb_version_device_info(BcdVersion::from_raw(0x0200)))]
 #[case::low_speed(speed_device_info(UsbConnectionSpeed::Low))]
 #[case::full_speed(speed_device_info(UsbConnectionSpeed::Full))]
 #[case::high_speed(speed_device_info(UsbConnectionSpeed::High))]

--- a/crates/ironrdp-testsuite-core/tests/rdpeusb/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeusb/mod.rs
@@ -51,3 +51,4 @@ mod io;
 mod server;
 mod sink;
 mod ts_urb;
+mod usb;

--- a/crates/ironrdp-testsuite-core/tests/rdpeusb/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeusb/mod.rs
@@ -1,11 +1,12 @@
 use ironrdp_core::encode_vec;
 use ironrdp_rdpeusb::{
     io::device::{
-        DeviceInfo, UsbBcdVersion, UsbClassCodes, UsbConfigInfo, UsbConnectionSpeed, UsbDeviceDescriptorInfo,
-        UsbDeviceLocation, UsbInterfaceInfo,
+        DeviceInfo, UsbClassCodes, UsbConfigInfo, UsbConnectionSpeed, UsbDeviceDescriptorInfo, UsbDeviceLocation,
+        UsbInterfaceInfo,
     },
     pdu::header::InterfaceId,
 };
+use ironrdp_usb::BcdVersion;
 
 fn simple_device_info() -> DeviceInfo {
     DeviceInfo {
@@ -18,7 +19,7 @@ fn simple_device_info() -> DeviceInfo {
             vendor_id: 0x1234,
             product_id: 0xabcd,
             device_version: 0x0210,
-            usb_version: UsbBcdVersion::from_bcd(0x0200),
+            usb_version: BcdVersion::from_raw(0x0200),
             class_codes: UsbClassCodes::PER_INTERFACE,
             num_configurations: 1,
         },

--- a/crates/ironrdp-testsuite-core/tests/rdpeusb/usb.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeusb/usb.rs
@@ -1,0 +1,1055 @@
+use ironrdp_rdpeusb::{
+    io::{
+        CompletionData, IoControlCompletionResult, TransferInCompletionResult, TransferOutCompletionResult,
+        TsUrbInKind, TsUrbOutKind, UrbFunction,
+    },
+    pdu::{
+        completion::ts_urb_result::{
+            TsUrbGetCurrFrameNumResult, TsUrbIsochTransferResult, TsUrbResult, TsUrbResultHeader, TsUrbResultPayload,
+            TsUrbSelectConfigResult, TsUrbSelectInterfaceResult, TsUsbdInterfaceInfoResult,
+        },
+        usb_dev::IoctlInternalUsb,
+        utils::UsbdIsoPacketDesc,
+    },
+    usb::{
+        CompletionError, ConversionError, TransferRequest, bulk_or_interrupt, control_transfer, current_frame_number,
+        current_frame_number_completion, get_configuration, get_configuration_completion, get_descriptor,
+        get_descriptor_completion, get_interface, get_interface_completion, isochronous, isochronous_completion,
+        pipe_request_completion, reset_device, reset_device_completion, reset_pipe_and_clear_stall,
+        select_configuration, select_configuration_completion, select_interface, select_interface_completion,
+        transfer_completion, unconfigure,
+    },
+};
+use ironrdp_usb::{
+    Direction, InterfaceSelection, UsbSpeed,
+    control::{GetDescriptorRequest, Recipient, RequestKind, RequestType, SetupPacket, standard_request},
+    descriptor::{ConfigurationDescriptorSet, descriptor_type},
+    endpoint::EndpointAddress,
+    transfer::{
+        DataTransferRequest, IsochronousPacketCompletion, IsochronousTransferOutput, IsochronousTransferRequest,
+        TransferCompletion, UsbError,
+    },
+};
+
+const USBD_TRANSFER_DIRECTION_IN: u32 = 0x0000_0001;
+const USBD_SHORT_TRANSFER_OK: u32 = 0x0000_0002;
+const USBD_DEFAULT_PIPE_TRANSFER: u32 = 0x0000_0008;
+const USBD_START_ISO_TRANSFER_ASAP: u32 = 0x0000_0004;
+const DEFAULT_CONTROL_PIPE_HANDLE: u32 = 0;
+
+const USBD_STATUS_CANCELED: u32 = 0xc001_0000;
+const USBD_STATUS_STALL_PID: u32 = 0xc000_0004;
+const USBD_STATUS_BABBLE_DETECTED: u32 = 0xc000_0012;
+const USBD_STATUS_TIMEOUT: u32 = 0xc000_6000;
+const USBD_STATUS_DEVICE_GONE: u32 = 0xc000_7000;
+
+const CONFIGURATION: [u8; 57] = [
+    9, 2, 57, 0, 2, 1, 0, 0x80, 50, // configuration
+    9, 4, 0, 0, 2, 0xff, 0, 0, 0, // interface 0, alternate 0
+    7, 5, 0x81, 3, 0x40, 0x10, 1, // high-bandwidth interrupt IN
+    7, 5, 0x02, 2, 0x00, 0x02, 0, // bulk OUT
+    9, 4, 1, 0, 0, 0xff, 0, 0, 0, // interface 1, alternate 0
+    9, 4, 1, 1, 1, 0xff, 0, 0, 0, // interface 1, alternate 1
+    7, 5, 0x83, 3, 32, 0, 4, // interrupt IN
+];
+
+fn setup(
+    direction: Direction,
+    kind: RequestKind,
+    recipient: Recipient,
+    request: u8,
+    value: u16,
+    index: u16,
+    length: u16,
+) -> SetupPacket {
+    SetupPacket {
+        request_type: RequestType::new(direction, kind, recipient),
+        request,
+        value,
+        index,
+        length,
+    }
+}
+
+fn selection(interface: u8, alternate_setting: u8) -> InterfaceSelection {
+    InterfaceSelection {
+        interface,
+        alternate_setting,
+    }
+}
+
+#[test]
+fn feature_out_uses_rdpeusb_transfer_in() {
+    let setup = setup(
+        Direction::Out,
+        RequestKind::STANDARD,
+        Recipient::ENDPOINT,
+        standard_request::SET_FEATURE,
+        0,
+        0x81,
+        0,
+    );
+
+    let TransferRequest::In(request) = control_transfer(setup, Vec::new()).unwrap() else {
+        panic!("feature request used TRANSFER_OUT_REQUEST");
+    };
+    assert_eq!(request.output_buffer_size, 0);
+    assert_eq!(request.ts_urb.func, UrbFunction::URB_FUNCTION_SET_FEATURE_TO_ENDPOINT);
+    let TsUrbInKind::CtlFeatReq(urb) = request.ts_urb.kind else {
+        panic!("feature request used the wrong TS_URB variant");
+    };
+    assert_eq!(urb.feat_selector, 0);
+    assert_eq!(urb.index, 0x81);
+}
+
+#[test]
+fn descriptor_request_preserves_typed_fields() {
+    let setup = setup(
+        Direction::In,
+        RequestKind::STANDARD,
+        Recipient::INTERFACE,
+        standard_request::GET_DESCRIPTOR,
+        0x2203,
+        0x0409,
+        64,
+    );
+
+    let TransferRequest::In(request) = control_transfer(setup, Vec::new()).unwrap() else {
+        panic!("GET_DESCRIPTOR used TRANSFER_OUT_REQUEST");
+    };
+    assert_eq!(request.output_buffer_size, 64);
+    assert_eq!(
+        request.ts_urb.func,
+        UrbFunction::URB_FUNCTION_GET_DESCRIPTOR_FROM_INTERFACE
+    );
+    let TsUrbInKind::CtlDescReq(urb) = request.ts_urb.kind else {
+        panic!("GET_DESCRIPTOR used the wrong TS_URB variant");
+    };
+    assert_eq!(urb.index, 3);
+    assert_eq!(urb.desc_type, 0x22);
+    assert_eq!(urb.lang_id, 0x0409);
+}
+
+#[test]
+fn typed_get_descriptor_rejects_an_unrepresentable_recipient() {
+    let error = get_descriptor(GetDescriptorRequest {
+        recipient: Recipient::VENDOR_SPECIFIC,
+        descriptor_type: descriptor_type::DEVICE,
+        descriptor_index: 0,
+        index: 0,
+        requested_length: 18,
+    })
+    .unwrap_err();
+
+    assert_eq!(
+        error,
+        ConversionError::UnsupportedDescriptorRecipient {
+            recipient: Recipient::VENDOR_SPECIFIC
+        }
+    );
+}
+
+#[test]
+fn get_descriptor_completion_returns_usb_data() {
+    let output = vec![18, descriptor_type::DEVICE, 0, 2];
+
+    assert_eq!(
+        get_descriptor_completion(transfer_in_completion(0, 0, output.clone())).unwrap(),
+        Ok(output.clone())
+    );
+    assert_eq!(
+        get_descriptor_completion(transfer_in_completion(1, 0, output.clone())).unwrap(),
+        Ok(output)
+    );
+    assert_eq!(
+        get_descriptor_completion(transfer_in_completion(0, 0, Vec::new())).unwrap(),
+        Ok(Vec::new())
+    );
+}
+
+#[test]
+fn get_descriptor_completion_maps_usb_failures() {
+    for (usbd_status, expected) in [
+        (USBD_STATUS_CANCELED, UsbError::Cancelled),
+        (USBD_STATUS_STALL_PID, UsbError::Stall),
+        (USBD_STATUS_BABBLE_DETECTED, UsbError::Overflow),
+        (USBD_STATUS_TIMEOUT, UsbError::Timeout),
+        (USBD_STATUS_DEVICE_GONE, UsbError::NoDevice),
+        (0xdead_beef, UsbError::Error),
+    ] {
+        assert_eq!(
+            get_descriptor_completion(transfer_in_completion(0, usbd_status, vec![1, 2, 3])).unwrap(),
+            Err(expected)
+        );
+    }
+
+    assert_eq!(
+        get_descriptor_completion(transfer_in_completion(0x8000_4005, 0, vec![1, 2, 3])).unwrap(),
+        Err(UsbError::Error)
+    );
+}
+
+#[test]
+fn get_descriptor_completion_rejects_a_mismatched_result() {
+    let result = TsUrbResult {
+        header: TsUrbResultHeader { usbd_status: 0 },
+        payload: None,
+    };
+    assert_eq!(
+        get_descriptor_completion(CompletionData::TransferOut(TransferOutCompletionResult {
+            ts_urb_result: result,
+            hresult: 0,
+            output_buffer_size: 0,
+        }))
+        .unwrap_err(),
+        CompletionError::ExpectedTransferIn
+    );
+
+    let result = TsUrbResult {
+        header: TsUrbResultHeader { usbd_status: 0 },
+        payload: Some(TsUrbResultPayload::FrameNum(TsUrbGetCurrFrameNumResult {
+            frame_number: 42,
+        })),
+    };
+    assert_eq!(
+        get_descriptor_completion(CompletionData::TransferIn(TransferInCompletionResult {
+            ts_urb_result: result,
+            hresult: 0,
+            output_buffer: Vec::new(),
+        }))
+        .unwrap_err(),
+        CompletionError::UnexpectedUrbResultPayload
+    );
+}
+
+fn transfer_in_completion(hresult: u32, usbd_status: u32, output_buffer: Vec<u8>) -> CompletionData {
+    CompletionData::TransferIn(TransferInCompletionResult {
+        ts_urb_result: TsUrbResult {
+            header: TsUrbResultHeader { usbd_status },
+            payload: None,
+        },
+        hresult,
+        output_buffer,
+    })
+}
+
+#[test]
+fn class_in_accepts_short_control_responses() {
+    let setup = SetupPacket {
+        request_type: RequestType::new(Direction::In, RequestKind::CLASS, Recipient::INTERFACE),
+        request: 0x81,
+        value: 0x0200,
+        index: 3,
+        length: 8,
+    };
+
+    let TransferRequest::In(request) = control_transfer(setup, Vec::new()).unwrap() else {
+        panic!("class IN request used TRANSFER_OUT_REQUEST");
+    };
+    let TsUrbInKind::VendorClassReq(urb) = request.ts_urb.kind else {
+        panic!("class request used the wrong TS_URB variant");
+    };
+    assert_eq!(urb.transfer_flags, USBD_TRANSFER_DIRECTION_IN | USBD_SHORT_TRANSFER_OK);
+}
+
+#[test]
+fn unknown_recipient_falls_back_without_losing_setup_fields() {
+    let setup = SetupPacket {
+        request_type: RequestType::new(Direction::In, RequestKind::VENDOR, Recipient::VENDOR_SPECIFIC),
+        request: 0xa5,
+        value: 0x1234,
+        index: 0x5678,
+        length: 17,
+    };
+
+    let TransferRequest::In(request) = control_transfer(setup, Vec::new()).unwrap() else {
+        panic!("vendor IN request used TRANSFER_OUT_REQUEST");
+    };
+    assert_eq!(request.output_buffer_size, 17);
+    assert_eq!(request.ts_urb.func, UrbFunction::URB_FUNCTION_CONTROL_TRANSFER);
+    let TsUrbInKind::CtlTransfer(urb) = request.ts_urb.kind else {
+        panic!("unknown recipient did not use generic control transfer");
+    };
+    assert_eq!(urb.pipe, DEFAULT_CONTROL_PIPE_HANDLE);
+    assert_eq!(
+        urb.transfer_flags,
+        USBD_TRANSFER_DIRECTION_IN | USBD_SHORT_TRANSFER_OK | USBD_DEFAULT_PIPE_TRANSFER
+    );
+    assert_eq!(urb.setup_packet.request_type, setup.request_type.raw());
+    assert_eq!(urb.setup_packet.request, setup.request);
+    assert_eq!(urb.setup_packet.value, setup.value);
+    assert_eq!(urb.setup_packet.index, setup.index);
+    assert_eq!(urb.setup_packet.length, setup.length);
+}
+
+#[test]
+fn noncanonical_typed_requests_fall_back_without_losing_fields() {
+    let requests = [
+        setup(
+            Direction::In,
+            RequestKind::STANDARD,
+            Recipient::DEVICE,
+            standard_request::GET_STATUS,
+            1,
+            0,
+            2,
+        ),
+        setup(
+            Direction::In,
+            RequestKind::STANDARD,
+            Recipient::DEVICE,
+            standard_request::GET_CONFIGURATION,
+            0,
+            1,
+            1,
+        ),
+        setup(
+            Direction::In,
+            RequestKind::STANDARD,
+            Recipient::INTERFACE,
+            standard_request::GET_INTERFACE,
+            1,
+            3,
+            1,
+        ),
+        setup(
+            Direction::In,
+            RequestKind::STANDARD,
+            Recipient::ENDPOINT,
+            standard_request::CLEAR_FEATURE,
+            0,
+            0x81,
+            0,
+        ),
+    ];
+
+    for setup in requests {
+        let TransferRequest::In(request) = control_transfer(setup, Vec::new()).unwrap() else {
+            panic!("noncanonical USB IN request used TRANSFER_OUT_REQUEST");
+        };
+        let TsUrbInKind::CtlTransfer(urb) = request.ts_urb.kind else {
+            panic!("noncanonical request lost fields in a typed TS_URB");
+        };
+        assert_eq!(urb.setup_packet.request_type, setup.request_type.raw());
+        assert_eq!(urb.setup_packet.request, setup.request);
+        assert_eq!(urb.setup_packet.value, setup.value);
+        assert_eq!(urb.setup_packet.index, setup.index);
+        assert_eq!(urb.setup_packet.length, setup.length);
+    }
+}
+
+#[test]
+fn stateful_standard_requests_do_not_use_generic_control() {
+    let requests = [
+        setup(
+            Direction::Out,
+            RequestKind::STANDARD,
+            Recipient::DEVICE,
+            standard_request::SET_ADDRESS,
+            5,
+            0,
+            0,
+        ),
+        setup(
+            Direction::Out,
+            RequestKind::STANDARD,
+            Recipient::DEVICE,
+            standard_request::SET_CONFIGURATION,
+            1,
+            0,
+            0,
+        ),
+        setup(
+            Direction::Out,
+            RequestKind::STANDARD,
+            Recipient::INTERFACE,
+            standard_request::SET_INTERFACE,
+            1,
+            0,
+            0,
+        ),
+    ];
+
+    for setup in requests {
+        assert_eq!(
+            control_transfer(setup, Vec::new()).unwrap_err(),
+            ConversionError::StatefulStandardRequest { request: setup.request }
+        );
+    }
+}
+
+#[test]
+fn control_data_shape_is_validated_before_translation() {
+    let input = setup(
+        Direction::In,
+        RequestKind::STANDARD,
+        Recipient::DEVICE,
+        standard_request::GET_STATUS,
+        0,
+        0,
+        2,
+    );
+    assert_eq!(
+        control_transfer(input, vec![0]).unwrap_err(),
+        ConversionError::InTransferHasData { actual: 1 }
+    );
+
+    let output = SetupPacket {
+        request_type: RequestType::new(Direction::Out, RequestKind::VENDOR, Recipient::DEVICE),
+        request: 1,
+        value: 0,
+        index: 0,
+        length: 2,
+    };
+    assert_eq!(
+        control_transfer(output, vec![0]).unwrap_err(),
+        ConversionError::OutTransferLengthMismatch { expected: 2, actual: 1 }
+    );
+}
+
+#[test]
+fn general_bulk_or_interrupt_validates_directional_data() {
+    let endpoint = EndpointAddress::from_raw(0x81).unwrap();
+    let TransferRequest::In(input) = bulk_or_interrupt(
+        7,
+        DataTransferRequest {
+            endpoint,
+            length: 512,
+            data: Vec::new(),
+        },
+    )
+    .unwrap() else {
+        panic!("bulk IN used TRANSFER_OUT_REQUEST");
+    };
+    assert_eq!(input.output_buffer_size, 512);
+    let TsUrbInKind::BulkInterruptTransfer(urb) = input.ts_urb.kind else {
+        panic!("bulk IN used the wrong TS_URB variant");
+    };
+    assert_eq!(urb.pipe_handle, 7);
+    assert_eq!(urb.transfer_flags, USBD_TRANSFER_DIRECTION_IN | USBD_SHORT_TRANSFER_OK);
+
+    assert_eq!(
+        bulk_or_interrupt(
+            7,
+            DataTransferRequest {
+                endpoint,
+                length: 1,
+                data: vec![1],
+            },
+        )
+        .unwrap_err(),
+        ConversionError::InTransferHasData { actual: 1 }
+    );
+
+    let endpoint = EndpointAddress::from_raw(0x02).unwrap();
+    let TransferRequest::Out(output) = bulk_or_interrupt(
+        9,
+        DataTransferRequest {
+            endpoint,
+            length: 3,
+            data: vec![1, 2, 3],
+        },
+    )
+    .unwrap() else {
+        panic!("bulk OUT used TRANSFER_IN_REQUEST");
+    };
+    assert_eq!(output.output_buffer, [1, 2, 3]);
+    assert!(!output.ts_urb.no_ack);
+    let TsUrbOutKind::BulkInterruptTransfer(urb) = output.ts_urb.kind else {
+        panic!("bulk OUT used the wrong TS_URB variant");
+    };
+    assert_eq!(urb.pipe_handle, 9);
+    assert_eq!(urb.transfer_flags, 0);
+
+    assert_eq!(
+        bulk_or_interrupt(
+            9,
+            DataTransferRequest {
+                endpoint,
+                length: 3,
+                data: vec![1, 2],
+            },
+        )
+        .unwrap_err(),
+        ConversionError::OutTransferLengthMismatch { expected: 3, actual: 2 }
+    );
+}
+
+#[test]
+fn general_transfer_completion_preserves_directional_results() {
+    assert_eq!(
+        transfer_completion(transfer_in_completion(0, 0, vec![1, 2, 3])).unwrap(),
+        TransferCompletion {
+            status: Ok(()),
+            actual_length: 3,
+            data: vec![1, 2, 3]
+        }
+    );
+
+    assert_eq!(
+        transfer_completion(CompletionData::TransferOut(TransferOutCompletionResult {
+            ts_urb_result: TsUrbResult {
+                header: TsUrbResultHeader {
+                    usbd_status: USBD_STATUS_STALL_PID,
+                },
+                payload: None,
+            },
+            hresult: 0,
+            output_buffer_size: 17,
+        }))
+        .unwrap(),
+        TransferCompletion {
+            status: Err(UsbError::Stall),
+            actual_length: 17,
+            data: Vec::new()
+        }
+    );
+}
+
+#[test]
+fn configuration_and_interface_queries_use_typed_urbs() {
+    let request = get_configuration();
+    assert_eq!(request.output_buffer_size, 1);
+    assert_eq!(request.ts_urb.func, UrbFunction::URB_FUNCTION_GET_CONFIGURATION);
+    assert!(matches!(request.ts_urb.kind, TsUrbInKind::CtlGetConfig(_)));
+    assert_eq!(
+        get_configuration_completion(transfer_in_completion(0, 0, vec![3])).unwrap(),
+        Ok(3)
+    );
+
+    let request = get_interface(5);
+    assert_eq!(request.output_buffer_size, 1);
+    assert_eq!(request.ts_urb.func, UrbFunction::URB_FUNCTION_GET_INTERFACE);
+    let TsUrbInKind::CtlGetIface(urb) = request.ts_urb.kind else {
+        panic!("GET_INTERFACE used the wrong TS_URB variant");
+    };
+    assert_eq!(urb.interface, 5);
+    assert_eq!(
+        get_interface_completion(transfer_in_completion(0, 0, vec![2])).unwrap(),
+        Ok(2)
+    );
+    assert_eq!(
+        get_interface_completion(transfer_in_completion(0, USBD_STATUS_STALL_PID, Vec::new())).unwrap(),
+        Err(UsbError::Stall)
+    );
+    assert_eq!(
+        get_configuration_completion(transfer_in_completion(0, 0, Vec::new())).unwrap_err(),
+        CompletionError::ExpectedOneByteOutput { actual: 0 }
+    );
+}
+
+#[test]
+fn isochronous_builder_uses_prefix_offsets_and_no_ack_only_for_out() {
+    let output_endpoint = EndpointAddress::from_raw(0x02).unwrap();
+    let TransferRequest::Out(output) = isochronous(
+        19,
+        IsochronousTransferRequest {
+            endpoint: output_endpoint,
+            start_frame: None,
+            data: vec![1, 2, 3, 4, 5, 6],
+            packets: vec![2, 1, 3],
+        },
+        true,
+    )
+    .unwrap() else {
+        panic!("isochronous OUT used TRANSFER_IN_REQUEST");
+    };
+    assert!(output.ts_urb.no_ack);
+    let TsUrbOutKind::IsochTransfer(urb) = output.ts_urb.kind else {
+        panic!("isochronous OUT used the wrong TS_URB variant");
+    };
+    assert_eq!(urb.pipe_handle, 19);
+    assert_eq!(urb.transfer_flags, USBD_START_ISO_TRANSFER_ASAP);
+    assert_eq!(urb.start_frame, 0);
+    assert_eq!(
+        urb.iso_packet
+            .iter()
+            .map(|packet| (packet.offset, packet.length, packet.status))
+            .collect::<Vec<_>>(),
+        [(0, 0, 0), (2, 0, 0), (3, 0, 0)]
+    );
+
+    let input_endpoint = EndpointAddress::from_raw(0x82).unwrap();
+    assert_eq!(
+        isochronous(
+            20,
+            IsochronousTransferRequest {
+                endpoint: input_endpoint,
+                start_frame: Some(42),
+                data: Vec::new(),
+                packets: vec![4],
+            },
+            true,
+        )
+        .unwrap_err(),
+        ConversionError::NoAckIsochronousIn
+    );
+    let TransferRequest::In(input) = isochronous(
+        20,
+        IsochronousTransferRequest {
+            endpoint: input_endpoint,
+            start_frame: Some(42),
+            data: Vec::new(),
+            packets: vec![4, 8],
+        },
+        false,
+    )
+    .unwrap() else {
+        panic!("isochronous IN used TRANSFER_OUT_REQUEST");
+    };
+    assert_eq!(input.output_buffer_size, 12);
+    let TsUrbInKind::IsochTransfer(urb) = input.ts_urb.kind else {
+        panic!("isochronous IN used the wrong TS_URB variant");
+    };
+    assert_eq!(urb.transfer_flags, USBD_TRANSFER_DIRECTION_IN);
+    assert_eq!(urb.start_frame, 42);
+}
+
+#[test]
+fn isochronous_completion_validates_and_unpacks_packet_results() {
+    let stall = i32::from_ne_bytes(USBD_STATUS_STALL_PID.to_ne_bytes());
+    let completion = CompletionData::TransferIn(TransferInCompletionResult {
+        ts_urb_result: TsUrbResult {
+            header: TsUrbResultHeader { usbd_status: 0 },
+            payload: Some(TsUrbResultPayload::Isoch(TsUrbIsochTransferResult {
+                start_frame: 101,
+                error_count: 1,
+                iso_packet: vec![
+                    UsbdIsoPacketDesc {
+                        offset: 0,
+                        length: 3,
+                        status: 0,
+                    },
+                    UsbdIsoPacketDesc {
+                        offset: 3,
+                        length: 0,
+                        status: stall,
+                    },
+                    UsbdIsoPacketDesc {
+                        offset: 3,
+                        length: 2,
+                        status: 0,
+                    },
+                ],
+            })),
+        },
+        hresult: 0,
+        // Failed packet data is omitted by RDPEUSB and successful packet data
+        // is packed in packet order.
+        output_buffer: vec![1, 2, 3, 8, 9],
+    });
+
+    assert_eq!(
+        isochronous_completion(completion, &[4, 3, 5]).unwrap(),
+        Ok(IsochronousTransferOutput {
+            start_frame: 101,
+            actual_length: 5,
+            data: vec![1, 2, 3, 8, 9],
+            packets: vec![
+                IsochronousPacketCompletion {
+                    status: Ok(()),
+                    actual_length: 3,
+                },
+                IsochronousPacketCompletion {
+                    status: Err(UsbError::Stall),
+                    actual_length: 0,
+                },
+                IsochronousPacketCompletion {
+                    status: Ok(()),
+                    actual_length: 2,
+                },
+            ],
+        })
+    );
+}
+
+#[test]
+fn isochronous_completion_rejects_inconsistent_input_data() {
+    let completion = |output_buffer| {
+        CompletionData::TransferIn(TransferInCompletionResult {
+            ts_urb_result: TsUrbResult {
+                header: TsUrbResultHeader { usbd_status: 0 },
+                payload: Some(TsUrbResultPayload::Isoch(TsUrbIsochTransferResult {
+                    start_frame: 1,
+                    error_count: 0,
+                    iso_packet: vec![UsbdIsoPacketDesc {
+                        offset: 17,
+                        length: 2,
+                        status: 0,
+                    }],
+                })),
+            },
+            hresult: 0,
+            output_buffer,
+        })
+    };
+
+    assert_eq!(
+        isochronous_completion(completion(vec![1]), &[4]).unwrap_err(),
+        CompletionError::IsochronousDataLengthMismatch { expected: 2, actual: 1 }
+    );
+}
+
+#[test]
+fn isochronous_completion_rejects_a_packet_longer_than_requested() {
+    let completion = CompletionData::TransferIn(TransferInCompletionResult {
+        ts_urb_result: TsUrbResult {
+            header: TsUrbResultHeader { usbd_status: 0 },
+            payload: Some(TsUrbResultPayload::Isoch(TsUrbIsochTransferResult {
+                start_frame: 1,
+                error_count: 0,
+                iso_packet: vec![
+                    UsbdIsoPacketDesc {
+                        offset: 0,
+                        length: 4,
+                        status: 0,
+                    },
+                    UsbdIsoPacketDesc {
+                        offset: 4,
+                        length: 5,
+                        status: 0,
+                    },
+                ],
+            })),
+        },
+        hresult: 0,
+        output_buffer: Vec::new(),
+    });
+
+    assert_eq!(
+        isochronous_completion(completion, &[4, 4]).unwrap_err(),
+        CompletionError::IsochronousPacketLengthExceeded {
+            packet: 1,
+            requested: 4,
+            actual: 5,
+        }
+    );
+}
+
+#[test]
+fn isochronous_completion_preserves_overall_failure_without_packet_validation() {
+    let completion = CompletionData::TransferIn(TransferInCompletionResult {
+        ts_urb_result: TsUrbResult {
+            header: TsUrbResultHeader {
+                usbd_status: USBD_STATUS_STALL_PID,
+            },
+            payload: Some(TsUrbResultPayload::Isoch(TsUrbIsochTransferResult {
+                start_frame: 0,
+                error_count: 0,
+                iso_packet: Vec::new(),
+            })),
+        },
+        hresult: 0,
+        output_buffer: Vec::new(),
+    });
+
+    assert_eq!(
+        isochronous_completion(completion, &[4, 4]).unwrap(),
+        Err(UsbError::Stall)
+    );
+}
+
+#[test]
+fn isochronous_out_completion_uses_the_envelope_actual_length() {
+    let stall = i32::from_ne_bytes(USBD_STATUS_STALL_PID.to_ne_bytes());
+    let completion = CompletionData::TransferOut(TransferOutCompletionResult {
+        ts_urb_result: TsUrbResult {
+            header: TsUrbResultHeader { usbd_status: 0 },
+            payload: Some(TsUrbResultPayload::Isoch(TsUrbIsochTransferResult {
+                start_frame: 101,
+                error_count: 1,
+                iso_packet: vec![
+                    UsbdIsoPacketDesc {
+                        offset: 0,
+                        length: 4,
+                        status: 0,
+                    },
+                    UsbdIsoPacketDesc {
+                        offset: 4,
+                        length: 0,
+                        status: stall,
+                    },
+                ],
+            })),
+        },
+        hresult: 0,
+        output_buffer_size: 7,
+    });
+
+    assert_eq!(
+        isochronous_completion(completion, &[4, 3]).unwrap(),
+        Ok(IsochronousTransferOutput {
+            start_frame: 101,
+            actual_length: 7,
+            data: Vec::new(),
+            packets: vec![
+                IsochronousPacketCompletion {
+                    status: Ok(()),
+                    actual_length: 4,
+                },
+                IsochronousPacketCompletion {
+                    status: Err(UsbError::Stall),
+                    actual_length: 0,
+                },
+            ],
+        })
+    );
+}
+
+#[test]
+fn select_configuration_carries_full_descriptor_and_selected_interfaces() {
+    let descriptor = ConfigurationDescriptorSet::parse(&CONFIGURATION)
+        .unwrap()
+        .validate()
+        .unwrap();
+    let selections = [selection(0, 0), selection(1, 1)];
+
+    let request = select_configuration(descriptor, &selections, UsbSpeed::High).unwrap();
+    assert_eq!(request.output_buffer_size, 0);
+    assert_eq!(request.ts_urb.func, UrbFunction::URB_FUNCTION_SELECT_CONFIGURATION);
+    let TsUrbInKind::SelectConfig(urb) = request.ts_urb.kind else {
+        panic!("selection used the wrong TS_URB variant");
+    };
+    let config = urb.desc.expect("configuration descriptor is present");
+    assert_eq!(config.total_length, u16::try_from(CONFIGURATION.len()).unwrap());
+    assert_eq!(config.trailing, CONFIGURATION[9..]);
+    assert_eq!(urb.usbd_ifaces.len(), 2);
+    assert_eq!(urb.usbd_ifaces[0].interface_number, 0);
+    assert_eq!(urb.usbd_ifaces[0].alternate_setting, 0);
+    assert_eq!(urb.usbd_ifaces[0].ts_usbd_pipe_info.len(), 2);
+    assert_eq!(urb.usbd_ifaces[0].ts_usbd_pipe_info[0].max_packet_size, 192);
+    assert_eq!(urb.usbd_ifaces[0].ts_usbd_pipe_info[1].max_packet_size, 512);
+    assert_eq!(urb.usbd_ifaces[1].interface_number, 1);
+    assert_eq!(urb.usbd_ifaces[1].alternate_setting, 1);
+}
+
+#[test]
+fn select_interface_uses_the_selected_alternate_setting() {
+    let descriptor = ConfigurationDescriptorSet::parse(&CONFIGURATION)
+        .unwrap()
+        .validate()
+        .unwrap();
+
+    let request = select_interface(42, descriptor, selection(1, 1), UsbSpeed::High).unwrap();
+    assert_eq!(request.output_buffer_size, 0);
+    assert_eq!(request.ts_urb.func, UrbFunction::URB_FUNCTION_SELECT_INTERFACE);
+    let TsUrbInKind::SelectIface(urb) = request.ts_urb.kind else {
+        panic!("interface selection used the wrong TS_URB variant");
+    };
+    assert_eq!(urb.config_handle, 42);
+    assert_eq!(urb.usbd_iface.interface_number, 1);
+    assert_eq!(urb.usbd_iface.alternate_setting, 1);
+    assert_eq!(urb.usbd_iface.ts_usbd_pipe_info[0].max_packet_size, 32);
+}
+
+#[test]
+fn selection_completions_return_opaque_rdpeusb_results() {
+    let configuration_result = TsUrbSelectConfigResult {
+        config_handle: 42,
+        interface: Vec::new(),
+    };
+    let completion = CompletionData::TransferIn(TransferInCompletionResult {
+        ts_urb_result: TsUrbResult {
+            header: TsUrbResultHeader { usbd_status: 0 },
+            payload: Some(TsUrbResultPayload::SelectConfig(configuration_result.clone())),
+        },
+        hresult: 0,
+        output_buffer: Vec::new(),
+    });
+    assert_eq!(
+        select_configuration_completion(completion).unwrap(),
+        Ok(configuration_result)
+    );
+
+    let interface_result = TsUrbSelectInterfaceResult {
+        interface: TsUsbdInterfaceInfoResult {
+            interface_number: 3,
+            alternate_setting: 1,
+            class: 0xff,
+            sub_class: 0,
+            protocol: 0,
+            interface_handle: 77,
+            pipes: Vec::new(),
+        },
+    };
+    let completion = CompletionData::TransferIn(TransferInCompletionResult {
+        ts_urb_result: TsUrbResult {
+            header: TsUrbResultHeader { usbd_status: 0 },
+            payload: Some(TsUrbResultPayload::SelectIface(interface_result.clone())),
+        },
+        hresult: 0,
+        output_buffer: Vec::new(),
+    });
+    assert_eq!(select_interface_completion(completion).unwrap(), Ok(interface_result));
+}
+
+#[test]
+fn pipe_frame_and_reset_helpers_use_the_required_rdpeusb_envelopes() {
+    let request = reset_pipe_and_clear_stall(55);
+    assert_eq!(request.output_buffer_size, 0);
+    assert_eq!(
+        request.ts_urb.func,
+        UrbFunction::URB_FUNCTION_SYNC_RESET_PIPE_AND_CLEAR_STALL
+    );
+    let TsUrbInKind::PipeReq(urb) = request.ts_urb.kind else {
+        panic!("pipe reset used the wrong TS_URB variant");
+    };
+    assert_eq!(urb.pipe_handle, 55);
+    assert_eq!(
+        pipe_request_completion(transfer_in_completion(0, 0, Vec::new())).unwrap(),
+        Ok(())
+    );
+
+    let request = current_frame_number();
+    assert_eq!(request.output_buffer_size, 0);
+    assert_eq!(request.ts_urb.func, UrbFunction::URB_FUNCTION_GET_CURRENT_FRAME_NUMBER);
+    assert!(matches!(request.ts_urb.kind, TsUrbInKind::GetCurFrameNum(_)));
+    let completion = CompletionData::TransferIn(TransferInCompletionResult {
+        ts_urb_result: TsUrbResult {
+            header: TsUrbResultHeader { usbd_status: 0 },
+            payload: Some(TsUrbResultPayload::FrameNum(TsUrbGetCurrFrameNumResult {
+                frame_number: 1234,
+            })),
+        },
+        hresult: 0,
+        output_buffer: Vec::new(),
+    });
+    assert_eq!(current_frame_number_completion(completion).unwrap(), Ok(1234));
+
+    let request = reset_device();
+    assert_eq!(request.ioctl_code, IoctlInternalUsb::ResetPort);
+    assert!(request.input_buffer.is_empty());
+    assert_eq!(request.output_buffer_size, 0);
+    assert_eq!(
+        reset_device_completion(CompletionData::IoControl(IoControlCompletionResult {
+            hresult: 0,
+            information: 0,
+            output_buffer: Vec::new(),
+        }))
+        .unwrap(),
+        Ok(())
+    );
+}
+
+#[test]
+fn selection_rejects_inconsistent_interface_sets() {
+    let descriptor = ConfigurationDescriptorSet::parse(&CONFIGURATION)
+        .unwrap()
+        .validate()
+        .unwrap();
+    assert_eq!(
+        select_configuration(descriptor, &[selection(0, 0), selection(0, 0)], UsbSpeed::High).unwrap_err(),
+        ConversionError::DuplicateInterface { interface: 0 }
+    );
+    assert_eq!(
+        select_configuration(descriptor, &[selection(0, 0)], UsbSpeed::High).unwrap_err(),
+        ConversionError::MissingInterfaceSelection { interface: 1 }
+    );
+    let missing = selection(7, 0);
+    assert_eq!(
+        select_configuration(descriptor, &[missing], UsbSpeed::Full).unwrap_err(),
+        ConversionError::InterfaceNotFound { selection: missing }
+    );
+}
+
+#[test]
+fn unconfigure_has_an_empty_transfer_in_request() {
+    let request = unconfigure();
+    assert_eq!(request.output_buffer_size, 0);
+    let TsUrbInKind::SelectConfig(urb) = request.ts_urb.kind else {
+        panic!("unconfigure used the wrong TS_URB variant");
+    };
+    assert!(urb.desc.is_none());
+    assert!(urb.usbd_ifaces.is_empty());
+}
+
+#[test]
+fn selection_rejects_high_bandwidth_bits_at_other_speeds() {
+    let mut bytes = CONFIGURATION;
+    bytes[22] = 0x40;
+    bytes[23] = 0x08;
+    let descriptor = ConfigurationDescriptorSet::parse(&bytes).unwrap().validate().unwrap();
+
+    assert_eq!(
+        select_configuration(descriptor, &[selection(0, 0), selection(1, 1)], UsbSpeed::Full).unwrap_err(),
+        ConversionError::InvalidMaximumPacketSize {
+            selection: selection(0, 0),
+            raw: 0x0840
+        }
+    );
+}
+
+#[test]
+fn selection_enforces_usb2_speed_dependent_packet_sizes() {
+    let mut full_speed_bulk = CONFIGURATION;
+    full_speed_bulk[22] = 64;
+    full_speed_bulk[23] = 0;
+    full_speed_bulk[29] = 64;
+    full_speed_bulk[30] = 0;
+    let descriptor = ConfigurationDescriptorSet::parse(&full_speed_bulk)
+        .unwrap()
+        .validate()
+        .unwrap();
+    select_configuration(descriptor, &[selection(0, 0), selection(1, 1)], UsbSpeed::Full).unwrap();
+
+    let mut invalid_full_speed_bulk = full_speed_bulk;
+    invalid_full_speed_bulk[29] = 0;
+    invalid_full_speed_bulk[30] = 2;
+    let descriptor = ConfigurationDescriptorSet::parse(&invalid_full_speed_bulk)
+        .unwrap()
+        .validate()
+        .unwrap();
+    assert_eq!(
+        select_configuration(descriptor, &[selection(0, 0), selection(1, 1)], UsbSpeed::Full).unwrap_err(),
+        ConversionError::InvalidMaximumPacketSize {
+            selection: selection(0, 0),
+            raw: 512
+        }
+    );
+
+    let mut invalid_high_speed_bulk = CONFIGURATION;
+    invalid_high_speed_bulk[29] = 64;
+    invalid_high_speed_bulk[30] = 0;
+    let descriptor = ConfigurationDescriptorSet::parse(&invalid_high_speed_bulk)
+        .unwrap()
+        .validate()
+        .unwrap();
+    assert_eq!(
+        select_configuration(descriptor, &[selection(0, 0), selection(1, 1)], UsbSpeed::High).unwrap_err(),
+        ConversionError::InvalidMaximumPacketSize {
+            selection: selection(0, 0),
+            raw: 64
+        }
+    );
+}
+
+#[test]
+fn selection_enforces_default_interface_zero_isochronous_bandwidth() {
+    let mut zero_bandwidth = CONFIGURATION;
+    zero_bandwidth[21] = 1;
+    zero_bandwidth[22] = 0;
+    zero_bandwidth[23] = 0;
+    let descriptor = ConfigurationDescriptorSet::parse(&zero_bandwidth)
+        .unwrap()
+        .validate()
+        .unwrap();
+    let request = select_configuration(descriptor, &[selection(0, 0), selection(1, 1)], UsbSpeed::High).unwrap();
+    let TsUrbInKind::SelectConfig(urb) = request.ts_urb.kind else {
+        panic!("configuration selection used the wrong TS_URB variant");
+    };
+    assert_eq!(urb.usbd_ifaces[0].ts_usbd_pipe_info[0].max_packet_size, 0);
+
+    let mut nonzero_bandwidth = zero_bandwidth;
+    nonzero_bandwidth[22] = 1;
+    let descriptor = ConfigurationDescriptorSet::parse(&nonzero_bandwidth)
+        .unwrap()
+        .validate()
+        .unwrap();
+    assert_eq!(
+        select_configuration(descriptor, &[selection(0, 0), selection(1, 1)], UsbSpeed::High).unwrap_err(),
+        ConversionError::InvalidMaximumPacketSize {
+            selection: selection(0, 0),
+            raw: 1
+        }
+    );
+}


### PR DESCRIPTION
Part of #1516, also see: #1417

## What this adds

RDPEUSB carries USB operations as `TS_URB` structures with Windows USBD conventions: URB function codes, USBD transfer flags, pipe and configuration handles, and USBD status values. A caller that already speaks USB in protocol-independent terms should not have to assemble those by hand.

More to the point, assembling them by hand is where things go quietly wrong. The `TS_URB` payload, the URB function code, the transfer envelope, the flags, and the buffer shape all have to agree with each other, and nothing in the type system says so.

The new `usb` module maps `ironrdp-usb` requests onto **complete** backend-facing RDPEUSB packets, so those five cannot disagree, and maps completions back:

- descriptor, configuration, interface, status, feature, and vendor/class control requests;
- bulk, interrupt, and isochronous transfers, in both directions;
- configuration and interface selection, including the pipe information the client returns;
- pipe reset, device reset, and current frame number;
- USBD status to `UsbError` on the completion path.

The module is sans-I/O. It does not allocate request IDs, track device state, or manage pending-request lifetimes — those belong to the layer above, in #1417.

## Why this lives in `ironrdp-rdpeusb`

Choosing `TS_URB` forms and applying Windows USBD conventions is RDPEUSB knowledge, so the adapter belongs here. Its *inputs* stay protocol-independent, which is exactly what lets #1417 expose a device facade expressed in plain USB terms.

## Also in this PR

- **`CompletionData`** — the channel delivers four distinct completion result types, and a caller correlating completions against its own pending requests needs to name them uniformly. This enum lets a single type carry any RDPEUSB completion payload.
- **`BcdVersion` reuse** — `io::device::UsbBcdVersion` is removed in favour of `ironrdp_usb::BcdVersion`, which is the same type with the same `is_valid()` semantics. `ironrdp-rdpeusb` is `publish = false`, so this is not a break in any released API.

Tests are in `ironrdp-testsuite-core` (`tests/rdpeusb/usb.rs`) and cover the translation contract: which URB form each request maps to, the flag and handle values carried, and how completions are validated and unpacked.
