### PR TITLE
fix(graphics): retain Progressive difference tiles

### DIFF
--- a/crates/ironrdp-graphics/src/progressive.rs
+++ b/crates/ironrdp-graphics/src/progressive.rs
@@ -2867,16 +2867,19 @@ mod tests {
         encoded
     }
 
-    fn simple_tile_stream(flags: u8, components: [i16; 3], include_context: bool) -> Vec<u8> {
+    fn progressive_tile_stream(
+        include_context: bool,
+        quant_vals: Vec<ComponentCodecQuant>,
+        quant_prog_vals: Vec<ironrdp_pdu::codecs::rfx::progressive::ProgressiveCodecQuant>,
+        tile: ironrdp_pdu::codecs::rfx::progressive::ProgressiveTile<'_>,
+    ) -> Vec<u8> {
         use ironrdp_pdu::codecs::rfx::RfxRectangle;
         use ironrdp_pdu::codecs::rfx::progressive::{
             ProgressiveBlock, ProgressiveContextPdu, ProgressiveFrameBeginPdu, ProgressiveFrameEndPdu,
-            ProgressiveRegion, ProgressiveSyncPdu, ProgressiveTile, TileSimple, encode_progressive_stream,
+            ProgressiveRegion, ProgressiveSyncPdu, encode_progressive_stream,
         };
 
-        let component_data = components.map(encode_full_quality_component);
         let mut blocks = vec![ProgressiveBlock::Sync(ProgressiveSyncPdu)];
-
         if include_context {
             blocks.push(ProgressiveBlock::Context(ProgressiveContextPdu {
                 context_id: 0,
@@ -2898,26 +2901,115 @@ mod tests {
                     width: 64,
                     height: 64,
                 }],
-                quant_vals: vec![ComponentCodecQuant::LOSSLESS],
-                quant_prog_vals: vec![],
+                quant_vals,
+                quant_prog_vals,
                 flags: 0,
-                tiles: vec![ProgressiveTile::Simple(TileSimple {
-                    quant_idx_y: 0,
-                    quant_idx_cb: 0,
-                    quant_idx_cr: 0,
-                    x_idx: 0,
-                    y_idx: 0,
-                    flags,
-                    y_data: &component_data[0],
-                    cb_data: &component_data[1],
-                    cr_data: &component_data[2],
-                    tail_data: &[],
-                })],
+                tiles: vec![tile],
             }),
             ProgressiveBlock::FrameEnd(ProgressiveFrameEndPdu),
         ]);
 
         encode_progressive_stream(&blocks).expect("synthetic progressive stream should encode")
+    }
+
+    fn simple_tile_stream(flags: u8, components: [i16; 3], include_context: bool) -> Vec<u8> {
+        use ironrdp_pdu::codecs::rfx::progressive::{ProgressiveTile, TileSimple};
+
+        let component_data = components.map(encode_full_quality_component);
+        progressive_tile_stream(
+            include_context,
+            vec![ComponentCodecQuant::LOSSLESS],
+            vec![],
+            ProgressiveTile::Simple(TileSimple {
+                quant_idx_y: 0,
+                quant_idx_cb: 0,
+                quant_idx_cr: 0,
+                x_idx: 0,
+                y_idx: 0,
+                flags,
+                y_data: &component_data[0],
+                cb_data: &component_data[1],
+                cr_data: &component_data[2],
+                tail_data: &[],
+            }),
+        )
+    }
+
+    fn first_tile_stream(
+        flags: u8,
+        component_data: &[u8],
+        base_quant: ComponentCodecQuant,
+        progressive_quant: ComponentCodecQuant,
+        include_context: bool,
+    ) -> Vec<u8> {
+        use ironrdp_pdu::codecs::rfx::progressive::{ProgressiveCodecQuant, ProgressiveTile, TileFirst};
+
+        progressive_tile_stream(
+            include_context,
+            vec![base_quant],
+            vec![ProgressiveCodecQuant {
+                quality: 0,
+                y_quant: progressive_quant,
+                cb_quant: progressive_quant,
+                cr_quant: progressive_quant,
+            }],
+            ProgressiveTile::First(TileFirst {
+                quant_idx_y: 0,
+                quant_idx_cb: 0,
+                quant_idx_cr: 0,
+                x_idx: 0,
+                y_idx: 0,
+                flags,
+                quality: 0,
+                y_data: component_data,
+                cb_data: component_data,
+                cr_data: component_data,
+                tail_data: &[],
+            }),
+        )
+    }
+
+    fn upgrade_tile_stream(
+        raw_data: &[u8],
+        base_quant: ComponentCodecQuant,
+        first_progressive_quant: ComponentCodecQuant,
+        upgrade_progressive_quant: ComponentCodecQuant,
+        include_context: bool,
+    ) -> Vec<u8> {
+        use ironrdp_pdu::codecs::rfx::progressive::{ProgressiveCodecQuant, ProgressiveTile, TileUpgrade};
+
+        progressive_tile_stream(
+            include_context,
+            vec![base_quant],
+            vec![
+                ProgressiveCodecQuant {
+                    quality: 0,
+                    y_quant: first_progressive_quant,
+                    cb_quant: first_progressive_quant,
+                    cr_quant: first_progressive_quant,
+                },
+                ProgressiveCodecQuant {
+                    quality: 1,
+                    y_quant: upgrade_progressive_quant,
+                    cb_quant: upgrade_progressive_quant,
+                    cr_quant: upgrade_progressive_quant,
+                },
+            ],
+            ProgressiveTile::Upgrade(TileUpgrade {
+                quant_idx_y: 0,
+                quant_idx_cb: 0,
+                quant_idx_cr: 0,
+                x_idx: 0,
+                y_idx: 0,
+                quality: 1,
+                y_srl_data: &[],
+                y_raw_data: raw_data,
+                cb_srl_data: &[],
+                cb_raw_data: raw_data,
+                cr_srl_data: &[],
+                cr_raw_data: raw_data,
+            }),
+        )
     }
 
     fn decode_full_quality_components(components: [i16; 3]) -> DecDwtQ {
@@ -3012,6 +3104,233 @@ mod tests {
                 .coefficients,
             other_reference
         );
+    }
+
+    #[test]
+    fn first_difference_tile_adds_to_its_retained_surface_reference() {
+        let progressive_quant = ComponentCodecQuant::LOSSLESS;
+        let original_data = encode_full_quality_component(64);
+        let difference_data = encode_full_quality_component(7);
+        let summed_data = encode_full_quality_component(71);
+        let mut decoder = ProgressiveDecoder::new();
+
+        decoder
+            .decode_bitmap(
+                1,
+                7,
+                64,
+                64,
+                &first_tile_stream(
+                    0,
+                    &original_data,
+                    ComponentCodecQuant::LOSSLESS,
+                    progressive_quant,
+                    true,
+                ),
+            )
+            .expect("original first-pass tile should decode");
+        let accumulated = decoder
+            .decode_bitmap(
+                1,
+                7,
+                64,
+                64,
+                &first_tile_stream(
+                    TILE_FLAG_DIFFERENCE,
+                    &difference_data,
+                    ComponentCodecQuant::LOSSLESS,
+                    progressive_quant,
+                    false,
+                ),
+            )
+            .expect("difference first-pass tile should decode");
+
+        let mut summed_decoder = ProgressiveDecoder::new();
+        let summed = summed_decoder
+            .decode_bitmap(
+                1,
+                7,
+                64,
+                64,
+                &first_tile_stream(0, &summed_data, ComponentCodecQuant::LOSSLESS, progressive_quant, true),
+            )
+            .expect("summed first-pass tile should decode");
+
+        assert_eq!(accumulated[0].pixels, summed[0].pixels);
+        assert_eq!(
+            decoder.references.get(&(1, 0, 0)),
+            summed_decoder.references.get(&(1, 0, 0))
+        );
+        assert!(
+            decoder
+                .contexts
+                .get(&(1, 7))
+                .and_then(|context| context.surface.get(0, 0))
+                .expect("difference tile state should be retained")
+                .is_difference
+        );
+    }
+
+    #[test]
+    fn original_tile_replaces_a_retained_surface_reference() {
+        let original_components = [64, -16, 24];
+        let difference_components = [7, -3, 5];
+        let replacement_components = [-48, 8, 40];
+        let mut decoder = ProgressiveDecoder::new();
+
+        decoder
+            .decode_bitmap(1, 7, 64, 64, &simple_tile_stream(0, original_components, true))
+            .expect("original tile should decode");
+        decoder
+            .decode_bitmap(
+                1,
+                7,
+                64,
+                64,
+                &simple_tile_stream(TILE_FLAG_DIFFERENCE, difference_components, false),
+            )
+            .expect("difference tile should decode");
+        let replacement = decoder
+            .decode_bitmap(1, 7, 64, 64, &simple_tile_stream(0, replacement_components, false))
+            .expect("replacement tile should decode");
+
+        let mut standalone_decoder = ProgressiveDecoder::new();
+        let standalone = standalone_decoder
+            .decode_bitmap(1, 7, 64, 64, &simple_tile_stream(0, replacement_components, true))
+            .expect("standalone replacement tile should decode");
+
+        assert_eq!(replacement[0].pixels, standalone[0].pixels);
+        assert_eq!(
+            decoder.references.get(&(1, 0, 0)),
+            standalone_decoder.references.get(&(1, 0, 0))
+        );
+        assert!(
+            !decoder
+                .contexts
+                .get(&(1, 7))
+                .and_then(|context| context.surface.get(0, 0))
+                .expect("replacement tile state should be retained")
+                .is_difference
+        );
+    }
+
+    #[test]
+    fn difference_tile_uses_the_reference_updated_by_an_upgrade() {
+        let base_quant = ComponentCodecQuant {
+            ll3: 6,
+            hl3: 6,
+            lh3: 6,
+            hh3: 6,
+            hl2: 6,
+            lh2: 6,
+            hh2: 6,
+            hl1: 6,
+            lh1: 6,
+            hh1: 6,
+        };
+        let mut progressive_quant = ComponentCodecQuant::LOSSLESS;
+        progressive_quant.ll3 = 1;
+
+        let mut original_coefficients = [0; COEFFICIENTS_PER_COMPONENT];
+        original_coefficients[4032] = 25;
+        let mut difference_coefficients = [0; COEFFICIENTS_PER_COMPONENT];
+        difference_coefficients[4032] = 5;
+        let original_data = {
+            let mut encoded = vec![0; 16 * 1024];
+            let len = crate::rlgr::encode(EntropyAlgorithm::Rlgr1, &original_coefficients, &mut encoded)
+                .expect("original RLGR encoding should succeed");
+            encoded.truncate(len);
+            encoded
+        };
+        let difference_data = {
+            let mut encoded = vec![0; 16 * 1024];
+            let len = crate::rlgr::encode(EntropyAlgorithm::Rlgr1, &difference_coefficients, &mut encoded)
+                .expect("difference RLGR encoding should succeed");
+            encoded.truncate(len);
+            encoded
+        };
+        let mut decoder = ProgressiveDecoder::new();
+
+        decoder
+            .decode_bitmap(
+                1,
+                7,
+                64,
+                64,
+                &first_tile_stream(0, &original_data, base_quant, progressive_quant, true),
+            )
+            .expect("original first-pass tile should decode");
+        let initial_reference = *decoder
+            .references
+            .get(&(1, 0, 0))
+            .expect("original tile should retain a reference");
+        let raw_data = [0xFF; 8];
+        decoder
+            .decode_bitmap(
+                1,
+                7,
+                64,
+                64,
+                &upgrade_tile_stream(
+                    &raw_data,
+                    base_quant,
+                    progressive_quant,
+                    ComponentCodecQuant::LOSSLESS,
+                    false,
+                ),
+            )
+            .expect("upgrade tile should decode");
+        let upgraded_reference = *decoder
+            .references
+            .get(&(1, 0, 0))
+            .expect("upgrade should update the retained reference");
+        assert_ne!(upgraded_reference[0][4032], initial_reference[0][4032]);
+
+        decoder
+            .decode_bitmap(
+                1,
+                7,
+                64,
+                64,
+                &first_tile_stream(
+                    TILE_FLAG_DIFFERENCE,
+                    &difference_data,
+                    base_quant,
+                    progressive_quant,
+                    false,
+                ),
+            )
+            .expect("difference first-pass tile should decode");
+        let updated_reference = decoder
+            .references
+            .get(&(1, 0, 0))
+            .expect("difference tile should update the retained reference");
+
+        let mut delta = TileState::new();
+        delta
+            .decode_first(
+                [&difference_data; 3],
+                [&base_quant; 3],
+                [progressive_quant; 3],
+                [0; 3],
+                0,
+                false,
+            )
+            .expect("difference tile payload should decode independently");
+
+        for ((updated_component, upgraded_component), delta_component) in updated_reference
+            .iter()
+            .zip(upgraded_reference.iter())
+            .zip(delta.coefficients.iter())
+        {
+            for ((updated, upgraded), delta) in updated_component
+                .iter()
+                .zip(upgraded_component.iter())
+                .zip(delta_component.iter())
+            {
+                assert_eq!(*updated, upgraded.saturating_add(*delta));
+            }
+        }
     }
 
     #[test]

--- a/crates/ironrdp-graphics/src/progressive.rs
+++ b/crates/ironrdp-graphics/src/progressive.rs
@@ -38,7 +38,7 @@ use alloc::collections::BTreeMap;
 use alloc::collections::btree_map::Entry;
 
 use ironrdp_pdu::codecs::rfx::EntropyAlgorithm;
-use ironrdp_pdu::codecs::rfx::progressive::ComponentCodecQuant;
+use ironrdp_pdu::codecs::rfx::progressive::{ComponentCodecQuant, TILE_FLAG_DIFFERENCE};
 
 use crate::dwt_extrapolate::BandInfo;
 use crate::rlgr::RlgrError;
@@ -807,6 +807,13 @@ pub struct TileState {
     pub use_reduce_extrapolate: bool,
 }
 
+struct FirstPassOptions {
+    quant_idx: [u8; 3],
+    quality: u8,
+    use_reduce_extrapolate: bool,
+    is_difference: bool,
+}
+
 impl TileState {
     /// Create a new tile with zeroed state.
     pub fn new() -> Self {
@@ -836,9 +843,8 @@ impl TileState {
 
     /// Decode a first-pass tile (TILE_SIMPLE or TILE_FIRST).
     ///
-    /// Resets this tile's state and decodes three components from RLGR1 data.
-    /// After this call, `coefficients` hold base-quantized DWT values for
-    /// progressive upgrades. Base dequantization occurs during reconstruction.
+    /// Clears persistent progressive state and decodes three original-tile
+    /// components from RLGR1 data.
     ///
     /// # Arguments
     /// - `component_data`: RLGR1-encoded data for [Y, Cb, Cr]
@@ -858,23 +864,57 @@ impl TileState {
         quality: u8,
         use_reduce_extrapolate: bool,
     ) -> Result<(), RlgrError> {
-        self.pass = 1;
-        self.quality = quality;
-        self.quant_idx = quant_idx;
-        self.base_quant = [*base_quants[0], *base_quants[1], *base_quants[2]];
-        self.use_reduce_extrapolate = use_reduce_extrapolate;
-        self.is_difference = false;
-        self.prog_quant = prog_quants;
+        self.decode_first_with_difference(
+            component_data,
+            base_quants,
+            prog_quants,
+            FirstPassOptions {
+                quant_idx,
+                quality,
+                use_reduce_extrapolate,
+                is_difference: false,
+            },
+        )
+    }
+
+    /// Decode a first pass, retaining the previous DWT coefficients for a
+    /// difference tile.
+    fn decode_first_with_difference(
+        &mut self,
+        component_data: [&[u8]; 3],
+        base_quants: [&ComponentCodecQuant; 3],
+        prog_quants: [ComponentCodecQuant; 3],
+        options: FirstPassOptions,
+    ) -> Result<(), RlgrError> {
+        let reference = options.is_difference.then_some(self.coefficients);
+        self.coefficients = [[0; COEFFICIENTS_PER_COMPONENT]; 3];
+        self.sign = [[SIGN_ZERO; COEFFICIENTS_PER_COMPONENT]; 3];
 
         for c in 0..3 {
             decode_first_pass_to_dwtq(
                 component_data[c],
                 &prog_quants[c],
-                use_reduce_extrapolate,
+                options.use_reduce_extrapolate,
                 &mut self.coefficients[c],
                 &mut self.sign[c],
             )?;
         }
+
+        if let Some(reference) = reference {
+            for (component, reference_component) in self.coefficients.iter_mut().zip(reference) {
+                for (coefficient, reference_coefficient) in component.iter_mut().zip(reference_component) {
+                    *coefficient = coefficient.saturating_add(reference_coefficient);
+                }
+            }
+        }
+
+        self.pass = 1;
+        self.quality = options.quality;
+        self.quant_idx = options.quant_idx;
+        self.base_quant = [*base_quants[0], *base_quants[1], *base_quants[2]];
+        self.use_reduce_extrapolate = options.use_reduce_extrapolate;
+        self.is_difference = options.is_difference;
+        self.prog_quant = prog_quants;
 
         Ok(())
     }
@@ -1054,6 +1094,12 @@ impl SurfaceTiles {
         self.tiles[idx].as_deref()
     }
 
+    /// Get an existing tile at the given grid position.
+    fn get_mut(&mut self, x_idx: u16, y_idx: u16) -> Option<&mut TileState> {
+        let idx = self.tile_index(x_idx, y_idx)?;
+        self.tiles[idx].as_deref_mut()
+    }
+
     /// Reset all tiles (e.g., on context reset or surface resize).
     pub fn reset(&mut self) {
         for tile in &mut self.tiles {
@@ -1108,6 +1154,8 @@ pub enum ProgressiveDecodeError {
     TileOutOfBounds { x_idx: u16, y_idx: u16 },
     /// Region references a quant index beyond the table.
     InvalidQuantIndex { index: usize, table_len: usize },
+    /// A difference tile has no retained coefficients for its tile and context.
+    MissingTileReference { x_idx: u16, y_idx: u16 },
     /// Surface dimensions exceed [`MAX_SURFACE_DIM`] per axis.
     SurfaceTooLarge { width: u16, height: u16 },
 }
@@ -1124,6 +1172,9 @@ impl core::fmt::Display for ProgressiveDecodeError {
             }
             Self::InvalidQuantIndex { index, table_len } => {
                 write!(f, "quant index {index} exceeds table length {table_len}")
+            }
+            Self::MissingTileReference { x_idx, y_idx } => {
+                write!(f, "difference tile ({x_idx}, {y_idx}) has no retained reference")
             }
             Self::SurfaceTooLarge { width, height } => {
                 write!(
@@ -1330,10 +1381,21 @@ fn decode_tile_block(
         ProgressiveTile::Simple(tile) => {
             let x_idx = tile.x_idx;
             let y_idx = tile.y_idx;
+            let is_difference = tile.flags & TILE_FLAG_DIFFERENCE != 0;
 
-            let tile_state = surface
-                .get_or_create(x_idx, y_idx)
-                .ok_or(ProgressiveDecodeError::TileOutOfBounds { x_idx, y_idx })?;
+            if surface.tile_index(x_idx, y_idx).is_none() {
+                return Err(ProgressiveDecodeError::TileOutOfBounds { x_idx, y_idx });
+            }
+            let tile_state = if is_difference {
+                surface
+                    .get_mut(x_idx, y_idx)
+                    .filter(|tile_state| tile_state.pass != 0)
+                    .ok_or(ProgressiveDecodeError::MissingTileReference { x_idx, y_idx })?
+            } else {
+                surface
+                    .get_or_create(x_idx, y_idx)
+                    .ok_or(ProgressiveDecodeError::TileOutOfBounds { x_idx, y_idx })?
+            };
 
             let q_y = usize::from(tile.quant_idx_y);
             let q_cb = usize::from(tile.quant_idx_cb);
@@ -1349,13 +1411,16 @@ fn decode_tile_block(
             // TILE_SIMPLE uses lossless progressive quant (no progressive refinement)
             let prog = ComponentCodecQuant::LOSSLESS;
 
-            tile_state.decode_first(
+            tile_state.decode_first_with_difference(
                 [tile.y_data, tile.cb_data, tile.cr_data],
                 [&quant_vals[q_y], &quant_vals[q_cb], &quant_vals[q_cr]],
                 [prog, prog, prog],
-                [tile.quant_idx_y, tile.quant_idx_cb, tile.quant_idx_cr],
-                0xFF, // full quality
-                use_reduce_extrapolate,
+                FirstPassOptions {
+                    quant_idx: [tile.quant_idx_y, tile.quant_idx_cb, tile.quant_idx_cr],
+                    quality: 0xFF, // full quality
+                    use_reduce_extrapolate,
+                    is_difference,
+                },
             )?;
 
             let mut pixels = vec![0u8; 64 * 64 * 4];
@@ -1367,10 +1432,21 @@ fn decode_tile_block(
         ProgressiveTile::First(tile) => {
             let x_idx = tile.x_idx;
             let y_idx = tile.y_idx;
+            let is_difference = tile.flags & TILE_FLAG_DIFFERENCE != 0;
 
-            let tile_state = surface
-                .get_or_create(x_idx, y_idx)
-                .ok_or(ProgressiveDecodeError::TileOutOfBounds { x_idx, y_idx })?;
+            if surface.tile_index(x_idx, y_idx).is_none() {
+                return Err(ProgressiveDecodeError::TileOutOfBounds { x_idx, y_idx });
+            }
+            let tile_state = if is_difference {
+                surface
+                    .get_mut(x_idx, y_idx)
+                    .filter(|tile_state| tile_state.pass != 0)
+                    .ok_or(ProgressiveDecodeError::MissingTileReference { x_idx, y_idx })?
+            } else {
+                surface
+                    .get_or_create(x_idx, y_idx)
+                    .ok_or(ProgressiveDecodeError::TileOutOfBounds { x_idx, y_idx })?
+            };
 
             let q_y = usize::from(tile.quant_idx_y);
             let q_cb = usize::from(tile.quant_idx_cb);
@@ -1392,13 +1468,16 @@ fn decode_tile_block(
             }
             let pq = &prog_quant_vals[pq_idx];
 
-            tile_state.decode_first(
+            tile_state.decode_first_with_difference(
                 [tile.y_data, tile.cb_data, tile.cr_data],
                 [&quant_vals[q_y], &quant_vals[q_cb], &quant_vals[q_cr]],
                 [pq.y_quant, pq.cb_quant, pq.cr_quant],
-                [tile.quant_idx_y, tile.quant_idx_cb, tile.quant_idx_cr],
-                tile.quality,
-                use_reduce_extrapolate,
+                FirstPassOptions {
+                    quant_idx: [tile.quant_idx_y, tile.quant_idx_cb, tile.quant_idx_cr],
+                    quality: tile.quality,
+                    use_reduce_extrapolate,
+                    is_difference,
+                },
             )?;
 
             let mut pixels = vec![0u8; 64 * 64 * 4];
@@ -2733,5 +2812,178 @@ mod tests {
             max_err <= 64,
             "quantize/dequantize round-trip max error {max_err} exceeds 64"
         );
+    }
+
+    fn encode_full_quality_component(value: i16) -> Vec<u8> {
+        let mut coefficients = [value; COEFFICIENTS_PER_COMPONENT];
+        let mut encoded = vec![0; 8192];
+        let encoded_len = encode_first_pass(
+            &mut coefficients,
+            &mut encoded,
+            &ComponentCodecQuant::LOSSLESS,
+            &ComponentCodecQuant::LOSSLESS,
+            false,
+        )
+        .expect("full-quality component encoding should succeed");
+        encoded.truncate(encoded_len);
+        encoded
+    }
+
+    fn simple_tile_stream(flags: u8, components: [i16; 3], include_context: bool) -> Vec<u8> {
+        use ironrdp_pdu::codecs::rfx::RfxRectangle;
+        use ironrdp_pdu::codecs::rfx::progressive::{
+            ProgressiveBlock, ProgressiveContextPdu, ProgressiveFrameBeginPdu, ProgressiveFrameEndPdu,
+            ProgressiveRegion, ProgressiveSyncPdu, ProgressiveTile, TileSimple, encode_progressive_stream,
+        };
+
+        let component_data = components.map(encode_full_quality_component);
+        let mut blocks = vec![ProgressiveBlock::Sync(ProgressiveSyncPdu)];
+
+        if include_context {
+            blocks.push(ProgressiveBlock::Context(ProgressiveContextPdu {
+                context_id: 0,
+                tile_size: 0x0040,
+                flags: 0,
+            }));
+        }
+
+        blocks.extend([
+            ProgressiveBlock::FrameBegin(ProgressiveFrameBeginPdu {
+                frame_index: 0,
+                region_count: 1,
+            }),
+            ProgressiveBlock::Region(ProgressiveRegion {
+                tile_size: 0x40,
+                rects: vec![RfxRectangle {
+                    x: 0,
+                    y: 0,
+                    width: 64,
+                    height: 64,
+                }],
+                quant_vals: vec![ComponentCodecQuant::LOSSLESS],
+                quant_prog_vals: vec![],
+                flags: 0,
+                tiles: vec![ProgressiveTile::Simple(TileSimple {
+                    quant_idx_y: 0,
+                    quant_idx_cb: 0,
+                    quant_idx_cr: 0,
+                    x_idx: 0,
+                    y_idx: 0,
+                    flags,
+                    y_data: &component_data[0],
+                    cb_data: &component_data[1],
+                    cr_data: &component_data[2],
+                    tail_data: &[],
+                })],
+            }),
+            ProgressiveBlock::FrameEnd(ProgressiveFrameEndPdu),
+        ]);
+
+        encode_progressive_stream(&blocks).expect("synthetic progressive stream should encode")
+    }
+
+    #[test]
+    fn difference_tile_adds_to_its_retained_context_reference() {
+        let original_components = [64, -16, 24];
+        let other_context_components = [-48, 8, 40];
+        let difference_components = [7, -3, 5];
+        let mut decoder = ProgressiveDecoder::new();
+
+        let first_pixels = decoder
+            .decode_bitmap(1, 7, 64, 64, &simple_tile_stream(0, original_components, true))
+            .expect("original tile should decode")
+            .pop()
+            .expect("original tile should produce an update")
+            .pixels;
+        let reference = decoder
+            .contexts
+            .get(&(1, 7))
+            .and_then(|context| context.surface.get(0, 0))
+            .expect("original tile state should be retained")
+            .coefficients;
+
+        decoder
+            .decode_bitmap(1, 8, 64, 64, &simple_tile_stream(0, other_context_components, true))
+            .expect("other context tile should decode");
+        let other_reference = decoder
+            .contexts
+            .get(&(1, 8))
+            .and_then(|context| context.surface.get(0, 0))
+            .expect("other context tile state should be retained")
+            .coefficients;
+
+        let difference_data = difference_components.map(encode_full_quality_component);
+        let mut expected_delta = TileState::new();
+        expected_delta
+            .decode_first(
+                [&difference_data[0], &difference_data[1], &difference_data[2]],
+                [&ComponentCodecQuant::LOSSLESS; 3],
+                [ComponentCodecQuant::LOSSLESS; 3],
+                [0; 3],
+                0xFF,
+                false,
+            )
+            .expect("difference payload should decode as a full tile");
+
+        let difference_pixels = decoder
+            .decode_bitmap(
+                1,
+                7,
+                64,
+                64,
+                &simple_tile_stream(TILE_FLAG_DIFFERENCE, difference_components, false),
+            )
+            .expect("difference tile should decode")
+            .pop()
+            .expect("difference tile should produce an update")
+            .pixels;
+        assert_ne!(first_pixels, difference_pixels);
+
+        let updated_tile = decoder
+            .contexts
+            .get(&(1, 7))
+            .and_then(|context| context.surface.get(0, 0))
+            .expect("difference tile state should be retained");
+        assert!(updated_tile.is_difference);
+        for ((updated_component, reference_component), delta_component) in updated_tile
+            .coefficients
+            .iter()
+            .zip(reference.iter())
+            .zip(expected_delta.coefficients.iter())
+        {
+            for ((updated, retained), delta) in updated_component
+                .iter()
+                .zip(reference_component.iter())
+                .zip(delta_component.iter())
+            {
+                assert_eq!(*updated, retained.saturating_add(*delta));
+            }
+        }
+
+        assert_eq!(
+            decoder
+                .contexts
+                .get(&(1, 8))
+                .and_then(|context| context.surface.get(0, 0))
+                .expect("other context tile state should remain retained")
+                .coefficients,
+            other_reference
+        );
+    }
+
+    #[test]
+    fn difference_tile_requires_a_retained_reference() {
+        let mut decoder = ProgressiveDecoder::new();
+
+        assert!(matches!(
+            decoder.decode_bitmap(
+                1,
+                7,
+                64,
+                64,
+                &simple_tile_stream(TILE_FLAG_DIFFERENCE, [7, -3, 5], true),
+            ),
+            Err(ProgressiveDecodeError::MissingTileReference { x_idx: 0, y_idx: 0 })
+        ));
     }
 }

--- a/crates/ironrdp-graphics/src/progressive.rs
+++ b/crates/ironrdp-graphics/src/progressive.rs
@@ -20,10 +20,12 @@
 //! - [`rgba_to_ycbcr`]: ITU-R BT.601 color space conversion
 //!
 //! ## State management
-//! - [`TileState`]: per-tile coefficient and DAS sign storage (~37 KB per tile)
+//! - [`TileState`]: per-codec-context tile coefficient and DAS sign storage
+//!   (~37 KB per tile)
 //! - [`SurfaceTiles`]: lazily-allocated tile grid for a surface
-//! - [`ProgressiveDecoder`]: high-level decoder maintaining per-context state,
-//!   wired into the EGFX `WireToSurface2Pdu` path
+//! - [`ProgressiveDecoder`]: high-level decoder maintaining per-context
+//!   progressive state and surface-scoped sub-band references, wired into the
+//!   EGFX `WireToSurface2Pdu` path
 //!
 //! # Progressive quantization
 //!
@@ -46,6 +48,9 @@ use crate::srl::{self, SrlError};
 
 /// Number of DWT coefficients per component in a 64x64 tile.
 pub const COEFFICIENTS_PER_COMPONENT: usize = 4096;
+
+type DecDwtQ = [[i16; COEFFICIENTS_PER_COMPONENT]; 3];
+type SubBandDiffingTileKey = (u16, u16, u16);
 
 /// Number of subbands in a 3-level DWT decomposition.
 pub const NUM_BANDS: usize = 10;
@@ -788,7 +793,7 @@ impl<'a> RawBitReader<'a> {
 /// Memory per tile: ~37 KB (24 KB coefficients + 12 KB signs + metadata).
 pub struct TileState {
     /// Accumulated base-quantized DWT coefficients (`DecDwtQ`) per component (Y, Cb, Cr).
-    pub coefficients: [[i16; COEFFICIENTS_PER_COMPONENT]; 3],
+    pub coefficients: DecDwtQ,
     /// Tri-state sign tracking per component (DAS array).
     pub sign: [[i8; COEFFICIENTS_PER_COMPONENT]; 3],
     /// Progressive quantization BitPos from the last applied pass.
@@ -811,7 +816,6 @@ struct FirstPassOptions {
     quant_idx: [u8; 3],
     quality: u8,
     use_reduce_extrapolate: bool,
-    is_difference: bool,
 }
 
 impl TileState {
@@ -868,52 +872,54 @@ impl TileState {
             component_data,
             base_quants,
             prog_quants,
+            None,
             FirstPassOptions {
                 quant_idx,
                 quality,
                 use_reduce_extrapolate,
-                is_difference: false,
             },
         )
     }
 
-    /// Decode a first pass, retaining the previous DWT coefficients for a
-    /// difference tile.
+    /// Decode a first pass and add difference-tile deltas to a retained DWT
+    /// reference.
     fn decode_first_with_difference(
         &mut self,
         component_data: [&[u8]; 3],
         base_quants: [&ComponentCodecQuant; 3],
         prog_quants: [ComponentCodecQuant; 3],
+        reference: Option<&DecDwtQ>,
         options: FirstPassOptions,
     ) -> Result<(), RlgrError> {
-        let reference = options.is_difference.then_some(self.coefficients);
-        self.coefficients = [[0; COEFFICIENTS_PER_COMPONENT]; 3];
-        self.sign = [[SIGN_ZERO; COEFFICIENTS_PER_COMPONENT]; 3];
+        let mut coefficients = [[0; COEFFICIENTS_PER_COMPONENT]; 3];
+        let mut sign = [[SIGN_ZERO; COEFFICIENTS_PER_COMPONENT]; 3];
 
         for c in 0..3 {
             decode_first_pass_to_dwtq(
                 component_data[c],
                 &prog_quants[c],
                 options.use_reduce_extrapolate,
-                &mut self.coefficients[c],
-                &mut self.sign[c],
+                &mut coefficients[c],
+                &mut sign[c],
             )?;
         }
 
         if let Some(reference) = reference {
-            for (component, reference_component) in self.coefficients.iter_mut().zip(reference) {
-                for (coefficient, reference_coefficient) in component.iter_mut().zip(reference_component) {
-                    *coefficient = coefficient.saturating_add(reference_coefficient);
+            for (component, reference_component) in coefficients.iter_mut().zip(reference.iter()) {
+                for (coefficient, reference_coefficient) in component.iter_mut().zip(reference_component.iter()) {
+                    *coefficient = coefficient.saturating_add(*reference_coefficient);
                 }
             }
         }
 
+        self.coefficients = coefficients;
+        self.sign = sign;
         self.pass = 1;
         self.quality = options.quality;
         self.quant_idx = options.quant_idx;
         self.base_quant = [*base_quants[0], *base_quants[1], *base_quants[2]];
         self.use_reduce_extrapolate = options.use_reduce_extrapolate;
-        self.is_difference = options.is_difference;
+        self.is_difference = reference.is_some();
         self.prog_quant = prog_quants;
 
         Ok(())
@@ -1094,12 +1100,6 @@ impl SurfaceTiles {
         self.tiles[idx].as_deref()
     }
 
-    /// Get an existing tile at the given grid position.
-    fn get_mut(&mut self, x_idx: u16, y_idx: u16) -> Option<&mut TileState> {
-        let idx = self.tile_index(x_idx, y_idx)?;
-        self.tiles[idx].as_deref_mut()
-    }
-
     /// Reset all tiles (e.g., on context reset or surface resize).
     pub fn reset(&mut self) {
         for tile in &mut self.tiles {
@@ -1154,7 +1154,7 @@ pub enum ProgressiveDecodeError {
     TileOutOfBounds { x_idx: u16, y_idx: u16 },
     /// Region references a quant index beyond the table.
     InvalidQuantIndex { index: usize, table_len: usize },
-    /// A difference tile has no retained coefficients for its tile and context.
+    /// A difference tile has no previously decoded state to use as its reference.
     MissingTileReference { x_idx: u16, y_idx: u16 },
     /// Surface dimensions exceed [`MAX_SURFACE_DIM`] per axis.
     SurfaceTooLarge { width: u16, height: u16 },
@@ -1212,10 +1212,10 @@ struct ProgressiveContext {
 
 /// High-level progressive bitmap decoder for EGFX WireToSurface2 processing.
 ///
-/// Maintains per-context tile state across frames, keyed by
-/// `(surface_id, codec_context_id)`.
+/// Maintains per-context progressive state and surface-scoped sub-band
+/// references across frames.
 /// MS-RDPEGFX section 3.3.1.1 associates each codec context with a surface, so
-/// two surfaces can reuse a codec context ID without sharing tile state.
+/// two surfaces can reuse a codec context ID without sharing progressive state.
 /// Feed it progressive bitmap data from `WireToSurface2Pdu.bitmap_data` and get
 /// back decoded RGBA tiles for compositing.
 ///
@@ -1238,6 +1238,7 @@ struct ProgressiveContext {
 /// ```
 pub struct ProgressiveDecoder {
     contexts: BTreeMap<(u16, u32), ProgressiveContext>,
+    references: BTreeMap<SubBandDiffingTileKey, DecDwtQ>,
 }
 
 impl ProgressiveDecoder {
@@ -1245,6 +1246,7 @@ impl ProgressiveDecoder {
     pub fn new() -> Self {
         Self {
             contexts: BTreeMap::new(),
+            references: BTreeMap::new(),
         }
     }
 
@@ -1297,8 +1299,10 @@ impl ProgressiveDecoder {
                 .ok_or(ProgressiveDecodeError::MissingBlock("CONTEXT"))?,
         };
 
+        let (contexts, references) = (&mut self.contexts, &mut self.references);
+
         // Get or create the context for this (surface_id, codec_context_id).
-        let context = match self.contexts.entry((surface_id, codec_context_id)) {
+        let context = match contexts.entry((surface_id, codec_context_id)) {
             Entry::Occupied(e) => e.into_mut(),
             Entry::Vacant(e) => {
                 let surface = SurfaceTiles::new(surface_width, surface_height, use_reduce_extrapolate)?;
@@ -1311,6 +1315,8 @@ impl ProgressiveDecoder {
         let expected_high = surface_height.div_ceil(64);
         if context.surface.tiles_wide != expected_wide || context.surface.tiles_high != expected_high {
             context.surface = SurfaceTiles::new(surface_width, surface_height, use_reduce_extrapolate)?;
+            // Replacing a surface tile grid invalidates its sub-band references.
+            references.retain(|(reference_surface_id, _, _), _| *reference_surface_id != surface_id);
         }
         context.surface.use_reduce_extrapolate = use_reduce_extrapolate;
 
@@ -1328,7 +1334,9 @@ impl ProgressiveDecoder {
 
             for tile_block in &region.tiles {
                 let tiles = decode_tile_block(
+                    surface_id,
                     &mut context.surface,
+                    references,
                     tile_block,
                     quant_vals,
                     prog_quant_vals,
@@ -1341,7 +1349,7 @@ impl ProgressiveDecoder {
         Ok(decoded_tiles)
     }
 
-    /// Delete a codec context, freeing its tile state.
+    /// Delete a codec context, freeing its progressive tile state.
     ///
     /// Called when the server sends RDPGFX_DELETE_ENCODING_CONTEXT, which
     /// identifies both the surface and codec context.
@@ -1356,11 +1364,14 @@ impl ProgressiveDecoder {
     pub fn delete_surface(&mut self, surface_id: u16) {
         self.contexts
             .retain(|(context_surface_id, _), _| *context_surface_id != surface_id);
+        self.references
+            .retain(|(reference_surface_id, _, _), _| *reference_surface_id != surface_id);
     }
 
     /// Reset all contexts (e.g., on EGFX channel reset).
     pub fn reset(&mut self) {
         self.contexts.clear();
+        self.references.clear();
     }
 }
 
@@ -1369,7 +1380,9 @@ impl ProgressiveDecoder {
     reason = "q_y/q_cb/q_cr are standard component quant index names"
 )]
 fn decode_tile_block(
+    surface_id: u16,
     surface: &mut SurfaceTiles,
+    references: &mut BTreeMap<SubBandDiffingTileKey, DecDwtQ>,
     tile_block: &ironrdp_pdu::codecs::rfx::progressive::ProgressiveTile<'_>,
     quant_vals: &[ComponentCodecQuant],
     prog_quant_vals: &[ironrdp_pdu::codecs::rfx::progressive::ProgressiveCodecQuant],
@@ -1386,16 +1399,19 @@ fn decode_tile_block(
             if surface.tile_index(x_idx, y_idx).is_none() {
                 return Err(ProgressiveDecodeError::TileOutOfBounds { x_idx, y_idx });
             }
-            let tile_state = if is_difference {
-                surface
-                    .get_mut(x_idx, y_idx)
-                    .filter(|tile_state| tile_state.pass != 0)
-                    .ok_or(ProgressiveDecodeError::MissingTileReference { x_idx, y_idx })?
+            let reference_key = (surface_id, x_idx, y_idx);
+            let reference = if is_difference {
+                Some(
+                    references
+                        .get(&reference_key)
+                        .ok_or(ProgressiveDecodeError::MissingTileReference { x_idx, y_idx })?,
+                )
             } else {
-                surface
-                    .get_or_create(x_idx, y_idx)
-                    .ok_or(ProgressiveDecodeError::TileOutOfBounds { x_idx, y_idx })?
+                None
             };
+            let tile_state = surface
+                .get_or_create(x_idx, y_idx)
+                .ok_or(ProgressiveDecodeError::TileOutOfBounds { x_idx, y_idx })?;
 
             let q_y = usize::from(tile.quant_idx_y);
             let q_cb = usize::from(tile.quant_idx_cb);
@@ -1415,13 +1431,14 @@ fn decode_tile_block(
                 [tile.y_data, tile.cb_data, tile.cr_data],
                 [&quant_vals[q_y], &quant_vals[q_cb], &quant_vals[q_cr]],
                 [prog, prog, prog],
+                reference,
                 FirstPassOptions {
                     quant_idx: [tile.quant_idx_y, tile.quant_idx_cb, tile.quant_idx_cr],
                     quality: 0xFF, // full quality
                     use_reduce_extrapolate,
-                    is_difference,
                 },
             )?;
+            references.insert(reference_key, tile_state.coefficients);
 
             let mut pixels = vec![0u8; 64 * 64 * 4];
             tile_state.reconstruct_to_rgba(&mut pixels);
@@ -1437,16 +1454,19 @@ fn decode_tile_block(
             if surface.tile_index(x_idx, y_idx).is_none() {
                 return Err(ProgressiveDecodeError::TileOutOfBounds { x_idx, y_idx });
             }
-            let tile_state = if is_difference {
-                surface
-                    .get_mut(x_idx, y_idx)
-                    .filter(|tile_state| tile_state.pass != 0)
-                    .ok_or(ProgressiveDecodeError::MissingTileReference { x_idx, y_idx })?
+            let reference_key = (surface_id, x_idx, y_idx);
+            let reference = if is_difference {
+                Some(
+                    references
+                        .get(&reference_key)
+                        .ok_or(ProgressiveDecodeError::MissingTileReference { x_idx, y_idx })?,
+                )
             } else {
-                surface
-                    .get_or_create(x_idx, y_idx)
-                    .ok_or(ProgressiveDecodeError::TileOutOfBounds { x_idx, y_idx })?
+                None
             };
+            let tile_state = surface
+                .get_or_create(x_idx, y_idx)
+                .ok_or(ProgressiveDecodeError::TileOutOfBounds { x_idx, y_idx })?;
 
             let q_y = usize::from(tile.quant_idx_y);
             let q_cb = usize::from(tile.quant_idx_cb);
@@ -1472,13 +1492,14 @@ fn decode_tile_block(
                 [tile.y_data, tile.cb_data, tile.cr_data],
                 [&quant_vals[q_y], &quant_vals[q_cb], &quant_vals[q_cr]],
                 [pq.y_quant, pq.cb_quant, pq.cr_quant],
+                reference,
                 FirstPassOptions {
                     quant_idx: [tile.quant_idx_y, tile.quant_idx_cb, tile.quant_idx_cr],
                     quality: tile.quality,
                     use_reduce_extrapolate,
-                    is_difference,
                 },
             )?;
+            references.insert(reference_key, tile_state.coefficients);
 
             let mut pixels = vec![0u8; 64 * 64 * 4];
             tile_state.reconstruct_to_rgba(&mut pixels);
@@ -1514,6 +1535,7 @@ fn decode_tile_block(
                 [pq.y_quant, pq.cb_quant, pq.cr_quant],
                 tile.quality,
             )?;
+            references.insert((surface_id, x_idx, y_idx), tile_state.coefficients);
 
             let mut pixels = vec![0u8; 64 * 64 * 4];
             tile_state.reconstruct_to_rgba(&mut pixels);
@@ -1967,12 +1989,14 @@ mod tests {
     fn decoder_reset_clears_contexts() {
         let mut decoder = ProgressiveDecoder::new();
 
-        let result = decoder.decode_bitmap(1, 1, 640, 480, &minimal_progressive_stream(true));
+        let result = decoder.decode_bitmap(1, 1, 64, 64, &simple_tile_stream(0, [64, -16, 24], true));
         assert!(result.is_ok());
         assert_eq!(decoder.contexts.len(), 1);
+        assert_eq!(decoder.references.len(), 1);
 
         decoder.reset();
         assert!(decoder.contexts.is_empty());
+        assert!(decoder.references.is_empty());
     }
 
     #[test]
@@ -2882,10 +2906,26 @@ mod tests {
         encode_progressive_stream(&blocks).expect("synthetic progressive stream should encode")
     }
 
+    fn decode_full_quality_components(components: [i16; 3]) -> DecDwtQ {
+        let component_data = components.map(encode_full_quality_component);
+        let mut state = TileState::new();
+        state
+            .decode_first(
+                [&component_data[0], &component_data[1], &component_data[2]],
+                [&ComponentCodecQuant::LOSSLESS; 3],
+                [ComponentCodecQuant::LOSSLESS; 3],
+                [0; 3],
+                0xFF,
+                false,
+            )
+            .expect("full-quality components should decode");
+        state.coefficients
+    }
+
     #[test]
-    fn difference_tile_adds_to_its_retained_context_reference() {
+    fn difference_tile_adds_to_its_retained_surface_reference() {
         let original_components = [64, -16, 24];
-        let other_context_components = [-48, 8, 40];
+        let other_surface_components = [-48, 8, 40];
         let difference_components = [7, -3, 5];
         let mut decoder = ProgressiveDecoder::new();
 
@@ -2903,27 +2943,16 @@ mod tests {
             .coefficients;
 
         decoder
-            .decode_bitmap(1, 8, 64, 64, &simple_tile_stream(0, other_context_components, true))
-            .expect("other context tile should decode");
+            .decode_bitmap(2, 8, 64, 64, &simple_tile_stream(0, other_surface_components, true))
+            .expect("other surface tile should decode");
         let other_reference = decoder
             .contexts
-            .get(&(1, 8))
+            .get(&(2, 8))
             .and_then(|context| context.surface.get(0, 0))
-            .expect("other context tile state should be retained")
+            .expect("other surface tile state should be retained")
             .coefficients;
 
-        let difference_data = difference_components.map(encode_full_quality_component);
-        let mut expected_delta = TileState::new();
-        expected_delta
-            .decode_first(
-                [&difference_data[0], &difference_data[1], &difference_data[2]],
-                [&ComponentCodecQuant::LOSSLESS; 3],
-                [ComponentCodecQuant::LOSSLESS; 3],
-                [0; 3],
-                0xFF,
-                false,
-            )
-            .expect("difference payload should decode as a full tile");
+        let expected_delta = decode_full_quality_components(difference_components);
 
         let difference_pixels = decoder
             .decode_bitmap(
@@ -2949,7 +2978,7 @@ mod tests {
             .coefficients
             .iter()
             .zip(reference.iter())
-            .zip(expected_delta.coefficients.iter())
+            .zip(expected_delta.iter())
         {
             for ((updated, retained), delta) in updated_component
                 .iter()
@@ -2963,12 +2992,100 @@ mod tests {
         assert_eq!(
             decoder
                 .contexts
-                .get(&(1, 8))
+                .get(&(2, 8))
                 .and_then(|context| context.surface.get(0, 0))
-                .expect("other context tile state should remain retained")
+                .expect("other surface tile state should remain retained")
                 .coefficients,
             other_reference
         );
+    }
+
+    #[test]
+    fn difference_tile_reference_survives_codec_context_deletion() {
+        let original_components = [64, -16, 24];
+        let difference_components = [7, -3, 5];
+        let mut decoder = ProgressiveDecoder::new();
+
+        decoder
+            .decode_bitmap(1, 7, 64, 64, &simple_tile_stream(0, original_components, true))
+            .expect("original tile should decode");
+        let reference = *decoder
+            .references
+            .get(&(1, 0, 0))
+            .expect("original tile reference should be retained");
+
+        decoder.delete_context(1, 7);
+        assert!(decoder.references.contains_key(&(1, 0, 0)));
+
+        decoder
+            .decode_bitmap(
+                1,
+                8,
+                64,
+                64,
+                &simple_tile_stream(TILE_FLAG_DIFFERENCE, difference_components, true),
+            )
+            .expect("difference tile should decode with the surface reference");
+        let expected_delta = decode_full_quality_components(difference_components);
+        let updated = decoder
+            .contexts
+            .get(&(1, 8))
+            .and_then(|context| context.surface.get(0, 0))
+            .expect("difference tile state should be retained")
+            .coefficients;
+
+        for ((updated_component, reference_component), delta_component) in
+            updated.iter().zip(reference.iter()).zip(expected_delta.iter())
+        {
+            for ((updated, retained), delta) in updated_component
+                .iter()
+                .zip(reference_component.iter())
+                .zip(delta_component.iter())
+            {
+                assert_eq!(*updated, retained.saturating_add(*delta));
+            }
+        }
+
+        assert_eq!(decoder.references.get(&(1, 0, 0)), Some(&updated));
+
+        decoder.delete_surface(1);
+        assert!(!decoder.references.contains_key(&(1, 0, 0)));
+        assert!(matches!(
+            decoder.decode_bitmap(
+                1,
+                9,
+                64,
+                64,
+                &simple_tile_stream(TILE_FLAG_DIFFERENCE, difference_components, true),
+            ),
+            Err(ProgressiveDecodeError::MissingTileReference { x_idx: 0, y_idx: 0 })
+        ));
+    }
+
+    #[test]
+    fn resizing_a_surface_clears_sub_band_references() {
+        let mut decoder = ProgressiveDecoder::new();
+
+        decoder
+            .decode_bitmap(1, 7, 64, 64, &simple_tile_stream(0, [64, -16, 24], true))
+            .expect("original tile should decode");
+        assert!(decoder.references.contains_key(&(1, 0, 0)));
+
+        decoder
+            .decode_bitmap(1, 7, 128, 64, &minimal_progressive_stream(true))
+            .expect("resized surface should decode");
+        assert!(!decoder.references.contains_key(&(1, 0, 0)));
+
+        assert!(matches!(
+            decoder.decode_bitmap(
+                1,
+                7,
+                128,
+                64,
+                &simple_tile_stream(TILE_FLAG_DIFFERENCE, [7, -3, 5], false),
+            ),
+            Err(ProgressiveDecodeError::MissingTileReference { x_idx: 0, y_idx: 0 })
+        ));
     }
 
     #[test]
@@ -2985,5 +3102,102 @@ mod tests {
             ),
             Err(ProgressiveDecodeError::MissingTileReference { x_idx: 0, y_idx: 0 })
         ));
+    }
+
+    #[test]
+    fn failed_difference_tile_keeps_retained_state() {
+        let original_data = [64, -16, 24].map(encode_full_quality_component);
+        let difference_data = [7, -3, 5].map(encode_full_quality_component);
+        let mut state = TileState::new();
+        let base_quants = [&ComponentCodecQuant::LOSSLESS; 3];
+        let prog_quants = [ComponentCodecQuant::LOSSLESS; 3];
+
+        state
+            .decode_first(
+                [&original_data[0], &original_data[1], &original_data[2]],
+                base_quants,
+                prog_quants,
+                [0; 3],
+                0xFF,
+                false,
+            )
+            .expect("original tile should decode");
+
+        let coefficients = state.coefficients;
+        let sign = state.sign;
+        let prog_quant = state.prog_quant;
+        let quant_idx = state.quant_idx;
+        let base_quant = state.base_quant;
+        let pass = state.pass;
+        let is_difference = state.is_difference;
+        let quality = state.quality;
+        let use_reduce_extrapolate = state.use_reduce_extrapolate;
+
+        assert!(
+            state
+                .decode_first_with_difference(
+                    [&difference_data[0], &difference_data[1], &[]],
+                    base_quants,
+                    prog_quants,
+                    Some(&coefficients),
+                    FirstPassOptions {
+                        quant_idx: [0; 3],
+                        quality: 0xFF,
+                        use_reduce_extrapolate: false,
+                    },
+                )
+                .is_err(),
+            "invalid difference payload should fail"
+        );
+
+        assert_eq!(state.coefficients, coefficients);
+        assert_eq!(state.sign, sign);
+        assert_eq!(state.prog_quant, prog_quant);
+        assert_eq!(state.quant_idx, quant_idx);
+        assert_eq!(state.base_quant, base_quant);
+        assert_eq!(state.pass, pass);
+        assert_eq!(state.is_difference, is_difference);
+        assert_eq!(state.quality, quality);
+        assert_eq!(state.use_reduce_extrapolate, use_reduce_extrapolate);
+
+        let mut delta = TileState::new();
+        delta
+            .decode_first(
+                [&difference_data[0], &difference_data[1], &difference_data[2]],
+                base_quants,
+                prog_quants,
+                [0; 3],
+                0xFF,
+                false,
+            )
+            .expect("valid difference payload should decode");
+        state
+            .decode_first_with_difference(
+                [&difference_data[0], &difference_data[1], &difference_data[2]],
+                base_quants,
+                prog_quants,
+                Some(&coefficients),
+                FirstPassOptions {
+                    quant_idx: [0; 3],
+                    quality: 0xFF,
+                    use_reduce_extrapolate: false,
+                },
+            )
+            .expect("difference tile after failed decode should use retained state");
+
+        for ((updated_component, retained_component), delta_component) in state
+            .coefficients
+            .iter()
+            .zip(coefficients.iter())
+            .zip(delta.coefficients.iter())
+        {
+            for ((updated, retained), delta) in updated_component
+                .iter()
+                .zip(retained_component.iter())
+                .zip(delta_component.iter())
+            {
+                assert_eq!(*updated, retained.saturating_add(*delta));
+            }
+        }
     }
 }

--- a/crates/ironrdp-graphics/src/progressive.rs
+++ b/crates/ironrdp-graphics/src/progressive.rs
@@ -1310,13 +1310,11 @@ impl ProgressiveDecoder {
             }
         };
 
-        // If surface dimensions changed, reallocate
+        // If surface dimensions changed, reallocate the codec-context tile grid.
         let expected_wide = surface_width.div_ceil(64);
         let expected_high = surface_height.div_ceil(64);
         if context.surface.tiles_wide != expected_wide || context.surface.tiles_high != expected_high {
             context.surface = SurfaceTiles::new(surface_width, surface_height, use_reduce_extrapolate)?;
-            // Replacing a surface tile grid invalidates its sub-band references.
-            references.retain(|(reference_surface_id, _, _), _| *reference_surface_id != surface_id);
         }
         context.surface.use_reduce_extrapolate = use_reduce_extrapolate;
 
@@ -1368,10 +1366,9 @@ impl ProgressiveDecoder {
             .retain(|(reference_surface_id, _, _), _| *reference_surface_id != surface_id);
     }
 
-    /// Reset all contexts (e.g., on EGFX channel reset).
+    /// Reset codec-context state while retaining surface sub-band references.
     pub fn reset(&mut self) {
         self.contexts.clear();
-        self.references.clear();
     }
 }
 
@@ -1986,17 +1983,34 @@ mod tests {
     }
 
     #[test]
-    fn decoder_reset_clears_contexts() {
+    fn decoder_reset_clears_contexts_but_preserves_sub_band_references() {
         let mut decoder = ProgressiveDecoder::new();
 
         let result = decoder.decode_bitmap(1, 1, 64, 64, &simple_tile_stream(0, [64, -16, 24], true));
         assert!(result.is_ok());
         assert_eq!(decoder.contexts.len(), 1);
         assert_eq!(decoder.references.len(), 1);
+        let reference = *decoder
+            .references
+            .get(&(1, 0, 0))
+            .expect("original tile reference should be retained");
 
         decoder.reset();
         assert!(decoder.contexts.is_empty());
-        assert!(decoder.references.is_empty());
+        assert_eq!(decoder.references.get(&(1, 0, 0)), Some(&reference));
+
+        assert!(
+            decoder
+                .decode_bitmap(
+                    1,
+                    2,
+                    64,
+                    64,
+                    &simple_tile_stream(TILE_FLAG_DIFFERENCE, [7, -3, 5], true),
+                )
+                .is_ok(),
+            "a new codec context should use the retained surface reference"
+        );
     }
 
     #[test]
@@ -3063,29 +3077,53 @@ mod tests {
     }
 
     #[test]
-    fn resizing_a_surface_clears_sub_band_references() {
+    fn resizing_a_surface_preserves_sub_band_references() {
         let mut decoder = ProgressiveDecoder::new();
+        let original_components = [64, -16, 24];
+        let difference_components = [7, -3, 5];
 
         decoder
-            .decode_bitmap(1, 7, 64, 64, &simple_tile_stream(0, [64, -16, 24], true))
+            .decode_bitmap(1, 7, 64, 64, &simple_tile_stream(0, original_components, true))
             .expect("original tile should decode");
-        assert!(decoder.references.contains_key(&(1, 0, 0)));
+        let reference = *decoder
+            .references
+            .get(&(1, 0, 0))
+            .expect("original tile reference should be retained");
 
         decoder
             .decode_bitmap(1, 7, 128, 64, &minimal_progressive_stream(true))
             .expect("resized surface should decode");
-        assert!(!decoder.references.contains_key(&(1, 0, 0)));
+        assert_eq!(decoder.references.get(&(1, 0, 0)), Some(&reference));
 
-        assert!(matches!(
-            decoder.decode_bitmap(
+        decoder
+            .decode_bitmap(
                 1,
                 7,
                 128,
                 64,
-                &simple_tile_stream(TILE_FLAG_DIFFERENCE, [7, -3, 5], false),
-            ),
-            Err(ProgressiveDecodeError::MissingTileReference { x_idx: 0, y_idx: 0 })
-        ));
+                &simple_tile_stream(TILE_FLAG_DIFFERENCE, difference_components, false),
+            )
+            .expect("difference tile should decode after resizing");
+
+        let expected_delta = decode_full_quality_components(difference_components);
+        let updated = decoder
+            .references
+            .get(&(1, 0, 0))
+            .expect("difference tile should update the retained reference");
+        for ((updated_component, reference_component), delta_component) in
+            updated.iter().zip(reference.iter()).zip(expected_delta.iter())
+        {
+            for ((updated_coefficient, reference_coefficient), delta_coefficient) in updated_component
+                .iter()
+                .zip(reference_component.iter())
+                .zip(delta_component.iter())
+            {
+                assert_eq!(
+                    *updated_coefficient,
+                    reference_coefficient.saturating_add(*delta_coefficient)
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/ironrdp-pdu/src/codecs/rfx/progressive.rs
+++ b/crates/ironrdp-pdu/src/codecs/rfx/progressive.rs
@@ -397,6 +397,12 @@ pub struct ProgressiveContextPdu {
 /// Bit 0 of context flags: use reduce-extrapolate DWT.
 pub const FLAG_DWT_REDUCE_EXTRAPOLATE: u8 = 0x01;
 
+/// RFX_TILE_DIFFERENCE in TILE_SIMPLE and TILE_FIRST flags.
+///
+/// The tile payload contains DWT coefficient deltas from the retained reference
+/// for the same tile instead of original coefficients.
+pub const TILE_FLAG_DIFFERENCE: u8 = 0x01;
+
 impl ProgressiveContextPdu {
     const NAME: &'static str = "ProgressiveContext";
     const FIXED_PART_SIZE: usize = 1 /* ctxId */ + 2 /* tileSize */ + 1 /* flags */;
@@ -1170,7 +1176,7 @@ mod tests {
             quant_idx_cr: 0,
             x_idx: 3,
             y_idx: 7,
-            flags: 0,
+            flags: TILE_FLAG_DIFFERENCE,
             y_data,
             cb_data,
             cr_data,
@@ -1184,6 +1190,7 @@ mod tests {
         assert_eq!(decoded.y_data, y_data);
         assert_eq!(decoded.cb_data, cb_data);
         assert_eq!(decoded.cr_data, cr_data);
+        assert_eq!(decoded.flags, TILE_FLAG_DIFFERENCE);
     }
 
     #[test]
@@ -1194,7 +1201,7 @@ mod tests {
             quant_idx_cr: 0,
             x_idx: 0,
             y_idx: 0,
-            flags: 0,
+            flags: TILE_FLAG_DIFFERENCE,
             quality: 0x40,
             y_data: &[10, 20],
             cb_data: &[30],
@@ -1206,6 +1213,7 @@ mod tests {
         let decoded = TileFirst::decode(&mut ReadCursor::new(&buf)).unwrap();
         assert_eq!(decoded.quality, 0x40);
         assert_eq!(decoded.quant_idx_cb, 1);
+        assert_eq!(decoded.flags, TILE_FLAG_DIFFERENCE);
     }
 
     #[test]


### PR DESCRIPTION
Retain quantized DWT coefficients per Progressive tile so difference updates compose with their matching surface reference while progressive codec-context state remains isolated.

Reject difference tiles that lack a retained reference instead of decoding them against zeros.

Keep retained surface references across codec grid replacement and ResetGraphics; only deleting the surface releases them.