### PR TITLE
feat(mstsgu): preserve gateway HRESULT errors

### DIFF
--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -127,6 +127,8 @@ type Error = ironrdp_error::Error<GwErrorKind>;
 pub enum GwErrorKind {
     InvalidGwTarget,
     Connect,
+    /// A nonzero HRESULT returned by the gateway during control setup.
+    GatewayCode(u32),
     HttpStatus(u16),
     PacketEof,
     UnsupportedFeature,
@@ -157,6 +159,10 @@ impl Display for GwErrorKind {
         let x = match self {
             GwErrorKind::InvalidGwTarget => "invalid GW Target",
             GwErrorKind::Connect => "connection error",
+            GwErrorKind::GatewayCode(code) => match gateway_code_label(*code) {
+                Some(label) => return write!(f, "gateway error 0x{code:08x} ({label})"),
+                None => return write!(f, "gateway error 0x{code:08x}"),
+            },
             GwErrorKind::HttpStatus(status) => return write!(f, "unexpected http status {status}"),
             GwErrorKind::PacketEof => "PacketEOF",
             GwErrorKind::UnsupportedFeature => "unsupported feature",
@@ -432,7 +438,10 @@ impl GwConn {
 
         let mut cur = ReadCursor::new(&bytes);
         let resp = HandshakeRespPkt::decode(&mut cur).map_err(|_| Error::new("Handshake", GwErrorKind::Decode))?;
-        if resp.error_code != 0 || resp.ver_major != 1 || resp.ver_minor != 0 || resp.server_version != 0 {
+        if resp.error_code != 0 {
+            return Err(Error::new("Handshake", GwErrorKind::GatewayCode(resp.error_code)));
+        }
+        if resp.ver_major != 1 || resp.ver_minor != 0 || resp.server_version != 0 {
             return Err(Error::new("Handshake", GwErrorKind::Connect));
         }
         Ok(())
@@ -452,7 +461,7 @@ impl GwConn {
 
         let resp = TunnelRespPkt::decode(&mut cur).map_err(|_| Error::new("TunnelDecode", GwErrorKind::Decode))?;
         if resp.status_code != 0 {
-            return Err(Error::new("Tunnel", GwErrorKind::Connect));
+            return Err(Error::new("Tunnel", GwErrorKind::GatewayCode(resp.status_code)));
         }
         assert!(cur.eof());
         evaluate_consent_message(&resp.consent_msg, consent_callback)?;
@@ -472,7 +481,7 @@ impl GwConn {
             TunnelAuthRespPkt::decode(&mut cur).map_err(|_| Error::new("TunnelAuth", GwErrorKind::Decode))?;
 
         if resp.error_code != 0 {
-            return Err(Error::new("TunnelAuth", GwErrorKind::Connect));
+            return Err(Error::new("TunnelAuth", GwErrorKind::GatewayCode(resp.error_code)));
         }
         Ok(GwTunnelPolicy {
             redirection_flags: resp.redirection_flags,
@@ -495,7 +504,7 @@ impl GwConn {
         let resp: ChannelResp =
             ChannelResp::decode(&mut cur).map_err(|_| Error::new("ChannelResp", GwErrorKind::Decode))?;
         if resp.error_code() != 0 {
-            return Err(Error::new("ChannelCreate", GwErrorKind::Connect));
+            return Err(Error::new("ChannelCreate", GwErrorKind::GatewayCode(resp.error_code())));
         }
         assert!(cur.eof());
         Ok(resp)

--- a/crates/ironrdp-mstsgu/tests/consent.rs
+++ b/crates/ironrdp-mstsgu/tests/consent.rs
@@ -73,8 +73,8 @@ async fn callback_rejection_stops_before_tunnel_authorization() {
     let (in_client, in_server) = tokio::io::duplex(4096);
     let consent = consent_message("Accept");
     let mut out_response = Vec::from([0; 10]);
-    out_response.extend(packet(2, &handshake_response()));
-    out_response.extend(packet(5, &tunnel_response(&consent)));
+    out_response.extend(packet(2, &handshake_response(0)));
+    out_response.extend(packet(5, &tunnel_response(0, &consent)));
 
     let out_server = tokio::spawn(async move {
         let service = service_fn(move |request: Request<hyper::body::Incoming>| {
@@ -144,6 +144,114 @@ async fn callback_rejection_stops_before_tunnel_authorization() {
     in_server.await.expect("IN task");
 }
 
+#[tokio::test]
+async fn control_errors_preserve_gateway_hresult() {
+    for (expected_packet_types, error_code, context, label) in [
+        (&[1][..], 0x8007_59DA, "Handshake", "E_PROXY_RAP_ACCESSDENIED"),
+        (&[1, 4][..], 0x8007_59DD, "Tunnel", "E_PROXY_TS_CONNECTFAILED"),
+        (&[1, 4, 6][..], 0x8009_030C, "TunnelAuth", "SEC_E_LOGON_DENIED"),
+        (&[1, 4, 6, 8][..], 0x0000_59E8, "ChannelCreate", "E_PROXY_NOTSUPPORTED"),
+    ] {
+        let (out_client, out_server) = tokio::io::duplex(4096);
+        let (in_client, in_server) = tokio::io::duplex(4096);
+        let mut out_response = Vec::from([0; 10]);
+        out_response.extend(packet(
+            2,
+            &handshake_response(if expected_packet_types.len() == 1 {
+                error_code
+            } else {
+                0
+            }),
+        ));
+        if 1 < expected_packet_types.len() {
+            out_response.extend(packet(
+                5,
+                &tunnel_response(
+                    if expected_packet_types.len() == 2 {
+                        error_code
+                    } else {
+                        0
+                    },
+                    &[],
+                ),
+            ));
+        }
+        if 2 < expected_packet_types.len() {
+            out_response.extend(packet(
+                7,
+                &control_response(if expected_packet_types.len() == 3 {
+                    error_code
+                } else {
+                    0
+                }),
+            ));
+        }
+        if 3 < expected_packet_types.len() {
+            out_response.extend(packet(9, &control_response(error_code)));
+        }
+
+        let out_server = tokio::spawn(async move {
+            let service = service_fn(move |request: Request<hyper::body::Incoming>| {
+                let out_response = out_response.clone();
+                async move {
+                    assert_eq!(request.method(), "RDG_OUT_DATA");
+                    Ok::<_, Infallible>(response(StatusCode::OK, Bytes::from(out_response)))
+                }
+            });
+            http1::Builder::new()
+                .serve_connection(TokioIo::new(out_server), service)
+                .await
+                .expect("serve OUT");
+        });
+
+        let in_server = tokio::spawn(async move {
+            let service = service_fn(move |mut request: Request<hyper::body::Incoming>| {
+                let expected_packet_types = expected_packet_types.to_vec();
+                async move {
+                    assert_eq!(request.method(), "RDG_IN_DATA");
+                    if request.headers().get("content-type").is_none() {
+                        return Ok::<_, Infallible>(response(StatusCode::OK, Bytes::new()));
+                    }
+
+                    for expected_packet_type in expected_packet_types {
+                        let frame = request
+                            .body_mut()
+                            .frame()
+                            .await
+                            .expect("IN request frame")
+                            .expect("IN request frame result")
+                            .into_data()
+                            .expect("IN request data frame");
+                        assert_eq!(packet_type(&frame), expected_packet_type);
+                    }
+
+                    Ok::<_, Infallible>(response(StatusCode::OK, Bytes::new()))
+                }
+            });
+            http1::Builder::new()
+                .serve_connection(TokioIo::new(in_server), service)
+                .await
+                .expect("serve IN");
+        });
+
+        let transport = GatewayTransport::connect(out_client, in_client)
+            .await
+            .expect("connect transport");
+        let error = match transport.connect_tunnel(test_target(), "client.test", 3389, None).await {
+            Ok(_) => panic!("gateway error"),
+            Err(error) => error,
+        };
+
+        assert!(matches!(error.kind(), GwErrorKind::GatewayCode(code) if *code == error_code));
+        assert_eq!(
+            error.to_string(),
+            format!("[{context}] gateway error 0x{error_code:08x} ({label})")
+        );
+        out_server.await.expect("OUT task");
+        in_server.await.expect("IN task");
+    }
+}
+
 #[test]
 fn malformed_consent_payload_is_rejected_before_callback() {
     let callback_count = Arc::new(Mutex::new(0));
@@ -182,19 +290,29 @@ fn packet_type(packet: &[u8]) -> u16 {
     u16::from_le_bytes([packet[0], packet[1]])
 }
 
-fn handshake_response() -> [u8; 10] {
-    [0, 0, 0, 0, 1, 0, 0, 0, 1, 0]
+fn handshake_response(error_code: u32) -> [u8; 10] {
+    let mut response = [0, 0, 0, 0, 1, 0, 0, 0, 1, 0];
+    response[..4].copy_from_slice(&error_code.to_le_bytes());
+    response
 }
 
-fn tunnel_response(consent: &[u8]) -> Vec<u8> {
+fn tunnel_response(status_code: u32, consent: &[u8]) -> Vec<u8> {
     let consent_length = u16::try_from(consent.len()).expect("consent length");
     let mut response = Vec::with_capacity(12 + consent.len());
     response.extend([0, 0]);
-    response.extend([0; 4]);
-    response.extend([0x10, 0]);
+    response.extend(status_code.to_le_bytes());
+    response.extend(if consent.is_empty() { [0, 0] } else { [0x10, 0] });
     response.extend([0; 2]);
-    response.extend(consent_length.to_le_bytes());
-    response.extend(consent);
+    if !consent.is_empty() {
+        response.extend(consent_length.to_le_bytes());
+        response.extend(consent);
+    }
+    response
+}
+
+fn control_response(error_code: u32) -> [u8; 8] {
+    let mut response = [0; 8];
+    response[..4].copy_from_slice(&error_code.to_le_bytes());
     response
 }
 

--- a/crates/ironrdp-mstsgu/tests/http_control.rs
+++ b/crates/ironrdp-mstsgu/tests/http_control.rs
@@ -14,6 +14,7 @@
 mod proto;
 
 use ironrdp_core::{Decode, Encode, ReadCursor, WriteCursor};
+use ironrdp_mstsgu::GwErrorKind;
 use ironrdp_mstsgu::{ChannelClosePkt, ReauthMessagePkt, ServiceMessagePkt, gateway_code_label};
 use proto::{ExtendedAuthPkt, HandshakeRespPkt, HttpExtendedAuth, TunnelReqPkt};
 
@@ -212,4 +213,16 @@ fn gateway_code_label_known_and_unknown() {
     assert_eq!(gateway_code_label(0x0000_59DD), Some("E_PROXY_TS_CONNECTFAILED"));
     assert_eq!(gateway_code_label(0x8007_59DD), Some("E_PROXY_TS_CONNECTFAILED"));
     assert_eq!(gateway_code_label(0xDEAD_BEEF), None);
+}
+
+#[test]
+fn gateway_error_kind_displays_fixed_width_raw_code() {
+    assert_eq!(
+        GwErrorKind::GatewayCode(0x8007_59DA).to_string(),
+        "gateway error 0x800759da (E_PROXY_RAP_ACCESSDENIED)"
+    );
+    assert_eq!(
+        GwErrorKind::GatewayCode(0xDEAD_BEEF).to_string(),
+        "gateway error 0xdeadbeef"
+    );
 }


### PR DESCRIPTION
Preserve nonzero gateway control HRESULTs for caller diagnostics.

Known codes retain established labels; unknown codes remain lossless.