### PR TITLE
feat(mstsgu): apply certificate validation to gateways

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3025,6 +3025,7 @@ dependencies = [
  "picky-asn1-x509",
  "sspi",
  "tokio",
+ "tokio-native-tls",
  "tokio-tungstenite",
  "tokio-util",
  "uuid",

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -9073,9 +9073,8 @@ impl Control {
             let certificate_events = Arc::clone(&self.events);
             let certificate_event_posted = Arc::clone(&self.event_posted);
             let certificate_dispatcher = hwnd.0 as isize;
-            let endpoint = destination.to_string();
             let callback: ironrdp_tls::CertificateValidationCallback =
-                Arc::new(move |certificate_der, validation_reason| {
+                Arc::new(move |certificate_der, endpoint, validation_reason| {
                     let fingerprint = certificate_fingerprint(certificate_der);
                     if !public_mode && certificate_exception_is_trusted(&endpoint, &fingerprint) {
                         trace_host_call("RdpWorker::TlsCertificateValidation:TrustedException");
@@ -9089,7 +9088,7 @@ impl Control {
                         HWND(certificate_dispatcher as *mut c_void),
                         WorkerEvent::CertificateWarning {
                             generation,
-                            endpoint: endpoint.clone(),
+                            endpoint: endpoint.to_owned(),
                             fingerprint,
                             validation_reason: validation_reason.to_owned(),
                             public_mode,

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -9076,7 +9076,7 @@ impl Control {
             let callback: ironrdp_tls::CertificateValidationCallback =
                 Arc::new(move |certificate_der, endpoint, validation_reason| {
                     let fingerprint = certificate_fingerprint(certificate_der);
-                    if !public_mode && certificate_exception_is_trusted(&endpoint, &fingerprint) {
+                    if !public_mode && certificate_exception_is_trusted(endpoint, &fingerprint) {
                         trace_host_call("RdpWorker::TlsCertificateValidation:TrustedException");
                         return true;
                     }

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -1759,9 +1759,10 @@ where
     let (initial_stream, leftover_bytes) = framed.into_inner();
 
     let tls_upgrade = if let Some(callback) = config.certificate_validation_callback() {
-        ironrdp_tls::upgrade_with_certificate_validation_callback(
+        ironrdp_tls::upgrade_with_certificate_validation_callback_for_endpoint(
             initial_stream,
             config.destination.name(),
+            &config.destination.to_string(),
             Arc::clone(callback),
         )
         .await

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -1562,10 +1562,12 @@ async fn connect_gateway(
         server: config.destination.name().to_owned(),
     };
 
-    let (gw_stream, client_addr) = ironrdp_mstsgu::GwClient::connect_with_port(
+    let (gw_stream, client_addr) = ironrdp_mstsgu::GwClient::connect_with_port_and_certificate_validation(
         &gw_target,
         &config.connector.client_name,
         config.destination.port(),
+        config.certificate_validation(),
+        config.certificate_validation_callback().cloned(),
     )
     .await
     .map_err(|e| ironrdp_connector::custom_err!("GW connect", e))?;

--- a/crates/ironrdp-mstsgu/Cargo.toml
+++ b/crates/ironrdp-mstsgu/Cargo.toml
@@ -77,7 +77,7 @@ hyper-util = { version = "0.1", features = ["tokio"] }
 hyper = { version = "1.9", features = ["client", "http1"] }
 ironrdp-core = { path = "../ironrdp-core", version = "0.2", features = ["std"] } # public
 ironrdp-error = { path = "../ironrdp-error", version = "0.2" }
-ironrdp-tls = { path = "../ironrdp-tls", version = "0.2" }
+ironrdp-tls = { path = "../ironrdp-tls", version = "0.2.2" } # public
 log = "0.4"
 sspi = { version = "0.21", features = ["network_client"] }
 tokio-tungstenite = { version = "0.29" }

--- a/crates/ironrdp-mstsgu/Cargo.toml
+++ b/crates/ironrdp-mstsgu/Cargo.toml
@@ -51,6 +51,11 @@ path = "tests/packet_io.rs"
 required-features = ["native-tls", "test-support"]
 
 [[test]]
+name = "packet_io_rustls"
+path = "tests/packet_io_rustls.rs"
+required-features = ["rustls", "test-support"]
+
+[[test]]
 name = "consent"
 path = "tests/consent.rs"
 required-features = ["native-tls", "test-support"]
@@ -90,7 +95,8 @@ picky-asn1-x509 = { version = "0.15", optional = true }
 
 [dev-dependencies]
 hyper = { version = "1.9", features = ["server", "http1"] }
-tokio = { version = "1.52", features = ["io-util", "macros", "rt", "sync"] }
+tokio = { version = "1.52", features = ["io-util", "macros", "net", "rt", "sync"] }
+tokio-native-tls = "0.3"
 
 [lints]
 workspace = true

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -27,6 +27,7 @@ use std::io;
 use futures_util::FutureExt as _;
 use hyper::body::Bytes;
 use ironrdp_core::{Decode as _, Encode, ReadCursor, WriteCursor};
+use ironrdp_tls::{CertificateValidation, CertificateValidationCallback};
 use log::warn;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::sync::PollSender;
@@ -213,7 +214,28 @@ impl GwClient {
         target: &GwConnectTarget,
         client_name: &str,
     ) -> Result<(GwClient, core::net::SocketAddr), Error> {
-        Self::connect_with_port(target, client_name, 3389).await
+        Self::connect_with_certificate_validation(target, client_name, CertificateValidation::default(), None).await
+    }
+
+    /// Open an MS-TSGU tunnel with an explicit TLS certificate-validation configuration.
+    ///
+    /// This presents port `3389` to the gateway.
+    ///
+    /// Certificate-validation callbacks require the Rustls TLS backend.
+    pub async fn connect_with_certificate_validation(
+        target: &GwConnectTarget,
+        client_name: &str,
+        certificate_validation: CertificateValidation,
+        certificate_validation_callback: Option<CertificateValidationCallback>,
+    ) -> Result<(GwClient, core::net::SocketAddr), Error> {
+        Self::connect_with_port_and_certificate_validation(
+            target,
+            client_name,
+            3389,
+            certificate_validation,
+            certificate_validation_callback,
+        )
+        .await
     }
 
     /// Open an MS-TSGU tunnel and decide a gateway consent message synchronously.
@@ -234,7 +256,35 @@ impl GwClient {
         client_name: &str,
         server_port: u16,
     ) -> Result<(GwClient, core::net::SocketAddr), Error> {
-        Self::connect_with_port_and_optional_consent(target, client_name, server_port, None).await
+        Self::connect_with_port_and_certificate_validation(
+            target,
+            client_name,
+            server_port,
+            CertificateValidation::default(),
+            None,
+        )
+        .await
+    }
+
+    /// Open an MS-TSGU tunnel with an explicit TLS certificate-validation configuration.
+    ///
+    /// Certificate-validation callbacks require the Rustls TLS backend.
+    pub async fn connect_with_port_and_certificate_validation(
+        target: &GwConnectTarget,
+        client_name: &str,
+        server_port: u16,
+        certificate_validation: CertificateValidation,
+        certificate_validation_callback: Option<CertificateValidationCallback>,
+    ) -> Result<(GwClient, core::net::SocketAddr), Error> {
+        Self::connect_with_port_and_optional_consent(
+            target,
+            client_name,
+            server_port,
+            certificate_validation,
+            certificate_validation_callback,
+            None,
+        )
+        .await
     }
 
     /// Open an MS-TSGU tunnel and decide a gateway consent message synchronously.
@@ -247,16 +297,27 @@ impl GwClient {
         server_port: u16,
         consent_callback: &mut GwConsentCallback<'_>,
     ) -> Result<(GwClient, core::net::SocketAddr), Error> {
-        Self::connect_with_port_and_optional_consent(target, client_name, server_port, Some(consent_callback)).await
+        Self::connect_with_port_and_optional_consent(
+            target,
+            client_name,
+            server_port,
+            CertificateValidation::default(),
+            None,
+            Some(consent_callback),
+        )
+        .await
     }
 
     async fn connect_with_port_and_optional_consent(
         target: &GwConnectTarget,
         client_name: &str,
         server_port: u16,
+        certificate_validation: CertificateValidation,
+        certificate_validation_callback: Option<CertificateValidationCallback>,
         consent_callback: Option<&mut GwConsentCallback<'_>>,
     ) -> Result<(GwClient, core::net::SocketAddr), Error> {
-        let (io, client_addr) = open_gateway_transport(target).await?;
+        let (io, client_addr) =
+            open_gateway_transport(target, certificate_validation, certificate_validation_callback).await?;
         Self::connect_ws(target.clone(), client_name, server_port, io, consent_callback)
             .await
             .map(|x| (x, client_addr))

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -1,6 +1,9 @@
 #![cfg_attr(doc, doc = include_str!("../README.md"))]
 #![doc(html_logo_url = "https://cdnweb.devolutions.net/images/projects/devolutions/logos/devolutions-icon-shadow.svg")]
 
+#[cfg(test)]
+use tokio_native_tls as _;
+
 #[macro_use]
 mod macros;
 

--- a/crates/ironrdp-mstsgu/src/lib.rs
+++ b/crates/ironrdp-mstsgu/src/lib.rs
@@ -127,6 +127,7 @@ type Error = ironrdp_error::Error<GwErrorKind>;
 #[non_exhaustive]
 pub enum GwErrorKind {
     InvalidGwTarget,
+    InvalidCertificateValidation,
     Connect,
     /// A nonzero HRESULT returned by the gateway during control setup.
     GatewayCode(u32),
@@ -159,6 +160,7 @@ impl Display for GwErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let x = match self {
             GwErrorKind::InvalidGwTarget => "invalid GW Target",
+            GwErrorKind::InvalidCertificateValidation => "invalid certificate validation configuration",
             GwErrorKind::Connect => "connection error",
             GwErrorKind::GatewayCode(code) => match gateway_code_label(*code) {
                 Some(label) => return write!(f, "gateway error 0x{code:08x} ({label})"),
@@ -221,7 +223,8 @@ impl GwClient {
     ///
     /// This presents port `3389` to the gateway.
     ///
-    /// Certificate-validation callbacks require the Rustls TLS backend.
+    /// Certificate-validation callbacks require the Rustls TLS backend and cannot be
+    /// combined with [`CertificateValidation::DangerouslyAcceptInvalidCertificate`].
     pub async fn connect_with_certificate_validation(
         target: &GwConnectTarget,
         client_name: &str,
@@ -268,7 +271,8 @@ impl GwClient {
 
     /// Open an MS-TSGU tunnel with an explicit TLS certificate-validation configuration.
     ///
-    /// Certificate-validation callbacks require the Rustls TLS backend.
+    /// Certificate-validation callbacks require the Rustls TLS backend and cannot be
+    /// combined with [`CertificateValidation::DangerouslyAcceptInvalidCertificate`].
     pub async fn connect_with_port_and_certificate_validation(
         target: &GwConnectTarget,
         client_name: &str,
@@ -276,6 +280,15 @@ impl GwClient {
         certificate_validation: CertificateValidation,
         certificate_validation_callback: Option<CertificateValidationCallback>,
     ) -> Result<(GwClient, core::net::SocketAddr), Error> {
+        if certificate_validation == CertificateValidation::DangerouslyAcceptInvalidCertificate
+            && certificate_validation_callback.is_some()
+        {
+            return Err(Error::new(
+                "certificate validation",
+                GwErrorKind::InvalidCertificateValidation,
+            ));
+        }
+
         Self::connect_with_port_and_optional_consent(
             target,
             client_name,

--- a/crates/ironrdp-mstsgu/src/packet_io.rs
+++ b/crates/ironrdp-mstsgu/src/packet_io.rs
@@ -10,6 +10,7 @@ use http_body_util::combinators::BoxBody;
 use http_body_util::{BodyExt as _, Empty};
 use hyper::body::{Bytes, Incoming};
 use ironrdp_core::{Decode as _, ReadCursor};
+use ironrdp_tls::{CertificateValidation, CertificateValidationCallback};
 use log::error;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::TcpStream;
@@ -184,6 +185,8 @@ impl PacketIo {
 /// Open a TLS transport to the gateway, preferring a WebSocket upgrade and falling back to dual HTTP.
 pub(crate) async fn open_gateway_transport(
     target: &GwConnectTarget,
+    certificate_validation: CertificateValidation,
+    certificate_validation_callback: Option<CertificateValidationCallback>,
 ) -> Result<(PacketIo, core::net::SocketAddr), Error> {
     let gw_host = target
         .gw_endpoint
@@ -198,22 +201,86 @@ pub(crate) async fn open_gateway_transport(
     let client_addr = stream
         .local_addr()
         .map_err(|e| custom_err!("get socket local address", e))?;
-    let (stream, _) = ironrdp_tls::upgrade(stream, &gw_host)
-        .await
-        .map_err(|e| custom_err!("tls connect", e))?;
+    let stream = upgrade_gateway_tls(
+        stream,
+        &gw_host,
+        certificate_validation,
+        certificate_validation_callback.clone(),
+    )
+    .await?;
 
     let in_gw_host = gw_host.clone();
-    open_transport_with_out_stream(Box::new(stream), client_addr, &gw_host, target, move || async move {
+    open_transport_with_out_stream(stream, client_addr, &gw_host, target, move || async move {
         let stream = TcpStream::connect(&target.gw_endpoint)
             .await
             .map_err(|e| custom_err!("tcp connect", e))?;
-        let (stream, _) = ironrdp_tls::upgrade(stream, &in_gw_host)
-            .await
-            .map_err(|e| custom_err!("tls connect", e))?;
-        let stream: GatewayStream = Box::new(stream);
-        Ok(stream)
+        upgrade_gateway_tls(
+            stream,
+            &in_gw_host,
+            certificate_validation,
+            certificate_validation_callback,
+        )
+        .await
     })
     .await
+}
+
+async fn upgrade_gateway_tls(
+    stream: TcpStream,
+    gw_host: &str,
+    certificate_validation: CertificateValidation,
+    certificate_validation_callback: Option<CertificateValidationCallback>,
+) -> Result<GatewayStream, Error> {
+    let (stream, _) = match select_gateway_tls_upgrade(certificate_validation, certificate_validation_callback) {
+        GatewayTlsUpgrade::CertificateValidation(certificate_validation) => {
+            ironrdp_tls::upgrade_with_certificate_validation(stream, gw_host, certificate_validation).await
+        }
+        GatewayTlsUpgrade::CertificateValidationCallback(certificate_validation_callback) => {
+            ironrdp_tls::upgrade_with_certificate_validation_callback(stream, gw_host, certificate_validation_callback)
+                .await
+        }
+    }
+    .map_err(|e| custom_err!("tls connect", e))?;
+
+    Ok(Box::new(stream))
+}
+
+enum GatewayTlsUpgrade {
+    CertificateValidation(CertificateValidation),
+    CertificateValidationCallback(CertificateValidationCallback),
+}
+
+#[cfg(feature = "test-support")]
+pub(crate) struct GatewayTlsUpgradeSelection {
+    pub(crate) certificate_validation: CertificateValidation,
+    pub(crate) uses_callback: bool,
+}
+
+fn select_gateway_tls_upgrade(
+    certificate_validation: CertificateValidation,
+    certificate_validation_callback: Option<CertificateValidationCallback>,
+) -> GatewayTlsUpgrade {
+    match certificate_validation_callback {
+        Some(certificate_validation_callback) => {
+            GatewayTlsUpgrade::CertificateValidationCallback(certificate_validation_callback)
+        }
+        None => GatewayTlsUpgrade::CertificateValidation(certificate_validation),
+    }
+}
+
+#[cfg(feature = "test-support")]
+pub(crate) fn select_gateway_tls_upgrade_for_test(
+    certificate_validation: CertificateValidation,
+    certificate_validation_callback: Option<CertificateValidationCallback>,
+) -> GatewayTlsUpgradeSelection {
+    let uses_callback = matches!(
+        select_gateway_tls_upgrade(certificate_validation, certificate_validation_callback),
+        GatewayTlsUpgrade::CertificateValidationCallback(_)
+    );
+    GatewayTlsUpgradeSelection {
+        certificate_validation,
+        uses_callback,
+    }
 }
 
 async fn open_transport_with_out_stream<F, Fut>(

--- a/crates/ironrdp-mstsgu/src/packet_io.rs
+++ b/crates/ironrdp-mstsgu/src/packet_io.rs
@@ -204,6 +204,7 @@ pub(crate) async fn open_gateway_transport(
     let stream = upgrade_gateway_tls(
         stream,
         &gw_host,
+        &target.gw_endpoint,
         certificate_validation,
         certificate_validation_callback.clone(),
     )
@@ -217,6 +218,7 @@ pub(crate) async fn open_gateway_transport(
         upgrade_gateway_tls(
             stream,
             &in_gw_host,
+            &target.gw_endpoint,
             certificate_validation,
             certificate_validation_callback,
         )
@@ -228,6 +230,7 @@ pub(crate) async fn open_gateway_transport(
 async fn upgrade_gateway_tls(
     stream: TcpStream,
     gw_host: &str,
+    gw_endpoint: &str,
     certificate_validation: CertificateValidation,
     certificate_validation_callback: Option<CertificateValidationCallback>,
 ) -> Result<GatewayStream, Error> {
@@ -236,8 +239,13 @@ async fn upgrade_gateway_tls(
             ironrdp_tls::upgrade_with_certificate_validation(stream, gw_host, certificate_validation).await
         }
         GatewayTlsUpgrade::CertificateValidationCallback(certificate_validation_callback) => {
-            ironrdp_tls::upgrade_with_certificate_validation_callback(stream, gw_host, certificate_validation_callback)
-                .await
+            ironrdp_tls::upgrade_with_certificate_validation_callback_for_endpoint(
+                stream,
+                gw_host,
+                gw_endpoint,
+                certificate_validation_callback,
+            )
+            .await
         }
     }
     .map_err(|e| custom_err!("tls connect", e))?;
@@ -250,12 +258,6 @@ enum GatewayTlsUpgrade {
     CertificateValidationCallback(CertificateValidationCallback),
 }
 
-#[cfg(feature = "test-support")]
-pub(crate) struct GatewayTlsUpgradeSelection {
-    pub(crate) certificate_validation: CertificateValidation,
-    pub(crate) uses_callback: bool,
-}
-
 fn select_gateway_tls_upgrade(
     certificate_validation: CertificateValidation,
     certificate_validation_callback: Option<CertificateValidationCallback>,
@@ -265,21 +267,6 @@ fn select_gateway_tls_upgrade(
             GatewayTlsUpgrade::CertificateValidationCallback(certificate_validation_callback)
         }
         None => GatewayTlsUpgrade::CertificateValidation(certificate_validation),
-    }
-}
-
-#[cfg(feature = "test-support")]
-pub(crate) fn select_gateway_tls_upgrade_for_test(
-    certificate_validation: CertificateValidation,
-    certificate_validation_callback: Option<CertificateValidationCallback>,
-) -> GatewayTlsUpgradeSelection {
-    let uses_callback = matches!(
-        select_gateway_tls_upgrade(certificate_validation, certificate_validation_callback),
-        GatewayTlsUpgrade::CertificateValidationCallback(_)
-    );
-    GatewayTlsUpgradeSelection {
-        certificate_validation,
-        uses_callback,
     }
 }
 

--- a/crates/ironrdp-mstsgu/src/test_support.rs
+++ b/crates/ironrdp-mstsgu/src/test_support.rs
@@ -2,7 +2,7 @@
 
 use hyper::body::Bytes;
 
-use crate::packet_io::{PacketIo, open_test_transport, select_gateway_tls_upgrade_for_test};
+use crate::packet_io::{PacketIo, open_gateway_transport, open_test_transport};
 use crate::{Error, GwClient, GwConnectTarget, GwConsentCallback};
 
 /// In-memory gateway transport used by the registered integration tests.
@@ -18,6 +18,17 @@ impl GatewayTransport {
             .await
             .map(Self)
             .map_err(|error| error.to_string())
+    }
+
+    /// Open an HTTPS gateway transport with the production TLS connection path.
+    pub async fn connect_tls(
+        target: &GwConnectTarget,
+        certificate_validation: ironrdp_tls::CertificateValidation,
+        certificate_validation_callback: Option<ironrdp_tls::CertificateValidationCallback>,
+    ) -> Result<Self, Error> {
+        open_gateway_transport(target, certificate_validation, certificate_validation_callback)
+            .await
+            .map(|(transport, _)| Self(transport))
     }
 
     /// Send one MS-TSGU packet to the mock gateway.
@@ -53,13 +64,4 @@ pub fn evaluate_consent_message(
     consent_callback: Option<&mut GwConsentCallback<'_>>,
 ) -> Result<(), Error> {
     crate::evaluate_consent_message(consent_message, consent_callback)
-}
-
-/// Report which TLS upgrader a gateway connection selects.
-pub fn tls_upgrade_selection(
-    certificate_validation: ironrdp_tls::CertificateValidation,
-    certificate_validation_callback: Option<ironrdp_tls::CertificateValidationCallback>,
-) -> (ironrdp_tls::CertificateValidation, bool) {
-    let selection = select_gateway_tls_upgrade_for_test(certificate_validation, certificate_validation_callback);
-    (selection.certificate_validation, selection.uses_callback)
 }

--- a/crates/ironrdp-mstsgu/src/test_support.rs
+++ b/crates/ironrdp-mstsgu/src/test_support.rs
@@ -2,7 +2,7 @@
 
 use hyper::body::Bytes;
 
-use crate::packet_io::{PacketIo, open_test_transport};
+use crate::packet_io::{PacketIo, open_test_transport, select_gateway_tls_upgrade_for_test};
 use crate::{Error, GwClient, GwConnectTarget, GwConsentCallback};
 
 /// In-memory gateway transport used by the registered integration tests.
@@ -53,4 +53,13 @@ pub fn evaluate_consent_message(
     consent_callback: Option<&mut GwConsentCallback<'_>>,
 ) -> Result<(), Error> {
     crate::evaluate_consent_message(consent_message, consent_callback)
+}
+
+/// Report which TLS upgrader a gateway connection selects.
+pub fn tls_upgrade_selection(
+    certificate_validation: ironrdp_tls::CertificateValidation,
+    certificate_validation_callback: Option<ironrdp_tls::CertificateValidationCallback>,
+) -> (ironrdp_tls::CertificateValidation, bool) {
+    let selection = select_gateway_tls_upgrade_for_test(certificate_validation, certificate_validation_callback);
+    (selection.certificate_validation, selection.uses_callback)
 }

--- a/crates/ironrdp-mstsgu/tests/packet_io.rs
+++ b/crates/ironrdp-mstsgu/tests/packet_io.rs
@@ -15,8 +15,11 @@ use hyper::service::service_fn;
 use hyper::{Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
 use ironrdp_mstsgu::test_support::GatewayTransport;
+use ironrdp_mstsgu::{GwClient, GwConnectTarget};
 use ironrdp_tls::{CertificateValidation, CertificateValidationCallback};
 use tokio::sync::oneshot;
+use tokio_native_tls::TlsAcceptor;
+use tokio_native_tls::native_tls::{Identity, TlsAcceptor as NativeTlsAcceptor};
 use tokio_tungstenite::WebSocketStream;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::tungstenite::protocol::Role;
@@ -29,17 +32,66 @@ const PACKET: &[u8] = &[
     0x08, 0x00, 0x00, 0x00, // length
 ];
 
-#[test]
-fn gateway_tls_upgrade_uses_policy_or_callback() {
-    assert_eq!(
-        ironrdp_mstsgu::test_support::tls_upgrade_selection(CertificateValidation::Strict, None),
-        (CertificateValidation::Strict, false)
+#[tokio::test]
+async fn strict_policy_rejects_self_signed_gateway_certificate() {
+    let (listener, acceptor) = tls_listener().await;
+    let target = gateway_target(listener.local_addr().expect("gateway listener address"));
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.expect("accept strict TLS client");
+        let _ = acceptor.accept(stream).await;
+    });
+
+    let error = match GatewayTransport::connect_tls(&target, CertificateValidation::Strict, None).await {
+        Ok(_) => panic!("strict validation must reject the self-signed gateway certificate"),
+        Err(error) => error,
+    };
+    assert!(error.to_string().contains("tls connect"));
+
+    server.await.expect("TLS server task");
+}
+
+#[tokio::test]
+async fn native_tls_rejects_gateway_certificate_callback() {
+    let (listener, acceptor) = tls_listener().await;
+    let target = gateway_target(listener.local_addr().expect("gateway listener address"));
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.expect("accept callback TLS client");
+        assert!(acceptor.accept(stream).await.is_err());
+    });
+    let callback: CertificateValidationCallback = Arc::new(|_, _, _| true);
+
+    let error = match GatewayTransport::connect_tls(&target, CertificateValidation::Strict, Some(callback)).await {
+        Ok(_) => panic!("native TLS must reject certificate callbacks"),
+        Err(error) => error,
+    };
+    assert!(
+        format!("{error:?}").contains("certificate validation callbacks require the rustls backend"),
+        "{error:?}"
     );
 
-    let callback: CertificateValidationCallback = Arc::new(|_, _| false);
-    assert_eq!(
-        ironrdp_mstsgu::test_support::tls_upgrade_selection(CertificateValidation::Strict, Some(Arc::clone(&callback))),
-        (CertificateValidation::Strict, true)
+    server.await.expect("TLS server task");
+}
+
+#[tokio::test]
+async fn dangerous_policy_with_gateway_callback_is_rejected() {
+    let target = gateway_target("127.0.0.1:1".parse().expect("socket address"));
+    let callback: CertificateValidationCallback = Arc::new(|_, _, _| true);
+
+    let error = match GwClient::connect_with_certificate_validation(
+        &target,
+        "test-client",
+        CertificateValidation::DangerouslyAcceptInvalidCertificate,
+        Some(callback),
+    )
+    .await
+    {
+        Ok(_) => panic!("dangerous policy and callback must be rejected"),
+        Err(error) => error,
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("invalid certificate validation configuration")
     );
 }
 
@@ -384,4 +436,27 @@ fn response(status: StatusCode, headers: &[(&str, &str)], body: Bytes) -> Respon
         );
     }
     response
+}
+
+async fn tls_listener() -> (tokio::net::TcpListener, TlsAcceptor) {
+    let identity = Identity::from_pkcs8(
+        include_bytes!("../../ironrdp-tls/tests/certs/server-cert.pem"),
+        include_bytes!("../../ironrdp-tls/tests/certs/server-key.pem"),
+    )
+    .expect("create TLS identity");
+    let acceptor = TlsAcceptor::from(NativeTlsAcceptor::new(identity).expect("create TLS acceptor"));
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .expect("bind TLS gateway listener");
+    (listener, acceptor)
+}
+
+fn gateway_target(address: core::net::SocketAddr) -> GwConnectTarget {
+    GwConnectTarget {
+        gw_endpoint: format!("localhost:{}", address.port()),
+        gw_user: "user".to_owned(),
+        gw_pass: "pass".to_owned(),
+        smart_card: None,
+        server: "server.test".to_owned(),
+    }
 }

--- a/crates/ironrdp-mstsgu/tests/packet_io.rs
+++ b/crates/ironrdp-mstsgu/tests/packet_io.rs
@@ -15,6 +15,7 @@ use hyper::service::service_fn;
 use hyper::{Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
 use ironrdp_mstsgu::test_support::GatewayTransport;
+use ironrdp_tls::{CertificateValidation, CertificateValidationCallback};
 use tokio::sync::oneshot;
 use tokio_tungstenite::WebSocketStream;
 use tokio_tungstenite::tungstenite::Message;
@@ -27,6 +28,20 @@ const PACKET: &[u8] = &[
     0x00, 0x00, // reserved
     0x08, 0x00, 0x00, 0x00, // length
 ];
+
+#[test]
+fn gateway_tls_upgrade_uses_policy_or_callback() {
+    assert_eq!(
+        ironrdp_mstsgu::test_support::tls_upgrade_selection(CertificateValidation::Strict, None),
+        (CertificateValidation::Strict, false)
+    );
+
+    let callback: CertificateValidationCallback = Arc::new(|_, _| false);
+    assert_eq!(
+        ironrdp_mstsgu::test_support::tls_upgrade_selection(CertificateValidation::Strict, Some(Arc::clone(&callback))),
+        (CertificateValidation::Strict, true)
+    );
+}
 
 #[tokio::test]
 async fn switching_protocols_keeps_websocket_transport() {

--- a/crates/ironrdp-mstsgu/tests/packet_io_rustls.rs
+++ b/crates/ironrdp-mstsgu/tests/packet_io_rustls.rs
@@ -1,0 +1,197 @@
+#![allow(unused_crate_dependencies)]
+
+use core::convert::Infallible;
+use core::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use futures_util::StreamExt as _;
+use http_body_util::combinators::BoxBody;
+use http_body_util::{BodyExt as _, Full};
+use hyper::body::Bytes;
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use ironrdp_mstsgu::GwConnectTarget;
+use ironrdp_mstsgu::test_support::GatewayTransport;
+use ironrdp_tls::{CertificateValidation, CertificateValidationCallback};
+use tokio::sync::oneshot;
+use tokio_native_tls::TlsAcceptor;
+use tokio_native_tls::native_tls::{Identity, TlsAcceptor as NativeTlsAcceptor};
+use tokio_tungstenite::WebSocketStream;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::protocol::Role;
+
+type TestBody = BoxBody<Bytes, Infallible>;
+
+#[tokio::test]
+async fn callback_validates_websocket_gateway_tls() {
+    let (listener, acceptor) = tls_listener().await;
+    let target = gateway_target(listener.local_addr().expect("gateway listener address"));
+    let (upgrade_tx, upgrade_rx) = oneshot::channel();
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.expect("accept WebSocket TLS client");
+        let stream = acceptor.accept(stream).await.expect("accept WebSocket TLS client");
+        let upgrade_tx = Arc::new(std::sync::Mutex::new(Some(upgrade_tx)));
+        let service = service_fn(move |mut request: Request<hyper::body::Incoming>| {
+            let upgrade = hyper::upgrade::on(&mut request);
+            let upgrade_tx = Arc::clone(&upgrade_tx);
+            async move {
+                assert_eq!(request.method(), "RDG_OUT_DATA");
+                upgrade_tx
+                    .lock()
+                    .expect("upgrade sender lock")
+                    .take()
+                    .expect("one WebSocket request")
+                    .send(upgrade)
+                    .expect("send WebSocket upgrade");
+
+                let mut response = Response::new(Full::new(Bytes::new()).boxed());
+                *response.status_mut() = StatusCode::SWITCHING_PROTOCOLS;
+                response
+                    .headers_mut()
+                    .insert("connection", "Upgrade".parse().expect("connection header"));
+                response
+                    .headers_mut()
+                    .insert("upgrade", "websocket".parse().expect("upgrade header"));
+                Ok::<_, Infallible>(response)
+            }
+        });
+        http1::Builder::new()
+            .serve_connection(TokioIo::new(stream), service)
+            .with_upgrades()
+            .await
+            .expect("serve WebSocket");
+    });
+
+    let callback_hits = Arc::new(AtomicUsize::new(0));
+    let callback: CertificateValidationCallback = {
+        let callback_hits = Arc::clone(&callback_hits);
+        let expected_endpoint = target.gw_endpoint.clone();
+        Arc::new(move |_, server_name, _| {
+            assert_eq!(server_name, expected_endpoint);
+            callback_hits.fetch_add(1, Ordering::SeqCst);
+            true
+        })
+    };
+    let mut transport = GatewayTransport::connect_tls(&target, CertificateValidation::Strict, Some(callback))
+        .await
+        .expect("callback accepts WebSocket gateway certificate");
+    let upgraded = upgrade_rx
+        .await
+        .expect("receive WebSocket upgrade")
+        .await
+        .expect("upgrade");
+    let mut websocket = WebSocketStream::<TokioIo<hyper::upgrade::Upgraded>>::from_raw_socket(
+        TokioIo::new(upgraded),
+        Role::Server,
+        None,
+    )
+    .await;
+
+    transport.close().await.expect("close WebSocket transport");
+    assert!(matches!(
+        websocket
+            .next()
+            .await
+            .expect("WebSocket close message")
+            .expect("WebSocket close result"),
+        Message::Close(_)
+    ));
+    assert_eq!(callback_hits.load(Ordering::SeqCst), 1);
+    server.await.expect("WebSocket server task");
+}
+
+#[tokio::test]
+async fn callback_validates_both_dual_http_gateway_tls_connections() {
+    let (listener, acceptor) = tls_listener().await;
+    let target = gateway_target(listener.local_addr().expect("gateway listener address"));
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.expect("accept OUT TLS client");
+        let stream = acceptor.accept(stream).await.expect("accept OUT TLS client");
+        let out_server = tokio::spawn(async move {
+            let service = service_fn(|request: Request<hyper::body::Incoming>| async move {
+                assert_eq!(request.method(), "RDG_OUT_DATA");
+                Ok::<_, Infallible>(response(StatusCode::OK, Bytes::from_static(b"0123456789")))
+            });
+            http1::Builder::new()
+                .serve_connection(TokioIo::new(stream), service)
+                .await
+                .expect("serve OUT");
+        });
+
+        let (stream, _) = listener.accept().await.expect("accept IN TLS client");
+        let stream = acceptor.accept(stream).await.expect("accept IN TLS client");
+        let in_server = tokio::spawn(async move {
+            let request_count = Arc::new(AtomicUsize::new(0));
+            let service = service_fn(move |request: Request<hyper::body::Incoming>| {
+                let request_count = Arc::clone(&request_count);
+                async move {
+                    assert_eq!(request.method(), "RDG_IN_DATA");
+                    match request_count.fetch_add(1, Ordering::SeqCst) {
+                        0 => Ok::<_, Infallible>(response(StatusCode::OK, Bytes::new())),
+                        1 => {
+                            request.into_body().collect().await.expect("drain IN request");
+                            Ok(response(StatusCode::OK, Bytes::new()))
+                        }
+                        _ => panic!("unexpected IN request"),
+                    }
+                }
+            });
+            http1::Builder::new()
+                .serve_connection(TokioIo::new(stream), service)
+                .await
+                .expect("serve IN");
+        });
+
+        out_server.await.expect("OUT server task");
+        in_server.await.expect("IN server task");
+    });
+
+    let callback_hits = Arc::new(AtomicUsize::new(0));
+    let callback: CertificateValidationCallback = {
+        let callback_hits = Arc::clone(&callback_hits);
+        let expected_endpoint = target.gw_endpoint.clone();
+        Arc::new(move |_, server_name, _| {
+            assert_eq!(server_name, expected_endpoint);
+            callback_hits.fetch_add(1, Ordering::SeqCst);
+            true
+        })
+    };
+    let mut transport = GatewayTransport::connect_tls(&target, CertificateValidation::Strict, Some(callback))
+        .await
+        .expect("callback accepts dual-HTTP gateway certificates");
+
+    assert_eq!(callback_hits.load(Ordering::SeqCst), 2);
+    transport.close().await.expect("close dual-HTTP transport");
+    server.await.expect("dual-HTTP server task");
+}
+
+fn response(status: StatusCode, body: Bytes) -> Response<TestBody> {
+    let mut response = Response::new(Full::new(body).boxed());
+    *response.status_mut() = status;
+    response
+}
+
+async fn tls_listener() -> (tokio::net::TcpListener, TlsAcceptor) {
+    let identity = Identity::from_pkcs8(
+        include_bytes!("../../ironrdp-tls/tests/certs/server-cert.pem"),
+        include_bytes!("../../ironrdp-tls/tests/certs/server-key.pem"),
+    )
+    .expect("create TLS identity");
+    let acceptor = TlsAcceptor::from(NativeTlsAcceptor::new(identity).expect("create TLS acceptor"));
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .expect("bind TLS gateway listener");
+    (listener, acceptor)
+}
+
+fn gateway_target(address: core::net::SocketAddr) -> GwConnectTarget {
+    GwConnectTarget {
+        gw_endpoint: format!("localhost:{}", address.port()),
+        gw_user: "user".to_owned(),
+        gw_pass: "pass".to_owned(),
+        smart_card: None,
+        server: "server.test".to_owned(),
+    }
+}

--- a/crates/ironrdp-testsuite-extra/tests/client/config.rs
+++ b/crates/ironrdp-testsuite-extra/tests/client/config.rs
@@ -294,8 +294,9 @@ fn certificate_validation_preserves_the_default_and_callbacks_are_explicit() {
         ironrdp_tls::CertificateValidation::DangerouslyAcceptInvalidCertificate
     );
 
-    let callback: ironrdp_tls::CertificateValidationCallback =
-        Arc::new(|certificate, reason| certificate == b"test certificate" && reason == "untrusted issuer");
+    let callback: ironrdp_tls::CertificateValidationCallback = Arc::new(|certificate, server_name, reason| {
+        certificate == b"test certificate" && server_name == "rdp.example.com" && reason == "untrusted issuer"
+    });
     let config = ConfigBuilder::new()
         .with_destination(Destination::from_parts("rdp.example.com", 3389))
         .with_username("test-user")
@@ -314,8 +315,8 @@ fn certificate_validation_preserves_the_default_and_callbacks_are_explicit() {
     let callback = config
         .certificate_validation_callback()
         .expect("certificate validation callback must be retained");
-    assert!(callback(b"test certificate", "untrusted issuer"));
-    assert!(!callback(b"other certificate", "untrusted issuer"));
+    assert!(callback(b"test certificate", "rdp.example.com", "untrusted issuer"));
+    assert!(!callback(b"other certificate", "rdp.example.com", "untrusted issuer"));
 }
 
 #[test]

--- a/crates/ironrdp-testsuite-extra/tests/e2e.rs
+++ b/crates/ironrdp-testsuite-extra/tests/e2e.rs
@@ -411,9 +411,9 @@ async fn tls_validation_preserves_the_default_and_strict_is_explicit() {
 
     let callback_called = Arc::new(AtomicBool::new(false));
     let callback_called_for_callback = Arc::clone(&callback_called);
-    let callback: ironrdp_tls::CertificateValidationCallback = Arc::new(move |certificate, reason| {
+    let callback: ironrdp_tls::CertificateValidationCallback = Arc::new(move |certificate, server_name, reason| {
         callback_called_for_callback.store(true, Ordering::Relaxed);
-        !certificate.is_empty() && !reason.is_empty()
+        !certificate.is_empty() && server_name == "localhost" && !reason.is_empty()
     });
     let (tls_stream, _) = ironrdp_tls::upgrade_with_certificate_validation_callback(
         TcpStream::connect(address).await.expect("connect callback TLS client"),

--- a/crates/ironrdp-tls/src/lib.rs
+++ b/crates/ironrdp-tls/src/lib.rs
@@ -31,18 +31,20 @@ compile_error!(
 #[cfg(any(feature = "stub", feature = "native-tls", feature = "rustls-no-provider"))]
 pub use impl_::{
     TlsStream, negotiated, upgrade, upgrade_with_certificate_validation, upgrade_with_certificate_validation_callback,
+    upgrade_with_certificate_validation_callback_for_endpoint,
 };
 
 /// Called when the Rustls backend cannot validate a server certificate.
 ///
-/// The callback receives the leaf certificate's DER encoding and a validation-error
-/// description. Returning `true` accepts that certificate for the current handshake.
+/// The callback receives the leaf certificate's DER encoding, the configured endpoint,
+/// and a validation-error description. Returning `true` accepts that certificate for the
+/// current handshake.
 /// Callers must make this decision explicitly and should retain the certificate
 /// fingerprint rather than accepting a host blindly.
 ///
 /// The `native-tls` and stub backends cannot safely support this operation and return
 /// an error if it is requested.
-pub type CertificateValidationCallback = Arc<dyn Fn(&[u8], &str) -> bool + Send + Sync>;
+pub type CertificateValidationCallback = Arc<dyn Fn(&[u8], &str, &str) -> bool + Send + Sync>;
 
 /// Certificate-validation policy applied during a TLS handshake.
 ///

--- a/crates/ironrdp-tls/src/native_tls.rs
+++ b/crates/ironrdp-tls/src/native_tls.rs
@@ -72,6 +72,20 @@ where
     ))
 }
 
+/// The `native-tls` backend cannot safely expose a certificate-validation callback.
+pub async fn upgrade_with_certificate_validation_callback_for_endpoint<S>(
+    stream: S,
+    server_name: &str,
+    endpoint: &str,
+    callback: CertificateValidationCallback,
+) -> io::Result<(TlsStream<S>, x509_cert::Certificate)>
+where
+    S: Unpin + AsyncRead + AsyncWrite,
+{
+    let _ = endpoint;
+    upgrade_with_certificate_validation_callback(stream, server_name, callback).await
+}
+
 /// The `native-tls` backend does not expose the negotiated version or cipher.
 pub fn negotiated<S>(_stream: &TlsStream<S>) -> crate::NegotiatedTls {
     crate::NegotiatedTls::default()

--- a/crates/ironrdp-tls/src/rustls.rs
+++ b/crates/ironrdp-tls/src/rustls.rs
@@ -87,13 +87,33 @@ pub async fn upgrade_with_certificate_validation_callback<S>(
 where
     S: Unpin + AsyncRead + AsyncWrite,
 {
+    upgrade_with_certificate_validation_callback_for_endpoint(stream, server_name, server_name, callback).await
+}
+
+/// Upgrades a stream with normal platform-root and server-name validation.
+///
+/// On validation failure, invokes `callback` with `endpoint` so callers can scope
+/// certificate exceptions to the configured connection endpoint.
+pub async fn upgrade_with_certificate_validation_callback_for_endpoint<S>(
+    stream: S,
+    server_name: &str,
+    endpoint: &str,
+    callback: CertificateValidationCallback,
+) -> io::Result<(TlsStream<S>, x509_cert::Certificate)>
+where
+    S: Unpin + AsyncRead + AsyncWrite,
+{
     let verifier = rustls::client::WebPkiServerVerifier::builder(Arc::new(platform_root_certificates()?))
         .build()
         .map_err(io::Error::other)?;
     let verifier: Arc<dyn ServerCertVerifier> = verifier;
     let mut config = rustls::client::ClientConfig::builder()
         .dangerous()
-        .with_custom_certificate_verifier(Arc::new(CallbackVerifier { verifier, callback }))
+        .with_custom_certificate_verifier(Arc::new(CallbackVerifier {
+            verifier,
+            endpoint: endpoint.to_owned(),
+            callback,
+        }))
         .with_no_client_auth();
     config.key_log = Arc::new(rustls::KeyLogFile::new());
     // TLS resumption is incompatible with CredSSP.
@@ -147,6 +167,7 @@ fn platform_root_certificates() -> io::Result<rustls::RootCertStore> {
 
 struct CallbackVerifier {
     verifier: Arc<dyn ServerCertVerifier>,
+    endpoint: String,
     callback: CertificateValidationCallback,
 }
 
@@ -170,7 +191,7 @@ impl ServerCertVerifier for CallbackVerifier {
             .verify_server_cert(end_entity, intermediates, server_name, ocsp_response, now)
         {
             Ok(verified) => Ok(verified),
-            Err(error) if (self.callback)(end_entity.as_ref(), &error.to_string()) => {
+            Err(error) if (self.callback)(end_entity.as_ref(), &self.endpoint, &error.to_string()) => {
                 Ok(ServerCertVerified::assertion())
             }
             Err(error) => Err(error),

--- a/crates/ironrdp-tls/src/stub.rs
+++ b/crates/ironrdp-tls/src/stub.rs
@@ -65,6 +65,20 @@ where
     Err(io::Error::other("no TLS backend enabled for this build"))
 }
 
+/// The stub backend cannot perform a certificate-validation callback.
+pub async fn upgrade_with_certificate_validation_callback_for_endpoint<S>(
+    stream: S,
+    server_name: &str,
+    endpoint: &str,
+    callback: CertificateValidationCallback,
+) -> io::Result<(TlsStream<S>, Vec<u8>)>
+where
+    S: Unpin + AsyncRead + AsyncWrite,
+{
+    let _ = endpoint;
+    upgrade_with_certificate_validation_callback(stream, server_name, callback).await
+}
+
 /// The stub backend performs no handshake and reports nothing.
 pub fn negotiated<S>(_stream: &TlsStream<S>) -> crate::NegotiatedTls {
     crate::NegotiatedTls::default()


### PR DESCRIPTION
Apply the RDP client's certificate-validation policy and callback to every
gateway HTTPS connection.

Existing gateway callers retain their compatibility default.