### PR TITLE
feat(replay): unwrap RD Gateway RPC-over-HTTP tunnels

### DIFF
--- a/crates/ironrdp-capture-replay/README.md
+++ b/crates/ironrdp-capture-replay/README.md
@@ -3,9 +3,10 @@
 `ironrdp-capture-replay` replays supported direct-TCP RDP captures offline and exports framebuffer snapshots without writing TLS secrets, decrypted payloads, or raw capture data.
 It is an internal analysis tool built on the replay routing pipeline.
 
-RD Gateway (MS-TSGU) WebSocket captures are supported after the outer HTTPS session is decrypted from an embedded or supplied TLS key log.
+RD Gateway (MS-TSGU) WebSocket and RPC-over-HTTP captures are supported after the outer HTTPS session is decrypted from an embedded or supplied TLS key log.
 When that plaintext starts with an `RDG_OUT_DATA /remoteDesktopGateway/` upgrade, the WebSocket frames and `HTTP_DATA_PACKET` wrappers are removed and the recovered inner stream is replayed like a direct capture.
-RPC-over-HTTP (`RPC_IN_DATA` / `RPC_OUT_DATA`) tunnels are not unwrapped.
+When the capture instead carries a pair of `RPC_IN_DATA` and `RPC_OUT_DATA` RPC-over-HTTP channels, those HTTP heads and DCE/RPC `TsProxy` stubs are unwrapped into the same inner RDP stream.
+A single IN or OUT channel is not a complete tunnel.
 Full TLS 1.2 and TLS 1.3 captures, including resumed sessions, are supported for the AES-GCM cipher suites handled by the replay decryptor.
 TLS 1.2 requires `CLIENT_RANDOM`, while TLS 1.3 requires `CLIENT_HANDSHAKE_TRAFFIC_SECRET`, `SERVER_HANDSHAKE_TRAFFIC_SECRET`, `CLIENT_TRAFFIC_SECRET_0`, and `SERVER_TRAFFIC_SECRET_0`.
 Mid-stream TLS captures without a ClientHello and ServerHello remain unsupported.

--- a/crates/ironrdp-capture-replay/src/gateway_rpch.rs
+++ b/crates/ironrdp-capture-replay/src/gateway_rpch.rs
@@ -48,7 +48,9 @@ pub fn rpch_channel(plaintext: &Plaintext) -> Option<RpchChannel> {
 
 /// Pair IN and OUT channel flows, or `None` when no RPCH tunnel is present.
 ///
-/// A single IN or OUT HTTP flow is not a complete tunnel.
+/// A single IN or OUT HTTP flow is not a complete tunnel. Channel matching for
+/// extraction tries every IN/OUT combination; this helper only reports whether
+/// both channel types exist.
 pub fn pair_rpch_channels(flows: &[Plaintext]) -> Result<Option<(&Plaintext, &Plaintext)>, ReplayError> {
     let input = flows.iter().find(|flow| rpch_channel(flow) == Some(RpchChannel::In));
     let output = flows.iter().find(|flow| rpch_channel(flow) == Some(RpchChannel::Out));
@@ -61,23 +63,74 @@ pub fn pair_rpch_channels(flows: &[Plaintext]) -> Result<Option<(&Plaintext, &Pl
     }
 }
 
+/// Unwrap a paired RPCH tunnel from decrypted gateway-port flows.
+///
+/// Candidate IN and OUT channels are tried until one pair yields an inner RDP
+/// stream. A single IN or OUT HTTP flow is not a complete tunnel.
+pub fn extract_rpch_from_flows(flows: &[Plaintext]) -> Result<Option<Plaintext>, ReplayError> {
+    let inputs: Vec<_> = flows
+        .iter()
+        .filter(|flow| rpch_channel(flow) == Some(RpchChannel::In))
+        .collect();
+    let outputs: Vec<_> = flows
+        .iter()
+        .filter(|flow| rpch_channel(flow) == Some(RpchChannel::Out))
+        .collect();
+    if inputs.is_empty() && outputs.is_empty() {
+        return Ok(None);
+    }
+    if inputs.is_empty() || outputs.is_empty() {
+        return Err(ReplayError::GatewayFraming(
+            "incomplete RPC-over-HTTP tunnel".to_owned(),
+        ));
+    }
+    let mut last_error = None;
+    for input in inputs {
+        for output in outputs.iter().copied() {
+            match extract_rpch_tunneled_rdp(input, output) {
+                Ok(plaintext) => return Ok(Some(plaintext)),
+                Err(error) => last_error = Some(error),
+            }
+        }
+    }
+    Err(last_error.unwrap_or(ReplayError::MissingRdpState))
+}
+
 /// Extract the tunneled RDP bytes from a pair of decrypted RPCH channel flows.
 ///
 /// `input` is the IN-channel flow (client requests) and `output` is the OUT-channel
 /// flow (server responses). The returned streams contain raw RDP traffic (starting
 /// with the X.224 connection request) exactly as a direct TCP capture would carry it.
 pub fn extract_rpch_tunneled_rdp(input: &Plaintext, output: &Plaintext) -> Result<Plaintext, ReplayError> {
-    let client_flat = flatten(&input.client);
-    let server_flat = flatten(&output.server);
-    let client_body = strip_http_heads(&client_flat, Direction::Client);
-    let server_body = strip_http_heads(&server_flat, Direction::Server);
+    let (client_flat, client_packets) = concat_stream(&input.client);
+    let (server_flat, server_packets) = concat_stream(&output.server);
+    let client_start = strip_http_heads(&client_flat, Direction::Client);
+    let server_start = strip_http_heads(&server_flat, Direction::Server);
 
-    let client = client_rdp_bytes(client_body)?;
-    let server = server_rdp_bytes(server_body)?;
+    let client = client_rdp_bytes(&client_flat[client_start..], &client_packets, client_start)?;
+    let server = server_rdp_bytes(&server_flat[server_start..], &server_packets, server_start)?;
     if client.is_empty() || server.is_empty() {
         return Err(ReplayError::MissingRdpState);
     }
     Ok(Plaintext { client, server })
+}
+
+fn concat_stream(stream: &PacketStream) -> (Vec<u8>, Vec<(usize, usize)>) {
+    let mut bytes = Vec::new();
+    let mut packet_offsets = Vec::with_capacity(stream.len());
+    for (packet, chunk) in stream {
+        packet_offsets.push((bytes.len(), *packet));
+        bytes.extend_from_slice(chunk);
+    }
+    (bytes, packet_offsets)
+}
+
+fn packet_at(packet_offsets: &[(usize, usize)], offset: usize) -> usize {
+    let index = packet_offsets.partition_point(|(chunk_offset, _)| *chunk_offset <= offset);
+    packet_offsets
+        .get(index.saturating_sub(1))
+        .map(|(_, packet)| *packet)
+        .unwrap_or(0)
 }
 
 #[derive(Clone, Copy)]
@@ -86,21 +139,21 @@ enum Direction {
     Server,
 }
 
-/// Strip every HTTP request/response head, returning the concatenated RPC body.
+/// Strip every HTTP request/response head, returning the offset of the RPC body.
 ///
 /// Authentication adds 401 round trips before the 200 that opens the streaming body;
 /// each head ends at `\r\n\r\n`, and a server head with a small `Content-Length`
 /// (an error page) is followed by that body before the next head.
-fn strip_http_heads(bytes: &[u8], direction: Direction) -> &[u8] {
+fn strip_http_heads(bytes: &[u8], direction: Direction) -> usize {
     let mut offset = 0;
     loop {
         let Some(rel) = bytes[offset..].windows(4).position(|window| window == b"\r\n\r\n") else {
-            return &bytes[bytes.len()..];
+            return bytes.len();
         };
         let head_end = offset + rel + 4;
         let head = &bytes[offset..head_end];
         let Ok(text) = core::str::from_utf8(head) else {
-            return &bytes[offset..];
+            return offset;
         };
         let content_length = text.split("\r\n").find_map(|line| {
             let (name, value) = line.split_once(':')?;
@@ -116,7 +169,7 @@ fn strip_http_heads(bytes: &[u8], direction: Direction) -> &[u8] {
                     offset = (head_end + n).min(bytes.len());
                     continue;
                 }
-                _ => return &bytes[head_end..],
+                _ => return head_end,
             }
         }
         let next = match direction {
@@ -129,7 +182,7 @@ fn strip_http_heads(bytes: &[u8], direction: Direction) -> &[u8] {
         if starts_head && next < bytes.len() {
             offset = next;
         } else {
-            return rest;
+            return next;
         }
     }
 }
@@ -141,6 +194,7 @@ struct Pdu {
     opnum: u16,
     /// The reassembled data stub, excluding trailing security trailers.
     stub: Vec<u8>,
+    packet: usize,
 }
 
 struct Fragment<'a> {
@@ -149,6 +203,7 @@ struct Fragment<'a> {
     call_id: u32,
     opnum: u16,
     stub: &'a [u8],
+    offset: usize,
 }
 
 /// Iterate well-formed DCE/RPC fragments in a channel body.
@@ -159,6 +214,7 @@ struct Fragment<'a> {
 /// itself ([MS-RPCE] 2.2.2.10 and 2.2.2.11). `alloc_hint` cannot be used here: on a
 /// continuation fragment it advertises the *remaining* stub, not this fragment's share.
 fn fragments(mut bytes: &[u8], header_size: usize) -> impl Iterator<Item = Fragment<'_>> {
+    let mut offset = 0;
     core::iter::from_fn(move || {
         let header = bytes.get(..COMMON_HEADER)?;
         if header[0] != 5 {
@@ -173,7 +229,9 @@ fn fragments(mut bytes: &[u8], header_size: usize) -> impl Iterator<Item = Fragm
         let auth_length = usize::from(u16::from_le_bytes([header[10], header[11]]));
         let call_id = u32::from_le_bytes([header[12], header[13], header[14], header[15]]);
         let pdu = bytes.get(..fragment_length)?;
+        let fragment_offset = offset;
         bytes = &bytes[fragment_length..];
+        offset += fragment_length;
         // Security trailer layout: auth type, auth level, auth pad length, reserved,
         // context id. The pad length precedes the trailer, so it shrinks the stub.
         let stub_end = if auth_length > 0 {
@@ -204,15 +262,16 @@ fn fragments(mut bytes: &[u8], header_size: usize) -> impl Iterator<Item = Fragm
             call_id,
             opnum,
             stub,
+            offset: fragment_offset,
         })
     })
 }
 
-/// Reassemble DCE/RPC fragments that share a call id into complete PDUs.
-fn pdus(bytes: &[u8], header_size: usize) -> Vec<Pdu> {
+/// Reassemble DCE/RPC request fragments that share a call id into complete PDUs.
+fn request_pdus(bytes: &[u8], packet_offsets: &[(usize, usize)], body_start: usize) -> Vec<Pdu> {
     let mut complete = Vec::new();
     let mut pending: Option<Pdu> = None;
-    for fragment in fragments(bytes, header_size) {
+    for fragment in fragments(bytes, REQUEST_HEADER) {
         let first = fragment.flags & PFC_FIRST_FRAG != 0;
         let last = fragment.flags & PFC_LAST_FRAG != 0;
         match pending.as_mut() {
@@ -225,6 +284,7 @@ fn pdus(bytes: &[u8], header_size: usize) -> Vec<Pdu> {
                     call_id: fragment.call_id,
                     opnum: fragment.opnum,
                     stub: fragment.stub.to_vec(),
+                    packet: packet_at(packet_offsets, body_start + fragment.offset),
                 });
             }
         }
@@ -239,35 +299,46 @@ fn pdus(bytes: &[u8], header_size: usize) -> Vec<Pdu> {
 
 /// Recover the client-to-server RDP stream from IN-channel `TsProxySendToServer`
 /// request stubs ([MS-TSGU] 2.2.9.3).
-fn client_rdp_bytes(body: &[u8]) -> Result<PacketStream, ReplayError> {
+fn client_rdp_bytes(
+    body: &[u8],
+    packet_offsets: &[(usize, usize)],
+    body_start: usize,
+) -> Result<PacketStream, ReplayError> {
     let mut output = Vec::new();
-    for pdu in pdus(body, REQUEST_HEADER) {
+    for pdu in request_pdus(body, packet_offsets, body_start) {
         if pdu.ptype != PTYPE_REQUEST || pdu.opnum != SEND_TO_SERVER_OPNUM {
             continue;
         }
         let data = send_to_server_payload(&pdu.stub)?;
         if !data.is_empty() {
-            output.push((usize::try_from(pdu.call_id).unwrap_or(0), data));
+            output.push((pdu.packet, data));
         }
     }
     Ok(output)
 }
 
 /// Parse a `TsProxySendToServer` stub: context handle, total bytes, buffer count, then
-/// per-buffer length-prefixed data. The data-plane length fields are little-endian on
-/// the wire (matching mstsc), like the NDR control stubs.
+/// per-buffer length-prefixed data.
+///
+/// [MS-TSGU] 3.6.5.1 requires network byte order. Some clients emit little-endian
+/// lengths, so both encodings are accepted when `numBuffers` is in 1..=3.
 fn send_to_server_payload(stub: &[u8]) -> Result<Vec<u8>, ReplayError> {
+    parse_send_to_server(stub, u32::from_be_bytes).or_else(|_| parse_send_to_server(stub, u32::from_le_bytes))
+}
+
+fn parse_send_to_server(stub: &[u8], from_bytes: fn([u8; 4]) -> u32) -> Result<Vec<u8>, ReplayError> {
     const HANDLE: usize = 20;
     let framing = || ReplayError::GatewayFraming("malformed send-to-server stub".to_owned());
     let mut cursor = stub.get(HANDLE..).ok_or_else(framing)?;
-    let _total = read_le_u32(&mut cursor).ok_or_else(framing)?;
-    let buffer_count = usize::try_from(read_le_u32(&mut cursor).ok_or_else(framing)?).map_err(|_| framing())?;
-    if buffer_count > 3 {
+    let _total = read_u32(&mut cursor, from_bytes).ok_or_else(framing)?;
+    let buffer_count =
+        usize::try_from(read_u32(&mut cursor, from_bytes).ok_or_else(framing)?).map_err(|_| framing())?;
+    if !(1..=3).contains(&buffer_count) {
         return Err(framing());
     }
     let mut lengths = Vec::with_capacity(buffer_count);
     for _ in 0..buffer_count {
-        lengths.push(usize::try_from(read_le_u32(&mut cursor).ok_or_else(framing)?).map_err(|_| framing())?);
+        lengths.push(usize::try_from(read_u32(&mut cursor, from_bytes).ok_or_else(framing)?).map_err(|_| framing())?);
     }
     let mut data = Vec::new();
     for length in lengths {
@@ -282,33 +353,42 @@ fn send_to_server_payload(stub: &[u8]) -> Result<Vec<u8>, ReplayError> {
 /// stubs. After `TsProxySetupReceivePipe` the data-plane responses carry the raw RDP
 /// bytes directly; control responses (bind ack, tunnel/channel setup) are skipped by
 /// their non-RDP stub content.
-fn server_rdp_bytes(body: &[u8]) -> Result<PacketStream, ReplayError> {
+fn server_rdp_bytes(
+    body: &[u8],
+    packet_offsets: &[(usize, usize)],
+    body_start: usize,
+) -> Result<PacketStream, ReplayError> {
     let mut output = Vec::new();
     // The receive pipe carries every server-to-client RDP byte on one RPC call: the
-    // `TsProxySetupReceivePipe` call. That call's response stream starts with the X.224
-    // connection confirm (TPKT). Other interleaved responses (bind ack, tunnel/channel
-    // setup, MakeTunnelCall admin replies) use their own call ids and are not RDP.
+    // `TsProxySetupReceivePipe` call. Ordinary data fragments stay non-final for the
+    // session lifetime; PFC_LAST_FRAG closes the pipe and the stub is the HRESULT
+    // ([MS-TSGU] 3.2.6.2.2). Other interleaved responses use their own call ids.
     let mut receive_pipe_call = None;
-    for pdu in pdus(body, RESPONSE_HEADER) {
-        if pdu.ptype != PTYPE_RESPONSE {
+    for fragment in fragments(body, RESPONSE_HEADER) {
+        if fragment.ptype != PTYPE_RESPONSE {
             continue;
         }
         match receive_pipe_call {
             None => {
                 // The receive pipe's first data response is the X.224 connection confirm.
-                if starts_with_tpkt(&pdu.stub) {
-                    receive_pipe_call = Some(pdu.call_id);
+                if starts_with_tpkt(fragment.stub) {
+                    receive_pipe_call = Some(fragment.call_id);
                 } else {
                     continue;
                 }
             }
-            // After the pipe opens, its data is a contiguous RDP byte stream split
-            // arbitrarily across responses; keep only this call's stubs.
-            Some(call) if call != pdu.call_id => continue,
+            Some(call) if call != fragment.call_id => continue,
             Some(_) => {}
         }
-        if !pdu.stub.is_empty() {
-            output.push((usize::try_from(pdu.call_id).unwrap_or(0), pdu.stub));
+        // The final pipe PDU is a 4-byte return code, not RDP payload.
+        if fragment.flags & PFC_LAST_FRAG != 0 && fragment.stub.len() == 4 {
+            continue;
+        }
+        if !fragment.stub.is_empty() {
+            output.push((
+                packet_at(packet_offsets, body_start + fragment.offset),
+                fragment.stub.to_vec(),
+            ));
         }
     }
     Ok(output)
@@ -319,8 +399,8 @@ fn starts_with_tpkt(stub: &[u8]) -> bool {
     matches!(stub, [0x03, 0x00, ..])
 }
 
-fn read_le_u32(cursor: &mut &[u8]) -> Option<u32> {
+fn read_u32(cursor: &mut &[u8], from_bytes: fn([u8; 4]) -> u32) -> Option<u32> {
     let (field, rest) = cursor.split_at_checked(4)?;
     *cursor = rest;
-    Some(u32::from_le_bytes(field.try_into().ok()?))
+    Some(from_bytes(field.try_into().ok()?))
 }

--- a/crates/ironrdp-capture-replay/src/gateway_rpch.rs
+++ b/crates/ironrdp-capture-replay/src/gateway_rpch.rs
@@ -27,7 +27,7 @@ const SEND_TO_SERVER_OPNUM: u16 = 9;
 
 /// Which RPCH channel a decrypted flow carries, keyed by its HTTP method.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum RpchChannel {
+enum RpchChannel {
     /// `RPC_IN_DATA`: client-to-server tunnel data (`TsProxySendToServer`).
     In,
     /// `RPC_OUT_DATA`: server-to-client tunnel data (the receive pipe).
@@ -35,7 +35,7 @@ pub enum RpchChannel {
 }
 
 /// Classify a decrypted RPCH flow, or `None` when it is not an RPCH tunnel.
-pub fn rpch_channel(plaintext: &Plaintext) -> Option<RpchChannel> {
+fn rpch_channel(plaintext: &Plaintext) -> Option<RpchChannel> {
     let client = flatten(&plaintext.client);
     if client.starts_with(b"RPC_IN_DATA ") {
         Some(RpchChannel::In)
@@ -43,23 +43,6 @@ pub fn rpch_channel(plaintext: &Plaintext) -> Option<RpchChannel> {
         Some(RpchChannel::Out)
     } else {
         None
-    }
-}
-
-/// Pair IN and OUT channel flows, or `None` when no RPCH tunnel is present.
-///
-/// A single IN or OUT HTTP flow is not a complete tunnel. Channel matching for
-/// extraction tries every IN/OUT combination; this helper only reports whether
-/// both channel types exist.
-pub fn pair_rpch_channels(flows: &[Plaintext]) -> Result<Option<(&Plaintext, &Plaintext)>, ReplayError> {
-    let input = flows.iter().find(|flow| rpch_channel(flow) == Some(RpchChannel::In));
-    let output = flows.iter().find(|flow| rpch_channel(flow) == Some(RpchChannel::Out));
-    match (input, output) {
-        (Some(input), Some(output)) => Ok(Some((input, output))),
-        (None, None) => Ok(None),
-        _ => Err(ReplayError::GatewayFraming(
-            "incomplete RPC-over-HTTP tunnel".to_owned(),
-        )),
     }
 }
 
@@ -213,31 +196,45 @@ struct Fragment<'a> {
 /// auth_len - 8 - auth_pad_len`, where `auth_pad_len` is read from the security trailer
 /// itself ([MS-RPCE] 2.2.2.10 and 2.2.2.11). `alloc_hint` cannot be used here: on a
 /// continuation fragment it advertises the *remaining* stub, not this fragment's share.
-fn fragments(mut bytes: &[u8], header_size: usize) -> impl Iterator<Item = Fragment<'_>> {
+fn fragments(mut bytes: &[u8], header_size: usize) -> Result<Vec<Fragment<'_>>, ReplayError> {
     let mut offset = 0;
-    core::iter::from_fn(move || {
-        let header = bytes.get(..COMMON_HEADER)?;
+    let mut fragments = Vec::new();
+    while !bytes.is_empty() {
+        let header = bytes
+            .get(..COMMON_HEADER)
+            .ok_or_else(|| ReplayError::GatewayFraming("truncated DCE/RPC header".to_owned()))?;
         if header[0] != 5 {
-            return None;
+            return Err(ReplayError::GatewayFraming("invalid DCE/RPC version".to_owned()));
         }
         let ptype = header[2];
         let flags = header[3];
         let fragment_length = usize::from(u16::from_le_bytes([header[8], header[9]]));
         if !(COMMON_HEADER..=MAX_FRAGMENT).contains(&fragment_length) {
-            return None;
+            return Err(ReplayError::GatewayFraming(
+                "invalid DCE/RPC fragment length".to_owned(),
+            ));
         }
         let auth_length = usize::from(u16::from_le_bytes([header[10], header[11]]));
         let call_id = u32::from_le_bytes([header[12], header[13], header[14], header[15]]);
-        let pdu = bytes.get(..fragment_length)?;
+        let pdu = bytes
+            .get(..fragment_length)
+            .ok_or_else(|| ReplayError::GatewayFraming("truncated DCE/RPC fragment".to_owned()))?;
         let fragment_offset = offset;
         bytes = &bytes[fragment_length..];
         offset += fragment_length;
         // Security trailer layout: auth type, auth level, auth pad length, reserved,
         // context id. The pad length precedes the trailer, so it shrinks the stub.
         let stub_end = if auth_length > 0 {
-            let sec_trailer = fragment_length.checked_sub(auth_length + 8)?;
-            let auth_pad_len = usize::from(*pdu.get(sec_trailer + 2)?);
-            sec_trailer.checked_sub(auth_pad_len)?
+            let sec_trailer = fragment_length
+                .checked_sub(auth_length + 8)
+                .ok_or_else(|| ReplayError::GatewayFraming("invalid DCE/RPC authentication trailer".to_owned()))?;
+            let auth_pad_len =
+                usize::from(*pdu.get(sec_trailer + 2).ok_or_else(|| {
+                    ReplayError::GatewayFraming("truncated DCE/RPC authentication trailer".to_owned())
+                })?);
+            sec_trailer
+                .checked_sub(auth_pad_len)
+                .ok_or_else(|| ReplayError::GatewayFraming("invalid DCE/RPC authentication padding".to_owned()))?
         } else {
             fragment_length
         };
@@ -256,22 +253,23 @@ fn fragments(mut bytes: &[u8], header_size: usize) -> impl Iterator<Item = Fragm
         } else {
             u16::MAX
         };
-        Some(Fragment {
+        fragments.push(Fragment {
             ptype,
             flags,
             call_id,
             opnum,
             stub,
             offset: fragment_offset,
-        })
-    })
+        });
+    }
+    Ok(fragments)
 }
 
 /// Reassemble DCE/RPC request fragments that share a call id into complete PDUs.
-fn request_pdus(bytes: &[u8], packet_offsets: &[(usize, usize)], body_start: usize) -> Vec<Pdu> {
+fn request_pdus(bytes: &[u8], packet_offsets: &[(usize, usize)], body_start: usize) -> Result<Vec<Pdu>, ReplayError> {
     let mut complete = Vec::new();
     let mut pending: Option<Pdu> = None;
-    for fragment in fragments(bytes, REQUEST_HEADER) {
+    for fragment in fragments(bytes, REQUEST_HEADER)? {
         let first = fragment.flags & PFC_FIRST_FRAG != 0;
         let last = fragment.flags & PFC_LAST_FRAG != 0;
         match pending.as_mut() {
@@ -294,7 +292,7 @@ fn request_pdus(bytes: &[u8], packet_offsets: &[(usize, usize)], body_start: usi
             }
         }
     }
-    complete
+    Ok(complete)
 }
 
 /// Recover the client-to-server RDP stream from IN-channel `TsProxySendToServer`
@@ -305,7 +303,7 @@ fn client_rdp_bytes(
     body_start: usize,
 ) -> Result<PacketStream, ReplayError> {
     let mut output = Vec::new();
-    for pdu in request_pdus(body, packet_offsets, body_start) {
+    for pdu in request_pdus(body, packet_offsets, body_start)? {
         if pdu.ptype != PTYPE_REQUEST || pdu.opnum != SEND_TO_SERVER_OPNUM {
             continue;
         }
@@ -364,7 +362,7 @@ fn server_rdp_bytes(
     // session lifetime; PFC_LAST_FRAG closes the pipe and the stub is the HRESULT
     // ([MS-TSGU] 3.2.6.2.2). Other interleaved responses use their own call ids.
     let mut receive_pipe_call = None;
-    for fragment in fragments(body, RESPONSE_HEADER) {
+    for fragment in fragments(body, RESPONSE_HEADER)? {
         if fragment.ptype != PTYPE_RESPONSE {
             continue;
         }

--- a/crates/ironrdp-capture-replay/src/gateway_rpch.rs
+++ b/crates/ironrdp-capture-replay/src/gateway_rpch.rs
@@ -1,0 +1,326 @@
+//! MS-TSGU RPC-over-HTTP (RPCH) tunnel extraction for captured TLS-decrypted flows.
+//!
+//! The legacy RD Gateway transport carries the tunneled RDP session inside DCE/RPC
+//! calls on two HTTP/1 connections: an IN channel (`RPC_IN_DATA`, client to server) and
+//! an OUT channel (`RPC_OUT_DATA`, server to client). This module unwraps the DCE/RPC
+//! and TsProxy framing and recovers the tunneled RDP byte stream ([MS-TSGU] 3.6).
+
+use crate::transport::flatten;
+use crate::{PacketStream, Plaintext, ReplayError};
+
+/// DCE/RPC common header length.
+const COMMON_HEADER: usize = 16;
+/// DCE/RPC response PDUs add alloc-hint/context/cancel fields before the stub.
+const RESPONSE_HEADER: usize = COMMON_HEADER + 8;
+/// DCE/RPC request PDUs add alloc-hint/context/opnum fields before the stub.
+const REQUEST_HEADER: usize = COMMON_HEADER + 8;
+/// Largest accepted RPC fragment, comfortably above the negotiated fragment size.
+const MAX_FRAGMENT: usize = 64 * 1024;
+
+const PTYPE_REQUEST: u8 = 0;
+const PTYPE_RESPONSE: u8 = 2;
+const PFC_FIRST_FRAG: u8 = 0x01;
+const PFC_LAST_FRAG: u8 = 0x02;
+
+/// `TsProxySendToServer` operation number ([MS-TSGU] 3.6.5.1).
+const SEND_TO_SERVER_OPNUM: u16 = 9;
+
+/// Which RPCH channel a decrypted flow carries, keyed by its HTTP method.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum RpchChannel {
+    /// `RPC_IN_DATA`: client-to-server tunnel data (`TsProxySendToServer`).
+    In,
+    /// `RPC_OUT_DATA`: server-to-client tunnel data (the receive pipe).
+    Out,
+}
+
+/// Classify a decrypted RPCH flow, or `None` when it is not an RPCH tunnel.
+pub fn rpch_channel(plaintext: &Plaintext) -> Option<RpchChannel> {
+    let client = flatten(&plaintext.client);
+    if client.starts_with(b"RPC_IN_DATA ") {
+        Some(RpchChannel::In)
+    } else if client.starts_with(b"RPC_OUT_DATA ") {
+        Some(RpchChannel::Out)
+    } else {
+        None
+    }
+}
+
+/// Pair IN and OUT channel flows, or `None` when no RPCH tunnel is present.
+///
+/// A single IN or OUT HTTP flow is not a complete tunnel.
+pub fn pair_rpch_channels(flows: &[Plaintext]) -> Result<Option<(&Plaintext, &Plaintext)>, ReplayError> {
+    let input = flows.iter().find(|flow| rpch_channel(flow) == Some(RpchChannel::In));
+    let output = flows.iter().find(|flow| rpch_channel(flow) == Some(RpchChannel::Out));
+    match (input, output) {
+        (Some(input), Some(output)) => Ok(Some((input, output))),
+        (None, None) => Ok(None),
+        _ => Err(ReplayError::GatewayFraming(
+            "incomplete RPC-over-HTTP tunnel".to_owned(),
+        )),
+    }
+}
+
+/// Extract the tunneled RDP bytes from a pair of decrypted RPCH channel flows.
+///
+/// `input` is the IN-channel flow (client requests) and `output` is the OUT-channel
+/// flow (server responses). The returned streams contain raw RDP traffic (starting
+/// with the X.224 connection request) exactly as a direct TCP capture would carry it.
+pub fn extract_rpch_tunneled_rdp(input: &Plaintext, output: &Plaintext) -> Result<Plaintext, ReplayError> {
+    let client_flat = flatten(&input.client);
+    let server_flat = flatten(&output.server);
+    let client_body = strip_http_heads(&client_flat, Direction::Client);
+    let server_body = strip_http_heads(&server_flat, Direction::Server);
+
+    let client = client_rdp_bytes(client_body)?;
+    let server = server_rdp_bytes(server_body)?;
+    if client.is_empty() || server.is_empty() {
+        return Err(ReplayError::MissingRdpState);
+    }
+    Ok(Plaintext { client, server })
+}
+
+#[derive(Clone, Copy)]
+enum Direction {
+    Client,
+    Server,
+}
+
+/// Strip every HTTP request/response head, returning the concatenated RPC body.
+///
+/// Authentication adds 401 round trips before the 200 that opens the streaming body;
+/// each head ends at `\r\n\r\n`, and a server head with a small `Content-Length`
+/// (an error page) is followed by that body before the next head.
+fn strip_http_heads(bytes: &[u8], direction: Direction) -> &[u8] {
+    let mut offset = 0;
+    loop {
+        let Some(rel) = bytes[offset..].windows(4).position(|window| window == b"\r\n\r\n") else {
+            return &bytes[bytes.len()..];
+        };
+        let head_end = offset + rel + 4;
+        let head = &bytes[offset..head_end];
+        let Ok(text) = core::str::from_utf8(head) else {
+            return &bytes[offset..];
+        };
+        let content_length = text.split("\r\n").find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.trim()
+                .eq_ignore_ascii_case("content-length")
+                .then(|| value.trim().parse::<usize>().ok())?
+        });
+        // A server success head (2xx) is followed by the streaming RPC body; a server
+        // error head with a small body is drained before the next head.
+        if matches!(direction, Direction::Server) && text.starts_with("HTTP/1.1 2") {
+            match content_length {
+                Some(n) if n < MAX_FRAGMENT => {
+                    offset = (head_end + n).min(bytes.len());
+                    continue;
+                }
+                _ => return &bytes[head_end..],
+            }
+        }
+        let next = match direction {
+            Direction::Client => head_end,
+            Direction::Server => (head_end + content_length.unwrap_or(0)).min(bytes.len()),
+        };
+        let rest = &bytes[next..];
+        let starts_head =
+            rest.starts_with(b"RPC_IN_DATA ") || rest.starts_with(b"RPC_OUT_DATA ") || rest.starts_with(b"HTTP/");
+        if starts_head && next < bytes.len() {
+            offset = next;
+        } else {
+            return rest;
+        }
+    }
+}
+
+struct Pdu {
+    ptype: u8,
+    call_id: u32,
+    /// The operation number for request PDUs (the last request-header field).
+    opnum: u16,
+    /// The reassembled data stub, excluding trailing security trailers.
+    stub: Vec<u8>,
+}
+
+struct Fragment<'a> {
+    ptype: u8,
+    flags: u8,
+    call_id: u32,
+    opnum: u16,
+    stub: &'a [u8],
+}
+
+/// Iterate well-formed DCE/RPC fragments in a channel body.
+///
+/// A connection using packet integrity pads the stub, then appends an 8-byte security
+/// trailer and an authentication token. The stub therefore ends at `frag_len -
+/// auth_len - 8 - auth_pad_len`, where `auth_pad_len` is read from the security trailer
+/// itself ([MS-RPCE] 2.2.2.10 and 2.2.2.11). `alloc_hint` cannot be used here: on a
+/// continuation fragment it advertises the *remaining* stub, not this fragment's share.
+fn fragments(mut bytes: &[u8], header_size: usize) -> impl Iterator<Item = Fragment<'_>> {
+    core::iter::from_fn(move || {
+        let header = bytes.get(..COMMON_HEADER)?;
+        if header[0] != 5 {
+            return None;
+        }
+        let ptype = header[2];
+        let flags = header[3];
+        let fragment_length = usize::from(u16::from_le_bytes([header[8], header[9]]));
+        if !(COMMON_HEADER..=MAX_FRAGMENT).contains(&fragment_length) {
+            return None;
+        }
+        let auth_length = usize::from(u16::from_le_bytes([header[10], header[11]]));
+        let call_id = u32::from_le_bytes([header[12], header[13], header[14], header[15]]);
+        let pdu = bytes.get(..fragment_length)?;
+        bytes = &bytes[fragment_length..];
+        // Security trailer layout: auth type, auth level, auth pad length, reserved,
+        // context id. The pad length precedes the trailer, so it shrinks the stub.
+        let stub_end = if auth_length > 0 {
+            let sec_trailer = fragment_length.checked_sub(auth_length + 8)?;
+            let auth_pad_len = usize::from(*pdu.get(sec_trailer + 2)?);
+            sec_trailer.checked_sub(auth_pad_len)?
+        } else {
+            fragment_length
+        };
+        // Control PDUs (bind, auth3) may carry no data stub; clamp instead of stopping so
+        // later data PDUs are still visited.
+        let stub = if stub_end >= header_size {
+            &pdu[header_size..stub_end]
+        } else {
+            &[][..]
+        };
+        // Request PDUs carry the opnum as the last two header bytes before the stub.
+        let opnum = if ptype == PTYPE_REQUEST {
+            pdu.get(header_size - 2..header_size)
+                .map(|bytes| u16::from_le_bytes([bytes[0], bytes[1]]))
+                .unwrap_or(u16::MAX)
+        } else {
+            u16::MAX
+        };
+        Some(Fragment {
+            ptype,
+            flags,
+            call_id,
+            opnum,
+            stub,
+        })
+    })
+}
+
+/// Reassemble DCE/RPC fragments that share a call id into complete PDUs.
+fn pdus(bytes: &[u8], header_size: usize) -> Vec<Pdu> {
+    let mut complete = Vec::new();
+    let mut pending: Option<Pdu> = None;
+    for fragment in fragments(bytes, header_size) {
+        let first = fragment.flags & PFC_FIRST_FRAG != 0;
+        let last = fragment.flags & PFC_LAST_FRAG != 0;
+        match pending.as_mut() {
+            Some(pdu) if !first && pdu.call_id == fragment.call_id && pdu.ptype == fragment.ptype => {
+                pdu.stub.extend_from_slice(fragment.stub);
+            }
+            _ => {
+                pending = Some(Pdu {
+                    ptype: fragment.ptype,
+                    call_id: fragment.call_id,
+                    opnum: fragment.opnum,
+                    stub: fragment.stub.to_vec(),
+                });
+            }
+        }
+        if last {
+            if let Some(pdu) = pending.take() {
+                complete.push(pdu);
+            }
+        }
+    }
+    complete
+}
+
+/// Recover the client-to-server RDP stream from IN-channel `TsProxySendToServer`
+/// request stubs ([MS-TSGU] 2.2.9.3).
+fn client_rdp_bytes(body: &[u8]) -> Result<PacketStream, ReplayError> {
+    let mut output = Vec::new();
+    for pdu in pdus(body, REQUEST_HEADER) {
+        if pdu.ptype != PTYPE_REQUEST || pdu.opnum != SEND_TO_SERVER_OPNUM {
+            continue;
+        }
+        let data = send_to_server_payload(&pdu.stub)?;
+        if !data.is_empty() {
+            output.push((usize::try_from(pdu.call_id).unwrap_or(0), data));
+        }
+    }
+    Ok(output)
+}
+
+/// Parse a `TsProxySendToServer` stub: context handle, total bytes, buffer count, then
+/// per-buffer length-prefixed data. The data-plane length fields are little-endian on
+/// the wire (matching mstsc), like the NDR control stubs.
+fn send_to_server_payload(stub: &[u8]) -> Result<Vec<u8>, ReplayError> {
+    const HANDLE: usize = 20;
+    let framing = || ReplayError::GatewayFraming("malformed send-to-server stub".to_owned());
+    let mut cursor = stub.get(HANDLE..).ok_or_else(framing)?;
+    let _total = read_le_u32(&mut cursor).ok_or_else(framing)?;
+    let buffer_count = usize::try_from(read_le_u32(&mut cursor).ok_or_else(framing)?).map_err(|_| framing())?;
+    if buffer_count > 3 {
+        return Err(framing());
+    }
+    let mut lengths = Vec::with_capacity(buffer_count);
+    for _ in 0..buffer_count {
+        lengths.push(usize::try_from(read_le_u32(&mut cursor).ok_or_else(framing)?).map_err(|_| framing())?);
+    }
+    let mut data = Vec::new();
+    for length in lengths {
+        let buffer = cursor.get(..length).ok_or_else(framing)?;
+        data.extend_from_slice(buffer);
+        cursor = &cursor[length..];
+    }
+    Ok(data)
+}
+
+/// Recover the server-to-client RDP stream from OUT-channel receive-pipe response
+/// stubs. After `TsProxySetupReceivePipe` the data-plane responses carry the raw RDP
+/// bytes directly; control responses (bind ack, tunnel/channel setup) are skipped by
+/// their non-RDP stub content.
+fn server_rdp_bytes(body: &[u8]) -> Result<PacketStream, ReplayError> {
+    let mut output = Vec::new();
+    // The receive pipe carries every server-to-client RDP byte on one RPC call: the
+    // `TsProxySetupReceivePipe` call. That call's response stream starts with the X.224
+    // connection confirm (TPKT). Other interleaved responses (bind ack, tunnel/channel
+    // setup, MakeTunnelCall admin replies) use their own call ids and are not RDP.
+    let mut receive_pipe_call = None;
+    for pdu in pdus(body, RESPONSE_HEADER) {
+        if pdu.ptype != PTYPE_RESPONSE {
+            continue;
+        }
+        match receive_pipe_call {
+            None => {
+                // The receive pipe's first data response is the X.224 connection confirm.
+                if starts_with_tpkt(&pdu.stub) {
+                    receive_pipe_call = Some(pdu.call_id);
+                } else {
+                    continue;
+                }
+            }
+            // After the pipe opens, its data is a contiguous RDP byte stream split
+            // arbitrarily across responses; keep only this call's stubs.
+            Some(call) if call != pdu.call_id => continue,
+            Some(_) => {}
+        }
+        if !pdu.stub.is_empty() {
+            output.push((usize::try_from(pdu.call_id).unwrap_or(0), pdu.stub));
+        }
+    }
+    Ok(output)
+}
+
+/// A tunneled RDP record begins with a TPKT header (`03 00`, big-endian length).
+fn starts_with_tpkt(stub: &[u8]) -> bool {
+    matches!(stub, [0x03, 0x00, ..])
+}
+
+fn read_le_u32(cursor: &mut &[u8]) -> Option<u32> {
+    let (field, rest) = cursor.split_at_checked(4)?;
+    *cursor = rest;
+    Some(u32::from_le_bytes(field.try_into().ok()?))
+}

--- a/crates/ironrdp-capture-replay/src/lib.rs
+++ b/crates/ironrdp-capture-replay/src/lib.rs
@@ -1,10 +1,12 @@
 //! Offline analysis support for direct TCP RDP captures.
 //!
-//! After TLS decryption, an `RDG_OUT_DATA` WebSocket tunnel is unwrapped into
+//! After TLS decryption, an `RDG_OUT_DATA` WebSocket tunnel or a paired
+//! `RPC_IN_DATA` / `RPC_OUT_DATA` RPC-over-HTTP tunnel is unwrapped into
 //! the inner RDP stream before negotiation recovery and routing.
 
 mod error;
 mod gateway;
+mod gateway_rpch;
 mod negotiation;
 mod output;
 mod routing;
@@ -13,6 +15,7 @@ mod transport;
 
 pub use error::ReplayError;
 pub use gateway::{extract_tunneled_rdp, is_gateway_tunnel};
+pub use gateway_rpch::{RpchChannel, extract_rpch_tunneled_rdp, pair_rpch_channels, rpch_channel};
 pub use negotiation::{NegotiatedState, StaticChannel, recover_negotiated_state};
 pub use output::{ExportError, ExportOptions, ExportSummary, export_capture};
 pub use routing::{

--- a/crates/ironrdp-capture-replay/src/lib.rs
+++ b/crates/ironrdp-capture-replay/src/lib.rs
@@ -15,7 +15,9 @@ mod transport;
 
 pub use error::ReplayError;
 pub use gateway::{extract_tunneled_rdp, is_gateway_tunnel};
-pub use gateway_rpch::{RpchChannel, extract_rpch_tunneled_rdp, pair_rpch_channels, rpch_channel};
+pub use gateway_rpch::{
+    RpchChannel, extract_rpch_from_flows, extract_rpch_tunneled_rdp, pair_rpch_channels, rpch_channel,
+};
 pub use negotiation::{NegotiatedState, StaticChannel, recover_negotiated_state};
 pub use output::{ExportError, ExportOptions, ExportSummary, export_capture};
 pub use routing::{

--- a/crates/ironrdp-capture-replay/src/lib.rs
+++ b/crates/ironrdp-capture-replay/src/lib.rs
@@ -15,9 +15,7 @@ mod transport;
 
 pub use error::ReplayError;
 pub use gateway::{extract_tunneled_rdp, is_gateway_tunnel};
-pub use gateway_rpch::{
-    RpchChannel, extract_rpch_from_flows, extract_rpch_tunneled_rdp, pair_rpch_channels, rpch_channel,
-};
+pub use gateway_rpch::{extract_rpch_from_flows, extract_rpch_tunneled_rdp};
 pub use negotiation::{NegotiatedState, StaticChannel, recover_negotiated_state};
 pub use output::{ExportError, ExportOptions, ExportSummary, export_capture};
 pub use routing::{

--- a/crates/ironrdp-capture-replay/src/routing.rs
+++ b/crates/ironrdp-capture-replay/src/routing.rs
@@ -22,7 +22,9 @@ use ironrdp_session::{ActiveStage, ActiveStageBuilder, ActiveStageOutput};
 use ironrdp_svc::{StaticChannelSet, StaticVirtualChannel, SvcMessage, SvcProcessor};
 
 use crate::tls::decrypt_tls_streams;
-use crate::{Capture, NegotiatedState, PacketStream, Plaintext, ReplayError, gateway, recover_negotiated_state};
+use crate::{
+    Capture, NegotiatedState, PacketStream, Plaintext, ReplayError, gateway, gateway_rpch, recover_negotiated_state,
+};
 
 const MAX_DESKTOP_DIM: u16 = 8192;
 const MAX_EGFX_OUTPUT_DIM: u16 = 32_766;
@@ -572,13 +574,9 @@ pub(crate) fn prepare_replay_capture(capture: &Capture) -> Result<(ReplayRouter,
     }
     let plaintext = if let Some(outer) = decrypted.iter().find(|plaintext| gateway::is_gateway_tunnel(plaintext)) {
         let tunneled = gateway::extract_tunneled_rdp(outer)?;
-        decrypt_tls_streams(&tunneled.client, &tunneled.server, capture.tls_key_log.as_str()).map_err(|error| {
-            if matches!(error, ReplayError::MissingTlsSecret) {
-                ReplayError::MissingTunneledTlsSecret
-            } else {
-                error
-            }
-        })?
+        decrypt_tunneled_rdp(&tunneled, capture)?
+    } else if let Some(tunneled) = gateway_rpch::extract_rpch_from_flows(&decrypted)? {
+        decrypt_tunneled_rdp(&tunneled, capture)?
     } else {
         match decrypted.into_iter().next() {
             Some(plaintext) => plaintext,
@@ -590,6 +588,16 @@ pub(crate) fn prepare_replay_capture(capture: &Capture) -> Result<(ReplayRouter,
         compression_type: captured_compression_type(&plaintext),
     })?;
     Ok((router, plaintext))
+}
+
+fn decrypt_tunneled_rdp(tunneled: &Plaintext, capture: &Capture) -> Result<Plaintext, ReplayError> {
+    decrypt_tls_streams(&tunneled.client, &tunneled.server, capture.tls_key_log.as_str()).map_err(|error| {
+        if matches!(error, ReplayError::MissingTlsSecret) {
+            ReplayError::MissingTunneledTlsSecret
+        } else {
+            error
+        }
+    })
 }
 
 fn captured_compression_type(plaintext: &Plaintext) -> Option<CompressionType> {

--- a/crates/ironrdp-capture-replay/src/transport.rs
+++ b/crates/ironrdp-capture-replay/src/transport.rs
@@ -41,8 +41,8 @@ pub struct Flow {
 pub struct Capture {
     /// Direct TCP RDP flow selected from the pcapng input.
     pub flow: Flow,
-    /// Other TLS flows to TCP port 443, tried when the primary flow is not an
-    /// RD Gateway WebSocket tunnel (a KDC-proxy connection shares that port).
+    /// Other TLS flows to TCP port 443, tried when the primary flow is not a
+    /// complete RD Gateway tunnel (one WebSocket flow, or paired RPCH IN+OUT).
     pub gateway_alternates: Vec<Flow>,
     /// NSS-compatible TLS key-log entries embedded in the capture.
     pub tls_key_log: TlsKeyLog,

--- a/crates/ironrdp-capture-replay/tests/gateway_rpch.rs
+++ b/crates/ironrdp-capture-replay/tests/gateway_rpch.rs
@@ -4,7 +4,8 @@
 )]
 
 use ironrdp_capture_replay::{
-    Plaintext, ReplayError, RpchChannel, extract_rpch_tunneled_rdp, pair_rpch_channels, rpch_channel,
+    Plaintext, ReplayError, RpchChannel, extract_rpch_from_flows, extract_rpch_tunneled_rdp, pair_rpch_channels,
+    rpch_channel,
 };
 
 const COMMON_HEADER: usize = 16;
@@ -42,9 +43,9 @@ fn request_pdu(call_id: u32, opnum: u16, stub: &[u8]) -> Vec<u8> {
     request_pdu_with_flags(call_id, opnum, stub, PFC_FIRST_FRAG | PFC_LAST_FRAG)
 }
 
-fn response_pdu(call_id: u32, stub: &[u8]) -> Vec<u8> {
+fn response_pdu_with_flags(call_id: u32, stub: &[u8], flags: u8) -> Vec<u8> {
     let fragment_length = RESPONSE_HEADER + stub.len();
-    let mut pdu = common_header(PTYPE_RESPONSE, PFC_FIRST_FRAG | PFC_LAST_FRAG, call_id, fragment_length);
+    let mut pdu = common_header(PTYPE_RESPONSE, flags, call_id, fragment_length);
     pdu.extend_from_slice(&u32::try_from(stub.len()).expect("stub length fits u32").to_le_bytes());
     pdu.extend_from_slice(&0u16.to_le_bytes());
     pdu.extend_from_slice(&[0, 0]);
@@ -52,26 +53,35 @@ fn response_pdu(call_id: u32, stub: &[u8]) -> Vec<u8> {
     pdu
 }
 
-fn send_to_server_stub(buffers: &[&[u8]]) -> Vec<u8> {
+fn response_pdu(call_id: u32, stub: &[u8]) -> Vec<u8> {
+    response_pdu_with_flags(call_id, stub, PFC_FIRST_FRAG)
+}
+
+fn encode_u32(value: usize, big_endian: bool) -> [u8; 4] {
+    let value = u32::try_from(value).expect("length fits u32");
+    if big_endian {
+        value.to_be_bytes()
+    } else {
+        value.to_le_bytes()
+    }
+}
+
+fn send_to_server_stub_with_endian(buffers: &[&[u8]], big_endian: bool) -> Vec<u8> {
     let mut stub = vec![0u8; 20];
     let total: usize = buffers.iter().map(|buffer| buffer.len()).sum::<usize>() + 4 * buffers.len();
-    stub.extend_from_slice(&u32::try_from(total).expect("total length fits u32").to_le_bytes());
-    stub.extend_from_slice(
-        &u32::try_from(buffers.len())
-            .expect("buffer count fits u32")
-            .to_le_bytes(),
-    );
+    stub.extend_from_slice(&encode_u32(total, big_endian));
+    stub.extend_from_slice(&encode_u32(buffers.len(), big_endian));
     for buffer in buffers {
-        stub.extend_from_slice(
-            &u32::try_from(buffer.len())
-                .expect("buffer length fits u32")
-                .to_le_bytes(),
-        );
+        stub.extend_from_slice(&encode_u32(buffer.len(), big_endian));
     }
     for buffer in buffers {
         stub.extend_from_slice(buffer);
     }
     stub
+}
+
+fn send_to_server_stub(buffers: &[&[u8]]) -> Vec<u8> {
+    send_to_server_stub_with_endian(buffers, true)
 }
 
 fn in_channel(body: Vec<u8>) -> Plaintext {
@@ -149,8 +159,8 @@ fn extracts_send_to_server_and_receive_pipe_payloads() {
 
     let inner = extract_rpch_tunneled_rdp(&input, &output).unwrap();
 
-    assert_eq!(inner.client, vec![(7, rdp.to_vec())]);
-    assert_eq!(inner.server, vec![(6, cc.to_vec())]);
+    assert_eq!(inner.client, vec![(1, rdp.to_vec())]);
+    assert_eq!(inner.server, vec![(2, cc.to_vec())]);
 }
 
 #[test]
@@ -167,8 +177,8 @@ fn skips_non_data_requests_and_control_responses() {
 
     let inner = extract_rpch_tunneled_rdp(&in_channel(client_body), &out_channel(server_body)).unwrap();
 
-    assert_eq!(inner.client, vec![(2, rdp.to_vec())]);
-    assert_eq!(inner.server, vec![(6, cc.to_vec()), (6, data.to_vec())]);
+    assert_eq!(inner.client, vec![(1, rdp.to_vec())]);
+    assert_eq!(inner.server, vec![(2, cc.to_vec()), (2, data.to_vec())]);
 }
 
 #[test]
@@ -192,7 +202,7 @@ fn strips_authentication_round_trips() {
     let inner = extract_rpch_tunneled_rdp(&input, &output).unwrap();
 
     assert_eq!(inner.client, vec![(1, rdp.to_vec())]);
-    assert_eq!(inner.server, vec![(1, vec![0x03, 0x00, 0x00, 0x13, 0x0e, 0xd0])]);
+    assert_eq!(inner.server, vec![(2, vec![0x03, 0x00, 0x00, 0x13, 0x0e, 0xd0])]);
 }
 
 #[test]
@@ -211,7 +221,7 @@ fn reassembles_fragmented_send_to_server_stubs() {
 
     let inner = extract_rpch_tunneled_rdp(&in_channel(body), &out_channel(response_pdu(6, &cc))).unwrap();
 
-    assert_eq!(inner.client, vec![(4, rdp.to_vec())]);
+    assert_eq!(inner.client, vec![(1, rdp.to_vec())]);
 }
 
 #[test]
@@ -223,4 +233,89 @@ fn rejects_a_tunnel_without_rdp_payloads() {
         extract_rpch_tunneled_rdp(&input, &output),
         Err(ReplayError::MissingRdpState)
     ));
+}
+
+#[test]
+fn preserves_source_packet_numbers() {
+    let rdp = [0x03, 0x00, 0x00, 0x13, 0x0e, 0xe0];
+    let cc = [0x03, 0x00, 0x00, 0x13, 0x0e, 0xd0];
+    let mut client = b"RPC_IN_DATA /rpc/rpcproxy.dll?x HTTP/1.1\r\nContent-Length: 1073741824\r\n\r\n".to_vec();
+    client.extend(request_pdu(7, SEND_TO_SERVER_OPNUM, &send_to_server_stub(&[&rdp])));
+    let mut server = b"HTTP/1.1 200 OK\r\n\r\n".to_vec();
+    server.extend(response_pdu(6, &cc));
+    let input = Plaintext {
+        client: vec![(10, client)],
+        server: Vec::new(),
+    };
+    let output = Plaintext {
+        client: vec![(11, b"RPC_OUT_DATA /rpc/rpcproxy.dll?x HTTP/1.1\r\n\r\n".to_vec())],
+        server: vec![(20, server)],
+    };
+
+    let inner = extract_rpch_tunneled_rdp(&input, &output).unwrap();
+
+    assert_eq!(inner.client, vec![(10, rdp.to_vec())]);
+    assert_eq!(inner.server, vec![(20, cc.to_vec())]);
+}
+
+#[test]
+fn accepts_little_endian_send_to_server_lengths() {
+    let rdp = [0x03, 0x00, 0x00, 0x13, 0x0e, 0xe0];
+    let cc = [0x03, 0x00, 0x00, 0x13, 0x0e, 0xd0];
+    let input = in_channel(request_pdu(
+        7,
+        SEND_TO_SERVER_OPNUM,
+        &send_to_server_stub_with_endian(&[&rdp], false),
+    ));
+
+    let inner = extract_rpch_tunneled_rdp(&input, &out_channel(response_pdu(6, &cc))).unwrap();
+
+    assert_eq!(inner.client, vec![(1, rdp.to_vec())]);
+}
+
+#[test]
+fn extracts_receive_pipe_without_last_frag() {
+    let rdp = [0x03, 0x00, 0x00, 0x13, 0x0e, 0xe0];
+    let cc = [0x03, 0x00, 0x00, 0x13, 0x0e, 0xd0];
+    let data = [0x03, 0x00, 0x00, 0x20, 0x02, 0xf0];
+    let mut server_body = response_pdu_with_flags(6, &cc, PFC_FIRST_FRAG);
+    server_body.extend(response_pdu_with_flags(6, &data, 0));
+
+    let inner = extract_rpch_tunneled_rdp(
+        &in_channel(request_pdu(2, SEND_TO_SERVER_OPNUM, &send_to_server_stub(&[&rdp]))),
+        &out_channel(server_body),
+    )
+    .unwrap();
+
+    assert_eq!(inner.server, vec![(2, cc.to_vec()), (2, data.to_vec())]);
+}
+
+#[test]
+fn skips_receive_pipe_final_return_code() {
+    let rdp = [0x03, 0x00, 0x00, 0x13, 0x0e, 0xe0];
+    let cc = [0x03, 0x00, 0x00, 0x13, 0x0e, 0xd0];
+    let mut server_body = response_pdu(6, &cc);
+    server_body.extend(response_pdu_with_flags(6, &0u32.to_le_bytes(), PFC_LAST_FRAG));
+
+    let inner = extract_rpch_tunneled_rdp(
+        &in_channel(request_pdu(2, SEND_TO_SERVER_OPNUM, &send_to_server_stub(&[&rdp]))),
+        &out_channel(server_body),
+    )
+    .unwrap();
+
+    assert_eq!(inner.server, vec![(2, cc.to_vec())]);
+}
+
+#[test]
+fn pairs_a_later_in_channel_when_the_first_has_no_rdp() {
+    let rdp = [0x03, 0x00, 0x00, 0x13, 0x0e, 0xe0];
+    let cc = [0x03, 0x00, 0x00, 0x13, 0x0e, 0xd0];
+    let dead_in = in_channel(request_pdu(1, 1, &[0u8; 32]));
+    let live_in = in_channel(request_pdu(2, SEND_TO_SERVER_OPNUM, &send_to_server_stub(&[&rdp])));
+    let output = out_channel(response_pdu(6, &cc));
+
+    let inner = extract_rpch_from_flows(&[dead_in, live_in, output]).unwrap().unwrap();
+
+    assert_eq!(inner.client, vec![(1, rdp.to_vec())]);
+    assert_eq!(inner.server, vec![(2, cc.to_vec())]);
 }

--- a/crates/ironrdp-capture-replay/tests/gateway_rpch.rs
+++ b/crates/ironrdp-capture-replay/tests/gateway_rpch.rs
@@ -3,10 +3,7 @@
     reason = "integration tests link the library crate and do not use its direct dependencies"
 )]
 
-use ironrdp_capture_replay::{
-    Plaintext, ReplayError, RpchChannel, extract_rpch_from_flows, extract_rpch_tunneled_rdp, pair_rpch_channels,
-    rpch_channel,
-};
+use ironrdp_capture_replay::{Plaintext, ReplayError, extract_rpch_from_flows, extract_rpch_tunneled_rdp};
 
 const COMMON_HEADER: usize = 16;
 const RESPONSE_HEADER: usize = COMMON_HEADER + 8;
@@ -57,6 +54,16 @@ fn response_pdu(call_id: u32, stub: &[u8]) -> Vec<u8> {
     response_pdu_with_flags(call_id, stub, PFC_FIRST_FRAG)
 }
 
+fn authenticated_response_pdu(call_id: u32, stub: &[u8]) -> Vec<u8> {
+    let mut pdu = response_pdu(call_id, stub);
+    pdu.extend_from_slice(&[0, 0, 0, 0, 0, 0, 0, 0]); // Security trailer.
+    pdu.push(0); // Authentication token.
+    let fragment_length = u16::try_from(pdu.len()).expect("fragment length fits u16");
+    pdu[8..10].copy_from_slice(&fragment_length.to_le_bytes());
+    pdu[10..12].copy_from_slice(&1u16.to_le_bytes());
+    pdu
+}
+
 fn encode_u32(value: usize, big_endian: bool) -> [u8; 4] {
     let value = u32::try_from(value).expect("length fits u32");
     if big_endian {
@@ -103,54 +110,6 @@ fn out_channel(body: Vec<u8>) -> Plaintext {
 }
 
 #[test]
-fn detects_rpch_in_and_out_channels() {
-    let input = in_channel(Vec::new());
-    let output = out_channel(Vec::new());
-
-    assert_eq!(rpch_channel(&input), Some(RpchChannel::In));
-    assert_eq!(rpch_channel(&output), Some(RpchChannel::Out));
-    assert_eq!(
-        rpch_channel(&Plaintext {
-            client: vec![(1, b"RDG_OUT_DATA /remoteDesktopGateway/ HTTP/1.1\r\n\r\n".to_vec())],
-            server: Vec::new(),
-        }),
-        None
-    );
-}
-
-#[test]
-fn pairs_in_and_out_channels() {
-    let input = in_channel(Vec::new());
-    let output = out_channel(Vec::new());
-    let flows = [input, output];
-
-    let pair = pair_rpch_channels(&flows).unwrap().unwrap();
-
-    assert_eq!(rpch_channel(pair.0), Some(RpchChannel::In));
-    assert_eq!(rpch_channel(pair.1), Some(RpchChannel::Out));
-}
-
-#[test]
-fn rejects_a_single_rpch_channel() {
-    let input = in_channel(Vec::new());
-
-    assert!(matches!(
-        pair_rpch_channels(&[input]),
-        Err(ReplayError::GatewayFraming(_))
-    ));
-}
-
-#[test]
-fn ignores_non_rpch_flows_when_pairing() {
-    let other = Plaintext {
-        client: vec![(1, b"GET /kdcproxy HTTP/1.1\r\n\r\n".to_vec())],
-        server: Vec::new(),
-    };
-
-    assert_eq!(pair_rpch_channels(&[other]).unwrap(), None);
-}
-
-#[test]
 fn extracts_send_to_server_and_receive_pipe_payloads() {
     let rdp = [0x03, 0x00, 0x00, 0x13, 0x0e, 0xe0];
     let cc = [0x03, 0x00, 0x00, 0x13, 0x0e, 0xd0];
@@ -161,6 +120,33 @@ fn extracts_send_to_server_and_receive_pipe_payloads() {
 
     assert_eq!(inner.client, vec![(1, rdp.to_vec())]);
     assert_eq!(inner.server, vec![(2, cc.to_vec())]);
+}
+
+#[test]
+fn handles_dce_rpc_authentication_trailers() {
+    let rdp = [0x03, 0x00, 0x00, 0x13, 0x0e, 0xe0];
+    let cc = [0x03, 0x00, 0x00, 0x13, 0x0e, 0xd0];
+    let input = in_channel(request_pdu(7, SEND_TO_SERVER_OPNUM, &send_to_server_stub(&[&rdp])));
+    let output = out_channel(authenticated_response_pdu(6, &cc));
+
+    let inner = extract_rpch_tunneled_rdp(&input, &output).unwrap();
+
+    assert_eq!(inner.server, vec![(2, cc.to_vec())]);
+}
+
+#[test]
+fn rejects_invalid_dce_rpc_authentication_padding() {
+    let rdp = [0x03, 0x00, 0x00, 0x13, 0x0e, 0xe0];
+    let cc = [0x03, 0x00, 0x00, 0x13, 0x0e, 0xd0];
+    let input = in_channel(request_pdu(7, SEND_TO_SERVER_OPNUM, &send_to_server_stub(&[&rdp])));
+    let mut response = response_pdu(6, &cc);
+    response[10..12].copy_from_slice(&1u16.to_le_bytes());
+    response[23] = 22; // The authentication padding is longer than the fragment prefix.
+
+    assert!(matches!(
+        extract_rpch_tunneled_rdp(&input, &out_channel(response)),
+        Err(ReplayError::GatewayFraming(message)) if message == "invalid DCE/RPC authentication padding"
+    ));
 }
 
 #[test]

--- a/crates/ironrdp-capture-replay/tests/gateway_rpch.rs
+++ b/crates/ironrdp-capture-replay/tests/gateway_rpch.rs
@@ -1,0 +1,226 @@
+#![expect(
+    unused_crate_dependencies,
+    reason = "integration tests link the library crate and do not use its direct dependencies"
+)]
+
+use ironrdp_capture_replay::{
+    Plaintext, ReplayError, RpchChannel, extract_rpch_tunneled_rdp, pair_rpch_channels, rpch_channel,
+};
+
+const COMMON_HEADER: usize = 16;
+const RESPONSE_HEADER: usize = COMMON_HEADER + 8;
+const REQUEST_HEADER: usize = COMMON_HEADER + 8;
+const PTYPE_REQUEST: u8 = 0;
+const PTYPE_RESPONSE: u8 = 2;
+const PFC_FIRST_FRAG: u8 = 0x01;
+const PFC_LAST_FRAG: u8 = 0x02;
+const SEND_TO_SERVER_OPNUM: u16 = 9;
+
+fn common_header(ptype: u8, flags: u8, call_id: u32, fragment_length: usize) -> Vec<u8> {
+    let mut pdu = vec![5, 0, ptype, flags, 0x10, 0, 0, 0];
+    pdu.extend_from_slice(
+        &u16::try_from(fragment_length)
+            .expect("fragment length fits u16")
+            .to_le_bytes(),
+    );
+    pdu.extend_from_slice(&0u16.to_le_bytes());
+    pdu.extend_from_slice(&call_id.to_le_bytes());
+    pdu
+}
+
+fn request_pdu_with_flags(call_id: u32, opnum: u16, stub: &[u8], flags: u8) -> Vec<u8> {
+    let fragment_length = REQUEST_HEADER + stub.len();
+    let mut pdu = common_header(PTYPE_REQUEST, flags, call_id, fragment_length);
+    pdu.extend_from_slice(&u32::try_from(stub.len()).expect("stub length fits u32").to_le_bytes());
+    pdu.extend_from_slice(&0u16.to_le_bytes());
+    pdu.extend_from_slice(&opnum.to_le_bytes());
+    pdu.extend_from_slice(stub);
+    pdu
+}
+
+fn request_pdu(call_id: u32, opnum: u16, stub: &[u8]) -> Vec<u8> {
+    request_pdu_with_flags(call_id, opnum, stub, PFC_FIRST_FRAG | PFC_LAST_FRAG)
+}
+
+fn response_pdu(call_id: u32, stub: &[u8]) -> Vec<u8> {
+    let fragment_length = RESPONSE_HEADER + stub.len();
+    let mut pdu = common_header(PTYPE_RESPONSE, PFC_FIRST_FRAG | PFC_LAST_FRAG, call_id, fragment_length);
+    pdu.extend_from_slice(&u32::try_from(stub.len()).expect("stub length fits u32").to_le_bytes());
+    pdu.extend_from_slice(&0u16.to_le_bytes());
+    pdu.extend_from_slice(&[0, 0]);
+    pdu.extend_from_slice(stub);
+    pdu
+}
+
+fn send_to_server_stub(buffers: &[&[u8]]) -> Vec<u8> {
+    let mut stub = vec![0u8; 20];
+    let total: usize = buffers.iter().map(|buffer| buffer.len()).sum::<usize>() + 4 * buffers.len();
+    stub.extend_from_slice(&u32::try_from(total).expect("total length fits u32").to_le_bytes());
+    stub.extend_from_slice(
+        &u32::try_from(buffers.len())
+            .expect("buffer count fits u32")
+            .to_le_bytes(),
+    );
+    for buffer in buffers {
+        stub.extend_from_slice(
+            &u32::try_from(buffer.len())
+                .expect("buffer length fits u32")
+                .to_le_bytes(),
+        );
+    }
+    for buffer in buffers {
+        stub.extend_from_slice(buffer);
+    }
+    stub
+}
+
+fn in_channel(body: Vec<u8>) -> Plaintext {
+    let mut client = b"RPC_IN_DATA /rpc/rpcproxy.dll?x HTTP/1.1\r\nContent-Length: 1073741824\r\n\r\n".to_vec();
+    client.extend(body);
+    Plaintext {
+        client: vec![(1, client)],
+        server: Vec::new(),
+    }
+}
+
+fn out_channel(body: Vec<u8>) -> Plaintext {
+    let mut server = b"HTTP/1.1 200 OK\r\n\r\n".to_vec();
+    server.extend(body);
+    Plaintext {
+        client: vec![(1, b"RPC_OUT_DATA /rpc/rpcproxy.dll?x HTTP/1.1\r\n\r\n".to_vec())],
+        server: vec![(2, server)],
+    }
+}
+
+#[test]
+fn detects_rpch_in_and_out_channels() {
+    let input = in_channel(Vec::new());
+    let output = out_channel(Vec::new());
+
+    assert_eq!(rpch_channel(&input), Some(RpchChannel::In));
+    assert_eq!(rpch_channel(&output), Some(RpchChannel::Out));
+    assert_eq!(
+        rpch_channel(&Plaintext {
+            client: vec![(1, b"RDG_OUT_DATA /remoteDesktopGateway/ HTTP/1.1\r\n\r\n".to_vec())],
+            server: Vec::new(),
+        }),
+        None
+    );
+}
+
+#[test]
+fn pairs_in_and_out_channels() {
+    let input = in_channel(Vec::new());
+    let output = out_channel(Vec::new());
+    let flows = [input, output];
+
+    let pair = pair_rpch_channels(&flows).unwrap().unwrap();
+
+    assert_eq!(rpch_channel(pair.0), Some(RpchChannel::In));
+    assert_eq!(rpch_channel(pair.1), Some(RpchChannel::Out));
+}
+
+#[test]
+fn rejects_a_single_rpch_channel() {
+    let input = in_channel(Vec::new());
+
+    assert!(matches!(
+        pair_rpch_channels(&[input]),
+        Err(ReplayError::GatewayFraming(_))
+    ));
+}
+
+#[test]
+fn ignores_non_rpch_flows_when_pairing() {
+    let other = Plaintext {
+        client: vec![(1, b"GET /kdcproxy HTTP/1.1\r\n\r\n".to_vec())],
+        server: Vec::new(),
+    };
+
+    assert_eq!(pair_rpch_channels(&[other]).unwrap(), None);
+}
+
+#[test]
+fn extracts_send_to_server_and_receive_pipe_payloads() {
+    let rdp = [0x03, 0x00, 0x00, 0x13, 0x0e, 0xe0];
+    let cc = [0x03, 0x00, 0x00, 0x13, 0x0e, 0xd0];
+    let input = in_channel(request_pdu(7, SEND_TO_SERVER_OPNUM, &send_to_server_stub(&[&rdp])));
+    let output = out_channel(response_pdu(6, &cc));
+
+    let inner = extract_rpch_tunneled_rdp(&input, &output).unwrap();
+
+    assert_eq!(inner.client, vec![(7, rdp.to_vec())]);
+    assert_eq!(inner.server, vec![(6, cc.to_vec())]);
+}
+
+#[test]
+fn skips_non_data_requests_and_control_responses() {
+    let rdp = [9u8; 8];
+    let cc = [0x03, 0x00, 0x00, 0x13, 0x0e, 0xd0];
+    let mut client_body = request_pdu(1, 1, &[0u8; 32]);
+    client_body.extend(request_pdu(2, SEND_TO_SERVER_OPNUM, &send_to_server_stub(&[&rdp])));
+    let mut server_body = response_pdu(1, &[0u8; 16]);
+    server_body.extend(response_pdu(6, &cc));
+    server_body.extend(response_pdu(7, &[0u8; 40]));
+    let data = [0x03, 0x00, 0x00, 0x20, 0x02, 0xf0];
+    server_body.extend(response_pdu(6, &data));
+
+    let inner = extract_rpch_tunneled_rdp(&in_channel(client_body), &out_channel(server_body)).unwrap();
+
+    assert_eq!(inner.client, vec![(2, rdp.to_vec())]);
+    assert_eq!(inner.server, vec![(6, cc.to_vec()), (6, data.to_vec())]);
+}
+
+#[test]
+fn strips_authentication_round_trips() {
+    let rdp = [1u8, 2, 3];
+    let mut client = b"RPC_IN_DATA /rpc/rpcproxy.dll?x HTTP/1.1\r\nContent-Length: 0\r\n\r\n".to_vec();
+    client.extend(b"RPC_IN_DATA /rpc/rpcproxy.dll?x HTTP/1.1\r\nContent-Length: 1073741824\r\n\r\n");
+    client.extend(request_pdu(1, SEND_TO_SERVER_OPNUM, &send_to_server_stub(&[&rdp])));
+    let input = Plaintext {
+        client: vec![(1, client)],
+        server: Vec::new(),
+    };
+    let mut server = b"HTTP/1.1 401 Unauthorized\r\nContent-Length: 13\r\n\r\nAccess Denied".to_vec();
+    server.extend(b"HTTP/1.1 200 OK\r\n\r\n");
+    server.extend(response_pdu(1, &[0x03, 0x00, 0x00, 0x13, 0x0e, 0xd0]));
+    let output = Plaintext {
+        client: vec![(1, b"RPC_OUT_DATA /rpc/rpcproxy.dll?x HTTP/1.1\r\n\r\n".to_vec())],
+        server: vec![(2, server)],
+    };
+
+    let inner = extract_rpch_tunneled_rdp(&input, &output).unwrap();
+
+    assert_eq!(inner.client, vec![(1, rdp.to_vec())]);
+    assert_eq!(inner.server, vec![(1, vec![0x03, 0x00, 0x00, 0x13, 0x0e, 0xd0])]);
+}
+
+#[test]
+fn reassembles_fragmented_send_to_server_stubs() {
+    let rdp = [0x03, 0x00, 0x00, 0x13, 0x0e, 0xe0];
+    let stub = send_to_server_stub(&[&rdp]);
+    let split = stub.len() / 2;
+    let mut body = request_pdu_with_flags(4, SEND_TO_SERVER_OPNUM, &stub[..split], PFC_FIRST_FRAG);
+    body.extend(request_pdu_with_flags(
+        4,
+        SEND_TO_SERVER_OPNUM,
+        &stub[split..],
+        PFC_LAST_FRAG,
+    ));
+    let cc = [0x03, 0x00, 0x00, 0x13, 0x0e, 0xd0];
+
+    let inner = extract_rpch_tunneled_rdp(&in_channel(body), &out_channel(response_pdu(6, &cc))).unwrap();
+
+    assert_eq!(inner.client, vec![(4, rdp.to_vec())]);
+}
+
+#[test]
+fn rejects_a_tunnel_without_rdp_payloads() {
+    let input = in_channel(request_pdu(1, 1, &[0u8; 32]));
+    let output = out_channel(response_pdu(1, &[0u8; 16]));
+
+    assert!(matches!(
+        extract_rpch_tunneled_rdp(&input, &output),
+        Err(ReplayError::MissingRdpState)
+    ));
+}


### PR DESCRIPTION
Direct TCP replay cannot recover RDP from a legacy RD Gateway capture because the inner stream is split across RPC_IN_DATA and RPC_OUT_DATA HTTP channels and wrapped in DCE/RPC TsProxy stubs.

After the outer HTTPS sessions are already decrypted from the capture's embedded key log, pair those channels, unwrap the RPC-over-HTTP tunnel into a normal RDP stream, and continue the existing replay pipeline.

A single IN or OUT channel is not a complete tunnel. External key-log files and resumed TLS decrypt remain out of scope.