### PR TITLE
feat(mstsgu): encode reauth tunnel context

### DIFF
--- a/crates/ironrdp-mstsgu/src/proto.rs
+++ b/crates/ironrdp-mstsgu/src/proto.rs
@@ -190,12 +190,16 @@ impl Decode<'_> for HandshakeRespPkt {
     }
 }
 
+/// 2.2.5.3.6 `HTTP_TUNNEL_PACKET_FIELD_REAUTH`.
+const HTTP_TUNNEL_PACKET_FIELD_REAUTH: u16 = 0x2;
+
 /// 2.2.10.18 HTTP_TUNNEL_PACKET
 #[derive(Default)]
 pub(crate) struct TunnelReqPkt {
     pub caps: u32,
     pub fields_present: u16,
     pub _reserved: u16,
+    pub reauth_tunnel_context: Option<u64>,
 }
 
 impl Encode for TunnelReqPkt {
@@ -209,9 +213,18 @@ impl Encode for TunnelReqPkt {
         };
         hdr.encode(dst)?;
 
+        let fields_present = if self.reauth_tunnel_context.is_some() {
+            self.fields_present | HTTP_TUNNEL_PACKET_FIELD_REAUTH
+        } else {
+            self.fields_present
+        };
+
         dst.write_u32(self.caps);
-        dst.write_u16(self.fields_present);
+        dst.write_u16(fields_present);
         dst.write_u16(self._reserved);
+        if let Some(tunnel_context) = self.reauth_tunnel_context {
+            dst.write_u64(tunnel_context);
+        }
         Ok(())
     }
 
@@ -220,7 +233,11 @@ impl Encode for TunnelReqPkt {
     }
 
     fn size(&self) -> usize {
-        PktHdr::default().size() + 8
+        PktHdr::FIXED_PART_SIZE
+            + 4 /* capsFlags */
+            + 2 /* fieldsPresent */
+            + 2 /* reserved */
+            + self.reauth_tunnel_context.map_or(0, |_| 8 /* reauthTunnelContext */)
     }
 }
 

--- a/crates/ironrdp-mstsgu/src/proto.rs
+++ b/crates/ironrdp-mstsgu/src/proto.rs
@@ -213,11 +213,12 @@ impl Encode for TunnelReqPkt {
         };
         hdr.encode(dst)?;
 
-        let fields_present = if self.reauth_tunnel_context.is_some() {
-            self.fields_present | HTTP_TUNNEL_PACKET_FIELD_REAUTH
-        } else {
-            self.fields_present
-        };
+        let fields_present = self.fields_present & !HTTP_TUNNEL_PACKET_FIELD_REAUTH
+            | if self.reauth_tunnel_context.is_some() {
+                HTTP_TUNNEL_PACKET_FIELD_REAUTH
+            } else {
+                0
+            };
 
         dst.write_u32(self.caps);
         dst.write_u16(fields_present);

--- a/crates/ironrdp-mstsgu/tests/http_control.rs
+++ b/crates/ironrdp-mstsgu/tests/http_control.rs
@@ -54,6 +54,17 @@ fn tunnel_request_without_reauth_context_preserves_existing_wire_format() {
 }
 
 #[test]
+fn tunnel_request_without_reauth_context_clears_reauth_field_bit() {
+    let bytes = encode_to_vec(&TunnelReqPkt {
+        fields_present: 0x2,
+        ..TunnelReqPkt::default()
+    });
+
+    assert_eq!(bytes.len(), 16);
+    assert_eq!(&bytes[12..14], &0u16.to_le_bytes());
+}
+
+#[test]
 fn tunnel_request_encodes_reauth_context() {
     let reauth_tunnel_context = 0x1122_3344_5566_7788;
     let bytes = encode_to_vec(&TunnelReqPkt {

--- a/crates/ironrdp-mstsgu/tests/http_control.rs
+++ b/crates/ironrdp-mstsgu/tests/http_control.rs
@@ -1,7 +1,21 @@
-#![allow(unused_crate_dependencies)]
+#![expect(
+    dead_code,
+    unreachable_pub,
+    unused_crate_dependencies,
+    reason = "tests import private protocol structures"
+)]
+
+#[path = "../src/proto.rs"]
+#[expect(
+    clippy::allow_attributes,
+    reason = "the imported protocol source contains an intentionally unfulfilled expectation"
+)]
+#[allow(unfulfilled_lint_expectations)]
+mod proto;
 
 use ironrdp_core::{Decode, Encode, ReadCursor, WriteCursor};
 use ironrdp_mstsgu::{ChannelClosePkt, ReauthMessagePkt, ServiceMessagePkt, gateway_code_label};
+use proto::TunnelReqPkt;
 
 fn encode_to_vec(payload: &impl Encode) -> Vec<u8> {
     let mut buf = vec![0u8; payload.size()];
@@ -17,6 +31,48 @@ fn decode_body<'a, T: Decode<'a>>(bytes: &'a [u8]) -> T {
     let decoded = T::decode(&mut cur).expect("decode");
     assert!(cur.eof());
     decoded
+}
+
+#[test]
+fn tunnel_request_without_reauth_context_preserves_existing_wire_format() {
+    let bytes = encode_to_vec(&TunnelReqPkt {
+        caps: 0x04,
+        fields_present: 0,
+        ..TunnelReqPkt::default()
+    });
+
+    assert_eq!(
+        bytes,
+        [
+            0x04, 0x00, 0x00, 0x00, // packetType, reserved
+            0x10, 0x00, 0x00, 0x00, // packet length
+            0x04, 0x00, 0x00, 0x00, // capsFlags
+            0x00, 0x00, // fieldsPresent
+            0x00, 0x00, // reserved
+        ]
+    );
+}
+
+#[test]
+fn tunnel_request_encodes_reauth_context() {
+    let reauth_tunnel_context = 0x1122_3344_5566_7788;
+    let bytes = encode_to_vec(&TunnelReqPkt {
+        caps: 0x04,
+        reauth_tunnel_context: Some(reauth_tunnel_context),
+        ..TunnelReqPkt::default()
+    });
+
+    assert_eq!(
+        bytes.len(),
+        8 /* HTTP_PACKET_HEADER */
+            + 4 /* capsFlags */
+            + 2 /* fieldsPresent */
+            + 2 /* reserved */
+            + 8 /* reauthTunnelContext */
+    );
+    assert_eq!(u32::from_le_bytes(bytes[4..8].try_into().unwrap()), 24);
+    assert_eq!(&bytes[12..14], &0x2u16.to_le_bytes());
+    assert_eq!(&bytes[16..24], &reauth_tunnel_context.to_le_bytes());
 }
 
 #[test]


### PR DESCRIPTION
Encode an optional reauth tunnel context in tunnel-create requests while clearing its presence bit when no context is supplied.
Requests without a context retain their existing wire format.