### PR TITLE
feat(server): make the RemoteFX quantization table configurable

### DIFF
--- a/crates/ironrdp-pdu/src/codecs/rfx/data_messages.rs
+++ b/crates/ironrdp-pdu/src/codecs/rfx/data_messages.rs
@@ -581,6 +581,17 @@ impl Quant {
 
         Ok(())
     }
+
+    /// Rejects any subband value outside [`Quant::VALID_RANGE`].
+    ///
+    /// `try_new` already runs this check on construction. Use this to validate a
+    /// [`Quant`] built some other way, such as via its public struct-literal fields,
+    /// before using it anywhere the out-of-range case would be worse than an error
+    /// (e.g. as a pixel-domain quantization factor, where it's a shift amount rather
+    /// than a wire field, ahead of any [`Encode::encode`] call).
+    pub fn validate(&self) -> EncodeResult<()> {
+        self.ensure_valid()
+    }
 }
 
 impl Encode for Quant {

--- a/crates/ironrdp-pdu/src/codecs/rfx/data_messages.rs
+++ b/crates/ironrdp-pdu/src/codecs/rfx/data_messages.rs
@@ -511,10 +511,81 @@ impl Quant {
     const NAME: &'static str = "RfxFrameEnd";
 
     const FIXED_PART_SIZE: usize = 5 /* 10 * 4 bits */;
+
+    /// [2.2.2.1.5] encodes each quantization value as a 4-bit field. The valid
+    /// range is 6 to 15, same as documented on [`Quant`]'s [`Default`] impl.
+    ///
+    /// [2.2.2.1.5]: https://learn.microsoft.com/pt-br/openspecs/windows_protocols/ms-rdprfx/3e9c8af4-7539-4c9d-95de-14b1558b902c
+    pub const VALID_RANGE: core::ops::RangeInclusive<u8> = 6..=15;
+
+    /// Builds a [`Quant`], rejecting any subband value outside [`Quant::VALID_RANGE`].
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "one 4-bit field per DWT subband, matching TS_RFX_CODEC_QUANT"
+    )]
+    pub fn try_new(
+        ll3: u8,
+        lh3: u8,
+        hl3: u8,
+        hh3: u8,
+        lh2: u8,
+        hl2: u8,
+        hh2: u8,
+        lh1: u8,
+        hl1: u8,
+        hh1: u8,
+    ) -> EncodeResult<Self> {
+        let quant = Self {
+            ll3,
+            lh3,
+            hl3,
+            hh3,
+            lh2,
+            hl2,
+            hh2,
+            lh1,
+            hl1,
+            hh1,
+        };
+        quant.ensure_valid()?;
+        Ok(quant)
+    }
+
+    /// Rejects any subband value outside [`Quant::VALID_RANGE`].
+    ///
+    /// `try_new` runs this on construction, but [`Quant`]'s fields are public
+    /// and predate `try_new`, so a caller can still build one via a struct
+    /// literal and hand it to [`Encode::encode`] directly. Checked again
+    /// there rather than trusted, since a value that doesn't fit its 4-bit
+    /// wire slot panics `bit_field::BitField::set_bits` instead of erroring.
+    fn ensure_valid(&self) -> EncodeResult<()> {
+        for (field, value) in [
+            ("ll3", self.ll3),
+            ("lh3", self.lh3),
+            ("hl3", self.hl3),
+            ("hh3", self.hh3),
+            ("lh2", self.lh2),
+            ("hl2", self.hl2),
+            ("hh2", self.hh2),
+            ("lh1", self.lh1),
+            ("hl1", self.hl1),
+            ("hh1", self.hh1),
+        ] {
+            if !Self::VALID_RANGE.contains(&value) {
+                return Err(invalid_field_err!(
+                    field,
+                    "quantization value outside of the 6..=15 range"
+                ));
+            }
+        }
+
+        Ok(())
+    }
 }
 
 impl Encode for Quant {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        self.ensure_valid()?;
         ensure_fixed_part_size!(in: dst);
 
         let mut level3 = 0;

--- a/crates/ironrdp-server/src/builder.rs
+++ b/crates/ironrdp-server/src/builder.rs
@@ -3,6 +3,7 @@ use core::sync::atomic::{AtomicBool, AtomicU32};
 use std::sync::Arc;
 
 use anyhow::Result;
+use ironrdp_pdu::codecs::rfx::Quant;
 use ironrdp_pdu::rdp::capability_sets::{BitmapCodecs, server_codecs_capabilities};
 use ironrdp_pdu::rdp::session_info::ServerAutoReconnect;
 use tokio_rustls::TlsAcceptor;
@@ -48,6 +49,7 @@ pub struct BuilderDone {
     autodetect_rtt: Option<Arc<AtomicU32>>,
     honor_client_desktop_size: Option<DesktopSize>,
     auto_reconnect_cookie: Option<ServerAutoReconnect>,
+    remotefx_quant: Quant,
 }
 
 pub struct RdpServerBuilder<State> {
@@ -151,6 +153,7 @@ impl RdpServerBuilder<WantsDisplay> {
                 autodetect_rtt: None,
                 honor_client_desktop_size: None,
                 auto_reconnect_cookie: None,
+                remotefx_quant: Quant::default(),
             },
         }
     }
@@ -175,6 +178,7 @@ impl RdpServerBuilder<WantsDisplay> {
                 autodetect_rtt: None,
                 honor_client_desktop_size: None,
                 auto_reconnect_cookie: None,
+                remotefx_quant: Quant::default(),
             },
         }
     }
@@ -334,6 +338,17 @@ impl RdpServerBuilder<BuilderDone> {
         self
     }
 
+    /// Set the quantization values the RemoteFX encoder uses once selected.
+    /// Defaults to [`Quant::default`], the same values Windows RDP servers
+    /// send. Build a validated [`Quant`] with [`Quant::try_new`].
+    ///
+    /// Has no effect unless the client and server negotiate RemoteFX; this
+    /// only changes the quantization RemoteFX uses when it is picked.
+    pub fn with_remotefx_quant(mut self, quant: Quant) -> Self {
+        self.state.remotefx_quant = quant;
+        self
+    }
+
     pub fn build(self) -> RdpServer {
         let mut server = RdpServer::new(
             RdpServerOptions {
@@ -342,6 +357,7 @@ impl RdpServerBuilder<BuilderDone> {
                 codecs: self.state.codecs,
                 max_request_size: self.state.max_request_size,
                 honor_client_desktop_size: self.state.honor_client_desktop_size,
+                remotefx_quant: self.state.remotefx_quant,
             },
             self.state.handler,
             self.state.display,

--- a/crates/ironrdp-server/src/encoder/rfx.rs
+++ b/crates/ironrdp-server/src/encoder/rfx.rs
@@ -80,6 +80,7 @@ impl RfxEncoder {
         Block::CodecChannel(CodecChannel::Region(region)).encode(&mut cursor)?;
 
         let quant = self.quant.clone();
+        quant.validate()?;
 
         let (encoder, mut data) = UpdateEncoder::new(bitmap, quant.clone(), entropy_algorithm);
         let tiles = encoder.encode(&mut data)?;

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -248,6 +248,11 @@ pub struct RdpServerOptions {
     /// server-provided size. Set via
     /// [`RdpServerBuilder::with_honor_client_desktop_size`](crate::RdpServerBuilder::with_honor_client_desktop_size).
     pub honor_client_desktop_size: Option<DesktopSize>,
+    /// Quantization values the RemoteFX encoder uses once selected. Defaults
+    /// to [`Quant::default`], the same values Windows RDP servers send. Set
+    /// via
+    /// [`RdpServerBuilder::with_remotefx_quant`](crate::RdpServerBuilder::with_remotefx_quant).
+    pub remotefx_quant: Quant,
 }
 
 impl RdpServerOptions {
@@ -1773,7 +1778,7 @@ impl RdpServer {
                             {
                                 for caps in c.caps_data.0.0 {
                                     update_codecs.set_remotefx(Some((caps.entropy_bits, codec.id)));
-                                    update_codecs.set_remotefx_quant(Quant::default());
+                                    update_codecs.set_remotefx_quant(self.opts.remotefx_quant.clone());
                                 }
                             }
                             CodecProperty::ImageRemoteFx(rdp::capability_sets::RemoteFxContainer::ClientContainer(
@@ -1781,7 +1786,7 @@ impl RdpServer {
                             )) if self.opts.has_image_remote_fx() => {
                                 for caps in c.caps_data.0.0 {
                                     update_codecs.set_remotefx(Some((caps.entropy_bits, codec.id)));
-                                    update_codecs.set_remotefx_quant(Quant::default());
+                                    update_codecs.set_remotefx_quant(self.opts.remotefx_quant.clone());
                                 }
                             }
                             #[cfg(feature = "nscodec")]

--- a/crates/ironrdp-testsuite-core/tests/pdu/rfx.rs
+++ b/crates/ironrdp-testsuite-core/tests/pdu/rfx.rs
@@ -435,3 +435,45 @@ fn quant_encode_rejects_a_bypassed_value_that_does_not_fit_its_wire_slot() {
 
     encode_vec(&quant).unwrap_err();
 }
+
+/// `validate` exists for callers on the other side of the same gap: code that
+/// receives a struct-literal-built [`Quant`] before it ever reaches
+/// [`Encode::encode`], and needs to reject an out-of-range value before doing
+/// anything with the fields itself (e.g. using one as a pixel-domain shift
+/// amount, where an unchecked value is a shift-overflow panic or a masked,
+/// wrong shift rather than a wire-format error).
+#[test]
+fn quant_validate_rejects_a_bypassed_value_out_of_range() {
+    let quant = Quant {
+        ll3: 6,
+        lh3: 6,
+        hl3: 6,
+        hh3: 6,
+        lh2: 7,
+        hl2: 7,
+        hh2: 8,
+        lh1: 8,
+        hl1: 8,
+        hh1: 255,
+    };
+
+    quant.validate().unwrap_err();
+}
+
+#[test]
+fn quant_validate_accepts_a_bypassed_value_in_range() {
+    let quant = Quant {
+        ll3: 6,
+        lh3: 6,
+        hl3: 6,
+        hh3: 6,
+        lh2: 7,
+        hl2: 7,
+        hh2: 8,
+        lh1: 8,
+        hl1: 8,
+        hh1: 9,
+    };
+
+    quant.validate().unwrap();
+}

--- a/crates/ironrdp-testsuite-core/tests/pdu/rfx.rs
+++ b/crates/ironrdp-testsuite-core/tests/pdu/rfx.rs
@@ -1,7 +1,7 @@
 use std::sync::LazyLock;
 
 use ironrdp_pdu::codecs::rfx::*;
-use ironrdp_pdu::decode;
+use ironrdp_pdu::{decode, encode_vec};
 use ironrdp_testsuite_core::encode_decode_test;
 
 const SYNC_PDU_BUFFER: [u8; 12] = [
@@ -374,4 +374,64 @@ fn from_buffer_returns_error_on_invalid_number_of_quants_for_tile_set_pdu() {
 #[test]
 fn from_buffer_returns_error_on_invalid_tiles_data_size_for_tile_set_pdu() {
     decode::<Block<'_>>(TILESET_PDU_BUFFER_WITH_INVALID_TILES_DATA_SIZE.as_ref()).unwrap_err();
+}
+
+#[test]
+fn quant_try_new_accepts_the_full_valid_range() {
+    Quant::try_new(6, 15, 6, 15, 6, 15, 6, 15, 6, 15).unwrap();
+}
+
+#[test]
+fn quant_try_new_rejects_a_value_below_the_valid_range() {
+    Quant::try_new(5, 6, 6, 6, 7, 7, 8, 8, 8, 9).unwrap_err();
+}
+
+#[test]
+fn quant_try_new_rejects_a_value_above_the_valid_range() {
+    Quant::try_new(6, 6, 6, 6, 7, 7, 8, 8, 8, 16).unwrap_err();
+}
+
+/// `try_new` is not the only way to build a [`Quant`]: its ten fields are
+/// public, so a struct literal reaches [`Encode::encode`] with no validation
+/// at all unless `encode` checks for itself. This value still fits its 4-bit
+/// wire slot (0..16), so nothing here would panic; without the check, it
+/// would encode a spec-violating value onto the wire silently.
+#[test]
+fn quant_encode_rejects_a_bypassed_value_below_the_valid_range() {
+    let quant = Quant {
+        ll3: 5,
+        lh3: 6,
+        hl3: 6,
+        hh3: 6,
+        lh2: 7,
+        hl2: 7,
+        hh2: 8,
+        lh1: 8,
+        hl1: 8,
+        hh1: 9,
+    };
+
+    encode_vec(&quant).unwrap_err();
+}
+
+/// The other direction of the same gap: a value that does not fit its 4-bit
+/// wire slot at all. Without the check, this panics inside
+/// `bit_field::BitField::set_bits` (`value does not fit into bit range`)
+/// rather than returning the `EncodeResult` the signature promises.
+#[test]
+fn quant_encode_rejects_a_bypassed_value_that_does_not_fit_its_wire_slot() {
+    let quant = Quant {
+        ll3: 6,
+        lh3: 6,
+        hl3: 6,
+        hh3: 6,
+        lh2: 7,
+        hl2: 7,
+        hh2: 8,
+        lh1: 8,
+        hl1: 8,
+        hh1: 16,
+    };
+
+    encode_vec(&quant).unwrap_err();
 }


### PR DESCRIPTION
Add Quant::try_new(), a validating constructor that rejects any subband value outside the 6..=15 range, and RdpServerBuilder::with_remotefx_quant(quant: Quant), wiring it through RdpServerOptions to the same capability-negotiation call site #1684 touched.

Per [MS-RDPRFX] 2.2.2.1.5, each of the 10 TS_RFX_CODEC_QUANT values is a 4-bit field, and the legal range is 6 to 15. #1557 reports the quant table is hardcoded to Quant::default(); this gives callers a validated way to set it instead.

Builds on #1684, which added the storage this PR wires up. Default behavior is unchanged: with_remotefx_quant is opt-in, and a server that doesn't call it still gets Quant::default(), the same values Windows RDP servers send.

Closes #1557.
