### PR TITLE
feat(agent): expose Hyper-V VMConnect

### DIFF
--- a/crates/ironrdp-agent/README.md
+++ b/crates/ironrdp-agent/README.md
@@ -82,6 +82,23 @@ The agent advertises no local RAIL shell-integration flags because it does not i
 The daemon reserves all queue slots before changing keyboard state, so queue backpressure sends none of a rejected request.
 The ActiveX backend explicitly rejects this bulk input operation.
 
+## Hyper-V VMConnect
+
+On Windows, the daemon can connect to a Hyper-V VM console through the host's VMConnect endpoint on port 2179.
+Use `--vmconnect-current-user` for native SSPI authentication with the caller's Windows logon token.
+The local host defaults to `localhost`, so this path needs neither `--server` nor a reusable password.
+
+```powershell
+ironrdp-agent daemon-start
+ironrdp-agent connect --vmconnect <VM_ID> --vmconnect-basic --vmconnect-current-user
+ironrdp-agent screenshot vm-console.png
+```
+
+List VM IDs with `Get-VM | Select-Object Name, Id`.
+The basic console accepts Hyper-V's private frame-buffer DVC and copies the host-created shared-memory DIB into the daemon's retained frame.
+Omit `--vmconnect-basic` for Enhanced Session mode.
+Omit `--vmconnect-current-user` and supply host credentials when integrated authentication is not appropriate.
+
 ## Windows Sandbox
 
 On Windows with the Windows Sandbox feature enabled, the agent can create and attach to a sandbox over the product's default **named-pipe** transport (`\\.\pipe\{VMId}`).
@@ -113,8 +130,8 @@ Low-level escape hatch when you already have the pipe path and guest password:
 ironrdp-agent connect --sandbox-pipe \\.\pipe\{VMId} -u WDAGUtilityAccount -p <password>
 ```
 
-`Local` (VMConnect `:2179` + PCB) and guest TCP `:3389` transports are not implemented as the
-primary path; use the default NamedPipe recipe.
+NamedPipe remains the default Windows Sandbox transport.
+Use VMConnect for Hyper-V VMs rather than replacing the Sandbox recipe.
 
 ## Prebuilt binaries
 

--- a/crates/ironrdp-agent/src/cli.rs
+++ b/crates/ironrdp-agent/src/cli.rs
@@ -509,6 +509,18 @@ struct ConnectArgs {
     #[cfg(windows)]
     #[arg(long, value_name = "PIPE", conflicts_with = "server")]
     sandbox_pipe: Option<String>,
+    /// Connect to a Hyper-V VM console by VM ID. Defaults the Hyper-V host to localhost.
+    #[cfg(windows)]
+    #[arg(long, value_name = "VM_ID", conflicts_with_all = ["sandbox_id", "sandbox_pipe"])]
+    vmconnect: Option<String>,
+    /// Use the Hyper-V basic console instead of Enhanced Session mode.
+    #[cfg(windows)]
+    #[arg(long, requires = "vmconnect")]
+    vmconnect_basic: bool,
+    /// Authenticate the Hyper-V host with the current Windows logon token.
+    #[cfg(windows)]
+    #[arg(long, requires = "vmconnect")]
+    vmconnect_current_user: bool,
 }
 
 #[derive(Args, Debug)]
@@ -1088,6 +1100,20 @@ fn build_connect_request(args: ConnectArgs) -> anyhow::Result<Request> {
 
     #[cfg(windows)]
     {
+        if let Some(vm_id) = args.vmconnect {
+            properties.set_vmconnect_id(vm_id);
+            properties.set_vmconnect_basic(args.vmconnect_basic);
+            properties.set_vmconnect_current_user(args.vmconnect_current_user);
+            if properties.full_address().context("invalid 'full address'")?.is_none()
+                && properties
+                    .alternate_full_address()
+                    .context("invalid 'alternate full address'")?
+                    .is_none()
+            {
+                properties.set_full_address(&"localhost".parse().expect("localhost is a valid target address"));
+            }
+        }
+
         // Sandbox defaults are the base; explicit .rdp / --prop / named flags win on conflict.
         // Transport/security invariants from the sandbox path are re-applied last so a file
         // cannot force TLS/CredSSP onto a NamedPipe session.
@@ -2163,10 +2189,16 @@ mod tests {
     use std::path::PathBuf;
 
     use clap::{CommandFactory as _, Parser as _};
+    #[cfg(windows)]
+    use ironrdp_cfg::PropertySetExt as _;
+    #[cfg(windows)]
+    use ironrdp_rpc::ipc::Request;
 
     use super::Command;
     #[cfg(windows)]
     use super::SandboxCommand;
+    #[cfg(windows)]
+    use super::build_connect_request;
     use super::{
         Backend, Cli, CommonExecutionArgs, MAX_UNICODE_TEXT_CHARS, NowExecutionKind, build_now_execution,
         endpoint_from_arg,
@@ -2245,6 +2277,39 @@ mod tests {
         };
         assert_eq!(id.as_deref(), Some("8825f947-7d05-46e5-9efb-317ca83500ec"));
         assert_eq!(config, Some(PathBuf::from("sandbox.wsb")));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn vmconnect_defaults_to_localhost_and_basic_mode_is_explicit() {
+        const VM_ID: &str = "efd1efab-c750-4262-b1bb-af0f7733bdd6";
+        let cli = Cli::try_parse_from([
+            "ironrdp-agent",
+            "connect",
+            "--vmconnect",
+            VM_ID,
+            "--vmconnect-basic",
+            "--vmconnect-current-user",
+        ])
+        .expect("valid VMConnect arguments");
+        let Some(Command::Connect(args)) = cli.command else {
+            panic!("expected connect command");
+        };
+        let Request::Connect { properties, .. } = build_connect_request(args).expect("valid VMConnect request") else {
+            panic!("expected connect request");
+        };
+
+        assert_eq!(properties.vmconnect_id(), Some(VM_ID));
+        assert_eq!(properties.vmconnect_basic(), Some(true));
+        assert_eq!(properties.vmconnect_current_user(), Some(true));
+        assert_eq!(
+            properties
+                .full_address()
+                .expect("valid full address")
+                .expect("localhost default")
+                .to_string(),
+            "localhost"
+        );
     }
 
     #[test]

--- a/crates/ironrdp-agent/src/cli.rs
+++ b/crates/ironrdp-agent/src/cli.rs
@@ -1101,6 +1101,7 @@ fn build_connect_request(args: ConnectArgs) -> anyhow::Result<Request> {
     #[cfg(windows)]
     {
         if let Some(vm_id) = args.vmconnect {
+            properties.clear_named_pipe();
             properties.set_vmconnect_id(vm_id);
             properties.set_vmconnect_basic(args.vmconnect_basic);
             properties.set_vmconnect_current_user(args.vmconnect_current_user);
@@ -2290,6 +2291,8 @@ mod tests {
             VM_ID,
             "--vmconnect-basic",
             "--vmconnect-current-user",
+            "--prop",
+            r"ironrdp_named_pipe:s:\\.\pipe\lower-precedence",
         ])
         .expect("valid VMConnect arguments");
         let Some(Command::Connect(args)) = cli.command else {
@@ -2302,6 +2305,7 @@ mod tests {
         assert_eq!(properties.vmconnect_id(), Some(VM_ID));
         assert_eq!(properties.vmconnect_basic(), Some(true));
         assert_eq!(properties.vmconnect_current_user(), Some(true));
+        assert_eq!(properties.named_pipe(), None);
         assert_eq!(
             properties
                 .full_address()

--- a/crates/ironrdp-agent/src/help.rs
+++ b/crates/ironrdp-agent/src/help.rs
@@ -53,7 +53,7 @@ Override with `--endpoint <PATH-OR-PIPE>` on any subcommand.
                                  TLS certificate and hostname validation is strict by default.
                                  `--skip-certificate-check` disables both for this daemon only.
                                  Use it only for an explicitly authorized test endpoint because it accepts any certificate and is vulnerable to on-path attacks.
-- `connect [--rdp-file F] [--prop KEY:TYPE:VALUE]... [--server H[:PORT]] [-u USER] [-p PASS] [-d DOMAIN] [--sandbox-id ID] [--sandbox-pipe PATH] [--log-directive D]`
+- `connect [--rdp-file F] [--prop KEY:TYPE:VALUE]... [--server H[:PORT]] [-u USER] [-p PASS] [-d DOMAIN] [--vmconnect VM_ID] [--vmconnect-basic] [--vmconnect-current-user] [--sandbox-id ID] [--sandbox-pipe PATH] [--log-directive D]`
                                  Merge an optional .rdp file with CLI overrides into one config and
                                  open a session. Precedence (low to high): .rdp file -> `--prop`
                                  overrides -> named flags (`--server`/`-u`/`-p`/`-d`). When those
@@ -75,6 +75,12 @@ Override with `--endpoint <PATH-OR-PIPE>` on any subcommand.
                                  them, except NamedPipe TLS/CredSSP stay forced off. Prefer
                                  `--sandbox-id` over `--sandbox-pipe`; the pipe escape hatch needs
                                  `-u`/`-p` (guest password from `sandbox config`).
+                                 On Windows, `--vmconnect VM_ID` routes the session through the
+                                 Hyper-V host on port 2179. `--vmconnect-basic` selects the basic
+                                 console. `--vmconnect-current-user` uses native SSPI with the
+                                 caller's logon token, needs no username or password, and defaults
+                                 an omitted server to localhost. Local VMConnect accepts the private
+                                 frame-buffer DVC and reads its shared-memory DIB.
 - `gw-forward --gateway HOST[:PORT] (--socks5 | --target HOST:PORT) [--listen ADDR]`
                                  Forward TCP through an RD Gateway without an RDP session.
                                  `--socks5` serves SOCKS5 CONNECT (no auth); `--target` is an
@@ -209,7 +215,7 @@ On retail builds that permit one active sandbox, stop that initial sandbox befor
                                  Low-level NamedPipe connect when you already have the guest password.
 
 Default product transport is NamedPipe.
-Local (VMConnect :2179 + PCB) and guest TCP are not the primary path.
+VMConnect is available for Hyper-V VMs; NamedPipe remains the Windows Sandbox default.
 
 ## Errors
 

--- a/crates/ironrdp-daemon/Cargo.toml
+++ b/crates/ironrdp-daemon/Cargo.toml
@@ -13,7 +13,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["rustls", "dvc-pipe-proxy", "rdpdr", "smartcard"] } # public
+ironrdp-client = { path = "../ironrdp-client", version = "0.1", features = ["rustls", "dvc-pipe-proxy", "rdpdr", "smartcard", "vmconnect"] } # public
 ironrdp-cfg = { path = "../ironrdp-cfg", version = "0.1" }
 ironrdp-input = { path = "../ironrdp-input", version = "0.7" }
 ironrdp-pdu = { path = "../ironrdp-pdu", version = "0.9" }
@@ -44,4 +44,3 @@ ironrdp-rdpdr-native = { path = "../ironrdp-rdpdr-native", version = "0.7" }
 
 [lints]
 workspace = true
-


### PR DESCRIPTION
Expose Hyper-V VMConnect through the agent CLI and daemon build. Add VMConnect mode and current-user options, default an omitted host to localhost, and enable the client VMConnect feature in the daemon.