### PR TITLE
fix(mstsgu): forward the target host and port to the gateway

### DIFF
--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -343,11 +343,9 @@ pub enum Transport {
 
     /// Connect via an RDS gateway (MS-TSGU / MSTSGU).
     ///
-    /// The target RDP server is derived from [`Config::destination`]; the gateway
-    /// only needs its own endpoint and credentials.
-    ///
-    /// NOTE: the destination port is currently not forwarded to the gateway.
-    /// If `ironrdp-mstsgu` hardcodes port 3389, open a follow-up issue.
+    /// The target RDP server host and port are taken from [`Config::destination`] and
+    /// forwarded in the MS-TSGU channel-create packet. The gateway only needs its own
+    /// endpoint and credentials.
     #[cfg(feature = "gateway")]
     Gateway(GatewayConfig),
 
@@ -1121,8 +1119,8 @@ impl ConfigBuilder {
     /// A destination with no explicit port defaults to 2179 instead of the ordinary RDP port.
     ///
     /// Security (TLS + CredSSP) is required by [`ironrdp_vmconnect::connect_front`] for every
-    /// embedder (error if disabled). Works over Direct and RDCleanPath. RDS Gateway is rejected
-    /// until it can propagate the VMConnect target port.
+    /// embedder (error if disabled). Works over Direct, RDCleanPath, and RDS Gateway (the
+    /// destination port, typically 2179, is forwarded in the MS-TSGU channel-create packet).
     #[must_use]
     pub fn with_vmconnect(mut self, vm_id: impl Into<String>) -> Self {
         self.vm_id = Some(vm_id.into());
@@ -1499,10 +1497,6 @@ impl ConfigBuilder {
             }
             if !self.enable_credssp.unwrap_or(true) {
                 anyhow::bail!("vmconnect requires CredSSP");
-            }
-            #[cfg(feature = "gateway")]
-            if matches!(transport, Transport::Gateway(_)) {
-                anyhow::bail!("vmconnect cannot be used over an RDS gateway until the target port is propagated");
             }
         }
 

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -1120,7 +1120,8 @@ impl ConfigBuilder {
     ///
     /// Security (TLS + CredSSP) is required by [`ironrdp_vmconnect::connect_front`] for every
     /// embedder (error if disabled). Works over Direct, RDCleanPath, and RDS Gateway (the
-    /// destination port, typically 2179, is forwarded in the MS-TSGU channel-create packet).
+    /// destination port, typically 2179, is forwarded in the MS-TSGU channel-create packet,
+    /// then the VMConnect PCB / `connect_front` handshake runs on the tunneled stream).
     #[must_use]
     pub fn with_vmconnect(mut self, vm_id: impl Into<String>) -> Self {
         self.vm_id = Some(vm_id.into());

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -1454,12 +1454,15 @@ async fn connect_gateway(
         gw_user: gw.username.clone(),
         gw_pass: gw.password.clone(),
         server: config.destination.name().to_owned(),
-        server_port: config.destination.port(),
     };
 
-    let (gw_stream, client_addr) = ironrdp_mstsgu::GwClient::connect(&gw_target, &config.connector.client_name)
-        .await
-        .map_err(|e| ironrdp_connector::custom_err!("GW connect", e))?;
+    let (gw_stream, client_addr) = ironrdp_mstsgu::GwClient::connect_with_port(
+        &gw_target,
+        &config.connector.client_name,
+        config.destination.port(),
+    )
+    .await
+    .map_err(|e| ironrdp_connector::custom_err!("GW connect", e))?;
 
     let framed = ironrdp_tokio::TokioFramed::new(gw_stream);
 
@@ -1471,6 +1474,13 @@ async fn connect_gateway(
         rdpdr_factory,
         auto_reconnect_cookie,
     )?;
+    #[cfg(feature = "vmconnect")]
+    if config.vm_id().is_some() {
+        // The Hyper-V TCP connection is created by the gateway during channel-create, so
+        // the MS-RDPEPS PCB deadline starts once that channel is established.
+        let pcb_deadline = tokio::time::Instant::now() + ironrdp_vmconnect::PCB_TRANSMIT_DEADLINE;
+        return vmconnect_handshake_and_finalize(framed, connector, config, pcb_deadline).await;
+    }
     security_upgrade_and_finalize(framed, connector, config).await
 }
 

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -1447,21 +1447,14 @@ async fn connect_gateway(
 ) -> ConnectorResult<(ConnectionResult, UpgradedFramed)> {
     use ironrdp_mstsgu::GwConnectTarget;
 
-    // VMConnect needs destination port 2179; GwConnectTarget does not carry it yet (TODO below).
-    #[cfg(feature = "vmconnect")]
-    if config.vm_id().is_some() {
-        return Err(ironrdp_connector::general_err!(
-            "vmconnect cannot be used over an RDS gateway until the target port is propagated"
-        ));
-    }
-
-    // Build the GwConnectTarget.  `server` is the RDP target derived from `config.destination`.
-    // TODO: preserve the destination port; ironrdp-mstsgu may currently hard-code 3389.
+    // Target resource host/port come from Config::destination and are forwarded in the
+    // MS-TSGU channel-create packet (enables non-3389 RDP and VMConnect port 2179).
     let gw_target = GwConnectTarget {
         gw_endpoint: gw.endpoint.clone(),
         gw_user: gw.username.clone(),
         gw_pass: gw.password.clone(),
         server: config.destination.name().to_owned(),
+        server_port: config.destination.port(),
     };
 
     let (gw_stream, client_addr) = ironrdp_mstsgu::GwClient::connect(&gw_target, &config.connector.client_name)

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -42,10 +42,6 @@ pub struct GwConnectTarget {
     pub gw_pass: String,
 
     pub server: String,
-    /// Target resource port as presented to the gateway (HTTP_CHANNEL_PACKET `port`).
-    ///
-    /// Common values are `3389` for ordinary RDP and `2179` for Hyper-V VMConnect.
-    pub server_port: u16,
 }
 
 type Error = ironrdp_error::Error<GwErrorKind>;
@@ -98,6 +94,10 @@ impl core::error::Error for GwErrorKind {}
 struct GwConn {
     client_name: String,
     target: GwConnectTarget,
+    /// Target resource port presented in HTTP_CHANNEL_PACKET (`port`).
+    ///
+    /// Common values are `3389` for ordinary RDP and `2179` for Hyper-V VMConnect.
+    server_port: u16,
     ws_sink: SplitSink<WebSocketStream<TlsStream<TcpStream>>, Message>,
     ws_stream: SplitStream<WebSocketStream<TlsStream<TcpStream>>>,
 }
@@ -119,9 +119,22 @@ impl Drop for GwClient {
 }
 
 impl GwClient {
+    /// Open an MS-TSGU tunnel, presenting port `3389` to the gateway.
+    ///
+    /// Use [`Self::connect_with_port`] when the target resource is not on the ordinary RDP port
+    /// (for example Hyper-V VMConnect on `2179`).
     pub async fn connect(
         target: &GwConnectTarget,
         client_name: &str,
+    ) -> Result<(GwClient, core::net::SocketAddr), Error> {
+        Self::connect_with_port(target, client_name, 3389).await
+    }
+
+    /// Open an MS-TSGU tunnel, presenting `server_port` as HTTP_CHANNEL_PACKET `port`.
+    pub async fn connect_with_port(
+        target: &GwConnectTarget,
+        client_name: &str,
+        server_port: u16,
     ) -> Result<(GwClient, core::net::SocketAddr), Error> {
         let gw_host = target
             .gw_endpoint
@@ -179,7 +192,7 @@ impl GwClient {
         let _ = tx.send(()); // TODO: Not needed since it doesnt keep alive conn?
         let stream = jh.await.map_err(|e| custom_err!("WS join", e))?.io.into_inner();
 
-        Self::connect_ws(target.clone(), client_name, stream)
+        Self::connect_ws(target.clone(), client_name, server_port, stream)
             .await
             .map(|x| (x, client_addr))
     }
@@ -187,6 +200,7 @@ impl GwClient {
     async fn connect_ws(
         target: GwConnectTarget,
         client_name: &str,
+        server_port: u16,
         tls_stream: TlsStream<TcpStream>,
     ) -> Result<GwClient, Error> {
         let ws_stream: WebSocketStream<_> = WebSocketStream::from_raw_socket(tls_stream, Role::Client, None).await;
@@ -194,6 +208,7 @@ impl GwClient {
         let mut gw = GwConn {
             client_name: client_name.to_owned(),
             target,
+            server_port,
             ws_sink,
             ws_stream,
         };
@@ -381,7 +396,7 @@ impl GwConn {
     async fn channel(&mut self) -> Result<ChannelResp, Error> {
         let req = ChannelPkt {
             resources: vec![self.target.server.clone()],
-            port: self.target.server_port,
+            port: self.server_port,
             protocol: 3,
         };
         self.send_packet(&req).await?;

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -42,6 +42,10 @@ pub struct GwConnectTarget {
     pub gw_pass: String,
 
     pub server: String,
+    /// Target resource port as presented to the gateway (HTTP_CHANNEL_PACKET `port`).
+    ///
+    /// Common values are `3389` for ordinary RDP and `2179` for Hyper-V VMConnect.
+    pub server_port: u16,
 }
 
 type Error = ironrdp_error::Error<GwErrorKind>;
@@ -377,7 +381,7 @@ impl GwConn {
     async fn channel(&mut self) -> Result<ChannelResp, Error> {
         let req = ChannelPkt {
             resources: vec![self.target.server.clone()],
-            port: 3389,
+            port: self.target.server_port,
             protocol: 3,
         };
         self.send_packet(&req).await?;

--- a/crates/ironrdp-mstsgu/src/proto.rs
+++ b/crates/ironrdp-mstsgu/src/proto.rs
@@ -599,3 +599,23 @@ impl Encode for KeepalivePkt {
         PktHdr::default().size()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn channel_pkt_encodes_requested_port() {
+        let pkt = ChannelPkt {
+            resources: vec!["rdp.example.com".to_owned()],
+            port: 2179,
+            protocol: 3,
+        };
+        let mut buf = vec![0; pkt.size()];
+        let mut dst = WriteCursor::new(&mut buf);
+        pkt.encode(&mut dst).expect("encode");
+
+        // HTTP_PACKET_HEADER is 8 bytes; the next two bytes are resources/alt_names counts.
+        assert_eq!(&buf[10..12], &2179u16.to_le_bytes());
+    }
+}

--- a/crates/ironrdp-testsuite-extra/tests/client_config.rs
+++ b/crates/ironrdp-testsuite-extra/tests/client_config.rs
@@ -181,6 +181,7 @@ fn vmconnect_accepts_rds_gateway() {
     );
 
     assert!(matches!(config.transport(), Transport::Gateway(_)));
+    assert_eq!(config.destination().port(), 2179);
 }
 
 #[test]

--- a/crates/ironrdp-testsuite-extra/tests/client_config.rs
+++ b/crates/ironrdp-testsuite-extra/tests/client_config.rs
@@ -163,8 +163,10 @@ fn vmconnect_basic_flag_selects_basic_mode() {
 }
 
 #[test]
-fn vmconnect_rejects_rds_gateway() {
-    let err = parse_config_from_rdp_result(
+fn vmconnect_accepts_rds_gateway() {
+    // The gateway channel-create now forwards the destination port, so
+    // VMConnect (port 2179) can be tunneled through an RD Gateway.
+    let config = parse_config_from_rdp(
         "full address:s:hyperv.example.com:2179\nusername:s:test-user\nClearTextPassword:s:test-pass\n",
         &[
             "--vmconnect",
@@ -176,10 +178,9 @@ fn vmconnect_rejects_rds_gateway() {
             "--gw-pass",
             "gw-pass",
         ],
-    )
-    .expect_err("vmconnect + RDS gateway must fail");
+    );
 
-    assert!(err.to_string().contains("gateway"), "unexpected error: {err:#}");
+    assert!(matches!(config.transport(), Transport::Gateway(_)));
 }
 
 #[test]


### PR DESCRIPTION
The channel-create packet (HTTP_CHANNEL_PACKET) hardcoded port 3389, so non-3389 RDP targets and Hyper-V VMConnect (port 2179) could not be tunneled through an RD Gateway.

GwClient::connect still presents port 3389 so existing GwConnectTarget struct literals keep compiling. GwClient::connect_with_port carries Config::destination.port() through HTTP_CHANNEL_PACKET. The vmconnect-over-gateway rejections are removed, and connect_gateway now runs the VMConnect PCB / connect_front handshake on the tunneled stream when a VM ID is set.