### PR TITLE
feat(mstsgu): extract PacketIo from the WebSocket gateway client

### DIFF
--- a/crates/ironrdp-mstsgu/CHANGELOG.md
+++ b/crates/ironrdp-mstsgu/CHANGELOG.md
@@ -13,10 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RDG-UDP PDU encode/decode helpers (`CONNECT_PKT`, `DATA_PKT`, `DISC_PKT`, and `UDP_CORRELATION_INFO`) without opening a live DTLS side channel.
 - Encode and decode for HTTP control packets (`HTTP_SERVICE_MESSAGE`, `HTTP_REAUTH_MESSAGE`, and `HTTP_CLOSE_PACKET`) without performing mid-session reauthentication.
 
-### Changed
-
-- `GwClient` write-side shutdown now closes the outbound queue and waits for the gateway worker to finish.
-
 ## [[0.0.1](https://github.com/Devolutions/IronRDP/releases/tag/ironrdp-mstsgu-v0.0.1)] - 2026-07-10
 
 Initial release.

--- a/crates/ironrdp-mstsgu/CHANGELOG.md
+++ b/crates/ironrdp-mstsgu/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RDG-UDP PDU encode/decode helpers (`CONNECT_PKT`, `DATA_PKT`, `DISC_PKT`, and `UDP_CORRELATION_INFO`) without opening a live DTLS side channel.
 - Encode and decode for HTTP control packets (`HTTP_SERVICE_MESSAGE`, `HTTP_REAUTH_MESSAGE`, and `HTTP_CLOSE_PACKET`) without performing mid-session reauthentication.
 
+### Changed
+
+- `GwClient` write-side shutdown now closes the outbound queue and waits for the gateway worker to finish.
+
 ## [[0.0.1](https://github.com/Devolutions/IronRDP/releases/tag/ironrdp-mstsgu-v0.0.1)] - 2026-07-10
 
 Initial release.

--- a/crates/ironrdp-mstsgu/README.md
+++ b/crates/ironrdp-mstsgu/README.md
@@ -7,7 +7,8 @@ This crate
 - only supports the HTTPS protocol with WebSocket (and not the legacy HTTP or HTTP-RPC transports),
 - decodes HTTP control packets (`HTTP_SERVICE_MESSAGE`, `HTTP_REAUTH_MESSAGE`, and `HTTP_CLOSE_PACKET`) without performing mid-session reauthentication,
 - does not implement reconnection, Detect, or a live UDP/DTLS side channel,
-- authenticates the WebSocket upgrade with HTTP Negotiate (Kerberos then NTLM), NTLM, or Basic fallback, and
-- encodes and decodes RDG-UDP PDUs (`CONNECT_PKT`, `DATA_PKT`, `DISC_PKT`, and correlation info) without opening that side channel.
+- authenticates the WebSocket upgrade with HTTP Negotiate (Kerberos then NTLM), NTLM, or Basic fallback,
+- encodes and decodes RDG-UDP PDUs (`CONNECT_PKT`, `DATA_PKT`, `DISC_PKT`, and correlation info) without opening that side channel, and
+- finishes write-side shutdown by closing the outbound WebSocket and waiting for the gateway worker.
 
 [MS-TSGU]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsgu/0007d661-a86d-4e8f-89f7-7f77f8824188

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -166,6 +166,7 @@ impl GwClient {
         let work = tokio::spawn(async move {
             let iv = Duration::from_secs(15 * 60);
             let mut keepalive_interval = tokio::time::interval_at(tokio::time::Instant::now() + iv, iv);
+            let mut inbound_open = true;
 
             loop {
                 let mut wsbuf = [0u8; 8192];
@@ -197,10 +198,10 @@ impl GwClient {
                             },
                             PktTy::Data => {
                                 let p = HttpDataPkt::decode(&mut cur).map_err(|e| custom_err!("PktDecode", e))?;
-                                if in_tx.send(Bytes::from(p.data.to_vec())).await.is_err() {
+                                if inbound_open && in_tx.send(Bytes::from(p.data.to_vec())).await.is_err() {
                                     // Reader gone or shutdown closed the inbound channel.
-                                    gw.io.close().await?;
-                                    return Ok(());
+                                    // Keep draining outbound bytes before closing the WebSocket.
+                                    inbound_open = false;
                                 }
                             },
                             PktTy::ServiceMessage => {

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -197,7 +197,11 @@ impl GwClient {
                             },
                             PktTy::Data => {
                                 let p = HttpDataPkt::decode(&mut cur).map_err(|e| custom_err!("PktDecode", e))?;
-                                in_tx.send(Bytes::from(p.data.to_vec())).await.map_err(|e| custom_err!("in_tx dead", e))?;
+                                if in_tx.send(Bytes::from(p.data.to_vec())).await.is_err() {
+                                    // Reader gone or shutdown closed the inbound channel.
+                                    gw.io.close().await?;
+                                    return Ok(());
+                                }
                             },
                             PktTy::ServiceMessage => {
                                 let msg = ServiceMessagePkt::decode(&mut cur).map_err(|e| custom_err!("PktDecode", e))?;
@@ -481,9 +485,11 @@ impl AsyncWrite for GwClient {
     }
 
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut core::task::Context<'_>) -> Poll<Result<(), io::Error>> {
-        // Closing the sender ends the outbound queue; the work task then closes the
-        // WebSocket so a local write-side EOF can finish.
+        // Closing the outbound sender ends the write queue. Closing the inbound
+        // receiver unblocks a worker parked on `in_tx.send` when the caller is not
+        // reading, so the work task can close the WebSocket and finish.
         self.tx.close();
+        self.rx.close();
         if self.work_done {
             return Poll::Ready(Ok(()));
         }

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -6,6 +6,7 @@ mod macros;
 
 #[doc(hidden)]
 pub mod http_auth;
+mod packet_io;
 mod proto;
 mod udp;
 
@@ -16,23 +17,14 @@ use core::task::Poll;
 use core::time::Duration;
 use std::io;
 
-use futures_util::stream::{SplitSink, SplitStream};
-use futures_util::{FutureExt as _, SinkExt as _, StreamExt as _};
-use http_body_util::BodyExt as _;
+use futures_util::FutureExt as _;
 use hyper::body::Bytes;
 use ironrdp_core::{Decode as _, Encode, ReadCursor, WriteCursor};
-use ironrdp_tls::TlsStream;
-use log::{error, warn};
+use log::warn;
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::net::TcpStream;
-use tokio::sync::oneshot;
-use tokio_tungstenite::WebSocketStream;
-use tokio_tungstenite::tungstenite::handshake::client::generate_key;
-use tokio_tungstenite::tungstenite::protocol::Role;
-use tokio_tungstenite::tungstenite::{Message, http};
 use tokio_util::sync::PollSender;
 
-use self::http_auth::{AuthStep, GatewayHttpAuth, basic_authorization, www_authenticate_values};
+use self::packet_io::{PacketIo, open_websocket_transport};
 #[doc(hidden)]
 pub use self::proto::{ChannelClosePkt, ReauthMessagePkt, ServiceMessagePkt, gateway_code_label};
 use self::proto::{
@@ -107,8 +99,7 @@ struct GwConn {
     ///
     /// Common values are `3389` for ordinary RDP and `2179` for Hyper-V VMConnect.
     server_port: u16,
-    ws_sink: SplitSink<WebSocketStream<TlsStream<TcpStream>>, Message>,
-    ws_stream: SplitStream<WebSocketStream<TlsStream<TcpStream>>>,
+    io: PacketIo,
 }
 
 pub struct GwClient {
@@ -145,45 +136,8 @@ impl GwClient {
         client_name: &str,
         server_port: u16,
     ) -> Result<(GwClient, core::net::SocketAddr), Error> {
-        let gw_host = target
-            .gw_endpoint
-            .split(":")
-            .nth(0)
-            .ok_or_else(|| Error::new("Connect", GwErrorKind::InvalidGwTarget))?;
-
-        let stream = TcpStream::connect(&target.gw_endpoint)
-            .await
-            .map_err(|e| custom_err!("TCP connect", e))?;
-        let client_addr = stream
-            .local_addr()
-            .map_err(|e| custom_err!("get socket local address", e))?;
-
-        let (stream, _) = ironrdp_tls::upgrade(stream, gw_host)
-            .await
-            .map_err(|e| custom_err!("TLS connect", e))?;
-
-        let connection_id = format!("{{{}}}", uuid::Uuid::new_v4());
-        let spn = format!("HTTP/{gw_host}");
-
-        let stream = hyper_util::rt::tokio::TokioIo::new(stream);
-        let (mut sender, mut conn) = hyper::client::conn::http1::handshake(stream)
-            .await
-            .map_err(|e| custom_err!("H1 Handshake", e))?;
-        let (tx, rx) = oneshot::channel();
-
-        let jh = tokio::task::spawn(async move {
-            tokio::select! {
-                Err(e) = &mut conn => error!("Handshake error: {:?}", e),
-                _ = rx => (),
-            }
-            conn.into_parts()
-        });
-        websocket_upgrade_with_auth(&mut sender, gw_host, &connection_id, target, &spn).await?;
-
-        let _ = tx.send(()); // TODO: Not needed since it doesnt keep alive conn?
-        let stream = jh.await.map_err(|e| custom_err!("WS join", e))?.io.into_inner();
-
-        Self::connect_ws(target.clone(), client_name, server_port, stream)
+        let (io, client_addr) = open_websocket_transport(target).await?;
+        Self::connect_ws(target.clone(), client_name, server_port, io)
             .await
             .map(|x| (x, client_addr))
     }
@@ -192,16 +146,13 @@ impl GwClient {
         target: GwConnectTarget,
         client_name: &str,
         server_port: u16,
-        tls_stream: TlsStream<TcpStream>,
+        io: PacketIo,
     ) -> Result<GwClient, Error> {
-        let ws_stream: WebSocketStream<_> = WebSocketStream::from_raw_socket(tls_stream, Role::Client, None).await;
-        let (ws_sink, ws_stream) = ws_stream.split();
         let mut gw = GwConn {
             client_name: client_name.to_owned(),
             target,
             server_port,
-            ws_sink,
-            ws_stream,
+            io,
         };
 
         gw.handshake().await?;
@@ -227,20 +178,14 @@ impl GwClient {
                             cur.pos()
                         };
 
-                        gw.ws_sink.send(Message::Binary(Bytes::copy_from_slice(&wsbuf[..pos]))).await.map_err(|e| custom_err!("ws send", e))?;
+                        gw.io.send_bytes(&wsbuf[..pos]).await?;
                     },
-                    next = gw.ws_stream.next() => {
-                        let msg = match next {
-                            // A clean close or an exhausted stream ends the work task with
-                            // `Ok`, so readers observe end-of-stream rather than an error.
-                            None => return Ok(()),
-                            Some(Ok(msg)) => msg,
-                            Some(Err(e)) => return Err(custom_err!("Stream", e)),
-                        };
-                        if matches!(msg, Message::Close(_)) {
+                    next = gw.io.read_packet_buf() => {
+                        // A clean close or an exhausted stream ends the work task with
+                        // `Ok`, so readers observe end-of-stream rather than an error.
+                        let Some(msg) = next? else {
                             return Ok(());
-                        }
-                        let msg = msg.into_data();
+                        };
                         let mut cur = ReadCursor::new(&msg);
                         let hdr = PktHdr::decode(&mut cur).map_err(|e| custom_err!("Header Decode", e))?;
 
@@ -279,10 +224,7 @@ impl GwClient {
                                             .map_err(|e| custom_err!("PktEncode", e))?;
                                         wcur.pos()
                                     };
-                                    gw.ws_sink
-                                        .send(Message::Binary(Bytes::copy_from_slice(&wsbuf[..pos])))
-                                        .await
-                                        .map_err(|e| custom_err!("ws send", e))?;
+                                    gw.io.send_bytes(&wsbuf[..pos]).await?;
                                 }
                                 return Ok(());
                             },
@@ -292,7 +234,11 @@ impl GwClient {
                         }
                     },
                     next = out_rx.recv() => {
-                        let next = next.ok_or_else(|| Error::new("WS Sink Dead", GwErrorKind::Connect))?;
+                        let Some(next) = next else {
+                            // Local write-side close: finish the WebSocket so poll_shutdown can complete.
+                            gw.io.close().await?;
+                            return Ok(());
+                        };
                         let pkt = HttpDataPkt { data: &next };
 
                         let pos = {
@@ -300,7 +246,7 @@ impl GwClient {
                             pkt.encode(&mut cur).map_err(|e| custom_err!("PktEncode", e))?;
                             cur.pos()
                         };
-                        gw.ws_sink.send(Message::Binary(Bytes::copy_from_slice(&wsbuf[..pos]))).await.map_err(|e| custom_err!("ws send", e))?;
+                        gw.io.send_bytes(&wsbuf[..pos]).await?;
                     }
                 );
             }
@@ -316,137 +262,6 @@ impl GwClient {
     }
 }
 
-/// Challenge-first WebSocket upgrade: omit Authorization until 401, then Negotiate/NTLM/Basic.
-async fn websocket_upgrade_with_auth(
-    sender: &mut hyper::client::conn::http1::SendRequest<http_body_util::Empty<Bytes>>,
-    gw_host: &str,
-    connection_id: &str,
-    target: &GwConnectTarget,
-    spn: &str,
-) -> Result<(), Error> {
-    let mut http_auth: Option<GatewayHttpAuth> = None;
-    let mut authorization: Option<String> = None;
-    let mut use_basic = false;
-    const MAX_AUTH_ROUNDS: usize = 8;
-
-    for _ in 0..MAX_AUTH_ROUNDS {
-        let req = build_ws_upgrade_request(
-            gw_host,
-            connection_id,
-            if use_basic {
-                Some(basic_authorization(&target.gw_user, &target.gw_pass))
-            } else {
-                authorization.clone()
-            }
-            .as_deref(),
-        )?;
-
-        let resp = sender
-            .send_request(req)
-            .await
-            .map_err(|e| custom_err!("WS Upgrade Send error", e))?;
-
-        if resp.status() == http::StatusCode::SWITCHING_PROTOCOLS {
-            if let Some(mut auth) = http_auth.take() {
-                let challenges: Vec<String> = www_authenticate_values(resp.headers())
-                    .into_iter()
-                    .map(str::to_owned)
-                    .collect();
-                run_http_auth(move || auth.finish_www_authenticate(challenges.iter().map(String::as_str))).await?;
-            }
-            return Ok(());
-        }
-
-        if resp.status() != http::StatusCode::UNAUTHORIZED {
-            return Err(Error::new("WS Upgrade", GwErrorKind::Connect));
-        }
-
-        if use_basic {
-            return Err(Error::new("websocket upgrade basic auth", GwErrorKind::Connect));
-        }
-
-        let challenges: Vec<String> = www_authenticate_values(resp.headers())
-            .into_iter()
-            .map(str::to_owned)
-            .collect();
-        resp.into_body()
-            .collect()
-            .await
-            .map_err(|e| custom_err!("drain websocket upgrade auth body", e))?;
-
-        let user = target.gw_user.clone();
-        let pass = target.gw_pass.clone();
-        let target_name = spn.to_owned();
-        let step = if let Some(mut auth) = http_auth.take() {
-            let (auth, step) = run_http_auth(move || {
-                let refs: Vec<&str> = challenges.iter().map(String::as_str).collect();
-                let step = auth.step_www_authenticate(refs)?;
-                Ok((auth, step))
-            })
-            .await?;
-            http_auth = Some(auth);
-            step
-        } else {
-            let (auth, step) = run_http_auth(move || {
-                let refs: Vec<&str> = challenges.iter().map(String::as_str).collect();
-                GatewayHttpAuth::from_challenges(&user, &pass, Some(target_name), &refs)
-            })
-            .await?;
-            http_auth = auth;
-            step
-        };
-
-        match step {
-            AuthStep::Continue(next) => authorization = Some(next),
-            AuthStep::TryBasic => use_basic = true,
-            AuthStep::Complete => {
-                return Err(Error::new(
-                    "websocket upgrade auth complete without switching protocols",
-                    GwErrorKind::Connect,
-                ));
-            }
-        }
-    }
-
-    Err(Error::new(
-        "websocket upgrade auth rounds exceeded",
-        GwErrorKind::Connect,
-    ))
-}
-
-async fn run_http_auth<T, F>(f: F) -> Result<T, Error>
-where
-    T: Send + 'static,
-    F: FnOnce() -> Result<T, Error> + Send + 'static,
-{
-    tokio::task::spawn_blocking(f)
-        .await
-        .map_err(|e| Error::custom("http auth task", e))?
-}
-
-fn build_ws_upgrade_request(
-    gw_host: &str,
-    connection_id: &str,
-    authorization: Option<&str>,
-) -> Result<http::Request<http_body_util::Empty<Bytes>>, Error> {
-    let mut req = http::Request::builder()
-        .method("RDG_OUT_DATA")
-        .header(hyper::header::HOST, gw_host)
-        .header("Rdg-Connection-Id", connection_id)
-        .uri("/remoteDesktopGateway/")
-        .header(hyper::header::CONNECTION, "Upgrade")
-        .header(hyper::header::UPGRADE, "websocket")
-        .header(hyper::header::SEC_WEBSOCKET_VERSION, "13")
-        .header(hyper::header::SEC_WEBSOCKET_KEY, generate_key());
-
-    if let Some(authorization) = authorization {
-        req = req.header(hyper::header::AUTHORIZATION, authorization);
-    }
-
-    req.body(http_body_util::Empty::<Bytes>::new())
-        .map_err(|e| custom_err!("failed to build request", e))
-}
-
 impl GwConn {
     async fn send_packet<E: Encode>(&mut self, payload: &E) -> Result<(), Error> {
         let mut buf = [0u8; 4096];
@@ -457,21 +272,15 @@ impl GwConn {
                 .map_err(|e| Error::new("packet encode", GwErrorKind::Encode).with_source(e))?;
             cur.pos()
         };
-        self.ws_sink
-            .send(Message::Binary(Bytes::copy_from_slice(&buf[..pos])))
-            .await
-            .map_err(|e| custom_err!("WebSocket send error", e))?;
-        Ok(())
+        self.io.send_bytes(&buf[..pos]).await
     }
 
     async fn read_packet(&mut self) -> Result<(PktHdr, Bytes), Error> {
         let mut msg = self
-            .ws_stream
-            .next()
-            .await
-            .ok_or_else(|| Error::new("Stream closed", GwErrorKind::Connect))?
-            .map_err(|e| custom_err!("WS err", e))?
-            .into_data();
+            .io
+            .read_packet_buf()
+            .await?
+            .ok_or_else(|| Error::new("Stream closed", GwErrorKind::Connect))?;
         let mut cur = ReadCursor::new(&msg);
 
         let hdr = PktHdr::decode(&mut cur).map_err(|_| Error::new("PktHdr", GwErrorKind::Decode))?;
@@ -671,7 +480,27 @@ impl AsyncWrite for GwClient {
         Poll::Ready(Ok(()))
     }
 
-    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut core::task::Context<'_>) -> Poll<Result<(), io::Error>> {
-        Poll::Ready(Ok(()))
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut core::task::Context<'_>) -> Poll<Result<(), io::Error>> {
+        // Closing the sender ends the outbound queue; the work task then closes the
+        // WebSocket so a local write-side EOF can finish.
+        self.tx.close();
+        if self.work_done {
+            return Poll::Ready(Ok(()));
+        }
+        match self.work.poll_unpin(cx) {
+            Poll::Ready(Ok(Ok(()))) => {
+                self.work_done = true;
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Ok(Err(e))) => {
+                self.work_done = true;
+                Poll::Ready(Err(io::Error::other(e)))
+            }
+            Poll::Ready(Err(e)) => {
+                self.work_done = true;
+                Poll::Ready(Err(io::Error::other(e)))
+            }
+            Poll::Pending => Poll::Pending,
+        }
     }
 }

--- a/crates/ironrdp-mstsgu/src/packet_io.rs
+++ b/crates/ironrdp-mstsgu/src/packet_io.rs
@@ -1,0 +1,239 @@
+//! Packet I/O over the MS-TSGU HTTPS WebSocket transport.
+
+use futures_util::stream::{SplitSink, SplitStream};
+use futures_util::{SinkExt as _, StreamExt as _};
+use http_body_util::BodyExt as _;
+use hyper::body::Bytes;
+use ironrdp_tls::TlsStream;
+use log::error;
+use tokio::net::TcpStream;
+use tokio::sync::oneshot;
+use tokio_tungstenite::WebSocketStream;
+use tokio_tungstenite::tungstenite::handshake::client::generate_key;
+use tokio_tungstenite::tungstenite::protocol::Role;
+use tokio_tungstenite::tungstenite::{Message, http};
+
+use crate::http_auth::{AuthStep, GatewayHttpAuth, basic_authorization, www_authenticate_values};
+use crate::{Error, GwConnectTarget, GwErrorKind};
+
+/// WebSocket byte transport used after the HTTP upgrade completes.
+pub(crate) struct PacketIo {
+    sink: SplitSink<WebSocketStream<TlsStream<TcpStream>>, Message>,
+    stream: SplitStream<WebSocketStream<TlsStream<TcpStream>>>,
+}
+
+impl PacketIo {
+    pub(crate) async fn send_bytes(&mut self, bytes: &[u8]) -> Result<(), Error> {
+        self.sink
+            .send(Message::Binary(Bytes::copy_from_slice(bytes)))
+            .await
+            .map_err(|e| custom_err!("ws send", e))?;
+        Ok(())
+    }
+
+    /// Sends a WebSocket close frame so a local write-side EOF can finish.
+    pub(crate) async fn close(&mut self) -> Result<(), Error> {
+        self.sink
+            .send(Message::Close(None))
+            .await
+            .map_err(|e| custom_err!("websocket close", e))?;
+        self.sink
+            .flush()
+            .await
+            .map_err(|e| custom_err!("websocket close flush", e))?;
+        Ok(())
+    }
+
+    /// Reads one WebSocket message as an MS-TSGU packet buffer.
+    ///
+    /// Returns `Ok(None)` on a clean close or an exhausted stream.
+    pub(crate) async fn read_packet_buf(&mut self) -> Result<Option<Bytes>, Error> {
+        let msg = match self.stream.next().await {
+            None => return Ok(None),
+            Some(Ok(msg)) => msg,
+            Some(Err(e)) => return Err(custom_err!("Stream", e)),
+        };
+        if matches!(msg, Message::Close(_)) {
+            return Ok(None);
+        }
+        Ok(Some(msg.into_data()))
+    }
+}
+
+/// Open a TLS WebSocket to the gateway and authenticate the upgrade.
+pub(crate) async fn open_websocket_transport(
+    target: &GwConnectTarget,
+) -> Result<(PacketIo, core::net::SocketAddr), Error> {
+    let gw_host = target
+        .gw_endpoint
+        .split(":")
+        .next()
+        .ok_or_else(|| Error::new("Connect", GwErrorKind::InvalidGwTarget))?;
+
+    let stream = TcpStream::connect(&target.gw_endpoint)
+        .await
+        .map_err(|e| custom_err!("TCP connect", e))?;
+    let client_addr = stream
+        .local_addr()
+        .map_err(|e| custom_err!("get socket local address", e))?;
+
+    let (stream, _) = ironrdp_tls::upgrade(stream, gw_host)
+        .await
+        .map_err(|e| custom_err!("TLS connect", e))?;
+
+    let connection_id = format!("{{{}}}", uuid::Uuid::new_v4());
+    let spn = format!("HTTP/{gw_host}");
+
+    let stream = hyper_util::rt::tokio::TokioIo::new(stream);
+    let (mut sender, mut conn) = hyper::client::conn::http1::handshake(stream)
+        .await
+        .map_err(|e| custom_err!("H1 Handshake", e))?;
+    let (tx, rx) = oneshot::channel();
+
+    let jh = tokio::task::spawn(async move {
+        tokio::select! {
+            Err(e) = &mut conn => error!("Handshake error: {:?}", e),
+            _ = rx => (),
+        }
+        conn.into_parts()
+    });
+    websocket_upgrade_with_auth(&mut sender, gw_host, &connection_id, target, &spn).await?;
+
+    let _ = tx.send(()); // TODO: Not needed since it doesnt keep alive conn?
+    let stream = jh.await.map_err(|e| custom_err!("WS join", e))?.io.into_inner();
+
+    let ws_stream = WebSocketStream::from_raw_socket(stream, Role::Client, None).await;
+    let (sink, stream) = ws_stream.split();
+    Ok((PacketIo { sink, stream }, client_addr))
+}
+
+/// Challenge-first WebSocket upgrade: omit Authorization until 401, then Negotiate/NTLM/Basic.
+async fn websocket_upgrade_with_auth(
+    sender: &mut hyper::client::conn::http1::SendRequest<http_body_util::Empty<Bytes>>,
+    gw_host: &str,
+    connection_id: &str,
+    target: &GwConnectTarget,
+    spn: &str,
+) -> Result<(), Error> {
+    let mut http_auth: Option<GatewayHttpAuth> = None;
+    let mut authorization: Option<String> = None;
+    let mut use_basic = false;
+    const MAX_AUTH_ROUNDS: usize = 8;
+
+    for _ in 0..MAX_AUTH_ROUNDS {
+        let req = build_ws_upgrade_request(
+            gw_host,
+            connection_id,
+            if use_basic {
+                Some(basic_authorization(&target.gw_user, &target.gw_pass))
+            } else {
+                authorization.clone()
+            }
+            .as_deref(),
+        )?;
+
+        let resp = sender
+            .send_request(req)
+            .await
+            .map_err(|e| custom_err!("WS Upgrade Send error", e))?;
+
+        if resp.status() == http::StatusCode::SWITCHING_PROTOCOLS {
+            if let Some(mut auth) = http_auth.take() {
+                let challenges: Vec<String> = www_authenticate_values(resp.headers())
+                    .into_iter()
+                    .map(str::to_owned)
+                    .collect();
+                run_http_auth(move || auth.finish_www_authenticate(challenges.iter().map(String::as_str))).await?;
+            }
+            return Ok(());
+        }
+
+        if resp.status() != http::StatusCode::UNAUTHORIZED {
+            return Err(Error::new("WS Upgrade", GwErrorKind::Connect));
+        }
+
+        if use_basic {
+            return Err(Error::new("websocket upgrade basic auth", GwErrorKind::Connect));
+        }
+
+        let challenges: Vec<String> = www_authenticate_values(resp.headers())
+            .into_iter()
+            .map(str::to_owned)
+            .collect();
+        resp.into_body()
+            .collect()
+            .await
+            .map_err(|e| custom_err!("drain websocket upgrade auth body", e))?;
+
+        let user = target.gw_user.clone();
+        let pass = target.gw_pass.clone();
+        let target_name = spn.to_owned();
+        let step = if let Some(mut auth) = http_auth.take() {
+            let (auth, step) = run_http_auth(move || {
+                let refs: Vec<&str> = challenges.iter().map(String::as_str).collect();
+                let step = auth.step_www_authenticate(refs)?;
+                Ok((auth, step))
+            })
+            .await?;
+            http_auth = Some(auth);
+            step
+        } else {
+            let (auth, step) = run_http_auth(move || {
+                let refs: Vec<&str> = challenges.iter().map(String::as_str).collect();
+                GatewayHttpAuth::from_challenges(&user, &pass, Some(target_name), &refs)
+            })
+            .await?;
+            http_auth = auth;
+            step
+        };
+
+        match step {
+            AuthStep::Continue(next) => authorization = Some(next),
+            AuthStep::TryBasic => use_basic = true,
+            AuthStep::Complete => {
+                return Err(Error::new(
+                    "websocket upgrade auth complete without switching protocols",
+                    GwErrorKind::Connect,
+                ));
+            }
+        }
+    }
+
+    Err(Error::new(
+        "websocket upgrade auth rounds exceeded",
+        GwErrorKind::Connect,
+    ))
+}
+
+async fn run_http_auth<T, F>(f: F) -> Result<T, Error>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, Error> + Send + 'static,
+{
+    tokio::task::spawn_blocking(f)
+        .await
+        .map_err(|e| custom_err!("http auth task", e))?
+}
+
+fn build_ws_upgrade_request(
+    gw_host: &str,
+    connection_id: &str,
+    authorization: Option<&str>,
+) -> Result<http::Request<http_body_util::Empty<Bytes>>, Error> {
+    let mut req = http::Request::builder()
+        .method("RDG_OUT_DATA")
+        .header(hyper::header::HOST, gw_host)
+        .header("Rdg-Connection-Id", connection_id)
+        .uri("/remoteDesktopGateway/")
+        .header(hyper::header::CONNECTION, "Upgrade")
+        .header(hyper::header::UPGRADE, "websocket")
+        .header(hyper::header::SEC_WEBSOCKET_VERSION, "13")
+        .header(hyper::header::SEC_WEBSOCKET_KEY, generate_key());
+
+    if let Some(authorization) = authorization {
+        req = req.header(hyper::header::AUTHORIZATION, authorization);
+    }
+
+    req.body(http_body_util::Empty::<Bytes>::new())
+        .map_err(|e| custom_err!("failed to build request", e))
+}


### PR DESCRIPTION
Move the HTTPS WebSocket transport, auth upgrade loop, and byte
read/write helpers out of lib.rs so handshake/tunnel/channel
sequencing stays separate from I/O.

GwClient write-side shutdown now closes the outbound sender and
inbound receiver, then waits for the worker so a local EOF can
finish even if inbound delivery is blocked. Local shutdown still
does not send HTTP_CLOSE_PACKET; inbound channel-close handling
from master is preserved.

This does not include dual-HTTP, RPCH, proxies, or certificate
policy APIs.