### PR TITLE
ci(pr-automation): retrigger review on opt-in

### DIFF
--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -1479,25 +1479,23 @@ test("writer upgrades a neutral automated review check instead of creating a dup
   assert.equal(update.output.title, "Automated review complete");
 });
 
-test("writer dispatches new or explicitly requested completed classifications", async () => {
-  const writeClassification = async ({ dispatchReview, existing = false, reviewRequested = false }) => {
+test("oversized opt-in dispatches review from a cached classification", async () => {
+  const workflow = fs.readFileSync(path.join(__dirname, "..", "workflows", "labeler.yml"), "utf8");
+  const requestReview = workflowJob(workflow, "request-review");
+  assert.match(requestReview, /needs: \[resolve-pr, classification-gate\]/);
+  assert.match(requestReview, /needs\.resolve-pr\.outputs\.review-requested == 'true'/);
+  assert.match(requestReview, /needs\.classification-gate\.outputs\.available == 'true'/);
+  assert.match(requestReview, /needs\.classification-gate\.outputs\.required == 'false'/);
+  assert.match(requestReview, /dispatchClassificationComplete/);
+});
+
+test("writer dispatches new but not forced completed classifications", async () => {
+  const writeClassification = async (dispatchReview) => {
     let dispatches = 0;
     const github = {
       paginate: { iterator: async function* () { yield { data: [] }; } },
       rest: {
-        checks: {
-          listForRef: async () => ({ data: { check_runs: existing ? [{
-            id: 7,
-            external_id: `classifier-v2:${SHA}`,
-            conclusion: "success",
-            output: {
-              title: "Classification complete",
-              summary: "Validated classification.\n\nironrdp-pr-automation-state: " +
-                "{\"schema_version\":\"classifier-v2\",\"protocol_related\":false,\"automatic_review_eligible\":true}",
-            },
-          }] : [] } }),
-          create: async () => {},
-        },
+        checks: { listForRef: () => {}, create: async () => {} },
         pulls: { get: async () => ({ data: { state: "open", head: { sha: SHA } } }) },
         issues: { get: async () => ({ data: { labels: [] } }) },
         repos: { createDispatchEvent: async () => { dispatches += 1; } },
@@ -1514,16 +1512,12 @@ test("writer dispatches new or explicitly requested completed classifications", 
           machineState: { protocolRelated: false },
         },
       },
-      reviewRequested,
     });
     return dispatches;
   };
 
-  assert.equal(await writeClassification({ dispatchReview: true }), 1);
-  assert.equal(await writeClassification({ dispatchReview: false }), 0);
-  assert.equal(await writeClassification({
-    dispatchReview: true, existing: true, reviewRequested: true,
-  }), 1);
+  assert.equal(await writeClassification(true), 1);
+  assert.equal(await writeClassification(false), 0);
 });
 
 test("writer deduplicates one forced review invocation but publishes a later one", async () => {

--- a/.github/pr-automation/automation.test.js
+++ b/.github/pr-automation/automation.test.js
@@ -827,6 +827,7 @@ test("only the persistent oversized-review label starts automation from a label 
   const requested = await resolve(OVERSIZED_REVIEW_LABEL);
   assert.equal(requested.ok, true);
   assert.equal(requested.classificationRequested, true);
+  assert.equal(requested.reviewRequested, true);
   assert.equal(requested.force, false);
   assert.equal((await resolve("size/XXL")).reason, "unrelated pull request label");
 });
@@ -1478,13 +1479,25 @@ test("writer upgrades a neutral automated review check instead of creating a dup
   assert.equal(update.output.title, "Automated review complete");
 });
 
-test("writer dispatches automatic but not forced completed classifications", async () => {
-  const writeClassification = async (dispatchReview) => {
+test("writer dispatches new or explicitly requested completed classifications", async () => {
+  const writeClassification = async ({ dispatchReview, existing = false, reviewRequested = false }) => {
     let dispatches = 0;
     const github = {
       paginate: { iterator: async function* () { yield { data: [] }; } },
       rest: {
-        checks: { listForRef: () => {}, create: async () => {} },
+        checks: {
+          listForRef: async () => ({ data: { check_runs: existing ? [{
+            id: 7,
+            external_id: `classifier-v2:${SHA}`,
+            conclusion: "success",
+            output: {
+              title: "Classification complete",
+              summary: "Validated classification.\n\nironrdp-pr-automation-state: " +
+                "{\"schema_version\":\"classifier-v2\",\"protocol_related\":false,\"automatic_review_eligible\":true}",
+            },
+          }] : [] } }),
+          create: async () => {},
+        },
         pulls: { get: async () => ({ data: { state: "open", head: { sha: SHA } } }) },
         issues: { get: async () => ({ data: { labels: [] } }) },
         repos: { createDispatchEvent: async () => { dispatches += 1; } },
@@ -1501,12 +1514,16 @@ test("writer dispatches automatic but not forced completed classifications", asy
           machineState: { protocolRelated: false },
         },
       },
+      reviewRequested,
     });
     return dispatches;
   };
 
-  assert.equal(await writeClassification(true), 1);
-  assert.equal(await writeClassification(false), 0);
+  assert.equal(await writeClassification({ dispatchReview: true }), 1);
+  assert.equal(await writeClassification({ dispatchReview: false }), 0);
+  assert.equal(await writeClassification({
+    dispatchReview: true, existing: true, reviewRequested: true,
+  }), 1);
 });
 
 test("writer deduplicates one forced review invocation but publishes a later one", async () => {

--- a/.github/pr-automation/resolve-pr.js
+++ b/.github/pr-automation/resolve-pr.js
@@ -56,6 +56,8 @@ async function resolvePr({ github, context, inputs = {} }) {
   const { owner, repo } = context.repo;
   const force = route === "dispatch" && ["true", true].includes(
     inputs.force ?? context.payload.inputs?.force);
+  const oversizedReviewRequested = route === "classification" &&
+    context.payload.action === "labeled" && context.payload.label?.name === OVERSIZED_REVIEW_LABEL;
   let pr;
   try {
     if (route === "classification") {
@@ -106,8 +108,8 @@ async function resolvePr({ github, context, inputs = {} }) {
       association: pr.author_association || null,
     },
     force,
-    reviewRequested: route === "dispatch" && ["true", true].includes(
-      inputs.review ?? context.payload.inputs?.review),
+    reviewRequested: oversizedReviewRequested ||
+      (route === "dispatch" && ["true", true].includes(inputs.review ?? context.payload.inputs?.review)),
     classificationRequested: route === "classification" ||
       (route === "dispatch" && !["true", true].includes(inputs.review ?? context.payload.inputs?.review)),
     reviewRoute: route === "ci" || route === "classification-complete" ||

--- a/.github/pr-automation/write-state.js
+++ b/.github/pr-automation/write-state.js
@@ -207,7 +207,7 @@ async function applyLabels(github, owner, repo, prNumber, state) {
   return true;
 }
 
-async function writeState({ github, owner, repo, prNumber, state, botLogin, reviewRequested = false }) {
+async function writeState({ github, owner, repo, prNumber, state, botLogin }) {
   if (!state?.ok || !["classification", "review"].includes(state.mode) ||
       typeof state.expectedSha !== "string" || !Number.isSafeInteger(prNumber) || prNumber <= 0) {
     throw new Error("invalid normalized state");
@@ -235,8 +235,7 @@ async function writeState({ github, owner, repo, prNumber, state, botLogin, revi
     }
     if (state.check) {
       const created = await ensureClassificationCheck(github, owner, repo, prNumber, state.expectedSha, state.check);
-      if ((created || reviewRequested) && state.check.title === "Classification complete" &&
-          state.dispatchReview !== false) {
+      if (created && state.check.title === "Classification complete" && state.dispatchReview !== false) {
         await dispatchClassificationComplete(github, owner, repo, prNumber, state.expectedSha);
       }
     }
@@ -245,6 +244,6 @@ async function writeState({ github, owner, repo, prNumber, state, botLogin, revi
 }
 
 module.exports = {
-  StaleHeadError, applyLabels, assertCurrentHead, deleteMarkedComment, escapeMarkdown, markerBody,
-  upsertMarkedComment, writeState,
+  StaleHeadError, applyLabels, assertCurrentHead, deleteMarkedComment, dispatchClassificationComplete,
+  escapeMarkdown, markerBody, upsertMarkedComment, writeState,
 };

--- a/.github/pr-automation/write-state.js
+++ b/.github/pr-automation/write-state.js
@@ -207,7 +207,7 @@ async function applyLabels(github, owner, repo, prNumber, state) {
   return true;
 }
 
-async function writeState({ github, owner, repo, prNumber, state, botLogin }) {
+async function writeState({ github, owner, repo, prNumber, state, botLogin, reviewRequested = false }) {
   if (!state?.ok || !["classification", "review"].includes(state.mode) ||
       typeof state.expectedSha !== "string" || !Number.isSafeInteger(prNumber) || prNumber <= 0) {
     throw new Error("invalid normalized state");
@@ -235,7 +235,8 @@ async function writeState({ github, owner, repo, prNumber, state, botLogin }) {
     }
     if (state.check) {
       const created = await ensureClassificationCheck(github, owner, repo, prNumber, state.expectedSha, state.check);
-      if (created && state.check.title === "Classification complete" && state.dispatchReview !== false) {
+      if ((created || reviewRequested) && state.check.title === "Classification complete" &&
+          state.dispatchReview !== false) {
         await dispatchClassificationComplete(github, owner, repo, prNumber, state.expectedSha);
       }
     }

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1039,6 +1039,7 @@ jobs:
       - uses: actions/github-script@v8
         env:
           PULL_REQUEST_NUMBER: ${{ needs.resolve-pr.outputs.pr-number }}
+          REVIEW_REQUESTED: ${{ needs.resolve-pr.outputs.review-requested }}
           CLASSIFICATION_STATE: ${{ needs.resolve-classification-state.outputs.state }}
           REVIEW_STATE: ${{ needs.resolve-review-state.outputs.state }}
           UPSTREAM_RESULTS: >-
@@ -1062,6 +1063,7 @@ jobs:
               github, owner: context.repo.owner, repo: context.repo.repo,
               prNumber: Number(process.env.PULL_REQUEST_NUMBER), state,
               botLogin: "github-actions[bot]",
+              reviewRequested: process.env.REVIEW_REQUESTED === "true",
             });
             core.info(JSON.stringify({
               event: "pr-automation.write-state-complete",

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -165,6 +165,39 @@ jobs:
               }));
             }
 
+  request-review:
+    name: Request automated review
+    needs: [resolve-pr, classification-gate]
+    if: >-
+      needs.resolve-pr.outputs.ok == 'true' &&
+      needs.resolve-pr.outputs.review-requested == 'true' &&
+      needs.classification-gate.outputs.available == 'true' &&
+      needs.classification-gate.outputs.required == 'false'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: master
+          persist-credentials: false
+
+      - uses: actions/github-script@v8
+        env:
+          PULL_REQUEST_NUMBER: ${{ needs.resolve-pr.outputs.pr-number }}
+          HEAD_SHA: ${{ needs.resolve-pr.outputs.head-sha }}
+        with:
+          script: |
+            const { dispatchClassificationComplete } = require("./.github/pr-automation/write-state");
+            await dispatchClassificationComplete(
+              github,
+              context.repo.owner,
+              context.repo.repo,
+              Number(process.env.PULL_REQUEST_NUMBER),
+              process.env.HEAD_SHA,
+            );
+
   deterministic-analysis:
     name: Calculate deterministic labels
     needs: resolve-pr
@@ -1039,7 +1072,6 @@ jobs:
       - uses: actions/github-script@v8
         env:
           PULL_REQUEST_NUMBER: ${{ needs.resolve-pr.outputs.pr-number }}
-          REVIEW_REQUESTED: ${{ needs.resolve-pr.outputs.review-requested }}
           CLASSIFICATION_STATE: ${{ needs.resolve-classification-state.outputs.state }}
           REVIEW_STATE: ${{ needs.resolve-review-state.outputs.state }}
           UPSTREAM_RESULTS: >-
@@ -1063,7 +1095,6 @@ jobs:
               github, owner: context.repo.owner, repo: context.repo.repo,
               prNumber: Number(process.env.PULL_REQUEST_NUMBER), state,
               botLogin: "github-actions[bot]",
-              reviewRequested: process.env.REVIEW_REQUESTED === "true",
             });
             core.info(JSON.stringify({
               event: "pr-automation.write-state-complete",


### PR DESCRIPTION
Treat the oversized-review label as an explicit review request so a maintainer can retry a failed review without waiting for another CI completion or classification-state change.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>