### PR TITLE
feat(mstsgu): add RDG-UDP PDU codecs

### DIFF
--- a/crates/ironrdp-mstsgu/CHANGELOG.md
+++ b/crates/ironrdp-mstsgu/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - HTTP multi-leg authentication for the WebSocket upgrade: Negotiate SPNEGO (Kerberos with NTLM fallback via KDC discovery / `SSPI_KDC_URL`), pure NTLM when only NTLM is advertised, and Basic fallback.
+- RDG-UDP PDU encode/decode helpers (`CONNECT_PKT`, `DATA_PKT`, `DISC_PKT`, and `UDP_CORRELATION_INFO`) without opening a live DTLS side channel.
 
 ## [[0.0.1](https://github.com/Devolutions/IronRDP/releases/tag/ironrdp-mstsgu-v0.0.1)] - 2026-07-10
 

--- a/crates/ironrdp-mstsgu/Cargo.toml
+++ b/crates/ironrdp-mstsgu/Cargo.toml
@@ -30,9 +30,6 @@ default = []
 rustls = ["ironrdp-tls/rustls", "tokio-tungstenite/rustls-tls-native-roots"]
 native-tls = ["ironrdp-tls/native-tls", "tokio-tungstenite/native-tls"]
 
-[dev-dependencies]
-ironrdp-core = { path = "../ironrdp-core", version = "0.2", features = ["std"] }
-
 [dependencies]
 base64 = "0.22"
 bitflags = "2.11"

--- a/crates/ironrdp-mstsgu/Cargo.toml
+++ b/crates/ironrdp-mstsgu/Cargo.toml
@@ -21,10 +21,17 @@ name = "http_auth"
 path = "tests/http_auth.rs"
 required-features = ["native-tls"]
 
+[[test]]
+name = "udp"
+path = "tests/udp.rs"
+
 [features]
 default = []
 rustls = ["ironrdp-tls/rustls", "tokio-tungstenite/rustls-tls-native-roots"]
 native-tls = ["ironrdp-tls/native-tls", "tokio-tungstenite/native-tls"]
+
+[dev-dependencies]
+ironrdp-core = { path = "../ironrdp-core", version = "0.2", features = ["std"] }
 
 [dependencies]
 base64 = "0.22"
@@ -33,7 +40,7 @@ futures-util = "0.3"
 http-body-util = { version = "0.1" }
 hyper-util = { version = "0.1", features = ["tokio"] }
 hyper = { version = "1.9", features = ["client", "http1"] }
-ironrdp-core = { path = "../ironrdp-core", version = "0.2", features = ["std"] }
+ironrdp-core = { path = "../ironrdp-core", version = "0.2", features = ["std"] } # public
 ironrdp-error = { path = "../ironrdp-error", version = "0.2" }
 ironrdp-tls = { path = "../ironrdp-tls", version = "0.2" }
 log = "0.4"

--- a/crates/ironrdp-mstsgu/README.md
+++ b/crates/ironrdp-mstsgu/README.md
@@ -4,8 +4,9 @@
 
 This crate
 - implements an MVP state needed to connect through Microsoft RD Gateway,
-- only supports the HTTPS protocol with WebSocket (and not the legacy HTTP, HTTP-RPC or UDP protocols),
-- does not implement reconnection/reauthentication, Detect, or a live UDP path, and
-- authenticates the WebSocket upgrade with HTTP Negotiate (Kerberos then NTLM), NTLM, or Basic fallback.
+- only supports the HTTPS protocol with WebSocket (and not the legacy HTTP or HTTP-RPC transports),
+- does not implement reconnection/reauthentication, Detect, or a live UDP/DTLS side channel,
+- authenticates the WebSocket upgrade with HTTP Negotiate (Kerberos then NTLM), NTLM, or Basic fallback, and
+- encodes and decodes RDG-UDP PDUs (`CONNECT_PKT`, `DATA_PKT`, `DISC_PKT`, and correlation info) without opening that side channel.
 
 [MS-TSGU]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsgu/0007d661-a86d-4e8f-89f7-7f77f8824188

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -7,6 +7,12 @@ mod macros;
 #[doc(hidden)]
 pub mod http_auth;
 mod proto;
+mod udp;
+
+pub use self::udp::{
+    AaSynData, AaSynDataResp, ConnectPkt, ConnectPktResp, DataPkt, DiscPkt, GwUdpOffer, UdpCorrelationInfo,
+    UdpPacketHeader, UdpPktType, encode_connect_request, fragment_connect_pkt,
+};
 
 use core::fmt;
 use core::fmt::Display;
@@ -33,8 +39,8 @@ use tokio_util::sync::PollSender;
 
 use self::http_auth::{AuthStep, GatewayHttpAuth, basic_authorization, www_authenticate_values};
 use self::proto::{
-    ChannelPkt, ChannelResp, DataPkt, HandshakeReqPkt, HandshakeRespPkt, HttpCapsTy, KeepalivePkt, PktHdr, PktTy,
-    TunnelAuthPkt, TunnelAuthRespPkt, TunnelReqPkt, TunnelRespPkt,
+    ChannelPkt, ChannelResp, DataPkt as HttpDataPkt, HandshakeReqPkt, HandshakeRespPkt, HttpCapsTy, KeepalivePkt,
+    PktHdr, PktTy, TunnelAuthPkt, TunnelAuthRespPkt, TunnelReqPkt, TunnelRespPkt,
 };
 
 #[derive(Clone, Debug)]
@@ -244,7 +250,7 @@ impl GwClient {
                                 continue;
                             },
                             PktTy::Data => {
-                                let p = DataPkt::decode(&mut cur).map_err(|e| custom_err!("PktDecode", e))?;
+                                let p = HttpDataPkt::decode(&mut cur).map_err(|e| custom_err!("PktDecode", e))?;
                                 in_tx.send(Bytes::from(p.data.to_vec())).await.map_err(|e| custom_err!("in_tx dead", e))?;
                             },
                             x => {
@@ -254,7 +260,7 @@ impl GwClient {
                     },
                     next = out_rx.recv() => {
                         let next = next.ok_or_else(|| Error::new("WS Sink Dead", GwErrorKind::Connect))?;
-                        let pkt = DataPkt { data: &next };
+                        let pkt = HttpDataPkt { data: &next };
 
                         let pos = {
                             let mut cur = WriteCursor::new(&mut wsbuf);

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -10,8 +10,8 @@ mod proto;
 mod udp;
 
 pub use self::udp::{
-    AaSynData, AaSynDataResp, ConnectPkt, ConnectPktResp, DataPkt, DiscPkt, GwUdpOffer, UdpCorrelationInfo,
-    UdpPacketHeader, UdpPktType, encode_connect_request, fragment_connect_pkt,
+    AaSynData, AaSynDataResp, ConnectPkt, ConnectPktResp, DataPkt, DiscPkt, GwUdpOffer, MAX_CONNECT_REQ_FRAGMENT_SIZE,
+    UdpCorrelationInfo, UdpPacketHeader, UdpPktType, encode_connect_request, fragment_connect_pkt,
 };
 
 use core::fmt;

--- a/crates/ironrdp-mstsgu/src/udp.rs
+++ b/crates/ironrdp-mstsgu/src/udp.rs
@@ -6,9 +6,13 @@
 //! [MS-TSGU]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsgu/0007d661-a86d-4e8f-89f7-7f77f8824188
 
 use ironrdp_core::{
-    Decode, Encode, ReadCursor, WriteCursor, cast_int, ensure_fixed_part_size, ensure_size, other_err,
-    unsupported_value_err,
+    Decode, Encode, ReadCursor, WriteCursor, cast_int, ensure_fixed_part_size, ensure_size, unsupported_value_err,
 };
+
+/// Maximum CONNECT_PKT fragment payload ([MS-TSGU] 3.8.3 `MAX_CONNECT_REQ_FRAGMENT_SIZE`).
+///
+/// [MS-TSGU]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsgu/0007d661-a86d-4e8f-89f7-7f77f8824188
+pub const MAX_CONNECT_REQ_FRAGMENT_SIZE: usize = 1000;
 
 /// Parameters from [`HTTP_CHANNEL_RESPONSE`][channel-resp] that enable a future RDG-UDP side channel.
 ///
@@ -201,6 +205,8 @@ pub struct ConnectPkt {
 }
 
 impl ConnectPkt {
+    const FIXED_BODY_SIZE: usize = 2 /* usPortNumber */ + 2 /* cbAuthnCookieLen */ + AaSynData::FIXED_PART_SIZE;
+
     /// Build a connect request from a main-channel UDP offer and target resource port.
     pub fn from_offer(offer: &GwUdpOffer, target_port: u16, syn_data: AaSynData) -> Self {
         Self {
@@ -233,11 +239,7 @@ impl Encode for ConnectPkt {
     }
 
     fn size(&self) -> usize {
-        UdpPacketHeader::FIXED_PART_SIZE
-            + 2 /* usPortNumber */
-            + 2 /* cbAuthnCookieLen */
-            + AaSynData::FIXED_PART_SIZE
-            + self.authn_cookie.len()
+        UdpPacketHeader::FIXED_PART_SIZE + Self::FIXED_BODY_SIZE + self.authn_cookie.len()
     }
 }
 
@@ -251,11 +253,25 @@ impl Decode<'_> for ConnectPkt {
                 format!("0x{:x}", hdr.pkt_id),
             ));
         }
-        ensure_size!(in: src, size: 4);
+        let body_len = usize::from(hdr.pkt_len);
+        ensure_size!(in: src, size: body_len);
+        if body_len < Self::FIXED_BODY_SIZE {
+            return Err(unsupported_value_err(
+                "CONNECT_PKT::pkt_len",
+                "pkt_len",
+                format!("{body_len}"),
+            ));
+        }
         let target_port = src.read_u16();
         let cookie_len = usize::from(src.read_u16());
+        if body_len != Self::FIXED_BODY_SIZE + cookie_len {
+            return Err(unsupported_value_err(
+                "CONNECT_PKT::pkt_len",
+                "pkt_len",
+                format!("{body_len}"),
+            ));
+        }
         let syn_data = AaSynData::decode(src)?;
-        ensure_size!(in: src, size: cookie_len);
         let authn_cookie = src.read_slice(cookie_len).to_vec();
         Ok(Self {
             target_port,
@@ -273,6 +289,10 @@ pub struct ConnectPktResp {
     pub syn_response: AaSynDataResp,
     /// Connection result (HRESULT-style `i64` on the wire as 8 little-endian bytes).
     pub result: i64,
+}
+
+impl ConnectPktResp {
+    const BODY_SIZE: usize = AaSynDataResp::FIXED_PART_SIZE + 8 /* result */;
 }
 
 impl Encode for ConnectPktResp {
@@ -294,7 +314,7 @@ impl Encode for ConnectPktResp {
     }
 
     fn size(&self) -> usize {
-        UdpPacketHeader::FIXED_PART_SIZE + AaSynDataResp::FIXED_PART_SIZE + 8 /* result */
+        UdpPacketHeader::FIXED_PART_SIZE + Self::BODY_SIZE
     }
 }
 
@@ -306,6 +326,13 @@ impl Decode<'_> for ConnectPktResp {
                 "CONNECT_PKT_RESP::pkt_id",
                 "pkt_id",
                 format!("0x{:x}", hdr.pkt_id),
+            ));
+        }
+        if usize::from(hdr.pkt_len) != Self::BODY_SIZE {
+            return Err(unsupported_value_err(
+                "CONNECT_PKT_RESP::pkt_len",
+                "pkt_len",
+                format!("{}", hdr.pkt_len),
             ));
         }
         let syn_response = AaSynDataResp::decode(src)?;
@@ -371,12 +398,16 @@ pub struct DiscPkt {
     pub reason: i64,
 }
 
+impl DiscPkt {
+    const BODY_SIZE: usize = 8 /* discReason */;
+}
+
 impl Encode for DiscPkt {
     fn encode(&self, dst: &mut WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
         ensure_size!(in: dst, size: self.size());
         let hdr = UdpPacketHeader {
             pkt_id: UdpPktType::Disconnect.as_u16(),
-            pkt_len: cast_int!("disconnect pkt body length", 8 /* discReason */)?,
+            pkt_len: cast_int!("disconnect pkt body length", Self::BODY_SIZE)?,
         };
         hdr.encode(dst)?;
         dst.write_i64(self.reason);
@@ -388,7 +419,7 @@ impl Encode for DiscPkt {
     }
 
     fn size(&self) -> usize {
-        UdpPacketHeader::FIXED_PART_SIZE + 8 /* discReason */
+        UdpPacketHeader::FIXED_PART_SIZE + Self::BODY_SIZE
     }
 }
 
@@ -402,7 +433,14 @@ impl Decode<'_> for DiscPkt {
                 format!("0x{:x}", hdr.pkt_id),
             ));
         }
-        ensure_size!(in: src, size: 8);
+        if usize::from(hdr.pkt_len) != Self::BODY_SIZE {
+            return Err(unsupported_value_err(
+                "DISC_PKT::pkt_len",
+                "pkt_len",
+                format!("{}", hdr.pkt_len),
+            ));
+        }
+        ensure_size!(in: src, size: Self::BODY_SIZE);
         Ok(Self { reason: src.read_i64() })
     }
 }
@@ -481,29 +519,24 @@ impl Decode<'_> for UdpCorrelationInfo {
     }
 }
 
-/// Split a connect request into fragment packets ([2.2.11.10]) when needed for MTU.
+/// Split a complete `CONNECT_PKT` into fragment packets ([2.2.11.10] / [3.8.3]).
+///
+/// [MS-TSGU] 3.8.3 sets `reqLen` to `hdr.pktLen + sizeof(UDP_PACKET_HEADER)` and splits that
+/// full request buffer into `MAX_CONNECT_REQ_FRAGMENT_SIZE` (1000-byte) payloads.
 ///
 /// [2.2.11.10]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsgu/0007d661-a86d-4e8f-89f7-7f77f8824188
-pub fn fragment_connect_pkt(
-    connect: &ConnectPkt,
-    max_fragment_payload: usize,
-) -> ironrdp_core::EncodeResult<Vec<Vec<u8>>> {
-    if max_fragment_payload == 0 {
-        return Err(other_err("udp fragment", "max fragment payload must be non-zero"));
-    }
-
+/// [3.8.3]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsgu/0007d661-a86d-4e8f-89f7-7f77f8824188
+pub fn fragment_connect_pkt(connect: &ConnectPkt) -> ironrdp_core::EncodeResult<Vec<Vec<u8>>> {
     let mut full = vec![0u8; connect.size()];
     {
         let mut cur = WriteCursor::new(&mut full);
         connect.encode(&mut cur)?;
     }
-    // Fragments carry CONNECT_PKT bytes after the UDP header of the full packet.
-    let payload = &full[UdpPacketHeader::FIXED_PART_SIZE..];
-    let total = payload.len().div_ceil(max_fragment_payload);
+    let total = full.len().div_ceil(MAX_CONNECT_REQ_FRAGMENT_SIZE);
     let total_u16: u16 = cast_int!("udp fragment count", total)?;
 
     let mut out = Vec::with_capacity(total);
-    for (idx, chunk) in payload.chunks(max_fragment_payload).enumerate() {
+    for (idx, chunk) in full.chunks(MAX_CONNECT_REQ_FRAGMENT_SIZE).enumerate() {
         let frag_id: u16 = cast_int!("udp fragment id", idx)?;
         let chunk_len: u16 = cast_int!("udp fragment length", chunk.len())?;
         let body_len = 2 /* usFragmentID */ + 2 /* usNoOfFragments */ + 2 /* cbFragmentLength */ + chunk.len();

--- a/crates/ironrdp-mstsgu/src/udp.rs
+++ b/crates/ironrdp-mstsgu/src/udp.rs
@@ -1,0 +1,539 @@
+//! RDG-UDP packet layouts ([MS-TSGU] 2.2.5.4 / 2.2.11).
+//!
+//! Opening a live side channel still requires DTLS + MS-RDPEUDP.
+//! This module only encodes and decodes the MS-TSGU UDP framing used after the main HTTP channel supplies a cookie.
+//!
+//! [MS-TSGU]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsgu/0007d661-a86d-4e8f-89f7-7f77f8824188
+
+use ironrdp_core::{
+    Decode, Encode, ReadCursor, WriteCursor, cast_int, ensure_fixed_part_size, ensure_size, other_err,
+    unsupported_value_err,
+};
+
+/// Parameters from [`HTTP_CHANNEL_RESPONSE`][channel-resp] that enable a future RDG-UDP side channel.
+///
+/// [channel-resp]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsgu/0007d661-a86d-4e8f-89f7-7f77f8824188
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GwUdpOffer {
+    /// UDP port on the gateway that accepts the side channel.
+    pub port: u16,
+    /// Opaque authentication cookie for [`CONNECT_PKT`](ConnectPkt).
+    pub authn_cookie: Vec<u8>,
+}
+
+/// [2.2.5.4.1] `UdpPktType` enumeration.
+///
+/// [2.2.5.4.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsgu/0007d661-a86d-4e8f-89f7-7f77f8824188
+#[repr(u16)]
+#[derive(Eq, PartialEq, Copy, Clone, Debug)]
+pub enum UdpPktType {
+    ConnectReq = 1,
+    ConnectResp = 2,
+    Payload = 3,
+    Disconnect = 4,
+    ConnectReqFragment = 5,
+}
+
+impl UdpPktType {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
+    pub fn as_u16(self) -> u16 {
+        self as u16
+    }
+}
+
+impl TryFrom<u16> for UdpPktType {
+    type Error = ();
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        Ok(match value {
+            1 => Self::ConnectReq,
+            2 => Self::ConnectResp,
+            3 => Self::Payload,
+            4 => Self::Disconnect,
+            5 => Self::ConnectReqFragment,
+            _ => return Err(()),
+        })
+    }
+}
+
+/// [2.2.11.7] `UDP_PACKET_HEADER` structure.
+///
+/// [2.2.11.7]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsgu/0007d661-a86d-4e8f-89f7-7f77f8824188
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct UdpPacketHeader {
+    pub pkt_id: u16,
+    /// Length of the body **excluding** this header.
+    pub pkt_len: u16,
+}
+
+impl UdpPacketHeader {
+    pub const FIXED_PART_SIZE: usize = 2 /* pktID */ + 2 /* pktLen */;
+}
+
+impl Encode for UdpPacketHeader {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u16(self.pkt_id);
+        dst.write_u16(self.pkt_len);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "UDP_PACKET_HEADER"
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl Decode<'_> for UdpPacketHeader {
+    fn decode(src: &mut ReadCursor<'_>) -> ironrdp_core::DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+        Ok(Self {
+            pkt_id: src.read_u16(),
+            pkt_len: src.read_u16(),
+        })
+    }
+}
+
+/// [2.2.11.1] `AASYNDATA` structure.
+///
+/// [2.2.11.1]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsgu/0007d661-a86d-4e8f-89f7-7f77f8824188
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct AaSynData {
+    pub up_stream_mtu: u16,
+    pub down_stream_mtu: u16,
+    pub lossy: u32,
+    pub send_isn: i32,
+}
+
+impl AaSynData {
+    pub const FIXED_PART_SIZE: usize =
+        2 /* uUpStreamMtu */ + 2 /* uDownStreamMtu */ + 4 /* fLossy */ + 4 /* snSendISN */;
+}
+
+impl Encode for AaSynData {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u16(self.up_stream_mtu);
+        dst.write_u16(self.down_stream_mtu);
+        dst.write_u32(self.lossy);
+        dst.write_i32(self.send_isn);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "AASYNDATA"
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl Decode<'_> for AaSynData {
+    fn decode(src: &mut ReadCursor<'_>) -> ironrdp_core::DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+        Ok(Self {
+            up_stream_mtu: src.read_u16(),
+            down_stream_mtu: src.read_u16(),
+            lossy: src.read_u32(),
+            send_isn: src.read_i32(),
+        })
+    }
+}
+
+/// [2.2.11.2] `AASYNDATARESP` structure.
+///
+/// [2.2.11.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsgu/0007d661-a86d-4e8f-89f7-7f77f8824188
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct AaSynDataResp {
+    pub up_stream_mtu: u16,
+    pub down_stream_mtu: u16,
+    pub recv_isn: i32,
+}
+
+impl AaSynDataResp {
+    pub const FIXED_PART_SIZE: usize = 2 /* uUpStreamMtu */ + 2 /* uDownStreamMtu */ + 4 /* snRecvISN */;
+}
+
+impl Encode for AaSynDataResp {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u16(self.up_stream_mtu);
+        dst.write_u16(self.down_stream_mtu);
+        dst.write_i32(self.recv_isn);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "AASYNDATARESP"
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl Decode<'_> for AaSynDataResp {
+    fn decode(src: &mut ReadCursor<'_>) -> ironrdp_core::DecodeResult<Self> {
+        ensure_fixed_part_size!(in: src);
+        Ok(Self {
+            up_stream_mtu: src.read_u16(),
+            down_stream_mtu: src.read_u16(),
+            recv_isn: src.read_i32(),
+        })
+    }
+}
+
+/// [2.2.11.3] `CONNECT_PKT` structure (body after DTLS, not including outer DTLS records).
+///
+/// [2.2.11.3]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsgu/0007d661-a86d-4e8f-89f7-7f77f8824188
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ConnectPkt {
+    pub target_port: u16,
+    pub syn_data: AaSynData,
+    pub authn_cookie: Vec<u8>,
+}
+
+impl ConnectPkt {
+    /// Build a connect request from a main-channel UDP offer and target resource port.
+    pub fn from_offer(offer: &GwUdpOffer, target_port: u16, syn_data: AaSynData) -> Self {
+        Self {
+            target_port,
+            syn_data,
+            authn_cookie: offer.authn_cookie.clone(),
+        }
+    }
+}
+
+impl Encode for ConnectPkt {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        let body_len = self.size() - UdpPacketHeader::FIXED_PART_SIZE;
+        let hdr = UdpPacketHeader {
+            pkt_id: UdpPktType::ConnectReq.as_u16(),
+            pkt_len: cast_int!("connect pkt body length", body_len)?,
+        };
+        hdr.encode(dst)?;
+        dst.write_u16(self.target_port);
+        let cookie_len: u16 = cast_int!("authn cookie length", self.authn_cookie.len())?;
+        dst.write_u16(cookie_len);
+        self.syn_data.encode(dst)?;
+        dst.write_slice(&self.authn_cookie);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "CONNECT_PKT"
+    }
+
+    fn size(&self) -> usize {
+        UdpPacketHeader::FIXED_PART_SIZE
+            + 2 /* usPortNumber */
+            + 2 /* cbAuthnCookieLen */
+            + AaSynData::FIXED_PART_SIZE
+            + self.authn_cookie.len()
+    }
+}
+
+impl Decode<'_> for ConnectPkt {
+    fn decode(src: &mut ReadCursor<'_>) -> ironrdp_core::DecodeResult<Self> {
+        let hdr = UdpPacketHeader::decode(src)?;
+        if hdr.pkt_id != UdpPktType::ConnectReq.as_u16() {
+            return Err(unsupported_value_err(
+                "CONNECT_PKT::pkt_id",
+                "pkt_id",
+                format!("0x{:x}", hdr.pkt_id),
+            ));
+        }
+        ensure_size!(in: src, size: 4);
+        let target_port = src.read_u16();
+        let cookie_len = usize::from(src.read_u16());
+        let syn_data = AaSynData::decode(src)?;
+        ensure_size!(in: src, size: cookie_len);
+        let authn_cookie = src.read_slice(cookie_len).to_vec();
+        Ok(Self {
+            target_port,
+            syn_data,
+            authn_cookie,
+        })
+    }
+}
+
+/// [2.2.11.4] `CONNECT_PKT_RESP` structure.
+///
+/// [2.2.11.4]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsgu/0007d661-a86d-4e8f-89f7-7f77f8824188
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ConnectPktResp {
+    pub syn_response: AaSynDataResp,
+    /// Connection result (HRESULT-style `i64` on the wire as 8 little-endian bytes).
+    pub result: i64,
+}
+
+impl Encode for ConnectPktResp {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        let body_len = self.size() - UdpPacketHeader::FIXED_PART_SIZE;
+        let hdr = UdpPacketHeader {
+            pkt_id: UdpPktType::ConnectResp.as_u16(),
+            pkt_len: cast_int!("connect resp body length", body_len)?,
+        };
+        hdr.encode(dst)?;
+        self.syn_response.encode(dst)?;
+        dst.write_i64(self.result);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "CONNECT_PKT_RESP"
+    }
+
+    fn size(&self) -> usize {
+        UdpPacketHeader::FIXED_PART_SIZE + AaSynDataResp::FIXED_PART_SIZE + 8 /* result */
+    }
+}
+
+impl Decode<'_> for ConnectPktResp {
+    fn decode(src: &mut ReadCursor<'_>) -> ironrdp_core::DecodeResult<Self> {
+        let hdr = UdpPacketHeader::decode(src)?;
+        if hdr.pkt_id != UdpPktType::ConnectResp.as_u16() {
+            return Err(unsupported_value_err(
+                "CONNECT_PKT_RESP::pkt_id",
+                "pkt_id",
+                format!("0x{:x}", hdr.pkt_id),
+            ));
+        }
+        let syn_response = AaSynDataResp::decode(src)?;
+        ensure_size!(in: src, size: 8);
+        let result = src.read_i64();
+        Ok(Self { syn_response, result })
+    }
+}
+
+/// [2.2.11.5] `DATA_PKT` structure.
+///
+/// [2.2.11.5]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsgu/0007d661-a86d-4e8f-89f7-7f77f8824188
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DataPkt {
+    pub data: Vec<u8>,
+}
+
+impl Encode for DataPkt {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        let hdr = UdpPacketHeader {
+            pkt_id: UdpPktType::Payload.as_u16(),
+            pkt_len: cast_int!("data pkt body length", self.data.len())?,
+        };
+        hdr.encode(dst)?;
+        dst.write_slice(&self.data);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "DATA_PKT"
+    }
+
+    fn size(&self) -> usize {
+        UdpPacketHeader::FIXED_PART_SIZE + self.data.len()
+    }
+}
+
+impl Decode<'_> for DataPkt {
+    fn decode(src: &mut ReadCursor<'_>) -> ironrdp_core::DecodeResult<Self> {
+        let hdr = UdpPacketHeader::decode(src)?;
+        if hdr.pkt_id != UdpPktType::Payload.as_u16() {
+            return Err(unsupported_value_err(
+                "DATA_PKT::pkt_id",
+                "pkt_id",
+                format!("0x{:x}", hdr.pkt_id),
+            ));
+        }
+        let data_len = usize::from(hdr.pkt_len);
+        ensure_size!(in: src, size: data_len);
+        Ok(Self {
+            data: src.read_slice(data_len).to_vec(),
+        })
+    }
+}
+
+/// [2.2.11.6] `DISC_PKT` structure.
+///
+/// [2.2.11.6]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsgu/0007d661-a86d-4e8f-89f7-7f77f8824188
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct DiscPkt {
+    /// Disconnect reason (HRESULT-style `i64` on the wire as 8 little-endian bytes).
+    pub reason: i64,
+}
+
+impl Encode for DiscPkt {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        let hdr = UdpPacketHeader {
+            pkt_id: UdpPktType::Disconnect.as_u16(),
+            pkt_len: cast_int!("disconnect pkt body length", 8 /* discReason */)?,
+        };
+        hdr.encode(dst)?;
+        dst.write_i64(self.reason);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "DISC_PKT"
+    }
+
+    fn size(&self) -> usize {
+        UdpPacketHeader::FIXED_PART_SIZE + 8 /* discReason */
+    }
+}
+
+impl Decode<'_> for DiscPkt {
+    fn decode(src: &mut ReadCursor<'_>) -> ironrdp_core::DecodeResult<Self> {
+        let hdr = UdpPacketHeader::decode(src)?;
+        if hdr.pkt_id != UdpPktType::Disconnect.as_u16() {
+            return Err(unsupported_value_err(
+                "DISC_PKT::pkt_id",
+                "pkt_id",
+                format!("0x{:x}", hdr.pkt_id),
+            ));
+        }
+        ensure_size!(in: src, size: 8);
+        Ok(Self { reason: src.read_i64() })
+    }
+}
+
+/// [2.2.11.9] `UDP_CORRELATION_INFO` structure appended to DTLS ClientHello.
+///
+/// This type encodes and decodes the trailing blob only.
+/// It does not inject the structure into a DTLS handshake.
+///
+/// [2.2.11.9]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsgu/0007d661-a86d-4e8f-89f7-7f77f8824188
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct UdpCorrelationInfo {
+    pub correlation_id: [u8; 16],
+}
+
+impl UdpCorrelationInfo {
+    pub const SIZE: usize = 4 /* uReserved */ + 2 /* uSignature1 */ + 16 /* uCorrelationId */ + 2 /* uSignature2 */ + 2 /* uCbStruct */;
+    const SIGNATURE1: u16 = 0x1DAA;
+    const SIGNATURE2: u16 = 0xAA1D;
+
+    pub fn new(correlation_id: [u8; 16]) -> Self {
+        Self { correlation_id }
+    }
+}
+
+impl Encode for UdpCorrelationInfo {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u32(0);
+        dst.write_u16(Self::SIGNATURE1);
+        dst.write_slice(&self.correlation_id);
+        dst.write_u16(Self::SIGNATURE2);
+        dst.write_u16(cast_int!("udp correlation struct size", Self::SIZE)?);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "UDP_CORRELATION_INFO"
+    }
+
+    fn size(&self) -> usize {
+        Self::SIZE
+    }
+}
+
+impl Decode<'_> for UdpCorrelationInfo {
+    fn decode(src: &mut ReadCursor<'_>) -> ironrdp_core::DecodeResult<Self> {
+        ensure_size!(in: src, size: Self::SIZE);
+        let _reserved = src.read_u32();
+        let sig1 = src.read_u16();
+        if sig1 != Self::SIGNATURE1 {
+            return Err(unsupported_value_err(
+                "UDP_CORRELATION_INFO::uSignature1",
+                "sig1",
+                format!("0x{sig1:x}"),
+            ));
+        }
+        let correlation_id = src.read_array();
+        let sig2 = src.read_u16();
+        if sig2 != Self::SIGNATURE2 {
+            return Err(unsupported_value_err(
+                "UDP_CORRELATION_INFO::uSignature2",
+                "sig2",
+                format!("0x{sig2:x}"),
+            ));
+        }
+        let cb = src.read_u16();
+        if usize::from(cb) != Self::SIZE {
+            return Err(unsupported_value_err(
+                "UDP_CORRELATION_INFO::uCbStruct",
+                "cb",
+                format!("{cb}"),
+            ));
+        }
+        Ok(Self { correlation_id })
+    }
+}
+
+/// Split a connect request into fragment packets ([2.2.11.10]) when needed for MTU.
+///
+/// [2.2.11.10]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsgu/0007d661-a86d-4e8f-89f7-7f77f8824188
+pub fn fragment_connect_pkt(
+    connect: &ConnectPkt,
+    max_fragment_payload: usize,
+) -> ironrdp_core::EncodeResult<Vec<Vec<u8>>> {
+    if max_fragment_payload == 0 {
+        return Err(other_err("udp fragment", "max fragment payload must be non-zero"));
+    }
+
+    let mut full = vec![0u8; connect.size()];
+    {
+        let mut cur = WriteCursor::new(&mut full);
+        connect.encode(&mut cur)?;
+    }
+    // Fragments carry CONNECT_PKT bytes after the UDP header of the full packet.
+    let payload = &full[UdpPacketHeader::FIXED_PART_SIZE..];
+    let total = payload.len().div_ceil(max_fragment_payload);
+    let total_u16: u16 = cast_int!("udp fragment count", total)?;
+
+    let mut out = Vec::with_capacity(total);
+    for (idx, chunk) in payload.chunks(max_fragment_payload).enumerate() {
+        let frag_id: u16 = cast_int!("udp fragment id", idx)?;
+        let chunk_len: u16 = cast_int!("udp fragment length", chunk.len())?;
+        let body_len = 2 /* usFragmentID */ + 2 /* usNoOfFragments */ + 2 /* cbFragmentLength */ + chunk.len();
+        let mut buf = vec![0u8; UdpPacketHeader::FIXED_PART_SIZE + body_len];
+        {
+            let mut cur = WriteCursor::new(&mut buf);
+            UdpPacketHeader {
+                pkt_id: UdpPktType::ConnectReqFragment.as_u16(),
+                pkt_len: cast_int!("udp fragment body length", body_len)?,
+            }
+            .encode(&mut cur)?;
+            cur.write_u16(frag_id);
+            cur.write_u16(total_u16);
+            cur.write_u16(chunk_len);
+            cur.write_slice(chunk);
+        }
+        out.push(buf);
+    }
+    Ok(out)
+}
+
+/// Encode a complete `CONNECT_PKT` for a channel UDP offer.
+pub fn encode_connect_request(
+    offer: &GwUdpOffer,
+    target_port: u16,
+    syn_data: AaSynData,
+) -> ironrdp_core::EncodeResult<Vec<u8>> {
+    let pkt = ConnectPkt::from_offer(offer, target_port, syn_data);
+    let mut buf = vec![0u8; pkt.size()];
+    let mut cur = WriteCursor::new(&mut buf);
+    pkt.encode(&mut cur)?;
+    Ok(buf)
+}

--- a/crates/ironrdp-mstsgu/tests/udp.rs
+++ b/crates/ironrdp-mstsgu/tests/udp.rs
@@ -2,8 +2,8 @@
 
 use ironrdp_core::{Decode as _, Encode, ReadCursor, WriteCursor};
 use ironrdp_mstsgu::{
-    AaSynData, AaSynDataResp, ConnectPkt, ConnectPktResp, DataPkt, DiscPkt, GwUdpOffer, UdpCorrelationInfo,
-    UdpPacketHeader, UdpPktType, encode_connect_request, fragment_connect_pkt,
+    AaSynData, AaSynDataResp, ConnectPkt, ConnectPktResp, DataPkt, DiscPkt, GwUdpOffer, MAX_CONNECT_REQ_FRAGMENT_SIZE,
+    UdpCorrelationInfo, UdpPacketHeader, UdpPktType, encode_connect_request, fragment_connect_pkt,
 };
 
 fn encode_to_vec(payload: &impl Encode) -> Vec<u8> {
@@ -93,27 +93,31 @@ fn correlation_info_roundtrip() {
 }
 
 #[test]
-fn fragment_connect_pkt_covers_payload() {
+fn fragment_connect_pkt_covers_full_request() {
     let offer = GwUdpOffer {
         port: 3391,
-        authn_cookie: vec![7; 40],
+        authn_cookie: vec![7; MAX_CONNECT_REQ_FRAGMENT_SIZE + 40],
     };
     let pkt = ConnectPkt::from_offer(&offer, 2179, AaSynData::default());
-    let frags = fragment_connect_pkt(&pkt, 16).expect("fragment");
+    let frags = fragment_connect_pkt(&pkt).expect("fragment");
     assert!(frags.len() > 1);
     let mut reassembled = Vec::new();
-    for frag in &frags {
+    for (idx, frag) in frags.iter().enumerate() {
         let mut cur = ReadCursor::new(frag);
         let hdr = UdpPacketHeader::decode(&mut cur).unwrap();
         assert_eq!(hdr.pkt_id, UdpPktType::ConnectReqFragment.as_u16());
-        let _id = cur.read_u16();
+        let id = cur.read_u16();
+        assert_eq!(usize::from(id), idx);
         let total = cur.read_u16();
         assert_eq!(usize::from(total), frags.len());
         let len = usize::from(cur.read_u16());
+        if idx + 1 < frags.len() {
+            assert_eq!(len, MAX_CONNECT_REQ_FRAGMENT_SIZE);
+        }
         reassembled.extend_from_slice(cur.read_slice(len));
     }
-    let mut full = encode_to_vec(&pkt);
-    assert_eq!(reassembled, full.split_off(UdpPacketHeader::FIXED_PART_SIZE));
+    let full = encode_to_vec(&pkt);
+    assert_eq!(reassembled, full);
 }
 
 #[test]
@@ -138,5 +142,37 @@ fn payload_and_disconnect_reject_wrong_pkt_id() {
     let mut cur = ReadCursor::new(&connect);
     assert!(DataPkt::decode(&mut cur).is_err());
     let mut cur = ReadCursor::new(&connect);
+    assert!(DiscPkt::decode(&mut cur).is_err());
+}
+
+fn patch_pkt_len(bytes: &mut [u8], pkt_len: u16) {
+    bytes[2..4].copy_from_slice(&pkt_len.to_le_bytes());
+}
+
+#[test]
+fn connect_pkt_rejects_mismatched_pkt_len() {
+    let mut bytes = encode_to_vec(&ConnectPkt {
+        target_port: 3389,
+        syn_data: AaSynData::default(),
+        authn_cookie: vec![1, 2, 3],
+    });
+    patch_pkt_len(&mut bytes, 4);
+    let mut cur = ReadCursor::new(&bytes);
+    assert!(ConnectPkt::decode(&mut cur).is_err());
+}
+
+#[test]
+fn connect_pkt_resp_rejects_mismatched_pkt_len() {
+    let mut bytes = encode_to_vec(&ConnectPktResp::default());
+    patch_pkt_len(&mut bytes, 0);
+    let mut cur = ReadCursor::new(&bytes);
+    assert!(ConnectPktResp::decode(&mut cur).is_err());
+}
+
+#[test]
+fn disc_pkt_rejects_mismatched_pkt_len() {
+    let mut bytes = encode_to_vec(&DiscPkt { reason: 1 });
+    patch_pkt_len(&mut bytes, 0);
+    let mut cur = ReadCursor::new(&bytes);
     assert!(DiscPkt::decode(&mut cur).is_err());
 }

--- a/crates/ironrdp-mstsgu/tests/udp.rs
+++ b/crates/ironrdp-mstsgu/tests/udp.rs
@@ -1,0 +1,142 @@
+#![allow(unused_crate_dependencies)]
+
+use ironrdp_core::{Decode as _, Encode, ReadCursor, WriteCursor};
+use ironrdp_mstsgu::{
+    AaSynData, AaSynDataResp, ConnectPkt, ConnectPktResp, DataPkt, DiscPkt, GwUdpOffer, UdpCorrelationInfo,
+    UdpPacketHeader, UdpPktType, encode_connect_request, fragment_connect_pkt,
+};
+
+fn encode_to_vec(payload: &impl Encode) -> Vec<u8> {
+    let mut buf = vec![0u8; payload.size()];
+    let mut cur = WriteCursor::new(&mut buf);
+    payload.encode(&mut cur).expect("encode");
+    assert_eq!(cur.pos(), payload.size());
+    buf
+}
+
+#[test]
+fn connect_pkt_roundtrip() {
+    let offer = GwUdpOffer {
+        port: 3391,
+        authn_cookie: vec![1, 2, 3, 4, 5],
+    };
+    let syn = AaSynData {
+        up_stream_mtu: 1234,
+        down_stream_mtu: 1400,
+        lossy: 1,
+        send_isn: 42,
+    };
+    let pkt = ConnectPkt::from_offer(&offer, 3389, syn);
+    let bytes = encode_to_vec(&pkt);
+    assert_eq!(&bytes[..2], &UdpPktType::ConnectReq.as_u16().to_le_bytes());
+    let mut cur = ReadCursor::new(&bytes);
+    let decoded = ConnectPkt::decode(&mut cur).expect("decode");
+    assert_eq!(decoded.target_port, 3389);
+    assert_eq!(decoded.syn_data, syn);
+    assert_eq!(decoded.authn_cookie, offer.authn_cookie);
+    assert!(cur.eof());
+}
+
+#[test]
+fn connect_pkt_resp_roundtrip() {
+    let pkt = ConnectPktResp {
+        syn_response: AaSynDataResp {
+            up_stream_mtu: 1200,
+            down_stream_mtu: 1300,
+            recv_isn: 7,
+        },
+        result: 0,
+    };
+    let bytes = encode_to_vec(&pkt);
+    assert_eq!(&bytes[..2], &UdpPktType::ConnectResp.as_u16().to_le_bytes());
+    let mut cur = ReadCursor::new(&bytes);
+    let decoded = ConnectPktResp::decode(&mut cur).expect("decode");
+    assert_eq!(decoded, pkt);
+    assert!(cur.eof());
+}
+
+#[test]
+fn data_pkt_roundtrip() {
+    let pkt = DataPkt {
+        data: b"rdp-udp-payload".to_vec(),
+    };
+    let bytes = encode_to_vec(&pkt);
+    assert_eq!(&bytes[..2], &UdpPktType::Payload.as_u16().to_le_bytes());
+    let mut cur = ReadCursor::new(&bytes);
+    let decoded = DataPkt::decode(&mut cur).expect("decode");
+    assert_eq!(decoded.data, pkt.data);
+    assert!(cur.eof());
+}
+
+#[test]
+fn disc_pkt_roundtrip() {
+    let pkt = DiscPkt { reason: 0x0000_04CA };
+    let bytes = encode_to_vec(&pkt);
+    assert_eq!(&bytes[..2], &UdpPktType::Disconnect.as_u16().to_le_bytes());
+    assert_eq!(bytes.len(), UdpPacketHeader::FIXED_PART_SIZE + 8);
+    let mut cur = ReadCursor::new(&bytes);
+    let decoded = DiscPkt::decode(&mut cur).expect("decode");
+    assert_eq!(decoded.reason, pkt.reason);
+    assert!(cur.eof());
+}
+
+#[test]
+fn correlation_info_roundtrip() {
+    let id = [9u8; 16];
+    let info = UdpCorrelationInfo::new(id);
+    let bytes = encode_to_vec(&info);
+    assert_eq!(bytes.len(), UdpCorrelationInfo::SIZE);
+    let mut cur = ReadCursor::new(&bytes);
+    let decoded = UdpCorrelationInfo::decode(&mut cur).expect("decode");
+    assert_eq!(decoded.correlation_id, id);
+    assert!(cur.eof());
+}
+
+#[test]
+fn fragment_connect_pkt_covers_payload() {
+    let offer = GwUdpOffer {
+        port: 3391,
+        authn_cookie: vec![7; 40],
+    };
+    let pkt = ConnectPkt::from_offer(&offer, 2179, AaSynData::default());
+    let frags = fragment_connect_pkt(&pkt, 16).expect("fragment");
+    assert!(frags.len() > 1);
+    let mut reassembled = Vec::new();
+    for frag in &frags {
+        let mut cur = ReadCursor::new(frag);
+        let hdr = UdpPacketHeader::decode(&mut cur).unwrap();
+        assert_eq!(hdr.pkt_id, UdpPktType::ConnectReqFragment.as_u16());
+        let _id = cur.read_u16();
+        let total = cur.read_u16();
+        assert_eq!(usize::from(total), frags.len());
+        let len = usize::from(cur.read_u16());
+        reassembled.extend_from_slice(cur.read_slice(len));
+    }
+    let mut full = encode_to_vec(&pkt);
+    assert_eq!(reassembled, full.split_off(UdpPacketHeader::FIXED_PART_SIZE));
+}
+
+#[test]
+fn encode_connect_request_matches_struct() {
+    let offer = GwUdpOffer {
+        port: 1,
+        authn_cookie: b"cookie".to_vec(),
+    };
+    let bytes = encode_connect_request(&offer, 3389, AaSynData::default()).expect("encode");
+    let mut cur = ReadCursor::new(&bytes);
+    let decoded = ConnectPkt::decode(&mut cur).expect("decode");
+    assert_eq!(decoded.authn_cookie, b"cookie");
+}
+
+#[test]
+fn payload_and_disconnect_reject_wrong_pkt_id() {
+    let connect = encode_to_vec(&ConnectPkt {
+        target_port: 3389,
+        syn_data: AaSynData::default(),
+        authn_cookie: vec![1],
+    });
+    let mut cur = ReadCursor::new(&connect);
+    assert!(DataPkt::decode(&mut cur).is_err());
+    let mut cur = ReadCursor::new(&connect);
+    assert!(DiscPkt::decode(&mut cur).is_err());
+}


### PR DESCRIPTION
Encode and decode MS-TSGU UDP framing (CONNECT_PKT, DATA_PKT, DISC_PKT, and UDP_CORRELATION_INFO) plus HTTP_CHANNEL_RESPONSE UDP offer metadata.

A live DTLS side channel is not opened; these helpers only cover the packet layouts in [MS-TSGU] 2.2.5.4 and 2.2.11.