### PR TITLE
feat(mstsgu): decode HTTP service, reauth, and channel-close packets

### DIFF
--- a/crates/ironrdp-mstsgu/CHANGELOG.md
+++ b/crates/ironrdp-mstsgu/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - HTTP multi-leg authentication for the WebSocket upgrade: Negotiate SPNEGO (Kerberos with NTLM fallback via KDC discovery / `SSPI_KDC_URL`), pure NTLM when only NTLM is advertised, and Basic fallback.
 - RDG-UDP PDU encode/decode helpers (`CONNECT_PKT`, `DATA_PKT`, `DISC_PKT`, and `UDP_CORRELATION_INFO`) without opening a live DTLS side channel.
+- Encode and decode for HTTP control packets (`HTTP_SERVICE_MESSAGE`, `HTTP_REAUTH_MESSAGE`, and `HTTP_CLOSE_PACKET`) without performing mid-session reauthentication.
 
 ## [[0.0.1](https://github.com/Devolutions/IronRDP/releases/tag/ironrdp-mstsgu-v0.0.1)] - 2026-07-10
 

--- a/crates/ironrdp-mstsgu/Cargo.toml
+++ b/crates/ironrdp-mstsgu/Cargo.toml
@@ -25,6 +25,10 @@ required-features = ["native-tls"]
 name = "udp"
 path = "tests/udp.rs"
 
+[[test]]
+name = "http_control"
+path = "tests/http_control.rs"
+
 [features]
 default = []
 rustls = ["ironrdp-tls/rustls", "tokio-tungstenite/rustls-tls-native-roots"]

--- a/crates/ironrdp-mstsgu/README.md
+++ b/crates/ironrdp-mstsgu/README.md
@@ -5,7 +5,8 @@
 This crate
 - implements an MVP state needed to connect through Microsoft RD Gateway,
 - only supports the HTTPS protocol with WebSocket (and not the legacy HTTP or HTTP-RPC transports),
-- does not implement reconnection/reauthentication, Detect, or a live UDP/DTLS side channel,
+- decodes HTTP control packets (`HTTP_SERVICE_MESSAGE`, `HTTP_REAUTH_MESSAGE`, and `HTTP_CLOSE_PACKET`) without performing mid-session reauthentication,
+- does not implement reconnection, Detect, or a live UDP/DTLS side channel,
 - authenticates the WebSocket upgrade with HTTP Negotiate (Kerberos then NTLM), NTLM, or Basic fallback, and
 - encodes and decodes RDG-UDP PDUs (`CONNECT_PKT`, `DATA_PKT`, `DISC_PKT`, and correlation info) without opening that side channel.
 

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -9,11 +9,6 @@ pub mod http_auth;
 mod proto;
 mod udp;
 
-pub use self::udp::{
-    AaSynData, AaSynDataResp, ConnectPkt, ConnectPktResp, DataPkt, DiscPkt, GwUdpOffer, MAX_CONNECT_REQ_FRAGMENT_SIZE,
-    UdpCorrelationInfo, UdpPacketHeader, UdpPktType, encode_connect_request, fragment_connect_pkt,
-};
-
 use core::fmt;
 use core::fmt::Display;
 use core::pin::Pin;
@@ -38,9 +33,15 @@ use tokio_tungstenite::tungstenite::{Message, http};
 use tokio_util::sync::PollSender;
 
 use self::http_auth::{AuthStep, GatewayHttpAuth, basic_authorization, www_authenticate_values};
+#[doc(hidden)]
+pub use self::proto::{ChannelClosePkt, ReauthMessagePkt, ServiceMessagePkt, gateway_code_label};
 use self::proto::{
     ChannelPkt, ChannelResp, DataPkt as HttpDataPkt, HandshakeReqPkt, HandshakeRespPkt, HttpCapsTy, KeepalivePkt,
     PktHdr, PktTy, TunnelAuthPkt, TunnelAuthRespPkt, TunnelReqPkt, TunnelRespPkt,
+};
+pub use self::udp::{
+    AaSynData, AaSynDataResp, ConnectPkt, ConnectPktResp, DataPkt, DiscPkt, GwUdpOffer, MAX_CONNECT_REQ_FRAGMENT_SIZE,
+    UdpCorrelationInfo, UdpPacketHeader, UdpPktType, encode_connect_request, fragment_connect_pkt,
 };
 
 #[derive(Clone, Debug)]
@@ -252,6 +253,25 @@ impl GwClient {
                             PktTy::Data => {
                                 let p = HttpDataPkt::decode(&mut cur).map_err(|e| custom_err!("PktDecode", e))?;
                                 in_tx.send(Bytes::from(p.data.to_vec())).await.map_err(|e| custom_err!("in_tx dead", e))?;
+                            },
+                            PktTy::ServiceMessage => {
+                                let msg = ServiceMessagePkt::decode(&mut cur).map_err(|e| custom_err!("PktDecode", e))?;
+                                warn!("RD Gateway service message: {}", msg.message);
+                            },
+                            PktTy::ReauthMessage => {
+                                let msg = ReauthMessagePkt::decode(&mut cur).map_err(|e| custom_err!("PktDecode", e))?;
+                                warn!(
+                                    "RD Gateway requested reauthentication (context 0x{:016x}); mid-session reauth is not performed",
+                                    msg.reauth_tunnel_context
+                                );
+                            },
+                            PktTy::ChannelClose => {
+                                let close = ChannelClosePkt::decode(&mut cur).map_err(|e| custom_err!("PktDecode", e))?;
+                                match gateway_code_label(close.status_code) {
+                                    Some(label) => warn!("RD Gateway closed the channel ({label})"),
+                                    None => warn!("RD Gateway closed the channel (0x{:08x})", close.status_code),
+                                }
+                                return Ok(());
                             },
                             x => {
                                 warn!("Unhandled gw packet type {x:?}");

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -265,11 +265,24 @@ impl GwClient {
                                     msg.reauth_tunnel_context
                                 );
                             },
-                            PktTy::ChannelClose => {
+                            PktTy::ChannelClose | PktTy::ChannelCloseResponse => {
                                 let close = ChannelClosePkt::decode(&mut cur).map_err(|e| custom_err!("PktDecode", e))?;
                                 match gateway_code_label(close.status_code) {
                                     Some(label) => warn!("RD Gateway closed the channel ({label})"),
                                     None => warn!("RD Gateway closed the channel (0x{:08x})", close.status_code),
+                                }
+                                if hdr.ty == PktTy::ChannelClose {
+                                    let pos = {
+                                        let mut wcur = WriteCursor::new(&mut wsbuf);
+                                        ChannelClosePkt { status_code: 0 }
+                                            .encode_as(PktTy::ChannelCloseResponse, &mut wcur)
+                                            .map_err(|e| custom_err!("PktEncode", e))?;
+                                        wcur.pos()
+                                    };
+                                    gw.ws_sink
+                                        .send(Message::Binary(Bytes::copy_from_slice(&wsbuf[..pos])))
+                                        .await
+                                        .map_err(|e| custom_err!("ws send", e))?;
                                 }
                                 return Ok(());
                             },

--- a/crates/ironrdp-mstsgu/src/proto.rs
+++ b/crates/ironrdp-mstsgu/src/proto.rs
@@ -31,6 +31,7 @@ pub(crate) enum PktTy {
     ChannelCreate = 0x08,
     ChannelResp = 0x09,
     ChannelClose = 0x10,
+    ChannelCloseResponse = 0x11,
     Data = 0x0A,
     ServiceMessage = 0x0B,
     ReauthMessage = 0x0C,
@@ -66,6 +67,7 @@ impl TryFrom<u16> for PktTy {
             0x0C => PktTy::ReauthMessage,
             0x0D => PktTy::Keepalive,
             0x10 => PktTy::ChannelClose,
+            0x11 => PktTy::ChannelCloseResponse,
             _ => return Err(()),
         };
         Ok(mapped)
@@ -706,20 +708,24 @@ pub struct ChannelClosePkt {
     pub status_code: u32,
 }
 
-impl Encode for ChannelClosePkt {
-    fn encode(&self, dst: &mut WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
+impl ChannelClosePkt {
+    pub(crate) fn encode_as(&self, ty: PktTy, dst: &mut WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
         ensure_size!(in: dst, size: self.size());
 
         let hdr = PktHdr {
-            ty: PktTy::ChannelClose,
+            ty,
             length: cast_int!("packet length", self.size())?,
             ..PktHdr::default()
         };
         hdr.encode(dst)?;
-
         dst.write_u32(self.status_code);
-
         Ok(())
+    }
+}
+
+impl Encode for ChannelClosePkt {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
+        self.encode_as(PktTy::ChannelClose, dst)
     }
 
     fn name(&self) -> &'static str {
@@ -753,7 +759,7 @@ pub fn gateway_code_label(code: u32) -> Option<&'static str> {
         0x0000_59D8 | 0x8007_59D8 => "E_PROXY_INTERNALERROR",
         0x0000_59DA | 0x8007_59DA => "E_PROXY_RAP_ACCESSDENIED",
         0x0000_59DB | 0x8007_59DB => "E_PROXY_NAP_ACCESSDENIED",
-        0x0000_59DD => "E_PROXY_TS_CONNECTFAILED",
+        0x0000_59DD | 0x8007_59DD => "E_PROXY_TS_CONNECTFAILED",
         0x0000_59DF | 0x8007_59DF => "E_PROXY_ALREADYDISCONNECTED",
         0x0000_59E6 => "E_PROXY_MAXCONNECTIONSREACHED",
         0x0000_59E8 => "E_PROXY_NOTSUPPORTED",

--- a/crates/ironrdp-mstsgu/src/proto.rs
+++ b/crates/ironrdp-mstsgu/src/proto.rs
@@ -600,6 +600,180 @@ impl Encode for KeepalivePkt {
     }
 }
 
+/// [2.2.10.13] `HTTP_SERVICE_MESSAGE` structure (body only; header stripped).
+///
+/// [2.2.10.13]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsgu/0007d661-a86d-4e8f-89f7-7f77f8824188
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceMessagePkt {
+    pub message: String,
+}
+
+impl Encode for ServiceMessagePkt {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+
+        let hdr = PktHdr {
+            ty: PktTy::ServiceMessage,
+            length: cast_int!("packet length", self.size())?,
+            ..PktHdr::default()
+        };
+        hdr.encode(dst)?;
+
+        let utf16_len = self.message.encode_utf16().count() * 2 + 2 /* NUL */;
+        let utf16_len = cast_int!("cbMessageLen", utf16_len)?;
+        dst.write_u16(utf16_len);
+        for c in self.message.encode_utf16() {
+            dst.write_u16(c);
+        }
+        dst.write_u16(0);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "HTTP_SERVICE_MESSAGE"
+    }
+
+    fn size(&self) -> usize {
+        PktHdr::FIXED_PART_SIZE + 2 /* cbMessageLen */ + 2 * (self.message.encode_utf16().count() + 1 /* NUL */)
+    }
+}
+
+impl Decode<'_> for ServiceMessagePkt {
+    fn decode(src: &mut ReadCursor<'_>) -> ironrdp_core::DecodeResult<Self> {
+        ensure_size!(in: src, size: 2 /* cbMessageLen */);
+        let cb_message = usize::from(src.read_u16());
+        ensure_size!(in: src, size: cb_message);
+        let raw = src.read_slice(cb_message);
+        let message = String::from_utf16_lossy(
+            &raw.chunks_exact(2)
+                .map(|c| u16::from_le_bytes([c[0], c[1]]))
+                .collect::<Vec<_>>(),
+        )
+        .trim_end_matches('\0')
+        .to_owned();
+        Ok(Self { message })
+    }
+}
+
+/// [2.2.10.12] `HTTP_REAUTH_MESSAGE` structure (body only; header stripped).
+///
+/// [2.2.10.12]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsgu/0007d661-a86d-4e8f-89f7-7f77f8824188
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReauthMessagePkt {
+    pub reauth_tunnel_context: u64,
+}
+
+impl Encode for ReauthMessagePkt {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+
+        let hdr = PktHdr {
+            ty: PktTy::ReauthMessage,
+            length: cast_int!("packet length", self.size())?,
+            ..PktHdr::default()
+        };
+        hdr.encode(dst)?;
+
+        dst.write_u64(self.reauth_tunnel_context);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "HTTP_REAUTH_MESSAGE"
+    }
+
+    fn size(&self) -> usize {
+        PktHdr::FIXED_PART_SIZE + 8 /* reauthTunnelContext */
+    }
+}
+
+impl Decode<'_> for ReauthMessagePkt {
+    fn decode(src: &mut ReadCursor<'_>) -> ironrdp_core::DecodeResult<Self> {
+        ensure_size!(in: src, size: 8 /* reauthTunnelContext */);
+        Ok(Self {
+            reauth_tunnel_context: src.read_u64(),
+        })
+    }
+}
+
+/// [2.2.10.23] `HTTP_CLOSE_PACKET` structure (body only; header stripped).
+///
+/// [2.2.10.23]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsgu/0007d661-a86d-4e8f-89f7-7f77f8824188
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChannelClosePkt {
+    pub status_code: u32,
+}
+
+impl Encode for ChannelClosePkt {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> ironrdp_core::EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+
+        let hdr = PktHdr {
+            ty: PktTy::ChannelClose,
+            length: cast_int!("packet length", self.size())?,
+            ..PktHdr::default()
+        };
+        hdr.encode(dst)?;
+
+        dst.write_u32(self.status_code);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "HTTP_CLOSE_PACKET"
+    }
+
+    fn size(&self) -> usize {
+        PktHdr::FIXED_PART_SIZE + 4 /* statusCode */
+    }
+}
+
+impl Decode<'_> for ChannelClosePkt {
+    fn decode(src: &mut ReadCursor<'_>) -> ironrdp_core::DecodeResult<Self> {
+        ensure_size!(in: src, size: 4 /* statusCode */);
+        Ok(Self {
+            status_code: src.read_u32(),
+        })
+    }
+}
+
+/// Human-readable label for common MS-TSGU HRESULTs ([2.2.6]).
+///
+/// [2.2.6]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsgu/0007d661-a86d-4e8f-89f7-7f77f8824188
+pub fn gateway_code_label(code: u32) -> Option<&'static str> {
+    Some(match code {
+        0x0000_0000 => "ERROR_SUCCESS",
+        0x0000_0005 => "ERROR_ACCESS_DENIED",
+        0x0000_00A0 => "ERROR_BAD_ARGUMENTS",
+        0x0000_04CA => "ERROR_GRACEFUL_DISCONNECT",
+        0x0000_04D4 => "E_PROXY_CONNECTIONABORTED",
+        0x0000_59D8 | 0x8007_59D8 => "E_PROXY_INTERNALERROR",
+        0x0000_59DA | 0x8007_59DA => "E_PROXY_RAP_ACCESSDENIED",
+        0x0000_59DB | 0x8007_59DB => "E_PROXY_NAP_ACCESSDENIED",
+        0x0000_59DD => "E_PROXY_TS_CONNECTFAILED",
+        0x0000_59DF | 0x8007_59DF => "E_PROXY_ALREADYDISCONNECTED",
+        0x0000_59E6 => "E_PROXY_MAXCONNECTIONSREACHED",
+        0x0000_59E8 => "E_PROXY_NOTSUPPORTED",
+        0x0000_59E9 | 0x8007_59E9 => "E_PROXY_CAPABILITYMISMATCH",
+        0x0000_59ED | 0x8007_59ED => "E_PROXY_QUARANTINE_ACCESSDENIED",
+        0x0000_59EE | 0x8007_59EE => "E_PROXY_NOCERTAVAILABLE",
+        0x0000_59F6 => "E_PROXY_SESSIONTIMEOUT",
+        0x0000_59F7 | 0x8007_59F7 => "E_PROXY_COOKIE_BADPACKET",
+        0x0000_59F8 | 0x8007_59F8 => "E_PROXY_COOKIE_AUTHENTICATION_ACCESS_DENIED",
+        0x0000_59F9 | 0x8007_59F9 => "E_PROXY_UNSUPPORTED_AUTHENTICATION_METHOD",
+        0x0000_59FA => "E_PROXY_REAUTH_AUTHN_FAILED",
+        0x0000_59FB => "E_PROXY_REAUTH_CAP_FAILED",
+        0x0000_59FC => "E_PROXY_REAUTH_RAP_FAILED",
+        0x0000_59FD => "E_PROXY_SDR_NOT_SUPPORTED_BY_TS",
+        0x0000_5A00 => "E_PROXY_REAUTH_NAP_FAILED",
+        0x8009_030C => "SEC_E_LOGON_DENIED",
+        _ => return None,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/ironrdp-mstsgu/tests/http_control.rs
+++ b/crates/ironrdp-mstsgu/tests/http_control.rs
@@ -1,0 +1,70 @@
+#![allow(unused_crate_dependencies)]
+
+use ironrdp_core::{Decode, Encode, ReadCursor, WriteCursor};
+use ironrdp_mstsgu::{ChannelClosePkt, ReauthMessagePkt, ServiceMessagePkt, gateway_code_label};
+
+fn encode_to_vec(payload: &impl Encode) -> Vec<u8> {
+    let mut buf = vec![0u8; payload.size()];
+    let mut cur = WriteCursor::new(&mut buf);
+    payload.encode(&mut cur).expect("encode");
+    assert_eq!(cur.pos(), payload.size());
+    buf
+}
+
+fn decode_body<'a, T: Decode<'a>>(bytes: &'a [u8]) -> T {
+    // HTTP_PACKET_HEADER is 8 bytes and is stripped before body decode.
+    let mut cur = ReadCursor::new(&bytes[8..]);
+    let decoded = T::decode(&mut cur).expect("decode");
+    assert!(cur.eof());
+    decoded
+}
+
+#[test]
+fn service_message_roundtrip() {
+    let pkt = ServiceMessagePkt {
+        message: "OK".to_owned(),
+    };
+    let bytes = encode_to_vec(&pkt);
+    assert_eq!(&bytes[..2], &0x0Bu16.to_le_bytes());
+    assert_eq!(
+        u32::from_le_bytes(bytes[4..8].try_into().unwrap()),
+        u32::try_from(bytes.len()).unwrap()
+    );
+    let decoded = decode_body::<ServiceMessagePkt>(&bytes);
+    assert_eq!(decoded, pkt);
+}
+
+#[test]
+fn reauth_message_roundtrip() {
+    let pkt = ReauthMessagePkt {
+        reauth_tunnel_context: 0x1122_3344_5566_7788,
+    };
+    let bytes = encode_to_vec(&pkt);
+    assert_eq!(&bytes[..2], &0x0Cu16.to_le_bytes());
+    assert_eq!(
+        bytes.len(),
+        8 /* HTTP_PACKET_HEADER */ + 8 /* reauthTunnelContext */
+    );
+    let decoded = decode_body::<ReauthMessagePkt>(&bytes);
+    assert_eq!(decoded, pkt);
+}
+
+#[test]
+fn channel_close_roundtrip() {
+    let pkt = ChannelClosePkt {
+        status_code: 0x8007_59DA,
+    };
+    let bytes = encode_to_vec(&pkt);
+    assert_eq!(&bytes[..2], &0x10u16.to_le_bytes());
+    assert_eq!(bytes.len(), 8 /* HTTP_PACKET_HEADER */ + 4 /* statusCode */);
+    let decoded = decode_body::<ChannelClosePkt>(&bytes);
+    assert_eq!(decoded, pkt);
+}
+
+#[test]
+fn gateway_code_label_known_and_unknown() {
+    assert_eq!(gateway_code_label(0), Some("ERROR_SUCCESS"));
+    assert_eq!(gateway_code_label(0x8007_59DA), Some("E_PROXY_RAP_ACCESSDENIED"));
+    assert_eq!(gateway_code_label(0x0000_59DA), Some("E_PROXY_RAP_ACCESSDENIED"));
+    assert_eq!(gateway_code_label(0xDEAD_BEEF), None);
+}

--- a/crates/ironrdp-mstsgu/tests/http_control.rs
+++ b/crates/ironrdp-mstsgu/tests/http_control.rs
@@ -66,5 +66,7 @@ fn gateway_code_label_known_and_unknown() {
     assert_eq!(gateway_code_label(0), Some("ERROR_SUCCESS"));
     assert_eq!(gateway_code_label(0x8007_59DA), Some("E_PROXY_RAP_ACCESSDENIED"));
     assert_eq!(gateway_code_label(0x0000_59DA), Some("E_PROXY_RAP_ACCESSDENIED"));
+    assert_eq!(gateway_code_label(0x0000_59DD), Some("E_PROXY_TS_CONNECTFAILED"));
+    assert_eq!(gateway_code_label(0x8007_59DD), Some("E_PROXY_TS_CONNECTFAILED"));
     assert_eq!(gateway_code_label(0xDEAD_BEEF), None);
 }


### PR DESCRIPTION
PktTy already named ChannelClose, ServiceMessage, and ReauthMessage without decoding those payloads.

Add encode/decode for HTTP_SERVICE_MESSAGE, HTTP_REAUTH_MESSAGE, and HTTP_CLOSE_PACKET, plus common MS-TSGU HRESULT display names. The work loop logs service and reauth packets. A server channel-close is answered with PKT_TYPE_CLOSE_CHANNEL_RESPONSE, then the work task ends. Mid-session reauthentication is not performed.