### PR TITLE
feat(activex): prompt for gateway credentials

### DIFF
--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -440,6 +440,8 @@ const CONNECT_E_CANNOTCONNECT: HRESULT = HRESULT(-2_147_220_990);
 const CONNECT_E_NOCONNECTION: HRESULT = HRESULT(-2_147_220_992);
 const CREDUI_MAX_USERNAME_LENGTH: usize = 513;
 const CREDUI_MAX_PASSWORD_LENGTH: usize = 256;
+const CREDUI_USERNAME_BUFFER_LENGTH: usize = CREDUI_MAX_USERNAME_LENGTH + 1;
+const CREDUI_PASSWORD_BUFFER_LENGTH: usize = CREDUI_MAX_PASSWORD_LENGTH + 1;
 const MSTSC_SEND_KEYS_MAX_KEYS: usize = 20;
 const CONTROL_RECONNECT_STARTED: i32 = 0;
 const CONTROL_RECONNECT_BLOCKED: i32 = 1;
@@ -7539,8 +7541,8 @@ impl Control {
         // the prompt, and CredUI's non-persistent flag prevents it from writing credential state.
         let initial_username = std::env::var("RDP_USERNAME").unwrap_or(configured_username);
         let initial_password = std::env::var("RDP_PASSWORD").unwrap_or_default();
-        let mut username = credential_prompt_buffer(&initial_username, CREDUI_MAX_USERNAME_LENGTH);
-        let mut password = credential_prompt_buffer(&initial_password, CREDUI_MAX_PASSWORD_LENGTH);
+        let mut username = credential_prompt_buffer(&initial_username, CREDUI_USERNAME_BUFFER_LENGTH);
+        let mut password = credential_prompt_buffer(&initial_password, CREDUI_PASSWORD_BUFFER_LENGTH);
         let mut save = windows_core::BOOL(0);
         let prompt = CREDUI_INFOW {
             cbSize: size_of::<CREDUI_INFOW>() as u32,
@@ -7627,8 +7629,8 @@ impl Control {
         } else {
             self.credential_parent.get()
         };
-        let mut username = credential_prompt_buffer("", CREDUI_MAX_USERNAME_LENGTH);
-        let mut password = credential_prompt_buffer("", CREDUI_MAX_PASSWORD_LENGTH);
+        let mut username = credential_prompt_buffer("", CREDUI_USERNAME_BUFFER_LENGTH);
+        let mut password = credential_prompt_buffer("", CREDUI_PASSWORD_BUFFER_LENGTH);
         let mut save = windows_core::BOOL(0);
         let prompt = CREDUI_INFOW {
             cbSize: size_of::<CREDUI_INFOW>() as u32,
@@ -16476,6 +16478,24 @@ mod tests {
             credential_prompt_buffer("long-name", 5),
             [u16::from(b'l'), u16::from(b'o'), u16::from(b'n'), u16::from(b'g'), 0]
         );
+        let username = credential_prompt_buffer(&"u".repeat(CREDUI_MAX_USERNAME_LENGTH), CREDUI_USERNAME_BUFFER_LENGTH);
+        assert_eq!(username.len(), CREDUI_USERNAME_BUFFER_LENGTH);
+        assert!(
+            username[..CREDUI_MAX_USERNAME_LENGTH]
+                .iter()
+                .all(|character| *character == u16::from(b'u'))
+        );
+        assert_eq!(username[CREDUI_MAX_USERNAME_LENGTH], 0);
+
+        let password = credential_prompt_buffer(&"p".repeat(CREDUI_MAX_PASSWORD_LENGTH), CREDUI_PASSWORD_BUFFER_LENGTH);
+        assert_eq!(password.len(), CREDUI_PASSWORD_BUFFER_LENGTH);
+        assert!(
+            password[..CREDUI_MAX_PASSWORD_LENGTH]
+                .iter()
+                .all(|character| *character == u16::from(b'p'))
+        );
+        assert_eq!(password[CREDUI_MAX_PASSWORD_LENGTH], 0);
+
         assert!(credential_prompt_buffer("ignored", 0).is_empty());
     }
 

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -2880,7 +2880,9 @@ fn domain_qualified_username(domain: &str, username: &str) -> String {
     }
 }
 
-fn active_x_transport(settings: &Settings, compatibility: &CompatibilitySettings) -> Result<ActiveXTransport> {
+fn active_x_gateway_credentials_source(
+    compatibility: &CompatibilitySettings,
+) -> Result<Option<GatewayCredentialsSource>> {
     let usage_method = GatewayUsageMethod::try_from(i64::from(compatibility.gateway_usage_method))
         .map_err(|error| Error::new(E_INVALIDARG, error.to_string()))?;
     let use_gateway = match usage_method {
@@ -2894,7 +2896,7 @@ fn active_x_transport(settings: &Settings, compatibility: &CompatibilitySettings
         }
     };
     if !use_gateway {
-        return Ok(ActiveXTransport::Direct);
+        return Ok(None);
     }
 
     if compatibility.gateway_hostname.trim().is_empty() {
@@ -2906,6 +2908,18 @@ fn active_x_transport(settings: &Settings, compatibility: &CompatibilitySettings
 
     let credentials_source = GatewayCredentialsSource::try_from(i64::from(compatibility.gateway_creds_source))
         .map_err(|error| Error::new(E_INVALIDARG, error.to_string()))?;
+    Ok(Some(credentials_source))
+}
+
+fn active_x_transport(
+    settings: &Settings,
+    compatibility: &CompatibilitySettings,
+    prompted_gateway_credentials: Option<(String, String)>,
+) -> Result<Option<ActiveXTransport>> {
+    let Some(credentials_source) = active_x_gateway_credentials_source(compatibility)? else {
+        return Ok(Some(ActiveXTransport::Direct));
+    };
+
     let (username, password) = match credentials_source {
         GatewayCredentialsSource::UseServerCredentials => (
             domain_qualified_username(&settings.domain, &settings.username),
@@ -2918,8 +2932,19 @@ fn active_x_transport(settings: &Settings, compatibility: &CompatibilitySettings
             domain_qualified_username(&compatibility.gateway_domain, &compatibility.gateway_username),
             compatibility.gateway_password.clone(),
         ),
+        GatewayCredentialsSource::Prompt => {
+            let Some((username, password)) = prompted_gateway_credentials else {
+                return Ok(None);
+            };
+            if password.is_empty() {
+                return Ok(None);
+            }
+            (
+                domain_qualified_username(&compatibility.gateway_domain, &username),
+                password,
+            )
+        }
         GatewayCredentialsSource::UseProfile
-        | GatewayCredentialsSource::Prompt
         | GatewayCredentialsSource::SmartCard
         | GatewayCredentialsSource::UseLogonCredentials => return Err(Error::from_hresult(E_NOTIMPL)),
     };
@@ -2930,11 +2955,11 @@ fn active_x_transport(settings: &Settings, compatibility: &CompatibilitySettings
         ));
     }
 
-    Ok(ActiveXTransport::Gateway {
+    Ok(Some(ActiveXTransport::Gateway {
         endpoint: compatibility.gateway_hostname.clone(),
         username,
         password,
-    })
+    }))
 }
 
 unsafe extern "system" fn advanced_put_audio_redirection(this: *mut c_void, value: u32) -> HRESULT {
@@ -7592,6 +7617,74 @@ impl Control {
         Ok(self.state.get() != ConnectionState::Disconnected)
     }
 
+    fn prompt_for_gateway_credentials(&self, endpoint: &str) -> Result<Option<(String, String)>> {
+        trace_host_call("ActiveXGatewayCredentialPrompt::Prompt");
+        let target = HSTRING::from(format!("IronRDP Gateway:{endpoint}"));
+        let message = HSTRING::from(format!("Enter credentials for RD Gateway {endpoint}"));
+        let caption = HSTRING::from("IronRDP RD Gateway Credentials");
+        let parent = if self.credential_parent.get().0.is_null() {
+            self.activex_window.get()
+        } else {
+            self.credential_parent.get()
+        };
+        let mut username = credential_prompt_buffer("", CREDUI_MAX_USERNAME_LENGTH);
+        let mut password = credential_prompt_buffer("", CREDUI_MAX_PASSWORD_LENGTH);
+        let mut save = windows_core::BOOL(0);
+        let prompt = CREDUI_INFOW {
+            cbSize: size_of::<CREDUI_INFOW>() as u32,
+            hwndParent: parent,
+            pszMessageText: PCWSTR(message.as_ptr()),
+            pszCaptionText: PCWSTR(caption.as_ptr()),
+            hbmBanner: Default::default(),
+        };
+        let result = unsafe {
+            CredUIPromptForCredentialsW(
+                Some(&prompt),
+                PCWSTR(target.as_ptr()),
+                None,
+                0,
+                &mut username,
+                &mut password,
+                Some(&mut save),
+                CREDUI_FLAGS_GENERIC_CREDENTIALS | CREDUI_FLAGS_ALWAYS_SHOW_UI | CREDUI_FLAGS_DO_NOT_PERSIST,
+            )
+        };
+
+        if result == ERROR_CANCELLED {
+            trace_host_call("ActiveXGatewayCredentialPrompt::Cancelled");
+            username.fill(0);
+            password.fill(0);
+            return Ok(None);
+        }
+        if result.0 != 0 {
+            trace_host_call("ActiveXGatewayCredentialPrompt::PromptFailed");
+            username.fill(0);
+            password.fill(0);
+            return Err(Error::new(
+                E_FAIL,
+                format!("gateway credential prompt failed with Win32 error {}", result.0),
+            ));
+        }
+
+        let prompted_username = String::from_utf16_lossy(
+            &username[..username
+                .iter()
+                .position(|character| *character == 0)
+                .unwrap_or(username.len())],
+        );
+        let prompted_password = String::from_utf16_lossy(
+            &password[..password
+                .iter()
+                .position(|character| *character == 0)
+                .unwrap_or(password.len())],
+        );
+        username.fill(0);
+        password.fill(0);
+
+        trace_host_call("ActiveXGatewayCredentialPrompt::CredentialsAccepted");
+        Ok(Some((prompted_username, prompted_password)))
+    }
+
     fn native_mstsc_server_from_host_ui(&self) -> Option<String> {
         let activex_window = self.activex_window.get();
         if activex_window.0.is_null() {
@@ -8823,6 +8916,29 @@ impl Control {
             return Ok(());
         }
         drop(settings);
+        let transport_override = match self.rpc_transport.borrow_mut().take() {
+            Some(transport) => Some(transport),
+            None => self.rdcleanpath_transport()?,
+        };
+        let gateway_prompt_endpoint = if transport_override.is_none() {
+            let compatibility = self.compatibility.borrow();
+            matches!(
+                active_x_gateway_credentials_source(&compatibility)?,
+                Some(GatewayCredentialsSource::Prompt)
+            )
+            .then(|| compatibility.gateway_hostname.clone())
+        } else {
+            None
+        };
+        let prompted_gateway_credentials = match gateway_prompt_endpoint {
+            Some(endpoint) => {
+                let Some(credentials) = self.prompt_for_gateway_credentials(&endpoint)? else {
+                    return Ok(());
+                };
+                Some(credentials)
+            }
+            None => None,
+        };
         let hwnd = self.ensure_dispatcher()?;
         let settings = self.settings.borrow();
         let destination = Destination::new(settings.server.clone())
@@ -8863,12 +8979,12 @@ impl Control {
         let keyboard_functional_keys_count = compatibility.keyboard_functional_keys_count;
         let alternate_shell = compatibility.secured_start_program.clone();
         let work_dir = compatibility.secured_work_dir.clone();
-        let transport = match self.rpc_transport.borrow_mut().take() {
-            Some(transport) => transport,
-            None => match self.rdcleanpath_transport()? {
-                Some(transport) => transport,
-                None => active_x_transport(&settings, &compatibility)?,
-            },
+        let transport = match transport_override {
+            Some(transport) => Some(transport),
+            None => active_x_transport(&settings, &compatibility, prompted_gateway_credentials)?,
+        };
+        let Some(transport) = transport else {
+            return Ok(());
         };
         let performance_flags = compatibility.performance_flags;
         let keyboard_layout = compatibility.keyboard_layout;
@@ -15544,7 +15660,9 @@ mod tests {
             endpoint,
             username,
             password,
-        } = active_x_transport(&settings, &compatibility).expect("explicit gateway is supported")
+        } = active_x_transport(&settings, &compatibility, None)
+            .expect("explicit gateway is supported")
+            .expect("explicit gateway creates a transport")
         else {
             panic!("expected gateway transport");
         };
@@ -15556,8 +15674,9 @@ mod tests {
         compatibility.gateway_domain = "GATEWAY".to_owned();
         compatibility.gateway_username = "gateway-user".to_owned();
         compatibility.gateway_password = "gateway-password".to_owned();
-        let ActiveXTransport::Gateway { username, password, .. } =
-            active_x_transport(&settings, &compatibility).expect("gateway user credentials are supported")
+        let ActiveXTransport::Gateway { username, password, .. } = active_x_transport(&settings, &compatibility, None)
+            .expect("gateway user credentials are supported")
+            .expect("gateway user credentials create a transport")
         else {
             panic!("expected gateway transport");
         };
@@ -15565,7 +15684,7 @@ mod tests {
         assert_eq!(password, "gateway-password");
 
         compatibility.gateway_usage_method = GatewayUsageMethod::UseDefaultSettings.as_i64() as u32;
-        let system_policy_error = match active_x_transport(&settings, &compatibility) {
+        let system_policy_error = match active_x_transport(&settings, &compatibility, None) {
             Ok(_) => panic!("system policy must not be silently approximated"),
             Err(error) => error,
         };
@@ -15573,11 +15692,36 @@ mod tests {
 
         compatibility.gateway_usage_method = GatewayUsageMethod::UseAlways.as_i64() as u32;
         compatibility.gateway_creds_source = GatewayCredentialsSource::Prompt.as_i64() as u32;
-        let prompt_error = match active_x_transport(&settings, &compatibility) {
-            Ok(_) => panic!("gateway prompting is not implemented"),
-            Err(error) => error,
+        compatibility.gateway_domain = "GATEWAY".to_owned();
+        let ActiveXTransport::Gateway {
+            endpoint,
+            username,
+            password,
+        } = active_x_transport(
+            &settings,
+            &compatibility,
+            Some(("prompted-user".to_owned(), "prompted-password".to_owned())),
+        )
+        .expect("gateway prompting is supported")
+        .expect("accepted gateway prompt creates a transport")
+        else {
+            panic!("expected gateway transport");
         };
-        assert_eq!(prompt_error.code(), E_NOTIMPL);
+        assert_eq!(endpoint, "gateway.example.test:443");
+        assert_eq!(username, "GATEWAY\\prompted-user");
+        assert_eq!(password, "prompted-password");
+
+        let cancelled =
+            active_x_transport(&settings, &compatibility, None).expect("gateway prompt cancellation is not an error");
+        assert!(cancelled.is_none());
+
+        let empty_password = active_x_transport(
+            &settings,
+            &compatibility,
+            Some(("prompted-user".to_owned(), String::new())),
+        )
+        .expect("an empty gateway prompt password is not an error");
+        assert!(empty_password.is_none());
     }
 
     #[test]


### PR DESCRIPTION
Prompt for non-persistent credentials for a configured RD Gateway.

Keep them scoped to the connection attempt and leave cancellation disconnected.