### PR TITLE
feat(replay): unwrap RD Gateway WebSocket tunnels

### DIFF
--- a/crates/ironrdp-capture-replay/README.md
+++ b/crates/ironrdp-capture-replay/README.md
@@ -3,6 +3,12 @@
 `ironrdp-capture-replay` replays supported direct-TCP RDP captures offline and exports framebuffer snapshots without writing TLS secrets, decrypted payloads, or raw capture data.
 It is an internal analysis tool built on the replay routing pipeline.
 
+RD Gateway (MS-TSGU) WebSocket captures are supported after the outer HTTPS session is already decrypted from the capture's embedded TLS key log.
+When that plaintext starts with an `RDG_OUT_DATA /remoteDesktopGateway/` upgrade, the WebSocket frames and `HTTP_DATA_PACKET` wrappers are removed and the recovered inner stream is replayed like a direct capture.
+RPC-over-HTTP (`RPC_IN_DATA` / `RPC_OUT_DATA`) tunnels are not unwrapped.
+External key-log files and resumed or mid-stream TLS decryption are out of scope.
+Unwrap runs only after TLS plaintext is already available.
+
 ## Exporting frames
 
 Run the CLI with a pcapng capture that contains the TLS key-log material required by the replay pipeline.

--- a/crates/ironrdp-capture-replay/src/error.rs
+++ b/crates/ironrdp-capture-replay/src/error.rs
@@ -53,4 +53,7 @@ pub enum ReplayError {
     /// A captured dynamic channel could not be attached.
     #[error("captured dynamic channel could not be attached")]
     DynamicChannelAttachment,
+    /// The gateway tunnel framing is incomplete or malformed.
+    #[error("capture gateway tunnel framing is invalid: {0}")]
+    GatewayFraming(String),
 }

--- a/crates/ironrdp-capture-replay/src/gateway.rs
+++ b/crates/ironrdp-capture-replay/src/gateway.rs
@@ -1,0 +1,219 @@
+//! MS-TSGU gateway tunnel extraction for captured TLS-decrypted HTTPS flows.
+//!
+//! Modern RD Gateway clients carry MS-TSGU packets in WebSocket binary frames
+//! after an `RDG_OUT_DATA` upgrade. This module unwraps that framing and
+//! recovers the tunneled RDP byte stream ([MS-TSGU] 2.2.10).
+
+use crate::transport::flatten;
+use crate::{PacketStream, Plaintext, ReplayError};
+
+/// `HTTP_DATA_PACKET` payload prefix: 2-byte length after the packet header.
+const DATA_PACKET_HEADER: usize = 8 /* packet header */ + 2 /* data length */;
+/// Maximum accepted WebSocket frame payload, larger than any TLS record batch.
+const MAX_WEBSOCKET_PAYLOAD: usize = 16 * 1024 * 1024;
+
+/// Returns `true` when the decrypted TLS streams carry an RDG WebSocket upgrade.
+pub fn is_gateway_tunnel(plaintext: &Plaintext) -> bool {
+    flatten(&plaintext.client).starts_with(b"RDG_OUT_DATA /remoteDesktopGateway/")
+}
+
+/// Extract the tunneled RDP bytes from a decrypted RDG WebSocket session.
+///
+/// The returned streams contain raw RDP traffic (starting with the X.224
+/// connection request) exactly as a direct TCP capture would carry it.
+pub fn extract_tunneled_rdp(plaintext: &Plaintext) -> Result<Plaintext, ReplayError> {
+    let client = websocket_payloads(&plaintext.client, true)?;
+    let server = websocket_payloads(&plaintext.server, false)?;
+    Ok(Plaintext {
+        client: data_packets(&client)?,
+        server: data_packets(&server)?,
+    })
+}
+
+/// HTTP method tokens that can start a WebSocket gateway request head.
+const REQUEST_HEAD_PREFIXES: [&[u8]; 2] = [b"RDG_OUT_DATA ".as_slice(), b"RDG_IN_DATA ".as_slice()];
+
+/// Split one direction into WebSocket message payloads, skipping the HTTP heads.
+///
+/// Client-to-server frames are masked per RFC 6455; server frames are not.
+/// Authentication can add request/response round trips (e.g. an NTLM 401
+/// challenge) before the final WebSocket upgrade, so interim HTTP heads are
+/// skipped until the bytes no longer look like HTTP.
+fn websocket_payloads(stream: &PacketStream, masked: bool) -> Result<PacketStream, ReplayError> {
+    let mut bytes = Vec::new();
+    let mut packet_offsets = Vec::with_capacity(stream.len());
+    for (packet, chunk) in stream {
+        packet_offsets.push((bytes.len(), *packet));
+        bytes.extend_from_slice(chunk);
+    }
+
+    let head_prefixes: &[&[u8]] = if masked {
+        &REQUEST_HEAD_PREFIXES
+    } else {
+        &[b"HTTP/".as_slice()]
+    };
+    let mut head_end = 0;
+    loop {
+        let head_start = head_end;
+        head_end += bytes[head_end..]
+            .windows(4)
+            .position(|window| window == b"\r\n\r\n")
+            .map(|position| position + 4)
+            .ok_or(ReplayError::UnsupportedTransport)?;
+        // Interim responses such as NTLM 401 challenges carry an error body.
+        if !masked {
+            head_end += content_length(&bytes[head_start..head_end]);
+        }
+        // WebSocket frames start with a non-ASCII opcode byte, never a head.
+        match bytes.get(head_end..) {
+            Some(rest) if head_prefixes.iter().any(|prefix| rest.starts_with(prefix)) => {}
+            _ => break,
+        }
+    }
+
+    let mut frames = Vec::new();
+    let mut offset = head_end;
+    let mut message = Vec::new();
+    let mut message_packet = 0usize;
+    while offset < bytes.len() {
+        let Some(frame) = parse_websocket_frame(&bytes[offset..], masked) else {
+            break;
+        };
+        let packet_index = packet_offsets.partition_point(|(chunk_offset, _)| *chunk_offset <= offset) - 1;
+        offset += frame.encoded_len;
+
+        match frame.opcode {
+            // Continuation or binary data.
+            0x0 | 0x2 => {
+                if message.is_empty() {
+                    message_packet = packet_offsets[packet_index].1;
+                }
+                message.extend_from_slice(&frame.payload);
+                if frame.fin {
+                    frames.push((message_packet, core::mem::take(&mut message)));
+                }
+            }
+            // Ping/pong carry no channel data.
+            0x9 | 0xA => {}
+            // Close ends the tunnel.
+            0x8 => break,
+            _ => return Err(ReplayError::UnsupportedTransport),
+        }
+    }
+
+    Ok(frames)
+}
+
+/// Extract the `Content-Length` of an HTTP head, if present.
+fn content_length(head: &[u8]) -> usize {
+    let Ok(head) = core::str::from_utf8(head) else {
+        return 0;
+    };
+    head.split("\r\n")
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.trim()
+                .eq_ignore_ascii_case("content-length")
+                .then(|| value.trim().parse::<usize>().ok())?
+        })
+        .unwrap_or(0)
+}
+
+struct WebsocketFrame {
+    encoded_len: usize,
+    fin: bool,
+    opcode: u8,
+    payload: Vec<u8>,
+}
+
+fn parse_websocket_frame(bytes: &[u8], masked: bool) -> Option<WebsocketFrame> {
+    let first = *bytes.first()?;
+    let second = *bytes.get(1)?;
+    let mut offset = 2;
+    let length = match second & 0x7f {
+        126 => {
+            let length = u16::from_be_bytes(bytes.get(offset..offset + 2)?.try_into().ok()?);
+            offset += 2;
+            usize::from(length)
+        }
+        127 => {
+            let length = u64::from_be_bytes(bytes.get(offset..offset + 8)?.try_into().ok()?);
+            offset += 8;
+            usize::try_from(length).ok()?
+        }
+        length => usize::from(length),
+    };
+    if length > MAX_WEBSOCKET_PAYLOAD {
+        return None;
+    }
+
+    let mask = if second & 0x80 != 0 {
+        let mask: [u8; 4] = bytes.get(offset..offset + 4)?.try_into().ok()?;
+        offset += 4;
+        Some(mask)
+    } else {
+        None
+    };
+    if masked != mask.is_some() {
+        return None;
+    }
+
+    let mut payload = bytes.get(offset..offset + length)?.to_vec();
+    if let Some(mask) = mask {
+        for (index, byte) in payload.iter_mut().enumerate() {
+            *byte ^= mask[index % 4];
+        }
+    }
+
+    Some(WebsocketFrame {
+        encoded_len: offset + length,
+        fin: first & 0x80 != 0,
+        opcode: first & 0x0f,
+        payload,
+    })
+}
+
+/// Keep the RDP payloads of `HTTP_DATA_PACKET` packets in tunnel order.
+fn data_packets(frames: &PacketStream) -> Result<PacketStream, ReplayError> {
+    let mut output = Vec::new();
+    let mut pending = Vec::new();
+    for (packet, frame) in frames {
+        pending.extend_from_slice(frame);
+        while let Some(header) = pending.get(..8) {
+            let length = usize::try_from(u32::from_le_bytes(
+                header[4..8].try_into().expect("header length slice"),
+            ))
+            .map_err(|_| ReplayError::GatewayFraming("packet length is too large".to_owned()))?;
+            if !(8..=MAX_WEBSOCKET_PAYLOAD).contains(&length) {
+                return Err(ReplayError::GatewayFraming("packet length is invalid".to_owned()));
+            }
+            if pending.len() < length {
+                break;
+            }
+            let packet_bytes = pending[..length].to_vec();
+            pending.drain(..length);
+
+            let packet_type = u16::from_le_bytes(packet_bytes[..2].try_into().expect("packet type slice"));
+            if packet_type == 0x0A {
+                // HTTP_DATA_PACKET ([MS-TSGU] 2.2.10.10).
+                let data = packet_bytes
+                    .get(DATA_PACKET_HEADER..)
+                    .ok_or_else(|| ReplayError::GatewayFraming("truncated data packet".to_owned()))?;
+                let declared = usize::from(u16::from_le_bytes(
+                    packet_bytes[8..10].try_into().expect("data length slice"),
+                ));
+                if declared != data.len() {
+                    return Err(ReplayError::GatewayFraming(
+                        "data packet length does not match its header".to_owned(),
+                    ));
+                }
+                output.push((*packet, data.to_vec()));
+            }
+        }
+    }
+
+    if output.is_empty() {
+        return Err(ReplayError::MissingRdpState);
+    }
+    Ok(output)
+}

--- a/crates/ironrdp-capture-replay/src/gateway.rs
+++ b/crates/ironrdp-capture-replay/src/gateway.rs
@@ -77,7 +77,7 @@ fn websocket_payloads(stream: &PacketStream, masked: bool) -> Result<PacketStrea
     let mut message_packet = 0usize;
     while offset < bytes.len() {
         let Some(frame) = parse_websocket_frame(&bytes[offset..], masked) else {
-            break;
+            return Err(ReplayError::GatewayFraming("truncated websocket frame".to_owned()));
         };
         let packet_index = packet_offsets.partition_point(|(chunk_offset, _)| *chunk_offset <= offset) - 1;
         offset += frame.encoded_len;
@@ -101,6 +101,9 @@ fn websocket_payloads(stream: &PacketStream, masked: bool) -> Result<PacketStrea
         }
     }
 
+    if !message.is_empty() {
+        return Err(ReplayError::GatewayFraming("truncated websocket message".to_owned()));
+    }
     Ok(frames)
 }
 
@@ -179,7 +182,8 @@ fn data_packets(frames: &PacketStream) -> Result<PacketStream, ReplayError> {
     let mut pending = Vec::new();
     for (packet, frame) in frames {
         pending.extend_from_slice(frame);
-        while let Some(header) = pending.get(..8) {
+        let mut offset = 0;
+        while let Some(header) = pending.get(offset..offset + 8) {
             let length = usize::try_from(u32::from_le_bytes(
                 header[4..8].try_into().expect("header length slice"),
             ))
@@ -187,15 +191,13 @@ fn data_packets(frames: &PacketStream) -> Result<PacketStream, ReplayError> {
             if !(8..=MAX_WEBSOCKET_PAYLOAD).contains(&length) {
                 return Err(ReplayError::GatewayFraming("packet length is invalid".to_owned()));
             }
-            if pending.len() < length {
+            if pending.len() - offset < length {
                 break;
             }
-            let packet_bytes = pending[..length].to_vec();
-            pending.drain(..length);
-
+            let packet_bytes = &pending[offset..offset + length];
             let packet_type = u16::from_le_bytes(packet_bytes[..2].try_into().expect("packet type slice"));
             if packet_type == 0x0A {
-                // HTTP_DATA_PACKET ([MS-TSGU] 2.2.10.10).
+                // HTTP_DATA_PACKET ([MS-TSGU] 2.2.10.6).
                 let data = packet_bytes
                     .get(DATA_PACKET_HEADER..)
                     .ok_or_else(|| ReplayError::GatewayFraming("truncated data packet".to_owned()))?;
@@ -209,9 +211,14 @@ fn data_packets(frames: &PacketStream) -> Result<PacketStream, ReplayError> {
                 }
                 output.push((*packet, data.to_vec()));
             }
+            offset += length;
         }
+        pending.drain(..offset);
     }
 
+    if !pending.is_empty() {
+        return Err(ReplayError::GatewayFraming("truncated gateway packet".to_owned()));
+    }
     if output.is_empty() {
         return Err(ReplayError::MissingRdpState);
     }

--- a/crates/ironrdp-capture-replay/src/lib.rs
+++ b/crates/ironrdp-capture-replay/src/lib.rs
@@ -1,6 +1,10 @@
 //! Offline analysis support for direct TCP RDP captures.
+//!
+//! After TLS decryption, an `RDG_OUT_DATA` WebSocket tunnel is unwrapped into
+//! the inner RDP stream before negotiation recovery and routing.
 
 mod error;
+mod gateway;
 mod negotiation;
 mod output;
 mod routing;
@@ -8,6 +12,7 @@ mod tls;
 mod transport;
 
 pub use error::ReplayError;
+pub use gateway::{extract_tunneled_rdp, is_gateway_tunnel};
 pub use negotiation::{NegotiatedState, StaticChannel, recover_negotiated_state};
 pub use output::{ExportError, ExportOptions, ExportSummary, export_capture};
 pub use routing::{

--- a/crates/ironrdp-capture-replay/src/routing.rs
+++ b/crates/ironrdp-capture-replay/src/routing.rs
@@ -574,10 +574,10 @@ pub(crate) fn prepare_replay_capture(capture: &Capture) -> Result<(ReplayRouter,
         let tunneled = gateway::extract_tunneled_rdp(outer)?;
         decrypt_tls_streams(&tunneled.client, &tunneled.server, capture.tls_key_log.as_str())?
     } else {
-        decrypted
-            .into_iter()
-            .next()
-            .ok_or(decrypt_error.unwrap_or(ReplayError::MissingRdpState))?
+        match decrypted.into_iter().next() {
+            Some(plaintext) => plaintext,
+            None => return Err(decrypt_error.unwrap_or(ReplayError::MissingRdpState)),
+        }
     };
     let router = ReplayRouter::new(CapturedActivation {
         state: recover_negotiated_state(&plaintext)?,

--- a/crates/ironrdp-capture-replay/src/routing.rs
+++ b/crates/ironrdp-capture-replay/src/routing.rs
@@ -21,7 +21,7 @@ use ironrdp_session::image::DecodedImage;
 use ironrdp_session::{ActiveStage, ActiveStageBuilder, ActiveStageOutput};
 use ironrdp_svc::{StaticChannelSet, StaticVirtualChannel, SvcMessage, SvcProcessor};
 
-use crate::tls::{decrypt_tls, decrypt_tls_streams};
+use crate::tls::decrypt_tls_streams;
 use crate::{Capture, NegotiatedState, PacketStream, Plaintext, ReplayError, gateway, recover_negotiated_state};
 
 const MAX_DESKTOP_DIM: u16 = 8192;
@@ -558,11 +558,27 @@ pub fn replay_capture(capture: &Capture) -> Result<ReplayReport, ReplayError> {
 }
 
 pub(crate) fn prepare_replay_capture(capture: &Capture) -> Result<(ReplayRouter, Plaintext), ReplayError> {
-    let mut plaintext = decrypt_tls(capture)?;
-    if gateway::is_gateway_tunnel(&plaintext) {
-        let tunneled = gateway::extract_tunneled_rdp(&plaintext)?;
-        plaintext = decrypt_tls_streams(&tunneled.client, &tunneled.server, capture.tls_key_log.as_str())?;
+    let mut decrypted = Vec::new();
+    let mut decrypt_error = None;
+    for flow in core::iter::once(&capture.flow).chain(capture.gateway_alternates.iter()) {
+        match decrypt_tls_streams(&flow.client_stream, &flow.server_stream, capture.tls_key_log.as_str()) {
+            Ok(plaintext) => decrypted.push(plaintext),
+            Err(error) => {
+                if decrypt_error.is_none() {
+                    decrypt_error = Some(error);
+                }
+            }
+        }
     }
+    let plaintext = if let Some(outer) = decrypted.iter().find(|plaintext| gateway::is_gateway_tunnel(plaintext)) {
+        let tunneled = gateway::extract_tunneled_rdp(outer)?;
+        decrypt_tls_streams(&tunneled.client, &tunneled.server, capture.tls_key_log.as_str())?
+    } else {
+        decrypted
+            .into_iter()
+            .next()
+            .ok_or(decrypt_error.unwrap_or(ReplayError::MissingRdpState))?
+    };
     let router = ReplayRouter::new(CapturedActivation {
         state: recover_negotiated_state(&plaintext)?,
         compression_type: captured_compression_type(&plaintext),

--- a/crates/ironrdp-capture-replay/src/routing.rs
+++ b/crates/ironrdp-capture-replay/src/routing.rs
@@ -21,7 +21,8 @@ use ironrdp_session::image::DecodedImage;
 use ironrdp_session::{ActiveStage, ActiveStageBuilder, ActiveStageOutput};
 use ironrdp_svc::{StaticChannelSet, StaticVirtualChannel, SvcMessage, SvcProcessor};
 
-use crate::{Capture, NegotiatedState, PacketStream, Plaintext, ReplayError, decrypt_tls, recover_negotiated_state};
+use crate::tls::{decrypt_tls, decrypt_tls_streams};
+use crate::{Capture, NegotiatedState, PacketStream, Plaintext, ReplayError, gateway, recover_negotiated_state};
 
 const MAX_DESKTOP_DIM: u16 = 8192;
 const MAX_EGFX_OUTPUT_DIM: u16 = 32_766;
@@ -557,7 +558,11 @@ pub fn replay_capture(capture: &Capture) -> Result<ReplayReport, ReplayError> {
 }
 
 pub(crate) fn prepare_replay_capture(capture: &Capture) -> Result<(ReplayRouter, Plaintext), ReplayError> {
-    let plaintext = decrypt_tls(capture)?;
+    let mut plaintext = decrypt_tls(capture)?;
+    if gateway::is_gateway_tunnel(&plaintext) {
+        let tunneled = gateway::extract_tunneled_rdp(&plaintext)?;
+        plaintext = decrypt_tls_streams(&tunneled.client, &tunneled.server, capture.tls_key_log.as_str())?;
+    }
     let router = ReplayRouter::new(CapturedActivation {
         state: recover_negotiated_state(&plaintext)?,
         compression_type: captured_compression_type(&plaintext),

--- a/crates/ironrdp-capture-replay/src/tls.rs
+++ b/crates/ironrdp-capture-replay/src/tls.rs
@@ -31,8 +31,23 @@ pub struct Plaintext {
 /// TLS key-log entries are used only in memory and are not retained by the
 /// returned streams.
 pub fn decrypt_tls(capture: &Capture) -> Result<Plaintext, ReplayError> {
-    let client_records = collect_tls_records(&capture.flow.client_stream, 0xe0)?;
-    let server_records = collect_tls_records(&capture.flow.server_stream, 0xd0)?;
+    decrypt_tls_streams(
+        &capture.flow.client_stream,
+        &capture.flow.server_stream,
+        capture.tls_key_log.as_str(),
+    )
+}
+
+/// Decrypt TLS application data from a pair of directional byte streams.
+///
+/// Used after gateway unwrap, when the inner RDP session is itself TLS.
+pub(crate) fn decrypt_tls_streams(
+    client_stream: &PacketStream,
+    server_stream: &PacketStream,
+    key_log: &str,
+) -> Result<Plaintext, ReplayError> {
+    let client_records = collect_tls_records(client_stream, 0xe0)?;
+    let server_records = collect_tls_records(server_stream, 0xd0)?;
     let (client_records, server_records) = match (client_records, server_records) {
         (Some(client_records), Some(server_records)) => (client_records, server_records),
         (None, None) => return Err(ReplayError::StandardSecurity),
@@ -41,7 +56,7 @@ pub fn decrypt_tls(capture: &Capture) -> Result<Plaintext, ReplayError> {
     if client_records.is_empty() && server_records.is_empty() {
         return Err(ReplayError::StandardSecurity);
     }
-    let tls = Tls::from_records(&client_records, &server_records, capture.tls_key_log.as_str())?;
+    let tls = Tls::from_records(&client_records, &server_records, key_log)?;
 
     Ok(Plaintext {
         client: tls.decrypt(Direction::Client, &client_records)?,

--- a/crates/ironrdp-capture-replay/src/tls.rs
+++ b/crates/ironrdp-capture-replay/src/tls.rs
@@ -661,6 +661,7 @@ mod tests {
                 client_stream: vec![(1, client_records.into_iter().flat_map(|(_, record)| record).collect())],
                 server_stream: vec![(4, server_records.into_iter().flat_map(|(_, record)| record).collect())],
             },
+            gateway_alternates: Vec::new(),
             tls_key_log: TlsKeyLog::new(key_log),
         };
 
@@ -693,6 +694,7 @@ mod tests {
                 client_stream: vec![(1, x224_connection(0xe0))],
                 server_stream: vec![(2, x224_connection(0xd0))],
             },
+            gateway_alternates: Vec::new(),
             tls_key_log: TlsKeyLog::new(String::new()),
         };
 

--- a/crates/ironrdp-capture-replay/src/transport.rs
+++ b/crates/ironrdp-capture-replay/src/transport.rs
@@ -41,6 +41,9 @@ pub struct Flow {
 pub struct Capture {
     /// Direct TCP RDP flow selected from the pcapng input.
     pub flow: Flow,
+    /// Other TLS flows to TCP port 443, tried when the primary flow is not an
+    /// RD Gateway WebSocket tunnel (a KDC-proxy connection shares that port).
+    pub gateway_alternates: Vec<Flow>,
     /// NSS-compatible TLS key-log entries embedded in the capture.
     pub tls_key_log: TlsKeyLog,
 }
@@ -152,8 +155,10 @@ pub fn read_capture(path: &Path) -> Result<Capture, ReplayError> {
         return Err(ReplayError::UnsupportedTransport);
     }
 
+    let (flow, gateway_alternates) = assemble_flow(segments)?;
     Ok(Capture {
-        flow: assemble_flow(segments)?,
+        flow,
+        gateway_alternates,
         tls_key_log: TlsKeyLog::new(tls_key_log),
     })
 }
@@ -243,10 +248,10 @@ fn parse_tcp_packet(packet: usize, bytes: &[u8]) -> Option<Segment> {
     })
 }
 
-fn assemble_flow(mut segments: Vec<Segment>) -> Result<Flow, ReplayError> {
+fn assemble_flow(mut segments: Vec<Segment>) -> Result<(Flow, Vec<Flow>), ReplayError> {
     segments.retain(|segment| !segment.data.is_empty() || segment.syn || segment.fin || segment.rst);
     let mut missing_tcp_flow = false;
-    let mut gateway = None;
+    let mut gateways = Vec::new();
     for (start, syn) in segments
         .iter()
         .enumerate()
@@ -307,15 +312,18 @@ fn assemble_flow(mut segments: Vec<Segment>) -> Result<Flow, ReplayError> {
             continue;
         };
         if has_x224_connection_initiation(&client_stream, &server_stream) {
-            return Ok(Flow {
-                client,
-                server,
-                client_stream,
-                server_stream,
-            });
+            return Ok((
+                Flow {
+                    client,
+                    server,
+                    client_stream,
+                    server_stream,
+                },
+                Vec::new(),
+            ));
         }
-        if server.port == 443 && gateway.is_none() {
-            gateway = Some(Flow {
+        if server.port == 443 {
+            gateways.push(Flow {
                 client,
                 server,
                 client_stream,
@@ -324,8 +332,9 @@ fn assemble_flow(mut segments: Vec<Segment>) -> Result<Flow, ReplayError> {
         }
     }
 
-    if let Some(flow) = gateway {
-        return Ok(flow);
+    let mut gateways = gateways.into_iter();
+    if let Some(flow) = gateways.next() {
+        return Ok((flow, gateways.collect()));
     }
 
     Err(if missing_tcp_flow {
@@ -536,7 +545,7 @@ mod tests {
     fn selects_a_gateway_port_flow_without_x224() {
         let client = endpoint(1);
         let server = endpoint(443);
-        let flow = assemble_flow(vec![
+        let (flow, alternates) = assemble_flow(vec![
             segment_between(client.clone(), server.clone(), 100, 1, true, false, &[]),
             segment_between(client.clone(), server.clone(), 101, 2, false, true, b"CLIENT"),
             segment_between(server, client, 200, 3, false, true, b"SERVER"),
@@ -544,6 +553,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(flow.server.port, 443);
+        assert!(alternates.is_empty());
         assert_eq!(flatten(&flow.client_stream), b"CLIENT");
         assert_eq!(flatten(&flow.server_stream), b"SERVER");
     }
@@ -554,7 +564,7 @@ mod tests {
         let gateway_server = endpoint(443);
         let rdp_client = endpoint(3);
         let rdp_server = endpoint(4);
-        let flow = assemble_flow(vec![
+        let (flow, alternates) = assemble_flow(vec![
             segment_between(gateway_client.clone(), gateway_server.clone(), 100, 1, true, false, &[]),
             segment_between(
                 gateway_client.clone(),
@@ -582,6 +592,38 @@ mod tests {
 
         assert_eq!(flow.client.port, 3);
         assert_eq!(flow.server.port, 4);
+        assert!(alternates.is_empty());
+    }
+
+    #[test]
+    fn keeps_later_gateway_port_flows_as_alternates() {
+        let first_client = endpoint(1);
+        let first_server = endpoint(443);
+        let second_client = endpoint(2);
+        let second_server = endpoint(443);
+        let (flow, alternates) = assemble_flow(vec![
+            segment_between(first_client.clone(), first_server.clone(), 100, 1, true, false, &[]),
+            segment_between(first_client.clone(), first_server.clone(), 101, 2, false, true, b"KDC"),
+            segment_between(first_server, first_client, 200, 3, false, true, b"KDC"),
+            segment_between(second_client.clone(), second_server.clone(), 300, 4, true, false, &[]),
+            segment_between(
+                second_client.clone(),
+                second_server.clone(),
+                301,
+                5,
+                false,
+                true,
+                b"RDG",
+            ),
+            segment_between(second_server, second_client, 400, 6, false, true, b"RDG"),
+        ])
+        .unwrap();
+
+        assert_eq!(flow.client.port, 1);
+        assert_eq!(flatten(&flow.client_stream), b"KDC");
+        assert_eq!(alternates.len(), 1);
+        assert_eq!(alternates[0].client.port, 2);
+        assert_eq!(flatten(&alternates[0].client_stream), b"RDG");
     }
 
     #[test]
@@ -590,7 +632,7 @@ mod tests {
         let first_server = endpoint(2);
         let second_client = endpoint(3);
         let second_server = endpoint(4);
-        let flow = assemble_flow(vec![
+        let (flow, _) = assemble_flow(vec![
             segment_between(first_client.clone(), first_server.clone(), 100, 1, true, false, &[]),
             segment_between(first_client.clone(), first_server.clone(), 101, 2, false, true, b"bad"),
             segment_between(first_client, first_server, 101, 3, false, true, b"XX"),
@@ -639,7 +681,7 @@ mod tests {
     fn separates_connections_that_reuse_a_tcp_tuple() {
         let client = endpoint(1);
         let server = endpoint(2);
-        let flow = assemble_flow(vec![
+        let (flow, _) = assemble_flow(vec![
             segment_between(client.clone(), server.clone(), 100, 1, true, false, &[]),
             segment_between(client.clone(), server.clone(), 101, 2, false, true, b"old"),
             segment_between(server.clone(), client.clone(), 300, 3, false, true, b"old"),
@@ -687,7 +729,7 @@ mod tests {
             &[],
         );
         server_fin.fin = true;
-        let flow = assemble_flow(vec![
+        let (flow, _) = assemble_flow(vec![
             segment_between(client.clone(), server.clone(), 100, 1, true, false, &[]),
             segment_between(client.clone(), server.clone(), 101, 2, false, true, &request),
             client_fin,

--- a/crates/ironrdp-capture-replay/src/transport.rs
+++ b/crates/ironrdp-capture-replay/src/transport.rs
@@ -246,6 +246,7 @@ fn parse_tcp_packet(packet: usize, bytes: &[u8]) -> Option<Segment> {
 fn assemble_flow(mut segments: Vec<Segment>) -> Result<Flow, ReplayError> {
     segments.retain(|segment| !segment.data.is_empty() || segment.syn || segment.fin || segment.rst);
     let mut missing_tcp_flow = false;
+    let mut gateway = None;
     for (start, syn) in segments
         .iter()
         .enumerate()
@@ -313,6 +314,18 @@ fn assemble_flow(mut segments: Vec<Segment>) -> Result<Flow, ReplayError> {
                 server_stream,
             });
         }
+        if server.port == 443 && gateway.is_none() {
+            gateway = Some(Flow {
+                client,
+                server,
+                client_stream,
+                server_stream,
+            });
+        }
+    }
+
+    if let Some(flow) = gateway {
+        return Ok(flow);
     }
 
     Err(if missing_tcp_flow {
@@ -517,6 +530,58 @@ mod tests {
         request.extend([1, 0, 8, 0, 3, 0, 0, 0]);
 
         assert_eq!(x224_connection_tpdu_end(&request, 0xe0), Some(47));
+    }
+
+    #[test]
+    fn selects_a_gateway_port_flow_without_x224() {
+        let client = endpoint(1);
+        let server = endpoint(443);
+        let flow = assemble_flow(vec![
+            segment_between(client.clone(), server.clone(), 100, 1, true, false, &[]),
+            segment_between(client.clone(), server.clone(), 101, 2, false, true, b"CLIENT"),
+            segment_between(server, client, 200, 3, false, true, b"SERVER"),
+        ])
+        .unwrap();
+
+        assert_eq!(flow.server.port, 443);
+        assert_eq!(flatten(&flow.client_stream), b"CLIENT");
+        assert_eq!(flatten(&flow.server_stream), b"SERVER");
+    }
+
+    #[test]
+    fn prefers_an_x224_flow_over_a_gateway_port_flow() {
+        let gateway_client = endpoint(1);
+        let gateway_server = endpoint(443);
+        let rdp_client = endpoint(3);
+        let rdp_server = endpoint(4);
+        let flow = assemble_flow(vec![
+            segment_between(gateway_client.clone(), gateway_server.clone(), 100, 1, true, false, &[]),
+            segment_between(
+                gateway_client.clone(),
+                gateway_server.clone(),
+                101,
+                2,
+                false,
+                true,
+                b"HTTPS",
+            ),
+            segment_between(gateway_server, gateway_client, 200, 3, false, true, b"HTTPS"),
+            segment_between(rdp_client.clone(), rdp_server.clone(), 300, 4, true, false, &[]),
+            segment_between(
+                rdp_client.clone(),
+                rdp_server.clone(),
+                301,
+                5,
+                false,
+                true,
+                &connection_request(),
+            ),
+            segment_between(rdp_server, rdp_client, 400, 6, false, true, &connection_confirm()),
+        ])
+        .unwrap();
+
+        assert_eq!(flow.client.port, 3);
+        assert_eq!(flow.server.port, 4);
     }
 
     #[test]

--- a/crates/ironrdp-capture-replay/tests/gateway.rs
+++ b/crates/ironrdp-capture-replay/tests/gateway.rs
@@ -17,19 +17,19 @@ fn response_head(status: &str, content_length: usize) -> Vec<u8> {
 
 /// Build an MS-TSGU packet wrapping `data` as an `HTTP_DATA_PACKET` payload.
 fn tsgu_data_packet(data: &[u8]) -> Vec<u8> {
-    let length = u32::try_from(DATA_PACKET_HEADER + data.len()).unwrap();
+    let length = u32::try_from(DATA_PACKET_HEADER + data.len()).expect("data packet length fits u32");
     let mut packet = Vec::new();
     packet.extend(0x0Au16.to_le_bytes());
     packet.extend(0u16.to_le_bytes());
     packet.extend(length.to_le_bytes());
-    packet.extend(u16::try_from(data.len()).unwrap().to_le_bytes());
+    packet.extend(u16::try_from(data.len()).expect("data length fits u16").to_le_bytes());
     packet.extend(data);
     packet
 }
 
 /// Build a non-data MS-TSGU packet (e.g. tunnel channel control).
 fn tsgu_control_packet(packet_type: u16, body: &[u8]) -> Vec<u8> {
-    let length = u32::try_from(8 + body.len()).unwrap();
+    let length = u32::try_from(8 + body.len()).expect("control packet length fits u32");
     let mut packet = Vec::new();
     packet.extend(packet_type.to_le_bytes());
     packet.extend(0u16.to_le_bytes());
@@ -43,13 +43,21 @@ fn websocket_frame(fin: bool, opcode: u8, payload: &[u8], mask: Option<[u8; 4]>)
     let mut frame = vec![(u8::from(fin) << 7) | opcode];
     let mask_bit = u8::from(mask.is_some()) << 7;
     if payload.len() < 126 {
-        frame.push(mask_bit | u8::try_from(payload.len()).unwrap());
+        frame.push(mask_bit | u8::try_from(payload.len()).expect("short payload length fits u8"));
     } else if u16::try_from(payload.len()).is_ok() {
         frame.push(mask_bit | 126);
-        frame.extend(u16::try_from(payload.len()).unwrap().to_be_bytes());
+        frame.extend(
+            u16::try_from(payload.len())
+                .expect("medium payload length fits u16")
+                .to_be_bytes(),
+        );
     } else {
         frame.push(mask_bit | 127);
-        frame.extend(u64::try_from(payload.len()).unwrap().to_be_bytes());
+        frame.extend(
+            u64::try_from(payload.len())
+                .expect("payload length fits u64")
+                .to_be_bytes(),
+        );
     }
     match mask {
         Some(mask) => {

--- a/crates/ironrdp-capture-replay/tests/gateway.rs
+++ b/crates/ironrdp-capture-replay/tests/gateway.rs
@@ -187,5 +187,46 @@ fn rejects_truncated_data_packet() {
     packet.truncate(packet.len() - 1);
     let plaintext = tunneled_capture(client_frame(&packet), server_frame(&tsgu_data_packet(&[1])));
 
-    assert!(extract_tunneled_rdp(&plaintext).is_err());
+    assert!(matches!(
+        extract_tunneled_rdp(&plaintext),
+        Err(ReplayError::GatewayFraming(_))
+    ));
+}
+
+#[test]
+fn rejects_trailing_truncated_websocket_bytes() {
+    let rdp = [1, 2, 3];
+    let mut body = client_frame(&tsgu_data_packet(&rdp));
+    body.push(0x82);
+    let plaintext = tunneled_capture(body, server_frame(&tsgu_data_packet(&rdp)));
+
+    assert!(matches!(
+        extract_tunneled_rdp(&plaintext),
+        Err(ReplayError::GatewayFraming(_))
+    ));
+}
+
+#[test]
+fn rejects_an_unfinished_websocket_message() {
+    let packet = tsgu_data_packet(&[1, 2, 3]);
+    let body = websocket_frame(false, 0x2, &packet, Some([9, 9, 9, 9]));
+    let plaintext = tunneled_capture(body, server_frame(&tsgu_data_packet(&[1])));
+
+    assert!(matches!(
+        extract_tunneled_rdp(&plaintext),
+        Err(ReplayError::GatewayFraming(_))
+    ));
+}
+
+#[test]
+fn rejects_a_truncated_packet_after_a_valid_data_packet() {
+    let rdp = [1, 2, 3];
+    let mut payload = tsgu_data_packet(&rdp);
+    payload.extend(&tsgu_data_packet(&[4, 5, 6])[..8]);
+    let plaintext = tunneled_capture(client_frame(&payload), server_frame(&tsgu_data_packet(&rdp)));
+
+    assert!(matches!(
+        extract_tunneled_rdp(&plaintext),
+        Err(ReplayError::GatewayFraming(_))
+    ));
 }

--- a/crates/ironrdp-capture-replay/tests/gateway.rs
+++ b/crates/ironrdp-capture-replay/tests/gateway.rs
@@ -1,0 +1,191 @@
+#![expect(
+    unused_crate_dependencies,
+    reason = "integration tests link the library crate and do not use its direct dependencies"
+)]
+
+use ironrdp_capture_replay::{Plaintext, ReplayError, extract_tunneled_rdp, is_gateway_tunnel};
+
+const DATA_PACKET_HEADER: usize = 8 /* packet header */ + 2 /* data length */;
+
+fn request_head() -> Vec<u8> {
+    b"RDG_OUT_DATA /remoteDesktopGateway/ HTTP/1.1\r\nConnection: Upgrade\r\n\r\n".to_vec()
+}
+
+fn response_head(status: &str, content_length: usize) -> Vec<u8> {
+    format!("HTTP/1.1 {status}\r\nContent-Length: {content_length}\r\n\r\n").into_bytes()
+}
+
+/// Build an MS-TSGU packet wrapping `data` as an `HTTP_DATA_PACKET` payload.
+fn tsgu_data_packet(data: &[u8]) -> Vec<u8> {
+    let length = u32::try_from(DATA_PACKET_HEADER + data.len()).unwrap();
+    let mut packet = Vec::new();
+    packet.extend(0x0Au16.to_le_bytes());
+    packet.extend(0u16.to_le_bytes());
+    packet.extend(length.to_le_bytes());
+    packet.extend(u16::try_from(data.len()).unwrap().to_le_bytes());
+    packet.extend(data);
+    packet
+}
+
+/// Build a non-data MS-TSGU packet (e.g. tunnel channel control).
+fn tsgu_control_packet(packet_type: u16, body: &[u8]) -> Vec<u8> {
+    let length = u32::try_from(8 + body.len()).unwrap();
+    let mut packet = Vec::new();
+    packet.extend(packet_type.to_le_bytes());
+    packet.extend(0u16.to_le_bytes());
+    packet.extend(length.to_le_bytes());
+    packet.extend(body);
+    packet
+}
+
+/// Encode one WebSocket frame, masking client frames per RFC 6455.
+fn websocket_frame(fin: bool, opcode: u8, payload: &[u8], mask: Option<[u8; 4]>) -> Vec<u8> {
+    let mut frame = vec![(u8::from(fin) << 7) | opcode];
+    let mask_bit = u8::from(mask.is_some()) << 7;
+    if payload.len() < 126 {
+        frame.push(mask_bit | u8::try_from(payload.len()).unwrap());
+    } else if u16::try_from(payload.len()).is_ok() {
+        frame.push(mask_bit | 126);
+        frame.extend(u16::try_from(payload.len()).unwrap().to_be_bytes());
+    } else {
+        frame.push(mask_bit | 127);
+        frame.extend(u64::try_from(payload.len()).unwrap().to_be_bytes());
+    }
+    match mask {
+        Some(mask) => {
+            frame.extend(mask);
+            frame.extend(payload.iter().enumerate().map(|(index, byte)| byte ^ mask[index % 4]));
+        }
+        None => frame.extend(payload),
+    }
+    frame
+}
+
+fn client_frame(payload: &[u8]) -> Vec<u8> {
+    websocket_frame(true, 0x2, payload, Some([1, 2, 3, 4]))
+}
+
+fn server_frame(payload: &[u8]) -> Vec<u8> {
+    websocket_frame(true, 0x2, payload, None)
+}
+
+fn tunneled_capture(client_body: Vec<u8>, server_body: Vec<u8>) -> Plaintext {
+    let mut client = request_head();
+    client.extend(client_body);
+    let mut server = response_head("101 Switching Protocols", 0);
+    server.extend(server_body);
+    Plaintext {
+        client: vec![(1, client)],
+        server: vec![(2, server)],
+    }
+}
+
+#[test]
+fn detects_gateway_upgrade() {
+    let plaintext = tunneled_capture(Vec::new(), Vec::new());
+    assert!(is_gateway_tunnel(&plaintext));
+
+    let direct = Plaintext {
+        client: vec![(1, vec![3, 0, 0, 11, 6, 0xe0, 0, 0, 0, 0, 0])],
+        server: vec![(2, vec![3, 0, 0, 11, 6, 0xd0, 0, 0, 0, 0, 0])],
+    };
+    assert!(!is_gateway_tunnel(&direct));
+}
+
+#[test]
+fn extracts_data_packets_from_masked_client_frames() {
+    let rdp = [0x03, 0x00, 0x00, 0x13, 0x0e, 0xe0];
+    let plaintext = tunneled_capture(
+        client_frame(&tsgu_data_packet(&rdp)),
+        server_frame(&tsgu_data_packet(&rdp)),
+    );
+
+    let inner = extract_tunneled_rdp(&plaintext).unwrap();
+
+    assert_eq!(inner.client, vec![(1, rdp.to_vec())]);
+    assert_eq!(inner.server, vec![(2, rdp.to_vec())]);
+}
+
+#[test]
+fn skips_interim_authentication_round_trips() {
+    let rdp = [0x03, 0x00, 0x00, 0x13, 0x0e, 0xe0];
+    let mut client = request_head();
+    client.extend(request_head());
+    client.extend(client_frame(&tsgu_data_packet(&rdp)));
+    let mut server = response_head("401 Unauthorized", 24);
+    server.extend([0xAA; 24]);
+    server.extend(response_head("101 Switching Protocols", 0));
+    server.extend(server_frame(&tsgu_data_packet(&rdp)));
+    let plaintext = Plaintext {
+        client: vec![(1, client)],
+        server: vec![(2, server)],
+    };
+
+    let inner = extract_tunneled_rdp(&plaintext).unwrap();
+
+    assert_eq!(inner.client, vec![(1, rdp.to_vec())]);
+    assert_eq!(inner.server, vec![(2, rdp.to_vec())]);
+}
+
+#[test]
+fn reassembles_packets_split_across_frames() {
+    let rdp: Vec<u8> = (0..200u16).map(|value| u8::try_from(value % 256).unwrap()).collect();
+    let packet = tsgu_data_packet(&rdp);
+    let split = packet.len() / 2;
+    let mut body = websocket_frame(false, 0x2, &packet[..split], Some([9, 9, 9, 9]));
+    body.extend(websocket_frame(true, 0x0, &packet[split..], Some([8, 8, 8, 8])));
+    let plaintext = tunneled_capture(body, server_frame(&tsgu_data_packet(&rdp)));
+
+    let inner = extract_tunneled_rdp(&plaintext).unwrap();
+
+    assert_eq!(inner.client, vec![(1, rdp.clone())]);
+    assert_eq!(inner.server, vec![(2, rdp)]);
+}
+
+#[test]
+fn merges_packets_coalesced_in_one_frame() {
+    let first = [1, 2, 3];
+    let second = [4, 5, 6, 7];
+    let mut payload = tsgu_control_packet(0x1, &[0; 12]);
+    payload.extend(tsgu_data_packet(&first));
+    payload.extend(tsgu_data_packet(&second));
+    let plaintext = tunneled_capture(client_frame(&payload), server_frame(&tsgu_data_packet(&first)));
+
+    let inner = extract_tunneled_rdp(&plaintext).unwrap();
+
+    assert_eq!(inner.client, vec![(1, first.to_vec()), (1, second.to_vec())]);
+    assert_eq!(inner.server, vec![(2, first.to_vec())]);
+}
+
+#[test]
+fn skips_ping_frames_and_stops_at_close() {
+    let rdp = [7, 7, 7];
+    let mut body = websocket_frame(true, 0x9, b"ping", Some([0, 0, 0, 0]));
+    body.extend(client_frame(&tsgu_data_packet(&rdp)));
+    body.extend(websocket_frame(true, 0x8, &[], Some([0, 0, 0, 0])));
+    body.extend(client_frame(&tsgu_data_packet(&[9, 9, 9])));
+    let plaintext = tunneled_capture(body, server_frame(&tsgu_data_packet(&rdp)));
+
+    let inner = extract_tunneled_rdp(&plaintext).unwrap();
+
+    assert_eq!(inner.client, vec![(1, rdp.to_vec())]);
+}
+
+#[test]
+fn rejects_tunneled_capture_without_data_packets() {
+    let plaintext = tunneled_capture(client_frame(&tsgu_control_packet(0x1, &[0; 12])), server_frame(&[]));
+
+    assert!(matches!(
+        extract_tunneled_rdp(&plaintext),
+        Err(ReplayError::MissingRdpState)
+    ));
+}
+
+#[test]
+fn rejects_truncated_data_packet() {
+    let mut packet = tsgu_data_packet(&[1, 2, 3]);
+    packet.truncate(packet.len() - 1);
+    let plaintext = tunneled_capture(client_frame(&packet), server_frame(&tsgu_data_packet(&[1])));
+
+    assert!(extract_tunneled_rdp(&plaintext).is_err());
+}


### PR DESCRIPTION
Direct TCP replay cannot recover RDP from an RD Gateway capture because the inner stream is wrapped in WebSocket frames and HTTP_DATA_PACKET headers.

After the outer HTTPS session is already decrypted from the capture's embedded key log, unwrap RDG_OUT_DATA tunnels into a normal RDP stream and continue the existing replay pipeline.

RPC-over-HTTP tunnels, external key-log files, and resumed TLS decrypt are out of scope.