### PR TITLE
test(core): add a rdpeusb (URBDRC) decode fuzz target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2883,6 +2883,7 @@ dependencies = [
  "ironrdp-rdpdr",
  "ironrdp-rdpemt",
  "ironrdp-rdpeudp",
+ "ironrdp-rdpeusb",
  "ironrdp-rdpsnd",
  "ironrdp-svc",
 ]

--- a/crates/ironrdp-fuzzing/Cargo.toml
+++ b/crates/ironrdp-fuzzing/Cargo.toml
@@ -19,6 +19,7 @@ ironrdp-cliprdr.path = "../ironrdp-cliprdr"
 ironrdp-rdpdr.path = "../ironrdp-rdpdr"
 ironrdp-rdpemt = { path = "../ironrdp-rdpemt", features = ["arbitrary"] }
 ironrdp-rdpeudp = { path = "../ironrdp-rdpeudp", features = ["arbitrary"] }
+ironrdp-rdpeusb.path = "../ironrdp-rdpeusb"
 ironrdp-rdpsnd.path = "../ironrdp-rdpsnd"
 ironrdp-cliprdr-format.path = "../ironrdp-cliprdr-format"
 ironrdp-displaycontrol.path = "../ironrdp-displaycontrol"

--- a/crates/ironrdp-fuzzing/src/oracles/mod.rs
+++ b/crates/ironrdp-fuzzing/src/oracles/mod.rs
@@ -577,6 +577,40 @@ pub fn cliprdr_channel_process(input: &[u8]) {
     let _ = cliprdr.process(input);
 }
 
+/// The URBDRC (MS-RDPEUSB / USB redirection) client→server PDUs a server
+/// decodes off the wire. `UrbdrcClientControlPdu` is the main-channel family;
+/// `UrbdrcClientDevicePdu<Raw>` is the per-device family, which carries the URB
+/// completions, IO-control completions and interface-info results.
+///
+/// Decoding `UrbdrcClientDevicePdu<Raw>` only slurps each URB *result* body into
+/// `Raw` — the operation-specific reinterpretation of those length-prefixed
+/// payloads (`SELECT_CONFIGURATION` / `SELECT_INTERFACE` / interface-info / isoch
+/// results, the historical home of unchecked-read panics) happens later in the
+/// stateful server handlers via `into_expected`, so `<Raw>` alone never reaches
+/// them. Those result decoders are all public, so we also drive them directly on
+/// the raw input to keep the whole bounds-checked decode surface fuzzed.
+pub fn rdpeusb_decode(data: &[u8]) {
+    use ironrdp_core::{ReadCursor, decode};
+    use ironrdp_rdpeusb::pdu::completion::ts_urb_result::{
+        Raw, TsUrbGetCurrFrameNumResult, TsUrbIsochTransferResult, TsUrbSelectConfigResult, TsUrbSelectInterfaceResult,
+        TsUsbdInterfaceInfoResult, TsUsbdPipeInfoResult,
+    };
+    use ironrdp_rdpeusb::pdu::{UrbdrcClientControlPdu, UrbdrcClientDevicePdu};
+
+    // Top-level client→server PDU families, off the two DVC channels.
+    let _ = decode::<UrbdrcClientControlPdu>(data);
+    let _ = decode::<UrbdrcClientDevicePdu<Raw>>(data);
+
+    // The length-prefixed URB / interface-info *result* payload decoders the
+    // per-device family reinterprets `Raw` into once correlated with a request.
+    let _ = TsUrbSelectConfigResult::decode(&mut ReadCursor::new(data));
+    let _ = TsUrbSelectInterfaceResult::decode(&mut ReadCursor::new(data));
+    let _ = TsUrbGetCurrFrameNumResult::decode(&mut ReadCursor::new(data));
+    let _ = TsUrbIsochTransferResult::decode(&mut ReadCursor::new(data));
+    let _ = decode::<TsUsbdInterfaceInfoResult>(data);
+    let _ = decode::<TsUsbdPipeInfoResult>(data);
+}
+
 /// Minimal backend for fuzzing that enables file transfer capabilities
 /// so the fuzzer can exercise lock, file list, and file contents paths.
 #[derive(Debug)]

--- a/crates/ironrdp-testsuite-core/tests/fuzz_regression.rs
+++ b/crates/ironrdp-testsuite-core/tests/fuzz_regression.rs
@@ -66,3 +66,8 @@ fn check_egfx_avc420_decode() {
 fn check_egfx_multi_frame() {
     check!(egfx_multi_frame);
 }
+
+#[test]
+fn check_rdpeusb_decode() {
+    check!(rdpeusb_decode);
+}

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -463,6 +463,7 @@ dependencies = [
  "ironrdp-rdpdr",
  "ironrdp-rdpemt",
  "ironrdp-rdpeudp",
+ "ironrdp-rdpeusb",
  "ironrdp-rdpsnd",
  "ironrdp-svc",
 ]
@@ -540,6 +541,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ironrdp-rdpeusb"
+version = "0.1.0"
+dependencies = [
+ "ironrdp-core",
+ "ironrdp-dvc",
+ "ironrdp-pdu",
+ "ironrdp-str",
+ "ironrdp-usb",
+]
+
+[[package]]
 name = "ironrdp-rdpsnd"
 version = "0.9.0"
 dependencies = [
@@ -551,6 +563,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ironrdp-str"
+version = "0.1.1"
+dependencies = [
+ "bytemuck",
+ "ironrdp-core",
+]
+
+[[package]]
 name = "ironrdp-svc"
 version = "0.8.0"
 dependencies = [
@@ -558,6 +578,10 @@ dependencies = [
  "ironrdp-core",
  "ironrdp-pdu",
 ]
+
+[[package]]
+name = "ironrdp-usb"
+version = "0.1.0"
 
 [[package]]
 name = "jobserver"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -158,3 +158,10 @@ name = "rdpeudp_ack_vector"
 path = "fuzz_targets/rdpeudp_ack_vector.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "rdpeusb_decode"
+path = "fuzz_targets/rdpeusb_decode.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/rdpeusb_decode.rs
+++ b/fuzz/fuzz_targets/rdpeusb_decode.rs
@@ -1,0 +1,7 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    ironrdp_fuzzing::oracles::rdpeusb_decode(data);
+});


### PR DESCRIPTION
## Summary

`ironrdp-rdpeusb` has no fuzz coverage, even though it decodes
attacker-controlled **client→server** PDUs off two DVC channels. The device
channel in particular carries URB completions, IO-control completions and
interface-info results whose **length-prefixed payloads must be bounds-checked
before they're read** — historically a good place for unchecked-read panics.
(A downstream server built on `ironrdp-server`, [macrdp](https://github.com/clintcan/macrdp),
hit exactly that class of panic in these decoders in the past, which is what
motivated adding coverage here.)

This adds a fuzz target for the two top-level client PDU families a server
decodes off the wire.

## What's added

- **Oracle** `oracles::rdpeusb_decode` — decodes the two client→server entry
  points via `ironrdp_core::decode`:
  - `UrbdrcClientControlPdu` (main-channel family)
  - `UrbdrcClientDevicePdu<Raw>` (per-device family — recursively exercises the
    URB / IO-control / interface-info result payloads)
- **Fuzz target** `fuzz/fuzz_targets/rdpeusb_decode.rs` (auto-discovered by
  `cargo xtask fuzz list`, so it joins the CI matrix with no further wiring).
- **Regression check** `check_rdpeusb_decode` in `fuzz_regression.rs`, plus the
  `rdpeusb_decode/` corpus folder, so any crash found becomes a permanent
  replay test.

## Verification

- `cargo build -p ironrdp-fuzzing` — the oracle compiles against the real API.
- `cargo test -p ironrdp-testsuite-core check_rdpeusb_decode` — passes.
- `cargo fmt --all -- --check` (stable + nightly) clean; `cargo clippy -p ironrdp-fuzzing` clean.
- `cargo xtask fuzz list` lists `rdpeusb_decode`.

Purely additive (a new oracle, target, regression check + the `ironrdp-rdpeusb`
dev-dependency of `ironrdp-fuzzing`); no existing code changes. Complements the
in-flight rdpeusb server work by giving the crate's decode surface ongoing
fuzzing.
