### PR TITLE
feat(xtask): add fuzz coverage subcommand

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,3 +1,4 @@
 /target
 /artifacts
 /corpus
+/coverage

--- a/xtask/src/cli.rs
+++ b/xtask/src/cli.rs
@@ -32,6 +32,9 @@ TASKS:
   fuzz corpus-min [--target <NAME>]
                           Minify fuzzing corpus for a specific target (or all if unspecified)
   fuzz corpus-push        Push fuzzing corpus to Azure storage
+  fuzz coverage [--target <NAME>]
+                          Run a target (or all targets) against its existing corpus and
+                          print per-file line coverage
   fuzz install            Install dependencies required for fuzzing
   fuzz list [--format <FMT>]
                           List fuzz targets (fmt: human (default) | github-matrix)
@@ -110,6 +113,9 @@ pub enum Action {
         target: Option<String>,
     },
     FuzzCorpusPush,
+    FuzzCoverage {
+        target: Option<String>,
+    },
     FuzzInstall,
     FuzzList {
         format: ListFormat,
@@ -178,6 +184,9 @@ pub fn parse_args() -> anyhow::Result<Args> {
                     target: args.opt_value_from_str("--target")?,
                 },
                 Some("corpus-push") => Action::FuzzCorpusPush,
+                Some("coverage") => Action::FuzzCoverage {
+                    target: args.opt_value_from_str("--target")?,
+                },
                 Some("install") => Action::FuzzInstall,
                 Some("list") => Action::FuzzList {
                     format: args.opt_value_from_str("--format")?.unwrap_or(ListFormat::DEFAULT),

--- a/xtask/src/fuzz.rs
+++ b/xtask/src/fuzz.rs
@@ -96,6 +96,15 @@ pub fn install(sh: &Shell) -> anyhow::Result<()> {
 
     cmd!(sh, "rustup install {NIGHTLY_TOOLCHAIN} --profile=minimal").run()?;
 
+    // Required by `coverage` to merge raw profile data and render a report.
+    // Without it, `cargo fuzz coverage` fails partway through with a missing
+    // llvm-profdata error instead of at install time.
+    cmd!(
+        sh,
+        "rustup component add llvm-tools-preview --toolchain {NIGHTLY_TOOLCHAIN}"
+    )
+    .run()?;
+
     Ok(())
 }
 
@@ -120,6 +129,87 @@ pub fn run(sh: &Shell, duration: Option<u32>, target: Option<String>) -> anyhow:
     }
 
     println!("All good!");
+
+    Ok(())
+}
+
+/// Locate the pinned nightly toolchain's bundled LLVM tools directory
+/// (`llvm-cov`, `llvm-profdata`), installed via the `llvm-tools-preview`
+/// rustup component. Neither `rustup run` nor `PATH` exposes these: `cargo
+/// fuzz coverage` itself locates `llvm-profdata` the same way internally,
+/// by resolving the toolchain's own `rustlib` tree rather than relying on
+/// whatever `llvm-cov` a plain `PATH` lookup might find (which can be an
+/// unrelated system-wide LLVM install with an incompatible profile format).
+fn llvm_tools_bin_dir(sh: &Shell) -> anyhow::Result<std::path::PathBuf> {
+    let libdir = cmd!(sh, "rustc +{NIGHTLY_TOOLCHAIN} --print target-libdir")
+        .read()
+        .context("locate the pinned nightly toolchain's target-libdir")?;
+
+    let bin_dir = std::path::Path::new(libdir.trim())
+        .parent()
+        .context("target-libdir has no parent directory")?
+        .join("bin");
+
+    anyhow::ensure!(
+        bin_dir.join("llvm-cov").is_file(),
+        "llvm-cov not found at {}; run `cargo xtask fuzz install` first",
+        bin_dir.display()
+    );
+
+    Ok(bin_dir)
+}
+
+/// Run each target against its existing corpus (`cargo xtask fuzz corpus-fetch`
+/// first, for a corpus worth reporting on) and print per-file line coverage.
+///
+/// Coverage-guided fuzzing typically plateaus around 12 hours in (Liyanage
+/// et al., ICSE 2023); several targets here have run far longer than that
+/// without any coverage-feedback check. Running a target for hours after
+/// its coverage has stopped growing hides bug-finding opportunity
+/// elsewhere; this surfaces that instead of leaving it implicit.
+///
+/// Only lines with nonzero coverage are printed, since the full report
+/// otherwise lists every source file linked into the fuzz binary, most of
+/// which the target never reaches and are not useful to see.
+pub fn coverage(sh: &Shell, target: Option<String>) -> anyhow::Result<()> {
+    let _s = Section::new("FUZZ-COVERAGE");
+    windows_skip!();
+
+    let _guard = sh.push_dir("./fuzz");
+
+    let targets = match target {
+        Some(value) => vec![value],
+        None => discover_targets()?,
+    };
+
+    let llvm_cov = llvm_tools_bin_dir(sh)?.join("llvm-cov");
+
+    for target in &targets {
+        cmd!(sh, "rustup run {NIGHTLY_TOOLCHAIN} cargo fuzz coverage {target}").run()?;
+
+        let binary = std::path::Path::new("target/x86_64-unknown-linux-gnu/coverage/x86_64-unknown-linux-gnu/release")
+            .join(target);
+        let profdata = format!("coverage/{target}/coverage.profdata");
+
+        let report = cmd!(
+            sh,
+            "{llvm_cov} report {binary} --instr-profile={profdata} --ignore-filename-regex=cargo/registry|/rustc/|\\.cargo/"
+        )
+        .read()
+        .with_context(|| format!("generate coverage report for {target}"))?;
+
+        println!("--- {target} ---");
+        for line in report.lines() {
+            // A fully-untouched file's row carries exactly three "0.00%" columns
+            // (regions, functions, lines; branches shows "-", not a percentage).
+            // Any row with fewer is touched and worth keeping; the header, the
+            // separator, and the TOTAL summary line never contain "0.00%" at
+            // all and are always kept.
+            if line.matches("0.00%").count() < 3 {
+                println!("{line}");
+            }
+        }
+    }
 
     Ok(())
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -108,6 +108,7 @@ fn main() -> anyhow::Result<()> {
         Action::FuzzCorpusFetch => fuzz::corpus_fetch(&sh)?,
         Action::FuzzCorpusMin { target } => fuzz::corpus_minify(&sh, target)?,
         Action::FuzzCorpusPush => fuzz::corpus_push(&sh)?,
+        Action::FuzzCoverage { target } => fuzz::coverage(&sh, target)?,
         Action::FuzzInstall => fuzz::install(&sh)?,
         Action::FuzzList { format } => match format {
             cli::ListFormat::Human => fuzz::list_human()?,


### PR DESCRIPTION
## Summary

- Coverage-guided fuzzing typically plateaus around 12 hours in (Liyanage et
  al., ICSE 2023), and several targets in this workspace have run far longer
  than that without any coverage-feedback check. A target can keep running
  for hours after its coverage stopped growing, hiding bug-finding
  opportunity elsewhere, with nothing surfacing it.
- Adds `cargo xtask fuzz coverage [--target NAME]`: runs a target (or all
  targets, matching `fuzz run`'s existing default) against its existing
  corpus via `cargo fuzz coverage`, then renders a per-file line coverage
  report via the toolchain's own `llvm-cov`, filtered to only files with
  nonzero coverage. Auto-discovers targets via the existing
  `discover_targets()` used by `run`/`list`/`corpus-min`.
- `llvm-cov`/`llvm-profdata` are resolved from the pinned nightly
  toolchain's own `rustlib` tree rather than a plain `PATH` lookup: a `PATH`
  resolution can land on an unrelated system-wide LLVM install with an
  incompatible profile format, which is what happened locally when testing
  this. `cargo fuzz coverage` resolves `llvm-profdata` the same way
  internally, for the same reason.
- Adds the `llvm-tools-preview` rustup component to `fuzz install`, needed
  to merge raw coverage profiles. Without it, `coverage` fails partway
  through with a missing `llvm-profdata` error instead of at install time.
- `fuzz/coverage/` is gitignored alongside the existing `corpus` and
  `artifacts` entries.

## Validation

`cargo xtask check fmt/lints/tests/typos/locks` all pass. Also ran the
subcommand end to end against a seeded `pdu_decoding` corpus: correctly
narrowed the full linked-binary report from ~60 source files down to the 49
the target actually touches.

## Notes

Pure additive, no existing subcommand changes. The compiled fuzz binary's
path assumes the `x86_64-unknown-linux-gnu` target triple, matching `cargo
fuzz coverage`'s own documented default rather than introducing a new
limitation.
