### PR TITLE
fix(rdpeudp)!: treat a full send buffer as backpressure, not a fatal error

### DIFF
--- a/crates/ironrdp-rdpeudp-tokio/src/driver.rs
+++ b/crates/ironrdp-rdpeudp-tokio/src/driver.rs
@@ -17,7 +17,7 @@ use std::io;
 use std::sync::{Arc, Mutex};
 
 use ironrdp_rdpeudp::pdu::{V1Datagram, V1Flags};
-use ironrdp_rdpeudp::{Event, RdpeudpConnection, RdpeudpError, RdpeudpErrorKind};
+use ironrdp_rdpeudp::{Event, RdpeudpConnection, RdpeudpError, RdpeudpErrorKind, SendError};
 use tokio::net::UdpSocket;
 use tokio::sync::Notify;
 
@@ -60,6 +60,10 @@ pub(crate) struct Driver {
     recv_buf: Vec<u8>,
     /// The only clock in the stack; the state machine has none.
     clock: Clock,
+    /// Data `RdpeudpConnection::send` rejected with `SendBufferFull`, held
+    /// here to retry once the send queue has room again instead of being
+    /// dropped or treated as a fatal error.
+    pending_write: Option<Vec<u8>>,
 }
 
 impl Driver {
@@ -77,6 +81,7 @@ impl Driver {
             connected_signaled: false,
             recv_buf: vec![0u8; RECV_BUF_SIZE],
             clock: Clock::new(),
+            pending_write: None,
         }
     }
 
@@ -110,18 +115,7 @@ impl Driver {
             shared.error.get_or_insert(kind);
         }
 
-        shared.closed = true;
-
-        for waker in [
-            shared.read_waker.take(),
-            shared.write_waker.take(),
-            shared.flush_waker.take(),
-        ]
-        .into_iter()
-        .flatten()
-        {
-            waker.wake();
-        }
+        shared.close();
     }
 
     async fn run_to_completion(&mut self) -> Result<(), DriverError> {
@@ -175,18 +169,27 @@ impl Driver {
                     self.drain_events();
                 }
 
-                // Branch 2: TLS layer has data to send
-                _ = WriteDataReady::new(&self.shared) => {
-                    let (data, stream_closed, flush_waker) = {
+                // Branch 2: TLS layer has data to send. Guarded off while a
+                // write is already pending backpressure: pulling more out of
+                // `write_buf` on top of it would let newer bytes reach
+                // `send()` before the older ones still waiting their turn,
+                // corrupting the stream's order.
+                _ = WriteDataReady::new(&self.shared), if self.pending_write.is_none() => {
+                    let (data, stream_closed, flush_waker, room_waker) = {
                         let mut shared = self.shared.lock()
                             .map_err(|_| DriverError::connection_closed("lock shared state"))?;
                         let closed = shared.closed && shared.write_buf.is_empty();
                         let buf = shared.write_buf.split().freeze().to_vec();
                         let flush = shared.flush_waker.take();
-                        (buf, closed, flush)
+                        let room = shared.write_room_waker.take();
+                        (buf, closed, flush, room)
                     };
                     // Wake any pending flush (write_buf has been drained)
                     if let Some(waker) = flush_waker {
+                        waker.wake();
+                    }
+                    // Wake a writer that was blocked on write_buf being full
+                    if let Some(waker) = room_waker {
                         waker.wake();
                     }
                     if stream_closed {
@@ -194,10 +197,7 @@ impl Driver {
                         self.drain_events();
                         return Ok(());
                     }
-                    if !data.is_empty() {
-                        self.conn
-                            .send(data)
-                            .map_err(|error| DriverError::rdpeudp("queue outbound data", error))?;
+                    if !data.is_empty() && self.queue_write(data)? {
                         self.drain_transmits().await?;
                     }
                 }
@@ -211,16 +211,21 @@ impl Driver {
                 }
             }
 
+            // A write that hit backpressure earlier may have room now: an
+            // incoming ACK (branch 1) or a retransmit (branch 3) can both
+            // have just moved entries out of the send buffer via
+            // `drain_transmits`. Self-guards on the connection already
+            // being closed, so this is safe to call unconditionally rather
+            // than threading it through every branch that might free room.
+            self.flush_pending_write().await?;
+
             if self.conn.is_closed() {
                 // Propagate close to the stream side
                 let mut shared = self
                     .shared
                     .lock()
                     .map_err(|_| DriverError::connection_closed("lock shared state"))?;
-                shared.closed = true;
-                if let Some(waker) = shared.read_waker.take() {
-                    waker.wake();
-                }
+                shared.close();
                 return Ok(());
             }
         }
@@ -257,6 +262,49 @@ impl Driver {
         Ok(())
     }
 
+    /// Hand `data` to the connection's send queue, or hold it in
+    /// `pending_write` to retry if the queue is at its backpressure limit.
+    ///
+    /// `SendBufferFull` is not fatal: on a slow or lossy link, sustained
+    /// writes can legitimately fill the bounded send queue while the
+    /// connection is otherwise healthy, and the error kind's own
+    /// documentation says the caller should retry rather than give up.
+    /// Every other rejection stays fatal, unchanged.
+    ///
+    /// Returns whether `data` was actually queued, so the caller knows
+    /// whether a `drain_transmits` is worth running.
+    fn queue_write(&mut self, data: Vec<u8>) -> Result<bool, DriverError> {
+        match self.conn.send(data) {
+            Ok(()) => Ok(true),
+            Err(SendError { error, data }) if matches!(error.kind(), RdpeudpErrorKind::SendBufferFull) => {
+                self.pending_write = Some(data);
+                Ok(false)
+            }
+            Err(SendError { error, .. }) => Err(DriverError::rdpeudp("queue outbound data", error)),
+        }
+    }
+
+    /// Retry a write that hit backpressure last time, now that something
+    /// may have drained the send buffer. A no-op if nothing is pending, or
+    /// if the connection has already closed (retrying into a closed
+    /// connection would surface as a fatal error and turn what should be a
+    /// clean shutdown into one).
+    async fn flush_pending_write(&mut self) -> Result<(), DriverError> {
+        if self.conn.is_closed() {
+            return Ok(());
+        }
+
+        let Some(data) = self.pending_write.take() else {
+            return Ok(());
+        };
+
+        if self.queue_write(data)? {
+            self.drain_transmits().await?;
+        }
+
+        Ok(())
+    }
+
     /// Process all pending events from the connection state machine.
     fn drain_events(&mut self) {
         while let Some(event) = self.conn.poll_event() {
@@ -277,10 +325,7 @@ impl Driver {
                 }
                 Event::ConnectionClosed => {
                     if let Ok(mut shared) = self.shared.lock() {
-                        shared.closed = true;
-                        if let Some(waker) = shared.read_waker.take() {
-                            waker.wake();
-                        }
+                        shared.close();
                     }
                 }
             }
@@ -424,6 +469,50 @@ mod tests {
             ..ConnectionConfig::default()
         }
     }
+
+    /// Build a client `RdpeudpConnection` past the handshake into
+    /// `Established`, entirely in memory (no sockets), for tests that only
+    /// care about data-phase behavior. Mirrors
+    /// `ironrdp-testsuite-core/tests/rdpeudp/connection.rs`'s `establish_pair`;
+    /// duplicated rather than shared because integration test binaries
+    /// aren't importable from another crate's inline unit tests. If the
+    /// handshake sequence changes there, update it here too.
+    fn established_client_connection() -> RdpeudpConnection {
+        let t = ironrdp_rdpeudp::MonotonicInstant::from_millis(0);
+
+        let mut client = RdpeudpConnection::connect(test_connection_config(), t).expect("connect");
+        let syn = client.poll_transmit(t).expect("SYN");
+
+        let syn_dg: V1Datagram = ironrdp_core::decode(&syn.contents).expect("decode SYN");
+        let mut server = RdpeudpConnection::accept(test_connection_config(), &syn_dg, t).expect("accept");
+        let syn_ack = server.poll_transmit(t).expect("SYN+ACK");
+
+        let mut syn_ack_bytes = syn_ack.contents;
+        let handshake_rtt = t.saturating_add(Duration::from_millis(50));
+        client
+            .handle_datagram(&mut syn_ack_bytes, handshake_rtt)
+            .expect("handle SYN+ACK");
+        while client.poll_event().is_some() {}
+
+        assert!(client.is_established(), "test setup: client should be established");
+        client
+    }
+
+    /// Bind two UDP sockets on localhost and connect them to each other, for
+    /// tests that need a `Driver`'s real socket send path to succeed without
+    /// caring what (if anything) is on the other end.
+    async fn connected_socket_pair() -> (UdpSocket, UdpSocket) {
+        let a = UdpSocket::bind("127.0.0.1:0").await.expect("bind a");
+        let b = UdpSocket::bind("127.0.0.1:0").await.expect("bind b");
+        a.connect(b.local_addr().expect("addr b"))
+            .await
+            .expect("connect a to b");
+        b.connect(a.local_addr().expect("addr a"))
+            .await
+            .expect("connect b to a");
+        (a, b)
+    }
+
     use ironrdp_rdpeudp::RdpeudpErrorExt as _;
 
     use super::*;
@@ -646,5 +735,164 @@ mod tests {
         let bytes = vec![0xFFu8; 12];
         let padded = pad_handshake_datagram(bytes.clone());
         assert_eq!(padded, bytes);
+    }
+
+    /// This is the actual defect: `RdpeudpConnection::send` returning
+    /// `SendBufferFull` used to propagate as a fatal `DriverError` via `?`,
+    /// tearing down an otherwise-healthy connection over transient
+    /// backpressure. `queue_write` must hold the data and report it as
+    /// merely not-yet-queued, never as an error, for that one kind.
+    #[tokio::test]
+    async fn queue_write_holds_data_instead_of_erroring_when_the_send_buffer_is_full() {
+        let conn = established_client_connection();
+        let (socket, _peer) = connected_socket_pair().await;
+        let shared = Arc::new(Mutex::new(SharedIo::new()));
+        let notify = Arc::new(Notify::new());
+        let mut driver = Driver::new(socket, conn, shared, notify);
+
+        // test_connection_config's log_window_size is 6 (64 slots); the
+        // bound is 8x that, matching ironrdp-testsuite-core's own
+        // send-buffer-full test. queue_write never calls drain_transmits,
+        // so nothing drains the buffer as it fills.
+        for _ in 0..512 {
+            assert!(
+                driver
+                    .queue_write(vec![0xAAu8; 4])
+                    .expect("queue_write should not error while filling"),
+                "every write under the bound should be queued"
+            );
+        }
+
+        let queued = driver
+            .queue_write(vec![0xBBu8; 4])
+            .expect("SendBufferFull must not surface as a DriverError");
+        assert!(!queued, "the write past the bound should be held, not queued");
+        assert_eq!(
+            driver.pending_write.as_deref(),
+            Some([0xBBu8; 4].as_slice()),
+            "the exact rejected payload should be preserved, not dropped"
+        );
+    }
+
+    /// `flush_pending_write` is a no-op, not an error, when there is nothing
+    /// held.
+    #[tokio::test]
+    async fn flush_pending_write_is_a_no_op_with_nothing_pending() {
+        let conn = established_client_connection();
+        let (socket, _peer) = connected_socket_pair().await;
+        let shared = Arc::new(Mutex::new(SharedIo::new()));
+        let notify = Arc::new(Notify::new());
+        let mut driver = Driver::new(socket, conn, shared, notify);
+
+        driver.flush_pending_write().await.expect("no-op should not error");
+        assert!(driver.pending_write.is_none());
+    }
+
+    /// Once `drain_transmits` moves entries out of the send buffer, a held
+    /// write is retried and actually goes out, closing the loop on the
+    /// backpressure fix rather than leaving data stuck forever.
+    #[tokio::test]
+    async fn flush_pending_write_delivers_once_the_send_buffer_has_room() {
+        let conn = established_client_connection();
+        let (socket, _peer) = connected_socket_pair().await;
+        let shared = Arc::new(Mutex::new(SharedIo::new()));
+        let notify = Arc::new(Notify::new());
+        let mut driver = Driver::new(socket, conn, shared, notify);
+
+        for _ in 0..512 {
+            driver.queue_write(vec![0xAAu8; 4]).expect("queue_write");
+        }
+        let queued = driver.queue_write(vec![0xCCu8; 4]).expect("queue_write");
+        assert!(!queued, "test setup: the buffer should be full");
+        assert!(driver.pending_write.is_some());
+
+        // Only draining what's already queued frees room; nothing else in
+        // this test touches the send buffer.
+        driver.drain_transmits().await.expect("drain_transmits");
+
+        driver.flush_pending_write().await.expect("flush_pending_write");
+        assert!(
+            driver.pending_write.is_none(),
+            "the held write should have been queued and sent once room opened"
+        );
+    }
+
+    /// `flush_pending_write` must not attempt the retry once the connection
+    /// has already closed: `send()` on a closed connection is a fatal error,
+    /// which would turn a clean shutdown into a spurious one.
+    #[tokio::test]
+    async fn flush_pending_write_does_not_error_on_an_already_closed_connection() {
+        let mut conn = established_client_connection();
+        conn.close();
+        assert!(conn.is_closed(), "test setup: connection should be closed");
+
+        let (socket, _peer) = connected_socket_pair().await;
+        let shared = Arc::new(Mutex::new(SharedIo::new()));
+        let notify = Arc::new(Notify::new());
+        let mut driver = Driver::new(socket, conn, shared, notify);
+        driver.pending_write = Some(vec![0xDDu8; 4]);
+
+        driver
+            .flush_pending_write()
+            .await
+            .expect("a closed connection must not turn the flush into an error");
+    }
+
+    /// This is the gap the isolated `queue_write`/`flush_pending_write` tests
+    /// above cannot reach on their own: does the real `select!` loop, driving
+    /// a real connection against a peer that never acks, actually stop
+    /// `write_buf` from growing without bound the way those tests assume?
+    ///
+    /// The peer socket is bound and connected but never read from, so
+    /// nothing ever acknowledges anything: the congestion window never grows
+    /// past its initial allowance, `send_buffer` fills, `pending_write`
+    /// engages and never clears, and branch 2 stops draining `write_buf` for
+    /// the rest of the test. It is deliberately not dropped: a closed peer
+    /// socket can turn a subsequent send into a real `ECONNREFUSED`, which
+    /// would kill the driver with a fatal error instead of sustaining the
+    /// congestion this test needs.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn sustained_writes_against_an_unresponsive_peer_bound_write_buf() {
+        let conn = established_client_connection();
+        let (socket, unresponsive_peer) = connected_socket_pair().await;
+
+        let shared = Arc::new(Mutex::new(SharedIo::new()));
+        let notify = Arc::new(Notify::new());
+        let driver = Driver::new(socket, conn, Arc::clone(&shared), notify);
+        let driver_handle = tokio::spawn(driver.run());
+
+        let mut stream = crate::stream::RdpeudpStream::new(Arc::clone(&shared));
+
+        // Keep writing well past WRITE_BUF_HIGH_WATER. If the bound holds,
+        // this never completes inside the timeout.
+        let outcome = tokio::time::timeout(Duration::from_secs(5), async {
+            let chunk = vec![0xABu8; 4096];
+            // Comfortably more than WRITE_BUF_HIGH_WATER / chunk.len() (256):
+            // if the bound holds, this never gets close to finishing before
+            // the timeout above fires, since a blocked write just sits
+            // pending. If the bound is broken, this actually would run to
+            // completion instead.
+            for _ in 0..100_000 {
+                tokio::io::AsyncWriteExt::write_all(&mut stream, &chunk)
+                    .await
+                    .expect("write_all");
+            }
+        })
+        .await;
+
+        assert!(
+            outcome.is_err(),
+            "writes should have blocked at the high-water mark well before completing 100,000 chunks"
+        );
+
+        let buf_len = shared.lock().expect("lock").write_buf.len();
+        assert!(
+            buf_len <= crate::stream::WRITE_BUF_HIGH_WATER,
+            "write_buf grew to {buf_len} bytes, past its {}-byte bound",
+            crate::stream::WRITE_BUF_HIGH_WATER
+        );
+
+        driver_handle.abort();
+        drop(unresponsive_peer);
     }
 }

--- a/crates/ironrdp-rdpeudp-tokio/src/stream.rs
+++ b/crates/ironrdp-rdpeudp-tokio/src/stream.rs
@@ -14,6 +14,17 @@ use std::sync::{Arc, Mutex};
 use bytes::BytesMut;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
+/// How many undelivered bytes may pile up in `SharedIo::write_buf` before
+/// `AsyncWrite::poll_write` stops accepting more.
+///
+/// Nothing else bounds it. `RdpeudpConnection::send`'s own `SendBufferFull`
+/// only rejects one call's worth of bytes; without this, a caller that keeps
+/// writing through that rejection (the pattern `queue_write`'s retry loop is
+/// built for) has nowhere for `write_buf` to stop growing, for as long as
+/// congestion or an unresponsive peer keeps the send buffer full. Mirrors
+/// `driver::READ_BUF_HIGH_WATER`'s reasoning on the other direction.
+pub(crate) const WRITE_BUF_HIGH_WATER: usize = 1 << 20;
+
 // ════════════════════════════════════════════════════════════════════
 // SharedIo
 // ════════════════════════════════════════════════════════════════════
@@ -54,6 +65,15 @@ pub(crate) struct SharedIo {
     /// and would sit throttled until some unrelated timer happened to fire.
     pub(crate) read_drained_waker: Option<Waker>,
 
+    /// Waker registered by `poll_write` when `write_buf` is at or over
+    /// `WRITE_BUF_HIGH_WATER`. Fired by the driver once it drains `write_buf`
+    /// into `conn.send()`.
+    ///
+    /// Without it a writer blocked on a full `write_buf` has no way to learn
+    /// the driver made room, and would stay pending until some unrelated
+    /// wake happened to reach it.
+    pub(crate) write_room_waker: Option<Waker>,
+
     /// Fatal error from the driver (propagated to reads/writes).
     pub(crate) error: Option<io::ErrorKind>,
 
@@ -70,8 +90,39 @@ impl SharedIo {
             write_waker: None,
             flush_waker: None,
             read_drained_waker: None,
+            write_room_waker: None,
             error: None,
             closed: false,
+        }
+    }
+
+    /// Mark the connection closed and wake every task that might be
+    /// blocked on this state, so a close is never missed by a task that
+    /// was mid-`Pending` when it happened.
+    ///
+    /// The five call sites that used to set `closed = true` directly each
+    /// hand-picked which wakers to fire, and drifted out of sync with each
+    /// other: two never woke `flush_waker` (a `poll_flush` in flight when
+    /// the connection self-closed, cleanly or via `Event::ConnectionClosed`,
+    /// hung forever), and two never woke `read_drained_waker` (the driver
+    /// itself, throttled on its own full `read_buf`, would never notice an
+    /// externally-initiated shutdown). Centralizing the wake list here means
+    /// a waker added for one reason automatically gets covered everywhere
+    /// closing can happen, rather than needing five separate updates found
+    /// by tracing each call site's `Future` by hand.
+    pub(crate) fn close(&mut self) {
+        self.closed = true;
+        for waker in [
+            self.read_waker.take(),
+            self.write_waker.take(),
+            self.flush_waker.take(),
+            self.read_drained_waker.take(),
+            self.write_room_waker.take(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            waker.wake();
         }
     }
 }
@@ -131,7 +182,7 @@ impl AsyncRead for RdpeudpStream {
 }
 
 impl AsyncWrite for RdpeudpStream {
-    fn poll_write(self: Pin<&mut Self>, _cx: &mut Context<'_>, buf: &[u8]) -> Poll<io::Result<usize>> {
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<io::Result<usize>> {
         let mut shared = self
             .shared
             .lock()
@@ -143,6 +194,14 @@ impl AsyncWrite for RdpeudpStream {
 
         if shared.closed {
             return Poll::Ready(Err(io::Error::new(io::ErrorKind::BrokenPipe, "connection closed")));
+        }
+
+        if shared.write_buf.len() >= WRITE_BUF_HIGH_WATER {
+            // The driver isn't keeping up (or the peer isn't acking): stop
+            // accepting more instead of letting write_buf grow without
+            // bound. The driver wakes this once it drains write_buf.
+            shared.write_room_waker = Some(cx.waker().clone());
+            return Poll::Pending;
         }
 
         shared.write_buf.extend_from_slice(buf);
@@ -182,11 +241,7 @@ impl AsyncWrite for RdpeudpStream {
             .lock()
             .map_err(|_| io::Error::other("shared lock poisoned"))?;
 
-        shared.closed = true;
-
-        if let Some(waker) = shared.write_waker.take() {
-            waker.wake();
-        }
+        shared.close();
 
         Poll::Ready(Ok(()))
     }
@@ -352,5 +407,102 @@ mod tests {
             assert!(result.is_err());
             assert_eq!(result.unwrap_err().kind(), io::ErrorKind::ConnectionReset);
         });
+    }
+
+    /// This is the actual defect: without a bound, `write_buf` had nothing
+    /// stopping it from growing without limit once `SendBufferFull` stopped
+    /// being fatal and became a retried condition instead. `poll_write` must
+    /// refuse once `write_buf` is full, the same way the read side already
+    /// stops pulling off the socket once `read_buf` is full.
+    #[test]
+    fn poll_write_blocks_once_write_buf_is_full() {
+        let shared = Arc::new(Mutex::new(SharedIo::new()));
+        {
+            let mut s = shared.lock().expect("lock");
+            s.write_buf.extend_from_slice(&vec![0u8; WRITE_BUF_HIGH_WATER]);
+        }
+
+        let mut stream = RdpeudpStream::new(Arc::clone(&shared));
+
+        let test_waker = TestWaker::new();
+        let waker = Waker::from(Arc::clone(&test_waker));
+        let mut cx = Context::from_waker(&waker);
+
+        let result = Pin::new(&mut stream).poll_write(&mut cx, b"one more byte");
+        assert!(result.is_pending(), "poll_write should block at the high-water mark");
+
+        let s = shared.lock().expect("lock");
+        assert_eq!(
+            s.write_buf.len(),
+            WRITE_BUF_HIGH_WATER,
+            "the blocked write must not have been appended"
+        );
+        assert!(!test_waker.was_woken(), "not woken yet, nothing has drained write_buf");
+    }
+
+    /// The driver wakes a blocked writer once it drains `write_buf`, the
+    /// same relationship `read_drained_waker` has on the read side.
+    #[test]
+    fn write_room_waker_fires_once_write_buf_drains() {
+        let shared = Arc::new(Mutex::new(SharedIo::new()));
+        {
+            let mut s = shared.lock().expect("lock");
+            s.write_buf.extend_from_slice(&vec![0u8; WRITE_BUF_HIGH_WATER]);
+        }
+
+        let mut stream = RdpeudpStream::new(Arc::clone(&shared));
+
+        let test_waker = TestWaker::new();
+        let waker = Waker::from(Arc::clone(&test_waker));
+        let mut cx = Context::from_waker(&waker);
+
+        let result = Pin::new(&mut stream).poll_write(&mut cx, b"blocked");
+        assert!(result.is_pending());
+
+        // The driver drains write_buf (mirrors what branch 2 does) and wakes
+        // the blocked writer, the same way it already does for flush_waker.
+        {
+            let mut s = shared.lock().expect("lock");
+            s.write_buf.clear();
+            if let Some(w) = s.write_room_waker.take() {
+                w.wake();
+            }
+        }
+
+        assert!(test_waker.was_woken());
+    }
+
+    /// This is the second defect the same review round found: the five call
+    /// sites that used to set `closed = true` directly had each hand-picked
+    /// which wakers to fire, and two of them never woke `flush_waker` (a
+    /// `poll_flush` in flight would have hung on a clean self-close) while
+    /// two others never woke `read_drained_waker` (the driver itself,
+    /// throttled on its own full `read_buf`, would never have noticed an
+    /// externally-initiated shutdown). `close()` must wake every one of
+    /// them, unconditionally, so no call site can drift out of sync again.
+    #[test]
+    fn close_wakes_every_registered_waker() {
+        let mut shared = SharedIo::new();
+
+        let read_waker = TestWaker::new();
+        let write_waker = TestWaker::new();
+        let flush_waker = TestWaker::new();
+        let read_drained_waker = TestWaker::new();
+        let write_room_waker = TestWaker::new();
+
+        shared.read_waker = Some(Waker::from(Arc::clone(&read_waker)));
+        shared.write_waker = Some(Waker::from(Arc::clone(&write_waker)));
+        shared.flush_waker = Some(Waker::from(Arc::clone(&flush_waker)));
+        shared.read_drained_waker = Some(Waker::from(Arc::clone(&read_drained_waker)));
+        shared.write_room_waker = Some(Waker::from(Arc::clone(&write_room_waker)));
+
+        shared.close();
+
+        assert!(shared.closed);
+        assert!(read_waker.was_woken(), "read_waker not woken");
+        assert!(write_waker.was_woken(), "write_waker not woken");
+        assert!(flush_waker.was_woken(), "flush_waker not woken");
+        assert!(read_drained_waker.was_woken(), "read_drained_waker not woken");
+        assert!(write_room_waker.was_woken(), "write_room_waker not woken");
     }
 }

--- a/crates/ironrdp-rdpeudp-tokio/src/transport.rs
+++ b/crates/ironrdp-rdpeudp-tokio/src/transport.rs
@@ -235,13 +235,7 @@ impl UdpTransport {
                 .shared
                 .lock()
                 .map_err(|_| UdpTransportError::driver_panic("shutdown"))?;
-            shared.closed = true;
-            if let Some(waker) = shared.read_waker.take() {
-                waker.wake();
-            }
-            if let Some(waker) = shared.write_waker.take() {
-                waker.wake();
-            }
+            shared.close();
         }
 
         // Wait for the pump task (should now get EOF and exit)

--- a/crates/ironrdp-rdpeudp/src/connection.rs
+++ b/crates/ironrdp-rdpeudp/src/connection.rs
@@ -29,7 +29,7 @@ use core::time::Duration;
 use ironrdp_core::{decode, encode_vec};
 
 use crate::congestion::CongestionControl;
-use crate::error::{RdpeudpError, RdpeudpErrorExt as _};
+use crate::error::{RdpeudpError, RdpeudpErrorExt as _, SendError};
 use crate::loss::LossDetector;
 use crate::pdu::prefix::{decode_with_prefix, encode_with_prefix};
 use crate::pdu::v1_ack::{V1AckVectorElement, V1AckVectorHeader, VectorElementState};
@@ -531,13 +531,30 @@ impl RdpeudpConnection {
     /// The data will be sent in the next `poll_transmit()` call,
     /// subject to congestion window availability.
     ///
-    /// Returns an error if the connection is not established or
-    /// the send buffer is full.
-    pub fn send(&mut self, data: Vec<u8>) -> Result<(), RdpeudpError> {
+    /// Returns an error if the connection is not established or the send
+    /// buffer is full. Either way, the rejected `data` comes back with the
+    /// error: for [`SendBufferFull`], the condition is transient, and a
+    /// caller with somewhere to hold the bytes can retry once
+    /// [`poll_transmit`] drains enough of the backlog for acknowledgements
+    /// to open the window again.
+    ///
+    /// [`SendBufferFull`]: crate::error::RdpeudpErrorKind::SendBufferFull
+    /// [`poll_transmit`]: Self::poll_transmit
+    pub fn send(&mut self, data: Vec<u8>) -> Result<(), SendError> {
         match self.state {
             State::Established => {}
-            State::Closed => return Err(RdpeudpError::connection_closed("send")),
-            _ => return Err(RdpeudpError::invalid_state("send")),
+            State::Closed => {
+                return Err(SendError {
+                    error: RdpeudpError::connection_closed("send"),
+                    data,
+                });
+            }
+            _ => {
+                return Err(SendError {
+                    error: RdpeudpError::invalid_state("send"),
+                    data,
+                });
+            }
         }
 
         let max_payload = self.max_payload();
@@ -552,7 +569,10 @@ impl RdpeudpConnection {
         let max_entries = SEND_BUFFER_WINDOW_MULTIPLE * (1usize << usize::from(self.config.log_window_size));
         let chunks_needed = data.len().div_ceil(max_payload).max(1);
         if self.send_buffer.len() + chunks_needed > max_entries {
-            return Err(RdpeudpError::send_buffer_full("send"));
+            return Err(SendError {
+                error: RdpeudpError::send_buffer_full("send"),
+                data,
+            });
         }
 
         if data.len() <= max_payload {

--- a/crates/ironrdp-rdpeudp/src/error.rs
+++ b/crates/ironrdp-rdpeudp/src/error.rs
@@ -8,6 +8,9 @@
 
 use core::fmt;
 
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 use ironrdp_core::{DecodeError, EncodeError};
 
 use crate::pdu::PrefixError;
@@ -119,5 +122,32 @@ impl RdpeudpErrorExt for RdpeudpError {
     #[track_caller]
     fn invalid_packet(context: &'static str, reason: &'static str) -> Self {
         Self::new(context, RdpeudpErrorKind::InvalidPacket { reason })
+    }
+}
+
+/// The payload [`RdpeudpConnection::send`] could not accept, handed back so
+/// the caller can decide what to do with it: retry once capacity opens for
+/// the transient [`SendBufferFull`] kind, or discard it for a terminal one.
+/// Every kind returns the data, not only `SendBufferFull`, so the caller
+/// never has to guess which rejections are recoverable from the type alone.
+///
+/// [`RdpeudpConnection::send`]: crate::RdpeudpConnection::send
+/// [`SendBufferFull`]: RdpeudpErrorKind::SendBufferFull
+#[derive(Debug)]
+pub struct SendError {
+    pub error: RdpeudpError,
+    pub data: Vec<u8>,
+}
+
+impl fmt::Display for SendError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.error, f)
+    }
+}
+
+#[cfg(feature = "std")]
+impl core::error::Error for SendError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        Some(&self.error)
     }
 }

--- a/crates/ironrdp-rdpeudp/src/lib.rs
+++ b/crates/ironrdp-rdpeudp/src/lib.rs
@@ -19,5 +19,5 @@ pub(crate) mod send_window;
 pub(crate) mod timer;
 
 pub use self::connection::{ConnectionConfig, Event, RdpeudpConnection, Side, Transmit};
-pub use self::error::{RdpeudpError, RdpeudpErrorExt, RdpeudpErrorKind, RdpeudpResult};
+pub use self::error::{RdpeudpError, RdpeudpErrorExt, RdpeudpErrorKind, RdpeudpResult, SendError};
 pub use self::time::MonotonicInstant;

--- a/crates/ironrdp-testsuite-core/tests/rdpeudp/connection.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeudp/connection.rs
@@ -220,7 +220,10 @@ fn send_before_established_returns_error() {
     let mut conn = RdpeudpConnection::connect(default_config(100), t).expect("connect");
 
     let result = conn.send(vec![0xAA; 100]);
-    assert!(matches!(result.unwrap_err().kind(), RdpeudpErrorKind::InvalidState));
+    assert!(matches!(
+        result.unwrap_err().error.kind(),
+        RdpeudpErrorKind::InvalidState
+    ));
 }
 
 /// `send` must eventually refuse more data rather than growing the buffer
@@ -236,7 +239,11 @@ fn send_returns_send_buffer_full_once_the_bound_is_reached() {
     }
 
     let result = client.send(vec![0xAA; 4]);
-    assert!(matches!(result.unwrap_err().kind(), RdpeudpErrorKind::SendBufferFull));
+    let error = result.unwrap_err();
+    assert!(matches!(error.error.kind(), RdpeudpErrorKind::SendBufferFull));
+    // The rejected payload comes back rather than being silently dropped, so
+    // a caller with somewhere to hold it can retry once capacity opens.
+    assert_eq!(error.data, vec![0xAA; 4]);
 }
 
 /// `log_window_size` shifts a `u16` and a `usize` elsewhere in the state
@@ -426,7 +433,10 @@ fn send_after_close_returns_error() {
     client.close();
 
     let result = client.send(vec![0x42]);
-    assert!(matches!(result.unwrap_err().kind(), RdpeudpErrorKind::ConnectionClosed));
+    assert!(matches!(
+        result.unwrap_err().error.kind(),
+        RdpeudpErrorKind::ConnectionClosed
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- RdpeudpConnection::send's SendBufferFull is documented as transient,
  but the async driver treated it as fatal, tearing down an otherwise
  healthy connection under sustained write load
- send() took the payload by value with no way to hand it back on
  error, so the rejected bytes were also gone by the time the error
  propagated
- send()'s signature now returns the rejected data alongside the
  error on every rejection, via a new SendError type; breaking change
  to this crate's public API, but it has no external consumers yet
- the driver holds a backpressured write in a new pending_write field
  instead of dropping it, and retries once poll_transmit has moved
  entries out of the send buffer (an incoming ACK or a retransmit
  both qualify)
- the write-data branch of the driver's select loop stops pulling new
  data out of the shared write buffer while a write is already
  pending, so a retry never gets interleaved out of order

## Validation
`cargo xtask check fmt/lints/tests/typos/locks` all pass. Four new
driver-level tests build a real, in-memory-established connection and
mutation-verify the fix: filling the send buffer to its bound no
longer errors, the rejected payload comes back intact, a retry
delivers once drain_transmits frees room, and a retry into an
already-closed connection does not turn a clean shutdown into an
error.

## Notes
Surfaced by Copilot's second review pass on #1687, posted 11 minutes
before that PR merged; not addressed there. Second of three follow-up
PRs (see #1704 for the first).