### PR TITLE
feat(client): wire local VMConnect features

### DIFF
--- a/crates/ironrdp-cfg/src/lib.rs
+++ b/crates/ironrdp-cfg/src/lib.rs
@@ -633,6 +633,27 @@ pub trait PropertySetExt {
     /// Removes the `ironrdp_named_pipe` property.
     fn clear_named_pipe(&mut self);
 
+    /// Select the Hyper-V basic console instead of Enhanced Session mode (`ironrdp_vmconnect_basic`).
+    fn vmconnect_basic(&self) -> Option<bool>;
+    /// Sets the `ironrdp_vmconnect_basic` property.
+    fn set_vmconnect_basic(&mut self, enabled: bool);
+    /// Removes the `ironrdp_vmconnect_basic` property.
+    fn clear_vmconnect_basic(&mut self);
+
+    /// Use the caller's current Windows logon token for VMConnect host authentication (`ironrdp_vmconnect_current_user`).
+    fn vmconnect_current_user(&self) -> Option<bool>;
+    /// Sets the `ironrdp_vmconnect_current_user` property.
+    fn set_vmconnect_current_user(&mut self, enabled: bool);
+    /// Removes the `ironrdp_vmconnect_current_user` property.
+    fn clear_vmconnect_current_user(&mut self);
+
+    /// Hyper-V VM ID for a VMConnect session (`ironrdp_vmconnect`).
+    fn vmconnect_id(&self) -> Option<&str>;
+    /// Sets the `ironrdp_vmconnect` property.
+    fn set_vmconnect_id(&mut self, value: impl Into<String>);
+    /// Removes the `ironrdp_vmconnect` property.
+    fn clear_vmconnect_id(&mut self);
+
     /// Windows Sandbox id used by agent tooling (`ironrdp_sandbox_id`).
     fn sandbox_id(&self) -> Option<&str>;
     /// Sets the `ironrdp_sandbox_id` property.
@@ -656,30 +677,6 @@ pub trait PropertySetExt {
     /// Removes every RDCleanPath-related key (`ironrdp_rdcleanpathurl` and
     /// `ironrdp_rdcleanpathtoken`).
     fn clear_rdcleanpath(&mut self);
-}
-
-/// Typed accessors for IronRDP VMConnect properties.
-pub trait VmConnectPropertySetExt {
-    /// Select the Hyper-V basic console instead of Enhanced Session mode (`ironrdp_vmconnect_basic`).
-    fn vmconnect_basic(&self) -> Option<bool>;
-    /// Sets the `ironrdp_vmconnect_basic` property.
-    fn set_vmconnect_basic(&mut self, enabled: bool);
-    /// Removes the `ironrdp_vmconnect_basic` property.
-    fn clear_vmconnect_basic(&mut self);
-
-    /// Use the caller's current Windows logon token for VMConnect host authentication (`ironrdp_vmconnect_current_user`).
-    fn vmconnect_current_user(&self) -> Option<bool>;
-    /// Sets the `ironrdp_vmconnect_current_user` property.
-    fn set_vmconnect_current_user(&mut self, enabled: bool);
-    /// Removes the `ironrdp_vmconnect_current_user` property.
-    fn clear_vmconnect_current_user(&mut self);
-
-    /// Hyper-V VM ID for a VMConnect session (`ironrdp_vmconnect`).
-    fn vmconnect_id(&self) -> Option<&str>;
-    /// Sets the `ironrdp_vmconnect` property.
-    fn set_vmconnect_id(&mut self, value: impl Into<String>);
-    /// Removes the `ironrdp_vmconnect` property.
-    fn clear_vmconnect_id(&mut self);
 }
 
 impl PropertySetExt for PropertySet {
@@ -1253,6 +1250,42 @@ impl PropertySetExt for PropertySet {
         self.remove("ironrdp_named_pipe");
     }
 
+    fn vmconnect_basic(&self) -> Option<bool> {
+        self.get::<bool>("ironrdp_vmconnect_basic")
+    }
+
+    fn set_vmconnect_basic(&mut self, enabled: bool) {
+        self.insert("ironrdp_vmconnect_basic", enabled);
+    }
+
+    fn clear_vmconnect_basic(&mut self) {
+        self.remove("ironrdp_vmconnect_basic");
+    }
+
+    fn vmconnect_current_user(&self) -> Option<bool> {
+        self.get::<bool>("ironrdp_vmconnect_current_user")
+    }
+
+    fn set_vmconnect_current_user(&mut self, enabled: bool) {
+        self.insert("ironrdp_vmconnect_current_user", enabled);
+    }
+
+    fn clear_vmconnect_current_user(&mut self) {
+        self.remove("ironrdp_vmconnect_current_user");
+    }
+
+    fn vmconnect_id(&self) -> Option<&str> {
+        self.get::<&str>("ironrdp_vmconnect")
+    }
+
+    fn set_vmconnect_id(&mut self, value: impl Into<String>) {
+        self.insert("ironrdp_vmconnect", value.into());
+    }
+
+    fn clear_vmconnect_id(&mut self) {
+        self.remove("ironrdp_vmconnect");
+    }
+
     /// Optional Windows Sandbox id used by agent tooling to resolve RDP config via gRPC.
     fn sandbox_id(&self) -> Option<&str> {
         self.get::<&str>("ironrdp_sandbox_id")
@@ -1291,43 +1324,5 @@ impl PropertySetExt for PropertySet {
     fn clear_rdcleanpath(&mut self) {
         self.remove("ironrdp_rdcleanpathurl");
         self.remove("ironrdp_rdcleanpathtoken");
-    }
-}
-
-impl VmConnectPropertySetExt for PropertySet {
-    fn vmconnect_basic(&self) -> Option<bool> {
-        self.get::<bool>("ironrdp_vmconnect_basic")
-    }
-
-    fn set_vmconnect_basic(&mut self, enabled: bool) {
-        self.insert("ironrdp_vmconnect_basic", enabled);
-    }
-
-    fn clear_vmconnect_basic(&mut self) {
-        self.remove("ironrdp_vmconnect_basic");
-    }
-
-    fn vmconnect_current_user(&self) -> Option<bool> {
-        self.get::<bool>("ironrdp_vmconnect_current_user")
-    }
-
-    fn set_vmconnect_current_user(&mut self, enabled: bool) {
-        self.insert("ironrdp_vmconnect_current_user", enabled);
-    }
-
-    fn clear_vmconnect_current_user(&mut self) {
-        self.remove("ironrdp_vmconnect_current_user");
-    }
-
-    fn vmconnect_id(&self) -> Option<&str> {
-        self.get::<&str>("ironrdp_vmconnect")
-    }
-
-    fn set_vmconnect_id(&mut self, value: impl Into<String>) {
-        self.insert("ironrdp_vmconnect", value.into());
-    }
-
-    fn clear_vmconnect_id(&mut self) {
-        self.remove("ironrdp_vmconnect");
     }
 }

--- a/crates/ironrdp-cfg/src/lib.rs
+++ b/crates/ironrdp-cfg/src/lib.rs
@@ -633,6 +633,27 @@ pub trait PropertySetExt {
     /// Removes the `ironrdp_named_pipe` property.
     fn clear_named_pipe(&mut self);
 
+    /// Select the Hyper-V basic console instead of Enhanced Session mode (`ironrdp_vmconnect_basic`).
+    fn vmconnect_basic(&self) -> Option<bool>;
+    /// Sets the `ironrdp_vmconnect_basic` property.
+    fn set_vmconnect_basic(&mut self, enabled: bool);
+    /// Removes the `ironrdp_vmconnect_basic` property.
+    fn clear_vmconnect_basic(&mut self);
+
+    /// Use the caller's current Windows logon token for VMConnect host authentication (`ironrdp_vmconnect_current_user`).
+    fn vmconnect_current_user(&self) -> Option<bool>;
+    /// Sets the `ironrdp_vmconnect_current_user` property.
+    fn set_vmconnect_current_user(&mut self, enabled: bool);
+    /// Removes the `ironrdp_vmconnect_current_user` property.
+    fn clear_vmconnect_current_user(&mut self);
+
+    /// Hyper-V VM ID for a VMConnect session (`ironrdp_vmconnect`).
+    fn vmconnect_id(&self) -> Option<&str>;
+    /// Sets the `ironrdp_vmconnect` property.
+    fn set_vmconnect_id(&mut self, value: impl Into<String>);
+    /// Removes the `ironrdp_vmconnect` property.
+    fn clear_vmconnect_id(&mut self);
+
     /// Windows Sandbox id used by agent tooling (`ironrdp_sandbox_id`).
     fn sandbox_id(&self) -> Option<&str>;
     /// Sets the `ironrdp_sandbox_id` property.
@@ -1227,6 +1248,42 @@ impl PropertySetExt for PropertySet {
 
     fn clear_named_pipe(&mut self) {
         self.remove("ironrdp_named_pipe");
+    }
+
+    fn vmconnect_basic(&self) -> Option<bool> {
+        self.get::<bool>("ironrdp_vmconnect_basic")
+    }
+
+    fn set_vmconnect_basic(&mut self, enabled: bool) {
+        self.insert("ironrdp_vmconnect_basic", enabled);
+    }
+
+    fn clear_vmconnect_basic(&mut self) {
+        self.remove("ironrdp_vmconnect_basic");
+    }
+
+    fn vmconnect_current_user(&self) -> Option<bool> {
+        self.get::<bool>("ironrdp_vmconnect_current_user")
+    }
+
+    fn set_vmconnect_current_user(&mut self, enabled: bool) {
+        self.insert("ironrdp_vmconnect_current_user", enabled);
+    }
+
+    fn clear_vmconnect_current_user(&mut self) {
+        self.remove("ironrdp_vmconnect_current_user");
+    }
+
+    fn vmconnect_id(&self) -> Option<&str> {
+        self.get::<&str>("ironrdp_vmconnect")
+    }
+
+    fn set_vmconnect_id(&mut self, value: impl Into<String>) {
+        self.insert("ironrdp_vmconnect", value.into());
+    }
+
+    fn clear_vmconnect_id(&mut self) {
+        self.remove("ironrdp_vmconnect");
     }
 
     /// Optional Windows Sandbox id used by agent tooling to resolve RDP config via gRPC.

--- a/crates/ironrdp-cfg/src/lib.rs
+++ b/crates/ironrdp-cfg/src/lib.rs
@@ -633,27 +633,6 @@ pub trait PropertySetExt {
     /// Removes the `ironrdp_named_pipe` property.
     fn clear_named_pipe(&mut self);
 
-    /// Select the Hyper-V basic console instead of Enhanced Session mode (`ironrdp_vmconnect_basic`).
-    fn vmconnect_basic(&self) -> Option<bool>;
-    /// Sets the `ironrdp_vmconnect_basic` property.
-    fn set_vmconnect_basic(&mut self, enabled: bool);
-    /// Removes the `ironrdp_vmconnect_basic` property.
-    fn clear_vmconnect_basic(&mut self);
-
-    /// Use the caller's current Windows logon token for VMConnect host authentication (`ironrdp_vmconnect_current_user`).
-    fn vmconnect_current_user(&self) -> Option<bool>;
-    /// Sets the `ironrdp_vmconnect_current_user` property.
-    fn set_vmconnect_current_user(&mut self, enabled: bool);
-    /// Removes the `ironrdp_vmconnect_current_user` property.
-    fn clear_vmconnect_current_user(&mut self);
-
-    /// Hyper-V VM ID for a VMConnect session (`ironrdp_vmconnect`).
-    fn vmconnect_id(&self) -> Option<&str>;
-    /// Sets the `ironrdp_vmconnect` property.
-    fn set_vmconnect_id(&mut self, value: impl Into<String>);
-    /// Removes the `ironrdp_vmconnect` property.
-    fn clear_vmconnect_id(&mut self);
-
     /// Windows Sandbox id used by agent tooling (`ironrdp_sandbox_id`).
     fn sandbox_id(&self) -> Option<&str>;
     /// Sets the `ironrdp_sandbox_id` property.
@@ -677,6 +656,30 @@ pub trait PropertySetExt {
     /// Removes every RDCleanPath-related key (`ironrdp_rdcleanpathurl` and
     /// `ironrdp_rdcleanpathtoken`).
     fn clear_rdcleanpath(&mut self);
+}
+
+/// Typed accessors for IronRDP VMConnect properties.
+pub trait VmConnectPropertySetExt {
+    /// Select the Hyper-V basic console instead of Enhanced Session mode (`ironrdp_vmconnect_basic`).
+    fn vmconnect_basic(&self) -> Option<bool>;
+    /// Sets the `ironrdp_vmconnect_basic` property.
+    fn set_vmconnect_basic(&mut self, enabled: bool);
+    /// Removes the `ironrdp_vmconnect_basic` property.
+    fn clear_vmconnect_basic(&mut self);
+
+    /// Use the caller's current Windows logon token for VMConnect host authentication (`ironrdp_vmconnect_current_user`).
+    fn vmconnect_current_user(&self) -> Option<bool>;
+    /// Sets the `ironrdp_vmconnect_current_user` property.
+    fn set_vmconnect_current_user(&mut self, enabled: bool);
+    /// Removes the `ironrdp_vmconnect_current_user` property.
+    fn clear_vmconnect_current_user(&mut self);
+
+    /// Hyper-V VM ID for a VMConnect session (`ironrdp_vmconnect`).
+    fn vmconnect_id(&self) -> Option<&str>;
+    /// Sets the `ironrdp_vmconnect` property.
+    fn set_vmconnect_id(&mut self, value: impl Into<String>);
+    /// Removes the `ironrdp_vmconnect` property.
+    fn clear_vmconnect_id(&mut self);
 }
 
 impl PropertySetExt for PropertySet {
@@ -1250,42 +1253,6 @@ impl PropertySetExt for PropertySet {
         self.remove("ironrdp_named_pipe");
     }
 
-    fn vmconnect_basic(&self) -> Option<bool> {
-        self.get::<bool>("ironrdp_vmconnect_basic")
-    }
-
-    fn set_vmconnect_basic(&mut self, enabled: bool) {
-        self.insert("ironrdp_vmconnect_basic", enabled);
-    }
-
-    fn clear_vmconnect_basic(&mut self) {
-        self.remove("ironrdp_vmconnect_basic");
-    }
-
-    fn vmconnect_current_user(&self) -> Option<bool> {
-        self.get::<bool>("ironrdp_vmconnect_current_user")
-    }
-
-    fn set_vmconnect_current_user(&mut self, enabled: bool) {
-        self.insert("ironrdp_vmconnect_current_user", enabled);
-    }
-
-    fn clear_vmconnect_current_user(&mut self) {
-        self.remove("ironrdp_vmconnect_current_user");
-    }
-
-    fn vmconnect_id(&self) -> Option<&str> {
-        self.get::<&str>("ironrdp_vmconnect")
-    }
-
-    fn set_vmconnect_id(&mut self, value: impl Into<String>) {
-        self.insert("ironrdp_vmconnect", value.into());
-    }
-
-    fn clear_vmconnect_id(&mut self) {
-        self.remove("ironrdp_vmconnect");
-    }
-
     /// Optional Windows Sandbox id used by agent tooling to resolve RDP config via gRPC.
     fn sandbox_id(&self) -> Option<&str> {
         self.get::<&str>("ironrdp_sandbox_id")
@@ -1324,5 +1291,43 @@ impl PropertySetExt for PropertySet {
     fn clear_rdcleanpath(&mut self) {
         self.remove("ironrdp_rdcleanpathurl");
         self.remove("ironrdp_rdcleanpathtoken");
+    }
+}
+
+impl VmConnectPropertySetExt for PropertySet {
+    fn vmconnect_basic(&self) -> Option<bool> {
+        self.get::<bool>("ironrdp_vmconnect_basic")
+    }
+
+    fn set_vmconnect_basic(&mut self, enabled: bool) {
+        self.insert("ironrdp_vmconnect_basic", enabled);
+    }
+
+    fn clear_vmconnect_basic(&mut self) {
+        self.remove("ironrdp_vmconnect_basic");
+    }
+
+    fn vmconnect_current_user(&self) -> Option<bool> {
+        self.get::<bool>("ironrdp_vmconnect_current_user")
+    }
+
+    fn set_vmconnect_current_user(&mut self, enabled: bool) {
+        self.insert("ironrdp_vmconnect_current_user", enabled);
+    }
+
+    fn clear_vmconnect_current_user(&mut self) {
+        self.remove("ironrdp_vmconnect_current_user");
+    }
+
+    fn vmconnect_id(&self) -> Option<&str> {
+        self.get::<&str>("ironrdp_vmconnect")
+    }
+
+    fn set_vmconnect_id(&mut self, value: impl Into<String>) {
+        self.insert("ironrdp_vmconnect", value.into());
+    }
+
+    fn clear_vmconnect_id(&mut self) {
+        self.remove("ironrdp_vmconnect");
     }
 }

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -99,6 +99,8 @@ pub struct Config {
     pub(crate) vm_id: Option<String>,
     #[cfg(feature = "vmconnect")]
     pub(crate) vmconnect_mode: VmConnectMode,
+    #[cfg(all(windows, feature = "vmconnect"))]
+    pub(crate) vmconnect_current_user: bool,
     pub(crate) kerberos_config: Option<ironrdp_connector::credssp::KerberosConfig>,
     pub(crate) fake_events_interval: Option<Duration>,
     pub(crate) channels: ChannelConfig,
@@ -174,6 +176,18 @@ impl Config {
         self.vm_id.as_ref().map(|_| self.vmconnect_mode)
     }
 
+    #[cfg(all(windows, feature = "vmconnect"))]
+    /// Whether VMConnect host authentication uses the caller's current Windows logon token.
+    pub fn vmconnect_current_user(&self) -> bool {
+        self.vm_id.is_some() && self.vmconnect_current_user
+    }
+
+    #[cfg(all(windows, feature = "vmconnect"))]
+    /// Whether this local VMConnect session accepts Hyper-V frame-buffer redirection.
+    pub fn vmconnect_framebuffer_redirection(&self) -> bool {
+        self.vm_id.is_some() && is_loopback_host(self.destination.name())
+    }
+
     /// Optional Kerberos/KDC proxy configuration.
     pub fn kerberos_config(&self) -> Option<&ironrdp_connector::credssp::KerberosConfig> {
         self.kerberos_config.as_ref()
@@ -244,6 +258,13 @@ impl fmt::Debug for Config {
         {
             s.field("vm_id", &self.vm_id);
             s.field("vmconnect_mode", &self.vmconnect_mode);
+            #[cfg(windows)]
+            s.field("vmconnect_current_user", &self.vmconnect_current_user);
+            #[cfg(windows)]
+            s.field(
+                "vmconnect_framebuffer_redirection",
+                &self.vmconnect_framebuffer_redirection(),
+            );
         }
         s.field("kerberos_config", &self.kerberos_config);
         s.field("fake_events_interval", &self.fake_events_interval);
@@ -739,6 +760,8 @@ pub struct ConfigBuilder {
     vm_id: Option<String>,
     #[cfg(feature = "vmconnect")]
     vmconnect_mode: VmConnectMode,
+    #[cfg(all(windows, feature = "vmconnect"))]
+    vmconnect_current_user: bool,
     rdcleanpath_token: Option<String>,
     kerberos_config: Option<ironrdp_connector::credssp::KerberosConfig>,
     fake_events_interval: Option<Duration>,
@@ -1228,7 +1251,11 @@ impl ConfigBuilder {
     /// then the VMConnect PCB / `connect_front` handshake runs on the tunneled stream).
     #[must_use]
     pub fn with_vmconnect(mut self, vm_id: impl Into<String>) -> Self {
-        self.vm_id = Some(vm_id.into());
+        let vm_id = vm_id.into();
+        self.properties.set_vmconnect_id(vm_id.clone());
+        self.properties.set_vmconnect_basic(false);
+        self.vm_id = Some(vm_id);
+        self.vmconnect_mode = VmConnectMode::Enhanced;
         self
     }
 
@@ -1238,8 +1265,22 @@ impl ConfigBuilder {
     /// See [`with_vmconnect`](Self::with_vmconnect) for transport notes.
     #[must_use]
     pub fn with_vmconnect_mode(mut self, vm_id: impl Into<String>, mode: VmConnectMode) -> Self {
-        self.vm_id = Some(vm_id.into());
+        let vm_id = vm_id.into();
+        self.properties.set_vmconnect_id(vm_id.clone());
+        self.properties.set_vmconnect_basic(mode == VmConnectMode::Basic);
+        self.vm_id = Some(vm_id);
         self.vmconnect_mode = mode;
+        self
+    }
+
+    #[cfg(all(windows, feature = "vmconnect"))]
+    /// Use the caller's current Windows logon token for VMConnect host authentication.
+    ///
+    /// This is the native VMConnect behavior for local Hyper-V connections and avoids handling a reusable host password.
+    #[must_use]
+    pub fn with_vmconnect_current_user(mut self, enabled: bool) -> Self {
+        self.properties.set_vmconnect_current_user(enabled);
+        self.vmconnect_current_user = enabled;
         self
     }
 
@@ -1491,13 +1532,17 @@ impl ConfigBuilder {
     /// because [`build`](Self::build) resolves them from the RDP server account.
     pub fn missing(&self) -> Vec<MissingField> {
         let mut missing = Vec::new();
+        #[cfg(all(windows, feature = "vmconnect"))]
+        let uses_current_vmconnect_credentials = self.vm_id.is_some() && self.vmconnect_current_user;
+        #[cfg(not(all(windows, feature = "vmconnect")))]
+        let uses_current_vmconnect_credentials = false;
         if self.destination.is_none() {
             missing.push(MissingField::ServerAddress);
         }
-        if self.username.is_none() {
+        if self.username.is_none() && !uses_current_vmconnect_credentials {
             missing.push(MissingField::Username);
         }
-        if self.password.is_none() {
+        if self.password.is_none() && !uses_current_vmconnect_credentials {
             missing.push(MissingField::Password);
         }
         #[cfg(feature = "gateway")]
@@ -1621,6 +1666,29 @@ impl ConfigBuilder {
         #[cfg(feature = "vmconnect")]
         if let Some(vm_id) = &self.vm_id {
             anyhow::ensure!(!vm_id.trim().is_empty(), "vmconnect VM ID is empty");
+        }
+
+        #[cfg(all(windows, feature = "vmconnect"))]
+        if self.vm_id.is_some()
+            && self.vmconnect_current_user
+            && matches!(self.transport, TransportKind::RDCleanPath { .. })
+        {
+            anyhow::bail!("vmconnect current-user authentication is not supported with RDCleanPath");
+        }
+
+        #[cfg(all(windows, feature = "vmconnect"))]
+        let vmconnect_framebuffer_redirection = self.vm_id.is_some()
+            && self
+                .destination
+                .as_ref()
+                .is_some_and(|destination| is_loopback_host(destination.name()));
+
+        #[cfg(all(windows, feature = "vmconnect"))]
+        if vmconnect_framebuffer_redirection && self.dig_product_id.as_deref().is_none_or(str::is_empty) {
+            self.dig_product_id = Some(
+                ironrdp_vmconnect::local_instance_id()
+                    .context("read local RDP InstanceID for VMConnect frame-buffer redirection")?,
+            );
         }
 
         #[cfg(feature = "vmconnect")]
@@ -1834,6 +1902,8 @@ impl ConfigBuilder {
             vm_id: self.vm_id,
             #[cfg(feature = "vmconnect")]
             vmconnect_mode: self.vmconnect_mode,
+            #[cfg(all(windows, feature = "vmconnect"))]
+            vmconnect_current_user: self.vmconnect_current_user,
             kerberos_config,
             fake_events_interval: self.fake_events_interval,
             channels: self.channels,
@@ -1931,6 +2001,22 @@ impl ConfigBuilder {
         }
         if let Some(dir) = ps.shell_working_directory() {
             self.work_dir = Some(dir.to_owned());
+        }
+        #[cfg(feature = "vmconnect")]
+        if let Some(vm_id) = ps.vmconnect_id() {
+            self.vm_id = Some(vm_id.to_owned());
+        }
+        #[cfg(feature = "vmconnect")]
+        if let Some(basic) = ps.vmconnect_basic() {
+            self.vmconnect_mode = if basic {
+                VmConnectMode::Basic
+            } else {
+                VmConnectMode::Enhanced
+            };
+        }
+        #[cfg(all(windows, feature = "vmconnect"))]
+        if let Some(current_user) = ps.vmconnect_current_user() {
+            self.vmconnect_current_user = current_user;
         }
         if let Some(remote_application_mode) = ps.remote_application_mode() {
             self.remote_application_mode = Some(remote_application_mode);
@@ -2156,6 +2242,15 @@ fn compression_type_from_level(level: u32) -> anyhow::Result<ironrdp_pdu::rdp::c
         3 => Ok(CompressionType::Rdp61),
         _ => anyhow::bail!("invalid compression level: valid values are 0, 1, 2, 3"),
     }
+}
+
+#[cfg(all(windows, feature = "vmconnect"))]
+fn is_loopback_host(host: &str) -> bool {
+    host.trim_end_matches('.').eq_ignore_ascii_case("localhost")
+        || host == "."
+        || host
+            .parse::<core::net::IpAddr>()
+            .is_ok_and(|address| address.is_loopback())
 }
 
 fn level_from_compression_type(ty: ironrdp_pdu::rdp::client_info::CompressionType) -> u32 {

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -7,6 +7,8 @@ use std::sync::Arc;
 
 use anyhow::Context as _;
 use ironrdp_cfg::PropertySetExt as _;
+#[cfg(feature = "vmconnect")]
+use ironrdp_cfg::VmConnectPropertySetExt as _;
 use ironrdp_propertyset::PropertySet;
 use ironrdp_rail::pdu::ExecutePdu;
 use url::Url;
@@ -185,7 +187,9 @@ impl Config {
     #[cfg(all(windows, feature = "vmconnect"))]
     /// Whether this local VMConnect session accepts Hyper-V frame-buffer redirection.
     pub fn vmconnect_framebuffer_redirection(&self) -> bool {
-        self.vm_id.is_some() && is_loopback_host(self.destination.name())
+        self.vm_id.is_some()
+            && matches!(&self.transport, Transport::Direct)
+            && is_loopback_host(self.destination.name())
     }
 
     /// Optional Kerberos/KDC proxy configuration.
@@ -1536,28 +1540,36 @@ impl ConfigBuilder {
         let uses_current_vmconnect_credentials = self.vm_id.is_some() && self.vmconnect_current_user;
         #[cfg(not(all(windows, feature = "vmconnect")))]
         let uses_current_vmconnect_credentials = false;
-        if self.destination.is_none() {
-            missing.push(MissingField::ServerAddress);
-        }
-        if self.username.is_none() && !uses_current_vmconnect_credentials {
-            missing.push(MissingField::Username);
-        }
-        if self.password.is_none() && !uses_current_vmconnect_credentials {
-            missing.push(MissingField::Password);
-        }
         #[cfg(feature = "gateway")]
-        if matches!(self.transport, TransportKind::Gateway { .. }) {
-            let uses_server_credentials = matches!(
+        let gateway_uses_server_credentials = matches!(self.transport, TransportKind::Gateway { .. })
+            && matches!(
                 self.properties.gateway_credentials_source(),
                 Ok(Some(ironrdp_cfg::GatewayCredentialsSource::UseServerCredentials))
             );
-            if !uses_server_credentials {
-                if self.gateway_username.is_none() {
-                    missing.push(MissingField::GatewayUsername);
-                }
-                if self.gateway_password.is_none() {
-                    missing.push(MissingField::GatewayPassword);
-                }
+        #[cfg(not(feature = "gateway"))]
+        let gateway_uses_server_credentials = false;
+        if self.destination.is_none() {
+            missing.push(MissingField::ServerAddress);
+        }
+        if self.username.is_none()
+            && (!uses_current_vmconnect_credentials
+                || (gateway_uses_server_credentials && self.gateway_username.is_none()))
+        {
+            missing.push(MissingField::Username);
+        }
+        if self.password.is_none()
+            && (!uses_current_vmconnect_credentials
+                || (gateway_uses_server_credentials && self.gateway_password.is_none()))
+        {
+            missing.push(MissingField::Password);
+        }
+        #[cfg(feature = "gateway")]
+        if matches!(self.transport, TransportKind::Gateway { .. }) && !gateway_uses_server_credentials {
+            if self.gateway_username.is_none() {
+                missing.push(MissingField::GatewayUsername);
+            }
+            if self.gateway_password.is_none() {
+                missing.push(MissingField::GatewayPassword);
             }
         }
         if matches!(self.transport, TransportKind::RDCleanPath { .. }) && self.rdcleanpath_token.is_none() {
@@ -1668,6 +1680,19 @@ impl ConfigBuilder {
             anyhow::ensure!(!vm_id.trim().is_empty(), "vmconnect VM ID is empty");
         }
 
+        #[cfg(feature = "vmconnect")]
+        if self.vm_id.is_some()
+            && let Some(destination) = self.destination.as_mut()
+            && destination.name == "."
+        {
+            destination.name = "localhost".to_owned();
+            self.properties.set_full_address(&ironrdp_cfg::TargetAddr {
+                host: ironrdp_cfg::TargetHost::Domain(destination.name.clone()),
+                port: destination.port,
+            });
+            self.properties.clear_alternate_full_address();
+        }
+
         #[cfg(all(windows, feature = "vmconnect"))]
         if self.vm_id.is_some()
             && self.vmconnect_current_user
@@ -1678,6 +1703,7 @@ impl ConfigBuilder {
 
         #[cfg(all(windows, feature = "vmconnect"))]
         let vmconnect_framebuffer_redirection = self.vm_id.is_some()
+            && matches!(&self.transport, TransportKind::Direct)
             && self
                 .destination
                 .as_ref()
@@ -2247,7 +2273,6 @@ fn compression_type_from_level(level: u32) -> anyhow::Result<ironrdp_pdu::rdp::c
 #[cfg(all(windows, feature = "vmconnect"))]
 fn is_loopback_host(host: &str) -> bool {
     host.trim_end_matches('.').eq_ignore_ascii_case("localhost")
-        || host == "."
         || host
             .parse::<core::net::IpAddr>()
             .is_ok_and(|address| address.is_loopback())

--- a/crates/ironrdp-client/src/config.rs
+++ b/crates/ironrdp-client/src/config.rs
@@ -7,8 +7,6 @@ use std::sync::Arc;
 
 use anyhow::Context as _;
 use ironrdp_cfg::PropertySetExt as _;
-#[cfg(feature = "vmconnect")]
-use ironrdp_cfg::VmConnectPropertySetExt as _;
 use ironrdp_propertyset::PropertySet;
 use ironrdp_rail::pdu::ExecutePdu;
 use url::Url;
@@ -1244,7 +1242,6 @@ impl ConfigBuilder {
         self
     }
 
-    #[cfg(feature = "vmconnect")]
     /// Connect to a Hyper-V VM console by VM GUID. Destination must use port
     /// [`ironrdp_vmconnect::PORT`] (2179) unless the caller explicitly selects another port.
     /// A destination with no explicit port defaults to 2179 instead of the ordinary RDP port.
@@ -1253,6 +1250,7 @@ impl ConfigBuilder {
     /// embedder (error if disabled). Works over Direct, RDCleanPath, and RDS Gateway (the
     /// destination port, typically 2179, is forwarded in the MS-TSGU channel-create packet,
     /// then the VMConnect PCB / `connect_front` handshake runs on the tunneled stream).
+    #[cfg(feature = "vmconnect")]
     #[must_use]
     pub fn with_vmconnect(mut self, vm_id: impl Into<String>) -> Self {
         let vm_id = vm_id.into();
@@ -1263,10 +1261,10 @@ impl ConfigBuilder {
         self
     }
 
-    #[cfg(feature = "vmconnect")]
     /// Connect to a Hyper-V VM console using the selected mode.
     ///
     /// See [`with_vmconnect`](Self::with_vmconnect) for transport notes.
+    #[cfg(feature = "vmconnect")]
     #[must_use]
     pub fn with_vmconnect_mode(mut self, vm_id: impl Into<String>, mode: VmConnectMode) -> Self {
         let vm_id = vm_id.into();
@@ -1277,10 +1275,10 @@ impl ConfigBuilder {
         self
     }
 
-    #[cfg(all(windows, feature = "vmconnect"))]
     /// Use the caller's current Windows logon token for VMConnect host authentication.
     ///
     /// This is the native VMConnect behavior for local Hyper-V connections and avoids handling a reusable host password.
+    #[cfg(all(windows, feature = "vmconnect"))]
     #[must_use]
     pub fn with_vmconnect_current_user(mut self, enabled: bool) -> Self {
         self.properties.set_vmconnect_current_user(enabled);

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -4164,10 +4164,11 @@ mod tests {
     fn noop_rdpdr_fallback_does_not_report_drive_hotplug() {
         let config = test_config();
         let (input_sender, _) = RdpInputSender::channel(1);
+        let (output_event_sender, _) = mpsc::channel(1);
         let mut connector = build_connector(
             &config,
             SocketAddr::from(([127, 0, 0, 1], 0)),
-            &input_sender,
+            (&input_sender, &output_event_sender),
             no_cliprdr_factory(),
             None,
             true,

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -784,6 +784,7 @@ impl RdpClient {
                     connect_direct(
                         &self.config,
                         &self.input_event_sender,
+                        &self.output_event_sender,
                         cliprdr_factory,
                         rdpdr_factory,
                         reconnect_cookie,
@@ -823,6 +824,7 @@ impl RdpClient {
                             connect_direct(
                                 &self.config,
                                 &self.input_event_sender,
+                                &self.output_event_sender,
                                 cliprdr_factory,
                                 rdpdr_factory,
                                 reconnect_cookie,
@@ -832,6 +834,7 @@ impl RdpClient {
                                     &self.config,
                                     gw,
                                     &self.input_event_sender,
+                                    &self.output_event_sender,
                                     cliprdr_factory,
                                     rdpdr_factory,
                                     reconnect_cookie,
@@ -845,6 +848,7 @@ impl RdpClient {
                                 &self.config,
                                 gw,
                                 &self.input_event_sender,
+                                &self.output_event_sender,
                                 cliprdr_factory,
                                 rdpdr_factory,
                                 reconnect_cookie,
@@ -884,6 +888,7 @@ impl RdpClient {
                         &self.config,
                         rdcp,
                         &self.input_event_sender,
+                        &self.output_event_sender,
                         cliprdr_factory,
                         rdpdr_factory,
                         reconnect_cookie,
@@ -921,6 +926,7 @@ impl RdpClient {
                         &self.config,
                         path,
                         &self.input_event_sender,
+                        &self.output_event_sender,
                         cliprdr_factory,
                         rdpdr_factory,
                         reconnect_cookie,
@@ -1356,12 +1362,14 @@ fn rdpsnd_backend_kind(audio_playback: bool, rdpdr_attached: bool) -> Option<Rdp
 fn build_connector(
     config: &Config,
     client_addr: SocketAddr,
-    input_sender: &RdpInputSender,
+    event_senders: (&RdpInputSender, &mpsc::Sender<RdpOutputEvent>),
     cliprdr_factory: CliprdrFactoryRef<'_>,
     rdpdr_factory: RdpdrFactoryRef<'_>,
     rdpdr_drives_allowed: bool,
     auto_reconnect_cookie: Option<&ServerAutoReconnect>,
 ) -> ConnectorResult<ironrdp_connector::ClientConnector> {
+    let (input_sender, output_event_sender) = event_senders;
+
     // `input_sender` is only consumed by the optional DVC wirings below, and `cliprdr_factory`
     // only by the optional CLIPRDR attachment; discard them explicitly when those are compiled out.
     #[cfg(not(any(
@@ -1375,6 +1383,8 @@ fn build_connector(
     let _ = cliprdr_factory;
     #[cfg(not(feature = "rdpdr"))]
     let _ = (rdpdr_factory, rdpdr_drives_allowed);
+    #[cfg(not(all(windows, feature = "vmconnect")))]
+    let _ = output_event_sender;
 
     let mut drdynvc = ironrdp_dvc::DrdynvcClient::new()
         .with_dynamic_channel(DisplayControlClient::new(|_| Ok(Vec::new())))
@@ -1384,6 +1394,29 @@ fn build_connector(
     #[cfg(feature = "location")]
     if config.channels.location {
         drdynvc = drdynvc.with_dynamic_channel(LocationClient::new());
+    }
+
+    #[cfg(all(windows, feature = "vmconnect"))]
+    if config.vmconnect_framebuffer_redirection() {
+        let output_event_sender = output_event_sender.clone();
+        drdynvc = drdynvc.with_dynamic_channel(ironrdp_vmconnect::FrameBufferClient::new(
+            move |buffer, width, height| {
+                let event = RdpOutputEvent::Image {
+                    buffer,
+                    width: NonZeroU16::new(width).expect("fbr validates nonzero width"),
+                    height: NonZeroU16::new(height).expect("fbr validates nonzero height"),
+                };
+                match output_event_sender.try_send(event) {
+                    Ok(()) => {}
+                    Err(mpsc::error::TrySendError::Full(_)) => {
+                        trace!("Dropping a Hyper-V FBR frame because the output queue is full");
+                    }
+                    Err(mpsc::error::TrySendError::Closed(_)) => {
+                        debug!("Dropping a Hyper-V FBR frame because the output queue is closed");
+                    }
+                }
+            },
+        ));
     }
 
     // Attach DVC pipe proxies.
@@ -1698,6 +1731,7 @@ type UpgradedFramed = ironrdp_tokio::TokioFramed<Box<dyn AsyncReadWrite + Unpin 
 async fn connect_direct(
     config: &Config,
     input_sender: &RdpInputSender,
+    output_event_sender: &mpsc::Sender<RdpOutputEvent>,
     cliprdr_factory: CliprdrFactoryRef<'_>,
     rdpdr_factory: RdpdrFactoryRef<'_>,
     auto_reconnect_cookie: Option<&ServerAutoReconnect>,
@@ -1716,7 +1750,7 @@ async fn connect_direct(
     let connector = build_connector(
         config,
         client_addr,
-        input_sender,
+        (input_sender, output_event_sender),
         cliprdr_factory,
         rdpdr_factory,
         true,
@@ -1738,6 +1772,7 @@ async fn connect_named_pipe(
     config: &Config,
     pipe_path: &str,
     input_sender: &RdpInputSender,
+    output_event_sender: &mpsc::Sender<RdpOutputEvent>,
     cliprdr_factory: CliprdrFactoryRef<'_>,
     rdpdr_factory: RdpdrFactoryRef<'_>,
     auto_reconnect_cookie: Option<&ServerAutoReconnect>,
@@ -1764,7 +1799,7 @@ async fn connect_named_pipe(
     let connector = build_connector(
         config,
         client_addr,
-        input_sender,
+        (input_sender, output_event_sender),
         cliprdr_factory,
         rdpdr_factory,
         true,
@@ -1780,6 +1815,7 @@ async fn connect_gateway(
     config: &Config,
     gw: &crate::config::GatewayConfig,
     input_sender: &RdpInputSender,
+    output_event_sender: &mpsc::Sender<RdpOutputEvent>,
     cliprdr_factory: CliprdrFactoryRef<'_>,
     rdpdr_factory: RdpdrFactoryRef<'_>,
     auto_reconnect_cookie: Option<&ServerAutoReconnect>,
@@ -1854,7 +1890,7 @@ async fn connect_gateway(
     let connector = build_connector(
         config,
         client_addr,
-        input_sender,
+        (input_sender, output_event_sender),
         cliprdr_factory,
         rdpdr_factory,
         rdpdr_drives_allowed,
@@ -1875,6 +1911,7 @@ async fn connect_rdcleanpath_transport(
     config: &Config,
     rdcp: &RDCleanPathConfig,
     input_sender: &RdpInputSender,
+    output_event_sender: &mpsc::Sender<RdpOutputEvent>,
     cliprdr_factory: CliprdrFactoryRef<'_>,
     rdpdr_factory: RdpdrFactoryRef<'_>,
     auto_reconnect_cookie: Option<&ServerAutoReconnect>,
@@ -1904,7 +1941,7 @@ async fn connect_rdcleanpath_transport(
     let mut connector = build_connector(
         config,
         client_addr,
-        input_sender,
+        (input_sender, output_event_sender),
         cliprdr_factory,
         rdpdr_factory,
         true,
@@ -2075,6 +2112,29 @@ where
 
     let mut network_client = ReqwestNetworkClient::new();
     let server_name = ironrdp_connector::ServerName::from(&config.destination);
+    #[cfg(windows)]
+    let upgraded = if config.vmconnect_current_user() {
+        ironrdp_vmconnect::connect_front_with_current_user(
+            pcb_sent,
+            &mut upgraded_framed,
+            &mut connector,
+            server_name.clone(),
+            &server_public_key,
+        )
+        .await?
+    } else {
+        ironrdp_vmconnect::connect_front(
+            pcb_sent,
+            &mut upgraded_framed,
+            &mut connector,
+            &mut network_client,
+            server_name.clone(),
+            &server_public_key,
+            config.kerberos_config.clone(),
+        )
+        .await?
+    };
+    #[cfg(not(windows))]
     let upgraded = ironrdp_vmconnect::connect_front(
         pcb_sent,
         &mut upgraded_framed,
@@ -4074,10 +4134,11 @@ mod tests {
         let factory = CountingRdpdrFactory::new(vec![RdpdrDrive::new(42, "fixtures".to_owned())]);
         let config = test_config();
         let (input_sender, _) = RdpInputSender::channel(1);
+        let (output_event_sender, _) = mpsc::channel(1);
         let mut connector = build_connector(
             &config,
             SocketAddr::from(([127, 0, 0, 1], 0)),
-            &input_sender,
+            (&input_sender, &output_event_sender),
             no_cliprdr_factory(),
             Some(&factory),
             true,

--- a/crates/ironrdp-testsuite-extra/tests/client/config.rs
+++ b/crates/ironrdp-testsuite-extra/tests/client/config.rs
@@ -3,8 +3,14 @@ use std::path::PathBuf;
 
 use std::sync::Arc;
 
-use ironrdp_cfg::PropertySetExt as _;
-use ironrdp_client::config::{AudioQualityMode, ClipboardType, ConfigBuilder, Destination, Transport, VmConnectMode};
+#[cfg(windows)]
+use ironrdp_cfg::GatewayCredentialsSource;
+use ironrdp_cfg::{PropertySetExt as _, VmConnectPropertySetExt as _};
+use ironrdp_client::config::{
+    AudioQualityMode, ClipboardType, ConfigBuilder, Destination, Transport, VmConnectMode,
+};
+#[cfg(windows)]
+use ironrdp_client::config::{MissingField, TransportKind};
 use ironrdp_pdu::gcc::{ClientMonitorData, Monitor, MonitorFlags};
 use ironrdp_pdu::rdp::capability_sets::{MajorPlatformType, RailSupportLevel};
 use ironrdp_viewer::cli::parse_config_from;
@@ -237,6 +243,52 @@ fn vmconnect_current_user_rejects_rdcleanpath() {
 
 #[cfg(windows)]
 #[test]
+fn current_user_vmconnect_requires_gateway_source_credentials() {
+    const VM_ID: &str = "efd1efab-c750-4262-b1bb-af0f7733bdd6";
+    let builder = |gateway_username: Option<&str>, gateway_password: Option<&str>| {
+        let mut properties = ironrdp_propertyset::PropertySet::new();
+        properties.set_gateway_credentials_source(GatewayCredentialsSource::UseServerCredentials);
+        let mut builder = ConfigBuilder::new()
+            .with_destination(Destination::new("localhost").expect("valid destination"))
+            .with_client_build(1)
+            .with_client_dir("C:\\")
+            .with_platform(MajorPlatformType::WINDOWS)
+            .with_client_name("client")
+            .with_vmconnect(VM_ID)
+            .with_vmconnect_current_user(true)
+            .with_transport(TransportKind::Gateway {
+                endpoint: "gateway.example.com:443".to_owned(),
+                prefer_direct: false,
+            })
+            .with_property_set(&properties)
+            .expect("valid gateway credential source");
+        if let Some(username) = gateway_username {
+            builder = builder.with_gateway_username(username);
+        }
+        if let Some(password) = gateway_password {
+            builder = builder.with_gateway_password(password);
+        }
+        builder
+    };
+
+    let missing = builder(None, None);
+    assert_eq!(missing.missing(), [MissingField::Username, MissingField::Password]);
+    assert_eq!(
+        missing
+            .build()
+            .expect_err("gateway source credentials must be required")
+            .to_string(),
+        "missing required configuration: username, password"
+    );
+    assert_eq!(builder(Some("gateway-user"), None).missing(), [MissingField::Password]);
+    assert_eq!(
+        builder(None, Some("gateway-password")).missing(),
+        [MissingField::Username]
+    );
+}
+
+#[cfg(windows)]
+#[test]
 fn loopback_vmconnect_hosts_offer_framebuffer_redirection() {
     const VM_ID: &str = "efd1efab-c750-4262-b1bb-af0f7733bdd6";
     const INSTANCE_ID: &str = "0123456789abcdef0123456789abcde";
@@ -250,7 +302,59 @@ fn loopback_vmconnect_hosts_offer_framebuffer_redirection() {
             config.vmconnect_framebuffer_redirection(),
             "{host} should be eligible for frame-buffer redirection"
         );
+        if host == "." {
+            assert_eq!(config.destination().name(), "localhost");
+            assert_eq!(
+                config
+                    .properties()
+                    .full_address()
+                    .expect("valid full address")
+                    .expect("normalized full address")
+                    .to_string(),
+                "localhost"
+            );
+        }
     }
+}
+
+#[cfg(windows)]
+#[test]
+fn gateway_fallback_vmconnect_does_not_offer_local_framebuffer_redirection() {
+    const VM_ID: &str = "efd1efab-c750-4262-b1bb-af0f7733bdd6";
+    let config = parse_config_from_rdp(
+        &format!(
+            "full address:s:localhost\nironrdp_vmconnect:s:{VM_ID}\nironrdp_vmconnect_current_user:i:1\ngatewayhostname:s:gateway.example.com\ngatewayusagemethod:i:2\ngatewayusername:s:gateway-user\nGatewayPassword:s:gateway-password\n"
+        ),
+        &[],
+    );
+
+    let Transport::Gateway(gateway) = config.transport() else {
+        panic!("gateway fallback transport expected");
+    };
+    assert!(gateway.prefer_direct);
+    assert!(!config.vmconnect_framebuffer_redirection());
+    assert!(config.connector().dig_product_id.is_empty());
+}
+
+#[cfg(windows)]
+#[test]
+fn rdcleanpath_vmconnect_does_not_offer_local_framebuffer_redirection() {
+    const VM_ID: &str = "efd1efab-c750-4262-b1bb-af0f7733bdd6";
+    let config = parse_config_from_rdp(
+        &format!(
+            "full address:s:localhost\nusername:s:test-user\nClearTextPassword:s:test-pass\nironrdp_vmconnect:s:{VM_ID}\n"
+        ),
+        &[
+            "--rdcleanpath-url",
+            "wss://rdcleanpath.example.com",
+            "--rdcleanpath-token",
+            "test-token",
+        ],
+    );
+
+    assert!(matches!(config.transport(), Transport::RDCleanPath(_)));
+    assert!(!config.vmconnect_framebuffer_redirection());
+    assert!(config.connector().dig_product_id.is_empty());
 }
 
 #[cfg(windows)]

--- a/crates/ironrdp-testsuite-extra/tests/client/config.rs
+++ b/crates/ironrdp-testsuite-extra/tests/client/config.rs
@@ -168,16 +168,105 @@ fn vmconnect_preserves_explicit_destination_port() {
 
 #[test]
 fn vmconnect_basic_flag_selects_basic_mode() {
+    const VM_ID: &str = "efd1efab-c750-4262-b1bb-af0f7733bdd6";
     let config = parse_config_from_rdp(
         "full address:s:hyperv.example.com:2179\nusername:s:test-user\nClearTextPassword:s:test-pass\n",
-        &[
-            "--vmconnect",
-            "efd1efab-c750-4262-b1bb-af0f7733bdd6",
-            "--vmconnect-basic",
-        ],
+        &["--vmconnect", VM_ID, "--vmconnect-basic"],
     );
 
     assert_eq!(config.vmconnect_mode(), Some(VmConnectMode::Basic));
+    assert_eq!(config.properties().vmconnect_id(), Some(VM_ID));
+    assert_eq!(config.properties().vmconnect_basic(), Some(true));
+}
+
+#[test]
+fn vmconnect_properties_restore_typed_config() {
+    const VM_ID: &str = "efd1efab-c750-4262-b1bb-af0f7733bdd6";
+    let config = parse_config_from_rdp(
+        &format!(
+            "full address:s:hyperv.example.com\nusername:s:test-user\nClearTextPassword:s:test-pass\nironrdp_vmconnect:s:{VM_ID}\nironrdp_vmconnect_basic:i:1\n"
+        ),
+        &[],
+    );
+
+    assert_eq!(config.vm_id(), Some(VM_ID));
+    assert_eq!(config.vmconnect_mode(), Some(VmConnectMode::Basic));
+    assert_eq!(config.destination().port(), 2179);
+}
+
+#[cfg(windows)]
+#[test]
+fn vmconnect_current_user_needs_no_password_and_preserves_explicit_product_id() {
+    const VM_ID: &str = "efd1efab-c750-4262-b1bb-af0f7733bdd6";
+    const INSTANCE_ID: &str = "0123456789abcdef0123456789abcde";
+    let config = parse_config_from_rdp(
+        &format!(
+            "full address:s:localhost\nironrdp_vmconnect:s:{VM_ID}\nironrdp_vmconnect_basic:i:1\nironrdp_vmconnect_current_user:i:1\n"
+        ),
+        &["--dig-product-id", INSTANCE_ID],
+    );
+
+    assert!(config.vmconnect_current_user());
+    assert_eq!(config.vmconnect_mode(), Some(VmConnectMode::Basic));
+    assert!(config.vmconnect_framebuffer_redirection());
+    assert_eq!(config.connector().dig_product_id, INSTANCE_ID);
+}
+
+#[cfg(windows)]
+#[test]
+fn vmconnect_current_user_rejects_rdcleanpath() {
+    const VM_ID: &str = "efd1efab-c750-4262-b1bb-af0f7733bdd6";
+    let error = parse_config_from_rdp_result(
+        &format!("full address:s:localhost\nironrdp_vmconnect:s:{VM_ID}\nironrdp_vmconnect_current_user:i:1\n"),
+        &[
+            "--rdcleanpath-url",
+            "wss://rdcleanpath.example.com",
+            "--rdcleanpath-token",
+            "test-token",
+        ],
+    )
+    .expect_err("current-user VMConnect must reject RDCleanPath");
+
+    assert!(
+        error
+            .to_string()
+            .contains("vmconnect current-user authentication is not supported with RDCleanPath"),
+        "unexpected error: {error:#}"
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn loopback_vmconnect_hosts_offer_framebuffer_redirection() {
+    const VM_ID: &str = "efd1efab-c750-4262-b1bb-af0f7733bdd6";
+    const INSTANCE_ID: &str = "0123456789abcdef0123456789abcde";
+    for host in ["localhost", "localhost.", ".", "127.0.0.1", "[::1]"] {
+        let config = parse_config_from_rdp(
+            &format!("full address:s:{host}\nironrdp_vmconnect:s:{VM_ID}\nironrdp_vmconnect_current_user:i:1\n"),
+            &["--dig-product-id", INSTANCE_ID],
+        );
+
+        assert!(
+            config.vmconnect_framebuffer_redirection(),
+            "{host} should be eligible for frame-buffer redirection"
+        );
+    }
+}
+
+#[cfg(windows)]
+#[test]
+fn remote_vmconnect_does_not_offer_local_framebuffer_redirection() {
+    const VM_ID: &str = "efd1efab-c750-4262-b1bb-af0f7733bdd6";
+    let config = parse_config_from_rdp(
+        &format!(
+            "full address:s:hyperv.example.com\nironrdp_vmconnect:s:{VM_ID}\nironrdp_vmconnect_current_user:i:1\n"
+        ),
+        &[],
+    );
+
+    assert!(config.vmconnect_current_user());
+    assert!(!config.vmconnect_framebuffer_redirection());
+    assert!(config.connector().dig_product_id.is_empty());
 }
 
 #[test]

--- a/crates/ironrdp-testsuite-extra/tests/client/config.rs
+++ b/crates/ironrdp-testsuite-extra/tests/client/config.rs
@@ -5,10 +5,8 @@ use std::sync::Arc;
 
 #[cfg(windows)]
 use ironrdp_cfg::GatewayCredentialsSource;
-use ironrdp_cfg::{PropertySetExt as _, VmConnectPropertySetExt as _};
-use ironrdp_client::config::{
-    AudioQualityMode, ClipboardType, ConfigBuilder, Destination, Transport, VmConnectMode,
-};
+use ironrdp_cfg::PropertySetExt as _;
+use ironrdp_client::config::{AudioQualityMode, ClipboardType, ConfigBuilder, Destination, Transport, VmConnectMode};
 #[cfg(windows)]
 use ironrdp_client::config::{MissingField, TransportKind};
 use ironrdp_pdu::gcc::{ClientMonitorData, Monitor, MonitorFlags};


### PR DESCRIPTION
Wire VMConnect modes through the client configuration and RDP connector. Support current-user host authentication without a password, preserve guest credential boundaries, and attach Hyper-V framebuffer redirection only for eligible local Windows sessions.