### PR TITLE
feat(mstsgu): add extended-auth packet codecs

### DIFF
--- a/crates/ironrdp-mstsgu/src/proto.rs
+++ b/crates/ironrdp-mstsgu/src/proto.rs
@@ -8,7 +8,7 @@ bitflags! {
     /// 2.2.5.3.2 HTTP_EXTENDED_AUTH Enumeration
     #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub(crate) struct HttpExtendedAuth: u16 {
-        const HTTP_EXTENDED_AUTH_NONE = 0x01;
+        const HTTP_EXTENDED_AUTH_NONE = 0x00;
         const HTTP_EXTENDED_AUTH_SC = 0x01;
         const HTTP_EXTENDED_AUTH_PAA = 0x02;
         const HTTP_EXTENDED_AUTH_SSPI_NTLM = 0x04;
@@ -165,11 +165,16 @@ pub(crate) struct HandshakeRespPkt {
     pub ver_major: u8,
     pub ver_minor: u8,
     pub server_version: u16,
-    pub _extended_auth: HttpExtendedAuth,
+    #[expect(
+        dead_code,
+        reason = "authentication flow does not negotiate extended authentication yet"
+    )]
+    pub extended_auth: HttpExtendedAuth,
 }
 
 impl HandshakeRespPkt {
-    const FIXED_PART_SIZE: usize = 4 /* error_code */ + 1 /* ver_major */ + 1 /* ver_minor */ + 2 /* server_auth */ + 1 /*extended_auth*/;
+    const FIXED_PART_SIZE: usize =
+        4 /* error_code */ + 1 /* ver_major */ + 1 /* ver_minor */ + 2 /* server_version */ + 2 /* extended_auth */;
 }
 
 impl Decode<'_> for HandshakeRespPkt {
@@ -181,11 +186,7 @@ impl Decode<'_> for HandshakeRespPkt {
             ver_major: src.read_u8(),
             ver_minor: src.read_u8(),
             server_version: src.read_u16(),
-            _extended_auth: {
-                let raw = src.read_u16();
-                HttpExtendedAuth::from_bits(raw)
-                    .ok_or_else(|| unsupported_value_err("HandshakeResp", "extended_auth", format!("0x{raw:x}")))?
-            },
+            extended_auth: HttpExtendedAuth::from_bits_retain(src.read_u16()),
         })
     }
 }
@@ -345,10 +346,17 @@ impl Decode<'_> for TunnelRespPkt {
 }
 
 /// 2.2.10.7 HTTP_EXTENDED_AUTH_PACKET Structure
-#[expect(dead_code, reason = "defined for completeness per spec; not yet used")]
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "authentication flow does not process extended authentication yet"
+    )
+)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ExtendedAuthPkt {
-    error_code: u32,
-    blob: Vec<u8>,
+    pub(crate) error_code: u32,
+    pub(crate) auth_blob: Vec<u8>,
 }
 
 impl Encode for ExtendedAuthPkt {
@@ -363,9 +371,9 @@ impl Encode for ExtendedAuthPkt {
         hdr.encode(dst)?;
 
         dst.write_u32(self.error_code);
-        let blob_len: u16 = cast_int!("blob length", self.blob.len())?;
-        dst.write_u16(blob_len);
-        dst.write_slice(&self.blob);
+        let auth_blob_len: u16 = cast_int!("auth blob length", self.auth_blob.len())?;
+        dst.write_u16(auth_blob_len);
+        dst.write_slice(&self.auth_blob);
 
         Ok(())
     }
@@ -375,20 +383,20 @@ impl Encode for ExtendedAuthPkt {
     }
 
     fn size(&self) -> usize {
-        PktHdr::default().size() + 6 + self.blob.len()
+        PktHdr::FIXED_PART_SIZE + 4 /* error_code */ + 2 /* cb_blob_len */ + self.auth_blob.len()
     }
 }
 
 impl Decode<'_> for ExtendedAuthPkt {
     fn decode(src: &mut ReadCursor<'_>) -> ironrdp_core::DecodeResult<Self> {
-        ensure_size!(in: src, size: 4 + 2);
+        ensure_size!(in: src, size: 4 /* error_code */ + 2 /* cb_blob_len */);
         let error_code = src.read_u32();
-        let len = usize::from(src.read_u16());
-        ensure_size!(in: src, size: len);
+        let auth_blob_len = usize::from(src.read_u16());
+        ensure_size!(in: src, size: auth_blob_len);
 
         Ok(ExtendedAuthPkt {
             error_code,
-            blob: src.read_slice(len).to_vec(),
+            auth_blob: src.read_slice(auth_blob_len).to_vec(),
         })
     }
 }

--- a/crates/ironrdp-mstsgu/src/proto.rs
+++ b/crates/ironrdp-mstsgu/src/proto.rs
@@ -851,4 +851,17 @@ mod tests {
         // HTTP_PACKET_HEADER is 8 bytes; the next two bytes are resources/alt_names counts.
         assert_eq!(&buf[10..12], &2179u16.to_le_bytes());
     }
+
+    #[test]
+    fn extended_auth_pkt_size_includes_header_and_blob() {
+        let pkt = ExtendedAuthPkt {
+            error_code: 0,
+            auth_blob: vec![0; 3],
+        };
+
+        assert_eq!(
+            pkt.size(),
+            PktHdr::FIXED_PART_SIZE + 4 /* error_code */ + 2 /* cb_blob_len */ + 3 /* auth_blob */
+        );
+    }
 }

--- a/crates/ironrdp-mstsgu/tests/http_control.rs
+++ b/crates/ironrdp-mstsgu/tests/http_control.rs
@@ -15,7 +15,7 @@ mod proto;
 
 use ironrdp_core::{Decode, Encode, ReadCursor, WriteCursor};
 use ironrdp_mstsgu::{ChannelClosePkt, ReauthMessagePkt, ServiceMessagePkt, gateway_code_label};
-use proto::TunnelReqPkt;
+use proto::{ExtendedAuthPkt, HandshakeRespPkt, HttpExtendedAuth, TunnelReqPkt};
 
 fn encode_to_vec(payload: &impl Encode) -> Vec<u8> {
     let mut buf = vec![0u8; payload.size()];
@@ -114,6 +114,82 @@ fn reauth_message_roundtrip() {
     );
     let decoded = decode_body::<ReauthMessagePkt>(&bytes);
     assert_eq!(decoded, pkt);
+}
+
+#[test]
+fn handshake_response_preserves_advertised_extended_auth_flags() {
+    assert_eq!(HttpExtendedAuth::HTTP_EXTENDED_AUTH_NONE.bits(), 0);
+
+    for flags in [0x0000u16, 0x0007, 0x8004] {
+        let mut bytes = [
+            0x02, 0x00, // packetType
+            0x00, 0x00, // reserved
+            0x12, 0x00, 0x00, 0x00, // packet length
+            0x00, 0x00, 0x00, 0x00, // errorCode
+            0x01, // verMajor
+            0x00, // verMinor
+            0x00, 0x00, // serverVersion
+            0x00, 0x00, // ExtendedAuth
+        ];
+        bytes[16..].copy_from_slice(&flags.to_le_bytes());
+        let response = decode_body::<HandshakeRespPkt>(&bytes);
+
+        assert_eq!(response.extended_auth.bits(), flags);
+    }
+}
+
+#[test]
+fn extended_auth_packet_roundtrip() {
+    let pkt = ExtendedAuthPkt {
+        error_code: 0x1122_3344,
+        auth_blob: vec![0xAA, 0xBB, 0xCC, 0xDD],
+    };
+    let bytes = encode_to_vec(&pkt);
+
+    assert_eq!(
+        bytes,
+        [
+            0x03, 0x00, // packetType
+            0x00, 0x00, // reserved
+            0x12, 0x00, 0x00, 0x00, // packet length
+            0x44, 0x33, 0x22, 0x11, // errorCode
+            0x04, 0x00, // cbBlobLen
+            0xAA, 0xBB, 0xCC, 0xDD, // authBlob
+        ]
+    );
+    assert_eq!(decode_body::<ExtendedAuthPkt>(&bytes), pkt);
+}
+
+#[test]
+fn extended_auth_packet_rejects_malformed_and_mismatched_blobs() {
+    let mut missing_length = ReadCursor::new(&[0x00; 5]);
+    assert!(ExtendedAuthPkt::decode(&mut missing_length).is_err());
+
+    let mut truncated_blob = ReadCursor::new(&[
+        0x00, 0x00, 0x00, 0x00, // errorCode
+        0x03, 0x00, // cbBlobLen
+        0xAA, 0xBB, // authBlob
+    ]);
+    assert!(ExtendedAuthPkt::decode(&mut truncated_blob).is_err());
+}
+
+#[test]
+fn extended_auth_packet_accepts_maximum_blob_and_rejects_larger_blobs() {
+    let pkt = ExtendedAuthPkt {
+        error_code: 0,
+        auth_blob: vec![0x5A; usize::from(u16::MAX)],
+    };
+    let bytes = encode_to_vec(&pkt);
+    assert_eq!(&bytes[12..14], &u16::MAX.to_le_bytes());
+    assert_eq!(decode_body::<ExtendedAuthPkt>(&bytes), pkt);
+
+    let oversized = ExtendedAuthPkt {
+        error_code: 0,
+        auth_blob: vec![0; usize::from(u16::MAX) + 1],
+    };
+    let mut bytes = vec![0; oversized.size()];
+    let mut cursor = WriteCursor::new(&mut bytes);
+    assert!(oversized.encode(&mut cursor).is_err());
 }
 
 #[test]


### PR DESCRIPTION
Preserve advertised handshake extended-auth flags, including unknown bits, and encode/decode extended-auth packet blobs with exact lengths.

Add wire vectors for flag combinations, packet round trips, malformed blobs, and u16 blob boundaries.