### PR TITLE
feat!: extract sequence contract

### DIFF
--- a/.agents/skills/commit-scope/SKILL.md
+++ b/.agents/skills/commit-scope/SKILL.md
@@ -10,7 +10,7 @@ Choose at most one optional scope for `<type>[optional scope][!]: <description>`
 ## Canonical scopes
 
 ```text
-meta core error pdu str bulk graphics config input connector session driver
+meta core error sequence pdu str bulk graphics config input connector session driver
 svc dvc cliprdr rdpdr rdpsnd rdpeai displaycontrol rdpei echo egfx rdpeudp rdpeusb rdpemt rdcleanpath
 tls mstsgu vmconnect
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -115,24 +115,17 @@ The Windows backend lives in [`crates/ironrdp-rdpewa-native`](./crates/ironrdp-r
 
 Sans-I/O state-machine contract shared by RDP connect and accept sequences.
 
-Defines the `Sequence` trait (one `step` per PDU, no I/O performed by the implementor) along with its
-supporting types: `State`, `Written`, `SequenceError`, `ServerName`, `DesktopSize`, and the
-`general_err!`/`reason_err!`/`custom_err!` helper macros. Also owns `MonotonicInstant`, the clock type
-passed into `Sequence::step`: it is colocated here, rather than in `ironrdp-core`, because reading time is
-part of what it means to drive this contract, not a foundational encoding primitive.
+Defines the `Sequence` trait (one `step` per PDU, no I/O performed by the implementor) along with its supporting types: `State`, `Written`, `SequenceError`, `ServerName`, `DesktopSize`, and the `general_err!`/`reason_err!`/`custom_err!` helper macros.
+Also owns `MonotonicInstant`, the clock type passed into `Sequence::step`.
+It is colocated here, rather than in `ironrdp-core`, because reading time is part of what it means to drive this contract, not a foundational encoding primitive.
 
-`MonotonicInstant` and `DesktopSize` carry no dependency beyond `core`/`alloc` and stay available
-unconditionally. Everything else needs `ironrdp-pdu`, so it is gated behind the `state-machine` feature
-(default-disabled): `ironrdp-rdpeudp` depends on this crate only for `MonotonicInstant` and must not be
-forced to pull in `ironrdp-pdu`'s much larger dependency tree just for the clock type.
+`MonotonicInstant` and `DesktopSize` need no allocation and stay available unconditionally.
+Everything else needs `ironrdp-pdu`, so it is gated behind the default-disabled `state-machine` feature.
+See the crate's `Cargo.toml` and README for the full feature-split rationale.
 
-`ironrdp-connector` and `ironrdp-rdpeudp` both re-export everything they previously defined directly from
-this crate, so existing `ironrdp_connector::{Sequence, MonotonicInstant, ...}` and
-`ironrdp_rdpeudp::MonotonicInstant` import paths remain stable.
+`ironrdp-connector` and `ironrdp-rdpeudp` both re-export everything they previously defined directly from this crate, so existing `ironrdp_connector::{Sequence, MonotonicInstant, ...}` and `ironrdp_rdpeudp::MonotonicInstant` import paths remain stable.
 
-This crate must never depend on `ironrdp-connector`, `sspi`, or any RDP connection-flow logic: it is the
-generic contract that `ironrdp-connector` (and any future accept-side or session-side sequence) is built
-on top of, not the other way around.
+**Architectural Invariant**: this crate must never depend on `ironrdp-connector`, `sspi`, or any RDP connection-flow logic; it is the generic contract that `ironrdp-connector` (and any future accept-side or session-side sequence) is built on top of, not the other way around.
 
 #### [`crates/ironrdp-connector`](./crates/ironrdp-connector)
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -111,6 +111,29 @@ AUDIO_INPUT dynamic channel for client microphone capture implemented as describ
 RDPEWA dynamic virtual channel for WebAuthn redirection as described in MS-RDPEWA.
 The Windows backend lives in [`crates/ironrdp-rdpewa-native`](./crates/ironrdp-rdpewa-native).
 
+#### [`crates/ironrdp-sequence`](./crates/ironrdp-sequence)
+
+Sans-I/O state-machine contract shared by RDP connect and accept sequences.
+
+Defines the `Sequence` trait (one `step` per PDU, no I/O performed by the implementor) along with its
+supporting types: `State`, `Written`, `SequenceError`, `ServerName`, `DesktopSize`, and the
+`general_err!`/`reason_err!`/`custom_err!` helper macros. Also owns `MonotonicInstant`, the clock type
+passed into `Sequence::step`: it is colocated here, rather than in `ironrdp-core`, because reading time is
+part of what it means to drive this contract, not a foundational encoding primitive.
+
+`MonotonicInstant` and `DesktopSize` carry no dependency beyond `core`/`alloc` and stay available
+unconditionally. Everything else needs `ironrdp-pdu`, so it is gated behind the `state-machine` feature
+(default-disabled): `ironrdp-rdpeudp` depends on this crate only for `MonotonicInstant` and must not be
+forced to pull in `ironrdp-pdu`'s much larger dependency tree just for the clock type.
+
+`ironrdp-connector` and `ironrdp-rdpeudp` both re-export everything they previously defined directly from
+this crate, so existing `ironrdp_connector::{Sequence, MonotonicInstant, ...}` and
+`ironrdp_rdpeudp::MonotonicInstant` import paths remain stable.
+
+This crate must never depend on `ironrdp-connector`, `sspi`, or any RDP connection-flow logic: it is the
+generic contract that `ironrdp-connector` (and any future accept-side or session-side sequence) is built
+on top of, not the other way around.
+
 #### [`crates/ironrdp-connector`](./crates/ironrdp-connector)
 
 State machines to drive an RDP connection sequence.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2726,6 +2726,7 @@ dependencies = [
  "ironrdp-core 0.2.1",
  "ironrdp-error 0.2.0",
  "ironrdp-pdu",
+ "ironrdp-sequence",
  "ironrdp-svc",
  "picky",
  "picky-asn1-der",
@@ -3061,6 +3062,7 @@ dependencies = [
  "bitflags 2.13.1",
  "ironrdp-core 0.2.1",
  "ironrdp-error 0.2.0",
+ "ironrdp-sequence",
 ]
 
 [[package]]
@@ -3160,6 +3162,15 @@ dependencies = [
  "tracing",
  "whoami",
  "windows",
+]
+
+[[package]]
+name = "ironrdp-sequence"
+version = "0.1.0"
+dependencies = [
+ "ironrdp-core 0.2.1",
+ "ironrdp-error 0.2.0",
+ "ironrdp-pdu",
 ]
 
 [[package]]

--- a/crates/ironrdp-connector/Cargo.toml
+++ b/crates/ironrdp-connector/Cargo.toml
@@ -26,6 +26,7 @@ ironrdp-svc = { path = "../ironrdp-svc", version = "0.8" } # public
 ironrdp-core = { path = "../ironrdp-core", version = "0.2" } # public
 ironrdp-error = { path = "../ironrdp-error", version = "0.2" } # public
 ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9", features = ["std"] } # public
+ironrdp-sequence = { path = "../ironrdp-sequence", version = "0.1", features = ["state-machine", "std"] } # public
 sspi = { version = "0.21", features = ["scard"] }
 url = "2.5" # public
 rand = { version = "0.9", features = ["std"] } # TODO: dependency injection?

--- a/crates/ironrdp-connector/src/lib.rs
+++ b/crates/ironrdp-connector/src/lib.rs
@@ -1,18 +1,13 @@
 #![cfg_attr(doc, doc = include_str!("../README.md"))]
 #![doc(html_logo_url = "https://cdnweb.devolutions.net/images/projects/devolutions/logos/devolutions-icon-shadow.svg")]
 
-mod macros;
-
 mod channel_connection;
 mod connection;
 pub mod connection_activation;
 mod connection_finalization;
 pub mod credssp;
 mod license_exchange;
-mod sequence_error;
-mod server_name;
 
-use core::any::Any;
 use core::fmt;
 use std::sync::Arc;
 
@@ -21,7 +16,7 @@ use ironrdp_pdu::nego::NegoRequestData;
 use ironrdp_pdu::rdp::capability_sets::{self, BitmapCodecs};
 use ironrdp_pdu::rdp::client_info::{self, PerformanceFlags, TimezoneInfo};
 use ironrdp_pdu::x224::X224;
-use ironrdp_pdu::{PduHint, gcc, x224};
+use ironrdp_pdu::{gcc, x224};
 pub use sspi;
 
 pub use self::channel_connection::{ChannelConnectionSequence, ChannelConnectionState};
@@ -31,69 +26,23 @@ pub use self::connection::{
 };
 pub use self::connection_finalization::{ConnectionFinalizationSequence, ConnectionFinalizationState};
 pub use self::license_exchange::{LicenseExchangeSequence, LicenseExchangeState};
-pub use self::sequence_error::{SequenceError, SequenceErrorExt, SequenceErrorKind, SequenceResult, SequenceResultExt};
-pub use self::server_name::ServerName;
 pub use crate::license_exchange::LicenseCache;
 /// Re-exported so `connect_*`/`accept_*` boundary functions across
 /// `ironrdp-async`, `ironrdp-blocking`, and `ironrdp-acceptor` can call
 /// `.map_err_as::<ConnectorErrorKind>()` without a direct `ironrdp-error`
 /// dependency. See the [`ironrdp_error::ErrorMapping`] impl on [`ConnectorErrorKind`] below.
 pub use ironrdp_error::ResultExt;
-
-/// Provides user-friendly error messages for RDP negotiation failures
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct NegotiationFailure(ironrdp_pdu::nego::FailureCode);
-
-impl NegotiationFailure {
-    pub fn code(self) -> ironrdp_pdu::nego::FailureCode {
-        self.0
-    }
-}
-
-impl core::error::Error for NegotiationFailure {}
-
-impl From<ironrdp_pdu::nego::FailureCode> for NegotiationFailure {
-    fn from(code: ironrdp_pdu::nego::FailureCode) -> Self {
-        Self(code)
-    }
-}
-
-impl fmt::Display for NegotiationFailure {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use ironrdp_pdu::nego::FailureCode;
-
-        match self.0 {
-            FailureCode::SSL_REQUIRED_BY_SERVER => {
-                write!(f, "server requires Enhanced RDP Security with TLS or CredSSP")
-            }
-            FailureCode::SSL_NOT_ALLOWED_BY_SERVER => {
-                write!(f, "server only supports Standard RDP Security")
-            }
-            FailureCode::SSL_CERT_NOT_ON_SERVER => {
-                write!(f, "server lacks valid authentication certificate")
-            }
-            FailureCode::INCONSISTENT_FLAGS => {
-                write!(f, "inconsistent security protocol flags")
-            }
-            FailureCode::HYBRID_REQUIRED_BY_SERVER => {
-                write!(f, "server requires Enhanced RDP Security with CredSSP")
-            }
-            FailureCode::SSL_WITH_USER_AUTH_REQUIRED_BY_SERVER => {
-                write!(
-                    f,
-                    "server requires Enhanced RDP Security with TLS and client certificate"
-                )
-            }
-            _ => write!(f, "unknown negotiation failure (code: 0x{:08x})", u32::from(self.0)),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct DesktopSize {
-    pub width: u16,
-    pub height: u16,
-}
+/// Permanent facade re-export. `ironrdp-sequence` is the sans-I/O state-machine
+/// contract crate that these items were extracted into; this crate keeps
+/// re-exporting them so existing `ironrdp_connector::{...}` import paths remain
+/// stable.
+pub use ironrdp_sequence::{
+    DesktopSize, MonotonicInstant, NegotiationFailure, Sequence, SequenceError, SequenceErrorExt, SequenceErrorKind,
+    SequenceResult, SequenceResultExt, ServerName, State, Written, state_downcast, state_is,
+};
+/// Permanent facade re-export of the macros previously defined directly in this
+/// crate; see [`ironrdp_sequence`] for their definitions.
+pub use ironrdp_sequence::{custom_err, general_err, reason_err};
 
 #[derive(Debug, Clone)]
 pub struct BitmapConfig {
@@ -302,116 +251,6 @@ pub struct Config {
 }
 
 ironrdp_core::assert_impl!(Config: Send, Sync);
-
-pub trait State: Send + fmt::Debug + 'static {
-    fn name(&self) -> &'static str;
-    fn is_terminal(&self) -> bool;
-    fn as_any(&self) -> &dyn Any;
-}
-
-ironrdp_core::assert_obj_safe!(State);
-
-pub fn state_downcast<T: State>(state: &dyn State) -> Option<&T> {
-    state.as_any().downcast_ref()
-}
-
-pub fn state_is<T: State>(state: &dyn State) -> bool {
-    state.as_any().is::<T>()
-}
-
-impl State for () {
-    fn name(&self) -> &'static str {
-        "()"
-    }
-
-    fn is_terminal(&self) -> bool {
-        true
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum Written {
-    Nothing,
-    Size(core::num::NonZeroUsize),
-}
-
-impl Written {
-    #[inline]
-    pub fn from_size(value: usize) -> SequenceResult<Self> {
-        core::num::NonZeroUsize::new(value)
-            .map(Self::Size)
-            .ok_or_else(|| SequenceError::general("invalid written length (can't be zero)"))
-    }
-
-    #[inline]
-    pub fn is_nothing(self) -> bool {
-        matches!(self, Self::Nothing)
-    }
-
-    #[inline]
-    pub fn size(self) -> Option<usize> {
-        if let Self::Size(size) = self {
-            Some(size.get())
-        } else {
-            None
-        }
-    }
-}
-
-/// A point on a monotonic millisecond clock owned by the I/O driver.
-///
-/// Lives in `ironrdp-core`, shared with `ironrdp-rdpeudp`, and re-exported
-/// here. The epoch is arbitrary and carries no meaning; only differences
-/// between two instants do. All instants passed to one connector across its
-/// lifetime must come from the same clock: comparing instants from two
-/// different epochs produces a meaningless delta rather than an error, either
-/// saturating to zero or landing on a huge value with no diagnostic.
-///
-/// The clock deliberately lives outside the sans-I/O sequences, because a
-/// sequence reading a clock itself would measure how quickly it drained an
-/// already-filled buffer rather than how long the bytes took to arrive. Only
-/// the driver that performed the read knows the latter, which is what the
-/// `None` in [`Sequence::step`] is for: a driver with no reading to pass on.
-/// `ironrdp-blocking` and `ironrdp-async` each stamp with their own
-/// driver-owned epoch; the FFI connector, which has no read loop of its own to
-/// time, stamps on entry to its `step` binding instead.
-pub use ironrdp_core::MonotonicInstant;
-
-pub trait Sequence: Send {
-    fn next_pdu_hint(&self) -> Option<&dyn PduHint>;
-
-    fn state(&self) -> &dyn State;
-
-    /// Advances the sequence.
-    ///
-    /// `received_at` is when `input` arrived on the wire, as observed by the I/O
-    /// driver, or `None` from a driver that does not observe arrival times. The
-    /// absence of a reading is deliberately not expressible as an instant: a
-    /// driver that cannot measure has taken no measurement, which is a different
-    /// thing from one that measured no elapsed time, and only the sequence
-    /// knows which of the two its reply may be derived from.
-    ///
-    /// A driver that always passes `None` never opens a connect-time bandwidth
-    /// window, so the Bandwidth Measure Results it sends report only the Stop's
-    /// own payload against the untimed floor. See `connection::counted_len`'s doc
-    /// for why the byte count is measurement-gated rather than reported in full.
-    fn step(
-        &mut self,
-        input: &[u8],
-        received_at: Option<MonotonicInstant>,
-        output: &mut WriteBuf,
-    ) -> SequenceResult<Written>;
-
-    fn step_no_input(&mut self, output: &mut WriteBuf) -> SequenceResult<Written> {
-        self.step(&[], None, output)
-    }
-}
-
-ironrdp_core::assert_obj_safe!(Sequence);
 
 pub type ConnectorResult<T> = Result<T, ConnectorError>;
 

--- a/crates/ironrdp-core/src/lib.rs
+++ b/crates/ironrdp-core/src/lib.rs
@@ -19,7 +19,6 @@ mod into_owned;
 #[cfg(feature = "alloc")]
 mod non_empty;
 mod padding;
-mod time;
 #[cfg(feature = "alloc")]
 mod write_buf;
 
@@ -49,6 +48,5 @@ pub use self::into_owned::IntoOwned;
 #[cfg(feature = "alloc")]
 pub use self::non_empty::NonEmpty;
 pub use self::padding::{read_padding, write_padding};
-pub use self::time::MonotonicInstant;
 #[cfg(feature = "alloc")]
 pub use self::write_buf::WriteBuf;

--- a/crates/ironrdp-rdpeudp/Cargo.toml
+++ b/crates/ironrdp-rdpeudp/Cargo.toml
@@ -31,6 +31,7 @@ arbitrary = ["dep:arbitrary", "std", "bitflags/arbitrary"]
 arbitrary = { version = "1", features = ["derive"], optional = true }
 ironrdp-core = { path = "../ironrdp-core", version = "0.2", features = ["alloc"] } # public
 ironrdp-error = { path = "../ironrdp-error", version = "0.2", features = ["alloc"] } # public
+ironrdp-sequence = { path = "../ironrdp-sequence", version = "0.1", default-features = false } # public
 bitflags = "2.11" # public
 
 [lints]

--- a/crates/ironrdp-rdpeudp/src/time.rs
+++ b/crates/ironrdp-rdpeudp/src/time.rs
@@ -4,10 +4,10 @@
 //! instant on every call that can advance time, and reports when it next wants
 //! to be woken through [`RdpeudpConnection::poll_timeout`].
 //!
-//! [`MonotonicInstant`] itself lives in `ironrdp-core`, shared with
+//! [`MonotonicInstant`] itself lives in `ironrdp-sequence`, shared with
 //! `ironrdp-connector`'s `Sequence::step`, and is re-exported here so
 //! existing callers of this crate are unaffected.
 //!
 //! [`RdpeudpConnection::poll_timeout`]: crate::RdpeudpConnection::poll_timeout
 
-pub use ironrdp_core::MonotonicInstant;
+pub use ironrdp_sequence::MonotonicInstant;

--- a/crates/ironrdp-sequence/Cargo.toml
+++ b/crates/ironrdp-sequence/Cargo.toml
@@ -45,3 +45,9 @@ ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9", optional = true } # pu
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+# `state-machine` (and the `ServerName` it implies via `alloc`) is
+# default-disabled, so without this docs.rs would build with `default = []`
+# and only render `DesktopSize`/`MonotonicInstant`.
+all-features = true

--- a/crates/ironrdp-sequence/Cargo.toml
+++ b/crates/ironrdp-sequence/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "ironrdp-sequence"
+version = "0.1.0"
+readme = "README.md"
+description = "Sans-I/O state-machine contract shared by RDP connect/accept sequences"
+edition.workspace = true
+rust-version = "1.94"
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lib]
+doctest = false
+test = false
+
+[features]
+# Matches `ironrdp-core`/`ironrdp-pdu`: `no_std` unless a consumer asks for `std`.
+default = []
+# Enables `ServerName`, which stores a heap-allocated string. `MonotonicInstant`
+# and `DesktopSize` need no allocation and stay available without this feature.
+alloc = []
+std = ["alloc", "ironrdp-core?/std", "ironrdp-error?/std", "ironrdp-pdu?/std"]
+# Gates the `Sequence` trait, `State`, `Written`, `SequenceError`, and the
+# `general_err!`/`reason_err!`/`custom_err!` macros, all of which need
+# `ironrdp-pdu` (for `PduHint` and negotiation failure codes) plus
+# `ironrdp-core`/`ironrdp-error`. Default-disabled and separate from
+# `MonotonicInstant`/`DesktopSize` (always available, dependency-free) so a
+# consumer that only needs the clock type -- e.g. `ironrdp-rdpeudp` -- is not
+# forced to pull in `ironrdp-pdu`'s much larger dependency tree (`der-parser`,
+# `x509-cert`, `pkcs1`, ...).
+state-machine = [
+  "ironrdp-core/alloc",
+  "ironrdp-error/alloc",
+  "dep:ironrdp-pdu",
+  "alloc",
+]
+
+[dependencies]
+ironrdp-core = { path = "../ironrdp-core", version = "0.2", optional = true } # public when `state-machine` is on
+ironrdp-error = { path = "../ironrdp-error", version = "0.2", optional = true } # public when `state-machine` is on
+ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9", optional = true } # public when `state-machine` is on
+
+[lints]
+workspace = true

--- a/crates/ironrdp-sequence/README.md
+++ b/crates/ironrdp-sequence/README.md
@@ -5,7 +5,8 @@ Sans-I/O state-machine contract shared by RDP connect and accept sequences.
 ## Purpose
 
 `ironrdp-connector` and `ironrdp-acceptor` each drive an RDP connection through a chain of phases (negotiation, channel connection, license exchange, activation, finalization).
-Both crates implement the same contract for that chain, so it lives here instead of being duplicated or having one crate depend on the other.
+Both crates implement the same contract for that chain; this crate is where it now lives, so it does not need to be defined a second time.
+`ironrdp-acceptor` still depends on `ironrdp-connector` directly today rather than on this crate; having it implement the contract from here instead, and drop that dependency, is a follow-up.
 
 The contract is entirely sans-I/O: a [`Sequence`] consumes at most one input PDU per [`Sequence::step`] call and produces at most one output PDU, leaving all reading, writing, and timing to the caller.
 

--- a/crates/ironrdp-sequence/README.md
+++ b/crates/ironrdp-sequence/README.md
@@ -1,0 +1,32 @@
+# IronRDP Sequence
+
+Sans-I/O state-machine contract shared by RDP connect and accept sequences.
+
+## Purpose
+
+`ironrdp-connector` and `ironrdp-acceptor` each drive an RDP connection through a chain of phases (negotiation, channel connection, license exchange, activation, finalization).
+Both crates implement the same contract for that chain, so it lives here instead of being duplicated or having one crate depend on the other.
+
+The contract is entirely sans-I/O: a [`Sequence`] consumes at most one input PDU per [`Sequence::step`] call and produces at most one output PDU, leaving all reading, writing, and timing to the caller.
+
+## What this crate provides
+
+- [`Sequence`], [`State`], and [`Written`]: the state-machine contract itself.
+- [`SequenceError`] and [`SequenceResult`]: the sspi-free error type a `Sequence` step can fail with.
+- [`ServerName`] and [`DesktopSize`]: small value types shared by every implementor.
+- [`MonotonicInstant`]: the millisecond clock reading passed to [`Sequence::step`], also used directly by `ironrdp-rdpeudp` for its own timers.
+
+`ironrdp-connector` re-exports every public item from this crate so downstream code keeps using `ironrdp_connector::{Sequence, MonotonicInstant, ...}` unchanged.
+`ironrdp-rdpeudp` re-exports [`MonotonicInstant`] the same way, as `ironrdp_rdpeudp::MonotonicInstant`.
+
+## Feature Flags
+
+- `std` (depends on `alloc`): enables `std` integration in `ironrdp-error`, `ironrdp-core`, and `ironrdp-pdu`.
+- `alloc`: enables [`ServerName`], which stores a heap-allocated string.
+- `state-machine` (depends on `alloc`): enables [`Sequence`], [`State`], [`Written`], [`SequenceError`], and the `general_err!`/`reason_err!`/`custom_err!` macros.
+  These need `ironrdp-pdu` (for the PDU framing hint returned by [`Sequence::next_pdu_hint`] and for negotiation failure codes), pulled in as an optional dependency only when this feature is on.
+  [`MonotonicInstant`], [`DesktopSize`], and [`ServerName`] have no such dependency and stay available without this feature, so a consumer that only needs the clock type — e.g. `ironrdp-rdpeudp` — is not forced to pull in `ironrdp-pdu`'s dependency tree.
+
+This crate is part of the [IronRDP] project.
+
+[IronRDP]: https://github.com/Devolutions/IronRDP

--- a/crates/ironrdp-sequence/src/desktop_size.rs
+++ b/crates/ironrdp-sequence/src/desktop_size.rs
@@ -1,0 +1,6 @@
+/// A negotiated remote desktop size, in pixels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DesktopSize {
+    pub width: u16,
+    pub height: u16,
+}

--- a/crates/ironrdp-sequence/src/lib.rs
+++ b/crates/ironrdp-sequence/src/lib.rs
@@ -10,6 +10,25 @@ extern crate alloc;
 #[cfg(feature = "state-machine")]
 mod macros;
 
+/// Not part of the public API. Exposed only so `reason_err!`'s expansion can
+/// reach `format!` through a `$crate`-qualified path.
+///
+/// A bare `format!` written inside a `macro_rules!` body is not fully
+/// hygienic: unlike item and type names, an unqualified macro invocation
+/// falls back to the *caller's* scope when it is not found at the
+/// definition site. A caller that has not itself imported `alloc::format`
+/// (e.g. a `no_std` crate depending on the `state-machine` feature) would
+/// then fail to compile `reason_err!(...)`, regardless of whether this
+/// crate itself is built with `alloc`/`std`. Routing through `$crate`
+/// resolves unconditionally against this crate's own `alloc`, sidestepping
+/// the caller's scope entirely. See `tests/reason_err.rs` for the
+/// regression test.
+#[cfg(feature = "state-machine")]
+#[doc(hidden)]
+pub mod __private {
+    pub use alloc::format;
+}
+
 mod desktop_size;
 #[cfg(feature = "state-machine")]
 mod negotiation_failure;

--- a/crates/ironrdp-sequence/src/lib.rs
+++ b/crates/ironrdp-sequence/src/lib.rs
@@ -1,0 +1,41 @@
+#![cfg_attr(doc, doc = include_str!("../README.md"))]
+#![doc(html_logo_url = "https://cdnweb.devolutions.net/images/projects/devolutions/logos/devolutions-icon-shadow.svg")]
+#![cfg_attr(not(feature = "std"), no_std)]
+#![warn(clippy::std_instead_of_alloc)]
+#![warn(clippy::std_instead_of_core)]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+#[cfg(feature = "state-machine")]
+mod macros;
+
+mod desktop_size;
+#[cfg(feature = "state-machine")]
+mod negotiation_failure;
+#[cfg(feature = "state-machine")]
+mod sequence;
+#[cfg(feature = "state-machine")]
+mod sequence_error;
+#[cfg(feature = "alloc")]
+mod server_name;
+#[cfg(feature = "state-machine")]
+mod state;
+mod time;
+#[cfg(feature = "state-machine")]
+mod written;
+
+pub use self::desktop_size::DesktopSize;
+#[cfg(feature = "state-machine")]
+pub use self::negotiation_failure::NegotiationFailure;
+#[cfg(feature = "state-machine")]
+pub use self::sequence::Sequence;
+#[cfg(feature = "state-machine")]
+pub use self::sequence_error::{SequenceError, SequenceErrorExt, SequenceErrorKind, SequenceResult, SequenceResultExt};
+#[cfg(feature = "alloc")]
+pub use self::server_name::ServerName;
+#[cfg(feature = "state-machine")]
+pub use self::state::{State, state_downcast, state_is};
+pub use self::time::MonotonicInstant;
+#[cfg(feature = "state-machine")]
+pub use self::written::Written;

--- a/crates/ironrdp-sequence/src/macros.rs
+++ b/crates/ironrdp-sequence/src/macros.rs
@@ -18,7 +18,7 @@ macro_rules! general_err {
 #[macro_export]
 macro_rules! reason_err {
     ( $context:expr, $($arg:tt)* ) => {{
-        <$crate::SequenceError as $crate::SequenceErrorExt>::reason($context, format!($($arg)*))
+        <$crate::SequenceError as $crate::SequenceErrorExt>::reason($context, $crate::__private::format!($($arg)*))
     }};
 }
 

--- a/crates/ironrdp-sequence/src/macros.rs
+++ b/crates/ironrdp-sequence/src/macros.rs
@@ -2,7 +2,7 @@
 ///
 /// Shorthand for
 /// ```rust
-/// <ironrdp_connector::SequenceError as ironrdp_connector::SequenceErrorExt>::general(context)
+/// <ironrdp_sequence::SequenceError as ironrdp_sequence::SequenceErrorExt>::general(context)
 /// ```
 #[macro_export]
 macro_rules! general_err {
@@ -13,7 +13,7 @@ macro_rules! general_err {
 ///
 /// Shorthand for
 /// ```rust
-/// <ironrdp_connector::SequenceError as ironrdp_connector::SequenceErrorExt>::reason(context, reason)
+/// <ironrdp_sequence::SequenceError as ironrdp_sequence::SequenceErrorExt>::reason(context, reason)
 /// ```
 #[macro_export]
 macro_rules! reason_err {
@@ -26,7 +26,7 @@ macro_rules! reason_err {
 ///
 /// Shorthand for
 /// ```rust
-/// <ironrdp_connector::SequenceError as ironrdp_connector::SequenceErrorExt>::custom(context, source)
+/// <ironrdp_sequence::SequenceError as ironrdp_sequence::SequenceErrorExt>::custom(context, source)
 /// ```
 #[macro_export]
 macro_rules! custom_err {

--- a/crates/ironrdp-sequence/src/negotiation_failure.rs
+++ b/crates/ironrdp-sequence/src/negotiation_failure.rs
@@ -1,0 +1,50 @@
+use core::fmt;
+
+/// Provides user-friendly error messages for RDP negotiation failures
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct NegotiationFailure(ironrdp_pdu::nego::FailureCode);
+
+impl NegotiationFailure {
+    pub fn code(self) -> ironrdp_pdu::nego::FailureCode {
+        self.0
+    }
+}
+
+impl core::error::Error for NegotiationFailure {}
+
+impl From<ironrdp_pdu::nego::FailureCode> for NegotiationFailure {
+    fn from(code: ironrdp_pdu::nego::FailureCode) -> Self {
+        Self(code)
+    }
+}
+
+impl fmt::Display for NegotiationFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use ironrdp_pdu::nego::FailureCode;
+
+        match self.0 {
+            FailureCode::SSL_REQUIRED_BY_SERVER => {
+                write!(f, "server requires Enhanced RDP Security with TLS or CredSSP")
+            }
+            FailureCode::SSL_NOT_ALLOWED_BY_SERVER => {
+                write!(f, "server only supports Standard RDP Security")
+            }
+            FailureCode::SSL_CERT_NOT_ON_SERVER => {
+                write!(f, "server lacks valid authentication certificate")
+            }
+            FailureCode::INCONSISTENT_FLAGS => {
+                write!(f, "inconsistent security protocol flags")
+            }
+            FailureCode::HYBRID_REQUIRED_BY_SERVER => {
+                write!(f, "server requires Enhanced RDP Security with CredSSP")
+            }
+            FailureCode::SSL_WITH_USER_AUTH_REQUIRED_BY_SERVER => {
+                write!(
+                    f,
+                    "server requires Enhanced RDP Security with TLS and client certificate"
+                )
+            }
+            _ => write!(f, "unknown negotiation failure (code: 0x{:08x})", u32::from(self.0)),
+        }
+    }
+}

--- a/crates/ironrdp-sequence/src/sequence.rs
+++ b/crates/ironrdp-sequence/src/sequence.rs
@@ -1,0 +1,46 @@
+use ironrdp_core::WriteBuf;
+use ironrdp_pdu::PduHint;
+
+use crate::sequence_error::SequenceResult;
+use crate::state::State;
+use crate::time::MonotonicInstant;
+use crate::written::Written;
+
+/// A single step of a sans-I/O PDU state machine.
+///
+/// Implementors drive one phase of an RDP connect or accept sequence (e.g.
+/// negotiation, channel connection, license exchange, activation,
+/// finalization). Each `step` call consumes at most one input PDU and
+/// produces at most one output PDU, leaving all I/O to the caller.
+pub trait Sequence: Send {
+    fn next_pdu_hint(&self) -> Option<&dyn PduHint>;
+
+    fn state(&self) -> &dyn State;
+
+    /// Advances the sequence.
+    ///
+    /// `received_at` is when `input` arrived on the wire, as observed by the I/O
+    /// driver, or `None` from a driver that does not observe arrival times. The
+    /// absence of a reading is deliberately not expressible as an instant: a
+    /// driver that cannot measure has taken no measurement, which is a different
+    /// thing from one that measured no elapsed time, and only the sequence
+    /// knows which of the two its reply may be derived from.
+    ///
+    /// A driver that always passes `None` never opens a connect-time bandwidth
+    /// window, so the Bandwidth Measure Results it sends report only the Stop's
+    /// own payload against the untimed floor. See `ironrdp-connector`'s
+    /// `connection::counted_len` doc for why the byte count is
+    /// measurement-gated rather than reported in full.
+    fn step(
+        &mut self,
+        input: &[u8],
+        received_at: Option<MonotonicInstant>,
+        output: &mut WriteBuf,
+    ) -> SequenceResult<Written>;
+
+    fn step_no_input(&mut self, output: &mut WriteBuf) -> SequenceResult<Written> {
+        self.step(&[], None, output)
+    }
+}
+
+ironrdp_core::assert_obj_safe!(Sequence);

--- a/crates/ironrdp-sequence/src/sequence_error.rs
+++ b/crates/ironrdp-sequence/src/sequence_error.rs
@@ -4,17 +4,15 @@
 //! PDU state machine (a [`Sequence`](crate::Sequence) impl and its helpers). It
 //! never carries an `sspi::Error` and never needs to know about CredSSP or
 //! access-denied semantics: those are connect-flow-level concerns owned by
-//! [`ConnectorError`](crate::ConnectorError), which nests a `SequenceError` in
-//! its own `Sequence` variant at each connect boundary (see the
-//! `ErrorMapping<SequenceErrorKind> for ConnectorErrorKind` impl).
-//!
-//! Keeping this type and its constructors in their own module (rather than
-//! inline in `lib.rs`) keeps it shaped for the planned extraction into a
-//! standalone `ironrdp-sequence` crate (tracked separately).
+//! `ironrdp-connector`'s `ConnectorError`, which nests a `SequenceError` in its
+//! own `Sequence` variant at each connect boundary.
 
 use core::fmt;
 
-use crate::NegotiationFailure;
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
+
+use crate::negotiation_failure::NegotiationFailure;
 
 pub type SequenceResult<T> = Result<T, SequenceError>;
 

--- a/crates/ironrdp-sequence/src/server_name.rs
+++ b/crates/ironrdp-sequence/src/server_name.rs
@@ -1,3 +1,9 @@
+#[cfg(not(feature = "std"))]
+use alloc::borrow::ToOwned as _;
+#[cfg(not(feature = "std"))]
+use alloc::string::{String, ToString as _};
+
+/// A sanitized server name or address to connect to.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ServerName(String);
 

--- a/crates/ironrdp-sequence/src/state.rs
+++ b/crates/ironrdp-sequence/src/state.rs
@@ -1,0 +1,32 @@
+use core::any::Any;
+use core::fmt;
+
+pub trait State: Send + fmt::Debug + 'static {
+    fn name(&self) -> &'static str;
+    fn is_terminal(&self) -> bool;
+    fn as_any(&self) -> &dyn Any;
+}
+
+ironrdp_core::assert_obj_safe!(State);
+
+pub fn state_downcast<T: State>(state: &dyn State) -> Option<&T> {
+    state.as_any().downcast_ref()
+}
+
+pub fn state_is<T: State>(state: &dyn State) -> bool {
+    state.as_any().is::<T>()
+}
+
+impl State for () {
+    fn name(&self) -> &'static str {
+        "()"
+    }
+
+    fn is_terminal(&self) -> bool {
+        true
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/crates/ironrdp-sequence/src/time.rs
+++ b/crates/ironrdp-sequence/src/time.rs
@@ -12,12 +12,9 @@
 //! on `wasm32-unknown-unknown`, which some drivers using this type compile
 //! for, and this crate is `no_std` besides.
 //!
-//! This type has no dependency on the rest of the crate (in particular, none
-//! on the `state-machine` feature's [`Sequence`](crate::Sequence) trait and
-//! its `ironrdp-pdu` dependency), so it stays available even when
-//! `state-machine` is disabled. `ironrdp-connector` and `ironrdp-rdpeudp` both
-//! re-export it as a permanent facade so existing callers are unaffected by
-//! this crate's introduction.
+//! This type needs no allocation and stays available even when the
+//! `state-machine` feature is disabled; see the crate's README for the full
+//! feature-split rationale.
 
 use core::ops::Add;
 use core::time::Duration;

--- a/crates/ironrdp-sequence/src/time.rs
+++ b/crates/ironrdp-sequence/src/time.rs
@@ -11,6 +11,13 @@
 //! `std::time::Instant` is deliberately not used here. `Instant::now` panics
 //! on `wasm32-unknown-unknown`, which some drivers using this type compile
 //! for, and this crate is `no_std` besides.
+//!
+//! This type has no dependency on the rest of the crate (in particular, none
+//! on the `state-machine` feature's [`Sequence`](crate::Sequence) trait and
+//! its `ironrdp-pdu` dependency), so it stays available even when
+//! `state-machine` is disabled. `ironrdp-connector` and `ironrdp-rdpeudp` both
+//! re-export it as a permanent facade so existing callers are unaffected by
+//! this crate's introduction.
 
 use core::ops::Add;
 use core::time::Duration;

--- a/crates/ironrdp-sequence/src/written.rs
+++ b/crates/ironrdp-sequence/src/written.rs
@@ -1,0 +1,30 @@
+use crate::sequence_error::{SequenceError, SequenceErrorExt as _, SequenceResult};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Written {
+    Nothing,
+    Size(core::num::NonZeroUsize),
+}
+
+impl Written {
+    #[inline]
+    pub fn from_size(value: usize) -> SequenceResult<Self> {
+        core::num::NonZeroUsize::new(value)
+            .map(Self::Size)
+            .ok_or_else(|| SequenceError::general("invalid written length (can't be zero)"))
+    }
+
+    #[inline]
+    pub fn is_nothing(self) -> bool {
+        matches!(self, Self::Nothing)
+    }
+
+    #[inline]
+    pub fn size(self) -> Option<usize> {
+        if let Self::Size(size) = self {
+            Some(size.get())
+        } else {
+            None
+        }
+    }
+}

--- a/crates/ironrdp-sequence/tests/reason_err.rs
+++ b/crates/ironrdp-sequence/tests/reason_err.rs
@@ -1,0 +1,28 @@
+//! `reason_err!` calls `format!` in its expansion. Rust resolves a bare macro
+//! invocation written inside a `macro_rules!` body against the *caller's*
+//! scope when it is not otherwise in scope at the definition site (unlike
+//! item/type names, which are fully hygienic) -- so a caller that does not
+//! have `format!` in scope (a no_std crate that has not imported
+//! `alloc::format`) fails to compile `reason_err!(...)`, no matter what
+//! features `ironrdp-sequence` itself is built with.
+//!
+//! `#![no_implicit_prelude]` reproduces that caller shape cheaply, without a
+//! full `#![no_std]` binary: it strips the std prelude -- including
+//! `format!` -- from this file's scope while keeping `std` itself linked, so
+//! `#[test]` still works. This only proves something if `reason_err!`
+//! resolves `format!` through `$crate`, not a bare call: see
+//! `crate::__private` in `ironrdp-sequence`'s `src/lib.rs`.
+#![no_implicit_prelude]
+
+use ::ironrdp_sequence::reason_err;
+
+// These are dependencies of `ironrdp-sequence` itself, linked into every one of
+// its test binaries regardless of whether this particular test exercises them.
+use ::ironrdp_core as _;
+use ::ironrdp_error as _;
+use ::ironrdp_pdu as _;
+
+#[test]
+fn reason_err_expands_without_format_in_caller_scope() {
+    let _err = reason_err!("test context", "value {}", 42);
+}

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -538,6 +538,7 @@ dependencies = [
  "bitflags",
  "ironrdp-core",
  "ironrdp-error",
+ "ironrdp-sequence",
 ]
 
 [[package]]
@@ -561,6 +562,10 @@ dependencies = [
  "ironrdp-svc",
  "tracing",
 ]
+
+[[package]]
+name = "ironrdp-sequence"
+version = "0.1.0"
 
 [[package]]
 name = "ironrdp-str"

--- a/xtask/src/check.rs
+++ b/xtask/src/check.rs
@@ -89,7 +89,14 @@ pub fn dependencies(sh: &Shell) -> anyhow::Result<()> {
     // Each pair `(package, banned)` asserts that `package` has no transitive
     // (non-dev) edge to `banned`, ensuring consumers can depend on the
     // former without pulling in the latter’s graph.
-    const FORBIDDEN: &[(&str, &str)] = &[("ironrdp-session", "ironrdp-connector"), ("ironrdp-session", "sspi")];
+    const FORBIDDEN: &[(&str, &str)] = &[
+        ("ironrdp-session", "ironrdp-connector"),
+        ("ironrdp-session", "sspi"),
+        // `ironrdp-rdpeudp` depends on `ironrdp-sequence` only for the dependency-free
+        // `MonotonicInstant` type; it must never gain a transitive edge to `ironrdp-pdu`'s
+        // much larger dependency tree just for that.
+        ("ironrdp-rdpeudp", "ironrdp-pdu"),
+    ];
 
     let mut violations = Vec::new();
 

--- a/xtask/src/features.rs
+++ b/xtask/src/features.rs
@@ -119,7 +119,13 @@ const CASES: &[FeatureCheckCase] = &[
     FeatureCheckCase {
         name: "workspace/powerset-foundation",
         invocation: Invocation::CargoHack {
-            packages: &["ironrdp-core", "ironrdp-error", "ironrdp-str", "ironrdp-bulk"],
+            packages: &[
+                "ironrdp-core",
+                "ironrdp-error",
+                "ironrdp-str",
+                "ironrdp-bulk",
+                "ironrdp-sequence",
+            ],
             depth: 2,
             extra_args: &[],
         },

--- a/xtask/src/pr.rs
+++ b/xtask/src/pr.rs
@@ -13,6 +13,7 @@ const CANONICAL_SCOPES: &[&str] = &[
     "meta",
     "core",
     "error",
+    "sequence",
     "pdu",
     "str",
     "bulk",


### PR DESCRIPTION
Stacked on #1751 (base branch: `cbenoit-introduce-sequenceerror-sspi-free-sequen`). This targets that branch, not `master`; it should merge after #1751.

Implements #1426. GitHub only auto-closes an issue when the closing PR lands on the repository's default branch, so `Closes #1426` below will only take effect once this stack (starting with #1751) reaches `master` — not on merge of this PR alone.

## What

Creates `ironrdp-sequence`, a new sans-I/O core-tier crate that owns the `Sequence` trait and its supporting contract types previously defined in `ironrdp-connector`: `State`, `Written`, `SequenceError`/`SequenceErrorKind`/`SequenceResult`, the `general_err!`/`reason_err!`/`custom_err!` macros, `ServerName`, and `DesktopSize`.

Also moves `MonotonicInstant` out of `ironrdp-core` into `ironrdp-sequence`, alongside `Sequence`. Per the maintainer audit on #1530, the clock read by a sequence's `step` is part of the sans-I/O contract, not a foundational encoding primitive, so it no longer belongs in `ironrdp-core`.

## Design decisions

- **Feature gating**: `MonotonicInstant` and `DesktopSize` need no allocation and stay available unconditionally (no features required). Everything else needs `ironrdp-pdu` (for `PduHint` and negotiation failure codes), so it is gated behind a default-disabled `state-machine` feature. This keeps `ironrdp-rdpeudp` — which depends on this crate only for `MonotonicInstant` — from acquiring `ironrdp-pdu`'s much larger dependency tree (`der-parser`, `x509-cert`, `pkcs1`, ...) just for the clock type. A new `xtask check dependencies` forbidden-edge entry (`ironrdp-rdpeudp` → `ironrdp-pdu`) enforces this permanently.
- **`alloc` vs `state-machine`**: `ServerName` only needs `alloc::string::String`, so it's gated on plain `alloc` rather than the heavier `state-machine`.
- **Facades preserved**: `ironrdp-connector` and `ironrdp-rdpeudp` both keep permanent re-exports of everything they previously defined directly, so existing `ironrdp_connector::{Sequence, MonotonicInstant, State, Written, SequenceError, ServerName, DesktopSize, ...}` and `ironrdp_rdpeudp::MonotonicInstant` import paths are unaffected.
- **Publishable from the start**: unlike a typical new internal crate, `ironrdp-sequence` is `version = "0.1.0"` with no `publish = false`, because published crates (`ironrdp-connector`) depend on it — `cargo publish` requires all path dependencies to be resolvable from the registry.
- **Scope discipline**: `ironrdp-sequence` has no dependency on `ironrdp-connector`, `sspi`, or any CredSSP/RDP connection-flow logic — verified via `cargo tree` and the new `xtask check dependencies` guard.

## Breaking change

`ironrdp_core::MonotonicInstant` is removed. This breaks the path as it exists on `master`/unreleased `ironrdp-core`; the type was never part of a published `ironrdp-core` release (it does not exist in `ironrdp-core` v0.2.1 on crates.io), so no published consumer is affected. Direct consumers on `master` must switch to `ironrdp_sequence::MonotonicInstant`, or use the stable facade re-exports at `ironrdp_connector::MonotonicInstant` / `ironrdp_rdpeudp::MonotonicInstant` (unaffected by this change).

## Explicitly out of scope

This PR is strictly the extraction layer. It does not touch the FFI timestamp/API surface (e.g. how the C#/native FFI layer supplies `MonotonicInstant` readings) — that is a separate follow-up.

## Checks

- `cargo check --workspace` (default features): clean.
- `cargo xtask check fmt -v`, `check lints -v`, `check tests -v`, `check locks -v`: all pass.
- `cargo xtask check features --case workspace/powerset-foundation` (now includes `ironrdp-sequence`): 29/29 sub-checks pass.
- `cargo xtask check dependencies`: all forbidden edges (including the new `ironrdp-rdpeudp` → `ironrdp-pdu` one) confirmed absent.
- `cargo tree -p ironrdp-rdpeudp -e no-dev -i ironrdp-pdu`: confirms `ironrdp-pdu` is absent from `ironrdp-rdpeudp`'s dependency tree.
- `cargo doc -p ironrdp-sequence --no-deps --all-features`: clean, no broken intra-doc links.
- `cargo test -p ironrdp-sequence --no-default-features --features state-machine` and `--features state-machine,std`: `reason_err!`'s macro-hygiene regression test passes in both configurations.
- Pre-existing, unrelated `--all-features` issues in `ironrdp-tls`/`ironrdp-rdpeusb` (mutually-exclusive TLS backend features) reproduce identically on the base branch and are out of scope here.