### PR TITLE
feat(mstsgu): add Negotiate and NTLM HTTP gateway auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2931,6 +2931,7 @@ dependencies = [
  "ironrdp-error 0.2.0",
  "ironrdp-tls",
  "log",
+ "sspi",
  "tokio",
  "tokio-tungstenite",
  "tokio-util",

--- a/crates/ironrdp-mstsgu/CHANGELOG.md
+++ b/crates/ironrdp-mstsgu/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- HTTP multi-leg authentication for the WebSocket upgrade: Negotiate SPNEGO (Kerberos with NTLM fallback via KDC discovery / `SSPI_KDC_URL`), pure NTLM when only NTLM is advertised, and Basic fallback.
 
 ## [[0.0.1](https://github.com/Devolutions/IronRDP/releases/tag/ironrdp-mstsgu-v0.0.1)] - 2026-07-10
 

--- a/crates/ironrdp-mstsgu/Cargo.toml
+++ b/crates/ironrdp-mstsgu/Cargo.toml
@@ -14,6 +14,12 @@ categories.workspace = true
 
 [lib]
 doctest = false
+test = false
+
+[[test]]
+name = "http_auth"
+path = "tests/http_auth.rs"
+required-features = ["native-tls"]
 
 [features]
 default = []

--- a/crates/ironrdp-mstsgu/Cargo.toml
+++ b/crates/ironrdp-mstsgu/Cargo.toml
@@ -14,7 +14,6 @@ categories.workspace = true
 
 [lib]
 doctest = false
-test = false
 
 [features]
 default = []
@@ -32,6 +31,7 @@ ironrdp-core = { path = "../ironrdp-core", version = "0.2", features = ["std"] }
 ironrdp-error = { path = "../ironrdp-error", version = "0.2" }
 ironrdp-tls = { path = "../ironrdp-tls", version = "0.2" }
 log = "0.4"
+sspi = { version = "0.21", features = ["network_client"] }
 tokio-tungstenite = { version = "0.29" }
 tokio-util = { version = "0.7" }
 tokio = { version = "1.52", features = ["macros", "rt"] }

--- a/crates/ironrdp-mstsgu/README.md
+++ b/crates/ironrdp-mstsgu/README.md
@@ -5,7 +5,7 @@
 This crate
 - implements an MVP state needed to connect through Microsoft RD Gateway,
 - only supports the HTTPS protocol with WebSocket (and not the legacy HTTP, HTTP-RPC or UDP protocols),
-- does not implement reconnection/reauthentication, and
-- only supports basic auth.
+- does not implement reconnection/reauthentication, Detect, or a live UDP path, and
+- authenticates the WebSocket upgrade with HTTP Negotiate (Kerberos then NTLM), NTLM, or Basic fallback.
 
 [MS-TSGU]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsgu/0007d661-a86d-4e8f-89f7-7f77f8824188

--- a/crates/ironrdp-mstsgu/src/http_auth.rs
+++ b/crates/ironrdp-mstsgu/src/http_auth.rs
@@ -2,8 +2,7 @@
 //!
 //! Corporate RD Gateways typically challenge with Negotiate and/or NTLM rather than Basic.
 //! Negotiate prefers Kerberos (via KDC / `SSPI_KDC_URL`) and falls back to NTLM inside SPNEGO.
-//! Pure NTLM is used when the server only offers the NTLM scheme, and for MS-TSGU extended-auth
-//! SSPI NTLM blobs after the handshake.
+//! Pure NTLM is used when the server only offers the NTLM scheme.
 
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD;
@@ -50,13 +49,6 @@ pub struct GatewayHttpAuth {
     complete: bool,
 }
 
-/// Client-side NTLM state for MS-TSGU `HTTP_EXTENDED_AUTH_PACKET` SSPI NTLM blobs.
-pub struct NtlmHttpAuth {
-    ntlm: Ntlm,
-    credentials_handle: Option<AuthIdentityBuffers>,
-    complete: bool,
-}
-
 impl GatewayHttpAuth {
     pub fn scheme(&self) -> &'static str {
         self.scheme
@@ -70,14 +62,14 @@ impl GatewayHttpAuth {
         password: &str,
         target_name: Option<String>,
         challenges: &[&str],
-    ) -> Result<(Self, AuthStep), Error> {
+    ) -> Result<(Option<Self>, AuthStep), Error> {
         let mut saw_negotiate = false;
         let mut saw_ntlm = false;
         let mut saw_basic = false;
         let mut negotiate_token: Option<Vec<u8>> = None;
         let mut ntlm_token: Option<Vec<u8>> = None;
 
-        for value in challenges {
+        for value in iter_auth_challenges(challenges.iter().copied()) {
             if let Some(rest) = split_auth_challenge(value, "Negotiate") {
                 saw_negotiate = true;
                 if rest.is_empty() {
@@ -117,7 +109,7 @@ impl GatewayHttpAuth {
             match auth.initialize(input) {
                 Ok(token) => {
                     let header = auth.format_authorization(&token);
-                    return Ok((auth, AuthStep::Continue(header)));
+                    return Ok((Some(auth), AuthStep::Continue(header)));
                 }
                 Err(error) if saw_ntlm => {
                     log::debug!("Negotiate failed ({error}); falling back to NTLM");
@@ -131,13 +123,11 @@ impl GatewayHttpAuth {
             let input = ntlm_token.as_deref().filter(|t| !t.is_empty());
             let token = auth.initialize(input)?;
             let header = auth.format_authorization(&token);
-            return Ok((auth, AuthStep::Continue(header)));
+            return Ok((Some(auth), AuthStep::Continue(header)));
         }
 
         if saw_basic {
-            // Dummy backend is not used when falling back to Basic.
-            let auth = Self::new_ntlm(username, password, target_name)?;
-            return Ok((auth, AuthStep::TryBasic));
+            return Ok((None, AuthStep::TryBasic));
         }
 
         Err(Error::new(
@@ -213,7 +203,7 @@ impl GatewayHttpAuth {
         let mut saw_basic = false;
         let mut token: Option<Vec<u8>> = None;
 
-        for value in challenges {
+        for value in iter_auth_challenges(challenges) {
             let preferred = match self.scheme {
                 "Negotiate" => split_auth_challenge(value, "Negotiate"),
                 _ => split_auth_challenge(value, "NTLM").or_else(|| split_auth_challenge(value, "Negotiate")),
@@ -252,6 +242,46 @@ impl GatewayHttpAuth {
                 GwErrorKind::UnsupportedFeature,
             )),
         }
+    }
+
+    /// Consume a final `WWW-Authenticate` token on a successful upgrade (RFC 4559).
+    ///
+    /// Missing tokens are accepted: NTLM upgrades typically omit them, and some
+    /// Negotiate servers do not send an AP-REP. A present token must complete SSPI.
+    pub(crate) fn finish_www_authenticate<'a, I>(&mut self, challenges: I) -> Result<(), Error>
+    where
+        I: IntoIterator<Item = &'a str>,
+    {
+        if self.complete {
+            return Ok(());
+        }
+
+        let mut token: Option<Vec<u8>> = None;
+        for value in iter_auth_challenges(challenges) {
+            let rest = match self.scheme {
+                "Negotiate" => split_auth_challenge(value, "Negotiate"),
+                _ => split_auth_challenge(value, "NTLM").or_else(|| split_auth_challenge(value, "Negotiate")),
+            };
+            if let Some(rest) = rest.filter(|rest| !rest.is_empty()) {
+                token = Some(
+                    STANDARD
+                        .decode(rest.as_bytes())
+                        .map_err(|e| Error::custom("decode auth challenge", e))?,
+                );
+            }
+        }
+
+        if let Some(raw) = token {
+            let _ = self.initialize(Some(&raw))?;
+            if !self.complete {
+                return Err(Error::new(
+                    "websocket upgrade mutual auth incomplete",
+                    GwErrorKind::Connect,
+                ));
+            }
+        }
+
+        Ok(())
     }
 
     fn format_authorization(&self, token: &[u8]) -> String {
@@ -326,66 +356,6 @@ impl GatewayHttpAuth {
     }
 }
 
-impl NtlmHttpAuth {
-    pub fn new(username: &str, password: &str) -> Result<Self, Error> {
-        let identity = auth_identity(username, password)?;
-        let mut ntlm = Ntlm::new();
-        let credentials_handle = ntlm
-            .acquire_credentials_handle()
-            .with_credential_use(CredentialUse::Outbound)
-            .with_auth_data(&identity)
-            .execute(&mut ntlm)
-            .map_err(|e| Error::custom("acquire ntlm credentials", e))?
-            .credentials_handle;
-
-        Ok(Self {
-            ntlm,
-            credentials_handle,
-            complete: false,
-        })
-    }
-
-    /// Produce the next NTLM token for extended-auth packet exchange.
-    ///
-    /// Returns `(token, complete)`.
-    pub fn step_token(&mut self, input: Option<&[u8]>) -> Result<(Vec<u8>, bool), Error> {
-        let mut input_token = [SecurityBuffer::new(
-            input.map(<[u8]>::to_vec).unwrap_or_default(),
-            BufferType::Token,
-        )];
-        let mut output_token = [SecurityBuffer::new(Vec::with_capacity(1024), BufferType::Token)];
-
-        let mut builder = self
-            .ntlm
-            .initialize_security_context()
-            .with_credentials_handle(&mut self.credentials_handle)
-            .with_context_requirements(default_context_flags())
-            .with_target_data_representation(DataRepresentation::Native)
-            .with_input(&mut input_token)
-            .with_output(&mut output_token);
-
-        let InitializeSecurityContextResult { status, .. } = self
-            .ntlm
-            .initialize_security_context_impl(&mut builder)
-            .map_err(|e| Error::custom("ntlm initialize security context", e))?
-            .resolve_to_result()
-            .map_err(|e| Error::custom("ntlm initialize security context", e))?;
-
-        match status {
-            SecurityStatus::Ok => {
-                self.complete = true;
-            }
-            SecurityStatus::ContinueNeeded => {}
-            other => {
-                return Err(Error::new("ntlm security status", GwErrorKind::Connect)
-                    .with_source(std::io::Error::other(format!("unexpected ntlm status: {other:?}"))));
-            }
-        }
-
-        Ok((core::mem::take(&mut output_token[0].buffer), self.complete))
-    }
-}
-
 /// Build a Basic authorization header value.
 pub fn basic_authorization(username: &str, password: &str) -> String {
     let token = STANDARD.encode(format!("{username}:{password}"));
@@ -414,6 +384,44 @@ fn default_context_flags() -> ClientRequestFlags {
         | ClientRequestFlags::CONFIDENTIALITY
         | ClientRequestFlags::INTEGRITY
         | ClientRequestFlags::MUTUAL_AUTH
+}
+
+fn iter_auth_challenges<'a, I>(values: I) -> impl Iterator<Item = &'a str>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    values.into_iter().flat_map(split_challenge_list)
+}
+
+/// Split a list-valued `WWW-Authenticate` field into individual challenges.
+///
+/// Commas inside quoted auth-param values are not separators.
+fn split_challenge_list(value: &str) -> Vec<&str> {
+    let mut out = Vec::new();
+    let mut start = 0;
+    let mut in_quotes = false;
+    let mut escaped = false;
+    for (i, ch) in value.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match ch {
+            '\\' if in_quotes => escaped = true,
+            '"' => in_quotes = !in_quotes,
+            ',' if !in_quotes => {
+                if let Some(piece) = value.get(start..i).map(str::trim).filter(|piece| !piece.is_empty()) {
+                    out.push(piece);
+                }
+                start = i + ch.len_utf8();
+            }
+            _ => {}
+        }
+    }
+    if let Some(piece) = value.get(start..).map(str::trim).filter(|piece| !piece.is_empty()) {
+        out.push(piece);
+    }
+    out
 }
 
 /// Case-insensitive scheme match; returns the remainder after the scheme (may be empty).

--- a/crates/ironrdp-mstsgu/src/http_auth.rs
+++ b/crates/ironrdp-mstsgu/src/http_auth.rs
@@ -18,7 +18,7 @@ use crate::{Error, GwErrorExt as _, GwErrorKind};
 
 /// Result of consuming one HTTP auth challenge/response.
 #[derive(Debug)]
-pub(crate) enum AuthStep {
+pub enum AuthStep {
     /// Send another request with this `Authorization` header value.
     Continue(String),
     /// Authentication finished (caller should inspect the final HTTP status).
@@ -41,7 +41,7 @@ enum AuthBackend {
 }
 
 /// Multi-leg HTTP auth state for `Authorization: NTLM …` / `Negotiate …`.
-pub(crate) struct GatewayHttpAuth {
+pub struct GatewayHttpAuth {
     backend: AuthBackend,
     /// Scheme used in the Authorization header (`NTLM` or `Negotiate`).
     scheme: &'static str,
@@ -51,17 +51,21 @@ pub(crate) struct GatewayHttpAuth {
 }
 
 /// Client-side NTLM state for MS-TSGU `HTTP_EXTENDED_AUTH_PACKET` SSPI NTLM blobs.
-pub(crate) struct NtlmHttpAuth {
+pub struct NtlmHttpAuth {
     ntlm: Ntlm,
     credentials_handle: Option<AuthIdentityBuffers>,
     complete: bool,
 }
 
 impl GatewayHttpAuth {
+    pub fn scheme(&self) -> &'static str {
+        self.scheme
+    }
+
     /// Build auth state from a first-round `WWW-Authenticate` challenge set.
     ///
     /// Prefers Negotiate (Kerberos → NTLM SPNEGO) when advertised, otherwise pure NTLM.
-    pub(crate) fn from_challenges(
+    pub fn from_challenges(
         username: &str,
         password: &str,
         target_name: Option<String>,
@@ -322,12 +326,8 @@ impl GatewayHttpAuth {
     }
 }
 
-#[cfg_attr(
-    not(test),
-    expect(dead_code, reason = "kept for post-handshake SSPI NTLM extended auth")
-)]
 impl NtlmHttpAuth {
-    pub(crate) fn new(username: &str, password: &str) -> Result<Self, Error> {
+    pub fn new(username: &str, password: &str) -> Result<Self, Error> {
         let identity = auth_identity(username, password)?;
         let mut ntlm = Ntlm::new();
         let credentials_handle = ntlm
@@ -348,7 +348,7 @@ impl NtlmHttpAuth {
     /// Produce the next NTLM token for extended-auth packet exchange.
     ///
     /// Returns `(token, complete)`.
-    pub(crate) fn step_token(&mut self, input: Option<&[u8]>) -> Result<(Vec<u8>, bool), Error> {
+    pub fn step_token(&mut self, input: Option<&[u8]>) -> Result<(Vec<u8>, bool), Error> {
         let mut input_token = [SecurityBuffer::new(
             input.map(<[u8]>::to_vec).unwrap_or_default(),
             BufferType::Token,
@@ -387,7 +387,7 @@ impl NtlmHttpAuth {
 }
 
 /// Build a Basic authorization header value.
-pub(crate) fn basic_authorization(username: &str, password: &str) -> String {
+pub fn basic_authorization(username: &str, password: &str) -> String {
     let token = STANDARD.encode(format!("{username}:{password}"));
     format!("Basic {token}")
 }
@@ -417,7 +417,7 @@ fn default_context_flags() -> ClientRequestFlags {
 }
 
 /// Case-insensitive scheme match; returns the remainder after the scheme (may be empty).
-fn split_auth_challenge<'a>(header_value: &'a str, scheme: &str) -> Option<&'a str> {
+pub fn split_auth_challenge<'a>(header_value: &'a str, scheme: &str) -> Option<&'a str> {
     let header_value = header_value.trim();
     let scheme_len = scheme.len();
     if header_value.len() < scheme_len {
@@ -444,83 +444,4 @@ pub(crate) fn www_authenticate_values(headers: &hyper::HeaderMap) -> Vec<&str> {
         .iter()
         .filter_map(|v| v.to_str().ok())
         .collect()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn split_auth_challenge_parses_schemes() {
-        assert_eq!(split_auth_challenge("NTLM TlRMTVNTUA==", "NTLM"), Some("TlRMTVNTUA=="));
-        assert_eq!(split_auth_challenge("ntlm", "NTLM"), Some(""));
-        assert_eq!(split_auth_challenge("Negotiate abc", "Negotiate"), Some("abc"));
-        assert_eq!(
-            split_auth_challenge("Basic realm=\"rdg\"", "Basic"),
-            Some("realm=\"rdg\"")
-        );
-        assert_eq!(split_auth_challenge("Digest qop=auth", "NTLM"), None);
-    }
-
-    #[test]
-    fn basic_authorization_format() {
-        let value = basic_authorization("user", "pass");
-        assert_eq!(value, "Basic dXNlcjpwYXNz");
-    }
-
-    #[test]
-    fn negotiate_type1_from_challenge() {
-        let (auth, step) = GatewayHttpAuth::from_challenges(
-            r"CONTOSO\alice",
-            "secret",
-            Some("HTTP/rdg.contoso.com".to_owned()),
-            &["Negotiate"],
-        )
-        .expect("negotiate init");
-        assert_eq!(auth.scheme, "Negotiate");
-        match step {
-            AuthStep::Continue(header) => {
-                assert!(header.starts_with("Negotiate "));
-                assert!(header.len() > "Negotiate ".len());
-            }
-            other => panic!("expected Continue, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn ntlm_type1_from_challenge() {
-        let (auth, step) =
-            GatewayHttpAuth::from_challenges(r"CONTOSO\alice", "secret", None, &["NTLM"]).expect("ntlm init");
-        assert_eq!(auth.scheme, "NTLM");
-        match step {
-            AuthStep::Continue(header) => {
-                assert!(header.starts_with("NTLM "));
-                assert!(header.len() > "NTLM ".len());
-            }
-            other => panic!("expected Continue, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn try_basic_when_only_basic_offered() {
-        let (_auth, step) =
-            GatewayHttpAuth::from_challenges("alice", "secret", None, &["Basic realm=\"RDG\""]).expect("basic");
-        assert!(matches!(step, AuthStep::TryBasic));
-    }
-
-    #[test]
-    fn extended_auth_ntlm_type1_non_empty() {
-        let mut auth = NtlmHttpAuth::new(r"CONTOSO\alice", "secret").expect("ntlm init");
-        let (token, complete) = auth.step_token(None).expect("type1");
-        assert!(!token.is_empty());
-        assert!(!complete);
-    }
-
-    #[test]
-    fn prefer_negotiate_over_ntlm() {
-        let (auth, _) =
-            GatewayHttpAuth::from_challenges("alice", "secret", None, &["NTLM", "Negotiate", "Basic realm=\"x\""])
-                .expect("init");
-        assert_eq!(auth.scheme, "Negotiate");
-    }
 }

--- a/crates/ironrdp-mstsgu/src/http_auth.rs
+++ b/crates/ironrdp-mstsgu/src/http_auth.rs
@@ -1,0 +1,526 @@
+//! HTTP authentication helpers for the MS-TSGU WebSocket upgrade.
+//!
+//! Corporate RD Gateways typically challenge with Negotiate and/or NTLM rather than Basic.
+//! Negotiate prefers Kerberos (via KDC / `SSPI_KDC_URL`) and falls back to NTLM inside SPNEGO.
+//! Pure NTLM is used when the server only offers the NTLM scheme, and for MS-TSGU extended-auth
+//! SSPI NTLM blobs after the handshake.
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD;
+use sspi::ntlm::NtlmConfig;
+use sspi::{
+    AuthIdentity, AuthIdentityBuffers, BufferType, ClientRequestFlags, CredentialUse, Credentials, CredentialsBuffers,
+    DataRepresentation, InitializeSecurityContextResult, Negotiate, NegotiateConfig, Ntlm, SecurityBuffer,
+    SecurityStatus, Sspi as _, SspiImpl as _, Username,
+};
+
+use crate::{Error, GwErrorExt as _, GwErrorKind};
+
+/// Result of consuming one HTTP auth challenge/response.
+#[derive(Debug)]
+pub(crate) enum AuthStep {
+    /// Send another request with this `Authorization` header value.
+    Continue(String),
+    /// Authentication finished (caller should inspect the final HTTP status).
+    Complete,
+    /// Server did not offer NTLM/Negotiate; try HTTP Basic instead.
+    TryBasic,
+}
+
+// SSPI state objects are large value types; boxing would add an indirection per call.
+#[expect(clippy::large_enum_variant, reason = "SSPI state objects are large value types")]
+enum AuthBackend {
+    Ntlm {
+        ntlm: Ntlm,
+        credentials_handle: Option<AuthIdentityBuffers>,
+    },
+    Negotiate {
+        negotiate: Negotiate,
+        credentials_handle: Option<CredentialsBuffers>,
+    },
+}
+
+/// Multi-leg HTTP auth state for `Authorization: NTLM …` / `Negotiate …`.
+pub(crate) struct GatewayHttpAuth {
+    backend: AuthBackend,
+    /// Scheme used in the Authorization header (`NTLM` or `Negotiate`).
+    scheme: &'static str,
+    /// Optional SPN / target name (for example `HTTP/rdg.contoso.com`).
+    target_name: Option<String>,
+    complete: bool,
+}
+
+/// Client-side NTLM state for MS-TSGU `HTTP_EXTENDED_AUTH_PACKET` SSPI NTLM blobs.
+pub(crate) struct NtlmHttpAuth {
+    ntlm: Ntlm,
+    credentials_handle: Option<AuthIdentityBuffers>,
+    complete: bool,
+}
+
+impl GatewayHttpAuth {
+    /// Build auth state from a first-round `WWW-Authenticate` challenge set.
+    ///
+    /// Prefers Negotiate (Kerberos → NTLM SPNEGO) when advertised, otherwise pure NTLM.
+    pub(crate) fn from_challenges(
+        username: &str,
+        password: &str,
+        target_name: Option<String>,
+        challenges: &[&str],
+    ) -> Result<(Self, AuthStep), Error> {
+        let mut saw_negotiate = false;
+        let mut saw_ntlm = false;
+        let mut saw_basic = false;
+        let mut negotiate_token: Option<Vec<u8>> = None;
+        let mut ntlm_token: Option<Vec<u8>> = None;
+
+        for value in challenges {
+            if let Some(rest) = split_auth_challenge(value, "Negotiate") {
+                saw_negotiate = true;
+                if rest.is_empty() {
+                    if negotiate_token.is_none() {
+                        negotiate_token = Some(Vec::new());
+                    }
+                } else {
+                    negotiate_token = Some(
+                        STANDARD
+                            .decode(rest.as_bytes())
+                            .map_err(|e| Error::custom("decode negotiate challenge", e))?,
+                    );
+                }
+            } else if let Some(rest) = split_auth_challenge(value, "NTLM") {
+                saw_ntlm = true;
+                if rest.is_empty() {
+                    if ntlm_token.is_none() {
+                        ntlm_token = Some(Vec::new());
+                    }
+                } else {
+                    ntlm_token = Some(
+                        STANDARD
+                            .decode(rest.as_bytes())
+                            .map_err(|e| Error::custom("decode ntlm challenge", e))?,
+                    );
+                }
+            } else if split_auth_challenge(value, "Basic").is_some() {
+                saw_basic = true;
+            }
+        }
+
+        if saw_negotiate {
+            let mut auth = Self::new_negotiate(username, password, target_name.clone())?;
+            let input = negotiate_token.as_deref().filter(|t| !t.is_empty());
+            // Kerberos SPNEGO can fail without a reachable KDC (for example a gateway SPN
+            // with no ticket path); fall back to plain NTLM, which needs no network.
+            match auth.initialize(input) {
+                Ok(token) => {
+                    let header = auth.format_authorization(&token);
+                    return Ok((auth, AuthStep::Continue(header)));
+                }
+                Err(error) if saw_ntlm => {
+                    log::debug!("Negotiate failed ({error}); falling back to NTLM");
+                }
+                Err(error) => return Err(error),
+            }
+        }
+
+        if saw_ntlm {
+            let mut auth = Self::new_ntlm(username, password, target_name)?;
+            let input = ntlm_token.as_deref().filter(|t| !t.is_empty());
+            let token = auth.initialize(input)?;
+            let header = auth.format_authorization(&token);
+            return Ok((auth, AuthStep::Continue(header)));
+        }
+
+        if saw_basic {
+            // Dummy backend is not used when falling back to Basic.
+            let auth = Self::new_ntlm(username, password, target_name)?;
+            return Ok((auth, AuthStep::TryBasic));
+        }
+
+        Err(Error::new(
+            "websocket upgrade auth challenge",
+            GwErrorKind::UnsupportedFeature,
+        ))
+    }
+
+    fn new_ntlm(username: &str, password: &str, target_name: Option<String>) -> Result<Self, Error> {
+        let identity = auth_identity(username, password)?;
+        let mut ntlm = Ntlm::new();
+        let credentials_handle = ntlm
+            .acquire_credentials_handle()
+            .with_credential_use(CredentialUse::Outbound)
+            .with_auth_data(&identity)
+            .execute(&mut ntlm)
+            .map_err(|e| Error::custom("acquire ntlm credentials", e))?
+            .credentials_handle;
+
+        Ok(Self {
+            backend: AuthBackend::Ntlm {
+                ntlm,
+                credentials_handle,
+            },
+            scheme: "NTLM",
+            target_name,
+            complete: false,
+        })
+    }
+
+    fn new_negotiate(username: &str, password: &str, target_name: Option<String>) -> Result<Self, Error> {
+        let identity = auth_identity(username, password)?;
+        let credentials = Credentials::AuthIdentity(identity);
+        let client_computer_name = client_computer_name();
+
+        // Start as NTLM; Negotiate upgrades to Kerberos when a KDC is discoverable.
+        let config = NegotiateConfig {
+            protocol_config: Box::new(NtlmConfig::new(client_computer_name.clone())),
+            // Prefer Kerberos when available; keep NTLM fallback; skip PKU2U for gateway HTTP.
+            package_list: Some("kerberos,ntlm".to_owned()),
+            client_computer_name,
+        };
+
+        let mut negotiate = Negotiate::new_client(config).map_err(|e| Error::custom("create negotiate package", e))?;
+        let credentials_handle = negotiate
+            .acquire_credentials_handle()
+            .with_credential_use(CredentialUse::Outbound)
+            .with_auth_data(&credentials)
+            .execute(&mut negotiate)
+            .map_err(|e| Error::custom("acquire negotiate credentials", e))?
+            .credentials_handle;
+
+        Ok(Self {
+            backend: AuthBackend::Negotiate {
+                negotiate,
+                credentials_handle,
+            },
+            scheme: "Negotiate",
+            target_name,
+            complete: false,
+        })
+    }
+
+    /// Consume a subsequent `WWW-Authenticate` challenge and produce the next step.
+    pub(crate) fn step_www_authenticate<'a, I>(&mut self, challenges: I) -> Result<AuthStep, Error>
+    where
+        I: IntoIterator<Item = &'a str>,
+    {
+        if self.complete {
+            return Ok(AuthStep::Complete);
+        }
+
+        let mut saw_basic = false;
+        let mut token: Option<Vec<u8>> = None;
+
+        for value in challenges {
+            let preferred = match self.scheme {
+                "Negotiate" => split_auth_challenge(value, "Negotiate"),
+                _ => split_auth_challenge(value, "NTLM").or_else(|| split_auth_challenge(value, "Negotiate")),
+            };
+
+            if let Some(rest) = preferred {
+                if rest.is_empty() {
+                    if token.is_none() {
+                        token = Some(Vec::new());
+                    }
+                } else {
+                    token = Some(
+                        STANDARD
+                            .decode(rest.as_bytes())
+                            .map_err(|e| Error::custom("decode auth challenge", e))?,
+                    );
+                }
+            } else if split_auth_challenge(value, "Basic").is_some() {
+                saw_basic = true;
+            }
+        }
+
+        match token {
+            Some(raw) => {
+                let input = if raw.is_empty() { None } else { Some(raw.as_slice()) };
+                let next = self.initialize(input)?;
+                if self.complete && next.is_empty() {
+                    Ok(AuthStep::Complete)
+                } else {
+                    Ok(AuthStep::Continue(self.format_authorization(&next)))
+                }
+            }
+            None if saw_basic => Ok(AuthStep::TryBasic),
+            None => Err(Error::new(
+                "websocket upgrade auth challenge",
+                GwErrorKind::UnsupportedFeature,
+            )),
+        }
+    }
+
+    fn format_authorization(&self, token: &[u8]) -> String {
+        format!("{} {}", self.scheme, STANDARD.encode(token))
+    }
+
+    fn initialize(&mut self, input: Option<&[u8]>) -> Result<Vec<u8>, Error> {
+        let mut input_token = [SecurityBuffer::new(
+            input.map(<[u8]>::to_vec).unwrap_or_default(),
+            BufferType::Token,
+        )];
+        let mut output_token = [SecurityBuffer::new(Vec::with_capacity(1024), BufferType::Token)];
+
+        let status = match &mut self.backend {
+            AuthBackend::Ntlm {
+                ntlm,
+                credentials_handle,
+            } => {
+                let mut builder = ntlm
+                    .initialize_security_context()
+                    .with_credentials_handle(credentials_handle)
+                    .with_context_requirements(default_context_flags())
+                    .with_target_data_representation(DataRepresentation::Native)
+                    .with_input(&mut input_token)
+                    .with_output(&mut output_token);
+                builder.target_name = self.target_name.as_deref();
+
+                let InitializeSecurityContextResult { status, .. } = ntlm
+                    .initialize_security_context_impl(&mut builder)
+                    .map_err(|e| Error::custom("ntlm initialize security context", e))?
+                    .resolve_to_result()
+                    .map_err(|e| Error::custom("ntlm initialize security context", e))?;
+                status
+            }
+            AuthBackend::Negotiate {
+                negotiate,
+                credentials_handle,
+            } => {
+                let mut builder = negotiate
+                    .initialize_security_context()
+                    .with_credentials_handle(credentials_handle)
+                    .with_context_requirements(default_context_flags())
+                    .with_target_data_representation(DataRepresentation::Native)
+                    .with_input(&mut input_token)
+                    .with_output(&mut output_token);
+                builder.target_name = self.target_name.as_deref();
+
+                let mut generator = negotiate
+                    .initialize_security_context_impl(&mut builder)
+                    .map_err(|e| Error::custom("negotiate initialize security context", e))?;
+
+                // Kerberos may suspend for KDC traffic; NTLM completes without network.
+                let InitializeSecurityContextResult { status, .. } = generator
+                    .resolve_with_default_network_client()
+                    .map_err(|e| Error::custom("negotiate initialize security context", e))?;
+                status
+            }
+        };
+
+        match status {
+            SecurityStatus::Ok => {
+                self.complete = true;
+            }
+            SecurityStatus::ContinueNeeded => {}
+            other => {
+                return Err(Error::new("http auth security status", GwErrorKind::Connect)
+                    .with_source(std::io::Error::other(format!("unexpected auth status: {other:?}"))));
+            }
+        }
+
+        Ok(core::mem::take(&mut output_token[0].buffer))
+    }
+}
+
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "kept for post-handshake SSPI NTLM extended auth")
+)]
+impl NtlmHttpAuth {
+    pub(crate) fn new(username: &str, password: &str) -> Result<Self, Error> {
+        let identity = auth_identity(username, password)?;
+        let mut ntlm = Ntlm::new();
+        let credentials_handle = ntlm
+            .acquire_credentials_handle()
+            .with_credential_use(CredentialUse::Outbound)
+            .with_auth_data(&identity)
+            .execute(&mut ntlm)
+            .map_err(|e| Error::custom("acquire ntlm credentials", e))?
+            .credentials_handle;
+
+        Ok(Self {
+            ntlm,
+            credentials_handle,
+            complete: false,
+        })
+    }
+
+    /// Produce the next NTLM token for extended-auth packet exchange.
+    ///
+    /// Returns `(token, complete)`.
+    pub(crate) fn step_token(&mut self, input: Option<&[u8]>) -> Result<(Vec<u8>, bool), Error> {
+        let mut input_token = [SecurityBuffer::new(
+            input.map(<[u8]>::to_vec).unwrap_or_default(),
+            BufferType::Token,
+        )];
+        let mut output_token = [SecurityBuffer::new(Vec::with_capacity(1024), BufferType::Token)];
+
+        let mut builder = self
+            .ntlm
+            .initialize_security_context()
+            .with_credentials_handle(&mut self.credentials_handle)
+            .with_context_requirements(default_context_flags())
+            .with_target_data_representation(DataRepresentation::Native)
+            .with_input(&mut input_token)
+            .with_output(&mut output_token);
+
+        let InitializeSecurityContextResult { status, .. } = self
+            .ntlm
+            .initialize_security_context_impl(&mut builder)
+            .map_err(|e| Error::custom("ntlm initialize security context", e))?
+            .resolve_to_result()
+            .map_err(|e| Error::custom("ntlm initialize security context", e))?;
+
+        match status {
+            SecurityStatus::Ok => {
+                self.complete = true;
+            }
+            SecurityStatus::ContinueNeeded => {}
+            other => {
+                return Err(Error::new("ntlm security status", GwErrorKind::Connect)
+                    .with_source(std::io::Error::other(format!("unexpected ntlm status: {other:?}"))));
+            }
+        }
+
+        Ok((core::mem::take(&mut output_token[0].buffer), self.complete))
+    }
+}
+
+/// Build a Basic authorization header value.
+pub(crate) fn basic_authorization(username: &str, password: &str) -> String {
+    let token = STANDARD.encode(format!("{username}:{password}"));
+    format!("Basic {token}")
+}
+
+fn auth_identity(username: &str, password: &str) -> Result<AuthIdentity, Error> {
+    let username = Username::parse(username)
+        .or_else(|_| Username::new(username, None))
+        .map_err(|e| Error::custom("parse gateway username", e))?;
+
+    Ok(AuthIdentity {
+        username,
+        password: password.to_owned().into(),
+    })
+}
+
+fn client_computer_name() -> String {
+    std::env::var("COMPUTERNAME")
+        .or_else(|_| std::env::var("HOSTNAME"))
+        .unwrap_or_else(|_| "IRONRDP".to_owned())
+}
+
+fn default_context_flags() -> ClientRequestFlags {
+    ClientRequestFlags::ALLOCATE_MEMORY
+        | ClientRequestFlags::CONFIDENTIALITY
+        | ClientRequestFlags::INTEGRITY
+        | ClientRequestFlags::MUTUAL_AUTH
+}
+
+/// Case-insensitive scheme match; returns the remainder after the scheme (may be empty).
+fn split_auth_challenge<'a>(header_value: &'a str, scheme: &str) -> Option<&'a str> {
+    let header_value = header_value.trim();
+    let scheme_len = scheme.len();
+    if header_value.len() < scheme_len {
+        return None;
+    }
+    if !header_value.as_bytes()[..scheme_len].eq_ignore_ascii_case(scheme.as_bytes()) {
+        return None;
+    }
+    // The scheme is ASCII, so this byte offset is always a char boundary.
+    let rest = header_value.get(scheme_len..)?;
+    if rest.is_empty() {
+        return Some("");
+    }
+    if !rest.starts_with([' ', '\t']) {
+        return None;
+    }
+    Some(rest.trim())
+}
+
+/// Collect all `WWW-Authenticate` header values as strings.
+pub(crate) fn www_authenticate_values(headers: &hyper::HeaderMap) -> Vec<&str> {
+    headers
+        .get_all(hyper::header::WWW_AUTHENTICATE)
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_auth_challenge_parses_schemes() {
+        assert_eq!(split_auth_challenge("NTLM TlRMTVNTUA==", "NTLM"), Some("TlRMTVNTUA=="));
+        assert_eq!(split_auth_challenge("ntlm", "NTLM"), Some(""));
+        assert_eq!(split_auth_challenge("Negotiate abc", "Negotiate"), Some("abc"));
+        assert_eq!(
+            split_auth_challenge("Basic realm=\"rdg\"", "Basic"),
+            Some("realm=\"rdg\"")
+        );
+        assert_eq!(split_auth_challenge("Digest qop=auth", "NTLM"), None);
+    }
+
+    #[test]
+    fn basic_authorization_format() {
+        let value = basic_authorization("user", "pass");
+        assert_eq!(value, "Basic dXNlcjpwYXNz");
+    }
+
+    #[test]
+    fn negotiate_type1_from_challenge() {
+        let (auth, step) = GatewayHttpAuth::from_challenges(
+            r"CONTOSO\alice",
+            "secret",
+            Some("HTTP/rdg.contoso.com".to_owned()),
+            &["Negotiate"],
+        )
+        .expect("negotiate init");
+        assert_eq!(auth.scheme, "Negotiate");
+        match step {
+            AuthStep::Continue(header) => {
+                assert!(header.starts_with("Negotiate "));
+                assert!(header.len() > "Negotiate ".len());
+            }
+            other => panic!("expected Continue, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ntlm_type1_from_challenge() {
+        let (auth, step) =
+            GatewayHttpAuth::from_challenges(r"CONTOSO\alice", "secret", None, &["NTLM"]).expect("ntlm init");
+        assert_eq!(auth.scheme, "NTLM");
+        match step {
+            AuthStep::Continue(header) => {
+                assert!(header.starts_with("NTLM "));
+                assert!(header.len() > "NTLM ".len());
+            }
+            other => panic!("expected Continue, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn try_basic_when_only_basic_offered() {
+        let (_auth, step) =
+            GatewayHttpAuth::from_challenges("alice", "secret", None, &["Basic realm=\"RDG\""]).expect("basic");
+        assert!(matches!(step, AuthStep::TryBasic));
+    }
+
+    #[test]
+    fn extended_auth_ntlm_type1_non_empty() {
+        let mut auth = NtlmHttpAuth::new(r"CONTOSO\alice", "secret").expect("ntlm init");
+        let (token, complete) = auth.step_token(None).expect("type1");
+        assert!(!token.is_empty());
+        assert!(!complete);
+    }
+
+    #[test]
+    fn prefer_negotiate_over_ntlm() {
+        let (auth, _) =
+            GatewayHttpAuth::from_challenges("alice", "secret", None, &["NTLM", "Negotiate", "Basic realm=\"x\""])
+                .expect("init");
+        assert_eq!(auth.scheme, "Negotiate");
+    }
+}

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -4,7 +4,8 @@
 #[macro_use]
 mod macros;
 
-mod http_auth;
+#[doc(hidden)]
+pub mod http_auth;
 mod proto;
 
 use core::fmt;

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -4,6 +4,7 @@
 #[macro_use]
 mod macros;
 
+mod http_auth;
 mod proto;
 
 use core::fmt;
@@ -13,10 +14,9 @@ use core::task::Poll;
 use core::time::Duration;
 use std::io;
 
-use base64::Engine as _;
-use base64::engine::general_purpose::STANDARD;
 use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{FutureExt as _, SinkExt as _, StreamExt as _};
+use http_body_util::BodyExt as _;
 use hyper::body::Bytes;
 use ironrdp_core::{Decode as _, Encode, ReadCursor, WriteCursor};
 use ironrdp_tls::TlsStream;
@@ -30,6 +30,7 @@ use tokio_tungstenite::tungstenite::protocol::Role;
 use tokio_tungstenite::tungstenite::{Message, http};
 use tokio_util::sync::PollSender;
 
+use self::http_auth::{AuthStep, GatewayHttpAuth, basic_authorization, www_authenticate_values};
 use self::proto::{
     ChannelPkt, ChannelResp, DataPkt, HandshakeReqPkt, HandshakeRespPkt, HttpCapsTy, KeepalivePkt, PktHdr, PktTy,
     TunnelAuthPkt, TunnelAuthRespPkt, TunnelReqPkt, TunnelRespPkt,
@@ -153,19 +154,8 @@ impl GwClient {
             .await
             .map_err(|e| custom_err!("TLS connect", e))?;
 
-        let auth_val: String = STANDARD.encode(format!("{}:{}", target.gw_user, target.gw_pass));
-        let req = http::Request::builder()
-            .method("RDG_OUT_DATA")
-            .header(hyper::header::HOST, gw_host)
-            .header("Rdg-Connection-Id", format!("{{{}}}", uuid::Uuid::new_v4()))
-            .uri("/remoteDesktopGateway/")
-            .header(hyper::header::AUTHORIZATION, format!("Basic {auth_val}"))
-            .header(hyper::header::CONNECTION, "Upgrade")
-            .header(hyper::header::UPGRADE, "websocket")
-            .header(hyper::header::SEC_WEBSOCKET_VERSION, "13")
-            .header(hyper::header::SEC_WEBSOCKET_KEY, generate_key())
-            .body(http_body_util::Empty::<Bytes>::new())
-            .map_err(|e| custom_err!("failed to build request", e))?;
+        let connection_id = format!("{{{}}}", uuid::Uuid::new_v4());
+        let spn = format!("HTTP/{gw_host}");
 
         let stream = hyper_util::rt::tokio::TokioIo::new(stream);
         let (mut sender, mut conn) = hyper::client::conn::http1::handshake(stream)
@@ -180,14 +170,7 @@ impl GwClient {
             }
             conn.into_parts()
         });
-        let resp = sender
-            .send_request(req)
-            .await
-            .map_err(|e| custom_err!("WS Upgrade Send error", e))?;
-
-        if resp.status() != http::StatusCode::SWITCHING_PROTOCOLS {
-            return Err(Error::new("WS Upgrade", GwErrorKind::Connect));
-        }
+        websocket_upgrade_with_auth(&mut sender, gw_host, &connection_id, target, &spn).await?;
 
         let _ = tx.send(()); // TODO: Not needed since it doesnt keep alive conn?
         let stream = jh.await.map_err(|e| custom_err!("WS join", e))?.io.into_inner();
@@ -291,6 +274,112 @@ impl GwClient {
             tx: PollSender::new(out_tx),
         })
     }
+}
+
+/// Challenge-first WebSocket upgrade: omit Authorization until 401, then Negotiate/NTLM/Basic.
+async fn websocket_upgrade_with_auth(
+    sender: &mut hyper::client::conn::http1::SendRequest<http_body_util::Empty<Bytes>>,
+    gw_host: &str,
+    connection_id: &str,
+    target: &GwConnectTarget,
+    spn: &str,
+) -> Result<(), Error> {
+    let mut http_auth: Option<GatewayHttpAuth> = None;
+    let mut authorization: Option<String> = None;
+    let mut use_basic = false;
+    const MAX_AUTH_ROUNDS: usize = 8;
+
+    for _ in 0..MAX_AUTH_ROUNDS {
+        let req = build_ws_upgrade_request(
+            gw_host,
+            connection_id,
+            if use_basic {
+                Some(basic_authorization(&target.gw_user, &target.gw_pass))
+            } else {
+                authorization.clone()
+            }
+            .as_deref(),
+        )?;
+
+        let resp = sender
+            .send_request(req)
+            .await
+            .map_err(|e| custom_err!("WS Upgrade Send error", e))?;
+
+        if resp.status() == http::StatusCode::SWITCHING_PROTOCOLS {
+            return Ok(());
+        }
+
+        if resp.status() != http::StatusCode::UNAUTHORIZED {
+            return Err(Error::new("WS Upgrade", GwErrorKind::Connect));
+        }
+
+        if use_basic {
+            return Err(Error::new("websocket upgrade basic auth", GwErrorKind::Connect));
+        }
+
+        let challenges: Vec<String> = www_authenticate_values(resp.headers())
+            .into_iter()
+            .map(str::to_owned)
+            .collect();
+        resp.into_body()
+            .collect()
+            .await
+            .map_err(|e| custom_err!("drain websocket upgrade auth body", e))?;
+
+        let challenge_refs: Vec<&str> = challenges.iter().map(String::as_str).collect();
+        let step = if let Some(auth) = http_auth.as_mut() {
+            auth.step_www_authenticate(challenge_refs)?
+        } else {
+            let (auth, step) = GatewayHttpAuth::from_challenges(
+                &target.gw_user,
+                &target.gw_pass,
+                Some(spn.to_owned()),
+                &challenge_refs,
+            )?;
+            http_auth = Some(auth);
+            step
+        };
+
+        match step {
+            AuthStep::Continue(next) => authorization = Some(next),
+            AuthStep::TryBasic => use_basic = true,
+            AuthStep::Complete => {
+                return Err(Error::new(
+                    "websocket upgrade auth complete without switching protocols",
+                    GwErrorKind::Connect,
+                ));
+            }
+        }
+    }
+
+    Err(Error::new(
+        "websocket upgrade auth rounds exceeded",
+        GwErrorKind::Connect,
+    ))
+}
+
+fn build_ws_upgrade_request(
+    gw_host: &str,
+    connection_id: &str,
+    authorization: Option<&str>,
+) -> Result<http::Request<http_body_util::Empty<Bytes>>, Error> {
+    let mut req = http::Request::builder()
+        .method("RDG_OUT_DATA")
+        .header(hyper::header::HOST, gw_host)
+        .header("Rdg-Connection-Id", connection_id)
+        .uri("/remoteDesktopGateway/")
+        .header(hyper::header::CONNECTION, "Upgrade")
+        .header(hyper::header::UPGRADE, "websocket")
+        .header(hyper::header::SEC_WEBSOCKET_VERSION, "13")
+        .header(hyper::header::SEC_WEBSOCKET_KEY, generate_key());
+
+    if let Some(authorization) = authorization {
+        req = req.header(hyper::header::AUTHORIZATION, authorization);
+    }
+
+    req.body(http_body_util::Empty::<Bytes>::new())
+        .map_err(|e| custom_err!("failed to build request", e))
 }
 
 impl GwConn {

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -308,6 +308,13 @@ async fn websocket_upgrade_with_auth(
             .map_err(|e| custom_err!("WS Upgrade Send error", e))?;
 
         if resp.status() == http::StatusCode::SWITCHING_PROTOCOLS {
+            if let Some(mut auth) = http_auth.take() {
+                let challenges: Vec<String> = www_authenticate_values(resp.headers())
+                    .into_iter()
+                    .map(str::to_owned)
+                    .collect();
+                run_http_auth(move || auth.finish_www_authenticate(challenges.iter().map(String::as_str))).await?;
+            }
             return Ok(());
         }
 
@@ -328,17 +335,25 @@ async fn websocket_upgrade_with_auth(
             .await
             .map_err(|e| custom_err!("drain websocket upgrade auth body", e))?;
 
-        let challenge_refs: Vec<&str> = challenges.iter().map(String::as_str).collect();
-        let step = if let Some(auth) = http_auth.as_mut() {
-            auth.step_www_authenticate(challenge_refs)?
-        } else {
-            let (auth, step) = GatewayHttpAuth::from_challenges(
-                &target.gw_user,
-                &target.gw_pass,
-                Some(spn.to_owned()),
-                &challenge_refs,
-            )?;
+        let user = target.gw_user.clone();
+        let pass = target.gw_pass.clone();
+        let target_name = spn.to_owned();
+        let step = if let Some(mut auth) = http_auth.take() {
+            let (auth, step) = run_http_auth(move || {
+                let refs: Vec<&str> = challenges.iter().map(String::as_str).collect();
+                let step = auth.step_www_authenticate(refs)?;
+                Ok((auth, step))
+            })
+            .await?;
             http_auth = Some(auth);
+            step
+        } else {
+            let (auth, step) = run_http_auth(move || {
+                let refs: Vec<&str> = challenges.iter().map(String::as_str).collect();
+                GatewayHttpAuth::from_challenges(&user, &pass, Some(target_name), &refs)
+            })
+            .await?;
+            http_auth = auth;
             step
         };
 
@@ -358,6 +373,16 @@ async fn websocket_upgrade_with_auth(
         "websocket upgrade auth rounds exceeded",
         GwErrorKind::Connect,
     ))
+}
+
+async fn run_http_auth<T, F>(f: F) -> Result<T, Error>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, Error> + Send + 'static,
+{
+    tokio::task::spawn_blocking(f)
+        .await
+        .map_err(|e| Error::custom("http auth task", e))?
 }
 
 fn build_ws_upgrade_request(

--- a/crates/ironrdp-mstsgu/tests/http_auth.rs
+++ b/crates/ironrdp-mstsgu/tests/http_auth.rs
@@ -1,0 +1,77 @@
+#![allow(unused_crate_dependencies)]
+
+use ironrdp_mstsgu::http_auth::{AuthStep, GatewayHttpAuth, NtlmHttpAuth, basic_authorization, split_auth_challenge};
+
+#[test]
+fn split_auth_challenge_parses_schemes() {
+    assert_eq!(split_auth_challenge("NTLM TlRMTVNTUA==", "NTLM"), Some("TlRMTVNTUA=="));
+    assert_eq!(split_auth_challenge("ntlm", "NTLM"), Some(""));
+    assert_eq!(split_auth_challenge("Negotiate abc", "Negotiate"), Some("abc"));
+    assert_eq!(
+        split_auth_challenge("Basic realm=\"rdg\"", "Basic"),
+        Some("realm=\"rdg\"")
+    );
+    assert_eq!(split_auth_challenge("Digest qop=auth", "NTLM"), None);
+}
+
+#[test]
+fn basic_authorization_format() {
+    let value = basic_authorization("user", "pass");
+    assert_eq!(value, "Basic dXNlcjpwYXNz");
+}
+
+#[test]
+fn negotiate_type1_from_challenge() {
+    let (auth, step) = GatewayHttpAuth::from_challenges(
+        r"CONTOSO\alice",
+        "secret",
+        Some("HTTP/rdg.contoso.com".to_owned()),
+        &["Negotiate"],
+    )
+    .expect("negotiate init");
+    assert_eq!(auth.scheme(), "Negotiate");
+    match step {
+        AuthStep::Continue(header) => {
+            assert!(header.starts_with("Negotiate "));
+            assert!(header.len() > "Negotiate ".len());
+        }
+        other => panic!("expected Continue, got {other:?}"),
+    }
+}
+
+#[test]
+fn ntlm_type1_from_challenge() {
+    let (auth, step) =
+        GatewayHttpAuth::from_challenges(r"CONTOSO\alice", "secret", None, &["NTLM"]).expect("ntlm init");
+    assert_eq!(auth.scheme(), "NTLM");
+    match step {
+        AuthStep::Continue(header) => {
+            assert!(header.starts_with("NTLM "));
+            assert!(header.len() > "NTLM ".len());
+        }
+        other => panic!("expected Continue, got {other:?}"),
+    }
+}
+
+#[test]
+fn try_basic_when_only_basic_offered() {
+    let (_auth, step) =
+        GatewayHttpAuth::from_challenges("alice", "secret", None, &["Basic realm=\"RDG\""]).expect("basic");
+    assert!(matches!(step, AuthStep::TryBasic));
+}
+
+#[test]
+fn extended_auth_ntlm_type1_non_empty() {
+    let mut auth = NtlmHttpAuth::new(r"CONTOSO\alice", "secret").expect("ntlm init");
+    let (token, complete) = auth.step_token(None).expect("type1");
+    assert!(!token.is_empty());
+    assert!(!complete);
+}
+
+#[test]
+fn prefer_negotiate_over_ntlm() {
+    let (auth, _) =
+        GatewayHttpAuth::from_challenges("alice", "secret", None, &["NTLM", "Negotiate", "Basic realm=\"x\""])
+            .expect("init");
+    assert_eq!(auth.scheme(), "Negotiate");
+}

--- a/crates/ironrdp-mstsgu/tests/http_auth.rs
+++ b/crates/ironrdp-mstsgu/tests/http_auth.rs
@@ -1,6 +1,6 @@
 #![allow(unused_crate_dependencies)]
 
-use ironrdp_mstsgu::http_auth::{AuthStep, GatewayHttpAuth, NtlmHttpAuth, basic_authorization, split_auth_challenge};
+use ironrdp_mstsgu::http_auth::{AuthStep, GatewayHttpAuth, basic_authorization, split_auth_challenge};
 
 #[test]
 fn split_auth_challenge_parses_schemes() {
@@ -29,6 +29,7 @@ fn negotiate_type1_from_challenge() {
         &["Negotiate"],
     )
     .expect("negotiate init");
+    let auth = auth.expect("negotiate backend");
     assert_eq!(auth.scheme(), "Negotiate");
     match step {
         AuthStep::Continue(header) => {
@@ -43,6 +44,7 @@ fn negotiate_type1_from_challenge() {
 fn ntlm_type1_from_challenge() {
     let (auth, step) =
         GatewayHttpAuth::from_challenges(r"CONTOSO\alice", "secret", None, &["NTLM"]).expect("ntlm init");
+    let auth = auth.expect("ntlm backend");
     assert_eq!(auth.scheme(), "NTLM");
     match step {
         AuthStep::Continue(header) => {
@@ -55,17 +57,10 @@ fn ntlm_type1_from_challenge() {
 
 #[test]
 fn try_basic_when_only_basic_offered() {
-    let (_auth, step) =
+    let (auth, step) =
         GatewayHttpAuth::from_challenges("alice", "secret", None, &["Basic realm=\"RDG\""]).expect("basic");
+    assert!(auth.is_none());
     assert!(matches!(step, AuthStep::TryBasic));
-}
-
-#[test]
-fn extended_auth_ntlm_type1_non_empty() {
-    let mut auth = NtlmHttpAuth::new(r"CONTOSO\alice", "secret").expect("ntlm init");
-    let (token, complete) = auth.step_token(None).expect("type1");
-    assert!(!token.is_empty());
-    assert!(!complete);
 }
 
 #[test]
@@ -73,5 +68,22 @@ fn prefer_negotiate_over_ntlm() {
     let (auth, _) =
         GatewayHttpAuth::from_challenges("alice", "secret", None, &["NTLM", "Negotiate", "Basic realm=\"x\""])
             .expect("init");
-    assert_eq!(auth.scheme(), "Negotiate");
+    assert_eq!(auth.expect("negotiate backend").scheme(), "Negotiate");
+}
+
+#[test]
+fn combined_www_authenticate_prefers_negotiate() {
+    let (auth, step) =
+        GatewayHttpAuth::from_challenges("alice", "secret", None, &[r#"Negotiate, NTLM, Basic realm="RDG""#])
+            .expect("init");
+    assert_eq!(auth.expect("negotiate backend").scheme(), "Negotiate");
+    assert!(matches!(step, AuthStep::Continue(_)));
+}
+
+#[test]
+fn quoted_comma_in_basic_realm_is_one_challenge() {
+    let (auth, step) =
+        GatewayHttpAuth::from_challenges("alice", "secret", None, &[r#"Basic realm="a, b""#]).expect("basic");
+    assert!(auth.is_none());
+    assert!(matches!(step, AuthStep::TryBasic));
 }

--- a/xtask/src/check.rs
+++ b/xtask/src/check.rs
@@ -241,6 +241,11 @@ pub fn tests_compile(sh: &Shell) -> anyhow::Result<()> {
         "{CARGO} test -p ironrdp-tls --test native_tls --features native-tls --locked --no-run"
     )
     .run()?;
+    cmd!(
+        sh,
+        "{CARGO} test -p ironrdp-mstsgu --test http_auth --features native-tls --locked --no-run"
+    )
+    .run()?;
     println!("All good!");
     Ok(())
 }
@@ -251,6 +256,11 @@ pub fn tests_run(sh: &Shell) -> anyhow::Result<()> {
     cmd!(
         sh,
         "{CARGO} test -p ironrdp-tls --test native_tls --features native-tls --locked"
+    )
+    .run()?;
+    cmd!(
+        sh,
+        "{CARGO} test -p ironrdp-mstsgu --test http_auth --features native-tls --locked"
     )
     .run()?;
     println!("All good!");


### PR DESCRIPTION
Corporate RD Gateways typically challenge with Negotiate or NTLM rather than Basic, so the WebSocket-only client could not complete the upgrade.

The first upgrade request omits Authorization. On 401, WWW-Authenticate is parsed as an HTTP challenge list and Negotiate is preferred (Kerberos then NTLM inside SPNEGO via sspi network_client), then NTLM, then HTTP Basic. SSPI and KDC resolution run on spawn_blocking. A 101 may complete SSPI from a final GSS token when present. connect and connect_with_port signatures are unchanged.

sspi 0.21 is an implementation-only dependency. HTTP auth tests live in tests/http_auth.rs so [lib] test = false can stay. xtask runs that target with native-tls. RPCH, UDP, reauth, Detect, extended-auth packet exchange, and TLS channel bindings remain out of scope.