### PR TITLE
feat(rdpdr): make the PDU layer bidirectional for a future server

### DIFF
--- a/crates/ironrdp-rdpdr/src/pdu/efs.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/efs.rs
@@ -112,6 +112,27 @@ impl VersionAndIdPdu {
             }
         };
 
+        Self::decode_with_kind(kind, src)
+    }
+
+    /// Decodes a `PacketId::CoreClientidConfirm` body received by a server, where it carries
+    /// a Client Announce Reply rather than the Server Client ID Confirm [`decode`] assumes.
+    ///
+    /// Per MS-RDPEFS 2.2.1.1, PAKID_CORE_CLIENTID_CONFIRM (0x4343) is the shared PacketId for
+    /// both the Client Announce Reply (2.2.2.3, client-to-server) and the Server Client ID
+    /// Confirm (2.2.2.6, server-to-client): the wire alone cannot disambiguate which one a
+    /// given caller is decoding, only the caller knows which side of the connection it is on.
+    /// [`decode`] serves the client, which never decodes its own reply, so it always tags this
+    /// PacketId [`VersionAndIdPduKind::ServerClientIdConfirm`]. A server decoding the client's
+    /// reply must call this instead to get the correct [`VersionAndIdPduKind::ClientAnnounceReply`]
+    /// tag; the fixed-part layout is identical either way.
+    ///
+    /// [`decode`]: Self::decode
+    pub fn decode_client_announce_reply(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        Self::decode_with_kind(VersionAndIdPduKind::ClientAnnounceReply, src)
+    }
+
+    fn decode_with_kind(kind: VersionAndIdPduKind, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
         ensure_size!(ctx: kind.name(), in: src, size: Self::FIXED_PART_SIZE);
         let version_major = src.read_u16();
         let version_minor = src.read_u16();
@@ -182,6 +203,17 @@ impl ClientNameRequest {
         write_string_to_cursor(dst, self.computer_name(), self.unicode_flag().into(), true)
     }
 
+    pub fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(ctx: Self::NAME, in: src, size: Self::FIXED_PART_SIZE);
+        let unicode_flag = ClientNameRequestUnicodeFlag::try_from(src.read_u32())?;
+        let _code_page = src.read_u32(); // CodePage: MUST be set to 0, ignored on decode
+        let computer_name_len = cast_length!(Self::NAME, "ComputerNameLen", src.read_u32())?;
+        ensure_size!(ctx: Self::NAME, in: src, size: computer_name_len);
+        let computer_name = decode_string(src.read_slice(computer_name_len), unicode_flag.into(), true)?;
+
+        Ok(Self::new(computer_name, unicode_flag))
+    }
+
     pub fn name(&self) -> &'static str {
         Self::NAME
     }
@@ -196,6 +228,22 @@ impl ClientNameRequest {
 pub enum ClientNameRequestUnicodeFlag {
     Ascii = 0x0,
     Unicode = 0x1,
+}
+
+impl TryFrom<u32> for ClientNameRequestUnicodeFlag {
+    type Error = DecodeError;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            0x0 => Ok(ClientNameRequestUnicodeFlag::Ascii),
+            0x1 => Ok(ClientNameRequestUnicodeFlag::Unicode),
+            _ => Err(invalid_field_err!(
+                "try_from",
+                "ClientNameRequestUnicodeFlag",
+                "invalid value"
+            )),
+        }
+    }
 }
 
 impl From<ClientNameRequestUnicodeFlag> for CharacterSet {
@@ -944,6 +992,21 @@ impl ClientDeviceListAnnounce {
         Ok(())
     }
 
+    pub fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(ctx: "DR_CORE_DEVICELIST_ANNOUNCE_REQ", in: src, size: Self::FIXED_PART_SIZE);
+        let device_count = src.read_u32();
+        // No capacity pre-allocation from device_count: it is remote-controlled and each
+        // DeviceAnnounceHeader::decode below already bounds-checks against the bytes actually
+        // present, so a too-large count fails on the first short read rather than allocating
+        // ahead of any validated data.
+        let mut device_list = Vec::new();
+        for _ in 0..device_count {
+            device_list.push(DeviceAnnounceHeader::decode(src)?);
+        }
+
+        Ok(Self { device_list })
+    }
+
     pub fn name(&self) -> &'static str {
         "DR_CORE_DEVICELIST_ANNOUNCE_REQ"
     }
@@ -982,6 +1045,21 @@ impl ClientDeviceListRemove {
         }
 
         Ok(())
+    }
+
+    pub fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(ctx: "DR_DEVICELIST_REMOVE", in: src, size: Self::FIXED_PART_SIZE);
+        let device_count = src.read_u32();
+        // No capacity pre-allocation from device_count: it is remote-controlled. Each element
+        // is a plain u32, so the ensure_size! below (checked once per element rather than
+        // pre-multiplied, avoiding its own overflow on a hostile count) bounds every read.
+        let mut device_list = Vec::new();
+        for _ in 0..device_count {
+            ensure_size!(ctx: "DR_DEVICELIST_REMOVE", in: src, size: size_of::<u32>());
+            device_list.push(src.read_u32());
+        }
+
+        Ok(Self { device_list })
     }
 
     pub fn name(&self) -> &'static str {
@@ -1228,6 +1306,21 @@ impl DeviceAnnounceHeader {
         self.device_type
     }
 
+    pub fn device_id(&self) -> u32 {
+        self.device_id
+    }
+
+    /// The device's preferred DOS name, with the ASCII null padding trimmed off.
+    pub fn preferred_dos_name(&self) -> &str {
+        &self.preferred_dos_name.0
+    }
+
+    /// Device-type-specific announce data (e.g. the null-terminated UTF-16LE drive
+    /// name for [`DeviceType::Filesystem`]); opaque to this crate.
+    pub fn device_data(&self) -> &[u8] {
+        &self.device_data
+    }
+
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         dst.write_u32(self.device_type.into());
         dst.write_u32(self.device_id);
@@ -1239,6 +1332,23 @@ impl DeviceAnnounceHeader {
         )?);
         dst.write_slice(&self.device_data);
         Ok(())
+    }
+
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(ctx: "DeviceAnnounceHeader", in: src, size: Self::FIXED_PART_SIZE);
+        let device_type = DeviceType::try_from(src.read_u32())?;
+        let device_id = src.read_u32();
+        let preferred_dos_name = PreferredDosName::decode(src)?;
+        let device_data_len = cast_length!("DeviceAnnounceHeader", "DeviceDataLength", src.read_u32())?;
+        ensure_size!(ctx: "DeviceAnnounceHeader", in: src, size: device_data_len);
+        let device_data = src.read_slice(device_data_len).to_vec();
+
+        Ok(Self {
+            device_type,
+            device_id,
+            preferred_dos_name,
+            device_data,
+        })
     }
 
     fn size(&self) -> usize {
@@ -1294,8 +1404,19 @@ impl PreferredDosName {
         Self(preferred)
     }
 
+    const SIZE: usize = 8;
+
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         write_string_to_cursor(dst, &self.format(), CharacterSet::Ansi, false)
+    }
+
+    /// Decodes the fixed 8-byte ASCII field, trimming the null padding.
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(ctx: "PreferredDosName", in: src, size: Self::SIZE);
+        let raw = decode_string(src.read_slice(Self::SIZE), CharacterSet::Ansi, false)?;
+        let trimmed = raw.trim_end_matches('\u{0}').to_owned();
+
+        Ok(Self(trimmed))
     }
 
     /// Returns the underlying String with a maximum length of 7 characters plus a null terminator.
@@ -1721,14 +1842,28 @@ where
 
         Ok(DecodedDeviceControlRequest { request, input_buffer })
     }
+
+    pub fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(ctx: "DeviceControlRequest", in: dst, size: self.size());
+        self.header.encode(dst)?;
+        dst.write_u32(self.output_buffer_length);
+        dst.write_u32(self.input_buffer_length);
+        dst.write_u32(self.io_control_code.into());
+        write_padding!(dst, 20); // Padding
+        Ok(())
+    }
+
+    pub fn size(&self) -> usize {
+        self.header.size() + Self::HEADERLESS_SIZE
+    }
 }
 
 /// A 32-bit unsigned integer. This field is specific to the redirected device.
-pub trait IoCtlCode: TryFrom<u32> {}
+pub trait IoCtlCode: TryFrom<u32> + Into<u32> + Copy {}
 
 /// An IoCtlCode that can be used when the IoCtlCode is not known
 /// or not important.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct AnyIoCtlCode(pub u32);
 
 impl TryFrom<u32> for AnyIoCtlCode {
@@ -1736,6 +1871,12 @@ impl TryFrom<u32> for AnyIoCtlCode {
 
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         Ok(Self(value))
+    }
+}
+
+impl From<AnyIoCtlCode> for u32 {
+    fn from(value: AnyIoCtlCode) -> Self {
+        value.0
     }
 }
 
@@ -1797,6 +1938,27 @@ impl DeviceControlResponse {
         Ok(())
     }
 
+    /// Decodes the response body. The output buffer's real structure is IOCTL-specific NDR
+    /// content (per MS-RDPEFS 2.2.1.5.5) that only the caller who issued the original
+    /// `DeviceControlRequest` can interpret, so it is decoded as raw bytes rather than into a
+    /// typed [`rpce::Encode`] the way [`Self::new`]'s caller supplies on the encode side.
+    pub fn decode(device_io_reply: DeviceIoResponse, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(ctx: Self::NAME, in: src, size: 4);
+        let output_buffer_length = cast_length!(Self::NAME, "OutputBufferLength", src.read_u32())?;
+        ensure_size!(ctx: Self::NAME, in: src, size: output_buffer_length);
+        let output_buffer = if output_buffer_length == 0 {
+            None
+        } else {
+            let raw: Box<dyn rpce::Encode> = Box::new(RawOutputBuffer(src.read_slice(output_buffer_length).to_vec()));
+            Some(raw)
+        };
+
+        Ok(Self {
+            device_io_reply,
+            output_buffer,
+        })
+    }
+
     pub fn size(&self) -> usize {
         self.device_io_reply.size() // DeviceIoResponse
             + 4 // OutputBufferLength
@@ -1807,6 +1969,29 @@ impl DeviceControlResponse {
             }
     }
 }
+
+/// A [`DeviceControlResponse::output_buffer`] decoded as opaque bytes rather than a typed
+/// IOCTL-specific structure. See [`DeviceControlResponse::decode`].
+#[derive(Debug)]
+struct RawOutputBuffer(Vec<u8>);
+
+impl ironrdp_core::Encode for RawOutputBuffer {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.0.len());
+        dst.write_slice(&self.0);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "RawOutputBuffer"
+    }
+
+    fn size(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl rpce::Encode for RawOutputBuffer {}
 
 /// [2.2.1.5] Device I/O Response (DR_DEVICE_IOCOMPLETION)
 ///
@@ -2096,6 +2281,29 @@ impl DeviceCreateRequest {
             path,
         })
     }
+
+    pub fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(ctx: "DeviceCreateRequest", in: dst, size: self.size());
+        self.device_io_request.encode(dst)?;
+        dst.write_u32(self.desired_access.bits());
+        dst.write_u64(self.allocation_size);
+        dst.write_u32(self.file_attributes.bits());
+        dst.write_u32(self.shared_access.bits());
+        dst.write_u32(self.create_disposition.into());
+        dst.write_u32(self.create_options.bits());
+        // Round-trips through decode's from_utf16_bytes(..).trim_end_matches('\0'), so the
+        // written PathLength must include the null terminator decode expects to trim.
+        dst.write_u32(cast_length!(
+            "DeviceCreateRequest",
+            "path_length",
+            encoded_str_len(&self.path, CharacterSet::Unicode, true)
+        )?);
+        write_string_to_cursor(dst, &self.path, CharacterSet::Unicode, true)
+    }
+
+    pub fn size(&self) -> usize {
+        self.device_io_request.size() + Self::FIXED_PART_SIZE + encoded_str_len(&self.path, CharacterSet::Unicode, true)
+    }
 }
 
 bitflags! {
@@ -2297,6 +2505,18 @@ impl DeviceCreateResponse {
         Ok(())
     }
 
+    pub fn decode(device_io_reply: DeviceIoResponse, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(ctx: Self::NAME, in: src, size: 5);
+        let file_id = src.read_u32();
+        let information = Information::from_bits_retain(src.read_u8());
+
+        Ok(Self {
+            device_io_reply,
+            file_id,
+            information,
+        })
+    }
+
     pub fn size(&self) -> usize {
         self.device_io_reply.size() // DeviceIoReply
         + 4 // FileId
@@ -2358,14 +2578,28 @@ pub struct ServerDriveQueryInformationRequest {
 }
 
 impl ServerDriveQueryInformationRequest {
+    const NAME: &'static str = "ServerDriveQueryInformationRequest";
+    const FIXED_PART_SIZE: usize = 4; // FsInformationClass
+
     pub fn decode(dev_io_req: DeviceIoRequest, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
-        ensure_size!(ctx: "ServerDriveQueryInformationRequest", in: src, size: 4);
+        ensure_size!(ctx: Self::NAME, in: src, size: 4);
         let file_info_class_lvl = FileInformationClassLevel::from(src.read_u32());
 
         Ok(Self {
             device_io_request: dev_io_req,
             file_info_class_lvl,
         })
+    }
+
+    pub fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(ctx: Self::NAME, in: dst, size: self.size());
+        self.device_io_request.encode(dst)?;
+        dst.write_u32(self.file_info_class_lvl.clone().into());
+        Ok(())
+    }
+
+    pub fn size(&self) -> usize {
+        self.device_io_request.size() + Self::FIXED_PART_SIZE
     }
 }
 
@@ -2480,6 +2714,16 @@ impl ClientDriveSetVolumeInformationResponse {
         Ok(())
     }
 
+    pub fn decode(device_io_reply: DeviceIoResponse, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(ctx: Self::NAME, in: src, size: 4);
+        let length = src.read_u32();
+
+        Ok(Self {
+            device_io_reply,
+            length,
+        })
+    }
+
     pub fn size(&self) -> usize {
         self.device_io_reply.size() // DeviceIoResponse
         + 4 // Length
@@ -2520,6 +2764,29 @@ impl ClientDriveQueryInformationResponse {
         Ok(())
     }
 
+    /// Decodes the response body. `file_info_class_lvl` is not carried on the wire here (per
+    /// MS-RDPEFS 2.2.3.4.8): the receiver must already know it from the [`ServerDriveQueryInformationRequest`]
+    /// this completes, so it is supplied by the caller rather than read from `src`.
+    pub fn decode_for_class(
+        file_info_class_lvl: FileInformationClassLevel,
+        device_io_response: DeviceIoResponse,
+        src: &mut ReadCursor<'_>,
+    ) -> DecodeResult<Self> {
+        ensure_size!(ctx: Self::NAME, in: src, size: 4);
+        let length = cast_length!(Self::NAME, "Length", src.read_u32())?;
+        let buffer = if length == 0 {
+            None
+        } else {
+            ensure_size!(ctx: Self::NAME, in: src, size: length);
+            Some(FileInformationClass::decode(file_info_class_lvl, length, src)?)
+        };
+
+        Ok(Self {
+            device_io_response,
+            buffer,
+        })
+    }
+
     pub fn size(&self) -> usize {
         self.device_io_response.size() // DeviceIoResponse
         + 4 // Length
@@ -2553,6 +2820,17 @@ impl ServerDriveQuerySecurityRequest {
             device_io_request: dev_io_req,
             security_information,
         })
+    }
+
+    pub fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(ctx: "ServerDriveQuerySecurityRequest", in: dst, size: self.size());
+        self.device_io_request.encode(dst)?;
+        dst.write_u32(self.security_information.bits());
+        Ok(())
+    }
+
+    pub fn size(&self) -> usize {
+        self.device_io_request.size() + Self::FIXED_PART_SIZE
     }
 }
 
@@ -2623,6 +2901,22 @@ impl ClientDriveQuerySecurityResponse {
         Ok(())
     }
 
+    pub fn decode(device_io_response: DeviceIoResponse, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(ctx: Self::NAME, in: src, size: 4);
+        let length = cast_length!(Self::NAME, "Length", src.read_u32())?;
+        ensure_size!(ctx: Self::NAME, in: src, size: length);
+        let security_descriptor = if length == 0 {
+            None
+        } else {
+            Some(src.read_slice(length).to_vec())
+        };
+
+        Ok(Self {
+            device_io_response,
+            security_descriptor,
+        })
+    }
+
     pub fn size(&self) -> usize {
         self.device_io_response.size() // DeviceIoResponse
             + 4 // Length
@@ -2659,6 +2953,24 @@ impl ServerDriveSetSecurityRequest {
             security_descriptor,
         })
     }
+
+    pub fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(ctx: "ServerDriveSetSecurityRequest", in: dst, size: self.size());
+        self.device_io_request.encode(dst)?;
+        dst.write_u32(self.security_information.bits());
+        dst.write_u32(cast_length!(
+            "ServerDriveSetSecurityRequest",
+            "length",
+            self.security_descriptor.len()
+        )?);
+        write_padding!(dst, 24); // Padding
+        dst.write_slice(&self.security_descriptor);
+        Ok(())
+    }
+
+    pub fn size(&self) -> usize {
+        self.device_io_request.size() + Self::FIXED_PART_SIZE + self.security_descriptor.len()
+    }
 }
 
 /// Set Security completion.
@@ -2691,6 +3003,16 @@ impl ClientDriveSetSecurityResponse {
         self.device_io_response.encode(dst)?;
         dst.write_u32(self.length);
         Ok(())
+    }
+
+    pub fn decode(device_io_response: DeviceIoResponse, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(ctx: Self::NAME, in: src, size: 4);
+        let length = src.read_u32();
+
+        Ok(Self {
+            device_io_response,
+            length,
+        })
     }
 
     pub fn size(&self) -> usize {
@@ -2730,11 +3052,10 @@ impl FileInformationClass {
             Self::Names(f) => f.encode(dst),
             Self::Directory(f) => f.encode(dst),
             Self::Stream(f) => f.encode(dst),
-            _ => Err(unsupported_value_err!(
-                "FileInformationClass::encode",
-                "FileInformationClass",
-                self.to_string()
-            )),
+            Self::EndOfFile(f) => f.encode(dst),
+            Self::Disposition(f) => f.encode(dst),
+            Self::Rename(f) => f.encode(dst),
+            Self::Allocation(f) => f.encode(dst),
         }
     }
 
@@ -2745,6 +3066,10 @@ impl FileInformationClass {
     ) -> DecodeResult<Self> {
         match file_info_class_level {
             FileInformationClassLevel::FILE_BASIC_INFORMATION => Ok(FileBasicInformation::decode(src)?.into()),
+            FileInformationClassLevel::FILE_STANDARD_INFORMATION => Ok(FileStandardInformation::decode(src)?.into()),
+            FileInformationClassLevel::FILE_ATTRIBUTE_TAG_INFORMATION => {
+                Ok(FileAttributeTagInformation::decode(src)?.into())
+            }
             FileInformationClassLevel::FILE_END_OF_FILE_INFORMATION => {
                 Ok(FileEndOfFileInformation::decode(src)?.into())
             }
@@ -2755,6 +3080,14 @@ impl FileInformationClass {
             FileInformationClassLevel::FILE_ALLOCATION_INFORMATION => {
                 Ok(FileAllocationInformation::decode(src)?.into())
             }
+            FileInformationClassLevel::FILE_DIRECTORY_INFORMATION => Ok(FileDirectoryInformation::decode(src)?.into()),
+            FileInformationClassLevel::FILE_FULL_DIRECTORY_INFORMATION => {
+                Ok(FileFullDirectoryInformation::decode(src)?.into())
+            }
+            FileInformationClassLevel::FILE_BOTH_DIRECTORY_INFORMATION => {
+                Ok(FileBothDirectoryInformation::decode(src)?.into())
+            }
+            FileInformationClassLevel::FILE_NAMES_INFORMATION => Ok(FileNamesInformation::decode(src)?.into()),
             _ => Err(unsupported_value_err!(
                 "FileInformationClass::decode",
                 "FileInformationClassLevel",
@@ -2983,6 +3316,23 @@ impl FileStandardInformation {
         Ok(())
     }
 
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(ctx: "FileStandardInformation", in: src, size: Self::size());
+        let allocation_size = src.read_i64();
+        let end_of_file = src.read_i64();
+        let number_of_links = src.read_u32();
+        let delete_pending = Boolean::from(src.read_u8());
+        let directory = Boolean::from(src.read_u8());
+
+        Ok(Self {
+            allocation_size,
+            end_of_file,
+            number_of_links,
+            delete_pending,
+            directory,
+        })
+    }
+
     pub fn size() -> usize {
         8 // AllocationSize
         + 8 // EndOfFile
@@ -3035,6 +3385,17 @@ impl FileAttributeTagInformation {
         dst.write_u32(self.file_attributes.bits());
         dst.write_u32(self.reparse_tag);
         Ok(())
+    }
+
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(ctx: "FileAttributeTagInformation", in: src, size: Self::size());
+        let file_attributes = FileAttributes::from_bits_retain(src.read_u32());
+        let reparse_tag = src.read_u32();
+
+        Ok(Self {
+            file_attributes,
+            reparse_tag,
+        })
     }
 
     fn size() -> usize {
@@ -3117,6 +3478,56 @@ impl FileBothDirectoryInformation {
         dst.write_slice(&self.short_name);
         write_string_to_cursor(dst, &self.file_name, CharacterSet::Unicode, false)?;
         Ok(())
+    }
+
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        const FIXED_PART_SIZE: usize = 4 // NextEntryOffset
+            + 4 // FileIndex
+            + 8 // CreationTime
+            + 8 // LastAccessTime
+            + 8 // LastWriteTime
+            + 8 // ChangeTime
+            + 8 // EndOfFile
+            + 8 // AllocationSize
+            + 4 // FileAttributes
+            + 4 // FileNameLength
+            + 4 // EaSize
+            + 1 // ShortNameLength
+            + 24; // ShortName
+        ensure_size!(ctx: "FileBothDirectoryInformation", in: src, size: FIXED_PART_SIZE);
+        let next_entry_offset = src.read_u32();
+        let file_index = src.read_u32();
+        let creation_time = src.read_i64();
+        let last_access_time = src.read_i64();
+        let last_write_time = src.read_i64();
+        let change_time = src.read_i64();
+        let end_of_file = src.read_i64();
+        let allocation_size = src.read_i64();
+        let file_attributes = FileAttributes::from_bits_retain(src.read_u32());
+        let file_name_length = cast_length!("FileBothDirectoryInformation", "file_name_length", src.read_u32())?;
+        let ea_size = src.read_u32();
+        let short_name_length = i8::from_ne_bytes([src.read_u8()]);
+        // reserved u8 MUST NOT be present, see the encode-side note above.
+        let mut short_name = [0u8; 24];
+        short_name.copy_from_slice(src.read_slice(24));
+        ensure_size!(ctx: "FileBothDirectoryInformation", in: src, size: file_name_length);
+        let file_name = decode_string(src.read_slice(file_name_length), CharacterSet::Unicode, false)?;
+
+        Ok(Self {
+            next_entry_offset,
+            file_index,
+            creation_time,
+            last_access_time,
+            last_write_time,
+            change_time,
+            end_of_file,
+            allocation_size,
+            file_attributes,
+            ea_size,
+            short_name_length,
+            short_name,
+            file_name,
+        })
     }
 
     fn size(&self) -> usize {
@@ -3203,6 +3614,48 @@ impl FileFullDirectoryInformation {
         Ok(())
     }
 
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        const FIXED_PART_SIZE: usize = 4 // NextEntryOffset
+            + 4 // FileIndex
+            + 8 // CreationTime
+            + 8 // LastAccessTime
+            + 8 // LastWriteTime
+            + 8 // ChangeTime
+            + 8 // EndOfFile
+            + 8 // AllocationSize
+            + 4 // FileAttributes
+            + 4 // FileNameLength
+            + 4; // EaSize
+        ensure_size!(ctx: "FileFullDirectoryInformation", in: src, size: FIXED_PART_SIZE);
+        let next_entry_offset = src.read_u32();
+        let file_index = src.read_u32();
+        let creation_time = src.read_i64();
+        let last_access_time = src.read_i64();
+        let last_write_time = src.read_i64();
+        let change_time = src.read_i64();
+        let end_of_file = src.read_i64();
+        let allocation_size = src.read_i64();
+        let file_attributes = FileAttributes::from_bits_retain(src.read_u32());
+        let file_name_length = cast_length!("FileFullDirectoryInformation", "file_name_length", src.read_u32())?;
+        let ea_size = src.read_u32();
+        ensure_size!(ctx: "FileFullDirectoryInformation", in: src, size: file_name_length);
+        let file_name = decode_string(src.read_slice(file_name_length), CharacterSet::Unicode, false)?;
+
+        Ok(Self {
+            next_entry_offset,
+            file_index,
+            creation_time,
+            last_access_time,
+            last_write_time,
+            change_time,
+            end_of_file,
+            allocation_size,
+            file_attributes,
+            ea_size,
+            file_name,
+        })
+    }
+
     fn size(&self) -> usize {
         4 // NextEntryOffset
         + 4 // FileIndex
@@ -3251,6 +3704,24 @@ impl FileNamesInformation {
         )?);
         write_string_to_cursor(dst, &self.file_name, CharacterSet::Unicode, false)?;
         Ok(())
+    }
+
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        const FIXED_PART_SIZE: usize = 4 // NextEntryOffset
+            + 4 // FileIndex
+            + 4; // FileNameLength
+        ensure_size!(ctx: "FileNamesInformation", in: src, size: FIXED_PART_SIZE);
+        let next_entry_offset = src.read_u32();
+        let file_index = src.read_u32();
+        let file_name_length = cast_length!("FileNamesInformation", "file_name_length", src.read_u32())?;
+        ensure_size!(ctx: "FileNamesInformation", in: src, size: file_name_length);
+        let file_name = decode_string(src.read_slice(file_name_length), CharacterSet::Unicode, false)?;
+
+        Ok(Self {
+            next_entry_offset,
+            file_index,
+            file_name,
+        })
     }
 
     fn size(&self) -> usize {
@@ -3324,6 +3795,45 @@ impl FileDirectoryInformation {
         Ok(())
     }
 
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        const FIXED_PART_SIZE: usize = 4 // NextEntryOffset
+            + 4 // FileIndex
+            + 8 // CreationTime
+            + 8 // LastAccessTime
+            + 8 // LastWriteTime
+            + 8 // ChangeTime
+            + 8 // EndOfFile
+            + 8 // AllocationSize
+            + 4 // FileAttributes
+            + 4; // FileNameLength
+        ensure_size!(ctx: "FileDirectoryInformation", in: src, size: FIXED_PART_SIZE);
+        let next_entry_offset = src.read_u32();
+        let file_index = src.read_u32();
+        let creation_time = src.read_i64();
+        let last_access_time = src.read_i64();
+        let last_write_time = src.read_i64();
+        let change_time = src.read_i64();
+        let end_of_file = src.read_i64();
+        let allocation_size = src.read_i64();
+        let file_attributes = FileAttributes::from_bits_retain(src.read_u32());
+        let file_name_length = cast_length!("FileDirectoryInformation", "file_name_length", src.read_u32())?;
+        ensure_size!(ctx: "FileDirectoryInformation", in: src, size: file_name_length);
+        let file_name = decode_string(src.read_slice(file_name_length), CharacterSet::Unicode, false)?;
+
+        Ok(Self {
+            next_entry_offset,
+            file_index,
+            creation_time,
+            last_access_time,
+            last_write_time,
+            change_time,
+            end_of_file,
+            allocation_size,
+            file_attributes,
+            file_name,
+        })
+    }
+
     fn size(&self) -> usize {
         4 // NextEntryOffset
         + 4 // FileIndex
@@ -3350,10 +3860,26 @@ pub struct DeviceCloseRequest {
 }
 
 impl DeviceCloseRequest {
+    const FIXED_PART_SIZE: usize = 32; // Padding
+
     pub fn decode(dev_io_req: DeviceIoRequest) -> Self {
         Self {
             device_io_request: dev_io_req,
         }
+    }
+
+    /// The 32-byte padding this decodes past (see the struct's own doc comment) is only
+    /// ignorable on the read side because it is unread here, not because the wire format
+    /// omits it; a real peer still expects a fixed-size `DR_CLOSE_REQ`, so encode writes it.
+    pub fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(ctx: "DeviceCloseRequest", in: dst, size: self.size());
+        self.device_io_request.encode(dst)?;
+        write_padding!(dst, Self::FIXED_PART_SIZE);
+        Ok(())
+    }
+
+    pub fn size(&self) -> usize {
+        self.device_io_request.size() + Self::FIXED_PART_SIZE
     }
 }
 
@@ -3370,6 +3896,14 @@ pub struct DeviceFlushBuffersRequest {
 impl DeviceFlushBuffersRequest {
     pub fn decode(device_io_request: DeviceIoRequest) -> Self {
         Self { device_io_request }
+    }
+
+    pub fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        self.device_io_request.encode(dst)
+    }
+
+    pub fn size(&self) -> usize {
+        self.device_io_request.size()
     }
 }
 
@@ -3392,6 +3926,10 @@ impl DeviceFlushBuffersResponse {
 
     pub fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         self.device_io_response.encode(dst)
+    }
+
+    pub fn decode(device_io_response: DeviceIoResponse) -> Self {
+        Self { device_io_response }
     }
 
     pub fn size(&self) -> usize {
@@ -3422,6 +3960,13 @@ impl DeviceCloseResponse {
         Ok(())
     }
 
+    pub fn decode(device_io_response: DeviceIoResponse, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(ctx: Self::NAME, in: src, size: 4);
+        read_padding!(src, 4); // Padding: reserved, MUST be ignored.
+
+        Ok(Self { device_io_response })
+    }
+
     pub fn size(&self) -> usize {
         self.device_io_response.size() // DeviceIoResponse
         + 4 // Padding
@@ -3442,7 +3987,7 @@ pub struct ServerDriveQueryDirectoryRequest {
 impl ServerDriveQueryDirectoryRequest {
     const FIXED_PART_SIZE: usize = 4 /* FsInformationClass */ + 1 /* InitialQuery */ + 4 /* PathLength */ + 23 /* Padding */;
 
-    fn decode(device_io_request: DeviceIoRequest, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+    pub fn decode(device_io_request: DeviceIoRequest, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
         ensure_fixed_part_size!(in: src);
         let file_info_class_lvl = FileInformationClassLevel::from(src.read_u32());
 
@@ -3483,6 +4028,38 @@ impl ServerDriveQueryDirectoryRequest {
             path,
         })
     }
+
+    pub fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(ctx: "ServerDriveQueryDirectoryRequest", in: dst, size: self.size());
+        self.device_io_request.encode(dst)?;
+        dst.write_u32(self.file_info_class_lvl.clone().into());
+        dst.write_u8(self.initial_query);
+        let path_len = if self.initial_query == 0 {
+            0
+        } else {
+            cast_length!(
+                "ServerDriveQueryDirectoryRequest",
+                "path_length",
+                encoded_str_len(&self.path, CharacterSet::Unicode, true)
+            )?
+        };
+        dst.write_u32(path_len);
+        write_padding!(dst, 23); // Padding
+        if self.initial_query != 0 {
+            write_string_to_cursor(dst, &self.path, CharacterSet::Unicode, true)?;
+        }
+        Ok(())
+    }
+
+    pub fn size(&self) -> usize {
+        self.device_io_request.size()
+            + Self::FIXED_PART_SIZE
+            + if self.initial_query == 0 {
+                0
+            } else {
+                encoded_str_len(&self.path, CharacterSet::Unicode, true)
+            }
+    }
 }
 
 /// 2.2.3.3.11 Server Drive NotifyChange Directory Request (DR_DRIVE_NOTIFY_CHANGE_DIRECTORY_REQ)
@@ -3498,7 +4075,7 @@ pub struct ServerDriveNotifyChangeDirectoryRequest {
 impl ServerDriveNotifyChangeDirectoryRequest {
     const FIXED_PART_SIZE: usize = 1 /* WatchTree */ + 4 /* CompletionFilter */ + 27 /* Padding */;
 
-    fn decode(device_io_request: DeviceIoRequest, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+    pub fn decode(device_io_request: DeviceIoRequest, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
         ensure_fixed_part_size!(in: src);
         let watch_tree = src.read_u8();
         let completion_filter = src.read_u32();
@@ -3510,6 +4087,19 @@ impl ServerDriveNotifyChangeDirectoryRequest {
             watch_tree,
             completion_filter,
         })
+    }
+
+    pub fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(ctx: "ServerDriveNotifyChangeDirectoryRequest", in: dst, size: self.size());
+        self.device_io_request.encode(dst)?;
+        dst.write_u8(self.watch_tree);
+        dst.write_u32(self.completion_filter);
+        write_padding!(dst, 27); // Padding
+        Ok(())
+    }
+
+    pub fn size(&self) -> usize {
+        self.device_io_request.size() + Self::FIXED_PART_SIZE
     }
 }
 
@@ -3543,6 +4133,30 @@ impl ClientDriveQueryDirectoryResponse {
             write_padding!(dst, 1) // Padding: https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L937
         }
         Ok(())
+    }
+
+    /// Decodes the response body. `file_info_class_lvl` is not carried on the wire (per
+    /// MS-RDPEFS 2.2.3.4.10): the receiver must already know it from the
+    /// [`ServerDriveQueryDirectoryRequest`] this completes, so it is supplied by the caller.
+    pub fn decode_for_class(
+        file_info_class_lvl: FileInformationClassLevel,
+        device_io_reply: DeviceIoResponse,
+        src: &mut ReadCursor<'_>,
+    ) -> DecodeResult<Self> {
+        ensure_size!(ctx: Self::NAME, in: src, size: 4);
+        let length = cast_length!(Self::NAME, "Length", src.read_u32())?;
+        let buffer = if length == 0 {
+            read_padding!(src, 1); // Padding, mirrors the encode-side FreeRDP interop quirk above.
+            None
+        } else {
+            ensure_size!(ctx: Self::NAME, in: src, size: length);
+            Some(FileInformationClass::decode(file_info_class_lvl, length, src)?)
+        };
+
+        Ok(Self {
+            device_io_reply,
+            buffer,
+        })
     }
 
     pub fn size(&self) -> usize {
@@ -3604,6 +4218,22 @@ impl ServerDriveQueryVolumeInformationRequest {
             device_io_request: dev_io_req,
             fs_info_class_lvl,
         })
+    }
+
+    /// A request built by this crate never carries a QueryVolumeBuffer: decode already
+    /// discards it (see the struct's own doc comment), so there is no round-tripped content
+    /// to write back. Length is encoded as 0 accordingly.
+    pub fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(ctx: "ServerDriveQueryVolumeInformationRequest", in: dst, size: self.size());
+        self.device_io_request.encode(dst)?;
+        dst.write_u32(self.fs_info_class_lvl.clone().into());
+        dst.write_u32(0); // Length
+        write_padding!(dst, 24); // Padding
+        Ok(())
+    }
+
+    pub fn size(&self) -> usize {
+        self.device_io_request.size() + Self::FIXED_PART_SIZE
     }
 }
 
@@ -3717,6 +4347,12 @@ impl From<u32> for FileSystemInformationClassLevel {
     }
 }
 
+impl From<FileSystemInformationClassLevel> for u32 {
+    fn from(fs_info_class_lvl: FileSystemInformationClassLevel) -> Self {
+        fs_info_class_lvl.0
+    }
+}
+
 /// [2.5] File System Information Classes
 ///
 /// [2.5]: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/ee12042a-9352-46e3-9f67-c094b75fe6c3
@@ -3730,6 +4366,36 @@ pub enum FileSystemInformationClass {
 }
 
 impl FileSystemInformationClass {
+    /// `length` is unused by every variant currently decodable here (each has a
+    /// self-describing fixed or length-prefixed layout), but is accepted for symmetry with
+    /// [`FileInformationClass::decode`] and in case a future variant needs it.
+    fn decode(
+        fs_info_class_lvl: FileSystemInformationClassLevel,
+        _length: usize,
+        src: &mut ReadCursor<'_>,
+    ) -> DecodeResult<Self> {
+        match fs_info_class_lvl {
+            FileSystemInformationClassLevel::FILE_FS_VOLUME_INFORMATION => {
+                Ok(FileFsVolumeInformation::decode(src)?.into())
+            }
+            FileSystemInformationClassLevel::FILE_FS_SIZE_INFORMATION => Ok(FileFsSizeInformation::decode(src)?.into()),
+            FileSystemInformationClassLevel::FILE_FS_ATTRIBUTE_INFORMATION => {
+                Ok(FileFsAttributeInformation::decode(src)?.into())
+            }
+            FileSystemInformationClassLevel::FILE_FS_FULL_SIZE_INFORMATION => {
+                Ok(FileFsFullSizeInformation::decode(src)?.into())
+            }
+            FileSystemInformationClassLevel::FILE_FS_DEVICE_INFORMATION => {
+                Ok(FileFsDeviceInformation::decode(src)?.into())
+            }
+            _ => Err(unsupported_value_err!(
+                "FileSystemInformationClass::decode",
+                "FileSystemInformationClassLevel",
+                format!("{fs_info_class_lvl:?}")
+            )),
+        }
+    }
+
     fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
         ensure_size!(in: dst, size: self.size());
         match self {
@@ -3810,6 +4476,24 @@ impl FileFsVolumeInformation {
         Ok(())
     }
 
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(ctx: "FileFsVolumeInformation", in: src, size: 17);
+        let volume_creation_time = src.read_i64();
+        let volume_serial_number = src.read_u32();
+        let volume_label_length = cast_length!("FileFsVolumeInformation", "volume_label_length", src.read_u32())?;
+        let supports_objects = Boolean::from(src.read_u8());
+        // MS-RDPEFS omits the FileFsVolumeInformation reserved byte from this response, matching encode above.
+        ensure_size!(ctx: "FileFsVolumeInformation", in: src, size: volume_label_length);
+        let volume_label = decode_string(src.read_slice(volume_label_length), CharacterSet::Unicode, true)?;
+
+        Ok(Self {
+            volume_creation_time,
+            volume_serial_number,
+            supports_objects,
+            volume_label,
+        })
+    }
+
     pub fn size(&self) -> usize {
         8 // VolumeCreationTime
         + 4 // VolumeSerialNumber
@@ -3838,6 +4522,21 @@ impl FileFsSizeInformation {
         dst.write_u32(self.sectors_per_alloc_unit);
         dst.write_u32(self.bytes_per_sector);
         Ok(())
+    }
+
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(ctx: "FileFsSizeInformation", in: src, size: 24);
+        let total_alloc_units = src.read_i64();
+        let available_alloc_units = src.read_i64();
+        let sectors_per_alloc_unit = src.read_u32();
+        let bytes_per_sector = src.read_u32();
+
+        Ok(Self {
+            total_alloc_units,
+            available_alloc_units,
+            sectors_per_alloc_unit,
+            bytes_per_sector,
+        })
     }
 
     pub fn size(&self) -> usize {
@@ -3872,6 +4571,22 @@ impl FileFsAttributeInformation {
         Ok(())
     }
 
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(ctx: "FileFsAttributeInformation", in: src, size: 12);
+        let file_system_attributes = FileSystemAttributes::from_bits_retain(src.read_u32());
+        let max_component_name_len = src.read_u32();
+        let file_system_name_length =
+            cast_length!("FileFsAttributeInformation", "file_system_name_length", src.read_u32())?;
+        ensure_size!(ctx: "FileFsAttributeInformation", in: src, size: file_system_name_length);
+        let file_system_name = decode_string(src.read_slice(file_system_name_length), CharacterSet::Unicode, false)?;
+
+        Ok(Self {
+            file_system_attributes,
+            max_component_name_len,
+            file_system_name,
+        })
+    }
+
     pub fn size(&self) -> usize {
         4 // FileSystemAttributes
         + 4 // MaximumComponentNameLength
@@ -3903,6 +4618,23 @@ impl FileFsFullSizeInformation {
         Ok(())
     }
 
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(ctx: "FileFsFullSizeInformation", in: src, size: Self::size());
+        let total_alloc_units = src.read_i64();
+        let caller_available_alloc_units = src.read_i64();
+        let actual_available_alloc_units = src.read_i64();
+        let sectors_per_alloc_unit = src.read_u32();
+        let bytes_per_sector = src.read_u32();
+
+        Ok(Self {
+            total_alloc_units,
+            caller_available_alloc_units,
+            actual_available_alloc_units,
+            sectors_per_alloc_unit,
+            bytes_per_sector,
+        })
+    }
+
     pub fn size() -> usize {
         8 // TotalAllocationUnits
         + 8 // CallerAvailableAllocationUnits
@@ -3927,6 +4659,17 @@ impl FileFsDeviceInformation {
         dst.write_u32(self.device_type);
         dst.write_u32(self.characteristics.bits());
         Ok(())
+    }
+
+    fn decode(src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(ctx: "FileFsDeviceInformation", in: src, size: Self::size());
+        let device_type = src.read_u32();
+        let characteristics = Characteristics::from_bits_retain(src.read_u32());
+
+        Ok(Self {
+            device_type,
+            characteristics,
+        })
     }
 
     pub fn size() -> usize {
@@ -4034,6 +4777,29 @@ impl ClientDriveQueryVolumeInformationResponse {
         Ok(())
     }
 
+    /// Decodes the response body. `fs_info_class_lvl` is not carried on the wire (per
+    /// MS-RDPEFS 2.2.3.4.6): the receiver must already know it from the
+    /// [`ServerDriveQueryVolumeInformationRequest`] this completes, so it is supplied by the caller.
+    pub fn decode_for_class(
+        fs_info_class_lvl: FileSystemInformationClassLevel,
+        device_io_reply: DeviceIoResponse,
+        src: &mut ReadCursor<'_>,
+    ) -> DecodeResult<Self> {
+        ensure_size!(ctx: Self::NAME, in: src, size: 4);
+        let length = cast_length!(Self::NAME, "length", src.read_u32())?;
+        let buffer = if length == 0 {
+            None
+        } else {
+            ensure_size!(ctx: Self::NAME, in: src, size: length);
+            Some(FileSystemInformationClass::decode(fs_info_class_lvl, length, src)?)
+        };
+
+        Ok(Self {
+            device_io_reply,
+            buffer,
+        })
+    }
+
     pub fn size(&self) -> usize {
         self.device_io_reply.size() // DeviceIoResponse
         + 4 // Length
@@ -4071,6 +4837,19 @@ impl DeviceReadRequest {
             offset,
         })
     }
+
+    pub fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(ctx: "DeviceReadRequest", in: dst, size: self.size());
+        self.device_io_request.encode(dst)?;
+        dst.write_u32(self.length);
+        dst.write_u64(self.offset);
+        write_padding!(dst, 20); // Padding
+        Ok(())
+    }
+
+    pub fn size(&self) -> usize {
+        self.device_io_request.size() + Self::FIXED_PART_SIZE
+    }
 }
 
 /// [2.2.1.5.3] Device Read Response (DR_READ_RSP)
@@ -4090,6 +4869,18 @@ impl DeviceReadResponse {
         dst.write_u32(cast_length!("DeviceReadResponse", "length", self.read_data.len())?);
         dst.write_slice(&self.read_data);
         Ok(())
+    }
+
+    pub fn decode(device_io_reply: DeviceIoResponse, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(ctx: Self::NAME, in: src, size: 4);
+        let length = cast_length!(Self::NAME, "length", src.read_u32())?;
+        ensure_size!(ctx: Self::NAME, in: src, size: length);
+        let read_data = src.read_slice(length).to_vec();
+
+        Ok(Self {
+            device_io_reply,
+            read_data,
+        })
     }
 
     pub fn name(&self) -> &'static str {
@@ -4141,6 +4932,20 @@ impl DeviceWriteRequest {
             write_data,
         })
     }
+
+    pub fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(ctx: "DeviceWriteRequest", in: dst, size: self.size());
+        self.device_io_request.encode(dst)?;
+        dst.write_u32(cast_length!("DeviceWriteRequest", "length", self.write_data.len())?);
+        dst.write_u64(self.offset);
+        write_padding!(dst, 20); // Padding
+        dst.write_slice(&self.write_data);
+        Ok(())
+    }
+
+    pub fn size(&self) -> usize {
+        self.device_io_request.size() + Self::FIXED_PART_SIZE + self.write_data.len()
+    }
 }
 
 impl Debug for DeviceWriteRequest {
@@ -4177,6 +4982,17 @@ impl DeviceWriteResponse {
         Ok(())
     }
 
+    pub fn decode(device_io_reply: DeviceIoResponse, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(ctx: Self::NAME, in: src, size: 5);
+        let length = src.read_u32();
+        read_padding!(src, 1); // Padding
+
+        Ok(Self {
+            device_io_reply,
+            length,
+        })
+    }
+
     pub fn size(&self) -> usize {
         self.device_io_reply.size() // DeviceIoResponse
         + 4 // Length
@@ -4196,7 +5012,7 @@ pub struct ServerDriveSetInformationRequest {
 impl ServerDriveSetInformationRequest {
     const FIXED_PART_SIZE: usize = 4 /* FileInformationClass */ + 4 /* Length */ + 24 /* Padding */;
 
-    fn decode(dev_io_req: DeviceIoRequest, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+    pub fn decode(dev_io_req: DeviceIoRequest, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
         ensure_fixed_part_size!(in: src);
         let file_information_class_level = FileInformationClassLevel::from(src.read_u32());
 
@@ -4227,6 +5043,40 @@ impl ServerDriveSetInformationRequest {
             set_buffer,
         })
     }
+
+    pub fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        // Only the five classes decode() (and this crate's own FileInformationClass::encode)
+        // support are valid on the wire for a Set Information request; see both above.
+        let file_information_class_level = match &self.set_buffer {
+            FileInformationClass::Basic(_) => FileInformationClassLevel::FILE_BASIC_INFORMATION,
+            FileInformationClass::EndOfFile(_) => FileInformationClassLevel::FILE_END_OF_FILE_INFORMATION,
+            FileInformationClass::Disposition(_) => FileInformationClassLevel::FILE_DISPOSITION_INFORMATION,
+            FileInformationClass::Rename(_) => FileInformationClassLevel::FILE_RENAME_INFORMATION,
+            FileInformationClass::Allocation(_) => FileInformationClassLevel::FILE_ALLOCATION_INFORMATION,
+            _ => {
+                return Err(unsupported_value_err!(
+                    "ServerDriveSetInformationRequest::encode",
+                    "FileInformationClass",
+                    self.set_buffer.to_string()
+                ));
+            }
+        };
+
+        ensure_size!(ctx: "ServerDriveSetInformationRequest", in: dst, size: self.size());
+        self.device_io_request.encode(dst)?;
+        dst.write_u32(file_information_class_level.into());
+        dst.write_u32(cast_length!(
+            "ServerDriveSetInformationRequest",
+            "length",
+            self.set_buffer.size()
+        )?);
+        write_padding!(dst, 24); // Padding
+        self.set_buffer.encode(dst)
+    }
+
+    pub fn size(&self) -> usize {
+        self.device_io_request.size() + Self::FIXED_PART_SIZE + self.set_buffer.size()
+    }
 }
 
 /// 2.4.13 FileEndOfFileInformation
@@ -4244,6 +5094,12 @@ impl FileEndOfFileInformation {
         ensure_fixed_part_size!(in: src);
         let end_of_file = src.read_i64();
         Ok(Self { end_of_file })
+    }
+
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: Self::size());
+        dst.write_i64(self.end_of_file);
+        Ok(())
     }
 
     fn size() -> usize {
@@ -4271,6 +5127,12 @@ impl FileDispositionInformation {
             1
         };
         Ok(Self { delete_pending })
+    }
+
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: Self::size());
+        dst.write_u8(self.delete_pending);
+        Ok(())
     }
 
     fn size() -> usize {
@@ -4306,6 +5168,18 @@ impl FileRenameInformation {
         })
     }
 
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: self.size());
+        dst.write_u8(self.replace_if_exists.into());
+        dst.write_u8(0); // RootDirectory: MS-RDPEFS 2.2.3.3.9.1 requires zero for network operations.
+        dst.write_u32(cast_length!(
+            "FileRenameInformation",
+            "file_name_length",
+            encoded_str_len(&self.file_name, CharacterSet::Unicode, true)
+        )?);
+        write_string_to_cursor(dst, &self.file_name, CharacterSet::Unicode, true)
+    }
+
     fn size(&self) -> usize {
         Self::FIXED_PART_SIZE + encoded_str_len(&self.file_name, CharacterSet::Unicode, true)
     }
@@ -4326,6 +5200,12 @@ impl FileAllocationInformation {
         ensure_fixed_part_size!(in: src);
         let allocation_size = src.read_i64();
         Ok(Self { allocation_size })
+    }
+
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(in: dst, size: Self::size());
+        dst.write_i64(self.allocation_size);
+        Ok(())
     }
 
     fn size() -> usize {
@@ -4358,6 +5238,16 @@ impl ClientDriveSetInformationResponse {
         self.device_io_reply.encode(dst)?;
         dst.write_u32(self.length);
         Ok(())
+    }
+
+    pub fn decode(device_io_reply: DeviceIoResponse, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(ctx: Self::NAME, in: src, size: 4);
+        let length = src.read_u32();
+
+        Ok(Self {
+            device_io_reply,
+            length,
+        })
     }
 
     pub fn name(&self) -> &'static str {
@@ -4403,6 +5293,18 @@ impl ClientDriveNotifyChangeDirectoryResponse {
         )?);
         dst.write_slice(&self.buffer);
         Ok(())
+    }
+
+    pub fn decode(device_io_reply: DeviceIoResponse, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(ctx: Self::NAME, in: src, size: 4);
+        let length = cast_length!(Self::NAME, "length", src.read_u32())?;
+        ensure_size!(ctx: Self::NAME, in: src, size: length);
+        let buffer = src.read_slice(length).to_vec();
+
+        Ok(Self {
+            device_io_reply,
+            buffer,
+        })
     }
 
     pub fn size(&self) -> usize {
@@ -4469,7 +5371,7 @@ impl ServerDriveLockControlRequest {
         + 20 /* Padding2 */;
     const LOCK_INFO_SIZE: usize = 8 /* Length */ + 8 /* Offset */;
 
-    fn decode(dev_io_req: DeviceIoRequest, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+    pub fn decode(dev_io_req: DeviceIoRequest, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
         ensure_size!(in: src, size: Self::FIXED_PART_SIZE);
         let operation = LockOperation::try_from(src.read_u32())?;
         let wait = src.read_u32() & 1 != 0;
@@ -4495,6 +5397,39 @@ impl ServerDriveLockControlRequest {
             wait,
             locks,
         })
+    }
+
+    pub fn encode(&self, dst: &mut WriteCursor<'_>) -> EncodeResult<()> {
+        ensure_size!(ctx: "ServerDriveLockControlRequest", in: dst, size: self.size());
+        self.device_io_request.encode(dst)?;
+        dst.write_u32(self.operation.into());
+        dst.write_u32(u32::from(self.wait)); // Flags: bit 0 is the only defined flag (wait)
+        dst.write_u32(cast_length!(
+            "ServerDriveLockControlRequest",
+            "num_locks",
+            self.locks.len()
+        )?);
+        write_padding!(dst, 20); // Padding2
+        for lock in &self.locks {
+            dst.write_u64(lock.length);
+            dst.write_u64(lock.offset);
+        }
+        Ok(())
+    }
+
+    pub fn size(&self) -> usize {
+        self.device_io_request.size() + Self::FIXED_PART_SIZE + self.locks.len() * Self::LOCK_INFO_SIZE
+    }
+}
+
+impl From<LockOperation> for u32 {
+    fn from(operation: LockOperation) -> Self {
+        match operation {
+            LockOperation::Shared => 0x0000_0002,
+            LockOperation::Exclusive => 0x0000_0003,
+            LockOperation::Unlock => 0x0000_0004,
+            LockOperation::UnlockMultiple => 0x0000_0005,
+        }
     }
 }
 
@@ -4524,6 +5459,13 @@ impl ClientDriveLockControlResponse {
         self.device_io_reply.encode(dst)?;
         write_padding!(dst, 5);
         Ok(())
+    }
+
+    pub fn decode(device_io_reply: DeviceIoResponse, src: &mut ReadCursor<'_>) -> DecodeResult<Self> {
+        ensure_size!(ctx: Self::NAME, in: src, size: 5);
+        read_padding!(src, 5);
+
+        Ok(Self { device_io_reply })
     }
 
     pub fn size(&self) -> usize {

--- a/crates/ironrdp-rdpdr/src/pdu/esc/mod.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/esc/mod.rs
@@ -532,6 +532,16 @@ impl TryFrom<u32> for ScardIoCtlCode {
     }
 }
 
+impl From<ScardIoCtlCode> for u32 {
+    #[expect(
+        clippy::as_conversions,
+        reason = "guarantees discriminant layout, and as is the only way to cast enum -> primitive"
+    )]
+    fn from(io_ctl_code: ScardIoCtlCode) -> Self {
+        io_ctl_code as u32
+    }
+}
+
 /// Allow [`ScardIoCtlCode`] to be used as an [`IoCtlCode`].
 impl IoCtlCode for ScardIoCtlCode {}
 

--- a/crates/ironrdp-rdpdr/src/pdu/mod.rs
+++ b/crates/ironrdp-rdpdr/src/pdu/mod.rs
@@ -11,8 +11,9 @@ use self::efs::{
     ClientDriveNotifyChangeDirectoryResponse, ClientDriveQueryDirectoryResponse, ClientDriveQueryInformationResponse,
     ClientDriveQuerySecurityResponse, ClientDriveQueryVolumeInformationResponse, ClientDriveSetInformationResponse,
     ClientDriveSetSecurityResponse, ClientNameRequest, CoreCapability, CoreCapabilityKind, DeviceCloseResponse,
-    DeviceControlResponse, DeviceCreateResponse, DeviceFlushBuffersResponse, DeviceIoRequest, DeviceReadResponse,
-    DeviceWriteResponse, ServerDeviceAnnounceResponse, VersionAndIdPdu, VersionAndIdPduKind,
+    DeviceControlResponse, DeviceCreateResponse, DeviceFlushBuffersResponse, DeviceIoRequest, DeviceIoResponse,
+    DeviceReadResponse, DeviceWriteResponse, FileInformationClassLevel, FileSystemInformationClassLevel, MajorFunction,
+    MinorFunction, ServerDeviceAnnounceResponse, VersionAndIdPdu, VersionAndIdPduKind,
 };
 
 pub mod efs;
@@ -128,10 +129,136 @@ impl RdpdrPdu {
             )),
             PacketId::CoreDeviceIoRequest => Ok(RdpdrPdu::DeviceIoRequest(DeviceIoRequest::decode(src)?)),
             PacketId::CoreUserLoggedon => Ok(RdpdrPdu::UserLoggedon),
+            PacketId::CoreClientName => Ok(RdpdrPdu::ClientNameRequest(ClientNameRequest::decode(src)?)),
+            PacketId::CoreClientCapability => Ok(RdpdrPdu::CoreCapability(CoreCapability::decode(header, src)?)),
+            PacketId::CoreDevicelistAnnounce => Ok(RdpdrPdu::ClientDeviceListAnnounce(
+                ClientDeviceListAnnounce::decode(src)?,
+            )),
+            PacketId::CoreDevicelistRemove => {
+                Ok(RdpdrPdu::ClientDeviceListRemove(ClientDeviceListRemove::decode(src)?))
+            }
             packet_id => Err(unsupported_value_err!(
                 "RdpdrPdu::decode_body",
                 "PacketId",
                 format!("{packet_id} ({:#06X})", u16::from(packet_id))
+            )),
+        }
+    }
+
+    /// Decodes a `PacketId::CoreDeviceIoCompletion` body once the caller already knows which
+    /// [`MajorFunction`] (and, for `DirectoryControl`, [`MinorFunction`]) the completion answers.
+    ///
+    /// This PacketId is shared by every completion response type (`RdpdrPdu::decode_body`
+    /// cannot route it: see [`Self::header`], where all of them map to the same `PacketId`), so
+    /// the wire alone cannot disambiguate which one a given completion is. That disambiguation
+    /// requires knowing the `MajorFunction` of the request being completed, which only a
+    /// caller tracking its own outstanding requests (by `CompletionId`) has. `info_class` and
+    /// `volume_info_class` are needed for the same reason, and only for the three completions
+    /// (`QueryInformation`, `DirectoryControl` + `IRP_MN_QUERY_DIRECTORY`, `QueryVolumeInformation`)
+    /// whose body layout depends on which class the original request asked for.
+    pub fn decode_io_completion(
+        major_function: MajorFunction,
+        minor_function: MinorFunction,
+        info_class: Option<FileInformationClassLevel>,
+        volume_info_class: Option<FileSystemInformationClassLevel>,
+        device_io_response: DeviceIoResponse,
+        src: &mut ReadCursor<'_>,
+    ) -> DecodeResult<Self> {
+        match major_function {
+            MajorFunction::Create => Ok(RdpdrPdu::DeviceCreateResponse(DeviceCreateResponse::decode(
+                device_io_response,
+                src,
+            )?)),
+            MajorFunction::Close => Ok(RdpdrPdu::DeviceCloseResponse(DeviceCloseResponse::decode(
+                device_io_response,
+                src,
+            )?)),
+            MajorFunction::Read => Ok(RdpdrPdu::DeviceReadResponse(DeviceReadResponse::decode(
+                device_io_response,
+                src,
+            )?)),
+            MajorFunction::Write => Ok(RdpdrPdu::DeviceWriteResponse(DeviceWriteResponse::decode(
+                device_io_response,
+                src,
+            )?)),
+            MajorFunction::FlushBuffers => Ok(RdpdrPdu::DeviceFlushBuffersResponse(
+                DeviceFlushBuffersResponse::decode(device_io_response),
+            )),
+            MajorFunction::DeviceControl => Ok(RdpdrPdu::DeviceControlResponse(DeviceControlResponse::decode(
+                device_io_response,
+                src,
+            )?)),
+            MajorFunction::QueryInformation => {
+                let info_class = info_class.ok_or_else(|| {
+                    invalid_field_err!(
+                        "RdpdrPdu::decode_io_completion",
+                        "info_class",
+                        "required for QueryInformation"
+                    )
+                })?;
+                Ok(RdpdrPdu::ClientDriveQueryInformationResponse(
+                    ClientDriveQueryInformationResponse::decode_for_class(info_class, device_io_response, src)?,
+                ))
+            }
+            MajorFunction::SetInformation => Ok(RdpdrPdu::ClientDriveSetInformationResponse(
+                ClientDriveSetInformationResponse::decode(device_io_response, src)?,
+            )),
+            MajorFunction::QueryVolumeInformation => {
+                let volume_info_class = volume_info_class.ok_or_else(|| {
+                    invalid_field_err!(
+                        "RdpdrPdu::decode_io_completion",
+                        "volume_info_class",
+                        "required for QueryVolumeInformation"
+                    )
+                })?;
+                Ok(RdpdrPdu::ClientDriveQueryVolumeInformationResponse(
+                    ClientDriveQueryVolumeInformationResponse::decode_for_class(
+                        volume_info_class,
+                        device_io_response,
+                        src,
+                    )?,
+                ))
+            }
+            MajorFunction::DirectoryControl => match minor_function {
+                MinorFunction::IRP_MN_QUERY_DIRECTORY => {
+                    let info_class = info_class.ok_or_else(|| {
+                        invalid_field_err!(
+                            "RdpdrPdu::decode_io_completion",
+                            "info_class",
+                            "required for DirectoryControl/IRP_MN_QUERY_DIRECTORY"
+                        )
+                    })?;
+                    Ok(RdpdrPdu::ClientDriveQueryDirectoryResponse(
+                        ClientDriveQueryDirectoryResponse::decode_for_class(info_class, device_io_response, src)?,
+                    ))
+                }
+                MinorFunction::IRP_MN_NOTIFY_CHANGE_DIRECTORY => {
+                    Ok(RdpdrPdu::ClientDriveNotifyChangeDirectoryResponse(
+                        ClientDriveNotifyChangeDirectoryResponse::decode(device_io_response, src)?,
+                    ))
+                }
+                _ => Err(invalid_field_err!(
+                    "RdpdrPdu::decode_io_completion",
+                    "MinorFunction",
+                    "invalid value"
+                )),
+            },
+            MajorFunction::LockControl => Ok(RdpdrPdu::ClientDriveLockControlResponse(
+                ClientDriveLockControlResponse::decode(device_io_response, src)?,
+            )),
+            MajorFunction::QuerySecurity => Ok(RdpdrPdu::ClientDriveQuerySecurityResponse(
+                ClientDriveQuerySecurityResponse::decode(device_io_response, src)?,
+            )),
+            MajorFunction::SetSecurity => Ok(RdpdrPdu::ClientDriveSetSecurityResponse(
+                ClientDriveSetSecurityResponse::decode(device_io_response, src)?,
+            )),
+            // Matches ServerDriveIoRequest::decode's own treatment of this MajorFunction on the
+            // request side (crates/ironrdp-rdpdr/src/pdu/efs.rs): unsupported end to end, not
+            // specific to the completion side.
+            MajorFunction::SetVolumeInformation => Err(unsupported_value_err!(
+                "RdpdrPdu::decode_io_completion",
+                "MajorFunction",
+                "SetVolumeInformation".to_owned()
             )),
         }
     }

--- a/crates/ironrdp-testsuite-core/tests/rdpdr/mod.rs
+++ b/crates/ironrdp-testsuite-core/tests/rdpdr/mod.rs
@@ -1,15 +1,37 @@
-use ironrdp_core::{encode_vec, impl_as_any};
+use ironrdp_core::{ReadCursor, WriteCursor, encode_vec, impl_as_any};
 use ironrdp_pdu::PduResult;
 use ironrdp_rdpdr::pdu::RdpdrPdu;
 use ironrdp_rdpdr::pdu::efs::{
-    Capabilities, CapabilityMessage, ClientDeviceListAnnounce, CoreCapability, CoreCapabilityKind,
-    DEFAULT_PRINTER_DRIVER_NAME, DeviceAnnounceHeader, DeviceControlRequest, DeviceIoRequest, DeviceType, Devices,
-    MajorFunction, MinorFunction, NtStatus, PRINTER_CAPABILITY_VERSION_01, RDPDR_PRINTER_ANNOUNCE_FLAG_DEFAULTPRINTER,
-    RDPDR_PRINTER_ANNOUNCE_FLAG_NETWORKPRINTER, ServerDeviceAnnounceResponse, ServerDriveIoRequest,
-    VERSION_MINOR_RDP51, VersionAndIdPdu, VersionAndIdPduKind,
+    AnyIoCtlCode, Boolean, Capabilities, CapabilityMessage, ClientDeviceListAnnounce, ClientDeviceListRemove,
+    ClientDriveLockControlResponse, ClientDriveNotifyChangeDirectoryResponse, ClientDriveQueryDirectoryResponse,
+    ClientDriveQueryInformationResponse, ClientDriveQuerySecurityResponse, ClientDriveQueryVolumeInformationResponse,
+    ClientDriveSetInformationResponse, ClientDriveSetSecurityResponse, ClientNameRequest, ClientNameRequestUnicodeFlag,
+    CoreCapability, CoreCapabilityKind, CreateDisposition, CreateOptions, DEFAULT_PRINTER_DRIVER_NAME, DesiredAccess,
+    DeviceAnnounceHeader, DeviceCloseRequest, DeviceCloseResponse, DeviceControlRequest, DeviceControlResponse,
+    DeviceCreateRequest, DeviceCreateResponse, DeviceFlushBuffersRequest, DeviceFlushBuffersResponse, DeviceIoRequest,
+    DeviceIoResponse, DeviceReadRequest, DeviceReadResponse, DeviceType, DeviceWriteRequest, DeviceWriteResponse,
+    Devices, FileAllocationInformation, FileAttributeTagInformation, FileAttributes, FileBasicInformation,
+    FileBothDirectoryInformation, FileDirectoryInformation, FileEndOfFileInformation, FileFsSizeInformation,
+    FileFullDirectoryInformation, FileInformationClass, FileInformationClassLevel, FileNamesInformation,
+    FileStandardInformation, FileSystemInformationClass, FileSystemInformationClassLevel, Information, MajorFunction,
+    MinorFunction, NtStatus, PRINTER_CAPABILITY_VERSION_01, RDPDR_PRINTER_ANNOUNCE_FLAG_DEFAULTPRINTER,
+    RDPDR_PRINTER_ANNOUNCE_FLAG_NETWORKPRINTER, RdpLockInfo, SecurityInformation, ServerDeviceAnnounceResponse,
+    ServerDriveIoRequest, ServerDriveLockControlRequest, ServerDriveNotifyChangeDirectoryRequest,
+    ServerDriveQueryDirectoryRequest, ServerDriveQueryInformationRequest, ServerDriveQuerySecurityRequest,
+    ServerDriveQueryVolumeInformationRequest, ServerDriveSetInformationRequest, ServerDriveSetSecurityRequest,
+    SharedAccess, VERSION_MINOR_RDP51, VersionAndIdPdu, VersionAndIdPduKind,
 };
 use ironrdp_rdpdr::pdu::esc::{ScardCall, ScardIoCtlCode};
 use ironrdp_rdpdr::{NoopRdpdrBackend, Rdpdr, RdpdrBackend};
+
+/// Encodes via a plain `Vec<u8>` buffer for the server-side types in this file, which have
+/// their own inherent `encode`/`size` rather than implementing the crate-wide `Encode` trait
+/// (their `decode` takes caller-supplied context `encode_vec` above has no way to provide).
+fn encode_to_vec(size: usize, f: impl FnOnce(&mut WriteCursor<'_>) -> ironrdp_core::EncodeResult<()>) -> Vec<u8> {
+    let mut buf = vec![0u8; size];
+    f(&mut WriteCursor::new(&mut buf)).unwrap();
+    buf
+}
 use ironrdp_svc::{SvcMessage, SvcProcessor as _};
 
 #[derive(Debug, Default)]
@@ -376,6 +398,25 @@ fn client_announce_reply_uses_minor_version_13() {
 }
 
 #[test]
+fn version_and_id_pdu_decode_client_announce_reply_tags_the_reply_not_the_confirm() {
+    let original = VersionAndIdPdu {
+        version_major: 1,
+        version_minor: 13,
+        client_id: 0x1234,
+        // The value written by encode() doesn't depend on kind: it's only a decode-side tag.
+        kind: VersionAndIdPduKind::ClientAnnounceReply,
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+
+    let decoded = VersionAndIdPdu::decode_client_announce_reply(&mut ReadCursor::new(&encoded)).unwrap();
+
+    assert_eq!(decoded.kind, VersionAndIdPduKind::ClientAnnounceReply);
+    assert_eq!(decoded.version_major, original.version_major);
+    assert_eq!(decoded.version_minor, original.version_minor);
+    assert_eq!(decoded.client_id, original.client_id);
+}
+
+#[test]
 fn devices_add_printer_appends_printer_entry() {
     let mut devices = Devices::new();
     devices.add_printer(9, "Lobby Printer".to_owned());
@@ -487,4 +528,818 @@ fn printer_cache_pdu_is_ignored_before_decode() {
     let pdu = [0x72, 0x44, 0x43, 0x50, 1, 2, 3, 4]; // RDPDR + PAKID_PRN_CACHE_DATA + ignored body
 
     assert!(rdpdr.process(&pdu).unwrap().is_empty());
+}
+
+// ─── Server-side decode / encode round-trips ──────────────────────────────
+//
+// The tests above exercise the existing client-side `Rdpdr` processor. These cover the new
+// server-side PDU codec surface: decode() on what a client sends (responses, device lists,
+// name/capability requests) and encode() on what a server sends (I/O requests). Each type is
+// round-tripped through its own encode/decode rather than through `RdpdrPdu`, except where the
+// dispatch itself (`RdpdrPdu::decode` / `RdpdrPdu::decode_io_completion`) is what's under test.
+
+fn some_device_io_response() -> DeviceIoResponse {
+    DeviceIoResponse {
+        device_id: 7,
+        completion_id: 99,
+        io_status: NtStatus::SUCCESS,
+    }
+}
+
+#[test]
+fn client_name_request_round_trips_ascii_and_unicode() {
+    for (kind, name) in [
+        (ClientNameRequestUnicodeFlag::Ascii, "workstation1"),
+        (ClientNameRequestUnicodeFlag::Unicode, "\u{5DE5}\u{4F5C}\u{7AD9}"),
+    ] {
+        let original = ClientNameRequest::new(name.to_owned(), kind);
+        let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+        let decoded = ClientNameRequest::decode(&mut ReadCursor::new(&encoded)).unwrap();
+        assert_eq!(decoded, original);
+    }
+}
+
+#[test]
+fn core_capability_decodes_both_server_and_client_packet_ids() {
+    let response = RdpdrPdu::CoreCapability(CoreCapability::new_response(vec![CapabilityMessage::new_general(0)]));
+    let encoded = encode_vec(&response).unwrap();
+    let RdpdrPdu::CoreCapability(decoded) = ironrdp_core::decode(&encoded).unwrap() else {
+        panic!("expected CoreCapability");
+    };
+    assert_eq!(decoded.kind, CoreCapabilityKind::ClientCoreCapabilityResponse);
+    assert_eq!(decoded.capabilities.len(), 1);
+}
+
+#[test]
+fn client_device_list_announce_round_trips() {
+    let original = ClientDeviceListAnnounce {
+        device_list: vec![
+            DeviceAnnounceHeader::new_smartcard(1),
+            DeviceAnnounceHeader::new_printer(2, "Lobby".to_owned()),
+        ],
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = ClientDeviceListAnnounce::decode(&mut ReadCursor::new(&encoded)).unwrap();
+
+    assert_eq!(decoded.device_list.len(), 2);
+    assert_eq!(decoded.device_list[0].device_id(), 1);
+    assert_eq!(decoded.device_list[0].preferred_dos_name(), "SCARD");
+    assert_eq!(decoded.device_list[1].device_id(), 2);
+}
+
+#[test]
+fn client_device_list_remove_round_trips() {
+    let original = ClientDeviceListRemove {
+        device_list: vec![1, 2, 3],
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = ClientDeviceListRemove::decode(&mut ReadCursor::new(&encoded)).unwrap();
+    assert_eq!(decoded, original);
+}
+
+#[test]
+fn device_create_response_round_trips() {
+    let original = DeviceCreateResponse {
+        device_io_reply: some_device_io_response(),
+        file_id: 5,
+        information: Information::file_opened(),
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded =
+        DeviceCreateResponse::decode(some_device_io_response(), &mut ReadCursor::new(&encoded[12..])).unwrap();
+    assert_eq!(decoded.file_id, original.file_id);
+    assert_eq!(decoded.information, original.information);
+}
+
+#[test]
+fn device_read_response_round_trips() {
+    let original = DeviceReadResponse {
+        device_io_reply: some_device_io_response(),
+        read_data: b"hello, drive".to_vec(),
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = DeviceReadResponse::decode(some_device_io_response(), &mut ReadCursor::new(&encoded[12..])).unwrap();
+    assert_eq!(decoded.read_data, original.read_data);
+}
+
+#[test]
+fn device_write_response_round_trips() {
+    let original = DeviceWriteResponse {
+        device_io_reply: some_device_io_response(),
+        length: 4096,
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = DeviceWriteResponse::decode(some_device_io_response(), &mut ReadCursor::new(&encoded[12..])).unwrap();
+    assert_eq!(decoded.length, original.length);
+}
+
+#[test]
+fn device_control_response_decodes_output_buffer_as_raw_bytes() {
+    // DeviceControlResponse::new's output_buffer is a generic rpce::Encode trait object with no
+    // decode counterpart (see DeviceControlResponse::decode's doc comment), so this constructs
+    // the wire bytes directly rather than round-tripping through encode().
+    let mut encoded = Vec::new();
+    encoded.extend_from_slice(&4u32.to_le_bytes()); // OutputBufferLength
+    encoded.extend_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD]);
+
+    let decoded = DeviceControlResponse::decode(some_device_io_response(), &mut ReadCursor::new(&encoded)).unwrap();
+    let output_buffer = decoded.output_buffer.expect("non-empty output buffer");
+    assert_eq!(output_buffer.size(), 4);
+
+    // Re-encoding the decoded raw buffer must reproduce the exact bytes read.
+    let re_encoded = encode_to_vec(output_buffer.size(), |dst| output_buffer.encode(dst));
+    assert_eq!(re_encoded, [0xAA, 0xBB, 0xCC, 0xDD]);
+}
+
+#[test]
+fn device_control_response_decodes_empty_output_buffer() {
+    let encoded = 0u32.to_le_bytes();
+    let decoded = DeviceControlResponse::decode(some_device_io_response(), &mut ReadCursor::new(&encoded)).unwrap();
+    assert!(decoded.output_buffer.is_none());
+}
+
+#[test]
+fn client_drive_query_information_response_round_trips_basic_class() {
+    let original = ClientDriveQueryInformationResponse {
+        device_io_response: some_device_io_response(),
+        buffer: Some(FileInformationClass::Basic(FileBasicInformation {
+            creation_time: 1,
+            last_access_time: 2,
+            last_write_time: 3,
+            change_time: 4,
+            file_attributes: FileAttributes::empty(),
+        })),
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = ClientDriveQueryInformationResponse::decode_for_class(
+        FileInformationClassLevel::FILE_BASIC_INFORMATION,
+        some_device_io_response(),
+        &mut ReadCursor::new(&encoded[12..]),
+    )
+    .unwrap();
+    assert_eq!(decoded.buffer, original.buffer);
+}
+
+#[test]
+fn client_drive_query_information_response_round_trips_standard_class() {
+    let original = ClientDriveQueryInformationResponse {
+        device_io_response: some_device_io_response(),
+        buffer: Some(FileInformationClass::Standard(FileStandardInformation {
+            allocation_size: 4096,
+            end_of_file: 1234,
+            number_of_links: 1,
+            delete_pending: Boolean::False,
+            directory: Boolean::True,
+        })),
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = ClientDriveQueryInformationResponse::decode_for_class(
+        FileInformationClassLevel::FILE_STANDARD_INFORMATION,
+        some_device_io_response(),
+        &mut ReadCursor::new(&encoded[12..]),
+    )
+    .unwrap();
+    assert_eq!(decoded.buffer, original.buffer);
+}
+
+#[test]
+fn client_drive_query_information_response_round_trips_attribute_tag_class() {
+    let original = ClientDriveQueryInformationResponse {
+        device_io_response: some_device_io_response(),
+        buffer: Some(FileInformationClass::AttributeTag(FileAttributeTagInformation {
+            file_attributes: FileAttributes::FILE_ATTRIBUTE_DIRECTORY,
+            reparse_tag: 0,
+        })),
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = ClientDriveQueryInformationResponse::decode_for_class(
+        FileInformationClassLevel::FILE_ATTRIBUTE_TAG_INFORMATION,
+        some_device_io_response(),
+        &mut ReadCursor::new(&encoded[12..]),
+    )
+    .unwrap();
+    assert_eq!(decoded.buffer, original.buffer);
+}
+
+#[test]
+fn client_drive_query_information_response_round_trips_no_buffer() {
+    let original = ClientDriveQueryInformationResponse {
+        device_io_response: some_device_io_response(),
+        buffer: None,
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = ClientDriveQueryInformationResponse::decode_for_class(
+        FileInformationClassLevel::FILE_BASIC_INFORMATION,
+        some_device_io_response(),
+        &mut ReadCursor::new(&encoded[12..]),
+    )
+    .unwrap();
+    assert!(decoded.buffer.is_none());
+}
+
+#[test]
+fn client_drive_query_directory_response_round_trips_both_directory_class() {
+    let original = ClientDriveQueryDirectoryResponse {
+        device_io_reply: some_device_io_response(),
+        buffer: Some(FileInformationClass::BothDirectory(FileBothDirectoryInformation::new(
+            10,
+            20,
+            30,
+            40,
+            4096,
+            FileAttributes::FILE_ATTRIBUTE_ARCHIVE,
+            "example.txt".to_owned(),
+        ))),
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = ClientDriveQueryDirectoryResponse::decode_for_class(
+        FileInformationClassLevel::FILE_BOTH_DIRECTORY_INFORMATION,
+        some_device_io_response(),
+        &mut ReadCursor::new(&encoded[12..]),
+    )
+    .unwrap();
+    assert_eq!(decoded.buffer, original.buffer);
+}
+
+#[test]
+fn client_drive_query_directory_response_round_trips_full_directory_class() {
+    let original = ClientDriveQueryDirectoryResponse {
+        device_io_reply: some_device_io_response(),
+        buffer: Some(FileInformationClass::FullDirectory(FileFullDirectoryInformation::new(
+            10,
+            20,
+            30,
+            40,
+            4096,
+            FileAttributes::FILE_ATTRIBUTE_ARCHIVE,
+            "example.txt".to_owned(),
+        ))),
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = ClientDriveQueryDirectoryResponse::decode_for_class(
+        FileInformationClassLevel::FILE_FULL_DIRECTORY_INFORMATION,
+        some_device_io_response(),
+        &mut ReadCursor::new(&encoded[12..]),
+    )
+    .unwrap();
+    assert_eq!(decoded.buffer, original.buffer);
+}
+
+#[test]
+fn client_drive_query_directory_response_round_trips_directory_class() {
+    let original = ClientDriveQueryDirectoryResponse {
+        device_io_reply: some_device_io_response(),
+        buffer: Some(FileInformationClass::Directory(FileDirectoryInformation::new(
+            10,
+            20,
+            30,
+            40,
+            4096,
+            FileAttributes::FILE_ATTRIBUTE_ARCHIVE,
+            "example.txt".to_owned(),
+        ))),
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = ClientDriveQueryDirectoryResponse::decode_for_class(
+        FileInformationClassLevel::FILE_DIRECTORY_INFORMATION,
+        some_device_io_response(),
+        &mut ReadCursor::new(&encoded[12..]),
+    )
+    .unwrap();
+    assert_eq!(decoded.buffer, original.buffer);
+}
+
+#[test]
+fn client_drive_query_directory_response_round_trips_names_class() {
+    let original = ClientDriveQueryDirectoryResponse {
+        device_io_reply: some_device_io_response(),
+        buffer: Some(FileInformationClass::Names(FileNamesInformation::new(
+            "example.txt".to_owned(),
+        ))),
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = ClientDriveQueryDirectoryResponse::decode_for_class(
+        FileInformationClassLevel::FILE_NAMES_INFORMATION,
+        some_device_io_response(),
+        &mut ReadCursor::new(&encoded[12..]),
+    )
+    .unwrap();
+    assert_eq!(decoded.buffer, original.buffer);
+}
+
+#[test]
+fn client_drive_query_security_response_round_trips() {
+    let original = ClientDriveQuerySecurityResponse {
+        device_io_response: some_device_io_response(),
+        security_descriptor: Some(vec![1, 2, 3, 4]),
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded =
+        ClientDriveQuerySecurityResponse::decode(some_device_io_response(), &mut ReadCursor::new(&encoded[12..]))
+            .unwrap();
+    assert_eq!(decoded.security_descriptor, original.security_descriptor);
+}
+
+#[test]
+fn client_drive_set_security_response_round_trips() {
+    let set_request = ServerDriveSetSecurityRequest {
+        device_io_request: some_device_io_request(MajorFunction::SetSecurity, MinorFunction::from(0)),
+        security_information: SecurityInformation::DACL,
+        security_descriptor: vec![1, 2, 3, 4, 5, 6],
+    };
+    let original = ClientDriveSetSecurityResponse::new(&set_request, NtStatus::SUCCESS).unwrap();
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded =
+        ClientDriveSetSecurityResponse::decode(some_device_io_response(), &mut ReadCursor::new(&encoded[12..]))
+            .unwrap();
+    assert_eq!(decoded.length, original.length);
+}
+
+#[test]
+fn device_flush_buffers_response_decodes() {
+    let decoded = DeviceFlushBuffersResponse::decode(some_device_io_response());
+    assert_eq!(decoded.size(), some_device_io_response().size());
+}
+
+#[test]
+fn device_close_response_round_trips() {
+    let original = DeviceCloseResponse {
+        device_io_response: some_device_io_response(),
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = DeviceCloseResponse::decode(some_device_io_response(), &mut ReadCursor::new(&encoded[12..])).unwrap();
+    assert_eq!(decoded, original);
+}
+
+#[test]
+fn client_drive_query_directory_response_round_trips_basic_class() {
+    let original = ClientDriveQueryDirectoryResponse {
+        device_io_reply: some_device_io_response(),
+        buffer: Some(FileInformationClass::Basic(FileBasicInformation {
+            creation_time: 10,
+            last_access_time: 20,
+            last_write_time: 30,
+            change_time: 40,
+            file_attributes: FileAttributes::empty(),
+        })),
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = ClientDriveQueryDirectoryResponse::decode_for_class(
+        FileInformationClassLevel::FILE_BASIC_INFORMATION,
+        some_device_io_response(),
+        &mut ReadCursor::new(&encoded[12..]),
+    )
+    .unwrap();
+    assert_eq!(decoded.buffer, original.buffer);
+}
+
+#[test]
+fn client_drive_query_directory_response_round_trips_empty_buffer() {
+    let original = ClientDriveQueryDirectoryResponse {
+        device_io_reply: some_device_io_response(),
+        buffer: None,
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = ClientDriveQueryDirectoryResponse::decode_for_class(
+        FileInformationClassLevel::FILE_BASIC_INFORMATION,
+        some_device_io_response(),
+        &mut ReadCursor::new(&encoded[12..]),
+    )
+    .unwrap();
+    assert!(decoded.buffer.is_none());
+}
+
+#[test]
+fn client_drive_query_volume_information_response_round_trips() {
+    let original = ClientDriveQueryVolumeInformationResponse {
+        device_io_reply: some_device_io_response(),
+        buffer: Some(FileSystemInformationClass::from(FileFsSizeInformation {
+            total_alloc_units: 1000,
+            available_alloc_units: 500,
+            sectors_per_alloc_unit: 8,
+            bytes_per_sector: 512,
+        })),
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = ClientDriveQueryVolumeInformationResponse::decode_for_class(
+        FileSystemInformationClassLevel::FILE_FS_SIZE_INFORMATION,
+        some_device_io_response(),
+        &mut ReadCursor::new(&encoded[12..]),
+    )
+    .unwrap();
+    assert_eq!(decoded.buffer, original.buffer);
+}
+
+#[test]
+fn client_drive_set_information_response_round_trips() {
+    let set_request = ServerDriveSetInformationRequest {
+        device_io_request: DeviceIoRequest {
+            device_id: 1,
+            file_id: 2,
+            completion_id: 3,
+            major_function: MajorFunction::SetInformation,
+            minor_function: MinorFunction::from(0),
+        },
+        set_buffer: FileInformationClass::EndOfFile(FileEndOfFileInformation { end_of_file: 42 }),
+    };
+    let original = ClientDriveSetInformationResponse::new(&set_request, NtStatus::SUCCESS).unwrap();
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded =
+        ClientDriveSetInformationResponse::decode(some_device_io_response(), &mut ReadCursor::new(&encoded[12..]))
+            .unwrap();
+    // Fields are private; encoding both and comparing bytes is the round-trip check.
+    let re_encoded = encode_to_vec(decoded.size(), |dst| decoded.encode(dst));
+    assert_eq!(re_encoded[12..], encoded[12..]);
+}
+
+#[test]
+fn client_drive_notify_change_directory_response_round_trips() {
+    let original = ClientDriveNotifyChangeDirectoryResponse::new(
+        DeviceIoRequest {
+            device_id: 1,
+            file_id: 2,
+            completion_id: 3,
+            major_function: MajorFunction::DirectoryControl,
+            minor_function: MinorFunction::IRP_MN_NOTIFY_CHANGE_DIRECTORY,
+        },
+        NtStatus::SUCCESS,
+        vec![9, 9, 9],
+    );
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = ClientDriveNotifyChangeDirectoryResponse::decode(
+        some_device_io_response(),
+        &mut ReadCursor::new(&encoded[12..]),
+    )
+    .unwrap();
+    assert_eq!(decoded.buffer, original.buffer);
+}
+
+#[test]
+fn client_drive_lock_control_response_round_trips() {
+    let original = ClientDriveLockControlResponse::new(
+        DeviceIoRequest {
+            device_id: 1,
+            file_id: 2,
+            completion_id: 3,
+            major_function: MajorFunction::LockControl,
+            minor_function: MinorFunction::from(0),
+        },
+        NtStatus::SUCCESS,
+    );
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded =
+        ClientDriveLockControlResponse::decode(original.device_io_reply.clone(), &mut ReadCursor::new(&encoded[12..]))
+            .unwrap();
+    assert_eq!(decoded, original);
+}
+
+fn some_device_io_request(major_function: MajorFunction, minor_function: MinorFunction) -> DeviceIoRequest {
+    DeviceIoRequest {
+        device_id: 1,
+        file_id: 2,
+        completion_id: 3,
+        major_function,
+        minor_function,
+    }
+}
+
+#[test]
+fn device_create_request_round_trips() {
+    let original = DeviceCreateRequest {
+        device_io_request: some_device_io_request(MajorFunction::Create, MinorFunction::from(0)),
+        desired_access: DesiredAccess::empty(),
+        allocation_size: 0,
+        file_attributes: FileAttributes::empty(),
+        shared_access: SharedAccess::empty(),
+        create_disposition: CreateDisposition::FILE_OPEN,
+        create_options: CreateOptions::empty(),
+        path: "\\subdir\\file.txt".to_owned(),
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = ServerDriveIoRequest::decode(
+        some_device_io_request(MajorFunction::Create, MinorFunction::from(0)),
+        &mut ReadCursor::new(&encoded[20..]),
+    )
+    .unwrap();
+    let ServerDriveIoRequest::ServerCreateDriveRequest(decoded) = decoded else {
+        panic!("expected ServerCreateDriveRequest");
+    };
+    assert_eq!(decoded.path, original.path);
+}
+
+#[test]
+fn server_drive_query_information_request_round_trips() {
+    let original = ServerDriveQueryInformationRequest {
+        device_io_request: some_device_io_request(MajorFunction::QueryInformation, MinorFunction::from(0)),
+        file_info_class_lvl: FileInformationClassLevel::FILE_BASIC_INFORMATION,
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = ServerDriveQueryInformationRequest::decode(
+        some_device_io_request(MajorFunction::QueryInformation, MinorFunction::from(0)),
+        &mut ReadCursor::new(&encoded[20..]),
+    )
+    .unwrap();
+    assert_eq!(decoded.file_info_class_lvl, original.file_info_class_lvl);
+}
+
+#[test]
+fn server_drive_query_directory_request_round_trips_with_path() {
+    let original = ServerDriveQueryDirectoryRequest {
+        device_io_request: some_device_io_request(
+            MajorFunction::DirectoryControl,
+            MinorFunction::IRP_MN_QUERY_DIRECTORY,
+        ),
+        file_info_class_lvl: FileInformationClassLevel::FILE_DIRECTORY_INFORMATION,
+        initial_query: 1,
+        path: "*".to_owned(),
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = ServerDriveQueryDirectoryRequest::decode(
+        some_device_io_request(MajorFunction::DirectoryControl, MinorFunction::IRP_MN_QUERY_DIRECTORY),
+        &mut ReadCursor::new(&encoded[20..]),
+    )
+    .unwrap();
+    assert_eq!(decoded.path, original.path);
+    assert_eq!(decoded.initial_query, original.initial_query);
+}
+
+#[test]
+fn server_drive_query_directory_request_round_trips_continuation() {
+    let original = ServerDriveQueryDirectoryRequest {
+        device_io_request: some_device_io_request(
+            MajorFunction::DirectoryControl,
+            MinorFunction::IRP_MN_QUERY_DIRECTORY,
+        ),
+        file_info_class_lvl: FileInformationClassLevel::FILE_DIRECTORY_INFORMATION,
+        initial_query: 0,
+        path: String::new(),
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = ServerDriveQueryDirectoryRequest::decode(
+        some_device_io_request(MajorFunction::DirectoryControl, MinorFunction::IRP_MN_QUERY_DIRECTORY),
+        &mut ReadCursor::new(&encoded[20..]),
+    )
+    .unwrap();
+    assert_eq!(decoded.initial_query, 0);
+    assert_eq!(decoded.path, "");
+}
+
+#[test]
+fn server_drive_query_volume_information_request_round_trips() {
+    let original = ServerDriveQueryVolumeInformationRequest {
+        device_io_request: some_device_io_request(MajorFunction::QueryVolumeInformation, MinorFunction::from(0)),
+        fs_info_class_lvl: FileSystemInformationClassLevel::FILE_FS_SIZE_INFORMATION,
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = ServerDriveQueryVolumeInformationRequest::decode(
+        some_device_io_request(MajorFunction::QueryVolumeInformation, MinorFunction::from(0)),
+        &mut ReadCursor::new(&encoded[20..]),
+    )
+    .unwrap();
+    assert_eq!(decoded.fs_info_class_lvl, original.fs_info_class_lvl);
+}
+
+#[test]
+fn server_drive_set_information_request_round_trips() {
+    let original = ServerDriveSetInformationRequest {
+        device_io_request: some_device_io_request(MajorFunction::SetInformation, MinorFunction::from(0)),
+        set_buffer: FileInformationClass::Allocation(FileAllocationInformation { allocation_size: 8192 }),
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = ServerDriveSetInformationRequest::decode(
+        some_device_io_request(MajorFunction::SetInformation, MinorFunction::from(0)),
+        &mut ReadCursor::new(&encoded[20..]),
+    )
+    .unwrap();
+    assert_eq!(decoded.set_buffer, original.set_buffer);
+}
+
+#[test]
+fn server_drive_notify_change_directory_request_round_trips() {
+    let original = ServerDriveNotifyChangeDirectoryRequest {
+        device_io_request: some_device_io_request(
+            MajorFunction::DirectoryControl,
+            MinorFunction::IRP_MN_NOTIFY_CHANGE_DIRECTORY,
+        ),
+        watch_tree: 1,
+        completion_filter: 0x17,
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = ServerDriveNotifyChangeDirectoryRequest::decode(
+        some_device_io_request(
+            MajorFunction::DirectoryControl,
+            MinorFunction::IRP_MN_NOTIFY_CHANGE_DIRECTORY,
+        ),
+        &mut ReadCursor::new(&encoded[20..]),
+    )
+    .unwrap();
+    assert_eq!(decoded.watch_tree, original.watch_tree);
+    assert_eq!(decoded.completion_filter, original.completion_filter);
+}
+
+#[test]
+fn server_drive_query_security_request_round_trips() {
+    let original = ServerDriveQuerySecurityRequest {
+        device_io_request: some_device_io_request(MajorFunction::QuerySecurity, MinorFunction::from(0)),
+        security_information: SecurityInformation::OWNER | SecurityInformation::DACL,
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = ServerDriveQuerySecurityRequest::decode(
+        some_device_io_request(MajorFunction::QuerySecurity, MinorFunction::from(0)),
+        &mut ReadCursor::new(&encoded[20..]),
+    )
+    .unwrap();
+    assert_eq!(decoded.security_information, original.security_information);
+}
+
+#[test]
+fn server_drive_set_security_request_round_trips() {
+    let original = ServerDriveSetSecurityRequest {
+        device_io_request: some_device_io_request(MajorFunction::SetSecurity, MinorFunction::from(0)),
+        security_information: SecurityInformation::DACL,
+        security_descriptor: vec![1, 2, 3, 4, 5],
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = ServerDriveSetSecurityRequest::decode(
+        some_device_io_request(MajorFunction::SetSecurity, MinorFunction::from(0)),
+        &mut ReadCursor::new(&encoded[20..]),
+    )
+    .unwrap();
+    assert_eq!(decoded.security_descriptor, original.security_descriptor);
+}
+
+#[test]
+fn server_drive_lock_control_request_round_trips() {
+    let original = ServerDriveLockControlRequest {
+        device_io_request: some_device_io_request(MajorFunction::LockControl, MinorFunction::from(0)),
+        operation: ironrdp_rdpdr::pdu::efs::LockOperation::Exclusive,
+        wait: true,
+        locks: vec![RdpLockInfo { length: 100, offset: 0 }],
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = ServerDriveLockControlRequest::decode(
+        some_device_io_request(MajorFunction::LockControl, MinorFunction::from(0)),
+        &mut ReadCursor::new(&encoded[20..]),
+    )
+    .unwrap();
+    assert_eq!(decoded.locks, original.locks);
+    assert_eq!(decoded.wait, original.wait);
+}
+
+#[test]
+fn device_read_request_round_trips() {
+    let original = DeviceReadRequest {
+        device_io_request: some_device_io_request(MajorFunction::Read, MinorFunction::from(0)),
+        length: 4096,
+        offset: 1024,
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = DeviceReadRequest::decode(
+        some_device_io_request(MajorFunction::Read, MinorFunction::from(0)),
+        &mut ReadCursor::new(&encoded[20..]),
+    )
+    .unwrap();
+    assert_eq!(decoded.length, original.length);
+    assert_eq!(decoded.offset, original.offset);
+}
+
+#[test]
+fn device_write_request_round_trips() {
+    let original = DeviceWriteRequest {
+        device_io_request: some_device_io_request(MajorFunction::Write, MinorFunction::from(0)),
+        offset: 2048,
+        write_data: b"payload".to_vec(),
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = DeviceWriteRequest::decode(
+        some_device_io_request(MajorFunction::Write, MinorFunction::from(0)),
+        &mut ReadCursor::new(&encoded[20..]),
+    )
+    .unwrap();
+    assert_eq!(decoded.write_data, original.write_data);
+    assert_eq!(decoded.offset, original.offset);
+}
+
+#[test]
+fn device_control_request_round_trips_any_io_ctl_code() {
+    let original = DeviceControlRequest {
+        header: some_device_io_request(MajorFunction::DeviceControl, MinorFunction::from(0)),
+        output_buffer_length: 1024,
+        input_buffer_length: 4,
+        io_control_code: AnyIoCtlCode(0x0009_0014),
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = DeviceControlRequest::<AnyIoCtlCode>::decode(
+        some_device_io_request(MajorFunction::DeviceControl, MinorFunction::from(0)),
+        &mut ReadCursor::new(&encoded[20..]),
+    )
+    .unwrap();
+    assert_eq!(decoded.output_buffer_length, original.output_buffer_length);
+    assert_eq!(decoded.input_buffer_length, original.input_buffer_length);
+    assert_eq!(decoded.io_control_code, original.io_control_code);
+}
+
+#[test]
+fn device_control_request_round_trips_scard_io_ctl_code() {
+    let original = DeviceControlRequest {
+        header: some_device_io_request(MajorFunction::DeviceControl, MinorFunction::from(0)),
+        output_buffer_length: 256,
+        input_buffer_length: 0,
+        io_control_code: ScardIoCtlCode::EstablishContext,
+    };
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    let decoded = DeviceControlRequest::<ScardIoCtlCode>::decode(
+        some_device_io_request(MajorFunction::DeviceControl, MinorFunction::from(0)),
+        &mut ReadCursor::new(&encoded[20..]),
+    )
+    .unwrap();
+    assert_eq!(decoded.output_buffer_length, original.output_buffer_length);
+    assert_eq!(decoded.io_control_code, original.io_control_code);
+}
+
+#[test]
+fn device_close_request_encodes_full_fixed_size() {
+    let original = DeviceCloseRequest::decode(some_device_io_request(MajorFunction::Close, MinorFunction::from(0)));
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    assert_eq!(encoded.len(), original.size());
+}
+
+#[test]
+fn device_flush_buffers_request_encodes() {
+    let original = DeviceFlushBuffersRequest::decode(some_device_io_request(
+        MajorFunction::FlushBuffers,
+        MinorFunction::from(0),
+    ));
+    let encoded = encode_to_vec(original.size(), |dst| original.encode(dst));
+    assert_eq!(encoded.len(), original.size());
+}
+
+#[test]
+fn decode_io_completion_dispatches_create() {
+    let decoded = RdpdrPdu::decode_io_completion(
+        MajorFunction::Create,
+        MinorFunction::from(0),
+        None,
+        None,
+        some_device_io_response(),
+        &mut ReadCursor::new(&[5, 0, 0, 0, 1]), // file_id=5, information=FILE_OPENED
+    )
+    .unwrap();
+    assert!(matches!(decoded, RdpdrPdu::DeviceCreateResponse(_)));
+}
+
+#[test]
+fn decode_io_completion_dispatches_directory_control_by_minor_function() {
+    let query_dir = RdpdrPdu::decode_io_completion(
+        MajorFunction::DirectoryControl,
+        MinorFunction::IRP_MN_QUERY_DIRECTORY,
+        Some(FileInformationClassLevel::FILE_BASIC_INFORMATION),
+        None,
+        some_device_io_response(),
+        &mut ReadCursor::new(&0u32.to_le_bytes()),
+    )
+    .unwrap();
+    assert!(matches!(query_dir, RdpdrPdu::ClientDriveQueryDirectoryResponse(_)));
+
+    let notify_change = RdpdrPdu::decode_io_completion(
+        MajorFunction::DirectoryControl,
+        MinorFunction::IRP_MN_NOTIFY_CHANGE_DIRECTORY,
+        None,
+        None,
+        some_device_io_response(),
+        &mut ReadCursor::new(&0u32.to_le_bytes()),
+    )
+    .unwrap();
+    assert!(matches!(
+        notify_change,
+        RdpdrPdu::ClientDriveNotifyChangeDirectoryResponse(_)
+    ));
+}
+
+#[test]
+fn decode_io_completion_requires_info_class_for_query_information() {
+    let err = RdpdrPdu::decode_io_completion(
+        MajorFunction::QueryInformation,
+        MinorFunction::from(0),
+        None,
+        None,
+        some_device_io_response(),
+        &mut ReadCursor::new(&0u32.to_le_bytes()),
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("info_class"));
+}
+
+#[test]
+fn decode_io_completion_rejects_set_volume_information() {
+    let err = RdpdrPdu::decode_io_completion(
+        MajorFunction::SetVolumeInformation,
+        MinorFunction::from(0),
+        None,
+        None,
+        some_device_io_response(),
+        &mut ReadCursor::new(&[]),
+    )
+    .unwrap_err();
+    assert!(err.to_string().to_lowercase().contains("majorfunction"));
 }


### PR DESCRIPTION
## Summary

- ironrdp-rdpdr only decodes what a client receives from a server (6 PacketIds) and only encodes what a client sends to a server. A server needs the opposite. This makes the PDU layer bidirectional: decode() added to every response type the client currently only encodes, and encode() added to every request type the client currently only decodes.
- CoreCapability::decode already branched on packet_id for both directions and just needed the client-capability arm wired into RdpdrPdu::decode_body, alongside three new decodes (ClientNameRequest, ClientDeviceListAnnounce, ClientDeviceListRemove).
- CoreDeviceIoCompletion is deliberately not wired into the automatic RdpdrPdu::decode dispatch. Fourteen different response variants share that one PacketId (see the header() method's match), and nothing on the wire disambiguates which one a given completion answers. That requires knowing the MajorFunction (and, for DirectoryControl, MinorFunction) of the original request, which only a future IRP-tracking layer will have. Added RdpdrPdu::decode_io_completion as an explicit entry point for that layer to call once it exists, taking the major/minor function and, for the three completions whose body layout depends on it, the FileInformationClass the original request asked for.
- DeviceControlResponse's output_buffer is a Box<dyn rpce::Encode> on the encode side, since it carries IOCTL-specific NDR content only the issuer of the original request can interpret. That can't be decoded back into a concrete type. Decode reads it as opaque bytes through a private RawOutputBuffer implementing the same trait, so the decoded value has the same shape without pretending to know a structure it can't actually know.
- Filled two response-decode gaps that were there before this PR touched the file, found while checking the new decode paths against MS-RDPEFS directly: FileStandardInformation and FileAttributeTagInformation are two of the exact three classes 2.2.3.3.8 allows for a Query Information response (the third, Basic, already round-tripped) and had encode with no decode. FileDirectoryInformation, FileFullDirectoryInformation, FileBothDirectoryInformation, and FileNamesInformation are the complete set 2.2.3.3.10 allows for a Query Directory response and were entirely unwired in FileInformationClass::decode, so directory listing had no working decode path at all.
- VersionAndIdPdu::decode always tagged PacketId::CoreClientidConfirm as ServerClientIdConfirm. Per MS-RDPEFS 2.2.1.1, that PacketId is shared between Server Client ID Confirm (2.2.2.6) and Client Announce Reply (2.2.2.3): correct for a client, which never decodes its own reply, but wrong for a server decoding the client's reply. Added decode_client_announce_reply as an explicit entry point for that case, mirroring decode_io_completion's precedent for the same class of PacketId ambiguity, and left decode() itself untouched.
- DeviceControlRequest<T> had decode and decode_with_input_buffer but no encode, the one server-sent I/O request missing it. Adding encode required tightening IoCtlCode to also require Into<u32>, which surfaced that ScardIoCtlCode (the trait's only other implementor) was missing that conversion too.

## Validation

`cargo xtask check fmt/lints/tests/typos/locks` all pass. Round-trip tests added for every new decode()/encode() pair in ironrdp-testsuite-core/tests/rdpdr/mod.rs, including one per Query Information and Query Directory class, plus the two additions above.

## Notes

PDU-codec layer only. The RdpdrServer state machine, IRP tracking, and ironrdp-server integration (a factory trait plus attach_channels wiring, the same shape as the recently landed RdpeiServerFactory) are a follow-up PR once this lands, so the server-relevant surface can be reviewed in a size a reviewer can actually hold in their head at once.
