### PR TITLE
feat(server): wire MS-RDPEI server-side into ironrdp-server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3272,6 +3272,7 @@ dependencies = [
  "ironrdp-graphics",
  "ironrdp-nscodec",
  "ironrdp-pdu",
+ "ironrdp-rdpei",
  "ironrdp-rdpsnd",
  "ironrdp-svc",
  "ironrdp-tokio",

--- a/crates/ironrdp-server/Cargo.toml
+++ b/crates/ironrdp-server/Cargo.toml
@@ -53,6 +53,7 @@ ironrdp-tokio = { path = "../ironrdp-tokio", version = "0.10", features = ["reqw
 ironrdp-acceptor = { path = "../ironrdp-acceptor", version = "0.10" } # public
 ironrdp-graphics = { path = "../ironrdp-graphics", version = "0.9" } # public
 ironrdp-rdpsnd = { path = "../ironrdp-rdpsnd", version = "0.9" } # public
+ironrdp-rdpei = { path = "../ironrdp-rdpei", version = "0.1" } # public
 tracing = { version = "0.1", features = ["log"] }
 x509-cert = { version = "0.3", optional = true }
 rustls-pemfile = { version = "2.2", optional = true }

--- a/crates/ironrdp-server/src/builder.rs
+++ b/crates/ironrdp-server/src/builder.rs
@@ -16,7 +16,7 @@ use super::handler::{KeyboardEvent, MouseEvent, RdpServerInputHandler};
 use super::server::{
     ConnectionHandler, CredentialValidator, RdpServer, RdpServerOptions, RdpServerSecurity, StaticChannelFactory,
 };
-use crate::{DisplayUpdate, RdpServerDisplayUpdates, SoundServerFactory};
+use crate::{DisplayUpdate, RdpServerDisplayUpdates, RdpeiServerFactory, SoundServerFactory};
 
 pub struct WantsAddr {}
 pub struct WantsSecurity {
@@ -41,6 +41,7 @@ pub struct BuilderDone {
     static_channel_factories: Vec<Box<dyn StaticChannelFactory>>,
     cliprdr_factory: Option<Box<dyn CliprdrServerFactory>>,
     sound_factory: Option<Box<dyn SoundServerFactory>>,
+    rdpei_factory: Option<Box<dyn RdpeiServerFactory>>,
     connection_handler: Option<Box<dyn ConnectionHandler>>,
     credential_validator: Option<Arc<dyn CredentialValidator>>,
     #[cfg(feature = "egfx")]
@@ -145,6 +146,7 @@ impl RdpServerBuilder<WantsDisplay> {
                 static_channel_factories: Vec::new(),
                 sound_factory: None,
                 cliprdr_factory: None,
+                rdpei_factory: None,
                 connection_handler: None,
                 credential_validator: None,
                 codecs: server_codecs_capabilities(&[]).expect("can't panic for &[]"),
@@ -172,6 +174,7 @@ impl RdpServerBuilder<WantsDisplay> {
                 static_channel_factories: Vec::new(),
                 sound_factory: None,
                 cliprdr_factory: None,
+                rdpei_factory: None,
                 connection_handler: None,
                 credential_validator: None,
                 codecs: server_codecs_capabilities(&[]).expect("can't panic for &[]"),
@@ -204,6 +207,12 @@ impl RdpServerBuilder<BuilderDone> {
 
     pub fn with_sound_factory(mut self, sound: Option<Box<dyn SoundServerFactory>>) -> Self {
         self.state.sound_factory = sound;
+        self
+    }
+
+    /// Configure MS-RDPEI (multitouch and pen input over a dynamic channel).
+    pub fn with_rdpei_factory(mut self, rdpei_factory: Option<Box<dyn RdpeiServerFactory>>) -> Self {
+        self.state.rdpei_factory = rdpei_factory;
         self
     }
 
@@ -402,6 +411,7 @@ impl RdpServerBuilder<BuilderDone> {
             self.state.static_channel_factories,
             self.state.sound_factory,
             self.state.cliprdr_factory,
+            self.state.rdpei_factory,
             self.state.connection_handler,
             #[cfg(feature = "egfx")]
             self.state.gfx_factory,

--- a/crates/ironrdp-server/src/lib.rs
+++ b/crates/ironrdp-server/src/lib.rs
@@ -18,6 +18,7 @@ mod gfx;
 mod handler;
 #[cfg(feature = "helper")]
 mod helper;
+mod rdpei;
 mod server;
 mod sound;
 
@@ -34,6 +35,10 @@ pub use handler::{KeyboardEvent, MouseEvent, RdpServerInputHandler};
 pub use helper::TlsIdentityCtx;
 pub use ironrdp_acceptor::Acceptor;
 pub use ironrdp_pdu::rdp::session_info::ServerAutoReconnect;
+pub use rdpei::{
+    CsReadyPdu, DismissHoveringTouchContactPdu, PenEventPdu, RdpInputProtocolVersion, RdpeiHandler, RdpeiServer,
+    RdpeiServerFactory, ScReadyFeatures, TouchContact, TouchContactFlags, TouchEventPdu, TouchFrame,
+};
 pub use server::{
     AutoReconnectCookieHandle, ConnectionHandler, ConnectionInfo, CredentialDecision, CredentialValidationError,
     CredentialValidator, Credentials, ExactMatchCredentialValidator, PostConnectionAction, RdpServer, RdpServerOptions,

--- a/crates/ironrdp-server/src/lib.rs
+++ b/crates/ironrdp-server/src/lib.rs
@@ -36,8 +36,10 @@ pub use helper::TlsIdentityCtx;
 pub use ironrdp_acceptor::Acceptor;
 pub use ironrdp_pdu::rdp::session_info::ServerAutoReconnect;
 pub use rdpei::{
-    CsReadyPdu, DismissHoveringTouchContactPdu, PenEventPdu, RdpInputProtocolVersion, RdpeiHandler, RdpeiServer,
-    RdpeiServerFactory, ScReadyFeatures, TouchContact, TouchContactFlags, TouchEventPdu, TouchFrame,
+    CsReadyFlags, CsReadyPdu, DismissHoveringTouchContactPdu, PenContact, PenContactDataFlags, PenContactFields,
+    PenContactFlags, PenEventPdu, PenFlags, PenFrame, RdpInputProtocolVersion, RdpeiHandler, RdpeiServer,
+    RdpeiServerFactory, ScReadyFeatures, TouchContact, TouchContactDataFlags, TouchContactFields, TouchContactFlags,
+    TouchEventPdu, TouchFrame,
 };
 pub use server::{
     AutoReconnectCookieHandle, ConnectionHandler, ConnectionInfo, CredentialDecision, CredentialValidationError,

--- a/crates/ironrdp-server/src/rdpei.rs
+++ b/crates/ironrdp-server/src/rdpei.rs
@@ -1,11 +1,16 @@
 pub use ironrdp_rdpei::pdu::{
-    CsReadyPdu, DismissHoveringTouchContactPdu, PenEventPdu, RdpInputProtocolVersion, ScReadyFeatures, TouchContact,
-    TouchContactFlags, TouchEventPdu, TouchFrame,
+    CsReadyFlags, CsReadyPdu, DismissHoveringTouchContactPdu, PenContact, PenContactDataFlags, PenContactFields,
+    PenContactFlags, PenEventPdu, PenFlags, PenFrame, RdpInputProtocolVersion, ScReadyFeatures, TouchContact,
+    TouchContactDataFlags, TouchContactFields, TouchContactFlags, TouchEventPdu, TouchFrame,
 };
 pub use ironrdp_rdpei::{RdpeiHandler, RdpeiServer};
 
 use crate::ServerEventSender;
 
 pub trait RdpeiServerFactory: ServerEventSender {
-    fn build_handler(&self) -> Box<dyn RdpeiHandler>;
+    /// Builds the configured server endpoint for a new connection. Returning the
+    /// whole [`RdpeiServer`], rather than just its handler, lets the factory call
+    /// [`RdpeiServer::with_protocol_version`] or [`RdpeiServer::with_supported_features`]
+    /// to advertise non-default capabilities.
+    fn build_server(&self) -> RdpeiServer;
 }

--- a/crates/ironrdp-server/src/rdpei.rs
+++ b/crates/ironrdp-server/src/rdpei.rs
@@ -1,0 +1,11 @@
+pub use ironrdp_rdpei::pdu::{
+    CsReadyPdu, DismissHoveringTouchContactPdu, PenEventPdu, RdpInputProtocolVersion, ScReadyFeatures, TouchContact,
+    TouchContactFlags, TouchEventPdu, TouchFrame,
+};
+pub use ironrdp_rdpei::{RdpeiHandler, RdpeiServer};
+
+use crate::ServerEventSender;
+
+pub trait RdpeiServerFactory: ServerEventSender {
+    fn build_handler(&self) -> Box<dyn RdpeiHandler>;
+}

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -48,6 +48,7 @@ use crate::encoder::{UpdateEncoder, UpdateEncoderCodecs};
 #[cfg(feature = "egfx")]
 use crate::gfx::{EgfxServerMessage, GfxServerFactory};
 use crate::handler::RdpServerInputHandler;
+use crate::rdpei::{RdpeiServer, RdpeiServerFactory};
 use crate::{SoundServerFactory, builder, capabilities};
 
 /// TCP listen backlog size for the RDP server socket.
@@ -544,6 +545,7 @@ pub struct RdpServer {
     static_channel_factories: Vec<Box<dyn StaticChannelFactory>>,
     sound_factory: Option<Box<dyn SoundServerFactory>>,
     cliprdr_factory: Option<Box<dyn CliprdrServerFactory>>,
+    rdpei_factory: Option<Box<dyn RdpeiServerFactory>>,
     echo_handle: EchoServerHandle,
     #[cfg(feature = "egfx")]
     gfx_factory: Option<Box<dyn GfxServerFactory>>,
@@ -699,6 +701,7 @@ impl RdpServer {
         static_channel_factories: Vec<Box<dyn StaticChannelFactory>>,
         mut sound_factory: Option<Box<dyn SoundServerFactory>>,
         mut cliprdr_factory: Option<Box<dyn CliprdrServerFactory>>,
+        mut rdpei_factory: Option<Box<dyn RdpeiServerFactory>>,
         connection_handler: Option<Box<dyn ConnectionHandler>>,
         #[cfg(feature = "egfx")] mut gfx_factory: Option<Box<dyn GfxServerFactory>>,
         display_suppressed: Option<Arc<AtomicBool>>,
@@ -712,6 +715,9 @@ impl RdpServer {
         if let Some(snd) = sound_factory.as_mut() {
             snd.set_sender(ev_sender.clone());
         }
+        if let Some(rdpei) = rdpei_factory.as_mut() {
+            rdpei.set_sender(ev_sender.clone());
+        }
         #[cfg(feature = "egfx")]
         if let Some(gfx) = gfx_factory.as_mut() {
             gfx.set_sender(ev_sender.clone());
@@ -724,6 +730,7 @@ impl RdpServer {
             static_channel_factories,
             sound_factory,
             cliprdr_factory,
+            rdpei_factory,
             echo_handle: EchoServerHandle::new(ev_sender.clone()),
             #[cfg(feature = "egfx")]
             gfx_factory,
@@ -1066,6 +1073,13 @@ impl RdpServer {
         let dvc = {
             let echo_handle = self.echo_handle.clone();
             dvc.with_dynamic_channel(EchoDvcBridge::new(echo_handle))
+        };
+
+        let dvc = if let Some(factory) = self.rdpei_factory.as_deref() {
+            let handler = factory.build_handler();
+            dvc.with_dynamic_channel(RdpeiServer::new(handler))
+        } else {
+            dvc
         };
 
         #[cfg(feature = "egfx")]

--- a/crates/ironrdp-server/src/server.rs
+++ b/crates/ironrdp-server/src/server.rs
@@ -48,7 +48,7 @@ use crate::encoder::{UpdateEncoder, UpdateEncoderCodecs};
 #[cfg(feature = "egfx")]
 use crate::gfx::{EgfxServerMessage, GfxServerFactory};
 use crate::handler::RdpServerInputHandler;
-use crate::rdpei::{RdpeiServer, RdpeiServerFactory};
+use crate::rdpei::RdpeiServerFactory;
 use crate::{SoundServerFactory, builder, capabilities};
 
 /// TCP listen backlog size for the RDP server socket.
@@ -1076,8 +1076,7 @@ impl RdpServer {
         };
 
         let dvc = if let Some(factory) = self.rdpei_factory.as_deref() {
-            let handler = factory.build_handler();
-            dvc.with_dynamic_channel(RdpeiServer::new(handler))
+            dvc.with_dynamic_channel(factory.build_server())
         } else {
             dvc
         };

--- a/crates/ironrdp-testsuite-core/Cargo.toml
+++ b/crates/ironrdp-testsuite-core/Cargo.toml
@@ -69,7 +69,7 @@ png = "0.18"
 pretty_assertions = "1.4"
 proptest.workspace = true
 rstest.workspace = true
-tokio = { version = "1", features = ["macros", "rt"] }
+tokio = { version = "1", features = ["macros", "rt", "io-util", "sync"] }
 
 [lints]
 workspace = true

--- a/crates/ironrdp-testsuite-core/tests/server/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/server/mod.rs
@@ -2,4 +2,5 @@ mod acceptor;
 mod autodetect;
 mod credential_validator;
 mod fast_path;
+mod rdpei;
 mod remotefx_entropy_coder;

--- a/crates/ironrdp-testsuite-core/tests/server/rdpei.rs
+++ b/crates/ironrdp-testsuite-core/tests/server/rdpei.rs
@@ -1,0 +1,54 @@
+use core::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use ironrdp_server::{RdpServer, RdpeiHandler, RdpeiServer, RdpeiServerFactory, ServerEvent, ServerEventSender};
+use tokio::sync::mpsc;
+
+struct NoopRdpeiHandler;
+
+impl RdpeiHandler for NoopRdpeiHandler {}
+
+struct RecordingRdpeiFactory {
+    invoked: Arc<AtomicBool>,
+}
+
+impl ServerEventSender for RecordingRdpeiFactory {
+    fn set_sender(&mut self, _sender: mpsc::UnboundedSender<ServerEvent>) {}
+}
+
+impl RdpeiServerFactory for RecordingRdpeiFactory {
+    fn build_server(&self) -> RdpeiServer {
+        self.invoked.store(true, Ordering::Relaxed);
+        RdpeiServer::new(Box::new(NoopRdpeiHandler))
+    }
+}
+
+/// `attach_channels` runs before the client ever sends a byte, so a factory
+/// registered via `with_rdpei_factory` must be invoked even on a connection
+/// that ends immediately. Regression test for #1773: `ironrdp-rdpei` had
+/// server-side support with nothing in `ironrdp-server` ever registering it,
+/// so `RdpeiServerFactory::build_server` going uncalled would silently
+/// reintroduce that gap rather than fail loudly.
+#[tokio::test]
+async fn rdpei_factory_is_invoked_during_channel_setup() {
+    let invoked = Arc::new(AtomicBool::new(false));
+
+    let mut server = RdpServer::builder()
+        .with_addr(([127, 0, 0, 1], 0))
+        .with_no_security()
+        .with_no_input()
+        .with_no_display()
+        .with_rdpei_factory(Some(Box::new(RecordingRdpeiFactory {
+            invoked: Arc::clone(&invoked),
+        })))
+        .build();
+
+    let (client, server_side) = tokio::io::duplex(64);
+    drop(client);
+    let _ = server.run_connection(server_side).await;
+
+    assert!(
+        invoked.load(Ordering::Relaxed),
+        "RdpeiServerFactory::build_server must be invoked during per-connection channel setup"
+    );
+}


### PR DESCRIPTION
## Summary

- MS-RDPEI (multitouch and pen) got server-side plumbing in `ironrdp-rdpei` (the recent Input DVC PR), but nothing in `ironrdp-server` ever registers the `RdpeiServer`/`RdpeiHandler` it added. Grepped the whole crate for `rdpei` before starting: zero references. This wires it in.
- Follows the exact shape of the existing `SoundServerFactory`/`with_sound_factory` (the simplest of the three existing opt-in factories, and RDPEI's needs are equally simple): a new `RdpeiServerFactory` trait, a `with_rdpei_factory` builder method, and registration in `attach_channels` alongside the other optional DVC factories. The factory builds and returns the whole configured `RdpeiServer`, not just a handler, so it can reach `with_protocol_version`/`with_supported_features` to advertise non-default capabilities.
- Re-exports everything a downstream `RdpeiHandler` implementation needs from the crate root: `RdpeiServerFactory`, `RdpeiHandler`, `RdpeiServer`, and the touch/pen/ready PDU types plus the nested payload types their callbacks embed (`CsReadyFlags`, `PenContact` and its fields/flags, `PenFrame`, `TouchContactFields`/`TouchContactDataFlags`).

## Validation

`cargo xtask check fmt/lints/tests/typos/locks` all pass. Adds a regression test in `ironrdp-testsuite-core` (`ironrdp-server` has `[lib] test = false`, so an inline test would never run in CI) covering that a registered `RdpeiServerFactory` is invoked during per-connection channel setup.

## Notes

Two crates: `ironrdp-server` (`Cargo.toml`, `Cargo.lock`, `builder.rs`, `lib.rs`, `server.rs`, the new `rdpei.rs`) and `ironrdp-testsuite-core` (`Cargo.toml`, `tests/server/mod.rs`, the new `tests/server/rdpei.rs`). `RdpServer::new` is `pub(crate)`, only ever called from the builder, so adding the new parameter there has no external API impact beyond the new builder method itself.
