### PR TITLE
fix(graphics): widen the Progressive YCbCr conversion to i64

### DIFF
--- a/crates/ironrdp-graphics/src/progressive.rs
+++ b/crates/ironrdp-graphics/src/progressive.rs
@@ -651,6 +651,25 @@ fn clamp_u8(value: i64) -> u8 {
     value.clamp(0, 255) as u8
 }
 
+/// ITU-R BT.601 YCbCr to RGB with 16-bit fixed point.
+///
+/// The samples come off the wire and can reach the full i16 range, where
+/// the fixed-point products overflow i32. Widening keeps the arithmetic
+/// exact for every input a tile can hold, and `clamp_u8` still bounds the
+/// result.
+#[expect(clippy::similar_names, reason = "y/cb/cr are standard YCbCr component names")]
+fn ycbcr_to_rgb(y: i16, cb: i16, cr: i16) -> [u8; 3] {
+    let y = i64::from(y) + 128;
+    let cb = i64::from(cb);
+    let cr = i64::from(cr);
+
+    let r = y + ((cr * 91881 + 32768) >> 16);
+    let g = y - ((cb * 22554 + cr * 46802 + 32768) >> 16);
+    let b = y + ((cb * 116130 + 32768) >> 16);
+
+    [clamp_u8(r), clamp_u8(g), clamp_u8(b)]
+}
+
 /// Clamp i32 to i16 range.
 #[expect(
     clippy::as_conversions,
@@ -958,25 +977,12 @@ impl TileState {
         }
 
         // YCbCr to RGBA conversion.
-        //
-        // The coefficients come off the wire, so a malformed stream can drive
-        // them to the full i16 range, where the fixed-point products overflow
-        // i32. Widening keeps the arithmetic exact for every input a tile can
-        // hold, and `clamp_u8` still bounds the result.
         for i in 0..64 * 64 {
-            let y = i64::from(y_buf[i]) + 128;
-            let cb = i64::from(cb_buf[i]);
-            let cr = i64::from(cr_buf[i]);
-
-            // ITU-R BT.601 YCbCr to RGB conversion
-            let r = y + ((cr * 91881 + 32768) >> 16);
-            let g = y - ((cb * 22554 + cr * 46802 + 32768) >> 16);
-            let b = y + ((cb * 116130 + 32768) >> 16);
-
+            let [r, g, b] = ycbcr_to_rgb(y_buf[i], cb_buf[i], cr_buf[i]);
             let off = i * 4;
-            pixels[off] = clamp_u8(r);
-            pixels[off + 1] = clamp_u8(g);
-            pixels[off + 2] = clamp_u8(b);
+            pixels[off] = r;
+            pixels[off + 1] = g;
+            pixels[off + 2] = b;
             pixels[off + 3] = 0xFF;
         }
     }
@@ -2204,19 +2210,24 @@ mod tests {
     }
 
     #[test]
-    fn reconstruct_handles_out_of_range_coefficients() {
-        // Tile coefficients come off the wire and can reach the full i16 range,
-        // where the fixed-point YCbCr products overflowed i32.
-        let mut tile = TileState::new();
-        let mut pixels = vec![0u8; 64 * 64 * 4];
-
-        for value in [i16::MIN, -20000, 20000, i16::MAX] {
-            tile.coefficients = [[value; COEFFICIENTS_PER_COMPONENT]; 3];
-            tile.reconstruct_to_rgba(&mut pixels);
-
-            for pixel in pixels.chunks_exact(4) {
-                assert_eq!(pixel[3], 0xFF);
-            }
+    #[expect(clippy::similar_names, reason = "Cb and Cr are standard YCbCr component names")]
+    fn ycbcr_to_rgb_handles_full_i16_range() {
+        // These products overflow i32: `cr * 91881` for |cr| > 23372,
+        // `cb * 116130` for |cb| > 18492, and the `cb`/`cr` sum.
+        let cases: [(i16, i16, i16, [u8; 3]); 10] = [
+            (0, 0, 0, [128, 128, 128]),
+            (0, 0, i16::MAX, [255, 0, 128]),
+            (0, i16::MAX, 0, [128, 0, 255]),
+            (0, i16::MAX, i16::MAX, [255, 0, 255]),
+            (0, 0, i16::MIN, [0, 255, 128]),
+            (0, i16::MIN, 0, [128, 255, 0]),
+            (i16::MIN, i16::MIN, i16::MIN, [0, 255, 0]),
+            (i16::MAX, i16::MAX, i16::MAX, [255, 0, 255]),
+            (-20000, -20000, -20000, [0, 255, 0]),
+            (20000, 20000, 20000, [255, 0, 255]),
+        ];
+        for (y, cb, cr, expected) in cases {
+            assert_eq!(ycbcr_to_rgb(y, cb, cr), expected, "y={y} cb={cb} cr={cr}");
         }
     }
 

--- a/crates/ironrdp-graphics/src/progressive.rs
+++ b/crates/ironrdp-graphics/src/progressive.rs
@@ -657,7 +657,6 @@ fn clamp_u8(value: i64) -> u8 {
 /// the fixed-point products overflow i32. Widening keeps the arithmetic
 /// exact for every input a tile can hold, and `clamp_u8` still bounds the
 /// result.
-#[expect(clippy::similar_names, reason = "y/cb/cr are standard YCbCr component names")]
 fn ycbcr_to_rgb(y: i16, cb: i16, cr: i16) -> [u8; 3] {
     let y = i64::from(y) + 128;
     let cb = i64::from(cb);
@@ -2210,7 +2209,6 @@ mod tests {
     }
 
     #[test]
-    #[expect(clippy::similar_names, reason = "Cb and Cr are standard YCbCr component names")]
     fn ycbcr_to_rgb_handles_full_i16_range() {
         // These products overflow i32: `cr * 91881` for |cr| > 23372,
         // `cb * 116130` for |cb| > 18492, and the `cb`/`cr` sum.

--- a/crates/ironrdp-graphics/src/progressive.rs
+++ b/crates/ironrdp-graphics/src/progressive.rs
@@ -641,13 +641,13 @@ fn band_zero_count(sign: &[i8], band: &BandInfo) -> usize {
     sign[start..end].iter().filter(|&&s| s == SIGN_ZERO).count()
 }
 
-/// Clamp i32 to u8 range (0-255).
+/// Clamp to u8 range (0-255).
 #[expect(
     clippy::as_conversions,
     clippy::cast_sign_loss,
     reason = "value is clamped to 0..255 before cast"
 )]
-fn clamp_u8(value: i32) -> u8 {
+fn clamp_u8(value: i64) -> u8 {
     value.clamp(0, 255) as u8
 }
 
@@ -957,11 +957,16 @@ impl TileState {
             crate::dwt::decode(&mut cr_buf, &mut dwt_temp);
         }
 
-        // YCbCr to RGBA conversion
+        // YCbCr to RGBA conversion.
+        //
+        // The coefficients come off the wire, so a malformed stream can drive
+        // them to the full i16 range, where the fixed-point products overflow
+        // i32. Widening keeps the arithmetic exact for every input a tile can
+        // hold, and `clamp_u8` still bounds the result.
         for i in 0..64 * 64 {
-            let y = i32::from(y_buf[i]) + 128;
-            let cb = i32::from(cb_buf[i]);
-            let cr = i32::from(cr_buf[i]);
+            let y = i64::from(y_buf[i]) + 128;
+            let cb = i64::from(cb_buf[i]);
+            let cr = i64::from(cr_buf[i]);
 
             // ITU-R BT.601 YCbCr to RGB conversion
             let r = y + ((cr * 91881 + 32768) >> 16);
@@ -2195,6 +2200,23 @@ mod tests {
                 assert!(difference.abs() <= 2, "expected {expected:?}, got {:?}", &actual[..3]);
             }
             assert_eq!(actual[3], 0xFF);
+        }
+    }
+
+    #[test]
+    fn reconstruct_handles_out_of_range_coefficients() {
+        // Tile coefficients come off the wire and can reach the full i16 range,
+        // where the fixed-point YCbCr products overflowed i32.
+        let mut tile = TileState::new();
+        let mut pixels = vec![0u8; 64 * 64 * 4];
+
+        for value in [i16::MIN, -20000, 20000, i16::MAX] {
+            tile.coefficients = [[value; COEFFICIENTS_PER_COMPONENT]; 3];
+            tile.reconstruct_to_rgba(&mut pixels);
+
+            for pixel in pixels.chunks_exact(4) {
+                assert_eq!(pixel[3], 0xFF);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #1702.

## Problem

`TileState::reconstruct_to_rgba` does the fixed-point YCbCr-to-RGB conversion in `i32`, but the coefficients it converts come straight off the wire and can reach the full `i16` range. Three products overflow:

```rust
let r = y + ((cr * 91881 + 32768) >> 16);              // |cr| > 23_372
let g = y - ((cb * 22554 + cr * 46802 + 32768) >> 16);  // on the sum
let b = y + ((cb * 116130 + 32768) >> 16);              // |cb| > 18_492
```

Debug and test builds have overflow checks on and panic. Release builds wrap and emit wrong pixels.

One `TILE_SIMPLE` reaches it — no progressive upgrade, no difference tile. The LL3 deltas are summed across the subband and then base dequantized, so a modest transmitted value lands well outside the nominal YCbCr range before the conversion. `decode_bitmap` is driven directly from `RDPGFX_WIRE_TO_SURFACE_PDU_2` in `ironrdp-egfx`, so a malformed server frame reaches it.

## Fix

Widen the conversion to `i64` rather than clamping the inputs. Clamping would need a threshold, and because `y` is unbounded too, a clamped chroma term can flip which side of the `clamp_u8` boundary a pixel lands on. Widening is exact for every value a tile can hold, so no valid stream changes behaviour, and `clamp_u8` still bounds the result. `clamp_u8` is private and had no other callers.

## Tests

`ycbcr_to_rgb_handles_full_i16_range` asserts independently computed RGB for the overflowing Cb/Cr products, including `i16::MIN`/`i16::MAX`. Without the widen those products panic under overflow checks and wrap in release.