### PR TITLE
fix(rdpeusb)!: add the capability exchange on each per-device channel

### DIFF
--- a/crates/ironrdp-rdpeusb/src/client.rs
+++ b/crates/ironrdp-rdpeusb/src/client.rs
@@ -523,6 +523,11 @@ impl DvcProcessor for UrbdrcDeviceClient {
 
         use UrbdrcServerDevicePdu::*;
         match pdu {
+            Caps(caps_req_pdu) => Ok(vec![Box::new(RimExchangeCapabilityResponse {
+                msg_id: caps_req_pdu.msg_id,
+                capability: Capability::RimCapabilityVersion01,
+                result: 0,
+            })]),
             ChanCreated(chan_created_pdu) => Ok(vec![Box::new(ChannelCreated {
                 msg_id: chan_created_pdu.msg_id,
                 direction: crate::pdu::notify::Direction::ToServer,

--- a/crates/ironrdp-rdpeusb/src/pdu/mod.rs
+++ b/crates/ironrdp-rdpeusb/src/pdu/mod.rs
@@ -68,6 +68,7 @@ impl UrbdrcServerControlPdu {
 }
 
 pub enum UrbdrcServerDevicePdu {
+    Caps(RimExchangeCapabilityRequest),
     ChanCreated(ChannelCreated),
     IfaceRelease(InterfaceRelease),
     QueryIfaceReq(QueryInterfaceRequest),
@@ -82,6 +83,19 @@ pub enum UrbdrcServerDevicePdu {
 }
 
 impl UrbdrcServerDevicePdu {
+    fn decode_caps(src: &mut ReadCursor<'_>, f_id: FunctionId, header: SharedMsgHeader) -> DecodeResult<Self> {
+        match f_id {
+            FunctionId::RIM_EXCHANGE_CAPABILITY_REQUEST => {
+                RimExchangeCapabilityRequest::decode(src, header).map(Self::Caps)
+            }
+            FunctionId::RIMCALL_RELEASE => Ok(Self::IfaceRelease(InterfaceRelease::from_header(header))),
+            FunctionId::RIMCALL_QUERYINTERFACE => QueryInterfaceRequest::decode(src, header).map(Self::QueryIfaceReq),
+            _ => Err(invalid_field_err!(
+                "SHARED_MSG_HEADER",
+                "invalid RIM_EXCHANGE_CAPABILITY_REQUEST header"
+            )),
+        }
+    }
     fn decode_notification(src: &mut ReadCursor<'_>, f_id: FunctionId, header: SharedMsgHeader) -> DecodeResult<Self> {
         match f_id {
             FunctionId::CHANNEL_CREATED => ChannelCreated::decode(src, header).map(Self::ChanCreated),
@@ -114,6 +128,7 @@ impl Decode<'_> for UrbdrcServerDevicePdu {
         let f_id = header.function_id.expect("missing function id");
 
         match unpack(header.iface_id)? {
+            (InterfaceId::CAPABILITIES, Mask::None) => Self::decode_caps(src, f_id, header),
             (InterfaceId::NOTIFY_CLIENT, Mask::Proxy) => Self::decode_notification(src, f_id, header),
             (udev_iface, Mask::Proxy) => match f_id {
                 FunctionId::RIMCALL_RELEASE => Ok(Self::IfaceRelease(InterfaceRelease::from_header(header))),
@@ -166,6 +181,7 @@ macro_rules! fill_server_dev_pdu_arms {
     ($pdu:expr, $($tokens:tt)*) => {{
         use UrbdrcServerDevicePdu::*;
         match <&UrbdrcServerDevicePdu>::from($pdu) {
+            Caps(rim_exchange_capability_request) => rim_exchange_capability_request$($tokens)*,
             ChanCreated(channel_created) => channel_created$($tokens)*,
             IfaceRelease(iface_release) => iface_release$($tokens)*,
             QueryIfaceReq(query_iface_req) => query_iface_req$($tokens)*,
@@ -219,6 +235,7 @@ pub enum UrbdrcClientControlPdu {
 }
 
 pub enum UrbdrcClientDevicePdu<P> {
+    Caps(RimExchangeCapabilityResponse),
     ChanCreated(ChannelCreated),
     AddDev(AddDevice),
     DevTextRsp(QueryDeviceTextRsp),
@@ -307,6 +324,9 @@ impl Decode<'_> for UrbdrcClientDevicePdu<Raw> {
         let header = SharedMsgHeader::decode(src)?;
 
         match unpack(header.iface_id)? {
+            (InterfaceId::CAPABILITIES, Mask::None) => {
+                RimExchangeCapabilityResponse::decode(src, header).map(Self::Caps)
+            }
             (InterfaceId::DEVICE_SINK, Mask::Proxy) => Self::decode_sink(src, header),
             (InterfaceId::NOTIFY_SERVER, Mask::Proxy) => Self::decode_notification(src, header),
             (udev_iface, Mask::Stub) => {
@@ -356,6 +376,7 @@ macro_rules! fill_client_dev_pdu_arms {
     ($pdu:expr, $($tokens:tt)*) => {{
         use UrbdrcClientDevicePdu::*;
         match <&UrbdrcClientDevicePdu<TsUrbResultPayload>>::from($pdu) {
+            Caps(rim_exchange_capability_response) => rim_exchange_capability_response$($tokens)*,
             ChanCreated(channel_created) => channel_created$($tokens)*,
             IfaceRelease(iface_release) => iface_release$($tokens)*,
             QueryIfaceReq(query_iface_req) => query_iface_req$($tokens)*,

--- a/crates/ironrdp-rdpeusb/src/server.rs
+++ b/crates/ironrdp-rdpeusb/src/server.rs
@@ -238,6 +238,8 @@ pub struct UrbdrcDeviceServer {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum DeviceState {
+    AwaitingCaps,
+    AwaitingChanCreated,
     AwaitingDevice,
     Ready,
     Retracted,
@@ -303,7 +305,7 @@ impl UrbdrcDeviceServer {
         Ok(Self {
             msg_alloc: IdAllocator::new(),
             request_id_alloc: RequestIdAllocator::new(),
-            state: DeviceState::AwaitingDevice,
+            state: DeviceState::AwaitingCaps,
             udev_iface: None,
             comp_iface,
             no_ack_isoch_write_jitter_buf_size: None,
@@ -655,9 +657,9 @@ impl DvcProcessor for UrbdrcDeviceServer {
     }
 
     fn start(&mut self, _channel_id: u32) -> PduResult<Vec<DvcMessage>> {
-        Ok(vec![Box::new(ChannelCreated {
+        Ok(vec![Box::new(RimExchangeCapabilityRequest {
             msg_id: self.msg_alloc.alloc(),
-            direction: crate::pdu::notify::Direction::ToClient,
+            capability: crate::pdu::caps::Capability::RimCapabilityVersion01,
         })])
     }
 
@@ -675,11 +677,30 @@ impl DvcProcessor for UrbdrcDeviceServer {
 
         use UrbdrcClientDevicePdu::*;
         match pdu {
+            Caps(_caps_response_pdu) => {
+                if self.state != DeviceState::AwaitingCaps {
+                    return Err(pdu_other_err!("invalid state"));
+                }
+                resp.push(Box::new(InterfaceRelease {
+                    iface_id: InterfaceId::CAPABILITIES.with_mask(Mask::None),
+                    msg_id: self.msg_alloc.alloc(),
+                }));
+                resp.push(Box::new(ChannelCreated {
+                    msg_id: self.msg_alloc.alloc(),
+                    direction: crate::pdu::notify::Direction::ToClient,
+                }));
+                self.state = DeviceState::AwaitingChanCreated;
+                Ok(resp)
+            }
             ChanCreated(_channel_created_pdu) => {
+                if self.state != DeviceState::AwaitingChanCreated {
+                    return Err(pdu_other_err!("invalid state"));
+                }
                 resp.push(Box::new(InterfaceRelease {
                     msg_id: self.msg_alloc.alloc(),
                     iface_id: InterfaceId::NOTIFY_CLIENT.with_mask(Mask::Proxy),
                 }));
+                self.state = DeviceState::AwaitingDevice;
                 Ok(resp)
             }
             AddDev(add_dev_pdu) => {

--- a/crates/ironrdp-testsuite-core/tests/rdpeusb/server.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpeusb/server.rs
@@ -166,7 +166,13 @@ fn capability_exchange_sequence() {
 }
 
 // Ref: [New Device Sequence][1.3.1.2]
+//
+// A per-device channel runs the same [Channel Setup Sequence][1.3.1.1] as the control channel:
+// the capability exchange precedes CHANNEL_CREATED, and only then does the Device Sink
+// interface carry ADD_DEVICE (section 3.2.5.2.2).
+//
 // [1.3.1.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeusb/7e3da218-9cdc-4ebd-bb76-e70202c7f264
+// [1.3.1.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpeusb/55bb34fc-7fd0-4aca-8739-5fb6759b66fc
 #[test]
 fn new_device_sequence() {
     let udev_iface = InterfaceId::try_from(4).expect("valid device interface id");
@@ -179,7 +185,29 @@ fn new_device_sequence() {
 
     let resp = server.start(11).expect("start should succeed");
     assert_eq!(resp.len(), 1);
-    let UrbdrcServerDevicePdu::ChanCreated(channel_created_request) = decode_device_msg(&resp[0]) else {
+    let UrbdrcServerDevicePdu::Caps(request) = decode_device_msg(&resp[0]) else {
+        panic!("expected capability request");
+    };
+    assert_eq!(request.capability, Capability::RimCapabilityVersion01);
+
+    let resp = server
+        .process(
+            11,
+            &encode_pdu(&UrbdrcClientDevicePdu::Caps(RimExchangeCapabilityResponse {
+                msg_id: request.msg_id,
+                capability: Capability::RimCapabilityVersion01,
+                result: 0,
+            })),
+        )
+        .expect("capability response should succeed");
+    assert_eq!(resp.len(), 2);
+
+    let UrbdrcServerDevicePdu::IfaceRelease(release) = decode_device_msg(&resp[0]) else {
+        panic!("expected capabilities interface release");
+    };
+    assert_eq!(release.iface_id, u32::from(InterfaceId::CAPABILITIES));
+
+    let UrbdrcServerDevicePdu::ChanCreated(channel_created_request) = decode_device_msg(&resp[1]) else {
         panic!("expected channel-created request");
     };
     assert_eq!(channel_created_request.direction, Direction::ToClient);
@@ -222,5 +250,49 @@ fn new_device_sequence() {
     assert!(
         matches!(announcement_rx.try_recv(), Err(TryRecvError::Empty)),
         "device should be announced exactly once"
+    );
+}
+
+// The server starts processing Device Sink interface messages only after the per-device channel
+// handshake completes (section 3.2.5.2.2), so an earlier ADD_DEVICE is out of sequence and is
+// ignored (section 3.1.5).
+#[test]
+fn add_device_before_the_channel_handshake_is_ignored() {
+    let udev_iface = InterfaceId::try_from(4).expect("valid device interface id");
+    let completion_iface = InterfaceId::try_from(5).expect("valid completion interface id");
+    let (device_announced, announcement_rx) = mpsc::channel();
+    let backend = Box::new(TestDeviceBackend { device_announced });
+    let mut server = UrbdrcDeviceServer::new(backend, completion_iface).expect("device server should be created");
+
+    let add_device = add_device_from_info(udev_iface, &simple_device_info()).expect("ADD_DEVICE should be generated");
+    let resp = server
+        .process(11, &encode_pdu(&UrbdrcClientDevicePdu::AddDev(add_device)))
+        .expect("add device before the capability exchange should be ignored");
+    assert!(resp.is_empty());
+
+    let resp = server.start(11).expect("start should succeed");
+    let UrbdrcServerDevicePdu::Caps(request) = decode_device_msg(&resp[0]) else {
+        panic!("expected capability request");
+    };
+    server
+        .process(
+            11,
+            &encode_pdu(&UrbdrcClientDevicePdu::Caps(RimExchangeCapabilityResponse {
+                msg_id: request.msg_id,
+                capability: Capability::RimCapabilityVersion01,
+                result: 0,
+            })),
+        )
+        .expect("capability response should succeed");
+
+    let add_device = add_device_from_info(udev_iface, &simple_device_info()).expect("ADD_DEVICE should be generated");
+    let resp = server
+        .process(11, &encode_pdu(&UrbdrcClientDevicePdu::AddDev(add_device)))
+        .expect("add device before CHANNEL_CREATED should be ignored");
+    assert!(resp.is_empty());
+
+    assert!(
+        matches!(announcement_rx.try_recv(), Err(TryRecvError::Empty)),
+        "no device should be announced before the handshake completes"
     );
 }


### PR DESCRIPTION
Reported by @clintcan in #1417:

> The per-device channel needs its own capability exchange, or mstsc closes it. Your per-device processor's start() (UrbdrcDeviceServer) returns CHANNEL_CREATED directly, with no preceding RIM_EXCHANGE_CAPABILITY_REQUEST — your main UrbdrcControlServer::start() sends one, the per-device one doesn't. That's fine on FreeRDP (its readiness is global to the main channel), but we found live (mstsc, mid-2026) that mstsc closes a per-device channel that gets CHANNEL_CREATED / RIMCALL_RELEASE without a preceding capability exchange — it keeps the channel open-but-silent waiting for the caps request, so the device never emits ADD_DEVICE. Our per-device processor therefore runs the full caps → CHANNEL_CREATED handshake on each per-device channel, same as the main one.

## Changes

- `UrbdrcDeviceServer::start()` emits `RIM_EXCHANGE_CAPABILITY_REQUEST`; on the response it releases the capabilities interface and sends `CHANNEL_CREATED`, mirroring `UrbdrcControlServer`.
- `UrbdrcDeviceClient` answers a capability request on the per-device channel.
- The capabilities interface is decodable on the per-device channel in both directions.
- Device handshake state is now `AwaitingCaps → AwaitingChanCreated → AwaitingDevice → Ready`, so `ADD_DEVICE` is processed only after the handshake completes per 3.2.5.2.2.

BREAKING CHANGE: `UrbdrcServerDevicePdu` and `UrbdrcClientDevicePdu` are public and not `#[non_exhaustive]`, so the new `Caps` variant breaks exhaustive matches.