### PR TITLE
feat(server): expose session-lifetime baseline RTT to the embedder

### DIFF
--- a/crates/ironrdp-server/src/autodetect.rs
+++ b/crates/ironrdp-server/src/autodetect.rs
@@ -312,6 +312,14 @@ impl AutoDetectManager {
         })
     }
 
+    /// Session-lifetime lowest RTT in milliseconds (`baseRTT` per
+    /// [MS-RDPBCGR] 2.2.14.1.5), or `None` if no measurement has landed yet.
+    /// Unlike [`Self::snapshot`]'s `min_ms`, this never rises as samples age
+    /// out of the window: it is the floor over the whole session.
+    pub fn baseline_rtt_ms(&self) -> Option<u32> {
+        self.min_rtt_ms
+    }
+
     /// Number of outstanding probes awaiting response.
     pub fn pending_count(&self) -> usize {
         self.pending_probes.len()

--- a/crates/ironrdp-server/src/builder.rs
+++ b/crates/ironrdp-server/src/builder.rs
@@ -47,6 +47,7 @@ pub struct BuilderDone {
     gfx_factory: Option<Box<dyn GfxServerFactory>>,
     display_suppressed: Option<Arc<AtomicBool>>,
     autodetect_rtt: Option<Arc<AtomicU32>>,
+    autodetect_baseline_rtt: Option<Arc<AtomicU32>>,
     honor_client_desktop_size: Option<DesktopSize>,
     auto_reconnect_cookie: Option<ServerAutoReconnect>,
     remotefx_quant: Quant,
@@ -152,6 +153,7 @@ impl RdpServerBuilder<WantsDisplay> {
                 gfx_factory: None,
                 display_suppressed: None,
                 autodetect_rtt: None,
+                autodetect_baseline_rtt: None,
                 honor_client_desktop_size: None,
                 auto_reconnect_cookie: None,
                 remotefx_quant: Quant::default(),
@@ -178,6 +180,7 @@ impl RdpServerBuilder<WantsDisplay> {
                 gfx_factory: None,
                 display_suppressed: None,
                 autodetect_rtt: None,
+                autodetect_baseline_rtt: None,
                 honor_client_desktop_size: None,
                 auto_reconnect_cookie: None,
                 remotefx_quant: Quant::default(),
@@ -323,6 +326,20 @@ impl RdpServerBuilder<BuilderDone> {
         self
     }
 
+    /// Inject a shared session-lifetime baseline RTT handle (milliseconds,
+    /// `u32::MAX` until the first measurement; see
+    /// [`RdpServer::autodetect_baseline_rtt_handle`] for what distinguishes
+    /// this from [`Self::with_autodetect_rtt_handle`]). The server writes the
+    /// latest baseline to the same instance the backend reads. When not
+    /// called, the server allocates its own (still readable via
+    /// [`RdpServer::autodetect_baseline_rtt_handle`]). The value stays
+    /// `u32::MAX` unless auto-detect is enabled via
+    /// [`RdpServer::enable_autodetect`].
+    pub fn with_autodetect_baseline_rtt_handle(mut self, handle: Arc<AtomicU32>) -> Self {
+        self.state.autodetect_baseline_rtt = Some(handle);
+        self
+    }
+
     /// Provision the Server Auto-Reconnect Cookie (MS-RDPBCGR 2.2.4.2
     /// `ARC_SC_PRIVATE_PACKET`) handed to the client during logon.
     ///
@@ -390,6 +407,7 @@ impl RdpServerBuilder<BuilderDone> {
             self.state.gfx_factory,
             self.state.display_suppressed,
             self.state.autodetect_rtt,
+            self.state.autodetect_baseline_rtt,
         );
         server.set_credential_validator(self.state.credential_validator);
         server.set_auto_reconnect_cookie(self.state.auto_reconnect_cookie);

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -576,6 +576,16 @@ pub struct RdpServer {
     /// RTT for flow control.
     autodetect_rtt: Arc<AtomicU32>,
 
+    /// Session-lifetime lowest RTT in milliseconds (`baseRTT` per MS-RDPBCGR
+    /// 2.2.14.1.5), or `u32::MAX` until the first measurement. Unlike
+    /// [`Self::autodetect_rtt`], this never rises: it is the floor over the
+    /// whole session, not a sliding-window figure, which is what makes
+    /// `averageRTT - baseRTT` a queueing-delay signal rather than two
+    /// unrelated latency numbers. Updated at the same point as
+    /// [`Self::autodetect_rtt`]. Exposed via
+    /// [`Self::autodetect_baseline_rtt_handle`].
+    autodetect_baseline_rtt: Arc<AtomicU32>,
+
     /// Optional Server Auto-Reconnect Cookie (MS-RDPBCGR 2.2.4.2
     /// `ARC_SC_PRIVATE_PACKET`). When `Some`, the server validates a returning
     /// `ARC_CS_PRIVATE_PACKET`, replaces its random after every connection, and
@@ -693,6 +703,7 @@ impl RdpServer {
         #[cfg(feature = "egfx")] mut gfx_factory: Option<Box<dyn GfxServerFactory>>,
         display_suppressed: Option<Arc<AtomicBool>>,
         autodetect_rtt: Option<Arc<AtomicU32>>,
+        autodetect_baseline_rtt: Option<Arc<AtomicU32>>,
     ) -> Self {
         let (ev_sender, ev_receiver) = ServerEvent::create_channel();
         if let Some(cliprdr) = cliprdr_factory.as_mut() {
@@ -729,6 +740,11 @@ impl RdpServer {
             autodetect_rtt: {
                 // Reset to the sentinel: an injected handle must not expose a stale value before the first measurement.
                 let handle = autodetect_rtt.unwrap_or_else(|| Arc::new(AtomicU32::new(u32::MAX)));
+                handle.store(u32::MAX, Ordering::Relaxed);
+                handle
+            },
+            autodetect_baseline_rtt: {
+                let handle = autodetect_baseline_rtt.unwrap_or_else(|| Arc::new(AtomicU32::new(u32::MAX)));
                 handle.store(u32::MAX, Ordering::Relaxed);
                 handle
             },
@@ -974,6 +990,19 @@ impl RdpServer {
     /// [`RdpServerBuilder::with_autodetect_rtt_handle`](crate::RdpServerBuilder::with_autodetect_rtt_handle).
     pub fn autodetect_rtt_handle(&self) -> Arc<AtomicU32> {
         Arc::clone(&self.autodetect_rtt)
+    }
+
+    /// Returns a handle to the session-lifetime lowest RTT in milliseconds
+    /// (`baseRTT` per MS-RDPBCGR 2.2.14.1.5; `u32::MAX` until the first
+    /// measurement, and while auto-detect is disabled). Unlike
+    /// [`Self::autodetect_rtt_handle`], this figure never rises: pair it with
+    /// that handle's average to derive queueing delay
+    /// (`averageRTT - baseRTT`), which `autodetect_rtt_handle` alone cannot
+    /// give since its figure is a sliding-window value that rises as low
+    /// samples age out. Inject a shared instance at construction with
+    /// [`RdpServerBuilder::with_autodetect_baseline_rtt_handle`](crate::RdpServerBuilder::with_autodetect_baseline_rtt_handle).
+    pub fn autodetect_baseline_rtt_handle(&self) -> Arc<AtomicU32> {
+        Arc::clone(&self.autodetect_baseline_rtt)
     }
 
     /// Returns the shared ECHO server handle for runtime probe requests and RTT measurements.
@@ -2072,7 +2101,19 @@ impl RdpServer {
                 if let Some(ref mut ad) = self.autodetect {
                     if let Some(rtt_ms) = ad.handle_response(&pdu.response, monotonic_now_ms()) {
                         self.autodetect_rtt.store(rtt_ms, Ordering::Relaxed);
-                        debug!(rtt_ms, seq = pdu.response.sequence_number(), "RTT measured");
+                        // A matched RTT sample always updates the session-lifetime low in the
+                        // same call (see `handle_response`'s RttResponse arm), so it is available
+                        // unconditionally here, not just on a new low.
+                        let baseline_rtt_ms = ad
+                            .baseline_rtt_ms()
+                            .expect("handle_response just recorded a sample above");
+                        self.autodetect_baseline_rtt.store(baseline_rtt_ms, Ordering::Relaxed);
+                        debug!(
+                            rtt_ms,
+                            baseline_rtt_ms,
+                            seq = pdu.response.sequence_number(),
+                            "RTT measured"
+                        );
                     } else {
                         trace!(seq = pdu.response.sequence_number(), "Unmatched auto-detect response");
                     }

--- a/crates/ironrdp-testsuite-core/tests/server/autodetect.rs
+++ b/crates/ironrdp-testsuite-core/tests/server/autodetect.rs
@@ -336,6 +336,54 @@ fn with_autodetect_rtt_handle_round_trips_the_same_arc() {
 }
 
 #[test]
+fn autodetect_baseline_rtt_handle_defaults_to_sentinel() {
+    use core::net::{Ipv4Addr, SocketAddr};
+    use core::sync::atomic::Ordering;
+
+    use ironrdp_server::RdpServer;
+
+    let server = RdpServer::builder()
+        .with_addr(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+        .with_no_security()
+        .with_no_input()
+        .with_no_display()
+        .build();
+
+    assert_eq!(
+        server.autodetect_baseline_rtt_handle().load(Ordering::Relaxed),
+        u32::MAX
+    );
+}
+
+#[test]
+fn with_autodetect_baseline_rtt_handle_round_trips_the_same_arc() {
+    use core::net::{Ipv4Addr, SocketAddr};
+    use core::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+
+    use ironrdp_server::RdpServer;
+
+    let handle = Arc::new(AtomicU32::new(42));
+    let server = RdpServer::builder()
+        .with_addr(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+        .with_no_security()
+        .with_no_input()
+        .with_no_display()
+        .with_autodetect_baseline_rtt_handle(Arc::clone(&handle))
+        .build();
+
+    assert!(Arc::ptr_eq(&handle, &server.autodetect_baseline_rtt_handle()));
+    // The server resets an injected handle to the sentinel at construction.
+    assert_eq!(
+        server.autodetect_baseline_rtt_handle().load(Ordering::Relaxed),
+        u32::MAX
+    );
+    // The Arc is shared: mutating the original is visible through the server's handle.
+    handle.store(42, Ordering::Relaxed);
+    assert_eq!(server.autodetect_baseline_rtt_handle().load(Ordering::Relaxed), 42);
+}
+
+#[test]
 fn stale_probe_expiry() {
     let mut mgr = AutoDetectManager::new();
     let _ = mgr.send_rtt_request(0);
@@ -491,6 +539,43 @@ fn base_rtt_is_the_session_low_not_the_window_low() {
         }
         other => panic!("expected NetworkCharacteristicsResult, got {other:?}"),
     }
+}
+
+/// The same session-lifetime-low property `base_rtt_is_the_session_low_not_the_window_low`
+/// pins on the wire result, but on the public getter directly rather than through
+/// `build_netchar_result`.
+#[test]
+fn baseline_rtt_ms_reflects_the_session_low_not_the_window_low() {
+    let mut mgr = AutoDetectManager::new();
+    assert!(mgr.baseline_rtt_ms().is_none(), "nothing measured yet");
+
+    let sample = |mgr: &mut AutoDetectManager, rtt: u64| {
+        let req = mgr.send_rtt_request(0);
+        let _ = mgr.handle_response(
+            &AutoDetectResponse::RttResponse {
+                sequence_number: req.sequence_number(),
+            },
+            rtt,
+        );
+    };
+
+    sample(&mut mgr, 5);
+    assert_eq!(mgr.baseline_rtt_ms(), Some(5));
+
+    for _ in 0..RTT_WINDOW {
+        sample(&mut mgr, 100);
+    }
+
+    assert_eq!(
+        mgr.snapshot().expect("samples recorded").min_ms,
+        100,
+        "the 5 ms sample has aged out of the window"
+    );
+    assert_eq!(
+        mgr.baseline_rtt_ms(),
+        Some(5),
+        "the session-lifetime low does not age out with it"
+    );
 }
 
 /// Pins which measured quantity lands in which wire field.


### PR DESCRIPTION
## Summary

- RttSnapshot.min_ms is a sliding-window low that can rise as low samples
  age out of the window, and is explicitly documented as not baseRTT per
  MS-RDPBCGR 2.2.14.1.5, which defines baseRTT as the session-lifetime
  lowest. AutoDetectManager already tracks that true low internally as
  min_rtt_ms for the wire NetworkCharacteristicsResult, but nothing
  exposed it as its own value: an embedder reading snapshot() or
  autodetect_rtt_handle() alone cannot derive averageRTT - baseRTT as a
  queueing-delay signal, since that relationship only holds when the
  floor cannot rise.
- Adds AutoDetectManager::baseline_rtt_ms() as the public getter for the
  existing field, and mirrors the autodetect_rtt_handle plumbing on
  RdpServer: a new autodetect_baseline_rtt: Arc<AtomicU32> field,
  autodetect_baseline_rtt_handle() accessor, and
  with_autodetect_baseline_rtt_handle() builder method.
- A matched RTT sample always updates min_rtt_ms in the same
  handle_response call that returns it, so the store site reads the new
  getter unconditionally right after storing the RTT sample, with no
  before/after comparison needed (unlike the bandwidth case in #1734,
  where the underlying value can be cleared to None on an unusable
  measurement).
- Adds a manager-level test pinning the session-low-not-window-low
  property on the new getter directly, plus the usual pair of
  handle-plumbing tests (sentinel default, injected-handle round trip).

## Validation

`cargo xtask check fmt/lints/tests/typos/locks` all pass, including the
3 new tests.

## Notes

No public API break: `RdpServer::new` is crate-private, and the public
surface (`RdpServerBuilder`) only gains an additive optional field and a
new method.