### PR TITLE
refactor(server): thread quantization values through the RemoteFX encoder

### DIFF
--- a/crates/ironrdp-server/src/encoder/mod.rs
+++ b/crates/ironrdp-server/src/encoder/mod.rs
@@ -4,6 +4,7 @@ use core::num::NonZeroU16;
 use anyhow::{Context as _, Result, anyhow};
 use ironrdp_acceptor::DesktopSize;
 use ironrdp_graphics::diff::{Rect, find_different_rects_sub};
+use ironrdp_pdu::codecs::rfx::Quant;
 use ironrdp_pdu::encode_vec;
 use ironrdp_pdu::fast_path::UpdateCode;
 use ironrdp_pdu::geometry::ExclusiveRectangle;
@@ -47,6 +48,11 @@ impl CodecId {
 #[derive(Debug)]
 pub(crate) struct UpdateEncoderCodecs {
     remotefx: Option<(EntropyBits, u8)>,
+    /// Quantization values for the RemoteFX encoder. Independent of
+    /// `remotefx` (entropy coder + codec id, negotiated from the client's
+    /// capabilities) because this is server-chosen, not client-negotiated:
+    /// [MS-RDPRFX] 2.2.2.1.5 leaves quantization entirely up to the sender.
+    remotefx_quant: Quant,
     #[cfg(feature = "qoi")]
     qoi: Option<u8>,
     #[cfg(feature = "qoiz")]
@@ -61,6 +67,7 @@ impl UpdateEncoderCodecs {
     pub(crate) fn new() -> Self {
         Self {
             remotefx: None,
+            remotefx_quant: Quant::default(),
             #[cfg(feature = "qoi")]
             qoi: None,
             #[cfg(feature = "qoiz")]
@@ -73,6 +80,15 @@ impl UpdateEncoderCodecs {
     #[cfg_attr(feature = "__bench", visibility::make(pub))]
     pub(crate) fn set_remotefx(&mut self, remotefx: Option<(EntropyBits, u8)>) {
         self.remotefx = remotefx
+    }
+
+    /// Set the quantization values the RemoteFX encoder uses once selected.
+    /// Has no effect unless `set_remotefx` also selects RemoteFX; kept
+    /// separate because quantization is server policy, not part of codec
+    /// selection.
+    #[cfg_attr(feature = "__bench", visibility::make(pub))]
+    pub(crate) fn set_remotefx_quant(&mut self, quant: Quant) {
+        self.remotefx_quant = quant
     }
 
     #[cfg(feature = "qoi")]
@@ -139,8 +155,9 @@ impl UpdateEncoder {
                 UpdateEncoderCodecs { qoi: Some(id), .. } => BitmapUpdater::Qoi(QoiHandler::new(id)),
                 UpdateEncoderCodecs {
                     remotefx: Some((algo, id)),
+                    remotefx_quant,
                     ..
-                } => BitmapUpdater::RemoteFx(RemoteFxHandler::new(algo, id, desktop_size)),
+                } => BitmapUpdater::RemoteFx(RemoteFxHandler::new(algo, remotefx_quant, id, desktop_size)),
                 // NSCodec is the lowest-priority codec because it predates
                 // RemoteFX and produces larger output. It's relevant mainly
                 // for clients (notably macOS Microsoft Remote Desktop /
@@ -550,9 +567,9 @@ struct RemoteFxHandler {
 }
 
 impl RemoteFxHandler {
-    fn new(algo: EntropyBits, codec_id: u8, desktop_size: DesktopSize) -> Self {
+    fn new(algo: EntropyBits, quant: Quant, codec_id: u8, desktop_size: DesktopSize) -> Self {
         Self {
-            remotefx: RfxEncoder::new(algo),
+            remotefx: RfxEncoder::new(algo, quant),
             desktop_size: Some(desktop_size),
             codec_id,
         }

--- a/crates/ironrdp-server/src/encoder/rfx.rs
+++ b/crates/ironrdp-server/src/encoder/rfx.rs
@@ -17,15 +17,19 @@ use crate::BitmapUpdate;
 #[derive(Debug, Clone)]
 pub(crate) struct RfxEncoder {
     entropy_algorithm: rfx::EntropyAlgorithm,
+    quant: Quant,
 }
 
 impl RfxEncoder {
-    pub(crate) fn new(entropy_bits: EntropyBits) -> Self {
+    pub(crate) fn new(entropy_bits: EntropyBits, quant: Quant) -> Self {
         let entropy_algorithm = match entropy_bits {
             EntropyBits::Rlgr1 => rfx::EntropyAlgorithm::Rlgr1,
             EntropyBits::Rlgr3 => rfx::EntropyAlgorithm::Rlgr3,
         };
-        Self { entropy_algorithm }
+        Self {
+            entropy_algorithm,
+            quant,
+        }
     }
 
     pub(crate) fn encode(
@@ -75,7 +79,7 @@ impl RfxEncoder {
         let region = RegionPdu { rectangles };
         Block::CodecChannel(CodecChannel::Region(region)).encode(&mut cursor)?;
 
-        let quant = Quant::default();
+        let quant = self.quant.clone();
 
         let (encoder, mut data) = UpdateEncoder::new(bitmap, quant.clone(), entropy_algorithm);
         let tiles = encoder.encode(&mut data)?;

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -16,6 +16,7 @@ use ironrdp_core::{decode, encode_vec, impl_as_any};
 use ironrdp_displaycontrol::pdu::DisplayControlMonitorLayout;
 use ironrdp_displaycontrol::server::{DisplayControlHandler, DisplayControlServer};
 use ironrdp_dvc as dvc;
+use ironrdp_pdu::codecs::rfx::Quant;
 use ironrdp_pdu::input::InputEventPdu;
 use ironrdp_pdu::input::fast_path::{FastPathInput, FastPathInputEvent};
 use ironrdp_pdu::mcs::{SendDataIndication, SendDataRequest};
@@ -1772,6 +1773,7 @@ impl RdpServer {
                             {
                                 for caps in c.caps_data.0.0 {
                                     update_codecs.set_remotefx(Some((caps.entropy_bits, codec.id)));
+                                    update_codecs.set_remotefx_quant(Quant::default());
                                 }
                             }
                             CodecProperty::ImageRemoteFx(rdp::capability_sets::RemoteFxContainer::ClientContainer(
@@ -1779,6 +1781,7 @@ impl RdpServer {
                             )) if self.opts.has_image_remote_fx() => {
                                 for caps in c.caps_data.0.0 {
                                     update_codecs.set_remotefx(Some((caps.entropy_bits, codec.id)));
+                                    update_codecs.set_remotefx_quant(Quant::default());
                                 }
                             }
                             #[cfg(feature = "nscodec")]


### PR DESCRIPTION
RfxEncoder hardcoded Quant::default() at the point of use instead of accepting it as encoder state. Add a quant field to RfxEncoder and a remotefx_quant field to UpdateEncoderCodecs, with a setter that mirrors the existing set_remotefx pattern.

Per [MS-RDPRFX] 2.2.2.1.5, quantization is chosen entirely by the sender and isn't part of capability negotiation, so making it configurable is purely a server-side plumbing problem. This is the first step: give the encoder somewhere to actually hold and use a caller-chosen Quant. #1557 asks for the ability to set it; this PR doesn't add that public entry point yet, it just makes the encoder capable of taking one.

Server behavior is unchanged. The capability negotiation call site still passes Quant::default(), so this is pure plumbing with no functional change.
