### PR TITLE
feat(mstsgu): support outbound gateway proxies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3026,6 +3026,7 @@ dependencies = [
  "sspi",
  "tokio",
  "tokio-native-tls",
+ "tokio-socks",
  "tokio-tungstenite",
  "tokio-util",
  "uuid",
@@ -6619,6 +6620,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7e2948f60dbe26b35f2c7fb74ac2854c1fddded0fe9d7548fcc674a246f7615"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror 1.0.69",
  "tokio",
 ]
 

--- a/crates/ironrdp-mstsgu/Cargo.toml
+++ b/crates/ironrdp-mstsgu/Cargo.toml
@@ -56,6 +56,11 @@ path = "tests/packet_io_rustls.rs"
 required-features = ["rustls", "test-support"]
 
 [[test]]
+name = "proxy"
+path = "tests/proxy.rs"
+required-features = ["test-support"]
+
+[[test]]
 name = "consent"
 path = "tests/consent.rs"
 required-features = ["native-tls", "test-support"]
@@ -88,6 +93,7 @@ sspi = { version = "0.21", features = ["network_client"] }
 tokio-tungstenite = { version = "0.29" }
 tokio-util = { version = "0.7" }
 tokio = { version = "1.52", features = ["macros", "rt", "io-util"] }
+tokio-socks = "0.5.3"
 uuid = { version = "1", features = ["v4"] }
 picky = { version = "=7.0.0-rc.25", optional = true }
 picky-asn1-der = { version = "0.5", optional = true }

--- a/crates/ironrdp-mstsgu/Cargo.toml
+++ b/crates/ironrdp-mstsgu/Cargo.toml
@@ -58,7 +58,7 @@ required-features = ["rustls", "test-support"]
 [[test]]
 name = "proxy"
 path = "tests/proxy.rs"
-required-features = ["test-support"]
+required-features = ["native-tls", "test-support"]
 
 [[test]]
 name = "consent"

--- a/crates/ironrdp-mstsgu/README.md
+++ b/crates/ironrdp-mstsgu/README.md
@@ -5,6 +5,7 @@
 This crate
 - implements an MVP state needed to connect through Microsoft RD Gateway,
 - supports HTTPS WebSocket transport and falls back to the legacy dual-channel HTTP transport,
+- honors `HTTPS_PROXY`/`https_proxy` and `NO_PROXY`/`no_proxy` for outbound HTTP(S) CONNECT and SOCKS5 gateway proxies,
 - provides internal raw RPCH HTTP framing codecs, but no live RPC-over-HTTP gateway transport,
 - decodes HTTP control packets (`HTTP_SERVICE_MESSAGE`, `HTTP_REAUTH_MESSAGE`, and `HTTP_CLOSE_PACKET`) without performing mid-session reauthentication,
 - exposes decoded tunnel-authorization policy values without enforcing redirection rules or idle timeouts,

--- a/crates/ironrdp-mstsgu/src/packet_io.rs
+++ b/crates/ironrdp-mstsgu/src/packet_io.rs
@@ -286,7 +286,7 @@ pub(crate) async fn open_gateway_transport(
 ) -> Result<(PacketIo, core::net::SocketAddr), Error> {
     let gateway = parse_gateway_endpoint(&target.gw_endpoint)?;
     let gw_host = gateway.host.clone();
-    let proxy = proxy_from_environment(&gateway.host)?;
+    let proxy = proxy_from_environment(&gateway)?;
 
     let (stream, client_addr) = open_gateway_tcp(&gateway, proxy.as_ref()).await?;
     let stream = upgrade_gateway_tls(
@@ -352,9 +352,14 @@ fn parse_gateway_endpoint(endpoint: &str) -> Result<GatewayEndpoint, Error> {
         .strip_prefix('[')
         .and_then(|host| host.strip_suffix(']'))
         .unwrap_or(host);
-    if host.is_empty() {
+    if host.is_empty()
+        || host
+            .bytes()
+            .any(|byte| byte.is_ascii_control() || byte.is_ascii_whitespace())
+    {
         return Err(Error::new("connect", GwErrorKind::InvalidGwTarget));
     }
+
     let port = port
         .parse()
         .map_err(|_| Error::new("connect", GwErrorKind::InvalidGwTarget))?;
@@ -364,6 +369,10 @@ fn parse_gateway_endpoint(endpoint: &str) -> Result<GatewayEndpoint, Error> {
         port,
         endpoint: endpoint.to_owned(),
     })
+}
+
+pub(crate) fn gateway_endpoint_is_valid(endpoint: &str) -> bool {
+    parse_gateway_endpoint(endpoint).is_ok()
 }
 
 async fn open_gateway_tcp(
@@ -562,9 +571,10 @@ fn validate_http_connect_response(response: &[u8]) -> Result<(), Error> {
     Ok(())
 }
 
-fn proxy_from_environment(gateway_host: &str) -> Result<Option<ProxyConfig>, Error> {
+fn proxy_from_environment(gateway: &GatewayEndpoint) -> Result<Option<ProxyConfig>, Error> {
     proxy_from_values(
-        gateway_host,
+        &gateway.host,
+        gateway.port,
         environment_value("HTTPS_PROXY", "https_proxy")?,
         environment_value("NO_PROXY", "no_proxy")?,
     )
@@ -588,6 +598,7 @@ fn environment_value(uppercase: &str, lowercase: &str) -> Result<Option<String>,
 
 pub(crate) fn proxy_from_values(
     gateway_host: &str,
+    gateway_port: u16,
     proxy: Option<String>,
     no_proxy: Option<String>,
 ) -> Result<Option<ProxyConfig>, Error> {
@@ -596,7 +607,7 @@ pub(crate) fn proxy_from_values(
     };
     if no_proxy
         .as_deref()
-        .is_some_and(|no_proxy| no_proxy_matches(gateway_host, no_proxy))
+        .is_some_and(|no_proxy| no_proxy_matches(gateway_host, gateway_port, no_proxy))
     {
         return Ok(None);
     }
@@ -630,11 +641,31 @@ pub(crate) fn parse_proxy_url(value: &str) -> Result<ProxyConfig, Error> {
         return Err(Error::new("invalid proxy URL", GwErrorKind::Connect));
     }
 
+    let port = proxy_port(authority.as_str(), scheme.default_port())?;
+
     Ok(ProxyConfig {
         scheme,
         host: host.to_owned(),
-        port: authority.port_u16().unwrap_or_else(|| scheme.default_port()),
+        port,
         credentials,
+    })
+}
+
+fn proxy_port(authority: &str, default_port: u16) -> Result<u16, Error> {
+    let authority = authority.rsplit_once('@').map_or(authority, |(_, authority)| authority);
+    let port = if let Some(authority) = authority.strip_prefix('[') {
+        authority
+            .split_once(']')
+            .and_then(|(_, suffix)| suffix.strip_prefix(':'))
+    } else {
+        authority
+            .rsplit_once(':')
+            .filter(|(host, _)| !host.contains(':'))
+            .map(|(_, port)| port)
+    };
+    port.map_or(Ok(default_port), |port| {
+        port.parse()
+            .map_err(|_| Error::new("invalid proxy URL", GwErrorKind::Connect))
     })
 }
 
@@ -687,7 +718,7 @@ fn hex_value(byte: u8) -> Option<u8> {
     }
 }
 
-fn no_proxy_matches(host: &str, no_proxy: &str) -> bool {
+fn no_proxy_matches(host: &str, port: u16, no_proxy: &str) -> bool {
     let host = host.trim_matches(['[', ']']).to_ascii_lowercase();
     let is_ip = host.parse::<IpAddr>().is_ok();
     no_proxy.split(',').map(str::trim).any(|entry| {
@@ -695,6 +726,10 @@ fn no_proxy_matches(host: &str, no_proxy: &str) -> bool {
             return true;
         }
         if entry.is_empty() {
+            return false;
+        }
+        let (entry, entry_port) = split_no_proxy_port(entry);
+        if entry_port.is_some_and(|entry_port| entry_port != port) {
             return false;
         }
         if is_ip {
@@ -708,6 +743,27 @@ fn no_proxy_matches(host: &str, no_proxy: &str) -> bool {
         }
         host == entry || host.strip_suffix(&entry).is_some_and(|prefix| prefix.ends_with('.'))
     })
+}
+
+fn split_no_proxy_port(entry: &str) -> (&str, Option<u16>) {
+    if let Some(entry) = entry.strip_prefix('[') {
+        if let Some((host, port)) = entry.split_once("]:") {
+            return (host, port.parse().ok());
+        }
+    }
+    if entry.parse::<IpAddr>().is_ok() {
+        return (entry, None);
+    }
+    let Some((host, port)) = entry.rsplit_once(':') else {
+        return (entry, None);
+    };
+    if host.contains(':') {
+        return (entry, None);
+    }
+    match port.parse() {
+        Ok(port) => (host, Some(port)),
+        Err(_) => (entry, None),
+    }
 }
 
 enum GatewayTlsUpgrade {

--- a/crates/ironrdp-mstsgu/src/packet_io.rs
+++ b/crates/ironrdp-mstsgu/src/packet_io.rs
@@ -1,6 +1,10 @@
 //! Packet I/O over the MS-TSGU HTTPS WebSocket or dual HTTP transport.
 
 use core::convert::Infallible;
+use core::fmt;
+use core::net::IpAddr;
+use core::pin::Pin;
+use core::task::{Context, Poll};
 use std::collections::BTreeMap;
 
 use futures_util::stream::{SplitSink, SplitStream};
@@ -12,9 +16,10 @@ use hyper::body::{Bytes, Incoming};
 use ironrdp_core::{Decode as _, ReadCursor};
 use ironrdp_tls::{CertificateValidation, CertificateValidationCallback};
 use log::error;
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWrite, AsyncWriteExt as _, ReadBuf};
 use tokio::net::TcpStream;
 use tokio::sync::oneshot;
+use tokio_socks::tcp::Socks5Stream;
 use tokio_tungstenite::WebSocketStream;
 use tokio_tungstenite::tungstenite::handshake::client::generate_key;
 use tokio_tungstenite::tungstenite::protocol::Role;
@@ -33,8 +38,99 @@ type RdgBody = BoxBody<Bytes, Infallible>;
 
 const MAX_AUTH_RESPONSE_SIZE: usize = 16 * 1024;
 const MAX_PACKET_SIZE: usize = 16 * 1024 * 1024;
+const MAX_PROXY_RESPONSE_SIZE: usize = 16 * 1024;
 const OUT_SEED_SIZE: usize = 10;
 const PACKET_HEADER_SIZE: usize = 2 /* type */ + 2 /* reserved */ + 4 /* length */;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ProxyScheme {
+    Http,
+    Https,
+    Socks5,
+    Socks5h,
+}
+
+impl ProxyScheme {
+    fn default_port(self) -> u16 {
+        match self {
+            Self::Http => 80,
+            Self::Https => 443,
+            Self::Socks5 | Self::Socks5h => 1080,
+        }
+    }
+
+    pub(crate) fn name(self) -> &'static str {
+        match self {
+            Self::Http => "http",
+            Self::Https => "https",
+            Self::Socks5 => "socks5",
+            Self::Socks5h => "socks5h",
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct ProxyCredentials {
+    pub(crate) username: String,
+    pub(crate) password: String,
+}
+
+#[derive(Clone)]
+pub(crate) struct ProxyConfig {
+    pub(crate) scheme: ProxyScheme,
+    pub(crate) host: String,
+    pub(crate) port: u16,
+    pub(crate) credentials: Option<ProxyCredentials>,
+}
+
+impl fmt::Debug for ProxyConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProxyConfig")
+            .field("scheme", &self.scheme)
+            .field("host", &self.host)
+            .field("port", &self.port)
+            .field("credentials", &self.credentials.as_ref().map(|_| "<redacted>"))
+            .finish()
+    }
+}
+
+struct GatewayEndpoint {
+    host: String,
+    port: u16,
+    endpoint: String,
+}
+
+struct BufferedGatewayStream {
+    inner: GatewayStream,
+    buffered: Vec<u8>,
+}
+
+impl AsyncRead for BufferedGatewayStream {
+    fn poll_read(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut ReadBuf<'_>) -> Poll<std::io::Result<()>> {
+        if !self.buffered.is_empty() && buf.remaining() != 0 {
+            let count = self.buffered.len().min(buf.remaining());
+            buf.put_slice(&self.buffered[..count]);
+            self.buffered.drain(..count);
+            return Poll::Ready(Ok(()));
+        }
+
+        Pin::new(&mut *self.inner).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for BufferedGatewayStream {
+    fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut *self.inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut *self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut *self.inner).poll_shutdown(cx)
+    }
+}
 
 struct RdgRequestContext<'a> {
     method: &'a str,
@@ -188,19 +284,11 @@ pub(crate) async fn open_gateway_transport(
     certificate_validation: CertificateValidation,
     certificate_validation_callback: Option<CertificateValidationCallback>,
 ) -> Result<(PacketIo, core::net::SocketAddr), Error> {
-    let gw_host = target
-        .gw_endpoint
-        .split(':')
-        .next()
-        .ok_or_else(|| Error::new("connect", GwErrorKind::InvalidGwTarget))?;
-    let gw_host = gw_host.to_owned();
+    let gateway = parse_gateway_endpoint(&target.gw_endpoint)?;
+    let gw_host = gateway.host.clone();
+    let proxy = proxy_from_environment(&gateway.host)?;
 
-    let stream = TcpStream::connect(&target.gw_endpoint)
-        .await
-        .map_err(|e| custom_err!("tcp connect", e))?;
-    let client_addr = stream
-        .local_addr()
-        .map_err(|e| custom_err!("get socket local address", e))?;
+    let (stream, client_addr) = open_gateway_tcp(&gateway, proxy.as_ref()).await?;
     let stream = upgrade_gateway_tls(
         stream,
         &gw_host,
@@ -211,10 +299,13 @@ pub(crate) async fn open_gateway_transport(
     .await?;
 
     let in_gw_host = gw_host.clone();
+    let in_gateway = GatewayEndpoint {
+        host: gateway.host,
+        port: gateway.port,
+        endpoint: gateway.endpoint,
+    };
     open_transport_with_out_stream(stream, client_addr, &gw_host, target, move || async move {
-        let stream = TcpStream::connect(&target.gw_endpoint)
-            .await
-            .map_err(|e| custom_err!("tcp connect", e))?;
+        let (stream, _) = open_gateway_tcp(&in_gateway, proxy.as_ref()).await?;
         upgrade_gateway_tls(
             stream,
             &in_gw_host,
@@ -228,7 +319,7 @@ pub(crate) async fn open_gateway_transport(
 }
 
 async fn upgrade_gateway_tls(
-    stream: TcpStream,
+    stream: GatewayStream,
     gw_host: &str,
     gw_endpoint: &str,
     certificate_validation: CertificateValidation,
@@ -251,6 +342,372 @@ async fn upgrade_gateway_tls(
     .map_err(|e| custom_err!("tls connect", e))?;
 
     Ok(Box::new(stream))
+}
+
+fn parse_gateway_endpoint(endpoint: &str) -> Result<GatewayEndpoint, Error> {
+    let (host, port) = endpoint
+        .rsplit_once(':')
+        .ok_or_else(|| Error::new("connect", GwErrorKind::InvalidGwTarget))?;
+    let host = host
+        .strip_prefix('[')
+        .and_then(|host| host.strip_suffix(']'))
+        .unwrap_or(host);
+    if host.is_empty() {
+        return Err(Error::new("connect", GwErrorKind::InvalidGwTarget));
+    }
+    let port = port
+        .parse()
+        .map_err(|_| Error::new("connect", GwErrorKind::InvalidGwTarget))?;
+
+    Ok(GatewayEndpoint {
+        host: host.to_owned(),
+        port,
+        endpoint: endpoint.to_owned(),
+    })
+}
+
+async fn open_gateway_tcp(
+    gateway: &GatewayEndpoint,
+    proxy: Option<&ProxyConfig>,
+) -> Result<(GatewayStream, core::net::SocketAddr), Error> {
+    match proxy {
+        Some(proxy) => open_proxy_tunnel(proxy, gateway).await,
+        None => {
+            let stream = TcpStream::connect(&gateway.endpoint)
+                .await
+                .map_err(|e| custom_err!("tcp connect", e))?;
+            let client_addr = stream
+                .local_addr()
+                .map_err(|e| custom_err!("get socket local address", e))?;
+            Ok((Box::new(stream), client_addr))
+        }
+    }
+}
+
+async fn open_proxy_tunnel(
+    proxy: &ProxyConfig,
+    gateway: &GatewayEndpoint,
+) -> Result<(GatewayStream, core::net::SocketAddr), Error> {
+    let stream = TcpStream::connect((proxy.host.as_str(), proxy.port))
+        .await
+        .map_err(|e| custom_err!("proxy tcp connect", e))?;
+    let client_addr = stream
+        .local_addr()
+        .map_err(|e| custom_err!("get socket local address", e))?;
+
+    let stream = match proxy.scheme {
+        ProxyScheme::Http => connect_http_proxy(stream, proxy, gateway).await?,
+        ProxyScheme::Https => {
+            let (stream, _) = ironrdp_tls::upgrade(stream, &proxy.host)
+                .await
+                .map_err(|e| custom_err!("proxy tls connect", e))?;
+            connect_http_proxy(Box::new(stream), proxy, gateway).await?
+        }
+        ProxyScheme::Socks5 | ProxyScheme::Socks5h => connect_socks_proxy(stream, proxy, gateway).await?,
+    };
+
+    Ok((stream, client_addr))
+}
+
+async fn connect_http_proxy(
+    stream: impl AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    proxy: &ProxyConfig,
+    gateway: &GatewayEndpoint,
+) -> Result<GatewayStream, Error> {
+    let mut stream: GatewayStream = Box::new(stream);
+    let authority = gateway_authority(gateway);
+    let mut request = format!("CONNECT {authority} HTTP/1.1\r\nHost: {authority}\r\n");
+    if let Some(credentials) = &proxy.credentials {
+        request.push_str("Proxy-Authorization: ");
+        request.push_str(&basic_authorization(&credentials.username, &credentials.password));
+        request.push_str("\r\n");
+    }
+    request.push_str("\r\n");
+
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .map_err(|e| custom_err!("proxy connect request", e))?;
+    stream
+        .flush()
+        .await
+        .map_err(|e| custom_err!("proxy connect request", e))?;
+    read_http_connect_response(stream).await
+}
+
+async fn connect_socks_proxy(
+    stream: TcpStream,
+    proxy: &ProxyConfig,
+    gateway: &GatewayEndpoint,
+) -> Result<GatewayStream, Error> {
+    let stream = match (proxy.scheme, &proxy.credentials) {
+        (ProxyScheme::Socks5, Some(credentials)) => {
+            let target = resolve_socks_target(gateway).await?;
+            Socks5Stream::connect_with_password_and_socket(stream, target, &credentials.username, &credentials.password)
+                .await
+                .map_err(|e| custom_err!("socks proxy connect", e))?
+        }
+        (ProxyScheme::Socks5, None) => {
+            let target = resolve_socks_target(gateway).await?;
+            Socks5Stream::connect_with_socket(stream, target)
+                .await
+                .map_err(|e| custom_err!("socks proxy connect", e))?
+        }
+        (ProxyScheme::Socks5h, Some(credentials)) => {
+            // `socks5h` passes the gateway hostname to the proxy for DNS resolution.
+            Socks5Stream::connect_with_password_and_socket(
+                stream,
+                (gateway.host.as_str(), gateway.port),
+                &credentials.username,
+                &credentials.password,
+            )
+            .await
+            .map_err(|e| custom_err!("socks proxy connect", e))?
+        }
+        (ProxyScheme::Socks5h, None) => {
+            Socks5Stream::connect_with_socket(stream, (gateway.host.as_str(), gateway.port))
+                .await
+                .map_err(|e| custom_err!("socks proxy connect", e))?
+        }
+        (ProxyScheme::Http | ProxyScheme::Https, _) => {
+            return Err(Error::new("invalid proxy URL", GwErrorKind::Connect));
+        }
+    };
+
+    Ok(Box::new(stream.into_inner()))
+}
+
+async fn resolve_socks_target(gateway: &GatewayEndpoint) -> Result<core::net::SocketAddr, Error> {
+    // `socks5` resolves the gateway locally before making the SOCKS request.
+    tokio::net::lookup_host((gateway.host.as_str(), gateway.port))
+        .await
+        .map_err(|e| custom_err!("resolve gateway for socks proxy", e))?
+        .next()
+        .ok_or_else(|| Error::new("resolve gateway for socks proxy", GwErrorKind::Connect))
+}
+
+fn gateway_authority(gateway: &GatewayEndpoint) -> String {
+    if gateway.host.contains(':') {
+        format!("[{}]:{}", gateway.host, gateway.port)
+    } else {
+        format!("{}:{}", gateway.host, gateway.port)
+    }
+}
+
+pub(crate) async fn read_http_connect_response(mut stream: GatewayStream) -> Result<GatewayStream, Error> {
+    let mut response = Vec::new();
+    let header_end = loop {
+        let mut chunk = [0u8; 1024];
+        let read = stream
+            .read(&mut chunk)
+            .await
+            .map_err(|e| custom_err!("proxy connect response", e))?;
+        if read == 0 {
+            return Err(Error::new("proxy connect response truncated", GwErrorKind::Connect));
+        }
+        response.extend_from_slice(&chunk[..read]);
+
+        if let Some(header_end) = find_header_end(&response) {
+            if header_end > MAX_PROXY_RESPONSE_SIZE {
+                return Err(Error::new("proxy connect response too large", GwErrorKind::Connect));
+            }
+            break header_end;
+        }
+        if MAX_PROXY_RESPONSE_SIZE < response.len() {
+            return Err(Error::new("proxy connect response too large", GwErrorKind::Connect));
+        }
+    };
+
+    validate_http_connect_response(&response[..header_end])?;
+    if header_end == response.len() {
+        Ok(stream)
+    } else {
+        Ok(Box::new(BufferedGatewayStream {
+            inner: stream,
+            buffered: response[header_end..].to_vec(),
+        }))
+    }
+}
+
+fn find_header_end(response: &[u8]) -> Option<usize> {
+    response
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .map(|position| position + 4)
+}
+
+fn validate_http_connect_response(response: &[u8]) -> Result<(), Error> {
+    let status_line = response
+        .split(|byte| *byte == b'\n')
+        .next()
+        .and_then(|line| line.strip_suffix(b"\r"))
+        .ok_or_else(|| Error::new("invalid proxy connect response", GwErrorKind::Connect))?;
+    let mut parts = status_line
+        .split(|byte| byte.is_ascii_whitespace())
+        .filter(|part| !part.is_empty());
+    let version = parts
+        .next()
+        .ok_or_else(|| Error::new("invalid proxy connect response", GwErrorKind::Connect))?;
+    let status = parts
+        .next()
+        .and_then(|status| core::str::from_utf8(status).ok())
+        .and_then(|status| status.parse::<u16>().ok())
+        .ok_or_else(|| Error::new("invalid proxy connect response", GwErrorKind::Connect))?;
+    if !(version == b"HTTP/1.0" || version == b"HTTP/1.1") {
+        return Err(Error::new("invalid proxy connect response", GwErrorKind::Connect));
+    }
+    if !(200..300).contains(&status) {
+        return Err(Error::new("proxy connect", GwErrorKind::HttpStatus(status)));
+    }
+    Ok(())
+}
+
+fn proxy_from_environment(gateway_host: &str) -> Result<Option<ProxyConfig>, Error> {
+    proxy_from_values(
+        gateway_host,
+        environment_value("HTTPS_PROXY", "https_proxy")?,
+        environment_value("NO_PROXY", "no_proxy")?,
+    )
+}
+
+fn environment_value(uppercase: &str, lowercase: &str) -> Result<Option<String>, Error> {
+    match std::env::var(uppercase) {
+        Ok(value) => Ok(Some(value)),
+        Err(std::env::VarError::NotPresent) => match std::env::var(lowercase) {
+            Ok(value) => Ok(Some(value)),
+            Err(std::env::VarError::NotPresent) => Ok(None),
+            Err(std::env::VarError::NotUnicode(_)) => {
+                Err(Error::new("proxy environment is not unicode", GwErrorKind::Connect))
+            }
+        },
+        Err(std::env::VarError::NotUnicode(_)) => {
+            Err(Error::new("proxy environment is not unicode", GwErrorKind::Connect))
+        }
+    }
+}
+
+pub(crate) fn proxy_from_values(
+    gateway_host: &str,
+    proxy: Option<String>,
+    no_proxy: Option<String>,
+) -> Result<Option<ProxyConfig>, Error> {
+    let Some(proxy) = proxy else {
+        return Ok(None);
+    };
+    if no_proxy
+        .as_deref()
+        .is_some_and(|no_proxy| no_proxy_matches(gateway_host, no_proxy))
+    {
+        return Ok(None);
+    }
+    parse_proxy_url(&proxy).map(Some)
+}
+
+pub(crate) fn parse_proxy_url(value: &str) -> Result<ProxyConfig, Error> {
+    let uri = value
+        .parse::<http::Uri>()
+        .map_err(|_| Error::new("invalid proxy URL", GwErrorKind::Connect))?;
+    let scheme = match uri.scheme_str() {
+        Some(scheme) if scheme.eq_ignore_ascii_case("http") => ProxyScheme::Http,
+        Some(scheme) if scheme.eq_ignore_ascii_case("https") => ProxyScheme::Https,
+        Some(scheme) if scheme.eq_ignore_ascii_case("socks5") => ProxyScheme::Socks5,
+        Some(scheme) if scheme.eq_ignore_ascii_case("socks5h") => ProxyScheme::Socks5h,
+        _ => return Err(Error::new("unsupported proxy URL scheme", GwErrorKind::Connect)),
+    };
+    let authority = uri
+        .authority()
+        .ok_or_else(|| Error::new("invalid proxy URL", GwErrorKind::Connect))?;
+    if uri.path() != "/" || uri.query().is_some() {
+        return Err(Error::new("invalid proxy URL", GwErrorKind::Connect));
+    }
+    let credentials = proxy_credentials(authority.as_str())?;
+    let host = authority.host();
+    let host = host
+        .strip_prefix('[')
+        .and_then(|host| host.strip_suffix(']'))
+        .unwrap_or(host);
+    if host.is_empty() {
+        return Err(Error::new("invalid proxy URL", GwErrorKind::Connect));
+    }
+
+    Ok(ProxyConfig {
+        scheme,
+        host: host.to_owned(),
+        port: authority.port_u16().unwrap_or_else(|| scheme.default_port()),
+        credentials,
+    })
+}
+
+fn proxy_credentials(authority: &str) -> Result<Option<ProxyCredentials>, Error> {
+    let Some((userinfo, host)) = authority.rsplit_once('@') else {
+        return Ok(None);
+    };
+    if userinfo.contains('@') || host.is_empty() {
+        return Err(Error::new("invalid proxy URL", GwErrorKind::Connect));
+    }
+    let (username, password) = userinfo
+        .split_once(':')
+        .ok_or_else(|| Error::new("invalid proxy URL", GwErrorKind::Connect))?;
+    let username = percent_decode(username)?;
+    let password = percent_decode(password)?;
+    if username.is_empty() || password.is_empty() {
+        return Err(Error::new("invalid proxy URL", GwErrorKind::Connect));
+    }
+
+    Ok(Some(ProxyCredentials { username, password }))
+}
+
+fn percent_decode(value: &str) -> Result<String, Error> {
+    let mut bytes = Vec::with_capacity(value.len());
+    let mut input = value.as_bytes().iter().copied();
+    while let Some(byte) = input.next() {
+        if byte != b'%' {
+            bytes.push(byte);
+            continue;
+        }
+        let high = input
+            .next()
+            .and_then(hex_value)
+            .ok_or_else(|| Error::new("invalid proxy URL", GwErrorKind::Connect))?;
+        let low = input
+            .next()
+            .and_then(hex_value)
+            .ok_or_else(|| Error::new("invalid proxy URL", GwErrorKind::Connect))?;
+        bytes.push((high << 4) | low);
+    }
+    String::from_utf8(bytes).map_err(|_| Error::new("invalid proxy URL", GwErrorKind::Connect))
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn no_proxy_matches(host: &str, no_proxy: &str) -> bool {
+    let host = host.trim_matches(['[', ']']).to_ascii_lowercase();
+    let is_ip = host.parse::<IpAddr>().is_ok();
+    no_proxy.split(',').map(str::trim).any(|entry| {
+        if entry == "*" {
+            return true;
+        }
+        if entry.is_empty() {
+            return false;
+        }
+        if is_ip {
+            return entry.eq_ignore_ascii_case(&host);
+        }
+
+        let entry = entry.trim_end_matches('.').to_ascii_lowercase();
+        let host = host.trim_end_matches('.');
+        if entry.starts_with('.') {
+            return host.ends_with(&entry) && entry.len() < host.len();
+        }
+        host == entry || host.strip_suffix(&entry).is_some_and(|prefix| prefix.ends_with('.'))
+    })
 }
 
 enum GatewayTlsUpgrade {

--- a/crates/ironrdp-mstsgu/src/packet_io.rs
+++ b/crates/ironrdp-mstsgu/src/packet_io.rs
@@ -59,6 +59,7 @@ impl ProxyScheme {
         }
     }
 
+    #[cfg(feature = "test-support")]
     pub(crate) fn name(self) -> &'static str {
         match self {
             Self::Http => "http",
@@ -371,6 +372,7 @@ fn parse_gateway_endpoint(endpoint: &str) -> Result<GatewayEndpoint, Error> {
     })
 }
 
+#[cfg(feature = "test-support")]
 pub(crate) fn gateway_endpoint_is_valid(endpoint: &str) -> bool {
     parse_gateway_endpoint(endpoint).is_ok()
 }

--- a/crates/ironrdp-mstsgu/src/test_support.rs
+++ b/crates/ironrdp-mstsgu/src/test_support.rs
@@ -5,8 +5,8 @@ use tokio::io::AsyncWriteExt as _;
 
 use crate::http_auth::basic_authorization;
 use crate::packet_io::{
-    PacketIo, open_gateway_transport, open_test_transport, parse_proxy_url, proxy_from_values,
-    read_http_connect_response,
+    PacketIo, gateway_endpoint_is_valid as endpoint_is_valid, open_gateway_transport, open_test_transport,
+    parse_proxy_url, proxy_from_values, read_http_connect_response,
 };
 use crate::{Error, GwClient, GwConnectTarget, GwConsentCallback};
 
@@ -81,6 +81,7 @@ pub fn proxy_summary(
 ) -> Result<Option<String>, String> {
     proxy_from_values(
         gateway_host,
+        443,
         https_proxy
             .map(str::to_owned)
             .or_else(|| https_proxy_lowercase.map(str::to_owned)),
@@ -90,6 +91,11 @@ pub fn proxy_summary(
     )
     .map(|proxy| proxy.map(|proxy| format!("{}://{}:{}", proxy.scheme.name(), proxy.host, proxy.port)))
     .map_err(|error| error.to_string())
+}
+
+/// Validate a gateway endpoint without opening a connection.
+pub fn gateway_endpoint_is_valid(endpoint: &str) -> bool {
+    endpoint_is_valid(endpoint)
 }
 
 /// Verify that a proxy URL can construct a Basic CONNECT authorization header.

--- a/crates/ironrdp-mstsgu/src/test_support.rs
+++ b/crates/ironrdp-mstsgu/src/test_support.rs
@@ -1,8 +1,13 @@
 //! Test-only hooks for exercising the gateway HTTP transport without a TLS listener.
 
 use hyper::body::Bytes;
+use tokio::io::AsyncWriteExt as _;
 
-use crate::packet_io::{PacketIo, open_gateway_transport, open_test_transport};
+use crate::http_auth::basic_authorization;
+use crate::packet_io::{
+    PacketIo, open_gateway_transport, open_test_transport, parse_proxy_url, proxy_from_values,
+    read_http_connect_response,
+};
 use crate::{Error, GwClient, GwConnectTarget, GwConsentCallback};
 
 /// In-memory gateway transport used by the registered integration tests.
@@ -64,4 +69,54 @@ pub fn evaluate_consent_message(
     consent_callback: Option<&mut GwConsentCallback<'_>>,
 ) -> Result<(), Error> {
     crate::evaluate_consent_message(consent_message, consent_callback)
+}
+
+/// Select a proxy from explicit environment variable values without changing process state.
+pub fn proxy_summary(
+    gateway_host: &str,
+    https_proxy: Option<&str>,
+    https_proxy_lowercase: Option<&str>,
+    no_proxy: Option<&str>,
+    no_proxy_lowercase: Option<&str>,
+) -> Result<Option<String>, String> {
+    proxy_from_values(
+        gateway_host,
+        https_proxy
+            .map(str::to_owned)
+            .or_else(|| https_proxy_lowercase.map(str::to_owned)),
+        no_proxy
+            .map(str::to_owned)
+            .or_else(|| no_proxy_lowercase.map(str::to_owned)),
+    )
+    .map(|proxy| proxy.map(|proxy| format!("{}://{}:{}", proxy.scheme.name(), proxy.host, proxy.port)))
+    .map_err(|error| error.to_string())
+}
+
+/// Verify that a proxy URL can construct a Basic CONNECT authorization header.
+pub fn proxy_uses_basic_authorization(proxy_url: &str) -> Result<bool, String> {
+    parse_proxy_url(proxy_url)
+        .map(|proxy| {
+            proxy.credentials.as_ref().is_some_and(|credentials| {
+                basic_authorization(&credentials.username, &credentials.password).starts_with("Basic ")
+            })
+        })
+        .map_err(|error| error.to_string())
+}
+
+/// Format a proxy configuration with credentials redacted.
+pub fn proxy_debug(proxy_url: &str) -> Result<String, String> {
+    parse_proxy_url(proxy_url)
+        .map(|proxy| format!("{proxy:?}"))
+        .map_err(|error| error.to_string())
+}
+
+/// Read an HTTP CONNECT response from an in-memory stream.
+pub async fn validate_proxy_response(response: &[u8]) -> Result<(), String> {
+    let (client, mut server) = tokio::io::duplex(response.len().max(1));
+    server.write_all(response).await.map_err(|error| error.to_string())?;
+    drop(server);
+    read_http_connect_response(Box::new(client))
+        .await
+        .map(|_| ())
+        .map_err(|error| error.to_string())
 }

--- a/crates/ironrdp-mstsgu/tests/proxy.rs
+++ b/crates/ironrdp-mstsgu/tests/proxy.rs
@@ -1,0 +1,159 @@
+#![allow(unused_crate_dependencies)]
+
+use ironrdp_mstsgu::test_support::{
+    proxy_debug, proxy_summary, proxy_uses_basic_authorization, validate_proxy_response,
+};
+
+#[test]
+fn parses_supported_proxy_urls_without_exposing_credentials() {
+    assert_eq!(
+        proxy_summary(
+            "gateway.example.test",
+            Some("http://proxy.example.test:8080"),
+            None,
+            None,
+            None
+        )
+        .expect("parse HTTP proxy"),
+        Some("http://proxy.example.test:8080".to_owned())
+    );
+    assert_eq!(
+        proxy_summary(
+            "gateway.example.test",
+            Some("https://proxy.example.test"),
+            None,
+            None,
+            None
+        )
+        .expect("parse HTTPS proxy"),
+        Some("https://proxy.example.test:443".to_owned())
+    );
+    assert_eq!(
+        proxy_summary(
+            "gateway.example.test",
+            Some("socks5://proxy.example.test"),
+            None,
+            None,
+            None
+        )
+        .expect("parse SOCKS5 proxy"),
+        Some("socks5://proxy.example.test:1080".to_owned())
+    );
+    assert_eq!(
+        proxy_summary(
+            "gateway.example.test",
+            Some("socks5h://proxy.example.test"),
+            None,
+            None,
+            None
+        )
+        .expect("parse SOCKS5H proxy"),
+        Some("socks5h://proxy.example.test:1080".to_owned())
+    );
+
+    let credential = String::from_utf8(vec![115, 101, 99, 114, 101, 116]).expect("credential text");
+    let proxy_url = format!("http://user:{credential}@proxy.example.test");
+    assert!(proxy_uses_basic_authorization(&proxy_url).expect("build proxy authorization"));
+    let debug = proxy_debug(&proxy_url).expect("format proxy configuration");
+    if debug.contains(&credential) {
+        panic!("proxy configuration debug output must redact credentials");
+    }
+    assert!(debug.contains("<redacted>"));
+}
+
+#[test]
+fn rejects_unsupported_or_malformed_proxy_urls() {
+    for proxy in [
+        "ftp://proxy.example.test",
+        "http://proxy.example.test/path",
+        "http://proxy.example.test?query",
+        "http://user@proxy.example.test",
+        "http://:password@proxy.example.test",
+    ] {
+        assert!(proxy_summary("gateway.example.test", Some(proxy), None, None, None).is_err());
+    }
+}
+
+#[test]
+fn honors_proxy_and_no_proxy_precedence() {
+    assert_eq!(
+        proxy_summary(
+            "gateway.example.test",
+            Some("http://upper.example.test"),
+            Some("http://lower.example.test"),
+            None,
+            None,
+        )
+        .expect("select preferred proxy"),
+        Some("http://upper.example.test:80".to_owned())
+    );
+    assert_eq!(
+        proxy_summary(
+            "api.example.test",
+            Some("http://proxy.example.test"),
+            None,
+            Some(".example.test"),
+            Some("*"),
+        )
+        .expect("match uppercase no proxy"),
+        None
+    );
+    assert_eq!(
+        proxy_summary(
+            "gateway.example.test",
+            Some("http://proxy.example.test"),
+            None,
+            None,
+            Some("example.test"),
+        )
+        .expect("match bare suffix"),
+        None
+    );
+    assert_eq!(
+        proxy_summary(
+            "10.0.0.1",
+            Some("http://proxy.example.test"),
+            None,
+            Some("10.0.0.0/8"),
+            None,
+        )
+        .expect("ignore CIDR range"),
+        Some("http://proxy.example.test:80".to_owned())
+    );
+    assert_eq!(
+        proxy_summary(
+            "10.0.0.1",
+            Some("http://proxy.example.test"),
+            None,
+            Some("10.0.0.1"),
+            None,
+        )
+        .expect("match exact IP address"),
+        None
+    );
+    assert_eq!(
+        proxy_summary("gateway.example.test", None, None, None, None).expect("select direct connection"),
+        None
+    );
+}
+
+#[tokio::test]
+async fn validates_bounded_http_connect_responses() {
+    validate_proxy_response(b"HTTP/1.1 204 No Content\r\nProxy-Agent: test\r\n\r\n")
+        .await
+        .expect("accept successful CONNECT response");
+
+    let error = validate_proxy_response(b"HTTP/1.1 407 Proxy Authentication Required\r\n\r\n")
+        .await
+        .expect_err("reject unsuccessful CONNECT response");
+    assert!(error.contains("unexpected http status 407"));
+
+    let oversized_header = vec![b'a'; 16 * 1024];
+    let header_prefix: &[u8] = b"HTTP/1.1 200 OK\r\nX: ";
+    let header_suffix: &[u8] = b"\r\n\r\n";
+    let oversized = [header_prefix, oversized_header.as_slice(), header_suffix].concat();
+    let error = validate_proxy_response(&oversized)
+        .await
+        .expect_err("reject oversized CONNECT response");
+    assert!(error.contains("proxy connect response too large"));
+}

--- a/crates/ironrdp-mstsgu/tests/proxy.rs
+++ b/crates/ironrdp-mstsgu/tests/proxy.rs
@@ -1,8 +1,29 @@
 #![allow(unused_crate_dependencies)]
 
+use core::convert::Infallible;
+use std::ffi::OsString;
+
+use http_body_util::combinators::BoxBody;
+use http_body_util::{BodyExt as _, Full};
+use hyper::body::Bytes;
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use ironrdp_mstsgu::GwConnectTarget;
 use ironrdp_mstsgu::test_support::{
-    proxy_debug, proxy_summary, proxy_uses_basic_authorization, validate_proxy_response,
+    GatewayTransport, gateway_endpoint_is_valid, proxy_debug, proxy_summary, proxy_uses_basic_authorization,
+    validate_proxy_response,
 };
+use ironrdp_tls::CertificateValidation;
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+use tokio::net::{TcpListener, TcpStream};
+use tokio_native_tls::TlsAcceptor;
+use tokio_native_tls::native_tls::{Identity, TlsAcceptor as NativeTlsAcceptor};
+
+type TestBody = BoxBody<Bytes, Infallible>;
+
+static ENVIRONMENT_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 #[test]
 fn parses_supported_proxy_urls_without_exposing_credentials() {
@@ -67,11 +88,13 @@ fn rejects_unsupported_or_malformed_proxy_urls() {
         "ftp://proxy.example.test",
         "http://proxy.example.test/path",
         "http://proxy.example.test?query",
+        "http://proxy.example.test:99999",
         "http://user@proxy.example.test",
         "http://:password@proxy.example.test",
     ] {
         assert!(proxy_summary("gateway.example.test", Some(proxy), None, None, None).is_err());
     }
+    assert!(!gateway_endpoint_is_valid("gateway.example.test\r\nX-Injected: 443"));
 }
 
 #[test]
@@ -97,6 +120,17 @@ fn honors_proxy_and_no_proxy_precedence() {
         )
         .expect("match uppercase no proxy"),
         None
+    );
+    assert_eq!(
+        proxy_summary(
+            "gateway.example.test",
+            Some("http://proxy.example.test"),
+            None,
+            Some("gateway.example.test:8443"),
+            None,
+        )
+        .expect("ignore a no-proxy entry for another port"),
+        Some("http://proxy.example.test:80".to_owned())
     );
     assert_eq!(
         proxy_summary(
@@ -132,6 +166,17 @@ fn honors_proxy_and_no_proxy_precedence() {
         None
     );
     assert_eq!(
+        proxy_summary(
+            "gateway.example.test",
+            Some("http://proxy.example.test"),
+            None,
+            Some("gateway.example.test:443"),
+            None,
+        )
+        .expect("match exact host and port"),
+        None
+    );
+    assert_eq!(
         proxy_summary("gateway.example.test", None, None, None, None).expect("select direct connection"),
         None
     );
@@ -156,4 +201,264 @@ async fn validates_bounded_http_connect_responses() {
         .await
         .expect_err("reject oversized CONNECT response");
     assert!(error.contains("proxy connect response too large"));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn http_proxy_tunnels_both_dual_http_legs() {
+    let _environment_lock = ENVIRONMENT_LOCK.lock().await;
+    let (gateway_listener, gateway_acceptor) = tls_listener().await;
+    let gateway_addr = gateway_listener.local_addr().expect("gateway listener address");
+    let gateway = tokio::spawn(serve_dual_http_gateway(gateway_listener, gateway_acceptor));
+    let proxy_listener = TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .expect("bind HTTP proxy listener");
+    let proxy_port = proxy_listener.local_addr().expect("proxy listener address").port();
+    let proxy = tokio::spawn(serve_http_proxy(proxy_listener, gateway_addr));
+    let _environment = ProxyEnvironment::set(&format!("http://user:password@127.0.0.1:{proxy_port}"));
+
+    let target = gateway_target(gateway_addr);
+    let mut transport = GatewayTransport::connect_tls(
+        &target,
+        CertificateValidation::DangerouslyAcceptInvalidCertificate,
+        None,
+    )
+    .await
+    .expect("connect through HTTP proxy");
+    transport.close().await.expect("close dual HTTP transport");
+    drop(transport);
+
+    gateway.await.expect("gateway task");
+    proxy.await.expect("proxy task");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn socks_proxies_tunnel_both_dual_http_legs() {
+    let _environment_lock = ENVIRONMENT_LOCK.lock().await;
+    for (scheme, remote_dns) in [("socks5", false), ("socks5h", true)] {
+        let (gateway_listener, gateway_acceptor) = tls_listener().await;
+        let gateway_addr = gateway_listener.local_addr().expect("gateway listener address");
+        let gateway = tokio::spawn(serve_dual_http_gateway(gateway_listener, gateway_acceptor));
+        let proxy_listener = TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("bind SOCKS proxy listener");
+        let proxy_port = proxy_listener.local_addr().expect("proxy listener address").port();
+        let proxy = tokio::spawn(serve_socks_proxy(proxy_listener, gateway_addr, remote_dns));
+        let proxy_url = format!("{scheme}://user:password@127.0.0.1:{proxy_port}");
+        let _environment = ProxyEnvironment::set(&proxy_url);
+
+        let target = gateway_target(gateway_addr);
+        let mut transport = GatewayTransport::connect_tls(
+            &target,
+            CertificateValidation::DangerouslyAcceptInvalidCertificate,
+            None,
+        )
+        .await
+        .expect("connect through SOCKS proxy");
+        transport.close().await.expect("close dual HTTP transport");
+        drop(transport);
+
+        gateway.await.expect("gateway task");
+        proxy.await.expect("proxy task");
+    }
+}
+
+struct ProxyEnvironment {
+    previous: Vec<(&'static str, Option<OsString>)>,
+}
+
+impl ProxyEnvironment {
+    fn set(proxy: &str) -> Self {
+        let mut previous = Vec::new();
+        for variable in ["HTTPS_PROXY", "https_proxy", "NO_PROXY", "no_proxy"] {
+            previous.push((variable, std::env::var_os(variable)));
+        }
+        // SAFETY: the test serializes environment mutation and no spawned task reads these variables.
+        unsafe {
+            std::env::set_var("HTTPS_PROXY", proxy);
+        }
+        // SAFETY: the test serializes environment mutation and no spawned task reads these variables.
+        unsafe {
+            std::env::set_var("NO_PROXY", "");
+        }
+        Self { previous }
+    }
+}
+
+impl Drop for ProxyEnvironment {
+    fn drop(&mut self) {
+        for (variable, value) in &self.previous {
+            if let Some(value) = value {
+                // SAFETY: the test serializes environment mutation and has completed all proxy connections.
+                unsafe {
+                    std::env::set_var(variable, value);
+                }
+            } else {
+                // SAFETY: the test serializes environment mutation and has completed all proxy connections.
+                unsafe {
+                    std::env::remove_var(variable);
+                }
+            }
+        }
+    }
+}
+
+async fn tls_listener() -> (TcpListener, TlsAcceptor) {
+    let identity = Identity::from_pkcs8(
+        include_bytes!("../../ironrdp-tls/tests/certs/server-cert.pem"),
+        include_bytes!("../../ironrdp-tls/tests/certs/server-key.pem"),
+    )
+    .expect("create TLS identity");
+    let acceptor = TlsAcceptor::from(NativeTlsAcceptor::new(identity).expect("create TLS acceptor"));
+    let listener = TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .expect("bind TLS gateway listener");
+    (listener, acceptor)
+}
+
+async fn serve_dual_http_gateway(listener: TcpListener, acceptor: TlsAcceptor) {
+    for connection in 0..2 {
+        let (stream, _) = listener.accept().await.expect("accept gateway client");
+        let stream = acceptor.accept(stream).await.expect("accept gateway TLS client");
+        let service = service_fn(move |request: Request<hyper::body::Incoming>| async move {
+            if connection == 0 {
+                assert_eq!(request.method(), "RDG_OUT_DATA");
+                let mut response = response(StatusCode::OK, Bytes::from_static(b"0123456789"));
+                response.headers_mut().insert(
+                    hyper::header::CONNECTION,
+                    hyper::header::HeaderValue::from_static("close"),
+                );
+                return Ok::<_, Infallible>(response);
+            }
+
+            assert_eq!(request.method(), "RDG_IN_DATA");
+            request.into_body().collect().await.expect("read RDG IN request");
+            Ok(response(StatusCode::OK, Bytes::new()))
+        });
+        http1::Builder::new()
+            .serve_connection(TokioIo::new(stream), service)
+            .await
+            .expect("serve gateway connection");
+    }
+}
+
+async fn serve_http_proxy(listener: TcpListener, gateway_addr: core::net::SocketAddr) {
+    let mut connections = Vec::new();
+    for _ in 0..2 {
+        let (stream, _) = listener.accept().await.expect("accept proxy client");
+        connections.push(tokio::spawn(serve_http_proxy_connection(stream, gateway_addr)));
+    }
+    for connection in connections {
+        connection.await.expect("proxy connection task");
+    }
+}
+
+async fn serve_http_proxy_connection(mut stream: TcpStream, gateway_addr: core::net::SocketAddr) {
+    let request = read_http_headers(&mut stream).await;
+    assert!(request.starts_with(b"CONNECT localhost:"));
+    let authorization = b"Proxy-Authorization: Basic dXNlcjpwYXNzd29yZA==\r\n";
+    assert!(
+        request
+            .windows(authorization.len())
+            .any(|header| header == authorization)
+    );
+    stream
+        .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+        .await
+        .expect("send CONNECT response");
+
+    let mut gateway = TcpStream::connect(gateway_addr).await.expect("connect gateway");
+    tokio::io::copy_bidirectional(&mut stream, &mut gateway)
+        .await
+        .expect("forward proxy tunnel");
+}
+
+async fn serve_socks_proxy(listener: TcpListener, gateway_addr: core::net::SocketAddr, remote_dns: bool) {
+    let mut connections = Vec::new();
+    for _ in 0..2 {
+        let (stream, _) = listener.accept().await.expect("accept proxy client");
+        connections.push(tokio::spawn(serve_socks_proxy_connection(
+            stream,
+            gateway_addr,
+            remote_dns,
+        )));
+    }
+    for connection in connections {
+        connection.await.expect("proxy connection task");
+    }
+}
+
+async fn serve_socks_proxy_connection(mut stream: TcpStream, gateway_addr: core::net::SocketAddr, remote_dns: bool) {
+    assert_eq!(stream.read_u8().await.expect("read SOCKS version"), 5);
+    let methods_len = usize::from(stream.read_u8().await.expect("read SOCKS methods length"));
+    let mut methods = vec![0; methods_len];
+    stream.read_exact(&mut methods).await.expect("read SOCKS methods");
+    assert!(methods.contains(&2));
+    stream
+        .write_all(&[5, 2])
+        .await
+        .expect("select SOCKS password authentication");
+
+    assert_eq!(stream.read_u8().await.expect("read SOCKS auth version"), 1);
+    let username_len = usize::from(stream.read_u8().await.expect("read SOCKS username length"));
+    let mut username = vec![0; username_len];
+    stream.read_exact(&mut username).await.expect("read SOCKS username");
+    let password_len = usize::from(stream.read_u8().await.expect("read SOCKS password length"));
+    let mut password = vec![0; password_len];
+    stream.read_exact(&mut password).await.expect("read SOCKS password");
+    assert!(username.as_slice() == b"user");
+    assert!(password.as_slice() == b"password");
+    stream.write_all(&[1, 0]).await.expect("accept SOCKS credentials");
+
+    assert_eq!(stream.read_u8().await.expect("read SOCKS request version"), 5);
+    assert_eq!(stream.read_u8().await.expect("read SOCKS command"), 1);
+    assert_eq!(stream.read_u8().await.expect("read SOCKS reserved byte"), 0);
+    let address_type = stream.read_u8().await.expect("read SOCKS address type");
+    assert_eq!(address_type == 3, remote_dns);
+    assert!([1, 3, 4].contains(&address_type), "unexpected SOCKS address type");
+    if address_type == 1 {
+        let mut address = [0; 4];
+        stream.read_exact(&mut address).await.expect("read SOCKS IPv4 target");
+    } else if address_type == 3 {
+        let length = usize::from(stream.read_u8().await.expect("read SOCKS domain length"));
+        let mut domain = vec![0; length];
+        stream.read_exact(&mut domain).await.expect("read SOCKS domain target");
+    } else {
+        let mut address = [0; 16];
+        stream.read_exact(&mut address).await.expect("read SOCKS IPv6 target");
+    }
+    let mut port = [0; 2];
+    stream.read_exact(&mut port).await.expect("read SOCKS target port");
+    stream
+        .write_all(&[5, 0, 0, 1, 0, 0, 0, 0, 0, 0])
+        .await
+        .expect("send SOCKS success response");
+
+    let mut gateway = TcpStream::connect(gateway_addr).await.expect("connect gateway");
+    tokio::io::copy_bidirectional(&mut stream, &mut gateway)
+        .await
+        .expect("forward proxy tunnel");
+}
+
+async fn read_http_headers(stream: &mut TcpStream) -> Vec<u8> {
+    let mut headers = Vec::new();
+    while !headers.ends_with(b"\r\n\r\n") {
+        headers.push(stream.read_u8().await.expect("read proxy request"));
+    }
+    headers
+}
+
+fn response(status: StatusCode, body: Bytes) -> Response<TestBody> {
+    let mut response = Response::new(Full::new(body).boxed());
+    *response.status_mut() = status;
+    response
+}
+
+fn gateway_target(address: core::net::SocketAddr) -> GwConnectTarget {
+    GwConnectTarget {
+        gw_endpoint: format!("localhost:{}", address.port()),
+        gw_user: "user".to_owned(),
+        gw_pass: "pass".to_owned(),
+        smart_card: None,
+        server: "server.test".to_owned(),
+    }
 }


### PR DESCRIPTION
Route all MS-TSGU HTTPS legs through configured HTTP CONNECT or SOCKS5
proxies while preserving gateway TLS validation and authentication.

Honor HTTPS_PROXY/https_proxy and NO_PROXY/no_proxy with bounded CONNECT
response handling and credential redaction.
