### PR TITLE
fix(egfx): compose scaled output surfaces

### DIFF
--- a/crates/ironrdp-egfx/src/client.rs
+++ b/crates/ironrdp-egfx/src/client.rs
@@ -602,6 +602,7 @@ impl GraphicsPipelineClient {
             }
             GfxPdu::MapSurfaceToScaledOutput(pdu) => {
                 trace!(surface_id = pdu.surface_id, "MapSurfaceToScaledOutput");
+                self.handle_map_surface_to_scaled_output(&pdu);
                 self.handler.on_map_surface_to_scaled_output(&pdu);
                 Ok(vec![])
             }
@@ -740,6 +741,34 @@ impl GraphicsPipelineClient {
             self.handler.on_surface_mapped(surface_id, origin_x, origin_y);
         } else {
             warn!(surface_id, "MapSurfaceToOutput for unknown surface");
+        }
+    }
+
+    fn handle_map_surface_to_scaled_output(&mut self, pdu: &MapSurfaceToScaledOutputPdu) {
+        if let Some(surface) = self.surfaces.get_mut(&pdu.surface_id) {
+            surface.is_mapped = true;
+            surface.output_origin_x = pdu.output_origin_x;
+            surface.output_origin_y = pdu.output_origin_y;
+            self.compositor.map_surface_scaled(
+                pdu.surface_id,
+                pdu.output_origin_x,
+                pdu.output_origin_y,
+                pdu.target_width,
+                pdu.target_height,
+            );
+            debug!(
+                surface_id = pdu.surface_id,
+                origin_x = pdu.output_origin_x,
+                origin_y = pdu.output_origin_y,
+                target_width = pdu.target_width,
+                target_height = pdu.target_height,
+                "Surface mapped to scaled output"
+            );
+        } else {
+            warn!(
+                surface_id = pdu.surface_id,
+                "MapSurfaceToScaledOutput for unknown surface"
+            );
         }
     }
 
@@ -1236,6 +1265,7 @@ mod tests {
     /// `(codec_id, width, height, rgba)` extracted from each update, since
     /// `BitmapUpdate` is not `Clone` and does not need to be.
     type CapturedUpdate = (Codec1Type, u16, u16, Vec<u8>);
+    type ScaledOutputMapping = (u16, u32, u32, u32, u32);
 
     struct CapturingHandler {
         updates: Arc<Mutex<Vec<CapturedUpdate>>>,
@@ -1260,6 +1290,91 @@ mod tests {
         fn on_unhandled_pdu(&mut self, _pdu: &GfxPdu) {
             *self.unhandled.lock().expect("unhandled lock") += 1;
         }
+    }
+
+    struct ScaledOutputHandler {
+        mappings: Arc<Mutex<Vec<ScaledOutputMapping>>>,
+    }
+
+    impl GraphicsPipelineHandler for ScaledOutputHandler {
+        fn on_capabilities_confirmed(&mut self, _caps: &CapabilitySet) {}
+        fn on_reset_graphics(&mut self, _width: u32, _height: u32) {}
+        fn on_surface_created(&mut self, _surface: &Surface) {}
+        fn on_surface_deleted(&mut self, _surface_id: u16) {}
+        fn on_surface_mapped(&mut self, _surface_id: u16, _x: u32, _y: u32) {}
+        fn on_bitmap_updated(&mut self, _update: &BitmapUpdate) {}
+        fn on_frame_complete(&mut self, _frame_id: u32) {}
+        fn on_close(&mut self) {}
+        fn on_unhandled_pdu(&mut self, _pdu: &GfxPdu) {}
+
+        fn on_map_surface_to_scaled_output(&mut self, pdu: &MapSurfaceToScaledOutputPdu) {
+            self.mappings.lock().expect("mappings lock").push((
+                pdu.surface_id,
+                pdu.output_origin_x,
+                pdu.output_origin_y,
+                pdu.target_width,
+                pdu.target_height,
+            ));
+        }
+    }
+
+    #[test]
+    fn map_surface_to_scaled_output_dispatches_to_compositor_and_handler() {
+        let mappings = Arc::new(Mutex::new(Vec::new()));
+        let mut client = GraphicsPipelineClient::new(
+            Box::new(ScaledOutputHandler {
+                mappings: Arc::clone(&mappings),
+            }),
+            None,
+        );
+        client
+            .handle_pdu(GfxPdu::ResetGraphics(crate::pdu::ResetGraphicsPdu {
+                width: 12,
+                height: 12,
+                monitors: vec![],
+            }))
+            .unwrap();
+        client
+            .handle_pdu(GfxPdu::CreateSurface(crate::pdu::CreateSurfacePdu {
+                surface_id: 1,
+                width: 2,
+                height: 2,
+                pixel_format: PixelFormat::XRgb,
+            }))
+            .unwrap();
+        client
+            .handle_pdu(GfxPdu::MapSurfaceToScaledOutput(MapSurfaceToScaledOutputPdu {
+                surface_id: 1,
+                output_origin_x: 3,
+                output_origin_y: 4,
+                target_width: 4,
+                target_height: 4,
+            }))
+            .unwrap();
+
+        assert!(client.drain_output().is_empty());
+        client
+            .handle_pdu(GfxPdu::EndFrame(crate::pdu::EndFramePdu { frame_id: 1 }))
+            .unwrap();
+
+        assert_eq!(*mappings.lock().expect("mappings lock"), vec![(1, 3, 4, 4, 4)]);
+        assert!(client.surfaces[&1].is_mapped);
+        assert_eq!(
+            (client.surfaces[&1].output_origin_x, client.surfaces[&1].output_origin_y),
+            (3, 4)
+        );
+
+        let output = client.drain_output();
+        assert_eq!(output.len(), 1);
+        assert_eq!(
+            output[0].region,
+            ExclusiveRectangle {
+                left: 3,
+                top: 4,
+                right: 7,
+                bottom: 8,
+            }
+        );
     }
 
     /// A Planar `WireToSurface1` decodes to the pixels that were encoded, rather

--- a/crates/ironrdp-egfx/src/client.rs
+++ b/crates/ironrdp-egfx/src/client.rs
@@ -764,6 +764,8 @@ impl GraphicsPipelineClient {
                 target_height = pdu.target_height,
                 "Surface mapped to scaled output"
             );
+            self.handler
+                .on_surface_mapped(pdu.surface_id, pdu.output_origin_x, pdu.output_origin_y);
         } else {
             warn!(
                 surface_id = pdu.surface_id,
@@ -1265,6 +1267,7 @@ mod tests {
     /// `(codec_id, width, height, rgba)` extracted from each update, since
     /// `BitmapUpdate` is not `Clone` and does not need to be.
     type CapturedUpdate = (Codec1Type, u16, u16, Vec<u8>);
+    type SurfaceMapping = (u16, u32, u32);
     type ScaledOutputMapping = (u16, u32, u32, u32, u32);
 
     struct CapturingHandler {
@@ -1294,6 +1297,7 @@ mod tests {
 
     struct ScaledOutputHandler {
         mappings: Arc<Mutex<Vec<ScaledOutputMapping>>>,
+        surface_mappings: Arc<Mutex<Vec<SurfaceMapping>>>,
     }
 
     impl GraphicsPipelineHandler for ScaledOutputHandler {
@@ -1301,7 +1305,12 @@ mod tests {
         fn on_reset_graphics(&mut self, _width: u32, _height: u32) {}
         fn on_surface_created(&mut self, _surface: &Surface) {}
         fn on_surface_deleted(&mut self, _surface_id: u16) {}
-        fn on_surface_mapped(&mut self, _surface_id: u16, _x: u32, _y: u32) {}
+        fn on_surface_mapped(&mut self, surface_id: u16, x: u32, y: u32) {
+            self.surface_mappings
+                .lock()
+                .expect("surface mappings lock")
+                .push((surface_id, x, y));
+        }
         fn on_bitmap_updated(&mut self, _update: &BitmapUpdate) {}
         fn on_frame_complete(&mut self, _frame_id: u32) {}
         fn on_close(&mut self) {}
@@ -1321,9 +1330,11 @@ mod tests {
     #[test]
     fn map_surface_to_scaled_output_dispatches_to_compositor_and_handler() {
         let mappings = Arc::new(Mutex::new(Vec::new()));
+        let surface_mappings = Arc::new(Mutex::new(Vec::new()));
         let mut client = GraphicsPipelineClient::new(
             Box::new(ScaledOutputHandler {
                 mappings: Arc::clone(&mappings),
+                surface_mappings: Arc::clone(&surface_mappings),
             }),
             None,
         );
@@ -1358,6 +1369,10 @@ mod tests {
             .unwrap();
 
         assert_eq!(*mappings.lock().expect("mappings lock"), vec![(1, 3, 4, 4, 4)]);
+        assert_eq!(
+            *surface_mappings.lock().expect("surface mappings lock"),
+            vec![(1, 3, 4)]
+        );
         assert!(client.surfaces[&1].is_mapped);
         assert_eq!(
             (client.surfaces[&1].output_origin_x, client.surfaces[&1].output_origin_y),

--- a/crates/ironrdp-egfx/src/client.rs
+++ b/crates/ironrdp-egfx/src/client.rs
@@ -1377,6 +1377,23 @@ mod tests {
         );
     }
 
+    #[test]
+    fn map_surface_to_scaled_output_ignores_unknown_surface() {
+        let mut client = GraphicsPipelineClient::new(Box::new(TestHandler), None);
+        client
+            .handle_pdu(GfxPdu::MapSurfaceToScaledOutput(MapSurfaceToScaledOutputPdu {
+                surface_id: 1,
+                output_origin_x: 0,
+                output_origin_y: 0,
+                target_width: 2,
+                target_height: 2,
+            }))
+            .unwrap();
+
+        assert!(client.surfaces.is_empty());
+        assert!(client.drain_output().is_empty());
+    }
+
     /// A Planar `WireToSurface1` decodes to the pixels that were encoded, rather
     /// than falling through to the handler as an unsupported codec.
     ///

--- a/crates/ironrdp-egfx/src/compositor.rs
+++ b/crates/ironrdp-egfx/src/compositor.rs
@@ -521,7 +521,12 @@ impl Compositor {
             right,
             bottom,
         };
-        let data = copy_scaled_region(&surface.data, (source_width, source_height), mapping, &output_rect);
+        let data =
+            if mapping.target_width == u32::from(source_width) && mapping.target_height == u32::from(source_height) {
+                copy_region(&surface.data, source_width, dirty.rect.left, dirty.rect.top, w, h)
+            } else {
+                copy_scaled_region(&surface.data, (source_width, source_height), mapping, &output_rect)
+            };
         self.ready.push(OutputUpdate {
             region: output_rect,
             data,
@@ -638,19 +643,25 @@ fn copy_scaled_region(
     let mut out = vec![0; len];
     let target_left = u32::from(output_rect.left).saturating_sub(mapping.origin.0);
     let target_top = u32::from(output_rect.top).saturating_sub(mapping.origin.1);
+    let source_column_offsets = (0..width)
+        .map(|x| {
+            usize::from(
+                u16::try_from(
+                    (u64::from(target_left) + u64::from(x)) * u64::from(src_width) / u64::from(mapping.target_width),
+                )
+                .unwrap_or(u16::MAX),
+            ) * BYTES_PER_PIXEL
+        })
+        .collect::<Vec<_>>();
 
     for y in 0..height {
         let source_y = u16::try_from(
             (u64::from(target_top) + u64::from(y)) * u64::from(src_height) / u64::from(mapping.target_height),
         )
         .unwrap_or(u16::MAX);
+        let source_row_offset = usize::from(source_y) * usize::from(src_width) * BYTES_PER_PIXEL;
         for x in 0..width {
-            let source_x = u16::try_from(
-                (u64::from(target_left) + u64::from(x)) * u64::from(src_width) / u64::from(mapping.target_width),
-            )
-            .unwrap_or(u16::MAX);
-            let source_offset =
-                (usize::from(source_y) * usize::from(src_width) + usize::from(source_x)) * BYTES_PER_PIXEL;
+            let source_offset = source_row_offset + source_column_offsets[usize::from(x)];
             let target_offset = (usize::from(y) * usize::from(width) + usize::from(x)) * BYTES_PER_PIXEL;
             if source_offset + BYTES_PER_PIXEL <= src.len() {
                 out[target_offset..target_offset + BYTES_PER_PIXEL]
@@ -830,6 +841,17 @@ mod tests {
             &updates[0].data[updates[0].data.len() - BYTES_PER_PIXEL..],
             &[0x10, 0x11, 0x12, 0xFF]
         );
+    }
+
+    #[test]
+    fn zero_scale_mapping_produces_no_output() {
+        let mut c = Compositor::default();
+        c.reset(8, 8);
+        c.create_surface(1, 2, 2);
+        c.map_surface_scaled(1, 0, 0, 0, 2);
+        c.end_frame();
+
+        assert!(c.drain_output().is_empty());
     }
 
     /// Deltas only become drainable after `EndFrame`.

--- a/crates/ironrdp-egfx/src/compositor.rs
+++ b/crates/ironrdp-egfx/src/compositor.rs
@@ -49,8 +49,8 @@ const MAX_COMPOSITOR_BYTES: usize = 256 * 1024 * 1024;
 
 /// A rectangular region of the graphics output whose pixels changed within a frame.
 ///
-/// `region` is in output space (after `MapSurfaceToOutput`), using the egfx
-/// exclusive-rectangle convention (`right`/`bottom` are one past the edge).
+/// `region` is in output space (after a surface-to-output mapping), using the
+/// egfx exclusive-rectangle convention (`right`/`bottom` are one past the edge).
 /// `data` is tightly-packed RGBA8888, row-major, exactly
 /// `region.width() * region.height() * 4` bytes.
 #[derive(Debug, Clone)]
@@ -83,8 +83,16 @@ struct Surface {
     height: u16,
     /// RGBA8888, `width * height * 4` bytes.
     data: Vec<u8>,
-    /// Output origin if this surface is mapped (`MapSurfaceToOutput`), else `None`.
-    mapped_origin: Option<(u16, u16)>,
+    /// Output mapping if this surface is visible, else `None`.
+    mapping: Option<OutputMapping>,
+}
+
+/// A surface-to-output mapping, including the scaled output dimensions.
+#[derive(Debug, Clone, Copy)]
+struct OutputMapping {
+    origin: (u32, u32),
+    target_width: u32,
+    target_height: u32,
 }
 
 impl Surface {
@@ -216,7 +224,7 @@ impl Compositor {
                 width,
                 height,
                 data: vec![0; len],
-                mapped_origin: None,
+                mapping: None,
             },
         );
     }
@@ -231,14 +239,32 @@ impl Compositor {
     /// Handle `MapSurfaceToOutput`: record the mapping and make the surface's
     /// current contents visible at `(origin_x, origin_y)`.
     pub(crate) fn map_surface(&mut self, id: u16, origin_x: u32, origin_y: u32) {
-        let origin = (
-            u16::try_from(origin_x).unwrap_or(u16::MAX),
-            u16::try_from(origin_y).unwrap_or(u16::MAX),
-        );
+        let Some((width, height)) = self.surfaces.get(&id).map(|surface| (surface.width, surface.height)) else {
+            return;
+        };
+
+        self.map_surface_scaled(id, origin_x, origin_y, u32::from(width), u32::from(height));
+    }
+
+    /// Handle `MapSurfaceToScaledOutput`: record the scaled mapping and make the
+    /// surface's current contents visible at `(origin_x, origin_y)`.
+    pub(crate) fn map_surface_scaled(
+        &mut self,
+        id: u16,
+        origin_x: u32,
+        origin_y: u32,
+        target_width: u32,
+        target_height: u32,
+    ) {
+        let mapping = OutputMapping {
+            origin: (origin_x, origin_y),
+            target_width,
+            target_height,
+        };
         let Some(surface) = self.surfaces.get_mut(&id) else {
             return;
         };
-        surface.mapped_origin = Some(origin);
+        surface.mapping = Some(mapping);
         let (w, h) = (surface.width, surface.height);
         // The whole surface becomes visible at its new origin.
         self.record_dirty(id, 0, 0, w, h);
@@ -428,30 +454,60 @@ impl Compositor {
 
     /// Copy the pixels for one dirty region into the drainable queue.
     ///
-    /// The region arrives clipped to its surface; what remains is the output-space
-    /// translation, against the mapping in force now rather than at draw time.
+    /// The region arrives clipped to its surface and is mapped against the output
+    /// mapping in force now rather than the one active when it was drawn.
     fn materialize(&mut self, dirty: &DirtyRegion) {
-        let Some((ox, oy)) = self
+        let Some((mapping, source_width, source_height)) = self
             .surfaces
             .get(&dirty.surface_id)
-            .and_then(|surface| surface.mapped_origin)
+            .and_then(|surface| surface.mapping.map(|mapping| (mapping, surface.width, surface.height)))
         else {
             return;
         };
+        if mapping.target_width == 0 || mapping.target_height == 0 {
+            return;
+        }
 
-        // Saturating adds keep the math in u16; the clips then bound both the
-        // output rect and the region copied out of the surface.
-        let left = ox.saturating_add(dirty.rect.left).min(self.output_width);
-        let top = oy.saturating_add(dirty.rect.top).min(self.output_height);
-        let right = ox.saturating_add(dirty.rect.right).min(self.output_width);
-        let bottom = oy.saturating_add(dirty.rect.bottom).min(self.output_height);
+        let mapped_left = scaled_edge(dirty.rect.left, source_width, mapping.target_width);
+        let mapped_top = scaled_edge(dirty.rect.top, source_height, mapping.target_height);
+        let mapped_right = scaled_edge(dirty.rect.right, source_width, mapping.target_width);
+        let mapped_bottom = scaled_edge(dirty.rect.bottom, source_height, mapping.target_height);
+
+        // Saturating adds and output clipping bound the output rectangle before
+        // allocating its RGBA8888 pixels.
+        let left = mapping
+            .origin
+            .0
+            .saturating_add(mapped_left)
+            .min(u32::from(self.output_width));
+        let top = mapping
+            .origin
+            .1
+            .saturating_add(mapped_top)
+            .min(u32::from(self.output_height));
+        let right = mapping
+            .origin
+            .0
+            .saturating_add(mapped_right)
+            .min(u32::from(self.output_width));
+        let bottom = mapping
+            .origin
+            .1
+            .saturating_add(mapped_bottom)
+            .min(u32::from(self.output_height));
         if right <= left || bottom <= top {
             return;
         }
 
+        let left = u16::try_from(left).unwrap_or(u16::MAX);
+        let top = u16::try_from(top).unwrap_or(u16::MAX);
+        let right = u16::try_from(right).unwrap_or(u16::MAX);
+        let bottom = u16::try_from(bottom).unwrap_or(u16::MAX);
         let w = right - left;
         let h = bottom - top;
-        let len = usize::from(w) * usize::from(h) * BYTES_PER_PIXEL;
+        let Some(len) = pixel_data_len(w, h) else {
+            return;
+        };
         if !self.charge(len) {
             return;
         }
@@ -459,14 +515,15 @@ impl Compositor {
             self.release(len);
             return;
         };
-        let data = copy_region(&surface.data, surface.width, dirty.rect.left, dirty.rect.top, w, h);
+        let output_rect = ExclusiveRectangle {
+            left,
+            top,
+            right,
+            bottom,
+        };
+        let data = copy_scaled_region(&surface.data, (source_width, source_height), mapping, &output_rect);
         self.ready.push(OutputUpdate {
-            region: ExclusiveRectangle {
-                left,
-                top,
-                right,
-                bottom,
-            },
+            region: output_rect,
             data,
         });
     }
@@ -523,6 +580,25 @@ fn covers(outer: &ExclusiveRectangle, inner: &ExclusiveRectangle) -> bool {
     outer.left <= inner.left && outer.top <= inner.top && outer.right >= inner.right && outer.bottom >= inner.bottom
 }
 
+/// Return the target-space edge for a source-space edge with nearest-neighbor
+/// scaling. Rounding up means a dirty source rectangle covers every output pixel
+/// that samples from it.
+fn scaled_edge(source_edge: u16, source_length: u16, target_length: u32) -> u32 {
+    if source_length == 0 {
+        return 0;
+    }
+
+    let scaled = (u64::from(source_edge) * u64::from(target_length)).div_ceil(u64::from(source_length));
+    u32::try_from(scaled).unwrap_or(u32::MAX)
+}
+
+/// Return the byte length of a tightly-packed RGBA8888 rectangle.
+fn pixel_data_len(width: u16, height: u16) -> Option<usize> {
+    usize::from(width)
+        .checked_mul(usize::from(height))?
+        .checked_mul(BYTES_PER_PIXEL)
+}
+
 /// Copy a sub-rectangle out of an RGBA8888 canvas into a tightly-packed buffer.
 ///
 /// Rows that fall outside the source (short buffer, out-of-range rect) are padded
@@ -543,6 +619,46 @@ fn copy_region(src: &[u8], src_width: u16, x: u16, y: u16, w: u16, h: u16) -> Ve
             out.resize(out.len() + row_bytes, 0);
         }
     }
+    out
+}
+
+/// Scale a target-space rectangle from a source RGBA8888 canvas using nearest
+/// neighbor sampling.
+fn copy_scaled_region(
+    src: &[u8],
+    (src_width, src_height): (u16, u16),
+    mapping: OutputMapping,
+    output_rect: &ExclusiveRectangle,
+) -> Vec<u8> {
+    let width = output_rect.right.saturating_sub(output_rect.left);
+    let height = output_rect.bottom.saturating_sub(output_rect.top);
+    let Some(len) = pixel_data_len(width, height) else {
+        return Vec::new();
+    };
+    let mut out = vec![0; len];
+    let target_left = u32::from(output_rect.left).saturating_sub(mapping.origin.0);
+    let target_top = u32::from(output_rect.top).saturating_sub(mapping.origin.1);
+
+    for y in 0..height {
+        let source_y = u16::try_from(
+            (u64::from(target_top) + u64::from(y)) * u64::from(src_height) / u64::from(mapping.target_height),
+        )
+        .unwrap_or(u16::MAX);
+        for x in 0..width {
+            let source_x = u16::try_from(
+                (u64::from(target_left) + u64::from(x)) * u64::from(src_width) / u64::from(mapping.target_width),
+            )
+            .unwrap_or(u16::MAX);
+            let source_offset =
+                (usize::from(source_y) * usize::from(src_width) + usize::from(source_x)) * BYTES_PER_PIXEL;
+            let target_offset = (usize::from(y) * usize::from(width) + usize::from(x)) * BYTES_PER_PIXEL;
+            if source_offset + BYTES_PER_PIXEL <= src.len() {
+                out[target_offset..target_offset + BYTES_PER_PIXEL]
+                    .copy_from_slice(&src[source_offset..source_offset + BYTES_PER_PIXEL]);
+            }
+        }
+    }
+
     out
 }
 
@@ -631,6 +747,89 @@ mod tests {
         );
         assert_eq!(u.data.len(), 4 * 2 * BYTES_PER_PIXEL);
         assert_eq!(&u.data[0..4], &[0x11, 0x22, 0x33, 0xFF]);
+    }
+
+    #[test]
+    fn scaled_surface_materializes_nearest_neighbor_pixels_and_dirty_bounds() {
+        let mut c = Compositor::default();
+        c.reset(10, 10);
+        c.create_surface(1, 2, 2);
+        c.apply_bitmap(
+            1,
+            &rect(0, 0, 2, 2),
+            &[
+                0x10, 0x11, 0x12, 0xFF, 0x20, 0x21, 0x22, 0xFF, 0x30, 0x31, 0x32, 0xFF, 0x40, 0x41, 0x42, 0xFF,
+            ],
+        );
+        c.end_frame();
+
+        c.map_surface_scaled(1, 4, 3, 3, 3);
+        c.end_frame();
+        let updates = c.drain_output();
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0].region, rect(4, 3, 7, 6));
+        assert_eq!(
+            updates[0].data,
+            [
+                0x10, 0x11, 0x12, 0xFF, 0x10, 0x11, 0x12, 0xFF, 0x20, 0x21, 0x22, 0xFF, 0x10, 0x11, 0x12, 0xFF, 0x10,
+                0x11, 0x12, 0xFF, 0x20, 0x21, 0x22, 0xFF, 0x30, 0x31, 0x32, 0xFF, 0x30, 0x31, 0x32, 0xFF, 0x40, 0x41,
+                0x42, 0xFF,
+            ]
+        );
+
+        c.solid_fill(
+            1,
+            &Color {
+                b: 0x53,
+                g: 0x52,
+                r: 0x51,
+                xa: 0,
+            },
+            &[rect(1, 1, 2, 2)],
+        );
+        c.end_frame();
+        let updates = c.drain_output();
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0].region, rect(6, 5, 7, 6));
+        assert_eq!(updates[0].data, [0x51, 0x52, 0x53, 0xFF]);
+    }
+
+    #[test]
+    fn scaled_mapping_clips_without_discarding_other_output() {
+        let mut c = Compositor::default();
+        c.reset(8, 8);
+        c.create_surface(1, 2, 2);
+        c.create_surface(2, 1, 1);
+        c.map_surface(2, 0, 0);
+        c.end_frame();
+        c.map_surface_scaled(1, 6, 5, 3, 3);
+        c.end_frame();
+
+        let updates = c.drain_output();
+        assert_eq!(updates.len(), 2);
+        assert_eq!(updates[0].region, rect(0, 0, 1, 1));
+        assert_eq!(updates[1].region, rect(6, 5, 8, 8));
+    }
+
+    #[test]
+    fn oversized_scaled_mapping_preserves_the_wire_scale_factor() {
+        let mut c = Compositor::default();
+        c.reset(u32::from(u16::MAX), 1);
+        c.create_surface(1, 2, 1);
+        c.apply_bitmap(1, &rect(0, 0, 2, 1), &[0x10, 0x11, 0x12, 0xFF, 0x20, 0x21, 0x22, 0xFF]);
+        c.end_frame();
+
+        c.map_surface_scaled(1, 0, 0, u32::MAX, 1);
+        c.end_frame();
+        let updates = c.drain_output();
+
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0].region, rect(0, 0, u16::MAX, 1));
+        assert_eq!(&updates[0].data[0..4], &[0x10, 0x11, 0x12, 0xFF]);
+        assert_eq!(
+            &updates[0].data[updates[0].data.len() - BYTES_PER_PIXEL..],
+            &[0x10, 0x11, 0x12, 0xFF]
+        );
     }
 
     /// Deltas only become drainable after `EndFrame`.


### PR DESCRIPTION
Implement client-side composition for MapSurfaceToScaledOutput.

Track scaled mappings in the EGFX compositor, materialize scaled dirty output at EndFrame, and preserve bounded output clipping and frame-atomic updates.

Add client and compositor coverage for dispatch, nearest-neighbor pixels, dirty bounds, persistent output, and oversized wire-scale factors.