### PR TITLE
feat(mstsgu): add smart-card gateway authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,6 +1043,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,6 +1630,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2109,6 +2130,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-proto"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.9.4",
+ "ring",
+ "thiserror 2.0.19",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "moka",
+ "once_cell",
+ "parking_lot",
+ "rand 0.9.4",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "hkdf"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2452,6 +2519,19 @@ dependencies = [
  "fuzzy-matcher",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2940,6 +3020,9 @@ dependencies = [
  "ironrdp-error 0.2.0",
  "ironrdp-tls",
  "log",
+ "picky",
+ "picky-asn1-der",
+ "picky-asn1-x509",
  "sspi",
  "tokio",
  "tokio-tungstenite",
@@ -3783,6 +3866,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4293f18e7567a1caf3c584855554377025c65e0aa445344d04171f5ad63d19b9"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4354,6 +4454,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -4881,6 +4985,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
 name = "portpicker"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5362,6 +5472,12 @@ checksum = "71725ecd5e0197b54fe859055b108688472ab6a358f8fbe5cee4a556b1b5bfea"
 dependencies = [
  "rgb",
 ]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "rfc6979"
@@ -6095,6 +6211,8 @@ dependencies = [
  "ed25519-dalek",
  "futures",
  "getrandom 0.3.4",
+ "hickory-proto",
+ "hickory-resolver",
  "hmac 0.13.0",
  "md-5 0.11.0",
  "md4",
@@ -6249,6 +6367,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tap"

--- a/crates/ironrdp-agent/src/gw_forward/mod.rs
+++ b/crates/ironrdp-agent/src/gw_forward/mod.rs
@@ -83,6 +83,7 @@ async fn open_tunnel(config: &GatewayTunnelConfig, target_host: &str, target_por
         gw_endpoint: config.gateway_endpoint.clone(),
         gw_user: config.username.clone(),
         gw_pass: config.password.clone(),
+        smart_card: None,
         server: target_host.to_owned(),
     };
 

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -1507,6 +1507,7 @@ async fn connect_gateway(
         gw_endpoint: gw.endpoint.clone(),
         gw_user: gw.username.clone(),
         gw_pass: gw.password.clone(),
+        smart_card: None,
         server: config.destination.name().to_owned(),
     };
 

--- a/crates/ironrdp-mstsgu/Cargo.toml
+++ b/crates/ironrdp-mstsgu/Cargo.toml
@@ -51,6 +51,13 @@ default = []
 rustls = ["ironrdp-tls/rustls", "tokio-tungstenite/rustls-tls-native-roots"]
 native-tls = ["ironrdp-tls/native-tls", "tokio-tungstenite/native-tls"]
 test-support = ["tokio/io-util"]
+smartcard = [
+    "sspi/scard",
+    "sspi/dns_resolver",
+    "dep:picky",
+    "dep:picky-asn1-der",
+    "dep:picky-asn1-x509",
+]
 
 [dependencies]
 base64 = "0.22"
@@ -68,6 +75,9 @@ tokio-tungstenite = { version = "0.29" }
 tokio-util = { version = "0.7" }
 tokio = { version = "1.52", features = ["macros", "rt", "io-util"] }
 uuid = { version = "1", features = ["v4"] }
+picky = { version = "=7.0.0-rc.25", optional = true }
+picky-asn1-der = { version = "0.5", optional = true }
+picky-asn1-x509 = { version = "0.15", optional = true }
 
 [dev-dependencies]
 hyper = { version = "1.9", features = ["server", "http1"] }

--- a/crates/ironrdp-mstsgu/README.md
+++ b/crates/ironrdp-mstsgu/README.md
@@ -10,6 +10,8 @@ This crate
 - exposes decoded tunnel-authorization policy values without enforcing redirection rules or idle timeouts,
 - does not implement reconnection, Detect, or a live UDP/DTLS side channel,
 - authenticates gateway setup with HTTP Negotiate (Kerberos then NTLM), NTLM, or Basic fallback,
+- can use Kerberos PKINIT with application-supplied UPN `smartcard` credentials for HTTP Negotiate authentication only,
+- does not implement `HTTP_EXTENDED_AUTH_SC`, PAA, or a credential-provider UI,
 - encodes and decodes RDG-UDP PDUs (`CONNECT_PKT`, `DATA_PKT`, `DISC_PKT`, and correlation info) without opening that side channel,
 - encodes and decodes DCE/RPC common-header fragments and reassembles responses, without a live RPC-over-HTTP transport, and
 - finishes write-side shutdown by closing the outbound WebSocket or ending the dual HTTP IN request body.

--- a/crates/ironrdp-mstsgu/src/http_auth.rs
+++ b/crates/ironrdp-mstsgu/src/http_auth.rs
@@ -47,6 +47,7 @@ pub struct GatewayHttpAuth {
     /// Optional SPN / target name (for example `HTTP/rdg.contoso.com`).
     target_name: Option<String>,
     complete: bool,
+    allow_basic_fallback: bool,
 }
 
 impl GatewayHttpAuth {
@@ -60,16 +61,54 @@ impl GatewayHttpAuth {
     pub fn from_challenges(
         username: &str,
         password: &str,
+        smart_card: Option<&crate::GwSmartCardCredentials>,
         target_name: Option<String>,
         challenges: &[&str],
     ) -> Result<(Option<Self>, AuthStep), Error> {
+        let challenges: Vec<&str> = iter_auth_challenges(challenges.iter().copied()).collect();
+
+        #[cfg(feature = "smartcard")]
+        if let Some(smart_card) = smart_card {
+            let Some(negotiate_token) = challenges
+                .iter()
+                .find_map(|challenge| split_auth_challenge(challenge, "Negotiate"))
+            else {
+                return Err(Error::new(
+                    "gateway does not offer Negotiate for smart-card authentication",
+                    GwErrorKind::UnsupportedFeature,
+                ));
+            };
+            let negotiate_token = if negotiate_token.is_empty() {
+                None
+            } else {
+                Some(
+                    STANDARD
+                        .decode(negotiate_token.as_bytes())
+                        .map_err(|error| Error::custom("decode negotiate challenge", error))?,
+                )
+            };
+
+            let mut auth = Self::new_negotiate_smartcard(smart_card, target_name)?;
+            let token = auth.initialize(negotiate_token.as_deref())?;
+            let header = auth.format_authorization(&token);
+            return Ok((Some(auth), AuthStep::Continue(header)));
+        }
+
+        #[cfg(not(feature = "smartcard"))]
+        if smart_card.is_some() {
+            return Err(Error::new(
+                "smart-card gateway authentication requires the `smartcard` feature",
+                GwErrorKind::UnsupportedFeature,
+            ));
+        }
+
         let mut saw_negotiate = false;
         let mut saw_ntlm = false;
         let mut saw_basic = false;
         let mut negotiate_token: Option<Vec<u8>> = None;
         let mut ntlm_token: Option<Vec<u8>> = None;
 
-        for value in iter_auth_challenges(challenges.iter().copied()) {
+        for value in challenges {
             if let Some(rest) = split_auth_challenge(value, "Negotiate") {
                 saw_negotiate = true;
                 if rest.is_empty() {
@@ -155,6 +194,7 @@ impl GatewayHttpAuth {
             scheme: "NTLM",
             target_name,
             complete: false,
+            allow_basic_fallback: true,
         })
     }
 
@@ -188,6 +228,90 @@ impl GatewayHttpAuth {
             scheme: "Negotiate",
             target_name,
             complete: false,
+            allow_basic_fallback: true,
+        })
+    }
+
+    #[cfg(feature = "smartcard")]
+    fn new_negotiate_smartcard(
+        smart_card: &crate::GwSmartCardCredentials,
+        target_name: Option<String>,
+    ) -> Result<Self, Error> {
+        use picky::key::PrivateKey;
+        use picky_asn1_x509::Certificate;
+        use sspi::{KerberosConfig, Secret, SmartCardIdentity, SmartCardType};
+
+        if smart_card.username.is_empty() {
+            return Err(Error::new(
+                "smart-card username is required",
+                GwErrorKind::UnsupportedFeature,
+            ));
+        }
+
+        let certificate: Certificate = picky_asn1_der::from_bytes(&smart_card.certificate)
+            .map_err(|error| Error::custom("parse smart-card certificate", error))?;
+        let username = smart_card.username.clone();
+
+        let (private_key, scard_type) = match &smart_card.private_key {
+            Some(private_key) => (
+                Some(
+                    PrivateKey::from_pkcs1(private_key)
+                        .map_err(|error| Error::custom("parse smart-card private key", error))?
+                        .into(),
+                ),
+                SmartCardType::Emulated {
+                    scard_pin: Secret::new(smart_card.pin.as_bytes().to_vec()),
+                },
+            ),
+            #[cfg(target_os = "windows")]
+            None => (None, SmartCardType::WindowsNative),
+            #[cfg(not(target_os = "windows"))]
+            None => {
+                return Err(Error::new(
+                    "smart card without a private key requires a Windows card reader",
+                    GwErrorKind::UnsupportedFeature,
+                ));
+            }
+        };
+
+        let credentials = Credentials::SmartCard(Box::new(SmartCardIdentity {
+            username,
+            certificate,
+            reader_name: smart_card.reader_name.clone(),
+            card_name: smart_card.card_name.clone(),
+            container_name: smart_card.container_name.clone(),
+            csp_name: smart_card.csp_name.clone().unwrap_or_default(),
+            pin: Secret::new(smart_card.pin.as_bytes().to_vec()),
+            private_key,
+            scard_type,
+        }));
+        let client_computer_name = client_computer_name();
+        let kdc_url = std::env::var("SSPI_KDC_URL").unwrap_or_default();
+        let config = NegotiateConfig {
+            protocol_config: Box::new(KerberosConfig::new(&kdc_url, client_computer_name.clone())),
+            package_list: Some("kerberos".to_owned()),
+            client_computer_name,
+        };
+
+        let mut negotiate =
+            Negotiate::new_client(config).map_err(|error| Error::custom("create negotiate package", error))?;
+        let credentials_handle = negotiate
+            .acquire_credentials_handle()
+            .with_credential_use(CredentialUse::Outbound)
+            .with_auth_data(&credentials)
+            .execute(&mut negotiate)
+            .map_err(|error| Error::custom("acquire negotiate smart-card credentials", error))?
+            .credentials_handle;
+
+        Ok(Self {
+            backend: AuthBackend::Negotiate {
+                negotiate,
+                credentials_handle,
+            },
+            scheme: "Negotiate",
+            target_name,
+            complete: false,
+            allow_basic_fallback: false,
         })
     }
 
@@ -236,7 +360,7 @@ impl GatewayHttpAuth {
                     Ok(AuthStep::Continue(self.format_authorization(&next)))
                 }
             }
-            None if saw_basic => Ok(AuthStep::TryBasic),
+            None if saw_basic && self.allow_basic_fallback => Ok(AuthStep::TryBasic),
             None => Err(Error::new(
                 "websocket upgrade auth challenge",
                 GwErrorKind::UnsupportedFeature,

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -43,11 +43,54 @@ pub use self::udp::{
     UdpCorrelationInfo, UdpPacketHeader, UdpPktType, encode_connect_request, fragment_connect_pkt,
 };
 
+/// Smart-card credentials used for HTTP Negotiate Kerberos PKINIT authentication.
+///
+/// This type owns application-supplied identity material and reader metadata.
+/// It does not perform smart-card I/O or prompt for a PIN.
+#[derive(Clone)]
+pub struct GwSmartCardCredentials {
+    /// User principal name supplied to Kerberos.
+    pub username: String,
+    /// PIN used to unlock the smart card.
+    pub pin: String,
+    /// DER-encoded X.509 certificate identifying the user.
+    pub certificate: Vec<u8>,
+    /// PKCS#1 private key for an emulated smart card.
+    ///
+    /// Set this to `None` to use the Windows smart-card API.
+    pub private_key: Option<Vec<u8>>,
+    /// Smart-card reader name.
+    pub reader_name: String,
+    /// Optional smart-card name.
+    pub card_name: Option<String>,
+    /// Optional key container name.
+    pub container_name: Option<String>,
+    /// Optional cryptographic service provider name.
+    pub csp_name: Option<String>,
+}
+
+impl fmt::Debug for GwSmartCardCredentials {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GwSmartCardCredentials")
+            .field("username", &"<redacted>")
+            .field("pin", &"<redacted>")
+            .field("certificate", &"<redacted>")
+            .field("private_key", &self.private_key.as_ref().map(|_| "<redacted>"))
+            .field("reader_name", &self.reader_name)
+            .field("card_name", &self.card_name)
+            .field("container_name", &self.container_name)
+            .field("csp_name", &self.csp_name)
+            .finish()
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct GwConnectTarget {
     pub gw_endpoint: String,
     pub gw_user: String,
     pub gw_pass: String,
+    /// Optional smart-card credentials for HTTP Negotiate Kerberos PKINIT authentication.
+    pub smart_card: Option<Box<GwSmartCardCredentials>>,
 
     pub server: String,
 }

--- a/crates/ironrdp-mstsgu/src/packet_io.rs
+++ b/crates/ironrdp-mstsgu/src/packet_io.rs
@@ -308,6 +308,7 @@ pub(crate) async fn open_test_transport(
         gw_endpoint: "gateway.test:443".to_owned(),
         gw_user: "user".to_owned(),
         gw_pass: "pass".to_owned(),
+        smart_card: None,
         server: "server.test".to_owned(),
     };
     let client_addr = "127.0.0.1:0"
@@ -449,6 +450,7 @@ async fn authenticated_rdg_request(
 
         let user = context.target.gw_user.clone();
         let pass = context.target.gw_pass.clone();
+        let smart_card = context.target.smart_card.clone();
         let target_name = spn.to_owned();
         let step = if let Some(mut auth) = http_auth.take() {
             let (auth, step) = run_http_auth(move || {
@@ -462,7 +464,7 @@ async fn authenticated_rdg_request(
         } else {
             let (auth, step) = run_http_auth(move || {
                 let refs: Vec<&str> = challenges.iter().map(String::as_str).collect();
-                GatewayHttpAuth::from_challenges(&user, &pass, Some(target_name), &refs)
+                GatewayHttpAuth::from_challenges(&user, &pass, smart_card.as_deref(), Some(target_name), &refs)
             })
             .await?;
             http_auth = auth;

--- a/crates/ironrdp-mstsgu/tests/http_auth.rs
+++ b/crates/ironrdp-mstsgu/tests/http_auth.rs
@@ -1,6 +1,20 @@
 #![allow(unused_crate_dependencies)]
 
+use ironrdp_mstsgu::GwSmartCardCredentials;
 use ironrdp_mstsgu::http_auth::{AuthStep, GatewayHttpAuth, basic_authorization, split_auth_challenge};
+
+fn smart_card_credentials() -> GwSmartCardCredentials {
+    GwSmartCardCredentials {
+        username: "alice@contoso.com".to_owned(),
+        pin: "sensitive-pin".to_owned(),
+        certificate: b"sensitive-certificate".to_vec(),
+        private_key: Some(b"sensitive-private-key".to_vec()),
+        reader_name: "Reader 0".to_owned(),
+        card_name: Some("Card".to_owned()),
+        container_name: Some("Container".to_owned()),
+        csp_name: Some("Provider".to_owned()),
+    }
+}
 
 #[test]
 fn split_auth_challenge_parses_schemes() {
@@ -25,6 +39,7 @@ fn negotiate_type1_from_challenge() {
     let (auth, step) = GatewayHttpAuth::from_challenges(
         r"CONTOSO\alice",
         "secret",
+        None,
         Some("HTTP/rdg.contoso.com".to_owned()),
         &["Negotiate"],
     )
@@ -43,7 +58,7 @@ fn negotiate_type1_from_challenge() {
 #[test]
 fn ntlm_type1_from_challenge() {
     let (auth, step) =
-        GatewayHttpAuth::from_challenges(r"CONTOSO\alice", "secret", None, &["NTLM"]).expect("ntlm init");
+        GatewayHttpAuth::from_challenges(r"CONTOSO\alice", "secret", None, None, &["NTLM"]).expect("ntlm init");
     let auth = auth.expect("ntlm backend");
     assert_eq!(auth.scheme(), "NTLM");
     match step {
@@ -58,24 +73,34 @@ fn ntlm_type1_from_challenge() {
 #[test]
 fn try_basic_when_only_basic_offered() {
     let (auth, step) =
-        GatewayHttpAuth::from_challenges("alice", "secret", None, &["Basic realm=\"RDG\""]).expect("basic");
+        GatewayHttpAuth::from_challenges("alice", "secret", None, None, &["Basic realm=\"RDG\""]).expect("basic");
     assert!(auth.is_none());
     assert!(matches!(step, AuthStep::TryBasic));
 }
 
 #[test]
 fn prefer_negotiate_over_ntlm() {
-    let (auth, _) =
-        GatewayHttpAuth::from_challenges("alice", "secret", None, &["NTLM", "Negotiate", "Basic realm=\"x\""])
-            .expect("init");
+    let (auth, _) = GatewayHttpAuth::from_challenges(
+        "alice",
+        "secret",
+        None,
+        None,
+        &["NTLM", "Negotiate", "Basic realm=\"x\""],
+    )
+    .expect("init");
     assert_eq!(auth.expect("negotiate backend").scheme(), "Negotiate");
 }
 
 #[test]
 fn combined_www_authenticate_prefers_negotiate() {
-    let (auth, step) =
-        GatewayHttpAuth::from_challenges("alice", "secret", None, &[r#"Negotiate, NTLM, Basic realm="RDG""#])
-            .expect("init");
+    let (auth, step) = GatewayHttpAuth::from_challenges(
+        "alice",
+        "secret",
+        None,
+        None,
+        &[r#"Negotiate, NTLM, Basic realm="RDG""#],
+    )
+    .expect("init");
     assert_eq!(auth.expect("negotiate backend").scheme(), "Negotiate");
     assert!(matches!(step, AuthStep::Continue(_)));
 }
@@ -83,7 +108,100 @@ fn combined_www_authenticate_prefers_negotiate() {
 #[test]
 fn quoted_comma_in_basic_realm_is_one_challenge() {
     let (auth, step) =
-        GatewayHttpAuth::from_challenges("alice", "secret", None, &[r#"Basic realm="a, b""#]).expect("basic");
+        GatewayHttpAuth::from_challenges("alice", "secret", None, None, &[r#"Basic realm="a, b""#]).expect("basic");
     assert!(auth.is_none());
     assert!(matches!(step, AuthStep::TryBasic));
+}
+
+#[test]
+fn smart_card_debug_redacts_secrets() {
+    let debug = format!("{:?}", smart_card_credentials());
+    assert!(!debug.contains("alice@contoso.com"));
+    assert!(!debug.contains("sensitive-pin"));
+    assert!(!debug.contains("sensitive-certificate"));
+    assert!(!debug.contains("sensitive-private-key"));
+}
+
+#[cfg(not(feature = "smartcard"))]
+#[test]
+fn smart_card_without_feature_is_an_explicit_error() {
+    let smart_card = smart_card_credentials();
+    let result = GatewayHttpAuth::from_challenges("alice", "password", Some(&smart_card), None, &["Negotiate"]);
+    let Err(error) = result else {
+        panic!("smart-card authentication needs its feature");
+    };
+    let error = error.to_string();
+
+    assert!(error.contains("smart-card"));
+    assert!(error.contains("smartcard"));
+    assert!(!error.contains("sensitive-pin"));
+    assert!(!error.contains("sensitive-certificate"));
+    assert!(!error.contains("sensitive-private-key"));
+}
+
+#[cfg(feature = "smartcard")]
+#[test]
+fn smart_card_requires_username() {
+    let mut smart_card = smart_card_credentials();
+    smart_card.username.clear();
+    let result = GatewayHttpAuth::from_challenges("alice", "password", Some(&smart_card), None, &["Negotiate"]);
+    let Err(error) = result else {
+        panic!("smart-card authentication requires a username");
+    };
+
+    assert!(error.to_string().contains("username"));
+}
+
+#[cfg(feature = "smartcard")]
+#[test]
+fn smart_card_requires_negotiate() {
+    let smart_card = smart_card_credentials();
+    let result = GatewayHttpAuth::from_challenges("alice", "password", Some(&smart_card), None, &["NTLM"]);
+    let Err(error) = result else {
+        panic!("smart-card authentication requires Negotiate");
+    };
+    let error = error.to_string();
+
+    assert!(error.contains("Negotiate"));
+    assert!(!error.contains("sensitive-pin"));
+    assert!(!error.contains("sensitive-certificate"));
+    assert!(!error.contains("sensitive-private-key"));
+}
+
+#[cfg(feature = "smartcard")]
+#[test]
+fn smart_card_rejects_malformed_negotiate_token() {
+    let smart_card = smart_card_credentials();
+    let result = GatewayHttpAuth::from_challenges("alice", "password", Some(&smart_card), None, &["Negotiate !"]);
+    let Err(error) = result else {
+        panic!("malformed Negotiate token must fail before PKINIT initialization");
+    };
+    let error = error.to_string();
+
+    assert!(error.contains("decode negotiate challenge"));
+    assert!(!error.contains("sensitive-pin"));
+    assert!(!error.contains("sensitive-certificate"));
+    assert!(!error.contains("sensitive-private-key"));
+}
+
+#[cfg(feature = "smartcard")]
+#[test]
+fn smart_card_recognizes_combined_negotiate_challenge() {
+    let smart_card = smart_card_credentials();
+    let result = GatewayHttpAuth::from_challenges(
+        "alice",
+        "password",
+        Some(&smart_card),
+        None,
+        &[r#"NTLM, Negotiate !, Basic realm="RDG""#],
+    );
+    let Err(error) = result else {
+        panic!("malformed Negotiate token must fail before PKINIT initialization");
+    };
+    let error = error.to_string();
+
+    assert!(error.contains("decode negotiate challenge"));
+    assert!(!error.contains("sensitive-pin"));
+    assert!(!error.contains("sensitive-certificate"));
+    assert!(!error.contains("sensitive-private-key"));
 }

--- a/xtask/src/check.rs
+++ b/xtask/src/check.rs
@@ -246,6 +246,11 @@ pub fn tests_compile(sh: &Shell) -> anyhow::Result<()> {
         "{CARGO} test -p ironrdp-mstsgu --test http_auth --features native-tls --locked --no-run"
     )
     .run()?;
+    cmd!(
+        sh,
+        "{CARGO} test -p ironrdp-mstsgu --test http_auth --features native-tls,smartcard --locked --no-run"
+    )
+    .run()?;
     println!("All good!");
     Ok(())
 }
@@ -261,6 +266,11 @@ pub fn tests_run(sh: &Shell) -> anyhow::Result<()> {
     cmd!(
         sh,
         "{CARGO} test -p ironrdp-mstsgu --test http_auth --features native-tls --locked"
+    )
+    .run()?;
+    cmd!(
+        sh,
+        "{CARGO} test -p ironrdp-mstsgu --test http_auth --features native-tls,smartcard --locked"
     )
     .run()?;
     println!("All good!");


### PR DESCRIPTION
Add an opt-in Kerberos PKINIT path for HTTP Negotiate gateway authentication while retaining the password Negotiate, NTLM, and Basic flows.

The public credentials type accepts an application-supplied UPN, redacts credentials, and rejects unsupported smart-card feature or challenge combinations without exposing them.