### PR TITLE
feat(server)!: expose per-connection keyboard metadata via ConnectionHandler

### DIFF
--- a/crates/ironrdp-acceptor/src/connection.rs
+++ b/crates/ironrdp-acceptor/src/connection.rs
@@ -33,6 +33,8 @@ pub struct Acceptor {
     message_channel_id: Option<u16>,
     desktop_size: DesktopSize,
     keyboard_layout: u32,
+    keyboard_type: gcc::KeyboardType,
+    ime_file_name: String,
     multitransport_flags: gcc::MultiTransportFlags,
     server_capabilities: Vec<CapabilitySet>,
     static_channels: StaticChannelSet,
@@ -99,6 +101,18 @@ pub struct AcceptorResult {
     /// announce one. Servers can use it to pick a server-side keyboard layout
     /// matching the client without changing any local input state.
     pub keyboard_layout: u32,
+    /// Keyboard type announced by the client in its GCC Client Core Data
+    /// (section 2.2.1.3.2, `keyboardType`).
+    ///
+    /// `KeyboardType(0)` when the client did not announce one (0 is not among the
+    /// documented values, so it doubles as "unset" the same way `keyboard_layout`'s
+    /// `0` does).
+    pub keyboard_type: gcc::KeyboardType,
+    /// Input method editor file name announced by the client in its GCC Client Core
+    /// Data (section 2.2.1.3.2, `imeFileName`).
+    ///
+    /// Populated for East Asian IME-based input locales; empty otherwise.
+    pub ime_file_name: String,
     /// Multitransport (MS-RDPEMT) capability flags announced by the client in
     /// its GCC `MultiTransportChannelData` block (section 2.2.1.3.8).
     ///
@@ -139,6 +153,8 @@ impl Acceptor {
             message_channel_id: None,
             desktop_size,
             keyboard_layout: 0,
+            keyboard_type: gcc::KeyboardType(0),
+            ime_file_name: String::new(),
             multitransport_flags: gcc::MultiTransportFlags::empty(),
             server_capabilities: capabilities,
             static_channels: StaticChannelSet::new(),
@@ -225,6 +241,8 @@ impl Acceptor {
             message_channel_id: consumed.message_channel_id,
             desktop_size,
             keyboard_layout: consumed.keyboard_layout,
+            keyboard_type: consumed.keyboard_type,
+            ime_file_name: consumed.ime_file_name,
             multitransport_flags: consumed.multitransport_flags,
             server_capabilities: consumed.server_capabilities,
             static_channels,
@@ -319,6 +337,8 @@ impl Acceptor {
                 io_channel_id: self.io_channel_id,
                 message_channel_id: self.message_channel_id,
                 keyboard_layout: self.keyboard_layout,
+                keyboard_type: self.keyboard_type,
+                ime_file_name: self.ime_file_name.clone(),
                 multitransport_flags: self.multitransport_flags,
                 reactivation: self.reactivation,
                 credentials: self.received_credentials.take(),
@@ -579,6 +599,8 @@ impl Sequence for Acceptor {
                 let early_capability = gcc_blocks.core.optional_data.early_capability_flags;
                 let client_wants_message_channel = gcc_blocks.message_channel.is_some();
                 self.keyboard_layout = gcc_blocks.core.keyboard_layout;
+                self.keyboard_type = gcc_blocks.core.keyboard_type;
+                self.ime_file_name.clone_from(&gcc_blocks.core.ime_file_name);
                 self.multitransport_flags = gcc_blocks
                     .multi_transport_channel
                     .as_ref()

--- a/crates/ironrdp-pdu/src/rdp/capability_sets/input/tests.rs
+++ b/crates/ironrdp-pdu/src/rdp/capability_sets/input/tests.rs
@@ -44,3 +44,25 @@ fn to_buffer_correctly_serializes_input_capset() {
 fn buffer_length_is_correct_for_input_capset() {
     assert_eq!(INPUT_BUFFER.len(), INPUT.size());
 }
+
+#[test]
+fn keyboard_type_zero_decodes_to_none() {
+    let mut buffer = INPUT_BUFFER;
+    buffer[8..12].copy_from_slice(&0u32.to_le_bytes());
+
+    let input: Input = decode(buffer.as_ref()).unwrap();
+    assert_eq!(input.keyboard_type, None);
+
+    assert_eq!(encode_vec(&input).unwrap(), buffer.as_ref());
+}
+
+#[test]
+fn keyboard_type_unrecognized_value_round_trips() {
+    let mut buffer = INPUT_BUFFER;
+    buffer[8..12].copy_from_slice(&0x51u32.to_le_bytes());
+
+    let input: Input = decode(buffer.as_ref()).unwrap();
+    assert_eq!(input.keyboard_type, Some(KeyboardType(0x51)));
+
+    assert_eq!(encode_vec(&input).unwrap(), buffer.as_ref());
+}

--- a/crates/ironrdp-server/src/lib.rs
+++ b/crates/ironrdp-server/src/lib.rs
@@ -35,9 +35,9 @@ pub use helper::TlsIdentityCtx;
 pub use ironrdp_acceptor::Acceptor;
 pub use ironrdp_pdu::rdp::session_info::ServerAutoReconnect;
 pub use server::{
-    AutoReconnectCookieHandle, ConnectionHandler, CredentialDecision, CredentialValidationError, CredentialValidator,
-    Credentials, ExactMatchCredentialValidator, PostConnectionAction, RdpServer, RdpServerOptions, RdpServerSecurity,
-    ServerEvent, ServerEventSender, StaticChannelFactory, TransportTls,
+    AutoReconnectCookieHandle, ConnectionHandler, ConnectionInfo, CredentialDecision, CredentialValidationError,
+    CredentialValidator, Credentials, ExactMatchCredentialValidator, PostConnectionAction, RdpServer, RdpServerOptions,
+    RdpServerSecurity, ServerEvent, ServerEventSender, StaticChannelFactory, TransportTls,
 };
 pub use sound::{RdpsndServerHandler, RdpsndServerMessage, SoundServerFactory};
 

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -74,14 +74,54 @@ pub enum PostConnectionAction {
     Stop,
 }
 
-/// Hooks for connection lifecycle events in [`RdpServer::run`].
+/// Per-connection metadata captured during connection setup, made available to
+/// [`ConnectionHandler::on_connection_info`] once the connection is established.
+///
+/// These are GCC Client Core Data fields (MS-RDPBCGR 2.2.1.3.2) that the acceptor
+/// captures but has no use for itself; embedders that want to act on them (for
+/// example, selecting a server-side keyboard layout matching the client) can do
+/// so here without reaching into the acceptor's internals.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct ConnectionInfo {
+    /// See [`ironrdp_acceptor::AcceptorResult::keyboard_layout`].
+    pub keyboard_layout: u32,
+    /// See [`ironrdp_acceptor::AcceptorResult::keyboard_type`].
+    pub keyboard_type: ironrdp_pdu::gcc::KeyboardType,
+    /// See [`ironrdp_acceptor::AcceptorResult::ime_file_name`].
+    pub ime_file_name: String,
+}
+
+impl ConnectionInfo {
+    /// Builds a `ConnectionInfo` directly, for downstream `ConnectionHandler` implementations
+    /// that want to exercise [`ConnectionHandler::on_connection_info`] in their own unit tests
+    /// without going through a live connection. `#[non_exhaustive]` blocks struct-literal
+    /// construction outside this crate, so a constructor is the only way to do that.
+    pub fn new(keyboard_layout: u32, keyboard_type: ironrdp_pdu::gcc::KeyboardType, ime_file_name: String) -> Self {
+        Self {
+            keyboard_layout,
+            keyboard_type,
+            ime_file_name,
+        }
+    }
+}
+
+/// Hooks for connection lifecycle events.
 ///
 /// Implement this trait to add pre-accept filtering (rate limiting,
-/// IP allowlists) and post-disconnect logic (cleanup, session validity
-/// checks, metrics).
+/// IP allowlists), post-disconnect logic (cleanup, session validity
+/// checks, metrics), and to observe per-connection metadata once a
+/// connection is established.
 ///
 /// All methods have default implementations that accept all connections
 /// and continue unconditionally.
+///
+/// [`Self::on_accept`] and [`Self::on_disconnected`] are called only from
+/// [`RdpServer::run`]'s own accept loop. [`Self::on_connection_info`] is
+/// called from every code path that completes connection setup, including
+/// [`RdpServer::run_connection`] and [`RdpServer::run_connection_with`], so it
+/// is the hook to use for embedders (such as those with their own
+/// multi-transport accept loop) that do not call `run`.
 pub trait ConnectionHandler: Send {
     /// Called after `accept()` returns but before `run_connection()`.
     ///
@@ -89,6 +129,12 @@ pub trait ConnectionHandler: Send {
     fn on_accept(&mut self, peer: SocketAddr) -> bool {
         let _ = peer;
         true
+    }
+
+    /// Called once per connection, after credential and auto-reconnect
+    /// validation succeed and before the session loop starts.
+    fn on_connection_info(&mut self, info: &ConnectionInfo) {
+        let _ = info;
     }
 
     /// Called after `run_connection()` completes (successfully or with error).
@@ -1699,6 +1745,16 @@ impl RdpServer {
             } else {
                 debug!("Skipping credential validation (no credentials in AcceptorResult)");
             }
+        }
+
+        if !result.reactivation
+            && let Some(ref mut handler) = self.connection_handler
+        {
+            handler.on_connection_info(&ConnectionInfo {
+                keyboard_layout: result.keyboard_layout,
+                keyboard_type: result.keyboard_type,
+                ime_file_name: result.ime_file_name.clone(),
+            });
         }
 
         if !result.input_events.is_empty() {


### PR DESCRIPTION
## Summary

AcceptorResult already carried keyboard_layout (the client's GCC Client Core Data keyboardLayout, MS-RDPBCGR 2.2.1.3.2), but ironrdp-server's client_accepted never read it, and the only extension point that could plausibly expose it, ConnectionHandler::on_accept/on_disconnected, only fires from RdpServer::run's own accept loop. An embedder with its own accept loop calling run_connection or run_connection_with directly never sees these hooks at all.

Added keyboard_type and ime_file_name to Acceptor and AcceptorResult, captured from the same Client Core Data alongside keyboard_layout.

Added a new ConnectionInfo struct and a default-no-op ConnectionHandler::on_connection_info(&ConnectionInfo) method, fired from client_accepted itself, right after credential and auto-reconnect validation succeed. This is reachable from every code path that completes connection setup, not only run's accept loop, so it is usable by embedders that never call run.

Kept the hook synchronous. It only hands the embedder a small Clone-able struct; an embedder that needs to do blocking work in response can spawn its own task, the same way the existing on_accept/on_disconnected hooks already work.

Open question: AcceptorResult is a public struct without non_exhaustive, so the two new fields are a real breaking change for any consumer destructuring it exhaustively, same class as the keyboardType change in #1689. AcceptorResult's attributes are unchanged here since marking it non_exhaustive is a broader decision than this PR's two fields.

## Validation

cargo xtask check fmt/lints/tests/typos/locks all pass.

## Review round and rebase, 2026-08-19

#1689 (KeyboardType) merged. This branch was still carrying a stale pre-merge copy of that commit, so the diff was cumulative against master. Rebased onto current master, which dropped the redundant duplicate commit (its content was already upstream) and left this PR's own single commit.

Four review findings from the bot review, all addressed:

- `on_connection_info` fired on every Deactivation-Reactivation resize, not just the initial connection, since `accept_finalize` loops back into `client_accepted` with `result.reactivation` set. Gated the call on `!result.reactivation`, matching the existing gate on the static-channel start block just below it.
- `get_result()` took `ime_file_name` via `mem::take`, emptying it out of the acceptor before `new_deactivation_reactivation` copied the same acceptor's field into the next result, so every reactivation after the first reported an empty IME name. Changed to a clone, matching how the Copy-type sibling fields on the same lines already survive.
- No regression test covered the permissive zero/unrecognized-value keyboardType decode in the Input capability set. Added `keyboard_type_zero_decodes_to_none` and `keyboard_type_unrecognized_value_round_trips` (0x51).
- A fourth finding asked for the same coverage on Client Core Data's own keyboardType field; that test already exists on master, added to #1689 in response to its own review. The rebase above inherits it directly, so no new code was needed there.
