### PR TITLE
chore: align USB crate boundaries

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -76,7 +76,13 @@ _TODO_: clean up the dependencies
 
 #### [`crates/ironrdp-usb`](./crates/ironrdp-usb)
 
-Protocol-independent, sans-I/O USB data structures, descriptor parsing, validation, and transfer semantics.
+Protocol-independent USB data structures, descriptor parsing, validation, and transfer semantics.
+
+**Architectural Invariant**: descriptor views borrow caller data, and transfer types are generic over caller-owned buffer and packet storage.
+The crate does not allocate.
+
+**Architectural Invariant**: parsing is limited to byte layouts defined by USB itself.
+RDPEUSB, usbredir, and other transport framing belong in their corresponding protocol crates.
 
 #### [`crates/ironrdp-graphics`](./crates/ironrdp-graphics)
 
@@ -117,7 +123,7 @@ RDPEUSB dynamic channel implementation for USB redirection as described in MS-RD
 **Architectural Invariant**: the `usb` module translates protocol-independent `ironrdp-usb` operations and descriptor semantics into complete backend-facing `TS_URB` requests, and maps USBD completions back.
 Selecting `TS_URB` forms and applying Windows USBD conventions remain in this crate.
 
-**Architectural Invariant**: the `usb` module is sans-I/O and does not allocate request IDs, track device state, or manage pending-request lifetimes.
+**Architectural Invariant**: the `usb` module does not allocate request IDs, track device state, or manage pending-request lifetimes.
 Those responsibilities belong to the layer above the channel implementation.
 
 #### [`crates/ironrdp-rdpewa`](./crates/ironrdp-rdpewa)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -74,6 +74,10 @@ PDU encoding and decoding.
 
 _TODO_: clean up the dependencies
 
+#### [`crates/ironrdp-usb`](./crates/ironrdp-usb)
+
+Protocol-independent, sans-I/O USB data structures, descriptor parsing, validation, and transfer semantics.
+
 #### [`crates/ironrdp-graphics`](./crates/ironrdp-graphics)
 
 Image processing primitives.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -110,6 +110,16 @@ RDPSND static channel for audio output implemented as described in MS-RDPEA.
 
 AUDIO_INPUT dynamic channel for client microphone capture implemented as described in MS-RDPEAI.
 
+#### [`crates/ironrdp-rdpeusb`](./crates/ironrdp-rdpeusb)
+
+RDPEUSB dynamic channel implementation for USB redirection as described in MS-RDPEUSB.
+
+**Architectural Invariant**: the `usb` module translates protocol-independent `ironrdp-usb` operations and descriptor semantics into complete backend-facing `TS_URB` requests, and maps USBD completions back.
+Selecting `TS_URB` forms and applying Windows USBD conventions remain in this crate.
+
+**Architectural Invariant**: the `usb` module is sans-I/O and does not allocate request IDs, track device state, or manage pending-request lifetimes.
+Those responsibilities belong to the layer above the channel implementation.
+
 #### [`crates/ironrdp-rdpewa`](./crates/ironrdp-rdpewa)
 
 RDPEWA dynamic virtual channel for WebAuthn redirection as described in MS-RDPEWA.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -78,8 +78,8 @@ _TODO_: clean up the dependencies
 
 Protocol-independent USB data structures, descriptor parsing, validation, and transfer semantics.
 
-**Architectural Invariant**: descriptor views borrow caller data, and transfer types are generic over caller-owned buffer and packet storage.
-The crate does not allocate.
+**Architectural Invariant**: the crate does not allocate.
+Descriptor views borrow caller data, and transfer types are generic over caller-owned buffer and packet storage.
 
 **Architectural Invariant**: parsing is limited to byte layouts defined by USB itself.
 RDPEUSB, usbredir, and other transport framing belong in their corresponding protocol crates.
@@ -252,6 +252,7 @@ fields, lock IDs, stream IDs, or protocol-specific flags, it belongs in the back
 be delivered via the extension mechanism.
 
 The extension system works as follows:
+
 - `Extension` is typed as `unknown`; intentionally opaque at this layer.
 - Backends define their own concrete `Extension` types and factory functions.
 - The consumer calls `userInteraction.configBuilder().withExtension(ext)` or

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -252,7 +252,6 @@ fields, lock IDs, stream IDs, or protocol-specific flags, it belongs in the back
 be delivered via the extension mechanism.
 
 The extension system works as follows:
-
 - `Extension` is typed as `unknown`; intentionally opaque at this layer.
 - Backends define their own concrete `Extension` types and factory functions.
 - The consumer calls `userInteraction.configBuilder().withExtension(ext)` or

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -120,7 +120,8 @@ AUDIO_INPUT dynamic channel for client microphone capture implemented as describ
 
 RDPEUSB dynamic channel implementation for USB redirection as described in MS-RDPEUSB.
 
-**Architectural Invariant**: the `usb` module translates protocol-independent `ironrdp-usb` operations and descriptor semantics into complete backend-facing `TS_URB` requests, and maps USBD completions back.
+**Architectural Invariant**: the `usb` module translates protocol-independent `ironrdp-usb` operations and descriptor semantics into complete backend-facing RDPEUSB packets.
+The generated packet keeps its `TS_URB` payload, URB function code, transfer envelope, flags, and buffer shape consistent, and maps USBD completions back.
 Selecting `TS_URB` forms and applying Windows USBD conventions remain in this crate.
 
 **Architectural Invariant**: the `usb` module does not allocate request IDs, track device state, or manage pending-request lifetimes.

--- a/crates/ironrdp-usb/Cargo.toml
+++ b/crates/ironrdp-usb/Cargo.toml
@@ -11,6 +11,11 @@ repository.workspace = true
 authors.workspace = true
 keywords.workspace = true
 categories.workspace = true
+publish = false
+
+[lib]
+doctest = false
+test = false
 
 [lints]
 workspace = true


### PR DESCRIPTION
Follow up to #1682.

Set publish = false for ironrdp-usb, until we are ready to publish it.

Document `ironrdp-usb`'s allocation-free caller-owned storage and USB-format-only parsing boundary, plus the RDPEUSB adapter's complete, internally consistent TS_URB/USBD request translation and intentionally excluded request and device lifecycle ownership.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>