### PR TITLE
fix(dvc): log channel name on DVC creation failure

### DIFF
--- a/crates/ironrdp-dvc/src/server.rs
+++ b/crates/ironrdp-dvc/src/server.rs
@@ -9,7 +9,7 @@ use ironrdp_pdu::{self as pdu, PduError, decode_err, encode_err, pdu_other_err};
 use ironrdp_svc::{ChannelFlags, CompressionCondition, SvcMessage, SvcProcessor, SvcServerProcessor};
 use pdu::PduResult;
 use pdu::gcc::ChannelName;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::pdu::{
     CapabilitiesRequestPdu, CapsVersion, ClosePdu, CreateRequestPdu, CreationStatus, DrdynvcClientPdu,
@@ -467,7 +467,10 @@ impl SvcProcessor for DrdynvcServer {
                     return Err(pdu_other_err!("invalid channel state"));
                 }
                 if create_resp.creation_status() != CreationStatus::OK {
-                    c.state = ChannelState::CreationFailed(create_resp.creation_status().into());
+                    let name = c.processor.channel_name();
+                    let status = create_resp.creation_status();
+                    warn!(channel_id = ?id, %name, ?status, "DVC channel creation failed");
+                    c.state = ChannelState::CreationFailed(status.into());
                     return Ok(resp);
                 }
                 c.state = ChannelState::Opened;


### PR DESCRIPTION
## Summary

- When a client rejects a DVC create request, `DrdynvcServer::process()` only logged the raw PDU (channel_id and status code). The channel's name is already in scope one line earlier, from building the original create request, but the failure branch never surfaces it.
- I found this while debugging a real server log: a channel_id 0 creation failure with no way to tell which channel it was without reading the source and tracing registration order by hand.
- Added the channel name to the failure log line using structured tracing fields, and raised the level from implicit debug to warn, since a channel creation failure is a real, actionable event most deployments would want visible at default verbosity rather than something requiring debug or trace logging to notice.

## Validation

`cargo xtask check fmt/lints/tests/typos/locks` all pass.

## Notes

Five-line diff, `crates/ironrdp-dvc/src/server.rs` only. No behavior change beyond the added log line.
