### PR TITLE
feat(cliprdr): add a clipboard sync loop detector

### DIFF
--- a/crates/ironrdp-cliprdr/src/lib.rs
+++ b/crates/ironrdp-cliprdr/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod backend;
 pub mod chunked_fetch;
+pub mod loop_detector;
 pub mod pdu;
 
 use std::collections::HashMap;

--- a/crates/ironrdp-cliprdr/src/loop_detector.rs
+++ b/crates/ironrdp-cliprdr/src/loop_detector.rs
@@ -1,0 +1,323 @@
+//! Clipboard synchronization loop detection.
+//!
+//! An embedder bridging CLIPRDR to a local OS clipboard commonly hits a
+//! feedback loop: content copied on one side is synced to the other, the
+//! other side's own change notification then fires for that same content,
+//! and the embedder syncs it back, forever. `ironrdp-cliprdr` has no
+//! visibility into the local OS clipboard on either side (that lives
+//! entirely in the [`crate::backend::CliprdrBackend`] implementation), so
+//! it cannot detect this on its own; [`LoopDetector`] is a building block
+//! an embedder can drive from both sides of the bridge to break the cycle.
+//!
+//! # How it works
+//!
+//! 1. **Format hashing**: hashes the list of formats/content offered.
+//! 2. **Content hashing**: optionally hashes actual clipboard bytes for
+//!    deduplication independent of format list shape.
+//! 3. **Time windowing**: only treats a match as a loop within a
+//!    configurable recent window, so an unrelated later copy of the same
+//!    content is not suppressed.
+//! 4. **Source tracking**: only a match against the *opposite* source
+//!    counts as a loop; two remote copies in a row are not one.
+//! 5. **Rate limiting**: an optional per-source throttle as a
+//!    belt-and-suspenders guard against rapid update storms even when
+//!    hash correlation alone would not catch them.
+//!
+//! # Clock
+//!
+//! Every method that needs the current time takes an explicit `now_ms`
+//! rather than reading a clock itself, matching
+//! [`CliprdrBackend::now_ms()`](crate::backend::CliprdrBackend::now_ms).
+//! This keeps the type usable on targets with no monotonic clock of their
+//! own (e.g. `wasm32-unknown-unknown`) and makes tests deterministic.
+//!
+//! # Example
+//!
+//! ```
+//! use ironrdp_cliprdr::loop_detector::{ClipboardSource, LoopDetector};
+//! use ironrdp_cliprdr::pdu::{ClipboardFormat, ClipboardFormatId};
+//!
+//! let mut detector = LoopDetector::new();
+//! let formats = vec![ClipboardFormat::new(ClipboardFormatId::CF_UNICODETEXT)];
+//!
+//! // Record that the remote side just offered these formats.
+//! detector.record_formats(&formats, ClipboardSource::Remote, 0);
+//!
+//! // Before syncing the same formats back out as a local change, check first.
+//! if detector.would_cause_loop(&formats, ClipboardSource::Local, 10) {
+//!     // Skip: this would just echo what the remote side already sent.
+//! }
+//! ```
+
+use core::hash::{Hash as _, Hasher as _};
+use std::collections::VecDeque;
+use std::collections::hash_map::DefaultHasher;
+
+use crate::pdu::ClipboardFormat;
+
+/// Configuration for [`LoopDetector`].
+#[derive(Debug, Clone)]
+pub struct LoopDetectionConfig {
+    /// Time window in milliseconds for detecting loops.
+    pub window_ms: u64,
+
+    /// Maximum number of operations to retain per history (format and content are tracked
+    /// separately).
+    pub max_history: usize,
+
+    /// Whether to hash and track clipboard content, not just format lists.
+    pub enable_content_hashing: bool,
+
+    /// Optional rate limit in milliseconds.
+    ///
+    /// When set, sync operations are throttled to at most one per `rate_limit_ms` per source.
+    /// This is a belt-and-suspenders guard against rapid clipboard updates even when hash
+    /// correlation alone passes.
+    pub rate_limit_ms: Option<u64>,
+}
+
+impl Default for LoopDetectionConfig {
+    fn default() -> Self {
+        Self {
+            window_ms: 500,
+            max_history: 10,
+            enable_content_hashing: true,
+            rate_limit_ms: None,
+        }
+    }
+}
+
+impl LoopDetectionConfig {
+    /// Config with rate limiting enabled, other fields at their default.
+    pub fn with_rate_limit(rate_limit_ms: u64) -> Self {
+        Self {
+            rate_limit_ms: Some(rate_limit_ms),
+            ..Self::default()
+        }
+    }
+}
+
+/// Which side of the bridge a clipboard operation came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClipboardSource {
+    /// The operation came from the CLIPRDR (RDP) side.
+    Remote,
+    /// The operation came from the local, non-RDP side the embedder bridges to.
+    Local,
+}
+
+impl ClipboardSource {
+    /// The other side.
+    #[must_use]
+    pub fn opposite(self) -> Self {
+        match self {
+            Self::Remote => Self::Local,
+            Self::Local => Self::Remote,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ClipboardOperation {
+    hash: u64,
+    source: ClipboardSource,
+    recorded_at_ms: u64,
+}
+
+/// Detects and helps prevent clipboard synchronization loops.
+///
+/// See the [module documentation](self) for the detection strategy and calling convention.
+#[derive(Debug)]
+pub struct LoopDetector {
+    config: LoopDetectionConfig,
+    format_history: VecDeque<ClipboardOperation>,
+    content_history: VecDeque<ClipboardOperation>,
+    last_sync_remote_ms: Option<u64>,
+    last_sync_local_ms: Option<u64>,
+}
+
+impl Default for LoopDetector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LoopDetector {
+    /// Create a detector with the default configuration.
+    pub fn new() -> Self {
+        Self::with_config(LoopDetectionConfig::default())
+    }
+
+    /// Create a detector with a custom configuration.
+    pub fn with_config(config: LoopDetectionConfig) -> Self {
+        Self {
+            config,
+            format_history: VecDeque::new(),
+            content_history: VecDeque::new(),
+            last_sync_remote_ms: None,
+            last_sync_local_ms: None,
+        }
+    }
+
+    /// Record a format list operation from `source`.
+    pub fn record_formats(&mut self, formats: &[ClipboardFormat], source: ClipboardSource, now_ms: u64) {
+        let hash = Self::hash_formats(formats);
+        self.format_history.push_back(ClipboardOperation {
+            hash,
+            source,
+            recorded_at_ms: now_ms,
+        });
+        self.cleanup_history(now_ms);
+    }
+
+    /// Record content data from `source` for deduplication.
+    ///
+    /// No-op if `enable_content_hashing` is `false` in the active config.
+    pub fn record_content(&mut self, data: &[u8], source: ClipboardSource, now_ms: u64) {
+        if !self.config.enable_content_hashing {
+            return;
+        }
+
+        let hash = Self::hash_content(data);
+        self.content_history.push_back(ClipboardOperation {
+            hash,
+            source,
+            recorded_at_ms: now_ms,
+        });
+        self.cleanup_history(now_ms);
+    }
+
+    /// Whether syncing `formats` out as `source` would just echo a recent operation from the
+    /// opposite source.
+    pub fn would_cause_loop(&self, formats: &[ClipboardFormat], source: ClipboardSource, now_ms: u64) -> bool {
+        let hash = Self::hash_formats(formats);
+        self.check_hash_collision(&self.format_history, hash, source, now_ms)
+    }
+
+    /// Whether syncing `data` out as `source` would just echo a recent operation from the
+    /// opposite source. Always `false` if `enable_content_hashing` is disabled.
+    pub fn would_cause_content_loop(&self, data: &[u8], source: ClipboardSource, now_ms: u64) -> bool {
+        if !self.config.enable_content_hashing {
+            return false;
+        }
+
+        let hash = Self::hash_content(data);
+        self.check_hash_collision(&self.content_history, hash, source, now_ms)
+    }
+
+    /// Hash arbitrary data the same way [`Self::record_content`]/[`Self::would_cause_content_loop`]
+    /// do internally, for a caller that wants to compute a hash once and compare it itself.
+    pub fn compute_hash(data: &[u8]) -> u64 {
+        Self::hash_content(data)
+    }
+
+    /// Clear all recorded history and rate-limit state.
+    pub fn clear(&mut self) {
+        self.format_history.clear();
+        self.content_history.clear();
+        self.last_sync_remote_ms = None;
+        self.last_sync_local_ms = None;
+    }
+
+    /// Whether a sync as `source` is currently rate-limited.
+    ///
+    /// Always `false` unless `rate_limit_ms` is configured.
+    pub fn is_rate_limited(&self, source: ClipboardSource, now_ms: u64) -> bool {
+        let Some(rate_limit_ms) = self.config.rate_limit_ms else {
+            return false;
+        };
+
+        let last_sync_ms = match source {
+            ClipboardSource::Remote => self.last_sync_remote_ms,
+            ClipboardSource::Local => self.last_sync_local_ms,
+        };
+
+        let Some(last_sync_ms) = last_sync_ms else {
+            return false;
+        };
+
+        now_ms.saturating_sub(last_sync_ms) < rate_limit_ms
+    }
+
+    /// Record that a sync as `source` was performed, for future [`Self::is_rate_limited`] checks.
+    pub fn record_sync(&mut self, source: ClipboardSource, now_ms: u64) {
+        match source {
+            ClipboardSource::Remote => self.last_sync_remote_ms = Some(now_ms),
+            ClipboardSource::Local => self.last_sync_local_ms = Some(now_ms),
+        }
+    }
+
+    /// Combined check: skip if either rate-limited or would cause a loop.
+    pub fn should_skip_sync(&self, formats: &[ClipboardFormat], source: ClipboardSource, now_ms: u64) -> bool {
+        if self.is_rate_limited(source, now_ms) {
+            return true;
+        }
+
+        let hash = Self::hash_formats(formats);
+        self.check_hash_collision(&self.format_history, hash, source, now_ms)
+    }
+
+    fn check_hash_collision(
+        &self,
+        history: &VecDeque<ClipboardOperation>,
+        hash: u64,
+        current_source: ClipboardSource,
+        now_ms: u64,
+    ) -> bool {
+        let opposite = current_source.opposite();
+
+        history
+            .iter()
+            .rev()
+            .take_while(|op| now_ms.saturating_sub(op.recorded_at_ms) <= self.config.window_ms)
+            .any(|op| op.source == opposite && op.hash == hash)
+    }
+
+    fn cleanup_history(&mut self, now_ms: u64) {
+        let retain_window_ms = self.config.window_ms.saturating_mul(2);
+
+        Self::cleanup_one(
+            &mut self.format_history,
+            retain_window_ms,
+            self.config.max_history,
+            now_ms,
+        );
+        Self::cleanup_one(
+            &mut self.content_history,
+            retain_window_ms,
+            self.config.max_history,
+            now_ms,
+        );
+    }
+
+    fn cleanup_one(history: &mut VecDeque<ClipboardOperation>, retain_window_ms: u64, max_history: usize, now_ms: u64) {
+        while let Some(front) = history.front() {
+            if now_ms.saturating_sub(front.recorded_at_ms) > retain_window_ms {
+                history.pop_front();
+            } else {
+                break;
+            }
+        }
+
+        while history.len() > max_history {
+            history.pop_front();
+        }
+    }
+
+    fn hash_formats(formats: &[ClipboardFormat]) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        for format in formats {
+            format.id().0.hash(&mut hasher);
+            if let Some(name) = format.name() {
+                name.value().hash(&mut hasher);
+            }
+        }
+        hasher.finish()
+    }
+
+    fn hash_content(data: &[u8]) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        data.hash(&mut hasher);
+        hasher.finish()
+    }
+}

--- a/crates/ironrdp-testsuite-core/tests/clipboard/loop_detector.rs
+++ b/crates/ironrdp-testsuite-core/tests/clipboard/loop_detector.rs
@@ -1,0 +1,172 @@
+use ironrdp_cliprdr::loop_detector::{ClipboardSource, LoopDetectionConfig, LoopDetector};
+use ironrdp_cliprdr::pdu::{ClipboardFormat, ClipboardFormatId, ClipboardFormatName};
+
+fn unicode_text() -> ClipboardFormat {
+    ClipboardFormat::new(ClipboardFormatId::CF_UNICODETEXT)
+}
+
+fn html() -> ClipboardFormat {
+    ClipboardFormat::new(ClipboardFormatId::CF_TEXT).with_name(ClipboardFormatName::HTML)
+}
+
+#[test]
+fn no_loop_different_formats() {
+    let mut detector = LoopDetector::new();
+
+    detector.record_formats(&[unicode_text()], ClipboardSource::Remote, 0);
+
+    assert!(!detector.would_cause_loop(&[html()], ClipboardSource::Local, 10));
+}
+
+#[test]
+fn loop_same_formats_opposite_source() {
+    let mut detector = LoopDetector::new();
+    let formats = [unicode_text()];
+
+    detector.record_formats(&formats, ClipboardSource::Remote, 0);
+
+    assert!(detector.would_cause_loop(&formats, ClipboardSource::Local, 10));
+}
+
+#[test]
+fn no_loop_same_source() {
+    let mut detector = LoopDetector::new();
+    let formats = [unicode_text()];
+
+    // Recorded from Local; checking as Local (i.e. against Remote history) must not match
+    // an operation that was itself recorded from Local.
+    detector.record_formats(&formats, ClipboardSource::Local, 0);
+
+    assert!(!detector.would_cause_loop(&formats, ClipboardSource::Local, 10));
+}
+
+#[test]
+fn loop_detection_respects_time_window() {
+    let mut detector = LoopDetector::with_config(LoopDetectionConfig {
+        window_ms: 100,
+        ..LoopDetectionConfig::default()
+    });
+    let formats = [unicode_text()];
+
+    detector.record_formats(&formats, ClipboardSource::Remote, 0);
+
+    // Inside the window: still a loop.
+    assert!(detector.would_cause_loop(&formats, ClipboardSource::Local, 100));
+    // Outside the window: a later, unrelated copy of the same content is not suppressed.
+    assert!(!detector.would_cause_loop(&formats, ClipboardSource::Local, 101));
+}
+
+#[test]
+fn content_hash_detects_loop_and_is_source_direction_aware() {
+    let mut detector = LoopDetector::new();
+    let data = b"Hello, World!";
+
+    detector.record_content(data, ClipboardSource::Remote, 0);
+
+    assert!(detector.would_cause_content_loop(data, ClipboardSource::Local, 10));
+    assert!(!detector.would_cause_content_loop(b"Different", ClipboardSource::Local, 10));
+    // Same source as the recording: not a loop.
+    assert!(!detector.would_cause_content_loop(data, ClipboardSource::Remote, 10));
+}
+
+#[test]
+fn content_hashing_can_be_disabled() {
+    let mut detector = LoopDetector::with_config(LoopDetectionConfig {
+        enable_content_hashing: false,
+        ..LoopDetectionConfig::default()
+    });
+    let data = b"Hello, World!";
+
+    detector.record_content(data, ClipboardSource::Remote, 0);
+
+    assert!(!detector.would_cause_content_loop(data, ClipboardSource::Local, 10));
+}
+
+#[test]
+fn clear_resets_history_and_rate_limit_state() {
+    let config = LoopDetectionConfig::with_rate_limit(200);
+    let mut detector = LoopDetector::with_config(config);
+    let formats = [unicode_text()];
+
+    detector.record_formats(&formats, ClipboardSource::Remote, 0);
+    detector.record_sync(ClipboardSource::Remote, 0);
+    assert!(detector.is_rate_limited(ClipboardSource::Remote, 50));
+
+    detector.clear();
+
+    assert!(!detector.would_cause_loop(&formats, ClipboardSource::Local, 10));
+    assert!(!detector.is_rate_limited(ClipboardSource::Remote, 50));
+}
+
+#[test]
+fn compute_hash_is_stable_within_a_process_and_content_sensitive() {
+    let hash1 = LoopDetector::compute_hash(b"test");
+    let hash2 = LoopDetector::compute_hash(b"test");
+    let hash3 = LoopDetector::compute_hash(b"different");
+
+    assert_eq!(hash1, hash2);
+    assert_ne!(hash1, hash3);
+}
+
+#[test]
+fn rate_limit_disabled_by_default() {
+    let detector = LoopDetector::new();
+
+    assert!(!detector.is_rate_limited(ClipboardSource::Remote, 0));
+    assert!(!detector.is_rate_limited(ClipboardSource::Local, 0));
+}
+
+#[test]
+fn rate_limit_is_per_source() {
+    let config = LoopDetectionConfig::with_rate_limit(200);
+    let mut detector = LoopDetector::with_config(config);
+
+    assert!(!detector.is_rate_limited(ClipboardSource::Remote, 0));
+
+    detector.record_sync(ClipboardSource::Remote, 0);
+
+    assert!(detector.is_rate_limited(ClipboardSource::Remote, 100));
+    assert!(!detector.is_rate_limited(ClipboardSource::Local, 100));
+    // Outside the rate-limit window: no longer limited.
+    assert!(!detector.is_rate_limited(ClipboardSource::Remote, 200));
+}
+
+#[test]
+fn should_skip_sync_combines_rate_limit_and_loop_detection() {
+    let config = LoopDetectionConfig::with_rate_limit(200);
+    let mut detector = LoopDetector::with_config(config);
+    let formats = [unicode_text()];
+
+    // Initially: not rate limited, no loop.
+    assert!(!detector.should_skip_sync(&formats, ClipboardSource::Remote, 0));
+
+    detector.record_formats(&formats, ClipboardSource::Remote, 0);
+    detector.record_sync(ClipboardSource::Remote, 0);
+
+    // Skipped for Local: would echo the just-recorded Remote operation.
+    assert!(detector.should_skip_sync(&formats, ClipboardSource::Local, 10));
+    // Skipped for Remote: rate limited.
+    assert!(detector.should_skip_sync(&formats, ClipboardSource::Remote, 10));
+}
+
+#[test]
+fn history_is_bounded_by_max_history() {
+    let mut detector = LoopDetector::with_config(LoopDetectionConfig {
+        max_history: 2,
+        window_ms: 10_000,
+        ..LoopDetectionConfig::default()
+    });
+
+    let first = [ClipboardFormat::new(ClipboardFormatId::new(1))];
+    let second = [ClipboardFormat::new(ClipboardFormatId::new(2))];
+    let third = [ClipboardFormat::new(ClipboardFormatId::new(3))];
+
+    detector.record_formats(&first, ClipboardSource::Remote, 0);
+    detector.record_formats(&second, ClipboardSource::Remote, 1);
+    detector.record_formats(&third, ClipboardSource::Remote, 2);
+
+    // The oldest entry (`first`) was evicted once max_history was exceeded.
+    assert!(!detector.would_cause_loop(&first, ClipboardSource::Local, 3));
+    assert!(detector.would_cause_loop(&second, ClipboardSource::Local, 3));
+    assert!(detector.would_cause_loop(&third, ClipboardSource::Local, 3));
+}

--- a/crates/ironrdp-testsuite-core/tests/clipboard/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/clipboard/mod.rs
@@ -9,6 +9,7 @@ mod format;
 mod lock_lifecycle;
 mod lock_strategy;
 mod lock_timeout;
+mod loop_detector;
 mod path_sanitization;
 mod preferred_drop_effect;
 mod server_role;


### PR DESCRIPTION
## Summary

- An embedder bridging CLIPRDR to a local OS clipboard commonly hits a
  feedback loop: content copied on one side syncs to the other, the
  other side's own change notification fires for that same content, and
  the embedder syncs it back, forever. ironrdp-cliprdr has no visibility
  into the local OS clipboard on either side by design (that lives
  entirely in the embedder's CliprdrBackend implementation), so it
  can't detect this on its own, but nothing in the crate gives an
  embedder a building block to break the cycle either. Every consumer
  bridging to a real desktop clipboard ends up needing to write the
  same hash-and-time-window correlation logic themselves.
- Adds LoopDetector: hashes recent format lists and content by source
  (Remote/Local) within a configurable time window, so an embedder can
  ask "would syncing this out right now just echo what the other side
  just sent" before acting, plus an optional per-source rate limit as
  a belt-and-suspenders guard against update storms.
- Every method that needs the time takes an explicit now_ms rather than
  reading a clock itself, matching CliprdrBackend::now_ms()/elapsed_ms()
  already on this crate for the same wasm/test-determinism reasons.
- Hashing uses DefaultHasher rather than adding a crypto dependency:
  nothing here defends against an adversary, it only needs to avoid
  mistaking two different clipboard payloads for the same one within
  one process's own recent history.
- would_cause_loop takes an explicit source parameter, matching its
  siblings would_cause_content_loop/should_skip_sync. An earlier
  version of this algorithm I'd written elsewhere hardcoded that
  direction on would_cause_loop specifically, which was an
  inconsistency with its own siblings rather than an intentional
  asymmetry; fixed here.

## Validation

`cargo xtask check fmt/lints/tests/typos/locks` all pass. Tests live in
ironrdp-testsuite-core since this crate sets [lib] test = false.

## Notes

No public API break: this is a new module with entirely new public
types, no existing signature changes.