### PR TITLE
fix(mstsgu): report EOF and stop polling a completed work task

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -296,6 +296,10 @@ Provides test case generators and oracles for use with fuzzing.
 
 Offline direct-TCP RDP capture analysis that routes recovered plaintext and exports payload-free replay diagnostics with rendered framebuffer snapshots.
 
+#### [`crates/ironrdp-gwforward`](./crates/ironrdp-gwforward)
+
+Generic TCP forwarding and SOCKS5 proxying over an MS-TSGU RD Gateway tunnel, built on `ironrdp-mstsgu`. Exposes local port-forward and SOCKS5 listeners that relay arbitrary TCP byte streams to internal hosts through the gateway.
+
 #### [`fuzz`](./fuzz)
 
 Fuzz targets for code in core tier.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,6 +1043,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,6 +1630,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2109,6 +2130,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-proto"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.9.4",
+ "ring",
+ "thiserror 2.0.19",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "moka",
+ "once_cell",
+ "parking_lot",
+ "rand 0.9.4",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "hkdf"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2166,6 +2233,7 @@ dependencies = [
  "http",
  "http-body",
  "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2447,6 +2515,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2557,10 +2638,12 @@ dependencies = [
  "http",
  "ironrdp-cfg",
  "ironrdp-daemon",
+ "ironrdp-gwforward",
  "ironrdp-input",
  "ironrdp-propertyset",
  "ironrdp-rdpfile",
  "ironrdp-rpc",
+ "ironrdp-tls",
  "md-5 0.10.6",
  "serde",
  "serde_json",
@@ -2907,6 +2990,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ironrdp-gwforward"
+version = "0.0.0"
+dependencies = [
+ "ironrdp-error 0.2.0",
+ "ironrdp-mstsgu",
+ "ironrdp-tls",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "ironrdp-input"
 version = "0.7.0"
 dependencies = [
@@ -2922,6 +3016,7 @@ dependencies = [
  "base64",
  "bitflags 2.13.1",
  "futures-util",
+ "http",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -2929,9 +3024,15 @@ dependencies = [
  "ironrdp-error 0.2.0",
  "ironrdp-tls",
  "log",
+ "picky",
+ "picky-asn1-der",
+ "picky-asn1-x509",
+ "sspi",
  "tokio",
+ "tokio-socks",
  "tokio-tungstenite",
  "tokio-util",
+ "url",
  "uuid",
 ]
 
@@ -3768,6 +3869,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4293f18e7567a1caf3c584855554377025c65e0aa445344d04171f5ad63d19b9"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4339,6 +4457,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -4866,6 +4988,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
 name = "portpicker"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5347,6 +5475,12 @@ checksum = "71725ecd5e0197b54fe859055b108688472ab6a358f8fbe5cee4a556b1b5bfea"
 dependencies = [
  "rgb",
 ]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "rfc6979"
@@ -6080,6 +6214,8 @@ dependencies = [
  "ed25519-dalek",
  "futures",
  "getrandom 0.3.4",
+ "hickory-proto",
+ "hickory-resolver",
  "hmac 0.13.0",
  "md-5 0.11.0",
  "md4",
@@ -6234,6 +6370,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tap"
@@ -6479,6 +6621,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7e2948f60dbe26b35f2c7fb74ac2854c1fddded0fe9d7548fcc674a246f7615"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror 1.0.69",
  "tokio",
 ]
 

--- a/crates/ironrdp-activex/README.md
+++ b/crates/ironrdp-activex/README.md
@@ -499,12 +499,13 @@ after either setting changes. `RedirectDirectX` reports disabled and rejects att
 `ClientProtocolSpec` return `E_NOTIMPL` because IronRDP has no equivalent automatic-detection or
 client-protocol policy; their getter outputs are initialized before failure. Gateway settings are wired
 to IronRDP's MS-TSGU gateway transport. `GatewayUsageMethod` accepts direct,
-explicit-gateway, and detect modes; detect selects an explicitly configured gateway eagerly because
-IronRDP cannot yet retry through a gateway after a direct connection fails. Gateway credentials can
-use the RDP credentials or configured gateway user credentials. Profile, prompt, smart-card,
-logged-on-user, and system-default gateway-policy modes return `E_NOTIMPL` rather than silently
-changing authentication or routing behavior. Every remaining setting is an explicit
-`TODO(activex)` stub and returns `E_NOTIMPL`; it must not be treated as enabled.
+explicit-gateway, detect, and default-settings modes; detect and default-settings try a direct TCP
+connection first and fall back to the configured MS-TSGU gateway on failure when a hostname is set.
+Gateway credentials can use the RDP credentials, configured gateway user credentials, or logged-on
+user identity (`USERDOMAIN`/`USERNAME`) with an explicit password. True Windows SSO without a
+password is not available yet. Profile, prompt, and smart-card gateway credential sources return
+`E_NOTIMPL` rather than silently changing authentication behavior. Every remaining setting is an
+explicit `TODO(activex)` stub and returns `E_NOTIMPL`; it must not be treated as enabled.
 `EnableMouse` now gates renderer mouse movement, buttons, and wheel forwarding while retaining
 keyboard forwarding.
 `IMsRdpDriveCollection` exposes Windows logical volumes with initially unselected `IMsRdpDrive::RedirectionState` values.

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -2814,6 +2814,7 @@ enum ActiveXTransport {
         endpoint: String,
         username: String,
         password: String,
+        prefer_direct: bool,
     },
     RDCleanPath(RDCleanPathConfig),
 }
@@ -2827,6 +2828,7 @@ fn active_x_transport_from_client_transport(
             endpoint: gateway.endpoint.clone(),
             username: gateway.username.clone(),
             password: gateway.password.clone(),
+            prefer_direct: gateway.prefer_direct,
         }),
         Transport::RDCleanPath(rdcleanpath) => Ok(ActiveXTransport::RDCleanPath(rdcleanpath.clone())),
         // Named-pipe RDP (e.g. Windows Sandbox) is agent/desktop-client only.
@@ -2880,22 +2882,200 @@ fn domain_qualified_username(domain: &str, username: &str) -> String {
     }
 }
 
-fn active_x_transport(settings: &Settings, compatibility: &CompatibilitySettings) -> Result<ActiveXTransport> {
+/// Best-effort Windows logon identity for `GatewayCredentialsSource::UseLogonCredentials`.
+///
+/// True SSO (default-credentials SSPI without a password) is not available yet; callers must still
+/// supply a password via gateway or server credentials. The username falls back to
+/// `USERDOMAIN`/`USERNAME` when gateway user fields are empty.
+fn windows_logon_username() -> String {
+    let user = std::env::var("USERNAME").unwrap_or_default();
+    let domain = std::env::var("USERDOMAIN").unwrap_or_default();
+    domain_qualified_username(&domain, &user)
+}
+
+/// Interactive CredUI for `GatewayCredentialsSource::Prompt`.
+///
+/// Prefers already-configured gateway username/password when both are non-empty so hosts and tests
+/// can supply credentials without showing UI.
+fn prompt_for_gateway_credentials(
+    parent: HWND,
+    gateway_hostname: &str,
+    initial_username: &str,
+    initial_password: &str,
+) -> Result<(String, String)> {
+    if !initial_username.trim().is_empty() && !initial_password.is_empty() {
+        return Ok((initial_username.to_owned(), initial_password.to_owned()));
+    }
+    if parent.0.is_null() {
+        return Err(Error::new(
+            E_INVALIDARG,
+            "gateway Prompt requires credentials or an interactive host window",
+        ));
+    }
+
+    let target = HSTRING::from(format!("IronRDP Gateway:{gateway_hostname}"));
+    let message = HSTRING::from(format!("Enter RD Gateway credentials for {gateway_hostname}"));
+    let caption = HSTRING::from("IronRDP Remote Desktop Gateway");
+    let mut username = credential_prompt_buffer(initial_username, CREDUI_MAX_USERNAME_LENGTH);
+    let mut password = credential_prompt_buffer(initial_password, CREDUI_MAX_PASSWORD_LENGTH);
+    let mut save = windows_core::BOOL(0);
+    let prompt = CREDUI_INFOW {
+        cbSize: size_of::<CREDUI_INFOW>() as u32,
+        hwndParent: parent,
+        pszMessageText: PCWSTR(message.as_ptr()),
+        pszCaptionText: PCWSTR(caption.as_ptr()),
+        hbmBanner: Default::default(),
+    };
+    let result = unsafe {
+        CredUIPromptForCredentialsW(
+            Some(&prompt),
+            PCWSTR(target.as_ptr()),
+            None,
+            0,
+            &mut username,
+            &mut password,
+            Some(&mut save),
+            CREDUI_FLAGS_GENERIC_CREDENTIALS | CREDUI_FLAGS_ALWAYS_SHOW_UI | CREDUI_FLAGS_DO_NOT_PERSIST,
+        )
+    };
+
+    if result == ERROR_CANCELLED {
+        username.fill(0);
+        password.fill(0);
+        return Err(Error::new(E_FAIL, "gateway credential prompt was cancelled"));
+    }
+    if result.0 != 0 {
+        username.fill(0);
+        password.fill(0);
+        return Err(Error::new(
+            E_FAIL,
+            format!("gateway credential prompt failed with Win32 error {}", result.0),
+        ));
+    }
+
+    let prompted_username = String::from_utf16_lossy(
+        &username[..username
+            .iter()
+            .position(|character| *character == 0)
+            .unwrap_or(username.len())],
+    );
+    let prompted_password = String::from_utf16_lossy(
+        &password[..password
+            .iter()
+            .position(|character| *character == 0)
+            .unwrap_or(password.len())],
+    );
+    username.fill(0);
+    password.fill(0);
+
+    if prompted_username.trim().is_empty() || prompted_password.is_empty() {
+        return Err(Error::new(
+            E_INVALIDARG,
+            "gateway credential prompt returned empty credentials",
+        ));
+    }
+
+    Ok((prompted_username, prompted_password))
+}
+
+/// Saved Windows Credential Manager entry for `GatewayCredentialsSource::UseProfile`.
+///
+/// Reads the generic credential registered under `TERMSRV/<gateway host>`, which is where
+/// mstsc persists gateway credentials saved by the user.
+#[cfg(windows)]
+fn profile_gateway_credentials(gateway_hostname: &str) -> Result<(String, String)> {
+    use windows::Win32::Security::Credentials::{CRED_TYPE_GENERIC, CREDENTIALW, CredFree, CredReadW};
+
+    // Strip any port suffix (watching for bracketed IPv6) to form the TERMSRV target name.
+    let host = if let Some(rest) = gateway_hostname.strip_prefix('[') {
+        rest.split_once(']').map(|(host, _)| host).unwrap_or(gateway_hostname)
+    } else {
+        gateway_hostname
+            .split_once(':')
+            .map(|(host, _)| host)
+            .unwrap_or(gateway_hostname)
+    };
+    let target = HSTRING::from(format!("TERMSRV/{host}"));
+
+    let mut credential: *mut CREDENTIALW = ptr::null_mut();
+    let read = unsafe { CredReadW(PCWSTR(target.as_ptr()), CRED_TYPE_GENERIC, None, &mut credential) };
+    if read.is_err() || credential.is_null() {
+        return Err(Error::new(
+            E_INVALIDARG,
+            format!("no saved Windows credentials for gateway {host}; save them or choose another credential source"),
+        ));
+    }
+
+    struct CredGuard(*mut CREDENTIALW);
+    impl Drop for CredGuard {
+        fn drop(&mut self) {
+            if !self.0.is_null() {
+                unsafe { CredFree(self.0.cast()) };
+            }
+        }
+    }
+    let credential = CredGuard(credential);
+
+    let username = unsafe { credential.0.as_ref().map(|cred| cred.UserName) }
+        .filter(|name| !name.is_null())
+        .map(|name| unsafe { name.to_string().unwrap_or_default() })
+        .unwrap_or_default();
+    let (blob, blob_size) = unsafe {
+        credential
+            .0
+            .as_ref()
+            .map(|cred| (cred.CredentialBlob, cred.CredentialBlobSize))
+            .unwrap_or((ptr::null_mut(), 0))
+    };
+    if username.trim().is_empty() || blob.is_null() || blob_size == 0 {
+        return Err(Error::new(
+            E_INVALIDARG,
+            format!("saved Windows credentials for gateway {host} are incomplete"),
+        ));
+    }
+
+    // The credential blob holds the password as UTF-16 bytes; its alignment is not
+    // guaranteed by the API type, so copy through a byte slice first.
+    let blob_len = usize::try_from(blob_size).unwrap_or(0);
+    let blob_bytes = unsafe { slice::from_raw_parts(blob.cast::<u8>(), blob_len) };
+    let password_utf16: Vec<u16> = blob_bytes
+        .chunks_exact(2)
+        .map(|unit| u16::from_le_bytes([unit[0], unit[1]]))
+        .collect();
+    let password = String::from_utf16_lossy(
+        &password_utf16[..password_utf16
+            .iter()
+            .position(|character| *character == 0)
+            .unwrap_or(password_utf16.len())],
+    );
+
+    if password.is_empty() {
+        return Err(Error::new(
+            E_INVALIDARG,
+            format!("saved Windows credentials for gateway {host} have an empty password"),
+        ));
+    }
+
+    Ok((username, password))
+}
+
+fn active_x_transport(
+    settings: &Settings,
+    compatibility: &CompatibilitySettings,
+    credential_parent: HWND,
+) -> Result<ActiveXTransport> {
     let usage_method = GatewayUsageMethod::try_from(i64::from(compatibility.gateway_usage_method))
         .map_err(|error| Error::new(E_INVALIDARG, error.to_string()))?;
-    let use_gateway = match usage_method {
-        GatewayUsageMethod::Direct | GatewayUsageMethod::DirectBypassLocal => false,
-        GatewayUsageMethod::UseAlways => true,
-        // IronRDP has no direct-then-gateway fallback. Match its .rdp behavior by selecting an
-        // explicitly supplied gateway eagerly for Detect mode.
-        GatewayUsageMethod::Detect => !compatibility.gateway_hostname.is_empty(),
-        GatewayUsageMethod::UseDefaultSettings => {
-            return Err(Error::from_hresult(E_NOTIMPL));
-        }
+    let prefer_direct = match usage_method {
+        GatewayUsageMethod::Direct | GatewayUsageMethod::DirectBypassLocal => return Ok(ActiveXTransport::Direct),
+        GatewayUsageMethod::UseAlways => false,
+        // Try direct first when a gateway hostname is configured; fall back on connect failure.
+        GatewayUsageMethod::Detect if !compatibility.gateway_hostname.is_empty() => true,
+        GatewayUsageMethod::Detect => return Ok(ActiveXTransport::Direct),
+        // No group-policy profile store yet: treat default settings like Detect.
+        GatewayUsageMethod::UseDefaultSettings if !compatibility.gateway_hostname.is_empty() => true,
+        GatewayUsageMethod::UseDefaultSettings => return Ok(ActiveXTransport::Direct),
     };
-    if !use_gateway {
-        return Ok(ActiveXTransport::Direct);
-    }
 
     if compatibility.gateway_hostname.trim().is_empty() {
         return Err(Error::new(
@@ -2918,10 +3098,64 @@ fn active_x_transport(settings: &Settings, compatibility: &CompatibilitySettings
             domain_qualified_username(&compatibility.gateway_domain, &compatibility.gateway_username),
             compatibility.gateway_password.clone(),
         ),
-        GatewayCredentialsSource::UseProfile
-        | GatewayCredentialsSource::Prompt
-        | GatewayCredentialsSource::SmartCard
-        | GatewayCredentialsSource::UseLogonCredentials => return Err(Error::from_hresult(E_NOTIMPL)),
+        GatewayCredentialsSource::UseLogonCredentials => {
+            let username = {
+                let gw_user = domain_qualified_username(&compatibility.gateway_domain, &compatibility.gateway_username);
+                if gw_user.trim().is_empty() {
+                    windows_logon_username()
+                } else {
+                    gw_user
+                }
+            };
+            let password = if !compatibility.gateway_password.is_empty() {
+                compatibility.gateway_password.clone()
+            } else {
+                settings.password.clone().unwrap_or_default()
+            };
+            if password.is_empty() {
+                return Err(Error::new(
+                    E_NOTIMPL,
+                    "UseLogonCredentials requires a password until native Windows SSO is supported",
+                ));
+            }
+            (username, password)
+        }
+        GatewayCredentialsSource::UseProfile => {
+            // Explicitly configured gateway credentials win; otherwise read the profile
+            // credential mstsc saves under TERMSRV/<gateway host>.
+            let gw_user = domain_qualified_username(&compatibility.gateway_domain, &compatibility.gateway_username);
+            if !gw_user.trim().is_empty() && !compatibility.gateway_password.is_empty() {
+                (gw_user, compatibility.gateway_password.clone())
+            } else {
+                #[cfg(windows)]
+                {
+                    profile_gateway_credentials(&compatibility.gateway_hostname)?
+                }
+                #[cfg(not(windows))]
+                {
+                    return Err(Error::new(
+                        E_NOTIMPL,
+                        "gateway profile credentials require the Windows Credential Manager",
+                    ));
+                }
+            }
+        }
+        GatewayCredentialsSource::Prompt => {
+            let initial_username =
+                domain_qualified_username(&compatibility.gateway_domain, &compatibility.gateway_username);
+            prompt_for_gateway_credentials(
+                credential_parent,
+                &compatibility.gateway_hostname,
+                &initial_username,
+                &compatibility.gateway_password,
+            )?
+        }
+        GatewayCredentialsSource::SmartCard => {
+            return Err(Error::new(
+                E_NOTIMPL,
+                "smart-card gateway credentials are not supported",
+            ));
+        }
     };
     if username.trim().is_empty() || password.is_empty() {
         return Err(Error::new(
@@ -2934,6 +3168,7 @@ fn active_x_transport(settings: &Settings, compatibility: &CompatibilitySettings
         endpoint: compatibility.gateway_hostname.clone(),
         username,
         password,
+        prefer_direct,
     })
 }
 
@@ -8632,7 +8867,11 @@ impl Control {
                     compatibility.gateway_username = gateway.username.clone();
                     compatibility.gateway_password = gateway.password.clone();
                     compatibility.gateway_domain.clear();
-                    compatibility.gateway_usage_method = GatewayUsageMethod::UseAlways.as_i64() as u32;
+                    compatibility.gateway_usage_method = if gateway.prefer_direct {
+                        GatewayUsageMethod::Detect.as_i64() as u32
+                    } else {
+                        GatewayUsageMethod::UseAlways.as_i64() as u32
+                    };
                     compatibility.gateway_creds_source = GatewayCredentialsSource::UseUserCredentials.as_i64() as u32;
                 }
                 Transport::RDCleanPath(_) => {
@@ -8867,7 +9106,14 @@ impl Control {
             Some(transport) => transport,
             None => match self.rdcleanpath_transport()? {
                 Some(transport) => transport,
-                None => active_x_transport(&settings, &compatibility)?,
+                None => {
+                    let parent = if self.credential_parent.get().0.is_null() {
+                        self.activex_window.get()
+                    } else {
+                        self.credential_parent.get()
+                    };
+                    active_x_transport(&settings, &compatibility, parent)?
+                }
             },
         };
         let performance_flags = compatibility.performance_flags;
@@ -9119,8 +9365,13 @@ impl Control {
                 endpoint,
                 username,
                 password,
+                prefer_direct,
             } => builder
-                .with_transport(TransportKind::Gateway { endpoint })
+                .with_transport(TransportKind::Gateway {
+                    endpoint,
+                    prefer_direct,
+                    transport: Default::default(),
+                })
                 .with_gateway_username(username)
                 .with_gateway_password(password),
             ActiveXTransport::RDCleanPath(rdcleanpath) => builder
@@ -15525,7 +15776,7 @@ mod tests {
 
     #[test]
     fn gateway_transport_maps_only_honored_public_modes() {
-        let settings = Settings {
+        let mut settings = Settings {
             domain: "RDP".to_owned(),
             username: "server-user".to_owned(),
             password: Some("server-password".to_owned()),
@@ -15537,24 +15788,37 @@ mod tests {
             ..CompatibilitySettings::default()
         };
 
+        let no_parent = HWND(ptr::null_mut());
         let ActiveXTransport::Gateway {
             endpoint,
             username,
             password,
-        } = active_x_transport(&settings, &compatibility).expect("explicit gateway is supported")
+            prefer_direct,
+        } = active_x_transport(&settings, &compatibility, no_parent).expect("explicit gateway is supported")
         else {
             panic!("expected gateway transport");
         };
         assert_eq!(endpoint, "gateway.example.test:443");
         assert_eq!(username, "RDP\\server-user");
         assert_eq!(password, "server-password");
+        assert!(!prefer_direct);
+
+        compatibility.gateway_usage_method = GatewayUsageMethod::Detect.as_i64() as u32;
+        let ActiveXTransport::Gateway {
+            prefer_direct: detect_prefer_direct,
+            ..
+        } = active_x_transport(&settings, &compatibility, no_parent).expect("detect with hostname selects gateway")
+        else {
+            panic!("expected gateway transport");
+        };
+        assert!(detect_prefer_direct);
 
         compatibility.gateway_creds_source = GatewayCredentialsSource::UseUserCredentials.as_i64() as u32;
         compatibility.gateway_domain = "GATEWAY".to_owned();
         compatibility.gateway_username = "gateway-user".to_owned();
         compatibility.gateway_password = "gateway-password".to_owned();
         let ActiveXTransport::Gateway { username, password, .. } =
-            active_x_transport(&settings, &compatibility).expect("gateway user credentials are supported")
+            active_x_transport(&settings, &compatibility, no_parent).expect("gateway user credentials are supported")
         else {
             panic!("expected gateway transport");
         };
@@ -15562,19 +15826,65 @@ mod tests {
         assert_eq!(password, "gateway-password");
 
         compatibility.gateway_usage_method = GatewayUsageMethod::UseDefaultSettings.as_i64() as u32;
-        let system_policy_error = match active_x_transport(&settings, &compatibility) {
-            Ok(_) => panic!("system policy must not be silently approximated"),
-            Err(error) => error,
+        let ActiveXTransport::Gateway {
+            prefer_direct: default_prefer_direct,
+            ..
+        } = active_x_transport(&settings, &compatibility, no_parent)
+            .expect("default settings with hostname select gateway like Detect")
+        else {
+            panic!("expected gateway transport");
         };
-        assert_eq!(system_policy_error.code(), E_NOTIMPL);
+        assert!(default_prefer_direct);
 
         compatibility.gateway_usage_method = GatewayUsageMethod::UseAlways.as_i64() as u32;
-        compatibility.gateway_creds_source = GatewayCredentialsSource::Prompt.as_i64() as u32;
-        let prompt_error = match active_x_transport(&settings, &compatibility) {
-            Ok(_) => panic!("gateway prompting is not implemented"),
+        compatibility.gateway_creds_source = GatewayCredentialsSource::UseLogonCredentials.as_i64() as u32;
+        compatibility.gateway_domain.clear();
+        compatibility.gateway_username.clear();
+        compatibility.gateway_password = "logon-password".to_owned();
+        let ActiveXTransport::Gateway {
+            username: logon_user,
+            password: logon_password,
+            ..
+        } = active_x_transport(&settings, &compatibility, no_parent)
+            .expect("UseLogonCredentials accepts an explicit password")
+        else {
+            panic!("expected gateway transport");
+        };
+        assert!(!logon_user.is_empty());
+        assert_eq!(logon_password, "logon-password");
+
+        compatibility.gateway_password.clear();
+        settings.password = None;
+        let logon_sso_error = match active_x_transport(&settings, &compatibility, no_parent) {
+            Ok(_) => panic!("passwordless UseLogonCredentials SSO is not implemented"),
             Err(error) => error,
         };
-        assert_eq!(prompt_error.code(), E_NOTIMPL);
+        assert_eq!(logon_sso_error.code(), E_NOTIMPL);
+
+        settings.password = Some("server-password".to_owned());
+        compatibility.gateway_creds_source = GatewayCredentialsSource::Prompt.as_i64() as u32;
+        compatibility.gateway_domain = "GATEWAY".to_owned();
+        compatibility.gateway_username = "prompt-user".to_owned();
+        compatibility.gateway_password = "prompt-password".to_owned();
+        let ActiveXTransport::Gateway {
+            username: prompt_user,
+            password: prompt_password,
+            ..
+        } = active_x_transport(&settings, &compatibility, no_parent)
+            .expect("Prompt accepts prefilled gateway credentials without UI")
+        else {
+            panic!("expected gateway transport");
+        };
+        assert_eq!(prompt_user, "GATEWAY\\prompt-user");
+        assert_eq!(prompt_password, "prompt-password");
+
+        compatibility.gateway_username.clear();
+        compatibility.gateway_password.clear();
+        let prompt_empty_error = match active_x_transport(&settings, &compatibility, no_parent) {
+            Ok(_) => panic!("empty Prompt without a host window must fail"),
+            Err(error) => error,
+        };
+        assert_eq!(prompt_empty_error.code(), E_INVALIDARG);
     }
 
     #[test]

--- a/crates/ironrdp-agent/Cargo.toml
+++ b/crates/ironrdp-agent/Cargo.toml
@@ -26,7 +26,9 @@ ironrdp-cfg = { path = "../ironrdp-cfg", version = "0.1" }
 ironrdp-rdpfile = { path = "../ironrdp-rdpfile", version = "0.1" }
 ironrdp-input = { path = "../ironrdp-input", version = "0.7" }
 ironrdp-daemon = { path = "../ironrdp-daemon", version = "0.1" }
+ironrdp-gwforward = { path = "../ironrdp-gwforward", version = "0.0" }
 ironrdp-rpc = { path = "../ironrdp-rpc", version = "0.1" }
+ironrdp-tls = { path = "../ironrdp-tls", version = "0.2" }
 
 # Async runtime
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "net", "io-util", "rt"] }

--- a/crates/ironrdp-agent/src/cli.rs
+++ b/crates/ironrdp-agent/src/cli.rs
@@ -55,6 +55,9 @@ enum Command {
     DaemonStart(DaemonArgs),
     /// Open an RDP session from a .rdp file and/or CLI overrides.
     Connect(ConnectArgs),
+    /// Forward TCP through an RD Gateway tunnel without an RDP session: a fixed local
+    /// port forward (SSH `-L`-style) or a SOCKS5 proxy a generic program can use.
+    GwForward(GwForwardArgs),
     /// Tear down the current RDP session (the daemon keeps running).
     Disconnect,
     /// Report the current session status.
@@ -491,6 +494,21 @@ struct ConnectArgs {
     /// RDP account domain. Overrides the .rdp file.
     #[arg(short, long)]
     domain: Option<String>,
+    /// RD Gateway server address (host[:port]). Enables the gateway for this session.
+    /// Overrides the .rdp file.
+    #[arg(long, env = "RDG_HOSTNAME")]
+    gateway: Option<String>,
+    /// RD Gateway user name. Defaults to the RDP username when unset, matching mstsc's
+    /// shared-credential behavior (`gatewaycredentialssource:i:0`).
+    #[arg(long, env = "RDG_USERNAME")]
+    gateway_username: Option<String>,
+    /// RD Gateway password. Defaults to the RDP password when unset.
+    #[arg(long, env = "RDG_PASSWORD", hide_env_values = true)]
+    gateway_password: Option<String>,
+    /// RD Gateway transport protocol: `websocket` (default, modern) or `rpc`
+    /// (legacy RPC-over-HTTP). Use `rpc` for gateways without WebSocket support.
+    #[arg(long, value_name = "websocket|rpc")]
+    gateway_transport: Option<String>,
     /// Tracing filter directive applied to this session's log capture (e.g.
     /// `ironrdp_connector=trace`), layered on top of the default `debug` level. Use it to raise
     /// verbosity up-front when troubleshooting a connection.
@@ -506,6 +524,43 @@ struct ConnectArgs {
     #[cfg(windows)]
     #[arg(long, value_name = "PIPE", conflicts_with = "server")]
     sandbox_pipe: Option<String>,
+}
+
+#[derive(Args, Debug)]
+struct GwForwardArgs {
+    /// Local listen address (host:port) for the forwarder / proxy.
+    #[arg(long, default_value = "127.0.0.1:1080")]
+    listen: String,
+    /// SOCKS5 proxy mode: each client CONNECT names its own destination. Omit for a
+    /// fixed port forward to `--target`.
+    #[arg(long)]
+    socks5: bool,
+    /// Fixed forward target (host:port) for non-SOCKS5 mode.
+    #[arg(long, value_name = "HOST:PORT")]
+    target: Option<String>,
+    /// RD Gateway server address (host[:port]). Enables the gateway tunnel.
+    #[arg(long, env = "RDG_HOSTNAME")]
+    gateway: Option<String>,
+    /// RD Gateway user name. Defaults to the RDP username when unset, matching mstsc's
+    /// shared-credential behavior.
+    #[arg(long, env = "RDG_USERNAME")]
+    gateway_username: Option<String>,
+    /// RD Gateway password. Defaults to the RDP password when unset.
+    #[arg(long, env = "RDG_PASSWORD", hide_env_values = true)]
+    gateway_password: Option<String>,
+    /// RDP account user name, used as the default gateway username.
+    #[arg(short, long, env = "RDP_USERNAME")]
+    username: Option<String>,
+    /// RDP account password, used as the default gateway password.
+    #[arg(short, long, env = "RDP_PASSWORD", hide_env_values = true)]
+    password: Option<String>,
+    /// RD Gateway transport protocol: `websocket` (default) or `rpc`.
+    #[arg(long, value_name = "websocket|rpc")]
+    gateway_transport: Option<String>,
+    /// Skip TLS certificate and hostname validation for the gateway. Use only for an
+    /// explicitly authorized test endpoint.
+    #[arg(long)]
+    skip_certificate_check: bool,
 }
 
 #[derive(Args, Debug)]
@@ -835,6 +890,9 @@ pub async fn run(cli: Cli) -> anyhow::Result<()> {
             return Ok(());
         }
         Command::Connect(args) => build_connect_request(args)?,
+        Command::GwForward(args) => {
+            return run_gw_forward(args).await;
+        }
         #[cfg(windows)]
         Command::Sandbox(args) => {
             return run_sandbox_command(args);
@@ -1048,6 +1106,32 @@ fn build_connect_request(args: ConnectArgs) -> anyhow::Result<Request> {
         properties.set_domain(domain);
     }
 
+    // RD Gateway: enable the gateway transport and share the RDP credentials with it by
+    // default, the same shared-credential behavior as mstsc (`gatewaycredentialssource:i:0`).
+    // Explicit RDG_USERNAME / RDG_PASSWORD (or --gateway-username / --gateway-password) win.
+    if let Some(gateway) = args.gateway {
+        properties.set_gateway_hostname(gateway);
+        properties.set_gateway_usage_method(ironrdp_cfg::GatewayUsageMethod::UseAlways);
+        let gateway_username = args
+            .gateway_username
+            .or_else(|| properties.username().map(str::to_owned))
+            .context("gateway username: set RDG_USERNAME or RDP_USERNAME")?;
+        let gateway_password = args
+            .gateway_password
+            .or_else(|| properties.clear_text_password().map(str::to_owned))
+            .context("gateway password: set RDG_PASSWORD or RDP_PASSWORD")?;
+        properties.set_gateway_username(gateway_username);
+        properties.set_gateway_password(gateway_password);
+        if let Some(transport) = &args.gateway_transport {
+            let value = match transport.as_str() {
+                "websocket" | "ws" => 0,
+                "rpc" | "rpch" => 1,
+                other => anyhow::bail!("invalid --gateway-transport {other:?}: expected websocket or rpc"),
+            };
+            properties.insert("ironrdp_gateway_transport", value);
+        }
+    }
+
     #[cfg(windows)]
     {
         // Sandbox defaults are the base; explicit .rdp / --prop / named flags win on conflict.
@@ -1123,6 +1207,75 @@ fn run_sandbox_command(args: SandboxArgs) -> anyhow::Result<()> {
             Ok(())
         }
     }
+}
+
+/// Forward TCP through an RD Gateway tunnel without an RDP session: a fixed local port
+/// forward, or a SOCKS5 proxy that opens a tunnel per requested destination.
+async fn run_gw_forward(args: GwForwardArgs) -> anyhow::Result<()> {
+    use ironrdp_gwforward::{GatewayTransport, GatewayTunnelConfig, run_port_forward, run_socks5};
+
+    let gateway = args
+        .gateway
+        .context("gateway endpoint: set RDG_HOSTNAME or pass --gateway")?;
+    // Reuse the RDP credentials for the gateway by default (mstsc shared-credential
+    // behavior); explicit RDG_USERNAME / RDG_PASSWORD win.
+    let username = args
+        .gateway_username
+        .or(args.username)
+        .context("gateway username: set RDG_USERNAME or RDP_USERNAME")?;
+    let password = args
+        .gateway_password
+        .or(args.password)
+        .context("gateway password: set RDG_PASSWORD or RDP_PASSWORD")?;
+    let transport = match args.gateway_transport.as_deref() {
+        None | Some("websocket" | "ws") => GatewayTransport::WebSocket,
+        Some("rpc" | "rpch") => GatewayTransport::Rpc,
+        Some(other) => anyhow::bail!("invalid --gateway-transport {other:?}: expected websocket or rpc"),
+    };
+    let certificate_validation = if args.skip_certificate_check {
+        ironrdp_tls::CertificateValidation::DangerouslyAcceptInvalidCertificate
+    } else {
+        ironrdp_tls::CertificateValidation::Strict
+    };
+    let config = GatewayTunnelConfig {
+        gateway_endpoint: gateway,
+        username,
+        password,
+        transport,
+        client_name: "ironrdp-agent".to_owned(),
+        certificate_validation,
+    };
+
+    if args.socks5 {
+        println!(
+            "socks5 proxy listening on {} (RD Gateway {})",
+            args.listen, config.gateway_endpoint
+        );
+        run_socks5(config, &args.listen).await?;
+    } else {
+        let target = args
+            .target
+            .context("fixed forward requires --target HOST:PORT (or use --socks5)")?;
+        let (host, port) = parse_host_port(&target)?;
+        println!(
+            "forwarding {} to {}:{} via RD Gateway {}",
+            args.listen, host, port, config.gateway_endpoint
+        );
+        run_port_forward(config, &args.listen, &host, port).await?;
+    }
+    Ok(())
+}
+
+/// Parse a `host:port` target, defaulting to port 3389.
+fn parse_host_port(target: &str) -> anyhow::Result<(String, u16)> {
+    let (host, port) = match target.rsplit_once(':') {
+        Some((host, port)) => (host, port.parse::<u16>().context("invalid target port")?),
+        None => (target, 3389),
+    };
+    if host.is_empty() {
+        anyhow::bail!("target host is empty");
+    }
+    Ok((host.to_owned(), port))
 }
 
 async fn run_rail(endpoint: &Endpoint, args: RailArgs) -> anyhow::Result<()> {
@@ -2187,6 +2340,9 @@ mod tests {
             ("server", "RDP_HOSTNAME"),
             ("username", "RDP_USERNAME"),
             ("password", "RDP_PASSWORD"),
+            ("gateway", "RDG_HOSTNAME"),
+            ("gateway_username", "RDG_USERNAME"),
+            ("gateway_password", "RDG_PASSWORD"),
         ] {
             let environment = connect
                 .get_arguments()
@@ -2199,6 +2355,77 @@ mod tests {
     #[test]
     fn shell_is_not_an_agent_command() {
         assert!(Cli::try_parse_from(["ironrdp-agent", "now", "shell"]).is_err());
+    }
+
+    #[test]
+    fn connect_gateway_shares_rdp_credentials_by_default() {
+        use super::{Request, build_connect_request};
+        use ironrdp_cfg::PropertySetExt as _;
+
+        let cli = Cli::try_parse_from([
+            "ironrdp-agent",
+            "connect",
+            "--server",
+            "rdp.contoso.com",
+            "--username",
+            "alice",
+            "--password",
+            "secret",
+            "--gateway",
+            "rdg.contoso.com",
+        ])
+        .expect("valid connect arguments");
+        let Some(Command::Connect(args)) = cli.command else {
+            panic!("expected connect command");
+        };
+
+        let Request::Connect { properties, .. } = build_connect_request(args).expect("connect request") else {
+            panic!("expected connect request");
+        };
+        // The gateway is enabled and inherits the RDP credentials when no
+        // RDG_USERNAME / RDG_PASSWORD is provided.
+        assert_eq!(properties.gateway_hostname(), Some("rdg.contoso.com"));
+        assert_eq!(properties.gateway_username(), Some("alice"));
+        assert_eq!(
+            properties.gateway_password().map(str::to_owned).as_deref(),
+            Some("secret")
+        );
+    }
+
+    #[test]
+    fn connect_gateway_prefers_explicit_gateway_credentials() {
+        use super::{Request, build_connect_request};
+        use ironrdp_cfg::PropertySetExt as _;
+
+        let cli = Cli::try_parse_from([
+            "ironrdp-agent",
+            "connect",
+            "--server",
+            "rdp.contoso.com",
+            "--username",
+            "alice",
+            "--password",
+            "secret",
+            "--gateway",
+            "rdg.contoso.com",
+            "--gateway-username",
+            "gw-alice",
+            "--gateway-password",
+            "gw-secret",
+        ])
+        .expect("valid connect arguments");
+        let Some(Command::Connect(args)) = cli.command else {
+            panic!("expected connect command");
+        };
+
+        let Request::Connect { properties, .. } = build_connect_request(args).expect("connect request") else {
+            panic!("expected connect request");
+        };
+        assert_eq!(properties.gateway_username(), Some("gw-alice"));
+        assert_eq!(
+            properties.gateway_password().map(str::to_owned).as_deref(),
+            Some("gw-secret")
+        );
     }
 
     #[test]

--- a/crates/ironrdp-capture-replay/README.md
+++ b/crates/ironrdp-capture-replay/README.md
@@ -3,12 +3,22 @@
 `ironrdp-capture-replay` replays supported direct-TCP RDP captures offline and exports framebuffer snapshots without writing TLS secrets, decrypted payloads, or raw capture data.
 It is an internal analysis tool built on the replay routing pipeline.
 
+RD Gateway (MS-TSGU) captures are supported: when the selected flow is a TLS session whose plaintext starts with an `RDG_OUT_DATA` WebSocket upgrade, the gateway framing (WebSocket messages carrying `HTTP_DATA_PACKET` packets) is unwrapped first and the recovered inner RDP stream is replayed like a direct capture.
+
 ## Exporting frames
 
 Run the CLI with a pcapng capture that contains the TLS key-log material required by the replay pipeline.
 
 ```shell
 cargo run -p ironrdp-capture-replay --bin ironrdp-capture-replay -- capture.pcapng replay-output
+```
+
+Captures exported from Wireshark only embed TLS secrets for flows Wireshark can see.
+A gateway-tunneled RDP session is a second TLS session inside the tunnel, which Wireshark does not dissect, so its secrets are missing from the exported capture.
+Pass the original key log (for example an LSA `tls-lsa.log`) with `--keylog` to supply those secrets:
+
+```shell
+cargo run -p ironrdp-capture-replay --bin ironrdp-capture-replay -- --keylog tls-lsa.log capture.pcapng replay-output
 ```
 
 The command succeeds only when replay produces visual framebuffer updates.

--- a/crates/ironrdp-capture-replay/src/bin/ironrdp-capture-replay.rs
+++ b/crates/ironrdp-capture-replay/src/bin/ironrdp-capture-replay.rs
@@ -22,22 +22,35 @@ fn main() -> ExitCode {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
             eprintln!("replay export failed: {error}");
+            let mut source = core::error::Error::source(error.as_ref());
+            while let Some(cause) = source {
+                eprintln!("  caused by: {cause}");
+                source = cause.source();
+            }
             ExitCode::FAILURE
         }
     }
 }
 
-fn run() -> Result<(), String> {
-    let arguments = parse_arguments(std::env::args_os().skip(1))?;
-    let capture = read_capture(&arguments.capture).map_err(|error| error.to_string())?;
+fn usage_error(message: String) -> Box<dyn core::error::Error> {
+    std::io::Error::new(std::io::ErrorKind::InvalidInput, message).into()
+}
+
+fn run() -> Result<(), Box<dyn core::error::Error>> {
+    let arguments = parse_arguments(std::env::args_os().skip(1)).map_err(usage_error)?;
+    let mut capture = read_capture(&arguments.capture)?;
+    if let Some(key_log) = &arguments.key_log {
+        let key_log = std::fs::read_to_string(key_log)
+            .map_err(|error| usage_error(format!("failed to read {}: {error}", key_log.display())))?;
+        capture.add_tls_key_log(&key_log);
+    }
     let summary = export_capture(
         &capture,
         &ExportOptions {
             directory: arguments.output,
             replace: arguments.replace,
         },
-    )
-    .map_err(|error| error.to_string())?;
+    )?;
 
     println!(
         "exported {} replay frame(s) to {}",
@@ -50,15 +63,20 @@ fn run() -> Result<(), String> {
 struct Arguments {
     capture: PathBuf,
     output: PathBuf,
+    key_log: Option<PathBuf>,
     replace: bool,
 }
 
 fn parse_arguments(arguments: impl Iterator<Item = OsString>) -> Result<Arguments, String> {
     let mut replace = false;
+    let mut key_log = None;
     let mut paths = Vec::new();
-    for argument in arguments {
+    let mut arguments = arguments.peekable();
+    while let Some(argument) = arguments.next() {
         if argument == "--replace" {
             replace = true;
+        } else if argument == "--keylog" {
+            key_log = Some(PathBuf::from(arguments.next().ok_or_else(usage)?));
         } else if argument.to_string_lossy().starts_with('-') {
             return Err(usage());
         } else {
@@ -70,10 +88,11 @@ fn parse_arguments(arguments: impl Iterator<Item = OsString>) -> Result<Argument
     Ok(Arguments {
         capture: PathBuf::from(capture),
         output: PathBuf::from(output),
+        key_log,
         replace,
     })
 }
 
 fn usage() -> String {
-    "usage: ironrdp-capture-replay [--replace] <capture.pcapng> <output-directory>".to_owned()
+    "usage: ironrdp-capture-replay [--replace] [--keylog <tls-keys.log>] <capture.pcapng> <output-directory>".to_owned()
 }

--- a/crates/ironrdp-capture-replay/src/error.rs
+++ b/crates/ironrdp-capture-replay/src/error.rs
@@ -26,6 +26,11 @@ pub enum ReplayError {
     /// The capture lacks the key-log entry required to decrypt its TLS session.
     #[error("capture does not include an NSS TLS secret for the negotiated session")]
     MissingTlsSecret,
+    /// The capture lacks the key-log entry for the gateway-tunneled TLS session.
+    #[error(
+        "capture does not include an NSS TLS secret for the gateway-tunneled session; exports only embed secrets for flows Wireshark sees, so supply the original key log with --keylog"
+    )]
+    MissingTunneledTlsSecret,
     /// TLS record authentication failed.
     #[error("capture TLS authentication failed")]
     TlsAuthentication,
@@ -53,4 +58,7 @@ pub enum ReplayError {
     /// A captured dynamic channel could not be attached.
     #[error("captured dynamic channel could not be attached")]
     DynamicChannelAttachment,
+    /// The gateway tunnel framing is incomplete or malformed.
+    #[error("capture gateway tunnel framing is invalid: {0}")]
+    GatewayFraming(String),
 }

--- a/crates/ironrdp-capture-replay/src/gateway.rs
+++ b/crates/ironrdp-capture-replay/src/gateway.rs
@@ -1,0 +1,413 @@
+//! MS-TSGU gateway tunnel extraction for captured TLS-decrypted HTTPS flows.
+//!
+//! Modern RD Gateway clients carry MS-TSGU packets in WebSocket binary frames
+//! after an `RDG_OUT_DATA` upgrade. This module unwraps that framing and
+//! recovers the tunneled RDP byte stream ([MS-TSGU] 2.2.10).
+
+use crate::transport::flatten;
+use crate::{PacketStream, Plaintext, ReplayError};
+
+/// `HTTP_DATA_PACKET` payload prefix: 2-byte length after the packet header.
+const DATA_PACKET_HEADER: usize = 8 /* packet header */ + 2 /* data length */;
+/// Maximum accepted WebSocket frame payload, larger than any TLS record batch.
+const MAX_WEBSOCKET_PAYLOAD: usize = 16 * 1024 * 1024;
+
+/// Returns `true` when the decrypted TLS streams carry an RDG WebSocket upgrade.
+pub fn is_gateway_tunnel(plaintext: &Plaintext) -> bool {
+    flatten(&plaintext.client).starts_with(b"RDG_OUT_DATA /remoteDesktopGateway/")
+}
+
+/// Extract the tunneled RDP bytes from a decrypted RDG WebSocket session.
+///
+/// The returned streams contain raw RDP traffic (starting with the X.224
+/// connection request) exactly as a direct TCP capture would carry it.
+pub fn extract_tunneled_rdp(plaintext: &Plaintext) -> Result<Plaintext, ReplayError> {
+    let client = websocket_payloads(&plaintext.client, true)?;
+    let server = websocket_payloads(&plaintext.server, false)?;
+    Ok(Plaintext {
+        client: data_packets(&client)?,
+        server: data_packets(&server)?,
+    })
+}
+
+/// HTTP method tokens that can start a gateway request head.
+const REQUEST_HEAD_PREFIXES: [&[u8]; 4] = [
+    b"RDG_OUT_DATA ".as_slice(),
+    b"RDG_IN_DATA ".as_slice(),
+    b"RPC_OUT_DATA ".as_slice(),
+    b"RPC_IN_DATA ".as_slice(),
+];
+
+/// Split one direction into WebSocket message payloads, skipping the HTTP heads.
+///
+/// Client-to-server frames are masked per RFC 6455; server frames are not.
+/// Authentication can add request/response round trips (e.g. an NTLM 401
+/// challenge) before the final WebSocket upgrade, so interim HTTP heads are
+/// skipped until the bytes no longer look like HTTP.
+fn websocket_payloads(stream: &PacketStream, masked: bool) -> Result<PacketStream, ReplayError> {
+    let mut bytes = Vec::new();
+    let mut packet_offsets = Vec::with_capacity(stream.len());
+    for (packet, chunk) in stream {
+        packet_offsets.push((bytes.len(), *packet));
+        bytes.extend_from_slice(chunk);
+    }
+
+    let head_prefixes: &[&[u8]] = if masked {
+        &REQUEST_HEAD_PREFIXES
+    } else {
+        &[b"HTTP/".as_slice()]
+    };
+    let mut head_end = 0;
+    loop {
+        let head_start = head_end;
+        head_end += bytes[head_end..]
+            .windows(4)
+            .position(|window| window == b"\r\n\r\n")
+            .map(|position| position + 4)
+            .ok_or(ReplayError::UnsupportedTransport)?;
+        // Interim responses such as NTLM 401 challenges carry an error body.
+        if !masked {
+            head_end += content_length(&bytes[head_start..head_end]);
+        }
+        // WebSocket frames start with a non-ASCII opcode byte, never a head.
+        match bytes.get(head_end..) {
+            Some(rest) if head_prefixes.iter().any(|prefix| rest.starts_with(prefix)) => {}
+            _ => break,
+        }
+    }
+
+    let mut frames = Vec::new();
+    let mut offset = head_end;
+    let mut message = Vec::new();
+    let mut message_packet = 0usize;
+    while offset < bytes.len() {
+        let Some(frame) = parse_websocket_frame(&bytes[offset..], masked) else {
+            break;
+        };
+        let packet_index = packet_offsets.partition_point(|(chunk_offset, _)| *chunk_offset <= offset) - 1;
+        offset += frame.encoded_len;
+
+        match frame.opcode {
+            // Continuation or binary data.
+            0x0 | 0x2 => {
+                if message.is_empty() {
+                    message_packet = packet_offsets[packet_index].1;
+                }
+                message.extend_from_slice(&frame.payload);
+                if frame.fin {
+                    frames.push((message_packet, core::mem::take(&mut message)));
+                }
+            }
+            // Ping/pong carry no channel data.
+            0x9 | 0xA => {}
+            // Close ends the tunnel.
+            0x8 => break,
+            _ => return Err(ReplayError::UnsupportedTransport),
+        }
+    }
+
+    Ok(frames)
+}
+
+/// Extract the `Content-Length` of an HTTP head, if present.
+fn content_length(head: &[u8]) -> usize {
+    let Ok(head) = core::str::from_utf8(head) else {
+        return 0;
+    };
+    head.split("\r\n")
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.trim()
+                .eq_ignore_ascii_case("content-length")
+                .then(|| value.trim().parse::<usize>().ok())?
+        })
+        .unwrap_or(0)
+}
+
+struct WebsocketFrame {
+    encoded_len: usize,
+    fin: bool,
+    opcode: u8,
+    payload: Vec<u8>,
+}
+
+fn parse_websocket_frame(bytes: &[u8], masked: bool) -> Option<WebsocketFrame> {
+    let first = *bytes.first()?;
+    let second = *bytes.get(1)?;
+    let mut offset = 2;
+    let length = match second & 0x7f {
+        126 => {
+            let length = u16::from_be_bytes(bytes.get(offset..offset + 2)?.try_into().ok()?);
+            offset += 2;
+            usize::from(length)
+        }
+        127 => {
+            let length = u64::from_be_bytes(bytes.get(offset..offset + 8)?.try_into().ok()?);
+            offset += 8;
+            usize::try_from(length).ok()?
+        }
+        length => usize::from(length),
+    };
+    if length > MAX_WEBSOCKET_PAYLOAD {
+        return None;
+    }
+
+    let mask = if second & 0x80 != 0 {
+        let mask: [u8; 4] = bytes.get(offset..offset + 4)?.try_into().ok()?;
+        offset += 4;
+        Some(mask)
+    } else {
+        None
+    };
+    if masked != mask.is_some() {
+        return None;
+    }
+
+    let mut payload = bytes.get(offset..offset + length)?.to_vec();
+    if let Some(mask) = mask {
+        for (index, byte) in payload.iter_mut().enumerate() {
+            *byte ^= mask[index % 4];
+        }
+    }
+
+    Some(WebsocketFrame {
+        encoded_len: offset + length,
+        fin: first & 0x80 != 0,
+        opcode: first & 0x0f,
+        payload,
+    })
+}
+
+/// Keep the RDP payloads of `HTTP_DATA_PACKET` packets in tunnel order.
+fn data_packets(frames: &PacketStream) -> Result<PacketStream, ReplayError> {
+    let mut output = Vec::new();
+    let mut pending = Vec::new();
+    for (packet, frame) in frames {
+        pending.extend_from_slice(frame);
+        while let Some(header) = pending.get(..8) {
+            let length = usize::try_from(u32::from_le_bytes(
+                header[4..8].try_into().expect("header length slice"),
+            ))
+            .map_err(|_| ReplayError::GatewayFraming("packet length is too large".to_owned()))?;
+            if !(8..=MAX_WEBSOCKET_PAYLOAD).contains(&length) {
+                return Err(ReplayError::GatewayFraming("packet length is invalid".to_owned()));
+            }
+            if pending.len() < length {
+                break;
+            }
+            let packet_bytes = pending[..length].to_vec();
+            pending.drain(..length);
+
+            let packet_type = u16::from_le_bytes(packet_bytes[..2].try_into().expect("packet type slice"));
+            if packet_type == 0x0A {
+                // HTTP_DATA_PACKET ([MS-TSGU] 2.2.10.10).
+                let data = packet_bytes
+                    .get(DATA_PACKET_HEADER..)
+                    .ok_or_else(|| ReplayError::GatewayFraming("truncated data packet".to_owned()))?;
+                let declared = usize::from(u16::from_le_bytes(
+                    packet_bytes[8..10].try_into().expect("data length slice"),
+                ));
+                if declared != data.len() {
+                    return Err(ReplayError::GatewayFraming(
+                        "data packet length does not match its header".to_owned(),
+                    ));
+                }
+                output.push((*packet, data.to_vec()));
+            }
+        }
+    }
+
+    if output.is_empty() {
+        return Err(ReplayError::MissingRdpState);
+    }
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request_head() -> Vec<u8> {
+        b"RDG_OUT_DATA /remoteDesktopGateway/ HTTP/1.1\r\nConnection: Upgrade\r\n\r\n".to_vec()
+    }
+
+    fn response_head(status: &str, content_length: usize) -> Vec<u8> {
+        format!("HTTP/1.1 {status}\r\nContent-Length: {content_length}\r\n\r\n").into_bytes()
+    }
+
+    /// Build an MS-TSGU packet of the given type wrapping `data` as an
+    /// `HTTP_DATA_PACKET` payload.
+    fn tsgu_data_packet(data: &[u8]) -> Vec<u8> {
+        let length = u32::try_from(DATA_PACKET_HEADER + data.len()).unwrap();
+        let mut packet = Vec::new();
+        packet.extend(0x0Au16.to_le_bytes());
+        packet.extend(0u16.to_le_bytes());
+        packet.extend(length.to_le_bytes());
+        packet.extend(u16::try_from(data.len()).unwrap().to_le_bytes());
+        packet.extend(data);
+        packet
+    }
+
+    /// Build a non-data MS-TSGU packet (e.g. tunnel channel control).
+    fn tsgu_control_packet(packet_type: u16, body: &[u8]) -> Vec<u8> {
+        let length = u32::try_from(8 + body.len()).unwrap();
+        let mut packet = Vec::new();
+        packet.extend(packet_type.to_le_bytes());
+        packet.extend(0u16.to_le_bytes());
+        packet.extend(length.to_le_bytes());
+        packet.extend(body);
+        packet
+    }
+
+    /// Encode one WebSocket frame, masking client frames per RFC 6455.
+    fn websocket_frame(fin: bool, opcode: u8, payload: &[u8], mask: Option<[u8; 4]>) -> Vec<u8> {
+        let mut frame = vec![(u8::from(fin) << 7) | opcode];
+        let mask_bit = u8::from(mask.is_some()) << 7;
+        if payload.len() < 126 {
+            frame.push(mask_bit | u8::try_from(payload.len()).unwrap());
+        } else if u16::try_from(payload.len()).is_ok() {
+            frame.push(mask_bit | 126);
+            frame.extend(u16::try_from(payload.len()).unwrap().to_be_bytes());
+        } else {
+            frame.push(mask_bit | 127);
+            frame.extend(u64::try_from(payload.len()).unwrap().to_be_bytes());
+        }
+        match mask {
+            Some(mask) => {
+                frame.extend(mask);
+                frame.extend(payload.iter().enumerate().map(|(index, byte)| byte ^ mask[index % 4]));
+            }
+            None => frame.extend(payload),
+        }
+        frame
+    }
+
+    fn client_frame(payload: &[u8]) -> Vec<u8> {
+        websocket_frame(true, 0x2, payload, Some([1, 2, 3, 4]))
+    }
+
+    fn server_frame(payload: &[u8]) -> Vec<u8> {
+        websocket_frame(true, 0x2, payload, None)
+    }
+
+    fn tunneled_capture(client_body: Vec<u8>, server_body: Vec<u8>) -> Plaintext {
+        let mut client = request_head();
+        client.extend(client_body);
+        let mut server = response_head("101 Switching Protocols", 0);
+        server.extend(server_body);
+        Plaintext {
+            client: vec![(1, client)],
+            server: vec![(2, server)],
+        }
+    }
+
+    #[test]
+    fn detects_gateway_upgrade() {
+        let plaintext = tunneled_capture(Vec::new(), Vec::new());
+        assert!(is_gateway_tunnel(&plaintext));
+
+        let direct = Plaintext {
+            client: vec![(1, vec![3, 0, 0, 11, 6, 0xe0, 0, 0, 0, 0, 0])],
+            server: vec![(2, vec![3, 0, 0, 11, 6, 0xd0, 0, 0, 0, 0, 0])],
+        };
+        assert!(!is_gateway_tunnel(&direct));
+    }
+
+    #[test]
+    fn extracts_data_packets_from_masked_client_frames() {
+        let rdp = [0x03, 0x00, 0x00, 0x13, 0x0e, 0xe0];
+        let plaintext = tunneled_capture(
+            client_frame(&tsgu_data_packet(&rdp)),
+            server_frame(&tsgu_data_packet(&rdp)),
+        );
+
+        let inner = extract_tunneled_rdp(&plaintext).unwrap();
+
+        assert_eq!(inner.client, vec![(1, rdp.to_vec())]);
+        assert_eq!(inner.server, vec![(2, rdp.to_vec())]);
+    }
+
+    #[test]
+    fn skips_interim_authentication_round_trips() {
+        let rdp = [0x03, 0x00, 0x00, 0x13, 0x0e, 0xe0];
+        let mut client = request_head();
+        client.extend(request_head());
+        client.extend(client_frame(&tsgu_data_packet(&rdp)));
+        let mut server = response_head("401 Unauthorized", 24);
+        server.extend([0xAA; 24]);
+        server.extend(response_head("101 Switching Protocols", 0));
+        server.extend(server_frame(&tsgu_data_packet(&rdp)));
+        let plaintext = Plaintext {
+            client: vec![(1, client)],
+            server: vec![(2, server)],
+        };
+
+        let inner = extract_tunneled_rdp(&plaintext).unwrap();
+
+        assert_eq!(inner.client, vec![(1, rdp.to_vec())]);
+        assert_eq!(inner.server, vec![(2, rdp.to_vec())]);
+    }
+
+    #[test]
+    fn reassembles_packets_split_across_frames() {
+        let rdp: Vec<u8> = (0..200u16).map(|value| u8::try_from(value % 256).unwrap()).collect();
+        let packet = tsgu_data_packet(&rdp);
+        let split = packet.len() / 2;
+        let mut body = websocket_frame(false, 0x2, &packet[..split], Some([9, 9, 9, 9]));
+        body.extend(websocket_frame(true, 0x0, &packet[split..], Some([8, 8, 8, 8])));
+        let plaintext = tunneled_capture(body, server_frame(&tsgu_data_packet(&rdp)));
+
+        let inner = extract_tunneled_rdp(&plaintext).unwrap();
+
+        assert_eq!(inner.client, vec![(1, rdp.clone())]);
+        assert_eq!(inner.server, vec![(2, rdp)]);
+    }
+
+    #[test]
+    fn merges_packets_coalesced_in_one_frame() {
+        let first = [1, 2, 3];
+        let second = [4, 5, 6, 7];
+        let mut payload = tsgu_control_packet(0x1, &[0; 12]);
+        payload.extend(tsgu_data_packet(&first));
+        payload.extend(tsgu_data_packet(&second));
+        let plaintext = tunneled_capture(client_frame(&payload), server_frame(&tsgu_data_packet(&first)));
+
+        let inner = extract_tunneled_rdp(&plaintext).unwrap();
+
+        assert_eq!(inner.client, vec![(1, first.to_vec()), (1, second.to_vec())]);
+        assert_eq!(inner.server, vec![(2, first.to_vec())]);
+    }
+
+    #[test]
+    fn skips_ping_frames_and_stops_at_close() {
+        let rdp = [7, 7, 7];
+        let mut body = websocket_frame(true, 0x9, b"ping", Some([0, 0, 0, 0]));
+        body.extend(client_frame(&tsgu_data_packet(&rdp)));
+        body.extend(websocket_frame(true, 0x8, &[], Some([0, 0, 0, 0])));
+        body.extend(client_frame(&tsgu_data_packet(&[9, 9, 9])));
+        let plaintext = tunneled_capture(body, server_frame(&tsgu_data_packet(&rdp)));
+
+        let inner = extract_tunneled_rdp(&plaintext).unwrap();
+
+        assert_eq!(inner.client, vec![(1, rdp.to_vec())]);
+    }
+
+    #[test]
+    fn rejects_tunneled_capture_without_data_packets() {
+        let plaintext = tunneled_capture(client_frame(&tsgu_control_packet(0x1, &[0; 12])), server_frame(&[]));
+
+        assert!(matches!(
+            extract_tunneled_rdp(&plaintext),
+            Err(ReplayError::MissingRdpState)
+        ));
+    }
+
+    #[test]
+    fn rejects_truncated_data_packet() {
+        let mut packet = tsgu_data_packet(&[1, 2, 3]);
+        packet.truncate(packet.len() - 1);
+        let plaintext = tunneled_capture(client_frame(&packet), server_frame(&tsgu_data_packet(&[1])));
+
+        assert!(extract_tunneled_rdp(&plaintext).is_err());
+    }
+}

--- a/crates/ironrdp-capture-replay/src/gateway_rpch.rs
+++ b/crates/ironrdp-capture-replay/src/gateway_rpch.rs
@@ -1,0 +1,390 @@
+//! MS-TSGU RPC-over-HTTP (RPCH) tunnel extraction for captured TLS-decrypted flows.
+//!
+//! The legacy RD Gateway transport carries the tunnelled RDP session inside DCE/RPC
+//! calls on two HTTP/1 connections: an IN channel (`RPC_IN_DATA`, client to server) and
+//! an OUT channel (`RPC_OUT_DATA`, server to client). This module unwraps the DCE/RPC
+//! and TsProxy framing and recovers the tunnelled RDP byte stream ([MS-TSGU] 3.6).
+
+use crate::transport::flatten;
+use crate::{PacketStream, Plaintext, ReplayError};
+
+/// DCE/RPC common header length.
+const COMMON_HEADER: usize = 16;
+/// DCE/RPC response PDUs add alloc-hint/context/cancel fields before the stub.
+const RESPONSE_HEADER: usize = COMMON_HEADER + 8;
+/// DCE/RPC request PDUs add alloc-hint/context/opnum fields before the stub.
+const REQUEST_HEADER: usize = COMMON_HEADER + 8;
+/// Largest accepted RPC fragment, comfortably above the negotiated fragment size.
+const MAX_FRAGMENT: usize = 64 * 1024;
+
+const PTYPE_REQUEST: u8 = 0;
+const PTYPE_RESPONSE: u8 = 2;
+
+/// `TsProxySendToServer` operation number ([MS-TSGU] 3.6.5.1).
+const SEND_TO_SERVER_OPNUM: u16 = 9;
+
+/// Which RPCH channel a decrypted flow carries, keyed by its HTTP method.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum RpchChannel {
+    /// `RPC_IN_DATA`: client-to-server tunnel data (`TsProxySendToServer`).
+    In,
+    /// `RPC_OUT_DATA`: server-to-client tunnel data (the receive pipe).
+    Out,
+}
+
+/// Classify a decrypted RPCH flow, or `None` when it is not an RPCH tunnel.
+pub(crate) fn rpch_channel(plaintext: &Plaintext) -> Option<RpchChannel> {
+    let client = flatten(&plaintext.client);
+    if client.starts_with(b"RPC_IN_DATA ") {
+        Some(RpchChannel::In)
+    } else if client.starts_with(b"RPC_OUT_DATA ") {
+        Some(RpchChannel::Out)
+    } else {
+        None
+    }
+}
+
+/// Extract the tunnelled RDP bytes from a pair of decrypted RPCH channel flows.
+///
+/// `input` is the IN-channel flow (client requests) and `output` is the OUT-channel
+/// flow (server responses). The returned streams contain raw RDP traffic (starting
+/// with the X.224 connection request) exactly as a direct TCP capture would carry it.
+pub(crate) fn extract_tunneled_rdp(input: &Plaintext, output: &Plaintext) -> Result<Plaintext, ReplayError> {
+    let client_flat = flatten(&input.client);
+    let server_flat = flatten(&output.server);
+    let client_body = strip_http_heads(&client_flat, Direction::Client);
+    let server_body = strip_http_heads(&server_flat, Direction::Server);
+
+    let client = client_rdp_bytes(client_body)?;
+    let server = server_rdp_bytes(server_body)?;
+    if client.is_empty() || server.is_empty() {
+        return Err(ReplayError::MissingRdpState);
+    }
+    Ok(Plaintext { client, server })
+}
+
+#[derive(Clone, Copy)]
+enum Direction {
+    Client,
+    Server,
+}
+
+/// Strip every HTTP request/response head, returning the concatenated RPC body.
+///
+/// Authentication adds 401 round trips before the 200 that opens the streaming body;
+/// each head ends at `\r\n\r\n`, and a server head with a small `Content-Length`
+/// (an error page) is followed by that body before the next head.
+fn strip_http_heads(bytes: &[u8], direction: Direction) -> &[u8] {
+    let mut offset = 0;
+    loop {
+        let Some(rel) = bytes[offset..].windows(4).position(|w| w == b"\r\n\r\n") else {
+            return &bytes[bytes.len()..];
+        };
+        let head_end = offset + rel + 4;
+        let head = &bytes[offset..head_end];
+        let Ok(text) = core::str::from_utf8(head) else {
+            return &bytes[offset..];
+        };
+        let content_length = text.split("\r\n").find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.trim()
+                .eq_ignore_ascii_case("content-length")
+                .then(|| value.trim().parse::<usize>().ok())?
+        });
+        // A server success head (2xx) is followed by the streaming RPC body; a server
+        // error head with a small body is drained before the next head.
+        if matches!(direction, Direction::Server) && text.starts_with("HTTP/1.1 2") {
+            match content_length {
+                Some(n) if n < MAX_FRAGMENT => {
+                    offset = (head_end + n).min(bytes.len());
+                    continue;
+                }
+                _ => return &bytes[head_end..],
+            }
+        }
+        let next = match direction {
+            Direction::Client => head_end,
+            Direction::Server => (head_end + content_length.unwrap_or(0)).min(bytes.len()),
+        };
+        let rest = &bytes[next..];
+        let starts_head =
+            rest.starts_with(b"RPC_IN_DATA ") || rest.starts_with(b"RPC_OUT_DATA ") || rest.starts_with(b"HTTP/");
+        if starts_head && next < bytes.len() {
+            offset = next;
+        } else {
+            return rest;
+        }
+    }
+}
+
+struct Pdu<'a> {
+    ptype: u8,
+    call_id: u32,
+    /// The operation number for request PDUs (the last request-header field).
+    opnum: u16,
+    /// The data stub, excluding any trailing security trailer and authentication token.
+    stub: &'a [u8],
+}
+
+/// Iterate the well-formed DCE/RPC PDUs in a channel body, yielding each data stub.
+///
+/// A connection using packet integrity pads the stub, then appends an 8-byte security
+/// trailer and an authentication token. The stub therefore ends at `frag_len -
+/// auth_len - 8 - auth_pad_len`, where `auth_pad_len` is read from the security trailer
+/// itself ([MS-RPCE] 2.2.2.10 and 2.2.2.11). `alloc_hint` cannot be used here: on a
+/// continuation fragment it advertises the *remaining* stub, not this fragment's share.
+fn pdus(mut bytes: &[u8], header_size: usize) -> impl Iterator<Item = Pdu<'_>> {
+    core::iter::from_fn(move || {
+        let header = bytes.get(..COMMON_HEADER)?;
+        if header[0] != 5 {
+            return None;
+        }
+        let ptype = header[2];
+        let fragment_length = usize::from(u16::from_le_bytes([header[8], header[9]]));
+        if !(COMMON_HEADER..=MAX_FRAGMENT).contains(&fragment_length) {
+            return None;
+        }
+        let auth_length = usize::from(u16::from_le_bytes([header[10], header[11]]));
+        let call_id = u32::from_le_bytes([header[12], header[13], header[14], header[15]]);
+        let pdu = bytes.get(..fragment_length)?;
+        bytes = &bytes[fragment_length..];
+        // Security trailer layout: auth type, auth level, auth pad length, reserved,
+        // context id. The pad length precedes the trailer, so it shrinks the stub.
+        let stub_end = if auth_length > 0 {
+            let sec_trailer = fragment_length.checked_sub(auth_length + 8)?;
+            let auth_pad_len = usize::from(*pdu.get(sec_trailer + 2)?);
+            sec_trailer.checked_sub(auth_pad_len)?
+        } else {
+            fragment_length
+        };
+        // Control PDUs (bind, auth3) may carry no data stub; clamp instead of stopping so
+        // later data PDUs are still visited.
+        let stub = if stub_end >= header_size {
+            &pdu[header_size..stub_end]
+        } else {
+            &[][..]
+        };
+        // Request PDUs carry the opnum as the last two header bytes before the stub.
+        let opnum = if ptype == PTYPE_REQUEST {
+            pdu.get(header_size - 2..header_size)
+                .map(|b| u16::from_le_bytes([b[0], b[1]]))
+                .unwrap_or(u16::MAX)
+        } else {
+            u16::MAX
+        };
+        Some(Pdu {
+            ptype,
+            call_id,
+            opnum,
+            stub,
+        })
+    })
+}
+
+/// Recover the client-to-server RDP stream from IN-channel `TsProxySendToServer`
+/// request stubs ([MS-TSGU] 2.2.9.3).
+fn client_rdp_bytes(body: &[u8]) -> Result<PacketStream, ReplayError> {
+    let mut output = Vec::new();
+    for pdu in pdus(body, REQUEST_HEADER) {
+        if pdu.ptype != PTYPE_REQUEST || pdu.opnum != SEND_TO_SERVER_OPNUM {
+            continue;
+        }
+        let data = send_to_server_payload(pdu.stub)?;
+        if !data.is_empty() {
+            output.push((usize::try_from(pdu.call_id).unwrap_or(0), data));
+        }
+    }
+    Ok(output)
+}
+
+/// Parse a `TsProxySendToServer` stub: context handle, total bytes, buffer count, then
+/// per-buffer length-prefixed data. The data-plane length fields are little-endian on
+/// the wire (matching mstsc), like the NDR control stubs.
+fn send_to_server_payload(stub: &[u8]) -> Result<Vec<u8>, ReplayError> {
+    const HANDLE: usize = 20;
+    let framing = || ReplayError::GatewayFraming("malformed send-to-server stub".to_owned());
+    let mut cursor = stub.get(HANDLE..).ok_or_else(framing)?;
+    let _total = read_le_u32(&mut cursor).ok_or_else(framing)?;
+    let buffer_count = usize::try_from(read_le_u32(&mut cursor).ok_or_else(framing)?).map_err(|_| framing())?;
+    if buffer_count > 3 {
+        return Err(framing());
+    }
+    let mut lengths = Vec::with_capacity(buffer_count);
+    for _ in 0..buffer_count {
+        lengths.push(usize::try_from(read_le_u32(&mut cursor).ok_or_else(framing)?).map_err(|_| framing())?);
+    }
+    let mut data = Vec::new();
+    for length in lengths {
+        let buffer = cursor.get(..length).ok_or_else(framing)?;
+        data.extend_from_slice(buffer);
+        cursor = &cursor[length..];
+    }
+    Ok(data)
+}
+
+/// Recover the server-to-client RDP stream from OUT-channel receive-pipe response
+/// stubs. After `TsProxySetupReceivePipe` the data-plane responses carry the raw RDP
+/// bytes directly; control responses (bind ack, tunnel/channel setup) are skipped by
+/// their non-RDP stub content.
+fn server_rdp_bytes(body: &[u8]) -> Result<PacketStream, ReplayError> {
+    let mut output = Vec::new();
+    // The receive pipe carries every server-to-client RDP byte on one RPC call: the
+    // `TsProxySetupReceivePipe` call. That call's response stream starts with the X.224
+    // connection confirm (TPKT). Other interleaved responses (bind ack, tunnel/channel
+    // setup, MakeTunnelCall admin replies) use their own call ids and are not RDP.
+    let mut receive_pipe_call = None;
+    for pdu in pdus(body, RESPONSE_HEADER) {
+        if pdu.ptype != PTYPE_RESPONSE {
+            continue;
+        }
+        let stub = pdu.stub;
+        match receive_pipe_call {
+            None => {
+                // The receive pipe's first data response is the X.224 connection confirm.
+                if starts_with_tpkt(stub) {
+                    receive_pipe_call = Some(pdu.call_id);
+                } else {
+                    continue;
+                }
+            }
+            // After the pipe opens, its data is a contiguous RDP byte stream split
+            // arbitrarily across responses; keep only this call's stubs.
+            Some(call) if call != pdu.call_id => continue,
+            Some(_) => {}
+        }
+        if !stub.is_empty() {
+            output.push((usize::try_from(pdu.call_id).unwrap_or(0), stub.to_vec()));
+        }
+    }
+    Ok(output)
+}
+
+/// A tunnelled RDP record begins with a TPKT header (`03 00`, big-endian length).
+fn starts_with_tpkt(stub: &[u8]) -> bool {
+    matches!(stub, [0x03, 0x00, ..])
+}
+
+fn read_le_u32(cursor: &mut &[u8]) -> Option<u32> {
+    let (field, rest) = cursor.split_at_checked(4)?;
+    *cursor = rest;
+    Some(u32::from_le_bytes(field.try_into().ok()?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Common 16-byte header: version, ptype, flags, data rep, fragment length,
+    /// auth length (0 = unsigned), call id.
+    fn common_header(ptype: u8, call_id: u32, fragment_length: usize) -> Vec<u8> {
+        let mut pdu = vec![5, 0, ptype, 0x03, 0x10, 0, 0, 0];
+        pdu.extend_from_slice(&u16::try_from(fragment_length).unwrap().to_le_bytes());
+        pdu.extend_from_slice(&0u16.to_le_bytes()); // auth length
+        pdu.extend_from_slice(&call_id.to_le_bytes());
+        pdu
+    }
+
+    fn request_pdu(call_id: u32, opnum: u16, stub: &[u8]) -> Vec<u8> {
+        let fragment_length = REQUEST_HEADER + stub.len();
+        let mut pdu = common_header(PTYPE_REQUEST, call_id, fragment_length);
+        pdu.extend_from_slice(&u32::try_from(stub.len()).unwrap().to_le_bytes()); // alloc hint
+        pdu.extend_from_slice(&0u16.to_le_bytes()); // context id
+        pdu.extend_from_slice(&opnum.to_le_bytes());
+        pdu.extend_from_slice(stub);
+        pdu
+    }
+
+    fn response_pdu(call_id: u32, stub: &[u8]) -> Vec<u8> {
+        let fragment_length = RESPONSE_HEADER + stub.len();
+        let mut pdu = common_header(PTYPE_RESPONSE, call_id, fragment_length);
+        pdu.extend_from_slice(&u32::try_from(stub.len()).unwrap().to_le_bytes()); // alloc hint
+        pdu.extend_from_slice(&0u16.to_le_bytes()); // context id
+        pdu.extend_from_slice(&[0, 0]); // cancel count + pad
+        pdu.extend_from_slice(stub);
+        pdu
+    }
+
+    fn send_to_server_stub(buffers: &[&[u8]]) -> Vec<u8> {
+        let mut stub = vec![0u8; 20]; // context handle
+        let total: usize = buffers.iter().map(|b| b.len()).sum::<usize>() + 4 * buffers.len();
+        stub.extend_from_slice(&u32::try_from(total).unwrap().to_le_bytes());
+        stub.extend_from_slice(&u32::try_from(buffers.len()).unwrap().to_le_bytes());
+        for buffer in buffers {
+            stub.extend_from_slice(&u32::try_from(buffer.len()).unwrap().to_le_bytes());
+        }
+        for buffer in buffers {
+            stub.extend_from_slice(buffer);
+        }
+        stub
+    }
+
+    #[test]
+    fn detects_rpch_tunnel() {
+        let plaintext = Plaintext {
+            client: vec![(1, b"RPC_OUT_DATA /rpc/rpcproxy.dll?x HTTP/1.1\r\n\r\n".to_vec())],
+            server: vec![(2, b"HTTP/1.1 200 OK\r\n\r\n".to_vec())],
+        };
+        assert_eq!(rpch_channel(&plaintext), Some(RpchChannel::Out));
+    }
+
+    #[test]
+    fn extracts_send_to_server_payload() {
+        let rdp = [0x03, 0x00, 0x00, 0x13, 0x0e, 0xe0];
+        let stub = send_to_server_stub(&[&rdp]);
+        let body = request_pdu(7, SEND_TO_SERVER_OPNUM, &stub);
+
+        let stream = client_rdp_bytes(&body).unwrap();
+
+        assert_eq!(stream, vec![(7, rdp.to_vec())]);
+    }
+
+    #[test]
+    fn skips_non_data_requests() {
+        let control = request_pdu(1, 1, &[0u8; 32]); // create tunnel
+        let rdp = [9u8; 8];
+        let mut body = control;
+        body.extend(request_pdu(2, SEND_TO_SERVER_OPNUM, &send_to_server_stub(&[&rdp])));
+
+        let stream = client_rdp_bytes(&body).unwrap();
+
+        assert_eq!(stream, vec![(2, rdp.to_vec())]);
+    }
+
+    #[test]
+    fn extracts_receive_pipe_data_after_first_tpkt() {
+        let mut body = response_pdu(1, &[0u8; 16]); // control response, no TPKT
+        let cc = [0x03, 0x00, 0x00, 0x13, 0x0e, 0xd0];
+        body.extend(response_pdu(6, &cc)); // receive-pipe call opens with the TPKT
+        body.extend(response_pdu(7, &[0u8; 40])); // interleaved admin response, other call
+        let data = [0x03, 0x00, 0x00, 0x20, 0x02, 0xf0];
+        body.extend(response_pdu(6, &data)); // more receive-pipe data
+
+        let stream = server_rdp_bytes(&body).unwrap();
+
+        assert_eq!(stream, vec![(6, cc.to_vec()), (6, data.to_vec())]);
+    }
+
+    #[test]
+    fn strips_authentication_round_trips() {
+        let rdp = [1u8, 2, 3];
+        let mut client = b"RPC_IN_DATA /rpc/rpcproxy.dll?x HTTP/1.1\r\nContent-Length: 0\r\n\r\n".to_vec();
+        client.extend(b"RPC_IN_DATA /rpc/rpcproxy.dll?x HTTP/1.1\r\nContent-Length: 1073741824\r\n\r\n");
+        client.extend(request_pdu(1, SEND_TO_SERVER_OPNUM, &send_to_server_stub(&[&rdp])));
+        let input = Plaintext {
+            client: vec![(1, client)],
+            server: Vec::new(),
+        };
+        let mut server = b"HTTP/1.1 401 Unauthorized\r\nContent-Length: 13\r\n\r\nAccess Denied".to_vec();
+        server.extend(b"HTTP/1.1 200 OK\r\n\r\n");
+        server.extend(response_pdu(1, &[0x03, 0x00, 0x00, 0x13, 0x0e, 0xd0]));
+        let output = Plaintext {
+            client: Vec::new(),
+            server: vec![(2, server)],
+        };
+
+        let inner = extract_tunneled_rdp(&input, &output).unwrap();
+
+        assert_eq!(inner.client, vec![(1, rdp.to_vec())]);
+        assert_eq!(inner.server, vec![(1, vec![0x03, 0x00, 0x00, 0x13, 0x0e, 0xd0])]);
+    }
+}

--- a/crates/ironrdp-capture-replay/src/lib.rs
+++ b/crates/ironrdp-capture-replay/src/lib.rs
@@ -1,6 +1,8 @@
 //! Offline analysis support for direct TCP RDP captures.
 
 mod error;
+mod gateway;
+pub(crate) mod gateway_rpch;
 mod negotiation;
 mod output;
 mod routing;
@@ -8,11 +10,12 @@ mod tls;
 mod transport;
 
 pub use error::ReplayError;
+pub use gateway::{extract_tunneled_rdp, is_gateway_tunnel};
 pub use negotiation::{NegotiatedState, StaticChannel, recover_negotiated_state};
 pub use output::{ExportError, ExportOptions, ExportSummary, export_capture};
 pub use routing::{
     CapturedActivation, CapturedDynamicChannel, ReplayDirection, ReplayEvent, ReplayGap, ReplayGapKind, ReplayReport,
     ReplayRoute, ReplayRouter, replay_capture,
 };
-pub use tls::{Plaintext, decrypt_tls};
+pub use tls::{Plaintext, decrypt_tls, decrypt_tls_streams};
 pub use transport::{Capture, Endpoint, Flow, PacketStream, TlsKeyLog, read_capture};

--- a/crates/ironrdp-capture-replay/src/routing.rs
+++ b/crates/ironrdp-capture-replay/src/routing.rs
@@ -21,7 +21,10 @@ use ironrdp_session::image::DecodedImage;
 use ironrdp_session::{ActiveStage, ActiveStageBuilder, ActiveStageOutput};
 use ironrdp_svc::{StaticChannelSet, StaticVirtualChannel, SvcMessage, SvcProcessor};
 
-use crate::{Capture, NegotiatedState, PacketStream, Plaintext, ReplayError, decrypt_tls, recover_negotiated_state};
+use crate::tls::decrypt_tls_streams;
+use crate::{
+    Capture, NegotiatedState, PacketStream, Plaintext, ReplayError, gateway, gateway_rpch, recover_negotiated_state,
+};
 
 const MAX_DESKTOP_DIM: u16 = 8192;
 const MAX_EGFX_OUTPUT_DIM: u16 = 32_766;
@@ -557,12 +560,64 @@ pub fn replay_capture(capture: &Capture) -> Result<ReplayReport, ReplayError> {
 }
 
 pub(crate) fn prepare_replay_capture(capture: &Capture) -> Result<(ReplayRouter, Plaintext), ReplayError> {
-    let plaintext = decrypt_tls(capture)?;
+    // Decrypt the selected gateway-port flow plus every alternate; a direct RDP capture
+    // has no gateway flow and yields its single TLS session, while a gateway capture
+    // yields one (WebSocket) or two (RPCH IN/OUT) tunnel flows.
+    let mut decrypted = Vec::new();
+    for flow in core::iter::once(&capture.flow).chain(capture.gateway_alternates.iter()) {
+        if let Ok(plaintext) =
+            decrypt_tls_streams(&flow.client_stream, &flow.server_stream, capture.tls_key_log.as_str())
+        {
+            decrypted.push(plaintext);
+        }
+    }
+    let plaintext = recover_rdp_stream(capture, decrypted)?;
     let router = ReplayRouter::new(CapturedActivation {
         state: recover_negotiated_state(&plaintext)?,
         compression_type: captured_compression_type(&plaintext),
     })?;
     Ok((router, plaintext))
+}
+
+/// Reduce the decrypted gateway-port flows to the inner RDP stream.
+fn recover_rdp_stream(capture: &Capture, decrypted: Vec<Plaintext>) -> Result<Plaintext, ReplayError> {
+    // A WebSocket MS-TSGU tunnel carries both directions on one flow.
+    if let Some(outer) = decrypted.iter().find(|p| gateway::is_gateway_tunnel(p)) {
+        return unwrap_gateway_tunnel(outer, capture);
+    }
+    // The legacy RPCH transport splits the tunnel across an IN and an OUT channel.
+    let input = decrypted
+        .iter()
+        .find(|p| gateway_rpch::rpch_channel(p) == Some(gateway_rpch::RpchChannel::In));
+    let output = decrypted
+        .iter()
+        .find(|p| gateway_rpch::rpch_channel(p) == Some(gateway_rpch::RpchChannel::Out));
+    if let (Some(input), Some(output)) = (input, output) {
+        let tunneled = gateway_rpch::extract_tunneled_rdp(input, output)?;
+        let inner =
+            decrypt_tls_streams(&tunneled.client, &tunneled.server, capture.tls_key_log.as_str()).map_err(|error| {
+                if matches!(error, ReplayError::MissingTlsSecret) {
+                    ReplayError::MissingTunneledTlsSecret
+                } else {
+                    error
+                }
+            })?;
+        return Ok(inner);
+    }
+    // No gateway tunnel: the single decrypted flow is the RDP session itself.
+    decrypted.into_iter().next().ok_or(ReplayError::MissingRdpState)
+}
+
+/// Unwrap the MS-TSGU tunnel and decrypt the recovered inner RDP session.
+fn unwrap_gateway_tunnel(outer: &Plaintext, capture: &Capture) -> Result<Plaintext, ReplayError> {
+    let tunneled = gateway::extract_tunneled_rdp(outer)?;
+    decrypt_tls_streams(&tunneled.client, &tunneled.server, capture.tls_key_log.as_str()).map_err(|error| {
+        if matches!(error, ReplayError::MissingTlsSecret) {
+            ReplayError::MissingTunneledTlsSecret
+        } else {
+            error
+        }
+    })
 }
 
 fn captured_compression_type(plaintext: &Plaintext) -> Option<CompressionType> {
@@ -599,6 +654,26 @@ fn valid_desktop_dimensions(width: u16, height: u16) -> bool {
     width != 0 && height != 0 && width <= MAX_DESKTOP_DIM && height <= MAX_DESKTOP_DIM
 }
 
+/// Offset of the first RDP data frame, skipping any leading authentication preamble.
+///
+/// RDP data over the channel begins with an X.224 data TPDU (TPKT `03 00` wrapping
+/// `02 f0 80`). A CredSSP exchange (DER `30 ...`) precedes it on TLS-secured streams; DER
+/// bytes can otherwise be misread as FastPath framing. Returns 0 when the stream already
+/// starts with RDP data or when no data frame is found.
+fn rdp_data_start(bytes: &[u8]) -> usize {
+    let mut offset = 0;
+    while offset + 7 <= bytes.len() {
+        if bytes[offset] == 3 && bytes[offset + 1] == 0 && bytes[offset + 4..offset + 7] == [2, 0xf0, 0x80] {
+            let length = usize::from(u16::from_be_bytes([bytes[offset + 2], bytes[offset + 3]]));
+            if length >= 7 && offset + length <= bytes.len() {
+                return offset;
+            }
+        }
+        offset += 1;
+    }
+    0
+}
+
 fn framed_stream(stream: &PacketStream, direction: ReplayDirection, gaps: &mut Vec<ReplayGap>) -> Vec<CapturedPdu> {
     let mut bytes = Vec::new();
     let mut boundaries = Vec::with_capacity(stream.len());
@@ -612,7 +687,20 @@ fn framed_stream(stream: &PacketStream, direction: ReplayDirection, gaps: &mut V
             .map_or(0, |(_, packet)| *packet)
     };
     let mut messages = Vec::new();
-    let mut offset = 0;
+    // A TLS-secured stream carries the CredSSP authentication exchange (DER, not RDP
+    // framing) before the RDP data. `find_size` would misread the DER as FastPath, so the
+    // preamble is skipped up to the first X.224 data TPDU, matching how the negotiation
+    // recovery locates the connect sequence.
+    let preamble = rdp_data_start(&bytes);
+    if preamble > 0 {
+        gaps.push(ReplayGap {
+            packet: packet_at(0),
+            direction,
+            kind: ReplayGapKind::Framing,
+            skipped_bytes: preamble,
+        });
+    }
+    let mut offset = preamble;
     let mut unframed = false;
     while offset < bytes.len() {
         match find_size(&bytes[offset..]) {

--- a/crates/ironrdp-capture-replay/src/tls.rs
+++ b/crates/ironrdp-capture-replay/src/tls.rs
@@ -31,8 +31,24 @@ pub struct Plaintext {
 /// TLS key-log entries are used only in memory and are not retained by the
 /// returned streams.
 pub fn decrypt_tls(capture: &Capture) -> Result<Plaintext, ReplayError> {
-    let client_records = collect_tls_records(&capture.flow.client_stream, 0xe0)?;
-    let server_records = collect_tls_records(&capture.flow.server_stream, 0xd0)?;
+    decrypt_tls_streams(
+        &capture.flow.client_stream,
+        &capture.flow.server_stream,
+        capture.tls_key_log.as_str(),
+    )
+}
+
+/// Decrypt TLS application data from a pair of directional byte streams.
+///
+/// Public for offline tooling that extracts inner streams (e.g. gateway tunnels)
+/// before decryption.
+pub fn decrypt_tls_streams(
+    client_stream: &PacketStream,
+    server_stream: &PacketStream,
+    key_log: &str,
+) -> Result<Plaintext, ReplayError> {
+    let client_records = collect_tls_records(client_stream, 0xe0)?;
+    let server_records = collect_tls_records(server_stream, 0xd0)?;
     let (client_records, server_records) = match (client_records, server_records) {
         (Some(client_records), Some(server_records)) => (client_records, server_records),
         (None, None) => return Err(ReplayError::StandardSecurity),
@@ -41,7 +57,11 @@ pub fn decrypt_tls(capture: &Capture) -> Result<Plaintext, ReplayError> {
     if client_records.is_empty() && server_records.is_empty() {
         return Err(ReplayError::StandardSecurity);
     }
-    let tls = Tls::from_records(&client_records, &server_records, capture.tls_key_log.as_str())?;
+    // Full-handshake sessions first; a mid-stream capture (tunneled session recorded
+    // after the handshake, or with secrets logged only for the application phase) falls
+    // back to application-secret-only decryption.
+    let tls = Tls::from_records(&client_records, &server_records, key_log)
+        .or_else(|_| Tls::from_records_midstream(&client_records, &server_records, key_log))?;
 
     Ok(Plaintext {
         client: tls.decrypt(Direction::Client, &client_records)?,
@@ -73,9 +93,28 @@ impl Tls {
         let suite = tls_cipher_suite(&server_hello)?;
 
         match suite {
-            0x1301 | 0x1302 => Tls13::from_hello(&client_hello, suite, key_log).map(Self::V13),
+            0x1301 | 0x1302 => Tls13::from_hello(&client_hello, suite, key_log, client, server).map(Self::V13),
             _ => Tls12::from_hello(&client_hello, &server_hello, suite, key_log).map(Self::V12),
         }
+    }
+
+    /// Builds a TLS 1.3 decryptor for a mid-stream capture where the handshake is absent
+    /// and only application-traffic secrets are logged.
+    ///
+    /// Tunneled sessions captured after the handshake carry no ClientHello/ServerHello; the
+    /// session is identified by trying every logged application secret against the first
+    /// application record.
+    fn from_records_midstream(
+        client: &PacketStream,
+        server: &PacketStream,
+        key_log: &str,
+    ) -> Result<Self, ReplayError> {
+        // Find each direction's first application-data record.
+        let first_client = first_application_record(client).ok_or(ReplayError::UnsupportedTls)?;
+        let first_server = first_application_record(server).ok_or(ReplayError::UnsupportedTls)?;
+        let cipher = guess_tls13_cipher(&first_client, &first_server).ok_or(ReplayError::UnsupportedTls)?;
+
+        Tls13::from_application_secrets(cipher, &first_client, &first_server, key_log).map(Self::V13)
     }
 
     fn decrypt(&self, direction: Direction, records: &PacketStream) -> Result<PacketStream, ReplayError> {
@@ -196,21 +235,30 @@ impl Tls12 {
     }
 }
 
+#[derive(Clone)]
 struct Tls13 {
     cipher: Cipher,
-    client_handshake: TrafficKey,
-    server_handshake: TrafficKey,
+    client_handshake: Option<TrafficKey>,
+    server_handshake: Option<TrafficKey>,
     client_application: TrafficKey,
     server_application: TrafficKey,
+    has_handshake_keys: bool,
 }
 
+#[derive(Clone)]
 struct TrafficKey {
     key: Vec<u8>,
     iv: [u8; 12],
 }
 
 impl Tls13 {
-    fn from_hello(client_hello: &[u8], suite: u16, key_log: &str) -> Result<Self, ReplayError> {
+    fn from_hello(
+        client_hello: &[u8],
+        suite: u16,
+        key_log: &str,
+        client_records: &PacketStream,
+        server_records: &PacketStream,
+    ) -> Result<Self, ReplayError> {
         let client_random = client_hello.get(2..34).ok_or(ReplayError::UnsupportedTls)?;
         let cipher = match suite {
             0x1301 => Cipher::Aes128GcmSha256,
@@ -221,52 +269,164 @@ impl Tls13 {
             Cipher::Aes128GcmSha256 => 16,
             Cipher::Aes256GcmSha384 => 32,
         };
-        let client_handshake = tls13_traffic_key(
-            cipher,
-            parse_tls13_secret(key_log, "CLIENT_HANDSHAKE_TRAFFIC_SECRET", client_random)?,
-            key_len,
-        )?;
-        let server_handshake = tls13_traffic_key(
-            cipher,
-            parse_tls13_secret(key_log, "SERVER_HANDSHAKE_TRAFFIC_SECRET", client_random)?,
-            key_len,
-        )?;
-        let client_application = tls13_traffic_key(
-            cipher,
-            parse_tls13_secret(key_log, "CLIENT_TRAFFIC_SECRET_0", client_random)?,
-            key_len,
-        )?;
-        let server_application = tls13_traffic_key(
-            cipher,
-            parse_tls13_secret(key_log, "SERVER_TRAFFIC_SECRET_0", client_random)?,
-            key_len,
-        )?;
+        // Application secrets are always required. Handshake secrets may be absent when a
+        // key log captured the session only after the handshake completed (common for
+        // tunneled sessions logged by an out-of-band dumper); such sessions start
+        // decryption at the application phase.
+        let client_handshake = parse_tls13_secret(key_log, "CLIENT_HANDSHAKE_TRAFFIC_SECRET", client_random)
+            .ok()
+            .map(|secret| tls13_traffic_key(cipher, secret, key_len))
+            .transpose()?;
+        let server_handshake = parse_tls13_secret(key_log, "SERVER_HANDSHAKE_TRAFFIC_SECRET", client_random)
+            .ok()
+            .map(|secret| tls13_traffic_key(cipher, secret, key_len))
+            .transpose()?;
 
-        Ok(Self {
-            cipher,
-            client_handshake,
-            server_handshake,
-            client_application,
-            server_application,
-        })
+        // A session's traffic secret can be logged several times under one client random
+        // (key update, re-key), and an out-of-band dumper does not guarantee log order.
+        // Score each candidate pair by how much of the session it actually decrypts and
+        // keep the best; a wrong key yields no application output because the
+        // handshake-tail skip consumes every record, while the right key decrypts the
+        // full stream.
+        let client_candidates = parse_tls13_secrets(key_log, "CLIENT_TRAFFIC_SECRET_0", client_random);
+        let server_candidates = parse_tls13_secrets(key_log, "SERVER_TRAFFIC_SECRET_0", client_random);
+        if client_candidates.is_empty() || server_candidates.is_empty() {
+            return Err(ReplayError::MissingTlsSecret);
+        }
+        let mut first_candidate: Option<Self> = None;
+        let mut best: Option<(usize, Self)> = None;
+        for client_secret in &client_candidates {
+            for server_secret in &server_candidates {
+                let client_application = tls13_traffic_key(cipher, client_secret.clone(), key_len)?;
+                let server_application = tls13_traffic_key(cipher, server_secret.clone(), key_len)?;
+                let candidate = Self {
+                    cipher,
+                    client_handshake: client_handshake.clone(),
+                    server_handshake: server_handshake.clone(),
+                    client_application,
+                    server_application,
+                    has_handshake_keys: client_handshake.is_some() && server_handshake.is_some(),
+                };
+                // Kept as a fallback so a session with no application records yet still
+                // builds a decryptor.
+                if first_candidate.is_none() {
+                    first_candidate = Some(candidate.clone());
+                }
+                let score = candidate.decrypted_len(Direction::Client, client_records)
+                    + candidate.decrypted_len(Direction::Server, server_records);
+                if score > 0 && best.as_ref().is_none_or(|(best_score, _)| score > *best_score) {
+                    best = Some((score, candidate));
+                }
+            }
+        }
+        best.map(|(_, candidate)| candidate)
+            .or(first_candidate)
+            .ok_or(ReplayError::MissingTlsSecret)
+    }
+
+    /// Total application bytes a candidate decrypts in one direction, or 0 when the key
+    /// does not fit (decryption error or empty output).
+    fn decrypted_len(&self, direction: Direction, records: &PacketStream) -> usize {
+        self.decrypt(direction, records)
+            .map(|stream| stream.iter().map(|(_, chunk)| chunk.len()).sum())
+            .unwrap_or(0)
+    }
+
+    /// Builds a decryptor from application-traffic secrets alone, for a mid-stream
+    /// capture whose handshake (and client random) is not in the capture.
+    ///
+    /// The session is identified by deriving keys from each logged
+    /// `CLIENT_TRAFFIC_SECRET_0`/`SERVER_TRAFFIC_SECRET_0` pair and authenticating the
+    /// first application record; the GCM tag check is decisive.
+    fn from_application_secrets(
+        cipher: Cipher,
+        first_client_record: &[u8],
+        first_server_record: &[u8],
+        key_log: &str,
+    ) -> Result<Self, ReplayError> {
+        let key_len = match cipher {
+            Cipher::Aes128GcmSha256 => 16,
+            Cipher::Aes256GcmSha384 => 32,
+        };
+        // Collect client randoms that have both application secrets logged.
+        let mut client_randoms = Vec::new();
+        for line in key_log.lines().map(|line| line.replace('\0', "")) {
+            let mut fields = line.split_ascii_whitespace();
+            if fields.next() == Some("CLIENT_TRAFFIC_SECRET_0")
+                && let Some(random) = fields.next()
+            {
+                client_randoms.push(random.to_owned());
+            }
+        }
+        client_randoms.sort_unstable();
+        client_randoms.dedup();
+
+        for random in client_randoms {
+            let client_random_bytes = decode_hex(&random).ok_or(ReplayError::MissingTlsSecret)?;
+            let Ok(client_application) = parse_tls13_secret(key_log, "CLIENT_TRAFFIC_SECRET_0", &client_random_bytes)
+                .and_then(|secret| tls13_traffic_key(cipher, secret, key_len))
+            else {
+                continue;
+            };
+            let Ok(server_application) = parse_tls13_secret(key_log, "SERVER_TRAFFIC_SECRET_0", &client_random_bytes)
+                .and_then(|secret| tls13_traffic_key(cipher, secret, key_len))
+            else {
+                continue;
+            };
+
+            // Try the candidate against both directions' first application records.
+            let candidate = Self {
+                cipher,
+                client_handshake: None,
+                server_handshake: None,
+                client_application,
+                server_application,
+                has_handshake_keys: false,
+            };
+            if candidate
+                .decrypt(Direction::Client, &vec![(0, first_client_record.to_vec())])
+                .is_ok()
+                && candidate
+                    .decrypt(Direction::Server, &vec![(0, first_server_record.to_vec())])
+                    .is_ok()
+            {
+                return Ok(candidate);
+            }
+        }
+        Err(ReplayError::MissingTlsSecret)
     }
 
     fn decrypt(&self, direction: Direction, records: &PacketStream) -> Result<PacketStream, ReplayError> {
+        // Without handshake secrets, decryption starts at the application phase.
         let (handshake, application) = match direction {
             Direction::Client => (&self.client_handshake, &self.client_application),
             Direction::Server => (&self.server_handshake, &self.server_application),
         };
-        let mut key = handshake;
+        let application: &TrafficKey = application;
+        let mut handshake_phase = self.has_handshake_keys;
+        let mut key: &TrafficKey = handshake.as_ref().unwrap_or(application);
         let mut sequence = 0u64;
         let mut output = Vec::new();
         let mut handshake_data = Vec::new();
-        let mut handshake_phase = true;
         for (packet, record) in records {
             let (content_type, version, body) = parse_tls_record(record).ok_or(ReplayError::UnsupportedTls)?;
             if content_type != TLS_CONTENT_APPLICATION_DATA {
                 continue;
             }
-            let plaintext = decrypt_tls13_record(self.cipher, key, sequence, content_type, version, body)?;
+            // When handshake secrets are absent, the opening application records may
+            // still carry the handshake tail (encrypted with the unknown handshake keys);
+            // skip records that fail authentication until the application phase starts.
+            let plaintext = match decrypt_tls13_record(self.cipher, key, sequence, content_type, version, body) {
+                Ok(plaintext) => plaintext,
+                // A record that fails the application key before the application phase has
+                // started is the handshake tail (EncryptedExtensions/Finished) encrypted
+                // with the unknown handshake key. It does not consume an application
+                // sequence number, so the sequence is left unchanged while skipping it.
+                Err(ReplayError::TlsAuthentication) if !handshake_phase && output.is_empty() => {
+                    continue;
+                }
+                Err(error) => return Err(error),
+            };
             sequence = sequence.checked_add(1).ok_or(ReplayError::UnsupportedTls)?;
             let (content, inner_type) = tls13_inner_plaintext(&plaintext).ok_or(ReplayError::UnsupportedTls)?;
             if inner_type == TLS_CONTENT_HANDSHAKE && handshake_phase {
@@ -295,16 +455,23 @@ fn collect_tls_records(stream: &PacketStream, x224_code: u8) -> Result<Option<Pa
         packet_offsets.push((bytes.len(), *packet));
         bytes.extend_from_slice(chunk);
     }
-    let tpkt_end = x224_connection_tpdu_end(&bytes, x224_code);
-    let start = if let Some(start) = tpkt_end {
-        bytes
-            .get(start..start + 3)
-            .is_some_and(|header| header[0] == TLS_CONTENT_HANDSHAKE && header[1] == 3 && header[2] >= 1)
-            .then_some(start)
-    } else {
+    // A direct capture starts TLS immediately after the X.224 connection TPDU. A
+    // gateway-unwrapped stream may pad between the TPDU and the first TLS record, so when
+    // the bytes right after the TPDU are not a handshake record, scan for the first one.
+    let scan = |bytes: &[u8]| {
         bytes
             .windows(3)
             .position(|window| window[0] == TLS_CONTENT_HANDSHAKE && window[1] == 3 && window[2] >= 1)
+    };
+    let start = match x224_connection_tpdu_end(&bytes, x224_code) {
+        Some(tpkt_end)
+            if bytes
+                .get(tpkt_end..tpkt_end + 3)
+                .is_some_and(|header| header[0] == TLS_CONTENT_HANDSHAKE && header[1] == 3 && header[2] >= 1) =>
+        {
+            Some(tpkt_end)
+        }
+        _ => scan(&bytes),
     };
     let Some(mut offset) = start else {
         return Ok(None);
@@ -357,6 +524,39 @@ fn first_handshake(records: &PacketStream, wanted_type: u8) -> Option<Vec<u8>> {
     None
 }
 
+/// First application-data record in a stream (header + ciphertext + tag), owned.
+fn first_application_record(stream: &PacketStream) -> Option<Vec<u8>> {
+    let mut bytes = Vec::new();
+    for (_, chunk) in stream {
+        bytes.extend_from_slice(chunk);
+    }
+    let mut offset = 0;
+    while offset + 5 <= bytes.len() {
+        if bytes[offset] != TLS_CONTENT_APPLICATION_DATA
+            || bytes[offset + 1] != 3
+            || !(1..=3).contains(&bytes[offset + 2])
+        {
+            offset += 1;
+            continue;
+        }
+        let length = usize::from(u16::from_be_bytes([bytes[offset + 3], bytes[offset + 4]]));
+        let end = offset.checked_add(5 + length)?;
+        if end > bytes.len() {
+            return None;
+        }
+        return Some(bytes[offset..end].to_vec());
+    }
+    None
+}
+
+/// Both directions of a mid-stream session share the cipher suite; guess it from the
+/// record lengths (AES-256-GCM has a 32-byte key, AES-128-GCM a 16-byte key; the tag is
+/// 16 bytes either way, so record size alone is ambiguous — prefer AES-256-GCM, the
+/// common RD Gateway choice, and let the caller retry with the other).
+fn guess_tls13_cipher(_client_record: &[u8], _server_record: &[u8]) -> Option<Cipher> {
+    Some(Cipher::Aes256GcmSha384)
+}
+
 fn tls_cipher_suite(server_hello: &[u8]) -> Result<u16, ReplayError> {
     let session_len = usize::from(*server_hello.get(34).ok_or(ReplayError::UnsupportedTls)?);
     let suite_offset = 35usize.checked_add(session_len).ok_or(ReplayError::UnsupportedTls)?;
@@ -370,9 +570,10 @@ fn tls_cipher_suite(server_hello: &[u8]) -> Result<u16, ReplayError> {
 
 fn parse_master_secret(key_log: &str, client_random: &[u8]) -> Option<Vec<u8>> {
     let client_random = hex(client_random);
-    key_log.lines().find_map(|line| {
+    // Same NUL tolerance as parse_tls13_secret for interleaved out-of-band logs.
+    key_log.lines().map(|line| line.replace('\0', "")).find_map(|line| {
         let mut fields = line.split_ascii_whitespace();
-        (fields.next()? == "CLIENT_RANDOM" && fields.next()? == client_random)
+        (fields.next()? == "CLIENT_RANDOM" && fields.next()?.eq_ignore_ascii_case(&client_random))
             .then(|| decode_hex(fields.next()?))
             .flatten()
             .filter(|secret| secret.len() == 48)
@@ -380,15 +581,34 @@ fn parse_master_secret(key_log: &str, client_random: &[u8]) -> Option<Vec<u8>> {
 }
 
 fn parse_tls13_secret(key_log: &str, label: &str, client_random: &[u8]) -> Result<Vec<u8>, ReplayError> {
+    parse_tls13_secrets(key_log, label, client_random)
+        .into_iter()
+        .next()
+        .ok_or(ReplayError::MissingTlsSecret)
+}
+
+/// Collect every logged value of `label` for `client_random`.
+///
+/// An out-of-band LSA dumper can log a session's traffic secret more than once (for
+/// example across a TLS key update, or when a connection is re-keyed), leaving several
+/// distinct values under one client random. Callers must try each candidate and keep the
+/// one that authenticates the captured records rather than trusting the first.
+fn parse_tls13_secrets(key_log: &str, label: &str, client_random: &[u8]) -> Vec<Vec<u8>> {
     let client_random = hex(client_random);
+    // Out-of-band key dumpers (for example an LSA SChannel logger writing from several
+    // sessions at once) interleave NUL bytes into the log; drop them before parsing.
     key_log
         .lines()
-        .find_map(|line| {
+        .map(|line| line.replace('\0', ""))
+        .filter_map(|line| {
             let mut fields = line.split_ascii_whitespace();
-            (fields.next()? == label && fields.next()? == client_random).then(|| decode_hex(fields.next()?))
+            // Key logs are mixed-case across dumpers (Wireshark lowercases, some LSA
+            // dumpers uppercase); match the client random case-insensitively.
+            (fields.next()? == label && fields.next()?.eq_ignore_ascii_case(&client_random))
+                .then(|| decode_hex(fields.next()?))
+                .flatten()
         })
-        .flatten()
-        .ok_or(ReplayError::MissingTlsSecret)
+        .collect()
 }
 
 fn hex(bytes: &[u8]) -> String {
@@ -647,6 +867,7 @@ mod tests {
                 server_stream: vec![(4, server_records.into_iter().flat_map(|(_, record)| record).collect())],
             },
             tls_key_log: TlsKeyLog::new(key_log),
+            gateway_alternates: Vec::new(),
         };
 
         let plaintext = decrypt_tls(&capture).unwrap();
@@ -679,6 +900,7 @@ mod tests {
                 server_stream: vec![(2, x224_connection(0xd0))],
             },
             tls_key_log: TlsKeyLog::new(String::new()),
+            gateway_alternates: Vec::new(),
         };
 
         assert!(matches!(decrypt_tls(&capture), Err(ReplayError::StandardSecurity)));
@@ -705,12 +927,25 @@ mod tests {
         .map(|(label, secret)| format!("{label} {} {}", hex(&client_random), hex(&secret)))
         .collect::<Vec<_>>()
         .join("\n");
-        let tls = Tls13::from_hello(&hello(1, client_random, None), 0x1301, &key_log).unwrap();
+        let tls = Tls13::from_hello(
+            &hello(1, client_random, None),
+            0x1301,
+            &key_log,
+            &Vec::new(),
+            &Vec::new(),
+        )
+        .unwrap();
         let finished = [20, 0, 0, 0];
         let client = vec![
             (
                 1,
-                encrypt_tls13_record(tls.cipher, &tls.client_handshake, 0, &finished, TLS_CONTENT_HANDSHAKE),
+                encrypt_tls13_record(
+                    tls.cipher,
+                    tls.client_handshake.as_ref().expect("handshake key"),
+                    0,
+                    &finished,
+                    TLS_CONTENT_HANDSHAKE,
+                ),
             ),
             (
                 2,
@@ -726,7 +961,13 @@ mod tests {
         let server = vec![
             (
                 3,
-                encrypt_tls13_record(tls.cipher, &tls.server_handshake, 0, &finished, TLS_CONTENT_HANDSHAKE),
+                encrypt_tls13_record(
+                    tls.cipher,
+                    tls.server_handshake.as_ref().expect("handshake key"),
+                    0,
+                    &finished,
+                    TLS_CONTENT_HANDSHAKE,
+                ),
             ),
             (
                 4,
@@ -849,5 +1090,62 @@ mod tests {
         record.extend(length.to_be_bytes());
         record.extend(body);
         record
+    }
+
+    #[test]
+    fn decrypts_tunneled_gateway_session() {
+        let client_random = [1; 32];
+        let master = [2; 48];
+        let key_log = format!("CLIENT_RANDOM {} {}", hex(&client_random), hex(&master));
+        let client_hello = hello(1, client_random, None);
+        let server_hello = hello(2, [3; 32], Some(0x009c));
+        let tls = Tls12::from_hello(&client_hello, &server_hello, 0x009c, &key_log).unwrap();
+
+        // Tunneled RDP stream: X.224 connection, then TLS handshake and data.
+        let mut inner_client = x224_connection(0xe0);
+        inner_client.extend(handshake_record(1, &client_hello));
+        inner_client.extend(change_cipher_spec());
+        inner_client.extend(encrypt_tls12_record(&tls, Direction::Client, 0, b"client"));
+        let mut inner_server = x224_connection(0xd0);
+        inner_server.extend(handshake_record(2, &server_hello));
+        inner_server.extend(change_cipher_spec());
+        inner_server.extend(encrypt_tls12_record(&tls, Direction::Server, 0, b"server"));
+
+        // Wrap each stream in MS-TSGU data packets carried by WebSocket frames.
+        let mut outer_client = b"RDG_OUT_DATA /remoteDesktopGateway/ HTTP/1.1\r\n\r\n".to_vec();
+        outer_client.extend(gateway_frame(&inner_client, Some([5, 6, 7, 8])));
+        let mut outer_server = b"HTTP/1.1 101 Switching Protocols\r\n\r\n".to_vec();
+        outer_server.extend(gateway_frame(&inner_server, None));
+        let outer = Plaintext {
+            client: vec![(1, outer_client)],
+            server: vec![(2, outer_server)],
+        };
+
+        let tunneled = crate::gateway::extract_tunneled_rdp(&outer).unwrap();
+        let plaintext = decrypt_tls_streams(&tunneled.client, &tunneled.server, &key_log).unwrap();
+
+        assert_eq!(plaintext.client, vec![(1, b"client".to_vec())]);
+        assert_eq!(plaintext.server, vec![(2, b"server".to_vec())]);
+    }
+
+    fn gateway_frame(data: &[u8], mask: Option<[u8; 4]>) -> Vec<u8> {
+        let packet_length = u32::try_from(10 + data.len()).unwrap();
+        let mut packet = Vec::new();
+        packet.extend(0x0Au16.to_le_bytes());
+        packet.extend(0u16.to_le_bytes());
+        packet.extend(packet_length.to_le_bytes());
+        packet.extend(u16::try_from(data.len()).unwrap().to_le_bytes());
+        packet.extend(data);
+
+        let mut frame = vec![0x82];
+        frame.push((u8::from(mask.is_some()) << 7) | u8::try_from(packet.len()).unwrap());
+        match mask {
+            Some(mask) => {
+                frame.extend(mask);
+                frame.extend(packet.iter().enumerate().map(|(index, byte)| byte ^ mask[index % 4]));
+            }
+            None => frame.extend(packet),
+        }
+        frame
     }
 }

--- a/crates/ironrdp-capture-replay/src/transport.rs
+++ b/crates/ironrdp-capture-replay/src/transport.rs
@@ -41,8 +41,26 @@ pub struct Flow {
 pub struct Capture {
     /// Direct TCP RDP flow selected from the pcapng input.
     pub flow: Flow,
+    /// Other TLS flows to the same gateway port, tried when the primary flow is not an
+    /// RD Gateway tunnel (a KDC-proxy connection shares the gateway's port 443).
+    pub gateway_alternates: Vec<Flow>,
     /// NSS-compatible TLS key-log entries embedded in the capture.
     pub tls_key_log: TlsKeyLog,
+}
+
+impl Capture {
+    /// Merge additional NSS key-log entries, e.g. from an external key log file.
+    ///
+    /// Captures exported through Wireshark's filtered "Inject TLS Secrets" flow
+    /// only embed secrets for flows Wireshark can see; a tunneled session such
+    /// as RDP inside an RD Gateway WebSocket is invisible to it, so its secrets
+    /// must come from the original key log.
+    pub fn add_tls_key_log(&mut self, key_log: &str) {
+        self.tls_key_log.0.push_str(key_log);
+        if !key_log.ends_with('\n') {
+            self.tls_key_log.0.push('\n');
+        }
+    }
 }
 
 impl core::fmt::Debug for Capture {
@@ -152,9 +170,114 @@ pub fn read_capture(path: &Path) -> Result<Capture, ReplayError> {
         return Err(ReplayError::UnsupportedTransport);
     }
 
+    let flows = assemble_flows(segments);
+    let (flow, alternates) = select_flow(flows)?;
     Ok(Capture {
-        flow: assemble_flow(segments)?,
+        flow,
+        gateway_alternates: alternates,
         tls_key_log: TlsKeyLog::new(tls_key_log),
+    })
+}
+
+/// Select the replayable flow: a direct RDP connection when present, otherwise
+/// the TLS session to a gateway on TCP port 443. Other gateway-port flows are
+/// returned as alternates for gateway-tunnel detection.
+fn select_flow(flows: Vec<Option<Flow>>) -> Result<(Flow, Vec<Flow>), ReplayError> {
+    let mut missing_tcp_flow = false;
+    let mut gateway: Option<Flow> = None;
+    let mut alternates = Vec::new();
+    for flow in flows {
+        let Some(flow) = flow else {
+            missing_tcp_flow = true;
+            continue;
+        };
+        if has_x224_connection_initiation(&flow.client_stream, &flow.server_stream) {
+            return Ok((flow, Vec::new()));
+        }
+        if flow.server.port == 443 {
+            match gateway {
+                None => gateway = Some(flow),
+                Some(_) => alternates.push(flow),
+            }
+        }
+    }
+
+    if let Some(flow) = gateway {
+        return Ok((flow, alternates));
+    }
+
+    Err(if missing_tcp_flow {
+        ReplayError::MissingTcpFlow
+    } else {
+        ReplayError::UnsupportedTransport
+    })
+}
+
+fn assemble_flows(segments: Vec<Segment>) -> Vec<Option<Flow>> {
+    let mut segments = segments;
+    segments.retain(|segment| !segment.data.is_empty() || segment.syn || segment.fin || segment.rst);
+    segments
+        .iter()
+        .enumerate()
+        .filter(|(_, segment)| segment.syn && !segment.ack)
+        .map(|(start, syn)| assemble_flow_at(&segments, start, syn))
+        .collect()
+}
+
+fn assemble_flow_at(segments: &[Segment], start: usize, syn: &Segment) -> Option<Flow> {
+    let client = syn.source.clone();
+    let server = syn.destination.clone();
+    let mut client_segments = Vec::new();
+    let mut server_segments = Vec::new();
+    let mut client_closed = false;
+    let mut server_closed = false;
+
+    for segment in segments.iter().skip(start) {
+        if segment.syn
+            && !segment.ack
+            && segment.packet != syn.packet
+            && segment.source == client
+            && segment.destination == server
+        {
+            break;
+        }
+        if segment.source == client && segment.destination == server {
+            if !client_closed {
+                client_segments.push(segment.clone());
+                client_closed |= segment.fin;
+            }
+        } else if segment.source == server && segment.destination == client {
+            if !server_closed {
+                server_segments.push(segment.clone());
+                server_closed |= segment.fin;
+            }
+        } else {
+            continue;
+        }
+        if segment.rst || (client_closed && server_closed) {
+            break;
+        }
+    }
+
+    let client_origin = syn.sequence.wrapping_add(1);
+    let server_origin = server_segments
+        .iter()
+        .find(|segment| segment.syn)
+        .map(|segment| segment.sequence.wrapping_add(1))
+        .or_else(|| {
+            server_segments
+                .iter()
+                .find(|segment| !segment.data.is_empty())
+                .map(|segment| segment.sequence)
+        })
+        .unwrap_or(0);
+    let client_stream = reassemble(client_segments, client_origin).ok()?;
+    let server_stream = reassemble(server_segments, server_origin).ok()?;
+    Some(Flow {
+        client,
+        server,
+        client_stream,
+        server_stream,
     })
 }
 
@@ -240,85 +363,6 @@ fn parse_tcp_packet(packet: usize, bytes: &[u8]) -> Option<Segment> {
         fin: flags & 0x01 != 0,
         rst: flags & 0x04 != 0,
         data: tcp[header_len..].to_vec(),
-    })
-}
-
-fn assemble_flow(mut segments: Vec<Segment>) -> Result<Flow, ReplayError> {
-    segments.retain(|segment| !segment.data.is_empty() || segment.syn || segment.fin || segment.rst);
-    let mut missing_tcp_flow = false;
-    for (start, syn) in segments
-        .iter()
-        .enumerate()
-        .filter(|(_, segment)| segment.syn && !segment.ack)
-    {
-        let client = syn.source.clone();
-        let server = syn.destination.clone();
-        let mut client_segments = Vec::new();
-        let mut server_segments = Vec::new();
-        let mut client_closed = false;
-        let mut server_closed = false;
-
-        for segment in segments.iter().skip(start) {
-            if segment.syn
-                && !segment.ack
-                && segment.packet != syn.packet
-                && segment.source == client
-                && segment.destination == server
-            {
-                break;
-            }
-            if segment.source == client && segment.destination == server {
-                if !client_closed {
-                    client_segments.push(segment.clone());
-                    client_closed |= segment.fin;
-                }
-            } else if segment.source == server && segment.destination == client {
-                if !server_closed {
-                    server_segments.push(segment.clone());
-                    server_closed |= segment.fin;
-                }
-            } else {
-                continue;
-            }
-            if segment.rst || (client_closed && server_closed) {
-                break;
-            }
-        }
-
-        let client_origin = syn.sequence.wrapping_add(1);
-        let server_origin = server_segments
-            .iter()
-            .find(|segment| segment.syn)
-            .map(|segment| segment.sequence.wrapping_add(1))
-            .or_else(|| {
-                server_segments
-                    .iter()
-                    .find(|segment| !segment.data.is_empty())
-                    .map(|segment| segment.sequence)
-            })
-            .unwrap_or(0);
-        let Ok(client_stream) = reassemble(client_segments, client_origin) else {
-            missing_tcp_flow = true;
-            continue;
-        };
-        let Ok(server_stream) = reassemble(server_segments, server_origin) else {
-            missing_tcp_flow = true;
-            continue;
-        };
-        if has_x224_connection_initiation(&client_stream, &server_stream) {
-            return Ok(Flow {
-                client,
-                server,
-                client_stream,
-                server_stream,
-            });
-        }
-    }
-
-    Err(if missing_tcp_flow {
-        ReplayError::MissingTcpFlow
-    } else {
-        ReplayError::UnsupportedTransport
     })
 }
 
@@ -525,7 +569,7 @@ mod tests {
         let first_server = endpoint(2);
         let second_client = endpoint(3);
         let second_server = endpoint(4);
-        let flow = assemble_flow(vec![
+        let (flow, _) = select_flow(assemble_flows(vec![
             segment_between(first_client.clone(), first_server.clone(), 100, 1, true, false, &[]),
             segment_between(first_client.clone(), first_server.clone(), 101, 2, false, true, b"bad"),
             segment_between(first_client, first_server, 101, 3, false, true, b"XX"),
@@ -540,7 +584,7 @@ mod tests {
                 &connection_request(),
             ),
             segment_between(second_server, second_client, 300, 6, false, true, &connection_confirm()),
-        ])
+        ]))
         .unwrap();
 
         assert_eq!(flow.client.port, 3);
@@ -552,7 +596,7 @@ mod tests {
         let client = endpoint(1);
         let server = endpoint(2);
         let request = connection_request();
-        let error = assemble_flow(vec![
+        let error = select_flow(assemble_flows(vec![
             segment_between(client.clone(), server.clone(), 100, 1, true, false, &[]),
             segment_between(client.clone(), server.clone(), 101, 2, false, true, &request[..8]),
             segment_between(
@@ -564,7 +608,7 @@ mod tests {
                 true,
                 &request[8..],
             ),
-        ])
+        ]))
         .unwrap_err();
 
         assert!(matches!(error, ReplayError::MissingTcpFlow));
@@ -574,7 +618,7 @@ mod tests {
     fn separates_connections_that_reuse_a_tcp_tuple() {
         let client = endpoint(1);
         let server = endpoint(2);
-        let flow = assemble_flow(vec![
+        let (flow, _) = select_flow(assemble_flows(vec![
             segment_between(client.clone(), server.clone(), 100, 1, true, false, &[]),
             segment_between(client.clone(), server.clone(), 101, 2, false, true, b"old"),
             segment_between(server.clone(), client.clone(), 300, 3, false, true, b"old"),
@@ -589,7 +633,7 @@ mod tests {
                 &connection_request(),
             ),
             segment_between(server, client, 700, 6, false, true, &connection_confirm()),
-        ])
+        ]))
         .unwrap();
 
         assert_eq!(flow.client_stream[0].0, 5);
@@ -622,7 +666,7 @@ mod tests {
             &[],
         );
         server_fin.fin = true;
-        let flow = assemble_flow(vec![
+        let (flow, _) = select_flow(assemble_flows(vec![
             segment_between(client.clone(), server.clone(), 100, 1, true, false, &[]),
             segment_between(client.clone(), server.clone(), 101, 2, false, true, &request),
             client_fin,
@@ -637,7 +681,7 @@ mod tests {
                 b"firstsecond",
             ),
             server_fin,
-        ])
+        ]))
         .unwrap();
 
         assert_eq!(

--- a/crates/ironrdp-cfg/src/lib.rs
+++ b/crates/ironrdp-cfg/src/lib.rs
@@ -67,9 +67,9 @@ pub enum GatewayUsageMethod {
     ///
     /// Windows semantics are "try direct, use gateway if direct fails".
     ///
-    /// IronRDP currently does not implement that two-step fallback, and if
-    /// an explicit gateway hostname is present, it selects it eagerly as the best
-    /// available approximation.
+    /// IronRDP implements that two-step fallback when a gateway hostname and
+    /// credentials are configured: the client attempts a direct TCP connection
+    /// first, then opens an MS-TSGU tunnel on failure.
     ///
     /// RDC UI: bypass-local is selected.
     #[default]

--- a/crates/ironrdp-client/Cargo.toml
+++ b/crates/ironrdp-client/Cargo.toml
@@ -40,6 +40,8 @@ clipboard = ["dep:ironrdp-cliprdr", "dep:ironrdp-cliprdr-native"]
 rdpdr = ["dep:ironrdp-rdpdr", "dep:ironrdp-rdpsnd"]
 smartcard = ["rdpdr"]
 gateway = ["dep:ironrdp-mstsgu"]
+# Smart-card gateway authentication (Kerberos PKINIT) through RD Gateway HTTP Negotiate.
+gateway-smartcard = ["gateway", "ironrdp-mstsgu/smartcard"]
 qoi = ["ironrdp-connector/qoi", "ironrdp-session/qoi"]
 qoiz = ["ironrdp-connector/qoiz", "ironrdp-session/qoiz"]
 dvc-pipe-proxy = ["dep:ironrdp-dvc-pipe-proxy"]
@@ -90,7 +92,7 @@ ironrdp-rdpeai = { path = "../ironrdp-rdpeai", version = "0.1", optional = true 
 # Optional backend crates (activated by features above)
 ironrdp-rdpsnd-native = { path = "../ironrdp-rdpsnd-native", version = "0.7", optional = true }
 ironrdp-cliprdr-native = { path = "../ironrdp-cliprdr-native", version = "0.7", optional = true }
-ironrdp-mstsgu = { path = "../ironrdp-mstsgu", version = "0.0.1", optional = true }
+ironrdp-mstsgu = { path = "../ironrdp-mstsgu", version = "0.0.1", optional = true } # public
 ironrdp-dvc-pipe-proxy = { path = "../ironrdp-dvc-pipe-proxy", version = "0.5", optional = true }
 
 # Logging

--- a/crates/ironrdp-client/README.md
+++ b/crates/ironrdp-client/README.md
@@ -14,7 +14,13 @@ for consuming them and dispatching them to whatever event loop or runtime it wis
 TLS peer-certificate validation remains disabled by default for compatibility with
 existing deployments. `ConfigBuilder` exposes an explicit
 `CertificateValidation::Strict` policy for callers that require platform-root and
-server-name validation.
+server-name validation. With `feature = "gateway"`, the same certificate policy is
+applied to the MS-TSGU HTTPS leg (`GwClient::connect_with_certificate_validation`).
+
+Gateway transport (`Transport::Gateway` / `GatewayConfig`) uses `ironrdp-mstsgu`:
+Negotiate/NTLM/Basic HTTP auth, optional SSPI NTLM extended auth, destination
+port forwarding, and `prefer_direct` for Detect/default-settings fallback.
+Legacy dual-channel HTTP, RDG-UDP, and mid-session reauth are not implemented yet.
 
 For the end-user RDP client binary, see [`ironrdp-viewer`](../ironrdp-viewer).
 

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -343,11 +343,9 @@ pub enum Transport {
 
     /// Connect via an RDS gateway (MS-TSGU / MSTSGU).
     ///
-    /// The target RDP server is derived from [`Config::destination`]; the gateway
-    /// only needs its own endpoint and credentials.
-    ///
-    /// NOTE: the destination port is currently not forwarded to the gateway.
-    /// If `ironrdp-mstsgu` hardcodes port 3389, open a follow-up issue.
+    /// The target RDP server host and port are taken from [`Config::destination`] and
+    /// forwarded in the MS-TSGU channel-create packet. The gateway only needs its own
+    /// endpoint and credentials.
     #[cfg(feature = "gateway")]
     Gateway(GatewayConfig),
 
@@ -392,6 +390,11 @@ pub enum TransportKind {
     Gateway {
         /// Gateway endpoint address (e.g., `"rdg.contoso.com:443"`).
         endpoint: String,
+        /// When `true` (`GatewayUsageMethod::Detect`), try a direct TCP connection first and fall
+        /// back to the gateway only if that fails.
+        prefer_direct: bool,
+        /// Gateway transport protocol (WebSocket by default, or legacy RPC-over-HTTP).
+        transport: GatewayTransport,
     },
 
     /// Connect via an RDCleanPath proxy (WebSocket-based).
@@ -421,6 +424,29 @@ pub struct GatewayConfig {
     pub username: String,
     /// Gateway password.
     pub password: String,
+    /// When `true` (`GatewayUsageMethod::Detect`), try direct TCP first and fall back to the
+    /// gateway on connection failure.
+    pub prefer_direct: bool,
+    /// Smart-card credentials for gateway authentication via Kerberos PKINIT.
+    ///
+    /// When set, the gateway HTTP layer authenticates with the Negotiate scheme using the
+    /// smart card instead of the password. Requires the `gateway-smartcard` feature.
+    pub smart_card: Option<ironrdp_mstsgu::GwSmartCardCredentials>,
+    /// Gateway transport protocol: modern WebSocket (default) or legacy RPC-over-HTTP.
+    ///
+    /// Use `Rpc` for gateways that do not support the WebSocket upgrade.
+    pub transport: GatewayTransport,
+}
+
+/// The MS-TSGU transport used to reach the RD Gateway.
+#[cfg(feature = "gateway")]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum GatewayTransport {
+    /// WebSocket upgrade, or dual-channel HTTP when the gateway declines the upgrade.
+    #[default]
+    WebSocket,
+    /// Legacy RPC-over-HTTP (MS-RPCH v2).
+    Rpc,
 }
 
 // ── Destination ───────────────────────────────────────────────────────────────
@@ -633,6 +659,8 @@ pub struct ConfigBuilder {
     platform: Option<ironrdp_pdu::rdp::capability_sets::MajorPlatformType>,
     gateway_username: Option<String>,
     gateway_password: Option<String>,
+    #[cfg(feature = "gateway")]
+    gateway_smart_card: Option<ironrdp_mstsgu::GwSmartCardCredentials>,
 
     // Optional (defaulted at build time).
     domain: Option<String>,
@@ -744,6 +772,18 @@ impl ConfigBuilder {
     #[must_use]
     pub fn with_gateway_password(mut self, password: impl Into<String>) -> Self {
         self.gateway_password = Some(password.into());
+        self
+    }
+
+    /// Use smart-card credentials (Kerberos PKINIT) for RD Gateway authentication.
+    ///
+    /// Requires the `gateway-smartcard` feature. The gateway username/password are still
+    /// required by [`build`](Self::build) today; the smart card takes precedence during
+    /// HTTP authentication.
+    #[cfg(feature = "gateway")]
+    #[must_use]
+    pub fn with_gateway_smart_card(mut self, credentials: ironrdp_mstsgu::GwSmartCardCredentials) -> Self {
+        self.gateway_smart_card = Some(credentials);
         self
     }
 
@@ -1096,13 +1136,27 @@ impl ConfigBuilder {
                 self.properties.set_rdcleanpath_url(url.to_string());
             }
             #[cfg(feature = "gateway")]
-            TransportKind::Gateway { endpoint } => {
+            TransportKind::Gateway {
+                endpoint,
+                prefer_direct,
+                transport,
+            } => {
                 self.properties.clear_rdcleanpath();
                 #[cfg(windows)]
                 self.properties.clear_named_pipe();
                 self.properties.set_gateway_hostname(endpoint.clone());
-                self.properties
-                    .set_gateway_usage_method(ironrdp_cfg::GatewayUsageMethod::UseAlways);
+                self.properties.set_gateway_usage_method(if *prefer_direct {
+                    ironrdp_cfg::GatewayUsageMethod::Detect
+                } else {
+                    ironrdp_cfg::GatewayUsageMethod::UseAlways
+                });
+                self.properties.insert(
+                    "ironrdp_gateway_transport",
+                    match transport {
+                        GatewayTransport::WebSocket => 0,
+                        GatewayTransport::Rpc => 1,
+                    },
+                );
             }
             #[cfg(windows)]
             TransportKind::NamedPipe { path } => {
@@ -1121,8 +1175,8 @@ impl ConfigBuilder {
     /// A destination with no explicit port defaults to 2179 instead of the ordinary RDP port.
     ///
     /// Security (TLS + CredSSP) is required by [`ironrdp_vmconnect::connect_front`] for every
-    /// embedder (error if disabled). Works over Direct and RDCleanPath. RDS Gateway is rejected
-    /// until it can propagate the VMConnect target port.
+    /// embedder (error if disabled). Works over Direct, RDCleanPath, and RDS Gateway (the
+    /// destination port, typically 2179, is forwarded in the MS-TSGU channel-create packet).
     #[must_use]
     pub fn with_vmconnect(mut self, vm_id: impl Into<String>) -> Self {
         self.vm_id = Some(vm_id.into());
@@ -1364,9 +1418,53 @@ impl ConfigBuilder {
         self
     }
 
+    /// Read the gateway transport protocol from the IronRDP-specific property
+    /// (`ironrdp_gateway_transport`: 0 = WebSocket, 1 = RPC-over-HTTP).
+    #[cfg(feature = "gateway")]
+    fn gateway_transport_from_property(ps: &PropertySet) -> GatewayTransport {
+        match ps.get::<i64>("ironrdp_gateway_transport") {
+            Some(1) => GatewayTransport::Rpc,
+            _ => GatewayTransport::WebSocket,
+        }
+    }
+
+    /// Resolve gateway HTTP auth credentials from explicit gateway fields and
+    /// `gatewaycredentialssource` (default: share RDP server credentials).
+    #[cfg(feature = "gateway")]
+    fn resolved_gateway_credentials(&self) -> (Option<&str>, Option<&str>) {
+        use ironrdp_cfg::{GatewayCredentialsSource, PropertySetExt as _};
+
+        let source = self
+            .properties
+            .gateway_credentials_source()
+            .ok()
+            .flatten()
+            .unwrap_or(GatewayCredentialsSource::UseServerCredentials);
+
+        let explicit_user = self.gateway_username.as_deref();
+        let explicit_pass = self.gateway_password.as_deref();
+        let server_user = self.username.as_deref();
+        let server_pass = self.password.as_deref();
+
+        match source {
+            GatewayCredentialsSource::UseUserCredentials => (explicit_user, explicit_pass),
+            GatewayCredentialsSource::UseServerCredentials | GatewayCredentialsSource::UseLogonCredentials => {
+                (explicit_user.or(server_user), explicit_pass.or(server_pass))
+            }
+            // Profile / Prompt / SmartCard are not implemented as credential providers yet.
+            // Prefer explicit gateway credentials when present; otherwise fall back to RDP creds
+            // so existing Always/Detect setups keep working.
+            GatewayCredentialsSource::UseProfile
+            | GatewayCredentialsSource::Prompt
+            | GatewayCredentialsSource::SmartCard => (explicit_user.or(server_user), explicit_pass.or(server_pass)),
+        }
+    }
+
     /// List the required fields that still need a value before [`build`](Self::build) can succeed.
     ///
     /// Gateway credentials are only required when a gateway transport is selected.
+    /// With `gatewaycredentialssource:i:0` (UseServerCredentials), the RDP username/password
+    /// satisfy the gateway credential requirement.
     pub fn missing(&self) -> Vec<MissingField> {
         let mut missing = Vec::new();
         if self.destination.is_none() {
@@ -1380,10 +1478,12 @@ impl ConfigBuilder {
         }
         #[cfg(feature = "gateway")]
         if matches!(self.transport, TransportKind::Gateway { .. }) {
-            if self.gateway_username.is_none() {
+            let (gw_user, gw_pass) = self.resolved_gateway_credentials();
+            if gw_user.is_none() && self.gateway_smart_card.is_none() {
                 missing.push(MissingField::GatewayUsername);
             }
-            if self.gateway_password.is_none() {
+            // Smart-card gateway authentication replaces the password with Kerberos PKINIT.
+            if gw_pass.is_none() && self.gateway_smart_card.is_none() {
                 missing.push(MissingField::GatewayPassword);
             }
         }
@@ -1412,11 +1512,25 @@ impl ConfigBuilder {
         clippy::missing_panics_doc,
         reason = "a panic here would be a bug (secrets are guaranteed present by missing()), not documented behavior"
     )]
-    // `mut` is only required when the vmconnect default-port path mutates destination/properties.
-    #[cfg_attr(not(feature = "vmconnect"), expect(unused_mut))]
+    // `mut` is required when gateway credential materialization and/or vmconnect default-port paths run.
+    #[cfg_attr(not(any(feature = "vmconnect", feature = "gateway")), expect(unused_mut))]
     pub fn build(mut self) -> anyhow::Result<Config> {
         use ironrdp_pdu::rdp::capability_sets::client_codecs_capabilities;
         use ironrdp_pdu::rdp::client_info::TimezoneInfo;
+
+        #[cfg(feature = "gateway")]
+        {
+            // Materialize UseServerCredentials / fallbacks before the missing() check.
+            let (gw_user, gw_pass) = self.resolved_gateway_credentials();
+            let gw_user = gw_user.map(str::to_owned);
+            let gw_pass = gw_pass.map(str::to_owned);
+            if self.gateway_username.is_none() {
+                self.gateway_username = gw_user;
+            }
+            if self.gateway_password.is_none() {
+                self.gateway_password = gw_pass;
+            }
+        }
 
         let missing = self.missing();
         if !missing.is_empty() {
@@ -1479,11 +1593,30 @@ impl ConfigBuilder {
         let transport = match self.transport {
             TransportKind::Direct => Transport::Direct,
             #[cfg(feature = "gateway")]
-            TransportKind::Gateway { endpoint } => Transport::Gateway(GatewayConfig {
+            TransportKind::Gateway {
                 endpoint,
-                username: self.gateway_username.unwrap(),
-                password: self.gateway_password.unwrap(),
-            }),
+                prefer_direct,
+                transport,
+            } => {
+                // Smart-card credentials authenticate without a password (Kerberos PKINIT).
+                let smart_card = self.gateway_smart_card;
+                Transport::Gateway(GatewayConfig {
+                    endpoint,
+                    username: if smart_card.is_some() {
+                        self.gateway_username.unwrap_or_default()
+                    } else {
+                        self.gateway_username.unwrap()
+                    },
+                    password: if smart_card.is_some() {
+                        self.gateway_password.unwrap_or_default()
+                    } else {
+                        self.gateway_password.unwrap()
+                    },
+                    prefer_direct,
+                    smart_card,
+                    transport,
+                })
+            }
             TransportKind::RDCleanPath { url } => Transport::RDCleanPath(RDCleanPathConfig {
                 url,
                 auth_token: self.rdcleanpath_token.unwrap(),
@@ -1499,10 +1632,6 @@ impl ConfigBuilder {
             }
             if !self.enable_credssp.unwrap_or(true) {
                 anyhow::bail!("vmconnect requires CredSSP");
-            }
-            #[cfg(feature = "gateway")]
-            if matches!(transport, Transport::Gateway(_)) {
-                anyhow::bail!("vmconnect cannot be used over an RDS gateway until the target port is propagated");
             }
         }
 
@@ -1804,23 +1933,27 @@ impl ConfigBuilder {
 
                 let select_gateway_transport = match gateway_usage {
                     // Explicit gateway use.
-                    GatewayUsageMethod::UseAlways => true,
+                    GatewayUsageMethod::UseAlways => Some(false),
 
-                    // Approximation of Windows "try direct, then gateway" behavior.
-                    GatewayUsageMethod::Detect => gateway_hostname.is_some(),
+                    // Try direct first; fall back to gateway when a hostname is configured.
+                    GatewayUsageMethod::Detect if gateway_hostname.is_some() => Some(true),
+                    GatewayUsageMethod::Detect => None,
 
-                    // IronRDP does not currently resolve MSTSC/client/GPO default gateway policy.
-                    GatewayUsageMethod::UseDefaultSettings => false,
+                    // No GPO profile store yet: treat default settings like Detect.
+                    GatewayUsageMethod::UseDefaultSettings if gateway_hostname.is_some() => Some(true),
+                    GatewayUsageMethod::UseDefaultSettings => None,
 
                     // Explicit no-gateway modes.
-                    GatewayUsageMethod::Direct | GatewayUsageMethod::DirectBypassLocal => false,
+                    GatewayUsageMethod::Direct | GatewayUsageMethod::DirectBypassLocal => None,
                 };
 
-                if select_gateway_transport {
+                if let Some(prefer_direct) = select_gateway_transport {
                     let endpoint = gateway_hostname.context("missing Gateway hostname")?;
 
                     self.transport = TransportKind::Gateway {
                         endpoint: endpoint.to_owned(),
+                        prefer_direct,
+                        transport: Self::gateway_transport_from_property(ps),
                     };
 
                     if let Some(user) = ps.gateway_username() {
@@ -1849,17 +1982,21 @@ impl ConfigBuilder {
                 let gateway_hostname = ps.gateway_hostname();
 
                 let select_gateway_transport = match gateway_usage {
-                    GatewayUsageMethod::UseAlways => true,
-                    GatewayUsageMethod::Detect => gateway_hostname.is_some(),
-                    GatewayUsageMethod::UseDefaultSettings => false,
-                    GatewayUsageMethod::Direct | GatewayUsageMethod::DirectBypassLocal => false,
+                    GatewayUsageMethod::UseAlways => Some(false),
+                    GatewayUsageMethod::Detect if gateway_hostname.is_some() => Some(true),
+                    GatewayUsageMethod::Detect => None,
+                    GatewayUsageMethod::UseDefaultSettings if gateway_hostname.is_some() => Some(true),
+                    GatewayUsageMethod::UseDefaultSettings => None,
+                    GatewayUsageMethod::Direct | GatewayUsageMethod::DirectBypassLocal => None,
                 };
 
-                if select_gateway_transport {
+                if let Some(prefer_direct) = select_gateway_transport {
                     let endpoint = gateway_hostname.context("missing Gateway hostname")?;
 
                     self.transport = TransportKind::Gateway {
                         endpoint: endpoint.to_owned(),
+                        prefer_direct,
+                        transport: Self::gateway_transport_from_property(ps),
                     };
 
                     if let Some(user) = ps.gateway_username() {

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -616,41 +616,81 @@ impl RdpClient {
                 },
 
                 #[cfg(feature = "gateway")]
-                Transport::Gateway(gw) => match Box::pin(cancelable_operation(
-                    connect_gateway(
-                        &self.config,
-                        gw,
-                        &self.input_event_sender,
-                        cliprdr_factory,
-                        rdpdr_factory,
-                        reconnect_cookie,
-                    ),
-                    &mut self.close_receiver,
-                ))
-                .await
-                {
-                    Some(Ok(result)) => result,
-                    Some(Err(error)) => {
-                        if self
-                            .try_auto_reconnect(
-                                auto_reconnect_policy,
-                                &mut reconnect_attempt,
-                                auto_reconnect_cookie.as_ref(),
-                            )
-                            .await
+                Transport::Gateway(gw) => {
+                    let connect_result = if gw.prefer_direct {
+                        // Detect: try direct first, then fall back to the gateway on failure.
+                        match Box::pin(cancelable_operation(
+                            connect_direct(
+                                &self.config,
+                                &self.input_event_sender,
+                                cliprdr_factory,
+                                rdpdr_factory,
+                                reconnect_cookie,
+                            ),
+                            &mut self.close_receiver,
+                        ))
+                        .await
                         {
-                            continue;
+                            Some(Ok(result)) => Some(Ok(result)),
+                            Some(Err(direct_error)) => {
+                                info!(
+                                    error = %direct_error,
+                                    "Direct connection failed; falling back to RD Gateway"
+                                );
+                                Box::pin(cancelable_operation(
+                                    connect_gateway(
+                                        &self.config,
+                                        gw,
+                                        &self.input_event_sender,
+                                        cliprdr_factory,
+                                        rdpdr_factory,
+                                        reconnect_cookie,
+                                    ),
+                                    &mut self.close_receiver,
+                                ))
+                                .await
+                            }
+                            None => None,
                         }
-                        if !self.send_output_event(RdpOutputEvent::ConnectionFailure(error)).await {
+                    } else {
+                        Box::pin(cancelable_operation(
+                            connect_gateway(
+                                &self.config,
+                                gw,
+                                &self.input_event_sender,
+                                cliprdr_factory,
+                                rdpdr_factory,
+                                reconnect_cookie,
+                            ),
+                            &mut self.close_receiver,
+                        ))
+                        .await
+                    };
+
+                    match connect_result {
+                        Some(Ok(result)) => result,
+                        Some(Err(error)) => {
+                            if self
+                                .try_auto_reconnect(
+                                    auto_reconnect_policy,
+                                    &mut reconnect_attempt,
+                                    auto_reconnect_cookie.as_ref(),
+                                )
+                                .await
+                            {
+                                continue;
+                            }
+                            if !self.send_output_event(RdpOutputEvent::ConnectionFailure(error)).await {
+                                self.emit_user_initiated_termination();
+                            }
+                            break;
+                        }
+                        None => {
                             self.emit_user_initiated_termination();
+                            break;
                         }
-                        break;
                     }
-                    None => {
-                        self.emit_user_initiated_termination();
-                        break;
-                    }
-                },
+                }
 
                 Transport::RDCleanPath(rdcp) => match Box::pin(cancelable_operation(
                     connect_rdcleanpath_transport(
@@ -1447,26 +1487,82 @@ async fn connect_gateway(
 ) -> ConnectorResult<(ConnectionResult, UpgradedFramed)> {
     use ironrdp_mstsgu::GwConnectTarget;
 
-    // VMConnect needs destination port 2179; GwConnectTarget does not carry it yet (TODO below).
-    #[cfg(feature = "vmconnect")]
-    if config.vm_id().is_some() {
-        return Err(ironrdp_connector::general_err!(
-            "vmconnect cannot be used over an RDS gateway until the target port is propagated"
-        ));
-    }
-
-    // Build the GwConnectTarget.  `server` is the RDP target derived from `config.destination`.
-    // TODO: preserve the destination port; ironrdp-mstsgu may currently hard-code 3389.
+    // Target resource host/port come from Config::destination and are forwarded in the
+    // MS-TSGU channel-create packet (enables non-3389 RDP and VMConnect port 2179).
     let gw_target = GwConnectTarget {
         gw_endpoint: gw.endpoint.clone(),
         gw_user: gw.username.clone(),
         gw_pass: gw.password.clone(),
         server: config.destination.name().to_owned(),
+        server_port: config.destination.port(),
+        smart_card: gw.smart_card.clone().map(Box::new),
     };
 
-    let (gw_stream, client_addr) = ironrdp_mstsgu::GwClient::connect(&gw_target, &config.connector.client_name)
-        .await
-        .map_err(|e| ironrdp_connector::custom_err!("GW connect", e))?;
+    // Apply the same TLS certificate policy used for direct RDP to the gateway HTTPS leg.
+    // The RPCH transport does not negotiate tunnel policy (device redirection), so it
+    // only carries the byte stream.
+    let (gw_stream, client_addr, policy) = match gw.transport {
+        crate::config::GatewayTransport::WebSocket => {
+            let (stream, addr) = ironrdp_mstsgu::GwClient::connect_with_certificate_validation(
+                &gw_target,
+                &config.connector.client_name,
+                config.certificate_validation(),
+                config.certificate_validation_callback().cloned(),
+            )
+            .await
+            .map_err(|e| ironrdp_connector::custom_err!("GW connect", e))?;
+            let policy = stream.tunnel_policy();
+            let boxed: Box<dyn AsyncReadWrite + Unpin + Send + Sync> = Box::new(stream);
+            (boxed, addr, policy)
+        }
+        crate::config::GatewayTransport::Rpc => {
+            let (stream, addr) = ironrdp_mstsgu::GwClient::connect_rpch(
+                &gw_target,
+                &config.connector.client_name,
+                config.certificate_validation(),
+                config.certificate_validation_callback().cloned(),
+            )
+            .await
+            .map_err(|e| ironrdp_connector::custom_err!("GW RPC connect", e))?;
+            let boxed: Box<dyn AsyncReadWrite + Unpin + Send + Sync> = Box::new(stream);
+            (boxed, addr, ironrdp_mstsgu::GwTunnelPolicy::default())
+        }
+    };
+
+    // The gateway may restrict device redirection for this session ([MS-TSGU] 2.2.5.3.7);
+    // gate the affected channel factories on the advertised policy.
+    if let Some(flags) = policy.redir_flags {
+        if flags.all_disabled() {
+            info!("RD Gateway policy disables all device redirection");
+        }
+    }
+    #[cfg(feature = "clipboard")]
+    let cliprdr_factory: CliprdrFactoryRef<'_> = match policy
+        .redir_flags
+        .map(|flags| flags.clipboard_disabled())
+        .unwrap_or(false)
+    {
+        true => {
+            warn!("RD Gateway policy disables clipboard redirection");
+            None
+        }
+        false => cliprdr_factory,
+    };
+    #[cfg(feature = "rdpdr")]
+    let rdpdr_factory: RdpdrFactoryRef<'_> = match policy
+        .redir_flags
+        .map(|flags| flags.drives_disabled() || flags.all_disabled())
+        .unwrap_or(false)
+    {
+        true => {
+            warn!("RD Gateway policy disables drive redirection");
+            None
+        }
+        false => rdpdr_factory,
+    };
+
+    #[cfg(feature = "vmconnect")]
+    let pcb_deadline = tokio::time::Instant::now() + ironrdp_vmconnect::PCB_TRANSMIT_DEADLINE;
 
     let framed = ironrdp_tokio::TokioFramed::new(gw_stream);
 
@@ -1478,6 +1574,10 @@ async fn connect_gateway(
         rdpdr_factory,
         auto_reconnect_cookie,
     )?;
+    #[cfg(feature = "vmconnect")]
+    if config.vm_id().is_some() {
+        return vmconnect_handshake_and_finalize(framed, connector, config, pcb_deadline).await;
+    }
     security_upgrade_and_finalize(framed, connector, config).await
 }
 
@@ -3079,12 +3179,12 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "clipboard")]
+    #[cfg(all(feature = "rdpdr", feature = "clipboard"))]
     fn no_cliprdr_factory() -> CliprdrFactoryRef<'static> {
         None
     }
 
-    #[cfg(not(feature = "clipboard"))]
+    #[cfg(all(feature = "rdpdr", not(feature = "clipboard")))]
     fn no_cliprdr_factory() -> CliprdrFactoryRef<'static> {
         core::marker::PhantomData
     }

--- a/crates/ironrdp-daemon/Cargo.toml
+++ b/crates/ironrdp-daemon/Cargo.toml
@@ -13,7 +13,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["rustls", "dvc-pipe-proxy", "rdpdr", "smartcard"] } # public
+ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["rustls", "dvc-pipe-proxy", "rdpdr", "smartcard", "gateway"] } # public
 ironrdp-cfg = { path = "../ironrdp-cfg", version = "0.1" }
 ironrdp-input = { path = "../ironrdp-input", version = "0.7" }
 ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9" }

--- a/crates/ironrdp-daemon/src/daemon.rs
+++ b/crates/ironrdp-daemon/src/daemon.rs
@@ -1549,7 +1549,7 @@ async fn consume_output(
             }
             RdpOutputEvent::ConnectionFailure(error) => {
                 guard.state = ConnState::Failed;
-                guard.error = Some(format!("{error}"));
+                guard.error = Some(format!("{error:#}"));
                 let rail_changed = guard.rail.fail_pending_launches();
                 error!(%error, "Session connection failed");
                 rail_changed

--- a/crates/ironrdp-gwforward/Cargo.toml
+++ b/crates/ironrdp-gwforward/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "ironrdp-gwforward"
+version = "0.0.0"
+publish = false
+readme = "README.md"
+description = "Generic TCP forwarding and SOCKS5 proxying over an MS-TSGU RD Gateway tunnel"
+edition.workspace = true
+rust-version = "1.94"
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lib]
+doctest = false
+test = false
+
+[dependencies]
+ironrdp-error = { path = "../ironrdp-error", version = "0.2" }
+ironrdp-mstsgu = { path = "../ironrdp-mstsgu", version = "0.0.1", features = ["rustls"] } # public
+ironrdp-tls = { path = "../ironrdp-tls", version = "0.2" } # public
+tokio = { version = "1.52", features = ["macros", "rt", "net", "io-util", "time"] }
+tracing = "0.1"
+
+[lints]
+workspace = true

--- a/crates/ironrdp-gwforward/README.md
+++ b/crates/ironrdp-gwforward/README.md
@@ -1,0 +1,48 @@
+# ironrdp-gwforward
+
+Generic TCP forwarding and SOCKS5 proxying over a Microsoft RD Gateway.
+
+The RD Gateway tunneling protocol ([MS-TSGU]) relays a TCP byte stream to any reachable
+target host and port; it is not limited to RDP. This crate builds on
+[`ironrdp-mstsgu`] to expose that capability to ordinary, non-RDP programs.
+
+## What it provides
+
+- **Local port forward** ([`run_port_forward`]) — SSH `-L`-style. Listen on a local port
+  and relay each inbound connection to a fixed `host:port` through the gateway.
+- **SOCKS5 proxy** ([`run_socks5`]) — a local SOCKS5 server (CONNECT, no auth). Any
+  SOCKS5-capable client (for example `curl --socks5`) names its destination per
+  connection and is tunnelled there through the gateway.
+
+Each inbound connection opens an independent gateway tunnel and relays bytes
+bidirectionally with `tokio::io::copy_bidirectional`.
+
+## Contract
+
+Callers supply a [`GatewayTunnelConfig`] (gateway endpoint, credentials, transport, and
+TLS certificate policy) plus a local listen address. The crate owns the accept loops and
+the per-connection tunnel setup; it does not manage RDP sessions.
+
+The default transport is the modern WebSocket path; [`GatewayTransport::Rpc`] selects the
+legacy RPC-over-HTTP transport for gateways without WebSocket support.
+
+## Example
+
+```rust,ignore
+use ironrdp_gwforward::{GatewayTunnelConfig, run_socks5};
+
+let config = GatewayTunnelConfig {
+    gateway_endpoint: "rdg.contoso.com:443".into(),
+    username: "CONTOSO\\alice".into(),
+    password: "...".into(),
+    ..Default::default()
+};
+run_socks5(config, "127.0.0.1:1080").await?;
+```
+
+[MS-TSGU]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsgu/
+[`ironrdp-mstsgu`]: ../ironrdp-mstsgu/README.md
+[`run_port_forward`]: ./src/forward.rs
+[`run_socks5`]: ./src/forward.rs
+[`GatewayTunnelConfig`]: ./src/tunnel.rs
+[`GatewayTransport::Rpc`]: ./src/tunnel.rs

--- a/crates/ironrdp-gwforward/src/error.rs
+++ b/crates/ironrdp-gwforward/src/error.rs
@@ -1,0 +1,39 @@
+//! Error type for the gateway forwarding crate.
+
+use core::fmt;
+
+/// Result alias for gateway forwarding operations.
+pub type Result<T> = core::result::Result<T, ForwardError>;
+
+/// Error kind for gateway forwarding and SOCKS5 operations.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum ForwardErrorKind {
+    /// The gateway tunnel could not be opened or was lost.
+    Tunnel,
+    /// A local listener could not be bound or accepted a connection.
+    Listener,
+    /// A SOCKS5 request was malformed or used an unsupported feature.
+    Socks5,
+    /// The target address could not be parsed or resolved.
+    Address,
+    /// A generic I/O failure while relaying bytes.
+    Io,
+}
+
+impl fmt::Display for ForwardErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Tunnel => f.write_str("gateway tunnel error"),
+            Self::Listener => f.write_str("listener error"),
+            Self::Socks5 => f.write_str("socks5 protocol error"),
+            Self::Address => f.write_str("address error"),
+            Self::Io => f.write_str("io error"),
+        }
+    }
+}
+
+impl core::error::Error for ForwardErrorKind {}
+
+/// Error for gateway forwarding operations.
+pub type ForwardError = ironrdp_error::Error<ForwardErrorKind>;

--- a/crates/ironrdp-gwforward/src/forward.rs
+++ b/crates/ironrdp-gwforward/src/forward.rs
@@ -1,0 +1,113 @@
+//! Local listeners that relay connections through an RD Gateway tunnel.
+
+use tokio::net::TcpListener;
+use tracing::{debug, info, instrument, warn};
+
+use crate::error::{ForwardError, ForwardErrorKind, Result};
+use crate::socks5;
+use crate::tunnel::{GatewayTunnelConfig, open_tunnel};
+
+/// Listen on `listen_addr` and forward each inbound TCP connection to
+/// `target_host:target_port` through the RD Gateway (SSH `-L`-style local forwarding).
+///
+/// Runs until the listener errors. Each accepted connection opens an independent tunnel.
+#[instrument(skip(config), fields(listen = %listen_addr, target = %format_args!("{target_host}:{target_port}")))]
+pub async fn run_port_forward(
+    config: GatewayTunnelConfig,
+    listen_addr: &str,
+    target_host: &str,
+    target_port: u16,
+) -> Result<()> {
+    let listener = TcpListener::bind(listen_addr)
+        .await
+        .map_err(|e| ForwardError::new("bind forward listener", ForwardErrorKind::Listener).with_source(e))?;
+    let local = listener
+        .local_addr()
+        .map_err(|e| ForwardError::new("forward listener address", ForwardErrorKind::Listener).with_source(e))?;
+    info!(%local, %target_host, target_port, "Port forward listening");
+
+    loop {
+        let (inbound, peer) = listener
+            .accept()
+            .await
+            .map_err(|e| ForwardError::new("accept forward connection", ForwardErrorKind::Listener).with_source(e))?;
+        debug!(%peer, "Accepted forward connection");
+        let config = config.clone();
+        let target_host = target_host.to_owned();
+        tokio::spawn(async move {
+            if let Err(e) = relay_forward(config, inbound, &target_host, target_port).await {
+                warn!(%peer, error = %e, "Forward connection failed");
+            }
+        });
+    }
+}
+
+/// Listen on `listen_addr` and serve SOCKS5 CONNECT, opening a gateway tunnel to each
+/// requested destination. Lets any SOCKS5-capable program reach internal hosts through
+/// the gateway without per-target configuration.
+#[instrument(skip(config), fields(listen = %listen_addr))]
+pub async fn run_socks5(config: GatewayTunnelConfig, listen_addr: &str) -> Result<()> {
+    let listener = TcpListener::bind(listen_addr)
+        .await
+        .map_err(|e| ForwardError::new("bind socks5 listener", ForwardErrorKind::Listener).with_source(e))?;
+    let local = listener
+        .local_addr()
+        .map_err(|e| ForwardError::new("socks5 listener address", ForwardErrorKind::Listener).with_source(e))?;
+    info!(%local, "SOCKS5 proxy listening");
+
+    loop {
+        let (inbound, peer) = listener
+            .accept()
+            .await
+            .map_err(|e| ForwardError::new("accept socks5 connection", ForwardErrorKind::Listener).with_source(e))?;
+        debug!(%peer, "Accepted socks5 connection");
+        let config = config.clone();
+        tokio::spawn(async move {
+            if let Err(e) = relay_socks5(config, inbound).await {
+                warn!(%peer, error = %e, "SOCKS5 connection failed");
+            }
+        });
+    }
+}
+
+async fn relay_forward(
+    config: GatewayTunnelConfig,
+    mut inbound: tokio::net::TcpStream,
+    target_host: &str,
+    target_port: u16,
+) -> Result<()> {
+    let mut tunnel = open_tunnel(&config, target_host, target_port).await?;
+    relay(&mut inbound, &mut *tunnel).await
+}
+
+async fn relay_socks5(config: GatewayTunnelConfig, mut inbound: tokio::net::TcpStream) -> Result<()> {
+    let target = match socks5::negotiate(&mut inbound).await {
+        Ok(target) => target,
+        Err(e) => return Err(socks5::reject(&mut inbound, e).await),
+    };
+    debug!(host = %target.host, port = target.port, "SOCKS5 CONNECT");
+
+    match open_tunnel(&config, &target.host, target.port).await {
+        Ok(mut tunnel) => {
+            socks5::write_reply(&mut inbound, true).await?;
+            relay(&mut inbound, &mut *tunnel).await
+        }
+        Err(e) => {
+            let err = ForwardError::new("open socks5 tunnel", ForwardErrorKind::Tunnel).with_source(e);
+            Err(socks5::reject(&mut inbound, err).await)
+        }
+    }
+}
+
+/// Bidirectionally copy bytes between the local connection and the gateway tunnel until
+/// either side closes.
+async fn relay<A, B>(a: &mut A, b: &mut B) -> Result<()>
+where
+    A: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + ?Sized,
+    B: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + ?Sized,
+{
+    tokio::io::copy_bidirectional(a, b)
+        .await
+        .map_err(|e| ForwardError::new("relay gateway stream", ForwardErrorKind::Io).with_source(e))?;
+    Ok(())
+}

--- a/crates/ironrdp-gwforward/src/lib.rs
+++ b/crates/ironrdp-gwforward/src/lib.rs
@@ -1,0 +1,20 @@
+//! Generic TCP forwarding and SOCKS5 proxying over an MS-TSGU RD Gateway tunnel.
+//!
+//! The RD Gateway tunneling protocol ([MS-TSGU]) relays a TCP byte stream to any
+//! reachable target host:port; it is not limited to RDP. This crate uses that to expose
+//! two local entry points that generic programs can use to traverse an RD Gateway:
+//!
+//! - [`run_port_forward`]: a fixed local forward (SSH `-L`-style) to one target.
+//! - [`run_socks5`]: a SOCKS5 proxy that opens a tunnel per requested destination.
+//!
+//! Each inbound connection opens an independent gateway tunnel via
+//! [`ironrdp_mstsgu::GwClient`] and relays bytes bidirectionally.
+
+mod error;
+mod forward;
+mod socks5;
+mod tunnel;
+
+pub use error::{ForwardError, ForwardErrorKind, Result};
+pub use forward::{run_port_forward, run_socks5};
+pub use tunnel::{GatewayTransport, GatewayTunnelConfig, TunnelStream, open_tunnel};

--- a/crates/ironrdp-gwforward/src/socks5.rs
+++ b/crates/ironrdp-gwforward/src/socks5.rs
@@ -1,0 +1,183 @@
+//! Minimal SOCKS5 server (RFC 1928) for CONNECT, no authentication.
+//!
+//! Supports the subset a generic client needs to tunnel through the gateway:
+//! no-auth method negotiation, CONNECT to an IPv4 address or a domain name, and a
+//! success/failure reply. UDP ASSOCIATE and BIND are not supported.
+
+use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWrite, AsyncWriteExt as _};
+
+use crate::error::{ForwardError, ForwardErrorKind, Result};
+
+const VERSION: u8 = 0x05;
+const METHOD_NO_AUTH: u8 = 0x00;
+const METHOD_NO_ACCEPTABLE: u8 = 0xFF;
+const CMD_CONNECT: u8 = 0x01;
+const ATYP_IPV4: u8 = 0x01;
+const ATYP_DOMAIN: u8 = 0x03;
+const ATYP_IPV6: u8 = 0x04;
+const REP_SUCCESS: u8 = 0x00;
+const REP_COMMAND_NOT_SUPPORTED: u8 = 0x07;
+const REP_ADDRESS_NOT_SUPPORTED: u8 = 0x08;
+const REP_HOST_UNREACHABLE: u8 = 0x04;
+
+/// A requested CONNECT destination.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct SocksTarget {
+    /// Hostname or dotted-decimal IP address.
+    pub(crate) host: String,
+    /// Destination port.
+    pub(crate) port: u16,
+}
+
+/// Run the SOCKS5 negotiation and read the CONNECT request.
+///
+/// On success, returns the requested target; the caller opens the tunnel and then calls
+/// [`write_reply`] to report the outcome before relaying bytes.
+pub(crate) async fn negotiate<S>(stream: &mut S) -> Result<SocksTarget>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    read_greeting(stream).await?;
+    read_connect_request(stream).await
+}
+
+/// Write the SOCKS5 reply for a CONNECT attempt (`success` selects the reply code) and
+/// flush it so the client can begin relaying immediately.
+pub(crate) async fn write_reply<S>(stream: &mut S, success: bool) -> Result<()>
+where
+    S: AsyncWrite + Unpin,
+{
+    let rep = if success { REP_SUCCESS } else { REP_HOST_UNREACHABLE };
+    // BND.ADDR/BND.PORT are reported as 0.0.0.0:0; clients ignore them for CONNECT.
+    let reply = [VERSION, rep, 0x00, ATYP_IPV4, 0, 0, 0, 0, 0, 0];
+    stream
+        .write_all(&reply)
+        .await
+        .map_err(|e| ForwardError::new("write socks5 reply", ForwardErrorKind::Io).with_source(e))?;
+    stream
+        .flush()
+        .await
+        .map_err(|e| ForwardError::new("flush socks5 reply", ForwardErrorKind::Io).with_source(e))?;
+    Ok(())
+}
+
+/// Write a failure reply for a malformed or unsupported CONNECT request, then yield the
+/// error. Used to answer the client before tearing the connection down.
+pub(crate) async fn reject<S>(stream: &mut S, error: ForwardError) -> ForwardError
+where
+    S: AsyncWrite + Unpin,
+{
+    let rep = match error.kind() {
+        ForwardErrorKind::Socks5 => REP_COMMAND_NOT_SUPPORTED,
+        _ => REP_ADDRESS_NOT_SUPPORTED,
+    };
+    let reply = [VERSION, rep, 0x00, ATYP_IPV4, 0, 0, 0, 0, 0, 0];
+    let _ = stream.write_all(&reply).await;
+    let _ = stream.flush().await;
+    error
+}
+
+async fn read_greeting<S>(stream: &mut S) -> Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let version = read_u8(stream).await?;
+    if version != VERSION {
+        return Err(ForwardError::new("socks5 version", ForwardErrorKind::Socks5));
+    }
+    let method_count = usize::from(read_u8(stream).await?);
+    let mut methods = vec![0u8; method_count];
+    read_exact(stream, &mut methods).await?;
+
+    let offers_no_auth = methods.contains(&METHOD_NO_AUTH);
+    let chosen = if offers_no_auth {
+        METHOD_NO_AUTH
+    } else {
+        METHOD_NO_ACCEPTABLE
+    };
+    stream
+        .write_all(&[VERSION, chosen])
+        .await
+        .map_err(|e| ForwardError::new("write socks5 greeting", ForwardErrorKind::Io).with_source(e))?;
+    stream
+        .flush()
+        .await
+        .map_err(|e| ForwardError::new("flush socks5 greeting", ForwardErrorKind::Io).with_source(e))?;
+
+    if !offers_no_auth {
+        return Err(ForwardError::new(
+            "client offers no no-auth method",
+            ForwardErrorKind::Socks5,
+        ));
+    }
+    Ok(())
+}
+
+async fn read_connect_request<S>(stream: &mut S) -> Result<SocksTarget>
+where
+    S: AsyncRead + Unpin,
+{
+    let version = read_u8(stream).await?;
+    if version != VERSION {
+        return Err(ForwardError::new("socks5 request version", ForwardErrorKind::Socks5));
+    }
+    let command = read_u8(stream).await?;
+    if command != CMD_CONNECT {
+        return Err(ForwardError::new(
+            "socks5 unsupported command",
+            ForwardErrorKind::Socks5,
+        ));
+    }
+    let _reserved = read_u8(stream).await?;
+    let atyp = read_u8(stream).await?;
+
+    let host = match atyp {
+        ATYP_IPV4 => {
+            let mut octets = [0u8; 4];
+            read_exact(stream, &mut octets).await?;
+            octets.map(|b| b.to_string()).join(".")
+        }
+        ATYP_DOMAIN => {
+            let len = usize::from(read_u8(stream).await?);
+            let mut bytes = vec![0u8; len];
+            read_exact(stream, &mut bytes).await?;
+            String::from_utf8(bytes)
+                .map_err(|_| ForwardError::new("socks5 domain not utf8", ForwardErrorKind::Socks5))?
+        }
+        ATYP_IPV6 => {
+            let mut octets = [0u8; 16];
+            read_exact(stream, &mut octets).await?;
+            let addr = core::net::Ipv6Addr::from(octets);
+            addr.to_string()
+        }
+        _ => {
+            return Err(ForwardError::new("socks5 address type", ForwardErrorKind::Socks5));
+        }
+    };
+
+    let mut port_bytes = [0u8; 2];
+    read_exact(stream, &mut port_bytes).await?;
+    let port = u16::from_be_bytes(port_bytes);
+
+    Ok(SocksTarget { host, port })
+}
+
+async fn read_u8<S>(stream: &mut S) -> Result<u8>
+where
+    S: AsyncRead + Unpin,
+{
+    let mut byte = [0u8; 1];
+    read_exact(stream, &mut byte).await?;
+    Ok(byte[0])
+}
+
+async fn read_exact<S>(stream: &mut S, buf: &mut [u8]) -> Result<()>
+where
+    S: AsyncRead + Unpin,
+{
+    stream
+        .read_exact(buf)
+        .await
+        .map_err(|e| ForwardError::new("read socks5", ForwardErrorKind::Socks5).with_source(e))?;
+    Ok(())
+}

--- a/crates/ironrdp-gwforward/src/tunnel.rs
+++ b/crates/ironrdp-gwforward/src/tunnel.rs
@@ -1,0 +1,87 @@
+//! Open an MS-TSGU RD Gateway tunnel to an arbitrary target host:port as a byte stream.
+//!
+//! The RD Gateway tunneling protocol is not RDP-specific: the gateway relays a TCP byte
+//! stream between the client and any reachable target. This module opens such a tunnel
+//! and surfaces it as a generic [`AsyncRead`]/[`AsyncWrite`] stream, so any TCP-based
+//! protocol (SSH, a database, a custom socket) can traverse the gateway.
+
+use tokio::io::{AsyncRead, AsyncWrite};
+
+use ironrdp_mstsgu::{GwClient, GwConnectTarget, RpchStream};
+use ironrdp_tls::CertificateValidation;
+
+use crate::error::{ForwardError, ForwardErrorKind, Result};
+
+/// A bidirectional byte stream carried over an RD Gateway tunnel.
+pub trait TunnelStream: AsyncRead + AsyncWrite + Unpin + Send {}
+impl<T> TunnelStream for T where T: AsyncRead + AsyncWrite + Unpin + Send {}
+
+/// Which MS-TSGU transport to use for the gateway tunnel.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum GatewayTransport {
+    /// Modern WebSocket transport (the default; requires gateway WebSocket support).
+    #[default]
+    WebSocket,
+    /// Legacy RPC-over-HTTP transport ([MS-RPCH] v2) for gateways without WebSocket.
+    Rpc,
+}
+
+/// Configuration for opening a gateway tunnel.
+#[derive(Clone, Debug)]
+pub struct GatewayTunnelConfig {
+    /// Gateway host:port (for example `rdg.contoso.com:443`).
+    pub gateway_endpoint: String,
+    /// Gateway username for HTTP authentication.
+    pub username: String,
+    /// Gateway password for HTTP authentication.
+    pub password: String,
+    /// Which gateway transport to use.
+    pub transport: GatewayTransport,
+    /// Client name presented to the gateway.
+    pub client_name: String,
+    /// TLS certificate policy for the gateway HTTPS leg.
+    pub certificate_validation: CertificateValidation,
+}
+
+/// Open one gateway tunnel to `target_host:target_port`.
+///
+/// Returns a byte stream bridged to the target through the gateway. Each call opens an
+/// independent tunnel; a port-forward or SOCKS5 listener calls this once per inbound
+/// connection.
+pub async fn open_tunnel(
+    config: &GatewayTunnelConfig,
+    target_host: &str,
+    target_port: u16,
+) -> Result<Box<dyn TunnelStream>> {
+    let target = GwConnectTarget {
+        gw_endpoint: config.gateway_endpoint.clone(),
+        gw_user: config.username.clone(),
+        gw_pass: config.password.clone(),
+        server: target_host.to_owned(),
+        server_port: target_port,
+        smart_card: None,
+    };
+
+    match config.transport {
+        GatewayTransport::WebSocket => {
+            let (client, _addr) = GwClient::connect_with_certificate_validation(
+                &target,
+                &config.client_name,
+                config.certificate_validation,
+                None,
+            )
+            .await
+            .map_err(|e| ForwardError::new("open gateway tunnel", ForwardErrorKind::Tunnel).with_source(e))?;
+            Ok(Box::new(client))
+        }
+        GatewayTransport::Rpc => {
+            let (stream, _addr): (RpchStream, _) =
+                GwClient::connect_rpch(&target, &config.client_name, config.certificate_validation, None)
+                    .await
+                    .map_err(|e| {
+                        ForwardError::new("open gateway rpc tunnel", ForwardErrorKind::Tunnel).with_source(e)
+                    })?;
+            Ok(Box::new(stream))
+        }
+    }
+}

--- a/crates/ironrdp-mstsgu/CHANGELOG.md
+++ b/crates/ironrdp-mstsgu/CHANGELOG.md
@@ -6,6 +6,40 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## Unreleased
+
+### Added
+
+- [`GwConnectTarget::server_port`] forwards the destination resource port in the MS-TSGU channel-create packet (non-3389 RDP and VMConnect 2179).
+- [`GwErrorKind::HttpStatus`] and [`GwErrorKind::GatewayCode`] surface HTTP upgrade status and gateway protocol/HRESULT codes (with common MS-TSGU HRESULT labels).
+- HTTP multi-leg authentication for the WebSocket upgrade: Negotiate SPNEGO (Kerberos with NTLM fallback via KDC discovery / `SSPI_KDC_URL`), pure NTLM when only NTLM is advertised, Basic fallback; optional `HTTP/<host>` SPN.
+- Post-handshake SSPI NTLM extended authentication when the gateway selects it ([MS-TSGU] 3.3.5.3).
+- Broader tunnel capability advertisement (consent, service message, idle timeout, reauth).
+- Service-message logging and channel-close handling.
+- Mid-session reauthentication: `HTTP_REAUTH_MESSAGE` triggers a secondary connection repeating the setup sequence with the reauth tunnel context, then the data path switches over ([MS-TSGU] 4.1.3).
+- Mock gateway harness (`#[cfg(test)]`) plus `Encode` impls for server-side packets, covering the full connection sequence and failure injection.
+- `GwClient::tunnel_policy` exposes gateway-negotiated device redirection flags (`GwTunnelRedirFlags`) and idle timeout.
+- `GwClient::connect_with_options` with `GwConnectOptions::consent_callback` lets products present the gateway consent message and decline the connection.
+- Smart-card gateway authentication (feature `smartcard`): `GwConnectTarget::smart_card` authenticates the HTTP Negotiate scheme with Kerberos PKINIT via sspi smart-card identities (emulated or Windows card readers).
+- MS-RPCH v2 client driver (not enabled as a fallback yet): IN/OUT channels over raw HTTP/1 with the 100-Continue IN-body gate, RTS CONN setup, DCE/RPC bind with optional NTLM packet integrity, TsProxy create/authorize/create-channel/setup-receive-pipe sequence, receive-pipe data plane, send/receive window flow control, ping scheduling, and administrative tunnel messages. Covered by an in-process mock RPC proxy test.
+- Consent messages are logged and auto-accepted until an interactive UI path exists.
+- Endpoint parsing defaults bare hosts to port 443 and supports bracketed IPv6.
+- Unit tests for core MS-TSGU packet encode/decode layouts and HTTP auth helpers.
+- Tunnel-auth optional fields: client SoH blob encode support; response redir flags, idle timeout, and SoH response decode.
+- Channel response UDP port and auth cookie accessors (for a future RDG-UDP path).
+- `GwClient::connect_with_certificate_validation` applies the same TLS certificate policy as direct RDP.
+- Multi-stage handshake/tunnel/channel encode+decode sequence unit test.
+- Dual-channel HTTP transport fallback when WebSocket upgrade is unavailable (`RDG_OUT_DATA` + `RDG_IN_DATA`, seed skip, chunked IN body).
+- RDG-UDP packet helpers: [`GwUdpOffer`], [`CONNECT_PKT`] encode/decode, correlation info, and connect fragmentation (no live DTLS open yet).
+- Session cookie replay across gateway HTTP request legs for load-balanced deployments.
+- HTTP CONNECT and SOCKS5 proxy support via `HTTPS_PROXY` / `NO_PROXY`, including proxy URL credentials.
+
+### Fixed
+
+- `HTTP_EXTENDED_AUTH_NONE` is now `0x00` per [MS-TSGU] 2.2.5.3.2 (was incorrectly `0x01`).
+- Handshake response fixed-part size now accounts for a 2-byte `extended_auth` field.
+- Packet header fixed-part size comment/layout corrected to `u16 + u16 + u32`.
+
 ## [[0.0.1](https://github.com/Devolutions/IronRDP/releases/tag/ironrdp-mstsgu-v0.0.1)] - 2026-07-10
 
 Initial release.

--- a/crates/ironrdp-mstsgu/Cargo.toml
+++ b/crates/ironrdp-mstsgu/Cargo.toml
@@ -14,28 +14,36 @@ categories.workspace = true
 
 [lib]
 doctest = false
-test = false
 
 [features]
 default = []
 rustls = ["ironrdp-tls/rustls", "tokio-tungstenite/rustls-tls-native-roots"]
 native-tls = ["ironrdp-tls/native-tls", "tokio-tungstenite/native-tls"]
+# Smart-card gateway authentication (Kerberos PKINIT) through the HTTP Negotiate scheme.
+smartcard = ["sspi/scard", "sspi/dns_resolver", "dep:picky", "dep:picky-asn1-der", "dep:picky-asn1-x509"]
 
 [dependencies]
 base64 = "0.22"
 bitflags = "2.11"
 futures-util = "0.3"
-http-body-util = { version = "0.1" }
+http = "1"
+http-body-util = { version = "0.1", features = ["channel"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 hyper = { version = "1.9", features = ["client", "http1"] }
 ironrdp-core = { path = "../ironrdp-core", version = "0.2", features = ["std"] }
 ironrdp-error = { path = "../ironrdp-error", version = "0.2" }
 ironrdp-tls = { path = "../ironrdp-tls", version = "0.2" }
 log = "0.4"
+picky = { version = "=7.0.0-rc.25", optional = true } # Pin matches ironrdp-connector; candidate numbers bump like minors.
+picky-asn1-der = { version = "0.5", optional = true }
+picky-asn1-x509 = { version = "0.15", optional = true }
+sspi = { version = "0.21", features = ["network_client"] }
 tokio-tungstenite = { version = "0.29" }
 tokio-util = { version = "0.7" }
 tokio = { version = "1.52", features = ["macros", "rt"] }
 uuid = { version = "1", features = ["v4"] }
+url = "2"
+tokio-socks = "0.5.3"
 
 [lints]
 workspace = true

--- a/crates/ironrdp-mstsgu/README.md
+++ b/crates/ironrdp-mstsgu/README.md
@@ -2,10 +2,54 @@
 
 [Terminal Services Gateway Server Protocol][MS-TSGU] implementation for IronRDP.
 
-This crate
-- implements an MVP state needed to connect through Microsoft RD Gateway,
-- only supports the HTTPS protocol with WebSocket (and not the legacy HTTP, HTTP-RPC or UDP protocols),
-- does not implement reconnection/reauthentication, and
-- only supports basic auth.
+## Supported path
+
+This crate implements the client side of the common modern RD Gateway path:
+
+- HTTPS transport:
+  - duplex **WebSocket** after `RDG_OUT_DATA` upgrade when the gateway returns `101 Switching Protocols`
+  - legacy **dual-channel HTTP** (`RDG_OUT_DATA` response body + `RDG_IN_DATA` request body) when the gateway returns `200 OK` without upgrade ([MS-TSGU] 3.3.5.1)
+- Endpoint parsing: bare host defaults to port `443`; bracketed IPv6 is supported
+- TLS certificate policy via [`GwClient::connect_with_certificate_validation`] (same
+  [`ironrdp_tls::CertificateValidation`] / callback surface as direct RDP)
+- HTTP authentication (challenge-first):
+  - **Negotiate** SPNEGO prefers Kerberos when a KDC is available (`SSPI_KDC_URL`, system config, or DNS), otherwise NTLM
+  - **NTLM** scheme when only NTLM is advertised
+  - optional `HTTP/<host>` SPN on both paths
+  - **Basic** fallback when neither Negotiate nor NTLM is offered
+  - **Smart card** ([MS-TSGU] 2.2.5.3.10 SMARTCARD): Negotiate with Kerberos PKINIT via [`GwConnectTarget::smart_card`] (feature `smartcard`; emulated cards and Windows card readers)
+- Session cookies are replayed across the WebSocket/dual-HTTP authentication and IN/OUT request legs for load-balanced gateways
+- HTTP CONNECT and SOCKS5 proxies are selected from `HTTPS_PROXY` / `https_proxy` and bypassed by `NO_PROXY` / `no_proxy`
+- Handshake may advertise and complete **SSPI NTLM extended auth** when the gateway selects it ([MS-TSGU] 3.3.5.3)
+- Tunnel sequence: handshake → (optional extended auth) → tunnel create → tunnel auth → channel create → data/keepalive
+- Tunnel caps advertised: consent sign, service message, idle timeout, reauth
+- Tunnel auth response optional fields (device-redirection flags, idle timeout, SoH response) are parsed and exposed through [`GwClient::tunnel_policy`]
+- Channel response may carry UDP port + auth cookie metadata; [`GwUdpOffer`] / [`CONNECT_PKT`] helpers encode the RDG-UDP connect framing (live DTLS side channel not opened yet)
+- Consent text is logged and auto-accepted by default; [`GwConnectOptions::consent_callback`] lets products present and decide the prompt
+- Service messages are logged; channel-close ends the stream
+- Mid-session **reauthentication**: on `HTTP_REAUTH_MESSAGE` a secondary connection repeats the setup sequence (handshake → tunnel create with the reauth tunnel context → tunnel auth → channel create) and the data path switches over ([MS-TSGU] 4.1.3)
+- Common gateway HRESULTs are labeled in [`GwErrorKind::GatewayCode`] display text
+
+The target resource **hostname and port** are taken from [`GwConnectTarget`] and sent in the
+MS-TSGU channel-create packet (`HTTP_CHANNEL_PACKET`). Callers should pass the real destination
+port (for example `3389` for ordinary RDP, or `2179` for Hyper-V VMConnect).
+
+Gateway failures report a stage-oriented context string and, when available, an HTTP status or
+gateway protocol/HRESULT code via [`GwErrorKind`].
+
+Product clients may implement `GatewayUsageMethod::Detect` (try direct TCP, then this crate) outside
+of `ironrdp-mstsgu`; this crate itself always opens a gateway tunnel.
+
+## Not yet supported
+
+- HTTP-RPC transport is implemented end to end (IN/OUT channels with the 100-Continue gate, RTS CONN setup, DCE/RPC bind with optional NTLM packet integrity, TsProxy tunnel/channel calls, receive-pipe data plane, flow control, ping scheduling, and administrative messages) but not wired as a fallback until validated against a real RD Gateway
+- Live RDG-UDP / DTLS side channel open (PDU helpers only; needs MS-RDPEUDP consumer)
+- PAA (pluggable authentication and authorization) cookies
+- `HTTP_EXTENDED_AUTH_SC` CredSSP blob exchange (smart card here uses HTTP Negotiate PKINIT instead, matching FreeRDP)
+- Kerberos without discoverable KDC (falls back to NTLM inside Negotiate)
+- Interactive consent UI in product clients (the `consent_callback` surface exists; IronRDP's own clients auto-accept)
+- Recoverable reconnect after transport failure
+
+Do not confuse this crate with `ironrdp-rdcleanpath` (Devolutions Gateway / RDCleanPath).
 
 [MS-TSGU]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsgu/0007d661-a86d-4e8f-89f7-7f77f8824188

--- a/crates/ironrdp-mstsgu/src/http_auth.rs
+++ b/crates/ironrdp-mstsgu/src/http_auth.rs
@@ -1,0 +1,719 @@
+//! HTTP authentication helpers for the MS-TSGU WebSocket upgrade.
+//!
+//! Corporate RD Gateways typically challenge with Negotiate and/or NTLM rather than Basic.
+//! Negotiate prefers Kerberos (via KDC / `SSPI_KDC_URL`) and falls back to NTLM inside SPNEGO.
+//! Pure NTLM is used when the server only offers the NTLM scheme, and for MS-TSGU extended-auth
+//! SSPI NTLM blobs after the handshake.
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD;
+use sspi::ntlm::NtlmConfig;
+use sspi::{
+    AuthIdentity, AuthIdentityBuffers, BufferType, ClientRequestFlags, CredentialUse, Credentials, CredentialsBuffers,
+    DataRepresentation, InitializeSecurityContextResult, Negotiate, NegotiateConfig, Ntlm, SecurityBuffer,
+    SecurityStatus, Sspi as _, SspiImpl as _, Username,
+};
+
+use crate::{Error, GwErrorExt as _, GwErrorKind};
+
+/// Result of consuming one HTTP auth challenge/response.
+#[derive(Debug)]
+pub(crate) enum AuthStep {
+    /// Send another request with this `Authorization` header value.
+    Continue(String),
+    /// Authentication finished (caller should inspect the final HTTP status).
+    Complete,
+    /// Server did not offer NTLM/Negotiate; try HTTP Basic instead.
+    TryBasic,
+}
+
+// SSPI state objects are large value types; boxing would add an indirection per call.
+#[expect(clippy::large_enum_variant, reason = "SSPI state objects are large value types")]
+enum AuthBackend {
+    Ntlm {
+        ntlm: Ntlm,
+        credentials_handle: Option<AuthIdentityBuffers>,
+    },
+    Negotiate {
+        negotiate: Negotiate,
+        credentials_handle: Option<CredentialsBuffers>,
+    },
+}
+
+/// Multi-leg HTTP auth state for `Authorization: NTLM …` / `Negotiate …`.
+pub(crate) struct GatewayHttpAuth {
+    backend: AuthBackend,
+    /// Scheme used in the Authorization header (`NTLM` or `Negotiate`).
+    scheme: &'static str,
+    /// Optional SPN / target name (for example `HTTP/rdg.contoso.com`).
+    target_name: Option<String>,
+    complete: bool,
+}
+
+/// Client-side NTLM state for MS-TSGU `HTTP_EXTENDED_AUTH_PACKET` SSPI NTLM blobs.
+pub(crate) struct NtlmHttpAuth {
+    ntlm: Ntlm,
+    credentials_handle: Option<AuthIdentityBuffers>,
+    complete: bool,
+}
+
+impl GatewayHttpAuth {
+    /// Build auth state from a first-round `WWW-Authenticate` challenge set.
+    ///
+    /// Prefers Negotiate (Kerberos → NTLM SPNEGO) when advertised, otherwise pure NTLM.
+    pub(crate) fn from_challenges(
+        username: &str,
+        password: &str,
+        smart_card: Option<&crate::GwSmartCardCredentials>,
+        target_name: Option<String>,
+        challenges: &[&str],
+    ) -> Result<(Self, AuthStep), Error> {
+        Self::from_challenges_ntlm_only(username, password, smart_card, target_name, challenges, false)
+    }
+
+    /// Like [`Self::from_challenges`], but prefers NTLM over Negotiate.
+    ///
+    /// The legacy RPC-over-HTTP transport uses NTLM packet integrity at the DCE/RPC
+    /// layer; its HTTP layer follows FreeRDP's ncacn_http and uses NTLM, since Kerberos
+    /// over the RPC proxy endpoint has no reliable KDC path.
+    pub(crate) fn from_challenges_ntlm_only(
+        username: &str,
+        password: &str,
+        smart_card: Option<&crate::GwSmartCardCredentials>,
+        target_name: Option<String>,
+        challenges: &[&str],
+        ntlm_only: bool,
+    ) -> Result<(Self, AuthStep), Error> {
+        // Smart-card credentials always take the Negotiate (Kerberos PKINIT) path.
+        #[cfg(feature = "smartcard")]
+        if let Some(smart_card) = smart_card {
+            if challenges
+                .iter()
+                .any(|value| split_auth_challenge(value, "Negotiate").is_some())
+            {
+                let mut auth = Self::new_negotiate_smartcard(smart_card, target_name)?;
+                let token = auth.initialize(None)?;
+                let header = auth.format_authorization(&token);
+                return Ok((auth, AuthStep::Continue(header)));
+            }
+            return Err(Error::new(
+                "gateway does not offer Negotiate for smart card authentication",
+                GwErrorKind::UnsupportedFeature,
+            ));
+        }
+        #[cfg(not(feature = "smartcard"))]
+        if smart_card.is_some() {
+            return Err(Error::new(
+                "smart card gateway authentication requires the `smartcard` feature",
+                GwErrorKind::UnsupportedFeature,
+            ));
+        }
+
+        let mut saw_negotiate = false;
+        let mut saw_ntlm = false;
+        let mut saw_basic = false;
+        let mut negotiate_token: Option<Vec<u8>> = None;
+        let mut ntlm_token: Option<Vec<u8>> = None;
+
+        for value in challenges {
+            if let Some(rest) = split_auth_challenge(value, "Negotiate") {
+                saw_negotiate = true;
+                if rest.is_empty() {
+                    if negotiate_token.is_none() {
+                        negotiate_token = Some(Vec::new());
+                    }
+                } else {
+                    negotiate_token = Some(
+                        STANDARD
+                            .decode(rest.as_bytes())
+                            .map_err(|e| Error::custom("decode negotiate challenge", e))?,
+                    );
+                }
+            } else if let Some(rest) = split_auth_challenge(value, "NTLM") {
+                saw_ntlm = true;
+                if rest.is_empty() {
+                    if ntlm_token.is_none() {
+                        ntlm_token = Some(Vec::new());
+                    }
+                } else {
+                    ntlm_token = Some(
+                        STANDARD
+                            .decode(rest.as_bytes())
+                            .map_err(|e| Error::custom("decode ntlm challenge", e))?,
+                    );
+                }
+            } else if split_auth_challenge(value, "Basic").is_some() {
+                saw_basic = true;
+            }
+        }
+
+        if saw_negotiate && !ntlm_only {
+            let mut auth = Self::new_negotiate(username, password, target_name.clone())?;
+            let input = negotiate_token.as_deref().filter(|t| !t.is_empty());
+            // Kerberos SPNEGO can fail without a reachable KDC (for example a gateway SPN
+            // with no ticket path); fall back to plain NTLM, which needs no network.
+            match auth.initialize(input) {
+                Ok(token) => {
+                    let header = auth.format_authorization(&token);
+                    return Ok((auth, AuthStep::Continue(header)));
+                }
+                Err(error) if saw_ntlm => {
+                    log::debug!("Negotiate failed ({error}); falling back to NTLM");
+                }
+                Err(error) => return Err(error),
+            }
+        }
+
+        if saw_ntlm {
+            let mut auth = Self::new_ntlm(username, password, target_name)?;
+            let input = ntlm_token.as_deref().filter(|t| !t.is_empty());
+            let token = auth.initialize(input)?;
+            let header = auth.format_authorization(&token);
+            return Ok((auth, AuthStep::Continue(header)));
+        }
+
+        if saw_basic {
+            // Dummy backend is not used when falling back to Basic.
+            let auth = Self::new_ntlm(username, password, target_name)?;
+            return Ok((auth, AuthStep::TryBasic));
+        }
+
+        Err(Error::new(
+            "websocket upgrade auth challenge",
+            GwErrorKind::UnsupportedFeature,
+        ))
+    }
+
+    fn new_ntlm(username: &str, password: &str, target_name: Option<String>) -> Result<Self, Error> {
+        let identity = auth_identity(username, password)?;
+        let mut ntlm = Ntlm::new();
+        let credentials_handle = ntlm
+            .acquire_credentials_handle()
+            .with_credential_use(CredentialUse::Outbound)
+            .with_auth_data(&identity)
+            .execute(&mut ntlm)
+            .map_err(|e| Error::custom("acquire ntlm credentials", e))?
+            .credentials_handle;
+
+        Ok(Self {
+            backend: AuthBackend::Ntlm {
+                ntlm,
+                credentials_handle,
+            },
+            scheme: "NTLM",
+            target_name,
+            complete: false,
+        })
+    }
+
+    fn new_negotiate(username: &str, password: &str, target_name: Option<String>) -> Result<Self, Error> {
+        let identity = auth_identity(username, password)?;
+        let credentials = Credentials::AuthIdentity(identity);
+        let client_computer_name = client_computer_name();
+
+        // Start as NTLM; Negotiate upgrades to Kerberos when a KDC is discoverable.
+        let config = NegotiateConfig {
+            protocol_config: Box::new(NtlmConfig::new(client_computer_name.clone())),
+            // Prefer Kerberos when available; keep NTLM fallback; skip PKU2U for gateway HTTP.
+            package_list: Some("kerberos,ntlm".to_owned()),
+            client_computer_name,
+        };
+
+        let mut negotiate = Negotiate::new_client(config).map_err(|e| Error::custom("create negotiate package", e))?;
+        let credentials_handle = negotiate
+            .acquire_credentials_handle()
+            .with_credential_use(CredentialUse::Outbound)
+            .with_auth_data(&credentials)
+            .execute(&mut negotiate)
+            .map_err(|e| Error::custom("acquire negotiate credentials", e))?
+            .credentials_handle;
+
+        Ok(Self {
+            backend: AuthBackend::Negotiate {
+                negotiate,
+                credentials_handle,
+            },
+            scheme: "Negotiate",
+            target_name,
+            complete: false,
+        })
+    }
+
+    /// Negotiate with smart-card credentials (Kerberos PKINIT) for the MS-TSGU
+    /// `SMARTCARD` gateway authentication scheme.
+    #[cfg(feature = "smartcard")]
+    fn new_negotiate_smartcard(
+        smart_card: &crate::GwSmartCardCredentials,
+        target_name: Option<String>,
+    ) -> Result<Self, Error> {
+        use picky::key::PrivateKey;
+        use picky_asn1_x509::Certificate;
+        use sspi::{KerberosConfig, Secret, SmartCardIdentity, SmartCardType};
+
+        let certificate: Certificate = picky_asn1_der::from_bytes(&smart_card.certificate)
+            .map_err(|e| Error::custom("parse smart card certificate", e))?;
+        let username = Self::smart_card_username(&certificate).unwrap_or_default();
+
+        let (private_key, scard_type) = match &smart_card.private_key {
+            // Emulated smart card: the private key signs in software.
+            Some(pkcs1) => (
+                Some(
+                    PrivateKey::from_pkcs1(pkcs1)
+                        .map_err(|e| Error::custom("parse smart card private key", e))?
+                        .into(),
+                ),
+                SmartCardType::Emulated {
+                    scard_pin: Secret::new(smart_card.pin.as_bytes().to_vec()),
+                },
+            ),
+            // System-provided card through the Windows native smart card API.
+            #[cfg(target_os = "windows")]
+            None => (None, SmartCardType::WindowsNative),
+            #[cfg(not(target_os = "windows"))]
+            None => {
+                return Err(Error::new(
+                    "smart card without a private key requires a Windows card reader",
+                    GwErrorKind::UnsupportedFeature,
+                ));
+            }
+        };
+
+        let credentials = Credentials::SmartCard(Box::new(SmartCardIdentity {
+            username,
+            certificate,
+            reader_name: smart_card.reader_name.clone(),
+            card_name: smart_card.card_name.clone(),
+            container_name: smart_card.container_name.clone(),
+            csp_name: smart_card.csp_name.clone().unwrap_or_default(),
+            pin: Secret::new(smart_card.pin.as_bytes().to_vec()),
+            private_key,
+            scard_type,
+        }));
+
+        let client_computer_name = client_computer_name();
+        let kdc_url = std::env::var("SSPI_KDC_URL").unwrap_or_default();
+        let config = NegotiateConfig {
+            // PKINIT is Kerberos-only; there is no NTLM fallback for smart cards.
+            protocol_config: Box::new(KerberosConfig::new(&kdc_url, client_computer_name.clone())),
+            package_list: Some("kerberos".to_owned()),
+            client_computer_name,
+        };
+
+        let mut negotiate = Negotiate::new_client(config).map_err(|e| Error::custom("create negotiate package", e))?;
+        let credentials_handle = negotiate
+            .acquire_credentials_handle()
+            .with_credential_use(CredentialUse::Outbound)
+            .with_auth_data(&credentials)
+            .execute(&mut negotiate)
+            .map_err(|e| Error::custom("acquire negotiate smart card credentials", e))?
+            .credentials_handle;
+
+        Ok(Self {
+            backend: AuthBackend::Negotiate {
+                negotiate,
+                credentials_handle,
+            },
+            scheme: "Negotiate",
+            target_name,
+            complete: false,
+        })
+    }
+
+    /// Username for a smart card identity: UPN from the certificate SAN, else subject CN.
+    #[cfg(feature = "smartcard")]
+    fn smart_card_username(certificate: &picky_asn1_x509::Certificate) -> Option<String> {
+        use picky_asn1_x509::{ExtensionView, GeneralName, oids};
+
+        certificate
+            .extensions()
+            .iter()
+            .find(|ext| ext.extn_id().0 == oids::subject_alternative_name())
+            .iter()
+            .flat_map(|ext| match ext.extn_value() {
+                ExtensionView::SubjectAltName(names) => names.0,
+                _ => vec![],
+            })
+            .find_map(|name| match name {
+                GeneralName::OtherName(name) if name.type_id.0 == oids::user_principal_name() => Some(name.value),
+                _ => None,
+            })
+            .and_then(|asn1| picky_asn1_der::from_bytes(&asn1.0.0).ok())
+            .or_else(|| {
+                certificate
+                    .tbs_certificate
+                    .subject
+                    .find_common_name()
+                    .map(ToString::to_string)
+            })
+    }
+
+    /// Consume a subsequent `WWW-Authenticate` challenge and produce the next step.
+    pub(crate) fn step_www_authenticate<'a, I>(&mut self, challenges: I) -> Result<AuthStep, Error>
+    where
+        I: IntoIterator<Item = &'a str>,
+    {
+        if self.complete {
+            return Ok(AuthStep::Complete);
+        }
+
+        let mut saw_basic = false;
+        let mut token: Option<Vec<u8>> = None;
+
+        for value in challenges {
+            let preferred = match self.scheme {
+                "Negotiate" => split_auth_challenge(value, "Negotiate"),
+                _ => split_auth_challenge(value, "NTLM").or_else(|| split_auth_challenge(value, "Negotiate")),
+            };
+
+            if let Some(rest) = preferred {
+                if rest.is_empty() {
+                    if token.is_none() {
+                        token = Some(Vec::new());
+                    }
+                } else {
+                    token = Some(
+                        STANDARD
+                            .decode(rest.as_bytes())
+                            .map_err(|e| Error::custom("decode auth challenge", e))?,
+                    );
+                }
+            } else if split_auth_challenge(value, "Basic").is_some() {
+                saw_basic = true;
+            }
+        }
+
+        match token {
+            Some(raw) => {
+                let input = if raw.is_empty() { None } else { Some(raw.as_slice()) };
+                let next = self.initialize(input)?;
+                if self.complete && next.is_empty() {
+                    Ok(AuthStep::Complete)
+                } else {
+                    Ok(AuthStep::Continue(self.format_authorization(&next)))
+                }
+            }
+            None if saw_basic => Ok(AuthStep::TryBasic),
+            None => Err(Error::new(
+                "websocket upgrade auth challenge",
+                GwErrorKind::UnsupportedFeature,
+            )),
+        }
+    }
+
+    fn format_authorization(&self, token: &[u8]) -> String {
+        format!("{} {}", self.scheme, STANDARD.encode(token))
+    }
+
+    fn initialize(&mut self, input: Option<&[u8]>) -> Result<Vec<u8>, Error> {
+        let mut input_token = [SecurityBuffer::new(
+            input.map(<[u8]>::to_vec).unwrap_or_default(),
+            BufferType::Token,
+        )];
+        let mut output_token = [SecurityBuffer::new(Vec::with_capacity(1024), BufferType::Token)];
+
+        let status = match &mut self.backend {
+            AuthBackend::Ntlm {
+                ntlm,
+                credentials_handle,
+            } => {
+                let mut builder = ntlm
+                    .initialize_security_context()
+                    .with_credentials_handle(credentials_handle)
+                    .with_context_requirements(default_context_flags())
+                    .with_target_data_representation(DataRepresentation::Native)
+                    .with_input(&mut input_token)
+                    .with_output(&mut output_token);
+                builder.target_name = self.target_name.as_deref();
+
+                let InitializeSecurityContextResult { status, .. } = ntlm
+                    .initialize_security_context_impl(&mut builder)
+                    .map_err(|e| Error::custom("ntlm initialize security context", e))?
+                    .resolve_to_result()
+                    .map_err(|e| Error::custom("ntlm initialize security context", e))?;
+                status
+            }
+            AuthBackend::Negotiate {
+                negotiate,
+                credentials_handle,
+            } => {
+                let mut builder = negotiate
+                    .initialize_security_context()
+                    .with_credentials_handle(credentials_handle)
+                    .with_context_requirements(default_context_flags())
+                    .with_target_data_representation(DataRepresentation::Native)
+                    .with_input(&mut input_token)
+                    .with_output(&mut output_token);
+                builder.target_name = self.target_name.as_deref();
+
+                let mut generator = negotiate
+                    .initialize_security_context_impl(&mut builder)
+                    .map_err(|e| Error::custom("negotiate initialize security context", e))?;
+
+                // Kerberos may suspend for KDC traffic; NTLM completes without network.
+                let InitializeSecurityContextResult { status, .. } = generator
+                    .resolve_with_default_network_client()
+                    .map_err(|e| Error::custom("negotiate initialize security context", e))?;
+                status
+            }
+        };
+
+        match status {
+            SecurityStatus::Ok => {
+                self.complete = true;
+            }
+            SecurityStatus::ContinueNeeded => {}
+            other => {
+                return Err(Error::new("http auth security status", GwErrorKind::Connect)
+                    .with_source(std::io::Error::other(format!("unexpected auth status: {other:?}"))));
+            }
+        }
+
+        Ok(core::mem::take(&mut output_token[0].buffer))
+    }
+}
+
+impl NtlmHttpAuth {
+    pub(crate) fn new(username: &str, password: &str) -> Result<Self, Error> {
+        let identity = auth_identity(username, password)?;
+        let mut ntlm = Ntlm::new();
+        let credentials_handle = ntlm
+            .acquire_credentials_handle()
+            .with_credential_use(CredentialUse::Outbound)
+            .with_auth_data(&identity)
+            .execute(&mut ntlm)
+            .map_err(|e| Error::custom("acquire ntlm credentials", e))?
+            .credentials_handle;
+
+        Ok(Self {
+            ntlm,
+            credentials_handle,
+            complete: false,
+        })
+    }
+
+    /// Produce the next NTLM token for extended-auth packet exchange.
+    ///
+    /// Returns `(token, complete)`.
+    pub(crate) fn step_token(&mut self, input: Option<&[u8]>) -> Result<(Vec<u8>, bool), Error> {
+        let mut input_token = [SecurityBuffer::new(
+            input.map(<[u8]>::to_vec).unwrap_or_default(),
+            BufferType::Token,
+        )];
+        let mut output_token = [SecurityBuffer::new(Vec::with_capacity(1024), BufferType::Token)];
+
+        let mut builder = self
+            .ntlm
+            .initialize_security_context()
+            .with_credentials_handle(&mut self.credentials_handle)
+            .with_context_requirements(default_context_flags())
+            .with_target_data_representation(DataRepresentation::Native)
+            .with_input(&mut input_token)
+            .with_output(&mut output_token);
+
+        let InitializeSecurityContextResult { status, .. } = self
+            .ntlm
+            .initialize_security_context_impl(&mut builder)
+            .map_err(|e| Error::custom("ntlm initialize security context", e))?
+            .resolve_to_result()
+            .map_err(|e| Error::custom("ntlm initialize security context", e))?;
+
+        match status {
+            SecurityStatus::Ok => {
+                self.complete = true;
+            }
+            SecurityStatus::ContinueNeeded => {}
+            other => {
+                return Err(Error::new("ntlm security status", GwErrorKind::Connect)
+                    .with_source(std::io::Error::other(format!("unexpected ntlm status: {other:?}"))));
+            }
+        }
+
+        Ok((core::mem::take(&mut output_token[0].buffer), self.complete))
+    }
+}
+
+/// Build a Basic authorization header value.
+pub(crate) fn basic_authorization(username: &str, password: &str) -> String {
+    let token = STANDARD.encode(format!("{username}:{password}"));
+    format!("Basic {token}")
+}
+
+fn auth_identity(username: &str, password: &str) -> Result<AuthIdentity, Error> {
+    let username = Username::parse(username)
+        .or_else(|_| Username::new(username, None))
+        .map_err(|e| Error::custom("parse gateway username", e))?;
+
+    Ok(AuthIdentity {
+        username,
+        password: password.to_owned().into(),
+    })
+}
+
+fn client_computer_name() -> String {
+    std::env::var("COMPUTERNAME")
+        .or_else(|_| std::env::var("HOSTNAME"))
+        .unwrap_or_else(|_| "IRONRDP".to_owned())
+}
+
+fn default_context_flags() -> ClientRequestFlags {
+    ClientRequestFlags::ALLOCATE_MEMORY
+        | ClientRequestFlags::CONFIDENTIALITY
+        | ClientRequestFlags::INTEGRITY
+        | ClientRequestFlags::MUTUAL_AUTH
+}
+
+/// Case-insensitive scheme match; returns the remainder after the scheme (may be empty).
+fn split_auth_challenge<'a>(header_value: &'a str, scheme: &str) -> Option<&'a str> {
+    let header_value = header_value.trim();
+    let scheme_len = scheme.len();
+    if header_value.len() < scheme_len {
+        return None;
+    }
+    if !header_value.as_bytes()[..scheme_len].eq_ignore_ascii_case(scheme.as_bytes()) {
+        return None;
+    }
+    // The scheme is ASCII, so this byte offset is always a char boundary.
+    let rest = header_value.get(scheme_len..)?;
+    if rest.is_empty() {
+        return Some("");
+    }
+    if !rest.starts_with([' ', '\t']) {
+        return None;
+    }
+    Some(rest.trim())
+}
+
+/// Collect all `WWW-Authenticate` header values as strings.
+pub(crate) fn www_authenticate_values(headers: &http::HeaderMap) -> Vec<&str> {
+    headers
+        .get_all(http::header::WWW_AUTHENTICATE)
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .collect()
+}
+
+/// Whether a `WWW-Authenticate` challenge set offers HTTP Basic.
+pub(crate) fn challenges_offer_basic(challenges: &[&str]) -> bool {
+    challenges
+        .iter()
+        .any(|value| split_auth_challenge(value, "Basic").is_some())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_auth_challenge_parses_schemes() {
+        assert_eq!(split_auth_challenge("NTLM TlRMTVNTUA==", "NTLM"), Some("TlRMTVNTUA=="));
+        assert_eq!(split_auth_challenge("ntlm", "NTLM"), Some(""));
+        assert_eq!(split_auth_challenge("Negotiate abc", "Negotiate"), Some("abc"));
+        assert_eq!(
+            split_auth_challenge("Basic realm=\"rdg\"", "Basic"),
+            Some("realm=\"rdg\"")
+        );
+        assert_eq!(split_auth_challenge("Digest qop=auth", "NTLM"), None);
+    }
+
+    #[test]
+    fn basic_authorization_format() {
+        let value = basic_authorization("user", "pass");
+        assert_eq!(value, "Basic dXNlcjpwYXNz");
+    }
+
+    #[test]
+    fn negotiate_type1_from_challenge() {
+        let (auth, step) = GatewayHttpAuth::from_challenges(
+            r"CONTOSO\alice",
+            "secret",
+            None,
+            Some("HTTP/rdg.contoso.com".to_owned()),
+            &["Negotiate"],
+        )
+        .expect("negotiate init");
+        assert_eq!(auth.scheme, "Negotiate");
+        match step {
+            AuthStep::Continue(header) => {
+                assert!(header.starts_with("Negotiate "));
+                assert!(header.len() > "Negotiate ".len());
+            }
+            other => panic!("expected Continue, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ntlm_type1_from_challenge() {
+        let (auth, step) =
+            GatewayHttpAuth::from_challenges(r"CONTOSO\alice", "secret", None, None, &["NTLM"]).expect("ntlm init");
+        assert_eq!(auth.scheme, "NTLM");
+        match step {
+            AuthStep::Continue(header) => {
+                assert!(header.starts_with("NTLM "));
+                assert!(header.len() > "NTLM ".len());
+            }
+            other => panic!("expected Continue, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn try_basic_when_only_basic_offered() {
+        let (_auth, step) =
+            GatewayHttpAuth::from_challenges("alice", "secret", None, None, &["Basic realm=\"RDG\""]).expect("basic");
+        assert!(matches!(step, AuthStep::TryBasic));
+    }
+
+    #[test]
+    fn extended_auth_ntlm_type1_non_empty() {
+        let mut auth = NtlmHttpAuth::new(r"CONTOSO\alice", "secret").expect("ntlm init");
+        let (token, complete) = auth.step_token(None).expect("type1");
+        assert!(!token.is_empty());
+        assert!(!complete);
+    }
+
+    #[test]
+    fn prefer_negotiate_over_ntlm() {
+        let (auth, _) = GatewayHttpAuth::from_challenges(
+            "alice",
+            "secret",
+            None,
+            None,
+            &["NTLM", "Negotiate", "Basic realm=\"x\""],
+        )
+        .expect("init");
+        assert_eq!(auth.scheme, "Negotiate");
+    }
+
+    #[cfg(feature = "smartcard")]
+    #[test]
+    fn smart_card_requires_negotiate_scheme() {
+        let smart_card = crate::GwSmartCardCredentials {
+            pin: "1234".to_owned(),
+            certificate: Vec::new(),
+            private_key: None,
+            reader_name: String::new(),
+            card_name: None,
+            container_name: None,
+            csp_name: None,
+        };
+        let result = GatewayHttpAuth::from_challenges("alice", "", Some(&smart_card), None, &["NTLM"]);
+        let error = result.err().expect("NTLM-only gateway must reject smart card");
+        assert!(error.to_string().contains("smart card"), "unexpected error: {error}");
+    }
+
+    #[cfg(not(feature = "smartcard"))]
+    #[test]
+    fn smart_card_without_feature_is_clear_error() {
+        let smart_card = crate::GwSmartCardCredentials {
+            pin: "1234".to_owned(),
+            certificate: Vec::new(),
+            private_key: None,
+            reader_name: String::new(),
+            card_name: None,
+            container_name: None,
+            csp_name: None,
+        };
+        let result = GatewayHttpAuth::from_challenges("alice", "", Some(&smart_card), None, &["Negotiate"]);
+        let error = result.err().expect("smart card without feature must fail");
+        assert!(error.to_string().contains("feature"), "unexpected error: {error}");
+    }
+}

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -4,7 +4,33 @@
 #[macro_use]
 mod macros;
 
+mod http_auth;
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod mock_rpch;
+mod packet_io;
 mod proto;
+#[expect(
+    dead_code,
+    reason = "the staged raw stubs and DCE/RPC codecs are consumed when the RPC-over-HTTP runtime is integrated"
+)]
+mod rpc;
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "consumed when the RPC-over-HTTP fallback is validated and enabled"
+    )
+)]
+mod rpch;
+// Consumed only by tests until the RPC-over-HTTP runtime is integrated.
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "consumed when the RPC-over-HTTP runtime is integrated")
+)]
+mod rpc_transport;
+mod udp;
 
 use core::fmt;
 use core::fmt::Display;
@@ -13,44 +39,108 @@ use core::task::Poll;
 use core::time::Duration;
 use std::io;
 
-use base64::Engine as _;
-use base64::engine::general_purpose::STANDARD;
-use futures_util::stream::{SplitSink, SplitStream};
-use futures_util::{FutureExt as _, SinkExt as _, StreamExt as _};
+use futures_util::FutureExt as _;
 use hyper::body::Bytes;
 use ironrdp_core::{Decode as _, Encode, ReadCursor, WriteCursor};
-use ironrdp_tls::TlsStream;
-use log::{error, warn};
+use ironrdp_tls::{CertificateValidation, CertificateValidationCallback};
+use log::{debug, info, warn};
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::net::TcpStream;
-use tokio::sync::oneshot;
-use tokio_tungstenite::WebSocketStream;
-use tokio_tungstenite::tungstenite::handshake::client::generate_key;
-use tokio_tungstenite::tungstenite::protocol::Role;
-use tokio_tungstenite::tungstenite::{Message, http};
 use tokio_util::sync::PollSender;
 
+use self::http_auth::NtlmHttpAuth;
+use self::packet_io::{PacketIo, open_rpch_transport, open_transport_prefer_websocket};
+pub use self::rpch::RpchStream;
+
 use self::proto::{
-    ChannelPkt, ChannelResp, DataPkt, HandshakeReqPkt, HandshakeRespPkt, HttpCapsTy, KeepalivePkt, PktHdr, PktTy,
-    TunnelAuthPkt, TunnelAuthRespPkt, TunnelReqPkt, TunnelRespPkt,
+    ChannelClosePkt, ChannelPkt, ChannelResp, DataPkt, ExtendedAuthPkt, HandshakeReqPkt, HandshakeRespPkt, HttpCapsTy,
+    HttpExtendedAuth, KeepalivePkt, PktHdr, PktTy, ReauthMessagePkt, ServiceMessagePkt, TunnelAuthPkt,
+    TunnelAuthRespPkt, TunnelReqPkt, TunnelRespPkt, gateway_code_label,
 };
 
+pub use self::udp::{
+    AaSynData, AaSynDataResp, ConnectPkt, ConnectPktResp, GwUdpOffer, UdpCorrelationInfo, UdpPacketHeader, UdpPktType,
+    encode_connect_request, fragment_connect_pkt,
+};
+
+/// Parameters for opening an MS-TSGU tunnel to a target RDP resource.
 #[derive(Clone, Debug)]
 pub struct GwConnectTarget {
+    /// Gateway host:port (for example `rdg.contoso.com:443`).
     pub gw_endpoint: String,
+    /// Gateway username used for HTTP NTLM/Negotiate or Basic authentication.
     pub gw_user: String,
+    /// Gateway password used for HTTP NTLM/Negotiate or Basic authentication.
     pub gw_pass: String,
 
+    /// Target resource hostname as presented to the gateway (HTTP_CHANNEL_PACKET resources).
     pub server: String,
+    /// Target resource port as presented to the gateway (HTTP_CHANNEL_PACKET `port`).
+    ///
+    /// Common values are `3389` for ordinary RDP and `2179` for Hyper-V VMConnect.
+    pub server_port: u16,
+
+    /// Smart-card credentials for gateway authentication via Kerberos PKINIT.
+    ///
+    /// When set, the HTTP authentication layer uses the Negotiate scheme with smart-card
+    /// credentials instead of the password. Requires the `smartcard` feature.
+    pub smart_card: Option<Box<GwSmartCardCredentials>>,
 }
 
-type Error = ironrdp_error::Error<GwErrorKind>;
+/// Smart-card credentials for RD Gateway authentication ([MS-TSGU] 2.2.5.3.10 SMARTCARD).
+///
+/// The gateway is authenticated through the HTTP Negotiate scheme using Kerberos PKINIT
+/// with the smart card identity, mirroring the FreeRDP `SmartcardLogon` gateway path.
+#[derive(Clone)]
+pub struct GwSmartCardCredentials {
+    /// Smart card PIN code.
+    pub pin: String,
+    /// DER-encoded X.509 certificate identifying the user.
+    pub certificate: Vec<u8>,
+    /// PKCS#1 private key for emulated smart cards; `None` for system-provided cards.
+    pub private_key: Option<Vec<u8>>,
+    /// Smart card reader name (empty for emulated cards).
+    pub reader_name: String,
+    /// Optional smart card name.
+    pub card_name: Option<String>,
+    /// Optional key container name.
+    pub container_name: Option<String>,
+    /// Optional CSP name.
+    pub csp_name: Option<String>,
+}
 
+impl fmt::Debug for GwSmartCardCredentials {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GwSmartCardCredentials")
+            .field("pin", &"<redacted>")
+            .field("certificate", &self.certificate)
+            .field("private_key", &self.private_key.as_ref().map(|_| "<redacted>"))
+            .field("reader_name", &self.reader_name)
+            .field("card_name", &self.card_name)
+            .field("container_name", &self.container_name)
+            .field("csp_name", &self.csp_name)
+            .finish()
+    }
+}
+
+pub(crate) type Error = ironrdp_error::Error<GwErrorKind>;
+
+/// Error kind for MS-TSGU client operations.
+///
+/// Stage-specific detail is carried in the error context string and, when available, in the
+/// numeric payload of [`GwErrorKind::HttpStatus`] / [`GwErrorKind::GatewayCode`].
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum GwErrorKind {
     InvalidGwTarget,
     Connect,
+    /// Unexpected HTTP status while establishing the gateway transport (WebSocket or dual HTTP).
+    HttpStatus(u16),
+    /// Non-success gateway protocol status or HRESULT from a handshake/tunnel/channel response.
+    GatewayCode(u32),
+    /// Packet type did not match the expected stage response.
+    UnexpectedPacket,
+    /// The user or a policy callback declined the connection (for example a consent prompt).
+    AccessDenied,
     PacketEof,
     UnsupportedFeature,
     Custom,
@@ -58,7 +148,7 @@ pub enum GwErrorKind {
     Decode,
 }
 
-trait GwErrorExt {
+pub(crate) trait GwErrorExt {
     fn custom<E>(context: &'static str, e: E) -> Self
     where
         E: core::error::Error + Sync + Send + 'static;
@@ -76,33 +166,159 @@ impl GwErrorExt for ironrdp_error::Error<GwErrorKind> {
 
 impl Display for GwErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let x = match self {
-            GwErrorKind::InvalidGwTarget => "invalid GW Target",
-            GwErrorKind::Connect => "connection error",
-            GwErrorKind::PacketEof => "PacketEOF",
-            GwErrorKind::UnsupportedFeature => "unsupported feature",
-            GwErrorKind::Custom => "custom",
-            GwErrorKind::Encode => "encode",
-            GwErrorKind::Decode => "decode",
-        };
-        f.write_str(x)
+        match self {
+            GwErrorKind::InvalidGwTarget => f.write_str("invalid gateway target"),
+            GwErrorKind::Connect => f.write_str("connection error"),
+            GwErrorKind::HttpStatus(status) => write!(f, "unexpected HTTP status {status}"),
+            GwErrorKind::GatewayCode(code) => match gateway_code_label(*code) {
+                Some(label) => write!(f, "gateway error code 0x{code:08x} ({label})"),
+                None => write!(f, "gateway error code 0x{code:08x}"),
+            },
+            GwErrorKind::UnexpectedPacket => f.write_str("unexpected gateway packet type"),
+            GwErrorKind::AccessDenied => f.write_str("access denied"),
+            GwErrorKind::PacketEof => f.write_str("truncated gateway packet"),
+            GwErrorKind::UnsupportedFeature => f.write_str("unsupported feature"),
+            GwErrorKind::Custom => f.write_str("custom"),
+            GwErrorKind::Encode => f.write_str("encode"),
+            GwErrorKind::Decode => f.write_str("decode"),
+        }
     }
 }
 
 impl core::error::Error for GwErrorKind {}
 
+/// Device redirection policy flags sent by the gateway in the tunnel authorization
+/// response ([MS-TSGU] 2.2.5.3.7).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct GwTunnelRedirFlags(pub u32);
+
+impl GwTunnelRedirFlags {
+    /// Device redirection is enabled for all devices.
+    pub const ENABLE_ALL: u32 = 0x8000_0000;
+    /// Device redirection is disabled for all devices.
+    pub const DISABLE_ALL: u32 = 0x4000_0000;
+    /// Drive redirection is disabled.
+    pub const DISABLE_DRIVE: u32 = 0x1;
+    /// Printer redirection is disabled.
+    pub const DISABLE_PRINTER: u32 = 0x2;
+    /// Port redirection is disabled.
+    pub const DISABLE_PORT: u32 = 0x4;
+    /// Clipboard redirection is disabled.
+    pub const DISABLE_CLIPBOARD: u32 = 0x8;
+    /// Plug and play device redirection is disabled.
+    pub const DISABLE_PNP: u32 = 0x10;
+
+    /// `true` when clipboard redirection is disabled by policy.
+    pub fn clipboard_disabled(self) -> bool {
+        self.disabled(Self::DISABLE_CLIPBOARD)
+    }
+
+    /// `true` when drive redirection is disabled by policy.
+    pub fn drives_disabled(self) -> bool {
+        self.disabled(Self::DISABLE_DRIVE)
+    }
+
+    /// `true` when all device redirection is disabled by policy.
+    pub fn all_disabled(self) -> bool {
+        self.0 & Self::DISABLE_ALL != 0
+    }
+
+    fn disabled(self, flag: u32) -> bool {
+        self.all_disabled() || self.0 & Self::ENABLE_ALL == 0 && self.0 & flag != 0
+    }
+}
+
+/// Policy parameters negotiated during tunnel authorization.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct GwTunnelPolicy {
+    /// Device redirection policy flags, when the gateway supplied them.
+    pub redir_flags: Option<GwTunnelRedirFlags>,
+    /// Idle timeout in minutes advertised by the gateway, when supplied.
+    ///
+    /// The gateway disconnects sessions idle beyond this limit; the value is
+    /// informational for the client (for example to schedule UI warnings).
+    pub idle_timeout_minutes: Option<u32>,
+}
+
+/// Called with the gateway consent message before the connection proceeds.
+///
+/// Return `true` to accept the consent terms and continue, `false` to abort.
+pub type GwConsentCallback = std::sync::Arc<dyn Fn(&str) -> bool + Send + Sync>;
+
 struct GwConn {
     client_name: String,
     target: GwConnectTarget,
-    ws_sink: SplitSink<WebSocketStream<TlsStream<TcpStream>>, Message>,
-    ws_stream: SplitStream<WebSocketStream<TlsStream<TcpStream>>>,
+    io: PacketIo,
+    consent_callback: Option<GwConsentCallback>,
+    policy: GwTunnelPolicy,
+}
+
+/// Options for [`GwClient::connect_with_options`].
+#[derive(Default)]
+pub struct GwConnectOptions {
+    /// TLS certificate policy for the gateway HTTPS leg (same surface as direct RDP).
+    pub certificate_validation: CertificateValidation,
+    /// Optional callback to prompt/accept untrusted gateway certificates (Rustls only).
+    pub certificate_validation_callback: Option<CertificateValidationCallback>,
+    /// Optional gateway consent prompt; without it, consent text is logged and accepted.
+    pub consent_callback: Option<GwConsentCallback>,
+}
+
+impl fmt::Debug for GwConnectOptions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GwConnectOptions")
+            .field("certificate_validation", &self.certificate_validation)
+            .field(
+                "certificate_validation_callback",
+                &self.certificate_validation_callback.as_ref().map(|_| "<callback>"),
+            )
+            .field(
+                "consent_callback",
+                &self.consent_callback.as_ref().map(|_| "<callback>"),
+            )
+            .finish()
+    }
+}
+
+/// Opens a fresh gateway transport for a reauthentication secondary connection.
+type TransportFactory =
+    Box<dyn FnMut() -> Pin<Box<dyn Future<Output = Result<PacketIo, Error>> + Send + 'static>> + Send>;
+
+/// Test-only connection path without a reauth transport factory.
+#[cfg(test)]
+fn unsupported_reauth() -> impl Future<Output = Result<PacketIo, Error>> {
+    core::future::ready(Err(Error::new(
+        "gateway reauthentication requires a transport factory",
+        GwErrorKind::UnsupportedFeature,
+    )))
+}
+
+/// Build the transport factory that reopens a network gateway transport for reauthentication.
+fn network_transport_factory(
+    target: GwConnectTarget,
+    certificate_validation: CertificateValidation,
+    certificate_validation_callback: Option<CertificateValidationCallback>,
+) -> TransportFactory {
+    Box::new(move || {
+        let target = target.clone();
+        let certificate_validation_callback = certificate_validation_callback.clone();
+        Box::pin(async move {
+            open_transport_prefer_websocket(&target, certificate_validation, certificate_validation_callback)
+                .await
+                .map(|(io, _)| io)
+        })
+    })
 }
 
 pub struct GwClient {
     work: tokio::task::JoinHandle<Result<(), Error>>,
+    /// Set once the work task has completed; its `JoinHandle` must not be polled again
+    /// (tokio panics if a completed `JoinHandle` is polled).
+    work_done: bool,
     rx: tokio::sync::mpsc::Receiver<Bytes>,
     rx_bufs: Vec<Bytes>,
     tx: PollSender<Bytes>,
+    policy: GwTunnelPolicy,
 }
 
 impl Drop for GwClient {
@@ -111,90 +327,169 @@ impl Drop for GwClient {
     }
 }
 
+/// Split `host`, `host:port`, `[ipv6]`, or `[ipv6]:port` into (host_for_sni, connect_addr).
+///
+/// When no port is present, `:443` is assumed (RD Gateway HTTPS default).
+pub(crate) fn parse_gateway_endpoint(endpoint: &str) -> Result<(&str, String), Error> {
+    let endpoint = endpoint.trim();
+    if endpoint.is_empty() {
+        return Err(Error::new("empty gateway endpoint", GwErrorKind::InvalidGwTarget));
+    }
+
+    if let Some(rest) = endpoint.strip_prefix('[') {
+        let Some((host, after)) = rest.split_once(']') else {
+            return Err(Error::new(
+                "invalid ipv6 gateway endpoint",
+                GwErrorKind::InvalidGwTarget,
+            ));
+        };
+        if after.is_empty() {
+            return Ok((host, format!("[{host}]:443")));
+        }
+        if let Some(port) = after.strip_prefix(':') {
+            if port.is_empty() {
+                return Err(Error::new("missing gateway port", GwErrorKind::InvalidGwTarget));
+            }
+            return Ok((host, format!("[{host}]:{port}")));
+        }
+        return Err(Error::new(
+            "invalid ipv6 gateway endpoint",
+            GwErrorKind::InvalidGwTarget,
+        ));
+    }
+
+    // host:port where host has no colons (IPv4 or DNS name).
+    if let Some((host, port)) = endpoint.rsplit_once(':')
+        && !host.is_empty()
+        && !host.contains(':')
+        && !port.is_empty()
+        && port.chars().all(|c| c.is_ascii_digit())
+    {
+        return Ok((host, endpoint.to_owned()));
+    }
+
+    // Bare host / IPv4 without port.
+    if !endpoint.contains(']') {
+        return Ok((endpoint, format!("{endpoint}:443")));
+    }
+
+    Err(Error::new("parse gateway endpoint", GwErrorKind::InvalidGwTarget))
+}
+
 impl GwClient {
+    /// Open an MS-TSGU tunnel using the default TLS certificate policy
+    /// ([`CertificateValidation::DangerouslyAcceptInvalidCertificate`]).
+    ///
+    /// Prefer [`Self::connect_with_certificate_validation`] when the product has an explicit
+    /// authentication level or certificate prompt policy.
     pub async fn connect(
         target: &GwConnectTarget,
         client_name: &str,
     ) -> Result<(GwClient, core::net::SocketAddr), Error> {
-        let gw_host = target
-            .gw_endpoint
-            .split(":")
-            .nth(0)
-            .ok_or_else(|| Error::new("Connect", GwErrorKind::InvalidGwTarget))?;
-
-        let stream = TcpStream::connect(&target.gw_endpoint)
-            .await
-            .map_err(|e| custom_err!("TCP connect", e))?;
-        let client_addr = stream
-            .local_addr()
-            .map_err(|e| custom_err!("get socket local address", e))?;
-
-        let (stream, _) = ironrdp_tls::upgrade(stream, gw_host)
-            .await
-            .map_err(|e| custom_err!("TLS connect", e))?;
-
-        let auth_val: String = STANDARD.encode(format!("{}:{}", target.gw_user, target.gw_pass));
-        let req = http::Request::builder()
-            .method("RDG_OUT_DATA")
-            .header(hyper::header::HOST, gw_host)
-            .header("Rdg-Connection-Id", format!("{{{}}}", uuid::Uuid::new_v4()))
-            .uri("/remoteDesktopGateway/")
-            .header(hyper::header::AUTHORIZATION, format!("Basic {auth_val}"))
-            .header(hyper::header::CONNECTION, "Upgrade")
-            .header(hyper::header::UPGRADE, "websocket")
-            .header(hyper::header::SEC_WEBSOCKET_VERSION, "13")
-            .header(hyper::header::SEC_WEBSOCKET_KEY, generate_key())
-            .body(http_body_util::Empty::<Bytes>::new())
-            .map_err(|e| custom_err!("failed to build request", e))?;
-
-        let stream = hyper_util::rt::tokio::TokioIo::new(stream);
-        let (mut sender, mut conn) = hyper::client::conn::http1::handshake(stream)
-            .await
-            .map_err(|e| custom_err!("H1 Handshake", e))?;
-        let (tx, rx) = oneshot::channel();
-
-        let jh = tokio::task::spawn(async move {
-            tokio::select! {
-                Err(e) = &mut conn => error!("Handshake error: {:?}", e),
-                _ = rx => (),
-            }
-            conn.into_parts()
-        });
-        let resp = sender
-            .send_request(req)
-            .await
-            .map_err(|e| custom_err!("WS Upgrade Send error", e))?;
-
-        if resp.status() != http::StatusCode::SWITCHING_PROTOCOLS {
-            return Err(Error::new("WS Upgrade", GwErrorKind::Connect));
-        }
-
-        let _ = tx.send(()); // TODO: Not needed since it doesnt keep alive conn?
-        let stream = jh.await.map_err(|e| custom_err!("WS join", e))?.io.into_inner();
-
-        Self::connect_ws(target.clone(), client_name, stream)
-            .await
-            .map(|x| (x, client_addr))
+        Self::connect_with_certificate_validation(target, client_name, CertificateValidation::default(), None).await
     }
 
-    async fn connect_ws(
+    /// Open an MS-TSGU tunnel with the same TLS certificate policy surface as direct RDP.
+    ///
+    /// When `certificate_validation_callback` is `Some`, the Rustls backend may prompt/accept
+    /// untrusted gateway certificates through that callback. The `native-tls` backend rejects
+    /// callback-based validation.
+    pub async fn connect_with_certificate_validation(
+        target: &GwConnectTarget,
+        client_name: &str,
+        certificate_validation: CertificateValidation,
+        certificate_validation_callback: Option<CertificateValidationCallback>,
+    ) -> Result<(GwClient, core::net::SocketAddr), Error> {
+        Self::connect_with_options(
+            target,
+            client_name,
+            GwConnectOptions {
+                certificate_validation,
+                certificate_validation_callback,
+                consent_callback: None,
+            },
+        )
+        .await
+    }
+
+    /// Open an MS-TSGU tunnel with explicit connection options.
+    ///
+    /// When [`GwConnectOptions::consent_callback`] is set, a gateway consent message is
+    /// presented through it; declining aborts the connection. Without a callback the
+    /// consent message is logged and auto-accepted.
+    pub async fn connect_with_options(
+        target: &GwConnectTarget,
+        client_name: &str,
+        options: GwConnectOptions,
+    ) -> Result<(GwClient, core::net::SocketAddr), Error> {
+        let (io, client_addr) = open_transport_prefer_websocket(
+            target,
+            options.certificate_validation,
+            options.certificate_validation_callback.clone(),
+        )
+        .await?;
+
+        let client = Self::connect_after_transport_with_reauth(
+            target.clone(),
+            client_name,
+            io,
+            network_transport_factory(
+                target.clone(),
+                options.certificate_validation,
+                options.certificate_validation_callback,
+            ),
+            options.consent_callback,
+        )
+        .await?;
+        Ok((client, client_addr))
+    }
+
+    /// Policy parameters negotiated during tunnel authorization.
+    pub fn tunnel_policy(&self) -> GwTunnelPolicy {
+        self.policy
+    }
+
+    /// Open an MS-TSGU tunnel over the legacy RPC-over-HTTP transport (MS-RPCH v2).
+    ///
+    /// For gateways that do not support the WebSocket upgrade or dual-channel HTTP.
+    /// Returns the tunnel as a boxed byte stream ready for the RDP layer.
+    pub async fn connect_rpch(
+        target: &GwConnectTarget,
+        client_name: &str,
+        certificate_validation: CertificateValidation,
+        certificate_validation_callback: Option<CertificateValidationCallback>,
+    ) -> Result<(RpchStream, core::net::SocketAddr), Error> {
+        Box::pin(open_rpch_transport(
+            target,
+            client_name,
+            certificate_validation,
+            certificate_validation_callback,
+        ))
+        .await
+    }
+
+    async fn connect_after_transport_with_reauth(
         target: GwConnectTarget,
         client_name: &str,
-        tls_stream: TlsStream<TcpStream>,
+        io: PacketIo,
+        mut open_transport: TransportFactory,
+        consent_callback: Option<GwConsentCallback>,
     ) -> Result<GwClient, Error> {
-        let ws_stream: WebSocketStream<_> = WebSocketStream::from_raw_socket(tls_stream, Role::Client, None).await;
-        let (ws_sink, ws_stream) = ws_stream.split();
         let mut gw = GwConn {
             client_name: client_name.to_owned(),
             target,
-            ws_sink,
-            ws_stream,
+            io,
+            consent_callback: consent_callback.clone(),
+            policy: GwTunnelPolicy::default(),
         };
 
         gw.handshake().await?;
-        gw.tunnel().await?;
+        gw.tunnel(None).await?;
         gw.tunnel_auth().await?;
         gw.channel().await?;
+        let client_name = gw.client_name.clone();
+        let target = gw.target.clone();
+        let policy = gw.policy;
 
         let (in_tx, in_rx) = tokio::sync::mpsc::channel(4);
         let (out_tx, mut out_rx) = tokio::sync::mpsc::channel::<Bytes>(4);
@@ -204,33 +499,74 @@ impl GwClient {
             let mut keepalive_interval = tokio::time::interval_at(tokio::time::Instant::now() + iv, iv);
 
             loop {
-                let mut wsbuf = [0u8; 8192];
+                let mut pktbuf = [0u8; 8192];
 
                 tokio::select!(
                     _ = keepalive_interval.tick() => {
                         let pos = {
-                            let mut cur = WriteCursor::new(&mut wsbuf);
-                            KeepalivePkt.encode(&mut cur).map_err(|e| custom_err!("PktEncode", e))?;
+                            let mut cur = WriteCursor::new(&mut pktbuf);
+                            KeepalivePkt.encode(&mut cur).map_err(|e| custom_err!("encode keepalive", e))?;
                             cur.pos()
                         };
-
-                        gw.ws_sink.send(Message::Binary(Bytes::copy_from_slice(&wsbuf[..pos]))).await.map_err(|e| custom_err!("ws send", e))?;
+                        gw.io.send_bytes(&pktbuf[..pos]).await?;
                     },
-                    next = gw.ws_stream.next() => {
-                        let tmp = next.ok_or_else(|| Error::new("WS Stream Dead", GwErrorKind::Connect))?;
-                        let msg = tmp.map_err(|e| custom_err!("Stream", e))?.into_data();
+                    msg = gw.io.read_packet_buf() => {
+                        let msg = msg?;
                         let mut cur = ReadCursor::new(&msg);
-                        let hdr = PktHdr::decode(&mut cur).map_err(|e| custom_err!("Header Decode", e))?;
+                        let hdr = PktHdr::decode(&mut cur).map_err(|e| custom_err!("decode packet header", e))?;
 
-                        let header_length = usize::try_from(hdr.length).map_err(|_| Error::new("PktHdr too big", GwErrorKind::Decode))?;
-                        assert!(cur.len() >= header_length - hdr.size());
+                        let header_length = usize::try_from(hdr.length).map_err(|_| Error::new("packet header length", GwErrorKind::Decode))?;
+                        if cur.len() < header_length.saturating_sub(hdr.size()) {
+                            return Err(Error::new("data loop packet body", GwErrorKind::PacketEof));
+                        }
                         match hdr.ty {
                             PktTy::Keepalive => {
                                 continue;
                             },
                             PktTy::Data => {
-                                let p = DataPkt::decode(&mut cur).map_err(|e| custom_err!("PktDecode", e))?;
-                                in_tx.send(Bytes::from(p.data.to_vec())).await.map_err(|e| custom_err!("in_tx dead", e))?;
+                                let p = DataPkt::decode(&mut cur).map_err(|e| custom_err!("decode data packet", e))?;
+                                in_tx.send(Bytes::from(p.data.to_vec())).await.map_err(|e| custom_err!("forward inbound data", e))?;
+                            },
+                            PktTy::ServiceMessage => {
+                                let msg = ServiceMessagePkt::decode(&mut cur)
+                                    .map_err(|e| custom_err!("decode service message", e))?;
+                                warn!("RD Gateway service message: {}", msg.message);
+                            },
+                            PktTy::ReauthMessage => {
+                                let msg = ReauthMessagePkt::decode(&mut cur)
+                                    .map_err(|e| custom_err!("decode reauth message", e))?;
+                                // MS-TSGU 4.1.3: repeat the connection setup sequence on a
+                                // secondary connection, passing the tunnel context from the
+                                // gateway in the tunnel-create packet, then swap the data path.
+                                info!(
+                                    "RD Gateway requested reauthentication (context 0x{:016x}); opening secondary connection",
+                                    msg.reauth_tunnel_context
+                                );
+                                let new_io = open_transport().await?;
+                                let mut secondary = GwConn {
+                                    client_name: client_name.clone(),
+                                    target: target.clone(),
+                                    io: new_io,
+                                    consent_callback: consent_callback.clone(),
+                                    policy: GwTunnelPolicy::default(),
+                                };
+                                secondary.handshake().await?;
+                                secondary.tunnel(Some(msg.reauth_tunnel_context)).await?;
+                                secondary.tunnel_auth().await?;
+                                secondary.channel().await?;
+                                gw = secondary;
+                                info!("RD Gateway reauthentication completed");
+                            },
+                            PktTy::ChannelClose | PktTy::ChannelCloseResponse => {
+                                let close = ChannelClosePkt::decode(&mut cur)
+                                    .map_err(|e| custom_err!("decode channel close", e))?;
+                                if close.status_code != 0 {
+                                    return Err(Error::new(
+                                        "channel closed by gateway",
+                                        GwErrorKind::GatewayCode(close.status_code),
+                                    ));
+                                }
+                                return Err(Error::new("channel closed by gateway", GwErrorKind::Connect));
                             },
                             x => {
                                 warn!("Unhandled gw packet type {x:?}");
@@ -238,15 +574,27 @@ impl GwClient {
                         }
                     },
                     next = out_rx.recv() => {
-                        let next = next.ok_or_else(|| Error::new("WS Sink Dead", GwErrorKind::Connect))?;
+                        let Some(next) = next else {
+                            // The client closed the write side: close the channel, then
+                            // the transport ([MS-TSGU] 3.3.5.5).
+                            let close = ChannelClosePkt { status_code: 0 };
+                            let pos = {
+                                let mut cur = WriteCursor::new(&mut pktbuf);
+                                close.encode(&mut cur).map_err(|e| custom_err!("encode channel close", e))?;
+                                cur.pos()
+                            };
+                            gw.io.send_bytes(&pktbuf[..pos]).await?;
+                            gw.io.close().await?;
+                            return Ok(());
+                        };
                         let pkt = DataPkt { data: &next };
 
                         let pos = {
-                            let mut cur = WriteCursor::new(&mut wsbuf);
-                            pkt.encode(&mut cur).map_err(|e| custom_err!("PktEncode", e))?;
+                            let mut cur = WriteCursor::new(&mut pktbuf);
+                            pkt.encode(&mut cur).map_err(|e| custom_err!("encode data packet", e))?;
                             cur.pos()
                         };
-                        gw.ws_sink.send(Message::Binary(Bytes::copy_from_slice(&wsbuf[..pos]))).await.map_err(|e| custom_err!("ws send", e))?;
+                        gw.io.send_bytes(&pktbuf[..pos]).await?;
                     }
                 );
             }
@@ -254,9 +602,11 @@ impl GwClient {
 
         Ok(GwClient {
             work,
+            work_done: false,
             rx: in_rx,
             rx_bufs: vec![],
             tx: PollSender::new(out_tx),
+            policy,
         })
     }
 }
@@ -271,92 +621,199 @@ impl GwConn {
                 .map_err(|e| Error::new("packet encode", GwErrorKind::Encode).with_source(e))?;
             cur.pos()
         };
-        self.ws_sink
-            .send(Message::Binary(Bytes::copy_from_slice(&buf[..pos])))
-            .await
-            .map_err(|e| custom_err!("WebSocket send error", e))?;
-        Ok(())
+        self.io.send_bytes(&buf[..pos]).await
     }
 
     async fn read_packet(&mut self) -> Result<(PktHdr, Bytes), Error> {
-        let mut msg = self
-            .ws_stream
-            .next()
-            .await
-            .ok_or_else(|| Error::new("Stream closed", GwErrorKind::Connect))?
-            .map_err(|e| custom_err!("WS err", e))?
-            .into_data();
+        let mut msg = self.io.read_packet_buf().await?;
         let mut cur = ReadCursor::new(&msg);
 
-        let hdr = PktHdr::decode(&mut cur).map_err(|_| Error::new("PktHdr", GwErrorKind::Decode))?;
+        let hdr = PktHdr::decode(&mut cur).map_err(|e| custom_err!("decode packet header", e))?;
 
         let header_length =
-            usize::try_from(hdr.length).map_err(|_| Error::new("PktHdr too big", GwErrorKind::Decode))?;
-        if cur.len() != header_length - hdr.size() {
-            return Err(Error::new("read_packet", GwErrorKind::PacketEof));
+            usize::try_from(hdr.length).map_err(|_| Error::new("packet header length", GwErrorKind::Decode))?;
+        if cur.len() != header_length.saturating_sub(hdr.size()) {
+            return Err(Error::new("read packet body", GwErrorKind::PacketEof));
         }
 
         Ok((hdr, msg.split_off(cur.pos())))
     }
 
     async fn handshake(&mut self) -> Result<(), Error> {
-        // For NTLM we would include extended_auth: NTLM_SSPI in this handshake req here.
+        // Advertise SSPI NTLM extended auth so gateways that require the post-handshake
+        // NTLM blob exchange (MS-TSGU 3.3.5.3) can select it. HTTP NTLM already done
+        // during WebSocket upgrade is independent and usually yields NONE here.
+        // Smart-card credentials authenticate via Kerberos PKINIT, and a Basic HTTP
+        // fallback produces no NTLM blobs, so extended auth is not advertised in either
+        // case.
         let hs = HandshakeReqPkt {
             ver_major: 1,
             ver_minor: 0,
+            extended_auth: if self.target.smart_card.is_some() || self.io.http_auth_basic() {
+                HttpExtendedAuth::HTTP_EXTENDED_AUTH_NONE
+            } else {
+                HttpExtendedAuth::HTTP_EXTENDED_AUTH_SSPI_NTLM
+            },
             ..HandshakeReqPkt::default()
         };
         self.send_packet(&hs).await?;
-        let (_hdr, bytes) = self.read_packet().await?;
+        let (hdr, bytes) = self.read_packet().await?;
+        if hdr.ty != PktTy::HandshakeResp {
+            return Err(Error::new("handshake response", GwErrorKind::UnexpectedPacket));
+        }
 
         let mut cur = ReadCursor::new(&bytes);
-        let resp = HandshakeRespPkt::decode(&mut cur).map_err(|_| Error::new("Handshake", GwErrorKind::Decode))?;
-        if resp.error_code != 0 || resp.ver_major != 1 || resp.ver_minor != 0 || resp.server_version != 0 {
-            return Err(Error::new("Handshake", GwErrorKind::Connect));
+        let resp = HandshakeRespPkt::decode(&mut cur).map_err(|e| custom_err!("decode handshake response", e))?;
+        if resp.error_code != 0 {
+            return Err(Error::new("handshake", GwErrorKind::GatewayCode(resp.error_code)));
         }
+        if resp.ver_major != 1 || resp.ver_minor != 0 || resp.server_version != 0 {
+            return Err(Error::new("handshake version negotiation", GwErrorKind::Connect));
+        }
+
+        // The response advertises the extended-auth methods the gateway supports; it is a
+        // capability mask, not a request. Only run the SSPI NTLM blob exchange when the
+        // HTTP layer authenticated with NTLM — a Basic fallback produces no NTLM blobs, so
+        // the exchange is skipped (the gateway treats a NONE advertisement as sufficient).
+        if !self.io.http_auth_basic()
+            && resp
+                .extended_auth
+                .contains(HttpExtendedAuth::HTTP_EXTENDED_AUTH_SSPI_NTLM)
+        {
+            self.extended_auth_sspi_ntlm().await?;
+        } else if !self.io.http_auth_basic()
+            && self.target.smart_card.is_none()
+            && resp
+                .extended_auth
+                .intersects(HttpExtendedAuth::HTTP_EXTENDED_AUTH_SC | HttpExtendedAuth::HTTP_EXTENDED_AUTH_PAA)
+        {
+            return Err(Error::new(
+                "gateway requested smart-card or PAA extended auth",
+                GwErrorKind::UnsupportedFeature,
+            ));
+        }
+
         Ok(())
     }
 
-    async fn tunnel(&mut self) -> Result<(), Error> {
+    /// MS-TSGU 3.3.5.3.2–3.3.5.3.3: exchange `HTTP_EXTENDED_AUTH_PACKET` NTLM blobs.
+    async fn extended_auth_sspi_ntlm(&mut self) -> Result<(), Error> {
+        let mut ntlm = NtlmHttpAuth::new(&self.target.gw_user, &self.target.gw_pass)?;
+        let (token, mut complete) = ntlm.step_token(None)?;
+        self.send_packet(&ExtendedAuthPkt::client_blob(token)).await?;
+
+        const MAX_ROUNDS: usize = 8;
+        for _ in 0..MAX_ROUNDS {
+            if complete {
+                return Ok(());
+            }
+
+            let (hdr, bytes) = self.read_packet().await?;
+            if hdr.ty != PktTy::ExtendedAuth {
+                return Err(Error::new("extended auth response", GwErrorKind::UnexpectedPacket));
+            }
+            let mut cur = ReadCursor::new(&bytes);
+            let resp = ExtendedAuthPkt::decode(&mut cur).map_err(|e| custom_err!("decode extended auth", e))?;
+            if resp.error_code() != 0 {
+                return Err(Error::new("extended auth", GwErrorKind::GatewayCode(resp.error_code())));
+            }
+
+            let (token, done) = ntlm.step_token(Some(resp.blob()))?;
+            complete = done;
+            if !token.is_empty() {
+                self.send_packet(&ExtendedAuthPkt::client_blob(token)).await?;
+            }
+            if complete {
+                return Ok(());
+            }
+        }
+
+        Err(Error::new("extended auth ntlm rounds exceeded", GwErrorKind::Connect))
+    }
+
+    async fn tunnel(&mut self, reauth_tunnel_context: Option<u64>) -> Result<(), Error> {
         let req = TunnelReqPkt {
-            // Havent seen any server working without this.
-            caps: HttpCapsTy::MessagingConsentSign.as_u32(),
+            // Advertise the messaging and reauth caps most corporate RDG policies expect.
+            // Consent text is logged and auto-accepted until a UI path exists.
+            caps: HttpCapsTy::MessagingConsentSign.as_u32()
+                | HttpCapsTy::MessagingServiceMsg.as_u32()
+                | HttpCapsTy::IdleTimeout.as_u32()
+                | HttpCapsTy::Reauth.as_u32(),
             fields_present: 0,
+            reauth_tunnel_context,
             ..TunnelReqPkt::default()
         };
         self.send_packet(&req).await?;
 
-        let (_hdr, bytes) = self.read_packet().await?;
+        let (hdr, bytes) = self.read_packet().await?;
+        if hdr.ty != PktTy::TunnelResp {
+            return Err(Error::new("tunnel response", GwErrorKind::UnexpectedPacket));
+        }
         let mut cur = ReadCursor::new(&bytes);
 
-        let resp = TunnelRespPkt::decode(&mut cur).map_err(|_| Error::new("TunnelDecode", GwErrorKind::Decode))?;
+        let resp = TunnelRespPkt::decode(&mut cur).map_err(|e| custom_err!("decode tunnel response", e))?;
         if resp.status_code != 0 {
-            return Err(Error::new("Tunnel", GwErrorKind::Connect));
+            return Err(Error::new("tunnel create", GwErrorKind::GatewayCode(resp.status_code)));
         }
-        assert!(cur.eof());
+        if !cur.eof() {
+            return Err(Error::new("tunnel response trailing bytes", GwErrorKind::Decode));
+        }
         if !resp.consent_msg.is_empty() {
-            return Err(Error::new(
-                "Received consent message but showing it not implemented",
-                GwErrorKind::UnsupportedFeature,
-            ));
+            let text = String::from_utf16_lossy(
+                &resp
+                    .consent_msg
+                    .chunks_exact(2)
+                    .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                    .collect::<Vec<_>>(),
+            )
+            .trim_end_matches('\0')
+            .to_owned();
+            match &self.consent_callback {
+                Some(callback) => {
+                    if !callback(&text) {
+                        return Err(Error::new(
+                            "gateway consent declined by user",
+                            GwErrorKind::AccessDenied,
+                        ));
+                    }
+                }
+                // Auto-accept until the product wires a consent UI through the callback.
+                None => warn!("RD Gateway consent message (auto-accepted): {text}"),
+            }
         }
         Ok(())
     }
 
     async fn tunnel_auth(&mut self) -> Result<(), Error> {
+        // NAP statement-of-health is not generated yet; send client name only.
         let req = TunnelAuthPkt {
             fields_present: 0,
             client_name: self.client_name.clone(),
+            statement_of_health: None,
         };
         self.send_packet(&req).await?;
 
-        let (_hdr, bytes) = self.read_packet().await?;
+        let (hdr, bytes) = self.read_packet().await?;
+        if hdr.ty != PktTy::TunnelAuthResponse {
+            return Err(Error::new("tunnel auth response", GwErrorKind::UnexpectedPacket));
+        }
         let mut cur = ReadCursor::new(&bytes);
-        let resp: TunnelAuthRespPkt =
-            TunnelAuthRespPkt::decode(&mut cur).map_err(|_| Error::new("TunnelAuth", GwErrorKind::Decode))?;
+        let resp = TunnelAuthRespPkt::decode(&mut cur).map_err(|e| custom_err!("decode tunnel auth response", e))?;
 
         if resp.error_code() != 0 {
-            return Err(Error::new("TunnelAuth", GwErrorKind::Connect));
+            return Err(Error::new("tunnel auth", GwErrorKind::GatewayCode(resp.error_code())));
+        }
+
+        if let Some(flags) = resp.redir_flags {
+            info!("RD Gateway device redirection policy: 0x{flags:08x}");
+            self.policy.redir_flags = Some(GwTunnelRedirFlags(flags));
+        }
+        if let Some(minutes) = resp.idle_timeout_minutes {
+            info!("RD Gateway idle timeout: {minutes} minute(s)");
+            self.policy.idle_timeout_minutes = Some(minutes);
+        }
+        if let Some(soh) = &resp.soh_response {
+            debug!("RD Gateway SoH response present ({} bytes)", soh.len());
         }
         Ok(())
     }
@@ -364,20 +821,46 @@ impl GwConn {
     async fn channel(&mut self) -> Result<ChannelResp, Error> {
         let req = ChannelPkt {
             resources: vec![self.target.server.clone()],
-            port: 3389,
+            port: self.target.server_port,
             protocol: 3,
         };
         self.send_packet(&req).await?;
 
         let (hdr, bytes) = self.read_packet().await?;
-        assert!(hdr.ty == PktTy::ChannelResp);
-        let mut cur: ReadCursor<'_> = ReadCursor::new(&bytes);
-        let resp: ChannelResp =
-            ChannelResp::decode(&mut cur).map_err(|_| Error::new("ChannelResp", GwErrorKind::Decode))?;
-        if resp.error_code() != 0 {
-            return Err(Error::new("ChannelCreate", GwErrorKind::Connect));
+        if hdr.ty != PktTy::ChannelResp {
+            return Err(Error::new("channel response", GwErrorKind::UnexpectedPacket));
         }
-        assert!(cur.eof());
+        let mut cur: ReadCursor<'_> = ReadCursor::new(&bytes);
+        let resp = ChannelResp::decode(&mut cur).map_err(|e| custom_err!("decode channel response", e))?;
+        if resp.error_code() != 0 {
+            return Err(Error::new(
+                "channel create",
+                GwErrorKind::GatewayCode(resp.error_code()),
+            ));
+        }
+        if !cur.eof() {
+            return Err(Error::new("channel response trailing bytes", GwErrorKind::Decode));
+        }
+        if resp.udp_port() != 0 && !resp.authn_cookie().is_empty() {
+            let offer = GwUdpOffer {
+                port: resp.udp_port(),
+                authn_cookie: resp.authn_cookie().to_vec(),
+            };
+            // DTLS + MS-RDPEUDP data path is not opened yet; CONNECT_PKT helpers are public for
+            // callers that implement the side channel themselves.
+            debug!(
+                "RD Gateway offered UDP channel parameters (port={}, cookie_len={})",
+                offer.port,
+                offer.authn_cookie.len()
+            );
+            let _ = offer;
+        } else if resp.udp_port() != 0 || !resp.authn_cookie().is_empty() {
+            debug!(
+                "RD Gateway UDP offer incomplete (port={}, cookie_len={})",
+                resp.udp_port(),
+                resp.authn_cookie().len()
+            );
+        }
         Ok(resp)
     }
 }
@@ -389,11 +872,21 @@ impl AsyncRead for GwClient {
         buf: &mut tokio::io::ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
         // Propagate error or premature exit (?)
-        match self.work.poll_unpin(cx) {
-            Poll::Ready(Err(e)) => return Poll::Ready(Err(io::Error::other(e))),
-            Poll::Ready(Ok(Err(e))) => return Poll::Ready(Err(io::Error::other(e))),
-            Poll::Ready(_) => return Poll::Ready(Err(io::Error::other("Premature Work Task end?"))),
-            _ => (),
+        if !self.work_done {
+            match self.work.poll_unpin(cx) {
+                Poll::Ready(Err(e)) => {
+                    self.work_done = true;
+                    return Poll::Ready(Err(io::Error::other(e)));
+                }
+                Poll::Ready(Ok(Err(e))) => {
+                    self.work_done = true;
+                    return Poll::Ready(Err(io::Error::other(e)));
+                }
+                Poll::Ready(Ok(Ok(()))) => {
+                    self.work_done = true;
+                }
+                Poll::Pending => (),
+            }
         }
 
         // Get new bufs
@@ -416,7 +909,17 @@ impl AsyncRead for GwClient {
             !rx_buf.is_empty()
         });
 
-        if n > 0 { Poll::Ready(Ok(())) } else { Poll::Pending }
+        if n > 0 {
+            return Poll::Ready(Ok(()));
+        }
+        if self.work_done {
+            // The work task ended and no data is buffered: the gateway stream is closed.
+            return Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "gateway tunnel closed",
+            )));
+        }
+        Poll::Pending
     }
 }
 
@@ -427,11 +930,21 @@ impl AsyncWrite for GwClient {
         buf: &[u8],
     ) -> Poll<Result<usize, io::Error>> {
         // Propagate error or premature exit (?)
-        match self.work.poll_unpin(cx) {
-            Poll::Ready(Err(e)) => return Poll::Ready(Err(io::Error::other(e))),
-            Poll::Ready(Ok(Err(e))) => return Poll::Ready(Err(io::Error::other(e))),
-            Poll::Ready(_) => return Poll::Ready(Err(io::Error::other("Premature Work Task end?"))),
-            Poll::Pending => (),
+        if !self.work_done {
+            match self.work.poll_unpin(cx) {
+                Poll::Ready(Err(e)) => {
+                    self.work_done = true;
+                    return Poll::Ready(Err(io::Error::other(e)));
+                }
+                Poll::Ready(Ok(Err(e))) => {
+                    self.work_done = true;
+                    return Poll::Ready(Err(io::Error::other(e)));
+                }
+                Poll::Ready(Ok(Ok(()))) => {
+                    self.work_done = true;
+                }
+                Poll::Pending => (),
+            }
         }
 
         match self.tx.poll_reserve(cx) {
@@ -455,7 +968,352 @@ impl AsyncWrite for GwClient {
         Poll::Ready(Ok(()))
     }
 
-    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut core::task::Context<'_>) -> Poll<Result<(), io::Error>> {
-        Poll::Ready(Ok(()))
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut core::task::Context<'_>) -> Poll<Result<(), io::Error>> {
+        // Closing the sender ends the outbound queue; the work task then performs the
+        // MS-TSGU channel close and the transport close handshake.
+        self.tx.close();
+        if self.work_done {
+            return Poll::Ready(Ok(()));
+        }
+        match self.work.poll_unpin(cx) {
+            Poll::Ready(Ok(Ok(()))) => {
+                self.work_done = true;
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Ok(Err(e))) => {
+                self.work_done = true;
+                Poll::Ready(Err(io::Error::other(e)))
+            }
+            Poll::Ready(Err(e)) => {
+                self.work_done = true;
+                Poll::Ready(Err(io::Error::other(e)))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    use super::*;
+    use crate::mock::{MockGatewayConfig, mock_gateway};
+
+    fn target() -> GwConnectTarget {
+        GwConnectTarget {
+            gw_endpoint: "rdg.contoso.com".to_owned(),
+            gw_user: "CONTOSO\\alice".to_owned(),
+            gw_pass: "secret".to_owned(),
+            server: "rdp.contoso.com".to_owned(),
+            server_port: 3389,
+            smart_card: None,
+        }
+    }
+
+    async fn connect_with_mock(
+        config: MockGatewayConfig,
+    ) -> Result<(GwClient, tokio::task::JoinHandle<Vec<PktTy>>), Error> {
+        connect_with_mock_consent(config, None).await
+    }
+
+    async fn connect_with_mock_consent(
+        config: MockGatewayConfig,
+        consent_callback: Option<GwConsentCallback>,
+    ) -> Result<(GwClient, tokio::task::JoinHandle<Vec<PktTy>>), Error> {
+        let (io, gateway) = mock_gateway(config);
+        let client = GwClient::connect_after_transport_with_reauth(
+            target(),
+            "test-client",
+            io,
+            Box::new(|| Box::pin(unsupported_reauth())),
+            consent_callback,
+        )
+        .await?;
+        Ok((client, gateway))
+    }
+
+    #[tokio::test]
+    async fn mock_gateway_happy_path_echoes_data() {
+        let (mut client, gateway) = connect_with_mock(MockGatewayConfig::default())
+            .await
+            .expect("connect through mock gateway");
+
+        client.write_all(b"hello-rdp").await.expect("write data");
+        let mut buf = [0u8; 9];
+        client.read_exact(&mut buf).await.expect("read echo");
+        assert_eq!(&buf, b"hello-rdp");
+
+        drop(client);
+        let received = gateway.await.expect("gateway task");
+        assert_eq!(
+            received,
+            [
+                PktTy::HandshakeReq,
+                PktTy::TunnelCreate,
+                PktTy::TunnelAuth,
+                PktTy::ChannelCreate,
+                PktTy::Data,
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn mock_gateway_tunnel_create_failure_surfaces_status() {
+        let result = connect_with_mock(MockGatewayConfig {
+            tunnel_status_code: 0x8007_59DA, // E_PROXY_RAP_ACCESSDENIED
+            ..MockGatewayConfig::default()
+        })
+        .await;
+
+        let error = result.err().expect("tunnel create must fail");
+        let text = error.to_string();
+        assert!(text.contains("tunnel create"), "unexpected error: {text}");
+    }
+
+    #[tokio::test]
+    async fn mock_gateway_tunnel_auth_failure_surfaces_status() {
+        let result = connect_with_mock(MockGatewayConfig {
+            tunnel_auth_error_code: 0x8007_59ED, // E_PROXY_QUARANTINE_ACCESSDENIED
+            ..MockGatewayConfig::default()
+        })
+        .await;
+
+        let error = result.err().expect("tunnel auth must fail");
+        let text = error.to_string();
+        assert!(text.contains("tunnel auth"), "unexpected error: {text}");
+    }
+
+    #[tokio::test]
+    async fn mock_gateway_channel_failure_surfaces_status() {
+        let result = connect_with_mock(MockGatewayConfig {
+            channel_error_code: 0x0000_59DD, // E_PROXY_TS_CONNECTFAILED
+            ..MockGatewayConfig::default()
+        })
+        .await;
+
+        let error = result.err().expect("channel create must fail");
+        let text = error.to_string();
+        assert!(text.contains("channel create"), "unexpected error: {text}");
+    }
+
+    #[tokio::test]
+    async fn mock_gateway_consent_message_is_accepted_and_logged() {
+        let (client, gateway) = connect_with_mock(MockGatewayConfig {
+            consent_message: Some("Authorized users only".to_owned()),
+            ..MockGatewayConfig::default()
+        })
+        .await
+        .expect("consent message should not block connect");
+        drop(client);
+        gateway.await.expect("gateway task");
+    }
+
+    #[tokio::test]
+    async fn mock_gateway_consent_decline_aborts_connect() {
+        let result = connect_with_mock_consent(
+            MockGatewayConfig {
+                consent_message: Some("Authorized users only".to_owned()),
+                ..MockGatewayConfig::default()
+            },
+            Some(std::sync::Arc::new(|_| false)),
+        )
+        .await;
+
+        let error = result.err().expect("declined consent must abort");
+        assert!(
+            error.to_string().contains("consent declined"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn mock_gateway_consent_callback_receives_message_text() {
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+        let seen_clone = std::sync::Arc::clone(&seen);
+        let (client, gateway) = connect_with_mock_consent(
+            MockGatewayConfig {
+                consent_message: Some("Authorized users only".to_owned()),
+                ..MockGatewayConfig::default()
+            },
+            Some(std::sync::Arc::new(move |text: &str| {
+                *seen_clone.lock().expect("seen lock") = text.to_owned();
+                true
+            })),
+        )
+        .await
+        .expect("accepted consent connects");
+
+        assert_eq!(*seen.lock().expect("seen lock"), "Authorized users only");
+        drop(client);
+        gateway.await.expect("gateway task");
+    }
+
+    #[tokio::test]
+    async fn mock_gateway_tunnel_policy_is_captured() {
+        let (client, gateway) = connect_with_mock(MockGatewayConfig {
+            redir_flags: Some(GwTunnelRedirFlags::DISABLE_CLIPBOARD | GwTunnelRedirFlags::DISABLE_DRIVE),
+            idle_timeout_minutes: Some(15),
+            ..MockGatewayConfig::default()
+        })
+        .await
+        .expect("connect through mock gateway");
+
+        let policy = client.tunnel_policy();
+        let flags = policy.redir_flags.expect("redir flags");
+        assert!(flags.clipboard_disabled());
+        assert!(flags.drives_disabled());
+        assert!(!flags.all_disabled());
+        assert_eq!(policy.idle_timeout_minutes, Some(15));
+
+        drop(client);
+        gateway.await.expect("gateway task");
+    }
+
+    #[test]
+    fn redir_flags_all_disabled_disables_everything() {
+        let flags = GwTunnelRedirFlags(GwTunnelRedirFlags::DISABLE_ALL);
+        assert!(flags.clipboard_disabled());
+        assert!(flags.drives_disabled());
+        assert!(flags.all_disabled());
+
+        let enabled = GwTunnelRedirFlags(GwTunnelRedirFlags::ENABLE_ALL);
+        assert!(!enabled.clipboard_disabled());
+        assert!(!enabled.all_disabled());
+    }
+
+    #[tokio::test]
+    async fn mock_gateway_reauth_opens_secondary_connection() {
+        use crate::mock::MockGatewayFactory;
+
+        const REAUTH_CONTEXT: u64 = 0x0123_4567_89ab_cdef;
+        let factory = MockGatewayFactory::new(MockGatewayConfig {
+            reauth_tunnel_context: Some(REAUTH_CONTEXT),
+            ..MockGatewayConfig::default()
+        });
+
+        let first = factory.open();
+        let transport_factory = {
+            let factory = std::sync::Arc::clone(&factory);
+            Box::new(
+                move || -> Pin<Box<dyn Future<Output = Result<PacketIo, Error>> + Send>> {
+                    let factory = std::sync::Arc::clone(&factory);
+                    Box::pin(async move { Ok(factory.open()) })
+                },
+            )
+        };
+        let mut client =
+            GwClient::connect_after_transport_with_reauth(target(), "test-client", first, transport_factory, None)
+                .await
+                .expect("connect through mock gateway");
+
+        // Wait for the secondary connection to finish before writing: data sent
+        // while the reauth handoff is in flight may still flow on the old channel.
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if factory
+                    .seen_reauth_context
+                    .lock()
+                    .expect("reauth context lock")
+                    .is_some()
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("reauth must complete");
+
+        assert_eq!(
+            *factory.seen_reauth_context.lock().expect("reauth context lock"),
+            Some(REAUTH_CONTEXT),
+            "secondary connection must carry the reauth tunnel context"
+        );
+
+        // Data flows through the secondary connection after reauthentication.
+        client.write_all(b"after-reauth").await.expect("write data");
+        let mut buf = [0u8; 12];
+        client.read_exact(&mut buf).await.expect("read echo");
+        assert_eq!(&buf, b"after-reauth");
+
+        drop(client);
+        let tasks = core::mem::take(&mut *factory.tasks.lock().expect("tasks lock"));
+        for task in tasks {
+            task.abort();
+        }
+    }
+
+    #[tokio::test]
+    async fn mock_gateway_graceful_shutdown_closes_channel() {
+        let (mut client, gateway) = connect_with_mock(MockGatewayConfig::default())
+            .await
+            .expect("connect through mock gateway");
+
+        client.shutdown().await.expect("graceful shutdown");
+        drop(client);
+
+        let received = gateway.await.expect("gateway task");
+        assert_eq!(
+            received,
+            [
+                PktTy::HandshakeReq,
+                PktTy::TunnelCreate,
+                PktTy::TunnelAuth,
+                PktTy::ChannelCreate,
+                PktTy::ChannelClose,
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn mock_gateway_channel_close_with_error_fails_stream() {
+        let (mut client, gateway) = connect_with_mock(MockGatewayConfig {
+            close_status_code: Some(0x0000_59F6), // E_PROXY_SESSIONTIMEOUT
+            ..MockGatewayConfig::default()
+        })
+        .await
+        .expect("connect through mock gateway");
+
+        let mut buf = [0u8; 1];
+        let error = client.read_exact(&mut buf).await.expect_err("close must fail the read");
+        assert!(
+            error.to_string().contains("channel closed"),
+            "unexpected error: {error}"
+        );
+
+        drop(client);
+        gateway.await.expect("gateway task");
+    }
+
+    #[test]
+    fn parse_endpoint_defaults_to_443() {
+        let (host, addr) = parse_gateway_endpoint("rdg.contoso.com").unwrap();
+        assert_eq!(host, "rdg.contoso.com");
+        assert_eq!(addr, "rdg.contoso.com:443");
+    }
+
+    #[test]
+    fn parse_endpoint_keeps_explicit_port() {
+        let (host, addr) = parse_gateway_endpoint("rdg.contoso.com:8443").unwrap();
+        assert_eq!(host, "rdg.contoso.com");
+        assert_eq!(addr, "rdg.contoso.com:8443");
+    }
+
+    #[test]
+    fn parse_endpoint_ipv6_bracketed() {
+        let (host, addr) = parse_gateway_endpoint("[2001:db8::1]").unwrap();
+        assert_eq!(host, "2001:db8::1");
+        assert_eq!(addr, "[2001:db8::1]:443");
+
+        let (host, addr) = parse_gateway_endpoint("[2001:db8::1]:8443").unwrap();
+        assert_eq!(host, "2001:db8::1");
+        assert_eq!(addr, "[2001:db8::1]:8443");
+    }
+
+    #[test]
+    fn gateway_code_display_includes_label() {
+        let kind = GwErrorKind::GatewayCode(0x8007_59DA);
+        assert!(kind.to_string().contains("E_PROXY_RAP_ACCESSDENIED"));
     }
 }

--- a/crates/ironrdp-mstsgu/src/mock.rs
+++ b/crates/ironrdp-mstsgu/src/mock.rs
@@ -1,0 +1,267 @@
+//! In-process mock RD Gateway for integration-style tests.
+//!
+//! Speaks the MS-TSGU packet sequence over an in-memory duplex stream:
+//! handshake → tunnel create → tunnel auth → channel create → data echo.
+//! Failure injection points let tests exercise error paths without a real gateway.
+
+use hyper::body::Bytes;
+use ironrdp_core::{Decode as _, Encode, ReadCursor, WriteCursor};
+use tokio::io::{AsyncWriteExt as _, DuplexStream};
+
+use crate::packet_io::PacketIo;
+use crate::proto::{
+    ChannelResp, DataPkt, HandshakeRespPkt, HttpExtendedAuth, PktHdr, PktTy, ReauthMessagePkt, TunnelAuthRespPkt,
+    TunnelRespPkt,
+};
+
+/// Tunable behavior of the mock gateway.
+#[derive(Clone, Debug)]
+pub(crate) struct MockGatewayConfig {
+    /// Extended auth modes advertised in the handshake response.
+    pub handshake_extended_auth: HttpExtendedAuth,
+    /// Status code for tunnel create (`0` = success).
+    pub tunnel_status_code: u32,
+    /// Error code for tunnel auth (`0` = success).
+    pub tunnel_auth_error_code: u32,
+    /// Error code for channel create (`0` = success).
+    pub channel_error_code: u32,
+    /// Consent message sent in the tunnel response, when set.
+    pub consent_message: Option<String>,
+    /// Device redirection policy flags from tunnel auth, when set.
+    pub redir_flags: Option<u32>,
+    /// Idle timeout in minutes from tunnel auth, when set.
+    pub idle_timeout_minutes: Option<u32>,
+    /// When set, send a reauth message with this context after channel create.
+    pub reauth_tunnel_context: Option<u64>,
+    /// Channel close status code sent after channel create, when set.
+    pub close_status_code: Option<u32>,
+}
+
+impl Default for MockGatewayConfig {
+    fn default() -> Self {
+        Self {
+            handshake_extended_auth: HttpExtendedAuth::HTTP_EXTENDED_AUTH_NONE,
+            tunnel_status_code: 0,
+            tunnel_auth_error_code: 0,
+            channel_error_code: 0,
+            consent_message: None,
+            redir_flags: None,
+            idle_timeout_minutes: None,
+            reauth_tunnel_context: None,
+            close_status_code: None,
+        }
+    }
+}
+
+/// One end of a mock gateway connection pair: `client_io` plugs into
+/// `GwClient::connect_after_transport`, the returned task runs the gateway.
+pub(crate) fn mock_gateway(config: MockGatewayConfig) -> (PacketIo, tokio::task::JoinHandle<Vec<PktTy>>) {
+    let (client, server) = tokio::io::duplex(64 * 1024);
+    let task = tokio::spawn(async move { run_gateway(server, config).await });
+    (PacketIo::duplex(client), task)
+}
+
+/// A factory of mock gateway connections, for reauth secondary-connection tests.
+///
+/// Each `open()` call spawns a fresh mock gateway and returns the client transport.
+/// The secondary connection's tunnel request is expected to carry the reauth tunnel
+/// context, which is recorded in `seen_reauth_context`.
+pub(crate) struct MockGatewayFactory {
+    config: MockGatewayConfig,
+    /// Only the first connection injects the reauth trigger; the secondary
+    /// connection must complete cleanly or the client would reauth forever.
+    reauth_pending: std::sync::Mutex<bool>,
+    pub(crate) tasks: std::sync::Mutex<Vec<tokio::task::JoinHandle<Vec<PktTy>>>>,
+    pub(crate) seen_reauth_context: std::sync::Mutex<Option<u64>>,
+}
+
+impl MockGatewayFactory {
+    pub(crate) fn new(config: MockGatewayConfig) -> std::sync::Arc<Self> {
+        let reauth_pending = config.reauth_tunnel_context.is_some();
+        std::sync::Arc::new(Self {
+            config,
+            reauth_pending: std::sync::Mutex::new(reauth_pending),
+            tasks: std::sync::Mutex::new(Vec::new()),
+            seen_reauth_context: std::sync::Mutex::new(None),
+        })
+    }
+
+    pub(crate) fn open(self: &std::sync::Arc<Self>) -> PacketIo {
+        let (client, server) = tokio::io::duplex(64 * 1024);
+        let mut config = self.config.clone();
+        {
+            let mut pending = self.reauth_pending.lock().expect("reauth pending lock");
+            if !*pending {
+                config.reauth_tunnel_context = None;
+            }
+            *pending = false;
+        }
+        let seen = std::sync::Arc::clone(self);
+        let task = tokio::spawn(async move { run_gateway_tracking_reauth(server, config, seen).await });
+        self.tasks.lock().expect("tasks lock").push(task);
+        PacketIo::duplex(client)
+    }
+}
+
+/// Like `run_gateway`, but records the reauth tunnel context from a tunnel-create
+/// request that carries one (secondary reauth connection).
+async fn run_gateway_tracking_reauth(
+    stream: DuplexStream,
+    config: MockGatewayConfig,
+    factory: std::sync::Arc<MockGatewayFactory>,
+) -> Vec<PktTy> {
+    run_gateway_inner(stream, config, Some(factory)).await
+}
+
+/// Run the gateway side; returns the packet types received, for assertions.
+async fn run_gateway(stream: DuplexStream, config: MockGatewayConfig) -> Vec<PktTy> {
+    run_gateway_inner(stream, config, None).await
+}
+
+async fn run_gateway_inner(
+    mut stream: DuplexStream,
+    config: MockGatewayConfig,
+    reauth_tracking: Option<std::sync::Arc<MockGatewayFactory>>,
+) -> Vec<PktTy> {
+    let mut received = Vec::new();
+
+    // Handshake
+    if read_packet(&mut stream, &mut received).await.is_none() {
+        return received;
+    }
+    let resp = HandshakeRespPkt {
+        error_code: 0,
+        ver_major: 1,
+        ver_minor: 0,
+        server_version: 0,
+        extended_auth: config.handshake_extended_auth,
+    };
+    if send_packet(&mut stream, &resp).await.is_err() {
+        return received;
+    }
+
+    // Tunnel create
+    let Some((_, tunnel_body)) = read_packet(&mut stream, &mut received).await else {
+        return received;
+    };
+    // Record the reauth tunnel context when the tunnel-create request carries one
+    // (HTTP_TUNNEL_PACKET_FIELD_REAUTH, [MS-TSGU] 2.2.10.19).
+    if let Some(tracking) = &reauth_tracking {
+        let mut cur = ReadCursor::new(&tunnel_body);
+        let _caps = cur.read_u32();
+        let fields_present = cur.read_u16();
+        let _reserved = cur.read_u16();
+        if fields_present & 0x2 != 0 && cur.len() >= 8 {
+            let context = cur.read_u64();
+            *tracking.seen_reauth_context.lock().expect("reauth context lock") = Some(context);
+        }
+    }
+    let resp = TunnelRespPkt {
+        status_code: config.tunnel_status_code,
+        tunnel_id: Some(1),
+        consent_msg: config
+            .consent_message
+            .as_ref()
+            .map(|msg| msg.encode_utf16().flat_map(u16::to_le_bytes).collect())
+            .unwrap_or_default(),
+        ..TunnelRespPkt::default()
+    };
+    if send_packet(&mut stream, &resp).await.is_err() {
+        return received;
+    }
+    if config.tunnel_status_code != 0 {
+        return received;
+    }
+
+    // Tunnel auth
+    if read_packet(&mut stream, &mut received).await.is_none() {
+        return received;
+    }
+    let resp = TunnelAuthRespPkt {
+        error_code: config.tunnel_auth_error_code,
+        redir_flags: config.redir_flags,
+        idle_timeout_minutes: config.idle_timeout_minutes,
+        ..TunnelAuthRespPkt::default()
+    };
+    if send_packet(&mut stream, &resp).await.is_err() {
+        return received;
+    }
+    if config.tunnel_auth_error_code != 0 {
+        return received;
+    }
+
+    // Channel create
+    if read_packet(&mut stream, &mut received).await.is_none() {
+        return received;
+    }
+    let resp = if config.channel_error_code == 0 {
+        ChannelResp::success(1)
+    } else {
+        ChannelResp {
+            error_code: config.channel_error_code,
+            ..ChannelResp::default()
+        }
+    };
+    if send_packet(&mut stream, &resp).await.is_err() {
+        return received;
+    }
+    if config.channel_error_code != 0 {
+        return received;
+    }
+
+    // Optional post-connect injections, then data echo loop.
+    if let Some(context) = config.reauth_tunnel_context {
+        let _ = send_packet(
+            &mut stream,
+            &ReauthMessagePkt {
+                reauth_tunnel_context: context,
+            },
+        )
+        .await;
+    }
+    if let Some(status_code) = config.close_status_code {
+        let _ = send_packet(&mut stream, &crate::proto::ChannelClosePkt { status_code }).await;
+        return received;
+    }
+
+    while let Some((hdr, body)) = read_packet(&mut stream, &mut received).await {
+        // Channel close completes the close handshake ([MS-TSGU] 3.3.5.5).
+        if hdr.ty == PktTy::ChannelClose {
+            let _ = send_packet(&mut stream, &crate::proto::ChannelClosePkt { status_code: 0 }).await;
+            return received;
+        }
+        if hdr.ty != PktTy::Data {
+            continue;
+        }
+        let mut cur = ReadCursor::new(&body);
+        let Ok(data) = DataPkt::decode(&mut cur) else {
+            break;
+        };
+        if send_packet(&mut stream, &DataPkt { data: data.data }).await.is_err() {
+            break;
+        }
+    }
+
+    received
+}
+
+async fn read_packet(stream: &mut DuplexStream, received: &mut Vec<PktTy>) -> Option<(PktHdr, Bytes)> {
+    use tokio::io::AsyncReadExt as _;
+
+    let mut header = [0u8; 8];
+    stream.read_exact(&mut header).await.ok()?;
+    let mut cur = ReadCursor::new(&header);
+    let hdr = PktHdr::decode(&mut cur).ok()?;
+    let body_len = usize::try_from(hdr.length).ok()?.checked_sub(8)?;
+    let mut body = vec![0u8; body_len];
+    stream.read_exact(&mut body).await.ok()?;
+    received.push(hdr.ty);
+    Some((hdr, Bytes::from(body)))
+}
+
+async fn send_packet(stream: &mut DuplexStream, packet: &impl Encode) -> Result<(), ()> {
+    let mut buf = vec![0u8; packet.size()];
+    let mut cur = WriteCursor::new(&mut buf);
+    packet.encode(&mut cur).map_err(|_| ())?;
+    stream.write_all(&buf).await.map_err(|_| ())
+}

--- a/crates/ironrdp-mstsgu/src/mock_rpch.rs
+++ b/crates/ironrdp-mstsgu/src/mock_rpch.rs
@@ -1,0 +1,264 @@
+//! In-process mock RPC proxy for the MS-RPCH v2 driver tests.
+//!
+//! Speaks raw HTTP/1 heads plus the RTS CONN setup, the unauthenticated DCE/RPC
+//! bind, and the TsProxy call sequence over two in-memory duplex streams.
+
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _, DuplexStream};
+
+use crate::rpc::{RpcContextHandle, fixtures};
+
+/// `TsProxyCreateTunnel` RPC operation number.
+const OP_CREATE_TUNNEL: u16 = 1;
+const OP_AUTHORIZE_TUNNEL: u16 = 2;
+const OP_MAKE_TUNNEL_CALL: u16 = 3;
+const OP_CREATE_CHANNEL: u16 = 4;
+const OP_SETUP_RECEIVE_PIPE: u16 = 8;
+const OP_SEND_TO_SERVER: u16 = 9;
+
+const PTYPE_REQUEST: u8 = 0;
+const PTYPE_BIND: u8 = 11;
+
+const TUNNEL_CONTEXT: [u8; RpcContextHandle::SIZE] = [0xAA; RpcContextHandle::SIZE];
+const CHANNEL_CONTEXT: [u8; RpcContextHandle::SIZE] = [0xBB; RpcContextHandle::SIZE];
+
+/// Client-side ends of a mock RPC proxy: `(out, in)` streams for `rpch_connect`.
+pub(crate) fn mock_rpch_proxy() -> (DuplexStream, DuplexStream, tokio::task::JoinHandle<()>) {
+    mock_rpch_proxy_with(None, None)
+}
+
+/// Mock proxy that completes the pending make-tunnel-call with a service message.
+pub(crate) fn mock_rpch_proxy_with_service_message(
+    service_message: Option<&'static str>,
+) -> (DuplexStream, DuplexStream, tokio::task::JoinHandle<()>) {
+    mock_rpch_proxy_with(service_message, None)
+}
+
+/// Mock proxy whose `TsProxySetupReceivePipe` fails with the given gateway error code.
+pub(crate) fn mock_rpch_proxy_with_receive_pipe_error(
+    result: u32,
+) -> (DuplexStream, DuplexStream, tokio::task::JoinHandle<()>) {
+    mock_rpch_proxy_with(None, Some(result))
+}
+
+fn mock_rpch_proxy_with(
+    service_message: Option<&'static str>,
+    receive_pipe_result: Option<u32>,
+) -> (DuplexStream, DuplexStream, tokio::task::JoinHandle<()>) {
+    let (out_client, out_server) = tokio::io::duplex(256 * 1024);
+    let (in_client, in_server) = tokio::io::duplex(256 * 1024);
+    let task =
+        tokio::spawn(async move { run_proxy(out_server, in_server, service_message, receive_pipe_result).await });
+    (out_client, in_client, task)
+}
+
+async fn run_proxy(
+    mut out: DuplexStream,
+    mut input: DuplexStream,
+    service_message: Option<&'static str>,
+    receive_pipe_result: Option<u32>,
+) {
+    // The client authenticates each channel with a Content-Length: 0 probe, then resends
+    // the request carrying the body. This mock enforces no authentication, so it accepts
+    // the probe with 200 and reads the resent request's body.
+    //
+    // IN channel is established before the OUT channel, matching the client driver.
+    if !accept_in_channel(&mut input).await {
+        return;
+    }
+
+    // OUT channel: probe, then request head + CONN/A1 body, then the streaming response.
+    if !accept_out_channel(&mut out).await {
+        return;
+    }
+    if write_all(
+        &mut out,
+        b"HTTP/1.1 200 OK\r\nContent-Type: application/rpc\r\nContent-Length: 1073741824\r\n\r\n",
+    )
+    .await
+    .is_err()
+    {
+        return;
+    }
+    if write_all(&mut out, &fixtures::rts_conn_a3(120_000)).await.is_err() {
+        return;
+    }
+    if write_all(&mut out, &fixtures::rts_conn_c2(1, 128 * 1024, 120_000))
+        .await
+        .is_err()
+    {
+        return;
+    }
+
+    // TsProxySetupReceivePipe switches the OUT channel to the target-server byte stream; on
+    // success it has no discrete response, so the echoed payload travels on that call.
+    let mut receive_pipe_call_id: Option<u32> = None;
+
+    loop {
+        let Some(pdu) = read_pdu(&mut input).await else {
+            return;
+        };
+        match pdu.get(2).copied() {
+            Some(PTYPE_BIND) => {
+                let call_id = call_id(&pdu);
+                if write_all(&mut out, &fixtures::bind_ack(call_id)).await.is_err() {
+                    return;
+                }
+            }
+            Some(PTYPE_REQUEST) => {
+                let call_id = call_id(&pdu);
+                // Request body: alloc hint (4) + context id (2) + opnum (2) + stub.
+                let Some(opnum) = pdu
+                    .get(22..24)
+                    .map(|b| u16::from_le_bytes(b.try_into().expect("opnum")))
+                else {
+                    return;
+                };
+                if opnum == OP_SETUP_RECEIVE_PIPE {
+                    receive_pipe_call_id = Some(call_id);
+                    // On failure the pipe answers with the terminal return-value fragment; on
+                    // success there is no response and the data stream follows on this call.
+                    if let Some(result) = receive_pipe_result {
+                        let stub = fixtures::receive_pipe_final_return_value(result);
+                        if write_all(&mut out, &fixtures::rpc_response(call_id, &stub))
+                            .await
+                            .is_err()
+                        {
+                            return;
+                        }
+                    }
+                    continue;
+                }
+                let stub = match opnum {
+                    OP_CREATE_TUNNEL => fixtures::create_tunnel_response(&TUNNEL_CONTEXT, 7),
+                    OP_AUTHORIZE_TUNNEL => fixtures::authorize_tunnel_response(),
+                    OP_CREATE_CHANNEL => fixtures::create_channel_response(&CHANNEL_CONTEXT, 3),
+                    // Administrative-message calls stay pending unless the mock was
+                    // configured to complete with a service message.
+                    OP_MAKE_TUNNEL_CALL => match service_message {
+                        Some(text) => fixtures::make_tunnel_call_service_response(text),
+                        None => continue,
+                    },
+                    OP_SEND_TO_SERVER => {
+                        // Echo the first payload buffer back as receive-pipe data.
+                        // TsProxySendToServer length fields are little-endian on the wire
+                        // (matching mstsc; [MS-TSGU] 3.6.5.1 notwithstanding).
+                        let Some(buffer_len) = pdu
+                            .get(52..56)
+                            .map(|b| u32::from_le_bytes(b.try_into().expect("buffer length")))
+                            .map(|len| usize::try_from(len).expect("buffer length"))
+                        else {
+                            return;
+                        };
+                        let Some(data) = pdu.get(56..56 + buffer_len) else {
+                            return;
+                        };
+                        data.to_vec()
+                    }
+                    _ => continue,
+                };
+                // Send-to-server data is echoed on the receive pipe's call, matching the
+                // gateway's streaming responses ([MS-TSGU] 3.2.6.2.3).
+                let response_call_id = if opnum == OP_SEND_TO_SERVER {
+                    receive_pipe_call_id.unwrap_or(call_id)
+                } else {
+                    call_id
+                };
+                if write_all(&mut out, &fixtures::rpc_response(response_call_id, &stub))
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Reads one HTTP/1 request or interim response head (up to `\r\n\r\n`).
+/// Reads one request head and returns its `Content-Length`.
+async fn read_request_content_length(stream: &mut DuplexStream) -> Option<usize> {
+    let head = read_http_head(stream).await?;
+    let text = core::str::from_utf8(&head).ok()?;
+    text.split("\r\n").find_map(|line| {
+        let (name, value) = line.split_once(':')?;
+        name.trim()
+            .eq_ignore_ascii_case("content-length")
+            .then(|| value.trim().parse().ok())?
+    })
+}
+
+/// Accepts the IN channel: a Content-Length: 0 probe answered 200, then the streaming
+/// request whose first body PDU is CONN/B1.
+async fn accept_in_channel(input: &mut DuplexStream) -> bool {
+    if read_request_content_length(input).await != Some(0) {
+        return false;
+    }
+    if write_all(input, b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+        .await
+        .is_err()
+    {
+        return false;
+    }
+    if read_request_content_length(input).await.is_none() {
+        return false;
+    }
+    // CONN/B1 is the first body PDU; consume it before the bind.
+    read_pdu(input).await.is_some()
+}
+
+/// Accepts the OUT channel: a Content-Length: 0 probe answered 200, then the request
+/// carrying the 76-byte CONN/A1 body.
+async fn accept_out_channel(out: &mut DuplexStream) -> bool {
+    if read_request_content_length(out).await != Some(0) {
+        return false;
+    }
+    if write_all(out, b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+        .await
+        .is_err()
+    {
+        return false;
+    }
+    if read_request_content_length(out).await != Some(76) {
+        return false;
+    }
+    let mut conn_a1 = [0u8; 76];
+    out.read_exact(&mut conn_a1).await.is_ok()
+}
+
+async fn read_http_head(stream: &mut DuplexStream) -> Option<Vec<u8>> {
+    let mut head = Vec::with_capacity(256);
+    let mut byte = [0u8; 1];
+    loop {
+        stream.read_exact(&mut byte).await.ok()?;
+        head.push(byte[0]);
+        if head.ends_with(b"\r\n\r\n") {
+            return Some(head);
+        }
+        if head.len() > 16 * 1024 {
+            return None;
+        }
+    }
+}
+
+/// Reads one DCE/RPC PDU, framed by the common-header fragment length.
+async fn read_pdu(stream: &mut DuplexStream) -> Option<Vec<u8>> {
+    let mut header = [0u8; 16];
+    stream.read_exact(&mut header).await.ok()?;
+    let length = usize::from(u16::from_le_bytes(header[8..10].try_into().expect("fragment length")));
+    if !(16..=1024 * 1024).contains(&length) {
+        return None;
+    }
+    let mut pdu = header.to_vec();
+    pdu.resize(length, 0);
+    stream.read_exact(&mut pdu[16..]).await.ok()?;
+    Some(pdu)
+}
+
+fn call_id(pdu: &[u8]) -> u32 {
+    u32::from_le_bytes(pdu[12..16].try_into().expect("call id"))
+}
+
+async fn write_all(stream: &mut DuplexStream, bytes: &[u8]) -> tokio::io::Result<()> {
+    stream.write_all(bytes).await
+}

--- a/crates/ironrdp-mstsgu/src/packet_io.rs
+++ b/crates/ironrdp-mstsgu/src/packet_io.rs
@@ -1,0 +1,1272 @@
+//! Packet I/O over WebSocket or legacy dual-channel HTTP ([MS-TSGU] 1.3.2 / 3.3.5.1).
+
+use core::convert::Infallible;
+use std::collections::BTreeMap;
+
+use base64::Engine as _;
+use futures_util::stream::{SplitSink, SplitStream};
+use futures_util::{SinkExt as _, StreamExt as _};
+use http_body_util::channel::Channel as BodyChannel;
+use http_body_util::combinators::BoxBody;
+use http_body_util::{BodyExt as _, Empty};
+use hyper::body::{Bytes, Incoming};
+use hyper::client::conn::http1::SendRequest;
+use ironrdp_core::{Decode as _, ReadCursor};
+use ironrdp_tls::{CertificateValidation, CertificateValidationCallback, TlsStream};
+use log::{debug, error, info};
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+use tokio::net::TcpStream;
+use tokio::sync::oneshot;
+use tokio_socks::tcp::Socks5Stream;
+use tokio_tungstenite::WebSocketStream;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::handshake::client::generate_key;
+use tokio_tungstenite::tungstenite::protocol::Role;
+use url::Url;
+
+use crate::http_auth::{
+    AuthStep, GatewayHttpAuth, basic_authorization, challenges_offer_basic, www_authenticate_values,
+};
+use crate::proto::PktHdr;
+use crate::{Error, GwConnectTarget, GwErrorKind, parse_gateway_endpoint};
+
+/// Erased HTTP body so auth (`Empty`) and dual-channel writes (`Channel`) share one `SendRequest`.
+type RdgBody = BoxBody<Bytes, Infallible>;
+
+struct RdgRequestContext<'a> {
+    method: &'a str,
+    gw_host: &'a str,
+    connection_id: &'a str,
+    target: &'a GwConnectTarget,
+    websocket_upgrade: bool,
+}
+
+fn empty_rdg_body() -> RdgBody {
+    Empty::<Bytes>::new().boxed()
+}
+
+/// Session cookies returned by an RD Gateway or its load balancer.
+///
+/// MS-TSGU may split a session across multiple HTTP connections, so cookies returned by one
+/// connection must be replayed on each subsequent request.
+#[derive(Default)]
+struct GatewayCookies {
+    values: BTreeMap<String, String>,
+}
+
+impl GatewayCookies {
+    fn capture(&mut self, headers: &http::HeaderMap) {
+        for value in &headers.get_all(hyper::header::SET_COOKIE) {
+            let Ok(value) = value.to_str() else {
+                continue;
+            };
+            let Some((name, value)) = value.split(';').next().and_then(|cookie| cookie.split_once('=')) else {
+                continue;
+            };
+            let name = name.trim();
+            if name.is_empty() {
+                continue;
+            }
+            self.values.insert(name.to_owned(), format!("{name}={value}"));
+        }
+    }
+
+    fn header_value(&self) -> Option<String> {
+        (!self.values.is_empty()).then(|| self.values.values().cloned().collect::<Vec<_>>().join("; "))
+    }
+}
+
+enum GatewayProxy {
+    HttpConnect {
+        authority: String,
+        authorization: Option<String>,
+    },
+    Socks5 {
+        authority: String,
+        credentials: Option<(String, String)>,
+    },
+}
+
+fn proxy_from_url(value: &str) -> Result<GatewayProxy, Error> {
+    let url = Url::parse(value).map_err(|e| custom_err!("parse HTTPS proxy URL", e))?;
+    let host = url
+        .host_str()
+        .ok_or_else(|| Error::new("HTTPS proxy host", GwErrorKind::InvalidGwTarget))?;
+    let port = url.port_or_known_default().expect("http URL has a known default port");
+    let authority = if host.contains(':') {
+        format!("[{host}]:{port}")
+    } else {
+        format!("{host}:{port}")
+    };
+    let credentials = (!url.username().is_empty() || url.password().is_some())
+        .then(|| (url.username().to_owned(), url.password().unwrap_or_default().to_owned()));
+
+    match url.scheme() {
+        "http" => {
+            let authorization = credentials.map(|(username, password)| {
+                let credentials = format!("{username}:{password}");
+                format!(
+                    "Basic {}",
+                    base64::engine::general_purpose::STANDARD.encode(credentials.as_bytes())
+                )
+            });
+            Ok(GatewayProxy::HttpConnect {
+                authority,
+                authorization,
+            })
+        }
+        "socks5" | "socks5h" => Ok(GatewayProxy::Socks5 { authority, credentials }),
+        _ => Err(Error::new("HTTPS proxy scheme", GwErrorKind::UnsupportedFeature)),
+    }
+}
+
+fn no_proxy_matches(gw_host: &str, no_proxy: &str) -> bool {
+    no_proxy.split(',').map(str::trim).any(|entry| {
+        if entry == "*" {
+            return true;
+        }
+        let entry = entry.strip_prefix('.').unwrap_or(entry);
+        if gw_host.eq_ignore_ascii_case(entry) {
+            return true;
+        }
+
+        let Some(suffix) = gw_host.get(gw_host.len().saturating_sub(entry.len())..) else {
+            return false;
+        };
+        let Some(prefix) = gw_host.get(..gw_host.len().saturating_sub(entry.len())) else {
+            return false;
+        };
+        suffix.eq_ignore_ascii_case(entry) && prefix.ends_with('.')
+    })
+}
+
+fn proxy_from_environment(gw_host: &str) -> Result<Option<GatewayProxy>, Error> {
+    let no_proxy = std::env::var("NO_PROXY")
+        .ok()
+        .or_else(|| std::env::var("no_proxy").ok());
+    if no_proxy
+        .as_deref()
+        .is_some_and(|value| no_proxy_matches(gw_host, value))
+    {
+        return Ok(None);
+    }
+
+    let value = std::env::var("HTTPS_PROXY")
+        .ok()
+        .or_else(|| std::env::var("https_proxy").ok());
+    value.as_deref().map(proxy_from_url).transpose()
+}
+
+async fn read_proxy_response_headers(stream: &mut TcpStream) -> Result<Vec<u8>, Error> {
+    const MAX_RESPONSE_SIZE: usize = 16 * 1024;
+    let mut response = Vec::with_capacity(128);
+    loop {
+        if response.len() == MAX_RESPONSE_SIZE {
+            return Err(Error::new("HTTP CONNECT proxy response headers", GwErrorKind::Decode));
+        }
+        response.push(
+            stream
+                .read_u8()
+                .await
+                .map_err(|e| custom_err!("read HTTP CONNECT response", e))?,
+        );
+        if response.ends_with(b"\r\n\r\n") {
+            return Ok(response);
+        }
+    }
+}
+
+async fn tcp_connect(connect_addr: &str, gw_host: &str) -> Result<(TcpStream, core::net::SocketAddr), Error> {
+    let Some(proxy) = proxy_from_environment(gw_host)? else {
+        let stream = TcpStream::connect(connect_addr)
+            .await
+            .map_err(|e| custom_err!("tcp connect", e))?;
+        let client_addr = stream
+            .local_addr()
+            .map_err(|e| custom_err!("get socket local address", e))?;
+        return Ok((stream, client_addr));
+    };
+
+    match proxy {
+        GatewayProxy::HttpConnect {
+            authority,
+            authorization,
+        } => {
+            let mut stream = TcpStream::connect(&authority)
+                .await
+                .map_err(|e| custom_err!("connect HTTPS proxy", e))?;
+            let client_addr = stream
+                .local_addr()
+                .map_err(|e| custom_err!("get HTTPS proxy local address", e))?;
+            let mut request = format!("CONNECT {connect_addr} HTTP/1.1\r\nHost: {connect_addr}\r\n");
+            if let Some(authorization) = authorization {
+                request.push_str("Proxy-Authorization: ");
+                request.push_str(&authorization);
+                request.push_str("\r\n");
+            }
+            request.push_str("Proxy-Connection: keep-alive\r\n\r\n");
+            stream
+                .write_all(request.as_bytes())
+                .await
+                .map_err(|e| custom_err!("send HTTP CONNECT request", e))?;
+
+            let response = read_proxy_response_headers(&mut stream).await?;
+            let response =
+                core::str::from_utf8(&response).map_err(|e| custom_err!("decode HTTP CONNECT response", e))?;
+            let status = response
+                .lines()
+                .next()
+                .and_then(|line| line.split_whitespace().nth(1))
+                .and_then(|status| status.parse::<u16>().ok())
+                .ok_or_else(|| Error::new("HTTP CONNECT proxy status", GwErrorKind::Decode))?;
+            if status != http::StatusCode::OK.as_u16() {
+                return Err(Error::new("HTTP CONNECT proxy", GwErrorKind::HttpStatus(status)));
+            }
+
+            Ok((stream, client_addr))
+        }
+        GatewayProxy::Socks5 { authority, credentials } => {
+            let stream = if let Some((username, password)) = credentials {
+                Socks5Stream::connect_with_password(authority.as_str(), connect_addr, &username, &password)
+                    .await
+                    .map_err(|e| custom_err!("connect SOCKS5 proxy", e))?
+            } else {
+                Socks5Stream::connect(authority.as_str(), connect_addr)
+                    .await
+                    .map_err(|e| custom_err!("connect SOCKS5 proxy", e))?
+            };
+            let client_addr = stream
+                .local_addr()
+                .map_err(|e| custom_err!("get SOCKS5 proxy local address", e))?;
+
+            Ok((stream.into_inner(), client_addr))
+        }
+    }
+}
+
+/// Backing transport for MS-TSGU protocol packets after HTTP setup.
+pub(crate) enum PacketIo {
+    WebSocket {
+        sink: SplitSink<WebSocketStream<TlsStream<TcpStream>>, Message>,
+        stream: SplitStream<WebSocketStream<TlsStream<TcpStream>>>,
+        /// Whether the HTTP layer authenticated with Basic (no SSPI NTLM blobs
+        /// available for the post-handshake extended-auth exchange).
+        http_auth_basic: bool,
+    },
+    /// Legacy dual channel: read from OUT response body, write to IN request body.
+    DualHttp {
+        out_body: Incoming,
+        out_buf: Vec<u8>,
+        in_tx: http_body_util::channel::Sender<Bytes>,
+        /// Whether the HTTP layer authenticated with Basic.
+        http_auth_basic: bool,
+        _out_stop_tx: oneshot::Sender<()>,
+        _out_conn: tokio::task::JoinHandle<()>,
+        _in_conn: tokio::task::JoinHandle<()>,
+    },
+    /// In-memory transport for mock gateway tests.
+    #[cfg(test)]
+    Duplex {
+        stream: tokio::io::DuplexStream,
+        buf: Vec<u8>,
+    },
+}
+
+impl PacketIo {
+    /// Whether the HTTP layer authenticated with Basic. Basic produces no SSPI NTLM
+    /// blobs, so the MS-TSGU extended-auth exchange must not be advertised.
+    pub(crate) fn http_auth_basic(&self) -> bool {
+        match self {
+            PacketIo::WebSocket { http_auth_basic, .. } => *http_auth_basic,
+            PacketIo::DualHttp { http_auth_basic, .. } => *http_auth_basic,
+            #[cfg(test)]
+            PacketIo::Duplex { .. } => false,
+        }
+    }
+
+    /// Wrap one side of an in-memory duplex pair for mock gateway tests.
+    #[cfg(test)]
+    pub(crate) fn duplex(stream: tokio::io::DuplexStream) -> Self {
+        Self::Duplex {
+            stream,
+            buf: Vec::new(),
+        }
+    }
+
+    pub(crate) async fn send_bytes(&mut self, bytes: &[u8]) -> Result<(), Error> {
+        match self {
+            PacketIo::WebSocket { sink, .. } => {
+                sink.send(Message::Binary(Bytes::copy_from_slice(bytes)))
+                    .await
+                    .map_err(|e| custom_err!("websocket send", e))?;
+                Ok(())
+            }
+            PacketIo::DualHttp { in_tx, .. } => {
+                in_tx
+                    .send_data(Bytes::copy_from_slice(bytes))
+                    .await
+                    .map_err(|e| custom_err!("dual-http send", e))?;
+                Ok(())
+            }
+            #[cfg(test)]
+            PacketIo::Duplex { stream, .. } => {
+                stream
+                    .write_all(bytes)
+                    .await
+                    .map_err(|e| custom_err!("duplex send", e))?;
+                Ok(())
+            }
+        }
+    }
+
+    /// Closes the transport gracefully: a WebSocket close frame, or the end of the
+    /// dual-channel IN request body.
+    pub(crate) async fn close(&mut self) -> Result<(), Error> {
+        match self {
+            PacketIo::WebSocket { sink, .. } => {
+                sink.send(Message::Close(None))
+                    .await
+                    .map_err(|e| custom_err!("websocket close", e))?;
+                sink.flush()
+                    .await
+                    .map_err(|e| custom_err!("websocket close flush", e))?;
+                Ok(())
+            }
+            PacketIo::DualHttp { in_tx, .. } => {
+                let _ = in_tx; // dropping the sender ends the IN request body
+                Ok(())
+            }
+            #[cfg(test)]
+            PacketIo::Duplex { stream, .. } => {
+                stream.shutdown().await.map_err(|e| custom_err!("duplex close", e))?;
+                Ok(())
+            }
+        }
+    }
+
+    /// Read one complete MS-TSGU packet buffer (header + body).
+    pub(crate) async fn read_packet_buf(&mut self) -> Result<Bytes, Error> {
+        match self {
+            PacketIo::WebSocket { stream, .. } => {
+                let msg = stream
+                    .next()
+                    .await
+                    .ok_or_else(|| Error::new("websocket stream closed", GwErrorKind::Connect))?
+                    .map_err(|e| custom_err!("websocket read", e))?
+                    .into_data();
+                Ok(msg)
+            }
+            PacketIo::DualHttp { out_body, out_buf, .. } => read_complete_packet(out_body, out_buf).await,
+            #[cfg(test)]
+            PacketIo::Duplex { stream, buf } => read_complete_packet_duplex(stream, buf).await,
+        }
+    }
+}
+
+/// Read one complete MS-TSGU packet from a duplex stream (header length prefixed).
+#[cfg(test)]
+async fn read_complete_packet_duplex(stream: &mut tokio::io::DuplexStream, buf: &mut Vec<u8>) -> Result<Bytes, Error> {
+    while buf.len() < PktHdr::FIXED_PART_SIZE {
+        pull_duplex_chunk(stream, buf).await?;
+    }
+
+    let hdr = {
+        let mut cur = ReadCursor::new(buf);
+        PktHdr::decode(&mut cur).map_err(|e| custom_err!("decode packet header", e))?
+    };
+    let total = usize::try_from(hdr.length).map_err(|_| Error::new("packet header length", GwErrorKind::Decode))?;
+    if total < PktHdr::FIXED_PART_SIZE {
+        return Err(Error::new("packet length smaller than header", GwErrorKind::Decode));
+    }
+
+    while buf.len() < total {
+        pull_duplex_chunk(stream, buf).await?;
+    }
+
+    let packet = Bytes::copy_from_slice(&buf[..total]);
+    buf.drain(..total);
+    Ok(packet)
+}
+
+#[cfg(test)]
+async fn pull_duplex_chunk(stream: &mut tokio::io::DuplexStream, buf: &mut Vec<u8>) -> Result<(), Error> {
+    let mut chunk = [0u8; 4096];
+    let n = stream
+        .read(&mut chunk)
+        .await
+        .map_err(|e| custom_err!("duplex read", e))?;
+    if n == 0 {
+        return Err(Error::new("duplex stream closed", GwErrorKind::Connect));
+    }
+    buf.extend_from_slice(&chunk[..n]);
+    Ok(())
+}
+
+async fn read_complete_packet(body: &mut Incoming, buf: &mut Vec<u8>) -> Result<Bytes, Error> {
+    while buf.len() < PktHdr::FIXED_PART_SIZE {
+        pull_body_chunk(body, buf).await?;
+    }
+
+    let hdr = {
+        let mut cur = ReadCursor::new(buf);
+        PktHdr::decode(&mut cur).map_err(|e| custom_err!("decode packet header", e))?
+    };
+    let total = usize::try_from(hdr.length).map_err(|_| Error::new("packet header length", GwErrorKind::Decode))?;
+    if total < PktHdr::FIXED_PART_SIZE {
+        return Err(Error::new("packet length smaller than header", GwErrorKind::Decode));
+    }
+
+    while buf.len() < total {
+        pull_body_chunk(body, buf).await?;
+    }
+
+    let packet = Bytes::copy_from_slice(&buf[..total]);
+    buf.drain(..total);
+    Ok(packet)
+}
+
+async fn pull_body_chunk(body: &mut Incoming, buf: &mut Vec<u8>) -> Result<(), Error> {
+    loop {
+        let frame = body
+            .frame()
+            .await
+            .ok_or_else(|| Error::new("dual-http out stream closed", GwErrorKind::Connect))?
+            .map_err(|e| custom_err!("dual-http out read", e))?;
+        if let Ok(data) = frame.into_data() {
+            if data.is_empty() {
+                continue;
+            }
+            buf.extend_from_slice(&data);
+            return Ok(());
+        }
+    }
+}
+
+/// Open transport: prefer WebSocket upgrade; fall back to dual-channel HTTP on HTTP 200.
+///
+/// Some gateways answer the SSPI (Negotiate/NTLM) handshake on the RDG_OUT_DATA channel
+/// by requesting a TLS renegotiation, which rustls does not support; the connection is
+/// reset mid-handshake. When that happens and the gateway offered Basic, retry once on a
+/// fresh connection using Basic (safe: the whole transport is TLS).
+pub(crate) async fn open_transport_prefer_websocket(
+    target: &GwConnectTarget,
+    certificate_validation: CertificateValidation,
+    certificate_validation_callback: Option<CertificateValidationCallback>,
+) -> Result<(PacketIo, core::net::SocketAddr), Error> {
+    let attempt = match rdg_out_handshake(target, certificate_validation, certificate_validation_callback.clone()).await
+    {
+        Ok(Ok(transport)) => return Ok(transport),
+        Ok(Err(error)) => {
+            // The handshake completed the auth exchange but failed at the transport step.
+            return Err(error);
+        }
+        Err(attempt) => attempt,
+    };
+
+    if attempt.saw_reset && attempt.basic_offered {
+        info!("RD Gateway reset the OUT channel during SSPI auth; retrying with Basic");
+        return rdg_out_handshake_basic(
+            target,
+            certificate_validation,
+            certificate_validation_callback,
+            &attempt.connection_id,
+        )
+        .await;
+    }
+
+    Err(attempt.error)
+}
+
+/// Outcome of a failed RDG OUT-channel handshake, tracking whether the connection was
+/// reset mid-auth and whether the gateway advertised Basic. Carries the connection id so
+/// a Basic retry reuses the channel identity the gateway saw during the first attempt.
+struct RdgOutFailure {
+    error: Error,
+    saw_reset: bool,
+    basic_offered: bool,
+    connection_id: String,
+}
+
+/// Retry the OUT-channel handshake using HTTP Basic on a fresh connection, reusing the
+/// connection id from the failed SSPI attempt.
+async fn rdg_out_handshake_basic(
+    target: &GwConnectTarget,
+    certificate_validation: CertificateValidation,
+    certificate_validation_callback: Option<CertificateValidationCallback>,
+    connection_id: &str,
+) -> Result<(PacketIo, core::net::SocketAddr), Error> {
+    let (gw_host, connect_addr) = parse_gateway_endpoint(&target.gw_endpoint)?;
+    let spn = format!("HTTP/{gw_host}");
+
+    let (out_stream, client_addr) = tls_connect(
+        &connect_addr,
+        gw_host,
+        certificate_validation,
+        certificate_validation_callback.clone(),
+    )
+    .await?;
+
+    let out_io = hyper_util::rt::tokio::TokioIo::new(out_stream);
+    let (mut out_sender, out_conn) = hyper::client::conn::http1::handshake(out_io)
+        .await
+        .map_err(|e| custom_err!("http/1 out handshake", e))?;
+
+    // The Basic retry sends a single committing request, so the upgrade completes the
+    // connection driver. Poll it with `without_shutdown`, which yields the connection
+    // parts once the upgrade finishes instead of shutting the IO down.
+    let out_conn_jh = tokio::task::spawn(out_conn.without_shutdown());
+
+    let mut cookies = GatewayCookies::default();
+    let request_context = RdgRequestContext {
+        method: "RDG_OUT_DATA",
+        gw_host,
+        connection_id,
+        target,
+        websocket_upgrade: true,
+    };
+    let req = build_rdg_request(&request_context, None, true, &cookies, empty_rdg_body())?;
+    let resp = out_sender
+        .send_request(req)
+        .await
+        .map_err(|e| custom_err!("rdg out send", e))?;
+    cookies.capture(resp.headers());
+
+    if resp.status() == http::StatusCode::SWITCHING_PROTOCOLS {
+        let parts = out_conn_jh
+            .await
+            .map_err(|e| custom_err!("websocket upgrade join", e))?
+            .map_err(|e| custom_err!("rdg out upgrade", e))?;
+        let tls_stream = parts.io.into_inner();
+        let ws_stream = WebSocketStream::from_raw_socket(tls_stream, Role::Client, None).await;
+        let (sink, stream) = ws_stream.split();
+        return Ok((
+            PacketIo::WebSocket {
+                sink,
+                stream,
+                http_auth_basic: true,
+            },
+            client_addr,
+        ));
+    }
+
+    if resp.status() == http::StatusCode::OK {
+        info!("RD Gateway WebSocket upgrade unavailable; using dual-channel HTTP");
+        let out_conn_task = tokio::task::spawn(async move {
+            let _ = out_conn_jh.await;
+        });
+        let (out_stop_tx, out_stop_rx) = oneshot::channel::<()>();
+        drop(out_stop_rx);
+        let mut out_body = resp.into_body();
+        let leftover = skip_seed_payload(&mut out_body).await?;
+        drop(out_sender);
+        let dual = open_in_channel(
+            &connect_addr,
+            gw_host,
+            connection_id,
+            target,
+            &spn,
+            certificate_validation,
+            certificate_validation_callback,
+            &mut cookies,
+            out_stop_tx,
+            out_body,
+            leftover,
+            out_conn_task,
+            true,
+        )
+        .await?;
+        return Ok((dual, client_addr));
+    }
+
+    Err(Error::new(
+        "rdg out data",
+        GwErrorKind::HttpStatus(resp.status().as_u16()),
+    ))
+}
+
+/// Run the RDG OUT-channel handshake (WebSocket upgrade or dual-channel HTTP), driving
+/// the SSPI auth exchange. On failure, reports whether a mid-auth connection reset and a
+/// Basic challenge were observed so the caller can retry with Basic.
+#[expect(clippy::too_many_lines, reason = "linear request/response auth sequence")]
+async fn rdg_out_handshake(
+    target: &GwConnectTarget,
+    certificate_validation: CertificateValidation,
+    certificate_validation_callback: Option<CertificateValidationCallback>,
+) -> Result<Result<(PacketIo, core::net::SocketAddr), Error>, RdgOutFailure> {
+    let connection_id = format!("{{{}}}", uuid::Uuid::new_v4());
+    let mut failure = RdgOutFailure {
+        error: Error::new("rdg out data", GwErrorKind::Connect),
+        saw_reset: false,
+        basic_offered: false,
+        connection_id: connection_id.clone(),
+    };
+
+    let (gw_host, connect_addr) = match parse_gateway_endpoint(&target.gw_endpoint) {
+        Ok(ok) => ok,
+        Err(error) => {
+            failure.error = error;
+            return Err(failure);
+        }
+    };
+    let spn = format!("HTTP/{gw_host}");
+
+    let (out_stream, client_addr) = match tls_connect(
+        &connect_addr,
+        gw_host,
+        certificate_validation,
+        certificate_validation_callback.clone(),
+    )
+    .await
+    {
+        Ok(ok) => ok,
+        Err(error) => {
+            failure.error = error;
+            return Err(failure);
+        }
+    };
+
+    let out_io = hyper_util::rt::tokio::TokioIo::new(out_stream);
+    let (mut out_sender, mut out_conn) = match hyper::client::conn::http1::handshake(out_io).await {
+        Ok(ok) => ok,
+        Err(e) => {
+            failure.error = custom_err!("http/1 out handshake", e);
+            return Err(failure);
+        }
+    };
+
+    let (out_stop_tx, out_stop_rx) = oneshot::channel::<()>();
+    let out_conn_jh = tokio::task::spawn(async move {
+        tokio::select! {
+            res = &mut out_conn => {
+                if let Err(e) = res {
+                    error!("RD Gateway OUT HTTP connection error: {e:?}");
+                }
+                None
+            }
+            _ = out_stop_rx => {
+                Some(out_conn.into_parts())
+            }
+        }
+    });
+
+    let mut http_auth: Option<GatewayHttpAuth> = None;
+    let mut authorization: Option<String> = None;
+    let mut use_basic = false;
+    let mut cookies = GatewayCookies::default();
+    let request_context = RdgRequestContext {
+        method: "RDG_OUT_DATA",
+        gw_host,
+        connection_id: &connection_id,
+        target,
+        websocket_upgrade: true,
+    };
+    const MAX_AUTH_ROUNDS: usize = 8;
+
+    for _ in 0..MAX_AUTH_ROUNDS {
+        let req = match build_rdg_request(
+            &request_context,
+            authorization.as_deref(),
+            use_basic,
+            &cookies,
+            empty_rdg_body(),
+        ) {
+            Ok(req) => req,
+            Err(error) => {
+                failure.error = error;
+                return Err(failure);
+            }
+        };
+
+        let resp = match out_sender.send_request(req).await {
+            Ok(resp) => resp,
+            Err(e) => {
+                failure.saw_reset = error_chain_has_connection_reset(&e);
+                failure.error = custom_err!("rdg out send", e);
+                return Err(failure);
+            }
+        };
+        cookies.capture(resp.headers());
+
+        if resp.status() == http::StatusCode::UNAUTHORIZED {
+            let challenges = www_authenticate_values(resp.headers());
+            failure.basic_offered |= challenges_offer_basic(&challenges);
+        }
+
+        let is_upgrade = resp.status() == http::StatusCode::SWITCHING_PROTOCOLS;
+        let is_dual_http = resp.status() == http::StatusCode::OK;
+        if is_upgrade || is_dual_http {
+            return match finish_rdg_out_response(
+                resp,
+                target,
+                &connect_addr,
+                gw_host,
+                &connection_id,
+                &spn,
+                certificate_validation,
+                certificate_validation_callback,
+                cookies,
+                out_sender,
+                out_stop_tx,
+                out_conn_jh,
+                client_addr,
+                use_basic,
+            )
+            .await
+            {
+                Ok(ok) => Ok(Ok(ok)),
+                Err(error) => {
+                    failure.error = error;
+                    Err(failure)
+                }
+            };
+        }
+
+        if resp.status() != http::StatusCode::UNAUTHORIZED {
+            failure.error = Error::new("rdg out data", GwErrorKind::HttpStatus(resp.status().as_u16()));
+            return Err(failure);
+        }
+
+        if use_basic {
+            failure.error = Error::new("rdg out basic auth", GwErrorKind::HttpStatus(resp.status().as_u16()));
+            return Err(failure);
+        }
+
+        let challenges: Vec<String> = www_authenticate_values(resp.headers())
+            .into_iter()
+            .map(str::to_owned)
+            .collect();
+        if let Err(e) = resp.into_body().collect().await {
+            failure.error = custom_err!("drain rdg out auth body", e);
+            return Err(failure);
+        }
+
+        let challenge_refs: Vec<&str> = challenges.iter().map(String::as_str).collect();
+        let step = match if let Some(auth) = http_auth.as_mut() {
+            auth.step_www_authenticate(challenge_refs)
+        } else {
+            GatewayHttpAuth::from_challenges(
+                &target.gw_user,
+                &target.gw_pass,
+                target.smart_card.as_deref(),
+                Some(spn.clone()),
+                &challenge_refs,
+            )
+            .map(|(auth, step)| {
+                http_auth = Some(auth);
+                step
+            })
+        } {
+            Ok(step) => step,
+            Err(error) => {
+                failure.error = error;
+                return Err(failure);
+            }
+        };
+
+        match step {
+            AuthStep::Continue(next) => authorization = Some(next),
+            AuthStep::TryBasic => use_basic = true,
+            AuthStep::Complete => {
+                failure.error = Error::new(
+                    "rdg out auth complete without upgrade or ok",
+                    GwErrorKind::HttpStatus(http::StatusCode::UNAUTHORIZED.as_u16()),
+                );
+                return Err(failure);
+            }
+        }
+    }
+
+    failure.error = Error::new("rdg out auth rounds exceeded", GwErrorKind::Connect);
+    Err(failure)
+}
+
+/// Whether an error chain carries an `io::ErrorKind::ConnectionReset`, which rustls
+/// reports when the peer closes the connection during a TLS renegotiation.
+fn error_chain_has_connection_reset(error: &(dyn core::error::Error + 'static)) -> bool {
+    let mut source = error.source();
+    while let Some(cause) = source {
+        if let Some(io) = cause.downcast_ref::<std::io::Error>()
+            && io.kind() == std::io::ErrorKind::ConnectionReset
+        {
+            return true;
+        }
+        source = cause.source();
+    }
+    false
+}
+
+/// Complete the OUT-channel response once it is not an auth challenge: upgrade to a
+/// WebSocket on 101, or open the dual-channel HTTP transport on 200.
+#[expect(clippy::too_many_arguments, reason = "carries the established OUT connection state")]
+async fn finish_rdg_out_response(
+    resp: http::Response<Incoming>,
+    target: &GwConnectTarget,
+    connect_addr: &str,
+    gw_host: &str,
+    connection_id: &str,
+    spn: &str,
+    certificate_validation: CertificateValidation,
+    certificate_validation_callback: Option<CertificateValidationCallback>,
+    mut cookies: GatewayCookies,
+    out_sender: SendRequest<RdgBody>,
+    out_stop_tx: oneshot::Sender<()>,
+    out_conn_jh: tokio::task::JoinHandle<
+        Option<hyper::client::conn::http1::Parts<hyper_util::rt::tokio::TokioIo<TlsStream<TcpStream>>>>,
+    >,
+    client_addr: core::net::SocketAddr,
+    http_auth_basic: bool,
+) -> Result<(PacketIo, core::net::SocketAddr), Error> {
+    if resp.status() == http::StatusCode::SWITCHING_PROTOCOLS {
+        let _ = out_stop_tx.send(());
+        let parts = out_conn_jh
+            .await
+            .map_err(|e| custom_err!("websocket upgrade join", e))?
+            .ok_or_else(|| Error::new("websocket upgrade connection lost", GwErrorKind::Connect))?;
+        let tls_stream = parts.io.into_inner();
+        let ws_stream = WebSocketStream::from_raw_socket(tls_stream, Role::Client, None).await;
+        let (sink, stream) = ws_stream.split();
+        return Ok((
+            PacketIo::WebSocket {
+                sink,
+                stream,
+                http_auth_basic,
+            },
+            client_addr,
+        ));
+    }
+
+    info!("RD Gateway WebSocket upgrade unavailable; using dual-channel HTTP");
+    // Keep the OUT HTTP driver alive while the response body is read.
+    // Keeping the stop sender in PacketIo delays its shutdown until the transport is dropped.
+    let out_conn_task = tokio::task::spawn(async move {
+        let _ = out_conn_jh.await;
+    });
+
+    let mut out_body = resp.into_body();
+    let leftover = skip_seed_payload(&mut out_body).await?;
+    drop(out_sender);
+
+    let dual = open_in_channel(
+        connect_addr,
+        gw_host,
+        connection_id,
+        target,
+        spn,
+        certificate_validation,
+        certificate_validation_callback,
+        &mut cookies,
+        out_stop_tx,
+        out_body,
+        leftover,
+        out_conn_task,
+        http_auth_basic,
+    )
+    .await?;
+    Ok((dual, client_addr))
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "a dual HTTP connection requires independent IN and OUT connection state"
+)]
+async fn open_in_channel(
+    connect_addr: &str,
+    gw_host: &str,
+    connection_id: &str,
+    target: &GwConnectTarget,
+    spn: &str,
+    certificate_validation: CertificateValidation,
+    certificate_validation_callback: Option<CertificateValidationCallback>,
+    cookies: &mut GatewayCookies,
+    out_stop_tx: oneshot::Sender<()>,
+    out_body: Incoming,
+    out_buf: Vec<u8>,
+    out_conn_task: tokio::task::JoinHandle<()>,
+    http_auth_basic: bool,
+) -> Result<PacketIo, Error> {
+    let (in_stream, _) = tls_connect(
+        connect_addr,
+        gw_host,
+        certificate_validation,
+        certificate_validation_callback,
+    )
+    .await?;
+    let in_io = hyper_util::rt::tokio::TokioIo::new(in_stream);
+    let (mut in_sender, in_conn) = hyper::client::conn::http1::handshake(in_io)
+        .await
+        .map_err(|e| custom_err!("http/1 in handshake", e))?;
+
+    let in_conn_task = tokio::task::spawn(async move {
+        if let Err(e) = in_conn.await {
+            error!("RD Gateway IN HTTP connection error: {e:?}");
+        }
+    });
+
+    let request_context = RdgRequestContext {
+        method: "RDG_IN_DATA",
+        gw_host,
+        connection_id,
+        target,
+        websocket_upgrade: false,
+    };
+    let in_resp = authenticated_rdg_request(&mut in_sender, &request_context, spn, cookies).await?;
+
+    if in_resp.status() != http::StatusCode::OK {
+        return Err(Error::new(
+            "rdg in data",
+            GwErrorKind::HttpStatus(in_resp.status().as_u16()),
+        ));
+    }
+    let _ = in_resp
+        .into_body()
+        .collect()
+        .await
+        .map_err(|e| custom_err!("drain rdg in body", e))?;
+
+    let (in_tx, in_body) = BodyChannel::<Bytes>::new(16);
+    let host_header = host_header_value(gw_host);
+    let mut write_req = http::Request::builder()
+        .method("RDG_IN_DATA")
+        .uri("/remoteDesktopGateway/")
+        .header(hyper::header::HOST, host_header.as_str())
+        .header("Rdg-Connection-Id", connection_id);
+    if let Some(cookie_header) = cookies.header_value() {
+        write_req = write_req.header(hyper::header::COOKIE, cookie_header);
+    }
+    let write_req = write_req
+        .body(in_body.boxed())
+        .map_err(|e| custom_err!("build rdg in write request", e))?;
+
+    tokio::task::spawn(async move {
+        match in_sender.send_request(write_req).await {
+            Ok(resp) => {
+                debug!("RD Gateway IN write-channel HTTP status {}", resp.status().as_u16());
+                let _ = resp.into_body().collect().await;
+            }
+            Err(e) => error!("RD Gateway IN write-channel error: {e:?}"),
+        }
+    });
+
+    Ok(PacketIo::DualHttp {
+        out_body,
+        out_buf,
+        in_tx,
+        http_auth_basic,
+        _out_stop_tx: out_stop_tx,
+        _out_conn: out_conn_task,
+        _in_conn: in_conn_task,
+    })
+}
+
+async fn authenticated_rdg_request(
+    sender: &mut SendRequest<RdgBody>,
+    request_context: &RdgRequestContext<'_>,
+    spn: &str,
+    cookies: &mut GatewayCookies,
+) -> Result<http::Response<Incoming>, Error> {
+    authenticated_http_request(
+        sender,
+        &request_context.target.gw_user,
+        &request_context.target.gw_pass,
+        request_context.target.smart_card.as_deref(),
+        spn,
+        cookies,
+        |authorization, use_basic, cookies| {
+            build_rdg_request(request_context, authorization, use_basic, cookies, empty_rdg_body())
+        },
+    )
+    .await
+}
+
+/// Sends a retry-safe request through the shared gateway HTTP authentication loop.
+///
+/// The closure can build either modern RDG or future RPCH requests, while the
+/// TLS, proxy, cookie, and NTLM/Negotiate authentication machinery remains
+/// shared. It is suitable only for request bodies that can be retried safely.
+async fn authenticated_http_request<F>(
+    sender: &mut SendRequest<RdgBody>,
+    username: &str,
+    password: &str,
+    smart_card: Option<&crate::GwSmartCardCredentials>,
+    spn: &str,
+    cookies: &mut GatewayCookies,
+    mut build_request: F,
+) -> Result<http::Response<Incoming>, Error>
+where
+    F: FnMut(Option<&str>, bool, &GatewayCookies) -> Result<http::Request<RdgBody>, Error>,
+{
+    let mut http_auth: Option<GatewayHttpAuth> = None;
+    let mut authorization: Option<String> = None;
+    let mut use_basic = false;
+    const MAX_AUTH_ROUNDS: usize = 8;
+
+    for _ in 0..MAX_AUTH_ROUNDS {
+        let req = build_request(authorization.as_deref(), use_basic, cookies)?;
+
+        let resp = sender
+            .send_request(req)
+            .await
+            .map_err(|e| custom_err!("gateway http auth send", e))?;
+        cookies.capture(resp.headers());
+
+        if resp.status() != http::StatusCode::UNAUTHORIZED {
+            return Ok(resp);
+        }
+
+        if use_basic {
+            return Err(Error::new(
+                "gateway http basic auth",
+                GwErrorKind::HttpStatus(resp.status().as_u16()),
+            ));
+        }
+
+        let challenges: Vec<String> = www_authenticate_values(resp.headers())
+            .into_iter()
+            .map(str::to_owned)
+            .collect();
+        let _ = resp
+            .into_body()
+            .collect()
+            .await
+            .map_err(|e| custom_err!("drain gateway http auth body", e))?;
+
+        let challenge_refs: Vec<&str> = challenges.iter().map(String::as_str).collect();
+        let step = if let Some(auth) = http_auth.as_mut() {
+            auth.step_www_authenticate(challenge_refs)?
+        } else {
+            let (auth, step) = GatewayHttpAuth::from_challenges(
+                username,
+                password,
+                smart_card,
+                Some(spn.to_owned()),
+                &challenge_refs,
+            )?;
+            http_auth = Some(auth);
+            step
+        };
+
+        match step {
+            AuthStep::Continue(next) => authorization = Some(next),
+            AuthStep::TryBasic => use_basic = true,
+            AuthStep::Complete => {
+                return Err(Error::new(
+                    "gateway http auth complete without success",
+                    GwErrorKind::HttpStatus(http::StatusCode::UNAUTHORIZED.as_u16()),
+                ));
+            }
+        }
+    }
+
+    Err(Error::new("gateway http auth rounds exceeded", GwErrorKind::Connect))
+}
+
+fn build_rdg_request(
+    request_context: &RdgRequestContext<'_>,
+    authorization: Option<&str>,
+    use_basic: bool,
+    cookies: &GatewayCookies,
+    body: RdgBody,
+) -> Result<http::Request<RdgBody>, Error> {
+    let host_header = host_header_value(request_context.gw_host);
+    let mut req = http::Request::builder()
+        .method(request_context.method)
+        .uri("/remoteDesktopGateway/")
+        .header(hyper::header::HOST, host_header.as_str())
+        .header("Rdg-Connection-Id", request_context.connection_id);
+    if let Some(cookie_header) = cookies.header_value() {
+        req = req.header(hyper::header::COOKIE, cookie_header);
+    }
+
+    if request_context.websocket_upgrade {
+        req = req
+            .header(hyper::header::CONNECTION, "Upgrade")
+            .header(hyper::header::UPGRADE, "websocket")
+            .header(hyper::header::SEC_WEBSOCKET_VERSION, "13")
+            .header(hyper::header::SEC_WEBSOCKET_KEY, generate_key());
+    }
+
+    if use_basic {
+        req = req.header(
+            hyper::header::AUTHORIZATION,
+            basic_authorization(&request_context.target.gw_user, &request_context.target.gw_pass),
+        );
+    } else if let Some(auth_header) = authorization {
+        req = req.header(hyper::header::AUTHORIZATION, auth_header);
+    }
+
+    req.body(body).map_err(|e| custom_err!("build rdg request", e))
+}
+
+fn host_header_value(gw_host: &str) -> String {
+    if gw_host.contains(':') {
+        format!("[{gw_host}]")
+    } else {
+        gw_host.to_owned()
+    }
+}
+
+/// Open the legacy MS-RPCH v2 transport: two TLS streams carrying RPC_IN_DATA and
+/// RPC_OUT_DATA, driven through the RTS/DCE/RPC setup in [`crate::rpch`].
+///
+/// Used for gateways that do not support the WebSocket upgrade or dual-channel HTTP.
+pub(crate) async fn open_rpch_transport(
+    target: &GwConnectTarget,
+    client_name: &str,
+    certificate_validation: CertificateValidation,
+    certificate_validation_callback: Option<CertificateValidationCallback>,
+) -> Result<(crate::rpch::RpchStream, core::net::SocketAddr), Error> {
+    let (gw_host, connect_addr) = parse_gateway_endpoint(&target.gw_endpoint)?;
+
+    // RPC-over-HTTP uses separate IN and OUT connections ([MS-RPCH] 2.1.1).
+    let (out_stream, client_addr) = tls_connect(
+        &connect_addr,
+        gw_host,
+        certificate_validation,
+        certificate_validation_callback.clone(),
+    )
+    .await?;
+    let (in_stream, _) = tls_connect(
+        &connect_addr,
+        gw_host,
+        certificate_validation,
+        certificate_validation_callback,
+    )
+    .await?;
+
+    // RPC-level NTLM packet integrity when credentials are present.
+    let rpc_auth = if target.gw_pass.is_empty() {
+        None
+    } else {
+        Some(crate::rpc::RpcNtlmAuth::new(&target.gw_user, &target.gw_pass)?)
+    };
+
+    // Match the reference client (mstsc): a 1 GB channel lifetime (the IN channel
+    // Content-Length), a 64 KB receive window, and a 300 s keepalive ([MS-RPCH] 2.2.3.5).
+    let settings = crate::rpc::RpcHttpV2Settings::new(64 * 1024, 1_073_741_824, 300_000)
+        .map_err(|e| custom_err!("rpch settings", e))?;
+    let mut session = Box::pin(crate::rpch::rpch_connect(
+        out_stream, in_stream, gw_host, target, settings, rpc_auth,
+    ))
+    .await?;
+    // Establish the TsProxy tunnel and channel to the target resource before handing the
+    // stream to the caller; without this the session cannot carry target-server data.
+    Box::pin(session.open_tunnel(client_name, &target.server, target.server_port)).await?;
+    Ok((crate::rpch::RpchStream::new(session), client_addr))
+}
+
+async fn tls_connect(
+    connect_addr: &str,
+    gw_host: &str,
+    certificate_validation: CertificateValidation,
+    certificate_validation_callback: Option<CertificateValidationCallback>,
+) -> Result<(TlsStream<TcpStream>, core::net::SocketAddr), Error> {
+    let (stream, client_addr) = tcp_connect(connect_addr, gw_host).await?;
+
+    let tls_upgrade = if let Some(callback) = certificate_validation_callback {
+        ironrdp_tls::upgrade_with_certificate_validation_callback(stream, gw_host, callback).await
+    } else {
+        ironrdp_tls::upgrade_with_certificate_validation(stream, gw_host, certificate_validation).await
+    };
+    let (stream, _) = tls_upgrade.map_err(|e| custom_err!("tls connect", e))?;
+    Ok((stream, client_addr))
+}
+
+/// Skip the reverse-proxy seed payload on OUT ([MS-TSGU] 3.3.5.1 / FreeRDP ~10 bytes).
+///
+/// Returns any bytes past the seed that already arrived in the same body frame.
+async fn skip_seed_payload(body: &mut Incoming) -> Result<Vec<u8>, Error> {
+    const SEED_LEN: usize = 10;
+    let mut skipped = 0usize;
+
+    while skipped < SEED_LEN {
+        let frame = match body.frame().await {
+            None => {
+                debug!("RD Gateway OUT body ended during seed skip ({skipped} bytes)");
+                return Ok(Vec::new());
+            }
+            Some(Err(e)) => return Err(custom_err!("dual-http seed read", e)),
+            Some(Ok(frame)) => frame,
+        };
+        let Ok(data) = frame.into_data() else {
+            continue;
+        };
+        if data.is_empty() {
+            continue;
+        }
+        let need = SEED_LEN - skipped;
+        if data.len() <= need {
+            skipped += data.len();
+        } else {
+            return Ok(data[need..].to_vec());
+        }
+    }
+
+    Ok(Vec::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn host_header_brackets_ipv6() {
+        assert_eq!(host_header_value("2001:db8::1"), "[2001:db8::1]");
+        assert_eq!(host_header_value("rdg.example"), "rdg.example");
+    }
+
+    #[test]
+    fn gateway_cookies_replace_and_replay_values() {
+        let mut cookies = GatewayCookies::default();
+        let mut headers = http::HeaderMap::new();
+        headers.append(
+            hyper::header::SET_COOKIE,
+            "ARRAffinity=first; Path=/".parse().expect("header"),
+        );
+        headers.append(hyper::header::SET_COOKIE, "route=west; Secure".parse().expect("header"));
+        cookies.capture(&headers);
+        assert_eq!(cookies.header_value().as_deref(), Some("ARRAffinity=first; route=west"));
+
+        let mut replacement = http::HeaderMap::new();
+        replacement.append(
+            hyper::header::SET_COOKIE,
+            "ARRAffinity=second; Path=/".parse().expect("header"),
+        );
+        cookies.capture(&replacement);
+        assert_eq!(
+            cookies.header_value().as_deref(),
+            Some("ARRAffinity=second; route=west")
+        );
+    }
+
+    #[test]
+    fn proxy_url_builds_basic_authorization() {
+        let GatewayProxy::HttpConnect {
+            authority,
+            authorization,
+        } = proxy_from_url("http://proxy-user:proxy-pass@proxy.example:8080").expect("proxy")
+        else {
+            panic!("expected HTTP CONNECT proxy");
+        };
+        assert_eq!(authority, "proxy.example:8080");
+        assert_eq!(authorization.as_deref(), Some("Basic cHJveHktdXNlcjpwcm94eS1wYXNz"));
+    }
+
+    #[test]
+    fn socks_proxy_url_preserves_credentials() {
+        let GatewayProxy::Socks5 { authority, credentials } =
+            proxy_from_url("socks5h://proxy-user:proxy-pass@proxy.example:1080").expect("proxy")
+        else {
+            panic!("expected SOCKS5 proxy");
+        };
+        assert_eq!(authority, "proxy.example:1080");
+        assert_eq!(credentials, Some(("proxy-user".to_owned(), "proxy-pass".to_owned())));
+    }
+
+    #[test]
+    fn no_proxy_matches_exact_hosts_and_suffixes() {
+        assert!(no_proxy_matches("rdg.example.test", "example.test"));
+        assert!(no_proxy_matches("rdg.example.test", ".example.test"));
+        assert!(no_proxy_matches("rdg.example.test", "rdg.example.test"));
+        assert!(!no_proxy_matches("not-example.test", "example.test"));
+    }
+}

--- a/crates/ironrdp-mstsgu/src/proto.rs
+++ b/crates/ironrdp-mstsgu/src/proto.rs
@@ -8,9 +8,13 @@ bitflags! {
     /// 2.2.5.3.2 HTTP_EXTENDED_AUTH Enumeration
     #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub(crate) struct HttpExtendedAuth: u16 {
-        const HTTP_EXTENDED_AUTH_NONE = 0x01;
+        /// No extended authentication.
+        const HTTP_EXTENDED_AUTH_NONE = 0x00;
+        /// Smart-card authentication.
         const HTTP_EXTENDED_AUTH_SC = 0x01;
+        /// Pluggable authentication and authorization (PAA).
         const HTTP_EXTENDED_AUTH_PAA = 0x02;
+        /// SSPI NTLM extended authentication.
         const HTTP_EXTENDED_AUTH_SSPI_NTLM = 0x04;
     }
 }
@@ -31,6 +35,7 @@ pub(crate) enum PktTy {
     ChannelCreate = 0x08,
     ChannelResp = 0x09,
     ChannelClose = 0x10,
+    ChannelCloseResponse = 0x11,
     Data = 0x0A,
     ServiceMessage = 0x0B,
     ReauthMessage = 0x0C,
@@ -66,6 +71,7 @@ impl TryFrom<u16> for PktTy {
             0x0C => PktTy::ReauthMessage,
             0x0D => PktTy::Keepalive,
             0x10 => PktTy::ChannelClose,
+            0x11 => PktTy::ChannelCloseResponse,
             _ => return Err(()),
         };
         Ok(mapped)
@@ -81,7 +87,7 @@ pub(crate) struct PktHdr {
 }
 
 impl PktHdr {
-    const FIXED_PART_SIZE: usize = 4 /* ty */ + 2 /* _reserved */ + 2 /* length */;
+    pub(crate) const FIXED_PART_SIZE: usize = 2 /* ty */ + 2 /* _reserved */ + 4 /* length */;
 }
 
 impl Encode for PktHdr {
@@ -163,11 +169,44 @@ pub(crate) struct HandshakeRespPkt {
     pub ver_major: u8,
     pub ver_minor: u8,
     pub server_version: u16,
-    pub _extended_auth: HttpExtendedAuth,
+    pub extended_auth: HttpExtendedAuth,
 }
 
 impl HandshakeRespPkt {
-    const FIXED_PART_SIZE: usize = 4 /* error_code */ + 1 /* ver_major */ + 1 /* ver_minor */ + 2 /* server_auth */ + 1 /*extended_auth*/;
+    const FIXED_PART_SIZE: usize = 4 /* error_code */
+        + 1 /* ver_major */
+        + 1 /* ver_minor */
+        + 2 /* server_version */
+        + 2 /* extended_auth */;
+}
+
+impl Encode for HandshakeRespPkt {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+
+        let hdr = PktHdr {
+            ty: PktTy::HandshakeResp,
+            length: cast_int!("packet length", self.size())?,
+            ..PktHdr::default()
+        };
+        hdr.encode(dst)?;
+
+        dst.write_u32(self.error_code);
+        dst.write_u8(self.ver_major);
+        dst.write_u8(self.ver_minor);
+        dst.write_u16(self.server_version);
+        dst.write_u16(self.extended_auth.bits());
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "HTTP_HANDSHAKE_RESPONSE_PACKET"
+    }
+
+    fn size(&self) -> usize {
+        PktHdr::FIXED_PART_SIZE + Self::FIXED_PART_SIZE
+    }
 }
 
 impl Decode<'_> for HandshakeRespPkt {
@@ -179,14 +218,14 @@ impl Decode<'_> for HandshakeRespPkt {
             ver_major: src.read_u8(),
             ver_minor: src.read_u8(),
             server_version: src.read_u16(),
-            _extended_auth: {
-                let raw = src.read_u16();
-                HttpExtendedAuth::from_bits(raw)
-                    .ok_or_else(|| unsupported_value_err("HandshakeResp", "extended_auth", format!("0x{raw:x}")))?
-            },
+            // Truncate unknown bits so newer gateways remain interoperable.
+            extended_auth: HttpExtendedAuth::from_bits_truncate(src.read_u16()),
         })
     }
 }
+
+/// 2.2.5.3.6 `HTTP_TUNNEL_PACKET_FIELD_REAUTH`.
+const HTTP_TUNNEL_PACKET_FIELD_REAUTH: u16 = 0x2;
 
 /// 2.2.10.18 HTTP_TUNNEL_PACKET
 #[derive(Default)]
@@ -194,6 +233,8 @@ pub(crate) struct TunnelReqPkt {
     pub caps: u32,
     pub fields_present: u16,
     pub _reserved: u16,
+    /// Tunnel context from an `HTTP_REAUTH_MESSAGE` for a secondary connection.
+    pub reauth_tunnel_context: Option<u64>,
 }
 
 impl Encode for TunnelReqPkt {
@@ -207,9 +248,18 @@ impl Encode for TunnelReqPkt {
         };
         hdr.encode(dst)?;
 
+        let fields_present = self.fields_present
+            | if self.reauth_tunnel_context.is_some() {
+                HTTP_TUNNEL_PACKET_FIELD_REAUTH
+            } else {
+                Default::default()
+            };
         dst.write_u32(self.caps);
-        dst.write_u16(self.fields_present);
+        dst.write_u16(fields_present);
         dst.write_u16(self._reserved);
+        if let Some(tunnel_context) = self.reauth_tunnel_context {
+            dst.write_u64(tunnel_context);
+        }
         Ok(())
     }
 
@@ -218,7 +268,7 @@ impl Encode for TunnelReqPkt {
     }
 
     fn size(&self) -> usize {
-        PktHdr::default().size() + 8
+        PktHdr::default().size() + 8 + self.reauth_tunnel_context.map_or(0, |_| 8)
     }
 }
 
@@ -286,6 +336,66 @@ impl TunnelRespPkt {
     const FIXED_PART_SIZE: usize = 2 /* server_version */ + 4 /* status_code */ + 2 /* fields_present */ + 2 /* reserved */;
 }
 
+impl Encode for TunnelRespPkt {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+
+        let hdr = PktHdr {
+            ty: PktTy::TunnelResp,
+            length: cast_int!("packet length", self.size())?,
+            ..PktHdr::default()
+        };
+        hdr.encode(dst)?;
+
+        dst.write_u16(self._server_version);
+        dst.write_u32(self.status_code);
+        let mut fields_present = self.fields_present;
+        fields_present |= u16::from(self.tunnel_id.is_some());
+        fields_present |= u16::from(self.caps_flags.is_some()) << 1;
+        fields_present |= u16::from(self.nonce.is_some()) << 2;
+        fields_present |= u16::from(!self.consent_msg.is_empty()) << 4;
+        dst.write_u16(fields_present);
+        dst.write_u16(self._reserved);
+
+        if let Some(tunnel_id) = self.tunnel_id {
+            dst.write_u32(tunnel_id);
+        }
+        if let Some(caps_flags) = self.caps_flags {
+            dst.write_u32(caps_flags);
+        }
+        if let Some(nonce) = self.nonce {
+            dst.write_u16(nonce);
+            let cert_len: u16 = cast_int!("server cert length", self.server_cert.len())?;
+            dst.write_u16(cert_len);
+            dst.write_slice(&self.server_cert);
+        }
+        if !self.consent_msg.is_empty() {
+            let consent_len: u16 = cast_int!("consent message length", self.consent_msg.len())?;
+            dst.write_u16(consent_len);
+            dst.write_slice(&self.consent_msg);
+        }
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "HTTP_TUNNEL_RESPONSE"
+    }
+
+    fn size(&self) -> usize {
+        PktHdr::FIXED_PART_SIZE
+            + Self::FIXED_PART_SIZE
+            + self.tunnel_id.map_or(0, |_| 4)
+            + self.caps_flags.map_or(0, |_| 4)
+            + self.nonce.map_or(0, |_| 4 + self.server_cert.len())
+            + if self.consent_msg.is_empty() {
+                0
+            } else {
+                2 + self.consent_msg.len()
+            }
+    }
+}
+
 impl Decode<'_> for TunnelRespPkt {
     fn decode(src: &mut ReadCursor<'_>) -> ironrdp_core::DecodeResult<Self> {
         ensure_fixed_part_size!(in: src);
@@ -325,10 +435,23 @@ impl Decode<'_> for TunnelRespPkt {
 }
 
 /// 2.2.10.7 HTTP_EXTENDED_AUTH_PACKET Structure
-#[expect(dead_code, reason = "defined for completeness per spec; not yet used")]
 pub(crate) struct ExtendedAuthPkt {
-    error_code: u32,
-    blob: Vec<u8>,
+    pub error_code: u32,
+    pub blob: Vec<u8>,
+}
+
+impl ExtendedAuthPkt {
+    pub(crate) fn client_blob(blob: Vec<u8>) -> Self {
+        Self { error_code: 0, blob }
+    }
+
+    pub(crate) fn error_code(&self) -> u32 {
+        self.error_code
+    }
+
+    pub(crate) fn blob(&self) -> &[u8] {
+        &self.blob
+    }
 }
 
 impl Encode for ExtendedAuthPkt {
@@ -373,10 +496,20 @@ impl Decode<'_> for ExtendedAuthPkt {
     }
 }
 
+/// 2.2.5.3.4 HTTP_TUNNEL_AUTH_FIELDS_PRESENT_FLAGS
+pub(crate) const HTTP_TUNNEL_AUTH_FIELD_SOH: u16 = 0x1;
+
+/// 2.2.5.3.5 HTTP_TUNNEL_AUTH_RESPONSE_FIELDS_PRESENT_FLAGS
+pub(crate) const HTTP_TUNNEL_AUTH_RESPONSE_FIELD_REDIR_FLAGS: u16 = 0x1;
+pub(crate) const HTTP_TUNNEL_AUTH_RESPONSE_FIELD_IDLE_TIMEOUT: u16 = 0x2;
+pub(crate) const HTTP_TUNNEL_AUTH_RESPONSE_FIELD_SOH_RESPONSE: u16 = 0x4;
+
 /// 2.2.10.14 HTTP_TUNNEL_AUTH_PACKET Structure
 pub(crate) struct TunnelAuthPkt {
     pub fields_present: u16,
     pub client_name: String,
+    /// Optional statement-of-health blob ([MS-TSGU] 2.2.10.15).
+    pub statement_of_health: Option<Vec<u8>>,
 }
 
 impl Encode for TunnelAuthPkt {
@@ -390,7 +523,11 @@ impl Encode for TunnelAuthPkt {
         };
         hdr.encode(dst)?;
 
-        dst.write_u16(self.fields_present);
+        let mut fields_present = self.fields_present;
+        if self.statement_of_health.is_some() {
+            fields_present |= HTTP_TUNNEL_AUTH_FIELD_SOH;
+        }
+        dst.write_u16(fields_present);
 
         let client_name_len = self.client_name.encode_utf16().count() * 2 + 2; // Add 2 to account for a null terminator (0x0000).
         let client_name_len: u16 = cast_int!("client name length", client_name_len)?;
@@ -402,6 +539,13 @@ impl Encode for TunnelAuthPkt {
 
         dst.write_u16(0);
 
+        if let Some(soh) = &self.statement_of_health {
+            // HTTP_byte_BLOB: cbLen (u16) + blob
+            let soh_len: u16 = cast_int!("statement of health length", soh.len())?;
+            dst.write_u16(soh_len);
+            dst.write_slice(soh);
+        }
+
         Ok(())
     }
 
@@ -410,16 +554,27 @@ impl Encode for TunnelAuthPkt {
     }
 
     fn size(&self) -> usize {
-        PktHdr::default().size() + 4 + 2 * (self.client_name.len() + 1)
+        let soh_size = self
+            .statement_of_health
+            .as_ref()
+            .map(|b| 2 /* cbLen */ + b.len())
+            .unwrap_or(0);
+        PktHdr::default().size() + 4 + 2 * (self.client_name.len() + 1) + soh_size
     }
 }
 
-/// 2.2.10.16 HTTP_TUNNEL_AUTH_RESPONSE Structure
-#[derive(Debug)]
+/// 2.2.10.16 HTTP_TUNNEL_AUTH_RESPONSE Structure (+ optional 2.2.10.17)
+#[derive(Debug, Default)]
 pub(crate) struct TunnelAuthRespPkt {
-    error_code: u32,
-    _fields_present: u16,
-    _reserved: u16,
+    pub(crate) error_code: u32,
+    pub(crate) fields_present: u16,
+    pub(crate) _reserved: u16,
+    /// Device redirection policy flags from the gateway ([MS-TSGU] 2.2.5.3.7).
+    pub(crate) redir_flags: Option<u32>,
+    /// Idle timeout in minutes when advertised by the gateway.
+    pub(crate) idle_timeout_minutes: Option<u32>,
+    /// Optional SoH response blob (skipped / retained for diagnostics).
+    pub(crate) soh_response: Option<Vec<u8>>,
 }
 
 impl TunnelAuthRespPkt {
@@ -430,15 +585,80 @@ impl TunnelAuthRespPkt {
     }
 }
 
+impl Encode for TunnelAuthRespPkt {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+
+        let hdr = PktHdr {
+            ty: PktTy::TunnelAuthResponse,
+            length: cast_int!("packet length", self.size())?,
+            ..PktHdr::default()
+        };
+        hdr.encode(dst)?;
+
+        dst.write_u32(self.error_code);
+        let mut fields_present = self.fields_present;
+        fields_present |= u16::from(self.redir_flags.is_some());
+        fields_present |= u16::from(self.idle_timeout_minutes.is_some()) << 1;
+        fields_present |= u16::from(self.soh_response.is_some()) << 2;
+        dst.write_u16(fields_present);
+        dst.write_u16(self._reserved);
+
+        if let Some(redir_flags) = self.redir_flags {
+            dst.write_u32(redir_flags);
+        }
+        if let Some(idle_timeout_minutes) = self.idle_timeout_minutes {
+            dst.write_u32(idle_timeout_minutes);
+        }
+        if let Some(soh_response) = &self.soh_response {
+            let soh_len: u16 = cast_int!("SoH response length", soh_response.len())?;
+            dst.write_u16(soh_len);
+            dst.write_slice(soh_response);
+        }
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "HTTP_TUNNEL_AUTH_RESPONSE"
+    }
+
+    fn size(&self) -> usize {
+        PktHdr::FIXED_PART_SIZE
+            + Self::FIXED_PART_SIZE
+            + self.redir_flags.map_or(0, |_| 4)
+            + self.idle_timeout_minutes.map_or(0, |_| 4)
+            + self.soh_response.as_ref().map_or(0, |soh| 2 + soh.len())
+    }
+}
+
 impl Decode<'_> for TunnelAuthRespPkt {
     fn decode(src: &mut ReadCursor<'_>) -> ironrdp_core::DecodeResult<Self> {
         ensure_fixed_part_size!(in: src);
 
-        Ok(TunnelAuthRespPkt {
+        let mut resp = TunnelAuthRespPkt {
             error_code: src.read_u32(),
-            _fields_present: src.read_u16(),
+            fields_present: src.read_u16(),
             _reserved: src.read_u16(),
-        })
+            ..TunnelAuthRespPkt::default()
+        };
+
+        if resp.fields_present & HTTP_TUNNEL_AUTH_RESPONSE_FIELD_REDIR_FLAGS != 0 {
+            ensure_size!(in: src, size: 4);
+            resp.redir_flags = Some(src.read_u32());
+        }
+        if resp.fields_present & HTTP_TUNNEL_AUTH_RESPONSE_FIELD_IDLE_TIMEOUT != 0 {
+            ensure_size!(in: src, size: 4);
+            resp.idle_timeout_minutes = Some(src.read_u32());
+        }
+        if resp.fields_present & HTTP_TUNNEL_AUTH_RESPONSE_FIELD_SOH_RESPONSE != 0 {
+            ensure_size!(in: src, size: 2);
+            let len = usize::from(src.read_u16());
+            ensure_size!(in: src, size: len);
+            resp.soh_response = Some(src.read_slice(len).to_vec());
+        }
+
+        Ok(resp)
     }
 }
 
@@ -492,14 +712,14 @@ impl Encode for ChannelPkt {
 /// 2.2.10.4 HTTP_CHANNEL_RESPONSE
 #[derive(Default, Debug)]
 pub(crate) struct ChannelResp {
-    error_code: u32,
-    fields_present: u16,
-    _reserved: u16,
+    pub(crate) error_code: u32,
+    pub(crate) fields_present: u16,
+    pub(crate) _reserved: u16,
 
     /// 2.2.10.5 HTTP_CHANNEL_RESPONSE_OPTIONAL
-    chan_id: Option<u32>,
-    udp_port: u16,
-    authn_cookie: Vec<u8>,
+    pub(crate) chan_id: Option<u32>,
+    pub(crate) udp_port: u16,
+    pub(crate) authn_cookie: Vec<u8>,
 }
 
 impl ChannelResp {
@@ -507,6 +727,77 @@ impl ChannelResp {
 
     pub(crate) fn error_code(&self) -> u32 {
         self.error_code
+    }
+
+    /// Successful channel response with a channel id, for test harnesses.
+    #[cfg(test)]
+    pub(crate) fn success(chan_id: u32) -> Self {
+        Self {
+            error_code: 0,
+            chan_id: Some(chan_id),
+            ..ChannelResp::default()
+        }
+    }
+
+    /// UDP port for a future RDG-UDP side channel, when the gateway supplies one.
+    pub(crate) fn udp_port(&self) -> u16 {
+        self.udp_port
+    }
+
+    /// Authentication cookie for RDG-UDP, when present.
+    pub(crate) fn authn_cookie(&self) -> &[u8] {
+        &self.authn_cookie
+    }
+}
+
+impl Encode for ChannelResp {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+
+        let hdr = PktHdr {
+            ty: PktTy::ChannelResp,
+            length: cast_int!("packet length", self.size())?,
+            ..PktHdr::default()
+        };
+        hdr.encode(dst)?;
+
+        dst.write_u32(self.error_code);
+        let mut fields_present = self.fields_present;
+        fields_present |= u16::from(self.chan_id.is_some());
+        fields_present |= u16::from(self.udp_port != 0) << 1;
+        fields_present |= u16::from(!self.authn_cookie.is_empty()) << 2;
+        dst.write_u16(fields_present);
+        dst.write_u16(self._reserved);
+
+        if let Some(chan_id) = self.chan_id {
+            dst.write_u32(chan_id);
+        }
+        if self.udp_port != 0 {
+            dst.write_u16(self.udp_port);
+        }
+        if !self.authn_cookie.is_empty() {
+            let cookie_len: u16 = cast_int!("authn cookie length", self.authn_cookie.len())?;
+            dst.write_u16(cookie_len);
+            dst.write_slice(&self.authn_cookie);
+        }
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "HTTP_CHANNEL_RESPONSE"
+    }
+
+    fn size(&self) -> usize {
+        PktHdr::FIXED_PART_SIZE
+            + Self::FIXED_PART_SIZE
+            + self.chan_id.map_or(0, |_| 4)
+            + if self.udp_port == 0 { 0 } else { 2 }
+            + if self.authn_cookie.is_empty() {
+                0
+            } else {
+                2 + self.authn_cookie.len()
+            }
     }
 }
 
@@ -597,5 +888,549 @@ impl Encode for KeepalivePkt {
 
     fn size(&self) -> usize {
         PktHdr::default().size()
+    }
+}
+
+/// 2.2.10.13 HTTP_SERVICE_MESSAGE Structure (body only; header stripped).
+#[derive(Debug)]
+pub(crate) struct ServiceMessagePkt {
+    pub message: String,
+}
+
+impl Encode for ServiceMessagePkt {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+
+        let hdr = PktHdr {
+            ty: PktTy::ServiceMessage,
+            length: cast_int!("packet length", self.size())?,
+            ..PktHdr::default()
+        };
+        hdr.encode(dst)?;
+
+        let utf16_len = self.message.encode_utf16().count() * 2 + 2 /* NUL */;
+        let utf16_len = cast_int!("service message length", utf16_len)?;
+        dst.write_u16(utf16_len);
+        for c in self.message.encode_utf16() {
+            dst.write_u16(c);
+        }
+        dst.write_u16(0);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "HTTP_SERVICE_MESSAGE"
+    }
+
+    fn size(&self) -> usize {
+        PktHdr::FIXED_PART_SIZE + 2 + 2 * (self.message.encode_utf16().count() + 1)
+    }
+}
+
+impl Decode<'_> for ServiceMessagePkt {
+    fn decode(src: &mut ReadCursor<'_>) -> ironrdp_core::DecodeResult<Self> {
+        ensure_size!(in: src, size: 2);
+        let cb_message = usize::from(src.read_u16());
+        ensure_size!(in: src, size: cb_message);
+        let raw = src.read_slice(cb_message);
+        let message = String::from_utf16_lossy(
+            &raw.chunks_exact(2)
+                .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                .collect::<Vec<_>>(),
+        )
+        .trim_end_matches('\0')
+        .to_owned();
+        Ok(Self { message })
+    }
+}
+
+/// 2.2.10.12 HTTP_REAUTH_MESSAGE Structure (body only; header stripped).
+#[derive(Debug)]
+pub(crate) struct ReauthMessagePkt {
+    pub reauth_tunnel_context: u64,
+}
+
+impl Encode for ReauthMessagePkt {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+
+        let hdr = PktHdr {
+            ty: PktTy::ReauthMessage,
+            length: cast_int!("packet length", self.size())?,
+            ..PktHdr::default()
+        };
+        hdr.encode(dst)?;
+
+        dst.write_u64(self.reauth_tunnel_context);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "HTTP_REAUTH_MESSAGE"
+    }
+
+    fn size(&self) -> usize {
+        PktHdr::FIXED_PART_SIZE + 8
+    }
+}
+
+impl Decode<'_> for ReauthMessagePkt {
+    fn decode(src: &mut ReadCursor<'_>) -> ironrdp_core::DecodeResult<Self> {
+        ensure_size!(in: src, size: 8);
+        Ok(Self {
+            reauth_tunnel_context: src.read_u64(),
+        })
+    }
+}
+
+/// 2.2.10.15 HTTP_CLOSE_PACKET Structure (body only; header stripped).
+#[derive(Debug)]
+pub(crate) struct ChannelClosePkt {
+    pub status_code: u32,
+}
+
+impl Encode for ChannelClosePkt {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+
+        let hdr = PktHdr {
+            ty: PktTy::ChannelClose,
+            length: cast_int!("packet length", self.size())?,
+            ..PktHdr::default()
+        };
+        hdr.encode(dst)?;
+
+        dst.write_u32(self.status_code);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "HTTP_CLOSE_PACKET"
+    }
+
+    fn size(&self) -> usize {
+        PktHdr::FIXED_PART_SIZE + 4
+    }
+}
+
+impl Decode<'_> for ChannelClosePkt {
+    fn decode(src: &mut ReadCursor<'_>) -> ironrdp_core::DecodeResult<Self> {
+        ensure_size!(in: src, size: 4);
+        Ok(Self {
+            status_code: src.read_u32(),
+        })
+    }
+}
+
+/// Human-readable label for common MS-TSGU HRESULTs ([MS-TSGU] 2.2.6).
+pub(crate) fn gateway_code_label(code: u32) -> Option<&'static str> {
+    // Normalize success-style low-word codes that may arrive without the FACILITY bit.
+    let c = code;
+    Some(match c {
+        0x0000_0000 => "ERROR_SUCCESS",
+        0x0000_0005 => "ERROR_ACCESS_DENIED",
+        0x0000_00A0 => "ERROR_BAD_ARGUMENTS",
+        0x0000_04CA => "ERROR_GRACEFUL_DISCONNECT",
+        0x0000_04D4 => "E_PROXY_CONNECTIONABORTED",
+        0x0000_59D8 | 0x8007_59D8 => "E_PROXY_INTERNALERROR",
+        0x0000_59DA | 0x8007_59DA => "E_PROXY_RAP_ACCESSDENIED",
+        0x0000_59DB | 0x8007_59DB => "E_PROXY_NAP_ACCESSDENIED",
+        0x0000_59DD => "E_PROXY_TS_CONNECTFAILED",
+        0x0000_59DF | 0x8007_59DF => "E_PROXY_ALREADYDISCONNECTED",
+        0x0000_59E6 => "E_PROXY_MAXCONNECTIONSREACHED",
+        0x0000_59E8 => "E_PROXY_NOTSUPPORTED",
+        0x0000_59E9 | 0x8007_59E9 => "E_PROXY_CAPABILITYMISMATCH",
+        0x0000_59ED | 0x8007_59ED => "E_PROXY_QUARANTINE_ACCESSDENIED",
+        0x0000_59EE | 0x8007_59EE => "E_PROXY_NOCERTAVAILABLE",
+        0x0000_59F6 => "E_PROXY_SESSIONTIMEOUT",
+        0x0000_59F7 | 0x8007_59F7 => "E_PROXY_COOKIE_BADPACKET",
+        0x0000_59F8 | 0x8007_59F8 => "E_PROXY_COOKIE_AUTHENTICATION_ACCESS_DENIED",
+        0x0000_59F9 | 0x8007_59F9 => "E_PROXY_UNSUPPORTED_AUTHENTICATION_METHOD",
+        0x0000_59FA => "E_PROXY_REAUTH_AUTHN_FAILED",
+        0x0000_59FB => "E_PROXY_REAUTH_CAP_FAILED",
+        0x0000_59FC => "E_PROXY_REAUTH_RAP_FAILED",
+        0x0000_59FD => "E_PROXY_SDR_NOT_SUPPORTED_BY_TS",
+        0x0000_5A00 => "E_PROXY_REAUTH_NAP_FAILED",
+        0x8009_030C => "SEC_E_LOGON_DENIED",
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn encode_to_vec(payload: &impl Encode) -> Vec<u8> {
+        let mut buf = vec![0u8; payload.size()];
+        let mut cur = WriteCursor::new(&mut buf);
+        payload.encode(&mut cur).expect("encode");
+        assert_eq!(cur.pos(), payload.size());
+        buf
+    }
+
+    #[test]
+    fn http_extended_auth_none_is_zero() {
+        assert_eq!(HttpExtendedAuth::HTTP_EXTENDED_AUTH_NONE.bits(), 0x00);
+        assert_eq!(HttpExtendedAuth::HTTP_EXTENDED_AUTH_SC.bits(), 0x01);
+        assert_eq!(HttpExtendedAuth::HTTP_EXTENDED_AUTH_PAA.bits(), 0x02);
+        assert_eq!(HttpExtendedAuth::HTTP_EXTENDED_AUTH_SSPI_NTLM.bits(), 0x04);
+        assert_eq!(HttpExtendedAuth::empty().bits(), 0x00);
+    }
+
+    #[test]
+    fn pkt_hdr_size_matches_wire_layout() {
+        assert_eq!(PktHdr::FIXED_PART_SIZE, 8);
+        let hdr = PktHdr {
+            ty: PktTy::Keepalive,
+            _reserved: 0,
+            length: 8,
+        };
+        let bytes = encode_to_vec(&hdr);
+        assert_eq!(bytes, [0x0d, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00]);
+
+        let mut cur = ReadCursor::new(&bytes);
+        let decoded = PktHdr::decode(&mut cur).expect("decode header");
+        assert_eq!(decoded.ty, PktTy::Keepalive);
+        assert_eq!(decoded.length, 8);
+        assert!(cur.eof());
+    }
+
+    #[test]
+    fn handshake_req_encode_layout() {
+        let pkt = HandshakeReqPkt {
+            ver_major: 1,
+            ver_minor: 0,
+            client_version: 0,
+            extended_auth: HttpExtendedAuth::HTTP_EXTENDED_AUTH_NONE,
+        };
+        let bytes = encode_to_vec(&pkt);
+        assert_eq!(bytes.len(), 14);
+        assert_eq!(&bytes[..8], &[0x01, 0x00, 0x00, 0x00, 0x0e, 0x00, 0x00, 0x00]);
+        assert_eq!(&bytes[8..], &[0x01, 0x00, 0x00, 0x00, 0x00, 0x00]);
+    }
+
+    #[test]
+    fn handshake_resp_decode_layout() {
+        // HTTP_PACKET_HEADER is stripped before HandshakeRespPkt::decode in the client.
+        let body = [
+            0x00, 0x00, 0x00, 0x00, // error_code
+            0x01, // ver_major
+            0x00, // ver_minor
+            0x00, 0x00, // server_version
+            0x00, 0x00, // extended_auth = NONE
+        ];
+        assert_eq!(body.len(), HandshakeRespPkt::FIXED_PART_SIZE);
+
+        let mut cur = ReadCursor::new(&body);
+        let resp = HandshakeRespPkt::decode(&mut cur).expect("decode handshake response");
+        assert_eq!(resp.error_code, 0);
+        assert_eq!(resp.ver_major, 1);
+        assert_eq!(resp.ver_minor, 0);
+        assert_eq!(resp.server_version, 0);
+        assert_eq!(resp.extended_auth, HttpExtendedAuth::HTTP_EXTENDED_AUTH_NONE);
+        assert!(cur.eof());
+    }
+
+    #[test]
+    fn extended_auth_pkt_roundtrip() {
+        let pkt = ExtendedAuthPkt::client_blob(vec![0x4e, 0x54, 0x4c, 0x4d]);
+        let bytes = encode_to_vec(&pkt);
+        let mut cur = ReadCursor::new(&bytes);
+        let hdr = PktHdr::decode(&mut cur).expect("header");
+        assert_eq!(hdr.ty, PktTy::ExtendedAuth);
+        let decoded = ExtendedAuthPkt::decode(&mut cur).expect("body");
+        assert_eq!(decoded.error_code(), 0);
+        assert_eq!(decoded.blob(), &[0x4e, 0x54, 0x4c, 0x4d]);
+        assert!(cur.eof());
+    }
+
+    #[test]
+    fn reauth_and_service_message_decode() {
+        let reauth_body = 0x1122_3344_5566_7788u64.to_le_bytes();
+        let mut cur = ReadCursor::new(&reauth_body);
+        let reauth = ReauthMessagePkt::decode(&mut cur).expect("reauth");
+        assert_eq!(reauth.reauth_tunnel_context, 0x1122_3344_5566_7788);
+
+        // "OK\0" as UTF-16LE
+        let service_body = [0x06, 0x00, b'O', 0x00, b'K', 0x00, 0x00, 0x00];
+        let mut cur = ReadCursor::new(&service_body);
+        let service = ServiceMessagePkt::decode(&mut cur).expect("service");
+        assert_eq!(service.message, "OK");
+    }
+
+    #[test]
+    fn tunnel_request_encodes_reauth_context() {
+        let bytes = encode_to_vec(&TunnelReqPkt {
+            caps: HttpCapsTy::Reauth.as_u32(),
+            fields_present: 0,
+            _reserved: 0,
+            reauth_tunnel_context: Some(0x1122_3344_5566_7788),
+        });
+        assert_eq!(bytes.len(), PktHdr::default().size() + 16);
+        assert_eq!(
+            u16::from_le_bytes(bytes[0..2].try_into().unwrap()),
+            PktTy::TunnelCreate.as_u16()
+        );
+        assert_eq!(
+            u16::from_le_bytes(bytes[12..14].try_into().unwrap()),
+            HTTP_TUNNEL_PACKET_FIELD_REAUTH
+        );
+        assert_eq!(
+            u64::from_le_bytes(bytes[16..24].try_into().unwrap()),
+            0x1122_3344_5566_7788
+        );
+    }
+
+    #[test]
+    fn gateway_code_label_known() {
+        assert_eq!(gateway_code_label(0), Some("ERROR_SUCCESS"));
+        assert_eq!(gateway_code_label(0x8007_59DA), Some("E_PROXY_RAP_ACCESSDENIED"));
+        assert_eq!(gateway_code_label(0xDEAD_BEEF), None);
+    }
+
+    #[test]
+    fn channel_pkt_encodes_port_and_resources() {
+        let pkt = ChannelPkt {
+            resources: vec!["rdp.example".to_owned()],
+            port: 2179,
+            protocol: 3,
+        };
+        let bytes = encode_to_vec(&pkt);
+
+        // Header type ChannelCreate = 0x08, length = full packet size.
+        assert_eq!(&bytes[..2], &[0x08, 0x00]);
+        let length = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
+        assert_eq!(usize::try_from(length).unwrap(), bytes.len());
+
+        let body = &bytes[8..];
+        assert_eq!(body[0], 1); // resources_count
+        assert_eq!(body[1], 0); // alt_names
+        assert_eq!(u16::from_le_bytes(body[2..4].try_into().unwrap()), 2179);
+        assert_eq!(u16::from_le_bytes(body[4..6].try_into().unwrap()), 3);
+
+        // resource name length is UTF-16 bytes including NUL.
+        let name_len = usize::from(u16::from_le_bytes(body[6..8].try_into().unwrap()));
+        assert_eq!(name_len, ("rdp.example".len() + 1) * 2);
+        assert_eq!(body.len(), 6 + 2 + name_len);
+    }
+
+    #[test]
+    fn channel_resp_decode_error_code() {
+        let body = [
+            0x05, 0x00, 0x00, 0x80, // error_code (HRESULT-style)
+            0x00, 0x00, // fields_present
+            0x00, 0x00, // reserved
+        ];
+        let mut cur = ReadCursor::new(&body);
+        let resp = ChannelResp::decode(&mut cur).expect("decode channel response");
+        assert_eq!(resp.error_code(), 0x8000_0005);
+        assert!(cur.eof());
+    }
+
+    #[test]
+    fn data_pkt_roundtrip() {
+        let payload = b"hello-rdg";
+        let pkt = DataPkt { data: payload };
+        let bytes = encode_to_vec(&pkt);
+
+        let mut cur = ReadCursor::new(&bytes);
+        let hdr = PktHdr::decode(&mut cur).expect("header");
+        assert_eq!(hdr.ty, PktTy::Data);
+        assert_eq!(usize::try_from(hdr.length).unwrap(), bytes.len());
+
+        let decoded = DataPkt::decode(&mut cur).expect("data");
+        assert_eq!(decoded.data, payload);
+        assert!(cur.eof());
+    }
+
+    #[test]
+    fn keepalive_encode() {
+        let bytes = encode_to_vec(&KeepalivePkt);
+        assert_eq!(bytes, [0x0d, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00]);
+    }
+
+    #[test]
+    fn tunnel_auth_pkt_encodes_optional_soh() {
+        let pkt = TunnelAuthPkt {
+            fields_present: 0,
+            client_name: "PC1".to_owned(),
+            statement_of_health: Some(vec![0xaa, 0xbb]),
+        };
+        let bytes = encode_to_vec(&pkt);
+        let mut cur = ReadCursor::new(&bytes);
+        let hdr = PktHdr::decode(&mut cur).expect("header");
+        assert_eq!(hdr.ty, PktTy::TunnelAuth);
+        assert_eq!(usize::try_from(hdr.length).unwrap(), bytes.len());
+
+        let fields = cur.read_u16();
+        assert_eq!(fields & HTTP_TUNNEL_AUTH_FIELD_SOH, HTTP_TUNNEL_AUTH_FIELD_SOH);
+        let name_len = usize::from(cur.read_u16());
+        assert_eq!(name_len, ("PC1".len() + 1) * 2);
+        cur.read_slice(name_len);
+        let soh_len = usize::from(cur.read_u16());
+        assert_eq!(soh_len, 2);
+        assert_eq!(cur.read_slice(2), &[0xaa, 0xbb]);
+        assert!(cur.eof());
+    }
+
+    #[test]
+    fn tunnel_auth_resp_decodes_optional_fields() {
+        let mut body = vec![
+            0x00, 0x00, 0x00, 0x00, // error_code
+            0x07, 0x00, // fields: redir | idle | soh
+            0x00, 0x00, // reserved
+            0x00, 0x00, 0x00, 0x80, // redir_flags = HTTP_TUNNEL_REDIR_ENABLE_ALL
+            0x0f, 0x00, 0x00, 0x00, // idle_timeout = 15 minutes
+            0x03, 0x00, // soh_response cbLen
+            0x01, 0x02, 0x03,
+        ];
+        let mut cur = ReadCursor::new(&body);
+        let resp = TunnelAuthRespPkt::decode(&mut cur).expect("decode");
+        assert_eq!(resp.error_code(), 0);
+        assert_eq!(resp.redir_flags, Some(0x8000_0000));
+        assert_eq!(resp.idle_timeout_minutes, Some(15));
+        assert_eq!(resp.soh_response.as_deref(), Some(&[1, 2, 3][..]));
+        assert!(cur.eof());
+
+        // Fixed-only response still works.
+        body.truncate(8);
+        body[4] = 0;
+        body[5] = 0;
+        let mut cur = ReadCursor::new(&body);
+        let resp = TunnelAuthRespPkt::decode(&mut cur).expect("fixed");
+        assert!(resp.redir_flags.is_none());
+        assert!(resp.idle_timeout_minutes.is_none());
+        assert!(resp.soh_response.is_none());
+    }
+
+    #[test]
+    fn channel_resp_decodes_udp_cookie() {
+        let body = [
+            0x00, 0x00, 0x00, 0x00, // error
+            0x06, 0x00, // fields: udp | cookie
+            0x00, 0x00, // reserved
+            0x39, 0x30, // udp_port 12345
+            0x02, 0x00, // cookie len
+            0xde, 0xad,
+        ];
+        let mut cur = ReadCursor::new(&body);
+        let resp = ChannelResp::decode(&mut cur).expect("decode");
+        assert_eq!(resp.udp_port(), 12345);
+        assert_eq!(resp.authn_cookie(), &[0xde, 0xad]);
+        assert!(cur.eof());
+    }
+
+    /// Encode the client request sequence and decode a synthetic multi-stage gateway response
+    /// stream (handshake → tunnel → tunnel auth → channel), matching the WebSocket data path.
+    #[test]
+    fn client_request_and_server_response_sequence() {
+        let handshake_req = encode_to_vec(&HandshakeReqPkt {
+            ver_major: 1,
+            ver_minor: 0,
+            client_version: 0,
+            extended_auth: HttpExtendedAuth::HTTP_EXTENDED_AUTH_SSPI_NTLM,
+        });
+        let tunnel_req = encode_to_vec(&TunnelReqPkt {
+            caps: HttpCapsTy::MessagingConsentSign.as_u32()
+                | HttpCapsTy::MessagingServiceMsg.as_u32()
+                | HttpCapsTy::IdleTimeout.as_u32()
+                | HttpCapsTy::Reauth.as_u32(),
+            fields_present: 0,
+            _reserved: 0,
+            reauth_tunnel_context: None,
+        });
+        let tunnel_auth_req = encode_to_vec(&TunnelAuthPkt {
+            fields_present: 0,
+            client_name: "IRONRDP".to_owned(),
+            statement_of_health: None,
+        });
+        let channel_req = encode_to_vec(&ChannelPkt {
+            resources: vec!["target.example".to_owned()],
+            port: 3389,
+            protocol: 3,
+        });
+
+        assert_eq!(
+            u16::from_le_bytes(handshake_req[0..2].try_into().unwrap()),
+            PktTy::HandshakeReq.as_u16()
+        );
+        assert_eq!(
+            u16::from_le_bytes(tunnel_req[0..2].try_into().unwrap()),
+            PktTy::TunnelCreate.as_u16()
+        );
+        assert_eq!(
+            u16::from_le_bytes(tunnel_auth_req[0..2].try_into().unwrap()),
+            PktTy::TunnelAuth.as_u16()
+        );
+        assert_eq!(
+            u16::from_le_bytes(channel_req[0..2].try_into().unwrap()),
+            PktTy::ChannelCreate.as_u16()
+        );
+
+        // Server responses as concatenated framed packets (header + body).
+        let mut stream = Vec::new();
+
+        // Handshake response (header + body).
+        stream.extend_from_slice(&[0x02, 0x00, 0x00, 0x00, 0x12, 0x00, 0x00, 0x00]); // HandshakeResp, len 18
+        stream.extend_from_slice(&[
+            0x00, 0x00, 0x00, 0x00, // error
+            0x01, 0x00, // ver
+            0x00, 0x00, // server_version
+            0x00, 0x00, // extended_auth NONE
+        ]);
+
+        // Tunnel response with tunnel id + caps (ConsentSign | IdleTimeout).
+        let tunnel_body = [
+            0x01, 0x00, // server_version
+            0x00, 0x00, 0x00, 0x00, // status
+            0x03, 0x00, // fields: tunnel_id | caps
+            0x00, 0x00, // reserved
+            0x11, 0x22, 0x33, 0x44, // tunnel_id
+            0x06, 0x00, 0x00, 0x00, // caps = ConsentSign | IdleTimeout
+        ];
+        let tunnel_len = u32::try_from(8 + tunnel_body.len()).unwrap();
+        stream.extend_from_slice(&[0x05, 0x00, 0x00, 0x00]); // TunnelResp
+        stream.extend_from_slice(&tunnel_len.to_le_bytes());
+        stream.extend_from_slice(&tunnel_body);
+
+        // Tunnel auth response fixed-only.
+        stream.extend_from_slice(&[0x07, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00]); // TunnelAuthResponse, len 16
+        stream.extend_from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+
+        // Channel response success.
+        stream.extend_from_slice(&[0x09, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00]); // ChannelResp, len 16
+        stream.extend_from_slice(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+
+        let mut cur = ReadCursor::new(&stream);
+
+        let hdr = PktHdr::decode(&mut cur).expect("hs hdr");
+        assert_eq!(hdr.ty, PktTy::HandshakeResp);
+        let hs = HandshakeRespPkt::decode(&mut cur).expect("hs body");
+        assert_eq!(hs.error_code, 0);
+        assert_eq!(hs.extended_auth, HttpExtendedAuth::HTTP_EXTENDED_AUTH_NONE);
+
+        let hdr = PktHdr::decode(&mut cur).expect("tunnel hdr");
+        assert_eq!(hdr.ty, PktTy::TunnelResp);
+        let tunnel = TunnelRespPkt::decode(&mut cur).expect("tunnel body");
+        assert_eq!(tunnel.status_code, 0);
+        assert_eq!(tunnel.tunnel_id, Some(0x4433_2211));
+        assert_eq!(
+            tunnel.caps_flags,
+            Some(HttpCapsTy::MessagingConsentSign.as_u32() | HttpCapsTy::IdleTimeout.as_u32())
+        );
+
+        let hdr = PktHdr::decode(&mut cur).expect("auth hdr");
+        assert_eq!(hdr.ty, PktTy::TunnelAuthResponse);
+        let auth = TunnelAuthRespPkt::decode(&mut cur).expect("auth body");
+        assert_eq!(auth.error_code(), 0);
+
+        let hdr = PktHdr::decode(&mut cur).expect("channel hdr");
+        assert_eq!(hdr.ty, PktTy::ChannelResp);
+        let channel = ChannelResp::decode(&mut cur).expect("channel body");
+        assert_eq!(channel.error_code(), 0);
+        assert!(cur.eof());
     }
 }

--- a/crates/ironrdp-mstsgu/src/rpc.rs
+++ b/crates/ironrdp-mstsgu/src/rpc.rs
@@ -1,0 +1,6558 @@
+//! DCE/RPC and raw RPC stub codecs for the MS-TSGU RPC-over-HTTP transport.
+//!
+//! This module implements the NDR32 control-operation stubs and raw data-plane
+//! stubs required by the MS-TSGU RPC-over-HTTP transport.
+
+use core::fmt;
+use core::time::Duration;
+
+use ironrdp_core::{Decode, Encode, ReadCursor, WriteCursor, ensure_fixed_part_size, ensure_size};
+use sspi::{
+    AuthIdentity, AuthIdentityBuffers, BufferType, ClientRequestFlags, CredentialUse, DataRepresentation,
+    InitializeSecurityContextResult, Ntlm, SecurityBuffer, SecurityBufferRef, SecurityStatus, Sspi as _, SspiImpl as _,
+    Username,
+};
+use uuid::Uuid;
+
+use crate::{Error, GwErrorExt as _, GwErrorKind};
+
+/// MS-TSGU RPC interface identifier.
+///
+/// [MS-TSGU] 1.9.1 / Appendix A.
+pub(crate) const TSPROXY_RPC_INTERFACE_ID: Uuid = Uuid::from_u128(0x44e265dd_7daf_42cd_8560_3cdb6e7a2729);
+
+/// `TsProxySetupReceivePipe` RPC operation number.
+///
+/// [MS-TSGU] 3.2.6 / Appendix A.
+pub(crate) const TSPROXY_SETUP_RECEIVE_PIPE_OPNUM: u16 = 8;
+
+/// `TsProxyCreateTunnel` RPC operation number.
+///
+/// [MS-TSGU] 3.2.6 / Appendix A.
+pub(crate) const TSPROXY_CREATE_TUNNEL_OPNUM: u16 = 1;
+
+/// `TsProxyAuthorizeTunnel` RPC operation number.
+///
+/// [MS-TSGU] 3.2.6 / Appendix A.
+pub(crate) const TSPROXY_AUTHORIZE_TUNNEL_OPNUM: u16 = 2;
+
+/// `TsProxyMakeTunnelCall` RPC operation number.
+///
+/// [MS-TSGU] 3.2.6 / Appendix A.
+pub(crate) const TSPROXY_MAKE_TUNNEL_CALL_OPNUM: u16 = 3;
+
+/// `TsProxyCreateChannel` RPC operation number.
+///
+/// [MS-TSGU] 3.2.6 / Appendix A.
+pub(crate) const TSPROXY_CREATE_CHANNEL_OPNUM: u16 = 4;
+
+/// `TsProxyCloseChannel` RPC operation number.
+///
+/// [MS-TSGU] 3.2.6 / Appendix A.
+pub(crate) const TSPROXY_CLOSE_CHANNEL_OPNUM: u16 = 6;
+
+/// `TsProxyCloseTunnel` RPC operation number.
+///
+/// [MS-TSGU] 3.2.6 / Appendix A.
+pub(crate) const TSPROXY_CLOSE_TUNNEL_OPNUM: u16 = 7;
+
+/// `TsProxySendToServer` RPC operation number.
+///
+/// [MS-TSGU] 3.2.6 / Appendix A.
+pub(crate) const TSPROXY_SEND_TO_SERVER_OPNUM: u16 = 9;
+
+/// Maximum raw stub size accepted by the `max_is(32767)` operation parameters.
+const MAX_RPC_MESSAGE_SIZE: usize = 32_767;
+const NDR_REFERENT_ID: u32 = 0x0002_0000;
+const TSG_COMPONENT_ID: u16 = 0x5452;
+const TSG_PACKET_TYPE_VERSIONCAPS: u32 = 0x0000_5643;
+const TSG_PACKET_TYPE_QUARREQUEST: u32 = 0x0000_5152;
+const TSG_PACKET_TYPE_RESPONSE: u32 = 0x0000_5052;
+const TSG_PACKET_TYPE_QUARENC_RESPONSE: u32 = 0x0000_4552;
+const TSG_PACKET_TYPE_CAPS_RESPONSE: u32 = 0x0000_4350;
+const TSG_PACKET_TYPE_REAUTH: u32 = 0x0000_5250;
+const TSG_PACKET_TYPE_MSGREQUEST: u32 = 0x0000_4752;
+const TSG_PACKET_TYPE_MESSAGE: u32 = 0x0000_4750;
+const TSG_TUNNEL_CALL_ASYNC_MSG_REQUEST: u32 = 1;
+const TSG_TUNNEL_CANCEL_ASYNC_MSG_REQUEST: u32 = 2;
+const TSG_ASYNC_MESSAGE_CONSENT: u32 = 1;
+const TSG_ASYNC_MESSAGE_SERVICE: u32 = 2;
+const TSG_ASYNC_MESSAGE_REAUTH: u32 = 3;
+const TSG_CAPABILITY_TYPE_NAP: u32 = 1;
+const TSG_MAX_CERT_CHAIN_LEN: usize = 24_000;
+const TSG_MAX_RESPONSE_DATA_SIZE: usize = 24_000;
+const TSG_MAX_MESSAGE_CHARS: usize = 65_536;
+
+/// A TS Gateway RPC context handle in its 20-byte network representation.
+///
+/// The representation is shared by the serialize and no-serialize tunnel and
+/// channel handle types. [MS-TSGU] 2.2.2.1 and 2.2.2.2 specify that the
+/// no-serialize forms are identical on the wire.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RpcContextHandle([u8; Self::SIZE]);
+
+impl RpcContextHandle {
+    /// Size of an RPC context handle network representation.
+    pub(crate) const SIZE: usize = 20;
+    const FIXED_PART_SIZE: usize = Self::SIZE;
+
+    /// Creates a context handle from exactly one network representation.
+    pub(crate) fn from_bytes(bytes: &[u8]) -> Result<Self, RpcWireError> {
+        let bytes: &[u8; Self::SIZE] = bytes
+            .try_into()
+            .map_err(|_| RpcWireError::ContextHandleLength { actual: bytes.len() })?;
+
+        Ok(Self(*bytes))
+    }
+
+    /// Returns the handle network representation unchanged.
+    pub(crate) const fn as_bytes(&self) -> &[u8; Self::SIZE] {
+        &self.0
+    }
+
+    /// Returns `true` if this is the null RPC context handle.
+    pub(crate) fn is_null(&self) -> bool {
+        self.0.iter().all(|byte| *byte == 0)
+    }
+
+    /// Converts this handle to a non-null handle required by channel operations.
+    pub(crate) fn require_non_null(self) -> Result<NonNullRpcContextHandle, RpcWireError> {
+        if self.is_null() {
+            return Err(RpcWireError::NullContextHandle);
+        }
+
+        Ok(NonNullRpcContextHandle(self))
+    }
+}
+
+impl fmt::Debug for RpcContextHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("RpcContextHandle(..)")
+    }
+}
+
+impl Encode for RpcContextHandle {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_slice(&self.0);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "RPC_CONTEXT_HANDLE"
+    }
+
+    fn size(&self) -> usize {
+        Self::SIZE
+    }
+}
+
+impl Decode<'_> for RpcContextHandle {
+    fn decode(src: &mut ReadCursor<'_>) -> ironrdp_core::DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+        Ok(Self(src.read_array()))
+    }
+}
+
+/// A non-null RPC context handle accepted by channel-related operations.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct NonNullRpcContextHandle(RpcContextHandle);
+
+impl NonNullRpcContextHandle {
+    /// Returns the handle network representation unchanged.
+    const fn as_bytes(&self) -> &[u8; RpcContextHandle::SIZE] {
+        self.0.as_bytes()
+    }
+}
+
+/// Byte order selected by the surrounding DCE/RPC PDU data representation.
+///
+/// The raw four-byte final receive-pipe stub does not identify its own byte
+/// order, so callers must derive this from their DCE/RPC implementation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RpcStubByteOrder {
+    LittleEndian,
+    BigEndian,
+}
+
+/// Errors reported by the raw TS Gateway RPC stub codecs.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RpcWireError {
+    ContextHandleLength { actual: usize },
+    NullContextHandle,
+    EmptyResourceName,
+    EmbeddedNulInResourceName,
+    BufferCount { actual: usize },
+    EmptyFirstBuffer,
+    LengthOverflow,
+    RequestTooLarge { actual: usize },
+    OutputLength { actual: usize, expected: usize },
+    ResponseLength { actual: usize, expected: usize },
+    RpcStatus { value: u32 },
+    FinalReturnValueLength { actual: usize },
+    UnexpectedPacketId { expected: u32, actual: u32 },
+    UnexpectedPacketSwitch { expected: u32, actual: u32 },
+    RequiredNdrPointerIsNull,
+    UnexpectedNdrPointer { actual: u32 },
+    InvalidNdrBoolean { value: u32 },
+    ConflictingRedirectionFlags,
+    ResponseDataTooLarge { actual: usize },
+    UnsupportedCapabilityCount { actual: u32 },
+    UnexpectedCapabilityType { expected: u32, actual: u32 },
+    InvalidNdrArrayLength { actual: u32, expected: u32 },
+    InvalidQuarencFlags { actual: u32 },
+    CertificateChainTooLarge { actual: usize },
+    UnterminatedNdrString,
+    InvalidMessageType { actual: u32 },
+    MessageTooLarge { actual: usize },
+}
+
+impl fmt::Display for RpcWireError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ContextHandleLength { actual } => {
+                write!(
+                    f,
+                    "invalid rpc context handle length {actual}, expected {}",
+                    RpcContextHandle::SIZE
+                )
+            }
+            Self::NullContextHandle => f.write_str("context handle must not be null"),
+            Self::EmptyResourceName => f.write_str("resource name must not be empty"),
+            Self::EmbeddedNulInResourceName => f.write_str("resource name must not contain a nul character"),
+            Self::BufferCount { actual } => write!(f, "invalid buffer count {actual}, expected 1 through 3"),
+            Self::EmptyFirstBuffer => f.write_str("first buffer must not be empty"),
+            Self::LengthOverflow => f.write_str("rpc stub length overflow"),
+            Self::RequestTooLarge { actual } => {
+                write!(f, "rpc stub length {actual} exceeds {MAX_RPC_MESSAGE_SIZE}")
+            }
+            Self::OutputLength { actual, expected } => {
+                write!(f, "invalid output length {actual}, expected {expected}")
+            }
+            Self::ResponseLength { actual, expected } => {
+                write!(f, "invalid rpc response length {actual}, expected {expected}")
+            }
+            Self::RpcStatus { value } => write!(f, "rpc operation returned status 0x{value:08x}"),
+            Self::FinalReturnValueLength { actual } => {
+                write!(f, "invalid final receive-pipe stub length {actual}, expected 4")
+            }
+            Self::UnexpectedPacketId { expected, actual } => {
+                write!(
+                    f,
+                    "unexpected TS Gateway packet id 0x{actual:08x}, expected 0x{expected:08x}"
+                )
+            }
+            Self::UnexpectedPacketSwitch { expected, actual } => {
+                write!(
+                    f,
+                    "unexpected TS Gateway packet switch 0x{actual:08x}, expected 0x{expected:08x}"
+                )
+            }
+            Self::RequiredNdrPointerIsNull => f.write_str("required NDR pointer is null"),
+            Self::UnexpectedNdrPointer { actual } => write!(f, "unexpected NDR pointer value 0x{actual:08x}"),
+            Self::InvalidNdrBoolean { value } => write!(f, "invalid NDR boolean value {value}"),
+            Self::ConflictingRedirectionFlags => f.write_str("enable-all and disable-all redirection flags conflict"),
+            Self::ResponseDataTooLarge { actual } => {
+                write!(
+                    f,
+                    "TS Gateway response data length {actual} exceeds {TSG_MAX_RESPONSE_DATA_SIZE}"
+                )
+            }
+            Self::UnsupportedCapabilityCount { actual } => {
+                write!(f, "unsupported TS Gateway capability count {actual}")
+            }
+            Self::UnexpectedCapabilityType { expected, actual } => {
+                write!(f, "unexpected TS Gateway capability type {actual}, expected {expected}")
+            }
+            Self::InvalidNdrArrayLength { actual, expected } => {
+                write!(f, "invalid NDR array length {actual}, expected {expected}")
+            }
+            Self::InvalidQuarencFlags { actual } => {
+                write!(f, "invalid TS Gateway QUARENC flags {actual}")
+            }
+            Self::CertificateChainTooLarge { actual } => {
+                write!(
+                    f,
+                    "TS Gateway certificate chain length {actual} exceeds {TSG_MAX_CERT_CHAIN_LEN}"
+                )
+            }
+            Self::UnterminatedNdrString => f.write_str("unterminated NDR string"),
+            Self::InvalidMessageType { actual } => write!(f, "invalid TS Gateway message type {actual}"),
+            Self::MessageTooLarge { actual } => {
+                write!(f, "TS Gateway message length {actual} exceeds {TSG_MAX_MESSAGE_CHARS}")
+            }
+        }
+    }
+}
+
+impl core::error::Error for RpcWireError {}
+
+/// NDR32 `TsProxyCreateTunnel` request stub.
+///
+/// The terminal-server gateway interface carries an additional 60-byte
+/// interface-negotiation trailer after the documented packet. Existing Windows
+/// gateways require this trailer despite it not being described by MS-TSGU.
+///
+/// [MS-TSGU] 3.2.6.1.1.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct TsProxyCreateTunnelRequest {
+    capabilities: u32,
+}
+
+impl TsProxyCreateTunnelRequest {
+    pub(crate) const fn new(capabilities: u32) -> Self {
+        Self { capabilities }
+    }
+
+    pub(crate) fn encode(self) -> Vec<u8> {
+        let mut output = Vec::with_capacity(108);
+
+        output.extend_from_slice(&TSG_PACKET_TYPE_VERSIONCAPS.to_le_bytes());
+        output.extend_from_slice(&TSG_PACKET_TYPE_VERSIONCAPS.to_le_bytes());
+        encode_ndr_pointer(&mut output, 0);
+
+        output.extend_from_slice(&TSG_COMPONENT_ID.to_le_bytes());
+        output.extend_from_slice(
+            &u16::try_from(TSG_PACKET_TYPE_VERSIONCAPS)
+                .expect("packet type fits in u16")
+                .to_le_bytes(),
+        );
+        encode_ndr_pointer(&mut output, 1);
+        output.extend_from_slice(&1u32.to_le_bytes()); // numCapabilities
+        output.extend_from_slice(&1u16.to_le_bytes()); // majorVersion
+        output.extend_from_slice(&1u16.to_le_bytes()); // minorVersion
+        output.extend_from_slice(&0u16.to_le_bytes()); // quarantineCapabilities
+        output.extend_from_slice(&0u16.to_le_bytes()); // NDR alignment
+        output.extend_from_slice(&1u32.to_le_bytes()); // capability array max count
+        output.extend_from_slice(&TSG_CAPABILITY_TYPE_NAP.to_le_bytes());
+        output.extend_from_slice(&TSG_CAPABILITY_TYPE_NAP.to_le_bytes());
+        output.extend_from_slice(&self.capabilities.to_le_bytes());
+
+        output.extend_from_slice(&[0x8a, 0xe3, 0x13, 0x71, 0x02, 0xf4, 0x36, 0x71]);
+        output.extend_from_slice(&0x0004_0001u32.to_le_bytes());
+        output.extend_from_slice(&1u32.to_le_bytes());
+        output.extend_from_slice(&[2, 0x40, 0x28, 0]);
+        encode_syntax_identifier(&mut output, TSPROXY_RPC_INTERFACE_ID, TSPROXY_RPC_INTERFACE_VERSION);
+        encode_syntax_identifier(&mut output, NDR32_TRANSFER_SYNTAX_ID, NDR32_TRANSFER_SYNTAX_VERSION);
+
+        debug_assert_eq!(output.len(), 108);
+        output
+    }
+}
+
+/// NDR32 `TsProxyCreateTunnel` reauthentication request stub.
+///
+/// [MS-TSGU] 2.2.9.2.1.11 and 4.1.3.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct TsProxyReauthenticateTunnelRequest {
+    tunnel_context: u64,
+    capabilities: u32,
+}
+
+impl TsProxyReauthenticateTunnelRequest {
+    pub(crate) const fn new(tunnel_context: u64, capabilities: u32) -> Self {
+        Self {
+            tunnel_context,
+            capabilities,
+        }
+    }
+
+    pub(crate) fn encode(self) -> Vec<u8> {
+        let mut output = Vec::with_capacity(64);
+
+        output.extend_from_slice(&TSG_PACKET_TYPE_REAUTH.to_le_bytes());
+        output.extend_from_slice(&TSG_PACKET_TYPE_REAUTH.to_le_bytes());
+        encode_ndr_pointer(&mut output, 0);
+
+        output.extend_from_slice(&self.tunnel_context.to_le_bytes());
+        output.extend_from_slice(&TSG_PACKET_TYPE_VERSIONCAPS.to_le_bytes());
+        encode_ndr_pointer(&mut output, 1);
+
+        output.extend_from_slice(&TSG_COMPONENT_ID.to_le_bytes());
+        output.extend_from_slice(
+            &u16::try_from(TSG_PACKET_TYPE_VERSIONCAPS)
+                .expect("packet type fits in u16")
+                .to_le_bytes(),
+        );
+        encode_ndr_pointer(&mut output, 2);
+        output.extend_from_slice(&1u32.to_le_bytes()); // numCapabilities
+        output.extend_from_slice(&1u16.to_le_bytes()); // majorVersion
+        output.extend_from_slice(&1u16.to_le_bytes()); // minorVersion
+        output.extend_from_slice(&0u16.to_le_bytes()); // quarantineCapabilities
+        output.extend_from_slice(&0u16.to_le_bytes()); // NDR alignment
+        output.extend_from_slice(&1u32.to_le_bytes()); // capability array max count
+        output.extend_from_slice(&TSG_CAPABILITY_TYPE_NAP.to_le_bytes());
+        output.extend_from_slice(&TSG_CAPABILITY_TYPE_NAP.to_le_bytes());
+        output.extend_from_slice(&self.capabilities.to_le_bytes());
+
+        debug_assert_eq!(output.len(), 64);
+        output
+    }
+}
+
+/// NDR32 `TsProxyMakeTunnelCall` request for one queued server message.
+///
+/// [MS-TSGU] 2.2.9.2.1.8 and 3.2.6.1.3.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct TsProxyMakeTunnelCallRequest {
+    tunnel_context: NonNullRpcContextHandle,
+    proc_id: u32,
+}
+
+impl TsProxyMakeTunnelCallRequest {
+    pub(crate) const fn new(tunnel_context: NonNullRpcContextHandle) -> Self {
+        Self {
+            tunnel_context,
+            proc_id: TSG_TUNNEL_CALL_ASYNC_MSG_REQUEST,
+        }
+    }
+
+    /// Cancels an unreturned asynchronous message request during tunnel shutdown.
+    ///
+    /// [MS-TSGU] 3.2.6.1.3 and 3.2.6.3.2.
+    pub(crate) const fn cancel_pending(tunnel_context: NonNullRpcContextHandle) -> Self {
+        Self {
+            tunnel_context,
+            proc_id: TSG_TUNNEL_CANCEL_ASYNC_MSG_REQUEST,
+        }
+    }
+
+    pub(crate) fn encode(self) -> [u8; 40] {
+        let mut output = [0; 40];
+        output[..RpcContextHandle::SIZE].copy_from_slice(self.tunnel_context.as_bytes());
+        output[20..24].copy_from_slice(&self.proc_id.to_le_bytes());
+        output[24..28].copy_from_slice(&TSG_PACKET_TYPE_MSGREQUEST.to_le_bytes());
+        output[28..32].copy_from_slice(&TSG_PACKET_TYPE_MSGREQUEST.to_le_bytes());
+        output[32..36].copy_from_slice(&NDR_REFERENT_ID.to_le_bytes());
+        output[36..40].copy_from_slice(&1u32.to_le_bytes()); // maxMessagesPerBatch
+        output
+    }
+}
+
+/// NDR32 context-handle stub for `TsProxyCloseChannel` and `TsProxyCloseTunnel`.
+///
+/// [MS-TSGU] 3.2.6.3.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct TsProxyCloseContextRequest {
+    context: NonNullRpcContextHandle,
+}
+
+impl TsProxyCloseContextRequest {
+    pub(crate) const fn new(context: NonNullRpcContextHandle) -> Self {
+        Self { context }
+    }
+
+    pub(crate) const fn encode(self) -> [u8; RpcContextHandle::SIZE] {
+        *self.context.as_bytes()
+    }
+}
+
+/// Validates the final context handle and HRESULT returned by a close operation.
+pub(crate) fn decode_tsgu_close_context_response(source: &[u8]) -> Result<(), RpcWireError> {
+    const RESPONSE_SIZE: usize = RpcContextHandle::SIZE + 4 /* return value */;
+    if source.len() != RESPONSE_SIZE {
+        return Err(RpcWireError::ResponseLength {
+            actual: source.len(),
+            expected: RESPONSE_SIZE,
+        });
+    }
+    let return_value = read_u32(source, RpcContextHandle::SIZE).map_err(|_| RpcWireError::LengthOverflow)?;
+    if return_value != 0 {
+        return Err(RpcWireError::RpcStatus { value: return_value });
+    }
+    Ok(())
+}
+
+/// NDR32 `TsProxyCreateChannel` request stub.
+///
+/// [MS-TSGU] 2.2.9.1 and 3.2.6.1.4.
+#[derive(Debug)]
+pub(crate) struct TsProxyCreateChannelRequest<'a> {
+    tunnel_context: NonNullRpcContextHandle,
+    resource_name: &'a str,
+    port: u16,
+}
+
+impl<'a> TsProxyCreateChannelRequest<'a> {
+    pub(crate) const fn new(tunnel_context: NonNullRpcContextHandle, resource_name: &'a str, port: u16) -> Self {
+        Self {
+            tunnel_context,
+            resource_name,
+            port,
+        }
+    }
+
+    pub(crate) fn encode(&self) -> Result<Vec<u8>, RpcWireError> {
+        let resource_name = encode_ndr_string(self.resource_name)?;
+        let mut output = Vec::with_capacity(48 + 2 * resource_name.len());
+
+        output.extend_from_slice(self.tunnel_context.as_bytes());
+        encode_ndr_pointer(&mut output, 0); // resourceName
+        output.extend_from_slice(&1u32.to_le_bytes()); // numResourceNames
+        output.extend_from_slice(&0u32.to_le_bytes()); // alternateResourceNames
+        output.extend_from_slice(&0u16.to_le_bytes()); // numAlternateResourceNames
+        output.extend_from_slice(&0u16.to_le_bytes()); // NDR alignment
+        output.extend_from_slice(&((u32::from(self.port) << 16) | 3).to_le_bytes());
+
+        output.extend_from_slice(&1u32.to_le_bytes()); // resourceName array max count
+        encode_ndr_pointer(&mut output, 1); // first resourceName
+        encode_ndr_string_referent(&mut output, &resource_name)?;
+
+        Ok(output)
+    }
+}
+
+/// NDR32 `TsProxyAuthorizeTunnel` request stub.
+///
+/// [MS-TSGU] 2.2.9.2.1.4 and 3.2.6.1.2.
+#[derive(Debug)]
+pub(crate) struct TsProxyAuthorizeTunnelRequest<'a> {
+    tunnel_context: NonNullRpcContextHandle,
+    machine_name: &'a str,
+    statement_of_health: &'a [u8],
+}
+
+impl<'a> TsProxyAuthorizeTunnelRequest<'a> {
+    pub(crate) const fn new(
+        tunnel_context: NonNullRpcContextHandle,
+        machine_name: &'a str,
+        statement_of_health: &'a [u8],
+    ) -> Self {
+        Self {
+            tunnel_context,
+            machine_name,
+            statement_of_health,
+        }
+    }
+
+    pub(crate) fn encode(&self) -> Result<Vec<u8>, RpcWireError> {
+        let machine_name = encode_ndr_string(self.machine_name)?;
+        let machine_name_len = u32::try_from(machine_name.len()).map_err(|_| RpcWireError::LengthOverflow)?;
+        let statement_of_health_len =
+            u32::try_from(self.statement_of_health.len()).map_err(|_| RpcWireError::LengthOverflow)?;
+        let mut output = Vec::with_capacity(64 + 2 * machine_name.len() + self.statement_of_health.len());
+
+        output.extend_from_slice(self.tunnel_context.as_bytes());
+        output.extend_from_slice(&TSG_PACKET_TYPE_QUARREQUEST.to_le_bytes());
+        output.extend_from_slice(&TSG_PACKET_TYPE_QUARREQUEST.to_le_bytes());
+        encode_ndr_pointer(&mut output, 0); // packetQuarRequest
+        output.extend_from_slice(&0u32.to_le_bytes()); // flags
+        encode_ndr_pointer(&mut output, 1); // machineName
+        output.extend_from_slice(&machine_name_len.to_le_bytes()); // nameLength
+        if self.statement_of_health.is_empty() {
+            output.extend_from_slice(&0u32.to_le_bytes());
+        } else {
+            encode_ndr_pointer(&mut output, 2); // data
+        }
+        output.extend_from_slice(&statement_of_health_len.to_le_bytes()); // dataLen
+        encode_ndr_string_referent(&mut output, &machine_name)?;
+        if !self.statement_of_health.is_empty() {
+            output.extend_from_slice(&statement_of_health_len.to_le_bytes()); // max count
+            output.extend_from_slice(self.statement_of_health);
+            pad_ndr_4(&mut output);
+        }
+
+        Ok(output)
+    }
+}
+
+/// Decoded `TsProxyCreateChannel` response values.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct TsProxyCreateChannelResponse {
+    pub(crate) channel_context: NonNullRpcContextHandle,
+    pub(crate) channel_id: u32,
+}
+
+/// Decoded `TsProxyCreateTunnel` response values.
+///
+/// [MS-TSGU] 2.2.9.2.1.6 and 3.2.6.1.1.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct TsProxyCreateTunnelResponse {
+    pub(crate) tunnel_context: NonNullRpcContextHandle,
+    pub(crate) tunnel_id: u32,
+    pub(crate) nonce: Uuid,
+    pub(crate) capabilities: u32,
+}
+
+/// Decodes one non-messaging `TsProxyCreateTunnel` response stub.
+///
+/// A gateway returns `TSG_PACKET_TYPE_QUARENC_RESPONSE` unless the client and
+/// server negotiated consent-signing. The latter has additional NDR structures
+/// and is decoded separately once legacy RPC message handling is available.
+pub(crate) fn decode_tsgu_create_tunnel_response(source: &[u8]) -> Result<TsProxyCreateTunnelResponse, RpcWireError> {
+    const PACKET_HEADER_SIZE: usize = 4 /* TSG packet pointer */
+        + 4 /* packet ID */
+        + 4 /* union switch */
+        + 4; /* QUARENC response pointer */
+    const QUARENC_FIXED_SIZE: usize = 4 /* flags */
+        + 4 /* certificate chain length */
+        + 4 /* certificate chain pointer */
+        + 16 /* nonce */
+        + 4; /* version capabilities pointer */
+    let fixed_size = PACKET_HEADER_SIZE
+        .checked_add(QUARENC_FIXED_SIZE)
+        .ok_or(RpcWireError::LengthOverflow)?;
+    let fixed = source.get(..fixed_size).ok_or(RpcWireError::ResponseLength {
+        actual: source.len(),
+        expected: fixed_size,
+    })?;
+    if read_u32(fixed, 0).map_err(|_| RpcWireError::LengthOverflow)? == 0
+        || read_u32(fixed, 12).map_err(|_| RpcWireError::LengthOverflow)? == 0
+    {
+        return Err(RpcWireError::RequiredNdrPointerIsNull);
+    }
+
+    // The server returns TSG_PACKET_TYPE_CAPS_RESPONSE when the negotiated capabilities
+    // include consent signing, embedding the quarantine response followed by a consent
+    // message; otherwise it returns TSG_PACKET_TYPE_QUARENC_RESPONSE. Both share the same
+    // quarantine-response prefix, so accept either ([MS-TSGU] 3.2.6.1.1).
+    let packet_id = read_u32(fixed, 4).map_err(|_| RpcWireError::LengthOverflow)?;
+    if packet_id != TSG_PACKET_TYPE_QUARENC_RESPONSE && packet_id != TSG_PACKET_TYPE_CAPS_RESPONSE {
+        return Err(RpcWireError::UnexpectedPacketId {
+            expected: TSG_PACKET_TYPE_QUARENC_RESPONSE,
+            actual: packet_id,
+        });
+    }
+    let packet_switch = read_u32(fixed, 8).map_err(|_| RpcWireError::LengthOverflow)?;
+    if packet_switch != packet_id {
+        return Err(RpcWireError::UnexpectedPacketSwitch {
+            expected: packet_id,
+            actual: packet_switch,
+        });
+    }
+    let flags = read_u32(fixed, PACKET_HEADER_SIZE).map_err(|_| RpcWireError::LengthOverflow)?;
+    if flags != 0 {
+        return Err(RpcWireError::InvalidQuarencFlags { actual: flags });
+    }
+
+    let certificate_chain_length =
+        usize::try_from(read_u32(fixed, PACKET_HEADER_SIZE + 4).map_err(|_| RpcWireError::LengthOverflow)?)
+            .map_err(|_| RpcWireError::LengthOverflow)?;
+    if certificate_chain_length > TSG_MAX_CERT_CHAIN_LEN {
+        return Err(RpcWireError::CertificateChainTooLarge {
+            actual: certificate_chain_length,
+        });
+    }
+    let certificate_chain_pointer =
+        read_u32(fixed, PACKET_HEADER_SIZE + 8).map_err(|_| RpcWireError::LengthOverflow)?;
+    if certificate_chain_length != 0 && certificate_chain_pointer == 0 {
+        return Err(RpcWireError::RequiredNdrPointerIsNull);
+    }
+    let nonce = Uuid::from_bytes_le(
+        fixed[PACKET_HEADER_SIZE + 12..PACKET_HEADER_SIZE + 28]
+            .try_into()
+            .map_err(|_| RpcWireError::LengthOverflow)?,
+    );
+    if read_u32(fixed, PACKET_HEADER_SIZE + 28).map_err(|_| RpcWireError::LengthOverflow)? == 0 {
+        return Err(RpcWireError::RequiredNdrPointerIsNull);
+    }
+
+    let mut offset = fixed_size;
+    if certificate_chain_pointer != 0 {
+        let array_header_end = offset.checked_add(12).ok_or(RpcWireError::LengthOverflow)?;
+        let array_header = source
+            .get(offset..array_header_end)
+            .ok_or(RpcWireError::ResponseLength {
+                actual: source.len(),
+                expected: array_header_end,
+            })?;
+        let max_count = read_u32(array_header, 0).map_err(|_| RpcWireError::LengthOverflow)?;
+        let offset_count = read_u32(array_header, 4).map_err(|_| RpcWireError::LengthOverflow)?;
+        let actual_count = read_u32(array_header, 8).map_err(|_| RpcWireError::LengthOverflow)?;
+        let expected_count = u32::try_from(certificate_chain_length).map_err(|_| RpcWireError::LengthOverflow)?;
+        if max_count != expected_count || offset_count != 0 || actual_count != expected_count {
+            return Err(RpcWireError::InvalidNdrArrayLength {
+                actual: actual_count,
+                expected: expected_count,
+            });
+        }
+        let certificate_bytes = certificate_chain_length
+            .checked_mul(2)
+            .ok_or(RpcWireError::LengthOverflow)?;
+        let certificate_end = array_header_end
+            .checked_add(certificate_bytes)
+            .ok_or(RpcWireError::LengthOverflow)?;
+        let certificate = source
+            .get(array_header_end..certificate_end)
+            .ok_or(RpcWireError::ResponseLength {
+                actual: source.len(),
+                expected: certificate_end,
+            })?;
+        if certificate_chain_length != 0 && certificate[certificate.len() - 2..] != [0, 0] {
+            return Err(RpcWireError::UnterminatedNdrString);
+        }
+        offset = (certificate_end + 3) & !3;
+    }
+
+    // Locate the version capabilities structure by its component ID and packet type
+    // signature. A capabilities (consent-signing) response inserts the consent message's
+    // fixed fields between the quarantine fixed part and this pointee, so its offset is
+    // not fixed ([MS-TSGU] 2.2.9.2.1.7). Scanning on the unambiguous signature is robust
+    // to that insertion.
+    let version_caps_id = u16::try_from(TSG_PACKET_TYPE_VERSIONCAPS).expect("packet type fits in u16");
+    let version_caps_signature = [
+        TSG_COMPONENT_ID.to_le_bytes()[0],
+        TSG_COMPONENT_ID.to_le_bytes()[1],
+        version_caps_id.to_le_bytes()[0],
+        version_caps_id.to_le_bytes()[1],
+    ];
+    let version_caps_offset = (offset..source.len().saturating_sub(3))
+        .step_by(4)
+        .find(|&candidate| source[candidate..candidate + 4] == version_caps_signature)
+        .ok_or(RpcWireError::UnexpectedPacketId {
+            expected: TSG_PACKET_TYPE_VERSIONCAPS,
+            actual: 0,
+        })?;
+
+    let version_caps_end = version_caps_offset
+        .checked_add(24)
+        .ok_or(RpcWireError::LengthOverflow)?;
+    let version_caps = source
+        .get(version_caps_offset..version_caps_end)
+        .ok_or(RpcWireError::ResponseLength {
+            actual: source.len(),
+            expected: version_caps_end,
+        })?;
+    if read_u16(version_caps, 0).map_err(|_| RpcWireError::LengthOverflow)? != TSG_COMPONENT_ID
+        || read_u16(version_caps, 2).map_err(|_| RpcWireError::LengthOverflow)? != version_caps_id
+        || read_u32(version_caps, 4).map_err(|_| RpcWireError::LengthOverflow)? == 0
+    {
+        return Err(RpcWireError::UnexpectedPacketId {
+            expected: TSG_PACKET_TYPE_VERSIONCAPS,
+            actual: u32::from(read_u16(version_caps, 2).map_err(|_| RpcWireError::LengthOverflow)?),
+        });
+    }
+    let capability_count = read_u32(version_caps, 8).map_err(|_| RpcWireError::LengthOverflow)?;
+    if capability_count != 1 {
+        return Err(RpcWireError::UnsupportedCapabilityCount {
+            actual: capability_count,
+        });
+    }
+    let array_count = read_u32(version_caps, 20).map_err(|_| RpcWireError::LengthOverflow)?;
+    if array_count != capability_count {
+        return Err(RpcWireError::InvalidNdrArrayLength {
+            actual: array_count,
+            expected: capability_count,
+        });
+    }
+
+    let capability_end = version_caps_end.checked_add(12).ok_or(RpcWireError::LengthOverflow)?;
+    let capability = source
+        .get(version_caps_end..capability_end)
+        .ok_or(RpcWireError::ResponseLength {
+            actual: source.len(),
+            expected: capability_end,
+        })?;
+    let capability_type = read_u32(capability, 0).map_err(|_| RpcWireError::LengthOverflow)?;
+    let capability_switch = read_u32(capability, 4).map_err(|_| RpcWireError::LengthOverflow)?;
+    if capability_type != TSG_CAPABILITY_TYPE_NAP {
+        return Err(RpcWireError::UnexpectedCapabilityType {
+            expected: TSG_CAPABILITY_TYPE_NAP,
+            actual: capability_type,
+        });
+    }
+    if capability_switch != capability_type {
+        return Err(RpcWireError::UnexpectedCapabilityType {
+            expected: capability_type,
+            actual: capability_switch,
+        });
+    }
+
+    // Both the quarantine and capabilities responses end with the tunnel context handle,
+    // the tunnel ID, and the HRESULT return value. A capabilities response inserts a
+    // consent message between the capability array and these trailing fields, so read
+    // them from the end of the stub ([MS-TSGU] 2.2.9.2.1.6, 2.2.9.2.1.7).
+    const TRAILER_SIZE: usize = RpcContextHandle::SIZE + 4 /* tunnel id */ + 4 /* return value */;
+    let context_offset = source
+        .len()
+        .checked_sub(TRAILER_SIZE)
+        .filter(|offset| *offset >= capability_end)
+        .ok_or(RpcWireError::ResponseLength {
+            actual: source.len(),
+            expected: capability_end + TRAILER_SIZE,
+        })?;
+    let context_end = context_offset
+        .checked_add(RpcContextHandle::SIZE)
+        .ok_or(RpcWireError::LengthOverflow)?;
+    let tunnel_context = RpcContextHandle::from_bytes(&source[context_offset..context_end])?.require_non_null()?;
+    let tunnel_id = read_u32(source, context_end).map_err(|_| RpcWireError::LengthOverflow)?;
+    let return_value = read_u32(source, context_end + 4).map_err(|_| RpcWireError::LengthOverflow)?;
+    if return_value != 0 {
+        return Err(RpcWireError::RpcStatus { value: return_value });
+    }
+
+    Ok(TsProxyCreateTunnelResponse {
+        tunnel_context,
+        tunnel_id,
+        nonce,
+        capabilities: read_u32(capability, 8).map_err(|_| RpcWireError::LengthOverflow)?,
+    })
+}
+
+/// Device-redirection policy returned by `TsProxyAuthorizeTunnel`.
+///
+/// [MS-TSGU] 2.2.9.2.1.5.2.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct TsProxyRedirectionFlags {
+    pub(crate) enable_all: bool,
+    pub(crate) disable_all: bool,
+    pub(crate) drive_disabled: bool,
+    pub(crate) printer_disabled: bool,
+    pub(crate) port_disabled: bool,
+    pub(crate) clipboard_disabled: bool,
+    pub(crate) pnp_disabled: bool,
+}
+
+/// Decoded `TsProxyAuthorizeTunnel` response values.
+///
+/// [MS-TSGU] 2.2.9.2.1.5 and 3.2.6.1.2.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct TsProxyAuthorizeTunnelResponse {
+    pub(crate) response_data: Vec<u8>,
+    pub(crate) redirection_flags: TsProxyRedirectionFlags,
+}
+
+/// Decodes one `TsProxyAuthorizeTunnel` response stub.
+///
+/// The opaque response data may contain a statement-of-health response and an
+/// idle timeout, depending on capabilities negotiated by `TsProxyCreateTunnel`.
+pub(crate) fn decode_tsgu_authorize_tunnel_response(
+    source: &[u8],
+) -> Result<TsProxyAuthorizeTunnelResponse, RpcWireError> {
+    const FIXED_SIZE: usize = 4 /* TSG packet pointer */
+        + 4 /* packet ID */
+        + 4 /* union switch */
+        + 4 /* packet response pointer */
+        + 4 /* flags */
+        + 4 /* reserved */
+        + 4 /* response data pointer */
+        + 4 /* response data length */
+        + 8 * 4; /* redirection flags */
+    let fixed = source.get(..FIXED_SIZE).ok_or(RpcWireError::ResponseLength {
+        actual: source.len(),
+        expected: FIXED_SIZE,
+    })?;
+    if read_u32(fixed, 0).map_err(|_| RpcWireError::LengthOverflow)? == 0
+        || read_u32(fixed, 12).map_err(|_| RpcWireError::LengthOverflow)? == 0
+    {
+        return Err(RpcWireError::RequiredNdrPointerIsNull);
+    }
+
+    let packet_id = read_u32(fixed, 4).map_err(|_| RpcWireError::LengthOverflow)?;
+    if packet_id != TSG_PACKET_TYPE_RESPONSE {
+        return Err(RpcWireError::UnexpectedPacketId {
+            expected: TSG_PACKET_TYPE_RESPONSE,
+            actual: packet_id,
+        });
+    }
+    let packet_switch = read_u32(fixed, 8).map_err(|_| RpcWireError::LengthOverflow)?;
+    if packet_switch != TSG_PACKET_TYPE_RESPONSE {
+        return Err(RpcWireError::UnexpectedPacketSwitch {
+            expected: TSG_PACKET_TYPE_RESPONSE,
+            actual: packet_switch,
+        });
+    }
+    let flags = read_u32(fixed, 16).map_err(|_| RpcWireError::LengthOverflow)?;
+    if flags != TSG_PACKET_TYPE_QUARREQUEST {
+        return Err(RpcWireError::UnexpectedPacketId {
+            expected: TSG_PACKET_TYPE_QUARREQUEST,
+            actual: flags,
+        });
+    }
+
+    let response_data_pointer = read_u32(fixed, 24).map_err(|_| RpcWireError::LengthOverflow)?;
+    let response_data_length = usize::try_from(read_u32(fixed, 28).map_err(|_| RpcWireError::LengthOverflow)?)
+        .map_err(|_| RpcWireError::LengthOverflow)?;
+    if response_data_length > TSG_MAX_RESPONSE_DATA_SIZE {
+        return Err(RpcWireError::ResponseDataTooLarge {
+            actual: response_data_length,
+        });
+    }
+    if response_data_length != 0 && response_data_pointer == 0 {
+        return Err(RpcWireError::RequiredNdrPointerIsNull);
+    }
+
+    let redirection_flags = TsProxyRedirectionFlags {
+        enable_all: decode_ndr_boolean(fixed, 32)?,
+        disable_all: decode_ndr_boolean(fixed, 36)?,
+        drive_disabled: decode_ndr_boolean(fixed, 40)?,
+        printer_disabled: decode_ndr_boolean(fixed, 44)?,
+        port_disabled: decode_ndr_boolean(fixed, 48)?,
+        clipboard_disabled: decode_ndr_boolean(fixed, 56)?,
+        pnp_disabled: decode_ndr_boolean(fixed, 60)?,
+    };
+    if redirection_flags.enable_all && redirection_flags.disable_all {
+        return Err(RpcWireError::ConflictingRedirectionFlags);
+    }
+
+    let response_data = if response_data_pointer == 0 {
+        if source.len() != FIXED_SIZE + 4 {
+            return Err(RpcWireError::ResponseLength {
+                actual: source.len(),
+                expected: FIXED_SIZE + 4,
+            });
+        }
+        Vec::new()
+    } else {
+        let data_header_end = FIXED_SIZE.checked_add(4).ok_or(RpcWireError::LengthOverflow)?;
+        let data_end = data_header_end
+            .checked_add(response_data_length)
+            .ok_or(RpcWireError::LengthOverflow)?;
+        let padded_data_end = (data_end + 3) & !3;
+        let return_value_end = padded_data_end.checked_add(4).ok_or(RpcWireError::LengthOverflow)?;
+        if source.len() != return_value_end {
+            return Err(RpcWireError::ResponseLength {
+                actual: source.len(),
+                expected: return_value_end,
+            });
+        }
+        let max_count = usize::try_from(read_u32(source, FIXED_SIZE).map_err(|_| RpcWireError::LengthOverflow)?)
+            .map_err(|_| RpcWireError::LengthOverflow)?;
+        if max_count != response_data_length {
+            return Err(RpcWireError::ResponseLength {
+                actual: max_count,
+                expected: response_data_length,
+            });
+        }
+        source[data_header_end..data_end].to_vec()
+    };
+
+    let return_value_offset = source.len().checked_sub(4).ok_or(RpcWireError::LengthOverflow)?;
+    let return_value = read_u32(source, return_value_offset).map_err(|_| RpcWireError::LengthOverflow)?;
+    if return_value != 0 {
+        return Err(RpcWireError::RpcStatus { value: return_value });
+    }
+
+    Ok(TsProxyAuthorizeTunnelResponse {
+        response_data,
+        redirection_flags,
+    })
+}
+
+/// Server message returned by `TsProxyMakeTunnelCall`.
+///
+/// [MS-TSGU] 2.2.9.2.1.9 and 3.2.6.1.3.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum TsProxyTunnelMessage {
+    None,
+    Consent {
+        display_mandatory: bool,
+        consent_mandatory: bool,
+        text: String,
+    },
+    Service {
+        display_mandatory: bool,
+        text: String,
+    },
+    Reauthenticate {
+        tunnel_context: u64,
+    },
+}
+
+/// Decodes one `TsProxyMakeTunnelCall` response stub.
+pub(crate) fn decode_tsgu_make_tunnel_call_response(source: &[u8]) -> Result<TsProxyTunnelMessage, RpcWireError> {
+    const FIXED_SIZE: usize = 4 /* TSG packet pointer */
+        + 4 /* packet ID */
+        + 4 /* union switch */
+        + 4 /* message response pointer */
+        + 4 /* message ID */
+        + 4 /* message type */
+        + 4 /* is message present */
+        + 4; /* message union pointer */
+    let fixed = source.get(..FIXED_SIZE).ok_or(RpcWireError::ResponseLength {
+        actual: source.len(),
+        expected: FIXED_SIZE,
+    })?;
+    if read_u32(fixed, 0).map_err(|_| RpcWireError::LengthOverflow)? == 0
+        || read_u32(fixed, 12).map_err(|_| RpcWireError::LengthOverflow)? == 0
+    {
+        return Err(RpcWireError::RequiredNdrPointerIsNull);
+    }
+
+    let packet_id = read_u32(fixed, 4).map_err(|_| RpcWireError::LengthOverflow)?;
+    if packet_id != TSG_PACKET_TYPE_MESSAGE {
+        return Err(RpcWireError::UnexpectedPacketId {
+            expected: TSG_PACKET_TYPE_MESSAGE,
+            actual: packet_id,
+        });
+    }
+    let packet_switch = read_u32(fixed, 8).map_err(|_| RpcWireError::LengthOverflow)?;
+    if packet_switch != TSG_PACKET_TYPE_MESSAGE {
+        return Err(RpcWireError::UnexpectedPacketSwitch {
+            expected: TSG_PACKET_TYPE_MESSAGE,
+            actual: packet_switch,
+        });
+    }
+
+    let message_type = read_u32(fixed, 20).map_err(|_| RpcWireError::LengthOverflow)?;
+    let message_present = decode_ndr_boolean(fixed, 24)?;
+    let message_pointer = read_u32(fixed, 28).map_err(|_| RpcWireError::LengthOverflow)?;
+    if !message_present {
+        if source.len() != FIXED_SIZE + 4 {
+            return Err(RpcWireError::ResponseLength {
+                actual: source.len(),
+                expected: FIXED_SIZE + 4,
+            });
+        }
+        let return_value = read_u32(source, FIXED_SIZE).map_err(|_| RpcWireError::LengthOverflow)?;
+        if return_value != 0 {
+            return Err(RpcWireError::RpcStatus { value: return_value });
+        }
+        return Ok(TsProxyTunnelMessage::None);
+    }
+    if message_pointer == 0 {
+        return Err(RpcWireError::RequiredNdrPointerIsNull);
+    }
+
+    match message_type {
+        TSG_ASYNC_MESSAGE_REAUTH => {
+            let response_end = FIXED_SIZE.checked_add(12).ok_or(RpcWireError::LengthOverflow)?;
+            if source.len() != response_end {
+                return Err(RpcWireError::ResponseLength {
+                    actual: source.len(),
+                    expected: response_end,
+                });
+            }
+            let tunnel_context = u64::from_le_bytes(
+                source[FIXED_SIZE..FIXED_SIZE + 8]
+                    .try_into()
+                    .map_err(|_| RpcWireError::LengthOverflow)?,
+            );
+            let return_value = read_u32(source, FIXED_SIZE + 8).map_err(|_| RpcWireError::LengthOverflow)?;
+            if return_value != 0 {
+                return Err(RpcWireError::RpcStatus { value: return_value });
+            }
+            Ok(TsProxyTunnelMessage::Reauthenticate { tunnel_context })
+        }
+        TSG_ASYNC_MESSAGE_CONSENT | TSG_ASYNC_MESSAGE_SERVICE => {
+            let string_fixed_end = FIXED_SIZE.checked_add(16).ok_or(RpcWireError::LengthOverflow)?;
+            let string_fixed = source
+                .get(FIXED_SIZE..string_fixed_end)
+                .ok_or(RpcWireError::ResponseLength {
+                    actual: source.len(),
+                    expected: string_fixed_end,
+                })?;
+            let display_mandatory = decode_ndr_boolean(string_fixed, 0)?;
+            let consent_mandatory = decode_ndr_boolean(string_fixed, 4)?;
+            let message_chars = usize::try_from(read_u32(string_fixed, 8).map_err(|_| RpcWireError::LengthOverflow)?)
+                .map_err(|_| RpcWireError::LengthOverflow)?;
+            if message_chars > TSG_MAX_MESSAGE_CHARS {
+                return Err(RpcWireError::MessageTooLarge { actual: message_chars });
+            }
+            let message_buffer_pointer = read_u32(string_fixed, 12).map_err(|_| RpcWireError::LengthOverflow)?;
+            if message_chars != 0 && message_buffer_pointer == 0 {
+                return Err(RpcWireError::RequiredNdrPointerIsNull);
+            }
+
+            let (message_start, message_end) = if message_buffer_pointer == 0 {
+                (string_fixed_end, string_fixed_end)
+            } else {
+                let array_header_end = string_fixed_end.checked_add(4).ok_or(RpcWireError::LengthOverflow)?;
+                let array_header =
+                    source
+                        .get(string_fixed_end..array_header_end)
+                        .ok_or(RpcWireError::ResponseLength {
+                            actual: source.len(),
+                            expected: array_header_end,
+                        })?;
+                let array_count = usize::try_from(read_u32(array_header, 0).map_err(|_| RpcWireError::LengthOverflow)?)
+                    .map_err(|_| RpcWireError::LengthOverflow)?;
+                if array_count != message_chars {
+                    return Err(RpcWireError::InvalidNdrArrayLength {
+                        actual: u32::try_from(array_count).map_err(|_| RpcWireError::LengthOverflow)?,
+                        expected: u32::try_from(message_chars).map_err(|_| RpcWireError::LengthOverflow)?,
+                    });
+                }
+                let message_bytes = message_chars.checked_mul(2).ok_or(RpcWireError::LengthOverflow)?;
+                let message_end = array_header_end
+                    .checked_add(message_bytes)
+                    .ok_or(RpcWireError::LengthOverflow)?;
+                (array_header_end, message_end)
+            };
+            let return_value_end = message_end.checked_add(4).ok_or(RpcWireError::LengthOverflow)?;
+            if source.len() != return_value_end {
+                return Err(RpcWireError::ResponseLength {
+                    actual: source.len(),
+                    expected: return_value_end,
+                });
+            }
+            let message_bytes = &source[message_start..message_end];
+            if message_chars != 0 && message_bytes[message_bytes.len() - 2..] != [0, 0] {
+                return Err(RpcWireError::UnterminatedNdrString);
+            }
+            let message_units = message_bytes
+                .chunks_exact(2)
+                .map(|bytes| u16::from_le_bytes([bytes[0], bytes[1]]))
+                .collect::<Vec<_>>();
+            let text = String::from_utf16(&message_units[..message_units.len().saturating_sub(1)])
+                .map_err(|_| RpcWireError::UnterminatedNdrString)?;
+            let return_value = read_u32(source, message_end).map_err(|_| RpcWireError::LengthOverflow)?;
+            if return_value != 0 {
+                return Err(RpcWireError::RpcStatus { value: return_value });
+            }
+
+            Ok(if message_type == TSG_ASYNC_MESSAGE_CONSENT {
+                TsProxyTunnelMessage::Consent {
+                    display_mandatory,
+                    consent_mandatory,
+                    text,
+                }
+            } else {
+                TsProxyTunnelMessage::Service {
+                    display_mandatory,
+                    text,
+                }
+            })
+        }
+        actual => Err(RpcWireError::InvalidMessageType { actual }),
+    }
+}
+
+/// Validates the null packet response and HRESULT from a cancelled message request.
+///
+/// [MS-TSGU] 3.2.6.1.3.
+pub(crate) fn decode_tsgu_cancel_tunnel_call_response(source: &[u8]) -> Result<(), RpcWireError> {
+    const RESPONSE_SIZE: usize = 4 /* null TSGPacketResponse pointer */ + 4 /* return value */;
+    if source.len() != RESPONSE_SIZE {
+        return Err(RpcWireError::ResponseLength {
+            actual: source.len(),
+            expected: RESPONSE_SIZE,
+        });
+    }
+    let packet_response_pointer = read_u32(source, 0).map_err(|_| RpcWireError::LengthOverflow)?;
+    if packet_response_pointer != 0 {
+        return Err(RpcWireError::UnexpectedNdrPointer {
+            actual: packet_response_pointer,
+        });
+    }
+    let return_value = read_u32(source, 4).map_err(|_| RpcWireError::LengthOverflow)?;
+    if return_value != 0 {
+        return Err(RpcWireError::RpcStatus { value: return_value });
+    }
+    Ok(())
+}
+
+/// Decodes one `TsProxyCreateChannel` response stub.
+///
+/// [MS-TSGU] 3.2.6.1.4.
+pub(crate) fn decode_tsgu_create_channel_response(source: &[u8]) -> Result<TsProxyCreateChannelResponse, RpcWireError> {
+    const RESPONSE_SIZE: usize = RpcContextHandle::SIZE + 4 /* channelId */ + 4 /* return value */;
+    if source.len() != RESPONSE_SIZE {
+        return Err(RpcWireError::ResponseLength {
+            actual: source.len(),
+            expected: RESPONSE_SIZE,
+        });
+    }
+
+    let channel_context = RpcContextHandle::from_bytes(&source[..RpcContextHandle::SIZE])?.require_non_null()?;
+    let channel_id = u32::from_le_bytes(source[20..24].try_into().expect("fixed-size response slice"));
+    let return_value = u32::from_le_bytes(source[24..28].try_into().expect("fixed-size response slice"));
+    if return_value != 0 {
+        return Err(RpcWireError::RpcStatus { value: return_value });
+    }
+
+    Ok(TsProxyCreateChannelResponse {
+        channel_context,
+        channel_id,
+    })
+}
+
+fn encode_ndr_pointer(output: &mut Vec<u8>, index: u32) {
+    output.extend_from_slice(&(NDR_REFERENT_ID + index * 4).to_le_bytes());
+}
+
+fn decode_ndr_boolean(source: &[u8], offset: usize) -> Result<bool, RpcWireError> {
+    match read_u32(source, offset).map_err(|_| RpcWireError::LengthOverflow)? {
+        0 => Ok(false),
+        1 => Ok(true),
+        value => Err(RpcWireError::InvalidNdrBoolean { value }),
+    }
+}
+
+fn encode_ndr_string(value: &str) -> Result<Vec<u16>, RpcWireError> {
+    if value.is_empty() {
+        return Err(RpcWireError::EmptyResourceName);
+    }
+    if value.contains('\0') {
+        return Err(RpcWireError::EmbeddedNulInResourceName);
+    }
+
+    let mut encoded: Vec<_> = value.encode_utf16().collect();
+    encoded.push(0);
+    Ok(encoded)
+}
+
+fn encode_ndr_string_referent(output: &mut Vec<u8>, value: &[u16]) -> Result<(), RpcWireError> {
+    let length = u32::try_from(value.len()).map_err(|_| RpcWireError::LengthOverflow)?;
+    output.extend_from_slice(&length.to_le_bytes()); // max count
+    output.extend_from_slice(&0u32.to_le_bytes()); // offset
+    output.extend_from_slice(&length.to_le_bytes()); // actual count
+    for character in value {
+        output.extend_from_slice(&character.to_le_bytes());
+    }
+    pad_ndr_4(output);
+
+    Ok(())
+}
+
+fn pad_ndr_4(output: &mut Vec<u8>) {
+    let padding = (4 - output.len() % 4) % 4;
+    output.resize(output.len() + padding, 0);
+}
+
+/// Raw `TsProxySetupReceivePipe` request stub.
+///
+/// [MS-TSGU] 2.2.9.4.1 and 3.6.5.3.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct TsProxySetupReceivePipeRequest {
+    channel_context: NonNullRpcContextHandle,
+}
+
+impl TsProxySetupReceivePipeRequest {
+    /// Size of the complete raw request stub.
+    pub(crate) const SIZE: usize = RpcContextHandle::SIZE;
+
+    pub(crate) const fn new(channel_context: NonNullRpcContextHandle) -> Self {
+        Self { channel_context }
+    }
+
+    /// Encodes the request into an output slice of exactly 20 bytes.
+    pub(crate) fn encode_into(&self, output: &mut [u8]) -> Result<(), RpcWireError> {
+        if output.len() != Self::SIZE {
+            return Err(RpcWireError::OutputLength {
+                actual: output.len(),
+                expected: Self::SIZE,
+            });
+        }
+
+        output.copy_from_slice(self.channel_context.as_bytes());
+        Ok(())
+    }
+
+    /// Encodes the request into its fixed-size raw stub.
+    pub(crate) fn encode(&self) -> [u8; Self::SIZE] {
+        *self.channel_context.as_bytes()
+    }
+}
+
+/// Raw `TsProxySendToServer` request stub builder.
+///
+/// The payload slices are borrowed until encoding, so only construction of the
+/// final contiguous RPC stub copies payload data.
+///
+/// [MS-TSGU] 2.2.9.3 and 3.6.5.1.
+#[derive(Debug)]
+pub(crate) struct TsProxySendToServerRequest<'a> {
+    channel_context: NonNullRpcContextHandle,
+    buffers: [&'a [u8]; 3],
+    buffer_count: usize,
+}
+
+impl<'a> TsProxySendToServerRequest<'a> {
+    const PREFIX_SIZE: usize =
+        RpcContextHandle::SIZE /* Context Handle */ + 4 /* Total Bytes */ + 4 /* Number of Buffers */;
+
+    /// Starts a request with its required, non-empty first buffer.
+    pub(crate) fn new(channel_context: NonNullRpcContextHandle, first_buffer: &'a [u8]) -> Result<Self, RpcWireError> {
+        if first_buffer.is_empty() {
+            return Err(RpcWireError::EmptyFirstBuffer);
+        }
+
+        Ok(Self {
+            channel_context,
+            buffers: [first_buffer, &[], &[]],
+            buffer_count: 1,
+        })
+    }
+
+    /// Adds an optional second or third buffer.
+    pub(crate) fn push_buffer(&mut self, buffer: &'a [u8]) -> Result<(), RpcWireError> {
+        if self.buffer_count == self.buffers.len() {
+            return Err(RpcWireError::BufferCount {
+                actual: self.buffer_count + 1,
+            });
+        }
+
+        self.buffers[self.buffer_count] = buffer;
+        self.buffer_count += 1;
+        Ok(())
+    }
+
+    /// Returns the complete raw stub length after validating the `max_is(32767)` bound.
+    pub(crate) fn encoded_len(&self) -> Result<usize, RpcWireError> {
+        let payload_len = self.payload_len()?;
+        let length_fields_len = 4usize
+            .checked_mul(self.buffer_count)
+            .ok_or(RpcWireError::LengthOverflow)?;
+        let total_data_bytes = payload_len
+            .checked_add(length_fields_len)
+            .ok_or(RpcWireError::LengthOverflow)?;
+        let encoded_len = Self::PREFIX_SIZE
+            .checked_add(total_data_bytes)
+            .ok_or(RpcWireError::LengthOverflow)?;
+
+        if encoded_len > MAX_RPC_MESSAGE_SIZE {
+            return Err(RpcWireError::RequestTooLarge { actual: encoded_len });
+        }
+
+        Ok(encoded_len)
+    }
+
+    /// Encodes this request into an output slice of exactly [`Self::encoded_len`] bytes.
+    pub(crate) fn encode_into(&self, output: &mut [u8]) -> Result<(), RpcWireError> {
+        let encoded_len = self.encoded_len()?;
+        if output.len() != encoded_len {
+            return Err(RpcWireError::OutputLength {
+                actual: output.len(),
+                expected: encoded_len,
+            });
+        }
+
+        let payload_len = self.payload_len()?;
+        let total_data_bytes = payload_len
+            .checked_add(4 * self.buffer_count)
+            .ok_or(RpcWireError::LengthOverflow)?;
+        let total_data_bytes = u32::try_from(total_data_bytes).map_err(|_| RpcWireError::LengthOverflow)?;
+        let buffer_count = u32::try_from(self.buffer_count).map_err(|_| RpcWireError::LengthOverflow)?;
+
+        let mut offset = 0;
+        output[offset..offset + RpcContextHandle::SIZE].copy_from_slice(self.channel_context.as_bytes());
+        offset += RpcContextHandle::SIZE;
+
+        // The length fields are little-endian. [MS-TSGU] 3.6.5.1 says "network byte
+        // order", but the authoritative client (mstsc) emits little-endian, and a real RD
+        // Gateway rejects the big-endian framing.
+        output[offset..offset + 4].copy_from_slice(&total_data_bytes.to_le_bytes());
+        offset += 4;
+        output[offset..offset + 4].copy_from_slice(&buffer_count.to_le_bytes());
+        offset += 4;
+
+        for buffer in self.buffers() {
+            let buffer_len = u32::try_from(buffer.len()).map_err(|_| RpcWireError::LengthOverflow)?;
+            output[offset..offset + 4].copy_from_slice(&buffer_len.to_le_bytes());
+            offset += 4;
+        }
+
+        for buffer in self.buffers() {
+            let end = offset.checked_add(buffer.len()).ok_or(RpcWireError::LengthOverflow)?;
+            output[offset..end].copy_from_slice(buffer);
+            offset = end;
+        }
+
+        debug_assert_eq!(offset, encoded_len);
+        Ok(())
+    }
+
+    /// Encodes this request into a newly allocated contiguous raw RPC stub.
+    pub(crate) fn encode(&self) -> Result<Vec<u8>, RpcWireError> {
+        let mut output = vec![0; self.encoded_len()?];
+        self.encode_into(&mut output)?;
+        Ok(output)
+    }
+
+    fn buffers(&self) -> &[&'a [u8]] {
+        &self.buffers[..self.buffer_count]
+    }
+
+    fn payload_len(&self) -> Result<usize, RpcWireError> {
+        self.buffers().iter().try_fold(0usize, |total, buffer| {
+            total.checked_add(buffer.len()).ok_or(RpcWireError::LengthOverflow)
+        })
+    }
+}
+
+/// Parses exactly the four-byte final `TsProxySetupReceivePipe` return-value stub.
+///
+/// This helper intentionally does not inspect a DCE/RPC PDU or infer byte order.
+/// The caller must provide the data representation determined by its surrounding
+/// DCE/RPC decoder.
+///
+/// [MS-TSGU] 2.2.9.4.3 and 3.6.5.5.
+pub(crate) fn parse_receive_pipe_final_return_value_stub(
+    stub: &[u8],
+    byte_order: RpcStubByteOrder,
+) -> Result<u32, RpcWireError> {
+    let return_value: &[u8; 4] = stub
+        .try_into()
+        .map_err(|_| RpcWireError::FinalReturnValueLength { actual: stub.len() })?;
+
+    Ok(match byte_order {
+        RpcStubByteOrder::LittleEndian => u32::from_le_bytes(*return_value),
+        RpcStubByteOrder::BigEndian => u32::from_be_bytes(*return_value),
+    })
+}
+
+/// DCE/RPC common-header size.
+///
+/// [MS-RPCE] 2.2.2.1 / [C706] 12.6.
+const RPC_COMMON_HEADER_SIZE: usize = 16;
+const RPC_REQUEST_HEADER_SIZE: usize = RPC_COMMON_HEADER_SIZE + 8 /* request fields */;
+const RPC_BIND_BODY_SIZE: usize = 12 /* bind fields and context-list header */
+    + 4 /* presentation-context header */
+    + 20 /* abstract syntax */
+    + 20 /* transfer syntax */;
+const RPC_BIND_PDU_SIZE: usize = RPC_COMMON_HEADER_SIZE + RPC_BIND_BODY_SIZE;
+
+const RPC_VERSION: u8 = 5;
+const RPC_VERSION_MINOR: u8 = 0;
+const RPC_DREP_LITTLE_ENDIAN: [u8; 4] = [0x10, 0, 0, 0];
+const PFC_FIRST_FRAG: u8 = 0x01;
+const PFC_LAST_FRAG: u8 = 0x02;
+const PFC_SUPPORT_HEADER_SIGN: u8 = 0x04;
+/// Concurrent multiplexing: advertised in the bind so the association can carry a
+/// held-open asynchronous call (TsProxyMakeTunnelCall) alongside synchronous calls
+/// ([C706] 12.6.2 / the PFC_CONC_MPX flag).
+const PFC_CONC_MPX: u8 = 0x10;
+
+const PTYPE_REQUEST: u8 = 0;
+const PTYPE_RESPONSE: u8 = 2;
+const PTYPE_FAULT: u8 = 3;
+const PTYPE_BIND: u8 = 11;
+const PTYPE_BIND_ACK: u8 = 12;
+const PTYPE_BIND_NAK: u8 = 13;
+const PTYPE_RPC_AUTH_3: u8 = 16;
+const PTYPE_RTS: u8 = 20;
+
+const RPC_CONTEXT_ID: u16 = 0;
+const RPC_AUTH_TYPE_WINNT: u8 = 0x0a;
+const RPC_AUTH_LEVEL_PACKET_INTEGRITY: u8 = 0x05;
+const RPC_AUTH_CONTEXT_ID: u32 = 0;
+const RPC_SEC_TRAILER_SIZE: usize = 8;
+const DEFAULT_FRAGMENT_SIZE: u16 = 0x10b8;
+const NDR32_TRANSFER_SYNTAX_ID: Uuid = Uuid::from_u128(0x8a885d04_1ceb_11c9_9fe8_08002b104860);
+const NDR32_TRANSFER_SYNTAX_VERSION: RpcSyntaxVersion = RpcSyntaxVersion::new(2, 0);
+const TSPROXY_RPC_INTERFACE_VERSION: RpcSyntaxVersion = RpcSyntaxVersion::new(1, 3);
+
+const RTS_HEADER_SIZE: usize = RPC_COMMON_HEADER_SIZE + 4 /* flags and command count */;
+const RTS_PFC_FLAGS: u8 = PFC_FIRST_FRAG | PFC_LAST_FRAG;
+const RTS_FLAG_NONE: u16 = 0;
+const RTS_FLAG_PING: u16 = 0x0001;
+const RTS_FLAG_OTHER_CMD: u16 = 0x0002;
+const RTS_FLAG_RECYCLE_CHANNEL: u16 = 0x0004;
+const RTS_FLAG_OUT_CHANNEL: u16 = 0x0010;
+const RTS_VERSION: u32 = 1;
+const RTS_COMMAND_RECEIVE_WINDOW_SIZE: u32 = 0;
+const RTS_COMMAND_FLOW_CONTROL_ACK: u32 = 1;
+const RTS_COMMAND_CONNECTION_TIMEOUT: u32 = 2;
+const RTS_COMMAND_COOKIE: u32 = 3;
+const RTS_COMMAND_CHANNEL_LIFETIME: u32 = 4;
+const RTS_COMMAND_CLIENT_KEEPALIVE: u32 = 5;
+const RTS_COMMAND_VERSION: u32 = 6;
+const RTS_COMMAND_ASSOCIATION_GROUP_ID: u32 = 12;
+const RTS_COMMAND_DESTINATION: u32 = 13;
+const RTS_COMMAND_ANCE: u32 = 10;
+const RTS_DESTINATION_FD_CLIENT: u32 = 0;
+const RTS_DESTINATION_FD_SERVER: u32 = 2;
+const RTS_MIN_RECEIVE_WINDOW_SIZE: u32 = 8 * 1024;
+const RTS_MAX_RECEIVE_WINDOW_SIZE: u32 = 256 * 1024;
+const RTS_MIN_CONNECTION_TIMEOUT: u32 = 120_000;
+const RTS_MAX_CONNECTION_TIMEOUT: u32 = 14_400_000;
+const RTS_MIN_CHANNEL_LIFETIME: u32 = 128 * 1024;
+const RTS_MAX_CHANNEL_LIFETIME: u32 = 2 * 1024 * 1024 * 1024;
+const RTS_MIN_CLIENT_KEEPALIVE: u32 = 60_000;
+const RPCH_OUT_CONTENT_LENGTH: u32 = 76;
+const RPCH_OUT_CONTENT_LENGTH_USIZE: usize = 76;
+const RPCH_MIN_CHANNEL_CONTENT_LENGTH: u32 = 128 * 1024;
+const RPCH_MAX_CHANNEL_CONTENT_LENGTH: u32 = 2 * 1024 * 1024 * 1024;
+const MAX_PENDING_RPC_FRAGMENTS: usize = 16;
+
+/// Errors reported by the DCE/RPC connection-oriented PDU codecs.
+///
+/// The codec supports the little-endian NDR32 path and the packet-integrity
+/// NTLM bind exchange needed by the TS Gateway RPC-over-HTTP runtime.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RpcPduError {
+    Truncated {
+        actual: usize,
+        required: usize,
+    },
+    UnsupportedVersion {
+        major: u8,
+        minor: u8,
+    },
+    UnsupportedDataRepresentation {
+        value: [u8; 4],
+    },
+    InvalidFragmentLength {
+        fragment_length: u16,
+    },
+    IncompleteFragment {
+        actual: usize,
+        fragment_length: u16,
+    },
+    AuthenticationUnsupported {
+        auth_length: u16,
+    },
+    AuthenticationRequired,
+    MissingSupportHeaderSign,
+    InvalidSecurityTrailer {
+        fragment_length: u16,
+        auth_length: u16,
+    },
+    InvalidAuthenticationPadding {
+        actual: u8,
+        expected: usize,
+    },
+    NonZeroAuthenticationPadding,
+    UnexpectedAuthenticationType {
+        expected: u8,
+        actual: u8,
+    },
+    UnexpectedAuthenticationLevel {
+        expected: u8,
+        actual: u8,
+    },
+    UnexpectedAuthenticationContextId {
+        expected: u32,
+        actual: u32,
+    },
+    EmptyAuthenticationToken,
+    UnexpectedPduType {
+        expected: u8,
+        actual: u8,
+    },
+    FragmentedPduUnsupported {
+        flags: u8,
+    },
+    UnexpectedResponseFragment {
+        flags: u8,
+    },
+    ResponseFragmentCallId {
+        expected: u32,
+        actual: u32,
+    },
+    ResponseStubTooLarge {
+        actual: usize,
+        maximum: usize,
+    },
+    InvalidFragmentSize {
+        maximum: u16,
+    },
+    FragmentExceedsMaximum {
+        fragment_length: u16,
+        maximum: u16,
+    },
+    PendingBytesExceedMaximum {
+        actual: usize,
+        maximum: usize,
+    },
+    FragmentTooLarge {
+        actual: usize,
+        maximum: u16,
+    },
+    LengthOverflow,
+    UnexpectedPresentationContextCount {
+        actual: u8,
+    },
+    PresentationContextRejected {
+        result: u16,
+        reason: u16,
+    },
+    UnexpectedTransferSyntax {
+        identifier: Uuid,
+        version: RpcSyntaxVersion,
+    },
+    UnexpectedContextId {
+        actual: u16,
+    },
+    InvalidAllocHint {
+        alloc_hint: u32,
+        stub_length: usize,
+    },
+    InvalidBindNakVersionsLength {
+        actual: usize,
+        expected: usize,
+    },
+    UnexpectedRtsCallId {
+        actual: u32,
+    },
+    InvalidRtsPfcFlags {
+        actual: u8,
+    },
+    UnexpectedRtsFlags {
+        expected: u16,
+        actual: u16,
+    },
+    UnexpectedRtsCommandCount {
+        expected: u16,
+        actual: u16,
+    },
+    InvalidRtsBodyLength {
+        expected: usize,
+        actual: usize,
+    },
+    UnexpectedRtsCommandType {
+        expected: u32,
+        actual: u32,
+    },
+    UnexpectedRtsDestination {
+        expected: u32,
+        actual: u32,
+    },
+    InvalidRtsReceiveWindowSize {
+        actual: u32,
+    },
+    InvalidRtsConnectionTimeout {
+        actual: u32,
+    },
+    InvalidRtsChannelLifetime {
+        actual: u32,
+    },
+    InvalidRtsClientKeepalive {
+        actual: u32,
+    },
+}
+
+impl fmt::Display for RpcPduError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Truncated { actual, required } => {
+                write!(f, "truncated rpc pdu: got {actual} bytes, need at least {required}")
+            }
+            Self::UnsupportedVersion { major, minor } => {
+                write!(f, "unsupported rpc version {major}.{minor}")
+            }
+            Self::UnsupportedDataRepresentation { value } => {
+                write!(f, "unsupported rpc data representation {value:02x?}")
+            }
+            Self::InvalidFragmentLength { fragment_length } => {
+                write!(f, "invalid rpc fragment length {fragment_length}")
+            }
+            Self::IncompleteFragment {
+                actual,
+                fragment_length,
+            } => {
+                write!(f, "incomplete rpc fragment: got {actual} bytes, need {fragment_length}")
+            }
+            Self::AuthenticationUnsupported { auth_length } => {
+                write!(
+                    f,
+                    "rpc authentication verifier of length {auth_length} is not supported"
+                )
+            }
+            Self::AuthenticationRequired => f.write_str("rpc authentication token is required"),
+            Self::MissingSupportHeaderSign => f.write_str("rpc pdu does not support header signing"),
+            Self::InvalidSecurityTrailer {
+                fragment_length,
+                auth_length,
+            } => {
+                write!(
+                    f,
+                    "invalid rpc security trailer for {fragment_length}-byte fragment and {auth_length}-byte token"
+                )
+            }
+            Self::InvalidAuthenticationPadding { actual, expected } => {
+                write!(f, "invalid rpc authentication padding {actual}, expected {expected}")
+            }
+            Self::NonZeroAuthenticationPadding => f.write_str("rpc authentication padding is not zero"),
+            Self::UnexpectedAuthenticationType { expected, actual } => {
+                write!(f, "unexpected rpc authentication type {actual}, expected {expected}")
+            }
+            Self::UnexpectedAuthenticationLevel { expected, actual } => {
+                write!(f, "unexpected rpc authentication level {actual}, expected {expected}")
+            }
+            Self::UnexpectedAuthenticationContextId { expected, actual } => {
+                write!(
+                    f,
+                    "unexpected rpc authentication context id {actual}, expected {expected}"
+                )
+            }
+            Self::EmptyAuthenticationToken => f.write_str("empty rpc authentication token"),
+            Self::UnexpectedPduType { expected, actual } => {
+                write!(f, "unexpected rpc pdu type {actual}, expected {expected}")
+            }
+            Self::FragmentedPduUnsupported { flags } => {
+                write!(f, "fragmented rpc pdu with flags 0x{flags:02x} is not supported")
+            }
+            Self::UnexpectedResponseFragment { flags } => {
+                write!(f, "unexpected rpc response fragment flags 0x{flags:02x}")
+            }
+            Self::ResponseFragmentCallId { expected, actual } => {
+                write!(f, "rpc response fragment call id {actual} does not match {expected}")
+            }
+            Self::ResponseStubTooLarge { actual, maximum } => {
+                write!(f, "rpc response stub length {actual} exceeds {maximum}")
+            }
+            Self::InvalidFragmentSize { maximum } => {
+                write!(f, "invalid rpc fragment maximum {maximum}")
+            }
+            Self::FragmentExceedsMaximum {
+                fragment_length,
+                maximum,
+            } => {
+                write!(
+                    f,
+                    "rpc fragment length {fragment_length} exceeds negotiated maximum {maximum}"
+                )
+            }
+            Self::PendingBytesExceedMaximum { actual, maximum } => {
+                write!(f, "pending rpc stream size {actual} exceeds maximum {maximum}")
+            }
+            Self::FragmentTooLarge { actual, maximum } => {
+                write!(f, "rpc pdu length {actual} exceeds maximum {maximum}")
+            }
+            Self::LengthOverflow => f.write_str("rpc pdu length overflow"),
+            Self::UnexpectedPresentationContextCount { actual } => {
+                write!(f, "unexpected rpc presentation-context count {actual}, expected 1")
+            }
+            Self::PresentationContextRejected { result, reason } => {
+                write!(
+                    f,
+                    "rpc presentation context rejected with result {result}, reason {reason}"
+                )
+            }
+            Self::UnexpectedTransferSyntax { identifier, version } => {
+                write!(
+                    f,
+                    "unexpected rpc transfer syntax {identifier} version {}.{}",
+                    version.major, version.minor
+                )
+            }
+            Self::UnexpectedContextId { actual } => {
+                write!(
+                    f,
+                    "unexpected rpc presentation context id {actual}, expected {RPC_CONTEXT_ID}"
+                )
+            }
+            Self::InvalidAllocHint {
+                alloc_hint,
+                stub_length,
+            } => {
+                write!(
+                    f,
+                    "invalid rpc allocation hint {alloc_hint} for {stub_length}-byte stub"
+                )
+            }
+            Self::InvalidBindNakVersionsLength { actual, expected } => {
+                write!(f, "invalid rpc bind_nak versions length {actual}, expected {expected}")
+            }
+            Self::UnexpectedRtsCallId { actual } => {
+                write!(f, "unexpected rts call id {actual}, expected 0")
+            }
+            Self::InvalidRtsPfcFlags { actual } => {
+                write!(f, "invalid rts pfc flags 0x{actual:02x}")
+            }
+            Self::UnexpectedRtsFlags { expected, actual } => {
+                write!(f, "unexpected rts flags 0x{actual:04x}, expected 0x{expected:04x}")
+            }
+            Self::UnexpectedRtsCommandCount { expected, actual } => {
+                write!(f, "unexpected rts command count {actual}, expected {expected}")
+            }
+            Self::InvalidRtsBodyLength { expected, actual } => {
+                write!(f, "invalid rts command body length {actual}, expected {expected}")
+            }
+            Self::UnexpectedRtsCommandType { expected, actual } => {
+                write!(f, "unexpected rts command type {actual}, expected {expected}")
+            }
+            Self::UnexpectedRtsDestination { expected, actual } => {
+                write!(f, "unexpected rts destination {actual}, expected {expected}")
+            }
+            Self::InvalidRtsReceiveWindowSize { actual } => {
+                write!(f, "invalid rts receive window size {actual}")
+            }
+            Self::InvalidRtsConnectionTimeout { actual } => {
+                write!(f, "invalid rts connection timeout {actual}")
+            }
+            Self::InvalidRtsChannelLifetime { actual } => {
+                write!(f, "invalid rts channel lifetime {actual}")
+            }
+            Self::InvalidRtsClientKeepalive { actual } => {
+                write!(f, "invalid rts client keepalive {actual}")
+            }
+        }
+    }
+}
+
+impl core::error::Error for RpcPduError {}
+
+/// A DCE/RPC syntax version.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct RpcSyntaxVersion {
+    major: u16,
+    minor: u16,
+}
+
+impl RpcSyntaxVersion {
+    const fn new(major: u16, minor: u16) -> Self {
+        Self { major, minor }
+    }
+}
+
+/// Negotiated client-to-server and server-to-client fragment maxima.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct RpcFragmentSizes {
+    max_xmit: u16,
+    max_recv: u16,
+}
+
+impl RpcFragmentSizes {
+    /// Conventional DCE/RPC fragment maxima used for the initial bind.
+    pub(crate) const DEFAULT: Self = Self {
+        max_xmit: DEFAULT_FRAGMENT_SIZE,
+        max_recv: DEFAULT_FRAGMENT_SIZE,
+    };
+
+    pub(crate) fn new(max_xmit: u16, max_recv: u16) -> Result<Self, RpcPduError> {
+        for maximum in [max_xmit, max_recv] {
+            if usize::from(maximum) < RPC_COMMON_HEADER_SIZE {
+                return Err(RpcPduError::InvalidFragmentSize { maximum });
+            }
+        }
+
+        Ok(Self { max_xmit, max_recv })
+    }
+
+    pub(crate) const fn max_xmit(self) -> u16 {
+        self.max_xmit
+    }
+
+    pub(crate) const fn max_recv(self) -> u16 {
+        self.max_recv
+    }
+}
+
+/// The parsed 16-byte DCE/RPC common header.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct RpcCommonHeader {
+    ptype: u8,
+    pfc_flags: u8,
+    fragment_length: u16,
+    auth_length: u16,
+    call_id: u32,
+}
+
+impl RpcCommonHeader {
+    /// Parses one common header and verifies that its claimed fragment is present.
+    ///
+    /// The returned header can be used to split a transport buffer at
+    /// [`Self::fragment_length`]. Any bytes following that fragment are left for
+    /// the transport to process as later PDUs.
+    pub(crate) fn decode(source: &[u8]) -> Result<Self, RpcPduError> {
+        let header = Self::decode_prefix(source)?;
+        if source.len() < usize::from(header.fragment_length) {
+            return Err(RpcPduError::IncompleteFragment {
+                actual: source.len(),
+                fragment_length: header.fragment_length,
+            });
+        }
+
+        Ok(header)
+    }
+
+    /// Parses a common header without requiring the complete fragment.
+    ///
+    /// This is used by stream transports to validate a fragment length before
+    /// buffering the whole PDU.
+    fn decode_prefix(source: &[u8]) -> Result<Self, RpcPduError> {
+        let header = source.get(..RPC_COMMON_HEADER_SIZE).ok_or(RpcPduError::Truncated {
+            actual: source.len(),
+            required: RPC_COMMON_HEADER_SIZE,
+        })?;
+
+        let major = header[0];
+        let minor = header[1];
+        if (major, minor) != (RPC_VERSION, RPC_VERSION_MINOR) {
+            return Err(RpcPduError::UnsupportedVersion { major, minor });
+        }
+
+        let drep = [header[4], header[5], header[6], header[7]];
+        if drep != RPC_DREP_LITTLE_ENDIAN {
+            return Err(RpcPduError::UnsupportedDataRepresentation { value: drep });
+        }
+
+        let fragment_length = u16::from_le_bytes([header[8], header[9]]);
+        if usize::from(fragment_length) < RPC_COMMON_HEADER_SIZE {
+            return Err(RpcPduError::InvalidFragmentLength { fragment_length });
+        }
+
+        Ok(Self {
+            ptype: header[2],
+            pfc_flags: header[3],
+            fragment_length,
+            auth_length: u16::from_le_bytes([header[10], header[11]]),
+            call_id: u32::from_le_bytes([header[12], header[13], header[14], header[15]]),
+        })
+    }
+
+    pub(crate) const fn fragment_length(self) -> u16 {
+        self.fragment_length
+    }
+
+    pub(crate) const fn ptype(self) -> u8 {
+        self.ptype
+    }
+
+    pub(crate) const fn pfc_flags(self) -> u8 {
+        self.pfc_flags
+    }
+
+    pub(crate) const fn auth_length(self) -> u16 {
+        self.auth_length
+    }
+
+    pub(crate) const fn call_id(self) -> u32 {
+        self.call_id
+    }
+
+    /// Encodes a common header for a body that excludes the security trailer and
+    /// authentication token.
+    ///
+    /// A future authentication codec can use `auth_length` to append its
+    /// padding, security trailer, and token without changing header layout.
+    fn encode(
+        ptype: u8,
+        pfc_flags: u8,
+        call_id: u32,
+        body_length: usize,
+        auth_length: u16,
+    ) -> Result<[u8; RPC_COMMON_HEADER_SIZE], RpcPduError> {
+        let authentication_length = if auth_length == 0 {
+            0
+        } else {
+            8usize
+                .checked_add(usize::from(auth_length))
+                .ok_or(RpcPduError::LengthOverflow)?
+        };
+        let fragment_length = RPC_COMMON_HEADER_SIZE
+            .checked_add(body_length)
+            .and_then(|length| length.checked_add(authentication_length))
+            .ok_or(RpcPduError::LengthOverflow)?;
+        let fragment_length = u16::try_from(fragment_length).map_err(|_| RpcPduError::LengthOverflow)?;
+
+        let mut header = [0; RPC_COMMON_HEADER_SIZE];
+        header[0] = RPC_VERSION;
+        header[1] = RPC_VERSION_MINOR;
+        header[2] = ptype;
+        header[3] = pfc_flags;
+        header[4..8].copy_from_slice(&RPC_DREP_LITTLE_ENDIAN);
+        header[8..10].copy_from_slice(&fragment_length.to_le_bytes());
+        header[10..12].copy_from_slice(&auth_length.to_le_bytes());
+        header[12..16].copy_from_slice(&call_id.to_le_bytes());
+        Ok(header)
+    }
+}
+
+/// Incrementally frames DCE/RPC PDUs from an RPCH response stream.
+///
+/// Each yielded buffer is exactly one complete DCE/RPC fragment. The stream
+/// validates the common header and negotiated receive maximum before retaining
+/// a claimed fragment, preventing a peer from making the client buffer an
+/// oversized PDU.
+#[derive(Debug)]
+pub(crate) struct RpcPduStream {
+    buffer: Vec<u8>,
+    maximum_fragment_size: u16,
+    maximum_pending_bytes: usize,
+}
+
+impl RpcPduStream {
+    pub(crate) fn new(maximum_fragment_size: u16) -> Result<Self, RpcPduError> {
+        if usize::from(maximum_fragment_size) < RPC_COMMON_HEADER_SIZE {
+            return Err(RpcPduError::InvalidFragmentSize {
+                maximum: maximum_fragment_size,
+            });
+        }
+
+        Ok(Self {
+            buffer: Vec::new(),
+            maximum_fragment_size,
+            maximum_pending_bytes: usize::from(maximum_fragment_size)
+                .checked_mul(MAX_PENDING_RPC_FRAGMENTS)
+                .ok_or(RpcPduError::LengthOverflow)?,
+        })
+    }
+
+    /// Adds received RPCH response bytes to the pending DCE/RPC stream.
+    ///
+    /// The caller must drain complete fragments with [`Self::next`] before
+    /// buffering more than [`MAX_PENDING_RPC_FRAGMENTS`] fragments.
+    pub(crate) fn push(&mut self, bytes: &[u8]) -> Result<(), RpcPduError> {
+        let pending = self
+            .buffer
+            .len()
+            .checked_add(bytes.len())
+            .ok_or(RpcPduError::LengthOverflow)?;
+        if pending > self.maximum_pending_bytes {
+            return Err(RpcPduError::PendingBytesExceedMaximum {
+                actual: pending,
+                maximum: self.maximum_pending_bytes,
+            });
+        }
+
+        self.buffer.extend_from_slice(bytes);
+        Ok(())
+    }
+
+    /// Returns the next complete DCE/RPC fragment, if one has been received.
+    pub(crate) fn next(&mut self) -> Result<Option<Vec<u8>>, RpcPduError> {
+        let header = match RpcCommonHeader::decode_prefix(&self.buffer) {
+            Ok(header) => header,
+            Err(RpcPduError::Truncated { .. }) => return Ok(None),
+            Err(error) => return Err(error),
+        };
+
+        if header.fragment_length > self.maximum_fragment_size {
+            return Err(RpcPduError::FragmentExceedsMaximum {
+                fragment_length: header.fragment_length,
+                maximum: self.maximum_fragment_size,
+            });
+        }
+
+        let fragment_length = usize::from(header.fragment_length);
+        if self.buffer.len() < fragment_length {
+            return Ok(None);
+        }
+
+        Ok(Some(self.buffer.drain(..fragment_length).collect()))
+    }
+}
+
+/// RPCH HTTP channel selected for a request.
+///
+/// [MS-RPCH] 2.1.2.1.1 and 2.1.2.1.2.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RpchHttpChannel {
+    In,
+    Out,
+}
+
+impl RpchHttpChannel {
+    const fn method(self) -> &'static str {
+        match self {
+            Self::In => "RPC_IN_DATA",
+            Self::Out => "RPC_OUT_DATA",
+        }
+    }
+
+    const fn expected_content_length(self) -> Option<u32> {
+        match self {
+            Self::In => None,
+            Self::Out => Some(RPCH_OUT_CONTENT_LENGTH),
+        }
+    }
+}
+
+/// RPCH virtual-connection opening state.
+///
+/// [MS-RPCH] 3.2.2.4.1.2 and 3.2.2.5.2 through 3.2.2.5.4.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RpcHttpV2State {
+    Initial,
+    InRequestStarted,
+    OutRequestStarted,
+    AwaitingOutResponse,
+    AwaitingA3,
+    AwaitingC2,
+    Open,
+    Failed,
+}
+
+/// Errors returned while building or advancing an RPCH v2 connection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RpcHttpV2Error {
+    InvalidState {
+        action: &'static str,
+        state: RpcHttpV2State,
+    },
+    InvalidGatewayHost,
+    InvalidTargetServer,
+    InvalidTargetPort,
+    InvalidContentLength {
+        channel: RpchHttpChannel,
+        actual: u32,
+    },
+    InvalidHttpHeader,
+    OutResponseStatus {
+        actual: u16,
+    },
+    OutResponseContentType,
+    OutResponseContentLength {
+        actual: Option<u32>,
+    },
+    UnsupportedProtocolVersion {
+        actual: u32,
+    },
+    Rpc(RpcPduError),
+}
+
+impl fmt::Display for RpcHttpV2Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidState { action, state } => {
+                write!(f, "cannot {action} while rpch setup is {state:?}")
+            }
+            Self::InvalidGatewayHost => f.write_str("invalid rpch gateway host"),
+            Self::InvalidTargetServer => f.write_str("invalid rpch target server"),
+            Self::InvalidTargetPort => f.write_str("invalid rpch target port"),
+            Self::InvalidContentLength { channel, actual } => {
+                write!(f, "invalid rpch {channel:?} content length {actual}")
+            }
+            Self::InvalidHttpHeader => f.write_str("invalid rpch HTTP header"),
+            Self::OutResponseStatus { actual } => {
+                write!(f, "invalid rpch OUT response status {actual}")
+            }
+            Self::OutResponseContentType => f.write_str("invalid rpch OUT response content type"),
+            Self::OutResponseContentLength { actual } => match actual {
+                Some(actual) => write!(f, "invalid rpch OUT response content length {actual}"),
+                None => f.write_str("missing rpch OUT response content length"),
+            },
+            Self::UnsupportedProtocolVersion { actual } => {
+                write!(f, "unsupported rpch protocol version {actual}")
+            }
+            Self::Rpc(error) => error.fmt(f),
+        }
+    }
+}
+
+impl core::error::Error for RpcHttpV2Error {}
+
+impl From<RpcPduError> for RpcHttpV2Error {
+    fn from(error: RpcPduError) -> Self {
+        Self::Rpc(error)
+    }
+}
+
+/// Client-controlled values used when opening an RPCH virtual connection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct RpcHttpV2Settings {
+    receive_window_size: u32,
+    channel_lifetime: u32,
+    client_keepalive: u32,
+}
+
+impl RpcHttpV2Settings {
+    const DEFAULT_CLIENT_KEEPALIVE: u32 = 300_000;
+
+    pub(crate) fn new(
+        receive_window_size: u32,
+        channel_lifetime: u32,
+        client_keepalive: u32,
+    ) -> Result<Self, RpcPduError> {
+        validate_rts_receive_window_size(receive_window_size)?;
+        validate_rts_channel_lifetime(channel_lifetime)?;
+        validate_rts_client_keepalive(client_keepalive)?;
+
+        Ok(Self {
+            receive_window_size,
+            channel_lifetime,
+            client_keepalive,
+        })
+    }
+
+    pub(crate) const fn receive_window_size(self) -> u32 {
+        self.receive_window_size
+    }
+
+    /// Returns the exact `Content-Length` for the default IN channel.
+    pub(crate) const fn channel_lifetime(self) -> u32 {
+        self.channel_lifetime
+    }
+
+    pub(crate) const fn client_keepalive(self) -> u32 {
+        self.client_keepalive
+    }
+
+    const fn effective_client_keepalive(self) -> u32 {
+        if self.client_keepalive == 0 {
+            Self::DEFAULT_CLIENT_KEEPALIVE
+        } else {
+            self.client_keepalive
+        }
+    }
+}
+
+impl Default for RpcHttpV2Settings {
+    fn default() -> Self {
+        Self {
+            receive_window_size: 64 * 1024,
+            channel_lifetime: 1024 * 1024 * 1024,
+            client_keepalive: Self::DEFAULT_CLIENT_KEEPALIVE,
+        }
+    }
+}
+
+/// Stateful validation for the initial RPCH v2 CONN sequence.
+///
+/// The HTTP implementation must first start the authenticated IN request, then
+/// send the fixed-length OUT request returned by [`Self::out_request_body`],
+/// then write [`Self::in_request_initial_pdu`] to the authenticated streaming
+/// IN body. Only then may it accept the OUT response and feed its body PDUs to
+/// [`Self::receive_out_pdu`].
+///
+/// [MS-RPCH] 3.2.2.4.1.2 and 3.2.2.5.2 through 3.2.2.5.4.
+#[derive(Debug)]
+pub(crate) struct RpcHttpV2Setup {
+    settings: RpcHttpV2Settings,
+    virtual_connection_cookie: RtsCookie,
+    out_channel_cookie: RtsCookie,
+    in_channel_cookie: RtsCookie,
+    association_group_id: RtsCookie,
+    state: RpcHttpV2State,
+    in_ping_timeout: Option<u32>,
+    connection_timeout: Option<u32>,
+    peer_receive_window_size: Option<u32>,
+}
+
+impl RpcHttpV2Setup {
+    pub(crate) fn new(settings: RpcHttpV2Settings) -> Self {
+        Self::with_cookies(
+            settings,
+            RtsCookie::new(*Uuid::new_v4().as_bytes()),
+            RtsCookie::new(*Uuid::new_v4().as_bytes()),
+            RtsCookie::new(*Uuid::new_v4().as_bytes()),
+            RtsCookie::new(*Uuid::new_v4().as_bytes()),
+        )
+    }
+
+    pub(crate) const fn with_cookies(
+        settings: RpcHttpV2Settings,
+        virtual_connection_cookie: RtsCookie,
+        out_channel_cookie: RtsCookie,
+        in_channel_cookie: RtsCookie,
+        association_group_id: RtsCookie,
+    ) -> Self {
+        Self {
+            settings,
+            virtual_connection_cookie,
+            out_channel_cookie,
+            in_channel_cookie,
+            association_group_id,
+            state: RpcHttpV2State::Initial,
+            in_ping_timeout: None,
+            connection_timeout: None,
+            peer_receive_window_size: None,
+        }
+    }
+
+    pub(crate) const fn state(&self) -> RpcHttpV2State {
+        self.state
+    }
+
+    pub(crate) const fn in_channel_content_length(&self) -> u32 {
+        self.settings.channel_lifetime()
+    }
+
+    pub(crate) const fn connection_timeout(&self) -> Option<u32> {
+        self.connection_timeout
+    }
+
+    pub(crate) const fn in_ping_timeout(&self) -> Option<u32> {
+        self.in_ping_timeout
+    }
+
+    pub(crate) const fn peer_receive_window_size(&self) -> Option<u32> {
+        self.peer_receive_window_size
+    }
+
+    /// Records that the authenticated IN request headers are in flight.
+    ///
+    /// The caller must not write an IN body PDU before
+    /// [`Self::in_request_initial_pdu`] is returned.
+    pub(crate) fn start_in_request(&mut self) -> Result<(), RpcHttpV2Error> {
+        if self.state != RpcHttpV2State::Initial {
+            return self.fail(RpcHttpV2Error::InvalidState {
+                action: "start the IN request",
+                state: self.state,
+            });
+        }
+
+        self.state = RpcHttpV2State::InRequestStarted;
+        Ok(())
+    }
+
+    /// Returns the exact 76-byte CONN/A1 body for the OUT request.
+    pub(crate) fn out_request_body(&mut self) -> Result<Vec<u8>, RpcHttpV2Error> {
+        if self.state != RpcHttpV2State::InRequestStarted {
+            return self.fail(RpcHttpV2Error::InvalidState {
+                action: "start the OUT request",
+                state: self.state,
+            });
+        }
+
+        let body = encode_rts_conn_a1(
+            self.virtual_connection_cookie,
+            self.out_channel_cookie,
+            self.settings.receive_window_size(),
+        )
+        .map_err(RpcHttpV2Error::from)?;
+        debug_assert_eq!(body.len(), RPCH_OUT_CONTENT_LENGTH_USIZE);
+        self.state = RpcHttpV2State::OutRequestStarted;
+        Ok(body)
+    }
+
+    /// Returns the CONN/B1 PDU, the first body PDU for the streaming IN request.
+    pub(crate) fn in_request_initial_pdu(&mut self) -> Result<Vec<u8>, RpcHttpV2Error> {
+        if self.state != RpcHttpV2State::OutRequestStarted {
+            return self.fail(RpcHttpV2Error::InvalidState {
+                action: "send CONN/B1",
+                state: self.state,
+            });
+        }
+
+        let pdu = encode_rts_conn_b1(
+            self.virtual_connection_cookie,
+            self.in_channel_cookie,
+            self.settings.channel_lifetime(),
+            self.settings.client_keepalive(),
+            self.association_group_id,
+        )
+        .map_err(RpcHttpV2Error::from)?;
+        self.state = RpcHttpV2State::AwaitingOutResponse;
+        Ok(pdu)
+    }
+
+    /// Validates the OUT response before its PDU body is consumed.
+    pub(crate) fn accept_out_response(
+        &mut self,
+        status: u16,
+        content_type: Option<&str>,
+        content_length: Option<u32>,
+    ) -> Result<(), RpcHttpV2Error> {
+        if self.state != RpcHttpV2State::AwaitingOutResponse {
+            return self.fail(RpcHttpV2Error::InvalidState {
+                action: "accept the OUT response",
+                state: self.state,
+            });
+        }
+        if status != http::StatusCode::OK.as_u16() {
+            return self.fail(RpcHttpV2Error::OutResponseStatus { actual: status });
+        }
+        if !content_type.is_some_and(|value| value.trim().eq_ignore_ascii_case("application/rpc")) {
+            return self.fail(RpcHttpV2Error::OutResponseContentType);
+        }
+        if !content_length
+            .is_some_and(|value| (RPCH_MIN_CHANNEL_CONTENT_LENGTH..=RPCH_MAX_CHANNEL_CONTENT_LENGTH).contains(&value))
+        {
+            return self.fail(RpcHttpV2Error::OutResponseContentLength { actual: content_length });
+        }
+
+        self.state = RpcHttpV2State::AwaitingA3;
+        Ok(())
+    }
+
+    /// Validates the next CONN/A3 or CONN/C2 PDU from the OUT response body.
+    pub(crate) fn receive_out_pdu(&mut self, pdu: &[u8]) -> Result<(), RpcHttpV2Error> {
+        match self.state {
+            RpcHttpV2State::AwaitingA3 => {
+                let a3 = match decode_rts_conn_a3(pdu) {
+                    Ok(a3) => a3,
+                    Err(error) => return self.fail(error.into()),
+                };
+                self.in_ping_timeout = Some(a3.connection_timeout);
+                self.state = RpcHttpV2State::AwaitingC2;
+                Ok(())
+            }
+            RpcHttpV2State::AwaitingC2 => {
+                let c2 = match decode_rts_conn_c2(pdu) {
+                    Ok(c2) => c2,
+                    Err(error) => return self.fail(error.into()),
+                };
+                if c2.version != RTS_VERSION {
+                    return self.fail(RpcHttpV2Error::UnsupportedProtocolVersion { actual: c2.version });
+                }
+
+                self.connection_timeout = Some(c2.connection_timeout);
+                self.peer_receive_window_size = Some(c2.receive_window_size);
+                self.state = RpcHttpV2State::Open;
+                Ok(())
+            }
+            state => self.fail(RpcHttpV2Error::InvalidState {
+                action: "consume an OUT setup PDU",
+                state,
+            }),
+        }
+    }
+
+    /// Rejects use of the RPC PDU streams until the CONN sequence has completed.
+    pub(crate) fn require_open(&mut self) -> Result<(), RpcHttpV2Error> {
+        if self.state == RpcHttpV2State::Open {
+            Ok(())
+        } else {
+            self.fail(RpcHttpV2Error::InvalidState {
+                action: "send an RPC PDU",
+                state: self.state,
+            })
+        }
+    }
+
+    /// Creates the flow-control state for the established default IN and OUT channels.
+    ///
+    /// [MS-RPCH] 3.2.1.4.1 and 3.2.1.5.1.
+    pub(crate) fn flow_control(&self) -> Result<RpcHttpV2FlowControl, RpcHttpV2Error> {
+        if self.state != RpcHttpV2State::Open {
+            return Err(RpcHttpV2Error::InvalidState {
+                action: "create RPCH flow-control state",
+                state: self.state,
+            });
+        }
+
+        let peer_receive_window_size = self.peer_receive_window_size.ok_or(RpcHttpV2Error::InvalidState {
+            action: "read the peer receive window",
+            state: self.state,
+        })?;
+        Ok(RpcHttpV2FlowControl::new(
+            self.settings.receive_window_size(),
+            peer_receive_window_size,
+            self.out_channel_cookie,
+            self.in_channel_cookie,
+        ))
+    }
+
+    /// Creates the ping schedule for the established default IN channel.
+    ///
+    /// [MS-RPCH] 3.2.1.2.1, 3.2.1.2.2, and 3.2.2.6.
+    pub(crate) fn ping_schedule(&self, now: Duration) -> Result<RpcHttpV2PingSchedule, RpcHttpV2Error> {
+        if self.state != RpcHttpV2State::Open {
+            return Err(RpcHttpV2Error::InvalidState {
+                action: "create RPCH ping schedule",
+                state: self.state,
+            });
+        }
+
+        let connection_timeout = self.in_ping_timeout.ok_or(RpcHttpV2Error::InvalidState {
+            action: "read the IN channel connection timeout",
+            state: self.state,
+        })?;
+        Ok(RpcHttpV2PingSchedule::new(
+            Duration::from_millis(u64::from(connection_timeout)),
+            Duration::from_millis(u64::from(self.settings.effective_client_keepalive())),
+            now,
+        ))
+    }
+
+    fn fail<T>(&mut self, error: RpcHttpV2Error) -> Result<T, RpcHttpV2Error> {
+        self.state = RpcHttpV2State::Failed;
+        Err(error)
+    }
+}
+
+/// Flow-control state for the default RPCH IN and OUT channels.
+///
+/// RPC PDUs received on the OUT channel consume the local receive window.
+/// RPC PDUs sent on the IN channel consume the peer's advertised receive window.
+///
+/// [MS-RPCH] 3.2.1.1.4, 3.2.1.1.5, 3.2.1.4.1, and 3.2.1.5.1.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct RpcHttpV2FlowControl {
+    receive_window_size: u32,
+    receive_available_window: u32,
+    // This tracks advertised capacity minus later queued PDUs and can become negative.
+    receive_available_window_advertised: i64,
+    receive_bytes_received: u32,
+    peer_receive_window_size: u32,
+    send_available_window: u32,
+    send_bytes_sent: u32,
+    receive_channel_cookie: RtsCookie,
+    send_channel_cookie: RtsCookie,
+}
+
+/// Errors reported while applying RPCH receive-window accounting.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RpcHttpV2FlowControlError {
+    PduLengthOverflow {
+        actual: usize,
+    },
+    SendWindowExhausted {
+        pdu_size: u32,
+        available_window: u32,
+    },
+    ReceiveWindowExhausted {
+        pdu_size: u32,
+        available_window: u32,
+    },
+    PduNotQueued {
+        pdu_size: u32,
+        queued_bytes: u32,
+    },
+    BytesReceivedOverflow {
+        current: u32,
+        pdu_size: u32,
+    },
+    BytesSentOverflow {
+        current: u32,
+        pdu_size: u32,
+    },
+    InvalidFlowControlAck {
+        bytes_received: u32,
+        bytes_sent: u32,
+    },
+    FlowControlAckWindowExceedsPeer {
+        available_window: u32,
+        peer_receive_window_size: u32,
+    },
+    FlowControlAckExhaustsSenderWindow {
+        available_window: u32,
+        unacknowledged_bytes: u32,
+    },
+}
+
+impl fmt::Display for RpcHttpV2FlowControlError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::PduLengthOverflow { actual } => write!(f, "rpch pdu length {actual} exceeds u32"),
+            Self::SendWindowExhausted {
+                pdu_size,
+                available_window,
+            } => write!(
+                f,
+                "rpch pdu size {pdu_size} exceeds available send window {available_window}"
+            ),
+            Self::ReceiveWindowExhausted {
+                pdu_size,
+                available_window,
+            } => write!(
+                f,
+                "rpch pdu size {pdu_size} exceeds available receive window {available_window}"
+            ),
+            Self::PduNotQueued { pdu_size, queued_bytes } => write!(
+                f,
+                "rpch consumed pdu size {pdu_size} exceeds queued bytes {queued_bytes}"
+            ),
+            Self::BytesReceivedOverflow { current, pdu_size } => {
+                write!(f, "rpch received byte count overflows: {current} + {pdu_size}")
+            }
+            Self::BytesSentOverflow { current, pdu_size } => {
+                write!(f, "rpch sent byte count overflows: {current} + {pdu_size}")
+            }
+            Self::InvalidFlowControlAck {
+                bytes_received,
+                bytes_sent,
+            } => write!(
+                f,
+                "rpch flow-control ack bytes received {bytes_received} exceeds bytes sent {bytes_sent}"
+            ),
+            Self::FlowControlAckWindowExceedsPeer {
+                available_window,
+                peer_receive_window_size,
+            } => write!(
+                f,
+                "rpch flow-control ack window {available_window} exceeds peer receive window {peer_receive_window_size}"
+            ),
+            Self::FlowControlAckExhaustsSenderWindow {
+                available_window,
+                unacknowledged_bytes,
+            } => write!(
+                f,
+                "rpch flow-control ack window {available_window} is below unacknowledged bytes {unacknowledged_bytes}"
+            ),
+        }
+    }
+}
+
+impl core::error::Error for RpcHttpV2FlowControlError {}
+
+/// Schedules PING PDUs for the default RPCH IN channel.
+///
+/// The caller records every PDU sent on that channel with [`Self::record_send`].
+/// A PING is due when the negotiated connection timeout expires without traffic,
+/// or halfway through the requested keepalive interval.
+///
+/// [MS-RPCH] 3.2.1.2.1, 3.2.1.2.2, and 3.2.2.6.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct RpcHttpV2PingSchedule {
+    connection_timeout: Duration,
+    keepalive_interval: Duration,
+    last_send: Duration,
+}
+
+impl RpcHttpV2PingSchedule {
+    const fn new(connection_timeout: Duration, keepalive_interval: Duration, now: Duration) -> Self {
+        Self {
+            connection_timeout,
+            keepalive_interval,
+            last_send: now,
+        }
+    }
+
+    /// Returns whether a PING must be sent at `now`.
+    pub(crate) fn ping_due(&self, now: Duration) -> bool {
+        let elapsed = now.saturating_sub(self.last_send);
+        elapsed >= self.connection_timeout
+            || (!self.keepalive_interval.is_zero() && elapsed >= self.keepalive_interval / 2)
+    }
+
+    /// Records a PDU sent on the default IN channel.
+    pub(crate) fn record_send(&mut self, now: Duration) {
+        self.last_send = now;
+    }
+}
+
+impl RpcHttpV2FlowControl {
+    fn new(
+        receive_window_size: u32,
+        peer_receive_window_size: u32,
+        receive_channel_cookie: RtsCookie,
+        send_channel_cookie: RtsCookie,
+    ) -> Self {
+        Self {
+            receive_window_size,
+            receive_available_window: receive_window_size,
+            receive_available_window_advertised: i64::from(receive_window_size),
+            receive_bytes_received: 0,
+            peer_receive_window_size,
+            send_available_window: peer_receive_window_size,
+            send_bytes_sent: 0,
+            receive_channel_cookie,
+            send_channel_cookie,
+        }
+    }
+
+    pub(crate) const fn send_available_window(&self) -> u32 {
+        self.send_available_window
+    }
+
+    pub(crate) const fn receive_available_window(&self) -> u32 {
+        self.receive_available_window
+    }
+
+    /// Records an RPC PDU queued on the default IN channel.
+    ///
+    /// The caller must wait for a flow-control acknowledgement when this returns
+    /// [`RpcHttpV2FlowControlError::SendWindowExhausted`].
+    pub(crate) fn sent_rpc_pdu(&mut self, pdu_length: usize) -> Result<(), RpcHttpV2FlowControlError> {
+        let pdu_size = u32::try_from(pdu_length)
+            .map_err(|_| RpcHttpV2FlowControlError::PduLengthOverflow { actual: pdu_length })?;
+        if self.send_available_window <= pdu_size {
+            return Err(RpcHttpV2FlowControlError::SendWindowExhausted {
+                pdu_size,
+                available_window: self.send_available_window,
+            });
+        }
+
+        self.send_bytes_sent =
+            self.send_bytes_sent
+                .checked_add(pdu_size)
+                .ok_or(RpcHttpV2FlowControlError::BytesSentOverflow {
+                    current: self.send_bytes_sent,
+                    pdu_size,
+                })?;
+        self.send_available_window -= pdu_size;
+        Ok(())
+    }
+
+    /// Records an RPC PDU queued in the local receive window.
+    pub(crate) fn received_rpc_pdu(&mut self, pdu_length: usize) -> Result<(), RpcHttpV2FlowControlError> {
+        let pdu_size = u32::try_from(pdu_length)
+            .map_err(|_| RpcHttpV2FlowControlError::PduLengthOverflow { actual: pdu_length })?;
+        if pdu_size > self.receive_available_window {
+            return Err(RpcHttpV2FlowControlError::ReceiveWindowExhausted {
+                pdu_size,
+                available_window: self.receive_available_window,
+            });
+        }
+
+        self.receive_bytes_received = self.receive_bytes_received.checked_add(pdu_size).ok_or(
+            RpcHttpV2FlowControlError::BytesReceivedOverflow {
+                current: self.receive_bytes_received,
+                pdu_size,
+            },
+        )?;
+        self.receive_available_window -= pdu_size;
+        self.receive_available_window_advertised -= i64::from(pdu_size);
+        Ok(())
+    }
+
+    /// Records a higher-layer consumer releasing an RPC PDU from the receive window.
+    ///
+    /// When enough space has been reclaimed since the last acknowledgement, returns
+    /// the acknowledgement to send on the IN channel.
+    pub(crate) fn consumed_rpc_pdu(
+        &mut self,
+        pdu_length: usize,
+    ) -> Result<Option<RtsFlowControlAck>, RpcHttpV2FlowControlError> {
+        let pdu_size = u32::try_from(pdu_length)
+            .map_err(|_| RpcHttpV2FlowControlError::PduLengthOverflow { actual: pdu_length })?;
+        let queued_bytes = self.receive_window_size - self.receive_available_window;
+        if pdu_size > queued_bytes {
+            return Err(RpcHttpV2FlowControlError::PduNotQueued { pdu_size, queued_bytes });
+        }
+        self.receive_available_window += pdu_size;
+
+        let reclaimed_window = i64::from(self.receive_available_window) - self.receive_available_window_advertised;
+        if reclaimed_window <= i64::from(self.receive_window_size / 2) {
+            return Ok(None);
+        }
+
+        self.receive_available_window_advertised = i64::from(self.receive_available_window);
+        Ok(Some(RtsFlowControlAck {
+            bytes_received: self.receive_bytes_received,
+            available_window: self.receive_available_window,
+            channel_cookie: self.receive_channel_cookie,
+        }))
+    }
+
+    /// Applies a flow-control acknowledgement received on the OUT channel.
+    ///
+    /// An acknowledgement for another channel is discarded as required by
+    /// [MS-RPCH] 3.2.1.5.1.2 and returns `Ok(false)`.
+    pub(crate) fn receive_flow_control_ack(
+        &mut self,
+        ack: RtsFlowControlAck,
+    ) -> Result<bool, RpcHttpV2FlowControlError> {
+        if ack.channel_cookie != self.send_channel_cookie {
+            return Ok(false);
+        }
+        if ack.bytes_received > self.send_bytes_sent {
+            return Err(RpcHttpV2FlowControlError::InvalidFlowControlAck {
+                bytes_received: ack.bytes_received,
+                bytes_sent: self.send_bytes_sent,
+            });
+        }
+        if ack.available_window > self.peer_receive_window_size {
+            return Err(RpcHttpV2FlowControlError::FlowControlAckWindowExceedsPeer {
+                available_window: ack.available_window,
+                peer_receive_window_size: self.peer_receive_window_size,
+            });
+        }
+
+        let unacknowledged_bytes = self.send_bytes_sent - ack.bytes_received;
+        self.send_available_window = ack.available_window.checked_sub(unacknowledged_bytes).ok_or(
+            RpcHttpV2FlowControlError::FlowControlAckExhaustsSenderWindow {
+                available_window: ack.available_window,
+                unacknowledged_bytes,
+            },
+        )?;
+        Ok(true)
+    }
+}
+
+/// Builds a standards-conforming RPCH v2 request with a caller-supplied body.
+///
+/// The authenticated HTTP request retry loop should call this only after it has
+/// selected the final authorization header. In particular, the streaming IN
+/// body must remain uncommitted until that loop has completed.
+///
+/// [MS-RPCH] 2.1.2.1.1, 2.1.2.1.2, and 2.2.2.
+pub(crate) fn build_rpch_v2_request<B>(
+    channel: RpchHttpChannel,
+    gateway_host: &str,
+    target: &crate::GwConnectTarget,
+    content_length: u32,
+    authorization: Option<&str>,
+    cookie: Option<&str>,
+    body: B,
+) -> Result<http::Request<B>, RpcHttpV2Error> {
+    validate_rpch_content_length(channel, content_length)?;
+    let uri = rpch_v2_uri(&target.server, target.server_port)?;
+    let host = rpch_host_header(gateway_host)?;
+
+    let mut request = http::Request::builder()
+        .method(channel.method())
+        .uri(uri)
+        .header(http::header::ACCEPT, "application/rpc")
+        .header(http::header::CACHE_CONTROL, "no-cache")
+        .header(http::header::CONNECTION, "Keep-Alive")
+        .header(http::header::CONTENT_LENGTH, content_length)
+        .header(http::header::HOST, host)
+        .header(http::header::PRAGMA, "no-cache")
+        .header("Protocol", "1.0")
+        .header(http::header::USER_AGENT, "MSRPC");
+    if let Some(authorization) = authorization {
+        request = request.header(http::header::AUTHORIZATION, authorization);
+    }
+    if let Some(cookie) = cookie {
+        request = request.header(http::header::COOKIE, cookie);
+    }
+
+    request.body(body).map_err(|_| RpcHttpV2Error::InvalidHttpHeader)
+}
+
+fn validate_rpch_content_length(channel: RpchHttpChannel, content_length: u32) -> Result<(), RpcHttpV2Error> {
+    match channel.expected_content_length() {
+        Some(expected) if content_length == expected => Ok(()),
+        Some(_) => Err(RpcHttpV2Error::InvalidContentLength {
+            channel,
+            actual: content_length,
+        }),
+        None if (RPCH_MIN_CHANNEL_CONTENT_LENGTH..=RPCH_MAX_CHANNEL_CONTENT_LENGTH).contains(&content_length) => Ok(()),
+        None => Err(RpcHttpV2Error::InvalidContentLength {
+            channel,
+            actual: content_length,
+        }),
+    }
+}
+
+fn rpch_v2_uri(server: &str, port: u16) -> Result<String, RpcHttpV2Error> {
+    let server = server
+        .strip_prefix('[')
+        .and_then(|server| server.strip_suffix(']'))
+        .unwrap_or(server);
+    if server.is_empty()
+        || server.len() >= 1024
+        || !server
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_' | b':'))
+    {
+        return Err(RpcHttpV2Error::InvalidTargetServer);
+    }
+    if port == 0 {
+        return Err(RpcHttpV2Error::InvalidTargetPort);
+    }
+
+    Ok(format!("/rpc/rpcproxy.dll?{server}:{port}"))
+}
+
+fn rpch_host_header(gateway_host: &str) -> Result<String, RpcHttpV2Error> {
+    if gateway_host.is_empty() || gateway_host.bytes().any(|byte| byte.is_ascii_control() || byte == b' ') {
+        return Err(RpcHttpV2Error::InvalidGatewayHost);
+    }
+
+    Ok(if gateway_host.contains(':') {
+        format!("[{gateway_host}]")
+    } else {
+        gateway_host.to_owned()
+    })
+}
+
+/// The successful result of binding the single TS Gateway presentation context.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct RpcBinding {
+    fragment_sizes: RpcFragmentSizes,
+    call_id: u32,
+}
+
+impl RpcBinding {
+    pub(crate) const fn fragment_sizes(self) -> RpcFragmentSizes {
+        self.fragment_sizes
+    }
+
+    pub(crate) const fn call_id(self) -> u32 {
+        self.call_id
+    }
+}
+
+/// The authenticated result of binding the single TS Gateway presentation context.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct RpcAuthenticatedBindAck<'a> {
+    binding: RpcBinding,
+    token: &'a [u8],
+}
+
+impl RpcAuthenticatedBindAck<'_> {
+    pub(crate) const fn binding(&self) -> RpcBinding {
+        self.binding
+    }
+
+    pub(crate) const fn token(&self) -> &[u8] {
+        self.token
+    }
+}
+
+/// Client-side NTLM state for the DCE/RPC security context.
+///
+/// This state intentionally owns an independent security package and credential
+/// handle; it is not shared with HTTP authentication.
+pub(crate) struct RpcNtlmAuth {
+    ntlm: Ntlm,
+    credentials_handle: Option<AuthIdentityBuffers>,
+    state: RpcNtlmAuthState,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RpcNtlmAuthState {
+    Initial,
+    AwaitingChallenge,
+    Established,
+}
+
+impl RpcNtlmAuth {
+    pub(crate) fn new(username: &str, password: &str) -> Result<Self, Error> {
+        let identity = rpc_auth_identity(username, password)?;
+        let mut ntlm = Ntlm::new();
+        let credentials_handle = ntlm
+            .acquire_credentials_handle()
+            .with_credential_use(CredentialUse::Outbound)
+            .with_auth_data(&identity)
+            .execute(&mut ntlm)
+            .map_err(|e| Error::custom("acquire rpc ntlm credentials", e))?
+            .credentials_handle;
+
+        Ok(Self {
+            ntlm,
+            credentials_handle,
+            state: RpcNtlmAuthState::Initial,
+        })
+    }
+
+    /// Produces the NTLM Type-1 token for an authenticated bind PDU.
+    pub(crate) fn initial_token(&mut self) -> Result<Vec<u8>, Error> {
+        if self.state != RpcNtlmAuthState::Initial {
+            return Err(Error::new("rpc ntlm initial token", GwErrorKind::Connect));
+        }
+
+        let token = self.next_token(None)?;
+        if self.state != RpcNtlmAuthState::AwaitingChallenge {
+            return Err(Error::new("rpc ntlm initial token", GwErrorKind::Connect));
+        }
+
+        Ok(token)
+    }
+
+    /// Consumes the bind_ack Type-2 token and produces the Type-3 token.
+    pub(crate) fn continue_token(&mut self, challenge: &[u8]) -> Result<Vec<u8>, Error> {
+        if self.state != RpcNtlmAuthState::AwaitingChallenge {
+            return Err(Error::new("rpc ntlm continuation token", GwErrorKind::Connect));
+        }
+
+        let token = self.next_token(Some(challenge))?;
+        if self.state != RpcNtlmAuthState::Established {
+            return Err(Error::new("rpc ntlm continuation token", GwErrorKind::Connect));
+        }
+
+        Ok(token)
+    }
+
+    /// Produces the packet-integrity signature for an established security context.
+    pub(crate) fn make_signature(&mut self, data: &mut [u8], sequence_number: u32) -> Result<[u8; 16], Error> {
+        if self.state != RpcNtlmAuthState::Established {
+            return Err(Error::new("make rpc ntlm signature", GwErrorKind::Connect));
+        }
+
+        let mut signature = [0; 16];
+        let mut buffers = [
+            SecurityBufferRef::data_buf(data),
+            SecurityBufferRef::token_buf(&mut signature),
+        ];
+        self.ntlm
+            .make_signature(0, &mut buffers, sequence_number)
+            .map_err(|e| Error::custom("make rpc ntlm signature", e))?;
+        Ok(signature)
+    }
+
+    /// Verifies the packet-integrity signature for an established security context.
+    pub(crate) fn verify_signature(
+        &mut self,
+        data: &mut [u8],
+        signature: &mut [u8],
+        sequence_number: u32,
+    ) -> Result<(), Error> {
+        if self.state != RpcNtlmAuthState::Established {
+            return Err(Error::new("verify rpc ntlm signature", GwErrorKind::Connect));
+        }
+
+        let mut buffers = [
+            SecurityBufferRef::data_buf(data),
+            SecurityBufferRef::token_buf(signature),
+        ];
+        self.ntlm
+            .verify_signature(&mut buffers, sequence_number)
+            .map(|_| ())
+            .map_err(|e| Error::custom("verify rpc ntlm signature", e))
+    }
+
+    pub(crate) fn is_complete(&self) -> bool {
+        self.state == RpcNtlmAuthState::Established
+    }
+
+    fn next_token(&mut self, input: Option<&[u8]>) -> Result<Vec<u8>, Error> {
+        let mut input_token = [SecurityBuffer::new(
+            input.map(<[u8]>::to_vec).unwrap_or_default(),
+            BufferType::Token,
+        )];
+        let mut output_token = [SecurityBuffer::new(Vec::with_capacity(1024), BufferType::Token)];
+        let mut builder = self
+            .ntlm
+            .initialize_security_context()
+            .with_credentials_handle(&mut self.credentials_handle)
+            .with_context_requirements(
+                ClientRequestFlags::USE_DCE_STYLE
+                    | ClientRequestFlags::INTEGRITY
+                    | ClientRequestFlags::REPLAY_DETECT
+                    | ClientRequestFlags::SEQUENCE_DETECT
+                    | ClientRequestFlags::ALLOCATE_MEMORY,
+            )
+            .with_target_data_representation(DataRepresentation::Native)
+            .with_input(&mut input_token)
+            .with_output(&mut output_token);
+
+        let InitializeSecurityContextResult { status, .. } = self
+            .ntlm
+            .initialize_security_context_impl(&mut builder)
+            .map_err(|e| Error::custom("initialize rpc ntlm security context", e))?
+            .resolve_to_result()
+            .map_err(|e| Error::custom("initialize rpc ntlm security context", e))?;
+
+        match status {
+            SecurityStatus::Ok => self.state = RpcNtlmAuthState::Established,
+            SecurityStatus::ContinueNeeded => self.state = RpcNtlmAuthState::AwaitingChallenge,
+            other => {
+                return Err(Error::new("rpc ntlm security status", GwErrorKind::Connect)
+                    .with_source(std::io::Error::other(format!("unexpected ntlm status: {other:?}"))));
+            }
+        }
+
+        Ok(core::mem::take(&mut output_token[0].buffer))
+    }
+}
+
+/// A decoded, single-fragment RPC response.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct RpcResponse<'a> {
+    pub(crate) call_id: u32,
+    pfc_flags: u8,
+    pub(crate) alloc_hint: u32,
+    pub(crate) cancel_count: u8,
+    pub(crate) reserved: u8,
+    pub(crate) stub: &'a [u8],
+}
+
+impl RpcResponse<'_> {
+    /// Whether this fragment carries the last-fragment flag, terminating its response
+    /// ([C706] 12.6.2).
+    pub(crate) fn is_last_fragment(&self) -> bool {
+        self.pfc_flags & PFC_LAST_FRAG != 0
+    }
+}
+
+/// An owned RPC response reassembled from one or more response fragments.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct RpcReassembledResponse {
+    pub(crate) call_id: u32,
+    pub(crate) cancel_count: u8,
+    pub(crate) reserved: u8,
+    pub(crate) stub: Vec<u8>,
+}
+
+/// Bounded reassembler for consecutive DCE/RPC response fragments.
+///
+/// Every fragment must belong to the same call and the first/last-fragment flags
+/// must delimit exactly one complete response.
+#[derive(Debug)]
+pub(crate) struct RpcResponseReassembler {
+    maximum_stub_size: usize,
+    call_id: Option<u32>,
+    cancel_count: u8,
+    reserved: u8,
+    alloc_hints: Vec<(usize, u32)>,
+    stub: Vec<u8>,
+}
+
+impl RpcResponseReassembler {
+    pub(crate) fn new(maximum_stub_size: usize) -> Self {
+        Self {
+            maximum_stub_size,
+            call_id: None,
+            cancel_count: 0,
+            reserved: 0,
+            alloc_hints: Vec::new(),
+            stub: Vec::new(),
+        }
+    }
+
+    /// Adds one decoded response fragment and returns an owned response after
+    /// receiving its last fragment.
+    pub(crate) fn push(&mut self, response: RpcResponse<'_>) -> Result<Option<RpcReassembledResponse>, RpcPduError> {
+        let flags = response.pfc_flags & (PFC_FIRST_FRAG | PFC_LAST_FRAG);
+        match self.call_id {
+            None if flags & PFC_FIRST_FRAG == 0 => return Err(RpcPduError::UnexpectedResponseFragment { flags }),
+            Some(_) if flags & PFC_FIRST_FRAG != 0 => return Err(RpcPduError::UnexpectedResponseFragment { flags }),
+            Some(expected) if expected != response.call_id => {
+                return Err(RpcPduError::ResponseFragmentCallId {
+                    expected,
+                    actual: response.call_id,
+                });
+            }
+            _ => {}
+        }
+
+        if self.call_id.is_none() {
+            self.call_id = Some(response.call_id);
+            self.cancel_count = response.cancel_count;
+            self.reserved = response.reserved;
+        }
+
+        let stub_offset = self.stub.len();
+        let stub_length = stub_offset
+            .checked_add(response.stub.len())
+            .ok_or(RpcPduError::LengthOverflow)?;
+        if stub_length > self.maximum_stub_size {
+            return Err(RpcPduError::ResponseStubTooLarge {
+                actual: stub_length,
+                maximum: self.maximum_stub_size,
+            });
+        }
+        if response.alloc_hint != 0 {
+            self.alloc_hints.push((stub_offset, response.alloc_hint));
+        }
+        self.stub.extend_from_slice(response.stub);
+
+        if flags & PFC_LAST_FRAG == 0 {
+            return Ok(None);
+        }
+
+        let total_length = self.stub.len();
+        let invalid_alloc_hint =
+            self.alloc_hints
+                .iter()
+                .find_map(|(offset, alloc_hint)| match usize::try_from(*alloc_hint) {
+                    Ok(hint) if hint <= total_length - *offset => None,
+                    _ => Some(*alloc_hint),
+                });
+        if let Some(alloc_hint) = invalid_alloc_hint {
+            self.reset();
+            return Err(RpcPduError::InvalidAllocHint {
+                alloc_hint,
+                stub_length: total_length,
+            });
+        }
+
+        let response = RpcReassembledResponse {
+            call_id: self.call_id.ok_or(RpcPduError::UnexpectedResponseFragment { flags })?,
+            cancel_count: self.cancel_count,
+            reserved: self.reserved,
+            stub: core::mem::take(&mut self.stub),
+        };
+        self.reset();
+        Ok(Some(response))
+    }
+
+    fn reset(&mut self) {
+        self.call_id = None;
+        self.cancel_count = 0;
+        self.reserved = 0;
+        self.alloc_hints.clear();
+        self.stub.clear();
+    }
+}
+
+/// A decoded, single-fragment RPC fault.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct RpcFault<'a> {
+    pub(crate) call_id: u32,
+    pub(crate) alloc_hint: u32,
+    pub(crate) cancel_count: u8,
+    pub(crate) reserved: u8,
+    pub(crate) status: u32,
+    pub(crate) reserved2: u32,
+    pub(crate) stub: &'a [u8],
+}
+
+/// An exact 16-byte RPC-over-HTTP RTS cookie.
+///
+/// [MS-RPCH] 2.2.3.5.4.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RtsCookie([u8; Self::SIZE]);
+
+impl RtsCookie {
+    pub(crate) const SIZE: usize = 16;
+
+    pub(crate) const fn new(bytes: [u8; Self::SIZE]) -> Self {
+        Self(bytes)
+    }
+
+    pub(crate) const fn as_bytes(&self) -> &[u8; Self::SIZE] {
+        &self.0
+    }
+}
+
+impl fmt::Debug for RtsCookie {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("RtsCookie(..)")
+    }
+}
+
+/// Values received in a CONN/A3 RTS PDU.
+///
+/// [MS-RPCH] 2.2.4.4.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct RtsConnA3 {
+    pub(crate) connection_timeout: u32,
+}
+
+/// Values received in a CONN/C2 RTS PDU.
+///
+/// [MS-RPCH] 2.2.4.9.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct RtsConnC2 {
+    pub(crate) version: u32,
+    pub(crate) receive_window_size: u32,
+    pub(crate) connection_timeout: u32,
+}
+
+/// Values received in an IN_R1/A4 RTS PDU.
+///
+/// [MS-RPCH] 2.2.4.13.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct RtsInRecycleA4 {
+    pub(crate) version: u32,
+    pub(crate) receive_window_size: u32,
+    pub(crate) connection_timeout: u32,
+}
+
+/// Values received in an OUT_R1/A6 RTS PDU.
+///
+/// [MS-RPCH] 2.2.4.28.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct RtsOutRecycleA6 {
+    pub(crate) version: u32,
+    pub(crate) connection_timeout: u32,
+}
+
+/// A flow-control acknowledgement for an RPCH channel.
+///
+/// [MS-RPCH] 2.2.3.4 and 2.2.4.50.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct RtsFlowControlAck {
+    pub(crate) bytes_received: u32,
+    pub(crate) available_window: u32,
+    pub(crate) channel_cookie: RtsCookie,
+}
+
+/// Encodes the client CONN/A1 RTS PDU for the OUT channel.
+///
+/// [MS-RPCH] 2.2.4.2.
+pub(crate) fn encode_rts_conn_a1(
+    virtual_connection_cookie: RtsCookie,
+    out_channel_cookie: RtsCookie,
+    receive_window_size: u32,
+) -> Result<Vec<u8>, RpcPduError> {
+    validate_rts_receive_window_size(receive_window_size)?;
+
+    let mut commands = Vec::with_capacity(
+        8 /* version */
+            + 20 /* virtual connection cookie */
+            + 20 /* OUT channel cookie */
+            + 8, /* receive window size */
+    );
+    encode_rts_u32_command(&mut commands, RTS_COMMAND_VERSION, RTS_VERSION);
+    encode_rts_cookie_command(&mut commands, RTS_COMMAND_COOKIE, virtual_connection_cookie);
+    encode_rts_cookie_command(&mut commands, RTS_COMMAND_COOKIE, out_channel_cookie);
+    encode_rts_u32_command(&mut commands, RTS_COMMAND_RECEIVE_WINDOW_SIZE, receive_window_size);
+    encode_rts_pdu(RTS_FLAG_NONE, 4, commands)
+}
+
+/// Encodes the client CONN/B1 RTS PDU for the IN channel.
+///
+/// [MS-RPCH] 2.2.4.5.
+pub(crate) fn encode_rts_conn_b1(
+    virtual_connection_cookie: RtsCookie,
+    in_channel_cookie: RtsCookie,
+    channel_lifetime: u32,
+    client_keepalive: u32,
+    association_group_id: RtsCookie,
+) -> Result<Vec<u8>, RpcPduError> {
+    validate_rts_channel_lifetime(channel_lifetime)?;
+    validate_rts_client_keepalive(client_keepalive)?;
+
+    let mut commands = Vec::with_capacity(
+        8 /* version */
+            + 20 /* virtual connection cookie */
+            + 20 /* IN channel cookie */
+            + 8 /* channel lifetime */
+            + 8 /* client keepalive */
+            + 20, /* association group id */
+    );
+    encode_rts_u32_command(&mut commands, RTS_COMMAND_VERSION, RTS_VERSION);
+    encode_rts_cookie_command(&mut commands, RTS_COMMAND_COOKIE, virtual_connection_cookie);
+    encode_rts_cookie_command(&mut commands, RTS_COMMAND_COOKIE, in_channel_cookie);
+    encode_rts_u32_command(&mut commands, RTS_COMMAND_CHANNEL_LIFETIME, channel_lifetime);
+    encode_rts_u32_command(&mut commands, RTS_COMMAND_CLIENT_KEEPALIVE, client_keepalive);
+    encode_rts_cookie_command(&mut commands, RTS_COMMAND_ASSOCIATION_GROUP_ID, association_group_id);
+    encode_rts_pdu(RTS_FLAG_NONE, 6, commands)
+}
+
+/// Encodes the client IN_R1/A1 RTS PDU for an IN-channel successor.
+///
+/// [MS-RPCH] 2.2.4.10.
+pub(crate) fn encode_rts_in_recycle_a1(
+    virtual_connection_cookie: RtsCookie,
+    predecessor_channel_cookie: RtsCookie,
+    successor_channel_cookie: RtsCookie,
+) -> Result<Vec<u8>, RpcPduError> {
+    let mut commands = Vec::with_capacity(
+        8 /* version */
+            + 20 /* virtual connection cookie */
+            + 20 /* predecessor IN channel cookie */
+            + 20, /* successor IN channel cookie */
+    );
+    encode_rts_u32_command(&mut commands, RTS_COMMAND_VERSION, RTS_VERSION);
+    encode_rts_cookie_command(&mut commands, RTS_COMMAND_COOKIE, virtual_connection_cookie);
+    encode_rts_cookie_command(&mut commands, RTS_COMMAND_COOKIE, predecessor_channel_cookie);
+    encode_rts_cookie_command(&mut commands, RTS_COMMAND_COOKIE, successor_channel_cookie);
+    encode_rts_pdu(RTS_FLAG_RECYCLE_CHANNEL, 4, commands)
+}
+
+/// Encodes the client IN_R1/A5 RTS PDU on the predecessor IN channel.
+///
+/// [MS-RPCH] 2.2.4.14.
+pub(crate) fn encode_rts_in_recycle_a5(successor_channel_cookie: RtsCookie) -> Result<Vec<u8>, RpcPduError> {
+    let mut commands = Vec::with_capacity(20 /* successor IN channel cookie */);
+    encode_rts_cookie_command(&mut commands, RTS_COMMAND_COOKIE, successor_channel_cookie);
+    encode_rts_pdu(RTS_FLAG_NONE, 1, commands)
+}
+
+/// Validates an OUT_R1/A2 RTS PDU that starts OUT-channel recycling.
+///
+/// [MS-RPCH] 2.2.4.24 and 3.2.2.5.6.
+pub(crate) fn decode_rts_out_recycle_a2(source: &[u8]) -> Result<(), RpcPduError> {
+    let body = decode_rts_pdu(source, RTS_FLAG_RECYCLE_CHANNEL, 1, 8)?;
+    let destination = decode_rts_u32_command(body, 0, RTS_COMMAND_DESTINATION)?;
+    if destination != RTS_DESTINATION_FD_CLIENT {
+        return Err(RpcPduError::UnexpectedRtsDestination {
+            expected: RTS_DESTINATION_FD_CLIENT,
+            actual: destination,
+        });
+    }
+    Ok(())
+}
+
+/// Encodes the client OUT_R1/A3 RTS PDU for an OUT-channel successor.
+///
+/// [MS-RPCH] 2.2.4.25.
+pub(crate) fn encode_rts_out_recycle_a3(
+    virtual_connection_cookie: RtsCookie,
+    predecessor_channel_cookie: RtsCookie,
+    successor_channel_cookie: RtsCookie,
+    receive_window_size: u32,
+) -> Result<Vec<u8>, RpcPduError> {
+    validate_rts_receive_window_size(receive_window_size)?;
+
+    let mut commands = Vec::with_capacity(
+        8 /* version */
+            + 20 /* virtual connection cookie */
+            + 20 /* predecessor OUT channel cookie */
+            + 20 /* successor OUT channel cookie */
+            + 8, /* receive window size */
+    );
+    encode_rts_u32_command(&mut commands, RTS_COMMAND_VERSION, RTS_VERSION);
+    encode_rts_cookie_command(&mut commands, RTS_COMMAND_COOKIE, virtual_connection_cookie);
+    encode_rts_cookie_command(&mut commands, RTS_COMMAND_COOKIE, predecessor_channel_cookie);
+    encode_rts_cookie_command(&mut commands, RTS_COMMAND_COOKIE, successor_channel_cookie);
+    encode_rts_u32_command(&mut commands, RTS_COMMAND_RECEIVE_WINDOW_SIZE, receive_window_size);
+    encode_rts_pdu(RTS_FLAG_RECYCLE_CHANNEL, 5, commands)
+}
+
+/// Decodes and validates an OUT_R1/A6 RTS PDU sent to the client.
+///
+/// [MS-RPCH] 2.2.4.28 and 3.2.2.5.7.
+pub(crate) fn decode_rts_out_recycle_a6(source: &[u8]) -> Result<RtsOutRecycleA6, RpcPduError> {
+    let body = decode_rts_pdu(source, RTS_FLAG_OUT_CHANNEL, 3, 24)?;
+    let destination = decode_rts_u32_command(body, 0, RTS_COMMAND_DESTINATION)?;
+    if destination != RTS_DESTINATION_FD_CLIENT {
+        return Err(RpcPduError::UnexpectedRtsDestination {
+            expected: RTS_DESTINATION_FD_CLIENT,
+            actual: destination,
+        });
+    }
+    let version = decode_rts_u32_command(body, 8, RTS_COMMAND_VERSION)?;
+    let connection_timeout = decode_rts_u32_command(body, 16, RTS_COMMAND_CONNECTION_TIMEOUT)?;
+    validate_rts_connection_timeout(connection_timeout)?;
+
+    Ok(RtsOutRecycleA6 {
+        version,
+        connection_timeout,
+    })
+}
+
+/// Encodes the client OUT_R1/A7 RTS PDU on the default IN channel.
+///
+/// [MS-RPCH] 2.2.4.29.
+pub(crate) fn encode_rts_out_recycle_a7(successor_channel_cookie: RtsCookie) -> Result<Vec<u8>, RpcPduError> {
+    let mut commands = Vec::with_capacity(
+        8 /* destination */
+            + 20, /* successor OUT channel cookie */
+    );
+    encode_rts_u32_command(&mut commands, RTS_COMMAND_DESTINATION, RTS_DESTINATION_FD_SERVER);
+    encode_rts_cookie_command(&mut commands, RTS_COMMAND_COOKIE, successor_channel_cookie);
+    encode_rts_pdu(RTS_FLAG_OUT_CHANNEL, 2, commands)
+}
+
+/// Validates an OUT_R1/A10 RTS PDU that confirms a successor OUT channel.
+///
+/// [MS-RPCH] 2.2.4.32 and 3.2.2.5.8.
+pub(crate) fn decode_rts_out_recycle_a10(source: &[u8]) -> Result<(), RpcPduError> {
+    let body = decode_rts_pdu(source, RTS_FLAG_NONE, 1, 4)?;
+    decode_rts_empty_command(body, 0, RTS_COMMAND_ANCE)?;
+    Ok(())
+}
+
+/// Encodes the client OUT_R1/A11 RTS PDU for the successor OUT channel.
+///
+/// [MS-RPCH] 2.2.4.33.
+pub(crate) fn encode_rts_out_recycle_a11() -> Result<Vec<u8>, RpcPduError> {
+    encode_rts_pdu(RTS_FLAG_NONE, 1, RTS_COMMAND_ANCE.to_le_bytes().to_vec())
+}
+
+/// Decodes and validates a server CONN/A3 RTS PDU.
+///
+/// [MS-RPCH] 2.2.4.4.
+pub(crate) fn decode_rts_conn_a3(source: &[u8]) -> Result<RtsConnA3, RpcPduError> {
+    let body = decode_rts_pdu(source, RTS_FLAG_NONE, 1, 8)?;
+    let connection_timeout = decode_rts_u32_command(body, 0, RTS_COMMAND_CONNECTION_TIMEOUT)?;
+    validate_rts_connection_timeout(connection_timeout)?;
+
+    Ok(RtsConnA3 { connection_timeout })
+}
+
+/// Decodes and validates a server CONN/C2 RTS PDU.
+///
+/// [MS-RPCH] 2.2.4.9.
+pub(crate) fn decode_rts_conn_c2(source: &[u8]) -> Result<RtsConnC2, RpcPduError> {
+    let body = decode_rts_pdu(source, RTS_FLAG_NONE, 3, 24)?;
+    let version = decode_rts_u32_command(body, 0, RTS_COMMAND_VERSION)?;
+    let receive_window_size = decode_rts_u32_command(body, 8, RTS_COMMAND_RECEIVE_WINDOW_SIZE)?;
+    let connection_timeout = decode_rts_u32_command(body, 16, RTS_COMMAND_CONNECTION_TIMEOUT)?;
+    validate_rts_receive_window_size(receive_window_size)?;
+    validate_rts_connection_timeout(connection_timeout)?;
+
+    Ok(RtsConnC2 {
+        version,
+        receive_window_size,
+        connection_timeout,
+    })
+}
+
+/// Decodes and validates an IN_R1/A4 RTS PDU sent to the client.
+///
+/// [MS-RPCH] 2.2.4.13 and 3.2.2.5.5.
+pub(crate) fn decode_rts_in_recycle_a4(source: &[u8]) -> Result<RtsInRecycleA4, RpcPduError> {
+    let body = decode_rts_pdu(source, RTS_FLAG_NONE, 4, 32)?;
+    let destination = decode_rts_u32_command(body, 0, RTS_COMMAND_DESTINATION)?;
+    if destination != RTS_DESTINATION_FD_CLIENT {
+        return Err(RpcPduError::UnexpectedRtsDestination {
+            expected: RTS_DESTINATION_FD_CLIENT,
+            actual: destination,
+        });
+    }
+    let version = decode_rts_u32_command(body, 8, RTS_COMMAND_VERSION)?;
+    let receive_window_size = decode_rts_u32_command(body, 16, RTS_COMMAND_RECEIVE_WINDOW_SIZE)?;
+    let connection_timeout = decode_rts_u32_command(body, 24, RTS_COMMAND_CONNECTION_TIMEOUT)?;
+    validate_rts_receive_window_size(receive_window_size)?;
+    validate_rts_connection_timeout(connection_timeout)?;
+
+    Ok(RtsInRecycleA4 {
+        version,
+        receive_window_size,
+        connection_timeout,
+    })
+}
+
+/// Encodes the client Ping RTS PDU.
+///
+/// [MS-RPCH] 2.2.4.49.
+pub(crate) fn encode_rts_ping() -> Result<Vec<u8>, RpcPduError> {
+    encode_rts_pdu(RTS_FLAG_PING, 0, Vec::new())
+}
+
+/// Decodes and validates a Ping RTS PDU.
+///
+/// [MS-RPCH] 2.2.4.49.
+pub(crate) fn decode_rts_ping(source: &[u8]) -> Result<(), RpcPduError> {
+    let _ = decode_rts_pdu(source, RTS_FLAG_PING, 0, 0)?;
+    Ok(())
+}
+
+/// Encodes a flow-control acknowledgement for data received on an RPCH channel.
+///
+/// [MS-RPCH] 2.2.4.50.
+pub(crate) fn encode_rts_flow_control_ack(ack: RtsFlowControlAck) -> Result<Vec<u8>, RpcPduError> {
+    let mut commands = Vec::with_capacity(
+        4 /* command type */
+            + 4 /* bytes received */
+            + 4 /* available window */
+            + RtsCookie::SIZE, /* channel cookie */
+    );
+    commands.extend_from_slice(&RTS_COMMAND_FLOW_CONTROL_ACK.to_le_bytes());
+    commands.extend_from_slice(&ack.bytes_received.to_le_bytes());
+    commands.extend_from_slice(&ack.available_window.to_le_bytes());
+    commands.extend_from_slice(ack.channel_cookie.as_bytes());
+    encode_rts_pdu(RTS_FLAG_OTHER_CMD, 1, commands)
+}
+
+/// Decodes and validates a flow-control acknowledgement.
+///
+/// [MS-RPCH] 2.2.4.50.
+pub(crate) fn decode_rts_flow_control_ack(source: &[u8]) -> Result<RtsFlowControlAck, RpcPduError> {
+    let body = decode_rts_pdu(source, RTS_FLAG_OTHER_CMD, 1, 28)?;
+    let command_type = read_u32(body, 0)?;
+    if command_type != RTS_COMMAND_FLOW_CONTROL_ACK {
+        return Err(RpcPduError::UnexpectedRtsCommandType {
+            expected: RTS_COMMAND_FLOW_CONTROL_ACK,
+            actual: command_type,
+        });
+    }
+
+    let channel_cookie = body
+        .get(12..12 + RtsCookie::SIZE)
+        .ok_or(RpcPduError::Truncated {
+            actual: body.len(),
+            required: 12 + RtsCookie::SIZE,
+        })?
+        .try_into()
+        .map(RtsCookie::new)
+        .map_err(|_| RpcPduError::LengthOverflow)?;
+    Ok(RtsFlowControlAck {
+        bytes_received: read_u32(body, 4)?,
+        available_window: read_u32(body, 8)?,
+        channel_cookie,
+    })
+}
+
+/// The reason returned by an RPC bind_nak PDU.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct RpcBindNakReason(pub(crate) u16);
+
+impl fmt::Display for RpcBindNakReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            0 => f.write_str("reason not specified"),
+            1 => f.write_str("temporary congestion"),
+            2 => f.write_str("local limit exceeded"),
+            4 => f.write_str("protocol version not supported"),
+            8 => f.write_str("authentication type not recognized"),
+            9 => f.write_str("invalid checksum"),
+            value => write!(f, "unknown provider rejection reason {value}"),
+        }
+    }
+}
+
+/// A decoded RPC bind_nak PDU.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct RpcBindNak {
+    pub(crate) call_id: u32,
+    pub(crate) reason: RpcBindNakReason,
+    pub(crate) supported_versions: Vec<RpcSyntaxVersion>,
+    pub(crate) extended_error_signature: Option<Uuid>,
+}
+
+/// Encodes a single-context, unauthenticated TS Gateway RPC bind PDU.
+///
+/// [MS-TSGU] 1.9.1 and Appendix A / [MS-RPCE] 2.2.2.7 / [C706] 12.6.
+pub(crate) fn encode_tsgu_bind(call_id: u32, fragment_sizes: RpcFragmentSizes) -> Result<Vec<u8>, RpcPduError> {
+    ensure_pdu_fits(RPC_BIND_PDU_SIZE, fragment_sizes.max_xmit)?;
+
+    encode_unprotected_pdu(PTYPE_BIND, call_id, encode_tsgu_bind_body(fragment_sizes))
+}
+
+/// Encodes a single-context, packet-integrity NTLM TS Gateway RPC bind PDU.
+///
+/// [MS-RPCE] 2.2.2.3 and 2.2.2.11-12 / [MS-TSGU] 3.2.5.
+pub(crate) fn encode_tsgu_bind_with_ntlm_auth(
+    call_id: u32,
+    fragment_sizes: RpcFragmentSizes,
+    type1_token: &[u8],
+) -> Result<Vec<u8>, RpcPduError> {
+    let pdu = encode_authenticated_pdu(PTYPE_BIND, call_id, encode_tsgu_bind_body(fragment_sizes), type1_token)?;
+    ensure_pdu_fits(pdu.len(), fragment_sizes.max_xmit)?;
+    Ok(pdu)
+}
+
+/// Decodes a bind_ack and validates the offered TS Gateway presentation context.
+pub(crate) fn decode_tsgu_bind_ack(
+    source: &[u8],
+    offered_fragment_sizes: RpcFragmentSizes,
+) -> Result<RpcBinding, RpcPduError> {
+    let (header, body) = decode_unprotected_single_fragment(source, PTYPE_BIND_ACK, offered_fragment_sizes.max_recv)?;
+    decode_tsgu_bind_ack_body(header, body, offered_fragment_sizes)
+}
+
+/// Decodes an authenticated bind_ack, validates its NTLM verifier, and returns
+/// the Type-2 token for [`RpcNtlmAuth::continue_token`].
+pub(crate) fn decode_tsgu_bind_ack_with_ntlm_auth<'a>(
+    source: &'a [u8],
+    offered_fragment_sizes: RpcFragmentSizes,
+) -> Result<RpcAuthenticatedBindAck<'a>, RpcPduError> {
+    let (header, body, token) =
+        decode_authenticated_single_fragment(source, PTYPE_BIND_ACK, offered_fragment_sizes.max_recv, true)?;
+    let binding = decode_tsgu_bind_ack_body(header, body, offered_fragment_sizes)?;
+    Ok(RpcAuthenticatedBindAck { binding, token })
+}
+
+/// Encodes the Type-3 continuation token in an rpc_auth_3 PDU.
+///
+/// [MS-RPCE] 2.2.2.10-12.
+pub(crate) fn encode_rpc_auth_3(
+    call_id: u32,
+    fragment_sizes: RpcFragmentSizes,
+    type3_token: &[u8],
+) -> Result<Vec<u8>, RpcPduError> {
+    let pdu = encode_authenticated_pdu(PTYPE_RPC_AUTH_3, call_id, vec![0; 4], type3_token)?;
+    ensure_pdu_fits(pdu.len(), fragment_sizes.max_xmit)?;
+    Ok(pdu)
+}
+
+fn encode_tsgu_bind_body(fragment_sizes: RpcFragmentSizes) -> Vec<u8> {
+    let mut body = Vec::with_capacity(RPC_BIND_BODY_SIZE);
+    body.extend_from_slice(&fragment_sizes.max_xmit.to_le_bytes());
+    body.extend_from_slice(&fragment_sizes.max_recv.to_le_bytes());
+    body.extend_from_slice(&0u32.to_le_bytes()); // assoc_group_id
+    body.push(1); // n_context_elem
+    body.push(0); // reserved
+    body.extend_from_slice(&0u16.to_le_bytes()); // reserved2
+    body.extend_from_slice(&RPC_CONTEXT_ID.to_le_bytes());
+    body.push(1); // n_transfer_syn
+    body.push(0); // reserved
+    encode_syntax_identifier(&mut body, TSPROXY_RPC_INTERFACE_ID, TSPROXY_RPC_INTERFACE_VERSION);
+    encode_syntax_identifier(&mut body, NDR32_TRANSFER_SYNTAX_ID, NDR32_TRANSFER_SYNTAX_VERSION);
+
+    debug_assert_eq!(body.len(), RPC_BIND_BODY_SIZE);
+    body
+}
+
+fn decode_tsgu_bind_ack_body(
+    header: RpcCommonHeader,
+    body: &[u8],
+    offered_fragment_sizes: RpcFragmentSizes,
+) -> Result<RpcBinding, RpcPduError> {
+    if body.len() < 10 {
+        return Err(RpcPduError::Truncated {
+            actual: body.len(),
+            required: 10,
+        });
+    }
+
+    let server_max_xmit = read_u16(body, 0)?;
+    let server_max_recv = read_u16(body, 2)?;
+    let server_fragment_sizes = RpcFragmentSizes::new(server_max_xmit, server_max_recv)?;
+    let secondary_address_length = usize::from(read_u16(body, 8)?);
+    let result_list_offset = 10usize
+        .checked_add(secondary_address_length)
+        .and_then(|offset| offset.checked_add(3))
+        .map(|offset| offset & !3)
+        .ok_or(RpcPduError::LengthOverflow)?;
+    let result_list_header_end = result_list_offset.checked_add(4).ok_or(RpcPduError::LengthOverflow)?;
+    let result_list = body
+        .get(result_list_offset..result_list_header_end)
+        .ok_or(RpcPduError::Truncated {
+            actual: body.len(),
+            required: result_list_header_end,
+        })?;
+
+    if result_list[0] != 1 {
+        return Err(RpcPduError::UnexpectedPresentationContextCount { actual: result_list[0] });
+    }
+
+    let result_offset = result_list_header_end;
+    let result_end = result_offset.checked_add(24).ok_or(RpcPduError::LengthOverflow)?;
+    let result = body.get(result_offset..result_end).ok_or(RpcPduError::Truncated {
+        actual: body.len(),
+        required: result_end,
+    })?;
+    if result_end != body.len() {
+        return Err(RpcPduError::Truncated {
+            actual: body.len(),
+            required: result_end,
+        });
+    }
+
+    let result_code = read_u16(result, 0)?;
+    let reason = read_u16(result, 2)?;
+    if result_code != 0 || reason != 0 {
+        return Err(RpcPduError::PresentationContextRejected {
+            result: result_code,
+            reason,
+        });
+    }
+
+    let transfer_syntax_bytes = result.get(4..24).ok_or(RpcPduError::Truncated {
+        actual: result.len(),
+        required: 24,
+    })?;
+    let transfer_syntax = (
+        Uuid::from_bytes_le(
+            transfer_syntax_bytes[..16]
+                .try_into()
+                .map_err(|_| RpcPduError::LengthOverflow)?,
+        ),
+        RpcSyntaxVersion::new(
+            read_u16(transfer_syntax_bytes, 16)?,
+            read_u16(transfer_syntax_bytes, 18)?,
+        ),
+    );
+    if transfer_syntax != (NDR32_TRANSFER_SYNTAX_ID, NDR32_TRANSFER_SYNTAX_VERSION) {
+        return Err(RpcPduError::UnexpectedTransferSyntax {
+            identifier: transfer_syntax.0,
+            version: transfer_syntax.1,
+        });
+    }
+
+    RpcFragmentSizes::new(
+        offered_fragment_sizes.max_xmit.min(server_fragment_sizes.max_recv),
+        offered_fragment_sizes.max_recv.min(server_fragment_sizes.max_xmit),
+    )
+    .map(|fragment_sizes| RpcBinding {
+        fragment_sizes,
+        call_id: header.call_id,
+    })
+}
+
+/// Decodes an RPC bind_nak PDU and preserves its advertised protocol versions.
+pub(crate) fn decode_bind_nak(source: &[u8]) -> Result<RpcBindNak, RpcPduError> {
+    let (header, body) = decode_unprotected_single_fragment(source, PTYPE_BIND_NAK, u16::MAX)?;
+    if body.len() < 3 {
+        return Err(RpcPduError::Truncated {
+            actual: body.len(),
+            required: 3,
+        });
+    }
+
+    let reason = RpcBindNakReason(read_u16(body, 0)?);
+    let versions_length = usize::from(body[2]);
+    let expected_length = 3usize
+        .checked_add(versions_length.checked_mul(2).ok_or(RpcPduError::LengthOverflow)?)
+        .ok_or(RpcPduError::LengthOverflow)?;
+    if body.len() < expected_length || (body.len() > expected_length && body.len() < expected_length + 16) {
+        return Err(RpcPduError::InvalidBindNakVersionsLength {
+            actual: body.len(),
+            expected: expected_length,
+        });
+    }
+
+    let supported_versions = body[3..]
+        .get(..versions_length * 2)
+        .ok_or(RpcPduError::LengthOverflow)?
+        .chunks_exact(2)
+        .map(|version| RpcSyntaxVersion::new(u16::from(version[0]), u16::from(version[1])))
+        .collect();
+    let extended_error_signature = match body.get(expected_length..expected_length + 16) {
+        Some(signature) => Some(Uuid::from_bytes_le(
+            signature.try_into().map_err(|_| RpcPduError::LengthOverflow)?,
+        )),
+        None => None,
+    };
+    Ok(RpcBindNak {
+        call_id: header.call_id,
+        reason,
+        supported_versions,
+        extended_error_signature,
+    })
+}
+
+/// Encodes one complete, unauthenticated TS Gateway request PDU.
+///
+/// The current runtime emits only a first-and-last fragment. Callers must split
+/// larger stubs before this layer gains DCE/RPC fragment reassembly support.
+pub(crate) fn encode_rpc_request(
+    call_id: u32,
+    opnum: u16,
+    stub: &[u8],
+    fragment_sizes: RpcFragmentSizes,
+) -> Result<Vec<u8>, RpcPduError> {
+    let body = encode_rpc_request_body(opnum, stub)?;
+    let pdu_length = RPC_COMMON_HEADER_SIZE
+        .checked_add(body.len())
+        .ok_or(RpcPduError::LengthOverflow)?;
+    ensure_pdu_fits(pdu_length, fragment_sizes.max_xmit)?;
+
+    encode_unprotected_pdu(PTYPE_REQUEST, call_id, body)
+}
+
+/// Encodes an unauthenticated TS Gateway request into DCE/RPC fragments.
+///
+/// Each fragment advertises the remaining stub size through `alloc_hint`, as
+/// required for interoperable DCE/RPC fragmentation.
+///
+/// [MS-RPCE] 2.2.2.6.
+pub(crate) fn encode_rpc_request_fragments(
+    call_id: u32,
+    opnum: u16,
+    stub: &[u8],
+    fragment_sizes: RpcFragmentSizes,
+) -> Result<Vec<Vec<u8>>, RpcPduError> {
+    let maximum_stub_size = maximum_unprotected_request_stub_size(fragment_sizes.max_xmit)?;
+    rpc_request_fragment_bodies(opnum, stub, maximum_stub_size)?
+        .into_iter()
+        .map(|(pfc_flags, body)| encode_unprotected_pdu_with_flags(PTYPE_REQUEST, pfc_flags, call_id, body))
+        .collect()
+}
+
+/// Encodes and signs one complete packet-integrity protected TS Gateway request.
+///
+/// The request remains single-fragment until the RPC runtime gains fragment
+/// reassembly. The NTLM signature covers the complete common header, padded
+/// request body, and security trailer.
+pub(crate) fn encode_rpc_request_with_ntlm_auth(
+    auth: &mut RpcNtlmAuth,
+    sequence_number: u32,
+    call_id: u32,
+    opnum: u16,
+    stub: &[u8],
+    fragment_sizes: RpcFragmentSizes,
+) -> Result<Vec<u8>, Error> {
+    let body =
+        encode_rpc_request_body(opnum, stub).map_err(|e| Error::custom("encode authenticated rpc request", e))?;
+    let mut pdu =
+        encode_authenticated_pdu_with_flags(PTYPE_REQUEST, PFC_FIRST_FRAG | PFC_LAST_FRAG, call_id, body, &[0; 16])
+            .map_err(|e| Error::custom("encode authenticated rpc request", e))?;
+    ensure_pdu_fits(pdu.len(), fragment_sizes.max_xmit)
+        .map_err(|e| Error::custom("encode authenticated rpc request", e))?;
+
+    let signature_offset = pdu
+        .len()
+        .checked_sub(16)
+        .ok_or_else(|| Error::new("encode authenticated rpc request", GwErrorKind::Encode))?;
+    let signature = auth.make_signature(&mut pdu[..signature_offset], sequence_number)?;
+    pdu[signature_offset..].copy_from_slice(&signature);
+    Ok(pdu)
+}
+
+/// Encodes and signs a TS Gateway request split across packet-integrity fragments.
+///
+/// The supplied sequence number is advanced once for every emitted fragment.
+///
+/// [MS-RPCE] 2.2.2.6.
+pub(crate) fn encode_rpc_request_fragments_with_ntlm_auth(
+    auth: &mut RpcNtlmAuth,
+    sequence_number: &mut u32,
+    call_id: u32,
+    opnum: u16,
+    stub: &[u8],
+    fragment_sizes: RpcFragmentSizes,
+) -> Result<Vec<Vec<u8>>, Error> {
+    let maximum_stub_size = maximum_authenticated_request_stub_size(fragment_sizes.max_xmit)
+        .map_err(|e| Error::custom("encode authenticated rpc request fragments", e))?;
+    let initial_sequence_number = *sequence_number;
+    let request_bodies = rpc_request_fragment_bodies(opnum, stub, maximum_stub_size)
+        .map_err(|e| Error::custom("encode authenticated rpc request fragments", e))?;
+    let mut fragments = Vec::with_capacity(request_bodies.len());
+    for (fragment_index, (pfc_flags, body)) in request_bodies.into_iter().enumerate() {
+        let mut pdu = encode_authenticated_pdu_with_flags(PTYPE_REQUEST, pfc_flags, call_id, body, &[0; 16])
+            .map_err(|e| Error::custom("encode authenticated rpc request fragments", e))?;
+        ensure_pdu_fits(pdu.len(), fragment_sizes.max_xmit)
+            .map_err(|e| Error::custom("encode authenticated rpc request fragments", e))?;
+        let signature_offset = pdu
+            .len()
+            .checked_sub(16)
+            .ok_or_else(|| Error::new("encode authenticated rpc request fragments", GwErrorKind::Encode))?;
+        let fragment_index = u32::try_from(fragment_index)
+            .map_err(|_| Error::new("encode authenticated rpc request fragments", GwErrorKind::Encode))?;
+        let signature = auth.make_signature(
+            &mut pdu[..signature_offset],
+            initial_sequence_number.wrapping_add(fragment_index),
+        )?;
+        pdu[signature_offset..].copy_from_slice(&signature);
+        fragments.push(pdu);
+    }
+    *sequence_number = initial_sequence_number.wrapping_add(
+        u32::try_from(fragments.len())
+            .map_err(|_| Error::new("encode authenticated rpc request fragments", GwErrorKind::Encode))?,
+    );
+    Ok(fragments)
+}
+
+/// Decodes one complete, unauthenticated RPC response PDU.
+pub(crate) fn decode_rpc_response<'a>(
+    source: &'a [u8],
+    maximum_fragment_size: u16,
+) -> Result<RpcResponse<'a>, RpcPduError> {
+    let (header, body) = decode_unprotected_single_fragment(source, PTYPE_RESPONSE, maximum_fragment_size)?;
+    let response = decode_rpc_response_body(header, body)?;
+    validate_single_response_alloc_hint(response)?;
+    Ok(response)
+}
+
+/// Decodes one unauthenticated RPC response fragment for a response reassembler.
+pub(crate) fn decode_rpc_response_fragment<'a>(
+    source: &'a [u8],
+    maximum_fragment_size: u16,
+) -> Result<RpcResponse<'a>, RpcPduError> {
+    let (header, body) = decode_unprotected_fragment(source, PTYPE_RESPONSE, maximum_fragment_size)?;
+    decode_rpc_response_body(header, body)
+}
+
+/// Verifies and decodes one packet-integrity protected RPC response PDU.
+pub(crate) fn decode_rpc_response_with_ntlm_auth<'a>(
+    auth: &mut RpcNtlmAuth,
+    sequence_number: u32,
+    source: &'a [u8],
+    maximum_fragment_size: u16,
+) -> Result<RpcResponse<'a>, Error> {
+    let (header, body, signature) =
+        decode_authenticated_single_fragment(source, PTYPE_RESPONSE, maximum_fragment_size, false)
+            .map_err(|e| Error::custom("decode authenticated rpc response", e))?;
+    let signature_offset = usize::from(header.fragment_length)
+        .checked_sub(usize::from(header.auth_length))
+        .ok_or_else(|| Error::new("decode authenticated rpc response", GwErrorKind::Decode))?;
+    let mut protected_data = source[..signature_offset].to_vec();
+    let mut signature = signature.to_vec();
+    auth.verify_signature(&mut protected_data, &mut signature, sequence_number)?;
+
+    let response =
+        decode_rpc_response_body(header, body).map_err(|e| Error::custom("decode authenticated rpc response", e))?;
+    validate_single_response_alloc_hint(response).map_err(|e| Error::custom("decode authenticated rpc response", e))?;
+    Ok(response)
+}
+
+/// Verifies and decodes one packet-integrity protected RPC response fragment.
+pub(crate) fn decode_rpc_response_fragment_with_ntlm_auth<'a>(
+    auth: &mut RpcNtlmAuth,
+    sequence_number: u32,
+    source: &'a [u8],
+    maximum_fragment_size: u16,
+) -> Result<RpcResponse<'a>, Error> {
+    let (header, body, signature) = decode_authenticated_fragment(source, PTYPE_RESPONSE, maximum_fragment_size, false)
+        .map_err(|e| Error::custom("decode authenticated rpc response fragment", e))?;
+    let signature_offset = usize::from(header.fragment_length)
+        .checked_sub(usize::from(header.auth_length))
+        .ok_or_else(|| Error::new("decode authenticated rpc response fragment", GwErrorKind::Decode))?;
+    let mut protected_data = source[..signature_offset].to_vec();
+    let mut signature = signature.to_vec();
+    auth.verify_signature(&mut protected_data, &mut signature, sequence_number)?;
+
+    decode_rpc_response_body(header, body).map_err(|e| Error::custom("decode authenticated rpc response fragment", e))
+}
+
+fn encode_rpc_request_body(opnum: u16, stub: &[u8]) -> Result<Vec<u8>, RpcPduError> {
+    let alloc_hint = u32::try_from(stub.len()).map_err(|_| RpcPduError::LengthOverflow)?;
+    encode_rpc_request_body_with_alloc_hint(opnum, alloc_hint, stub)
+}
+
+fn encode_rpc_request_body_with_alloc_hint(opnum: u16, alloc_hint: u32, stub: &[u8]) -> Result<Vec<u8>, RpcPduError> {
+    let body_length = 8usize.checked_add(stub.len()).ok_or(RpcPduError::LengthOverflow)?;
+    let mut body = Vec::with_capacity(body_length);
+    body.extend_from_slice(&alloc_hint.to_le_bytes());
+    body.extend_from_slice(&RPC_CONTEXT_ID.to_le_bytes());
+    body.extend_from_slice(&opnum.to_le_bytes());
+    body.extend_from_slice(stub);
+    Ok(body)
+}
+
+fn rpc_request_fragment_bodies(
+    opnum: u16,
+    stub: &[u8],
+    maximum_stub_size: usize,
+) -> Result<Vec<(u8, Vec<u8>)>, RpcPduError> {
+    if maximum_stub_size == 0 && !stub.is_empty() {
+        return Err(RpcPduError::FragmentTooLarge {
+            actual: RPC_COMMON_HEADER_SIZE
+                + 8 /* request header */
+                + 1, /* stub byte */
+            maximum: u16::try_from(RPC_COMMON_HEADER_SIZE).expect("header size fits in u16") + 8,
+        });
+    }
+
+    let mut fragments = Vec::new();
+    let mut offset = 0;
+    loop {
+        let remaining = stub.len().checked_sub(offset).ok_or(RpcPduError::LengthOverflow)?;
+        let fragment_stub_size = remaining.min(maximum_stub_size);
+        let is_last = fragment_stub_size == remaining;
+        let mut pfc_flags = if offset == 0 { PFC_FIRST_FRAG } else { 0 };
+        if is_last {
+            pfc_flags |= PFC_LAST_FRAG;
+        }
+        let alloc_hint = u32::try_from(remaining).map_err(|_| RpcPduError::LengthOverflow)?;
+        let body =
+            encode_rpc_request_body_with_alloc_hint(opnum, alloc_hint, &stub[offset..offset + fragment_stub_size])?;
+        fragments.push((pfc_flags, body));
+        if is_last {
+            return Ok(fragments);
+        }
+        offset = offset
+            .checked_add(fragment_stub_size)
+            .ok_or(RpcPduError::LengthOverflow)?;
+    }
+}
+
+fn maximum_unprotected_request_stub_size(maximum_fragment_size: u16) -> Result<usize, RpcPduError> {
+    usize::from(maximum_fragment_size)
+        .checked_sub(RPC_COMMON_HEADER_SIZE + 8 /* request header */)
+        .ok_or(RpcPduError::FragmentTooLarge {
+            actual: RPC_COMMON_HEADER_SIZE + 8,
+            maximum: maximum_fragment_size,
+        })
+}
+
+fn maximum_authenticated_request_stub_size(maximum_fragment_size: u16) -> Result<usize, RpcPduError> {
+    const AUTHENTICATED_PDU_OVERHEAD: usize = RPC_COMMON_HEADER_SIZE + RPC_SEC_TRAILER_SIZE + 16 /* signature */;
+    let maximum_body_size = usize::from(maximum_fragment_size)
+        .checked_sub(AUTHENTICATED_PDU_OVERHEAD)
+        .ok_or(RpcPduError::FragmentTooLarge {
+            actual: AUTHENTICATED_PDU_OVERHEAD + 16, /* minimum padded request body */
+            maximum: maximum_fragment_size,
+        })?;
+    let maximum_padded_body_size = maximum_body_size & !15;
+    maximum_padded_body_size
+        .checked_sub(8 /* request header */)
+        .ok_or(RpcPduError::FragmentTooLarge {
+            actual: AUTHENTICATED_PDU_OVERHEAD + 16, /* minimum padded request body */
+            maximum: maximum_fragment_size,
+        })
+}
+
+fn decode_rpc_response_body<'a>(header: RpcCommonHeader, body: &'a [u8]) -> Result<RpcResponse<'a>, RpcPduError> {
+    let request_header = body.get(..8).ok_or(RpcPduError::Truncated {
+        actual: body.len(),
+        required: 8,
+    })?;
+    let alloc_hint = read_u32(request_header, 0)?;
+    let context_id = read_u16(request_header, 4)?;
+    if context_id != RPC_CONTEXT_ID {
+        return Err(RpcPduError::UnexpectedContextId { actual: context_id });
+    }
+    let stub = &body[8..];
+    Ok(RpcResponse {
+        call_id: header.call_id,
+        pfc_flags: header.pfc_flags,
+        alloc_hint,
+        cancel_count: request_header[6],
+        reserved: request_header[7],
+        stub,
+    })
+}
+
+fn validate_single_response_alloc_hint(response: RpcResponse<'_>) -> Result<(), RpcPduError> {
+    if response.alloc_hint != 0 && usize::try_from(response.alloc_hint).map_or(true, |hint| hint > response.stub.len())
+    {
+        return Err(RpcPduError::InvalidAllocHint {
+            alloc_hint: response.alloc_hint,
+            stub_length: response.stub.len(),
+        });
+    }
+
+    Ok(())
+}
+
+/// Decodes one complete, unauthenticated RPC fault PDU.
+pub(crate) fn decode_rpc_fault<'a>(source: &'a [u8], maximum_fragment_size: u16) -> Result<RpcFault<'a>, RpcPduError> {
+    let (header, body) = decode_unprotected_single_fragment(source, PTYPE_FAULT, maximum_fragment_size)?;
+    let fault_header = body.get(..16).ok_or(RpcPduError::Truncated {
+        actual: body.len(),
+        required: 16,
+    })?;
+    let context_id = read_u16(fault_header, 4)?;
+    if context_id != RPC_CONTEXT_ID {
+        return Err(RpcPduError::UnexpectedContextId { actual: context_id });
+    }
+
+    Ok(RpcFault {
+        call_id: header.call_id,
+        alloc_hint: read_u32(fault_header, 0)?,
+        cancel_count: fault_header[6],
+        reserved: fault_header[7],
+        status: read_u32(fault_header, 8)?,
+        reserved2: read_u32(fault_header, 12)?,
+        stub: &body[16..],
+    })
+}
+
+fn encode_rts_pdu(flags: u16, command_count: u16, commands: Vec<u8>) -> Result<Vec<u8>, RpcPduError> {
+    let body_length = 4usize.checked_add(commands.len()).ok_or(RpcPduError::LengthOverflow)?;
+    let pdu_length = RTS_HEADER_SIZE
+        .checked_add(commands.len())
+        .ok_or(RpcPduError::LengthOverflow)?;
+    let header = RpcCommonHeader::encode(PTYPE_RTS, RTS_PFC_FLAGS, 0, body_length, 0)?;
+    let mut pdu = Vec::with_capacity(pdu_length);
+    pdu.extend_from_slice(&header);
+    pdu.extend_from_slice(&flags.to_le_bytes());
+    pdu.extend_from_slice(&command_count.to_le_bytes());
+    pdu.extend_from_slice(&commands);
+    Ok(pdu)
+}
+
+fn encode_rts_u32_command(output: &mut Vec<u8>, command_type: u32, value: u32) {
+    output.extend_from_slice(&command_type.to_le_bytes());
+    output.extend_from_slice(&value.to_le_bytes());
+}
+
+fn encode_rts_cookie_command(output: &mut Vec<u8>, command_type: u32, cookie: RtsCookie) {
+    output.extend_from_slice(&command_type.to_le_bytes());
+    output.extend_from_slice(cookie.as_bytes());
+}
+
+fn decode_rts_pdu(
+    source: &[u8],
+    expected_flags: u16,
+    expected_command_count: u16,
+    expected_body_length: usize,
+) -> Result<&[u8], RpcPduError> {
+    let header = RpcCommonHeader::decode(source)?;
+    if header.ptype != PTYPE_RTS {
+        return Err(RpcPduError::UnexpectedPduType {
+            expected: PTYPE_RTS,
+            actual: header.ptype,
+        });
+    }
+    if header.pfc_flags != RTS_PFC_FLAGS {
+        return Err(RpcPduError::InvalidRtsPfcFlags {
+            actual: header.pfc_flags,
+        });
+    }
+    if header.auth_length != 0 {
+        return Err(RpcPduError::AuthenticationUnsupported {
+            auth_length: header.auth_length,
+        });
+    }
+    if header.call_id != 0 {
+        return Err(RpcPduError::UnexpectedRtsCallId { actual: header.call_id });
+    }
+
+    let pdu = &source[..usize::from(header.fragment_length)];
+    let rts_header = pdu
+        .get(RPC_COMMON_HEADER_SIZE..RTS_HEADER_SIZE)
+        .ok_or(RpcPduError::Truncated {
+            actual: pdu.len(),
+            required: RTS_HEADER_SIZE,
+        })?;
+    let flags = read_u16(rts_header, 0)?;
+    if flags != expected_flags {
+        return Err(RpcPduError::UnexpectedRtsFlags {
+            expected: expected_flags,
+            actual: flags,
+        });
+    }
+    let command_count = read_u16(rts_header, 2)?;
+    if command_count != expected_command_count {
+        return Err(RpcPduError::UnexpectedRtsCommandCount {
+            expected: expected_command_count,
+            actual: command_count,
+        });
+    }
+
+    let body = &pdu[RTS_HEADER_SIZE..];
+    if body.len() != expected_body_length {
+        return Err(RpcPduError::InvalidRtsBodyLength {
+            expected: expected_body_length,
+            actual: body.len(),
+        });
+    }
+
+    Ok(body)
+}
+
+fn decode_rts_u32_command(source: &[u8], offset: usize, expected_type: u32) -> Result<u32, RpcPduError> {
+    let command_type = read_u32(source, offset)?;
+    if command_type != expected_type {
+        return Err(RpcPduError::UnexpectedRtsCommandType {
+            expected: expected_type,
+            actual: command_type,
+        });
+    }
+
+    let value_offset = offset.checked_add(4).ok_or(RpcPduError::LengthOverflow)?;
+    read_u32(source, value_offset)
+}
+
+fn decode_rts_empty_command(source: &[u8], offset: usize, expected_type: u32) -> Result<(), RpcPduError> {
+    let command_type = read_u32(source, offset)?;
+    if command_type != expected_type {
+        return Err(RpcPduError::UnexpectedRtsCommandType {
+            expected: expected_type,
+            actual: command_type,
+        });
+    }
+    Ok(())
+}
+
+fn validate_rts_receive_window_size(value: u32) -> Result<(), RpcPduError> {
+    if !(RTS_MIN_RECEIVE_WINDOW_SIZE..=RTS_MAX_RECEIVE_WINDOW_SIZE).contains(&value) {
+        return Err(RpcPduError::InvalidRtsReceiveWindowSize { actual: value });
+    }
+
+    Ok(())
+}
+
+fn validate_rts_connection_timeout(value: u32) -> Result<(), RpcPduError> {
+    if !(RTS_MIN_CONNECTION_TIMEOUT..=RTS_MAX_CONNECTION_TIMEOUT).contains(&value) {
+        return Err(RpcPduError::InvalidRtsConnectionTimeout { actual: value });
+    }
+
+    Ok(())
+}
+
+fn validate_rts_channel_lifetime(value: u32) -> Result<(), RpcPduError> {
+    if !(RTS_MIN_CHANNEL_LIFETIME..=RTS_MAX_CHANNEL_LIFETIME).contains(&value) {
+        return Err(RpcPduError::InvalidRtsChannelLifetime { actual: value });
+    }
+
+    Ok(())
+}
+
+fn validate_rts_client_keepalive(value: u32) -> Result<(), RpcPduError> {
+    if value != 0 && value < RTS_MIN_CLIENT_KEEPALIVE {
+        return Err(RpcPduError::InvalidRtsClientKeepalive { actual: value });
+    }
+
+    Ok(())
+}
+
+fn decode_unprotected_fragment(
+    source: &[u8],
+    expected_ptype: u8,
+    maximum_fragment_size: u16,
+) -> Result<(RpcCommonHeader, &[u8]), RpcPduError> {
+    let header = RpcCommonHeader::decode(source)?;
+    if header.ptype != expected_ptype {
+        return Err(RpcPduError::UnexpectedPduType {
+            expected: expected_ptype,
+            actual: header.ptype,
+        });
+    }
+    if header.fragment_length > maximum_fragment_size {
+        return Err(RpcPduError::FragmentExceedsMaximum {
+            fragment_length: header.fragment_length,
+            maximum: maximum_fragment_size,
+        });
+    }
+    if header.auth_length != 0 {
+        return Err(RpcPduError::AuthenticationUnsupported {
+            auth_length: header.auth_length,
+        });
+    }
+
+    Ok((
+        header,
+        &source[RPC_COMMON_HEADER_SIZE..usize::from(header.fragment_length)],
+    ))
+}
+
+fn decode_unprotected_single_fragment(
+    source: &[u8],
+    expected_ptype: u8,
+    maximum_fragment_size: u16,
+) -> Result<(RpcCommonHeader, &[u8]), RpcPduError> {
+    let (header, body) = decode_unprotected_fragment(source, expected_ptype, maximum_fragment_size)?;
+    validate_single_fragment(header)?;
+    Ok((header, body))
+}
+
+fn encode_unprotected_pdu(ptype: u8, call_id: u32, body: Vec<u8>) -> Result<Vec<u8>, RpcPduError> {
+    encode_unprotected_pdu_with_flags(ptype, PFC_FIRST_FRAG | PFC_LAST_FRAG, call_id, body)
+}
+
+fn encode_unprotected_pdu_with_flags(
+    ptype: u8,
+    pfc_flags: u8,
+    call_id: u32,
+    body: Vec<u8>,
+) -> Result<Vec<u8>, RpcPduError> {
+    let header = RpcCommonHeader::encode(ptype, pfc_flags, call_id, body.len(), 0)?;
+    let mut pdu = Vec::with_capacity(RPC_COMMON_HEADER_SIZE + body.len());
+    pdu.extend_from_slice(&header);
+    pdu.extend_from_slice(&body);
+    Ok(pdu)
+}
+
+fn encode_authenticated_pdu(ptype: u8, call_id: u32, body: Vec<u8>, token: &[u8]) -> Result<Vec<u8>, RpcPduError> {
+    encode_authenticated_pdu_with_flags(
+        ptype,
+        PFC_FIRST_FRAG | PFC_LAST_FRAG | PFC_SUPPORT_HEADER_SIGN | PFC_CONC_MPX,
+        call_id,
+        body,
+        token,
+    )
+}
+
+fn encode_authenticated_pdu_with_flags(
+    ptype: u8,
+    pfc_flags: u8,
+    call_id: u32,
+    mut body: Vec<u8>,
+    token: &[u8],
+) -> Result<Vec<u8>, RpcPduError> {
+    if token.is_empty() {
+        return Err(RpcPduError::EmptyAuthenticationToken);
+    }
+
+    let auth_length = u16::try_from(token.len()).map_err(|_| RpcPduError::LengthOverflow)?;
+    // The security trailer must be 16-byte aligned with respect to the PDU body
+    // ([MS-RPCE] 2.2.2.11); pad the body so it is.
+    let padding_length = (16 - body.len() % 16) % 16;
+    body.resize(
+        body.len()
+            .checked_add(padding_length)
+            .ok_or(RpcPduError::LengthOverflow)?,
+        0,
+    );
+    let header = RpcCommonHeader::encode(ptype, pfc_flags, call_id, body.len(), auth_length)?;
+    let mut pdu = Vec::with_capacity(
+        RPC_COMMON_HEADER_SIZE
+            .checked_add(body.len())
+            .and_then(|length| length.checked_add(RPC_SEC_TRAILER_SIZE))
+            .and_then(|length| length.checked_add(token.len()))
+            .ok_or(RpcPduError::LengthOverflow)?,
+    );
+    pdu.extend_from_slice(&header);
+    pdu.extend_from_slice(&body);
+    pdu.push(RPC_AUTH_TYPE_WINNT);
+    pdu.push(RPC_AUTH_LEVEL_PACKET_INTEGRITY);
+    pdu.push(u8::try_from(padding_length).map_err(|_| RpcPduError::LengthOverflow)?);
+    pdu.push(0); // auth_reserved
+    pdu.extend_from_slice(&RPC_AUTH_CONTEXT_ID.to_le_bytes());
+    pdu.extend_from_slice(token);
+    Ok(pdu)
+}
+
+fn decode_authenticated_fragment(
+    source: &[u8],
+    expected_ptype: u8,
+    maximum_fragment_size: u16,
+    require_support_header_sign: bool,
+) -> Result<(RpcCommonHeader, &[u8], &[u8]), RpcPduError> {
+    let header = RpcCommonHeader::decode(source)?;
+    if header.ptype != expected_ptype {
+        return Err(RpcPduError::UnexpectedPduType {
+            expected: expected_ptype,
+            actual: header.ptype,
+        });
+    }
+    if require_support_header_sign && header.pfc_flags & PFC_SUPPORT_HEADER_SIGN == 0 {
+        return Err(RpcPduError::MissingSupportHeaderSign);
+    }
+    if header.fragment_length > maximum_fragment_size {
+        return Err(RpcPduError::FragmentExceedsMaximum {
+            fragment_length: header.fragment_length,
+            maximum: maximum_fragment_size,
+        });
+    }
+    if header.auth_length == 0 {
+        return Err(RpcPduError::AuthenticationRequired);
+    }
+
+    let fragment_length = usize::from(header.fragment_length);
+    let trailer_offset = fragment_length
+        .checked_sub(usize::from(header.auth_length))
+        .and_then(|offset| offset.checked_sub(RPC_SEC_TRAILER_SIZE))
+        .ok_or(RpcPduError::InvalidSecurityTrailer {
+            fragment_length: header.fragment_length,
+            auth_length: header.auth_length,
+        })?;
+    if trailer_offset < RPC_COMMON_HEADER_SIZE {
+        return Err(RpcPduError::InvalidSecurityTrailer {
+            fragment_length: header.fragment_length,
+            auth_length: header.auth_length,
+        });
+    }
+
+    let trailer_end = trailer_offset
+        .checked_add(RPC_SEC_TRAILER_SIZE)
+        .ok_or(RpcPduError::LengthOverflow)?;
+    let trailer = source
+        .get(trailer_offset..trailer_end)
+        .ok_or(RpcPduError::InvalidSecurityTrailer {
+            fragment_length: header.fragment_length,
+            auth_length: header.auth_length,
+        })?;
+    if trailer[0] != RPC_AUTH_TYPE_WINNT {
+        return Err(RpcPduError::UnexpectedAuthenticationType {
+            expected: RPC_AUTH_TYPE_WINNT,
+            actual: trailer[0],
+        });
+    }
+    if trailer[1] != RPC_AUTH_LEVEL_PACKET_INTEGRITY {
+        return Err(RpcPduError::UnexpectedAuthenticationLevel {
+            expected: RPC_AUTH_LEVEL_PACKET_INTEGRITY,
+            actual: trailer[1],
+        });
+    }
+    let auth_context_id = u32::from_le_bytes(trailer[4..8].try_into().map_err(|_| RpcPduError::LengthOverflow)?);
+    if auth_context_id != RPC_AUTH_CONTEXT_ID {
+        return Err(RpcPduError::UnexpectedAuthenticationContextId {
+            expected: RPC_AUTH_CONTEXT_ID,
+            actual: auth_context_id,
+        });
+    }
+
+    let body_with_padding = &source[RPC_COMMON_HEADER_SIZE..trailer_offset];
+    let padding_length = usize::from(trailer[2]);
+    // Per MS-RPCE the auth_pad_len field is authoritative for how many bytes of the
+    // stub are padding. Real gateways align the stub to NDR (4-byte) boundaries, not
+    // the 16-byte boundary our encoder uses, so validate against auth_pad_len and
+    // require zero padding bytes instead of assuming a fixed alignment.
+    let body_length = body_with_padding
+        .len()
+        .checked_sub(padding_length)
+        .filter(|length| *length != 0)
+        .ok_or(RpcPduError::InvalidAuthenticationPadding {
+            actual: trailer[2],
+            expected: 0,
+        })?;
+    if body_with_padding[body_length..].iter().any(|&byte| byte != 0) {
+        return Err(RpcPduError::NonZeroAuthenticationPadding);
+    }
+
+    let token = source
+        .get(trailer_end..fragment_length)
+        .ok_or(RpcPduError::InvalidSecurityTrailer {
+            fragment_length: header.fragment_length,
+            auth_length: header.auth_length,
+        })?;
+    debug_assert_eq!(token.len(), usize::from(header.auth_length));
+    Ok((header, &body_with_padding[..body_length], token))
+}
+
+fn decode_authenticated_single_fragment(
+    source: &[u8],
+    expected_ptype: u8,
+    maximum_fragment_size: u16,
+    require_support_header_sign: bool,
+) -> Result<(RpcCommonHeader, &[u8], &[u8]), RpcPduError> {
+    let (header, body, token) = decode_authenticated_fragment(
+        source,
+        expected_ptype,
+        maximum_fragment_size,
+        require_support_header_sign,
+    )?;
+    validate_single_fragment(header)?;
+    Ok((header, body, token))
+}
+
+fn validate_single_fragment(header: RpcCommonHeader) -> Result<(), RpcPduError> {
+    if header.pfc_flags & (PFC_FIRST_FRAG | PFC_LAST_FRAG) != PFC_FIRST_FRAG | PFC_LAST_FRAG {
+        return Err(RpcPduError::FragmentedPduUnsupported {
+            flags: header.pfc_flags,
+        });
+    }
+
+    Ok(())
+}
+
+fn rpc_auth_identity(username: &str, password: &str) -> Result<AuthIdentity, Error> {
+    let username = Username::parse(username)
+        .or_else(|_| Username::new(username, None))
+        .map_err(|e| Error::custom("parse rpc username", e))?;
+
+    Ok(AuthIdentity {
+        username,
+        password: password.to_owned().into(),
+    })
+}
+
+fn encode_syntax_identifier(output: &mut Vec<u8>, identifier: Uuid, version: RpcSyntaxVersion) {
+    output.extend_from_slice(&identifier.to_bytes_le());
+    output.extend_from_slice(&version.major.to_le_bytes());
+    output.extend_from_slice(&version.minor.to_le_bytes());
+}
+
+fn ensure_pdu_fits(actual: usize, maximum: u16) -> Result<(), RpcPduError> {
+    if actual > usize::from(maximum) {
+        return Err(RpcPduError::FragmentTooLarge { actual, maximum });
+    }
+    Ok(())
+}
+
+fn read_u16(source: &[u8], offset: usize) -> Result<u16, RpcPduError> {
+    let end = offset.checked_add(2).ok_or(RpcPduError::LengthOverflow)?;
+    let bytes = source.get(offset..end).ok_or(RpcPduError::Truncated {
+        actual: source.len(),
+        required: end,
+    })?;
+    Ok(u16::from_le_bytes(
+        bytes.try_into().map_err(|_| RpcPduError::LengthOverflow)?,
+    ))
+}
+
+fn read_u32(source: &[u8], offset: usize) -> Result<u32, RpcPduError> {
+    let end = offset.checked_add(4).ok_or(RpcPduError::LengthOverflow)?;
+    let bytes = source.get(offset..end).ok_or(RpcPduError::Truncated {
+        actual: source.len(),
+        required: end,
+    })?;
+    Ok(u32::from_le_bytes(
+        bytes.try_into().map_err(|_| RpcPduError::LengthOverflow)?,
+    ))
+}
+
+/// Server-side PDU encoders for the in-process mock RPC proxy.
+#[cfg(test)]
+pub(crate) mod fixtures {
+    use super::*;
+
+    /// CONN/A3 with the given connection timeout ([MS-RPCH] 2.2.3.1).
+    pub(crate) fn rts_conn_a3(connection_timeout: u32) -> Vec<u8> {
+        let mut commands = Vec::new();
+        encode_rts_u32_command(&mut commands, 2 /* ConnectionTimeout */, connection_timeout);
+        encode_rts_pdu(RTS_FLAG_NONE, 1, commands).expect("valid A3")
+    }
+
+    /// CONN/C2 with the negotiated version, receive window, and timeout ([MS-RPCH] 2.2.3.8).
+    pub(crate) fn rts_conn_c2(version: u32, receive_window_size: u32, connection_timeout: u32) -> Vec<u8> {
+        let mut commands = Vec::new();
+        encode_rts_u32_command(&mut commands, 6 /* Version */, version);
+        encode_rts_u32_command(&mut commands, 0 /* ReceiveWindowSize */, receive_window_size);
+        encode_rts_u32_command(&mut commands, 2 /* ConnectionTimeout */, connection_timeout);
+        encode_rts_pdu(RTS_FLAG_NONE, 3, commands).expect("valid C2")
+    }
+
+    /// Unauthenticated bind acknowledgement accepting the NDR32 context.
+    pub(crate) fn bind_ack(call_id: u32) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(&0x2000u16.to_le_bytes()); // max_xmit_frag
+        body.extend_from_slice(&0x2000u16.to_le_bytes()); // max_recv_frag
+        body.extend_from_slice(&0u32.to_le_bytes()); // assoc group
+        body.extend_from_slice(&0u16.to_le_bytes()); // secondary address length (none)
+        body.extend_from_slice(&[0, 0]); // NDR alignment
+        body.extend_from_slice(&[1, 0, 0, 0]); // one presentation result (u8 + reserved u8 + u16)
+        body.extend_from_slice(&[0, 0, 0, 0]); // accepted (result + reason)
+        // NDR32 transfer syntax identifier in wire order.
+        body.extend_from_slice(&[
+            0x04, 0x5d, 0x88, 0x8a, 0xeb, 0x1c, 0xc9, 0x11, 0x9f, 0xe8, 0x08, 0x00, 0x2b, 0x10, 0x48, 0x60,
+        ]);
+        body.extend_from_slice(&2u32.to_le_bytes()); // NDR32 version
+        encode_unprotected_pdu(PTYPE_BIND_ACK, call_id, body).expect("valid bind ack")
+    }
+
+    /// Single-fragment unauthenticated RPC response carrying `stub`.
+    pub(crate) fn rpc_response(call_id: u32, stub: &[u8]) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(&u32::try_from(stub.len()).expect("stub length fits").to_le_bytes()); // alloc hint
+        body.extend_from_slice(&0u16.to_le_bytes()); // context id
+        body.extend_from_slice(&0u8.to_le_bytes()); // cancel count
+        body.extend_from_slice(&0u8.to_le_bytes()); // reserved
+        body.extend_from_slice(stub);
+        encode_unprotected_pdu(PTYPE_RESPONSE, call_id, body).expect("valid rpc response")
+    }
+
+    /// `TsProxyCreateTunnel` success response with the given context and tunnel ID.
+    pub(crate) fn create_tunnel_response(tunnel_context: &[u8; RpcContextHandle::SIZE], tunnel_id: u32) -> Vec<u8> {
+        let nonce = Uuid::from_u128(0x0011_2233_4455_6677_8899_aabb_ccdd_eeff);
+        let mut response = Vec::new();
+        response.extend_from_slice(&NDR_REFERENT_ID.to_le_bytes()); // TSG packet
+        response.extend_from_slice(&TSG_PACKET_TYPE_QUARENC_RESPONSE.to_le_bytes());
+        response.extend_from_slice(&TSG_PACKET_TYPE_QUARENC_RESPONSE.to_le_bytes());
+        response.extend_from_slice(&(NDR_REFERENT_ID + 4).to_le_bytes()); // QUARENC response
+        response.extend_from_slice(&0u32.to_le_bytes()); // flags
+        response.extend_from_slice(&0u32.to_le_bytes()); // certificate chain length
+        response.extend_from_slice(&0u32.to_le_bytes()); // certificate chain pointer
+        response.extend_from_slice(&nonce.into_bytes());
+        response.extend_from_slice(&(NDR_REFERENT_ID + 8).to_le_bytes()); // version capabilities
+        response.extend_from_slice(&TSG_COMPONENT_ID.to_le_bytes());
+        response.extend_from_slice(
+            &u16::try_from(TSG_PACKET_TYPE_VERSIONCAPS)
+                .expect("packet type fits in u16")
+                .to_le_bytes(),
+        );
+        response.extend_from_slice(&(NDR_REFERENT_ID + 12).to_le_bytes()); // capability array
+        response.extend_from_slice(&1u32.to_le_bytes()); // number of capabilities
+        response.extend_from_slice(&1u16.to_le_bytes()); // major version
+        response.extend_from_slice(&1u16.to_le_bytes()); // minor version
+        response.extend_from_slice(&0u16.to_le_bytes()); // quarantine capabilities
+        response.extend_from_slice(&0u16.to_le_bytes()); // NDR alignment
+        response.extend_from_slice(&1u32.to_le_bytes()); // capability array max count
+        response.extend_from_slice(&TSG_CAPABILITY_TYPE_NAP.to_le_bytes());
+        response.extend_from_slice(&TSG_CAPABILITY_TYPE_NAP.to_le_bytes());
+        response.extend_from_slice(&0x0000_0003u32.to_le_bytes());
+        response.extend_from_slice(tunnel_context);
+        response.extend_from_slice(&tunnel_id.to_le_bytes());
+        response.extend_from_slice(&0u32.to_le_bytes()); // HRESULT
+        response
+    }
+
+    /// `TsProxyAuthorizeTunnel` success response with empty response data.
+    pub(crate) fn authorize_tunnel_response() -> Vec<u8> {
+        let mut response = Vec::new();
+        response.extend_from_slice(&NDR_REFERENT_ID.to_le_bytes()); // TSG packet
+        response.extend_from_slice(&TSG_PACKET_TYPE_RESPONSE.to_le_bytes());
+        response.extend_from_slice(&TSG_PACKET_TYPE_RESPONSE.to_le_bytes());
+        response.extend_from_slice(&(NDR_REFERENT_ID + 4).to_le_bytes()); // packet response
+        response.extend_from_slice(&TSG_PACKET_TYPE_QUARREQUEST.to_le_bytes());
+        response.extend_from_slice(&0u32.to_le_bytes()); // reserved
+        response.extend_from_slice(&0u32.to_le_bytes()); // response data pointer (none)
+        response.extend_from_slice(&0u32.to_le_bytes()); // response data length
+        response.extend_from_slice(&0u32.to_le_bytes()); // enable all
+        response.extend_from_slice(&0u32.to_le_bytes()); // disable all
+        response.extend_from_slice(&0u32.to_le_bytes()); // drive disabled
+        response.extend_from_slice(&0u32.to_le_bytes()); // printer disabled
+        response.extend_from_slice(&0u32.to_le_bytes()); // port disabled
+        response.extend_from_slice(&0u32.to_le_bytes()); // reserved
+        response.extend_from_slice(&0u32.to_le_bytes()); // clipboard disabled
+        response.extend_from_slice(&0u32.to_le_bytes()); // PnP disabled
+        response.extend_from_slice(&0u32.to_le_bytes()); // HRESULT
+        response
+    }
+
+    /// `TsProxyCreateChannel` success response with the given context and channel ID.
+    pub(crate) fn create_channel_response(channel_context: &[u8; RpcContextHandle::SIZE], channel_id: u32) -> Vec<u8> {
+        let mut response = Vec::new();
+        response.extend_from_slice(channel_context);
+        response.extend_from_slice(&channel_id.to_le_bytes());
+        response.extend_from_slice(&0u32.to_le_bytes()); // HRESULT
+        response
+    }
+
+    /// `TsProxySetupReceivePipe` terminal response: the 4-byte return value sent when the
+    /// pipe closes or fails ([MS-TSGU] 3.2.6.2.3).
+    pub(crate) fn receive_pipe_final_return_value(result: u32) -> Vec<u8> {
+        result.to_le_bytes().to_vec()
+    }
+
+    /// `TsProxyMakeTunnelCall` response carrying a service message ([MS-TSGU] 2.2.9.2.1.9.1).
+    pub(crate) fn make_tunnel_call_service_response(text: &str) -> Vec<u8> {
+        let utf16: Vec<u8> = text.encode_utf16().chain([0]).flat_map(u16::to_le_bytes).collect();
+        let char_count = u32::try_from(text.chars().count() + 1).expect("message length fits");
+        let padded_len = (utf16.len() + 3) & !3;
+        let mut response = Vec::new();
+        response.extend_from_slice(&NDR_REFERENT_ID.to_le_bytes()); // TSG packet
+        response.extend_from_slice(&TSG_PACKET_TYPE_MESSAGE.to_le_bytes());
+        response.extend_from_slice(&TSG_PACKET_TYPE_MESSAGE.to_le_bytes());
+        response.extend_from_slice(&(NDR_REFERENT_ID + 4).to_le_bytes()); // message response
+        response.extend_from_slice(&1u32.to_le_bytes()); // message ID
+        response.extend_from_slice(&TSG_ASYNC_MESSAGE_SERVICE.to_le_bytes());
+        response.extend_from_slice(&1u32.to_le_bytes()); // is message present
+        response.extend_from_slice(&(NDR_REFERENT_ID + 8).to_le_bytes()); // service message
+        response.extend_from_slice(&1u32.to_le_bytes()); // display mandatory
+        response.extend_from_slice(&0u32.to_le_bytes()); // consent mandatory
+        response.extend_from_slice(&char_count.to_le_bytes()); // message characters
+        response.extend_from_slice(&(NDR_REFERENT_ID + 12).to_le_bytes()); // message buffer
+        response.extend_from_slice(&char_count.to_le_bytes()); // NDR array count
+        response.extend_from_slice(&utf16);
+        response.resize(response.len() + (padded_len - utf16.len()), 0); // NDR alignment
+        response.extend_from_slice(&0u32.to_le_bytes()); // HRESULT
+        response
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    const CHANNEL_CONTEXT: [u8; RpcContextHandle::SIZE] = [
+        0, 0, 0, 0, 0x36, 0x41, 0x18, 0x41, 0xdd, 0x2d, 0x84, 0x43, 0x83, 0x63, 0x82, 0xcc, 0xb6, 0xea, 0xf3, 0xf9,
+    ];
+
+    fn channel_context() -> NonNullRpcContextHandle {
+        RpcContextHandle::from_bytes(&CHANNEL_CONTEXT)
+            .expect("valid context handle")
+            .require_non_null()
+            .expect("non-null context handle")
+    }
+
+    #[test]
+    fn close_context_encodes_and_validates_the_context_handle_stub() {
+        assert_eq!(
+            TsProxyCloseContextRequest::new(channel_context()).encode(),
+            CHANNEL_CONTEXT
+        );
+
+        let response = [CHANNEL_CONTEXT.as_slice(), &[0, 0, 0, 0]].concat();
+        assert_eq!(decode_tsgu_close_context_response(&response), Ok(()));
+
+        let mut failed_response = response;
+        failed_response[RpcContextHandle::SIZE..].copy_from_slice(&0x8007_0005u32.to_le_bytes());
+        assert_eq!(
+            decode_tsgu_close_context_response(&failed_response),
+            Err(RpcWireError::RpcStatus { value: 0x8007_0005 })
+        );
+        assert_eq!(
+            decode_tsgu_close_context_response(&failed_response[..RpcContextHandle::SIZE]),
+            Err(RpcWireError::ResponseLength {
+                actual: RpcContextHandle::SIZE,
+                expected: RpcContextHandle::SIZE + 4,
+            })
+        );
+    }
+
+    fn completed_rpc_ntlm_auth() -> RpcNtlmAuth {
+        let mut auth = RpcNtlmAuth::new(r"CONTOSO\alice", "secret").expect("valid credentials");
+        let _type1 = auth.initial_token().expect("offline Type-1 token");
+        let type2 = [
+            b"NTLMSSP\0".as_slice(),
+            &[2, 0, 0, 0],
+            &[8, 0, 8, 0, 56, 0, 0, 0],
+            &0xe288_82b7u32.to_le_bytes(),
+            &[0x26, 0x6e, 0xcd, 0x75, 0xaa, 0x41, 0xe7, 0x6f],
+            &[0; 8],
+            &[64, 0, 64, 0, 64, 0, 0, 0],
+            &[6, 1, 0xb0, 0x1d, 0, 0, 0, 0x0f],
+            &[0x57, 0, 0x49, 0, 0x4e, 0, 0x37, 0],
+            &[
+                2, 0, 8, 0, 0x57, 0, 0x49, 0, 0x4e, 0, 0x37, 0, 1, 0, 8, 0, 0x57, 0, 0x49, 0, 0x4e, 0, 0x37, 0, 4, 0,
+                8, 0, 0x77, 0, 0x69, 0, 0x6e, 0, 0x37, 0, 3, 0, 8, 0, 0x77, 0, 0x69, 0, 0x6e, 0, 0x37, 0, 7, 0, 8, 0,
+                0xa9, 0x8d, 0x9b, 0x1a, 0x6c, 0xb0, 0xcb, 1, 0, 0, 0, 0,
+            ],
+        ]
+        .concat();
+        let _type3 = auth.continue_token(&type2).expect("valid Type-2 token");
+        assert!(auth.is_complete());
+        auth
+    }
+
+    fn conn_a3_pdu() -> Vec<u8> {
+        [
+            [5, 0, PTYPE_RTS, RTS_PFC_FLAGS, 0x10, 0, 0, 0].as_slice(),
+            [28, 0, 0, 0, 0, 0, 0, 0].as_slice(),
+            [0, 0, 1, 0].as_slice(),
+            [2, 0, 0, 0, 0xc0, 0xd4, 1, 0].as_slice(),
+        ]
+        .concat()
+    }
+
+    fn conn_c2_pdu(version: u32) -> Vec<u8> {
+        [
+            [5, 0, PTYPE_RTS, RTS_PFC_FLAGS, 0x10, 0, 0, 0].as_slice(),
+            [44, 0, 0, 0, 0, 0, 0, 0].as_slice(),
+            [0, 0, 3, 0].as_slice(),
+            [6, 0, 0, 0].as_slice(),
+            version.to_le_bytes().as_slice(),
+            [0, 0, 0, 0, 0, 0, 2, 0].as_slice(),
+            [2, 0, 0, 0, 0xc0, 0xd4, 1, 0].as_slice(),
+        ]
+        .concat()
+    }
+
+    #[test]
+    fn rpc_context_handle_is_exactly_twenty_bytes() {
+        assert_eq!(
+            RpcContextHandle::from_bytes(&CHANNEL_CONTEXT[..RpcContextHandle::SIZE - 1]),
+            Err(RpcWireError::ContextHandleLength {
+                actual: RpcContextHandle::SIZE - 1
+            })
+        );
+        assert_eq!(
+            RpcContextHandle::from_bytes(&[0; RpcContextHandle::SIZE + 1]),
+            Err(RpcWireError::ContextHandleLength {
+                actual: RpcContextHandle::SIZE + 1
+            })
+        );
+
+        let handle = RpcContextHandle::from_bytes(&CHANNEL_CONTEXT).expect("valid context handle");
+        let mut encoded = [0; RpcContextHandle::SIZE];
+        handle
+            .encode(&mut WriteCursor::new(&mut encoded))
+            .expect("sufficient output");
+        assert_eq!(encoded, CHANNEL_CONTEXT);
+
+        let decoded = RpcContextHandle::decode(&mut ReadCursor::new(&encoded)).expect("sufficient input");
+        assert_eq!(decoded, handle);
+        assert!(RpcContextHandle::decode(&mut ReadCursor::new(&encoded[..RpcContextHandle::SIZE - 1])).is_err());
+    }
+
+    #[test]
+    fn null_context_handle_is_rejected_for_channel_requests() {
+        let null = RpcContextHandle::from_bytes(&[0; RpcContextHandle::SIZE]).expect("valid null representation");
+        assert!(null.is_null());
+        assert_eq!(null.require_non_null(), Err(RpcWireError::NullContextHandle));
+    }
+
+    #[test]
+    fn setup_receive_pipe_contains_only_the_channel_context() {
+        let request = TsProxySetupReceivePipeRequest::new(channel_context());
+        assert_eq!(request.encode(), CHANNEL_CONTEXT);
+
+        let mut output = [0; RpcContextHandle::SIZE - 1];
+        assert_eq!(
+            request.encode_into(&mut output),
+            Err(RpcWireError::OutputLength {
+                actual: output.len(),
+                expected: RpcContextHandle::SIZE
+            })
+        );
+    }
+
+    #[test]
+    fn send_to_server_encodes_single_buffer_little_endian() {
+        let request = TsProxySendToServerRequest::new(channel_context(), &[4, 0, 0, 3]).expect("valid request");
+        assert_eq!(
+            request.encode().expect("valid encoding"),
+            [
+                CHANNEL_CONTEXT.as_slice(),
+                &[8, 0, 0, 0], // totalDataBytes
+                &[1, 0, 0, 0], // numBuffers
+                &[4, 0, 0, 0], // buffer1Length
+                &[4, 0, 0, 3],
+            ]
+            .concat()
+        );
+    }
+
+    #[test]
+    fn send_to_server_encodes_three_buffers_little_endian() {
+        let mut request = TsProxySendToServerRequest::new(channel_context(), &[1]).expect("valid request");
+        request.push_buffer(&[2, 3]).expect("second buffer");
+        request.push_buffer(&[4, 5, 6]).expect("third buffer");
+
+        assert_eq!(
+            request.encode().expect("valid encoding"),
+            [
+                CHANNEL_CONTEXT.as_slice(),
+                &[18, 0, 0, 0], // totalDataBytes: 1 + 2 + 3 + 3 length fields
+                &[3, 0, 0, 0],  // numBuffers
+                &[1, 0, 0, 0],  // buffer1Length
+                &[2, 0, 0, 0],  // buffer2Length
+                &[3, 0, 0, 0],  // buffer3Length
+                &[1, 2, 3, 4, 5, 6],
+            ]
+            .concat()
+        );
+    }
+
+    #[test]
+    fn send_to_server_validates_buffer_count_and_size() {
+        assert!(matches!(
+            TsProxySendToServerRequest::new(channel_context(), &[]),
+            Err(RpcWireError::EmptyFirstBuffer)
+        ));
+
+        let mut request = TsProxySendToServerRequest::new(channel_context(), &[1]).expect("valid request");
+        request.push_buffer(&[]).expect("second buffer");
+        request.push_buffer(&[]).expect("third buffer");
+        assert_eq!(request.push_buffer(&[]), Err(RpcWireError::BufferCount { actual: 4 }));
+
+        let payload = vec![0; MAX_RPC_MESSAGE_SIZE];
+        let request = TsProxySendToServerRequest::new(channel_context(), &payload).expect("valid request shape");
+        assert_eq!(
+            request.encoded_len(),
+            Err(RpcWireError::RequestTooLarge {
+                actual: RpcContextHandle::SIZE + 4 + 4 + 4 + payload.len()
+            })
+        );
+
+        let payload = vec![0; MAX_RPC_MESSAGE_SIZE - TsProxySendToServerRequest::PREFIX_SIZE - 4];
+        let request = TsProxySendToServerRequest::new(channel_context(), &payload).expect("maximum request shape");
+        assert_eq!(request.encoded_len(), Ok(MAX_RPC_MESSAGE_SIZE));
+    }
+
+    #[test]
+    fn create_tunnel_encodes_the_version_caps_and_interface_trailer() {
+        let request = TsProxyCreateTunnelRequest::new(0x7856_3412).encode();
+        let expected: [&[u8]; 10] = [
+            &[0x43, 0x56, 0, 0, 0x43, 0x56, 0, 0, 0, 0, 2, 0],
+            &[0x52, 0x54, 0x43, 0x56, 4, 0, 2, 0],
+            &[1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0],
+            &[1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0x12, 0x34, 0x56, 0x78],
+            &[0x8a, 0xe3, 0x13, 0x71, 0x02, 0xf4, 0x36, 0x71],
+            &[1, 0, 4, 0, 1, 0, 0, 0, 2, 0x40, 0x28, 0],
+            &TSPROXY_RPC_INTERFACE_ID.to_bytes_le(),
+            &[1, 0, 3, 0],
+            &NDR32_TRANSFER_SYNTAX_ID.to_bytes_le(),
+            &[2, 0, 0, 0],
+        ];
+        assert_eq!(request, expected.concat());
+    }
+
+    #[test]
+    fn reauthenticate_tunnel_encodes_the_tunnel_context_and_version_caps() {
+        let request = TsProxyReauthenticateTunnelRequest::new(0x1122_3344_5566_7788, 3).encode();
+        let expected: [&[u8]; 5] = [
+            &[0x50, 0x52, 0, 0, 0x50, 0x52, 0, 0, 0, 0, 2, 0],
+            &[
+                0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x43, 0x56, 0, 0, 4, 0, 2, 0,
+            ],
+            &[0x52, 0x54, 0x43, 0x56, 8, 0, 2, 0],
+            &[1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0],
+            &[1, 0, 0, 0, 1, 0, 0, 0, 3, 0, 0, 0],
+        ];
+        assert_eq!(request, expected.concat());
+    }
+
+    #[test]
+    fn make_tunnel_call_requests_one_queued_server_message() {
+        let request = TsProxyMakeTunnelCallRequest::new(channel_context()).encode();
+        assert_eq!(
+            request.as_slice(),
+            [
+                CHANNEL_CONTEXT.as_slice(),
+                &[1, 0, 0, 0], // TSG_TUNNEL_CALL_ASYNC_MSG_REQUEST
+                &[0x52, 0x47, 0, 0, 0x52, 0x47, 0, 0, 0, 0, 2, 0],
+                &[1, 0, 0, 0], // maxMessagesPerBatch
+            ]
+            .concat()
+        );
+    }
+
+    #[test]
+    fn cancel_tunnel_call_uses_the_message_request_stub_and_requires_a_null_response() {
+        let request = TsProxyMakeTunnelCallRequest::cancel_pending(channel_context()).encode();
+        assert_eq!(
+            request.as_slice(),
+            [
+                CHANNEL_CONTEXT.as_slice(),
+                &[2, 0, 0, 0], // TSG_TUNNEL_CANCEL_ASYNC_MSG_REQUEST
+                &[0x52, 0x47, 0, 0, 0x52, 0x47, 0, 0, 0, 0, 2, 0],
+                &[1, 0, 0, 0], // maxMessagesPerBatch
+            ]
+            .concat()
+        );
+        assert_eq!(decode_tsgu_cancel_tunnel_call_response(&[0; 8]), Ok(()));
+        assert_eq!(
+            decode_tsgu_cancel_tunnel_call_response(&[1, 0, 0, 0, 0, 0, 0, 0]),
+            Err(RpcWireError::UnexpectedNdrPointer { actual: 1 })
+        );
+        assert_eq!(
+            decode_tsgu_cancel_tunnel_call_response(&[0, 0, 0, 0, 5, 0, 0, 0]),
+            Err(RpcWireError::RpcStatus { value: 5 })
+        );
+    }
+
+    #[test]
+    fn create_channel_encodes_a_single_resource_name_and_endpoint_port() {
+        let request = TsProxyCreateChannelRequest::new(channel_context(), "rdp.example", 3389)
+            .encode()
+            .expect("valid endpoint");
+        assert_eq!(
+            request,
+            [
+                CHANNEL_CONTEXT.as_slice(),
+                &[0, 0, 2, 0],                           // resourceName
+                &[1, 0, 0, 0],                           // numResourceNames
+                &[0, 0, 0, 0],                           // alternateResourceNames
+                &[0, 0, 0, 0],                           // numAlternateResourceNames and alignment
+                &[3, 0, 0x3d, 0x0d],                     // RDP protocol and port
+                &[1, 0, 0, 0],                           // resourceName array max count
+                &[4, 0, 2, 0],                           // first resourceName
+                &[12, 0, 0, 0, 0, 0, 0, 0, 12, 0, 0, 0], // string bounds
+                &[
+                    b'r', 0, b'd', 0, b'p', 0, b'.', 0, b'e', 0, b'x', 0, b'a', 0, b'm', 0, b'p', 0, b'l', 0, b'e', 0,
+                    0, 0,
+                ],
+            ]
+            .concat()
+        );
+    }
+
+    #[test]
+    fn authorize_tunnel_encodes_machine_name_and_optional_health_statement() {
+        let request = TsProxyAuthorizeTunnelRequest::new(channel_context(), "client", &[1, 2, 3])
+            .encode()
+            .expect("valid authorization");
+        assert_eq!(
+            request,
+            [
+                CHANNEL_CONTEXT.as_slice(),
+                &[0x52, 0x51, 0, 0, 0x52, 0x51, 0, 0], // TSG_PACKET_TYPE_QUARREQUEST
+                &[0, 0, 2, 0],                         // packetQuarRequest
+                &[0, 0, 0, 0],                         // flags
+                &[4, 0, 2, 0],                         // machineName
+                &[7, 0, 0, 0],                         // nameLength
+                &[8, 0, 2, 0],                         // data
+                &[3, 0, 0, 0],                         // dataLen
+                &[7, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0], // string bounds
+                &[b'c', 0, b'l', 0, b'i', 0, b'e', 0, b'n', 0, b't', 0, 0, 0, 0, 0],
+                &[3, 0, 0, 0, 1, 2, 3, 0], // data array and NDR alignment
+            ]
+            .concat()
+        );
+
+        let request = TsProxyAuthorizeTunnelRequest::new(channel_context(), "client", &[])
+            .encode()
+            .expect("valid authorization without health statement");
+        assert_eq!(&request[44..52], &[0, 0, 0, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn create_channel_rejects_invalid_resource_names_and_response_statuses() {
+        assert_eq!(
+            TsProxyCreateChannelRequest::new(channel_context(), "", 3389).encode(),
+            Err(RpcWireError::EmptyResourceName)
+        );
+        assert_eq!(
+            TsProxyCreateChannelRequest::new(channel_context(), "rdp\0.example", 3389).encode(),
+            Err(RpcWireError::EmbeddedNulInResourceName)
+        );
+
+        let response = [CHANNEL_CONTEXT.as_slice(), &[0x12, 0x34, 0x56, 0x78], &[0, 0, 0, 0]].concat();
+        assert_eq!(
+            decode_tsgu_create_channel_response(&response),
+            Ok(TsProxyCreateChannelResponse {
+                channel_context: channel_context(),
+                channel_id: 0x7856_3412,
+            })
+        );
+
+        let mut failed_response = response;
+        failed_response[24..28].copy_from_slice(&0x8007_59dau32.to_le_bytes());
+        assert_eq!(
+            decode_tsgu_create_channel_response(&failed_response),
+            Err(RpcWireError::RpcStatus { value: 0x8007_59da })
+        );
+    }
+
+    #[test]
+    fn receive_pipe_final_return_value_requires_explicit_byte_order() {
+        assert_eq!(
+            parse_receive_pipe_final_return_value_stub(&[0x78, 0x56, 0x34, 0x12], RpcStubByteOrder::LittleEndian),
+            Ok(0x1234_5678)
+        );
+        assert_eq!(
+            parse_receive_pipe_final_return_value_stub(&[0x12, 0x34, 0x56, 0x78], RpcStubByteOrder::BigEndian),
+            Ok(0x1234_5678)
+        );
+        assert_eq!(
+            parse_receive_pipe_final_return_value_stub(&[0; 3], RpcStubByteOrder::LittleEndian),
+            Err(RpcWireError::FinalReturnValueLength { actual: 3 })
+        );
+    }
+    #[test]
+    fn tsgu_bind_encodes_the_single_ndr32_context_exactly() {
+        assert_eq!(
+            encode_tsgu_bind(0x7856_3412, RpcFragmentSizes::DEFAULT).expect("valid bind"),
+            [
+                [5, 0, PTYPE_BIND, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
+                &[0x48, 0, 0, 0, 0x12, 0x34, 0x56, 0x78],
+                &[0xb8, 0x10, 0xb8, 0x10, 0, 0, 0, 0],
+                &[1, 0, 0, 0, 0, 0, 1, 0],
+                &[
+                    0xdd, 0x65, 0xe2, 0x44, 0xaf, 0x7d, 0xcd, 0x42, 0x85, 0x60, 0x3c, 0xdb, 0x6e, 0x7a, 0x27, 0x29
+                ],
+                &[1, 0, 3, 0],
+                &[
+                    0x04, 0x5d, 0x88, 0x8a, 0xeb, 0x1c, 0xc9, 0x11, 0x9f, 0xe8, 0x08, 0x00, 0x2b, 0x10, 0x48, 0x60
+                ],
+                &[2, 0, 0, 0],
+            ]
+            .concat()
+        );
+    }
+
+    #[test]
+    fn authenticated_tsgu_bind_has_aligned_security_trailer() {
+        let token = [1, 2, 3, 4];
+        let bind = encode_tsgu_bind_with_ntlm_auth(0x7856_3412, RpcFragmentSizes::DEFAULT, &token)
+            .expect("valid authenticated bind");
+
+        assert_eq!(bind.len(), 92);
+        assert_eq!(
+            bind,
+            [
+                [
+                    5,
+                    0,
+                    PTYPE_BIND,
+                    PFC_FIRST_FRAG | PFC_LAST_FRAG | PFC_SUPPORT_HEADER_SIGN | PFC_CONC_MPX,
+                    0x10,
+                    0,
+                    0,
+                    0
+                ]
+                .as_slice(),
+                &[92, 0, 4, 0, 0x12, 0x34, 0x56, 0x78],
+                &encode_tsgu_bind_body(RpcFragmentSizes::DEFAULT),
+                &[0; 8],
+                &[RPC_AUTH_TYPE_WINNT, RPC_AUTH_LEVEL_PACKET_INTEGRITY, 8, 0, 0, 0, 0, 0,],
+                &token,
+            ]
+            .concat()
+        );
+    }
+
+    #[test]
+    fn authenticated_bind_ack_extracts_type2_token() {
+        let token = [0x82, 1, 2, 3];
+        let body = [
+            [0x00u8, 0x20, 0x00, 0x30, 0, 0, 0, 0].as_slice(),
+            &[0, 0, 0, 0],
+            &[1, 0, 0, 0, 0, 0, 0, 0],
+            &[
+                0x04, 0x5d, 0x88, 0x8a, 0xeb, 0x1c, 0xc9, 0x11, 0x9f, 0xe8, 0x08, 0x00, 0x2b, 0x10, 0x48, 0x60,
+            ],
+            &[2, 0, 0, 0],
+        ]
+        .concat();
+        let bind_ack = encode_authenticated_pdu(PTYPE_BIND_ACK, 0x7856_3412, body, &token).expect("valid bind ack");
+
+        assert_eq!(bind_ack.len(), 76);
+        assert_eq!(
+            &bind_ack[64..72],
+            &[RPC_AUTH_TYPE_WINNT, RPC_AUTH_LEVEL_PACKET_INTEGRITY, 8, 0, 0, 0, 0, 0]
+        );
+        let ack = decode_tsgu_bind_ack_with_ntlm_auth(&bind_ack, RpcFragmentSizes::DEFAULT)
+            .expect("accepted authenticated bind ack");
+        assert_eq!(ack.token(), token);
+        assert_eq!(ack.binding().call_id(), 0x7856_3412);
+        assert_eq!(
+            ack.binding().fragment_sizes(),
+            RpcFragmentSizes::new(0x10b8, 0x10b8).expect("valid negotiated maxima")
+        );
+    }
+
+    #[test]
+    fn rpc_auth_3_has_required_pad_and_security_trailer() {
+        let token = [5, 6, 7, 8];
+        let auth3 = encode_rpc_auth_3(0x7856_3412, RpcFragmentSizes::DEFAULT, &token).expect("valid auth3");
+
+        assert_eq!(
+            auth3,
+            [
+                [
+                    5,
+                    0,
+                    PTYPE_RPC_AUTH_3,
+                    PFC_FIRST_FRAG | PFC_LAST_FRAG | PFC_SUPPORT_HEADER_SIGN | PFC_CONC_MPX,
+                    0x10,
+                    0,
+                    0,
+                    0,
+                ]
+                .as_slice(),
+                &[44, 0, 4, 0, 0x12, 0x34, 0x56, 0x78],
+                &[0; 16],
+                &[RPC_AUTH_TYPE_WINNT, RPC_AUTH_LEVEL_PACKET_INTEGRITY, 12, 0, 0, 0, 0, 0,],
+                &token,
+            ]
+            .concat()
+        );
+    }
+
+    #[test]
+    fn protected_request_uses_a_normal_request_pfc_flags() {
+        let body =
+            encode_rpc_request_body(TSPROXY_SETUP_RECEIVE_PIPE_OPNUM, &[0xaa, 0xbb]).expect("valid request body");
+        let request = encode_authenticated_pdu_with_flags(
+            PTYPE_REQUEST,
+            PFC_FIRST_FRAG | PFC_LAST_FRAG,
+            0x7856_3412,
+            body,
+            &[0; 16],
+        )
+        .expect("valid protected request");
+
+        assert_eq!(request[3], PFC_FIRST_FRAG | PFC_LAST_FRAG);
+        assert_eq!(&request[10..12], &16u16.to_le_bytes());
+        let (header, body, signature) =
+            decode_authenticated_single_fragment(&request, PTYPE_REQUEST, RpcFragmentSizes::DEFAULT.max_xmit(), false)
+                .expect("normal request flags accepted");
+        assert_eq!(header.call_id(), 0x7856_3412);
+        assert_eq!(
+            body,
+            &[
+                2,
+                0,
+                0,
+                0,
+                0,
+                0,
+                u8::try_from(TSPROXY_SETUP_RECEIVE_PIPE_OPNUM).expect("opnum fits in u8"),
+                0,
+                0xaa,
+                0xbb
+            ]
+        );
+        assert_eq!(signature, [0; 16]);
+        assert_eq!(
+            decode_authenticated_single_fragment(&request, PTYPE_REQUEST, RpcFragmentSizes::DEFAULT.max_xmit(), true),
+            Err(RpcPduError::MissingSupportHeaderSign)
+        );
+    }
+
+    #[test]
+    fn protected_response_preserves_the_unpadded_stub() {
+        let response = encode_authenticated_pdu_with_flags(
+            PTYPE_RESPONSE,
+            PFC_FIRST_FRAG | PFC_LAST_FRAG,
+            0x7856_3412,
+            vec![3, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3],
+            &[0; 16],
+        )
+        .expect("valid protected response");
+        let (header, body, signature) = decode_authenticated_single_fragment(
+            &response,
+            PTYPE_RESPONSE,
+            RpcFragmentSizes::DEFAULT.max_recv(),
+            false,
+        )
+        .expect("normal response flags accepted");
+
+        assert_eq!(signature, [0; 16]);
+        assert_eq!(
+            decode_rpc_response_body(header, body).expect("valid response body"),
+            RpcResponse {
+                call_id: 0x7856_3412,
+                pfc_flags: PFC_FIRST_FRAG | PFC_LAST_FRAG,
+                alloc_hint: 3,
+                cancel_count: 0,
+                reserved: 0,
+                stub: &[1, 2, 3],
+            }
+        );
+    }
+
+    #[test]
+    fn authenticated_bind_ack_rejects_invalid_verifier_layout() {
+        let token = [0x82, 1, 2, 3];
+        let body = [
+            [0x00u8, 0x20, 0x00, 0x30, 0, 0, 0, 0].as_slice(),
+            &[0, 0, 0, 0],
+            &[1, 0, 0, 0, 0, 0, 0, 0],
+            &[
+                0x04, 0x5d, 0x88, 0x8a, 0xeb, 0x1c, 0xc9, 0x11, 0x9f, 0xe8, 0x08, 0x00, 0x2b, 0x10, 0x48, 0x60,
+            ],
+            &[2, 0, 0, 0],
+        ]
+        .concat();
+        let bind_ack = encode_authenticated_pdu(PTYPE_BIND_ACK, 1, body, &token).expect("valid bind ack");
+
+        let mut missing_header_sign = bind_ack.clone();
+        missing_header_sign[3] &= !PFC_SUPPORT_HEADER_SIGN;
+        assert_eq!(
+            decode_tsgu_bind_ack_with_ntlm_auth(&missing_header_sign, RpcFragmentSizes::DEFAULT),
+            Err(RpcPduError::MissingSupportHeaderSign)
+        );
+
+        let mut wrong_auth_type = bind_ack.clone();
+        wrong_auth_type[64] = 9;
+        assert_eq!(
+            decode_tsgu_bind_ack_with_ntlm_auth(&wrong_auth_type, RpcFragmentSizes::DEFAULT),
+            Err(RpcPduError::UnexpectedAuthenticationType {
+                expected: RPC_AUTH_TYPE_WINNT,
+                actual: 9
+            })
+        );
+
+        let mut wrong_context = bind_ack.clone();
+        wrong_context[68..72].copy_from_slice(&1u32.to_le_bytes());
+        assert_eq!(
+            decode_tsgu_bind_ack_with_ntlm_auth(&wrong_context, RpcFragmentSizes::DEFAULT),
+            Err(RpcPduError::UnexpectedAuthenticationContextId {
+                expected: RPC_AUTH_CONTEXT_ID,
+                actual: 1
+            })
+        );
+        let mut non_zero_padding = bind_ack.clone();
+        non_zero_padding[63] = 1;
+        assert_eq!(
+            decode_tsgu_bind_ack_with_ntlm_auth(&non_zero_padding, RpcFragmentSizes::DEFAULT),
+            Err(RpcPduError::NonZeroAuthenticationPadding)
+        );
+
+        let mut invalid_trailer_bounds = bind_ack;
+        invalid_trailer_bounds[10..12].copy_from_slice(&61u16.to_le_bytes());
+        assert_eq!(
+            decode_tsgu_bind_ack_with_ntlm_auth(&invalid_trailer_bounds, RpcFragmentSizes::DEFAULT),
+            Err(RpcPduError::InvalidSecurityTrailer {
+                fragment_length: 76,
+                auth_length: 61
+            })
+        );
+    }
+
+    #[test]
+    fn rpc_ntlm_initial_token_is_non_empty() {
+        let mut auth = RpcNtlmAuth::new(r"CONTOSO\alice", "secret").expect("valid credentials");
+        let token = auth.initial_token().expect("offline Type-1 token");
+
+        assert_eq!(&token[..12], b"NTLMSSP\0\x01\0\0\0");
+        assert!(!auth.is_complete());
+        assert!(auth.initial_token().is_err());
+        assert!(auth.make_signature(&mut [], 0).is_err());
+    }
+
+    #[test]
+    fn rpc_ntlm_packet_integrity_signature_covers_the_sequence_number() {
+        let mut auth = completed_rpc_ntlm_auth();
+        let mut first = b"authenticated rpc message".to_vec();
+        let mut second = first.clone();
+        let first_signature = auth.make_signature(&mut first, 1).expect("first signature");
+        let second_signature = auth.make_signature(&mut second, 2).expect("second signature");
+
+        assert_ne!(first_signature, [0; 16]);
+        assert_ne!(first_signature, second_signature);
+    }
+
+    #[test]
+    fn protected_request_is_signed_after_its_security_trailer_is_encoded() {
+        let mut auth = completed_rpc_ntlm_auth();
+        let request = encode_rpc_request_with_ntlm_auth(
+            &mut auth,
+            1,
+            0x7856_3412,
+            TSPROXY_SETUP_RECEIVE_PIPE_OPNUM,
+            &[0xaa, 0xbb],
+            RpcFragmentSizes::DEFAULT,
+        )
+        .expect("valid signed request");
+
+        assert_eq!(request[3], PFC_FIRST_FRAG | PFC_LAST_FRAG);
+        assert_ne!(&request[request.len() - 16..], &[0; 16]);
+        assert_eq!(request[request.len() - 24], RPC_AUTH_TYPE_WINNT);
+    }
+
+    #[test]
+    fn bind_ack_negotiates_the_single_accepted_ndr32_context() {
+        let bind_ack = [
+            [5, 0, PTYPE_BIND_ACK, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
+            &[0x38, 0, 0, 0, 0x12, 0x34, 0x56, 0x78],
+            &[0x00, 0x20, 0x00, 0x30, 0, 0, 0, 0],
+            &[0, 0, 0, 0],
+            &[1, 0, 0, 0, 0, 0, 0, 0],
+            &[
+                0x04, 0x5d, 0x88, 0x8a, 0xeb, 0x1c, 0xc9, 0x11, 0x9f, 0xe8, 0x08, 0x00, 0x2b, 0x10, 0x48, 0x60,
+            ],
+            &[2, 0, 0, 0],
+        ]
+        .concat();
+
+        let binding = decode_tsgu_bind_ack(&bind_ack, RpcFragmentSizes::DEFAULT).expect("accepted bind ack");
+        assert_eq!(binding.call_id(), 0x7856_3412);
+        assert_eq!(
+            binding.fragment_sizes(),
+            RpcFragmentSizes::new(0x10b8, 0x10b8).expect("valid negotiated maxima")
+        );
+    }
+
+    #[test]
+    fn bind_nak_preserves_reason_and_supported_versions() {
+        let bind_nak = [
+            [5, 0, PTYPE_BIND_NAK, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
+            &[23, 0, 0, 0, 4, 3, 2, 1],
+            &[4, 0, 2, 5, 0, 4, 0],
+        ]
+        .concat();
+
+        assert_eq!(
+            decode_bind_nak(&bind_nak).expect("valid bind nak"),
+            RpcBindNak {
+                call_id: 0x0102_0304,
+                reason: RpcBindNakReason(4),
+                supported_versions: vec![RpcSyntaxVersion::new(5, 0), RpcSyntaxVersion::new(4, 0)],
+                extended_error_signature: None,
+            }
+        );
+    }
+
+    #[test]
+    fn bind_nak_accepts_the_optional_extended_error_signature() {
+        let bind_nak = [
+            [5, 0, PTYPE_BIND_NAK, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
+            &[39, 0, 0, 0, 4, 3, 2, 1],
+            &[4, 0, 2, 5, 0, 4, 0],
+            &[
+                0x04, 0x5d, 0x88, 0x8a, 0xeb, 0x1c, 0xc9, 0x11, 0x9f, 0xe8, 0x08, 0x00, 0x2b, 0x10, 0x48, 0x60,
+            ],
+        ]
+        .concat();
+
+        assert_eq!(
+            decode_bind_nak(&bind_nak)
+                .expect("valid bind nak")
+                .extended_error_signature,
+            Some(NDR32_TRANSFER_SYNTAX_ID)
+        );
+    }
+
+    #[test]
+    fn request_response_and_fault_vectors_round_trip_metadata_and_stubs() {
+        let request = encode_rpc_request(
+            0x7856_3412,
+            TSPROXY_SETUP_RECEIVE_PIPE_OPNUM,
+            &[0xaa, 0xbb],
+            RpcFragmentSizes::DEFAULT,
+        )
+        .expect("request fits");
+        assert_eq!(
+            request,
+            [
+                [5, 0, PTYPE_REQUEST, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
+                &[26, 0, 0, 0, 0x12, 0x34, 0x56, 0x78],
+                &[
+                    2,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    u8::try_from(TSPROXY_SETUP_RECEIVE_PIPE_OPNUM).expect("opnum fits in u8"),
+                    0,
+                    0xaa,
+                    0xbb
+                ],
+            ]
+            .concat()
+        );
+
+        let response = [
+            [5, 0, PTYPE_RESPONSE, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
+            &[27, 0, 0, 0, 0x12, 0x34, 0x56, 0x78],
+            &[3, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3],
+        ]
+        .concat();
+        assert_eq!(
+            decode_rpc_response(&response, DEFAULT_FRAGMENT_SIZE).expect("valid response"),
+            RpcResponse {
+                call_id: 0x7856_3412,
+                pfc_flags: PFC_FIRST_FRAG | PFC_LAST_FRAG,
+                alloc_hint: 3,
+                cancel_count: 0,
+                reserved: 0,
+                stub: &[1, 2, 3],
+            }
+        );
+        let mut fragmented_response = response;
+        fragmented_response[3] = PFC_FIRST_FRAG;
+        assert_eq!(
+            decode_rpc_response_fragment(&fragmented_response, DEFAULT_FRAGMENT_SIZE).expect("valid response fragment"),
+            RpcResponse {
+                call_id: 0x7856_3412,
+                pfc_flags: PFC_FIRST_FRAG,
+                alloc_hint: 3,
+                cancel_count: 0,
+                reserved: 0,
+                stub: &[1, 2, 3],
+            }
+        );
+
+        let fault = [
+            [5, 0, PTYPE_FAULT, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
+            &[34, 0, 0, 0, 4, 3, 2, 1],
+            &[2, 0, 0, 0, 0, 0, 0, 0, 0xef, 0xbe, 0xad, 0xde, 1, 0, 0, 0, 0x12, 0x34],
+        ]
+        .concat();
+        assert_eq!(
+            decode_rpc_fault(&fault, DEFAULT_FRAGMENT_SIZE).expect("valid fault"),
+            RpcFault {
+                call_id: 0x0102_0304,
+                alloc_hint: 2,
+                cancel_count: 0,
+                reserved: 0,
+                status: 0xdead_beef,
+                reserved2: 1,
+                stub: &[0x12, 0x34],
+            }
+        );
+    }
+
+    #[test]
+    fn common_header_rejects_invalid_versions_drep_and_fragment_lengths() {
+        assert_eq!(
+            RpcCommonHeader::decode(&[0; RPC_COMMON_HEADER_SIZE - 1]),
+            Err(RpcPduError::Truncated {
+                actual: RPC_COMMON_HEADER_SIZE - 1,
+                required: RPC_COMMON_HEADER_SIZE
+            })
+        );
+
+        let mut pdu = encode_rpc_request(1, 0, &[], RpcFragmentSizes::DEFAULT).expect("valid request");
+        pdu[0] = 4;
+        assert_eq!(
+            RpcCommonHeader::decode(&pdu),
+            Err(RpcPduError::UnsupportedVersion { major: 4, minor: 0 })
+        );
+
+        let mut pdu = encode_rpc_request(1, 0, &[], RpcFragmentSizes::DEFAULT).expect("valid request");
+        pdu[4] = 0;
+        assert_eq!(
+            RpcCommonHeader::decode(&pdu),
+            Err(RpcPduError::UnsupportedDataRepresentation { value: [0, 0, 0, 0] })
+        );
+
+        let mut pdu = encode_rpc_request(1, 0, &[], RpcFragmentSizes::DEFAULT).expect("valid request");
+        pdu[8..10].copy_from_slice(&15u16.to_le_bytes());
+        assert_eq!(
+            RpcCommonHeader::decode(&pdu),
+            Err(RpcPduError::InvalidFragmentLength { fragment_length: 15 })
+        );
+    }
+
+    #[test]
+    fn authorize_tunnel_response_decodes_response_data_and_redirection_policy() {
+        let mut response = Vec::new();
+        response.extend_from_slice(&NDR_REFERENT_ID.to_le_bytes()); // TSG packet
+        response.extend_from_slice(&TSG_PACKET_TYPE_RESPONSE.to_le_bytes());
+        response.extend_from_slice(&TSG_PACKET_TYPE_RESPONSE.to_le_bytes());
+        response.extend_from_slice(&(NDR_REFERENT_ID + 4).to_le_bytes()); // packet response
+        response.extend_from_slice(&TSG_PACKET_TYPE_QUARREQUEST.to_le_bytes());
+        response.extend_from_slice(&0u32.to_le_bytes()); // reserved
+        response.extend_from_slice(&(NDR_REFERENT_ID + 8).to_le_bytes()); // response data
+        response.extend_from_slice(&3u32.to_le_bytes());
+        response.extend_from_slice(&0u32.to_le_bytes()); // enable all
+        response.extend_from_slice(&0u32.to_le_bytes()); // disable all
+        response.extend_from_slice(&1u32.to_le_bytes()); // drive disabled
+        response.extend_from_slice(&0u32.to_le_bytes()); // printer disabled
+        response.extend_from_slice(&0u32.to_le_bytes()); // port disabled
+        response.extend_from_slice(&0u32.to_le_bytes()); // reserved
+        response.extend_from_slice(&1u32.to_le_bytes()); // clipboard disabled
+        response.extend_from_slice(&0u32.to_le_bytes()); // PnP disabled
+        response.extend_from_slice(&3u32.to_le_bytes()); // max count
+        response.extend_from_slice(&[1, 2, 3]);
+        response.push(0); // NDR alignment
+        response.extend_from_slice(&0u32.to_le_bytes()); // HRESULT
+
+        assert_eq!(
+            decode_tsgu_authorize_tunnel_response(&response).expect("valid response"),
+            TsProxyAuthorizeTunnelResponse {
+                response_data: vec![1, 2, 3],
+                redirection_flags: TsProxyRedirectionFlags {
+                    enable_all: false,
+                    disable_all: false,
+                    drive_disabled: true,
+                    printer_disabled: false,
+                    port_disabled: false,
+                    clipboard_disabled: true,
+                    pnp_disabled: false,
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn authorize_tunnel_response_rejects_invalid_packet_and_policy_values() {
+        let mut response = vec![0; 68];
+        response[0..4].copy_from_slice(&NDR_REFERENT_ID.to_le_bytes());
+        response[4..8].copy_from_slice(&TSG_PACKET_TYPE_RESPONSE.to_le_bytes());
+        response[8..12].copy_from_slice(&TSG_PACKET_TYPE_RESPONSE.to_le_bytes());
+        response[12..16].copy_from_slice(&(NDR_REFERENT_ID + 4).to_le_bytes());
+        response[16..20].copy_from_slice(&TSG_PACKET_TYPE_QUARREQUEST.to_le_bytes());
+
+        response[4..8].copy_from_slice(&TSG_PACKET_TYPE_QUARREQUEST.to_le_bytes());
+        assert_eq!(
+            decode_tsgu_authorize_tunnel_response(&response),
+            Err(RpcWireError::UnexpectedPacketId {
+                expected: TSG_PACKET_TYPE_RESPONSE,
+                actual: TSG_PACKET_TYPE_QUARREQUEST,
+            })
+        );
+        response[4..8].copy_from_slice(&TSG_PACKET_TYPE_RESPONSE.to_le_bytes());
+
+        response[32..36].copy_from_slice(&1u32.to_le_bytes());
+        response[36..40].copy_from_slice(&1u32.to_le_bytes());
+        assert_eq!(
+            decode_tsgu_authorize_tunnel_response(&response),
+            Err(RpcWireError::ConflictingRedirectionFlags)
+        );
+        response[36..40].copy_from_slice(&0u32.to_le_bytes());
+
+        response[28..32].copy_from_slice(&1u32.to_le_bytes());
+        assert_eq!(
+            decode_tsgu_authorize_tunnel_response(&response),
+            Err(RpcWireError::RequiredNdrPointerIsNull)
+        );
+    }
+
+    #[test]
+    fn make_tunnel_call_response_decodes_reauthentication() {
+        let response = [
+            NDR_REFERENT_ID.to_le_bytes().as_slice(), // TSG packet
+            &TSG_PACKET_TYPE_MESSAGE.to_le_bytes(),
+            &TSG_PACKET_TYPE_MESSAGE.to_le_bytes(),
+            &(NDR_REFERENT_ID + 4).to_le_bytes(), // message response
+            &1u32.to_le_bytes(),                  // message ID
+            &TSG_ASYNC_MESSAGE_REAUTH.to_le_bytes(),
+            &1u32.to_le_bytes(),                  // is message present
+            &(NDR_REFERENT_ID + 8).to_le_bytes(), // reauth message
+            &0x1122_3344_5566_7788u64.to_le_bytes(),
+            &0u32.to_le_bytes(), // HRESULT
+        ]
+        .concat();
+
+        assert_eq!(
+            decode_tsgu_make_tunnel_call_response(&response).expect("valid response"),
+            TsProxyTunnelMessage::Reauthenticate {
+                tunnel_context: 0x1122_3344_5566_7788,
+            }
+        );
+    }
+
+    #[test]
+    fn make_tunnel_call_response_decodes_service_message() {
+        let response = [
+            NDR_REFERENT_ID.to_le_bytes().as_slice(), // TSG packet
+            &TSG_PACKET_TYPE_MESSAGE.to_le_bytes(),
+            &TSG_PACKET_TYPE_MESSAGE.to_le_bytes(),
+            &(NDR_REFERENT_ID + 4).to_le_bytes(), // message response
+            &1u32.to_le_bytes(),                  // message ID
+            &TSG_ASYNC_MESSAGE_SERVICE.to_le_bytes(),
+            &1u32.to_le_bytes(),                   // is message present
+            &(NDR_REFERENT_ID + 8).to_le_bytes(),  // service message
+            &1u32.to_le_bytes(),                   // display mandatory
+            &0u32.to_le_bytes(),                   // consent mandatory
+            &3u32.to_le_bytes(),                   // message characters
+            &(NDR_REFERENT_ID + 12).to_le_bytes(), // message buffer
+            &3u32.to_le_bytes(),                   // NDR array count
+            &[b'h', 0, b'i', 0, 0, 0],
+            &0u32.to_le_bytes(), // HRESULT
+        ]
+        .concat();
+
+        assert_eq!(
+            decode_tsgu_make_tunnel_call_response(&response).expect("valid response"),
+            TsProxyTunnelMessage::Service {
+                display_mandatory: true,
+                text: "hi".to_owned(),
+            }
+        );
+    }
+
+    fn create_tunnel_response() -> Vec<u8> {
+        let nonce = Uuid::from_u128(0x00112233_4455_6677_8899_aabbccddeeff);
+        let mut response = Vec::new();
+        response.extend_from_slice(&NDR_REFERENT_ID.to_le_bytes()); // TSG packet
+        response.extend_from_slice(&TSG_PACKET_TYPE_QUARENC_RESPONSE.to_le_bytes());
+        response.extend_from_slice(&TSG_PACKET_TYPE_QUARENC_RESPONSE.to_le_bytes());
+        response.extend_from_slice(&(NDR_REFERENT_ID + 4).to_le_bytes()); // QUARENC response
+        response.extend_from_slice(&0u32.to_le_bytes()); // flags
+        response.extend_from_slice(&0u32.to_le_bytes()); // certificate chain length
+        response.extend_from_slice(&0u32.to_le_bytes()); // certificate chain pointer
+        response.extend_from_slice(&nonce.to_bytes_le());
+        response.extend_from_slice(&(NDR_REFERENT_ID + 8).to_le_bytes()); // version capabilities
+        response.extend_from_slice(&TSG_COMPONENT_ID.to_le_bytes());
+        response.extend_from_slice(
+            &u16::try_from(TSG_PACKET_TYPE_VERSIONCAPS)
+                .expect("packet type fits in u16")
+                .to_le_bytes(),
+        );
+        response.extend_from_slice(&(NDR_REFERENT_ID + 12).to_le_bytes()); // capability array
+        response.extend_from_slice(&1u32.to_le_bytes()); // number of capabilities
+        response.extend_from_slice(&1u16.to_le_bytes()); // major version
+        response.extend_from_slice(&1u16.to_le_bytes()); // minor version
+        response.extend_from_slice(&0u16.to_le_bytes()); // quarantine capabilities
+        response.extend_from_slice(&0u16.to_le_bytes()); // NDR alignment
+        response.extend_from_slice(&1u32.to_le_bytes()); // capability array max count
+        response.extend_from_slice(&TSG_CAPABILITY_TYPE_NAP.to_le_bytes());
+        response.extend_from_slice(&TSG_CAPABILITY_TYPE_NAP.to_le_bytes());
+        response.extend_from_slice(&0x0000_0003u32.to_le_bytes());
+        response.extend_from_slice(&CHANNEL_CONTEXT);
+        response.extend_from_slice(&42u32.to_le_bytes()); // tunnel ID
+        response.extend_from_slice(&0u32.to_le_bytes()); // HRESULT
+        response
+    }
+
+    #[test]
+    fn create_tunnel_response_decodes_context_nonce_and_capabilities() {
+        assert_eq!(
+            decode_tsgu_create_tunnel_response(&create_tunnel_response()).expect("valid response"),
+            TsProxyCreateTunnelResponse {
+                tunnel_context: channel_context(),
+                tunnel_id: 42,
+                nonce: Uuid::from_u128(0x00112233_4455_6677_8899_aabbccddeeff),
+                capabilities: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn create_tunnel_response_rejects_invalid_capability_count() {
+        let mut response = create_tunnel_response();
+        response[56..60].copy_from_slice(&2u32.to_le_bytes());
+
+        assert_eq!(
+            decode_tsgu_create_tunnel_response(&response),
+            Err(RpcWireError::UnsupportedCapabilityCount { actual: 2 })
+        );
+    }
+
+    #[test]
+    fn create_tunnel_response_rejects_reserved_flags_and_oversized_certificates() {
+        let mut response = create_tunnel_response();
+        response[16..20].copy_from_slice(&1u32.to_le_bytes());
+        assert_eq!(
+            decode_tsgu_create_tunnel_response(&response),
+            Err(RpcWireError::InvalidQuarencFlags { actual: 1 })
+        );
+
+        let mut response = create_tunnel_response();
+        let length = u32::try_from(TSG_MAX_CERT_CHAIN_LEN + 1).expect("test value fits");
+        response[20..24].copy_from_slice(&length.to_le_bytes());
+        assert_eq!(
+            decode_tsgu_create_tunnel_response(&response),
+            Err(RpcWireError::CertificateChainTooLarge {
+                actual: TSG_MAX_CERT_CHAIN_LEN + 1,
+            })
+        );
+    }
+
+    #[test]
+    fn pdu_stream_yields_complete_fragments_without_losing_partial_data() {
+        let first = encode_rpc_request(1, 0, &[1, 2], RpcFragmentSizes::DEFAULT).expect("valid request");
+        let second = encode_rpc_request(2, 1, &[3], RpcFragmentSizes::DEFAULT).expect("valid request");
+        let mut stream = RpcPduStream::new(RpcFragmentSizes::DEFAULT.max_recv()).expect("valid maximum");
+
+        stream
+            .push(&first[..RPC_COMMON_HEADER_SIZE - 1])
+            .expect("bounded partial fragment");
+        assert_eq!(stream.next(), Ok(None));
+
+        stream
+            .push(&first[RPC_COMMON_HEADER_SIZE - 1..])
+            .expect("bounded first fragment");
+        stream.push(&second).expect("bounded second fragment");
+        assert_eq!(stream.next(), Ok(Some(first)));
+        assert_eq!(stream.next(), Ok(Some(second)));
+        assert_eq!(stream.next(), Ok(None));
+    }
+
+    #[test]
+    fn pdu_stream_rejects_oversized_and_invalid_fragments_before_buffering_them() {
+        let mut stream = RpcPduStream::new(32).expect("valid maximum");
+        let oversized = encode_rpc_request(1, 0, &[0; 17], RpcFragmentSizes::DEFAULT).expect("valid request");
+        stream
+            .push(&oversized[..RPC_COMMON_HEADER_SIZE])
+            .expect("bounded oversized header");
+        assert_eq!(
+            stream.next(),
+            Err(RpcPduError::FragmentExceedsMaximum {
+                fragment_length: u16::try_from(oversized.len()).expect("test length fits in u16"),
+                maximum: 32,
+            })
+        );
+
+        let mut stream = RpcPduStream::new(RpcFragmentSizes::DEFAULT.max_recv()).expect("valid maximum");
+        stream
+            .push(&[4; RPC_COMMON_HEADER_SIZE])
+            .expect("bounded invalid header");
+        assert_eq!(
+            stream.next(),
+            Err(RpcPduError::UnsupportedVersion { major: 4, minor: 4 })
+        );
+    }
+
+    #[test]
+    fn request_fragmenter_sets_pfc_flags_and_remaining_allocation_hints() {
+        let fragments = encode_rpc_request_fragments(
+            7,
+            TSPROXY_SETUP_RECEIVE_PIPE_OPNUM,
+            &[1, 2, 3, 4, 5, 6, 7, 8, 9],
+            RpcFragmentSizes::new(32, 32).expect("valid fragment sizes"),
+        )
+        .expect("request fragments");
+
+        assert_eq!(fragments.len(), 2);
+        assert_eq!(fragments[0][3], PFC_FIRST_FRAG);
+        assert_eq!(fragments[1][3], PFC_LAST_FRAG);
+        assert_eq!(&fragments[0][16..20], &9u32.to_le_bytes());
+        assert_eq!(&fragments[1][16..20], &1u32.to_le_bytes());
+        assert_eq!(&fragments[0][24..], &[1, 2, 3, 4, 5, 6, 7, 8]);
+        assert_eq!(&fragments[1][24..], &[9]);
+        assert_eq!(
+            encode_rpc_request_fragments(
+                7,
+                TSPROXY_SETUP_RECEIVE_PIPE_OPNUM,
+                &[1],
+                RpcFragmentSizes::new(24, 24).expect("valid fragment sizes"),
+            ),
+            Err(RpcPduError::FragmentTooLarge {
+                actual: 25,
+                maximum: 24,
+            })
+        );
+    }
+
+    #[test]
+    fn response_reassembler_requires_ordered_fragments_and_bounds_the_stub() {
+        let mut reassembler = RpcResponseReassembler::new(5);
+        let first = RpcResponse {
+            call_id: 7,
+            pfc_flags: PFC_FIRST_FRAG,
+            alloc_hint: 5,
+            cancel_count: 0,
+            reserved: 0,
+            stub: &[1, 2],
+        };
+        assert_eq!(reassembler.push(first), Ok(None));
+        let last = RpcResponse {
+            call_id: 7,
+            pfc_flags: PFC_LAST_FRAG,
+            alloc_hint: 3,
+            cancel_count: 0,
+            reserved: 0,
+            stub: &[3, 4, 5],
+        };
+        assert_eq!(
+            reassembler.push(last),
+            Ok(Some(RpcReassembledResponse {
+                call_id: 7,
+                cancel_count: 0,
+                reserved: 0,
+                stub: vec![1, 2, 3, 4, 5],
+            }))
+        );
+
+        let unexpected = RpcResponse {
+            call_id: 8,
+            pfc_flags: PFC_LAST_FRAG,
+            alloc_hint: 1,
+            cancel_count: 0,
+            reserved: 0,
+            stub: &[1],
+        };
+        assert_eq!(
+            reassembler.push(unexpected),
+            Err(RpcPduError::UnexpectedResponseFragment { flags: PFC_LAST_FRAG })
+        );
+
+        let oversized = RpcResponse {
+            call_id: 8,
+            pfc_flags: PFC_FIRST_FRAG | PFC_LAST_FRAG,
+            alloc_hint: 6,
+            cancel_count: 0,
+            reserved: 0,
+            stub: &[1, 2, 3, 4, 5, 6],
+        };
+        assert_eq!(
+            reassembler.push(oversized),
+            Err(RpcPduError::ResponseStubTooLarge { actual: 6, maximum: 5 })
+        );
+    }
+
+    #[test]
+    fn rpc_decoders_reject_unsupported_fragments_auth_and_untrusted_lengths() {
+        let mut response = [
+            [5, 0, PTYPE_RESPONSE, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
+            &[24, 0, 0, 0, 1, 0, 0, 0],
+            &[0, 0, 0, 0, 0, 0, 0, 0],
+        ]
+        .concat();
+        response[3] = PFC_FIRST_FRAG;
+        assert_eq!(
+            decode_rpc_response(&response, DEFAULT_FRAGMENT_SIZE),
+            Err(RpcPduError::FragmentedPduUnsupported { flags: PFC_FIRST_FRAG })
+        );
+
+        response[3] = PFC_FIRST_FRAG | PFC_LAST_FRAG;
+        response[10..12].copy_from_slice(&1u16.to_le_bytes());
+        assert_eq!(
+            decode_rpc_response(&response, DEFAULT_FRAGMENT_SIZE),
+            Err(RpcPduError::AuthenticationUnsupported { auth_length: 1 })
+        );
+
+        response[10..12].copy_from_slice(&0u16.to_le_bytes());
+        response[16..20].copy_from_slice(&1u32.to_le_bytes());
+        assert_eq!(
+            decode_rpc_response(&response, DEFAULT_FRAGMENT_SIZE),
+            Err(RpcPduError::InvalidAllocHint {
+                alloc_hint: 1,
+                stub_length: 0
+            })
+        );
+
+        let oversized = vec![0; usize::from(DEFAULT_FRAGMENT_SIZE) - RPC_REQUEST_HEADER_SIZE + 1];
+        assert!(matches!(
+            encode_rpc_request(1, 0, &oversized, RpcFragmentSizes::DEFAULT),
+            Err(RpcPduError::FragmentTooLarge { .. })
+        ));
+    }
+
+    #[test]
+    fn bind_ack_rejects_unsuccessful_or_wrong_context_negotiation() {
+        let mut bind_ack = [
+            [5, 0, PTYPE_BIND_ACK, PFC_FIRST_FRAG | PFC_LAST_FRAG, 0x10, 0, 0, 0].as_slice(),
+            &[0x38, 0, 0, 0, 0, 0, 0, 0],
+            &[0xb8, 0x10, 0xb8, 0x10, 0, 0, 0, 0],
+            &[0, 0, 0, 0],
+            &[1, 0, 0, 0, 0, 0, 0, 0],
+            &[
+                0x04, 0x5d, 0x88, 0x8a, 0xeb, 0x1c, 0xc9, 0x11, 0x9f, 0xe8, 0x08, 0x00, 0x2b, 0x10, 0x48, 0x60,
+            ],
+            &[2, 0, 0, 0],
+        ]
+        .concat();
+        bind_ack[32..34].copy_from_slice(&2u16.to_le_bytes());
+        assert_eq!(
+            decode_tsgu_bind_ack(&bind_ack, RpcFragmentSizes::DEFAULT),
+            Err(RpcPduError::PresentationContextRejected { result: 2, reason: 0 })
+        );
+
+        bind_ack[32..34].copy_from_slice(&0u16.to_le_bytes());
+        bind_ack[36] ^= 1;
+        assert!(matches!(
+            decode_tsgu_bind_ack(&bind_ack, RpcFragmentSizes::DEFAULT),
+            Err(RpcPduError::UnexpectedTransferSyntax { .. })
+        ));
+    }
+
+    #[test]
+    fn rts_conn_a1_and_b1_encode_exact_initial_flow_vectors() {
+        let virtual_connection_cookie = RtsCookie::new([
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+        ]);
+        let out_channel_cookie = RtsCookie::new([
+            0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+        ]);
+        let in_channel_cookie = RtsCookie::new([
+            0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f,
+        ]);
+        let association_group_id = RtsCookie::new([
+            0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f,
+        ]);
+
+        assert_eq!(
+            encode_rts_conn_a1(virtual_connection_cookie, out_channel_cookie, 128 * 1024).expect("valid A1"),
+            [
+                [5, 0, PTYPE_RTS, RTS_PFC_FLAGS, 0x10, 0, 0, 0].as_slice(),
+                &[76, 0, 0, 0, 0, 0, 0, 0],
+                &[0, 0, 4, 0],
+                &[6, 0, 0, 0, 1, 0, 0, 0],
+                &[3, 0, 0, 0],
+                virtual_connection_cookie.as_bytes(),
+                &[3, 0, 0, 0],
+                out_channel_cookie.as_bytes(),
+                &[0, 0, 0, 0, 0, 0, 2, 0],
+            ]
+            .concat()
+        );
+        assert_eq!(
+            encode_rts_conn_b1(
+                virtual_connection_cookie,
+                in_channel_cookie,
+                256 * 1024,
+                0,
+                association_group_id,
+            )
+            .expect("valid B1"),
+            [
+                [5, 0, PTYPE_RTS, RTS_PFC_FLAGS, 0x10, 0, 0, 0].as_slice(),
+                &[104, 0, 0, 0, 0, 0, 0, 0],
+                &[0, 0, 6, 0],
+                &[6, 0, 0, 0, 1, 0, 0, 0],
+                &[3, 0, 0, 0],
+                virtual_connection_cookie.as_bytes(),
+                &[3, 0, 0, 0],
+                in_channel_cookie.as_bytes(),
+                &[4, 0, 0, 0, 0, 0, 4, 0],
+                &[5, 0, 0, 0, 0, 0, 0, 0],
+                &[12, 0, 0, 0],
+                association_group_id.as_bytes(),
+            ]
+            .concat()
+        );
+    }
+
+    #[test]
+    fn rts_ping_and_flow_control_ack_round_trip() {
+        assert_eq!(
+            encode_rts_ping().expect("valid ping"),
+            [
+                [5, 0, PTYPE_RTS, RTS_PFC_FLAGS, 0x10, 0, 0, 0].as_slice(),
+                &[20, 0, 0, 0, 0, 0, 0, 0],
+                &[1, 0, 0, 0],
+            ]
+            .concat()
+        );
+        decode_rts_ping(&encode_rts_ping().expect("valid ping")).expect("valid ping");
+
+        let ack = RtsFlowControlAck {
+            bytes_received: 0x7856_3412,
+            available_window: 128 * 1024,
+            channel_cookie: RtsCookie::new([
+                0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+            ]),
+        };
+        let encoded = encode_rts_flow_control_ack(ack).expect("valid acknowledgement");
+        assert_eq!(
+            encoded,
+            [
+                [5, 0, PTYPE_RTS, RTS_PFC_FLAGS, 0x10, 0, 0, 0].as_slice(),
+                &[48, 0, 0, 0, 0, 0, 0, 0],
+                &[2, 0, 1, 0],
+                &[1, 0, 0, 0, 0x12, 0x34, 0x56, 0x78, 0, 0, 2, 0],
+                ack.channel_cookie.as_bytes(),
+            ]
+            .concat()
+        );
+        assert_eq!(
+            decode_rts_flow_control_ack(&encoded).expect("valid acknowledgement"),
+            ack
+        );
+    }
+
+    #[test]
+    fn rts_ping_and_flow_control_ack_reject_invalid_headers() {
+        let mut ping = encode_rts_ping().expect("valid ping");
+        ping[16..18].copy_from_slice(&RTS_FLAG_OTHER_CMD.to_le_bytes());
+        assert_eq!(
+            decode_rts_ping(&ping),
+            Err(RpcPduError::UnexpectedRtsFlags {
+                expected: RTS_FLAG_PING,
+                actual: RTS_FLAG_OTHER_CMD,
+            })
+        );
+
+        let ack = RtsFlowControlAck {
+            bytes_received: 0,
+            available_window: 128 * 1024,
+            channel_cookie: RtsCookie::new([0; RtsCookie::SIZE]),
+        };
+        let mut encoded = encode_rts_flow_control_ack(ack).expect("valid acknowledgement");
+        encoded[20..24].copy_from_slice(&RTS_COMMAND_COOKIE.to_le_bytes());
+        assert_eq!(
+            decode_rts_flow_control_ack(&encoded),
+            Err(RpcPduError::UnexpectedRtsCommandType {
+                expected: RTS_COMMAND_FLOW_CONTROL_ACK,
+                actual: RTS_COMMAND_COOKIE,
+            })
+        );
+    }
+
+    #[test]
+    fn rts_conn_a3_and_c2_decode_initial_flow_vectors() {
+        let a3_bytes = [
+            [5, 0, PTYPE_RTS, RTS_PFC_FLAGS, 0x10, 0, 0, 0].as_slice(),
+            &[28, 0, 0, 0, 0, 0, 0, 0],
+            &[0, 0, 1, 0],
+            &[2, 0, 0, 0, 0xc0, 0xd4, 1, 0],
+        ]
+        .concat();
+        assert_eq!(
+            decode_rts_conn_a3(&a3_bytes).expect("valid A3"),
+            RtsConnA3 {
+                connection_timeout: 120_000
+            }
+        );
+
+        let c2_bytes = [
+            [5, 0, PTYPE_RTS, RTS_PFC_FLAGS, 0x10, 0, 0, 0].as_slice(),
+            &[44, 0, 0, 0, 0, 0, 0, 0],
+            &[0, 0, 3, 0],
+            &[6, 0, 0, 0, 0x12, 0x34, 0x56, 0x78],
+            &[0, 0, 0, 0, 0, 0x20, 0, 0],
+            &[2, 0, 0, 0, 0xc0, 0xd4, 1, 0],
+        ]
+        .concat();
+        assert_eq!(
+            decode_rts_conn_c2(&c2_bytes).expect("valid C2"),
+            RtsConnC2 {
+                version: 0x7856_3412,
+                receive_window_size: 8 * 1024,
+                connection_timeout: 120_000,
+            }
+        );
+
+        let mut conn_c2_with_invalid_receive_window = c2_bytes;
+        conn_c2_with_invalid_receive_window[32..36].copy_from_slice(&(8u32 * 1024 - 1).to_le_bytes());
+        assert_eq!(
+            decode_rts_conn_c2(&conn_c2_with_invalid_receive_window),
+            Err(RpcPduError::InvalidRtsReceiveWindowSize { actual: 8 * 1024 - 1 })
+        );
+    }
+
+    #[test]
+    fn rts_in_recycling_encodes_client_messages_and_decodes_a4() {
+        let virtual_connection_cookie = RtsCookie::new([0x10; RtsCookie::SIZE]);
+        let predecessor_channel_cookie = RtsCookie::new([0x20; RtsCookie::SIZE]);
+        let successor_channel_cookie = RtsCookie::new([0x30; RtsCookie::SIZE]);
+        assert_eq!(
+            encode_rts_in_recycle_a1(
+                virtual_connection_cookie,
+                predecessor_channel_cookie,
+                successor_channel_cookie,
+            )
+            .expect("valid IN_R1/A1"),
+            [
+                [5, 0, PTYPE_RTS, RTS_PFC_FLAGS, 0x10, 0, 0, 0].as_slice(),
+                &[88, 0, 0, 0, 0, 0, 0, 0],
+                &[
+                    u8::try_from(RTS_FLAG_RECYCLE_CHANNEL).expect("flag fits in u8"),
+                    0,
+                    4,
+                    0
+                ],
+                &[6, 0, 0, 0, 1, 0, 0, 0],
+                &[3, 0, 0, 0],
+                virtual_connection_cookie.as_bytes(),
+                &[3, 0, 0, 0],
+                predecessor_channel_cookie.as_bytes(),
+                &[3, 0, 0, 0],
+                successor_channel_cookie.as_bytes(),
+            ]
+            .concat()
+        );
+        assert_eq!(
+            encode_rts_in_recycle_a5(successor_channel_cookie).expect("valid IN_R1/A5"),
+            [
+                [5, 0, PTYPE_RTS, RTS_PFC_FLAGS, 0x10, 0, 0, 0].as_slice(),
+                &[40, 0, 0, 0, 0, 0, 0, 0],
+                &[0, 0, 1, 0],
+                &[3, 0, 0, 0],
+                successor_channel_cookie.as_bytes(),
+            ]
+            .concat()
+        );
+
+        let a4 = [
+            [5, 0, PTYPE_RTS, RTS_PFC_FLAGS, 0x10, 0, 0, 0].as_slice(),
+            &[52, 0, 0, 0, 0, 0, 0, 0],
+            &[0, 0, 4, 0],
+            &[13, 0, 0, 0, 0, 0, 0, 0],
+            &[6, 0, 0, 0, 0x12, 0x34, 0x56, 0x78],
+            &[0, 0, 0, 0, 0, 0x20, 0, 0],
+            &[2, 0, 0, 0, 0xc0, 0xd4, 1, 0],
+        ]
+        .concat();
+        assert_eq!(
+            decode_rts_in_recycle_a4(&a4).expect("valid IN_R1/A4"),
+            RtsInRecycleA4 {
+                version: 0x7856_3412,
+                receive_window_size: 8 * 1024,
+                connection_timeout: 120_000,
+            }
+        );
+
+        let mut invalid_destination = a4;
+        invalid_destination[24..28].copy_from_slice(&1u32.to_le_bytes());
+        assert_eq!(
+            decode_rts_in_recycle_a4(&invalid_destination),
+            Err(RpcPduError::UnexpectedRtsDestination {
+                expected: RTS_DESTINATION_FD_CLIENT,
+                actual: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn rts_out_recycling_encodes_client_messages_and_decodes_peer_messages() {
+        let virtual_connection_cookie = RtsCookie::new([0x10; RtsCookie::SIZE]);
+        let predecessor_channel_cookie = RtsCookie::new([0x20; RtsCookie::SIZE]);
+        let successor_channel_cookie = RtsCookie::new([0x30; RtsCookie::SIZE]);
+        let a2 = [
+            [5, 0, PTYPE_RTS, RTS_PFC_FLAGS, 0x10, 0, 0, 0].as_slice(),
+            &[28, 0, 0, 0, 0, 0, 0, 0],
+            &[
+                u8::try_from(RTS_FLAG_RECYCLE_CHANNEL).expect("flag fits in u8"),
+                0,
+                1,
+                0,
+            ],
+            &[13, 0, 0, 0, 0, 0, 0, 0],
+        ]
+        .concat();
+        decode_rts_out_recycle_a2(&a2).expect("valid OUT_R1/A2");
+        assert_eq!(
+            encode_rts_out_recycle_a3(
+                virtual_connection_cookie,
+                predecessor_channel_cookie,
+                successor_channel_cookie,
+                8 * 1024,
+            )
+            .expect("valid OUT_R1/A3"),
+            [
+                [5, 0, PTYPE_RTS, RTS_PFC_FLAGS, 0x10, 0, 0, 0].as_slice(),
+                &[96, 0, 0, 0, 0, 0, 0, 0],
+                &[
+                    u8::try_from(RTS_FLAG_RECYCLE_CHANNEL).expect("flag fits in u8"),
+                    0,
+                    5,
+                    0
+                ],
+                &[6, 0, 0, 0, 1, 0, 0, 0],
+                &[3, 0, 0, 0],
+                virtual_connection_cookie.as_bytes(),
+                &[3, 0, 0, 0],
+                predecessor_channel_cookie.as_bytes(),
+                &[3, 0, 0, 0],
+                successor_channel_cookie.as_bytes(),
+                &[0, 0, 0, 0, 0, 0x20, 0, 0],
+            ]
+            .concat()
+        );
+
+        let a6 = [
+            [5, 0, PTYPE_RTS, RTS_PFC_FLAGS, 0x10, 0, 0, 0].as_slice(),
+            &[44, 0, 0, 0, 0, 0, 0, 0],
+            &[u8::try_from(RTS_FLAG_OUT_CHANNEL).expect("flag fits in u8"), 0, 3, 0],
+            &[13, 0, 0, 0, 0, 0, 0, 0],
+            &[6, 0, 0, 0, 0x12, 0x34, 0x56, 0x78],
+            &[2, 0, 0, 0, 0xc0, 0xd4, 1, 0],
+        ]
+        .concat();
+        assert_eq!(
+            decode_rts_out_recycle_a6(&a6).expect("valid OUT_R1/A6"),
+            RtsOutRecycleA6 {
+                version: 0x7856_3412,
+                connection_timeout: 120_000,
+            }
+        );
+        assert_eq!(
+            encode_rts_out_recycle_a7(successor_channel_cookie).expect("valid OUT_R1/A7"),
+            [
+                [5, 0, PTYPE_RTS, RTS_PFC_FLAGS, 0x10, 0, 0, 0].as_slice(),
+                &[48, 0, 0, 0, 0, 0, 0, 0],
+                &[u8::try_from(RTS_FLAG_OUT_CHANNEL).expect("flag fits in u8"), 0, 2, 0],
+                &[13, 0, 0, 0, 2, 0, 0, 0],
+                &[3, 0, 0, 0],
+                successor_channel_cookie.as_bytes(),
+            ]
+            .concat()
+        );
+
+        let a10 = [
+            [5, 0, PTYPE_RTS, RTS_PFC_FLAGS, 0x10, 0, 0, 0].as_slice(),
+            &[24, 0, 0, 0, 0, 0, 0, 0],
+            &[0, 0, 1, 0],
+            &[10, 0, 0, 0],
+        ]
+        .concat();
+        decode_rts_out_recycle_a10(&a10).expect("valid OUT_R1/A10");
+        assert_eq!(encode_rts_out_recycle_a11().expect("valid OUT_R1/A11"), a10);
+    }
+
+    #[test]
+    fn rts_initial_flow_rejects_invalid_headers_commands_and_fixed_values() {
+        let mut conn_a3 = [
+            [5, 0, PTYPE_RTS, RTS_PFC_FLAGS, 0x10, 0, 0, 0].as_slice(),
+            &[28, 0, 0, 0, 0, 0, 0, 0],
+            &[0, 0, 1, 0],
+            &[2, 0, 0, 0, 0xc0, 0xd4, 1, 0],
+        ]
+        .concat();
+
+        conn_a3[2] = PTYPE_REQUEST;
+        assert_eq!(
+            decode_rts_conn_a3(&conn_a3),
+            Err(RpcPduError::UnexpectedPduType {
+                expected: PTYPE_RTS,
+                actual: PTYPE_REQUEST
+            })
+        );
+        conn_a3[2] = PTYPE_RTS;
+
+        let mut common_header_only = conn_a3[..RPC_COMMON_HEADER_SIZE].to_vec();
+        common_header_only[8..10]
+            .copy_from_slice(&(u16::try_from(RPC_COMMON_HEADER_SIZE).expect("header size fits in u16")).to_le_bytes());
+        assert_eq!(
+            decode_rts_conn_a3(&common_header_only),
+            Err(RpcPduError::Truncated {
+                actual: RPC_COMMON_HEADER_SIZE,
+                required: RTS_HEADER_SIZE
+            })
+        );
+
+        conn_a3[3] |= 0x04;
+        assert_eq!(
+            decode_rts_conn_a3(&conn_a3),
+            Err(RpcPduError::InvalidRtsPfcFlags {
+                actual: RTS_PFC_FLAGS | 0x04
+            })
+        );
+        conn_a3[3] = RTS_PFC_FLAGS;
+
+        conn_a3[16..18].copy_from_slice(&1u16.to_le_bytes());
+        assert_eq!(
+            decode_rts_conn_a3(&conn_a3),
+            Err(RpcPduError::UnexpectedRtsFlags {
+                expected: RTS_FLAG_NONE,
+                actual: 1
+            })
+        );
+        conn_a3[16..18].copy_from_slice(&RTS_FLAG_NONE.to_le_bytes());
+
+        conn_a3[10..12].copy_from_slice(&1u16.to_le_bytes());
+        assert_eq!(
+            decode_rts_conn_a3(&conn_a3),
+            Err(RpcPduError::AuthenticationUnsupported { auth_length: 1 })
+        );
+        conn_a3[10..12].copy_from_slice(&0u16.to_le_bytes());
+
+        conn_a3[8..10].copy_from_slice(&27u16.to_le_bytes());
+        assert_eq!(
+            decode_rts_conn_a3(&conn_a3),
+            Err(RpcPduError::InvalidRtsBodyLength { expected: 8, actual: 7 })
+        );
+        conn_a3[8..10].copy_from_slice(&28u16.to_le_bytes());
+
+        conn_a3[12] = 1;
+        assert_eq!(
+            decode_rts_conn_a3(&conn_a3),
+            Err(RpcPduError::UnexpectedRtsCallId { actual: 1 })
+        );
+        conn_a3[12] = 0;
+
+        conn_a3[18..20].copy_from_slice(&2u16.to_le_bytes());
+        assert_eq!(
+            decode_rts_conn_a3(&conn_a3),
+            Err(RpcPduError::UnexpectedRtsCommandCount { expected: 1, actual: 2 })
+        );
+        conn_a3[18..20].copy_from_slice(&1u16.to_le_bytes());
+
+        conn_a3[20..24].copy_from_slice(&RTS_COMMAND_VERSION.to_le_bytes());
+        assert_eq!(
+            decode_rts_conn_a3(&conn_a3),
+            Err(RpcPduError::UnexpectedRtsCommandType {
+                expected: RTS_COMMAND_CONNECTION_TIMEOUT,
+                actual: RTS_COMMAND_VERSION
+            })
+        );
+        conn_a3[20..24].copy_from_slice(&RTS_COMMAND_CONNECTION_TIMEOUT.to_le_bytes());
+
+        conn_a3[24..28].copy_from_slice(&0u32.to_le_bytes());
+        assert_eq!(
+            decode_rts_conn_a3(&conn_a3),
+            Err(RpcPduError::InvalidRtsConnectionTimeout { actual: 0 })
+        );
+
+        assert_eq!(
+            encode_rts_conn_a1(RtsCookie::new([0; 16]), RtsCookie::new([1; 16]), 8 * 1024 - 1),
+            Err(RpcPduError::InvalidRtsReceiveWindowSize { actual: 8 * 1024 - 1 })
+        );
+        assert_eq!(
+            encode_rts_conn_b1(
+                RtsCookie::new([0; 16]),
+                RtsCookie::new([1; 16]),
+                128 * 1024 - 1,
+                0,
+                RtsCookie::new([2; 16])
+            ),
+            Err(RpcPduError::InvalidRtsChannelLifetime { actual: 128 * 1024 - 1 })
+        );
+        assert_eq!(
+            encode_rts_conn_b1(
+                RtsCookie::new([0; 16]),
+                RtsCookie::new([1; 16]),
+                128 * 1024,
+                59_999,
+                RtsCookie::new([2; 16])
+            ),
+            Err(RpcPduError::InvalidRtsClientKeepalive { actual: 59_999 })
+        );
+    }
+
+    #[test]
+    fn rpch_setup_enforces_initial_sequence_and_opens_after_a3_and_c2() {
+        let settings = RpcHttpV2Settings::new(128 * 1024, 256 * 1024, 0).expect("valid settings");
+        let virtual_connection_cookie = RtsCookie::new([0x10; RtsCookie::SIZE]);
+        let out_channel_cookie = RtsCookie::new([0x20; RtsCookie::SIZE]);
+        let in_channel_cookie = RtsCookie::new([0x30; RtsCookie::SIZE]);
+        let association_group_id = RtsCookie::new([0x40; RtsCookie::SIZE]);
+        let mut setup = RpcHttpV2Setup::with_cookies(
+            settings,
+            virtual_connection_cookie,
+            out_channel_cookie,
+            in_channel_cookie,
+            association_group_id,
+        );
+
+        setup.start_in_request().expect("start IN request");
+        assert_eq!(setup.state(), RpcHttpV2State::InRequestStarted);
+        assert_eq!(
+            setup.out_request_body().expect("CONN/A1"),
+            encode_rts_conn_a1(virtual_connection_cookie, out_channel_cookie, 128 * 1024).expect("valid CONN/A1")
+        );
+        assert_eq!(setup.state(), RpcHttpV2State::OutRequestStarted);
+        assert_eq!(
+            setup.in_request_initial_pdu().expect("CONN/B1"),
+            encode_rts_conn_b1(
+                virtual_connection_cookie,
+                in_channel_cookie,
+                256 * 1024,
+                0,
+                association_group_id,
+            )
+            .expect("valid CONN/B1")
+        );
+
+        setup
+            .accept_out_response(http::StatusCode::OK.as_u16(), Some("application/rpc"), Some(128 * 1024))
+            .expect("successful OUT response");
+        setup.receive_out_pdu(&conn_a3_pdu()).expect("CONN/A3");
+        assert_eq!(setup.state(), RpcHttpV2State::AwaitingC2);
+        assert_eq!(setup.in_ping_timeout(), Some(120_000));
+
+        setup.receive_out_pdu(&conn_c2_pdu(1)).expect("CONN/C2");
+        assert_eq!(setup.state(), RpcHttpV2State::Open);
+        assert_eq!(setup.connection_timeout(), Some(120_000));
+        assert_eq!(setup.peer_receive_window_size(), Some(128 * 1024));
+        setup.require_open().expect("opened setup permits RPC PDUs");
+        assert!(
+            setup
+                .ping_schedule(Duration::ZERO)
+                .expect("opened setup provides a ping schedule")
+                .ping_due(Duration::from_secs(120))
+        );
+    }
+
+    #[test]
+    fn rpch_flow_control_tracks_windows_and_acknowledgements() {
+        let settings = RpcHttpV2Settings::new(128 * 1024, 256 * 1024, 0).expect("valid settings");
+        let virtual_connection_cookie = RtsCookie::new([0x10; RtsCookie::SIZE]);
+        let out_channel_cookie = RtsCookie::new([0x20; RtsCookie::SIZE]);
+        let in_channel_cookie = RtsCookie::new([0x30; RtsCookie::SIZE]);
+        let association_group_id = RtsCookie::new([0x40; RtsCookie::SIZE]);
+        let mut setup = RpcHttpV2Setup::with_cookies(
+            settings,
+            virtual_connection_cookie,
+            out_channel_cookie,
+            in_channel_cookie,
+            association_group_id,
+        );
+        setup.start_in_request().expect("start IN request");
+        let _ = setup.out_request_body().expect("CONN/A1");
+        let _ = setup.in_request_initial_pdu().expect("CONN/B1");
+        setup
+            .accept_out_response(http::StatusCode::OK.as_u16(), Some("application/rpc"), Some(128 * 1024))
+            .expect("successful OUT response");
+        setup.receive_out_pdu(&conn_a3_pdu()).expect("CONN/A3");
+        setup.receive_out_pdu(&conn_c2_pdu(1)).expect("CONN/C2");
+
+        let mut flow_control = setup.flow_control().expect("open RPCH flow control");
+        flow_control.sent_rpc_pdu(64 * 1024).expect("send within peer window");
+        assert_eq!(flow_control.send_available_window(), 64 * 1024);
+        assert_eq!(
+            flow_control.receive_flow_control_ack(RtsFlowControlAck {
+                bytes_received: 64 * 1024,
+                available_window: 128 * 1024,
+                channel_cookie: in_channel_cookie,
+            }),
+            Ok(true)
+        );
+        assert_eq!(flow_control.send_available_window(), 128 * 1024);
+        assert_eq!(
+            flow_control.receive_flow_control_ack(RtsFlowControlAck {
+                bytes_received: 0,
+                available_window: 128 * 1024,
+                channel_cookie: RtsCookie::new([0xff; RtsCookie::SIZE]),
+            }),
+            Ok(false)
+        );
+
+        flow_control.received_rpc_pdu(100 * 1024).expect("queue received PDU");
+        assert_eq!(flow_control.receive_available_window(), 28 * 1024);
+        assert_eq!(
+            flow_control.consumed_rpc_pdu(100 * 1024),
+            Ok(Some(RtsFlowControlAck {
+                bytes_received: 100 * 1024,
+                available_window: 128 * 1024,
+                channel_cookie: out_channel_cookie,
+            }))
+        );
+
+        flow_control.received_rpc_pdu(60 * 1024).expect("queue first PDU");
+        assert_eq!(flow_control.consumed_rpc_pdu(30 * 1024), Ok(None));
+        flow_control
+            .received_rpc_pdu(60 * 1024)
+            .expect("track received PDU after partial consumption");
+        assert_eq!(flow_control.receive_available_window(), 38 * 1024);
+
+        assert_eq!(
+            flow_control.sent_rpc_pdu(128 * 1024),
+            Err(RpcHttpV2FlowControlError::SendWindowExhausted {
+                pdu_size: 128 * 1024,
+                available_window: 128 * 1024,
+            })
+        );
+        assert_eq!(
+            flow_control.received_rpc_pdu(40 * 1024),
+            Err(RpcHttpV2FlowControlError::ReceiveWindowExhausted {
+                pdu_size: 40 * 1024,
+                available_window: 38 * 1024,
+            })
+        );
+        assert_eq!(
+            flow_control.receive_flow_control_ack(RtsFlowControlAck {
+                bytes_received: 64 * 1024 + 1,
+                available_window: 128 * 1024,
+                channel_cookie: in_channel_cookie,
+            }),
+            Err(RpcHttpV2FlowControlError::InvalidFlowControlAck {
+                bytes_received: 64 * 1024 + 1,
+                bytes_sent: 64 * 1024,
+            })
+        );
+    }
+
+    #[test]
+    fn rpch_ping_schedule_uses_keepalive_and_connection_timeouts() {
+        let mut keepalive =
+            RpcHttpV2PingSchedule::new(Duration::from_secs(120), Duration::from_secs(30), Duration::ZERO);
+        assert!(!keepalive.ping_due(Duration::from_secs(14)));
+        assert!(keepalive.ping_due(Duration::from_secs(15)));
+        keepalive.record_send(Duration::from_secs(15));
+        assert!(!keepalive.ping_due(Duration::from_secs(29)));
+        assert!(keepalive.ping_due(Duration::from_secs(30)));
+
+        let connection = RpcHttpV2PingSchedule::new(Duration::from_secs(120), Duration::ZERO, Duration::ZERO);
+        assert!(!connection.ping_due(Duration::from_secs(119)));
+        assert!(connection.ping_due(Duration::from_secs(120)));
+    }
+
+    #[test]
+    fn rpch_settings_use_default_keepalive_for_zero() {
+        let settings = RpcHttpV2Settings::new(128 * 1024, 256 * 1024, 0).expect("valid settings");
+        assert_eq!(settings.client_keepalive(), 0);
+        assert_eq!(settings.effective_client_keepalive(), 300_000);
+    }
+
+    #[test]
+    fn rpch_setup_rejects_wrong_order_and_invalid_c2_version() {
+        let mut setup = RpcHttpV2Setup::new(RpcHttpV2Settings::default());
+        assert_eq!(
+            setup.in_request_initial_pdu(),
+            Err(RpcHttpV2Error::InvalidState {
+                action: "send CONN/B1",
+                state: RpcHttpV2State::Initial,
+            })
+        );
+        assert_eq!(setup.state(), RpcHttpV2State::Failed);
+
+        let mut setup = RpcHttpV2Setup::new(RpcHttpV2Settings::default());
+        setup.start_in_request().expect("start IN request");
+        let _ = setup.out_request_body().expect("CONN/A1");
+        let _ = setup.in_request_initial_pdu().expect("CONN/B1");
+        setup
+            .accept_out_response(http::StatusCode::OK.as_u16(), Some("application/rpc"), Some(128 * 1024))
+            .expect("OUT response");
+        setup.receive_out_pdu(&conn_a3_pdu()).expect("CONN/A3");
+        let unsupported_c2 = conn_c2_pdu(2);
+        assert_eq!(
+            setup.receive_out_pdu(&unsupported_c2),
+            Err(RpcHttpV2Error::UnsupportedProtocolVersion { actual: 2 })
+        );
+        assert_eq!(setup.state(), RpcHttpV2State::Failed);
+    }
+
+    #[test]
+    fn rpch_setup_requires_a_bounded_out_response_body() {
+        let mut setup = RpcHttpV2Setup::new(RpcHttpV2Settings::default());
+        setup.start_in_request().expect("start IN request");
+        let _ = setup.out_request_body().expect("CONN/A1");
+        let _ = setup.in_request_initial_pdu().expect("CONN/B1");
+
+        assert_eq!(
+            setup.accept_out_response(http::StatusCode::OK.as_u16(), Some("application/rpc"), None),
+            Err(RpcHttpV2Error::OutResponseContentLength { actual: None })
+        );
+        assert_eq!(setup.state(), RpcHttpV2State::Failed);
+    }
+
+    #[test]
+    fn rpch_http_request_encodes_required_headers_and_target() {
+        let target = crate::GwConnectTarget {
+            gw_endpoint: "rdg.contoso.com".to_owned(),
+            gw_user: "alice".to_owned(),
+            gw_pass: "secret".to_owned(),
+            server: "rdp.contoso.com".to_owned(),
+            server_port: 3389,
+            smart_card: None,
+        };
+        let request = build_rpch_v2_request(
+            RpchHttpChannel::In,
+            "rdg.contoso.com",
+            &target,
+            128 * 1024,
+            Some("Basic YWxpY2U6c2VjcmV0"),
+            Some("session=abc"),
+            (),
+        )
+        .expect("valid IN request");
+
+        assert_eq!(request.method(), "RPC_IN_DATA");
+        assert_eq!(request.uri(), "/rpc/rpcproxy.dll?rdp.contoso.com:3389");
+        assert_eq!(request.headers()[http::header::ACCEPT], "application/rpc");
+        assert_eq!(request.headers()[http::header::CACHE_CONTROL], "no-cache");
+        assert_eq!(request.headers()[http::header::CONNECTION], "Keep-Alive");
+        assert_eq!(request.headers()[http::header::CONTENT_LENGTH], "131072");
+        assert_eq!(request.headers()[http::header::HOST], "rdg.contoso.com");
+        assert_eq!(request.headers()[http::header::PRAGMA], "no-cache");
+        assert_eq!(request.headers()["Protocol"], "1.0");
+        assert_eq!(request.headers()[http::header::USER_AGENT], "MSRPC");
+        assert_eq!(request.headers()[http::header::AUTHORIZATION], "Basic YWxpY2U6c2VjcmV0");
+        assert_eq!(request.headers()[http::header::COOKIE], "session=abc");
+
+        assert!(matches!(
+            build_rpch_v2_request(
+                RpchHttpChannel::Out,
+                "rdg.contoso.com",
+                &target,
+                RPCH_OUT_CONTENT_LENGTH - 1,
+                None,
+                None,
+                (),
+            ),
+            Err(RpcHttpV2Error::InvalidContentLength {
+                channel: RpchHttpChannel::Out,
+                actual,
+            }) if actual == RPCH_OUT_CONTENT_LENGTH - 1
+        ));
+        let mut invalid_target = target;
+        invalid_target.server = "rdp/invalid".to_owned();
+        assert!(matches!(
+            build_rpch_v2_request(
+                RpchHttpChannel::In,
+                "rdg.contoso.com",
+                &invalid_target,
+                128 * 1024,
+                None,
+                None,
+                (),
+            ),
+            Err(RpcHttpV2Error::InvalidTargetServer)
+        ));
+    }
+
+    #[test]
+    fn pdu_stream_caps_pending_bytes() {
+        let mut stream = RpcPduStream::new(32).expect("valid maximum");
+        assert_eq!(
+            stream.push(&[0; 32 * MAX_PENDING_RPC_FRAGMENTS + 1]),
+            Err(RpcPduError::PendingBytesExceedMaximum {
+                actual: 32 * MAX_PENDING_RPC_FRAGMENTS + 1,
+                maximum: 32 * MAX_PENDING_RPC_FRAGMENTS,
+            })
+        );
+    }
+}

--- a/crates/ironrdp-mstsgu/src/rpc_transport.rs
+++ b/crates/ironrdp-mstsgu/src/rpc_transport.rs
@@ -1,0 +1,429 @@
+//! Raw HTTP/1 primitives for the non-replayable RPCH IN channel.
+
+use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWrite, AsyncWriteExt as _};
+
+use crate::{Error, GwErrorKind};
+
+const MAX_RESPONSE_HEADERS: usize = 16 * 1024;
+
+/// The TS Proxy RPC interface UUID, advertised in the `Pragma: ResourceTypeUuid` header
+/// so the RPC proxy routes the channel to the gateway service ([MS-TSGU] 2.2.2.1).
+const TSPROXY_RESOURCE_TYPE_UUID: &str = "44e265dd-7daf-42cd-8560-3cdb6e7a2729";
+
+/// A parsed HTTP/1 response head from the RPCH proxy.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct RpchResponseHead {
+    pub(crate) status: u16,
+    pub(crate) content_length: Option<u32>,
+    pub(crate) content_type: Option<String>,
+    pub(crate) www_authenticate: Vec<String>,
+}
+
+/// An RPCH IN request whose streaming body is committed only once the channel is
+/// authenticated. Authentication probes carry no body (`Content-Length: 0`); the final
+/// request carries the channel-lifetime length, mirroring mstsc ([MS-RPCH] 3.2.2.2.1).
+pub(crate) struct RpchInRequest<S> {
+    stream: S,
+    host: String,
+    target: String,
+    remaining: u32,
+    body_committed: bool,
+}
+
+/// Parameters for an RPCH request head.
+pub(crate) struct RpchRequestHead<'a> {
+    pub(crate) method: &'a str,
+    pub(crate) host: &'a str,
+    pub(crate) target: &'a str,
+    pub(crate) content_length: u32,
+    pub(crate) authorization: Option<&'a str>,
+    pub(crate) cookie: Option<&'a str>,
+    /// The HTTP-level session identifier pairing the OUT and IN channels. Sent on the
+    /// OUT channel only ([MS-RPCH] 2.1.3.1).
+    pub(crate) session_id: Option<&'a str>,
+    pub(crate) expect_continue: bool,
+}
+
+impl<S> RpchInRequest<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    /// Opens the IN channel with an authentication probe (`Content-Length: 0`, no body).
+    pub(crate) async fn open(
+        mut stream: S,
+        host: &str,
+        target: &str,
+        authorization: Option<&str>,
+    ) -> Result<Self, Error> {
+        write_rpch_request_head(
+            &mut stream,
+            RpchRequestHead {
+                method: "RPC_IN_DATA",
+                host,
+                target,
+                content_length: 0,
+                authorization,
+                cookie: None,
+                session_id: None,
+                expect_continue: false,
+            },
+        )
+        .await?;
+        Ok(Self {
+            stream,
+            host: host.to_owned(),
+            target: target.to_owned(),
+            remaining: 0,
+            body_committed: false,
+        })
+    }
+
+    /// Reads the response to the current request head. A 401 error body is drained so the
+    /// connection stays clean for an authentication retry.
+    pub(crate) async fn receive_response(&mut self) -> Result<RpchResponseHead, Error> {
+        let response = read_rpch_response_head(&mut self.stream).await?;
+        if response.status == 401
+            && let Some(length) = response.content_length
+        {
+            drain_body(&mut self.stream, length).await?;
+        }
+        Ok(response)
+    }
+
+    /// Retries the request head with new authorization after a 401 response. When
+    /// `content_length` is non-zero this is the final, authenticated request and the
+    /// streaming body may follow; a zero length is another authentication probe.
+    pub(crate) async fn retry(mut self, authorization: Option<&str>, content_length: u32) -> Result<Self, Error> {
+        if self.body_committed {
+            return Err(Error::new("rpch IN retry after body", GwErrorKind::Connect));
+        }
+        let host = self.host.clone();
+        let target = self.target.clone();
+        write_rpch_request_head(
+            &mut self.stream,
+            RpchRequestHead {
+                method: "RPC_IN_DATA",
+                host: &host,
+                target: &target,
+                content_length,
+                authorization,
+                cookie: None,
+                session_id: None,
+                expect_continue: false,
+            },
+        )
+        .await?;
+        self.remaining = content_length;
+        self.body_committed = content_length > 0;
+        Ok(self)
+    }
+
+    pub(crate) async fn write_body(&mut self, bytes: &[u8]) -> Result<(), Error> {
+        if !self.body_committed {
+            return Err(Error::new("rpch IN body before authentication", GwErrorKind::Connect));
+        }
+        let length = u32::try_from(bytes.len()).map_err(|_| Error::new("rpch IN body length", GwErrorKind::Encode))?;
+        if length > self.remaining {
+            return Err(Error::new("rpch IN body exceeds content length", GwErrorKind::Encode));
+        }
+        self.stream
+            .write_all(bytes)
+            .await
+            .map_err(|error| custom_err!("write rpch IN body", error))?;
+        self.remaining -= length;
+        Ok(())
+    }
+
+    pub(crate) const fn remaining(&self) -> u32 {
+        self.remaining
+    }
+
+    /// Flushes buffered body bytes to the gateway.
+    pub(crate) async fn flush(&mut self) -> Result<(), Error> {
+        self.stream
+            .flush()
+            .await
+            .map_err(|error| custom_err!("flush rpch IN body", error))
+    }
+}
+
+/// Writes an RPCH request head without committing any body bytes.
+///
+/// The caller must wait for a `100 Continue` response before writing an IN
+/// channel body so an authentication retry can never replay RPC bytes.
+pub(crate) async fn write_rpch_request_head<S>(stream: &mut S, head: RpchRequestHead<'_>) -> Result<(), Error>
+where
+    S: AsyncWrite + Unpin,
+{
+    // The ResourceTypeUuid identifies the TS Proxy RPC interface to the gateway; the
+    // SessionId pairs the OUT channel with its IN channel at the HTTP level. Both are
+    // required by the RPC proxy ([MS-RPCH] 2.1.3.1, [MS-TSGU] 2.2.2.1).
+    let mut pragma = format!("ResourceTypeUuid={TSPROXY_RESOURCE_TYPE_UUID}");
+    if let Some(session_id) = head.session_id {
+        pragma.push_str(", SessionId=");
+        pragma.push_str(session_id);
+    }
+    let mut request = format!(
+        "{} /rpc/rpcproxy.dll?{} HTTP/1.1\r\n\
+         Accept: application/rpc\r\n\
+         Cache-Control: no-cache\r\n\
+         Connection: Keep-Alive\r\n\
+         Content-Length: {}\r\n\
+         Host: {}\r\n\
+         Pragma: {}\r\n\
+         User-Agent: MSRPC\r\n",
+        head.method, head.target, head.content_length, head.host, pragma
+    );
+    if head.expect_continue {
+        request.push_str("Expect: 100-continue\r\n");
+    }
+    if let Some(authorization) = head.authorization {
+        request.push_str("Authorization: ");
+        request.push_str(authorization);
+        request.push_str("\r\n");
+    }
+    if let Some(cookie) = head.cookie {
+        request.push_str("Cookie: ");
+        request.push_str(cookie);
+        request.push_str("\r\n");
+    }
+    request.push_str("\r\n");
+
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .map_err(|error| custom_err!("write rpch request headers", error))?;
+    stream
+        .flush()
+        .await
+        .map_err(|error| custom_err!("flush rpch request headers", error))
+}
+
+/// Reads one bounded HTTP/1 response head without consuming the body. Callers that need to
+/// re-use the connection after an error response (authentication retry) drain the body via
+/// [`RpchInRequest::receive_gate`]; the OUT-channel success response keeps its body attached
+/// because the body is the streaming RPC data.
+pub(crate) async fn read_rpch_response_head<S>(stream: &mut S) -> Result<RpchResponseHead, Error>
+where
+    S: AsyncRead + Unpin,
+{
+    let mut bytes = Vec::with_capacity(512);
+    loop {
+        if bytes.len() == MAX_RESPONSE_HEADERS {
+            return Err(Error::new("rpch response headers exceed limit", GwErrorKind::Decode));
+        }
+        let byte = stream
+            .read_u8()
+            .await
+            .map_err(|error| custom_err!("read rpch response headers", error))?;
+        bytes.push(byte);
+        if bytes.ends_with(b"\r\n\r\n") {
+            break;
+        }
+    }
+
+    parse_rpch_response_head(&bytes)
+}
+
+/// Drain exactly `length` body bytes (authentication error pages). Called after an error
+/// response head so the connection is clean before the request is retried.
+pub(crate) async fn drain_body<S>(stream: &mut S, length: u32) -> Result<(), Error>
+where
+    S: AsyncRead + Unpin,
+{
+    let mut remaining = usize::try_from(length).map_err(|_| Error::new("rpch body length", GwErrorKind::Decode))?;
+    let mut chunk = [0u8; 4096];
+    while remaining > 0 {
+        let read_len = remaining.min(chunk.len());
+        let read = stream
+            .read(&mut chunk[..read_len])
+            .await
+            .map_err(|error| custom_err!("drain rpch body", error))?;
+        if read == 0 {
+            return Err(Error::new("rpch body truncated", GwErrorKind::PacketEof));
+        }
+        remaining -= read;
+    }
+    Ok(())
+}
+
+fn parse_rpch_response_head(bytes: &[u8]) -> Result<RpchResponseHead, Error> {
+    let text = core::str::from_utf8(bytes).map_err(|error| custom_err!("decode rpch response headers", error))?;
+    let mut lines = text.split("\r\n");
+    let status_line = lines
+        .next()
+        .ok_or_else(|| Error::new("missing rpch response status", GwErrorKind::Decode))?;
+    let mut status = status_line.split_ascii_whitespace();
+    let version = status
+        .next()
+        .ok_or_else(|| Error::new("missing rpch HTTP version", GwErrorKind::Decode))?;
+    if !version.starts_with("HTTP/") {
+        return Err(Error::new("invalid rpch HTTP version", GwErrorKind::Decode));
+    }
+    let status = status
+        .next()
+        .ok_or_else(|| Error::new("missing rpch response status", GwErrorKind::Decode))?
+        .parse()
+        .map_err(|error| custom_err!("parse rpch response status", error))?;
+
+    let mut content_length = None;
+    let mut content_type = None;
+    let mut www_authenticate = Vec::new();
+    for line in lines {
+        if line.is_empty() {
+            break;
+        }
+        let (name, value) = line
+            .split_once(':')
+            .ok_or_else(|| Error::new("malformed rpch response header", GwErrorKind::Decode))?;
+        let value = value.trim();
+        if name.eq_ignore_ascii_case("Content-Length") {
+            if content_length
+                .replace(
+                    value
+                        .parse()
+                        .map_err(|error| custom_err!("parse rpch content length", error))?,
+                )
+                .is_some()
+            {
+                return Err(Error::new("duplicate rpch content length", GwErrorKind::Decode));
+            }
+        } else if name.eq_ignore_ascii_case("Content-Type") {
+            content_type = Some(value.to_owned());
+        } else if name.eq_ignore_ascii_case("WWW-Authenticate") {
+            www_authenticate.push(value.to_owned());
+        }
+    }
+
+    Ok(RpchResponseHead {
+        status,
+        content_length,
+        content_type,
+        www_authenticate,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn rpch_in_headers_hold_body_for_continue() {
+        let (mut client, mut server) = tokio::io::duplex(4096);
+        let write = tokio::spawn(async move {
+            write_rpch_request_head(
+                &mut client,
+                RpchRequestHead {
+                    method: "RPC_IN_DATA",
+                    host: "gateway.example",
+                    target: "target.example:3389",
+                    content_length: 128 * 1024,
+                    authorization: Some("NTLM token"),
+                    cookie: Some("session=value"),
+                    session_id: None,
+                    expect_continue: true,
+                },
+            )
+            .await
+            .expect("write headers");
+        });
+        let mut request = Vec::new();
+        server.read_to_end(&mut request).await.expect("read request");
+        write.await.expect("join");
+        let request = String::from_utf8(request).expect("ASCII request");
+        assert!(request.contains("Expect: 100-continue\r\n"));
+        assert!(request.ends_with("\r\n\r\n"));
+        assert!(!request.contains("CONN/B1"));
+    }
+
+    #[tokio::test]
+    async fn response_head_preserves_authentication_challenges() {
+        let (mut client, mut server) = tokio::io::duplex(4096);
+        let server = tokio::spawn(async move {
+            server
+                .write_all(
+                    b"HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\nWWW-Authenticate: NTLM\r\nWWW-Authenticate: Negotiate\r\n\r\n",
+                )
+                .await
+                .expect("write response");
+        });
+        let response = read_rpch_response_head(&mut client).await.expect("read response");
+        server.await.expect("join");
+        assert_eq!(response.status, 401);
+        assert_eq!(response.content_length, Some(0));
+        assert_eq!(response.www_authenticate, ["NTLM", "Negotiate"]);
+    }
+
+    #[tokio::test]
+    async fn in_request_commits_body_after_authenticated_retry() {
+        let (client, mut server) = tokio::io::duplex(4096);
+        let server_task = tokio::spawn(async move {
+            // Authentication probe carries no body (Content-Length: 0).
+            let head = read_head(&mut server).await;
+            assert!(head.contains("Content-Length: 0"), "probe head: {head}");
+            server
+                .write_all(b"HTTP/1.1 401 Unauthorized\r\nContent-Length: 4\r\nWWW-Authenticate: NTLM\r\n\r\n")
+                .await
+                .expect("write 401");
+            server.write_all(b"deny").await.expect("write 401 body");
+            // The authenticated retry commits the streaming body.
+            let head = read_head(&mut server).await;
+            assert!(head.contains("Content-Length: 4"), "retry head: {head}");
+            assert!(head.contains("Authorization: NTLM token"), "retry head: {head}");
+            let mut body = [0; 4];
+            server.read_exact(&mut body).await.expect("read body");
+            assert_eq!(body, *b"B1!!");
+        });
+
+        let mut request = RpchInRequest::open(client, "gateway.example", "target.example:3389", None)
+            .await
+            .expect("open request");
+        // The body cannot be written before the authenticated request.
+        assert!(request.write_body(b"B1!!").await.is_err());
+        let response = request.receive_response().await.expect("401");
+        assert_eq!(response.status, 401);
+        let mut request = request.retry(Some("NTLM token"), 4).await.expect("retry");
+        request.write_body(b"B1!!").await.expect("write body");
+        assert_eq!(request.remaining(), 0);
+        server_task.await.expect("join");
+    }
+
+    #[tokio::test]
+    async fn in_request_drains_401_body_before_retry() {
+        let (client, mut server) = tokio::io::duplex(4096);
+        let server_task = tokio::spawn(async move {
+            let _ = read_head(&mut server).await;
+            server
+                .write_all(b"HTTP/1.1 401 Unauthorized\r\nContent-Length: 4\r\nWWW-Authenticate: NTLM\r\n\r\ndeny")
+                .await
+                .expect("write 401 with body");
+            // After the drained 401, the retried head must parse as a fresh request.
+            let head = read_head(&mut server).await;
+            assert!(head.starts_with("RPC_IN_DATA "), "retried head: {head}");
+        });
+
+        let request = RpchInRequest::open(client, "gateway.example", "target.example:3389", None)
+            .await
+            .expect("open request");
+        let mut request = request;
+        let response = request.receive_response().await.expect("401");
+        assert_eq!(response.status, 401);
+        let _ = request.retry(Some("NTLM token"), 0).await.expect("retry");
+        server_task.await.expect("join");
+    }
+
+    async fn read_head(stream: &mut tokio::io::DuplexStream) -> String {
+        let mut head = Vec::new();
+        let mut byte = [0u8; 1];
+        loop {
+            stream.read_exact(&mut byte).await.expect("read head byte");
+            head.push(byte[0]);
+            if head.ends_with(b"\r\n\r\n") {
+                return String::from_utf8(head).expect("utf8 head");
+            }
+            assert!(head.len() <= 16 * 1024, "head too large");
+        }
+    }
+}

--- a/crates/ironrdp-mstsgu/src/rpch.rs
+++ b/crates/ironrdp-mstsgu/src/rpch.rs
@@ -1,0 +1,1058 @@
+//! MS-RPCH v2 client driver for the legacy MS-TSGU RPC-over-HTTP transport.
+//!
+//! Sequences the IN/OUT channel setup ([MS-RPCH] 3.2.2), the DCE/RPC bind with
+//! optional NTLM packet integrity, and the TsProxy tunnel/channel calls
+//! ([MS-TSGU] 3.2.6.1) over caller-supplied streams. Streams are generic so the
+//! mock server can drive the whole exchange in memory; production wiring uses
+//! TLS streams to the RPC proxy.
+
+use core::time::Duration;
+
+use futures_util::FutureExt as _;
+use hyper::body::Bytes;
+use log::{debug, error, warn};
+use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWrite, AsyncWriteExt as _};
+use uuid::Uuid;
+
+use crate::http_auth::{AuthStep, GatewayHttpAuth};
+use crate::rpc::{
+    NonNullRpcContextHandle, RpcFragmentSizes, RpcHttpV2FlowControl, RpcHttpV2PingSchedule, RpcHttpV2Settings,
+    RpcHttpV2Setup, RpcHttpV2State, RpcNtlmAuth, RpcResponseReassembler, RtsCookie, TSPROXY_AUTHORIZE_TUNNEL_OPNUM,
+    TSPROXY_CREATE_CHANNEL_OPNUM, TSPROXY_CREATE_TUNNEL_OPNUM, TSPROXY_MAKE_TUNNEL_CALL_OPNUM,
+    TSPROXY_SEND_TO_SERVER_OPNUM, TSPROXY_SETUP_RECEIVE_PIPE_OPNUM, TsProxyAuthorizeTunnelRequest,
+    TsProxyCreateChannelRequest, TsProxyCreateTunnelRequest, TsProxyCreateTunnelResponse, TsProxyMakeTunnelCallRequest,
+    TsProxySendToServerRequest, TsProxySetupReceivePipeRequest, TsProxyTunnelMessage, decode_rpc_response_fragment,
+    decode_rpc_response_fragment_with_ntlm_auth, decode_rts_flow_control_ack, decode_rts_ping,
+    decode_tsgu_authorize_tunnel_response, decode_tsgu_bind_ack, decode_tsgu_bind_ack_with_ntlm_auth,
+    decode_tsgu_create_channel_response, decode_tsgu_create_tunnel_response, decode_tsgu_make_tunnel_call_response,
+    encode_rpc_auth_3, encode_rpc_request_fragments, encode_rpc_request_fragments_with_ntlm_auth,
+    encode_rts_flow_control_ack, encode_rts_ping, encode_tsgu_bind, encode_tsgu_bind_with_ntlm_auth,
+};
+use crate::rpc_transport::{
+    RpchInRequest, RpchRequestHead, drain_body, read_rpch_response_head, write_rpch_request_head,
+};
+use crate::{Error, GwConnectTarget, GwErrorKind};
+
+/// DCE/RPC common header size prefixing every PDU on the wire.
+const RPC_COMMON_HEADER: usize = 16;
+
+/// Maximum accepted PDU size on the OUT channel.
+const MAX_OUT_PDU: usize = 1024 * 1024;
+
+/// Maximum reassembled response stub size ([MS-RPCE] stub sanity bound).
+const MAX_RESPONSE_STUB: usize = 32_767;
+
+const PTYPE_RESPONSE: u8 = 2;
+const PTYPE_FAULT: u8 = 3;
+const PTYPE_RTS: u8 = 20;
+
+/// TsProxy capability bits advertised in `TsProxyCreateTunnel` ([MS-TSGU] 2.2.9.2.1.1).
+const TSG_CAPS: u32 = 0x1 /* quarantine SoH */
+    | 0x2 /* idle timeout */
+    | 0x4 /* consent message */
+    | 0x8 /* service message */
+    | 0x10 /* reauthentication */;
+
+/// An established RPCH session: RTS CONN sequence complete and the TsProxy
+/// interface bound. Drives TsProxy calls and the RDP data plane.
+pub(crate) struct RpchSession<S> {
+    out: OutChannel<S>,
+    input: RpchInRequest<S>,
+    flow_control: RpcHttpV2FlowControl,
+    ping: RpcHttpV2PingSchedule,
+    fragment_sizes: RpcFragmentSizes,
+    rpc_auth: Option<RpcNtlmAuth>,
+    /// Signature sequence number for PDUs written to the IN channel.
+    send_sequence: u32,
+    /// Signature sequence number for PDUs read from the OUT channel.
+    receive_sequence: u32,
+    responses: RpcResponseReassembler,
+    call_id: u32,
+    /// Call ID of the pending asynchronous administrative-message request.
+    tunnel_message_call_id: Option<u32>,
+    /// Call ID of `TsProxySetupReceivePipe`, whose streaming responses carry target-server
+    /// data once the tunnel is up ([MS-TSGU] 3.2.6.2.3).
+    receive_pipe_call_id: Option<u32>,
+    /// Administrative messages received while a TsProxy call was in flight.
+    messages: std::collections::VecDeque<TsProxyTunnelMessage>,
+    tunnel_context: Option<NonNullRpcContextHandle>,
+    channel_context: Option<NonNullRpcContextHandle>,
+}
+
+/// Open the RPCH session over two already-connected streams to the RPC proxy.
+///
+/// `out_stream` carries `RPC_OUT_DATA` (server→client PDUs) and `in_stream` carries
+/// `RPC_IN_DATA` (client→server PDUs). Production callers pass separate TLS streams.
+/// `rpc_auth` enables NTLM packet integrity; the mock server path leaves it `None`.
+#[expect(clippy::too_many_lines, reason = "linear channel and RTS setup sequence")]
+pub(crate) async fn rpch_connect<S>(
+    mut out_stream: S,
+    in_stream: S,
+    gateway_host: &str,
+    target: &GwConnectTarget,
+    settings: RpcHttpV2Settings,
+    rpc_auth: Option<RpcNtlmAuth>,
+) -> Result<RpchSession<S>, Error>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    // The HTTP-level SessionId on the OUT channel must equal the RTS association group id
+    // carried in the IN channel's CONN/B1, or the gateway cannot pair the channels. The
+    // cookie crosses the wire in little-endian GUID form ([MS-RPCH] 2.2.4.3).
+    let association_group_id = Uuid::new_v4();
+    let session_id = association_group_id.to_string();
+    let mut setup = RpcHttpV2Setup::with_cookies(
+        settings,
+        RtsCookie::new(*Uuid::new_v4().as_bytes()),
+        RtsCookie::new(*Uuid::new_v4().as_bytes()),
+        RtsCookie::new(*Uuid::new_v4().as_bytes()),
+        RtsCookie::new(association_group_id.to_bytes_le()),
+    );
+    let mut http_auth: Option<GatewayHttpAuth> = None;
+    let mut authorization: Option<String> = None;
+    let proxy_target = rpc_proxy_target(target);
+    let spn = format!("HTTP/{gateway_host}");
+
+    // Generate both connection PDUs up front; the wire order below sends CONN/B1 on the
+    // IN channel before CONN/A1 on the OUT channel, matching mstsc ([MS-RPCH] 3.2.2.2).
+    debug!("RPCH connect: opening channels to {proxy_target} via {gateway_host}");
+    setup
+        .start_in_request()
+        .map_err(|e| custom_err!("rpch out request state", e))?;
+    let out_body = setup
+        .out_request_body()
+        .map_err(|e| custom_err!("rpch CONN/A1 encode", e))?;
+    let in_content_length = setup.in_channel_content_length();
+    let initial_pdu = setup
+        .in_request_initial_pdu()
+        .map_err(|e| custom_err!("rpch CONN/B1 encode", e))?;
+    let out_content_length =
+        u32::try_from(out_body.len()).map_err(|_| Error::new("rpch out body length", GwErrorKind::Encode))?;
+    const MAX_AUTH_ROUNDS: usize = 8;
+
+    // IN channel first: the gateway pairs the channels before answering the OUT channel.
+    // Authentication probes carry no body (Content-Length: 0); the streaming body is
+    // committed only on the request that answers the challenge, matching mstsc.
+    // NTLM tokens are bound to their connection, so the IN channel authenticates
+    // independently on its own connection.
+    debug!("RPCH connect: opening IN channel");
+    let mut in_auth: Option<GatewayHttpAuth> = None;
+    let mut in_authorization: Option<String> = None;
+    let mut input = RpchInRequest::open(in_stream, gateway_host, &proxy_target, None).await?;
+    let mut in_rounds = 0;
+    let mut input = loop {
+        in_rounds += 1;
+        if in_rounds > MAX_AUTH_ROUNDS {
+            return Err(Error::new("rpch in auth rounds exceeded", GwErrorKind::Connect));
+        }
+        let response = input
+            .receive_response()
+            .await
+            .map_err(|e| custom_err!("rpch in response", e))?;
+        debug!("RPCH IN channel: response status {}", response.status);
+        match response.status {
+            401 => {
+                let final_round = challenge_has_token(&response.www_authenticate);
+                in_authorization = Some(step_gateway_auth(
+                    &mut in_auth,
+                    target,
+                    &spn,
+                    in_authorization.as_deref(),
+                    &response.www_authenticate,
+                )?);
+                let content_length = if final_round { in_content_length } else { 0 };
+                input = input
+                    .retry(in_authorization.as_deref(), content_length)
+                    .await
+                    .map_err(|e| custom_err!("rpch in retry", e))?;
+                if final_round {
+                    break input;
+                }
+            }
+            // A gateway that accepts the probe without authentication still needs the real
+            // request carrying the channel-lifetime length before the body is written.
+            200 => {
+                input = input
+                    .retry(None, in_content_length)
+                    .await
+                    .map_err(|e| custom_err!("rpch in retry", e))?;
+                break input;
+            }
+            status => {
+                return Err(Error::new("rpch in channel rejected", GwErrorKind::HttpStatus(status)));
+            }
+        }
+    };
+    input
+        .write_body(&initial_pdu)
+        .await
+        .map_err(|e| custom_err!("rpch CONN/B1", e))?;
+    // Ensure CONN/B1 reaches the gateway before the OUT channel's CONN/A1 so the virtual
+    // connection can be paired.
+    input.flush().await.map_err(|e| custom_err!("rpch CONN/B1 flush", e))?;
+
+    // OUT channel: CONN/A1 body is small and buffered, so committing it on the final
+    // authenticated request is safe. The 200 response streams the server-to-client PDUs.
+    debug!("RPCH connect: IN channel streaming; opening OUT channel");
+    let mut commit_body = false;
+    let mut out_rounds = 0;
+    let out_response = loop {
+        out_rounds += 1;
+        if out_rounds > MAX_AUTH_ROUNDS {
+            return Err(Error::new("rpch out auth rounds exceeded", GwErrorKind::Connect));
+        }
+        let content_length = if commit_body { out_content_length } else { 0 };
+        write_rpch_request_head(
+            &mut out_stream,
+            RpchRequestHead {
+                method: "RPC_OUT_DATA",
+                host: gateway_host,
+                target: &proxy_target,
+                content_length,
+                authorization: authorization.as_deref(),
+                cookie: None,
+                session_id: Some(&session_id),
+                expect_continue: false,
+            },
+        )
+        .await?;
+        if commit_body {
+            out_stream
+                .write_all(&out_body)
+                .await
+                .map_err(|e| custom_err!("rpch out body", e))?;
+        }
+        out_stream.flush().await.map_err(|e| custom_err!("rpch out flush", e))?;
+
+        let response = read_rpch_response_head(&mut out_stream).await?;
+        debug!("RPCH OUT response status {}", response.status);
+        if response.status == 200 && !commit_body {
+            // The gateway accepted the request without authentication; the probe carried
+            // no body, so reissue the request committing CONN/A1.
+            commit_body = true;
+            continue;
+        }
+        if response.status == 401 {
+            // The 401 carries an error body that must be drained before the request is
+            // retried on this connection.
+            if let Some(length) = response.content_length {
+                drain_body(&mut out_stream, length)
+                    .await
+                    .map_err(|e| custom_err!("drain rpch out 401 body", e))?;
+            }
+            // A challenge bearing a token (the NTLM type-2) is answered with the final
+            // type-3; that request commits the body.
+            commit_body = challenge_has_token(&response.www_authenticate);
+            authorization = Some(step_gateway_auth(
+                &mut http_auth,
+                target,
+                &spn,
+                authorization.as_deref(),
+                &response.www_authenticate,
+            )?);
+            continue;
+        }
+        break response;
+    };
+
+    setup
+        .accept_out_response(
+            out_response.status,
+            out_response.content_type.as_deref(),
+            out_response.content_length,
+        )
+        .map_err(|e| custom_err!("rpch out response", e))?;
+
+    // CONN/A3 then CONN/C2 arrive on the OUT channel body. The gateway may interleave
+    // flow-control or ping RTS PDUs, which are not part of the handshake and are skipped.
+    debug!("RPCH connect: IN channel gated; awaiting CONN/A3 + CONN/C2");
+    let mut out = OutChannel::new(out_stream);
+    while setup.state() != RpcHttpV2State::Open {
+        let pdu = out.read_pdu().await?;
+        // Skip flow-control acknowledgements and pings that arrive before the handshake
+        // completes; they carry no setup state.
+        if decode_rts_flow_control_ack(&pdu).is_ok() || decode_rts_ping(&pdu).is_ok() {
+            debug!("RPCH connect: skipping a flow-control/ping RTS PDU during setup");
+            continue;
+        }
+        setup
+            .receive_out_pdu(&pdu)
+            .map_err(|e| custom_err!("rpch setup pdu", e))?;
+    }
+    debug!("RPCH connect: CONN sequence complete; binding TsProxy interface");
+
+    let flow_control = setup.flow_control().map_err(|e| custom_err!("rpch flow control", e))?;
+    let ping = setup
+        .ping_schedule(Duration::ZERO)
+        .map_err(|e| custom_err!("rpch ping schedule", e))?;
+
+    let mut session = RpchSession {
+        out,
+        input,
+        flow_control,
+        ping,
+        fragment_sizes: RpcFragmentSizes::DEFAULT,
+        rpc_auth,
+        send_sequence: 0,
+        receive_sequence: 0,
+        responses: RpcResponseReassembler::new(MAX_RESPONSE_STUB),
+        call_id: 0,
+        tunnel_message_call_id: None,
+        receive_pipe_call_id: None,
+        messages: std::collections::VecDeque::new(),
+        tunnel_context: None,
+        channel_context: None,
+    };
+    session.bind().await?;
+    Ok(session)
+}
+
+impl<S> RpchSession<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    /// Runs the TsProxy tunnel/channel setup sequence ([MS-TSGU] 3.2.6.1).
+    pub(crate) async fn open_tunnel(&mut self, client_name: &str, resource: &str, port: u16) -> Result<(), Error> {
+        // TsProxyCreateTunnel.
+        let request = TsProxyCreateTunnelRequest::new(TSG_CAPS).encode();
+        let stub = self.call(TSPROXY_CREATE_TUNNEL_OPNUM, &request).await?;
+        let tunnel: TsProxyCreateTunnelResponse =
+            decode_tsgu_create_tunnel_response(&stub).map_err(|e| custom_err!("decode create tunnel", e))?;
+        self.tunnel_context = Some(tunnel.tunnel_context);
+        debug!("RPCH tunnel created (id {})", tunnel.tunnel_id);
+
+        // TsProxyAuthorizeTunnel with an empty statement of health (NAP not enforced).
+        let request = TsProxyAuthorizeTunnelRequest::new(tunnel.tunnel_context, client_name, &[])
+            .encode()
+            .map_err(|e| custom_err!("encode authorize tunnel", e))?;
+        let stub = self.call(TSPROXY_AUTHORIZE_TUNNEL_OPNUM, &request).await?;
+        decode_tsgu_authorize_tunnel_response(&stub).map_err(|e| custom_err!("decode authorize tunnel", e))?;
+
+        // Queue the asynchronous administrative-message call ([MS-TSGU] 3.2.6.1.3).
+        let request = TsProxyMakeTunnelCallRequest::new(tunnel.tunnel_context).encode();
+        let call_id = self.next_call_id();
+        self.send_call(call_id, TSPROXY_MAKE_TUNNEL_CALL_OPNUM, &request)
+            .await?;
+        self.tunnel_message_call_id = Some(call_id);
+
+        // TsProxyCreateChannel for the target resource.
+        let request = TsProxyCreateChannelRequest::new(tunnel.tunnel_context, resource, port)
+            .encode()
+            .map_err(|e| custom_err!("encode create channel", e))?;
+        let stub = self.call(TSPROXY_CREATE_CHANNEL_OPNUM, &request).await?;
+        let channel =
+            decode_tsgu_create_channel_response(&stub).map_err(|e| custom_err!("decode create channel", e))?;
+        self.channel_context = Some(channel.channel_context);
+        debug!("RPCH channel created (id {})", channel.channel_id);
+
+        // TsProxySetupReceivePipe switches the OUT channel to target-server data. The
+        // server streams the RDP byte stream as response fragments on this call; its
+        // return value is sent only as the final fragment when the pipe closes
+        // ([MS-TSGU] 3.2.6.2.3). Do not wait for a response here: on success there is no
+        // discrete reply, so read_data surfaces the data and any terminal error.
+        let mut request = [0u8; TsProxySetupReceivePipeRequest::SIZE];
+        TsProxySetupReceivePipeRequest::new(channel.channel_context)
+            .encode_into(&mut request)
+            .map_err(|e| custom_err!("encode setup receive pipe", e))?;
+        let call_id = self.next_call_id();
+        self.send_call(call_id, TSPROXY_SETUP_RECEIVE_PIPE_OPNUM, &request)
+            .await?;
+        self.receive_pipe_call_id = Some(call_id);
+        Ok(())
+    }
+
+    /// Sends target-server-bound bytes through `TsProxySendToServer` ([MS-TSGU] 3.2.6.2.1).
+    pub(crate) async fn send_to_server(&mut self, data: &[u8]) -> Result<(), Error> {
+        let channel_context = self
+            .channel_context
+            .ok_or_else(|| Error::new("rpch send before channel create", GwErrorKind::Connect))?;
+        let request =
+            TsProxySendToServerRequest::new(channel_context, data).map_err(|e| custom_err!("send to server", e))?;
+        let stub = request.encode().map_err(|e| custom_err!("send to server", e))?;
+        let call_id = self.next_call_id();
+        self.send_call(call_id, TSPROXY_SEND_TO_SERVER_OPNUM, &stub).await
+    }
+
+    /// Reads the next event from the OUT channel.
+    ///
+    /// After `TsProxySetupReceivePipe`, response stubs on the OUT channel carry raw
+    /// target-server bytes. RTS control PDUs (pings, flow-control acknowledgements)
+    /// are handled internally, as are administrative tunnel messages.
+    pub(crate) async fn read_data(&mut self) -> Result<RpchRead, Error> {
+        if let Some(message) = self.messages.pop_front() {
+            return Ok(RpchRead::Message(message));
+        }
+        loop {
+            let pdu = self.out.read_pdu().await?;
+            self.flow_control
+                .received_rpc_pdu(pdu.len())
+                .map_err(|e| custom_err!("rpch receive window", e))?;
+
+            match pdu.get(2).copied() {
+                Some(PTYPE_RTS) => {
+                    self.handle_rts_pdu(&pdu).await?;
+                }
+                Some(PTYPE_FAULT) => {
+                    return Err(Error::new("rpc fault on receive pipe", GwErrorKind::Connect));
+                }
+                Some(PTYPE_RESPONSE) => {
+                    let response = self.decode_response(&pdu)?;
+                    // The pending make-tunnel-call completes with administrative messages.
+                    if self.tunnel_message_call_id == Some(response.call_id) {
+                        self.tunnel_message_call_id = None;
+                        let stub = response.stub.to_vec();
+                        self.consume_out_pdu(pdu.len()).await?;
+                        self.handle_tunnel_message(&stub).await?;
+                        if let Some(message) = self.messages.pop_front() {
+                            return Ok(RpchRead::Message(message));
+                        }
+                        continue;
+                    }
+                    if self.receive_pipe_call_id == Some(response.call_id) {
+                        // The receive pipe's final fragment carries only the 4-byte return
+                        // value; a non-zero value is a gateway error ([MS-TSGU] 3.2.6.2.3).
+                        // All other fragments on this call are the target-server byte stream.
+                        if response.is_last_fragment() && response.stub.len() == 4 {
+                            let result = crate::rpc::parse_receive_pipe_final_return_value_stub(
+                                response.stub,
+                                crate::rpc::RpcStubByteOrder::LittleEndian,
+                            )
+                            .map_err(|e| custom_err!("decode receive pipe result", e))?;
+                            if result != 0 {
+                                return Err(Error::new("receive pipe failed", GwErrorKind::GatewayCode(result)));
+                            }
+                            return Err(Error::new("receive pipe closed", GwErrorKind::Connect));
+                        }
+                        self.consume_out_pdu(pdu.len()).await?;
+                        return Ok(RpchRead::Data(Bytes::copy_from_slice(response.stub)));
+                    }
+                    // A response on any other call (such as a TsProxySendToServer
+                    // acknowledgement) carries a 4-byte return value; surface a non-zero
+                    // code and otherwise ignore it so it is not mistaken for target data.
+                    if response.is_last_fragment() && response.stub.len() == 4 {
+                        let result = crate::rpc::parse_receive_pipe_final_return_value_stub(
+                            response.stub,
+                            crate::rpc::RpcStubByteOrder::LittleEndian,
+                        )
+                        .map_err(|e| custom_err!("decode rpc call result", e))?;
+                        self.consume_out_pdu(pdu.len()).await?;
+                        if result != 0 {
+                            return Err(Error::new("rpc call failed", GwErrorKind::GatewayCode(result)));
+                        }
+                        continue;
+                    }
+                    self.consume_out_pdu(pdu.len()).await?;
+                    continue;
+                }
+                _ => {
+                    return Err(Error::new("unexpected rpch out pdu", GwErrorKind::UnexpectedPacket));
+                }
+            }
+        }
+    }
+
+    /// Returns whether a PING must be sent now ([MS-RPCH] 3.2.1.2.1).
+    pub(crate) fn ping_due(&self, now: Duration) -> bool {
+        self.ping.ping_due(now)
+    }
+
+    /// Sends a PING on the IN channel.
+    pub(crate) async fn send_ping(&mut self, now: Duration) -> Result<(), Error> {
+        let pdu = encode_rts_ping().map_err(|e| custom_err!("encode rpch ping", e))?;
+        self.write_in(&pdu).await?;
+        self.ping.record_send(now);
+        Ok(())
+    }
+
+    /// DCE/RPC bind of the TsProxy interface, with optional NTLM packet integrity.
+    async fn bind(&mut self) -> Result<(), Error> {
+        let call_id = self.next_call_id();
+        // Take the auth state out so the NTLM leg and channel writes can both borrow self.
+        match self.rpc_auth.take() {
+            Some(mut auth) => {
+                let type1 = auth.initial_token()?;
+                let bind = encode_tsgu_bind_with_ntlm_auth(call_id, self.fragment_sizes, &type1)
+                    .map_err(|e| custom_err!("encode authenticated bind", e))?;
+                self.write_in(&bind).await?;
+
+                let ack_pdu = self.out.read_pdu().await?;
+                let ack = decode_tsgu_bind_ack_with_ntlm_auth(&ack_pdu, self.fragment_sizes)
+                    .map_err(|e| custom_err!("decode bind ack", e))?;
+                let type3 = auth.continue_token(ack.token())?;
+                let auth3 = encode_rpc_auth_3(call_id, self.fragment_sizes, &type3)
+                    .map_err(|e| custom_err!("encode rpc auth3", e))?;
+                self.write_in(&auth3).await?;
+                self.fragment_sizes = ack.binding().fragment_sizes();
+                self.rpc_auth = Some(auth);
+            }
+            None => {
+                let bind = encode_tsgu_bind(call_id, self.fragment_sizes).map_err(|e| custom_err!("encode bind", e))?;
+                self.write_in(&bind).await?;
+
+                let ack_pdu = self.out.read_pdu().await?;
+                let binding = decode_tsgu_bind_ack(&ack_pdu, self.fragment_sizes)
+                    .map_err(|e| custom_err!("decode bind ack", e))?;
+                self.fragment_sizes = binding.fragment_sizes();
+            }
+        }
+        Ok(())
+    }
+
+    /// Drives one synchronous TsProxy call and returns the reassembled response stub.
+    async fn call(&mut self, opnum: u16, stub: &[u8]) -> Result<Vec<u8>, Error> {
+        let call_id = self.next_call_id();
+        self.send_call(call_id, opnum, stub).await?;
+        self.receive_response(call_id).await
+    }
+
+    /// Reads and reassembles the response for an already-sent call.
+    async fn receive_response(&mut self, call_id: u32) -> Result<Vec<u8>, Error> {
+        loop {
+            let pdu = self.out.read_pdu().await?;
+            self.flow_control
+                .received_rpc_pdu(pdu.len())
+                .map_err(|e| custom_err!("rpch receive window", e))?;
+
+            match pdu.get(2).copied() {
+                Some(PTYPE_RTS) => self.handle_rts_pdu(&pdu).await?,
+                Some(PTYPE_FAULT) => {
+                    let fault_call_id = pdu.get(12..16).map(|b| u32::from_le_bytes([b[0], b[1], b[2], b[3]]));
+                    if fault_call_id.is_some() && fault_call_id == self.tunnel_message_call_id {
+                        // The asynchronous administrative-message call faulted; the main
+                        // channel flow can proceed without it.
+                        warn!("RPCH asynchronous tunnel-message call faulted");
+                        self.tunnel_message_call_id = None;
+                        self.consume_out_pdu(pdu.len()).await?;
+                        continue;
+                    }
+                    return Err(Error::new("rpc fault in tsproxy call", GwErrorKind::Connect));
+                }
+                Some(PTYPE_RESPONSE) => {
+                    let response = self.decode_response(&pdu)?;
+                    let pushed = self
+                        .responses
+                        .push(response)
+                        .map_err(|e| custom_err!("reassemble rpc response", e))?;
+                    if let Some(assembled) = pushed {
+                        if self.tunnel_message_call_id == Some(assembled.call_id) {
+                            // An administrative message completed the pending tunnel call;
+                            // log it and queue the next pending call ([MS-TSGU] 3.2.6.1.3).
+                            self.tunnel_message_call_id = None;
+                            self.handle_tunnel_message(&assembled.stub).await?;
+                            self.consume_out_pdu(pdu.len()).await?;
+                            continue;
+                        }
+                        if assembled.call_id != call_id {
+                            return Err(Error::new("tsproxy response call id", GwErrorKind::UnexpectedPacket));
+                        }
+                        self.consume_out_pdu(pdu.len()).await?;
+                        return Ok(assembled.stub);
+                    }
+                }
+                _ => return Err(Error::new("unexpected rpch out pdu", GwErrorKind::UnexpectedPacket)),
+            }
+        }
+    }
+
+    /// Decodes one response PDU, verifying the NTLM signature when bound with auth.
+    fn decode_response<'a>(&mut self, pdu: &'a [u8]) -> Result<crate::rpc::RpcResponse<'a>, Error> {
+        match self.rpc_auth.as_mut() {
+            Some(auth) => {
+                let response = decode_rpc_response_fragment_with_ntlm_auth(
+                    auth,
+                    self.receive_sequence,
+                    pdu,
+                    self.fragment_sizes.max_recv(),
+                )?;
+                self.receive_sequence = self.receive_sequence.wrapping_add(1);
+                Ok(response)
+            }
+            None => decode_rpc_response_fragment(pdu, self.fragment_sizes.max_recv())
+                .map_err(|e| custom_err!("decode rpc response", e)),
+        }
+    }
+
+    async fn send_call(&mut self, call_id: u32, opnum: u16, stub: &[u8]) -> Result<(), Error> {
+        let fragments = match self.rpc_auth.as_mut() {
+            Some(auth) => encode_rpc_request_fragments_with_ntlm_auth(
+                auth,
+                &mut self.send_sequence,
+                call_id,
+                opnum,
+                stub,
+                self.fragment_sizes,
+            )?,
+            None => encode_rpc_request_fragments(call_id, opnum, stub, self.fragment_sizes)
+                .map_err(|e| custom_err!("encode rpc request", e))?,
+        };
+        for fragment in fragments {
+            self.write_in(&fragment).await?;
+        }
+        Ok(())
+    }
+
+    /// Decodes one administrative tunnel message, queues it for [`Self::read_data`],
+    /// and re-queues the pending call ([MS-TSGU] 3.2.6.1.3).
+    async fn handle_tunnel_message(&mut self, stub: &[u8]) -> Result<(), Error> {
+        let message =
+            decode_tsgu_make_tunnel_call_response(stub).map_err(|e| custom_err!("decode tunnel message", e))?;
+        match message {
+            TsProxyTunnelMessage::None => {}
+            message => {
+                if matches!(message, TsProxyTunnelMessage::Reauthenticate { .. }) {
+                    return Err(Error::new(
+                        "rpch reauthentication is not supported on this transport",
+                        GwErrorKind::UnsupportedFeature,
+                    ));
+                }
+                self.messages.push_back(message);
+            }
+        }
+
+        // Re-queue the pending administrative-message call when a tunnel exists.
+        if let Some(tunnel_context) = self.tunnel_context {
+            let request = TsProxyMakeTunnelCallRequest::new(tunnel_context).encode();
+            let call_id = self.next_call_id();
+            self.send_call(call_id, TSPROXY_MAKE_TUNNEL_CALL_OPNUM, &request)
+                .await?;
+            self.tunnel_message_call_id = Some(call_id);
+        }
+        Ok(())
+    }
+
+    /// Handles an RTS PDU from the OUT channel (flow-control acks, pings).
+    async fn handle_rts_pdu(&mut self, pdu: &[u8]) -> Result<(), Error> {
+        // Ping PDUs are a no-op keepalive from the proxy.
+        if decode_rts_ping(pdu).is_ok() {
+            return Ok(());
+        }
+        match decode_rts_flow_control_ack(pdu) {
+            Ok(ack) => {
+                self.flow_control
+                    .receive_flow_control_ack(ack)
+                    .map_err(|e| custom_err!("rpch flow-control ack", e))?;
+                Ok(())
+            }
+            Err(_) => {
+                warn!("unhandled RTS PDU on RPCH OUT channel");
+                Ok(())
+            }
+        }
+    }
+
+    /// Releases an OUT-channel PDU from the receive window, sending a flow-control
+    /// acknowledgement when enough capacity has been reclaimed ([MS-RPCH] 3.2.1.5.1).
+    async fn consume_out_pdu(&mut self, pdu_len: usize) -> Result<(), Error> {
+        if let Some(ack) = self
+            .flow_control
+            .consumed_rpc_pdu(pdu_len)
+            .map_err(|e| custom_err!("rpch receive accounting", e))?
+        {
+            let pdu = encode_rts_flow_control_ack(ack).map_err(|e| custom_err!("encode flow-control ack", e))?;
+            self.write_in(&pdu).await?;
+        }
+        Ok(())
+    }
+
+    /// Writes one PDU to the IN channel with send-window accounting.
+    async fn write_in(&mut self, pdu: &[u8]) -> Result<(), Error> {
+        self.flow_control
+            .sent_rpc_pdu(pdu.len())
+            .map_err(|e| custom_err!("rpch send window", e))?;
+        self.input
+            .write_body(pdu)
+            .await
+            .map_err(|e| custom_err!("rpch in write", e))?;
+        self.ping.record_send(Duration::ZERO);
+        Ok(())
+    }
+
+    fn next_call_id(&mut self) -> u32 {
+        self.call_id = self.call_id.wrapping_add(1);
+        self.call_id
+    }
+}
+
+/// One event read from the RPCH OUT channel.
+#[derive(Debug)]
+pub(crate) enum RpchRead {
+    /// Target-server bytes from the receive pipe.
+    Data(Bytes),
+    /// An administrative tunnel message (consent, service, reauthentication).
+    Message(TsProxyTunnelMessage),
+}
+
+/// Drives an RPCH session over a byte channel, surfacing it as an `AsyncRead`/`AsyncWrite` stream.
+///
+/// `read_data` consumes the OUT channel, `send_to_server` produces IN-channel PDUs.
+/// A background task bridges them so the returned value can be polled like a socket.
+pub struct RpchStream {
+    work: tokio::task::JoinHandle<Result<(), Error>>,
+    /// Set once the work task has completed; its `JoinHandle` must not be polled again
+    /// (tokio panics if a completed `JoinHandle` is polled).
+    work_done: bool,
+    rx: tokio::sync::mpsc::Receiver<Bytes>,
+    rx_bufs: Vec<Bytes>,
+    tx: tokio_util::sync::PollSender<Bytes>,
+}
+
+impl RpchStream {
+    pub(crate) fn new<S>(mut session: RpchSession<S>) -> Self
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
+        let (in_tx, in_rx) = tokio::sync::mpsc::channel::<Bytes>(4);
+        let (out_tx, mut out_rx) = tokio::sync::mpsc::channel::<Bytes>(4);
+
+        let work = tokio::spawn(async move {
+            loop {
+                tokio::select!(
+                    read = session.read_data() => {
+                        match read {
+                            Ok(RpchRead::Data(data)) => {
+                                in_tx.send(data).await.map_err(|e| custom_err!("forward rpch data", e))?;
+                            }
+                            Ok(RpchRead::Message(message)) => {
+                                warn!("RPCH administrative message: {message:?}");
+                            }
+                            Err(e) => {
+                                error!("RPCH receive pipe failed: {e:#}");
+                                return Err(e);
+                            }
+                        }
+                    },
+                    next = out_rx.recv() => {
+                        let next = next.ok_or_else(|| Error::new("rpch write channel closed", GwErrorKind::Connect))?;
+                        if let Err(e) = session.send_to_server(&next).await {
+                            error!("RPCH send to server failed: {e:#}");
+                            return Err(e);
+                        }
+                    }
+                );
+            }
+        });
+
+        Self {
+            work,
+            work_done: false,
+            rx: in_rx,
+            rx_bufs: Vec::new(),
+            tx: tokio_util::sync::PollSender::new(out_tx),
+        }
+    }
+}
+
+impl AsyncRead for RpchStream {
+    fn poll_read(
+        mut self: core::pin::Pin<&mut Self>,
+        cx: &mut core::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> core::task::Poll<std::io::Result<()>> {
+        if !self.work_done {
+            match self.work.poll_unpin(cx) {
+                core::task::Poll::Ready(Err(e)) => {
+                    self.work_done = true;
+                    return core::task::Poll::Ready(Err(std::io::Error::other(e)));
+                }
+                core::task::Poll::Ready(Ok(Err(e))) => {
+                    self.work_done = true;
+                    return core::task::Poll::Ready(Err(std::io::Error::other(e.to_string())));
+                }
+                core::task::Poll::Ready(Ok(Ok(()))) => {
+                    self.work_done = true;
+                }
+                core::task::Poll::Pending => (),
+            }
+        }
+
+        if let core::task::Poll::Ready(Some(new_buf)) = self.rx.poll_recv(cx) {
+            self.rx_bufs.push(new_buf);
+        }
+
+        let mut n = 0;
+        self.rx_bufs.retain_mut(|rx_buf| {
+            let rem = buf.remaining();
+            if rem == 0 {
+                return true;
+            }
+            let max = core::cmp::min(rem, rx_buf.len());
+            buf.put_slice(&rx_buf[..max]);
+            n += max;
+            let _ = rx_buf.split_to(max);
+            !rx_buf.is_empty()
+        });
+
+        if n > 0 {
+            return core::task::Poll::Ready(Ok(()));
+        }
+        if self.work_done {
+            // The work task ended and no data is buffered: the gateway stream is closed.
+            return core::task::Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "rpch tunnel closed",
+            )));
+        }
+        core::task::Poll::Pending
+    }
+}
+
+impl AsyncWrite for RpchStream {
+    fn poll_write(
+        mut self: core::pin::Pin<&mut Self>,
+        cx: &mut core::task::Context<'_>,
+        buf: &[u8],
+    ) -> core::task::Poll<Result<usize, std::io::Error>> {
+        if !self.work_done {
+            match self.work.poll_unpin(cx) {
+                core::task::Poll::Ready(Err(e)) => {
+                    self.work_done = true;
+                    return core::task::Poll::Ready(Err(std::io::Error::other(e)));
+                }
+                core::task::Poll::Ready(Ok(Err(e))) => {
+                    self.work_done = true;
+                    return core::task::Poll::Ready(Err(std::io::Error::other(e.to_string())));
+                }
+                core::task::Poll::Ready(Ok(Ok(()))) => {
+                    self.work_done = true;
+                }
+                core::task::Poll::Pending => (),
+            }
+        }
+
+        match self.tx.poll_reserve(cx) {
+            core::task::Poll::Ready(Ok(())) => {
+                if self.tx.send_item(Bytes::from(buf.to_vec())).is_err() {
+                    return core::task::Poll::Ready(Err(std::io::Error::other("Sender closed")));
+                }
+                core::task::Poll::Ready(Ok(buf.len()))
+            }
+            core::task::Poll::Ready(Err(err)) => core::task::Poll::Ready(Err(std::io::Error::other(err))),
+            core::task::Poll::Pending => core::task::Poll::Pending,
+        }
+    }
+
+    fn poll_flush(
+        self: core::pin::Pin<&mut Self>,
+        _cx: &mut core::task::Context<'_>,
+    ) -> core::task::Poll<Result<(), std::io::Error>> {
+        core::task::Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(
+        mut self: core::pin::Pin<&mut Self>,
+        _cx: &mut core::task::Context<'_>,
+    ) -> core::task::Poll<Result<(), std::io::Error>> {
+        self.tx.close();
+        core::task::Poll::Ready(Ok(()))
+    }
+}
+
+/// Streaming reader for DCE/RPC PDUs on the RPC_OUT_DATA response body.
+struct OutChannel<S> {
+    stream: S,
+    buf: Vec<u8>,
+}
+
+impl<S> OutChannel<S>
+where
+    S: AsyncRead + Unpin,
+{
+    fn new(stream: S) -> Self {
+        Self {
+            stream,
+            buf: Vec::new(),
+        }
+    }
+
+    /// Reads one complete PDU, framed by the common header fragment length.
+    async fn read_pdu(&mut self) -> Result<Vec<u8>, Error> {
+        loop {
+            if self.buf.len() >= RPC_COMMON_HEADER {
+                let fragment_length = usize::from(u16::from_le_bytes(
+                    self.buf[8..10].try_into().expect("fragment length slice"),
+                ));
+                if !(RPC_COMMON_HEADER..=MAX_OUT_PDU).contains(&fragment_length) {
+                    return Err(Error::new("rpch out pdu length", GwErrorKind::Decode));
+                }
+                if self.buf.len() >= fragment_length {
+                    return Ok(self.buf.drain(..fragment_length).collect());
+                }
+            }
+            let mut chunk = [0u8; 8192];
+            let read = match self.stream.read(&mut chunk).await {
+                Ok(n) => n,
+                // RD Gateways end the streaming OUT channel with a bare TCP FIN and skip the
+                // TLS close_notify, which rustls reports as UnexpectedEof; treat it as the
+                // end of the stream rather than a transport error.
+                Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => 0,
+                Err(e) => return Err(custom_err!("rpch out read", e)),
+            };
+            if read == 0 {
+                return Err(Error::new("rpch out stream closed", GwErrorKind::PacketEof));
+            }
+            self.buf.extend_from_slice(&chunk[..read]);
+        }
+    }
+}
+
+/// The `/rpc/rpcproxy.dll?<server>:<port>` target of RPCH requests ([MS-RPCH] 2.1.2.1.1).
+/// The RPC proxy request target is the gateway's own TS Proxy RPC endpoint, not the RDP
+/// resource — the resource is named later by `TsProxyCreateChannel` ([MS-RPCH] 2.1.3.1,
+/// [MS-TSGU] 3.2.6.1). The TS Proxy service listens on the gateway loopback at 3388.
+fn rpc_proxy_target(_target: &GwConnectTarget) -> String {
+    "localhost:3388".to_owned()
+}
+
+/// Advances the gateway HTTP authentication state from a 401 challenge set and
+/// returns the `Authorization` header for the retry.
+/// Whether a 401 challenge set carries a token (the NTLM type-2 challenge) rather than
+/// bare scheme offers. Answering a token challenge produces the final type-3 token, whose
+/// request commits the streaming body ([MS-RPCH] 3.2.2.2).
+fn challenge_has_token(www_authenticate: &[String]) -> bool {
+    www_authenticate
+        .iter()
+        .any(|value| value.starts_with("Negotiate ") || value.starts_with("NTLM "))
+}
+
+fn step_gateway_auth(
+    http_auth: &mut Option<GatewayHttpAuth>,
+    target: &GwConnectTarget,
+    spn: &str,
+    current_authorization: Option<&str>,
+    www_authenticate: &[String],
+) -> Result<String, Error> {
+    let challenges: Vec<&str> = www_authenticate.iter().map(String::as_str).collect();
+    let step = if let Some(auth) = http_auth.as_mut() {
+        auth.step_www_authenticate(challenges)?
+    } else {
+        let (auth, step) = GatewayHttpAuth::from_challenges_ntlm_only(
+            &target.gw_user,
+            &target.gw_pass,
+            target.smart_card.as_deref(),
+            Some(spn.to_owned()),
+            &challenges,
+            true,
+        )?;
+        *http_auth = Some(auth);
+        step
+    };
+
+    match step {
+        AuthStep::Continue(header) => Ok(header),
+        // Basic retries the same replayable head, so it needs no gateway state.
+        AuthStep::TryBasic => Ok(crate::http_auth::basic_authorization(&target.gw_user, &target.gw_pass)),
+        AuthStep::Complete => match current_authorization {
+            Some(header) => Ok(header.to_owned()),
+            None => Err(Error::new("rpch auth completed without a token", GwErrorKind::Connect)),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mock_rpch::mock_rpch_proxy;
+
+    fn target() -> GwConnectTarget {
+        GwConnectTarget {
+            gw_endpoint: "rdg.contoso.com".to_owned(),
+            gw_user: "CONTOSO\\alice".to_owned(),
+            gw_pass: "secret".to_owned(),
+            server: "rdp.contoso.com".to_owned(),
+            server_port: 3389,
+            smart_card: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn rpch_session_runs_setup_and_echoes_data() {
+        let (out, input, proxy) = mock_rpch_proxy();
+        let settings = RpcHttpV2Settings::new(128 * 1024, 256 * 1024, 0).expect("valid settings");
+        let mut session = Box::pin(rpch_connect(out, input, "rdg.contoso.com", &target(), settings, None))
+            .await
+            .expect("rpch connect");
+
+        session
+            .open_tunnel("test-client", "rdp.contoso.com", 3389)
+            .await
+            .expect("open tunnel");
+
+        session.send_to_server(b"hello-rdp").await.expect("send");
+        match session.read_data().await.expect("read data") {
+            RpchRead::Data(data) => assert_eq!(&*data, b"hello-rdp"),
+            other => panic!("expected data, got {other:?}"),
+        }
+
+        drop(session);
+        proxy.abort();
+    }
+
+    #[tokio::test]
+    async fn rpch_session_reports_service_messages() {
+        let (out, input, proxy) = crate::mock_rpch::mock_rpch_proxy_with_service_message(Some("scheduled maintenance"));
+        let settings = RpcHttpV2Settings::new(128 * 1024, 256 * 1024, 0).expect("valid settings");
+        let mut session = Box::pin(rpch_connect(out, input, "rdg.contoso.com", &target(), settings, None))
+            .await
+            .expect("rpch connect");
+
+        session
+            .open_tunnel("test-client", "rdp.contoso.com", 3389)
+            .await
+            .expect("open tunnel");
+
+        match session.read_data().await.expect("read message") {
+            RpchRead::Message(TsProxyTunnelMessage::Service {
+                display_mandatory,
+                text,
+            }) => {
+                assert!(display_mandatory);
+                assert_eq!(text, "scheduled maintenance");
+            }
+            other => panic!("expected service message, got {other:?}"),
+        }
+
+        drop(session);
+        proxy.abort();
+    }
+
+    #[tokio::test]
+    async fn rpch_session_surfaces_receive_pipe_error() {
+        const E_PROXY_INTERNALERROR: u32 = 0x59d8;
+        let (out, input, proxy) = crate::mock_rpch::mock_rpch_proxy_with_receive_pipe_error(E_PROXY_INTERNALERROR);
+        let settings = RpcHttpV2Settings::new(128 * 1024, 256 * 1024, 0).expect("valid settings");
+        let mut session = Box::pin(rpch_connect(out, input, "rdg.contoso.com", &target(), settings, None))
+            .await
+            .expect("rpch connect");
+
+        // The receive pipe is fire-and-stream: open_tunnel returns without waiting, so the
+        // gateway's terminal error surfaces on the first read ([MS-TSGU] 3.2.6.2.3).
+        session
+            .open_tunnel("test-client", "rdp.contoso.com", 3389)
+            .await
+            .expect("open tunnel");
+
+        let err = session.read_data().await.expect_err("receive pipe error");
+        assert!(matches!(err.kind(), GwErrorKind::GatewayCode(code) if *code == E_PROXY_INTERNALERROR));
+
+        drop(session);
+        proxy.abort();
+    }
+
+    #[tokio::test]
+    async fn rpch_session_sends_ping_after_connection_timeout() {
+        let (out, input, proxy) = mock_rpch_proxy();
+        let settings = RpcHttpV2Settings::new(128 * 1024, 256 * 1024, 0).expect("valid settings");
+        let mut session = Box::pin(rpch_connect(out, input, "rdg.contoso.com", &target(), settings, None))
+            .await
+            .expect("rpch connect");
+
+        // The mock negotiated a 120-second connection timeout; nothing is due at t=0.
+        assert!(!session.ping_due(Duration::ZERO));
+        assert!(session.ping_due(Duration::from_secs(120)));
+        session.send_ping(Duration::from_secs(120)).await.expect("ping");
+        assert!(!session.ping_due(Duration::from_secs(120)));
+
+        drop(session);
+        proxy.abort();
+    }
+}

--- a/crates/ironrdp-mstsgu/src/udp.rs
+++ b/crates/ironrdp-mstsgu/src/udp.rs
@@ -1,0 +1,468 @@
+//! RDG-UDP packet layouts ([MS-TSGU] 2.2.5.4 / 2.2.11).
+//!
+//! Opening a live side channel still requires DTLS + MS-RDPEUDP; this module encodes and
+//! decodes the MS-TSGU UDP framing used after the main HTTP channel supplies a cookie.
+
+use ironrdp_core::{
+    Decode, Encode, ReadCursor, WriteCursor, cast_int, ensure_fixed_part_size, ensure_size, other_err,
+    unsupported_value_err,
+};
+
+/// Parameters from `HTTP_CHANNEL_RESPONSE` that enable a future RDG-UDP side channel.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GwUdpOffer {
+    /// UDP port on the gateway that accepts the side channel.
+    pub port: u16,
+    /// Opaque authentication cookie for [`CONNECT_PKT`](ConnectPkt).
+    pub authn_cookie: Vec<u8>,
+}
+
+/// [MS-TSGU] 2.2.5.4.1 `UdpPktType`.
+#[repr(u16)]
+#[derive(Eq, PartialEq, Copy, Clone, Debug)]
+pub enum UdpPktType {
+    ConnectReq = 1,
+    ConnectResp = 2,
+    Payload = 3,
+    Disconnect = 4,
+    ConnectReqFragment = 5,
+}
+
+impl UdpPktType {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
+    fn as_u16(self) -> u16 {
+        self as u16
+    }
+}
+
+impl TryFrom<u16> for UdpPktType {
+    type Error = ();
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        Ok(match value {
+            1 => Self::ConnectReq,
+            2 => Self::ConnectResp,
+            3 => Self::Payload,
+            4 => Self::Disconnect,
+            5 => Self::ConnectReqFragment,
+            _ => return Err(()),
+        })
+    }
+}
+
+/// [MS-TSGU] 2.2.11.7 `UDP_PACKET_HEADER`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct UdpPacketHeader {
+    pub pkt_id: u16,
+    /// Length of the body **excluding** this header.
+    pub pkt_len: u16,
+}
+
+impl UdpPacketHeader {
+    pub(crate) const FIXED_PART_SIZE: usize = 2 /* pkt_id */ + 2 /* pkt_len */;
+}
+
+impl Encode for UdpPacketHeader {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u16(self.pkt_id);
+        dst.write_u16(self.pkt_len);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "UDP_PACKET_HEADER"
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl Decode<'_> for UdpPacketHeader {
+    fn decode(src: &mut ReadCursor<'_>) -> ironrdp_core::DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+        Ok(Self {
+            pkt_id: src.read_u16(),
+            pkt_len: src.read_u16(),
+        })
+    }
+}
+
+/// [MS-TSGU] 2.2.11.1 `AASYNDATA`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct AaSynData {
+    pub up_stream_mtu: u16,
+    pub down_stream_mtu: u16,
+    pub lossy: u32,
+    pub send_isn: i32,
+}
+
+impl AaSynData {
+    pub(crate) const FIXED_PART_SIZE: usize =
+        2 /* up */ + 2 /* down */ + 4 /* lossy */ + 4 /* send_isn */;
+}
+
+impl Encode for AaSynData {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u16(self.up_stream_mtu);
+        dst.write_u16(self.down_stream_mtu);
+        dst.write_u32(self.lossy);
+        dst.write_i32(self.send_isn);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "AASYNDATA"
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl Decode<'_> for AaSynData {
+    fn decode(src: &mut ReadCursor<'_>) -> ironrdp_core::DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+        Ok(Self {
+            up_stream_mtu: src.read_u16(),
+            down_stream_mtu: src.read_u16(),
+            lossy: src.read_u32(),
+            send_isn: src.read_i32(),
+        })
+    }
+}
+
+/// [MS-TSGU] 2.2.11.2 `AASYNDATARESP`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct AaSynDataResp {
+    pub up_stream_mtu: u16,
+    pub down_stream_mtu: u16,
+    pub recv_isn: i32,
+}
+
+impl AaSynDataResp {
+    pub(crate) const FIXED_PART_SIZE: usize = 2 /* up */ + 2 /* down */ + 4 /* recv_isn */;
+}
+
+impl Decode<'_> for AaSynDataResp {
+    fn decode(src: &mut ReadCursor<'_>) -> ironrdp_core::DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+        Ok(Self {
+            up_stream_mtu: src.read_u16(),
+            down_stream_mtu: src.read_u16(),
+            recv_isn: src.read_i32(),
+        })
+    }
+}
+
+/// [MS-TSGU] 2.2.11.3 `CONNECT_PKT` (body after DTLS, not including outer DTLS records).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ConnectPkt {
+    pub target_port: u16,
+    pub syn_data: AaSynData,
+    pub authn_cookie: Vec<u8>,
+}
+
+impl ConnectPkt {
+    /// Build a connect request from a main-channel UDP offer and target resource port.
+    pub fn from_offer(offer: &GwUdpOffer, target_port: u16, syn_data: AaSynData) -> Self {
+        Self {
+            target_port,
+            syn_data,
+            authn_cookie: offer.authn_cookie.clone(),
+        }
+    }
+}
+
+impl Encode for ConnectPkt {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        let body_len = self.size() - UdpPacketHeader::FIXED_PART_SIZE;
+        let hdr = UdpPacketHeader {
+            pkt_id: UdpPktType::ConnectReq.as_u16(),
+            pkt_len: cast_int!("connect pkt body length", body_len)?,
+        };
+        hdr.encode(dst)?;
+        dst.write_u16(self.target_port);
+        let cookie_len: u16 = cast_int!("authn cookie length", self.authn_cookie.len())?;
+        dst.write_u16(cookie_len);
+        self.syn_data.encode(dst)?;
+        dst.write_slice(&self.authn_cookie);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "CONNECT_PKT"
+    }
+
+    fn size(&self) -> usize {
+        UdpPacketHeader::FIXED_PART_SIZE
+            + 2 /* target_port */
+            + 2 /* cookie_len */
+            + AaSynData::FIXED_PART_SIZE
+            + self.authn_cookie.len()
+    }
+}
+
+impl Decode<'_> for ConnectPkt {
+    fn decode(src: &mut ReadCursor<'_>) -> ironrdp_core::DecodeResult<Self> {
+        let hdr = UdpPacketHeader::decode(src)?;
+        if hdr.pkt_id != UdpPktType::ConnectReq.as_u16() {
+            return Err(unsupported_value_err(
+                "CONNECT_PKT::pkt_id",
+                "pkt_id",
+                format!("0x{:x}", hdr.pkt_id),
+            ));
+        }
+        ensure_size!(in: src, size: 4);
+        let target_port = src.read_u16();
+        let cookie_len = usize::from(src.read_u16());
+        let syn_data = AaSynData::decode(src)?;
+        ensure_size!(in: src, size: cookie_len);
+        let authn_cookie = src.read_slice(cookie_len).to_vec();
+        Ok(Self {
+            target_port,
+            syn_data,
+            authn_cookie,
+        })
+    }
+}
+
+/// [MS-TSGU] 2.2.11.4 `CONNECT_PKT_RESP`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ConnectPktResp {
+    pub syn_response: AaSynDataResp,
+    /// Connection result (HRESULT-style `i64` on the wire as 8 little-endian bytes).
+    pub result: i64,
+}
+
+impl Decode<'_> for ConnectPktResp {
+    fn decode(src: &mut ReadCursor<'_>) -> ironrdp_core::DecodeResult<Self> {
+        let hdr = UdpPacketHeader::decode(src)?;
+        if hdr.pkt_id != UdpPktType::ConnectResp.as_u16() {
+            return Err(unsupported_value_err(
+                "CONNECT_PKT_RESP::pkt_id",
+                "pkt_id",
+                format!("0x{:x}", hdr.pkt_id),
+            ));
+        }
+        let syn_response = AaSynDataResp::decode(src)?;
+        ensure_size!(in: src, size: 8);
+        let result = src.read_i64();
+        Ok(Self { syn_response, result })
+    }
+}
+
+/// [MS-TSGU] 2.2.11.9 `UDP_CORRELATION_INFO` appended to DTLS ClientHello.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct UdpCorrelationInfo {
+    pub correlation_id: [u8; 16],
+}
+
+impl UdpCorrelationInfo {
+    pub const SIZE: usize = 4 /* reserved */ + 2 /* sig1 */ + 16 /* id */ + 2 /* sig2 */ + 2 /* cb */;
+    const SIGNATURE1: u16 = 0x1DAA;
+    const SIGNATURE2: u16 = 0xAA1D;
+
+    pub fn new(correlation_id: [u8; 16]) -> Self {
+        Self { correlation_id }
+    }
+}
+
+impl Encode for UdpCorrelationInfo {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u32(0);
+        dst.write_u16(Self::SIGNATURE1);
+        dst.write_slice(&self.correlation_id);
+        dst.write_u16(Self::SIGNATURE2);
+        dst.write_u16(cast_int!("udp correlation struct size", Self::SIZE)?);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "UDP_CORRELATION_INFO"
+    }
+
+    fn size(&self) -> usize {
+        Self::SIZE
+    }
+}
+
+impl Decode<'_> for UdpCorrelationInfo {
+    fn decode(src: &mut ReadCursor<'_>) -> ironrdp_core::DecodeResult<Self> {
+        ensure_size!(in: src, size: Self::SIZE);
+        let _reserved = src.read_u32();
+        let sig1 = src.read_u16();
+        if sig1 != Self::SIGNATURE1 {
+            return Err(unsupported_value_err(
+                "UDP_CORRELATION_INFO::uSignature1",
+                "sig1",
+                format!("0x{sig1:x}"),
+            ));
+        }
+        let correlation_id = src.read_array();
+        let sig2 = src.read_u16();
+        if sig2 != Self::SIGNATURE2 {
+            return Err(unsupported_value_err(
+                "UDP_CORRELATION_INFO::uSignature2",
+                "sig2",
+                format!("0x{sig2:x}"),
+            ));
+        }
+        let cb = src.read_u16();
+        if usize::from(cb) != Self::SIZE {
+            return Err(unsupported_value_err(
+                "UDP_CORRELATION_INFO::uCbStruct",
+                "cb",
+                format!("{cb}"),
+            ));
+        }
+        Ok(Self { correlation_id })
+    }
+}
+
+/// Split a connect request into fragment packets ([MS-TSGU] 2.2.11.10) when needed for MTU.
+pub fn fragment_connect_pkt(
+    connect: &ConnectPkt,
+    max_fragment_payload: usize,
+) -> ironrdp_core::EncodeResult<Vec<Vec<u8>>> {
+    if max_fragment_payload == 0 {
+        return Err(other_err("udp fragment", "max fragment payload must be non-zero"));
+    }
+
+    let mut full = vec![0u8; connect.size()];
+    {
+        let mut cur = WriteCursor::new(&mut full);
+        connect.encode(&mut cur)?;
+    }
+    // Fragments carry CONNECT_PKT bytes after the UDP header of the full packet.
+    let payload = &full[UdpPacketHeader::FIXED_PART_SIZE..];
+    let total = payload.len().div_ceil(max_fragment_payload);
+    let total_u16: u16 = cast_int!("udp fragment count", total)?;
+
+    let mut out = Vec::with_capacity(total);
+    for (idx, chunk) in payload.chunks(max_fragment_payload).enumerate() {
+        let frag_id: u16 = cast_int!("udp fragment id", idx)?;
+        let chunk_len: u16 = cast_int!("udp fragment length", chunk.len())?;
+        // header(4) + frag_id(2) + no_of_fragments(2) + cb(2) + chunk
+        let body_len = 2 + 2 + 2 + chunk.len();
+        let mut buf = vec![0u8; UdpPacketHeader::FIXED_PART_SIZE + body_len];
+        {
+            let mut cur = WriteCursor::new(&mut buf);
+            UdpPacketHeader {
+                pkt_id: UdpPktType::ConnectReqFragment.as_u16(),
+                pkt_len: cast_int!("udp fragment body length", body_len)?,
+            }
+            .encode(&mut cur)?;
+            cur.write_u16(frag_id);
+            cur.write_u16(total_u16);
+            cur.write_u16(chunk_len);
+            cur.write_slice(chunk);
+        }
+        out.push(buf);
+    }
+    Ok(out)
+}
+
+/// Encode a complete CONNECT_PKT for a channel UDP offer.
+pub fn encode_connect_request(
+    offer: &GwUdpOffer,
+    target_port: u16,
+    syn_data: AaSynData,
+) -> ironrdp_core::EncodeResult<Vec<u8>> {
+    let pkt = ConnectPkt::from_offer(offer, target_port, syn_data);
+    let mut buf = vec![0u8; pkt.size()];
+    let mut cur = WriteCursor::new(&mut buf);
+    pkt.encode(&mut cur)?;
+    Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn encode_to_vec(payload: &impl Encode) -> Vec<u8> {
+        let mut buf = vec![0u8; payload.size()];
+        let mut cur = WriteCursor::new(&mut buf);
+        payload.encode(&mut cur).expect("encode");
+        assert_eq!(cur.pos(), payload.size());
+        buf
+    }
+
+    #[test]
+    fn connect_pkt_roundtrip() {
+        let offer = GwUdpOffer {
+            port: 3391,
+            authn_cookie: vec![1, 2, 3, 4, 5],
+        };
+        let syn = AaSynData {
+            up_stream_mtu: 1234,
+            down_stream_mtu: 1400,
+            lossy: 1,
+            send_isn: 42,
+        };
+        let pkt = ConnectPkt::from_offer(&offer, 3389, syn);
+        let bytes = encode_to_vec(&pkt);
+        assert_eq!(&bytes[..2], &1u16.to_le_bytes()); // ConnectReq
+        let mut cur = ReadCursor::new(&bytes);
+        let decoded = ConnectPkt::decode(&mut cur).expect("decode");
+        assert_eq!(decoded.target_port, 3389);
+        assert_eq!(decoded.syn_data, syn);
+        assert_eq!(decoded.authn_cookie, offer.authn_cookie);
+        assert!(cur.eof());
+    }
+
+    #[test]
+    fn correlation_info_roundtrip() {
+        let id = [9u8; 16];
+        let info = UdpCorrelationInfo::new(id);
+        let bytes = encode_to_vec(&info);
+        assert_eq!(bytes.len(), UdpCorrelationInfo::SIZE);
+        let mut cur = ReadCursor::new(&bytes);
+        let decoded = UdpCorrelationInfo::decode(&mut cur).expect("decode");
+        assert_eq!(decoded.correlation_id, id);
+        assert!(cur.eof());
+    }
+
+    #[test]
+    fn fragment_connect_pkt_covers_payload() {
+        let offer = GwUdpOffer {
+            port: 3391,
+            authn_cookie: vec![7; 40],
+        };
+        let pkt = ConnectPkt::from_offer(&offer, 2179, AaSynData::default());
+        let frags = fragment_connect_pkt(&pkt, 16).expect("fragment");
+        assert!(frags.len() > 1);
+        let mut reassembled = Vec::new();
+        for frag in &frags {
+            let mut cur = ReadCursor::new(frag);
+            let hdr = UdpPacketHeader::decode(&mut cur).unwrap();
+            assert_eq!(hdr.pkt_id, UdpPktType::ConnectReqFragment.as_u16());
+            let _id = cur.read_u16();
+            let total = cur.read_u16();
+            assert_eq!(usize::from(total), frags.len());
+            let len = usize::from(cur.read_u16());
+            reassembled.extend_from_slice(cur.read_slice(len));
+        }
+        let mut full = encode_to_vec(&pkt);
+        assert_eq!(reassembled, full.split_off(UdpPacketHeader::FIXED_PART_SIZE));
+    }
+
+    #[test]
+    fn encode_connect_request_matches_struct() {
+        let offer = GwUdpOffer {
+            port: 1,
+            authn_cookie: b"cookie".to_vec(),
+        };
+        let bytes = encode_connect_request(&offer, 3389, AaSynData::default()).expect("encode");
+        let mut cur = ReadCursor::new(&bytes);
+        let decoded = ConnectPkt::decode(&mut cur).expect("decode");
+        assert_eq!(decoded.authn_cookie, b"cookie");
+    }
+}

--- a/crates/ironrdp-testsuite-extra/tests/client_config.rs
+++ b/crates/ironrdp-testsuite-extra/tests/client_config.rs
@@ -163,8 +163,10 @@ fn vmconnect_basic_flag_selects_basic_mode() {
 }
 
 #[test]
-fn vmconnect_rejects_rds_gateway() {
-    let err = parse_config_from_rdp_result(
+fn vmconnect_accepts_rds_gateway() {
+    // The gateway channel-create now forwards the destination port, so
+    // VMConnect (port 2179) can be tunneled through an RD Gateway.
+    let config = parse_config_from_rdp(
         "full address:s:hyperv.example.com:2179\nusername:s:test-user\nClearTextPassword:s:test-pass\n",
         &[
             "--vmconnect",
@@ -176,10 +178,9 @@ fn vmconnect_rejects_rds_gateway() {
             "--gw-pass",
             "gw-pass",
         ],
-    )
-    .expect_err("vmconnect + RDS gateway must fail");
+    );
 
-    assert!(err.to_string().contains("gateway"), "unexpected error: {err:#}");
+    assert!(matches!(config.transport(), Transport::Gateway(_)));
 }
 
 #[test]

--- a/crates/ironrdp-viewer/src/cli.rs
+++ b/crates/ironrdp-viewer/src/cli.rs
@@ -447,7 +447,11 @@ fn apply_cli_to_builder(
             builder = builder.with_rdcleanpath_token(token);
         }
     } else if let Some(endpoint) = args.gw_endpoint {
-        builder = builder.with_transport(TransportKind::Gateway { endpoint });
+        builder = builder.with_transport(TransportKind::Gateway {
+            endpoint,
+            prefer_direct: false,
+            transport: Default::default(),
+        });
 
         if let Some(username) = args.gw_user {
             builder = builder.with_gateway_username(username);


### PR DESCRIPTION
GwClient polled its background work JoinHandle on every read and write,
which tokio panics on once the task completes, and it never reported
end-of-stream when the gateway stream closed. A caller that holds a read
across the connection lifetime (for example a bidirectional relay) hit
`JoinHandle polled after completion` or hung forever instead of seeing
EOF.

Track work completion with a flag so the handle is polled at most once,
and surface UnexpectedEof once the task has ended and no data remains.