### PR TITLE
feat(mstsgu): fall back to dual HTTP gateway transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2166,6 +2166,7 @@ dependencies = [
  "http",
  "http-body",
  "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2173,6 +2174,12 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
@@ -2199,6 +2206,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",

--- a/crates/ironrdp-mstsgu/Cargo.toml
+++ b/crates/ironrdp-mstsgu/Cargo.toml
@@ -41,16 +41,22 @@ path = "tests/rpch_http.rs"
 name = "tunnel_policy"
 path = "tests/tunnel_policy.rs"
 
+[[test]]
+name = "packet_io"
+path = "tests/packet_io.rs"
+required-features = ["native-tls", "test-support"]
+
 [features]
 default = []
 rustls = ["ironrdp-tls/rustls", "tokio-tungstenite/rustls-tls-native-roots"]
 native-tls = ["ironrdp-tls/native-tls", "tokio-tungstenite/native-tls"]
+test-support = ["tokio/io-util"]
 
 [dependencies]
 base64 = "0.22"
 bitflags = "2.11"
 futures-util = "0.3"
-http-body-util = { version = "0.1" }
+http-body-util = { version = "0.1.4", features = ["channel"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 hyper = { version = "1.9", features = ["client", "http1"] }
 ironrdp-core = { path = "../ironrdp-core", version = "0.2", features = ["std"] } # public
@@ -62,6 +68,10 @@ tokio-tungstenite = { version = "0.29" }
 tokio-util = { version = "0.7" }
 tokio = { version = "1.52", features = ["macros", "rt", "io-util"] }
 uuid = { version = "1", features = ["v4"] }
+
+[dev-dependencies]
+hyper = { version = "1.9", features = ["server", "http1"] }
+tokio = { version = "1.52", features = ["io-util", "macros", "rt", "sync"] }
 
 [lints]
 workspace = true

--- a/crates/ironrdp-mstsgu/README.md
+++ b/crates/ironrdp-mstsgu/README.md
@@ -4,14 +4,14 @@
 
 This crate
 - implements an MVP state needed to connect through Microsoft RD Gateway,
-- only supports the HTTPS protocol with WebSocket (and not the legacy HTTP or HTTP-RPC transports),
+- supports HTTPS WebSocket transport and falls back to the legacy dual-channel HTTP transport,
 - provides internal raw RPCH HTTP framing codecs, but no live RPC-over-HTTP gateway transport,
 - decodes HTTP control packets (`HTTP_SERVICE_MESSAGE`, `HTTP_REAUTH_MESSAGE`, and `HTTP_CLOSE_PACKET`) without performing mid-session reauthentication,
 - exposes decoded tunnel-authorization policy values without enforcing redirection rules or idle timeouts,
 - does not implement reconnection, Detect, or a live UDP/DTLS side channel,
-- authenticates the WebSocket upgrade with HTTP Negotiate (Kerberos then NTLM), NTLM, or Basic fallback,
+- authenticates gateway setup with HTTP Negotiate (Kerberos then NTLM), NTLM, or Basic fallback,
 - encodes and decodes RDG-UDP PDUs (`CONNECT_PKT`, `DATA_PKT`, `DISC_PKT`, and correlation info) without opening that side channel,
 - encodes and decodes DCE/RPC common-header fragments and reassembles responses, without a live RPC-over-HTTP transport, and
-- finishes write-side shutdown by closing the outbound WebSocket and waiting for the gateway worker.
+- finishes write-side shutdown by closing the outbound WebSocket or ending the dual HTTP IN request body.
 
 [MS-TSGU]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsgu/0007d661-a86d-4e8f-89f7-7f77f8824188

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -12,6 +12,9 @@ mod proto;
 pub mod rpc;
 #[expect(dead_code)]
 mod rpc_transport;
+#[cfg(feature = "test-support")]
+#[doc(hidden)]
+pub mod test_support;
 mod udp;
 
 use core::fmt;
@@ -28,7 +31,7 @@ use log::warn;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::sync::PollSender;
 
-use self::packet_io::{PacketIo, open_websocket_transport};
+use self::packet_io::{PacketIo, open_gateway_transport};
 #[doc(hidden)]
 pub use self::proto::{ChannelClosePkt, ReauthMessagePkt, ServiceMessagePkt, gateway_code_label};
 use self::proto::{
@@ -71,6 +74,7 @@ type Error = ironrdp_error::Error<GwErrorKind>;
 pub enum GwErrorKind {
     InvalidGwTarget,
     Connect,
+    HttpStatus(u16),
     PacketEof,
     UnsupportedFeature,
     Custom,
@@ -99,6 +103,7 @@ impl Display for GwErrorKind {
         let x = match self {
             GwErrorKind::InvalidGwTarget => "invalid GW Target",
             GwErrorKind::Connect => "connection error",
+            GwErrorKind::HttpStatus(status) => return write!(f, "unexpected http status {status}"),
             GwErrorKind::PacketEof => "PacketEOF",
             GwErrorKind::UnsupportedFeature => "unsupported feature",
             GwErrorKind::Custom => "custom",
@@ -156,7 +161,7 @@ impl GwClient {
         client_name: &str,
         server_port: u16,
     ) -> Result<(GwClient, core::net::SocketAddr), Error> {
-        let (io, client_addr) = open_websocket_transport(target).await?;
+        let (io, client_addr) = open_gateway_transport(target).await?;
         Self::connect_ws(target.clone(), client_name, server_port, io)
             .await
             .map(|x| (x, client_addr))

--- a/crates/ironrdp-mstsgu/src/packet_io.rs
+++ b/crates/ironrdp-mstsgu/src/packet_io.rs
@@ -128,8 +128,13 @@ impl PacketIo {
                     .map_err(|e| custom_err!("websocket close flush", e))?;
                 Ok(())
             }
-            PacketIo::DualHttp { in_tx, .. } => {
+            PacketIo::DualHttp { in_tx, in_response, .. } => {
                 let _ = in_tx.take();
+                if let Some(response) = in_response.take() {
+                    response
+                        .await
+                        .map_err(|e| custom_err!("dual-http in response task", e))??;
+                }
                 Ok(())
             }
         }

--- a/crates/ironrdp-mstsgu/src/packet_io.rs
+++ b/crates/ironrdp-mstsgu/src/packet_io.rs
@@ -1,11 +1,17 @@
-//! Packet I/O over the MS-TSGU HTTPS WebSocket transport.
+//! Packet I/O over the MS-TSGU HTTPS WebSocket or dual HTTP transport.
+
+use core::convert::Infallible;
+use std::collections::BTreeMap;
 
 use futures_util::stream::{SplitSink, SplitStream};
-use futures_util::{SinkExt as _, StreamExt as _};
-use http_body_util::BodyExt as _;
-use hyper::body::Bytes;
-use ironrdp_tls::TlsStream;
+use futures_util::{FutureExt as _, SinkExt as _, StreamExt as _};
+use http_body_util::channel::{Channel as BodyChannel, Sender as BodySender};
+use http_body_util::combinators::BoxBody;
+use http_body_util::{BodyExt as _, Empty};
+use hyper::body::{Bytes, Incoming};
+use ironrdp_core::{Decode as _, ReadCursor};
 use log::error;
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::TcpStream;
 use tokio::sync::oneshot;
 use tokio_tungstenite::WebSocketStream;
@@ -14,159 +20,430 @@ use tokio_tungstenite::tungstenite::protocol::Role;
 use tokio_tungstenite::tungstenite::{Message, http};
 
 use crate::http_auth::{AuthStep, GatewayHttpAuth, basic_authorization, www_authenticate_values};
+use crate::proto::PktHdr;
 use crate::{Error, GwConnectTarget, GwErrorKind};
 
-/// WebSocket byte transport used after the HTTP upgrade completes.
-pub(crate) struct PacketIo {
-    sink: SplitSink<WebSocketStream<TlsStream<TcpStream>>, Message>,
-    stream: SplitStream<WebSocketStream<TlsStream<TcpStream>>>,
+pub(crate) trait GatewayIo: AsyncRead + AsyncWrite + Unpin {}
+
+impl<T: AsyncRead + AsyncWrite + Unpin + ?Sized> GatewayIo for T {}
+
+type GatewayStream = Box<dyn GatewayIo + Send>;
+type RdgBody = BoxBody<Bytes, Infallible>;
+
+const MAX_AUTH_RESPONSE_SIZE: usize = 16 * 1024;
+const MAX_PACKET_SIZE: usize = 16 * 1024 * 1024;
+const OUT_SEED_SIZE: usize = 10;
+const PACKET_HEADER_SIZE: usize = 2 /* type */ + 2 /* reserved */ + 4 /* length */;
+
+struct RdgRequestContext<'a> {
+    method: &'a str,
+    gw_host: &'a str,
+    connection_id: &'a str,
+    target: &'a GwConnectTarget,
+    websocket_upgrade: bool,
+}
+
+/// Session cookies returned by an RD Gateway or its load balancer.
+///
+/// MS-TSGU can establish its OUT and IN channels on different connections, so
+/// cookies returned by either authenticated request are replayed on the next one.
+#[derive(Default)]
+struct GatewayCookies {
+    values: BTreeMap<String, String>,
+}
+
+impl GatewayCookies {
+    fn capture(&mut self, headers: &http::HeaderMap) {
+        for value in &headers.get_all(hyper::header::SET_COOKIE) {
+            let Ok(value) = value.to_str() else {
+                continue;
+            };
+            let Some((name, value)) = value.split(';').next().and_then(|cookie| cookie.split_once('=')) else {
+                continue;
+            };
+            let name = name.trim();
+            if name.is_empty() {
+                continue;
+            }
+            self.values.insert(name.to_owned(), format!("{name}={value}"));
+        }
+    }
+
+    fn header_value(&self) -> Option<String> {
+        (!self.values.is_empty()).then(|| self.values.values().cloned().collect::<Vec<_>>().join("; "))
+    }
+}
+
+/// Backing transport for MS-TSGU protocol packets after HTTP setup.
+pub(crate) enum PacketIo {
+    WebSocket {
+        sink: SplitSink<WebSocketStream<GatewayStream>, Message>,
+        stream: SplitStream<WebSocketStream<GatewayStream>>,
+    },
+    /// Legacy dual channel: read from the OUT response body and write to the IN request body.
+    DualHttp {
+        out_body: Incoming,
+        out_buf: Vec<u8>,
+        in_tx: Option<BodySender<Bytes>>,
+        in_response: Option<tokio::task::JoinHandle<Result<(), Error>>>,
+        _out_stop_tx: oneshot::Sender<()>,
+        _out_conn: tokio::task::JoinHandle<()>,
+        _in_conn: tokio::task::JoinHandle<()>,
+    },
 }
 
 impl PacketIo {
     pub(crate) async fn send_bytes(&mut self, bytes: &[u8]) -> Result<(), Error> {
-        self.sink
-            .send(Message::Binary(Bytes::copy_from_slice(bytes)))
-            .await
-            .map_err(|e| custom_err!("ws send", e))?;
-        Ok(())
+        self.check_in_response()?;
+        match self {
+            PacketIo::WebSocket { sink, .. } => {
+                sink.send(Message::Binary(Bytes::copy_from_slice(bytes)))
+                    .await
+                    .map_err(|e| custom_err!("websocket send", e))?;
+                Ok(())
+            }
+            PacketIo::DualHttp { in_tx, .. } => {
+                let in_tx = in_tx
+                    .as_mut()
+                    .ok_or_else(|| Error::new("dual-http in stream closed", GwErrorKind::Connect))?;
+                in_tx
+                    .send_data(Bytes::copy_from_slice(bytes))
+                    .await
+                    .map_err(|e| custom_err!("dual-http send", e))?;
+                Ok(())
+            }
+        }
     }
 
-    /// Sends a WebSocket close frame so a local write-side EOF can finish.
+    /// Finishes the WebSocket or dual HTTP IN stream so local write-side EOF can complete.
     pub(crate) async fn close(&mut self) -> Result<(), Error> {
-        self.sink
-            .send(Message::Close(None))
-            .await
-            .map_err(|e| custom_err!("websocket close", e))?;
-        self.sink
-            .flush()
-            .await
-            .map_err(|e| custom_err!("websocket close flush", e))?;
-        Ok(())
+        self.check_in_response()?;
+        match self {
+            PacketIo::WebSocket { sink, .. } => {
+                sink.send(Message::Close(None))
+                    .await
+                    .map_err(|e| custom_err!("websocket close", e))?;
+                sink.flush()
+                    .await
+                    .map_err(|e| custom_err!("websocket close flush", e))?;
+                Ok(())
+            }
+            PacketIo::DualHttp { in_tx, .. } => {
+                let _ = in_tx.take();
+                Ok(())
+            }
+        }
     }
 
-    /// Reads one WebSocket message as an MS-TSGU packet buffer.
+    /// Reads one complete MS-TSGU packet buffer.
     ///
     /// Returns `Ok(None)` on a clean close or an exhausted stream.
     pub(crate) async fn read_packet_buf(&mut self) -> Result<Option<Bytes>, Error> {
-        let msg = match self.stream.next().await {
-            None => return Ok(None),
-            Some(Ok(msg)) => msg,
-            Some(Err(e)) => return Err(custom_err!("Stream", e)),
-        };
-        if matches!(msg, Message::Close(_)) {
-            return Ok(None);
+        self.check_in_response()?;
+        match self {
+            PacketIo::WebSocket { stream, .. } => {
+                let msg = match stream.next().await {
+                    None => return Ok(None),
+                    Some(Ok(msg)) => msg,
+                    Some(Err(e)) => return Err(custom_err!("websocket read", e)),
+                };
+                if matches!(msg, Message::Close(_)) {
+                    return Ok(None);
+                }
+                Ok(Some(msg.into_data()))
+            }
+            PacketIo::DualHttp { out_body, out_buf, .. } => read_complete_packet(out_body, out_buf).await,
         }
-        Ok(Some(msg.into_data()))
+    }
+
+    fn check_in_response(&mut self) -> Result<(), Error> {
+        let PacketIo::DualHttp { in_response, .. } = self else {
+            return Ok(());
+        };
+        let Some(task) = in_response.as_ref() else {
+            return Ok(());
+        };
+        if !task.is_finished() {
+            return Ok(());
+        }
+        let task = in_response
+            .take()
+            .ok_or_else(|| Error::new("dual-http in response task missing", GwErrorKind::Connect))?;
+        let result = task
+            .now_or_never()
+            .ok_or_else(|| Error::new("dual-http in response task pending", GwErrorKind::Connect))?;
+        result.map_err(|e| custom_err!("dual-http in response task", e))?
     }
 }
 
-/// Open a TLS WebSocket to the gateway and authenticate the upgrade.
-pub(crate) async fn open_websocket_transport(
+/// Open a TLS transport to the gateway, preferring a WebSocket upgrade and falling back to dual HTTP.
+pub(crate) async fn open_gateway_transport(
     target: &GwConnectTarget,
 ) -> Result<(PacketIo, core::net::SocketAddr), Error> {
     let gw_host = target
         .gw_endpoint
-        .split(":")
+        .split(':')
         .next()
-        .ok_or_else(|| Error::new("Connect", GwErrorKind::InvalidGwTarget))?;
+        .ok_or_else(|| Error::new("connect", GwErrorKind::InvalidGwTarget))?;
+    let gw_host = gw_host.to_owned();
 
     let stream = TcpStream::connect(&target.gw_endpoint)
         .await
-        .map_err(|e| custom_err!("TCP connect", e))?;
+        .map_err(|e| custom_err!("tcp connect", e))?;
     let client_addr = stream
         .local_addr()
         .map_err(|e| custom_err!("get socket local address", e))?;
-
-    let (stream, _) = ironrdp_tls::upgrade(stream, gw_host)
+    let (stream, _) = ironrdp_tls::upgrade(stream, &gw_host)
         .await
-        .map_err(|e| custom_err!("TLS connect", e))?;
+        .map_err(|e| custom_err!("tls connect", e))?;
 
-    let connection_id = format!("{{{}}}", uuid::Uuid::new_v4());
-    let spn = format!("HTTP/{gw_host}");
-
-    let stream = hyper_util::rt::tokio::TokioIo::new(stream);
-    let (mut sender, mut conn) = hyper::client::conn::http1::handshake(stream)
-        .await
-        .map_err(|e| custom_err!("H1 Handshake", e))?;
-    let (tx, rx) = oneshot::channel();
-
-    let jh = tokio::task::spawn(async move {
-        tokio::select! {
-            Err(e) = &mut conn => error!("Handshake error: {:?}", e),
-            _ = rx => (),
-        }
-        conn.into_parts()
-    });
-    websocket_upgrade_with_auth(&mut sender, gw_host, &connection_id, target, &spn).await?;
-
-    let _ = tx.send(()); // TODO: Not needed since it doesnt keep alive conn?
-    let stream = jh.await.map_err(|e| custom_err!("WS join", e))?.io.into_inner();
-
-    let ws_stream = WebSocketStream::from_raw_socket(stream, Role::Client, None).await;
-    let (sink, stream) = ws_stream.split();
-    Ok((PacketIo { sink, stream }, client_addr))
+    let in_gw_host = gw_host.clone();
+    open_transport_with_out_stream(Box::new(stream), client_addr, &gw_host, target, move || async move {
+        let stream = TcpStream::connect(&target.gw_endpoint)
+            .await
+            .map_err(|e| custom_err!("tcp connect", e))?;
+        let (stream, _) = ironrdp_tls::upgrade(stream, &in_gw_host)
+            .await
+            .map_err(|e| custom_err!("tls connect", e))?;
+        let stream: GatewayStream = Box::new(stream);
+        Ok(stream)
+    })
+    .await
 }
 
-/// Challenge-first WebSocket upgrade: omit Authorization until 401, then Negotiate/NTLM/Basic.
-async fn websocket_upgrade_with_auth(
-    sender: &mut hyper::client::conn::http1::SendRequest<http_body_util::Empty<Bytes>>,
+async fn open_transport_with_out_stream<F, Fut>(
+    out_stream: GatewayStream,
+    client_addr: core::net::SocketAddr,
     gw_host: &str,
-    connection_id: &str,
     target: &GwConnectTarget,
+    open_in_stream: F,
+) -> Result<(PacketIo, core::net::SocketAddr), Error>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = Result<GatewayStream, Error>>,
+{
+    let connection_id = format!("{{{}}}", uuid::Uuid::new_v4());
+    let spn = format!("HTTP/{gw_host}");
+    let out_io = hyper_util::rt::tokio::TokioIo::new(out_stream);
+    let (mut out_sender, out_conn) = hyper::client::conn::http1::handshake(out_io)
+        .await
+        .map_err(|e| custom_err!("http/1 out handshake", e))?;
+    let (out_stop_tx, out_stop_rx) = oneshot::channel();
+    let mut out_conn = Box::pin(out_conn.without_shutdown());
+    let out_conn_jh = tokio::task::spawn(async move {
+        tokio::select! {
+            result = &mut out_conn => {
+                match result {
+                    Ok(parts) => Some(parts),
+                    Err(error) => {
+                        error!("RD Gateway OUT HTTP connection error: {error:?}");
+                        None
+                    }
+                }
+            }
+            _ = out_stop_rx => None,
+        }
+    });
+
+    let mut cookies = GatewayCookies::default();
+    let context = RdgRequestContext {
+        method: "RDG_OUT_DATA",
+        gw_host,
+        connection_id: &connection_id,
+        target,
+        websocket_upgrade: true,
+    };
+    let response = authenticated_rdg_request(&mut out_sender, &context, &spn, &mut cookies).await?;
+
+    match response.status() {
+        http::StatusCode::SWITCHING_PROTOCOLS => {
+            let parts = out_conn_jh
+                .await
+                .map_err(|e| custom_err!("websocket upgrade join", e))?
+                .ok_or_else(|| Error::new("websocket upgrade connection lost", GwErrorKind::Connect))?;
+            let stream = WebSocketStream::from_raw_socket(parts.io.into_inner(), Role::Client, None).await;
+            let (sink, stream) = stream.split();
+            Ok((PacketIo::WebSocket { sink, stream }, client_addr))
+        }
+        http::StatusCode::OK => {
+            let mut out_body = response.into_body();
+            let out_buf = skip_out_seed(&mut out_body).await?;
+            drop(out_sender);
+            let out_conn = tokio::spawn(async move {
+                let _ = out_conn_jh.await;
+            });
+            let io = open_in_channel(
+                open_in_stream().await?,
+                gw_host,
+                target,
+                &connection_id,
+                &spn,
+                &mut cookies,
+                out_body,
+                out_buf,
+                out_stop_tx,
+                out_conn,
+            )
+            .await?;
+            Ok((io, client_addr))
+        }
+        status => {
+            drain_response_body(response.into_body(), "drain rdg out response body").await?;
+            Err(Error::new("rdg out data", GwErrorKind::HttpStatus(status.as_u16())))
+        }
+    }
+}
+
+#[cfg(feature = "test-support")]
+pub(crate) async fn open_test_transport(
+    out_stream: tokio::io::DuplexStream,
+    in_stream: tokio::io::DuplexStream,
+) -> Result<PacketIo, Error> {
+    let target = GwConnectTarget {
+        gw_endpoint: "gateway.test:443".to_owned(),
+        gw_user: "user".to_owned(),
+        gw_pass: "pass".to_owned(),
+        server: "server.test".to_owned(),
+    };
+    let client_addr = "127.0.0.1:0"
+        .parse()
+        .map_err(|e| custom_err!("parse test client address", e))?;
+    open_transport_with_out_stream(
+        Box::new(out_stream),
+        client_addr,
+        "gateway.test",
+        &target,
+        move || async move {
+            let stream: GatewayStream = Box::new(in_stream);
+            Ok(stream)
+        },
+    )
+    .await
+    .map(|(io, _)| io)
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "carries both established dual HTTP channel states"
+)]
+async fn open_in_channel(
+    in_stream: GatewayStream,
+    gw_host: &str,
+    target: &GwConnectTarget,
+    connection_id: &str,
     spn: &str,
-) -> Result<(), Error> {
+    cookies: &mut GatewayCookies,
+    out_body: Incoming,
+    out_buf: Vec<u8>,
+    out_stop_tx: oneshot::Sender<()>,
+    out_conn: tokio::task::JoinHandle<()>,
+) -> Result<PacketIo, Error> {
+    let in_io = hyper_util::rt::tokio::TokioIo::new(in_stream);
+    let (mut in_sender, in_conn) = hyper::client::conn::http1::handshake(in_io)
+        .await
+        .map_err(|e| custom_err!("http/1 in handshake", e))?;
+    let in_conn = tokio::spawn(async move {
+        if let Err(error) = in_conn.await {
+            error!("RD Gateway IN HTTP connection error: {error:?}");
+        }
+    });
+
+    let context = RdgRequestContext {
+        method: "RDG_IN_DATA",
+        gw_host,
+        connection_id,
+        target,
+        websocket_upgrade: false,
+    };
+    let response = authenticated_rdg_request(&mut in_sender, &context, spn, cookies).await?;
+    if response.status() != http::StatusCode::OK {
+        let status = response.status();
+        drain_response_body(response.into_body(), "drain rdg in response body").await?;
+        return Err(Error::new("rdg in data", GwErrorKind::HttpStatus(status.as_u16())));
+    }
+    drain_response_body(response.into_body(), "drain rdg in authentication body").await?;
+
+    let (in_tx, in_body) = BodyChannel::<Bytes>::new(16);
+    let write_req = build_rdg_request(&context, None, false, cookies, in_body.boxed(), true)?;
+
+    let in_response = tokio::spawn(async move {
+        let response = in_sender
+            .send_request(write_req)
+            .await
+            .map_err(|e| custom_err!("send rdg in data request", e))?;
+        let status = response.status();
+        drain_response_body(response.into_body(), "drain rdg in data response").await?;
+        if status != http::StatusCode::OK {
+            return Err(Error::new("rdg in data", GwErrorKind::HttpStatus(status.as_u16())));
+        }
+        Ok(())
+    });
+
+    Ok(PacketIo::DualHttp {
+        out_body,
+        out_buf,
+        in_tx: Some(in_tx),
+        in_response: Some(in_response),
+        _out_stop_tx: out_stop_tx,
+        _out_conn: out_conn,
+        _in_conn: in_conn,
+    })
+}
+
+async fn authenticated_rdg_request(
+    sender: &mut hyper::client::conn::http1::SendRequest<RdgBody>,
+    context: &RdgRequestContext<'_>,
+    spn: &str,
+    cookies: &mut GatewayCookies,
+) -> Result<http::Response<Incoming>, Error> {
     let mut http_auth: Option<GatewayHttpAuth> = None;
     let mut authorization: Option<String> = None;
     let mut use_basic = false;
     const MAX_AUTH_ROUNDS: usize = 8;
 
     for _ in 0..MAX_AUTH_ROUNDS {
-        let req = build_ws_upgrade_request(
-            gw_host,
-            connection_id,
-            if use_basic {
-                Some(basic_authorization(&target.gw_user, &target.gw_pass))
-            } else {
-                authorization.clone()
-            }
-            .as_deref(),
+        let request = build_rdg_request(
+            context,
+            authorization.as_deref(),
+            use_basic,
+            cookies,
+            empty_rdg_body(),
+            false,
         )?;
-
-        let resp = sender
-            .send_request(req)
+        let response = sender
+            .send_request(request)
             .await
-            .map_err(|e| custom_err!("WS Upgrade Send error", e))?;
+            .map_err(|e| custom_err!("send rdg authentication request", e))?;
+        cookies.capture(response.headers());
 
-        if resp.status() == http::StatusCode::SWITCHING_PROTOCOLS {
-            if let Some(mut auth) = http_auth.take() {
-                let challenges: Vec<String> = www_authenticate_values(resp.headers())
+        if response.status() != http::StatusCode::UNAUTHORIZED {
+            if let Some(mut auth) = http_auth {
+                let challenges: Vec<String> = www_authenticate_values(response.headers())
                     .into_iter()
                     .map(str::to_owned)
                     .collect();
                 run_http_auth(move || auth.finish_www_authenticate(challenges.iter().map(String::as_str))).await?;
             }
-            return Ok(());
-        }
-
-        if resp.status() != http::StatusCode::UNAUTHORIZED {
-            return Err(Error::new("WS Upgrade", GwErrorKind::Connect));
+            return Ok(response);
         }
 
         if use_basic {
-            return Err(Error::new("websocket upgrade basic auth", GwErrorKind::Connect));
+            let status = response.status();
+            drain_response_body(response.into_body(), "drain rdg basic authentication body").await?;
+            return Err(Error::new(
+                "rdg basic authentication",
+                GwErrorKind::HttpStatus(status.as_u16()),
+            ));
         }
 
-        let challenges: Vec<String> = www_authenticate_values(resp.headers())
+        let challenges: Vec<String> = www_authenticate_values(response.headers())
             .into_iter()
             .map(str::to_owned)
             .collect();
-        resp.into_body()
-            .collect()
-            .await
-            .map_err(|e| custom_err!("drain websocket upgrade auth body", e))?;
+        drain_response_body(response.into_body(), "drain rdg authentication body").await?;
 
-        let user = target.gw_user.clone();
-        let pass = target.gw_pass.clone();
+        let user = context.target.gw_user.clone();
+        let pass = context.target.gw_pass.clone();
         let target_name = spn.to_owned();
         let step = if let Some(mut auth) = http_auth.take() {
             let (auth, step) = run_http_auth(move || {
@@ -192,17 +469,146 @@ async fn websocket_upgrade_with_auth(
             AuthStep::TryBasic => use_basic = true,
             AuthStep::Complete => {
                 return Err(Error::new(
-                    "websocket upgrade auth complete without switching protocols",
+                    "rdg authentication completed without a successful response",
                     GwErrorKind::Connect,
                 ));
             }
         }
     }
 
-    Err(Error::new(
-        "websocket upgrade auth rounds exceeded",
-        GwErrorKind::Connect,
-    ))
+    Err(Error::new("rdg authentication rounds exceeded", GwErrorKind::Connect))
+}
+
+fn empty_rdg_body() -> RdgBody {
+    Empty::<Bytes>::new().boxed()
+}
+
+fn build_rdg_request(
+    context: &RdgRequestContext<'_>,
+    authorization: Option<&str>,
+    use_basic: bool,
+    cookies: &GatewayCookies,
+    body: RdgBody,
+    content_type: bool,
+) -> Result<http::Request<RdgBody>, Error> {
+    let mut request = http::Request::builder()
+        .method(context.method)
+        .uri("/remoteDesktopGateway/")
+        .header(hyper::header::HOST, context.gw_host)
+        .header("Rdg-Connection-Id", context.connection_id)
+        .header(hyper::header::ACCEPT, "*/*")
+        .header(hyper::header::CACHE_CONTROL, "no-cache")
+        .header(hyper::header::PRAGMA, "no-cache");
+    if let Some(cookie_header) = cookies.header_value() {
+        request = request.header(hyper::header::COOKIE, cookie_header);
+    }
+    if context.websocket_upgrade {
+        request = request
+            .header(hyper::header::CONNECTION, "Upgrade")
+            .header(hyper::header::UPGRADE, "websocket")
+            .header(hyper::header::SEC_WEBSOCKET_VERSION, "13")
+            .header(hyper::header::SEC_WEBSOCKET_KEY, generate_key());
+    }
+    if use_basic {
+        request = request.header(
+            hyper::header::AUTHORIZATION,
+            basic_authorization(&context.target.gw_user, &context.target.gw_pass),
+        );
+    } else if let Some(authorization) = authorization {
+        request = request.header(hyper::header::AUTHORIZATION, authorization);
+    }
+    if content_type {
+        request = request.header(hyper::header::CONTENT_TYPE, "application/octet-stream");
+    }
+    request.body(body).map_err(|e| custom_err!("build rdg request", e))
+}
+
+async fn read_complete_packet(body: &mut Incoming, buf: &mut Vec<u8>) -> Result<Option<Bytes>, Error> {
+    while buf.len() < PACKET_HEADER_SIZE {
+        if !pull_body_chunk(body, buf).await? {
+            return if buf.is_empty() {
+                Ok(None)
+            } else {
+                Err(Error::new("dual-http packet header truncated", GwErrorKind::PacketEof))
+            };
+        }
+    }
+    let total = {
+        let mut cursor = ReadCursor::new(buf);
+        let header = PktHdr::decode(&mut cursor).map_err(|e| custom_err!("decode packet header", e))?;
+        usize::try_from(header.length).map_err(|_| Error::new("packet length", GwErrorKind::Decode))?
+    };
+    if !(PACKET_HEADER_SIZE..=MAX_PACKET_SIZE).contains(&total) {
+        return Err(Error::new("invalid packet length", GwErrorKind::Decode));
+    }
+    while buf.len() < total {
+        if !pull_body_chunk(body, buf).await? {
+            return Err(Error::new("dual-http packet truncated", GwErrorKind::PacketEof));
+        }
+    }
+    let packet = Bytes::copy_from_slice(&buf[..total]);
+    buf.drain(..total);
+    Ok(Some(packet))
+}
+
+async fn pull_body_chunk(body: &mut Incoming, buf: &mut Vec<u8>) -> Result<bool, Error> {
+    loop {
+        let Some(frame) = body.frame().await else {
+            return Ok(false);
+        };
+        let frame = frame.map_err(|e| custom_err!("dual-http out read", e))?;
+        let Ok(data) = frame.into_data() else {
+            continue;
+        };
+        if data.is_empty() {
+            continue;
+        }
+        if buf.len().saturating_add(data.len()) > MAX_PACKET_SIZE {
+            return Err(Error::new("dual-http packet exceeds limit", GwErrorKind::Decode));
+        }
+        buf.extend_from_slice(&data);
+        return Ok(true);
+    }
+}
+
+async fn skip_out_seed(body: &mut Incoming) -> Result<Vec<u8>, Error> {
+    let mut skipped = 0usize;
+    while skipped < OUT_SEED_SIZE {
+        let Some(frame) = body.frame().await else {
+            return Ok(Vec::new());
+        };
+        let frame = frame.map_err(|e| custom_err!("read rdg out seed", e))?;
+        let Ok(data) = frame.into_data() else {
+            continue;
+        };
+        let needed = OUT_SEED_SIZE - skipped;
+        if data.len() <= needed {
+            skipped += data.len();
+        } else {
+            if data.len() - needed > MAX_PACKET_SIZE {
+                return Err(Error::new("dual-http packet exceeds limit", GwErrorKind::Decode));
+            }
+            return Ok(data[needed..].to_vec());
+        }
+    }
+    Ok(Vec::new())
+}
+
+async fn drain_response_body(mut body: Incoming, context: &'static str) -> Result<(), Error> {
+    let mut size = 0usize;
+    while let Some(frame) = body.frame().await {
+        let frame = frame.map_err(|e| custom_err!(context, e))?;
+        let Ok(data) = frame.into_data() else {
+            continue;
+        };
+        size = size
+            .checked_add(data.len())
+            .ok_or_else(|| Error::new("http response body too large", GwErrorKind::Decode))?;
+        if size > MAX_AUTH_RESPONSE_SIZE {
+            return Err(Error::new("http response body too large", GwErrorKind::Decode));
+        }
+    }
+    Ok(())
 }
 
 async fn run_http_auth<T, F>(f: F) -> Result<T, Error>
@@ -213,27 +619,4 @@ where
     tokio::task::spawn_blocking(f)
         .await
         .map_err(|e| custom_err!("http auth task", e))?
-}
-
-fn build_ws_upgrade_request(
-    gw_host: &str,
-    connection_id: &str,
-    authorization: Option<&str>,
-) -> Result<http::Request<http_body_util::Empty<Bytes>>, Error> {
-    let mut req = http::Request::builder()
-        .method("RDG_OUT_DATA")
-        .header(hyper::header::HOST, gw_host)
-        .header("Rdg-Connection-Id", connection_id)
-        .uri("/remoteDesktopGateway/")
-        .header(hyper::header::CONNECTION, "Upgrade")
-        .header(hyper::header::UPGRADE, "websocket")
-        .header(hyper::header::SEC_WEBSOCKET_VERSION, "13")
-        .header(hyper::header::SEC_WEBSOCKET_KEY, generate_key());
-
-    if let Some(authorization) = authorization {
-        req = req.header(hyper::header::AUTHORIZATION, authorization);
-    }
-
-    req.body(http_body_util::Empty::<Bytes>::new())
-        .map_err(|e| custom_err!("failed to build request", e))
 }

--- a/crates/ironrdp-mstsgu/src/test_support.rs
+++ b/crates/ironrdp-mstsgu/src/test_support.rs
@@ -1,0 +1,36 @@
+//! Test-only hooks for exercising the gateway HTTP transport without a TLS listener.
+
+use hyper::body::Bytes;
+
+use crate::packet_io::{PacketIo, open_test_transport};
+
+/// In-memory gateway transport used by the registered integration tests.
+pub struct GatewayTransport(PacketIo);
+
+impl GatewayTransport {
+    /// Connect the client side of the mock OUT and IN HTTP connections.
+    pub async fn connect(
+        out_stream: tokio::io::DuplexStream,
+        in_stream: tokio::io::DuplexStream,
+    ) -> Result<Self, String> {
+        open_test_transport(out_stream, in_stream)
+            .await
+            .map(Self)
+            .map_err(|error| error.to_string())
+    }
+
+    /// Send one MS-TSGU packet to the mock gateway.
+    pub async fn send_packet(&mut self, packet: &[u8]) -> Result<(), String> {
+        self.0.send_bytes(packet).await.map_err(|error| error.to_string())
+    }
+
+    /// Read one MS-TSGU packet from the mock gateway.
+    pub async fn read_packet(&mut self) -> Result<Option<Bytes>, String> {
+        self.0.read_packet_buf().await.map_err(|error| error.to_string())
+    }
+
+    /// Finish the mock gateway IN request body.
+    pub async fn close(&mut self) -> Result<(), String> {
+        self.0.close().await.map_err(|error| error.to_string())
+    }
+}

--- a/crates/ironrdp-mstsgu/tests/packet_io.rs
+++ b/crates/ironrdp-mstsgu/tests/packet_io.rs
@@ -296,6 +296,69 @@ async fn dual_http_reports_in_authentication_rejection() {
     in_server.await.expect("IN task");
 }
 
+#[tokio::test]
+async fn dual_http_close_reports_final_in_status() {
+    let (out_client, out_server) = tokio::io::duplex(4096);
+    let (in_client, in_server) = tokio::io::duplex(4096);
+
+    let out_server = tokio::spawn(async move {
+        let steps = Arc::new(AtomicUsize::new(0));
+        let service = service_fn(move |request: Request<hyper::body::Incoming>| {
+            let steps = Arc::clone(&steps);
+            async move {
+                assert_eq!(request.method(), "RDG_OUT_DATA");
+                match steps.fetch_add(1, Ordering::SeqCst) {
+                    0 => Ok::<_, Infallible>(response(
+                        StatusCode::UNAUTHORIZED,
+                        &[("www-authenticate", "Basic realm=\"RDG\"")],
+                        Bytes::new(),
+                    )),
+                    1 => Ok(response(StatusCode::OK, &[], Bytes::from_static(b"0123456789"))),
+                    _ => panic!("unexpected OUT request"),
+                }
+            }
+        });
+        http1::Builder::new()
+            .serve_connection(TokioIo::new(out_server), service)
+            .await
+            .expect("serve OUT");
+    });
+
+    let in_server = tokio::spawn(async move {
+        let steps = Arc::new(AtomicUsize::new(0));
+        let service = service_fn(move |request: Request<hyper::body::Incoming>| {
+            let steps = Arc::clone(&steps);
+            async move {
+                match steps.fetch_add(1, Ordering::SeqCst) {
+                    0 => Ok::<_, Infallible>(response(
+                        StatusCode::UNAUTHORIZED,
+                        &[("www-authenticate", "Basic realm=\"RDG\"")],
+                        Bytes::new(),
+                    )),
+                    1 => Ok(response(StatusCode::OK, &[], Bytes::new())),
+                    2 => {
+                        request.into_body().collect().await.expect("drain IN request");
+                        Ok(response(StatusCode::FORBIDDEN, &[], Bytes::new()))
+                    }
+                    _ => panic!("unexpected IN request"),
+                }
+            }
+        });
+        http1::Builder::new()
+            .serve_connection(TokioIo::new(in_server), service)
+            .await
+            .expect("serve IN");
+    });
+
+    let mut transport = GatewayTransport::connect(out_client, in_client).await.expect("connect");
+    let error = transport.close().await.expect_err("final IN status must fail close");
+    assert!(error.contains("rdg in data"));
+    assert!(error.contains("unexpected http status 403"));
+
+    out_server.await.expect("OUT task");
+    in_server.await.expect("IN task");
+}
+
 fn response(status: StatusCode, headers: &[(&str, &str)], body: Bytes) -> Response<TestBody> {
     let mut response = Response::new(Full::new(body).boxed());
     *response.status_mut() = status;

--- a/crates/ironrdp-mstsgu/tests/packet_io.rs
+++ b/crates/ironrdp-mstsgu/tests/packet_io.rs
@@ -1,0 +1,309 @@
+#![allow(unused_crate_dependencies)]
+
+use core::convert::Infallible;
+use core::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use futures_util::{SinkExt as _, StreamExt as _};
+use http_body_util::combinators::BoxBody;
+use http_body_util::{BodyExt as _, Full};
+use hyper::body::Bytes;
+use hyper::header::{HeaderName, HeaderValue};
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use ironrdp_mstsgu::test_support::GatewayTransport;
+use tokio::sync::oneshot;
+use tokio_tungstenite::WebSocketStream;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::protocol::Role;
+
+type TestBody = BoxBody<Bytes, Infallible>;
+
+const PACKET: &[u8] = &[
+    0x0D, 0x00, // type: keepalive
+    0x00, 0x00, // reserved
+    0x08, 0x00, 0x00, 0x00, // length
+];
+
+#[tokio::test]
+async fn switching_protocols_keeps_websocket_transport() {
+    let (out_client, out_server) = tokio::io::duplex(4096);
+    let (in_client, _in_server) = tokio::io::duplex(4096);
+    let (upgrade_tx, upgrade_rx) = oneshot::channel();
+
+    let server = tokio::spawn(async move {
+        let upgrade_tx = Arc::new(Mutex::new(Some(upgrade_tx)));
+        let service = service_fn(move |mut request: Request<hyper::body::Incoming>| {
+            let upgrade = hyper::upgrade::on(&mut request);
+            let upgrade_tx = Arc::clone(&upgrade_tx);
+            async move {
+                assert_eq!(request.method(), "RDG_OUT_DATA");
+                assert!(request.headers().get("authorization").is_none());
+                upgrade_tx
+                    .lock()
+                    .expect("upgrade sender lock")
+                    .take()
+                    .expect("one websocket request")
+                    .send(upgrade)
+                    .expect("send upgrade");
+
+                let mut response = Response::new(Full::new(Bytes::new()).boxed());
+                *response.status_mut() = StatusCode::SWITCHING_PROTOCOLS;
+                response
+                    .headers_mut()
+                    .insert("connection", "Upgrade".parse().expect("header"));
+                response
+                    .headers_mut()
+                    .insert("upgrade", "websocket".parse().expect("header"));
+                Ok::<_, Infallible>(response)
+            }
+        });
+        http1::Builder::new()
+            .serve_connection(TokioIo::new(out_server), service)
+            .with_upgrades()
+            .await
+            .expect("serve websocket");
+    });
+
+    let mut transport = GatewayTransport::connect(out_client, in_client).await.expect("connect");
+    let upgraded = upgrade_rx.await.expect("receive upgrade").await.expect("upgrade");
+    let mut websocket = WebSocketStream::<TokioIo<hyper::upgrade::Upgraded>>::from_raw_socket(
+        TokioIo::new(upgraded),
+        Role::Server,
+        None,
+    )
+    .await;
+
+    websocket
+        .send(Message::Binary(Bytes::from_static(b"gateway packet")))
+        .await
+        .expect("send websocket packet");
+    assert_eq!(
+        transport.read_packet().await.expect("read websocket packet"),
+        Some(Bytes::from_static(b"gateway packet"))
+    );
+
+    transport
+        .send_packet(b"client packet")
+        .await
+        .expect("send websocket packet");
+    assert_eq!(
+        websocket
+            .next()
+            .await
+            .expect("websocket message")
+            .expect("websocket result")
+            .into_data(),
+        Bytes::from_static(b"client packet")
+    );
+
+    transport.close().await.expect("close websocket");
+    server.await.expect("server task");
+}
+
+#[tokio::test]
+async fn dual_http_authenticates_replays_cookies_and_transfers_packets() {
+    let (out_client, out_server) = tokio::io::duplex(4096);
+    let (in_client, in_server) = tokio::io::duplex(4096);
+    let (in_packet_tx, in_packet_rx) = oneshot::channel();
+    let out_step = Arc::new(AtomicUsize::new(0));
+    let in_step = Arc::new(AtomicUsize::new(0));
+
+    let out_server = tokio::spawn({
+        let out_step = Arc::clone(&out_step);
+        async move {
+            let service = service_fn(move |request: Request<hyper::body::Incoming>| {
+                let out_step = Arc::clone(&out_step);
+                async move {
+                    assert_eq!(request.method(), "RDG_OUT_DATA");
+                    assert_eq!(request.headers()["rdg-connection-id"].as_bytes().first(), Some(&b'{'));
+                    match out_step.fetch_add(1, Ordering::SeqCst) {
+                        0 => {
+                            assert!(request.headers().get("authorization").is_none());
+                            Ok::<_, Infallible>(response(
+                                StatusCode::UNAUTHORIZED,
+                                &[
+                                    ("www-authenticate", "Basic realm=\"RDG\""),
+                                    ("set-cookie", "route=out; Path=/"),
+                                ],
+                                Bytes::new(),
+                            ))
+                        }
+                        1 => {
+                            assert_eq!(request.headers()["authorization"], "Basic dXNlcjpwYXNz");
+                            assert_eq!(request.headers()["cookie"], "route=out");
+                            Ok(response(
+                                StatusCode::OK,
+                                &[("set-cookie", "route=out-auth; Path=/")],
+                                Bytes::from([b"0123456789".as_slice(), PACKET].concat()),
+                            ))
+                        }
+                        _ => panic!("unexpected OUT request"),
+                    }
+                }
+            });
+            http1::Builder::new()
+                .serve_connection(TokioIo::new(out_server), service)
+                .await
+                .expect("serve OUT");
+        }
+    });
+
+    let in_server = tokio::spawn({
+        let in_step = Arc::clone(&in_step);
+        async move {
+            let in_packet_tx = Arc::new(Mutex::new(Some(in_packet_tx)));
+            let service = service_fn(move |mut request: Request<hyper::body::Incoming>| {
+                let in_step = Arc::clone(&in_step);
+                let in_packet_tx = Arc::clone(&in_packet_tx);
+                async move {
+                    assert_eq!(request.method(), "RDG_IN_DATA");
+                    match in_step.fetch_add(1, Ordering::SeqCst) {
+                        0 => {
+                            assert!(request.headers().get("authorization").is_none());
+                            assert_eq!(request.headers()["cookie"], "route=out-auth");
+                            Ok::<_, Infallible>(response(
+                                StatusCode::UNAUTHORIZED,
+                                &[
+                                    ("www-authenticate", "Basic realm=\"RDG\""),
+                                    ("set-cookie", "session=in-auth; Path=/"),
+                                ],
+                                Bytes::new(),
+                            ))
+                        }
+                        1 => {
+                            assert_eq!(request.headers()["authorization"], "Basic dXNlcjpwYXNz");
+                            assert_eq!(request.headers()["cookie"], "route=out-auth; session=in-auth");
+                            Ok(response(StatusCode::OK, &[], Bytes::new()))
+                        }
+                        2 => {
+                            let in_packet_tx = in_packet_tx
+                                .lock()
+                                .expect("IN data response sender lock")
+                                .take()
+                                .expect("IN data response sender");
+                            assert!(request.headers().get("authorization").is_none());
+                            assert_eq!(request.headers()["content-type"], "application/octet-stream");
+                            assert_eq!(request.headers()["transfer-encoding"], "chunked");
+                            assert_eq!(request.headers()["cookie"], "route=out-auth; session=in-auth");
+                            let frame = request
+                                .body_mut()
+                                .frame()
+                                .await
+                                .expect("IN request frame")
+                                .expect("IN request frame result")
+                                .into_data()
+                                .expect("IN request data frame");
+                            in_packet_tx.send(frame).expect("record IN packet");
+                            Ok(response(StatusCode::OK, &[], Bytes::new()))
+                        }
+                        _ => panic!("unexpected IN request"),
+                    }
+                }
+            });
+            http1::Builder::new()
+                .serve_connection(TokioIo::new(in_server), service)
+                .await
+                .expect("serve IN");
+        }
+    });
+
+    let mut transport = GatewayTransport::connect(out_client, in_client).await.expect("connect");
+    transport.send_packet(PACKET).await.expect("send IN packet");
+    assert_eq!(
+        in_packet_rx.await.expect("recorded IN packet"),
+        Bytes::from_static(PACKET)
+    );
+    assert_eq!(
+        transport.read_packet().await.expect("read OUT packet"),
+        Some(Bytes::from_static(PACKET))
+    );
+    transport.close().await.expect("close dual HTTP");
+
+    out_server.await.expect("OUT task");
+    in_server.await.expect("IN task");
+    assert_eq!(out_step.load(Ordering::SeqCst), 2);
+    assert_eq!(in_step.load(Ordering::SeqCst), 3);
+}
+
+#[tokio::test]
+async fn dual_http_reports_in_authentication_rejection() {
+    let (out_client, out_server) = tokio::io::duplex(4096);
+    let (in_client, in_server) = tokio::io::duplex(4096);
+
+    let out_server = tokio::spawn(async move {
+        let steps = Arc::new(AtomicUsize::new(0));
+        let service = service_fn(move |request: Request<hyper::body::Incoming>| {
+            let steps = Arc::clone(&steps);
+            async move {
+                match steps.fetch_add(1, Ordering::SeqCst) {
+                    0 => {
+                        assert!(request.headers().get("authorization").is_none());
+                        Ok::<_, Infallible>(response(
+                            StatusCode::UNAUTHORIZED,
+                            &[("www-authenticate", "Basic realm=\"RDG\"")],
+                            Bytes::new(),
+                        ))
+                    }
+                    1 => Ok(response(StatusCode::OK, &[], Bytes::from_static(b"0123456789"))),
+                    _ => panic!("unexpected OUT request"),
+                }
+            }
+        });
+        http1::Builder::new()
+            .serve_connection(TokioIo::new(out_server), service)
+            .await
+            .expect("serve OUT");
+    });
+
+    let in_server = tokio::spawn(async move {
+        let steps = Arc::new(AtomicUsize::new(0));
+        let service = service_fn(move |request: Request<hyper::body::Incoming>| {
+            let steps = Arc::clone(&steps);
+            async move {
+                assert_eq!(request.method(), "RDG_IN_DATA");
+                match steps.fetch_add(1, Ordering::SeqCst) {
+                    0 => Ok::<_, Infallible>(response(
+                        StatusCode::UNAUTHORIZED,
+                        &[("www-authenticate", "Basic realm=\"RDG\"")],
+                        Bytes::new(),
+                    )),
+                    1 => {
+                        assert_eq!(request.headers()["authorization"], "Basic dXNlcjpwYXNz");
+                        Ok(response(StatusCode::FORBIDDEN, &[], Bytes::new()))
+                    }
+                    _ => panic!("unexpected IN request"),
+                }
+            }
+        });
+        http1::Builder::new()
+            .serve_connection(TokioIo::new(in_server), service)
+            .await
+            .expect("serve IN");
+    });
+
+    let error = match GatewayTransport::connect(out_client, in_client).await {
+        Ok(_) => panic!("IN authentication must fail"),
+        Err(error) => error,
+    };
+    assert!(error.contains("rdg in data"));
+    assert!(error.contains("unexpected http status 403"));
+
+    out_server.await.expect("OUT task");
+    in_server.await.expect("IN task");
+}
+
+fn response(status: StatusCode, headers: &[(&str, &str)], body: Bytes) -> Response<TestBody> {
+    let mut response = Response::new(Full::new(body).boxed());
+    *response.status_mut() = status;
+    for (name, value) in headers {
+        response.headers_mut().insert(
+            HeaderName::from_bytes(name.as_bytes()).expect("response header name"),
+            HeaderValue::from_str(value).expect("response header value"),
+        );
+    }
+    response
+}


### PR DESCRIPTION
Support authenticated dual HTTP fallback after an RDG_OUT_DATA 200.
Retain WebSocket on 101 and replay gateway cookies across setup.