### PR TITLE
feat(rdpsnd): carry the capture timestamp on waves and surface wave confirms

### DIFF
--- a/crates/ironrdp-rdpsnd/src/server.rs
+++ b/crates/ironrdp-rdpsnd/src/server.rs
@@ -117,6 +117,22 @@ pub trait RdpsndServerHandler: Send + core::fmt::Debug {
     /// Called when the audio stream is torn down (e.g. the client closed the
     /// channel or the session ended).
     fn stop(&mut self);
+
+    /// Called for every Wave Confirm PDU the client sends.
+    ///
+    /// `timestamp` answers the `wTimeStamp` the server put on the wave with
+    /// this `block_no`. It is not an echo: [\[MS-RDPEA\] 2.2.3.8] sets it to
+    /// that value *plus* the milliseconds between receiving the complete wave
+    /// and sending the confirm, so the difference from the wave's own
+    /// timestamp is the time the client held the data, not a round trip.
+    ///
+    /// One block may be confirmed more than once, with different timestamps.
+    /// The default implementation ignores it.
+    ///
+    /// [\[MS-RDPEA\] 2.2.3.8]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpea/1c67d6d0-4e8b-4e1a-9d3a-cd0d6f0d1c5f
+    fn wave_confirm(&mut self, block_no: u8, timestamp: u16) {
+        let _ = (block_no, timestamp);
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -187,11 +203,19 @@ impl RdpsndServer {
             .format_no
             .ok_or_else(|| pdu_other_err!("invalid state - no format"))?;
 
+        // The client answers wTimeStamp in the Wave Confirm PDU, offset by how
+        // long it held the data, so sending zero leaves that measurement no
+        // reference to be relative to. Carry the low bits of the same capture
+        // time the 32-bit dwAudioTimeStamp gets, so both fields describe one
+        // instant.
+        let [timestamp_lo, timestamp_hi, _, _] = ts.to_le_bytes();
+        let wire_timestamp = u16::from_le_bytes([timestamp_lo, timestamp_hi]);
+
         // The server doesn't wait for wave confirm, apparently FreeRDP neither.
         let msg = if version >= pdu::Version::V8 {
             let pdu = pdu::Wave2Pdu {
                 block_no: self.block_no,
-                timestamp: 0,
+                timestamp: wire_timestamp,
                 audio_timestamp: ts,
                 format_no,
                 data: data.into(),
@@ -212,7 +236,7 @@ impl RdpsndServer {
             let info = pdu::WavePdu {
                 block_no: self.block_no,
                 format_no,
-                timestamp: 0,
+                timestamp: wire_timestamp,
                 data_prefix,
                 audio_length,
             };
@@ -352,6 +376,7 @@ impl SvcProcessor for RdpsndServer {
             RdpsndState::Ready => {
                 if let pdu::ClientAudioOutputPdu::WaveConfirm(c) = pdu {
                     debug!(?c);
+                    self.handler.wave_confirm(c.block_no, c.timestamp);
                 }
                 vec![]
             }

--- a/crates/ironrdp-testsuite-core/tests/rdpsnd/server.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpsnd/server.rs
@@ -11,10 +11,11 @@ use std::sync::{Arc, Mutex};
 
 use ironrdp_core::encode_vec;
 use ironrdp_rdpsnd::pdu::{
-    AudioFormat, AudioFormatFlags, ClientAudioFormatPdu, ClientAudioOutputPdu, TrainingConfirmPdu, Version, WaveFormat,
+    AudioFormat, AudioFormatFlags, ClientAudioFormatPdu, ClientAudioOutputPdu, TrainingConfirmPdu, Version,
+    WaveConfirmPdu, WaveFormat,
 };
 use ironrdp_rdpsnd::server::{NegotiatedFormat, RdpsndError, RdpsndServer, RdpsndServerHandler, negotiate_formats};
-use ironrdp_svc::SvcProcessor as _;
+use ironrdp_svc::{StaticVirtualChannel, SvcProcessor as _};
 
 fn fmt(format: WaveFormat, rate: u32) -> AudioFormat {
     AudioFormat {
@@ -136,6 +137,7 @@ struct Recording {
     choose_format_calls: usize,
     start_calls: usize,
     chosen_wformat: Option<u16>,
+    wave_confirms: Vec<(u8, u16)>,
 }
 
 #[derive(Debug)]
@@ -168,6 +170,14 @@ impl RdpsndServerHandler for FakeHandler {
     }
 
     fn stop(&mut self) {}
+
+    fn wave_confirm(&mut self, block_no: u8, timestamp: u16) {
+        self.rec
+            .lock()
+            .expect("poisoned")
+            .wave_confirms
+            .push((block_no, timestamp));
+    }
 }
 
 /// Drive a fresh server through the handshake (server announce → client formats
@@ -259,4 +269,52 @@ fn processor_declines_when_start_fails() {
     // declines, so no audio is streamed — rather than a silent
     // "negotiated, no audio" state with a committed format and no producer.
     assert!(server.wave(vec![0; 4], 0).is_err());
+}
+
+#[test]
+fn wave_carries_the_capture_timestamp_the_client_echoes() {
+    let rec = Arc::new(Mutex::new(Recording::default()));
+    let mut server = RdpsndServer::new(Box::new(FakeHandler {
+        formats: vec![fmt(WaveFormat::PCM, 44100)],
+        rec: Arc::clone(&rec),
+        start_ok: true,
+    }));
+
+    drive_to_ready(&mut server, vec![fmt(WaveFormat::PCM, 44100)]);
+
+    // A capture time past the 16-bit range: the wire field carries its low
+    // bits, which is what the client echoes back in the Wave Confirm PDU.
+    let messages = server.wave(vec![0; 8], 0x0001_2345).expect("wave");
+    let chunks = StaticVirtualChannel::chunkify(messages.into()).expect("chunkify wave");
+    let expected = 0x2345u16.to_le_bytes();
+    assert!(
+        chunks
+            .iter()
+            .any(|chunk| chunk.filled().windows(2).any(|w| w == expected)),
+        "wTimeStamp is missing from the encoded wave"
+    );
+}
+
+#[test]
+fn wave_confirm_reaches_the_handler() {
+    let rec = Arc::new(Mutex::new(Recording::default()));
+    let mut server = RdpsndServer::new(Box::new(FakeHandler {
+        formats: vec![fmt(WaveFormat::PCM, 44100)],
+        rec: Arc::clone(&rec),
+        start_ok: true,
+    }));
+
+    drive_to_ready(&mut server, vec![fmt(WaveFormat::PCM, 44100)]);
+
+    let confirm = ClientAudioOutputPdu::WaveConfirm(WaveConfirmPdu {
+        timestamp: 0x2345,
+        block_no: 7,
+    });
+    server
+        .process(&encode_vec(&confirm).expect("encode wave confirm"))
+        .expect("process wave confirm");
+
+    // Without this the server cannot tell how long the client held the data:
+    // the echo is the only latency signal MS-RDPEA gives it.
+    assert_eq!(rec.lock().expect("poisoned").wave_confirms, vec![(7, 0x2345)]);
 }


### PR DESCRIPTION
MS-RDPEA 2.2.3.8 has the client answer a wave's wTimeStamp in the Wave Confirm
PDU, set to "the same field of the originating WaveInfo PDU [...] plus the
time, in milliseconds, between receiving the complete wave PDU from the network
and sending this PDU". The server hardcoded that field to zero for both Wave
and Wave2, so the client's answer was relative to nothing and the confirm was
only logged, never delivered - an embedder chasing an audio/video offset had no
way to tell "the delay is on my side of the socket" from "the client is
buffering".

Waves now carry the low bits of the same capture time the 32-bit
dwAudioTimeStamp gets, and RdpsndServerHandler gains a defaulted wave_confirm
method that receives the block number and that timestamp. Existing handlers are
unaffected.

The value is not an echo, and one block can be confirmed more than once.
FreeRDP's client sends two confirms per wave: the first on receipt with the
timestamp unchanged, "to determine the network latency", and a second after
playback with the elapsed time added, "to determine the actual render latency"
(channels/rdpsnd/client/rdpsnd_main.c, both comments citing 2.2.3.8). A handler
therefore sees the two measurements as two calls with the same block_no, which
the rustdoc now says.

The trait method has no consumer inside this repository. Its consumer is
hypr-rdp, which times its own PipeWire captures and needs the confirm to
separate capture-to-wire delay from client-side buffering; without a hook there
is no way to reach the PDU at all, since the server discards it after a debug
log. Setting the field and surfacing the confirm are separable, but only in the
sense that either alone leaves the measurement impossible: a timestamp nobody
receives, or a confirm relative to zero.

