### PR TITLE
fix(rdpeudp)!: thread server_cert_verifier through MultitransportBootstrap::connect

### DIFF
--- a/crates/ironrdp-rdpeudp-tokio/src/multitransport.rs
+++ b/crates/ironrdp-rdpeudp-tokio/src/multitransport.rs
@@ -14,6 +14,7 @@
 //! connection flow.
 
 use core::net::SocketAddr;
+use std::sync::Arc;
 
 use ironrdp_pdu::rdp::multitransport::{MultitransportRequestPdu, MultitransportResponsePdu, RequestedProtocol};
 use ironrdp_rdpemt::{RdpemtError, RdpemtErrorExt as _, TunnelConfig};
@@ -39,7 +40,9 @@ use crate::transport::{UdpTransport, UdpTransportConfig, connect_udp};
 /// let mut bootstrap = MultitransportBootstrap::new(request);
 ///
 /// // Attempt the UDP connection
-/// let _ = bootstrap.connect(server_addr, "server.example.com".into(), Default::default()).await;
+/// let _ = bootstrap
+///     .connect(server_addr, "server.example.com".into(), Default::default(), None)
+///     .await;
 ///
 /// // Always send the response back on TCP (S_OK or E_ABORT)
 /// let response_bytes = bootstrap.response_pdu().expect("response available after connect");
@@ -85,6 +88,13 @@ impl MultitransportBootstrap {
     /// On success, stores the transport and prepares an `S_OK` response.
     /// On failure, prepares an `E_ABORT` response and returns the error.
     ///
+    /// `server_cert_verifier` is forwarded to the underlying [`connect_udp`]
+    /// call the same way `connection_config` is: `None` preserves the
+    /// historic no-verification behavior, `Some(verifier)` opts into real
+    /// TLS certificate validation. Without threading it through here, a
+    /// caller going through this orchestrator had no way to reach the
+    /// verification `connect_udp` itself already supports.
+    ///
     /// After calling this, use [`response_pdu()`] to get the bytes to
     /// send back to the server on the TCP connection.
     ///
@@ -94,6 +104,7 @@ impl MultitransportBootstrap {
         server_addr: SocketAddr,
         server_name: String,
         connection_config: ConnectionConfig,
+        server_cert_verifier: Option<Arc<dyn tokio_rustls::rustls::client::danger::ServerCertVerifier>>,
     ) -> Result<(), UdpTransportError> {
         // This driver only implements the reliable transport (RDPEUDP2 + TLS).
         // UdpFecL (lossy RDPEUDP + DTLS) is a distinct wire protocol this crate
@@ -114,6 +125,7 @@ impl MultitransportBootstrap {
         };
         let mut config = UdpTransportConfig::new(server_addr, server_name, tunnel_config);
         config.connection_config = connection_config;
+        config.server_cert_verifier = server_cert_verifier;
 
         match connect_udp(config).await {
             Ok(transport) => {
@@ -226,7 +238,7 @@ mod tests {
         let unreachable_addr: SocketAddr = "127.0.0.1:1".parse().expect("valid loopback address");
 
         let result = bootstrap
-            .connect(unreachable_addr, "localhost".into(), ConnectionConfig::default())
+            .connect(unreachable_addr, "localhost".into(), ConnectionConfig::default(), None)
             .await;
 
         // Checking the specific error kind (not just is_err()) is the point:

--- a/crates/ironrdp-testsuite-extra/tests/rdpeudp_tokio.rs
+++ b/crates/ironrdp-testsuite-extra/tests/rdpeudp_tokio.rs
@@ -322,6 +322,72 @@ async fn connect_rejects_certificate_when_caller_supplies_a_verifier() {
     let _ = server_handle.await;
 }
 
+/// The same proof as `connect_rejects_certificate_when_caller_supplies_a_verifier`,
+/// through `MultitransportBootstrap::connect` instead of `connect_udp`
+/// directly: before this path also accepted a `server_cert_verifier`, a
+/// caller going through the high-level orchestrator had no way to reach
+/// the verification `connect_udp` itself already supported.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn bootstrap_connect_rejects_certificate_when_caller_supplies_a_verifier() {
+    let server_sock = UdpSocket::bind("127.0.0.1:0").await.expect("bind");
+    let server_addr = server_sock.local_addr().expect("addr");
+    let tunnel_config = test_tunnel_config();
+
+    let server_handle = tokio::spawn({
+        let tunnel_config = tunnel_config.clone();
+        async move {
+            accept_udp(
+                server_sock,
+                UdpAcceptConfig {
+                    tls_config: test_tls_server_config(),
+                    tunnel_config,
+                    connection_config: ConnectionConfig::default(),
+                    accept_timeout: Duration::from_secs(10),
+                },
+            )
+            .await
+        }
+    });
+
+    // Wire bytes for a MultitransportRequestPdu (UdpFecR); see
+    // failed_reconnect_clears_the_transport_from_an_earlier_success for the
+    // layout note. Must match test_tunnel_config()'s request_id/cookie.
+    let request_wire = {
+        let mut wire = vec![0x02, 0x00, 0x00, 0x00]; // BasicSecurityHeader: TRANSPORT_REQ
+        wire.extend_from_slice(&42u32.to_le_bytes()); // requestId
+        wire.extend_from_slice(&1u16.to_le_bytes()); // requestedProtocol = UdpFecR
+        wire.extend_from_slice(&[0x00, 0x00]); // reserved
+        wire.extend_from_slice(&[0xAB; 16]); // securityCookie
+        wire
+    };
+
+    let client_handle = tokio::spawn(async move {
+        let mut bootstrap = MultitransportBootstrap::from_pdu(&request_wire).expect("decode request");
+        let result = bootstrap
+            .connect(
+                server_addr,
+                "localhost".into(),
+                ConnectionConfig::default(),
+                Some(Arc::new(AlwaysRejectVerifier)),
+            )
+            .await;
+        (result, bootstrap.is_connected())
+    });
+
+    let (client_result, is_connected) = client_handle.await.expect("client join");
+    assert!(
+        client_result.is_err(),
+        "the self-signed test certificate must be rejected once a verifier is supplied through the bootstrap"
+    );
+    assert!(
+        !is_connected,
+        "a rejected certificate must not leave a transport behind"
+    );
+
+    // The server side also errors, since the client aborts mid-handshake.
+    let _ = server_handle.await;
+}
+
 /// A failed reconnect must not leave a stale transport from an earlier
 /// successful `connect()` reachable through `is_connected()` /
 /// `take_transport()`: the bootstrap just told the server the connection
@@ -365,7 +431,7 @@ async fn failed_reconnect_clears_the_transport_from_an_earlier_success() {
     };
     let mut bootstrap = MultitransportBootstrap::from_pdu(&request_wire).expect("decode request");
     bootstrap
-        .connect(server_addr, "localhost".into(), ConnectionConfig::default())
+        .connect(server_addr, "localhost".into(), ConnectionConfig::default(), None)
         .await
         .expect("first connect succeeds");
     assert!(bootstrap.is_connected());
@@ -374,7 +440,7 @@ async fn failed_reconnect_clears_the_transport_from_an_earlier_success() {
     // Reconnect against a closed loopback port nothing is listening on.
     let unreachable_addr: core::net::SocketAddr = "127.0.0.1:1".parse().expect("valid loopback address");
     let result = bootstrap
-        .connect(unreachable_addr, "localhost".into(), ConnectionConfig::default())
+        .connect(unreachable_addr, "localhost".into(), ConnectionConfig::default(), None)
         .await;
     assert!(result.is_err(), "reconnect against an unreachable address must fail");
 


### PR DESCRIPTION
## Summary
- connect_udp already accepted a server_cert_verifier to opt into real
  TLS certificate validation, added in #1687's own first review round
- MultitransportBootstrap builds its UdpTransportConfig internally
  and never set that field, so a caller going through the high-level
  bootstrap API had no way to reach the verification connect_udp
  itself already supported
- connect() now takes server_cert_verifier as a fourth parameter and
  forwards it the same way connection_config already is
- breaking change to this crate's public API (adds a required
  parameter); the crate has no external consumers yet

## Validation
`cargo xtask check fmt/lints/tests/typos/locks` all pass. Added a
full-stack test proving the verifier is actually consulted through
the bootstrap path, reusing the AlwaysRejectVerifier double from the
sibling connect_udp test; mutation-verified by temporarily reverting
the fix and confirming the new test fails.

## Notes
Surfaced by Copilot's second review pass on #1687, posted 11 minutes
before that PR merged; not addressed there. Third of three follow-up
PRs (see #1704 and #1705 for the other two).