### PR TITLE
feat(server): expose measured bandwidth to the embedder

### DIFF
--- a/crates/ironrdp-server/src/autodetect.rs
+++ b/crates/ironrdp-server/src/autodetect.rs
@@ -325,6 +325,17 @@ impl AutoDetectManager {
         self.pending_probes.len()
     }
 
+    /// Most recently measured bandwidth in kilobits per second, or `None` if
+    /// no bandwidth measurement has completed yet. Unlike
+    /// [`Self::build_netchar_result`], this is not gated on freshness or
+    /// pacing: it reports the last completed figure even if a subsequent
+    /// failed measurement or an idle client has left it unrefreshed for a
+    /// while, the same relationship [`Self::snapshot`] has to RTT. Staleness
+    /// is the caller's to judge.
+    pub fn bandwidth_kbps(&self) -> Option<u32> {
+        self.bandwidth_kbps
+    }
+
     /// Discard probes older than `max_age_ms` to prevent unbounded growth.
     ///
     /// `now_ms` is on the same clock passed to

--- a/crates/ironrdp-server/src/autodetect.rs
+++ b/crates/ironrdp-server/src/autodetect.rs
@@ -95,6 +95,20 @@ pub struct AutoDetectManager {
     bandwidth_is_fresh: bool,
 }
 
+/// Result of [`AutoDetectManager::handle_response()`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AutoDetectOutcome {
+    /// An RTT Measure Response matched a pending probe; carries the measured RTT
+    /// in milliseconds.
+    Rtt(u32),
+    /// A Bandwidth Measure Results matched the pending transaction. `None` means
+    /// the measurement completed without a usable figure, and any previously
+    /// stored bandwidth was cleared rather than left in place.
+    Bandwidth(Option<u32>),
+    /// The response did not match any pending probe or transaction.
+    Unmatched,
+}
+
 /// State of an in-flight continuous bandwidth measurement.
 enum PendingBandwidth {
     /// Start has been sent; the window stays open for this many more ticks
@@ -240,17 +254,23 @@ impl AutoDetectManager {
 
     /// Process an Auto-Detect Response from the client.
     ///
-    /// For an RTT Measure Response, records the sample and returns the measured
-    /// RTT in milliseconds. For a Bandwidth Measure Results, records the
-    /// computed bandwidth internally and returns `None`. Returns `None` for an
-    /// unexpected or unmatched response.
+    /// For an RTT Measure Response, records the sample and returns
+    /// [`AutoDetectOutcome::Rtt`] with the measured RTT in milliseconds. For a
+    /// Bandwidth Measure Results, records the computed bandwidth internally and
+    /// returns [`AutoDetectOutcome::Bandwidth`]; its payload is `None` when the
+    /// measurement completed without a usable figure, in which case any
+    /// previously stored bandwidth was just cleared (see the note on
+    /// [`build_netchar_result()`](Self::build_netchar_result)). Returns
+    /// [`AutoDetectOutcome::Unmatched`] for an unexpected or unmatched response.
     ///
     /// `now_ms` is the receipt time on the same clock passed to
     /// [`send_rtt_request()`](Self::send_rtt_request).
-    pub fn handle_response(&mut self, response: &AutoDetectResponse, now_ms: u64) -> Option<u32> {
+    pub fn handle_response(&mut self, response: &AutoDetectResponse, now_ms: u64) -> AutoDetectOutcome {
         match response {
             AutoDetectResponse::RttResponse { sequence_number } => {
-                let idx = self.pending_probes.iter().position(|(s, _)| *s == *sequence_number)?;
+                let Some(idx) = self.pending_probes.iter().position(|(s, _)| *s == *sequence_number) else {
+                    return AutoDetectOutcome::Unmatched;
+                };
                 let (_, sent_at_ms) = self.pending_probes.remove(idx);
 
                 // Saturating rather than wrapping: a caller whose clock went backwards gets
@@ -264,27 +284,28 @@ impl AutoDetectManager {
                 self.min_rtt_ms = Some(self.min_rtt_ms.map_or(rtt_ms, |m| m.min(rtt_ms)));
                 self.rtt_is_fresh = true;
 
-                Some(rtt_ms)
+                AutoDetectOutcome::Rtt(rtt_ms)
             }
             AutoDetectResponse::BandwidthMeasureResults { sequence_number, .. } => {
                 let awaiting = matches!(
                     self.pending_bw,
                     Some(PendingBandwidth::AwaitingResults { sequence }) if sequence == *sequence_number
                 );
-                if awaiting {
-                    self.pending_bw = None;
-                    // A transaction that completes without a usable figure clears the
-                    // previous one rather than leaving it in place, so a run of failures
-                    // withholds the result (see `build_netchar_result`) instead of
-                    // reporting an increasingly stale bandwidth.
-                    self.bandwidth_kbps = response.computed_bandwidth_kbps();
-                    if self.bandwidth_kbps.is_some() {
-                        self.bandwidth_is_fresh = true;
-                    }
+                if !awaiting {
+                    return AutoDetectOutcome::Unmatched;
                 }
-                None
+                self.pending_bw = None;
+                // A transaction that completes without a usable figure clears the
+                // previous one rather than leaving it in place, so a run of failures
+                // withholds the result (see `build_netchar_result`) instead of
+                // reporting an increasingly stale bandwidth.
+                self.bandwidth_kbps = response.computed_bandwidth_kbps();
+                if self.bandwidth_kbps.is_some() {
+                    self.bandwidth_is_fresh = true;
+                }
+                AutoDetectOutcome::Bandwidth(self.bandwidth_kbps)
             }
-            _ => None,
+            _ => AutoDetectOutcome::Unmatched,
         }
     }
 

--- a/crates/ironrdp-server/src/builder.rs
+++ b/crates/ironrdp-server/src/builder.rs
@@ -53,6 +53,7 @@ pub struct BuilderDone {
     display_suppressed: Option<Arc<AtomicBool>>,
     autodetect_rtt: Option<Arc<AtomicU32>>,
     autodetect_baseline_rtt: Option<Arc<AtomicU32>>,
+    autodetect_bandwidth: Option<Arc<AtomicU32>>,
     honor_client_desktop_size: Option<DesktopSize>,
     auto_reconnect_cookie: Option<ServerAutoReconnect>,
     remotefx_quant: Quant,
@@ -162,6 +163,7 @@ impl RdpServerBuilder<WantsDisplay> {
                 display_suppressed: None,
                 autodetect_rtt: None,
                 autodetect_baseline_rtt: None,
+                autodetect_bandwidth: None,
                 honor_client_desktop_size: None,
                 auto_reconnect_cookie: None,
                 remotefx_quant: Quant::default(),
@@ -192,6 +194,7 @@ impl RdpServerBuilder<WantsDisplay> {
                 display_suppressed: None,
                 autodetect_rtt: None,
                 autodetect_baseline_rtt: None,
+                autodetect_bandwidth: None,
                 honor_client_desktop_size: None,
                 auto_reconnect_cookie: None,
                 remotefx_quant: Quant::default(),
@@ -363,6 +366,18 @@ impl RdpServerBuilder<BuilderDone> {
         self
     }
 
+    /// Inject a shared NetworkAutoDetect bandwidth handle (kilobits per
+    /// second, `u32::MAX` until the first measurement completes). The server
+    /// writes the latest measured bandwidth to the same instance the backend
+    /// reads. When not called, the server allocates its own (still readable
+    /// via [`RdpServer::autodetect_bandwidth_handle`]). The value stays
+    /// `u32::MAX` unless auto-detect is enabled via
+    /// [`RdpServer::enable_autodetect`].
+    pub fn with_autodetect_bandwidth_handle(mut self, handle: Arc<AtomicU32>) -> Self {
+        self.state.autodetect_bandwidth = Some(handle);
+        self
+    }
+
     /// Provision the Server Auto-Reconnect Cookie (MS-RDPBCGR 2.2.4.2
     /// `ARC_SC_PRIVATE_PACKET`) handed to the client during logon.
     ///
@@ -434,6 +449,7 @@ impl RdpServerBuilder<BuilderDone> {
             self.state.usb_factory,
             self.state.autodetect_rtt,
             self.state.autodetect_baseline_rtt,
+            self.state.autodetect_bandwidth,
         );
         server.set_credential_validator(self.state.credential_validator);
         server.set_auto_reconnect_cookie(self.state.auto_reconnect_cookie);

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -630,6 +630,16 @@ pub struct RdpServer {
     /// [`Self::autodetect_baseline_rtt_handle`].
     autodetect_baseline_rtt: Arc<AtomicU32>,
 
+    /// Latest NetworkAutoDetect measured bandwidth in kilobits per second, or
+    /// `u32::MAX` until the first measurement completes (and while auto-detect
+    /// is disabled). Updated whenever a Bandwidth Measure Results response is
+    /// processed, same trigger point as [`Self::autodetect_rtt`]. Exposed via
+    /// [`Self::autodetect_bandwidth_handle`]: without it, the server can tell
+    /// the *client* its measured bandwidth over the wire but has no way to
+    /// tell the embedder, which the connect-time figure carried to the client
+    /// alone does not fix.
+    autodetect_bandwidth: Arc<AtomicU32>,
+
     /// Optional Server Auto-Reconnect Cookie (MS-RDPBCGR 2.2.4.2
     /// `ARC_SC_PRIVATE_PACKET`). When `Some`, the server validates a returning
     /// `ARC_CS_PRIVATE_PACKET`, replaces its random after every connection, and
@@ -754,6 +764,7 @@ impl RdpServer {
         #[cfg(feature = "usb")] usb_factory: Option<Box<dyn DeviceFactory>>,
         autodetect_rtt: Option<Arc<AtomicU32>>,
         autodetect_baseline_rtt: Option<Arc<AtomicU32>>,
+        autodetect_bandwidth: Option<Arc<AtomicU32>>,
     ) -> Self {
         let (ev_sender, ev_receiver) = ServerEvent::create_channel();
         if let Some(cliprdr) = cliprdr_factory.as_mut() {
@@ -802,6 +813,11 @@ impl RdpServer {
             },
             autodetect_baseline_rtt: {
                 let handle = autodetect_baseline_rtt.unwrap_or_else(|| Arc::new(AtomicU32::new(u32::MAX)));
+                handle.store(u32::MAX, Ordering::Relaxed);
+                handle
+            },
+            autodetect_bandwidth: {
+                let handle = autodetect_bandwidth.unwrap_or_else(|| Arc::new(AtomicU32::new(u32::MAX)));
                 handle.store(u32::MAX, Ordering::Relaxed);
                 handle
             },
@@ -1081,6 +1097,17 @@ impl RdpServer {
     /// [`RdpServerBuilder::with_autodetect_baseline_rtt_handle`](crate::RdpServerBuilder::with_autodetect_baseline_rtt_handle).
     pub fn autodetect_baseline_rtt_handle(&self) -> Arc<AtomicU32> {
         Arc::clone(&self.autodetect_baseline_rtt)
+    }
+
+    /// Returns a handle to the latest NetworkAutoDetect measured bandwidth in
+    /// kilobits per second (`u32::MAX` until the first measurement completes,
+    /// and while auto-detect is disabled). The server updates it whenever a
+    /// Bandwidth Measure Results response completes a measurement; backends
+    /// clone the handle to read the figure the server also reports to the
+    /// client on the wire. Inject a shared instance at construction with
+    /// [`RdpServerBuilder::with_autodetect_bandwidth_handle`](crate::RdpServerBuilder::with_autodetect_bandwidth_handle).
+    pub fn autodetect_bandwidth_handle(&self) -> Arc<AtomicU32> {
+        Arc::clone(&self.autodetect_bandwidth)
     }
 
     /// Returns the shared ECHO server handle for runtime probe requests and RTT measurements.
@@ -2408,23 +2435,45 @@ impl RdpServer {
         match decode::<rdp::autodetect::AutoDetectRspPdu>(data.user_data.as_ref()) {
             Ok(pdu) => {
                 if let Some(ref mut ad) = self.autodetect {
-                    if let Some(rtt_ms) = ad.handle_response(&pdu.response, monotonic_now_ms()) {
-                        self.autodetect_rtt.store(rtt_ms, Ordering::Relaxed);
-                        // A matched RTT sample always updates the session-lifetime low in the
-                        // same call (see `handle_response`'s RttResponse arm), so it is available
-                        // unconditionally here, not just on a new low.
-                        let baseline_rtt_ms = ad
-                            .baseline_rtt_ms()
-                            .expect("handle_response just recorded a sample above");
-                        self.autodetect_baseline_rtt.store(baseline_rtt_ms, Ordering::Relaxed);
-                        debug!(
-                            rtt_ms,
-                            baseline_rtt_ms,
-                            seq = pdu.response.sequence_number(),
-                            "RTT measured"
-                        );
-                    } else {
-                        trace!(seq = pdu.response.sequence_number(), "Unmatched auto-detect response");
+                    // `handle_response` reports a matched RTT sample via its return value but
+                    // only updates bandwidth internally (see its own doc comment), so a fresh
+                    // bandwidth figure is detected by comparing before and after rather than
+                    // from the call's result. That also keeps a stray or unmatched bandwidth
+                    // response (which leaves the internal value unchanged) from being
+                    // mislabeled as a new measurement below.
+                    let bandwidth_before = ad.bandwidth_kbps();
+                    let rtt_result = ad.handle_response(&pdu.response, monotonic_now_ms());
+                    let bandwidth_after = ad.bandwidth_kbps();
+
+                    match rtt_result {
+                        Some(rtt_ms) => {
+                            self.autodetect_rtt.store(rtt_ms, Ordering::Relaxed);
+                            // A matched RTT sample always updates the session-lifetime low in the
+                            // same call (see `handle_response`'s RttResponse arm), so it is available
+                            // unconditionally here, not just on a new low.
+                            let baseline_rtt_ms = ad
+                                .baseline_rtt_ms()
+                                .expect("handle_response just recorded a sample above");
+                            self.autodetect_baseline_rtt.store(baseline_rtt_ms, Ordering::Relaxed);
+                            debug!(
+                                rtt_ms,
+                                baseline_rtt_ms,
+                                seq = pdu.response.sequence_number(),
+                                "RTT measured"
+                            );
+                        }
+                        None if bandwidth_after.is_some() && bandwidth_after != bandwidth_before => {
+                            let bandwidth_kbps = bandwidth_after.expect("checked Some above");
+                            self.autodetect_bandwidth.store(bandwidth_kbps, Ordering::Relaxed);
+                            debug!(
+                                bandwidth_kbps,
+                                seq = pdu.response.sequence_number(),
+                                "Bandwidth measured"
+                            );
+                        }
+                        None => {
+                            trace!(seq = pdu.response.sequence_number(), "Unmatched auto-detect response");
+                        }
                     }
                 }
             }

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -46,7 +46,7 @@ use tokio::task;
 use tokio_rustls::TlsAcceptor;
 use tracing::{debug, error, trace, warn};
 
-use crate::autodetect::{AutoDetectManager, RttSnapshot};
+use crate::autodetect::{AutoDetectManager, AutoDetectOutcome, RttSnapshot};
 use crate::clipboard::CliprdrServerFactory;
 use crate::display::{DisplayUpdate, RdpServerDisplay};
 use crate::echo::{EchoDvcBridge, EchoServerHandle, EchoServerMessage, build_echo_request};
@@ -2435,18 +2435,8 @@ impl RdpServer {
         match decode::<rdp::autodetect::AutoDetectRspPdu>(data.user_data.as_ref()) {
             Ok(pdu) => {
                 if let Some(ref mut ad) = self.autodetect {
-                    // `handle_response` reports a matched RTT sample via its return value but
-                    // only updates bandwidth internally (see its own doc comment), so a fresh
-                    // bandwidth figure is detected by comparing before and after rather than
-                    // from the call's result. That also keeps a stray or unmatched bandwidth
-                    // response (which leaves the internal value unchanged) from being
-                    // mislabeled as a new measurement below.
-                    let bandwidth_before = ad.bandwidth_kbps();
-                    let rtt_result = ad.handle_response(&pdu.response, monotonic_now_ms());
-                    let bandwidth_after = ad.bandwidth_kbps();
-
-                    match rtt_result {
-                        Some(rtt_ms) => {
+                    match ad.handle_response(&pdu.response, monotonic_now_ms()) {
+                        AutoDetectOutcome::Rtt(rtt_ms) => {
                             self.autodetect_rtt.store(rtt_ms, Ordering::Relaxed);
                             // A matched RTT sample always updates the session-lifetime low in the
                             // same call (see `handle_response`'s RttResponse arm), so it is available
@@ -2462,8 +2452,7 @@ impl RdpServer {
                                 "RTT measured"
                             );
                         }
-                        None if bandwidth_after.is_some() && bandwidth_after != bandwidth_before => {
-                            let bandwidth_kbps = bandwidth_after.expect("checked Some above");
+                        AutoDetectOutcome::Bandwidth(Some(bandwidth_kbps)) => {
                             self.autodetect_bandwidth.store(bandwidth_kbps, Ordering::Relaxed);
                             debug!(
                                 bandwidth_kbps,
@@ -2471,7 +2460,17 @@ impl RdpServer {
                                 "Bandwidth measured"
                             );
                         }
-                        None => {
+                        AutoDetectOutcome::Bandwidth(None) => {
+                            // The manager just cleared its own figure rather than keep
+                            // reporting a stale one (see `handle_response`'s doc comment);
+                            // mirror that here so the exposed handle does not disagree.
+                            self.autodetect_bandwidth.store(u32::MAX, Ordering::Relaxed);
+                            trace!(
+                                seq = pdu.response.sequence_number(),
+                                "Bandwidth measurement completed without a usable figure"
+                            );
+                        }
+                        AutoDetectOutcome::Unmatched => {
                             trace!(seq = pdu.response.sequence_number(), "Unmatched auto-detect response");
                         }
                     }

--- a/crates/ironrdp-testsuite-core/tests/server/autodetect.rs
+++ b/crates/ironrdp-testsuite-core/tests/server/autodetect.rs
@@ -1,5 +1,5 @@
 use ironrdp_pdu::rdp::autodetect::{AutoDetectRequest, AutoDetectResponse};
-use ironrdp_server::autodetect::AutoDetectManager;
+use ironrdp_server::autodetect::{AutoDetectManager, AutoDetectOutcome};
 
 /// Upper bound on ticks to drive while waiting for a bandwidth transaction:
 /// generous enough to cover the pacing plus the window, tight enough that a
@@ -57,7 +57,7 @@ fn rtt_response_returns_latency() {
     };
     // Both timestamps come from the caller, so the measurement is exact rather than
     // dependent on how fast the test happens to run.
-    assert_eq!(mgr.handle_response(&response, 20), Some(20));
+    assert_eq!(mgr.handle_response(&response, 20), AutoDetectOutcome::Rtt(20));
     assert_eq!(mgr.pending_count(), 0);
 }
 
@@ -67,7 +67,7 @@ fn unknown_sequence_returns_none() {
     let _ = mgr.send_rtt_request(0);
 
     let response = AutoDetectResponse::RttResponse { sequence_number: 999 };
-    assert!(mgr.handle_response(&response, 20).is_none());
+    assert_eq!(mgr.handle_response(&response, 20), AutoDetectOutcome::Unmatched);
     assert_eq!(mgr.pending_count(), 1, "original probe should remain");
 }
 
@@ -107,7 +107,7 @@ fn backwards_clock_yields_a_zero_sample() {
     let response = AutoDetectResponse::RttResponse {
         sequence_number: req.sequence_number(),
     };
-    assert_eq!(mgr.handle_response(&response, 400), Some(0));
+    assert_eq!(mgr.handle_response(&response, 400), AutoDetectOutcome::Rtt(0));
 
     // The zero has to reach the window, not just the return value, since the
     // snapshot is what the peer eventually sees.
@@ -140,7 +140,10 @@ fn an_enormous_gap_clamps_to_u32_max() {
     let response = AutoDetectResponse::RttResponse {
         sequence_number: req.sequence_number(),
     };
-    assert_eq!(mgr.handle_response(&response, u64::from(u32::MAX) + 1), Some(u32::MAX));
+    assert_eq!(
+        mgr.handle_response(&response, u64::from(u32::MAX) + 1),
+        AutoDetectOutcome::Rtt(u32::MAX)
+    );
 }
 
 #[test]
@@ -189,7 +192,10 @@ fn bandwidth_measure_transacts_and_enables_netchar() {
         time_delta_ms: 10,
         byte_count: 100_000,
     };
-    assert!(mgr.handle_response(&results, 20).is_none());
+    assert_eq!(
+        mgr.handle_response(&results, 20),
+        AutoDetectOutcome::Bandwidth(Some(80_000))
+    );
 
     match mgr
         .build_netchar_result(20)
@@ -214,7 +220,10 @@ fn bandwidth_kbps_reflects_the_last_completed_measurement() {
         time_delta_ms: 10,
         byte_count: 100_000,
     };
-    assert!(mgr.handle_response(&results, 20).is_none());
+    assert_eq!(
+        mgr.handle_response(&results, 20),
+        AutoDetectOutcome::Bandwidth(Some(80_000))
+    );
 
     assert_eq!(mgr.bandwidth_kbps(), Some(80_000), "byte_count * 8 / time_delta_ms");
 }
@@ -261,7 +270,7 @@ fn mismatched_bandwidth_sequence_is_ignored() {
         time_delta_ms: 10,
         byte_count: 100_000,
     };
-    assert!(mgr.handle_response(&mismatched, 20).is_none());
+    assert_eq!(mgr.handle_response(&mismatched, 20), AutoDetectOutcome::Unmatched);
     assert!(
         mgr.build_netchar_result(1_000).is_none(),
         "a mismatched reply must not have recorded a bandwidth figure"
@@ -277,7 +286,10 @@ fn mismatched_bandwidth_sequence_is_ignored() {
         time_delta_ms: 10,
         byte_count: 100_000,
     };
-    assert!(mgr.handle_response(&matching, 20).is_none());
+    assert_eq!(
+        mgr.handle_response(&matching, 20),
+        AutoDetectOutcome::Bandwidth(Some(80_000))
+    );
     assert!(
         mgr.build_netchar_result(1_000).is_some(),
         "the outstanding transaction's own reply must still complete it"
@@ -307,7 +319,10 @@ fn zero_time_delta_ages_out_a_previous_bandwidth_figure() {
         time_delta_ms: 10,
         byte_count: 100_000,
     };
-    assert!(mgr.handle_response(&good_results, 20).is_none());
+    assert_eq!(
+        mgr.handle_response(&good_results, 20),
+        AutoDetectOutcome::Bandwidth(Some(80_000))
+    );
     assert!(
         mgr.build_netchar_result(1_000).is_some(),
         "a real bandwidth figure is known"
@@ -328,7 +343,14 @@ fn zero_time_delta_ages_out_a_previous_bandwidth_figure() {
         time_delta_ms: 0,
         byte_count: 100_000,
     };
-    assert!(mgr.handle_response(&zero_delta_results, 1_020).is_none());
+    // Matched (it completes the outstanding transaction), but unusable: distinct from
+    // an unmatched reply, and distinct from `Bandwidth(Some(_))`. A caller collapsing
+    // this into "no measurement happened" would miss that the manager just cleared its
+    // own figure right here.
+    assert_eq!(
+        mgr.handle_response(&zero_delta_results, 1_020),
+        AutoDetectOutcome::Bandwidth(None)
+    );
 
     // The RTT sample is fresh, but the old bandwidth figure must not ride
     // along as though it were still current.
@@ -336,6 +358,38 @@ fn zero_time_delta_ages_out_a_previous_bandwidth_figure() {
         mgr.build_netchar_result(2_000).is_none(),
         "the aged-out bandwidth figure must withhold the result, not report the stale one"
     );
+}
+
+/// Two consecutive measurements landing on the identical kbps figure (plausible on a
+/// stable link) must both be reported as a match. A caller that derives "did this
+/// complete a measurement" from comparing the value before and after the call, rather
+/// than from `handle_response`'s own return value, would see no change on the second
+/// one and misclassify a real match as unmatched.
+#[test]
+fn identical_consecutive_bandwidth_measurements_are_both_reported_as_matched() {
+    let mut mgr = AutoDetectManager::new();
+    let req = mgr.send_rtt_request(0);
+    let _ = mgr.handle_response(
+        &AutoDetectResponse::RttResponse {
+            sequence_number: req.sequence_number(),
+        },
+        20,
+    );
+
+    for now_ms in [20u64, 1_020] {
+        let bw_seq = drive_bandwidth_start_and_stop(&mut mgr);
+        let results = AutoDetectResponse::BandwidthMeasureResults {
+            sequence_number: bw_seq,
+            response_type: ironrdp_pdu::rdp::autodetect::BW_RESULTS_CONTINUOUS,
+            time_delta_ms: 10,
+            byte_count: 100_000,
+        };
+        assert_eq!(
+            mgr.handle_response(&results, now_ms),
+            AutoDetectOutcome::Bandwidth(Some(80_000)),
+            "the same kbps figure twice in a row is still a match, not a repeat of nothing"
+        );
+    }
 }
 
 #[test]
@@ -525,7 +579,10 @@ fn netchar_result_is_paced_independently_of_the_probe_cadence() {
         time_delta_ms: 10,
         byte_count: 100_000,
     };
-    assert!(mgr.handle_response(&results, 20).is_none());
+    assert_eq!(
+        mgr.handle_response(&results, 20),
+        AutoDetectOutcome::Bandwidth(Some(80_000))
+    );
 
     assert!(mgr.build_netchar_result(1_000).is_some(), "the first one is due");
 
@@ -570,7 +627,10 @@ fn netchar_result_stops_when_the_client_stops_answering() {
         time_delta_ms: 10,
         byte_count: 100_000,
     };
-    assert!(mgr.handle_response(&results, 20).is_none());
+    assert_eq!(
+        mgr.handle_response(&results, 20),
+        AutoDetectOutcome::Bandwidth(Some(80_000))
+    );
 
     let mut now = 1_000;
     assert!(mgr.build_netchar_result(now).is_some(), "the first one is due");
@@ -637,7 +697,10 @@ fn base_rtt_is_the_session_low_not_the_window_low() {
         time_delta_ms: 10,
         byte_count: 100_000,
     };
-    assert!(mgr.handle_response(&results, 20).is_none());
+    assert_eq!(
+        mgr.handle_response(&results, 20),
+        AutoDetectOutcome::Bandwidth(Some(80_000))
+    );
 
     match mgr.build_netchar_result(1_000).expect("RTT and bandwidth are known") {
         AutoDetectRequest::NetworkCharacteristicsResult { base_rtt_ms, .. } => {
@@ -718,7 +781,10 @@ fn netchar_result_maps_each_measurement_to_its_own_field() {
         time_delta_ms: 10,
         byte_count: 100_000,
     };
-    assert!(mgr.handle_response(&results, 20).is_none());
+    assert_eq!(
+        mgr.handle_response(&results, 20),
+        AutoDetectOutcome::Bandwidth(Some(80_000))
+    );
 
     match mgr.build_netchar_result(1_000).expect("RTT and bandwidth are known") {
         AutoDetectRequest::NetworkCharacteristicsResult {

--- a/crates/ironrdp-testsuite-core/tests/server/autodetect.rs
+++ b/crates/ironrdp-testsuite-core/tests/server/autodetect.rs
@@ -202,6 +202,23 @@ fn bandwidth_measure_transacts_and_enables_netchar() {
     }
 }
 
+#[test]
+fn bandwidth_kbps_reflects_the_last_completed_measurement() {
+    let mut mgr = AutoDetectManager::new();
+    assert!(mgr.bandwidth_kbps().is_none(), "nothing measured yet");
+
+    let bw_seq = drive_bandwidth_start_and_stop(&mut mgr);
+    let results = AutoDetectResponse::BandwidthMeasureResults {
+        sequence_number: bw_seq,
+        response_type: ironrdp_pdu::rdp::autodetect::BW_RESULTS_CONTINUOUS,
+        time_delta_ms: 10,
+        byte_count: 100_000,
+    };
+    assert!(mgr.handle_response(&results, 20).is_none());
+
+    assert_eq!(mgr.bandwidth_kbps(), Some(80_000), "byte_count * 8 / time_delta_ms");
+}
+
 /// A second call to `build_bandwidth_measure` after Stop has been sent, while
 /// the client's Bandwidth Measure Results is still outstanding, must not
 /// start a new transaction. `drive_bandwidth_start_and_stop` already pins
@@ -428,6 +445,48 @@ fn with_autodetect_baseline_rtt_handle_round_trips_the_same_arc() {
     // The Arc is shared: mutating the original is visible through the server's handle.
     handle.store(42, Ordering::Relaxed);
     assert_eq!(server.autodetect_baseline_rtt_handle().load(Ordering::Relaxed), 42);
+}
+
+#[test]
+fn autodetect_bandwidth_handle_defaults_to_sentinel() {
+    use core::net::{Ipv4Addr, SocketAddr};
+    use core::sync::atomic::Ordering;
+
+    use ironrdp_server::RdpServer;
+
+    let server = RdpServer::builder()
+        .with_addr(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+        .with_no_security()
+        .with_no_input()
+        .with_no_display()
+        .build();
+
+    assert_eq!(server.autodetect_bandwidth_handle().load(Ordering::Relaxed), u32::MAX);
+}
+
+#[test]
+fn with_autodetect_bandwidth_handle_round_trips_the_same_arc() {
+    use core::net::{Ipv4Addr, SocketAddr};
+    use core::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+
+    use ironrdp_server::RdpServer;
+
+    let handle = Arc::new(AtomicU32::new(42));
+    let server = RdpServer::builder()
+        .with_addr(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+        .with_no_security()
+        .with_no_input()
+        .with_no_display()
+        .with_autodetect_bandwidth_handle(Arc::clone(&handle))
+        .build();
+
+    assert!(Arc::ptr_eq(&handle, &server.autodetect_bandwidth_handle()));
+    // The server resets an injected handle to the sentinel at construction.
+    assert_eq!(server.autodetect_bandwidth_handle().load(Ordering::Relaxed), u32::MAX);
+    // The Arc is shared: mutating the original is visible through the server's handle.
+    handle.store(42, Ordering::Relaxed);
+    assert_eq!(server.autodetect_bandwidth_handle().load(Ordering::Relaxed), 42);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- After #1470/#1471, the server can tell the client its measured
  bandwidth over the wire (Network Characteristics Result), but nothing
  exposes that figure outside the crate: `snapshot()` returns
  `RttSnapshot` (min/max/avg/sample_count only) and
  `autodetect_rtt_handle()` carries RTT alone. An embedder's own
  health or flow-control layer that wants the same bandwidth figure
  the client already received has no way to read it.
- Mirrors the existing `autodetect_rtt_handle` shape exactly: a new
  `autodetect_bandwidth` `Arc<AtomicU32>` field (`u32::MAX` sentinel
  until the first measurement, matching `autodetect_rtt`), an
  `autodetect_bandwidth_handle()` accessor, and a
  `with_autodetect_bandwidth_handle()` builder method for injecting a
  shared instance. Adds `AutoDetectManager::bandwidth_kbps()` as the
  underlying getter; the field already existed internally with no
  public accessor.
- The store site needed a before/after comparison rather than a plain
  `else` branch on `handle_response`'s result: that function reports a
  matched RTT sample through its return value but only updates
  bandwidth internally, so a naive `else` would also fire, and
  mislabel the store as a fresh bandwidth measurement, on any
  unmatched or stray RTT response once a bandwidth figure had been
  recorded at least once. Comparing `bandwidth_kbps()` before and
  after the call only stores and logs when a measurement genuinely
  completed.
- Adds three tests to the existing autodetect test file, mirroring the
  RTT-handle tests already there: `bandwidth_kbps()` reflecting a
  completed measurement, the handle's sentinel default, and the
  injected-handle round trip.

## Validation

`cargo xtask check fmt/lints/tests/typos/locks` all pass, including the
3 new tests (22/22 passing in `server::autodetect`).

## Notes

No public API break: `RdpServer::new` is crate-private, and the public
surface (`RdpServerBuilder`) only gains an additive optional field and a
new method.
