### PR TITLE
feat(viewer): add current-user VMConnect

### DIFF
--- a/crates/ironrdp-testsuite-extra/tests/client/config.rs
+++ b/crates/ironrdp-testsuite-extra/tests/client/config.rs
@@ -183,6 +183,24 @@ fn vmconnect_basic_flag_selects_basic_mode() {
     assert_eq!(config.properties().vmconnect_basic(), Some(true));
 }
 
+#[cfg(windows)]
+#[test]
+fn vmconnect_current_user_cli_flag_needs_no_credentials() {
+    const VM_ID: &str = "efd1efab-c750-4262-b1bb-af0f7733bdd6";
+    let config = parse_config_from([
+        "ironrdp-viewer",
+        "localhost",
+        "--vmconnect",
+        VM_ID,
+        "--vmconnect-current-user",
+    ])
+    .expect("valid current-user VMConnect configuration");
+
+    assert!(config.vmconnect_current_user());
+    assert_eq!(config.vm_id(), Some(VM_ID));
+    assert_eq!(config.properties().vmconnect_current_user(), Some(true));
+}
+
 #[test]
 fn vmconnect_properties_restore_typed_config() {
     const VM_ID: &str = "efd1efab-c750-4262-b1bb-af0f7733bdd6";

--- a/crates/ironrdp-viewer/README.md
+++ b/crates/ironrdp-viewer/README.md
@@ -27,6 +27,15 @@ RDP_HOSTNAME=<HOSTNAME> RDP_USERNAME=<USERNAME> RDP_PASSWORD=<PASSWORD> ironrdp-
 On Windows, pass `--smartcard` (or set `ironrdp_smartcard:i:1` in a `.rdp` file) to redirect local smart cards through WinSCard.
 RPC mode (`--rpc`) enables smartcard the same way via agent connect properties (`ironrdp_smartcard` / sandbox `SmartCardRedirection`).
 
+To open the basic console of a local Hyper-V VM with the current Windows account:
+
+```powershell
+ironrdp-viewer localhost --vmconnect <VM_ID> --vmconnect-basic --vmconnect-current-user
+```
+
+List VM IDs with `Get-VM | Select-Object Name, Id`.
+On local Windows VMConnect connections, the viewer accepts Hyper-V's private frame-buffer DVC and renders its shared-memory DIB.
+
 ## Agent RPC host
 
 The viewer can host the same local RPC protocol used by `ironrdp-agent`, while keeping its visible
@@ -66,6 +75,9 @@ Currently supported properties:
 - `shell working directory:s:<value>`
 - `redirectclipboard:i:<0|1>`
 - `ironrdp_smartcard:i:<0|1>` (Windows WinSCard smartcard redirection)
+- `ironrdp_vmconnect:s:<VM_ID>`
+- `ironrdp_vmconnect_basic:i:<0|1>`
+- `ironrdp_vmconnect_current_user:i:<0|1>` (Windows current-account host authentication)
 - `audiomode:i:<0|1|2>`
 - `desktopwidth:i:<value>`
 - `desktopheight:i:<value>`

--- a/crates/ironrdp-viewer/src/cli.rs
+++ b/crates/ironrdp-viewer/src/cli.rs
@@ -119,6 +119,11 @@ struct Args {
     #[clap(long, requires = "vmconnect")]
     vmconnect_basic: bool,
 
+    /// Authenticate the Hyper-V host with the current Windows logon token.
+    #[cfg(windows)]
+    #[clap(long, requires = "vmconnect")]
+    vmconnect_current_user: bool,
+
     /// The keyboard type
     #[clap(long, value_enum, default_value_t = KeyboardType::IbmEnhanced)]
     keyboard_type: KeyboardType,
@@ -445,6 +450,10 @@ fn apply_cli_to_builder(
             VmConnectMode::Enhanced
         };
         builder = builder.with_vmconnect_mode(vm_id, mode);
+    }
+    #[cfg(windows)]
+    if args.vmconnect_current_user {
+        builder = builder.with_vmconnect_current_user(true);
     }
 
     if let Some(url) = args.rdcleanpath_url {


### PR DESCRIPTION
Expose current-user Hyper-V VMConnect authentication through the viewer CLI. Document the local Windows invocation while preserving existing credential requirements for ordinary RDP sessions.