### PR TITLE
feat(activex): redirect dynamic drives

### DIFF
--- a/crates/ironrdp-activex/README.md
+++ b/crates/ironrdp-activex/README.md
@@ -519,9 +519,14 @@ keyboard forwarding.
 `RescanDrives` preserves known selections and applies its Boolean argument only to newly discovered volumes.
 `RedirectDrives` selects or clears the current catalog before connecting.
 `DisableRdpdr` is a hard preconnect override, so it suppresses RDPDR even when drives are selected.
-The worker receives only a snapshot of selected drive names and roots through a `WindowsRdpdrBackendFactory`.
-Drive selection, catalog refresh, and `DisableRdpdr` are sealed after connection setup.
-`RedirectDynamicDrives` remains unsupported, so the collection does not modify an active session.
+The worker receives the selected drive IDs plus a bounded A-through-Z logical-volume catalog through a `WindowsRdpdrBackendFactory`.
+`RedirectDynamicDrives` keeps drive capability negotiation active even when no volume is initially selected.
+`NotifyRedirectDeviceChange` rescans the catalog, preserves stable device IDs and selections, announces newly selected volumes, and removes disappeared volumes from an active session.
+Connected `IMsRdpDrive::RedirectionState` changes use the same RDPDR announce/remove path, while connecting and stopping states reject mutation.
+These updates follow [MS-RDPEFS sections 3.2.5.1.9 and 3.2.5.2.2], including the requirement to announce only new devices and remove disconnected devices before reusing their IDs.
+`RedirectDynamicDevices` reports disabled and rejects enablement because generic Plug and Play devices have no IronRDP backend.
+`IMsRdpDeviceCollection` is therefore retained as an empty collection whose rescan operation returns `E_NOTIMPL`.
+Printer, serial, and parallel-port redirection remain unsupported; smartcard redirection remains independent of drive selection.
 `IMsRdpPreferredRedirectionInfo::UseRedirectionServerName` likewise reports disabled and rejects
 enabling it because IronRDP does not currently consume load-balancing redirection names. Remote
 actions also return `E_NOTIMPL` until an IronRDP session-operation mapping exists.
@@ -803,3 +808,5 @@ sink for the event interface IID before retaining its `IDispatch`.
 This is an Automation, lifecycle, hosting, framebuffer, basic input, RemoteApp projection, persistence, static virtual-channel, and bounded read-only OLE clipboard-snapshot foundation.
 It does not implement writable or file-backed OLE clipboard exchange, monikers, non-filesystem RDPDR device redirection, or arbitrary persisted designer state.
 Those contracts must be added as exact ABI implementations before advertising their individual methods as supported.
+
+[MS-RDPEFS sections 3.2.5.1.9 and 3.2.5.2.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/34d9de58-b2b5-40b6-b970-f82d4603bdb5

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -1322,6 +1322,7 @@ struct CompatibilitySettings {
     redirect_clipboard: bool,
     redirect_webauthn: bool,
     redirect_drives: bool,
+    redirect_dynamic_drives: bool,
     redirect_smart_cards: bool,
     disable_rdpdr: bool,
     drive_catalog: Rc<RefCell<DriveCatalog>>,
@@ -1401,6 +1402,7 @@ impl Default for CompatibilitySettings {
             redirect_clipboard: true,
             redirect_webauthn: true,
             redirect_drives: false,
+            redirect_dynamic_drives: false,
             redirect_smart_cards: false,
             disable_rdpdr: false,
             drive_catalog: Rc::new(RefCell::new(DriveCatalog::new())),
@@ -5941,11 +5943,11 @@ struct ViewAdvise {
 }
 
 #[implement(IMsRdpDeviceCollection)]
-struct EmptyDeviceCollection {
+struct UnsupportedDeviceCollection {
     _lifetime: ServerObjectLifetime,
 }
 
-impl EmptyDeviceCollection {
+impl UnsupportedDeviceCollection {
     fn new() -> Self {
         Self {
             _lifetime: ServerObjectLifetime::new(),
@@ -5953,10 +5955,10 @@ impl EmptyDeviceCollection {
     }
 }
 
-impl IMsRdpDeviceCollection_Impl for EmptyDeviceCollection_Impl {
-    unsafe fn RescanDevices(&self, _dynamic_redirection: i16) -> Result<()> {
-        // TODO(activex): enumerate devices after IronRDP RDPDR exposes a host-device backend.
-        Ok(())
+impl IMsRdpDeviceCollection_Impl for UnsupportedDeviceCollection_Impl {
+    unsafe fn RescanDevices(&self, dynamic_redirection: i16) -> Result<()> {
+        normalize_variant_bool(dynamic_redirection)?;
+        Err(Error::from_hresult(E_NOTIMPL))
     }
 
     unsafe fn get_DeviceByIndex(&self, _index: u32, device: InterfaceOut) -> Result<()> {
@@ -5979,6 +5981,13 @@ struct DriveCatalogEntry {
     name: String,
     root_path: PathBuf,
     redirection_state: Cell<bool>,
+}
+
+impl DriveCatalogEntry {
+    fn redirected_drive(&self) -> Result<ironrdp_rdpdr_native::RedirectedDrive> {
+        ironrdp_rdpdr_native::RedirectedDrive::new(self.device_id, self.name.clone(), self.root_path.clone(), false)
+            .map_err(|error| Error::new(E_FAIL, format!("invalid redirected drive: {error}")))
+    }
 }
 
 struct DriveCatalog {
@@ -6009,22 +6018,34 @@ impl DriveCatalog {
     fn rescan_from_roots(&mut self, roots: Vec<PathBuf>, redirect_new_drives: bool) {
         self.entries = roots
             .into_iter()
-            .map(|root_path| {
-                Rc::clone(self.known_entries.entry(root_path.clone()).or_insert_with(|| {
-                    let device_id = self.next_device_id;
-                    self.next_device_id = self
-                        .next_device_id
-                        .checked_add(1)
-                        .expect("logical-volume RDPDR device IDs must not exhaust u32");
-                    Rc::new(DriveCatalogEntry {
-                        device_id,
-                        name: logical_volume_name(&root_path),
-                        root_path,
-                        redirection_state: Cell::new(redirect_new_drives),
-                    })
-                }))
-            })
+            .map(|root_path| self.get_or_insert(root_path, redirect_new_drives))
             .collect();
+    }
+
+    fn reserve_logical_volume_roots(&mut self) {
+        for root_path in possible_logical_volume_roots() {
+            self.get_or_insert(root_path, false);
+        }
+    }
+
+    fn get_or_insert(&mut self, root_path: PathBuf, redirect_new_drives: bool) -> Rc<DriveCatalogEntry> {
+        if let Some(entry) = self.known_entries.get(&root_path) {
+            return Rc::clone(entry);
+        }
+
+        let device_id = self.next_device_id;
+        self.next_device_id = self
+            .next_device_id
+            .checked_add(1)
+            .expect("logical-volume RDPDR device IDs must not exhaust u32");
+        let entry = Rc::new(DriveCatalogEntry {
+            device_id,
+            name: logical_volume_name(&root_path),
+            root_path: root_path.clone(),
+            redirection_state: Cell::new(redirect_new_drives),
+        });
+        self.known_entries.insert(root_path, Rc::clone(&entry));
+        entry
     }
 
     fn set_redirection_state(&self, value: bool) {
@@ -6033,19 +6054,26 @@ impl DriveCatalog {
         }
     }
 
+    #[cfg(test)]
     fn selected_drives(&self) -> Result<Vec<ironrdp_rdpdr_native::RedirectedDrive>> {
         self.entries
             .iter()
             .filter(|entry| entry.redirection_state.get())
-            .map(|entry| {
-                ironrdp_rdpdr_native::RedirectedDrive::new(
-                    entry.device_id,
-                    entry.name.clone(),
-                    entry.root_path.clone(),
-                    false,
-                )
-                .map_err(|error| Error::new(E_FAIL, format!("invalid redirected drive: {error}")))
-            })
+            .map(|entry| entry.redirected_drive())
+            .collect()
+    }
+
+    fn configured_drives(&self) -> Result<Vec<ironrdp_rdpdr_native::RedirectedDrive>> {
+        let mut entries = self.known_entries.values().collect::<Vec<_>>();
+        entries.sort_unstable_by_key(|entry| entry.device_id);
+        entries.into_iter().map(|entry| entry.redirected_drive()).collect()
+    }
+
+    fn selected_drive_ids(&self) -> Vec<u32> {
+        self.entries
+            .iter()
+            .filter(|entry| entry.redirection_state.get())
+            .map(|entry| entry.device_id)
             .collect()
     }
 
@@ -6065,14 +6093,66 @@ fn logical_volume_roots() -> Vec<PathBuf> {
         tracing::warn!("Unable to enumerate logical drives for ActiveX RDPDR redirection");
     }
 
-    (0..26)
-        .filter(|index| mask & (1u32 << index) != 0)
-        .map(|index| PathBuf::from(format!("{}:\\", char::from(b'A' + index))))
+    possible_logical_volume_roots()
+        .enumerate()
+        .filter(|(index, _)| mask & (1u32 << index) != 0)
+        .map(|(_, root_path)| root_path)
         .collect()
+}
+
+fn possible_logical_volume_roots() -> impl Iterator<Item = PathBuf> {
+    (0..26).map(|index| PathBuf::from(format!("{}:\\", char::from(b'A' + index))))
 }
 
 fn logical_volume_name(root_path: &Path) -> String {
     root_path.to_string_lossy().trim_end_matches(['\\', '/']).to_owned()
+}
+
+#[derive(Default)]
+struct DriveSessionState {
+    drive_hotplug_enabled: Cell<bool>,
+    drive_ids: RefCell<BTreeSet<u32>>,
+}
+
+fn queue_drive_change(
+    session: &DriveSessionState,
+    input_sender: &RefCell<Option<RdpInputSender>>,
+    device_id: u32,
+    name: &str,
+    redirected: bool,
+) -> Result<()> {
+    let is_active = session.drive_ids.borrow().contains(&device_id);
+    if is_active == redirected {
+        return Ok(());
+    }
+    if !session.drive_hotplug_enabled.get() {
+        return Err(Error::new(
+            E_FAIL,
+            "RDPDR drive hotplug is unavailable for this session",
+        ));
+    }
+    let sender = input_sender
+        .borrow()
+        .as_ref()
+        .cloned()
+        .ok_or_else(|| Error::new(E_FAIL, "RDPDR input queue is unavailable"))?;
+    let event = if redirected {
+        RdpInputEvent::AddRdpdrDrive {
+            device_id,
+            name: name.to_owned(),
+        }
+    } else {
+        RdpInputEvent::RemoveRdpdrDrive { device_id }
+    };
+    sender
+        .try_send(event)
+        .map_err(|error| Error::new(E_FAIL, format!("unable to queue RDPDR drive change: {error}")))?;
+    if redirected {
+        session.drive_ids.borrow_mut().insert(device_id);
+    } else {
+        session.drive_ids.borrow_mut().remove(&device_id);
+    }
+    Ok(())
 }
 
 #[implement(IMsRdpDrive)]
@@ -6081,6 +6161,9 @@ struct Drive {
     catalog: Rc<RefCell<DriveCatalog>>,
     entry: Rc<DriveCatalogEntry>,
     settings: Rc<RefCell<CompatibilitySettings>>,
+    connection_state: Rc<Cell<ConnectionState>>,
+    input_sender: Rc<RefCell<Option<RdpInputSender>>>,
+    session: Rc<DriveSessionState>,
 }
 
 impl Drive {
@@ -6088,12 +6171,18 @@ impl Drive {
         catalog: Rc<RefCell<DriveCatalog>>,
         entry: Rc<DriveCatalogEntry>,
         settings: Rc<RefCell<CompatibilitySettings>>,
+        connection_state: Rc<Cell<ConnectionState>>,
+        input_sender: Rc<RefCell<Option<RdpInputSender>>>,
+        session: Rc<DriveSessionState>,
     ) -> Self {
         Self {
             _lifetime: ServerObjectLifetime::new(),
             catalog,
             entry,
             settings,
+            connection_state,
+            input_sender,
+            session,
         }
     }
 }
@@ -6116,12 +6205,28 @@ impl IMsRdpDrive_Impl for Drive_Impl {
             return Err(Error::from_hresult(E_FAIL));
         }
 
-        let settings = self.settings.borrow();
-        if settings.connection_settings_sealed {
-            return Err(Error::from_hresult(E_FAIL));
+        match self.connection_state.get() {
+            ConnectionState::Disconnected => {
+                let settings = self.settings.borrow();
+                if settings.connection_settings_sealed {
+                    return Err(Error::from_hresult(E_FAIL));
+                }
+                mark_compatibility_persistence_dirty(&settings);
+            }
+            ConnectionState::Connected => {
+                queue_drive_change(
+                    &self.session,
+                    &self.input_sender,
+                    self.entry.device_id,
+                    &self.entry.name,
+                    state,
+                )?;
+            }
+            ConnectionState::Connecting | ConnectionState::Stopping => {
+                return Err(Error::from_hresult(E_FAIL));
+            }
         }
         self.entry.redirection_state.set(state);
-        mark_compatibility_persistence_dirty(&settings);
         Ok(())
     }
 
@@ -6142,14 +6247,26 @@ struct DriveCollection {
     _lifetime: ServerObjectLifetime,
     catalog: Rc<RefCell<DriveCatalog>>,
     settings: Rc<RefCell<CompatibilitySettings>>,
+    connection_state: Rc<Cell<ConnectionState>>,
+    input_sender: Rc<RefCell<Option<RdpInputSender>>>,
+    session: Rc<DriveSessionState>,
 }
 
 impl DriveCollection {
-    fn new(catalog: Rc<RefCell<DriveCatalog>>, settings: Rc<RefCell<CompatibilitySettings>>) -> Self {
+    fn new(
+        catalog: Rc<RefCell<DriveCatalog>>,
+        settings: Rc<RefCell<CompatibilitySettings>>,
+        connection_state: Rc<Cell<ConnectionState>>,
+        input_sender: Rc<RefCell<Option<RdpInputSender>>>,
+        session: Rc<DriveSessionState>,
+    ) -> Self {
         Self {
             _lifetime: ServerObjectLifetime::new(),
             catalog,
             settings,
+            connection_state,
+            input_sender,
+            session,
         }
     }
 }
@@ -6157,10 +6274,26 @@ impl DriveCollection {
 impl IMsRdpDriveCollection_Impl for DriveCollection_Impl {
     unsafe fn RescanDrives(&self, redirect_new_drives: i16) -> Result<()> {
         let redirect_new_drives = normalize_variant_bool(redirect_new_drives)? == VARIANT_TRUE.0;
-        if self.settings.borrow().connection_settings_sealed {
+        if matches!(
+            self.connection_state.get(),
+            ConnectionState::Connecting | ConnectionState::Stopping
+        ) {
             return Err(Error::from_hresult(E_FAIL));
         }
-        self.catalog.borrow_mut().rescan(redirect_new_drives);
+        let mut catalog = self.catalog.borrow_mut();
+        catalog.rescan(redirect_new_drives);
+        if self.connection_state.get() == ConnectionState::Connected {
+            let desired_ids = catalog.selected_drive_ids().into_iter().collect::<BTreeSet<_>>();
+            let active_ids = self.session.drive_ids.borrow().clone();
+            for &device_id in active_ids.difference(&desired_ids) {
+                queue_drive_change(&self.session, &self.input_sender, device_id, "", false)?;
+            }
+            for entry in &catalog.entries {
+                if entry.redirection_state.get() && !active_ids.contains(&entry.device_id) {
+                    queue_drive_change(&self.session, &self.input_sender, entry.device_id, &entry.name, true)?;
+                }
+            }
+        }
         mark_compatibility_persistence_dirty(&self.settings.borrow());
         Ok(())
     }
@@ -6178,7 +6311,15 @@ impl IMsRdpDriveCollection_Impl for DriveCollection_Impl {
             // mstscax returns E_UNEXPECTED and does not overwrite the output pointer for an
             // out-of-range index.
             .ok_or_else(|| Error::from_hresult(E_UNEXPECTED))?;
-        let drive: IMsRdpDrive = Drive::new(Rc::clone(&self.catalog), entry, Rc::clone(&self.settings)).into();
+        let drive: IMsRdpDrive = Drive::new(
+            Rc::clone(&self.catalog),
+            entry,
+            Rc::clone(&self.settings),
+            Rc::clone(&self.connection_state),
+            Rc::clone(&self.input_sender),
+            Rc::clone(&self.session),
+        )
+        .into();
         write_out(output, drive.into_raw().cast())
     }
 
@@ -6734,8 +6875,9 @@ pub(crate) struct Control {
     settings: RefCell<Settings>,
     compatibility: Rc<RefCell<CompatibilitySettings>>,
     remote_application: RefCell<RemoteApplicationConfiguration>,
+    device_collection: IMsRdpDeviceCollection,
     drive_collection: IMsRdpDriveCollection,
-    state: Cell<ConnectionState>,
+    state: Rc<Cell<ConnectionState>>,
     last_disconnect: Cell<DisconnectInfo>,
     clipboard_state: Rc<ClipboardState>,
     clipboard_backend: RefCell<Option<WinClipboard>>,
@@ -6744,7 +6886,8 @@ pub(crate) struct Control {
     remote_size: Cell<Option<(i32, i32)>>,
     configured_monitor_topology: RefCell<Option<MonitorTopology>>,
     active_monitor_topology: RefCell<Option<MonitorTopology>>,
-    input_sender: RefCell<Option<RdpInputSender>>,
+    input_sender: Rc<RefCell<Option<RdpInputSender>>>,
+    drive_session: Rc<DriveSessionState>,
     static_channels: RefCell<BTreeMap<String, ActiveXStaticChannelSpec>>,
     input_database: Rc<RefCell<InputDatabase>>,
     touch_tracker: RefCell<TouchContactTracker>,
@@ -6940,8 +7083,18 @@ impl Control {
         let compatibility = Rc::new(RefCell::new(CompatibilitySettings::default()));
         compatibility.borrow_mut().persistence_dirty = Some(Rc::clone(&persistence_dirty));
         let drive_catalog = Rc::clone(&compatibility.borrow().drive_catalog);
-        let drive_collection: IMsRdpDriveCollection =
-            DriveCollection::new(drive_catalog, Rc::clone(&compatibility)).into();
+        let state = Rc::new(Cell::new(ConnectionState::Disconnected));
+        let input_sender = Rc::new(RefCell::new(None));
+        let drive_session = Rc::new(DriveSessionState::default());
+        let device_collection: IMsRdpDeviceCollection = UnsupportedDeviceCollection::new().into();
+        let drive_collection: IMsRdpDriveCollection = DriveCollection::new(
+            drive_catalog,
+            Rc::clone(&compatibility),
+            Rc::clone(&state),
+            Rc::clone(&input_sender),
+            Rc::clone(&drive_session),
+        )
+        .into();
         let input_database = Rc::new(RefCell::new(InputDatabase::new()));
         let frame = Rc::new(RefCell::new(None));
         let presentation_surface = Rc::new(RefCell::new(None));
@@ -6956,8 +7109,9 @@ impl Control {
             settings: RefCell::new(Settings::default()),
             compatibility,
             remote_application: RefCell::new(RemoteApplicationConfiguration::default()),
+            device_collection,
             drive_collection,
-            state: Cell::new(ConnectionState::Disconnected),
+            state,
             last_disconnect: Cell::new(DisconnectInfo::no_info()),
             clipboard_state: Rc::new(ClipboardState {
                 enabled_for_session: Cell::new(false),
@@ -6969,7 +7123,8 @@ impl Control {
             remote_size: Cell::new(None),
             configured_monitor_topology: RefCell::new(None),
             active_monitor_topology: RefCell::new(None),
-            input_sender: RefCell::new(None),
+            input_sender,
+            drive_session,
             static_channels: RefCell::new(BTreeMap::new()),
             input_database,
             touch_tracker: RefCell::new(TouchContactTracker::new()),
@@ -9261,6 +9416,8 @@ impl Control {
                     self.release_input();
                     self.stop_clipboard_redirection();
                     self.input_sender.borrow_mut().take();
+                    self.drive_session.drive_hotplug_enabled.set(false);
+                    self.drive_session.drive_ids.borrow_mut().clear();
                     self.remote_size.set(None);
                     self.active_monitor_topology.borrow_mut().take();
                     self.configured_monitor_topology.borrow_mut().take();
@@ -9780,19 +9937,27 @@ impl Control {
         let redirect_webauthn = compatibility.redirect_webauthn;
         let warn_about_credentials = compatibility.warn_about_sending_credentials;
         let warn_about_clipboard = clipboard && compatibility.warn_about_clipboard_redirection;
-        let redirected_drives = if compatibility.disable_rdpdr {
-            Vec::new()
+        let redirect_dynamic_drives = !compatibility.disable_rdpdr && compatibility.redirect_dynamic_drives;
+        let (configured_drives, initial_drive_ids) = if compatibility.disable_rdpdr {
+            (Vec::new(), Vec::new())
         } else {
-            compatibility.drive_catalog.borrow().selected_drives()?
+            let mut catalog = compatibility.drive_catalog.borrow_mut();
+            catalog.reserve_logical_volume_roots();
+            let initial_drive_ids = catalog.selected_drive_ids();
+            (catalog.configured_drives()?, initial_drive_ids)
         };
         let redirect_smart_cards = !compatibility.disable_rdpdr && compatibility.redirect_smart_cards;
-        let rdpdr_factory = if redirected_drives.is_empty() && !redirect_smart_cards {
+        let rdpdr_factory = if initial_drive_ids.is_empty() && !redirect_dynamic_drives && !redirect_smart_cards {
             None
         } else {
             Some(
-                ironrdp_rdpdr_native::WindowsRdpdrBackendFactory::from_drives(redirected_drives)
-                    .map_err(|error| Error::new(E_FAIL, format!("invalid redirected-drive configuration: {error}")))?
-                    .with_smartcard(redirect_smart_cards),
+                ironrdp_rdpdr_native::WindowsRdpdrBackendFactory::from_drive_configuration(
+                    configured_drives,
+                    initial_drive_ids.clone(),
+                )
+                .map_err(|error| Error::new(E_FAIL, format!("invalid redirected-drive configuration: {error}")))?
+                .with_dynamic_drives(redirect_dynamic_drives)
+                .with_smartcard(redirect_smart_cards),
             )
         };
         let rdpdr_enabled = rdpdr_factory.is_some();
@@ -10436,6 +10601,10 @@ impl Control {
         if consume_initial_execute {
             self.remote_application.borrow_mut().initial_execute = None;
         }
+        self.drive_session
+            .drive_hotplug_enabled
+            .set(rdpdr_enabled && (redirect_dynamic_drives || !initial_drive_ids.is_empty()));
+        *self.drive_session.drive_ids.borrow_mut() = initial_drive_ids.into_iter().collect();
         self.rail_windows.borrow_mut().start(
             remote_program_mode
                 .then(|| self.input_sender.borrow().as_ref().cloned())
@@ -12350,9 +12519,12 @@ impl IMsTscNonScriptable_Impl for Control_Impl {
 
 impl IMsRdpClientNonScriptable_Impl for Control_Impl {
     unsafe fn NotifyRedirectDeviceChange(&self, _wparam: usize, _lparam: isize) -> Result<()> {
-        // This control does not expose a configured ActiveX device collection, so a host device
-        // change cannot affect the RDPDR state that this control advertises.
-        Ok(())
+        let redirect_new_drives = if self.compatibility.borrow().redirect_dynamic_drives {
+            VARIANT_TRUE.0
+        } else {
+            VARIANT_FALSE.0
+        };
+        unsafe { self.drive_collection.RescanDrives(redirect_new_drives) }
     }
 
     unsafe fn SendKeys(&self, key_count: i32, key_up: *mut i16, key_data: *mut i32) -> Result<()> {
@@ -12420,30 +12592,51 @@ impl IMsRdpClientNonScriptable3_Impl for Control_Impl {
         )
     }
 
-    unsafe fn put_RedirectDynamicDrives(&self, _value: i16) -> Result<()> {
-        // TODO(activex): map dynamic-drive redirection to IronRDP RDPDR support.
-        unsupported()
+    unsafe fn put_RedirectDynamicDrives(&self, value: i16) -> Result<()> {
+        let value = normalize_variant_bool(value)? == VARIANT_TRUE.0;
+        match self.state.get() {
+            ConnectionState::Connecting | ConnectionState::Stopping => {
+                return Err(Error::from_hresult(E_FAIL));
+            }
+            ConnectionState::Connected if value && !self.drive_session.drive_hotplug_enabled.get() => {
+                return Err(Error::from_hresult(E_FAIL));
+            }
+            ConnectionState::Disconnected | ConnectionState::Connected => {}
+        }
+        let mut compatibility = self.compatibility.borrow_mut();
+        compatibility.redirect_dynamic_drives = value;
+        mark_compatibility_persistence_dirty(&compatibility);
+        Ok(())
     }
 
     unsafe fn get_RedirectDynamicDrives(&self, value: *mut i16) -> Result<()> {
-        unsupported_out(value)
+        write_out(
+            value,
+            if self.compatibility.borrow().redirect_dynamic_drives {
+                VARIANT_TRUE.0
+            } else {
+                VARIANT_FALSE.0
+            },
+        )
     }
 
-    unsafe fn put_RedirectDynamicDevices(&self, _value: i16) -> Result<()> {
-        // TODO(activex): map dynamic-device redirection to IronRDP RDPDR support.
-        unsupported()
+    unsafe fn put_RedirectDynamicDevices(&self, value: i16) -> Result<()> {
+        if normalize_variant_bool(value)? == VARIANT_FALSE.0 {
+            Ok(())
+        } else {
+            Err(Error::from_hresult(E_NOTIMPL))
+        }
     }
 
     unsafe fn get_RedirectDynamicDevices(&self, value: *mut i16) -> Result<()> {
-        unsupported_out(value)
+        write_out(value, VARIANT_FALSE.0)
     }
 
     unsafe fn get_DeviceCollection(&self, output: InterfaceOut) -> Result<()> {
         if output.is_null() {
             return Err(Error::from_hresult(E_POINTER));
         }
-        let collection: IMsRdpDeviceCollection = EmptyDeviceCollection::new().into();
-        write_out(output, collection.into_raw().cast())
+        write_out(output, self.device_collection.clone().into_raw().cast())
     }
 
     unsafe fn get_DriveCollection(&self, output: InterfaceOut) -> Result<()> {
@@ -17862,10 +18055,16 @@ mod tests {
 
     #[test]
     fn independently_returned_com_children_keep_the_server_loaded() {
-        let _devices: IMsRdpDeviceCollection = EmptyDeviceCollection::new().into();
+        let _devices: IMsRdpDeviceCollection = UnsupportedDeviceCollection::new().into();
         let settings = Rc::new(RefCell::new(CompatibilitySettings::default()));
-        let _drives: IMsRdpDriveCollection =
-            DriveCollection::new(Rc::clone(&settings.borrow().drive_catalog), Rc::clone(&settings)).into();
+        let _drives: IMsRdpDriveCollection = DriveCollection::new(
+            Rc::clone(&settings.borrow().drive_catalog),
+            Rc::clone(&settings),
+            Rc::new(Cell::new(ConnectionState::Disconnected)),
+            Rc::new(RefCell::new(None)),
+            Rc::new(DriveSessionState::default()),
+        )
+        .into();
         let _cameras: IMsRdpCameraRedirConfigCollection = EmptyCameraRedirConfigCollection::new().into();
         let _clipboard: IMsRdpClipboard = ClipboardCapabilities::new(Rc::new(ClipboardState {
             enabled_for_session: Cell::new(false),
@@ -21836,6 +22035,7 @@ mod tests {
     #[test]
     fn drive_catalog_preserves_selection_and_defaults_only_new_volumes() {
         let mut catalog = DriveCatalog::from_roots(vec![PathBuf::from(r"C:\"), PathBuf::from(r"D:\")], false);
+        let system_device_id = catalog.entries[0].device_id;
         catalog.entries[0].redirection_state.set(true);
 
         catalog.rescan_from_roots(
@@ -21852,6 +22052,11 @@ mod tests {
             false,
         );
         assert_eq!(catalog.selected_drive_names(), vec!["C:".to_owned(), "E:".to_owned()]);
+        assert_eq!(catalog.entries[0].device_id, system_device_id);
+
+        catalog.reserve_logical_volume_roots();
+        assert_eq!(catalog.configured_drives().expect("valid drive catalog").len(), 26);
+        assert_eq!(catalog.entries[0].device_id, system_device_id);
     }
 
     #[test]
@@ -21866,7 +22071,17 @@ mod tests {
             persistence_dirty: Some(Rc::clone(&persistence_dirty)),
             ..Default::default()
         }));
-        let collection: IMsRdpDriveCollection = DriveCollection::new(Rc::clone(&catalog), Rc::clone(&settings)).into();
+        let connection_state = Rc::new(Cell::new(ConnectionState::Disconnected));
+        let input_sender = Rc::new(RefCell::new(None));
+        let session = Rc::new(DriveSessionState::default());
+        let collection: IMsRdpDriveCollection = DriveCollection::new(
+            Rc::clone(&catalog),
+            Rc::clone(&settings),
+            Rc::clone(&connection_state),
+            Rc::clone(&input_sender),
+            Rc::clone(&session),
+        )
+        .into();
 
         let mut count = 0;
         unsafe { collection.get_DriveCount(&mut count) }.expect("get drive count");
@@ -21916,6 +22131,69 @@ mod tests {
     }
 
     #[test]
+    fn drive_redirection_state_queues_connected_session_changes() {
+        let catalog = Rc::new(RefCell::new(DriveCatalog::from_roots(
+            vec![PathBuf::from(r"E:\")],
+            false,
+        )));
+        let settings = Rc::new(RefCell::new(CompatibilitySettings {
+            drive_catalog: Rc::clone(&catalog),
+            connection_settings_sealed: true,
+            ..Default::default()
+        }));
+        let connection_state = Rc::new(Cell::new(ConnectionState::Connected));
+        let (sender, mut receiver) = RdpInputSender::channel(2);
+        let input_sender = Rc::new(RefCell::new(Some(sender)));
+        let session = Rc::new(DriveSessionState::default());
+        session.drive_hotplug_enabled.set(true);
+        let collection: IMsRdpDriveCollection = DriveCollection::new(
+            Rc::clone(&catalog),
+            Rc::clone(&settings),
+            connection_state,
+            input_sender,
+            Rc::clone(&session),
+        )
+        .into();
+
+        let mut drive = ptr::null_mut();
+        unsafe { collection.get_DriveByIndex(0, &mut drive) }.expect("get drive");
+        let drive = unsafe { IMsRdpDrive::from_raw(drive) };
+        unsafe { drive.put_RedirectionState(VARIANT_TRUE.0) }.expect("queue dynamic drive");
+
+        assert!(matches!(
+            receiver.try_recv(),
+            Ok(RdpInputEvent::AddRdpdrDrive { device_id: 1, name }) if name == "E:"
+        ));
+        assert!(session.drive_ids.borrow().contains(&1));
+
+        unsafe { drive.put_RedirectionState(VARIANT_FALSE.0) }.expect("queue drive removal");
+        assert!(matches!(
+            receiver.try_recv(),
+            Ok(RdpInputEvent::RemoveRdpdrDrive { device_id: 1 })
+        ));
+        assert!(!session.drive_ids.borrow().contains(&1));
+    }
+
+    #[test]
+    fn drive_change_backpressure_does_not_commit_session_state() {
+        let (sender, _receiver) = RdpInputSender::channel(1);
+        sender
+            .try_send(RdpInputEvent::FastPath(Vec::new().into()))
+            .expect("fill bounded input queue");
+        let input_sender = RefCell::new(Some(sender));
+        let session = DriveSessionState::default();
+        session.drive_hotplug_enabled.set(true);
+
+        assert_eq!(
+            queue_drive_change(&session, &input_sender, 7, "E:", true)
+                .expect_err("full input queue rejects drive change")
+                .code(),
+            E_FAIL
+        );
+        assert!(session.drive_ids.borrow().is_empty());
+    }
+
+    #[test]
     fn control_retains_its_drive_collection() {
         let control: IMsRdpClient10 = Control::new().into();
         let non_scriptable = control
@@ -21929,5 +22207,70 @@ mod tests {
         assert_eq!(first, second);
         drop(unsafe { IMsRdpDriveCollection::from_raw(first) });
         drop(unsafe { IMsRdpDriveCollection::from_raw(second) });
+    }
+
+    #[test]
+    fn control_reports_only_supported_dynamic_redirection() {
+        let control: IMsRdpClient10 = Control::new().into();
+        let non_scriptable = control
+            .cast::<IMsRdpClientNonScriptable3>()
+            .expect("control supports dynamic redirection settings");
+
+        unsafe { non_scriptable.put_RedirectDynamicDrives(VARIANT_TRUE.0) }
+            .expect("dynamic drive redirection is supported");
+        let mut dynamic_drives = VARIANT_FALSE.0;
+        unsafe { non_scriptable.get_RedirectDynamicDrives(&mut dynamic_drives) }.expect("read dynamic drive setting");
+        assert_eq!(dynamic_drives, VARIANT_TRUE.0);
+
+        let mut dynamic_devices = VARIANT_TRUE.0;
+        unsafe { non_scriptable.get_RedirectDynamicDevices(&mut dynamic_devices) }
+            .expect("generic dynamic devices report disabled");
+        assert_eq!(dynamic_devices, VARIANT_FALSE.0);
+        assert_eq!(
+            unsafe { non_scriptable.put_RedirectDynamicDevices(VARIANT_TRUE.0) }
+                .expect_err("generic dynamic devices remain unsupported")
+                .code(),
+            E_NOTIMPL
+        );
+        unsafe { non_scriptable.put_RedirectDynamicDevices(VARIANT_FALSE.0) }
+            .expect("disabling unsupported generic devices is truthful");
+        assert_eq!(
+            unsafe { non_scriptable.put_RedirectDynamicDrives(1) }
+                .expect_err("invalid VARIANT_BOOL is rejected")
+                .code(),
+            E_INVALIDARG
+        );
+    }
+
+    #[test]
+    fn control_retains_an_empty_unsupported_device_collection() {
+        let control: IMsRdpClient10 = Control::new().into();
+        let non_scriptable = control
+            .cast::<IMsRdpClientNonScriptable3>()
+            .expect("control supports the device collection contract");
+
+        let mut first = ptr::null_mut();
+        let mut second = ptr::null_mut();
+        unsafe { non_scriptable.get_DeviceCollection(&mut first) }.expect("get first device collection");
+        unsafe { non_scriptable.get_DeviceCollection(&mut second) }.expect("get second device collection");
+        assert_eq!(first, second);
+        let collection = unsafe { IMsRdpDeviceCollection::from_raw(first) };
+        drop(unsafe { IMsRdpDeviceCollection::from_raw(second) });
+
+        let mut count = u32::MAX;
+        unsafe { collection.get_DeviceCount(&mut count) }.expect("read empty device count");
+        assert_eq!(count, 0);
+        assert_eq!(
+            unsafe { collection.RescanDevices(VARIANT_TRUE.0) }
+                .expect_err("generic device enumeration is unsupported")
+                .code(),
+            E_NOTIMPL
+        );
+        assert_eq!(
+            unsafe { collection.RescanDevices(1) }
+                .expect_err("invalid VARIANT_BOOL is rejected before capability checks")
+                .code(),
+            E_INVALIDARG
+        );
     }
 }

--- a/crates/ironrdp-activex/src/control.rs
+++ b/crates/ironrdp-activex/src/control.rs
@@ -5981,6 +5981,7 @@ struct DriveCatalogEntry {
     name: String,
     root_path: PathBuf,
     redirection_state: Cell<bool>,
+    observed: Cell<bool>,
 }
 
 impl DriveCatalogEntry {
@@ -6018,18 +6019,26 @@ impl DriveCatalog {
     fn rescan_from_roots(&mut self, roots: Vec<PathBuf>, redirect_new_drives: bool) {
         self.entries = roots
             .into_iter()
-            .map(|root_path| self.get_or_insert(root_path, redirect_new_drives))
+            .map(|root_path| self.get_or_insert(root_path, redirect_new_drives, true))
             .collect();
     }
 
     fn reserve_logical_volume_roots(&mut self) {
         for root_path in possible_logical_volume_roots() {
-            self.get_or_insert(root_path, false);
+            self.get_or_insert(root_path, false, false);
         }
     }
 
-    fn get_or_insert(&mut self, root_path: PathBuf, redirect_new_drives: bool) -> Rc<DriveCatalogEntry> {
+    fn get_or_insert(
+        &mut self,
+        root_path: PathBuf,
+        redirect_new_drives: bool,
+        observed: bool,
+    ) -> Rc<DriveCatalogEntry> {
         if let Some(entry) = self.known_entries.get(&root_path) {
+            if observed && !entry.observed.replace(true) {
+                entry.redirection_state.set(redirect_new_drives);
+            }
             return Rc::clone(entry);
         }
 
@@ -6043,6 +6052,7 @@ impl DriveCatalog {
             name: logical_volume_name(&root_path),
             root_path: root_path.clone(),
             redirection_state: Cell::new(redirect_new_drives),
+            observed: Cell::new(observed),
         });
         self.known_entries.insert(root_path, Rc::clone(&entry));
         entry
@@ -6111,7 +6121,8 @@ fn logical_volume_name(root_path: &Path) -> String {
 #[derive(Default)]
 struct DriveSessionState {
     drive_hotplug_enabled: Cell<bool>,
-    drive_ids: RefCell<BTreeSet<u32>>,
+    // ActiveX exposes the desired selection; RDPDR owns pending and acknowledged protocol state.
+    desired_drive_ids: RefCell<BTreeSet<u32>>,
 }
 
 fn queue_drive_change(
@@ -6121,8 +6132,8 @@ fn queue_drive_change(
     name: &str,
     redirected: bool,
 ) -> Result<()> {
-    let is_active = session.drive_ids.borrow().contains(&device_id);
-    if is_active == redirected {
+    let is_desired = session.desired_drive_ids.borrow().contains(&device_id);
+    if !redirected && !is_desired {
         return Ok(());
     }
     if !session.drive_hotplug_enabled.get() {
@@ -6148,9 +6159,9 @@ fn queue_drive_change(
         .try_send(event)
         .map_err(|error| Error::new(E_FAIL, format!("unable to queue RDPDR drive change: {error}")))?;
     if redirected {
-        session.drive_ids.borrow_mut().insert(device_id);
+        session.desired_drive_ids.borrow_mut().insert(device_id);
     } else {
-        session.drive_ids.borrow_mut().remove(&device_id);
+        session.desired_drive_ids.borrow_mut().remove(&device_id);
     }
     Ok(())
 }
@@ -6284,12 +6295,12 @@ impl IMsRdpDriveCollection_Impl for DriveCollection_Impl {
         catalog.rescan(redirect_new_drives);
         if self.connection_state.get() == ConnectionState::Connected {
             let desired_ids = catalog.selected_drive_ids().into_iter().collect::<BTreeSet<_>>();
-            let active_ids = self.session.drive_ids.borrow().clone();
-            for &device_id in active_ids.difference(&desired_ids) {
+            let previous_desired_ids = self.session.desired_drive_ids.borrow().clone();
+            for &device_id in previous_desired_ids.difference(&desired_ids) {
                 queue_drive_change(&self.session, &self.input_sender, device_id, "", false)?;
             }
             for entry in &catalog.entries {
-                if entry.redirection_state.get() && !active_ids.contains(&entry.device_id) {
+                if entry.redirection_state.get() {
                     queue_drive_change(&self.session, &self.input_sender, entry.device_id, &entry.name, true)?;
                 }
             }
@@ -9257,6 +9268,12 @@ impl Control {
                     let _ = response.send(decision);
                 }
                 WorkerEvent::Connected { .. } => {
+                    self.drive_session.drive_hotplug_enabled.set(
+                        self.input_sender
+                            .borrow()
+                            .as_ref()
+                            .is_some_and(RdpInputSender::rdpdr_drive_hotplug_available),
+                    );
                     if self.state.get() == ConnectionState::Connecting {
                         self.state.set(ConnectionState::Connected);
                         if let Some(rpc) = &self.rpc {
@@ -9417,7 +9434,7 @@ impl Control {
                     self.stop_clipboard_redirection();
                     self.input_sender.borrow_mut().take();
                     self.drive_session.drive_hotplug_enabled.set(false);
-                    self.drive_session.drive_ids.borrow_mut().clear();
+                    self.drive_session.desired_drive_ids.borrow_mut().clear();
                     self.remote_size.set(None);
                     self.active_monitor_topology.borrow_mut().take();
                     self.configured_monitor_topology.borrow_mut().take();
@@ -10601,10 +10618,8 @@ impl Control {
         if consume_initial_execute {
             self.remote_application.borrow_mut().initial_execute = None;
         }
-        self.drive_session
-            .drive_hotplug_enabled
-            .set(rdpdr_enabled && (redirect_dynamic_drives || !initial_drive_ids.is_empty()));
-        *self.drive_session.drive_ids.borrow_mut() = initial_drive_ids.into_iter().collect();
+        self.drive_session.drive_hotplug_enabled.set(false);
+        *self.drive_session.desired_drive_ids.borrow_mut() = initial_drive_ids.into_iter().collect();
         self.rail_windows.borrow_mut().start(
             remote_program_mode
                 .then(|| self.input_sender.borrow().as_ref().cloned())
@@ -22057,6 +22072,15 @@ mod tests {
         catalog.reserve_logical_volume_roots();
         assert_eq!(catalog.configured_drives().expect("valid drive catalog").len(), 26);
         assert_eq!(catalog.entries[0].device_id, system_device_id);
+
+        let future_root = PathBuf::from(r"Z:\");
+        let future_entry = Rc::clone(catalog.known_entries.get(&future_root).expect("reserved future drive"));
+        let future_device_id = future_entry.device_id;
+        assert!(!future_entry.observed.get());
+        catalog.rescan_from_roots(vec![future_root], true);
+        assert_eq!(catalog.entries[0].device_id, future_device_id);
+        assert!(catalog.entries[0].observed.get());
+        assert!(catalog.entries[0].redirection_state.get());
     }
 
     #[test]
@@ -22142,7 +22166,7 @@ mod tests {
             ..Default::default()
         }));
         let connection_state = Rc::new(Cell::new(ConnectionState::Connected));
-        let (sender, mut receiver) = RdpInputSender::channel(2);
+        let (sender, mut receiver) = RdpInputSender::channel(3);
         let input_sender = Rc::new(RefCell::new(Some(sender)));
         let session = Rc::new(DriveSessionState::default());
         session.drive_hotplug_enabled.set(true);
@@ -22164,14 +22188,20 @@ mod tests {
             receiver.try_recv(),
             Ok(RdpInputEvent::AddRdpdrDrive { device_id: 1, name }) if name == "E:"
         ));
-        assert!(session.drive_ids.borrow().contains(&1));
+        assert!(session.desired_drive_ids.borrow().contains(&1));
+
+        unsafe { drive.put_RedirectionState(VARIANT_TRUE.0) }.expect("retry desired dynamic drive");
+        assert!(matches!(
+            receiver.try_recv(),
+            Ok(RdpInputEvent::AddRdpdrDrive { device_id: 1, name }) if name == "E:"
+        ));
 
         unsafe { drive.put_RedirectionState(VARIANT_FALSE.0) }.expect("queue drive removal");
         assert!(matches!(
             receiver.try_recv(),
             Ok(RdpInputEvent::RemoveRdpdrDrive { device_id: 1 })
         ));
-        assert!(!session.drive_ids.borrow().contains(&1));
+        assert!(!session.desired_drive_ids.borrow().contains(&1));
     }
 
     #[test]
@@ -22190,7 +22220,7 @@ mod tests {
                 .code(),
             E_FAIL
         );
-        assert!(session.drive_ids.borrow().is_empty());
+        assert!(session.desired_drive_ids.borrow().is_empty());
     }
 
     #[test]
@@ -22239,6 +22269,19 @@ mod tests {
                 .expect_err("invalid VARIANT_BOOL is rejected")
                 .code(),
             E_INVALIDARG
+        );
+
+        let connected_control = Control::new();
+        connected_control.state.set(ConnectionState::Connected);
+        let connected_control: IMsRdpClient10 = connected_control.into();
+        let connected_non_scriptable = connected_control
+            .cast::<IMsRdpClientNonScriptable3>()
+            .expect("connected control supports dynamic redirection settings");
+        assert_eq!(
+            unsafe { connected_non_scriptable.put_RedirectDynamicDrives(VARIANT_TRUE.0) }
+                .expect_err("unavailable connected hotplug is rejected")
+                .code(),
+            E_FAIL
         );
     }
 

--- a/crates/ironrdp-activex/src/mstsc.rs
+++ b/crates/ironrdp-activex/src/mstsc.rs
@@ -47,10 +47,10 @@ pub(crate) unsafe trait ITSRemoteProgram3: ITSRemoteProgram2 {
 
 #[interface("56540617-D281-488C-8738-6A8FDF64A118")]
 pub(crate) unsafe trait IMsRdpDeviceCollection: IUnknown {
-    fn RescanDevices(&self, dynamic_redirection: i16) -> Result<()>;
+    pub(crate) fn RescanDevices(&self, dynamic_redirection: i16) -> Result<()>;
     fn get_DeviceByIndex(&self, index: u32, device: InterfaceOut) -> Result<()>;
     fn get_DeviceById(&self, instance_id: Bstr, device: InterfaceOut) -> Result<()>;
-    fn get_DeviceCount(&self, count: *mut u32) -> Result<()>;
+    pub(crate) fn get_DeviceCount(&self, count: *mut u32) -> Result<()>;
 }
 
 #[interface("7FF17599-DA2C-4677-AD35-F60C04FE1585")]
@@ -133,11 +133,11 @@ pub(crate) unsafe trait IMsRdpClientNonScriptable3: IMsRdpClientNonScriptable2 {
     fn get_NegotiateSecurityLayer(&self, value: *mut i16) -> Result<()>;
     fn put_EnableCredSspSupport(&self, value: i16) -> Result<()>;
     fn get_EnableCredSspSupport(&self, value: *mut i16) -> Result<()>;
-    fn put_RedirectDynamicDrives(&self, value: i16) -> Result<()>;
-    fn get_RedirectDynamicDrives(&self, value: *mut i16) -> Result<()>;
-    fn put_RedirectDynamicDevices(&self, value: i16) -> Result<()>;
-    fn get_RedirectDynamicDevices(&self, value: *mut i16) -> Result<()>;
-    fn get_DeviceCollection(&self, collection: InterfaceOut) -> Result<()>;
+    pub(crate) fn put_RedirectDynamicDrives(&self, value: i16) -> Result<()>;
+    pub(crate) fn get_RedirectDynamicDrives(&self, value: *mut i16) -> Result<()>;
+    pub(crate) fn put_RedirectDynamicDevices(&self, value: i16) -> Result<()>;
+    pub(crate) fn get_RedirectDynamicDevices(&self, value: *mut i16) -> Result<()>;
+    pub(crate) fn get_DeviceCollection(&self, collection: InterfaceOut) -> Result<()>;
     pub(crate) fn get_DriveCollection(&self, collection: InterfaceOut) -> Result<()>;
     fn put_WarnAboutSendingCredentials(&self, value: i16) -> Result<()>;
     fn get_WarnAboutSendingCredentials(&self, value: *mut i16) -> Result<()>;

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -1,5 +1,7 @@
 use core::net::SocketAddr;
 use core::num::NonZeroU16;
+#[cfg(feature = "rdpdr")]
+use core::sync::atomic::{AtomicBool, Ordering};
 use core::time::Duration;
 use std::io;
 use std::sync::Arc;
@@ -247,6 +249,8 @@ pub struct RdpInputSender {
     clipboard_sender: mpsc::UnboundedSender<RdpInputEvent>,
     close_sender: watch::Sender<bool>,
     graceful_close_sender: watch::Sender<bool>,
+    #[cfg(feature = "rdpdr")]
+    rdpdr_drive_hotplug_available: Arc<AtomicBool>,
 }
 
 impl RdpInputSender {
@@ -279,6 +283,8 @@ impl RdpInputSender {
                 clipboard_sender,
                 close_sender,
                 graceful_close_sender,
+                #[cfg(feature = "rdpdr")]
+                rdpdr_drive_hotplug_available: Arc::new(AtomicBool::new(false)),
             },
             input_receiver,
             clipboard_receiver,
@@ -331,6 +337,17 @@ impl RdpInputSender {
     /// immediately cancel a connection attempt or active session instead.
     pub fn request_graceful_close(&self) {
         self.graceful_close_sender.send_replace(true);
+    }
+
+    /// Returns whether the active session negotiated support for RDPDR drive hotplug.
+    #[cfg(feature = "rdpdr")]
+    pub fn rdpdr_drive_hotplug_available(&self) -> bool {
+        self.rdpdr_drive_hotplug_available.load(Ordering::Acquire)
+    }
+
+    #[cfg(feature = "rdpdr")]
+    fn set_rdpdr_drive_hotplug_available(&self, available: bool) {
+        self.rdpdr_drive_hotplug_available.store(available, Ordering::Release);
     }
 }
 
@@ -1435,6 +1452,12 @@ fn build_connector(
                 .enabled
                 .then(|| ironrdp_rdpdr::Rdpdr::new(Box::new(ironrdp_rdpdr::NoopRdpdrBackend), "IronRDP".to_owned()))
         });
+    #[cfg(feature = "rdpdr")]
+    input_sender.set_rdpdr_drive_hotplug_available(
+        rdpdr_channel
+            .as_ref()
+            .is_some_and(ironrdp_rdpdr::Rdpdr::drive_hotplug_available),
+    );
 
     // Windows servers only issue RDPDR traffic when RDPSND is also advertised.
     #[cfg(any(feature = "sound", feature = "rdpdr"))]
@@ -3212,7 +3235,7 @@ mod tests {
     #[cfg(feature = "rdpdr")]
     use core::any::TypeId;
     #[cfg(feature = "rdpdr")]
-    use core::sync::atomic::{AtomicUsize, Ordering};
+    use core::sync::atomic::AtomicUsize;
 
     #[cfg(feature = "rdpdr")]
     use ironrdp_core::encode_vec;
@@ -3811,6 +3834,7 @@ mod tests {
         )
         .expect("RDPDR connector should build");
 
+        assert!(input_sender.rdpdr_drive_hotplug_available());
         assert!(
             connector
                 .get_static_channel_processor::<ironrdp_rdpdr::Rdpdr>()
@@ -3819,6 +3843,30 @@ mod tests {
         assert!(
             connector
                 .get_static_channel_processor::<ironrdp_rdpsnd::client::Rdpsnd>()
+                .is_some()
+        );
+    }
+
+    #[cfg(feature = "rdpdr")]
+    #[test]
+    fn noop_rdpdr_fallback_does_not_report_drive_hotplug() {
+        let config = test_config();
+        let (input_sender, _) = RdpInputSender::channel(1);
+        let mut connector = build_connector(
+            &config,
+            SocketAddr::from(([127, 0, 0, 1], 0)),
+            &input_sender,
+            no_cliprdr_factory(),
+            None,
+            true,
+            None,
+        )
+        .expect("Noop RDPDR connector should build");
+
+        assert!(!input_sender.rdpdr_drive_hotplug_available());
+        assert!(
+            connector
+                .get_static_channel_processor::<ironrdp_rdpdr::Rdpdr>()
                 .is_some()
         );
     }

--- a/crates/ironrdp-client/src/rdp.rs
+++ b/crates/ironrdp-client/src/rdp.rs
@@ -213,6 +213,17 @@ pub enum RdpInputEvent {
         channel_name: ChannelName,
         data: Vec<u8>,
     },
+    /// Activates and announces a preconfigured RDPDR filesystem device.
+    #[cfg(feature = "rdpdr")]
+    AddRdpdrDrive {
+        device_id: u32,
+        name: String,
+    },
+    /// Removes an active RDPDR filesystem device.
+    #[cfg(feature = "rdpdr")]
+    RemoveRdpdrDrive {
+        device_id: u32,
+    },
     /// Requests a RemoteApp launch over the RAIL static channel.
     RailExecute(ExecutePdu),
     /// Queues a client-originated RAIL input event.
@@ -1088,10 +1099,11 @@ fn build_rdpdr_channel(
         return Ok(None);
     };
 
-    let (backend, initial_drives) = factory
+    let product = factory
         .build_rdpdr_backend()
-        .map_err(|error| ironrdp_connector::custom_err!("build RDPDR backend", RdpdrBackendBuildError(error)))?
-        .into_parts();
+        .map_err(|error| ironrdp_connector::custom_err!("build RDPDR backend", RdpdrBackendBuildError(error)))?;
+    let drive_hotplug = allow_drives && product.drive_hotplug();
+    let (backend, initial_drives) = product.into_parts();
     // Gateway drive restrictions do not apply to smartcard redirection, which shares RDPDR.
     let initial_drives = if allow_drives { initial_drives } else { Vec::new() };
 
@@ -1100,7 +1112,7 @@ fn build_rdpdr_channel(
     #[cfg(not(feature = "smartcard"))]
     let smartcard = false;
 
-    if initial_drives.is_empty() && !smartcard {
+    if initial_drives.is_empty() && !smartcard && !drive_hotplug {
         return Ok(None);
     }
 
@@ -1114,7 +1126,7 @@ fn build_rdpdr_channel(
     // `Rdpdr::add_dynamic_drive` hot-plug is unavailable on that session.
     // Prefer attaching an empty drive list only when drive hot-plug is required.
     let mut rdpdr_channel = ironrdp_rdpdr::Rdpdr::new(backend, "IronRDP".to_owned());
-    if !initial_drives.is_empty() {
+    if !initial_drives.is_empty() || drive_hotplug {
         rdpdr_channel = rdpdr_channel.with_drives(Some(initial_drives));
     }
 
@@ -2160,6 +2172,39 @@ fn poll_deferred_rdpdr_output(active_stage: &mut ActiveStage) -> SessionResult<O
     }
 }
 
+#[cfg(feature = "rdpdr")]
+fn process_rdpdr_drive_change(
+    active_stage: &mut ActiveStage,
+    device_id: u32,
+    name: Option<String>,
+) -> SessionResult<Vec<ActiveStageOutput>> {
+    let Some(rdpdr) = active_stage.get_svc_processor_mut::<ironrdp_rdpdr::Rdpdr>() else {
+        warn!(device_id, "Ignoring dynamic drive change because RDPDR is disabled");
+        return Ok(Vec::new());
+    };
+    let messages = match name {
+        Some(name) => rdpdr.add_dynamic_drive(device_id, name),
+        None => rdpdr.remove_drive(device_id),
+    };
+    let messages = match messages {
+        Ok(messages) => messages,
+        Err(error) => {
+            warn!(device_id, %error, "Unable to apply dynamic RDPDR drive change");
+            return Ok(Vec::new());
+        }
+    };
+    if messages.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let frame = active_stage.process_svc_messages_by_name(&ironrdp_rdpdr::Rdpdr::NAME, messages)?;
+    if frame.is_empty() {
+        Ok(Vec::new())
+    } else {
+        Ok(vec![ActiveStageOutput::ResponseFrame(frame)])
+    }
+}
+
 #[expect(
     clippy::too_many_arguments,
     reason = "the active loop owns independent transport, input, clipboard, and cancellation sources"
@@ -2484,6 +2529,14 @@ async fn active_session(
                                 Vec::new()
                             }
                         }
+                    }
+                    #[cfg(feature = "rdpdr")]
+                    RdpInputEvent::AddRdpdrDrive { device_id, name } => {
+                        process_rdpdr_drive_change(&mut active_stage, device_id, Some(name))?
+                    }
+                    #[cfg(feature = "rdpdr")]
+                    RdpInputEvent::RemoveRdpdrDrive { device_id } => {
+                        process_rdpdr_drive_change(&mut active_stage, device_id, None)?
                     }
                     RdpInputEvent::RailExecute(execute) => {
                         let executable = execute.executable.clone();
@@ -3182,6 +3235,7 @@ mod tests {
     struct TestRdpdrBackend {
         instance: usize,
         deferred_messages: Vec<SvcMessage>,
+        dynamic_drive_count: Arc<AtomicUsize>,
     }
 
     #[cfg(feature = "rdpdr")]
@@ -3190,6 +3244,7 @@ mod tests {
             Self {
                 instance,
                 deferred_messages: Vec::new(),
+                dynamic_drive_count: Arc::new(AtomicUsize::new(0)),
             }
         }
 
@@ -3197,6 +3252,7 @@ mod tests {
             Self {
                 instance: 0,
                 deferred_messages: vec![SvcMessage::from(RdpdrPdu::EmptyResponse)],
+                dynamic_drive_count: Arc::new(AtomicUsize::new(0)),
             }
         }
     }
@@ -3228,6 +3284,16 @@ mod tests {
         fn poll_deferred_messages(&mut self) -> ironrdp_pdu::PduResult<Vec<SvcMessage>> {
             Ok(core::mem::take(&mut self.deferred_messages))
         }
+
+        fn add_drive(&mut self, _device_id: u32) -> ironrdp_pdu::PduResult<()> {
+            self.dynamic_drive_count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        fn remove_drive(&mut self, _device_id: u32) -> ironrdp_pdu::PduResult<Vec<SvcMessage>> {
+            self.dynamic_drive_count.fetch_sub(1, Ordering::SeqCst);
+            Ok(Vec::new())
+        }
     }
 
     #[cfg(feature = "rdpdr")]
@@ -3235,6 +3301,7 @@ mod tests {
     struct CountingRdpdrFactory {
         builds: AtomicUsize,
         initial_drives: Vec<RdpdrDrive>,
+        drive_hotplug: bool,
     }
 
     #[cfg(feature = "rdpdr")]
@@ -3243,7 +3310,13 @@ mod tests {
             Self {
                 builds: AtomicUsize::new(0),
                 initial_drives,
+                drive_hotplug: false,
             }
+        }
+
+        fn with_drive_hotplug(mut self) -> Self {
+            self.drive_hotplug = true;
+            self
         }
     }
 
@@ -3251,10 +3324,10 @@ mod tests {
     impl RdpdrBackendFactory for CountingRdpdrFactory {
         fn build_rdpdr_backend(&self) -> RdpdrBackendFactoryResult<RdpdrBackendProduct> {
             let instance = self.builds.fetch_add(1, Ordering::SeqCst) + 1;
-            Ok(RdpdrBackendProduct::new(
-                Box::new(TestRdpdrBackend::new(instance)),
-                self.initial_drives.clone(),
-            ))
+            Ok(
+                RdpdrBackendProduct::new(Box::new(TestRdpdrBackend::new(instance)), self.initial_drives.clone())
+                    .with_drive_hotplug(self.drive_hotplug),
+            )
         }
     }
 
@@ -3476,6 +3549,35 @@ mod tests {
             build_rdpdr_channel(Some(&factory), &config, true)
                 .expect("empty RDPDR product should not fail")
                 .is_none()
+        );
+        assert_eq!(factory.builds.load(Ordering::SeqCst), 1);
+    }
+
+    #[cfg(feature = "rdpdr")]
+    #[test]
+    fn hotplug_only_rdpdr_product_negotiates_drive_capability() {
+        let factory = CountingRdpdrFactory::new(Vec::new()).with_drive_hotplug();
+        let config = crate::config::RdpdrConfig {
+            enabled: true,
+            #[cfg(feature = "smartcard")]
+            smartcard: false,
+        };
+
+        let mut rdpdr = build_rdpdr_channel(Some(&factory), &config, true)
+            .expect("hotplug-only RDPDR product should not fail")
+            .expect("hotplug-only product should build a channel");
+        let server_capability = RdpdrPdu::CoreCapability(CoreCapability {
+            capabilities: vec![CapabilityMessage::new_general(0), CapabilityMessage::new_drive()],
+            kind: CoreCapabilityKind::ServerCoreCapabilityRequest,
+        });
+        rdpdr
+            .process(&encode_vec(&server_capability).expect("encode server capability"))
+            .expect("process server capability");
+        assert!(
+            rdpdr
+                .add_dynamic_drive(42, "E:".to_owned())
+                .expect("hotplug capability was configured before negotiation")
+                .is_empty()
         );
         assert_eq!(factory.builds.load(Ordering::SeqCst), 1);
     }
@@ -3762,6 +3864,44 @@ mod tests {
                 .expect("polling an empty backend should succeed")
                 .is_none()
         );
+    }
+
+    #[cfg(feature = "rdpdr")]
+    #[test]
+    fn dynamic_drive_changes_reach_the_rdpdr_processor() {
+        let backend = TestRdpdrBackend::new(0);
+        let dynamic_drive_count = Arc::clone(&backend.dynamic_drive_count);
+        let mut static_channels = StaticChannelSet::new();
+        assert!(
+            static_channels
+                .insert(ironrdp_rdpdr::Rdpdr::new(Box::new(backend), "test".to_owned()).with_drives(None))
+                .is_none()
+        );
+        let mut active_stage = ActiveStageBuilder {
+            static_channels,
+            user_channel_id: 1001,
+            io_channel_id: 1003,
+            message_channel_id: None,
+            share_id: 0,
+            compression_type: None,
+            enable_server_pointer: false,
+            pointer_software_rendering: false,
+        }
+        .build();
+
+        assert!(
+            process_rdpdr_drive_change(&mut active_stage, 7, Some("E:".to_owned()))
+                .expect("dynamic add is accepted before post-logon announcement")
+                .is_empty()
+        );
+        assert_eq!(dynamic_drive_count.load(Ordering::SeqCst), 1);
+
+        assert!(
+            process_rdpdr_drive_change(&mut active_stage, 7, None)
+                .expect("dynamic removal is accepted")
+                .is_empty()
+        );
+        assert_eq!(dynamic_drive_count.load(Ordering::SeqCst), 0);
     }
 
     #[cfg(feature = "clipboard")]

--- a/crates/ironrdp-rdpdr-native/src/windows/factory.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/factory.rs
@@ -100,6 +100,8 @@ impl core::error::Error for RedirectedDriveError {}
 #[derive(Clone, Debug)]
 pub struct WindowsRdpdrBackendFactory {
     drives: Vec<RedirectedDrive>,
+    initial_drive_ids: Vec<u32>,
+    dynamic_drives: bool,
     smartcard: bool,
 }
 
@@ -107,25 +109,58 @@ impl WindowsRdpdrBackendFactory {
     /// Configures the single logical-volume root supported by this baseline.
     #[must_use]
     pub fn new(drive: RedirectedDrive) -> Self {
+        let device_id = drive.device_id();
         Self {
             drives: vec![drive],
+            initial_drive_ids: vec![device_id],
+            dynamic_drives: false,
             smartcard: false,
         }
     }
 
     /// Configures the logical-volume roots selected for one connection.
     pub fn from_drives(drives: Vec<RedirectedDrive>) -> Result<Self, RedirectedDriveFactoryError> {
+        let initial_drive_ids = drives.iter().map(RedirectedDrive::device_id).collect();
+        Self::from_drive_configuration(drives, initial_drive_ids)
+    }
+
+    /// Configures all logical-volume roots that may be activated during one connection.
+    ///
+    /// Only IDs in `initial_drive_ids` are announced during channel initialization.
+    /// Other configured roots remain available for a later dynamic announcement.
+    pub fn from_drive_configuration(
+        drives: Vec<RedirectedDrive>,
+        initial_drive_ids: Vec<u32>,
+    ) -> Result<Self, RedirectedDriveFactoryError> {
         let mut device_ids = HashSet::with_capacity(drives.len());
         for drive in &drives {
             if !device_ids.insert(drive.device_id()) {
-                return Err(RedirectedDriveFactoryError::DuplicateDeviceId(drive.device_id()));
+                return Err(RedirectedDriveFactoryError::ConfiguredIdCollision(drive.device_id()));
+            }
+        }
+        let mut selected_ids = HashSet::with_capacity(initial_drive_ids.len());
+        for device_id in &initial_drive_ids {
+            if !selected_ids.insert(*device_id) {
+                return Err(RedirectedDriveFactoryError::InitialIdDuplicate(*device_id));
+            }
+            if !device_ids.contains(device_id) {
+                return Err(RedirectedDriveFactoryError::InitialIdUnknown(*device_id));
             }
         }
 
         Ok(Self {
             drives,
+            initial_drive_ids,
+            dynamic_drives: false,
             smartcard: false,
         })
+    }
+
+    /// Keeps RDPDR drive capability available for later logical-volume hotplug.
+    #[must_use]
+    pub fn with_dynamic_drives(mut self, enabled: bool) -> Self {
+        self.dynamic_drives = enabled;
+        self
     }
 
     /// Records whether products intend WinSCard smartcard redirection with this factory.
@@ -151,9 +186,16 @@ impl WindowsRdpdrBackendFactory {
     /// Returns the initial `(device_id, name)` pair for `Rdpdr::with_drives`.
     #[must_use]
     pub fn initial_drives(&self) -> Vec<(u32, String)> {
-        self.drives
+        self.initial_drive_ids
             .iter()
-            .map(|drive| (drive.device_id, drive.display_name.clone()))
+            .map(|device_id| {
+                let drive = self
+                    .drives
+                    .iter()
+                    .find(|drive| drive.device_id == *device_id)
+                    .expect("initial RDPDR drive IDs are validated when the factory is created");
+                (drive.device_id, drive.display_name.clone())
+            })
             .collect()
     }
 
@@ -176,7 +218,8 @@ impl RdpdrBackendFactory for WindowsRdpdrBackendFactory {
                 .into_iter()
                 .map(|(device_id, name)| RdpdrDrive::new(device_id, name))
                 .collect(),
-        ))
+        )
+        .with_drive_hotplug(self.dynamic_drives))
     }
 }
 
@@ -184,13 +227,21 @@ impl RdpdrBackendFactory for WindowsRdpdrBackendFactory {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RedirectedDriveFactoryError {
     /// More than one selected drive used the same RDPDR device ID.
-    DuplicateDeviceId(u32),
+    ConfiguredIdCollision(u32),
+    /// An initial drive ID was listed more than once.
+    InitialIdDuplicate(u32),
+    /// An initial drive ID has no matching configured logical volume.
+    InitialIdUnknown(u32),
 }
 
 impl fmt::Display for RedirectedDriveFactoryError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::DuplicateDeviceId(device_id) => write!(f, "duplicate RDPDR device ID {device_id}"),
+            Self::ConfiguredIdCollision(device_id) => write!(f, "duplicate RDPDR device ID {device_id}"),
+            Self::InitialIdDuplicate(device_id) => write!(f, "duplicate initial RDPDR device ID {device_id}"),
+            Self::InitialIdUnknown(device_id) => {
+                write!(f, "initial RDPDR device ID {device_id} is not configured")
+            }
         }
     }
 }
@@ -200,6 +251,7 @@ impl core::error::Error for RedirectedDriveFactoryError {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ironrdp_rdpdr::RdpdrBackend as _;
 
     #[test]
     fn factory_preserves_portable_initial_drive_names() {
@@ -242,6 +294,24 @@ mod tests {
     }
 
     #[test]
+    fn factory_keeps_unannounced_drives_available_to_the_backend() {
+        let factory = WindowsRdpdrBackendFactory::from_drive_configuration(
+            vec![
+                RedirectedDrive::new(1, "System", r"C:\", false).expect("valid system drive"),
+                RedirectedDrive::new(2, "Removable", r"E:\", false).expect("valid removable drive"),
+            ],
+            vec![1],
+        )
+        .expect("valid drive configuration");
+
+        assert_eq!(factory.initial_drives(), vec![(1, "System".to_owned())]);
+        let mut backend = factory.build();
+        backend
+            .add_drive(2)
+            .expect("configured drive can be activated dynamically");
+    }
+
+    #[test]
     fn factory_tracks_smartcard_enablement() {
         let factory = WindowsRdpdrBackendFactory::from_drives(Vec::new())
             .expect("empty drive list is valid")
@@ -252,12 +322,41 @@ mod tests {
     }
 
     #[test]
+    fn factory_tracks_dynamic_drive_enablement() {
+        let product = WindowsRdpdrBackendFactory::from_drives(Vec::new())
+            .expect("empty drive list is valid")
+            .with_dynamic_drives(true)
+            .build_rdpdr_backend()
+            .expect("build hotplug-only product");
+
+        assert!(product.drive_hotplug());
+        assert!(product.initial_drives().is_empty());
+    }
+
+    #[test]
     fn factory_rejects_duplicate_device_ids() {
         let result = WindowsRdpdrBackendFactory::from_drives(vec![
             RedirectedDrive::new(1, "System", r"C:\", false).expect("valid system drive"),
             RedirectedDrive::new(1, "Data", r"D:\", false).expect("valid data drive"),
         ]);
 
-        assert!(matches!(result, Err(RedirectedDriveFactoryError::DuplicateDeviceId(1))));
+        assert!(matches!(
+            result,
+            Err(RedirectedDriveFactoryError::ConfiguredIdCollision(1))
+        ));
+    }
+
+    #[test]
+    fn factory_rejects_invalid_initial_drive_ids() {
+        let drive = RedirectedDrive::new(1, "System", r"C:\", false).expect("valid system drive");
+
+        assert!(matches!(
+            WindowsRdpdrBackendFactory::from_drive_configuration(vec![drive.clone()], vec![1, 1]),
+            Err(RedirectedDriveFactoryError::InitialIdDuplicate(1))
+        ));
+        assert!(matches!(
+            WindowsRdpdrBackendFactory::from_drive_configuration(vec![drive], vec![2]),
+            Err(RedirectedDriveFactoryError::InitialIdUnknown(2))
+        ));
     }
 }

--- a/crates/ironrdp-rdpdr-native/src/windows/factory.rs
+++ b/crates/ironrdp-rdpdr-native/src/windows/factory.rs
@@ -135,16 +135,16 @@ impl WindowsRdpdrBackendFactory {
         let mut device_ids = HashSet::with_capacity(drives.len());
         for drive in &drives {
             if !device_ids.insert(drive.device_id()) {
-                return Err(RedirectedDriveFactoryError::ConfiguredIdCollision(drive.device_id()));
+                return Err(RedirectedDriveFactoryError::DuplicateDeviceId(drive.device_id()));
             }
         }
         let mut selected_ids = HashSet::with_capacity(initial_drive_ids.len());
         for device_id in &initial_drive_ids {
             if !selected_ids.insert(*device_id) {
-                return Err(RedirectedDriveFactoryError::InitialIdDuplicate(*device_id));
+                return Err(RedirectedDriveFactoryError::RepeatedInitialSelection(*device_id));
             }
             if !device_ids.contains(device_id) {
-                return Err(RedirectedDriveFactoryError::InitialIdUnknown(*device_id));
+                return Err(RedirectedDriveFactoryError::UnconfiguredInitialSelection(*device_id));
             }
         }
 
@@ -227,19 +227,19 @@ impl RdpdrBackendFactory for WindowsRdpdrBackendFactory {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RedirectedDriveFactoryError {
     /// More than one selected drive used the same RDPDR device ID.
-    ConfiguredIdCollision(u32),
+    DuplicateDeviceId(u32),
     /// An initial drive ID was listed more than once.
-    InitialIdDuplicate(u32),
+    RepeatedInitialSelection(u32),
     /// An initial drive ID has no matching configured logical volume.
-    InitialIdUnknown(u32),
+    UnconfiguredInitialSelection(u32),
 }
 
 impl fmt::Display for RedirectedDriveFactoryError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::ConfiguredIdCollision(device_id) => write!(f, "duplicate RDPDR device ID {device_id}"),
-            Self::InitialIdDuplicate(device_id) => write!(f, "duplicate initial RDPDR device ID {device_id}"),
-            Self::InitialIdUnknown(device_id) => {
+            Self::DuplicateDeviceId(device_id) => write!(f, "duplicate RDPDR device ID {device_id}"),
+            Self::RepeatedInitialSelection(device_id) => write!(f, "duplicate initial RDPDR device ID {device_id}"),
+            Self::UnconfiguredInitialSelection(device_id) => {
                 write!(f, "initial RDPDR device ID {device_id} is not configured")
             }
         }
@@ -340,10 +340,7 @@ mod tests {
             RedirectedDrive::new(1, "Data", r"D:\", false).expect("valid data drive"),
         ]);
 
-        assert!(matches!(
-            result,
-            Err(RedirectedDriveFactoryError::ConfiguredIdCollision(1))
-        ));
+        assert!(matches!(result, Err(RedirectedDriveFactoryError::DuplicateDeviceId(1))));
     }
 
     #[test]
@@ -352,11 +349,11 @@ mod tests {
 
         assert!(matches!(
             WindowsRdpdrBackendFactory::from_drive_configuration(vec![drive.clone()], vec![1, 1]),
-            Err(RedirectedDriveFactoryError::InitialIdDuplicate(1))
+            Err(RedirectedDriveFactoryError::RepeatedInitialSelection(1))
         ));
         assert!(matches!(
             WindowsRdpdrBackendFactory::from_drive_configuration(vec![drive], vec![2]),
-            Err(RedirectedDriveFactoryError::InitialIdUnknown(2))
+            Err(RedirectedDriveFactoryError::UnconfiguredInitialSelection(2))
         ));
     }
 }

--- a/crates/ironrdp-rdpdr/src/backend/mod.rs
+++ b/crates/ironrdp-rdpdr/src/backend/mod.rs
@@ -158,10 +158,12 @@ impl RdpdrDrive {
 
 /// Per-connection product created by an [`RdpdrBackendFactory`].
 ///
-/// The backend and drive list describe the same immutable device set.
+/// The initial list is announced during channel initialization.
+/// A backend that enables drive hotplug may also contain dormant filesystem devices.
 pub struct RdpdrBackendProduct {
     backend: Box<dyn RdpdrBackend>,
     initial_drives: Vec<RdpdrDrive>,
+    drive_hotplug: bool,
 }
 
 impl RdpdrBackendProduct {
@@ -170,12 +172,25 @@ impl RdpdrBackendProduct {
         Self {
             backend,
             initial_drives,
+            drive_hotplug: false,
         }
+    }
+
+    /// Enables drive capability negotiation even when no drive is announced initially.
+    #[must_use]
+    pub fn with_drive_hotplug(mut self, enabled: bool) -> Self {
+        self.drive_hotplug = enabled;
+        self
     }
 
     /// Returns the filesystem devices announced when the server accepts RDPDR.
     pub fn initial_drives(&self) -> &[RdpdrDrive] {
         &self.initial_drives
+    }
+
+    /// Returns whether the channel must remain available for later drive announcements.
+    pub fn drive_hotplug(&self) -> bool {
+        self.drive_hotplug
     }
 
     /// Consumes the product into its backend and matching announcement metadata.

--- a/crates/ironrdp-rdpdr/src/lib.rs
+++ b/crates/ironrdp-rdpdr/src/lib.rs
@@ -113,6 +113,11 @@ impl Rdpdr {
         self
     }
 
+    /// Returns whether this channel can accept dynamic filesystem devices.
+    pub fn drive_hotplug_available(&self) -> bool {
+        self.drive_capability_configured
+    }
+
     /// Adds printer redirection capability and announces a single
     /// virtual printer under `device_id` with the user-visible name
     /// `print_name`.
@@ -168,8 +173,19 @@ impl Rdpdr {
         if name.is_empty() || name.contains('\0') {
             return Err(pdu_other_err!("dynamic drive name must be nonempty and contain no NUL"));
         }
-        if self.device_types.iter().any(|(id, _)| *id == device_id) {
-            return Err(pdu_other_err!("dynamic drive uses an already-live device ID"));
+        if let Some((_, device_type)) = self.device_types.iter().find(|(id, _)| *id == device_id) {
+            if *device_type != DeviceType::Filesystem {
+                return Err(pdu_other_err!("dynamic drive uses an already-live device ID"));
+            }
+            if self.pending_drive_removals.contains(&device_id) {
+                self.pending_drive_removals.retain(|id| *id != device_id);
+                return Ok(Vec::new());
+            }
+            if self.rejected_device_ids.contains(&device_id) {
+                self.unregister_drive(device_id)?;
+            } else {
+                return Ok(Vec::new());
+            }
         }
         if !self.drive_capability_configured && self.server_capabilities_received {
             return Err(pdu_other_err!(
@@ -227,14 +243,7 @@ impl Rdpdr {
             Vec::new()
         };
 
-        self.device_list
-            .remove_device(device_id)
-            .ok_or_else(|| pdu_other_err!("device disappeared from the RDPDR device list"))?;
-        self.device_types.retain(|(id, _)| *id != device_id);
-        self.active_device_ids.retain(|id| *id != device_id);
-        self.rejected_device_ids.retain(|id| *id != device_id);
-        self.manually_announced_device_ids.retain(|id| *id != device_id);
-        self.backend_active_drive_ids.retain(|id| *id != device_id);
+        self.unregister_drive(device_id)?;
 
         if was_active {
             messages.push(SvcMessage::from(RdpdrPdu::ClientDeviceListRemove(
@@ -243,6 +252,20 @@ impl Rdpdr {
         }
 
         Ok(messages)
+    }
+
+    fn unregister_drive(&mut self, device_id: u32) -> PduResult<()> {
+        self.device_list
+            .remove_device(device_id)
+            .ok_or_else(|| pdu_other_err!("device disappeared from the RDPDR device list"))?;
+        self.device_types.retain(|(id, _)| *id != device_id);
+        self.pending_device_announcements.retain(|id| *id != device_id);
+        self.pending_drive_removals.retain(|id| *id != device_id);
+        self.manually_announced_device_ids.retain(|id| *id != device_id);
+        self.active_device_ids.retain(|id| *id != device_id);
+        self.rejected_device_ids.retain(|id| *id != device_id);
+        self.backend_active_drive_ids.retain(|id| *id != device_id);
+        Ok(())
     }
 
     /// Builds a removal PDU for a non-filesystem or externally managed device.
@@ -287,6 +310,9 @@ impl Rdpdr {
     }
 
     fn handle_server_announce(&mut self, req: VersionAndIdPdu) -> PduResult<Vec<SvcMessage>> {
+        for device_id in core::mem::take(&mut self.pending_drive_removals) {
+            self.unregister_drive(device_id)?;
+        }
         let configured_drive_ids = self
             .device_list
             .clone_inner()
@@ -312,7 +338,6 @@ impl Rdpdr {
         self.client_id_confirmed = false;
         self.post_logon_devices_announced = false;
         self.pending_device_announcements.clear();
-        self.pending_drive_removals.clear();
         self.manually_announced_device_ids.clear();
         self.active_device_ids.clear();
         self.rejected_device_ids.clear();
@@ -507,11 +532,7 @@ impl Rdpdr {
         }
         self.active_device_ids.retain(|id| *id != device_id);
         if removal_requested {
-            self.device_list
-                .remove_device(device_id)
-                .ok_or_else(|| pdu_other_err!("device disappeared from the RDPDR device list"))?;
-            self.device_types.retain(|(id, _)| *id != device_id);
-            self.rejected_device_ids.retain(|id| *id != device_id);
+            self.unregister_drive(device_id)?;
         }
 
         messages.push(SvcMessage::from(RdpdrPdu::ClientDeviceListRemove(
@@ -1171,6 +1192,116 @@ mod tests {
                 .removed_drives,
             vec![42]
         );
+
+        assert_eq!(
+            rdpdr
+                .add_dynamic_drive(42, "C:".to_owned())
+                .expect("readd dynamically removed drive")
+                .len(),
+            1
+        );
+        assert!(
+            rdpdr
+                .process(&encoded_server_device_announce_response(42, NtStatus::SUCCESS))
+                .expect("accept readded dynamic drive")
+                .is_empty()
+        );
+        assert_eq!(
+            rdpdr
+                .downcast_backend::<TrackingBackend>()
+                .expect("tracking backend")
+                .added_drives,
+            vec![42, 42]
+        );
+        assert_eq!(
+            rdpdr
+                .downcast_backend::<TrackingBackend>()
+                .expect("tracking backend")
+                .removed_drives,
+            vec![42]
+        );
+    }
+
+    #[test]
+    fn rapid_add_remove_add_cancels_pending_removal() {
+        let mut rdpdr = Rdpdr::new(Box::new(TrackingBackend::default()), "test".to_owned());
+        rdpdr.add_dynamic_drive(42, "C:".to_owned()).expect("add dynamic drive");
+        let responses = rdpdr
+            .process(&encoded_server_announce(0x1234))
+            .expect("process server announce");
+        let client_id = read_u32(
+            &responses[0]
+                .encode_unframed_pdu()
+                .expect("encode client announce response"),
+            8,
+        );
+        rdpdr
+            .process(&encoded_server_client_id_confirm(client_id))
+            .expect("process server client ID confirm");
+        rdpdr
+            .process(&encode_vec(&RdpdrPdu::UserLoggedon).expect("encode user logged on"))
+            .expect("process user logged on");
+
+        assert!(rdpdr.remove_drive(42).expect("defer pending removal").is_empty());
+        assert!(
+            rdpdr
+                .add_dynamic_drive(42, "C:".to_owned())
+                .expect("cancel pending removal")
+                .is_empty()
+        );
+        assert!(
+            rdpdr
+                .process(&encoded_server_device_announce_response(42, NtStatus::SUCCESS))
+                .expect("accept retained dynamic drive")
+                .is_empty()
+        );
+        assert!(
+            rdpdr
+                .downcast_backend::<TrackingBackend>()
+                .expect("tracking backend")
+                .removed_drives
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn replacement_sequence_applies_pending_drive_removal() {
+        let mut rdpdr = Rdpdr::new(Box::new(TrackingBackend::default()), "test".to_owned());
+        let responses = rdpdr
+            .process(&encoded_server_announce(0x1234))
+            .expect("process server announce");
+        let client_id = read_u32(
+            &responses[0]
+                .encode_unframed_pdu()
+                .expect("encode client announce response"),
+            8,
+        );
+        rdpdr
+            .process(&encoded_server_client_id_confirm(client_id))
+            .expect("process server client ID confirm");
+        rdpdr
+            .process(&encode_vec(&RdpdrPdu::UserLoggedon).expect("encode user logged on"))
+            .expect("process user logged on");
+        assert_eq!(
+            rdpdr
+                .add_dynamic_drive(42, "C:".to_owned())
+                .expect("announce dynamic drive")
+                .len(),
+            1
+        );
+        assert!(rdpdr.remove_drive(42).expect("defer pending removal").is_empty());
+
+        rdpdr
+            .process(&encoded_server_announce(0x5678))
+            .expect("process replacement server announce");
+        assert!(
+            rdpdr
+                .downcast_backend::<TrackingBackend>()
+                .expect("tracking backend")
+                .restored_drives
+                .is_empty()
+        );
+        assert!(!rdpdr.device_types.iter().any(|(device_id, _)| *device_id == 42));
     }
 
     #[test]

--- a/crates/ironrdp-rdpdr/src/lib.rs
+++ b/crates/ironrdp-rdpdr/src/lib.rs
@@ -53,8 +53,9 @@ pub struct Rdpdr {
     client_id_confirmed: bool,
     post_logon_devices_announced: bool,
     pending_device_announcements: Vec<u32>,
+    pending_drive_removals: Vec<u32>,
     manually_announced_device_ids: Vec<u32>,
-    activated_dynamic_drive_ids: Vec<u32>,
+    backend_active_drive_ids: Vec<u32>,
     active_device_ids: Vec<u32>,
     rejected_device_ids: Vec<u32>,
     backend: Option<Box<dyn RdpdrBackend>>,
@@ -78,8 +79,9 @@ impl Rdpdr {
             client_id_confirmed: false,
             post_logon_devices_announced: false,
             pending_device_announcements: Vec::new(),
+            pending_drive_removals: Vec::new(),
             manually_announced_device_ids: Vec::new(),
-            activated_dynamic_drive_ids: Vec::new(),
+            backend_active_drive_ids: Vec::new(),
             active_device_ids: Vec::new(),
             rejected_device_ids: Vec::new(),
             backend: Some(backend),
@@ -158,6 +160,10 @@ impl Rdpdr {
 
     /// Activates a filesystem device and, when allowed by the current sequence,
     /// announces it to the server.
+    ///
+    /// [MS-RDPEFS section 3.2.5.1.9] permits later announcements containing only previously unannounced devices.
+    ///
+    /// [MS-RDPEFS section 3.2.5.1.9]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/34d9de58-b2b5-40b6-b970-f82d4603bdb5
     pub fn add_dynamic_drive(&mut self, device_id: u32, name: String) -> PduResult<Vec<SvcMessage>> {
         if name.is_empty() || name.contains('\0') {
             return Err(pdu_other_err!("dynamic drive name must be nonempty and contain no NUL"));
@@ -176,7 +182,7 @@ impl Rdpdr {
             .as_mut()
             .ok_or_else(|| pdu_other_err!("missing rdpdr backend"))?
             .add_drive(device_id)?;
-        self.activated_dynamic_drive_ids.push(device_id);
+        self.backend_active_drive_ids.push(device_id);
         self.device_list.add_drive(device_id, name.clone());
         self.device_types.push((device_id, DeviceType::Filesystem));
 
@@ -192,6 +198,10 @@ impl Rdpdr {
 
     /// Releases a filesystem device and sends its removal after pending IRP
     /// cancellations have been returned by the backend.
+    ///
+    /// [MS-RDPEFS section 3.2.5.2.2] requires post-connect removal and invalidates later requests for that device ID.
+    ///
+    /// [MS-RDPEFS section 3.2.5.2.2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/34d9de58-b2b5-40b6-b970-f82d4603bdb5
     pub fn remove_drive(&mut self, device_id: u32) -> PduResult<Vec<SvcMessage>> {
         if !self
             .device_types
@@ -201,13 +211,14 @@ impl Rdpdr {
             return Err(pdu_other_err!("device removal requires a filesystem device"));
         }
         if self.pending_device_announcements.contains(&device_id) {
-            return Err(pdu_other_err!(
-                "device removal requires the server announcement response"
-            ));
+            if !self.pending_drive_removals.contains(&device_id) {
+                self.pending_drive_removals.push(device_id);
+            }
+            return Ok(Vec::new());
         }
 
         let was_active = self.active_device_ids.contains(&device_id);
-        let mut messages = if self.activated_dynamic_drive_ids.contains(&device_id) {
+        let mut messages = if self.backend_active_drive_ids.contains(&device_id) {
             self.backend
                 .as_mut()
                 .ok_or_else(|| pdu_other_err!("missing rdpdr backend"))?
@@ -223,7 +234,7 @@ impl Rdpdr {
         self.active_device_ids.retain(|id| *id != device_id);
         self.rejected_device_ids.retain(|id| *id != device_id);
         self.manually_announced_device_ids.retain(|id| *id != device_id);
-        self.activated_dynamic_drive_ids.retain(|id| *id != device_id);
+        self.backend_active_drive_ids.retain(|id| *id != device_id);
 
         if was_active {
             messages.push(SvcMessage::from(RdpdrPdu::ClientDeviceListRemove(
@@ -259,10 +270,11 @@ impl Rdpdr {
             self.device_types.remove(index);
         }
         self.pending_device_announcements.retain(|id| *id != device_id);
+        self.pending_drive_removals.retain(|id| *id != device_id);
         self.manually_announced_device_ids.retain(|id| *id != device_id);
         self.active_device_ids.retain(|id| *id != device_id);
         self.rejected_device_ids.retain(|id| *id != device_id);
-        self.activated_dynamic_drive_ids.retain(|id| *id != device_id);
+        self.backend_active_drive_ids.retain(|id| *id != device_id);
         Some(ClientDeviceListRemove::remove_device(device_id))
     }
 
@@ -290,15 +302,17 @@ impl Rdpdr {
                 .as_mut()
                 .ok_or_else(|| pdu_other_err!("missing rdpdr backend"))?;
             backend.reset()?;
-            for device_id in configured_drive_ids {
-                backend.restore_drive(device_id)?;
+            for device_id in &configured_drive_ids {
+                backend.restore_drive(*device_id)?;
             }
         }
+        self.backend_active_drive_ids = configured_drive_ids;
 
         self.server_capabilities_received = false;
         self.client_id_confirmed = false;
         self.post_logon_devices_announced = false;
         self.pending_device_announcements.clear();
+        self.pending_drive_removals.clear();
         self.manually_announced_device_ids.clear();
         self.active_device_ids.clear();
         self.rejected_device_ids.clear();
@@ -470,10 +484,13 @@ impl Rdpdr {
                 self.active_device_ids.push(device_id);
             }
             self.rejected_device_ids.retain(|id| *id != device_id);
+            if self.pending_drive_removals.contains(&device_id) {
+                return self.remove_drive(device_id);
+            }
             return Ok(Vec::new());
         }
 
-        let mut messages = if self.activated_dynamic_drive_ids.contains(&device_id) {
+        let mut messages = if self.backend_active_drive_ids.contains(&device_id) {
             self.backend
                 .as_mut()
                 .ok_or_else(|| pdu_other_err!("missing rdpdr backend"))?
@@ -481,12 +498,21 @@ impl Rdpdr {
         } else {
             Vec::new()
         };
-        self.activated_dynamic_drive_ids.retain(|id| *id != device_id);
+        self.backend_active_drive_ids.retain(|id| *id != device_id);
         self.pending_device_announcements.retain(|id| *id != device_id);
+        let removal_requested = self.pending_drive_removals.contains(&device_id);
+        self.pending_drive_removals.retain(|id| *id != device_id);
         if !self.rejected_device_ids.contains(&device_id) {
             self.rejected_device_ids.push(device_id);
         }
         self.active_device_ids.retain(|id| *id != device_id);
+        if removal_requested {
+            self.device_list
+                .remove_device(device_id)
+                .ok_or_else(|| pdu_other_err!("device disappeared from the RDPDR device list"))?;
+            self.device_types.retain(|(id, _)| *id != device_id);
+            self.rejected_device_ids.retain(|id| *id != device_id);
+        }
 
         messages.push(SvcMessage::from(RdpdrPdu::ClientDeviceListRemove(
             ClientDeviceListRemove::remove_device(device_id),
@@ -1117,13 +1143,20 @@ mod tests {
                 .len(),
             1
         );
+        assert!(
+            rdpdr
+                .remove_drive(42)
+                .expect("defer removal until announcement response")
+                .is_empty()
+        );
+        assert_eq!(
+            rdpdr
+                .process(&encoded_server_device_announce_response(42, NtStatus::SUCCESS))
+                .expect("accept then remove dynamic drive")
+                .len(),
+            1
+        );
         assert!(rdpdr.remove_drive(42).is_err());
-        rdpdr
-            .process(&encoded_server_device_announce_response(42, NtStatus::SUCCESS))
-            .expect("process accepted device announcement");
-
-        let responses = rdpdr.remove_drive(42).expect("remove active dynamic drive");
-        assert_eq!(responses.len(), 1);
         assert_eq!(
             rdpdr
                 .downcast_backend::<TrackingBackend>()
@@ -1136,6 +1169,37 @@ mod tests {
                 .downcast_backend::<TrackingBackend>()
                 .expect("tracking backend")
                 .removed_drives,
+            vec![42]
+        );
+    }
+
+    #[test]
+    fn initial_drive_can_be_removed_and_readded_dynamically() {
+        let mut rdpdr = Rdpdr::new(Box::new(TrackingBackend::default()), "test".to_owned())
+            .with_drives(Some(vec![(42, "C:".to_owned())]));
+        initialize_drive(&mut rdpdr, 42);
+
+        assert_eq!(rdpdr.remove_drive(42).expect("remove initial drive").len(), 1);
+        assert_eq!(
+            rdpdr
+                .downcast_backend::<TrackingBackend>()
+                .expect("tracking backend")
+                .removed_drives,
+            vec![42]
+        );
+
+        assert_eq!(
+            rdpdr
+                .add_dynamic_drive(42, "C:".to_owned())
+                .expect("readd drive with its stable ID")
+                .len(),
+            1
+        );
+        assert_eq!(
+            rdpdr
+                .downcast_backend::<TrackingBackend>()
+                .expect("tracking backend")
+                .added_drives,
             vec![42]
         );
     }
@@ -1160,6 +1224,12 @@ mod tests {
         rdpdr
             .process(&encode_vec(&RdpdrPdu::UserLoggedon).expect("encode user logged on"))
             .expect("process user logged on");
+        assert!(
+            rdpdr
+                .remove_drive(42)
+                .expect("defer removal until rejected announcement")
+                .is_empty()
+        );
 
         assert_eq!(
             rdpdr
@@ -1175,12 +1245,7 @@ mod tests {
                 .removed_drives,
             vec![42]
         );
-        assert!(
-            rdpdr
-                .remove_drive(42)
-                .expect("remove rejected dynamic drive")
-                .is_empty()
-        );
+        assert!(rdpdr.remove_drive(42).is_err());
         assert_eq!(
             rdpdr
                 .downcast_backend::<TrackingBackend>()


### PR DESCRIPTION
Keep drive capability active for hotplug-only sessions and route ActiveX drive rescans and selection changes through the live RDPDR channel. Preserve stable drive IDs, defer removals until server acknowledgement, and keep generic devices, printers, and ports explicitly unsupported.

Smartcard redirection remains independent.