### PR TITLE
feat(rdpeudp): add the async driver for the RDP-UDP transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros 4.1.0",
  "thiserror 2.0.19",
+ "time",
 ]
 
 [[package]]
@@ -458,7 +459,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -466,6 +467,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bit_field"
@@ -1285,6 +1295,7 @@ dependencies = [
  "asn1-rs",
  "displaydoc",
  "nom 7.1.3",
+ "num-bigint 0.4.8",
  "num-traits",
  "rusticata-macros 4.1.0",
 ]
@@ -3046,6 +3057,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ironrdp-rdpeudp-tokio"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "ironrdp-async",
+ "ironrdp-core 0.2.1",
+ "ironrdp-error 0.2.0",
+ "ironrdp-pdu",
+ "ironrdp-rdpemt",
+ "ironrdp-rdpeudp",
+ "sha2 0.10.9",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+]
+
+[[package]]
 name = "ironrdp-rdpeusb"
 version = "0.1.0"
 dependencies = [
@@ -3267,6 +3295,9 @@ dependencies = [
  "ironrdp-propertyset",
  "ironrdp-rdpdr",
  "ironrdp-rdpdr-native",
+ "ironrdp-rdpemt",
+ "ironrdp-rdpeudp",
+ "ironrdp-rdpeudp-tokio",
  "ironrdp-rdpsnd",
  "ironrdp-rdpsnd-native",
  "ironrdp-rpc",
@@ -3275,8 +3306,10 @@ dependencies = [
  "ironrdp-tokio",
  "ironrdp-viewer",
  "ironrdp-vmconnect",
+ "rcgen",
  "semver",
  "tokio",
+ "tokio-rustls",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -4284,6 +4317,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4500,6 +4542,16 @@ dependencies = [
  "circular",
  "nom 8.0.0",
  "rusticata-macros 5.0.0",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
 ]
 
 [[package]]
@@ -4904,7 +4956,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
- "bit-vec",
+ "bit-vec 0.8.0",
  "bitflags 2.13.1",
  "num-traits",
  "rand 0.9.4",
@@ -5156,6 +5208,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceda21af1ae61033b63175653a1af86cae399d79cd03ca80ba347eb3a6c4a7fe"
 dependencies = [
  "cipher 0.5.2",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091e7a8e7d86e6feb87a27ce8e2cba29d49eff9507afeebefab7eeb2ca667fb4"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
 ]
 
 [[package]]
@@ -7556,6 +7622,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry",
+ "ring",
+ "rusticata-macros 4.1.0",
+ "thiserror 2.0.19",
+ "time",
+]
+
+[[package]]
 name = "xcursor"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7610,6 +7694,16 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/crates/ironrdp-rdpeudp-tokio/Cargo.toml
+++ b/crates/ironrdp-rdpeudp-tokio/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "ironrdp-rdpeudp-tokio"
+version = "0.1.0"
+readme = "README.md"
+description = "Tokio driver wiring RDP-UDP, TLS and the multitransport tunnel into a usable transport"
+edition.workspace = true
+rust-version = "1.94"
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lib]
+doctest = false
+
+[features]
+# No default: matches `ironrdp-tls`'s own stance. Neither feature changes
+# behavior for a consumer that already installs a process-default
+# CryptoProvider itself (for example by depending on `ironrdp-tls` in the
+# same process); they exist for a consumer using this crate standalone, so
+# `ClientConfig::builder()` doesn't panic for lack of one.
+rustls-aws-lc-rs = ["tokio-rustls/aws_lc_rs"]
+rustls-ring = ["tokio-rustls/ring"]
+
+[dependencies]
+ironrdp-async = { path = "../ironrdp-async", version = "0.10" } # public
+ironrdp-core = { path = "../ironrdp-core", version = "0.2", features = ["std"] } # public
+ironrdp-error = { path = "../ironrdp-error", version = "0.2" } # public
+ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9", features = ["std"] } # public
+ironrdp-rdpemt = { path = "../ironrdp-rdpemt", version = "0.1", features = ["std"] } # public
+ironrdp-rdpeudp = { path = "../ironrdp-rdpeudp", version = "0.1", features = ["std"] } # public
+bytes = "1"
+tokio = { version = "1", features = ["io-util", "macros", "net", "rt", "sync", "time"] } # public
+sha2 = "0.10"
+# Mirrors `ironrdp-tls`: rustls is reached through `tokio_rustls::rustls` rather
+# than declared separately. The crypto provider is not bundled, so the process
+# default must be installed before connecting.
+tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12"] } # public
+tracing = { version = "0.1", features = ["log"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util"] }
+
+[lints]
+workspace = true

--- a/crates/ironrdp-rdpeudp-tokio/README.md
+++ b/crates/ironrdp-rdpeudp-tokio/README.md
@@ -1,0 +1,55 @@
+# IronRDP RDP-UDP Tokio
+
+Tokio driver wiring the RDP-UDP transport, TLS and the multitransport tunnel
+into a usable async transport.
+
+This crate is the I/O layer for three sans-I/O pieces:
+
+- [`ironrdp-rdpeudp`](../ironrdp-rdpeudp): reliable UDP with congestion control
+- `tokio-rustls`: encryption over the RDP-UDP byte stream
+- [`ironrdp-rdpemt`](../ironrdp-rdpemt): tunnel negotiation and data framing
+
+## Architecture
+
+```text
+Application <-> UdpTransport (channels)
+                     |
+              Driver task (tokio::spawn)
+              owns UdpSocket + RdpeudpConnection
+                     |
+              RdpeudpStream (AsyncRead/AsyncWrite adapter)
+                     |
+              TLS (tokio-rustls)
+                     |
+              multitransport tunnel (data framing)
+```
+
+The driver task owns the socket and the connection state machine. It is also
+the only place in the stack that reads a clock: `RdpeudpConnection` takes the
+current instant as an argument and reports the deadline it next wants, so the
+state machine stays testable and free of ambient time.
+
+## Usage
+
+```rust,ignore
+use ironrdp_rdpemt::TunnelConfig;
+use ironrdp_rdpeudp_tokio::{UdpTransportConfig, connect_udp};
+
+let config = UdpTransportConfig::new(
+    server_addr,
+    "rdp-server.example.com".into(),
+    TunnelConfig { request_id, security_cookie },
+);
+
+let mut transport = connect_udp(config).await?;
+
+// Send higher-layer data.
+transport.send(dvc_frame).await?;
+
+// Receive higher-layer data.
+while let Some(data) = transport.recv().await {
+    process_dvc_frame(&data);
+}
+
+transport.shutdown().await?;
+```

--- a/crates/ironrdp-rdpeudp-tokio/src/clock.rs
+++ b/crates/ironrdp-rdpeudp-tokio/src/clock.rs
@@ -1,0 +1,79 @@
+//! The clock the sans-I/O state machine deliberately does not have.
+//!
+//! [`ironrdp_rdpeudp::RdpeudpConnection`] never reads a clock. It takes a
+//! [`MonotonicInstant`] on every call that can advance time, and reports the
+//! deadline it next wants through `poll_timeout`. This module is the only place
+//! in the transport that calls [`Instant::now`], and it translates in both
+//! directions across that boundary.
+
+use core::time::Duration;
+use std::time::Instant;
+
+use ironrdp_rdpeudp::MonotonicInstant;
+
+/// Translates between the driver's [`Instant`] readings and the millisecond
+/// instants the state machine understands.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Clock {
+    epoch: Instant,
+}
+
+impl Clock {
+    /// Starts a clock whose epoch is now.
+    pub(crate) fn new() -> Self {
+        Self { epoch: Instant::now() }
+    }
+
+    /// The current reading.
+    pub(crate) fn now(&self) -> MonotonicInstant {
+        self.reading(Instant::now())
+    }
+
+    /// The reading for an instant the driver already observed, such as the
+    /// moment a datagram came off the socket.
+    pub(crate) fn reading(&self, instant: Instant) -> MonotonicInstant {
+        let elapsed = instant.saturating_duration_since(self.epoch).as_millis();
+        MonotonicInstant::from_millis(u64::try_from(elapsed).unwrap_or(u64::MAX))
+    }
+
+    /// The [`Instant`] a state-machine deadline corresponds to, for handing to
+    /// `tokio::time::sleep_until`.
+    pub(crate) fn deadline(&self, instant: MonotonicInstant) -> Instant {
+        self.epoch
+            .checked_add(Duration::from_millis(instant.as_millis()))
+            .unwrap_or(self.epoch)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn readings_advance_with_the_epoch() {
+        let clock = Clock::new();
+        let epoch = clock.epoch;
+
+        assert_eq!(clock.reading(epoch), MonotonicInstant::from_millis(0));
+        assert_eq!(
+            clock.reading(epoch + Duration::from_millis(250)),
+            MonotonicInstant::from_millis(250)
+        );
+    }
+
+    #[test]
+    fn readings_saturate_before_the_epoch() {
+        let clock = Clock::new();
+        let before = clock.epoch - Duration::from_secs(1);
+
+        assert_eq!(clock.reading(before), MonotonicInstant::from_millis(0));
+    }
+
+    #[test]
+    fn deadlines_round_trip_through_readings() {
+        let clock = Clock::new();
+        let instant = MonotonicInstant::from_millis(1_500);
+
+        assert_eq!(clock.reading(clock.deadline(instant)), instant);
+    }
+}

--- a/crates/ironrdp-rdpeudp-tokio/src/driver.rs
+++ b/crates/ironrdp-rdpeudp-tokio/src/driver.rs
@@ -1,0 +1,650 @@
+//! Driver task: the async event loop bridging UDP socket ↔ sans-I/O state machine.
+//!
+//! A single `tokio::spawn`'d task owns the `UdpSocket` and `RdpeudpConnection`,
+//! running a `select!` loop over three event sources:
+//!
+//! 1. **UDP recv**: incoming datagrams from the network
+//! 2. **Write data**: the TLS layer has plaintext to transmit
+//! 3. **Timer**: RDPEUDP2 retransmit / ACK-delay / keep-alive / idle timeouts
+//!
+//! The driver communicates with the `RdpeudpStream` (which tokio-rustls wraps)
+//! through `Arc<Mutex<SharedIo>>`.
+
+use crate::clock::Clock;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use std::io;
+use std::sync::{Arc, Mutex};
+
+use ironrdp_rdpeudp::pdu::{V1Datagram, V1Flags};
+use ironrdp_rdpeudp::{Event, RdpeudpConnection, RdpeudpError, RdpeudpErrorKind};
+use tokio::net::UdpSocket;
+use tokio::sync::Notify;
+
+use crate::error::{DriverError, DriverErrorExt as _, DriverErrorKind};
+use crate::stream::SharedIo;
+
+/// Maximum UDP datagram size we'll attempt to receive.
+/// RDPEUDP2 typically negotiates 1232-byte MTU, but we budget
+/// a full Ethernet jumbo frame for safety.
+const RECV_BUF_SIZE: usize = 9000;
+
+/// How many undelivered bytes may pile up in `SharedIo::read_buf` before the
+/// driver stops taking packets off the socket.
+///
+/// Nothing else bounds it. The receive window limits how much the peer may
+/// have in flight, but the driver drains that window into `read_buf` on every
+/// pass, so a peer sending faster than the TLS and tunnel layers consume grows
+/// it without limit and the process runs out of memory.
+///
+/// Ceasing to read is real backpressure rather than a dropped-on-the-floor
+/// policy: unread datagrams stay in the socket buffer, our acknowledgements
+/// stop, and [MS-RDPEUDP2] 3.1.1.2.2's receive window closes on the sender,
+/// which is the protocol's own way of saying "wait".
+const READ_BUF_HIGH_WATER: usize = 1 << 20;
+
+// ════════════════════════════════════════════════════════════════════
+// Driver
+// ════════════════════════════════════════════════════════════════════
+
+/// The driver task's internal state.
+pub(crate) struct Driver {
+    socket: UdpSocket,
+    conn: RdpeudpConnection,
+    shared: Arc<Mutex<SharedIo>>,
+    /// Notified by the driver when Event::Connected fires.
+    connected_notify: Arc<Notify>,
+    /// Whether Event::Connected has already been signaled.
+    connected_signaled: bool,
+    /// Receive buffer (reused across iterations).
+    recv_buf: Vec<u8>,
+    /// The only clock in the stack; the state machine has none.
+    clock: Clock,
+}
+
+impl Driver {
+    pub(crate) fn new(
+        socket: UdpSocket,
+        conn: RdpeudpConnection,
+        shared: Arc<Mutex<SharedIo>>,
+        connected_notify: Arc<Notify>,
+    ) -> Self {
+        Self {
+            socket,
+            conn,
+            shared,
+            connected_notify,
+            connected_signaled: false,
+            recv_buf: vec![0u8; RECV_BUF_SIZE],
+            clock: Clock::new(),
+        }
+    }
+
+    /// Run the driver event loop until the connection closes or errors.
+    pub(crate) async fn run(mut self) -> Result<(), DriverError> {
+        let result = self.run_to_completion().await;
+
+        // However this ended, the stream side has to hear about it. A reader
+        // parked in `poll_read` has left its waker here and nothing else will
+        // poll it, so returning an error without coming through here hangs
+        // that task for the life of the process.
+        self.release_stream(result.as_ref().err());
+
+        result
+    }
+
+    /// Mark the shared state closed and wake everything waiting on it.
+    fn release_stream(&self, error: Option<&DriverError>) {
+        let Ok(mut shared) = self.shared.lock() else {
+            // A poisoned lock means the stream side already panicked, and
+            // there is nothing left to wake.
+            return;
+        };
+
+        if let Some(error) = error {
+            let kind = match error.kind() {
+                DriverErrorKind::Socket(io_error) => io_error.kind(),
+                DriverErrorKind::Rdpeudp(_) => io::ErrorKind::InvalidData,
+                DriverErrorKind::ConnectionClosed => io::ErrorKind::ConnectionAborted,
+            };
+            shared.error.get_or_insert(kind);
+        }
+
+        shared.closed = true;
+
+        for waker in [
+            shared.read_waker.take(),
+            shared.write_waker.take(),
+            shared.flush_waker.take(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            waker.wake();
+        }
+    }
+
+    async fn run_to_completion(&mut self) -> Result<(), DriverError> {
+        // Send any initial transmits (the SYN packet for client-side connections)
+        self.drain_transmits().await?;
+
+        loop {
+            let timeout = self
+                .conn
+                .poll_timeout()
+                .map(|deadline| tokio::time::Instant::from_std(self.clock.deadline(deadline)));
+
+            // Reading a datagram may append to `read_buf`, so stop reading while
+            // it is over its mark and wait for the consumer instead.
+            let has_room = self.read_buf_has_room();
+
+            // Not `biased`: branches 1-3 can all be genuinely ready at once
+            // (incoming data, a queued TLS write, and an expired timer), and
+            // fixed-order priority would let a continuously-readable socket
+            // (steady traffic, or an adversarial ACK-only flood that never
+            // fills read_buf) starve the write and timer branches forever.
+            // Branch 0 and 1 are mutually exclusive via their `has_room`
+            // guards, so fairness between them is moot either way.
+            tokio::select! {
+                // Branch 0: the consumer caught up, so go round again and read.
+                _ = ReadBufDrained::new(&self.shared), if !has_room => {}
+
+                // Branch 1: Incoming UDP datagram (highest priority)
+                result = self.socket.recv(&mut self.recv_buf), if has_room => {
+                    let n = result.map_err(|error| DriverError::socket("receive datagram", error))?;
+                    let now = self.clock.now();
+
+                    // handle_datagram takes &mut [u8] for in-place prefix byte swap
+                    match self.conn.handle_datagram(&mut self.recv_buf[..n], now) {
+                        Ok(()) => {}
+                        // One datagram the state machine cannot make sense of
+                        // is not grounds for tearing down the connection. UDP
+                        // delivers whatever arrives at the socket, including
+                        // corruption and anything an off-path sender puts
+                        // there, and a peer whose retransmitted handshake
+                        // datagram lands late produces this too. Drop it and
+                        // carry on; a genuinely dead connection still closes
+                        // on the idle timeout.
+                        Err(error) if is_droppable(&error) => {
+                            tracing::debug!(%error, "dropping an unusable datagram");
+                        }
+                        Err(error) => return Err(DriverError::rdpeudp("handle datagram", error)),
+                    }
+
+                    self.drain_transmits().await?;
+                    self.drain_events();
+                }
+
+                // Branch 2: TLS layer has data to send
+                _ = WriteDataReady::new(&self.shared) => {
+                    let (data, stream_closed, flush_waker) = {
+                        let mut shared = self.shared.lock()
+                            .map_err(|_| DriverError::connection_closed("lock shared state"))?;
+                        let closed = shared.closed && shared.write_buf.is_empty();
+                        let buf = shared.write_buf.split().freeze().to_vec();
+                        let flush = shared.flush_waker.take();
+                        (buf, closed, flush)
+                    };
+                    // Wake any pending flush (write_buf has been drained)
+                    if let Some(waker) = flush_waker {
+                        waker.wake();
+                    }
+                    if stream_closed {
+                        self.conn.close();
+                        self.drain_events();
+                        return Ok(());
+                    }
+                    if !data.is_empty() {
+                        self.conn
+                            .send(data)
+                            .map_err(|error| DriverError::rdpeudp("queue outbound data", error))?;
+                        self.drain_transmits().await?;
+                    }
+                }
+
+                // Branch 3: Timer expiry
+                _ = optional_sleep(timeout) => {
+                    let now = self.clock.now();
+                    self.conn.handle_timeout(now);
+                    self.drain_transmits().await?;
+                    self.drain_events();
+                }
+            }
+
+            if self.conn.is_closed() {
+                // Propagate close to the stream side
+                let mut shared = self
+                    .shared
+                    .lock()
+                    .map_err(|_| DriverError::connection_closed("lock shared state"))?;
+                shared.closed = true;
+                if let Some(waker) = shared.read_waker.take() {
+                    waker.wake();
+                }
+                return Ok(());
+            }
+        }
+    }
+
+    /// Whether `read_buf` is under its high-water mark.
+    ///
+    /// A poisoned lock means the stream side is gone, in which case there is
+    /// no reason to keep throttling; the loop will notice and exit.
+    fn read_buf_has_room(&self) -> bool {
+        self.shared
+            .lock()
+            .map_or(true, |shared| shared.read_buf.len() < READ_BUF_HIGH_WATER)
+    }
+
+    /// Send all pending transmits to the UDP socket.
+    async fn drain_transmits(&mut self) -> Result<(), DriverError> {
+        let now = self.clock.now();
+        while let Some(transmit) = self.conn.poll_transmit(now) {
+            // `RdpeudpConnection` never hands back a V1Datagram once
+            // established (only prefix-framed V2 packets), so there is
+            // nothing to check on the data path.
+            let bytes = if self.conn.is_established() {
+                transmit.contents
+            } else {
+                pad_handshake_datagram(transmit.contents)
+            };
+
+            self.socket
+                .send(&bytes)
+                .await
+                .map_err(|error| DriverError::socket("send datagram", error))?;
+        }
+        Ok(())
+    }
+
+    /// Process all pending events from the connection state machine.
+    fn drain_events(&mut self) {
+        while let Some(event) = self.conn.poll_event() {
+            match event {
+                Event::Connected => {
+                    if !self.connected_signaled {
+                        self.connected_signaled = true;
+                        self.connected_notify.notify_one();
+                    }
+                }
+                Event::DataReceived(data) => {
+                    if let Ok(mut shared) = self.shared.lock() {
+                        shared.read_buf.extend_from_slice(&data);
+                        if let Some(waker) = shared.read_waker.take() {
+                            waker.wake();
+                        }
+                    }
+                }
+                Event::ConnectionClosed => {
+                    if let Ok(mut shared) = self.shared.lock() {
+                        shared.closed = true;
+                        if let Some(waker) = shared.read_waker.take() {
+                            waker.wake();
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Helper futures
+// ════════════════════════════════════════════════════════════════════
+
+/// Future that resolves when `SharedIo::write_buf` has data OR when
+/// the stream is shut down.
+///
+/// Cancel-safe: only registers a waker, no side effects on drop.
+/// Resolves once `read_buf` has fallen back under its high-water mark.
+struct ReadBufDrained {
+    shared: Arc<Mutex<SharedIo>>,
+}
+
+impl ReadBufDrained {
+    fn new(shared: &Arc<Mutex<SharedIo>>) -> Self {
+        Self {
+            shared: Arc::clone(shared),
+        }
+    }
+}
+
+impl Future for ReadBufDrained {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        let Ok(mut shared) = self.shared.lock() else {
+            return Poll::Ready(());
+        };
+
+        if shared.read_buf.len() < READ_BUF_HIGH_WATER || shared.closed {
+            return Poll::Ready(());
+        }
+
+        shared.read_drained_waker = Some(cx.waker().clone());
+        Poll::Pending
+    }
+}
+
+struct WriteDataReady {
+    shared: Arc<Mutex<SharedIo>>,
+}
+
+impl WriteDataReady {
+    fn new(shared: &Arc<Mutex<SharedIo>>) -> Self {
+        Self {
+            shared: Arc::clone(shared),
+        }
+    }
+}
+
+impl Future for WriteDataReady {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        let Ok(mut shared) = self.shared.lock() else {
+            return Poll::Ready(());
+        };
+
+        if !shared.write_buf.is_empty() || shared.closed {
+            return Poll::Ready(());
+        }
+
+        shared.write_waker = Some(cx.waker().clone());
+        Poll::Pending
+    }
+}
+
+/// Sleep until the given deadline, or pend forever if `None`.
+async fn optional_sleep(deadline: Option<tokio::time::Instant>) {
+    match deadline {
+        Some(deadline) => tokio::time::sleep_until(deadline).await,
+        None => core::future::pending().await,
+    }
+}
+
+/// Zero-pad a SYN or SYN+ACK datagram to the smaller of its own advertised
+/// upstream and downstream MTU.
+///
+/// [MS-RDPEUDP] 3.1.5.1.1: "This datagram MUST be zero-padded to increase
+/// the size of this datagram to uUpStreamMtu or uDownStreamMtu, whichever is
+/// smaller", inherited by the SYN+ACK via 3.1.5.1.3 ("A SYN+ACK datagram
+/// consists of a SYN packet, generated as specified in section 3.1.5.1.1").
+/// `V1Datagram::encode` deliberately does not do this itself: it has no
+/// socket to size against, so the responsibility falls to whoever hands the
+/// bytes to one.
+///
+/// Every other handshake datagram (the plain final ACK) is returned
+/// unchanged; §3.1.5.1.2 carries no padding requirement.
+fn pad_handshake_datagram(mut bytes: Vec<u8>) -> Vec<u8> {
+    let Ok(datagram) = ironrdp_core::decode::<V1Datagram>(&bytes) else {
+        return bytes;
+    };
+    if !datagram.header.flags.contains(V1Flags::SYN) {
+        return bytes;
+    }
+    let Some(syn_data) = datagram.syn_data.as_ref() else {
+        return bytes;
+    };
+
+    let target = usize::from(syn_data.upstream_mtu.min(syn_data.downstream_mtu));
+    if bytes.len() < target {
+        bytes.resize(target, 0);
+    }
+    bytes
+}
+
+/// Whether a datagram that the state machine rejected can simply be dropped.
+///
+/// Anything the peer could put on the wire, deliberately or by accident, is
+/// droppable: a malformed packet, a packet that makes no sense in the current
+/// state. What is not droppable is the state machine reporting that this end
+/// is finished, which is a real reason to stop the loop.
+fn is_droppable(error: &RdpeudpError) -> bool {
+    matches!(
+        error.kind(),
+        RdpeudpErrorKind::Decode(_)
+            | RdpeudpErrorKind::Prefix(_)
+            | RdpeudpErrorKind::InvalidPacket { .. }
+            | RdpeudpErrorKind::InvalidState
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use core::time::Duration;
+
+    use ironrdp_rdpeudp::ConnectionConfig;
+
+    /// `connect` requires the cookie hash a version 3 SYN carries. These tests
+    /// never reach a real multitransport request, so any value will do.
+    fn test_connection_config() -> ConnectionConfig {
+        ConnectionConfig {
+            cookie_hash: Some([0x5A; 32]),
+            ..ConnectionConfig::default()
+        }
+    }
+    use ironrdp_rdpeudp::RdpeudpErrorExt as _;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn driver_sends_initial_syn() {
+        // Bind two UDP sockets on localhost to simulate client/server
+        let client_sock = UdpSocket::bind("127.0.0.1:0").await.expect("bind client");
+        let server_sock = UdpSocket::bind("127.0.0.1:0").await.expect("bind server");
+
+        let server_addr = server_sock.local_addr().expect("server addr");
+        client_sock.connect(server_addr).await.expect("connect");
+
+        let conn = RdpeudpConnection::connect(test_connection_config(), Clock::new().now()).expect("connect");
+
+        let shared = Arc::new(Mutex::new(SharedIo::new()));
+        let notify = Arc::new(Notify::new());
+        let driver = Driver::new(client_sock, conn, shared, notify);
+
+        // Run the driver briefly: it should send the SYN packet
+        let handle = tokio::spawn(driver.run());
+
+        // Receive the SYN on the server side
+        let mut buf = [0u8; 1500];
+        let recv_result = tokio::time::timeout(Duration::from_secs(2), server_sock.recv(&mut buf)).await;
+
+        assert!(recv_result.is_ok(), "should receive SYN packet");
+        let n = recv_result.expect("timeout").expect("recv");
+        assert_eq!(
+            n,
+            usize::from(ironrdp_rdpeudp::pdu::MTU_MAX),
+            "the SYN should be zero-padded to the negotiated MTU, not sent at its natural encoded size"
+        );
+
+        // Abort the driver (we only needed to test the initial SYN)
+        handle.abort();
+    }
+
+    /// The driver stops reading once `read_buf` is full, and starts again once
+    /// the consumer has taken bytes out.
+    ///
+    /// The resume half is the part that is easy to leave out: without a wake
+    /// from `poll_read` the driver sits throttled until some unrelated timer
+    /// happens to fire, which on an idle connection is the keep-alive, eight
+    /// seconds away.
+    #[tokio::test]
+    async fn a_full_read_buffer_throttles_the_driver_until_it_drains() {
+        let socket = UdpSocket::bind("127.0.0.1:0").await.expect("bind");
+        let conn = RdpeudpConnection::connect(test_connection_config(), Clock::new().now()).expect("connect");
+
+        let shared = Arc::new(Mutex::new(SharedIo::new()));
+        let driver = Driver::new(socket, conn, Arc::clone(&shared), Arc::new(Notify::new()));
+
+        assert!(driver.read_buf_has_room(), "an empty buffer has room");
+
+        shared
+            .lock()
+            .expect("lock")
+            .read_buf
+            .extend_from_slice(&vec![0u8; READ_BUF_HIGH_WATER]);
+
+        assert!(!driver.read_buf_has_room(), "a full buffer does not");
+
+        // Park on the resume future, then let a reader take the bytes out.
+        let waiter = tokio::spawn({
+            let shared = Arc::clone(&shared);
+            async move { ReadBufDrained::new(&shared).await }
+        });
+
+        tokio::task::yield_now().await;
+        assert!(!waiter.is_finished(), "it should still be waiting");
+
+        let mut stream = crate::stream::RdpeudpStream::new(Arc::clone(&shared));
+        let mut buf = vec![0u8; READ_BUF_HIGH_WATER];
+        tokio::io::AsyncReadExt::read(&mut stream, &mut buf)
+            .await
+            .expect("read");
+
+        tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("the driver was never told the buffer drained")
+            .expect("join");
+
+        assert!(driver.read_buf_has_room());
+    }
+
+    /// Anything the peer can put on the wire is droppable; our own state
+    /// machine telling us this end is finished is not.
+    #[test]
+    fn droppable_errors_are_the_ones_the_peer_controls() {
+        assert!(is_droppable(&RdpeudpError::invalid_packet("test", "malformed")));
+        assert!(!is_droppable(&RdpeudpError::connection_closed("test")));
+    }
+
+    /// A driver that exits on an error has to release the stream side. A
+    /// reader parked in `poll_read` left its waker in the shared state and
+    /// nothing else is going to poll it.
+    #[tokio::test]
+    async fn an_error_exit_wakes_a_parked_reader() {
+        let socket = UdpSocket::bind("127.0.0.1:0").await.expect("bind");
+        let conn = RdpeudpConnection::connect(test_connection_config(), Clock::new().now()).expect("connect");
+
+        let shared = Arc::new(Mutex::new(SharedIo::new()));
+        let woken = Arc::new(core::sync::atomic::AtomicBool::new(false));
+
+        {
+            let mut guard = shared.lock().expect("lock");
+            guard.read_waker = Some(futures_waker(Arc::clone(&woken)));
+        }
+
+        let driver = Driver::new(socket, conn, Arc::clone(&shared), Arc::new(Notify::new()));
+        driver.release_stream(Some(&DriverError::connection_closed("test")));
+
+        assert!(
+            woken.load(core::sync::atomic::Ordering::SeqCst),
+            "the reader was left parked"
+        );
+
+        let guard = shared.lock().expect("lock");
+        assert!(guard.closed);
+        assert_eq!(guard.error, Some(io::ErrorKind::ConnectionAborted));
+    }
+
+    /// Build a waker that records having been woken.
+    fn futures_waker(flag: Arc<core::sync::atomic::AtomicBool>) -> core::task::Waker {
+        struct Flag(Arc<core::sync::atomic::AtomicBool>);
+
+        impl std::task::Wake for Flag {
+            fn wake(self: Arc<Self>) {
+                self.0.store(true, core::sync::atomic::Ordering::SeqCst);
+            }
+        }
+
+        core::task::Waker::from(Arc::new(Flag(flag)))
+    }
+
+    fn test_syn(upstream_mtu: u16, downstream_mtu: u16) -> V1Datagram {
+        V1Datagram {
+            header: ironrdp_rdpeudp::pdu::FecHeader {
+                sn_source_ack: 0xFFFF_FFFF,
+                receive_window_size: 64,
+                flags: V1Flags::SYN,
+            },
+            ack_vector: None,
+            ack_of_acks: None,
+            syn_data: Some(ironrdp_rdpeudp::pdu::SynDataPayload {
+                initial_sequence_number: 1,
+                upstream_mtu,
+                downstream_mtu,
+            }),
+            correlation_id: None,
+            syn_data_ex: None,
+        }
+    }
+
+    #[test]
+    fn pads_a_syn_to_the_smaller_advertised_mtu() {
+        let datagram = test_syn(1200, 1150);
+        let encoded = ironrdp_core::encode_vec(&datagram).expect("encode");
+        let natural_len = encoded.len();
+
+        let padded = pad_handshake_datagram(encoded);
+
+        assert_eq!(padded.len(), 1150, "should pad to the smaller of the two MTUs");
+        assert!(
+            padded[natural_len..].iter().all(|&b| b == 0),
+            "padding must be zero bytes"
+        );
+        // The bytes before the padding are untouched.
+        let redecoded: V1Datagram = ironrdp_core::decode(&padded).expect("decode padded");
+        assert_eq!(redecoded.syn_data, datagram.syn_data);
+    }
+
+    #[test]
+    fn pads_a_syn_ack_the_same_way() {
+        let mut datagram = test_syn(1232, 1232);
+        datagram.header.flags |= V1Flags::ACK;
+        datagram.header.sn_source_ack = 42;
+        let encoded = ironrdp_core::encode_vec(&datagram).expect("encode");
+
+        let padded = pad_handshake_datagram(encoded);
+
+        assert_eq!(padded.len(), 1232);
+    }
+
+    /// The plain final ACK carries no SYN flag, and MS-RDPEUDP 3.1.5.1.2
+    /// gives it no padding requirement.
+    #[test]
+    fn leaves_the_final_ack_unpadded() {
+        let datagram = V1Datagram {
+            header: ironrdp_rdpeudp::pdu::FecHeader {
+                sn_source_ack: 7,
+                receive_window_size: 64,
+                flags: V1Flags::ACK,
+            },
+            ack_vector: Some(ironrdp_rdpeudp::pdu::V1AckVectorHeader {
+                elements: vec![ironrdp_rdpeudp::pdu::V1AckVectorElement {
+                    state: ironrdp_rdpeudp::pdu::VectorElementState::DatagramReceived,
+                    length: 1,
+                }],
+            }),
+            ack_of_acks: None,
+            syn_data: None,
+            correlation_id: None,
+            syn_data_ex: None,
+        };
+        let encoded = ironrdp_core::encode_vec(&datagram).expect("encode");
+        let natural_len = encoded.len();
+
+        let padded = pad_handshake_datagram(encoded);
+
+        assert_eq!(padded.len(), natural_len, "a plain ACK must not be padded");
+    }
+
+    /// Bytes that don't decode as a V1Datagram at all (e.g. a prefix-framed
+    /// V2 data packet, which the caller never actually passes here, but the
+    /// function must still be safe against) pass through unchanged.
+    #[test]
+    fn leaves_non_v1_datagram_bytes_unchanged() {
+        let bytes = vec![0xFFu8; 12];
+        let padded = pad_handshake_datagram(bytes.clone());
+        assert_eq!(padded, bytes);
+    }
+}

--- a/crates/ironrdp-rdpeudp-tokio/src/error.rs
+++ b/crates/ironrdp-rdpeudp-tokio/src/error.rs
@@ -1,0 +1,216 @@
+//! Error types for the async UDP transport.
+
+use core::fmt;
+use std::io;
+
+use ironrdp_pdu::rdp::multitransport::RequestedProtocol;
+use ironrdp_rdpemt::RdpemtError;
+use ironrdp_rdpeudp::RdpeudpError;
+
+pub type DriverResult<T> = Result<T, DriverError>;
+
+pub type DriverError = ironrdp_error::Error<DriverErrorKind>;
+
+/// A fatal condition in the driver task.
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum DriverErrorKind {
+    /// The UDP socket failed.
+    Socket(io::Error),
+
+    /// The RDP-UDP state machine rejected an operation.
+    Rdpeudp(RdpeudpError),
+
+    /// The peer closed the connection, or the idle timeout fired.
+    ConnectionClosed,
+}
+
+impl fmt::Display for DriverErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Socket(_) => write!(f, "UDP socket error"),
+            Self::Rdpeudp(_) => write!(f, "RDP-UDP error"),
+            Self::ConnectionClosed => write!(f, "connection is closed"),
+        }
+    }
+}
+
+impl core::error::Error for DriverErrorKind {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::Socket(error) => Some(error),
+            Self::Rdpeudp(error) => Some(error),
+            Self::ConnectionClosed => None,
+        }
+    }
+}
+
+pub trait DriverErrorExt {
+    fn socket(context: &'static str, error: io::Error) -> Self;
+    fn rdpeudp(context: &'static str, error: RdpeudpError) -> Self;
+    fn connection_closed(context: &'static str) -> Self;
+}
+
+impl DriverErrorExt for DriverError {
+    #[track_caller]
+    fn socket(context: &'static str, error: io::Error) -> Self {
+        Self::new(context, DriverErrorKind::Socket(error))
+    }
+
+    #[track_caller]
+    fn rdpeudp(context: &'static str, error: RdpeudpError) -> Self {
+        Self::new(context, DriverErrorKind::Rdpeudp(error))
+    }
+
+    #[track_caller]
+    fn connection_closed(context: &'static str) -> Self {
+        Self::new(context, DriverErrorKind::ConnectionClosed)
+    }
+}
+
+pub type UdpTransportResult<T> = Result<T, UdpTransportError>;
+
+pub type UdpTransportError = ironrdp_error::Error<UdpTransportErrorKind>;
+
+/// A failure somewhere in the connection sequence: UDP handshake, then TLS,
+/// then the multitransport tunnel.
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum UdpTransportErrorKind {
+    /// The UDP socket failed.
+    Socket(io::Error),
+
+    /// The RDP-UDP handshake failed.
+    Handshake(DriverError),
+
+    /// The RDP-UDP handshake did not complete within the configured budget.
+    HandshakeTimeout,
+
+    /// The TLS handshake failed.
+    Tls(io::Error),
+
+    /// The tunnel state machine rejected an operation.
+    Rdpemt(RdpemtError),
+
+    /// The peer rejected the tunnel creation request.
+    TunnelRejected { hr_response: u32 },
+
+    /// The driver task ended without reporting an outcome.
+    DriverPanic,
+
+    /// The driver task reported a fatal condition.
+    Driver(DriverError),
+
+    /// The server requested a transport variant this driver does not
+    /// implement (only `UdpFecR` is supported; `UdpFecL` is not).
+    UnsupportedProtocol { requested: RequestedProtocol },
+
+    /// A `send()` payload exceeds the wire `PayloadLength` field's 65535-byte
+    /// capacity ([MS-RDPEMT] 2.2.2.3, `RDP_TUNNEL_DATA`).
+    PayloadTooLarge { len: usize },
+}
+
+impl fmt::Display for UdpTransportErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Socket(_) => write!(f, "UDP socket error"),
+            Self::Handshake(_) => write!(f, "RDP-UDP handshake failed"),
+            Self::HandshakeTimeout => write!(f, "RDP-UDP handshake timed out"),
+            Self::Tls(_) => write!(f, "TLS error"),
+            Self::Rdpemt(_) => write!(f, "multitransport tunnel error"),
+            Self::TunnelRejected { hr_response } => {
+                write!(f, "tunnel creation rejected: HRESULT {hr_response:#010x}")
+            }
+            Self::DriverPanic => write!(f, "driver task ended without an outcome"),
+            Self::Driver(_) => write!(f, "driver error"),
+            Self::UnsupportedProtocol { requested } => {
+                write!(f, "requested transport protocol not supported: {requested:?}")
+            }
+            Self::PayloadTooLarge { len } => {
+                write!(
+                    f,
+                    "send payload of {len} bytes exceeds the 65535-byte tunnel data limit"
+                )
+            }
+        }
+    }
+}
+
+impl core::error::Error for UdpTransportErrorKind {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::Socket(error) => Some(error),
+            Self::Tls(error) => Some(error),
+            Self::Handshake(error) => Some(error),
+            Self::Driver(error) => Some(error),
+            Self::Rdpemt(error) => Some(error),
+            Self::HandshakeTimeout | Self::TunnelRejected { .. } | Self::DriverPanic => None,
+            Self::UnsupportedProtocol { .. } | Self::PayloadTooLarge { .. } => None,
+        }
+    }
+}
+
+pub trait UdpTransportErrorExt {
+    fn socket(context: &'static str, error: io::Error) -> Self;
+    fn handshake(context: &'static str, error: DriverError) -> Self;
+    fn handshake_timeout(context: &'static str) -> Self;
+    fn tls(context: &'static str, error: io::Error) -> Self;
+    fn rdpemt(context: &'static str, error: RdpemtError) -> Self;
+    fn tunnel_rejected(context: &'static str, hr_response: u32) -> Self;
+    fn driver_panic(context: &'static str) -> Self;
+    fn driver(context: &'static str, error: DriverError) -> Self;
+    fn unsupported_protocol(context: &'static str, requested: RequestedProtocol) -> Self;
+    fn payload_too_large(context: &'static str, len: usize) -> Self;
+}
+
+impl UdpTransportErrorExt for UdpTransportError {
+    #[track_caller]
+    fn socket(context: &'static str, error: io::Error) -> Self {
+        Self::new(context, UdpTransportErrorKind::Socket(error))
+    }
+
+    #[track_caller]
+    fn handshake(context: &'static str, error: DriverError) -> Self {
+        Self::new(context, UdpTransportErrorKind::Handshake(error))
+    }
+
+    #[track_caller]
+    fn handshake_timeout(context: &'static str) -> Self {
+        Self::new(context, UdpTransportErrorKind::HandshakeTimeout)
+    }
+
+    #[track_caller]
+    fn tls(context: &'static str, error: io::Error) -> Self {
+        Self::new(context, UdpTransportErrorKind::Tls(error))
+    }
+
+    #[track_caller]
+    fn rdpemt(context: &'static str, error: RdpemtError) -> Self {
+        Self::new(context, UdpTransportErrorKind::Rdpemt(error))
+    }
+
+    #[track_caller]
+    fn tunnel_rejected(context: &'static str, hr_response: u32) -> Self {
+        Self::new(context, UdpTransportErrorKind::TunnelRejected { hr_response })
+    }
+
+    #[track_caller]
+    fn driver_panic(context: &'static str) -> Self {
+        Self::new(context, UdpTransportErrorKind::DriverPanic)
+    }
+
+    #[track_caller]
+    fn driver(context: &'static str, error: DriverError) -> Self {
+        Self::new(context, UdpTransportErrorKind::Driver(error))
+    }
+
+    #[track_caller]
+    fn unsupported_protocol(context: &'static str, requested: RequestedProtocol) -> Self {
+        Self::new(context, UdpTransportErrorKind::UnsupportedProtocol { requested })
+    }
+
+    #[track_caller]
+    fn payload_too_large(context: &'static str, len: usize) -> Self {
+        Self::new(context, UdpTransportErrorKind::PayloadTooLarge { len })
+    }
+}

--- a/crates/ironrdp-rdpeudp-tokio/src/framed.rs
+++ b/crates/ironrdp-rdpeudp-tokio/src/framed.rs
@@ -1,0 +1,183 @@
+//! `FramedRead` + `FramedWrite` trait implementations for `UdpTransport`.
+//!
+//! These allow `UdpTransport` to be used with `ironrdp-async`'s `Framed`
+//! infrastructure, so the session layer can read/write DVC frames over
+//! the UDP tunnel using the same trait interface as the TCP path.
+//!
+//! Unlike TCP (which is a byte stream requiring `find_size()` framing),
+//! UDP tunnel data arrives as complete RDPEMT-deframed messages. Each
+//! `read()` appends exactly one message to the buffer.
+
+use core::pin::Pin;
+use std::io;
+
+use bytes::BytesMut;
+use ironrdp_async::{FramedRead, FramedWrite};
+
+use crate::transport::UdpTransport;
+
+impl FramedRead for UdpTransport {
+    type ReadFut<'read>
+        = Pin<Box<dyn Future<Output = io::Result<usize>> + Send + Sync + 'read>>
+    where
+        Self: 'read;
+
+    fn read<'a>(&'a mut self, buf: &'a mut BytesMut) -> Self::ReadFut<'a> {
+        Box::pin(async move {
+            // `ironrdp_async::Framed` reads a zero return as end of stream, so
+            // an empty message must never be reported as one. Carrying no
+            // higher-layer bytes is not the same as the peer hanging up.
+            //
+            // Empty Tunnel Data PDUs are ordinary traffic. [MS-RDPEMT] 2.2.2.3
+            // puts no minimum on HigherLayerData, and [MS-RDPBCGR] 1.3.9 sends
+            // the four Continuous Auto-Detection messages "encapsulated in the
+            // RDP_TUNNEL_SUBHEADER structure ... over the sideband channels
+            // that are in active use". The tunnel has already taken what it
+            // needs from those subheaders by the time we get here, leaving a
+            // payload of nothing to pass on.
+            loop {
+                match self.recv().await {
+                    Some(data) if data.is_empty() => continue,
+                    Some(data) => {
+                        let n = data.len();
+                        buf.extend_from_slice(&data);
+                        return Ok(n);
+                    }
+                    None => return Ok(0), // EOF: tunnel closed
+                }
+            }
+        })
+    }
+}
+
+impl FramedWrite for UdpTransport {
+    type WriteAllFut<'write>
+        = Pin<Box<dyn Future<Output = io::Result<()>> + Send + Sync + 'write>>
+    where
+        Self: 'write;
+
+    fn write_all<'a>(&'a mut self, buf: &'a [u8]) -> Self::WriteAllFut<'a> {
+        Box::pin(async move {
+            self.send(buf.to_vec())
+                .await
+                .map_err(|e| io::Error::new(io::ErrorKind::ConnectionReset, e.to_string()))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::mpsc;
+
+    use super::*;
+
+    /// Build a `UdpTransport` backed by test channels (no real network).
+    fn test_transport() -> (UdpTransport, mpsc::Sender<Vec<u8>>, mpsc::Receiver<Vec<u8>>) {
+        let (incoming_tx, incoming_rx) = mpsc::channel::<Vec<u8>>(16);
+        let (outgoing_tx, outgoing_rx) = mpsc::channel::<Vec<u8>>(16);
+
+        let transport = UdpTransport::from_channels(incoming_rx, outgoing_tx);
+
+        (transport, incoming_tx, outgoing_rx)
+    }
+
+    #[tokio::test]
+    async fn framed_read_delivers_one_message() {
+        let (mut transport, feeder, _) = test_transport();
+        feeder.send(vec![0xDE, 0xAD, 0xBE, 0xEF]).await.unwrap();
+
+        let mut buf = BytesMut::new();
+        let n = FramedRead::read(&mut transport, &mut buf).await.unwrap();
+        assert_eq!(n, 4);
+        assert_eq!(&*buf, &[0xDE, 0xAD, 0xBE, 0xEF]);
+    }
+
+    #[tokio::test]
+    async fn framed_read_returns_eof_on_closed_channel() {
+        let (mut transport, feeder, _) = test_transport();
+        drop(feeder);
+
+        let mut buf = BytesMut::new();
+        let n = FramedRead::read(&mut transport, &mut buf).await.unwrap();
+        assert_eq!(n, 0);
+        assert!(buf.is_empty());
+    }
+
+    /// A Tunnel Data PDU carrying no higher-layer bytes is ordinary traffic,
+    /// not the end of the stream.
+    ///
+    /// [MS-RDPEMT] 2.2.2.3 sets no minimum on HigherLayerData, and the
+    /// Continuous Auto-Detection messages of [MS-RDPBCGR] 1.3.9 ride the
+    /// sideband channels in the subheaders, leaving the payload empty. Since
+    /// `ironrdp_async::Framed` turns a zero-length read into
+    /// `UnexpectedEof`, reporting one here tears down a session whose
+    /// transport, TLS and tunnel are all still healthy.
+    #[tokio::test]
+    async fn framed_read_does_not_mistake_an_empty_message_for_eof() {
+        let (mut transport, feeder, _) = test_transport();
+
+        feeder.send(Vec::new()).await.unwrap();
+        feeder.send(vec![0x11, 0x22]).await.unwrap();
+
+        let mut buf = BytesMut::new();
+        let n = FramedRead::read(&mut transport, &mut buf).await.unwrap();
+
+        assert_eq!(n, 2, "an empty message must not read as end of stream");
+        assert_eq!(&*buf, &[0x11, 0x22]);
+    }
+
+    /// The channel closing after an empty message is still end of stream.
+    #[tokio::test]
+    async fn framed_read_still_reports_eof_after_an_empty_message() {
+        let (mut transport, feeder, _) = test_transport();
+
+        feeder.send(Vec::new()).await.unwrap();
+        drop(feeder);
+
+        let mut buf = BytesMut::new();
+        let n = FramedRead::read(&mut transport, &mut buf).await.unwrap();
+
+        assert_eq!(n, 0);
+        assert!(buf.is_empty());
+    }
+
+    #[tokio::test]
+    async fn framed_write_sends_data() {
+        let (mut transport, _, mut receiver) = test_transport();
+
+        FramedWrite::write_all(&mut transport, &[0x01, 0x02, 0x03])
+            .await
+            .unwrap();
+
+        let data = receiver.recv().await.unwrap();
+        assert_eq!(data, vec![0x01, 0x02, 0x03]);
+    }
+
+    #[tokio::test]
+    async fn framed_write_returns_error_on_closed_channel() {
+        let (mut transport, _, receiver) = test_transport();
+        drop(receiver);
+
+        let result = FramedWrite::write_all(&mut transport, &[0x01]).await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::ConnectionReset);
+    }
+
+    #[tokio::test]
+    async fn framed_read_multiple_messages_accumulate() {
+        let (mut transport, feeder, _) = test_transport();
+
+        feeder.send(vec![0xAA, 0xBB]).await.unwrap();
+        feeder.send(vec![0xCC, 0xDD]).await.unwrap();
+
+        let mut buf = BytesMut::new();
+
+        let n1 = FramedRead::read(&mut transport, &mut buf).await.unwrap();
+        assert_eq!(n1, 2);
+        assert_eq!(&*buf, &[0xAA, 0xBB]);
+
+        let n2 = FramedRead::read(&mut transport, &mut buf).await.unwrap();
+        assert_eq!(n2, 2);
+        assert_eq!(&*buf, &[0xAA, 0xBB, 0xCC, 0xDD]);
+    }
+}

--- a/crates/ironrdp-rdpeudp-tokio/src/lib.rs
+++ b/crates/ironrdp-rdpeudp-tokio/src/lib.rs
@@ -1,0 +1,17 @@
+#![cfg_attr(doc, doc = include_str!("../README.md"))]
+#![forbid(unsafe_code)]
+
+pub mod error;
+pub mod framed;
+pub mod multitransport;
+pub mod transport;
+
+pub(crate) mod clock;
+pub(crate) mod driver;
+pub(crate) mod stream;
+pub(crate) mod tls;
+pub(crate) mod tunnel;
+
+pub use self::error::{DriverError, DriverErrorKind, UdpTransportError, UdpTransportErrorKind};
+pub use self::multitransport::MultitransportBootstrap;
+pub use self::transport::{UdpAcceptConfig, UdpTransport, UdpTransportConfig, accept_udp, connect_udp};

--- a/crates/ironrdp-rdpeudp-tokio/src/multitransport.rs
+++ b/crates/ironrdp-rdpeudp-tokio/src/multitransport.rs
@@ -1,0 +1,248 @@
+//! Multitransport bootstrapping orchestrator.
+//!
+//! When an RDP server sends an Initiate Multitransport Request PDU on
+//! the TCP connection, the client must:
+//!
+//! 1. Parse the request (requestId + requestedProtocol + securityCookie)
+//! 2. Establish a UDP transport using `connect_udp()`
+//! 3. Send an Initiate Multitransport Response PDU (S_OK or E_ABORT)
+//!    back on the TCP connection
+//!
+//! `MultitransportBootstrap` orchestrates this sequence. The upstream
+//! `ironrdp-connector` doesn't implement multitransport yet, so this
+//! acts as a standalone shim that an application wires into its
+//! connection flow.
+
+use core::net::SocketAddr;
+
+use ironrdp_pdu::rdp::multitransport::{MultitransportRequestPdu, MultitransportResponsePdu, RequestedProtocol};
+use ironrdp_rdpemt::{RdpemtError, RdpemtErrorExt as _, TunnelConfig};
+use ironrdp_rdpeudp::ConnectionConfig;
+
+use crate::error::{UdpTransportError, UdpTransportErrorExt as _};
+use crate::transport::{UdpTransport, UdpTransportConfig, connect_udp};
+
+/// Orchestrates the multitransport connection sequence.
+///
+/// Created from the raw Initiate Multitransport Request PDU payload
+/// received on the TCP MCS message channel. Call [`connect()`] to
+/// establish the UDP transport, then [`response_pdu()`] to get the
+/// bytes to send back on TCP.
+///
+/// [`connect()`]: MultitransportBootstrap::connect
+/// [`response_pdu()`]: MultitransportBootstrap::response_pdu
+///
+/// # Example
+///
+/// ```ignore
+/// // In the TCP connection handler, after receiving MultitransportRequestPdu:
+/// let mut bootstrap = MultitransportBootstrap::new(request);
+///
+/// // Attempt the UDP connection
+/// let _ = bootstrap.connect(server_addr, "server.example.com".into(), Default::default()).await;
+///
+/// // Always send the response back on TCP (S_OK or E_ABORT)
+/// let response_bytes = bootstrap.response_pdu().expect("response available after connect");
+/// tcp_writer.write_all(&response_bytes).await?;
+///
+/// // If successful, use the transport
+/// if let Some(transport) = bootstrap.take_transport() {
+///     // ... use transport for DVC data
+/// }
+/// ```
+pub struct MultitransportBootstrap {
+    request: MultitransportRequestPdu,
+    transport: Option<UdpTransport>,
+    response: Option<MultitransportResponsePdu>,
+}
+
+impl MultitransportBootstrap {
+    /// Create from a parsed `MultitransportRequestPdu`.
+    pub fn new(request: MultitransportRequestPdu) -> Self {
+        Self {
+            request,
+            transport: None,
+            response: None,
+        }
+    }
+
+    /// Parse from raw PDU bytes.
+    ///
+    /// The bytes are the Initiate Multitransport Request PDU (after TPKT +
+    /// X224 + MCS have been stripped by the existing ironrdp-pdu stack, but
+    /// including the leading `BasicSecurityHeader`): `MultitransportRequestPdu`
+    /// decodes and validates that header itself, rejecting anything whose
+    /// flags are not exactly `SEC_TRANSPORT_REQ`.
+    pub fn from_pdu(pdu_bytes: &[u8]) -> Result<Self, UdpTransportError> {
+        let request: MultitransportRequestPdu = ironrdp_core::decode(pdu_bytes)
+            .map_err(|error| UdpTransportError::rdpemt("decode multitransport request", RdpemtError::decode(error)))?;
+
+        Ok(Self::new(request))
+    }
+
+    /// Attempt to establish the UDP transport.
+    ///
+    /// On success, stores the transport and prepares an `S_OK` response.
+    /// On failure, prepares an `E_ABORT` response and returns the error.
+    ///
+    /// After calling this, use [`response_pdu()`] to get the bytes to
+    /// send back to the server on the TCP connection.
+    ///
+    /// [`response_pdu()`]: MultitransportBootstrap::response_pdu
+    pub async fn connect(
+        &mut self,
+        server_addr: SocketAddr,
+        server_name: String,
+        connection_config: ConnectionConfig,
+    ) -> Result<(), UdpTransportError> {
+        // This driver only implements the reliable transport (RDPEUDP2 + TLS).
+        // UdpFecL (lossy RDPEUDP + DTLS) is a distinct wire protocol this crate
+        // does not speak; connecting the reliable stack anyway and reporting
+        // S_OK would tell the server a different transport succeeded than the
+        // one it asked for, so reject it before attempting a connection.
+        if self.request.requested_protocol != RequestedProtocol::UdpFecR {
+            self.response = Some(MultitransportResponsePdu::abort(self.request.request_id));
+            return Err(UdpTransportError::unsupported_protocol(
+                "multitransport connect",
+                self.request.requested_protocol,
+            ));
+        }
+
+        let tunnel_config = TunnelConfig {
+            request_id: self.request.request_id,
+            security_cookie: self.request.security_cookie,
+        };
+        let mut config = UdpTransportConfig::new(server_addr, server_name, tunnel_config);
+        config.connection_config = connection_config;
+
+        match connect_udp(config).await {
+            Ok(transport) => {
+                self.transport = Some(transport);
+                self.response = Some(MultitransportResponsePdu::success(self.request.request_id));
+                Ok(())
+            }
+            Err(e) => {
+                // A stale transport from an earlier successful call must not
+                // survive a failed reconnect: the response below tells the
+                // server the connection is down, so is_connected() and
+                // take_transport() must agree, not keep handing out a
+                // transport the server was just told doesn't exist.
+                self.transport = None;
+                self.response = Some(MultitransportResponsePdu::abort(self.request.request_id));
+                Err(e)
+            }
+        }
+    }
+
+    /// Get the response PDU bytes to send back on the TCP connection.
+    ///
+    /// Returns `None` if [`connect()`] hasn't been called yet.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the response fails to encode. The response is a fixed-size
+    /// structure built by this crate, so a failure here means the encoder and
+    /// the type have gone out of sync rather than anything a caller can cause.
+    ///
+    /// [`connect()`]: MultitransportBootstrap::connect
+    pub fn response_pdu(&self) -> Option<Vec<u8>> {
+        self.response
+            .as_ref()
+            .map(|r| ironrdp_core::encode_vec(r).expect("MultitransportResponsePdu encoding cannot fail"))
+    }
+
+    /// The original request from the server.
+    pub fn request(&self) -> &MultitransportRequestPdu {
+        &self.request
+    }
+
+    /// Take ownership of the established UDP transport.
+    ///
+    /// Returns `None` if the connection failed or hasn't been attempted.
+    pub fn take_transport(&mut self) -> Option<UdpTransport> {
+        self.transport.take()
+    }
+
+    /// Whether the UDP transport was established.
+    pub fn is_connected(&self) -> bool {
+        self.transport.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ironrdp_pdu::rdp::headers::{BasicSecurityHeader, BasicSecurityHeaderFlags};
+
+    use super::*;
+
+    fn request(
+        request_id: u32,
+        security_cookie: [u8; 16],
+        requested_protocol: RequestedProtocol,
+    ) -> MultitransportRequestPdu {
+        MultitransportRequestPdu {
+            security_header: BasicSecurityHeader {
+                flags: BasicSecurityHeaderFlags::TRANSPORT_REQ,
+            },
+            request_id,
+            requested_protocol,
+            security_cookie,
+        }
+    }
+
+    #[test]
+    fn new_from_request() {
+        let bootstrap = MultitransportBootstrap::new(request(42, [0xAB; 16], RequestedProtocol::UdpFecR));
+        assert_eq!(bootstrap.request().request_id, 42);
+        assert!(!bootstrap.is_connected());
+        assert!(bootstrap.response_pdu().is_none());
+    }
+
+    #[test]
+    fn from_pdu_roundtrip() {
+        let encoded = ironrdp_core::encode_vec(&request(99, [0xCC; 16], RequestedProtocol::UdpFecR)).expect("encode");
+        let bootstrap = MultitransportBootstrap::from_pdu(&encoded).expect("decode");
+        assert_eq!(bootstrap.request().request_id, 99);
+        assert_eq!(bootstrap.request().security_cookie, [0xCC; 16]);
+    }
+
+    #[test]
+    fn from_pdu_rejects_garbage() {
+        let result = MultitransportBootstrap::from_pdu(&[0xFF, 0xFF]);
+        assert!(result.is_err());
+    }
+
+    /// `UdpFecL` (lossy RDPEUDP + DTLS) is not implemented by this driver.
+    /// `connect()` must reject it with `abort` before attempting the
+    /// reliable transport it does implement, rather than silently
+    /// connecting the wrong protocol and reporting success.
+    #[tokio::test]
+    async fn connect_rejects_unsupported_protocol_without_attempting_transport() {
+        let mut bootstrap = MultitransportBootstrap::new(request(7, [0x11; 16], RequestedProtocol::UdpFecL));
+
+        // An address nothing is listening on: if the guard didn't short-circuit
+        // before connect_udp, this would hang until the handshake timeout
+        // instead of returning immediately.
+        let unreachable_addr: SocketAddr = "127.0.0.1:1".parse().expect("valid loopback address");
+
+        let result = bootstrap
+            .connect(unreachable_addr, "localhost".into(), ConnectionConfig::default())
+            .await;
+
+        // Checking the specific error kind (not just is_err()) is the point:
+        // a driver that attempted the connection anyway would also end up
+        // Err here, just as HandshakeTimeout instead, ten seconds later.
+        let error = result.expect_err("UdpFecL must be rejected");
+        assert!(matches!(
+            error.kind(),
+            crate::error::UdpTransportErrorKind::UnsupportedProtocol {
+                requested: RequestedProtocol::UdpFecL
+            }
+        ));
+
+        let response = bootstrap.response_pdu().expect("response set after connect");
+        let decoded: MultitransportResponsePdu = ironrdp_core::decode(&response).expect("decode response");
+        assert!(!decoded.is_success());
+        assert!(!bootstrap.is_connected());
+    }
+}

--- a/crates/ironrdp-rdpeudp-tokio/src/stream.rs
+++ b/crates/ironrdp-rdpeudp-tokio/src/stream.rs
@@ -1,0 +1,356 @@
+//! AsyncRead/AsyncWrite adapter bridging the driver task to TLS.
+//!
+//! The driver owns the `RdpeudpConnection` and `UdpSocket`. This module
+//! provides `RdpeudpStream`, which tokio-rustls wraps for TLS. Two ring
+//! buffers behind `Arc<Mutex<SharedIo>>` shuttle bytes between the driver
+//! and the TLS layer without requiring the TLS layer to know it's running
+//! over UDP.
+
+use core::pin::Pin;
+use core::task::{Context, Poll, Waker};
+use std::io;
+use std::sync::{Arc, Mutex};
+
+use bytes::BytesMut;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+// ════════════════════════════════════════════════════════════════════
+// SharedIo
+// ════════════════════════════════════════════════════════════════════
+
+/// Shared state between the driver task and the `RdpeudpStream`.
+///
+/// The driver deposits decrypted RDPEUDP2 payload bytes into `read_buf`
+/// (waking the TLS reader), and picks up plaintext bytes from `write_buf`
+/// (placed there by TLS) to feed into `conn.send()`.
+pub(crate) struct SharedIo {
+    /// Bytes available for `AsyncRead` consumers (driver writes here
+    /// when `Event::DataReceived` fires).
+    pub(crate) read_buf: BytesMut,
+
+    /// Waker registered by `AsyncRead::poll_read` when `read_buf` is empty.
+    pub(crate) read_waker: Option<Waker>,
+
+    /// Bytes queued for transmission. `AsyncWrite::poll_write` appends
+    /// here; the driver drains this into `conn.send()`.
+    pub(crate) write_buf: BytesMut,
+
+    /// Waker registered by the driver when it finds `write_buf` empty.
+    /// Fired by `poll_write` after depositing data.
+    pub(crate) write_waker: Option<Waker>,
+
+    /// Waker registered by `poll_flush` when `write_buf` is non-empty.
+    /// Fired by the driver after draining `write_buf`, so the flusher
+    /// can re-check and return `Ready`.
+    ///
+    /// Separate from `write_waker` because the two have opposite
+    /// trigger conditions (data-present vs data-drained).
+    pub(crate) flush_waker: Option<Waker>,
+
+    /// Waker registered by the driver when `read_buf` has grown past what it
+    /// is willing to hold. Fired by `poll_read` once it has taken bytes out.
+    ///
+    /// Without it the driver has no way to learn that the consumer caught up,
+    /// and would sit throttled until some unrelated timer happened to fire.
+    pub(crate) read_drained_waker: Option<Waker>,
+
+    /// Fatal error from the driver (propagated to reads/writes).
+    pub(crate) error: Option<io::ErrorKind>,
+
+    /// Set when the RDPEUDP2 connection has been cleanly shut down.
+    pub(crate) closed: bool,
+}
+
+impl SharedIo {
+    pub(crate) fn new() -> Self {
+        Self {
+            read_buf: BytesMut::with_capacity(8192),
+            read_waker: None,
+            write_buf: BytesMut::with_capacity(8192),
+            write_waker: None,
+            flush_waker: None,
+            read_drained_waker: None,
+            error: None,
+            closed: false,
+        }
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// RdpeudpStream
+// ════════════════════════════════════════════════════════════════════
+
+/// Async byte-stream adapter over an RDPEUDP2 connection.
+///
+/// Implements `AsyncRead + AsyncWrite + Unpin` so tokio-rustls can
+/// wrap it for TLS. The stream itself doesn't touch the network; the
+/// driver task does all UDP I/O and state-machine driving.
+pub(crate) struct RdpeudpStream {
+    pub(crate) shared: Arc<Mutex<SharedIo>>,
+}
+
+impl RdpeudpStream {
+    pub(crate) fn new(shared: Arc<Mutex<SharedIo>>) -> Self {
+        Self { shared }
+    }
+}
+
+impl AsyncRead for RdpeudpStream {
+    fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut ReadBuf<'_>) -> Poll<io::Result<()>> {
+        let mut shared = self
+            .shared
+            .lock()
+            .map_err(|_| io::Error::other("shared lock poisoned"))?;
+
+        if !shared.read_buf.is_empty() {
+            let n = core::cmp::min(buf.remaining(), shared.read_buf.len());
+            buf.put_slice(&shared.read_buf.split_to(n));
+
+            // Tell the driver it has room again, in case it stopped taking
+            // packets off the socket while this buffer was full.
+            if let Some(waker) = shared.read_drained_waker.take() {
+                waker.wake();
+            }
+
+            return Poll::Ready(Ok(()));
+        }
+
+        if let Some(kind) = shared.error {
+            return Poll::Ready(Err(io::Error::new(kind, "RDPEUDP2 transport error")));
+        }
+
+        if shared.closed {
+            // EOF
+            return Poll::Ready(Ok(()));
+        }
+
+        // No data available: register waker so the driver can wake us
+        shared.read_waker = Some(cx.waker().clone());
+        Poll::Pending
+    }
+}
+
+impl AsyncWrite for RdpeudpStream {
+    fn poll_write(self: Pin<&mut Self>, _cx: &mut Context<'_>, buf: &[u8]) -> Poll<io::Result<usize>> {
+        let mut shared = self
+            .shared
+            .lock()
+            .map_err(|_| io::Error::other("shared lock poisoned"))?;
+
+        if let Some(kind) = shared.error {
+            return Poll::Ready(Err(io::Error::new(kind, "RDPEUDP2 transport error")));
+        }
+
+        if shared.closed {
+            return Poll::Ready(Err(io::Error::new(io::ErrorKind::BrokenPipe, "connection closed")));
+        }
+
+        shared.write_buf.extend_from_slice(buf);
+
+        // Wake the driver so it picks up the new data
+        if let Some(waker) = shared.write_waker.take() {
+            waker.wake();
+        }
+
+        Poll::Ready(Ok(buf.len()))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let mut shared = self
+            .shared
+            .lock()
+            .map_err(|_| io::Error::other("shared lock poisoned"))?;
+
+        if let Some(kind) = shared.error {
+            return Poll::Ready(Err(io::Error::new(kind, "RDPEUDP2 transport error")));
+        }
+
+        if shared.write_buf.is_empty() {
+            return Poll::Ready(Ok(()));
+        }
+
+        // Data still pending: register on flush_waker (separate from
+        // write_waker, which the driver uses to detect new data).
+        // The driver wakes flush_waker after draining write_buf.
+        shared.flush_waker = Some(cx.waker().clone());
+        Poll::Pending
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let mut shared = self
+            .shared
+            .lock()
+            .map_err(|_| io::Error::other("shared lock poisoned"))?;
+
+        shared.closed = true;
+
+        if let Some(waker) = shared.write_waker.take() {
+            waker.wake();
+        }
+
+        Poll::Ready(Ok(()))
+    }
+}
+
+// Unpin is auto-derived because RdpeudpStream contains only Arc (no self-referential state).
+
+#[cfg(test)]
+mod tests {
+    use std::task::Wake;
+
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    use super::*;
+
+    /// Minimal waker that tracks whether it was woken.
+    struct TestWaker {
+        woken: core::sync::atomic::AtomicBool,
+    }
+
+    impl TestWaker {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                woken: core::sync::atomic::AtomicBool::new(false),
+            })
+        }
+
+        fn was_woken(&self) -> bool {
+            self.woken.load(core::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    impl Wake for TestWaker {
+        fn wake(self: Arc<Self>) {
+            self.woken.store(true, core::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn shared_io_starts_empty() {
+        let shared = SharedIo::new();
+        assert!(shared.read_buf.is_empty());
+        assert!(shared.write_buf.is_empty());
+        assert!(!shared.closed);
+        assert!(shared.error.is_none());
+    }
+
+    #[test]
+    fn write_deposits_into_write_buf_and_wakes_driver() {
+        let driver_waker = TestWaker::new();
+
+        let shared = Arc::new(Mutex::new(SharedIo::new()));
+        {
+            let mut s = shared.lock().expect("lock");
+            s.write_waker = Some(Waker::from(Arc::clone(&driver_waker)));
+        }
+
+        let mut stream = RdpeudpStream::new(Arc::clone(&shared));
+
+        let rt = tokio::runtime::Builder::new_current_thread().build().expect("rt");
+        rt.block_on(async {
+            stream.write_all(b"hello").await.expect("write");
+        });
+
+        let s = shared.lock().expect("lock");
+        assert_eq!(&*s.write_buf, b"hello");
+        assert!(driver_waker.was_woken());
+    }
+
+    #[test]
+    fn read_returns_data_deposited_by_driver() {
+        let shared = Arc::new(Mutex::new(SharedIo::new()));
+        {
+            let mut s = shared.lock().expect("lock");
+            s.read_buf.extend_from_slice(b"world");
+        }
+
+        let mut stream = RdpeudpStream::new(shared);
+
+        let rt = tokio::runtime::Builder::new_current_thread().build().expect("rt");
+        rt.block_on(async {
+            let mut buf = [0u8; 32];
+            let n = stream.read(&mut buf).await.expect("read");
+            assert_eq!(&buf[..n], b"world");
+        });
+    }
+
+    #[test]
+    fn read_returns_eof_when_closed() {
+        let shared = Arc::new(Mutex::new(SharedIo::new()));
+        {
+            let mut s = shared.lock().expect("lock");
+            s.closed = true;
+        }
+
+        let mut stream = RdpeudpStream::new(shared);
+
+        let rt = tokio::runtime::Builder::new_current_thread().build().expect("rt");
+        rt.block_on(async {
+            let mut buf = [0u8; 32];
+            let n = stream.read(&mut buf).await.expect("read");
+            assert_eq!(n, 0);
+        });
+    }
+
+    #[test]
+    fn write_fails_when_closed() {
+        let shared = Arc::new(Mutex::new(SharedIo::new()));
+        {
+            let mut s = shared.lock().expect("lock");
+            s.closed = true;
+        }
+
+        let mut stream = RdpeudpStream::new(shared);
+
+        let rt = tokio::runtime::Builder::new_current_thread().build().expect("rt");
+        rt.block_on(async {
+            let result = stream.write_all(b"nope").await;
+            assert!(result.is_err());
+        });
+    }
+
+    #[test]
+    fn read_registers_waker_when_empty() {
+        let shared = Arc::new(Mutex::new(SharedIo::new()));
+        let mut stream = RdpeudpStream::new(Arc::clone(&shared));
+
+        let test_waker = TestWaker::new();
+        let waker = Waker::from(Arc::clone(&test_waker));
+        let mut cx = Context::from_waker(&waker);
+
+        let mut buf = [0u8; 32];
+        let mut read_buf = ReadBuf::new(&mut buf);
+        let result = Pin::new(&mut stream).poll_read(&mut cx, &mut read_buf);
+        assert!(result.is_pending());
+
+        // Now the driver deposits data and wakes the reader
+        {
+            let mut s = shared.lock().expect("lock");
+            s.read_buf.extend_from_slice(b"data");
+            if let Some(w) = s.read_waker.take() {
+                w.wake();
+            }
+        }
+
+        assert!(test_waker.was_woken());
+    }
+
+    #[test]
+    fn read_propagates_error() {
+        let shared = Arc::new(Mutex::new(SharedIo::new()));
+        {
+            let mut s = shared.lock().expect("lock");
+            s.error = Some(io::ErrorKind::ConnectionReset);
+        }
+
+        let mut stream = RdpeudpStream::new(shared);
+
+        let rt = tokio::runtime::Builder::new_current_thread().build().expect("rt");
+        rt.block_on(async {
+            let mut buf = [0u8; 32];
+            let result = stream.read(&mut buf).await;
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().kind(), io::ErrorKind::ConnectionReset);
+        });
+    }
+}

--- a/crates/ironrdp-rdpeudp-tokio/src/tls.rs
+++ b/crates/ironrdp-rdpeudp-tokio/src/tls.rs
@@ -1,0 +1,142 @@
+//! TLS upgrade over an RDPEUDP2 stream.
+//!
+//! Mirrors the rustls configuration from `ironrdp-tls`: no certificate
+//! verification (RDP uses self-signed certs), disabled TLS resumption
+//! (CredSSP compatibility), and SSLKEYLOGFILE support for Wireshark.
+//!
+//! The caller passes an `RdpeudpStream` which provides `AsyncRead +
+//! AsyncWrite` over the RDPEUDP2 connection. tokio-rustls wraps it
+//! transparently: the TLS layer doesn't know it's running over UDP.
+
+use std::io;
+use std::sync::Arc;
+
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt as _};
+use tokio_rustls::rustls::pki_types::ServerName;
+
+pub(crate) type TlsStream<S> = tokio_rustls::client::TlsStream<S>;
+pub(crate) type ServerTlsStream<S> = tokio_rustls::server::TlsStream<S>;
+
+/// Perform TLS handshake over an established RDPEUDP2 stream.
+///
+/// `server_cert_verifier` selects how the peer certificate is validated.
+/// `None` preserves the historic behavior (no verification: RDP servers
+/// commonly present self-signed certificates). `Some(verifier)` lets a
+/// caller opt into real validation, for example a
+/// `rustls::client::WebPkiServerVerifier` built against the platform root
+/// store, mirroring the choice `ironrdp-tls` already exposes on the TCP
+/// path without this crate taking on that crate's certificate-store
+/// dependencies itself.
+///
+/// Returns the encrypted stream. The driver task continues running
+/// in the background, transparently shuttling encrypted bytes between
+/// the UDP socket and this TLS stream via `SharedIo`.
+pub(crate) async fn tls_upgrade<S>(
+    stream: S,
+    server_name: &str,
+    server_cert_verifier: Option<Arc<dyn tokio_rustls::rustls::client::danger::ServerCertVerifier>>,
+) -> io::Result<TlsStream<S>>
+where
+    S: Unpin + AsyncRead + AsyncWrite,
+{
+    let verifier: Arc<dyn tokio_rustls::rustls::client::danger::ServerCertVerifier> =
+        server_cert_verifier.unwrap_or_else(|| Arc::new(danger::NoCertificateVerification));
+
+    let mut tls_stream = {
+        let mut config = tokio_rustls::rustls::client::ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(verifier)
+            .with_no_client_auth();
+
+        // SSLKEYLOGFILE support for debugging with Wireshark
+        config.key_log = Arc::new(tokio_rustls::rustls::KeyLogFile::new());
+
+        // Disable TLS resumption: not supported by CredSSP and some
+        // RDP server configurations.
+        config.resumption = tokio_rustls::rustls::client::Resumption::disabled();
+
+        let config = Arc::new(config);
+
+        let domain = ServerName::try_from(server_name.to_owned()).map_err(io::Error::other)?;
+
+        tokio_rustls::TlsConnector::from(config).connect(domain, stream).await?
+    };
+
+    tls_stream.flush().await?;
+
+    Ok(tls_stream)
+}
+
+/// Perform TLS server-side handshake over an established RDPEUDP2 stream.
+///
+/// The caller provides a `ServerConfig` with certificate and private key.
+/// Returns the encrypted stream for the RDPEMT tunnel handshake.
+pub(crate) async fn tls_accept<S>(
+    stream: S,
+    config: Arc<tokio_rustls::rustls::ServerConfig>,
+) -> io::Result<ServerTlsStream<S>>
+where
+    S: Unpin + AsyncRead + AsyncWrite,
+{
+    let acceptor = tokio_rustls::TlsAcceptor::from(config);
+    let mut tls_stream = acceptor.accept(stream).await?;
+    tls_stream.flush().await?;
+    Ok(tls_stream)
+}
+
+mod danger {
+    use tokio_rustls::rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+    use tokio_rustls::rustls::{DigitallySignedStruct, Error, SignatureScheme, pki_types};
+
+    #[derive(Debug)]
+    pub(super) struct NoCertificateVerification;
+
+    impl ServerCertVerifier for NoCertificateVerification {
+        fn verify_server_cert(
+            &self,
+            _: &pki_types::CertificateDer<'_>,
+            _: &[pki_types::CertificateDer<'_>],
+            _: &pki_types::ServerName<'_>,
+            _: &[u8],
+            _: pki_types::UnixTime,
+        ) -> Result<ServerCertVerified, Error> {
+            Ok(ServerCertVerified::assertion())
+        }
+
+        fn verify_tls12_signature(
+            &self,
+            _: &[u8],
+            _: &pki_types::CertificateDer<'_>,
+            _: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, Error> {
+            Ok(HandshakeSignatureValid::assertion())
+        }
+
+        fn verify_tls13_signature(
+            &self,
+            _: &[u8],
+            _: &pki_types::CertificateDer<'_>,
+            _: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, Error> {
+            Ok(HandshakeSignatureValid::assertion())
+        }
+
+        fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+            vec![
+                SignatureScheme::RSA_PKCS1_SHA1,
+                SignatureScheme::ECDSA_SHA1_Legacy,
+                SignatureScheme::RSA_PKCS1_SHA256,
+                SignatureScheme::ECDSA_NISTP256_SHA256,
+                SignatureScheme::RSA_PKCS1_SHA384,
+                SignatureScheme::ECDSA_NISTP384_SHA384,
+                SignatureScheme::RSA_PKCS1_SHA512,
+                SignatureScheme::ECDSA_NISTP521_SHA512,
+                SignatureScheme::RSA_PSS_SHA256,
+                SignatureScheme::RSA_PSS_SHA384,
+                SignatureScheme::RSA_PSS_SHA512,
+                SignatureScheme::ED25519,
+                SignatureScheme::ED448,
+            ]
+        }
+    }
+}

--- a/crates/ironrdp-rdpeudp-tokio/src/transport.rs
+++ b/crates/ironrdp-rdpeudp-tokio/src/transport.rs
@@ -1,0 +1,781 @@
+//! Public API: `UdpTransport`, `connect_udp()`, and `accept_udp()`.
+//!
+//! `connect_udp()` orchestrates the full client-side connection sequence:
+//! UDP SYN/SYN+ACK/ACK → TLS handshake → RDPEMT CreateRequest/Response
+//! → spawns data pump → returns `UdpTransport` handle.
+//!
+//! `accept_udp()` orchestrates the server-side accept sequence:
+//! receive SYN → SYN+ACK/ACK → TLS accept → RDPEMT CreateResponse
+//! → spawns data pump → returns `UdpTransport` handle.
+//!
+//! `UdpTransport` provides bidirectional higher-layer data transfer
+//! (DVC frames) through the tunnel, decoupled from all the protocol
+//! machinery running in background tasks.
+
+use crate::clock::Clock;
+use core::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use core::time::Duration;
+use std::sync::{Arc, Mutex};
+
+use ironrdp_rdpemt::{RdpemtErrorExt as _, TunnelConfig};
+use ironrdp_rdpeudp::pdu::V1Datagram;
+use ironrdp_rdpeudp::{ConnectionConfig, RdpeudpConnection, RdpeudpErrorExt as _};
+use sha2::{Digest as _, Sha256};
+use tokio::io::AsyncWriteExt as _;
+use tokio::net::UdpSocket;
+use tokio::sync::{Notify, mpsc};
+use tokio::task::JoinHandle;
+
+use crate::driver::Driver;
+use crate::error::{DriverError, DriverErrorExt as _, DriverErrorKind, UdpTransportError, UdpTransportErrorExt as _};
+use crate::stream::{RdpeudpStream, SharedIo};
+use crate::tls::{tls_accept, tls_upgrade};
+use crate::tunnel::{read_tunnel_pdu, tunnel_data_loop, write_tunnel_pdu};
+
+// ════════════════════════════════════════════════════════════════════
+// Configuration
+// ════════════════════════════════════════════════════════════════════
+
+/// Configuration for establishing a UDP transport to an RDP server.
+///
+/// The caller must have already received the Initiate Multitransport
+/// Request PDU from the TCP connection to obtain the `tunnel_config`
+/// (request_id + security_cookie).
+#[derive(Clone)]
+pub struct UdpTransportConfig {
+    /// Server address (same IP as the TCP connection, same or different port).
+    pub server_addr: SocketAddr,
+    /// TLS server name for SNI.
+    pub server_name: String,
+    /// RDPEMT tunnel parameters from the Initiate Multitransport Request PDU.
+    pub tunnel_config: TunnelConfig,
+    /// RDPEUDP2 connection parameters (MTU, window size, timeouts).
+    /// Uses sensible defaults if not customized.
+    pub connection_config: ConnectionConfig,
+    /// Maximum time to wait for the RDPEUDP2 handshake to complete.
+    /// Default: 10 seconds (matching FreeRDP).
+    pub handshake_timeout: Duration,
+    /// How the server's TLS certificate is validated.
+    ///
+    /// `None` (the default) preserves the historic behavior: no
+    /// verification, since RDP servers commonly present self-signed
+    /// certificates. `Some(verifier)` opts into real validation, mirroring
+    /// the choice `ironrdp-tls` exposes on the TCP path.
+    pub server_cert_verifier: Option<Arc<dyn tokio_rustls::rustls::client::danger::ServerCertVerifier>>,
+}
+
+impl UdpTransportConfig {
+    /// Create a config with the required parameters, using defaults
+    /// for everything else.
+    pub fn new(server_addr: SocketAddr, server_name: String, tunnel_config: TunnelConfig) -> Self {
+        Self {
+            server_addr,
+            server_name,
+            tunnel_config,
+            connection_config: ConnectionConfig::default(),
+            handshake_timeout: Duration::from_secs(10),
+            server_cert_verifier: None,
+        }
+    }
+}
+
+impl core::fmt::Debug for UdpTransportConfig {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("UdpTransportConfig")
+            .field("server_addr", &self.server_addr)
+            .field("server_name", &self.server_name)
+            .field("tunnel_config", &self.tunnel_config)
+            .field("connection_config", &self.connection_config)
+            .field("handshake_timeout", &self.handshake_timeout)
+            .field(
+                "server_cert_verifier",
+                &self.server_cert_verifier.as_ref().map(|_| "Some(..)").unwrap_or("None"),
+            )
+            .finish()
+    }
+}
+
+/// Configuration for accepting a UDP transport connection from a client.
+///
+/// Used by test harnesses or server implementations that need to
+/// accept the client-side RDPEUDP2 connection.
+pub struct UdpAcceptConfig {
+    /// TLS server configuration (certificate + private key).
+    pub tls_config: Arc<tokio_rustls::rustls::ServerConfig>,
+    /// RDPEMT tunnel parameters: the expected request_id and
+    /// security_cookie that the client will present in the
+    /// Tunnel Create Request.
+    pub tunnel_config: TunnelConfig,
+    /// RDPEUDP2 connection parameters (MTU, window size, timeouts).
+    pub connection_config: ConnectionConfig,
+    /// Maximum time to wait for the full accept sequence.
+    pub accept_timeout: Duration,
+}
+
+// ════════════════════════════════════════════════════════════════════
+// UdpTransport
+// ════════════════════════════════════════════════════════════════════
+
+/// A spawned task that is aborted if its handle is dropped without being
+/// taken back.
+///
+/// Dropping a bare `JoinHandle` detaches the task rather than stopping it, so
+/// every early return between spawning the driver and handing it to the caller
+/// used to leave it running: still holding the UDP socket, still arming
+/// timers, still answering keep-alives, for the life of the process. Wrapping
+/// the handle makes each `?` clean up on the way out instead of relying on
+/// every path remembering to.
+struct AbortOnDrop<T>(Option<JoinHandle<T>>);
+
+impl<T> AbortOnDrop<T> {
+    fn new(handle: JoinHandle<T>) -> Self {
+        Self(Some(handle))
+    }
+
+    /// Take the handle back so it can be awaited instead of aborted.
+    fn take(&mut self) -> Option<JoinHandle<T>> {
+        self.0.take()
+    }
+
+    fn is_finished(&self) -> bool {
+        self.0.as_ref().is_some_and(JoinHandle::is_finished)
+    }
+
+    /// Take the handle back only if the task has already ended, so the result
+    /// can be inspected rather than discarded.
+    fn take_if_finished(&mut self) -> Option<JoinHandle<T>> {
+        if self.is_finished() { self.0.take() } else { None }
+    }
+}
+
+impl<T> Drop for AbortOnDrop<T> {
+    fn drop(&mut self) {
+        if let Some(handle) = self.0.as_ref() {
+            handle.abort();
+        }
+    }
+}
+
+/// Handle to an established UDP transport.
+///
+/// Provides bidirectional higher-layer data (DVC frames) over the
+/// RDPEUDP2 + TLS + RDPEMT tunnel. The protocol machinery runs in
+/// background tasks; this handle communicates via channels.
+///
+/// Drop this handle to initiate shutdown of the background tasks.
+pub struct UdpTransport {
+    /// Receives higher-layer data (DVC frames) from the tunnel.
+    data_rx: mpsc::Receiver<Vec<u8>>,
+
+    /// Sends higher-layer data into the tunnel for encryption and transmission.
+    data_tx: mpsc::Sender<Vec<u8>>,
+
+    /// Shared I/O bridge between the driver and the TLS/RDPEMT layer.
+    /// Held here so `shutdown()` can signal closure to both the
+    /// driver (via `write_waker`) and the read pump (via `read_waker`).
+    shared: Arc<Mutex<SharedIo>>,
+
+    /// Handle to the UDP driver task (RDPEUDP2 I/O loop).
+    driver_handle: AbortOnDrop<Result<(), DriverError>>,
+
+    /// Handle to the data pump task (TLS read → RDPEMT decode → channel).
+    pump_handle: AbortOnDrop<Result<(), UdpTransportError>>,
+
+    /// Handle to the write pump task (channel → RDPEMT encode → TLS write).
+    write_pump_handle: AbortOnDrop<Result<(), UdpTransportError>>,
+}
+
+impl UdpTransport {
+    /// Receive the next higher-layer data frame from the tunnel.
+    ///
+    /// Returns `None` when the tunnel is closed.
+    pub async fn recv(&mut self) -> Option<Vec<u8>> {
+        self.data_rx.recv().await
+    }
+
+    /// Send a higher-layer data frame through the tunnel.
+    ///
+    /// The data is wrapped in an RDPEMT TunnelData PDU, encrypted
+    /// with TLS, and transmitted over the RDPEUDP2 connection.
+    ///
+    /// # Errors
+    ///
+    /// Returns `PayloadTooLarge` if `data` exceeds 65535 bytes, the wire
+    /// `PayloadLength` field's capacity ([MS-RDPEMT] 2.2.2.3). Checked here,
+    /// synchronously, rather than left for the background write pump to
+    /// discover: that task has no way to report a per-payload failure back
+    /// to a caller who already received `Ok(())` from a channel send.
+    pub async fn send(&self, data: Vec<u8>) -> Result<(), UdpTransportError> {
+        if data.len() > usize::from(u16::MAX) {
+            return Err(UdpTransportError::payload_too_large("send", data.len()));
+        }
+
+        self.data_tx
+            .send(data)
+            .await
+            .map_err(|_| UdpTransportError::driver("send", DriverError::connection_closed("send")))
+    }
+
+    /// Shut down the transport, closing the RDPEUDP2 connection.
+    ///
+    /// Signals the shared I/O bridge as closed, which propagates to
+    /// both the driver (exits the select! loop) and the read pump
+    /// (gets EOF from the TLS stream); the write pump stops on its own
+    /// once the send channel is dropped, below. Then waits for all
+    /// three background tasks to complete.
+    pub async fn shutdown(mut self) -> Result<(), UdpTransportError> {
+        // Drop the send channel to signal the write pump to stop
+        drop(self.data_tx);
+        drop(self.data_rx);
+
+        // Signal the shared I/O bridge as closed so the driver
+        // and read pump can exit cleanly.
+        {
+            let mut shared = self
+                .shared
+                .lock()
+                .map_err(|_| UdpTransportError::driver_panic("shutdown"))?;
+            shared.closed = true;
+            if let Some(waker) = shared.read_waker.take() {
+                waker.wake();
+            }
+            if let Some(waker) = shared.write_waker.take() {
+                waker.wake();
+            }
+        }
+
+        // Wait for the pump task (should now get EOF and exit)
+        if let Some(pump) = self.pump_handle.take() {
+            match pump.await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => return Err(e),
+                Err(_join_err) => return Err(UdpTransportError::driver_panic("shutdown")),
+            }
+        }
+
+        // Wait for the write pump (already exited once data_tx was dropped above)
+        if let Some(write_pump) = self.write_pump_handle.take() {
+            match write_pump.await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => return Err(e),
+                Err(_join_err) => return Err(UdpTransportError::driver_panic("shutdown")),
+            }
+        }
+
+        // Abort the driver (it may still be running the select! loop)
+        let Some(driver) = self.driver_handle.take() else {
+            return Ok(());
+        };
+
+        driver.abort();
+        match driver.await {
+            Ok(Ok(())) | Err(_) => Ok(()),
+            Ok(Err(e)) if matches!(e.kind(), DriverErrorKind::ConnectionClosed) => Ok(()),
+            Ok(Err(e)) => Err(UdpTransportError::driver("shutdown", e)),
+        }
+    }
+
+    /// Whether the driver task is still running.
+    pub fn is_alive(&self) -> bool {
+        !self.driver_handle.is_finished()
+    }
+
+    /// Create a `UdpTransport` from raw channels, without background tasks.
+    ///
+    /// For unit tests that exercise the channel-based API (FramedRead,
+    /// FramedWrite) without needing a real UDP socket or TLS stack.
+    #[cfg(test)]
+    pub(crate) fn from_channels(data_rx: mpsc::Receiver<Vec<u8>>, data_tx: mpsc::Sender<Vec<u8>>) -> Self {
+        Self {
+            data_rx,
+            data_tx,
+            shared: Arc::new(Mutex::new(SharedIo::new())),
+            driver_handle: AbortOnDrop::new(tokio::spawn(async { Ok(()) })),
+            pump_handle: AbortOnDrop::new(tokio::spawn(async { Ok(()) })),
+            write_pump_handle: AbortOnDrop::new(tokio::spawn(async { Ok(()) })),
+        }
+    }
+}
+
+impl core::fmt::Debug for UdpTransport {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("UdpTransport")
+            .field("driver_alive", &!self.driver_handle.is_finished())
+            .field("pump_alive", &!self.pump_handle.is_finished())
+            .field("write_pump_alive", &!self.write_pump_handle.is_finished())
+            .finish()
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// connect_udp
+// ════════════════════════════════════════════════════════════════════
+
+/// Establish a UDP transport to an RDP server.
+///
+/// Performs the complete connection sequence:
+/// 1. Binds a UDP socket and performs the RDPEUDP2 three-way handshake
+/// 2. Performs a TLS handshake over the RDPEUDP2 connection
+/// 3. Negotiates the RDPEMT tunnel (CreateRequest/CreateResponse)
+/// 4. Spawns background data pump tasks
+/// 5. Returns a `UdpTransport` handle for bidirectional data transfer
+///
+/// # Errors
+///
+/// Returns `UdpTransportError` if any phase of the connection fails:
+/// socket binding, RDPEUDP2 handshake, TLS negotiation, or RDPEMT tunnel
+/// rejection.
+pub async fn connect_udp(config: UdpTransportConfig) -> Result<UdpTransport, UdpTransportError> {
+    // Phase 1: Bind UDP socket and connect to server.
+    // The bind address's family must match server_addr's: an IPv4 socket cannot
+    // connect() to an IPv6 destination. Mirrors the TCP listener's family match
+    // in ironrdp-server/src/server.rs (RdpServer::run).
+    let bind_addr = match config.server_addr {
+        SocketAddr::V4(_) => SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0),
+        SocketAddr::V6(_) => SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0),
+    };
+    let socket = UdpSocket::bind(bind_addr)
+        .await
+        .map_err(|error| UdpTransportError::socket("connect udp", error))?;
+    socket
+        .connect(config.server_addr)
+        .await
+        .map_err(|error| UdpTransportError::socket("connect udp", error))?;
+
+    tracing::debug!(
+        server = %config.server_addr,
+        "UDP socket bound, starting RDPEUDP2 handshake"
+    );
+
+    // Phase 2: Create the sans-I/O connection and shared I/O bridge
+    let shared = Arc::new(Mutex::new(SharedIo::new()));
+    let connected_notify = Arc::new(Notify::new());
+
+    let mut connection_config = config.connection_config;
+    connection_config.cookie_hash = Some(cookie_hash(&config.tunnel_config));
+
+    let conn = RdpeudpConnection::connect(connection_config, Clock::new().now()).map_err(|error| {
+        UdpTransportError::handshake("connect UDP", DriverError::rdpeudp("build RDP-UDP connection", error))
+    })?;
+    let driver = Driver::new(socket, conn, Arc::clone(&shared), Arc::clone(&connected_notify));
+
+    // Spawn the driver task (it immediately sends the SYN packet)
+    // Guarded from here on, so the TLS and tunnel steps below abort the driver
+    // if they fail rather than detaching it.
+    let mut driver_handle = AbortOnDrop::new(tokio::spawn(async move { driver.run().await }));
+
+    // Wait for the RDPEUDP2 handshake to complete (Event::Connected)
+    let handshake_result = tokio::time::timeout(config.handshake_timeout, connected_notify.notified()).await;
+
+    if handshake_result.is_err() {
+        return Err(UdpTransportError::handshake_timeout("connect udp"));
+    }
+
+    // Check if driver died during handshake
+    if let Some(driver) = driver_handle.take_if_finished() {
+        return match driver.await {
+            Ok(Ok(())) => Err(UdpTransportError::handshake(
+                "connect udp",
+                DriverError::connection_closed("connect udp"),
+            )),
+            Ok(Err(e)) => Err(UdpTransportError::handshake("connect udp", e)),
+            Err(_) => Err(UdpTransportError::driver_panic("connect udp")),
+        };
+    }
+
+    tracing::debug!("RDPEUDP2 handshake complete, starting TLS");
+
+    // Phase 3: TLS handshake over the RDPEUDP2 stream
+    let rdpeudp_stream = RdpeudpStream::new(Arc::clone(&shared));
+    let tls_stream = tls_upgrade(rdpeudp_stream, &config.server_name, config.server_cert_verifier)
+        .await
+        .map_err(|error| UdpTransportError::tls("connect udp", error))?;
+
+    tracing::debug!("TLS handshake complete, starting RDPEMT tunnel negotiation");
+
+    // Phase 4: RDPEMT tunnel handshake
+    //
+    // Split the TLS stream so we can read and write concurrently.
+    // tokio::io::split gives us independent read/write halves.
+    let (mut tls_read, mut tls_write) = tokio::io::split(tls_stream);
+
+    let mut tunnel = establish_tunnel_split(&mut tls_read, &mut tls_write, config.tunnel_config).await?;
+
+    tracing::debug!("RDPEMT tunnel established, starting data pump");
+
+    // Phase 5: Set up data channels and spawn the read pump
+    let (incoming_tx, incoming_rx) = mpsc::channel::<Vec<u8>>(64);
+    let (outgoing_tx, mut outgoing_rx) = mpsc::channel::<Vec<u8>>(64);
+
+    // Read pump: TLS → RDPEMT decode → channel
+    let pump_handle = AbortOnDrop::new(tokio::spawn(async move {
+        tunnel_data_loop(&mut tls_read, &mut tunnel, &incoming_tx).await
+    }));
+
+    // Write pump: channel → RDPEMT encode → TLS
+    let write_pump_handle = AbortOnDrop::new(tokio::spawn(async move {
+        write_pump(&mut tls_write, &mut outgoing_rx).await
+    }));
+
+    Ok(UdpTransport {
+        data_rx: incoming_rx,
+        data_tx: outgoing_tx,
+        shared,
+        driver_handle,
+        pump_handle,
+        write_pump_handle,
+    })
+}
+
+/// Establish the RDPEMT tunnel using already-split TLS read/write halves.
+async fn establish_tunnel_split<R, W>(
+    reader: &mut R,
+    writer: &mut W,
+    config: TunnelConfig,
+) -> Result<ironrdp_rdpemt::RdpemtTunnel, UdpTransportError>
+where
+    R: tokio::io::AsyncRead + Unpin,
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    let mut tunnel = ironrdp_rdpemt::RdpemtTunnel::client(config);
+
+    // Send CreateRequest
+    if let Some(pdu_bytes) = tunnel.poll_pdu() {
+        write_tunnel_pdu(writer, &pdu_bytes).await?;
+    }
+
+    // Read CreateResponse. The peer closing before it arrives is a failed
+    // handshake, not a legitimate clean shutdown (there is no established
+    // tunnel yet for a clean shutdown to end).
+    let response = read_tunnel_pdu(reader).await?.ok_or_else(|| {
+        UdpTransportError::tls(
+            "establish tunnel split",
+            std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "connection closed before tunnel response",
+            ),
+        )
+    })?;
+    tunnel
+        .handle_pdu(&response)
+        .map_err(|error| UdpTransportError::rdpemt("establish tunnel split", error))?;
+
+    match tunnel.poll_event() {
+        Some(ironrdp_rdpemt::TunnelEvent::Established) => Ok(tunnel),
+        Some(ironrdp_rdpemt::TunnelEvent::Failed { hr_response }) => Err(UdpTransportError::tunnel_rejected(
+            "establish tunnel split",
+            hr_response,
+        )),
+        _ => Err(UdpTransportError::rdpemt(
+            "establish tunnel split",
+            ironrdp_rdpemt::RdpemtError::invalid_state("establish tunnel split"),
+        )),
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// accept_udp (server side)
+// ════════════════════════════════════════════════════════════════════
+
+/// Accept a UDP transport connection from a client.
+///
+/// Performs the server-side connection sequence:
+/// 1. Receives the initial SYN datagram from the pre-bound socket
+/// 2. Performs the RDPEUDP2 handshake (SYN+ACK → ACK)
+/// 3. Performs a TLS server-side handshake
+/// 4. Handles the RDPEMT tunnel negotiation (CreateRequest → CreateResponse)
+/// 5. Spawns background data pump tasks
+/// 6. Returns a `UdpTransport` handle for bidirectional data transfer
+///
+/// The caller must provide a pre-bound `UdpSocket`. After the first
+/// datagram is received, the socket is `connect()`ed to the client's
+/// address so all subsequent I/O is scoped to that peer.
+///
+/// # Errors
+///
+/// Returns `UdpTransportError` if any phase of the accept fails.
+pub async fn accept_udp(socket: UdpSocket, config: UdpAcceptConfig) -> Result<UdpTransport, UdpTransportError> {
+    // Wrap the entire accept sequence in a timeout
+    tokio::time::timeout(config.accept_timeout, accept_udp_inner(socket, config))
+        .await
+        .map_err(|_| UdpTransportError::handshake_timeout("accept udp"))?
+}
+
+async fn accept_udp_inner(socket: UdpSocket, config: UdpAcceptConfig) -> Result<UdpTransport, UdpTransportError> {
+    // Phase 1: Receive the initial SYN datagram and learn the client address
+    let mut recv_buf = vec![0u8; 9000];
+    let (n, client_addr) = socket
+        .recv_from(&mut recv_buf)
+        .await
+        .map_err(|error| UdpTransportError::socket("accept udp inner", error))?;
+
+    tracing::debug!(client = %client_addr, "Received initial datagram, decoding SYN");
+
+    // Connect the socket to the client so the driver can use send/recv
+    socket
+        .connect(client_addr)
+        .await
+        .map_err(|error| UdpTransportError::socket("accept udp inner", error))?;
+
+    // Phase 2: Decode the V1 SYN datagram and create a server-side connection
+    let syn_datagram: V1Datagram = ironrdp_core::decode(&recv_buf[..n]).map_err(|_| {
+        UdpTransportError::handshake(
+            "accept UDP",
+            DriverError::rdpeudp(
+                "decode SYN datagram",
+                ironrdp_rdpeudp::RdpeudpError::invalid_packet("decode SYN datagram", "SYN datagram did not decode"),
+            ),
+        )
+    })?;
+
+    let mut connection_config = config.connection_config;
+    connection_config.cookie_hash = Some(cookie_hash(&config.tunnel_config));
+
+    let conn = RdpeudpConnection::accept(connection_config, &syn_datagram, Clock::new().now()).map_err(|error| {
+        UdpTransportError::handshake("accept UDP", DriverError::rdpeudp("accept RDP-UDP connection", error))
+    })?;
+
+    // Phase 3: Start the driver (it picks up the SYN+ACK from poll_transmit)
+    let shared = Arc::new(Mutex::new(SharedIo::new()));
+    let connected_notify = Arc::new(Notify::new());
+
+    let driver = Driver::new(socket, conn, Arc::clone(&shared), Arc::clone(&connected_notify));
+    // Guarded from here on, so the TLS and tunnel steps below abort the driver
+    // if they fail rather than detaching it.
+    let mut driver_handle = AbortOnDrop::new(tokio::spawn(async move { driver.run().await }));
+
+    // Wait for the RDPEUDP2 handshake to complete (ACK received)
+    connected_notify.notified().await;
+
+    if let Some(driver) = driver_handle.take_if_finished() {
+        return match driver.await {
+            Ok(Ok(())) => Err(UdpTransportError::handshake(
+                "accept udp inner",
+                DriverError::connection_closed("accept udp inner"),
+            )),
+            Ok(Err(e)) => Err(UdpTransportError::handshake("accept udp inner", e)),
+            Err(_) => Err(UdpTransportError::driver_panic("accept udp inner")),
+        };
+    }
+
+    tracing::debug!("RDPEUDP2 server handshake complete, starting TLS accept");
+
+    // Phase 4: TLS server-side handshake
+    let rdpeudp_stream = RdpeudpStream::new(Arc::clone(&shared));
+    let tls_stream = tls_accept(rdpeudp_stream, config.tls_config)
+        .await
+        .map_err(|error| UdpTransportError::tls("accept udp inner", error))?;
+
+    tracing::debug!("TLS accept complete, starting RDPEMT tunnel negotiation");
+
+    // Phase 5: RDPEMT server-side tunnel handshake
+    let (mut tls_read, mut tls_write) = tokio::io::split(tls_stream);
+
+    let mut tunnel = establish_tunnel_server_split(&mut tls_read, &mut tls_write, config.tunnel_config).await?;
+
+    tracing::debug!("RDPEMT server tunnel established, starting data pump");
+
+    // Phase 6: Set up data channels and spawn pumps (identical to client side)
+    let (incoming_tx, incoming_rx) = mpsc::channel::<Vec<u8>>(64);
+    let (outgoing_tx, mut outgoing_rx) = mpsc::channel::<Vec<u8>>(64);
+
+    let pump_handle = AbortOnDrop::new(tokio::spawn(async move {
+        tunnel_data_loop(&mut tls_read, &mut tunnel, &incoming_tx).await
+    }));
+
+    // Write pump: channel → RDPEMT encode → TLS
+    let write_pump_handle = AbortOnDrop::new(tokio::spawn(async move {
+        write_pump(&mut tls_write, &mut outgoing_rx).await
+    }));
+
+    Ok(UdpTransport {
+        data_rx: incoming_rx,
+        data_tx: outgoing_tx,
+        shared,
+        driver_handle,
+        pump_handle,
+        write_pump_handle,
+    })
+}
+
+/// Server-side RDPEMT tunnel establishment.
+///
+/// Mirrors `establish_tunnel_split` but uses `RdpemtTunnel::server()`:
+/// reads the client's CreateRequest, validates it, sends CreateResponse.
+async fn establish_tunnel_server_split<R, W>(
+    reader: &mut R,
+    writer: &mut W,
+    config: TunnelConfig,
+) -> Result<ironrdp_rdpemt::RdpemtTunnel, UdpTransportError>
+where
+    R: tokio::io::AsyncRead + Unpin,
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    let mut tunnel = ironrdp_rdpemt::RdpemtTunnel::server(config);
+
+    // Read CreateRequest from client. A close before it arrives is a failed
+    // handshake, not a legitimate clean shutdown.
+    let request = read_tunnel_pdu(reader).await?.ok_or_else(|| {
+        UdpTransportError::tls(
+            "establish tunnel server split",
+            std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "connection closed before tunnel request",
+            ),
+        )
+    })?;
+    tunnel
+        .handle_pdu(&request)
+        .map_err(|error| UdpTransportError::rdpemt("establish tunnel server split", error))?;
+
+    // Send CreateResponse
+    if let Some(pdu_bytes) = tunnel.poll_pdu() {
+        write_tunnel_pdu(writer, &pdu_bytes).await?;
+    }
+
+    match tunnel.poll_event() {
+        Some(ironrdp_rdpemt::TunnelEvent::Established) => Ok(tunnel),
+        Some(ironrdp_rdpemt::TunnelEvent::Failed { hr_response }) => Err(UdpTransportError::tunnel_rejected(
+            "establish tunnel server split",
+            hr_response,
+        )),
+        _ => Err(UdpTransportError::rdpemt(
+            "establish tunnel server side",
+            ironrdp_rdpemt::RdpemtError::invalid_state("establish tunnel server side"),
+        )),
+    }
+}
+
+/// Write pump: drains outgoing channel → RDPEMT encode → TLS write.
+///
+/// Shared by both `connect_udp` and `accept_udp`. Returns the first failure
+/// encountered rather than only logging it, so `shutdown()` can surface it
+/// to the caller instead of the pump silently going quiet.
+async fn write_pump<W>(tls_write: &mut W, outgoing_rx: &mut mpsc::Receiver<Vec<u8>>) -> Result<(), UdpTransportError>
+where
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    while let Some(data) = outgoing_rx.recv().await {
+        let pdu = ironrdp_rdpemt::TunnelData {
+            sub_headers: Vec::new(),
+            higher_layer_data: data,
+        };
+        let encoded = ironrdp_core::encode_vec(&pdu)
+            .map_err(|error| UdpTransportError::rdpemt("write pump", ironrdp_rdpemt::RdpemtError::encode(error)))?;
+        tls_write
+            .write_all(&encoded)
+            .await
+            .map_err(|error| UdpTransportError::tls("write pump", error))?;
+        tls_write
+            .flush()
+            .await
+            .map_err(|error| UdpTransportError::tls("write pump", error))?;
+    }
+    Ok(())
+}
+
+/// The value a version 3 SYN binds itself to: the SHA-256 of the
+/// `securityCookie` the server sent in the Initiate Multitransport Request
+/// PDU ([MS-RDPEUDP] 2.2.2.9).
+///
+/// Derived here rather than asked of the caller, so the hash in the handshake
+/// is always over the same cookie the RDPEMT tunnel will present a moment
+/// later. The sans-I/O crate takes the finished hash and stays free of any
+/// cryptographic dependency.
+fn cookie_hash(tunnel_config: &TunnelConfig) -> [u8; 32] {
+    Sha256::digest(tunnel_config.security_cookie).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use core::sync::atomic::{AtomicBool, Ordering};
+
+    use super::*;
+
+    /// Dropping the guard stops the task rather than detaching it.
+    ///
+    /// A bare `JoinHandle` detaches on drop, so every early return between
+    /// spawning the driver and returning a `UdpTransport` used to leave it
+    /// running with the socket, the timers and the keep-alives.
+    #[tokio::test]
+    async fn the_guard_aborts_a_task_it_still_owns() {
+        static STILL_RUNNING: AtomicBool = AtomicBool::new(false);
+        STILL_RUNNING.store(false, Ordering::SeqCst);
+
+        let guard = AbortOnDrop::new(tokio::spawn(async {
+            loop {
+                STILL_RUNNING.store(true, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+        }));
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(STILL_RUNNING.load(Ordering::SeqCst), "the task should have started");
+
+        drop(guard);
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        STILL_RUNNING.store(false, Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        assert!(
+            !STILL_RUNNING.load(Ordering::SeqCst),
+            "the task outlived the guard that owned it"
+        );
+    }
+
+    /// Taking the handle back disarms the guard, so a task that is about to be
+    /// awaited is not killed underneath the caller.
+    #[tokio::test]
+    async fn taking_the_handle_back_disarms_the_guard() {
+        let mut guard = AbortOnDrop::new(tokio::spawn(async {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            7u8
+        }));
+
+        let handle = guard.take().expect("the handle is still there");
+        drop(guard);
+
+        assert_eq!(handle.await.expect("the task should not have been aborted"), 7);
+    }
+
+    /// Dropping a `UdpTransport` stops its background tasks. Without this the
+    /// driver keeps the socket open and keeps answering keep-alives for the
+    /// life of the process.
+    #[tokio::test]
+    async fn dropping_the_transport_stops_its_tasks() {
+        static DRIVER_RUNNING: AtomicBool = AtomicBool::new(false);
+        DRIVER_RUNNING.store(false, Ordering::SeqCst);
+
+        let (_incoming_tx, incoming_rx) = mpsc::channel::<Vec<u8>>(4);
+        let (outgoing_tx, _outgoing_rx) = mpsc::channel::<Vec<u8>>(4);
+
+        let transport = UdpTransport {
+            data_rx: incoming_rx,
+            data_tx: outgoing_tx,
+            shared: Arc::new(Mutex::new(SharedIo::new())),
+            driver_handle: AbortOnDrop::new(tokio::spawn(async {
+                loop {
+                    DRIVER_RUNNING.store(true, Ordering::SeqCst);
+                    tokio::time::sleep(Duration::from_millis(1)).await;
+                }
+            })),
+            pump_handle: AbortOnDrop::new(tokio::spawn(async { Ok(()) })),
+            write_pump_handle: AbortOnDrop::new(tokio::spawn(async { Ok(()) })),
+        };
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(DRIVER_RUNNING.load(Ordering::SeqCst));
+
+        drop(transport);
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        DRIVER_RUNNING.store(false, Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        assert!(
+            !DRIVER_RUNNING.load(Ordering::SeqCst),
+            "the driver outlived the transport that owned it"
+        );
+    }
+}

--- a/crates/ironrdp-rdpeudp-tokio/src/tunnel.rs
+++ b/crates/ironrdp-rdpeudp-tokio/src/tunnel.rs
@@ -1,0 +1,246 @@
+//! Async wrapper for RDPEMT tunnel handshake and data framing.
+//!
+//! The sans-I/O `RdpemtTunnel` from `ironrdp-rdpemt` handles the
+//! protocol state machine. This module provides async I/O helpers
+//! to drive it over a TLS stream:
+//!
+//! - `establish_tunnel()`: perform the CreateRequest/CreateResponse handshake
+//! - `read_tunnel_pdu()`: read a complete RDPEMT PDU using the self-framing header
+//! - `write_tunnel_pdu()`: write a PDU and flush
+
+use std::io;
+
+use ironrdp_rdpemt::{RdpemtTunnel, TunnelEvent};
+use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWrite, AsyncWriteExt as _};
+
+use crate::error::{UdpTransportError, UdpTransportErrorExt as _};
+
+/// Read a complete RDPEMT PDU from the stream using self-framing.
+///
+/// Wire layout:
+/// ```text
+/// Byte 0:   Action
+/// Byte 1-2: PayloadLength (u16 LE)
+/// Byte 3:   HeaderLength (u8, >= 4)
+/// Bytes 4..HeaderLength:  SubHeaders (optional)
+/// Bytes HeaderLength..:   Higher-layer data (PayloadLength bytes)
+/// ```
+///
+/// Total PDU size = HeaderLength + PayloadLength.
+///
+/// Returns `Ok(None)` only for EOF before any byte of a new PDU has been
+/// read: that is the sole case that is a clean shutdown between frames.
+/// Once even the first header byte has been consumed, an EOF anywhere
+/// later (mid-header, mid-subheader, mid-payload) means the peer closed
+/// mid-frame, and is reported as an error rather than folded into the
+/// clean-shutdown case, so a truncated PDU cannot be silently mistaken
+/// for a graceful close.
+pub(crate) async fn read_tunnel_pdu<S>(stream: &mut S) -> Result<Option<Vec<u8>>, UdpTransportError>
+where
+    S: AsyncRead + Unpin,
+{
+    // Read the first header byte alone. Both a zero-length read (a plain
+    // stream at true EOF) and an UnexpectedEof error (rustls reports EOF
+    // without a TLS close_notify this way rather than as Ok(0); this
+    // transport's own shutdown() doesn't send one) are legitimate here: no
+    // byte of a new PDU has been consumed, so this is a clean shutdown
+    // between frames. Any other error kind, or any EOF once this first byte
+    // is in hand, means the peer closed mid-frame and is a truncated PDU,
+    // not a clean close.
+    let mut header = [0u8; 4];
+    match stream.read(&mut header[..1]).await {
+        Ok(0) => return Ok(None),
+        Ok(_) => {}
+        Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(error) => return Err(UdpTransportError::tls("read tunnel pdu", error)),
+    }
+
+    // Any EOF from here on is mid-frame: a truncated PDU, not a clean close.
+    stream
+        .read_exact(&mut header[1..])
+        .await
+        .map_err(|error| UdpTransportError::tls("read tunnel pdu", error))?;
+
+    let payload_len = usize::from(u16::from_le_bytes([header[1], header[2]]));
+    let header_len = usize::from(header[3]);
+
+    // Sub-headers occupy the space between the fixed 4-byte header
+    // and the end of the header region
+    let extra_header = header_len.saturating_sub(4);
+    let total = header_len + payload_len;
+
+    let mut buf = Vec::with_capacity(total);
+    buf.extend_from_slice(&header);
+
+    if extra_header > 0 {
+        buf.resize(4 + extra_header, 0);
+        stream
+            .read_exact(&mut buf[4..4 + extra_header])
+            .await
+            .map_err(|error| UdpTransportError::tls("read tunnel pdu", error))?;
+    }
+
+    if payload_len > 0 {
+        let offset = buf.len();
+        buf.resize(offset + payload_len, 0);
+        stream
+            .read_exact(&mut buf[offset..])
+            .await
+            .map_err(|error| UdpTransportError::tls("read tunnel pdu", error))?;
+    }
+
+    Ok(Some(buf))
+}
+
+/// Write a complete RDPEMT PDU to the stream and flush.
+pub(crate) async fn write_tunnel_pdu<S>(stream: &mut S, pdu: &[u8]) -> Result<(), UdpTransportError>
+where
+    S: AsyncWrite + Unpin,
+{
+    stream
+        .write_all(pdu)
+        .await
+        .map_err(|error| UdpTransportError::tls("write tunnel pdu", error))?;
+    stream
+        .flush()
+        .await
+        .map_err(|error| UdpTransportError::tls("write tunnel pdu", error))?;
+    Ok(())
+}
+
+/// Read RDPEMT data PDUs from the TLS stream and forward higher-layer
+/// data to the application via a channel.
+///
+/// This runs in the same task as the data forwarding loop after the
+/// tunnel is established. It reads tunnel PDUs, processes them through
+/// the sans-I/O state machine, and sends `TunnelEvent::Data` payloads
+/// to the application.
+pub(crate) async fn tunnel_data_loop<S>(
+    stream: &mut S,
+    tunnel: &mut RdpemtTunnel,
+    data_tx: &tokio::sync::mpsc::Sender<Vec<u8>>,
+) -> Result<(), UdpTransportError>
+where
+    S: AsyncRead + Unpin,
+{
+    loop {
+        let pdu = match read_tunnel_pdu(stream).await {
+            Ok(Some(pdu)) => pdu,
+            // Clean shutdown: EOF before any byte of a new PDU.
+            Ok(None) => return Ok(()),
+            Err(e) => return Err(e),
+        };
+
+        tunnel
+            .handle_pdu(&pdu)
+            .map_err(|error| UdpTransportError::rdpemt("tunnel data loop", error))?;
+
+        while let Some(event) = tunnel.poll_event() {
+            match event {
+                // `sub_headers` (e.g. auto-detect bandwidth measurement, MS-RDPBCGR
+                // 2.2.14) are not consumed here; this driver only wires the DVC
+                // payload through. A future auto-detect integration would need to
+                // dispatch them instead of discarding them.
+                TunnelEvent::Data { data, .. } => {
+                    if data_tx.send(data).await.is_err() {
+                        // Application dropped the receiver
+                        return Ok(());
+                    }
+                }
+                TunnelEvent::Established => {
+                    // Already established, ignore duplicate
+                }
+                TunnelEvent::Failed { hr_response } => {
+                    return Err(UdpTransportError::tunnel_rejected("tunnel data loop", hr_response));
+                }
+                // `TunnelEvent` is `#[non_exhaustive]`; a variant this driver
+                // doesn't know about yet is ignored rather than treated as an
+                // error, matching how `Established` is handled above.
+                _ => {}
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verify that read_tunnel_pdu correctly reassembles a simple Data PDU.
+    #[tokio::test]
+    async fn read_tunnel_pdu_simple_data() {
+        // Encode a TunnelData PDU: Action=2, PayloadLen=5, HeaderLen=4, "Hello"
+        let wire: Vec<u8> = vec![0x02, 0x05, 0x00, 0x04, 0x48, 0x65, 0x6C, 0x6C, 0x6F];
+
+        let mut cursor = io::Cursor::new(wire);
+        let pdu = read_tunnel_pdu(&mut cursor).await.expect("read").expect("pdu present");
+        assert_eq!(pdu, [0x02, 0x05, 0x00, 0x04, 0x48, 0x65, 0x6C, 0x6C, 0x6F]);
+    }
+
+    /// Verify that read_tunnel_pdu handles sub-headers.
+    #[tokio::test]
+    async fn read_tunnel_pdu_with_subheader() {
+        // Action=2, PayloadLen=2, HeaderLen=7 (4 + 3 subheader), subheader=[03, 00, FF], payload=[01, 02]
+        let expected: &[u8] = &[0x02, 0x02, 0x00, 0x07, 0x03, 0x00, 0xFF, 0x01, 0x02];
+
+        let mut cursor = io::Cursor::new(expected.to_vec());
+        let pdu = read_tunnel_pdu(&mut cursor).await.expect("read").expect("pdu present");
+        assert_eq!(pdu, expected);
+    }
+
+    /// Verify that read_tunnel_pdu handles empty payload.
+    #[tokio::test]
+    async fn read_tunnel_pdu_empty_payload() {
+        // Action=2, PayloadLen=0, HeaderLen=4
+        let expected: &[u8] = &[0x02, 0x00, 0x00, 0x04];
+
+        let mut cursor = io::Cursor::new(expected.to_vec());
+        let pdu = read_tunnel_pdu(&mut cursor).await.expect("read").expect("pdu present");
+        assert_eq!(pdu, expected);
+    }
+
+    /// Verify that write + read roundtrips through an in-memory pipe.
+    #[tokio::test]
+    async fn write_read_roundtrip() {
+        let (mut client, mut server) = tokio::io::duplex(4096);
+
+        let original: Vec<u8> = vec![0x02, 0x03, 0x00, 0x04, 0xAA, 0xBB, 0xCC];
+
+        let write_handle = tokio::spawn(async move {
+            write_tunnel_pdu(&mut client, &original).await.expect("write");
+        });
+
+        let pdu = read_tunnel_pdu(&mut server).await.expect("read").expect("pdu present");
+        write_handle.await.expect("join");
+
+        assert_eq!(pdu, [0x02, 0x03, 0x00, 0x04, 0xAA, 0xBB, 0xCC]);
+    }
+
+    /// EOF before any byte of a new PDU is a clean shutdown: `Ok(None)`, not
+    /// an error and not confused with a truncated PDU.
+    #[tokio::test]
+    async fn read_tunnel_pdu_clean_eof_between_frames() {
+        let mut cursor = io::Cursor::new(Vec::<u8>::new());
+        let pdu = read_tunnel_pdu(&mut cursor).await.expect("read");
+        assert!(pdu.is_none());
+    }
+
+    /// EOF after the first header byte, but before the PDU is complete, is a
+    /// truncated PDU: an error, never `Ok(None)`. Covers all three points a
+    /// real peer could die mid-frame: mid-header, mid-subheader, mid-payload.
+    #[tokio::test]
+    async fn read_tunnel_pdu_mid_frame_eof_is_an_error_not_clean_shutdown() {
+        // Mid fixed header: only 2 of the 4 header bytes arrive.
+        let mut cursor = io::Cursor::new(vec![0x02, 0x05]);
+        assert!(read_tunnel_pdu(&mut cursor).await.is_err());
+
+        // Complete header (HeaderLen=7, so 3 subheader bytes expected) but the
+        // stream dies after only 1 of them.
+        let mut cursor = io::Cursor::new(vec![0x02, 0x02, 0x00, 0x07, 0x03]);
+        assert!(read_tunnel_pdu(&mut cursor).await.is_err());
+
+        // Complete header (PayloadLen=5) but only 2 payload bytes arrive.
+        let mut cursor = io::Cursor::new(vec![0x02, 0x05, 0x00, 0x04, 0x48, 0x65]);
+        assert!(read_tunnel_pdu(&mut cursor).await.is_err());
+    }
+}

--- a/crates/ironrdp-testsuite-extra/Cargo.toml
+++ b/crates/ironrdp-testsuite-extra/Cargo.toml
@@ -37,6 +37,9 @@ ironrdp-svc.path = "../ironrdp-svc"
 ironrdp-input.path = "../ironrdp-input"
 ironrdp-propertyset.path = "../ironrdp-propertyset"
 ironrdp-rdpdr.path = "../ironrdp-rdpdr"
+ironrdp-rdpemt = { path = "../ironrdp-rdpemt", features = ["std"] }
+ironrdp-rdpeudp = { path = "../ironrdp-rdpeudp", features = ["std"] }
+ironrdp-rdpeudp-tokio.path = "../ironrdp-rdpeudp-tokio"
 ironrdp-rdpsnd.path = "../ironrdp-rdpsnd"
 ironrdp-rdpsnd-native = { path = "../ironrdp-rdpsnd-native", features = ["capture"] }
 ironrdp-rpc = { path = "../ironrdp-rpc", features = ["__test"] }
@@ -44,10 +47,15 @@ ironrdp-viewer.path = "../ironrdp-viewer"
 ironrdp-tokio.path = "../ironrdp-tokio"
 ironrdp-tls = { path = "../ironrdp-tls", features = ["rustls"] }
 ironrdp-vmconnect.path = "../ironrdp-vmconnect"
+rcgen = "0.14"
 semver = "1.0"
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-tokio = { version = "1", features = ["sync", "time", "net", "rt", "macros", "io-util"] }
+tokio = { version = "1", features = ["sync", "time", "net", "rt", "rt-multi-thread", "macros", "io-util"] }
+# No provider feature here on purpose: `ironrdp-tls` already brings
+# aws-lc-rs, and enabling a second one leaves rustls unable to pick a
+# process default, which fails every TLS test in this binary.
+tokio-rustls = { version = "0.26", default-features = false }
 uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(windows)'.dev-dependencies]

--- a/crates/ironrdp-testsuite-extra/tests/main.rs
+++ b/crates/ironrdp-testsuite-extra/tests/main.rs
@@ -6,5 +6,6 @@ mod capture_helpers;
 mod client_config;
 mod dvc_pipe_proxy;
 mod e2e;
+mod rdpeudp_tokio;
 mod vmconnect;
 mod volume;

--- a/crates/ironrdp-testsuite-extra/tests/rdpeudp_tokio.rs
+++ b/crates/ironrdp-testsuite-extra/tests/rdpeudp_tokio.rs
@@ -1,0 +1,389 @@
+//! Full-stack integration tests: client <-> server over loopback UDP.
+//!
+//! Each test establishes a complete RDPEUDP2 + TLS + RDPEMT tunnel
+//! between a client (`connect_udp`) and server (`accept_udp`) on
+//! localhost, then exercises bidirectional data transfer.
+//!
+//! These tests use `multi_thread` flavor because they perform real
+//! UDP I/O, which conflicts with tokio's mock clock (test-util).
+
+use core::time::Duration;
+use std::sync::Arc;
+
+use ironrdp_rdpemt::TunnelConfig;
+use ironrdp_rdpeudp::ConnectionConfig;
+use ironrdp_rdpeudp_tokio::{
+    MultitransportBootstrap, UdpAcceptConfig, UdpTransport, UdpTransportConfig, accept_udp, connect_udp,
+};
+use tokio::net::UdpSocket;
+
+/// Generate a self-signed TLS server config for testing.
+fn test_tls_server_config() -> Arc<tokio_rustls::rustls::ServerConfig> {
+    let cert = rcgen::generate_simple_self_signed(vec!["localhost".into()]).expect("generate cert");
+
+    let cert_der = tokio_rustls::rustls::pki_types::CertificateDer::from(cert.cert.der().to_vec());
+    // rcgen 0.14 renamed `CertifiedKey::key_pair` to `signing_key`.
+    let key_der = tokio_rustls::rustls::pki_types::PrivateKeyDer::try_from(cert.signing_key.serialize_der())
+        .expect("serialize key");
+
+    let config = tokio_rustls::rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(vec![cert_der], key_der)
+        .expect("server config");
+
+    Arc::new(config)
+}
+
+fn test_tunnel_config() -> TunnelConfig {
+    TunnelConfig {
+        request_id: 42,
+        security_cookie: [0xAB; 16],
+    }
+}
+
+/// Establish a connected client/server pair over loopback.
+///
+/// `bind_addr` selects the address family for both ends (`connect_udp`'s own
+/// bind must match the server's family, which this exercises end to end).
+///
+/// Returns `(client, server)`: both are `UdpTransport` handles
+/// ready for bidirectional data transfer.
+async fn establish_loopback_pair_on(bind_addr: &str) -> (UdpTransport, UdpTransport) {
+    let server_sock = UdpSocket::bind(bind_addr).await.expect("bind server");
+    let server_addr = server_sock.local_addr().expect("server addr");
+
+    let tunnel_config = test_tunnel_config();
+
+    let server_handle = tokio::spawn({
+        let tunnel_config = tunnel_config.clone();
+        async move {
+            accept_udp(
+                server_sock,
+                UdpAcceptConfig {
+                    tls_config: test_tls_server_config(),
+                    tunnel_config,
+                    connection_config: ConnectionConfig::default(),
+                    accept_timeout: Duration::from_secs(10),
+                },
+            )
+            .await
+        }
+    });
+
+    let client_handle = tokio::spawn(async move {
+        connect_udp(UdpTransportConfig::new(server_addr, "localhost".into(), tunnel_config)).await
+    });
+
+    let (server_result, client_result) = tokio::join!(server_handle, client_handle);
+
+    let server_transport = server_result.expect("server join").expect("server accept_udp");
+    let client_transport = client_result.expect("client join").expect("client connect_udp");
+
+    (client_transport, server_transport)
+}
+
+/// Verify the full connection sequence completes on loopback.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn full_stack_loopback_handshake() {
+    let (client, server) = establish_loopback_pair_on("127.0.0.1:0").await;
+    assert!(client.is_alive());
+    assert!(server.is_alive());
+    client.shutdown().await.expect("client shutdown");
+    server.shutdown().await.expect("server shutdown");
+}
+
+/// Verify the full connection sequence completes on IPv6 loopback.
+///
+/// `connect_udp` binds its own socket to match `server_addr`'s family; this
+/// is the only test that exercises the IPv6 side of that match, guarding
+/// against a hardcoded-IPv4 regression.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn full_stack_loopback_handshake_ipv6() {
+    let (client, server) = establish_loopback_pair_on("[::1]:0").await;
+    assert!(client.is_alive());
+    assert!(server.is_alive());
+    client.shutdown().await.expect("client shutdown");
+    server.shutdown().await.expect("server shutdown");
+}
+
+/// Verify bidirectional data transfer through the tunnel.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn full_stack_bidirectional_data() {
+    let (mut client, mut server) = establish_loopback_pair_on("127.0.0.1:0").await;
+
+    // Client -> Server
+    client.send(vec![0x01, 0x02, 0x03]).await.expect("client send");
+    let received = server.recv().await.expect("server recv");
+    assert_eq!(received, vec![0x01, 0x02, 0x03]);
+
+    // Server -> Client
+    server.send(vec![0x04, 0x05, 0x06]).await.expect("server send");
+    let received = client.recv().await.expect("client recv");
+    assert_eq!(received, vec![0x04, 0x05, 0x06]);
+
+    client.shutdown().await.expect("client shutdown");
+    server.shutdown().await.expect("server shutdown");
+}
+
+/// A payload over the wire `PayloadLength` field's 65535-byte capacity must
+/// be rejected synchronously by `send()`, and must not take the write pump
+/// down with it: a normal-sized send right after must still succeed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn send_rejects_oversized_payload_without_killing_the_pump() {
+    let (client, mut server) = establish_loopback_pair_on("127.0.0.1:0").await;
+
+    let oversized = vec![0u8; 65536];
+    let result = client.send(oversized).await;
+    assert!(result.is_err(), "a 65536-byte payload must be rejected");
+
+    // The pump must still be alive: an ordinary send right after succeeds.
+    client.send(vec![0x01, 0x02, 0x03]).await.expect("send after rejection");
+    let received = server.recv().await.expect("server recv");
+    assert_eq!(received, vec![0x01, 0x02, 0x03]);
+
+    client.shutdown().await.expect("client shutdown");
+    server.shutdown().await.expect("server shutdown");
+}
+
+/// Verify multiple messages maintain ordering through the tunnel.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn full_stack_message_ordering() {
+    let (client, mut server) = establish_loopback_pair_on("127.0.0.1:0").await;
+
+    // Send multiple messages rapidly
+    for i in 0u8..10 {
+        client.send(vec![i]).await.expect("send");
+    }
+
+    // Verify they arrive in order
+    for i in 0u8..10 {
+        let received = server.recv().await.expect("recv");
+        assert_eq!(received, vec![i], "message {i} arrived out of order");
+    }
+
+    client.shutdown().await.expect("shutdown");
+    server.shutdown().await.expect("shutdown");
+}
+
+/// Verify that a payload larger than one RDPEUDP2 packet survives the full
+/// stack.
+///
+/// Sized well past the 1232 byte MTU on purpose, to check that a split write
+/// comes back together. It does not check that the split happened: loopback
+/// carries an oversized datagram perfectly well, which is why an unsegmented
+/// 16 KiB write passed here for as long as it did. The datagram sizes
+/// themselves are asserted in `rdpeudp::connection`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn full_stack_larger_payload() {
+    let (client, mut server) = establish_loopback_pair_on("127.0.0.1:0").await;
+
+    let payload: Vec<u8> = (0..8192u32)
+        .map(|i| u8::try_from(i % 256).expect("modulo 256 fits in u8"))
+        .collect();
+    client.send(payload.clone()).await.expect("send");
+
+    let received = server.recv().await.expect("recv");
+    assert_eq!(received, payload);
+
+    client.shutdown().await.expect("shutdown");
+    server.shutdown().await.expect("shutdown");
+}
+
+/// Verify tunnel rejection when the server has a different security cookie.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tunnel_rejection_mismatched_cookie() {
+    let server_sock = UdpSocket::bind("127.0.0.1:0").await.expect("bind");
+    let server_addr = server_sock.local_addr().expect("addr");
+
+    // Server expects a different cookie than the client will send
+    let server_config = TunnelConfig {
+        request_id: 42,
+        security_cookie: [0xFF; 16],
+    };
+    let client_config = TunnelConfig {
+        request_id: 42,
+        security_cookie: [0xAA; 16],
+    };
+
+    let server_handle = tokio::spawn(async move {
+        accept_udp(
+            server_sock,
+            UdpAcceptConfig {
+                tls_config: test_tls_server_config(),
+                tunnel_config: server_config,
+                connection_config: ConnectionConfig::default(),
+                accept_timeout: Duration::from_secs(10),
+            },
+        )
+        .await
+    });
+
+    let client_handle = tokio::spawn(async move {
+        connect_udp(UdpTransportConfig::new(server_addr, "localhost".into(), client_config)).await
+    });
+
+    let (server_result, client_result) = tokio::join!(server_handle, client_handle);
+
+    // The mismatch is now caught during the RDPEUDP handshake rather than at
+    // the tunnel: the client's SYN carries the SHA-256 of its cookie
+    // ([MS-RDPEUDP] 2.2.2.9) and the server compares it against its own, so an
+    // unauthenticated peer never reaches the TLS handshake.
+    let server_err = server_result.expect("server join").is_err();
+    let client_err = client_result.expect("client join").is_err();
+
+    assert!(
+        server_err || client_err,
+        "at least one side should fail with mismatched cookies"
+    );
+}
+
+/// A `ServerCertVerifier` that rejects every certificate, used to prove a
+/// caller-supplied verifier is actually consulted rather than silently
+/// ignored in favor of the built-in no-verification default.
+#[derive(Debug)]
+struct AlwaysRejectVerifier;
+
+impl tokio_rustls::rustls::client::danger::ServerCertVerifier for AlwaysRejectVerifier {
+    fn verify_server_cert(
+        &self,
+        _: &tokio_rustls::rustls::pki_types::CertificateDer<'_>,
+        _: &[tokio_rustls::rustls::pki_types::CertificateDer<'_>],
+        _: &tokio_rustls::rustls::pki_types::ServerName<'_>,
+        _: &[u8],
+        _: tokio_rustls::rustls::pki_types::UnixTime,
+    ) -> Result<tokio_rustls::rustls::client::danger::ServerCertVerified, tokio_rustls::rustls::Error> {
+        Err(tokio_rustls::rustls::Error::General(
+            "test verifier rejects every certificate".into(),
+        ))
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _: &[u8],
+        _: &tokio_rustls::rustls::pki_types::CertificateDer<'_>,
+        _: &tokio_rustls::rustls::DigitallySignedStruct,
+    ) -> Result<tokio_rustls::rustls::client::danger::HandshakeSignatureValid, tokio_rustls::rustls::Error> {
+        Ok(tokio_rustls::rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _: &[u8],
+        _: &tokio_rustls::rustls::pki_types::CertificateDer<'_>,
+        _: &tokio_rustls::rustls::DigitallySignedStruct,
+    ) -> Result<tokio_rustls::rustls::client::danger::HandshakeSignatureValid, tokio_rustls::rustls::Error> {
+        Ok(tokio_rustls::rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<tokio_rustls::rustls::SignatureScheme> {
+        vec![tokio_rustls::rustls::SignatureScheme::ECDSA_NISTP256_SHA256]
+    }
+}
+
+/// Verify a caller-supplied `server_cert_verifier` is actually used: the
+/// server's self-signed test certificate must be rejected when the caller
+/// asks for real validation, where the default (no verifier supplied)
+/// accepts it unconditionally.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn connect_rejects_certificate_when_caller_supplies_a_verifier() {
+    let server_sock = UdpSocket::bind("127.0.0.1:0").await.expect("bind");
+    let server_addr = server_sock.local_addr().expect("addr");
+    let tunnel_config = test_tunnel_config();
+
+    let server_handle = tokio::spawn({
+        let tunnel_config = tunnel_config.clone();
+        async move {
+            accept_udp(
+                server_sock,
+                UdpAcceptConfig {
+                    tls_config: test_tls_server_config(),
+                    tunnel_config,
+                    connection_config: ConnectionConfig::default(),
+                    accept_timeout: Duration::from_secs(10),
+                },
+            )
+            .await
+        }
+    });
+
+    let client_handle = tokio::spawn(async move {
+        let mut config = UdpTransportConfig::new(server_addr, "localhost".into(), tunnel_config);
+        config.server_cert_verifier = Some(Arc::new(AlwaysRejectVerifier));
+        connect_udp(config).await
+    });
+
+    let client_result = client_handle.await.expect("client join");
+    assert!(
+        client_result.is_err(),
+        "the self-signed test certificate must be rejected once a verifier is supplied"
+    );
+
+    // The server side also errors, since the client aborts mid-handshake.
+    let _ = server_handle.await;
+}
+
+/// A failed reconnect must not leave a stale transport from an earlier
+/// successful `connect()` reachable through `is_connected()` /
+/// `take_transport()`: the bootstrap just told the server the connection
+/// is down via the abort response, so its own state must agree.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn failed_reconnect_clears_the_transport_from_an_earlier_success() {
+    let server_sock = UdpSocket::bind("127.0.0.1:0").await.expect("bind server");
+    let server_addr = server_sock.local_addr().expect("server addr");
+    let tunnel_config = test_tunnel_config();
+
+    let server_handle = tokio::spawn({
+        let tunnel_config = tunnel_config.clone();
+        async move {
+            accept_udp(
+                server_sock,
+                UdpAcceptConfig {
+                    tls_config: test_tls_server_config(),
+                    tunnel_config,
+                    connection_config: ConnectionConfig::default(),
+                    accept_timeout: Duration::from_secs(10),
+                },
+            )
+            .await
+        }
+    });
+
+    // Wire bytes for a MultitransportRequestPdu (UdpFecR), built by hand to
+    // avoid a new ironrdp-pdu dev-dependency for a single test. Layout per
+    // MS-RDPBCGR 2.2.15.1: BasicSecurityHeader, requestId, requestedProtocol,
+    // 2 reserved bytes, 16-byte securityCookie. Must match the server's
+    // test_tunnel_config() (request_id 42, cookie 0xAB) or the RDPEUDP2 SYN's
+    // cookie hash mismatches and the server silently ignores it, which times
+    // out rather than failing fast.
+    let request_wire = {
+        let mut wire = vec![0x02, 0x00, 0x00, 0x00]; // BasicSecurityHeader: TRANSPORT_REQ
+        wire.extend_from_slice(&42u32.to_le_bytes()); // requestId
+        wire.extend_from_slice(&1u16.to_le_bytes()); // requestedProtocol = UdpFecR
+        wire.extend_from_slice(&[0x00, 0x00]); // reserved
+        wire.extend_from_slice(&[0xAB; 16]); // securityCookie
+        wire
+    };
+    let mut bootstrap = MultitransportBootstrap::from_pdu(&request_wire).expect("decode request");
+    bootstrap
+        .connect(server_addr, "localhost".into(), ConnectionConfig::default())
+        .await
+        .expect("first connect succeeds");
+    assert!(bootstrap.is_connected());
+    server_handle.await.expect("server join").expect("server accept_udp");
+
+    // Reconnect against a closed loopback port nothing is listening on.
+    let unreachable_addr: core::net::SocketAddr = "127.0.0.1:1".parse().expect("valid loopback address");
+    let result = bootstrap
+        .connect(unreachable_addr, "localhost".into(), ConnectionConfig::default())
+        .await;
+    assert!(result.is_err(), "reconnect against an unreachable address must fail");
+
+    assert!(
+        !bootstrap.is_connected(),
+        "is_connected() must not report the stale transport from the earlier success"
+    );
+    assert!(
+        bootstrap.take_transport().is_none(),
+        "take_transport() must not hand back the stale transport"
+    );
+}


### PR DESCRIPTION

Fifth of six. **Stacked on the connection state machine PR**, and needs the
RDPEMT PR too.

Wires the sans-I/O connection and the RDPEMT tunnel to a real socket. A single
task owns the `UdpSocket` and the `RdpeudpConnection` and runs a select loop over
three sources: datagrams arriving, plaintext the TLS layer wants to send, and
timer expiry. It is the only place in the stack that reads a clock.

`RdpeudpStream` gives tokio-rustls something to wrap, bridging the driver to TLS
through a pair of buffers so the TLS layer never learns it is running over UDP.
`connect_udp` and `accept_udp` run the whole sequence: RDP-UDP handshake, TLS,
RDPEMT tunnel, then a data pump. `UdpTransport` implements `FramedRead` and
`FramedWrite`, so the session layer reaches it through the same traits as the TCP
path.

## Three things this layer has to get right

**A spawned task that is dropped keeps running.** All three handles (driver,
read pump, write pump) live in a guard that aborts on drop and can be taken
back when the task is meant to be awaited. That matters because the TLS
upgrade and the tunnel handshake both sit between spawning the driver and
returning the transport, and both propagate with `?`. Making the guard
structural means each early return cleans up without every path having to
remember. `shutdown()` follows the same three-task shape in reverse: the read
pump gets EOF once the shared I/O bridge is marked closed, the write pump
exits on its own once the send channel is dropped, and the driver is aborted
last since it may still be sitting in its select loop.

**The read buffer is bounded.** Ceasing to read from the socket is the
backpressure the protocol expects rather than a drop policy: unread datagrams
stay in the socket buffer, acknowledgements stop, and the receive window closes
on the sender, which is what [MS-RDPEUDP2] 3.1.1.2.2 has it for. The half that is
easy to leave out is resuming, so `poll_read` wakes the driver once it has taken
bytes out.

**An empty tunnel PDU is not end of stream.** `Framed` reads a zero-length result
as EOF, and [MS-RDPEMT] 2.2.2.3 puts no minimum on `HigherLayerData`.
[MS-RDPBCGR] 1.3.9 sends the four Continuous Auto-Detection messages
"encapsulated in the RDP_TUNNEL_SUBHEADER structure ... over the sideband
channels that are in active use", and those carriers have nothing behind the
subheaders.

## On the cookie hash

The SHA-256 the version 3 SYN carries is derived here from the tunnel config,
which already holds the security cookie. That keeps `ironrdp-rdpeudp` free of a
cryptographic dependency and means a caller cannot supply a hash over a different
cookie than the tunnel will present.

## Test plan

`cargo xtask check fmt/lints/tests/typos/locks` plus `cargo xtask wasm check`

Unit tests for the stream adapter, the framing adapter, task lifetime,
backpressure, and clean-vs-truncated tunnel PDU framing, plus nine full-stack
loopback tests in `ironrdp-testsuite-extra` that run a client and server
through handshake, TLS, tunnel and bidirectional data over localhost,
including IPv4 and IPv6, an oversized-payload rejection, a caller-supplied
certificate verifier, and a failed-reconnect state check.

One caveat on those loopback tests, since it caught me out: localhost carries an
oversized datagram perfectly well, so they cannot detect an MTU violation. The
datagram sizes are asserted in the connection tests instead.

