### PR TITLE
fix(server): weigh RemoteFX ICAP entropy coders instead of taking the last

### DIFF
--- a/crates/ironrdp-server/src/builder.rs
+++ b/crates/ironrdp-server/src/builder.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use ironrdp_pdu::codecs::rfx::Quant;
-use ironrdp_pdu::rdp::capability_sets::{BitmapCodecs, server_codecs_capabilities};
+use ironrdp_pdu::rdp::capability_sets::{BitmapCodecs, EntropyBits, server_codecs_capabilities};
 use ironrdp_pdu::rdp::session_info::ServerAutoReconnect;
 use tokio_rustls::TlsAcceptor;
 
@@ -50,6 +50,7 @@ pub struct BuilderDone {
     honor_client_desktop_size: Option<DesktopSize>,
     auto_reconnect_cookie: Option<ServerAutoReconnect>,
     remotefx_quant: Quant,
+    remotefx_entropy_coder: Option<EntropyBits>,
 }
 
 pub struct RdpServerBuilder<State> {
@@ -154,6 +155,7 @@ impl RdpServerBuilder<WantsDisplay> {
                 honor_client_desktop_size: None,
                 auto_reconnect_cookie: None,
                 remotefx_quant: Quant::default(),
+                remotefx_entropy_coder: None,
             },
         }
     }
@@ -179,6 +181,7 @@ impl RdpServerBuilder<WantsDisplay> {
                 honor_client_desktop_size: None,
                 auto_reconnect_cookie: None,
                 remotefx_quant: Quant::default(),
+                remotefx_entropy_coder: None,
             },
         }
     }
@@ -349,6 +352,23 @@ impl RdpServerBuilder<BuilderDone> {
         self
     }
 
+    /// State a preferred RemoteFX entropy coder (RLGR1 or RLGR3). If the
+    /// client's advertised TS_RFX_ICAP array includes it, the server uses
+    /// it; otherwise the server falls back to whichever coder the client
+    /// offered first.
+    ///
+    /// `None` (the default) always uses whichever coder the client offered
+    /// first: [MS-RDPRFX] 3.1.5.1 has the server arbitrarily pick one
+    /// supported TS_RFX_ICAP element rather than rank the array as a
+    /// preference order. Has no effect unless the client and server
+    /// negotiate RemoteFX.
+    ///
+    /// [MS-RDPRFX]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdprfx/
+    pub fn with_remotefx_entropy_coder(mut self, coder: Option<EntropyBits>) -> Self {
+        self.state.remotefx_entropy_coder = coder;
+        self
+    }
+
     pub fn build(self) -> RdpServer {
         let mut server = RdpServer::new(
             RdpServerOptions {
@@ -358,6 +378,7 @@ impl RdpServerBuilder<BuilderDone> {
                 max_request_size: self.state.max_request_size,
                 honor_client_desktop_size: self.state.honor_client_desktop_size,
                 remotefx_quant: self.state.remotefx_quant,
+                remotefx_entropy_coder: self.state.remotefx_entropy_coder,
             },
             self.state.handler,
             self.state.display,

--- a/crates/ironrdp-server/src/lib.rs
+++ b/crates/ironrdp-server/src/lib.rs
@@ -37,7 +37,7 @@ pub use ironrdp_pdu::rdp::session_info::ServerAutoReconnect;
 pub use server::{
     AutoReconnectCookieHandle, ConnectionHandler, ConnectionInfo, CredentialDecision, CredentialValidationError,
     CredentialValidator, Credentials, ExactMatchCredentialValidator, PostConnectionAction, RdpServer, RdpServerOptions,
-    RdpServerSecurity, ServerEvent, ServerEventSender, StaticChannelFactory, TransportTls,
+    RdpServerSecurity, ServerEvent, ServerEventSender, StaticChannelFactory, TransportTls, pick_remotefx_entropy_coder,
 };
 pub use sound::{RdpsndServerHandler, RdpsndServerMessage, SoundServerFactory};
 

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -20,7 +20,9 @@ use ironrdp_pdu::codecs::rfx::Quant;
 use ironrdp_pdu::input::InputEventPdu;
 use ironrdp_pdu::input::fast_path::{FastPathInput, FastPathInputEvent};
 use ironrdp_pdu::mcs::{SendDataIndication, SendDataRequest};
-use ironrdp_pdu::rdp::capability_sets::{BitmapCodecs, CapabilitySet, CmdFlags, CodecProperty, GeneralExtraFlags};
+use ironrdp_pdu::rdp::capability_sets::{
+    BitmapCodecs, CapabilitySet, CmdFlags, CodecProperty, EntropyBits, GeneralExtraFlags,
+};
 pub use ironrdp_pdu::rdp::client_info::Credentials;
 use ironrdp_pdu::rdp::headers::{ServerDeactivateAll, ShareControlPdu};
 use ironrdp_pdu::rdp::server_error_info::{ErrorInfo, ProtocolIndependentCode, ServerSetErrorInfoPdu};
@@ -299,6 +301,17 @@ pub struct RdpServerOptions {
     /// via
     /// [`RdpServerBuilder::with_remotefx_quant`](crate::RdpServerBuilder::with_remotefx_quant).
     pub remotefx_quant: Quant,
+    /// Preferred RemoteFX entropy coder. If the client's advertised
+    /// TS_RFX_ICAP array includes it, the server uses it; otherwise the
+    /// server falls back to whichever coder the client offered first.
+    /// `None` (the default) always uses whichever coder is offered first,
+    /// since [MS-RDPRFX] 3.1.5.1 has the server arbitrarily pick one
+    /// supported TS_RFX_ICAP element rather than rank the array as a
+    /// preference order. Set via
+    /// [`RdpServerBuilder::with_remotefx_entropy_coder`](crate::RdpServerBuilder::with_remotefx_entropy_coder).
+    ///
+    /// [MS-RDPRFX]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdprfx/
+    pub remotefx_entropy_coder: Option<EntropyBits>,
 }
 
 impl RdpServerOptions {
@@ -349,6 +362,28 @@ impl RdpServerOptions {
             .iter()
             .any(|codec| matches!(codec.property, CodecProperty::NsCodec(_)))
     }
+}
+
+/// Picks a RemoteFX entropy coder out of the client's advertised TS_RFX_ICAP
+/// array. Returns `preferred` if the client offered it, otherwise the first
+/// coder the client offered. Returns `None` if `offered` is empty.
+pub fn pick_remotefx_entropy_coder(
+    preferred: Option<EntropyBits>,
+    offered: impl Iterator<Item = EntropyBits>,
+) -> Option<EntropyBits> {
+    let mut first = None;
+
+    for entropy_bits in offered {
+        if first.is_none() {
+            first = Some(entropy_bits);
+        }
+
+        if preferred == Some(entropy_bits) {
+            return Some(entropy_bits);
+        }
+    }
+
+    first
 }
 
 #[derive(Clone)]
@@ -1826,22 +1861,24 @@ impl RdpServer {
                             // implementation of the video mode. which allows to
                             // skip sending Header for each image.
                             //
-                            // We should distinguish parameters for both modes,
-                            // and somehow choose the "best", instead of picking
-                            // the last parsed here.
+                            // We should distinguish parameters for both modes.
                             CodecProperty::RemoteFx(rdp::capability_sets::RemoteFxContainer::ClientContainer(c))
                                 if self.opts.has_remote_fx() =>
                             {
-                                for caps in c.caps_data.0.0 {
-                                    update_codecs.set_remotefx(Some((caps.entropy_bits, codec.id)));
+                                let offered = c.caps_data.0.0.iter().map(|caps| caps.entropy_bits);
+                                let preferred = self.opts.remotefx_entropy_coder;
+                                if let Some(entropy_bits) = pick_remotefx_entropy_coder(preferred, offered) {
+                                    update_codecs.set_remotefx(Some((entropy_bits, codec.id)));
                                     update_codecs.set_remotefx_quant(self.opts.remotefx_quant.clone());
                                 }
                             }
                             CodecProperty::ImageRemoteFx(rdp::capability_sets::RemoteFxContainer::ClientContainer(
                                 c,
                             )) if self.opts.has_image_remote_fx() => {
-                                for caps in c.caps_data.0.0 {
-                                    update_codecs.set_remotefx(Some((caps.entropy_bits, codec.id)));
+                                let offered = c.caps_data.0.0.iter().map(|caps| caps.entropy_bits);
+                                let preferred = self.opts.remotefx_entropy_coder;
+                                if let Some(entropy_bits) = pick_remotefx_entropy_coder(preferred, offered) {
+                                    update_codecs.set_remotefx(Some((entropy_bits, codec.id)));
                                     update_codecs.set_remotefx_quant(self.opts.remotefx_quant.clone());
                                 }
                             }

--- a/crates/ironrdp-testsuite-core/tests/server/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/server/mod.rs
@@ -2,3 +2,4 @@ mod acceptor;
 mod autodetect;
 mod credential_validator;
 mod fast_path;
+mod remotefx_entropy_coder;

--- a/crates/ironrdp-testsuite-core/tests/server/remotefx_entropy_coder.rs
+++ b/crates/ironrdp-testsuite-core/tests/server/remotefx_entropy_coder.rs
@@ -1,0 +1,43 @@
+use ironrdp_pdu::rdp::capability_sets::EntropyBits;
+use ironrdp_server::pick_remotefx_entropy_coder;
+
+#[test]
+fn no_preference_picks_whichever_coder_is_offered_first() {
+    let offered = [EntropyBits::Rlgr1, EntropyBits::Rlgr3].into_iter();
+    assert_eq!(pick_remotefx_entropy_coder(None, offered), Some(EntropyBits::Rlgr1));
+
+    let offered = [EntropyBits::Rlgr3, EntropyBits::Rlgr1].into_iter();
+    assert_eq!(pick_remotefx_entropy_coder(None, offered), Some(EntropyBits::Rlgr3));
+}
+
+#[test]
+fn preference_wins_regardless_of_offered_order() {
+    let offered = [EntropyBits::Rlgr1, EntropyBits::Rlgr3].into_iter();
+    assert_eq!(
+        pick_remotefx_entropy_coder(Some(EntropyBits::Rlgr3), offered),
+        Some(EntropyBits::Rlgr3)
+    );
+
+    let offered = [EntropyBits::Rlgr3, EntropyBits::Rlgr1].into_iter();
+    assert_eq!(
+        pick_remotefx_entropy_coder(Some(EntropyBits::Rlgr1), offered),
+        Some(EntropyBits::Rlgr1)
+    );
+}
+
+#[test]
+fn unoffered_preference_falls_back_to_whichever_coder_is_offered_first() {
+    let offered = [EntropyBits::Rlgr3].into_iter();
+    assert_eq!(
+        pick_remotefx_entropy_coder(Some(EntropyBits::Rlgr1), offered),
+        Some(EntropyBits::Rlgr3)
+    );
+}
+
+#[test]
+fn nothing_offered_picks_nothing() {
+    assert_eq!(
+        pick_remotefx_entropy_coder(Some(EntropyBits::Rlgr1), core::iter::empty()),
+        None
+    );
+}


### PR DESCRIPTION
The client's advertised TS_RFX_ICAP array was folded with a plain assignment in the capability exchange loop, so whichever entry happened to be parsed last silently decided the entropy coder. Add pick_remotefx_entropy_coder and RdpServerBuilder::with_remotefx_entropy_coder so the caller can state a preferred coder, with a documented fallback instead of an accidental one.

Per MS-RDPRFX 2.2.1.1.1.1, the TS_RFX_ICAP array is the set of codecs the client supports, not a ranked preference, so the server is entitled to pick any entry. With no preference configured, the new fallback is whichever coder the client offers first, which is deterministic and matches the array's natural order, instead of whichever happened to be parsed last. mstsc sends RLGR1 then RLGR3, so today's last-wins behavior always lands on RLGR3, and RLGR1 never runs against a real client.

Builds on #1684 and #1685, which give the quant table (#1557) the same server-side shape. Default behavior changes for clients that offer both coders: the server now uses the first-offered coder instead of the last-offered one, unless with_remotefx_entropy_coder states otherwise.

Closes #1562.
