### PR TITLE
feat(mstsgu): handle gateway consent messages

### DIFF
--- a/crates/ironrdp-mstsgu/CHANGELOG.md
+++ b/crates/ironrdp-mstsgu/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Encode and decode for HTTP control packets (`HTTP_SERVICE_MESSAGE`, `HTTP_REAUTH_MESSAGE`, and `HTTP_CLOSE_PACKET`) without performing mid-session reauthentication.
 - DCE/RPC common-header fragment codecs and response reassembly, without a live RPC-over-HTTP transport.
 - Decode and expose tunnel-authorization policy fields (`redirFlags`, `idleTimeout`, and `SoHResponse`) without enforcing redirection restrictions or idle timeouts.
+- Decode gateway consent messages and let callers accept or decline them before tunnel authorization.
 
 ## [[0.0.1](https://github.com/Devolutions/IronRDP/releases/tag/ironrdp-mstsgu-v0.0.1)] - 2026-07-10
 

--- a/crates/ironrdp-mstsgu/Cargo.toml
+++ b/crates/ironrdp-mstsgu/Cargo.toml
@@ -46,6 +46,11 @@ name = "packet_io"
 path = "tests/packet_io.rs"
 required-features = ["native-tls", "test-support"]
 
+[[test]]
+name = "consent"
+path = "tests/consent.rs"
+required-features = ["native-tls", "test-support"]
+
 [features]
 default = []
 rustls = ["ironrdp-tls/rustls", "tokio-tungstenite/rustls-tls-native-roots"]

--- a/crates/ironrdp-mstsgu/README.md
+++ b/crates/ironrdp-mstsgu/README.md
@@ -8,7 +8,7 @@ This crate
 - provides internal raw RPCH HTTP framing codecs, but no live RPC-over-HTTP gateway transport,
 - decodes HTTP control packets (`HTTP_SERVICE_MESSAGE`, `HTTP_REAUTH_MESSAGE`, and `HTTP_CLOSE_PACKET`) without performing mid-session reauthentication,
 - exposes decoded tunnel-authorization policy values without enforcing redirection rules or idle timeouts,
-- accepts gateway consent messages by default to preserve existing connection behavior,
+- accepts gateway consent messages by default,
 - lets applications inspect and accept or decline a consent message synchronously through [`GwClient::connect_with_consent`] or [`GwClient::connect_with_port_and_consent`],
 - does not implement reconnection, Detect, or a live UDP/DTLS side channel,
 - authenticates gateway setup with HTTP Negotiate (Kerberos then NTLM), NTLM, or Basic fallback,

--- a/crates/ironrdp-mstsgu/README.md
+++ b/crates/ironrdp-mstsgu/README.md
@@ -8,6 +8,8 @@ This crate
 - provides internal raw RPCH HTTP framing codecs, but no live RPC-over-HTTP gateway transport,
 - decodes HTTP control packets (`HTTP_SERVICE_MESSAGE`, `HTTP_REAUTH_MESSAGE`, and `HTTP_CLOSE_PACKET`) without performing mid-session reauthentication,
 - exposes decoded tunnel-authorization policy values without enforcing redirection rules or idle timeouts,
+- accepts gateway consent messages by default to preserve existing connection behavior,
+- lets applications inspect and accept or decline a consent message synchronously through [`GwClient::connect_with_consent`] or [`GwClient::connect_with_port_and_consent`],
 - does not implement reconnection, Detect, or a live UDP/DTLS side channel,
 - authenticates gateway setup with HTTP Negotiate (Kerberos then NTLM), NTLM, or Basic fallback,
 - can use Kerberos PKINIT with application-supplied UPN `smartcard` credentials for HTTP Negotiate authentication only,

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -118,7 +118,7 @@ pub struct GwTunnelPolicy {
 ///
 /// [MS-TSGU 2.2.10.21]: https://winprotocoldocs-bhdugrdyduf5h2e4.b02.azurefd.net/MS-TSGU/%5bMS-TSGU%5d.pdf#page=72
 /// [MS-TSGU 2.2.10.22]: https://winprotocoldocs-bhdugrdyduf5h2e4.b02.azurefd.net/MS-TSGU/%5bMS-TSGU%5d.pdf#page=73
-pub type GwConsentCallback = dyn FnMut(&str) -> bool + Send;
+pub type GwConsentCallback<'a> = dyn FnMut(&str) -> bool + 'a;
 
 type Error = ironrdp_error::Error<GwErrorKind>;
 
@@ -217,7 +217,7 @@ impl GwClient {
     pub async fn connect_with_consent(
         target: &GwConnectTarget,
         client_name: &str,
-        consent_callback: &mut GwConsentCallback,
+        consent_callback: &mut GwConsentCallback<'_>,
     ) -> Result<(GwClient, core::net::SocketAddr), Error> {
         Self::connect_with_port_and_consent(target, client_name, 3389, consent_callback).await
     }
@@ -239,7 +239,7 @@ impl GwClient {
         target: &GwConnectTarget,
         client_name: &str,
         server_port: u16,
-        consent_callback: &mut GwConsentCallback,
+        consent_callback: &mut GwConsentCallback<'_>,
     ) -> Result<(GwClient, core::net::SocketAddr), Error> {
         Self::connect_with_port_and_optional_consent(target, client_name, server_port, Some(consent_callback)).await
     }
@@ -248,7 +248,7 @@ impl GwClient {
         target: &GwConnectTarget,
         client_name: &str,
         server_port: u16,
-        consent_callback: Option<&mut GwConsentCallback>,
+        consent_callback: Option<&mut GwConsentCallback<'_>>,
     ) -> Result<(GwClient, core::net::SocketAddr), Error> {
         let (io, client_addr) = open_gateway_transport(target).await?;
         Self::connect_ws(target.clone(), client_name, server_port, io, consent_callback)
@@ -261,7 +261,7 @@ impl GwClient {
         client_name: &str,
         server_port: u16,
         io: PacketIo,
-        consent_callback: Option<&mut GwConsentCallback>,
+        consent_callback: Option<&mut GwConsentCallback<'_>>,
     ) -> Result<GwClient, Error> {
         let mut gw = GwConn {
             client_name: client_name.to_owned(),
@@ -438,7 +438,7 @@ impl GwConn {
         Ok(())
     }
 
-    async fn tunnel(&mut self, consent_callback: Option<&mut GwConsentCallback>) -> Result<(), Error> {
+    async fn tunnel(&mut self, consent_callback: Option<&mut GwConsentCallback<'_>>) -> Result<(), Error> {
         let req = TunnelReqPkt {
             // Havent seen any server working without this.
             caps: HttpCapsTy::MessagingConsentSign.as_u32(),
@@ -517,7 +517,7 @@ fn decode_consent_message(bytes: &[u8]) -> Result<String, Error> {
 
 fn evaluate_consent_message(
     consent_message: &[u8],
-    consent_callback: Option<&mut GwConsentCallback>,
+    consent_callback: Option<&mut GwConsentCallback<'_>>,
 ) -> Result<(), Error> {
     if consent_message.is_empty() {
         return Ok(());

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -110,6 +110,16 @@ pub struct GwTunnelPolicy {
     pub soh_response: Option<Vec<u8>>,
 }
 
+/// Synchronously decides whether to accept a gateway consent message.
+///
+/// The callback receives the UTF-16LE consent message decoded from
+/// [HTTP_TUNNEL_RESPONSE_OPTIONAL][MS-TSGU 2.2.10.21] as an [HTTP_UNICODE_STRING][MS-TSGU 2.2.10.22].
+/// Returning `false` declines the gateway consent and stops tunnel setup.
+///
+/// [MS-TSGU 2.2.10.21]: https://winprotocoldocs-bhdugrdyduf5h2e4.b02.azurefd.net/MS-TSGU/%5bMS-TSGU%5d.pdf#page=72
+/// [MS-TSGU 2.2.10.22]: https://winprotocoldocs-bhdugrdyduf5h2e4.b02.azurefd.net/MS-TSGU/%5bMS-TSGU%5d.pdf#page=73
+pub type GwConsentCallback = dyn FnMut(&str) -> bool + Send;
+
 type Error = ironrdp_error::Error<GwErrorKind>;
 
 #[derive(Debug)]
@@ -120,6 +130,7 @@ pub enum GwErrorKind {
     HttpStatus(u16),
     PacketEof,
     UnsupportedFeature,
+    ConsentDeclined,
     Custom,
     Encode,
     Decode,
@@ -149,6 +160,7 @@ impl Display for GwErrorKind {
             GwErrorKind::HttpStatus(status) => return write!(f, "unexpected http status {status}"),
             GwErrorKind::PacketEof => "PacketEOF",
             GwErrorKind::UnsupportedFeature => "unsupported feature",
+            GwErrorKind::ConsentDeclined => "gateway consent declined",
             GwErrorKind::Custom => "custom",
             GwErrorKind::Encode => "encode",
             GwErrorKind::Decode => "decode",
@@ -198,14 +210,48 @@ impl GwClient {
         Self::connect_with_port(target, client_name, 3389).await
     }
 
+    /// Open an MS-TSGU tunnel and decide a gateway consent message synchronously.
+    ///
+    /// The callback is invoked once for each consent message returned while creating the tunnel.
+    /// Returning `false` stops tunnel setup with [`GwErrorKind::ConsentDeclined`].
+    pub async fn connect_with_consent(
+        target: &GwConnectTarget,
+        client_name: &str,
+        consent_callback: &mut GwConsentCallback,
+    ) -> Result<(GwClient, core::net::SocketAddr), Error> {
+        Self::connect_with_port_and_consent(target, client_name, 3389, consent_callback).await
+    }
+
     /// Open an MS-TSGU tunnel, presenting `server_port` as HTTP_CHANNEL_PACKET `port`.
     pub async fn connect_with_port(
         target: &GwConnectTarget,
         client_name: &str,
         server_port: u16,
     ) -> Result<(GwClient, core::net::SocketAddr), Error> {
+        Self::connect_with_port_and_optional_consent(target, client_name, server_port, None).await
+    }
+
+    /// Open an MS-TSGU tunnel and decide a gateway consent message synchronously.
+    ///
+    /// The callback is invoked once for each consent message returned while creating the tunnel.
+    /// Returning `false` stops tunnel setup with [`GwErrorKind::ConsentDeclined`].
+    pub async fn connect_with_port_and_consent(
+        target: &GwConnectTarget,
+        client_name: &str,
+        server_port: u16,
+        consent_callback: &mut GwConsentCallback,
+    ) -> Result<(GwClient, core::net::SocketAddr), Error> {
+        Self::connect_with_port_and_optional_consent(target, client_name, server_port, Some(consent_callback)).await
+    }
+
+    async fn connect_with_port_and_optional_consent(
+        target: &GwConnectTarget,
+        client_name: &str,
+        server_port: u16,
+        consent_callback: Option<&mut GwConsentCallback>,
+    ) -> Result<(GwClient, core::net::SocketAddr), Error> {
         let (io, client_addr) = open_gateway_transport(target).await?;
-        Self::connect_ws(target.clone(), client_name, server_port, io)
+        Self::connect_ws(target.clone(), client_name, server_port, io, consent_callback)
             .await
             .map(|x| (x, client_addr))
     }
@@ -215,6 +261,7 @@ impl GwClient {
         client_name: &str,
         server_port: u16,
         io: PacketIo,
+        consent_callback: Option<&mut GwConsentCallback>,
     ) -> Result<GwClient, Error> {
         let mut gw = GwConn {
             client_name: client_name.to_owned(),
@@ -224,7 +271,7 @@ impl GwClient {
         };
 
         gw.handshake().await?;
-        gw.tunnel().await?;
+        gw.tunnel(consent_callback).await?;
         let policy = gw.tunnel_auth().await?;
         gw.channel().await?;
 
@@ -391,7 +438,7 @@ impl GwConn {
         Ok(())
     }
 
-    async fn tunnel(&mut self) -> Result<(), Error> {
+    async fn tunnel(&mut self, consent_callback: Option<&mut GwConsentCallback>) -> Result<(), Error> {
         let req = TunnelReqPkt {
             // Havent seen any server working without this.
             caps: HttpCapsTy::MessagingConsentSign.as_u32(),
@@ -408,12 +455,7 @@ impl GwConn {
             return Err(Error::new("Tunnel", GwErrorKind::Connect));
         }
         assert!(cur.eof());
-        if !resp.consent_msg.is_empty() {
-            return Err(Error::new(
-                "Received consent message but showing it not implemented",
-                GwErrorKind::UnsupportedFeature,
-            ));
-        }
+        evaluate_consent_message(&resp.consent_msg, consent_callback)?;
         Ok(())
     }
 
@@ -458,6 +500,36 @@ impl GwConn {
         assert!(cur.eof());
         Ok(resp)
     }
+}
+
+fn decode_consent_message(bytes: &[u8]) -> Result<String, Error> {
+    if !bytes.len().is_multiple_of(2) {
+        return Err(Error::new("TunnelConsent", GwErrorKind::Decode));
+    }
+
+    let code_units = bytes
+        .chunks_exact(2)
+        .map(|unit| u16::from_le_bytes([unit[0], unit[1]]))
+        .collect::<Vec<_>>();
+    let message = String::from_utf16(&code_units).map_err(|_| Error::new("TunnelConsent", GwErrorKind::Decode))?;
+    Ok(message.strip_suffix('\0').unwrap_or(&message).to_owned())
+}
+
+fn evaluate_consent_message(
+    consent_message: &[u8],
+    consent_callback: Option<&mut GwConsentCallback>,
+) -> Result<(), Error> {
+    if consent_message.is_empty() {
+        return Ok(());
+    }
+
+    let message = decode_consent_message(consent_message)?;
+    if let Some(consent_callback) = consent_callback {
+        if !consent_callback(&message) {
+            return Err(Error::new("TunnelConsent", GwErrorKind::ConsentDeclined));
+        }
+    }
+    Ok(())
 }
 
 impl AsyncRead for GwClient {

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -118,7 +118,7 @@ pub struct GwTunnelPolicy {
 ///
 /// [MS-TSGU 2.2.10.21]: https://winprotocoldocs-bhdugrdyduf5h2e4.b02.azurefd.net/MS-TSGU/%5bMS-TSGU%5d.pdf#page=72
 /// [MS-TSGU 2.2.10.22]: https://winprotocoldocs-bhdugrdyduf5h2e4.b02.azurefd.net/MS-TSGU/%5bMS-TSGU%5d.pdf#page=73
-pub type GwConsentCallback<'a> = dyn FnMut(&str) -> bool + 'a;
+pub type GwConsentCallback<'a> = dyn FnMut(&str) -> bool + Send + 'a;
 
 type Error = ironrdp_error::Error<GwErrorKind>;
 

--- a/crates/ironrdp-mstsgu/src/test_support.rs
+++ b/crates/ironrdp-mstsgu/src/test_support.rs
@@ -3,6 +3,7 @@
 use hyper::body::Bytes;
 
 use crate::packet_io::{PacketIo, open_test_transport};
+use crate::{Error, GwConsentCallback};
 
 /// In-memory gateway transport used by the registered integration tests.
 pub struct GatewayTransport(PacketIo);
@@ -33,4 +34,12 @@ impl GatewayTransport {
     pub async fn close(&mut self) -> Result<(), String> {
         self.0.close().await.map_err(|error| error.to_string())
     }
+}
+
+/// Evaluate a consent message received during tunnel creation.
+pub fn evaluate_consent_message(
+    consent_message: &[u8],
+    consent_callback: Option<&mut GwConsentCallback>,
+) -> Result<(), Error> {
+    crate::evaluate_consent_message(consent_message, consent_callback)
 }

--- a/crates/ironrdp-mstsgu/src/test_support.rs
+++ b/crates/ironrdp-mstsgu/src/test_support.rs
@@ -3,7 +3,7 @@
 use hyper::body::Bytes;
 
 use crate::packet_io::{PacketIo, open_test_transport};
-use crate::{Error, GwConsentCallback};
+use crate::{Error, GwClient, GwConnectTarget, GwConsentCallback};
 
 /// In-memory gateway transport used by the registered integration tests.
 pub struct GatewayTransport(PacketIo);
@@ -34,12 +34,23 @@ impl GatewayTransport {
     pub async fn close(&mut self) -> Result<(), String> {
         self.0.close().await.map_err(|error| error.to_string())
     }
+
+    /// Establish a gateway tunnel through this test transport.
+    pub async fn connect_tunnel(
+        self,
+        target: GwConnectTarget,
+        client_name: &str,
+        server_port: u16,
+        consent_callback: Option<&mut GwConsentCallback<'_>>,
+    ) -> Result<GwClient, Error> {
+        GwClient::connect_ws(target, client_name, server_port, self.0, consent_callback).await
+    }
 }
 
 /// Evaluate a consent message received during tunnel creation.
 pub fn evaluate_consent_message(
     consent_message: &[u8],
-    consent_callback: Option<&mut GwConsentCallback>,
+    consent_callback: Option<&mut GwConsentCallback<'_>>,
 ) -> Result<(), Error> {
     crate::evaluate_consent_message(consent_message, consent_callback)
 }

--- a/crates/ironrdp-mstsgu/tests/consent.rs
+++ b/crates/ironrdp-mstsgu/tests/consent.rs
@@ -2,8 +2,19 @@
 
 use std::sync::{Arc, Mutex};
 
+use core::convert::Infallible;
+use http_body_util::combinators::BoxBody;
+use http_body_util::{BodyExt as _, Full};
+use hyper::body::Bytes;
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use ironrdp_mstsgu::GwConnectTarget;
 use ironrdp_mstsgu::GwErrorKind;
-use ironrdp_mstsgu::test_support::evaluate_consent_message;
+use ironrdp_mstsgu::test_support::{GatewayTransport, evaluate_consent_message};
+
+type TestBody = BoxBody<Bytes, Infallible>;
 
 fn consent_message(message: &str) -> Vec<u8> {
     message
@@ -56,6 +67,83 @@ fn callback_rejection_returns_consent_declined() {
     assert!(matches!(error.kind(), GwErrorKind::ConsentDeclined));
 }
 
+#[tokio::test]
+async fn callback_rejection_stops_before_tunnel_authorization() {
+    let (out_client, out_server) = tokio::io::duplex(4096);
+    let (in_client, in_server) = tokio::io::duplex(4096);
+    let consent = consent_message("Accept");
+    let mut out_response = Vec::from([0; 10]);
+    out_response.extend(packet(2, &handshake_response()));
+    out_response.extend(packet(5, &tunnel_response(&consent)));
+
+    let out_server = tokio::spawn(async move {
+        let service = service_fn(move |request: Request<hyper::body::Incoming>| {
+            let out_response = out_response.clone();
+            async move {
+                assert_eq!(request.method(), "RDG_OUT_DATA");
+                Ok::<_, Infallible>(response(StatusCode::OK, Bytes::from(out_response)))
+            }
+        });
+        http1::Builder::new()
+            .serve_connection(TokioIo::new(out_server), service)
+            .await
+            .expect("serve OUT");
+    });
+
+    let in_server = tokio::spawn(async move {
+        let service = service_fn(move |mut request: Request<hyper::body::Incoming>| async move {
+            assert_eq!(request.method(), "RDG_IN_DATA");
+            if request.headers().get("content-type").is_none() {
+                return Ok::<_, Infallible>(response(StatusCode::OK, Bytes::new()));
+            }
+
+            for expected_packet_type in [1, 4] {
+                let frame = request
+                    .body_mut()
+                    .frame()
+                    .await
+                    .expect("IN request frame")
+                    .expect("IN request frame result")
+                    .into_data()
+                    .expect("IN request data frame");
+                assert_eq!(packet_type(&frame), expected_packet_type);
+            }
+
+            let next = tokio::time::timeout(core::time::Duration::from_millis(100), request.body_mut().frame()).await;
+            assert!(
+                !matches!(next, Ok(Some(Ok(_)))),
+                "no tunnel authorization or channel packet must follow a declined consent message"
+            );
+            Ok::<_, Infallible>(response(StatusCode::OK, Bytes::new()))
+        });
+        http1::Builder::new()
+            .serve_connection(TokioIo::new(in_server), service)
+            .await
+            .expect("serve IN");
+    });
+
+    let transport = GatewayTransport::connect(out_client, in_client)
+        .await
+        .expect("connect transport");
+    let mut callback_invoked = false;
+    let mut callback = |_message: &str| {
+        callback_invoked = true;
+        false
+    };
+    let error = match transport
+        .connect_tunnel(test_target(), "client.test", 3389, Some(&mut callback))
+        .await
+    {
+        Ok(_) => panic!("declined consent"),
+        Err(error) => error,
+    };
+
+    assert!(callback_invoked);
+    assert!(matches!(error.kind(), GwErrorKind::ConsentDeclined));
+    out_server.await.expect("OUT task");
+    in_server.await.expect("IN task");
+}
+
 #[test]
 fn malformed_consent_payload_is_rejected_before_callback() {
     let callback_count = Arc::new(Mutex::new(0));
@@ -68,4 +156,50 @@ fn malformed_consent_payload_is_rejected_before_callback() {
 
     assert!(matches!(error.kind(), GwErrorKind::Decode));
     assert_eq!(*callback_count.lock().expect("callback count lock"), 0);
+}
+
+fn test_target() -> GwConnectTarget {
+    GwConnectTarget {
+        gw_endpoint: "gateway.test:443".to_owned(),
+        gw_user: "user".to_owned(),
+        gw_pass: "pass".to_owned(),
+        smart_card: None,
+        server: "server.test".to_owned(),
+    }
+}
+
+fn packet(packet_type: u16, payload: &[u8]) -> Vec<u8> {
+    let length = u32::try_from(8 + payload.len()).expect("packet length");
+    let mut packet = Vec::with_capacity(8 + payload.len());
+    packet.extend(packet_type.to_le_bytes());
+    packet.extend([0; 2]);
+    packet.extend(length.to_le_bytes());
+    packet.extend(payload);
+    packet
+}
+
+fn packet_type(packet: &[u8]) -> u16 {
+    u16::from_le_bytes([packet[0], packet[1]])
+}
+
+fn handshake_response() -> [u8; 10] {
+    [0, 0, 0, 0, 1, 0, 0, 0, 1, 0]
+}
+
+fn tunnel_response(consent: &[u8]) -> Vec<u8> {
+    let consent_length = u16::try_from(consent.len()).expect("consent length");
+    let mut response = Vec::with_capacity(12 + consent.len());
+    response.extend([0, 0]);
+    response.extend([0; 4]);
+    response.extend([0x10, 0]);
+    response.extend([0; 2]);
+    response.extend(consent_length.to_le_bytes());
+    response.extend(consent);
+    response
+}
+
+fn response(status: StatusCode, body: Bytes) -> Response<TestBody> {
+    let mut response = Response::new(Full::new(body).boxed());
+    *response.status_mut() = status;
+    response
 }

--- a/crates/ironrdp-mstsgu/tests/consent.rs
+++ b/crates/ironrdp-mstsgu/tests/consent.rs
@@ -1,0 +1,71 @@
+#![allow(unused_crate_dependencies)]
+
+use std::sync::{Arc, Mutex};
+
+use ironrdp_mstsgu::GwErrorKind;
+use ironrdp_mstsgu::test_support::evaluate_consent_message;
+
+fn consent_message(message: &str) -> Vec<u8> {
+    message
+        .encode_utf16()
+        .chain(core::iter::once(0))
+        .flat_map(u16::to_le_bytes)
+        .collect()
+}
+
+#[test]
+fn no_consent_preserves_existing_behavior() {
+    let callback_count = Arc::new(Mutex::new(0));
+    let callback_count_for_callback = Arc::clone(&callback_count);
+    let mut callback = move |_message: &str| {
+        *callback_count_for_callback.lock().expect("callback count lock") += 1;
+        false
+    };
+
+    evaluate_consent_message(&[], Some(&mut callback)).expect("no consent");
+    assert_eq!(*callback_count.lock().expect("callback count lock"), 0);
+}
+
+#[test]
+fn default_accepts_gateway_consent() {
+    evaluate_consent_message(&consent_message("Accept"), None).expect("default consent acceptance");
+}
+
+#[test]
+fn callback_receives_decoded_consent_message_once() {
+    let messages = Arc::new(Mutex::new(Vec::new()));
+    let callback_messages = Arc::clone(&messages);
+    let mut callback = move |message: &str| {
+        callback_messages
+            .lock()
+            .expect("callback messages lock")
+            .push(message.to_owned());
+        true
+    };
+
+    evaluate_consent_message(&consent_message("Accept"), Some(&mut callback)).expect("accepted consent");
+    assert_eq!(*messages.lock().expect("callback messages lock"), ["Accept"]);
+}
+
+#[test]
+fn callback_rejection_returns_consent_declined() {
+    let mut callback = |_message: &str| false;
+    let error =
+        evaluate_consent_message(&consent_message("Accept"), Some(&mut callback)).expect_err("declined consent");
+
+    assert!(matches!(error.kind(), GwErrorKind::ConsentDeclined));
+}
+
+#[test]
+fn malformed_consent_payload_is_rejected_before_callback() {
+    let callback_count = Arc::new(Mutex::new(0));
+    let callback_count_for_callback = Arc::clone(&callback_count);
+    let mut callback = move |_message: &str| {
+        *callback_count_for_callback.lock().expect("callback count lock") += 1;
+        true
+    };
+    let error = evaluate_consent_message(&[0x41], Some(&mut callback)).expect_err("malformed consent");
+
+    assert!(matches!(error.kind(), GwErrorKind::Decode));
+    assert_eq!(*callback_count.lock().expect("callback count lock"), 0);
+}


### PR DESCRIPTION
Decode gateway consent messages as UTF-16LE during tunnel creation.

Accept consent by default, and let callbacks decline it before tunnel authorization and channel setup.