### PR TITLE
fix(graphics): honour RFX_TILE_DIFFERENCE in Progressive decode

### DIFF
--- a/crates/ironrdp-graphics/src/progressive.rs
+++ b/crates/ironrdp-graphics/src/progressive.rs
@@ -907,6 +907,15 @@ impl TileState {
         quality: u8,
         use_reduce_extrapolate: bool,
     ) -> Result<(), RlgrError> {
+        // The retained coefficients are still base-quantized, so they only mean
+        // anything while the base quantization and the DWT variant hold. A
+        // stream that changes either mid-tile has no defined reference, so drop
+        // it and decode the tile as an original one.
+        let base_quant = [*base_quants[0], *base_quants[1], *base_quants[2]];
+        if self.base_quant != base_quant || self.use_reduce_extrapolate != use_reduce_extrapolate {
+            self.coefficients = [[0; COEFFICIENTS_PER_COMPONENT]; 3];
+        }
+
         self.begin_first_pass(
             base_quants,
             prog_quants,
@@ -2522,6 +2531,57 @@ mod tests {
 
         assert_eq!(difference_tile.coefficients, absolute_tile.coefficients);
         assert_eq!(difference_tile.sign, absolute_tile.sign);
+    }
+
+    #[test]
+    fn difference_tile_drops_an_incompatible_reference() {
+        // The retained coefficients are base-quantized, so they are only a
+        // meaningful reference while the base quantization and the DWT variant
+        // hold. A zero-valued difference must stay a no-op either way.
+        let mut absolute = [0i16; COEFFICIENTS_PER_COMPONENT];
+        absolute[0] = 100;
+        absolute[4032] = 25;
+        let absolute_data = rlgr_encode_component(&absolute);
+        let zero_data = rlgr_encode_component(&[0i16; COEFFICIENTS_PER_COMPONENT]);
+        let prog_quant = ComponentCodecQuant::LOSSLESS;
+
+        for (first, second, extrapolate) in [
+            (uniform_quant(6), uniform_quant(8), false),
+            (uniform_quant(6), uniform_quant(6), true),
+        ] {
+            let mut tile = TileState::new();
+            tile.decode_first([&absolute_data; 3], [&first; 3], [prog_quant; 3], [0; 3], 0xFF, false)
+                .expect("original first-pass decoding should succeed");
+            tile.decode_first_difference(
+                [&zero_data; 3],
+                [&second; 3],
+                [prog_quant; 3],
+                [1; 3],
+                0xFF,
+                extrapolate,
+            )
+            .expect("difference first-pass decoding should succeed");
+
+            let mut reference = TileState::new();
+            reference
+                .decode_first(
+                    [&zero_data; 3],
+                    [&second; 3],
+                    [prog_quant; 3],
+                    [1; 3],
+                    0xFF,
+                    extrapolate,
+                )
+                .expect("reference decoding should succeed");
+
+            let mut actual = vec![0u8; 64 * 64 * 4];
+            let mut expected = vec![0u8; 64 * 64 * 4];
+            tile.reconstruct_to_rgba(&mut actual);
+            reference.reconstruct_to_rgba(&mut expected);
+
+            let differing = actual.iter().zip(expected.iter()).filter(|(a, b)| a != b).count();
+            assert_eq!(differing, 0, "extrapolate {extrapolate}: {differing} bytes differ");
+        }
     }
 
     #[test]

--- a/crates/ironrdp-graphics/src/progressive.rs
+++ b/crates/ironrdp-graphics/src/progressive.rs
@@ -896,8 +896,9 @@ impl TileState {
     /// Arguments match [`TileState::decode_first`].
     ///
     /// # Errors
-    /// Returns `RlgrError` if any component's RLGR decode fails; components
-    /// decoded before the failure stay accumulated.
+    /// Returns `RlgrError` if any component's RLGR decode fails. On error the
+    /// tile keeps its prior state, so a truncated stream cannot corrupt the
+    /// reference the next difference tile is decoded against.
     pub fn decode_first_difference(
         &mut self,
         component_data: [&[u8]; 3],
@@ -912,10 +913,32 @@ impl TileState {
         // stream that changes either mid-tile has no defined reference, so drop
         // it and decode the tile as an original one.
         let base_quant = [*base_quants[0], *base_quants[1], *base_quants[2]];
-        if self.base_quant != base_quant || self.use_reduce_extrapolate != use_reduce_extrapolate {
-            self.coefficients = [[0; COEFFICIENTS_PER_COMPONENT]; 3];
+        let mut coefficients = if self.base_quant == base_quant && self.use_reduce_extrapolate == use_reduce_extrapolate
+        {
+            self.coefficients
+        } else {
+            [[0; COEFFICIENTS_PER_COMPONENT]; 3]
+        };
+        let mut sign = self.sign;
+
+        for c in 0..3 {
+            let mut difference = [0i16; COEFFICIENTS_PER_COMPONENT];
+
+            decode_first_pass_to_dwtq(
+                component_data[c],
+                &prog_quants[c],
+                use_reduce_extrapolate,
+                &mut difference,
+                &mut sign[c],
+            )?;
+
+            for (coefficient, difference) in coefficients[c].iter_mut().zip(difference) {
+                *coefficient = clamp_i16(i32::from(*coefficient) + i32::from(difference));
+            }
         }
 
+        self.coefficients = coefficients;
+        self.sign = sign;
         self.begin_first_pass(
             base_quants,
             prog_quants,
@@ -924,24 +947,6 @@ impl TileState {
             use_reduce_extrapolate,
             true,
         );
-
-        for c in 0..3 {
-            // Decode into scratch so a malformed RLGR stream leaves this
-            // component's retained coefficients intact.
-            let mut difference = [0i16; COEFFICIENTS_PER_COMPONENT];
-
-            decode_first_pass_to_dwtq(
-                component_data[c],
-                &prog_quants[c],
-                use_reduce_extrapolate,
-                &mut difference,
-                &mut self.sign[c],
-            )?;
-
-            for (coefficient, difference) in self.coefficients[c].iter_mut().zip(difference) {
-                *coefficient = clamp_i16(i32::from(*coefficient) + i32::from(difference));
-            }
-        }
 
         Ok(())
     }
@@ -2531,6 +2536,51 @@ mod tests {
 
         assert_eq!(difference_tile.coefficients, absolute_tile.coefficients);
         assert_eq!(difference_tile.sign, absolute_tile.sign);
+    }
+
+    #[test]
+    fn failed_difference_decode_leaves_the_tile_unchanged() {
+        // An empty component stream is trivially reachable on the wire, and it
+        // must not corrupt the reference the next difference tile builds on.
+        let base_quant = uniform_quant(6);
+        let prog_quant = ComponentCodecQuant::LOSSLESS;
+
+        let mut absolute = [0i16; COEFFICIENTS_PER_COMPONENT];
+        absolute[0] = 100;
+        absolute[4032] = 25;
+        let mut difference = [0i16; COEFFICIENTS_PER_COMPONENT];
+        difference[0] = -30;
+
+        let absolute_data = rlgr_encode_component(&absolute);
+        let difference_data = rlgr_encode_component(&difference);
+
+        let mut tile = TileState::new();
+        tile.decode_first(
+            [&absolute_data; 3],
+            [&base_quant; 3],
+            [prog_quant; 3],
+            [0; 3],
+            0xFF,
+            false,
+        )
+        .expect("original first-pass decoding should succeed");
+        let coefficients = tile.coefficients;
+        let sign = tile.sign;
+
+        tile.decode_first_difference(
+            [&difference_data, &difference_data, &[]],
+            [&base_quant; 3],
+            [prog_quant; 3],
+            [0; 3],
+            0xFF,
+            false,
+        )
+        .expect_err("an empty component stream should fail");
+
+        assert!(tile.coefficients == coefficients);
+        assert!(tile.sign == sign);
+        assert!(!tile.is_difference);
+        assert_eq!(tile.pass, 1);
     }
 
     #[test]

--- a/crates/ironrdp-graphics/src/progressive.rs
+++ b/crates/ironrdp-graphics/src/progressive.rs
@@ -20,10 +20,8 @@
 //! - [`rgba_to_ycbcr`]: ITU-R BT.601 color space conversion
 //!
 //! ## State management
-//! - [`TileState`]: per-tile coefficient and DAS sign storage (~37 KB per tile).
-//!   A first-pass tile whose `RFX_TILE_DIFFERENCE` flag is set carries deltas
-//!   against that storage rather than absolute coefficients, and is decoded
-//!   with [`TileState::decode_first_difference`]
+//! - [`TileState`]: per-tile coefficient and DAS sign storage (~37 KB per tile),
+//!   which `RFX_TILE_DIFFERENCE` tiles accumulate into
 //! - [`SurfaceTiles`]: lazily-allocated tile grid for a surface
 //! - [`ProgressiveDecoder`]: high-level decoder maintaining per-context state,
 //!   wired into the EGFX `WireToSurface2Pdu` path
@@ -72,10 +70,8 @@ pub const SIGN_NEGATIVE: i8 = -1;
 /// Performs: RLGR1 decode -> LL3 delta decode -> progressive dequantization
 /// -> sign capture -> base dequantization.
 ///
-/// This decodes an original tile, whose coefficients are absolute. A difference
-/// tile must accumulate before base dequantization, so it goes through
-/// [`TileState::decode_first_difference`], which keeps the retained
-/// coefficients in the `DecDwtQ` domain.
+/// Original tiles only: `RFX_TILE_DIFFERENCE` accumulates before base
+/// dequantization, see [`TileState::decode_first_difference`].
 ///
 /// # Arguments
 /// - `data`: RLGR1-encoded coefficient stream
@@ -807,8 +803,7 @@ pub struct TileState {
     pub base_quant: [ComponentCodecQuant; 3],
     /// Progressive pass counter (0 = no data, 1 = first pass complete, 2+ = upgrade).
     pub pass: u16,
-    /// Whether the most recent first-pass tile carried coefficient differences
-    /// (`RFX_TILE_DIFFERENCE`) rather than absolute values.
+    /// Whether the last first-pass tile set `RFX_TILE_DIFFERENCE`.
     pub is_difference: bool,
     /// Last progressive quality byte (0xFF = full quality).
     pub quality: u8,
@@ -843,14 +838,12 @@ impl TileState {
         }
     }
 
-    /// Decode a first-pass tile (TILE_SIMPLE or TILE_FIRST) carrying absolute
-    /// coefficients, that is one whose `RFX_TILE_DIFFERENCE` flag is clear.
+    /// Decode a first-pass tile (TILE_SIMPLE or TILE_FIRST) without
+    /// `RFX_TILE_DIFFERENCE`.
     ///
     /// Resets this tile's state and decodes three components from RLGR1 data.
     /// After this call, `coefficients` hold base-quantized DWT values for
     /// progressive upgrades. Base dequantization occurs during reconstruction.
-    ///
-    /// Use [`TileState::decode_first_difference`] when the flag is set.
     ///
     /// # Arguments
     /// - `component_data`: RLGR1-encoded data for [Y, Cb, Cr]
@@ -892,32 +885,19 @@ impl TileState {
         Ok(())
     }
 
-    /// Decode a first-pass tile (TILE_SIMPLE or TILE_FIRST) whose
-    /// `RFX_TILE_DIFFERENCE` flag is set.
+    /// Decode a first-pass tile with `RFX_TILE_DIFFERENCE` set.
     ///
-    /// Such a tile carries the difference of the DWT coefficients for the same
-    /// tile between the current and the previous frame, so the decoded values
-    /// are added to the retained ones rather than replacing them:
-    /// `DecDwtQ = DecDwtQ + DecProgQ * PQF`. See MS-RDPEGFX sections
-    /// 2.2.4.2.1.5.3, 2.2.4.2.1.5.4 and 3.3.8.2.1.1.
+    /// The tile carries the DWT coefficient difference against the previous
+    /// frame, so the decoded values are added to the retained ones:
+    /// `DecDwtQ = DecDwtQ + DecProgQ * PQF` (MS-RDPEGFX 3.3.8.2.1.1). The DAS
+    /// sign state describes the differences, which is what later upgrade
+    /// passes refine.
     ///
-    /// Takes the same arguments as [`TileState::decode_first`], and leaves the
-    /// tile in the same shape: the accumulated coefficients stay base-quantized
-    /// and are dequantized during reconstruction, and further upgrade passes
-    /// refine them exactly as they refine an absolute tile.
-    ///
-    /// The DAS sign state describes the incoming differences rather than the
-    /// accumulated result, because it is what the upgrade passes refining this
-    /// very transmission are encoded against.
-    ///
-    /// A tile that has not been decoded yet holds zeroed coefficients, so a
-    /// difference tile arriving as the first tile of a surface reconstructs to
-    /// the same values as an absolute one.
+    /// Arguments match [`TileState::decode_first`].
     ///
     /// # Errors
-    /// Returns `RlgrError` if any component's RLGR decode fails. Components
-    /// decoded before the failure keep their accumulated values; the failing
-    /// component keeps the values it had.
+    /// Returns `RlgrError` if any component's RLGR decode fails; components
+    /// decoded before the failure stay accumulated.
     pub fn decode_first_difference(
         &mut self,
         component_data: [&[u8]; 3],
@@ -937,8 +917,8 @@ impl TileState {
         );
 
         for c in 0..3 {
-            // Decoding into a scratch buffer keeps the retained coefficients
-            // intact when the RLGR stream turns out to be malformed.
+            // Decode into scratch so a malformed RLGR stream leaves this
+            // component's retained coefficients intact.
             let mut difference = [0i16; COEFFICIENTS_PER_COMPONENT];
 
             decode_first_pass_to_dwtq(
@@ -1586,28 +1566,16 @@ impl Default for ProgressiveDecoder {
 #[cfg(test)]
 #[expect(clippy::as_conversions, clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 mod tests {
+    use ironrdp_pdu::codecs::rfx::RfxRectangle;
+    use ironrdp_pdu::codecs::rfx::progressive::{
+        FLAG_TILE_DIFFERENCE, ProgressiveBlock, ProgressiveCodecQuant, ProgressiveContextPdu, ProgressiveFrameBeginPdu,
+        ProgressiveFrameEndPdu, ProgressiveRegion, ProgressiveSyncPdu, ProgressiveTile, TileFirst, TileSimple,
+        encode_progressive_stream,
+    };
+
     use super::*;
 
-    fn minimal_progressive_stream(include_context: bool) -> Vec<u8> {
-        use ironrdp_pdu::codecs::rfx::RfxRectangle;
-        use ironrdp_pdu::codecs::rfx::progressive::{
-            ProgressiveBlock, ProgressiveContextPdu, ProgressiveFrameBeginPdu, ProgressiveFrameEndPdu,
-            ProgressiveRegion, ProgressiveSyncPdu, encode_progressive_stream,
-        };
-
-        let region = ProgressiveRegion {
-            tile_size: 0x40,
-            rects: vec![RfxRectangle {
-                x: 0,
-                y: 0,
-                width: 64,
-                height: 64,
-            }],
-            quant_vals: vec![],
-            quant_prog_vals: vec![],
-            flags: 0,
-            tiles: vec![],
-        };
+    fn progressive_stream(include_context: bool, region: ProgressiveRegion<'_>) -> Vec<u8> {
         let mut blocks = vec![ProgressiveBlock::Sync(ProgressiveSyncPdu)];
         if include_context {
             blocks.push(ProgressiveBlock::Context(ProgressiveContextPdu {
@@ -1626,6 +1594,31 @@ mod tests {
         ]);
 
         encode_progressive_stream(&blocks).unwrap()
+    }
+
+    /// Region covering one 64x64 tile at (0, 0).
+    fn single_tile_region<'a>(
+        quant_vals: Vec<ComponentCodecQuant>,
+        quant_prog_vals: Vec<ProgressiveCodecQuant>,
+        tiles: Vec<ProgressiveTile<'a>>,
+    ) -> ProgressiveRegion<'a> {
+        ProgressiveRegion {
+            tile_size: 0x40,
+            rects: vec![RfxRectangle {
+                x: 0,
+                y: 0,
+                width: 64,
+                height: 64,
+            }],
+            quant_vals,
+            quant_prog_vals,
+            flags: 0,
+            tiles,
+        }
+    }
+
+    fn minimal_progressive_stream(include_context: bool) -> Vec<u8> {
+        progressive_stream(include_context, single_tile_region(vec![], vec![], vec![]))
     }
 
     #[test]
@@ -2278,60 +2271,57 @@ mod tests {
         encoded
     }
 
-    /// Build a stream carrying a single TILE_SIMPLE at (0, 0) with the given flags.
+    /// Stream carrying one TILE_SIMPLE at (0, 0) with the given tile flags.
     fn simple_tile_stream(quant: ComponentCodecQuant, component_data: &[u8], tile_flags: u8) -> Vec<u8> {
-        use ironrdp_pdu::codecs::rfx::RfxRectangle;
-        use ironrdp_pdu::codecs::rfx::progressive::{
-            ProgressiveBlock, ProgressiveContextPdu, ProgressiveFrameBeginPdu, ProgressiveFrameEndPdu,
-            ProgressiveRegion, ProgressiveSyncPdu, ProgressiveTile, TileSimple, encode_progressive_stream,
+        let tile = ProgressiveTile::Simple(TileSimple {
+            quant_idx_y: 0,
+            quant_idx_cb: 0,
+            quant_idx_cr: 0,
+            x_idx: 0,
+            y_idx: 0,
+            flags: tile_flags,
+            y_data: component_data,
+            cb_data: component_data,
+            cr_data: component_data,
+            tail_data: &[],
+        });
+
+        progressive_stream(true, single_tile_region(vec![quant], vec![], vec![tile]))
+    }
+
+    /// Stream carrying one TILE_FIRST at (0, 0) at progressive quality index 0.
+    fn first_tile_stream(
+        quant: ComponentCodecQuant,
+        prog_quant: ComponentCodecQuant,
+        component_data: &[u8],
+        tile_flags: u8,
+    ) -> Vec<u8> {
+        let tile = ProgressiveTile::First(TileFirst {
+            quant_idx_y: 0,
+            quant_idx_cb: 0,
+            quant_idx_cr: 0,
+            x_idx: 0,
+            y_idx: 0,
+            flags: tile_flags,
+            quality: 0,
+            y_data: component_data,
+            cb_data: component_data,
+            cr_data: component_data,
+            tail_data: &[],
+        });
+        let prog = ProgressiveCodecQuant {
+            quality: 0,
+            y_quant: prog_quant,
+            cb_quant: prog_quant,
+            cr_quant: prog_quant,
         };
 
-        let region = ProgressiveRegion {
-            tile_size: 0x40,
-            rects: vec![RfxRectangle {
-                x: 0,
-                y: 0,
-                width: 64,
-                height: 64,
-            }],
-            quant_vals: vec![quant],
-            quant_prog_vals: vec![],
-            flags: 0,
-            tiles: vec![ProgressiveTile::Simple(TileSimple {
-                quant_idx_y: 0,
-                quant_idx_cb: 0,
-                quant_idx_cr: 0,
-                x_idx: 0,
-                y_idx: 0,
-                flags: tile_flags,
-                y_data: component_data,
-                cb_data: component_data,
-                cr_data: component_data,
-                tail_data: &[],
-            })],
-        };
-
-        let blocks = vec![
-            ProgressiveBlock::Sync(ProgressiveSyncPdu),
-            ProgressiveBlock::Context(ProgressiveContextPdu {
-                context_id: 0,
-                tile_size: 0x0040,
-                flags: 0,
-            }),
-            ProgressiveBlock::FrameBegin(ProgressiveFrameBeginPdu {
-                frame_index: 0,
-                region_count: 1,
-            }),
-            ProgressiveBlock::Region(region),
-            ProgressiveBlock::FrameEnd(ProgressiveFrameEndPdu),
-        ];
-
-        encode_progressive_stream(&blocks).expect("progressive stream encoding should succeed")
+        progressive_stream(true, single_tile_region(vec![quant], vec![prog], vec![tile]))
     }
 
     #[test]
     fn difference_tile_accumulates_into_retained_coefficients() {
-        // MS-RDPRFX 3.1.8.1.7.1: a tile with RFX_TILE_DIFFERENCE set carries
+        // MS-RDPEGFX 3.3.8.2.1.1: a tile with RFX_TILE_DIFFERENCE set carries
         // deltas against the coefficients retained for the same tile position.
         let base_quant = uniform_quant(6);
         let prog_quant = ComponentCodecQuant::LOSSLESS;
@@ -2363,9 +2353,7 @@ mod tests {
         assert!(!tile.is_difference);
         let retained = tile.coefficients;
         assert_eq!(retained[0][0], 100);
-        assert_eq!(retained[0][1], -40);
         assert_eq!(retained[0][4032], 25);
-        assert_eq!(retained[0][4095], 25);
 
         tile.decode_first_difference(
             [&difference_data; 3],
@@ -2380,9 +2368,7 @@ mod tests {
         assert!(tile.is_difference);
         assert_eq!(tile.pass, 1);
         assert_eq!(tile.coefficients[0][0], 70);
-        assert_eq!(tile.coefficients[0][1], -25);
         assert_eq!(tile.coefficients[0][4032], 30);
-        assert_eq!(tile.coefficients[0][4095], 30);
 
         // The whole buffer accumulated, not just the positions checked above.
         let mut expected = TileState::new();
@@ -2407,12 +2393,15 @@ mod tests {
             for (i, ((accumulated, retained), delta)) in
                 accumulated.iter().zip(retained.iter()).zip(delta.iter()).enumerate()
             {
-                assert_eq!(*accumulated, retained + delta, "component {component}, coefficient {i}");
+                assert_eq!(
+                    i32::from(*accumulated),
+                    i32::from(*retained) + i32::from(*delta),
+                    "component {component}, coefficient {i}"
+                );
             }
         }
 
-        // The DAS state describes the incoming deltas, which is what the
-        // upgrade passes refining this transmission are encoded against.
+        // The DAS state describes the deltas, which is what upgrade passes refine.
         assert_eq!(tile.sign[0][0], SIGN_NEGATIVE);
         assert_eq!(tile.sign[0][1], SIGN_POSITIVE);
     }
@@ -2477,6 +2466,38 @@ mod tests {
     }
 
     #[test]
+    fn original_tile_decode_ignores_retained_coefficients() {
+        // MS-RDPEGFX 3.3.8.2.1: an original tile is zeroed in the current frame
+        // before the decoded coefficients are added. A stream that stops short
+        // of the whole tile must therefore not leave the previous values behind.
+        let base_quant = uniform_quant(6);
+        let prog_quant = ComponentCodecQuant::LOSSLESS;
+
+        let mut dense = [0i16; COEFFICIENTS_PER_COMPONENT];
+        for (i, coefficient) in dense.iter_mut().enumerate() {
+            *coefficient = i16::try_from(i % 97).expect("value fits in i16") - 48;
+        }
+        let dense_data = rlgr_encode_component(&dense);
+        let truncated = &dense_data[..dense_data.len() / 4];
+
+        let mut reused = TileState::new();
+        reused
+            .decode_first([&dense_data; 3], [&base_quant; 3], [prog_quant; 3], [0; 3], 0xFF, false)
+            .expect("dense first-pass decoding should succeed");
+        reused
+            .decode_first([truncated; 3], [&base_quant; 3], [prog_quant; 3], [0; 3], 0xFF, false)
+            .expect("truncated first-pass decoding should succeed");
+
+        let mut fresh = TileState::new();
+        fresh
+            .decode_first([truncated; 3], [&base_quant; 3], [prog_quant; 3], [0; 3], 0xFF, false)
+            .expect("truncated first-pass decoding should succeed");
+
+        assert_eq!(reused.coefficients, fresh.coefficients);
+        assert_eq!(reused.sign, fresh.sign);
+    }
+
+    #[test]
     fn difference_tile_on_untouched_tile_matches_absolute_tile() {
         // The first tile of a surface has zeroed coefficients, so a difference
         // tile arriving there reconstructs the same values as an absolute one.
@@ -2524,6 +2545,87 @@ mod tests {
     }
 
     #[test]
+    fn difference_tile_accumulates_with_reduce_extrapolate() {
+        // The extrapolate variant moves LL3 to offset 4015 and resizes every
+        // band, so the accumulation is exercised against that layout too.
+        let base_quant = uniform_quant(6);
+        let prog_quant = ComponentCodecQuant::LOSSLESS;
+
+        let mut absolute = [0i16; COEFFICIENTS_PER_COMPONENT];
+        absolute[0] = 100;
+        absolute[ll3_offset(true)] = 25;
+
+        let mut difference = [0i16; COEFFICIENTS_PER_COMPONENT];
+        difference[0] = -30;
+        difference[ll3_offset(true)] = 5;
+
+        let absolute_data = rlgr_encode_component(&absolute);
+        let difference_data = rlgr_encode_component(&difference);
+
+        let mut tile = TileState::new();
+        tile.decode_first(
+            [&absolute_data; 3],
+            [&base_quant; 3],
+            [prog_quant; 3],
+            [0; 3],
+            0xFF,
+            true,
+        )
+        .expect("original first-pass decoding should succeed");
+        tile.decode_first_difference(
+            [&difference_data; 3],
+            [&base_quant; 3],
+            [prog_quant; 3],
+            [0; 3],
+            0xFF,
+            true,
+        )
+        .expect("difference first-pass decoding should succeed");
+
+        assert_eq!(tile.coefficients[0][0], 70);
+        assert_eq!(tile.coefficients[0][ll3_offset(true)], 30);
+        assert_eq!(tile.coefficients[0][COEFFICIENTS_PER_COMPONENT - 1], 30);
+    }
+
+    #[test]
+    fn difference_tile_after_upgrade_accumulates_onto_the_upgraded_state() {
+        // A new first-pass tile clears the progressive state but, when it is a
+        // difference tile, keeps the coefficients the upgrade passes produced.
+        let base_quant = uniform_quant(6);
+        let mut prog_quant = ComponentCodecQuant::LOSSLESS;
+        prog_quant.ll3 = 1;
+
+        let mut absolute = [0i16; COEFFICIENTS_PER_COMPONENT];
+        absolute[4032] = 25;
+        let mut difference = [0i16; COEFFICIENTS_PER_COMPONENT];
+        difference[4032] = 5;
+
+        let absolute_data = rlgr_encode_component(&absolute);
+        let difference_data = rlgr_encode_component(&difference);
+
+        let mut tile = TileState::new();
+        tile.decode_first([&absolute_data; 3], [&base_quant; 3], [prog_quant; 3], [0; 3], 0, false)
+            .expect("original first-pass decoding should succeed");
+        tile.decode_upgrade([&[]; 3], [&[0xFFu8; 8]; 3], [ComponentCodecQuant::LOSSLESS; 3], 0)
+            .expect("upgrade decoding should succeed");
+        assert_eq!(tile.pass, 2);
+        assert_eq!(tile.coefficients[0][4032], 51);
+
+        tile.decode_first_difference(
+            [&difference_data; 3],
+            [&base_quant; 3],
+            [ComponentCodecQuant::LOSSLESS; 3],
+            [0; 3],
+            0xFF,
+            false,
+        )
+        .expect("difference first-pass decoding should succeed");
+
+        assert_eq!(tile.pass, 1);
+        assert_eq!(tile.coefficients[0][4032], 56);
+    }
+
+    #[test]
     fn upgrade_pass_refines_accumulated_difference_coefficients() {
         // An upgrade pass following a difference tile must refine the
         // accumulated coefficients, not the deltas that produced them.
@@ -2566,12 +2668,9 @@ mod tests {
         assert_eq!(tile.coefficients[0][4095], 61);
     }
 
-    #[test]
-    fn decoder_accumulates_difference_tiles_signalled_on_the_wire() {
-        use ironrdp_pdu::codecs::rfx::progressive::FLAG_TILE_DIFFERENCE;
-
-        let quant = uniform_quant(6);
-
+    /// Coefficients used by the end-to-end wire tests: an original tile, a
+    /// difference tile, and the absolute tile the two sum to.
+    fn wire_test_coefficients() -> [[i16; COEFFICIENTS_PER_COMPONENT]; 3] {
         let mut absolute = [0i16; COEFFICIENTS_PER_COMPONENT];
         absolute[0] = 100;
         absolute[1] = -40;
@@ -2587,16 +2686,17 @@ mod tests {
             *summed = absolute + difference;
         }
 
-        let absolute_data = rlgr_encode_component(&absolute);
-        let difference_data = rlgr_encode_component(&difference);
-        let summed_data = rlgr_encode_component(&summed);
+        [absolute, difference, summed]
+    }
 
-        let absolute_stream = simple_tile_stream(quant, &absolute_data, 0);
-        let difference_stream = simple_tile_stream(quant, &difference_data, FLAG_TILE_DIFFERENCE);
-        let replacement_stream = simple_tile_stream(quant, &difference_data, 0);
-        let summed_stream = simple_tile_stream(quant, &summed_data, 0);
+    #[test]
+    fn decoder_accumulates_difference_tiles_signalled_on_the_wire() {
+        let quant = uniform_quant(6);
+        let [absolute, difference, summed] = wire_test_coefficients();
+        let absolute_stream = simple_tile_stream(quant, &rlgr_encode_component(&absolute), 0);
+        let difference_stream = simple_tile_stream(quant, &rlgr_encode_component(&difference), FLAG_TILE_DIFFERENCE);
+        let summed_stream = simple_tile_stream(quant, &rlgr_encode_component(&summed), 0);
 
-        // Absolute tile, then the same payload flagged as a difference.
         let mut decoder = ProgressiveDecoder::new();
         decoder
             .decode_bitmap(1, 0, 64, 64, &absolute_stream)
@@ -2611,45 +2711,86 @@ mod tests {
             .expect("the tile should have been created");
         assert!(tile.is_difference);
         assert_eq!(tile.coefficients[0][0], 70);
-        assert_eq!(tile.coefficients[0][1], -25);
         assert_eq!(tile.coefficients[0][4032], 30);
 
-        // Accumulating the delta renders the same image as one absolute tile
-        // carrying the summed coefficients.
+        // Accumulating renders the same image as one original tile carrying the
+        // summed coefficients.
         let mut summed_decoder = ProgressiveDecoder::new();
         let summed_tiles = summed_decoder
             .decode_bitmap(1, 0, 64, 64, &summed_stream)
             .expect("summed tile should decode");
-        assert_eq!(accumulated.len(), 1);
-        assert_eq!(summed_tiles.len(), 1);
         assert_eq!(accumulated[0].pixels, summed_tiles[0].pixels);
+    }
 
-        // Without the flag the same payload replaces, as it always has.
-        let mut replacing_decoder = ProgressiveDecoder::new();
-        replacing_decoder
+    #[test]
+    fn decoder_replaces_when_the_difference_flag_is_clear() {
+        let quant = uniform_quant(6);
+        let [absolute, difference, _] = wire_test_coefficients();
+        let absolute_stream = simple_tile_stream(quant, &rlgr_encode_component(&absolute), 0);
+        let replacement_stream = simple_tile_stream(quant, &rlgr_encode_component(&difference), 0);
+
+        let mut decoder = ProgressiveDecoder::new();
+        decoder
             .decode_bitmap(1, 0, 64, 64, &absolute_stream)
             .expect("absolute tile should decode");
-        let replaced = replacing_decoder
+        let replaced = decoder
             .decode_bitmap(1, 0, 64, 64, &replacement_stream)
             .expect("replacement tile should decode");
 
-        let replaced_tile = replacing_decoder.contexts[&(1, 0)]
+        let tile = decoder.contexts[&(1, 0)]
             .surface
             .get(0, 0)
             .expect("the tile should have been created");
-        assert!(!replaced_tile.is_difference);
-        assert_eq!(replaced_tile.coefficients[0][0], -30);
-        assert_eq!(replaced_tile.coefficients[0][1], 15);
-        assert_eq!(replaced_tile.coefficients[0][4032], 5);
+        assert!(!tile.is_difference);
+        assert_eq!(tile.coefficients[0][0], -30);
+        assert_eq!(tile.coefficients[0][4032], 5);
 
+        // Identical to decoding that tile on its own.
         let mut standalone_decoder = ProgressiveDecoder::new();
         let standalone = standalone_decoder
             .decode_bitmap(1, 0, 64, 64, &replacement_stream)
             .expect("standalone tile should decode");
         assert_eq!(replaced[0].pixels, standalone[0].pixels);
+    }
 
-        // The flag changes what is rendered, which is the whole point.
-        assert_ne!(accumulated[0].pixels, replaced[0].pixels);
+    #[test]
+    fn decoder_honours_the_difference_flag_on_tile_first() {
+        // TILE_FIRST carries the same flag byte as TILE_SIMPLE and is dispatched
+        // separately, so it needs its own end-to-end coverage.
+        let quant = uniform_quant(6);
+        let prog_quant = ComponentCodecQuant::LOSSLESS;
+        let [absolute, difference, summed] = wire_test_coefficients();
+        let absolute_data = rlgr_encode_component(&absolute);
+        let difference_data = rlgr_encode_component(&difference);
+        let summed_data = rlgr_encode_component(&summed);
+
+        let mut decoder = ProgressiveDecoder::new();
+        decoder
+            .decode_bitmap(1, 0, 64, 64, &first_tile_stream(quant, prog_quant, &absolute_data, 0))
+            .expect("original tile should decode");
+        let accumulated = decoder
+            .decode_bitmap(
+                1,
+                0,
+                64,
+                64,
+                &first_tile_stream(quant, prog_quant, &difference_data, FLAG_TILE_DIFFERENCE),
+            )
+            .expect("difference tile should decode");
+
+        let tile = decoder.contexts[&(1, 0)]
+            .surface
+            .get(0, 0)
+            .expect("the tile should have been created");
+        assert!(tile.is_difference);
+        assert_eq!(tile.coefficients[0][0], 70);
+        assert_eq!(tile.coefficients[0][4032], 30);
+
+        let mut summed_decoder = ProgressiveDecoder::new();
+        let summed_tiles = summed_decoder
+            .decode_bitmap(1, 0, 64, 64, &first_tile_stream(quant, prog_quant, &summed_data, 0))
+            .expect("summed tile should decode");
+        assert_eq!(accumulated[0].pixels, summed_tiles[0].pixels);
     }
 
     #[test]

--- a/crates/ironrdp-graphics/src/progressive.rs
+++ b/crates/ironrdp-graphics/src/progressive.rs
@@ -20,7 +20,10 @@
 //! - [`rgba_to_ycbcr`]: ITU-R BT.601 color space conversion
 //!
 //! ## State management
-//! - [`TileState`]: per-tile coefficient and DAS sign storage (~37 KB per tile)
+//! - [`TileState`]: per-tile coefficient and DAS sign storage (~37 KB per tile).
+//!   A first-pass tile whose `RFX_TILE_DIFFERENCE` flag is set carries deltas
+//!   against that storage rather than absolute coefficients, and is decoded
+//!   with [`TileState::decode_first_difference`]
 //! - [`SurfaceTiles`]: lazily-allocated tile grid for a surface
 //! - [`ProgressiveDecoder`]: high-level decoder maintaining per-context state,
 //!   wired into the EGFX `WireToSurface2Pdu` path
@@ -68,6 +71,11 @@ pub const SIGN_NEGATIVE: i8 = -1;
 ///
 /// Performs: RLGR1 decode -> LL3 delta decode -> progressive dequantization
 /// -> sign capture -> base dequantization.
+///
+/// This decodes an original tile, whose coefficients are absolute. A difference
+/// tile must accumulate before base dequantization, so it goes through
+/// [`TileState::decode_first_difference`], which keeps the retained
+/// coefficients in the `DecDwtQ` domain.
 ///
 /// # Arguments
 /// - `data`: RLGR1-encoded coefficient stream
@@ -799,7 +807,8 @@ pub struct TileState {
     pub base_quant: [ComponentCodecQuant; 3],
     /// Progressive pass counter (0 = no data, 1 = first pass complete, 2+ = upgrade).
     pub pass: u16,
-    /// Whether the tile was encoded as a difference tile.
+    /// Whether the most recent first-pass tile carried coefficient differences
+    /// (`RFX_TILE_DIFFERENCE`) rather than absolute values.
     pub is_difference: bool,
     /// Last progressive quality byte (0xFF = full quality).
     pub quality: u8,
@@ -834,11 +843,14 @@ impl TileState {
         }
     }
 
-    /// Decode a first-pass tile (TILE_SIMPLE or TILE_FIRST).
+    /// Decode a first-pass tile (TILE_SIMPLE or TILE_FIRST) carrying absolute
+    /// coefficients, that is one whose `RFX_TILE_DIFFERENCE` flag is clear.
     ///
     /// Resets this tile's state and decodes three components from RLGR1 data.
     /// After this call, `coefficients` hold base-quantized DWT values for
     /// progressive upgrades. Base dequantization occurs during reconstruction.
+    ///
+    /// Use [`TileState::decode_first_difference`] when the flag is set.
     ///
     /// # Arguments
     /// - `component_data`: RLGR1-encoded data for [Y, Cb, Cr]
@@ -858,13 +870,14 @@ impl TileState {
         quality: u8,
         use_reduce_extrapolate: bool,
     ) -> Result<(), RlgrError> {
-        self.pass = 1;
-        self.quality = quality;
-        self.quant_idx = quant_idx;
-        self.base_quant = [*base_quants[0], *base_quants[1], *base_quants[2]];
-        self.use_reduce_extrapolate = use_reduce_extrapolate;
-        self.is_difference = false;
-        self.prog_quant = prog_quants;
+        self.begin_first_pass(
+            base_quants,
+            prog_quants,
+            quant_idx,
+            quality,
+            use_reduce_extrapolate,
+            false,
+        );
 
         for c in 0..3 {
             decode_first_pass_to_dwtq(
@@ -877,6 +890,90 @@ impl TileState {
         }
 
         Ok(())
+    }
+
+    /// Decode a first-pass tile (TILE_SIMPLE or TILE_FIRST) whose
+    /// `RFX_TILE_DIFFERENCE` flag is set.
+    ///
+    /// Such a tile carries the difference of the DWT coefficients for the same
+    /// tile between the current and the previous frame, so the decoded values
+    /// are added to the retained ones rather than replacing them:
+    /// `DecDwtQ = DecDwtQ + DecProgQ * PQF`. See MS-RDPEGFX sections
+    /// 2.2.4.2.1.5.3, 2.2.4.2.1.5.4 and 3.3.8.2.1.1.
+    ///
+    /// Takes the same arguments as [`TileState::decode_first`], and leaves the
+    /// tile in the same shape: the accumulated coefficients stay base-quantized
+    /// and are dequantized during reconstruction, and further upgrade passes
+    /// refine them exactly as they refine an absolute tile.
+    ///
+    /// The DAS sign state describes the incoming differences rather than the
+    /// accumulated result, because it is what the upgrade passes refining this
+    /// very transmission are encoded against.
+    ///
+    /// A tile that has not been decoded yet holds zeroed coefficients, so a
+    /// difference tile arriving as the first tile of a surface reconstructs to
+    /// the same values as an absolute one.
+    ///
+    /// # Errors
+    /// Returns `RlgrError` if any component's RLGR decode fails. Components
+    /// decoded before the failure keep their accumulated values; the failing
+    /// component keeps the values it had.
+    pub fn decode_first_difference(
+        &mut self,
+        component_data: [&[u8]; 3],
+        base_quants: [&ComponentCodecQuant; 3],
+        prog_quants: [ComponentCodecQuant; 3],
+        quant_idx: [u8; 3],
+        quality: u8,
+        use_reduce_extrapolate: bool,
+    ) -> Result<(), RlgrError> {
+        self.begin_first_pass(
+            base_quants,
+            prog_quants,
+            quant_idx,
+            quality,
+            use_reduce_extrapolate,
+            true,
+        );
+
+        for c in 0..3 {
+            // Decoding into a scratch buffer keeps the retained coefficients
+            // intact when the RLGR stream turns out to be malformed.
+            let mut difference = [0i16; COEFFICIENTS_PER_COMPONENT];
+
+            decode_first_pass_to_dwtq(
+                component_data[c],
+                &prog_quants[c],
+                use_reduce_extrapolate,
+                &mut difference,
+                &mut self.sign[c],
+            )?;
+
+            for (coefficient, difference) in self.coefficients[c].iter_mut().zip(difference) {
+                *coefficient = clamp_i16(i32::from(*coefficient) + i32::from(difference));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Record the quantization and quality state a first-pass tile establishes.
+    fn begin_first_pass(
+        &mut self,
+        base_quants: [&ComponentCodecQuant; 3],
+        prog_quants: [ComponentCodecQuant; 3],
+        quant_idx: [u8; 3],
+        quality: u8,
+        use_reduce_extrapolate: bool,
+        is_difference: bool,
+    ) {
+        self.pass = 1;
+        self.quality = quality;
+        self.quant_idx = quant_idx;
+        self.base_quant = [*base_quants[0], *base_quants[1], *base_quants[2]];
+        self.use_reduce_extrapolate = use_reduce_extrapolate;
+        self.is_difference = is_difference;
+        self.prog_quant = prog_quants;
     }
 
     /// Decode an upgrade-pass tile (TILE_UPGRADE).
@@ -1349,14 +1446,30 @@ fn decode_tile_block(
             // TILE_SIMPLE uses lossless progressive quant (no progressive refinement)
             let prog = ComponentCodecQuant::LOSSLESS;
 
-            tile_state.decode_first(
-                [tile.y_data, tile.cb_data, tile.cr_data],
-                [&quant_vals[q_y], &quant_vals[q_cb], &quant_vals[q_cr]],
-                [prog, prog, prog],
-                [tile.quant_idx_y, tile.quant_idx_cb, tile.quant_idx_cr],
-                0xFF, // full quality
-                use_reduce_extrapolate,
-            )?;
+            let component_data = [tile.y_data, tile.cb_data, tile.cr_data];
+            let base_quants = [&quant_vals[q_y], &quant_vals[q_cb], &quant_vals[q_cr]];
+            let quant_idx = [tile.quant_idx_y, tile.quant_idx_cb, tile.quant_idx_cr];
+            let quality = 0xFF; // full quality
+
+            if tile.is_difference() {
+                tile_state.decode_first_difference(
+                    component_data,
+                    base_quants,
+                    [prog, prog, prog],
+                    quant_idx,
+                    quality,
+                    use_reduce_extrapolate,
+                )?;
+            } else {
+                tile_state.decode_first(
+                    component_data,
+                    base_quants,
+                    [prog, prog, prog],
+                    quant_idx,
+                    quality,
+                    use_reduce_extrapolate,
+                )?;
+            }
 
             let mut pixels = vec![0u8; 64 * 64 * 4];
             tile_state.reconstruct_to_rgba(&mut pixels);
@@ -1392,14 +1505,30 @@ fn decode_tile_block(
             }
             let pq = &prog_quant_vals[pq_idx];
 
-            tile_state.decode_first(
-                [tile.y_data, tile.cb_data, tile.cr_data],
-                [&quant_vals[q_y], &quant_vals[q_cb], &quant_vals[q_cr]],
-                [pq.y_quant, pq.cb_quant, pq.cr_quant],
-                [tile.quant_idx_y, tile.quant_idx_cb, tile.quant_idx_cr],
-                tile.quality,
-                use_reduce_extrapolate,
-            )?;
+            let component_data = [tile.y_data, tile.cb_data, tile.cr_data];
+            let base_quants = [&quant_vals[q_y], &quant_vals[q_cb], &quant_vals[q_cr]];
+            let prog_quants = [pq.y_quant, pq.cb_quant, pq.cr_quant];
+            let quant_idx = [tile.quant_idx_y, tile.quant_idx_cb, tile.quant_idx_cr];
+
+            if tile.is_difference() {
+                tile_state.decode_first_difference(
+                    component_data,
+                    base_quants,
+                    prog_quants,
+                    quant_idx,
+                    tile.quality,
+                    use_reduce_extrapolate,
+                )?;
+            } else {
+                tile_state.decode_first(
+                    component_data,
+                    base_quants,
+                    prog_quants,
+                    quant_idx,
+                    tile.quality,
+                    use_reduce_extrapolate,
+                )?;
+            }
 
             let mut pixels = vec![0u8; 64 * 64 * 4];
             tile_state.reconstruct_to_rgba(&mut pixels);
@@ -2124,6 +2253,403 @@ mod tests {
         // dequantization, so the factor-5 and BitPos-1 scales cancel exactly.
         assert_eq!(coefficients[0], 7);
         assert_eq!(coefficients[1], -7);
+    }
+
+    fn uniform_quant(value: u8) -> ComponentCodecQuant {
+        ComponentCodecQuant {
+            ll3: value,
+            hl3: value,
+            lh3: value,
+            hh3: value,
+            hl2: value,
+            lh2: value,
+            hh2: value,
+            hl1: value,
+            lh1: value,
+            hh1: value,
+        }
+    }
+
+    fn rlgr_encode_component(coefficients: &[i16; COEFFICIENTS_PER_COMPONENT]) -> Vec<u8> {
+        let mut encoded = vec![0u8; 16384];
+        let len = crate::rlgr::encode(EntropyAlgorithm::Rlgr1, coefficients, &mut encoded)
+            .expect("RLGR encoding should succeed");
+        encoded.truncate(len);
+        encoded
+    }
+
+    /// Build a stream carrying a single TILE_SIMPLE at (0, 0) with the given flags.
+    fn simple_tile_stream(quant: ComponentCodecQuant, component_data: &[u8], tile_flags: u8) -> Vec<u8> {
+        use ironrdp_pdu::codecs::rfx::RfxRectangle;
+        use ironrdp_pdu::codecs::rfx::progressive::{
+            ProgressiveBlock, ProgressiveContextPdu, ProgressiveFrameBeginPdu, ProgressiveFrameEndPdu,
+            ProgressiveRegion, ProgressiveSyncPdu, ProgressiveTile, TileSimple, encode_progressive_stream,
+        };
+
+        let region = ProgressiveRegion {
+            tile_size: 0x40,
+            rects: vec![RfxRectangle {
+                x: 0,
+                y: 0,
+                width: 64,
+                height: 64,
+            }],
+            quant_vals: vec![quant],
+            quant_prog_vals: vec![],
+            flags: 0,
+            tiles: vec![ProgressiveTile::Simple(TileSimple {
+                quant_idx_y: 0,
+                quant_idx_cb: 0,
+                quant_idx_cr: 0,
+                x_idx: 0,
+                y_idx: 0,
+                flags: tile_flags,
+                y_data: component_data,
+                cb_data: component_data,
+                cr_data: component_data,
+                tail_data: &[],
+            })],
+        };
+
+        let blocks = vec![
+            ProgressiveBlock::Sync(ProgressiveSyncPdu),
+            ProgressiveBlock::Context(ProgressiveContextPdu {
+                context_id: 0,
+                tile_size: 0x0040,
+                flags: 0,
+            }),
+            ProgressiveBlock::FrameBegin(ProgressiveFrameBeginPdu {
+                frame_index: 0,
+                region_count: 1,
+            }),
+            ProgressiveBlock::Region(region),
+            ProgressiveBlock::FrameEnd(ProgressiveFrameEndPdu),
+        ];
+
+        encode_progressive_stream(&blocks).expect("progressive stream encoding should succeed")
+    }
+
+    #[test]
+    fn difference_tile_accumulates_into_retained_coefficients() {
+        // MS-RDPRFX 3.1.8.1.7.1: a tile with RFX_TILE_DIFFERENCE set carries
+        // deltas against the coefficients retained for the same tile position.
+        let base_quant = uniform_quant(6);
+        let prog_quant = ComponentCodecQuant::LOSSLESS;
+
+        let mut absolute = [0i16; COEFFICIENTS_PER_COMPONENT];
+        absolute[0] = 100; // HL1
+        absolute[1] = -40; // HL1
+        absolute[4032] = 25; // LL3, delta-coded across the whole subband
+
+        let mut difference = [0i16; COEFFICIENTS_PER_COMPONENT];
+        difference[0] = -30;
+        difference[1] = 15;
+        difference[4032] = 5;
+
+        let absolute_data = rlgr_encode_component(&absolute);
+        let difference_data = rlgr_encode_component(&difference);
+
+        let mut tile = TileState::new();
+        tile.decode_first(
+            [&absolute_data; 3],
+            [&base_quant; 3],
+            [prog_quant; 3],
+            [0; 3],
+            0xFF,
+            false,
+        )
+        .expect("absolute first-pass decoding should succeed");
+
+        assert!(!tile.is_difference);
+        let retained = tile.coefficients;
+        assert_eq!(retained[0][0], 100);
+        assert_eq!(retained[0][1], -40);
+        assert_eq!(retained[0][4032], 25);
+        assert_eq!(retained[0][4095], 25);
+
+        tile.decode_first_difference(
+            [&difference_data; 3],
+            [&base_quant; 3],
+            [prog_quant; 3],
+            [0; 3],
+            0xFF,
+            false,
+        )
+        .expect("difference first-pass decoding should succeed");
+
+        assert!(tile.is_difference);
+        assert_eq!(tile.pass, 1);
+        assert_eq!(tile.coefficients[0][0], 70);
+        assert_eq!(tile.coefficients[0][1], -25);
+        assert_eq!(tile.coefficients[0][4032], 30);
+        assert_eq!(tile.coefficients[0][4095], 30);
+
+        // The whole buffer accumulated, not just the positions checked above.
+        let mut expected = TileState::new();
+        expected
+            .decode_first(
+                [&difference_data; 3],
+                [&base_quant; 3],
+                [prog_quant; 3],
+                [0; 3],
+                0xFF,
+                false,
+            )
+            .expect("reference decoding should succeed");
+
+        for (component, ((accumulated, retained), delta)) in tile
+            .coefficients
+            .iter()
+            .zip(retained.iter())
+            .zip(expected.coefficients.iter())
+            .enumerate()
+        {
+            for (i, ((accumulated, retained), delta)) in
+                accumulated.iter().zip(retained.iter()).zip(delta.iter()).enumerate()
+            {
+                assert_eq!(*accumulated, retained + delta, "component {component}, coefficient {i}");
+            }
+        }
+
+        // The DAS state describes the incoming deltas, which is what the
+        // upgrade passes refining this transmission are encoded against.
+        assert_eq!(tile.sign[0][0], SIGN_NEGATIVE);
+        assert_eq!(tile.sign[0][1], SIGN_POSITIVE);
+    }
+
+    #[test]
+    fn non_difference_tile_replaces_retained_coefficients() {
+        let base_quant = uniform_quant(6);
+        let prog_quant = ComponentCodecQuant::LOSSLESS;
+
+        let mut absolute = [0i16; COEFFICIENTS_PER_COMPONENT];
+        absolute[0] = 100;
+        absolute[1] = -40;
+        absolute[4032] = 25;
+
+        let mut replacement = [0i16; COEFFICIENTS_PER_COMPONENT];
+        replacement[0] = -30;
+        replacement[1] = 15;
+        replacement[4032] = 5;
+
+        let absolute_data = rlgr_encode_component(&absolute);
+        let replacement_data = rlgr_encode_component(&replacement);
+
+        let mut tile = TileState::new();
+        tile.decode_first(
+            [&absolute_data; 3],
+            [&base_quant; 3],
+            [prog_quant; 3],
+            [0; 3],
+            0xFF,
+            false,
+        )
+        .expect("absolute first-pass decoding should succeed");
+        tile.decode_first(
+            [&replacement_data; 3],
+            [&base_quant; 3],
+            [prog_quant; 3],
+            [0; 3],
+            0xFF,
+            false,
+        )
+        .expect("second absolute first-pass decoding should succeed");
+
+        assert!(!tile.is_difference);
+        assert_eq!(tile.coefficients[0][0], -30);
+        assert_eq!(tile.coefficients[0][1], 15);
+        assert_eq!(tile.coefficients[0][4032], 5);
+
+        // Identical to decoding the second tile on its own.
+        let mut fresh = TileState::new();
+        fresh
+            .decode_first(
+                [&replacement_data; 3],
+                [&base_quant; 3],
+                [prog_quant; 3],
+                [0; 3],
+                0xFF,
+                false,
+            )
+            .expect("fresh first-pass decoding should succeed");
+        assert_eq!(tile.coefficients, fresh.coefficients);
+        assert_eq!(tile.sign, fresh.sign);
+    }
+
+    #[test]
+    fn difference_tile_on_untouched_tile_matches_absolute_tile() {
+        // The first tile of a surface has zeroed coefficients, so a difference
+        // tile arriving there reconstructs the same values as an absolute one.
+        let base_quant = uniform_quant(6);
+        let prog_quant = ComponentCodecQuant::LOSSLESS;
+
+        let mut coefficients = [0i16; COEFFICIENTS_PER_COMPONENT];
+        coefficients[0] = 100;
+        coefficients[1] = -40;
+        coefficients[4032] = 25;
+        let data = rlgr_encode_component(&coefficients);
+
+        let mut difference_tile = TileState::new();
+        difference_tile
+            .decode_first_difference([&data; 3], [&base_quant; 3], [prog_quant; 3], [0; 3], 0xFF, false)
+            .expect("difference first-pass decoding should succeed");
+
+        let mut absolute_tile = TileState::new();
+        absolute_tile
+            .decode_first([&data; 3], [&base_quant; 3], [prog_quant; 3], [0; 3], 0xFF, false)
+            .expect("absolute first-pass decoding should succeed");
+
+        assert_eq!(difference_tile.coefficients, absolute_tile.coefficients);
+        assert_eq!(difference_tile.sign, absolute_tile.sign);
+    }
+
+    #[test]
+    fn difference_tile_accumulation_saturates() {
+        let base_quant = uniform_quant(6);
+        let prog_quant = ComponentCodecQuant::LOSSLESS;
+
+        let mut extreme = [0i16; COEFFICIENTS_PER_COMPONENT];
+        extreme[0] = 30000;
+        extreme[1] = -30000;
+        let data = rlgr_encode_component(&extreme);
+
+        let mut tile = TileState::new();
+        tile.decode_first([&data; 3], [&base_quant; 3], [prog_quant; 3], [0; 3], 0xFF, false)
+            .expect("absolute first-pass decoding should succeed");
+        tile.decode_first_difference([&data; 3], [&base_quant; 3], [prog_quant; 3], [0; 3], 0xFF, false)
+            .expect("difference first-pass decoding should succeed");
+
+        assert_eq!(tile.coefficients[0][0], i16::MAX);
+        assert_eq!(tile.coefficients[0][1], i16::MIN);
+    }
+
+    #[test]
+    fn upgrade_pass_refines_accumulated_difference_coefficients() {
+        // An upgrade pass following a difference tile must refine the
+        // accumulated coefficients, not the deltas that produced them.
+        let base_quant = uniform_quant(6);
+        let mut prog_quant = ComponentCodecQuant::LOSSLESS;
+        prog_quant.ll3 = 1;
+
+        let mut absolute = [0i16; COEFFICIENTS_PER_COMPONENT];
+        absolute[4032] = 25;
+        let mut difference = [0i16; COEFFICIENTS_PER_COMPONENT];
+        difference[4032] = 5;
+
+        let absolute_data = rlgr_encode_component(&absolute);
+        let difference_data = rlgr_encode_component(&difference);
+
+        let mut tile = TileState::new();
+        tile.decode_first([&absolute_data; 3], [&base_quant; 3], [prog_quant; 3], [0; 3], 0, false)
+            .expect("absolute first-pass decoding should succeed");
+        tile.decode_first_difference(
+            [&difference_data; 3],
+            [&base_quant; 3],
+            [prog_quant; 3],
+            [0; 3],
+            0,
+            false,
+        )
+        .expect("difference first-pass decoding should succeed");
+
+        // BitPos 1 doubles both passes: (25 + 5) << 1.
+        assert_eq!(tile.coefficients[0][4032], 60);
+
+        // LL3 is always read from the raw stream, so this upgrade needs no SRL
+        // data: 64 one-bits, one per LL3 coefficient, at BitPos 0.
+        let raw_data = [0xFFu8; 8];
+        tile.decode_upgrade([&[]; 3], [&raw_data; 3], [ComponentCodecQuant::LOSSLESS; 3], 0)
+            .expect("upgrade decoding should succeed");
+
+        assert_eq!(tile.pass, 2);
+        assert_eq!(tile.coefficients[0][4032], 61);
+        assert_eq!(tile.coefficients[0][4095], 61);
+    }
+
+    #[test]
+    fn decoder_accumulates_difference_tiles_signalled_on_the_wire() {
+        use ironrdp_pdu::codecs::rfx::progressive::FLAG_TILE_DIFFERENCE;
+
+        let quant = uniform_quant(6);
+
+        let mut absolute = [0i16; COEFFICIENTS_PER_COMPONENT];
+        absolute[0] = 100;
+        absolute[1] = -40;
+        absolute[4032] = 25;
+
+        let mut difference = [0i16; COEFFICIENTS_PER_COMPONENT];
+        difference[0] = -30;
+        difference[1] = 15;
+        difference[4032] = 5;
+
+        let mut summed = [0i16; COEFFICIENTS_PER_COMPONENT];
+        for (summed, (absolute, difference)) in summed.iter_mut().zip(absolute.iter().zip(difference.iter())) {
+            *summed = absolute + difference;
+        }
+
+        let absolute_data = rlgr_encode_component(&absolute);
+        let difference_data = rlgr_encode_component(&difference);
+        let summed_data = rlgr_encode_component(&summed);
+
+        let absolute_stream = simple_tile_stream(quant, &absolute_data, 0);
+        let difference_stream = simple_tile_stream(quant, &difference_data, FLAG_TILE_DIFFERENCE);
+        let replacement_stream = simple_tile_stream(quant, &difference_data, 0);
+        let summed_stream = simple_tile_stream(quant, &summed_data, 0);
+
+        // Absolute tile, then the same payload flagged as a difference.
+        let mut decoder = ProgressiveDecoder::new();
+        decoder
+            .decode_bitmap(1, 0, 64, 64, &absolute_stream)
+            .expect("absolute tile should decode");
+        let accumulated = decoder
+            .decode_bitmap(1, 0, 64, 64, &difference_stream)
+            .expect("difference tile should decode");
+
+        let tile = decoder.contexts[&(1, 0)]
+            .surface
+            .get(0, 0)
+            .expect("the tile should have been created");
+        assert!(tile.is_difference);
+        assert_eq!(tile.coefficients[0][0], 70);
+        assert_eq!(tile.coefficients[0][1], -25);
+        assert_eq!(tile.coefficients[0][4032], 30);
+
+        // Accumulating the delta renders the same image as one absolute tile
+        // carrying the summed coefficients.
+        let mut summed_decoder = ProgressiveDecoder::new();
+        let summed_tiles = summed_decoder
+            .decode_bitmap(1, 0, 64, 64, &summed_stream)
+            .expect("summed tile should decode");
+        assert_eq!(accumulated.len(), 1);
+        assert_eq!(summed_tiles.len(), 1);
+        assert_eq!(accumulated[0].pixels, summed_tiles[0].pixels);
+
+        // Without the flag the same payload replaces, as it always has.
+        let mut replacing_decoder = ProgressiveDecoder::new();
+        replacing_decoder
+            .decode_bitmap(1, 0, 64, 64, &absolute_stream)
+            .expect("absolute tile should decode");
+        let replaced = replacing_decoder
+            .decode_bitmap(1, 0, 64, 64, &replacement_stream)
+            .expect("replacement tile should decode");
+
+        let replaced_tile = replacing_decoder.contexts[&(1, 0)]
+            .surface
+            .get(0, 0)
+            .expect("the tile should have been created");
+        assert!(!replaced_tile.is_difference);
+        assert_eq!(replaced_tile.coefficients[0][0], -30);
+        assert_eq!(replaced_tile.coefficients[0][1], 15);
+        assert_eq!(replaced_tile.coefficients[0][4032], 5);
+
+        let mut standalone_decoder = ProgressiveDecoder::new();
+        let standalone = standalone_decoder
+            .decode_bitmap(1, 0, 64, 64, &replacement_stream)
+            .expect("standalone tile should decode");
+        assert_eq!(replaced[0].pixels, standalone[0].pixels);
+
+        // The flag changes what is rendered, which is the whole point.
+        assert_ne!(accumulated[0].pixels, replaced[0].pixels);
     }
 
     #[test]

--- a/crates/ironrdp-pdu/src/codecs/rfx/progressive.rs
+++ b/crates/ironrdp-pdu/src/codecs/rfx/progressive.rs
@@ -446,6 +446,16 @@ impl Decode<'_> for ProgressiveContextPdu {
 // Tile blocks
 // ---------------------------------------------------------------------------
 
+/// Bit 0 of the tile flags: RFX_TILE_DIFFERENCE.
+///
+/// Indicates that the tile contains the compressed difference of the DWT
+/// coefficients for the same tile between the current frame and the previous
+/// frame, rather than absolute coefficients. Carried by TILE_SIMPLE and
+/// TILE_FIRST blocks; see MS-RDPEGFX sections 2.2.4.2.1.5.3 and 2.2.4.2.1.5.4.
+///
+/// The seven high bits of the flags field are reserved and ignored.
+pub const FLAG_TILE_DIFFERENCE: u8 = 0x01;
+
 /// TILE_SIMPLE: non-progressive full-quality tile (single pass).
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
@@ -466,6 +476,11 @@ impl TileSimple<'_> {
     const NAME: &'static str = "TileSimple";
     /// Fixed header: 3 quant idx + 2 x_idx + 2 y_idx + 1 flags + 4x2 lengths = 16 bytes.
     const HEADER_SIZE: usize = 3 + 2 + 2 + 1 + 8;
+
+    /// Whether this tile carries coefficient differences instead of absolute values.
+    pub fn is_difference(&self) -> bool {
+        self.flags & FLAG_TILE_DIFFERENCE != 0
+    }
 }
 
 impl Encode for TileSimple<'_> {
@@ -555,6 +570,11 @@ impl TileFirst<'_> {
     const NAME: &'static str = "TileFirst";
     /// Same as TileSimple + 1 byte for quality = 17 bytes.
     const HEADER_SIZE: usize = 3 + 2 + 2 + 1 + 1 + 8;
+
+    /// Whether this tile carries coefficient differences instead of absolute values.
+    pub fn is_difference(&self) -> bool {
+        self.flags & FLAG_TILE_DIFFERENCE != 0
+    }
 }
 
 impl Encode for TileFirst<'_> {
@@ -1184,6 +1204,64 @@ mod tests {
         assert_eq!(decoded.y_data, y_data);
         assert_eq!(decoded.cb_data, cb_data);
         assert_eq!(decoded.cr_data, cr_data);
+    }
+
+    #[test]
+    fn tile_difference_flag_survives_round_trip() {
+        let original = TileSimple {
+            quant_idx_y: 0,
+            quant_idx_cb: 0,
+            quant_idx_cr: 0,
+            x_idx: 1,
+            y_idx: 2,
+            flags: FLAG_TILE_DIFFERENCE,
+            y_data: &[1, 2, 3],
+            cb_data: &[4],
+            cr_data: &[5],
+            tail_data: &[],
+        };
+        let mut buf = vec![0u8; original.size()];
+        original.encode(&mut WriteCursor::new(&mut buf)).unwrap();
+        let decoded = TileSimple::decode(&mut ReadCursor::new(&buf)).unwrap();
+        assert_eq!(decoded.flags, FLAG_TILE_DIFFERENCE);
+        assert!(decoded.is_difference());
+
+        // The seven high bits are reserved and MUST be ignored by the decoder.
+        let mut reserved_bits_set = original.clone();
+        reserved_bits_set.flags = 0xFE;
+        let mut buf = vec![0u8; reserved_bits_set.size()];
+        reserved_bits_set.encode(&mut WriteCursor::new(&mut buf)).unwrap();
+        let decoded = TileSimple::decode(&mut ReadCursor::new(&buf)).unwrap();
+        assert!(!decoded.is_difference());
+    }
+
+    #[test]
+    fn tile_first_difference_flag_survives_round_trip() {
+        let original = TileFirst {
+            quant_idx_y: 0,
+            quant_idx_cb: 0,
+            quant_idx_cr: 0,
+            x_idx: 1,
+            y_idx: 2,
+            flags: FLAG_TILE_DIFFERENCE,
+            quality: 5,
+            y_data: &[1, 2, 3],
+            cb_data: &[4],
+            cr_data: &[5],
+            tail_data: &[],
+        };
+        let mut buf = vec![0u8; original.size()];
+        original.encode(&mut WriteCursor::new(&mut buf)).unwrap();
+        let decoded = TileFirst::decode(&mut ReadCursor::new(&buf)).unwrap();
+        assert_eq!(decoded.flags, FLAG_TILE_DIFFERENCE);
+        assert!(decoded.is_difference());
+
+        let mut absolute = original.clone();
+        absolute.flags = 0;
+        let mut buf = vec![0u8; absolute.size()];
+        absolute.encode(&mut WriteCursor::new(&mut buf)).unwrap();
+        let decoded = TileFirst::decode(&mut ReadCursor::new(&buf)).unwrap();
+        assert!(!decoded.is_difference());
     }
 
     #[test]

--- a/crates/ironrdp-pdu/src/codecs/rfx/progressive.rs
+++ b/crates/ironrdp-pdu/src/codecs/rfx/progressive.rs
@@ -1288,6 +1288,31 @@ mod tests {
         simple.encode(&mut WriteCursor::new(&mut buf)).unwrap();
         let decoded = TileSimple::decode(&mut ReadCursor::new(&buf)).unwrap();
         assert!(decoded.is_difference());
+
+        let mut first = TileFirst {
+            quant_idx_y: 0,
+            quant_idx_cb: 0,
+            quant_idx_cr: 0,
+            x_idx: 1,
+            y_idx: 2,
+            flags: 0xFE,
+            quality: 5,
+            y_data: &[1, 2, 3],
+            cb_data: &[4],
+            cr_data: &[5],
+            tail_data: &[],
+        };
+        let mut buf = vec![0u8; first.size()];
+        first.encode(&mut WriteCursor::new(&mut buf)).unwrap();
+        let decoded = TileFirst::decode(&mut ReadCursor::new(&buf)).unwrap();
+        assert_eq!(decoded.flags, 0xFE);
+        assert!(!decoded.is_difference());
+
+        first.flags = 0xFF;
+        let mut buf = vec![0u8; first.size()];
+        first.encode(&mut WriteCursor::new(&mut buf)).unwrap();
+        let decoded = TileFirst::decode(&mut ReadCursor::new(&buf)).unwrap();
+        assert!(decoded.is_difference());
     }
 
     #[test]

--- a/crates/ironrdp-pdu/src/codecs/rfx/progressive.rs
+++ b/crates/ironrdp-pdu/src/codecs/rfx/progressive.rs
@@ -446,14 +446,8 @@ impl Decode<'_> for ProgressiveContextPdu {
 // Tile blocks
 // ---------------------------------------------------------------------------
 
-/// Bit 0 of the tile flags: RFX_TILE_DIFFERENCE.
-///
-/// Indicates that the tile contains the compressed difference of the DWT
-/// coefficients for the same tile between the current frame and the previous
-/// frame, rather than absolute coefficients. Carried by TILE_SIMPLE and
-/// TILE_FIRST blocks; see MS-RDPEGFX sections 2.2.4.2.1.5.3 and 2.2.4.2.1.5.4.
-///
-/// The seven high bits of the flags field are reserved and ignored.
+/// Bit 0 of the tile flags: the tile carries the difference of the DWT
+/// coefficients against the previous frame (MS-RDPEGFX 2.2.4.2.1.5.3, 2.2.4.2.1.5.4).
 pub const FLAG_TILE_DIFFERENCE: u8 = 0x01;
 
 /// TILE_SIMPLE: non-progressive full-quality tile (single pass).
@@ -1207,64 +1201,6 @@ mod tests {
     }
 
     #[test]
-    fn tile_difference_flag_survives_round_trip() {
-        let original = TileSimple {
-            quant_idx_y: 0,
-            quant_idx_cb: 0,
-            quant_idx_cr: 0,
-            x_idx: 1,
-            y_idx: 2,
-            flags: FLAG_TILE_DIFFERENCE,
-            y_data: &[1, 2, 3],
-            cb_data: &[4],
-            cr_data: &[5],
-            tail_data: &[],
-        };
-        let mut buf = vec![0u8; original.size()];
-        original.encode(&mut WriteCursor::new(&mut buf)).unwrap();
-        let decoded = TileSimple::decode(&mut ReadCursor::new(&buf)).unwrap();
-        assert_eq!(decoded.flags, FLAG_TILE_DIFFERENCE);
-        assert!(decoded.is_difference());
-
-        // The seven high bits are reserved and MUST be ignored by the decoder.
-        let mut reserved_bits_set = original.clone();
-        reserved_bits_set.flags = 0xFE;
-        let mut buf = vec![0u8; reserved_bits_set.size()];
-        reserved_bits_set.encode(&mut WriteCursor::new(&mut buf)).unwrap();
-        let decoded = TileSimple::decode(&mut ReadCursor::new(&buf)).unwrap();
-        assert!(!decoded.is_difference());
-    }
-
-    #[test]
-    fn tile_first_difference_flag_survives_round_trip() {
-        let original = TileFirst {
-            quant_idx_y: 0,
-            quant_idx_cb: 0,
-            quant_idx_cr: 0,
-            x_idx: 1,
-            y_idx: 2,
-            flags: FLAG_TILE_DIFFERENCE,
-            quality: 5,
-            y_data: &[1, 2, 3],
-            cb_data: &[4],
-            cr_data: &[5],
-            tail_data: &[],
-        };
-        let mut buf = vec![0u8; original.size()];
-        original.encode(&mut WriteCursor::new(&mut buf)).unwrap();
-        let decoded = TileFirst::decode(&mut ReadCursor::new(&buf)).unwrap();
-        assert_eq!(decoded.flags, FLAG_TILE_DIFFERENCE);
-        assert!(decoded.is_difference());
-
-        let mut absolute = original.clone();
-        absolute.flags = 0;
-        let mut buf = vec![0u8; absolute.size()];
-        absolute.encode(&mut WriteCursor::new(&mut buf)).unwrap();
-        let decoded = TileFirst::decode(&mut ReadCursor::new(&buf)).unwrap();
-        assert!(!decoded.is_difference());
-    }
-
-    #[test]
     fn tile_first_round_trip() {
         let original = TileFirst {
             quant_idx_y: 0,
@@ -1284,6 +1220,74 @@ mod tests {
         let decoded = TileFirst::decode(&mut ReadCursor::new(&buf)).unwrap();
         assert_eq!(decoded.quality, 0x40);
         assert_eq!(decoded.quant_idx_cb, 1);
+    }
+
+    #[test]
+    fn tile_difference_flag_round_trip() {
+        let simple = TileSimple {
+            quant_idx_y: 0,
+            quant_idx_cb: 0,
+            quant_idx_cr: 0,
+            x_idx: 1,
+            y_idx: 2,
+            flags: FLAG_TILE_DIFFERENCE,
+            y_data: &[1, 2, 3],
+            cb_data: &[4],
+            cr_data: &[5],
+            tail_data: &[],
+        };
+        let mut buf = vec![0u8; simple.size()];
+        simple.encode(&mut WriteCursor::new(&mut buf)).unwrap();
+        let decoded = TileSimple::decode(&mut ReadCursor::new(&buf)).unwrap();
+        assert_eq!(decoded.flags, FLAG_TILE_DIFFERENCE);
+        assert!(decoded.is_difference());
+
+        let first = TileFirst {
+            quant_idx_y: 0,
+            quant_idx_cb: 0,
+            quant_idx_cr: 0,
+            x_idx: 1,
+            y_idx: 2,
+            flags: FLAG_TILE_DIFFERENCE,
+            quality: 5,
+            y_data: &[1, 2, 3],
+            cb_data: &[4],
+            cr_data: &[5],
+            tail_data: &[],
+        };
+        let mut buf = vec![0u8; first.size()];
+        first.encode(&mut WriteCursor::new(&mut buf)).unwrap();
+        let decoded = TileFirst::decode(&mut ReadCursor::new(&buf)).unwrap();
+        assert_eq!(decoded.flags, FLAG_TILE_DIFFERENCE);
+        assert!(decoded.is_difference());
+    }
+
+    #[test]
+    fn tile_reserved_flag_bits_are_not_difference() {
+        // The seven high bits MUST be ignored by the decoder.
+        let mut simple = TileSimple {
+            quant_idx_y: 0,
+            quant_idx_cb: 0,
+            quant_idx_cr: 0,
+            x_idx: 1,
+            y_idx: 2,
+            flags: 0xFE,
+            y_data: &[1, 2, 3],
+            cb_data: &[4],
+            cr_data: &[5],
+            tail_data: &[],
+        };
+        let mut buf = vec![0u8; simple.size()];
+        simple.encode(&mut WriteCursor::new(&mut buf)).unwrap();
+        let decoded = TileSimple::decode(&mut ReadCursor::new(&buf)).unwrap();
+        assert_eq!(decoded.flags, 0xFE);
+        assert!(!decoded.is_difference());
+
+        simple.flags = 0xFF;
+        let mut buf = vec![0u8; simple.size()];
+        simple.encode(&mut WriteCursor::new(&mut buf)).unwrap();
+        let decoded = TileSimple::decode(&mut ReadCursor::new(&buf)).unwrap();
+        assert!(decoded.is_difference());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The Progressive RemoteFX decoder parses the tile `flags` byte on `TILE_SIMPLE` and `TILE_FIRST` blocks, but nothing ever consumes it. `TileState::decode_first` unconditionally set `self.is_difference = false`, and no coefficient path read that field, so a tile flagged `RFX_TILE_DIFFERENCE` (`0x01`) was decoded as if it carried absolute coefficients.

The delta is then rendered as if it were the image, and every later progressive upgrade pass refines the wrong coefficients, so the error compounds across the frame.

## Spec

[MS-RDPEGFX] sections 2.2.4.2.1.5.3 (`RFX_PROGRESSIVE_TILE_SIMPLE`) and 2.2.4.2.1.5.4 (`RFX_PROGRESSIVE_TILE_FIRST`) define the flag:

> **RFX_TILE_DIFFERENCE 0x01** — Indicates that the tile contains the compressed difference of the DWT coefficients for the same tile between the current frame and the previous frame.

Section 3.3.8.2.1.1 gives the decode rule:

> If the tile is a difference tile (section 3.1.8.1.2), then the progressively quantized coefficients are simply added to the DecDwtQ elements:
> `DecDwtQ = DecDwtQ + DecProgQ * PQF`

and section 3.3.8.2.1 states the complementary rule for original tiles — the tile is zeroed in the current frame first, and the entropy decode result is added to it.

The same section requires the LL3 deltas to be summed up "even if the tile is not an original tile", so the LL3 differential decode stays unconditional. FreeRDP's `progressive_decompress` behaves the same way (`progressive_rfx_dwt_2d_decode` adds the freshly decoded buffer into the persisted `current` buffer, saturating at the `INT16` bounds, when `coeffDiff` is set).

[MS-RDPEGFX]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpegfx/da5c75f9-cd99-450c-98c4-014a496942b0

## Changes

**`ironrdp-pdu`** — `crates/ironrdp-pdu/src/codecs/rfx/progressive.rs`

- Add `FLAG_TILE_DIFFERENCE` and `is_difference()` accessors on `TileSimple` and `TileFirst`, following the existing `FLAG_DWT_REDUCE_EXTRAPOLATE` / `uses_reduce_extrapolate()` pattern. The seven high bits of the flags field remain reserved and ignored, as the spec requires.

**`ironrdp-graphics`** — `crates/ironrdp-graphics/src/progressive.rs`

- Add `TileState::decode_first_difference`, which decodes the three components into a scratch buffer and accumulates them into the retained coefficients, saturating at the `i16` bounds. The accumulation happens in the `DecDwtQ` domain — before base dequantization and the inverse DWT — which is where both the retained coefficients and the incoming differences live.
- `decode_tile_block` routes `TILE_SIMPLE` and `TILE_FIRST` to that path when the flag is set, and to the existing path otherwise.
- The shared first-pass bookkeeping moves into a private `begin_first_pass`, and `is_difference` now records how the most recent first-pass tile was encoded instead of being hardcoded to `false`.

Notes on the semantics:

- **DAS sign state** keeps describing the incoming differences rather than the accumulated result, because that is what the upgrade passes refining this transmission are encoded against. This matches both the spec (section 3.3.8.2.1.1 derives the tri-state from `DecProgQ`) and FreeRDP, which fills its `sign` buffer from the freshly RLGR-decoded data regardless of the flag.
- **Unusable reference**: the retained coefficients stay base-quantized until reconstruction, so they only mean anything while the base quantization tables and the DWT variant hold. If a stream changes either, the reference is dropped and the tile decodes as an original one. Without that, a difference tile carrying an all-zero delta corrupted most of the tile. The spec does not define the case; degrading one tile beats erroring out the whole frame.
- **First tile of a surface**: a tile that has not been decoded yet holds zeroed coefficients, so a difference tile arriving first reconstructs to the same values as an absolute one. No special case is needed, and there is a test for it.
- **Upgrade passes**: `TILE_UPGRADE` has no `flags` field on the wire, and it already accumulates into the retained coefficients, so it is unaffected. FreeRDP reads `tile->flags` in its upgrade path but the value is unused there, since it copies the persisted buffer into the DWT buffer regardless.

**No public API break.** `decode_first` keeps its signature and its behaviour for original tiles; the difference path is a new method.

**No new dependencies.**

## Tests

`ironrdp-graphics`:

- `difference_tile_accumulates_into_retained_coefficients` — an absolute tile followed by a flagged one; asserts the full 4096-coefficient buffer of all three components equals retained + newly decoded, and that the DAS state describes the incoming differences.
- `non_difference_tile_replaces_retained_coefficients` — two absolute tiles in a row still replace, and the result is identical to decoding the second one on a fresh tile.
- `difference_tile_on_untouched_tile_matches_absolute_tile` — first tile of a surface.
- `difference_tile_accumulation_saturates` — accumulation clamps at the `i16` bounds.
- `upgrade_pass_refines_accumulated_difference_coefficients` — an upgrade pass after a difference tile refines the accumulated coefficients.
- `decoder_accumulates_difference_tiles_signalled_on_the_wire` — end-to-end through `ProgressiveDecoder::decode_bitmap`, driven by the real flags byte: a flagged tile renders pixel-identical to a single absolute tile carrying the summed coefficients, an unflagged one renders identically to decoding it standalone, and the two differ.

`ironrdp-pdu`: `tile_difference_flag_survives_round_trip` and `tile_first_difference_flag_survives_round_trip` cover the flags byte and the reserved high bits.

The fixtures are built with the crate's existing `rlgr::encode` helper, the same approach as the surrounding progressive tests; there were no captured progressive fixtures in the repo to reuse.

Each new test was checked against a deliberately broken build (accumulation reverted to replacement, and the wire dispatch forced to the absolute path) to confirm it fails without the fix.

## Verification

```
cargo xtask check fmt -v      # All good!
cargo xtask check lints -v    # All good!
cargo xtask check tests -v    # All good!
cargo xtask check typos -v    # All good!
cargo xtask check locks -v    # All good!
```

`cargo test -p ironrdp-graphics -p ironrdp-pdu`: 217 passed / 0 failed, 412 passed / 0 failed.

Additional tests cover TILE_FIRST end to end, the reduce-extrapolate band layout, and a difference tile arriving after an upgrade pass. Each new test was checked against a deliberately broken build to confirm it fails without the fix.

## Overlap and known gaps

- **#1698 covers the same bug** and models the retained state better: it keys the sub-band diffing reference by surface and keeps it across `ResetGraphics`, per MS-RDPEGFX 3.3.1.3. This PR reuses `TileState::coefficients`, which is keyed by `(surface_id, codec_context_id)`, so `RDPGFX_DELETE_ENCODING_CONTEXT` drops the reference that 3.3.1.3 says must survive. Maintainers should take whichever base they prefer; the tests here apply to both.
- Not validated against a captured difference-encoded frame; the correctness argument rests on the spec text and on matching FreeRDP.
- Separately, `use_reduce_extrapolate` is read from the CONTEXT block, where bit 0 is `RFX_SUBBAND_DIFFING` (2.2.4.2.1.4). `RFX_DWT_REDUCE_EXTRAPOLATE` is a REGION flag (2.2.4.2.1.5), and `ProgressiveRegion::uses_reduce_extrapolate()` is currently dead code. Pre-existing and out of scope here.

Refs #1240
