### PR TITLE
feat(cliprdr): add a chunked file-contents fetch primitive

### DIFF
--- a/crates/ironrdp-cliprdr/src/chunked_fetch.rs
+++ b/crates/ironrdp-cliprdr/src/chunked_fetch.rs
@@ -70,6 +70,11 @@ pub struct ChunkedFetch {
     next_offset: u64,
     state: State,
     awaiting_response: bool,
+    /// `requested_size` of the outstanding `RANGE` request, if any. Set by
+    /// [`Self::next_request`], checked by [`Self::on_response`]: MS-RDPECLIP 2.2.5.3 defines
+    /// `cbRequested` as the maximum a `RANGE` responder may return, so a response longer than
+    /// this is a protocol violation, not extra data to accept.
+    last_requested_size: Option<u32>,
 }
 
 impl ChunkedFetch {
@@ -92,6 +97,7 @@ impl ChunkedFetch {
                 State::Fetching
             },
             awaiting_response: false,
+            last_requested_size: None,
         }
     }
 
@@ -108,6 +114,7 @@ impl ChunkedFetch {
             next_offset: 0,
             state: State::AwaitingSize,
             awaiting_response: false,
+            last_requested_size: None,
         }
     }
 
@@ -149,6 +156,7 @@ impl ChunkedFetch {
                 let requested_size = remaining.min(u64::from(self.chunk_size));
                 // Infallible: bounded above by self.chunk_size (a u32) via the min() just above.
                 let requested_size = u32::try_from(requested_size).unwrap_or(self.chunk_size);
+                self.last_requested_size = Some(requested_size);
 
                 FileContentsRequest {
                     stream_id: self.stream_id,
@@ -189,17 +197,25 @@ impl ChunkedFetch {
             },
             State::Fetching => {
                 let data = response.data();
+                let exceeds_requested = self
+                    .last_requested_size
+                    .is_some_and(|requested| u64::from(requested) < u64::try_from(data.len()).unwrap_or(u64::MAX));
 
                 // A compliant peer never sends an empty range response before the file is
                 // complete (MS-RDPECLIP defines no "not ready yet" signal here). Treating
                 // one as failure rather than InProgress avoids looping forever re-requesting
                 // the same range against a peer that keeps answering with nothing.
-                if data.is_empty() {
+                //
+                // A response longer than cbRequested is a protocol violation, not extra data
+                // to accept: [MS-RDPECLIP] 2.2.5.3 defines cbRequested as the maximum a RANGE
+                // responder may return, and bytes beyond it were never validated as the range
+                // this fetch actually asked for.
+                if data.is_empty() || exceeds_requested {
                     self.state = State::Failed;
                 } else {
-                    // Clamp rather than trust the peer's byte count: a response longer than
-                    // what's left would otherwise grow the buffer past total_size and desync
-                    // next_offset from what was actually requested.
+                    // Still clamp against total_size defensively: a response within
+                    // cbRequested that nonetheless overruns a (possibly attacker-influenced)
+                    // total_size must not grow the buffer past it or desync next_offset.
                     let data_len = u64::try_from(data.len()).unwrap_or(u64::MAX);
                     let remaining = self
                         .total_size

--- a/crates/ironrdp-cliprdr/src/chunked_fetch.rs
+++ b/crates/ironrdp-cliprdr/src/chunked_fetch.rs
@@ -1,0 +1,237 @@
+//! Chunked, receiver-driven fetch of one file's contents.
+//!
+//! [MS-RDPECLIP]'s file-contents protocol is receiver-driven: the side that
+//! wants the data sends a [`FileContentsRequest`] naming a byte range
+//! (`flags: RANGE`, `position`, `requested_size`), and the other side answers
+//! with exactly that range in a [`FileContentsResponse`]. Fetching a whole
+//! file therefore means issuing a sequence of these requests and
+//! reassembling the responses; [`ChunkedFetch`] is that sequence as a small
+//! state machine, so each [`crate::backend::CliprdrBackend`] implementation
+//! does not have to write its own.
+//!
+//! # What this does not do
+//!
+//! `ChunkedFetch` only tracks one file's own progress (next offset, buffered
+//! bytes so far). It does not send anything itself, does not allocate its
+//! `stream_id`, and does not touch [`crate::Cliprdr`]'s lock or pending-request
+//! state: [`crate::Cliprdr::request_file_contents`] already validates every
+//! request against the negotiated capabilities and the remote file list, and
+//! already renews the active lock's activity timestamp on every call that
+//! carries a `data_id` (including an auto-filled one), so there is nothing
+//! left for this type to do on that front. Driving one looks like:
+//!
+//! ```ignore
+//! let request = fetch.next_request().expect("fetch not finished");
+//! let messages = cliprdr.request_file_contents(request)?;
+//! // ... send `messages`, then later, in `on_file_contents_response`:
+//! match fetch.on_response(&response) {
+//!     ChunkedFetchProgress::InProgress => { /* call next_request() again */ }
+//!     ChunkedFetchProgress::Complete => { let data = fetch.into_data(); }
+//!     ChunkedFetchProgress::Failed => { /* abandon the fetch */ }
+//! }
+//! ```
+//!
+//! Since more than one fetch can be outstanding at once, each needs its own
+//! `stream_id`; [`ChunkedFetch::stream_id`] is the key a backend should use
+//! to route an incoming response to the right instance.
+
+use crate::pdu::{FileContentsFlags, FileContentsRequest, FileContentsResponse};
+
+/// Result of feeding a [`FileContentsResponse`] to [`ChunkedFetch::on_response`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChunkedFetchProgress {
+    /// More data remains; call [`ChunkedFetch::next_request`] again.
+    InProgress,
+    /// The fetch is complete. Call [`ChunkedFetch::into_data`] to take the assembled bytes.
+    Complete,
+    /// The fetch failed: either the response reported `CB_RESPONSE_FAIL`, a `SIZE` response
+    /// was malformed, or the peer stopped sending data before the file was complete.
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum State {
+    AwaitingSize,
+    Fetching,
+    Complete,
+    Failed,
+}
+
+/// Drives the request/response sequence to fetch one file's contents.
+///
+/// See the [module documentation](self) for what this does and does not handle.
+#[derive(Debug)]
+pub struct ChunkedFetch {
+    stream_id: u32,
+    file_index: i32,
+    chunk_size: u32,
+    total_size: Option<u64>,
+    received: Vec<u8>,
+    next_offset: u64,
+    state: State,
+    awaiting_response: bool,
+}
+
+impl ChunkedFetch {
+    /// Start a fetch for a file whose size is already known.
+    ///
+    /// This is the common case: the size is usually already available from an earlier
+    /// `FileGroupDescriptorW` exchange, so a `SIZE` round-trip is unnecessary overhead.
+    /// `chunk_size` must be greater than 0.
+    pub fn new(stream_id: u32, file_index: i32, total_size: u64, chunk_size: u32) -> Self {
+        Self {
+            stream_id,
+            file_index,
+            chunk_size: chunk_size.max(1),
+            total_size: Some(total_size),
+            received: Vec::new(),
+            next_offset: 0,
+            state: if total_size == 0 {
+                State::Complete
+            } else {
+                State::Fetching
+            },
+            awaiting_response: false,
+        }
+    }
+
+    /// Start a fetch that must first learn the file's size via a `SIZE` request.
+    ///
+    /// `chunk_size` must be greater than 0.
+    pub fn new_with_size_query(stream_id: u32, file_index: i32, chunk_size: u32) -> Self {
+        Self {
+            stream_id,
+            file_index,
+            chunk_size: chunk_size.max(1),
+            total_size: None,
+            received: Vec::new(),
+            next_offset: 0,
+            state: State::AwaitingSize,
+            awaiting_response: false,
+        }
+    }
+
+    /// The stream ID every request/response in this fetch's sequence uses.
+    ///
+    /// A caller driving more than one `ChunkedFetch` concurrently should use this as the key
+    /// to route an incoming [`crate::backend::CliprdrBackend::on_file_contents_response`] to
+    /// the right instance.
+    pub fn stream_id(&self) -> u32 {
+        self.stream_id
+    }
+
+    /// Whether the fetch finished, successfully or not.
+    pub fn is_finished(&self) -> bool {
+        matches!(self.state, State::Complete | State::Failed)
+    }
+
+    /// The next request to send via [`crate::Cliprdr::request_file_contents`].
+    ///
+    /// Returns `None` if the fetch has finished, or if a request from a previous call is
+    /// still outstanding (call [`Self::on_response`] first).
+    pub fn next_request(&mut self) -> Option<FileContentsRequest> {
+        if self.awaiting_response {
+            return None;
+        }
+
+        let request = match self.state {
+            State::AwaitingSize => FileContentsRequest {
+                stream_id: self.stream_id,
+                index: self.file_index,
+                flags: FileContentsFlags::SIZE,
+                position: 0,
+                requested_size: 8,
+                data_id: None,
+            },
+            State::Fetching => {
+                let total_size = self.total_size?;
+                let remaining = total_size.saturating_sub(self.next_offset);
+                let requested_size = remaining.min(u64::from(self.chunk_size));
+                // Infallible: bounded above by self.chunk_size (a u32) via the min() just above.
+                let requested_size = u32::try_from(requested_size).unwrap_or(self.chunk_size);
+
+                FileContentsRequest {
+                    stream_id: self.stream_id,
+                    index: self.file_index,
+                    flags: FileContentsFlags::RANGE,
+                    position: self.next_offset,
+                    requested_size,
+                    data_id: None,
+                }
+            }
+            State::Complete | State::Failed => return None,
+        };
+
+        self.awaiting_response = true;
+        Some(request)
+    }
+
+    /// Feed the response to the request most recently returned by [`Self::next_request`].
+    pub fn on_response(&mut self, response: &FileContentsResponse<'_>) -> ChunkedFetchProgress {
+        self.awaiting_response = false;
+
+        if response.is_error() {
+            self.state = State::Failed;
+            return ChunkedFetchProgress::Failed;
+        }
+
+        match self.state {
+            State::AwaitingSize => match response.data_as_size() {
+                Ok(total_size) => {
+                    self.total_size = Some(total_size);
+                    self.state = if total_size == 0 {
+                        State::Complete
+                    } else {
+                        State::Fetching
+                    };
+                }
+                Err(_) => self.state = State::Failed,
+            },
+            State::Fetching => {
+                let data = response.data();
+
+                // A compliant peer never sends an empty range response before the file is
+                // complete (MS-RDPECLIP defines no "not ready yet" signal here). Treating
+                // one as failure rather than InProgress avoids looping forever re-requesting
+                // the same range against a peer that keeps answering with nothing.
+                if data.is_empty() {
+                    self.state = State::Failed;
+                } else {
+                    // Clamp rather than trust the peer's byte count: a response longer than
+                    // what's left would otherwise grow the buffer past total_size and desync
+                    // next_offset from what was actually requested.
+                    let data_len = u64::try_from(data.len()).unwrap_or(u64::MAX);
+                    let remaining = self
+                        .total_size
+                        .unwrap_or(0)
+                        .saturating_sub(self.next_offset)
+                        .min(data_len);
+                    // Infallible: just clamped to `data.len()` via `data_len`/`min()` above.
+                    let take = usize::try_from(remaining).unwrap_or(data.len());
+
+                    self.received.extend_from_slice(&data[..take]);
+                    self.next_offset = self.next_offset.saturating_add(remaining);
+
+                    if self.next_offset >= self.total_size.unwrap_or(0) {
+                        self.state = State::Complete;
+                    }
+                }
+            }
+            State::Complete | State::Failed => {}
+        }
+
+        match self.state {
+            State::Complete => ChunkedFetchProgress::Complete,
+            State::Failed => ChunkedFetchProgress::Failed,
+            State::AwaitingSize | State::Fetching => ChunkedFetchProgress::InProgress,
+        }
+    }
+
+    /// Take the bytes assembled so far.
+    ///
+    /// Meaningful once [`Self::on_response`] has returned [`ChunkedFetchProgress::Complete`];
+    /// returns whatever has been accumulated so far if called earlier.
+    pub fn into_data(self) -> Vec<u8> {
+        self.received
+    }
+}

--- a/crates/ironrdp-cliprdr/src/chunked_fetch.rs
+++ b/crates/ironrdp-cliprdr/src/chunked_fetch.rs
@@ -65,6 +65,14 @@ pub struct ChunkedFetch {
     stream_id: u32,
     file_index: i32,
     chunk_size: u32,
+    /// Caller-supplied ceiling on `total_size`, independent of what the size itself claims to
+    /// be. `total_size` for [`Self::new`] and the `SIZE` response for
+    /// [`Self::new_with_size_query`] both ultimately trace back to remote-controlled metadata
+    /// (a `FileGroupDescriptorW` entry, or the peer's own `SIZE` answer), so without this a
+    /// peer can name an arbitrarily large file and this type will retain every byte of it
+    /// until allocation fails. Checked as soon as `total_size` is known; a fetch whose size
+    /// exceeds it fails before any `RANGE` request is ever issued.
+    max_total_size: u64,
     total_size: Option<u64>,
     received: Vec<u8>,
     next_offset: u64,
@@ -75,6 +83,13 @@ pub struct ChunkedFetch {
     /// `cbRequested` as the maximum a `RANGE` responder may return, so a response longer than
     /// this is a protocol violation, not extra data to accept.
     last_requested_size: Option<u32>,
+    /// `clipDataId` of the lock this fetch is bound to, sent explicitly on every request
+    /// instead of left for [`crate::Cliprdr::request_file_contents`] to fill in from
+    /// `current_lock_id`. A fetch spans multiple requests, and a `FormatList` between them
+    /// expires the old lock and can install a new one under the same field; auto-filling
+    /// would silently redirect a request already in flight to whatever lock happens to be
+    /// current at send time, splicing bytes from two different files into one buffer.
+    clip_data_id: Option<u32>,
 }
 
 impl ChunkedFetch {
@@ -82,39 +97,65 @@ impl ChunkedFetch {
     ///
     /// This is the common case: the size is usually already available from an earlier
     /// `FileGroupDescriptorW` exchange, so a `SIZE` round-trip is unnecessary overhead.
-    /// `chunk_size` must be greater than 0.
-    pub fn new(stream_id: u32, file_index: i32, total_size: u64, chunk_size: u32) -> Self {
+    /// `chunk_size` must be greater than 0. `clip_data_id` should be the id passed to
+    /// [`crate::backend::CliprdrBackend::on_remote_file_list`] alongside the file this fetch
+    /// targets, so every request in the sequence stays bound to that same locked snapshot.
+    /// The fetch fails immediately if `total_size` exceeds `max_total_size`.
+    pub fn new(
+        stream_id: u32,
+        file_index: i32,
+        total_size: u64,
+        chunk_size: u32,
+        clip_data_id: Option<u32>,
+        max_total_size: u64,
+    ) -> Self {
         Self {
             stream_id,
             file_index,
             chunk_size: chunk_size.max(1),
+            max_total_size,
             total_size: Some(total_size),
             received: Vec::new(),
             next_offset: 0,
-            state: if total_size == 0 {
+            state: if total_size > max_total_size {
+                State::Failed
+            } else if total_size == 0 {
                 State::Complete
             } else {
                 State::Fetching
             },
             awaiting_response: false,
             last_requested_size: None,
+            clip_data_id,
         }
     }
 
     /// Start a fetch that must first learn the file's size via a `SIZE` request.
     ///
-    /// `chunk_size` must be greater than 0.
-    pub fn new_with_size_query(stream_id: u32, file_index: i32, chunk_size: u32) -> Self {
+    /// `chunk_size` must be greater than 0. `clip_data_id` should be the id passed to
+    /// [`crate::backend::CliprdrBackend::on_remote_file_list`] alongside the file this fetch
+    /// targets, so every request in the sequence, including the `SIZE` request, stays bound
+    /// to that same locked snapshot. The fetch fails once the `SIZE` response arrives if the
+    /// reported size exceeds `max_total_size`.
+    pub fn new_with_size_query(
+        stream_id: u32,
+        file_index: i32,
+        chunk_size: u32,
+        clip_data_id: Option<u32>,
+        max_total_size: u64,
+    ) -> Self {
         Self {
             stream_id,
             file_index,
             chunk_size: chunk_size.max(1),
+            max_total_size,
             total_size: None,
             received: Vec::new(),
             next_offset: 0,
             state: State::AwaitingSize,
             awaiting_response: false,
             last_requested_size: None,
+            clip_data_id,
         }
     }
 
@@ -148,7 +189,7 @@ impl ChunkedFetch {
                 flags: FileContentsFlags::SIZE,
                 position: 0,
                 requested_size: 8,
-                data_id: None,
+                data_id: self.clip_data_id,
             },
             State::Fetching => {
                 let total_size = self.total_size?;
@@ -164,7 +205,7 @@ impl ChunkedFetch {
                     flags: FileContentsFlags::RANGE,
                     position: self.next_offset,
                     requested_size,
-                    data_id: None,
+                    data_id: self.clip_data_id,
                 }
             }
             State::Complete | State::Failed => return None,
@@ -187,7 +228,9 @@ impl ChunkedFetch {
             State::AwaitingSize => match response.data_as_size() {
                 Ok(total_size) => {
                     self.total_size = Some(total_size);
-                    self.state = if total_size == 0 {
+                    self.state = if total_size > self.max_total_size {
+                        State::Failed
+                    } else if total_size == 0 {
                         State::Complete
                     } else {
                         State::Fetching

--- a/crates/ironrdp-cliprdr/src/lib.rs
+++ b/crates/ironrdp-cliprdr/src/lib.rs
@@ -2,6 +2,7 @@
 #![doc(html_logo_url = "https://cdnweb.devolutions.net/images/projects/devolutions/logos/devolutions-icon-shadow.svg")]
 
 pub mod backend;
+pub mod chunked_fetch;
 pub mod pdu;
 
 use std::collections::HashMap;

--- a/crates/ironrdp-testsuite-core/tests/clipboard/chunked_fetch.rs
+++ b/crates/ironrdp-testsuite-core/tests/clipboard/chunked_fetch.rs
@@ -1,0 +1,137 @@
+use ironrdp_cliprdr::chunked_fetch::{ChunkedFetch, ChunkedFetchProgress};
+use ironrdp_cliprdr::pdu::{FileContentsFlags, FileContentsResponse};
+
+#[test]
+fn known_size_skips_the_size_phase() {
+    let mut fetch = ChunkedFetch::new(1, 0, 10, 64);
+
+    let request = fetch.next_request().expect("fetch not finished");
+    assert_eq!(request.flags, FileContentsFlags::RANGE);
+    assert_eq!(request.position, 0);
+    assert_eq!(request.requested_size, 10);
+}
+
+#[test]
+fn zero_size_file_completes_immediately() {
+    let mut fetch = ChunkedFetch::new(1, 0, 0, 64);
+    assert!(fetch.is_finished());
+    assert!(fetch.next_request().is_none());
+    assert_eq!(fetch.into_data(), Vec::<u8>::new());
+}
+
+#[test]
+fn size_query_phase_then_fetching() {
+    let mut fetch = ChunkedFetch::new_with_size_query(1, 0, 4);
+
+    let size_request = fetch.next_request().expect("fetch not finished");
+    assert_eq!(size_request.flags, FileContentsFlags::SIZE);
+    assert_eq!(size_request.position, 0);
+    assert_eq!(size_request.requested_size, 8);
+
+    // Nothing until the SIZE response lands.
+    assert!(fetch.next_request().is_none());
+
+    let size_response = FileContentsResponse::new_size_response(1, 9);
+    let progress = fetch.on_response(&size_response);
+    assert_eq!(progress, ChunkedFetchProgress::InProgress);
+
+    let range_request = fetch.next_request().expect("fetch not finished");
+    assert_eq!(range_request.flags, FileContentsFlags::RANGE);
+    assert_eq!(range_request.position, 0);
+    assert_eq!(range_request.requested_size, 4);
+}
+
+#[test]
+fn size_query_of_zero_completes_without_a_range_request() {
+    let mut fetch = ChunkedFetch::new_with_size_query(1, 0, 4);
+    let _ = fetch.next_request();
+
+    let progress = fetch.on_response(&FileContentsResponse::new_size_response(1, 0));
+
+    assert_eq!(progress, ChunkedFetchProgress::Complete);
+    assert!(fetch.into_data().is_empty());
+}
+
+#[test]
+fn assembles_multiple_chunks_in_order() {
+    let mut fetch = ChunkedFetch::new(1, 0, 10, 4);
+
+    let r1 = fetch.next_request().unwrap();
+    assert_eq!((r1.position, r1.requested_size), (0, 4));
+    let progress = fetch.on_response(&FileContentsResponse::new_data_response(1, b"abcd".as_slice()));
+    assert_eq!(progress, ChunkedFetchProgress::InProgress);
+
+    let r2 = fetch.next_request().unwrap();
+    assert_eq!((r2.position, r2.requested_size), (4, 4));
+    let progress = fetch.on_response(&FileContentsResponse::new_data_response(1, b"efgh".as_slice()));
+    assert_eq!(progress, ChunkedFetchProgress::InProgress);
+
+    // Last chunk is shorter than chunk_size: 10 - 8 = 2 bytes remain.
+    let r3 = fetch.next_request().unwrap();
+    assert_eq!((r3.position, r3.requested_size), (8, 2));
+    let progress = fetch.on_response(&FileContentsResponse::new_data_response(1, b"ij".as_slice()));
+    assert_eq!(progress, ChunkedFetchProgress::Complete);
+
+    assert_eq!(fetch.into_data(), b"abcdefghij".to_vec());
+}
+
+#[test]
+fn next_request_returns_none_while_a_response_is_outstanding() {
+    let mut fetch = ChunkedFetch::new(1, 0, 10, 4);
+
+    assert!(fetch.next_request().is_some());
+    // A second call before on_response() must not produce a duplicate/overlapping request.
+    assert!(fetch.next_request().is_none());
+}
+
+#[test]
+fn error_response_fails_the_fetch() {
+    let mut fetch = ChunkedFetch::new(1, 0, 10, 4);
+    let _ = fetch.next_request();
+
+    let progress = fetch.on_response(&FileContentsResponse::new_error(1));
+
+    assert_eq!(progress, ChunkedFetchProgress::Failed);
+    assert!(fetch.is_finished());
+    assert!(fetch.next_request().is_none());
+}
+
+#[test]
+fn malformed_size_response_fails_the_fetch() {
+    let mut fetch = ChunkedFetch::new_with_size_query(1, 0, 4);
+    let _ = fetch.next_request();
+
+    // Not exactly 8 bytes, per MS-RDPECLIP 2.2.5.4 SIZE response contract.
+    let malformed = FileContentsResponse::new_data_response(1, b"abc".as_slice());
+    let progress = fetch.on_response(&malformed);
+
+    assert_eq!(progress, ChunkedFetchProgress::Failed);
+}
+
+#[test]
+fn empty_data_before_completion_fails_rather_than_looping_forever() {
+    let mut fetch = ChunkedFetch::new(1, 0, 10, 4);
+    let _ = fetch.next_request();
+
+    let progress = fetch.on_response(&FileContentsResponse::new_data_response(1, Vec::<u8>::new()));
+
+    assert_eq!(progress, ChunkedFetchProgress::Failed);
+}
+
+#[test]
+fn oversized_response_is_clamped_to_the_remaining_bytes() {
+    let mut fetch = ChunkedFetch::new(1, 0, 4, 64);
+    let _ = fetch.next_request();
+
+    // Peer sends more than the file's total size; must not overrun.
+    let progress = fetch.on_response(&FileContentsResponse::new_data_response(1, b"abcdEXTRA".as_slice()));
+
+    assert_eq!(progress, ChunkedFetchProgress::Complete);
+    assert_eq!(fetch.into_data(), b"abcd".to_vec());
+}
+
+#[test]
+fn stream_id_is_stable_across_the_whole_fetch() {
+    let fetch = ChunkedFetch::new(42, 0, 10, 4);
+    assert_eq!(fetch.stream_id(), 42);
+}

--- a/crates/ironrdp-testsuite-core/tests/clipboard/chunked_fetch.rs
+++ b/crates/ironrdp-testsuite-core/tests/clipboard/chunked_fetch.rs
@@ -119,11 +119,28 @@ fn empty_data_before_completion_fails_rather_than_looping_forever() {
 }
 
 #[test]
-fn oversized_response_is_clamped_to_the_remaining_bytes() {
+fn response_exceeding_requested_size_fails_the_fetch() {
     let mut fetch = ChunkedFetch::new(1, 0, 4, 64);
-    let _ = fetch.next_request();
+    let request = fetch.next_request().unwrap();
+    assert_eq!(
+        request.requested_size, 4,
+        "requested exactly the file's remaining 4 bytes"
+    );
 
-    // Peer sends more than the file's total size; must not overrun.
+    // Peer sends more than cbRequested. MS-RDPECLIP 2.2.5.3 makes that a protocol
+    // violation regardless of whether it would still fit under the file's total size.
+    let progress = fetch.on_response(&FileContentsResponse::new_data_response(1, b"abcdEXTRA".as_slice()));
+
+    assert_eq!(progress, ChunkedFetchProgress::Failed);
+}
+
+#[test]
+fn response_within_requested_size_still_clamps_against_total_size_as_a_backstop() {
+    // Feeding a response with no prior next_request() call (so last_requested_size is
+    // still None) exercises the defensive total_size clamp on its own, independent of
+    // the cbRequested check above.
+    let mut fetch = ChunkedFetch::new(1, 0, 4, 64);
+
     let progress = fetch.on_response(&FileContentsResponse::new_data_response(1, b"abcdEXTRA".as_slice()));
 
     assert_eq!(progress, ChunkedFetchProgress::Complete);

--- a/crates/ironrdp-testsuite-core/tests/clipboard/chunked_fetch.rs
+++ b/crates/ironrdp-testsuite-core/tests/clipboard/chunked_fetch.rs
@@ -1,9 +1,13 @@
 use ironrdp_cliprdr::chunked_fetch::{ChunkedFetch, ChunkedFetchProgress};
 use ironrdp_cliprdr::pdu::{FileContentsFlags, FileContentsResponse};
 
+/// Generous enough to be a no-op against every file size used in these tests, so tests not
+/// about the cap itself don't have to think about it.
+const NO_EFFECTIVE_CAP: u64 = u64::MAX;
+
 #[test]
 fn known_size_skips_the_size_phase() {
-    let mut fetch = ChunkedFetch::new(1, 0, 10, 64);
+    let mut fetch = ChunkedFetch::new(1, 0, 10, 64, None, NO_EFFECTIVE_CAP);
 
     let request = fetch.next_request().expect("fetch not finished");
     assert_eq!(request.flags, FileContentsFlags::RANGE);
@@ -13,7 +17,7 @@ fn known_size_skips_the_size_phase() {
 
 #[test]
 fn zero_size_file_completes_immediately() {
-    let mut fetch = ChunkedFetch::new(1, 0, 0, 64);
+    let mut fetch = ChunkedFetch::new(1, 0, 0, 64, None, NO_EFFECTIVE_CAP);
     assert!(fetch.is_finished());
     assert!(fetch.next_request().is_none());
     assert_eq!(fetch.into_data(), Vec::<u8>::new());
@@ -21,7 +25,7 @@ fn zero_size_file_completes_immediately() {
 
 #[test]
 fn size_query_phase_then_fetching() {
-    let mut fetch = ChunkedFetch::new_with_size_query(1, 0, 4);
+    let mut fetch = ChunkedFetch::new_with_size_query(1, 0, 4, None, NO_EFFECTIVE_CAP);
 
     let size_request = fetch.next_request().expect("fetch not finished");
     assert_eq!(size_request.flags, FileContentsFlags::SIZE);
@@ -43,7 +47,7 @@ fn size_query_phase_then_fetching() {
 
 #[test]
 fn size_query_of_zero_completes_without_a_range_request() {
-    let mut fetch = ChunkedFetch::new_with_size_query(1, 0, 4);
+    let mut fetch = ChunkedFetch::new_with_size_query(1, 0, 4, None, NO_EFFECTIVE_CAP);
     let _ = fetch.next_request();
 
     let progress = fetch.on_response(&FileContentsResponse::new_size_response(1, 0));
@@ -54,7 +58,7 @@ fn size_query_of_zero_completes_without_a_range_request() {
 
 #[test]
 fn assembles_multiple_chunks_in_order() {
-    let mut fetch = ChunkedFetch::new(1, 0, 10, 4);
+    let mut fetch = ChunkedFetch::new(1, 0, 10, 4, None, NO_EFFECTIVE_CAP);
 
     let r1 = fetch.next_request().unwrap();
     assert_eq!((r1.position, r1.requested_size), (0, 4));
@@ -77,7 +81,7 @@ fn assembles_multiple_chunks_in_order() {
 
 #[test]
 fn next_request_returns_none_while_a_response_is_outstanding() {
-    let mut fetch = ChunkedFetch::new(1, 0, 10, 4);
+    let mut fetch = ChunkedFetch::new(1, 0, 10, 4, None, NO_EFFECTIVE_CAP);
 
     assert!(fetch.next_request().is_some());
     // A second call before on_response() must not produce a duplicate/overlapping request.
@@ -86,7 +90,7 @@ fn next_request_returns_none_while_a_response_is_outstanding() {
 
 #[test]
 fn error_response_fails_the_fetch() {
-    let mut fetch = ChunkedFetch::new(1, 0, 10, 4);
+    let mut fetch = ChunkedFetch::new(1, 0, 10, 4, None, NO_EFFECTIVE_CAP);
     let _ = fetch.next_request();
 
     let progress = fetch.on_response(&FileContentsResponse::new_error(1));
@@ -98,7 +102,7 @@ fn error_response_fails_the_fetch() {
 
 #[test]
 fn malformed_size_response_fails_the_fetch() {
-    let mut fetch = ChunkedFetch::new_with_size_query(1, 0, 4);
+    let mut fetch = ChunkedFetch::new_with_size_query(1, 0, 4, None, NO_EFFECTIVE_CAP);
     let _ = fetch.next_request();
 
     // Not exactly 8 bytes, per MS-RDPECLIP 2.2.5.4 SIZE response contract.
@@ -110,7 +114,7 @@ fn malformed_size_response_fails_the_fetch() {
 
 #[test]
 fn empty_data_before_completion_fails_rather_than_looping_forever() {
-    let mut fetch = ChunkedFetch::new(1, 0, 10, 4);
+    let mut fetch = ChunkedFetch::new(1, 0, 10, 4, None, NO_EFFECTIVE_CAP);
     let _ = fetch.next_request();
 
     let progress = fetch.on_response(&FileContentsResponse::new_data_response(1, Vec::<u8>::new()));
@@ -120,7 +124,7 @@ fn empty_data_before_completion_fails_rather_than_looping_forever() {
 
 #[test]
 fn response_exceeding_requested_size_fails_the_fetch() {
-    let mut fetch = ChunkedFetch::new(1, 0, 4, 64);
+    let mut fetch = ChunkedFetch::new(1, 0, 4, 64, None, NO_EFFECTIVE_CAP);
     let request = fetch.next_request().unwrap();
     assert_eq!(
         request.requested_size, 4,
@@ -139,7 +143,7 @@ fn response_within_requested_size_still_clamps_against_total_size_as_a_backstop(
     // Feeding a response with no prior next_request() call (so last_requested_size is
     // still None) exercises the defensive total_size clamp on its own, independent of
     // the cbRequested check above.
-    let mut fetch = ChunkedFetch::new(1, 0, 4, 64);
+    let mut fetch = ChunkedFetch::new(1, 0, 4, 64, None, NO_EFFECTIVE_CAP);
 
     let progress = fetch.on_response(&FileContentsResponse::new_data_response(1, b"abcdEXTRA".as_slice()));
 
@@ -149,6 +153,47 @@ fn response_within_requested_size_still_clamps_against_total_size_as_a_backstop(
 
 #[test]
 fn stream_id_is_stable_across_the_whole_fetch() {
-    let fetch = ChunkedFetch::new(42, 0, 10, 4);
+    let fetch = ChunkedFetch::new(42, 0, 10, 4, None, NO_EFFECTIVE_CAP);
     assert_eq!(fetch.stream_id(), 42);
+}
+
+#[test]
+fn clip_data_id_is_sent_on_every_request_instead_of_left_for_the_caller_to_default() {
+    // A FormatList between requests can change what current_lock_id would default to;
+    // ChunkedFetch must keep sending the id it was constructed with, not None.
+    let mut fetch = ChunkedFetch::new(1, 0, 8, 4, Some(7), NO_EFFECTIVE_CAP);
+
+    let r1 = fetch.next_request().unwrap();
+    assert_eq!(r1.data_id, Some(7));
+    let _ = fetch.on_response(&FileContentsResponse::new_data_response(1, b"abcd".as_slice()));
+
+    let r2 = fetch.next_request().unwrap();
+    assert_eq!(r2.data_id, Some(7));
+}
+
+#[test]
+fn clip_data_id_is_sent_on_the_size_request_too() {
+    let mut fetch = ChunkedFetch::new_with_size_query(1, 0, 4, Some(3), NO_EFFECTIVE_CAP);
+
+    let size_request = fetch.next_request().unwrap();
+    assert_eq!(size_request.data_id, Some(3));
+}
+
+#[test]
+fn known_size_over_the_cap_fails_before_any_request_is_issued() {
+    let mut fetch = ChunkedFetch::new(1, 0, 1_000_000, 64, None, 10);
+
+    assert!(fetch.is_finished());
+    assert!(fetch.next_request().is_none());
+}
+
+#[test]
+fn queried_size_over_the_cap_fails_before_any_range_request() {
+    let mut fetch = ChunkedFetch::new_with_size_query(1, 0, 64, None, 10);
+    let _ = fetch.next_request();
+
+    let progress = fetch.on_response(&FileContentsResponse::new_size_response(1, 1_000_000));
+
+    assert_eq!(progress, ChunkedFetchProgress::Failed);
+    assert!(fetch.next_request().is_none());
 }

--- a/crates/ironrdp-testsuite-core/tests/clipboard/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/clipboard/mod.rs
@@ -1,3 +1,4 @@
+mod chunked_fetch;
 mod delayed_rendering;
 mod delayed_rendering_integration;
 mod file_contents_state_machine;


### PR DESCRIPTION
## Summary

- MS-RDPECLIP's file-contents protocol is receiver-driven: fetching a
  file means sending a sequence of byte-range FileContentsRequests and
  reassembling the FileContentsResponses. Nothing in this crate helps
  with that sequencing, so every consumer that wants a whole file ends
  up writing its own request/response loop by hand.
- Adds ChunkedFetch: a small state machine that produces the next
  request to send and consumes each response, tracking offset and
  buffered bytes so the caller doesn't have to. The size phase is
  optional: construct with a known size (the common case, since it's
  usually already available from an earlier FileGroupDescriptorW
  exchange) to skip straight to range requests, or without one to
  query it first.
- Every request carries an explicit clip_data_id, the id
  CliprdrBackend::on_remote_file_list already hands the caller for the
  file's locked snapshot. request_file_contents can auto-fill this from
  current_lock_id when left unset, but a fetch spans multiple requests
  and a FormatList between them can expire the old lock and install a
  new one under the same field, so auto-filling would let a fetch
  already in flight silently retarget to whichever lock happens to be
  current at send time.
- A caller-provided max_total_size bounds how large a file this type
  will try to buffer in memory, checked as soon as the size is known
  (either the caller-supplied total_size, or the peer's own SIZE
  response), independent of what that size claims to be.
- Two defensive cases beyond the happy path: an empty range response
  before the file is complete fails the fetch rather than
  re-requesting the same range forever, since the protocol has no
  "not ready yet" signal that would legitimately produce one, and a
  response longer than what's left is clamped rather than trusted,
  since accepting it as-is would grow the buffer past the file's
  total size.

## Validation

`cargo xtask check fmt/lints/tests/typos/locks` all pass. Tests live
in ironrdp-testsuite-core since this crate sets [lib] test = false.

## Notes

No public API break: this is a new module with entirely new public
types, no existing signature changes.
