### PR TITLE
perf(egfx): allocate the ClearCodec decoder lazily on first use

### DIFF
--- a/crates/ironrdp-egfx/src/client.rs
+++ b/crates/ironrdp-egfx/src/client.rs
@@ -398,7 +398,11 @@ enum ClientState {
 pub struct GraphicsPipelineClient {
     handler: Box<dyn GraphicsPipelineHandler>,
     h264_decoder: Option<Box<dyn H264Decoder>>,
-    clearcodec_decoder: ClearCodecDecoder,
+    /// Built on first use via [`Self::decode_clearcodec`]. `None` means no ClearCodec
+    /// frame has arrived yet, not that the codec is unsupported: keeping the ~1.37 MiB
+    /// V-bar and glyph cache spine (see `ClearCodecDecoder::new`) unallocated saves that
+    /// much per session for the common case of a server that never sends ClearCodec.
+    clearcodec_decoder: Option<ClearCodecDecoder>,
     planar_decoder: BitmapStreamDecoder,
     progressive_decoder: ProgressiveDecoder,
 
@@ -420,12 +424,14 @@ impl GraphicsPipelineClient {
     /// Create a new `GraphicsPipelineClient`
     ///
     /// If `h264_decoder` is `None`, AVC420 frames are logged and skipped.
-    /// ClearCodec decoding is always available (no external decoder required).
+    /// ClearCodec decoding is always available (no external decoder required)
+    /// and its cache spine is allocated lazily, on the first ClearCodec frame,
+    /// rather than up front for a codec the session may never use.
     pub fn new(handler: Box<dyn GraphicsPipelineHandler>, h264_decoder: Option<Box<dyn H264Decoder>>) -> Self {
         Self {
             handler,
             h264_decoder,
-            clearcodec_decoder: ClearCodecDecoder::new(),
+            clearcodec_decoder: None,
             planar_decoder: BitmapStreamDecoder::default(),
             progressive_decoder: ProgressiveDecoder::new(),
             decompressor: zgfx::Decompressor::new(),
@@ -952,6 +958,7 @@ impl GraphicsPipelineClient {
 
         let bgra = self
             .clearcodec_decoder
+            .get_or_insert_with(ClearCodecDecoder::new)
             .decode(bitmap_data, dest_width, dest_height)
             .map_err(|e| pdu_other_err!("ClearCodec decode", source: e))?;
 


### PR DESCRIPTION
## Summary

- #1175 constructs ClearCodecDecoder eagerly in GraphicsPipelineClient::new,
  and its own PR body describes that as a deliberate choice: "Constructed
  eagerly in GraphicsPipelineClient::new(), so V-bar (32K full + 16K short
  entries) and glyph (4000 entries) ring buffers are allocated up front
  regardless of whether ClearCodec frames are subsequently received."
  Revisiting that tradeoff for one case it does not fit well: the caches
  are not lazy either (VBarCache::new and GlyphCache::new both resize_with
  their full capacity), so every EGFX client session pays the full spine,
  around 1.37 MiB on 64-bit and about half that on wasm32, whether or not
  a single ClearCodec frame ever arrives, including against a server that
  never negotiates the codec at all. ironrdp-web instantiates one
  GraphicsPipelineClient per session, so this is a per-session wasm cost
  for a codec many sessions will never touch.
- Change clearcodec_decoder to Option<ClearCodecDecoder>, None at
  construction, built via get_or_insert_with on first dispatch to
  decode_clearcodec. Same shape as the eager-BulkCompressor fix in #1255.
  Nothing observable changes: the cost just moves from construction time
  to first use.
- Does not touch the reset-graphics path, which already never resets
  clearcodec_decoder (dropping it there would drop the glyph cache and
  break a legitimate post-reset GLYPH_HIT unless the server redundantly
  re-sent every glyph, per the existing comment on that code). The Option
  wrapper does not change that behavior: decode still get_or_insert_with-s
  the same instance across resets once it exists.

## Validation

`cargo xtask check fmt/lints/tests/typos/locks` all pass, including the
existing ClearCodec coverage (dispatch, RGBA output, glyph-cache-survives-
reset) unchanged.

## Notes

No public API break: clearcodec_decoder is a private field, and
GraphicsPipelineClient::new's signature is unchanged.