### PR TITLE
fix(graphics): decode Progressive SRL refinements

### DIFF
--- a/crates/ironrdp-graphics/src/progressive.rs
+++ b/crates/ironrdp-graphics/src/progressive.rs
@@ -165,16 +165,17 @@ pub fn decode_upgrade_pass(
     assert!(sign.len() >= COEFFICIENTS_PER_COMPONENT);
 
     let bands = get_band_layout(use_reduce_extrapolate);
-    let has_srl_values = bands.iter().enumerate().any(|(band_idx, band)| {
+    let zero_counts: [usize; NUM_BANDS] = core::array::from_fn(|band_idx| band_zero_count(sign, &bands[band_idx]));
+    let has_srl_values = bands.iter().enumerate().any(|(band_idx, _)| {
         let num_bits = prev_prog_quant
             .for_band(band_idx)
             .saturating_sub(curr_prog_quant.for_band(band_idx));
-        band_idx != NUM_BANDS - 1 && num_bits != 0 && band_zero_count(sign, band) != 0
+        band_idx != NUM_BANDS - 1 && num_bits != 0 && zero_counts[band_idx] != 0
     });
     let mut srl_decoder = has_srl_values.then(|| srl::SrlDecoder::new(srl_data)).transpose()?;
     let mut srl_values = Vec::with_capacity(NUM_BANDS);
 
-    for (band_idx, band) in bands.iter().enumerate() {
+    for (band_idx, _) in bands.iter().enumerate() {
         let prev_bit_pos = prev_prog_quant.for_band(band_idx);
         let curr_bit_pos = curr_prog_quant.for_band(band_idx);
 
@@ -191,7 +192,7 @@ pub fn decode_upgrade_pass(
             continue;
         }
 
-        let zero_count = band_zero_count(sign, band);
+        let zero_count = zero_counts[band_idx];
         let values = match srl_decoder.as_mut() {
             Some(decoder) => decoder.decode(zero_count, num_bits)?,
             None => Vec::new(),
@@ -881,6 +882,7 @@ impl TileState {
     /// Decode an upgrade-pass tile (TILE_UPGRADE).
     ///
     /// Accumulates refinement data into existing coefficients.
+    /// On error, leaves the tile at its prior upgrade state.
     ///
     /// # Arguments
     /// - `srl_data`: SRL-encoded streams for [Y, Cb, Cr]
@@ -895,6 +897,8 @@ impl TileState {
         quality: u8,
     ) -> Result<(), SrlError> {
         let prev_prog_quant = self.prog_quant;
+        let mut coefficients = self.coefficients;
+        let mut sign = self.sign;
 
         for c in 0..3 {
             decode_upgrade_pass(
@@ -903,11 +907,13 @@ impl TileState {
                 &prev_prog_quant[c],
                 &prog_quants[c],
                 self.use_reduce_extrapolate,
-                &mut self.coefficients[c],
-                &mut self.sign[c],
+                &mut coefficients[c],
+                &mut sign[c],
             )?;
         }
 
+        self.coefficients = coefficients;
+        self.sign = sign;
         self.prog_quant = prog_quants;
         self.quality = quality;
         self.pass = self.pass.saturating_add(1);
@@ -1778,6 +1784,37 @@ mod tests {
             ),
             Err(SrlError::Truncated)
         );
+    }
+
+    #[test]
+    fn tile_upgrade_keeps_all_components_on_srl_error() {
+        let mut tile = TileState::new();
+        let mut prev_prog_quant = ComponentCodecQuant::LOSSLESS;
+        prev_prog_quant.hl1 = 4;
+        tile.prog_quant = [prev_prog_quant; 3];
+        tile.pass = 1;
+        tile.quality = 50;
+        tile.sign[0][0] = SIGN_ZERO;
+        tile.sign[1][0] = SIGN_ZERO;
+
+        let coefficients = tile.coefficients;
+        let sign = tile.sign;
+
+        assert_eq!(
+            tile.decode_upgrade(
+                [&[0x90, 0x00], &[0x80, 0x00], &[]],
+                [&[], &[], &[]],
+                [ComponentCodecQuant::LOSSLESS; 3],
+                75,
+            ),
+            Err(SrlError::Truncated)
+        );
+
+        assert_eq!(tile.coefficients, coefficients);
+        assert_eq!(tile.sign, sign);
+        assert_eq!(tile.prog_quant, [prev_prog_quant; 3]);
+        assert_eq!(tile.pass, 1);
+        assert_eq!(tile.quality, 50);
     }
 
     #[test]

--- a/crates/ironrdp-graphics/src/progressive.rs
+++ b/crates/ironrdp-graphics/src/progressive.rs
@@ -42,7 +42,7 @@ use ironrdp_pdu::codecs::rfx::progressive::ComponentCodecQuant;
 
 use crate::dwt_extrapolate::BandInfo;
 use crate::rlgr::RlgrError;
-use crate::srl;
+use crate::srl::{self, SrlError};
 
 /// Number of DWT coefficients per component in a 64x64 tile.
 pub const COEFFICIENTS_PER_COMPONENT: usize = 4096;
@@ -147,6 +147,11 @@ fn decode_first_pass_to_dwtq(
 /// # Panics
 ///
 /// Panics if `coefficients` or `sign` has fewer than 4096 elements.
+///
+/// # Errors
+///
+/// Returns [`SrlError`] for a malformed or truncated SRL stream.
+/// See MS-RDPEGFX section 3.3.8.2.1.2.
 pub fn decode_upgrade_pass(
     srl_data: &[u8],
     raw_data: &[u8],
@@ -155,11 +160,19 @@ pub fn decode_upgrade_pass(
     use_reduce_extrapolate: bool,
     coefficients: &mut [i16],
     sign: &mut [i8],
-) {
+) -> Result<(), SrlError> {
     assert!(coefficients.len() >= COEFFICIENTS_PER_COMPONENT);
     assert!(sign.len() >= COEFFICIENTS_PER_COMPONENT);
 
     let bands = get_band_layout(use_reduce_extrapolate);
+    let has_srl_values = bands.iter().enumerate().any(|(band_idx, band)| {
+        let num_bits = prev_prog_quant
+            .for_band(band_idx)
+            .saturating_sub(curr_prog_quant.for_band(band_idx));
+        band_idx != NUM_BANDS - 1 && num_bits != 0 && band_zero_count(sign, band) != 0
+    });
+    let mut srl_decoder = has_srl_values.then(|| srl::SrlDecoder::new(srl_data)).transpose()?;
+    let mut srl_values = Vec::with_capacity(NUM_BANDS);
 
     for (band_idx, band) in bands.iter().enumerate() {
         let prev_bit_pos = prev_prog_quant.for_band(band_idx);
@@ -168,36 +181,48 @@ pub fn decode_upgrade_pass(
         // Number of raw bits per coefficient in this band
         let num_bits = prev_bit_pos.saturating_sub(curr_bit_pos);
         if num_bits == 0 {
+            srl_values.push(Vec::new());
             continue;
         }
 
-        // Count zero-DAS positions in this band (for SRL decode)
+        if band_idx == NUM_BANDS - 1 {
+            // LL3 entries are always decoded from the raw stream.
+            srl_values.push(Vec::new());
+            continue;
+        }
+
         let zero_count = band_zero_count(sign, band);
+        let values = match srl_decoder.as_mut() {
+            Some(decoder) => decoder.decode(zero_count, num_bits)?,
+            None => Vec::new(),
+        };
+        srl_values.push(values);
+    }
 
-        // SRL decode for zero-DAS positions
-        let srl_values = srl::decode_srl(srl_data, zero_count, num_bits);
+    let mut raw_reader = RawBitReader::new(raw_data);
+    for (band_idx, band) in bands.iter().enumerate() {
+        let prev_bit_pos = prev_prog_quant.for_band(band_idx);
+        let curr_bit_pos = curr_prog_quant.for_band(band_idx);
+        let num_bits = prev_bit_pos.saturating_sub(curr_bit_pos);
+        if num_bits == 0 {
+            continue;
+        }
 
-        // Apply upgrade values to this band
+        let is_ll3 = band_idx == NUM_BANDS - 1;
         let mut srl_idx = 0;
-        let mut raw_reader = RawBitReader::new(raw_data);
 
         for i in 0..band.count() {
             let coeff_idx = band.offset + i;
-            let is_ll3 = band_idx == 9;
 
-            if sign[coeff_idx] == SIGN_ZERO {
+            if !is_ll3 && sign[coeff_idx] == SIGN_ZERO {
                 // Zero-DAS: get value from SRL stream
-                let value = if srl_idx < srl_values.len() {
-                    srl_values[srl_idx]
-                } else {
-                    0
-                };
+                let value = srl_values[band_idx][srl_idx];
                 srl_idx += 1;
 
                 if value != 0 {
                     // Coefficient transitions from zero to non-zero
                     let shifted = i32::from(value) << i32::from(curr_bit_pos);
-                    coefficients[coeff_idx] = clamp_i16(shifted);
+                    coefficients[coeff_idx] = clamp_i16(i32::from(coefficients[coeff_idx]) + shifted);
                     sign[coeff_idx] = if value > 0 { SIGN_POSITIVE } else { SIGN_NEGATIVE };
                 }
             } else {
@@ -219,6 +244,8 @@ pub fn decode_upgrade_pass(
             }
         }
     }
+
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -398,7 +425,7 @@ fn quantize_component_ccq(coefficients: &mut [i16], quant: &ComponentCodecQuant,
 /// # Returns
 /// A tuple of `(srl_data, raw_data)` byte vectors.
 ///
-/// # Wire-format invariants (MS-RDPRFX 3.1.8.1.7.2)
+/// # Wire-format invariants (MS-RDPEGFX 3.2.8.1.5.2)
 ///
 /// The non-zero-DAS raw-magnitude path uses `saturating_sub` to compute
 /// `raw_mag = curr_q - prev_q`. Upgrade passes are *monotonic refinements*:
@@ -420,9 +447,10 @@ pub fn encode_upgrade_pass(
     curr_prog_quant: &ComponentCodecQuant,
     sign: &[i8],
     use_reduce_extrapolate: bool,
-) -> (Vec<u8>, Vec<u8>) {
+) -> Result<(Vec<u8>, Vec<u8>), SrlError> {
     let bands = get_band_layout(use_reduce_extrapolate);
-    let mut all_srl_values = Vec::new();
+    let mut srl_encoder = srl::SrlEncoder::new();
+    let mut has_srl_values = false;
     let mut raw_writer = RawBitWriter::new();
 
     for (band_idx, band) in bands.iter().enumerate() {
@@ -438,8 +466,9 @@ pub fn encode_upgrade_pass(
 
         for i in 0..band.count() {
             let coeff_idx = band.offset + i;
+            let is_ll3 = band_idx == NUM_BANDS - 1;
 
-            if sign[coeff_idx] == SIGN_ZERO {
+            if !is_ll3 && sign[coeff_idx] == SIGN_ZERO {
                 // Zero-DAS: compute the refined value and encode via SRL
                 let curr_shifted = i32::from(coefficients[coeff_idx]) >> i32::from(curr_bit_pos);
                 let prev_shifted = i32::from(prev_coefficients[coeff_idx]) >> i32::from(curr_bit_pos);
@@ -458,13 +487,19 @@ pub fn encode_upgrade_pass(
             }
         }
 
-        // Encode SRL values for this band
-        let srl_encoded = srl::encode_srl(&band_srl_values, num_bits);
-        all_srl_values.extend_from_slice(&srl_encoded);
+        if !band_srl_values.is_empty() {
+            srl_encoder.encode(&band_srl_values, num_bits)?;
+            has_srl_values = true;
+        }
     }
 
     let raw_data = raw_writer.finish();
-    (all_srl_values, raw_data)
+    let srl_data = if has_srl_values {
+        srl_encoder.finish()?
+    } else {
+        Vec::new()
+    };
+    Ok((srl_data, raw_data))
 }
 
 /// Encode RGBA pixels to spatial-domain i16 coefficients (RGB to YCbCr).
@@ -858,7 +893,7 @@ impl TileState {
         raw_data: [&[u8]; 3],
         prog_quants: [ComponentCodecQuant; 3],
         quality: u8,
-    ) {
+    ) -> Result<(), SrlError> {
         let prev_prog_quant = self.prog_quant;
 
         for c in 0..3 {
@@ -870,12 +905,14 @@ impl TileState {
                 self.use_reduce_extrapolate,
                 &mut self.coefficients[c],
                 &mut self.sign[c],
-            );
+            )?;
         }
 
         self.prog_quant = prog_quants;
         self.quality = quality;
         self.pass = self.pass.saturating_add(1);
+
+        Ok(())
     }
 
     /// Reconstruct the tile to spatial domain and write RGBA pixels.
@@ -1057,6 +1094,8 @@ pub enum ProgressiveDecodeError {
     Pdu(ironrdp_core::DecodeError),
     /// RLGR decode failed within a tile.
     Rlgr(RlgrError),
+    /// SRL decode failed within an upgrade tile.
+    Srl(SrlError),
     /// The progressive stream is missing a required block.
     MissingBlock(&'static str),
     /// Tile coordinates are out of bounds for the surface.
@@ -1072,6 +1111,7 @@ impl core::fmt::Display for ProgressiveDecodeError {
         match self {
             Self::Pdu(e) => write!(f, "progressive PDU decode: {e}"),
             Self::Rlgr(e) => write!(f, "progressive RLGR decode: {e}"),
+            Self::Srl(e) => write!(f, "progressive srl decode: {e}"),
             Self::MissingBlock(name) => write!(f, "progressive stream missing {name} block"),
             Self::TileOutOfBounds { x_idx, y_idx } => {
                 write!(f, "tile ({x_idx}, {y_idx}) out of surface bounds")
@@ -1099,6 +1139,12 @@ impl From<ironrdp_core::DecodeError> for ProgressiveDecodeError {
 impl From<RlgrError> for ProgressiveDecodeError {
     fn from(e: RlgrError) -> Self {
         Self::Rlgr(e)
+    }
+}
+
+impl From<SrlError> for ProgressiveDecodeError {
+    fn from(e: SrlError) -> Self {
+        Self::Srl(e)
     }
 }
 
@@ -1382,7 +1428,7 @@ fn decode_tile_block(
                 [tile.y_raw_data, tile.cb_raw_data, tile.cr_raw_data],
                 [pq.y_quant, pq.cb_quant, pq.cr_quant],
                 tile.quality,
-            );
+            )?;
 
             let mut pixels = vec![0u8; 64 * 64 * 4];
             tile_state.reconstruct_to_rgba(&mut pixels);
@@ -1629,7 +1675,8 @@ mod tests {
     #[test]
     fn upgrade_pass_zero_das_becomes_nonzero() {
         let mut coefficients = vec![0i16; 4096];
-        let mut sign = vec![SIGN_ZERO; 4096];
+        let mut sign = vec![SIGN_POSITIVE; 4096];
+        sign[0] = SIGN_ZERO;
 
         // Set up SRL data that produces a non-zero value for the first position
         // For band 0 (HL1), with num_bits=2, SRL should produce some values
@@ -1658,10 +1705,9 @@ mod tests {
             hh1: 0,
         };
 
-        // Simple SRL data: a non-zero value (the SRL decoder will interpret
-        // bits as magnitude + sign). With num_bits=2, k=0 initially,
-        // it goes straight to magnitude decode.
-        let srl_data = vec![0b01000000, 0x00]; // sign=0(+), magnitude bits follow
+        // Zero run 0 (10), positive sign (0), magnitude 1 (1), then the
+        // required trailing zero byte.
+        let srl_data = vec![0b1001_0000, 0x00];
         let raw_data = vec![];
 
         decode_upgrade_pass(
@@ -1672,10 +1718,66 @@ mod tests {
             false,
             &mut coefficients,
             &mut sign,
-        );
+        )
+        .unwrap();
 
-        // After decode, at least some positions should have been updated
-        // (exact values depend on SRL interpretation, but the function shouldn't panic)
+        assert_eq!(coefficients[0], 4);
+        assert_eq!(sign[0], SIGN_POSITIVE);
+    }
+
+    #[test]
+    fn upgrade_pass_preserves_component_streams_across_bands() {
+        // MS-RDPEGFX 4.1.2.1.2 treats SRL entries in different bands as
+        // consecutive. A component also has one raw bit stream for the upgrade.
+        let mut coefficients = [0i16; COEFFICIENTS_PER_COMPONENT];
+        let mut sign = [SIGN_POSITIVE; COEFFICIENTS_PER_COMPONENT];
+        sign[0] = SIGN_ZERO;
+        sign[1024] = SIGN_ZERO;
+
+        let mut prev_prog_quant = ComponentCodecQuant::LOSSLESS;
+        prev_prog_quant.hl1 = 1;
+        prev_prog_quant.lh1 = 1;
+
+        // The bits encode +1 in HL1 followed by -1 in LH1. The raw stream
+        // provides one bit for HL1 and then runs out before LH1.
+        decode_upgrade_pass(
+            &[0b1001_1000, 0x00],
+            &[0b1000_0000],
+            &prev_prog_quant,
+            &ComponentCodecQuant::LOSSLESS,
+            false,
+            &mut coefficients,
+            &mut sign,
+        )
+        .unwrap();
+
+        assert_eq!(coefficients[0], 1);
+        assert_eq!(coefficients[1024], -1);
+        assert_eq!(coefficients[1], 1);
+        assert_eq!(coefficients[1025], 0);
+    }
+
+    #[test]
+    fn upgrade_pass_rejects_truncated_srl() {
+        let mut coefficients = [0i16; COEFFICIENTS_PER_COMPONENT];
+        let mut sign = [SIGN_POSITIVE; COEFFICIENTS_PER_COMPONENT];
+        sign[0] = SIGN_ZERO;
+
+        let mut prev_prog_quant = ComponentCodecQuant::LOSSLESS;
+        prev_prog_quant.hl1 = 4;
+
+        assert_eq!(
+            decode_upgrade_pass(
+                &[0x80, 0x00],
+                &[],
+                &prev_prog_quant,
+                &ComponentCodecQuant::LOSSLESS,
+                false,
+                &mut coefficients,
+                &mut sign,
+            ),
+            Err(SrlError::Truncated)
+        );
     }
 
     #[test]
@@ -2249,7 +2351,8 @@ mod tests {
             &prog_quant,
             &sign,
             false,
-        );
+        )
+        .unwrap();
 
         assert!(srl_data.is_empty(), "no refinement bits, SRL should be empty");
         assert!(raw_data.is_empty(), "no refinement bits, raw should be empty");
@@ -2520,7 +2623,8 @@ mod tests {
             &curr_prog_quant,
             &sign,
             false,
-        );
+        )
+        .unwrap();
 
         let mut decoded = prev_coeffs.clone();
         let mut decoded_sign = sign.clone();
@@ -2532,7 +2636,8 @@ mod tests {
             false,
             &mut decoded,
             &mut decoded_sign,
-        );
+        )
+        .unwrap();
 
         let post_dist: u32 = decoded
             .iter()

--- a/crates/ironrdp-graphics/src/srl.rs
+++ b/crates/ironrdp-graphics/src/srl.rs
@@ -1,210 +1,269 @@
-//! SRL (Simplified Run-Length) entropy codec for progressive upgrade passes.
+//! Simplified Run-Length (SRL) entropy coding for progressive upgrade passes.
 //!
-//! Used during progressive TILE_UPGRADE decoding where the tri-state sign
-//! array (DAS) indicates zero-valued coefficients. SRL encodes/decodes
-//! magnitudes for coefficients that were previously zero.
-//!
-//! The algorithm is similar to RLGR's zero-run mode with a simpler structure:
-//! adaptive K parameter controlling zero-run lengths, followed by unary-coded
-//! magnitudes with sign bits.
+//! SRL is a stateful bit stream for each component of a TILE_UPGRADE.
+//! Its zero runs and adaptive `KP` state continue across DWT bands.
+//! See MS-RDPEGFX sections 3.1.8.1.5 through 3.1.8.1.5.2.
 
-/// Decode SRL data for a set of zero-valued (DAS=0) coefficient positions.
-///
-/// `data` is the SRL byte stream (terminated by a 0x00 sentinel).
-/// `num_values` is the number of coefficients to decode.
-/// `num_bits` is the bit width for each magnitude value.
-///
-/// Returns a vector of decoded signed coefficient values. Zero entries
-/// mean the coefficient remains zero after this upgrade pass.
-pub fn decode_srl(data: &[u8], num_values: usize, num_bits: u8) -> Vec<i16> {
-    if num_values == 0 || data.is_empty() {
-        return vec![0; num_values];
-    }
+const INITIAL_KP: u8 = 8;
+const MAX_KP: u8 = 80;
+const MAX_ZERO_RUN: usize = 4096;
 
-    let mut output = vec![0i16; num_values];
-    let mut reader = BitReader::new(data);
-    let mut kp: u32 = 0;
-    let mut out_idx = 0;
-    let mut nz: u32 = 0; // remaining zeros in current run
-
-    while out_idx < num_values {
-        let k = kp >> 3;
-
-        if nz > 0 {
-            // Still emitting zeros from a previous run
-            nz -= 1;
-            output[out_idx] = 0;
-            out_idx += 1;
-            continue;
-        }
-
-        // Zero-run mode: chunk_size = 1 << k (1 when k=0).
-        // read_bits(0) returns 0, so k=0 degenerates to single-zero runs.
-        {
-            let bit = reader.read_bit();
-            if !bit {
-                nz = 1u32.checked_shl(k).unwrap_or(0);
-                kp = kp.saturating_add(4).min(80);
-                nz -= 1;
-                output[out_idx] = 0;
-                out_idx += 1;
-                continue;
-            }
-            let zeros = reader.read_bits(k);
-            if zeros > 0 {
-                nz = zeros;
-                nz -= 1;
-                output[out_idx] = 0;
-                out_idx += 1;
-                continue;
-            }
-            // Fall through to unary mode (no more zeros)
-        }
-
-        // Unary mode: decode a non-zero magnitude
-        kp = kp.saturating_sub(6);
-
-        if num_bits == 0 {
-            // No bits to decode, just emit +/-1 from sign bit
-            let sign = reader.read_bit();
-            output[out_idx] = if sign { -1 } else { 1 };
-            out_idx += 1;
-            continue;
-        }
-
-        // Read sign bit
-        let sign = reader.read_bit();
-
-        if num_bits == 1 {
-            output[out_idx] = if sign { -1 } else { 1 };
-            out_idx += 1;
-            continue;
-        }
-
-        // Decode unary quotient: count 0-bits before the terminating 1-bit.
-        // magnitude = (quotient << extra_bits) | remainder.
-        let mut quotient: u32 = 0;
-        loop {
-            let bit = reader.read_bit();
-            if bit || quotient >= 0x8000 {
-                break;
-            }
-            quotient += 1;
-        }
-
-        let extra_bits = u32::from(num_bits).saturating_sub(1);
-        let magnitude = if extra_bits > 0 && extra_bits < 16 {
-            let remainder = reader.read_bits(extra_bits);
-            (quotient << extra_bits) | remainder
-        } else {
-            quotient
-        };
-
-        let value = i16::try_from(magnitude.min(0x7FFF)).unwrap_or(i16::MAX);
-        output[out_idx] = if sign { -value } else { value };
-        out_idx += 1;
-    }
-
-    output
+/// Errors encountered while decoding or encoding an SRL stream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SrlError {
+    /// The required trailing zero byte is absent.
+    MissingTerminator,
+    /// The stream ended before a complete code word was read.
+    Truncated,
+    /// An SRL value requires between one and fifteen magnitude bits.
+    InvalidBitCount(u8),
+    /// A value cannot be represented by the magnitude width.
+    MagnitudeOutOfRange { magnitude: u16, max: u16 },
+    /// A zero run exceeds the number of coefficients in one component.
+    ZeroRunTooLong,
 }
 
-/// Encode coefficient magnitudes using the SRL algorithm.
+impl core::fmt::Display for SrlError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::MissingTerminator => write!(f, "srl stream is missing its trailing zero byte"),
+            Self::Truncated => write!(f, "srl stream is truncated"),
+            Self::InvalidBitCount(bits) => write!(f, "invalid srl magnitude bit count {bits}"),
+            Self::MagnitudeOutOfRange { magnitude, max } => {
+                write!(f, "srl magnitude {magnitude} exceeds maximum {max}")
+            }
+            Self::ZeroRunTooLong => write!(f, "srl zero run exceeds the component coefficient count"),
+        }
+    }
+}
+
+impl core::error::Error for SrlError {}
+
+/// Stateful decoder for one component's SRL stream.
 ///
-/// `values` contains signed coefficient values (non-zero = needs encoding,
-/// zero = contributes to zero runs).
-/// `num_bits` is the bit width for magnitude encoding.
-///
-/// Returns the encoded SRL byte stream (with trailing 0x00 sentinel).
-pub fn encode_srl(values: &[i16], num_bits: u8) -> Vec<u8> {
-    if values.is_empty() {
-        return vec![0x00];
+/// Construct one decoder for each of the Y, Cb, and Cr streams in a
+/// TILE_UPGRADE, then call [`Self::decode`] for each band that has SRL entries.
+pub struct SrlDecoder<'a> {
+    reader: BitReader<'a>,
+    kp: u8,
+    zero_run_remaining: usize,
+    nonzero_pending: bool,
+}
+
+impl<'a> SrlDecoder<'a> {
+    /// Create a decoder for an SRL stream, excluding its required trailing zero byte.
+    pub fn new(data: &'a [u8]) -> Result<Self, SrlError> {
+        let Some((&terminator, payload)) = data.split_last() else {
+            return Err(SrlError::MissingTerminator);
+        };
+
+        if terminator != 0 {
+            return Err(SrlError::MissingTerminator);
+        }
+
+        Ok(Self {
+            reader: BitReader::new(payload),
+            kp: INITIAL_KP,
+            zero_run_remaining: 0,
+            nonzero_pending: false,
+        })
     }
 
-    let mut writer = BitWriter::new();
-    let mut kp: u32 = 0;
-    let mut idx = 0;
+    /// Decode `num_values` entries for one DWT band.
+    ///
+    /// The adaptive state and a partially consumed zero run are retained for the
+    /// next call, as required when SRL entries span bands.
+    pub fn decode(&mut self, num_values: usize, num_bits: u8) -> Result<Vec<i16>, SrlError> {
+        let mut output = Vec::with_capacity(num_values);
 
-    while idx < values.len() {
-        // Count leading zeros (may be 0)
-        let mut zero_count: u32 = 0;
-        while idx + usize::try_from(zero_count).unwrap_or(usize::MAX) < values.len()
-            && values[idx + usize::try_from(zero_count).unwrap_or(usize::MAX)] == 0
-        {
+        while output.len() < num_values {
+            if self.zero_run_remaining != 0 {
+                self.zero_run_remaining -= 1;
+                output.push(0);
+                continue;
+            }
+
+            if self.nonzero_pending {
+                output.push(self.decode_nonzero(num_bits)?);
+                self.nonzero_pending = false;
+                continue;
+            }
+
+            self.zero_run_remaining = self.decode_zero_run()?;
+            self.nonzero_pending = true;
+        }
+
+        Ok(output)
+    }
+
+    fn decode_zero_run(&mut self) -> Result<usize, SrlError> {
+        let mut zeros = 0usize;
+
+        loop {
+            let k = self.kp / 8;
+
+            if self.reader.read_bit()? {
+                let tail = usize::try_from(self.reader.read_bits(k)?).map_err(|_| SrlError::ZeroRunTooLong)?;
+                self.kp = self.kp.saturating_sub(6);
+
+                let zeros = zeros.checked_add(tail).ok_or(SrlError::ZeroRunTooLong)?;
+                return (zeros <= MAX_ZERO_RUN).then_some(zeros).ok_or(SrlError::ZeroRunTooLong);
+            }
+
+            let chunk = 1usize << k;
+            zeros = zeros.checked_add(chunk).ok_or(SrlError::ZeroRunTooLong)?;
+            if zeros > MAX_ZERO_RUN {
+                return Err(SrlError::ZeroRunTooLong);
+            }
+
+            self.kp = self.kp.saturating_add(4).min(MAX_KP);
+        }
+    }
+
+    fn decode_nonzero(&mut self, num_bits: u8) -> Result<i16, SrlError> {
+        let maximum = max_magnitude(num_bits)?;
+        let sign = self.reader.read_bit()?;
+        let mut zero_count = 0u16;
+
+        while zero_count + 1 < maximum {
+            if self.reader.read_bit()? {
+                break;
+            }
+
             zero_count += 1;
         }
 
-        // Encode zero run one chunk at a time, recomputing k after
-        // each kp update to stay in sync with the decoder.
-        while zero_count > 0 {
-            let cur_k = kp >> 3;
-            let chunk_size = 1u32.checked_shl(cur_k).unwrap_or(u32::MAX);
-            if zero_count >= chunk_size {
-                writer.write_bit(false);
-                kp = kp.saturating_add(4).min(80);
-                zero_count -= chunk_size;
-                idx += usize::try_from(chunk_size).unwrap_or(usize::MAX);
-            } else {
-                // Remaining zeros < chunk: escape bit + count
-                writer.write_bit(true);
-                writer.write_bits(zero_count, cur_k);
-                idx += usize::try_from(zero_count).unwrap_or(usize::MAX);
-                zero_count = 0;
-                continue;
-            }
-        }
-        // No remaining zeros: write escape with zero count
-        let cur_k = kp >> 3;
-        writer.write_bit(true);
-        writer.write_bits(0, cur_k);
+        let magnitude = zero_count + 1;
+        let magnitude = i16::try_from(magnitude).map_err(|_| SrlError::MagnitudeOutOfRange {
+            magnitude,
+            max: maximum,
+        })?;
 
-        if idx >= values.len() {
-            break;
-        }
-
-        // Encode non-zero value
-        kp = kp.saturating_sub(6);
-        let value = values[idx];
-        let sign = value < 0;
-        let magnitude = u32::from(value.unsigned_abs());
-
-        writer.write_bit(sign);
-
-        if num_bits <= 1 {
-            idx += 1;
-            continue;
-        }
-
-        // Unary encode: quotient zeros + terminator + remainder bits.
-        // magnitude = (quotient << extra_bits) | remainder.
-        let extra_bits = u32::from(num_bits).saturating_sub(1);
-        if extra_bits > 0 && extra_bits < 16 {
-            let quotient = magnitude >> extra_bits;
-            let remainder = magnitude & ((1u32 << extra_bits) - 1);
-
-            for _ in 0..quotient {
-                writer.write_bit(false);
-            }
-            writer.write_bit(true);
-            writer.write_bits(remainder, extra_bits);
-        }
-
-        idx += 1;
+        Ok(if sign { -magnitude } else { magnitude })
     }
-
-    // Trailing sentinel
-    let mut result = writer.finish();
-    result.push(0x00);
-    result
 }
 
-// ---------------------------------------------------------------------------
-// Bit-level I/O helpers
-// ---------------------------------------------------------------------------
+/// Stateful encoder for one component's SRL stream.
+pub struct SrlEncoder {
+    writer: BitWriter,
+    kp: u8,
+    pending_zeros: usize,
+}
+
+impl SrlEncoder {
+    /// Create an encoder for a component's SRL stream.
+    pub fn new() -> Self {
+        Self {
+            writer: BitWriter::new(),
+            kp: INITIAL_KP,
+            pending_zeros: 0,
+        }
+    }
+
+    /// Encode SRL entries for one DWT band.
+    ///
+    /// The caller must use one encoder across all bands in a component.
+    pub fn encode(&mut self, values: &[i16], num_bits: u8) -> Result<(), SrlError> {
+        let maximum = max_magnitude(num_bits)?;
+        for &value in values {
+            if value == 0 {
+                let zeros = self.pending_zeros.checked_add(1).ok_or(SrlError::ZeroRunTooLong)?;
+                self.pending_zeros = (zeros <= MAX_ZERO_RUN)
+                    .then_some(zeros)
+                    .ok_or(SrlError::ZeroRunTooLong)?;
+                continue;
+            }
+
+            self.encode_zero_run(self.pending_zeros)?;
+            self.pending_zeros = 0;
+
+            let magnitude = value.unsigned_abs();
+            if magnitude == 0 || magnitude > maximum {
+                return Err(SrlError::MagnitudeOutOfRange {
+                    magnitude,
+                    max: maximum,
+                });
+            }
+
+            self.writer.write_bit(value < 0);
+            for _ in 1..magnitude {
+                self.writer.write_bit(false);
+            }
+            if magnitude < maximum {
+                self.writer.write_bit(true);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Finish the stream, adding the required trailing zero byte.
+    pub fn finish(mut self) -> Result<Vec<u8>, SrlError> {
+        if self.pending_zeros != 0 {
+            self.encode_zero_run(self.pending_zeros)?;
+        }
+
+        let mut result = self.writer.finish();
+        result.push(0);
+        Ok(result)
+    }
+
+    fn encode_zero_run(&mut self, mut zeros: usize) -> Result<(), SrlError> {
+        while zeros >= 1usize << (self.kp / 8) {
+            self.writer.write_bit(false);
+            zeros -= 1usize << (self.kp / 8);
+            self.kp = self.kp.saturating_add(4).min(MAX_KP);
+        }
+
+        let k = self.kp / 8;
+        self.writer.write_bit(true);
+        self.writer
+            .write_bits(u32::try_from(zeros).map_err(|_| SrlError::ZeroRunTooLong)?, k);
+        self.kp = self.kp.saturating_sub(6);
+
+        Ok(())
+    }
+}
+
+impl Default for SrlEncoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Decode one complete SRL stream.
+///
+/// This convenience function is suitable when all entries use the same
+/// magnitude width. Progressive tile decoding should use [`SrlDecoder`]
+/// directly so its state continues between bands.
+pub fn decode_srl(data: &[u8], num_values: usize, num_bits: u8) -> Result<Vec<i16>, SrlError> {
+    let mut decoder = SrlDecoder::new(data)?;
+    decoder.decode(num_values, num_bits)
+}
+
+/// Encode one complete SRL stream.
+///
+/// This convenience function is suitable when all entries use the same
+/// magnitude width. Progressive tile encoding should use [`SrlEncoder`]
+/// directly so its state continues between bands.
+pub fn encode_srl(values: &[i16], num_bits: u8) -> Result<Vec<u8>, SrlError> {
+    let mut encoder = SrlEncoder::new();
+    encoder.encode(values, num_bits)?;
+    encoder.finish()
+}
+
+fn max_magnitude(num_bits: u8) -> Result<u16, SrlError> {
+    if !(1..=15).contains(&num_bits) {
+        return Err(SrlError::InvalidBitCount(num_bits));
+    }
+
+    Ok((1u16 << num_bits) - 1)
+}
 
 struct BitReader<'a> {
     data: &'a [u8],
     byte_idx: usize,
-    bit_idx: u8, // 0..7, MSB first
+    bit_idx: u8,
 }
 
 impl<'a> BitReader<'a> {
@@ -216,32 +275,34 @@ impl<'a> BitReader<'a> {
         }
     }
 
-    fn read_bit(&mut self) -> bool {
-        if self.byte_idx >= self.data.len() {
-            return false;
-        }
-        let bit = (self.data[self.byte_idx] >> (7 - self.bit_idx)) & 1 != 0;
+    fn read_bit(&mut self) -> Result<bool, SrlError> {
+        let Some(&byte) = self.data.get(self.byte_idx) else {
+            return Err(SrlError::Truncated);
+        };
+
+        let bit = (byte >> (7 - self.bit_idx)) & 1 != 0;
         self.bit_idx += 1;
-        if self.bit_idx >= 8 {
+        if self.bit_idx == 8 {
             self.bit_idx = 0;
             self.byte_idx += 1;
         }
-        bit
+
+        Ok(bit)
     }
 
-    fn read_bits(&mut self, count: u32) -> u32 {
+    fn read_bits(&mut self, count: u8) -> Result<u32, SrlError> {
         let mut value = 0u32;
         for _ in 0..count {
-            value = (value << 1) | u32::from(self.read_bit());
+            value = (value << 1) | u32::from(self.read_bit()?);
         }
-        value
+        Ok(value)
     }
 }
 
 struct BitWriter {
     bytes: Vec<u8>,
     current: u8,
-    bit_count: u8, // bits written in current byte (0..7)
+    bit_count: u8,
 }
 
 impl BitWriter {
@@ -256,22 +317,21 @@ impl BitWriter {
     fn write_bit(&mut self, bit: bool) {
         self.current = (self.current << 1) | u8::from(bit);
         self.bit_count += 1;
-        if self.bit_count >= 8 {
+        if self.bit_count == 8 {
             self.bytes.push(self.current);
             self.current = 0;
             self.bit_count = 0;
         }
     }
 
-    fn write_bits(&mut self, value: u32, count: u32) {
+    fn write_bits(&mut self, value: u32, count: u8) {
         for i in (0..count).rev() {
             self.write_bit((value >> i) & 1 != 0);
         }
     }
 
     fn finish(mut self) -> Vec<u8> {
-        if self.bit_count > 0 {
-            // Pad remaining bits with zeros (MSB aligned)
+        if self.bit_count != 0 {
             self.current <<= 8 - self.bit_count;
             self.bytes.push(self.current);
         }
@@ -284,90 +344,76 @@ mod tests {
     use super::*;
 
     #[test]
-    fn decode_empty() {
-        let result = decode_srl(&[], 0, 1);
-        assert!(result.is_empty());
+    fn decodes_initial_kp_and_unary_magnitude() {
+        // MS-RDPEGFX 3.1.8.1.5.1 initializes KP to 8, so K is one.
+        // The wire bits are zero run 0 (10), positive sign (0), magnitude 3 (001).
+        assert_eq!(decode_srl(&[0x84, 0x00], 1, 4), Ok(vec![3]));
     }
 
     #[test]
-    fn decode_empty_data() {
-        // With no data (empty slice), all positions default to zero
-        let result = decode_srl(&[], 5, 1);
-        assert_eq!(result, vec![0, 0, 0, 0, 0]);
+    fn preserves_zero_run_and_kp_between_bands() {
+        // A two-zero run (010) spans the first and second calls.
+        // The following positive magnitude-one value uses K=0 after the run.
+        let mut decoder = SrlDecoder::new(&[0x48, 0x00]).unwrap();
+        assert_eq!(decoder.decode(1, 4), Ok(vec![0]));
+        assert_eq!(decoder.decode(2, 4), Ok(vec![0, 1]));
     }
 
     #[test]
-    fn encode_empty() {
-        let encoded = encode_srl(&[], 1);
-        assert_eq!(encoded, vec![0x00]); // just sentinel
+    fn decodes_unterminated_maximum_magnitude() {
+        // MS-RDPEGFX 3.1.8.1.5.2 omits the unary terminator for the maximum value.
+        // The payload is zero run 0, negative sign, and six zero unary bits for -7.
+        assert_eq!(decode_srl(&[0xA0, 0x00, 0x00], 1, 3), Ok(vec![-7]));
     }
 
     #[test]
-    fn encode_all_zeros() {
-        let encoded = encode_srl(&[0, 0, 0], 1);
-        // Sentinel must be present
-        assert_eq!(*encoded.last().unwrap(), 0x00);
-        // Round-trip: all zeros must survive
-        let decoded = decode_srl(&encoded, 3, 1);
-        assert_eq!(decoded, vec![0, 0, 0]);
+    fn rejects_truncated_stream() {
+        assert_eq!(decode_srl(&[0x80, 0x00], 1, 4), Err(SrlError::Truncated));
     }
 
     #[test]
-    fn round_trip_single_positive() {
-        let original = vec![1];
-        let encoded = encode_srl(&original, 1);
-        let decoded = decode_srl(&encoded, 1, 1);
-        assert_eq!(decoded, original);
+    fn rejects_missing_terminator() {
+        assert_eq!(decode_srl(&[0x84], 1, 4), Err(SrlError::MissingTerminator));
     }
 
     #[test]
-    fn round_trip_single_negative() {
-        let original = vec![-1];
-        let encoded = encode_srl(&original, 1);
-        let decoded = decode_srl(&encoded, 1, 1);
-        assert_eq!(decoded, original);
+    fn rejects_out_of_range_magnitude() {
+        assert_eq!(
+            encode_srl(&[8], 3),
+            Err(SrlError::MagnitudeOutOfRange { magnitude: 8, max: 7 })
+        );
     }
 
     #[test]
-    fn round_trip_mixed_zeros() {
-        // Zeros at the start (where k=0) must survive the round-trip
-        let original = vec![0, 0, 1, -1, 0, 3];
-        let encoded = encode_srl(&original, 4);
-        let decoded = decode_srl(&encoded, original.len(), 4);
-        assert_eq!(decoded, original);
+    fn rejects_zero_run_longer_than_component() {
+        assert_eq!(encode_srl(&vec![0; MAX_ZERO_RUN + 1], 1), Err(SrlError::ZeroRunTooLong));
     }
 
     #[test]
-    fn round_trip_nonzero_only() {
-        let original = vec![1, -1, 2, -3, 1];
-        let encoded = encode_srl(&original, 4);
-        let decoded = decode_srl(&encoded, original.len(), 4);
-        assert_eq!(decoded, original);
+    fn encodes_empty_stream() {
+        assert_eq!(encode_srl(&[], 1), Ok(vec![0x00]));
     }
 
     #[test]
-    fn bit_reader_basic() {
-        let data = [0b10110000];
-        let mut reader = BitReader::new(&data);
-        assert!(reader.read_bit()); // 1
-        assert!(!reader.read_bit()); // 0
-        assert!(reader.read_bit()); // 1
-        assert!(reader.read_bit()); // 1
+    fn round_trips_mixed_values() {
+        let original = [0, 0, 1, -1, 0, 3];
+        let encoded = encode_srl(&original, 4).unwrap();
+        assert_eq!(encoded, vec![0x4F, 0x44, 0x00]);
+        let mut decoder = SrlDecoder::new(&encoded).unwrap();
+        assert_eq!(decoder.decode(2, 4), Ok(vec![0, 0]));
+        assert_eq!(decoder.decode(1, 4), Ok(vec![1]));
+        assert_eq!(decoder.decode(1, 4), Ok(vec![-1]));
+        assert_eq!(decoder.decode(1, 4), Ok(vec![0]));
+        assert_eq!(decoder.decode(1, 4), Ok(vec![3]));
+        assert_eq!(decode_srl(&encoded, original.len(), 4), Ok(original.to_vec()));
     }
 
     #[test]
-    fn bit_writer_basic() {
-        let mut writer = BitWriter::new();
-        writer.write_bit(true);
-        writer.write_bit(false);
-        writer.write_bit(true);
-        writer.write_bit(true);
-        writer.write_bit(false);
-        writer.write_bit(false);
-        writer.write_bit(false);
-        writer.write_bit(false);
-        let result = writer.finish();
-        assert_eq!(result, vec![0b10110000]);
+    fn preserves_zero_runs_between_bands_when_encoding() {
+        let mut encoder = SrlEncoder::new();
+        encoder.encode(&[0], 4).unwrap();
+        encoder.encode(&[0, 1], 4).unwrap();
+        assert_eq!(encoder.finish(), Ok(vec![0x48, 0x00]));
     }
 
     #[test]
@@ -375,7 +421,6 @@ mod tests {
         let mut writer = BitWriter::new();
         writer.write_bits(0xFF, 8);
         writer.write_bits(0x00, 8);
-        let result = writer.finish();
-        assert_eq!(result, vec![0xFF, 0x00]);
+        assert_eq!(writer.finish(), vec![0xFF, 0x00]);
     }
 }

--- a/crates/ironrdp-graphics/src/srl.rs
+++ b/crates/ironrdp-graphics/src/srl.rs
@@ -6,6 +6,7 @@
 
 const INITIAL_KP: u8 = 8;
 const MAX_KP: u8 = 80;
+// This conservative malformed-stream bound includes LL3 entries, although LL3 is raw-coded.
 const MAX_ZERO_RUN: usize = 4096;
 
 /// Errors encountered while decoding or encoding an SRL stream.


### PR DESCRIPTION
Preserve SRL and raw-bit state across Progressive DWT bands.

Reject malformed SRL refinement streams without decoding invented zero data or partially updating tiles.